### PR TITLE
fix(tabs): sync tab bar scroll position across all tab renderers

### DIFF
--- a/src/constants.js
+++ b/src/constants.js
@@ -32,6 +32,7 @@ const IpcChannels = {
   TABS_UPDATE_TITLE: 'tabs-update-title',
   TABS_EXIT_FULLSCREEN: 'tabs-exit-fullscreen',
   TABS_SET_PLAYBACK_STATE: 'tabs-set-playback-state',
+  TABS_SET_TAB_BAR_SCROLL: 'tabs-set-tab-bar-scroll',
   CREATE_NEW_TAB: 'create-new-tab',
 
   DB_SETTINGS: 'db-settings',

--- a/src/main/tabs/TabManager.js
+++ b/src/main/tabs/TabManager.js
@@ -48,6 +48,8 @@ export class TabManager {
     this.closedTabUrls = [] // For restore closed tab functionality
     /** @type {number} */
     this.tabCounter = 0
+    /** @type {number} */
+    this.tabBarScrollPosition = 0
 
     tabManagers.set(browserWindow.id, this)
 
@@ -530,7 +532,8 @@ export class TabManager {
 
     return {
       tabs,
-      activeTabId: this.activeTabId
+      activeTabId: this.activeTabId,
+      tabBarScrollPosition: this.tabBarScrollPosition
     }
   }
 
@@ -744,6 +747,16 @@ export function setupTabsIPC() {
         manager._broadcastStateUpdate()
         manager._saveSession()
       }
+    }
+  })
+
+  // Update tab bar scroll position (keeps scroll in sync across all tab renderers)
+  ipcMain.on(IpcChannels.TABS_SET_TAB_BAR_SCROLL, (event, position) => {
+    if (typeof position !== 'number') return
+
+    const manager = TabManager.getFromWebContents(event.sender)
+    if (manager) {
+      manager.tabBarScrollPosition = position
     }
   })
 

--- a/src/preload/interface.js
+++ b/src/preload/interface.js
@@ -422,6 +422,14 @@ export default {
     },
 
     /**
+     * Set the tab bar scroll position (synced across all tab renderers via main process)
+     * @param {number} position
+     */
+    setTabBarScroll: (position) => {
+      ipcRenderer.send(IpcChannels.TABS_SET_TAB_BAR_SCROLL, position)
+    },
+
+    /**
      * Listen for tab state updates
      * @param {(state: {tabs: Array, activeTabId: string|null}) => void} handler
      */

--- a/src/renderer/components/TabBar/TabBar.vue
+++ b/src/renderer/components/TabBar/TabBar.vue
@@ -35,7 +35,7 @@
 
 <script setup>
 import { FontAwesomeIcon } from '@fortawesome/vue-fontawesome'
-import { computed, onMounted, watch, onUnmounted } from 'vue'
+import { computed, onMounted, watch, onUnmounted, nextTick } from 'vue'
 import { useI18n } from '../../composables/use-i18n-polyfill'
 import { useDroppable, useDnDStore } from '@vue-dnd-kit/core'
 
@@ -191,6 +191,8 @@ function createNewTab() {
   store.dispatch('createTab', { makeActive: true })
 }
 
+const tabBarScrollPosition = computed(() => store.getters.getTabBarScrollPosition)
+
 let scrollTarget = null
 let scrollAnimationId = null
 
@@ -228,10 +230,32 @@ function handleWheel(event) {
   }
   scrollTarget = Math.max(0, Math.min(maxScroll, scrollTarget + delta))
 
+  if (isElectron) {
+    window.ftElectron.tabs.setTabBarScroll(scrollTarget)
+  }
+
   if (!scrollAnimationId) {
     scrollAnimationId = requestAnimationFrame(animateScroll)
   }
 }
+
+// Apply scroll position received from main process state broadcasts.
+// This keeps all tab renderers' tab bars at the same scroll offset.
+watch(tabBarScrollPosition, (newPosition) => {
+  if (newPosition == null) return
+
+  nextTick(() => {
+    const container = dropZoneRef.value
+    if (!container) return
+
+    if (scrollAnimationId) {
+      scrollTarget = newPosition
+    } else {
+      container.scrollLeft = newPosition
+      scrollTarget = newPosition
+    }
+  })
+})
 </script>
 
 <style scoped src="./TabBar.css" />

--- a/src/renderer/store/modules/tabs.js
+++ b/src/renderer/store/modules/tabs.js
@@ -5,6 +5,7 @@
 const state = {
   tabs: [],
   activeTabId: null,
+  tabBarScrollPosition: 0,
   currentWatchTimestamp: null
 }
 
@@ -13,13 +14,17 @@ const getters = {
   getActiveTabId: (state) => state.activeTabId,
   getActiveTab: (state) => state.tabs.find(tab => tab.id === state.activeTabId),
   getTabCount: (state) => state.tabs.length,
+  getTabBarScrollPosition: (state) => state.tabBarScrollPosition,
   getCurrentWatchTimestamp: (state) => state.currentWatchTimestamp
 }
 
 const mutations = {
-  setTabsState(state, { tabs, activeTabId }) {
+  setTabsState(state, { tabs, activeTabId, tabBarScrollPosition }) {
     state.tabs = tabs
     state.activeTabId = activeTabId
+    if (tabBarScrollPosition != null) {
+      state.tabBarScrollPosition = tabBarScrollPosition
+    }
   },
   setCurrentWatchTimestamp(state, value) {
     state.currentWatchTimestamp = value


### PR DESCRIPTION
Store the tab bar scroll position in the main process TabManager and include it in the shared tab state. Each renderer sends its scroll target to main on wheel events, and applies the position from state broadcasts, ensuring all WebContentsView tab bars stay consistent.