### PR TITLE
use archlinux for appimage deployment, simplify appimage scirpt

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -175,7 +175,8 @@ jobs:
       env:
         VERSION: ${{ steps.versionNumber.outputs.version }}
       run: |
-        bash _scripts/package-anylinux-appimage.sh "$VERSION" "${{ matrix.runtime }}"
+        docker run --rm -v "$PWD":/work -w /work ghcr.io/pkgforge-dev/archlinux:latest \
+          sh _scripts/package-anylinux-appimage.sh "build/opentubex_${VERSION}_amd64.deb"
 
     - name: Convert ARM64 AppImage to Anylinux AppImage
       if: startsWith(matrix.os, 'ubuntu') && startsWith(matrix.runtime, 'linux-arm64')
@@ -183,7 +184,8 @@ jobs:
       env:
         VERSION: ${{ steps.versionNumber.outputs.version }}
       run: |
-        bash _scripts/package-anylinux-appimage.sh "$VERSION" "${{ matrix.runtime }}"
+        docker run --rm -v "$PWD":/work -w /work ghcr.io/pkgforge-dev/archlinux:latest \
+          sh _scripts/package-anylinux-appimage.sh "build/opentubex_${VERSION}_arm64.deb"
 
     - name: Upload Linux .zip x64 Artifact
       uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a #v7.0.1
@@ -253,7 +255,7 @@ jobs:
       if: startsWith(matrix.os, 'ubuntu') && startsWith(matrix.runtime, 'linux-x64')
       with:
         name: opentubex-${{ steps.versionNumber.outputs.version }}-amd64.AppImage
-        path: build/OpenTubeX-${{ steps.versionNumber.outputs.version }}.AppImage
+        path: build/opentubex-${{ steps.versionNumber.outputs.version }}-amd64.AppImage
 
     - name: Upload AppImage ARMv7l Artifact
       uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a #v7.0.1
@@ -267,7 +269,7 @@ jobs:
       if: startsWith(matrix.os, 'ubuntu') && startsWith(matrix.runtime, 'linux-arm64')
       with:
         name: opentubex-${{ steps.versionNumber.outputs.version }}-arm64.AppImage
-        path: build/OpenTubeX-${{ steps.versionNumber.outputs.version }}-arm64.AppImage
+        path: build/opentubex-${{ steps.versionNumber.outputs.version }}-arm64.AppImage
 
     - name: Upload .rpm x64 Artifact
       uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a #v7.0.1

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -128,9 +128,10 @@ jobs:
       shell: bash
       env:
         VERSION: ${{ steps.getPackageInfo.outputs.version }}
+        UPINFO: 'gh-releases-zsync|OpenTubeX|OpenTubeX|latest-all|opentubex-*-amd64.AppImage.zsync'
       run: |
-        update_information='gh-releases-zsync|OpenTubeX|OpenTubeX|latest-all|opentubex-*-amd64.AppImage.zsync'
-        bash _scripts/package-anylinux-appimage.sh "$VERSION" "${{ matrix.runtime }}" "$update_information"
+        docker run --rm -v "$PWD":/work -w /work -e UPINFO ghcr.io/pkgforge-dev/archlinux:latest \
+          sh _scripts/package-anylinux-appimage.sh "build/opentubex_${VERSION}_amd64.deb"
 
     - name: Convert ARMv7l AppImage to static runtime and add update information
       if: startsWith(matrix.os, 'ubuntu') && startsWith(matrix.runtime, 'linux-armv7l')
@@ -154,9 +155,10 @@ jobs:
       shell: bash
       env:
         VERSION: ${{ steps.getPackageInfo.outputs.version }}
+        UPINFO: 'gh-releases-zsync|OpenTubeX|OpenTubeX|latest-all|opentubex-*-arm64.AppImage.zsync'
       run: |
-        update_information='gh-releases-zsync|OpenTubeX|OpenTubeX|latest-all|opentubex-*-arm64.AppImage.zsync'
-        bash _scripts/package-anylinux-appimage.sh "$VERSION" "${{ matrix.runtime }}" "$update_information"
+        docker run --rm -v "$PWD":/work -w /work -e UPINFO ghcr.io/pkgforge-dev/archlinux:latest \
+          sh _scripts/package-anylinux-appimage.sh "build/opentubex_${VERSION}_arm64.deb"
 
     - name: Upload Linux .zip x64 Release
       uses: actions/upload-release-asset@e8f9f06c4b078e705bd2ea027f0926603fc9b4d5 #v1.0.2
@@ -265,7 +267,7 @@ jobs:
       with:
         upload_url: https://uploads.github.com/repos/OpenTubeX/OpenTubeX/releases/${{ inputs.releaseId }}/assets{?name,label}
         asset_name: opentubex-${{ steps.getPackageInfo.outputs.version }}-beta-amd64.AppImage
-        asset_path: build/OpenTubeX-${{ steps.getPackageInfo.outputs.version }}.AppImage
+        asset_path: build/opentubex-${{ steps.getPackageInfo.outputs.version }}-amd64.AppImage
         asset_content_type: application/vnd.appimage
 
     - name: Upload AppImage .zsync x64 Release
@@ -276,7 +278,7 @@ jobs:
       with:
         upload_url: https://uploads.github.com/repos/OpenTubeX/OpenTubeX/releases/${{ inputs.releaseId }}/assets{?name,label}
         asset_name: opentubex-${{ steps.getPackageInfo.outputs.version }}-beta-amd64.AppImage.zsync
-        asset_path: build/OpenTubeX-${{ steps.getPackageInfo.outputs.version }}.AppImage.zsync
+        asset_path: build/opentubex-${{ steps.getPackageInfo.outputs.version }}-amd64.AppImage.zsync
         asset_content_type: application/x-zsync
 
     - name: Upload AppImage ARMv7l Release
@@ -309,7 +311,7 @@ jobs:
       with:
         upload_url: https://uploads.github.com/repos/OpenTubeX/OpenTubeX/releases/${{ inputs.releaseId }}/assets{?name,label}
         asset_name: opentubex-${{ steps.getPackageInfo.outputs.version }}-beta-arm64.AppImage
-        asset_path: build/OpenTubeX-${{ steps.getPackageInfo.outputs.version }}-arm64.AppImage
+        asset_path: build/opentubex-${{ steps.getPackageInfo.outputs.version }}-arm64.AppImage
         asset_content_type: application/vnd.appimage
 
     - name: Upload AppImage .zsync ARM64 Release
@@ -320,7 +322,7 @@ jobs:
       with:
         upload_url: https://uploads.github.com/repos/OpenTubeX/OpenTubeX/releases/${{ inputs.releaseId }}/assets{?name,label}
         asset_name: opentubex-${{ steps.getPackageInfo.outputs.version }}-beta-arm64.AppImage.zsync
-        asset_path: build/OpenTubeX-${{ steps.getPackageInfo.outputs.version }}-arm64.AppImage.zsync
+        asset_path: build/opentubex-${{ steps.getPackageInfo.outputs.version }}-arm64.AppImage.zsync
         asset_content_type: application/x-zsync
 
     - name: Upload Linux .rpm x64 Release

--- a/_scripts/package-anylinux-appimage.sh
+++ b/_scripts/package-anylinux-appimage.sh
@@ -1,123 +1,76 @@
-#!/usr/bin/env bash
+#!/bin/sh
 
-set -euo pipefail
+set -e
 
-readonly VERSION="${1:?Usage: $0 <version> <runtime> [update-info]}"
-readonly RUNTIME="${2:?Usage: $0 <version> <runtime> [update-info]}"
-readonly UPDATE_INFO="${3:-}"
+DEB_PATH=$1
 
-readonly ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
-readonly BUILD_DIR="$ROOT_DIR/build"
-readonly QUICK_SHARUN_URL="https://raw.githubusercontent.com/pkgforge-dev/Anylinux-AppImages/refs/heads/main/useful-tools/quick-sharun.sh"
-
-case "$RUNTIME" in
-  linux-x64)
-    appimage_arch="x86_64"
-    deb_arch="amd64"
-    appimage_name="OpenTubeX-$VERSION.AppImage"
-    ;;
-  linux-arm64)
-    appimage_arch="aarch64"
-    deb_arch="arm64"
-    appimage_name="OpenTubeX-$VERSION-arm64.AppImage"
-    ;;
-  *)
-    if [[ "$RUNTIME" == linux-armv7l ]]; then
-      printf 'Anylinux AppImages are not supported for ARMv7: sharun only publishes x86_64 and aarch64 binaries.\n' >&2
-      printf 'Use the classic static-runtime AppImage conversion in CI instead.\n' >&2
-    else
-      printf 'Unsupported Anylinux AppImage runtime: %s\n' "$RUNTIME" >&2
-    fi
-    exit 1
-    ;;
-esac
-
-if [[ "$(uname -m)" != "$appimage_arch" ]]; then
-  printf 'Anylinux AppImages must be packaged on the target architecture (%s), got %s.\n' "$appimage_arch" "$(uname -m)" >&2
-  exit 1
+if [ ! -f "$DEB_PATH" ]; then
+	>&2 echo "ERROR: Debian package not found: $1"
+	exit 1
 fi
 
-for command_name in bsdtar wget; do
-  if ! command -v "$command_name" >/dev/null 2>&1; then
-    printf 'Missing required command: %s\n' "$command_name" >&2
-    exit 1
-  fi
-done
+# Install packaging tools (mirrors anylinux-setup-action)
+pacman-key --init
+pacman -Syy --noconfirm archlinux-keyring
+pacman -Syu --noconfirm \
+	7zip             \
+	base-devel       \
+	freetype2        \
+	libx11           \
+	libxrandr        \
+	libxss           \
+	nspr             \
+	nss              \
+	nss-mdns         \
+	nss-myhostname   \
+	patchelf         \
+	pipewire-audio   \
+	pipewire-jack    \
+	pulseaudio       \
+	pulseaudio-alsa  \
+	unzip            \
+	wget             \
+	xorg-server-xvfb \
+	zsync
 
-deb_path="$BUILD_DIR/opentubex_${VERSION}_${deb_arch}.deb"
-if [[ ! -f "$deb_path" ]]; then
-  printf 'Missing Debian package: %s\n' "$deb_path" >&2
-  exit 1
-fi
+mkdir -p /usr/local/bin
+TOOLS_SOURCE=https://raw.githubusercontent.com/pkgforge-dev/Anylinux-AppImages/refs/heads/main/useful-tools
+wget --retry-connrefused --tries=30 \
+	"$TOOLS_SOURCE"/quick-sharun.sh -O /usr/local/bin/quick-sharun
+wget --retry-connrefused --tries=30 \
+	"$TOOLS_SOURCE"/get-debloated-pkgs.sh -O /usr/local/bin/get-debloated-pkgs
+chmod +x /usr/local/bin/quick-sharun /usr/local/bin/get-debloated-pkgs
+get-debloated-pkgs --add-common --prefer-nano
 
-work_dir="$(mktemp -d)"
-trap 'rm -rf "$work_dir"' EXIT
+mkdir -p ./AppDir/bin
+extracted_deb=$(mktemp -d)
+trap 'rm -rf "$extracted_deb"' EXIT
 
-mkdir -p "$work_dir/deb" "$work_dir/root" "$work_dir/AppDir/bin" "$work_dir/out"
+# Extract .deb and get the path to the data.tar.*
+bsdtar -xf "$DEB_PATH" -C "$extracted_deb"
+data_archive=$(set -- "$extracted_deb"/data.tar.* && echo "$1")
+bsdtar -xf "$data_archive" -C "$extracted_deb"
 
-bsdtar -xf "$deb_path" -C "$work_dir/deb"
-data_archive="$(printf '%s\n' "$work_dir"/deb/data.tar.* | head -n 1)"
-if [[ ! -f "$data_archive" ]]; then
-  printf 'Could not find data archive inside %s\n' "$deb_path" >&2
-  exit 1
-fi
+cp -rv "$extracted_deb"/opt/OpenTubeX/* ./AppDir/bin
+cp -v  "$extracted_deb"/usr/share/icons/hicolor/scalable/apps/opentubex.svg ./AppDir/.DirIcon
+cp -v  "$extracted_deb"/usr/share/icons/hicolor/scalable/apps/opentubex.svg ./AppDir/
+cp -v  "$extracted_deb"/usr/share/applications/opentubex.desktop  ./AppDir/
 
-bsdtar -xf "$data_archive" -C "$work_dir/root"
+# use the .deb name as reference for the name of the final appimage
+# replace .deb for .AppImage and replace _ for -
+OUTNAME=$(basename "$DEB_PATH" .deb | sed 's/_/-/g').AppImage
 
-app_payload="$work_dir/root/opt/OpenTubeX"
-desktop_file="$work_dir/root/usr/share/applications/opentubex.desktop"
-icon_file="$work_dir/root/usr/share/icons/hicolor/scalable/apps/opentubex.svg"
-
-if [[ ! -d "$app_payload" || ! -f "$desktop_file" || ! -f "$icon_file" ]]; then
-  printf 'The Debian package did not contain the expected OpenTubeX payload, desktop file, or icon.\n' >&2
-  exit 1
-fi
-
-cp -a "$app_payload"/. "$work_dir/AppDir/bin/"
-cp "$desktop_file" "$work_dir/AppDir/"
-cp "$icon_file" "$work_dir/AppDir/"
-cp "$icon_file" "$work_dir/AppDir/.DirIcon"
-sed -i 's|^Exec=.*|Exec=opentubex %U|' "$work_dir/AppDir/opentubex.desktop"
-
-quick_sharun="$work_dir/quick-sharun"
-wget -q "$QUICK_SHARUN_URL" -O "$quick_sharun"
-chmod +x "$quick_sharun"
-
-target_appimage="$BUILD_DIR/$appimage_name"
-rm -f "$target_appimage" "$target_appimage.zsync"
-
-export ADD_HOOKS="self-updater.hook"
-export APPDIR="$work_dir/AppDir"
-export ARCH="$appimage_arch"
-export DEPLOY_DATADIR="${DEPLOY_DATADIR:-0}"
+ARCH=$(uname -m)
+export ARCH
+export OUTNAME
+export OUTPATH=./build
+export ADD_HOOKS=self-updater.hook:fix-namespaces.hook
 export DEPLOY_OPENGL=1
-export DEPLOY_PIPEWIRE=1
 export DEPLOY_VULKAN=1
-export MAIN_BIN=opentubex
-export OUTNAME="$appimage_name"
-export OUTPATH="$work_dir/out"
+export DEPLOY_PIPEWIRE=1
 export STARTUPWMCLASS=opentubex
-export UPINFO="$UPDATE_INFO"
+export MAIN_BIN=opentubex
 
-"$quick_sharun" "$APPDIR"/bin/*
-"$quick_sharun" --make-appimage
+quick-sharun ./AppDir/bin/*
+quick-sharun --make-appimage
 
-produced_appimage="$(printf '%s\n' "$work_dir"/out/*.AppImage | head -n 1)"
-if [[ ! -f "$produced_appimage" ]]; then
-  printf 'quick-sharun did not produce an AppImage.\n' >&2
-  exit 1
-fi
-
-mv "$produced_appimage" "$target_appimage"
-if [[ -f "$produced_appimage.zsync" ]]; then
-  mv "$produced_appimage.zsync" "$target_appimage.zsync"
-elif compgen -G "$work_dir/out/*.AppImage.zsync" >/dev/null; then
-  mv "$(printf '%s\n' "$work_dir"/out/*.AppImage.zsync | head -n 1)" "$target_appimage.zsync"
-fi
-
-if [[ -f "$target_appimage.zsync" ]]; then
-  sed -i "s|^Filename: .*|Filename: $appimage_name|" "$target_appimage.zsync"
-fi
-
-chmod +x "$target_appimage"
-printf 'Anylinux AppImage created at %s\n' "$target_appimage"


### PR DESCRIPTION
Script has been simplified to use the `.deb` name as reference for the output appimage by replacing `.deb` for `.AppImage` and underscores for dashes.

Example: If you feed it `opentubex_0.25.6_beta_amd64.deb` you will get `opentubex-0.25.6-beta-amd64.AppImage` matching the current artifact release schema.

With quick-sharun you can set the `OUTNAME` env var which will tell it to named the output appimage with whatever is in the variable.

This avoids the need to manually rename the appimage and edit the .zsync file.

---

**NOTE:** I tested the script locally on my machine on an archlinux container, not sure if the `.yml` changes are correct. I asked deepseek for help with that 😅