### PR TITLE
fix(shortcuts): restore contextual keyboard behavior

### DIFF
--- a/e2e/tests/offline/findbar-keyboard.spec.mjs
+++ b/e2e/tests/offline/findbar-keyboard.spec.mjs
@@ -1,0 +1,21 @@
+import { test, expect } from '../../helpers/app.mjs'
+
+test('Enter and Shift+Enter navigate one find bar match at a time', async ({ page }) => {
+  await page.locator('.tabContent[aria-hidden="false"]').evaluate((tabContent) => {
+    const fixture = document.createElement('div')
+    fixture.textContent = 'findbar regression marker findbar regression marker'
+    tabContent.prepend(fixture)
+  })
+
+  await page.keyboard.press('Control+f')
+  const findbarInput = page.locator('.findbarInput')
+  const findbarStatus = page.locator('.findbarStatus')
+  await findbarInput.fill('findbar regression marker')
+  await expect(findbarStatus).toHaveText('1/2')
+
+  await findbarInput.press('Enter')
+  await expect(findbarStatus).toHaveText('2/2')
+
+  await findbarInput.press('Shift+Enter')
+  await expect(findbarStatus).toHaveText('1/2')
+})

--- a/e2e/tests/offline/keyboard-shortcut-restrictions.spec.mjs
+++ b/e2e/tests/offline/keyboard-shortcut-restrictions.spec.mjs
@@ -1,0 +1,24 @@
+import { test, expect } from '../../helpers/app.mjs'
+
+test('context-dependent shortcuts are shown as non-editable', async ({ page }) => {
+  await page.evaluate(() => {
+    const store = document.querySelector('#app').__vue_app__.config.globalProperties.$store
+    store.commit('setIsKeyboardShortcutPromptShown', true)
+  })
+  await expect(page.getByRole('heading', { name: 'Keyboard Shortcuts' })).toBeVisible()
+
+  const reservedPaths = [
+    'APP.GENERAL.FOCUS_SEARCH_ALT_SLASH',
+    'APP.GENERAL.SEARCH_IN_NEW_WINDOW',
+    'APP.GENERAL.FIND_NEXT_ALT_ENTER',
+    'APP.GENERAL.FIND_PREVIOUS_ALT_ENTER',
+    'APP.GENERAL.NEXT_TAB',
+    'APP.GENERAL.PREV_TAB',
+  ]
+
+  for (const path of reservedPaths) {
+    await expect(page.locator(`[data-shortcut-path="${path}"]`)).toHaveCount(0)
+  }
+
+  await expect(page.locator('[data-shortcut-path="APP.GENERAL.FOCUS_SEARCH"]')).toHaveCount(1)
+})

--- a/e2e/tests/offline/search-keyboard.spec.mjs
+++ b/e2e/tests/offline/search-keyboard.spec.mjs
@@ -1,0 +1,37 @@
+import { test, expect, sel, waitForAppReady } from '../../helpers/app.mjs'
+
+test.use({
+  seed: {
+    settings: {
+      enableSearchSuggestions: false,
+      keyboardShortcuts: JSON.stringify({
+        APP: {
+          GENERAL: {
+            SEARCH_IN_NEW_WINDOW: 'ctrl+enter'
+          }
+        }
+      })
+    }
+  }
+})
+
+test('Enter searches in place', async ({ page }) => {
+  await page.locator(sel.searchInput).fill('enter search')
+  await page.locator(sel.searchInput).press('Enter')
+
+  await expect(page).toHaveURL(/#\/search\/enter%20search/)
+})
+
+test('Shift+Enter searches in a new window', async ({ app, page }) => {
+  await page.locator(sel.searchInput).fill('shift enter search')
+
+  const [newWindow] = await Promise.all([
+    app.electronApp.waitForEvent('window'),
+    page.locator(sel.searchInput).press('Shift+Enter')
+  ])
+  await waitForAppReady(newWindow)
+
+  await expect(newWindow).toHaveURL(/#\/search\/shift%20enter%20search/)
+  await expect(newWindow.locator('.navFilterButton')).not.toHaveClass(/filterChanged/)
+  await expect(page).not.toHaveURL(/#\/search\//)
+})

--- a/src/constants.js
+++ b/src/constants.js
@@ -295,6 +295,15 @@ const DefaultKeyboardShortcuts = {
   },
 }
 
+const NonEditableKeyboardShortcutPaths = new Set([
+  'APP.GENERAL.FOCUS_SEARCH_ALT_SLASH',
+  'APP.GENERAL.SEARCH_IN_NEW_WINDOW',
+  'APP.GENERAL.FIND_NEXT_ALT_ENTER',
+  'APP.GENERAL.FIND_PREVIOUS_ALT_ENTER',
+  'APP.GENERAL.NEXT_TAB',
+  'APP.GENERAL.PREV_TAB',
+])
+
 const KeyboardShortcuts = getConfiguredKeyboardShortcuts()
 
 /**
@@ -315,8 +324,8 @@ function getConfiguredKeyboardShortcuts(overrides = {}) {
 }
 
 /**
- * Removes overrides for range shortcuts, which represent multiple keys and
- * cannot be replaced by recording one keyboard event.
+ * Removes overrides for reserved shortcuts and ranges, which represent
+ * multiple keys and cannot be replaced by recording one keyboard event.
  * @param {string | object} overrides
  * @returns {string}
  */
@@ -333,6 +342,16 @@ function sanitizeKeyboardShortcutOverrides(overrides) {
  */
 function isKeyboardShortcutRange(shortcut) {
   return /^\d(?:\.\.|-)\d$/.test(shortcut.split('+').at(-1))
+}
+
+/**
+ * @param {string[]} path
+ * @param {string} shortcut
+ * @returns {boolean}
+ */
+function isKeyboardShortcutEditable(path, shortcut) {
+  return !NonEditableKeyboardShortcutPaths.has(path.join('.')) &&
+    !isKeyboardShortcutRange(shortcut)
 }
 
 /**
@@ -357,9 +376,9 @@ function parseKeyboardShortcutOverrides(overrides) {
  * @param {unknown} overrides
  * @returns {object | string | undefined}
  */
-function filterEditableKeyboardShortcutOverrides(defaults, overrides) {
+function filterEditableKeyboardShortcutOverrides(defaults, overrides, path = []) {
   if (typeof defaults === 'string') {
-    if (isKeyboardShortcutRange(defaults)) {
+    if (!isKeyboardShortcutEditable(path, defaults)) {
       return undefined
     }
     return typeof overrides === 'string' ? overrides : undefined
@@ -369,7 +388,7 @@ function filterEditableKeyboardShortcutOverrides(defaults, overrides) {
   return Object.fromEntries(Object.entries(defaults)
     .map(([key, value]) => [
       key,
-      filterEditableKeyboardShortcutOverrides(value, overrideDictionary[key])
+      filterEditableKeyboardShortcutOverrides(value, overrideDictionary[key], [...path, key])
     ])
     .filter(([_key, value]) => value !== undefined && (
       typeof value === 'string' || Object.keys(value).length > 0
@@ -536,6 +555,7 @@ export {
   applyKeyboardShortcutOverrides,
   getConfiguredKeyboardShortcuts,
   getElectronAccelerator,
+  isKeyboardShortcutEditable,
   isKeyboardShortcutRange,
   sanitizeKeyboardShortcutOverrides,
   PlayerIcons,

--- a/src/main/index.js
+++ b/src/main/index.js
@@ -2876,11 +2876,18 @@ function runApp() {
       path = `/${path}`
     }
 
-    let windowStartupUrl = `${ROOT_APP_URL}#${path}`
-
-    if (query) {
-      windowStartupUrl += '?' + new URLSearchParams(query).toString()
+    const searchParams = new URLSearchParams()
+    for (const [key, value] of Object.entries(query ?? {})) {
+      if (Array.isArray(value)) {
+        for (const item of value) {
+          searchParams.append(key, String(item))
+        }
+      } else if (value !== null && value !== undefined) {
+        searchParams.set(key, String(value))
+      }
     }
+    const search = searchParams.toString()
+    const windowStartupUrl = `${ROOT_APP_URL}#${path}${search.length > 0 ? `?${search}` : ''}`
 
     createWindow({
       replaceMainWindow: false,

--- a/src/main/index.js
+++ b/src/main/index.js
@@ -2880,7 +2880,9 @@ function runApp() {
     for (const [key, value] of Object.entries(query ?? {})) {
       if (Array.isArray(value)) {
         for (const item of value) {
-          searchParams.append(key, String(item))
+          if (item !== null && item !== undefined) {
+            searchParams.append(key, String(item))
+          }
         }
       } else if (value !== null && value !== undefined) {
         searchParams.set(key, String(value))

--- a/src/renderer/App.vue
+++ b/src/renderer/App.vue
@@ -1788,12 +1788,10 @@ function handleFindbarNavigationShortcut(event) {
   const isNextShortcut = [
     shortcuts.FIND_NEXT,
     shortcuts.FIND_NEXT_ALT,
-    shortcuts.FIND_NEXT_ALT_ENTER,
   ].some(shortcut => matchesKeyboardShortcut(event, shortcut))
   const isPreviousShortcut = [
     shortcuts.FIND_PREVIOUS,
     shortcuts.FIND_PREVIOUS_ALT,
-    shortcuts.FIND_PREVIOUS_ALT_ENTER,
   ].some(shortcut => matchesKeyboardShortcut(event, shortcut))
 
   if (!isNextShortcut && !isPreviousShortcut) {

--- a/src/renderer/components/FtKeyboardShortcutPrompt/FtKeyboardShortcutPrompt.vue
+++ b/src/renderer/components/FtKeyboardShortcutPrompt/FtKeyboardShortcutPrompt.vue
@@ -123,7 +123,7 @@ import { computed, nextTick, ref } from 'vue'
 import {
   DefaultKeyboardShortcuts,
   getConfiguredKeyboardShortcuts,
-  isKeyboardShortcutRange,
+  isKeyboardShortcutEditable,
 } from '../../../constants'
 import { getLocalizedShortcut } from '../../helpers/utils'
 import {
@@ -396,7 +396,7 @@ function getLocalizedShortcutNamesAndValues(dictionary, dictionaryPath, included
             path: [...dictionaryPath, code].join('.'),
             shortcut: dictionary[code],
             dictionaryPath,
-            editable: !isKeyboardShortcutRange(defaultShortcut),
+            editable: isKeyboardShortcutEditable([...dictionaryPath, code], defaultShortcut),
             modified: dictionary[code] !== defaultShortcut,
           }
         })
@@ -542,7 +542,10 @@ function getAllKeyboardShortcutBindings(dictionary, dictionaryPath = []) {
         code,
         path: path.join('.'),
         shortcut: value,
-        editable: !isKeyboardShortcutRange(getNestedValue(DefaultKeyboardShortcuts, path)),
+        editable: isKeyboardShortcutEditable(
+          path,
+          getNestedValue(DefaultKeyboardShortcuts, path)
+        ),
       }]
     }
     return getAllKeyboardShortcutBindings(value, path)

--- a/src/renderer/components/TopNav/TopNav.vue
+++ b/src/renderer/components/TopNav/TopNav.vue
@@ -109,7 +109,6 @@
           show-data-when-empty
           @input="getSearchSuggestionsDebounce"
           @click="goToSearch"
-          @keydown="handleSearchKeyboardShortcut"
           @clear="clearLastSuggestionQuery"
           @remove="removeSearchHistoryEntryInDbAndCache"
         >
@@ -469,9 +468,7 @@ const searchSettings = computed(() => store.getters.getSearchSettings(searchFilt
  * @param {number} [options.dataListIndex]
  */
 function goToSearch(queryText, { event, dataListIndex }) {
-  const doCreateNewWindow = event instanceof KeyboardEvent
-    ? matchesKeyboardShortcut(event, appKeyboardShortcuts.value.SEARCH_IN_NEW_WINDOW)
-    : event && event.shiftKey
+  const doCreateNewWindow = event && event.shiftKey
   const ctrlOrCmdPressed = event && ((process.platform !== 'darwin' && event.ctrlKey) ||
     (process.platform === 'darwin' && event.metaKey))
   const doCreateNewTab = ctrlOrCmdPressed && !doCreateNewWindow
@@ -633,19 +630,6 @@ function goToSearch(queryText, { event, dataListIndex }) {
       updateSearchInputText('')
     }
   })
-}
-
-/**
- * @param {KeyboardEvent} event
- */
-function handleSearchKeyboardShortcut(event) {
-  if (
-    event.key !== 'Enter' &&
-    matchesKeyboardShortcut(event, appKeyboardShortcuts.value.SEARCH_IN_NEW_WINDOW)
-  ) {
-    event.preventDefault()
-    goToSearch(currentSearchText, { event })
-  }
 }
 
 function clearLastSuggestionQuery() {

--- a/tests/unit/keyboard-shortcuts.test.mjs
+++ b/tests/unit/keyboard-shortcuts.test.mjs
@@ -1,0 +1,40 @@
+import assert from 'node:assert/strict'
+import test from 'node:test'
+
+import {
+  getConfiguredKeyboardShortcuts,
+  sanitizeKeyboardShortcutOverrides,
+} from '../../src/constants.js'
+
+test('keeps contextual app shortcuts fixed', () => {
+  const overrides = {
+    APP: {
+      GENERAL: {
+        FOCUS_SEARCH: 'ctrl+k',
+        FOCUS_SEARCH_ALT_SLASH: 'ctrl+shift+f',
+        SEARCH_IN_NEW_WINDOW: 'ctrl+enter',
+        FIND_NEXT_ALT_ENTER: 'ctrl+down',
+        FIND_PREVIOUS_ALT_ENTER: 'ctrl+up',
+        NEXT_TAB: 'alt+arrowright',
+        PREV_TAB: 'alt+arrowleft',
+      }
+    }
+  }
+
+  const shortcuts = getConfiguredKeyboardShortcuts(overrides)
+  assert.equal(shortcuts.APP.GENERAL.FOCUS_SEARCH, 'ctrl+k')
+  assert.equal(shortcuts.APP.GENERAL.FOCUS_SEARCH_ALT_SLASH, '/')
+  assert.equal(shortcuts.APP.GENERAL.SEARCH_IN_NEW_WINDOW, 'shift+enter')
+  assert.equal(shortcuts.APP.GENERAL.FIND_NEXT_ALT_ENTER, 'enter')
+  assert.equal(shortcuts.APP.GENERAL.FIND_PREVIOUS_ALT_ENTER, 'shift+enter')
+  assert.equal(shortcuts.APP.GENERAL.NEXT_TAB, 'control+tab')
+  assert.equal(shortcuts.APP.GENERAL.PREV_TAB, 'control+shift+tab')
+
+  assert.deepEqual(JSON.parse(sanitizeKeyboardShortcutOverrides(overrides)), {
+    APP: {
+      GENERAL: {
+        FOCUS_SEARCH: 'ctrl+k',
+      }
+    }
+  })
+})

--- a/tests/unit/keyboard-shortcuts.test.mjs
+++ b/tests/unit/keyboard-shortcuts.test.mjs
@@ -22,6 +22,7 @@ test('keeps contextual app shortcuts fixed', () => {
   }
 
   const shortcuts = getConfiguredKeyboardShortcuts(overrides)
+  const persistedShortcuts = getConfiguredKeyboardShortcuts(JSON.stringify(overrides))
   assert.equal(shortcuts.APP.GENERAL.FOCUS_SEARCH, 'ctrl+k')
   assert.equal(shortcuts.APP.GENERAL.FOCUS_SEARCH_ALT_SLASH, '/')
   assert.equal(shortcuts.APP.GENERAL.SEARCH_IN_NEW_WINDOW, 'shift+enter')
@@ -29,12 +30,18 @@ test('keeps contextual app shortcuts fixed', () => {
   assert.equal(shortcuts.APP.GENERAL.FIND_PREVIOUS_ALT_ENTER, 'shift+enter')
   assert.equal(shortcuts.APP.GENERAL.NEXT_TAB, 'control+tab')
   assert.equal(shortcuts.APP.GENERAL.PREV_TAB, 'control+shift+tab')
+  assert.deepEqual(persistedShortcuts, shortcuts)
 
-  assert.deepEqual(JSON.parse(sanitizeKeyboardShortcutOverrides(overrides)), {
+  const sanitizedOverrides = {
     APP: {
       GENERAL: {
         FOCUS_SEARCH: 'ctrl+k',
       }
     }
-  })
+  }
+  assert.deepEqual(JSON.parse(sanitizeKeyboardShortcutOverrides(overrides)), sanitizedOverrides)
+  assert.deepEqual(
+    JSON.parse(sanitizeKeyboardShortcutOverrides(JSON.stringify(overrides))),
+    sanitizedOverrides
+  )
 })


### PR DESCRIPTION
## Summary

- restore single-step Enter and Shift+Enter navigation in the app find bar
- keep context-dependent search, find, slash-focus, and tab-switcher shortcuts visible but non-editable
- sanitize previously persisted overrides for reserved shortcuts
- preserve default and repeated search-filter query values when opening searches in a new window
- add unit and Electron E2E regression coverage

## Root cause

The shortcut-customization work routed find-bar Enter bindings through both the configurable wrapper and the input's native handler, causing each keypress to run twice. New-window query serialization also converted an empty features array into an active empty feature while dropping other empty default filter values.

## Validation

- ESLint on the changed source and test files
- all 27 unit tests
- 12 relevant Electron E2E tests under a private Xvfb server
- dedicated shortcut restriction E2E coverage