### PR TITLE
feat(about): show runtime versions

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,3 +1,3 @@
 Always run Electron/Playwright E2E tests under a private X server using `xvfb-run -a -s "-screen 0 1920x1080x24"`.
-If the request somehow involves other repos (e.g. Website, APT, RPM, Flatpak, AUR, ...) you can find them in the parent folder .
+If the request somehow involves other repos (e.g. Website, APT, RPM, Flatpak, AUR, ...) you can find them in the parent folder.
 Before considering work done here, you need to reproduce it with the test suite (for bugfixes), and verify that your fix/feature works (unless otherwise told to do so).

--- a/e2e/tests/offline/about.spec.mjs
+++ b/e2e/tests/offline/about.spec.mjs
@@ -1,0 +1,17 @@
+import { test, expect, goTo } from '../../helpers/app.mjs'
+
+test('about page shows the bundled runtime versions', async ({ app, page }) => {
+  const expectedVersions = await app.electronApp.evaluate(() => ({
+    Electron: process.versions.electron,
+    Chromium: process.versions.chrome,
+    'Node.js': process.versions.node,
+    V8: process.versions.v8
+  }))
+
+  await goTo(page, 'about')
+
+  const versionList = page.locator('.runtimeVersions')
+  for (const [runtime, version] of Object.entries(expectedVersions)) {
+    await expect(versionList).toContainText(`${runtime}${version}`)
+  }
+})

--- a/e2e/tests/offline/about.spec.mjs
+++ b/e2e/tests/offline/about.spec.mjs
@@ -10,8 +10,13 @@ test('about page shows the bundled runtime versions', async ({ app, page }) => {
 
   await goTo(page, 'about')
 
-  const versionList = page.locator('.runtimeVersions')
-  for (const [runtime, version] of Object.entries(expectedVersions)) {
-    await expect(versionList).toContainText(`${runtime}${version}`)
+  const versionRows = page.locator('.runtimeVersion')
+  const expectedEntries = Object.entries(expectedVersions)
+  await expect(versionRows).toHaveCount(expectedEntries.length)
+
+  for (const [index, [runtime, version]] of expectedEntries.entries()) {
+    const row = versionRows.nth(index)
+    await expect(row.locator('dt')).toHaveText(runtime)
+    await expect(row.locator('dd')).toHaveText(version)
   }
 })

--- a/src/preload/interface.js
+++ b/src/preload/interface.js
@@ -21,6 +21,12 @@ ipcRenderer.on(IpcChannels.YT_DLP_BINARY_DOWNLOAD_PROGRESS, (_, progress) => {
 
 export default {
   isFlatpak: process.env.FLATPAK_ID !== undefined,
+  runtimeVersions: Object.freeze({
+    electron: process.versions.electron,
+    chromium: process.versions.chrome,
+    node: process.versions.node,
+    v8: process.versions.v8
+  }),
 
   /**
    * @param {string} title

--- a/src/renderer/views/About/About.css
+++ b/src/renderer/views/About/About.css
@@ -16,7 +16,28 @@
 .version {
   text-align: center;
   font-size: 2em;
-  margin-block-end: 1em;
+}
+
+.runtimeVersions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 4px 16px;
+  justify-content: center;
+  margin-block: 8px 2em;
+  margin-inline: 0;
+}
+
+.runtimeVersion {
+  display: flex;
+  gap: 4px;
+}
+
+.runtimeVersion dt {
+  font-weight: bold;
+}
+
+.runtimeVersion dd {
+  margin-inline-start: 0;
 }
 
 .about-chunks {

--- a/src/renderer/views/About/About.vue
+++ b/src/renderer/views/About/About.vue
@@ -13,6 +13,19 @@
         <div class="version">
           {{ versionNumber }} {{ $t("About.Beta") }}
         </div>
+        <dl
+          v-if="runtimeVersions"
+          class="runtimeVersions"
+        >
+          <div
+            v-for="runtime in runtimeVersions"
+            :key="runtime.name"
+            class="runtimeVersion"
+          >
+            <dt>{{ runtime.name }}</dt>
+            <dd>{{ runtime.version }}</dd>
+          </div>
+        </dl>
       </section>
       <section class="about-chunks">
         <figure
@@ -51,6 +64,14 @@ import packageDetails from '../../../../package.json'
 const { t } = useI18n()
 
 const versionNumber = `v${packageDetails.version}`
+const runtimeVersions = process.env.IS_ELECTRON
+  ? [
+      { name: 'Electron', version: window.ftElectron.runtimeVersions.electron },
+      { name: 'Chromium', version: window.ftElectron.runtimeVersions.chromium },
+      { name: 'Node.js', version: window.ftElectron.runtimeVersions.node },
+      { name: 'V8', version: window.ftElectron.runtimeVersions.v8 }
+    ]
+  : null
 
 const chunks = computed(() => [
   {


### PR DESCRIPTION
## Summary

- expose the bundled Electron, Chromium, Node.js, and V8 versions through the preload bridge
- display those runtime versions on the About page in Electron builds
- add an offline E2E test that checks the displayed values against the running Electron process
- fix a stray space in `AGENTS.md`

## Why

The About page previously showed only the OpenTubeX application version. Including the bundled runtime versions makes environment details easier to find when reporting or diagnosing problems.

Web builds remain unchanged because the runtime list is only rendered in Electron.

## Validation

- ESLint
- Stylelint
- `pnpm run test:unit` (26 passed)
- packaged offline Playwright test under Xvfb (1 passed)
- `git diff --check`