### PR TITLE
fix(ui): improve global progress visibility

### DIFF
--- a/e2e/tests/offline/settings.spec.mjs
+++ b/e2e/tests/offline/settings.spec.mjs
@@ -116,6 +116,7 @@ test.describe('synced setting indicators', () => {
   test.use({
     seed: {
       settings: {
+        reducedMotion: 'on',
         syncServerAutoSync: false,
         syncServerSyncSettings: true,
         syncServerToken: 'e2e-sync-token'

--- a/src/renderer/components/FtProgressBar/FtProgressBar.css
+++ b/src/renderer/components/FtProgressBar/FtProgressBar.css
@@ -1,12 +1,35 @@
 .progressBar {
   position: fixed;
-  block-size: 3px;
+  box-sizing: border-box;
+  block-size: 6px;
+  padding-block: 1px;
   inset-block-end: 0;
   inset-inline: 0;
   z-index: 4;
+  background-color: color-mix(in srgb, var(--bg-color) 75%, #000);
+  box-shadow: 0 -1px 3px rgb(0 0 0 / 65%);
+  pointer-events: none;
 }
 
 .progressBarFill {
+  position: relative;
   block-size: 100%;
   background-color: var(--primary-color);
+  background-image: linear-gradient(
+    color-mix(in srgb, var(--primary-color) 45%, #fff),
+    var(--primary-color) 55%,
+    color-mix(in srgb, var(--primary-color) 75%, #000)
+  );
+  box-shadow: 0 -2px 8px color-mix(in srgb, var(--primary-color) 70%, transparent);
+}
+
+.progressBarFill::after {
+  position: absolute;
+  inset-block: -1px;
+  inset-inline-end: 0;
+  inline-size: 6px;
+  border-radius: 999px;
+  background-color: color-mix(in srgb, var(--primary-color) 55%, #fff);
+  box-shadow: 0 0 8px 2px color-mix(in srgb, var(--primary-color) 75%, transparent);
+  content: '';
 }

--- a/src/renderer/components/FtProgressBar/FtProgressBar.css
+++ b/src/renderer/components/FtProgressBar/FtProgressBar.css
@@ -14,6 +14,7 @@
 .progressBarFill {
   position: relative;
   block-size: 100%;
+  overflow: hidden;
   background-color: var(--primary-color);
   background-image: linear-gradient(
     color-mix(in srgb, var(--primary-color) 45%, #fff),

--- a/src/renderer/components/FtProgressBar/FtProgressBar.vue
+++ b/src/renderer/components/FtProgressBar/FtProgressBar.vue
@@ -3,6 +3,7 @@
     class="progressBar"
   >
     <div
+      v-show="progressBarPercentage > 0"
       class="progressBarFill"
       :style="{ inlineSize: progressBarPercentage + '%' }"
     />


### PR DESCRIPTION
## What changed

- add a dark contrast rail around the global progress indicator
- add a highlighted gradient, glow, and bright leading edge to the progress fill
- prevent the fixed indicator from intercepting pointer input

## Why

The global progress bar used the same flat theme color as nearby controls, making it difficult to distinguish when it overlapped buttons. The added luminance and dark separation keep it legible independently of the selected theme color.

<img width="619" height="88" alt="image" src="https://github.com/user-attachments/assets/eb592bda-8dda-4855-b7df-482b4209fbb8" />

## Validation

- `pnpm exec stylelint src/renderer/components/FtProgressBar/FtProgressBar.css`
- `git diff --check`
- visually verified in the development profile over button controls