### PR TITLE
fix(subscriptions): align new feed with display filters

### DIFF
--- a/e2e/tests/offline/settings.spec.mjs
+++ b/e2e/tests/offline/settings.spec.mjs
@@ -185,7 +185,7 @@ test.describe('synced setting indicators', () => {
     expect(resetBox.x - syncBox.x - syncBox.width).toBeGreaterThanOrEqual(6)
 
     const tooltipText = select.locator('.selectTooltip .text')
-    await select.locator('.selectTooltip button').hover()
+    await select.locator('.selectTooltip button').focus()
     await expect(tooltipText).toBeVisible()
 
     const [tooltipTextBox, sectionBox] = await Promise.all([
@@ -236,7 +236,7 @@ test.describe('synced setting indicators', () => {
     await startupSelect.locator('select').selectOption('restoreTabLoadState')
 
     const tooltipText = startupSelect.locator('.selectTooltip .text')
-    await startupSelect.locator('.selectTooltip button').hover()
+    await startupSelect.locator('.selectTooltip button').focus()
     await expect(tooltipText).toBeVisible()
 
     const thumbnailIndicators = page.locator('.select')

--- a/e2e/tests/offline/subscriptions-new-feed.spec.mjs
+++ b/e2e/tests/offline/subscriptions-new-feed.spec.mjs
@@ -175,6 +175,62 @@ test.describe('new feed settings and seen state', () => {
   })
 })
 
+test.describe('new feed display filters', () => {
+  const hiddenPremiere = video('hidden-premiere', 'Hidden premiere', now + HOUR, {
+    isNewInSubscriptionFeed: true,
+    isUpcoming: true,
+    premiereDate: new Date(now + HOUR).toISOString()
+  })
+  const forbiddenVideo = video('forbidden-video', 'Blocked title', now - HOUR, {
+    isNewInSubscriptionFeed: true
+  })
+  const hiddenLive = video('hidden-live', 'Hidden live stream', now, {
+    isNewInSubscriptionFeed: true,
+    liveNow: true
+  })
+  const forbiddenPost = {
+    ...post('forbidden-post', 'Forbidden post', now),
+    author: 'Blocked channel'
+  }
+  const hiddenCache = [{
+    _id: CHANNEL_ID,
+    videos: [hiddenPremiere, forbiddenVideo],
+    videosTimestamp: new Date(now).toISOString(),
+    shorts: [],
+    shortsTimestamp: new Date(now).toISOString(),
+    liveStreams: [hiddenLive],
+    liveStreamsTimestamp: new Date(now).toISOString(),
+    communityPosts: [forbiddenPost],
+    communityPostsTimestamp: new Date(now).toISOString()
+  }]
+
+  test.use({
+    seed: {
+      settings: {
+        ...commonSettings,
+        forbiddenTitles: JSON.stringify(['Blocked']),
+        hideLiveStreams: true,
+        hideUpcomingPremieres: true,
+        showNewSubscriptionFeedIndicators: true
+      },
+      profiles: [profile()],
+      subscriptionCache: hiddenCache
+    }
+  })
+
+  test('does not advertise new content hidden by display preferences', async ({ page }) => {
+    await goTo(page, 'subscriptions')
+
+    await expect(page.getByRole('button', { name: 'Mark all as seen' })).toHaveCount(0)
+    await page.locator('[data-subscription-feed-tab="all"]').click()
+
+    await expect(page.getByText('There is no new content.')).toBeVisible()
+    await expect(page.getByRole('heading', { name: 'Videos', exact: true })).toHaveCount(0)
+    await expect(page.getByRole('heading', { name: 'Posts', exact: true })).toHaveCount(0)
+    await expect(page.getByRole('button', { name: 'Mark all as seen' })).toHaveCount(0)
+  })
+})
+
 test.describe('independent new feed setting', () => {
   test.use({
     seed: {
@@ -220,7 +276,9 @@ test.describe('large new feed refresh', () => {
     await page.locator('[data-subscription-feed-tab="all"]').click()
     await expect(page.getByText('There is no new content.')).toBeVisible()
 
-    await page.locator('.headerRefreshWidget .refreshButton').click()
+    const refreshNewContent = page.getByRole('button', { name: /Refresh New content/ })
+    await expect(refreshNewContent).toBeVisible()
+    await refreshNewContent.click()
     await expect(page.getByRole('heading', { name: 'Refresh all subscription feeds?' })).toBeVisible()
     await expect(page.getByText(/126 subscriptions can take a long time/)).toBeVisible()
 

--- a/e2e/tests/offline/subscriptions-new-feed.spec.mjs
+++ b/e2e/tests/offline/subscriptions-new-feed.spec.mjs
@@ -222,6 +222,11 @@ test.describe('new feed display filters', () => {
     await goTo(page, 'subscriptions')
 
     await expect(page.getByRole('button', { name: 'Mark all as seen' })).toHaveCount(0)
+    await page.locator('[data-subscription-feed-tab="posts"]').click()
+    await expect(page.getByText(/Posts feed last updated:/)).toBeVisible()
+    await expect(page.getByText('Forbidden post', { exact: true })).toHaveCount(0)
+    await expect(page.getByRole('button', { name: 'Mark all as seen' })).toHaveCount(0)
+
     await page.locator('[data-subscription-feed-tab="all"]').click()
 
     await expect(page.getByText('There is no new content.')).toBeVisible()

--- a/src/renderer/components/FtListLazyWrapper/FtListLazyWrapper.vue
+++ b/src/renderer/components/FtListLazyWrapper/FtListLazyWrapper.vue
@@ -74,7 +74,7 @@ import FtCommunityPost from '../FtCommunityPost/FtCommunityPost.vue'
 import FtListHashtag from '../FtListHashtag/FtListHashtag.vue'
 
 import store from '../../store/index'
-import { isRssUpcomingPremiere } from '../../helpers/subscriptions'
+import { isVideoHiddenByPreferences } from '../../helpers/subscriptions'
 
 const props = defineProps({
   data: {
@@ -218,16 +218,6 @@ const forbiddenTitles = computed(() => {
   return store.getters.getForbiddenTitlesParsed
 })
 
-/**
- * @param {{
- *  liveNow?: boolean,
- *  isUpcoming?: boolean,
- * }} video
- */
-function shouldHideLiveStreamVideo(video) {
-  return hideLiveStreams.value && (video.liveNow || video.isUpcoming)
-}
-
 const showResult = computed(() => {
   const dataType = finalDataType.value
 
@@ -236,33 +226,12 @@ const showResult = computed(() => {
   }
 
   if (dataType === 'video' || dataType === 'shortVideo') {
-    if (shouldHideLiveStreamVideo(props.data)) {
-      // hide livestreams
-      return false
-    }
-
-    if (hideUpcomingPremieres.value &&
-        // Observed for premieres in Local API Channels.
-        (props.data.premiereDate != null ||
-          // Invidious API
-          // `premiereTimestamp` only available on premiered videos
-          // https://docs.invidious.io/api/common_types/#videoobject
-          props.data.premiereTimestamp != null ||
-          isRssUpcomingPremiere(props.data))) {
-      // hide upcoming
-      return false
-    }
-
-    const lowerCaseAuthor = props.data.author?.toLowerCase()
-
-    if (channelsHiddenNames.value.has(props.data.authorId) || channelsHiddenNames.value.has(props.data.author) || (forbiddenTitles.value.some((text) => lowerCaseAuthor.includes(text)))) {
-      // hide videos by author
-      return false
-    }
-
-    const lowerCaseTitle = props.data.title?.toLowerCase()
-
-    if (forbiddenTitles.value.some((text) => lowerCaseTitle.includes(text))) {
+    if (isVideoHiddenByPreferences(props.data, {
+      hideLiveStreams: hideLiveStreams.value,
+      hideUpcomingPremieres: hideUpcomingPremieres.value,
+      hiddenChannelNames: channelsHiddenNames.value,
+      forbiddenTitles: forbiddenTitles.value
+    })) {
       return false
     }
   } else if (dataType === 'channel') {

--- a/src/renderer/components/SubscriptionsNew.vue
+++ b/src/renderer/components/SubscriptionsNew.vue
@@ -1,5 +1,6 @@
 <template>
   <SubscriptionsTabUi
+    ref="tabUi"
     class="newFeed"
     :is-loading="isLoading"
     :video-list="newMedia"
@@ -11,8 +12,8 @@
     stable-item-keys
     @refresh="refresh"
   >
-    <template #before-list>
-      <h3 v-if="newMedia.length > 0">
+    <template #before-list="{ hasVisibleContent }">
+      <h3 v-if="hasVisibleContent">
         {{ $t('Global.Videos') }}
       </h3>
     </template>
@@ -43,7 +44,7 @@
 </template>
 
 <script setup>
-import { computed } from 'vue'
+import { computed, useTemplateRef } from 'vue'
 import { useI18n } from 'vue-i18n'
 
 import FtElementList from './FtElementList/FtElementList.vue'
@@ -56,6 +57,7 @@ import { useRefreshAllSubscriptionFeeds } from '../composables/useRefreshAllSubs
 import { isHistoryEntryWatched } from '../helpers/history'
 
 const { t } = useI18n()
+const tabUi = useTemplateRef('tabUi')
 const {
   activeSubscriptionIds,
   attemptedFetch,
@@ -103,13 +105,21 @@ const newContent = computed(() => {
 })
 
 const newMedia = computed(() => newContent.value.filter(entry => entry.videoId != null))
-const newPosts = computed(() => newContent.value.filter(entry => entry.postId != null))
+const forbiddenTitles = computed(() => store.getters.getForbiddenTitlesParsed)
+const newPosts = computed(() => newContent.value.filter(entry => {
+  const lowerCaseAuthor = entry.author?.toLowerCase()
+
+  return entry.postId != null &&
+    !forbiddenTitles.value.some(text => lowerCaseAuthor?.includes(text))
+}))
 
 const isLoading = computed(() => {
   return !store.getters.getSubscriptionCacheReady || isRefreshing.value
 })
 
-const hasNewContent = computed(() => newContent.value.length > 0)
+const hasNewContent = computed(() => {
+  return newPosts.value.length > 0 || tabUi.value?.hasNewContent === true
+})
 
 defineExpose({
   refresh,

--- a/src/renderer/components/SubscriptionsPosts.vue
+++ b/src/renderer/components/SubscriptionsPosts.vue
@@ -219,11 +219,6 @@ function loadPostsFromCacheSometimes() {
   isLoading.value = false
 }
 
-/** @type {import('vue').ComputedRef<string[]>} */
-const forbiddenTitles = computed(() => {
-  return store.getters.getForbiddenTitlesParsed
-})
-
 function loadPostsFromCacheForAllActiveProfileChannels() {
   const postList_ = cacheEntriesForAllActiveProfileChannels.value.flatMap((cacheEntry) => {
     return cacheEntry.posts
@@ -233,7 +228,7 @@ function loadPostsFromCacheForAllActiveProfileChannels() {
     return b.publishedTime - a.publishedTime
   })
 
-  postList.value = postList_.filter(post => !forbiddenTitles.value.some(text => post.author.toLowerCase().includes(text)))
+  postList.value = postList_
   isLoading.value = false
 }
 

--- a/src/renderer/components/SubscriptionsTabUi/SubscriptionsTabUi.vue
+++ b/src/renderer/components/SubscriptionsTabUi/SubscriptionsTabUi.vue
@@ -207,13 +207,12 @@ const forbiddenTitles = computed(() => store.getters.getForbiddenTitlesParsed)
 const filteredVideoList = computed(() => {
   let videoList = props.videoList
 
-  if (!props.isCommunity) {
-    videoList = videoList.filter(video => !isVideoHiddenByPreferences(video, {
-      hideLiveStreams: hideLiveStreams.value,
-      hideUpcomingPremieres: hideUpcomingPremieres.value,
-      forbiddenTitles: forbiddenTitles.value
-    }))
-  }
+  // Subscription feeds intentionally ignore the general hidden-channel list.
+  videoList = videoList.filter(video => !isVideoHiddenByPreferences(video, {
+    hideLiveStreams: hideLiveStreams.value,
+    hideUpcomingPremieres: hideUpcomingPremieres.value,
+    forbiddenTitles: forbiddenTitles.value
+  }))
 
   if (props.onlyShowNew) {
     videoList = videoList.filter(entry => {

--- a/src/renderer/components/SubscriptionsTabUi/SubscriptionsTabUi.vue
+++ b/src/renderer/components/SubscriptionsTabUi/SubscriptionsTabUi.vue
@@ -48,7 +48,10 @@
         {{ isCommunity ? $t("Subscriptions.Empty Posts") : $t("Subscriptions.Empty Channels") }}
       </p>
     </FtFlexBox>
-    <slot name="before-list" />
+    <slot
+      name="before-list"
+      :has-visible-content="activeVideoList.length > 0"
+    />
     <FtElementList
       :data="activeVideoList"
       :use-channels-hidden-preference="false"
@@ -88,6 +91,7 @@ import store from '../../store/index'
 import { KeyboardShortcuts } from '../../../constants'
 import { isHistoryEntryWatched } from '../../helpers/history'
 import { matchesKeyboardShortcut } from '../../helpers/keyboardShortcuts'
+import { isVideoHiddenByPreferences } from '../../helpers/subscriptions'
 import { useTabContext } from '../../tabs/TabContext'
 
 const { tabId, isTabPresented } = useTabContext()
@@ -196,8 +200,20 @@ const onlyShowLatestFromChannelNumber = computed(() => {
   return store.getters.getOnlyShowLatestFromChannelNumber
 })
 
+const hideLiveStreams = computed(() => store.getters.getHideLiveStreams)
+const hideUpcomingPremieres = computed(() => store.getters.getHideUpcomingPremieres)
+const forbiddenTitles = computed(() => store.getters.getForbiddenTitlesParsed)
+
 const filteredVideoList = computed(() => {
   let videoList = props.videoList
+
+  if (!props.isCommunity) {
+    videoList = videoList.filter(video => !isVideoHiddenByPreferences(video, {
+      hideLiveStreams: hideLiveStreams.value,
+      hideUpcomingPremieres: hideUpcomingPremieres.value,
+      forbiddenTitles: forbiddenTitles.value
+    }))
+  }
 
   if (props.onlyShowNew) {
     videoList = videoList.filter(entry => {

--- a/src/renderer/helpers/subscriptions.js
+++ b/src/renderer/helpers/subscriptions.js
@@ -258,6 +258,48 @@ export function isRssUpcomingPremiere(video) {
 }
 
 /**
+ * @param {object} video
+ * @param {{
+ *  hideLiveStreams?: boolean,
+ *  hideUpcomingPremieres?: boolean,
+ *  hiddenChannelNames?: Set<string>,
+ *  forbiddenTitles?: string[],
+ * }} preferences
+ */
+export function isVideoHiddenByPreferences(video, {
+  hideLiveStreams = false,
+  hideUpcomingPremieres = false,
+  hiddenChannelNames = new Set(),
+  forbiddenTitles = []
+} = {}) {
+  if (hideLiveStreams && (video.liveNow || video.isUpcoming)) {
+    return true
+  }
+
+  if (
+    hideUpcomingPremieres &&
+    (
+      video.premiereDate != null ||
+      video.premiereTimestamp != null ||
+      isRssUpcomingPremiere(video)
+    )
+  ) {
+    return true
+  }
+
+  if (hiddenChannelNames.has(video.authorId) || hiddenChannelNames.has(video.author)) {
+    return true
+  }
+
+  const lowerCaseAuthor = video.author?.toLowerCase()
+  const lowerCaseTitle = video.title?.toLowerCase()
+
+  return forbiddenTitles.some(text =>
+    lowerCaseAuthor?.includes(text) || lowerCaseTitle?.includes(text)
+  )
+}
+
+/**
  * @param {string} videoId
  */
 async function fetchRssVideoUpcomingInfo(videoId) {


### PR DESCRIPTION
## Summary

- centralize video visibility checks for live streams, upcoming premieres, hidden channels, and forbidden text
- apply those checks before subscription lists calculate headings, empty states, and new-content controls
- keep the New feed consistent for community posts from forbidden authors
- add regression coverage for hidden new content

## Root cause

The New feed and its `hasNewContent` state were computed from raw cached entries, while cards applied display preferences later during rendering. An unseen upcoming premiere could therefore produce a Videos heading and “Mark all as seen” button even though its card was hidden.

## User impact

Subscription headings, empty states, indicators, and “Mark all as seen” now agree with the content that is actually visible. Hidden entries retain their unseen state and can appear if the relevant preference is later disabled.

## Validation

- ESLint on all changed source and test files
- `pnpm test:unit` — 27 passed
- Electron E2E renderer packaging
- subscription New-feed Playwright suite under Xvfb — 6 passed