### PR TITLE
Fix player overlays and responsive layouts

### DIFF
--- a/e2e/tests/network/watch.spec.mjs
+++ b/e2e/tests/network/watch.spec.mjs
@@ -226,6 +226,7 @@ test.describe('watch page', () => {
         tabBarBox,
         topNavBox,
         routeBox,
+        sideNavBox,
         headerBox,
         titleBox,
         actionsBox,
@@ -235,6 +236,7 @@ test.describe('watch page', () => {
         page.locator('.tabBar.vertical').boundingBox(),
         page.locator('.topNav').boundingBox(),
         page.locator('.app > .routerView').boundingBox(),
+        page.locator('.sideNav').boundingBox(),
         commentHeader.boundingBox(),
         commentTitle.boundingBox(),
         commentActions.boundingBox(),
@@ -246,6 +248,8 @@ test.describe('watch page', () => {
         topNavBox.x >= tabBarBox.x + tabBarBox.width - 1 &&
         topNavBox.x + topNavBox.width <= viewportWidth + 1 &&
         routeBox.x + routeBox.width <= viewportWidth + 1 &&
+        sideNavBox.x >= tabBarBox.x + tabBarBox.width - 1 &&
+        sideNavBox.x + sideNavBox.width <= viewportWidth + 1 &&
         actionsBox.y >= titleBox.y + titleBox.height &&
         Math.abs(actionsBox.width - headerBox.width) <= 1 &&
         sortBox.x >= headerBox.x &&

--- a/e2e/tests/network/watch.spec.mjs
+++ b/e2e/tests/network/watch.spec.mjs
@@ -490,18 +490,27 @@ test.describe('watch page', () => {
     const actions = page.locator('.fullscreenActions')
     const seekBar = page.locator('.shaka-seek-bar-container')
     const fullscreenButton = page.locator('.shaka-fullscreen-button')
+    await actions.evaluate((element) => {
+      const sponsorBlockNotice = element.cloneNode(false)
+      sponsorBlockNotice.className = 'skippedSegmentsWrapper'
+      element.parentElement.append(sponsorBlockNotice)
+    })
+    const sponsorBlockNotice = page.locator('.skippedSegmentsWrapper')
 
     await expect(actions).toBeVisible()
     await expect(actions).toHaveCSS('z-index', '2')
+    await expect(sponsorBlockNotice).toHaveCSS('z-index', '3')
     await fullscreenButton.hover()
     await expect(fullscreenButton).toHaveClass(/shaka-tooltip/)
     await expect(actions).toHaveCSS('z-index', '0')
+    await expect(sponsorBlockNotice).toHaveCSS('z-index', '3')
     const seekBarBounds = await seekBar.boundingBox()
     await page.mouse.move(
       seekBarBounds.x + (seekBarBounds.width / 2),
       seekBarBounds.y + (seekBarBounds.height / 2)
     )
     await expect(actions).toHaveCSS('z-index', '0')
+    await expect(sponsorBlockNotice).toHaveCSS('z-index', '0')
   })
 
   test('full window playlist action shows its prompt above the player', async ({ page, innertube }) => {

--- a/e2e/tests/network/watch.spec.mjs
+++ b/e2e/tests/network/watch.spec.mjs
@@ -30,6 +30,14 @@ async function openVideo(page, video = { id: 'jNQXAC9IVRw', title: 'Me at the zo
   await expect(page.locator('.videoTitle')).toContainText(video.title, { timeout: 30_000 })
 }
 
+async function setWindowWidth(app, width) {
+  await app.electronApp.evaluate(({ BrowserWindow }, targetWidth) => {
+    const browserWindow = BrowserWindow.getAllWindows()[0]
+    const bounds = browserWindow.getBounds()
+    browserWindow.setBounds({ ...bounds, width: targetWidth })
+  }, width)
+}
+
 test.describe('watch page', () => {
   test('shows video metadata', async ({ page, innertube }) => {
     test.skip(innertube.replay, 'watch page hydration needs the real API')
@@ -189,7 +197,7 @@ test.describe('watch page', () => {
     await expect(layout).toHaveClass(/noSidebar/)
   })
 
-  test('comments load on request', async ({ page, innertube }) => {
+  test('comments load on request', async ({ app, page, innertube }) => {
     test.skip(innertube.replay, 'watch page hydration needs the real API')
     await openVideo(page)
 
@@ -200,32 +208,44 @@ test.describe('watch page', () => {
     await expect(page.locator('.commentsTitle')).toBeVisible({ timeout: 30_000 })
     expect(await page.locator('.comment').count()).toBeGreaterThan(0)
 
-    const commentsWrapper = page.locator('.commentsContentWrapper')
     const commentHeader = page.locator('.commentHeader')
     const commentTitle = commentHeader.locator('.commentsTitle')
     const commentActions = commentHeader.locator('.commentHeaderActions')
     const commentSort = commentActions.locator('.select')
     const reloadComments = commentActions.locator('.reloadComments')
 
-    await commentsWrapper.evaluate((element) => { element.style.inlineSize = '700px' })
+    await page.evaluate(() => {
+      const store = document.querySelector('#app').__vue_app__.config.globalProperties.$store
+      store.commit('setUseVerticalTabBar', true)
+      store.commit('setVerticalTabBarWidth', 180)
+    })
+    await expect(page.locator('.app')).toHaveClass(/verticalTabs/)
+    await setWindowWidth(app, 660)
     await expect.poll(async () => {
-      const [titleBox, actionsBox] = await Promise.all([
-        commentTitle.boundingBox(),
-        commentActions.boundingBox()
-      ])
-      return actionsBox.y < titleBox.y + titleBox.height
-    }).toBe(true)
-
-    await commentsWrapper.evaluate((element) => { element.style.inlineSize = '480px' })
-    await expect.poll(async () => {
-      const [headerBox, titleBox, actionsBox, sortBox, reloadBox] = await Promise.all([
+      const [
+        tabBarBox,
+        topNavBox,
+        routeBox,
+        headerBox,
+        titleBox,
+        actionsBox,
+        sortBox,
+        reloadBox
+      ] = await Promise.all([
+        page.locator('.tabBar.vertical').boundingBox(),
+        page.locator('.topNav').boundingBox(),
+        page.locator('.app > .routerView').boundingBox(),
         commentHeader.boundingBox(),
         commentTitle.boundingBox(),
         commentActions.boundingBox(),
         commentSort.boundingBox(),
         reloadComments.boundingBox()
       ])
+      const viewportWidth = await page.evaluate(() => window.innerWidth)
       return (
+        topNavBox.x >= tabBarBox.x + tabBarBox.width - 1 &&
+        topNavBox.x + topNavBox.width <= viewportWidth + 1 &&
+        routeBox.x + routeBox.width <= viewportWidth + 1 &&
         actionsBox.y >= titleBox.y + titleBox.height &&
         Math.abs(actionsBox.width - headerBox.width) <= 1 &&
         sortBox.x >= headerBox.x &&
@@ -233,7 +253,28 @@ test.describe('watch page', () => {
       )
     }).toBe(true)
     await reloadComments.click({ trial: true })
-    await commentsWrapper.evaluate((element) => { element.style.inlineSize = '' })
+
+    await page.evaluate(() => {
+      const store = document.querySelector('#app').__vue_app__.config.globalProperties.$store
+      store.commit('setUseVerticalTabBar', false)
+    })
+    await expect(page.locator('.app')).not.toHaveClass(/verticalTabs/)
+    await expect.poll(async () => {
+      const [topNavBox, routeBox, titleBox, actionsBox] = await Promise.all([
+        page.locator('.topNav').boundingBox(),
+        page.locator('.app > .routerView').boundingBox(),
+        commentTitle.boundingBox(),
+        commentActions.boundingBox()
+      ])
+      const viewportWidth = await page.evaluate(() => window.innerWidth)
+      return (
+        topNavBox.x <= 1 &&
+        topNavBox.x + topNavBox.width <= viewportWidth + 1 &&
+        routeBox.x + routeBox.width <= viewportWidth + 1 &&
+        actionsBox.y < titleBox.y + titleBox.height
+      )
+    }).toBe(true)
+    await setWindowWidth(app, 1600)
 
     await page.evaluate(() => {
       const store = document.querySelector('#app').__vue_app__.config.globalProperties.$store

--- a/e2e/tests/network/watch.spec.mjs
+++ b/e2e/tests/network/watch.spec.mjs
@@ -200,6 +200,41 @@ test.describe('watch page', () => {
     await expect(page.locator('.commentsTitle')).toBeVisible({ timeout: 30_000 })
     expect(await page.locator('.comment').count()).toBeGreaterThan(0)
 
+    const commentsWrapper = page.locator('.commentsContentWrapper')
+    const commentHeader = page.locator('.commentHeader')
+    const commentTitle = commentHeader.locator('.commentsTitle')
+    const commentActions = commentHeader.locator('.commentHeaderActions')
+    const commentSort = commentActions.locator('.select')
+    const reloadComments = commentActions.locator('.reloadComments')
+
+    await commentsWrapper.evaluate((element) => { element.style.inlineSize = '700px' })
+    await expect.poll(async () => {
+      const [titleBox, actionsBox] = await Promise.all([
+        commentTitle.boundingBox(),
+        commentActions.boundingBox()
+      ])
+      return actionsBox.y < titleBox.y + titleBox.height
+    }).toBe(true)
+
+    await commentsWrapper.evaluate((element) => { element.style.inlineSize = '480px' })
+    await expect.poll(async () => {
+      const [headerBox, titleBox, actionsBox, sortBox, reloadBox] = await Promise.all([
+        commentHeader.boundingBox(),
+        commentTitle.boundingBox(),
+        commentActions.boundingBox(),
+        commentSort.boundingBox(),
+        reloadComments.boundingBox()
+      ])
+      return (
+        actionsBox.y >= titleBox.y + titleBox.height &&
+        Math.abs(actionsBox.width - headerBox.width) <= 1 &&
+        sortBox.x >= headerBox.x &&
+        reloadBox.x + reloadBox.width <= headerBox.x + headerBox.width
+      )
+    }).toBe(true)
+    await reloadComments.click({ trial: true })
+    await commentsWrapper.evaluate((element) => { element.style.inlineSize = '' })
+
     await page.evaluate(() => {
       const store = document.querySelector('#app').__vue_app__.config.globalProperties.$store
       store.commit('setGeneralAutoLoadMorePaginatedItemsEnabled', true)

--- a/e2e/tests/network/watch.spec.mjs
+++ b/e2e/tests/network/watch.spec.mjs
@@ -581,7 +581,15 @@ test.describe('watch page', () => {
     await expect(actions).toHaveCSS('z-index', '2')
     await expect(sponsorBlockNotice).toHaveCSS('z-index', '3')
     await fullscreenButton.hover()
-    await expect(fullscreenButton).toHaveClass(/shaka-tooltip/)
+    // The Shaka tooltip is a hover-only ::after pseudo-element whose content is
+    // pulled from the button's aria-label. Assert it actually renders (rather
+    // than only checking the static capability class) so a tooltip
+    // rendering/config regression fails the test; the z-index checks below then
+    // confirm it sits above the action dock.
+    await expect.poll(() => fullscreenButton.evaluate((element) => {
+      const { content } = getComputedStyle(element, '::after')
+      return content !== 'none' && content !== 'normal' && content !== ''
+    })).toBe(true)
     await expect(actions).toHaveCSS('z-index', '0')
     await expect(sponsorBlockNotice).toHaveCSS('z-index', '3')
     const seekBarBounds = await seekBar.boundingBox()

--- a/e2e/tests/network/watch.spec.mjs
+++ b/e2e/tests/network/watch.spec.mjs
@@ -481,7 +481,7 @@ test.describe('watch page', () => {
     await expect(title).toHaveAttribute('aria-expanded', 'false')
   })
 
-  test('fullscreen seek preview appears above the action pill', async ({ page, innertube }) => {
+  test('fullscreen player overlays appear above the action pill', async ({ page, innertube }) => {
     test.skip(innertube.replay, 'watch page hydration needs the real API')
     await openVideo(page)
     await waitForPlaybackOrSkip(test, page)
@@ -489,9 +489,13 @@ test.describe('watch page', () => {
     await setPlayerFullscreen(page, true)
     const actions = page.locator('.fullscreenActions')
     const seekBar = page.locator('.shaka-seek-bar-container')
+    const fullscreenButton = page.locator('.shaka-fullscreen-button')
 
     await expect(actions).toBeVisible()
     await expect(actions).toHaveCSS('z-index', '2')
+    await fullscreenButton.hover()
+    await expect(fullscreenButton).toHaveClass(/shaka-tooltip/)
+    await expect(actions).toHaveCSS('z-index', '0')
     const seekBarBounds = await seekBar.boundingBox()
     await page.mouse.move(
       seekBarBounds.x + (seekBarBounds.width / 2),

--- a/e2e/tests/offline/appearance.spec.mjs
+++ b/e2e/tests/offline/appearance.spec.mjs
@@ -1,5 +1,22 @@
 import { test, expect, goTo, sel } from '../../helpers/app.mjs'
 
+async function setWindowWidth(app, width) {
+  await app.electronApp.evaluate(({ BrowserWindow }, targetWidth) => {
+    const browserWindow = BrowserWindow.getAllWindows()[0]
+    const bounds = browserWindow.getBounds()
+    browserWindow.setBounds({ ...bounds, width: targetWidth })
+  }, width)
+}
+
+async function enableVerticalTabBar(page, width) {
+  await page.evaluate((tabBarWidth) => {
+    const store = document.querySelector('#app').__vue_app__.config.globalProperties.$store
+    store.commit('setUseVerticalTabBar', true)
+    store.commit('setVerticalTabBarWidth', tabBarWidth)
+  }, width)
+  await expect(page.locator('.app')).toHaveClass(/verticalTabs/)
+}
+
 test.describe('distraction and appearance settings', () => {
   test.use({
     seed: {
@@ -34,5 +51,62 @@ test.describe('default appearance', () => {
     await expect(page.locator(sel.sideNavLink('trending'))).not.toHaveCount(0)
     await expect(page.locator('.topNav .profiles .colorOption').first()).toBeVisible()
     await expect(page.locator('body')).toHaveClass(/system/)
+  })
+})
+
+test.describe('top nav beside the vertical tab bar', () => {
+  test('search bar and profile selector stay clear of the tab column', async ({ app, page }) => {
+    await enableVerticalTabBar(page, 220)
+
+    // Wide enough viewport for the 3-column grid, but the top nav itself (beside
+    // the 220px tab column) is not — the profile selector on the inline-end must
+    // not overflow off the right edge (the grid must fall back to the flex row).
+    await setWindowWidth(app, 1000)
+    const profiles = page.locator('.topNav .profiles')
+    await expect.poll(async () => {
+      const [tabBarBox, profilesBox] = await Promise.all([
+        page.locator('.tabBar.vertical').boundingBox(),
+        profiles.boundingBox()
+      ])
+      const viewportWidth = await page.evaluate(() => window.innerWidth)
+      return (
+        profilesBox.x >= tabBarBox.x + tabBarBox.width - 1 &&
+        profilesBox.x + profilesBox.width <= viewportWidth + 1
+      )
+    }).toBe(true)
+
+    // Mobile layout: the fixed search bar opens beside the tab column, not behind it.
+    await setWindowWidth(app, 660)
+    await page.locator('.topNav .navSearchButton').click()
+    const searchContainer = page.locator('.topNav .searchContainer')
+    await expect.poll(async () => {
+      const [tabBarBox, searchBox] = await Promise.all([
+        page.locator('.tabBar.vertical').boundingBox(),
+        searchContainer.boundingBox()
+      ])
+      const viewportWidth = await page.evaluate(() => window.innerWidth)
+      return (
+        searchBox.x >= tabBarBox.x + tabBarBox.width - 1 &&
+        searchBox.x + searchBox.width <= viewportWidth + 1
+      )
+    }).toBe(true)
+  })
+})
+
+test.describe('narrow layout top padding', () => {
+  test('page content clears the fixed top nav and tab bar', async ({ app, page }) => {
+    // On mobile widths the top nav is fixed and taller when a tab bar is
+    // present; the page content must keep a gap below it instead of tucking
+    // underneath (previously the content sat flush against the nav).
+    await setWindowWidth(app, 560)
+    const routerView = page.locator('.app > .routerView').first()
+    await expect.poll(async () => {
+      const [topNavBox, routerBox] = await Promise.all([
+        page.locator('.topNav').boundingBox(),
+        routerView.boundingBox()
+      ])
+      const gap = routerBox.y - (topNavBox.y + topNavBox.height)
+      return gap >= 4 && gap <= 40
+    }).toBe(true)
   })
 })

--- a/e2e/tests/offline/history.spec.mjs
+++ b/e2e/tests/offline/history.spec.mjs
@@ -42,6 +42,21 @@ test.describe('watch history', () => {
     await expect(titles.first()).toContainText('First test video')
   })
 
+  test('the sort options row keeps a gap above the video grid', async ({ page }) => {
+    await goTo(page, 'history')
+    await expect(page.getByText('First test video')).toBeVisible()
+
+    const optionsRow = page.locator('.optionsRow')
+    const firstVideo = page.locator('.ft-list-video, [class*="ft-list-video"]').first()
+    await expect.poll(async () => {
+      const [optionsBox, videoBox] = await Promise.all([
+        optionsRow.boundingBox(),
+        firstVideo.boundingBox()
+      ])
+      return videoBox.y - (optionsBox.y + optionsBox.height)
+    }).toBeGreaterThanOrEqual(10)
+  })
+
   test('history search filters entries', async ({ page }) => {
     await goTo(page, 'history')
     await expect(page.getByText('First test video')).toBeVisible()

--- a/e2e/tests/offline/playlists.spec.mjs
+++ b/e2e/tests/offline/playlists.spec.mjs
@@ -86,6 +86,11 @@ test.describe('seeded playlists', () => {
     await expect(page.locator(sel.activeTab)).toContainText('My seeded playlist')
 
     await page.locator(sel.newTabButton).click()
+    await expect(page.locator(sel.tabs)).toHaveCount(2)
+    // Wait for the new tab to settle on its landing page before switching back.
+    // Clicking while its title is still resolving races the tab bar re-render,
+    // and the switch can be lost on a loaded machine.
+    await expect(page.locator(sel.activeTab)).toContainText('Subscriptions')
     await expect(page.locator(sel.activeTab)).not.toContainText('My seeded playlist')
     await page.locator(sel.tabs).filter({ hasText: 'My seeded playlist' }).click()
 

--- a/e2e/tests/offline/search-history.spec.mjs
+++ b/e2e/tests/offline/search-history.spec.mjs
@@ -135,3 +135,52 @@ test.describe('search history suggestions', () => {
     await expect(suggestions(page).first()).toContainText('baking bread')
   })
 })
+
+test.describe('search suggestion remove button layout', () => {
+  test('the remove control stays compact in a narrow dropdown', async ({ app, page }) => {
+    // Squeeze the search dropdown by shrinking the window and adding the vertical
+    // tab column, so the suggestion text has to truncate. The remove button must
+    // stay clear of the text instead of covering it (2nd screenshot bug).
+    await app.electronApp.evaluate(({ BrowserWindow }) => {
+      const browserWindow = BrowserWindow.getAllWindows()[0]
+      const bounds = browserWindow.getBounds()
+      browserWindow.setBounds({ ...bounds, width: 760 })
+    })
+    await page.locator(sel.searchInput).click()
+    await expect(suggestions(page)).toHaveCount(2)
+
+    // Narrow the middle column further; the input keeps focus so the dropdown
+    // stays open.
+    await page.evaluate(() => {
+      const store = document.querySelector('#app').__vue_app__.config.globalProperties.$store
+      store.commit('setUseVerticalTabBar', true)
+      store.commit('setVerticalTabBarWidth', 300)
+    })
+    await expect(page.locator('.app')).toHaveClass(/verticalTabs/)
+
+    const entry = suggestions(page).first()
+    const removeButton = entry.locator('.removeButton')
+    await entry.hover()
+
+    // The remove control is a compact icon (~26px) rather than the wider
+    // "Remove" word (~47px), so it no longer eats into the suggestion text.
+    await expect.poll(async () => {
+      const removeBox = await removeButton.boundingBox()
+      return removeBox.width
+    }).toBeLessThan(40)
+  })
+
+  test('the leading icon is vertically centered in its row', async ({ page }) => {
+    await page.locator(sel.searchInput).click()
+    const entry = suggestions(page).first()
+    await expect(entry).toBeVisible()
+    const icon = entry.locator('.searchResultIcon')
+
+    await expect.poll(async () => {
+      const [rowBox, iconBox] = await Promise.all([entry.boundingBox(), icon.boundingBox()])
+      const rowCenter = rowBox.y + rowBox.height / 2
+      const iconCenter = iconBox.y + iconBox.height / 2
+      return Math.abs(rowCenter - iconCenter)
+    }).toBeLessThanOrEqual(1.5)
+  })
+})

--- a/e2e/tests/offline/subscriptions-scroll.spec.mjs
+++ b/e2e/tests/offline/subscriptions-scroll.spec.mjs
@@ -3,6 +3,23 @@ import { test, expect, goTo, sel } from '../../helpers/app.mjs'
 const now = Date.now()
 const CHANNEL_ID = 'UCaaaaaaaaaaaaaaaaaaaaaa'
 
+/**
+ * Scroll to an exact offset. The feed fills in lazily, so on a loaded machine
+ * the document can still be too short when we scroll, which silently clamps the
+ * offset and fails the assertion. Wait for enough scrollable height first.
+ *
+ * @param {import('@playwright/test').Page} page
+ * @param {number} top
+ */
+async function scrollFeedTo(page, top) {
+  await expect
+    .poll(() => page.evaluate(() => document.documentElement.scrollHeight - window.innerHeight))
+    .toBeGreaterThanOrEqual(top)
+
+  await page.evaluate((offset) => window.scrollTo(0, offset), top)
+  await expect.poll(() => page.evaluate(() => window.scrollY)).toBe(top)
+}
+
 const videos = Array.from({ length: 80 }, (_, index) => ({
   videoId: `video${String(index).padStart(6, '0')}`,
   title: `Feed video ${String(index).padStart(2, '0')}`,
@@ -43,8 +60,7 @@ test.use({
 
 test('a background feed refresh resets its logical tab scroll across restart', async ({ app, page }) => {
   await expect(page.getByText('Feed video 00')).toBeVisible()
-  await page.evaluate(() => window.scrollTo(0, 600))
-  await expect.poll(() => page.evaluate(() => window.scrollY)).toBe(600)
+  await scrollFeedTo(page, 600)
 
   const subscriptionsTabId = await page.locator(sel.tabs).first().getAttribute('data-tab-id')
   await page.locator(sel.newTabButton).click()
@@ -92,8 +108,7 @@ test('a background feed refresh resets its logical tab scroll across restart', a
 
 test('a visible feed stays at the top while refreshed content is applied', async ({ page }) => {
   await expect(page.getByText('Feed video 00')).toBeVisible()
-  await page.evaluate(() => window.scrollTo(0, 600))
-  await expect.poll(() => page.evaluate(() => window.scrollY)).toBe(600)
+  await scrollFeedTo(page, 600)
 
   const displacedScroll = await page.evaluate(async () => {
     window.dispatchEvent(new CustomEvent('opentubex-subscription-refresh-completed', {

--- a/src/renderer/App.css
+++ b/src/renderer/App.css
@@ -20,6 +20,12 @@
   margin-inline: 10px;
 }
 
+.app > .routerView {
+  min-inline-size: 0;
+  container-name: route;
+  container-type: inline-size;
+}
+
 .banner {
   inline-size: 85%;
   margin-block: 40px 0;

--- a/src/renderer/App.css
+++ b/src/renderer/App.css
@@ -369,6 +369,12 @@
   .sideNavBackdrop {
     display: none;
   }
+
+  /* The fixed top nav is taller when a tab bar is present, so restore the gap
+     between it and the page content (the .flexBox rule above shrinks it). */
+  .app:has(.tabBar) .routerView {
+    margin-block-start: 68px;
+  }
 }
 
 /* Vertical tab bar layout: the tab bar is a fixed column on the inline-start
@@ -393,5 +399,13 @@
 
   .watchSideNavOverlay.verticalTabs :deep(.sideNav) {
     inset-inline-start: var(--vertical-tab-bar-width, 220px);
+  }
+}
+
+/* The mobile bottom nav is fixed, so shift it past the vertical tab column */
+@media only screen and (width <= 680px) {
+  .app.verticalTabs :deep(.sideNav) {
+    inset-inline-start: var(--vertical-tab-bar-width, 220px);
+    inline-size: calc(100% - var(--vertical-tab-bar-width, 220px));
   }
 }

--- a/src/renderer/components/CommentSection/CommentSection.css
+++ b/src/renderer/components/CommentSection/CommentSection.css
@@ -2,14 +2,15 @@
   padding-block: 0;
   padding-inline: 16px;
 
-  /* Contain the floated header actions so they don't spill outside the card,
-     e.g. in the empty state where the message is shorter than the sort select */
+  /* Contain floated comment content inside the card. */
   display: flow-root;
 }
 
 .commentsContentWrapper {
-  /* Contain the floated header actions, like the flow-root on .card */
+  /* Contain floated comment avatars inside the comments area. */
   display: flow-root;
+  container-name: comments;
+  container-type: inline-size;
 }
 
 .fullscreenCommentCard {
@@ -143,13 +144,25 @@
 .commentsTitle {
   padding-block: 1em;
   display: inline-block;
+  flex: 0 0 auto;
+  max-inline-size: 100%;
+}
+
+.commentHeader {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: flex-start;
+  justify-content: space-between;
+  column-gap: 16px;
 }
 
 .commentHeaderActions {
-  float: inline-end;
   display: flex;
+  min-inline-size: 0;
   align-items: flex-start;
+  justify-content: flex-end;
   gap: 8px;
+  margin-inline-start: auto;
 }
 
 .commentHeaderActionsEmpty {
@@ -157,10 +170,15 @@
   margin-inline-end: 8px;
 }
 
-@media only screen and (width <= 1000px) {
+@container comments (width <= 520px) {
   .commentHeaderActions {
-    float: none;
-    justify-content: flex-end;
+    flex: 1 0 100%;
+  }
+
+  .commentHeaderActions :deep(.select) {
+    flex: 1 1 auto;
+    min-inline-size: 0;
+    inline-size: auto;
   }
 }
 

--- a/src/renderer/components/CommentSection/CommentSection.vue
+++ b/src/renderer/components/CommentSection/CommentSection.vue
@@ -70,22 +70,51 @@
       ref="commentsContentWrapper"
       class="commentsContentWrapper"
     >
-      <h3
-        v-if="!fullscreenOverlay && commentData.length > 0 && !isLoading && showComments"
-        class="commentsTitle"
+      <div
+        v-if="!fullscreenOverlay && showComments && !isLoading"
+        class="commentHeader"
       >
-        <span>{{ commentsTitle }}</span>
-        <span
-          class="commentTitleAction"
-          role="button"
-          tabindex="0"
-          @click="showComments = false"
-          @keydown.space.prevent="showComments = false"
-          @keydown.enter.prevent="showComments = false"
+        <h3
+          v-if="commentData.length > 0"
+          class="commentsTitle"
         >
-          {{ $t("Comments.Hide Comments") }}
-        </span>
-      </h3>
+          <span>{{ commentsTitle }}</span>
+          <span
+            class="commentTitleAction"
+            role="button"
+            tabindex="0"
+            @click="showComments = false"
+            @keydown.space.prevent="showComments = false"
+            @keydown.enter.prevent="showComments = false"
+          >
+            {{ $t("Comments.Hide Comments") }}
+          </span>
+        </h3>
+        <div
+          class="commentHeaderActions"
+          :class="{ commentHeaderActionsEmpty: !showSortBy }"
+        >
+          <FtSelect
+            v-if="showSortBy"
+            :placeholder="$t('Global.Sort By')"
+            :value="currentSortValue"
+            :select-names="sortNames"
+            :select-values="sortValues"
+            :icon="['fas', 'arrow-down-short-wide']"
+            @change="handleSortChange"
+          />
+          <FtIconButton
+            :title="$t('Comments.Reload Comments')"
+            :icon="['fas', 'sync']"
+            :size="12"
+            :padding="8"
+            :use-shadow="false"
+            class="reloadComments"
+            :class="{ reloadCommentsAligned: showSortBy }"
+            @click="reloadCommentData"
+          />
+        </div>
+      </div>
       <h4
         v-if="canPerformInitialCommentLoading"
         class="getCommentsTitle"
@@ -108,31 +137,6 @@
       >
         {{ $t("Comments.Click to View Comments") }}
       </h4>
-      <div
-        v-if="!fullscreenOverlay && showComments && !isLoading"
-        class="commentHeaderActions"
-        :class="{ commentHeaderActionsEmpty: !showSortBy }"
-      >
-        <FtSelect
-          v-if="showSortBy"
-          :placeholder="$t('Global.Sort By')"
-          :value="currentSortValue"
-          :select-names="sortNames"
-          :select-values="sortValues"
-          :icon="['fas', 'arrow-down-short-wide']"
-          @change="handleSortChange"
-        />
-        <FtIconButton
-          :title="$t('Comments.Reload Comments')"
-          :icon="['fas', 'sync']"
-          :size="12"
-          :padding="8"
-          :use-shadow="false"
-          class="reloadComments"
-          :class="{ reloadCommentsAligned: showSortBy }"
-          @click="reloadCommentData"
-        />
-      </div>
       <div
         v-if="commentData.length > 0 && showComments"
       >

--- a/src/renderer/components/DownloadSettings.vue
+++ b/src/renderer/components/DownloadSettings.vue
@@ -35,7 +35,7 @@
         @change="updateYtDlpFfmpegSource"
       />
     </FtFlexBox>
-    <FtFlexBox>
+    <FtFlexBox class="binaryStatusStart">
       <p
         v-if="ytDlpInfo === null"
         class="ytDlpStatus"
@@ -58,7 +58,7 @@
         {{ t('Settings.Download Settings.Detected Version Template', { version: ytDlpInfo.version }) }}
       </p>
     </FtFlexBox>
-    <FtFlexBox>
+    <FtFlexBox class="binaryStatusEnd">
       <p
         v-if="ffmpegInfo === null"
         class="ytDlpStatus"
@@ -124,7 +124,7 @@
         />
       </div>
     </div>
-    <FtFlexBox class="settingsFlexStart460px">
+    <FtFlexBox class="downloadPathInputs settingsFlexStart460px">
       <FtInput
         v-if="ytDlpSource === 'system'"
         :placeholder="t('Settings.Download Settings.yt-dlp Executable Path')"
@@ -460,6 +460,23 @@ async function chooseExecutablePath(binary) {
 <style scoped>
 .sourceSelect {
   inline-size: 250px;
+}
+
+.downloadPathInputs {
+  column-gap: 12px;
+}
+
+.downloadPathInputs :deep(.ft-input-component) {
+  inline-size: 340px;
+  max-inline-size: 100%;
+}
+
+.binaryStatusStart {
+  margin-block-start: 8px;
+}
+
+.binaryStatusEnd {
+  margin-block-end: 8px;
 }
 
 .ytDlpStatus {

--- a/src/renderer/components/FtInput/FtInput.css
+++ b/src/renderer/components/FtInput/FtInput.css
@@ -261,17 +261,22 @@ body[dir='rtl'] .ft-input-component.search.showClearTextButton:focus-within .inp
   justify-content: space-between;
   padding-block: 0;
   line-height: 2rem;
-  padding-inline: 15px;
+  padding-inline: 15px 4px;
 }
 
 .optionWrapper {
   display: flex;
-  align-items: baseline;
+  align-items: center;
   overflow: hidden;
+  flex: 1;
+  min-inline-size: 0;
 }
 
-.optionWrapper span {
+.optionWrapper span,
+.optionWrapper bdi {
   overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
 }
 
 .searchResultIcon {
@@ -279,18 +284,24 @@ body[dir='rtl'] .ft-input-component.search.showClearTextButton:focus-within .inp
   padding-inline-end: 10px;
   inline-size: 16px;
   block-size: 16px;
+  flex-shrink: 0;
 }
 
 .removeButton {
+  display: flex;
+  align-items: center;
+  flex-shrink: 0;
+  margin-inline-start: 8px;
+  padding-block: 6px;
+  padding-inline: 8px 0;
   text-decoration: none;
-  float: inline-end;
-  font-size: 13px;
+  font-size: 14px;
+  opacity: 0.65;
 }
 
 .removeButton:hover,
 .removeButtonSelected {
-  text-decoration: underline;
-  font-weight: bold;
+  opacity: 1;
 }
 
 .hover {

--- a/src/renderer/components/FtInput/FtInput.vue
+++ b/src/renderer/components/FtInput/FtInput.vue
@@ -107,10 +107,11 @@
             :class="{ removeButtonSelected: removeButtonSelectedIndex === index }"
             role="button"
             :aria-label="t('Search Bar.Remove')"
+            :title="t('Search Bar.Remove')"
             href="javascript:void(0)"
             @click.prevent.stop="handleRemoveClick(index)"
           >
-            {{ t('Search Bar.Remove') }}
+            <FontAwesomeIcon :icon="['fas', 'xmark']" />
           </a>
         </li>
         <!-- skipped -->

--- a/src/renderer/components/TopNav/TopNav.scss
+++ b/src/renderer/components/TopNav/TopNav.scss
@@ -8,11 +8,8 @@
 }
 
 .topNav {
-  align-content: center;
-  align-items: center;
   background-color: var(--card-bg-color);
   box-shadow: 0 2px 1px 0 var(--primary-shadow-color);
-  display: flex;
   block-size: 60px;
   inset-inline: 0;
   line-height: 60px;
@@ -21,10 +18,10 @@
   inline-size: 100%;
   z-index: 4;
 
-  @media only screen and (width >= 961px) {
-    display: grid;
-    grid-template-columns: 1fr 440px 1fr;
-  }
+  /* Query container so the centered layout responds to the top nav's own width
+     (which shrinks beside the vertical tab bar) instead of the viewport, and so
+     the fixed mobile search bar is positioned relative to the top nav. */
+  container: top-nav / inline-size;
 
   @include top-nav-is-colored {
     background-color: var(--primary-color);
@@ -36,6 +33,19 @@
     &:has(+ .sideNav + .routerView .floatingRefreshSection) {
       box-shadow: none;
     }
+  }
+}
+
+.topNavInner {
+  align-content: center;
+  align-items: center;
+  display: flex;
+  block-size: 100%;
+  inline-size: 100%;
+
+  @container top-nav (width >= 961px) {
+    display: grid;
+    grid-template-columns: 1fr 440px 1fr;
   }
 }
 
@@ -258,7 +268,8 @@
   }
 }
 
-/* Adjust search container position when tab bar is present (mobile) */
+/* The fixed mobile search bar is positioned against the viewport, so it needs
+   the same vertical/horizontal offsets as the top nav when a tab bar is present. */
 .app:has(.tabBar) .middle .searchContainer {
   @media only screen and (width <= 680px) {
     inset-block-start: 92px;
@@ -268,5 +279,7 @@
 .app.verticalTabs .middle .searchContainer {
   @media only screen and (width <= 680px) {
     inset-block-start: 60px;
+    inset-inline-start: var(--vertical-tab-bar-width, 220px);
   }
 }
+

--- a/src/renderer/components/TopNav/TopNav.scss
+++ b/src/renderer/components/TopNav/TopNav.scss
@@ -51,6 +51,11 @@
 /* The vertical tab bar sits beside the content instead of above it */
 .app.verticalTabs .topNav {
   inset-block-start: 0;
+
+  @media only screen and (width <= 680px) {
+    inset-inline-start: var(--vertical-tab-bar-width, 220px);
+    inline-size: calc(100% - var(--vertical-tab-bar-width, 220px));
+  }
 }
 
 .menuButton {

--- a/src/renderer/components/TopNav/TopNav.vue
+++ b/src/renderer/components/TopNav/TopNav.vue
@@ -3,136 +3,138 @@
     class="topNav"
     :class="{ topNavBarColor: barColor }"
   >
-    <div class="side">
-      <button
-        class="menuButton navButton"
-        :aria-label="expandCollapseSideBarLabel"
-        :title="expandCollapseSideBarLabel"
-        @click="toggleSideNav"
-      >
-        <FontAwesomeIcon
-          class="navIcon"
-          :icon="['fas', 'bars']"
-        />
-      </button>
-      <FtIconButton
-        class="navIconButton"
-        :disabled="isArrowBackwardDisabled"
-        :class="{ arrowDisabled: isArrowBackwardDisabled }"
-        :icon="['fas', 'arrow-left']"
-        :theme="null"
-        :size="20"
-        :use-shadow="false"
-        dropdown-position-x="right"
-        :dropdown-options="navigationHistoryDropdownOptions"
-        open-on-right-or-long-click
-        :title="backwardText"
-        @click="historyBack"
-      />
-      <FtIconButton
-        class="navIconButton"
-        :disabled="isArrowForwardDisabled"
-        :class="{ arrowDisabled: isArrowForwardDisabled }"
-        :icon="['fas', 'arrow-right']"
-        :theme="null"
-        :size="20"
-        :use-shadow="false"
-        dropdown-position-x="right"
-        :dropdown-options="navigationHistoryDropdownOptions"
-        open-on-right-or-long-click
-        :title="forwardText"
-        @click="historyForward"
-      />
-      <button
-        v-if="!hideSearchBar"
-        class="navSearchButton navButton"
-        @click="toggleSearchContainer"
-      >
-        <FontAwesomeIcon
-          class="navIcon"
-          :icon="['fas', 'search']"
-        />
-      </button>
-      <button
-        class="navNewWindowButton navButton"
-        :aria-label="t('Open New Window')"
-        :title="newWindowText"
-        @click="createNewWindow"
-      >
-        <FontAwesomeIcon
-          class="navIcon"
-          :icon="['fas', 'clone']"
-        />
-      </button>
-      <button
-        v-if="isElectron"
-        class="navTabLayoutButton navButton"
-        :aria-label="tabLayoutText"
-        :title="tabLayoutText"
-        @click="toggleVerticalTabBar"
-      >
-        <FontAwesomeIcon
-          class="navIcon"
-          :icon="tabLayoutIcon"
-        />
-      </button>
-      <RouterLink
-        v-if="!hideHeaderLogo"
-        class="logo"
-        dir="ltr"
-        :title="headerLogoTitle"
-        :to="landingPage"
-      >
-        <div
-          class="logoIcon"
-        />
-        <div
-          class="logoText"
-        />
-      </RouterLink>
-    </div>
-    <div class="middle">
-      <div
-        v-if="!hideSearchBar"
-        v-show="showSearchContainer"
-        ref="searchContainer"
-        class="searchContainer"
-      >
-        <FtInput
-          ref="searchInput"
-          :placeholder="t('Search / Go to URL')"
-          class="searchInput"
-          is-search
-          :data-list="activeDataList"
-          :data-list-properties="activeDataListProperties"
-          show-clear-text-button
-          show-data-when-empty
-          @input="getSearchSuggestionsDebounce"
-          @click="goToSearch"
-          @clear="clearLastSuggestionQuery"
-          @remove="removeSearchHistoryEntryInDbAndCache"
+    <div class="topNavInner">
+      <div class="side">
+        <button
+          class="menuButton navButton"
+          :aria-label="expandCollapseSideBarLabel"
+          :title="expandCollapseSideBarLabel"
+          @click="toggleSideNav"
         >
-          <template #extraAction>
-            <button
-              type="button"
-              class="navFilterButton navButton"
-              :class="{ filterChanged: searchFilterValueChanged }"
-              :aria-label="t('Search Filters.Search Filters')"
-              :title="t('Search Filters.Search Filters')"
-              @click="showSearchFilters"
-            >
-              <FontAwesomeIcon
-                class="navIcon"
-                :icon="['fas', 'filter']"
-              />
-            </button>
-          </template>
-        </FtInput>
+          <FontAwesomeIcon
+            class="navIcon"
+            :icon="['fas', 'bars']"
+          />
+        </button>
+        <FtIconButton
+          class="navIconButton"
+          :disabled="isArrowBackwardDisabled"
+          :class="{ arrowDisabled: isArrowBackwardDisabled }"
+          :icon="['fas', 'arrow-left']"
+          :theme="null"
+          :size="20"
+          :use-shadow="false"
+          dropdown-position-x="right"
+          :dropdown-options="navigationHistoryDropdownOptions"
+          open-on-right-or-long-click
+          :title="backwardText"
+          @click="historyBack"
+        />
+        <FtIconButton
+          class="navIconButton"
+          :disabled="isArrowForwardDisabled"
+          :class="{ arrowDisabled: isArrowForwardDisabled }"
+          :icon="['fas', 'arrow-right']"
+          :theme="null"
+          :size="20"
+          :use-shadow="false"
+          dropdown-position-x="right"
+          :dropdown-options="navigationHistoryDropdownOptions"
+          open-on-right-or-long-click
+          :title="forwardText"
+          @click="historyForward"
+        />
+        <button
+          v-if="!hideSearchBar"
+          class="navSearchButton navButton"
+          @click="toggleSearchContainer"
+        >
+          <FontAwesomeIcon
+            class="navIcon"
+            :icon="['fas', 'search']"
+          />
+        </button>
+        <button
+          class="navNewWindowButton navButton"
+          :aria-label="t('Open New Window')"
+          :title="newWindowText"
+          @click="createNewWindow"
+        >
+          <FontAwesomeIcon
+            class="navIcon"
+            :icon="['fas', 'clone']"
+          />
+        </button>
+        <button
+          v-if="isElectron"
+          class="navTabLayoutButton navButton"
+          :aria-label="tabLayoutText"
+          :title="tabLayoutText"
+          @click="toggleVerticalTabBar"
+        >
+          <FontAwesomeIcon
+            class="navIcon"
+            :icon="tabLayoutIcon"
+          />
+        </button>
+        <RouterLink
+          v-if="!hideHeaderLogo"
+          class="logo"
+          dir="ltr"
+          :title="headerLogoTitle"
+          :to="landingPage"
+        >
+          <div
+            class="logoIcon"
+          />
+          <div
+            class="logoText"
+          />
+        </RouterLink>
       </div>
-    </div>
-    <div class="side profiles">
-      <FtThumbnailSizeControl v-if="showThumbnailSizeControl" />
-      <FtProfileSelector v-if="!hideProfileSelectorInHeader" />
+      <div class="middle">
+        <div
+          v-if="!hideSearchBar"
+          v-show="showSearchContainer"
+          ref="searchContainer"
+          class="searchContainer"
+        >
+          <FtInput
+            ref="searchInput"
+            :placeholder="t('Search / Go to URL')"
+            class="searchInput"
+            is-search
+            :data-list="activeDataList"
+            :data-list-properties="activeDataListProperties"
+            show-clear-text-button
+            show-data-when-empty
+            @input="getSearchSuggestionsDebounce"
+            @click="goToSearch"
+            @clear="clearLastSuggestionQuery"
+            @remove="removeSearchHistoryEntryInDbAndCache"
+          >
+            <template #extraAction>
+              <button
+                type="button"
+                class="navFilterButton navButton"
+                :class="{ filterChanged: searchFilterValueChanged }"
+                :aria-label="t('Search Filters.Search Filters')"
+                :title="t('Search Filters.Search Filters')"
+                @click="showSearchFilters"
+              >
+                <FontAwesomeIcon
+                  class="navIcon"
+                  :icon="['fas', 'filter']"
+                />
+              </button>
+            </template>
+          </FtInput>
+        </div>
+      </div>
+      <div class="side profiles">
+        <FtThumbnailSizeControl v-if="showThumbnailSizeControl" />
+        <FtProfileSelector v-if="!hideProfileSelectorInHeader" />
+      </div>
     </div>
   </nav>
 </template>

--- a/src/renderer/components/ft-shaka-video-player/ft-shaka-video-player.css
+++ b/src/renderer/components/ft-shaka-video-player/ft-shaka-video-player.css
@@ -868,6 +868,17 @@
   transition: inset-inline-end 250ms ease;
 }
 
+/* Scale the SponsorBlock skip notice down with the mini player so it stays
+   inside it instead of overflowing at small sizes. */
+.ftVideoPlayer.scrollMiniPlayer .skippedSegmentsWrapper {
+  transform: scale(var(--scroll-mini-scale, 1));
+  transform-origin: bottom right;
+}
+
+.ftVideoPlayer.scrollMiniPlayer .skippedSegmentsWrapper:where(:dir(rtl)) {
+  transform-origin: bottom left;
+}
+
 .skippedSegment {
   display: flex;
   flex-direction: column;

--- a/src/renderer/components/ft-shaka-video-player/ft-shaka-video-player.css
+++ b/src/renderer/components/ft-shaka-video-player/ft-shaka-video-player.css
@@ -1308,7 +1308,7 @@
 }
 
 /* Let Shaka's seek preview and control tooltips pass in front of the fullscreen action pill. */
-.ftVideoPlayer:has(:deep(.shaka-seek-bar-container:hover)) .fullscreenActions,
+.ftVideoPlayer:has(:deep(.shaka-seek-bar-container:hover)) :is(.fullscreenActions, .skippedSegmentsWrapper),
   .ftVideoPlayer:has(:deep(
     .shaka-controls-button-panel > :is(.shaka-tooltip, .shaka-tooltip-status):is(:hover, :focus-visible, :active)
   )) .fullscreenActions {

--- a/src/renderer/components/ft-shaka-video-player/ft-shaka-video-player.css
+++ b/src/renderer/components/ft-shaka-video-player/ft-shaka-video-player.css
@@ -1307,8 +1307,11 @@
   display: flex;
 }
 
-/* Let Shaka's seek preview pass in front of the fullscreen action pill. */
-.ftVideoPlayer:has(:deep(.shaka-seek-bar-container:hover)) .fullscreenActions {
+/* Let Shaka's seek preview and control tooltips pass in front of the fullscreen action pill. */
+.ftVideoPlayer:has(:deep(.shaka-seek-bar-container:hover)) .fullscreenActions,
+  .ftVideoPlayer:has(:deep(
+    .shaka-controls-button-panel > :is(.shaka-tooltip, .shaka-tooltip-status):is(:hover, :focus-visible, :active)
+  )) .fullscreenActions {
   z-index: 0;
 }
 

--- a/src/renderer/components/ft-shaka-video-player/opentubex/useScrollMiniPlayer.js
+++ b/src/renderer/components/ft-shaka-video-player/opentubex/useScrollMiniPlayer.js
@@ -570,12 +570,21 @@ export function useScrollMiniPlayer({ container, fullWindowEnabled, getUi, isAct
     updateScrollMiniPlayer()
   }
 
-  function handleScrollMiniWindowResize() {
-    if (scrollMiniPlayerActive.value) {
-      const clamped = clampScrollMiniPlayerRect(scrollMiniPlayerRect.value, scrollMiniVideoAspectRatio.value)
-      applyScrollMiniPlayerRect(snapScrollMiniPlayerToEdge(clamped, getViewportInsets()), true)
-    }
+  /**
+   * Re-dock to the current insets. Needed whenever the usable area changes
+   * (window resize, or the vertical tab bar being toggled/resized), otherwise
+   * the player is stranded mid-screen at its old edge.
+   */
+  function resnapScrollMiniPlayerToEdge() {
+    if (!scrollMiniPlayerActive.value || scrollMiniPointerSession) return
 
+    cancelScrollMiniPlayerBounce()
+    const clamped = clampScrollMiniPlayerRect(scrollMiniPlayerRect.value, scrollMiniVideoAspectRatio.value)
+    applyScrollMiniPlayerRect(snapScrollMiniPlayerToEdge(clamped, getViewportInsets()), true)
+  }
+
+  function handleScrollMiniWindowResize() {
+    resnapScrollMiniPlayerToEdge()
     updateScrollMiniPlayer()
   }
 
@@ -817,6 +826,14 @@ export function useScrollMiniPlayer({ container, fullWindowEnabled, getUi, isAct
 
   watch(scrollMiniPlayerEnabled, updateScrollMiniPlayer)
   watch(fullWindowEnabled, updateScrollMiniPlayer)
+
+  // Toggling or resizing the vertical tab bar changes the usable area without
+  // firing a window resize, so re-dock explicitly (after the DOM updates, so the
+  // rail's new bounds are measurable).
+  watch(
+    () => [store.getters.getUseVerticalTabBar, store.getters.getVerticalTabBarWidth],
+    () => { nextTick(resnapScrollMiniPlayerToEdge) }
+  )
 
   return {
     deactivateScrollMiniPlayer,

--- a/src/renderer/components/ft-shaka-video-player/opentubex/useScrollMiniPlayer.js
+++ b/src/renderer/components/ft-shaka-video-player/opentubex/useScrollMiniPlayer.js
@@ -576,7 +576,10 @@ export function useScrollMiniPlayer({ container, fullWindowEnabled, getUi, isAct
    * the player is stranded mid-screen at its old edge.
    */
   function resnapScrollMiniPlayerToEdge() {
-    if (!scrollMiniPlayerActive.value || scrollMiniPointerSession) return
+    if (!scrollMiniPlayerActive.value) return
+    // Only a drag/resize is positioning the player; a volume session must not
+    // block re-docking, since its pointer-up path never snaps.
+    if (scrollMiniPointerSession?.type === 'drag' || scrollMiniPointerSession?.type === 'resize') return
 
     cancelScrollMiniPlayerBounce()
     const clamped = clampScrollMiniPlayerRect(scrollMiniPlayerRect.value, scrollMiniVideoAspectRatio.value)

--- a/src/renderer/helpers/scrollMiniPlayer.js
+++ b/src/renderer/helpers/scrollMiniPlayer.js
@@ -103,11 +103,23 @@ export function serializeScrollMiniPlayerSavedRect(rect) {
 }
 
 /**
+ * Usable viewport width. `window.innerWidth` includes the vertical scrollbar,
+ * which would otherwise eat the inline-end margin (the mini player only shows
+ * while the page is scrolled, so the scrollbar is always there).
+ *
+ * @returns {number}
+ */
+export function getViewportWidth() {
+  return document.documentElement.clientWidth || window.innerWidth
+}
+
+/**
  * @returns {{ top: number, left: number, right: number, bottom: number }}
  */
 export function getViewportInsets() {
   let topInset = MARGIN
   let leftInset = MARGIN
+  let rightInset = MARGIN
 
   const topNav = document.querySelector('.topNav')
   const tabBar = document.querySelector('.tabBar')
@@ -121,16 +133,23 @@ export function getViewportInsets() {
     topInset = Math.max(topInset, rect.bottom + MARGIN)
   }
 
-  // Keep clear of the fixed vertical tab bar column on the inline-start side
+  // Keep clear of the fixed vertical tab bar column. It sits on the inline-start
+  // side, which is the right edge under RTL, so derive the physical side from
+  // its bounds rather than assuming the left.
   if (verticalTabBar) {
     const rect = verticalTabBar.getBoundingClientRect()
-    leftInset = Math.max(leftInset, rect.right + MARGIN)
+    const viewportWidth = getViewportWidth()
+    if (rect.left <= viewportWidth - rect.right) {
+      leftInset = Math.max(leftInset, rect.right + MARGIN)
+    } else {
+      rightInset = Math.max(rightInset, viewportWidth - rect.left + MARGIN)
+    }
   }
 
   return {
     top: topInset,
     left: leftInset,
-    right: MARGIN,
+    right: rightInset,
     bottom: MARGIN,
   }
 }
@@ -145,7 +164,7 @@ export function getDefaultScrollMiniPlayerRect(aspectRatio = DEFAULT_ASPECT_RATI
   const height = getHeightForAspectRatio(width, aspectRatio)
 
   return {
-    left: window.innerWidth - width - insets.right,
+    left: getViewportWidth() - width - insets.right,
     top: window.innerHeight - height - insets.bottom,
     width,
     height,
@@ -160,7 +179,7 @@ export function getDefaultScrollMiniPlayerRect(aspectRatio = DEFAULT_ASPECT_RATI
  */
 export function clampScrollMiniPlayerRect(rect, aspectRatio = DEFAULT_ASPECT_RATIO) {
   const insets = getViewportInsets()
-  const maxWidth = Math.min(MAX_WIDTH, window.innerWidth - insets.left - insets.right)
+  const maxWidth = Math.min(MAX_WIDTH, getViewportWidth() - insets.left - insets.right)
   const maxHeight = window.innerHeight - insets.top - insets.bottom
   const normalizedAspectRatio = normalizeAspectRatio(aspectRatio)
 
@@ -171,7 +190,7 @@ export function clampScrollMiniPlayerRect(rect, aspectRatio = DEFAULT_ASPECT_RAT
     width = getWidthForAspectRatio(height, normalizedAspectRatio)
   }
 
-  const maxLeft = window.innerWidth - insets.right - width
+  const maxLeft = getViewportWidth() - insets.right - width
   const maxTop = window.innerHeight - insets.bottom - height
   const left = Math.min(Math.max(rect.left, insets.left), maxLeft)
   const top = Math.min(Math.max(rect.top, insets.top), maxTop)
@@ -187,7 +206,7 @@ export function clampScrollMiniPlayerRect(rect, aspectRatio = DEFAULT_ASPECT_RAT
  */
 export function getDockFromRect(rect, insets) {
   const leftDist = rect.left - insets.left
-  const rightDist = window.innerWidth - insets.right - (rect.left + rect.width)
+  const rightDist = getViewportWidth() - insets.right - (rect.left + rect.width)
   return leftDist <= rightDist ? 'left' : 'right'
 }
 
@@ -227,7 +246,7 @@ export function getAnchorVisibleRatio(element, layoutHeight) {
   const visibleTop = Math.max(rect.top, 0)
   const visibleBottom = Math.min(bottom, window.innerHeight)
   const visibleLeft = Math.max(rect.left, 0)
-  const visibleRight = Math.min(rect.right, window.innerWidth)
+  const visibleRight = Math.min(rect.right, getViewportWidth())
 
   const visibleWidth = Math.max(0, visibleRight - visibleLeft)
   const visibleHeight = Math.max(0, visibleBottom - visibleTop)
@@ -250,7 +269,7 @@ export function getAnchorVisibleRatio(element, layoutHeight) {
  */
 export function shouldBounceScrollMiniPlayerToEdge(rect, insets) {
   const leftEdge = insets.left
-  const rightEdge = window.innerWidth - insets.right - rect.width
+  const rightEdge = getViewportWidth() - insets.right - rect.width
   const nearLeft = rect.left - leftEdge <= EDGE_SNAP
   const nearRight = rightEdge - rect.left <= EDGE_SNAP
   return !nearLeft && !nearRight
@@ -265,7 +284,7 @@ export function snapScrollMiniPlayerToEdge(rect, insets) {
   const dock = rect.dock
   const left = dock === 'left'
     ? insets.left
-    : window.innerWidth - insets.right - rect.width
+    : getViewportWidth() - insets.right - rect.width
 
   return { ...rect, left, dock }
 }
@@ -377,7 +396,7 @@ export function getResizeHandleCorner(rect, insets) {
  */
 export function resizeScrollMiniPlayerFromCorner(rect, corner, pointerX, pointerY, insets, aspectRatio = DEFAULT_ASPECT_RATIO) {
   const dock = getDockFromRect(rect, insets)
-  const maxWidth = Math.min(MAX_WIDTH, window.innerWidth - insets.left - insets.right)
+  const maxWidth = Math.min(MAX_WIDTH, getViewportWidth() - insets.left - insets.right)
   const maxHeight = window.innerHeight - insets.top - insets.bottom
   const normalizedAspectRatio = normalizeAspectRatio(aspectRatio)
 
@@ -396,7 +415,7 @@ export function resizeScrollMiniPlayerFromCorner(rect, corner, pointerX, pointer
     width = getWidthForAspectRatio(height, normalizedAspectRatio)
   }
 
-  const left = dock === 'left' ? insets.left : window.innerWidth - insets.right - width
+  const left = dock === 'left' ? insets.left : getViewportWidth() - insets.right - width
   let top
 
   if (corner.startsWith('top')) {

--- a/src/renderer/helpers/scrollMiniPlayer.js
+++ b/src/renderer/helpers/scrollMiniPlayer.js
@@ -68,21 +68,25 @@ export function parseScrollMiniPlayerSavedRect(value) {
 
     if (
       parsed == null ||
-      typeof parsed.left !== 'number' ||
-      typeof parsed.top !== 'number' ||
-      typeof parsed.width !== 'number' ||
-      typeof parsed.height !== 'number'
+      !Number.isFinite(parsed.left) ||
+      !Number.isFinite(parsed.top) ||
+      !Number.isFinite(parsed.width) ||
+      !Number.isFinite(parsed.height)
     ) {
       return null
     }
 
-    return clampScrollMiniPlayerRect({
+    // Deliberately not clamped here: restoring runs while the tab is still
+    // loading, when the viewport can be unsized or mid-layout. Clamping against
+    // that would shrink the rect and pin it to a corner, permanently losing the
+    // saved size/position. The caller clamps on activation, once layout settled.
+    return {
       left: parsed.left,
       top: parsed.top,
       width: parsed.width,
       height: parsed.height,
       dock: parsed.dock === 'left' ? 'left' : 'right',
-    })
+    }
   } catch {
     return null
   }

--- a/src/renderer/helpers/scrollMiniPlayer.js
+++ b/src/renderer/helpers/scrollMiniPlayer.js
@@ -107,9 +107,11 @@ export function serializeScrollMiniPlayerSavedRect(rect) {
  */
 export function getViewportInsets() {
   let topInset = MARGIN
+  let leftInset = MARGIN
 
   const topNav = document.querySelector('.topNav')
   const tabBar = document.querySelector('.tabBar')
+  const verticalTabBar = document.querySelector('.tabBar.vertical')
 
   if (topNav) {
     const rect = topNav.getBoundingClientRect()
@@ -119,9 +121,15 @@ export function getViewportInsets() {
     topInset = Math.max(topInset, rect.bottom + MARGIN)
   }
 
+  // Keep clear of the fixed vertical tab bar column on the inline-start side
+  if (verticalTabBar) {
+    const rect = verticalTabBar.getBoundingClientRect()
+    leftInset = Math.max(leftInset, rect.right + MARGIN)
+  }
+
   return {
     top: topInset,
-    left: MARGIN,
+    left: leftInset,
     right: MARGIN,
     bottom: MARGIN,
   }
@@ -188,6 +196,10 @@ export function getDockFromRect(rect, insets) {
  * @returns {Record<string, string>}
  */
 export function scrollMiniPlayerRectToStyle(rect) {
+  // Overlays (e.g. the SponsorBlock skip notice) are sized for a full-size
+  // player, so scale them down with the mini player to keep them inside it.
+  const scale = Math.max(0.6, Math.min(1, rect.width / DEFAULT_WIDTH))
+
   return {
     position: 'fixed',
     left: `${rect.left}px`,
@@ -195,6 +207,7 @@ export function scrollMiniPlayerRectToStyle(rect) {
     width: `${rect.width}px`,
     height: `${rect.height}px`,
     zIndex: '150',
+    '--scroll-mini-scale': `${scale}`,
   }
 }
 

--- a/src/renderer/views/History/History.css
+++ b/src/renderer/views/History/History.css
@@ -11,6 +11,9 @@
   grid-template-columns: repeat(2, 1fr);
   grid-template-rows: 1fr;
   align-items: center;
+
+  /* Keep the sort select from sticking to the video grid below it */
+  margin-block-end: 16px;
 }
 
 .toggleOptions {

--- a/src/renderer/views/Subscriptions/Subscriptions.css
+++ b/src/renderer/views/Subscriptions/Subscriptions.css
@@ -67,7 +67,10 @@
 }
 
 .headerRefreshWidget {
-  min-inline-size: min(100%, 360px);
+  /* Size to its content so the title row positions the whole widget: tucked to
+     the inline-end while it fits beside the title, and flush to the inline-start
+     once it wraps onto its own line. */
+  max-inline-size: 100%;
 }
 
 .message {
@@ -162,10 +165,6 @@
 
   .pageTitle {
     inline-size: 100%;
-  }
-
-  .headerRefreshWidget {
-    min-inline-size: 100%;
   }
 
   .tabs {

--- a/src/renderer/views/Watch/Watch.scss
+++ b/src/renderer/views/Watch/Watch.scss
@@ -7,7 +7,7 @@
 }
 
 @mixin single-column-template {
-  grid-template: 'video' auto 'info' auto 'sidebar' auto 'comments' auto / auto;
+  grid-template: 'video' auto 'info' auto 'sidebar' auto 'comments' auto / minmax(0, 1fr);
 }
 
 .ageRestricted {
@@ -16,7 +16,7 @@
   display: inline-block;
   max-inline-size: calc(80vh * 1.78);
 
-  @media only screen and (width >= 1051px) {
+  @container route (width >= 1051px) {
     inline-size: 300%;
   }
 }
@@ -148,7 +148,7 @@
     position: relative;
     z-index: 2;
 
-    @media only screen and (width >= 1051px) {
+    @container route (width >= 1051px) {
       min-inline-size: 380px;
     }
 
@@ -317,7 +317,7 @@
       margin-block: auto;
     }
 
-    @media (width <= 768px) {
+    @container route (width <= 768px) {
       block-size: auto;
     }
   }
@@ -331,23 +331,23 @@
     margin-block: 0 16px;
     margin-inline: 0;
 
-    @media only screen and (width >= 1051px) {
+    @container route (width >= 1051px) {
       margin-block: 0 16px;
       margin-inline: 8px;
     }
   }
 
-  @media only screen and (width <= 1350px) {
+  @container route (width <= 1350px) {
     @include theatre-mode-template;
   }
 
-  @media only screen and (width >= 1051px) {
+  @container route (width >= 1051px) {
     &.useTheatreMode {
       @include theatre-mode-template;
     }
   }
 
-  @media only screen and (width <= 1050px) {
+  @container route (width <= 1050px) {
     @include single-column-template;
   }
 
@@ -357,7 +357,7 @@
     @include single-column-template;
   }
 
-  @media only screen and (width >= 1051px) {
+  @container route (width >= 1051px) {
     .infoArea {
       scroll-margin-block-start: 76px;
     }

--- a/tests/unit/scroll-mini-player-insets.test.mjs
+++ b/tests/unit/scroll-mini-player-insets.test.mjs
@@ -1,0 +1,93 @@
+import assert from 'node:assert/strict'
+import test from 'node:test'
+
+import {
+  getViewportInsets,
+  getViewportWidth,
+  snapScrollMiniPlayerToEdge,
+  MARGIN
+} from '../../src/renderer/helpers/scrollMiniPlayer.js'
+
+/**
+ * @param {object} options
+ * @param {{ left: number, right: number } | null} [options.verticalTabBarRect]
+ * @param {number} options.clientWidth usable width (excludes the scrollbar)
+ * @param {number} [options.scrollbarWidth]
+ */
+function stubViewport({ verticalTabBarRect = null, clientWidth, scrollbarWidth = 0 }) {
+  global.window = { innerWidth: clientWidth + scrollbarWidth, innerHeight: 800 }
+  global.document = {
+    querySelector(selector) {
+      if (selector === '.tabBar.vertical' && verticalTabBarRect) {
+        return { getBoundingClientRect: () => verticalTabBarRect }
+      }
+      return null
+    },
+    documentElement: { clientWidth }
+  }
+}
+
+test.afterEach(() => {
+  delete global.document
+  delete global.window
+})
+
+test('the usable viewport width excludes the vertical scrollbar', () => {
+  stubViewport({ clientWidth: 1585, scrollbarWidth: 15 })
+
+  assert.equal(getViewportWidth(), 1585)
+})
+
+test('docking to the inline-end leaves a margin clear of the scrollbar', () => {
+  stubViewport({ clientWidth: 1585, scrollbarWidth: 15 })
+  const insets = getViewportInsets()
+
+  const snapped = snapScrollMiniPlayerToEdge(
+    { left: 800, top: 100, width: 360, height: 202, dock: 'right' },
+    insets
+  )
+
+  // The right edge must sit MARGIN away from the content edge, not be swallowed
+  // by the scrollbar (regression: window.innerWidth left only a 1px gap).
+  assert.equal(1585 - (snapped.left + snapped.width), MARGIN)
+})
+
+test('a vertical tab bar on the inline-start side pads the left inset', () => {
+  stubViewport({ verticalTabBarRect: { left: 0, right: 220 }, clientWidth: 1000 })
+
+  const insets = getViewportInsets()
+
+  assert.equal(insets.left, 220 + MARGIN)
+  assert.equal(insets.right, MARGIN)
+})
+
+test('a vertical tab bar on the right (RTL) pads the right inset instead', () => {
+  stubViewport({ verticalTabBarRect: { left: 780, right: 1000 }, clientWidth: 1000 })
+
+  const insets = getViewportInsets()
+
+  assert.equal(insets.right, (1000 - 780) + MARGIN)
+  assert.equal(insets.left, MARGIN)
+})
+
+test('without a vertical tab bar both inline insets stay at the margin', () => {
+  stubViewport({ clientWidth: 1000 })
+
+  const insets = getViewportInsets()
+
+  assert.equal(insets.left, MARGIN)
+  assert.equal(insets.right, MARGIN)
+})
+
+test('the left dock edge follows the tab rail width', () => {
+  stubViewport({ verticalTabBarRect: { left: 0, right: 400 }, clientWidth: 1585 })
+  const insets = getViewportInsets()
+
+  const snapped = snapScrollMiniPlayerToEdge(
+    { left: 236, top: 100, width: 360, height: 202, dock: 'left' },
+    insets
+  )
+
+  // Regression: widening the rail used to strand the player at its old edge.
+  assert.equal(snapped.left, 400 + MARGIN)
+})

--- a/tests/unit/scroll-mini-player-insets.test.mjs
+++ b/tests/unit/scroll-mini-player-insets.test.mjs
@@ -5,6 +5,8 @@ import {
   getViewportInsets,
   getViewportWidth,
   snapScrollMiniPlayerToEdge,
+  parseScrollMiniPlayerSavedRect,
+  serializeScrollMiniPlayerSavedRect,
   MARGIN
 } from '../../src/renderer/helpers/scrollMiniPlayer.js'
 
@@ -90,4 +92,34 @@ test('the left dock edge follows the tab rail width', () => {
 
   // Regression: widening the rail used to strand the player at its old edge.
   assert.equal(snapped.left, 400 + MARGIN)
+})
+
+test('a saved rect survives being restored before the viewport is laid out', () => {
+  const saved = serializeScrollMiniPlayerSavedRect({
+    left: 1000, top: 500, width: 520, height: 292, dock: 'right'
+  })
+
+  // Restoring runs while the tab is still loading, so the viewport can be
+  // unsized. Clamping here used to shrink the player and pin it bottom-left.
+  stubViewport({ clientWidth: 0 })
+  assert.deepEqual(parseScrollMiniPlayerSavedRect(saved), {
+    left: 1000, top: 500, width: 520, height: 292, dock: 'right'
+  })
+
+  stubViewport({ clientWidth: 300 })
+  assert.deepEqual(parseScrollMiniPlayerSavedRect(saved), {
+    left: 1000, top: 500, width: 520, height: 292, dock: 'right'
+  })
+})
+
+test('a malformed saved rect is rejected', () => {
+  stubViewport({ clientWidth: 1585 })
+
+  assert.equal(parseScrollMiniPlayerSavedRect(''), null)
+  assert.equal(parseScrollMiniPlayerSavedRect('not json'), null)
+  assert.equal(parseScrollMiniPlayerSavedRect(JSON.stringify({ left: 1 })), null)
+  assert.equal(
+    parseScrollMiniPlayerSavedRect(JSON.stringify({ left: NaN, top: 0, width: 1, height: 1 })),
+    null
+  )
 })

--- a/tests/unit/scroll-mini-player-insets.test.mjs
+++ b/tests/unit/scroll-mini-player-insets.test.mjs
@@ -5,6 +5,7 @@ import {
   getViewportInsets,
   getViewportWidth,
   snapScrollMiniPlayerToEdge,
+  clampScrollMiniPlayerRect,
   parseScrollMiniPlayerSavedRect,
   serializeScrollMiniPlayerSavedRect,
   MARGIN
@@ -16,10 +17,10 @@ import {
  * @param {number} options.clientWidth usable width (excludes the scrollbar)
  * @param {number} [options.scrollbarWidth]
  */
-function stubViewport({ verticalTabBarRect = null, clientWidth, scrollbarWidth = 0 }) {
+function stubViewport ({ verticalTabBarRect = null, clientWidth, scrollbarWidth = 0 }) {
   global.window = { innerWidth: clientWidth + scrollbarWidth, innerHeight: 800 }
   global.document = {
-    querySelector(selector) {
+    querySelector (selector) {
       if (selector === '.tabBar.vertical' && verticalTabBarRect) {
         return { getBoundingClientRect: () => verticalTabBarRect }
       }
@@ -94,22 +95,54 @@ test('the left dock edge follows the tab rail width', () => {
   assert.equal(snapped.left, 400 + MARGIN)
 })
 
-test('a saved rect survives being restored before the viewport is laid out', () => {
-  const saved = serializeScrollMiniPlayerSavedRect({
-    left: 1000, top: 500, width: 520, height: 292, dock: 'right'
-  })
+// Fits the 800px-tall stub viewport, so activation must preserve it verbatim.
+const SAVED_RECT = { left: 1000, top: 400, width: 520, height: 292, dock: 'right' }
+
+test('parsing a saved rect round-trips it without consulting the viewport', () => {
+  const saved = serializeScrollMiniPlayerSavedRect(SAVED_RECT)
 
   // Restoring runs while the tab is still loading, so the viewport can be
-  // unsized. Clamping here used to shrink the player and pin it bottom-left.
+  // unsized. Clamping here used to shrink the rect and pin it bottom-left, so
+  // the parsed result must not vary with the viewport.
   stubViewport({ clientWidth: 0 })
-  assert.deepEqual(parseScrollMiniPlayerSavedRect(saved), {
-    left: 1000, top: 500, width: 520, height: 292, dock: 'right'
-  })
+  assert.deepEqual(parseScrollMiniPlayerSavedRect(saved), SAVED_RECT)
 
   stubViewport({ clientWidth: 300 })
-  assert.deepEqual(parseScrollMiniPlayerSavedRect(saved), {
-    left: 1000, top: 500, width: 520, height: 292, dock: 'right'
-  })
+  assert.deepEqual(parseScrollMiniPlayerSavedRect(saved), SAVED_RECT)
+})
+
+test('restoring while unsized then activating keeps the saved position and size', () => {
+  const saved = serializeScrollMiniPlayerSavedRect(SAVED_RECT)
+
+  // The restore/activation sequence: parse while the tab is still loading...
+  stubViewport({ clientWidth: 0 })
+  const restored = parseScrollMiniPlayerSavedRect(saved)
+
+  // ...then activation clamps it, once layout has settled.
+  stubViewport({ clientWidth: 1585, scrollbarWidth: 15 })
+  const activated = clampScrollMiniPlayerRect(restored)
+
+  assert.equal(activated.width, SAVED_RECT.width)
+  assert.equal(activated.left, SAVED_RECT.left)
+  assert.equal(activated.top, SAVED_RECT.top)
+  assert.equal(activated.dock, 'right')
+})
+
+test('a restored rect that no longer fits is pulled back into view on activation', () => {
+  const saved = serializeScrollMiniPlayerSavedRect(SAVED_RECT)
+
+  stubViewport({ clientWidth: 0 })
+  const restored = parseScrollMiniPlayerSavedRect(saved)
+
+  // Saved against a wide window, reopened in a narrow one.
+  stubViewport({ clientWidth: 600 })
+  const activated = clampScrollMiniPlayerRect(restored)
+
+  assert.ok(activated.left >= MARGIN, `left ${activated.left} should clear the margin`)
+  assert.ok(
+    activated.left + activated.width <= 600 - MARGIN,
+    `right edge ${activated.left + activated.width} should stay inside the viewport`
+  )
 })
 
 test('a malformed saved rect is rejected', () => {

--- a/tests/unit/scroll-mini-player-insets.test.mjs
+++ b/tests/unit/scroll-mini-player-insets.test.mjs
@@ -95,8 +95,9 @@ test('the left dock edge follows the tab rail width', () => {
   assert.equal(snapped.left, 400 + MARGIN)
 })
 
-// Fits the 800px-tall stub viewport, so activation must preserve it verbatim.
-const SAVED_RECT = { left: 1000, top: 400, width: 520, height: 292, dock: 'right' }
+// Exactly 16:9 and fits the 800px-tall stub viewport, so activation must
+// preserve it verbatim (including the height, which is derived from the width).
+const SAVED_RECT = { left: 1000, top: 400, width: 512, height: 288, dock: 'right' }
 
 test('parsing a saved rect round-trips it without consulting the viewport', () => {
   const saved = serializeScrollMiniPlayerSavedRect(SAVED_RECT)
@@ -123,6 +124,7 @@ test('restoring while unsized then activating keeps the saved position and size'
   const activated = clampScrollMiniPlayerRect(restored)
 
   assert.equal(activated.width, SAVED_RECT.width)
+  assert.equal(activated.height, SAVED_RECT.height)
   assert.equal(activated.left, SAVED_RECT.left)
   assert.equal(activated.top, SAVED_RECT.top)
   assert.equal(activated.dock, 'right')


### PR DESCRIPTION
## Summary

- keep Shaka player control tooltips above the fullscreen action dock
- keep seekbar thumbnails above SponsorBlock notices while seeking
- make the comments title, sort selector, and reload action a container-aware responsive header
- base watch-page column breakpoints on the usable route width so vertical and horizontal tabs produce the correct layout
- keep the fixed app header beside the vertical tab rail at narrow window widths
- add breathing room around detected binary versions
- narrow download path inputs so two fields fit at smaller widths

### Additional responsive-layout fixes

- keep the mobile bottom navigation and the top nav clear of the vertical tab column, and drive the top nav's centered layout from its own width (container query) so the search bar and profile selector are no longer cut off
- restore the top padding between the (taller) tab-bar top nav and page content on narrow layouts
- account for the vertical tab column when docking the scroll mini player, and scale the SponsorBlock skip notice down with the mini player so it stays inside it
- replace the search suggestion "Remove" text with a compact x icon, truncate long suggestions, and vertically center the leading icon
- left-align the embedded subscriptions refresh widget when it wraps onto its own line
- add spacing below the history sort options row so it no longer sticks to the video grid
- strengthen the fullscreen tooltip test to assert the tooltip actually renders (review feedback)
- keep the scroll mini player docked with a real margin (the inline-end gap was swallowed by the scrollbar) and re-dock it when the vertical tab bar is toggled or resized, instead of stranding it mid-screen; the rail's side is now derived from its bounds so RTL works too
- restore the saved mini player position/size after a tab reload (the rect was clamped against a viewport that was still mid-layout, so it came back small in the bottom-left)
- harden two load-sensitive offline e2e tests that intermittently failed CI (lazy feed height before an exact scroll assertion; tab switch racing the tab bar re-render)

## Root cause

The fullscreen action dock and SponsorBlock notices used higher stacking layers than Shaka's CSS-generated overlays. Separately, the watch page and comments controls relied on viewport breakpoints even though vertical tabs reduce the usable content width. The single-column grid also retained an intrinsic minimum width, allowing content and the fixed header to extend beyond the visible route.

The additional fixes share the same theme: fixed/overlay elements (bottom nav, top nav search bar, scroll mini player and its notice) were positioned against the viewport without accounting for the vertical tab column, and several list/header rows relied on viewport breakpoints or fixed min-widths that broke once the usable width shrank.

## Validation

- `xvfb-run -a -s "-screen 0 1920x1080x24" pnpm exec playwright test -c e2e/playwright.config.mjs --project=network e2e/tests/network/watch.spec.mjs --grep "fullscreen player overlays appear above the action pill"`
- `xvfb-run -a -s "-screen 0 1920x1080x24" pnpm exec playwright test -c e2e/playwright.config.mjs --project=network e2e/tests/network/watch.spec.mjs --grep "comments load on request"`
- `xvfb-run -a -s "-screen 0 1920x1080x24" pnpm exec playwright test -c e2e/playwright.config.mjs --project=offline e2e/tests/offline/appearance.spec.mjs e2e/tests/offline/search-history.spec.mjs e2e/tests/offline/history.spec.mjs`
- `pnpm run lint-style`
- `pnpm run test:unit`
- targeted Stylelint and Vue ESLint checks
- `git diff --check`


