### PR TITLE
fix(comments): recover missing author avatars from author thumbnail

### DIFF
--- a/patches/youtubei.js@17.2.0.patch
+++ b/patches/youtubei.js@17.2.0.patch
@@ -1,20 +1,3 @@
-diff --git a/dist/src/parser/classes/comments/CommentView.js b/dist/src/parser/classes/comments/CommentView.js
---- a/dist/src/parser/classes/comments/CommentView.js
-+++ b/dist/src/parser/classes/comments/CommentView.js
-@@ -77,10 +77,11 @@ export default class CommentView extends YTNode {
-                     a11y: comment.author.A11y
-                 };
-             }
-+            const avatar = comment.avatar;
-             this.author = new Author({
-                 simpleText: comment.author.displayName,
--                navigationEndpoint: comment.avatar.endpoint
--            }, comment.author, comment.avatar.image, comment.author.channelId);
-+                navigationEndpoint: avatar?.endpoint
-+            }, comment.author, avatar?.image, comment.author.channelId);
-         }
-         if (toolbar_state) {
-             this.is_hearted = toolbar_state.heartState === 'TOOLBAR_HEART_STATE_HEARTED';
 diff --git a/dist/src/parser/classes/comments/CommentReplies.d.ts b/dist/src/parser/classes/comments/CommentReplies.d.ts
 index 3a48b70d187b2f854452d56ce292d2548b660f27..4b5ea214f8ae2a208b0d00191473012e4d4aaa75 100644
 --- a/dist/src/parser/classes/comments/CommentReplies.d.ts
@@ -234,6 +217,30 @@ index 48205eb74eb64f588e1ddcbfc631fc6a5d111acd..032e114cc02f949e41a69c6b3a57d96a
  }
  //# sourceMappingURL=CommentThread.js.map
 \ No newline at end of file
+diff --git a/dist/src/parser/classes/comments/CommentView.js b/dist/src/parser/classes/comments/CommentView.js
+index 727d2d1624c7921c34c8c696a71ab8ba3c670be0..80565b13743a23b611225b7ad532685092c6759f 100644
+--- a/dist/src/parser/classes/comments/CommentView.js
++++ b/dist/src/parser/classes/comments/CommentView.js
+@@ -77,10 +77,17 @@ export default class CommentView extends YTNode {
+                     a11y: comment.author.A11y
+                 };
+             }
++            const avatar = comment.avatar;
++            // YouTube intermittently omits the avatar view model entity from the
++            // comment mutations, but `author.avatarThumbnailUrl` is always
++            // present. Fall back to it so author avatars don't go missing.
++            const avatar_image = avatar?.image ?? (comment.author.avatarThumbnailUrl
++                ? { sources: [{ url: comment.author.avatarThumbnailUrl }] }
++                : undefined);
+             this.author = new Author({
+                 simpleText: comment.author.displayName,
+-                navigationEndpoint: comment.avatar.endpoint
+-            }, comment.author, comment.avatar.image, comment.author.channelId);
++                navigationEndpoint: avatar?.endpoint
++            }, comment.author, avatar_image, comment.author.channelId);
+         }
+         if (toolbar_state) {
+             this.is_hearted = toolbar_state.heartState === 'TOOLBAR_HEART_STATE_HEARTED';
 diff --git a/dist/src/parser/classes/misc/CommentsContinuation.d.ts b/dist/src/parser/classes/misc/CommentsContinuation.d.ts
 new file mode 100644
 index 0000000000000000000000000000000000000000..c7507258a5755e01d0e102808cb0f343c6f84162

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -10,7 +10,7 @@ overrides:
 
 patchedDependencies:
   shaka-player@5.1.12: d7a625baee43220165232606838fe34de9c31643a38f4d8b81cb37f6b14a420c
-  youtubei.js@17.2.0: 5062fcdebe048b48ccd6a8a1e9dd8797c1b9ae83f7fc11add8f8928b4d4f0c83
+  youtubei.js@17.2.0: d6bc7c51e55711aa228bc7958a1b254742daec8aaed75d92bb35a2b27b3012c0
 
 importers:
 
@@ -78,7 +78,7 @@ importers:
         version: 4.1.0(vue@3.5.40)
       youtubei.js:
         specifier: ^17.2.0
-        version: 17.2.0(patch_hash=5062fcdebe048b48ccd6a8a1e9dd8797c1b9ae83f7fc11add8f8928b4d4f0c83)
+        version: 17.2.0(patch_hash=d6bc7c51e55711aa228bc7958a1b254742daec8aaed75d92bb35a2b27b3012c0)
     devDependencies:
       '@babel/core':
         specifier: ^8.0.1
@@ -10517,7 +10517,7 @@ snapshots:
 
   yocto-queue@0.1.0: {}
 
-  youtubei.js@17.2.0(patch_hash=5062fcdebe048b48ccd6a8a1e9dd8797c1b9ae83f7fc11add8f8928b4d4f0c83):
+  youtubei.js@17.2.0(patch_hash=d6bc7c51e55711aa228bc7958a1b254742daec8aaed75d92bb35a2b27b3012c0):
     dependencies:
       '@bufbuild/protobuf': 2.1.0
       fflate: 0.8.3

--- a/src/renderer/components/CommentSection/CommentSection.vue
+++ b/src/renderer/components/CommentSection/CommentSection.vue
@@ -377,7 +377,7 @@
 
 <script setup>
 import { FontAwesomeIcon } from '@fortawesome/vue-fontawesome'
-import { computed, nextTick, onBeforeUnmount, ref, shallowRef, useTemplateRef, watch } from 'vue'
+import { computed, nextTick, ref, shallowRef, useTemplateRef, watch } from 'vue'
 import { useI18n } from 'vue-i18n'
 
 import FtCard from '../ft-card/ft-card.vue'
@@ -455,10 +455,6 @@ const commentData = ref([])
 const commentCount = ref(props.initialCommentCount)
 const commentsContentWrapper = useTemplateRef('commentsContentWrapper')
 let fullscreenScrollTop = 0
-let missingAvatarRetryTimeoutId
-let hasRetriedMissingAvatars = false
-
-const MISSING_AVATAR_RETRY_DELAY_MS = 3000
 
 watch(() => props.fullscreenOverlay, (fullscreenOverlay, wasFullscreenOverlay) => {
   if (wasFullscreenOverlay) {
@@ -791,42 +787,7 @@ function copyCommentYoutubeLink(commentId) {
   })
 }
 
-/**
- * @param {Comment} comment
- */
-function commentHasMissingAvatar(comment) {
-  return !comment.authorThumb || comment.replies.some(commentHasMissingAvatar)
-}
-
-function resetMissingAvatarRetry() {
-  clearTimeout(missingAvatarRetryTimeoutId)
-  missingAvatarRetryTimeoutId = undefined
-  hasRetriedMissingAvatars = false
-}
-
-function scheduleMissingAvatarRetry() {
-  if (hasRetriedMissingAvatars || missingAvatarRetryTimeoutId !== undefined) {
-    return
-  }
-
-  const commentVideoId = props.id
-  missingAvatarRetryTimeoutId = setTimeout(() => {
-    missingAvatarRetryTimeoutId = undefined
-
-    if (props.id !== commentVideoId) {
-      return
-    }
-
-    hasRetriedMissingAvatars = true
-    localCommentsInstance = undefined
-    getCommentDataLocal(false, true, true)
-  }, MISSING_AVATAR_RETRY_DELAY_MS)
-}
-
-onBeforeUnmount(() => clearTimeout(missingAvatarRetryTimeoutId))
-
 function getCommentData({ preserveSort = false } = {}) {
-  resetMissingAvatarRetry()
   isLoading.value = true
 
   if (!process.env.SUPPORTS_LOCAL_API || backendPreference.value === 'invidious') {
@@ -981,9 +942,8 @@ function findComment(comment, commentId) {
 /**
  * @param {boolean | undefined} more
  * @param {boolean} preserveSort
- * @param {boolean} silentRetry
  */
-async function getCommentDataLocal(more = false, preserveSort = false, silentRetry = false) {
+async function getCommentDataLocal(more = false, preserveSort = false) {
   try {
     /** @type {import('youtubei.js').YT.Comments} */
     let comments
@@ -1020,21 +980,10 @@ async function getCommentDataLocal(more = false, preserveSort = false, silentRet
       commentData.value = parsedComments
     }
 
-    if (!more && !silentRetry && parsedComments.some(commentHasMissingAvatar)) {
-      scheduleMissingAvatarRetry()
-    }
-
     nextPageToken.value = comments.has_continuation ? comments : null
-    if (!silentRetry) {
-      isLoading.value = false
-    }
+    isLoading.value = false
     showComments.value = true
   } catch (err) {
-    if (silentRetry) {
-      console.error(err)
-      return
-    }
-
     // region No comment detection
     // No comment related info when video info requested earlier in parent component
     if (err.message.includes('Comments page did not have any content')) {


### PR DESCRIPTION
## Problem

After changing the comment loading behavior, author profile pictures were frequently missing (rendering as letter placeholders), and did not recover on the automatic 3s reload — requiring a manual comments reload that often didn't help either. In some cases this also surfaced as `TypeError: Cannot read properties of undefined (reading 'endpoint')`.

## Root cause

Reproduced against the live API: the failure is **intermittent and all-or-nothing** — roughly 30% of comment fetches return with the avatar missing for **every** comment in the response. Reloading just re-rolls the same ~30% chance, which is why repeated reloads didn't reliably fix it.

Inspecting the raw entity showed YouTube sometimes **omits the entire `comment.avatar` view-model entity** from the mutations, while `comment.author.avatarThumbnailUrl` is **always present** in both good and bad responses. youtubei.js only reads the thumbnail from `avatar.image`, so when `avatar` is gone the avatar goes missing. It also does `comment.avatar.endpoint` unguarded, which is the `reading 'endpoint'` TypeError when `avatar` is undefined.

## Fix

Patch youtubei.js (`CommentView.applyMutations`) to fall back to the always-present `author.avatarThumbnailUrl` when `avatar.image` is absent:

```js
const avatar_image = avatar?.image ?? (comment.author.avatarThumbnailUrl
  ? { sources: [{ url: comment.author.avatarThumbnailUrl }] }
  : undefined);
```

With avatars now never missing, the reload-based retry workaround in `CommentSection.vue` is obsolete and has been removed (net −54 lines there). `FtRetryImage` is kept — it handles transient image *load* failures, which is a separate concern.

## Verification

- Before: ~2 of 6 fresh fetches lost all avatars.
- After: 21/21 fetches across repeated runs fully populated (0 missing).
- Lint clean; unit suite green.

## Notes

This is genuinely an upstream youtubei.js gap and is worth reporting/PRing there so the local patch can eventually be dropped.