### PR TITLE
feat(toast): redesign toasts with thumbnails, bottom-left position and swipe-to-dismiss

### DIFF
--- a/src/renderer/components/FtListVideo/FtListVideo.vue
+++ b/src/renderer/components/FtListVideo/FtListVideo.vue
@@ -814,9 +814,12 @@ function addToWatchQueue(playNext) {
     video: deepCopy(props.data),
     playNext
   })
-  showToast(playNext
-    ? t('Video.Added to Play Next')
-    : t('Video.Added to Queue'))
+  showToast({
+    message: playNext
+      ? t('Video.Added to Play Next')
+      : t('Video.Added to Queue'),
+    image: thumbnail.value
+  })
 }
 
 const thumbnail = computed(() => {
@@ -1310,9 +1313,10 @@ function markAsWatched() {
 
   store.dispatch('updateHistory', videoData)
 
-  if (!historyEntryExists.value) {
-    showToast(t('Video.Video has been marked as watched'))
-  }
+  showToast({
+    message: t('Video.Video has been marked as watched'),
+    image: thumbnail.value
+  })
 }
 
 function unmarkAsWatched() {
@@ -1321,13 +1325,19 @@ function unmarkAsWatched() {
     isWatched: false,
   })
 
-  showToast(t('Video.Video has been unmarked as watched'))
+  showToast({
+    message: t('Video.Video has been unmarked as watched'),
+    image: thumbnail.value
+  })
 }
 
 function removeFromHistory() {
   store.dispatch('removeFromHistory', id.value)
 
-  showToast(t('Video.Video has been removed from your history'))
+  showToast({
+    message: t('Video.Video has been removed from your history'),
+    image: thumbnail.value
+  })
 }
 
 function togglePlaylistPrompt() {
@@ -1400,7 +1410,10 @@ function addToQuickBookmarkPlaylist() {
   })
 
   // TODO: Maybe show playlist name
-  showToast(t('Video.Video has been saved'))
+  showToast({
+    message: t('Video.Video has been saved'),
+    image: thumbnail.value,
+  })
 }
 
 function removeFromQuickBookmarkPlaylist() {
@@ -1411,7 +1424,10 @@ function removeFromQuickBookmarkPlaylist() {
   })
 
   // TODO: Maybe show playlist name
-  showToast(t('Video.Video has been removed from your saved list'))
+  showToast({
+    message: t('Video.Video has been removed from your saved list'),
+    image: thumbnail.value
+  })
 }
 
 function moveVideoUp() {

--- a/src/renderer/components/FtPlaylistAddVideoPrompt/FtPlaylistAddVideoPrompt.vue
+++ b/src/renderer/components/FtPlaylistAddVideoPrompt/FtPlaylistAddVideoPrompt.vue
@@ -118,7 +118,8 @@ import {
   debounce,
   showToast,
   ctrlFHandler,
-  getIconForSortPreference
+  getIconForSortPreference,
+  getVideoThumbnailUrl
 } from '../../helpers/utils'
 
 const { locale, t } = useI18n()
@@ -180,6 +181,10 @@ const title = computed(() => {
 })
 
 const selectedPlaylistCount = computed(() => selectedPlaylistIdList.value.length)
+
+const backendPreference = computed(() => store.getters.getBackendPreference)
+
+const currentInvidiousInstanceUrl = computed(() => store.getters.getCurrentInvidiousInstanceUrl)
 
 /** @type {import('vue').ComputedRef<{ videoId: string, [key: string]: any }[]>} */
 const toBeAddedToPlaylistVideoList = computed(() => store.getters.getToBeAddedToPlaylistVideoList)
@@ -395,9 +400,15 @@ function addSelectedToPlaylists() {
     addedPlaylistIds.add(playlist._id)
   })
 
-  showToast(t('User Playlists.AddVideoPrompt.Toast.Video(s) added to {playlistCount} playlists', {
-    playlistCount: addedPlaylistIds.size,
-  }, addedPlaylistIds.size))
+  showToast({
+    message: t('User Playlists.AddVideoPrompt.Toast.Video(s) added to {playlistCount} playlists', {
+      playlistCount: addedPlaylistIds.size,
+    }, addedPlaylistIds.size),
+    // Show the thumbnail when a single video was added
+    image: toBeAddedToPlaylistVideoList_.length === 1
+      ? getVideoThumbnailUrl(toBeAddedToPlaylistVideoList_[0].videoId, backendPreference.value, currentInvidiousInstanceUrl.value)
+      : null,
+  })
 
   hide()
 }

--- a/src/renderer/components/FtPlaylistAddVideoPrompt/FtPlaylistAddVideoPrompt.vue
+++ b/src/renderer/components/FtPlaylistAddVideoPrompt/FtPlaylistAddVideoPrompt.vue
@@ -186,6 +186,8 @@ const backendPreference = computed(() => store.getters.getBackendPreference)
 
 const currentInvidiousInstanceUrl = computed(() => store.getters.getCurrentInvidiousInstanceUrl)
 
+const thumbnailPreference = computed(() => store.getters.getThumbnailPreference)
+
 /** @type {import('vue').ComputedRef<{ videoId: string, [key: string]: any }[]>} */
 const toBeAddedToPlaylistVideoList = computed(() => store.getters.getToBeAddedToPlaylistVideoList)
 
@@ -406,7 +408,7 @@ function addSelectedToPlaylists() {
     }, addedPlaylistIds.size),
     // Show the thumbnail when a single video was added
     image: toBeAddedToPlaylistVideoList_.length === 1
-      ? getVideoThumbnailUrl(toBeAddedToPlaylistVideoList_[0].videoId, backendPreference.value, currentInvidiousInstanceUrl.value)
+      ? getVideoThumbnailUrl(toBeAddedToPlaylistVideoList_[0].videoId, backendPreference.value, currentInvidiousInstanceUrl.value, thumbnailPreference.value)
       : null,
   })
 

--- a/src/renderer/components/FtToast/FtToast.css
+++ b/src/renderer/components/FtToast/FtToast.css
@@ -1,14 +1,13 @@
 .toast-holder {
   position: fixed;
-  inset-inline-start: 50vw;
-  transform: translate(calc(-50% * var(--horizontal-directionality-coefficient)), 0);
-  inset-block-end: 50px;
+  inset-inline-start: 24px;
+  inset-block-end: 24px;
 
   /* Higher than any prompt */
   z-index: 300;
   display: flex;
   flex-direction: column;
-  align-items: center;
+  align-items: flex-start;
   pointer-events: none;
 }
 
@@ -17,19 +16,51 @@
 }
 
 .toast {
-  padding: 10px;
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  max-inline-size: 400px;
+  padding-block: 12px;
+  padding-inline: 18px;
   margin: 5px;
-  text-align: center;
+  text-align: start;
   overflow-y: auto;
-  background-color: rgb(0 0 0 / 70%);
+  background-color: rgb(28 28 28 / 92%);
   color: #fff;
-  border-radius: 20px;
+  border-radius: 12px;
+  box-shadow: 0 4px 16px rgb(0 0 0 / 35%);
+
+  /* Many toasts are clickable, so keep the click affordance until a drag starts */
   cursor: pointer;
   pointer-events: auto;
+  user-select: none;
+
+  /* Let the component own horizontal drag gestures instead of the browser */
+  touch-action: pan-y;
+  transition: transform 300ms ease, opacity 300ms ease;
+}
+
+/* Follow the pointer instantly while dragging */
+.toast.dragging {
+  cursor: grabbing;
+  transition: none;
+}
+
+/* Tighten the leading padding so the thumbnail sits closer to the edge */
+.toast.hasImage {
+  padding-inline-start: 10px;
+}
+
+.image {
+  flex-shrink: 0;
+  inline-size: 64px;
+  block-size: 36px;
+  object-fit: cover;
+  border-radius: 6px;
 }
 
 .message {
-  margin: auto;
+  margin: 0;
 }
 
 .toast-enter-active {
@@ -37,6 +68,9 @@
 }
 
 .toast-leave-active {
+  /* Taken out of flow (pinned via position: fixed in the before-leave hook) so
+     the ones above animate up to fill the gap (via .toast-move) instead of
+     jumping once it is finally removed */
   transition: opacity 300ms, transform 300ms ease-in;
   pointer-events: none;
 }
@@ -45,6 +79,11 @@
 .toast-leave-to {
   opacity: 0;
   transform: translateY(15px) scale(0.95);
+}
+
+/* When dismissed by a leftward swipe, continue sliding off to the left */
+.toast-slot.dismiss-left.toast-leave-to {
+  transform: translateX(-110%);
 }
 
 /* stack reflow when a toast is removed */

--- a/src/renderer/components/FtToast/FtToast.css
+++ b/src/renderer/components/FtToast/FtToast.css
@@ -19,7 +19,10 @@
   display: flex;
   align-items: center;
   gap: 12px;
-  max-inline-size: 400px;
+
+  /* Stay within the viewport on narrow windows, accounting for the holder's
+     inline inset and this element's own margins */
+  max-inline-size: min(400px, calc(100vw - 60px));
   padding-block: 12px;
   padding-inline: 18px;
   margin: 5px;

--- a/src/renderer/components/FtToast/FtToast.vue
+++ b/src/renderer/components/FtToast/FtToast.vue
@@ -60,7 +60,7 @@ let removeShowToastListener = null
  * @property {NodeJS.Timeout | number} timeout
  * @property {NodeJS.Timeout | number} interval
  * @property {number} id
- * @property {number} time resolved display duration in ms, used to reschedule auto-dismiss after a drag
+ * @property {number} expiresAt timestamp the toast is due to auto-dismiss at, used to reschedule after a drag
  * @property {boolean} dragging
  * @property {boolean} pointerMoved whether the pointer moved enough to count as a drag (suppresses the click action)
  * @property {number} dragOffset current horizontal (leftward, <= 0) drag offset in px
@@ -96,7 +96,7 @@ function open({ detail: { message, time, action, abortSignal, image } }) {
     image: image ?? null,
     timeout: 0,
     interval: 0,
-    time,
+    expiresAt: Date.now() + time,
     dragging: false,
     pointerMoved: false,
     dragOffset: 0,
@@ -206,9 +206,12 @@ function onPointerUp(toast) {
     toast.dismissing = true
     nextTick(() => remove(toast))
   } else {
-    // Snap back into place and resume the auto-dismiss countdown
+    // Snap back into place and resume the auto-dismiss countdown for whatever
+    // is left of the original lifetime. Keeping the deadline absolute matters
+    // for toasts whose action expires on its own schedule (e.g. the playlist
+    // undo toast), which must not stay clickable after that deadline passes.
     toast.dragOffset = 0
-    toast.timeout = setTimeout(remove, toast.time, toast)
+    toast.timeout = setTimeout(remove, Math.max(0, toast.expiresAt - Date.now()), toast)
   }
 }
 

--- a/src/renderer/components/FtToast/FtToast.vue
+++ b/src/renderer/components/FtToast/FtToast.vue
@@ -7,27 +7,46 @@
       tag="div"
       name="toast"
       class="toast-holder"
+      @before-leave="onBeforeLeave"
     >
       <div
         v-for="toast in toasts"
         :key="toast.id"
-        class="toast"
-        tabindex="0"
-        role="status"
-        @click="performAction(toast)"
-        @keydown.enter.prevent="performAction(toast)"
-        @keydown.space.prevent="performAction(toast)"
+        class="toast-slot"
+        :class="{ 'dismiss-left': toast.dismissing }"
       >
-        <p class="message">
-          {{ toast.message }}
-        </p>
+        <div
+          class="toast"
+          :class="{ hasImage: toast.image, dragging: toast.dragging }"
+          :style="dragStyle(toast)"
+          tabindex="0"
+          role="status"
+          @click="onClick(toast)"
+          @keydown.enter.prevent="performAction(toast)"
+          @keydown.space.prevent="performAction(toast)"
+          @pointerdown="onPointerDown(toast, $event)"
+          @pointermove="onPointerMove(toast, $event)"
+          @pointerup="onPointerUp(toast)"
+          @pointercancel="onPointerUp(toast)"
+        >
+          <img
+            v-if="toast.image"
+            :src="toast.image"
+            class="image"
+            alt=""
+            draggable="false"
+          >
+          <p class="message">
+            {{ toast.message }}
+          </p>
+        </div>
       </div>
     </TransitionGroup>
   </Teleport>
 </template>
 
 <script setup>
-import { onBeforeUnmount, onMounted, reactive, ref } from 'vue'
+import { nextTick, onBeforeUnmount, onMounted, reactive, ref } from 'vue'
 import { showToast, ToastEventBus } from '../../helpers/utils'
 
 let idCounter = 0
@@ -37,10 +56,20 @@ let removeShowToastListener = null
  * @typedef Toast
  * @property {string | (({elapsedMs: number, remainingMs: number}) => string)} message
  * @property {Function | null} action
+ * @property {string | null} image
  * @property {NodeJS.Timeout | number} timeout
  * @property {NodeJS.Timeout | number} interval
  * @property {number} id
+ * @property {number} time resolved display duration in ms, used to reschedule auto-dismiss after a drag
+ * @property {boolean} dragging
+ * @property {boolean} pointerMoved whether the pointer moved enough to count as a drag (suppresses the click action)
+ * @property {number} dragOffset current horizontal (leftward, <= 0) drag offset in px
+ * @property {boolean} dismissing whether the toast is being swiped off to the left (picks the slide-left leave animation)
+ * @property {number} [dragStartX] pointer x position where the current drag started
  */
+
+/** Distance in px a toast must be dragged before it slides away instead of snapping back */
+const DRAG_DISMISS_THRESHOLD = 80
 
 /** @type {import('vue').Reactive<Toast[]>} */
 const toasts = reactive([])
@@ -52,20 +81,27 @@ function updateFullscreenTarget() {
 }
 
 /**
- * @param {CustomEvent<{ message: string | (({elapsedMs: number, remainingMs: number}) => string), time: number | null, action: Function | null, abortSignal: AbortSignal | null }>} event
+ * @param {CustomEvent<{ message: string | (({elapsedMs: number, remainingMs: number}) => string), time: number | null, action: Function | null, abortSignal: AbortSignal | null, image: string | null }>} event
  */
-function open({ detail: { message, time, action, abortSignal } }) {
+function open({ detail: { message, time, action, abortSignal, image } }) {
   const id = idCounter++
+
+  time ||= 3000
 
   /** @type {Toast} */
   const toast = {
     id,
     message,
     action,
+    image: image ?? null,
     timeout: 0,
-    interval: 0
+    interval: 0,
+    time,
+    dragging: false,
+    pointerMoved: false,
+    dragOffset: 0,
+    dismissing: false
   }
-  time ||= 3000
   let elapsed = 0
   const updateDelay = 1000
 
@@ -105,6 +141,106 @@ function open({ detail: { message, time, action, abortSignal } }) {
 function performAction(toast) {
   toast.action?.()
   remove(toast)
+}
+
+/**
+ * Runs the toast action on click, unless the pointer was dragged (in which case
+ * the click is the tail end of a drag gesture and should be ignored).
+ * @param {Toast} toast
+ */
+function onClick(toast) {
+  if (toast.pointerMoved) {
+    toast.pointerMoved = false
+    return
+  }
+  performAction(toast)
+}
+
+/**
+ * @param {Toast} toast
+ * @param {PointerEvent} event
+ */
+function onPointerDown(toast, event) {
+  // Only start dragging with the primary (left) mouse button or touch/pen
+  if (event.pointerType === 'mouse' && event.button !== 0) { return }
+
+  toast.dragging = true
+  toast.pointerMoved = false
+  toast.dragStartX = event.clientX
+  toast.dragOffset = 0
+
+  // Freeze auto-dismiss while the user is interacting with the toast
+  clearTimeout(toast.timeout)
+
+  event.currentTarget.setPointerCapture(event.pointerId)
+}
+
+/**
+ * @param {Toast} toast
+ * @param {PointerEvent} event
+ */
+function onPointerMove(toast, event) {
+  if (!toast.dragging) { return }
+
+  // Only allow dragging towards the left; ignore any rightward movement
+  toast.dragOffset = Math.min(0, event.clientX - toast.dragStartX)
+
+  if (toast.dragOffset < -5) {
+    toast.pointerMoved = true
+  }
+}
+
+/**
+ * @param {Toast} toast
+ */
+function onPointerUp(toast) {
+  if (!toast.dragging) { return }
+
+  toast.dragging = false
+
+  if (toast.dragOffset < -DRAG_DISMISS_THRESHOLD) {
+    // Flag the toast for the slide-left leave animation, then remove it on the
+    // next tick so the `dismiss-left` class is rendered before the leave starts.
+    // Removing promptly (rather than after a timeout) lets the toasts above
+    // start animating down into the freed space without any delay.
+    toast.dismissing = true
+    nextTick(() => remove(toast))
+  } else {
+    // Snap back into place and resume the auto-dismiss countdown
+    toast.dragOffset = 0
+    toast.timeout = setTimeout(remove, toast.time, toast)
+  }
+}
+
+/**
+ * Pin a leaving toast to the exact viewport spot it occupied before it is taken
+ * out of flow, so the remaining toasts can animate up to fill the gap without
+ * the leaving one jumping. Fixed positioning keeps it put even though the
+ * bottom-anchored holder shrinks as soon as this toast leaves the flow.
+ * @param {HTMLElement} el the `.toast-slot` element being removed
+ */
+function onBeforeLeave(el) {
+  const { top, left, width, height } = el.getBoundingClientRect()
+
+  el.style.position = 'fixed'
+  el.style.top = `${top}px`
+  el.style.left = `${left}px`
+  el.style.width = `${width}px`
+  el.style.height = `${height}px`
+  el.style.margin = '0'
+}
+
+/**
+ * @param {Toast} toast
+ * @returns {Record<string, string | number>}
+ */
+function dragStyle(toast) {
+  if (toast.dragOffset === 0) { return {} }
+
+  return {
+    transform: `translateX(${toast.dragOffset}px)`,
+    opacity: Math.max(0, 1 + toast.dragOffset / 200)
+  }
 }
 
 /**

--- a/src/renderer/components/FtToast/FtToast.vue
+++ b/src/renderer/components/FtToast/FtToast.vue
@@ -24,6 +24,7 @@
           @click="onClick(toast)"
           @keydown.enter.prevent="performAction(toast)"
           @keydown.space.prevent="performAction(toast)"
+          @keydown.esc.prevent="dismiss(toast)"
           @pointerdown="onPointerDown(toast, $event)"
           @pointermove="onPointerMove(toast, $event)"
           @pointerup="onPointerUp(toast)"
@@ -144,6 +145,19 @@ function performAction(toast) {
 }
 
 /**
+ * Dismisses a toast without running its action, for users who want it out of
+ * the way. Flags it for the slide-left leave animation, then removes it on the
+ * next tick so the `dismiss-left` class is rendered before the leave starts.
+ * Removing promptly (rather than after a timeout) lets the toasts above start
+ * animating into the freed space without any delay.
+ * @param {Toast} toast
+ */
+function dismiss(toast) {
+  toast.dismissing = true
+  nextTick(() => remove(toast))
+}
+
+/**
  * Runs the toast action on click, unless the pointer was dragged (in which case
  * the click is the tail end of a drag gesture and should be ignored).
  * @param {Toast} toast
@@ -199,12 +213,7 @@ function onPointerUp(toast) {
   toast.dragging = false
 
   if (toast.dragOffset < -DRAG_DISMISS_THRESHOLD) {
-    // Flag the toast for the slide-left leave animation, then remove it on the
-    // next tick so the `dismiss-left` class is rendered before the leave starts.
-    // Removing promptly (rather than after a timeout) lets the toasts above
-    // start animating down into the freed space without any delay.
-    toast.dismissing = true
-    nextTick(() => remove(toast))
+    dismiss(toast)
   } else {
     // Snap back into place and resume the auto-dismiss countdown for whatever
     // is left of the original lifetime. Keeping the deadline absolute matters

--- a/src/renderer/components/FtToast/FtToast.vue
+++ b/src/renderer/components/FtToast/FtToast.vue
@@ -183,7 +183,8 @@ function onPointerDown(toast, event) {
   toast.dragStartX = event.clientX
   toast.dragOffset = 0
 
-  // Freeze auto-dismiss while the user is interacting with the toast
+  // Hold off auto-dismiss so the toast can't vanish mid-drag. The deadline in
+  // `expiresAt` keeps running, so this can't be used to keep a toast alive.
   clearTimeout(toast.timeout)
 
   event.currentTarget.setPointerCapture(event.pointerId)

--- a/src/renderer/components/WatchVideoInfo/WatchVideoInfo.vue
+++ b/src/renderer/components/WatchVideoInfo/WatchVideoInfo.vue
@@ -678,7 +678,7 @@ function togglePlaylistPrompt() {
 const quickBookmarkPlaylist = computed(() => store.getters.getQuickBookmarkPlaylist)
 
 const quickBookmarkThumbnail = computed(() => {
-  return getVideoThumbnailUrl(props.id, store.getters.getBackendPreference, store.getters.getCurrentInvidiousInstanceUrl)
+  return getVideoThumbnailUrl(props.id, store.getters.getBackendPreference, store.getters.getCurrentInvidiousInstanceUrl, store.getters.getThumbnailPreference)
 })
 
 const isQuickBookmarkEnabled = computed(() => quickBookmarkPlaylist.value != null)

--- a/src/renderer/components/WatchVideoInfo/WatchVideoInfo.vue
+++ b/src/renderer/components/WatchVideoInfo/WatchVideoInfo.vue
@@ -257,7 +257,7 @@ import WatchVideoDownloadPrompt from '../WatchVideoDownloadPrompt/WatchVideoDown
 
 import store from '../../store'
 
-import { formatNumber, getRelativeTimeFromDate, openInternalPath, showToast } from '../../helpers/utils'
+import { formatNumber, getRelativeTimeFromDate, getVideoThumbnailUrl, openInternalPath, showToast } from '../../helpers/utils'
 import { useTabContext } from '../../tabs/TabContext'
 import { tabMediaCoordinator } from '../../tabs/TabMediaCoordinator'
 
@@ -677,6 +677,10 @@ function togglePlaylistPrompt() {
 
 const quickBookmarkPlaylist = computed(() => store.getters.getQuickBookmarkPlaylist)
 
+const quickBookmarkThumbnail = computed(() => {
+  return getVideoThumbnailUrl(props.id, store.getters.getBackendPreference, store.getters.getCurrentInvidiousInstanceUrl)
+})
+
 const isQuickBookmarkEnabled = computed(() => quickBookmarkPlaylist.value != null)
 const quickBookmarkIcon = computed(() => store.getters.getQuickBookmarkIcon)
 
@@ -737,7 +741,10 @@ function addToQuickBookmarkPlaylist() {
   })
 
   // TODO: Maybe show playlist name
-  showToast(t('Video.Video has been saved'))
+  showToast({
+    message: t('Video.Video has been saved'),
+    image: quickBookmarkThumbnail.value,
+  })
 }
 
 function removeFromQuickBookmarkPlaylist() {
@@ -748,7 +755,10 @@ function removeFromQuickBookmarkPlaylist() {
   })
 
   // TODO: Maybe show playlist name
-  showToast(t('Video.Video has been removed from your saved list'))
+  showToast({
+    message: t('Video.Video has been removed from your saved list'),
+    image: quickBookmarkThumbnail.value
+  })
 }
 
 const enableChannelLinks = computed(() => !store.getters.getDisableChannelLinks)

--- a/src/renderer/components/WatchVideoPlaylist/WatchVideoPlaylist.vue
+++ b/src/renderer/components/WatchVideoPlaylist/WatchVideoPlaylist.vue
@@ -233,7 +233,7 @@ import FtPrompt from '../FtPrompt/FtPrompt.vue'
 
 import store from '../../store/index'
 
-import { copyToClipboard, deepCopy, showToast, throttle } from '../../helpers/utils'
+import { copyToClipboard, deepCopy, getVideoThumbnailUrl, showToast, throttle } from '../../helpers/utils'
 import {
   getLocalCachedFeedContinuation,
   getLocalPlaylist,
@@ -710,7 +710,10 @@ async function removeVideoFromPlaylist(videoId, playlistItemId) {
       videoId,
       playlistItemId,
     })
-    showToast(t('User Playlists.SinglePlaylistView.Toast.Video has been removed'))
+    showToast({
+      message: t('User Playlists.SinglePlaylistView.Toast.Video has been removed'),
+      image: getVideoThumbnailUrl(videoId, backendPreference.value, currentInvidiousInstanceUrl.value)
+    })
   } catch (error) {
     showToast(t('User Playlists.SinglePlaylistView.Toast.There was a problem with removing this video'))
     console.error(error)

--- a/src/renderer/components/WatchVideoPlaylist/WatchVideoPlaylist.vue
+++ b/src/renderer/components/WatchVideoPlaylist/WatchVideoPlaylist.vue
@@ -310,6 +310,8 @@ const backendFallback = computed(() => store.getters.getBackendFallback)
 /** @type {import('vue').ComputedRef<string>} */
 const currentInvidiousInstanceUrl = computed(() => store.getters.getCurrentInvidiousInstanceUrl)
 
+const thumbnailPreference = computed(() => store.getters.getThumbnailPreference)
+
 const isUserPlaylist = computed(() => props.playlistType === 'user')
 
 const playlistReverseStateKey = computed(() => {
@@ -712,7 +714,7 @@ async function removeVideoFromPlaylist(videoId, playlistItemId) {
     })
     showToast({
       message: t('User Playlists.SinglePlaylistView.Toast.Video has been removed'),
-      image: getVideoThumbnailUrl(videoId, backendPreference.value, currentInvidiousInstanceUrl.value)
+      image: getVideoThumbnailUrl(videoId, backendPreference.value, currentInvidiousInstanceUrl.value, thumbnailPreference.value)
     })
   } catch (error) {
     showToast(t('User Playlists.SinglePlaylistView.Toast.There was a problem with removing this video'))

--- a/src/renderer/helpers/utils.js
+++ b/src/renderer/helpers/utils.js
@@ -191,15 +191,49 @@ function secondsToVttTimestamp(seconds) {
   return `${formattedHours}:${formattedMinutes}:${formattedSeconds}`
 }
 
+/**
+ * Builds a medium-quality thumbnail URL for a video, honouring the current backend.
+ * Handy for toasts that reference a single video by id.
+ * @param {string} videoId
+ * @param {'local' | 'invidious'} backendPreference
+ * @param {string} currentInvidiousInstanceUrl
+ * @returns {string}
+ */
+export function getVideoThumbnailUrl(videoId, backendPreference, currentInvidiousInstanceUrl) {
+  const baseUrl = backendPreference === 'invidious'
+    ? currentInvidiousInstanceUrl
+    : 'https://i.ytimg.com'
+
+  return `${baseUrl}/vi/${videoId}/mqdefault.jpg`
+}
+
 export const ToastEventBus = new EventTarget()
 
 /**
- * @param {string | (({elapsedMs: number, remainingMs: number}) => string)} message
+ * @typedef {object} ToastOptions
+ * @property {string | (({elapsedMs: number, remainingMs: number}) => string)} message
+ * @property {number} [time]
+ * @property {Function} [action]
+ * @property {AbortSignal} [abortSignal]
+ * @property {string} [image] optional image URL (e.g. a video thumbnail) shown alongside the message
+ */
+
+/**
+ * @param {string | (({elapsedMs: number, remainingMs: number}) => string) | ToastOptions} message
+ *   the message to display, or an options object for more control (e.g. to show an image)
  * @param {number} time
  * @param {Function} action
  * @param {AbortSignal} abortSignal
  */
 export function showToast(message, time = null, action = null, abortSignal = null) {
+  let image = null
+
+  // Allow calling with a single options object while staying backwards compatible
+  // with the positional (message, time, action, abortSignal) signature
+  if (message !== null && typeof message === 'object') {
+    ({ message, time = null, action = null, abortSignal = null, image = null } = message)
+  }
+
   // Sometimes caller just pass user setting based value in and it can be zero
   if (time === 0) {
     console.warn('showToast called with time: 0', { message, time, action, abortSignal })
@@ -212,6 +246,7 @@ export function showToast(message, time = null, action = null, abortSignal = nul
       time,
       action,
       abortSignal,
+      image,
     }
   }))
 }

--- a/src/renderer/helpers/utils.js
+++ b/src/renderer/helpers/utils.js
@@ -192,19 +192,35 @@ function secondsToVttTimestamp(seconds) {
 }
 
 /**
- * Builds a medium-quality thumbnail URL for a video, honouring the current backend.
- * Handy for toasts that reference a single video by id.
+ * Builds a medium-quality thumbnail URL for a video, honouring the current backend
+ * and the user's thumbnail preference. Handy for toasts that reference a single
+ * video by id. Returns null when thumbnails are hidden, so callers can omit the
+ * image entirely rather than showing a meaningless placeholder.
  * @param {string} videoId
  * @param {'local' | 'invidious'} backendPreference
  * @param {string} currentInvidiousInstanceUrl
- * @returns {string}
+ * @param {'' | 'hidden' | 'start' | 'middle' | 'end'} thumbnailPreference
+ * @returns {string | null}
  */
-export function getVideoThumbnailUrl(videoId, backendPreference, currentInvidiousInstanceUrl) {
+export function getVideoThumbnailUrl(videoId, backendPreference, currentInvidiousInstanceUrl, thumbnailPreference = '') {
+  if (thumbnailPreference === 'hidden') {
+    return null
+  }
+
   const baseUrl = backendPreference === 'invidious'
     ? currentInvidiousInstanceUrl
     : 'https://i.ytimg.com'
 
-  return `${baseUrl}/vi/${videoId}/mqdefault.jpg`
+  switch (thumbnailPreference) {
+    case 'start':
+      return `${baseUrl}/vi/${videoId}/mq1.jpg`
+    case 'middle':
+      return `${baseUrl}/vi/${videoId}/mq2.jpg`
+    case 'end':
+      return `${baseUrl}/vi/${videoId}/mq3.jpg`
+    default:
+      return `${baseUrl}/vi/${videoId}/mqdefault.jpg`
+  }
 }
 
 export const ToastEventBus = new EventTarget()

--- a/src/renderer/views/Playlist/Playlist.vue
+++ b/src/renderer/views/Playlist/Playlist.vue
@@ -200,6 +200,7 @@ import {
   debounce,
   extractNumberFromString,
   getIconForSortPreference,
+  getVideoThumbnailUrl,
   showToast,
   deepCopy,
   throttle,
@@ -874,16 +875,17 @@ function removeVideoFromPlaylist(videoId, playlistItemId) {
           removeToBeDeletedVideosSometimes()
         }, timeoutMs)
 
-        showToast(
-          t('User Playlists.SinglePlaylistView.Toast["Video has been removed. Click here to undo."]'),
-          timeoutMs,
-          () => {
+        showToast({
+          message: t('User Playlists.SinglePlaylistView.Toast["Video has been removed. Click here to undo."]'),
+          time: timeoutMs,
+          action: () => {
             clearTimeout(actualRemoveVideosTimeout)
             toBeDeletedPlaylistItemIds.value = []
             undoToastAbortController = null
           },
-          undoToastAbortController.signal,
-        )
+          abortSignal: undoToastAbortController.signal,
+          image: getVideoThumbnailUrl(videoId, backendPreference.value, currentInvidiousInstanceUrl.value),
+        })
       }
     }
   } catch (e) {

--- a/src/renderer/views/Playlist/Playlist.vue
+++ b/src/renderer/views/Playlist/Playlist.vue
@@ -264,6 +264,8 @@ const backendFallback = computed(() => store.getters.getBackendFallback)
 /** @type {import('vue').ComputedRef<string>} */
 const currentInvidiousInstanceUrl = computed(() => store.getters.getCurrentInvidiousInstanceUrl)
 
+const thumbnailPreference = computed(() => store.getters.getThumbnailPreference)
+
 /** @type {import('vue').ComputedRef<string>} */
 const userPlaylistSortOrder = computed(() => store.getters.getUserPlaylistSortOrder)
 
@@ -884,7 +886,7 @@ function removeVideoFromPlaylist(videoId, playlistItemId) {
             undoToastAbortController = null
           },
           abortSignal: undoToastAbortController.signal,
-          image: getVideoThumbnailUrl(videoId, backendPreference.value, currentInvidiousInstanceUrl.value),
+          image: getVideoThumbnailUrl(videoId, backendPreference.value, currentInvidiousInstanceUrl.value, thumbnailPreference.value),
         })
       }
     }

--- a/src/renderer/views/Watch/Watch.js
+++ b/src/renderer/views/Watch/Watch.js
@@ -619,7 +619,10 @@ export default defineComponent({
           _id: this.quickBookmarkPlaylist._id,
           videoId: this.videoId
         })
-        showToast(this.$t('Video.Video has been removed from your saved list'))
+        showToast({
+          message: this.$t('Video.Video has been removed from your saved list'),
+          image: this.thumbnail
+        })
         return
       }
 
@@ -635,7 +638,10 @@ export default defineComponent({
           premiereDate: this.premiereDate
         }
       })
-      showToast(this.$t('Video.Video has been saved'))
+      showToast({
+        message: this.$t('Video.Video has been saved'),
+        image: this.thumbnail
+      })
     },
     handleChaptersOverlayChange(open) {
       const shouldUseDefaultTheatreMode = open && !this.theatrePossible &&

--- a/src/renderer/views/Watch/Watch.js
+++ b/src/renderer/views/Watch/Watch.js
@@ -369,6 +369,10 @@ export default defineComponent({
     thumbnailPreference: function () {
       return this.$store.getters.getThumbnailPreference
     },
+    /** Thumbnail to show in toasts about this video, omitted when thumbnails are hidden */
+    toastThumbnail: function () {
+      return this.thumbnailPreference === 'hidden' ? null : this.thumbnail
+    },
     autoplayNextRecommendedVideoByDefault: function () {
       return this.$store.getters.getPlayNextVideo
     },
@@ -621,7 +625,7 @@ export default defineComponent({
         })
         showToast({
           message: this.$t('Video.Video has been removed from your saved list'),
-          image: this.thumbnail
+          image: this.toastThumbnail
         })
         return
       }
@@ -640,7 +644,7 @@ export default defineComponent({
       })
       showToast({
         message: this.$t('Video.Video has been saved'),
-        image: this.thumbnail
+        image: this.toastThumbnail
       })
     },
     handleChaptersOverlayChange(open) {


### PR DESCRIPTION
## Summary

Redesigns the toast notifications to be more compact and informative, moves them to the bottom-left, and makes them dismissable by swiping.

### Design

Toasts are now compact dark rounded pills with a drop shadow, anchored to the **bottom-left** of the window. They can optionally show a leading 16:9 thumbnail.

`showToast` accepts an options object in addition to its existing positional signature, so existing call sites are unchanged:

```js
showToast({ message: t('Video.Video has been saved'), image: thumbnail.value })
```

Video thumbnails are now shown on the toasts where a single video is the subject of the action:

- Save / remove from saved list (list, watch info, watch page)
- Mark / unmark as watched, remove from history
- Add to queue / play next
- Add to playlist (when a single video is added) and remove from playlist (including the undo toast)

Thumbnail URLs respect the Invidious/local backend preference via a new shared `getVideoThumbnailUrl` helper in `helpers/utils.js`. In `FtListVideo` the existing `thumbnail` computed is reused, so DeArrow and the thumbnail preference (including the hidden placeholder) are honoured.

Settings, profile, export, playback and error toasts remain text-only.

### Swipe to dismiss

Toasts can be dragged to the **left** to dismiss them. The toast follows the pointer and fades as it moves; released past a threshold it slides off the left edge and is removed, otherwise it snaps back and resumes its auto-dismiss countdown. Auto-dismiss is paused while dragging, and a drag no longer triggers the toast's click action (many toasts are clickable). The cursor only changes to `grabbing` once a drag starts, so the click affordance is preserved at rest.

### Animation fixes

- Each toast is wrapped in a stable slot element so `TransitionGroup`'s FLIP move-animation no longer fights the drag transform (previously, with multiple toasts, dragging only faded the toast instead of moving it).
- A leaving toast is pinned to its exact viewport position in a `before-leave` hook, so the toasts above animate into the freed space instead of jumping, and the leaving toast no longer teleports and reflows its text on the way out.
- Dismissal no longer waits on a timeout before removing the toast, which removes a noticeable delay before the stack reflowed.

### Bugfix

The "Video has been marked as watched" toast was suppressed whenever a history entry already existed, so marking an already partially-watched video as watched silently showed nothing. It now always shows, consistent with the unmark action.

## Test plan

- `pnpm run lint` (eslint + stylelint) passes on all touched files
- `pnpm run test:e2e:pack` builds successfully
- Full offline E2E suite passes (108 tests), including `video-actions` (quick bookmark, watched toggle) and `watch-queue`
- The network watch-page toast test (`full window playlist action shows its prompt above the player`) passes
- Drag/leave behaviour verified in a Vue `TransitionGroup` harness using the component's real CSS: drag follows the pointer and is clamped leftward, dismiss past threshold removes the toast, small drags snap back, the leaving toast stays pinned while remaining toasts animate via FLIP