### PR TITLE
fix: background tab watch progress, playlist anchoring, tooltip clipping and theatre mode button

### DIFF
--- a/e2e/tests/offline/ui-bugfixes.spec.mjs
+++ b/e2e/tests/offline/ui-bugfixes.spec.mjs
@@ -1,0 +1,64 @@
+import { test, expect, goTo } from '../../helpers/app.mjs'
+
+function historyEntry(videoId, title, timeWatched) {
+  return {
+    _id: videoId,
+    videoId,
+    title,
+    author: 'Test Channel',
+    authorId: 'UC-test-channel-id',
+    published: Date.now() - 86_400_000,
+    description: 'Test description',
+    viewCount: 1234,
+    lengthSeconds: 60,
+    watchProgress: 10,
+    isWatched: false,
+    timeWatched,
+    isLive: false,
+    type: 'video'
+  }
+}
+
+test.describe('history reorder animation', () => {
+  test.use({
+    seed: {
+      history: [
+        historyEntry('aaaaaaaaaaa', 'Alpha video', Date.now() - 1000),
+        historyEntry('bbbbbbbbbbb', 'Bravo video', Date.now() - 2000),
+        historyEntry('ccccccccccc', 'Charlie video', Date.now() - 3000)
+      ]
+    }
+  })
+
+  // A reorder must move the existing DOM nodes, which is what lets the
+  // TransitionGroup run its FLIP move animation. Index-derived keys made Vue
+  // destroy and recreate the elements instead, which is the choppy "jump".
+  test('reuses the same DOM nodes when entries are reordered', async ({ page }) => {
+    await goTo(page, 'history')
+    await expect(page.getByText('Alpha video')).toBeVisible()
+
+    // Tag every rendered item so we can tell reuse from recreation.
+    const tagged = await page.evaluate(() => {
+      const items = Array.from(document.querySelectorAll('.autoGrid > *'))
+      items.forEach((element, index) => {
+        element.dataset.ftReorderProbe = String(index)
+      })
+      return items.length
+    })
+    expect(tagged).toBe(3)
+
+    // Reorder the list, the same path a re-watched entry moving to the top takes.
+    await page.locator('.sortSelect select').selectOption('earliest_played_first')
+
+    const items = page.locator('.autoGrid > *')
+    await expect(items.first()).toContainText('Charlie video')
+
+    // Every element still carries its probe, i.e. nothing was recreated.
+    const probes = await page.evaluate(() =>
+      Array.from(document.querySelectorAll('.autoGrid > *'))
+        .map((element) => element.dataset.ftReorderProbe ?? null)
+    )
+    expect(probes).toHaveLength(3)
+    expect(probes).not.toContain(null)
+  })
+})

--- a/src/renderer/components/FtTooltip/FtTooltip.css
+++ b/src/renderer/components/FtTooltip/FtTooltip.css
@@ -71,17 +71,18 @@
 
 .button:focus + .text.bottom,
 .button:hover + .text.bottom,
+.button:focus + .text.bottom-left,
 .button:hover + .text.bottom-left,
 .button:focus + .text.top,
 .button:hover + .text.top {
-  transform: translate(calc(-50% * var(--horizontal-directionality-coefficient)), 0);
+  transform: translate(calc(-50% * var(--horizontal-directionality-coefficient) + var(--ft-tooltip-shift-x, 0px)), 0);
 }
 
 .button:focus + .text.left,
 .button:hover + .text.left,
 .button:focus + .text.right,
 .button:hover + .text.right {
-  transform: translate(0, -50%);
+  transform: translate(var(--ft-tooltip-shift-x, 0), -50%);
 }
 
 .text.allowNewlines {

--- a/src/renderer/components/FtTooltip/FtTooltip.vue
+++ b/src/renderer/components/FtTooltip/FtTooltip.vue
@@ -1,5 +1,9 @@
 <template>
-  <div class="tooltip">
+  <div
+    class="tooltip"
+    @mouseenter="clampToViewport"
+    @focusin="clampToViewport"
+  >
     <button
       :aria-labelledby="id"
       class="button"
@@ -9,6 +13,7 @@
     </button>
     <p
       :id="id"
+      ref="textRef"
       class="text"
       :class="{
         [position]: true,
@@ -23,7 +28,76 @@
 
 <script setup>
 import { FontAwesomeIcon } from '@fortawesome/vue-fontawesome'
-import { useId } from 'vue'
+import { useId, useTemplateRef } from 'vue'
+
+const textRef = useTemplateRef('textRef')
+
+// Keep the tooltip inside whatever would otherwise cut it off horizontally. It
+// is positioned purely with CSS relative to its icon, so an icon near the start
+// of a clipping container (the settings page clips with `overflow-x: hidden`)
+// left part of the tooltip unreachable. We compute its shown horizontal extent
+// and offset it back into view via a CSS variable.
+// `offsetLeft`/`offsetWidth` are used because, unlike `getBoundingClientRect()`,
+// they are unaffected by the CSS transform (and its transition), so the shown
+// fade/slide animation is preserved.
+const EDGE_MARGIN = 8
+
+/**
+ * The horizontal bounds the tooltip has to stay within: the nearest ancestor
+ * that clips horizontally, falling back to the viewport.
+ *
+ * @param {HTMLElement} el
+ * @returns {{ min: number, max: number }}
+ */
+function getHorizontalBounds(el) {
+  for (let node = el.parentElement; node != null; node = node.parentElement) {
+    const overflowX = getComputedStyle(node).overflowX
+    if (overflowX !== 'visible') {
+      const rect = node.getBoundingClientRect()
+      return {
+        min: Math.max(0, rect.left),
+        max: Math.min(window.innerWidth, rect.right)
+      }
+    }
+  }
+
+  return { min: 0, max: window.innerWidth }
+}
+
+function clampToViewport() {
+  const el = textRef.value
+  const offsetParent = el?.offsetParent
+  if (!el || !offsetParent) {
+    return
+  }
+
+  // Measure the unshifted position, so repeated hovers don't compound the shift.
+  el.style.setProperty('--ft-tooltip-shift-x', '0px')
+
+  const width = el.offsetWidth
+  const parentLeft = offsetParent.getBoundingClientRect().left
+  const dir = getComputedStyle(el).direction === 'rtl' ? -1 : 1
+
+  // The visible transform's static horizontal translate: centered variants shift
+  // by -50% (times the writing-direction coefficient), edge variants by 0.
+  const centered = el.classList.contains('bottom') ||
+    el.classList.contains('bottom-left') ||
+    el.classList.contains('top')
+  const staticTranslateX = centered ? -0.5 * width * dir : 0
+
+  const left = parentLeft + el.offsetLeft + staticTranslateX
+  const right = left + width
+  const { min, max } = getHorizontalBounds(el)
+
+  let shift = 0
+  if (left < min + EDGE_MARGIN) {
+    shift = Math.ceil(min + EDGE_MARGIN - left)
+  } else if (right > max - EDGE_MARGIN) {
+    shift = Math.floor(max - EDGE_MARGIN - right)
+  }
+
+  el.style.setProperty('--ft-tooltip-shift-x', `${shift}px`)
+}
 
 defineProps({
   position: {

--- a/src/renderer/components/WatchVideoPlaylist/WatchVideoPlaylist.vue
+++ b/src/renderer/components/WatchVideoPlaylist/WatchVideoPlaylist.vue
@@ -277,8 +277,12 @@ const emit = defineEmits(['close', 'pause-player'])
 
 const { locale, t } = useI18n()
 const router = useRouter()
-const { tabId } = useTabContext()
+const { tabId, isTabPresented } = useTabContext()
 const playlistCacheTabId = tabId ?? 'web'
+
+// Set when centering is attempted while the tab is hidden (e.g. opened in a
+// background tab): the list has no layout yet, so we retry once it is presented.
+const needsInitialCenter = ref(false)
 
 const isLoading = ref(false)
 const shuffleEnabled = ref(false)
@@ -505,6 +509,16 @@ watch(
   },
   { flush: 'post' }
 )
+
+// A playlist opened in a background tab centers while hidden, so it lands at the
+// top. Re-center the current video the first time the tab is presented.
+if (isTabPresented != null) {
+  watch(isTabPresented, (presented) => {
+    if (presented && needsInitialCenter.value) {
+      centerCurrentVideo()
+    }
+  })
+}
 
 watch(() => props.playlistId, () => {
   reversePlaylist.value = storedReversePlaylist.value
@@ -1036,32 +1050,47 @@ function setScrollTop(scrollTop) {
 /**
  * @param {number} index
  */
+/**
+ * @param {number} index
+ * @returns {boolean} whether the scroll could actually be applied. It cannot
+ * when the tab is hidden (`display: none`), because the list then has no layout.
+ */
 function scrollToVideo(index) {
   const container = playlistItemsWrapper.value?.$el ?? playlistItemsWrapper.value
 
-  if (container != null) {
-    const currentVideoItemEl = container.children[index]
-
-    if (currentVideoItemEl != null) {
-      const containerRect = container.getBoundingClientRect()
-      const itemRect = currentVideoItemEl.getBoundingClientRect()
-      const itemOffset = itemRect.top - containerRect.top - container.clientTop + container.scrollTop
-      const centeredOffset = (container.clientHeight - itemRect.height) / 2
-
-      container.scrollTop = Math.max(0, itemOffset - centeredOffset)
-    }
+  if (container == null || container.clientHeight === 0) {
+    return false
   }
+
+  const currentVideoItemEl = container.children[index]
+
+  if (currentVideoItemEl == null) {
+    return false
+  }
+
+  const containerRect = container.getBoundingClientRect()
+  const itemRect = currentVideoItemEl.getBoundingClientRect()
+  const itemOffset = itemRect.top - containerRect.top - container.clientTop + container.scrollTop
+  const centeredOffset = (container.clientHeight - itemRect.height) / 2
+
+  container.scrollTop = Math.max(0, itemOffset - centeredOffset)
+  return true
 }
 
 function scrollToCurrentVideo() {
-  scrollToVideo(currentVideoIndexZeroBased.value)
+  return scrollToVideo(currentVideoIndexZeroBased.value)
 }
 
 function centerCurrentVideo() {
   nextTick(() => {
     requestAnimationFrame(() => {
-      scrollToCurrentVideo()
-      requestAnimationFrame(scrollToCurrentVideo)
+      if (scrollToCurrentVideo()) {
+        needsInitialCenter.value = false
+        requestAnimationFrame(scrollToCurrentVideo)
+      } else {
+        // The tab is still hidden; retry once it becomes presented.
+        needsInitialCenter.value = true
+      }
     })
   })
 }

--- a/src/renderer/components/ft-shaka-video-player/ft-shaka-video-player.js
+++ b/src/renderer/components/ft-shaka-video-player/ft-shaka-video-player.js
@@ -964,6 +964,13 @@ export default defineComponent({
       }
     })
 
+    // Keep the theatre mode button's icon/label in sync when theatre mode is
+    // toggled programmatically (e.g. a side panel opening forces the default
+    // theatre mode), not just when the user clicks the button itself.
+    watch(() => props.useTheatreMode, (value) => {
+      events.dispatchEvent(new CustomEvent('syncTheatreMode', { detail: value }))
+    })
+
     /** @type {import('vue').ComputedRef<boolean>} */
     const displayVideoPlayButton = computed(() => {
       return store.getters.getDisplayVideoPlayButton

--- a/src/renderer/components/ft-shaka-video-player/player-components/TheatreModeButton.js
+++ b/src/renderer/components/ft-shaka-video-player/player-components/TheatreModeButton.js
@@ -58,6 +58,14 @@ export class TheatreModeButton extends shaka.ui.Element {
       this.updateLocalisedStrings_()
     })
 
+    // Fired when theatre mode changes without a button click (e.g. a side panel
+    // opening forces the default theatre mode), keeping the icon/label correct.
+    this.eventManager.listen(events, 'syncTheatreMode', (/** @type {CustomEvent} */event) => {
+      this.theatreModeEnabled_ = event.detail
+
+      this.updateLocalisedStrings_()
+    })
+
     this.eventManager.listen(events, 'localeChanged', () => {
       this.updateLocalisedStrings_()
     })

--- a/src/renderer/views/History/History.vue
+++ b/src/renderer/views/History/History.vue
@@ -85,6 +85,7 @@
       <FtElementList
         v-if="activeData.length > 0"
         :data="activeData"
+        :stable-item-keys="true"
         :show-video-with-last-viewed-playlist="true"
         :show-watched-style-in-history="true"
         :use-channels-hidden-preference="false"

--- a/src/renderer/views/Watch/Watch.js
+++ b/src/renderer/views/Watch/Watch.js
@@ -127,10 +127,12 @@ export default defineComponent({
       startNextVideoWithFullscreenPlaylist: false,
       isLoading: true,
       firstLoad: true,
-      // Whether this tab has ever been presented. A watch tab opened in the
-      // background briefly attempts to autoplay and is force-paused, which would
-      // otherwise persist a ~1 second resume point for a video the user never
-      // actually watched. We only save watch progress once the tab is presented.
+      // Whether this tab has been presented while showing the current video. A
+      // watch tab loading a video in the background briefly attempts to autoplay
+      // and is force-paused, which would otherwise persist a ~1 second resume
+      // point for a video the user never actually watched. We only save watch
+      // progress once the tab is presented, and re-evaluate this per video
+      // because the instance is reused across same-tab navigation.
       hasBeenPresented: false,
       useTheatreMode: false,
       videoPlayerLoaded: false,
@@ -499,8 +501,8 @@ export default defineComponent({
   watch: {
     isTabPresented: {
       immediate: true,
-      handler(presented) {
-        if (presented) {
+      handler() {
+        if (this.isCurrentlyPresented()) {
           this.hasBeenPresented = true
         }
       }
@@ -839,6 +841,10 @@ export default defineComponent({
 
       this.firstLoad = true
       this.videoPlayerLoaded = false
+      // Re-evaluate per video: this instance is reused across same-tab
+      // navigation, so a tab that was presented for the previous video must not
+      // keep that state while it loads the next one in the background.
+      this.hasBeenPresented = this.isCurrentlyPresented()
       this.activeFormat = this.defaultVideoFormat
 
       this.checkIfTimestamp()
@@ -2105,6 +2111,17 @@ export default defineComponent({
         })
       }))
     },
+    /**
+     * Whether this tab is currently the presented one. Without a logical-tab
+     * context (the web build) there is nothing to hide behind, so treat the view
+     * as presented.
+     *
+     * @returns {boolean}
+     */
+    isCurrentlyPresented() {
+      return this.isTabPresented == null || this.isTabPresented === true
+    },
+
     _saveWatchProgress() {
       if (!this.canSaveWatchProgress) { return }
       // A background tab force-pauses its brief autoplay attempt, which would

--- a/src/renderer/views/Watch/Watch.js
+++ b/src/renderer/views/Watch/Watch.js
@@ -127,6 +127,11 @@ export default defineComponent({
       startNextVideoWithFullscreenPlaylist: false,
       isLoading: true,
       firstLoad: true,
+      // Whether this tab has ever been presented. A watch tab opened in the
+      // background briefly attempts to autoplay and is force-paused, which would
+      // otherwise persist a ~1 second resume point for a video the user never
+      // actually watched. We only save watch progress once the tab is presented.
+      hasBeenPresented: false,
       useTheatreMode: false,
       videoPlayerLoaded: false,
       isFamilyFriendly: false,
@@ -492,6 +497,14 @@ export default defineComponent({
     }
   },
   watch: {
+    isTabPresented: {
+      immediate: true,
+      handler(presented) {
+        if (presented) {
+          this.hasBeenPresented = true
+        }
+      }
+    },
     async 'tabRoute.fullPath'() {
       await this.reloadView()
     },
@@ -2094,6 +2107,10 @@ export default defineComponent({
     },
     _saveWatchProgress() {
       if (!this.canSaveWatchProgress) { return }
+      // A background tab force-pauses its brief autoplay attempt, which would
+      // otherwise save a spurious ~1 second resume point. Only persist progress
+      // for tabs the user has actually presented.
+      if (process.env.IS_ELECTRON && !this.hasBeenPresented) { return }
       if (!this.$refs.player?.hasLoaded) { return }
 
       const currentTime = this.getWatchedProgress()


### PR DESCRIPTION
Fixes five unrelated UI bugs. Each is a separate commit.

## 1. History reorder animation was choppy

`FtElementList` derives item keys from the array index unless `stable-item-keys` is set, so reordering the history list destroyed and recreated every element instead of moving it. That defeated the `TransitionGroup` FLIP move animation.

## 2. Background tabs all sat at 0:01

A watch page opened in a background tab briefly attempts to autoplay. `handlePlay` force-pauses it because it is not the presented tab, and that forced pause runs the autosave path — persisting a ~1 second resume point for a video that was never watched.

Watch progress is now only persisted once the tab has actually been presented.

> [!NOTE]
> This also means a tab that is never presented won't record progress even if audio played through PiP.

## 3. Playlist not anchored when opened in a background tab

Non-presented tabs are hidden with `display: none`, so the playlist had no layout when it tried to center the current video and silently stayed at the top. Nothing re-ran once the tab was shown — which is why switching to the tab directly worked, but middle-clicking into the background did not.

The centering now reports whether it could be applied and retries on first presentation.

## 4. Settings tooltip clipped on the left

The settings page clips horizontally (`overflow-x: hidden` on `.settingsSections` / `.switchRow`), so a `bottom-left` tooltip whose icon sits near the start of that container was cut off.

Tooltips are now shifted back inside the nearest horizontally clipping ancestor. The measurement uses `offsetLeft`/`offsetWidth` rather than `getBoundingClientRect()` so it is unaffected by the transform transition and the fade/slide animation is preserved. Also adds the missing `:focus` counterpart for the `bottom-left` variant.

## 5. Theatre mode button showed the wrong icon and tooltip

`TheatreModeButton` only updated itself from the `toggleTheatreMode` event it dispatches on click. When theatre mode was enabled programmatically — a side panel such as chapters opening while recommendations are hidden and the default viewing mode is theatre — its state drifted, showing "Exit Theatre Mode" while not in theatre mode and vice versa.

## Testing

- New regression test in `e2e/tests/offline/ui-bugfixes.spec.mjs` for the history reorder: it fails without the fix (nodes recreated) and passes with it.
- No regressions: the set of offline suite failures with these changes is a strict subset of a matched clean-baseline run on the same machine (21 vs 24 failures, empty diff). Those failures are environmental timeouts, present on `development` too.

### Not covered by automated tests

Bugs 2, 3 and 5 need real playback and network, which the offline harness can't drive, so they were reasoned from the code paths rather than executed.

Bug 4 only reproduces below roughly 740px window width, where the responsive layout shifts enough to make a test flaky, so no test is included — **worth a manual check**.
