### PR TITLE
feat(tabs): make the tab selected after closing configurable

### DIFF
--- a/e2e/tests/offline/tabs.spec.mjs
+++ b/e2e/tests/offline/tabs.spec.mjs
@@ -1,5 +1,24 @@
 import { test, expect, sel, goTo } from '../../helpers/app.mjs'
 
+/**
+ * Leaves three tabs open with the middle one active and returns their ids in
+ * tab bar order.
+ * @param {import('@playwright/test').Page} page
+ * @returns {Promise<string[]>}
+ */
+async function openThreeTabsAndActivateMiddle(page) {
+  await page.locator(sel.newTabButton).click()
+  await page.locator(sel.newTabButton).click()
+  await expect(page.locator(sel.tabs)).toHaveCount(3)
+
+  await page.locator(sel.tabs).nth(1).click()
+  await expect(page.locator(sel.tabs).nth(1)).toHaveClass(/active/)
+
+  return await page.locator(sel.tabs).evaluateAll(
+    (tabs) => tabs.map((tab) => tab.dataset.tabId)
+  )
+}
+
 test.describe('tab bar', () => {
   test('new tab button opens a tab and activates it', async ({ page }) => {
     await page.locator(sel.newTabButton).click()
@@ -367,6 +386,13 @@ test.describe('tab bar', () => {
     await expect(page.locator(sel.activeTab)).toHaveCount(1)
   })
 
+  test('closing the active tab selects the previous tab by default', async ({ page }) => {
+    const tabIds = await openThreeTabsAndActivateMiddle(page)
+
+    await page.locator(sel.activeTab).locator('.closeButton').click()
+    await expect(page.locator(sel.activeTab)).toHaveAttribute('data-tab-id', tabIds[0])
+  })
+
   // Regression: removing a logical tab left its detached video presented in
   // the native PiP window (#268). A canvas stream keeps this independent of
   // external media servers while exercising Chromium's real PiP API.
@@ -466,6 +492,17 @@ test.describe('closed tabs', () => {
       await expect(page).toHaveURL(/#\/history/)
       await expect(page.locator(sel.backButton)).toBeDisabled()
     })
+  })
+})
+
+test.describe('tab close focus set to the next tab', () => {
+  test.use({ seed: { settings: { tabCloseFocus: 'nextTab' } } })
+
+  test('closing the active tab selects the next tab', async ({ page }) => {
+    const tabIds = await openThreeTabsAndActivateMiddle(page)
+
+    await page.locator(sel.activeTab).locator('.closeButton').click()
+    await expect(page.locator(sel.activeTab)).toHaveAttribute('data-tab-id', tabIds[2])
   })
 })
 

--- a/e2e/tests/offline/tabs.spec.mjs
+++ b/e2e/tests/offline/tabs.spec.mjs
@@ -1,18 +1,19 @@
 import { test, expect, sel, goTo } from '../../helpers/app.mjs'
 
 /**
- * Leaves three tabs open with the middle one active and returns their ids in
+ * Leaves three tabs open with the requested one active and returns their ids in
  * tab bar order.
  * @param {import('@playwright/test').Page} page
+ * @param {number} activeIndex
  * @returns {Promise<string[]>}
  */
-async function openThreeTabsAndActivateMiddle(page) {
+async function openThreeTabsAndActivate(page, activeIndex) {
   await page.locator(sel.newTabButton).click()
   await page.locator(sel.newTabButton).click()
   await expect(page.locator(sel.tabs)).toHaveCount(3)
 
-  await page.locator(sel.tabs).nth(1).click()
-  await expect(page.locator(sel.tabs).nth(1)).toHaveClass(/active/)
+  await page.locator(sel.tabs).nth(activeIndex).click()
+  await expect(page.locator(sel.tabs).nth(activeIndex)).toHaveClass(/active/)
 
   return await page.locator(sel.tabs).evaluateAll(
     (tabs) => tabs.map((tab) => tab.dataset.tabId)
@@ -387,10 +388,17 @@ test.describe('tab bar', () => {
   })
 
   test('closing the active tab selects the previous tab by default', async ({ page }) => {
-    const tabIds = await openThreeTabsAndActivateMiddle(page)
+    const tabIds = await openThreeTabsAndActivate(page, 1)
 
     await page.locator(sel.activeTab).locator('.closeButton').click()
     await expect(page.locator(sel.activeTab)).toHaveAttribute('data-tab-id', tabIds[0])
+  })
+
+  test('falls back to the next tab when there is no previous tab', async ({ page }) => {
+    const tabIds = await openThreeTabsAndActivate(page, 0)
+
+    await page.locator(sel.activeTab).locator('.closeButton').click()
+    await expect(page.locator(sel.activeTab)).toHaveAttribute('data-tab-id', tabIds[1])
   })
 
   // Regression: removing a logical tab left its detached video presented in
@@ -499,10 +507,17 @@ test.describe('tab close focus set to the next tab', () => {
   test.use({ seed: { settings: { tabCloseFocus: 'nextTab' } } })
 
   test('closing the active tab selects the next tab', async ({ page }) => {
-    const tabIds = await openThreeTabsAndActivateMiddle(page)
+    const tabIds = await openThreeTabsAndActivate(page, 1)
 
     await page.locator(sel.activeTab).locator('.closeButton').click()
     await expect(page.locator(sel.activeTab)).toHaveAttribute('data-tab-id', tabIds[2])
+  })
+
+  test('falls back to the previous tab when there is no next tab', async ({ page }) => {
+    const tabIds = await openThreeTabsAndActivate(page, 2)
+
+    await page.locator(sel.activeTab).locator('.closeButton').click()
+    await expect(page.locator(sel.activeTab)).toHaveAttribute('data-tab-id', tabIds[1])
   })
 })
 

--- a/src/main/index.js
+++ b/src/main/index.js
@@ -3115,6 +3115,9 @@ function runApp() {
             case 'keyboardShortcuts':
               await setMenu()
               break
+            case 'tabCloseFocus':
+              TabManager.setTabCloseFocus(data.value)
+              break
             case 'hideToTrayOnMinimize':
               if (isTrayOnMinimizeSupported) {
                 trayOnMinimize = data.value

--- a/src/main/index.js
+++ b/src/main/index.js
@@ -1387,7 +1387,7 @@ function runApp() {
     }
 
     // Setup tab IPC handlers
-    setupTabsIPC({
+    await setupTabsIPC({
       confirmCloseWindow: (browserWindow) => {
         const isLastWindow = BrowserWindow.getAllWindows().length === 1
         return isLastWindow ? confirmCloseApp(browserWindow) : true

--- a/src/main/tabs/TabManager.js
+++ b/src/main/tabs/TabManager.js
@@ -2387,13 +2387,15 @@ function cloneRoute(route) {
  * @param {(browserWindow: import('electron').BrowserWindow) => boolean | Promise<boolean>} [options.confirmCloseWindow]
  * @param {(browserWindow: import('electron').BrowserWindow) => void} [options.markWindowCloseConfirmed]
  */
-export function setupTabsIPC(options = {}) {
+export async function setupTabsIPC(options = {}) {
   const {
     confirmCloseWindow = () => true,
     markWindowCloseConfirmed = () => {}
   } = options
 
-  TabManager.refreshStoredTabCloseFocus()
+  // Loaded before the first window exists, so a tab can never be closed while
+  // the preference still holds its default.
+  await TabManager.refreshStoredTabCloseFocus()
 
   const getManager = event => TabManager.getFromWebContents(event.sender)
 

--- a/src/main/tabs/TabManager.js
+++ b/src/main/tabs/TabManager.js
@@ -18,6 +18,11 @@ const tabManagers = new Map()
 
 const DEFAULT_NEW_TAB_POSITION = 'afterCurrent'
 const VALID_NEW_TAB_POSITIONS = new Set(['end', 'afterCurrent'])
+const DEFAULT_TAB_CLOSE_FOCUS = 'previousTab'
+const VALID_TAB_CLOSE_FOCUS = new Set(['previousTab', 'nextTab'])
+// Closing a tab has to pick the replacement synchronously, so the preference is
+// cached here instead of being read from the settings store on every close.
+let tabCloseFocus = DEFAULT_TAB_CLOSE_FOCUS
 const VALID_TAB_COLORS = new Set(['red', 'orange', 'yellow', 'green', 'blue', 'purple'])
 const TAB_PREVIEW_MAX_WIDTH = 360
 const TAB_PREVIEW_MAX_HEIGHT = 220
@@ -79,6 +84,34 @@ export class TabManager {
     return VALID_NEW_TAB_POSITIONS.has(value)
       ? value
       : DEFAULT_NEW_TAB_POSITION
+  }
+
+  /**
+   * @param {unknown} value
+   * @returns {'previousTab' | 'nextTab'}
+   */
+  static normalizeTabCloseFocus(value) {
+    return VALID_TAB_CLOSE_FOCUS.has(value)
+      ? value
+      : DEFAULT_TAB_CLOSE_FOCUS
+  }
+
+  /**
+   * @param {unknown} value
+   */
+  static setTabCloseFocus(value) {
+    tabCloseFocus = TabManager.normalizeTabCloseFocus(value)
+  }
+
+  /**
+   * @returns {Promise<void>}
+   */
+  static async refreshStoredTabCloseFocus() {
+    try {
+      TabManager.setTabCloseFocus((await baseHandlers.settings._findOne('tabCloseFocus'))?.value)
+    } catch (error) {
+      console.error('Failed to load tab close focus preference:', error)
+    }
   }
 
   /**
@@ -1040,10 +1073,13 @@ export class TabManager {
       return null
     }
 
-    const candidates = [
-      ...orderedTabIds.slice(0, tabIndex).reverse(),
-      ...orderedTabIds.slice(tabIndex + 1)
-    ]
+    const previousTabIds = orderedTabIds.slice(0, tabIndex).reverse()
+    const nextTabIds = orderedTabIds.slice(tabIndex + 1)
+    // The preferred side wins, the other one is the fallback when that side has
+    // no selectable tab left.
+    const candidates = tabCloseFocus === 'nextTab'
+      ? [...nextTabIds, ...previousTabIds]
+      : [...previousTabIds, ...nextTabIds]
     // A tab already queued for deferred close/unload must never be selected as
     // the replacement, otherwise a rapid second close/unload would leave the
     // window with no selectable tab.
@@ -2356,6 +2392,8 @@ export function setupTabsIPC(options = {}) {
     confirmCloseWindow = () => true,
     markWindowCloseConfirmed = () => {}
   } = options
+
+  TabManager.refreshStoredTabCloseFocus()
 
   const getManager = event => TabManager.getFromWebContents(event.sender)
 

--- a/src/renderer/components/GeneralSettings/GeneralSettings.vue
+++ b/src/renderer/components/GeneralSettings/GeneralSettings.vue
@@ -108,6 +108,16 @@
       />
       <FtSelect
         v-if="USING_ELECTRON"
+        :placeholder="t('Settings.General Settings.Tab Close Focus.Tab Close Focus')"
+        :value="tabCloseFocus"
+        setting-key="tabCloseFocus"
+        :select-names="tabCloseFocusNames"
+        :select-values="TAB_CLOSE_FOCUS_VALUES"
+        :icon="['fas', 'xmark']"
+        @change="updateTabCloseFocus"
+      />
+      <FtSelect
+        v-if="USING_ELECTRON"
         :placeholder="t('Settings.General Settings.Startup Behavior.Startup Behavior')"
         :value="startupBehavior"
         setting-key="startupBehavior"
@@ -470,6 +480,23 @@ const newTabPosition = computed(() => store.getters.getNewTabPosition)
  */
 function updateNewTabPosition(value) {
   store.dispatch('updateNewTabPosition', value)
+}
+
+const TAB_CLOSE_FOCUS_VALUES = ['previousTab', 'nextTab']
+
+const tabCloseFocusNames = computed(() => [
+  t('Settings.General Settings.Tab Close Focus.Previous tab'),
+  t('Settings.General Settings.Tab Close Focus.Next tab')
+])
+
+/** @type {import('vue').ComputedRef<'previousTab' | 'nextTab'>} */
+const tabCloseFocus = computed(() => store.getters.getTabCloseFocus)
+
+/**
+ * @param {'previousTab' | 'nextTab'} value
+ */
+function updateTabCloseFocus(value) {
+  store.dispatch('updateTabCloseFocus', value)
 }
 
 const STARTUP_BEHAVIOR_VALUES = ['loadAllTabs', 'restoreTabLoadState', 'loadLastActiveTab', 'emptySession']

--- a/src/renderer/store/modules/settings.js
+++ b/src/renderer/store/modules/settings.js
@@ -268,6 +268,7 @@ const state = {
   showDistractionFreeTitles: false,
   landingPage: 'subscriptions',
   newTabPosition: 'afterCurrent',
+  tabCloseFocus: 'previousTab',
   startupBehavior: 'loadLastActiveTab',
   showTabIcons: true,
   useVerticalTabBar: false,

--- a/static/locales/en-US.yaml
+++ b/static/locales/en-US.yaml
@@ -369,6 +369,10 @@ Settings:
       New Tab Position: New Tab Position
       At the end: At the end
       After current tab: After current tab
+    Tab Close Focus:
+      Tab Close Focus: After Closing a Tab
+      Previous tab: Select the previous tab
+      Next tab: Select the next tab
     Startup Behavior:
       Startup Behavior: On Startup
       Load all tabs: Load all tabs


### PR DESCRIPTION
## What

Closing a tab always activated the tab on the left, with the right side only as a fallback. This adds a `tabCloseFocus` setting so that can be flipped.

New select in **Settings → General → After Closing a Tab**:

- **Select the previous tab** (default, current behavior)
- **Select the next tab**

The non-preferred side stays as the fallback, so closing the last tab on the preferred side still activates a remaining tab.

## How

- `_getNeighborTabId` orders its candidates by the preference. This also covers the unload paths that share the helper.
- Closing has to pick the replacement synchronously, so the preference is cached in the main process: primed in `setupTabsIPC` and refreshed from the settings upsert handler, which keeps every window in sync.

## Testing

Two new offline e2e cases in `tabs.spec.mjs`: three tabs with the middle one active, closed — the default selects the left neighbor, and a `tabCloseFocus: 'nextTab'` seeded block selects the right one. Full `tabs.spec.mjs`, `settings.spec.mjs` and `session-restore.spec.mjs` pass; lint is clean.
