### PR TITLE
fix(description): keep the collapse link visible outside the scroll area

### DIFF
--- a/e2e/tests/network/watch.spec.mjs
+++ b/e2e/tests/network/watch.spec.mjs
@@ -387,7 +387,7 @@ test.describe('watch page', () => {
     const dockDescription = page.locator('.fullscreenMetadataTarget .videoDescription')
     await expect(dockDescription).toHaveClass(/alwaysExpanded/)
     await expect(dockDescription).not.toHaveClass(/short/)
-    await expect(dockDescription.locator('.descriptionCloseButton, .descriptionStatus')).toHaveCount(0)
+    await expect(dockDescription.locator('.descriptionStatus')).toHaveCount(0)
     await expect(page.locator('.infoArea .videoTitle')).toHaveCount(0)
     await expect(page.locator('.fullscreenMetadataHeader')).not.toHaveCSS('cursor', 'grab')
     const playerVideo = page.locator('.ftVideoPlayer video.player')
@@ -553,7 +553,7 @@ test.describe('watch page', () => {
     await expect(page.locator('.infoArea .videoTitle')).toBeVisible()
     const inlineDescription = page.locator('.infoArea .videoDescription')
     await expect(inlineDescription).not.toHaveClass(/alwaysExpanded/)
-    await expect(inlineDescription.locator('.descriptionCloseButton, .descriptionStatus')).not.toHaveCount(0)
+    await expect(inlineDescription.locator('.descriptionStatus')).not.toHaveCount(0)
     await setPlayerFullscreen(page, true)
     await expect(page.locator('.fullscreenMetadataOverlay.open')).toBeVisible()
 

--- a/src/renderer/components/WatchVideoDescription/WatchVideoDescription.css
+++ b/src/renderer/components/WatchVideoDescription/WatchVideoDescription.css
@@ -58,5 +58,7 @@
 }
 
 .license {
+  /* bdi is inline by default, block keeps the margins now that it isn't a flex item */
+  display: block;
   margin-block: 1em;
 }

--- a/src/renderer/components/WatchVideoDescription/WatchVideoDescription.css
+++ b/src/renderer/components/WatchVideoDescription/WatchVideoDescription.css
@@ -2,9 +2,16 @@
   position: relative;
   display: flex;
   flex-direction: column;
+}
+
+.descriptionScroll {
   overflow-y: auto;
   scrollbar-gutter: stable;
   max-block-size: 20lh;
+
+  /* stretch into the card's inline padding so the scrollbar stays anchored to the card edge */
+  margin-inline: -16px;
+  padding-inline: 16px;
 }
 
 .description {
@@ -20,15 +27,6 @@
   text-decoration: underline;
   cursor: pointer;
   color: var(--title-color);
-}
-
-.descriptionCloseButton {
-  position: sticky;
-  inset-block-start: 8px;
-  align-self: flex-end;
-  margin-block-end: -36px;
-  margin-inline-end: -16px;
-  z-index: 1;
 }
 
 .videoDescription.short {
@@ -48,10 +46,6 @@
 .videoDescription:not(.short) .descriptionStatus {
   position: relative;
   margin-block-start: 1em;
-}
-
-.videoDescription:not(.short, .alwaysExpanded) .description {
-  padding-inline-end: 48px;
 }
 
 .videoDescription.short .descriptionStatus:dir(rtl) {

--- a/src/renderer/components/WatchVideoDescription/WatchVideoDescription.vue
+++ b/src/renderer/components/WatchVideoDescription/WatchVideoDescription.vue
@@ -7,17 +7,6 @@
       alwaysExpanded
     }"
   >
-    <FtIconButton
-      v-if="showControls && isExpanded && !alwaysExpanded"
-      class="descriptionCloseButton"
-      :title="$t('Description.Collapse Description')"
-      :icon="['fas', 'xmark']"
-      theme="base-no-default"
-      :use-shadow="false"
-      :padding="8"
-      :size="18"
-      @click="collapseDescription"
-    />
     <span
       v-if="showControls && !isExpanded && !alwaysExpanded"
       class="descriptionStatus"
@@ -29,20 +18,22 @@
     >
       {{ $t("Description.Expand Description") }}
     </span>
-    <FtTimestampCatcher
-      ref="descriptionContainer"
-      class="description"
-      :input-html="processedShownDescription"
-      :link-tab-index="linkTabIndex"
-      @timestamp-event="onTimestamp"
-      @click="expandDescriptionWithClick"
-    />
-    <bdi
-      v-if="license && isExpanded"
-      class="license"
-    >
-      {{ license }}
-    </bdi>
+    <div class="descriptionScroll">
+      <FtTimestampCatcher
+        ref="descriptionContainer"
+        class="description"
+        :input-html="processedShownDescription"
+        :link-tab-index="linkTabIndex"
+        @timestamp-event="onTimestamp"
+        @click="expandDescriptionWithClick"
+      />
+      <bdi
+        v-if="license && isExpanded"
+        class="license"
+      >
+        {{ license }}
+      </bdi>
+    </div>
     <span
       v-if="showControls && isExpanded && !alwaysExpanded"
       class="descriptionStatus"
@@ -62,7 +53,6 @@ import autolinker from 'autolinker'
 
 import { onMounted, ref, computed, nextTick, useTemplateRef, watch } from 'vue'
 import FtCard from '../ft-card/ft-card.vue'
-import FtIconButton from '../FtIconButton/FtIconButton.vue'
 import FtTimestampCatcher from '../FtTimestampCatcher.vue'
 
 import { useTabContext } from '../../tabs/TabContext'


### PR DESCRIPTION
## Summary

The expanded video description used a sticky ✕ button in the top-right corner to collapse it, plus a "Show less" link that was only reachable after scrolling to the bottom of the description.

This removes the sticky button entirely and instead keeps the "Show less" link permanently visible, placed outside the scroll area.

## Changes

- `WatchVideoDescription.vue`: drop the `FtIconButton` close button, wrap description + license in a `.descriptionScroll` container so the collapse link sits below it.
- `WatchVideoDescription.css`: move `overflow-y` / `max-block-size` / `scrollbar-gutter` from the card onto `.descriptionScroll`; remove `.descriptionCloseButton` and the `padding-inline-end: 48px` that reserved space for the ✕. Negative inline margins keep the scrollbar anchored to the card edge while the text keeps its 16px inset.
- `e2e/tests/network/watch.spec.mjs`: selectors no longer reference `.descriptionCloseButton`.

## Testing

- `pnpm run test:e2e:network -g "fullscreen"` — passes.
- Verified in the running app that the description scrolls internally while "Show less" stays pinned below it.
- Verified scrollbar geometry in the Electron renderer: the scroll box spans the full card width, so the scrollbar hugs the card edge as before.