### PR TITLE
fix(sponsorblock): don't let the highlight button steal the Enter shortcut

### DIFF
--- a/src/renderer/components/ft-shaka-video-player/ft-shaka-video-player.js
+++ b/src/renderer/components/ft-shaka-video-player/ft-shaka-video-player.js
@@ -54,6 +54,7 @@ import { appendTimestamp, getInvidiousVideoUrl, getYoutubeVideoShareUrl } from '
 import { MANIFEST_TYPE_SABR } from '../../helpers/player/SabrManifestParser'
 import { setupSabrScheme } from '../../helpers/player/SabrSchemePlugin'
 import { getRememberedPlayerVolume, setRememberedPlayerVolume } from '../../helpers/player/volume-storage'
+import { resolveSponsorBlockEnterTarget } from '../../helpers/player/sponsorBlockShortcut'
 import { matchesKeyboardShortcut } from '../../helpers/keyboardShortcuts'
 import { voteOnSponsorBlockSegment } from '../../helpers/sponsorblock'
 import {
@@ -1908,7 +1909,7 @@ export default defineComponent({
         : t('Video.Player.SponsorBlock.SkipToastUnskip')
 
       const activeToast = getActiveSponsorBlockToast()
-      if (getActivePromptSponsorBlockToast() || activeSponsorBlockHighlightSegment.value || activeToast?.uuid !== uuid) {
+      if (getActivePromptSponsorBlockToast() || activeToast?.uuid !== uuid) {
         return actionLabel
       }
 
@@ -2097,26 +2098,23 @@ export default defineComponent({
 
     function toggleActiveSponsorBlockSkipState() {
       const promptToastEntry = getActivePromptSponsorBlockToast()
-      if (promptToastEntry) {
-        return skipPromptSponsorBlockSegment(promptToastEntry.uuid)
-      }
-
-      if (activeSponsorBlockHighlightSegment.value) {
-        return skipToSponsorBlockHighlight()
-      }
-
       const toastEntry = getActiveSponsorBlockToast()
-      if (!toastEntry) {
-        return false
-      }
 
-      if (toastEntry.unskipped) {
-        redoSkipSponsorBlockSegment(toastEntry.uuid)
-      } else {
-        unskipSponsorBlockSegment(toastEntry.uuid)
+      switch (resolveSponsorBlockEnterTarget(!!promptToastEntry, !!toastEntry, !!activeSponsorBlockHighlightSegment.value)) {
+        case 'prompt':
+          return skipPromptSponsorBlockSegment(promptToastEntry.uuid)
+        case 'toast':
+          if (toastEntry.unskipped) {
+            redoSkipSponsorBlockSegment(toastEntry.uuid)
+          } else {
+            unskipSponsorBlockSegment(toastEntry.uuid)
+          }
+          return true
+        case 'highlight':
+          return skipToSponsorBlockHighlight()
+        default:
+          return false
       }
-
-      return true
     }
 
     /**
@@ -2183,10 +2181,25 @@ export default defineComponent({
       events.dispatchEvent(new CustomEvent('sponsorBlockHighlightStateChanged', {
         detail: {
           visible: nextHighlightSegment !== null,
-          labelVisible: sponsorBlockHighlightLabelVisible
+          labelVisible: sponsorBlockHighlightLabelVisible,
+          shortcutAvailable: resolveSponsorBlockEnterTarget(
+            !!getActivePromptSponsorBlockToast(),
+            !!getActiveSponsorBlockToast(),
+            nextHighlightSegment !== null
+          ) === 'highlight'
         }
       }))
     }
+
+    // the highlight button only advertises the Enter shortcut while no toast is claiming it
+    watch(
+      () => skippedSponsorBlockSegments.value.length > 0 || promptSponsorBlockSegments.value.length > 0,
+      () => {
+        if (activeSponsorBlockHighlightSegment.value) {
+          updateSponsorBlockHighlightState()
+        }
+      }
+    )
 
     function pauseSponsorBlockHighlightLabelCountdown() {
       if (sponsorBlockHighlightLabelStartedAt === null) {

--- a/src/renderer/components/ft-shaka-video-player/ft-shaka-video-player.js
+++ b/src/renderer/components/ft-shaka-video-player/ft-shaka-video-player.js
@@ -54,7 +54,7 @@ import { appendTimestamp, getInvidiousVideoUrl, getYoutubeVideoShareUrl } from '
 import { MANIFEST_TYPE_SABR } from '../../helpers/player/SabrManifestParser'
 import { setupSabrScheme } from '../../helpers/player/SabrSchemePlugin'
 import { getRememberedPlayerVolume, setRememberedPlayerVolume } from '../../helpers/player/volume-storage'
-import { resolveSponsorBlockEnterTarget } from '../../helpers/player/sponsorBlockShortcut'
+import { resolveSponsorBlockEnterTarget, resolveSponsorBlockEnterTargets } from '../../helpers/player/sponsorBlockShortcut'
 import { matchesKeyboardShortcut } from '../../helpers/keyboardShortcuts'
 import { voteOnSponsorBlockSegment } from '../../helpers/sponsorblock'
 import {
@@ -2100,21 +2100,37 @@ export default defineComponent({
       const promptToastEntry = getActivePromptSponsorBlockToast()
       const toastEntry = getActiveSponsorBlockToast()
 
-      switch (resolveSponsorBlockEnterTarget(!!promptToastEntry, !!toastEntry, !!activeSponsorBlockHighlightSegment.value)) {
-        case 'prompt':
-          return skipPromptSponsorBlockSegment(promptToastEntry.uuid)
-        case 'toast':
-          if (toastEntry.unskipped) {
-            redoSkipSponsorBlockSegment(toastEntry.uuid)
-          } else {
-            unskipSponsorBlockSegment(toastEntry.uuid)
-          }
+      const targets = resolveSponsorBlockEnterTargets(
+        !!promptToastEntry,
+        !!toastEntry,
+        !!activeSponsorBlockHighlightSegment.value
+      )
+
+      // a target can turn out to be a no-op (e.g. a toast whose segment vanished on a SponsorBlock
+      // refresh), so fall through to the next one instead of swallowing the key press
+      for (const target of targets) {
+        let handled = false
+
+        switch (target) {
+          case 'prompt':
+            handled = skipPromptSponsorBlockSegment(promptToastEntry.uuid)
+            break
+          case 'toast':
+            handled = toastEntry.unskipped
+              ? redoSkipSponsorBlockSegment(toastEntry.uuid)
+              : unskipSponsorBlockSegment(toastEntry.uuid)
+            break
+          case 'highlight':
+            handled = skipToSponsorBlockHighlight()
+            break
+        }
+
+        if (handled) {
           return true
-        case 'highlight':
-          return skipToSponsorBlockHighlight()
-        default:
-          return false
+        }
       }
+
+      return false
     }
 
     /**
@@ -2345,28 +2361,31 @@ export default defineComponent({
      * Unskips a SponsorBlock segment by seeking back to its start time
      * and preventing it from being auto-skipped again until the user leaves the segment.
      * @param {string} uuid - The UUID of the segment to unskip
+     * @returns {boolean} whether anything was actually unskipped
      */
     function unskipSponsorBlockSegment(uuid) {
       const segment = sponsorBlockSegments.find(seg => seg.uuid === uuid)
       if (!segment) {
-        return
+        return false
       }
 
       const toastEntry = skippedSponsorBlockSegments.value.find(skipped => skipped.uuid === uuid)
 
       if (isSponsorBlockPointSegment(segment)) {
-        if (toastEntry?.isHighlight && toastEntry.unskipTime !== null && canSeek()) {
-          const seekRange = player.seekRange()
-          const targetTime = Math.min(
-            Math.max(toastEntry.unskipTime, seekRange.start),
-            seekRange.end
-          )
-          video.value.currentTime = targetTime
-          sponsorBlockCurrentTime.value = targetTime
-          removeSponsorBlockToast(uuid)
-          updateSponsorBlockHighlightState(targetTime)
+        if (!toastEntry?.isHighlight || toastEntry.unskipTime === null || !canSeek()) {
+          return false
         }
-        return
+
+        const seekRange = player.seekRange()
+        const targetTime = Math.min(
+          Math.max(toastEntry.unskipTime, seekRange.start),
+          seekRange.end
+        )
+        video.value.currentTime = targetTime
+        sponsorBlockCurrentTime.value = targetTime
+        removeSponsorBlockToast(uuid)
+        updateSponsorBlockHighlightState(targetTime)
+        return true
       }
 
       sponsorBlockDoNotSkipSegments.add(uuid)
@@ -2390,17 +2409,20 @@ export default defineComponent({
         toastEntry.countdownPaused = false
         toastEntry.timeoutId = 0
       }
+
+      return true
     }
 
     /**
      * Re-skips a SponsorBlock segment that was previously unskipped,
      * seeking to the end of the segment and restoring auto-skip behavior.
      * @param {string} uuid - The UUID of the segment to re-skip
+     * @returns {boolean} whether anything was actually re-skipped
      */
     function redoSkipSponsorBlockSegment(uuid) {
       const segment = sponsorBlockSegments.find(seg => seg.uuid === uuid)
       if (!segment || isSponsorBlockPointSegment(segment)) {
-        return
+        return false
       }
 
       sponsorBlockDoNotSkipSegments.delete(uuid)
@@ -2423,6 +2445,8 @@ export default defineComponent({
           color: toastEntry.color
         })
       }
+
+      return true
     }
 
     // #endregion SponsorBlock

--- a/src/renderer/components/ft-shaka-video-player/player-components/SponsorBlockHighlightButton.js
+++ b/src/renderer/components/ft-shaka-video-player/player-components/SponsorBlockHighlightButton.js
@@ -29,6 +29,9 @@ export class SponsorBlockHighlightButton extends shaka.ui.Element {
     this.button_.appendChild(this.nameSpan_)
     this.parent.appendChild(this.button_)
 
+    /** @private */
+    this.shortcutAvailable_ = true
+
     this.eventManager.listen(this.button_, 'click', () => {
       events.dispatchEvent(new CustomEvent('skipToSponsorBlockHighlight'))
     })
@@ -46,11 +49,11 @@ export class SponsorBlockHighlightButton extends shaka.ui.Element {
 
   /** @private */
   updateLocalisedStrings_() {
-    const label = addKeyboardShortcutToActionTitle(
-      i18n.global.t('Video.Player.SponsorBlock.SkipToHighlight'),
-      i18n.global.t('Keys.enter')
-    )
-    const tooltipLabel = i18n.global.t('Video.Player.SponsorBlock.SkipToHighlight').replace(/\?$/, '')
+    const name = i18n.global.t('Video.Player.SponsorBlock.SkipToHighlight')
+    const label = this.shortcutAvailable_
+      ? addKeyboardShortcutToActionTitle(name, i18n.global.t('Keys.enter'))
+      : name
+    const tooltipLabel = name.replace(/\?$/, '')
 
     this.nameSpan_.textContent = label
     this.button_.ariaLabel = tooltipLabel
@@ -58,9 +61,14 @@ export class SponsorBlockHighlightButton extends shaka.ui.Element {
 
   /**
    * @private
-   * @param {{ visible: boolean, labelVisible: boolean }} state
+   * @param {{ visible: boolean, labelVisible: boolean, shortcutAvailable: boolean }} state
    */
   updateVisibility_(state) {
+    if (state.shortcutAvailable !== this.shortcutAvailable_) {
+      this.shortcutAvailable_ = state.shortcutAvailable
+      this.updateLocalisedStrings_()
+    }
+
     this.button_.classList.toggle('ft-shaka-highlight-button-collapsed', !state.labelVisible)
 
     if (state.visible) {

--- a/src/renderer/helpers/player/sponsorBlockShortcut.js
+++ b/src/renderer/helpers/player/sponsorBlockShortcut.js
@@ -1,22 +1,47 @@
 /**
- * Decides what the Enter shortcut acts on while SponsorBlock UI is on screen.
+ * @typedef {'prompt'|'toast'|'highlight'} SponsorBlockEnterTarget
+ */
+
+/**
+ * Lists what the Enter shortcut can act on while SponsorBlock UI is on screen, most preferred first.
  *
  * Toasts take priority over the highlight button, because the highlight button sticks around
  * for the whole video while a toast is a short-lived notification the user is reacting to.
  *
+ * More than one target is returned so the caller can fall through when the preferred one turns
+ * out to be a no-op, rather than swallowing the key press.
+ *
  * @param {boolean} hasPromptToast
  * @param {boolean} hasSkippedToast
  * @param {boolean} hasHighlight
- * @returns {'prompt'|'toast'|'highlight'|null}
+ * @returns {SponsorBlockEnterTarget[]}
  */
-export function resolveSponsorBlockEnterTarget(hasPromptToast, hasSkippedToast, hasHighlight) {
+export function resolveSponsorBlockEnterTargets(hasPromptToast, hasSkippedToast, hasHighlight) {
+  const targets = []
+
   if (hasPromptToast) {
-    return 'prompt'
+    targets.push('prompt')
   }
 
   if (hasSkippedToast) {
-    return 'toast'
+    targets.push('toast')
   }
 
-  return hasHighlight ? 'highlight' : null
+  if (hasHighlight) {
+    targets.push('highlight')
+  }
+
+  return targets
+}
+
+/**
+ * The target the Enter shortcut advertises itself on, i.e. the one whose label gets the hint.
+ *
+ * @param {boolean} hasPromptToast
+ * @param {boolean} hasSkippedToast
+ * @param {boolean} hasHighlight
+ * @returns {SponsorBlockEnterTarget|null}
+ */
+export function resolveSponsorBlockEnterTarget(hasPromptToast, hasSkippedToast, hasHighlight) {
+  return resolveSponsorBlockEnterTargets(hasPromptToast, hasSkippedToast, hasHighlight)[0] ?? null
 }

--- a/src/renderer/helpers/player/sponsorBlockShortcut.js
+++ b/src/renderer/helpers/player/sponsorBlockShortcut.js
@@ -1,0 +1,22 @@
+/**
+ * Decides what the Enter shortcut acts on while SponsorBlock UI is on screen.
+ *
+ * Toasts take priority over the highlight button, because the highlight button sticks around
+ * for the whole video while a toast is a short-lived notification the user is reacting to.
+ *
+ * @param {boolean} hasPromptToast
+ * @param {boolean} hasSkippedToast
+ * @param {boolean} hasHighlight
+ * @returns {'prompt'|'toast'|'highlight'|null}
+ */
+export function resolveSponsorBlockEnterTarget(hasPromptToast, hasSkippedToast, hasHighlight) {
+  if (hasPromptToast) {
+    return 'prompt'
+  }
+
+  if (hasSkippedToast) {
+    return 'toast'
+  }
+
+  return hasHighlight ? 'highlight' : null
+}

--- a/tests/unit/sponsorblock-enter-shortcut.test.mjs
+++ b/tests/unit/sponsorblock-enter-shortcut.test.mjs
@@ -1,10 +1,14 @@
 import assert from 'node:assert/strict'
 import test from 'node:test'
 
-import { resolveSponsorBlockEnterTarget } from '../../src/renderer/helpers/player/sponsorBlockShortcut.js'
+import {
+  resolveSponsorBlockEnterTarget,
+  resolveSponsorBlockEnterTargets
+} from '../../src/renderer/helpers/player/sponsorBlockShortcut.js'
 
 test('does nothing when no SponsorBlock UI is on screen', () => {
   assert.equal(resolveSponsorBlockEnterTarget(false, false, false), null)
+  assert.deepEqual(resolveSponsorBlockEnterTargets(false, false, false), [])
 })
 
 test('skips to the highlight when it is the only thing on screen', () => {
@@ -21,4 +25,16 @@ test('prefers a skip prompt over the highlight button', () => {
 
 test('prefers a skip prompt over both other targets', () => {
   assert.equal(resolveSponsorBlockEnterTarget(true, true, true), 'prompt')
+})
+
+test('offers the remaining targets as fallbacks in priority order', () => {
+  assert.deepEqual(resolveSponsorBlockEnterTargets(true, true, true), ['prompt', 'toast', 'highlight'])
+  assert.deepEqual(resolveSponsorBlockEnterTargets(false, true, true), ['toast', 'highlight'])
+  assert.deepEqual(resolveSponsorBlockEnterTargets(true, false, true), ['prompt', 'highlight'])
+})
+
+test('only offers targets that are actually on screen', () => {
+  assert.deepEqual(resolveSponsorBlockEnterTargets(false, false, true), ['highlight'])
+  assert.deepEqual(resolveSponsorBlockEnterTargets(false, true, false), ['toast'])
+  assert.deepEqual(resolveSponsorBlockEnterTargets(true, false, false), ['prompt'])
 })

--- a/tests/unit/sponsorblock-enter-shortcut.test.mjs
+++ b/tests/unit/sponsorblock-enter-shortcut.test.mjs
@@ -1,0 +1,24 @@
+import assert from 'node:assert/strict'
+import test from 'node:test'
+
+import { resolveSponsorBlockEnterTarget } from '../../src/renderer/helpers/player/sponsorBlockShortcut.js'
+
+test('does nothing when no SponsorBlock UI is on screen', () => {
+  assert.equal(resolveSponsorBlockEnterTarget(false, false, false), null)
+})
+
+test('skips to the highlight when it is the only thing on screen', () => {
+  assert.equal(resolveSponsorBlockEnterTarget(false, false, true), 'highlight')
+})
+
+test('prefers a skipped-segment toast over the highlight button', () => {
+  assert.equal(resolveSponsorBlockEnterTarget(false, true, true), 'toast')
+})
+
+test('prefers a skip prompt over the highlight button', () => {
+  assert.equal(resolveSponsorBlockEnterTarget(true, false, true), 'prompt')
+})
+
+test('prefers a skip prompt over both other targets', () => {
+  assert.equal(resolveSponsorBlockEnterTarget(true, true, true), 'prompt')
+})


### PR DESCRIPTION
## Problem

While a SponsorBlock highlight (`poi_highlight`) exists in a video, the "Skip to highlight" button is visible for the entire duration. Pressing <kbd>Enter</kbd> always jumped to the highlight, so it swallowed the shortcut from any skipped-segment toast that showed up — you could never unskip/re-skip a segment with the keyboard on a video that has a highlight.

## Fix

Enter now resolves in this order:

1. Skip prompt toast (unchanged, still highest)
2. Skipped-segment toast (**new** — previously below the highlight)
3. Highlight button (fallback)

The highlight button is the fallback because it sticks around for the whole video, while a toast is a short-lived notification the user is actively reacting to.

Follow-on label fixes so the UI matches the new behaviour:

- The skipped-segment toast no longer drops its `(Enter)` hint just because a highlight exists.
- The highlight button only shows `(Enter)` when the shortcut actually targets it, and re-renders its label when a toast appears or disappears.

## Implementation

The priority order is extracted into a pure helper, `resolveSponsorBlockEnterTarget`, so it is testable outside the 268 KB player file and so the shortcut handler and both labels can't drift apart.

## Testing

- New unit tests in `tests/unit/sponsorblock-enter-shortcut.test.mjs` covering each priority combination.
- `pnpm run test:unit` — 51 passing.
- `pnpm run lint` — clean.
