### PR TITLE
feat(subscriptions): stream feed refreshes and make them cancellable

### DIFF
--- a/e2e/tests/offline/subscriptions-context-menu.spec.mjs
+++ b/e2e/tests/offline/subscriptions-context-menu.spec.mjs
@@ -28,6 +28,8 @@ test.use({
 })
 
 test('subscription tabs expose feed-specific reload actions', async ({ page }) => {
+  // The reload actions start real refreshes, which fail immediately offline
+  await page.route(/^https?:\/\//, (route) => route.abort())
   await goTo(page, 'subscriptions')
 
   await page.evaluate(() => {
@@ -46,6 +48,9 @@ test('subscription tabs expose feed-specific reload actions', async ({ page }) =
   ]
 
   for (const [index, { feedTab, label }] of feedTabs.entries()) {
+    // While a refresh is running the entry cancels it instead of reloading
+    await expect(page.locator('.tabLoadingIndicator')).toHaveCount(0, { timeout: 30_000 })
+
     await page.locator(`[data-subscription-feed-tab="${feedTab}"]`).click({ button: 'right' })
     const menu = page.getByRole('menu', { name: 'Context menu' })
     await expect(menu).toBeVisible()

--- a/e2e/tests/offline/subscriptions-refresh.spec.mjs
+++ b/e2e/tests/offline/subscriptions-refresh.spec.mjs
@@ -1,0 +1,190 @@
+import { test, expect, goTo } from '../../helpers/app.mjs'
+
+const HOUR = 3_600_000
+const now = Date.now()
+
+// The RSS refresh path is the one that can be driven without Innertube.
+const commonSettings = {
+  fetchSubscriptionsAutomatically: false,
+  useRssFeeds: true,
+  backendPreference: 'local',
+  hideSubscriptionsShorts: true,
+  hideSubscriptionsLive: true,
+  thumbnailSize: 180
+}
+
+function channelId(index) {
+  return `UC${String(index).padStart(22, '0')}`
+}
+
+function channelIndexFromUrl(url) {
+  return Number(new URL(url).searchParams.get('playlist_id').match(/0*(\d+)$/)[1])
+}
+
+function rssFeed(index) {
+  return `<?xml version="1.0" encoding="UTF-8"?>
+<feed xmlns:yt="http://www.youtube.com/xml/schemas/2015" xmlns:media="http://search.yahoo.com/mrss/" xmlns="http://www.w3.org/2005/Atom">
+  <author><name>Channel ${index}</name></author>
+  <entry>
+    <yt:videoId>fresh${index}</yt:videoId>
+    <title>Fresh video ${index}</title>
+    <published>${new Date(now - HOUR).toISOString()}</published>
+    <media:group>
+      <media:statistics views="1000"/>
+    </media:group>
+  </entry>
+</feed>`
+}
+
+function cachedChannel(index) {
+  return {
+    _id: channelId(index),
+    videos: [{
+      videoId: `cached${index}`,
+      title: `Cached video ${index}`,
+      author: `Channel ${index}`,
+      authorId: channelId(index),
+      published: now - (index + 2) * HOUR,
+      viewCount: 1000,
+      lengthSeconds: 120,
+      liveNow: false,
+      isUpcoming: false,
+      type: 'video'
+    }],
+    videosTimestamp: new Date(now - 2 * HOUR).toISOString()
+  }
+}
+
+function profileWith(channelCount) {
+  return {
+    _id: 'allChannels',
+    name: 'All Channels',
+    bgColor: '#000000',
+    textColor: '#FFFFFF',
+    subscriptions: Array.from({ length: channelCount }, (_, index) => ({
+      id: channelId(index),
+      name: `Channel ${index}`,
+      thumbnail: ''
+    }))
+  }
+}
+
+/**
+ * @param {(index: number) => number} delayFor per channel response delay
+ */
+async function routeFeeds(page, delayFor) {
+  await page.route(/^https?:\/\//, (route) => route.abort())
+
+  await page.route('**/feeds/videos.xml**', async (route, request) => {
+    const index = channelIndexFromUrl(request.url())
+    const delay = delayFor(index)
+
+    if (delay > 0) {
+      await new Promise(resolve => setTimeout(resolve, delay))
+    }
+
+    // The window may already be gone when a delayed response arrives.
+    await route.fulfill({
+      status: 200,
+      contentType: 'application/xml',
+      body: rssFeed(index)
+    }).catch(() => {})
+  })
+}
+
+test.describe('incremental subscription feed refresh', () => {
+  test.use({
+    seed: {
+      settings: commonSettings,
+      profiles: [profileWith(2)],
+      subscriptionCache: [cachedChannel(0), cachedChannel(1)]
+    }
+  })
+
+  test('shows fetched channels before the whole refresh is done', async ({ page }) => {
+    await routeFeeds(page, (index) => index === 1 ? 8_000 : 0)
+    await goTo(page, 'subscriptions')
+    await expect(page.getByText('Cached video 0', { exact: true })).toBeVisible()
+
+    await page.getByRole('button', { name: /Refresh Videos/ }).click()
+
+    // Channel 0 is done well before the pending channel 1, which keeps its
+    // cached entry in the meantime
+    await expect(page.getByText('Fresh video 0', { exact: true })).toBeVisible({ timeout: 3_000 })
+    await expect(page.getByText('Fresh video 1', { exact: true })).toHaveCount(0)
+    await expect(page.getByText('Cached video 1', { exact: true })).toBeVisible()
+    await expect(page.locator('.tabsProgressBar')).toBeVisible()
+
+    await expect(page.getByText('Fresh video 1', { exact: true })).toBeVisible({ timeout: 30_000 })
+  })
+})
+
+test.describe('cancelling a subscription feed refresh', () => {
+  // More channels than are fetched at once, so that the cancellation can skip
+  // the ones that haven't started yet
+  const channelCount = 12
+
+  test.use({
+    seed: {
+      settings: commonSettings,
+      profiles: [profileWith(channelCount)],
+      subscriptionCache: Array.from({ length: channelCount }, (_, index) => cachedChannel(index))
+    }
+  })
+
+  test('stops a running refresh and keeps what was already fetched', async ({ page }) => {
+    await routeFeeds(page, () => 4_000)
+    await goTo(page, 'subscriptions')
+    await expect(page.getByText('Cached video 0', { exact: true })).toBeVisible()
+
+    await page.getByRole('button', { name: /Refresh Videos/ }).click()
+
+    const cancelRefresh = page.getByRole('button', { name: 'Cancel refresh' })
+    await expect(cancelRefresh).toBeVisible()
+    await cancelRefresh.click()
+
+    // The channels that were in flight still finish, the remaining ones are
+    // skipped instead of being fetched
+    await expect(page.locator('.tabsProgressBar')).toHaveCount(0, { timeout: 20_000 })
+    await expect(cancelRefresh).toHaveCount(0)
+    await expect(page.getByText('Fresh video 0', { exact: true })).toBeVisible()
+    await expect(page.getByText(`Fresh video ${channelCount - 1}`, { exact: true })).toHaveCount(0)
+    await expect(page.getByText(`Cached video ${channelCount - 1}`, { exact: true })).toBeVisible()
+  })
+
+  test('offers the cancellation in the feed tab context menu', async ({ page }) => {
+    await routeFeeds(page, () => 4_000)
+    await goTo(page, 'subscriptions')
+    await expect(page.getByText('Cached video 0', { exact: true })).toBeVisible()
+
+    await page.locator('[data-subscription-feed-tab="videos"]').click({ button: 'right' })
+    const menu = page.getByRole('menu', { name: 'Context menu' })
+    await menu.getByRole('menuitem', { name: 'Reload Videos' }).click()
+
+    await expect(page.getByRole('button', { name: 'Cancel refresh' })).toBeVisible()
+
+    await page.locator('[data-subscription-feed-tab="videos"]').click({ button: 'right' })
+    await expect(menu.getByRole('menuitem', { name: 'Reload Videos' })).toHaveCount(0)
+    await menu.getByRole('menuitem', { name: 'Cancel Refresh' }).click()
+
+    await expect(page.locator('.tabsProgressBar')).toHaveCount(0, { timeout: 20_000 })
+    await expect(page.getByText('Fresh video 0', { exact: true })).toBeVisible()
+    await expect(page.getByText(`Cached video ${channelCount - 1}`, { exact: true })).toBeVisible()
+  })
+
+  test('turns the open context menu entry back into a reload when the refresh ends', async ({ page }) => {
+    await routeFeeds(page, () => 1_000)
+    await goTo(page, 'subscriptions')
+    await expect(page.getByText('Cached video 0', { exact: true })).toBeVisible()
+
+    await page.getByRole('button', { name: /Refresh Videos/ }).click()
+
+    const menu = page.getByRole('menu', { name: 'Context menu' })
+    await page.locator('[data-subscription-feed-tab="videos"]').click({ button: 'right' })
+    await expect(menu.getByRole('menuitem', { name: 'Cancel Refresh' })).toBeVisible()
+
+    // The menu stays open while the refresh finishes
+    await expect(menu.getByRole('menuitem', { name: 'Reload Videos' })).toBeVisible({ timeout: 30_000 })
+    await expect(menu.getByRole('menuitem', { name: 'Cancel Refresh' })).toHaveCount(0)
+  })
+})

--- a/src/constants.js
+++ b/src/constants.js
@@ -20,6 +20,7 @@ const IpcChannels = {
   CHANGE_VIEW: 'change-view',
   SHOW_TOAST: 'show-toast',
   SUBSCRIPTION_AUTO_REFRESH_ACQUIRE: 'subscription-auto-refresh-acquire',
+  SUBSCRIPTION_AUTO_REFRESH_CANCEL: 'subscription-auto-refresh-cancel',
   SUBSCRIPTION_AUTO_REFRESH_GET_STATE: 'subscription-auto-refresh-get-state',
   SUBSCRIPTION_AUTO_REFRESH_RELEASE: 'subscription-auto-refresh-release',
   SUBSCRIPTION_AUTO_REFRESH_SET_PROGRESS: 'subscription-auto-refresh-set-progress',

--- a/src/main/index.js
+++ b/src/main/index.js
@@ -390,10 +390,19 @@ function runApp() {
 
       return [
         {
+          // While a refresh runs, the same entry cancels it
           label: `Reload ${subscriptionFeedLabels[subscriptionFeedTab] ?? 'Feed'}`,
+          refreshingLabel: 'Cancel Refresh',
           visible: subscriptionFeedTab != null,
           click: () => {
-            if (!manager || !subscriptionFeedTab || !manager.presentedTabId) return
+            if (!manager || !subscriptionFeedTab) return
+
+            if (isSubscriptionAutoRefreshInProgress()) {
+              requestSubscriptionAutoRefreshCancellation()
+              return
+            }
+
+            if (!manager.presentedTabId) return
 
             manager.bridge.send(IpcChannels.SUBSCRIPTION_FEED_REQUEST_RELOAD, {
               tabId: manager.presentedTabId,
@@ -849,6 +858,9 @@ function runApp() {
       return {
         type: item.type ?? 'normal',
         label: String(item.label ?? ''),
+        // Shown instead of the label while a subscription refresh is running,
+        // so that an open menu doesn't go stale when the refresh ends
+        refreshingLabel: item.refreshingLabel != null ? String(item.refreshingLabel) : undefined,
         enabled: item.enabled !== false,
         checked: item.checked === true,
         actionId: hasAction ? actionId : undefined,
@@ -2375,7 +2387,7 @@ function runApp() {
     }
 
     return {
-      inProgress: subscriptionAutoRefreshOwner !== null && !subscriptionAutoRefreshOwner.webContents.isDestroyed(),
+      inProgress: isSubscriptionAutoRefreshInProgress(),
       percentage: subscriptionAutoRefreshProgress,
       tab: subscriptionAutoRefreshOwner?.feedTab ?? null
     }
@@ -2394,6 +2406,26 @@ function runApp() {
     broadcastSubscriptionAutoRefreshState()
   })
 
+  ipcMain.on(IpcChannels.SUBSCRIPTION_AUTO_REFRESH_CANCEL, (event) => {
+    if (!isOpenTubeXUrl(event.senderFrame.url)) {
+      return
+    }
+
+    requestSubscriptionAutoRefreshCancellation()
+  })
+
+  function isSubscriptionAutoRefreshInProgress() {
+    return subscriptionAutoRefreshOwner !== null && !subscriptionAutoRefreshOwner.webContents.isDestroyed()
+  }
+
+  // Any window may ask for the cancellation, only the one running the refresh
+  // can carry it out
+  function requestSubscriptionAutoRefreshCancellation() {
+    if (isSubscriptionAutoRefreshInProgress()) {
+      subscriptionAutoRefreshOwner.webContents.send(IpcChannels.SUBSCRIPTION_AUTO_REFRESH_CANCEL)
+    }
+  }
+
   ipcMain.handle(IpcChannels.SUBSCRIPTION_AUTO_REFRESH_RELEASE, (event, tabId) => {
     if (
       subscriptionAutoRefreshOwner?.webContents.id === event.sender.id &&
@@ -2407,7 +2439,7 @@ function runApp() {
 
   function broadcastSubscriptionAutoRefreshState() {
     const state = {
-      inProgress: subscriptionAutoRefreshOwner !== null && !subscriptionAutoRefreshOwner.webContents.isDestroyed(),
+      inProgress: isSubscriptionAutoRefreshInProgress(),
       percentage: subscriptionAutoRefreshProgress,
       tab: subscriptionAutoRefreshOwner?.feedTab ?? null
     }

--- a/src/preload/interface.js
+++ b/src/preload/interface.js
@@ -446,6 +446,28 @@ export default {
     },
 
     /**
+     * Ask the renderer that owns the subscription refresh to cancel it.
+     */
+    cancel: () => {
+      ipcRenderer.send(IpcChannels.SUBSCRIPTION_AUTO_REFRESH_CANCEL)
+    },
+
+    /**
+     * Listen for cancellation requests from other windows.
+     * @param {() => void} handler
+     * @returns {() => void}
+     */
+    onCancelRequested: (handler) => {
+      const listener = () => {
+        handler()
+      }
+      ipcRenderer.on(IpcChannels.SUBSCRIPTION_AUTO_REFRESH_CANCEL, listener)
+      return () => {
+        ipcRenderer.removeListener(IpcChannels.SUBSCRIPTION_AUTO_REFRESH_CANCEL, listener)
+      }
+    },
+
+    /**
      * Check whether a renderer currently owns the subscription refresh.
      * @returns {Promise<{inProgress: boolean, percentage: number, tab: string | null}>}
      */

--- a/src/renderer/App.vue
+++ b/src/renderer/App.vue
@@ -289,10 +289,12 @@ import { matchesKeyboardShortcut } from './helpers/keyboardShortcuts'
 import { findUpdateRelease } from './helpers/releaseUpdates'
 import { openExternalLink, openInternalPath, showToast } from './helpers/utils'
 import {
+  cancelSubscriptionRefresh,
   refreshSubscriptionLiveFromRemote,
   refreshSubscriptionPostsFromRemote,
   refreshSubscriptionShortsFromRemote,
   refreshSubscriptionVideosFromRemote,
+  SUBSCRIPTION_REFRESH_CANCEL_STORAGE_KEY,
   SUBSCRIPTION_REFRESH_COMPLETED_EVENT,
   SUBSCRIPTION_REFRESH_FINISHED_EVENT,
   SUBSCRIPTION_REFRESH_LOCK_NAME,
@@ -538,6 +540,7 @@ const SUBSCRIPTION_AUTO_REFRESH_PROGRESS_STORAGE_KEY = 'opentubex.subscriptionAu
 let historyCleanupTimer = null
 const subscriptionAutoRefreshTabs = ['videos', 'shorts', 'live', 'posts']
 let removeSubscriptionAutoRefreshActiveChangedListener = null
+let removeSubscriptionAutoRefreshCancelListener = null
 let removeSubscriptionAutoRefreshStateChangedListener = null
 let removeTabsStateListener = null
 let removeReloadRequestListener = null
@@ -783,6 +786,9 @@ onMounted(async () => {
     removeSubscriptionAutoRefreshStateChangedListener = window.ftElectron.subscriptionAutoRefresh.onStateChanged(
       applySubscriptionAutoRefreshState
     )
+    removeSubscriptionAutoRefreshCancelListener = window.ftElectron.subscriptionAutoRefresh.onCancelRequested(
+      cancelSubscriptionRefresh
+    )
     synchronizeSubscriptionRefreshInProgress()
     removeSubscriptionAutoRefreshActiveChangedListener = window.ftElectron.tabs.onActiveChanged((isActive) => {
       if (isActive) {
@@ -818,6 +824,7 @@ onBeforeUnmount(() => {
   window.removeEventListener(SUBSCRIPTION_REFRESH_STARTED_EVENT, handleSubscriptionRefreshStarted)
   document.removeEventListener('visibilitychange', handleSubscriptionAutoRefreshVisibilityChange)
   removeSubscriptionAutoRefreshActiveChangedListener?.()
+  removeSubscriptionAutoRefreshCancelListener?.()
   removeSubscriptionAutoRefreshStateChangedListener?.()
   removeTabsStateListener?.()
   removeReloadRequestListener?.()
@@ -1421,6 +1428,13 @@ function handleSubscriptionRefreshFinished() {
  * @param {StorageEvent} event
  */
 function handleSubscriptionAutoRefreshStorage(event) {
+  if (!process.env.IS_ELECTRON && event.key === SUBSCRIPTION_REFRESH_CANCEL_STORAGE_KEY) {
+    if (event.newValue !== null) {
+      cancelSubscriptionRefresh()
+    }
+    return
+  }
+
   if (!process.env.IS_ELECTRON && event.key === SUBSCRIPTION_AUTO_REFRESH_PROGRESS_STORAGE_KEY) {
     const state = getSubscriptionRefreshProgressState(event.newValue)
     applySubscriptionAutoRefreshState({

--- a/src/renderer/components/FtContextMenu/FtContextMenu.vue
+++ b/src/renderer/components/FtContextMenu/FtContextMenu.vue
@@ -16,7 +16,7 @@
         @pointerdown.stop
       >
         <template
-          v-for="(item, index) in items"
+          v-for="(item, index) in displayedItems"
           :key="item.actionId ?? `separator-${index}`"
         >
           <div
@@ -126,6 +126,8 @@ import { FontAwesomeIcon } from '@fortawesome/vue-fontawesome'
 import { computed, nextTick, onBeforeUnmount, onMounted, ref, useTemplateRef } from 'vue'
 import { useI18n } from 'vue-i18n'
 
+import store from '../../store/index'
+
 const { t, te } = useI18n()
 const menuRef = useTemplateRef('menuRef')
 const fullscreenTarget = ref(null)
@@ -142,11 +144,26 @@ const menuStyle = computed(() => ({
   top: `${position.value.y}px`
 }))
 
+/**
+ * Entries with a refreshing label follow the refresh state while the menu is
+ * open, as the refresh can end (or be started elsewhere) in the meantime.
+ */
+const displayedItems = computed(() => {
+  if (!store.getters.getSubscriptionFeedRefreshInProgress) {
+    return items.value
+  }
+
+  return items.value.map(item => item.refreshingLabel
+    ? { ...item, label: item.refreshingLabel }
+    : item)
+})
+
 function updateFullscreenTarget() {
   fullscreenTarget.value = document.fullscreenElement
 }
 
 const itemIcons = {
+  'Cancel Refresh': ['fas', 'xmark'],
   'Close Tab': ['fas', 'xmark'],
   'Close Tabs': ['fas', 'rectangle-xmark'],
   'Copy Image': ['fas', 'images'],

--- a/src/renderer/components/FtRefreshWidget/FtRefreshWidget.vue
+++ b/src/renderer/components/FtRefreshWidget/FtRefreshWidget.vue
@@ -59,11 +59,12 @@
           {{ t('Feed.Next Auto Refresh', { date: nextAutoRefreshTimestamp }) }}
         </p>
       </div>
+      <!-- While a refresh runs, the same button cancels it -->
       <FtIconButton
-        :disabled="disableRefresh"
-        :icon="['fas', 'sync']"
+        :disabled="!refreshInProgress && disableRefresh"
+        :icon="refreshInProgress ? ['fas', 'xmark'] : ['fas', 'sync']"
         class="refreshButton"
-        :title="refreshFeedButtonTitle"
+        :title="refreshInProgress ? t('Feed.Cancel Refresh') : refreshFeedButtonTitle"
         :size="12"
         theme="primary"
         @click="click"
@@ -108,6 +109,10 @@ const props = defineProps({
     default: 0
   },
   embedded: {
+    type: Boolean,
+    default: false
+  },
+  refreshInProgress: {
     type: Boolean,
     default: false
   },
@@ -188,10 +193,14 @@ const refreshFeedButtonTitle = computed(() => {
   )
 })
 
-const emit = defineEmits(['click'])
+const emit = defineEmits(['cancel', 'click'])
 
 function click() {
-  emit('click')
+  if (props.refreshInProgress) {
+    emit('cancel')
+  } else {
+    emit('click')
+  }
 }
 </script>
 

--- a/src/renderer/components/SubscriptionsLive.vue
+++ b/src/renderer/components/SubscriptionsLive.vue
@@ -18,6 +18,7 @@ import SubscriptionsTabUi from './SubscriptionsTabUi/SubscriptionsTabUi.vue'
 
 import store from '../store/index'
 
+import { useSubscriptionChannelUpdates } from '../composables/useSubscriptionChannelUpdates'
 import { getCachedRelativeTimeFormat, getCachedShortDateTimeFormat, getRelativeTimeFromDate } from '../helpers/utils'
 import {
   refreshSubscriptionLiveFromRemote,
@@ -222,17 +223,31 @@ function loadVideosFromCacheSometimes() {
 
 function loadVideosFromCacheForAllActiveProfileChannels() {
   const videoList_ = cacheEntriesForAllActiveProfileChannels.value.flatMap((cacheEntry) => {
-    return cacheEntry.videos
+    return cacheEntry.videos ?? []
   })
 
   videoList.value = updateVideoListAfterProcessing(videoList_)
   isLoading.value = false
 }
 
+// Show the channels that have been fetched so far, instead of waiting for the
+// whole refresh to finish
+useSubscriptionChannelUpdates('live', () => {
+  if (subscriptionCacheReady.value) {
+    loadVideosFromCacheForAllActiveProfileChannels()
+  }
+})
+
 async function loadVideosForSubscriptionsFromRemote() {
   isLoading.value = true
   attemptedFetch.value = true
   errorChannels.value = []
+
+  // Whatever is cached is shown right away, the refresh then replaces it
+  // channel by channel
+  if (subscriptionCacheReady.value && cacheEntriesForAllActiveProfileChannels.value.length > 0) {
+    loadVideosFromCacheForAllActiveProfileChannels()
+  }
 
   try {
     const refreshedVideos = await refreshSubscriptionLiveFromRemote({

--- a/src/renderer/components/SubscriptionsPosts.vue
+++ b/src/renderer/components/SubscriptionsPosts.vue
@@ -20,6 +20,7 @@ import SubscriptionsTabUi from './SubscriptionsTabUi/SubscriptionsTabUi.vue'
 
 import store from '../store/index'
 
+import { useSubscriptionChannelUpdates } from '../composables/useSubscriptionChannelUpdates'
 import { getCachedRelativeTimeFormat, getCachedShortDateTimeFormat, getRelativeTimeFromDate } from '../helpers/utils'
 import { refreshSubscriptionPostsFromRemote } from '../helpers/subscriptions'
 
@@ -221,7 +222,7 @@ function loadPostsFromCacheSometimes() {
 
 function loadPostsFromCacheForAllActiveProfileChannels() {
   const postList_ = cacheEntriesForAllActiveProfileChannels.value.flatMap((cacheEntry) => {
-    return cacheEntry.posts
+    return cacheEntry.posts ?? []
   })
 
   postList_.sort((a, b) => {
@@ -232,10 +233,25 @@ function loadPostsFromCacheForAllActiveProfileChannels() {
   isLoading.value = false
 }
 
+// Show the channels that have been fetched so far, instead of waiting for the
+// whole refresh to finish
+useSubscriptionChannelUpdates('posts', () => {
+  if (subscriptionCacheReady.value) {
+    loadPostsFromCacheForAllActiveProfileChannels()
+  }
+})
+
 async function loadPostsForSubscriptionsFromRemote() {
   isLoading.value = true
   attemptedFetch.value = true
   errorChannels.value = []
+
+  // Whatever is cached is shown right away, the refresh then replaces it
+  // channel by channel
+  if (subscriptionCacheReady.value && cacheEntriesForAllActiveProfileChannels.value.length > 0) {
+    loadPostsFromCacheForAllActiveProfileChannels()
+  }
+
   try {
     const refreshedPosts = await refreshSubscriptionPostsFromRemote({
       t,

--- a/src/renderer/components/SubscriptionsShorts.vue
+++ b/src/renderer/components/SubscriptionsShorts.vue
@@ -18,6 +18,7 @@ import SubscriptionsTabUi from './SubscriptionsTabUi/SubscriptionsTabUi.vue'
 
 import store from '../store/index'
 
+import { useSubscriptionChannelUpdates } from '../composables/useSubscriptionChannelUpdates'
 import {
   refreshSubscriptionShortsFromRemote,
   updateVideoListAfterProcessing
@@ -221,17 +222,31 @@ function loadVideosFromCacheSometimes() {
 
 function loadVideosFromCacheForAllActiveProfileChannels() {
   const videoList_ = cacheEntriesForAllActiveProfileChannels.value.flatMap((cacheEntry) => {
-    return cacheEntry.videos
+    return cacheEntry.videos ?? []
   })
 
   videoList.value = updateVideoListAfterProcessing(videoList_)
   isLoading.value = false
 }
 
+// Show the channels that have been fetched so far, instead of waiting for the
+// whole refresh to finish
+useSubscriptionChannelUpdates('shorts', () => {
+  if (subscriptionCacheReady.value) {
+    loadVideosFromCacheForAllActiveProfileChannels()
+  }
+})
+
 async function loadVideosForSubscriptionsFromRemote() {
   isLoading.value = true
   attemptedFetch.value = true
   errorChannels.value = []
+
+  // Whatever is cached is shown right away, the refresh then replaces it
+  // channel by channel
+  if (subscriptionCacheReady.value && cacheEntriesForAllActiveProfileChannels.value.length > 0) {
+    loadVideosFromCacheForAllActiveProfileChannels()
+  }
 
   try {
     const refreshedVideos = await refreshSubscriptionShortsFromRemote({

--- a/src/renderer/components/SubscriptionsVideos.vue
+++ b/src/renderer/components/SubscriptionsVideos.vue
@@ -18,6 +18,7 @@ import SubscriptionsTabUi from './SubscriptionsTabUi/SubscriptionsTabUi.vue'
 
 import store from '../store/index'
 
+import { useSubscriptionChannelUpdates } from '../composables/useSubscriptionChannelUpdates'
 import { getCachedRelativeTimeFormat, getCachedShortDateTimeFormat, getRelativeTimeFromDate } from '../helpers/utils'
 import {
   refreshSubscriptionVideosFromRemote,
@@ -221,17 +222,31 @@ function loadVideosFromCacheSometimes() {
 
 function loadVideosFromCacheForAllActiveProfileChannels() {
   const videoList_ = cacheEntriesForAllActiveProfileChannels.value.flatMap((cacheEntry) => {
-    return cacheEntry.videos
+    return cacheEntry.videos ?? []
   })
 
   videoList.value = updateVideoListAfterProcessing(videoList_)
   isLoading.value = false
 }
 
+// Show the channels that have been fetched so far, instead of waiting for the
+// whole refresh to finish
+useSubscriptionChannelUpdates('videos', () => {
+  if (subscriptionCacheReady.value) {
+    loadVideosFromCacheForAllActiveProfileChannels()
+  }
+})
+
 async function loadVideosForSubscriptionsFromRemote() {
   isLoading.value = true
   attemptedFetch.value = true
   errorChannels.value = []
+
+  // Whatever is cached is shown right away, the refresh then replaces it
+  // channel by channel
+  if (subscriptionCacheReady.value && cacheEntriesForAllActiveProfileChannels.value.length > 0) {
+    loadVideosFromCacheForAllActiveProfileChannels()
+  }
 
   try {
     const refreshedVideos = await refreshSubscriptionVideosFromRemote({

--- a/src/renderer/composables/useRefreshAllSubscriptionFeeds.js
+++ b/src/renderer/composables/useRefreshAllSubscriptionFeeds.js
@@ -3,6 +3,7 @@ import { useI18n } from 'vue-i18n'
 
 import store from '../store/index'
 import {
+  getSubscriptionRefreshCancelCount,
   refreshSubscriptionLiveFromRemote,
   refreshSubscriptionPostsFromRemote,
   refreshSubscriptionShortsFromRemote,
@@ -59,8 +60,16 @@ export function useRefreshAllSubscriptionFeeds() {
     attemptedFetch.value = true
     errorChannels.value = []
 
+    const cancelCountAtStart = getSubscriptionRefreshCancelCount()
+
     try {
       for (const feed of enabledFeeds.value) {
+        // Also covers a cancellation between two feeds, when no feed refresh
+        // was running to receive it
+        if (getSubscriptionRefreshCancelCount() !== cancelCountAtStart) {
+          break
+        }
+
         await feed.refresh({ t, errorChannels: errorChannels.value })
       }
     } finally {

--- a/src/renderer/composables/useSubscriptionChannelUpdates.js
+++ b/src/renderer/composables/useSubscriptionChannelUpdates.js
@@ -1,0 +1,50 @@
+import { onBeforeUnmount, onMounted } from 'vue'
+
+import { SUBSCRIPTION_REFRESH_CHANNEL_EVENT } from '../helpers/subscriptions'
+
+// Rebuilding and sorting the whole feed for every channel would be wasteful
+// with hundreds of subscriptions, so updates are coalesced.
+const FEED_UPDATE_INTERVAL_MS = 500
+
+/**
+ * Runs the callback while a refresh of the given feed is in progress, whenever
+ * newly fetched channels have been added to its cache.
+ * @param {'videos' | 'shorts' | 'live' | 'posts'} tab
+ * @param {() => void} onChannelsRefreshed
+ */
+export function useSubscriptionChannelUpdates(tab, onChannelsRefreshed) {
+  let timeout = null
+  let lastRun = 0
+
+  function run() {
+    timeout = null
+    lastRun = Date.now()
+    onChannelsRefreshed()
+  }
+
+  /**
+   * @param {CustomEvent<{tab: string}>} event
+   */
+  function handleChannelRefreshed(event) {
+    if (event.detail.tab !== tab || timeout !== null) {
+      return
+    }
+
+    const remaining = FEED_UPDATE_INTERVAL_MS - (Date.now() - lastRun)
+
+    if (remaining <= 0) {
+      run()
+    } else {
+      timeout = setTimeout(run, remaining)
+    }
+  }
+
+  onMounted(() => {
+    window.addEventListener(SUBSCRIPTION_REFRESH_CHANNEL_EVENT, handleChannelRefreshed)
+  })
+
+  onBeforeUnmount(() => {
+    window.removeEventListener(SUBSCRIPTION_REFRESH_CHANNEL_EVENT, handleChannelRefreshed)
+    clearTimeout(timeout)
+  })
+}

--- a/src/renderer/helpers/subscription-entries.js
+++ b/src/renderer/helpers/subscription-entries.js
@@ -1,0 +1,94 @@
+import { isHistoryEntryWatched } from '../../history.js'
+
+// Scraped relative publication dates are approximate, so allow a small amount
+// of rounding around the previous fetch without admitting genuinely old items.
+const NEW_CONTENT_PUBLICATION_TOLERANCE_MS = 60 * 60 * 1000
+
+/**
+ * Scraped publication dates are derived from relative texts ("3 days ago") and
+ * are therefore recalculated against the current time on every fetch. Entries
+ * of already fetched channels would drift forwards past entries of channels
+ * that haven't been refetched yet, which visibly reorders the feed while it
+ * refreshes. Premieres and live streams are excluded, as their publication
+ * dates legitimately change.
+ * @param {object} entry
+ */
+function hasVolatilePublicationDate(entry) {
+  return entry.liveNow === true ||
+    entry.isUpcoming === true ||
+    entry.premiereDate != null ||
+    entry.premiereTimestamp != null
+}
+
+/**
+ * @param {object} entry
+ * @param {object} previousEntry
+ * @param {'published' | 'publishedTime'} key
+ */
+function keepPreviousPublicationDate(entry, previousEntry, key) {
+  return Number.isFinite(Number(previousEntry[key])) &&
+    Number.isFinite(Number(entry[key])) &&
+    !hasVolatilePublicationDate(entry) &&
+    !hasVolatilePublicationDate(previousEntry) &&
+    // RSS feeds report exact dates, so they may replace a scraped estimate
+    !(entry.isRSS === true && previousEntry.isRSS !== true)
+}
+
+/**
+ * Keeps previously-new entries marked and marks unwatched leading entries
+ * which were plausibly published since the previous successful channel fetch.
+ * Missing caches, old reordered entries, and responses without overlap are not
+ * presented as newly published.
+ *
+ * Publication dates of entries which were already cached are kept, so that
+ * refetching a channel doesn't reorder the feed.
+ * @param {object[]} entries
+ * @param {object[] | null | undefined} previousEntries
+ * @param {'videoId' | 'postId'} idKey
+ * @param {Date | number | string | null | undefined} previousFetchTimestamp
+ * @param {Record<string, object>} [historyById]
+ */
+export function reconcileFetchedSubscriptionEntries(
+  entries,
+  previousEntries,
+  idKey,
+  previousFetchTimestamp,
+  historyById = {}
+) {
+  const previousEntriesById = Array.isArray(previousEntries)
+    ? new Map(previousEntries
+        .filter(entry => entry[idKey] != null)
+        .map(entry => [entry[idKey], entry]))
+    : null
+  const firstPreviouslyFetchedIndex = previousEntriesById?.size > 0
+    ? entries.findIndex(entry => previousEntriesById.has(entry[idKey]))
+    : -1
+  const previousFetchTime = previousFetchTimestamp == null
+    ? Number.NaN
+    : new Date(previousFetchTimestamp).getTime()
+  const publicationDateKey = idKey === 'postId' ? 'publishedTime' : 'published'
+
+  return entries.map((entry, index) => {
+    const publishedTime = Number(entry.published ?? entry.publishedTime)
+    const isPlausiblyRecent = Number.isFinite(previousFetchTime) &&
+      Number.isFinite(publishedTime) &&
+      publishedTime >= previousFetchTime - NEW_CONTENT_PUBLICATION_TOLERANCE_MS
+    const isWatched = idKey === 'videoId' && isHistoryEntryWatched(historyById?.[entry[idKey]])
+    const previousEntry = previousEntriesById?.get(entry[idKey])
+    const wasPreviouslyNew = previousEntry?.isNewInSubscriptionFeed === true
+    const isNewlyFetched = firstPreviouslyFetchedIndex > 0 &&
+      index < firstPreviouslyFetchedIndex &&
+      isPlausiblyRecent
+
+    const reconciledEntry = {
+      ...entry,
+      isNewInSubscriptionFeed: !isWatched && (wasPreviouslyNew || isNewlyFetched)
+    }
+
+    if (previousEntry != null && keepPreviousPublicationDate(entry, previousEntry, publicationDateKey)) {
+      reconciledEntry[publicationDateKey] = previousEntry[publicationDateKey]
+    }
+
+    return reconciledEntry
+  })
+}

--- a/src/renderer/helpers/subscriptions.js
+++ b/src/renderer/helpers/subscriptions.js
@@ -12,77 +12,79 @@ import {
   showToast,
   showToastOnAllTabs
 } from './utils'
-import { isHistoryEntryWatched } from './history'
 import { getValidSubscriptionChannels } from './subscription-channels'
+import { reconcileFetchedSubscriptionEntries } from './subscription-entries'
 import { mapConcurrently } from './concurrent-map'
 
 const AUTO_REFRESH_TOAST_DURATION = 5000
+export const SUBSCRIPTION_REFRESH_CHANNEL_EVENT = 'opentubex-subscription-refresh-channel'
 export const SUBSCRIPTION_REFRESH_COMPLETED_EVENT = 'opentubex-subscription-refresh-completed'
 export const SUBSCRIPTION_REFRESH_FINISHED_EVENT = 'opentubex-subscription-refresh-finished'
 export const SUBSCRIPTION_REFRESH_LOCK_NAME = 'opentubex-subscription-refresh'
 export const SUBSCRIPTION_REFRESH_PROGRESS_EVENT = 'opentubex-subscription-refresh-progress'
 export const SUBSCRIPTION_REFRESH_STARTED_EVENT = 'opentubex-subscription-refresh-started'
+export const SUBSCRIPTION_REFRESH_CANCEL_STORAGE_KEY = 'opentubex.subscriptionAutoRefresh.cancel'
 
 // The tab id the Electron refresh lock was acquired with. Progress reports to the
 // main process must use this id, as the active tab may change during the refresh.
 let electronRefreshOwnerTabId = null
+
+/**
+ * Cancellation state of the refresh this renderer is running, if any.
+ * @type {{ cancelled: boolean } | null}
+ */
+let activeRefresh = null
+
+// Incremented on every cancellation request, so that a cancellation is not
+// missed when it arrives between two feed refreshes.
+let cancelCount = 0
 
 const IS_UPCOMING_REGEX = /"isUpcoming"\s*:\s*true/
 const SCHEDULED_START_REGEX = /"scheduledStartTime"\s*:\s*"(\d+)"/
 const SUBSCRIPTION_FETCH_BATCH_SIZE = 80
 const SUBSCRIPTION_FETCH_BATCH_DELAY_MS = 2000
 const SUBSCRIPTION_FETCH_CONCURRENCY = 8
-// Scraped relative publication dates are approximate, so allow a small amount
-// of rounding around the previous fetch without admitting genuinely old items.
-const NEW_CONTENT_PUBLICATION_TOLERANCE_MS = 60 * 60 * 1000
 
 /**
- * Keeps previously-new entries marked and marks unwatched leading entries
- * which were plausibly published since the previous successful channel fetch.
- * Missing caches, old reordered entries, and responses without overlap are not
- * presented as newly published.
- * @param {object[]} entries
- * @param {object[] | null | undefined} previousEntries
- * @param {'videoId' | 'postId'} idKey
- * @param {Date | number | string | null | undefined} previousFetchTimestamp
- * @param {Record<string, object>} [historyById]
+ * Stops the refresh running in this renderer after the channels that are
+ * currently being fetched. Already fetched channels stay cached.
  */
-export function markNewSubscriptionEntries(
-  entries,
-  previousEntries,
-  idKey,
-  previousFetchTimestamp,
-  historyById = {}
-) {
-  const previousEntriesById = Array.isArray(previousEntries)
-    ? new Map(previousEntries
-        .filter(entry => entry[idKey] != null)
-        .map(entry => [entry[idKey], entry]))
-    : null
-  const firstPreviouslyFetchedIndex = previousEntriesById?.size > 0
-    ? entries.findIndex(entry => previousEntriesById.has(entry[idKey]))
-    : -1
-  const previousFetchTime = previousFetchTimestamp == null
-    ? Number.NaN
-    : new Date(previousFetchTimestamp).getTime()
+export function cancelSubscriptionRefresh() {
+  cancelCount++
 
-  return entries.map((entry, index) => {
-    const publishedTime = Number(entry.published ?? entry.publishedTime)
-    const isPlausiblyRecent = Number.isFinite(previousFetchTime) &&
-      Number.isFinite(publishedTime) &&
-      publishedTime >= previousFetchTime - NEW_CONTENT_PUBLICATION_TOLERANCE_MS
-    const isWatched = idKey === 'videoId' && isHistoryEntryWatched(historyById?.[entry[idKey]])
-    const wasPreviouslyNew = previousEntriesById?.get(entry[idKey])
-      ?.isNewInSubscriptionFeed === true
-    const isNewlyFetched = firstPreviouslyFetchedIndex > 0 &&
-      index < firstPreviouslyFetchedIndex &&
-      isPlausiblyRecent
+  if (activeRefresh !== null) {
+    activeRefresh.cancelled = true
+  }
+}
 
-    return {
-      ...entry,
-      isNewInSubscriptionFeed: !isWatched && (wasPreviouslyNew || isNewlyFetched)
-    }
-  })
+/**
+ * Cancels the refresh wherever it is running, as another window may own it.
+ */
+export function requestSubscriptionRefreshCancellation() {
+  cancelSubscriptionRefresh()
+
+  if (process.env.IS_ELECTRON) {
+    window.ftElectron.subscriptionAutoRefresh.cancel()
+    return
+  }
+
+  try {
+    localStorage.setItem(SUBSCRIPTION_REFRESH_CANCEL_STORAGE_KEY, `${Date.now()}-${cancelCount}`)
+  } catch {
+    // Only the refresh of this browser tab can be cancelled then.
+  }
+}
+
+/**
+ * Lets callers that refresh several feeds in a row notice a cancellation that
+ * happened between two feeds, when no refresh was running.
+ */
+export function getSubscriptionRefreshCancelCount() {
+  return cancelCount
+}
+
+function isRefreshCancelled() {
+  return activeRefresh?.cancelled === true
 }
 
 /**
@@ -101,10 +103,12 @@ async function withSubscriptionRefreshLock(tab, profileId, refresh) {
     window.dispatchEvent(new CustomEvent(SUBSCRIPTION_REFRESH_STARTED_EVENT, {
       detail: { tab, profileId }
     }))
+    activeRefresh = { cancelled: false }
 
     try {
       return await refresh()
     } finally {
+      activeRefresh = null
       window.dispatchEvent(new CustomEvent(SUBSCRIPTION_REFRESH_FINISHED_EVENT, {
         detail: { tab, profileId }
       }))
@@ -158,11 +162,28 @@ function setSubscriptionRefreshProgress(percentage) {
   }))
 }
 
+/**
+ * Lets the feed views render the channels that have been fetched so far,
+ * instead of waiting for the whole refresh to finish.
+ * @param {'videos' | 'shorts' | 'live' | 'posts'} tab
+ */
+function notifySubscriptionChannelRefreshed(tab) {
+  window.dispatchEvent(new CustomEvent(SUBSCRIPTION_REFRESH_CHANNEL_EVENT, {
+    detail: { tab }
+  }))
+}
+
 async function fetchSubscriptionsConcurrently(channels, fetchChannel) {
   const results = await mapConcurrently(
     channels,
     SUBSCRIPTION_FETCH_CONCURRENCY,
     async channel => {
+      // Channels that haven't started yet are skipped, the ones in flight
+      // still finish and are cached.
+      if (isRefreshCancelled()) {
+        return []
+      }
+
       if (process.env.IS_ELECTRON) {
         await window.ftElectron.waitForIpBlockRecoveryScript()
       }
@@ -183,6 +204,10 @@ async function fetchSubscriptionsInBatches(channels, fetchChannel) {
   const results = []
 
   for (let index = 0; index < channels.length; index += SUBSCRIPTION_FETCH_BATCH_SIZE) {
+    if (isRefreshCancelled()) {
+      break
+    }
+
     if (index > 0) {
       await new Promise(resolve => setTimeout(resolve, SUBSCRIPTION_FETCH_BATCH_DELAY_MS))
     }
@@ -488,7 +513,7 @@ async function refreshSubscriptionVideosFromRemoteUnlocked({
 
       if (videos != null) {
         const previousCache = store.getters.getVideoCache[channel.id]
-        videos = markNewSubscriptionEntries(
+        videos = reconcileFetchedSubscriptionEntries(
           videos,
           previousCache?.videos,
           'videoId',
@@ -499,6 +524,7 @@ async function refreshSubscriptionVideosFromRemoteUnlocked({
           channelId: channel.id,
           videos
         })
+        notifySubscriptionChannelRefreshed('videos')
       }
 
       if (name || thumbnailUrl) {
@@ -517,6 +543,11 @@ async function refreshSubscriptionVideosFromRemoteUnlocked({
       : await fetchSubscriptionsInBatches(activeSubscriptionList, fetchChannel)
 
     store.dispatch('batchUpdateSubscriptionDetails', subscriptionUpdates)
+
+    if (isRefreshCancelled()) {
+      return null
+    }
+
     completeSubscriptionRefresh('videos', activeProfile._id)
 
     return updateVideoListAfterProcessing(videoListFromRemote)
@@ -577,7 +608,7 @@ async function refreshSubscriptionShortsFromRemoteUnlocked({
 
       if (videos != null) {
         const previousCache = store.getters.getShortsCache[channel.id]
-        videos = markNewSubscriptionEntries(
+        videos = reconcileFetchedSubscriptionEntries(
           videos,
           previousCache?.videos,
           'videoId',
@@ -588,6 +619,7 @@ async function refreshSubscriptionShortsFromRemoteUnlocked({
           channelId: channel.id,
           videos
         })
+        notifySubscriptionChannelRefreshed('shorts')
       }
 
       if (name) {
@@ -601,6 +633,11 @@ async function refreshSubscriptionShortsFromRemoteUnlocked({
     })
 
     store.dispatch('batchUpdateSubscriptionDetails', subscriptionUpdates)
+
+    if (isRefreshCancelled()) {
+      return null
+    }
+
     completeSubscriptionRefresh('shorts', activeProfile._id)
 
     return updateVideoListAfterProcessing(videoListFromRemote)
@@ -670,7 +707,7 @@ async function refreshSubscriptionLiveFromRemoteUnlocked({
 
       if (videos != null) {
         const previousCache = store.getters.getLiveCache[channel.id]
-        videos = markNewSubscriptionEntries(
+        videos = reconcileFetchedSubscriptionEntries(
           videos,
           previousCache?.videos,
           'videoId',
@@ -681,6 +718,7 @@ async function refreshSubscriptionLiveFromRemoteUnlocked({
           channelId: channel.id,
           videos
         })
+        notifySubscriptionChannelRefreshed('live')
       }
 
       if (name || thumbnailUrl) {
@@ -699,6 +737,11 @@ async function refreshSubscriptionLiveFromRemoteUnlocked({
       : await fetchSubscriptionsInBatches(activeSubscriptionList, fetchChannel)
 
     store.dispatch('batchUpdateSubscriptionDetails', subscriptionUpdates)
+
+    if (isRefreshCancelled()) {
+      return null
+    }
+
     completeSubscriptionRefresh('live', activeProfile._id)
 
     return updateVideoListAfterProcessing(videoListFromRemote)
@@ -759,7 +802,7 @@ async function refreshSubscriptionPostsFromRemoteUnlocked({
       setSubscriptionRefreshProgress((channelCount / activeSubscriptionList.length) * 100)
 
       const previousCache = store.getters.getPostsCache[channel.id]
-      posts = markNewSubscriptionEntries(
+      posts = reconcileFetchedSubscriptionEntries(
         posts,
         previousCache?.posts,
         'postId',
@@ -769,6 +812,7 @@ async function refreshSubscriptionPostsFromRemoteUnlocked({
         channelId: channel.id,
         posts
       })
+      notifySubscriptionChannelRefreshed('posts')
 
       const channelPost = posts.find(post => post.authorId === channel.id)
       if (channelPost) {
@@ -800,6 +844,11 @@ async function refreshSubscriptionPostsFromRemoteUnlocked({
     })
 
     store.dispatch('batchUpdateSubscriptionDetails', subscriptionUpdates)
+
+    if (isRefreshCancelled()) {
+      return null
+    }
+
     completeSubscriptionRefresh('posts', activeProfile._id)
 
     return filteredPosts

--- a/src/renderer/views/Subscriptions/Subscriptions.vue
+++ b/src/renderer/views/Subscriptions/Subscriptions.vue
@@ -24,7 +24,9 @@
             :next-auto-refresh-at="currentAutoRefresh.timestamp"
             :auto-refresh-interval="currentAutoRefresh.interval"
             :title="currentTabPanel.refreshTitle"
+            :refresh-in-progress="subscriptionFeedRefreshInProgress"
             @click="refreshCurrentTab"
+            @cancel="cancelRefresh"
           />
         </div>
         <div class="tabsRow">
@@ -254,6 +256,7 @@ import { useTabContext } from '../../tabs/TabContext'
 import { getTabNavigationService } from '../../tabs/TabNavigationService'
 import { useRefreshAllSubscriptionFeeds } from '../../composables/useRefreshAllSubscriptionFeeds'
 import {
+  requestSubscriptionRefreshCancellation,
   refreshSubscriptionLiveFromRemote,
   refreshSubscriptionPostsFromRemote,
   refreshSubscriptionShortsFromRemote,
@@ -654,6 +657,11 @@ function focusTab(event, focusedTab) {
 
 function refreshCurrentTab() {
   currentTabPanel.value?.refresh()
+}
+
+function cancelRefresh() {
+  // The refresh may be owned by another window, so it is cancelled everywhere
+  requestSubscriptionRefreshCancellation()
 }
 
 /**

--- a/static/locales/en-US.yaml
+++ b/static/locales/en-US.yaml
@@ -208,6 +208,7 @@ Trending:
   Trending Tabs: Trending Tabs
 Most Popular: Most Popular
 Feed:
+  Cancel Refresh: Cancel refresh
   Feed Last Updated: '{feedName} feed last updated: {date}'
   Next Auto Refresh: 'Next auto refresh: {date}'
   Refresh Feed: Refresh {subscriptionName}
@@ -1470,6 +1471,7 @@ Context Menu:
   Save Image As…: Save Image As…
   Copy Image: Copy Image
   Copy Image Address: Copy Image Address
+  Cancel Refresh: Cancel Refresh
   Reload Videos: Reload Videos
   Reload Shorts: Reload Shorts
   Reload Live: Reload Live

--- a/tests/unit/subscription-entries.test.mjs
+++ b/tests/unit/subscription-entries.test.mjs
@@ -1,0 +1,127 @@
+import assert from 'node:assert/strict'
+import test from 'node:test'
+
+import { reconcileFetchedSubscriptionEntries } from '../../src/renderer/helpers/subscription-entries.js'
+
+const HOUR = 3_600_000
+const now = Date.now()
+
+function video(videoId, published, extra = {}) {
+  return { videoId, published, type: 'video', ...extra }
+}
+
+test('keeps the cached publication date of entries that were already fetched', () => {
+  const previousEntries = [
+    video('a', now - 25 * HOUR),
+    video('b', now - 49 * HOUR)
+  ]
+  // Scraped dates are recalculated against the current time on every fetch,
+  // so the same videos come back with dates that moved forwards
+  const entries = [
+    video('a', now - 24 * HOUR),
+    video('b', now - 48 * HOUR)
+  ]
+
+  const reconciled = reconcileFetchedSubscriptionEntries(entries, previousEntries, 'videoId', now - HOUR)
+
+  assert.deepEqual(reconciled.map(entry => entry.published), [now - 25 * HOUR, now - 49 * HOUR])
+})
+
+test('does not reorder a feed when only some channels are refetched', () => {
+  // Both channels were fetched an hour ago, channel b's video is the newer one
+  const cachedChannelA = [video('a1', now - 25 * HOUR)]
+  const cachedChannelB = [video('b1', now - 24.5 * HOUR)]
+
+  // Refetching channel a returns the same video, with its relative date
+  // ("1 day ago") resolved against the current time
+  const refetchedChannelA = reconcileFetchedSubscriptionEntries(
+    [video('a1', now - 24 * HOUR)],
+    cachedChannelA,
+    'videoId',
+    now - HOUR
+  )
+
+  const feed = [...refetchedChannelA, ...cachedChannelB]
+    .sort((a, b) => b.published - a.published)
+    .map(entry => entry.videoId)
+
+  assert.deepEqual(feed, ['b1', 'a1'])
+})
+
+test('takes the new publication date for premieres and live streams', () => {
+  const previousEntries = [
+    video('live', now - 5 * HOUR, { liveNow: true }),
+    video('premiere', now + 5 * HOUR, { isUpcoming: true, premiereDate: new Date(now + 5 * HOUR) })
+  ]
+  const entries = [
+    video('live', now, { liveNow: true }),
+    video('premiere', now + HOUR, { isUpcoming: true, premiereDate: new Date(now + HOUR) })
+  ]
+
+  const reconciled = reconcileFetchedSubscriptionEntries(entries, previousEntries, 'videoId', now - HOUR)
+
+  assert.deepEqual(reconciled.map(entry => entry.published), [now, now + HOUR])
+})
+
+test('prefers the exact date of an RSS entry over a cached estimate', () => {
+  const reconciled = reconcileFetchedSubscriptionEntries(
+    [video('a', now - 24 * HOUR, { isRSS: true })],
+    [video('a', now - 25 * HOUR)],
+    'videoId',
+    now - HOUR
+  )
+
+  assert.equal(reconciled[0].published, now - 24 * HOUR)
+})
+
+test('keeps the cached publication time of posts', () => {
+  const reconciled = reconcileFetchedSubscriptionEntries(
+    [{ postId: 'p1', publishedTime: now - 24 * HOUR }],
+    [{ postId: 'p1', publishedTime: now - 25 * HOUR }],
+    'postId',
+    now - HOUR
+  )
+
+  assert.equal(reconciled[0].publishedTime, now - 25 * HOUR)
+})
+
+test('marks entries published since the previous fetch as new', () => {
+  const previousEntries = [video('a', now - 25 * HOUR)]
+  const entries = [
+    video('new', now - 30 * 60_000),
+    video('a', now - 25 * HOUR)
+  ]
+
+  const reconciled = reconcileFetchedSubscriptionEntries(entries, previousEntries, 'videoId', now - HOUR)
+
+  assert.deepEqual(reconciled.map(entry => entry.isNewInSubscriptionFeed), [true, false])
+})
+
+test('keeps entries that were already marked as new', () => {
+  const previousEntries = [video('a', now - 2 * HOUR, { isNewInSubscriptionFeed: true })]
+  const entries = [video('a', now - 2 * HOUR)]
+
+  const reconciled = reconcileFetchedSubscriptionEntries(entries, previousEntries, 'videoId', now - HOUR)
+
+  assert.equal(reconciled[0].isNewInSubscriptionFeed, true)
+})
+
+test('does not mark watched videos as new', () => {
+  const entries = [
+    video('watched', now - 30 * 60_000),
+    video('a', now - 25 * HOUR)
+  ]
+  const historyById = {
+    watched: { videoId: 'watched', watchProgress: 120, lengthSeconds: 120, isWatched: true }
+  }
+
+  const reconciled = reconcileFetchedSubscriptionEntries(
+    entries,
+    [video('a', now - 25 * HOUR)],
+    'videoId',
+    now - HOUR,
+    historyById
+  )
+
+  assert.equal(reconciled[0].isNewInSubscriptionFeed, false)
+})


### PR DESCRIPTION
## Feed order no longer shuffles while refreshing

Scraped publication dates come from relative texts ("3 days ago") and are resolved against `Date.now()` on **every** fetch. A refetched channel's videos therefore drift forwards by however long ago the last fetch was and leapfrog the videos of channels that haven't been refetched yet. The New feed renders straight off the cache, so this was visible as the list reshuffling mid-refresh.

`markNewSubscriptionEntries` moved into a store-free `helpers/subscription-entries.js` (so it is unit-testable) as `reconcileFetchedSubscriptionEntries`, which now also keeps the cached publication date of entries that were already fetched. Premieres and live streams are excluded — their dates legitimately change — and an exact RSS date may still replace a scraped estimate.

## Feeds show content as it arrives

Every channel written to the cache now dispatches a refresh-channel event. `useSubscriptionChannelUpdates` coalesces those (500 ms) and the videos/shorts/live/posts tabs rebuild from the cache as channels land, so the skeleton is replaced by the first fetched channel instead of the completed refresh. Starting a refresh also paints the cached feed right away, so the channels that aren't done yet stay visible instead of showing a loader.

## Refreshes can be cancelled

While a refresh runs, the refresh button and the feed tab context menu entry turn into a cancel action:

- channels that haven't started are skipped, the ones in flight still finish and stay cached
- the feed is not marked as successfully refreshed, so the "last updated" time is untouched
- the request reaches the window that owns the refresh over IPC (localStorage broadcast on web)
- the context menu entry follows the refresh state while the menu is open, so it can't go stale

The refresh lock is global, so the entry reads "Cancel Refresh" on every feed tab while a refresh runs — right-clicking Shorts during a videos refresh previously offered "Reload Shorts", which the renderer silently ignored.

The up-to-8 requests already in flight are not aborted; that would mean threading an `AbortSignal` through youtubei.js and the Invidious/RSS paths.

## Tests

- `tests/unit/subscription-entries.test.mjs` covers the publication date reconciliation, including a feed that stays ordered when only some channels are refetched
- `e2e/tests/offline/subscriptions-refresh.spec.mjs` drives real refreshes through mocked RSS responses: partial rendering, cancelling from the button and from the context menu, and the open menu entry reverting when the refresh ends
- `subscriptions-context-menu.spec.mjs` clicked all five reload entries in a row, which only worked because reloads 2-5 were silently dropped while the first refresh was still running; it now blocks network and waits for each refresh to finish

`pnpm run lint`, `pnpm run test:unit` (54) and `pnpm run test:e2e:offline` (128) pass.