### PR TITLE
feat(player): modernize the buffering spinner

### DIFF
--- a/src/renderer/components/ft-shaka-video-player/ft-shaka-video-player.css
+++ b/src/renderer/components/ft-shaka-video-player/ft-shaka-video-player.css
@@ -1811,6 +1811,108 @@
   transition: inset-inline-end 250ms ease;
 }
 
+/*
+  Buffering indicator, a Material style arc that grows and shrinks as it spins.
+  shaka's own markup is reused: its fixed half arc <path> is dropped and the
+  <circle> underneath it is animated instead, which gets us round stroke caps
+  for free. The fade in is delayed so that the short buffers you get while
+  seeking don't flash a spinner.
+*/
+:deep(.shaka-spinner-container) {
+  animation: ft-buffer-spinner-appear 150ms ease-out 400ms both;
+}
+
+:deep(.shaka-spinner) {
+  position: relative;
+
+  /* Maps shaka's 38 unit viewBox to exactly 1.5px per unit, so the track below lines up. */
+  inline-size: 57px;
+  block-size: 57px;
+
+  /* Keeps the arc legible over bright or busy frames. */
+  filter: drop-shadow(0 1px 2px rgb(0 0 0 / 65%)) drop-shadow(0 0 6px rgb(0 0 0 / 45%));
+}
+
+/* Track, so the circle still reads where the arc has shrunk away. */
+:deep(.shaka-spinner)::before {
+  content: '';
+  position: absolute;
+  box-sizing: border-box;
+  inset: 1.5px;
+  border: 6px solid rgb(255 255 255 / 20%);
+  border-radius: 50%;
+}
+
+:deep(.shaka-spinner) > svg {
+  inline-size: 100%;
+  block-size: 100%;
+  transform-origin: center;
+  animation: ft-buffer-spinner-spin 1.8s linear infinite;
+}
+
+/* shaka's fixed half arc, replaced by the animated circle below */
+:deep(.shaka-spinner) svg path {
+  display: none;
+}
+
+:deep(.shaka-spinner) svg circle {
+  stroke: #fff;
+  stroke-opacity: 1;
+  stroke-width: 4;
+  stroke-linecap: round;
+  animation: ft-buffer-spinner-dash 1.4s ease-in-out infinite;
+}
+
+@keyframes ft-buffer-spinner-appear {
+  from {
+    opacity: 0;
+    transform: scale(0.85);
+  }
+
+  to {
+    opacity: 1;
+    transform: scale(1);
+  }
+}
+
+@keyframes ft-buffer-spinner-spin {
+  to {
+    transform: rotate(360deg);
+  }
+}
+
+/* The circle's circumference is 2 * pi * r, with shaka's r of 16 units. */
+@keyframes ft-buffer-spinner-dash {
+  0% {
+    stroke-dasharray: 1 100.5;
+    stroke-dashoffset: 0;
+  }
+
+  50% {
+    stroke-dasharray: 75 100.5;
+    stroke-dashoffset: -20;
+  }
+
+  100% {
+    stroke-dasharray: 1 100.5;
+    stroke-dashoffset: -99.5;
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  :deep(.shaka-spinner-container) {
+    animation: none;
+  }
+
+  :deep(.shaka-spinner) > svg {
+    animation-duration: 3s;
+  }
+
+  :deep(.shaka-spinner) svg circle {
+    animation-duration: 2.8s;
+  }
+}
+
 :deep(.shaka-text-container),
 :deep(.shaka-speech-to-text-container) {
   /* Keep shaka's caption raise animation alongside the panel push. */


### PR DESCRIPTION
Replaces shaka's static SMIL ring with a Material style arc that grows and shrinks as it spins.

## Approach

shaka's own markup is reused rather than hidden and redrawn:

- its fixed half arc `<path>` is dropped, which also stops the SMIL rotation competing with the CSS one
- the `<circle>` beneath it, which shaka only used as a faint track, is animated into the arc via `stroke-dasharray` / `stroke-dashoffset`

That gets round stroke caps for free, and avoids `conic-gradient` + `mask` entirely.

## Details

- Arc is white, so there is no `--primary-color` dependency and no theming edge cases.
- A two layer drop shadow keeps the arc legible over bright or busy frames. It sits on the parent `.shaka-spinner` deliberately: `filter` is applied before `mask`/`clip`, so on the ring itself it would shadow the full disc instead of the arc.
- The `57px` box maps shaka's 38 unit viewBox to exactly `1.5px` per unit, so the CSS track ring lines up with the SVG stroke without fractional drift.
- The fade in is delayed 400ms so the short buffers you get while seeking no longer flash a spinner.
- `prefers-reduced-motion` drops the entry animation and slows both the spin and the dash.

## Testing

`pnpm lint-style` passes.

Verified by rendering the committed CSS against shaka's real spinner markup (copied verbatim from `shaka-player.ui.debug.js`) in Chromium, captured at several points in the cycle over four backdrops — busy, white, gradient and black. The arc grows and shrinks, the caps are round, and it sits concentric with the track.

Not covered by that check: `:deep()` resolving in Vue's scoped style context. Low risk, as the rest of the file uses the same pattern throughout, but it has not been confirmed in a running build.
