### PR TITLE
feat(toasts): add icons and fix the missing thumbnail under the player

### DIFF
--- a/e2e/tests/offline/tabs.spec.mjs
+++ b/e2e/tests/offline/tabs.spec.mjs
@@ -1,5 +1,26 @@
 import { test, expect, sel, goTo } from '../../helpers/app.mjs'
 
+/**
+ * Returns the box of an element that has stopped moving. Menus and submenus
+ * animate in, so measuring right after they become visible yields coordinates
+ * that are still a few pixels off their resting place.
+ * @param {import('@playwright/test').Locator} locator
+ * @returns {Promise<{ x: number, y: number, width: number, height: number }>}
+ */
+async function boundingBoxWhenSettled(locator) {
+  let previous = null
+
+  await expect.poll(async () => {
+    const box = await locator.boundingBox()
+    const current = box && `${box.x},${box.y},${box.width},${box.height}`
+    const settled = current !== null && current === previous
+    previous = current
+    return settled
+  }).toBe(true)
+
+  return await locator.boundingBox()
+}
+
 test.describe('tab bar', () => {
   test('new tab button opens a tab and activates it', async ({ page }) => {
     await page.locator(sel.newTabButton).click()
@@ -282,10 +303,11 @@ test.describe('tab bar', () => {
     const submenu = closeTabs.locator('xpath=following-sibling::*[@role="menu"]')
     await expect(submenu).toBeVisible()
 
-    const parentBox = await closeTabs.boundingBox()
-    const submenuBox = await submenu.boundingBox()
-    expect(parentBox).not.toBeNull()
-    expect(submenuBox).not.toBeNull()
+    // The path below only clears the safe triangle by a couple of pixels, so it
+    // has to be built from where the submenu comes to rest rather than from
+    // where it is mid-animation.
+    const parentBox = await boundingBoxWhenSettled(closeTabs)
+    const submenuBox = await boundingBoxWhenSettled(submenu)
 
     await page.mouse.move(
       parentBox.x + parentBox.width * 0.75,

--- a/e2e/tests/offline/tabs.spec.mjs
+++ b/e2e/tests/offline/tabs.spec.mjs
@@ -9,16 +9,20 @@ import { test, expect, sel, goTo } from '../../helpers/app.mjs'
  */
 async function boundingBoxWhenSettled(locator) {
   let previous = null
+  let settledBox = null
 
   await expect.poll(async () => {
     const box = await locator.boundingBox()
     const current = box && `${box.x},${box.y},${box.width},${box.height}`
     const settled = current !== null && current === previous
     previous = current
+    if (settled) {
+      settledBox = box
+    }
     return settled
   }).toBe(true)
 
-  return await locator.boundingBox()
+  return settledBox
 }
 
 /**

--- a/e2e/tests/offline/video-actions.spec.mjs
+++ b/e2e/tests/offline/video-actions.spec.mjs
@@ -23,33 +23,33 @@ function historyEntry(videoId, title) {
   }
 }
 
-test.use({
-  seed: {
-    settings: { quickBookmarkTargetPlaylistId: 'favorites' },
-    playlists: [
-      {
-        _id: 'favorites',
-        playlistName: 'Favorites',
-        protected: true,
-        description: '',
-        quickBookmarkIcon: 'clock',
-        videos: [],
-        createdAt: Date.now() - 86_400_000,
-        lastUpdatedAt: Date.now() - 86_400_000
-      },
-      {
-        _id: 'saved-videos',
-        playlistName: 'Saved videos',
-        protected: false,
-        description: '',
-        videos: [historyEntry('eeeeeeeeeee', 'Bookmarkable video')],
-        createdAt: Date.now() - 86_400_000,
-        lastUpdatedAt: Date.now() - 86_400_000
-      }
-    ],
-    history: [historyEntry('eeeeeeeeeee', 'Bookmarkable video')]
-  }
-})
+const SEED = {
+  settings: { quickBookmarkTargetPlaylistId: 'favorites' },
+  playlists: [
+    {
+      _id: 'favorites',
+      playlistName: 'Favorites',
+      protected: true,
+      description: '',
+      quickBookmarkIcon: 'clock',
+      videos: [],
+      createdAt: Date.now() - 86_400_000,
+      lastUpdatedAt: Date.now() - 86_400_000
+    },
+    {
+      _id: 'saved-videos',
+      playlistName: 'Saved videos',
+      protected: false,
+      description: '',
+      videos: [historyEntry('eeeeeeeeeee', 'Bookmarkable video')],
+      createdAt: Date.now() - 86_400_000,
+      lastUpdatedAt: Date.now() - 86_400_000
+    }
+  ],
+  history: [historyEntry('eeeeeeeeeee', 'Bookmarkable video')]
+}
+
+test.use({ seed: SEED })
 
 async function readPlaylist(app, id) {
   const contents = await readFile(path.join(app.userDataDir, 'playlists.db'), 'utf8')
@@ -98,6 +98,9 @@ test.describe('list video actions', () => {
     await favoritesRow.click()
     await expect(favoritesRow.locator('[data-prefix="fas"][data-icon="bookmark"]')).toBeVisible()
     await expect(page.locator('.toast .message', { hasText: 'Video has been saved to Favorites' })).toBeVisible()
+
+    // The toast shows the video's thumbnail, not just the message
+    await expect(page.locator('.toast.hasImage .image')).toHaveAttribute('src', /eeeeeeeeeee/)
     await expect.poll(async () => {
       const favorites = await readPlaylist(app, 'favorites')
       return favorites?.videos?.map((entry) => entry.videoId)
@@ -304,5 +307,39 @@ test.describe('list video actions', () => {
       const records = contents.trim().split('\n').map((line) => JSON.parse(line))
       return records.filter((record) => record._id === 'eeeeeeeeeee').at(-1)?.$$deleted
     }).toBe(true)
+  })
+})
+
+test.describe('toast icons', () => {
+  test.use({
+    seed: {
+      ...SEED,
+      settings: { ...SEED.settings, thumbnailPreference: 'hidden' }
+    }
+  })
+
+  test('falls back to an icon when the video has no thumbnail', async ({ page }) => {
+    await goTo(page, 'history')
+
+    const video = page.locator('.ft-list-video').first()
+    await video.hover()
+    await video.locator('.addToPlaylistIcon .iconButton').click()
+
+    const favoritesRow = video.locator('.addToPlaylistIcon .iconDropdown .playlistRow', { hasText: 'Favorites' })
+    await favoritesRow.click()
+
+    await expect(page.locator('.toast .message', { hasText: 'Video has been saved to Favorites' })).toBeVisible()
+    await expect(page.locator('.toast .image')).toBeHidden()
+    await expect(page.locator('.toast .icon[data-prefix="fas"][data-icon="bookmark"]')).toBeVisible()
+  })
+
+  test('shows a fitting icon on toasts that have no thumbnail at all', async ({ page }) => {
+    await goTo(page, 'history')
+
+    await page.getByRole('button', { name: 'Mark All As Watched' }).click()
+    await page.getByRole('button', { name: 'Mark All As Watched', exact: true }).last().click()
+
+    await expect(page.locator('.toast .message', { hasText: 'All videos in your history have been marked as watched' })).toBeVisible()
+    await expect(page.locator('.toast .icon[data-prefix="fas"][data-icon="eye"]')).toBeVisible()
   })
 })

--- a/src/main/index.js
+++ b/src/main/index.js
@@ -2305,18 +2305,19 @@ function runApp() {
     openPendingUrlForReadyWebContents(event)
   })
 
-  ipcMain.on(IpcChannels.SHOW_TOAST, (event, message, time) => {
+  ipcMain.on(IpcChannels.SHOW_TOAST, (event, message, time, icon) => {
     if (
       !isOpenTubeXUrl(event.senderFrame.url) ||
       typeof message !== 'string' ||
-      (time !== null && typeof time !== 'number')
+      (time !== null && typeof time !== 'number') ||
+      (icon != null && (!Array.isArray(icon) || icon.length !== 2 || icon.some(part => typeof part !== 'string')))
     ) {
       return
     }
 
     for (const window of BrowserWindow.getAllWindows()) {
       if (!window.webContents.isDestroyed() && isOpenTubeXUrl(window.webContents.getURL())) {
-        window.webContents.send(IpcChannels.SHOW_TOAST, message, time)
+        window.webContents.send(IpcChannels.SHOW_TOAST, message, time, icon ?? null)
       }
     }
   })

--- a/src/preload/interface.js
+++ b/src/preload/interface.js
@@ -429,9 +429,10 @@ export default {
   /**
    * @param {string} message
    * @param {number | null} time
+   * @param {[string, string] | null} icon
    */
-  showToastOnAllTabs: (message, time) => {
-    ipcRenderer.send(IpcChannels.SHOW_TOAST, message, time)
+  showToastOnAllTabs: (message, time, icon = null) => {
+    ipcRenderer.send(IpcChannels.SHOW_TOAST, message, time, icon)
   },
 
   subscriptionAutoRefresh: {
@@ -522,12 +523,12 @@ export default {
   },
 
   /**
-   * @param {(message: string, time: number | null) => void} handler
+   * @param {(message: string, time: number | null, icon: [string, string] | null) => void} handler
    * @returns {() => void}
    */
   handleShowToast: (handler) => {
-    const listener = (_, message, time) => {
-      handler(message, time)
+    const listener = (_, message, time, icon) => {
+      handler(message, time, icon)
     }
 
     ipcRenderer.on(IpcChannels.SHOW_TOAST, listener)

--- a/src/renderer/App.vue
+++ b/src/renderer/App.vue
@@ -624,7 +624,10 @@ async function initializeManagedDownloadTools() {
 
   if (downloadStarted) {
     const missingTools = missingBinaries.join(' and ')
-    showToast(t('Settings.Download Settings.Managed Tools Download Started Template', { tools: missingTools }))
+    showToast({
+      message: t('Settings.Download Settings.Managed Tools Download Started Template', { tools: missingTools }),
+      icon: ['fas', 'download'],
+    })
     showToolProgress()
   }
 
@@ -648,7 +651,10 @@ async function initializeManagedDownloadTools() {
 
     if (!downloadStarted) {
       downloadStarted = true
-      showToast(t('Settings.Download Settings.Managed Tools Update Started Template', { tools: binary }))
+      showToast({
+        message: t('Settings.Download Settings.Managed Tools Update Started Template', { tools: binary }),
+        icon: ['fas', 'download'],
+      })
       showToolProgress()
     }
 
@@ -680,13 +686,19 @@ async function initializeManagedDownloadTools() {
         store.commit('setProgressBarPercentage', toolProgressPercentage)
       }
       const updatedTools = updatedBinaries.join(' and ')
-      showToast(missingBinaries.length > 0
-        ? t('Settings.Download Settings.Managed Tools Download Finished Template', { tools: updatedTools })
-        : t('Settings.Download Settings.Managed Tools Update Finished Template', { tools: updatedTools }))
+      showToast({
+        message: missingBinaries.length > 0
+          ? t('Settings.Download Settings.Managed Tools Download Finished Template', { tools: updatedTools })
+          : t('Settings.Download Settings.Managed Tools Update Finished Template', { tools: updatedTools }),
+        icon: ['fas', 'check'],
+      })
     } else {
       if (failures.length > 0) {
         const errors = failures.map(({ binary, result }) => `${binary}: ${result?.error ?? ''}`).join('; ')
-        showToast(t('Settings.Download Settings.Managed Tools Download Error Template', { errors }))
+        showToast({
+          message: t('Settings.Download Settings.Managed Tools Download Error Template', { errors }),
+          icon: ['fas', 'circle-exclamation'],
+        })
       }
     }
   } finally {
@@ -2293,7 +2305,10 @@ function handleLinkClick(event) {
     })
   } else if (externalLinkHandling.value === 'doNothing') {
     // Let user know opening external link is disabled via setting
-    showToast(t('External link opening has been disabled in the general settings'))
+    showToast({
+      message: t('External link opening has been disabled in the general settings'),
+      icon: ['fas', 'link-slash'],
+    })
   } else if (externalLinkHandling.value === 'openLinkAfterPrompt') {
     // Storing the URL is necessary as
     // there is no other way to pass the URL to click callback
@@ -2428,7 +2443,10 @@ async function handleYoutubeLink(href, {
 
     default: {
       // Unknown URL type
-      showToast(t('Unknown YouTube url type, cannot be opened in app'))
+      showToast({
+        message: t('Unknown YouTube url type, cannot be opened in app'),
+        icon: ['fas', 'circle-exclamation'],
+      })
     }
   }
 }

--- a/src/renderer/components/CommentSection/CommentSection.vue
+++ b/src/renderer/components/CommentSection/CommentSection.vue
@@ -395,7 +395,7 @@ import FtTimestampCatcher from '../FtTimestampCatcher.vue'
 
 import store from '../../store/index'
 
-import { copyToClipboard, formatNumber, showToast } from '../../helpers/utils'
+import { copyToClipboard, formatNumber, showApiErrorToast, showToast } from '../../helpers/utils'
 import { getYoutubeCommunityPostCommentUrl, getYoutubeVideoCommentUrl } from '../../helpers/share'
 import {
   getLocalCommunityPostComments,
@@ -807,7 +807,7 @@ function getCommentData({ preserveSort = false } = {}) {
 
 function getMoreComments() {
   if (commentData.value.length === 0 || nextPageToken.value == null) {
-    showToast(t('Comments.There are no more comments for this video'))
+    showToast({ message: t('Comments.There are no more comments for this video'), icon: ['fas', 'comment'] })
   } else {
     isLoadingMoreComments.value = true
     let commentLoadPromise
@@ -1005,12 +1005,10 @@ async function getCommentDataLocal(more = false, preserveSort = false) {
 
     console.error(err)
     const errorMessage = t('Local API Error (Click to copy)')
-    showToast(`${errorMessage}: ${err}`, 10000, () => {
-      copyToClipboard(err)
-    })
+    showApiErrorToast(errorMessage, err)
     if (backendFallback.value && backendPreference.value === 'local') {
       localCommentsInstance = undefined
-      showToast(t('Falling back to Invidious API'))
+      showToast({ message: t('Falling back to Invidious API'), icon: ['fas', 'exchange-alt'] })
       if (props.isPostComments) {
         return getPostCommentsInvidious()
       } else {
@@ -1068,11 +1066,9 @@ async function getCommentRepliesLocal(index, commentId = null) {
   } catch (err) {
     console.error(err)
     const errorMessage = t('Local API Error (Click to copy)')
-    showToast(`${errorMessage}: ${err}`, 10000, () => {
-      copyToClipboard(err)
-    })
+    showApiErrorToast(errorMessage, err)
     if (backendFallback.value && backendPreference.value === 'local') {
-      showToast(t('Falling back to Invidious API'))
+      showToast({ message: t('Falling back to Invidious API'), icon: ['fas', 'exchange-alt'] })
       getCommentDataInvidious()
     } else {
       isLoading.value = false
@@ -1121,12 +1117,10 @@ async function getCommentDataInvidious() {
 
     console.error(err)
     const errorMessage = t('Invidious API Error (Click to copy)')
-    showToast(`${errorMessage}: ${err}`, 10000, () => {
-      copyToClipboard(err)
-    })
+    showApiErrorToast(errorMessage, err)
 
     if (process.env.SUPPORTS_LOCAL_API && backendFallback.value && backendPreference.value === 'invidious') {
-      showToast(t('Falling back to Local API'))
+      showToast({ message: t('Falling back to Local API'), icon: ['fas', 'exchange-alt'] })
       return getCommentDataLocal()
     } else {
       isLoading.value = false
@@ -1159,9 +1153,7 @@ async function getCommentRepliesInvidious(index) {
   } catch (error) {
     console.error(error)
     const errorMessage = t('Invidious API Error (Click to copy)')
-    showToast(`${errorMessage}: ${error}`, 10000, () => {
-      copyToClipboard(error)
-    })
+    showApiErrorToast(errorMessage, error)
     isLoading.value = false
   }
 }
@@ -1191,12 +1183,10 @@ function getPostCommentsInvidious() {
   }).catch((err) => {
     console.error(err)
     const errorMessage = t('Invidious API Error (Click to copy)')
-    showToast(`${errorMessage}: ${err}`, 10000, () => {
-      copyToClipboard(err)
-    })
+    showApiErrorToast(errorMessage, err)
 
     if (process.env.SUPPORTS_LOCAL_API && backendFallback.value && backendPreference.value === 'invidious') {
-      showToast(t('Falling back to Local API'))
+      showToast({ message: t('Falling back to Local API'), icon: ['fas', 'exchange-alt'] })
       return getCommentDataLocal()
     } else {
       isLoading.value = false
@@ -1229,9 +1219,7 @@ async function getPostCommentRepliesInvidious(index) {
   } catch (error) {
     console.error(error)
     const errorMessage = t('Invidious API Error (Click to copy)')
-    showToast(`${errorMessage}: ${error}`, 10000, () => {
-      copyToClipboard(error)
-    })
+    showApiErrorToast(errorMessage, error)
     isLoading.value = false
   }
 }

--- a/src/renderer/components/DataSettings/DataSettings.vue
+++ b/src/renderer/components/DataSettings/DataSettings.vue
@@ -191,11 +191,11 @@ async function promptAndWriteToFile(
     )
 
     if (response) {
-      showToast(successMessage)
+      showToast({ message: successMessage, icon: ['fas', 'check'] })
     }
   } catch (error) {
     const message = t('Settings.Data Settings.Unable to write file')
-    showToast(`${message}: ${error}`)
+    showToast({ message: `${message}: ${error}`, icon: ['fas', 'circle-exclamation'] })
   }
 }
 
@@ -208,7 +208,7 @@ function parseImportedJson(content, invalidMessage) {
     return JSON.parse(content)
   } catch (error) {
     console.error('Unable to parse imported JSON file', error)
-    showToast(invalidMessage)
+    showToast({ message: invalidMessage, icon: ['fas', 'circle-exclamation'] })
     return null
   }
 }
@@ -258,7 +258,7 @@ async function importSubscriptions() {
     )
   } catch (err) {
     const message = t('Settings.Data Settings.Unable to read file')
-    showToast(`${message}: ${err}`)
+    showToast({ message: `${message}: ${err}`, icon: ['fas', 'circle-exclamation'] })
     return
   }
 
@@ -296,7 +296,10 @@ async function importSubscriptions() {
         importYouTubeSubscriptions(jsonContent)
         break
       default:
-        showToast(t('Settings.Data Settings.Invalid subscriptions file'))
+        showToast({
+          message: t('Settings.Data Settings.Invalid subscriptions file'),
+          icon: ['fas', 'circle-exclamation'],
+        })
     }
   }
 }
@@ -384,7 +387,7 @@ function importFreeTubeSubscriptions(textDecode) {
     Object.keys(profileData).forEach((key) => {
       if (!requiredKeys.includes(key)) {
         const message = t('Settings.Data Settings.Unknown data key')
-        showToast(`${message}: ${key}`)
+        showToast({ message: `${message}: ${key}`, icon: ['fas', 'circle-exclamation'] })
       } else {
         profileObject[key] = profileData[key]
       }
@@ -392,7 +395,7 @@ function importFreeTubeSubscriptions(textDecode) {
 
     if (Object.keys(profileObject).length < requiredKeys.length) {
       const message = t('Settings.Data Settings.Profile object has insufficient data, skipping item')
-      showToast(message)
+      showToast({ message: message, icon: ['fas', 'circle-exclamation'] })
     } else {
       if (profileObject._id === MAIN_PROFILE_ID) {
         primaryProfile.value.subscriptions = primaryProfile.value.subscriptions.concat(profileObject.subscriptions)
@@ -437,7 +440,10 @@ function importFreeTubeSubscriptions(textDecode) {
     }
   })
 
-  showToast(t('Settings.Data Settings.All subscriptions and profiles have been successfully imported'))
+  showToast({
+    message: t('Settings.Data Settings.All subscriptions and profiles have been successfully imported'),
+    icon: ['fas', 'rss'],
+  })
 }
 
 /**
@@ -481,7 +487,10 @@ function importCsvYouTubeSubscriptions(textDecode) { // first row = header, last
 
   primaryProfile.value.subscriptions = primaryProfile.value.subscriptions.concat(subscriptions)
   store.dispatch('updateProfile', primaryProfile.value)
-  showToast(t('Settings.Data Settings.All subscriptions have been successfully imported'))
+  showToast({
+    message: t('Settings.Data Settings.All subscriptions have been successfully imported'),
+    icon: ['fas', 'rss'],
+  })
   store.commit('setShowProgressBar', false)
 }
 
@@ -499,7 +508,7 @@ function importYouTubeSubscriptions(textDecode) {
     const snippet = channel.snippet
     if (typeof snippet === 'undefined') {
       const message = t('Settings.Data Settings.Invalid subscriptions file')
-      showToast(message)
+      showToast({ message: message, icon: ['fas', 'circle-exclamation'] })
       throw new Error('Unable to find channel data')
     }
 
@@ -520,7 +529,10 @@ function importYouTubeSubscriptions(textDecode) {
 
   primaryProfile.value.subscriptions = primaryProfile.value.subscriptions.concat(subscriptions)
   store.dispatch('updateProfile', primaryProfile.value)
-  showToast(t('Settings.Data Settings.All subscriptions have been successfully imported'))
+  showToast({
+    message: t('Settings.Data Settings.All subscriptions have been successfully imported'),
+    icon: ['fas', 'rss'],
+  })
   store.commit('setShowProgressBar', false)
 }
 
@@ -548,7 +560,7 @@ function importOpmlYouTubeSubscriptions(data) {
       xmlDom = htmlDom
     } catch {
       const message = t('Settings.Data Settings.Invalid subscriptions file')
-      showToast(`${message}: ${err}`)
+      showToast({ message: `${message}: ${err}`, icon: ['fas', 'circle-exclamation'] })
       return
     }
   }
@@ -556,7 +568,7 @@ function importOpmlYouTubeSubscriptions(data) {
   const feedData = xmlDom.querySelectorAll('body outline[xmlUrl]')
   if (feedData.length === 0) {
     const message = t('Settings.Data Settings.Invalid subscriptions file')
-    showToast(message)
+    showToast({ message: message, icon: ['fas', 'circle-exclamation'] })
     return
   }
 
@@ -597,7 +609,10 @@ function importOpmlYouTubeSubscriptions(data) {
 
   primaryProfile.value.subscriptions = primaryProfile.value.subscriptions.concat(subscriptions)
   store.dispatch('updateProfile', primaryProfile.value)
-  showToast(t('Settings.Data Settings.All subscriptions have been successfully imported'))
+  showToast({
+    message: t('Settings.Data Settings.All subscriptions have been successfully imported'),
+    icon: ['fas', 'rss'],
+  })
   store.commit('setShowProgressBar', false)
 }
 
@@ -608,7 +623,7 @@ function importLibreTubeSubscriptions(libreTubeSubscriptions) {
   const subscriptions = convertLibreTubeSubscriptions(libreTubeSubscriptions)
 
   if (subscriptions.length === 0) {
-    showToast(t('Settings.Data Settings.Invalid subscriptions file'))
+    showToast({ message: t('Settings.Data Settings.Invalid subscriptions file'), icon: ['fas', 'circle-exclamation'] })
     return
   }
 
@@ -635,7 +650,10 @@ function mergeSubscriptionsIntoPrimaryProfile(subscriptions) {
 
   primaryProfile.value.subscriptions = primaryProfile.value.subscriptions.concat(newSubscriptions)
   store.dispatch('updateProfile', primaryProfile.value)
-  showToast(t('Settings.Data Settings.All subscriptions have been successfully imported'))
+  showToast({
+    message: t('Settings.Data Settings.All subscriptions have been successfully imported'),
+    icon: ['fas', 'rss'],
+  })
   store.commit('setShowProgressBar', false)
 }
 
@@ -644,7 +662,7 @@ function mergeSubscriptionsIntoPrimaryProfile(subscriptions) {
  */
 function importNewPipeSubscriptions(newPipeData) {
   if (typeof newPipeData.subscriptions === 'undefined') {
-    showToast(t('Settings.Data Settings.Invalid subscriptions file'))
+    showToast({ message: t('Settings.Data Settings.Invalid subscriptions file'), icon: ['fas', 'circle-exclamation'] })
 
     return
   }
@@ -887,7 +905,7 @@ async function importWatchHistory() {
     )
   } catch (err) {
     const message = t('Settings.Data Settings.Unable to read file')
-    showToast(`${message}: ${err}`)
+    showToast({ message: `${message}: ${err}`, icon: ['fas', 'circle-exclamation'] })
     return
   }
 
@@ -910,7 +928,7 @@ async function importWatchHistory() {
     } else if (Array.isArray(jsonContent)) {
       importYouTubeWatchHistory(jsonContent)
     } else {
-      showToast(t('Settings.Data Settings.Invalid history file'))
+      showToast({ message: t('Settings.Data Settings.Invalid history file'), icon: ['fas', 'circle-exclamation'] })
     }
   }
 }
@@ -964,7 +982,7 @@ async function importFreeTubeWatchHistory(textDecode) {
       if (requiredKeys.includes(key) || optionalKeys.includes(key)) {
         historyObject[key] = historyData[key]
       } else if (!ignoredKeys.includes(key)) {
-        showToast(`Unknown data key: ${key}`)
+        showToast({ message: `Unknown data key: ${key}`, icon: ['fas', 'circle-exclamation'] })
       }
       // Else do not import the key
     })
@@ -972,7 +990,10 @@ async function importFreeTubeWatchHistory(textDecode) {
     const historyObjectKeysSet = new Set(Object.keys(historyObject))
     const missingKeys = requiredKeys.filter(x => !historyObjectKeysSet.has(x))
     if (missingKeys.length > 0) {
-      showToast(t('Settings.Data Settings.History object has insufficient data, skipping item'))
+      showToast({
+        message: t('Settings.Data Settings.History object has insufficient data, skipping item'),
+        icon: ['fas', 'circle-exclamation'],
+      })
       console.error('Missing Keys: ', missingKeys, historyData)
     } else {
       // FreeTube history export does not have this data if the video was marked as watched manually, setting default value
@@ -984,7 +1005,10 @@ async function importFreeTubeWatchHistory(textDecode) {
 
   await store.dispatch('overwriteHistory', historyItems)
 
-  showToast(t('Settings.Data Settings.All watched history has been successfully imported'))
+  showToast({
+    message: t('Settings.Data Settings.All watched history has been successfully imported'),
+    icon: ['fas', 'history'],
+  })
 }
 
 /**
@@ -992,7 +1016,7 @@ async function importFreeTubeWatchHistory(textDecode) {
  */
 async function importLibreTubeWatchHistory(backupData) {
   if (backupData.watchHistory.length === 0) {
-    showToast(t('Settings.Data Settings.Invalid history file'))
+    showToast({ message: t('Settings.Data Settings.Invalid history file'), icon: ['fas', 'circle-exclamation'] })
     return
   }
 
@@ -1007,17 +1031,23 @@ async function importLibreTubeWatchHistory(backupData) {
   )
 
   if (importedCount === 0) {
-    showToast(t('Settings.Data Settings.Invalid history file'))
+    showToast({ message: t('Settings.Data Settings.Invalid history file'), icon: ['fas', 'circle-exclamation'] })
     return
   }
 
   if (skippedCount > 0) {
-    showToast(t('Settings.Data Settings.History object has insufficient data, skipping item'))
+    showToast({
+      message: t('Settings.Data Settings.History object has insufficient data, skipping item'),
+      icon: ['fas', 'circle-exclamation'],
+    })
   }
 
   await store.dispatch('overwriteHistory', convertedHistoryItems)
 
-  showToast(t('Settings.Data Settings.All watched history has been successfully imported'))
+  showToast({
+    message: t('Settings.Data Settings.All watched history has been successfully imported'),
+    icon: ['fas', 'history'],
+  })
 }
 
 /**
@@ -1083,7 +1113,7 @@ async function importYouTubeWatchHistory(historyData) {
 
     Object.keys(element).forEach((key) => {
       if (!knownKeys.includes(key)) {
-        showToast(`Unknown data key: ${key}`)
+        showToast({ message: `Unknown data key: ${key}`, icon: ['fas', 'circle-exclamation'] })
       } else {
         const mapping = keyMapping[key]
 
@@ -1096,7 +1126,10 @@ async function importYouTubeWatchHistory(historyData) {
     })
 
     if (Object.keys(historyObject).length < keyMapping.length - 1) {
-      showToast(t('Settings.Data Settings.History object has insufficient data, skipping item'))
+      showToast({
+        message: t('Settings.Data Settings.History object has insufficient data, skipping item'),
+        icon: ['fas', 'circle-exclamation'],
+      })
     } else {
       // YouTube history export does not have this data, setting some defaults.
       historyObject.type = 'video'
@@ -1113,7 +1146,10 @@ async function importYouTubeWatchHistory(historyData) {
 
   await store.dispatch('overwriteHistory', historyItems)
 
-  showToast(t('Settings.Data Settings.All watched history has been successfully imported'))
+  showToast({
+    message: t('Settings.Data Settings.All watched history has been successfully imported'),
+    icon: ['fas', 'history'],
+  })
 }
 
 const showExportWatchHistoryPrompt = ref(false)
@@ -1203,7 +1239,7 @@ async function importPlaylists() {
     )
   } catch (err) {
     const message = t('Settings.Data Settings.Unable to read file')
-    showToast(`${message}: ${err}`)
+    showToast({ message: `${message}: ${err}`, icon: ['fas', 'circle-exclamation'] })
     return
   }
 
@@ -1287,7 +1323,7 @@ async function importPlaylists() {
     Object.keys(playlistData).forEach((key) => {
       if (!knownKeys.includes(key)) {
         const message = `${t('Settings.Data Settings.Unknown data key')}: ${key}`
-        showToast(message)
+        showToast({ message: message, icon: ['fas', 'circle-exclamation'] })
       } else if (key === 'videos') {
         const videoArray = []
         playlistData.videos.forEach((video) => {
@@ -1317,7 +1353,7 @@ async function importPlaylists() {
 
     if (countRequiredKeysPresent !== requiredKeys.length) {
       const message = t('Settings.Data Settings.Playlist insufficient data', { playlist: playlistData.playlistName })
-      showToast(message)
+      showToast({ message: message, icon: ['fas', 'circle-exclamation'] })
       return
     }
 
@@ -1398,7 +1434,10 @@ async function importPlaylists() {
     store.dispatch('addPlaylists', newPlaylists)
   }
 
-  showToast(t('Settings.Data Settings.All playlists has been successfully imported'))
+  showToast({
+    message: t('Settings.Data Settings.All playlists has been successfully imported'),
+    icon: ['fas', 'bookmark'],
+  })
 }
 
 async function exportPlaylists() {
@@ -1442,7 +1481,7 @@ async function importSearchHistory() {
     )
   } catch (err) {
     const message = t('Settings.Data Settings.Unable to read file')
-    showToast(`${message}: ${err}`)
+    showToast({ message: `${message}: ${err}`, icon: ['fas', 'circle-exclamation'] })
     return
   }
 
@@ -1472,7 +1511,10 @@ async function importFreeTubeSearchHistory(textDecode) {
     const entry = JSON.parse(rawEntry)
 
     if (typeof entry._id !== 'string' || typeof entry.lastUpdatedAt !== 'number') {
-      showToast(t('Settings.Data Settings.History object has insufficient data, skipping item'))
+      showToast({
+        message: t('Settings.Data Settings.History object has insufficient data, skipping item'),
+        icon: ['fas', 'circle-exclamation'],
+      })
       console.error('Missing keys:', entry)
     } else {
       const existingEntry = historyItems.get(entry._id)
@@ -1495,7 +1537,10 @@ async function importFreeTubeSearchHistory(textDecode) {
 
   await store.dispatch('overwriteSearchHistory', newSearchHistoryEntries)
 
-  showToast(t('Settings.Data Settings.All search history has been successfully imported'))
+  showToast({
+    message: t('Settings.Data Settings.All search history has been successfully imported'),
+    icon: ['fas', 'history'],
+  })
 }
 
 /**
@@ -1518,7 +1563,10 @@ async function importYouTubeSearchHistory(historyData) {
         const lastUpdatedAt = Date.parse(entry.time)
 
         if (!query || typeof query !== 'string' || query.length === 0 || isNaN(lastUpdatedAt)) {
-          showToast(t('Settings.Data Settings.History object has insufficient data, skipping item'))
+          showToast({
+            message: t('Settings.Data Settings.History object has insufficient data, skipping item'),
+            icon: ['fas', 'circle-exclamation'],
+          })
           console.error('Missing keys:', entry)
         } else {
           const existingEntry = historyItems.get(query)
@@ -1529,7 +1577,10 @@ async function importYouTubeSearchHistory(historyData) {
         }
       } catch (error) {
         console.error(error)
-        showToast(t('Settings.Data Settings.History object has insufficient data, skipping item'))
+        showToast({
+          message: t('Settings.Data Settings.History object has insufficient data, skipping item'),
+          icon: ['fas', 'circle-exclamation'],
+        })
       }
     }
   }
@@ -1538,7 +1589,10 @@ async function importYouTubeSearchHistory(historyData) {
 
   await store.dispatch('overwriteSearchHistory', newSearchHistoryEntries)
 
-  showToast(t('Settings.Data Settings.All search history has been successfully imported'))
+  showToast({
+    message: t('Settings.Data Settings.All search history has been successfully imported'),
+    icon: ['fas', 'history'],
+  })
 }
 
 const showExportSearchHistoryPrompt = ref(false)
@@ -1628,7 +1682,7 @@ async function importSettings() {
     )
   } catch (err) {
     const message = t('Settings.Data Settings.Unable to read file')
-    showToast(`${message}: ${err}`)
+    showToast({ message: `${message}: ${err}`, icon: ['fas', 'circle-exclamation'] })
     return
   }
 
@@ -1645,7 +1699,10 @@ async function importSettings() {
       content.split('\n').map((rawEntry) => {
         const entry = JSON.parse(rawEntry)
         if (typeof entry._id !== 'string' || !Object.hasOwn(entry, 'value')) {
-          showToast(t('Settings.Data Settings.Setting object has insufficient data, skipping item'))
+          showToast({
+            message: t('Settings.Data Settings.Setting object has insufficient data, skipping item'),
+            icon: ['fas', 'circle-exclamation'],
+          })
           console.error('Missing keys:', entry)
           return []
         }
@@ -1660,13 +1717,13 @@ async function importSettings() {
   for (const [importedKey, importedValue] of Object.entries(importedSettings)) {
     if (!Object.hasOwn(currentSettings, importedKey)) {
       const message = t('Settings.Data Settings.Unknown setting key', { key: importedKey })
-      showToast(message)
+      showToast({ message: message, icon: ['fas', 'circle-exclamation'] })
       continue
     }
 
     if (NON_TRANSFERABLE_SETTINGS.has(importedKey)) {
       const message = t('Settings.Data Settings.Non-transferable setting key', { key: importedKey })
-      showToast(message)
+      showToast({ message: message, icon: ['fas', 'circle-exclamation'] })
       continue
     }
 
@@ -1681,7 +1738,10 @@ async function importSettings() {
     await store.dispatch(updaterId, importedValue)
   }
 
-  showToast(t('Settings.Data Settings.All settings have been successfully imported'))
+  showToast({
+    message: t('Settings.Data Settings.All settings have been successfully imported'),
+    icon: ['fas', 'sliders-h'],
+  })
 }
 
 async function exportSettings() {

--- a/src/renderer/components/DistractionSettings/DistractionSettings.vue
+++ b/src/renderer/components/DistractionSettings/DistractionSettings.vue
@@ -729,15 +729,24 @@ onMounted(() => {
 })
 
 function handleInvalidChannel() {
-  showToast(t('Settings.Distraction Free Settings.Hide Channels Invalid'))
+  showToast({
+    message: t('Settings.Distraction Free Settings.Hide Channels Invalid'),
+    icon: ['fas', 'circle-exclamation'],
+  })
 }
 
 function handleChannelAPIError() {
-  showToast(t('Settings.Distraction Free Settings.Hide Channels API Error'))
+  showToast({
+    message: t('Settings.Distraction Free Settings.Hide Channels API Error'),
+    icon: ['fas', 'circle-exclamation'],
+  })
 }
 
 function handleChannelsExists() {
-  showToast(t('Settings.Distraction Free Settings.Hide Channels Already Exists'))
+  showToast({
+    message: t('Settings.Distraction Free Settings.Hide Channels Already Exists'),
+    icon: ['fas', 'circle-exclamation'],
+  })
 }
 
 /**

--- a/src/renderer/components/DownloadSettings.vue
+++ b/src/renderer/components/DownloadSettings.vue
@@ -407,21 +407,30 @@ async function downloadBinary(binary) {
 
     if (result != null && 'version' in result) {
       if (result.updated) {
-        showToast(binary === 'yt-dlp'
-          ? t('Settings.Download Settings.yt-dlp Downloaded Template', { version: result.version })
-          : t('Settings.Download Settings.FFmpeg Downloaded Template', { version: result.version }))
+        showToast({
+          message: binary === 'yt-dlp'
+            ? t('Settings.Download Settings.yt-dlp Downloaded Template', { version: result.version })
+            : t('Settings.Download Settings.FFmpeg Downloaded Template', { version: result.version }),
+          icon: ['fas', 'download'],
+        })
       } else {
         const tool = binary === 'yt-dlp' ? 'yt-dlp' : 'FFmpeg'
-        showToast(t('Settings.Download Settings.Managed Tool Already Current Template', {
-          tool,
-          version: result.version
-        }))
+        showToast({
+          message: t('Settings.Download Settings.Managed Tool Already Current Template', {
+            tool,
+            version: result.version
+          }),
+          icon: ['fas', 'check'],
+        })
       }
     } else {
       const error = result?.error ?? ''
-      showToast(binary === 'yt-dlp'
-        ? t('Settings.Download Settings.yt-dlp Download Error Template', { error })
-        : t('Settings.Download Settings.FFmpeg Download Error Template', { error }))
+      showToast({
+        message: binary === 'yt-dlp'
+          ? t('Settings.Download Settings.yt-dlp Download Error Template', { error })
+          : t('Settings.Download Settings.FFmpeg Download Error Template', { error }),
+        icon: ['fas', 'circle-exclamation'],
+      })
     }
   } finally {
     if (activeBinaryDownloads.size === 0) {

--- a/src/renderer/components/FtAddToPlaylistDropdown/FtAddToPlaylistDropdown.vue
+++ b/src/renderer/components/FtAddToPlaylistDropdown/FtAddToPlaylistDropdown.vue
@@ -55,7 +55,7 @@ import { computed } from 'vue'
 import { useI18n } from 'vue-i18n'
 
 import store from '../../store/index'
-import { showToast } from '../../helpers/utils'
+import { getVideoThumbnailUrl, showToast } from '../../helpers/utils'
 
 import thumbnailPlaceholder from '../../assets/img/thumbnail_placeholder.svg'
 
@@ -93,6 +93,15 @@ const playlists = computed(() => {
   rows.push(...playlistsById.values())
 
   return rows
+})
+
+const videoThumbnail = computed(() => {
+  return getVideoThumbnailUrl(
+    props.videoData.videoId,
+    store.getters.getBackendPreference,
+    store.getters.getCurrentInvidiousInstanceUrl,
+    store.getters.getThumbnailPreference
+  )
 })
 
 const containedIds = computed(() => {
@@ -133,9 +142,13 @@ async function togglePlaylist(playlist) {
       videoId: props.videoData.videoId,
     })
 
-    showToast(removed
-      ? t('Video.Video has been removed from {playlistName}', { playlistName })
-      : t('Video.There was a problem removing the video from {playlistName}', { playlistName }))
+    showToast({
+      message: removed
+        ? t('Video.Video has been removed from {playlistName}', { playlistName })
+        : t('Video.There was a problem removing the video from {playlistName}', { playlistName }),
+      image: videoThumbnail.value,
+      icon: ['fas', 'trash'],
+    })
   } else {
     // Concurrent activations are collapsed by the store, so a rapid second
     // click (or the quick bookmark button) cannot append a duplicate entry
@@ -145,9 +158,13 @@ async function togglePlaylist(playlist) {
       videoData: { ...props.videoData },
     })
 
-    showToast(saved
-      ? t('Video.Video has been saved to {playlistName}', { playlistName })
-      : t('Video.There was a problem saving the video to {playlistName}', { playlistName }))
+    showToast({
+      message: saved
+        ? t('Video.Video has been saved to {playlistName}', { playlistName })
+        : t('Video.There was a problem saving the video to {playlistName}', { playlistName }),
+      image: videoThumbnail.value,
+      icon: ['fas', 'bookmark'],
+    })
   }
 }
 

--- a/src/renderer/components/FtCreatePlaylistPrompt/FtCreatePlaylistPrompt.vue
+++ b/src/renderer/components/FtCreatePlaylistPrompt/FtCreatePlaylistPrompt.vue
@@ -122,11 +122,17 @@ async function createNewPlaylist() {
 
   try {
     await store.dispatch('addPlaylist', playlistObject)
-    showToast(t('User Playlists.CreatePlaylistPrompt.Toast["Playlist {playlistName} has been successfully created."]', {
-      playlistName: playlistName.value,
-    }))
+    showToast({
+      message: t('User Playlists.CreatePlaylistPrompt.Toast["Playlist {playlistName} has been successfully created."]', {
+        playlistName: playlistName.value,
+      }),
+      icon: ['fac', 'playlist-check'],
+    })
   } catch (e) {
-    showToast(t('User Playlists.CreatePlaylistPrompt.Toast["There was an issue with creating the playlist."]'))
+    showToast({
+      message: t('User Playlists.CreatePlaylistPrompt.Toast["There was an issue with creating the playlist."]'),
+      icon: ['fas', 'circle-exclamation'],
+    })
     console.error(e)
   } finally {
     hideCreatePlaylistPrompt()

--- a/src/renderer/components/FtInputTags/FtInputTags.vue
+++ b/src/renderer/components/FtInputTags/FtInputTags.vue
@@ -163,12 +163,15 @@ async function updateTags(text) {
   const trimmedText = text.trim()
 
   if (props.minInputLength > trimmedText.length) {
-    showToast(t('Trimmed input must be at least N characters long', { length: props.minInputLength }, props.minInputLength))
+    showToast({
+      message: t('Trimmed input must be at least N characters long', { length: props.minInputLength }, props.minInputLength),
+      icon: ['fas', 'circle-exclamation'],
+    })
     return
   }
 
   if (props.tagList.includes(trimmedText)) {
-    showToast(t('Tag already exists', { tagName: trimmedText }))
+    showToast({ message: t('Tag already exists', { tagName: trimmedText }), icon: ['fas', 'circle-exclamation'] })
     return
   }
 

--- a/src/renderer/components/FtListPlaylist/FtListPlaylist.vue
+++ b/src/renderer/components/FtListPlaylist/FtListPlaylist.vue
@@ -234,7 +234,10 @@ const markedAsQuickBookmarkTarget = computed(() => {
 })
 
 function handleQuickBookmarkEnabledDisabledClick() {
-  showToast(t('User Playlists.SinglePlaylistView.Toast["This playlist is already being used for quick bookmark."]'))
+  showToast({
+    message: t('User Playlists.SinglePlaylistView.Toast["This playlist is already being used for quick bookmark."]'),
+    icon: ['fas', 'bookmark'],
+  })
 }
 
 async function enableQuickBookmarkForThisPlaylist() {
@@ -243,23 +246,28 @@ async function enableQuickBookmarkForThisPlaylist() {
   store.dispatch('updateQuickBookmarkTargetPlaylistId', playlistId)
 
   if (currentQuickBookmarkTargetPlaylist != null) {
-    showToast(
-      t('User Playlists.SinglePlaylistView.Toast["This playlist is now used for quick bookmark instead of {oldPlaylistName}. Click here to undo"]', {
+    showToast({
+      message: t('User Playlists.SinglePlaylistView.Toast["This playlist is now used for quick bookmark instead of {oldPlaylistName}. Click here to undo"]', {
         oldPlaylistName: currentQuickBookmarkTargetPlaylist.playlistName,
       }),
-      5000,
-      () => {
+      time: 5000,
+      action: () => {
         store.dispatch('updateQuickBookmarkTargetPlaylistId', currentQuickBookmarkTargetPlaylist._id)
-        showToast(
-          t('User Playlists.SinglePlaylistView.Toast["Reverted to use {oldPlaylistName} for quick bookmark"]', {
+        showToast({
+          message: t('User Playlists.SinglePlaylistView.Toast["Reverted to use {oldPlaylistName} for quick bookmark"]', {
             oldPlaylistName: currentQuickBookmarkTargetPlaylist.playlistName,
           }),
-          5000,
-        )
+          time: 5000,
+          icon: ['fas', 'undo'],
+        })
       },
-    )
+      icon: ['fas', 'bookmark'],
+    })
   } else {
-    showToast(t('User Playlists.SinglePlaylistView.Toast.This playlist is now used for quick bookmark'))
+    showToast({
+      message: t('User Playlists.SinglePlaylistView.Toast.This playlist is now used for quick bookmark'),
+      icon: ['fas', 'bookmark'],
+    })
   }
 }
 

--- a/src/renderer/components/FtListVideo/FtListVideo.vue
+++ b/src/renderer/components/FtListVideo/FtListVideo.vue
@@ -823,7 +823,8 @@ function addToWatchQueue(playNext) {
     message: playNext
       ? t('Video.Added to Play Next')
       : t('Video.Added to Queue'),
-    image: thumbnail.value
+    image: toastThumbnail.value,
+    icon: ['fas', 'list'],
   })
 }
 
@@ -854,6 +855,10 @@ const thumbnail = computed(() => {
       return `${baseUrl}/vi/${id.value}/mqdefault.jpg`
   }
 })
+
+// The placeholder is fine in the list, but in a toast it would just be a grey
+// box in place of the toast's fallback icon, so leave the image out instead
+const toastThumbnail = computed(() => thumbnailPreference.value === 'hidden' ? null : thumbnail.value)
 
 /** @type {import('vue').ComputedRef<boolean>} */
 const hideVideoViews = computed(() => store.getters.getHideVideoViews)
@@ -1211,7 +1216,7 @@ async function openCollaboratorsPrompt() {
     }
   } catch (error) {
     console.error(`Failed to fetch collaborators for ${id.value}`, error)
-    showToast(t('Video.Failed to load collaborators'))
+    showToast({ message: t('Video.Failed to load collaborators'), icon: ['fas', 'circle-exclamation'] })
   } finally {
     isFetchingCollaborators.value = false
   }
@@ -1321,7 +1326,8 @@ function markAsWatched() {
 
   showToast({
     message: t('Video.Video has been marked as watched'),
-    image: thumbnail.value
+    image: toastThumbnail.value,
+    icon: ['fas', 'eye'],
   })
 }
 
@@ -1333,7 +1339,8 @@ function unmarkAsWatched() {
 
   showToast({
     message: t('Video.Video has been unmarked as watched'),
-    image: thumbnail.value
+    image: toastThumbnail.value,
+    icon: ['fas', 'eye-slash'],
   })
 }
 
@@ -1342,7 +1349,8 @@ function removeFromHistory() {
 
   showToast({
     message: t('Video.Video has been removed from your history'),
-    image: thumbnail.value
+    image: toastThumbnail.value,
+    icon: ['fas', 'trash'],
   })
 }
 
@@ -1368,7 +1376,7 @@ function hideChannel(channelName, channelId) {
 
   store.dispatch('updateChannelsHidden', JSON.stringify(newHiddenChannels))
 
-  showToast(t('Channel Hidden', { channel: channelName }))
+  showToast({ message: t('Channel Hidden', { channel: channelName }), icon: ['fas', 'eye-slash'] })
 }
 
 /**
@@ -1378,7 +1386,7 @@ function hideChannel(channelName, channelId) {
 function unhideChannel(channelName, channelId) {
   store.dispatch('updateChannelsHidden', JSON.stringify(hiddenChannels.value.filter(c => c.name !== channelId)))
 
-  showToast(t('Channel Unhidden', { channel: channelName }))
+  showToast({ message: t('Channel Unhidden', { channel: channelName }), icon: ['fas', 'eye'] })
 }
 
 function toggleQuickBookmarked() {
@@ -1417,7 +1425,8 @@ async function addToQuickBookmarkPlaylist() {
     message: saved
       ? t('Video.Video has been saved to {playlistName}', { playlistName })
       : t('Video.There was a problem saving the video to {playlistName}', { playlistName }),
-    image: thumbnail.value,
+    image: toastThumbnail.value,
+    icon: ['fas', 'bookmark'],
   })
 }
 
@@ -1434,7 +1443,8 @@ async function removeFromQuickBookmarkPlaylist() {
     message: removed
       ? t('Video.Video has been removed from {playlistName}', { playlistName })
       : t('Video.There was a problem removing the video from {playlistName}', { playlistName }),
-    image: thumbnail.value
+    image: toastThumbnail.value,
+    icon: ['fas', 'trash'],
   })
 }
 

--- a/src/renderer/components/FtPlaylistAddVideoPrompt/FtPlaylistAddVideoPrompt.vue
+++ b/src/renderer/components/FtPlaylistAddVideoPrompt/FtPlaylistAddVideoPrompt.vue
@@ -373,7 +373,10 @@ function addSelectedToPlaylists() {
   const addedPlaylistIds = new Set()
 
   if (selectedPlaylistIdList.value.length === 0) {
-    showToast(t('User Playlists.AddVideoPrompt.Toast["You haven\'t selected any playlist yet."]'))
+    showToast({
+      message: t('User Playlists.AddVideoPrompt.Toast["You haven\'t selected any playlist yet."]'),
+      icon: ['fas', 'circle-exclamation'],
+    })
     return
   }
 
@@ -410,6 +413,7 @@ function addSelectedToPlaylists() {
     image: toBeAddedToPlaylistVideoList_.length === 1
       ? getVideoThumbnailUrl(toBeAddedToPlaylistVideoList_[0].videoId, backendPreference.value, currentInvidiousInstanceUrl.value, thumbnailPreference.value)
       : null,
+    icon: ['fac', 'playlist-check'],
   })
 
   hide()

--- a/src/renderer/components/FtProfileChannelList/FtProfileChannelList.vue
+++ b/src/renderer/components/FtProfileChannelList/FtProfileChannelList.vue
@@ -194,7 +194,7 @@ const deletePromptMessage = computed(() => {
 
 function displayDeletePrompt() {
   if (selected.size === 0) {
-    showToast(t('Profile.No channel(s) have been selected'))
+    showToast({ message: t('Profile.No channel(s) have been selected'), icon: ['fas', 'circle-exclamation'] })
   } else {
     showDeletePrompt.value = true
   }
@@ -223,7 +223,7 @@ function handleDeletePromptClick(value) {
         }
       })
 
-      showToast(t('Profile.Profile has been updated'))
+      showToast({ message: t('Profile.Profile has been updated'), icon: ['fas', 'user-check'] })
       selectNone()
     } else {
       /** @type {Profile} */
@@ -234,7 +234,7 @@ function handleDeletePromptClick(value) {
 
       store.dispatch('updateProfile', profile)
 
-      showToast(t('Profile.Profile has been updated'))
+      showToast({ message: t('Profile.Profile has been updated'), icon: ['fas', 'user-check'] })
       selectNone()
     }
   }

--- a/src/renderer/components/FtProfileEdit/FtProfileEdit.vue
+++ b/src/renderer/components/FtProfileEdit/FtProfileEdit.vue
@@ -197,7 +197,7 @@ const editOrCreateProfileNameLabel = computed(() => {
 
 function saveProfile() {
   if (profileName.value === '') {
-    showToast(t('Profile.Your profile name cannot be empty'))
+    showToast({ message: t('Profile.Your profile name cannot be empty'), icon: ['fas', 'circle-exclamation'] })
     return
   }
 
@@ -214,17 +214,20 @@ function saveProfile() {
 
   if (props.isNew) {
     store.dispatch('createProfile', profile)
-    showToast(t('Profile.Profile has been created'))
+    showToast({ message: t('Profile.Profile has been created'), icon: ['fas', 'user-plus'] })
     emit('new-profile-created')
   } else {
     store.dispatch('updateProfile', profile)
-    showToast(t('Profile.Profile has been updated'))
+    showToast({ message: t('Profile.Profile has been updated'), icon: ['fas', 'user-check'] })
   }
 }
 
 function setDefaultProfile() {
   store.dispatch('updateDefaultProfile', profileId.value)
-  showToast(t('Profile.Your default profile has been set to {profile}', { profile: translatedProfileName.value }))
+  showToast({
+    message: t('Profile.Your default profile has been set to {profile}', { profile: translatedProfileName.value }),
+    icon: ['fas', 'user-check'],
+  })
 }
 
 const DELETE_PROMPT_VALUES = ['delete', 'cancel']
@@ -254,11 +257,17 @@ function handleDeletePrompt(response) {
 
     store.dispatch('removeProfile', profileId.value)
 
-    showToast(t('Profile.Removed {profile} from your profiles', { profile: translatedProfileName.value }))
+    showToast({
+      message: t('Profile.Removed {profile} from your profiles', { profile: translatedProfileName.value }),
+      icon: ['fas', 'trash'],
+    })
 
     if (defaultProfile.value === profileId.value) {
       store.dispatch('updateDefaultProfile', MAIN_PROFILE_ID)
-      showToast(t('Profile.Your default profile has been changed to your primary profile'))
+      showToast({
+        message: t('Profile.Your default profile has been changed to your primary profile'),
+        icon: ['fas', 'user-check'],
+      })
     }
 
     emit('profile-deleted')

--- a/src/renderer/components/FtProfileFilterChannelsList/FtProfileFilterChannelsList.vue
+++ b/src/renderer/components/FtProfileFilterChannelsList/FtProfileFilterChannelsList.vue
@@ -220,7 +220,7 @@ function handleProfileFilterChange(profileId) {
 
 function addChannelsToProfile() {
   if (selected.size === 0) {
-    showToast(t('Profile.No channel(s) have been selected'))
+    showToast({ message: t('Profile.No channel(s) have been selected'), icon: ['fas', 'circle-exclamation'] })
   } else {
     const profileId = profileIdList.value[filteredProfileIndex.value]
     const subscriptions = profileList.value
@@ -232,7 +232,7 @@ function addChannelsToProfile() {
     profile.subscriptions.push(...deepCopy(subscriptions))
 
     store.dispatch('updateProfile', profile)
-    showToast(t('Profile.Profile has been updated'))
+    showToast({ message: t('Profile.Profile has been updated'), icon: ['fas', 'user-check'] })
     selectNone()
   }
 }

--- a/src/renderer/components/FtProfileSelector/FtProfileSelector.vue
+++ b/src/renderer/components/FtProfileSelector/FtProfileSelector.vue
@@ -203,7 +203,10 @@ function setActiveProfile(event) {
     if (targetProfile) {
       store.commit('setActiveProfile', profileId)
 
-      showToast(t('Profile.{profile} is now the active profile', { profile: translateProfileName(targetProfile) }))
+      showToast({
+        message: t('Profile.{profile} is now the active profile', { profile: translateProfileName(targetProfile) }),
+        icon: ['fas', 'user-check'],
+      })
     }
   }
 

--- a/src/renderer/components/FtSubscribeButton/FtSubscribeButton.vue
+++ b/src/renderer/components/FtSubscribeButton/FtSubscribeButton.vue
@@ -256,7 +256,7 @@ function handleSubscription(profile) {
       profileIds
     })
 
-    showToast(t('Channel.Added channel to your subscriptions'))
+    showToast({ message: t('Channel.Added channel to your subscriptions'), icon: ['fas', 'rss'] })
     emit('subscribed')
   }
 
@@ -312,10 +312,13 @@ function handleUnsubscription(profile) {
 
   store.dispatch('removeChannelFromProfiles', { channelId: props.channelId, profileIds })
 
-  showToast(t('Channel.Channel has been removed from your subscriptions'))
+  showToast({ message: t('Channel.Channel has been removed from your subscriptions'), icon: ['fas', 'trash'] })
 
   if (profile._id === MAIN_PROFILE_ID && profileIds.length > 1) {
-    showToast(t('Channel.Removed subscription from {count} other channel(s)', { count: profileIds.length - 1 }))
+    showToast({
+      message: t('Channel.Removed subscription from {count} other channel(s)', { count: profileIds.length - 1 }),
+      icon: ['fas', 'trash'],
+    })
   }
 }
 

--- a/src/renderer/components/FtToast/FtToast.css
+++ b/src/renderer/components/FtToast/FtToast.css
@@ -62,6 +62,12 @@
   border-radius: 6px;
 }
 
+.icon {
+  flex-shrink: 0;
+  font-size: 18px;
+  opacity: 0.85;
+}
+
 .message {
   margin: 0;
 }

--- a/src/renderer/components/FtToast/FtToast.vue
+++ b/src/renderer/components/FtToast/FtToast.vue
@@ -37,6 +37,12 @@
             alt=""
             draggable="false"
           >
+          <FontAwesomeIcon
+            v-else-if="toast.icon"
+            :icon="toast.icon"
+            class="icon"
+            fixed-width
+          />
           <p class="message">
             {{ toast.message }}
           </p>
@@ -47,6 +53,7 @@
 </template>
 
 <script setup>
+import { FontAwesomeIcon } from '@fortawesome/vue-fontawesome'
 import { nextTick, onBeforeUnmount, onMounted, reactive, ref } from 'vue'
 import { showToast, ToastEventBus } from '../../helpers/utils'
 
@@ -58,6 +65,7 @@ let removeShowToastListener = null
  * @property {string | (({elapsedMs: number, remainingMs: number}) => string)} message
  * @property {Function | null} action
  * @property {string | null} image
+ * @property {[string, string] | null} icon
  * @property {NodeJS.Timeout | number} timeout
  * @property {NodeJS.Timeout | number} interval
  * @property {number} id
@@ -82,9 +90,9 @@ function updateFullscreenTarget() {
 }
 
 /**
- * @param {CustomEvent<{ message: string | (({elapsedMs: number, remainingMs: number}) => string), time: number | null, action: Function | null, abortSignal: AbortSignal | null, image: string | null }>} event
+ * @param {CustomEvent<{ message: string | (({elapsedMs: number, remainingMs: number}) => string), time: number | null, action: Function | null, abortSignal: AbortSignal | null, image: string | null, icon: [string, string] | null }>} event
  */
-function open({ detail: { message, time, action, abortSignal, image } }) {
+function open({ detail: { message, time, action, abortSignal, image, icon } }) {
   const id = idCounter++
 
   time ||= 3000
@@ -95,6 +103,7 @@ function open({ detail: { message, time, action, abortSignal, image } }) {
     message,
     action,
     image: image ?? null,
+    icon: icon ?? null,
     timeout: 0,
     interval: 0,
     expiresAt: Date.now() + time,
@@ -283,7 +292,9 @@ onMounted(() => {
   updateFullscreenTarget()
 
   if (process.env.IS_ELECTRON) {
-    removeShowToastListener = window.ftElectron.handleShowToast(showToast)
+    removeShowToastListener = window.ftElectron.handleShowToast((message, time, icon) => {
+      showToast({ message, time, icon })
+    })
   }
 })
 

--- a/src/renderer/components/GeneralSettings/GeneralSettings.vue
+++ b/src/renderer/components/GeneralSettings/GeneralSettings.vue
@@ -688,12 +688,12 @@ function handleSetDefaultInstanceClick() {
   store.dispatch('updateDefaultInvidiousInstance', instance)
 
   const message = t('Default Invidious instance has been set to {instance}', { instance })
-  showToast(message)
+  showToast({ message: message, icon: ['fas', 'check'] })
 }
 
 function handleClearDefaultInstanceClick() {
   store.dispatch('updateDefaultInvidiousInstance', '')
-  showToast(t('Default Invidious instance has been cleared'))
+  showToast({ message: t('Default Invidious instance has been cleared'), icon: ['fas', 'trash'] })
 }
 </script>
 

--- a/src/renderer/components/PlaylistInfo/PlaylistInfo.vue
+++ b/src/renderer/components/PlaylistInfo/PlaylistInfo.vue
@@ -578,8 +578,13 @@ function handlePlaylistNameInput(input) {
 
 function toggleCopyVideosPrompt(force = false) {
   if (props.moreVideoDataAvailable && !isUserPlaylist.value && !force) {
-    showToast(t('User Playlists.SinglePlaylistView.Toast["Some videos in the playlist are not loaded yet. Click here to copy anyway."]'), 5000, () => {
-      toggleCopyVideosPrompt(true)
+    showToast({
+      message: t('User Playlists.SinglePlaylistView.Toast["Some videos in the playlist are not loaded yet. Click here to copy anyway."]'),
+      time: 5000,
+      action: () => {
+        toggleCopyVideosPrompt(true)
+      },
+      icon: ['fas', 'copy'],
     })
     return
   }
@@ -606,9 +611,15 @@ async function savePlaylistInfo() {
   }
   try {
     await store.dispatch('updatePlaylist', playlist)
-    showToast(t('User Playlists.SinglePlaylistView.Toast["Playlist has been updated."]'))
+    showToast({
+      message: t('User Playlists.SinglePlaylistView.Toast["Playlist has been updated."]'),
+      icon: ['fas', 'check'],
+    })
   } catch (e) {
-    showToast(t('User Playlists.SinglePlaylistView.Toast["There was an issue with updating this playlist."]'))
+    showToast({
+      message: t('User Playlists.SinglePlaylistView.Toast["There was an issue with updating this playlist."]'),
+      icon: ['fas', 'circle-exclamation'],
+    })
     console.error(e)
   } finally {
     exitEditMode()
@@ -631,11 +642,14 @@ function enterEditMode() {
 }
 
 function handleQuickBookmarkEnabledDisabledClick() {
-  showToast(t('User Playlists.SinglePlaylistView.Toast["This playlist is already being used for quick bookmark."]'))
+  showToast({
+    message: t('User Playlists.SinglePlaylistView.Toast["This playlist is already being used for quick bookmark."]'),
+    icon: ['fas', 'bookmark'],
+  })
 }
 
 function handlePlaylistDeleteDisabledClick() {
-  showToast(playlistDeletionDisabledLabel.value)
+  showToast({ message: playlistDeletionDisabledLabel.value, icon: ['fas', 'circle-exclamation'] })
 }
 
 const EXPORT_VALUES = [
@@ -700,11 +714,14 @@ async function exportAsFreeTubeDatabase() {
     )
 
     if (response) {
-      showToast(t('User Playlists.The playlist has been successfully exported'))
+      showToast({
+        message: t('User Playlists.The playlist has been successfully exported'),
+        icon: ['fas', 'file-download'],
+      })
     }
   } catch (error) {
     const message = t('Settings.Data Settings.Unable to write file')
-    showToast(`${message}: ${error}`)
+    showToast({ message: `${message}: ${error}`, icon: ['fas', 'circle-exclamation'] })
   }
 }
 
@@ -735,11 +752,14 @@ async function exportAsYouTubeCsv() {
     )
 
     if (response) {
-      showToast(t('User Playlists.The playlist has been successfully exported'))
+      showToast({
+        message: t('User Playlists.The playlist has been successfully exported'),
+        icon: ['fas', 'file-download'],
+      })
     }
   } catch (error) {
     const message = t('Settings.Data Settings.Unable to write file')
-    showToast(`${message}: ${error}`)
+    showToast({ message: `${message}: ${error}`, icon: ['fas', 'circle-exclamation'] })
   }
 }
 
@@ -764,11 +784,14 @@ async function exportAsListOfUrls() {
     )
 
     if (response) {
-      showToast(t('User Playlists.The playlist has been successfully exported'))
+      showToast({
+        message: t('User Playlists.The playlist has been successfully exported'),
+        icon: ['fas', 'file-download'],
+      })
     }
   } catch (error) {
     const message = t('Settings.Data Settings.Unable to write file')
-    showToast(`${message}: ${error}`)
+    showToast({ message: `${message}: ${error}`, icon: ['fas', 'circle-exclamation'] })
   }
 }
 
@@ -830,7 +853,10 @@ async function handleRemoveDuplicateVideosPromptAnswer(option) {
 
   const removedVideosCount = userPlaylistDuplicateItemCount.value
   if (removedVideosCount === 0) {
-    showToast(t('User Playlists.SinglePlaylistView.Toast["There were no videos to remove."]'))
+    showToast({
+      message: t('User Playlists.SinglePlaylistView.Toast["There were no videos to remove."]'),
+      icon: ['fas', 'circle-exclamation'],
+    })
     return
   }
 
@@ -843,11 +869,17 @@ async function handleRemoveDuplicateVideosPromptAnswer(option) {
   }
   try {
     await store.dispatch('updatePlaylist', playlist)
-    showToast(t('User Playlists.SinglePlaylistView.Toast.{videoCount} video(s) have been removed', {
-      videoCount: removedVideosCount
-    }, removedVideosCount))
+    showToast({
+      message: t('User Playlists.SinglePlaylistView.Toast.{videoCount} video(s) have been removed', {
+        videoCount: removedVideosCount
+      }, removedVideosCount),
+      icon: ['fas', 'trash'],
+    })
   } catch (e) {
-    showToast(t('User Playlists.SinglePlaylistView.Toast["There was an issue with updating this playlist."]'))
+    showToast({
+      message: t('User Playlists.SinglePlaylistView.Toast["There was an issue with updating this playlist."]'),
+      icon: ['fas', 'circle-exclamation'],
+    })
     console.error(e)
   }
 }
@@ -867,7 +899,10 @@ async function handleRemoveVideosOnWatchPromptAnswer(option) {
   const removedVideosCount = selectedUserPlaylist.value.videos.length - videosToWatch.length
 
   if (removedVideosCount === 0) {
-    showToast(t('User Playlists.SinglePlaylistView.Toast["There were no videos to remove."]'))
+    showToast({
+      message: t('User Playlists.SinglePlaylistView.Toast["There were no videos to remove."]'),
+      icon: ['fas', 'circle-exclamation'],
+    })
     return
   }
 
@@ -880,11 +915,17 @@ async function handleRemoveVideosOnWatchPromptAnswer(option) {
   }
   try {
     await store.dispatch('updatePlaylist', playlist)
-    showToast(t('User Playlists.SinglePlaylistView.Toast.{videoCount} video(s) have been removed', {
-      videoCount: removedVideosCount
-    }, removedVideosCount))
+    showToast({
+      message: t('User Playlists.SinglePlaylistView.Toast.{videoCount} video(s) have been removed', {
+        videoCount: removedVideosCount
+      }, removedVideosCount),
+      icon: ['fas', 'trash'],
+    })
   } catch (e) {
-    showToast(t('User Playlists.SinglePlaylistView.Toast["There was an issue with updating this playlist."]'))
+    showToast({
+      message: t('User Playlists.SinglePlaylistView.Toast["There was an issue with updating this playlist."]'),
+      icon: ['fas', 'circle-exclamation'],
+    })
     console.error(e)
   }
 }
@@ -899,7 +940,10 @@ function handleDeletePlaylistPromptAnswer(option) {
   if (option !== 'delete') { return }
 
   if (selectedUserPlaylist.value.protected) {
-    showToast(t('User Playlists.SinglePlaylistView.Toast["This playlist is protected and cannot be removed."]'))
+    showToast({
+      message: t('User Playlists.SinglePlaylistView.Toast["This playlist is protected and cannot be removed."]'),
+      icon: ['fas', 'circle-exclamation'],
+    })
   } else {
     store.dispatch('removePlaylist', props.id)
     router.push(
@@ -907,9 +951,12 @@ function handleDeletePlaylistPromptAnswer(option) {
         path: '/userPlaylists'
       }
     )
-    showToast(t('User Playlists.SinglePlaylistView.Toast["Playlist {playlistName} has been deleted."]', {
-      playlistName: props.title
-    }))
+    showToast({
+      message: t('User Playlists.SinglePlaylistView.Toast["Playlist {playlistName} has been deleted."]', {
+        playlistName: props.title
+      }),
+      icon: ['fas', 'trash'],
+    })
   }
 }
 
@@ -918,23 +965,28 @@ function enableQuickBookmarkForThisPlaylist() {
 
   store.dispatch('updateQuickBookmarkTargetPlaylistId', props.id)
   if (currentQuickBookmarkTargetPlaylist != null) {
-    showToast(
-      t('User Playlists.SinglePlaylistView.Toast["This playlist is now used for quick bookmark instead of {oldPlaylistName}. Click here to undo"]', {
+    showToast({
+      message: t('User Playlists.SinglePlaylistView.Toast["This playlist is now used for quick bookmark instead of {oldPlaylistName}. Click here to undo"]', {
         oldPlaylistName: currentQuickBookmarkTargetPlaylist.playlistName
       }),
-      5000,
-      () => {
+      time: 5000,
+      action: () => {
         store.dispatch('updateQuickBookmarkTargetPlaylistId', currentQuickBookmarkTargetPlaylist._id)
-        showToast(
-          t('User Playlists.SinglePlaylistView.Toast["Reverted to use {oldPlaylistName} for quick bookmark"]', {
+        showToast({
+          message: t('User Playlists.SinglePlaylistView.Toast["Reverted to use {oldPlaylistName} for quick bookmark"]', {
             oldPlaylistName: currentQuickBookmarkTargetPlaylist.playlistName
           }),
-          5000,
-        )
+          time: 5000,
+          icon: ['fas', 'undo'],
+        })
       },
-    )
+      icon: ['fas', 'bookmark'],
+    })
   } else {
-    showToast(t('User Playlists.SinglePlaylistView.Toast.This playlist is now used for quick bookmark'))
+    showToast({
+      message: t('User Playlists.SinglePlaylistView.Toast.This playlist is now used for quick bookmark'),
+      icon: ['fas', 'bookmark'],
+    })
   }
 }
 

--- a/src/renderer/components/PrivacySettings.vue
+++ b/src/renderer/components/PrivacySettings.vue
@@ -256,7 +256,10 @@ function parseDays(value, allowEmpty = false) {
 async function saveHistoryRetention() {
   const days = parseDays(historyRetentionDaysInput.value, true)
   if (days === null) {
-    showToast(t('Settings.Privacy Settings.Invalid History Retention Days'))
+    showToast({
+      message: t('Settings.Privacy Settings.Invalid History Retention Days'),
+      icon: ['fas', 'circle-exclamation'],
+    })
     return
   }
 
@@ -265,7 +268,7 @@ async function saveHistoryRetention() {
   if (days !== '') {
     await store.dispatch('removeHistoryOlderThan', days)
   }
-  showToast(t('Settings.Privacy Settings.History Retention Saved'))
+  showToast({ message: t('Settings.Privacy Settings.History Retention Saved'), icon: ['fas', 'check'] })
 }
 
 /** @type {import('vue').ComputedRef<boolean>} */
@@ -327,7 +330,10 @@ function handleSearchCache(option) {
 
   store.dispatch('clearSessionSearchHistory')
   store.dispatch('removeAllSearchHistoryEntries')
-  showToast(t('Settings.Privacy Settings.Search history and cache have been cleared'))
+  showToast({
+    message: t('Settings.Privacy Settings.Search history and cache have been cleared'),
+    icon: ['fas', 'trash'],
+  })
 }
 
 const showRemoveHistoryPrompt = ref(false)
@@ -341,7 +347,7 @@ function handleRemoveHistory(option) {
   if (option !== 'delete') { return }
 
   store.dispatch('removeAllHistory')
-  showToast(t('Settings.Privacy Settings.Watch history has been cleared'))
+  showToast({ message: t('Settings.Privacy Settings.Watch history has been cleared'), icon: ['fas', 'trash'] })
 }
 
 const showRemoveSubscriptionsPrompt = ref(false)
@@ -388,6 +394,6 @@ function handleRemovePlaylists(option) {
 
   store.dispatch('removeAllPlaylists')
   store.dispatch('updateQuickBookmarkTargetPlaylistId', 'favorites')
-  showToast(t('Settings.Privacy Settings.All playlists have been removed'))
+  showToast({ message: t('Settings.Privacy Settings.All playlists have been removed'), icon: ['fas', 'trash'] })
 }
 </script>

--- a/src/renderer/components/ProxySettings/ProxySettings.vue
+++ b/src/renderer/components/ProxySettings/ProxySettings.vue
@@ -324,7 +324,10 @@ async function handlePickVideoIpBlockRecoveryScriptPath() {
     }
   } catch (error) {
     console.error('Failed to select IP block recovery script:', error)
-    showToast(t('Settings.Proxy Settings.Failed to select IP block recovery script'))
+    showToast({
+      message: t('Settings.Proxy Settings.Failed to select IP block recovery script'),
+      icon: ['fas', 'circle-exclamation'],
+    })
   }
 }
 
@@ -366,7 +369,10 @@ async function testProxy() {
     dataAvailable.value = true
   } catch (error) {
     console.error('errored while testing proxy:', error)
-    showToast(t('Settings.Proxy Settings["Error getting network information. Is your proxy configured properly?"]'))
+    showToast({
+      message: t('Settings.Proxy Settings["Error getting network information. Is your proxy configured properly?"]'),
+      icon: ['fas', 'circle-exclamation'],
+    })
     dataAvailable.value = false
   } finally {
     if (!useProxy.value) {

--- a/src/renderer/components/SyncSettings/SyncSettings.vue
+++ b/src/renderer/components/SyncSettings/SyncSettings.vue
@@ -489,7 +489,7 @@ async function authenticate(mode) {
     username.value = store.getters.getSyncServerUsername
     password.value = ''
     privacyPassphrase.value = ''
-    showToast(t('Settings.Sync Settings.Sync completed'))
+    showToast({ message: t('Settings.Sync Settings.Sync completed'), icon: ['fas', 'sync'] })
   } catch (error) {
     localError.value = error.message
   }
@@ -500,7 +500,7 @@ async function syncNow() {
   localError.value = ''
   try {
     await store.dispatch('syncWithSyncServer')
-    showToast(t('Settings.Sync Settings.Sync completed'))
+    showToast({ message: t('Settings.Sync Settings.Sync completed'), icon: ['fas', 'sync'] })
   } catch (error) {
     if (error instanceof SyncServerDataLossError) {
       dataLossWarning.value = error
@@ -516,7 +516,7 @@ async function confirmDataLossSync() {
   localError.value = ''
   try {
     await store.dispatch('syncWithSyncServer', { allowDataLoss: true })
-    showToast(t('Settings.Sync Settings.Sync completed'))
+    showToast({ message: t('Settings.Sync Settings.Sync completed'), icon: ['fas', 'sync'] })
   } catch (error) {
     localError.value = error.message
   }
@@ -549,7 +549,7 @@ async function deleteAccount() {
   try {
     await store.dispatch('deleteSyncServerAccount', deleteAccountPassword.value)
     closeDeleteAccountPrompt()
-    showToast(t('Settings.Sync Settings.Account Deleted'))
+    showToast({ message: t('Settings.Sync Settings.Account Deleted'), icon: ['fas', 'trash'] })
   } catch (error) {
     deleteAccountError.value = error.message
   }

--- a/src/renderer/components/WatchVideoDownloadPrompt/WatchVideoDownloadPrompt.vue
+++ b/src/renderer/components/WatchVideoDownloadPrompt/WatchVideoDownloadPrompt.vue
@@ -264,7 +264,7 @@ function saveTemplate() {
   store.dispatch('updateYtDlpSelectedTemplate', `template:${name}`)
 
   newTemplateName.value = ''
-  showToast(t('Downloads.Template Saved', { name }))
+  showToast({ message: t('Downloads.Template Saved', { name }), icon: ['fas', 'save'] })
 }
 
 function deleteTemplate() {
@@ -326,7 +326,7 @@ async function startDownload() {
     downloadId.value = result.id
   } else if (result != null && 'error' in result) {
     // downloading the managed yt-dlp binary failed
-    showToast(t('Downloads.Download Failed'))
+    showToast({ message: t('Downloads.Download Failed'), icon: ['fas', 'circle-exclamation'] })
   }
 }
 

--- a/src/renderer/components/WatchVideoInfo/WatchVideoInfo.vue
+++ b/src/renderer/components/WatchVideoInfo/WatchVideoInfo.vue
@@ -748,6 +748,7 @@ async function addToQuickBookmarkPlaylist() {
       ? t('Video.Video has been saved to {playlistName}', { playlistName })
       : t('Video.There was a problem saving the video to {playlistName}', { playlistName }),
     image: quickBookmarkThumbnail.value,
+    icon: ['fas', 'bookmark'],
   })
 }
 
@@ -764,7 +765,8 @@ async function removeFromQuickBookmarkPlaylist() {
     message: removed
       ? t('Video.Video has been removed from {playlistName}', { playlistName })
       : t('Video.There was a problem removing the video from {playlistName}', { playlistName }),
-    image: quickBookmarkThumbnail.value
+    image: quickBookmarkThumbnail.value,
+    icon: ['fas', 'trash'],
   })
 }
 

--- a/src/renderer/components/WatchVideoPlaylist/WatchVideoPlaylist.vue
+++ b/src/renderer/components/WatchVideoPlaylist/WatchVideoPlaylist.vue
@@ -233,7 +233,7 @@ import FtPrompt from '../FtPrompt/FtPrompt.vue'
 
 import store from '../../store/index'
 
-import { copyToClipboard, deepCopy, getVideoThumbnailUrl, showToast, throttle } from '../../helpers/utils'
+import { deepCopy, getVideoThumbnailUrl, showApiErrorToast, showToast, throttle } from '../../helpers/utils'
 import {
   getLocalCachedFeedContinuation,
   getLocalPlaylist,
@@ -611,27 +611,27 @@ function getPlaylistInfoWithDelay() {
 function toggleLoop() {
   if (loopEnabled.value) {
     loopEnabled.value = false
-    showToast(t('Loop is now disabled'))
+    showToast({ message: t('Loop is now disabled'), icon: ['fas', 'retweet'] })
   } else {
     loopEnabled.value = true
-    showToast(t('Loop is now enabled'))
+    showToast({ message: t('Loop is now enabled'), icon: ['fas', 'retweet'] })
   }
 }
 
 function toggleShuffle() {
   if (shuffleEnabled.value) {
     shuffleEnabled.value = false
-    showToast(t('Shuffle is now disabled'))
+    showToast({ message: t('Shuffle is now disabled'), icon: ['fas', 'random'] })
   } else {
     shuffleEnabled.value = true
-    showToast(t('Shuffle is now enabled'))
+    showToast({ message: t('Shuffle is now enabled'), icon: ['fas', 'random'] })
     shufflePlaylistItems()
   }
 }
 
 function toggleReversePlaylist() {
   isLoading.value = true
-  showToast(t('The playlist has been reversed'))
+  showToast({ message: t('The playlist has been reversed'), icon: ['fas', 'exchange-alt'] })
 
   reversePlaylist.value = !reversePlaylist.value
   persistReversePlaylistState()
@@ -683,7 +683,10 @@ async function persistPlaylistOrder(items) {
   try {
     await store.dispatch('updatePlaylist', playlist)
   } catch (error) {
-    showToast(t('User Playlists.SinglePlaylistView.Toast["There was an issue with updating this playlist."]'))
+    showToast({
+      message: t('User Playlists.SinglePlaylistView.Toast["There was an issue with updating this playlist."]'),
+      icon: ['fas', 'circle-exclamation'],
+    })
     console.error(error)
   }
 }
@@ -728,10 +731,14 @@ async function removeVideoFromPlaylist(videoId, playlistItemId) {
     })
     showToast({
       message: t('User Playlists.SinglePlaylistView.Toast.Video has been removed'),
-      image: getVideoThumbnailUrl(videoId, backendPreference.value, currentInvidiousInstanceUrl.value, thumbnailPreference.value)
+      image: getVideoThumbnailUrl(videoId, backendPreference.value, currentInvidiousInstanceUrl.value, thumbnailPreference.value),
+      icon: ['fas', 'trash'],
     })
   } catch (error) {
-    showToast(t('User Playlists.SinglePlaylistView.Toast.There was a problem with removing this video'))
+    showToast({
+      message: t('User Playlists.SinglePlaylistView.Toast.There was a problem with removing this video'),
+      icon: ['fas', 'circle-exclamation'],
+    })
     console.error(error)
   }
 }
@@ -747,7 +754,10 @@ async function handleRemoveWatchedVideosPromptAnswer(option) {
     .map((video) => video.playlistItemId)
 
   if (playlistItemIds.length === 0) {
-    showToast(t('User Playlists.SinglePlaylistView.Toast["There were no videos to remove."]'))
+    showToast({
+      message: t('User Playlists.SinglePlaylistView.Toast["There were no videos to remove."]'),
+      icon: ['fas', 'circle-exclamation'],
+    })
     return
   }
 
@@ -756,11 +766,17 @@ async function handleRemoveWatchedVideosPromptAnswer(option) {
       _id: props.playlistId,
       playlistItemIds,
     })
-    showToast(t('User Playlists.SinglePlaylistView.Toast.{videoCount} video(s) have been removed', {
-      videoCount: playlistItemIds.length
-    }, playlistItemIds.length))
+    showToast({
+      message: t('User Playlists.SinglePlaylistView.Toast.{videoCount} video(s) have been removed', {
+        videoCount: playlistItemIds.length
+      }, playlistItemIds.length),
+      icon: ['fas', 'trash'],
+    })
   } catch (error) {
-    showToast(t('User Playlists.SinglePlaylistView.Toast["There was an issue with updating this playlist."]'))
+    showToast({
+      message: t('User Playlists.SinglePlaylistView.Toast["There was an issue with updating this playlist."]'),
+      icon: ['fas', 'circle-exclamation'],
+    })
     console.error(error)
   }
 }
@@ -822,7 +838,7 @@ function playNextVideo() {
     let doShufflePlaylistItems = false
 
     if (videoIsLastPlaylistItem.value && !loopEnabled.value) {
-      showToast(t('The playlist has ended. Enable loop to continue playing'))
+      showToast({ message: t('The playlist has ended. Enable loop to continue playing'), icon: ['fas', 'retweet'] })
       return
     }
     // loopEnabled = true
@@ -832,7 +848,7 @@ function playNextVideo() {
 
     router.push(routerPushPayload)
 
-    showToast(t('Playing Next Video'))
+    showToast({ message: t('Playing Next Video'), icon: ['fas', 'step-forward'] })
 
     if (doShufflePlaylistItems) {
       shufflePlaylistItems()
@@ -841,17 +857,17 @@ function playNextVideo() {
     const stopDueToLoopDisabled = videoIsLastPlaylistItem.value && !loopEnabled.value
 
     if (stopDueToLoopDisabled) {
-      showToast(t('The playlist has ended. Enable loop to continue playing'))
+      showToast({ message: t('The playlist has ended. Enable loop to continue playing'), icon: ['fas', 'retweet'] })
       return
     }
 
     router.push(routerPushPayload)
-    showToast(t('Playing Next Video'))
+    showToast({ message: t('Playing Next Video'), icon: ['fas', 'step-forward'] })
   }
 }
 
 function playPreviousVideo() {
-  showToast(t('Playing Previous Video'))
+  showToast({ message: t('Playing Previous Video'), icon: ['fas', 'step-backward'] })
 
   let videoIndex = videoIndexInPlaylistItems.value
 
@@ -952,11 +968,9 @@ async function getPlaylistInformationLocal() {
   } catch (err) {
     console.error(err)
     const errorMessage = t('Local API Error (Click to copy)')
-    showToast(`${errorMessage}: ${err}`, 10000, () => {
-      copyToClipboard(err)
-    })
+    showApiErrorToast(errorMessage, err)
     if (backendPreference.value === 'local' && backendFallback.value) {
-      showToast(t('Falling back to Invidious API'))
+      showToast({ message: t('Falling back to Invidious API'), icon: ['fas', 'exchange-alt'] })
       getPlaylistInformationInvidious()
     } else {
       isLoading.value = false
@@ -980,11 +994,9 @@ async function getPlaylistInformationInvidious() {
   } catch (err) {
     console.error(err)
     const errorMessage = t('Invidious API Error (Click to copy)')
-    showToast(`${errorMessage}: ${err}`, 10000, () => {
-      copyToClipboard(err)
-    })
+    showApiErrorToast(errorMessage, err)
     if (process.env.SUPPORTS_LOCAL_API && backendPreference.value === 'invidious' && backendFallback.value) {
-      showToast(t('Falling back to Local API'))
+      showToast({ message: t('Falling back to Local API'), icon: ['fas', 'exchange-alt'] })
       getPlaylistInformationLocal()
     } else {
       isLoading.value = false

--- a/src/renderer/components/WatchVideoPlaylist/WatchVideoPlaylist.vue
+++ b/src/renderer/components/WatchVideoPlaylist/WatchVideoPlaylist.vue
@@ -867,8 +867,6 @@ function playNextVideo() {
 }
 
 function playPreviousVideo() {
-  showToast({ message: t('Playing Previous Video'), icon: ['fas', 'step-backward'] })
-
   let videoIndex = videoIndexInPlaylistItems.value
 
   /*
@@ -893,6 +891,8 @@ function playPreviousVideo() {
   if (!targetPlaylistItem?.videoId) {
     return
   }
+
+  showToast({ message: t('Playing Previous Video'), icon: ['fas', 'step-backward'] })
 
   router.push(
     {

--- a/src/renderer/components/WatchVideoTranscript/WatchVideoTranscript.vue
+++ b/src/renderer/components/WatchVideoTranscript/WatchVideoTranscript.vue
@@ -374,11 +374,15 @@ async function saveTranscript() {
     )
 
     if (saved) {
-      showToast(t('Video.Transcript.Saved'))
+      showToast({ message: t('Video.Transcript.Saved'), icon: ['fas', 'save'] })
     }
   } catch (error) {
     console.error('Unable to save transcript', error)
-    showToast(`${t('Video.Transcript.Save Error')}: ${error}`, 5000)
+    showToast({
+      message: `${t('Video.Transcript.Save Error')}: ${error}`,
+      time: 5000,
+      icon: ['fas', 'circle-exclamation'],
+    })
   }
 }
 

--- a/src/renderer/components/ft-shaka-video-player/ft-shaka-video-player.js
+++ b/src/renderer/components/ft-shaka-video-player/ft-shaka-video-player.js
@@ -485,7 +485,7 @@ export default defineComponent({
     const sleepTimer = useSleepTimer({
       getVideoId: () => props.videoId,
       isPaused: () => video.value?.paused ?? true,
-      onExpired: () => showToast(t('Video.Player.Sleep Timer.Timer ended')),
+      onExpired: () => showToast({ message: t('Video.Player.Sleep Timer.Timer ended'), icon: ['fas', 'clock'] }),
       pausePlayback: () => video.value?.pause(),
       tabId,
     })
@@ -1756,7 +1756,7 @@ export default defineComponent({
         }
       } catch (error) {
         console.error(error)
-        showToast(t('Video.Player.SponsorBlock.VoteFailed'))
+        showToast({ message: t('Video.Player.SponsorBlock.VoteFailed'), icon: ['fas', 'circle-exclamation'] })
       } finally {
         sponsorBlockVotePending.value = null
         emitSponsorBlockInfoState()
@@ -4775,7 +4775,7 @@ export default defineComponent({
             })
           } catch (err) {
             console.error(`Parse failed: ${err.message}`)
-            showToast(t('Screenshot Error', { error: err.message }))
+            showToast({ message: t('Screenshot Error', { error: err.message }), icon: ['fas', 'circle-exclamation'] })
             canvas.remove()
             return
           }
@@ -4794,19 +4794,19 @@ export default defineComponent({
             )
 
             if (saved) {
-              showToast(t('Screenshot Success'))
+              showToast({ message: t('Screenshot Success'), icon: ['fas', 'file-image'] })
             }
           } else {
             const arrayBuffer = await blob.arrayBuffer()
 
             if (await window.ftElectron.writeToDefaultFolder(filenameWithExtension, arrayBuffer)) {
-              showToast(t('Screenshot Success'))
+              showToast({ message: t('Screenshot Success'), icon: ['fas', 'file-image'] })
             }
           }
         }
       } catch (error) {
         console.error(error)
-        showToast(t('Screenshot Error', { error }))
+        showToast({ message: t('Screenshot Error', { error }), icon: ['fas', 'circle-exclamation'] })
       } finally {
         canvas.remove()
 
@@ -5971,7 +5971,7 @@ export default defineComponent({
       }
 
       pendingMusicPlaybackRateToast = false
-      showToast(t('Video.Player.MusicPlaybackRateOverride'))
+      showToast({ message: t('Video.Player.MusicPlaybackRateOverride'), icon: ['fas', 'gauge'] })
       musicPlaybackRateToastShown = true
     }
 

--- a/src/renderer/components/ft-shaka-video-player/opentubex/useSponsorBlockSubmission.js
+++ b/src/renderer/components/ft-shaka-video-player/opentubex/useSponsorBlockSubmission.js
@@ -395,7 +395,7 @@ export function useSponsorBlockSubmission({
     if (clampedEndTime <= draft.startTime) {
       const errorMessage = t('Video.Player.SponsorBlock.EndTimeAfterStart')
       sponsorBlockSubmissionError.value = errorMessage
-      showToast(errorMessage)
+      showToast({ message: errorMessage, icon: ['fas', 'circle-exclamation'] })
       return
     }
 
@@ -474,14 +474,14 @@ export function useSponsorBlockSubmission({
     if (startTime == null) {
       const errorMessage = t('Video.Player.SponsorBlock.InvalidStartTime')
       sponsorBlockSubmissionError.value = errorMessage
-      showToast(errorMessage)
+      showToast({ message: errorMessage, icon: ['fas', 'circle-exclamation'] })
       return false
     }
 
     if (!isPointCategory && endTime != null && endTime <= startTime) {
       const errorMessage = t('Video.Player.SponsorBlock.EndTimeAfterStart')
       sponsorBlockSubmissionError.value = errorMessage
-      showToast(errorMessage)
+      showToast({ message: errorMessage, icon: ['fas', 'circle-exclamation'] })
       return false
     }
 
@@ -489,7 +489,7 @@ export function useSponsorBlockSubmission({
     if (currentDuration != null && (isPointCategory ? startTime : endTime) > currentDuration) {
       const errorMessage = t('Video.Player.SponsorBlock.EndTimeBeforeVideoEnd')
       sponsorBlockSubmissionError.value = errorMessage
-      showToast(errorMessage)
+      showToast({ message: errorMessage, icon: ['fas', 'circle-exclamation'] })
       return false
     }
 
@@ -678,7 +678,7 @@ export function useSponsorBlockSubmission({
 
     if (sponsorBlockHasIncompleteDraft.value) {
       sponsorBlockSubmissionError.value = t('Video.Player.SponsorBlock.CompleteSegmentsBeforeSubmitting')
-      showToast(sponsorBlockSubmissionError.value)
+      showToast({ message: sponsorBlockSubmissionError.value, icon: ['fas', 'circle-exclamation'] })
       return
     }
 
@@ -690,7 +690,7 @@ export function useSponsorBlockSubmission({
 
     if (sponsorBlockDraftSegments.value.some(segment => sponsorBlockDraftRequiresPreview(segment) && !segment.previewed)) {
       sponsorBlockSubmissionError.value = t('Video.Player.SponsorBlock.PreviewRequired')
-      showToast(sponsorBlockSubmissionError.value)
+      showToast({ message: sponsorBlockSubmissionError.value, icon: ['fas', 'circle-exclamation'] })
       return
     }
 
@@ -699,7 +699,7 @@ export function useSponsorBlockSubmission({
       const duplicateKey = `${segment.startTime}-${segment.endTime}-${segment.category}`
       if (duplicateKeySet.has(duplicateKey)) {
         sponsorBlockSubmissionError.value = t('Video.Player.SponsorBlock.DuplicateSegments')
-        showToast(sponsorBlockSubmissionError.value)
+        showToast({ message: sponsorBlockSubmissionError.value, icon: ['fas', 'circle-exclamation'] })
         return
       }
 
@@ -734,10 +734,10 @@ export function useSponsorBlockSubmission({
       pruneSponsorBlockDraftEditValues()
       closeSponsorBlockSubmissionMenu()
       await persistSponsorBlockDrafts()
-      showToast(t('Video.Player.SponsorBlock.SubmissionSuccess'))
+      showToast({ message: t('Video.Player.SponsorBlock.SubmissionSuccess'), icon: ['fas', 'check'] })
     } catch (error) {
       sponsorBlockSubmissionError.value = getSponsorBlockSubmitErrorMessage(error)
-      showToast(sponsorBlockSubmissionError.value, 5000)
+      showToast({ message: sponsorBlockSubmissionError.value, time: 5000, icon: ['fas', 'circle-exclamation'] })
     } finally {
       sponsorBlockSubmissionPending.value = false
     }

--- a/src/renderer/helpers/subscriptions.js
+++ b/src/renderer/helpers/subscriptions.js
@@ -7,10 +7,10 @@ import {
 } from './api/invidious'
 import { getLocalChannelCommunity, getLocalChannelLiveStreams, getLocalChannelVideos } from './api/local'
 import {
-  copyToClipboard,
   getChannelPlaylistId,
+  showApiErrorToast,
   showToast,
-  showToastOnAllTabs
+  showToastOnAllTabs,
 } from './utils'
 import { isHistoryEntryWatched } from './history'
 import { getValidSubscriptionChannels } from './subscription-channels'
@@ -204,9 +204,7 @@ export function showSubscriptionFetchError(channel, error, title) {
   const message = `${channelLabel}: ${error}`
 
   console.error(`Failed to fetch subscription channel ${channelLabel}`, error)
-  showToast(`${title}: ${message}`, 10000, () => {
-    copyToClipboard(message)
-  })
+  showApiErrorToast(title, message)
 }
 
 /**
@@ -458,7 +456,7 @@ async function refreshSubscriptionVideosFromRemoteUnlocked({
   setSubscriptionRefreshProgress(0)
 
   if (showStartToast) {
-    showToastOnAllTabs(t('Subscriptions.Refreshing Subscription Videos'), AUTO_REFRESH_TOAST_DURATION)
+    showToastOnAllTabs(t('Subscriptions.Refreshing Subscription Videos'), AUTO_REFRESH_TOAST_DURATION, ['fas', 'sync'])
   }
 
   const subscriptionUpdates = []
@@ -556,7 +554,7 @@ async function refreshSubscriptionShortsFromRemoteUnlocked({
   setSubscriptionRefreshProgress(0)
 
   if (showStartToast) {
-    showToastOnAllTabs(t('Subscriptions.Refreshing Subscription Shorts'), AUTO_REFRESH_TOAST_DURATION)
+    showToastOnAllTabs(t('Subscriptions.Refreshing Subscription Shorts'), AUTO_REFRESH_TOAST_DURATION, ['fas', 'sync'])
   }
 
   const subscriptionUpdates = []
@@ -640,7 +638,7 @@ async function refreshSubscriptionLiveFromRemoteUnlocked({
   setSubscriptionRefreshProgress(0)
 
   if (showStartToast) {
-    showToastOnAllTabs(t('Subscriptions.Refreshing Subscription Live Streams'), AUTO_REFRESH_TOAST_DURATION)
+    showToastOnAllTabs(t('Subscriptions.Refreshing Subscription Live Streams'), AUTO_REFRESH_TOAST_DURATION, ['fas', 'sync'])
   }
 
   const subscriptionUpdates = []
@@ -738,7 +736,7 @@ async function refreshSubscriptionPostsFromRemoteUnlocked({
   setSubscriptionRefreshProgress(0)
 
   if (showStartToast) {
-    showToastOnAllTabs(t('Subscriptions.Refreshing Subscription Posts'), AUTO_REFRESH_TOAST_DURATION)
+    showToastOnAllTabs(t('Subscriptions.Refreshing Subscription Posts'), AUTO_REFRESH_TOAST_DURATION, ['fas', 'sync'])
   }
 
   const subscriptionUpdates = []
@@ -822,7 +820,7 @@ async function getChannelPostsLocal(channel, t, errorChannels) {
     showSubscriptionFetchError(channel, err, t('Local API Error (Click to copy)'))
 
     if (store.getters.getBackendPreference === 'local' && store.getters.getBackendFallback) {
-      showToast(t('Falling back to Invidious API'))
+      showToast({ message: t('Falling back to Invidious API'), icon: ['fas', 'exchange-alt'] })
       return await getChannelPostsInvidious(channel, t, errorChannels)
     }
 
@@ -843,7 +841,7 @@ async function getChannelPostsInvidious(channel, t, errorChannels) {
       store.getters.getBackendPreference === 'invidious' &&
       store.getters.getBackendFallback
     ) {
-      showToast(t('Falling back to Local API'))
+      showToast({ message: t('Falling back to Local API'), icon: ['fas', 'exchange-alt'] })
       return await getChannelPostsLocal(channel, t, errorChannels)
     }
 
@@ -869,7 +867,7 @@ async function getChannelVideosLocalScraper(channel, t, errorChannels, failedAtt
         return await getChannelVideosLocalRSS(channel, t, errorChannels, failedAttempts + 1)
       case 1:
         if (store.getters.getBackendFallback) {
-          showToast(t('Falling back to Invidious API'))
+          showToast({ message: t('Falling back to Invidious API'), icon: ['fas', 'exchange-alt'] })
           return await getChannelVideosInvidiousScraper(channel, t, errorChannels, failedAttempts + 1)
         }
         return { videos: null }
@@ -914,7 +912,7 @@ async function getChannelVideosLocalRSS(channel, t, errorChannels, failedAttempt
         return await getChannelVideosLocalScraper(channel, t, errorChannels, failedAttempts + 1)
       case 1:
         if (store.getters.getBackendFallback) {
-          showToast(t('Falling back to Invidious API'))
+          showToast({ message: t('Falling back to Invidious API'), icon: ['fas', 'exchange-alt'] })
           return await getChannelVideosInvidiousRSS(channel, t, errorChannels, failedAttempts + 1)
         }
         return { videos: null }
@@ -947,7 +945,7 @@ async function getChannelVideosInvidiousScraper(channel, t, errorChannels, faile
         return await getChannelVideosInvidiousRSS(channel, t, errorChannels, failedAttempts + 1)
       case 1:
         if (process.env.SUPPORTS_LOCAL_API && store.getters.getBackendFallback) {
-          showToast(t('Falling back to Local API'))
+          showToast({ message: t('Falling back to Local API'), icon: ['fas', 'exchange-alt'] })
           return await getChannelVideosLocalScraper(channel, t, errorChannels, failedAttempts + 1)
         }
         return { videos: null }
@@ -988,7 +986,7 @@ async function getChannelVideosInvidiousRSS(channel, t, errorChannels, failedAtt
         return await getChannelVideosInvidiousScraper(channel, t, errorChannels, failedAttempts + 1)
       case 1:
         if (process.env.SUPPORTS_LOCAL_API && store.getters.getBackendFallback) {
-          showToast(t('Falling back to Local API'))
+          showToast({ message: t('Falling back to Local API'), icon: ['fas', 'exchange-alt'] })
           return await getChannelVideosLocalRSS(channel, t, errorChannels, failedAttempts + 1)
         }
         return { videos: null }
@@ -1029,7 +1027,7 @@ async function getChannelShortsLocal(channel, t, errorChannels, failedAttempts =
     showSubscriptionFetchError(channel, error, t('Local API Error (Click to copy)'))
 
     if (failedAttempts === 0 && store.getters.getBackendFallback) {
-      showToast(t('Falling back to Invidious API'))
+      showToast({ message: t('Falling back to Invidious API'), icon: ['fas', 'exchange-alt'] })
       return await getChannelShortsInvidious(channel, t, errorChannels, failedAttempts + 1)
     }
 
@@ -1062,7 +1060,7 @@ async function getChannelShortsInvidious(channel, t, errorChannels, failedAttemp
     showSubscriptionFetchError(channel, error, t('Invidious API Error (Click to copy)'))
 
     if (failedAttempts === 0 && process.env.SUPPORTS_LOCAL_API && store.getters.getBackendFallback) {
-      showToast(t('Falling back to Local API'))
+      showToast({ message: t('Falling back to Local API'), icon: ['fas', 'exchange-alt'] })
       return await getChannelShortsLocal(channel, t, errorChannels, failedAttempts + 1)
     }
 
@@ -1088,7 +1086,7 @@ async function getChannelLiveLocal(channel, t, errorChannels, failedAttempts = 0
         return await getChannelLiveLocalRSS(channel, t, errorChannels, failedAttempts + 1)
       case 1:
         if (store.getters.getBackendFallback) {
-          showToast(t('Falling back to Invidious API'))
+          showToast({ message: t('Falling back to Invidious API'), icon: ['fas', 'exchange-alt'] })
           return await getChannelLiveInvidious(channel, t, errorChannels, failedAttempts + 1)
         }
         return { videos: null }
@@ -1133,7 +1131,7 @@ async function getChannelLiveLocalRSS(channel, t, errorChannels, failedAttempts 
         return await getChannelLiveLocal(channel, t, errorChannels, failedAttempts + 1)
       case 1:
         if (store.getters.getBackendFallback) {
-          showToast(t('Falling back to Invidious API'))
+          showToast({ message: t('Falling back to Invidious API'), icon: ['fas', 'exchange-alt'] })
           return await getChannelLiveInvidiousRSS(channel, t, errorChannels, failedAttempts + 1)
         }
         return { videos: null }
@@ -1166,7 +1164,7 @@ async function getChannelLiveInvidious(channel, t, errorChannels, failedAttempts
         return await getChannelLiveInvidiousRSS(channel, t, errorChannels, failedAttempts + 1)
       case 1:
         if (process.env.SUPPORTS_LOCAL_API && store.getters.getBackendFallback) {
-          showToast(t('Falling back to Local API'))
+          showToast({ message: t('Falling back to Local API'), icon: ['fas', 'exchange-alt'] })
           return await getChannelLiveLocal(channel, t, errorChannels, failedAttempts + 1)
         }
         return { videos: null }
@@ -1207,7 +1205,7 @@ async function getChannelLiveInvidiousRSS(channel, t, errorChannels, failedAttem
         return await getChannelLiveInvidious(channel, t, errorChannels, failedAttempts + 1)
       case 1:
         if (process.env.SUPPORTS_LOCAL_API && store.getters.getBackendFallback) {
-          showToast(t('Falling back to Local API'))
+          showToast({ message: t('Falling back to Local API'), icon: ['fas', 'exchange-alt'] })
           return await getChannelLiveLocalRSS(channel, t, errorChannels, failedAttempts + 1)
         }
         return { videos: null }

--- a/src/renderer/helpers/utils.js
+++ b/src/renderer/helpers/utils.js
@@ -225,6 +225,9 @@ export function getVideoThumbnailUrl(videoId, backendPreference, currentInvidiou
 
 export const ToastEventBus = new EventTarget()
 
+/** Icon shown on toasts that report a failure */
+const ERROR_TOAST_ICON = ['fas', 'circle-exclamation']
+
 /**
  * @typedef {object} ToastOptions
  * @property {string | (({elapsedMs: number, remainingMs: number}) => string)} message
@@ -232,22 +235,25 @@ export const ToastEventBus = new EventTarget()
  * @property {Function} [action]
  * @property {AbortSignal} [abortSignal]
  * @property {string} [image] optional image URL (e.g. a video thumbnail) shown alongside the message
+ * @property {[string, string]} [icon] optional Font Awesome icon (e.g. `['fas', 'trash']`) shown
+ *   alongside the message, ignored when an image is given
  */
 
 /**
  * @param {string | (({elapsedMs: number, remainingMs: number}) => string) | ToastOptions} message
- *   the message to display, or an options object for more control (e.g. to show an image)
+ *   the message to display, or an options object for more control (e.g. to show an image or icon)
  * @param {number} time
  * @param {Function} action
  * @param {AbortSignal} abortSignal
  */
 export function showToast(message, time = null, action = null, abortSignal = null) {
   let image = null
+  let icon = null
 
   // Allow calling with a single options object while staying backwards compatible
   // with the positional (message, time, action, abortSignal) signature
   if (message !== null && typeof message === 'object') {
-    ({ message, time = null, action = null, abortSignal = null, image = null } = message)
+    ({ message, time = null, action = null, abortSignal = null, image = null, icon = null } = message)
   }
 
   // Sometimes caller just pass user setting based value in and it can be zero
@@ -263,6 +269,7 @@ export function showToast(message, time = null, action = null, abortSignal = nul
       action,
       abortSignal,
       image,
+      icon,
     }
   }))
 }
@@ -271,12 +278,13 @@ export function showToast(message, time = null, action = null, abortSignal = nul
  * Shows a non-interactive toast in every tab.
  * @param {string} message
  * @param {number} time
+ * @param {[string, string] | null} icon optional Font Awesome icon shown alongside the message
  */
-export function showToastOnAllTabs(message, time = null) {
+export function showToastOnAllTabs(message, time = null, icon = null) {
   if (process.env.IS_ELECTRON) {
-    window.ftElectron.showToastOnAllTabs(message, time)
+    window.ftElectron.showToastOnAllTabs(message, time, icon)
   } else {
-    showToast(message, time)
+    showToast({ message, time, icon })
   }
 }
 
@@ -303,7 +311,7 @@ export async function copyToClipboard(content, { messageOnSuccess = null, messag
       }
 
       if (messageOnSuccess !== null) {
-        showToast(messageOnSuccess)
+        showToast({ message: messageOnSuccess, icon: ['fas', 'copy'] })
       }
     } catch (error) {
       if (content instanceof Blob) {
@@ -311,15 +319,40 @@ export async function copyToClipboard(content, { messageOnSuccess = null, messag
       } else {
         console.error(`Failed to copy ${content} to clipboard`, error)
       }
-      if (messageOnError !== null) {
-        showToast(`${messageOnError}: ${error}`, 5000)
-      } else {
-        showToast(`${i18n.global.t('Clipboard.Copy failed')}: ${error}`, 5000)
-      }
+      showToast({
+        message: messageOnError !== null
+          ? `${messageOnError}: ${error}`
+          : `${i18n.global.t('Clipboard.Copy failed')}: ${error}`,
+        time: 5000,
+        icon: ERROR_TOAST_ICON,
+      })
     }
   } else {
-    showToast(i18n.global.t('Clipboard.Cannot access clipboard without a secure connection'), 5000)
+    showToast({
+      message: i18n.global.t('Clipboard.Cannot access clipboard without a secure connection'),
+      time: 5000,
+      icon: ERROR_TOAST_ICON,
+    })
   }
+}
+
+/**
+ * Shows an error toast for a failed request, which copies the error to the
+ * clipboard when clicked.
+ * @param {string} message the message describing what failed
+ * @param {Error | string} error the error to report and make copyable
+ * @param {(options: ToastOptions) => void} [show] toast function to use,
+ *   e.g. the tab-scoped one from {@link import('../composables/useTabToast').useTabToast}
+ */
+export function showApiErrorToast(message, error, show = showToast) {
+  show({
+    message: `${message}: ${error}`,
+    time: 10000,
+    action: () => {
+      copyToClipboard(error)
+    },
+    icon: ERROR_TOAST_ICON,
+  })
 }
 
 /**

--- a/src/renderer/main.js
+++ b/src/renderer/main.js
@@ -358,7 +358,10 @@ if (process.env.IS_ELECTRON) {
         ? i18n.global.t('Video.External Player.playlist')
         : i18n.global.t('Video.External Player.video')
 
-      showToast(i18n.global.t('Video.External Player.OpeningTemplate', { videoOrPlaylist, externalPlayer }))
+      showToast({
+        message: i18n.global.t('Video.External Player.OpeningTemplate', { videoOrPlaylist, externalPlayer }),
+        icon: ['fas', 'external-link-alt'],
+      })
     }
   )
 
@@ -366,13 +369,17 @@ if (process.env.IS_ELECTRON) {
     store.commit('upsertYtDlpDownload', download)
 
     if (download.status === 'completed') {
-      showToast(i18n.global.t('Downloads.Download Complete Template', { title: download.title }))
+      showToast({
+        message: i18n.global.t('Downloads.Download Complete Template', { title: download.title }),
+        icon: ['fas', 'download'],
+      })
     } else if (download.status === 'failed') {
-      showToast(
-        download.errorMessage === 'ENOENT'
+      showToast({
+        message: download.errorMessage === 'ENOENT'
           ? i18n.global.t('Downloads.yt-dlp Not Found')
-          : i18n.global.t('Downloads.Download Failed Template', { title: download.title })
-      )
+          : i18n.global.t('Downloads.Download Failed Template', { title: download.title }),
+        icon: ['fas', 'circle-exclamation'],
+      })
     }
   })
 }

--- a/src/renderer/store/modules/settings.js
+++ b/src/renderer/store/modules/settings.js
@@ -474,7 +474,7 @@ const sideEffectHandlers = {
         // Translating this string isn't necessary
         // because the user will always see it in the default locale
         // (in this case, English (US))
-        showToast(`Locale not found, defaulting to ${fallbackLocale}`)
+        showToast({ message: `Locale not found, defaulting to ${fallbackLocale}`, icon: ['fas', 'circle-exclamation'] })
       }
     }
 

--- a/src/renderer/views/Channel/Channel.vue
+++ b/src/renderer/views/Channel/Channel.vue
@@ -292,12 +292,12 @@ import FtButton from '../../components/FtButton/FtButton.vue'
 import store from '../../store/index'
 
 import {
-  copyToClipboard,
   extractNumberFromString,
-  showToast,
   getChannelPlaylistId,
   getIconForSortPreference,
-  removeFromArrayIfExists
+  removeFromArrayIfExists,
+  showApiErrorToast,
+  showToast,
 } from '../../helpers/utils'
 import { isNullOrEmpty } from '../../helpers/strings'
 import {
@@ -869,11 +869,9 @@ async function getChannelLocal() {
   } catch (err) {
     console.error(err)
     const errorMessage = t('Local API Error (Click to copy)')
-    showToast(`${errorMessage}: ${err}`, 10000, () => {
-      copyToClipboard(err)
-    })
+    showApiErrorToast(errorMessage, err)
     if (backendPreference.value === 'local' && backendFallback.value) {
-      showToast(t('Falling back to Invidious API'))
+      showToast({ message: t('Falling back to Invidious API'), icon: ['fas', 'exchange-alt'] })
       getChannelInfoInvidious()
     } else {
       isLoading.value = false
@@ -913,11 +911,9 @@ async function getChannelAboutLocal() {
   } catch (err) {
     console.error(err)
     const errorMessage = t('Local API Error (Click to copy)')
-    showToast(`${errorMessage}: ${err}`, 10000, () => {
-      copyToClipboard(err)
-    })
+    showApiErrorToast(errorMessage, err)
     if (backendPreference.value === 'local' && backendFallback.value) {
-      showToast(t('Falling back to Invidious API'))
+      showToast({ message: t('Falling back to Invidious API'), icon: ['fas', 'exchange-alt'] })
       getChannelInfoInvidious()
     } else {
       isLoading.value = false
@@ -973,9 +969,7 @@ function getChannelHomeLocal() {
   } catch (err) {
     console.error(err)
     const errorMessage = t('Local API Error (Click to copy)')
-    showToast(`${errorMessage}: ${err}`, 10000, () => {
-      copyToClipboard(err)
-    })
+    showApiErrorToast(errorMessage, err)
   }
 }
 
@@ -1070,12 +1064,10 @@ async function getChannelInfoInvidious() {
     console.error(err)
 
     const errorMessage = t('Invidious API Error (Click to copy)')
-    showToast(`${errorMessage}: ${err}`, 10000, () => {
-      copyToClipboard(err)
-    })
+    showApiErrorToast(errorMessage, err)
 
     if (process.env.SUPPORTS_LOCAL_API && backendPreference.value === 'invidious' && backendFallback.value) {
-      showToast(t('Falling back to Local API'))
+      showToast({ message: t('Falling back to Local API'), icon: ['fas', 'exchange-alt'] })
       getChannelLocal()
     } else {
       isLoading.value = false
@@ -1187,11 +1179,9 @@ async function getChannelVideosLocal() {
 
     console.error(err)
     const errorMessage = t('Local API Error (Click to copy)')
-    showToast(`${errorMessage}: ${err}`, 10000, () => {
-      copyToClipboard(err)
-    })
+    showApiErrorToast(errorMessage, err)
     if (backendPreference.value === 'local' && backendFallback.value) {
-      showToast(t('Falling back to Invidious API'))
+      showToast({ message: t('Falling back to Invidious API'), icon: ['fas', 'exchange-alt'] })
       getChannelInfoInvidious()
     } else {
       isLoading.value = false
@@ -1223,9 +1213,7 @@ async function getChannelVideosLocalMore() {
   } catch (err) {
     console.error(err)
     const errorMessage = t('Local API Error (Click to copy)')
-    showToast(`${errorMessage}: ${err}`, 10000, () => {
-      copyToClipboard(err)
-    })
+    showApiErrorToast(errorMessage, err)
   }
 }
 
@@ -1263,9 +1251,7 @@ async function channelInvidiousVideos(sortByChanged = false) {
   } catch (err) {
     console.error(err)
     const errorMessage = t('Invidious API Error (Click to copy)')
-    showToast(`${errorMessage}: ${err}`, 10000, () => {
-      copyToClipboard(err)
-    })
+    showApiErrorToast(errorMessage, err)
   }
 }
 
@@ -1332,11 +1318,9 @@ async function getChannelShortsLocal() {
   } catch (err) {
     console.error(err)
     const errorMessage = t('Local API Error (Click to copy)')
-    showToast(`${errorMessage}: ${err}`, 10000, () => {
-      copyToClipboard(err)
-    })
+    showApiErrorToast(errorMessage, err)
     if (backendPreference.value === 'local' && backendFallback.value) {
-      showToast(t('Falling back to Invidious API'))
+      showToast({ message: t('Falling back to Invidious API'), icon: ['fas', 'exchange-alt'] })
       getChannelInfoInvidious()
     } else {
       isLoading.value = false
@@ -1364,9 +1348,7 @@ async function getChannelShortsLocalMore() {
   } catch (err) {
     console.error(err)
     const errorMessage = t('Local API Error (Click to copy)')
-    showToast(`${errorMessage}: ${err}`, 10000, () => {
-      copyToClipboard(err)
-    })
+    showApiErrorToast(errorMessage, err)
   }
 }
 
@@ -1408,9 +1390,7 @@ async function channelInvidiousShorts(sortByChanged = false) {
   } catch (err) {
     console.error(err)
     const errorMessage = t('Invidious API Error (Click to copy)')
-    showToast(`${errorMessage}: ${err}`, 10000, () => {
-      copyToClipboard(err)
-    })
+    showApiErrorToast(errorMessage, err)
   }
 }
 
@@ -1475,11 +1455,9 @@ async function getChannelLiveLocal() {
   } catch (err) {
     console.error(err)
     const errorMessage = t('Local API Error (Click to copy)')
-    showToast(`${errorMessage}: ${err}`, 10000, () => {
-      copyToClipboard(err)
-    })
+    showApiErrorToast(errorMessage, err)
     if (backendPreference.value === 'local' && backendFallback.value) {
-      showToast(t('Falling back to Invidious API'))
+      showToast({ message: t('Falling back to Invidious API'), icon: ['fas', 'exchange-alt'] })
       getChannelInfoInvidious()
     } else {
       isLoading.value = false
@@ -1499,9 +1477,7 @@ async function getChannelLiveLocalMore() {
   } catch (err) {
     console.error(err)
     const errorMessage = t('Local API Error (Click to copy)')
-    showToast(`${errorMessage}: ${err}`, 10000, () => {
-      copyToClipboard(err)
-    })
+    showApiErrorToast(errorMessage, err)
   }
 }
 
@@ -1539,9 +1515,7 @@ async function channelInvidiousLive(sortByChanged) {
   } catch (err) {
     console.error(err)
     const errorMessage = t('Invidious API Error (Click to copy)')
-    showToast(`${errorMessage}: ${err}`, 10000, () => {
-      copyToClipboard(err)
-    })
+    showApiErrorToast(errorMessage, err)
   }
 }
 
@@ -1607,11 +1581,9 @@ async function getChannelPlaylistsLocal() {
   } catch (err) {
     console.error(err)
     const errorMessage = t('Local API Error (Click to copy)')
-    showToast(`${errorMessage}: ${err}`, 10000, () => {
-      copyToClipboard(err)
-    })
+    showApiErrorToast(errorMessage, err)
     if (backendPreference.value === 'local' && backendFallback.value) {
-      showToast(t('Falling back to Invidious API'))
+      showToast({ message: t('Falling back to Invidious API'), icon: ['fas', 'exchange-alt'] })
       getPlaylistsInvidious()
     } else {
       isLoading.value = false
@@ -1632,9 +1604,7 @@ async function getChannelPlaylistsLocalMore() {
   } catch (err) {
     console.error(err)
     const errorMessage = t('Local API Error (Click to copy)')
-    showToast(`${errorMessage}: ${err}`, 10000, () => {
-      copyToClipboard(err)
-    })
+    showApiErrorToast(errorMessage, err)
   }
 }
 
@@ -1649,11 +1619,9 @@ async function getPlaylistsInvidious() {
   } catch (err) {
     console.error(err)
     const errorMessage = t('Invidious API Error (Click to copy)')
-    showToast(`${errorMessage}: ${err}`, 10000, () => {
-      copyToClipboard(err)
-    })
+    showApiErrorToast(errorMessage, err)
     if (process.env.SUPPORTS_LOCAL_API && backendPreference.value === 'invidious' && backendFallback.value) {
-      showToast(t('Falling back to Local API'))
+      showToast({ message: t('Falling back to Local API'), icon: ['fas', 'exchange-alt'] })
       getChannelPlaylistsLocal()
     } else {
       isLoading.value = false
@@ -1671,9 +1639,7 @@ async function getPlaylistsInvidiousMore() {
     console.error(err)
 
     const errorMessage = t('Invidious API Error (Click to copy)')
-    showToast(`${errorMessage}: ${err}`, 10000, () => {
-      copyToClipboard(err)
-    })
+    showApiErrorToast(errorMessage, err)
   }
 }
 
@@ -1711,12 +1677,10 @@ async function getChannelReleasesLocal() {
     console.error(err)
 
     const errorMessage = t('Local API Error (Click to copy)')
-    showToast(`${errorMessage}: ${err}`, 10000, () => {
-      copyToClipboard(err)
-    })
+    showApiErrorToast(errorMessage, err)
 
     if (backendPreference.value === 'local' && backendFallback.value) {
-      showToast(t('Falling back to Invidious API'))
+      showToast({ message: t('Falling back to Invidious API'), icon: ['fas', 'exchange-alt'] })
       channelInvidiousReleases()
     } else {
       isLoading.value = false
@@ -1748,9 +1712,7 @@ async function getChannelReleasesLocalMore() {
   } catch (err) {
     console.error(err)
     const errorMessage = t('Local API Error (Click to copy)')
-    showToast(`${errorMessage}: ${err}`, 10000, () => {
-      copyToClipboard(err)
-    })
+    showApiErrorToast(errorMessage, err)
   }
 }
 
@@ -1765,11 +1727,9 @@ async function channelInvidiousReleases() {
   } catch (err) {
     console.error(err)
     const errorMessage = t('Invidious API Error (Click to copy)')
-    showToast(`${errorMessage}: ${err}`, 10000, () => {
-      copyToClipboard(err)
-    })
+    showApiErrorToast(errorMessage, err)
     if (process.env.SUPPORTS_LOCAL_API && backendPreference.value === 'invidious' && backendFallback.value) {
-      showToast(t('Falling back to Local API'))
+      showToast({ message: t('Falling back to Local API'), icon: ['fas', 'exchange-alt'] })
       getChannelReleasesLocal()
     } else {
       isLoading.value = false
@@ -1786,9 +1746,7 @@ async function channelInvidiousReleasesMore() {
   } catch (err) {
     console.error(err)
     const errorMessage = t('Invidious API Error (Click to copy)')
-    showToast(`${errorMessage}: ${err}`, 10000, () => {
-      copyToClipboard(err)
-    })
+    showApiErrorToast(errorMessage, err)
   }
 }
 
@@ -1814,11 +1772,9 @@ async function getChannelPodcastsLocal() {
   } catch (err) {
     console.error(err)
     const errorMessage = t('Local API Error (Click to copy)')
-    showToast(`${errorMessage}: ${err}`, 10000, () => {
-      copyToClipboard(err)
-    })
+    showApiErrorToast(errorMessage, err)
     if (backendPreference.value === 'local' && backendFallback.value) {
-      showToast(t('Falling back to Invidious API'))
+      showToast({ message: t('Falling back to Invidious API'), icon: ['fas', 'exchange-alt'] })
       channelInvidiousPodcasts()
     } else {
       isLoading.value = false
@@ -1839,9 +1795,7 @@ async function getChannelPodcastsLocalMore() {
   } catch (err) {
     console.error(err)
     const errorMessage = t('Local API Error (Click to copy)')
-    showToast(`${errorMessage}: ${err}`, 10000, () => {
-      copyToClipboard(err)
-    })
+    showApiErrorToast(errorMessage, err)
   }
 }
 
@@ -1857,12 +1811,10 @@ async function channelInvidiousPodcasts() {
     console.error(err)
 
     const errorMessage = t('Invidious API Error (Click to copy)')
-    showToast(`${errorMessage}: ${err}`, 10000, () => {
-      copyToClipboard(err)
-    })
+    showApiErrorToast(errorMessage, err)
 
     if (process.env.SUPPORTS_LOCAL_API && backendPreference.value === 'invidious' && backendFallback.value) {
-      showToast(t('Falling back to Local API'))
+      showToast({ message: t('Falling back to Local API'), icon: ['fas', 'exchange-alt'] })
       getChannelPodcastsLocal()
     } else {
       isLoading.value = false
@@ -1879,9 +1831,7 @@ async function channelInvidiousPodcastsMore() {
   } catch (err) {
     console.error(err)
     const errorMessage = t('Invidious API Error (Click to copy)')
-    showToast(`${errorMessage}: ${err}`, 10000, () => {
-      copyToClipboard(err)
-    })
+    showApiErrorToast(errorMessage, err)
   }
 }
 
@@ -1908,12 +1858,10 @@ async function getChannelCoursesLocal() {
     console.error(err)
 
     const errorMessage = t('Local API Error (Click to copy)')
-    showToast(`${errorMessage}: ${err}`, 10000, () => {
-      copyToClipboard(err)
-    })
+    showApiErrorToast(errorMessage, err)
 
     if (backendPreference.value === 'local' && backendFallback.value) {
-      showToast(t('Falling back to Invidious API'))
+      showToast({ message: t('Falling back to Invidious API'), icon: ['fas', 'exchange-alt'] })
       channelInvidiousCourses()
     } else {
       isLoading.value = false
@@ -1934,9 +1882,7 @@ async function getChannelCoursesLocalMore() {
   } catch (err) {
     console.error(err)
     const errorMessage = t('Local API Error (Click to copy)')
-    showToast(`${errorMessage}: ${err}`, 10000, () => {
-      copyToClipboard(err)
-    })
+    showApiErrorToast(errorMessage, err)
   }
 }
 
@@ -1952,12 +1898,10 @@ async function channelInvidiousCourses() {
     console.error(err)
 
     const errorMessage = t('Invidious API Error (Click to copy)')
-    showToast(`${errorMessage}: ${err}`, 10000, () => {
-      copyToClipboard(err)
-    })
+    showApiErrorToast(errorMessage, err)
 
     if (process.env.SUPPORTS_LOCAL_API && backendPreference.value === 'invidious' && backendFallback.value) {
-      showToast(t('Falling back to Local API'))
+      showToast({ message: t('Falling back to Local API'), icon: ['fas', 'exchange-alt'] })
       getChannelCoursesLocal()
     } else {
       isLoading.value = false
@@ -1974,9 +1918,7 @@ async function channelInvidiousCoursesMore() {
   } catch (err) {
     console.error(err)
     const errorMessage = t('Invidious API Error (Click to copy)')
-    showToast(`${errorMessage}: ${err}`, 10000, () => {
-      copyToClipboard(err)
-    })
+    showApiErrorToast(errorMessage, err)
   }
 }
 
@@ -2019,12 +1961,10 @@ async function getCommunityPostsLocal() {
     console.error(err)
 
     const errorMessage = t('Local API Error (Click to copy)')
-    showToast(`${errorMessage}: ${err}`, 10000, () => {
-      copyToClipboard(err)
-    })
+    showApiErrorToast(errorMessage, err)
 
     if (backendPreference.value === 'local' && backendFallback.value) {
-      showToast(t('Falling back to Invidious API'))
+      showToast({ message: t('Falling back to Invidious API'), icon: ['fas', 'exchange-alt'] })
       getCommunityPostsInvidious()
     } else {
       isLoading.value = false
@@ -2052,9 +1992,7 @@ async function getCommunityPostsLocalMore() {
   } catch (err) {
     console.error(err)
     const errorMessage = t('Local API Error (Click to copy)')
-    showToast(`${errorMessage}: ${err}`, 10000, () => {
-      copyToClipboard(err)
-    })
+    showApiErrorToast(errorMessage, err)
   }
 }
 
@@ -2080,12 +2018,10 @@ async function getCommunityPostsInvidious() {
     console.error(err)
 
     const errorMessage = t('Invidious API Error (Click to copy)')
-    showToast(`${errorMessage}: ${err}`, 10000, () => {
-      copyToClipboard(err)
-    })
+    showApiErrorToast(errorMessage, err)
 
     if (process.env.SUPPORTS_LOCAL_API && backendPreference.value === 'invidious' && backendFallback.value) {
-      showToast(t('Falling back to Local API'))
+      showToast({ message: t('Falling back to Local API'), icon: ['fas', 'exchange-alt'] })
       getCommunityPostsLocal()
     }
   }
@@ -2107,7 +2043,11 @@ async function searchChannelLocal() {
 
     if (isNewSearch) {
       if (!channelInstance.has_search) {
-        showToast(t('Channel.This channel does not allow searching'), 5000)
+        showToast({
+          message: t('Channel.This channel does not allow searching'),
+          time: 5000,
+          icon: ['fas', 'search'],
+        })
         showSearchBar.value = false
         return
       }
@@ -2142,13 +2082,11 @@ async function searchChannelLocal() {
     console.error(err)
     const errorMessage = t('Local API Error (Click to copy)')
 
-    showToast(`${errorMessage}: ${err}`, 10000, () => {
-      copyToClipboard(err)
-    })
+    showApiErrorToast(errorMessage, err)
 
     if (isNewSearch) {
       if (backendPreference.value === 'local' && backendFallback.value) {
-        showToast(t('Falling back to Invidious API'))
+        showToast({ message: t('Falling back to Invidious API'), icon: ['fas', 'exchange-alt'] })
         searchChannelInvidious()
       } else {
         isLoading.value = false
@@ -2173,12 +2111,10 @@ async function searchChannelInvidious() {
     console.error(err)
 
     const errorMessage = t('Invidious API Error (Click to copy)')
-    showToast(`${errorMessage}: ${err}`, 10000, () => {
-      copyToClipboard(err)
-    })
+    showApiErrorToast(errorMessage, err)
 
     if (process.env.SUPPORTS_LOCAL_API && backendPreference.value === 'invidious' && backendFallback.value) {
-      showToast(t('Falling back to Local API'))
+      showToast({ message: t('Falling back to Local API'), icon: ['fas', 'exchange-alt'] })
       searchChannelLocal()
     } else {
       isLoading.value = false

--- a/src/renderer/views/Hashtag/Hashtag.vue
+++ b/src/renderer/views/Hashtag/Hashtag.vue
@@ -67,7 +67,7 @@ import FtAutoLoadNextPageWrapper from '../../components/FtAutoLoadNextPageWrappe
 import store from '../../store/index'
 import { useRoute } from 'vue-router'
 import { getHashtagLocal, parseLocalListVideo } from '../../helpers/api/local'
-import { copyToClipboard, showToast } from '../../helpers/utils'
+import { showApiErrorToast, showToast } from '../../helpers/utils'
 import { getHashtagInvidious } from '../../helpers/api/invidious'
 import { useI18n } from 'vue-i18n'
 import { useTabTitle } from '../../tabs/TabContext'
@@ -140,11 +140,9 @@ async function getInvidiousHashtag(page = 1) {
   } catch (error) {
     console.error(error)
     const errorMessage = t('Invidious API Error (Click to copy)')
-    showToast(`${errorMessage}: ${error}`, 10000, () => {
-      copyToClipboard(error)
-    })
+    showApiErrorToast(errorMessage, error)
     if (process.env.SUPPORTS_LOCAL_API && backendPreference.value === 'invidious' && backendFallback.value) {
-      showToast(t('Falling back to Local API'))
+      showToast({ message: t('Falling back to Local API'), icon: ['fas', 'exchange-alt'] })
       resetData()
       getLocalHashtag()
     } else {
@@ -164,11 +162,9 @@ async function getLocalHashtag() {
   } catch (error) {
     console.error(error)
     const errorMessage = t('Local API Error (Click to copy)')
-    showToast(`${errorMessage}: ${error}`, 10000, () => {
-      copyToClipboard(error)
-    })
+    showApiErrorToast(errorMessage, error)
     if (backendPreference.value === 'local' && backendFallback.value) {
-      showToast(t('Falling back to Invidious API'))
+      showToast({ message: t('Falling back to Invidious API'), icon: ['fas', 'exchange-alt'] })
       resetData()
       getInvidiousHashtag()
     } else {
@@ -187,11 +183,9 @@ async function getLocalHashtagMore() {
   } catch (error) {
     console.error(error)
     const errorMessage = t('Local API Error (Click to copy)')
-    showToast(`${errorMessage}: ${error}`, 10000, () => {
-      copyToClipboard(error)
-    })
+    showApiErrorToast(errorMessage, error)
     if (backendPreference.value === 'local' && backendFallback.value) {
-      showToast(t('Falling back to Invidious API'))
+      showToast({ message: t('Falling back to Invidious API'), icon: ['fas', 'exchange-alt'] })
       resetData()
       getInvidiousHashtag()
     } else {

--- a/src/renderer/views/History/History.vue
+++ b/src/renderer/views/History/History.vue
@@ -245,7 +245,7 @@ async function deleteOldHistory() {
 
   await store.dispatch('removeHistoryOlderThan', days)
   closeHistoryCleanupPrompt()
-  showToast(t('History.History Older Than Days Removed', { days }))
+  showToast({ message: t('History.History Older Than Days Removed', { days }), icon: ['fas', 'trash'] })
 }
 
 const HISTORY_SORT_BY_VALUES = {
@@ -290,7 +290,7 @@ async function markAllAsWatched() {
   const markedCount = await store.dispatch('markAllHistoryAsWatched')
 
   if (markedCount > 0) {
-    showToast(t('History.All History Marked as Watched'))
+    showToast({ message: t('History.All History Marked as Watched'), icon: ['fas', 'eye'] })
   }
 }
 

--- a/src/renderer/views/Playlist/Playlist.vue
+++ b/src/renderer/views/Playlist/Playlist.vue
@@ -451,7 +451,10 @@ function getPlaylistInfo() {
     if (selectedUserPlaylist.value != null) {
       parseUserPlaylist(selectedUserPlaylist.value)
     } else {
-      showTabToast(t('User Playlists.SinglePlaylistView.Toast.This playlist does not exist'))
+      showTabToast({
+        message: t('User Playlists.SinglePlaylistView.Toast.This playlist does not exist'),
+        icon: ['fas', 'circle-exclamation'],
+      })
     }
   } else {
     if (!process.env.SUPPORTS_LOCAL_API || backendPreference.value === 'invidious') {
@@ -655,7 +658,11 @@ function getPlaylistItemsWithDuration() {
 
   // Show notice if not already shown before returning playlist items
   if (anyVideoMissingDuration && !alreadyShownNotice) {
-    showTabToast(t('User Playlists.SinglePlaylistView.Toast.This playlist has a video with a duration error'), 5000)
+    showTabToast({
+      message: t('User Playlists.SinglePlaylistView.Toast.This playlist has a video with a duration error'),
+      time: 5000,
+      icon: ['fas', 'circle-exclamation'],
+    })
     alreadyShownNotice = true
   }
 
@@ -730,7 +737,10 @@ function moveVideoUp(videoId, playlistItemId) {
   })
 
   if (index === 0) {
-    showToast(t('User Playlists.SinglePlaylistView.Toast["This video cannot be moved up."]'))
+    showToast({
+      message: t('User Playlists.SinglePlaylistView.Toast["This video cannot be moved up."]'),
+      icon: ['fas', 'circle-exclamation'],
+    })
     return
   }
 
@@ -748,7 +758,10 @@ function moveVideoUp(videoId, playlistItemId) {
     store.dispatch('updatePlaylist', playlist)
     playlistItems.value = playlistItems_
   } catch (e) {
-    showToast(t('User Playlists.SinglePlaylistView.Toast["There was an issue with updating this playlist."]'))
+    showToast({
+      message: t('User Playlists.SinglePlaylistView.Toast["There was an issue with updating this playlist."]'),
+      icon: ['fas', 'circle-exclamation'],
+    })
     console.error(e)
   }
 }
@@ -765,7 +778,10 @@ function moveVideoDown(videoId, playlistItemId) {
   })
 
   if (index + 1 >= playlistItems_.length) {
-    showToast(t('User Playlists.SinglePlaylistView.Toast["This video cannot be moved down."]'))
+    showToast({
+      message: t('User Playlists.SinglePlaylistView.Toast["This video cannot be moved down."]'),
+      icon: ['fas', 'circle-exclamation'],
+    })
     return
   }
 
@@ -783,7 +799,10 @@ function moveVideoDown(videoId, playlistItemId) {
     store.dispatch('updatePlaylist', playlist)
     playlistItems.value = playlistItems_
   } catch (e) {
-    showToast(t('User Playlists.SinglePlaylistView.Toast["There was an issue with updating this playlist."]'))
+    showToast({
+      message: t('User Playlists.SinglePlaylistView.Toast["There was an issue with updating this playlist."]'),
+      icon: ['fas', 'circle-exclamation'],
+    })
     console.error(e)
   }
 }
@@ -811,7 +830,10 @@ function onDragVideoEnd() {
       store.dispatch('updatePlaylist', playlist)
       playlistItems.value = tempShownPlaylistItems.value
     } catch (e) {
-      showToast(t('User Playlists.SinglePlaylistView.Toast["There was an issue with updating this playlist."]'))
+      showToast({
+        message: t('User Playlists.SinglePlaylistView.Toast["There was an issue with updating this playlist."]'),
+        icon: ['fas', 'circle-exclamation'],
+      })
       console.error(e)
     }
   }
@@ -887,11 +909,15 @@ function removeVideoFromPlaylist(videoId, playlistItemId) {
           },
           abortSignal: undoToastAbortController.signal,
           image: getVideoThumbnailUrl(videoId, backendPreference.value, currentInvidiousInstanceUrl.value, thumbnailPreference.value),
+          icon: ['fas', 'trash'],
         })
       }
     }
   } catch (e) {
-    showToast(t('User Playlists.SinglePlaylistView.Toast.There was a problem with removing this video'))
+    showToast({
+      message: t('User Playlists.SinglePlaylistView.Toast.There was a problem with removing this video'),
+      icon: ['fas', 'circle-exclamation'],
+    })
     console.error(e)
   }
 }

--- a/src/renderer/views/Popular/Popular.vue
+++ b/src/renderer/views/Popular/Popular.vue
@@ -47,7 +47,7 @@ import FtRefreshWidget from '../../components/FtRefreshWidget/FtRefreshWidget.vu
 import store from '../../store/index'
 
 import { getInvidiousPopularFeed } from '../../helpers/api/invidious'
-import { copyToClipboard, getRelativeTimeFromDate, showToast } from '../../helpers/utils'
+import { getRelativeTimeFromDate, showApiErrorToast } from '../../helpers/utils'
 import { useI18n } from 'vue-i18n'
 import { KeyboardShortcuts } from '../../../constants'
 import { matchesKeyboardShortcut } from '../../helpers/keyboardShortcuts'
@@ -97,9 +97,7 @@ async function fetchPopularInfo() {
   } catch (err) {
     isLoading.value = false
     const errorMessage = t('Invidious API Error (Click to copy)')
-    showToast(`${errorMessage}: ${err}`, 10000, () => {
-      copyToClipboard(err)
-    })
+    showApiErrorToast(errorMessage, err)
   }
 }
 

--- a/src/renderer/views/Post.vue
+++ b/src/renderer/views/Post.vue
@@ -39,7 +39,7 @@ import store from '../store/index'
 
 import { getInvidiousCommunityPost } from '../helpers/api/invidious'
 import { getLocalCommunityPost } from '../helpers/api/local'
-import { copyToClipboard, showToast } from '../helpers/utils'
+import { showApiErrorToast, showToast } from '../helpers/utils'
 import { useTabTitle } from '../tabs/TabContext'
 
 const { t } = useI18n()
@@ -107,11 +107,9 @@ async function loadDataLocalAsync() {
   } catch (error) {
     console.error(error)
     const errorMessage = t('Local API Error (Click to copy)')
-    showToast(`${errorMessage}: ${error}`, 10000, () => {
-      copyToClipboard(error)
-    })
+    showApiErrorToast(errorMessage, error)
     if (backendPreference.value === 'local' && backendFallback.value) {
-      showToast(t('Falling back to Invidious API'))
+      showToast({ message: t('Falling back to Invidious API'), icon: ['fas', 'exchange-alt'] })
       await loadDataInvidiousAsync()
     } else {
       isLoading.value = false
@@ -127,12 +125,10 @@ async function loadDataInvidiousAsync() {
   } catch (error) {
     console.error(error)
     const errorMessage = t('Invidious API Error (Click to copy)')
-    showToast(`${errorMessage}: ${error}`, 10000, () => {
-      copyToClipboard(error)
-    })
+    showApiErrorToast(errorMessage, error)
 
     if (process.env.SUPPORTS_LOCAL_API && backendPreference.value === 'invidious' && backendFallback.value) {
-      showToast(t('Falling back to Local API'))
+      showToast({ message: t('Falling back to Local API'), icon: ['fas', 'exchange-alt'] })
       await loadDataLocalAsync()
     } else {
       isLoading.value = false

--- a/src/renderer/views/SearchPage/SearchPage.vue
+++ b/src/renderer/views/SearchPage/SearchPage.vue
@@ -59,8 +59,8 @@ import FtAutoLoadNextPageWrapper from '../../components/FtAutoLoadNextPageWrappe
 import store from '../../store'
 
 import {
-  copyToClipboard,
   searchFiltersMatch,
+  showApiErrorToast,
   showToast,
 } from '../../helpers/utils'
 import {
@@ -200,7 +200,10 @@ function updateSearchHistoryEntry(searchSettings) {
 function checkSearchCache(payload) {
   if (payload.query.length > SEARCH_CHAR_LIMIT) {
     console.warn(`Search character limit is: ${SEARCH_CHAR_LIMIT}`)
-    showToast(t('Search character limit', { searchCharacterLimit: SEARCH_CHAR_LIMIT }))
+    showToast({
+      message: t('Search character limit', { searchCharacterLimit: SEARCH_CHAR_LIMIT }),
+      icon: ['fas', 'circle-exclamation'],
+    })
     return
   }
 
@@ -266,12 +269,10 @@ async function performSearchLocal(payload) {
     console.error(err)
 
     const errorMessage = t('Local API Error (Click to copy)')
-    showToast(`${errorMessage}: ${err}`, 10000, () => {
-      copyToClipboard(err)
-    })
+    showApiErrorToast(errorMessage, err)
 
     if (backendPreference.value === 'local' && backendFallback.value) {
-      showToast(t('Falling back to Invidious API'))
+      showToast({ message: t('Falling back to Invidious API'), icon: ['fas', 'exchange-alt'] })
       await performSearchInvidious(payload)
     } else {
       isLoading.value = false
@@ -305,12 +306,10 @@ async function getNextpageLocal(payload) {
     console.error(err)
 
     const errorMessage = t('Local API Error (Click to copy)')
-    showToast(`${errorMessage}: ${err}`, 10000, () => {
-      copyToClipboard(err)
-    })
+    showApiErrorToast(errorMessage, err)
 
     if (backendPreference.value === 'local' && backendFallback.value) {
-      showToast(t('Falling back to Invidious API'))
+      showToast({ message: t('Falling back to Invidious API'), icon: ['fas', 'exchange-alt'] })
       await performSearchInvidious(payload)
     } else {
       isLoading.value = false
@@ -363,12 +362,10 @@ async function performSearchInvidious(payload, options = { resetSearchPage: fals
     console.error(err)
 
     const errorMessage = t('Invidious API Error (Click to copy)')
-    showToast(`${errorMessage}: ${err}`, 10000, () => {
-      copyToClipboard(err)
-    })
+    showApiErrorToast(errorMessage, err)
 
     if (process.env.SUPPORTS_LOCAL_API && backendPreference.value === 'invidious' && backendFallback.value) {
-      showToast(t('Falling back to Local API'))
+      showToast({ message: t('Falling back to Local API'), icon: ['fas', 'exchange-alt'] })
       await performSearchLocal(payload)
     } else {
       isLoading.value = false
@@ -399,7 +396,7 @@ async function nextPage() {
         isLoadingMore.value = false
       }
     } else {
-      showToast(t('Search Filters.There are no more results for this search'))
+      showToast({ message: t('Search Filters.There are no more results for this search'), icon: ['fas', 'search'] })
     }
   } else {
     isLoadingMore.value = true

--- a/src/renderer/views/Stats/Stats.vue
+++ b/src/renderer/views/Stats/Stats.vue
@@ -355,7 +355,7 @@ async function applyHistoricalAdjustment() {
   if (!adjusted) { return }
 
   showHistoricalAdjustment.value = false
-  showToast(t('Stats.Imported watch time adjusted'))
+  showToast({ message: t('Stats.Imported watch time adjusted'), icon: ['fas', 'chart-line'] })
 }
 
 /**
@@ -366,7 +366,7 @@ async function handleResetStats(option) {
   if (option !== 'reset') { return }
 
   await store.dispatch('clearWatchStats')
-  showToast(t('Stats.Reset success'))
+  showToast({ message: t('Stats.Reset success'), icon: ['fas', 'undo'] })
 }
 
 function toDateKey(date) {

--- a/src/renderer/views/Trending/Trending.vue
+++ b/src/renderer/views/Trending/Trending.vue
@@ -123,7 +123,7 @@ import FtRefreshWidget from '../../components/FtRefreshWidget/FtRefreshWidget.vu
 import store from '../../store/index'
 import { useTabContext } from '../../tabs/TabContext'
 
-import { copyToClipboard, getRelativeTimeFromDate } from '../../helpers/utils'
+import { getRelativeTimeFromDate, showApiErrorToast } from '../../helpers/utils'
 import { useTabToast } from '../../composables/useTabToast'
 import { getLocalTrending } from '../../helpers/api/local'
 import { KeyboardShortcuts } from '../../../constants'
@@ -214,9 +214,7 @@ async function getTrendingInfoLocal() {
   } catch (error) {
     console.error(error)
     const errorMessage = t('Local API Error (Click to copy)')
-    showTabToast(`${errorMessage}: ${error}`, 10000, () => {
-      copyToClipboard(error)
-    })
+    showApiErrorToast(errorMessage, error, showTabToast)
     isLoading.value[currentTab.value] = false
   }
 }

--- a/src/renderer/views/Watch/Watch.js
+++ b/src/renderer/views/Watch/Watch.js
@@ -21,12 +21,12 @@ import { hasReachedWatchedThreshold, isHistoryEntryWatched } from '../../helpers
 import {
   buildChaptersVttFile,
   buildVTTFileLocally,
-  copyToClipboard,
   extractNumberFromString,
   formatDurationAsTimestamp,
   formatNumber,
   getCachedOembedTitle,
   getOembedTitle,
+  showApiErrorToast,
   showToast,
   showToastOnAllTabs
 } from '../../helpers/utils'
@@ -642,7 +642,8 @@ export default defineComponent({
           message: removed
             ? this.$t('Video.Video has been removed from {playlistName}', { playlistName })
             : this.$t('Video.There was a problem removing the video from {playlistName}', { playlistName }),
-          image: this.toastThumbnail
+          image: this.toastThumbnail,
+          icon: ['fas', 'trash'],
         })
         return
       }
@@ -663,7 +664,8 @@ export default defineComponent({
         message: saved
           ? this.$t('Video.Video has been saved to {playlistName}', { playlistName })
           : this.$t('Video.There was a problem saving the video to {playlistName}', { playlistName }),
-        image: this.toastThumbnail
+        image: this.toastThumbnail,
+        icon: ['fas', 'bookmark'],
       })
     },
     handleChaptersOverlayChange(open) {
@@ -1439,10 +1441,11 @@ export default defineComponent({
             }
           } else {
             // video might be region locked or something else. This leads to no formats being available
-            this.showTabToast(
-              this.t('This video is unavailable because of missing formats. This can happen due to country unavailability.'),
-              7000
-            )
+            this.showTabToast({
+              message: this.t('This video is unavailable because of missing formats. This can happen due to country unavailability.'),
+              time: 7000,
+              icon: ['fas', 'circle-exclamation'],
+            })
             this.handleVideoEnded()
             return
           }
@@ -1512,10 +1515,8 @@ export default defineComponent({
         console.error(err)
         if (this.backendPreference === 'local' && this.backendFallback && !err.toString().includes('private') && !err.toString().includes('unavailable')) {
           const errorMessage = this.t('Local API Error (Click to copy)')
-          this.showTabToast(`${errorMessage}: ${err}`, 10000, () => {
-            copyToClipboard(err)
-          })
-          this.showTabToast(this.t('Falling back to Invidious API'))
+          showApiErrorToast(errorMessage, err, this.showTabToast)
+          this.showTabToast({ message: this.t('Falling back to Invidious API'), icon: ['fas', 'exchange-alt'] })
           this.getVideoInformationInvidious()
         } else {
           const didReload = await this.runIpBlockRecoveryScriptAndReload()
@@ -1717,10 +1718,8 @@ export default defineComponent({
           console.error(err)
           if (process.env.SUPPORTS_LOCAL_API && this.backendPreference === 'invidious' && this.backendFallback) {
             const errorMessage = this.t('Invidious API Error (Click to copy)')
-            this.showTabToast(`${errorMessage}: ${err}`, 10000, () => {
-              copyToClipboard(err)
-            })
-            this.showTabToast(this.t('Falling back to Local API'))
+            showApiErrorToast(errorMessage, err, this.showTabToast)
+            this.showTabToast({ message: this.t('Falling back to Local API'), icon: ['fas', 'exchange-alt'] })
             this.getVideoInformationLocal()
           } else {
             const didReload = await this.runIpBlockRecoveryScriptAndReload()
@@ -1762,26 +1761,30 @@ export default defineComponent({
       if (startedRecovery) {
         // IP block recovery affects the whole app (network level), so surface it
         // globally once, from the tab that atomically started the shared run.
-        showToastOnAllTabs(this.t('Settings.Proxy Settings.Running IP block recovery script'), longToastDurationMs)
+        showToastOnAllTabs(this.t('Settings.Proxy Settings.Running IP block recovery script'), longToastDurationMs, ['fas', 'shield-halved'])
       }
 
       try {
         const result = await window.ftElectron.executeIpBlockRecoveryScript(scriptPath)
         if (startedRecovery && result?.exitCode !== 0) {
           const exitCode = result?.exitCode == null ? 'unknown' : `${result.exitCode}`
-          showToastOnAllTabs(this.t('Settings.Proxy Settings.IP block recovery script failed', { exitCode }), longToastDurationMs)
+          showToastOnAllTabs(this.t('Settings.Proxy Settings.IP block recovery script failed', { exitCode }), longToastDurationMs, ['fas', 'circle-exclamation'])
         } else if (startedRecovery) {
-          showToastOnAllTabs(this.t('Settings.Proxy Settings.IP block recovery script finished'), longToastDurationMs)
+          showToastOnAllTabs(this.t('Settings.Proxy Settings.IP block recovery script finished'), longToastDurationMs, ['fas', 'check'])
         }
       } catch (error) {
         console.error('IP block recovery script failed:', error)
         if (startedRecovery) {
-          showToastOnAllTabs(this.t('Settings.Proxy Settings.IP block recovery script failed', { exitCode: 'unknown' }), longToastDurationMs)
+          showToastOnAllTabs(this.t('Settings.Proxy Settings.IP block recovery script failed', { exitCode: 'unknown' }), longToastDurationMs, ['fas', 'circle-exclamation'])
         }
       }
 
       // The reload only affects this tab's video, so keep it scoped.
-      this.showTabToast(this.t('Settings.Proxy Settings.Reloading video after IP block recovery'), longToastDurationMs)
+      this.showTabToast({
+        message: this.t('Settings.Proxy Settings.Reloading video after IP block recovery'),
+        time: longToastDurationMs,
+        icon: ['fas', 'sync'],
+      })
       await this.reloadView()
       return true
     },
@@ -2041,7 +2044,7 @@ export default defineComponent({
     handleWatchProgressManualSave() {
       // Should be called by manual action, settings should be checked in UI
       this._saveWatchProgress()
-      showToast(this.t('Video.Watched Progress Saved'))
+      showToast({ message: this.t('Video.Watched Progress Saved'), icon: ['fas', 'save'] })
     },
     handleChannelPlaybackSpeedManualSave() {
       // Should be called by manual action, settings should be checked in UI
@@ -2051,7 +2054,7 @@ export default defineComponent({
       }
 
       this.saveChannelPlaybackSpeed(this.currentPlaybackRate)
-      showToast(this.t('Video.Channel Playback Speed Saved'))
+      showToast({ message: this.t('Video.Channel Playback Speed Saved'), icon: ['fas', 'gauge'] })
     },
     handleChannelVideoQualityManualSave() {
       // Should be called by manual action, settings should be checked in UI
@@ -2061,7 +2064,7 @@ export default defineComponent({
       }
 
       if (this.saveChannelVideoQuality(this.currentVideoQuality)) {
-        showToast(this.t('Video.Channel Video Quality Saved'))
+        showToast({ message: this.t('Video.Channel Video Quality Saved'), icon: ['fas', 'film'] })
       }
     },
     handleWatchProgressAutoSave() {
@@ -2302,7 +2305,10 @@ export default defineComponent({
       }
 
       if (this.manifestSrc === null) {
-        showToast(this.t('Change Format.Dash formats are not available for this video'))
+        showToast({
+          message: this.t('Change Format.Dash formats are not available for this video'),
+          icon: ['fas', 'circle-exclamation'],
+        })
         return
       }
 
@@ -2315,7 +2321,10 @@ export default defineComponent({
       }
 
       if (this.isLive || this.isPostLiveDvr || this.legacyFormats.length === 0) {
-        showToast(this.t('Change Format.Legacy formats are not available for this video'))
+        showToast({
+          message: this.t('Change Format.Legacy formats are not available for this video'),
+          icon: ['fas', 'circle-exclamation'],
+        })
         return
       }
 
@@ -2332,7 +2341,10 @@ export default defineComponent({
         // The WEB HLS manifests only contain combined audio and video files, so we can't do audio only
         // The IOS HLS manifests have audio-only streams
           this.manifestMimeType === MANIFEST_TYPE_HLS && !this.manifestSrc.includes('/demuxed/1'))) {
-        showToast(this.t('Change Format.Audio formats are not available for this video'))
+        showToast({
+          message: this.t('Change Format.Audio formats are not available for this video'),
+          icon: ['fas', 'circle-exclamation'],
+        })
         return
       }
 
@@ -2367,13 +2379,15 @@ export default defineComponent({
       }
 
       if (this.blockVideoAutoplay) {
-        showToast(this.t('Autoplay Interruption Timer',
-          this.defaultAutoplayInterruptionIntervalHours,
-          {
-            autoplayInterruptionIntervalHours: this.defaultAutoplayInterruptionIntervalHours
-          }),
-        3_600_000
-        )
+        showToast({
+          message: this.t('Autoplay Interruption Timer',
+            this.defaultAutoplayInterruptionIntervalHours,
+            {
+              autoplayInterruptionIntervalHours: this.defaultAutoplayInterruptionIntervalHours
+            }),
+          time: 3_600_000,
+          icon: ['fas', 'clock'],
+        })
         this.resetAutoplayInterruptionTimeout()
         return
       }
@@ -2450,7 +2464,7 @@ export default defineComponent({
         this.tabRouter.push({
           path: `/watch/${nextVideoId}`
         })
-        showToast(this.t('Playing Next Video'))
+        showToast({ message: this.t('Playing Next Video'), icon: ['fas', 'step-forward'] })
       }
     },
 
@@ -2466,7 +2480,7 @@ export default defineComponent({
         this.tabRouter.push({
           path: `/watch/${this.nextRecommendedVideo.videoId}`
         })
-        showToast(this.t('Playing Next Video'))
+        showToast({ message: this.t('Playing Next Video'), icon: ['fas', 'step-forward'] })
       }
     },
 
@@ -2478,7 +2492,7 @@ export default defineComponent({
 
       this.$store.commit('removeVideoFromWatchQueue', nextVideo.queueItemId)
       this.tabRouter.push({ path: `/watch/${nextVideo.videoId}` })
-      showToast(this.t('Playing Next Video'))
+      showToast({ message: this.t('Playing Next Video'), icon: ['fas', 'step-forward'] })
       return true
     },
 
@@ -2495,7 +2509,7 @@ export default defineComponent({
       this.autoplayCountdown = null
 
       if (!hideToast) {
-        showToast(this.t('Canceled next video autoplay'))
+        showToast({ message: this.t('Canceled next video autoplay'), icon: ['fas', 'times-circle'] })
       }
     },
 
@@ -3139,7 +3153,7 @@ export default defineComponent({
         ? playbackRate
         : this.currentPlaybackRate
       this.preserveTitleOnNextReload = true
-      this.showTabToast(toastMessage)
+      this.showTabToast({ message: toastMessage, icon: ['fas', 'sync'] })
 
       const timestamp = this.getTimestamp()
       if (timestamp > 0) {


### PR DESCRIPTION
Follow-up for #249.

## The bug

The playlist controls under the player use `FtAddToPlaylistDropdown`, which fired plain string toasts. Unlike the quick bookmark button right next to it, its toasts never showed the video thumbnail. The dropdown now resolves the thumbnail and passes it along, so saving/removing from the player controls looks the same as everywhere else.

## Toast icons

`showToast` gained an `icon` option (`icon: ['fas', 'trash']`), rendered when the toast has no thumbnail — so users with thumbnails hidden still get a meaningful glyph instead of a bare line of text. It is plumbed through `showToastOnAllTabs` and the cross-tab IPC path (validated in the main process).

Every toast in the app now passes a fitting icon: errors `circle-exclamation`, API fallbacks `exchange-alt`, playlist saves `bookmark`, removals `trash`, history `eye`/`eye-slash`, downloads `download`, subscriptions `rss`, profiles `user-check`, playback `step-forward`/`retweet`/`random`, and so on.

Two clean-ups came out of that pass:

- The 52 identical `showToast(\`${errorMessage}: ${err}\`, 10000, () => copyToClipboard(err))` blocks collapse into a shared `showApiErrorToast()` helper, which optionally takes the tab-scoped toast function for `Watch`/`Trending`.
- `FtListVideo`'s `thumbnail` is a grey placeholder image when thumbnails are hidden, which would have covered up the new icon. Its toasts now use a `toastThumbnail` that yields `null` in that case, matching what `Watch.js` already did.

## Testing

- `pnpm run lint` clean, `pnpm run test:unit` 46/46, offline Playwright suite passes.
- Three new assertions in `e2e/tests/offline/video-actions.spec.mjs`: the dropdown toast carries the video thumbnail (fails without the fix), the icon fallback when thumbnails are hidden, and an icon on a toast that never has a thumbnail.