### PR TITLE
Add configurable toast positions

### DIFF
--- a/e2e/tests/offline/settings.spec.mjs
+++ b/e2e/tests/offline/settings.spec.mjs
@@ -227,6 +227,13 @@ test.describe('invalid toast position', () => {
   test.use({ seed: { settings: { toastPosition: 'unsupported' } } })
 
   test('falls back to bottom left', async ({ page }) => {
+    await goTo(page, 'settings')
+
+    const positionSelect = page.locator('.select')
+      .filter({ hasText: 'Toast Position' })
+      .locator('select')
+    await expect(positionSelect).toHaveValue('bottom-left')
+
     await page.evaluate(() => {
       window.ftElectron.showToastOnAllTabs('Fallback toast', 10000)
     })

--- a/e2e/tests/offline/settings.spec.mjs
+++ b/e2e/tests/offline/settings.spec.mjs
@@ -162,6 +162,7 @@ test.describe('settings', () => {
 
     await positionSelect.selectOption('bottom-center')
     await expect(holder).toHaveClass(/position-bottom-center/)
+    await expect(holder).toHaveCSS('transform', 'none')
     toast = await showToast('Center toast dragged left')
     bounds = await toast.boundingBox()
     viewport = await viewportSize()
@@ -219,6 +220,20 @@ test.describe('settings', () => {
     await dragToast(toast, 100)
     await page.mouse.up()
     await expect(toast).toHaveCount(0)
+  })
+})
+
+test.describe('invalid toast position', () => {
+  test.use({ seed: { settings: { toastPosition: 'unsupported' } } })
+
+  test('falls back to bottom left', async ({ page }) => {
+    await page.evaluate(() => {
+      window.ftElectron.showToastOnAllTabs('Fallback toast', 10000)
+    })
+
+    const holder = page.locator('.toast-holder')
+    await expect(holder.locator('.toast', { hasText: 'Fallback toast' })).toBeVisible()
+    await expect(holder).toHaveClass(/position-bottom-left/)
   })
 })
 

--- a/e2e/tests/offline/settings.spec.mjs
+++ b/e2e/tests/offline/settings.spec.mjs
@@ -146,6 +146,8 @@ test.describe('settings', () => {
       }))
     }
 
+    const dismissDragDistance = 120
+
     await positionSelect.selectOption('bottom-left')
     await expect(holder).toHaveClass(/position-bottom-left/)
     let toast = await showToast('Left toast')
@@ -153,10 +155,10 @@ test.describe('settings', () => {
     let viewport = await viewportSize()
     expect(bounds.x).toBeLessThan(50)
     expect(bounds.y + bounds.height).toBeGreaterThan(viewport.height - 50)
-    await dragToast(toast, 100)
+    await dragToast(toast, dismissDragDistance)
     await page.mouse.up()
     await expect(toast).toBeVisible()
-    await dragToast(toast, -100)
+    await dragToast(toast, -dismissDragDistance)
     await page.mouse.up()
     await expect(toast).toHaveCount(0)
 
@@ -167,12 +169,12 @@ test.describe('settings', () => {
     bounds = await toast.boundingBox()
     viewport = await viewportSize()
     expect(bounds.x + bounds.width / 2).toBeCloseTo(viewport.width / 2, 0)
-    await dragToast(toast, -100)
+    await dragToast(toast, -dismissDragDistance)
     await page.mouse.up()
     await expect(toast).toHaveCount(0)
 
     toast = await showToast('Center toast dragged right')
-    await dragToast(toast, 100)
+    await dragToast(toast, dismissDragDistance)
     await page.mouse.up()
     await expect(toast).toHaveCount(0)
 
@@ -182,10 +184,10 @@ test.describe('settings', () => {
     bounds = await toast.boundingBox()
     viewport = await viewportSize()
     expect(bounds.x + bounds.width).toBeGreaterThan(viewport.width - 50)
-    await dragToast(toast, -100)
+    await dragToast(toast, -dismissDragDistance)
     await page.mouse.up()
     await expect(toast).toBeVisible()
-    await dragToast(toast, 100)
+    await dragToast(toast, dismissDragDistance)
     await page.mouse.up()
     await expect(toast).toHaveCount(0)
 
@@ -195,7 +197,7 @@ test.describe('settings', () => {
     bounds = await toast.boundingBox()
     expect(bounds.x).toBeLessThan(50)
     expect(bounds.y).toBeLessThan(50)
-    await dragToast(toast, -100)
+    await dragToast(toast, -dismissDragDistance)
     await page.mouse.up()
     await expect(toast).toHaveCount(0)
 
@@ -206,7 +208,7 @@ test.describe('settings', () => {
     viewport = await viewportSize()
     expect(bounds.x + bounds.width / 2).toBeCloseTo(viewport.width / 2, 0)
     expect(bounds.y).toBeLessThan(50)
-    await dragToast(toast, 100)
+    await dragToast(toast, dismissDragDistance)
     await page.mouse.up()
     await expect(toast).toHaveCount(0)
 
@@ -217,7 +219,7 @@ test.describe('settings', () => {
     viewport = await viewportSize()
     expect(bounds.x + bounds.width).toBeGreaterThan(viewport.width - 50)
     expect(bounds.y).toBeLessThan(50)
-    await dragToast(toast, 100)
+    await dragToast(toast, dismissDragDistance)
     await page.mouse.up()
     await expect(toast).toHaveCount(0)
   })

--- a/e2e/tests/offline/settings.spec.mjs
+++ b/e2e/tests/offline/settings.spec.mjs
@@ -110,6 +110,116 @@ test.describe('settings', () => {
     await expect(autoLoadToggle).not.toBeChecked()
     await expect(resetButton).toHaveCount(0)
   })
+
+  test('positions toasts and dismisses them towards the configured edge', async ({ page }) => {
+    await goTo(page, 'settings')
+
+    const positionSelect = page.locator('.select')
+      .filter({ hasText: 'Toast Position' })
+      .locator('select')
+    const holder = page.locator('.toast-holder')
+
+    async function showToast (message) {
+      await page.evaluate((text) => {
+        window.ftElectron.showToastOnAllTabs(text, 10000)
+      }, message)
+
+      const toast = holder.locator('.toast', { hasText: message })
+      await expect(toast).toBeVisible()
+      return toast
+    }
+
+    async function dragToast (toast, distance) {
+      const bounds = await toast.boundingBox()
+      const x = bounds.x + bounds.width / 2
+      const y = bounds.y + bounds.height / 2
+
+      await page.mouse.move(x, y)
+      await page.mouse.down()
+      await page.mouse.move(x + distance, y, { steps: 5 })
+    }
+
+    function viewportSize () {
+      return page.evaluate(() => ({
+        width: document.documentElement.clientWidth,
+        height: document.documentElement.clientHeight
+      }))
+    }
+
+    await positionSelect.selectOption('bottom-left')
+    await expect(holder).toHaveClass(/position-bottom-left/)
+    let toast = await showToast('Left toast')
+    let bounds = await toast.boundingBox()
+    let viewport = await viewportSize()
+    expect(bounds.x).toBeLessThan(50)
+    expect(bounds.y + bounds.height).toBeGreaterThan(viewport.height - 50)
+    await dragToast(toast, 100)
+    await page.mouse.up()
+    await expect(toast).toBeVisible()
+    await dragToast(toast, -100)
+    await page.mouse.up()
+    await expect(toast).toHaveCount(0)
+
+    await positionSelect.selectOption('bottom-center')
+    await expect(holder).toHaveClass(/position-bottom-center/)
+    toast = await showToast('Center toast dragged left')
+    bounds = await toast.boundingBox()
+    viewport = await viewportSize()
+    expect(bounds.x + bounds.width / 2).toBeCloseTo(viewport.width / 2, 0)
+    await dragToast(toast, -100)
+    await page.mouse.up()
+    await expect(toast).toHaveCount(0)
+
+    toast = await showToast('Center toast dragged right')
+    await dragToast(toast, 100)
+    await page.mouse.up()
+    await expect(toast).toHaveCount(0)
+
+    await positionSelect.selectOption('bottom-right')
+    await expect(holder).toHaveClass(/position-bottom-right/)
+    toast = await showToast('Right toast')
+    bounds = await toast.boundingBox()
+    viewport = await viewportSize()
+    expect(bounds.x + bounds.width).toBeGreaterThan(viewport.width - 50)
+    await dragToast(toast, -100)
+    await page.mouse.up()
+    await expect(toast).toBeVisible()
+    await dragToast(toast, 100)
+    await page.mouse.up()
+    await expect(toast).toHaveCount(0)
+
+    await positionSelect.selectOption('top-left')
+    await expect(holder).toHaveClass(/position-top-left/)
+    toast = await showToast('Top left toast')
+    bounds = await toast.boundingBox()
+    expect(bounds.x).toBeLessThan(50)
+    expect(bounds.y).toBeLessThan(50)
+    await dragToast(toast, -100)
+    await page.mouse.up()
+    await expect(toast).toHaveCount(0)
+
+    await positionSelect.selectOption('top-center')
+    await expect(holder).toHaveClass(/position-top-center/)
+    toast = await showToast('Top center toast')
+    bounds = await toast.boundingBox()
+    viewport = await viewportSize()
+    expect(bounds.x + bounds.width / 2).toBeCloseTo(viewport.width / 2, 0)
+    expect(bounds.y).toBeLessThan(50)
+    await dragToast(toast, 100)
+    await page.mouse.up()
+    await expect(toast).toHaveCount(0)
+
+    await positionSelect.selectOption('top-right')
+    await expect(holder).toHaveClass(/position-top-right/)
+    toast = await showToast('Top right toast')
+    bounds = await toast.boundingBox()
+    viewport = await viewportSize()
+    expect(bounds.x + bounds.width).toBeGreaterThan(viewport.width - 50)
+    expect(bounds.y).toBeLessThan(50)
+    await dragToast(toast, 100)
+    await page.mouse.up()
+    await expect(toast).toHaveCount(0)
+  })
 })
 
 test.describe('synced setting indicators', () => {

--- a/e2e/tests/offline/settings.spec.mjs
+++ b/e2e/tests/offline/settings.spec.mjs
@@ -130,11 +130,11 @@ test.describe('settings', () => {
     }
 
     async function dragToast (toast, distance) {
+      await toast.hover()
       const bounds = await toast.boundingBox()
       const x = bounds.x + bounds.width / 2
       const y = bounds.y + bounds.height / 2
 
-      await page.mouse.move(x, y)
       await page.mouse.down()
       await page.mouse.move(x + distance, y, { steps: 5 })
     }

--- a/src/renderer/components/FtToast/FtToast.css
+++ b/src/renderer/components/FtToast/FtToast.css
@@ -1,15 +1,47 @@
 .toast-holder {
   position: fixed;
-  inset-inline-start: 24px;
-  inset-block-end: 24px;
 
   /* Higher than any prompt */
   z-index: 300;
   display: flex;
   flex-direction: column;
-  align-items: flex-start;
   pointer-events: none;
 }
+
+.toast-holder.position-bottom-left,
+.toast-holder.position-bottom-center,
+.toast-holder.position-bottom-right {
+  inset-block-end: 24px;
+}
+
+.toast-holder.position-top-left,
+.toast-holder.position-top-center,
+.toast-holder.position-top-right {
+  inset-block-start: 24px;
+  flex-direction: column-reverse;
+}
+
+/* These settings name physical screen edges, independent of text direction. */
+/* stylelint-disable liberty/use-logical-spec */
+.toast-holder.position-bottom-left,
+.toast-holder.position-top-left {
+  left: 24px;
+  align-items: flex-start;
+}
+
+.toast-holder.position-bottom-center,
+.toast-holder.position-top-center {
+  left: 50%;
+  align-items: center;
+  transform: translateX(-50%);
+}
+
+.toast-holder.position-bottom-right,
+.toast-holder.position-top-right {
+  right: 24px;
+  align-items: flex-end;
+}
+/* stylelint-enable liberty/use-logical-spec */
 
 :global(body.playerFullWindow .toast-holder) {
   z-index: 1002;
@@ -78,15 +110,41 @@
   pointer-events: none;
 }
 
-.toast-enter-from,
-.toast-leave-to {
+.position-bottom-center .toast-enter-from,
+.position-bottom-center .toast-leave-to {
   opacity: 0;
   transform: translateY(15px) scale(0.95);
 }
 
-/* When dismissed by a leftward swipe, continue sliding off to the left */
+.position-top-center .toast-enter-from,
+.position-top-center .toast-leave-to {
+  opacity: 0;
+  transform: translateY(-15px) scale(0.95);
+}
+
+.position-bottom-left .toast-enter-from,
+.position-bottom-left .toast-leave-to,
+.position-top-left .toast-enter-from,
+.position-top-left .toast-leave-to {
+  opacity: 0;
+  transform: translateX(-15px) scale(0.95);
+}
+
+.position-bottom-right .toast-enter-from,
+.position-bottom-right .toast-leave-to,
+.position-top-right .toast-enter-from,
+.position-top-right .toast-leave-to {
+  opacity: 0;
+  transform: translateX(15px) scale(0.95);
+}
+
+/* When dismissed by a swipe, continue sliding off through that side */
 .toast-slot.dismiss-left.toast-leave-to {
   transform: translateX(-110%);
+}
+
+.toast-slot.dismiss-right.toast-leave-to {
+  transform: translateX(110%);
 }
 
 /* stack reflow when a toast is removed */

--- a/src/renderer/components/FtToast/FtToast.css
+++ b/src/renderer/components/FtToast/FtToast.css
@@ -31,9 +31,9 @@
 
 .toast-holder.position-bottom-center,
 .toast-holder.position-top-center {
-  left: 50%;
+  right: 0;
+  left: 0;
   align-items: center;
-  transform: translateX(-50%);
 }
 
 .toast-holder.position-bottom-right,

--- a/src/renderer/components/FtToast/FtToast.vue
+++ b/src/renderer/components/FtToast/FtToast.vue
@@ -7,13 +7,14 @@
       tag="div"
       name="toast"
       class="toast-holder"
+      :class="`position-${toastPosition}`"
       @before-leave="onBeforeLeave"
     >
       <div
         v-for="toast in toasts"
         :key="toast.id"
         class="toast-slot"
-        :class="{ 'dismiss-left': toast.dismissing }"
+        :class="toast.dismissDirection && `dismiss-${toast.dismissDirection}`"
       >
         <div
           class="toast"
@@ -47,8 +48,9 @@
 </template>
 
 <script setup>
-import { nextTick, onBeforeUnmount, onMounted, reactive, ref } from 'vue'
+import { computed, nextTick, onBeforeUnmount, onMounted, reactive, ref } from 'vue'
 import { showToast, ToastEventBus } from '../../helpers/utils'
+import store from '../../store'
 
 let idCounter = 0
 let removeShowToastListener = null
@@ -64,8 +66,8 @@ let removeShowToastListener = null
  * @property {number} expiresAt timestamp the toast is due to auto-dismiss at, used to reschedule after a drag
  * @property {boolean} dragging
  * @property {boolean} pointerMoved whether the pointer moved enough to count as a drag (suppresses the click action)
- * @property {number} dragOffset current horizontal (leftward, <= 0) drag offset in px
- * @property {boolean} dismissing whether the toast is being swiped off to the left (picks the slide-left leave animation)
+ * @property {number} dragOffset current horizontal drag offset in px
+ * @property {'left' | 'right' | null} dismissDirection side through which the toast is being dismissed
  * @property {number} [dragStartX] pointer x position where the current drag started
  */
 
@@ -76,6 +78,8 @@ const DRAG_DISMISS_THRESHOLD = 80
 const toasts = reactive([])
 /** @type {import('vue').Ref<Element|null>} */
 const fullscreenTarget = ref(null)
+/** @type {import('vue').ComputedRef<'bottom-left' | 'bottom-center' | 'bottom-right' | 'top-left' | 'top-center' | 'top-right'>} */
+const toastPosition = computed(() => store.getters.getToastPosition)
 
 function updateFullscreenTarget() {
   fullscreenTarget.value = document.fullscreenElement
@@ -101,7 +105,7 @@ function open({ detail: { message, time, action, abortSignal, image } }) {
     dragging: false,
     pointerMoved: false,
     dragOffset: 0,
-    dismissing: false
+    dismissDirection: null
   }
   let elapsed = 0
   const updateDelay = 1000
@@ -146,14 +150,14 @@ function performAction(toast) {
 
 /**
  * Dismisses a toast without running its action, for users who want it out of
- * the way. Flags it for the slide-left leave animation, then removes it on the
- * next tick so the `dismiss-left` class is rendered before the leave starts.
+ * the way. Flags it for the appropriate horizontal leave animation, then removes
+ * it on the next tick so the dismiss class is rendered before the leave starts.
  * Removing promptly (rather than after a timeout) lets the toasts above start
  * animating into the freed space without any delay.
  * @param {Toast} toast
  */
-function dismiss(toast) {
-  toast.dismissing = true
+function dismiss(toast, direction = toastPosition.value.endsWith('right') ? 'right' : 'left') {
+  toast.dismissDirection = direction
   nextTick(() => remove(toast))
 }
 
@@ -197,10 +201,17 @@ function onPointerDown(toast, event) {
 function onPointerMove(toast, event) {
   if (!toast.dragging) { return }
 
-  // Only allow dragging towards the left; ignore any rightward movement
-  toast.dragOffset = Math.min(0, event.clientX - toast.dragStartX)
+  const offset = event.clientX - toast.dragStartX
 
-  if (toast.dragOffset < -5) {
+  if (toastPosition.value.endsWith('left')) {
+    toast.dragOffset = Math.min(0, offset)
+  } else if (toastPosition.value.endsWith('right')) {
+    toast.dragOffset = Math.max(0, offset)
+  } else {
+    toast.dragOffset = offset
+  }
+
+  if (Math.abs(offset) > 5) {
     toast.pointerMoved = true
   }
 }
@@ -213,8 +224,8 @@ function onPointerUp(toast) {
 
   toast.dragging = false
 
-  if (toast.dragOffset < -DRAG_DISMISS_THRESHOLD) {
-    dismiss(toast)
+  if (Math.abs(toast.dragOffset) > DRAG_DISMISS_THRESHOLD) {
+    dismiss(toast, toast.dragOffset < 0 ? 'left' : 'right')
   } else {
     // Snap back into place and resume the auto-dismiss countdown for whatever
     // is left of the original lifetime. Keeping the deadline absolute matters
@@ -252,7 +263,7 @@ function dragStyle(toast) {
 
   return {
     transform: `translateX(${toast.dragOffset}px)`,
-    opacity: Math.max(0, 1 + toast.dragOffset / 200)
+    opacity: Math.max(0, 1 - Math.abs(toast.dragOffset) / 200)
   }
 }
 

--- a/src/renderer/components/FtToast/FtToast.vue
+++ b/src/renderer/components/FtToast/FtToast.vue
@@ -56,7 +56,7 @@
 <script setup>
 import { FontAwesomeIcon } from '@fortawesome/vue-fontawesome'
 import { computed, nextTick, onBeforeUnmount, onMounted, reactive, ref } from 'vue'
-import { TOAST_POSITION_VALUES } from '../../constants/toastPosition'
+import { normalizeToastPosition } from '../../constants/toastPosition'
 import { showToast, ToastEventBus } from '../../helpers/utils'
 import store from '../../store'
 
@@ -89,8 +89,7 @@ const toasts = reactive([])
 const fullscreenTarget = ref(null)
 /** @type {import('vue').ComputedRef<'bottom-left' | 'bottom-center' | 'bottom-right' | 'top-left' | 'top-center' | 'top-right'>} */
 const toastPosition = computed(() => {
-  const position = store.getters.getToastPosition
-  return TOAST_POSITION_VALUES.includes(position) ? position : 'bottom-left'
+  return normalizeToastPosition(store.getters.getToastPosition)
 })
 
 function updateFullscreenTarget() {

--- a/src/renderer/components/FtToast/FtToast.vue
+++ b/src/renderer/components/FtToast/FtToast.vue
@@ -56,6 +56,7 @@
 <script setup>
 import { FontAwesomeIcon } from '@fortawesome/vue-fontawesome'
 import { computed, nextTick, onBeforeUnmount, onMounted, reactive, ref } from 'vue'
+import { TOAST_POSITION_VALUES } from '../../constants/toastPosition'
 import { showToast, ToastEventBus } from '../../helpers/utils'
 import store from '../../store'
 
@@ -81,14 +82,6 @@ let removeShowToastListener = null
 
 /** Distance in px a toast must be dragged before it slides away instead of snapping back */
 const DRAG_DISMISS_THRESHOLD = 80
-const TOAST_POSITIONS = new Set([
-  'bottom-left',
-  'bottom-center',
-  'bottom-right',
-  'top-left',
-  'top-center',
-  'top-right'
-])
 
 /** @type {import('vue').Reactive<Toast[]>} */
 const toasts = reactive([])
@@ -97,7 +90,7 @@ const fullscreenTarget = ref(null)
 /** @type {import('vue').ComputedRef<'bottom-left' | 'bottom-center' | 'bottom-right' | 'top-left' | 'top-center' | 'top-right'>} */
 const toastPosition = computed(() => {
   const position = store.getters.getToastPosition
-  return TOAST_POSITIONS.has(position) ? position : 'bottom-left'
+  return TOAST_POSITION_VALUES.includes(position) ? position : 'bottom-left'
 })
 
 function updateFullscreenTarget() {

--- a/src/renderer/components/FtToast/FtToast.vue
+++ b/src/renderer/components/FtToast/FtToast.vue
@@ -81,13 +81,24 @@ let removeShowToastListener = null
 
 /** Distance in px a toast must be dragged before it slides away instead of snapping back */
 const DRAG_DISMISS_THRESHOLD = 80
+const TOAST_POSITIONS = new Set([
+  'bottom-left',
+  'bottom-center',
+  'bottom-right',
+  'top-left',
+  'top-center',
+  'top-right'
+])
 
 /** @type {import('vue').Reactive<Toast[]>} */
 const toasts = reactive([])
 /** @type {import('vue').Ref<Element|null>} */
 const fullscreenTarget = ref(null)
 /** @type {import('vue').ComputedRef<'bottom-left' | 'bottom-center' | 'bottom-right' | 'top-left' | 'top-center' | 'top-right'>} */
-const toastPosition = computed(() => store.getters.getToastPosition)
+const toastPosition = computed(() => {
+  const position = store.getters.getToastPosition
+  return TOAST_POSITIONS.has(position) ? position : 'bottom-left'
+})
 
 function updateFullscreenTarget() {
   fullscreenTarget.value = document.fullscreenElement

--- a/src/renderer/components/GeneralSettings/GeneralSettings.vue
+++ b/src/renderer/components/GeneralSettings/GeneralSettings.vue
@@ -282,6 +282,7 @@ import FtButton from '../FtButton/FtButton.vue'
 import store from '../../store/index'
 
 import allLocales from '../../../../static/locales/activeLocales.json'
+import { TOAST_POSITION_VALUES } from '../../constants/toastPosition'
 import { debounce, randomArrayItem, showToast } from '../../helpers/utils'
 import { translateWindowTitle } from '../../helpers/strings'
 
@@ -625,15 +626,6 @@ const reducedMotion = computed(() => store.getters.getReducedMotion)
 function updateReducedMotion(value) {
   store.dispatch('updateReducedMotion', value)
 }
-
-const TOAST_POSITION_VALUES = [
-  'bottom-left',
-  'bottom-center',
-  'bottom-right',
-  'top-left',
-  'top-center',
-  'top-right'
-]
 
 const toastPositionNames = computed(() => [
   t('Settings.General Settings.Toast Position.Bottom Left'),

--- a/src/renderer/components/GeneralSettings/GeneralSettings.vue
+++ b/src/renderer/components/GeneralSettings/GeneralSettings.vue
@@ -175,6 +175,15 @@
         @change="updateReducedMotion"
       />
       <FtSelect
+        :placeholder="t('Settings.General Settings.Toast Position.Toast Position')"
+        :value="toastPosition"
+        setting-key="toastPosition"
+        :select-names="toastPositionNames"
+        :select-values="TOAST_POSITION_VALUES"
+        :icon="['fas', 'message']"
+        @change="updateToastPosition"
+      />
+      <FtSelect
         v-if="SUPPORTS_LOCAL_API && (backendPreference === 'local' || backendFallback)"
         :placeholder="t('Settings.General Settings.Avoid translation.Avoid translation')"
         :value="avoidTranslation"
@@ -615,6 +624,34 @@ const reducedMotion = computed(() => store.getters.getReducedMotion)
  */
 function updateReducedMotion(value) {
   store.dispatch('updateReducedMotion', value)
+}
+
+const TOAST_POSITION_VALUES = [
+  'bottom-left',
+  'bottom-center',
+  'bottom-right',
+  'top-left',
+  'top-center',
+  'top-right'
+]
+
+const toastPositionNames = computed(() => [
+  t('Settings.General Settings.Toast Position.Bottom Left'),
+  t('Settings.General Settings.Toast Position.Bottom Center'),
+  t('Settings.General Settings.Toast Position.Bottom Right'),
+  t('Settings.General Settings.Toast Position.Top Left'),
+  t('Settings.General Settings.Toast Position.Top Center'),
+  t('Settings.General Settings.Toast Position.Top Right')
+])
+
+/** @type {import('vue').ComputedRef<'bottom-left' | 'bottom-center' | 'bottom-right' | 'top-left' | 'top-center' | 'top-right'>} */
+const toastPosition = computed(() => store.getters.getToastPosition)
+
+/**
+ * @param {'bottom-left' | 'bottom-center' | 'bottom-right' | 'top-left' | 'top-center' | 'top-right'} value
+ */
+function updateToastPosition(value) {
+  store.dispatch('updateToastPosition', value)
 }
 
 /** @type {import('vue').ComputedRef<'disabled' | 'watch_only' | 'entire_app'>} */

--- a/src/renderer/components/GeneralSettings/GeneralSettings.vue
+++ b/src/renderer/components/GeneralSettings/GeneralSettings.vue
@@ -282,7 +282,7 @@ import FtButton from '../FtButton/FtButton.vue'
 import store from '../../store/index'
 
 import allLocales from '../../../../static/locales/activeLocales.json'
-import { TOAST_POSITION_VALUES } from '../../constants/toastPosition'
+import { normalizeToastPosition, TOAST_POSITION_VALUES } from '../../constants/toastPosition'
 import { debounce, randomArrayItem, showToast } from '../../helpers/utils'
 import { translateWindowTitle } from '../../helpers/strings'
 
@@ -637,7 +637,7 @@ const toastPositionNames = computed(() => [
 ])
 
 /** @type {import('vue').ComputedRef<'bottom-left' | 'bottom-center' | 'bottom-right' | 'top-left' | 'top-center' | 'top-right'>} */
-const toastPosition = computed(() => store.getters.getToastPosition)
+const toastPosition = computed(() => normalizeToastPosition(store.getters.getToastPosition))
 
 /**
  * @param {'bottom-left' | 'bottom-center' | 'bottom-right' | 'top-left' | 'top-center' | 'top-right'} value

--- a/src/renderer/constants/toastPosition.js
+++ b/src/renderer/constants/toastPosition.js
@@ -6,3 +6,11 @@ export const TOAST_POSITION_VALUES = [
   'top-center',
   'top-right'
 ]
+
+/**
+ * @param {string} position
+ * @returns {'bottom-left' | 'bottom-center' | 'bottom-right' | 'top-left' | 'top-center' | 'top-right'}
+ */
+export function normalizeToastPosition(position) {
+  return TOAST_POSITION_VALUES.includes(position) ? position : 'bottom-left'
+}

--- a/src/renderer/constants/toastPosition.js
+++ b/src/renderer/constants/toastPosition.js
@@ -1,0 +1,8 @@
+export const TOAST_POSITION_VALUES = [
+  'bottom-left',
+  'bottom-center',
+  'bottom-right',
+  'top-left',
+  'top-center',
+  'top-right'
+]

--- a/src/renderer/store/modules/settings.js
+++ b/src/renderer/store/modules/settings.js
@@ -349,6 +349,7 @@ const state = {
   thumbnailPreference: '',
   thumbnailSize: DEFAULT_THUMBNAIL_SIZE,
   showThumbnailSizeButtonInHeader: true,
+  toastPosition: 'bottom-left',
   extraThumbnailAction: '',
   blurThumbnails: false,
   syncServerUrl: 'https://sync.d3sox.me',

--- a/static/locales/en-US.yaml
+++ b/static/locales/en-US.yaml
@@ -386,6 +386,14 @@ Settings:
       System: System
       Force On: Force on
       Force Off: Force off
+    Toast Position:
+      Toast Position: Toast Position
+      Bottom Left: Bottom left
+      Bottom Center: Bottom center
+      Bottom Right: Bottom right
+      Top Left: Top left
+      Top Center: Top center
+      Top Right: Top right
     System Default: System Default
     Avoid translation:
       Avoid translation: Keep original text


### PR DESCRIPTION
## Summary

- add a persisted toast position setting with top/bottom and left/center/right variants
- align toast stacking, entry/exit animations, and swipe dismissal with the selected position
- allow centered toasts to be dismissed by dragging in either direction
- preserve physical left/right placement in RTL layouts
- cover all six positions and gesture directions with Electron E2E tests

## User impact

Users can place notifications in any corner or at the top/bottom center. Toast animations and hold-and-drag dismissal now follow that placement consistently.

## Validation

- `pnpm run lint`
- `pnpm run test:unit` (61 passed)
- `pnpm run test:e2e:pack`
- `xvfb-run -a -s "-screen 0 1920x1080x24" pnpm exec playwright test -c e2e/playwright.config.mjs --project=offline e2e/tests/offline/settings.spec.mjs --workers=1` (11 passed)