### PR TITLE
Fix auto-refresh cancellation timer reset

### DIFF
--- a/e2e/tests/offline/subscriptions-refresh.spec.mjs
+++ b/e2e/tests/offline/subscriptions-refresh.spec.mjs
@@ -188,3 +188,39 @@ test.describe('cancelling a subscription feed refresh', () => {
     await expect(menu.getByRole('menuitem', { name: 'Cancel Refresh' })).toHaveCount(0)
   })
 })
+
+test.describe('cancelling an automatic subscription feed refresh', () => {
+  const channelCount = 12
+
+  test.use({
+    seed: {
+      settings: {
+        ...commonSettings,
+        subscriptionFeedAutoRefreshInterval: '5000'
+      },
+      profiles: [profileWith(channelCount)],
+      subscriptionCache: Array.from({ length: channelCount }, (_, index) => cachedChannel(index))
+    }
+  })
+
+  test('resets the timer instead of immediately refreshing again', async ({ page }) => {
+    let requestCount = 0
+    await routeFeeds(page, () => {
+      requestCount++
+      return 4_000
+    })
+    await goTo(page, 'subscriptions')
+
+    const cancelRefresh = page.getByRole('button', { name: 'Cancel refresh' })
+    await expect(cancelRefresh).toBeVisible({ timeout: 10_000 })
+    await cancelRefresh.click()
+
+    await expect(page.locator('.tabsProgressBar')).toHaveCount(0, { timeout: 20_000 })
+    const requestCountAfterCancel = requestCount
+    await page.waitForTimeout(2_000)
+
+    expect(requestCountAfterCancel).toBeGreaterThan(0)
+    expect(requestCount).toBe(requestCountAfterCancel)
+    await expect(cancelRefresh).toHaveCount(0)
+  })
+})

--- a/src/renderer/App.vue
+++ b/src/renderer/App.vue
@@ -290,6 +290,7 @@ import { findUpdateRelease } from './helpers/releaseUpdates'
 import { openExternalLink, openInternalPath, showToast } from './helpers/utils'
 import {
   cancelSubscriptionRefresh,
+  getSubscriptionRefreshCancelCount,
   refreshSubscriptionLiveFromRemote,
   refreshSubscriptionPostsFromRemote,
   refreshSubscriptionShortsFromRemote,
@@ -1018,13 +1019,18 @@ async function processPendingSubscriptionAutoRefreshes() {
           continue
         }
 
+        const cancelCountAtStart = getSubscriptionRefreshCancelCount()
         const result = await getSubscriptionTabRefreshHandler(tab)({
           t,
           showStartToast: true
         })
 
         if (result === null) {
-          scheduleSubscriptionTabAutoRefreshLockRetry(tab, profileId)
+          if (getSubscriptionRefreshCancelCount() === cancelCountAtStart) {
+            scheduleSubscriptionTabAutoRefreshLockRetry(tab, profileId)
+          } else {
+            scheduleSubscriptionTabAutoRefresh(tab, profileId, Date.now() + getSubscriptionTabAutoRefreshInterval(tab))
+          }
         }
       } catch (error) {
         console.error(`Failed to auto refresh subscription ${tab}`, error)
@@ -1157,8 +1163,15 @@ function getSubscriptionTabRefreshHandler(tab) {
 /**
  * @param {'videos' | 'shorts' | 'live' | 'posts'} tab
  */
+function getSubscriptionTabAutoRefreshInterval(tab) {
+  return parseInt(getSubscriptionAutoRefreshInterval(tab).value, 10)
+}
+
+/**
+ * @param {'videos' | 'shorts' | 'live' | 'posts'} tab
+ */
 function isSubscriptionTabAutoRefreshEnabled(tab) {
-  const interval = parseInt(getSubscriptionAutoRefreshInterval(tab).value, 10)
+  const interval = getSubscriptionTabAutoRefreshInterval(tab)
 
   return (
     dataReady.value &&

--- a/src/renderer/App.vue
+++ b/src/renderer/App.vue
@@ -290,12 +290,12 @@ import { findUpdateRelease } from './helpers/releaseUpdates'
 import { openExternalLink, openInternalPath, showToast } from './helpers/utils'
 import {
   cancelSubscriptionRefresh,
-  getSubscriptionRefreshCancelCount,
   refreshSubscriptionLiveFromRemote,
   refreshSubscriptionPostsFromRemote,
   refreshSubscriptionShortsFromRemote,
   refreshSubscriptionVideosFromRemote,
   SUBSCRIPTION_REFRESH_CANCEL_STORAGE_KEY,
+  SUBSCRIPTION_REFRESH_CANCELLED_EVENT,
   SUBSCRIPTION_REFRESH_COMPLETED_EVENT,
   SUBSCRIPTION_REFRESH_FINISHED_EVENT,
   SUBSCRIPTION_REFRESH_LOCK_NAME,
@@ -548,6 +548,7 @@ let removeReloadRequestListener = null
 let removeOpenUrlListener = null
 const pendingSubscriptionAutoRefreshes = []
 const pendingSubscriptionAutoRefreshKeys = new Set()
+const cancelledSubscriptionAutoRefreshKeys = new Set()
 let processingSubscriptionAutoRefreshes = false
 let tabSwitcherPreviewRequestId = 0
 let findbarMatches = []
@@ -790,6 +791,7 @@ onMounted(async () => {
   window.addEventListener('blur', cancelTabSwitcher)
   window.addEventListener('online', refreshOverdueSubscriptionFeeds)
   window.addEventListener('storage', handleSubscriptionAutoRefreshStorage)
+  window.addEventListener(SUBSCRIPTION_REFRESH_CANCELLED_EVENT, handleSubscriptionRefreshCancelled)
   window.addEventListener(SUBSCRIPTION_REFRESH_COMPLETED_EVENT, handleSubscriptionRefreshCompleted)
   window.addEventListener(SUBSCRIPTION_REFRESH_FINISHED_EVENT, handleSubscriptionRefreshFinished)
   window.addEventListener(SUBSCRIPTION_REFRESH_PROGRESS_EVENT, handleSubscriptionRefreshProgress)
@@ -831,6 +833,7 @@ onBeforeUnmount(() => {
   window.removeEventListener('blur', cancelTabSwitcher)
   window.removeEventListener('online', refreshOverdueSubscriptionFeeds)
   window.removeEventListener('storage', handleSubscriptionAutoRefreshStorage)
+  window.removeEventListener(SUBSCRIPTION_REFRESH_CANCELLED_EVENT, handleSubscriptionRefreshCancelled)
   window.removeEventListener(SUBSCRIPTION_REFRESH_COMPLETED_EVENT, handleSubscriptionRefreshCompleted)
   window.removeEventListener(SUBSCRIPTION_REFRESH_FINISHED_EVENT, handleSubscriptionRefreshFinished)
   window.removeEventListener(SUBSCRIPTION_REFRESH_PROGRESS_EVENT, handleSubscriptionRefreshProgress)
@@ -1019,20 +1022,22 @@ async function processPendingSubscriptionAutoRefreshes() {
           continue
         }
 
-        const cancelCountAtStart = getSubscriptionRefreshCancelCount(tab, profileId)
+        cancelledSubscriptionAutoRefreshKeys.delete(key)
         const result = await getSubscriptionTabRefreshHandler(tab)({
           t,
           showStartToast: true
         })
+        const wasCancelled = cancelledSubscriptionAutoRefreshKeys.delete(key)
 
         if (result === null) {
-          if (getSubscriptionRefreshCancelCount(tab, profileId) === cancelCountAtStart) {
-            scheduleSubscriptionTabAutoRefreshLockRetry(tab, profileId)
-          } else {
+          if (wasCancelled) {
             scheduleSubscriptionTabAutoRefresh(tab, profileId, Date.now() + getSubscriptionTabAutoRefreshInterval(tab))
+          } else {
+            scheduleSubscriptionTabAutoRefreshLockRetry(tab, profileId)
           }
         }
       } catch (error) {
+        cancelledSubscriptionAutoRefreshKeys.delete(key)
         console.error(`Failed to auto refresh subscription ${tab}`, error)
         scheduleSubscriptionTabAutoRefreshRetry(
           tab,
@@ -1365,6 +1370,21 @@ function synchronizeSubscriptionAutoRefreshProfile(profileId) {
     )
     scheduleSubscriptionTabAutoRefresh(tab, profileId)
   }
+}
+
+/**
+ * @param {CustomEvent<{tab: 'videos' | 'shorts' | 'live' | 'posts', profileId: string}>} event
+ */
+function handleSubscriptionRefreshCancelled(event) {
+  const { tab, profileId } = event.detail
+  if (
+    profileId !== activeSubscriptionProfileId.value ||
+    !subscriptionAutoRefreshTabs.includes(tab)
+  ) {
+    return
+  }
+
+  cancelledSubscriptionAutoRefreshKeys.add(`${profileId}:${tab}`)
 }
 
 /**

--- a/src/renderer/App.vue
+++ b/src/renderer/App.vue
@@ -1019,14 +1019,14 @@ async function processPendingSubscriptionAutoRefreshes() {
           continue
         }
 
-        const cancelCountAtStart = getSubscriptionRefreshCancelCount()
+        const cancelCountAtStart = getSubscriptionRefreshCancelCount(tab, profileId)
         const result = await getSubscriptionTabRefreshHandler(tab)({
           t,
           showStartToast: true
         })
 
         if (result === null) {
-          if (getSubscriptionRefreshCancelCount() === cancelCountAtStart) {
+          if (getSubscriptionRefreshCancelCount(tab, profileId) === cancelCountAtStart) {
             scheduleSubscriptionTabAutoRefreshLockRetry(tab, profileId)
           } else {
             scheduleSubscriptionTabAutoRefresh(tab, profileId, Date.now() + getSubscriptionTabAutoRefreshInterval(tab))

--- a/src/renderer/helpers/subscriptions.js
+++ b/src/renderer/helpers/subscriptions.js
@@ -18,6 +18,7 @@ import { mapConcurrently } from './concurrent-map'
 
 const AUTO_REFRESH_TOAST_DURATION = 5000
 export const SUBSCRIPTION_REFRESH_CHANNEL_EVENT = 'opentubex-subscription-refresh-channel'
+export const SUBSCRIPTION_REFRESH_CANCELLED_EVENT = 'opentubex-subscription-refresh-cancelled'
 export const SUBSCRIPTION_REFRESH_COMPLETED_EVENT = 'opentubex-subscription-refresh-completed'
 export const SUBSCRIPTION_REFRESH_FINISHED_EVENT = 'opentubex-subscription-refresh-finished'
 export const SUBSCRIPTION_REFRESH_LOCK_NAME = 'opentubex-subscription-refresh'
@@ -38,7 +39,6 @@ let activeRefresh = null
 // Incremented on every cancellation request, so that a cancellation is not
 // missed when it arrives between two feed refreshes.
 let cancelCount = 0
-const cancelCountsByRefresh = new Map()
 
 const IS_UPCOMING_REGEX = /"isUpcoming"\s*:\s*true/
 const SCHEDULED_START_REGEX = /"scheduledStartTime"\s*:\s*"(\d+)"/
@@ -52,11 +52,18 @@ const SUBSCRIPTION_FETCH_CONCURRENCY = 8
  */
 export function cancelSubscriptionRefresh() {
   cancelCount++
+  markActiveSubscriptionRefreshCancelled()
+}
 
-  if (activeRefresh !== null) {
+function markActiveSubscriptionRefreshCancelled() {
+  if (activeRefresh !== null && !activeRefresh.cancelled) {
     activeRefresh.cancelled = true
-    const key = `${activeRefresh.profileId}:${activeRefresh.tab}`
-    cancelCountsByRefresh.set(key, (cancelCountsByRefresh.get(key) ?? 0) + 1)
+    window.dispatchEvent(new CustomEvent(SUBSCRIPTION_REFRESH_CANCELLED_EVENT, {
+      detail: {
+        tab: activeRefresh.tab,
+        profileId: activeRefresh.profileId
+      }
+    }))
   }
 }
 
@@ -82,11 +89,7 @@ export function requestSubscriptionRefreshCancellation() {
  * Lets callers that refresh several feeds in a row notice a cancellation that
  * happened between two feeds, when no refresh was running.
  */
-export function getSubscriptionRefreshCancelCount(tab, profileId) {
-  if (tab && profileId) {
-    return cancelCountsByRefresh.get(`${profileId}:${tab}`) ?? 0
-  }
-
+export function getSubscriptionRefreshCancelCount() {
   return cancelCount
 }
 
@@ -106,11 +109,16 @@ async function withSubscriptionRefreshLock(tab, profileId, refresh) {
     return null
   }
 
+  const cancelCountAtStart = cancelCount
   const runRefresh = async () => {
+    activeRefresh = { cancelled: false, tab, profileId }
     window.dispatchEvent(new CustomEvent(SUBSCRIPTION_REFRESH_STARTED_EVENT, {
       detail: { tab, profileId }
     }))
-    activeRefresh = { cancelled: false, tab, profileId }
+
+    if (cancelCount !== cancelCountAtStart) {
+      markActiveSubscriptionRefreshCancelled()
+    }
 
     try {
       return await refresh()

--- a/src/renderer/helpers/subscriptions.js
+++ b/src/renderer/helpers/subscriptions.js
@@ -31,13 +31,14 @@ let electronRefreshOwnerTabId = null
 
 /**
  * Cancellation state of the refresh this renderer is running, if any.
- * @type {{ cancelled: boolean } | null}
+ * @type {{ cancelled: boolean, tab: string, profileId: string } | null}
  */
 let activeRefresh = null
 
 // Incremented on every cancellation request, so that a cancellation is not
 // missed when it arrives between two feed refreshes.
 let cancelCount = 0
+const cancelCountsByRefresh = new Map()
 
 const IS_UPCOMING_REGEX = /"isUpcoming"\s*:\s*true/
 const SCHEDULED_START_REGEX = /"scheduledStartTime"\s*:\s*"(\d+)"/
@@ -54,6 +55,8 @@ export function cancelSubscriptionRefresh() {
 
   if (activeRefresh !== null) {
     activeRefresh.cancelled = true
+    const key = `${activeRefresh.profileId}:${activeRefresh.tab}`
+    cancelCountsByRefresh.set(key, (cancelCountsByRefresh.get(key) ?? 0) + 1)
   }
 }
 
@@ -79,7 +82,11 @@ export function requestSubscriptionRefreshCancellation() {
  * Lets callers that refresh several feeds in a row notice a cancellation that
  * happened between two feeds, when no refresh was running.
  */
-export function getSubscriptionRefreshCancelCount() {
+export function getSubscriptionRefreshCancelCount(tab, profileId) {
+  if (tab && profileId) {
+    return cancelCountsByRefresh.get(`${profileId}:${tab}`) ?? 0
+  }
+
   return cancelCount
 }
 
@@ -103,7 +110,7 @@ async function withSubscriptionRefreshLock(tab, profileId, refresh) {
     window.dispatchEvent(new CustomEvent(SUBSCRIPTION_REFRESH_STARTED_EVENT, {
       detail: { tab, profileId }
     }))
-    activeRefresh = { cancelled: false }
+    activeRefresh = { cancelled: false, tab, profileId }
 
     try {
       return await refresh()


### PR DESCRIPTION
## Summary

- distinguish canceled auto-refreshes from refresh-lock contention
- reset canceled auto-refreshes to the configured interval instead of retrying after one second
- add an Electron E2E regression test covering cancellation and the absence of an immediate refresh

## Root cause

Canceled refreshes and failed lock acquisitions both returned `null`. The auto-refresh queue treated every `null` result as lock contention and scheduled a one-second retry, making a canceled refresh start again almost immediately.

## User impact

Canceling an automatic subscription refresh now stops it and schedules the next attempt for the normal configured interval.

## Validation

- `pnpm exec eslint --config eslint.config.mjs src/renderer/App.vue`
- `pnpm run test:e2e:pack`
- `xvfb-run -a -s "-screen 0 1920x1080x24" pnpm exec playwright test -c e2e/playwright.config.mjs --project=offline e2e/tests/offline/subscriptions-refresh.spec.mjs` (5 passed)