### PR TITLE
feat(ui): overlay scrollbars that float above the content

### DIFF
--- a/e2e/tests/network/watch.spec.mjs
+++ b/e2e/tests/network/watch.spec.mjs
@@ -66,15 +66,13 @@ test.describe('watch page', () => {
     test.skip(innertube.replay, 'watch page hydration needs the real API')
     await openVideo(page)
 
-    // The description and the comments both scroll; their scrollbars must float
-    // above the content rather than narrowing it.
-    for (const selector of ['.videoDescription', '.commentsContentWrapper']) {
-      const panel = page.locator(selector)
-      await expect(panel).toBeVisible({ timeout: 30_000 })
-      await expect(panel.locator('> .os-scrollbar-vertical')).toHaveCount(1)
-      expect(
-        await panel.evaluate((element) => element.clientWidth === element.offsetWidth)
-      ).toBe(true)
+    // Whether these overflow depends on the video, so assert that the directive
+    // took hold rather than measuring widths: the panel stays the scrolling
+    // element and gets its own overlay scrollbars.
+    for (const selector of ['.descriptionScroll', '.commentsContentWrapper']) {
+      await expect(page.locator(selector)).toBeVisible({ timeout: 30_000 })
+      await expect(page.locator(`${selector}[data-overlayscrollbars-viewport]`)).toHaveCount(1)
+      await expect(page.locator(`${selector} > .os-scrollbar-vertical`)).toHaveCount(1)
     }
   })
 

--- a/e2e/tests/network/watch.spec.mjs
+++ b/e2e/tests/network/watch.spec.mjs
@@ -46,6 +46,22 @@ test.describe('watch page', () => {
     await expect(page.locator(sel.activeTab).locator('.tabAvatar')).toBeVisible()
   })
 
+  test('the sidebar panels use overlay scrollbars', async ({ page, innertube }) => {
+    test.skip(innertube.replay, 'watch page hydration needs the real API')
+    await openVideo(page)
+
+    // The description and the comments both scroll; their scrollbars must float
+    // above the content rather than narrowing it.
+    for (const selector of ['.videoDescription', '.commentsContentWrapper']) {
+      const panel = page.locator(selector)
+      await expect(panel).toBeVisible({ timeout: 30_000 })
+      await expect(panel.locator('> .os-scrollbar-vertical')).toHaveCount(1)
+      expect(
+        await panel.evaluate((element) => element.clientWidth === element.offsetWidth)
+      ).toBe(true)
+    }
+  })
+
   test('playback starts', async ({ page, innertube }) => {
     test.skip(!innertube.playback, 'needs real media streams')
     await openVideo(page)

--- a/e2e/tests/offline/scrollbar-overlay.spec.mjs
+++ b/e2e/tests/offline/scrollbar-overlay.spec.mjs
@@ -1,0 +1,78 @@
+import { test, expect, goTo } from '../../helpers/app.mjs'
+
+// The page's own scrollbars are the ones appended to the body.
+const PAGE_SCROLLBAR = 'body > .os-scrollbar-vertical'
+
+test.describe('overlay scrollbars', () => {
+  test('the main scroll container reserves no layout space for its scrollbar', async ({ page }) => {
+    await goTo(page, 'settings')
+
+    // A classic scrollbar shrinks clientWidth below the viewport width, an
+    // overlay one floats above the content and leaves the layout untouched.
+    const { clientWidth, innerWidth } = await page.evaluate(() => ({
+      clientWidth: document.documentElement.clientWidth,
+      innerWidth: window.innerWidth
+    }))
+
+    expect(clientWidth).toBe(innerWidth)
+  })
+
+  test('the scrollbar hides once the pointer rests and follows it back', async ({ page }) => {
+    await goTo(page, 'settings')
+    const scrollbar = page.locator(PAGE_SCROLLBAR)
+
+    await page.mouse.move(800, 400)
+    await page.mouse.wheel(0, 300)
+    await expect(scrollbar).toHaveCSS('opacity', '1')
+
+    // Idle pointer: gone after the library's 1300ms auto hide delay.
+    await expect(scrollbar).toHaveCSS('opacity', '0', { timeout: 5000 })
+
+    await page.mouse.move(800, 500)
+    await expect(scrollbar).toHaveCSS('opacity', '1')
+  })
+
+  test('the scrollbar handle picks up the theme', async ({ page }) => {
+    await goTo(page, 'settings')
+    await page.mouse.wheel(0, 300)
+
+    await expect(page.locator(`${PAGE_SCROLLBAR} .os-scrollbar-handle`)).toHaveCSS(
+      'background-color',
+      // --scrollbar-color of the light theme
+      'rgb(204, 204, 204)'
+    )
+  })
+
+  test('nested scroll containers scroll themselves, so scrollTop keeps working', async ({ page }) => {
+    const sideNavInner = page.locator('.sideNav .inner')
+
+    await expect(sideNavInner).toHaveCSS('overflow-y', 'auto')
+    expect(await sideNavInner.evaluate(element => element.clientWidth === element.offsetWidth)).toBe(true)
+  })
+
+  test('turning "Always Show Scrollbars" on keeps them visible while idle', async ({ page }) => {
+    await goTo(page, 'settings')
+    const scrollbar = page.locator(PAGE_SCROLLBAR)
+
+    await page.mouse.move(800, 400)
+    await page.mouse.wheel(0, 300)
+    await expect.poll(() => page.evaluate(() => window.scrollY)).toBe(300)
+
+    const toggle = page.getByRole('checkbox', { name: 'Always Show Scrollbars' })
+    await expect(toggle).not.toBeChecked()
+    // The styled label covers the checkbox input, so click that instead.
+    await page.locator('label.switch-label').filter({ hasText: 'Always Show Scrollbars' }).click()
+    await expect(toggle).toBeChecked()
+
+    // The switch takes effect on the scrollbars that already exist, and
+    // rebuilding them mustn't lose where the page was scrolled to.
+    await page.mouse.move(400, 700)
+    await page.waitForTimeout(2500)
+
+    await expect(scrollbar).toBeVisible()
+    await expect(scrollbar).toHaveCSS('opacity', '1')
+    // Roughly, not exactly: flipping the switch also reflows the settings page
+    // a little by revealing the "changed setting" indicator.
+    expect(await page.evaluate(() => window.scrollY)).toBeGreaterThan(250)
+  })
+})

--- a/e2e/tests/offline/scrollbar-overlay.spec.mjs
+++ b/e2e/tests/offline/scrollbar-overlay.spec.mjs
@@ -3,20 +3,23 @@ import { test, expect, goTo, sel } from '../../helpers/app.mjs'
 // The page's own scrollbars are the ones appended to the body.
 const PAGE_SCROLLBAR = 'body > .os-scrollbar-vertical'
 
+/** The assertions below only mean anything once there is something to scroll. */
+const pageOverflows = (page) => page.evaluate(
+  () => document.documentElement.scrollHeight > window.innerHeight
+)
+
 test.describe('overlay scrollbars', () => {
   test('the main scroll container reserves no layout space for its scrollbar', async ({ page }) => {
     await goTo(page, 'settings')
+    await expect.poll(() => pageOverflows(page)).toBe(true)
 
     // A classic scrollbar shrinks clientWidth below the viewport width, an
     // overlay one floats above the content and leaves the layout untouched.
-    // Only meaningful while the page actually overflows.
-    const { clientWidth, innerWidth, overflows } = await page.evaluate(() => ({
+    const { clientWidth, innerWidth } = await page.evaluate(() => ({
       clientWidth: document.documentElement.clientWidth,
-      innerWidth: window.innerWidth,
-      overflows: document.documentElement.scrollHeight > window.innerHeight
+      innerWidth: window.innerWidth
     }))
 
-    expect(overflows).toBe(true)
     expect(clientWidth).toBe(innerWidth)
   })
 
@@ -48,6 +51,11 @@ test.describe('overlay scrollbars', () => {
 
   test('clicking the track jumps to that position', async ({ page }) => {
     await goTo(page, 'settings')
+    // Otherwise there is nothing to scroll and the assertion below would fail
+    // whether or not click scrolling works.
+    await expect.poll(() => pageOverflows(page)).toBe(true)
+    expect(await page.evaluate(() => window.scrollY)).toBe(0)
+
     // Needs the ClickScrollPlugin to be registered; without it the library
     // ignores clickScroll and the track does nothing.
     const track = page.locator(`${PAGE_SCROLLBAR} .os-scrollbar-track`)

--- a/e2e/tests/offline/scrollbar-overlay.spec.mjs
+++ b/e2e/tests/offline/scrollbar-overlay.spec.mjs
@@ -1,4 +1,4 @@
-import { test, expect, goTo } from '../../helpers/app.mjs'
+import { test, expect, goTo, sel } from '../../helpers/app.mjs'
 
 // The page's own scrollbars are the ones appended to the body.
 const PAGE_SCROLLBAR = 'body > .os-scrollbar-vertical'
@@ -9,11 +9,14 @@ test.describe('overlay scrollbars', () => {
 
     // A classic scrollbar shrinks clientWidth below the viewport width, an
     // overlay one floats above the content and leaves the layout untouched.
-    const { clientWidth, innerWidth } = await page.evaluate(() => ({
+    // Only meaningful while the page actually overflows.
+    const { clientWidth, innerWidth, overflows } = await page.evaluate(() => ({
       clientWidth: document.documentElement.clientWidth,
-      innerWidth: window.innerWidth
+      innerWidth: window.innerWidth,
+      overflows: document.documentElement.scrollHeight > window.innerHeight
     }))
 
+    expect(overflows).toBe(true)
     expect(clientWidth).toBe(innerWidth)
   })
 
@@ -43,11 +46,51 @@ test.describe('overlay scrollbars', () => {
     )
   })
 
-  test('nested scroll containers scroll themselves, so scrollTop keeps working', async ({ page }) => {
-    const sideNavInner = page.locator('.sideNav .inner')
+  test('clicking the track jumps to that position', async ({ page }) => {
+    await goTo(page, 'settings')
+    // Needs the ClickScrollPlugin to be registered; without it the library
+    // ignores clickScroll and the track does nothing.
+    const track = page.locator(`${PAGE_SCROLLBAR} .os-scrollbar-track`)
+    const box = await track.boundingBox()
 
-    await expect(sideNavInner).toHaveCSS('overflow-y', 'auto')
-    expect(await sideNavInner.evaluate(element => element.clientWidth === element.offsetWidth)).toBe(true)
+    await page.mouse.move(box.x + box.width / 2, box.y + box.height - 20)
+    await page.mouse.down()
+    await page.mouse.up()
+
+    await expect.poll(() => page.evaluate(() => window.scrollY)).toBeGreaterThan(0)
+  })
+
+  test.describe('a nested scroll container', () => {
+    const now = Date.now()
+    test.use({
+      seed: {
+        settings: { enableSearchSuggestions: false },
+        searchHistory: Array.from({ length: 25 }, (_, index) => ({
+          _id: `search ${index + 1}`,
+          lastUpdatedAt: now - index
+        }))
+      }
+    })
+
+    test('stays the scrolling element, so scrollTop keeps working', async ({ page }) => {
+      await page.locator(sel.searchInput).click()
+      const list = page.locator('.topNav .searchContainer .options .list')
+      await expect(list).toBeVisible()
+
+      const measurements = await list.evaluate((element) => {
+        const overflows = element.scrollHeight > element.clientHeight
+        element.scrollTop = 120
+        return {
+          overflows,
+          noLayoutCost: element.clientWidth === element.offsetWidth,
+          scrollTop: element.scrollTop
+        }
+      })
+
+      expect(measurements.overflows).toBe(true)
+      expect(measurements.noLayoutCost).toBe(true)
+      expect(measurements.scrollTop).toBe(120)
+    })
   })
 
   test('turning "Always Show Scrollbars" on keeps them visible while idle', async ({ page }) => {

--- a/e2e/tests/offline/search-history-limit.spec.mjs
+++ b/e2e/tests/offline/search-history-limit.spec.mjs
@@ -24,7 +24,9 @@ test('shows every saved search in a scrollable list', async ({ page }) => {
   await expect(suggestions.last()).toContainText(entries.at(-1)._id)
   await expect(list).toHaveCSS('overflow-y', 'scroll')
   await expect.poll(() => list.evaluate(element => element.scrollHeight > element.clientHeight)).toBe(true)
+  // The scrollbar is an overlay one, so it floats above the suggestions
+  // instead of narrowing them.
   await expect.poll(() => list.evaluate(element => {
-    return getComputedStyle(element, '::-webkit-scrollbar').inlineSize
-  })).toBe('10px')
+    return element.clientWidth === element.offsetWidth
+  })).toBe(true)
 })

--- a/package.json
+++ b/package.json
@@ -71,6 +71,7 @@
     "dompurify": "^3.4.12",
     "googlevideo": "^4.1.1",
     "marked": "^18.0.6",
+    "overlayscrollbars": "^2.16.0",
     "process": "^0.11.10",
     "shaka-player": "^5.1.12",
     "swiper": "^14.0.5",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -49,6 +49,9 @@ importers:
       marked:
         specifier: ^18.0.6
         version: 18.0.6
+      overlayscrollbars:
+        specifier: ^2.16.0
+        version: 2.16.0
       process:
         specifier: ^0.11.10
         version: 0.11.10
@@ -3836,6 +3839,9 @@ packages:
   optionator@0.9.4:
     resolution: {integrity: sha512-6IpQ7mKUxRcZNLIObR0hz7lxsapSSIYNZJwXPGeF0mTVqGKFIXj1DQcMoT22S3ROcLyY/rz0PWaWZ9ayWmad9g==}
     engines: {node: '>= 0.8.0'}
+
+  overlayscrollbars@2.16.0:
+    resolution: {integrity: sha512-N03oje/q7j93D0aLZtoCdsDSYLmhheSsv8H7oSLE7HhdV9P/bmCURtLV/KbPye7P/bpfyt/obSfDpGUYoJ0OWg==}
 
   p-cancelable@2.1.1:
     resolution: {integrity: sha512-BZOr3nRQHOntUjTrH8+Lh54smKHoHyur8We1V8DSMVrl5A2malOOwuJRnKRDjSnkoeBh4at6BwEnb5I7Jl31wg==}
@@ -9088,6 +9094,8 @@ snapshots:
       prelude-ls: 1.2.1
       type-check: 0.4.0
       word-wrap: 1.2.5
+
+  overlayscrollbars@2.16.0: {}
 
   p-cancelable@2.1.1: {}
 

--- a/src/index.ejs
+++ b/src/index.ejs
@@ -1,5 +1,7 @@
 <!DOCTYPE html>
-<html>
+<!-- data-overlayscrollbars-initialize keeps the native scrollbars hidden until
+     OverlayScrollbars takes over, so they don't flash during startup -->
+<html data-overlayscrollbars-initialize>
 
   <head>
     <meta charset="utf-8" />
@@ -11,7 +13,7 @@
     <title></title>
   </head>
 
-  <body>
+  <body data-overlayscrollbars-initialize>
     <div id="app"></div>
     <% if (process.env.IS_ELECTRON) { %>
     <iframe

--- a/src/renderer/components/CommentSection/CommentSection.css
+++ b/src/renderer/components/CommentSection/CommentSection.css
@@ -31,7 +31,11 @@
   min-block-size: 0;
   overflow: hidden auto;
   overscroll-behavior: contain;
-  scrollbar-color: rgb(255 255 255 / 45%) transparent;
+
+  /* Sits above the video, so the scrollbar needs a light handle rather than the
+     theme's. The overlay scrollbars inherit these from their container. */
+  --scrollbar-color: rgb(255 255 255 / 45%);
+  --scrollbar-color-hover: rgb(255 255 255 / 65%);
 }
 
 /* Matches the chapter overlay header in the video player. */

--- a/src/renderer/components/CommentSection/CommentSection.vue
+++ b/src/renderer/components/CommentSection/CommentSection.vue
@@ -68,6 +68,7 @@
     </header>
     <div
       ref="commentsContentWrapper"
+      v-overlay-scrollbars
       class="commentsContentWrapper"
     >
       <div

--- a/src/renderer/components/FtInput/FtInput.css
+++ b/src/renderer/components/FtInput/FtInput.css
@@ -240,20 +240,6 @@ body[dir='rtl'] .ft-input-component.search.showClearTextButton:focus-within .inp
 .search .list {
   max-block-size: min(50vh, 20rem);
   overflow-y: scroll;
-  scrollbar-color: var(--scrollbar-color-hover) transparent;
-  scrollbar-gutter: stable;
-  scrollbar-width: auto;
-}
-
-.search .list::-webkit-scrollbar {
-  display: block;
-  inline-size: 10px;
-}
-
-.search .list::-webkit-scrollbar-thumb {
-  background: var(--scrollbar-color-hover);
-  border: 2px solid var(--search-bar-color);
-  border-radius: 6px;
 }
 
 .list li {

--- a/src/renderer/components/FtInput/FtInput.vue
+++ b/src/renderer/components/FtInput/FtInput.vue
@@ -80,6 +80,7 @@
     <div class="options">
       <ul
         v-if="showOptions"
+        v-overlay-scrollbars
         class="list"
         @mouseenter="searchState.isPointerInList = true"
         @mouseleave="searchState.isPointerInList = false"

--- a/src/renderer/components/SideNav/SideNav.css
+++ b/src/renderer/components/SideNav/SideNav.css
@@ -169,11 +169,6 @@
 }
 
 @media only screen and (width > 680px) {
-  ::-webkit-scrollbar {
-    inline-size: 10px;
-    block-size: 10px;
-  }
-
   .expanded {
     inline-size: 200px;
   }

--- a/src/renderer/components/SideNav/SideNav.vue
+++ b/src/renderer/components/SideNav/SideNav.vue
@@ -6,6 +6,7 @@
   >
     <div
       ref="innerRef"
+      v-overlay-scrollbars
       class="inner"
       :class="applyHiddenLabels"
     >

--- a/src/renderer/components/TabBar/TabBar.css
+++ b/src/renderer/components/TabBar/TabBar.css
@@ -31,13 +31,13 @@
   display: flex;
   min-inline-size: 0;
   overflow: auto hidden;
+
+  /* The horizontal layout draws its own scrollbar below (.tabsScrollbar). The
+     vertical one gets overlay scrollbars from v-overlay-scrollbars instead,
+     which hides the native ones itself. */
   scrollbar-width: none;
   gap: 2px;
   -webkit-app-region: no-drag;
-}
-
-.tabsContainer::-webkit-scrollbar {
-  display: none;
 }
 
 .tabsScrollbar {
@@ -135,16 +135,6 @@
   block-size: 100%;
   overflow: hidden auto;
   overscroll-behavior: contain;
-
-  /* `auto` re-enables the themed ::-webkit-scrollbar styling (any other value
-     makes Chromium fall back to its native scrollbar) */
-  scrollbar-width: auto;
-}
-
-/* Same themed scrollbar as the main view, just narrower */
-.tabBar.vertical .tabsContainer::-webkit-scrollbar {
-  display: block;
-  inline-size: 10px;
 }
 
 /* The handle draws the divider line itself, so the hover highlight is always

--- a/src/renderer/components/TabBar/TabBar.vue
+++ b/src/renderer/components/TabBar/TabBar.vue
@@ -12,6 +12,7 @@
     >
       <div
         ref="dropZoneRef"
+        v-overlay-scrollbars="vertical"
         class="tabsContainer"
         @scroll="handleScroll"
         @wheel="handleWheel"

--- a/src/renderer/components/ThemeSettings.vue
+++ b/src/renderer/components/ThemeSettings.vue
@@ -32,6 +32,14 @@
           setting-key="showThumbnailSizeButtonInHeader"
           @change="updateShowThumbnailSizeButtonInHeader"
         />
+        <FtToggleSwitch
+          :label="$t('Settings.Theme Settings.Always Show Scrollbars')"
+          :tooltip="$t('Tooltips.Theme Settings.Always Show Scrollbars')"
+          compact
+          :default-value="alwaysShowScrollbars"
+          setting-key="alwaysShowScrollbars"
+          @change="updateAlwaysShowScrollbars"
+        />
       </div>
       <div class="switchColumn">
         <FtToggleSwitch
@@ -313,6 +321,18 @@ const hideLabelsSideBar = computed(() => {
  */
 function updateHideLabelsSideBar(value) {
   store.dispatch('updateHideLabelsSideBar', value)
+}
+
+/** @type {import('vue').ComputedRef<boolean>} */
+const alwaysShowScrollbars = computed(() => {
+  return store.getters.getAlwaysShowScrollbars
+})
+
+/**
+ * @param {boolean} value
+ */
+function updateAlwaysShowScrollbars(value) {
+  store.dispatch('updateAlwaysShowScrollbars', value)
 }
 
 /** @type {import('vue').ComputedRef<boolean>} */

--- a/src/renderer/components/WatchVideoChapters/WatchVideoChapters.css
+++ b/src/renderer/components/WatchVideoChapters/WatchVideoChapters.css
@@ -5,7 +5,11 @@
   min-block-size: 0;
   overflow-y: auto;
   overscroll-behavior: contain;
-  scrollbar-color: rgb(255 255 255 / 45%) transparent;
+
+  /* Light handle for the chapter overlay above the video. Watch.scss puts the
+     theme's colour back for the regular sidebar. */
+  --scrollbar-color: rgb(255 255 255 / 45%);
+  --scrollbar-color-hover: rgb(255 255 255 / 65%);
 }
 
 .chapter {

--- a/src/renderer/components/WatchVideoChapters/WatchVideoChapters.vue
+++ b/src/renderer/components/WatchVideoChapters/WatchVideoChapters.vue
@@ -2,6 +2,7 @@
   <div
     ref="chaptersWrapper"
     v-observe-visibility="observeVisibilityOptions"
+    v-overlay-scrollbars
     class="chaptersWrapper"
     :class="{ compact }"
     role="list"

--- a/src/renderer/components/WatchVideoDescription/WatchVideoDescription.css
+++ b/src/renderer/components/WatchVideoDescription/WatchVideoDescription.css
@@ -3,7 +3,6 @@
   display: flex;
   flex-direction: column;
   overflow-y: auto;
-  scrollbar-gutter: stable;
   max-block-size: 20lh;
 }
 

--- a/src/renderer/components/WatchVideoDescription/WatchVideoDescription.vue
+++ b/src/renderer/components/WatchVideoDescription/WatchVideoDescription.vue
@@ -1,6 +1,7 @@
 <template>
   <FtCard
     v-if="shownDescription.length > 0"
+    v-overlay-scrollbars
     :class="{
       videoDescription: true,
       short: !isExpanded,

--- a/src/renderer/components/WatchVideoDescription/WatchVideoDescription.vue
+++ b/src/renderer/components/WatchVideoDescription/WatchVideoDescription.vue
@@ -1,7 +1,6 @@
 <template>
   <FtCard
     v-if="shownDescription.length > 0"
-    v-overlay-scrollbars
     :class="{
       videoDescription: true,
       short: !isExpanded,
@@ -19,7 +18,10 @@
     >
       {{ $t("Description.Expand Description") }}
     </span>
-    <div class="descriptionScroll">
+    <div
+      v-overlay-scrollbars
+      class="descriptionScroll"
+    >
       <FtTimestampCatcher
         ref="descriptionContainer"
         class="description"

--- a/src/renderer/components/WatchVideoPlaylist/WatchVideoPlaylist.css
+++ b/src/renderer/components/WatchVideoPlaylist/WatchVideoPlaylist.css
@@ -253,8 +253,13 @@
   min-block-size: 0;
   overflow: hidden auto;
   overscroll-behavior: contain;
-  scrollbar-color: rgb(255 255 255 / 45%) transparent;
   resize: none;
+
+  /* Deliberately a native scrollbar. Watch.js re-centres this list when it
+     moves between the sidebar and the dock, but OverlayScrollbars restores the
+     scroll offset it had before the move and there's no option to stop it, so
+     the list would end up thousands of pixels away from the current video. */
+  scrollbar-color: rgb(255 255 255 / 45%) transparent;
 }
 
 .playlistItemsWrapper::-webkit-resizer {

--- a/src/renderer/components/WatchVideoTranscript/WatchVideoTranscript.css
+++ b/src/renderer/components/WatchVideoTranscript/WatchVideoTranscript.css
@@ -120,7 +120,6 @@
   position: relative;
   max-block-size: 420px;
   overflow-y: auto;
-  scrollbar-gutter: stable;
 }
 
 .transcriptSegment {

--- a/src/renderer/components/WatchVideoTranscript/WatchVideoTranscript.vue
+++ b/src/renderer/components/WatchVideoTranscript/WatchVideoTranscript.vue
@@ -131,6 +131,7 @@
     <div
       v-else
       ref="segmentList"
+      v-overlay-scrollbars
       class="transcriptSegments"
       role="list"
       :aria-label="t('Video.Transcript.Title')"

--- a/src/renderer/helpers/overlayScrollbars.js
+++ b/src/renderer/helpers/overlayScrollbars.js
@@ -1,7 +1,11 @@
 import { watch } from 'vue'
-import { OverlayScrollbars } from 'overlayscrollbars'
+import { ClickScrollPlugin, OverlayScrollbars } from 'overlayscrollbars'
 
 import store from '../store/index'
+
+// Kept out of the core bundle by the library, so `clickScroll` below silently
+// does nothing unless it is registered.
+OverlayScrollbars.plugin(ClickScrollPlugin)
 
 /*
  * Chromium's own overlay scrollbars can't be styled and fade out when idle,
@@ -67,10 +71,14 @@ function toggleOverlayScrollbars(element, enabled) {
   const instance = OverlayScrollbars(element)
 
   if (enabled && !instance) {
+    // Hides the native scrollbars for the moment before the library takes over,
+    // the same way index.ejs does it for the page itself.
+    element.setAttribute('data-overlayscrollbars-initialize', '')
     // Reusing the element as the viewport keeps it the scrolling element, so
     // existing scrollTop/scrollLeft handling and CSS carry on working.
     create({ target: element, elements: { viewport: element } })
   } else if (!enabled && instance) {
+    element.removeAttribute('data-overlayscrollbars-initialize')
     instance.destroy()
   }
 }

--- a/src/renderer/helpers/overlayScrollbars.js
+++ b/src/renderer/helpers/overlayScrollbars.js
@@ -1,0 +1,100 @@
+import { watch } from 'vue'
+import { OverlayScrollbars } from 'overlayscrollbars'
+
+import store from '../store/index'
+
+/*
+ * Chromium's own overlay scrollbars can't be styled and fade out when idle,
+ * so we hide the native ones and draw our own instead. The look is themed in
+ * themes.css via the library's --os-* custom properties.
+ */
+
+/**
+ * Every live instance and how it was set up, so the "Always Show Scrollbars"
+ * switch can rebuild them.
+ *
+ * @type {Map<import('overlayscrollbars').OverlayScrollbars, HTMLElement | object>}
+ */
+const instances = new Map()
+
+function scrollbarOptions() {
+  return {
+    scrollbars: {
+      // 'move' hides the scrollbars once the pointer has been still for
+      // `autoHideDelay` and brings them back as soon as it moves again.
+      autoHide: store.getters.getAlwaysShowScrollbars ? 'never' : 'move',
+      // Matches how the native scrollbars behaved: clicking the track jumps
+      // straight to that position instead of paging towards it.
+      clickScroll: true
+    }
+  }
+}
+
+/**
+ * @param {HTMLElement | object} initialization the target element, or a full
+ * initialization object when the caller wants to pick the scrolling element
+ */
+function create(initialization) {
+  const instance = OverlayScrollbars(initialization, scrollbarOptions())
+  instances.set(instance, initialization)
+  instance.on('destroyed', () => instances.delete(instance))
+  return instance
+}
+
+/**
+ * Replaces the main window's scrollbars. `window.scrollTo`, `window.scrollY`
+ * and the document's scroll events keep working when the body is the target.
+ */
+export function initializeAppScrollbars() {
+  create(document.body)
+
+  // Rebuilt rather than reconfigured: switching `autoHide` on a live instance
+  // leaves its already scheduled hide behind, so the scrollbars disappear again
+  // a second after being switched to "always show".
+  watch(() => store.getters.getAlwaysShowScrollbars, () => {
+    for (const [instance, initialization] of [...instances]) {
+      instance.destroy()
+      create(initialization)
+    }
+  })
+}
+
+/**
+ * @param {HTMLElement} element
+ * @param {boolean} enabled
+ */
+function toggleOverlayScrollbars(element, enabled) {
+  const instance = OverlayScrollbars(element)
+
+  if (enabled && !instance) {
+    // Reusing the element as the viewport keeps it the scrolling element, so
+    // existing scrollTop/scrollLeft handling and CSS carry on working.
+    create({ target: element, elements: { viewport: element } })
+  } else if (!enabled && instance) {
+    instance.destroy()
+  }
+}
+
+/**
+ * `v-overlay-scrollbars` - does the same for a nested scroll container.
+ * Pass `false` to leave the native scrollbars alone, for containers that only
+ * scroll in some layouts.
+ *
+ * Surviving a `<Teleport>` is fine, but note that the library restores the
+ * scroll offset the container had before the move, where a native scroll
+ * container would have been reset to the top. Containers that recompute their
+ * own scroll position after moving (the watch page playlist) can't use this.
+ */
+export const overlayScrollbarsDirective = {
+  mounted(element, binding) {
+    toggleOverlayScrollbars(element, binding.value !== false)
+  },
+
+  updated(element, binding) {
+    toggleOverlayScrollbars(element, binding.value !== false)
+  },
+
+  unmounted(element) {
+    toggleOverlayScrollbars(element, false)
+  }
+}

--- a/src/renderer/main.js
+++ b/src/renderer/main.js
@@ -13,8 +13,10 @@ import {
   facPlaylistCheck,
   facVerticalTabs
 } from './customIcons'
+import { initializeAppScrollbars, overlayScrollbarsDirective } from './helpers/overlayScrollbars'
 // import the styles
 import '@fortawesome/fontawesome-svg-core/styles.css'
+import 'overlayscrollbars/styles/overlayscrollbars.css'
 
 import { register as registerSwiper } from 'swiper/element'
 
@@ -322,6 +324,7 @@ app
   .component('FontAwesomeIcon', FontAwesomeIcon)
   .component('FontAwesomeLayers', FontAwesomeLayers)
   .directive('observe-visibility', ObserveVisibility)
+  .directive('overlay-scrollbars', overlayScrollbarsDirective)
 
   .use(router)
   .use(store)
@@ -333,6 +336,7 @@ const tabNavigation = initializeTabNavigationService(router, store)
 
 router.isReady().then(() => {
   app.mount('#app')
+  initializeAppScrollbars()
 })
 
 // to avoid accessing electron api from web app build

--- a/src/renderer/store/modules/settings.js
+++ b/src/renderer/store/modules/settings.js
@@ -168,6 +168,7 @@ export const defaultSideEffectsTriggerId = settingId =>
 /*****/
 
 const state = {
+  alwaysShowScrollbars: false,
   autoOpenChapters: false,
   autoplayPlaylists: true,
   autoplayVideos: true,

--- a/src/renderer/themes.css
+++ b/src/renderer/themes.css
@@ -2157,9 +2157,21 @@ a:visited {
   animation-duration: 200ms;
 }
 
-::-webkit-scrollbar {
-  inline-size: auto;
-  block-size: auto;
+/* Scrollbars are drawn by OverlayScrollbars (see helpers/overlayScrollbars.js)
+   so they float above the content instead of taking up layout space. The
+   library resets every --os-* variable on `.os-scrollbar` itself, so these have
+   to be set on the same element rather than inherited from `body`. */
+body .os-scrollbar {
+  box-sizing: border-box;
+
+  --os-size: 10px;
+  --os-padding-perpendicular: 2px;
+  --os-padding-axis: 2px;
+  --os-handle-interactive-area-offset: 4px;
+  --os-handle-border-radius: 6px;
+  --os-handle-bg: var(--scrollbar-color);
+  --os-handle-bg-hover: var(--scrollbar-color-hover);
+  --os-handle-bg-active: var(--scrollbar-color-hover);
 }
 
 /* shared shimmer for skeleton loading placeholders */
@@ -2184,18 +2196,3 @@ a:visited {
   }
 }
 
-::-webkit-scrollbar-thumb {
-  background: var(--scrollbar-color);
-  border-radius: 6px;
-  border: 2px solid transparent;
-  background-clip: padding-box;
-}
-
-::-webkit-scrollbar-thumb:hover {
-  border: 0;
-}
-
-::-webkit-scrollbar-thumb:hover,
-::-webkit-scrollbar-thumb:focus {
-  background: var(--scrollbar-color-hover);
-}

--- a/src/renderer/views/Watch/Watch.scss
+++ b/src/renderer/views/Watch/Watch.scss
@@ -204,7 +204,11 @@
 
     :deep(.chaptersWrapper) {
       max-block-size: 480px;
-      scrollbar-color: var(--scrollbar-color) transparent;
+
+      // In the sidebar the chapters sit on a card rather than above the video,
+      // so drop the light handle and take the theme's colour again
+      --scrollbar-color: inherit;
+      --scrollbar-color-hover: inherit;
     }
 
     :deep(.chapter) {

--- a/static/locales/en-US.yaml
+++ b/static/locales/en-US.yaml
@@ -432,6 +432,7 @@ Settings:
     UI Scale: UI Scale
     Thumbnail Size: Thumbnail Size
     Show Thumbnail Size Button in Header: Show Thumbnail Size Button in Header
+    Always Show Scrollbars: Always Show Scrollbars
     Hide Side Bar Labels: Hide Side Bar Labels
     Hide OpenTubeX Header Logo: Hide OpenTubeX Header Logo
     Hide Profile Selector in Header: Hide Profile Selector in Header
@@ -1657,6 +1658,7 @@ Tooltips:
     Auto Refresh Interval: How often OpenTubeX automatically refreshes your subscription feed while the app is open.
   Theme Settings:
     Hide Profile Selector in Header: Hides the profile selector from the top bar. The profile selector will be shown at the top of the Subscribed Channels page instead.
+    Always Show Scrollbars: Keeps the scrollbars visible at all times. When disabled, they fade out shortly after you stop moving the mouse and reappear as soon as you move it again.
   Experimental Settings:
     Replace HTTP Cache: Disables Electron's disk based HTTP cache and enables a custom in-memory image cache. Will lead to increased RAM usage.
   SponsorBlock Settings:


### PR DESCRIPTION
Replaces the app's scrollbars with [OverlayScrollbars](https://github.com/KingSora/OverlayScrollbars) so they float above the content instead of taking up layout space.

## Why not the native ones

Two dead ends worth recording, both confirmed by experiment on Electron 43 (Chromium 142):

- **Chromium's own overlay scrollbars** (`--enable-features=OverlayScrollbar`) do float above the content, but they can't be styled, they grow arrow buttons on hover, and they fade out on a timer with no CSS or flag to stop it.
- **Keeping `::-webkit-scrollbar` styling** forces Chromium straight back to classic, space-taking scrollbars. `overflow: overlay` is gone too - it computes to `auto` and still reserves space.

So a CSS-only version of "overlays the content, always visible, no arrows" isn't possible any more.

## What's covered

`initializeAppScrollbars()` handles the page itself; a `v-overlay-scrollbars` directive handles the side nav, the vertical tab bar, the search suggestions, and the watch page description, transcript, comments and chapters. Nested containers are registered as their own viewport, so they stay the scrolling element and existing `scrollTop` code and CSS keep working.

Theming reuses the existing `--scrollbar-color` / `--scrollbar-color-hover` variables, mapped onto the library's `--os-*` properties in `themes.css`. The player-overlay panels set those variables locally to keep their light handle.

**The fullscreen playlist deliberately keeps native scrollbars.** `Watch.js` re-centres that list when it moves between the sidebar and the dock, but the library restores the scroll offset from before the move and there's no option to turn that off. Measured while the list moves:

| | scrollHeight | clientHeight | scrollTop | off-centre |
|---|---|---|---|---|
| sidebar | 71639 | 360 | 53624 | 0.5 |
| dock (+1s) | 65372 | 713 | 53550 | 6186 |
| dock (+5s) | 65372 | 713 | 53550 | 53645 |

The restored offset means something else entirely in the dock's layout, so the current video ends up thousands of pixels away.

## New setting

"Always Show Scrollbars" in Theme Settings, **off by default**. Off means they hide once the pointer rests and come back as soon as it moves; on means they stay put. Changing it rebuilds the live instances rather than reconfiguring them - swapping `autoHide` on a running instance leaves its already scheduled hide behind, so the scrollbars would vanish a second after being switched to "always show".

## Testing

- New `e2e/tests/offline/scrollbar-overlay.spec.mjs`: no layout cost, hide-on-idle and return-on-move, theming, nested containers still scrolling themselves, and the setting taking effect on existing scrollbars without losing the scroll position.
- New case in `e2e/tests/network/watch.spec.mjs` covering the sidebar panels.
- `search-history-limit.spec.mjs` pinned the removed `::-webkit-scrollbar` width; retargeted at the overlay behaviour.
- Offline 130/130, unit 46/46, eslint and stylelint clean. Network passes apart from the two `automatic picture-in-picture` tests, which fail on `development` too.

## Follow-up

The scrollbar-width compensation in `FtAutoGrid/gridWidth.js` and `FtPrompt.vue` now always measures zero. It's inert rather than harmful, so I've left it for a separate cleanup.
