### PR TITLE
fix(comments): give auto-load sentinel visible area

### DIFF
--- a/e2e/tests/network/watch.spec.mjs
+++ b/e2e/tests/network/watch.spec.mjs
@@ -374,7 +374,6 @@ test.describe('watch page', () => {
     await page.addStyleTag({
       content: `
         .fullscreenCommentsOverlay .comment { display: none; }
-        .fullscreenCommentsOverlay .commentAutoLoadSentinel { min-height: 1px; }
       `
     })
     await page.route(/\/youtubei\/v1\/next/, async (route) => {

--- a/src/renderer/components/CommentSection/CommentSection.css
+++ b/src/renderer/components/CommentSection/CommentSection.css
@@ -128,6 +128,10 @@
   margin: 0;
 }
 
+.commentAutoLoadSentinel {
+  min-block-size: 1px;
+}
+
 .getCommentsTitle {
   padding-block: 8px;
   text-align: center;


### PR DESCRIPTION
Follow-up to #305. The fullscreen auto-load regression test was injecting a one-pixel sentinel height that production did not have, so it masked the remaining failure. Move that geometry into the real component and remove the test-only workaround.\n\nVerification:\n- fullscreen consecutive auto-load regression: 3/3 passed\n- style lint passed\n- JavaScript syntax and diff checks passed