### PR TITLE
fix: support shortcuts for selected tabs

### DIFF
--- a/e2e/tests/offline/tabs.spec.mjs
+++ b/e2e/tests/offline/tabs.spec.mjs
@@ -124,6 +124,37 @@ test.describe('tab bar', () => {
     await expect(tabs.nth(1)).toHaveClass(/active/)
   })
 
+  test('applies close and reload shortcuts to the selected tabs', async ({ page }) => {
+    await page.locator(sel.newTabButton).click()
+    await page.locator(sel.newTabButton).click()
+
+    let tabs = page.locator(sel.tabs)
+    await tabs.first().click()
+    await tabs.nth(2).click({ modifiers: ['Control'] })
+
+    const beforeReload = await page.evaluate(() => window.ftElectron.tabs.getState())
+    const selectedIds = [beforeReload.tabs[0].id, beforeReload.tabs[2].id]
+    const unselectedId = beforeReload.tabs[1].id
+    const refreshKeys = Object.fromEntries(
+      beforeReload.tabs.map(tab => [tab.id, tab.refreshKey])
+    )
+
+    await page.keyboard.press('Control+r')
+    await expect.poll(async () => {
+      const state = await page.evaluate(() => window.ftElectron.tabs.getState())
+      return Object.fromEntries(state.tabs.map(tab => [tab.id, tab.refreshKey]))
+    }).toEqual({
+      [selectedIds[0]]: refreshKeys[selectedIds[0]] + 1,
+      [unselectedId]: refreshKeys[unselectedId],
+      [selectedIds[1]]: refreshKeys[selectedIds[1]] + 1
+    })
+
+    await page.keyboard.press('Control+w')
+    await expect(tabs).toHaveCount(1)
+    tabs = page.locator(sel.tabs)
+    await expect(tabs).toHaveAttribute('data-tab-id', unselectedId)
+  })
+
   test('applies a complete tab reorder in one state update', async ({ page }) => {
     await page.locator(sel.newTabButton).click()
     await page.locator(sel.newTabButton).click()
@@ -673,6 +704,21 @@ test.describe('background tab shortcuts', () => {
         }
       ]
     }
+  })
+
+  test('Ctrl+R refreshes the current feed on an active subscriptions tab', async ({ page }) => {
+    await expect(page.getByText(/disabled automatic subscription fetching/i)).toBeVisible()
+    await page.route(/^https?:\/\//, (route) => route.abort())
+
+    const externalRequests = []
+    page.on('request', (request) => {
+      if (/^https?:/.test(request.url())) {
+        externalRequests.push(request.url())
+      }
+    })
+
+    await page.keyboard.press('Control+r')
+    await expect.poll(() => externalRequests.length).toBeGreaterThan(0)
   })
 
   // Regression: the document-level subscriptions listener refreshed a hidden

--- a/e2e/tests/offline/tabs.spec.mjs
+++ b/e2e/tests/offline/tabs.spec.mjs
@@ -124,6 +124,22 @@ test.describe('tab bar', () => {
     await expect(tabs.nth(1)).toHaveClass(/active/)
   })
 
+  test('clears multi-selection when a shortcut activates another tab', async ({ page }) => {
+    const tabIds = await openThreeTabsAndActivate(page, 0)
+    const tabs = page.locator(sel.tabs)
+    await tabs.nth(2).click({ modifiers: ['Control'] })
+    await expect(page.locator(`${sel.tabs}[aria-pressed="true"]`)).toHaveCount(2)
+
+    await page.keyboard.press('Control+2')
+    await expect(tabs.nth(1)).toHaveClass(/active/)
+    await expect(page.locator(`${sel.tabs}[aria-pressed="true"]`)).toHaveCount(0)
+
+    await page.keyboard.press('Control+w')
+    await expect(tabs).toHaveCount(2)
+    const remainingTabIds = await tabs.evaluateAll(elements => elements.map(tab => tab.dataset.tabId))
+    expect(remainingTabIds).toEqual([tabIds[0], tabIds[2]])
+  })
+
   test('applies close and reload shortcuts to the selected tabs', async ({ page }) => {
     await page.locator(sel.newTabButton).click()
     await page.locator(sel.newTabButton).click()

--- a/src/constants.js
+++ b/src/constants.js
@@ -39,6 +39,7 @@ const IpcChannels = {
   TABS_REORDER: 'tabs-reorder',
   TABS_SET_PINNED: 'tabs-set-pinned',
   TABS_SET_COLOR: 'tabs-set-color',
+  TABS_SET_SELECTED: 'tabs-set-selected',
   TABS_SET_LOADING: 'tabs-set-loading',
   TABS_CAPTURE_PREVIEW: 'tabs-capture-preview',
   TABS_GET_CACHED_PREVIEWS: 'tabs-get-cached-previews',

--- a/src/main/index.js
+++ b/src/main/index.js
@@ -4213,7 +4213,15 @@ function runApp() {
               if (browserWindow) {
                 const tabManager = TabManager.getForWindow(browserWindow.id)
                 if (tabManager && tabManager.activeTabId) {
-                  const hasRemainingTabs = tabManager.closeTab(tabManager.activeTabId)
+                  const tabIds = tabManager.selectedTabIds.length > 1
+                    ? [...tabManager.selectedTabIds]
+                    : [tabManager.activeTabId]
+                  tabIds.sort((a, b) => Number(a === tabManager.activeTabId) - Number(b === tabManager.activeTabId))
+                  let hasRemainingTabs = true
+                  for (const tabId of tabIds) {
+                    hasRemainingTabs = tabManager.closeTab(tabId)
+                    if (!hasRemainingTabs) break
+                  }
                   if (!hasRemainingTabs) {
                     browserWindow.close()
                   }
@@ -4230,7 +4238,12 @@ function runApp() {
               if (browserWindow) {
                 const tabManager = TabManager.getForWindow(browserWindow.id)
                 if (tabManager) {
-                  tabManager.requestReload()
+                  const tabIds = tabManager.selectedTabIds.length > 1
+                    ? tabManager.selectedTabIds
+                    : [tabManager.activeTabId]
+                  for (const tabId of tabIds) {
+                    tabManager.requestReload(tabId)
+                  }
                 }
               }
             }

--- a/src/main/tabs/TabManager.js
+++ b/src/main/tabs/TabManager.js
@@ -552,6 +552,8 @@ export class TabManager {
     this.contextMenuTabId = null
     /** @type {string[]} */
     this.contextMenuSelectedTabIds = []
+    /** @type {string[]} */
+    this.selectedTabIds = []
     this.contextMenuSurface = 'content'
     this.contextMenuSubscriptionFeedTab = null
     this.contextMenuTabBarVertical = false
@@ -1163,6 +1165,7 @@ export class TabManager {
       : null
 
     this.tabs.delete(tabId)
+    this.selectedTabIds = this.selectedTabIds.filter(selectedTabId => selectedTabId !== tabId)
     this._deferredCloseTabIds.delete(tabId)
     this._deferredUnloadTabIds.delete(tabId)
     this._resolveTabMountWaiters(tabId, Number.MAX_SAFE_INTEGER, false)
@@ -2491,6 +2494,17 @@ export async function setupTabsIPC(options = {}) {
     if (manager && typeof tabId === 'string') {
       manager.activateTab(tabId)
     }
+  })
+
+  ipcMain.on(IpcChannels.TABS_SET_SELECTED, (event, tabIds) => {
+    const manager = getManager(event)
+    if (!manager) return
+
+    manager.selectedTabIds = Array.isArray(tabIds)
+      ? Array.from(new Set(tabIds.filter(tabId => {
+          return typeof tabId === 'string' && manager.tabs.has(tabId)
+        })))
+      : []
   })
 
   ipcMain.handle(IpcChannels.TABS_IS_ACTIVE, (event, tabId) => {

--- a/src/preload/interface.js
+++ b/src/preload/interface.js
@@ -809,6 +809,15 @@ export default {
     },
 
     /**
+     * Keep the main process aware of the tab bar's multi-selection so native
+     * menu shortcuts can target the same tabs.
+     * @param {string[]} tabIds
+     */
+    setSelected: (tabIds) => {
+      ipcRenderer.send(IpcChannels.TABS_SET_SELECTED, tabIds)
+    },
+
+    /**
      * Listen for reload requests from main (e.g. menu "Reload Tab").
      * @param {(tabId: string) => void} handler
      * @returns {() => void}

--- a/src/renderer/App.vue
+++ b/src/renderer/App.vue
@@ -1799,7 +1799,7 @@ function handleKeyboardShortcuts(event) {
     // Ctrl+W: Close tab (handled in menu, but also here for robustness)
     if (matchesKeyboardShortcut(event, shortcuts.CLOSE_TAB)) {
       event.preventDefault()
-      store.dispatch('closeActiveTab').then((hasRemainingTabs) => {
+      closeShortcutTabs().then((hasRemainingTabs) => {
         if (!hasRemainingTabs) {
           window.close()
         }
@@ -1823,12 +1823,15 @@ function handleKeyboardShortcuts(event) {
 
     // Ctrl+R: Reload tab (unless the current view handles refresh itself)
     if (matchesKeyboardShortcut(event, shortcuts.RELOAD_TAB)) {
-      if (route.path.startsWith('/subscriptions')) {
+      const tabIds = getShortcutTabIds()
+      if (tabIds.length === 1 && route.path.startsWith('/subscriptions')) {
         event.preventDefault()
         return
       }
       event.preventDefault()
-      prepareAndReloadTab()
+      for (const tabId of tabIds) {
+        prepareAndReloadTab(tabId)
+      }
     }
   }
 }
@@ -2270,6 +2273,26 @@ async function prepareAndReloadTab(tabId = activeTabId.value) {
     }
   }
   store.dispatch('reloadTab', tabId)
+}
+
+function getShortcutTabIds() {
+  const selectedTabIds = store.getters.getSelectedTabIds
+  return selectedTabIds.length > 1
+    ? [...selectedTabIds]
+    : activeTabId.value ? [activeTabId.value] : []
+}
+
+async function closeShortcutTabs() {
+  const tabIds = getShortcutTabIds()
+  const activeId = activeTabId.value
+  tabIds.sort((a, b) => Number(a === activeId) - Number(b === activeId))
+
+  let hasRemainingTabs = true
+  for (const tabId of tabIds) {
+    hasRemainingTabs = await store.dispatch('closeTab', tabId)
+    if (!hasRemainingTabs) break
+  }
+  return hasRemainingTabs
 }
 
 function handleMouseDown() {

--- a/src/renderer/components/SubscriptionsTabUi/SubscriptionsTabUi.vue
+++ b/src/renderer/components/SubscriptionsTabUi/SubscriptionsTabUi.vue
@@ -283,7 +283,13 @@ function keyboardShortcutHandler(event) {
   if (event.repeat) { return }
 
   if (
-    matchesKeyboardShortcut(event, KeyboardShortcuts.APP.SITUATIONAL.REFRESH) &&
+    (
+      matchesKeyboardShortcut(event, KeyboardShortcuts.APP.SITUATIONAL.REFRESH) ||
+      (
+        store.getters.getSelectedTabIds.length <= 1 &&
+        matchesKeyboardShortcut(event, KeyboardShortcuts.APP.GENERAL.RELOAD_TAB)
+      )
+    ) &&
     !displayIsLoading.value &&
     activeProfileHasSubscriptions.value
   ) {

--- a/src/renderer/components/SubscriptionsTabUi/SubscriptionsTabUi.vue
+++ b/src/renderer/components/SubscriptionsTabUi/SubscriptionsTabUi.vue
@@ -286,6 +286,7 @@ function keyboardShortcutHandler(event) {
     (
       matchesKeyboardShortcut(event, KeyboardShortcuts.APP.SITUATIONAL.REFRESH) ||
       (
+        process.env.IS_ELECTRON &&
         store.getters.getSelectedTabIds.length <= 1 &&
         matchesKeyboardShortcut(event, KeyboardShortcuts.APP.GENERAL.RELOAD_TAB)
       )

--- a/src/renderer/components/TabBar/TabBar.vue
+++ b/src/renderer/components/TabBar/TabBar.vue
@@ -119,8 +119,7 @@ const tabsViewportRef = useTemplateRef('tabsViewportRef')
 const dropZoneRef = useTemplateRef('dropZoneRef')
 const scrollbarRef = useTemplateRef('scrollbarRef')
 const closeTooltipsSignal = ref(0)
-/** @type {import('vue').Ref<Set<string>>} */
-const selectedTabIds = ref(new Set())
+const selectedTabIds = computed(() => new Set(store.getters.getSelectedTabIds))
 /** @type {string | null} */
 let selectionAnchorId = null
 
@@ -278,9 +277,7 @@ function handleDragPointerMove(event) {
       !selectedTabIds.value.has(dragSession.tabId) ||
       selectedTabIds.value.size !== dragSession.tabIds.length
     ) {
-      selectedTabIds.value = dragSession.tabIds.length > 1
-        ? new Set(dragSession.tabIds)
-        : new Set()
+      setTabSelection(dragSession.tabIds.length > 1 ? dragSession.tabIds : [])
       selectionAnchorId = dragSession.tabId
     }
     draggingTabIds.value = new Set(dragSession.tabIds)
@@ -647,7 +644,7 @@ function handleActivate(event, tabId) {
     const targetIndex = tabs.value.findIndex(tab => tab.id === tabId)
     if (anchorIndex !== -1 && targetIndex !== -1) {
       const [start, end] = [anchorIndex, targetIndex].sort((a, b) => a - b)
-      selectedTabIds.value = new Set(tabs.value.slice(start, end + 1).map(tab => tab.id))
+      setTabSelection(tabs.value.slice(start, end + 1).map(tab => tab.id))
       return
     }
   }
@@ -663,7 +660,7 @@ function handleActivate(event, tabId) {
     } else {
       nextSelection.add(tabId)
     }
-    selectedTabIds.value = nextSelection
+    setTabSelection([...nextSelection])
     selectionAnchorId = tabId
     return
   }
@@ -674,7 +671,14 @@ function handleActivate(event, tabId) {
 }
 
 function clearTabSelection() {
-  selectedTabIds.value = new Set()
+  setTabSelection([])
+}
+
+/**
+ * @param {string[]} tabIds
+ */
+function setTabSelection(tabIds) {
+  store.dispatch('setTabSelection', tabIds)
 }
 
 /**
@@ -1108,7 +1112,7 @@ watch(tabs, (nextTabs) => {
   const currentIds = new Set(nextTabs.map(tab => tab.id))
   const nextSelection = new Set([...selectedTabIds.value].filter(tabId => currentIds.has(tabId)))
   if (nextSelection.size !== selectedTabIds.value.size) {
-    selectedTabIds.value = nextSelection
+    setTabSelection([...nextSelection])
   }
   if (selectionAnchorId && !currentIds.has(selectionAnchorId)) {
     selectionAnchorId = null

--- a/src/renderer/store/modules/tabs.js
+++ b/src/renderer/store/modules/tabs.js
@@ -7,6 +7,7 @@ const HALF_NAV_HISTORY_DISPLAY_LIMIT = Math.trunc(NAV_HISTORY_DISPLAY_LIMIT / 2)
 const state = {
   tabs: [],
   activeTabId: null,
+  selectedTabIds: [],
   presentedTabId: null,
   mainPresentedTabId: null,
   selectionRevision: 0,
@@ -21,6 +22,7 @@ const getters = {
   getTabs: (state) => state.tabs,
   getActiveTabId: (state) => state.activeTabId,
   getActiveTab: (state) => state.tabs.find(tab => tab.id === state.activeTabId) ?? null,
+  getSelectedTabIds: (state) => state.selectedTabIds,
   getPresentedTabId: (state) => state.presentedTabId,
   getPresentedTab: (state) => state.tabs.find(tab => tab.id === state.presentedTabId) ?? null,
   getTabById: (state) => (tabId) => state.tabs.find(tab => tab.id === tabId) ?? null,
@@ -77,6 +79,7 @@ const mutations = {
     }
 
     state.tabs = incomingTabs.map(tab => reconcileTab(previousTabsById.get(tab.id), tab))
+    state.selectedTabIds = state.selectedTabIds.filter(tabId => incomingIds.has(tabId))
     state.activeTabId = payload.activeTabId ?? null
     state.mainPresentedTabId = payload.presentedTabId ?? null
     state.selectionRevision = Number.isInteger(payload.selectionRevision)
@@ -96,6 +99,11 @@ const mutations = {
 
   setPresentedTab(state, tabId) {
     state.presentedTabId = tabId
+  },
+
+  setSelectedTabIds(state, tabIds) {
+    const existingIds = new Set(state.tabs.map(tab => tab.id))
+    state.selectedTabIds = Array.from(new Set(tabIds.filter(tabId => existingIds.has(tabId))))
   },
 
   setTabTransition(state, { revision, tabId }) {
@@ -204,6 +212,12 @@ const actions = {
   activateTab(_context, tabId) {
     if (!process.env.IS_ELECTRON) return
     window.ftElectron.tabs.activate(tabId)
+  },
+
+  setTabSelection({ commit }, tabIds) {
+    if (!process.env.IS_ELECTRON) return
+    commit('setSelectedTabIds', tabIds)
+    window.ftElectron.tabs.setSelected(tabIds)
   },
 
   async closeTab(_context, tabId) {


### PR DESCRIPTION
## What changed

- synchronize multi-tab selection with the renderer store and Electron main process
- apply Ctrl+W and Ctrl+R to every selected tab
- preserve subscription feed refresh behavior for single-tab Ctrl+R
- reload selected subscription tabs when Ctrl+R is used with a multi-selection
- add Electron E2E coverage for close, reload, and subscription feed refresh shortcuts

## Why

Tab selection previously lived only inside the tab bar component, while Electron's native menu handled the primary close and reload accelerators. As a result, those shortcuts only knew about the active tab. The subscriptions shortcut guard also swallowed Ctrl+R before multi-selection handling could run.

The selection is now shared with both shortcut paths, while single active subscription tabs continue to route Ctrl+R to their current feed refresh.

## Validation

- `pnpm run test:unit` — 61 passed
- packaged Electron tab suite under Xvfb — 30 passed
- ESLint on changed source files
- `git diff --check`
