### PR TITLE
Fix default filters for context-menu searches

### DIFF
--- a/e2e/tests/offline/search-context-menu.spec.mjs
+++ b/e2e/tests/offline/search-context-menu.spec.mjs
@@ -1,0 +1,24 @@
+import { test, expect, sel } from '../../helpers/app.mjs'
+
+test('searching selected text in a new tab uses the default filters', async ({ page }) => {
+  const contextMenu = await page.evaluate(() => window.ftElectron.contextMenu.open({
+    selectionText: 'context search'
+  }))
+  const search = contextMenu.items.find(item => item.label === 'Search "context search" in a New Tab')
+
+  await page.evaluate(({ sessionId, actionId }) => {
+    return window.ftElectron.contextMenu.execute(sessionId, actionId)
+  }, { sessionId: contextMenu.sessionId, actionId: search.actionId })
+
+  await expect(page.locator(sel.tabs)).toHaveCount(2)
+  await expect(page).toHaveURL(/#\/search\/context%20search/)
+
+  const filterButton = page.locator('.navFilterButton')
+  await expect(filterButton).not.toHaveClass(/filterChanged/)
+  await filterButton.click()
+
+  await expect(page.locator('input[type="radio"][value="relevance"]')).toBeChecked()
+  await expect(page.locator('input[type="radio"][value="all"]')).toBeChecked()
+  await expect(page.locator('.searchRadio', { hasText: 'Time' }).locator('input[value=""]')).toBeChecked()
+  await expect(page.locator('.searchRadio', { hasText: 'Duration' }).locator('input[value=""]')).toBeChecked()
+})

--- a/src/renderer/views/SearchPage/SearchPage.vue
+++ b/src/renderer/views/SearchPage/SearchPage.vue
@@ -125,20 +125,25 @@ function restoreActiveSearchFilters(settings) {
   })
 }
 
-watch(route, () => {
-  const query_ = route.params.query.trim()
+function getRouteSearchSettings() {
   let features = route.query.features
   // if page gets refreshed and there's only one feature then it will be a string
   if (typeof features === 'string') {
     features = [features]
   }
-  const searchSettings = {
-    prioritize: route.query.prioritize,
-    time: route.query.time,
-    type: route.query.type,
-    duration: route.query.duration,
+
+  return {
+    prioritize: route.query.prioritize ?? 'relevance',
+    time: route.query.time ?? '',
+    type: route.query.type ?? 'all',
+    duration: route.query.duration ?? '',
     features: features ?? [],
   }
+}
+
+watch(route, () => {
+  const query_ = route.params.query.trim()
+  const searchSettings = getRouteSearchSettings()
 
   const payload = {
     query: query_,
@@ -157,19 +162,7 @@ onMounted(() => {
   query.value = route.params.query
   setTabTitle(processedQuery.value)
 
-  let features = route.query.features
-  // if page gets refreshed and there's only one feature then it will be a string
-  if (typeof features === 'string') {
-    features = [features]
-  }
-
-  searchSettings.value = {
-    prioritize: route.query.prioritize,
-    time: route.query.time,
-    type: route.query.type,
-    duration: route.query.duration,
-    features: features ?? [],
-  }
+  searchSettings.value = getRouteSearchSettings()
   restoreActiveSearchFilters(searchSettings.value)
 
   const payload = {


### PR DESCRIPTION
## Summary

- normalize missing search route filter parameters to their default values
- keep the filter indicator inactive for context-menu searches without explicit filters
- add an offline E2E regression test covering “Search selected text in a New Tab” and the default radio selections

## Root cause

The context-menu search route omits filter query parameters. `SearchPage` copied those missing parameters into per-tab search state as `undefined`, which did not match any radio option and was also treated as a changed filter value.

## User impact

Right-click searches now open with visibly selected defaults and no misleading active-filter indicator.

## Validation

- `pnpm exec eslint --config eslint.config.mjs src/renderer/views/SearchPage/SearchPage.vue e2e/tests/offline/search-context-menu.spec.mjs`
- `xvfb-run -a -s "-screen 0 1920x1080x24" pnpm exec playwright test -c e2e/playwright.config.mjs --project=offline e2e/tests/offline/search-context-menu.spec.mjs`
- `xvfb-run -a -s "-screen 0 1920x1080x24" pnpm exec playwright test -c e2e/playwright.config.mjs --project=offline e2e/tests/offline/search-history.spec.mjs e2e/tests/offline/search-keyboard.spec.mjs`
- `git diff --check`