### PR TITLE
fix(player): refill the SABR refetch budget after the stream settles

### DIFF
--- a/e2e/tests/offline/sabr-error-recovery.spec.mjs
+++ b/e2e/tests/offline/sabr-error-recovery.spec.mjs
@@ -1,0 +1,214 @@
+import crypto from 'node:crypto'
+import { readFile, readdir } from 'node:fs/promises'
+import path from 'node:path'
+import { gunzipSync } from 'node:zlib'
+
+import { goTo, repoRoot, test, expect } from '../../helpers/app.mjs'
+import { fixtureKey } from '../../helpers/innertube.mjs'
+
+const fixtureDir = path.join(repoRoot, 'e2e', 'fixtures', 'innertube', 'watch', 'shows-video-metadata')
+const sharedDir = path.join(repoRoot, 'e2e', 'fixtures', 'innertube', 'shared')
+
+test.use({
+  seed: {
+    history: [{
+      _id: 'jNQXAC9IVRw',
+      videoId: 'jNQXAC9IVRw',
+      title: 'SABR test video',
+      author: 'Test Channel',
+      authorId: 'UC-test-channel-id',
+      published: Date.now() - 86_400_000,
+      description: '',
+      viewCount: 1234,
+      lengthSeconds: 600,
+      watchProgress: 10,
+      isWatched: false,
+      timeWatched: Date.now(),
+      isLive: false,
+      type: 'video'
+    }]
+  }
+})
+
+async function fixture(dir, name) {
+  try {
+    return gunzipSync(await readFile(path.join(dir, name)))
+  } catch {
+    return null
+  }
+}
+
+/**
+ * Serves the watch page from fixtures with an unplayable video, so the Watch
+ * view mounts without a real player emitting errors of its own.
+ */
+async function mockWatchPage(app, page) {
+  await app.electronApp.evaluate(({ ipcMain }) => {
+    ipcMain.removeHandler('generate-po-token')
+    ipcMain.handle('generate-po-token', () => 'test-po-token')
+  })
+
+  await page.route(/^https?:\/\//, (route) => route.abort())
+  await page.route(/^https?:\/\//, async (route, request) => {
+    const url = request.url()
+
+    if (url.includes('/img/desktop/unavailable/')) {
+      return route.fulfill({ status: 200, contentType: 'image/png', body: '' })
+    }
+
+    if (/\/s\/player\//.test(url) || /\/sw\.js_data/.test(url)) {
+      const { pathname } = new URL(url)
+      const name = `shared-${crypto.createHash('sha1').update(pathname).digest('hex').slice(0, 12)}.gz`
+      const body = await fixture(sharedDir, name) ??
+        (url.includes('/s/player/') ? await fixture(sharedDir, 'shared-99c4a5c04897.gz') : null)
+      if (body) {
+        return route.fulfill({
+          status: 200,
+          contentType: url.includes('/s/player/') ? 'text/javascript' : 'application/json',
+          body
+        })
+      }
+      return route.abort()
+    }
+
+    if (url.includes('/youtubei/v1/player')) {
+      const files = await readdir(fixtureDir)
+      const body = await fixture(fixtureDir, files.find((file) => file.startsWith('player-')))
+      const json = JSON.parse(body.toString())
+      json.playabilityStatus = { status: 'UNPLAYABLE', reason: 'Video unavailable' }
+      delete json.streamingData
+      return route.fulfill({ status: 200, contentType: 'application/json', body: JSON.stringify(json) })
+    }
+
+    if (url.includes('/youtubei/v1/')) {
+      const key = fixtureKey(url, request.postData())
+      let body = await fixture(fixtureDir, `${key}.0.json.gz`)
+      if (!body) {
+        const endpoint = key.replace(/-[0-9a-f]{12}$/, '')
+        const files = (await readdir(fixtureDir)).filter((file) => file.startsWith(`${endpoint}-`))
+        if (files.length > 0) body = await fixture(fixtureDir, files[0])
+      }
+      if (body) {
+        return route.fulfill({ status: 200, contentType: 'application/json', body })
+      }
+      return route.abort()
+    }
+
+    return route.fallback()
+  })
+}
+
+/**
+ * Puts the mounted Watch view into "playing a SABR stream on DASH" state, then
+ * replays a scripted sequence of critical player errors and playback progress
+ * against it. Reload requests are recorded instead of performed, so the run
+ * stays offline and deterministic.
+ *
+ * @param {import('@playwright/test').Page} page
+ * @param {Array<{ error: true } | { playTo: number }>} script
+ */
+function driveWatchView(page, script) {
+  return page.evaluate(async (steps) => {
+    const app = document.querySelector('#app')?.__vue_app__
+
+    const findWatchView = (vnode) => {
+      if (vnode?.component?.type?.name === 'Watch') {
+        return vnode.component.proxy
+      }
+      if (vnode?.component?.subTree) {
+        const match = findWatchView(vnode.component.subTree)
+        if (match) return match
+      }
+      if (Array.isArray(vnode?.children)) {
+        for (const child of vnode.children) {
+          const match = findWatchView(child)
+          if (match) return match
+        }
+      }
+      return null
+    }
+
+    const watchView = findWatchView(app?._container?._vnode)
+    if (!watchView) {
+      throw new Error('Unable to access the watch view')
+    }
+
+    // The state a video that is playing a SABR stream on the DASH format is in.
+    watchView.errorMessage = ''
+    watchView.isLoading = false
+    watchView.isLive = false
+    watchView.isPostLiveDvr = false
+    watchView.activeFormat = 'dash'
+    watchView.manifestMimeType = 'application/sabr+json'
+    watchView.manifestSrc = 'sabr://test'
+    watchView.legacyFormats = [{ itag: 18, qualityLabel: '360p', height: 360, width: 640, url: 'https://example.invalid/360p' }]
+
+    const reloads = []
+    watchView.onPlayerReloadRequested = async (_payload, toastMessage) => {
+      reloads.push(toastMessage)
+    }
+
+    // A critical, non-abort shaka error: the kind that walks the format
+    // fallback chain. 1002 = BAD_HTTP_STATUS, category 1 = NETWORK.
+    const criticalError = () => ({
+      severity: 2,
+      category: 1,
+      code: 1002,
+      data: ['https://example.invalid/sabr', 500]
+    })
+
+    const formats = []
+    for (const step of steps) {
+      if (step.error) {
+        await watchView.handlePlayerError(criticalError())
+      } else {
+        watchView.handleTimeUpdate(step.playTo)
+      }
+      formats.push(watchView.activeFormat)
+    }
+
+    return { reloads, formats, finalFormat: watchView.activeFormat }
+  }, script)
+}
+
+test('a second SABR failure after successful playback refetches instead of dropping to legacy', async ({ app, page }) => {
+  await mockWatchPage(app, page)
+  await goTo(page, 'history')
+  await page.getByText('SABR test video').click()
+  await expect(page).toHaveURL(/#\/watch\/jNQXAC9IVRw/)
+  await expect(page.locator('.errorMessage')).toBeVisible({ timeout: 30_000 })
+
+  const result = await driveWatchView(page, [
+    { error: true },
+    // The refreshed stream plays well past the settle threshold.
+    { playTo: 10 },
+    { playTo: 120 },
+    // An unrelated failure much later in the same video.
+    { error: true }
+  ])
+
+  expect(result.reloads).toEqual([
+    'Refreshing SABR stream after playback error',
+    'Refreshing SABR stream after playback error'
+  ])
+  expect(result.finalFormat).toBe('dash')
+})
+
+test('SABR failures that never settle stop refetching and fall back to legacy', async ({ app, page }) => {
+  await mockWatchPage(app, page)
+  await goTo(page, 'history')
+  await page.getByText('SABR test video').click()
+  await expect(page).toHaveURL(/#\/watch\/jNQXAC9IVRw/)
+  await expect(page.locator('.errorMessage')).toBeVisible({ timeout: 30_000 })
+
+  // Four back-to-back failures with no playback progress in between.
+  const result = await driveWatchView(page, [
+    { error: true },
+    { error: true },
+    { error: true },
+    { error: true }
+  ])
+
+  expect(result.reloads).toHaveLength(3)
+  expect(result.formats).toEqual(['dash', 'dash', 'dash', 'legacy'])
+})

--- a/e2e/tests/offline/sabr-error-recovery.spec.mjs
+++ b/e2e/tests/offline/sabr-error-recovery.spec.mjs
@@ -105,7 +105,7 @@ async function mockWatchPage(app, page) {
  * stays offline and deterministic.
  *
  * @param {import('@playwright/test').Page} page
- * @param {Array<{ error: true } | { playTo: number }>} script
+ * @param {Array<{ error: true } | { playFor: number } | { seekTo: number }>} script
  */
 function driveWatchView(page, script) {
   return page.evaluate(async (steps) => {
@@ -157,12 +157,23 @@ function driveWatchView(page, script) {
       data: ['https://example.invalid/sabr', 500]
     })
 
+    // The real player emits timeupdate straight off the video element, roughly
+    // four times a second, so playback is replayed here at that granularity.
+    const TICK_SECONDS = 0.25
+    let position = 0
+
     const formats = []
     for (const step of steps) {
       if (step.error) {
         await watchView.handlePlayerError(criticalError())
+      } else if (step.seekTo !== undefined) {
+        position = step.seekTo
+        watchView.handleTimeUpdate(position)
       } else {
-        watchView.handleTimeUpdate(step.playTo)
+        for (let played = 0; played < step.playFor; played += TICK_SECONDS) {
+          position += TICK_SECONDS
+          watchView.handleTimeUpdate(position)
+        }
       }
       formats.push(watchView.activeFormat)
     }
@@ -181,8 +192,7 @@ test('a second SABR failure after successful playback refetches instead of dropp
   const result = await driveWatchView(page, [
     { error: true },
     // The refreshed stream plays well past the settle threshold.
-    { playTo: 10 },
-    { playTo: 120 },
+    { playFor: 60 },
     // An unrelated failure much later in the same video.
     { error: true }
   ])
@@ -211,4 +221,27 @@ test('SABR failures that never settle stop refetching and fall back to legacy', 
 
   expect(result.reloads).toHaveLength(3)
   expect(result.formats).toEqual(['dash', 'dash', 'dash', 'legacy'])
+})
+
+test('seeking around a stream that never plays does not refill the budget', async ({ app, page }) => {
+  await mockWatchPage(app, page)
+  await goTo(page, 'history')
+  await page.getByText('SABR test video').click()
+  await expect(page).toHaveURL(/#\/watch\/jNQXAC9IVRw/)
+  await expect(page.locator('.errorMessage')).toBeVisible({ timeout: 30_000 })
+
+  // Each failure is followed by a long seek rather than real playback, so the
+  // budget must still run out instead of being topped up by the position jump.
+  const result = await driveWatchView(page, [
+    { error: true },
+    { seekTo: 300 },
+    { error: true },
+    { seekTo: 900 },
+    { error: true },
+    { seekTo: 60 },
+    { error: true }
+  ])
+
+  expect(result.reloads).toHaveLength(3)
+  expect(result.finalFormat).toBe('legacy')
 })

--- a/src/renderer/views/Watch/Watch.js
+++ b/src/renderer/views/Watch/Watch.js
@@ -80,6 +80,12 @@ const THEATRE_MODE_ANIMATION_DURATION = 400
 // where the refreshed stream fails again before it ever settles.
 const MAX_SABR_ERROR_RECOVERIES = 3
 const SABR_ERROR_RECOVERY_SETTLE_SECONDS = 30
+// timeupdate fires about four times a second, so a natural tick stays well
+// under a second even at the fastest playback rate, while the smallest seek
+// shortcut jumps 5s. Anything above this is a seek and must not count as played
+// content, otherwise seeking around a broken stream would keep handing it fresh
+// recovery attempts.
+const SABR_ERROR_RECOVERY_MAX_TICK_SECONDS = 2
 let nextSabrSchemeId = 0
 const UNAVAILABLE_VIDEO_THUMBNAILS = {
   light: 'https://www.youtube.com/img/desktop/unavailable/unavailable_video.png',
@@ -265,7 +271,8 @@ export default defineComponent({
       ipBlockRecoveryAttemptedForCurrentVideo: false,
       sabrErrorRecoveryAttempts: 0,
       /** @type {number|null} */
-      sabrErrorRecoveryResumedAtSeconds: null,
+      sabrErrorRecoveryLastSeconds: null,
+      sabrErrorRecoveryPlayedSeconds: 0,
       /** @type {number|null} */
       watchTimeLastTick: null,
       /** @type {Record<string, number>} */
@@ -856,7 +863,8 @@ export default defineComponent({
       if (videoIdChanged) {
         this.ipBlockRecoveryAttemptedForCurrentVideo = false
         this.sabrErrorRecoveryAttempts = 0
-        this.sabrErrorRecoveryResumedAtSeconds = null
+        this.sabrErrorRecoveryLastSeconds = null
+        this.sabrErrorRecoveryPlayedSeconds = 0
       }
       this.ipBlockDetectedInCurrentChain = false
       this.resetVideoState({
@@ -1984,13 +1992,20 @@ export default defineComponent({
       // Once the refreshed stream has actually played a stretch of content it
       // has proven itself, so refill the budget: a later, unrelated SABR
       // failure gets its own refetch instead of dropping straight to legacy
-      // 360p. Seeking backwards past the marker just rebases it.
-      if (this.sabrErrorRecoveryResumedAtSeconds !== null) {
-        if (currentSeconds < this.sabrErrorRecoveryResumedAtSeconds) {
-          this.sabrErrorRecoveryResumedAtSeconds = currentSeconds
-        } else if (currentSeconds - this.sabrErrorRecoveryResumedAtSeconds > SABR_ERROR_RECOVERY_SETTLE_SECONDS) {
-          this.sabrErrorRecoveryAttempts = 0
-          this.sabrErrorRecoveryResumedAtSeconds = null
+      // 360p. Only natural playback ticks count towards that, so seeking around
+      // a stream that never plays can't keep the budget topped up.
+      if (this.sabrErrorRecoveryLastSeconds !== null) {
+        const elapsed = currentSeconds - this.sabrErrorRecoveryLastSeconds
+        this.sabrErrorRecoveryLastSeconds = currentSeconds
+
+        if (elapsed > 0 && elapsed <= SABR_ERROR_RECOVERY_MAX_TICK_SECONDS) {
+          this.sabrErrorRecoveryPlayedSeconds += elapsed
+
+          if (this.sabrErrorRecoveryPlayedSeconds >= SABR_ERROR_RECOVERY_SETTLE_SECONDS) {
+            this.sabrErrorRecoveryAttempts = 0
+            this.sabrErrorRecoveryLastSeconds = null
+            this.sabrErrorRecoveryPlayedSeconds = 0
+          }
         }
       }
 
@@ -2608,8 +2623,9 @@ export default defineComponent({
         // the legacy 360p stream.
         this.sabrErrorRecoveryAttempts++
         // The reload resumes here, so this is the baseline the refreshed stream
-        // has to play past before the refetch budget refills.
-        this.sabrErrorRecoveryResumedAtSeconds = this.getTimestamp()
+        // starts accumulating played content from before the budget refills.
+        this.sabrErrorRecoveryLastSeconds = this.getTimestamp()
+        this.sabrErrorRecoveryPlayedSeconds = 0
         await this.onPlayerReloadRequested(
           this.$refs.player?.getSabrReloadState(),
           'Refreshing SABR stream after playback error'

--- a/src/renderer/views/Watch/Watch.js
+++ b/src/renderer/views/Watch/Watch.js
@@ -74,6 +74,12 @@ import { useTabToast } from '../../composables/useTabToast'
 const MANIFEST_TYPE_DASH = 'application/dash+xml'
 const MANIFEST_TYPE_HLS = 'application/x-mpegurl'
 const THEATRE_MODE_ANIMATION_DURATION = 400
+// A SABR session can go stale more than once during a long video, so the
+// refetch budget is per incident rather than per video: it refills once the
+// refreshed stream has played this many seconds, and only bounds reload loops
+// where the refreshed stream fails again before it ever settles.
+const MAX_SABR_ERROR_RECOVERIES = 3
+const SABR_ERROR_RECOVERY_SETTLE_SECONDS = 30
 let nextSabrSchemeId = 0
 const UNAVAILABLE_VIDEO_THUMBNAILS = {
   light: 'https://www.youtube.com/img/desktop/unavailable/unavailable_video.png',
@@ -257,7 +263,9 @@ export default defineComponent({
       preserveTitleOnNextReload: false,
       ipBlockDetectedInCurrentChain: false,
       ipBlockRecoveryAttemptedForCurrentVideo: false,
-      sabrErrorRecoveryAttemptedForCurrentVideo: false,
+      sabrErrorRecoveryAttempts: 0,
+      /** @type {number|null} */
+      sabrErrorRecoveryResumedAtSeconds: null,
       /** @type {number|null} */
       watchTimeLastTick: null,
       /** @type {Record<string, number>} */
@@ -847,7 +855,8 @@ export default defineComponent({
       const videoIdChanged = this.videoId !== previousVideoId
       if (videoIdChanged) {
         this.ipBlockRecoveryAttemptedForCurrentVideo = false
-        this.sabrErrorRecoveryAttemptedForCurrentVideo = false
+        this.sabrErrorRecoveryAttempts = 0
+        this.sabrErrorRecoveryResumedAtSeconds = null
       }
       this.ipBlockDetectedInCurrentChain = false
       this.resetVideoState({
@@ -1500,10 +1509,15 @@ export default defineComponent({
               this.manifestSrc = await this.createLocalDashManifest(result)
               this.manifestMimeType = MANIFEST_TYPE_DASH
             } else {
+              // Neither a SABR streaming URL nor playable adaptive format URLs,
+              // so the only thing left is the 360p legacy stream. This is a
+              // silent quality drop, so make it identifiable in the logs.
+              console.error(`No SABR or adaptive stream URLs for ${this.videoId}, falling back to the legacy formats...`)
               this.manifestSrc = null
               this.enableLegacyFormat()
             }
           } else {
+            console.error(`No adaptive formats for ${this.videoId}, falling back to the legacy formats...`)
             this.manifestSrc = null
             this.enableLegacyFormat()
           }
@@ -1967,6 +1981,19 @@ export default defineComponent({
     },
 
     handleTimeUpdate: function (currentSeconds) {
+      // Once the refreshed stream has actually played a stretch of content it
+      // has proven itself, so refill the budget: a later, unrelated SABR
+      // failure gets its own refetch instead of dropping straight to legacy
+      // 360p. Seeking backwards past the marker just rebases it.
+      if (this.sabrErrorRecoveryResumedAtSeconds !== null) {
+        if (currentSeconds < this.sabrErrorRecoveryResumedAtSeconds) {
+          this.sabrErrorRecoveryResumedAtSeconds = currentSeconds
+        } else if (currentSeconds - this.sabrErrorRecoveryResumedAtSeconds > SABR_ERROR_RECOVERY_SETTLE_SECONDS) {
+          this.sabrErrorRecoveryAttempts = 0
+          this.sabrErrorRecoveryResumedAtSeconds = null
+        }
+      }
+
       this.updateCurrentTime(currentSeconds)
       this.updateCurrentChapter(currentSeconds)
       this.$store.commit('setCurrentWatchTimestamp', {
@@ -2574,12 +2601,15 @@ export default defineComponent({
       if (
         this.activeFormat === 'dash' &&
         this.manifestMimeType === MANIFEST_TYPE_SABR &&
-        !this.sabrErrorRecoveryAttemptedForCurrentVideo
+        this.sabrErrorRecoveryAttempts < MAX_SABR_ERROR_RECOVERIES
       ) {
         // A SABR playback session may no longer be reusable after a critical
-        // error. Refetch it once in-place before giving up HD and falling back
-        // to the legacy 360p stream.
-        this.sabrErrorRecoveryAttemptedForCurrentVideo = true
+        // error. Refetch it in-place before giving up HD and falling back to
+        // the legacy 360p stream.
+        this.sabrErrorRecoveryAttempts++
+        // The reload resumes here, so this is the baseline the refreshed stream
+        // has to play past before the refetch budget refills.
+        this.sabrErrorRecoveryResumedAtSeconds = this.getTimestamp()
         await this.onPlayerReloadRequested(
           this.$refs.player?.getSabrReloadState(),
           'Refreshing SABR stream after playback error'


### PR DESCRIPTION
## Problem

Videos playing a SABR stream still sometimes drop to the legacy 360p format mid-playback, despite #d43e649e8 and #f7ac24eb4.

Those commits fixed the *spurious* fallbacks — abort/lifecycle errors no longer walk the format chain. What they left behind was the **genuine** recovery being one-shot for a video's entire lifetime.

`sabrErrorRecoveryAttemptedForCurrentVideo` only reset when the videoId changed, so on a long video:

1. First real SABR failure → refetch the stream in place, toast, plays fine again.
2. Any later, unrelated SABR failure → flag still set → skips the refetch → straight to legacy 360p, no toast.

Since `f7ac24eb4` deliberately backed out the DASH auto-recovery, there was no way back up short of a manual reload. The reported symptom matches exactly: mid-playback, after watching a while, no toast.

## Fix

The budget is now **per incident instead of per video**. It refills once the refreshed stream has actually played 30 seconds of content, and caps at 3 attempts that never settle — so a genuinely broken stream still stops looping and lands on the working format, but a hiccup an hour into a video gets its own refetch.

The settle check is keyed on playback progress rather than wall clock, so a long pause doesn't falsely refill it; a backwards seek just rebases the marker.

Also added `console.error` to the two silent legacy drops in `getVideoInformationLocal`. That's a *second*, independent path to 360p — when a reload's `/player` response comes back with no SABR URL and no adaptive format URLs. Unconfirmed as a live cause, but it was completely silent, so if 360p recurs the log will now say which path it took.

## Testing

New offline E2E test at `e2e/tests/offline/sabr-error-recovery.spec.mjs` covering both directions: a second failure after successful playback refetches rather than dropping to legacy, and back-to-back failures that never settle do exhaust the budget and fall back.

Confirmed it's a real regression test by reverting `Watch.js` to HEAD and rebuilding — it fails with `Received length: 1` (one refetch, then legacy), and passes with the fix.

Full offline suite: 138 passed. Two failures (`collaborators-modal-animation`, `playlists`) were Electron launch timeouts under parallel load; both pass in isolation and are unrelated.

## Notes for reviewers

- The 3-attempt cap and 30-second settle threshold are judgement calls. If we'd rather never give up on SABR, dropping the cap is a one-line change.
- `pnpm run eslint-lint` is clean. The `e2e/` directory isn't in its globs and has a pre-existing parser error on numeric separators (`86_400_000`) — the existing `watch-error-navigation.spec.mjs` fails identically, so I matched the surrounding files rather than diverge.