### PR TITLE
fix(player): hide mini-player handles with controls

### DIFF
--- a/src/renderer/components/ft-shaka-video-player/ft-shaka-video-player.css
+++ b/src/renderer/components/ft-shaka-video-player/ft-shaka-video-player.css
@@ -2705,6 +2705,13 @@
   background: rgb(0 0 0 / 75%);
 }
 
+.scrollMiniPlayPause,
+.scrollMiniDragHandle,
+.scrollMiniResizeHandle {
+  opacity: 1;
+  transition: opacity 0.15s ease;
+}
+
 .scrollMiniPlayPause {
   position: absolute;
   top: 50%;
@@ -2723,11 +2730,11 @@
   display: flex;
   align-items: center;
   justify-content: center;
-  opacity: 1;
-  transition: opacity 0.15s ease;
 }
 
-.scrollMiniPlayPause.isHidden {
+.scrollMiniPlayPause.isHidden,
+.scrollMiniDragHandle.isHidden,
+.scrollMiniResizeHandle.isHidden {
   opacity: 0;
   pointer-events: none;
   transition: opacity 0.25s ease 0.35s;

--- a/src/renderer/components/ft-shaka-video-player/ft-shaka-video-player.vue
+++ b/src/renderer/components/ft-shaka-video-player/ft-shaka-video-player.vue
@@ -998,7 +998,10 @@
         </div>
         <div
           class="scrollMiniDragHandle"
-          :class="{ 'scrollMiniDragHandle-onLightBg': scrollMiniDragHandleOnLightBg }"
+          :class="{
+            isHidden: !scrollMiniPlayPauseVisible,
+            'scrollMiniDragHandle-onLightBg': scrollMiniDragHandleOnLightBg
+          }"
           :title="$t('Video.Player.Scroll Mini Player.Drag Handle')"
           @pointerdown.stop="handleScrollMiniDragPointerDown"
           @mousedown.stop.prevent
@@ -1007,7 +1010,10 @@
           class="scrollMiniResizeHandle"
           :class="[
             `scrollMiniResizeHandle-${scrollMiniResizeCorner}`,
-            { 'scrollMiniResizeHandle-onLightBg': scrollMiniResizeHandleOnLightBg }
+            {
+              isHidden: !scrollMiniPlayPauseVisible,
+              'scrollMiniResizeHandle-onLightBg': scrollMiniResizeHandleOnLightBg
+            }
           ]"
           @pointerdown.stop="handleScrollMiniResizePointerDown"
           @mousedown.stop.prevent


### PR DESCRIPTION
## What changed

- hide the scroll mini-player move and resize handles with the play/pause control
- share the same fade timing and disable pointer interaction while hidden

## Why

The play/pause control already fades after pointer inactivity, but the move and resize handles remained visible because they did not use the shared visibility state. This left persistent chrome over the video.

The handles now follow `scrollMiniPlayPauseVisible`, so the mini-player controls disappear and reappear together.

## Validation

- `pnpm exec eslint src/renderer/components/ft-shaka-video-player/ft-shaka-video-player.vue`
- `pnpm exec stylelint src/renderer/components/ft-shaka-video-player/ft-shaka-video-player.css`
- `pnpm run test:unit` (61 passed)
- `git diff --check`