### PR TITLE
feat: add channel search type filters

### DIFF
--- a/e2e/tests/network/channel.spec.mjs
+++ b/e2e/tests/network/channel.spec.mjs
@@ -31,12 +31,18 @@ test.describe('channel page', () => {
 
     const searchTypeFilters = page.getByRole('group', { name: 'Search result types' })
     const allResultsFilter = searchTypeFilters.getByRole('button', { name: 'All' })
+    const shortsResultsFilter = searchTypeFilters.getByRole('button', { name: 'Shorts' })
     const playlistResultsFilter = searchTypeFilters.getByRole('button', { name: 'Playlists' })
     const videoResults = page.locator('.channelSearchResults .ft-list-video:not(:has(.videoCountContainer))')
     const playlistResults = page.locator('.channelSearchResults .ft-list-video:has(.videoCountContainer)')
     await expect(allResultsFilter).toHaveAttribute('aria-pressed', 'true')
     await expect(videoResults.first()).toBeVisible()
     await expect(playlistResults.first()).toBeVisible()
+
+    await shortsResultsFilter.click()
+    await expect(shortsResultsFilter).toHaveAttribute('aria-pressed', 'true')
+    await expect(videoResults.first()).toBeVisible()
+    await expect(playlistResults).toHaveCount(0)
 
     await playlistResultsFilter.click()
     await expect(playlistResultsFilter).toHaveAttribute('aria-pressed', 'true')

--- a/e2e/tests/network/channel.spec.mjs
+++ b/e2e/tests/network/channel.spec.mjs
@@ -29,6 +29,20 @@ test.describe('channel page', () => {
     await expect(page.locator(sel.activeTab)).toContainText('Blender')
     await expect(page.locator(sel.activeTab)).not.toContainText('/channel/')
 
+    const searchTypeFilters = page.getByRole('group', { name: 'Search result types' })
+    const allResultsFilter = searchTypeFilters.getByRole('button', { name: 'All' })
+    const playlistResultsFilter = searchTypeFilters.getByRole('button', { name: 'Playlists' })
+    const videoResults = page.locator('.channelSearchResults .ft-list-video:not(:has(.videoCountContainer))')
+    const playlistResults = page.locator('.channelSearchResults .ft-list-video:has(.videoCountContainer)')
+    await expect(allResultsFilter).toHaveAttribute('aria-pressed', 'true')
+    await expect(videoResults.first()).toBeVisible()
+    await expect(playlistResults.first()).toBeVisible()
+
+    await playlistResultsFilter.click()
+    await expect(playlistResultsFilter).toHaveAttribute('aria-pressed', 'true')
+    await expect(videoResults).toHaveCount(0)
+    await expect(playlistResults.first()).toBeVisible()
+
     await page.locator('.channelSearch .clearInputTextButton').click()
     await expect(page).not.toHaveURL(/searchQueryText=/)
     await expect(page.locator(sel.activeTab)).toContainText('Blender')

--- a/src/renderer/views/Channel/Channel.css
+++ b/src/renderer/views/Channel/Channel.css
@@ -20,6 +20,34 @@
   margin-block-end: 10px;
 }
 
+.channelSearchFilters {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px;
+  margin-block-end: 16px;
+}
+
+.channelSearchFilter {
+  color: var(--primary-text-color);
+  background-color: var(--search-bar-color);
+  border: 1px solid var(--tertiary-text-color);
+  border-radius: 999px;
+  padding-block: 7px;
+  padding-inline: 14px;
+  cursor: pointer;
+}
+
+.channelSearchFilter:hover,
+.channelSearchFilter:focus {
+  border-color: var(--primary-color);
+}
+
+.channelSearchFilter.selected {
+  color: var(--text-with-accent-color);
+  background-color: var(--accent-color);
+  border-color: var(--accent-color);
+}
+
 .elementListLoading {
   margin-block-start: 200px;
 }

--- a/src/renderer/views/Channel/Channel.vue
+++ b/src/renderer/views/Channel/Channel.vue
@@ -2075,7 +2075,11 @@ const availableChannelSearchFilters = computed(() => {
     })
   }
 
-  if (channelTabs.value.includes('shorts') && !hideChannelShorts.value) {
+  const hasShortResults = searchResults.value.some(result => {
+    return result.channelSearchResultType === CHANNEL_SEARCH_FILTERS.SHORTS
+  })
+
+  if (hasShortResults && !hideChannelShorts.value) {
     filters.push({
       value: CHANNEL_SEARCH_FILTERS.SHORTS,
       label: t('Global.Shorts'),

--- a/src/renderer/views/Channel/Channel.vue
+++ b/src/renderer/views/Channel/Channel.vue
@@ -2075,11 +2075,7 @@ const availableChannelSearchFilters = computed(() => {
     })
   }
 
-  const hasShortResults = searchResults.value.some(result => {
-    return result.channelSearchResultType === CHANNEL_SEARCH_FILTERS.SHORTS
-  })
-
-  if (hasShortResults && !hideChannelShorts.value) {
+  if (channelTabs.value.includes('shorts') && !hideChannelShorts.value) {
     filters.push({
       value: CHANNEL_SEARCH_FILTERS.SHORTS,
       label: t('Global.Shorts'),

--- a/src/renderer/views/Channel/Channel.vue
+++ b/src/renderer/views/Channel/Channel.vue
@@ -86,6 +86,24 @@
           @change="playlistSortBy = $event"
         />
       </div>
+      <div
+        v-if="currentTab === 'search'"
+        class="channelSearchFilters"
+        role="group"
+        :aria-label="$t('Channel.Search Result Types')"
+      >
+        <button
+          v-for="filter in availableChannelSearchFilters"
+          :key="filter.value"
+          type="button"
+          class="channelSearchFilter"
+          :class="{ selected: channelSearchFilter === filter.value }"
+          :aria-pressed="channelSearchFilter === filter.value"
+          @click="channelSearchFilter = filter.value"
+        >
+          {{ filter.label }}
+        </button>
+      </div>
       <FtLoader
         v-if="isCurrentTabLoading"
       />
@@ -226,11 +244,12 @@
         </FtFlexBox>
         <FtElementList
           v-show="currentTab === 'search'"
-          :data="searchResults"
+          class="channelSearchResults"
+          :data="filteredSearchResults"
           :use-channels-hidden-preference="false"
         />
         <FtFlexBox
-          v-if="currentTab === 'search' && !isSearchTabLoading && searchResults.length === 0"
+          v-if="currentTab === 'search' && !isSearchTabLoading && filteredSearchResults.length === 0"
         >
           <p class="message">
             {{ $t("Channel.Your search results have returned 0 results") }}
@@ -332,6 +351,12 @@ import {
   parseChannelHomeTab
 } from '../../helpers/api/local'
 import { useTabTitle } from '../../tabs/TabContext'
+import {
+  CHANNEL_SEARCH_FILTERS,
+  filterChannelSearchResults,
+  getInvidiousChannelSearchResultType,
+  getLocalChannelSearchResultType,
+} from './channel-search'
 
 const { t } = useI18n()
 const route = useRoute()
@@ -2031,6 +2056,48 @@ let searchPage = 1
 const lastSearchQuery = ref('')
 const searchResults = shallowRef([])
 const searchContinuationData = shallowRef(null)
+const channelSearchFilter = ref(CHANNEL_SEARCH_FILTERS.ALL)
+
+const filteredSearchResults = computed(() => {
+  return filterChannelSearchResults(searchResults.value, channelSearchFilter.value)
+})
+
+const availableChannelSearchFilters = computed(() => {
+  const filters = [{
+    value: CHANNEL_SEARCH_FILTERS.ALL,
+    label: t('Channel.All Results'),
+  }]
+
+  if (channelTabs.value.includes('videos')) {
+    filters.push({
+      value: CHANNEL_SEARCH_FILTERS.VIDEOS,
+      label: t('Global.Videos'),
+    })
+  }
+
+  if (channelTabs.value.includes('shorts') && !hideChannelShorts.value) {
+    filters.push({
+      value: CHANNEL_SEARCH_FILTERS.SHORTS,
+      label: t('Global.Shorts'),
+    })
+  }
+
+  if (channelTabs.value.includes('live')) {
+    filters.push({
+      value: CHANNEL_SEARCH_FILTERS.LIVE,
+      label: t('Global.Live'),
+    })
+  }
+
+  if (channelTabs.value.includes('playlists') && !hideChannelPlaylists.value) {
+    filters.push({
+      value: CHANNEL_SEARCH_FILTERS.PLAYLISTS,
+      label: t('Channel.Playlists.Playlists'),
+    })
+  }
+
+  return filters
+})
 
 async function searchChannelLocal() {
   const isNewSearch = searchContinuationData.value === null
@@ -2063,10 +2130,18 @@ async function searchChannelLocal() {
       .flatMap(itemSection => itemSection.contents)
       .filter(item => item.type === 'Video' || (!hideChannelPlaylists.value && item.type === 'Playlist'))
       .map(item => {
+        const channelSearchResultType = getLocalChannelSearchResultType(item)
+
         if (item.type === 'Video') {
-          return parseLocalListVideo(item)
+          return {
+            ...parseLocalListVideo(item),
+            channelSearchResultType,
+          }
         } else {
-          return parseLocalListPlaylist(item, id.value, channelName.value)
+          return {
+            ...parseLocalListPlaylist(item, id.value, channelName.value),
+            channelSearchResultType,
+          }
         }
       })
 
@@ -2098,11 +2173,15 @@ async function searchChannelLocal() {
 async function searchChannelInvidious() {
   try {
     const response = await searchInvidiousChannel(id.value, lastSearchQuery.value, searchPage)
+    const typedResponse = response.map(item => ({
+      ...item,
+      channelSearchResultType: getInvidiousChannelSearchResultType(item),
+    }))
 
     if (hideChannelPlaylists.value) {
-      searchResults.value = searchResults.value.concat(response.filter(item => item.type !== 'playlist'))
+      searchResults.value = searchResults.value.concat(typedResponse.filter(item => item.type !== 'playlist'))
     } else {
-      searchResults.value = searchResults.value.concat(response)
+      searchResults.value = searchResults.value.concat(typedResponse)
     }
 
     isSearchTabLoading.value = false
@@ -2136,6 +2215,7 @@ function newSearch(query) {
   isSearchTabLoading.value = true
   searchPage = 1
   searchResults.value = []
+  channelSearchFilter.value = CHANNEL_SEARCH_FILTERS.ALL
   changeTab('search')
 
   if (process.env.SUPPORTS_LOCAL_API && apiUsed === 'local') {
@@ -2159,6 +2239,7 @@ function clearSearch() {
   isSearchTabLoading.value = false
   searchPage = 1
   searchResults.value = []
+  channelSearchFilter.value = CHANNEL_SEARCH_FILTERS.ALL
   changeTab(currentOrFirstTab(undefined))
 }
 

--- a/src/renderer/views/Channel/channel-search.js
+++ b/src/renderer/views/Channel/channel-search.js
@@ -6,6 +6,8 @@ export const CHANNEL_SEARCH_FILTERS = {
   PLAYLISTS: 'playlists',
 }
 
+const YOUTUBE_SHORT_MAX_DURATION_SECONDS = 180
+
 /**
  * @param {{
  *   type: string,
@@ -16,6 +18,7 @@ export const CHANNEL_SEARCH_FILTERS = {
  *   is_live?: boolean,
  *   is_upcoming?: boolean,
  *   is_premiere?: boolean,
+ *   duration?: { seconds?: number },
  * }} item
  * @returns {'videos' | 'shorts' | 'live' | 'playlists'}
  */
@@ -33,6 +36,13 @@ export function getLocalChannelSearchResultType(item) {
     return CHANNEL_SEARCH_FILTERS.SHORTS
   }
 
+  // YouTube also considers aspect ratio and upload date, but channel search
+  // does not expose those fields. Duration is the best available fallback.
+  if (item.duration?.seconds > 0 &&
+      item.duration.seconds <= YOUTUBE_SHORT_MAX_DURATION_SECONDS) {
+    return CHANNEL_SEARCH_FILTERS.SHORTS
+  }
+
   return CHANNEL_SEARCH_FILTERS.VIDEOS
 }
 
@@ -41,8 +51,9 @@ export function getLocalChannelSearchResultType(item) {
  *   type: string,
  *   liveNow?: boolean,
  *   isUpcoming?: boolean,
+ *   lengthSeconds?: number,
  * }} item
- * @returns {'videos' | 'live' | 'playlists'}
+ * @returns {'videos' | 'shorts' | 'live' | 'playlists'}
  */
 export function getInvidiousChannelSearchResultType(item) {
   if (item.type === 'playlist') {
@@ -51,6 +62,11 @@ export function getInvidiousChannelSearchResultType(item) {
 
   if (item.liveNow || item.isUpcoming) {
     return CHANNEL_SEARCH_FILTERS.LIVE
+  }
+
+  if (item.lengthSeconds > 0 &&
+      item.lengthSeconds <= YOUTUBE_SHORT_MAX_DURATION_SECONDS) {
+    return CHANNEL_SEARCH_FILTERS.SHORTS
   }
 
   return CHANNEL_SEARCH_FILTERS.VIDEOS

--- a/src/renderer/views/Channel/channel-search.js
+++ b/src/renderer/views/Channel/channel-search.js
@@ -16,7 +16,6 @@ export const CHANNEL_SEARCH_FILTERS = {
  *   is_live?: boolean,
  *   is_upcoming?: boolean,
  *   is_premiere?: boolean,
- *   duration?: { seconds?: number },
  * }} item
  * @returns {'videos' | 'shorts' | 'live' | 'playlists'}
  */
@@ -34,12 +33,6 @@ export function getLocalChannelSearchResultType(item) {
     return CHANNEL_SEARCH_FILTERS.SHORTS
   }
 
-  // Channel search does not expose YouTube's Shorts classification. Duration
-  // is the only content signal shared by the local and Invidious responses.
-  if (item.duration?.seconds > 0 && item.duration.seconds <= 180) {
-    return CHANNEL_SEARCH_FILTERS.SHORTS
-  }
-
   return CHANNEL_SEARCH_FILTERS.VIDEOS
 }
 
@@ -48,9 +41,8 @@ export function getLocalChannelSearchResultType(item) {
  *   type: string,
  *   liveNow?: boolean,
  *   isUpcoming?: boolean,
- *   lengthSeconds?: number,
  * }} item
- * @returns {'videos' | 'shorts' | 'live' | 'playlists'}
+ * @returns {'videos' | 'live' | 'playlists'}
  */
 export function getInvidiousChannelSearchResultType(item) {
   if (item.type === 'playlist') {
@@ -59,10 +51,6 @@ export function getInvidiousChannelSearchResultType(item) {
 
   if (item.liveNow || item.isUpcoming) {
     return CHANNEL_SEARCH_FILTERS.LIVE
-  }
-
-  if (item.lengthSeconds > 0 && item.lengthSeconds <= 180) {
-    return CHANNEL_SEARCH_FILTERS.SHORTS
   }
 
   return CHANNEL_SEARCH_FILTERS.VIDEOS

--- a/src/renderer/views/Channel/channel-search.js
+++ b/src/renderer/views/Channel/channel-search.js
@@ -1,0 +1,81 @@
+export const CHANNEL_SEARCH_FILTERS = {
+  ALL: 'all',
+  VIDEOS: 'videos',
+  SHORTS: 'shorts',
+  LIVE: 'live',
+  PLAYLISTS: 'playlists',
+}
+
+/**
+ * @param {{
+ *   type: string,
+ *   endpoint?: {
+ *     name?: string,
+ *     metadata?: { url?: string },
+ *   },
+ *   is_live?: boolean,
+ *   is_upcoming?: boolean,
+ *   is_premiere?: boolean,
+ *   duration?: { seconds?: number },
+ * }} item
+ * @returns {'videos' | 'shorts' | 'live' | 'playlists'}
+ */
+export function getLocalChannelSearchResultType(item) {
+  if (item.type === 'Playlist') {
+    return CHANNEL_SEARCH_FILTERS.PLAYLISTS
+  }
+
+  if (item.is_live || item.is_upcoming || item.is_premiere) {
+    return CHANNEL_SEARCH_FILTERS.LIVE
+  }
+
+  if (item.endpoint?.name === 'reelWatchEndpoint' ||
+      item.endpoint?.metadata?.url?.startsWith('/shorts/')) {
+    return CHANNEL_SEARCH_FILTERS.SHORTS
+  }
+
+  // Channel search does not expose YouTube's Shorts classification. Duration
+  // is the only content signal shared by the local and Invidious responses.
+  if (item.duration?.seconds > 0 && item.duration.seconds <= 180) {
+    return CHANNEL_SEARCH_FILTERS.SHORTS
+  }
+
+  return CHANNEL_SEARCH_FILTERS.VIDEOS
+}
+
+/**
+ * @param {{
+ *   type: string,
+ *   liveNow?: boolean,
+ *   isUpcoming?: boolean,
+ *   lengthSeconds?: number,
+ * }} item
+ * @returns {'videos' | 'shorts' | 'live' | 'playlists'}
+ */
+export function getInvidiousChannelSearchResultType(item) {
+  if (item.type === 'playlist') {
+    return CHANNEL_SEARCH_FILTERS.PLAYLISTS
+  }
+
+  if (item.liveNow || item.isUpcoming) {
+    return CHANNEL_SEARCH_FILTERS.LIVE
+  }
+
+  if (item.lengthSeconds > 0 && item.lengthSeconds <= 180) {
+    return CHANNEL_SEARCH_FILTERS.SHORTS
+  }
+
+  return CHANNEL_SEARCH_FILTERS.VIDEOS
+}
+
+/**
+ * @param {{ channelSearchResultType?: string }[]} results
+ * @param {string} filter
+ */
+export function filterChannelSearchResults(results, filter) {
+  if (filter === CHANNEL_SEARCH_FILTERS.ALL) {
+    return results
+  }
+
+  return results.filter(result => result.channelSearchResultType === filter)
+}

--- a/static/locales/en-US.yaml
+++ b/static/locales/en-US.yaml
@@ -1095,6 +1095,8 @@ Channel:
   Removed subscription from {count} other channel(s): Removed subscription from {count} other channel(s)
   Added channel to your subscriptions: Added channel to your subscriptions
   Search Channel: Search Channel
+  Search Result Types: Search result types
+  All Results: All
   Your search results have returned 0 results: Your search results have returned 0
     results
   This channel does not exist: This channel does not exist

--- a/tests/unit/channel-search.test.mjs
+++ b/tests/unit/channel-search.test.mjs
@@ -27,14 +27,7 @@ test('classifies local channel search results by content type', () => {
   assert.equal(
     getLocalChannelSearchResultType({
       type: 'Video',
-      duration: { seconds: 180 },
-    }),
-    CHANNEL_SEARCH_FILTERS.SHORTS
-  )
-  assert.equal(
-    getLocalChannelSearchResultType({
-      type: 'Video',
-      duration: { seconds: 181 },
+      duration: { seconds: 30 },
     }),
     CHANNEL_SEARCH_FILTERS.VIDEOS
   )
@@ -51,10 +44,6 @@ test('classifies the content types exposed by Invidious channel search', () => {
   )
   assert.equal(
     getInvidiousChannelSearchResultType({ type: 'video', lengthSeconds: 30 }),
-    CHANNEL_SEARCH_FILTERS.SHORTS
-  )
-  assert.equal(
-    getInvidiousChannelSearchResultType({ type: 'video', lengthSeconds: 181 }),
     CHANNEL_SEARCH_FILTERS.VIDEOS
   )
 })

--- a/tests/unit/channel-search.test.mjs
+++ b/tests/unit/channel-search.test.mjs
@@ -27,7 +27,14 @@ test('classifies local channel search results by content type', () => {
   assert.equal(
     getLocalChannelSearchResultType({
       type: 'Video',
-      duration: { seconds: 30 },
+      duration: { seconds: 180 },
+    }),
+    CHANNEL_SEARCH_FILTERS.SHORTS
+  )
+  assert.equal(
+    getLocalChannelSearchResultType({
+      type: 'Video',
+      duration: { seconds: 181 },
     }),
     CHANNEL_SEARCH_FILTERS.VIDEOS
   )
@@ -44,6 +51,10 @@ test('classifies the content types exposed by Invidious channel search', () => {
   )
   assert.equal(
     getInvidiousChannelSearchResultType({ type: 'video', lengthSeconds: 30 }),
+    CHANNEL_SEARCH_FILTERS.SHORTS
+  )
+  assert.equal(
+    getInvidiousChannelSearchResultType({ type: 'video', lengthSeconds: 181 }),
     CHANNEL_SEARCH_FILTERS.VIDEOS
   )
 })

--- a/tests/unit/channel-search.test.mjs
+++ b/tests/unit/channel-search.test.mjs
@@ -1,0 +1,74 @@
+import assert from 'node:assert/strict'
+import test from 'node:test'
+
+import {
+  CHANNEL_SEARCH_FILTERS,
+  filterChannelSearchResults,
+  getInvidiousChannelSearchResultType,
+  getLocalChannelSearchResultType,
+} from '../../src/renderer/views/Channel/channel-search.js'
+
+test('classifies local channel search results by content type', () => {
+  assert.equal(
+    getLocalChannelSearchResultType({ type: 'Playlist' }),
+    CHANNEL_SEARCH_FILTERS.PLAYLISTS
+  )
+  assert.equal(
+    getLocalChannelSearchResultType({ type: 'Video', is_live: true }),
+    CHANNEL_SEARCH_FILTERS.LIVE
+  )
+  assert.equal(
+    getLocalChannelSearchResultType({
+      type: 'Video',
+      endpoint: { metadata: { url: '/shorts/example' } },
+    }),
+    CHANNEL_SEARCH_FILTERS.SHORTS
+  )
+  assert.equal(
+    getLocalChannelSearchResultType({
+      type: 'Video',
+      duration: { seconds: 180 },
+    }),
+    CHANNEL_SEARCH_FILTERS.SHORTS
+  )
+  assert.equal(
+    getLocalChannelSearchResultType({
+      type: 'Video',
+      duration: { seconds: 181 },
+    }),
+    CHANNEL_SEARCH_FILTERS.VIDEOS
+  )
+})
+
+test('classifies the content types exposed by Invidious channel search', () => {
+  assert.equal(
+    getInvidiousChannelSearchResultType({ type: 'playlist' }),
+    CHANNEL_SEARCH_FILTERS.PLAYLISTS
+  )
+  assert.equal(
+    getInvidiousChannelSearchResultType({ type: 'video', isUpcoming: true }),
+    CHANNEL_SEARCH_FILTERS.LIVE
+  )
+  assert.equal(
+    getInvidiousChannelSearchResultType({ type: 'video', lengthSeconds: 30 }),
+    CHANNEL_SEARCH_FILTERS.SHORTS
+  )
+  assert.equal(
+    getInvidiousChannelSearchResultType({ type: 'video', lengthSeconds: 181 }),
+    CHANNEL_SEARCH_FILTERS.VIDEOS
+  )
+})
+
+test('filters channel results without changing their server order', () => {
+  const results = [
+    { title: 'Video', channelSearchResultType: CHANNEL_SEARCH_FILTERS.VIDEOS },
+    { title: 'Short', channelSearchResultType: CHANNEL_SEARCH_FILTERS.SHORTS },
+    { title: 'Playlist', channelSearchResultType: CHANNEL_SEARCH_FILTERS.PLAYLISTS },
+  ]
+
+  assert.equal(filterChannelSearchResults(results, CHANNEL_SEARCH_FILTERS.ALL), results)
+  assert.deepEqual(
+    filterChannelSearchResults(results, CHANNEL_SEARCH_FILTERS.SHORTS),
+    [results[1]]
+  )
+})


### PR DESCRIPTION
## Summary

- add accessible filter chips for all channel search results, videos, Shorts, live streams, and playlists
- preserve the server-provided result order and pagination while filtering loaded results
- classify results consistently across the local and Invidious backends
- add unit coverage and channel-page network E2E coverage

## Why

Channel search currently mixes every supported content type into one list, which makes it difficult to find a specific video among Shorts, live streams, and playlists. The new chips keep the complete result set as the default while letting users narrow it without tying search to the active channel tab.

Sorting is intentionally not included: the channel-search endpoint used by OpenTubeX does not expose a server-side order, and sorting only loaded pages would reorder results as continuations arrive.

## Validation

- `pnpm test:unit` (64 passed)
- ESLint on the changed Vue, JavaScript, test, and locale files
- Stylelint on `Channel.css`
- production E2E renderer pack
- `xvfb-run -a -s "-screen 0 1920x1080x24" pnpm exec playwright test -c e2e/playwright.config.mjs --project=network e2e/tests/network/channel.spec.mjs` (2 passed)

Resolves #280