### PR TITLE
Fix end-screen annotations behind fullscreen docks

### DIFF
--- a/e2e/tests/network/watch.spec.mjs
+++ b/e2e/tests/network/watch.spec.mjs
@@ -466,6 +466,25 @@ test.describe('watch page', () => {
       ])
       return currentVideoBounds.x + currentVideoBounds.width - currentMetadataBounds.x
     }).toBeLessThanOrEqual(1)
+    await page.locator('.ftVideoPlayer').evaluate((element) => {
+      const annotations = document.createElement('div')
+      annotations.className = 'videoAnnotations'
+      annotations.dataset.testAnnotations = ''
+      annotations.style.position = 'absolute'
+      annotations.style.insetBlock = '0'
+      annotations.style.insetInlineStart = '0'
+      element.append(annotations)
+    })
+    const annotations = page.locator('[data-test-annotations]')
+    await expect.poll(async () => {
+      const [videoBounds, annotationBounds] = await Promise.all([
+        playerVideo.boundingBox(),
+        annotations.boundingBox()
+      ])
+      return Math.abs(
+        videoBounds.x + videoBounds.width - annotationBounds.x - annotationBounds.width
+      )
+    }).toBeLessThanOrEqual(1)
     await page.locator('.fullscreenActions').getByRole('button', { name: 'Show transcript' }).click()
     await expect(page.locator('.fullscreenTranscriptOverlay.open')).toBeVisible()
     await expect(page.locator('.fullscreenMetadataHeader')).toHaveCSS('cursor', 'grab')

--- a/e2e/tests/network/watch.spec.mjs
+++ b/e2e/tests/network/watch.spec.mjs
@@ -476,6 +476,8 @@ test.describe('watch page', () => {
       element.append(annotations)
     })
     const annotations = page.locator('[data-test-annotations]')
+    await expect(annotations).toHaveCSS('transition-property', 'inset-inline-end')
+    await expect(annotations).toHaveCSS('transition-duration', '0.25s')
     await expect.poll(async () => {
       const [videoBounds, annotationBounds] = await Promise.all([
         playerVideo.boundingBox(),

--- a/src/renderer/components/ft-shaka-video-player/ft-shaka-video-player.css
+++ b/src/renderer/components/ft-shaka-video-player/ft-shaka-video-player.css
@@ -2887,6 +2887,7 @@
   :deep(.shaka-controls-container),
   :deep(.shaka-spinner-container),
   .countdownOverlay,
+  :deep(.videoAnnotations),
   :deep(.shaka-text-container),
   :deep(.shaka-speech-to-text-container)
 ),
@@ -2894,6 +2895,7 @@
   :deep(.shaka-controls-container),
   :deep(.shaka-spinner-container),
   .countdownOverlay,
+  :deep(.videoAnnotations),
   :deep(.shaka-text-container),
   :deep(.shaka-speech-to-text-container)
 ) {

--- a/src/renderer/components/ft-shaka-video-player/ft-shaka-video-player.css
+++ b/src/renderer/components/ft-shaka-video-player/ft-shaka-video-player.css
@@ -32,6 +32,10 @@
   transition: inline-size 250ms ease;
 }
 
+.ftVideoPlayer :deep(.videoAnnotations) {
+  transition: inset-inline-end 250ms ease;
+}
+
 .autoplayCountdownOverlay {
   position: absolute;
   z-index: 13;
@@ -2867,6 +2871,7 @@
 .ftVideoPlayer.presentationModeChanging :deep(.shaka-controls-container),
 .ftVideoPlayer.presentationModeChanging :deep(.shaka-spinner-container),
 .ftVideoPlayer.presentationModeChanging .countdownOverlay,
+.ftVideoPlayer.presentationModeChanging :deep(.videoAnnotations),
 .ftVideoPlayer.presentationModeChanging :deep(.shaka-text-container),
 .ftVideoPlayer.presentationModeChanging :deep(.shaka-speech-to-text-container) {
   transition: none !important;


### PR DESCRIPTION
## What changed

- constrain the end-screen annotation layer to the same dock-aware player area as video, controls, captions, and loading overlays
- add a fullscreen metadata-dock regression assertion that checks the annotation layer ends at the video edge

## Why

Fullscreen and full-window docks reduce the usable video width, but the annotation overlay still filled the entire player. End-screen cards could therefore extend underneath the side dock and render at the wrong size and position.

## Impact

End-screen annotations now remain fully inside the visible video area whenever a side dock is active.

## Validation

- `pnpm lint-style`
- `pnpm test:unit` (61 passed)
- `pnpm test:e2e:pack`
- targeted Playwright test launched under Xvfb; skipped because the live YouTube fixture could not hydrate in the local environment