### PR TITLE
Add configurable UI roundness

### DIFF
--- a/e2e/tests/network/channel.spec.mjs
+++ b/e2e/tests/network/channel.spec.mjs
@@ -9,6 +9,8 @@ const CHANNEL_URL = 'https://www.youtube.com/channel/UCSMOQeBJ2RAnuFungnQOxLg'
 const CHANNEL_ID = 'UCSMOQeBJ2RAnuFungnQOxLg'
 
 test.describe('channel page', () => {
+  test.use({ seed: { settings: { uiRoundness: 200 } } })
+
   test('shows channel info and videos', async ({ page }) => {
     await page.locator(sel.searchInput).fill(CHANNEL_URL)
     await page.locator(sel.searchInput).press('Enter')
@@ -16,6 +18,11 @@ test.describe('channel page', () => {
     await expect(page).toHaveURL(/#\/channel\/UCSMOQeBJ2RAnuFungnQOxLg/)
     await expect(page.getByText('Blender').first()).toBeVisible({ timeout: 30_000 })
     await expect(page.locator('.ft-list-video').first()).toBeVisible({ timeout: 30_000 })
+    await expect(page.locator('body')).toHaveCSS('--ui-roundness', '2')
+    await expect(page.locator('.channelDetails .bannerContainer')).toHaveCSS('border-top-left-radius', '16px')
+    await expect(page.locator('.channelDetails .bannerContainer')).toHaveCSS('border-top-right-radius', '16px')
+    await expect(page.locator('.channelDetails .infoContainer')).toHaveCSS('border-bottom-left-radius', '16px')
+    await expect(page.locator('.channelDetails .infoContainer')).toHaveCSS('border-bottom-right-radius', '16px')
 
     // Channel tab changes must update the route and title without creating a
     // new history entry for every tab selection (796650405, 912e5ea6e).

--- a/e2e/tests/offline/appearance.spec.mjs
+++ b/e2e/tests/offline/appearance.spec.mjs
@@ -3,7 +3,7 @@ import path from 'node:path'
 
 import { test, expect, goTo, sel } from '../../helpers/app.mjs'
 
-async function setWindowWidth(app, width) {
+async function setWindowWidth (app, width) {
   await app.electronApp.evaluate(({ BrowserWindow }, targetWidth) => {
     const browserWindow = BrowserWindow.getAllWindows()[0]
     const bounds = browserWindow.getBounds()
@@ -11,7 +11,7 @@ async function setWindowWidth(app, width) {
   }, width)
 }
 
-async function enableVerticalTabBar(page, width) {
+async function enableVerticalTabBar (page, width) {
   await page.evaluate((tabBarWidth) => {
     const store = document.querySelector('#app').__vue_app__.config.globalProperties.$store
     store.commit('setUseVerticalTabBar', true)
@@ -54,6 +54,64 @@ test.describe('default appearance', () => {
     await expect(page.locator(sel.sideNavLink('trending'))).not.toHaveCount(0)
     await expect(page.locator('.topNav .profiles .colorOption').first()).toBeVisible()
     await expect(page.locator('body')).toHaveClass(/system/)
+  })
+})
+
+test.describe('UI roundness', () => {
+  test.use({ seed: { settings: { uiRoundness: 0 } } })
+
+  test('applies to controls, cards, popovers, and modals', async ({ app, page }) => {
+    await expect(page.locator('body')).toHaveCSS('--ui-roundness', '0')
+
+    await goTo(page, 'settings')
+    const roundnessSlider = page.getByRole('slider', { name: /UI Roundness/ })
+    await expect(roundnessSlider).toHaveValue('0')
+    await expect(page.locator('.sectionBody').first()).toHaveCSS('border-radius', '0px')
+    await expect(page.getByRole('button').first()).toHaveCSS('border-radius', '0px')
+
+    await page.locator('.settingsMenu [data-section="data"]').click()
+    await page.getByRole('button', { name: 'Export Subscriptions' }).click()
+    await expect(page.getByRole('dialog')).toHaveCSS('border-radius', '0px')
+
+    await page.getByRole('dialog').getByRole('button', { name: 'Close' }).click()
+    await page.locator(sel.tabs).first().click({ button: 'right' })
+    await expect(page.getByRole('menu', { name: 'Context menu' })).toHaveCSS('border-radius', '0px')
+
+    await page.keyboard.press('Escape')
+    await roundnessSlider.fill('150')
+    await expect(page.locator('body')).toHaveCSS('--ui-roundness', '1.5')
+    await expect(page.locator('.sectionBody').first()).toHaveCSS('border-radius', '12px')
+
+    ;({ page } = await app.relaunch())
+    await goTo(page, 'settings')
+    await expect(page.getByRole('slider', { name: /UI Roundness/ })).toHaveValue('150')
+  })
+})
+
+test.describe('rounded feed page headers', () => {
+  test.use({
+    seed: {
+      settings: {
+        uiRoundness: 200,
+        backendPreference: 'invidious',
+        backendFallback: true,
+        fetchSubscriptionsAutomatically: false
+      }
+    }
+  })
+
+  test('preserves scaled card corners on feed pages', async ({ page }) => {
+    const pages = [
+      { route: 'subscriptions', header: '.subscriptionsHeader' },
+      { route: 'trending', header: '.pageHeader' },
+      { route: 'popular', header: '.pageHeader' }
+    ]
+
+    for (const { route, header } of pages) {
+      await goTo(page, route)
+      await expect(page.locator(header)).toHaveCSS('border-top-left-radius', '16px')
+      await expect(page.locator(header)).toHaveCSS('border-top-right-radius', '16px')
+    }
   })
 })
 
@@ -103,6 +161,13 @@ test.describe('tab orientation shortcut', () => {
 
     await page.keyboard.press('F1')
     await expect(app).toHaveClass(/verticalTabs/)
+    await expect.poll(async () => {
+      return page.locator('.tab.vertical.active').evaluate((tab) => {
+        const tabEnd = tab.getBoundingClientRect().right
+        const viewportEnd = tab.parentElement.getBoundingClientRect().right
+        return viewportEnd - tabEnd
+      })
+    }).toBeGreaterThanOrEqual(1)
 
     await page.keyboard.press('F1')
     await expect(app).not.toHaveClass(/verticalTabs/)

--- a/e2e/tests/offline/navigation.spec.mjs
+++ b/e2e/tests/offline/navigation.spec.mjs
@@ -26,4 +26,17 @@ test.describe('side nav navigation', () => {
     await page.locator(sel.forwardButton).click()
     await expect(page).toHaveURL(/#\/settings/)
   })
+
+  test('navigation history popout shows page icons and a drop shadow', async ({ page }) => {
+    await goTo(page, 'history')
+    await goTo(page, 'settings')
+
+    await page.locator(sel.backButton).click({ button: 'right' })
+
+    const popout = page.locator('.topNav .iconDropdown')
+    await expect(popout).toBeVisible()
+    await expect(popout.locator('[role="option"]')).toHaveCount(3)
+    await expect(popout.locator('[role="option"] svg')).toHaveCount(3)
+    await expect(popout).not.toHaveCSS('box-shadow', 'none')
+  })
 })

--- a/e2e/tests/offline/video-actions.spec.mjs
+++ b/e2e/tests/offline/video-actions.spec.mjs
@@ -57,6 +57,25 @@ async function readPlaylist(app, id) {
   return records.filter((record) => record._id === id).at(-1)
 }
 
+test.describe('rounded action popovers', () => {
+  test.use({
+    seed: {
+      ...SEED,
+      settings: { ...SEED.settings, uiRoundness: 0 }
+    }
+  })
+
+  test('applies UI roundness to icon-button dropdowns', async ({ page }) => {
+    await goTo(page, 'history')
+
+    const video = page.locator('.ft-list-video').first()
+    await video.hover()
+    await video.locator('.addToPlaylistIcon .iconButton').click()
+
+    await expect(video.locator('.addToPlaylistIcon .iconDropdown')).toHaveCSS('border-radius', '0px')
+  })
+})
+
 test.describe('list video actions', () => {
   test('the options dropdown shows an icon for each action', async ({ page }) => {
     await goTo(page, 'history')
@@ -66,8 +85,20 @@ test.describe('list video actions', () => {
     await video.locator('.optionsButton').click()
 
     const actions = page.getByRole('option')
+    const dropdown = video.locator('.optionsButton .iconDropdown')
     await expect(actions).not.toHaveCount(0)
     await expect(actions.locator('.optionIconColumn svg')).toHaveCount(await actions.count())
+    await expect(dropdown).toHaveCSS('font-size', '14px')
+    await expect(dropdown).not.toHaveCSS('box-shadow', 'none')
+    await expect(actions.first()).toHaveCSS('text-align', 'center')
+    await expect(actions.first()).toHaveCSS('justify-content', 'center')
+    expect(await actions.locator('span').evaluateAll((labels) => {
+      return labels.every((label) => label.scrollWidth <= label.clientWidth)
+    })).toBe(true)
+    const actionRows = await actions.evaluateAll((items) => items.map((item) => item.offsetTop))
+    expect(actionRows[0]).toBe(actionRows[1])
+    expect(new Set(actionRows.slice(2, 5)).size).toBe(1)
+    expect(actionRows.at(-3)).toBe(actionRows.at(-2))
   })
 
   test('shows a filled playlist icon when the video is already in a playlist', async ({ page }) => {
@@ -261,10 +292,11 @@ test.describe('list video actions', () => {
     await expect(video.locator('.quickBookmarkVideoIcon [data-icon="clock"]')).toBeVisible()
     await video.locator('.quickBookmarkVideoIcon').click()
 
-    // Once saved, the button keeps the configured icon and overlays a checkmark on it.
+    // Once saved, the button keeps the configured icon and indicates state with color.
     await expect(video.locator('.quickBookmarkVideoIcon.bookmarked')).toBeVisible()
     await expect(video.locator('.quickBookmarkVideoIcon [data-icon="clock"]')).toBeVisible()
-    await expect(video.locator('.quickBookmarkVideoIcon .overlayIcon[data-icon="check"]')).toBeVisible()
+    await expect(video.locator('.quickBookmarkVideoIcon .overlayIcon')).toHaveCount(0)
+    await expect(video.locator('.quickBookmarkVideoIcon .iconButton')).toHaveCSS('color', 'rgb(110, 170, 115)')
     await expect(page.locator('.toast .message', { hasText: 'Video has been saved to Favorites' })).toBeVisible()
 
     await expect.poll(async () => {

--- a/src/renderer/App.css
+++ b/src/renderer/App.css
@@ -126,7 +126,7 @@
   color: var(--primary-text-color);
   background-color: color-mix(in srgb, var(--bg-color) 94%, #000);
   border: 1px solid var(--tertiary-text-color);
-  border-radius: 8px;
+  border-radius: calc(8px * var(--ui-roundness));
   box-shadow: 0 12px 32px rgb(0 0 0 / 32%);
 }
 
@@ -145,7 +145,7 @@
   color: var(--primary-text-color);
   background-color: var(--card-bg-color);
   border: 1px solid var(--tertiary-text-color);
-  border-radius: 6px;
+  border-radius: calc(6px * var(--ui-roundness));
   outline: none;
 }
 
@@ -173,7 +173,7 @@
   color: var(--primary-text-color);
   background-color: transparent;
   border: 0;
-  border-radius: 6px;
+  border-radius: calc(6px * var(--ui-roundness));
   cursor: pointer;
 }
 
@@ -223,7 +223,7 @@
   padding: 12px;
   background-color: color-mix(in srgb, var(--bg-color) 92%, #000);
   border: 1px solid var(--tertiary-text-color);
-  border-radius: 8px;
+  border-radius: calc(8px * var(--ui-roundness));
   box-shadow: 0 16px 40px rgb(0 0 0 / 38%);
 }
 
@@ -236,7 +236,7 @@
   color: var(--primary-text-color);
   background-color: var(--card-bg-color);
   border: 2px solid transparent;
-  border-radius: 8px;
+  border-radius: calc(8px * var(--ui-roundness));
   cursor: pointer;
   text-align: start;
   transition: border-color 0.12s ease, background-color 0.12s ease, transform 0.12s ease;
@@ -259,7 +259,7 @@
   block-size: 112px;
   overflow: hidden;
   background-color: color-mix(in srgb, var(--bg-color) 84%, #000);
-  border-radius: 6px;
+  border-radius: calc(6px * var(--ui-roundness));
 }
 
 .tabSwitcherPreview img {

--- a/src/renderer/App.vue
+++ b/src/renderer/App.vue
@@ -1632,12 +1632,22 @@ const secColor = computed(() => store.getters.getSecColor)
 
 watch(secColor, updateTheme)
 
+/** @type {import('vue').ComputedRef<number>} */
+const uiRoundness = computed(() => store.getters.getUiRoundness)
+
+watch(uiRoundness, updateUiRoundness)
+
 function updateTheme() {
   document.body.className = `${baseTheme.value || 'system'} main${mainColor.value || 'Red'} sec${secColor.value || 'Blue'}`
   document.body.dataset.systemTheme = window.matchMedia('(prefers-color-scheme: dark)').matches ? 'dark' : 'light'
 }
 
+function updateUiRoundness() {
+  document.body.style.setProperty('--ui-roundness', String(uiRoundness.value / 100))
+}
+
 updateTheme()
+updateUiRoundness()
 
 const showUpdatesBanner = ref(false)
 const latestVersionNumber = ref('')

--- a/src/renderer/components/CaptionSettings/CaptionSettings.css
+++ b/src/renderer/components/CaptionSettings/CaptionSettings.css
@@ -3,7 +3,7 @@
   box-sizing: border-box;
   min-block-size: 120px;
   margin-block-end: 1rem;
-  border-radius: 5px;
+  border-radius: calc(5px * var(--ui-roundness));
   background: linear-gradient(135deg, #576574, #222f3e);
   font-size: calc(20px * var(--caption-font-scale));
   overflow: hidden;
@@ -66,7 +66,7 @@
   min-block-size: 76px;
   padding: 0.75rem;
   border: 1px solid var(--border-color);
-  border-radius: 5px;
+  border-radius: calc(5px * var(--ui-roundness));
   background-color: var(--card-bg-color);
 }
 
@@ -93,7 +93,7 @@
   block-size: 36px;
   padding: 2px;
   border: 1px solid var(--border-color);
-  border-radius: 4px;
+  border-radius: calc(4px * var(--ui-roundness));
   background: transparent;
   cursor: pointer;
 }

--- a/src/renderer/components/ChannelAbout/ChannelAbout.css
+++ b/src/renderer/components/ChannelAbout/ChannelAbout.css
@@ -28,7 +28,7 @@
 .aboutTagLink {
   background-color: var(--secondary-card-bg-color);
   color: var(--primary-text-color);
-  border-radius: 7px;
+  border-radius: calc(7px * var(--ui-roundness));
   padding: 7px;
   text-decoration: none;
 }

--- a/src/renderer/components/ChannelDetails/ChannelDetails.css
+++ b/src/renderer/components/ChannelDetails/ChannelDetails.css
@@ -1,5 +1,6 @@
 .bannerContainer {
   background: center / cover no-repeat var(--banner-url, transparent);
+  border-radius: calc(8px * var(--ui-roundness)) calc(8px * var(--ui-roundness)) 0 0;
   block-size: 13vw;
   min-block-size: 110px;
   max-block-size: 32vh;
@@ -16,6 +17,7 @@
 .infoContainer {
   position: relative;
   background-color: var(--card-bg-color);
+  border-radius: 0 0 calc(8px * var(--ui-roundness)) calc(8px * var(--ui-roundness));
   margin-block-start: 10px;
   padding-block: 0;
   padding-inline: 16px;

--- a/src/renderer/components/ChannelHome/ChannelHome.css
+++ b/src/renderer/components/ChannelHome/ChannelHome.css
@@ -30,7 +30,7 @@
   font-style: italic;
   padding-block: 5px;
   padding-inline: 7px;
-  border-radius: 10px;
+  border-radius: calc(10px * var(--ui-roundness));
   text-decoration: none;
 }
 

--- a/src/renderer/components/CommentSection/CommentReply.css
+++ b/src/renderer/components/CommentSection/CommentReply.css
@@ -25,7 +25,7 @@
   block-size: 15px;
   border-block-end: 1px solid var(--comment-thread-line-color);
   border-inline-start: 1px solid var(--comment-thread-line-color);
-  border-end-start-radius: 12px;
+  border-end-start-radius: calc(12px * var(--ui-roundness));
   pointer-events: none;
 }
 

--- a/src/renderer/components/CommentSection/CommentSection.css
+++ b/src/renderer/components/CommentSection/CommentSection.css
@@ -97,7 +97,7 @@
   padding: 6px;
   background-color: rgb(12 12 12 / 62%);
   border: 1px solid rgb(255 255 255 / 10%);
-  border-radius: 10px;
+  border-radius: calc(10px * var(--ui-roundness));
   box-shadow: 0 6px 20px rgb(0 0 0 / 35%);
   backdrop-filter: blur(14px) saturate(1.05);
 }
@@ -112,7 +112,7 @@
   text-align: start;
   background: transparent;
   border: 0;
-  border-radius: 8px;
+  border-radius: calc(8px * var(--ui-roundness));
   cursor: pointer;
 }
 
@@ -137,8 +137,30 @@
 }
 
 .noCommentMsg {
-  padding-block: 1em;
+  flex: 1 1 auto;
+  margin: 0;
   text-align: center;
+}
+
+.noComments {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  justify-content: space-between;
+  gap: 8px;
+  padding-block: 8px;
+}
+
+.noCommentActions {
+  display: flex;
+  flex: 0 0 auto;
+  align-items: flex-start;
+  gap: 8px;
+  margin-inline-start: auto;
+}
+
+.noCommentActions :deep(.select) {
+  margin-block-start: 20px;
 }
 
 .commentsTitle {
@@ -188,6 +210,10 @@
 
 .reloadCommentsAligned {
   margin-block-start: 39px;
+}
+
+.noCommentActions .reloadCommentsAligned {
+  margin-block-start: 29px;
 }
 
 .comment {
@@ -249,7 +275,7 @@
 
 .commentOwner {
   background-color: var(--secondary-card-bg-color);
-  border-radius: 10px;
+  border-radius: calc(10px * var(--ui-roundness));
   padding-inline: 10px;
 }
 
@@ -395,7 +421,7 @@
   block-size: 15px;
   border-block-end: 1px solid var(--comment-thread-line-color);
   border-inline-start: 1px solid var(--comment-thread-line-color);
-  border-end-start-radius: 12px;
+  border-end-start-radius: calc(12px * var(--ui-roundness));
   pointer-events: none;
 }
 

--- a/src/renderer/components/CommentSection/CommentSection.vue
+++ b/src/renderer/components/CommentSection/CommentSection.vue
@@ -71,7 +71,7 @@
       class="commentsContentWrapper"
     >
       <div
-        v-if="!fullscreenOverlay && showComments && !isLoading"
+        v-if="!fullscreenOverlay && showComments && !isLoading && commentData.length > 0"
         class="commentHeader"
       >
         <h3
@@ -336,6 +336,7 @@
       </div>
       <div
         v-else-if="showComments && !isLoading"
+        class="noComments"
       >
         <h3
           v-if="isPostComments"
@@ -349,6 +350,30 @@
         >
           {{ $t("Comments.There are no comments available for this video") }}
         </h3>
+        <div
+          v-if="!fullscreenOverlay"
+          class="noCommentActions"
+        >
+          <FtSelect
+            v-if="showSortBy"
+            :placeholder="$t('Global.Sort By')"
+            :value="currentSortValue"
+            :select-names="sortNames"
+            :select-values="sortValues"
+            :icon="['fas', 'arrow-down-short-wide']"
+            @change="handleSortChange"
+          />
+          <FtIconButton
+            :title="$t('Comments.Reload Comments')"
+            :icon="['fas', 'sync']"
+            :size="12"
+            :padding="8"
+            :use-shadow="false"
+            class="reloadComments"
+            :class="{ reloadCommentsAligned: showSortBy }"
+            @click="reloadCommentData"
+          />
+        </div>
       </div>
       <FtSpinner
         v-if="shouldShowAutoLoadMoreCommentsSpinner"

--- a/src/renderer/components/DownloadSettings.vue
+++ b/src/renderer/components/DownloadSettings.vue
@@ -503,7 +503,7 @@ async function chooseExecutablePath(binary) {
 .binaryProgressBarTrack {
   background-color: #9e9e9e;
   block-size: 8px;
-  border-radius: 4px;
+  border-radius: calc(4px * var(--ui-roundness));
   margin-block: 10px;
   margin-inline: auto;
   max-inline-size: 500px;
@@ -513,7 +513,7 @@ async function chooseExecutablePath(binary) {
 .binaryProgressBarFill {
   background-color: var(--accent-color);
   block-size: 100%;
-  border-radius: 4px;
+  border-radius: calc(4px * var(--ui-roundness));
   transition: inline-size 0.3s ease;
 }
 

--- a/src/renderer/components/FtAddToPlaylistDropdown/FtAddToPlaylistDropdown.scss
+++ b/src/renderer/components/FtAddToPlaylistDropdown/FtAddToPlaylistDropdown.scss
@@ -51,7 +51,7 @@
 
 .playlistThumbnail {
   block-size: 27px;
-  border-radius: 3px;
+  border-radius: calc(3px * var(--ui-roundness));
   flex-shrink: 0;
   inline-size: 48px;
   object-fit: cover;

--- a/src/renderer/components/FtButton/FtButton.css
+++ b/src/renderer/components/FtButton/FtButton.css
@@ -12,7 +12,7 @@
   text-align: center;
   text-decoration: none;
   transition: 0.3s;
-  border-radius: 4px;
+  border-radius: calc(4px * var(--ui-roundness));
   white-space: nowrap;
   font-weight: 500;
   vertical-align: middle;

--- a/src/renderer/components/FtCommunityPoll/FtCommunityPoll.css
+++ b/src/renderer/components/FtCommunityPoll/FtCommunityPoll.css
@@ -34,7 +34,7 @@
   display: flex;
   align-items: center;
   padding-block: 5px;
-  border-radius: 5px;
+  border-radius: calc(5px * var(--ui-roundness));
   border-style: solid;
   border-width: 1px;
   padding-inline-start: 10px;

--- a/src/renderer/components/FtCommunityPost/FtCommunityPost.scss
+++ b/src/renderer/components/FtCommunityPost/FtCommunityPost.scss
@@ -80,7 +80,7 @@
   }
 
   .likeBar {
-    border-radius: 4px;
+    border-radius: calc(4px * var(--ui-roundness));
     block-size: 8px;
     margin-block-end: 4px;
   }

--- a/src/renderer/components/FtContextMenu/FtContextMenu.css
+++ b/src/renderer/components/FtContextMenu/FtContextMenu.css
@@ -6,7 +6,7 @@
   color: var(--primary-text-color);
   background-color: color-mix(in srgb, var(--card-bg-color) 96%, var(--bg-color));
   border: 1px solid color-mix(in srgb, var(--tertiary-text-color) 55%, transparent);
-  border-radius: 8px;
+  border-radius: calc(8px * var(--ui-roundness));
   box-shadow: 0 12px 32px rgb(0 0 0 / 34%);
 }
 
@@ -43,7 +43,7 @@
   color: inherit;
   background: transparent;
   border: 0;
-  border-radius: 5px;
+  border-radius: calc(5px * var(--ui-roundness));
   font: inherit;
   text-align: start;
   cursor: default;

--- a/src/renderer/components/FtIconButton/FtIconButton.scss
+++ b/src/renderer/components/FtIconButton/FtIconButton.scss
@@ -141,6 +141,7 @@
 
 .iconDropdown {
   background-color: var(--side-nav-color);
+  border-radius: calc(8px * var(--ui-roundness));
   box-shadow: 0 1px 2px rgb(0 0 0 / 50%);
   color: var(--secondary-text-color);
   display: inline;
@@ -150,6 +151,7 @@
   text-align: center;
   user-select: none;
   z-index: 3;
+  overflow: hidden;
 
   &.left {
     inset-inline-end: calc(50% - 10px);

--- a/src/renderer/components/FtInput/FtInput.css
+++ b/src/renderer/components/FtInput/FtInput.css
@@ -112,7 +112,7 @@ body[dir='rtl'] .ft-input-component.search.showClearTextButton:focus-within .inp
   font-size: 16px;
   block-size: 45px;
   color: var(--secondary-text-color);
-  border-radius: 5px;
+  border-radius: calc(5px * var(--ui-roundness));
   background-color: var(--search-bar-color);
 }
 
@@ -231,7 +231,7 @@ body[dir='rtl'] .ft-input-component.search.showClearTextButton:focus-within .inp
   padding-block: 5px;
   padding-inline: 0;
   z-index: 10;
-  border-radius: 0 0 5px 5px;
+  border-radius: 0 0 calc(5px * var(--ui-roundness)) calc(5px * var(--ui-roundness));
   overflow-wrap: break-word;
   box-shadow: 0 0 10px var(--scrollbar-color-hover);
   background-color: var(--search-bar-color);
@@ -253,7 +253,7 @@ body[dir='rtl'] .ft-input-component.search.showClearTextButton:focus-within .inp
 .search .list::-webkit-scrollbar-thumb {
   background: var(--scrollbar-color-hover);
   border: 2px solid var(--search-bar-color);
-  border-radius: 6px;
+  border-radius: calc(6px * var(--ui-roundness));
 }
 
 .list li {

--- a/src/renderer/components/FtInputTags/FtInputTags.css
+++ b/src/renderer/components/FtInputTags/FtInputTags.css
@@ -2,7 +2,7 @@
   position: relative;
   background-color: var(--bg-color);
   padding: 20px;
-  border-radius: 5px;
+  border-radius: calc(5px * var(--ui-roundness));
   display: block;
   inline-size: 60%;
 }
@@ -23,7 +23,7 @@
   list-style: none;
   background-color: var(--card-bg-color);
   margin: 5px;
-  border-radius: 5px;
+  border-radius: calc(5px * var(--ui-roundness));
   display: flex;
   float: inline-start;
 }

--- a/src/renderer/components/FtKeyboardShortcutPrompt/FtKeyboardShortcutPrompt.css
+++ b/src/renderer/components/FtKeyboardShortcutPrompt/FtKeyboardShortcutPrompt.css
@@ -105,7 +105,7 @@ h3 {
   padding-block: 0.35em;
   padding-inline: 0.6em;
   border: 1px solid var(--primary-shadow-color);
-  border-radius: 4px;
+  border-radius: calc(4px * var(--ui-roundness));
   color: var(--primary-text-color);
   background: var(--card-bg-color);
   font: inherit;

--- a/src/renderer/components/FtListVideo/FtListVideo.scss
+++ b/src/renderer/components/FtListVideo/FtListVideo.scss
@@ -59,7 +59,7 @@
   margin-inline: 2px;
   background-color: var(--secondary-card-bg-color);
   font-size: 10px;
-  border-radius: 2px;
+  border-radius: calc(2px * var(--ui-roundness));
   display: inline-block;
   font-weight: 500;
   white-space-collapse: collapse;

--- a/src/renderer/components/FtListVideo/FtListVideo.vue
+++ b/src/renderer/components/FtListVideo/FtListVideo.vue
@@ -89,7 +89,6 @@
           v-if="isQuickBookmarkEnabled && quickBookmarkButtonEnabled"
           :title="quickBookmarkIconText"
           :icon="quickBookmarkIcon"
-          :overlay-icon="isInQuickBookmarkPlaylist ? ['fas', 'check'] : null"
           class="quickBookmarkVideoIcon"
           :class="{
             bookmarked: isInQuickBookmarkPlaylist,
@@ -669,9 +668,6 @@ const dropdownOptions = computed(() => {
               icon: ['fas', 'link']
             }]
           : [],
-        {
-          type: 'divider'
-        },
         {
           label: t('Video.Open Channel in YouTube'),
           value: 'openYoutubeChannel',

--- a/src/renderer/components/FtProgressBar/FtProgressBar.css
+++ b/src/renderer/components/FtProgressBar/FtProgressBar.css
@@ -29,7 +29,7 @@
   inset-block: -1px;
   inset-inline-end: 0;
   inline-size: 6px;
-  border-radius: 999px;
+  border-radius: calc(999px * var(--ui-roundness));
   background-color: color-mix(in srgb, var(--primary-color) 55%, #fff);
   box-shadow: 0 0 8px 2px color-mix(in srgb, var(--primary-color) 75%, transparent);
   content: '';

--- a/src/renderer/components/FtQuickBookmarkIconPicker/FtQuickBookmarkIconPicker.vue
+++ b/src/renderer/components/FtQuickBookmarkIconPicker/FtQuickBookmarkIconPicker.vue
@@ -68,7 +68,7 @@ const iconLabels = {
   align-items: center;
   background: var(--card-bg-color);
   border: 2px solid transparent;
-  border-radius: 6px;
+  border-radius: calc(6px * var(--ui-roundness));
   color: var(--primary-text-color);
   cursor: pointer;
   display: flex;

--- a/src/renderer/components/FtSelect/FtSelect.css
+++ b/src/renderer/components/FtSelect/FtSelect.css
@@ -40,7 +40,7 @@
   block-size: 45px;
   padding-inline-start: 1rem;
   font-size: 16px;
-  border-radius: 5px;
+  border-radius: calc(5px * var(--ui-roundness));
   border: 0;
 }
 

--- a/src/renderer/components/FtSettingsSection/FtSettingsSection.scss
+++ b/src/renderer/components/FtSettingsSection/FtSettingsSection.scss
@@ -14,6 +14,7 @@
 
 .sectionBody {
   background-color: var(--card-bg-color);
+  border-radius: calc(8px * var(--ui-roundness));
   padding-block: 10px;
 
   > :deep(div) {

--- a/src/renderer/components/FtSkeletonGrid/FtSkeletonGrid.css
+++ b/src/renderer/components/FtSkeletonGrid/FtSkeletonGrid.css
@@ -14,7 +14,7 @@
 .skeletonThumbnail {
   aspect-ratio: 16 / 9;
   inline-size: 100%;
-  border-radius: 5px;
+  border-radius: calc(5px * var(--ui-roundness));
 }
 
 .listCard .skeletonThumbnail {
@@ -31,7 +31,7 @@
 
 .skeletonLine {
   block-size: 14px;
-  border-radius: 4px;
+  border-radius: calc(4px * var(--ui-roundness));
   inline-size: 90%;
 }
 

--- a/src/renderer/components/FtSlider/FtSlider.css
+++ b/src/renderer/components/FtSlider/FtSlider.css
@@ -55,7 +55,7 @@
 .input::-webkit-slider-runnable-track {
   margin-block: 17px;
   margin-inline: 0;
-  border-radius: 1px;
+  border-radius: calc(1px * var(--ui-roundness));
   inline-size: 100%;
   block-size: 2px;
   background-color: var(--accent-color-opacity4);
@@ -102,7 +102,7 @@
 .input::-moz-range-track {
   margin-block: 0;
   margin: 17px;
-  border-radius: 1px;
+  border-radius: calc(1px * var(--ui-roundness));
   inline-size: 100%;
   block-size: 2px;
   background-color: var(--accent-color-opacity4);
@@ -120,7 +120,7 @@
 }
 
 .input::-moz-range-progress {
-  border-radius: 1px;
+  border-radius: calc(1px * var(--ui-roundness));
   block-size: 2px;
   background-color: var(--accent-color);
 }

--- a/src/renderer/components/FtSubscribeButton/FtSubscribeButton.css
+++ b/src/renderer/components/FtSubscribeButton/FtSubscribeButton.css
@@ -1,7 +1,7 @@
 .buttonList {
   margin: 5px;
   margin-block-end: 10px;
-  border-radius: 4px;
+  border-radius: calc(4px * var(--ui-roundness));
   block-size: fit-content;
   box-shadow: 0 1px 2px rgb(0 0 0 / 50%);
   display: flex;

--- a/src/renderer/components/FtToast/FtToast.css
+++ b/src/renderer/components/FtToast/FtToast.css
@@ -30,7 +30,7 @@
   overflow-y: auto;
   background-color: rgb(28 28 28 / 92%);
   color: #fff;
-  border-radius: 12px;
+  border-radius: calc(12px * var(--ui-roundness));
   box-shadow: 0 4px 16px rgb(0 0 0 / 35%);
 
   /* Many toasts are clickable, so keep the click affordance until a drag starts */
@@ -59,7 +59,7 @@
   inline-size: 64px;
   block-size: 36px;
   object-fit: cover;
-  border-radius: 6px;
+  border-radius: calc(6px * var(--ui-roundness));
 }
 
 .icon {

--- a/src/renderer/components/FtToggleSwitch/FtToggleSwitch.scss
+++ b/src/renderer/components/FtToggleSwitch/FtToggleSwitch.scss
@@ -42,7 +42,7 @@
 
   &::before {
     background-color: #9e9e9e;
-    border-radius: 8px;
+    border-radius: calc(8px * var(--ui-roundness));
     block-size: 14px;
     inset-inline-start: 1px;
     inline-size: 34px;

--- a/src/renderer/components/FtTooltip/FtTooltip.css
+++ b/src/renderer/components/FtTooltip/FtTooltip.css
@@ -9,7 +9,7 @@
 
 .text {
   background-color: color-mix(in srgb, var(--primary-text-color) 80%, transparent);
-  border-radius: 20px;
+  border-radius: calc(20px * var(--ui-roundness));
   color: var(--card-bg-color);
   font-size: 1rem;
   line-height: 120%;

--- a/src/renderer/components/FtVideoAnnotations/FtVideoAnnotations.css
+++ b/src/renderer/components/FtVideoAnnotations/FtVideoAnnotations.css
@@ -14,7 +14,7 @@
   align-items: center;
   gap: 5px;
   border: 0;
-  border-radius: 3px;
+  border-radius: calc(3px * var(--ui-roundness));
   padding-block: 5px;
   padding-inline: 8px;
   background: rgb(0 0 0 / 72%);
@@ -36,7 +36,7 @@
   display: block;
   overflow: hidden;
   border: 1px solid rgb(255 255 255 / 65%);
-  border-radius: clamp(3px, 0.7cqw, 9px);
+  border-radius: clamp(calc(3px * var(--ui-roundness)), calc(0.7cqw * var(--ui-roundness)), calc(9px * var(--ui-roundness)));
   background: #000;
   box-shadow: 0 2px 8px rgb(0 0 0 / 55%);
   color: #fff;
@@ -85,7 +85,7 @@
   position: absolute;
   inset-block-end: clamp(3px, 0.55cqw, 8px);
   inset-inline-end: clamp(3px, 0.55cqw, 8px);
-  border-radius: 2px;
+  border-radius: calc(2px * var(--ui-roundness));
   padding-block: 2px;
   padding-inline: 4px;
   background: rgb(0 0 0 / 78%);
@@ -135,7 +135,7 @@
   padding-block: var(--hovercard-padding);
   padding-inline: var(--hovercard-padding) calc(var(--channel-avatar-size) + 2 * var(--hovercard-padding));
   border: 1px solid rgb(0 0 0 / 25%);
-  border-radius: min(0.7cqw, 8px);
+  border-radius: min(calc(0.7cqw * var(--ui-roundness)), calc(8px * var(--ui-roundness)));
   background: #fff;
   box-shadow: 0 4px 18px rgb(0 0 0 / 55%);
   color: #282828;

--- a/src/renderer/components/PlayerSettings/PlayerSettings.css
+++ b/src/renderer/components/PlayerSettings/PlayerSettings.css
@@ -37,7 +37,7 @@
   gap: 1rem;
   padding: 1rem;
   border: 1px solid var(--border-color);
-  border-radius: 4px;
+  border-radius: calc(4px * var(--ui-roundness));
 }
 
 .channelSpeedInfo {
@@ -72,7 +72,7 @@
   gap: 0.75rem;
   padding: 0.75rem;
   border: 1px solid var(--border-color);
-  border-radius: 4px;
+  border-radius: calc(4px * var(--ui-roundness));
   background-color: var(--card-bg-color);
   transition: transform 0.18s ease, opacity 0.18s ease;
   will-change: transform;
@@ -126,7 +126,7 @@
   block-size: 45px;
   padding: 1rem;
   border: 0;
-  border-radius: 5px;
+  border-radius: calc(5px * var(--ui-roundness));
   background-color: var(--search-bar-color);
   color: var(--secondary-text-color);
   font-size: 16px;
@@ -140,7 +140,7 @@
   inline-size: 40px;
   block-size: 40px;
   border: 0;
-  border-radius: 4px;
+  border-radius: calc(4px * var(--ui-roundness));
   background: transparent;
   color: var(--primary-text-color);
   cursor: pointer;

--- a/src/renderer/components/SideNav/SideNav.css
+++ b/src/renderer/components/SideNav/SideNav.css
@@ -30,8 +30,8 @@
   /* paint above the nav entries' hover/active backgrounds */
   z-index: 1;
   inline-size: 3px;
-  border-start-end-radius: 999px;
-  border-end-end-radius: 999px;
+  border-start-end-radius: calc(999px * var(--ui-roundness));
+  border-end-end-radius: calc(999px * var(--ui-roundness));
   background-color: var(--primary-color);
   pointer-events: none;
   transition: transform 200ms ease, block-size 200ms ease;

--- a/src/renderer/components/SyncSettings/SyncSettings.css
+++ b/src/renderer/components/SyncSettings/SyncSettings.css
@@ -49,7 +49,7 @@
 .syncProgressTrack {
   background-color: var(--side-nav-color);
   block-size: 0.4rem;
-  border-radius: 999px;
+  border-radius: calc(999px * var(--ui-roundness));
   overflow: hidden;
 }
 

--- a/src/renderer/components/TabBar/SortableTab.vue
+++ b/src/renderer/components/TabBar/SortableTab.vue
@@ -432,7 +432,7 @@ watch(() => props.disableTooltips, (disableTooltips) => {
   padding-inline: 10px;
   padding-block: 6px;
   background-color: var(--tab-surface-color, var(--bg-color));
-  border-radius: 6px 6px 0 0;
+  border-radius: calc(6px * var(--ui-roundness)) calc(6px * var(--ui-roundness)) 0 0;
   cursor: pointer;
   block-size: 31px;
   min-inline-size: 100px;
@@ -454,10 +454,10 @@ watch(() => props.disableTooltips, (disableTooltips) => {
 }
 
 .tab.vertical {
-  inline-size: 100%;
+  inline-size: calc(100% - 1px);
   min-inline-size: 0;
   max-inline-size: none;
-  border-radius: 6px;
+  border-radius: calc(6px * var(--ui-roundness));
   border-block-end: 1px solid transparent;
 }
 
@@ -474,7 +474,7 @@ watch(() => props.disableTooltips, (disableTooltips) => {
 }
 
 .tab.vertical.pinned {
-  inline-size: 100%;
+  inline-size: calc(100% - 1px);
   min-inline-size: 0;
   max-inline-size: none;
 }
@@ -650,7 +650,7 @@ watch(() => props.disableTooltips, (disableTooltips) => {
   border: 0;
   cursor: pointer;
   padding: 2px;
-  border-radius: 4px;
+  border-radius: calc(4px * var(--ui-roundness));
   color: var(--tertiary-text-color);
   opacity: 0;
   transition: opacity 0.15s ease, background-color 0.15s ease, color 0.15s ease;
@@ -698,7 +698,7 @@ watch(() => props.disableTooltips, (disableTooltips) => {
   z-index: 10000;
   padding: 8px;
   border: 1px solid var(--tertiary-text-color);
-  border-radius: 8px;
+  border-radius: calc(8px * var(--ui-roundness));
   background-color: var(--card-bg-color);
   box-shadow: 0 8px 26px rgb(0 0 0 / 32%);
   color: var(--primary-text-color);
@@ -727,7 +727,7 @@ watch(() => props.disableTooltips, (disableTooltips) => {
   aspect-ratio: 16 / 9;
   inline-size: 100%;
   overflow: hidden;
-  border-radius: 5px;
+  border-radius: calc(5px * var(--ui-roundness));
   background-color: var(--secondary-card-bg-color);
 }
 

--- a/src/renderer/components/TabBar/TabBar.css
+++ b/src/renderer/components/TabBar/TabBar.css
@@ -45,7 +45,7 @@
   inset-inline: 0;
   inset-block-end: 0;
   block-size: 3px;
-  border-radius: 999px;
+  border-radius: calc(999px * var(--ui-roundness));
   background-color: var(--scrollbar-color);
   cursor: pointer;
   -webkit-app-region: no-drag;
@@ -84,7 +84,7 @@
   border: 0;
   cursor: pointer;
   padding: 6px;
-  border-radius: 4px;
+  border-radius: calc(4px * var(--ui-roundness));
   color: var(--secondary-text-color);
   transition: background-color 0.15s ease, color 0.15s ease;
   flex-shrink: 0;

--- a/src/renderer/components/ThemeSettings.vue
+++ b/src/renderer/components/ThemeSettings.vue
@@ -91,6 +91,17 @@
           @input="previewThumbnailSize"
           @change="updateThumbnailSize"
         />
+        <FtSlider
+          :label="t('Settings.Theme Settings.UI Roundness')"
+          :default-value="uiRoundness"
+          setting-key="uiRoundness"
+          :min-value="0"
+          :max-value="200"
+          :step="5"
+          value-extension="%"
+          @input="previewUiRoundness"
+          @change="updateUiRoundness"
+        />
       </div>
     </FtFlexBox>
     <br>
@@ -363,6 +374,7 @@ function updateUiScale(value) {
 
 /** @type {import('vue').ComputedRef<number>} */
 const thumbnailSize = computed(() => store.getters.getThumbnailSize)
+const uiRoundness = computed(() => store.getters.getUiRoundness)
 
 /**
  * @param {number} value
@@ -376,6 +388,20 @@ function previewThumbnailSize(value) {
  */
 function updateThumbnailSize(value) {
   store.dispatch('updateThumbnailSize', value)
+}
+
+/**
+ * @param {number} value
+ */
+function previewUiRoundness(value) {
+  store.commit('setUiRoundness', value)
+}
+
+/**
+ * @param {number} value
+ */
+function updateUiRoundness(value) {
+  store.dispatch('updateUiRoundness', value)
 }
 
 /** @type {boolean} */

--- a/src/renderer/components/TopNav/TopNav.scss
+++ b/src/renderer/components/TopNav/TopNav.scss
@@ -83,6 +83,12 @@
   user-select: none;
 }
 
+.navIconButton :deep(.iconDropdown) {
+  box-shadow:
+    0 16px 40px rgb(0 0 0 / 55%),
+    0 3px 10px rgb(0 0 0 / 45%);
+}
+
 .navButton {
   border-radius: 50%;
   border-style: none;
@@ -282,4 +288,3 @@
     inset-inline-start: var(--vertical-tab-bar-width, 220px);
   }
 }
-

--- a/src/renderer/components/WatchVideoChapters/WatchVideoChapters.css
+++ b/src/renderer/components/WatchVideoChapters/WatchVideoChapters.css
@@ -55,7 +55,7 @@
   display: block;
   align-self: center;
   inline-size: 100px;
-  border-radius: 8px;
+  border-radius: calc(8px * var(--ui-roundness));
   background-color: rgb(255 255 255 / 8%);
   background-position: center;
   background-repeat: no-repeat;
@@ -87,7 +87,7 @@
 .chapterTimestamp {
   padding-block: 4px;
   padding-inline: 6px;
-  border-radius: 2px;
+  border-radius: calc(2px * var(--ui-roundness));
   background-color: rgb(36 76 119 / 88%);
   color: #55b6ff;
   font-size: 13px;

--- a/src/renderer/components/WatchVideoDownloadPrompt/WatchVideoDownloadPrompt.css
+++ b/src/renderer/components/WatchVideoDownloadPrompt/WatchVideoDownloadPrompt.css
@@ -43,7 +43,7 @@
 .downloadProgressBarTrack {
   background-color: #9e9e9e;
   block-size: 8px;
-  border-radius: 4px;
+  border-radius: calc(4px * var(--ui-roundness));
   margin-block: 20px 10px;
   margin-inline: auto;
   max-inline-size: 500px;
@@ -53,7 +53,7 @@
 .downloadProgressBarFill {
   background-color: var(--accent-color);
   block-size: 100%;
-  border-radius: 4px;
+  border-radius: calc(4px * var(--ui-roundness));
   transition: inline-size 0.3s ease;
 }
 

--- a/src/renderer/components/WatchVideoInfo/WatchVideoInfo.css
+++ b/src/renderer/components/WatchVideoInfo/WatchVideoInfo.css
@@ -32,7 +32,7 @@
 .videoBadge {
   align-items: center;
   background-color: var(--secondary-card-bg-color);
-  border-radius: 5px;
+  border-radius: calc(5px * var(--ui-roundness));
   display: inline-flex;
   gap: 3px;
   padding-inline: 5px;
@@ -121,7 +121,7 @@
 }
 
 .likeBar {
-  border-radius: 4px;
+  border-radius: calc(4px * var(--ui-roundness));
   block-size: 8px;
   margin-block-end: 4px;
 }

--- a/src/renderer/components/WatchVideoInfo/WatchVideoInfo.vue
+++ b/src/renderer/components/WatchVideoInfo/WatchVideoInfo.vue
@@ -164,7 +164,6 @@
             v-if="isQuickBookmarkEnabled && !hidePlaylistActions"
             :title="quickBookmarkIconText"
             :icon="quickBookmarkIcon"
-            :overlay-icon="isInQuickBookmarkPlaylist ? ['fas', 'check'] : null"
             class="quickBookmarkVideoIcon"
             :class="{
               bookmarked: isInQuickBookmarkPlaylist,

--- a/src/renderer/components/WatchVideoLiveChat/WatchVideoLiveChat.css
+++ b/src/renderer/components/WatchVideoLiveChat/WatchVideoLiveChat.css
@@ -120,7 +120,7 @@
   margin-inline: 5%;
   margin-block: 25px 10px;
   background-color: var(--primary-color);
-  border-radius: 5px;
+  border-radius: calc(5px * var(--ui-roundness));
   position: relative;
 }
 
@@ -129,7 +129,7 @@
   inline-size: 100%;
   block-size: 55px;
   background-color: var(--primary-color-hover);
-  border-radius: 5px 5px 0 0;
+  border-radius: calc(5px * var(--ui-roundness)) calc(5px * var(--ui-roundness)) 0 0;
 }
 
 .openedSuperChat .superChatMessage {

--- a/src/renderer/components/WatchVideoPlaylist/WatchVideoPlaylist.css
+++ b/src/renderer/components/WatchVideoPlaylist/WatchVideoPlaylist.css
@@ -36,7 +36,7 @@
   cursor: pointer;
   background-color: var(--secondary-text-color);
   block-size: 6px;
-  border-radius: 3px;
+  border-radius: calc(3px * var(--ui-roundness));
   overflow: visible;
   position: relative;
   transition: block-size 0.2s ease, margin-block 0.2s ease;
@@ -65,7 +65,7 @@
 .previewTooltip {
   background-color: var(--card-bg-color);
   border: 1px solid var(--primary-border-color);
-  border-radius: 8px;
+  border-radius: calc(8px * var(--ui-roundness));
   padding-block: 8px;
   padding-inline: 12px;
   font-size: 12px;
@@ -86,7 +86,7 @@
   block-size: 36px;
   inline-size: 48px;
   object-fit: cover;
-  border-radius: 4px;
+  border-radius: calc(4px * var(--ui-roundness));
 }
 
 .previewText {

--- a/src/renderer/components/WatchVideoSponsorBlock/WatchVideoSponsorBlock.vue
+++ b/src/renderer/components/WatchVideoSponsorBlock/WatchVideoSponsorBlock.vue
@@ -250,7 +250,7 @@ function isSegmentPassed(segment) {
   overflow: hidden;
   color: var(--primary-text-color);
   background-color: var(--card-bg-color);
-  border-radius: 5px;
+  border-radius: calc(5px * var(--ui-roundness));
   box-shadow: 0 1px 2px rgb(0 0 0 / 10%);
 }
 
@@ -332,7 +332,7 @@ function isSegmentPassed(segment) {
 }
 
 .sponsorBlockSegment {
-  border-radius: 6px;
+  border-radius: calc(6px * var(--ui-roundness));
 }
 
 .sponsorBlockSegment:hover,
@@ -424,7 +424,7 @@ function isSegmentPassed(segment) {
   color: inherit;
   background-color: var(--secondary-card-bg-color);
   border: 0;
-  border-radius: 6px;
+  border-radius: calc(6px * var(--ui-roundness));
   cursor: pointer;
 }
 
@@ -526,7 +526,7 @@ function isSegmentPassed(segment) {
   color: var(--primary-text-color);
   background-color: var(--secondary-card-bg-color);
   border: 1px solid transparent;
-  border-radius: 10px;
+  border-radius: calc(10px * var(--ui-roundness));
   cursor: pointer;
   font-size: 13px;
   font-weight: 600;
@@ -562,7 +562,7 @@ function isSegmentPassed(segment) {
   block-size: 30px;
   color: var(--secondary-text-color);
   background-color: var(--card-bg-color);
-  border-radius: 8px;
+  border-radius: calc(8px * var(--ui-roundness));
   font-size: 13px;
   transition: background-color 160ms ease, color 160ms ease;
 }
@@ -598,7 +598,7 @@ function isSegmentPassed(segment) {
   block-size: 24px;
   background-color: var(--secondary-card-bg-color);
   border: 1px solid var(--side-nav-hover-color);
-  border-radius: 999px;
+  border-radius: calc(999px * var(--ui-roundness));
   transition: background-color 160ms ease, border-color 160ms ease;
 }
 

--- a/src/renderer/components/WatchVideoTranscript/WatchVideoTranscript.css
+++ b/src/renderer/components/WatchVideoTranscript/WatchVideoTranscript.css
@@ -71,7 +71,7 @@
   color: var(--primary-text-color);
   background-color: var(--side-nav-color);
   border: 1px solid var(--side-nav-hover-color);
-  border-radius: 10px;
+  border-radius: calc(10px * var(--ui-roundness));
   box-shadow: 0 6px 20px rgb(0 0 0 / 35%);
 }
 
@@ -85,7 +85,7 @@
   text-align: start;
   background: transparent;
   border: 0;
-  border-radius: 8px;
+  border-radius: calc(8px * var(--ui-roundness));
   cursor: pointer;
 }
 
@@ -131,7 +131,7 @@
   padding-block: 10px;
   padding-inline: 12px;
   border: 0;
-  border-radius: 5px;
+  border-radius: calc(5px * var(--ui-roundness));
   background: transparent;
   color: var(--primary-text-color);
   cursor: pointer;

--- a/src/renderer/components/ft-card/ft-card.css
+++ b/src/renderer/components/ft-card/ft-card.css
@@ -1,5 +1,6 @@
 .ft-card {
   background-color: var(--card-bg-color);
+  border-radius: calc(8px * var(--ui-roundness));
   margin: 8px;
   padding-block: 3px 16px;
   padding-inline: 16px;

--- a/src/renderer/components/ft-shaka-video-player/ft-shaka-video-player.css
+++ b/src/renderer/components/ft-shaka-video-player/ft-shaka-video-player.css
@@ -65,7 +65,7 @@
   inline-size: 100%;
   aspect-ratio: 16 / 9;
   background-color: #151515;
-  border-radius: 8px;
+  border-radius: calc(8px * var(--ui-roundness));
 }
 
 .autoplayThumbnail {
@@ -82,7 +82,7 @@
   padding: 2px 4px;
   color: #fff;
   background-color: rgb(0 0 0 / 80%);
-  border-radius: 3px;
+  border-radius: calc(3px * var(--ui-roundness));
   font-size: 13px;
   font-variant-numeric: tabular-nums;
   line-height: 1.2;
@@ -123,7 +123,7 @@
   color: #fff;
   background-color: #252525;
   border: 0;
-  border-radius: 999px;
+  border-radius: calc(999px * var(--ui-roundness));
   cursor: pointer;
   font-size: 14px;
   font-weight: 600;
@@ -281,7 +281,7 @@
   inline-size: 42px;
   block-size: 3px;
   background-color: rgb(255 255 255 / 42%);
-  border-radius: 999px;
+  border-radius: calc(999px * var(--ui-roundness));
   opacity: 0;
   transform: translate(-50%, -50%);
   transition: opacity 150ms ease;
@@ -338,7 +338,7 @@
   contain: layout paint;
   background-color: rgb(12 12 12 / 62%);
   border: 1px solid var(--side-nav-hover-color);
-  border-radius: 12px;
+  border-radius: calc(12px * var(--ui-roundness));
   box-shadow: 0 8px 30px rgb(0 0 0 / 45%);
   backdrop-filter: blur(14px);
   color: #fff;
@@ -431,7 +431,7 @@
   position: absolute;
   inset-block: 8px;
   inset-inline: 0;
-  border-radius: 18px;
+  border-radius: calc(18px * var(--ui-roundness));
   background-color: rgb(0 0 0 / 16%);
   content: '';
   pointer-events: none;
@@ -564,7 +564,7 @@
   inset-inline-start: 50%;
   inline-size: 26px;
   block-size: 2.5px;
-  border-radius: 999px;
+  border-radius: calc(999px * var(--ui-roundness));
   background-color: currentcolor;
   pointer-events: none;
   transform: translate(-50%, -50%) rotate(45deg) scaleX(1);
@@ -627,7 +627,7 @@
   inset-inline-start: 50%;
   inline-size: 26px;
   block-size: 2.5px;
-  border-radius: 999px;
+  border-radius: calc(999px * var(--ui-roundness));
   background-color: currentcolor;
   pointer-events: none;
   transform: translate(-50%, -50%) rotate(45deg) scaleX(0);
@@ -653,7 +653,7 @@
   inline-size: 36px;
   block-size: 18px;
   padding: 1px;
-  border-radius: 999px;
+  border-radius: calc(999px * var(--ui-roundness));
   background-color: #424242;
   transition: background-color 180ms cubic-bezier(0.4, 0, 0.2, 1);
 }
@@ -726,7 +726,7 @@
   left: 5px;
   top: 5px;
   padding: 10px;
-  border-radius: 5px;
+  border-radius: calc(5px * var(--ui-roundness));
   line-height: 1.4em;
   background-color: rgb(0 0 0 / 70%);
   color: #fff;
@@ -746,7 +746,7 @@
   left: 50%;
   transform: translateX(-50%);
   padding: 10px;
-  border-radius: 5px;
+  border-radius: calc(5px * var(--ui-roundness));
   font-size: 1.1em;
   background-color: rgb(0 0 0 / 60%);
   color: #fff;
@@ -785,7 +785,7 @@
   background-color: #000;
   color: #fff;
   padding: 10px;
-  border-radius: 10px;
+  border-radius: calc(10px * var(--ui-roundness));
 }
 
 .offlineIcon {
@@ -888,7 +888,7 @@
   min-width: min(320px, calc(100vw - 32px));
   padding: 10px 12px;
   border: 1px solid rgb(255 255 255 / 14%);
-  border-radius: 10px;
+  border-radius: calc(10px * var(--ui-roundness));
   background-color: rgb(33 37 43 / 96%);
   box-shadow: 0 10px 28px rgb(0 0 0 / 35%);
   color: #fff;
@@ -915,7 +915,7 @@
   box-sizing: border-box;
   padding: 10px 12px 12px;
   border: 1px solid rgb(255 255 255 / 14%);
-  border-radius: 10px;
+  border-radius: calc(10px * var(--ui-roundness));
   background-color: rgb(24 24 24 / 96%);
   color: #fff;
   box-shadow: 0 10px 28px rgb(0 0 0 / 35%);
@@ -960,7 +960,7 @@
 .sponsorBlockSubmissionClose {
   width: 24px;
   height: 24px;
-  border-radius: 999px;
+  border-radius: calc(999px * var(--ui-roundness));
   cursor: pointer;
 }
 
@@ -1011,7 +1011,7 @@
   min-height: 30px;
   padding: 4px 8px;
   border: 1px solid rgb(255 255 255 / 18%);
-  border-radius: 4px;
+  border-radius: calc(4px * var(--ui-roundness));
   background-color: rgb(0 0 0 / 35%);
   color: inherit;
 }
@@ -1105,7 +1105,7 @@
 .skippedSegmentTimer {
   min-width: 42px;
   padding: 2px 6px;
-  border-radius: 4px;
+  border-radius: calc(4px * var(--ui-roundness));
   background-color: rgb(255 255 255 / 10%);
   color: rgb(255 255 255 / 88%);
   font-size: 12px;
@@ -1122,7 +1122,7 @@
   padding: 0;
   border-width: 0;
   border-style: none;
-  border-radius: 999px;
+  border-radius: calc(999px * var(--ui-roundness));
   background-color: transparent;
   color: rgb(255 255 255 / 70%);
   cursor: pointer;
@@ -1144,7 +1144,7 @@
   padding: 6px 10px;
   border-width: 0;
   border-style: none;
-  border-radius: 6px;
+  border-radius: calc(6px * var(--ui-roundness));
   background-color: rgb(255 255 255 / 10%);
   color: #fff;
   font-size: 13px;
@@ -1218,7 +1218,7 @@
   text-shadow: 0 1px 2px #000, 0 2px 8px rgb(0 0 0 / 85%);
   background-color: transparent;
   border: 0;
-  border-radius: 12px;
+  border-radius: calc(12px * var(--ui-roundness));
   padding: 8px 12px;
   cursor: pointer !important;
   pointer-events: auto !important;
@@ -1263,7 +1263,7 @@
   background-color: rgb(0 0 0 / 25%);
   backdrop-filter: blur(6px);
   border: 1px solid rgb(255 255 255 / 8%);
-  border-radius: 24px;
+  border-radius: calc(24px * var(--ui-roundness));
   box-shadow: 0 2px 8px rgb(0 0 0 / 35%);
   opacity: 0;
   pointer-events: none;
@@ -1304,9 +1304,8 @@
   background-color: rgb(255 255 255 / 18%);
 }
 
-/* Reads as a cut-out of the white quick bookmark icon against the dark actions pill */
-.fullscreenAction .quickBookmarkCheck {
-  color: #000;
+.fullscreenAction.fullscreenQuickBookmarkAction.open {
+  color: var(--favorite-icon-color);
 }
 
 .fullscreenActions:has(:focus-visible) {
@@ -1359,7 +1358,7 @@
   color: #fff;
   background-color: rgb(12 12 12 / 62%);
   border: 1px solid var(--side-nav-hover-color);
-  border-radius: 12px;
+  border-radius: calc(12px * var(--ui-roundness));
   box-shadow: 0 8px 30px rgb(0 0 0 / 45%);
   opacity: 0;
   visibility: hidden;
@@ -1613,7 +1612,7 @@
   color: var(--primary-text-color);
   background-color: rgb(12 12 12 / 62%);
   border: 1px solid rgb(255 255 255 / 10%);
-  border-radius: 10px;
+  border-radius: calc(10px * var(--ui-roundness));
   box-shadow: 0 6px 20px rgb(0 0 0 / 35%);
   backdrop-filter: blur(14px) saturate(1.05);
 }
@@ -2110,7 +2109,7 @@
   min-height: 28px;
   padding: 0 6px;
   border: 1px solid rgb(255 255 255 / 18%);
-  border-radius: 999px;
+  border-radius: calc(999px * var(--ui-roundness));
   background: rgb(0 0 0 / 22%);
   color: rgb(255 255 255 / 92%);
   font-size: 10px;
@@ -2242,7 +2241,7 @@
   min-width: 0;
   min-height: 34px;
   padding: 6px 8px;
-  border-radius: 8px;
+  border-radius: calc(8px * var(--ui-roundness));
   font-size: 13px;
 }
 
@@ -2276,7 +2275,7 @@
   width: 38px;
   height: 26px;
   min-height: 26px !important;
-  border-radius: 6px !important;
+  border-radius: calc(6px * var(--ui-roundness)) !important;
 }
 
 :deep(.ft-caption-color-swatch:focus-visible),
@@ -2290,7 +2289,7 @@
   margin-top: 4px;
   padding: 10px;
   border: 1px solid rgb(255 255 255 / 18%);
-  border-radius: 8px;
+  border-radius: calc(8px * var(--ui-roundness));
   background: rgb(18 18 18 / 96%);
   box-shadow: 0 5px 18px rgb(0 0 0 / 35%);
   cursor: default;
@@ -2329,7 +2328,7 @@
   height: 30px;
   padding-inline: 8px;
   border: 1px solid rgb(255 255 255 / 24%);
-  border-radius: 6px;
+  border-radius: calc(6px * var(--ui-roundness));
   outline: 0;
   background: rgb(255 255 255 / 8%);
   color: #fff;
@@ -2360,7 +2359,7 @@
 :deep(.ft-caption-appearance-controls input[type='range']::-webkit-slider-runnable-track) {
   width: 100%;
   height: 2px;
-  border-radius: 1px;
+  border-radius: calc(1px * var(--ui-roundness));
   background-color: var(--accent-color-opacity4);
 }
 
@@ -2391,13 +2390,13 @@
 :deep(.ft-caption-appearance-controls input[type='range']::-moz-range-track) {
   width: 100%;
   height: 2px;
-  border-radius: 1px;
+  border-radius: calc(1px * var(--ui-roundness));
   background-color: var(--accent-color-opacity4);
 }
 
 :deep(.ft-caption-appearance-controls input[type='range']::-moz-range-progress) {
   height: 2px;
-  border-radius: 1px;
+  border-radius: calc(1px * var(--ui-roundness));
   background-color: var(--accent-color);
 }
 
@@ -2431,7 +2430,7 @@
   min-height: 28px;
   padding: 3px 4px 3px 8px;
   border: 0;
-  border-radius: 6px;
+  border-radius: calc(6px * var(--ui-roundness));
   background: transparent;
   color: #fff;
   color-scheme: dark;
@@ -2497,7 +2496,7 @@
   padding: 6px 12px;
   overflow: hidden;
   background-color: rgb(27 27 27 / 67%);
-  border-radius: 999px;
+  border-radius: calc(999px * var(--ui-roundness));
   color: #fff;
   font-size: 13px;
   font-weight: bold;
@@ -2601,7 +2600,7 @@
 
 .ftVideoPlayer.scrollMiniPlayer {
   box-shadow: 0 8px 28px rgb(0 0 0 / 45%);
-  border-radius: 10px;
+  border-radius: calc(10px * var(--ui-roundness));
   overflow: visible;
   touch-action: none;
   isolation: isolate;
@@ -2609,7 +2608,7 @@
 
 .ftVideoPlayer.scrollMiniPlayer > .player,
 .ftVideoPlayer.scrollMiniPlayer > .vrCanvas {
-  border-radius: 10px;
+  border-radius: calc(10px * var(--ui-roundness));
 }
 
 .ftVideoPlayer.scrollMiniPlayer :deep(.shaka-bottom-controls),
@@ -2673,7 +2672,7 @@
   transform: translateX(-50%);
   width: 36px;
   height: 4px;
-  border-radius: 999px;
+  border-radius: calc(999px * var(--ui-roundness));
   background: rgb(255 255 255 / 70%);
   box-shadow: 0 0 3px rgb(0 0 0 / 45%);
 }
@@ -2745,7 +2744,7 @@
   align-items: center;
   gap: 0;
   padding: 4px 6px;
-  border-radius: 999px;
+  border-radius: calc(999px * var(--ui-roundness));
   background: rgb(0 0 0 / 55%);
   color: #fff;
   z-index: 3;

--- a/src/renderer/components/ft-shaka-video-player/ft-shaka-video-player.vue
+++ b/src/renderer/components/ft-shaka-video-player/ft-shaka-video-player.vue
@@ -246,18 +246,7 @@
           :title="quickBookmarkTitle"
           @click="toggleQuickBookmark"
         >
-          <FontAwesomeLayers v-if="quickBookmarked">
-            <FontAwesomeIcon :icon="quickBookmarkIcon" />
-            <FontAwesomeIcon
-              class="quickBookmarkCheck"
-              :icon="['fas', 'check']"
-              transform="shrink-7 up-1"
-            />
-          </FontAwesomeLayers>
-          <FontAwesomeIcon
-            v-else
-            :icon="quickBookmarkIcon"
-          />
+          <FontAwesomeIcon :icon="quickBookmarkIcon" />
         </button>
       </div>
       <!--

--- a/src/renderer/scss-partials/_ft-list-item.scss
+++ b/src/renderer/scss-partials/_ft-list-item.scss
@@ -91,11 +91,14 @@ $watched-transition-duration: 0.5s;
     }
 
     .thumbnailLink {
+      border-radius: calc(8px * var(--ui-roundness));
       display: flex;
       overflow: hidden;
     }
 
     .thumbnailImage {
+      border-radius: inherit;
+
       @include is-sidebar-item {
         block-size: 75px;
       }
@@ -118,7 +121,7 @@ $watched-transition-duration: 0.5s;
     .videoDuration {
       place-self: flex-end end;
       background-color: var(--card-bg-color);
-      border-radius: 5px;
+      border-radius: calc(5px * var(--ui-roundness));
       color: var(--primary-text-color);
       font-size: 15px;
       line-height: 1.2;
@@ -234,6 +237,40 @@ $watched-transition-duration: 0.5s;
 
     .optionsButton {
       grid-area: optionsExternalButton;
+
+      :deep(.iconDropdown) {
+        inline-size: min(320px, calc(100vw - 16px));
+        font-size: 14px;
+        box-shadow:
+          0 16px 40px rgb(0 0 0 / 55%),
+          0 3px 10px rgb(0 0 0 / 45%);
+      }
+
+      :deep(.iconDropdown .list) {
+        display: flex;
+        flex-wrap: wrap;
+      }
+
+      :deep(.iconDropdown .listItem) {
+        box-sizing: border-box;
+        flex: 1 1 100px;
+        justify-content: center;
+        white-space: normal;
+      }
+
+      :deep(.iconDropdown .listItem.hasIcon),
+      :deep(.iconDropdown .listItem.active) {
+        display: flex;
+        text-align: center;
+      }
+
+      :deep(.iconDropdown .listItem > span) {
+        text-align: center;
+      }
+
+      :deep(.iconDropdown .listItemDivider) {
+        flex: 0 0 calc(100% - 14px);
+      }
     }
 
     .externalPlayerButton {

--- a/src/renderer/store/modules/settings.js
+++ b/src/renderer/store/modules/settings.js
@@ -348,6 +348,7 @@ const state = {
   },
   thumbnailPreference: '',
   thumbnailSize: DEFAULT_THUMBNAIL_SIZE,
+  uiRoundness: 100,
   showThumbnailSizeButtonInHeader: true,
   extraThumbnailAction: '',
   blurThumbnails: false,

--- a/src/renderer/store/modules/tabs.js
+++ b/src/renderer/store/modules/tabs.js
@@ -1,4 +1,5 @@
 import packageDetails from '../../../../package.json'
+import { getTabPageIcon } from '../../tabs/tabPageIcon'
 
 const MAX_LOGICAL_HISTORY_ENTRIES = 100
 const NAV_HISTORY_DISPLAY_LIMIT = 15
@@ -53,7 +54,8 @@ const getters = {
       options.push({
         label: entry.title || entry.route.fullPath,
         value: index - tab.historyIndex,
-        active: index === tab.historyIndex
+        active: index === tab.historyIndex,
+        icon: getTabPageIcon(entry)
       })
     }
 

--- a/src/renderer/tabs/tabPageIcon.js
+++ b/src/renderer/tabs/tabPageIcon.js
@@ -1,0 +1,21 @@
+const PAGE_ICONS = [
+  [/^\/$|^\/subscriptions(?:\/|$)/, ['fas', 'rss']],
+  [/^\/subscribedchannels(?:\/|$)/, ['fas', 'user-check']],
+  [/^\/trending(?:\/|$)/, ['fas', 'fire']],
+  [/^\/popular(?:\/|$)/, ['fas', 'users']],
+  [/^\/(?:userplaylists|playlist)(?:\/|$)/, ['fas', 'bookmark']],
+  [/^\/history(?:\/|$)/, ['fas', 'history']],
+  [/^\/stats(?:\/|$)/, ['fas', 'chart-line']],
+  [/^\/settings(?:\/|$)/, ['fas', 'sliders-h']],
+  [/^\/about(?:\/|$)/, ['fas', 'info-circle']],
+  [/^\/search(?:\/|$)/, ['fas', 'search']],
+  [/^\/channel(?:\/|$)/, ['fas', 'circle-user']],
+  [/^\/hashtag(?:\/|$)/, ['fas', 'hashtag']],
+  [/^\/post(?:\/|$)/, ['fas', 'comment']],
+  [/^\/watch(?:\/|$)/, ['fas', 'clapperboard']],
+]
+
+export function getTabPageIcon(tab) {
+  const path = tab?.route?.path ?? ''
+  return PAGE_ICONS.find(([pattern]) => pattern.test(path))?.[1] ?? null
+}

--- a/src/renderer/tabs/tabPreview.js
+++ b/src/renderer/tabs/tabPreview.js
@@ -1,5 +1,7 @@
 import store from '../store/index'
 
+export { getTabPageIcon } from './tabPageIcon'
+
 /**
  * Resolve the fallback preview image for a tab when no screenshot has been
  * captured yet. Currently this is the channel's profile picture for channel
@@ -18,26 +20,4 @@ export function getTabAvatarUrl(tab) {
 
   const videoId = path.match(/^\/watch\/([^/]+)/)?.[1]
   return videoId ? store.getters.getVideoAvatar(videoId) : null
-}
-
-const PAGE_ICONS = [
-  [/^\/$|^\/subscriptions(?:\/|$)/, ['fas', 'rss']],
-  [/^\/subscribedchannels(?:\/|$)/, ['fas', 'user-check']],
-  [/^\/trending(?:\/|$)/, ['fas', 'fire']],
-  [/^\/popular(?:\/|$)/, ['fas', 'users']],
-  [/^\/(?:userplaylists|playlist)(?:\/|$)/, ['fas', 'bookmark']],
-  [/^\/history(?:\/|$)/, ['fas', 'history']],
-  [/^\/stats(?:\/|$)/, ['fas', 'chart-line']],
-  [/^\/settings(?:\/|$)/, ['fas', 'sliders-h']],
-  [/^\/about(?:\/|$)/, ['fas', 'info-circle']],
-  [/^\/search(?:\/|$)/, ['fas', 'search']],
-  [/^\/channel(?:\/|$)/, ['fas', 'circle-user']],
-  [/^\/hashtag(?:\/|$)/, ['fas', 'hashtag']],
-  [/^\/post(?:\/|$)/, ['fas', 'comment']],
-  [/^\/watch(?:\/|$)/, ['fas', 'clapperboard']],
-]
-
-export function getTabPageIcon(tab) {
-  const path = tab?.route?.path ?? ''
-  return PAGE_ICONS.find(([pattern]) => pattern.test(path))?.[1] ?? null
 }

--- a/src/renderer/themes.css
+++ b/src/renderer/themes.css
@@ -4,6 +4,8 @@ body {
   color: var(--primary-text-color);
   background-color: var(--bg-color);
 
+  --ui-roundness: 1;
+
   /*
     This works because CSS variables are just a find and replace and
     are replaced before the expressions are evaluated
@@ -161,7 +163,7 @@ it can be safely elided. This looks quite pleasant on this theme. */
   --primary-shadow-color: rgb(200 200 200 / 75%);
   --title-color: #3f7ac6;
   --bg-color: #f1f1f1;
-  --favorite-icon-color: #0c0;
+  --favorite-icon-color: #6eaa73;
   --card-bg-color: #fff;
   --secondary-card-bg-color: #eee;
   --scrollbar-color: #ccc;
@@ -181,7 +183,7 @@ it can be safely elided. This looks quite pleasant on this theme. */
   --tertiary-text-color: #999;
   --title-color: #eee;
   --bg-color: #212121;
-  --favorite-icon-color: #0f0;
+  --favorite-icon-color: #6eaa73;
   --card-bg-color: #303030;
   --secondary-card-bg-color: rgb(0 0 0 / 75%);
   --scrollbar-color: #414141;
@@ -200,7 +202,7 @@ it can be safely elided. This looks quite pleasant on this theme. */
   --tertiary-text-color: #eee;
   --title-color: #eee;
   --bg-color: #000;
-  --favorite-icon-color: #0f0;
+  --favorite-icon-color: #6eaa73;
   --card-bg-color: #000;
   --secondary-card-bg-color: rgb(0 0 0 / 75%);
   --scrollbar-color: #515151;
@@ -219,7 +221,7 @@ it can be safely elided. This looks quite pleasant on this theme. */
   --tertiary-text-color: #eee;
   --title-color: #eee;
   --bg-color: #2b2f3a;
-  --favorite-icon-color: #0f0;
+  --favorite-icon-color: #6eaa73;
   --card-bg-color: #2e3440;
   --secondary-card-bg-color: rgb(59 66 82 / 75%);
   --scrollbar-color: #4b566a;
@@ -238,7 +240,7 @@ it can be safely elided. This looks quite pleasant on this theme. */
   --tertiary-text-color: #ffff;
   --title-color: #000;
   --bg-color: #ff008a;
-  --favorite-icon-color: #0f0;
+  --favorite-icon-color: #6eaa73;
   --card-bg-color: #de1c85;
   --secondary-card-bg-color: rgb(0 0 0 / 75%);
   --scrollbar-color: #fff;
@@ -279,7 +281,7 @@ it can be safely elided. This looks quite pleasant on this theme. */
   --tertiary-text-color: #5a285a;
   --title-color: #185eb4;
   --bg-color: #ffeadd;
-  --favorite-icon-color: #760278;
+  --favorite-icon-color: #6eaa73;
   --card-bg-color: #ffd1dc;
   --secondary-card-bg-color: #fff;
   --scrollbar-color: #f5c8d3;
@@ -300,7 +302,7 @@ it can be safely elided. This looks quite pleasant on this theme. */
   --tertiary-text-color: #a6adc8;
   --title-color: #cdd6f4;
   --bg-color: #1e1e2e;
-  --favorite-icon-color: #0f0;
+  --favorite-icon-color: #6eaa73;
   --card-bg-color: #181825;
   --secondary-card-bg-color: #1e1e2e;
   --scrollbar-color: #313244;
@@ -319,7 +321,7 @@ it can be safely elided. This looks quite pleasant on this theme. */
   --tertiary-text-color: #e5e8f3;
   --title-color: #bd93f9;
   --bg-color: #282a36;
-  --favorite-icon-color: #0f0;
+  --favorite-icon-color: #6eaa73;
   --card-bg-color: #33353f;
   --secondary-card-bg-color: #282a36;
   --scrollbar-color: #44475a;
@@ -338,7 +340,7 @@ it can be safely elided. This looks quite pleasant on this theme. */
   --tertiary-text-color: #ddd6c3;
   --title-color: #fdf6e3;
   --bg-color: #002b36;
-  --favorite-icon-color: #0f0;
+  --favorite-icon-color: #6eaa73;
   --card-bg-color: #204b56;
   --secondary-card-bg-color: #102b36;
   --scrollbar-color: #608b96;
@@ -357,7 +359,7 @@ it can be safely elided. This looks quite pleasant on this theme. */
   --tertiary-text-color: #204b56;
   --title-color: #002b36;
   --bg-color: #fdf6e3;
-  --favorite-icon-color: #0f0;
+  --favorite-icon-color: #6eaa73;
   --card-bg-color: #eee8d5;
   --secondary-card-bg-color: #fdf6e3;
   --scrollbar-color: #a9a895;
@@ -376,7 +378,7 @@ it can be safely elided. This looks quite pleasant on this theme. */
   --tertiary-text-color: #d5c4a1;
   --title-color: #ebdbb2;
   --bg-color: #282828;
-  --favorite-icon-color: #0f0;
+  --favorite-icon-color: #6eaa73;
   --card-bg-color: #504945;
   --secondary-card-bg-color: #3c3836;
   --scrollbar-color: #665c54;
@@ -395,7 +397,7 @@ it can be safely elided. This looks quite pleasant on this theme. */
   --tertiary-text-color: #282828;
   --title-color: #3c3836;
   --bg-color: #fbf1c7;
-  --favorite-icon-color: #0f0;
+  --favorite-icon-color: #6eaa73;
   --card-bg-color: #ebdbb2;
   --secondary-card-bg-color: #d5c4a1;
   --scrollbar-color: #bdae93;
@@ -414,7 +416,7 @@ it can be safely elided. This looks quite pleasant on this theme. */
   --tertiary-text-color: #a5adce;
   --title-color: #c6d0f5;
   --bg-color: #303446;
-  --favorite-icon-color: #0f0;
+  --favorite-icon-color: #6eaa73;
   --card-bg-color: #292c3c;
   --secondary-card-bg-color: #303446;
   --scrollbar-color: #414559;
@@ -433,7 +435,7 @@ it can be safely elided. This looks quite pleasant on this theme. */
   --tertiary-text-color: #d3c6aa;
   --title-color: #d3c6aa;
   --bg-color: #272e33;
-  --favorite-icon-color: #0f0;
+  --favorite-icon-color: #6eaa73;
   --card-bg-color: #1e2326;
   --secondary-card-bg-color: #272e33;
   --scrollbar-color: #394146;
@@ -452,7 +454,7 @@ it can be safely elided. This looks quite pleasant on this theme. */
   --tertiary-text-color: #d3c6aa;
   --title-color: #d3c6aa;
   --bg-color: #2d353b;
-  --favorite-icon-color: #0f0;
+  --favorite-icon-color: #6eaa73;
   --card-bg-color: #232a2e;
   --secondary-card-bg-color: #2d353b;
   --scrollbar-color: #3f484e;
@@ -471,7 +473,7 @@ it can be safely elided. This looks quite pleasant on this theme. */
   --tertiary-text-color: #d3c6aa;
   --title-color: #d3c6aa;
   --bg-color: #333c43;
-  --favorite-icon-color: #0f0;
+  --favorite-icon-color: #6eaa73;
   --card-bg-color: #293136;
   --secondary-card-bg-color: #333c43;
   --scrollbar-color: #454f56;
@@ -490,7 +492,7 @@ it can be safely elided. This looks quite pleasant on this theme. */
   --tertiary-text-color: #3c4a52;
   --title-color: #3c4a52;
   --bg-color: #fffbef;
-  --favorite-icon-color: #0f0;
+  --favorite-icon-color: #6eaa73;
   --card-bg-color: #f2efdf;
   --secondary-card-bg-color: #fffbef;
   --scrollbar-color: #d8d5c5;
@@ -509,7 +511,7 @@ it can be safely elided. This looks quite pleasant on this theme. */
   --tertiary-text-color: #3c4a52;
   --title-color: #3c4a52;
   --bg-color: #fdf6e3;
-  --favorite-icon-color: #0f0;
+  --favorite-icon-color: #6eaa73;
   --card-bg-color: #efe8d4;
   --secondary-card-bg-color: #fdf6e3;
   --scrollbar-color: #d0ccb7;
@@ -528,7 +530,7 @@ it can be safely elided. This looks quite pleasant on this theme. */
   --tertiary-text-color: #3c4a52;
   --title-color: #3c4a52;
   --bg-color: #f3ead3;
-  --favorite-icon-color: #0f0;
+  --favorite-icon-color: #6eaa73;
   --card-bg-color: #eee8ce;
   --secondary-card-bg-color: #f3ead3;
   --scrollbar-color: #c8c3aa;
@@ -547,7 +549,7 @@ it can be safely elided. This looks quite pleasant on this theme. */
   --tertiary-text-color: #6c6f85;
   --title-color: #4c4f69;
   --bg-color: #eff1f5;
-  --favorite-icon-color: #0f0;
+  --favorite-icon-color: #6eaa73;
   --card-bg-color: #e6e9ef;
   --secondary-card-bg-color: #eff1f5;
   --scrollbar-color: #ccd0da;
@@ -2186,7 +2188,7 @@ a:visited {
 
 ::-webkit-scrollbar-thumb {
   background: var(--scrollbar-color);
-  border-radius: 6px;
+  border-radius: calc(6px * var(--ui-roundness));
   border: 2px solid transparent;
   background-clip: padding-box;
 }

--- a/src/renderer/views/About/About.css
+++ b/src/renderer/views/About/About.css
@@ -51,7 +51,7 @@
 .chunk {
   align-items: start;
   background-color: var(--bg-color);
-  border-radius: 8px;
+  border-radius: calc(8px * var(--ui-roundness));
   box-shadow: 0 1px 4px -1px rgb(0 0 0 / 50%);
   display: grid;
   gap: 6px 14px;

--- a/src/renderer/views/Popular/Popular.css
+++ b/src/renderer/views/Popular/Popular.css
@@ -21,6 +21,8 @@
   margin-inline: -16px;
   padding-block: calc(3px + var(--popular-header-gap)) 12px;
   padding-inline: 16px;
+  border-start-start-radius: calc(8px * var(--ui-roundness));
+  border-start-end-radius: calc(8px * var(--ui-roundness));
   background-color: var(--card-bg-color);
   box-shadow: 0 1px 0 var(--primary-shadow-color);
 }

--- a/src/renderer/views/Stats/Stats.css
+++ b/src/renderer/views/Stats/Stats.css
@@ -29,7 +29,7 @@
 .summaryCard,
 .chartCard {
   border: 1px solid color-mix(in srgb, var(--tertiary-text-color) 18%, transparent);
-  border-radius: 18px;
+  border-radius: calc(18px * var(--ui-roundness));
   background-color: var(--card-bg-color);
   box-shadow: 0 8px 30px rgb(0 0 0 / 7%);
 }
@@ -101,7 +101,7 @@
 .chartScale {
   padding-block: 7px;
   padding-inline: 10px;
-  border-radius: 999px;
+  border-radius: calc(999px * var(--ui-roundness));
   color: var(--tertiary-text-color);
   background-color: color-mix(in srgb, var(--primary-color) 9%, transparent);
   font-size: 0.75rem;
@@ -170,7 +170,7 @@
   padding-block: 7px;
   padding-inline: 10px;
   border: 1px solid color-mix(in srgb, var(--primary-text-color) 20%, transparent);
-  border-radius: 9px;
+  border-radius: calc(9px * var(--ui-roundness));
   color: var(--card-bg-color);
   background-color: color-mix(in srgb, var(--primary-text-color) 94%, transparent);
   box-shadow: 0 6px 18px rgb(0 0 0 / 24%);
@@ -251,7 +251,7 @@
 }
 
 .barTarget:focus-visible {
-  border-radius: 8px;
+  border-radius: calc(8px * var(--ui-roundness));
   box-shadow: 0 0 0 2px var(--primary-color);
   outline: none;
 }
@@ -263,14 +263,14 @@
   min-block-size: 0;
   align-items: flex-end;
   overflow: hidden;
-  border-radius: 8px;
+  border-radius: calc(8px * var(--ui-roundness));
   background-color: color-mix(in srgb, var(--tertiary-text-color) 8%, transparent);
 }
 
 .bar {
   inline-size: 100%;
   block-size: var(--bar-height);
-  border-radius: 8px;
+  border-radius: calc(8px * var(--ui-roundness));
   background: linear-gradient(to top, var(--primary-color), color-mix(in srgb, var(--primary-color) 55%, rgb(255 255 255)));
   transition: block-size 300ms ease;
 }
@@ -368,7 +368,7 @@
   padding-block: 6px;
   padding-inline: 9px;
   border: 1px solid transparent;
-  border-radius: 7px;
+  border-radius: calc(7px * var(--ui-roundness));
   color: var(--tertiary-text-color);
   background-color: transparent;
   cursor: pointer;
@@ -406,7 +406,7 @@
 
   .summaryCard,
   .chartCard {
-    border-radius: 14px;
+    border-radius: calc(14px * var(--ui-roundness));
     padding-block: 16px;
     padding-inline: 16px;
   }

--- a/src/renderer/views/Subscriptions/Subscriptions.css
+++ b/src/renderer/views/Subscriptions/Subscriptions.css
@@ -21,6 +21,8 @@
   margin-inline: -16px;
   padding-block: calc(3px + var(--subscriptions-header-gap)) 12px;
   padding-inline: 16px;
+  border-start-start-radius: calc(8px * var(--ui-roundness));
+  border-start-end-radius: calc(8px * var(--ui-roundness));
   background-color: var(--card-bg-color);
   box-shadow: 0 1px 0 var(--primary-shadow-color);
 }
@@ -44,7 +46,7 @@
   align-items: center;
   background: transparent;
   border: 0;
-  border-radius: 4px;
+  border-radius: calc(4px * var(--ui-roundness));
   color: var(--primary-color);
   cursor: pointer;
   display: inline-flex;

--- a/src/renderer/views/Trending/Trending.css
+++ b/src/renderer/views/Trending/Trending.css
@@ -21,6 +21,8 @@
   margin-inline: -16px;
   padding-block: calc(3px + var(--trending-header-gap)) 12px;
   padding-inline: 16px;
+  border-start-start-radius: calc(8px * var(--ui-roundness));
+  border-start-end-radius: calc(8px * var(--ui-roundness));
   background-color: var(--card-bg-color);
   box-shadow: 0 1px 0 var(--primary-shadow-color);
 }

--- a/src/renderer/views/Watch/Watch.scss
+++ b/src/renderer/views/Watch/Watch.scss
@@ -24,7 +24,7 @@
 .premiereDate {
   align-items: center;
   background-color: rgb(0 0 0 / 80%);
-  border-radius: 5px;
+  border-radius: calc(5px * var(--ui-roundness));
   inset-block-end: 12px;
   color: #fff;
   display: flex;
@@ -96,7 +96,7 @@
         align-items: center;
         gap: 20px;
         padding: 10px;
-        border-radius: 20px;
+        border-radius: calc(20px * var(--ui-roundness));
         background-color: rgb(0 0 0 / 90%);
         color: #fff;
       }
@@ -381,12 +381,12 @@
 
 .skeletonLine {
   block-size: 14px;
-  border-radius: 4px;
+  border-radius: calc(4px * var(--ui-roundness));
 }
 
 .infoSkeleton {
   padding: 16px;
-  border-radius: 5px;
+  border-radius: calc(5px * var(--ui-roundness));
   background-color: var(--card-bg-color);
   box-sizing: border-box;
 
@@ -419,7 +419,7 @@
   overflow: hidden;
   padding-block: 20px 16px;
   padding-inline: 16px;
-  border-radius: 5px;
+  border-radius: calc(5px * var(--ui-roundness));
   background-color: var(--card-bg-color);
 
   .skeletonPlaylistTitle {
@@ -437,7 +437,7 @@
   .skeletonPlaylistProgress {
     inline-size: 100%;
     block-size: 6px;
-    border-radius: 3px;
+    border-radius: calc(3px * var(--ui-roundness));
     margin-block-end: 14px;
   }
 
@@ -469,14 +469,14 @@
   .skeletonPlaylistIndex {
     inline-size: 10px;
     block-size: 12px;
-    border-radius: 3px;
+    border-radius: calc(3px * var(--ui-roundness));
     justify-self: center;
   }
 
   .skeletonPlaylistThumbnail {
     aspect-ratio: 16 / 9;
     inline-size: 128px;
-    border-radius: 3px;
+    border-radius: calc(3px * var(--ui-roundness));
   }
 
   .skeletonPlaylistDetails {
@@ -488,7 +488,7 @@
   .skeletonPlaylistDetailLine {
     block-size: 11px;
     inline-size: 92%;
-    border-radius: 4px;
+    border-radius: calc(4px * var(--ui-roundness));
   }
 
   .skeletonPlaylistDetailLine.short {
@@ -519,7 +519,7 @@
   .skeletonRecommendationThumbnail {
     aspect-ratio: 16 / 9;
     inline-size: 163px;
-    border-radius: 5px;
+    border-radius: calc(5px * var(--ui-roundness));
     flex-shrink: 0;
   }
 

--- a/static/locales/en-GB.yaml
+++ b/static/locales/en-GB.yaml
@@ -377,6 +377,7 @@ Settings:
     Secondary Color Theme: 'Secondary colour theme'
         #* Main Color Theme
     UI Scale: UI Scale
+    UI Roundness: UI Roundness
     Disable Smooth Scrolling: Disable smooth scrolling
     Expand Side Bar by Default: Expand side bar by default
     Hide Side Bar Labels: Hide side bar labels

--- a/static/locales/en-US.yaml
+++ b/static/locales/en-US.yaml
@@ -435,6 +435,7 @@ Settings:
     Hide Side Bar on Watch Pages: Hide Side Bar on Watch Pages
     Disable Smooth Scrolling: Disable Smooth Scrolling
     UI Scale: UI Scale
+    UI Roundness: UI Roundness
     Thumbnail Size: Thumbnail Size
     Show Thumbnail Size Button in Header: Show Thumbnail Size Button in Header
     Hide Side Bar Labels: Hide Side Bar Labels


### PR DESCRIPTION
## Summary

- add a persisted Appearance setting for scaling UI corner roundness from square through highly rounded
- apply the setting consistently across cards, thumbnails, controls, popovers, modals, player surfaces, feeds, tabs, and channel headers
- refine related UI states: compact sortable empty-comments cards, responsive grouped thumbnail action menus, and subtle color-only quick-bookmark feedback
- polish the back/forward history popout with a stronger shadow and destination icons shared with the tab bar
- add Electron regression coverage for the setting, feed/channel card corners, popovers, menus, quick bookmarks, and navigation history

## Why

Corner radii were previously hard-coded across many independent components. This made the UI inconsistent and caused full-bleed child surfaces or specialized popovers to mask the parent card radius. The new shared CSS multiplier keeps those surfaces synchronized while preserving intentional circular controls.

## User impact

Users can choose their preferred UI roundness in Appearance settings. The value persists across relaunches and applies consistently throughout the app, including high values such as 200%. Related popouts and menus are clearer and make better use of their available space.

## Validation

- `pnpm run lint-all`
- `pnpm run test:unit` — 61 passed
- targeted YAML lint for `static/locales/en-GB.yaml` and `static/locales/en-US.yaml`
- Electron/Playwright focused regression set — 13 passed
- Electron/Playwright offline navigation suite — 7 passed
- production renderer and main-process E2E bundles compiled successfully
- GitHub CI passed before the latest focused popout commit and is rerunning against the updated head

## Notes

The repository-wide YAML lint still reports pre-existing issues in untouched files `e2e/sync-server/compose.yml`, `static/locales/ar.yaml`, and `static/locales/pl.yaml`.
