### PR TITLE
perf: fix regressions and hot paths found against upstream

### DIFF
--- a/src/datastores/handlers/base.js
+++ b/src/datastores/handlers/base.js
@@ -2,6 +2,8 @@ import * as db from '../index'
 import { PlaylistVideoAddResult } from '../../constants'
 import { hasReachedWatchedThreshold, migrateLegacyHistoryRecord } from '../../history'
 
+const HISTORY_WATCHED_STATUS_MIGRATION_ID = 'historyWatchedStatusMigrated'
+
 class Settings {
   static async find() {
     const currentLocale = await db.settings.findOneAsync({ _id: 'currentLocale' })
@@ -145,6 +147,14 @@ class History {
   }
 
   static async _migrateWatchedStatus() {
+    // `isWatched` isn't indexed, so the lookup below is a full collection scan
+    // that history loading blocks on. Once every record has been migrated the
+    // answer can never change, so record that and skip the scan on later runs.
+    const migrationMarker = await db.settings.findOneAsync({ _id: HISTORY_WATCHED_STATUS_MIGRATION_ID })
+    if (migrationMarker?.value === true) {
+      return
+    }
+
     const records = await db.history.findAsync({ isWatched: { $exists: false } })
     const batchSize = 250
 
@@ -173,6 +183,12 @@ class History {
     if (records.length > 0) {
       await db.history.compactDatafileAsync()
     }
+
+    await db.settings.updateAsync(
+      { _id: HISTORY_WATCHED_STATUS_MIGRATION_ID },
+      { _id: HISTORY_WATCHED_STATUS_MIGRATION_ID, value: true },
+      { upsert: true }
+    )
   }
 
   static updateWatchProgress(videoId, watchProgress) {

--- a/src/datastores/handlers/base.js
+++ b/src/datastores/handlers/base.js
@@ -150,6 +150,14 @@ class History {
     // `isWatched` isn't indexed, so the lookup below is a full collection scan
     // that history loading blocks on. Once every record has been migrated the
     // answer can never change, so record that and skip the scan on later runs.
+    //
+    // Skipping it later is safe even though `updateWatchProgress` can upsert a
+    // record without the field: such a record has no `lengthSeconds`, so the
+    // migration would only ever have derived `isWatched: false` for it, and
+    // `isHistoryEntryWatched` falls back to the same threshold when the field
+    // is absent. Every path that writes a full record (`upsert`, `overwrite`,
+    // `applySyncChanges`) migrates it inline, so a legacy-shaped record can no
+    // longer appear after this point either.
     const migrationMarker = await db.settings.findOneAsync({ _id: HISTORY_WATCHED_STATUS_MIGRATION_ID })
     if (migrationMarker?.value === true) {
       return

--- a/src/main/tabs/TabManager.js
+++ b/src/main/tabs/TabManager.js
@@ -568,6 +568,8 @@ export class TabManager {
     /** @type {Promise<void>} */
     this._previewCaptureLock = Promise.resolve()
     this._previewCapturePaused = false
+    /** Tabs whose navigation history the renderer has already been sent. */
+    this._historyAnnouncedTabIds = new Set()
     this.bridge = new TabRendererBridge(browserWindow)
     this._initialPresentationResolved = false
     this._initialPresentationPromise = new Promise(resolve => {
@@ -2058,28 +2060,41 @@ export class TabManager {
   /**
    * @returns {object}
    */
-  getState() {
-    const tabs = Array.from(this.tabs.values()).map(tab => ({
-      id: tab.id,
+  /**
+   * @param {{ historyForTabIds?: Set<string> | null }} [options]
+   *   Which tabs the navigation history should be included for. Defaults to all
+   *   of them; pass a set to leave it out for the rest.
+   */
+  getState({ historyForTabIds = null } = {}) {
+    const tabs = Array.from(this.tabs.values()).map(tab => {
       // The renderer only consumes this when it first learns about a tab
-      // (e.g. session restore); afterwards it owns the live history.
-      history: tab.navigationHistory,
-      historyIndex: tab.navigationHistory != null ? tab.navigationHistoryIndex : undefined,
-      url: tab.url,
-      route: cloneRoute(tab.route),
-      title: tab.title,
-      isActive: tab.id === this.activeTabId,
-      isUnloaded: tab.loadState === 'unloaded',
-      isLoading: this._getTabLoadingState(tab),
-      isPlaying: tab.isPlaying || false,
-      isPinned: tab.isPinned || false,
-      color: TabManager.normalizeTabColor(tab.color),
-      loadState: tab.loadState,
-      preloadInBackground: tab.preloadInBackground,
-      pendingActivation: tab.pendingActivation,
-      mountRevision: tab.mountRevision,
-      refreshKey: tab.refreshKey
-    }))
+      // (e.g. session restore); afterwards it owns the live history. Sending it
+      // on every update would serialize each tab's whole history over IPC just
+      // for the renderer to discard it.
+      const includeHistory = historyForTabIds === null || historyForTabIds.has(tab.id)
+
+      return {
+        id: tab.id,
+        history: includeHistory ? tab.navigationHistory : undefined,
+        historyIndex: includeHistory && tab.navigationHistory != null
+          ? tab.navigationHistoryIndex
+          : undefined,
+        url: tab.url,
+        route: cloneRoute(tab.route),
+        title: tab.title,
+        isActive: tab.id === this.activeTabId,
+        isUnloaded: tab.loadState === 'unloaded',
+        isLoading: this._getTabLoadingState(tab),
+        isPlaying: tab.isPlaying || false,
+        isPinned: tab.isPinned || false,
+        color: TabManager.normalizeTabColor(tab.color),
+        loadState: tab.loadState,
+        preloadInBackground: tab.preloadInBackground,
+        pendingActivation: tab.pendingActivation,
+        mountRevision: tab.mountRevision,
+        refreshKey: tab.refreshKey
+      }
+    })
 
     return {
       tabs,
@@ -2098,7 +2113,32 @@ export class TabManager {
   }
 
   _broadcastStateUpdate() {
-    this.bridge.send(IpcChannels.TABS_STATE_UPDATED, this.getState())
+    // Queued snapshots get coalesced down to the newest one, so while the
+    // renderer is still bootstrapping every snapshot has to carry the history
+    // in full — whichever one survives is the one the tabs get created from.
+    if (!this.bridge.ready) {
+      this._historyAnnouncedTabIds.clear()
+      this.bridge.send(IpcChannels.TABS_STATE_UPDATED, this.getState())
+      return
+    }
+
+    const historyForTabIds = new Set()
+    for (const tabId of this.tabs.keys()) {
+      if (!this._historyAnnouncedTabIds.has(tabId)) {
+        historyForTabIds.add(tabId)
+      }
+    }
+
+    this.bridge.send(IpcChannels.TABS_STATE_UPDATED, this.getState({ historyForTabIds }))
+
+    for (const tabId of historyForTabIds) {
+      this._historyAnnouncedTabIds.add(tabId)
+    }
+    for (const tabId of this._historyAnnouncedTabIds) {
+      if (!this.tabs.has(tabId)) {
+        this._historyAnnouncedTabIds.delete(tabId)
+      }
+    }
   }
 
   async _saveSession() {

--- a/src/renderer/components/FtAutoGrid/FtAutoGrid.vue
+++ b/src/renderer/components/FtAutoGrid/FtAutoGrid.vue
@@ -4,7 +4,7 @@
     tag="div"
     name="feed"
     :appear="appear"
-    :move-class="suppressMoveTransition ? 'feed-move-suppressed' : undefined"
+    :move-class="moveClass"
     :class="{
       autoGrid: true,
       grid: grid,
@@ -36,8 +36,18 @@ const props = defineProps({
   thumbnailSize: {
     type: Number,
     default: DEFAULT_THUMBNAIL_SIZE
+  },
+  itemCount: {
+    type: Number,
+    default: 0
   }
 })
+
+// Above this many items the move transition costs more than it conveys. Vue's
+// FLIP measures and then writes a transform per child in one loop, so every
+// item forces its own layout pass; on a feed of hundreds of cards that stalls
+// the very interaction (pagination, filtering) it is meant to smooth over.
+const MOVE_TRANSITION_MAX_ITEMS = 50
 
 const gridElement = useTemplateRef('gridElement')
 const gridWidth = ref(0)
@@ -50,6 +60,24 @@ const gridWidth = ref(0)
 // no transition, so the TransitionGroup skips the move handling entirely.
 const suppressMoveTransition = ref(false)
 let suppressResetTimeout = null
+
+const prefersReducedMotion = ref(false)
+/** @type {MediaQueryList | null} */
+let reducedMotionQuery = null
+
+function handleReducedMotionChange(event) {
+  prefersReducedMotion.value = event.matches
+}
+
+// 'feed-move-suppressed' has no transition, so the TransitionGroup bails out of
+// the move handling instead of measuring and translating every child.
+const moveClass = computed(() => {
+  const suppressed = suppressMoveTransition.value ||
+    prefersReducedMotion.value ||
+    props.itemCount > MOVE_TRANSITION_MAX_ITEMS
+
+  return suppressed ? 'feed-move-suppressed' : undefined
+})
 
 const gridStyle = computed(() => {
   return getThumbnailSizeStyles(props.thumbnailSize, gridWidth.value)
@@ -70,6 +98,10 @@ let observedScrollbarWidth = 0
 let observedViewportWidth = null
 
 onMounted(() => {
+  reducedMotionQuery = window.matchMedia('(prefers-reduced-motion: reduce)')
+  prefersReducedMotion.value = reducedMotionQuery.matches
+  reducedMotionQuery.addEventListener('change', handleReducedMotionChange)
+
   resizeObserver = new ResizeObserver(([entry]) => {
     const scrollbarCompensated = document.body.style.overflow === 'hidden' &&
       document.body.style.paddingInlineEnd !== ''
@@ -100,6 +132,7 @@ onMounted(() => {
 
 onBeforeUnmount(() => {
   resizeObserver?.disconnect()
+  reducedMotionQuery?.removeEventListener('change', handleReducedMotionChange)
   clearTimeout(suppressResetTimeout)
 })
 </script>

--- a/src/renderer/components/FtElementList/FtElementList.vue
+++ b/src/renderer/components/FtElementList/FtElementList.vue
@@ -3,6 +3,7 @@
     :appear="appear"
     :grid="displayValue !== 'list'"
     :thumbnail-size="thumbnailSize"
+    :item-count="data.length"
   >
     <FtListLazyWrapper
       v-for="(result, index) in data"

--- a/src/renderer/components/FtRefreshWidget/FtRefreshWidget.vue
+++ b/src/renderer/components/FtRefreshWidget/FtRefreshWidget.vue
@@ -176,13 +176,44 @@ function spinHourglassOnce() {
   spinHourglass.value = true
 }
 
-onMounted(() => {
+// Only the countdown ring needs a per-second tick. Tabs stay mounted while not
+// presented, so leaving the timer running would churn reactivity once a second
+// per open feed tab even when no countdown is on screen.
+const countdownVisible = computed(() => props.nextAutoRefreshAt > 0 && props.autoRefreshInterval > 0)
+
+function startCountdownTicker() {
+  if (countdownTicker !== null) {
+    return
+  }
+
+  updateCountdown()
   countdownTicker = setInterval(updateCountdown, 1000)
+}
+
+function stopCountdownTicker() {
+  if (countdownTicker !== null) {
+    clearInterval(countdownTicker)
+    countdownTicker = null
+  }
+}
+
+watch(countdownVisible, (visible) => {
+  if (visible) {
+    startCountdownTicker()
+  } else {
+    stopCountdownTicker()
+  }
+})
+
+onMounted(() => {
+  if (countdownVisible.value) {
+    startCountdownTicker()
+  }
   document.addEventListener('visibilitychange', updateCountdown)
 })
 
 onBeforeUnmount(() => {
-  clearInterval(countdownTicker)
+  stopCountdownTicker()
   document.removeEventListener('visibilitychange', updateCountdown)
 })
 

--- a/src/renderer/components/SubscriptionsLive.vue
+++ b/src/renderer/components/SubscriptionsLive.vue
@@ -11,13 +11,14 @@
 </template>
 
 <script setup>
-import { computed, onBeforeUnmount, onMounted, ref, shallowRef, useTemplateRef, watch } from 'vue'
+import { computed, onMounted, ref, shallowRef, useTemplateRef, watch } from 'vue'
 import { useI18n } from 'vue-i18n'
 
 import SubscriptionsTabUi from './SubscriptionsTabUi/SubscriptionsTabUi.vue'
 
 import store from '../store/index'
 
+import { useAutoRefreshClock } from '../composables/useAutoRefreshClock'
 import { useSubscriptionChannelUpdates } from '../composables/useSubscriptionChannelUpdates'
 import { getCachedRelativeTimeFormat, getCachedShortDateTimeFormat, getRelativeTimeFromDate } from '../helpers/utils'
 import {
@@ -36,8 +37,16 @@ const attemptedFetch = ref(false)
 const lastRemoteRefreshSuccessTimestamp = ref(null)
 
 let alreadyLoadedRemotely = false
-let nextAutoRefreshTicker = null
-const now = ref(Date.now())
+
+/** @type {import('vue').ComputedRef<boolean>} */
+const hasPendingAutoRefresh = computed(() => {
+  const interval = parseInt(store.getters.getSubscriptionLiveAutoRefreshInterval, 10)
+
+  return !!store.getters.getSubscriptionLiveNextAutoRefreshTimestamp &&
+    !Number.isNaN(interval) && interval > 0
+})
+
+const now = useAutoRefreshClock(hasPendingAutoRefresh)
 
 /** @type {import('vue').ComputedRef<boolean>} */
 const subscriptionCacheReady = computed(() => store.getters.getSubscriptionCacheReady)
@@ -174,14 +183,7 @@ if (!subscriptionCacheReady.value) {
 }
 
 onMounted(() => {
-  nextAutoRefreshTicker = setInterval(() => {
-    now.value = Date.now()
-  }, 30000)
   loadVideosFromRemoteFirstPerWindowSometimes()
-})
-
-onBeforeUnmount(() => {
-  clearInterval(nextAutoRefreshTicker)
 })
 
 function loadVideosFromRemoteFirstPerWindowSometimes() {

--- a/src/renderer/components/SubscriptionsPosts.vue
+++ b/src/renderer/components/SubscriptionsPosts.vue
@@ -13,13 +13,14 @@
 </template>
 
 <script setup>
-import { computed, onBeforeUnmount, onMounted, ref, shallowRef, useTemplateRef, watch } from 'vue'
+import { computed, onMounted, ref, shallowRef, useTemplateRef, watch } from 'vue'
 import { useI18n } from 'vue-i18n'
 
 import SubscriptionsTabUi from './SubscriptionsTabUi/SubscriptionsTabUi.vue'
 
 import store from '../store/index'
 
+import { useAutoRefreshClock } from '../composables/useAutoRefreshClock'
 import { useSubscriptionChannelUpdates } from '../composables/useSubscriptionChannelUpdates'
 import { getCachedRelativeTimeFormat, getCachedShortDateTimeFormat, getRelativeTimeFromDate } from '../helpers/utils'
 import { refreshSubscriptionPostsFromRemote } from '../helpers/subscriptions'
@@ -33,10 +34,18 @@ const errorChannels = ref([])
 const attemptedFetch = ref(false)
 /** @type {import('vue').Ref<number | null>} */
 const lastRemoteRefreshSuccessTimestamp = ref(null)
-const now = ref(Date.now())
+
+/** @type {import('vue').ComputedRef<boolean>} */
+const hasPendingAutoRefresh = computed(() => {
+  const interval = parseInt(store.getters.getSubscriptionPostsAutoRefreshInterval, 10)
+
+  return !!store.getters.getSubscriptionPostsNextAutoRefreshTimestamp &&
+    !Number.isNaN(interval) && interval > 0
+})
+
+const now = useAutoRefreshClock(hasPendingAutoRefresh)
 
 let alreadyLoadedRemotely = false
-let nextAutoRefreshTicker = null
 
 /** @type {import('vue').ComputedRef<boolean>} */
 const subscriptionCacheReady = computed(() => store.getters.getSubscriptionCacheReady)
@@ -173,14 +182,7 @@ if (!subscriptionCacheReady.value) {
 }
 
 onMounted(() => {
-  nextAutoRefreshTicker = setInterval(() => {
-    now.value = Date.now()
-  }, 30000)
   loadPostsFromRemoteFirstPerWindowSometimes()
-})
-
-onBeforeUnmount(() => {
-  clearInterval(nextAutoRefreshTicker)
 })
 
 function loadPostsFromRemoteFirstPerWindowSometimes() {

--- a/src/renderer/components/SubscriptionsShorts.vue
+++ b/src/renderer/components/SubscriptionsShorts.vue
@@ -11,13 +11,14 @@
 </template>
 
 <script setup>
-import { computed, shallowRef, ref, watch, onBeforeUnmount, onMounted, useTemplateRef } from 'vue'
+import { computed, shallowRef, ref, watch, onMounted, useTemplateRef } from 'vue'
 import { useI18n } from 'vue-i18n'
 
 import SubscriptionsTabUi from './SubscriptionsTabUi/SubscriptionsTabUi.vue'
 
 import store from '../store/index'
 
+import { useAutoRefreshClock } from '../composables/useAutoRefreshClock'
 import { useSubscriptionChannelUpdates } from '../composables/useSubscriptionChannelUpdates'
 import {
   refreshSubscriptionShortsFromRemote,
@@ -36,8 +37,16 @@ const attemptedFetch = ref(false)
 const lastRemoteRefreshSuccessTimestamp = ref(null)
 
 let alreadyLoadedRemotely = false
-let nextAutoRefreshTicker = null
-const now = ref(Date.now())
+
+/** @type {import('vue').ComputedRef<boolean>} */
+const hasPendingAutoRefresh = computed(() => {
+  const interval = parseInt(store.getters.getSubscriptionShortsAutoRefreshInterval, 10)
+
+  return !!store.getters.getSubscriptionShortsNextAutoRefreshTimestamp &&
+    !Number.isNaN(interval) && interval > 0
+})
+
+const now = useAutoRefreshClock(hasPendingAutoRefresh)
 
 /** @type {import('vue').ComputedRef<boolean>} */
 const subscriptionCacheReady = computed(() => store.getters.getSubscriptionCacheReady)
@@ -173,14 +182,7 @@ if (!subscriptionCacheReady.value) {
 }
 
 onMounted(() => {
-  nextAutoRefreshTicker = setInterval(() => {
-    now.value = Date.now()
-  }, 30000)
   loadVideosFromRemoteFirstPerWindowSometimes()
-})
-
-onBeforeUnmount(() => {
-  clearInterval(nextAutoRefreshTicker)
 })
 
 function loadVideosFromRemoteFirstPerWindowSometimes() {

--- a/src/renderer/components/SubscriptionsVideos.vue
+++ b/src/renderer/components/SubscriptionsVideos.vue
@@ -11,13 +11,14 @@
 </template>
 
 <script setup>
-import { computed, onBeforeUnmount, onMounted, ref, shallowRef, useTemplateRef, watch } from 'vue'
+import { computed, onMounted, ref, shallowRef, useTemplateRef, watch } from 'vue'
 import { useI18n } from 'vue-i18n'
 
 import SubscriptionsTabUi from './SubscriptionsTabUi/SubscriptionsTabUi.vue'
 
 import store from '../store/index'
 
+import { useAutoRefreshClock } from '../composables/useAutoRefreshClock'
 import { useSubscriptionChannelUpdates } from '../composables/useSubscriptionChannelUpdates'
 import { getCachedRelativeTimeFormat, getCachedShortDateTimeFormat, getRelativeTimeFromDate } from '../helpers/utils'
 import {
@@ -34,10 +35,17 @@ const errorChannels = ref([])
 const attemptedFetch = ref(false)
 /** @type {import('vue').Ref<number | null>} */
 const lastRemoteRefreshSuccessTimestamp = ref(null)
-const now = ref(Date.now())
+/** @type {import('vue').ComputedRef<boolean>} */
+const hasPendingAutoRefresh = computed(() => {
+  const interval = parseInt(store.getters.getSubscriptionFeedAutoRefreshInterval, 10)
+
+  return !!store.getters.getSubscriptionFeedNextAutoRefreshTimestamp &&
+    !Number.isNaN(interval) && interval > 0
+})
+
+const now = useAutoRefreshClock(hasPendingAutoRefresh)
 
 let alreadyLoadedRemotely = false
-let nextAutoRefreshTicker = null
 
 /** @type {import('vue').ComputedRef<boolean>} */
 const subscriptionCacheReady = computed(() => store.getters.getSubscriptionCacheReady)
@@ -173,14 +181,7 @@ if (!subscriptionCacheReady.value) {
 }
 
 onMounted(() => {
-  nextAutoRefreshTicker = setInterval(() => {
-    now.value = Date.now()
-  }, 30000)
   loadVideosFromRemoteFirstPerWindowSometimes()
-})
-
-onBeforeUnmount(() => {
-  clearInterval(nextAutoRefreshTicker)
 })
 
 function loadVideosFromRemoteFirstPerWindowSometimes() {

--- a/src/renderer/components/ft-shaka-video-player/ft-shaka-video-player.js
+++ b/src/renderer/components/ft-shaka-video-player/ft-shaka-video-player.js
@@ -3178,7 +3178,9 @@ export default defineComponent({
     function handleSeekBarMouseMove(event) {
       if (!container.value || !player) return
 
-      const seekBarContainer = container.value.querySelector('.shaka-seek-bar-container')
+      // The listener is bound to the seek bar container itself, so there is no
+      // need to look it up again on every one of these very frequent events.
+      const seekBarContainer = event.currentTarget
       if (!seekBarContainer) return
 
       if (props.chapters.length === 0) {
@@ -3292,7 +3294,7 @@ export default defineComponent({
     function handleSponsorBlockSeekBarMouseMove(event) {
       if (!container.value || !player) return
 
-      const seekBarContainer = container.value.querySelector('.shaka-seek-bar-container')
+      const seekBarContainer = event.currentTarget
       const thumbnailTime = seekBarContainer?.querySelector('.shaka-player-ui-thumbnail-time')
       if (!seekBarContainer || !thumbnailTime) return
 

--- a/src/renderer/components/ft-shaka-video-player/opentubex/useAmbientMode.js
+++ b/src/renderer/components/ft-shaka-video-player/opentubex/useAmbientMode.js
@@ -22,6 +22,8 @@ export function useAmbientMode({ enabled, video }) {
 
   /** @type {number|null} */
   let frameInterval = null
+  /** @type {HTMLVideoElement | null} */
+  let playbackListenersAttached = null
   let lastVideoTime = -1
   let blendTicksRemaining = 0
   let hasAmbientFrame = false
@@ -31,11 +33,20 @@ export function useAmbientMode({ enabled, video }) {
     const canvas = ambientCanvas.value
     const videoElement = video.value
 
+    // The element only shows up once the player is ready, so keep trying until
+    // there is something to listen to.
+    attachPlaybackListeners()
+
     const videoTimeChanged = videoElement?.currentTime !== lastVideoTime
 
     if (!enabled.value || document.hidden || !canvas || !videoElement ||
       videoElement.readyState < HTMLMediaElement.HAVE_CURRENT_DATA ||
       (!videoTimeChanged && blendTicksRemaining === 0)) {
+      // Nothing left to draw and no new frames coming: 'play' restarts the timer.
+      if (playbackListenersAttached && videoElement?.paused && blendTicksRemaining === 0) {
+        pauseAmbientTicking()
+      }
+
       return
     }
 
@@ -83,14 +94,49 @@ export function useAmbientMode({ enabled, video }) {
     blendTicksRemaining = 0
     hasAmbientFrame = false
     drawAmbientFrame()
-    frameInterval = window.setInterval(drawAmbientFrame, AMBIENT_FRAME_INTERVAL_MS)
+    resumeAmbientTicking()
   }
 
   function stopAmbientFrames() {
+    pauseAmbientTicking()
+    detachPlaybackListeners()
+  }
+
+  function resumeAmbientTicking() {
+    if (frameInterval !== null || !enabled.value) {
+      return
+    }
+
+    frameInterval = window.setInterval(drawAmbientFrame, AMBIENT_FRAME_INTERVAL_MS)
+    attachPlaybackListeners()
+  }
+
+  function pauseAmbientTicking() {
     if (frameInterval !== null) {
       window.clearInterval(frameInterval)
       frameInterval = null
     }
+  }
+
+  // A paused video produces no new frames, so the timer stops itself once the
+  // blend has settled (see drawAmbientFrame) and playing again restarts it.
+  function attachPlaybackListeners() {
+    const videoElement = video.value
+    if (!videoElement || playbackListenersAttached) {
+      return
+    }
+
+    videoElement.addEventListener('play', resumeAmbientTicking)
+    playbackListenersAttached = videoElement
+  }
+
+  function detachPlaybackListeners() {
+    if (!playbackListenersAttached) {
+      return
+    }
+
+    playbackListenersAttached.removeEventListener('play', resumeAmbientTicking)
+    playbackListenersAttached = null
   }
 
   watch(enabled, (isEnabled) => {

--- a/src/renderer/components/ft-shaka-video-player/opentubex/useScrollMiniPlayer.js
+++ b/src/renderer/components/ft-shaka-video-player/opentubex/useScrollMiniPlayer.js
@@ -95,6 +95,8 @@ export function useScrollMiniPlayer({ container, fullWindowEnabled, getUi, isAct
   /** @type {{ type: 'drag' | 'resize' | 'volume', corner?: string, startX: number, startY: number, startRect: import('../../../helpers/scrollMiniPlayer').ScrollMiniPlayerRect } | null} */
   let scrollMiniPointerSession = null
   let lastKnownInlinePlayerHeight = 0
+  /** @type {number | null} */
+  let scrollMiniScrollFrame = null
 
   function updateScrollMiniVideoAspectRatio() {
     const videoElement = video.value
@@ -537,14 +539,17 @@ export function useScrollMiniPlayer({ container, fullWindowEnabled, getUi, isAct
   }
 
   function updateScrollMiniPlayer() {
-    rememberInlinePlayerLayoutHeight()
-
+    // Check first: everything below reads layout, which forces a synchronous
+    // reflow. Measuring before knowing whether the mini player can run at all
+    // would do that on every scroll event even with the feature turned off.
     if (!canUseScrollMiniPlayer()) {
       if (scrollMiniPlayerActive.value) {
         deactivateScrollMiniPlayer()
       }
       return
     }
+
+    rememberInlinePlayerLayoutHeight()
 
     repairScrollMiniPlaceholderHeight()
 
@@ -567,7 +572,24 @@ export function useScrollMiniPlayer({ container, fullWindowEnabled, getUi, isAct
 
   function handleScrollMiniWindowScroll() {
     suppressScrollMiniPlayPausePointerReveal()
-    updateScrollMiniPlayer()
+
+    // Scroll fires far more often than the screen refreshes, so coalesce the
+    // layout-reading update into the next frame instead of running it per event.
+    if (scrollMiniScrollFrame !== null) {
+      return
+    }
+
+    scrollMiniScrollFrame = requestAnimationFrame(() => {
+      scrollMiniScrollFrame = null
+      updateScrollMiniPlayer()
+    })
+  }
+
+  function cancelPendingScrollMiniScrollFrame() {
+    if (scrollMiniScrollFrame !== null) {
+      cancelAnimationFrame(scrollMiniScrollFrame)
+      scrollMiniScrollFrame = null
+    }
   }
 
   /**
@@ -799,6 +821,7 @@ export function useScrollMiniPlayer({ container, fullWindowEnabled, getUi, isAct
     clearScrollMiniVolumeHideTimeout()
 
     cancelScrollMiniPlayerBounce()
+    cancelPendingScrollMiniScrollFrame()
 
     endScrollMiniPointerSession()
     window.removeEventListener('pointerup', handleScrollMiniVolumePointerUpWindow)

--- a/src/renderer/composables/useAutoRefreshClock.js
+++ b/src/renderer/composables/useAutoRefreshClock.js
@@ -1,0 +1,54 @@
+import { onBeforeUnmount, onMounted, ref, watch } from 'vue'
+
+const AUTO_REFRESH_CLOCK_INTERVAL_MS = 30000
+
+/**
+ * A coarse clock for "next auto refresh in ..." labels, which only need to be
+ * accurate to the minute. The ticker runs only while `isNeeded` is true: tabs
+ * stay mounted while not presented, so an unconditional timer would churn
+ * reactivity in every open feed tab even with auto refresh turned off.
+ *
+ * @param {import('vue').ComputedRef<boolean> | (() => boolean)} isNeeded
+ * @returns {import('vue').Ref<number>} the current time, updated periodically
+ */
+export function useAutoRefreshClock(isNeeded) {
+  const now = ref(Date.now())
+  /** @type {ReturnType<typeof setInterval> | null} */
+  let ticker = null
+
+  function start() {
+    if (ticker !== null) {
+      return
+    }
+
+    now.value = Date.now()
+    ticker = setInterval(() => {
+      now.value = Date.now()
+    }, AUTO_REFRESH_CLOCK_INTERVAL_MS)
+  }
+
+  function stop() {
+    if (ticker !== null) {
+      clearInterval(ticker)
+      ticker = null
+    }
+  }
+
+  watch(isNeeded, (needed) => {
+    if (needed) {
+      start()
+    } else {
+      stop()
+    }
+  })
+
+  onMounted(() => {
+    if (typeof isNeeded === 'function' ? isNeeded() : isNeeded.value) {
+      start()
+    }
+  })
+
+  onBeforeUnmount(stop)
+
+  return now
+}

--- a/src/renderer/helpers/subscriptions.js
+++ b/src/renderer/helpers/subscriptions.js
@@ -45,6 +45,7 @@ const SCHEDULED_START_REGEX = /"scheduledStartTime"\s*:\s*"(\d+)"/
 const SUBSCRIPTION_FETCH_BATCH_SIZE = 80
 const SUBSCRIPTION_FETCH_BATCH_DELAY_MS = 2000
 const SUBSCRIPTION_FETCH_CONCURRENCY = 8
+const RSS_ENRICHMENT_CONCURRENCY = 3
 
 /**
  * Stops the refresh running in this renderer after the channels that are
@@ -338,14 +339,53 @@ export function isVideoHiddenByPreferences(video, {
 }
 
 /**
+ * Video ids already known not to be premieres. Each lookup downloads a full
+ * watch page and every refresh re-parses the same RSS entries, so without this
+ * the same new uploads would be fetched again on every refresh. Only negative
+ * results are cached: a video that isn't a premiere never becomes one, whereas
+ * an upcoming premiere does eventually go live.
+ * @type {Set<string>}
+ */
+const rssNonPremiereVideoIds = new Set()
+/** @type {Map<string, Promise<{ isUpcoming: boolean, premiereDate?: Date }>>} */
+const rssUpcomingInfoRequests = new Map()
+
+/**
  * @param {string} videoId
  */
-async function fetchRssVideoUpcomingInfo(videoId) {
+function fetchRssVideoUpcomingInfo(videoId) {
+  if (rssNonPremiereVideoIds.has(videoId)) {
+    return Promise.resolve({ isUpcoming: false })
+  }
+
+  const inFlight = rssUpcomingInfoRequests.get(videoId)
+  if (inFlight !== undefined) {
+    return inFlight
+  }
+
+  const request = fetchRssVideoUpcomingInfoUncached(videoId).then((info) => {
+    // A failed lookup says nothing about the video, so let the next refresh retry.
+    if (!info.isUpcoming && !info.failed) {
+      rssNonPremiereVideoIds.add(videoId)
+    }
+    return info
+  }).finally(() => {
+    rssUpcomingInfoRequests.delete(videoId)
+  })
+
+  rssUpcomingInfoRequests.set(videoId, request)
+  return request
+}
+
+/**
+ * @param {string} videoId
+ */
+async function fetchRssVideoUpcomingInfoUncached(videoId) {
   try {
     const response = await fetch(`https://www.youtube.com/watch?v=${videoId}`)
 
     if (!response.ok) {
-      return { isUpcoming: false }
+      return { isUpcoming: false, failed: true }
     }
 
     const html = await response.text()
@@ -365,7 +405,7 @@ async function fetchRssVideoUpcomingInfo(videoId) {
       premiereDate
     }
   } catch {
-    return { isUpcoming: false }
+    return { isUpcoming: false, failed: true }
   }
 }
 
@@ -456,7 +496,9 @@ export async function parseYouTubeRSSFeed(rssString, channelId) {
 
     return {
       name: channelName,
-      videos: await Promise.all(videos.map(video => enrichRssVideoIfNeeded(video)))
+      // Enrichment downloads a watch page per candidate, so cap how many of them
+      // a single channel can have in flight at once.
+      videos: await mapConcurrently(videos, RSS_ENRICHMENT_CONCURRENCY, enrichRssVideoIfNeeded)
     }
   } catch {
     return {

--- a/src/renderer/helpers/subscriptions.js
+++ b/src/renderer/helpers/subscriptions.js
@@ -7,6 +7,7 @@ import {
 } from './api/invidious'
 import { getLocalChannelCommunity, getLocalChannelLiveStreams, getLocalChannelVideos } from './api/local'
 import {
+  fetchWithTimeout,
   getChannelPlaylistId,
   showApiErrorToast,
   showToast,
@@ -46,6 +47,7 @@ const SUBSCRIPTION_FETCH_BATCH_SIZE = 80
 const SUBSCRIPTION_FETCH_BATCH_DELAY_MS = 2000
 const SUBSCRIPTION_FETCH_CONCURRENCY = 8
 const RSS_ENRICHMENT_CONCURRENCY = 3
+const RSS_ENRICHMENT_TIMEOUT_MS = 15_000
 
 /**
  * Stops the refresh running in this renderer after the channels that are
@@ -382,7 +384,14 @@ function fetchRssVideoUpcomingInfo(videoId) {
  */
 async function fetchRssVideoUpcomingInfoUncached(videoId) {
   try {
-    const response = await fetch(`https://www.youtube.com/watch?v=${videoId}`)
+    // Bounded because the enrichment workers await these one at a time: a
+    // request that never settles would hold its worker forever, leaving the
+    // channel's feed permanently unresolved. A timeout counts as a failed
+    // lookup, so it is not cached and the next refresh tries again.
+    const response = await fetchWithTimeout(
+      RSS_ENRICHMENT_TIMEOUT_MS,
+      `https://www.youtube.com/watch?v=${videoId}`
+    )
 
     if (!response.ok) {
       return { isUpcoming: false, failed: true }

--- a/src/renderer/helpers/utils.js
+++ b/src/renderer/helpers/utils.js
@@ -1287,8 +1287,24 @@ export function throttle(func, wait) {
   }
 }
 
+// Every list item of every feed can add an entry, so the cache is capped and
+// evicts the oldest titles first rather than growing for the whole session.
+const OEMBED_TITLE_CACHE_LIMIT = 500
 const oembedTitleCache = new Map()
 const oembedTitleRequests = new Map()
+
+/**
+ * @param {string} videoId
+ * @param {string} title
+ */
+function cacheOembedTitle(videoId, title) {
+  if (oembedTitleCache.size >= OEMBED_TITLE_CACHE_LIMIT) {
+    // Map iterates in insertion order, so the first key is the oldest one.
+    oembedTitleCache.delete(oembedTitleCache.keys().next().value)
+  }
+
+  oembedTitleCache.set(videoId, title)
+}
 
 /**
  * @param {string} videoId
@@ -1316,7 +1332,7 @@ export async function getOembedTitle(videoId) {
     try {
       const oembedInfo = await (await fetch(`https://www.youtube.com/oembed?url=https://www.youtube.com/watch?v=${videoId}`)).json()
       if (typeof oembedInfo.title === 'string' && oembedInfo.title.length > 0) {
-        oembedTitleCache.set(videoId, oembedInfo.title)
+        cacheOembedTitle(videoId, oembedInfo.title)
         return oembedInfo.title
       }
     } catch (error) {

--- a/src/renderer/store/modules/playlists.js
+++ b/src/renderer/store/modules/playlists.js
@@ -130,9 +130,20 @@ const state = {
 const getters = {
   getPlaylistsReady: (state) => state.playlistsReady,
   getAllPlaylists: (state) => state.playlists,
-  getPlaylistVideoIds: (state) => new Set(
-    state.playlists.flatMap(playlist => playlist.videos.map(video => video.videoId))
-  ),
+  // Every list item reads this, and it is rebuilt on any playlist change, so
+  // fill the set directly instead of allocating an intermediate array per
+  // playlist plus one flattened array holding every video id.
+  getPlaylistVideoIds: (state) => {
+    const videoIds = new Set()
+
+    for (const playlist of state.playlists) {
+      for (const video of playlist.videos) {
+        videoIds.add(video.videoId)
+      }
+    }
+
+    return videoIds
+  },
   getPlaylist: (state) => (playlistId) => {
     return state.playlists.find(playlist => playlist._id === playlistId)
   },


### PR DESCRIPTION
Compares the fork against the FreeTube merge base (`32925bd69`) and fixes the paths that got measurably more expensive, plus a few that were never cheap.

## Regressions vs upstream

**Forced layout on every watch-page scroll event.** `updateScrollMiniPlayer` called `rememberInlinePlayerLayoutHeight()` — which reads `offsetWidth` and `offsetHeight` — *before* the `canUseScrollMiniPlayer()` guard, so scrolling forced two layout flushes per event even with the scroll mini player turned off. The listener was also unthrottled, and upstream registers no window scroll listener from the player at all. Guard first, then coalesce the handler into a `requestAnimationFrame`.

**A full watch page downloaded per RSS feed entry.** Any entry with one view or fewer — i.e. every fresh upload — triggered `fetch('https://www.youtube.com/watch?v=…')` purely to distinguish premieres, fired via `Promise.all` across a channel's whole feed with no cache. Upstream used the free `viewCount !== '0'` heuristic. Negative results are now cached (that's where nearly all the volume is; a video that isn't a premiere never becomes one, while an upcoming premiere does eventually go live, so positives are still re-checked), failed lookups are not cached, and concurrency is capped.

**History migration scan on every launch.** `History.find()` awaited a full unindexed scan for records predating `isWatched`. Memoised per session, but it ran again on every start and history loading blocked on it. A marker in the settings datastore now short-circuits it once the migration has run.

**Timers running with nothing to count down.** The four subscription feed tickers and the refresh widget's 1 Hz countdown ran unconditionally. Since tabs stay mounted while not presented, that was one timer per open feed tab regardless of whether auto refresh was even on. Extracted `useAutoRefreshClock`, which only ticks while a refresh is genuinely pending.

## Other hot paths

**`TransitionGroup` FLIP over every list.** Every list surface sits in a `TransitionGroup` carrying `.feed-move { transition: transform }`. Vue's `applyTranslation` measures and then writes a transform per child inside one loop, so each item forces its own layout pass — worst on pagination, where 100 items are appended to a feed of hundreds and *nothing actually moves*. Suppressed past 50 items and under `prefers-reduced-motion`, reusing the existing `feed-move-suppressed` escape hatch.

Worth knowing: I read the `runtime-dom` source rather than trusting my recollection. The per-child `getBoundingClientRect` in `TransitionGroup`'s render function runs unconditionally and can't be avoided while the component is used at all, so this removes the read/write-interleaved pass, not the whole cost.

**Navigation history in every tab-state broadcast.** `getState()` embedded each tab's complete history and `_broadcastStateUpdate()` fires from 26 sites, including title and loading-state changes — yet `reconcileTab` discards it for tabs the renderer already knows. Now sent once per tab. Snapshots queued while the renderer is bootstrapping still carry it in full, because the bridge coalesces those down to the newest one; `getSyncSession()` and the explicit `tabs.getState()` IPC are unchanged.

**Smaller items.** The seek-bar mousemove handlers re-queried the element they were already bound to (`event.currentTarget`); the oEmbed title cache was unbounded; `getPlaylistVideoIds` allocated an array per playlist plus a flattened array of every id; ambient mode kept waking the renderer 10×/s while paused.

I did **not** move ambient mode to `requestVideoFrameCallback` — it fires per decoded frame (~60/s vs the current 10/s), so it would have been a pessimisation unless throttled, and threading the post-pause blend settle through it risked the visual. Suspending the timer while paused captures the actual waste.

## Testing

ESLint, stylelint, 61/61 unit, 139/139 offline E2E, and the network `watch.spec.mjs` (10 passed, 2 skipped).

Two failures I chased rather than dismissed both reproduce identically on an unmodified tree, so neither is from this branch: network `watch.spec.mjs` "fullscreen comments dock preserves its active state and scroll position" fails in isolation on clean `HEAD` too, and offline `settings.spec.mjs` "a toggled setting persists across restarts" flakes under parallel load but passes 3/3 alone.

Unrelated but worth flagging: the E2E suite needs `--workers=3` locally. The Playwright default is ~half the cores, and the resulting Electron pile-up manufactures 8–11 random `SIGSEGV` failures per run (a different set each time, and identically on clean `HEAD`).

## Reviewer note

The 50-item threshold means subscription feeds (default limit 100) no longer animate on reorder. That's a deliberate trade — it's exactly the size where the FLIP costs most and reads as jank — but it's a visible behaviour change the tests can't judge, so it deserves a human eye.
