### PR TITLE
fix(ui): resolve overlay scrollbar regressions

### DIFF
--- a/e2e/tests/network/watch.spec.mjs
+++ b/e2e/tests/network/watch.spec.mjs
@@ -194,7 +194,12 @@ test.describe('watch page', () => {
 
       await watchView.$store.dispatch('updateHideRecommendedVideos', true)
       watchView.useTheatreMode = true
-      watchView.videoChapters = [{ title: 'Test chapter', timestamp: '0:00', startSeconds: 0 }]
+      watchView.videoChapters = Array.from({ length: 20 }, (_, index) => ({
+        title: `Test chapter ${index + 1}`,
+        timestamp: `${index}:00`,
+        startSeconds: index * 60
+      }))
+      watchView.videoCurrentChapterIndex = 19
       watchView.showSidebarChapters = true
       await watchView.$nextTick()
     })
@@ -203,6 +208,18 @@ test.describe('watch page', () => {
     const panel = page.locator('.watchVideoChaptersPanel')
     await expect(layout).toHaveClass(/useTheatreMode/)
     await expect(panel).toBeVisible()
+    await expect.poll(() => panel.evaluate((element) => {
+      const container = element.querySelector('.chaptersWrapper')
+      const currentChapter = container?.querySelector('.chapter.current')
+      const containerBounds = container?.getBoundingClientRect()
+      const chapterBounds = currentChapter?.getBoundingClientRect()
+      return Boolean(
+        containerBounds &&
+        chapterBounds &&
+        chapterBounds.top >= containerBounds.top &&
+        chapterBounds.bottom <= containerBounds.bottom
+      )
+    })).toBe(true)
 
     await panel.getByRole('button', { name: 'Close Chapters' }).click()
     await expect(panel).toHaveClass(/chapters-panel-leave-active/)

--- a/e2e/tests/network/watch.spec.mjs
+++ b/e2e/tests/network/watch.spec.mjs
@@ -388,7 +388,7 @@ test.describe('watch page', () => {
     await page.addStyleTag({
       content: `
         .fullscreenCommentsOverlay .comment { display: none; }
-        .fullscreenCommentsOverlay .commentAutoLoadSentinel { min-height: 1px; }
+        .fullscreenCommentsOverlay.open { inset-block-start: calc(100% - 306px) !important; }
       `
     })
     await page.route(/\/youtubei\/v1\/next/, async (route) => {
@@ -403,6 +403,57 @@ test.describe('watch page', () => {
     await expect.poll(() => commentCards.count(), { timeout: 30_000 }).toBeGreaterThan(initialCommentCount)
     const repeatedLoadCount = await commentCards.count()
     await expect.poll(() => commentCards.count(), { timeout: 30_000 }).toBeGreaterThan(repeatedLoadCount)
+  })
+
+  test('fullscreen metadata uses one full-dock scrollbar', async ({ page, innertube }) => {
+    test.skip(innertube.replay, 'watch page hydration needs the real API')
+    await openVideo(page)
+    await setPlayerFullscreen(page, true)
+    await page.locator('.playerFullscreenTitleOverlay').click({ force: true })
+
+    const metadata = page.locator('.fullscreenMetadataOverlay.open')
+    await expect(metadata).toBeVisible()
+    await expect(metadata.locator('.fullscreenMetadataTarget'))
+      .toHaveAttribute('data-overlayscrollbars-viewport')
+    await expect(metadata.locator('.os-scrollbar-vertical')).toHaveCount(1)
+    await expect(metadata.locator('.descriptionScroll'))
+      .not.toHaveAttribute('data-overlayscrollbars-viewport')
+  })
+
+  test('fullscreen comments scrollbar reaches the dock bottom', async ({ page, innertube }) => {
+    test.skip(innertube.replay, 'watch page hydration needs the real API')
+    await openVideo(page)
+    await setPlayerFullscreen(page, true)
+    await page.locator('.fullscreenCommentsToggle').click({ force: true })
+
+    const dock = page.locator('.fullscreenCommentsOverlay.open')
+    const content = dock.locator('.commentsContentWrapper')
+    await expect(content).toBeVisible()
+
+    const bottomGap = await Promise.all([dock.boundingBox(), content.boundingBox()])
+      .then(([dockBox, contentBox]) => (
+        dockBox.y + dockBox.height - contentBox.y - contentBox.height
+      ))
+    expect(bottomGap).toBeLessThanOrEqual(2)
+  })
+
+  test('fullscreen SponsorBlock uses one content scrollbar', async ({ page, innertube }) => {
+    test.skip(innertube.replay, 'watch page hydration needs the real API')
+    await page.evaluate(() => {
+      const store = document.querySelector('#app').__vue_app__.config.globalProperties.$store
+      store.commit('setUseSponsorBlock', true)
+    })
+    await openVideo(page)
+    await setPlayerFullscreen(page, true)
+    await page.locator('.fullscreenSponsorBlockToggle').click({ force: true })
+
+    const sponsorBlock = page.locator('.fullscreenSponsorBlockOverlay.open')
+    await expect(sponsorBlock).toBeVisible()
+    await expect(sponsorBlock.locator('.sponsorBlockContent'))
+      .toHaveAttribute('data-overlayscrollbars-viewport')
+    await expect(sponsorBlock.locator('.sponsorBlockSegments'))
+      .not.toHaveAttribute('data-overlayscrollbars-viewport')
+    await expect(sponsorBlock.locator('.os-scrollbar-vertical')).toHaveCount(1)
   })
 
   test('fullscreen title opens the video information dock', async ({ page, innertube }) => {
@@ -443,6 +494,10 @@ test.describe('watch page', () => {
     await expect(title).toHaveAttribute('aria-expanded', 'true')
     await expect(page.locator('.fullscreenMetadataOverlay.open')).toBeVisible()
     await expect(page.locator('.fullscreenMetadataTarget .videoTitle')).toContainText(CAPTIONED_VIDEO.title)
+    await expect(page.locator('.fullscreenMetadataTarget')).toHaveAttribute('data-overlayscrollbars-viewport')
+    await expect(page.locator('.fullscreenMetadataOverlay .os-scrollbar-vertical')).toHaveCount(1)
+    await expect(page.locator('.fullscreenMetadataTarget .descriptionScroll'))
+      .not.toHaveAttribute('data-overlayscrollbars-viewport')
     await expect(page.locator('.fullscreenMetadataTarget .shareButton')).toHaveCount(0)
     await expect(page.locator('.fullscreenMetadataTarget .quickBookmarkVideoIcon')).toHaveCount(0)
     await expect(page.locator('.fullscreenMetadataTarget').getByRole('button', { name: 'Add to playlist' })).toHaveCount(0)
@@ -471,6 +526,8 @@ test.describe('watch page', () => {
     await expect(page.locator('.fullscreenMetadataHeader')).toHaveCSS('cursor', 'grab')
     await expect(page.locator('.fullscreenTranscriptTarget .transcriptCard')).toBeVisible()
     await expect(page.locator('.fullscreenTranscriptTarget .transcriptSegment').first()).toBeVisible({ timeout: 30_000 })
+    await expect(page.locator('.fullscreenTranscriptTarget .transcriptSegments'))
+      .toHaveAttribute('data-overlayscrollbars-viewport')
     await expect(page.locator('.fullscreenTranscriptTarget .transcriptActions .iconButton')).toHaveCount(2)
 
     const transcriptDock = page.locator('.fullscreenTranscriptOverlay.open')

--- a/e2e/tests/offline/scrollbar-overlay.spec.mjs
+++ b/e2e/tests/offline/scrollbar-overlay.spec.mjs
@@ -68,6 +68,20 @@ test.describe('overlay scrollbars', () => {
     await expect.poll(() => page.evaluate(() => window.scrollY)).toBeGreaterThan(0)
   })
 
+  test('dragging the page handle scrolls the document', async ({ page }) => {
+    await goTo(page, 'settings')
+    await expect.poll(() => pageOverflows(page)).toBe(true)
+
+    const handle = page.locator(`${PAGE_SCROLLBAR} .os-scrollbar-handle`)
+    const box = await handle.boundingBox()
+    await page.mouse.move(box.x + box.width / 2, box.y + box.height / 2)
+    await page.mouse.down()
+    await page.mouse.move(box.x + box.width / 2, box.y + box.height / 2 + 100, { steps: 10 })
+    await page.mouse.up()
+
+    await expect.poll(() => page.evaluate(() => window.scrollY)).toBeGreaterThan(0)
+  })
+
   test.describe('a nested scroll container', () => {
     const now = Date.now()
     test.use({

--- a/e2e/tests/offline/search-history.spec.mjs
+++ b/e2e/tests/offline/search-history.spec.mjs
@@ -168,6 +168,20 @@ test.describe('search suggestion remove button layout', () => {
       const removeBox = await removeButton.boundingBox()
       return removeBox.width
     }).toBeLessThan(40)
+
+    const [entryBox, removeBox] = await Promise.all([
+      entry.boundingBox(),
+      removeButton.boundingBox()
+    ])
+    expect(entryBox.x + entryBox.width - removeBox.x - removeBox.width).toBeGreaterThanOrEqual(8)
+
+    const colors = await entry.evaluate((element) => ({
+      row: getComputedStyle(element).backgroundColor,
+      handle: getComputedStyle(
+        element.closest('.list').querySelector('.os-scrollbar-vertical .os-scrollbar-handle')
+      ).backgroundColor
+    }))
+    expect(colors.handle).toBe(colors.row)
   })
 
   test('the leading icon is vertically centered in its row', async ({ page }) => {

--- a/e2e/tests/offline/subscriptions-new-feed.spec.mjs
+++ b/e2e/tests/offline/subscriptions-new-feed.spec.mjs
@@ -286,6 +286,9 @@ test.describe('large new feed refresh', () => {
     await refreshNewContent.click()
     await expect(page.getByRole('heading', { name: 'Refresh all subscription feeds?' })).toBeVisible()
     await expect(page.getByText(/126 subscriptions can take a long time/)).toBeVisible()
+    expect(await page.locator('.promptCard').evaluate(
+      element => element.scrollHeight <= element.clientHeight
+    )).toBe(true)
 
     await page.getByRole('button', { name: 'No', exact: true }).click()
     await expect(page.getByRole('heading', { name: 'Refresh all subscription feeds?' })).toHaveCount(0)

--- a/src/renderer/components/CommentSection/CommentSection.css
+++ b/src/renderer/components/CommentSection/CommentSection.css
@@ -38,6 +38,12 @@
   --scrollbar-color-hover: rgb(255 255 255 / 65%);
 }
 
+/* A zero-height target can sit exactly on the clipped edge of a short dock and
+   stop intersecting even though the "Load More" row is visible. */
+.commentAutoLoadSentinel {
+  min-block-size: 1px;
+}
+
 /* Matches the chapter overlay header in the video player. */
 .fullscreenCommentHeader {
   position: relative;

--- a/src/renderer/components/FtInput/FtInput.css
+++ b/src/renderer/components/FtInput/FtInput.css
@@ -235,6 +235,10 @@ body[dir='rtl'] .ft-input-component.search.showClearTextButton:focus-within .inp
   overflow-wrap: break-word;
   box-shadow: 0 0 10px var(--scrollbar-color-hover);
   background-color: var(--search-bar-color);
+
+  /* The handle crosses hovered rows because this is an overlay scrollbar.
+     Match the row highlight instead of drawing a darker stripe through it. */
+  --scrollbar-color: var(--scrollbar-color-hover);
 }
 
 .search .list {
@@ -247,7 +251,7 @@ body[dir='rtl'] .ft-input-component.search.showClearTextButton:focus-within .inp
   justify-content: space-between;
   padding-block: 0;
   line-height: 2rem;
-  padding-inline: 15px 4px;
+  padding-inline: 15px 10px;
 }
 
 .optionWrapper {

--- a/src/renderer/components/FtPrompt/FtPrompt.css
+++ b/src/renderer/components/FtPrompt/FtPrompt.css
@@ -22,7 +22,7 @@
 
 .promptCard {
   animation: prompt-card-enter 150ms ease-out;
-  overflow-y: scroll;
+  overflow-y: auto;
   max-block-size: 95%;
 }
 

--- a/src/renderer/components/WatchVideoChapters/WatchVideoChapters.vue
+++ b/src/renderer/components/WatchVideoChapters/WatchVideoChapters.vue
@@ -141,7 +141,7 @@ function getThumbnailStyle(thumbnail) {
 const observeVisibilityOptions = {
   callback: (isVisible, _entry) => {
     if (isVisible) {
-      scrollToCurrentChapter(true)
+      chaptersWrapper.value.scrollTop = 0
     }
   },
   intersection: {
@@ -185,9 +185,8 @@ function navigateChapters(direction) {
 }
 
 /**
- * @param {boolean} [alignToTop]
  */
-function scrollToCurrentChapter(alignToTop = false) {
+function scrollToCurrentChapter() {
   const container = chaptersWrapper.value
   const currentItem = container?.children[currentIndex.value]
 
@@ -198,7 +197,7 @@ function scrollToCurrentChapter(alignToTop = false) {
   const containerRect = container.getBoundingClientRect()
   const currentItemRect = currentItem.getBoundingClientRect()
 
-  if (alignToTop || currentItemRect.top < containerRect.top) {
+  if (currentItemRect.top < containerRect.top) {
     container.scrollTop += currentItemRect.top - containerRect.top
   } else if (currentItemRect.bottom > containerRect.bottom) {
     container.scrollTop += currentItemRect.bottom - containerRect.bottom

--- a/src/renderer/components/WatchVideoChapters/WatchVideoChapters.vue
+++ b/src/renderer/components/WatchVideoChapters/WatchVideoChapters.vue
@@ -141,7 +141,7 @@ function getThumbnailStyle(thumbnail) {
 const observeVisibilityOptions = {
   callback: (isVisible, _entry) => {
     if (isVisible) {
-      chaptersWrapper.value.scrollTop = 0
+      scrollToCurrentChapter()
     }
   },
   intersection: {

--- a/src/renderer/components/WatchVideoDescription/WatchVideoDescription.vue
+++ b/src/renderer/components/WatchVideoDescription/WatchVideoDescription.vue
@@ -19,7 +19,8 @@
       {{ $t("Description.Expand Description") }}
     </span>
     <div
-      v-overlay-scrollbars
+      ref="descriptionScroll"
+      v-overlay-scrollbars="!alwaysExpanded"
       class="descriptionScroll"
     >
       <FtTimestampCatcher
@@ -82,6 +83,7 @@ const props = defineProps({
 const emit = defineEmits(['timestamp-event'])
 
 let shownDescription = ''
+const descriptionScroll = useTemplateRef('descriptionScroll')
 const descriptionContainer = useTemplateRef('descriptionContainer')
 const showFullDescription = ref(false)
 const showControls = ref(false)
@@ -144,6 +146,7 @@ function expandDescription() {
  * Enables user to collapse contents of description
  */
 function collapseDescription() {
+  descriptionScroll.value.scrollTop = 0
   showFullDescription.value = false
 }
 

--- a/src/renderer/components/WatchVideoSponsorBlock/WatchVideoSponsorBlock.vue
+++ b/src/renderer/components/WatchVideoSponsorBlock/WatchVideoSponsorBlock.vue
@@ -33,172 +33,179 @@
         </button>
       </div>
     </header>
-    <p class="sponsorBlockSubtitle">
-      {{ loading
-        ? $t('Video.Player.SponsorBlock.InfoPanelLoading')
-        : segments.length > 0
-          ? $t('Video.Player.SponsorBlock.InfoPanelHasSegments')
-          : $t('Video.Player.SponsorBlock.InfoPanelNoSegments') }}
-    </p>
     <div
-      v-if="loading && segments.length === 0"
-      class="sponsorBlockLoading"
-      role="status"
-    >
-      <font-awesome-icon
-        :icon="['fas', 'sync']"
-        spin
-      />
-    </div>
-    <div
-      v-else
-      class="sponsorBlockSegments"
+      v-overlay-scrollbars
+      class="sponsorBlockContent"
     >
       <div
-        v-for="segment in segments"
-        :key="segment.uuid"
-        class="sponsorBlockSegment"
-        :class="{
-          passed: isSegmentPassed(segment),
-          selected: selectedUuid === segment.uuid
-        }"
+        class="sponsorBlockSubtitle"
       >
-        <button
-          type="button"
-          class="sponsorBlockSegmentSummary"
-          :aria-expanded="String(selectedUuid === segment.uuid)"
-          @click="selectSegment(segment.uuid)"
-        >
-          <span
-            class="sponsorBlockDot"
-            :style="{ backgroundColor: segment.color }"
-          />
-          <span class="sponsorBlockCategory">
-            {{ segment.description || segment.translatedCategory }}
-            <font-awesome-icon
-              v-if="segment.locked"
-              class="sponsorBlockLocked"
-              :icon="['fas', 'lock']"
-              :title="$t('Video.Player.SponsorBlock.LockedSegment')"
-            />
-          </span>
-          <span class="sponsorBlockTime">{{ segment.timeLabel }}</span>
-        </button>
+        {{ loading
+          ? $t('Video.Player.SponsorBlock.InfoPanelLoading')
+          : segments.length > 0
+            ? $t('Video.Player.SponsorBlock.InfoPanelHasSegments')
+            : $t('Video.Player.SponsorBlock.InfoPanelNoSegments') }}
+      </div>
+      <div
+        v-if="loading && segments.length === 0"
+        class="sponsorBlockLoading"
+        role="status"
+      >
+        <font-awesome-icon
+          :icon="['fas', 'sync']"
+          spin
+        />
+      </div>
+      <div
+        v-else
+        class="sponsorBlockSegments"
+      >
         <div
-          v-if="selectedUuid === segment.uuid"
-          class="sponsorBlockVoteActions"
+          v-for="segment in segments"
+          :key="segment.uuid"
+          class="sponsorBlockSegment"
+          :class="{
+            passed: isSegmentPassed(segment),
+            selected: selectedUuid === segment.uuid
+          }"
         >
           <button
             type="button"
-            class="sponsorBlockCollapseActions"
-            :aria-label="$t('Video.Player.SponsorBlock.CloseSegmentActions')"
-            :title="$t('Video.Player.SponsorBlock.CloseSegmentActions')"
+            class="sponsorBlockSegmentSummary"
+            :aria-expanded="String(selectedUuid === segment.uuid)"
             @click="selectSegment(segment.uuid)"
-          />
-          <button
-            v-if="submissionEnabled"
-            type="button"
-            class="sponsorBlockVoteButton"
-            :class="{ active: segment.userVote === 1 }"
-            :disabled="pendingUuid !== null"
-            :aria-label="$t('Video.Player.SponsorBlock.UpvoteSegment')"
-            :title="$t('Video.Player.SponsorBlock.UpvoteSegment')"
-            @click="$emit('vote', segment.uuid, 1)"
           >
-            <font-awesome-icon :icon="['fas', 'thumbs-up']" />
+            <span
+              class="sponsorBlockDot"
+              :style="{ backgroundColor: segment.color }"
+            />
+            <span class="sponsorBlockCategory">
+              {{ segment.description || segment.translatedCategory }}
+              <font-awesome-icon
+                v-if="segment.locked"
+                class="sponsorBlockLocked"
+                :icon="['fas', 'lock']"
+                :title="$t('Video.Player.SponsorBlock.LockedSegment')"
+              />
+            </span>
+            <span class="sponsorBlockTime">{{ segment.timeLabel }}</span>
           </button>
-          <button
-            v-if="submissionEnabled"
-            type="button"
-            class="sponsorBlockVoteButton"
-            :class="{ active: segment.userVote === 0 }"
-            :disabled="pendingUuid !== null"
-            :aria-label="$t('Video.Player.SponsorBlock.DownvoteSegment')"
-            :title="$t('Video.Player.SponsorBlock.DownvoteSegment')"
-            @click="$emit('vote', segment.uuid, 0)"
+          <div
+            v-if="selectedUuid === segment.uuid"
+            class="sponsorBlockVoteActions"
           >
-            <font-awesome-icon :icon="['fas', 'thumbs-down']" />
-          </button>
-          <button
-            type="button"
-            class="sponsorBlockVoteButton sponsorBlockSkipButton"
-            :aria-label="$t('Video.Player.SponsorBlock.SkipSegment')"
-            :title="$t('Video.Player.SponsorBlock.SkipSegment')"
-            @click="$emit('skip', segment.uuid)"
-          >
-            <font-awesome-icon :icon="['fas', 'forward-fast']" />
-          </button>
+            <button
+              type="button"
+              class="sponsorBlockCollapseActions"
+              :aria-label="$t('Video.Player.SponsorBlock.CloseSegmentActions')"
+              :title="$t('Video.Player.SponsorBlock.CloseSegmentActions')"
+              @click="selectSegment(segment.uuid)"
+            />
+            <button
+              v-if="submissionEnabled"
+              type="button"
+              class="sponsorBlockVoteButton"
+              :class="{ active: segment.userVote === 1 }"
+              :disabled="pendingUuid !== null"
+              :aria-label="$t('Video.Player.SponsorBlock.UpvoteSegment')"
+              :title="$t('Video.Player.SponsorBlock.UpvoteSegment')"
+              @click="$emit('vote', segment.uuid, 1)"
+            >
+              <font-awesome-icon :icon="['fas', 'thumbs-up']" />
+            </button>
+            <button
+              v-if="submissionEnabled"
+              type="button"
+              class="sponsorBlockVoteButton"
+              :class="{ active: segment.userVote === 0 }"
+              :disabled="pendingUuid !== null"
+              :aria-label="$t('Video.Player.SponsorBlock.DownvoteSegment')"
+              :title="$t('Video.Player.SponsorBlock.DownvoteSegment')"
+              @click="$emit('vote', segment.uuid, 0)"
+            >
+              <font-awesome-icon :icon="['fas', 'thumbs-down']" />
+            </button>
+            <button
+              type="button"
+              class="sponsorBlockVoteButton sponsorBlockSkipButton"
+              :aria-label="$t('Video.Player.SponsorBlock.SkipSegment')"
+              :title="$t('Video.Player.SponsorBlock.SkipSegment')"
+              @click="$emit('skip', segment.uuid)"
+            >
+              <font-awesome-icon :icon="['fas', 'forward-fast']" />
+            </button>
+          </div>
         </div>
       </div>
-    </div>
-    <footer class="sponsorBlockFooter">
-      <div class="sponsorBlockFooterOptions">
-        <div class="sponsorBlockOption">
-          <label
-            class="sponsorBlockToggle"
-            :class="{ disabled: channelWhitelisted }"
-          >
-            <input
-              id="sponsorBlockAutoSkip"
-              class="sponsorBlockToggleInput"
-              type="checkbox"
-              :checked="!autoSkipDisabled"
-              :disabled="channelWhitelisted"
-              :aria-label="$t('Video.Player.SponsorBlock.AutoSkipEnabled')"
-              @change="$emit('auto-skip-change', $event.target.checked)"
+      <footer class="sponsorBlockFooter">
+        <div class="sponsorBlockFooterOptions">
+          <div class="sponsorBlockOption">
+            <label
+              class="sponsorBlockToggle"
+              :class="{ disabled: channelWhitelisted }"
             >
-            <span
-              class="sponsorBlockToggleTrack"
-              aria-hidden="true"
-            >
-              <span class="sponsorBlockToggleThumb">
-                <font-awesome-icon :icon="['fas', autoSkipDisabled ? 'pause' : 'forward-fast']" />
+              <input
+                id="sponsorBlockAutoSkip"
+                class="sponsorBlockToggleInput"
+                type="checkbox"
+                :checked="!autoSkipDisabled"
+                :disabled="channelWhitelisted"
+                :aria-label="$t('Video.Player.SponsorBlock.AutoSkipEnabled')"
+                @change="$emit('auto-skip-change', $event.target.checked)"
+              >
+              <span
+                class="sponsorBlockToggleTrack"
+                aria-hidden="true"
+              >
+                <span class="sponsorBlockToggleThumb">
+                  <font-awesome-icon :icon="['fas', autoSkipDisabled ? 'pause' : 'forward-fast']" />
+                </span>
               </span>
-            </span>
-          </label>
-          <label
-            for="sponsorBlockAutoSkip"
-            class="sponsorBlockOptionLabel"
-            :class="{ muted: channelWhitelisted }"
-          >
-            {{ $t('Video.Player.SponsorBlock.AutoSkipEnabled') }}
-            <span class="sponsorBlockOptionState">
-              {{ autoSkipDisabled
-                ? $t('Video.Player.SponsorBlock.AutoSkipOff')
-                : $t('Video.Player.SponsorBlock.AutoSkipOn') }}
-            </span>
-          </label>
-        </div>
-        <div class="sponsorBlockOption">
-          <button
-            type="button"
-            class="sponsorBlockWhitelistButton"
-            :class="{ active: channelWhitelisted }"
-            :disabled="!canWhitelistChannel"
-            :aria-pressed="String(channelWhitelisted)"
-            :aria-label="channelWhitelisted
-              ? $t('Video.Player.SponsorBlock.RemoveChannelFromWhitelist')
-              : $t('Video.Player.SponsorBlock.WhitelistChannel')"
-            :title="channelWhitelisted
-              ? $t('Video.Player.SponsorBlock.RemoveChannelFromWhitelist')
-              : $t('Video.Player.SponsorBlock.WhitelistChannel')"
-            @click="$emit('channel-whitelist-change', !channelWhitelisted)"
-          >
-            <span
-              class="sponsorBlockWhitelistBadge"
-              aria-hidden="true"
+            </label>
+            <label
+              for="sponsorBlockAutoSkip"
+              class="sponsorBlockOptionLabel"
+              :class="{ muted: channelWhitelisted }"
             >
-              <font-awesome-icon :icon="['fas', channelWhitelisted ? 'check' : 'plus']" />
-            </span>
-            <span class="sponsorBlockWhitelistLabel">
-              {{ channelWhitelisted
-                ? $t('Video.Player.SponsorBlock.ChannelWhitelisted')
-                : $t('Video.Player.SponsorBlock.WhitelistChannel') }}
-            </span>
-          </button>
+              {{ $t('Video.Player.SponsorBlock.AutoSkipEnabled') }}
+              <span class="sponsorBlockOptionState">
+                {{ autoSkipDisabled
+                  ? $t('Video.Player.SponsorBlock.AutoSkipOff')
+                  : $t('Video.Player.SponsorBlock.AutoSkipOn') }}
+              </span>
+            </label>
+          </div>
+          <div class="sponsorBlockOption">
+            <button
+              type="button"
+              class="sponsorBlockWhitelistButton"
+              :class="{ active: channelWhitelisted }"
+              :disabled="!canWhitelistChannel"
+              :aria-pressed="String(channelWhitelisted)"
+              :aria-label="channelWhitelisted
+                ? $t('Video.Player.SponsorBlock.RemoveChannelFromWhitelist')
+                : $t('Video.Player.SponsorBlock.WhitelistChannel')"
+              :title="channelWhitelisted
+                ? $t('Video.Player.SponsorBlock.RemoveChannelFromWhitelist')
+                : $t('Video.Player.SponsorBlock.WhitelistChannel')"
+              @click="$emit('channel-whitelist-change', !channelWhitelisted)"
+            >
+              <span
+                class="sponsorBlockWhitelistBadge"
+                aria-hidden="true"
+              >
+                <font-awesome-icon :icon="['fas', channelWhitelisted ? 'check' : 'plus']" />
+              </span>
+              <span class="sponsorBlockWhitelistLabel">
+                {{ channelWhitelisted
+                  ? $t('Video.Player.SponsorBlock.ChannelWhitelisted')
+                  : $t('Video.Player.SponsorBlock.WhitelistChannel') }}
+              </span>
+            </button>
+          </div>
         </div>
-      </div>
-    </footer>
+      </footer>
+    </div>
   </section>
 </template>
 
@@ -324,11 +331,15 @@ function isSegmentPassed(segment) {
   font-size: 22px;
 }
 
-.sponsorBlockSegments {
+.sponsorBlockContent {
+  flex: 1 1 auto;
   min-block-size: 0;
+  overflow-y: auto;
+}
+
+.sponsorBlockSegments {
   padding-block: 4px 10px;
   padding-inline: 8px;
-  overflow-y: auto;
 }
 
 .sponsorBlockSegment {

--- a/src/renderer/components/ft-shaka-video-player/ft-shaka-video-player.css
+++ b/src/renderer/components/ft-shaka-video-player/ft-shaka-video-player.css
@@ -1417,8 +1417,9 @@
   transition-delay: 0s;
 }
 
-.fullscreenCommentsOverlay :deep(.watchVideo) {
+.ftVideoPlayer.fullscreenCommentsOpen .fullscreenCommentsOverlay :deep(.watchVideo) {
   flex: 1 1 auto;
+  block-size: 100%;
   min-block-size: 0;
   margin: 0;
   border-radius: 0;
@@ -1478,7 +1479,10 @@
   flex-direction: column;
   min-block-size: 0;
   max-inline-size: 100%;
-  overflow: hidden;
+  overflow: hidden auto;
+
+  --scrollbar-color: rgb(255 255 255 / 45%);
+  --scrollbar-color-hover: rgb(255 255 255 / 65%);
 }
 
 .fullscreenMetadataTarget :deep(.watchVideo) {
@@ -1491,59 +1495,19 @@
   box-shadow: none;
 }
 
+.fullscreenMetadataTarget :deep(.watchVideoInfo),
 .fullscreenMetadataTarget :deep(.videoDescription) {
-  flex: 1 1 auto;
-  min-block-size: 0;
-  max-block-size: none;
-  overflow: hidden auto;
+  flex: 0 0 auto;
 }
 
 .fullscreenMetadataTarget :deep(.watchVideoInfo) {
   padding-block-end: 4px;
 }
 
-.fullscreenMetadataTarget :deep(.videoDescription.short) {
-  flex: 0 0 auto;
-}
-
-/* A stacked metadata dock can be shorter than its non-description content.
-   Scroll the complete dock in that state so every section remains reachable. */
-.ftVideoPlayer.fullscreenMetadataOpen:is(
-  .fullscreenTranscriptOpen,
-  .fullscreenSponsorBlockOpen,
-  .fullscreenCommentsOpen,
-  .fullscreenPlaylistOpen,
-  .chaptersOverlayOpen
-) .fullscreenMetadataTarget {
-  overflow-y: auto;
-  scrollbar-gutter: stable;
-}
-
-.ftVideoPlayer.fullscreenMetadataOpen:is(
-  .fullscreenTranscriptOpen,
-  .fullscreenSponsorBlockOpen,
-  .fullscreenCommentsOpen,
-  .fullscreenPlaylistOpen,
-  .chaptersOverlayOpen
-) .fullscreenMetadataTarget :deep(.watchVideoInfo),
-  .ftVideoPlayer.fullscreenMetadataOpen:is(
-  .fullscreenTranscriptOpen,
-  .fullscreenSponsorBlockOpen,
-  .fullscreenCommentsOpen,
-  .fullscreenPlaylistOpen,
-  .chaptersOverlayOpen
-) .fullscreenMetadataTarget :deep(.videoDescription) {
-  flex: 0 0 auto;
-}
-
-.ftVideoPlayer.fullscreenMetadataOpen:is(
-  .fullscreenTranscriptOpen,
-  .fullscreenSponsorBlockOpen,
-  .fullscreenCommentsOpen,
-  .fullscreenPlaylistOpen,
-  .chaptersOverlayOpen
-) .fullscreenMetadataTarget :deep(.videoDescription) {
+.fullscreenMetadataTarget :deep(.videoDescription),
+.fullscreenMetadataTarget :deep(.descriptionScroll) {
   overflow: visible;
+  max-block-size: none;
 }
 
 .fullscreenMetadataTarget :deep(.videoMetrics),
@@ -1715,6 +1679,24 @@
   flex: 1 1 auto;
   max-block-size: none;
   padding-inline: 8px;
+
+  --scrollbar-color: rgb(255 255 255 / 45%);
+  --scrollbar-color-hover: rgb(255 255 255 / 65%);
+}
+
+.fullscreenSponsorBlockTarget :deep(.sponsorBlockContent) {
+  --scrollbar-color: rgb(255 255 255 / 45%);
+  --scrollbar-color-hover: rgb(255 255 255 / 65%);
+}
+
+:is(
+  .chapterOverlay,
+  .fullscreenMetadataTarget,
+  .fullscreenTranscriptTarget,
+  .fullscreenSponsorBlockTarget,
+  .fullscreenCommentsOverlay
+) :deep(.os-scrollbar-vertical) {
+  --os-padding-axis: 0;
 }
 
 /* Hide the pre-component playlist close control if it survives a hot reload. */

--- a/src/renderer/components/ft-shaka-video-player/ft-shaka-video-player.vue
+++ b/src/renderer/components/ft-shaka-video-player/ft-shaka-video-player.vue
@@ -394,6 +394,7 @@
         </header>
         <div
           ref="fullscreenMetadataTarget"
+          v-overlay-scrollbars
           class="fullscreenMetadataTarget"
         />
       </aside>

--- a/src/renderer/helpers/overlayScrollbars.js
+++ b/src/renderer/helpers/overlayScrollbars.js
@@ -21,8 +21,8 @@ OverlayScrollbars.plugin(ClickScrollPlugin)
  */
 const instances = new Map()
 
-function scrollbarOptions() {
-  return {
+function scrollbarOptions(initialization) {
+  const options = {
     scrollbars: {
       // 'move' hides the scrollbars once the pointer has been still for
       // `autoHideDelay` and brings them back as soon as it moves again.
@@ -32,6 +32,17 @@ function scrollbarOptions() {
       clickScroll: true
     }
   }
+
+  if (initialization === document.body) {
+    // The page viewport is always a normal block-flow body. Avoid repeatedly
+    // reading all flow-related computed styles while long feeds are changing;
+    // only direction can change at runtime.
+    options.update = {
+      flowDirectionStyles: () => ({ direction: document.documentElement.dir })
+    }
+  }
+
+  return options
 }
 
 /**
@@ -39,10 +50,88 @@ function scrollbarOptions() {
  * initialization object when the caller wants to pick the scrolling element
  */
 function create(initialization) {
-  const instance = OverlayScrollbars(initialization, scrollbarOptions())
+  const instance = OverlayScrollbars(initialization, scrollbarOptions(initialization))
   instances.set(instance, initialization)
   instance.on('destroyed', () => instances.delete(instance))
+
+  if (initialization === document.body) {
+    optimizeBodyScrollbarDrag(instance)
+  }
+
   return instance
+}
+
+/**
+ * OverlayScrollbars applies every pointermove directly while a handle is
+ * dragged. Mouse input can arrive faster than Chromium can paint a long video
+ * feed, making the handle trail the pointer. Coalesce the page scrollbar's
+ * moves to one native scroll per animation frame.
+ *
+ * @param {import('overlayscrollbars').OverlayScrollbars} instance
+ */
+function optimizeBodyScrollbarDrag(instance) {
+  const { handle, track } = instance.elements().scrollbarVertical
+
+  const onPointerDown = (event) => {
+    if (event.button !== 0 || !event.isPrimary) {
+      return
+    }
+
+    event.preventDefault()
+    event.stopPropagation()
+
+    const pointerId = event.pointerId
+    const startClientY = event.clientY
+    const startScrollY = window.scrollY
+    const scrollRange = instance.state().overflowAmount.y
+    const trackRange = track.clientHeight - handle.clientHeight
+    let clientY = startClientY
+    let frame = null
+
+    if (trackRange <= 0 || scrollRange <= 0) {
+      return
+    }
+
+    const applyDrag = () => {
+      frame = null
+      window.scrollTo(0, startScrollY + (clientY - startClientY) / trackRange * scrollRange)
+    }
+
+    const onPointerMove = (moveEvent) => {
+      if (moveEvent.pointerId !== pointerId) {
+        return
+      }
+
+      moveEvent.preventDefault()
+      moveEvent.stopPropagation()
+      clientY = moveEvent.clientY
+      frame ??= requestAnimationFrame(applyDrag)
+    }
+
+    const finish = (finishEvent) => {
+      if (finishEvent.pointerId !== pointerId) {
+        return
+      }
+
+      finishEvent.stopPropagation()
+      handle.removeEventListener('pointermove', onPointerMove)
+      handle.removeEventListener('pointerup', finish)
+      handle.removeEventListener('pointercancel', finish)
+
+      if (frame !== null) {
+        cancelAnimationFrame(frame)
+        applyDrag()
+      }
+    }
+
+    handle.addEventListener('pointermove', onPointerMove)
+    handle.addEventListener('pointerup', finish)
+    handle.addEventListener('pointercancel', finish)
+    handle.setPointerCapture(pointerId)
+  }
+
+  handle.addEventListener('pointerdown', onPointerDown)
+  instance.on('destroyed', () => handle.removeEventListener('pointerdown', onPointerDown))
 }
 
 /**

--- a/src/renderer/helpers/overlayScrollbars.js
+++ b/src/renderer/helpers/overlayScrollbars.js
@@ -78,7 +78,7 @@ function optimizeBodyScrollbarDrag(instance) {
     }
 
     event.preventDefault()
-    event.stopPropagation()
+    event.stopImmediatePropagation()
 
     const pointerId = event.pointerId
     const startClientY = event.clientY
@@ -94,7 +94,7 @@ function optimizeBodyScrollbarDrag(instance) {
 
     const applyDrag = () => {
       frame = null
-      window.scrollTo(0, startScrollY + (clientY - startClientY) / trackRange * scrollRange)
+      window.scrollTo(window.scrollX, startScrollY + (clientY - startClientY) / trackRange * scrollRange)
     }
 
     const onPointerMove = (moveEvent) => {
@@ -130,8 +130,8 @@ function optimizeBodyScrollbarDrag(instance) {
     handle.setPointerCapture(pointerId)
   }
 
-  handle.addEventListener('pointerdown', onPointerDown)
-  instance.on('destroyed', () => handle.removeEventListener('pointerdown', onPointerDown))
+  handle.addEventListener('pointerdown', onPointerDown, true)
+  instance.on('destroyed', () => handle.removeEventListener('pointerdown', onPointerDown, true))
 }
 
 /**


### PR DESCRIPTION
Follow-up to #306.

## What changed

- prevent unnecessary and stale scrollbars in prompts, chapters, and collapsed descriptions
- use one full-height overlay scrollbar for fullscreen metadata and SponsorBlock docks
- make fullscreen metadata, comments, transcript, SponsorBlock, and chapters scrollbars consistently reach the dock edge
- preserve automatic comment pagination in short fullscreen docks
- keep search suggestion remove controls and hover colors visually continuous beneath the overlay scrollbar
- coalesce page scrollbar drag updates to animation frames and skip unnecessary flow-style reads for smoother long feeds
- add focused regression coverage for prompt overflow, search suggestion layout, page dragging, and fullscreen dock scrolling

## Root causes

Several nested containers retained their pre-overlay scrolling behavior, creating competing native and overlay scroll areas. Teleported fullscreen cards also kept watch-page sizing and margins, while zero-height comment pagination sentinels could fall exactly on a short dock's clipped boundary. The page scrollbar additionally applied every high-frequency pointer move directly while dragging long feeds.

## Impact

Fullscreen docks now have predictable single-scroll-region behavior, short comment docks continue auto-loading, compact prompts no longer show forced scrollbars, search suggestions retain a continuous hover treatment, and dragging long page scrollbars is smoother.

## Validation

- `pnpm lint`
- `pnpm test:unit` — 61 passed
- targeted offline Playwright overlay/search tests — 15 passed
- targeted live Playwright metadata/comments/SponsorBlock dock tests — 3 passed
- short fullscreen comments auto-load regression — passed
- full offline Playwright suite — 150 passed; one concurrent Electron launch crashed with `SIGSEGV`, and its isolated rerun passed