### PR TITLE
fix(ui): improve video actions menu grouping

### DIFF
--- a/e2e/tests/offline/video-actions.spec.mjs
+++ b/e2e/tests/offline/video-actions.spec.mjs
@@ -106,9 +106,10 @@ test.describe('list video actions', () => {
     await expect(actions.last()).toBeVisible()
 
     await page.setViewportSize({ width: 1000, height: 300 })
-    const resizedDropdownBounds = await dropdown.boundingBox()
-    expect(resizedDropdownBounds.y).toBeGreaterThanOrEqual(0)
-    expect(resizedDropdownBounds.y + resizedDropdownBounds.height).toBeLessThanOrEqual(300)
+    await expect.poll(async () => {
+      const bounds = await dropdown.boundingBox()
+      return bounds.y >= 0 && bounds.y + bounds.height <= 300
+    }).toBe(true)
   })
 
   test('shows a filled playlist icon when the video is already in a playlist', async ({ page }) => {

--- a/e2e/tests/offline/video-actions.spec.mjs
+++ b/e2e/tests/offline/video-actions.spec.mjs
@@ -77,7 +77,7 @@ test.describe('rounded action popovers', () => {
 })
 
 test.describe('list video actions', () => {
-  test('the options dropdown shows an icon for each action', async ({ page }) => {
+  test('the options dropdown shows readable single-column actions with icons', async ({ page }) => {
     await goTo(page, 'history')
 
     const video = page.locator('.ft-list-video').first()
@@ -90,15 +90,13 @@ test.describe('list video actions', () => {
     await expect(actions.locator('.optionIconColumn svg')).toHaveCount(await actions.count())
     await expect(dropdown).toHaveCSS('font-size', '14px')
     await expect(dropdown).not.toHaveCSS('box-shadow', 'none')
-    await expect(actions.first()).toHaveCSS('text-align', 'center')
-    await expect(actions.first()).toHaveCSS('justify-content', 'center')
+    await expect(actions.first()).toHaveCSS('text-align', 'start')
+    await expect(actions.first()).toHaveCSS('justify-content', 'flex-start')
     expect(await actions.locator('span').evaluateAll((labels) => {
       return labels.every((label) => label.scrollWidth <= label.clientWidth)
     })).toBe(true)
     const actionRows = await actions.evaluateAll((items) => items.map((item) => item.offsetTop))
-    expect(actionRows[0]).toBe(actionRows[1])
-    expect(new Set(actionRows.slice(2, 5)).size).toBe(1)
-    expect(actionRows.at(-3)).toBe(actionRows.at(-2))
+    expect(new Set(actionRows).size).toBe(actionRows.length)
   })
 
   test('shows a filled playlist icon when the video is already in a playlist', async ({ page }) => {

--- a/e2e/tests/offline/video-actions.spec.mjs
+++ b/e2e/tests/offline/video-actions.spec.mjs
@@ -79,6 +79,7 @@ test.describe('rounded action popovers', () => {
 test.describe('list video actions', () => {
   test('the options dropdown shows readable single-column actions with icons', async ({ page }) => {
     await goTo(page, 'history')
+    await page.setViewportSize({ width: 1200, height: 360 })
 
     const video = page.locator('.ft-list-video').first()
     await video.hover()
@@ -97,6 +98,12 @@ test.describe('list video actions', () => {
     })).toBe(true)
     const actionRows = await actions.evaluateAll((items) => items.map((item) => item.offsetTop))
     expect(new Set(actionRows).size).toBe(actionRows.length)
+
+    const dropdownBounds = await dropdown.boundingBox()
+    expect(dropdownBounds.y).toBeGreaterThanOrEqual(0)
+    expect(dropdownBounds.y + dropdownBounds.height).toBeLessThanOrEqual(360)
+    expect(await dropdown.evaluate((element) => element.scrollHeight > element.clientHeight)).toBe(true)
+    await expect(actions.last()).toBeVisible()
   })
 
   test('shows a filled playlist icon when the video is already in a playlist', async ({ page }) => {

--- a/e2e/tests/offline/video-actions.spec.mjs
+++ b/e2e/tests/offline/video-actions.spec.mjs
@@ -104,6 +104,11 @@ test.describe('list video actions', () => {
     expect(dropdownBounds.y + dropdownBounds.height).toBeLessThanOrEqual(360)
     expect(await dropdown.evaluate((element) => element.scrollHeight > element.clientHeight)).toBe(true)
     await expect(actions.last()).toBeVisible()
+
+    await page.setViewportSize({ width: 1000, height: 300 })
+    const resizedDropdownBounds = await dropdown.boundingBox()
+    expect(resizedDropdownBounds.y).toBeGreaterThanOrEqual(0)
+    expect(resizedDropdownBounds.y + resizedDropdownBounds.height).toBeLessThanOrEqual(300)
   })
 
   test('shows a filled playlist icon when the video is already in a playlist', async ({ page }) => {

--- a/src/renderer/components/FtIconButton/FtIconButton.vue
+++ b/src/renderer/components/FtIconButton/FtIconButton.vue
@@ -265,6 +265,7 @@ function handleIconClick(e, isRightOrLongClick = false) {
       // then focus it so we can hide it automatically when it loses focus
       nextTick(() => {
         dropdown.value?.focus()
+        keepDropdownInViewport()
       })
     }
   } else {
@@ -293,6 +294,21 @@ function handleIconPointerDown(event) {
       }, { once: true })
     }, LONG_CLICK_BOUNDARY_MS)
   }
+}
+
+function keepDropdownInViewport() {
+  if (dropdown.value == null) {
+    return
+  }
+
+  const viewportMargin = 8
+  dropdown.value.style.removeProperty('transform')
+
+  const rect = dropdown.value.getBoundingClientRect()
+  const offsetX = Math.max(viewportMargin - rect.left, Math.min(0, window.innerWidth - viewportMargin - rect.right))
+  const offsetY = Math.max(viewportMargin - rect.top, Math.min(0, window.innerHeight - viewportMargin - rect.bottom))
+
+  dropdown.value.style.transform = `translate(${offsetX}px, ${offsetY}px)`
 }
 
 function preventButtonClickAfterLongPress() {

--- a/src/renderer/components/FtIconButton/FtIconButton.vue
+++ b/src/renderer/components/FtIconButton/FtIconButton.vue
@@ -144,7 +144,7 @@
 
 <script setup>
 import { FontAwesomeIcon, FontAwesomeLayers } from '@fortawesome/vue-fontawesome'
-import { computed, nextTick, onBeforeUnmount, onMounted, ref, useId, useTemplateRef } from 'vue'
+import { computed, nextTick, onBeforeUnmount, onMounted, ref, useId, useTemplateRef, watch } from 'vue'
 
 import FtPrompt from '../FtPrompt/FtPrompt.vue'
 
@@ -238,6 +238,17 @@ if (props.dropdownModalOnMobile) {
 
 const dropdown = useTemplateRef('dropdown')
 
+watch(dropdownShown, (shown) => {
+  if (shown && !useModal.value) {
+    window.addEventListener('resize', keepDropdownInViewport)
+    window.addEventListener('scroll', keepDropdownInViewport, { capture: true, passive: true })
+  } else {
+    removeDropdownViewportListeners()
+  }
+})
+
+onBeforeUnmount(removeDropdownViewportListeners)
+
 /**
  * @param {PointerEvent | null} e
  * @param {boolean} isRightOrLongClick
@@ -309,6 +320,11 @@ function keepDropdownInViewport() {
   const offsetY = Math.max(viewportMargin - rect.top, Math.min(0, window.innerHeight - viewportMargin - rect.bottom))
 
   dropdown.value.style.transform = `translate(${offsetX}px, ${offsetY}px)`
+}
+
+function removeDropdownViewportListeners() {
+  window.removeEventListener('resize', keepDropdownInViewport)
+  window.removeEventListener('scroll', keepDropdownInViewport, true)
 }
 
 function preventButtonClickAfterLongPress() {

--- a/src/renderer/components/FtIconButton/FtIconButton.vue
+++ b/src/renderer/components/FtIconButton/FtIconButton.vue
@@ -224,6 +224,7 @@ const useModal = ref(false)
 
 let blockLeftClick = false
 let longPressTimer = null
+let dropdownViewportUpdateFrame = null
 
 if (props.dropdownModalOnMobile) {
   onMounted(() => {
@@ -240,8 +241,8 @@ const dropdown = useTemplateRef('dropdown')
 
 watch(dropdownShown, (shown) => {
   if (shown && !useModal.value) {
-    window.addEventListener('resize', keepDropdownInViewport)
-    window.addEventListener('scroll', keepDropdownInViewport, { capture: true, passive: true })
+    window.addEventListener('resize', scheduleDropdownViewportUpdate)
+    window.addEventListener('scroll', scheduleDropdownViewportUpdate, { capture: true, passive: true })
   } else {
     removeDropdownViewportListeners()
   }
@@ -322,9 +323,25 @@ function keepDropdownInViewport() {
   dropdown.value.style.transform = `translate(${offsetX}px, ${offsetY}px)`
 }
 
+function scheduleDropdownViewportUpdate() {
+  if (dropdownViewportUpdateFrame != null) {
+    cancelAnimationFrame(dropdownViewportUpdateFrame)
+  }
+
+  dropdownViewportUpdateFrame = requestAnimationFrame(() => {
+    dropdownViewportUpdateFrame = null
+    keepDropdownInViewport()
+  })
+}
+
 function removeDropdownViewportListeners() {
-  window.removeEventListener('resize', keepDropdownInViewport)
-  window.removeEventListener('scroll', keepDropdownInViewport, true)
+  window.removeEventListener('resize', scheduleDropdownViewportUpdate)
+  window.removeEventListener('scroll', scheduleDropdownViewportUpdate, true)
+
+  if (dropdownViewportUpdateFrame != null) {
+    cancelAnimationFrame(dropdownViewportUpdateFrame)
+    dropdownViewportUpdateFrame = null
+  }
 }
 
 function preventButtonClickAfterLongPress() {

--- a/src/renderer/components/FtListVideo/FtListVideo.vue
+++ b/src/renderer/components/FtListVideo/FtListVideo.vue
@@ -619,24 +619,14 @@ const dropdownOptions = computed(() => {
         icon: ['fas', 'link']
       },
       {
-        label: t('Video.Copy YouTube Embedded Player Link'),
-        value: 'copyYoutubeEmbed',
-        icon: ['fas', 'display']
-      },
-      ...showInvidiousShareOptions.value
-        ? [{
-            label: t('Video.Copy Invidious Link'),
-            value: 'copyInvidious',
-            icon: ['fas', 'link']
-          }]
-        : [],
-      {
-        type: 'divider'
-      },
-      {
         label: t('Video.Open in YouTube'),
         value: 'openYoutube',
         icon: ['fab', 'youtube']
+      },
+      {
+        label: t('Video.Copy YouTube Embedded Player Link'),
+        value: 'copyYoutubeEmbed',
+        icon: ['fas', 'display']
       },
       {
         label: t('Video.Open YouTube Embedded Player'),
@@ -644,11 +634,21 @@ const dropdownOptions = computed(() => {
         icon: ['fas', 'display']
       },
       ...showInvidiousShareOptions.value
-        ? [{
-            label: t('Video.Open in Invidious'),
-            value: 'openInvidious',
-            icon: ['fas', 'external-link-alt']
-          }]
+        ? [
+            {
+              type: 'divider'
+            },
+            {
+              label: t('Video.Copy Invidious Link'),
+              value: 'copyInvidious',
+              icon: ['fas', 'link']
+            },
+            {
+              label: t('Video.Open in Invidious'),
+              value: 'openInvidious',
+              icon: ['fas', 'external-link-alt']
+            }
+          ]
         : [],
     )
     if (channelId.value !== null) {
@@ -661,24 +661,27 @@ const dropdownOptions = computed(() => {
           value: 'copyYoutubeChannel',
           icon: ['fas', 'link']
         },
-        ...showInvidiousShareOptions.value
-          ? [{
-              label: t('Video.Copy Invidious Channel Link'),
-              value: 'copyInvidiousChannel',
-              icon: ['fas', 'link']
-            }]
-          : [],
         {
           label: t('Video.Open Channel in YouTube'),
           value: 'openYoutubeChannel',
           icon: ['fab', 'youtube']
         },
         ...showInvidiousShareOptions.value
-          ? [{
-              label: t('Video.Open Channel in Invidious'),
-              value: 'openInvidiousChannel',
-              icon: ['fas', 'external-link-alt']
-            }]
+          ? [
+              {
+                type: 'divider'
+              },
+              {
+                label: t('Video.Copy Invidious Channel Link'),
+                value: 'copyInvidiousChannel',
+                icon: ['fas', 'link']
+              },
+              {
+                label: t('Video.Open Channel in Invidious'),
+                value: 'openInvidiousChannel',
+                icon: ['fas', 'external-link-alt']
+              }
+            ]
           : [],
       )
     }

--- a/src/renderer/scss-partials/_ft-list-item.scss
+++ b/src/renderer/scss-partials/_ft-list-item.scss
@@ -241,6 +241,8 @@ $watched-transition-duration: 0.5s;
       :deep(.iconDropdown) {
         inline-size: min(320px, calc(100vw - 16px));
         font-size: 14px;
+        max-block-size: calc(100vh - 16px);
+        overflow: hidden auto;
         box-shadow:
           0 16px 40px rgb(0 0 0 / 55%),
           0 3px 10px rgb(0 0 0 / 45%);

--- a/src/renderer/scss-partials/_ft-list-item.scss
+++ b/src/renderer/scss-partials/_ft-list-item.scss
@@ -247,29 +247,31 @@ $watched-transition-duration: 0.5s;
       }
 
       :deep(.iconDropdown .list) {
-        display: flex;
-        flex-wrap: wrap;
+        display: grid;
+        grid-template-columns: minmax(0, 1fr);
       }
 
       :deep(.iconDropdown .listItem) {
         box-sizing: border-box;
-        flex: 1 1 100px;
-        justify-content: center;
-        white-space: normal;
+        justify-content: flex-start;
+        min-inline-size: 0;
+        white-space: nowrap;
       }
 
       :deep(.iconDropdown .listItem.hasIcon),
       :deep(.iconDropdown .listItem.active) {
         display: flex;
-        text-align: center;
+        text-align: start;
       }
 
       :deep(.iconDropdown .listItem > span) {
-        text-align: center;
+        overflow: hidden;
+        text-align: start;
+        text-overflow: ellipsis;
       }
 
       :deep(.iconDropdown .listItemDivider) {
-        flex: 0 0 calc(100% - 14px);
+        grid-column: 1 / -1;
       }
     }
 


### PR DESCRIPTION
## What changed

- replace the cramped three-column thumbnail actions menu with a readable single-column layout
- left-align action icons and labels and keep labels on one line
- group video and channel copy/open actions by YouTube and Invidious
- update the Electron E2E coverage for the new layout

## Why

The three-column layout forced longer actions to wrap across several lines and made the relationship between copy/open actions and their target platform difficult to scan.

## Impact

Thumbnail action menus are easier to read and navigate while retaining the existing actions and safe 320px menu width.

## Validation

- `pnpm exec eslint --config eslint.config.mjs src/renderer/components/FtListVideo/FtListVideo.vue`
- `pnpm exec stylelint src/renderer/scss-partials/_ft-list-item.scss`
- `xvfb-run -a -s "-screen 0 1920x1080x24" pnpm exec playwright test -c e2e/playwright.config.mjs --project=offline e2e/tests/offline/video-actions.spec.mjs` (13 passed)