### PR TITLE
fix(ui): keep toggle switches rounded

### DIFF
--- a/e2e/tests/offline/appearance.spec.mjs
+++ b/e2e/tests/offline/appearance.spec.mjs
@@ -65,7 +65,11 @@ test.describe('UI roundness', () => {
 
     await goTo(page, 'settings')
     const roundnessSlider = page.getByRole('slider', { name: /UI Roundness/ })
+    const toggleSwitch = page.locator('label.switch-label').first()
+    const toggleTrackRadius = () => toggleSwitch.evaluate((element) =>
+      getComputedStyle(element, '::before').borderRadius)
     await expect(roundnessSlider).toHaveValue('0')
+    expect(await toggleTrackRadius()).toBe('8px')
     await expect(page.locator('.sectionBody').first()).toHaveCSS('border-radius', '0px')
     await expect(page.getByRole('button').first()).toHaveCSS('border-radius', '0px')
 
@@ -80,6 +84,7 @@ test.describe('UI roundness', () => {
     await page.keyboard.press('Escape')
     await roundnessSlider.fill('150')
     await expect(page.locator('body')).toHaveCSS('--ui-roundness', '1.5')
+    expect(await toggleTrackRadius()).toBe('8px')
     await expect(page.locator('.sectionBody').first()).toHaveCSS('border-radius', '12px')
 
     ;({ page } = await app.relaunch())

--- a/src/renderer/components/FtToggleSwitch/FtToggleSwitch.scss
+++ b/src/renderer/components/FtToggleSwitch/FtToggleSwitch.scss
@@ -42,7 +42,7 @@
 
   &::before {
     background-color: #9e9e9e;
-    border-radius: calc(8px * var(--ui-roundness));
+    border-radius: 8px;
     block-size: 14px;
     inset-inline-start: 1px;
     inline-size: 34px;


### PR DESCRIPTION
## Summary

- keep toggle-switch tracks pill-shaped regardless of the UI roundness setting
- add regression coverage for toggle track radius at 0% and 150% UI roundness

## Root cause

The toggle track radius was multiplied by the global `--ui-roundness` value while its circular thumb remained fixed. At 0%, this produced a round thumb on a square track.

## User impact

Toggle switches retain their intended Material-style appearance at every UI roundness setting.

## Validation

- `pnpm exec stylelint src/renderer/components/FtToggleSwitch/FtToggleSwitch.scss`
- `pnpm exec eslint --config eslint.config.mjs e2e/tests/offline/appearance.spec.mjs`
- focused Electron appearance E2E test under Xvfb