### PR TITLE
fix(player): keep fullscreen metadata scrollbar interactive

### DIFF
--- a/e2e/tests/network/watch.spec.mjs
+++ b/e2e/tests/network/watch.spec.mjs
@@ -449,14 +449,20 @@ test.describe('watch page', () => {
     const scrollbar = target.locator(':scope > .os-scrollbar-vertical')
     const scrollbarBounds = await scrollbar.boundingBox()
     const targetBounds = await target.boundingBox()
-    expect(scrollbarBounds.y - targetBounds.y).toBeLessThanOrEqual(1)
+    expect(Math.abs(scrollbarBounds.y - targetBounds.y)).toBeLessThanOrEqual(1)
     expect(
-      targetBounds.y + targetBounds.height - scrollbarBounds.y - scrollbarBounds.height
+      Math.abs(
+        targetBounds.y + targetBounds.height -
+        scrollbarBounds.y - scrollbarBounds.height
+      )
     ).toBeLessThanOrEqual(1)
 
     await target.evaluate(element => {
       element.scrollTop = (element.scrollHeight - element.clientHeight) / 3
     })
+    await expect.poll(() => target.evaluate(
+      element => element.scrollTop
+    )).toBeGreaterThan(0)
     const handle = scrollbar.locator('.os-scrollbar-handle')
     await handle.hover()
   })

--- a/e2e/tests/network/watch.spec.mjs
+++ b/e2e/tests/network/watch.spec.mjs
@@ -429,12 +429,36 @@ test.describe('watch page', () => {
     await page.locator('.playerFullscreenTitleOverlay').click({ force: true })
 
     const metadata = page.locator('.fullscreenMetadataOverlay.open')
+    const target = metadata.locator('.fullscreenMetadataTarget')
     await expect(metadata).toBeVisible()
-    await expect(metadata.locator('.fullscreenMetadataTarget'))
-      .toHaveAttribute('data-overlayscrollbars-viewport')
+    await expect(target).toHaveAttribute('data-overlayscrollbars-viewport')
     await expect(metadata.locator('.os-scrollbar-vertical')).toHaveCount(1)
     await expect(metadata.locator('.descriptionScroll'))
       .not.toHaveAttribute('data-overlayscrollbars-viewport')
+
+    await metadata.locator('.description').evaluate((element) => {
+      element.textContent = Array.from(
+        { length: 100 },
+        (_, index) => `Long description line ${index + 1}`
+      ).join('\n')
+    })
+    await expect.poll(() => target.evaluate(
+      element => element.scrollHeight > element.clientHeight
+    )).toBe(true)
+
+    const scrollbar = target.locator(':scope > .os-scrollbar-vertical')
+    const scrollbarBounds = await scrollbar.boundingBox()
+    const targetBounds = await target.boundingBox()
+    expect(scrollbarBounds.y - targetBounds.y).toBeLessThanOrEqual(1)
+    expect(
+      targetBounds.y + targetBounds.height - scrollbarBounds.y - scrollbarBounds.height
+    ).toBeLessThanOrEqual(1)
+
+    await target.evaluate(element => {
+      element.scrollTop = (element.scrollHeight - element.clientHeight) / 3
+    })
+    const handle = scrollbar.locator('.os-scrollbar-handle')
+    await handle.hover()
   })
 
   test('fullscreen comments scrollbar reaches the dock bottom', async ({ page, innertube }) => {

--- a/src/renderer/components/ft-shaka-video-player/ft-shaka-video-player.css
+++ b/src/renderer/components/ft-shaka-video-player/ft-shaka-video-player.css
@@ -1480,6 +1480,7 @@
   display: flex;
   flex: 1 1 auto;
   flex-direction: column;
+  isolation: isolate;
   min-block-size: 0;
   max-inline-size: 100%;
   overflow: hidden auto;
@@ -1488,7 +1489,13 @@
   --scrollbar-color-hover: rgb(255 255 255 / 65%);
 }
 
+.fullscreenMetadataTarget > :deep(.os-scrollbar-vertical) {
+  z-index: 2;
+}
+
 .fullscreenMetadataTarget :deep(.watchVideo) {
+  position: relative;
+  z-index: 0;
   box-sizing: border-box;
   max-inline-size: 100%;
   margin: 0;

--- a/src/renderer/themes.css
+++ b/src/renderer/themes.css
@@ -2172,8 +2172,8 @@ body .os-scrollbar {
   --os-handle-interactive-area-offset: 4px;
   --os-handle-border-radius: calc(6px * var(--ui-roundness));
   --os-handle-bg: var(--scrollbar-color);
-  --os-handle-bg-hover: var(--scrollbar-color-hover);
-  --os-handle-bg-active: var(--scrollbar-color-hover);
+  --os-handle-bg-hover: color-mix(in srgb, var(--scrollbar-color) 90%, #fff);
+  --os-handle-bg-active: color-mix(in srgb, var(--scrollbar-color) 80%, #fff);
 }
 
 /* shared shimmer for skeleton loading placeholders */


### PR DESCRIPTION
Follow-up to #316.

## Summary
- keep the fullscreen video information dock on one full-height scrollbar
- layer the scrollbar above teleported metadata so its handle remains interactive
- keep dragged scrollbar handles visible in themes whose hover color matches the page background
- expand the fullscreen metadata regression coverage

## Verification
- `pnpm lint`
- `xvfb-run -a -s "-screen 0 1920x1080x24" pnpm test:e2e:network e2e/tests/network/watch.spec.mjs --grep "fullscreen metadata uses one full-dock scrollbar" --repeat-each=3`