### PR TITLE
Automate noteworthy release note highlights

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -20,6 +20,20 @@
 ## Screenshots <!-- If appropriate -->
 <!-- Please add before and after screenshots if there is a visible change. -->
 
+## Release note
+<!-- Required when the PR has the `noteworthy-for-release` label. -->
+<!-- Write one concise, user-facing highlight without a leading bullet. -->
+<!-- release-note:start -->
+
+<!-- release-note:end -->
+
+## Release note image
+<!-- Optional. Paste one Markdown image or HTML image tag here. -->
+<!-- The release notes will use an HTML image tag and limit images taller than 300 pixels. -->
+<!-- release-note-image:start -->
+
+<!-- release-note-image:end -->
+
 ## Testing
 <!-- How can reviewers verify that the PR produces correct results? -->
 <!-- Please provide instructions so that others can ensure that your pull request would produce correct results. For examples see, https://github.com/FreeTubeApp/FreeTube/pull/5743, https://github.com/FreeTubeApp/FreeTube/pull/7349, https://github.com/FreeTubeApp/FreeTube/pull/5125, https://github.com/FreeTubeApp/FreeTube/pull/7338 -->

--- a/.github/workflows/create-draft-release.yml
+++ b/.github/workflows/create-draft-release.yml
@@ -1,0 +1,64 @@
+name: Create Draft Release
+
+on:
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: New release tag (for example, v0.30.0-beta)
+        required: true
+        type: string
+      previousTag:
+        description: Previous release tag
+        required: true
+        type: string
+      target:
+        description: Target branch
+        required: true
+        default: development
+        type: string
+
+permissions: {}
+
+jobs:
+  create:
+    runs-on: ubuntu-latest
+
+    permissions:
+      contents: write
+      pull-requests: read
+
+    steps:
+    - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+      with:
+        fetch-depth: 0
+        persist-credentials: false
+        ref: ${{ inputs.target }}
+
+    - name: Generate release notes
+      env:
+        GH_TOKEN: ${{ github.token }}
+        PREVIOUS_TAG: ${{ inputs.previousTag }}
+        TARGET: ${{ inputs.target }}
+      run: node _scripts/releaseNotes.mjs generate release-notes.md
+
+    - name: Create draft release
+      env:
+        GH_TOKEN: ${{ github.token }}
+        TAG: ${{ inputs.tag }}
+        TARGET: ${{ inputs.target }}
+      run: |
+        set -euo pipefail
+
+        release_url="$(gh release create "$TAG" \
+          --draft \
+          --target "$TARGET" \
+          --title "OpenTubeX ${TAG#v}" \
+          --notes-file release-notes.md)"
+        release_id="$(gh api "repos/${GITHUB_REPOSITORY}/releases/tags/${TAG}" --jq .id)"
+
+        {
+          echo "## Draft release created"
+          echo
+          echo "- Release: ${release_url}"
+          echo "- Release ID for the Upload Release workflow: \`${release_id}\`"
+        } >> "$GITHUB_STEP_SUMMARY"

--- a/.github/workflows/create-draft-release.yml
+++ b/.github/workflows/create-draft-release.yml
@@ -34,24 +34,29 @@ jobs:
         persist-credentials: false
         ref: ${{ inputs.target }}
 
+    - name: Resolve release target
+      id: target
+      run: echo "sha=$(git rev-parse HEAD)" >> "$GITHUB_OUTPUT"
+
     - name: Generate release notes
       env:
         GH_TOKEN: ${{ github.token }}
         PREVIOUS_TAG: ${{ inputs.previousTag }}
-        TARGET: ${{ inputs.target }}
+        TARGET_BRANCH: ${{ inputs.target }}
+        TARGET_SHA: ${{ steps.target.outputs.sha }}
       run: node _scripts/releaseNotes.mjs generate release-notes.md
 
     - name: Create draft release
       env:
         GH_TOKEN: ${{ github.token }}
         TAG: ${{ inputs.tag }}
-        TARGET: ${{ inputs.target }}
+        TARGET_SHA: ${{ steps.target.outputs.sha }}
       run: |
         set -euo pipefail
 
         release_url="$(gh release create "$TAG" \
           --draft \
-          --target "$TARGET" \
+          --target "$TARGET_SHA" \
           --title "OpenTubeX ${TAG#v}" \
           --notes-file release-notes.md)"
         release_id="$(gh api "repos/${GITHUB_REPOSITORY}/releases/tags/${TAG}" --jq .id)"

--- a/.github/workflows/validate-release-note.yml
+++ b/.github/workflows/validate-release-note.yml
@@ -1,0 +1,27 @@
+name: Validate Release Note
+
+on:
+  pull_request_target:
+    types: [opened, edited, labeled, unlabeled, reopened, synchronize, ready_for_review]
+
+permissions: {}
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
+
+jobs:
+  validate-release-note:
+    name: Release Note
+    runs-on: ubuntu-latest
+
+    permissions:
+      contents: read
+
+    steps:
+    - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+      with:
+        persist-credentials: false
+
+    - name: Validate release note
+      run: node _scripts/releaseNotes.mjs validate-event "$GITHUB_EVENT_PATH"

--- a/_scripts/releaseNotes.mjs
+++ b/_scripts/releaseNotes.mjs
@@ -1,0 +1,370 @@
+import { execFileSync, spawnSync } from 'node:child_process'
+import fs from 'node:fs'
+import path from 'node:path'
+import process from 'node:process'
+import { fileURLToPath } from 'node:url'
+
+const NOTEWORTHY_LABEL = 'noteworthy-for-release'
+const RELEASE_NOTE_MARKER = 'release-note'
+const RELEASE_IMAGE_MARKER = 'release-note-image'
+const MAX_IMAGE_HEIGHT = 300
+const ALLOWED_IMAGE_HOSTS = new Set([
+  'github.com',
+  'private-user-images.githubusercontent.com',
+  'raw.githubusercontent.com',
+  'user-images.githubusercontent.com',
+])
+
+function stripComments(value) {
+  return value.replaceAll(/<!--[\s\S]*?-->/g, '').trim()
+}
+
+function extractMarkedSection(body, marker) {
+  const startMarker = `<!-- ${marker}:start -->`
+  const endMarker = `<!-- ${marker}:end -->`
+  const start = body.indexOf(startMarker)
+  const end = body.indexOf(endMarker)
+
+  if (start === -1 || end === -1 || end < start) { return null }
+
+  return stripComments(body.slice(start + startMarker.length, end))
+}
+
+function decodeHtml(value) {
+  return value
+    .replaceAll('&amp;', '&')
+    .replaceAll('&quot;', '"')
+    .replaceAll('&#39;', '\'')
+    .replaceAll('&lt;', '<')
+    .replaceAll('&gt;', '>')
+}
+
+function extractHtmlAttribute(tag, attribute) {
+  const match = tag.match(new RegExp(`\\b${attribute}\\s*=\\s*(?:"([^"]*)"|'([^']*)')`, 'i'))
+  return match?.[1] ?? match?.[2] ?? null
+}
+
+export function parseReleaseImage(section) {
+  if (!section) { return null }
+
+  const markdownImage = section.match(/!\[([^\]]*)\]\((https:\/\/[^\s)]+)(?:\s+["'][^"']*["'])?\)/)
+
+  if (markdownImage) {
+    return {
+      alt: markdownImage[1].trim(),
+      url: markdownImage[2],
+    }
+  }
+
+  const htmlImage = section.match(/<img\b[^>]*>/i)
+
+  if (!htmlImage) { throw new Error('The release note image must be a Markdown image or an <img> tag.') }
+
+  const url = extractHtmlAttribute(htmlImage[0], 'src')
+
+  if (!url) { throw new Error('The release note image is missing its src attribute.') }
+
+  return {
+    alt: decodeHtml(extractHtmlAttribute(htmlImage[0], 'alt') ?? ''),
+    url: decodeHtml(url),
+  }
+}
+
+function validateImageUrl(value) {
+  let url
+
+  try {
+    url = new URL(value)
+  } catch {
+    throw new Error('The release note image has an invalid URL.')
+  }
+
+  if (url.protocol !== 'https:' || !ALLOWED_IMAGE_HOSTS.has(url.hostname)) { throw new Error('Release note images must be hosted by GitHub.') }
+
+  return url
+}
+
+export function parseReleaseNote(body) {
+  const note = extractMarkedSection(body, RELEASE_NOTE_MARKER)
+
+  if (!note) { throw new Error('Fill in the release note section before merging this noteworthy PR.') }
+
+  const imageSection = extractMarkedSection(body, RELEASE_IMAGE_MARKER)
+  const image = parseReleaseImage(imageSection)
+
+  if (image) { validateImageUrl(image.url) }
+
+  return { image, note }
+}
+
+export function validatePullRequestEvent(event) {
+  const pullRequest = event.pull_request
+
+  if (!pullRequest) { throw new Error('The event does not contain a pull request.') }
+
+  const isNoteworthy = pullRequest.labels.some(({ name }) => name === NOTEWORTHY_LABEL)
+
+  if (!isNoteworthy) { return null }
+
+  return parseReleaseNote(pullRequest.body ?? '')
+}
+
+function readUInt24LE(buffer, offset) {
+  return buffer[offset] | (buffer[offset + 1] << 8) | (buffer[offset + 2] << 16)
+}
+
+function probeJpeg(buffer) {
+  let offset = 2
+
+  while (offset + 9 < buffer.length) {
+    if (buffer[offset] !== 0xff) {
+      offset += 1
+      continue
+    }
+
+    const marker = buffer[offset + 1]
+    const isStartOfFrame = [
+      0xc0, 0xc1, 0xc2, 0xc3, 0xc5, 0xc6, 0xc7,
+      0xc9, 0xca, 0xcb, 0xcd, 0xce, 0xcf,
+    ].includes(marker)
+
+    if (isStartOfFrame) {
+      return {
+        height: buffer.readUInt16BE(offset + 5),
+        width: buffer.readUInt16BE(offset + 7),
+      }
+    }
+
+    if (marker === 0xd8 || marker === 0xd9 || marker === 0x01) {
+      offset += 2
+      continue
+    }
+
+    const length = buffer.readUInt16BE(offset + 2)
+
+    if (length < 2) { break }
+
+    offset += length + 2
+  }
+
+  return null
+}
+
+function probeWebp(buffer) {
+  const type = buffer.toString('ascii', 12, 16)
+
+  if (type === 'VP8X' && buffer.length >= 30) {
+    return {
+      height: readUInt24LE(buffer, 27) + 1,
+      width: readUInt24LE(buffer, 24) + 1,
+    }
+  }
+
+  if (type === 'VP8 ' && buffer.length >= 30) {
+    return {
+      height: buffer.readUInt16LE(28) & 0x3fff,
+      width: buffer.readUInt16LE(26) & 0x3fff,
+    }
+  }
+
+  if (type === 'VP8L' && buffer.length >= 25) {
+    const bits = buffer.readUInt32LE(21)
+
+    return {
+      height: ((bits >> 14) & 0x3fff) + 1,
+      width: (bits & 0x3fff) + 1,
+    }
+  }
+
+  return null
+}
+
+export function probeImageSize(buffer) {
+  if (buffer.length >= 24 && buffer.subarray(0, 8).equals(Buffer.from('\x89PNG\r\n\x1a\n', 'binary'))) {
+    return {
+      height: buffer.readUInt32BE(20),
+      width: buffer.readUInt32BE(16),
+    }
+  }
+
+  if (buffer.length >= 10 && ['GIF87a', 'GIF89a'].includes(buffer.toString('ascii', 0, 6))) {
+    return {
+      height: buffer.readUInt16LE(8),
+      width: buffer.readUInt16LE(6),
+    }
+  }
+
+  if (buffer.length >= 12 && buffer[0] === 0xff && buffer[1] === 0xd8) { return probeJpeg(buffer) }
+
+  if (
+    buffer.length >= 30 &&
+    buffer.toString('ascii', 0, 4) === 'RIFF' &&
+    buffer.toString('ascii', 8, 12) === 'WEBP'
+  ) {
+    return probeWebp(buffer)
+  }
+
+  return null
+}
+
+async function downloadImage(url) {
+  const response = await fetch(url, {
+    headers: {
+      Accept: 'image/*',
+      'User-Agent': 'OpenTubeX-release-notes',
+    },
+    redirect: 'follow',
+  })
+
+  if (!response.ok) { throw new Error(`Could not download release note image (${response.status}).`) }
+
+  const finalUrl = validateImageUrl(response.url)
+
+  if (!ALLOWED_IMAGE_HOSTS.has(finalUrl.hostname)) { throw new Error('The release note image redirected outside GitHub.') }
+
+  return Buffer.from(await response.arrayBuffer())
+}
+
+function escapeHtmlAttribute(value) {
+  return value
+    .replaceAll('&', '&amp;')
+    .replaceAll('"', '&quot;')
+    .replaceAll('<', '&lt;')
+    .replaceAll('>', '&gt;')
+}
+
+export async function normalizeReleaseImage(image, fallbackAlt, loadImage = downloadImage) {
+  const url = validateImageUrl(image.url)
+  const buffer = await loadImage(url)
+  const size = probeImageSize(buffer)
+
+  if (!size) { throw new Error(`Could not determine the dimensions of ${url}.`) }
+
+  const alt = image.alt || fallbackAlt
+  const height = size.height > MAX_IMAGE_HEIGHT ? ` height="${MAX_IMAGE_HEIGHT}"` : ''
+
+  return `<img src="${escapeHtmlAttribute(url.href)}" alt="${escapeHtmlAttribute(alt)}"${height}>`
+}
+
+function gitIsAncestor(ancestor, descendant) {
+  const result = spawnSync('git', ['merge-base', '--is-ancestor', ancestor, descendant], {
+    stdio: 'ignore',
+  })
+
+  if (result.status === 0) { return true }
+
+  if (result.status === 1) { return false }
+
+  throw new Error(`Could not compare Git commits ${ancestor} and ${descendant}.`)
+}
+
+export function selectPullRequests(pullRequests, previousTag, target) {
+  if (!gitIsAncestor(previousTag, target)) { throw new Error(`${previousTag} is not an ancestor of ${target}.`) }
+
+  return pullRequests
+    .filter(({ mergeCommit }) => {
+      const commit = mergeCommit?.oid
+
+      return commit &&
+        gitIsAncestor(commit, target) &&
+        !gitIsAncestor(commit, previousTag)
+    })
+    .sort((left, right) => left.mergedAt.localeCompare(right.mergedAt))
+}
+
+function listNoteworthyPullRequests(repository, target) {
+  const output = execFileSync('gh', [
+    'pr',
+    'list',
+    '--repo',
+    repository,
+    '--state',
+    'merged',
+    '--base',
+    target,
+    '--label',
+    NOTEWORTHY_LABEL,
+    '--limit',
+    '1000',
+    '--json',
+    'body,mergeCommit,mergedAt,number,title,url',
+  ], { encoding: 'utf8' })
+
+  return JSON.parse(output)
+}
+
+function indentContinuationLines(value) {
+  return value.split('\n').map((line, index) => index === 0 ? line : `  ${line}`).join('\n')
+}
+
+export async function renderReleaseNotes(pullRequests, loadImage = downloadImage) {
+  if (pullRequests.length === 0) { throw new Error('No noteworthy pull requests were found between the selected refs.') }
+
+  const highlights = []
+
+  for (const pullRequest of pullRequests) {
+    let parsed
+
+    try {
+      parsed = parseReleaseNote(pullRequest.body ?? '')
+    } catch (error) {
+      throw new Error(`PR #${pullRequest.number}: ${error.message}`, { cause: error })
+    }
+
+    let highlight = `- ${indentContinuationLines(parsed.note)}`
+
+    if (parsed.image) {
+      try {
+        highlight += `\n  ${await normalizeReleaseImage(parsed.image, pullRequest.title, loadImage)}`
+      } catch (error) {
+        throw new Error(`PR #${pullRequest.number}: ${error.message}`, { cause: error })
+      }
+    }
+
+    highlights.push(highlight)
+  }
+
+  return `# Highlights\n\n${highlights.join('\n\n')}\n`
+}
+
+async function validateEvent(eventPath) {
+  const event = JSON.parse(fs.readFileSync(eventPath, 'utf8'))
+  const releaseNote = validatePullRequestEvent(event)
+
+  if (releaseNote) { console.log('Release note is valid.') } else { console.log(`PR does not have the ${NOTEWORTHY_LABEL} label.`) }
+}
+
+async function generate(outputPath) {
+  const repository = process.env.GITHUB_REPOSITORY
+  const previousTag = process.env.PREVIOUS_TAG
+  const target = process.env.TARGET
+
+  if (!repository || !previousTag || !target) { throw new Error('GITHUB_REPOSITORY, PREVIOUS_TAG, and TARGET are required.') }
+
+  const pullRequests = listNoteworthyPullRequests(repository, target)
+  const selectedPullRequests = selectPullRequests(pullRequests, previousTag, target)
+  const releaseNotes = await renderReleaseNotes(selectedPullRequests)
+
+  fs.writeFileSync(outputPath, releaseNotes)
+  console.log(`Wrote ${selectedPullRequests.length} highlights to ${outputPath}.`)
+}
+
+async function main() {
+  const [command, argument] = process.argv.slice(2)
+
+  if (command === 'validate-event' && argument) { return validateEvent(argument) }
+
+  if (command === 'generate' && argument) { return generate(argument) }
+
+  throw new Error('Usage: releaseNotes.mjs <validate-event EVENT_PATH | generate OUTPUT_PATH>')
+}
+
+const isMainModule = process.argv[1] &&
+  path.resolve(process.argv[1]) === fileURLToPath(import.meta.url)
+
+if (isMainModule) {
+  main().catch((error) => {
+    console.error(error.message)
+    process.exitCode = 1
+  })
+}

--- a/_scripts/releaseNotes.mjs
+++ b/_scripts/releaseNotes.mjs
@@ -15,10 +15,6 @@ const ALLOWED_IMAGE_HOSTS = new Set([
   'user-images.githubusercontent.com',
 ])
 
-function stripComments(value) {
-  return value.replaceAll(/<!--[\s\S]*?-->/g, '').trim()
-}
-
 function extractMarkedSection(body, marker) {
   const startMarker = `<!-- ${marker}:start -->`
   const endMarker = `<!-- ${marker}:end -->`
@@ -27,16 +23,19 @@ function extractMarkedSection(body, marker) {
 
   if (start === -1 || end === -1 || end < start) { return null }
 
-  return stripComments(body.slice(start + startMarker.length, end))
+  return body.slice(start + startMarker.length, end).trim()
 }
 
 function decodeHtml(value) {
-  return value
-    .replaceAll('&amp;', '&')
-    .replaceAll('&quot;', '"')
-    .replaceAll('&#39;', '\'')
-    .replaceAll('&lt;', '<')
-    .replaceAll('&gt;', '>')
+  const entities = {
+    '#39': '\'',
+    amp: '&',
+    gt: '>',
+    lt: '<',
+    quot: '"',
+  }
+
+  return value.replaceAll(/&(#39|amp|gt|lt|quot);/g, (entity, name) => entities[name])
 }
 
 function extractHtmlAttribute(tag, attribute) {

--- a/_scripts/releaseNotes.mjs
+++ b/_scripts/releaseNotes.mjs
@@ -8,6 +8,7 @@ const NOTEWORTHY_LABEL = 'noteworthy-for-release'
 const RELEASE_NOTE_MARKER = 'release-note'
 const RELEASE_IMAGE_MARKER = 'release-note-image'
 const MAX_IMAGE_HEIGHT = 300
+const IMAGE_DOWNLOAD_TIMEOUT_MS = 30_000
 const ALLOWED_IMAGE_HOSTS = new Set([
   'github.com',
   'private-user-images.githubusercontent.com',
@@ -43,7 +44,7 @@ function decodeHtml(value) {
 }
 
 function extractHtmlAttribute(tag, attribute) {
-  const match = tag.match(new RegExp(`\\b${attribute}\\s*=\\s*(?:"([^"]*)"|'([^']*)')`, 'i'))
+  const match = tag.match(new RegExp(`(?:^|\\s)${attribute}\\s*=\\s*(?:"([^"]*)"|'([^']*)')`, 'i'))
   return match?.[1] ?? match?.[2] ?? null
 }
 
@@ -221,6 +222,7 @@ async function downloadImage(url) {
       'User-Agent': 'OpenTubeX-release-notes',
     },
     redirect: 'follow',
+    signal: AbortSignal.timeout(IMAGE_DOWNLOAD_TIMEOUT_MS),
   })
 
   if (!response.ok) { throw new Error(`Could not download release note image (${response.status}).`) }
@@ -342,12 +344,15 @@ async function validateEvent(eventPath) {
 async function generate(outputPath) {
   const repository = process.env.GITHUB_REPOSITORY
   const previousTag = process.env.PREVIOUS_TAG
-  const target = process.env.TARGET
+  const targetBranch = process.env.TARGET_BRANCH
+  const targetSha = process.env.TARGET_SHA
 
-  if (!repository || !previousTag || !target) { throw new Error('GITHUB_REPOSITORY, PREVIOUS_TAG, and TARGET are required.') }
+  if (!repository || !previousTag || !targetBranch || !targetSha) {
+    throw new Error('GITHUB_REPOSITORY, PREVIOUS_TAG, TARGET_BRANCH, and TARGET_SHA are required.')
+  }
 
-  const pullRequests = listNoteworthyPullRequests(repository, target)
-  const selectedPullRequests = selectPullRequests(pullRequests, previousTag, target)
+  const pullRequests = listNoteworthyPullRequests(repository, targetBranch)
+  const selectedPullRequests = selectPullRequests(pullRequests, previousTag, targetSha)
   const releaseNotes = await renderReleaseNotes(selectedPullRequests)
 
   fs.writeFileSync(outputPath, releaseNotes)

--- a/_scripts/releaseNotes.mjs
+++ b/_scripts/releaseNotes.mjs
@@ -14,6 +14,10 @@ const ALLOWED_IMAGE_HOSTS = new Set([
   'raw.githubusercontent.com',
   'user-images.githubusercontent.com',
 ])
+const ALLOWED_IMAGE_DOWNLOAD_HOSTS = new Set([
+  ...ALLOWED_IMAGE_HOSTS,
+  'github-production-user-asset-6210df.s3.amazonaws.com',
+])
 
 function extractMarkedSection(body, marker) {
   const startMarker = `<!-- ${marker}:start -->`
@@ -69,7 +73,7 @@ export function parseReleaseImage(section) {
   }
 }
 
-function validateImageUrl(value) {
+function validateImageUrl(value, allowedHosts = ALLOWED_IMAGE_HOSTS) {
   let url
 
   try {
@@ -78,9 +82,13 @@ function validateImageUrl(value) {
     throw new Error('The release note image has an invalid URL.')
   }
 
-  if (url.protocol !== 'https:' || !ALLOWED_IMAGE_HOSTS.has(url.hostname)) { throw new Error('Release note images must be hosted by GitHub.') }
+  if (url.protocol !== 'https:' || !allowedHosts.has(url.hostname)) { throw new Error('Release note images must be hosted by GitHub.') }
 
   return url
+}
+
+export function validateDownloadedImageUrl(value) {
+  return validateImageUrl(value, ALLOWED_IMAGE_DOWNLOAD_HOSTS)
 }
 
 export function parseReleaseNote(body) {
@@ -217,9 +225,7 @@ async function downloadImage(url) {
 
   if (!response.ok) { throw new Error(`Could not download release note image (${response.status}).`) }
 
-  const finalUrl = validateImageUrl(response.url)
-
-  if (!ALLOWED_IMAGE_HOSTS.has(finalUrl.hostname)) { throw new Error('The release note image redirected outside GitHub.') }
+  validateDownloadedImageUrl(response.url)
 
   return Buffer.from(await response.arrayBuffer())
 }

--- a/tests/unit/release-notes.test.mjs
+++ b/tests/unit/release-notes.test.mjs
@@ -1,0 +1,122 @@
+import assert from 'node:assert/strict'
+import test from 'node:test'
+
+import {
+  normalizeReleaseImage,
+  parseReleaseNote,
+  probeImageSize,
+  renderReleaseNotes,
+  validatePullRequestEvent,
+} from '../../_scripts/releaseNotes.mjs'
+
+const NOTE_MARKERS = `
+<!-- release-note:start -->
+Adds a compact player.
+<!-- release-note:end -->
+`
+
+function png(width, height) {
+  const buffer = Buffer.alloc(24)
+
+  Buffer.from('\x89PNG\r\n\x1a\n', 'binary').copy(buffer)
+  buffer.writeUInt32BE(width, 16)
+  buffer.writeUInt32BE(height, 20)
+
+  return buffer
+}
+
+test('release notes are required only for noteworthy pull requests', () => {
+  assert.equal(validatePullRequestEvent({
+    pull_request: {
+      body: '',
+      labels: [],
+    },
+  }), null)
+
+  assert.throws(() => validatePullRequestEvent({
+    pull_request: {
+      body: '',
+      labels: [{ name: 'noteworthy-for-release' }],
+    },
+  }), /Fill in the release note section/)
+})
+
+test('a release note and optional Markdown image are parsed', () => {
+  const result = parseReleaseNote(`
+${NOTE_MARKERS}
+<!-- release-note-image:start -->
+![Compact player](https://github.com/user-attachments/assets/example)
+<!-- release-note-image:end -->
+`)
+
+  assert.deepEqual(result, {
+    image: {
+      alt: 'Compact player',
+      url: 'https://github.com/user-attachments/assets/example',
+    },
+    note: 'Adds a compact player.',
+  })
+})
+
+test('image dimensions are read from PNG data', () => {
+  assert.deepEqual(probeImageSize(png(640, 480)), {
+    height: 480,
+    width: 640,
+  })
+})
+
+test('images taller than 300 pixels receive only a height attribute', async () => {
+  const result = await normalizeReleaseImage({
+    alt: 'Compact player',
+    url: 'https://github.com/user-attachments/assets/example',
+  }, 'Fallback', async () => png(800, 301))
+
+  assert.equal(
+    result,
+    '<img src="https://github.com/user-attachments/assets/example" alt="Compact player" height="300">',
+  )
+})
+
+test('images up to 300 pixels have no dimensions', async () => {
+  const result = await normalizeReleaseImage({
+    alt: '',
+    url: 'https://github.com/user-attachments/assets/example',
+  }, 'Compact player', async () => png(800, 300))
+
+  assert.equal(
+    result,
+    '<img src="https://github.com/user-attachments/assets/example" alt="Compact player">',
+  )
+})
+
+test('release notes render as highlights with normalized image tags', async () => {
+  const result = await renderReleaseNotes([
+    {
+      body: `
+${NOTE_MARKERS}
+<!-- release-note-image:start -->
+<img src="https://github.com/user-attachments/assets/example" alt="Screenshot" width="800" height="600">
+<!-- release-note-image:end -->
+`,
+      number: 42,
+      title: 'Compact player',
+    },
+    {
+      body: `
+<!-- release-note:start -->
+Adds keyboard shortcuts.
+<!-- release-note:end -->
+`,
+      number: 43,
+      title: 'Keyboard shortcuts',
+    },
+  ], async () => png(800, 600))
+
+  assert.equal(result, `# Highlights
+
+- Adds a compact player.
+  <img src="https://github.com/user-attachments/assets/example" alt="Screenshot" height="300">
+
+- Adds keyboard shortcuts.
+`)
+})

--- a/tests/unit/release-notes.test.mjs
+++ b/tests/unit/release-notes.test.mjs
@@ -58,6 +58,20 @@ ${NOTE_MARKERS}
   })
 })
 
+test('HTML entities in image attributes are decoded only once', () => {
+  const result = parseReleaseNote(`
+${NOTE_MARKERS}
+<!-- release-note-image:start -->
+<img src="https://github.com/user-attachments/assets/example?name=a&amp;amp;b" alt="A &amp; B">
+<!-- release-note-image:end -->
+`)
+
+  assert.deepEqual(result.image, {
+    alt: 'A & B',
+    url: 'https://github.com/user-attachments/assets/example?name=a&amp;b',
+  })
+})
+
 test('image dimensions are read from PNG data', () => {
   assert.deepEqual(probeImageSize(png(640, 480)), {
     height: 480,

--- a/tests/unit/release-notes.test.mjs
+++ b/tests/unit/release-notes.test.mjs
@@ -26,6 +26,40 @@ function png(width, height) {
   return buffer
 }
 
+function jpeg(width, height) {
+  const buffer = Buffer.alloc(18)
+
+  buffer.set([0xff, 0xd8, 0xff, 0xe0])
+  buffer.writeUInt16BE(4, 4)
+  buffer.set([0xff, 0xc0], 8)
+  buffer.writeUInt16BE(8, 10)
+  buffer[12] = 8
+  buffer.writeUInt16BE(height, 13)
+  buffer.writeUInt16BE(width, 15)
+
+  return buffer
+}
+
+function webp(type, width, height) {
+  const buffer = Buffer.alloc(30)
+
+  buffer.write('RIFF', 0)
+  buffer.write('WEBP', 8)
+  buffer.write(type, 12)
+
+  if (type === 'VP8X') {
+    buffer.writeUIntLE(width - 1, 24, 3)
+    buffer.writeUIntLE(height - 1, 27, 3)
+  } else if (type === 'VP8 ') {
+    buffer.writeUInt16LE(width, 26)
+    buffer.writeUInt16LE(height, 28)
+  } else {
+    buffer.writeUInt32LE((width - 1) | ((height - 1) << 14), 21)
+  }
+
+  return buffer
+}
+
 test('release notes are required only for noteworthy pull requests', () => {
   assert.equal(validatePullRequestEvent({
     pull_request: {
@@ -73,6 +107,38 @@ ${NOTE_MARKERS}
   })
 })
 
+test('HTML image parsing ignores data attributes', () => {
+  const result = parseReleaseNote(`
+${NOTE_MARKERS}
+<!-- release-note-image:start -->
+<img data-src="https://github.com/user-attachments/assets/wrong" src="https://github.com/user-attachments/assets/right" data-alt="Wrong" alt="Right">
+<!-- release-note-image:end -->
+`)
+
+  assert.deepEqual(result.image, {
+    alt: 'Right',
+    url: 'https://github.com/user-attachments/assets/right',
+  })
+})
+
+test('initial image URLs must use HTTPS and a GitHub host', () => {
+  const releaseNoteWithImage = (url) => `
+${NOTE_MARKERS}
+<!-- release-note-image:start -->
+<img src="${url}" alt="Screenshot">
+<!-- release-note-image:end -->
+`
+
+  assert.throws(
+    () => parseReleaseNote(releaseNoteWithImage('http://github.com/user-attachments/assets/example')),
+    /must be hosted by GitHub/,
+  )
+  assert.throws(
+    () => parseReleaseNote(releaseNoteWithImage('https://example.com/image.png')),
+    /must be hosted by GitHub/,
+  )
+})
+
 test('GitHub user attachment storage redirects are accepted narrowly', () => {
   assert.equal(
     validateDownloadedImageUrl('https://github-production-user-asset-6210df.s3.amazonaws.com/image.png').hostname,
@@ -89,6 +155,22 @@ test('image dimensions are read from PNG data', () => {
     height: 480,
     width: 640,
   })
+})
+
+test('image dimensions are read from JPEG data after metadata', () => {
+  assert.deepEqual(probeImageSize(jpeg(1024, 768)), {
+    height: 768,
+    width: 1024,
+  })
+})
+
+test('image dimensions are read from WebP variants', () => {
+  for (const type of ['VP8X', 'VP8 ', 'VP8L']) {
+    assert.deepEqual(probeImageSize(webp(type, 640, 480)), {
+      height: 480,
+      width: 640,
+    })
+  }
 })
 
 test('images taller than 300 pixels receive only a height attribute', async () => {

--- a/tests/unit/release-notes.test.mjs
+++ b/tests/unit/release-notes.test.mjs
@@ -6,6 +6,7 @@ import {
   parseReleaseNote,
   probeImageSize,
   renderReleaseNotes,
+  validateDownloadedImageUrl,
   validatePullRequestEvent,
 } from '../../_scripts/releaseNotes.mjs'
 
@@ -70,6 +71,17 @@ ${NOTE_MARKERS}
     alt: 'A & B',
     url: 'https://github.com/user-attachments/assets/example?name=a&amp;b',
   })
+})
+
+test('GitHub user attachment storage redirects are accepted narrowly', () => {
+  assert.equal(
+    validateDownloadedImageUrl('https://github-production-user-asset-6210df.s3.amazonaws.com/image.png').hostname,
+    'github-production-user-asset-6210df.s3.amazonaws.com',
+  )
+  assert.throws(
+    () => validateDownloadedImageUrl('https://untrusted-bucket.s3.amazonaws.com/image.png'),
+    /must be hosted by GitHub/,
+  )
 })
 
 test('image dimensions are read from PNG data', () => {


### PR DESCRIPTION
## Summary

- require a user-facing release note for pull requests labeled `noteworthy-for-release`
- add a manually triggered workflow that collects labeled PRs between release refs and creates a draft GitHub release
- normalize optional screenshots to `<img>` tags, remove width attributes, and cap intrinsic heights above 300px
- add unit coverage for validation, parsing, formatting, and the 300px image boundary

## Testing

- `pnpm run test:unit` — 70 passing
- `pnpm run lint` — passing
- focused YAML lint for both new workflows — passing
- `git diff --check` — passing

The repository-wide YAML lint still reports the existing `yml/no-empty-mapping-value` error in `e2e/sync-server/compose.yml`.

## Repository setup

The `noteworthy-for-release` label has been created. After this workflow runs once on the default branch, `Release Note` should be configured as a required status check for protected release branches.