### PR TITLE
fix: restore search text on history navigation

### DIFF
--- a/e2e/tests/offline/search-keyboard.spec.mjs
+++ b/e2e/tests/offline/search-keyboard.spec.mjs
@@ -22,6 +22,23 @@ test('Enter searches in place', async ({ page }) => {
   await expect(page).toHaveURL(/#\/search\/enter%20search/)
 })
 
+test('back navigation restores the previous search text', async ({ page }) => {
+  const searchInput = page.locator(sel.searchInput)
+
+  await searchInput.fill('first search')
+  await searchInput.press('Enter')
+  await expect(page).toHaveURL(/#\/search\/first%20search/)
+
+  await searchInput.fill('second search')
+  await searchInput.press('Enter')
+  await expect(page).toHaveURL(/#\/search\/second%20search/)
+
+  await page.locator(sel.backButton).click()
+
+  await expect(page).toHaveURL(/#\/search\/first%20search/)
+  await expect(searchInput).toHaveValue('first search')
+})
+
 test('Shift+Enter searches in a new window', async ({ app, page }) => {
   await page.locator(sel.searchInput).fill('shift enter search')
 

--- a/src/renderer/components/TopNav/TopNav.vue
+++ b/src/renderer/components/TopNav/TopNav.vue
@@ -415,6 +415,23 @@ const searchTextByTabId = new Map()
 let currentSearchText = ''
 
 /**
+ * @param {string} path
+ * @returns {string | null}
+ */
+function getSearchTextFromPath(path) {
+  const encodedQuery = path.match(/^\/search\/(.+)$/)?.[1]
+  if (encodedQuery == null) {
+    return null
+  }
+
+  try {
+    return decodeURIComponent(encodedQuery)
+  } catch {
+    return encodedQuery
+  }
+}
+
+/**
  * @param {string} tabId
  * @returns {string}
  */
@@ -424,17 +441,31 @@ function getSearchTextForTab(tabId) {
   }
 
   const path = store.getters.getTabById(tabId)?.route.path ?? ''
-  const encodedQuery = path.match(/^\/search\/(.+)$/)?.[1]
-  if (encodedQuery == null) {
-    return ''
+  return getSearchTextFromPath(path) ?? ''
+}
+
+const presentedRoutePath = computed(() => {
+  if (!process.env.IS_ELECTRON) {
+    return route.path
   }
 
-  try {
-    return decodeURIComponent(encodedQuery)
-  } catch {
-    return encodedQuery
+  const tabId = store.getters.getPresentedTabId
+  return store.getters.getTabById(tabId)?.route.path ?? ''
+})
+
+watch([searchFilterTabId, presentedRoutePath], ([tabId, path], [previousTabId]) => {
+  // Tab switches restore that tab's cached draft in the watcher below. Route
+  // changes within one tab restore the submitted query from navigation history.
+  if (tabId !== previousTabId) {
+    return
   }
-}
+
+  const searchText = getSearchTextFromPath(path)
+  if (searchText != null) {
+    updateSearchInputText(searchText)
+    clearLastSuggestionQuery()
+  }
+})
 
 if (process.env.IS_ELECTRON) {
   const presentedTabId = computed(() => store.getters.getPresentedTabId)


### PR DESCRIPTION
## What changed

- synchronize the shared search input with same-tab search history navigation
- preserve per-tab search drafts when switching tabs
- add an end-to-end regression test for navigating back between two searches

## Why

The search results route was restored by back navigation, but the shared header input kept its latest local value. This left the first search results visible while the search bar still showed the second query.

## Validation

- ESLint on the modified component and test
- search keyboard E2E suite: 3 passed
- search tab-isolation E2E coverage: 2 passed
- search history E2E suite: 8 passed
- `git diff --check`
