### PR TITLE
fix(subscriptions): preserve new feed entries

### DIFF
--- a/e2e/tests/offline/subscriptions-new-feed.spec.mjs
+++ b/e2e/tests/offline/subscriptions-new-feed.spec.mjs
@@ -120,6 +120,28 @@ test.describe('new subscriptions feed', () => {
     await expect(page.locator('.newContentDot')).toHaveCount(0)
     await expect(page.locator('.headerRefreshWidget .lastRefreshTimestamp')).toHaveCount(0)
   })
+
+  test('keeps a new video and its menus open until the video is chosen', async ({ page }) => {
+    await goTo(page, 'subscriptions')
+    await page.locator('[data-subscription-feed-tab="all"]').click()
+
+    const video = page.locator('.ft-list-video').filter({ hasText: 'New video' })
+    await video.locator('.thumbnailLink').click({ button: 'right' })
+
+    await expect(page.getByRole('menu', { name: 'Context menu' })).toBeVisible()
+    await expect(video).toBeVisible()
+    // The broken behavior removed the card after its 200 ms leave transition.
+    await page.waitForTimeout(300)
+    await expect(page.getByRole('menu', { name: 'Context menu' })).toBeVisible()
+    await expect(video).toBeVisible()
+
+    await page.keyboard.press('Escape')
+    await video.hover()
+    await video.locator('.optionsButton').click()
+
+    await expect(video.locator('.optionsButton .iconDropdown')).toBeVisible()
+    await expect(video).toBeVisible()
+  })
 })
 
 test.describe('new feed settings and seen state', () => {

--- a/src/renderer/components/FtListVideo/FtListVideo.vue
+++ b/src/renderer/components/FtListVideo/FtListVideo.vue
@@ -1079,6 +1079,13 @@ const disableChannelLinks = computed(() => store.getters.getDisableChannelLinks)
 const shouldShowCollaboratorsButton = computed(() => !!props.data.hasCollaborators && channelName.value !== null)
 
 function handleWatchPageLinkClick(event) {
+  // `auxclick` also fires for the right mouse button after `contextmenu`.
+  // Treat only middle clicks as opening the video so a new-feed entry is not
+  // marked as seen (and removed) while its context menu is open.
+  if (event?.type === 'auxclick' && event.button !== 1) {
+    return
+  }
+
   markSubscriptionVideoAsSeen()
 
   if (externalPlayerIsDefaultViewingMode.value) {

--- a/src/renderer/helpers/subscription-entries.js
+++ b/src/renderer/helpers/subscription-entries.js
@@ -92,3 +92,33 @@ export function reconcileFetchedSubscriptionEntries(
     return reconciledEntry
   })
 }
+
+/**
+ * Channel pages return raw entries without New-feed state, while subscription
+ * refreshes reconcile that state before updating the cache. Reconcile only the
+ * raw entries so opening a channel cannot clear previously-new items.
+ * @param {object[]} entries
+ * @param {object[] | null | undefined} previousEntries
+ * @param {'videoId' | 'postId'} idKey
+ * @param {Date | number | string | null | undefined} previousFetchTimestamp
+ * @param {Record<string, object>} [historyById]
+ */
+export function ensureSubscriptionFeedEntryState(
+  entries,
+  previousEntries,
+  idKey,
+  previousFetchTimestamp,
+  historyById = {}
+) {
+  if (entries.every(entry => typeof entry.isNewInSubscriptionFeed === 'boolean')) {
+    return entries
+  }
+
+  return reconcileFetchedSubscriptionEntries(
+    entries,
+    previousEntries,
+    idKey,
+    previousFetchTimestamp,
+    historyById
+  )
+}

--- a/src/renderer/store/modules/subscription-cache.js
+++ b/src/renderer/store/modules/subscription-cache.js
@@ -1,6 +1,7 @@
 import {
   DBSubscriptionCacheHandlers,
 } from '../../../datastores/handlers/index'
+import { ensureSubscriptionFeedEntryState } from '../../helpers/subscription-entries'
 
 /**
  * Electron datastore payloads are converted to plain JSON before crossing IPC,
@@ -108,7 +109,16 @@ const actions = {
     }
   },
 
-  async updateSubscriptionVideosCacheByChannel({ commit }, { channelId, videos, timestamp = new Date() }) {
+  async updateSubscriptionVideosCacheByChannel({ commit, state, rootGetters }, { channelId, videos, timestamp = new Date() }) {
+    const previousCache = state.videoCache[channelId]
+    videos = ensureSubscriptionFeedEntryState(
+      videos,
+      previousCache?.videos,
+      'videoId',
+      previousCache?.timestamp,
+      rootGetters.getHistoryCacheById
+    )
+
     try {
       await DBSubscriptionCacheHandlers.updateVideosByChannelId(channelId, videos, timestamp)
       commit('updateVideoCacheByChannel', { channelId, entries: videos, timestamp })
@@ -135,7 +145,16 @@ const actions = {
     }
   },
 
-  async updateSubscriptionLiveCacheByChannel({ commit }, { channelId, videos, timestamp = new Date() }) {
+  async updateSubscriptionLiveCacheByChannel({ commit, state, rootGetters }, { channelId, videos, timestamp = new Date() }) {
+    const previousCache = state.liveCache[channelId]
+    videos = ensureSubscriptionFeedEntryState(
+      videos,
+      previousCache?.videos,
+      'videoId',
+      previousCache?.timestamp,
+      rootGetters.getHistoryCacheById
+    )
+
     try {
       await DBSubscriptionCacheHandlers.updateLiveStreamsByChannelId(channelId, videos, timestamp)
       commit('updateLiveCacheByChannel', { channelId, entries: videos, timestamp })
@@ -144,7 +163,15 @@ const actions = {
     }
   },
 
-  async updateSubscriptionPostsCacheByChannel({ commit }, { channelId, posts, timestamp = new Date() }) {
+  async updateSubscriptionPostsCacheByChannel({ commit, state }, { channelId, posts, timestamp = new Date() }) {
+    const previousCache = state.postsCache[channelId]
+    posts = ensureSubscriptionFeedEntryState(
+      posts,
+      previousCache?.posts,
+      'postId',
+      previousCache?.timestamp
+    )
+
     try {
       await DBSubscriptionCacheHandlers.updateCommunityPostsByChannelId(channelId, posts, timestamp)
       commit('updatePostsCacheByChannel', { channelId, entries: posts, timestamp })

--- a/tests/unit/subscription-entries.test.mjs
+++ b/tests/unit/subscription-entries.test.mjs
@@ -1,7 +1,10 @@
 import assert from 'node:assert/strict'
 import test from 'node:test'
 
-import { reconcileFetchedSubscriptionEntries } from '../../src/renderer/helpers/subscription-entries.js'
+import {
+  ensureSubscriptionFeedEntryState,
+  reconcileFetchedSubscriptionEntries
+} from '../../src/renderer/helpers/subscription-entries.js'
 
 const HOUR = 3_600_000
 const now = Date.now()
@@ -104,6 +107,26 @@ test('keeps entries that were already marked as new', () => {
   const reconciled = reconcileFetchedSubscriptionEntries(entries, previousEntries, 'videoId', now - HOUR)
 
   assert.equal(reconciled[0].isNewInSubscriptionFeed, true)
+})
+
+test('preserves New-feed state when a channel page updates raw cached entries', () => {
+  const previousEntries = [
+    video('new', now - HOUR, { isNewInSubscriptionFeed: true }),
+    video('seen', now - 2 * HOUR, { isNewInSubscriptionFeed: false })
+  ]
+  const channelPageEntries = [
+    video('new', now - HOUR),
+    video('seen', now - 2 * HOUR)
+  ]
+
+  const reconciled = ensureSubscriptionFeedEntryState(
+    channelPageEntries,
+    previousEntries,
+    'videoId',
+    now - 3 * HOUR
+  )
+
+  assert.deepEqual(reconciled.map(entry => entry.isNewInSubscriptionFeed), [true, false])
 })
 
 test('does not mark watched videos as new', () => {


### PR DESCRIPTION
## Summary

- keep New-feed videos visible when their native context menu is opened
- preserve per-entry New-feed state when opening a subscribed channel refreshes its cached videos, live streams, or posts
- cover the context-menu lifecycle and raw channel-cache reconciliation with regression tests

## Root cause

Right-clicking a video link emitted `auxclick` after `contextmenu`, and the handler treated every auxiliary click as opening the video. This marked the entry as seen and removed its card.

Separately, channel pages wrote raw API entries back to the subscription cache. Those entries do not include `isNewInSubscriptionFeed`, so the existing seen state was lost for the entire channel.

## Impact

Context menus now remain anchored until the user chooses an action, and opening a channel with either a left or middle click no longer clears that channel's New-feed entries.

## Validation

- `pnpm test:unit` — 65 passed
- New-feed offline Playwright spec — 7 passed under private Xvfb
- focused ESLint checks
- `git diff --check`