### PR TITLE
Fix native scrollbars in scrollable UI surfaces

### DIFF
--- a/e2e/tests/offline/keyboard-shortcut-restrictions.spec.mjs
+++ b/e2e/tests/offline/keyboard-shortcut-restrictions.spec.mjs
@@ -6,6 +6,9 @@ test('context-dependent shortcuts are shown as non-editable', async ({ page }) =
     store.commit('setIsKeyboardShortcutPromptShown', true)
   })
   await expect(page.getByRole('heading', { name: 'Keyboard Shortcuts' })).toBeVisible()
+  await expect(page.getByRole('dialog', { name: 'Keyboard Shortcuts' })).toHaveAttribute(
+    'data-overlayscrollbars-viewport'
+  )
 
   const reservedPaths = [
     'APP.GENERAL.FOCUS_SEARCH_ALT_SLASH',

--- a/e2e/tests/offline/subscribed-channels.spec.mjs
+++ b/e2e/tests/offline/subscribed-channels.spec.mjs
@@ -18,7 +18,14 @@ test.use({
           { id: 'UCaaaaaaaaaaaaaaaaaaaaaa', name: 'Alpha Channel', thumbnail: '' },
           { id: 'UCbbbbbbbbbbbbbbbbbbbbbb', name: 'Beta Channel', thumbnail: '' }
         ]
-      }
+      },
+      ...Array.from({ length: 6 }, (_, index) => ({
+        _id: `profile-${index}`,
+        name: `Profile ${index}`,
+        bgColor: '#000000',
+        textColor: '#FFFFFF',
+        subscriptions: []
+      }))
     ]
   }
 })
@@ -34,6 +41,17 @@ test.describe('subscribed channels', () => {
     await page.getByPlaceholder('Search Channels').fill('Beta')
     await expect(page.locator('.channel', { hasText: 'Beta Channel' })).toBeVisible()
     await expect(page.locator('.channel', { hasText: 'Alpha Channel' })).toBeHidden()
+  })
+
+  test('profile dropdown uses an overlay scrollbar', async ({ page }) => {
+    await goTo(page, 'subscribedchannels')
+
+    const alpha = page.locator('.channel', { hasText: 'Alpha Channel' })
+    await alpha.locator('.profileDropdownToggle').click()
+
+    const dropdown = alpha.locator('.profileDropdown')
+    await expect(dropdown).toHaveAttribute('data-overlayscrollbars-viewport')
+    expect(await dropdown.evaluate((element) => element.scrollHeight > element.clientHeight)).toBe(true)
   })
 
   test('unsubscribing asks for confirmation and persists', async ({ app, page }) => {

--- a/src/renderer/App.vue
+++ b/src/renderer/App.vue
@@ -85,6 +85,7 @@
       </template>
       <bdo
         v-safer-html.lenient="updateChangelog"
+        v-overlay-scrollbars
         class="changeLogText"
         dir="ltr"
         lang="en"
@@ -201,6 +202,7 @@
     >
       <div
         ref="tabSwitcherRef"
+        v-overlay-scrollbars
         class="tabSwitcher"
         :class="{ pointerActive: tabSwitcherPointerActive }"
         role="listbox"

--- a/src/renderer/components/FtAddToPlaylistDropdown/FtAddToPlaylistDropdown.vue
+++ b/src/renderer/components/FtAddToPlaylistDropdown/FtAddToPlaylistDropdown.vue
@@ -4,6 +4,7 @@
       {{ t('User Playlists.Save to') }}
     </p>
     <ul
+      v-overlay-scrollbars
       class="playlistList"
       role="listbox"
       :aria-label="t('User Playlists.Add to Playlist')"

--- a/src/renderer/components/FtIconButton/FtIconButton.vue
+++ b/src/renderer/components/FtIconButton/FtIconButton.vue
@@ -91,6 +91,7 @@
       <div
         v-else
         ref="dropdown"
+        v-overlay-scrollbars
         tabindex="-1"
         class="iconDropdown"
         :class="{

--- a/src/renderer/components/FtPlaylistAddVideoPrompt/FtPlaylistAddVideoPrompt.vue
+++ b/src/renderer/components/FtPlaylistAddVideoPrompt/FtPlaylistAddVideoPrompt.vue
@@ -57,7 +57,10 @@
         @change="sortBy = $event"
       />
     </div>
-    <div class="playlists-container">
+    <div
+      v-overlay-scrollbars
+      class="playlists-container"
+    >
       <FtFlexBox>
         <div
           v-for="playlist in activePlaylists"

--- a/src/renderer/components/FtProfileSelector/FtProfileSelector.vue
+++ b/src/renderer/components/FtProfileSelector/FtProfileSelector.vue
@@ -41,6 +41,7 @@
         @click="openProfileSettings"
       />
       <div
+        v-overlay-scrollbars
         class="profileWrapper"
         role="listbox"
         :aria-labelledby="id + 'title'"

--- a/src/renderer/components/FtPrompt/FtPrompt.vue
+++ b/src/renderer/components/FtPrompt/FtPrompt.vue
@@ -11,6 +11,7 @@
     >
       <FtCard
         ref="promptCard"
+        v-overlay-scrollbars
         class="promptCard"
         :class="{ autosize, [theme]: true }"
         role="dialog"

--- a/src/renderer/components/FtSubscribeButton/FtSubscribeButton.vue
+++ b/src/renderer/components/FtSubscribeButton/FtSubscribeButton.vue
@@ -52,6 +52,7 @@
         class="profileDropdown"
       >
         <ul
+          v-overlay-scrollbars
           class="profileList"
         >
           <li

--- a/src/renderer/components/FtSubscribeButton/FtSubscribeButton.vue
+++ b/src/renderer/components/FtSubscribeButton/FtSubscribeButton.vue
@@ -48,11 +48,11 @@
     <Transition name="profile-dropdown">
       <div
         v-if="isProfileDropdownOpen"
+        v-overlay-scrollbars
         tabindex="-1"
         class="profileDropdown"
       >
         <ul
-          v-overlay-scrollbars
           class="profileList"
         >
           <li

--- a/src/renderer/components/FtToast/FtToast.vue
+++ b/src/renderer/components/FtToast/FtToast.vue
@@ -17,6 +17,7 @@
         :class="toast.dismissDirection && `dismiss-${toast.dismissDirection}`"
       >
         <div
+          v-overlay-scrollbars
           class="toast"
           :class="{ hasImage: toast.image, dragging: toast.dragging }"
           :style="dragStyle(toast)"

--- a/src/renderer/components/PlaylistInfo/PlaylistInfo.vue
+++ b/src/renderer/components/PlaylistInfo/PlaylistInfo.vue
@@ -101,6 +101,7 @@
     />
     <p
       v-else
+      v-overlay-scrollbars
       class="playlistDescription"
       dir="auto"
     >

--- a/src/renderer/components/WatchVideoLiveChat/WatchVideoLiveChat.vue
+++ b/src/renderer/components/WatchVideoLiveChat/WatchVideoLiveChat.vue
@@ -70,6 +70,7 @@
       </div>
       <div
         v-if="superChatComments.length > 0"
+        v-overlay-scrollbars
         class="superChatComments"
       >
         <div
@@ -143,6 +144,7 @@
       </div>
       <div
         ref="commentsRef"
+        v-overlay-scrollbars
         class="liveChatComments"
         :style="{ blockSize: chatHeight }"
         @mousewheel.passive="onScroll"

--- a/src/renderer/components/WatchVideoQueue/WatchVideoQueue.vue
+++ b/src/renderer/components/WatchVideoQueue/WatchVideoQueue.vue
@@ -20,6 +20,7 @@
       </button>
     </header>
     <TransitionGroup
+      v-overlay-scrollbars
       name="queueItem"
       tag="ol"
       class="queueItems"

--- a/src/renderer/components/ft-shaka-video-player/ft-shaka-video-player.vue
+++ b/src/renderer/components/ft-shaka-video-player/ft-shaka-video-player.vue
@@ -89,6 +89,7 @@
       <Transition name="fade">
         <div
           v-if="autoplayCountdown"
+          v-overlay-scrollbars
           class="autoplayCountdownOverlay shaka-no-propagation"
           role="dialog"
           :aria-label="$t('Up Next')"
@@ -781,7 +782,10 @@
           >
             {{ sponsorBlockSubmissionError }}
           </p>
-          <div class="sponsorBlockSubmissionSegments">
+          <div
+            v-overlay-scrollbars
+            class="sponsorBlockSubmissionSegments"
+          >
             <div
               v-for="segment in sponsorBlockDraftSegments"
               :key="segment.id"


### PR DESCRIPTION
## Summary

- use the shared overlay scrollbar directive on prompt cards, including the keyboard shortcuts modal
- apply the same custom scrollbar treatment to other scrollable dropdowns, lists, overlays, and player surfaces found in the repo scan
- retain the intentionally native watch-playlist scrollbar because overlay scroll restoration conflicts with its teleported layout
- add a regression assertion for the keyboard shortcuts modal

## Root cause

Several components declared `overflow: auto` or `overflow: scroll` but did not opt into the overlay scrollbar directive, so Chromium rendered native scrollbars instead of the themed custom scrollbar.

## Validation

- ESLint and Stylelint
- 64 unit tests
- 159 offline Electron E2E tests under Xvfb