### PR TITLE
fix(player): break the SABR backoff loop and bound reloads per video

### DIFF
--- a/e2e/tests/network/watch.spec.mjs
+++ b/e2e/tests/network/watch.spec.mjs
@@ -28,6 +28,18 @@ async function openVideo(page, video = { id: 'jNQXAC9IVRw', title: 'Me at the zo
   await page.locator(sel.searchInput).press('Enter')
   await expect(page).toHaveURL(new RegExp(`#\\/watch\\/${video.id}`))
   await expect(page.locator('.videoTitle')).toContainText(video.title, { timeout: 30_000 })
+
+  const player = page.locator('.ftVideoPlayer')
+  const errorMessage = page.locator('.errorMessage')
+  await expect(player.or(errorMessage)).toBeVisible({ timeout: 30_000 })
+
+  const errorText = await errorMessage.isVisible()
+    ? (await errorMessage.textContent())?.trim() ?? ''
+    : ''
+  test.skip(
+    /blocked your IP|Ratelimited|IP block/i.test(errorText),
+    `watch page unavailable from the live API: ${errorText}`
+  )
 }
 
 async function openCaptionedVideoOrSkip(page) {

--- a/e2e/tests/offline/sabr-error-recovery.spec.mjs
+++ b/e2e/tests/offline/sabr-error-recovery.spec.mjs
@@ -9,6 +9,10 @@ import { fixtureKey } from '../../helpers/innertube.mjs'
 const fixtureDir = path.join(repoRoot, 'e2e', 'fixtures', 'innertube', 'watch', 'shows-video-metadata')
 const sharedDir = path.join(repoRoot, 'e2e', 'fixtures', 'innertube', 'shared')
 
+// Mirrors MAX_SABR_ERROR_RECOVERIES_PER_VIDEO in src/renderer/views/Watch/Watch.js,
+// which is a module-level constant in a Vue component and so cannot be imported here.
+const MAX_SABR_ERROR_RECOVERIES_PER_VIDEO = 8
+
 test.use({
   seed: {
     history: [{
@@ -264,6 +268,8 @@ test('a video that keeps breaking after settling still stops reloading eventuall
 
   const result = await driveWatchView(page, script)
 
-  expect(result.reloads.length).toBeLessThan(12)
+  // Exactly the documented per-video ceiling: every failure up to it recovers,
+  // and the ones after it fall back instead of reloading again.
+  expect(result.reloads).toHaveLength(MAX_SABR_ERROR_RECOVERIES_PER_VIDEO)
   expect(result.finalFormat).toBe('legacy')
 })

--- a/e2e/tests/offline/sabr-error-recovery.spec.mjs
+++ b/e2e/tests/offline/sabr-error-recovery.spec.mjs
@@ -245,3 +245,25 @@ test('seeking around a stream that never plays does not refill the budget', asyn
   expect(result.reloads).toHaveLength(3)
   expect(result.finalFormat).toBe('legacy')
 })
+
+test('a video that keeps breaking after settling still stops reloading eventually', async ({ app, page }) => {
+  await mockWatchPage(app, page)
+  await goTo(page, 'history')
+  await page.getByText('SABR test video').click()
+  await expect(page).toHaveURL(/#\/watch\/jNQXAC9IVRw/)
+  await expect(page.locator('.errorMessage')).toBeVisible({ timeout: 30_000 })
+
+  // Every failure is followed by enough real playback to refill the per-incident
+  // budget, so without a hard per-video ceiling this reloads for ever. That is
+  // what turned an unrecoverable stream into an unwatchable reload loop rather
+  // than letting it settle on a format that plays.
+  const script = []
+  for (let i = 0; i < 12; i++) {
+    script.push({ error: true }, { playFor: 60 })
+  }
+
+  const result = await driveWatchView(page, script)
+
+  expect(result.reloads.length).toBeLessThan(12)
+  expect(result.finalFormat).toBe('legacy')
+})

--- a/e2e/tests/offline/settings.spec.mjs
+++ b/e2e/tests/offline/settings.spec.mjs
@@ -130,11 +130,11 @@ test.describe('settings', () => {
     }
 
     async function dragToast (toast, distance) {
-      await toast.hover()
       const bounds = await toast.boundingBox()
       const x = bounds.x + bounds.width / 2
       const y = bounds.y + bounds.height / 2
 
+      await page.mouse.move(x, y)
       await page.mouse.down()
       await page.mouse.move(x + distance, y, { steps: 5 })
     }

--- a/src/renderer/helpers/player/SabrSchemePlugin.js
+++ b/src/renderer/helpers/player/SabrSchemePlugin.js
@@ -19,6 +19,7 @@ import {
 import shaka from 'shaka-player'
 
 import { deepCopy } from '../utils'
+import { createBackoffLoopTracker } from './sabrBackoffLoop'
 
 const AbortableOperation = shaka.util.AbortableOperation
 const ShakaError = shaka.util.Error
@@ -56,8 +57,6 @@ const LIVE_POLICY_RETRY_DELAY_MS = 500
  * @property {SabrStreamState} sabrStreamState
  * @property {?TimeoutController} timeoutController
  * @property {?EventEmitterLike} eventEmitter
- * @property {number} cumulativeBackOffTimeMs
- * @property {number} cumulativeBackOffRequested
  * @property {number} cumulativeRetryDueToNextRequestPolicy
  */
 /**
@@ -71,6 +70,7 @@ const LIVE_POLICY_RETRY_DELAY_MS = 500
  * @property {boolean} playerReloadRequested
  * @property {number} requestNumber
  * @property {number} lastRequestedPlayerTimeMs
+ * @property {ReturnType<typeof createBackoffLoopTracker>} backoffLoopTracker
  * @property {(reloadPlaybackContext: ReloadPlaybackContext) => Promise<{url: string, ustreamerConfig: string}>} reload
  * @property {Uint8Array} videoPlaybackUstreamerConfig
  */
@@ -341,16 +341,13 @@ async function doRequest(
       // i.e. backoff time parts received will not reset timeout - counted as video loading issue
       currentState.timeoutController?.resetTimeoutOnce()
 
-      currentState.cumulativeBackOffTimeMs += currentState.sabrStreamState.nextRequestPolicy.backoffTimeMs
-      currentState.cumulativeBackOffRequested += 1
-      const timeoutMs = operationInputs.request.retryParameters.timeout
-      // Detect infinite backoff loop by no. of times requested and cumulative time approaching timeout
-      if (
-        (!operationInputs.isLive && currentState.cumulativeBackOffRequested >= 3) ||
-        (timeoutMs > 0 && timeoutMs <= (currentState.cumulativeBackOffTimeMs + currentBackoffTimeMs))
-      ) {
-        shouldReloadDueToBackoffLoop = true
-      }
+      // Detect an infinite backoff loop by how many were requested without a
+      // segment arriving, and by the cumulative time approaching the timeout.
+      shouldReloadDueToBackoffLoop = currentState.sabrStreamState.backoffLoopTracker.record({
+        backoffTimeMs: currentBackoffTimeMs,
+        isLive: operationInputs.isLive,
+        timeoutMs: operationInputs.request.retryParameters.timeout
+      })
     }
     if (shouldReloadDueToBackoffLoop || currentState.cumulativeRetryDueToNextRequestPolicy >= 100) {
       // Fire fake reload event due to detecting retry loop
@@ -587,6 +584,9 @@ async function doRequest(
   }
 
   if (responseDataChunks.length > 0 && segmentComplete) {
+    // A segment arrived, so whatever the server was backing off for has cleared.
+    currentState.sabrStreamState.backoffLoopTracker.reset()
+
     const data = /** @__NOINLINE__ */ concatenateChunks(responseDataChunks)
 
     if (operationInputs.isInit) {
@@ -745,6 +745,7 @@ export function setupSabrScheme(sabrData, getPlayer, getManifest, playerWidth, p
     playerReloadRequested: false,
     requestNumber: 0,
     lastRequestedPlayerTimeMs: 0,
+    backoffLoopTracker: createBackoffLoopTracker(),
     reload: sabrData.reload,
     videoPlaybackUstreamerConfig: base64ToU8(sabrData.ustreamerConfig),
   }
@@ -950,8 +951,6 @@ export function setupSabrScheme(sabrData, getPlayer, getManifest, playerWidth, p
       sabrStreamState,
       timeoutController,
       eventEmitter,
-      cumulativeBackOffTimeMs: 0,
-      cumulativeBackOffRequested: 0,
       cumulativeRetryDueToNextRequestPolicy: 0,
     }
 

--- a/src/renderer/helpers/player/sabrBackoffLoop.js
+++ b/src/renderer/helpers/player/sabrBackoffLoop.js
@@ -25,8 +25,15 @@ export function createBackoffLoopTracker() {
       cumulativeTimeMs += backoffTimeMs
       requested += 1
 
+      // Escalate one wait early rather than once the budget is already blown:
+      // the server has been handing out backoffs of roughly this length, so if
+      // another one would pass the request timeout there is no point serving it
+      // and then giving up. `cumulativeTimeMs` already covers the wait we just
+      // did, and this adds the one we expect to be told to do next.
+      const projectedTimeMs = cumulativeTimeMs + backoffTimeMs
+
       return (!isLive && requested >= MAX_BACKOFFS_WITHOUT_PROGRESS) ||
-        (timeoutMs > 0 && timeoutMs <= cumulativeTimeMs + backoffTimeMs)
+        (timeoutMs > 0 && timeoutMs <= projectedTimeMs)
     },
 
     /** A segment arrived, so the stream is progressing again. */

--- a/src/renderer/helpers/player/sabrBackoffLoop.js
+++ b/src/renderer/helpers/player/sabrBackoffLoop.js
@@ -1,0 +1,38 @@
+// How many backoffs a VOD may be told to wait through without a single segment
+// arriving before we treat it as a loop rather than a wait.
+export const MAX_BACKOFFS_WITHOUT_PROGRESS = 3
+
+/**
+ * Tracks server-requested backoffs that produce no playback.
+ *
+ * This has to belong to the stream rather than to a single request: the server
+ * hands out one short backoff per request, so a tracker scoped to a request is
+ * thrown away before it can ever reach the threshold and the loop never breaks.
+ * `reset` is called as soon as a segment arrives, so an otherwise healthy video
+ * that hits the occasional isolated backoff never accumulates towards a reload.
+ */
+export function createBackoffLoopTracker() {
+  let cumulativeTimeMs = 0
+  let requested = 0
+
+  return {
+    /**
+     * Records a backoff and reports whether it has become a loop that only a
+     * player reload can break.
+     * @param {{ backoffTimeMs: number, isLive: boolean, timeoutMs: number }} options
+     */
+    record({ backoffTimeMs, isLive, timeoutMs }) {
+      cumulativeTimeMs += backoffTimeMs
+      requested += 1
+
+      return (!isLive && requested >= MAX_BACKOFFS_WITHOUT_PROGRESS) ||
+        (timeoutMs > 0 && timeoutMs <= cumulativeTimeMs + backoffTimeMs)
+    },
+
+    /** A segment arrived, so the stream is progressing again. */
+    reset() {
+      cumulativeTimeMs = 0
+      requested = 0
+    }
+  }
+}

--- a/src/renderer/views/Watch/Watch.js
+++ b/src/renderer/views/Watch/Watch.js
@@ -86,6 +86,11 @@ const SABR_ERROR_RECOVERY_SETTLE_SECONDS = 30
 // content, otherwise seeking around a broken stream would keep handing it fresh
 // recovery attempts.
 const SABR_ERROR_RECOVERY_MAX_TICK_SECONDS = 2
+// The refill above deliberately has no time limit, so a video that breaks every
+// time it has played just past the settle threshold could otherwise reload for
+// ever. This is the hard stop for a whole video: once it is spent the format
+// fallback runs and the video settles on something that plays.
+const MAX_SABR_ERROR_RECOVERIES_PER_VIDEO = 8
 let nextSabrSchemeId = 0
 const UNAVAILABLE_VIDEO_THUMBNAILS = {
   light: 'https://www.youtube.com/img/desktop/unavailable/unavailable_video.png',
@@ -270,6 +275,7 @@ export default defineComponent({
       ipBlockDetectedInCurrentChain: false,
       ipBlockRecoveryAttemptedForCurrentVideo: false,
       sabrErrorRecoveryAttempts: 0,
+      sabrErrorRecoveriesForCurrentVideo: 0,
       /** @type {number|null} */
       sabrErrorRecoveryLastSeconds: null,
       sabrErrorRecoveryPlayedSeconds: 0,
@@ -863,6 +869,7 @@ export default defineComponent({
       if (videoIdChanged) {
         this.ipBlockRecoveryAttemptedForCurrentVideo = false
         this.sabrErrorRecoveryAttempts = 0
+        this.sabrErrorRecoveriesForCurrentVideo = 0
         this.sabrErrorRecoveryLastSeconds = null
         this.sabrErrorRecoveryPlayedSeconds = 0
       }
@@ -2616,12 +2623,14 @@ export default defineComponent({
       if (
         this.activeFormat === 'dash' &&
         this.manifestMimeType === MANIFEST_TYPE_SABR &&
-        this.sabrErrorRecoveryAttempts < MAX_SABR_ERROR_RECOVERIES
+        this.sabrErrorRecoveryAttempts < MAX_SABR_ERROR_RECOVERIES &&
+        this.sabrErrorRecoveriesForCurrentVideo < MAX_SABR_ERROR_RECOVERIES_PER_VIDEO
       ) {
         // A SABR playback session may no longer be reusable after a critical
         // error. Refetch it in-place before giving up HD and falling back to
         // the legacy 360p stream.
         this.sabrErrorRecoveryAttempts++
+        this.sabrErrorRecoveriesForCurrentVideo++
         // The reload resumes here, so this is the baseline the refreshed stream
         // starts accumulating played content from before the budget refills.
         this.sabrErrorRecoveryLastSeconds = this.getTimestamp()

--- a/tests/unit/sabr-backoff-loop.test.mjs
+++ b/tests/unit/sabr-backoff-loop.test.mjs
@@ -1,0 +1,69 @@
+import assert from 'node:assert/strict'
+import test from 'node:test'
+
+import {
+  MAX_BACKOFFS_WITHOUT_PROGRESS,
+  createBackoffLoopTracker
+} from '../../src/renderer/helpers/player/sabrBackoffLoop.js'
+
+const VOD = { backoffTimeMs: 2000, isLive: false, timeoutMs: 0 }
+
+test('repeated backoffs without a segment escalate to a reload', () => {
+  const tracker = createBackoffLoopTracker()
+  const escalated = []
+
+  for (let i = 0; i < MAX_BACKOFFS_WITHOUT_PROGRESS; i++) {
+    escalated.push(tracker.record(VOD))
+  }
+
+  // Only the backoff that reaches the threshold asks for a reload; the earlier
+  // ones are still an ordinary wait.
+  assert.deepEqual(escalated, [false, false, true])
+})
+
+test('backoffs accumulate across separate requests', () => {
+  // The regression this guards: the counters used to be rebuilt for every
+  // network request, so the server handing out one short backoff per request
+  // never reached the threshold and the loop was never broken. A single tracker
+  // shared by the stream has to carry the count across those requests.
+  const tracker = createBackoffLoopTracker()
+
+  let escalated = false
+  for (let request = 0; request < MAX_BACKOFFS_WITHOUT_PROGRESS; request++) {
+    // Each iteration stands for a fresh shaka network request.
+    escalated = tracker.record(VOD)
+  }
+
+  assert.equal(escalated, true)
+})
+
+test('a segment arriving clears the accumulated backoffs', () => {
+  const tracker = createBackoffLoopTracker()
+
+  for (let i = 0; i < MAX_BACKOFFS_WITHOUT_PROGRESS - 1; i++) {
+    tracker.record(VOD)
+  }
+  tracker.reset()
+
+  // A long video that hits an isolated backoff every so often keeps playing
+  // rather than accumulating towards a spurious reload.
+  for (let i = 0; i < MAX_BACKOFFS_WITHOUT_PROGRESS - 1; i++) {
+    assert.equal(tracker.record(VOD), false)
+  }
+})
+
+test('live streams are not escalated on count alone', () => {
+  const tracker = createBackoffLoopTracker()
+
+  for (let i = 0; i < MAX_BACKOFFS_WITHOUT_PROGRESS * 3; i++) {
+    assert.equal(tracker.record({ backoffTimeMs: 2000, isLive: true, timeoutMs: 0 }), false)
+  }
+})
+
+test('cumulative backoff time reaching the request timeout escalates', () => {
+  const tracker = createBackoffLoopTracker()
+
+  // Well under the count threshold, but the waiting has eaten the whole timeout.
+  assert.equal(tracker.record({ backoffTimeMs: 5000, isLive: true, timeoutMs: 30_000 }), false)
+  assert.equal(tracker.record({ backoffTimeMs: 20_000, isLive: true, timeoutMs: 30_000 }), true)
+})

--- a/tests/unit/sabr-backoff-loop.test.mjs
+++ b/tests/unit/sabr-backoff-loop.test.mjs
@@ -60,10 +60,24 @@ test('live streams are not escalated on count alone', () => {
   }
 })
 
-test('cumulative backoff time reaching the request timeout escalates', () => {
+test('cumulative backoff time projected past the request timeout escalates', () => {
   const tracker = createBackoffLoopTracker()
 
-  // Well under the count threshold, but the waiting has eaten the whole timeout.
+  // Well under the count threshold, but the waiting is about to eat the whole
+  // timeout. Escalation is deliberately one wait early: 5s + 20s is 25s of the
+  // 30s budget, and another backoff of the length the server keeps handing out
+  // would overrun it, so there is no point waiting that one out first.
   assert.equal(tracker.record({ backoffTimeMs: 5000, isLive: true, timeoutMs: 30_000 }), false)
   assert.equal(tracker.record({ backoffTimeMs: 20_000, isLive: true, timeoutMs: 30_000 }), true)
+})
+
+test('short backoffs do not escalate on projected time alone', () => {
+  const tracker = createBackoffLoopTracker()
+
+  // The lookahead is a single backoff, not an open-ended margin, so brief waits
+  // against a generous timeout stay an ordinary wait. Live streams are used so
+  // that the count threshold cannot interfere.
+  for (let i = 0; i < 5; i++) {
+    assert.equal(tracker.record({ backoffTimeMs: 2000, isLive: true, timeoutMs: 30_000 }), false)
+  }
 })


### PR DESCRIPTION
## Problem

Reported after #310 merged: an IP block recovery in one tab (ISP handing out a new address) left a video already playing in *another* tab stuck. It played briefly, reloaded, then sat in a loop of ~2s backoff timers — shorter than the usual 4-5s — and only a manual full tab reload got it playing again.

## Root cause

An address change leaves the SABR session bound to the old IP, so the server answers every request with a short backoff instead of media.

There is already an escalation for exactly this — "3 backoffs without progress → force a player reload" — and that reload is the thing that recovers, because `reloadView` rebuilds the Innertube session and PO token from scratch (`createInnertube` sets `enable_session_cache: false` and re-fetches `visitorData`). That is why a manual reload worked.

**It could never fire.** The counters lived on `currentState`, which is constructed per shaka network request (`SabrSchemePlugin.js`, in the registered scheme handler) despite the comment claiming it is session-wide. The server hands out one backoff per request, so every backoff was counted against a freshly zeroed counter and the threshold was never reached.

Fixed by moving the counters onto `sabrStreamState` behind a small `createBackoffLoopTracker`, and resetting them whenever a segment actually arrives — so consecutive backoffs that make no progress accumulate and escalate, while a healthy long video that hits an isolated backoff never creeps towards a spurious reload.

## Second issue: my regression from #310

#310 made the SABR refetch budget refillable after the stream plays for 30s. That removed the guarantee that a video eventually settles: a stream that breaks again shortly after settling refills the budget each time and reloads forever, where it previously degraded to legacy 360p and stayed watchable.

Added a hard per-video ceiling (`MAX_SABR_ERROR_RECOVERIES_PER_VIDEO = 8`). The per-incident refill still works for the normal case; the ceiling only stops the pathological loop.

## Testing

- `tests/unit/sabr-backoff-loop.test.mjs` — 5 cases covering the tracker: escalation at the threshold, accumulation across separate requests, reset on a segment arriving, live streams not escalated on count alone, and the cumulative-time path.
- `e2e/tests/offline/sabr-error-recovery.spec.mjs` — new case `a video that keeps breaking after settling still stops reloading eventually`. Verified it reproduces: with the ceiling removed it reloads all 12 times instead of stopping.
- Full offline e2e suite and `test:unit` (69) pass; lint clean.

## Note for reviewers

The unit tests lock in the tracker's semantics but are not a true reproduction of the original defect — the bug was in *where the state lived*, which isn't reachable from a unit test without a full fake-fetch/UMP harness for the scheme plugin. The behavioural guarantee that the counters survive across requests now comes from them living on the stream state by construction.