### PR TITLE
Fix playlist tab icon and flaky E2E checks

### DIFF
--- a/e2e/tests/network/watch.spec.mjs
+++ b/e2e/tests/network/watch.spec.mjs
@@ -28,6 +28,18 @@ async function openVideo(page, video = { id: 'jNQXAC9IVRw', title: 'Me at the zo
   await page.locator(sel.searchInput).press('Enter')
   await expect(page).toHaveURL(new RegExp(`#\\/watch\\/${video.id}`))
   await expect(page.locator('.videoTitle')).toContainText(video.title, { timeout: 30_000 })
+
+  const player = page.locator('.ftVideoPlayer')
+  const errorMessage = page.locator('.errorMessage')
+  await expect(player.or(errorMessage)).toBeVisible({ timeout: 30_000 })
+
+  const errorText = await errorMessage.isVisible()
+    ? (await errorMessage.textContent())?.trim() ?? ''
+    : ''
+  test.skip(
+    /blocked your IP|Ratelimited|IP block/i.test(errorText),
+    `watch page unavailable from the live API: ${errorText}`
+  )
 }
 
 async function openCaptionedVideoOrSkip(page) {

--- a/e2e/tests/offline/playlists.spec.mjs
+++ b/e2e/tests/offline/playlists.spec.mjs
@@ -116,7 +116,7 @@ test.describe('seeded playlists', () => {
 
     await page.getByTitle('Delete Playlist').click()
     await page.getByRole('button', { name: 'Yes, Delete' }).click()
-    await expect(page).toHaveURL(/#\/userplaylists/)
+    await expect(page).toHaveURL(/#\/userplaylists\/?$/)
     await expect(page.locator(sel.activeTab).locator('[data-icon="bookmark"]')).toBeVisible()
     await expect(page.getByText('Renamed seeded playlist')).toHaveCount(0)
 

--- a/e2e/tests/offline/playlists.spec.mjs
+++ b/e2e/tests/offline/playlists.spec.mjs
@@ -116,7 +116,8 @@ test.describe('seeded playlists', () => {
 
     await page.getByTitle('Delete Playlist').click()
     await page.getByRole('button', { name: 'Yes, Delete' }).click()
-    await expect(page).toHaveURL(/#\/user[Pp]laylists/)
+    await expect(page).toHaveURL(/#\/userplaylists/)
+    await expect(page.locator(sel.activeTab).locator('[data-icon="bookmark"]')).toBeVisible()
     await expect(page.getByText('Renamed seeded playlist')).toHaveCount(0)
 
     await expect.poll(async () => {

--- a/e2e/tests/offline/settings.spec.mjs
+++ b/e2e/tests/offline/settings.spec.mjs
@@ -130,11 +130,11 @@ test.describe('settings', () => {
     }
 
     async function dragToast (toast, distance) {
-      await toast.hover()
       const bounds = await toast.boundingBox()
       const x = bounds.x + bounds.width / 2
       const y = bounds.y + bounds.height / 2
 
+      await page.mouse.move(x, y)
       await page.mouse.down()
       await page.mouse.move(x + distance, y, { steps: 5 })
     }

--- a/src/renderer/components/PlaylistInfo/PlaylistInfo.vue
+++ b/src/renderer/components/PlaylistInfo/PlaylistInfo.vue
@@ -948,7 +948,7 @@ function handleDeletePlaylistPromptAnswer(option) {
     store.dispatch('removePlaylist', props.id)
     router.push(
       {
-        path: '/userPlaylists'
+        path: '/userplaylists'
       }
     )
     showToast({


### PR DESCRIPTION
## Summary

- redirect playlist deletion to the canonical lowercase playlists route
- assert that the active tab retains its bookmark icon after deletion
- make toast drag tests start from an exact pointer position
- skip live watch tests when YouTube explicitly reports an IP block or rate limit

## Root causes

The deletion flow navigated to `/userPlaylists`, while tab page icons are matched against the canonical lowercase `/userplaylists` route. Vue displayed the playlists page, but the logical tab route no longer matched the bookmark icon rule.

The toast test calculated its drag destination from the toast center without moving the pointer there first, making the effective drag distance nondeterministic. The watch-page retries were caused by GitHub Actions receiving an explicit YouTube IP-block response; those live-network tests cannot exercise player behavior in that state.

## User impact

Deleting a playlist now returns to Your Playlists without making the active tab lose its icon. E2E checks no longer fail randomly because of pointer placement or retry after a recognized external IP block.

## Validation

- playlist offline spec: 5 passed
- toast-position test repeated concurrently: 5 passed
- four previously flaky watch tests repeated three times: 12 passed
- unit tests: 64 passed
- changed E2E files pass `node --check`
- source lint passed for `PlaylistInfo.vue`