### PR TITLE
fix: exclude active live content from watched

### DIFF
--- a/e2e/tests/offline/history.spec.mjs
+++ b/e2e/tests/offline/history.spec.mjs
@@ -3,7 +3,7 @@ import path from 'node:path'
 
 import { test, expect, sel, goTo } from '../../helpers/app.mjs'
 
-function historyEntry(videoId, title, timeWatched, isWatched = false) {
+function historyEntry(videoId, title, timeWatched, isWatched = false, isLive = false) {
   return {
     _id: videoId,
     videoId,
@@ -17,7 +17,7 @@ function historyEntry(videoId, title, timeWatched, isWatched = false) {
     watchProgress: 10,
     isWatched,
     timeWatched,
-    isLive: false,
+    isLive,
     type: 'video'
   }
 }
@@ -26,7 +26,8 @@ test.use({
   seed: {
     history: [
       historyEntry('aaaaaaaaaaa', 'First test video', Date.now() - 1000, true),
-      historyEntry('bbbbbbbbbbb', 'Second test video', Date.now() - 2000)
+      historyEntry('bbbbbbbbbbb', 'Second test video', Date.now() - 2000),
+      historyEntry('ccccccccccc', 'Active live stream', Date.now() - 3000, false, true)
     ]
   }
 })
@@ -118,7 +119,8 @@ test.describe('watch history', () => {
       const latestRecords = Object.values(Object.fromEntries(
         records.filter(record => record.videoId).map(record => [record.videoId, record])
       ))
-      return latestRecords.every(record => record.isWatched === true)
+      return latestRecords.every(record => record.isLive === true || record.isWatched === true) &&
+        latestRecords.find(record => record.videoId === 'ccccccccccc')?.isWatched === false
     }).toBe(true)
   })
 })

--- a/e2e/tests/offline/history.spec.mjs
+++ b/e2e/tests/offline/history.spec.mjs
@@ -98,6 +98,18 @@ test.describe('watch history', () => {
     await expect(videos.nth(1)).toContainText('Second test video')
   })
 
+  test('does not offer watched actions for an active live history entry', async ({ page }) => {
+    await goTo(page, 'history')
+
+    const activeLiveStream = page.locator('.ft-list-video').filter({ hasText: 'Active live stream' })
+    await activeLiveStream.hover()
+    await activeLiveStream.locator('.optionsButton').click()
+
+    await expect(page.getByRole('option', { name: 'Mark As Watched' })).toHaveCount(0)
+    await expect(page.getByRole('option', { name: 'Unmark As Watched' })).toHaveCount(0)
+    await expect(page.getByRole('option', { name: 'Remove From History' })).toBeVisible()
+  })
+
   test('marks every history entry as watched', async ({ app, page }) => {
     await goTo(page, 'history')
 

--- a/e2e/tests/offline/subscriptions-feed.spec.mjs
+++ b/e2e/tests/offline/subscriptions-feed.spec.mjs
@@ -121,6 +121,17 @@ test.describe('subscriptions feed from cache', () => {
     await expect(page.getByText('Upcoming premiere video')).toHaveCount(0)
   })
 
+  test('does not offer to mark a running premiere as watched', async ({ page }) => {
+    await goTo(page, 'subscriptions')
+
+    const runningPremiere = page.locator('.ft-list-video').filter({ hasText: 'Running premiere video' })
+    await runningPremiere.hover()
+    await runningPremiere.locator('.optionsButton').click()
+
+    await expect(page.getByRole('option', { name: 'Mark As Watched' })).toHaveCount(0)
+    await expect(page.getByRole('option', { name: 'Add to Queue' })).toBeVisible()
+  })
+
   test('shows when the cache was last refreshed, from the oldest channel timestamp', async ({ page }) => {
     await goTo(page, 'subscriptions')
     await expect(page.getByText('Video B newest')).toBeVisible()

--- a/e2e/tests/offline/subscriptions-feed.spec.mjs
+++ b/e2e/tests/offline/subscriptions-feed.spec.mjs
@@ -129,6 +129,7 @@ test.describe('subscriptions feed from cache', () => {
     await runningPremiere.locator('.optionsButton').click()
 
     await expect(page.getByRole('option', { name: 'Mark As Watched' })).toHaveCount(0)
+    await expect(page.getByRole('option', { name: 'Unmark As Watched' })).toHaveCount(0)
     await expect(page.getByRole('option', { name: 'Add to Queue' })).toBeVisible()
   })
 

--- a/src/history.js
+++ b/src/history.js
@@ -9,8 +9,16 @@ export { DEFAULT_WATCHED_PERCENTAGE_THRESHOLD, WATCHED_MAX_REMAINING_SECONDS }
  * @param {object | undefined} historyEntry
  * @returns {boolean}
  */
+export function canMarkHistoryEntryAsWatched(historyEntry) {
+  return historyEntry?.isLive !== true
+}
+
+/**
+ * @param {object | undefined} historyEntry
+ * @returns {boolean}
+ */
 export function isHistoryEntryWatched(historyEntry) {
-  if (!historyEntry) {
+  if (!historyEntry || !canMarkHistoryEntryAsWatched(historyEntry)) {
     return false
   }
 

--- a/src/renderer/components/FtListVideo/FtListVideo.vue
+++ b/src/renderer/components/FtListVideo/FtListVideo.vue
@@ -1299,7 +1299,7 @@ function parseVideoData() {
   }
 
   description.value = props.data.description
-  isLive.value = props.data.liveNow || props.data.lengthSeconds === undefined
+  isLive.value = props.data.isLive || props.data.liveNow || props.data.lengthSeconds === undefined
   isPremiere.value = props.data.isPremiere === true ||
     (isLive.value && props.data.premiereTimestamp > 0)
   isUpcoming.value = props.data.isUpcoming || props.data.premiere

--- a/src/renderer/components/FtListVideo/FtListVideo.vue
+++ b/src/renderer/components/FtListVideo/FtListVideo.vue
@@ -474,6 +474,8 @@ const historyEntryExists = computed(() => historyEntry.value !== undefined)
 
 const isWatched = computed(() => isHistoryEntryWatched(historyEntry.value))
 
+const canMarkAsWatched = computed(() => !isLive.value)
+
 const watchProgress = computed(() => {
   if (!historyEntryExists.value || !watchedProgressSavingEnabled.value) {
     return 0
@@ -509,6 +511,9 @@ const extraThumbnailAction = computed(() => store.getters.getExtraThumbnailActio
 const extraThumbnailActionButton = computed(() => {
   switch (extraThumbnailAction.value) {
     case 'history':
+      if (!canMarkAsWatched.value) {
+        return null
+      }
       return {
         title: isWatched.value
           ? t('Video.Unmark As Watched')
@@ -593,13 +598,15 @@ const dropdownOptions = computed(() => {
     {
       type: 'divider'
     },
-    {
-      label: isWatched.value
-        ? t('Video.Unmark As Watched')
-        : t('Video.Mark As Watched'),
-      value: 'history',
-      icon: isWatched.value ? ['fas', 'eye-slash'] : ['fas', 'eye']
-    },
+    ...canMarkAsWatched.value
+      ? [{
+          label: isWatched.value
+            ? t('Video.Unmark As Watched')
+            : t('Video.Mark As Watched'),
+          value: 'history',
+          icon: isWatched.value ? ['fas', 'eye-slash'] : ['fas', 'eye']
+        }]
+      : [],
     ...historyEntryExists.value
       ? [{
           label: t('Video.Remove From History'),
@@ -1226,7 +1233,7 @@ function openInExternalPlayer() {
     window.ftElectron.openInExternalPlayer(payload)
   }
 
-  if (rememberHistory.value) {
+  if (rememberHistory.value && canMarkAsWatched.value) {
     markAsWatched()
   }
 }
@@ -1341,6 +1348,10 @@ function parseVideoData() {
 }
 
 function markAsWatched() {
+  if (!canMarkAsWatched.value) {
+    return
+  }
+
   const videoData = {
     ...historyEntry.value,
     videoId: id.value,

--- a/src/renderer/helpers/history.js
+++ b/src/renderer/helpers/history.js
@@ -1,4 +1,5 @@
 export {
+  canMarkHistoryEntryAsWatched,
   hasReachedWatchedThreshold,
   isHistoryEntryWatched,
   migrateLegacyHistoryRecord,

--- a/src/renderer/store/modules/history.js
+++ b/src/renderer/store/modules/history.js
@@ -1,5 +1,8 @@
 import { DBHistoryHandlers } from '../../../datastores/handlers/index'
-import { migrateLegacyHistoryRecord } from '../../helpers/history'
+import {
+  canMarkHistoryEntryAsWatched,
+  migrateLegacyHistoryRecord,
+} from '../../helpers/history'
 
 const MILLISECONDS_PER_DAY = 24 * 60 * 60 * 1000
 
@@ -102,7 +105,7 @@ const actions = {
   async markAllHistoryAsWatched({ dispatch, state }) {
     let markedCount = 0
     const records = state.historyCacheSorted.map(record => {
-      if (record.isWatched === true) {
+      if (record.isWatched === true || !canMarkHistoryEntryAsWatched(record)) {
         return record
       }
 

--- a/src/renderer/views/History/History.vue
+++ b/src/renderer/views/History/History.vue
@@ -283,7 +283,7 @@ const historyCacheSorted = computed(() => {
 })
 
 const hasUnwatchedHistory = computed(() => {
-  return historyCacheSorted.value.some(record => record.isWatched !== true)
+  return historyCacheSorted.value.some(record => record.isWatched !== true && record.isLive !== true)
 })
 
 async function markAllAsWatched() {

--- a/src/renderer/views/Watch/Watch.js
+++ b/src/renderer/views/Watch/Watch.js
@@ -2032,7 +2032,7 @@ export default defineComponent({
         watchProgress: watchProgress,
         isWatched,
         timeWatched: now,
-        isLive: false,
+        isLive: this.isLive,
         type: 'video',
       }
 

--- a/src/renderer/views/Watch/Watch.js
+++ b/src/renderer/views/Watch/Watch.js
@@ -2062,7 +2062,12 @@ export default defineComponent({
     },
 
     markAsWatchedIfFinished(currentSeconds, isFinished = false) {
-      if (!this.rememberHistory || this.isUpcoming || this.isLive || this.historyEntry?.isWatched === true) {
+      if (
+        !this.rememberHistory ||
+        this.isUpcoming ||
+        this.isLive ||
+        isHistoryEntryWatched(this.historyEntry)
+      ) {
         return
       }
 

--- a/tests/unit/history.test.mjs
+++ b/tests/unit/history.test.mjs
@@ -2,8 +2,10 @@ import assert from 'node:assert/strict'
 import test from 'node:test'
 
 import {
+  canMarkHistoryEntryAsWatched,
   DEFAULT_WATCHED_PERCENTAGE_THRESHOLD,
   hasReachedWatchedThreshold,
+  isHistoryEntryWatched,
 } from '../../src/history.js'
 
 test('uses the hybrid threshold by default', () => {
@@ -31,4 +33,11 @@ test('rejects invalid video progress and falls back from invalid thresholds', ()
   assert.equal(hasReachedWatchedThreshold(30, 0, 50), false)
   assert.equal(hasReachedWatchedThreshold(0, 60, -1), false)
   assert.equal(hasReachedWatchedThreshold(54 * 60, 60 * 60, 101), false)
+})
+
+test('active live content cannot be marked as watched', () => {
+  assert.equal(canMarkHistoryEntryAsWatched({ isLive: true }), false)
+  assert.equal(isHistoryEntryWatched({ isLive: true, isWatched: true }), false)
+  assert.equal(canMarkHistoryEntryAsWatched({ isLive: false }), true)
+  assert.equal(isHistoryEntryWatched({ isLive: false, isWatched: true }), true)
 })

--- a/tests/unit/history.test.mjs
+++ b/tests/unit/history.test.mjs
@@ -40,4 +40,9 @@ test('active live content cannot be marked as watched', () => {
   assert.equal(isHistoryEntryWatched({ isLive: true, isWatched: true }), false)
   assert.equal(canMarkHistoryEntryAsWatched({ isLive: false }), true)
   assert.equal(isHistoryEntryWatched({ isLive: false, isWatched: true }), true)
+  assert.equal(isHistoryEntryWatched({
+    isLive: false,
+    watchProgress: 9 * 60,
+    lengthSeconds: 10 * 60,
+  }), true)
 })


### PR DESCRIPTION
## Summary

- prevent active livestreams and running premieres from being marked as watched
- hide manual watched actions for active live content and skip it in bulk updates
- preserve normal watched behavior for completed livestream recordings
- cover active livestream history and running premiere UI behavior with tests

## Root cause

Active live content shared the same manual and bulk watched-state paths as completed videos, and history entries were persisted with `isLive: false`.

## Validation

- `pnpm test:unit` (66 passed)
- `xvfb-run -a -s "-screen 0 1920x1080x24" pnpm test:e2e:offline e2e/tests/offline/history.spec.mjs e2e/tests/offline/subscriptions-feed.spec.mjs --workers=1` (12 passed)
- `pnpm lint`
- `git diff --check`

Resolves #222