### PR TITLE
Fix overlay scrollbar drag offset during content loads

### DIFF
--- a/e2e/tests/offline/scrollbar-overlay.spec.mjs
+++ b/e2e/tests/offline/scrollbar-overlay.spec.mjs
@@ -82,6 +82,35 @@ test.describe('overlay scrollbars', () => {
     await expect.poll(() => page.evaluate(() => window.scrollY)).toBeGreaterThan(0)
   })
 
+  test('keeps the page handle under the pointer when content loads during a drag', async ({ page }) => {
+    await goTo(page, 'settings')
+    await expect.poll(() => pageOverflows(page)).toBe(true)
+
+    const handle = page.locator(`${PAGE_SCROLLBAR} .os-scrollbar-handle`)
+    const initialBox = await handle.boundingBox()
+    const pointerX = initialBox.x + initialBox.width / 2
+    const pointerY = initialBox.y + initialBox.height / 2 + 150
+
+    await page.mouse.move(initialBox.x + initialBox.width / 2, initialBox.y + initialBox.height / 2)
+    await page.mouse.down()
+    await page.mouse.move(pointerX, pointerY)
+
+    const heightBefore = await handle.evaluate((element) => element.clientHeight)
+    await page.evaluate(() => {
+      const addedContent = document.createElement('div')
+      addedContent.style.height = '3000px'
+      document.body.append(addedContent)
+    })
+
+    await expect.poll(() => handle.evaluate((element) => element.clientHeight)).toBeLessThan(heightBefore)
+    await expect.poll(async () => {
+      const box = await handle.boundingBox()
+      return Math.abs(box.y + box.height / 2 - pointerY)
+    }).toBeLessThan(2)
+
+    await page.mouse.up()
+  })
+
   test.describe('a nested scroll container', () => {
     const now = Date.now()
     test.use({

--- a/src/renderer/helpers/overlayScrollbars.js
+++ b/src/renderer/helpers/overlayScrollbars.js
@@ -81,20 +81,35 @@ function optimizeBodyScrollbarDrag(instance) {
     event.stopImmediatePropagation()
 
     const pointerId = event.pointerId
-    const startClientY = event.clientY
-    const startScrollY = window.scrollY
-    const scrollRange = instance.state().overflowAmount.y
-    const trackRange = track.clientHeight - handle.clientHeight
-    let clientY = startClientY
+    const handleBounds = handle.getBoundingClientRect()
+    const grabRatio = (event.clientY - handleBounds.top) / handleBounds.height
+    let clientY = event.clientY
     let frame = null
 
-    if (trackRange <= 0 || scrollRange <= 0) {
+    if (track.clientHeight <= handle.clientHeight || instance.state().overflowAmount.y <= 0) {
       return
     }
 
     const applyDrag = () => {
       frame = null
-      window.scrollTo(window.scrollX, startScrollY + (clientY - startClientY) / trackRange * scrollRange)
+      const scrollRange = instance.state().overflowAmount.y
+      const currentHandleBounds = handle.getBoundingClientRect()
+      const trackRange = track.clientHeight - handle.clientHeight
+      const handleOffset = clientY -
+        (currentHandleBounds.top + currentHandleBounds.height * grabRatio)
+
+      if (trackRange <= 0 || scrollRange <= 0) {
+        return
+      }
+
+      window.scrollTo(
+        window.scrollX,
+        window.scrollY + handleOffset / trackRange * scrollRange
+      )
+    }
+
+    const scheduleDrag = () => {
+      frame ??= requestAnimationFrame(applyDrag)
     }
 
     const onPointerMove = (moveEvent) => {
@@ -105,7 +120,13 @@ function optimizeBodyScrollbarDrag(instance) {
       moveEvent.preventDefault()
       moveEvent.stopPropagation()
       clientY = moveEvent.clientY
-      frame ??= requestAnimationFrame(applyDrag)
+      scheduleDrag()
+    }
+
+    const onUpdated = (_, { updateHints }) => {
+      if (updateHints.overflowAmountChanged || updateHints.overflowEdgeChanged) {
+        scheduleDrag()
+      }
     }
 
     const finish = (finishEvent) => {
@@ -117,6 +138,7 @@ function optimizeBodyScrollbarDrag(instance) {
       handle.removeEventListener('pointermove', onPointerMove)
       handle.removeEventListener('pointerup', finish)
       handle.removeEventListener('pointercancel', finish)
+      instance.off('updated', onUpdated)
 
       if (frame !== null) {
         cancelAnimationFrame(frame)
@@ -127,6 +149,7 @@ function optimizeBodyScrollbarDrag(instance) {
     handle.addEventListener('pointermove', onPointerMove)
     handle.addEventListener('pointerup', finish)
     handle.addEventListener('pointercancel', finish)
+    instance.on('updated', onUpdated)
     handle.setPointerCapture(pointerId)
   }
 


### PR DESCRIPTION
## What changed

- Recompute page scrollbar drags from the handle's live geometry and current scroll range.
- Reapply the held drag position when content or viewport updates change the scrollbar geometry.
- Add an end-to-end regression test that grows the page while the scrollbar handle is held.

## Why

The optimized page scrollbar drag captured the scroll and track ranges only at pointer-down. When infinite content loaded during a drag, OverlayScrollbars resized and repositioned the handle, while the drag calculation continued using stale geometry. This made the handle jump away from the cursor by an amount related to the newly loaded content.

The updated calculation preserves the pointer's relative grab position on the handle and maps against the current geometry, so the handle remains attached to the cursor even when the pointer is stationary during a content update.

## Validation

- `xvfb-run -a -s "-screen 0 1920x1080x24" pnpm exec playwright test -c e2e/playwright.config.mjs --project=offline e2e/tests/offline/scrollbar-overlay.spec.mjs` — 8 passed
- `pnpm exec eslint --config eslint.config.mjs src/renderer/helpers/overlayScrollbars.js e2e/tests/offline/scrollbar-overlay.spec.mjs`
- `git diff --check`