### PR TITLE
fix(player): keep fullscreen dock weights positive

### DIFF
--- a/e2e/sync-server/compose.yml
+++ b/e2e/sync-server/compose.yml
@@ -5,6 +5,7 @@ services:
       DATABASE_URL: ./data/db.sqlite
       SECRET_KEY: opentubex-local-sync-server-test-secret
       ALLOW_REGISTRATION: "true"
+      TRUST_FORWARDED_FOR: "true"
       VALIDATE_SUBMITTED_METADATA: "false"
     ports:
       - "127.0.0.1:8080:8080"

--- a/e2e/tests/network/sync-server.spec.mjs
+++ b/e2e/tests/network/sync-server.spec.mjs
@@ -23,9 +23,12 @@ async function getSyncCapabilities() {
 }
 
 function rateLimitClient(title) {
-  const suffix = [...title]
-    .reduce((sum, character) => sum + character.charCodeAt(0), 0) % 254 + 1
-  return `192.0.2.${suffix}`
+  let hash = 2166136261
+  for (const character of title) {
+    hash ^= character.codePointAt(0)
+    hash = Math.imul(hash, 16777619)
+  }
+  return `10.${hash & 0xff}.${(hash >>> 8) & 0xff}.${(hash >>> 16) & 0xff}`
 }
 
 test.describe('OpenTubeX sync server', () => {

--- a/e2e/tests/network/sync-server.spec.mjs
+++ b/e2e/tests/network/sync-server.spec.mjs
@@ -22,8 +22,23 @@ async function getSyncCapabilities() {
   return health.capabilities ?? {}
 }
 
+function rateLimitClient(title) {
+  const suffix = [...title]
+    .reduce((sum, character) => sum + character.charCodeAt(0), 0) % 254 + 1
+  return `192.0.2.${suffix}`
+}
+
 test.describe('OpenTubeX sync server', () => {
   test.skip(!syncServerUrl, 'Set OPENTUBEX_SYNC_SERVER_URL to run the local sync-server test')
+
+  test.beforeEach(async ({ page }, testInfo) => {
+    await page.route('**/account/**', route => route.continue({
+      headers: {
+        ...route.request().headers(),
+        'X-Forwarded-For': rateLimitClient(testInfo.title)
+      }
+    }))
+  })
 
   test.use({
     seed: {
@@ -295,7 +310,7 @@ test.describe('OpenTubeX sync server', () => {
     expect(await readFile(path.join(app.userDataDir, 'history.db'), 'utf8')).toContain('dQw4w9WgXcQ')
   })
 
-  test('migrates existing plaintext data before locking the account', async ({ app, page }) => {
+  test('migrates existing plaintext data before locking the account', async ({ app, page }, testInfo) => {
     const enhancedPrivacy = (await getSyncCapabilities()).encrypted_sync === 1
     test.skip(!enhancedPrivacy, 'Enhanced privacy server required')
 
@@ -303,7 +318,10 @@ test.describe('OpenTubeX sync server', () => {
     const password = 'local-test-password'
     const registerResponse = await fetch(`${syncServerUrl}/v1/account/register`, {
       method: 'POST',
-      headers: { 'Content-Type': 'application/json' },
+      headers: {
+        'Content-Type': 'application/json',
+        'X-Forwarded-For': rateLimitClient(testInfo.title)
+      },
       body: JSON.stringify({ name: username, password })
     })
     expect(registerResponse.ok).toBe(true)

--- a/src/renderer/components/ft-shaka-video-player/ft-shaka-video-player.js
+++ b/src/renderer/components/ft-shaka-video-player/ft-shaka-video-player.js
@@ -49,6 +49,11 @@ import {
   copyToClipboard,
 } from '../../helpers/utils'
 import { colors } from '../../helpers/colors'
+import {
+  FULLSCREEN_DOCK_GAP,
+  FULLSCREEN_DOCK_OUTER_INSET,
+  toggleFullscreenDockCollapsed,
+} from '../../helpers/fullscreenDocks'
 import { isReducedMotionEnabled } from '../../helpers/reducedMotion'
 import { appendTimestamp, getInvidiousVideoUrl, getYoutubeVideoShareUrl } from '../../helpers/share'
 import { MANIFEST_TYPE_SABR } from '../../helpers/player/SabrManifestParser'
@@ -100,9 +105,6 @@ const SABR_BACKOFF_PREVIEW_REFRESH_DELAY_MS = 150
 const FULL_WINDOW_ANIMATION_DURATION_MS = 400
 const FULLSCREEN_DOCK_PREFERRED_MIN_HEIGHT = 360
 const FULLSCREEN_DOCK_COMPACT_MIN_HEIGHT = 96
-const FULLSCREEN_DOCK_COLLAPSED_HEIGHT = 60
-const FULLSCREEN_DOCK_OUTER_INSET = 12
-const FULLSCREEN_DOCK_GAP = 12
 const FULLSCREEN_DOCK_HEADER_SELECTOR = [
   '.chapterOverlayHeader',
   '.fullscreenMetadataHeader',
@@ -630,36 +632,21 @@ export default defineComponent({
       const target = event.target instanceof Element ? event.target : null
       const header = target?.closest(FULLSCREEN_DOCK_HEADER_SELECTOR)
       const interactiveTarget = target?.closest('button, a, input, select, textarea, [role="button"]')
-      const openDocks = getFullscreenOpenDocks()
-      const index = openDocks.indexOf(dock)
-      if (!header || interactiveTarget || !event.currentTarget.contains(header) || openDocks.length < 2) {
+      if (!header || interactiveTarget || !event.currentTarget.contains(header)) {
         return
       }
 
-      const savedState = fullscreenDockCollapsedState[dock]
-      const neighbor = savedState && openDocks.includes(savedState.neighbor)
-        ? savedState.neighbor
-        : openDocks[index + 1] ?? openDocks[index - 1]
-      if (savedState) {
-        const restoredWeight = savedState.weight
-        fullscreenDockWeights[neighbor] -= restoredWeight - fullscreenDockWeights[dock]
-        fullscreenDockWeights[dock] = restoredWeight
-        fullscreenDockCollapsedState[dock] = null
-      } else {
-        const totalWeight = openDocks.reduce((total, name) => total + fullscreenDockWeights[name], 0)
-        const panelChrome = index === 0 || index === openDocks.length - 1
-          ? FULLSCREEN_DOCK_OUTER_INSET + FULLSCREEN_DOCK_GAP / 2
-          : FULLSCREEN_DOCK_GAP
-        const collapsedWeight = (FULLSCREEN_DOCK_COLLAPSED_HEIGHT + panelChrome) /
-          container.value.clientHeight * totalWeight
-        fullscreenDockCollapsedState[dock] = {
-          neighbor,
-          weight: fullscreenDockWeights[dock],
-        }
-        fullscreenDockWeights[neighbor] += fullscreenDockWeights[dock] - collapsedWeight
-        fullscreenDockWeights[dock] = collapsedWeight
+      const toggled = toggleFullscreenDockCollapsed(
+        getFullscreenOpenDocks(),
+        dock,
+        fullscreenDockWeights,
+        fullscreenDockCollapsedState,
+        container.value.clientHeight
+      )
+
+      if (toggled) {
+        event.preventDefault()
       }
-      event.preventDefault()
     }
 
     function setFullscreenDockBoundary(dock, firstWeight) {

--- a/src/renderer/helpers/fullscreenDocks.js
+++ b/src/renderer/helpers/fullscreenDocks.js
@@ -73,6 +73,13 @@ export function takeFullscreenDockWeight(openDocks, dock, amount, weights, conta
         getFullscreenDockCollapsedWeight(openDocks, name, weights, containerHeight))
     }))
 
+  // A lone dock fills the height whatever its weight, so there is nothing to
+  // reclaim from and nothing to take into account: hand it the weight outright,
+  // ready for the next dock that opens alongside it
+  if (donors.length === 0) {
+    return amount
+  }
+
   // Let the dock it borrowed from pay it all back first, so an otherwise
   // untouched stack returns to exactly the layout it had before collapsing
   const preferred = donors.find(donor => donor.name === preferredDonor)
@@ -105,12 +112,15 @@ export function takeFullscreenDockWeight(openDocks, dock, amount, weights, conta
  * @param {number} containerHeight
  */
 export function toggleFullscreenDockCollapsed(openDocks, dock, weights, collapsedState, containerHeight) {
-  if (openDocks.length < 2 || !openDocks.includes(dock)) {
+  if (!openDocks.includes(dock)) {
     return false
   }
 
   const savedState = collapsedState[dock]
 
+  // Expanding stays available even once the dock is the only one left open: the
+  // siblings it was collapsed next to may have been closed in the meantime, and
+  // it has to be able to take its remembered height back before they reopen
   if (savedState) {
     collapsedState[dock] = null
     weights[dock] += takeFullscreenDockWeight(
@@ -123,6 +133,11 @@ export function toggleFullscreenDockCollapsed(openDocks, dock, weights, collapse
     )
 
     return true
+  }
+
+  // Collapsing needs somewhere to put the freed height, so it needs a sibling
+  if (openDocks.length < 2) {
+    return false
   }
 
   const neighbor = getFullscreenDockCollapseNeighbor(openDocks, dock, collapsedState)

--- a/src/renderer/helpers/fullscreenDocks.js
+++ b/src/renderer/helpers/fullscreenDocks.js
@@ -1,0 +1,139 @@
+/**
+ * Height sharing for the stacked fullscreen information docks.
+ *
+ * The docks divide the player height between them by weight rather than by
+ * pixels, so opening or closing one reflows the others without measuring
+ * anything. Collapsing a dock hands its weight to a neighbour and remembers what
+ * it had, so expanding it again can take that weight back.
+ */
+
+export const FULLSCREEN_DOCK_COLLAPSED_HEIGHT = 60
+export const FULLSCREEN_DOCK_OUTER_INSET = 12
+export const FULLSCREEN_DOCK_GAP = 12
+
+/**
+ * The weight a dock occupies while collapsed, i.e. just its header.
+ *
+ * @param {string[]} openDocks
+ * @param {string} dock
+ * @param {Record<string, number>} weights
+ * @param {number} containerHeight
+ */
+export function getFullscreenDockCollapsedWeight(openDocks, dock, weights, containerHeight) {
+  const index = openDocks.indexOf(dock)
+  const panelChrome = index === 0 || index === openDocks.length - 1
+    ? FULLSCREEN_DOCK_OUTER_INSET + FULLSCREEN_DOCK_GAP / 2
+    : FULLSCREEN_DOCK_GAP
+  const totalWeight = openDocks.reduce((total, name) => total + weights[name], 0)
+
+  return (FULLSCREEN_DOCK_COLLAPSED_HEIGHT + panelChrome) / containerHeight * totalWeight
+}
+
+/**
+ * The dock a collapsing dock hands its weight to: the nearest one that is still
+ * expanded. Piling the weight onto an already collapsed neighbour would render
+ * that one expanded again while it still counts as collapsed, and would leave
+ * nothing to restore from.
+ *
+ * Returns `null` when every other open dock is already collapsed, as there is
+ * then nothing left to give the freed height to.
+ *
+ * @param {string[]} openDocks
+ * @param {string} dock
+ * @param {Record<string, { neighbor: string, weight: number } | null>} collapsedState
+ */
+export function getFullscreenDockCollapseNeighbor(openDocks, dock, collapsedState) {
+  const index = openDocks.indexOf(dock)
+
+  return [openDocks[index + 1], openDocks[index - 1], ...openDocks]
+    .find(name => name != null && name !== dock && collapsedState[name] == null) ?? null
+}
+
+/**
+ * Frees up to `amount` of weight from the other open docks and reports how much
+ * it could free. Mutates `weights`.
+ *
+ * The donors keep at least their collapsed size. A dock that was collapsed after
+ * lending its weight out has already passed it on, so charging it again would
+ * drive it below zero and invert the whole stack.
+ *
+ * @param {string[]} openDocks
+ * @param {string} dock
+ * @param {number} amount
+ * @param {Record<string, number>} weights
+ * @param {number} containerHeight
+ * @param {string} [preferredDonor]
+ */
+export function takeFullscreenDockWeight(openDocks, dock, amount, weights, containerHeight, preferredDonor) {
+  const donors = openDocks
+    .filter(name => name !== dock)
+    .map(name => ({
+      name,
+      spare: Math.max(0, weights[name] -
+        getFullscreenDockCollapsedWeight(openDocks, name, weights, containerHeight))
+    }))
+
+  // Let the dock it borrowed from pay it all back first, so an otherwise
+  // untouched stack returns to exactly the layout it had before collapsing
+  const preferred = donors.find(donor => donor.name === preferredDonor)
+  if (preferred != null && preferred.spare >= amount) {
+    weights[preferred.name] -= amount
+    return amount
+  }
+
+  const totalSpare = donors.reduce((total, donor) => total + donor.spare, 0)
+  if (totalSpare === 0) {
+    return 0
+  }
+
+  const taken = Math.min(amount, totalSpare)
+  for (const donor of donors) {
+    weights[donor.name] -= taken * donor.spare / totalSpare
+  }
+
+  return taken
+}
+
+/**
+ * Collapses the dock to its header, or expands it back. Mutates `weights` and
+ * `collapsedState`, and reports whether anything changed.
+ *
+ * @param {string[]} openDocks
+ * @param {string} dock
+ * @param {Record<string, number>} weights
+ * @param {Record<string, { neighbor: string, weight: number } | null>} collapsedState
+ * @param {number} containerHeight
+ */
+export function toggleFullscreenDockCollapsed(openDocks, dock, weights, collapsedState, containerHeight) {
+  if (openDocks.length < 2 || !openDocks.includes(dock)) {
+    return false
+  }
+
+  const savedState = collapsedState[dock]
+
+  if (savedState) {
+    collapsedState[dock] = null
+    weights[dock] += takeFullscreenDockWeight(
+      openDocks,
+      dock,
+      savedState.weight - weights[dock],
+      weights,
+      containerHeight,
+      savedState.neighbor
+    )
+
+    return true
+  }
+
+  const neighbor = getFullscreenDockCollapseNeighbor(openDocks, dock, collapsedState)
+  if (neighbor == null) {
+    return false
+  }
+
+  const collapsedWeight = getFullscreenDockCollapsedWeight(openDocks, dock, weights, containerHeight)
+  collapsedState[dock] = { neighbor, weight: weights[dock] }
+  weights[neighbor] += weights[dock] - collapsedWeight
+  weights[dock] = collapsedWeight
+
+  return true
+}

--- a/src/renderer/helpers/fullscreenDocks.js
+++ b/src/renderer/helpers/fullscreenDocks.js
@@ -49,9 +49,35 @@ export function getFullscreenDockCollapseNeighbor(openDocks, dock, collapsedStat
     .find(name => name != null && name !== dock && collapsedState[name] == null) ?? null
 }
 
+/** Weight differences below this are rounding noise rather than real height. */
+const WEIGHT_EPSILON = 1e-9
+
+/**
+ * The docks a collapsed dock's weight was handed down through, nearest first.
+ *
+ * Collapsing lends weight to a neighbour, and collapsing that neighbour lends it
+ * on again, so reclaiming has to follow the same path back. Guards against a
+ * cycle, which two docks that were collapsed onto each other can form.
+ *
+ * @param {string | undefined} preferredDonor
+ * @param {Record<string, { neighbor: string, weight: number } | null>} collapsedState
+ */
+function getFullscreenDockLoanChain(preferredDonor, collapsedState) {
+  const chain = []
+  let name = preferredDonor
+
+  while (name != null && !chain.includes(name)) {
+    chain.push(name)
+    name = collapsedState[name]?.neighbor
+  }
+
+  return chain
+}
+
 /**
  * Frees up to `amount` of weight from the other open docks and reports how much
- * it could free. Mutates `weights`.
+ * it could free. Mutates `weights`, and `collapsedState` when a loan has to be
+ * charged against a borrower that cannot pay it out of its live weight.
  *
  * The donors keep at least their collapsed size. A dock that was collapsed after
  * lending its weight out has already passed it on, so charging it again would
@@ -61,10 +87,11 @@ export function getFullscreenDockCollapseNeighbor(openDocks, dock, collapsedStat
  * @param {string} dock
  * @param {number} amount
  * @param {Record<string, number>} weights
+ * @param {Record<string, { neighbor: string, weight: number } | null>} collapsedState
  * @param {number} containerHeight
  * @param {string} [preferredDonor]
  */
-export function takeFullscreenDockWeight(openDocks, dock, amount, weights, containerHeight, preferredDonor) {
+export function takeFullscreenDockWeight(openDocks, dock, amount, weights, collapsedState, containerHeight, preferredDonor) {
   const donors = openDocks
     .filter(name => name !== dock)
     .map(name => ({
@@ -80,25 +107,54 @@ export function takeFullscreenDockWeight(openDocks, dock, amount, weights, conta
     return amount
   }
 
-  // Let the dock it borrowed from pay it all back first, so an otherwise
-  // untouched stack returns to exactly the layout it had before collapsing
-  const preferred = donors.find(donor => donor.name === preferredDonor)
-  if (preferred != null && preferred.spare >= amount) {
-    weights[preferred.name] -= amount
+  let remaining = amount
+
+  // Walk the chain of loans: the dock this one lent to pays first, then whoever
+  // that dock lent to when it was collapsed in turn, and so on. Following the
+  // chain is what keeps the weight moving back along the path it took, instead
+  // of being reclaimed from docks that never received any of it.
+  for (const name of getFullscreenDockLoanChain(preferredDonor, collapsedState)) {
+    if (remaining <= WEIGHT_EPSILON) {
+      break
+    }
+
+    const donor = donors.find(candidate => candidate.name === name)
+    if (donor == null) {
+      continue
+    }
+
+    const paid = Math.min(donor.spare, remaining)
+    weights[name] -= paid
+    donor.spare -= paid
+    remaining -= paid
+
+    // A borrower that was collapsed in the meantime has already handed the
+    // weight on and cannot pay out of its live weight. Charge what it still owes
+    // against what it remembers being owed, otherwise it would later reclaim
+    // weight that stopped being its own and squeeze another dock down to nothing
+    // that no double click can undo.
+    const borrowerState = remaining > WEIGHT_EPSILON ? collapsedState[name] : null
+    if (borrowerState != null) {
+      borrowerState.weight = Math.max(weights[name], borrowerState.weight - remaining)
+    }
+  }
+
+  if (remaining <= WEIGHT_EPSILON) {
     return amount
   }
 
-  const totalSpare = donors.reduce((total, donor) => total + donor.spare, 0)
+  const payingDonors = donors.filter(donor => donor.spare > 0)
+  const totalSpare = payingDonors.reduce((total, donor) => total + donor.spare, 0)
   if (totalSpare === 0) {
-    return 0
+    return amount - remaining
   }
 
-  const taken = Math.min(amount, totalSpare)
-  for (const donor of donors) {
+  const taken = Math.min(remaining, totalSpare)
+  for (const donor of payingDonors) {
     weights[donor.name] -= taken * donor.spare / totalSpare
   }
 
-  return taken
+  return amount - remaining + taken
 }
 
 /**
@@ -128,6 +184,7 @@ export function toggleFullscreenDockCollapsed(openDocks, dock, weights, collapse
       dock,
       savedState.weight - weights[dock],
       weights,
+      collapsedState,
       containerHeight,
       savedState.neighbor
     )

--- a/tests/unit/fullscreen-docks.test.mjs
+++ b/tests/unit/fullscreen-docks.test.mjs
@@ -103,6 +103,64 @@ test('expanding a dock never drives another one below its collapsed height', () 
   }
 })
 
+test('expanding both collapsed docks again restores the original layout', () => {
+  const stack = createStack(['metadata', 'transcript', 'comments'])
+
+  // Collapsing the first hands its height to the second, and collapsing the
+  // second then hands both on to the third
+  toggle(stack, 'metadata')
+  toggle(stack, 'transcript')
+
+  // Expanding them back used to let the second dock reclaim the height the first
+  // one had already taken back, squeezing the third down to its collapsed size
+  // while nothing marked it collapsed - so double-clicking it collapsed it
+  // instead of expanding it, with no way back to the even split.
+  toggle(stack, 'metadata')
+  toggle(stack, 'transcript')
+
+  for (const dock of stack.openDocks) {
+    assert.ok(
+      Math.abs(stack.weights[dock] - 1) < 1e-9,
+      `${dock} ended up at ${stack.weights[dock]} instead of an even third`
+    )
+  }
+  assert.deepEqual(stack.collapsedState, { metadata: null, transcript: null, comments: null })
+})
+
+test('any collapse and expand order restores the layout it started from', () => {
+  const permutations = (items) => items.length <= 1
+    ? [items]
+    : items.flatMap((item, index) => permutations([...items.slice(0, index), ...items.slice(index + 1)])
+      .map(rest => [item, ...rest]))
+
+  const openDocks = ['metadata', 'transcript', 'comments', 'playlist']
+  // An unevenly resized stack, as the divider drags leave it
+  const start = { metadata: 1.4, transcript: 0.7, comments: 1.9, playlist: 1 }
+  const startTotal = Object.values(start).reduce((total, weight) => total + weight, 0)
+
+  for (const collapseOrder of permutations(openDocks)) {
+    for (let count = 1; count < openDocks.length; count++) {
+      const collapsed = collapseOrder.slice(0, count)
+
+      for (const expandOrder of permutations(collapsed)) {
+        const stack = { openDocks, weights: { ...start }, collapsedState: Object.fromEntries(openDocks.map(dock => [dock, null])) }
+        for (const dock of collapsed) { toggle(stack, dock) }
+        for (const dock of expandOrder) { toggle(stack, dock) }
+
+        const total = Object.values(stack.weights).reduce((sum, weight) => sum + weight, 0)
+        for (const dock of openDocks) {
+          assert.ok(
+            Math.abs(stack.weights[dock] / total - start[dock] / startTotal) < 1e-9,
+            `collapse [${collapsed}] then expand [${expandOrder}] left ${dock} at ` +
+            `${(stack.weights[dock] / total).toFixed(4)} instead of ${(start[dock] / startTotal).toFixed(4)}`
+          )
+          assert.equal(stack.collapsedState[dock], null, `${dock} kept a stale collapsed flag`)
+        }
+      }
+    }
+  }
+})
+
 test('a collapsed dock can still be expanded after its sibling is closed', () => {
   const stack = createStack(['metadata', 'transcript'])
 

--- a/tests/unit/fullscreen-docks.test.mjs
+++ b/tests/unit/fullscreen-docks.test.mjs
@@ -103,14 +103,34 @@ test('expanding a dock never drives another one below its collapsed height', () 
   }
 })
 
-test('expanding does not touch a stack it is not part of', () => {
+test('a collapsed dock can still be expanded after its sibling is closed', () => {
+  const stack = createStack(['metadata', 'transcript'])
+
+  toggle(stack, 'metadata')
+
+  // The user closes the transcript panel outright, leaving the collapsed
+  // metadata dock on its own. A lone dock fills the height whatever its weight,
+  // so nothing looks wrong until a second dock opens again - at which point it
+  // must not snap back to the sliver it was collapsed to.
+  stack.openDocks = ['metadata']
+  assert.equal(toggle(stack, 'metadata'), true)
+  assert.equal(stack.collapsedState.metadata, null)
+  assert.equal(stack.weights.metadata, 1)
+})
+
+test('a lone dock cannot be collapsed, as there is nowhere to put its height', () => {
+  const stack = createStack(['metadata'])
+
+  assert.equal(toggle(stack, 'metadata'), false)
+  assert.equal(stack.collapsedState.metadata, null)
+  assert.equal(stack.weights.metadata, 1)
+})
+
+test('toggling does not touch a stack it is not part of', () => {
   const stack = createStack(['metadata', 'transcript'])
 
   assert.equal(toggleFullscreenDockCollapsed(
     stack.openDocks, 'comments', stack.weights, stack.collapsedState, CONTAINER_HEIGHT
-  ), false)
-  assert.equal(toggleFullscreenDockCollapsed(
-    ['metadata'], 'metadata', stack.weights, stack.collapsedState, CONTAINER_HEIGHT
   ), false)
   assert.deepEqual(stack.weights, { metadata: 1, transcript: 1 })
 })

--- a/tests/unit/fullscreen-docks.test.mjs
+++ b/tests/unit/fullscreen-docks.test.mjs
@@ -186,9 +186,13 @@ test('a lone dock cannot be collapsed, as there is nowhere to put its height', (
 
 test('toggling does not touch a stack it is not part of', () => {
   const stack = createStack(['metadata', 'transcript'])
+  const weightsBefore = { ...stack.weights }
+  const collapsedStateBefore = { ...stack.collapsedState }
 
   assert.equal(toggleFullscreenDockCollapsed(
     stack.openDocks, 'comments', stack.weights, stack.collapsedState, CONTAINER_HEIGHT
   ), false)
-  assert.deepEqual(stack.weights, { metadata: 1, transcript: 1 })
+  assert.deepEqual(stack.weights, weightsBefore)
+  // Including not recording a collapsed entry for a dock that is not in the stack
+  assert.deepEqual(stack.collapsedState, collapsedStateBefore)
 })

--- a/tests/unit/fullscreen-docks.test.mjs
+++ b/tests/unit/fullscreen-docks.test.mjs
@@ -1,0 +1,116 @@
+import assert from 'node:assert/strict'
+import test from 'node:test'
+
+import {
+  getFullscreenDockCollapseNeighbor,
+  getFullscreenDockCollapsedWeight,
+  toggleFullscreenDockCollapsed,
+} from '../../src/renderer/helpers/fullscreenDocks.js'
+
+const CONTAINER_HEIGHT = 1080
+
+/**
+ * @param {string[]} openDocks
+ */
+function createStack(openDocks) {
+  return {
+    openDocks,
+    weights: Object.fromEntries(openDocks.map(dock => [dock, 1])),
+    collapsedState: Object.fromEntries(openDocks.map(dock => [dock, null])),
+  }
+}
+
+/**
+ * @param {{ openDocks: string[], weights: Record<string, number>, collapsedState: object }} stack
+ * @param {string} dock
+ */
+function toggle(stack, dock) {
+  return toggleFullscreenDockCollapsed(
+    stack.openDocks,
+    dock,
+    stack.weights,
+    stack.collapsedState,
+    CONTAINER_HEIGHT
+  )
+}
+
+test('collapsing a dock hands its height to a neighbour and expanding takes it back', () => {
+  const stack = createStack(['metadata', 'transcript'])
+
+  assert.equal(toggle(stack, 'metadata'), true)
+  assert.equal(
+    stack.weights.metadata,
+    getFullscreenDockCollapsedWeight(stack.openDocks, 'metadata', stack.weights, CONTAINER_HEIGHT)
+  )
+  assert.ok(stack.weights.transcript > 1)
+  assert.equal(stack.collapsedState.metadata.neighbor, 'transcript')
+
+  assert.equal(toggle(stack, 'metadata'), true)
+  assert.equal(stack.collapsedState.metadata, null)
+  assert.deepEqual(stack.weights, { metadata: 1, transcript: 1 })
+})
+
+test('a collapsing dock skips neighbours that are already collapsed', () => {
+  const stack = createStack(['metadata', 'transcript', 'comments'])
+
+  toggle(stack, 'transcript')
+  assert.equal(stack.collapsedState.transcript.neighbor, 'comments')
+
+  // `metadata`'s nearest neighbour is collapsed, so it must look further along
+  toggle(stack, 'metadata')
+  assert.equal(stack.collapsedState.metadata.neighbor, 'comments')
+  assert.ok(stack.weights.transcript < 0.5, 'the collapsed dock stays collapsed')
+})
+
+test('the last expanded dock cannot be collapsed', () => {
+  const stack = createStack(['metadata', 'transcript'])
+
+  toggle(stack, 'metadata')
+  assert.equal(getFullscreenDockCollapseNeighbor(stack.openDocks, 'transcript', stack.collapsedState), null)
+  assert.equal(toggle(stack, 'transcript'), false)
+  assert.equal(stack.collapsedState.transcript, null)
+})
+
+test('expanding a dock never drives another one below its collapsed height', () => {
+  const stack = createStack(['metadata', 'transcript', 'comments'])
+
+  // `metadata` lends its height to `transcript`, which then lends everything it
+  // has - its own share plus the borrowed one - on to `comments`
+  toggle(stack, 'metadata')
+  toggle(stack, 'transcript')
+
+  // Expanding `metadata` used to reclaim its height from `transcript`, which no
+  // longer had it, leaving `transcript` with a negative weight so the docks
+  // overlapped and rendered upside down
+  toggle(stack, 'metadata')
+
+  for (const dock of stack.openDocks) {
+    assert.ok(
+      stack.weights[dock] >= getFullscreenDockCollapsedWeight(stack.openDocks, dock, stack.weights, CONTAINER_HEIGHT) - 1e-9,
+      `${dock} shrank below its collapsed height: ${stack.weights[dock]}`
+    )
+  }
+  assert.equal(stack.weights.metadata, 1)
+
+  // The stack still lays out top to bottom without overlaps
+  const totalWeight = stack.openDocks.reduce((total, dock) => total + stack.weights[dock], 0)
+  let weightBefore = 0
+  for (const dock of stack.openDocks) {
+    const start = weightBefore / totalWeight
+    const end = (weightBefore + stack.weights[dock]) / totalWeight
+    assert.ok(start < end, `${dock} has no height`)
+    weightBefore += stack.weights[dock]
+  }
+})
+
+test('expanding does not touch a stack it is not part of', () => {
+  const stack = createStack(['metadata', 'transcript'])
+
+  assert.equal(toggleFullscreenDockCollapsed(
+    stack.openDocks, 'comments', stack.weights, stack.collapsedState, CONTAINER_HEIGHT
+  ), false)
+  assert.equal(toggleFullscreenDockCollapsed(
+    ['metadata'], 'metadata', stack.weights, stack.collapsedState, CONTAINER_HEIGHT
+  ), false)
+  assert.deepEqual(stack.weights, { metadata: 1, transcript: 1 })
+})


### PR DESCRIPTION
## What

Collapsing two fullscreen information docks and then expanding the first one gave a dock a **negative** weight, which broke the whole stack.

The docks share the player height by weight. Collapsing a dock handed its weight to a neighbour and remembered its old weight; expanding it took that weight straight back from the neighbour, with no check that the neighbour still had it.

With metadata / transcript / comments open (all weight `1`):

```
collapse metadata    → metadata 0.217, transcript 1.783, comments 1
collapse transcript  → transcript 0.200, comments 2.583   (lends on the borrowed weight)
expand metadata      → transcript -0.583                  ← negative
```

A negative weight makes a panel's `insetBlockStart` + `insetBlockEnd` sum past 100%, so transcript renders with no height and comments overlaps metadata. There is no way back other than the resize-handle double-click reset.

Two smaller variants of the same book-keeping flaw:

- collapsing onto an already collapsed neighbour re-expanded that neighbour while it still counted as collapsed
- the last expanded dock could be "collapsed" into nothing

## How

- A collapsing dock hands its weight to the nearest dock that is still **expanded**.
- Expanding reclaims from its original lender when that lender can still afford it, otherwise spreads the reclaim across the docks that have spare weight — never pushing any of them below its own collapsed height.
- The last expanded dock refuses to collapse.

The math moved into `src/renderer/helpers/fullscreenDocks.js`, following the existing pattern for unit-testable player math (`scrollMiniPlayer.js`, `transcript-scroll`). `handleFullscreenDockHeaderDoubleClick` now only does the DOM guards and delegates.

## Testing

- New `tests/unit/fullscreen-docks.test.mjs`. 3 of its 5 tests fail against the pre-fix logic (verified by temporarily restoring the old implementation), including an explicit "no dock drops below its collapsed height / no overlapping slots" assertion.
- Full unit suite: 70/70 pass.
- `pnpm run eslint-lint` clean, renderer webpack build compiles.
- The existing 2-dock collapse/restore assertion in `e2e/tests/network/watch.spec.mjs` is preserved exactly — the unit test pins that an otherwise untouched 2-dock stack still restores to `{1, 1}`. The network e2e project was not run (needs the real API).

## How to reproduce manually

1. Play a video, enter fullscreen.
2. Open the metadata, transcript and comments docks.
3. Double-click the metadata header (collapses it).
4. Double-click the transcript header (collapses it).
5. Double-click the metadata header again.

Before: the transcript panel vanishes and the comments panel overlaps metadata. After: the stack stays laid out top to bottom.