### PR TITLE
Fix comment auto-loading in background tabs

### DIFF
--- a/e2e/tests/network/watch.spec.mjs
+++ b/e2e/tests/network/watch.spec.mjs
@@ -66,6 +66,33 @@ async function setWindowWidth(app, width) {
   }, width)
 }
 
+test.describe('background watch tab', () => {
+  test.use({
+    seed: {
+      settings: {
+        generalAutoLoadMorePaginatedItemsEnabled: true
+      }
+    }
+  })
+
+  test('auto-loads comments for a video opened in the background', async ({ page, innertube }) => {
+    test.skip(innertube.replay, 'watch page hydration needs the real API')
+    await page.evaluate((route) => window.ftElectron.tabs.create({
+      route,
+      makeActive: false
+    }), '/watch/jNQXAC9IVRw')
+
+    const backgroundTab = page.locator(sel.tabs).nth(1)
+    const backgroundContent = page.locator('.tabContent[aria-hidden="true"]').nth(0)
+    await expect(backgroundContent.locator('.videoTitle')).toContainText('Me at the zoo', { timeout: 30_000 })
+    await expect(backgroundContent.locator('.commentsTitle')).toHaveCount(1, { timeout: 30_000 })
+    expect(await backgroundContent.locator('.comment').count()).toBeGreaterThan(0)
+
+    await backgroundTab.click()
+    await expect(page.locator('.commentsTitle')).toBeVisible()
+  })
+})
+
 test.describe('watch page', () => {
   test('shows video metadata', async ({ page, innertube }) => {
     test.skip(innertube.replay, 'watch page hydration needs the real API')

--- a/e2e/tests/network/watch.spec.mjs
+++ b/e2e/tests/network/watch.spec.mjs
@@ -86,7 +86,7 @@ test.describe('background watch tab', () => {
     const backgroundContent = page.locator('.tabContent[aria-hidden="true"]').nth(0)
     await expect(backgroundContent.locator('.videoTitle')).toContainText('Me at the zoo', { timeout: 30_000 })
     await expect(backgroundContent.locator('.commentsTitle')).toHaveCount(1, { timeout: 30_000 })
-    expect(await backgroundContent.locator('.comment').count()).toBeGreaterThan(0)
+    await expect(backgroundContent.locator('.comment')).not.toHaveCount(0, { timeout: 30_000 })
 
     await backgroundTab.click()
     await expect(page.locator('.commentsTitle')).toBeVisible()

--- a/src/renderer/components/CommentSection/CommentSection.vue
+++ b/src/renderer/components/CommentSection/CommentSection.vue
@@ -422,6 +422,7 @@ import FtSpinner from '../FtSpinner/FtSpinner.vue'
 import FtTimestampCatcher from '../FtTimestampCatcher.vue'
 
 import store from '../../store/index'
+import { useTabContext } from '../../tabs/TabContext'
 
 import { copyToClipboard, formatNumber, showApiErrorToast, showToast } from '../../helpers/utils'
 import { getYoutubeCommunityPostCommentUrl, getYoutubeVideoCommentUrl } from '../../helpers/share'
@@ -439,6 +440,7 @@ import {
 } from '../../helpers/api/invidious'
 
 const { t } = useI18n()
+const { isTabPresented } = useTabContext()
 
 const props = defineProps({
   id: {
@@ -635,6 +637,18 @@ const generalAutoLoadMorePaginatedItemsEnabled = computed(() => {
 const canPerformInitialCommentLoading = computed(() => {
   return commentData.value.length === 0 && !isLoading.value && !showComments.value
 })
+
+watch(
+  [generalAutoLoadMorePaginatedItemsEnabled, () => isTabPresented?.value],
+  ([autoLoadEnabled, presented]) => {
+    // Background tabs have no layout, so their visibility observer cannot
+    // trigger the initial load.
+    if (autoLoadEnabled && presented === false && canPerformInitialCommentLoading.value) {
+      getCommentData()
+    }
+  },
+  { immediate: true }
+)
 
 const canPerformMoreCommentLoading = computed(() => {
   return commentData.value.length > 0 && !isLoading.value && !isLoadingMoreComments.value && showComments.value && !!nextPageToken.value


### PR DESCRIPTION
## Summary

- load the initial comment page when an auto-loading watch tab is hidden in the background
- retain the existing visibility-driven loading behavior for presented tabs and pagination
- add an Electron regression test that verifies comments load before the background tab is activated

## Root cause

The single-renderer tab model hides background tab content with `display: none`. That prevents the comment sentinel's `IntersectionObserver` from ever intersecting, so the initial automatic comment request was never made.

## Validation

- `pnpm run test:unit` — 18 passed
- focused Electron/Playwright comment-loading tests — 2 passed
- ESLint on `CommentSection.vue`
- `git diff --check`