### PR TITLE
Fix nightly releases for regularly released commits

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -18,7 +18,7 @@ jobs:
       contents: read
 
     steps:
-    - name: Check for an existing nightly
+    - name: Check for an existing release
       id: nightly
       env:
         GH_TOKEN: ${{ github.token }}
@@ -36,11 +36,26 @@ jobs:
             )] | first | .tag_name // \"\""
         )"
 
+        if [[ -z "$existing_tag" ]]; then
+          while IFS= read -r tag; do
+            release_sha="$(
+              gh api "repos/${GITHUB_REPOSITORY}/commits/$tag" --jq .sha
+            )"
+            if [[ "$release_sha" == "$development_sha" ]]; then
+              existing_tag="$tag"
+              break
+            fi
+          done < <(
+            gh api --paginate "repos/${GITHUB_REPOSITORY}/releases?per_page=100" \
+              --jq '.[] | select(.draft == false and .prerelease == false) | .tag_name'
+          )
+        fi
+
         if [[ -n "$existing_tag" ]]; then
-          echo "Nightly $existing_tag already targets development commit $development_sha."
+          echo "Release $existing_tag already contains development commit $development_sha."
           echo "needed=false" >> "$GITHUB_OUTPUT"
         else
-          echo "No nightly targets development commit $development_sha."
+          echo "No release contains development commit $development_sha."
           echo "needed=true" >> "$GITHUB_OUTPUT"
         fi
 

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -37,18 +37,28 @@ jobs:
         )"
 
         if [[ -z "$existing_tag" ]]; then
+          release_tags="$(
+            gh api --paginate "repos/${GITHUB_REPOSITORY}/releases?per_page=100" \
+              --jq '.[] | select(.draft == false and .prerelease == false) | .tag_name'
+          )"
           while IFS= read -r tag; do
-            release_sha="$(
-              gh api "repos/${GITHUB_REPOSITORY}/commits/$tag" --jq .sha
-            )"
+            [[ -z "$tag" ]] && continue
+            if release_sha="$(
+              gh api "repos/${GITHUB_REPOSITORY}/commits/$tag" --jq .sha 2>&1
+            )"; then
+              :
+            elif [[ "$release_sha" == *"(HTTP 404)"* ||
+              "$release_sha" == *"No commit found for SHA:"*"(HTTP 422)"* ]]; then
+              continue
+            else
+              echo "$release_sha" >&2
+              exit 1
+            fi
             if [[ "$release_sha" == "$development_sha" ]]; then
               existing_tag="$tag"
               break
             fi
-          done < <(
-            gh api --paginate "repos/${GITHUB_REPOSITORY}/releases?per_page=100" \
-              --jq '.[] | select(.draft == false and .prerelease == false) | .tag_name'
-          )
+          done <<< "$release_tags"
         fi
 
         if [[ -n "$existing_tag" ]]; then


### PR DESCRIPTION
## Summary

- check published regular releases before dispatching a nightly build
- resolve regular release tags to immutable commit SHAs
- skip the nightly when either a nightly or regular release already contains the current development commit

## Root cause

The existing guard only matched prereleases with nightly-style tags. Regular releases record `target_commitish` as the branch name (`development`), so their release tag must be resolved to determine the commit that was actually released.

## Validation

- `pnpm exec eslint --config eslint.config.mjs .github/workflows/nightly.yml`
- `git diff --check`
- controlled shell fixture confirming a matching regular release suppresses the nightly

Repository-wide `pnpm run lint-yml` still reports the pre-existing `yml/no-empty-mapping-value` error in `e2e/sync-server/compose.yml`.