### PR TITLE
fix(comments): keep empty reply loads retryable

### DIFF
--- a/src/renderer/components/CommentSection/CommentSection.vue
+++ b/src/renderer/components/CommentSection/CommentSection.vue
@@ -424,6 +424,7 @@ import FtTimestampCatcher from '../FtTimestampCatcher.vue'
 import store from '../../store/index'
 
 import { copyToClipboard, formatNumber, showApiErrorToast, showToast } from '../../helpers/utils'
+import { getReplyLoadState } from '../../helpers/comment-replies'
 import { getYoutubeCommunityPostCommentUrl, getYoutubeVideoCommentUrl } from '../../helpers/share'
 import {
   getLocalCommunityPostComments,
@@ -1068,7 +1069,7 @@ async function getCommentRepliesLocal(index, commentId = null) {
 
     let replyThreads
     let nextContinuation
-    if ('getReplies' in continuation && !continuation.replies) {
+    if ('getReplies' in continuation && comment.replies.length === 0) {
       await continuation.getReplies()
       replyThreads = continuation.replies ?? []
       nextContinuation = continuation.has_continuation ? continuation : null
@@ -1083,15 +1084,22 @@ async function getCommentRepliesLocal(index, commentId = null) {
       .filter(Boolean)
     comment.replies = comment.replies.concat(parsedReplies)
 
-    if (nextContinuation) {
-      replyTokens.set(comment.id, nextContinuation)
+    const replyLoadState = getReplyLoadState(
+      parsedReplies.length,
+      comment.replies.length,
+      comment.numReplies,
+      nextContinuation !== null
+    )
+
+    if (replyLoadState.hasMore) {
+      replyTokens.set(comment.id, nextContinuation ?? continuation)
       comment.hasReplyToken = true
     } else {
       replyTokens.delete(comment.id)
       comment.hasReplyToken = false
     }
 
-    comment.showReplies = true
+    comment.showReplies = replyLoadState.showReplies
   } catch (err) {
     console.error(err)
     const errorMessage = t('Local API Error (Click to copy)')
@@ -1168,10 +1176,16 @@ async function getCommentRepliesInvidious(index) {
     const { commentData, continuation } = await invidiousGetCommentReplies({ id: props.id, replyToken })
 
     comment.replies = comment.replies.concat(commentData)
-    comment.showReplies = true
+    const replyLoadState = getReplyLoadState(
+      commentData.length,
+      comment.replies.length,
+      comment.numReplies,
+      continuation !== null
+    )
+    comment.showReplies = replyLoadState.showReplies
 
-    if (continuation) {
-      replyTokens.set(comment.id, continuation)
+    if (replyLoadState.hasMore) {
+      replyTokens.set(comment.id, continuation ?? replyToken)
       comment.hasReplyToken = true
     } else {
       replyTokens.delete(comment.id)
@@ -1234,10 +1248,16 @@ async function getPostCommentRepliesInvidious(index) {
       authorId: props.postAuthorId
     })
     comment.replies = comment.replies.concat(comments)
-    comment.showReplies = true
+    const replyLoadState = getReplyLoadState(
+      comments.length,
+      comment.replies.length,
+      comment.numReplies,
+      continuation !== null
+    )
+    comment.showReplies = replyLoadState.showReplies
 
-    if (continuation) {
-      replyTokens.set(comment.id, continuation)
+    if (replyLoadState.hasMore) {
+      replyTokens.set(comment.id, continuation ?? replyToken)
       comment.hasReplyToken = true
     } else {
       replyTokens.delete(comment.id)

--- a/src/renderer/components/CommentSection/CommentSection.vue
+++ b/src/renderer/components/CommentSection/CommentSection.vue
@@ -424,7 +424,7 @@ import FtTimestampCatcher from '../FtTimestampCatcher.vue'
 import store from '../../store/index'
 
 import { copyToClipboard, formatNumber, showApiErrorToast, showToast } from '../../helpers/utils'
-import { getReplyLoadState } from '../../helpers/comment-replies'
+import { getReplyLoadState, shouldLoadInitialReplies } from '../../helpers/comment-replies'
 import { getYoutubeCommunityPostCommentUrl, getYoutubeVideoCommentUrl } from '../../helpers/share'
 import {
   getLocalCommunityPostComments,
@@ -1069,7 +1069,15 @@ async function getCommentRepliesLocal(index, commentId = null) {
 
     let replyThreads
     let nextContinuation
-    if ('getReplies' in continuation && comment.replies.length === 0) {
+    const hasLoadedReplyBatch = !!continuation.replies
+    const loadInitialReplies = 'getReplies' in continuation &&
+      shouldLoadInitialReplies(
+        hasLoadedReplyBatch,
+        comment.replies.length > 0,
+        hasLoadedReplyBatch && continuation.has_continuation
+      )
+
+    if (loadInitialReplies) {
       await continuation.getReplies()
       replyThreads = continuation.replies ?? []
       nextContinuation = continuation.has_continuation ? continuation : null

--- a/src/renderer/helpers/comment-replies.js
+++ b/src/renderer/helpers/comment-replies.js
@@ -1,0 +1,15 @@
+/**
+ * @param {number} parsedReplyCount
+ * @param {number} loadedReplyCount
+ * @param {number} expectedReplyCount
+ * @param {boolean} hasNextContinuation
+ */
+export function getReplyLoadState(parsedReplyCount, loadedReplyCount, expectedReplyCount, hasNextContinuation) {
+  const shouldRetry = parsedReplyCount === 0 && loadedReplyCount < expectedReplyCount
+
+  return {
+    hasMore: hasNextContinuation || shouldRetry,
+    showReplies: loadedReplyCount > 0,
+    shouldRetry
+  }
+}

--- a/src/renderer/helpers/comment-replies.js
+++ b/src/renderer/helpers/comment-replies.js
@@ -13,3 +13,12 @@ export function getReplyLoadState(parsedReplyCount, loadedReplyCount, expectedRe
     shouldRetry
   }
 }
+
+/**
+ * @param {boolean} hasLoadedBatch
+ * @param {boolean} hasUsableReplies
+ * @param {boolean} hasContinuation
+ */
+export function shouldLoadInitialReplies(hasLoadedBatch, hasUsableReplies, hasContinuation) {
+  return !hasLoadedBatch || (!hasUsableReplies && !hasContinuation)
+}

--- a/tests/unit/comment-replies.test.mjs
+++ b/tests/unit/comment-replies.test.mjs
@@ -1,7 +1,10 @@
 import assert from 'node:assert/strict'
 import test from 'node:test'
 
-import { getReplyLoadState } from '../../src/renderer/helpers/comment-replies.js'
+import {
+  getReplyLoadState,
+  shouldLoadInitialReplies
+} from '../../src/renderer/helpers/comment-replies.js'
 
 test('keeps an empty reply load retryable without opening the reply panel', () => {
   assert.deepEqual(getReplyLoadState(0, 0, 1, false), {
@@ -33,4 +36,12 @@ test('keeps a zero-progress continuation retryable after earlier replies loaded'
     showReplies: true,
     shouldRetry: true
   })
+})
+
+test('retries an unusable initial batch when it has no continuation', () => {
+  assert.equal(shouldLoadInitialReplies(true, false, false), true)
+})
+
+test('advances after an unusable initial batch when it has a continuation', () => {
+  assert.equal(shouldLoadInitialReplies(true, false, true), false)
 })

--- a/tests/unit/comment-replies.test.mjs
+++ b/tests/unit/comment-replies.test.mjs
@@ -1,0 +1,36 @@
+import assert from 'node:assert/strict'
+import test from 'node:test'
+
+import { getReplyLoadState } from '../../src/renderer/helpers/comment-replies.js'
+
+test('keeps an empty reply load retryable without opening the reply panel', () => {
+  assert.deepEqual(getReplyLoadState(0, 0, 1, false), {
+    hasMore: true,
+    showReplies: false,
+    shouldRetry: true
+  })
+})
+
+test('marks a completed reply load as exhausted', () => {
+  assert.deepEqual(getReplyLoadState(1, 1, 1, false), {
+    hasMore: false,
+    showReplies: true,
+    shouldRetry: false
+  })
+})
+
+test('keeps a loaded reply panel open while its continuation is available', () => {
+  assert.deepEqual(getReplyLoadState(1, 3, 4, true), {
+    hasMore: true,
+    showReplies: true,
+    shouldRetry: false
+  })
+})
+
+test('keeps a zero-progress continuation retryable after earlier replies loaded', () => {
+  assert.deepEqual(getReplyLoadState(0, 3, 4, false), {
+    hasMore: true,
+    showReplies: true,
+    shouldRetry: true
+  })
+})


### PR DESCRIPTION
## What changed

- preserve reply continuation tokens when a request returns no usable replies
- keep empty reply panels closed so the user can retry with **View replies**
- apply the retry state consistently to local and Invidious video/post comments
- add deterministic regression coverage for initial and later zero-progress reply batches

## Why

YouTube can intermittently return a reply batch with no usable comment items, especially after several reply requests. The previous state transition treated that response as permanent exhaustion, opened an empty reply panel, and discarded the token. After hiding the panel, **View replies** could no longer issue another request.

The new transition treats a zero-progress batch as retryable while the advertised reply count has not been reached.

## Validation

- `pnpm test:unit`
- targeted ESLint for the changed component, helper, and test
- `pnpm test:e2e:pack`
- `xvfb-run -a -s "-screen 0 1920x1080x24" pnpm test:e2e:network --grep "comments load on request"`