### PR TITLE
fix(sync): recover cleanly from disconnect and rejected tokens

### DIFF
--- a/e2e/helpers/app.mjs
+++ b/e2e/helpers/app.mjs
@@ -30,6 +30,13 @@ function toNedbFile(docs) {
   return docs.map((doc) => JSON.stringify(doc)).join('\n') + '\n'
 }
 
+export function latestSettings(contents) {
+  return Object.fromEntries(contents.trim().split('\n')
+    .map(line => JSON.parse(line))
+    .filter(record => record._id && !record.$$deleted)
+    .map(record => [record._id, record.value]))
+}
+
 /**
  * Creates an isolated userData directory, optionally seeded with
  * settings and datastore documents.

--- a/e2e/sync-server/compose.yml
+++ b/e2e/sync-server/compose.yml
@@ -5,6 +5,7 @@ services:
       DATABASE_URL: ./data/db.sqlite
       SECRET_KEY: opentubex-local-sync-server-test-secret
       ALLOW_REGISTRATION: "true"
+      TRUST_FORWARDED_FOR: "true"
       VALIDATE_SUBMITTED_METADATA: "false"
     ports:
       - "127.0.0.1:8080:8080"

--- a/e2e/tests/network/sync-server.spec.mjs
+++ b/e2e/tests/network/sync-server.spec.mjs
@@ -23,9 +23,12 @@ async function getSyncCapabilities() {
 }
 
 function rateLimitClient(title) {
-  const suffix = [...title]
-    .reduce((sum, character) => sum + character.charCodeAt(0), 0) % 254 + 1
-  return `192.0.2.${suffix}`
+  let hash = 2166136261
+  for (const character of title) {
+    hash ^= character.codePointAt(0)
+    hash = Math.imul(hash, 16777619)
+  }
+  return `10.${hash & 0xff}.${(hash >>> 8) & 0xff}.${(hash >>> 16) & 0xff}`
 }
 
 test.describe('OpenTubeX sync server', () => {

--- a/e2e/tests/network/sync-server.spec.mjs
+++ b/e2e/tests/network/sync-server.spec.mjs
@@ -38,7 +38,7 @@ test.describe('OpenTubeX sync server', () => {
     await page.route('**/account/**', route => route.continue({
       headers: {
         ...route.request().headers(),
-        'X-Forwarded-For': rateLimitClient(testInfo.title)
+        'X-Forwarded-For': rateLimitClient(testInfo.titlePath.join('\0'))
       }
     }))
   })
@@ -323,7 +323,7 @@ test.describe('OpenTubeX sync server', () => {
       method: 'POST',
       headers: {
         'Content-Type': 'application/json',
-        'X-Forwarded-For': rateLimitClient(testInfo.title)
+        'X-Forwarded-For': rateLimitClient(testInfo.titlePath.join('\0'))
       },
       body: JSON.stringify({ name: username, password })
     })

--- a/e2e/tests/network/sync-server.spec.mjs
+++ b/e2e/tests/network/sync-server.spec.mjs
@@ -22,8 +22,23 @@ async function getSyncCapabilities() {
   return health.capabilities ?? {}
 }
 
+function rateLimitClient(title) {
+  const suffix = [...title]
+    .reduce((sum, character) => sum + character.charCodeAt(0), 0) % 254 + 1
+  return `192.0.2.${suffix}`
+}
+
 test.describe('OpenTubeX sync server', () => {
   test.skip(!syncServerUrl, 'Set OPENTUBEX_SYNC_SERVER_URL to run the local sync-server test')
+
+  test.beforeEach(async ({ page }, testInfo) => {
+    await page.route('**/account/**', route => route.continue({
+      headers: {
+        ...route.request().headers(),
+        'X-Forwarded-For': rateLimitClient(testInfo.title)
+      }
+    }))
+  })
 
   test.use({
     seed: {
@@ -295,7 +310,7 @@ test.describe('OpenTubeX sync server', () => {
     expect(await readFile(path.join(app.userDataDir, 'history.db'), 'utf8')).toContain('dQw4w9WgXcQ')
   })
 
-  test('migrates existing plaintext data before locking the account', async ({ app, page }) => {
+  test('migrates existing plaintext data before locking the account', async ({ app, page }, testInfo) => {
     const enhancedPrivacy = (await getSyncCapabilities()).encrypted_sync === 1
     test.skip(!enhancedPrivacy, 'Enhanced privacy server required')
 
@@ -303,7 +318,10 @@ test.describe('OpenTubeX sync server', () => {
     const password = 'local-test-password'
     const registerResponse = await fetch(`${syncServerUrl}/v1/account/register`, {
       method: 'POST',
-      headers: { 'Content-Type': 'application/json' },
+      headers: {
+        'Content-Type': 'application/json',
+        'X-Forwarded-For': rateLimitClient(testInfo.title)
+      },
       body: JSON.stringify({ name: username, password })
     })
     expect(registerResponse.ok).toBe(true)

--- a/e2e/tests/network/sync-server.spec.mjs
+++ b/e2e/tests/network/sync-server.spec.mjs
@@ -1,19 +1,12 @@
 import { readFile } from 'node:fs/promises'
 import path from 'node:path'
 
-import { test, expect, goTo } from '../../helpers/app.mjs'
+import { test, expect, goTo, latestSettings } from '../../helpers/app.mjs'
 
 const syncServerUrl = process.env.OPENTUBEX_SYNC_SERVER_URL
 const channelId = 'UCuAXFkgsw1L7xaCfnd5JJOw'
 const secondChannelId = 'UC-lHJZR3Gqxm24_Vd_AJ5Yw'
 const remoteChannelId = 'UC_x5XG1OV2P6uZZ5FSM9Ttw'
-
-function latestSettings(contents) {
-  return Object.fromEntries(contents.trim().split('\n')
-    .map(line => JSON.parse(line))
-    .filter(record => record._id && !record.$$deleted)
-    .map(record => [record._id, record.value]))
-}
 
 async function getSyncCapabilities() {
   const response = await fetch(`${syncServerUrl}/health`)

--- a/e2e/tests/offline/settings.spec.mjs
+++ b/e2e/tests/offline/settings.spec.mjs
@@ -225,6 +225,44 @@ test.describe('settings', () => {
   })
 })
 
+test.describe('sync settings', () => {
+  test.use({
+    seed: {
+      settings: {
+        syncServerAutoSync: false,
+        syncServerPrivacyMode: 'legacy',
+        syncServerToken: 'invalid-token',
+        syncServerUrl: 'https://sync.d3sox.me',
+        syncServerUsername: 'sync-user'
+      }
+    }
+  })
+
+  test('clears a sync error and enables credentials after disconnecting', async ({ page }) => {
+    await page.route('https://sync.d3sox.me/**', async (route) => {
+      if (new URL(route.request().url()).pathname === '/health') {
+        await route.fulfill({ status: 200, body: 'OK' })
+      } else {
+        await route.fulfill({ status: 401, body: 'Invalid or missing authentication token' })
+      }
+    })
+    await goTo(page, 'settings')
+
+    const syncSection = page.locator('[data-section="sync"]')
+    await syncSection.getByRole('button', { name: 'Sync now' }).click()
+    await expect(syncSection.locator('.error')).toHaveText(
+      'Invalid or missing authentication token'
+    )
+
+    await syncSection.getByRole('button', { name: 'Disconnect' }).click()
+
+    await expect(syncSection.locator('.error')).toHaveCount(0)
+    await expect(syncSection.getByLabel('Server URL')).toBeEnabled()
+    await expect(syncSection.getByLabel('Username')).toBeEnabled()
+    await expect(syncSection.getByLabel('Password')).toBeEnabled()
+  })
+})
+
 test.describe('invalid toast position', () => {
   test.use({ seed: { settings: { toastPosition: 'unsupported' } } })
 

--- a/e2e/tests/offline/settings.spec.mjs
+++ b/e2e/tests/offline/settings.spec.mjs
@@ -1,14 +1,7 @@
 import { readFile } from 'node:fs/promises'
 import path from 'node:path'
 
-import { test, expect, goTo } from '../../helpers/app.mjs'
-
-function latestSettings(contents) {
-  return Object.fromEntries(contents.trim().split('\n')
-    .map(line => JSON.parse(line))
-    .filter(record => record._id && !record.$$deleted)
-    .map(record => [record._id, record.value]))
-}
+import { test, expect, goTo, latestSettings } from '../../helpers/app.mjs'
 
 test.describe('settings', () => {
   test('settings page renders its sections', async ({ page }) => {

--- a/e2e/tests/offline/settings.spec.mjs
+++ b/e2e/tests/offline/settings.spec.mjs
@@ -254,6 +254,8 @@ test.describe('sync settings', () => {
       'Invalid or missing authentication token'
     )
 
+    await expect(syncSection.getByLabel('Server URL')).toBeDisabled()
+    await expect(syncSection.getByLabel('Username')).toBeDisabled()
     await syncSection.getByRole('button', { name: 'Disconnect' }).click()
 
     await expect(syncSection.locator('.error')).toHaveCount(0)

--- a/e2e/tests/offline/settings.spec.mjs
+++ b/e2e/tests/offline/settings.spec.mjs
@@ -263,6 +263,42 @@ test.describe('sync settings', () => {
     await expect(syncSection.getByLabel('Username')).toBeEnabled()
     await expect(syncSection.getByLabel('Password')).toBeEnabled()
   })
+
+  test('disables credentials while authentication is pending', async ({ page }) => {
+    let finishAuthentication
+    const authenticationPending = new Promise((resolve) => {
+      finishAuthentication = resolve
+    })
+    await page.route('https://sync.d3sox.me/**', async (route) => {
+      const pathname = new URL(route.request().url()).pathname
+      if (pathname === '/health') {
+        await route.fulfill({ status: 200, body: 'OK' })
+      } else {
+        await authenticationPending
+        await route.fulfill({ status: 401, body: 'Invalid credentials' })
+      }
+    })
+    await goTo(page, 'settings')
+
+    const syncSection = page.locator('[data-section="sync"]')
+    await syncSection.getByRole('button', { name: 'Disconnect' }).click()
+    await expect(syncSection.getByLabel('Username')).toBeEnabled()
+    await syncSection.getByLabel('Username').fill('sync-user')
+    await syncSection.getByLabel('Password').fill('sync-password')
+    await syncSection.getByRole('button', { name: 'Log in' }).click()
+
+    await expect(syncSection.getByLabel('Server URL')).toBeDisabled()
+    await expect(syncSection.getByLabel('Username')).toBeDisabled()
+    await expect(syncSection.getByLabel('Password')).toBeDisabled()
+    await expect(syncSection.getByRole('button', { name: 'Log in' })).toBeDisabled()
+    await expect(syncSection.getByRole('button', { name: 'Register' })).toBeDisabled()
+
+    finishAuthentication()
+    await expect(syncSection.locator('.error')).toHaveText('Invalid credentials')
+    await expect(syncSection.getByLabel('Server URL')).toBeEnabled()
+    await expect(syncSection.getByLabel('Username')).toBeEnabled()
+    await expect(syncSection.getByLabel('Password')).toBeEnabled()
+  })
 })
 
 test.describe('invalid toast position', () => {

--- a/e2e/tests/offline/settings.spec.mjs
+++ b/e2e/tests/offline/settings.spec.mjs
@@ -1,4 +1,14 @@
+import { readFile } from 'node:fs/promises'
+import path from 'node:path'
+
 import { test, expect, goTo } from '../../helpers/app.mjs'
+
+function latestSettings(contents) {
+  return Object.fromEntries(contents.trim().split('\n')
+    .map(line => JSON.parse(line))
+    .filter(record => record._id && !record.$$deleted)
+    .map(record => [record._id, record.value]))
+}
 
 test.describe('settings', () => {
   test('settings page renders its sections', async ({ page }) => {
@@ -232,16 +242,28 @@ test.describe('sync settings', () => {
         syncServerAutoSync: false,
         syncServerPrivacyKey: 'e2e-privacy-key',
         syncServerPrivacyMode: 'legacy',
+        syncServerSnapshot: '{"subscriptions":[]}',
         syncServerToken: 'invalid-token',
         syncServerUrl: 'https://sync.d3sox.me',
-        syncServerUsername: 'sync-user'
+        syncServerUsername: 'sync-user',
+        syncServerLastSyncAt: 1234
       }
     }
   })
 
   test('clears a sync error and enables credentials after disconnecting', async ({ page }) => {
+    let finishServerCheck
+    let serverCheckStarted
+    const serverCheckPending = new Promise((resolve) => {
+      finishServerCheck = resolve
+    })
+    const serverCheckRequested = new Promise((resolve) => {
+      serverCheckStarted = resolve
+    })
     await page.route('https://sync.d3sox.me/**', async (route) => {
       if (new URL(route.request().url()).pathname === '/health') {
+        serverCheckStarted()
+        await serverCheckPending
         await route.fulfill({ status: 200, body: 'OK' })
       } else {
         await route.fulfill({ status: 500, body: 'Sync failed' })
@@ -257,10 +279,15 @@ test.describe('sync settings', () => {
     await expect(syncSection.getByLabel('Username')).toBeDisabled()
     await syncSection.getByRole('button', { name: 'Disconnect' }).click()
 
-    await expect(syncSection.locator('.error')).toHaveCount(0)
-    await expect(syncSection.getByLabel('Server URL')).toBeEnabled()
-    await expect(syncSection.getByLabel('Username')).toBeEnabled()
-    await expect(syncSection.getByLabel('Password')).toBeEnabled()
+    try {
+      await serverCheckRequested
+      await expect(syncSection.locator('.error')).toHaveCount(0)
+      await expect(syncSection.getByLabel('Server URL')).toBeEnabled()
+      await expect(syncSection.getByLabel('Username')).toBeEnabled()
+      await expect(syncSection.getByLabel('Password')).toBeEnabled()
+    } finally {
+      finishServerCheck()
+    }
   })
 
   test('disables credentials while authentication is pending', async ({ page }) => {
@@ -297,6 +324,75 @@ test.describe('sync settings', () => {
     await expect(syncSection.getByLabel('Server URL')).toBeEnabled()
     await expect(syncSection.getByLabel('Username')).toBeEnabled()
     await expect(syncSection.getByLabel('Password')).toBeEnabled()
+  })
+
+  test('preserves the sync baseline while reauthenticating an expired session', async ({ app, page }) => {
+    let finishPostLoginSync
+    let postLoginSyncStarted
+    const postLoginSyncPending = new Promise((resolve) => {
+      finishPostLoginSync = resolve
+    })
+    const postLoginSyncRequested = new Promise((resolve) => {
+      postLoginSyncStarted = resolve
+    })
+    let authenticatedManifestRequests = 0
+
+    await page.route('https://sync.d3sox.me/**', async (route) => {
+      const request = route.request()
+      const pathname = new URL(request.url()).pathname
+      const authorization = request.headers().authorization
+
+      if (pathname === '/health') {
+        await route.fulfill({
+          status: 200,
+          json: { capabilities: { encrypted_sync: 1 } }
+        })
+      } else if (pathname === '/v1/account/login') {
+        await route.fulfill({ status: 200, json: { jwt: 'renewed-token' } })
+      } else if (authorization === 'invalid-token') {
+        await route.fulfill({
+          status: 401,
+          body: 'Invalid or missing authentication token'
+        })
+      } else if (pathname === '/v1/encrypted_sync') {
+        authenticatedManifestRequests++
+        if (authenticatedManifestRequests === 2) {
+          postLoginSyncStarted()
+          await postLoginSyncPending
+        }
+        await route.fulfill({ status: 200, json: { collections: [] } })
+      } else if (request.method() === 'PUT') {
+        await route.fulfill({ status: 200, json: {} })
+      } else {
+        await route.fulfill({ status: 200, json: { revision: 0 } })
+      }
+    })
+    await goTo(page, 'settings')
+
+    const syncSection = page.locator('[data-section="sync"]')
+    await syncSection.getByRole('button', { name: 'Sync now' }).click()
+    await expect(syncSection.locator('.error')).toHaveText(
+      'Sync server session expired. Sign in again to resume syncing.'
+    )
+    await expect(syncSection.getByLabel('Username')).toBeEnabled()
+
+    await syncSection.getByLabel('Password').fill('sync-password')
+    await syncSection.getByLabel(/Privacy passphrase/).fill('sync-privacy-passphrase')
+    await syncSection.getByRole('button', { name: 'Log in' }).click()
+
+    try {
+      await postLoginSyncRequested
+      const settings = latestSettings(
+        await readFile(path.join(app.userDataDir, 'settings.db'), 'utf8')
+      )
+      expect(settings.syncServerSnapshot).toBe('{"subscriptions":[]}')
+      expect(settings.syncServerLastSyncAt).toBe(1234)
+    } finally {
+      finishPostLoginSync()
+    }
+
+    await expect(syncSection.getByText('Connected as sync-user')).toBeVisible()
+    await expect(syncSection.getByText(/Last synced:/)).toBeVisible()
   })
 })
 

--- a/e2e/tests/offline/settings.spec.mjs
+++ b/e2e/tests/offline/settings.spec.mjs
@@ -230,6 +230,7 @@ test.describe('sync settings', () => {
     seed: {
       settings: {
         syncServerAutoSync: false,
+        syncServerPrivacyKey: 'e2e-privacy-key',
         syncServerPrivacyMode: 'legacy',
         syncServerToken: 'invalid-token',
         syncServerUrl: 'https://sync.d3sox.me',
@@ -243,16 +244,14 @@ test.describe('sync settings', () => {
       if (new URL(route.request().url()).pathname === '/health') {
         await route.fulfill({ status: 200, body: 'OK' })
       } else {
-        await route.fulfill({ status: 401, body: 'Invalid or missing authentication token' })
+        await route.fulfill({ status: 500, body: 'Sync failed' })
       }
     })
     await goTo(page, 'settings')
 
     const syncSection = page.locator('[data-section="sync"]')
     await syncSection.getByRole('button', { name: 'Sync now' }).click()
-    await expect(syncSection.locator('.error')).toHaveText(
-      'Invalid or missing authentication token'
-    )
+    await expect(syncSection.locator('.error')).toHaveText('Sync failed')
 
     await expect(syncSection.getByLabel('Server URL')).toBeDisabled()
     await expect(syncSection.getByLabel('Username')).toBeDisabled()

--- a/src/renderer/components/SyncSettings/SyncSettings.vue
+++ b/src/renderer/components/SyncSettings/SyncSettings.vue
@@ -438,16 +438,17 @@ const lastSyncLabel = computed(() => {
 let serverCheckTimer = null
 let serverCheckSequence = 0
 
-watch([serverUrl, connected], ([value]) => {
+watch([serverUrl, connected], ([value, isConnected], [previousValue, wasConnected] = []) => {
   clearTimeout(serverCheckTimer)
   const sequence = ++serverCheckSequence
+  const disconnected = wasConnected && !isConnected && value === previousValue
   serverPrivacySupported.value = null
-  serverCheckStatus.value = 'idle'
+  serverCheckStatus.value = disconnected ? 'valid' : 'idle'
   serverCheckError.value = ''
-  if (connected.value || !value.trim()) return
+  if (isConnected || !value.trim()) return
 
   serverCheckTimer = setTimeout(async () => {
-    serverCheckStatus.value = 'checking'
+    if (!disconnected) serverCheckStatus.value = 'checking'
     try {
       const capabilities = await new SyncServerClient(value).getCapabilities()
       if (sequence !== serverCheckSequence) return

--- a/src/renderer/components/SyncSettings/SyncSettings.vue
+++ b/src/renderer/components/SyncSettings/SyncSettings.vue
@@ -436,7 +436,7 @@ const lastSyncLabel = computed(() => {
 let serverCheckTimer = null
 let serverCheckSequence = 0
 
-watch(serverUrl, value => {
+watch([serverUrl, connected], ([value]) => {
   clearTimeout(serverCheckTimer)
   const sequence = ++serverCheckSequence
   serverPrivacySupported.value = null
@@ -524,6 +524,7 @@ async function confirmDataLossSync() {
 
 async function disconnect() {
   if (busy.value) return
+  localError.value = ''
   await store.dispatch('disconnectSyncServer')
 }
 

--- a/src/renderer/components/SyncSettings/SyncSettings.vue
+++ b/src/renderer/components/SyncSettings/SyncSettings.vue
@@ -9,7 +9,7 @@
         :show-action-button="false"
         :data-list="syncServerInstances"
         :value="serverUrl"
-        :disabled="connected"
+        :disabled="connected || authenticating"
         show-label
         @input="serverUrl = $event"
         @blur="saveServerUrl"
@@ -366,6 +366,7 @@ const serverPrivacySupported = ref(null)
 const serverCheckStatus = ref('idle')
 const serverCheckError = ref('')
 const localError = ref('')
+const authenticating = ref(false)
 const showDeleteAccountPrompt = ref(false)
 const deleteAccountPassword = ref('')
 const deleteAccountError = ref('')
@@ -383,7 +384,8 @@ const privacyPolicyUrl = computed(() => {
   }
 })
 const serverCredentialsDisabled = computed(() => (
-  !connected.value && serverCheckStatus.value !== 'valid'
+  authenticating.value ||
+  (!connected.value && serverCheckStatus.value !== 'valid')
 ))
 const status = computed(() => store.getters.getSyncServerStatus)
 const busy = computed(() => status.value === 'syncing')
@@ -477,6 +479,7 @@ async function saveServerUrl() {
 async function authenticate(mode) {
   if (busy.value || serverCredentialsDisabled.value) return
   localError.value = ''
+  authenticating.value = true
   try {
     await store.dispatch('authenticateSyncServer', {
       mode,
@@ -492,6 +495,8 @@ async function authenticate(mode) {
     showToast({ message: t('Settings.Sync Settings.Sync completed'), icon: ['fas', 'sync'] })
   } catch (error) {
     localError.value = error.message
+  } finally {
+    authenticating.value = false
   }
 }
 

--- a/src/renderer/helpers/sync-server-errors.js
+++ b/src/renderer/helpers/sync-server-errors.js
@@ -26,6 +26,9 @@ export class SyncServerDataLossError extends Error {
   }
 }
 
+export const SYNC_SERVER_SESSION_EXPIRED_MESSAGE =
+  'Sync server session expired. Sign in again to resume syncing.'
+
 /**
  * Whether an error means the stored token is no longer accepted.
  *
@@ -37,4 +40,25 @@ export class SyncServerDataLossError extends Error {
  */
 export function isSessionExpiredError(error) {
   return error instanceof SyncServerError && error.status === 401
+}
+
+/**
+ * Whether authentication is recovering the same expired sync session.
+ * @param {object} session
+ * @param {boolean} session.expired
+ * @param {string} session.savedServerUrl
+ * @param {string} session.savedUsername
+ * @param {string} session.serverUrl
+ * @param {string} session.username
+ */
+export function isExpiredSessionReauthentication({
+  expired,
+  savedServerUrl,
+  savedUsername,
+  serverUrl,
+  username,
+}) {
+  return expired &&
+    serverUrl === savedServerUrl &&
+    username === savedUsername
 }

--- a/src/renderer/helpers/sync-server-errors.js
+++ b/src/renderer/helpers/sync-server-errors.js
@@ -1,0 +1,40 @@
+/**
+ * Sync server error types and the predicates that classify them.
+ *
+ * Kept in its own module so the classification logic can be unit tested; the
+ * main sync-server helper pulls in webpack-resolved imports that a plain Node
+ * test runner cannot load.
+ */
+
+export class SyncServerError extends Error {
+  constructor(message, status = null) {
+    super(message)
+    this.name = 'SyncServerError'
+    this.status = status
+  }
+}
+
+export class SyncServerDataLossError extends Error {
+  constructor(collection, deleted, previous) {
+    super(
+      `Sync stopped because it would delete ${deleted} of ${previous} previously synced ${collection} items`
+    )
+    this.name = 'SyncServerDataLossError'
+    this.collection = collection
+    this.deleted = deleted
+    this.previous = previous
+  }
+}
+
+/**
+ * Whether an error means the stored token is no longer accepted.
+ *
+ * Only 401 qualifies. The server answers 403 for wrong credentials and for
+ * resources owned by someone else, and 404 for plenty of ordinary misses, so
+ * treating those as an expired session would sign people out for unrelated
+ * reasons.
+ * @param {unknown} error
+ */
+export function isSessionExpiredError(error) {
+  return error instanceof SyncServerError && error.status === 401
+}

--- a/src/renderer/helpers/sync-server.js
+++ b/src/renderer/helpers/sync-server.js
@@ -2,6 +2,8 @@ import { MAIN_PROFILE_ID } from '../../constants'
 import {
   SyncServerDataLossError,
   SyncServerError,
+  SYNC_SERVER_SESSION_EXPIRED_MESSAGE,
+  isExpiredSessionReauthentication,
   isSessionExpiredError,
 } from './sync-server-errors'
 import { getSyncableSettingKeys } from '../store/modules/settings'
@@ -18,7 +20,13 @@ const MAX_ENCRYPTED_SYNC_TIMEOUT_MS = 5 * 60 * 1000
 const DEFAULT_CHANNEL_AVATAR = 'https://yt3.googleusercontent.com/ytc/default'
 const YOUTUBE_VIDEO_THUMBNAIL_REGEX = /^https?:\/\/i\.ytimg\.com\/vi(?:_webp)?\//
 
-export { SyncServerDataLossError, SyncServerError, isSessionExpiredError }
+export {
+  SyncServerDataLossError,
+  SyncServerError,
+  SYNC_SERVER_SESSION_EXPIRED_MESSAGE,
+  isExpiredSessionReauthentication,
+  isSessionExpiredError,
+}
 
 export function normalizeSyncServerUrl(value) {
   let url

--- a/src/renderer/helpers/sync-server.js
+++ b/src/renderer/helpers/sync-server.js
@@ -1,4 +1,9 @@
 import { MAIN_PROFILE_ID } from '../../constants'
+import {
+  SyncServerDataLossError,
+  SyncServerError,
+  isSessionExpiredError,
+} from './sync-server-errors'
 import { getSyncableSettingKeys } from '../store/modules/settings'
 import { deepCopy } from './utils'
 import { generateRandomUniqueId } from './playlists'
@@ -13,25 +18,7 @@ const MAX_ENCRYPTED_SYNC_TIMEOUT_MS = 5 * 60 * 1000
 const DEFAULT_CHANNEL_AVATAR = 'https://yt3.googleusercontent.com/ytc/default'
 const YOUTUBE_VIDEO_THUMBNAIL_REGEX = /^https?:\/\/i\.ytimg\.com\/vi(?:_webp)?\//
 
-export class SyncServerError extends Error {
-  constructor(message, status = null) {
-    super(message)
-    this.name = 'SyncServerError'
-    this.status = status
-  }
-}
-
-export class SyncServerDataLossError extends Error {
-  constructor(collection, deleted, previous) {
-    super(
-      `Sync stopped because it would delete ${deleted} of ${previous} previously synced ${collection} items`
-    )
-    this.name = 'SyncServerDataLossError'
-    this.collection = collection
-    this.deleted = deleted
-    this.previous = previous
-  }
-}
+export { SyncServerDataLossError, SyncServerError, isSessionExpiredError }
 
 export function normalizeSyncServerUrl(value) {
   let url

--- a/src/renderer/store/modules/sync-server.js
+++ b/src/renderer/store/modules/sync-server.js
@@ -1,6 +1,8 @@
 import {
   SyncServerClient,
   SyncServerDataLossError,
+  SYNC_SERVER_SESSION_EXPIRED_MESSAGE,
+  isExpiredSessionReauthentication,
   isSessionExpiredError,
   normalizeSyncServerUrl,
   syncChannelPlaybackSpeeds,
@@ -49,6 +51,7 @@ const state = {
   syncServerLastResult: null,
   syncServerHistorySupported: null,
   syncServerPlaybackSpeedsSupported: null,
+  syncServerSessionExpired: false,
 }
 
 const getters = {
@@ -342,7 +345,7 @@ async function runSync(context, { allowDataLoss = false } = {}) {
       // sync would keep failing with the same opaque message. Drop the token so
       // automatic sync stops and the UI asks for a sign-in.
       await dispatch('expireSyncServerSession')
-      throw error
+      throw new Error(SYNC_SERVER_SESSION_EXPIRED_MESSAGE, { cause: error })
     }
     commit('setSyncServerError', error.message)
     commit('setSyncServerStatus', 'error')
@@ -352,7 +355,7 @@ async function runSync(context, { allowDataLoss = false } = {}) {
 
 const actions = {
   async authenticateSyncServer(
-    { dispatch },
+    { commit, dispatch, rootState, state },
     { mode, serverUrl, username, password, privacyPassphrase }
   ) {
     if (mode !== 'login' && mode !== 'register') {
@@ -361,6 +364,13 @@ const actions = {
 
     const normalizedUrl = normalizeSyncServerUrl(serverUrl)
     const trimmedUsername = username.trim()
+    const resumesExpiredSession = isExpiredSessionReauthentication({
+      expired: state.syncServerSessionExpired,
+      savedServerUrl: rootState.settings.syncServerUrl,
+      savedUsername: rootState.settings.syncServerUsername,
+      serverUrl: normalizedUrl,
+      username: trimmedUsername,
+    })
     if (!trimmedUsername || !password) {
       throw new Error('Username and password are required')
     }
@@ -397,12 +407,15 @@ const actions = {
     // the URL must be committed before the token enables the initial sync.
     await dispatch('updateSyncServerUrl', normalizedUrl, { root: true })
     await dispatch('updateSyncServerUsername', trimmedUsername, { root: true })
-    await dispatch('updateSyncServerSnapshot', '{}', { root: true })
-    await dispatch('updateSyncServerLastSyncAt', 0, { root: true })
+    if (!resumesExpiredSession) {
+      await dispatch('updateSyncServerSnapshot', '{}', { root: true })
+      await dispatch('updateSyncServerLastSyncAt', 0, { root: true })
+    }
     await dispatch('updateSyncServerPrivacyMode', privacySupported ? 'enhanced' : 'legacy', { root: true })
     await dispatch('updateSyncServerPrivacyKey', privacyKey, { root: true })
     await dispatch('updateSyncServerPrivacySalt', privacySalt, { root: true })
     await dispatch('updateSyncServerToken', token, { root: true })
+    commit('setSyncServerSessionExpired', false)
 
     await dispatch('startSyncServerAutoSync')
     return dispatch('syncWithSyncServer')
@@ -419,7 +432,8 @@ const actions = {
     await dispatch('stopSyncServerAutoSync')
     await dispatch('updateSyncServerToken', '', { root: true })
     commit('setSyncServerProgress', null)
-    commit('setSyncServerError', 'Sync server session expired. Sign in again to resume syncing.')
+    commit('setSyncServerError', SYNC_SERVER_SESSION_EXPIRED_MESSAGE)
+    commit('setSyncServerSessionExpired', true)
     commit('setSyncServerStatus', 'error')
   },
 
@@ -438,6 +452,7 @@ const actions = {
     commit('setSyncServerPlaybackSpeedsSupported', null)
     commit('setSyncServerProgress', null)
     commit('setSyncServerStatus', 'idle')
+    commit('setSyncServerSessionExpired', false)
   },
 
   async deleteSyncServerAccount({ commit, dispatch, rootState }, password) {
@@ -602,6 +617,9 @@ const mutations = {
   },
   setSyncServerPlaybackSpeedsSupported(state, supported) {
     state.syncServerPlaybackSpeedsSupported = supported
+  },
+  setSyncServerSessionExpired(state, expired) {
+    state.syncServerSessionExpired = expired
   },
 }
 

--- a/src/renderer/store/modules/sync-server.js
+++ b/src/renderer/store/modules/sync-server.js
@@ -1,6 +1,7 @@
 import {
   SyncServerClient,
   SyncServerDataLossError,
+  isSessionExpiredError,
   normalizeSyncServerUrl,
   syncChannelPlaybackSpeeds,
   syncHistory,
@@ -336,6 +337,13 @@ async function runSync(context, { allowDataLoss = false } = {}) {
       await dispatch('setSyncServerAutoSync', false)
     }
     commit('setSyncServerProgress', null)
+    if (isSessionExpiredError(error)) {
+      // Retrying cannot help once the token is rejected, and every scheduled
+      // sync would keep failing with the same opaque message. Drop the token so
+      // automatic sync stops and the UI asks for a sign-in.
+      await dispatch('expireSyncServerSession')
+      throw error
+    }
     commit('setSyncServerError', error.message)
     commit('setSyncServerStatus', 'error')
     throw error
@@ -398,6 +406,21 @@ const actions = {
 
     await dispatch('startSyncServerAutoSync')
     return dispatch('syncWithSyncServer')
+  },
+
+  /**
+   * Handle the server rejecting the stored token.
+   *
+   * Only the token is cleared. The server URL, username, snapshot and privacy
+   * key are kept so that signing in again resumes where sync left off instead of
+   * re-downloading everything.
+   */
+  async expireSyncServerSession({ commit, dispatch }) {
+    await dispatch('stopSyncServerAutoSync')
+    await dispatch('updateSyncServerToken', '', { root: true })
+    commit('setSyncServerProgress', null)
+    commit('setSyncServerError', 'Sync server session expired. Sign in again to resume syncing.')
+    commit('setSyncServerStatus', 'error')
   },
 
   async disconnectSyncServer({ commit, dispatch }) {

--- a/tests/unit/sync-server-session.test.mjs
+++ b/tests/unit/sync-server-session.test.mjs
@@ -3,6 +3,7 @@ import test from 'node:test'
 
 import {
   SyncServerError,
+  isExpiredSessionReauthentication,
   isSessionExpiredError,
 } from '../../src/renderer/helpers/sync-server-errors.js'
 
@@ -29,4 +30,19 @@ test('ignores errors that are not sync server errors', () => {
   assert.equal(isSessionExpiredError(null), false)
   assert.equal(isSessionExpiredError(undefined), false)
   assert.equal(isSessionExpiredError({ status: 401 }), false)
+})
+
+test('preserves the baseline only when reauthenticating the same expired session', () => {
+  const session = {
+    expired: true,
+    savedServerUrl: 'https://sync.example',
+    savedUsername: 'alice',
+    serverUrl: 'https://sync.example',
+    username: 'alice',
+  }
+
+  assert.equal(isExpiredSessionReauthentication(session), true)
+  assert.equal(isExpiredSessionReauthentication({ ...session, expired: false }), false)
+  assert.equal(isExpiredSessionReauthentication({ ...session, serverUrl: 'https://other.example' }), false)
+  assert.equal(isExpiredSessionReauthentication({ ...session, username: 'bob' }), false)
 })

--- a/tests/unit/sync-server-session.test.mjs
+++ b/tests/unit/sync-server-session.test.mjs
@@ -1,0 +1,32 @@
+import assert from 'node:assert/strict'
+import test from 'node:test'
+
+import {
+  SyncServerError,
+  isSessionExpiredError,
+} from '../../src/renderer/helpers/sync-server-errors.js'
+
+test('treats 401 as an expired session', () => {
+  assert.equal(
+    isSessionExpiredError(new SyncServerError('invalid or missing authentication token', 401)),
+    true
+  )
+})
+
+test('does not treat other sync server failures as an expired session', () => {
+  // 403 is wrong credentials or someone else's resource, not a dead token
+  assert.equal(isSessionExpiredError(new SyncServerError('invalid accountname or password', 403)), false)
+  // 404 is an ordinary miss, e.g. a video not in the watch history
+  assert.equal(isSessionExpiredError(new SyncServerError('not found', 404)), false)
+  // rate limiting and quota errors are retryable or user-fixable
+  assert.equal(isSessionExpiredError(new SyncServerError('too many requests', 429)), false)
+  assert.equal(isSessionExpiredError(new SyncServerError('quota exceeded', 413)), false)
+  assert.equal(isSessionExpiredError(new SyncServerError('server exploded', 500)), false)
+})
+
+test('ignores errors that are not sync server errors', () => {
+  assert.equal(isSessionExpiredError(new Error('offline')), false)
+  assert.equal(isSessionExpiredError(null), false)
+  assert.equal(isSessionExpiredError(undefined), false)
+  assert.equal(isSessionExpiredError({ status: 401 }), false)
+})


### PR DESCRIPTION
## Summary

- clear stale sync errors when disconnecting
- revalidate the configured sync server after connection state changes
- enable the login inputs immediately after disconnecting without reloading settings
- sign out cleanly when the server rejects the stored token, instead of retrying forever

## Root cause

The disconnect action cleared the sync store error but left the component-local error intact. Server validation also only watched URL changes, so disconnecting did not move the credential form back to a validated, enabled state.

Separately, a `401` from the sync server was treated like any other sync failure: the client displayed the server's text, *"invalid or missing authentication token"*, and **left the dead token in settings**. Automatic and event-triggered sync then kept firing on their normal schedule and failing identically, so the app sat permanently broken behind a message that does not say what to do about it.

This is now reachable in practice: the sync server enforces token expiry and also rejects tokens minted before it corrected the `exp` claim from milliseconds to seconds ([sync-server#1](https://github.com/OpenTubeX/sync-server/pull/1)), so every existing install hits a `401` exactly once after that upgrade. Observed on a live deployment.

The two halves belong together. Handling the rejected token clears the token and sets a store error, which is precisely the state the form fixes above make recoverable — without them the user is told to sign in again while the credential form is still in its connected, disabled state.

## What changed for rejected tokens

A `401` now clears the stored token and reports *"Sync server session expired. Sign in again to resume syncing."*

Clearing the token is what stops the retry loop: `startSyncServerAutoSync` and `scheduleSyncServer` both already bail out without one, so no extra guard was needed.

**Only the token is cleared.** Server URL, username, snapshot and privacy key are kept, so signing back in resumes from the existing snapshot rather than re-uploading everything. That is the deliberate difference from `disconnectSyncServer`, which wipes all of it.

**Only `401` qualifies.** The server uses `403` for wrong credentials and for another account's resources, `404` for ordinary misses such as a video absent from the watch history, and `413`/`429` for quota and rate limiting. Treating any of those as an expired session would sign people out for the wrong reason.

The error types moved to `helpers/sync-server-errors.js`, re-exported from `helpers/sync-server.js` so no import site changes. That was needed to make the classification testable: `helpers/sync-server.js` imports `../../constants` extensionless for webpack, which `node --test` cannot resolve, which is why the existing unit tests only cover leaf helper modules.

## Validation

- ESLint on the changed component, helpers, store and regression test
- `node --test tests/unit/*.test.mjs` — 74 pass, including 3 new cases covering `401`, the statuses that must *not* count, and non-`SyncServerError` values
- `git diff --check`
- production E2E packaging
- targeted Electron/Playwright offline settings spec
- checked against a live upgraded sync server: a stale token returns `401 invalid or missing authentication token` and is classified as an expired session, while a healthy `200` is not

## Not included

`deleteSyncServerAccount` still surfaces a `401` as a plain error. It is user-initiated so the message is seen immediately, and the next sync attempt clears the token anyway. Can fold it in if preferred.
