### PR TITLE
fix(sync): sign out cleanly when the server rejects the token

### DIFF
--- a/src/renderer/helpers/sync-server-errors.js
+++ b/src/renderer/helpers/sync-server-errors.js
@@ -1,0 +1,40 @@
+/**
+ * Sync server error types and the predicates that classify them.
+ *
+ * Kept in its own module so the classification logic can be unit tested; the
+ * main sync-server helper pulls in webpack-resolved imports that a plain Node
+ * test runner cannot load.
+ */
+
+export class SyncServerError extends Error {
+  constructor(message, status = null) {
+    super(message)
+    this.name = 'SyncServerError'
+    this.status = status
+  }
+}
+
+export class SyncServerDataLossError extends Error {
+  constructor(collection, deleted, previous) {
+    super(
+      `Sync stopped because it would delete ${deleted} of ${previous} previously synced ${collection} items`
+    )
+    this.name = 'SyncServerDataLossError'
+    this.collection = collection
+    this.deleted = deleted
+    this.previous = previous
+  }
+}
+
+/**
+ * Whether an error means the stored token is no longer accepted.
+ *
+ * Only 401 qualifies. The server answers 403 for wrong credentials and for
+ * resources owned by someone else, and 404 for plenty of ordinary misses, so
+ * treating those as an expired session would sign people out for unrelated
+ * reasons.
+ * @param {unknown} error
+ */
+export function isSessionExpiredError(error) {
+  return error instanceof SyncServerError && error.status === 401
+}

--- a/src/renderer/helpers/sync-server.js
+++ b/src/renderer/helpers/sync-server.js
@@ -1,4 +1,9 @@
 import { MAIN_PROFILE_ID } from '../../constants'
+import {
+  SyncServerDataLossError,
+  SyncServerError,
+  isSessionExpiredError,
+} from './sync-server-errors'
 import { getSyncableSettingKeys } from '../store/modules/settings'
 import { deepCopy } from './utils'
 import { generateRandomUniqueId } from './playlists'
@@ -13,25 +18,7 @@ const MAX_ENCRYPTED_SYNC_TIMEOUT_MS = 5 * 60 * 1000
 const DEFAULT_CHANNEL_AVATAR = 'https://yt3.googleusercontent.com/ytc/default'
 const YOUTUBE_VIDEO_THUMBNAIL_REGEX = /^https?:\/\/i\.ytimg\.com\/vi(?:_webp)?\//
 
-export class SyncServerError extends Error {
-  constructor(message, status = null) {
-    super(message)
-    this.name = 'SyncServerError'
-    this.status = status
-  }
-}
-
-export class SyncServerDataLossError extends Error {
-  constructor(collection, deleted, previous) {
-    super(
-      `Sync stopped because it would delete ${deleted} of ${previous} previously synced ${collection} items`
-    )
-    this.name = 'SyncServerDataLossError'
-    this.collection = collection
-    this.deleted = deleted
-    this.previous = previous
-  }
-}
+export { SyncServerDataLossError, SyncServerError, isSessionExpiredError }
 
 export function normalizeSyncServerUrl(value) {
   let url

--- a/src/renderer/store/modules/sync-server.js
+++ b/src/renderer/store/modules/sync-server.js
@@ -1,6 +1,7 @@
 import {
   SyncServerClient,
   SyncServerDataLossError,
+  isSessionExpiredError,
   normalizeSyncServerUrl,
   syncChannelPlaybackSpeeds,
   syncHistory,
@@ -336,6 +337,13 @@ async function runSync(context, { allowDataLoss = false } = {}) {
       await dispatch('setSyncServerAutoSync', false)
     }
     commit('setSyncServerProgress', null)
+    if (isSessionExpiredError(error)) {
+      // Retrying cannot help once the token is rejected, and every scheduled
+      // sync would keep failing with the same opaque message. Drop the token so
+      // automatic sync stops and the UI asks for a sign-in.
+      await dispatch('expireSyncServerSession')
+      throw error
+    }
     commit('setSyncServerError', error.message)
     commit('setSyncServerStatus', 'error')
     throw error
@@ -398,6 +406,21 @@ const actions = {
 
     await dispatch('startSyncServerAutoSync')
     return dispatch('syncWithSyncServer')
+  },
+
+  /**
+   * Handle the server rejecting the stored token.
+   *
+   * Only the token is cleared. The server URL, username, snapshot and privacy
+   * key are kept so that signing in again resumes where sync left off instead of
+   * re-downloading everything.
+   */
+  async expireSyncServerSession({ commit, dispatch }) {
+    await dispatch('stopSyncServerAutoSync')
+    await dispatch('updateSyncServerToken', '', { root: true })
+    commit('setSyncServerProgress', null)
+    commit('setSyncServerError', 'Sync server session expired. Sign in again to resume syncing.')
+    commit('setSyncServerStatus', 'error')
   },
 
   async disconnectSyncServer({ commit, dispatch }) {

--- a/tests/unit/sync-server-session.test.mjs
+++ b/tests/unit/sync-server-session.test.mjs
@@ -1,0 +1,32 @@
+import assert from 'node:assert/strict'
+import test from 'node:test'
+
+import {
+  SyncServerError,
+  isSessionExpiredError,
+} from '../../src/renderer/helpers/sync-server-errors.js'
+
+test('treats 401 as an expired session', () => {
+  assert.equal(
+    isSessionExpiredError(new SyncServerError('invalid or missing authentication token', 401)),
+    true
+  )
+})
+
+test('does not treat other sync server failures as an expired session', () => {
+  // 403 is wrong credentials or someone else's resource, not a dead token
+  assert.equal(isSessionExpiredError(new SyncServerError('invalid accountname or password', 403)), false)
+  // 404 is an ordinary miss, e.g. a video not in the watch history
+  assert.equal(isSessionExpiredError(new SyncServerError('not found', 404)), false)
+  // rate limiting and quota errors are retryable or user-fixable
+  assert.equal(isSessionExpiredError(new SyncServerError('too many requests', 429)), false)
+  assert.equal(isSessionExpiredError(new SyncServerError('quota exceeded', 413)), false)
+  assert.equal(isSessionExpiredError(new SyncServerError('server exploded', 500)), false)
+})
+
+test('ignores errors that are not sync server errors', () => {
+  assert.equal(isSessionExpiredError(new Error('offline')), false)
+  assert.equal(isSessionExpiredError(null), false)
+  assert.equal(isSessionExpiredError(undefined), false)
+  assert.equal(isSessionExpiredError({ status: 401 }), false)
+})


### PR DESCRIPTION
## Why

The sync server now enforces token expiry, and additionally rejects tokens minted before it corrected the `exp` claim from milliseconds to seconds ([sync-server#1](https://github.com/OpenTubeX/sync-server/pull/1)). Every existing install therefore hits a 401 exactly once after the server upgrade. That part is intended.

The problem is what the client did with it. A 401 was treated like any other sync failure: it displayed the server's text, *"invalid or missing authentication token"*, and **left the dead token in settings**. Automatic sync and event-triggered sync then kept firing on their normal schedule and kept failing identically, so the app sat in a permanently broken state behind a message that does not say what to do. Signing in again fixes it, but nothing tells the user that — this was observed on a real deployment.

## What changed

A 401 now clears the stored token and reports *"Sync server session expired. Sign in again to resume syncing."*

Clearing the token is what stops the retry loop: `startSyncServerAutoSync` and `scheduleSyncServer` both already bail out when there is no token, so no extra guard is needed.

**Only the token is cleared.** The server URL, username, snapshot and privacy key are kept, so signing back in resumes from the existing snapshot instead of re-uploading everything. That is the difference from `disconnectSyncServer`, which intentionally wipes all of it.

**Only 401 qualifies.** The server uses 403 for wrong credentials and for another account's resources, 404 for ordinary misses such as a video absent from the watch history, and 413/429 for quota and rate limiting. Treating any of those as an expired session would sign people out for the wrong reason, so the predicate is deliberately narrow.

## Structure

The error types moved to `helpers/sync-server-errors.js` and `helpers/sync-server.js` re-exports them, so no import site changes. This was necessary to make the classification testable: `helpers/sync-server.js` imports `../../constants` extensionless for webpack, which `node --test` cannot resolve — the reason the existing unit tests only cover leaf helper modules.

## Verification

- `node --test tests/unit/*.test.mjs` — 74 pass, including 3 new cases covering 401, the statuses that must *not* count, and non-`SyncServerError` values.
- eslint clean on the touched files (also enforced by the pre-commit hook).
- Checked against a live upgraded server: a stale token returns `401 invalid or missing authentication token` and is classified as an expired session, while a healthy `200` is not.

## Not included

`deleteSyncServerAccount` still surfaces a 401 as a plain error. It is user-initiated so the message is seen immediately, and the next sync attempt clears the token anyway. Happy to fold it in if you would rather have it consistent.
