### PR TITLE
ci: run only changed E2E tests in pull requests

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -34,6 +34,8 @@ jobs:
     steps:
     - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
       with:
+        # Playwright needs the base branch history to identify tests changed by a PR.
+        fetch-depth: 0
         persist-credentials: false
 
     - name: Use Node.js 24.x
@@ -89,10 +91,15 @@ jobs:
     # attempt and automatically falls back to recorded fixtures on retry.
     - name: Run E2E tests
       run: |
+        test_args=()
+        if [ "${{ github.event_name }}" = "pull_request" ]; then
+          test_args+=("--only-changed=origin/${GITHUB_BASE_REF}" "--pass-with-no-tests")
+        fi
+
         if [ "${{ steps.project.outputs.project }}" = "all" ]; then
-          xvfb-run --auto-servernum --server-args='-screen 0 1920x1080x24' pnpm run test:e2e
+          xvfb-run --auto-servernum --server-args='-screen 0 1920x1080x24' pnpm run test:e2e "${test_args[@]}"
         else
-          xvfb-run --auto-servernum --server-args='-screen 0 1920x1080x24' pnpm run test:e2e:${{ steps.project.outputs.project }}
+          xvfb-run --auto-servernum --server-args='-screen 0 1920x1080x24' pnpm run test:e2e:${{ steps.project.outputs.project }} "${test_args[@]}"
         fi
       shell: bash
 

--- a/e2e/README.md
+++ b/e2e/README.md
@@ -27,7 +27,7 @@ mobile layout and breaks selectors.
   Seed settings/datastores per file via `test.use({ seed: { ... } })`.
   The main process honours `OPENTUBEX_E2E_USER_DATA_DIR` for isolation.
 - `helpers/innertube.mjs` – record/replay for Innertube requests (see below).
-- `tests/offline/` – must pass without any external network. Runs on every PR.
+- `tests/offline/` – must pass without any external network.
 - `tests/network/` – requires YouTube. Runs nightly and via workflow dispatch.
 - `fixtures/innertube/` – gzipped recorded Innertube responses, committed to git.
 
@@ -67,10 +67,11 @@ E2E_USE_FIXTURES=1 pnpm run test:e2e:network
 
 `.github/workflows/e2e.yml`:
 
-- **Pull requests** → full offline and network suites (blocking).
+- **Pull requests** → changed test files and tests importing changed helpers.
 - **Nightly** → full offline and network suites.
 - **Manual dispatch** → all suites by default, or an individual suite.
 
+Pull requests without changed or affected E2E tests pass without running tests.
 Network tests use the fixture fallback on retry.
 
 On failure the Playwright HTML report and traces are uploaded as artifacts.


### PR DESCRIPTION
## Summary

- fetch full Git history in the E2E workflow
- use Playwright's native changed-test dependency analysis for pull requests
- allow pull requests with no affected E2E tests to complete successfully
- preserve full-suite behavior for scheduled and manual runs

## Why

Pull requests currently run every E2E test even when only one test file or one of its imported helpers changed. Playwright can identify changed and transitively affected test files from the Git diff, reducing CI time and resource usage.

## Impact

Pull request E2E runs are scoped to changed or affected test files. Nightly and manually dispatched E2E runs continue to execute the complete selected project suite.

## Validation

- `git diff --check`
- parsed `.github/workflows/e2e.yml` with Ruby's YAML parser
- checked the embedded Bash block with `bash -n`

The repository dependency-based YAML lint command was unavailable because dependencies are not installed in this worktree.