### PR TITLE
Add configurable context menu web search

### DIFF
--- a/e2e/tests/offline/search-context-menu.spec.mjs
+++ b/e2e/tests/offline/search-context-menu.spec.mjs
@@ -213,6 +213,39 @@ test.describe('with one external search engine enabled', () => {
   })
 })
 
+test.describe('with the maximum custom search engines configured', () => {
+  test.use({
+    seed: {
+      settings: {
+        contextMenuSearchEngines: JSON.stringify(Array.from({ length: 20 }, (_, index) => ({
+          id: `custom-${index}`,
+          name: `Engine ${index}`,
+          url: `https://example${index}.com/search?q=%s`,
+          enabled: true
+        })))
+      }
+    }
+  })
+
+  test('rejects another engine without clearing its inputs', async ({ page }) => {
+    await goTo(page, 'settings')
+    await page.locator('.settingsMenu [data-section="context-menu-search"]').click()
+
+    const addRow = page.locator('.settingsSections [data-section="context-menu-search"] .addEngine')
+    const nameInput = addRow.getByLabel('Engine name')
+    const urlInput = addRow.getByLabel('Search URL')
+    await nameInput.fill('One Too Many')
+    await urlInput.fill('https://overflow.example/search?q=%s')
+    await addRow.getByRole('button', { name: 'Add engine' }).click()
+
+    await expect(nameInput).toHaveValue('One Too Many')
+    await expect(urlInput).toHaveValue('https://overflow.example/search?q=%s')
+    await expect(page.locator('.toast .message', {
+      hasText: 'You can add up to 20 custom search engines.'
+    })).toBeVisible()
+  })
+})
+
 test.describe('German locale', () => {
   test.use({ seed: { settings: { currentLocale: 'de-DE' } } })
 

--- a/e2e/tests/offline/search-context-menu.spec.mjs
+++ b/e2e/tests/offline/search-context-menu.spec.mjs
@@ -64,6 +64,23 @@ test('keeps web search enabled and below in-app search for long selections', asy
   expect(webSearchIndex).toBeGreaterThan(Math.max(...inAppSearchIndices))
 })
 
+test('keeps the newest overlapping context menu session executable', async ({ page }) => {
+  const contextMenus = await page.evaluate(() => {
+    return Promise.all(Array.from({ length: 10 }, (_, index) => {
+      return window.ftElectron.contextMenu.open({ selectionText: `overlap ${index}` })
+    }))
+  })
+  const contextMenu = contextMenus.at(-1)
+  const search = contextMenu.items.find(item => item.label === 'Search "overlap 9" in a New Tab')
+
+  await page.evaluate(({ sessionId, actionId }) => {
+    return window.ftElectron.contextMenu.execute(sessionId, actionId)
+  }, { sessionId: contextMenu.sessionId, actionId: search.actionId })
+
+  await expect(page.locator(sel.tabs)).toHaveCount(2)
+  await expect(page).toHaveURL(/#\/search\/overlap%209/)
+})
+
 test('adds a custom search engine from settings', async ({ page }) => {
   await goTo(page, 'settings')
   const sectionOrder = await page.locator('.settingsMenu [data-section]').evaluateAll(items => {
@@ -107,6 +124,11 @@ test('adds a custom search engine from settings', async ({ page }) => {
     })
   ]).then(([inputCenter, buttonCenter]) => Math.abs(inputCenter - buttonCenter))
   expect(centerDifference).toBeLessThan(1)
+
+  const urlInput = customRow.getByLabel('Search URL')
+  await urlInput.fill('not a search URL')
+  await urlInput.blur()
+  await expect(urlInput).toHaveValue('https://example.com/search?q=%s')
 
   const contextMenu = await page.evaluate(() => window.ftElectron.contextMenu.open({
     selectionText: 'custom search'

--- a/e2e/tests/offline/search-context-menu.spec.mjs
+++ b/e2e/tests/offline/search-context-menu.spec.mjs
@@ -1,4 +1,4 @@
-import { test, expect, sel } from '../../helpers/app.mjs'
+import { test, expect, goTo, sel } from '../../helpers/app.mjs'
 
 test('searching selected text in a new tab uses the default filters', async ({ page }) => {
   const contextMenu = await page.evaluate(() => window.ftElectron.contextMenu.open({
@@ -21,4 +21,159 @@ test('searching selected text in a new tab uses the default filters', async ({ p
   await expect(page.locator('input[type="radio"][value="all"]')).toBeChecked()
   await expect(page.locator('.searchRadio', { hasText: 'Time' }).locator('input[value=""]')).toBeChecked()
   await expect(page.locator('.searchRadio', { hasText: 'Duration' }).locator('input[value=""]')).toBeChecked()
+})
+
+test('offers enabled external search engines in a submenu', async ({ page }) => {
+  const contextMenu = await page.evaluate(() => window.ftElectron.contextMenu.open({
+    selectionText: 'private search'
+  }))
+  const searchWith = contextMenu.items.find(item => item.label === 'Search with...')
+
+  expect(searchWith.submenu.map(item => item.label)).toEqual([
+    'DuckDuckGo',
+    'Startpage',
+    'Qwant',
+    'Brave Search'
+  ])
+  expect(searchWith.submenu.map(item => item.icon)).toEqual([
+    'https://duckduckgo.com/favicon.ico',
+    'https://www.startpage.com/favicon.ico',
+    'https://www.qwant.com/favicon.ico',
+    'https://search.brave.com/favicon.ico'
+  ])
+  expect(searchWith.submenu.map(item => item.faviconSource)).toEqual([
+    'https://duckduckgo.com/?q=%s',
+    'https://www.startpage.com/sp/search?query=%s',
+    'https://www.qwant.com/?q=%s',
+    'https://search.brave.com/search?q=%s'
+  ])
+})
+
+test('keeps web search enabled and below in-app search for long selections', async ({ page }) => {
+  const contextMenu = await page.evaluate(() => window.ftElectron.contextMenu.open({
+    selectionText: 'x'.repeat(101)
+  }))
+  const webSearchIndex = contextMenu.items.findIndex(item => item.label === 'Search with...')
+  const inAppSearchIndices = contextMenu.items
+    .map((item, index) => typeof item.label === 'string' && item.label.includes('is too long for search')
+      ? index
+      : -1)
+    .filter(index => index !== -1)
+
+  expect(contextMenu.items[webSearchIndex].enabled).toBe(true)
+  expect(webSearchIndex).toBeGreaterThan(Math.max(...inAppSearchIndices))
+})
+
+test('adds a custom search engine from settings', async ({ page }) => {
+  await goTo(page, 'settings')
+  const sectionOrder = await page.locator('.settingsMenu [data-section]').evaluateAll(items => {
+    return items.map(item => item.dataset.section)
+  })
+  expect(sectionOrder.indexOf('context-menu-search'))
+    .toBe(sectionOrder.indexOf('return-youtube-dislike') + 1)
+
+  await page.locator('.settingsMenu [data-section="context-menu-search"]').click()
+
+  const section = page.locator('.settingsSections [data-section="context-menu-search"]')
+  await section.getByLabel('Engine name').fill('Example Search')
+  await section.getByLabel('Search URL').fill('https://example.com/search?q=%s')
+  const addButton = section.getByRole('button', { name: 'Add engine' })
+  const addRowCenterDifference = await Promise.all([
+    section.getByLabel('Engine name').evaluate(element => {
+      const bounds = element.getBoundingClientRect()
+      return bounds.top + bounds.height / 2
+    }),
+    addButton.evaluate(element => {
+      const bounds = element.getBoundingClientRect()
+      return bounds.top + bounds.height / 2
+    })
+  ]).then(([inputCenter, buttonCenter]) => Math.abs(inputCenter - buttonCenter))
+  expect(addRowCenterDifference).toBeLessThan(1)
+
+  await addButton.click()
+  await expect(section.getByRole('checkbox', { name: 'Example Search' })).toBeChecked()
+
+  const customRow = section.locator('.engineRow').filter({ hasText: 'Example Search' })
+  const nameInput = customRow.getByLabel('Engine name')
+  const removeButton = customRow.getByRole('button', { name: 'Remove Example Search' })
+  const centerDifference = await Promise.all([
+    nameInput.evaluate(element => {
+      const bounds = element.getBoundingClientRect()
+      return bounds.top + bounds.height / 2
+    }),
+    removeButton.evaluate(element => {
+      const bounds = element.getBoundingClientRect()
+      return bounds.top + bounds.height / 2
+    })
+  ]).then(([inputCenter, buttonCenter]) => Math.abs(inputCenter - buttonCenter))
+  expect(centerDifference).toBeLessThan(1)
+
+  const contextMenu = await page.evaluate(() => window.ftElectron.contextMenu.open({
+    selectionText: 'custom search'
+  }))
+  const searchWith = contextMenu.items.find(item => item.label === 'Search with...')
+
+  expect(searchWith.submenu.map(item => item.label)).toContain('Example Search')
+  expect(searchWith.submenu.find(item => item.label === 'Example Search').icon)
+    .toBe('https://example.com/favicon.ico')
+})
+
+test.describe('with one external search engine enabled', () => {
+  test.use({
+    seed: {
+      settings: {
+        contextMenuSearchEngines: JSON.stringify([
+          {
+            id: 'duckduckgo',
+            name: 'DuckDuckGo',
+            url: 'https://duckduckgo.com/?q=%s',
+            enabled: true
+          },
+          {
+            id: 'startpage',
+            name: 'Startpage',
+            url: 'https://www.startpage.com/sp/search?query=%s',
+            enabled: false
+          },
+          {
+            id: 'qwant',
+            name: 'Qwant',
+            url: 'https://www.qwant.com/?q=%s',
+            enabled: false
+          },
+          {
+            id: 'brave',
+            name: 'Brave Search',
+            url: 'https://search.brave.com/search?q=%s',
+            enabled: false
+          }
+        ])
+      }
+    }
+  })
+
+  test('shows a direct action and opens the encoded URL in the default browser', async ({ app, page }) => {
+    await app.electronApp.evaluate(({ shell }) => {
+      globalThis.openedExternalSearchUrls = []
+      shell.openExternal = async (url) => {
+        globalThis.openedExternalSearchUrls.push(url)
+      }
+    })
+
+    const contextMenu = await page.evaluate(() => window.ftElectron.contextMenu.open({
+      selectionText: 'privacy & cats'
+    }))
+    const searchWith = contextMenu.items.find(item => item.label === 'Search with DuckDuckGo')
+
+    expect(searchWith.submenu).toBeUndefined()
+    expect(searchWith.icon).toBe('https://duckduckgo.com/favicon.ico')
+    expect(searchWith.faviconSource).toBe('https://duckduckgo.com/?q=%s')
+    await page.evaluate(({ sessionId, actionId }) => {
+      return window.ftElectron.contextMenu.execute(sessionId, actionId)
+    }, { sessionId: contextMenu.sessionId, actionId: searchWith.actionId })
+
+    await expect.poll(() => app.electronApp.evaluate(() => {
+      return globalThis.openedExternalSearchUrls
+    })).toEqual(['https://duckduckgo.com/?q=privacy%20%26%20cats'])
+  })
 })

--- a/e2e/tests/offline/search-context-menu.spec.mjs
+++ b/e2e/tests/offline/search-context-menu.spec.mjs
@@ -5,6 +5,10 @@ test('searching selected text in a new tab uses the default filters', async ({ p
     selectionText: 'context search'
   }))
   const search = contextMenu.items.find(item => item.label === 'Search "context search" in a New Tab')
+  expect(search).toMatchObject({
+    labelKey: 'Context Menu.Search Selection in New Tab',
+    labelParameters: { selection: 'context search' }
+  })
 
   await page.evaluate(({ sessionId, actionId }) => {
     return window.ftElectron.contextMenu.execute(sessionId, actionId)
@@ -29,6 +33,10 @@ test('offers enabled external search engines in a submenu', async ({ page }) => 
   }))
   const searchWith = contextMenu.items.find(item => item.label === 'Search with...')
 
+  expect(searchWith).toMatchObject({
+    labelKey: 'Context Menu.Search With Multiple',
+    labelParameters: {}
+  })
   expect(searchWith.submenu.map(item => item.label)).toEqual([
     'DuckDuckGo',
     'Startpage',
@@ -47,6 +55,7 @@ test('offers enabled external search engines in a submenu', async ({ page }) => 
     'https://www.qwant.com/?q=%s',
     'https://search.brave.com/search?q=%s'
   ])
+  expect(searchWith.submenu.every(item => item.labelKey == null)).toBe(true)
 })
 
 test('keeps web search enabled and below in-app search for long selections', async ({ page }) => {
@@ -188,6 +197,10 @@ test.describe('with one external search engine enabled', () => {
     const searchWith = contextMenu.items.find(item => item.label === 'Search with DuckDuckGo')
 
     expect(searchWith.submenu).toBeUndefined()
+    expect(searchWith).toMatchObject({
+      labelKey: 'Context Menu.Search With',
+      labelParameters: { engine: 'DuckDuckGo' }
+    })
     expect(searchWith.icon).toBe('https://duckduckgo.com/favicon.ico')
     expect(searchWith.faviconSource).toBe('https://duckduckgo.com/?q=%s')
     await page.evaluate(({ sessionId, actionId }) => {
@@ -197,5 +210,20 @@ test.describe('with one external search engine enabled', () => {
     await expect.poll(() => app.electronApp.evaluate(() => {
       return globalThis.openedExternalSearchUrls
     })).toEqual(['https://duckduckgo.com/?q=privacy%20%26%20cats'])
+  })
+})
+
+test.describe('German locale', () => {
+  test.use({ seed: { settings: { currentLocale: 'de-DE' } } })
+
+  test('translates external search labels from explicit menu metadata', async ({ page }) => {
+    const searchInput = page.locator('.searchInput input')
+    await searchInput.fill('Auswahl')
+    await searchInput.selectText()
+    await searchInput.click({ button: 'right' })
+
+    const menu = page.getByRole('menu', { name: 'Kontextmenü' })
+    await expect(menu).toBeVisible()
+    await expect(menu.getByRole('menuitem', { name: 'Suchen mit …' })).toBeVisible()
   })
 })

--- a/src/constants.js
+++ b/src/constants.js
@@ -68,6 +68,7 @@ const IpcChannels = {
   TABS_SET_CONTEXT_MENU_TAB: 'tabs-set-context-menu-tab',
   CONTEXT_MENU_OPEN: 'context-menu-open',
   CONTEXT_MENU_EXECUTE: 'context-menu-execute',
+  RESOLVE_FAVICON: 'resolve-favicon',
   CREATE_NEW_TAB: 'create-new-tab',
 
   DB_SETTINGS: 'db-settings',

--- a/src/main/favicon.js
+++ b/src/main/favicon.js
@@ -1,0 +1,112 @@
+import { getFaviconUrl } from '../searchEngines.js'
+
+/**
+ * @param {string} tag
+ * @returns {Record<string, string>}
+ */
+function parseAttributes(tag) {
+  const attributes = {}
+  const pattern = /([^\s=]+)\s*=\s*(?:"([^"]*)"|'([^']*)'|([^\s"'=<>`]+))/g
+
+  for (const match of tag.matchAll(pattern)) {
+    attributes[match[1].toLowerCase()] = match[2] ?? match[3] ?? match[4] ?? ''
+  }
+
+  return attributes
+}
+
+/**
+ * @param {Record<string, string>} attributes
+ * @returns {number}
+ */
+function faviconScore(attributes) {
+  const type = attributes.type?.toLowerCase() ?? ''
+  const sizes = attributes.sizes?.toLowerCase() ?? ''
+
+  // Prefer the exact menu target size. Some sites serve SVG favicons with
+  // response policies that prevent Electron image elements from displaying
+  // them even though a browser-declared PNG is available alongside them.
+  if (sizes.split(/\s+/).includes('32x32')) return 100
+  if (type === 'image/svg+xml') return 90
+  if (sizes.split(/\s+/).includes('16x16')) return 80
+  if (type === 'image/png') return 70
+  return 50
+}
+
+/**
+ * Find the favicon that a browser would use, preferring scalable or small
+ * raster icons over legacy ICO files.
+ *
+ * @param {string} html
+ * @param {string} pageUrl
+ * @returns {string | null}
+ */
+export function extractFaviconUrl(html, pageUrl) {
+  const candidates = []
+
+  for (const match of html.matchAll(/<link\b[^>]*>/gi)) {
+    const attributes = parseAttributes(match[0])
+    const rel = new Set((attributes.rel ?? '').toLowerCase().split(/\s+/))
+    if (!rel.has('icon') || !attributes.href) continue
+
+    try {
+      const url = new URL(attributes.href, pageUrl)
+      if (url.protocol !== 'https:' && url.protocol !== 'http:') continue
+      candidates.push({ url: url.href, score: faviconScore(attributes) })
+    } catch {
+      // Ignore malformed icon declarations.
+    }
+  }
+
+  return candidates.toSorted((a, b) => b.score - a.score)[0]?.url ?? null
+}
+
+/**
+ * @param {string} searchUrl
+ * @param {(input: string, init: RequestInit) => Promise<Response>} fetchPage
+ * @returns {Promise<string>}
+ */
+export async function resolveFaviconUrl(searchUrl, fetchPage) {
+  const fallback = getFaviconUrl(searchUrl)
+  if (!fallback) return ''
+
+  try {
+    const homepage = new URL(searchUrl.replaceAll('%s', 'query')).origin
+    const response = await fetchPage(homepage, {
+      headers: { Accept: 'text/html' },
+      signal: AbortSignal.timeout(5000)
+    })
+    const contentType = response.headers.get('content-type') ?? ''
+    if (!contentType.includes('text/html')) return fallback
+
+    return extractFaviconUrl(await response.text(), response.url || homepage) ?? fallback
+  } catch {
+    return fallback
+  }
+}
+
+/**
+ * Fetch an icon in the main process so renderer image policies and cross-origin
+ * response headers cannot prevent it from displaying.
+ *
+ * @param {string} iconUrl
+ * @param {(input: string, init: RequestInit) => Promise<Response>} fetchIcon
+ * @returns {Promise<string>}
+ */
+export async function fetchFaviconDataUrl(iconUrl, fetchIcon) {
+  try {
+    const response = await fetchIcon(iconUrl, {
+      headers: { Accept: 'image/*' },
+      signal: AbortSignal.timeout(5000)
+    })
+    const contentType = response.headers.get('content-type')?.split(';')[0] ?? ''
+    if (!response.ok || !contentType.startsWith('image/')) return iconUrl
+
+    const data = Buffer.from(await response.arrayBuffer())
+    if (data.length === 0 || data.length > 262_144) return iconUrl
+
+    return `data:${contentType};base64,${data.toString('base64')}`
+  } catch {
+    return iconUrl
+  }
+}

--- a/src/main/index.js
+++ b/src/main/index.js
@@ -2,7 +2,7 @@ import {
   app, BrowserWindow, dialog, Menu, ipcMain,
   powerSaveBlocker, screen, session,
   nativeTheme, net, protocol, clipboard,
-  Tray
+  shell, Tray
 } from 'electron'
 import './e2eUserDataOverride'
 import path from 'path'
@@ -33,6 +33,13 @@ import { isOpenTubeXUrl } from './utils'
 import { TabManager, setupTabsIPC } from './tabs/TabManager'
 import { clearAllTabSessions, loadAllTabSessions } from './tabs/TabSessionStore'
 import { isShareableOpenTubeXRoute, transformOpenTubeXRouteUrl } from '../renderer/helpers/share'
+import {
+  buildSearchUrl,
+  DEFAULT_SEARCH_ENGINES_SETTING,
+  getFaviconUrl,
+  parseSearchEngines
+} from '../searchEngines'
+import { fetchFaviconDataUrl, resolveFaviconUrl } from './favicon'
 
 const brotliDecompressAsync = promisify(brotliDecompress)
 
@@ -110,6 +117,23 @@ function runApp() {
   let subscriptionAutoRefreshProgress = 0
   /** @type {Promise<{ exitCode: number | null, signal: NodeJS.Signals | null, stdout: string, stderr: string }> | null} */
   let ipBlockRecoveryScriptPromise = null
+  const faviconPromises = new Map()
+
+  function resolveSearchEngineFavicon(searchUrl) {
+    const fallback = getFaviconUrl(searchUrl)
+    if (!fallback) return Promise.resolve('')
+
+    const origin = new URL(fallback).origin
+    if (!faviconPromises.has(origin)) {
+      const promise = process.env.OPENTUBEX_E2E_USER_DATA_DIR
+        ? Promise.resolve(fallback)
+        : resolveFaviconUrl(searchUrl, (url, options) => net.fetch(url, options))
+            .then(icon => fetchFaviconDataUrl(icon, (url, options) => net.fetch(url, options)))
+      faviconPromises.set(origin, promise)
+    }
+
+    return faviconPromises.get(origin)
+  }
 
   /**
    * @param {string} url
@@ -677,7 +701,7 @@ function runApp() {
     },
     // only show the copy link entry for external links and the /playlist, /channel and /watch in-app URLs
     // the /playlist, /channel and /watch in-app URLs get transformed to their equivalent YouTube or Invidious URLs
-    append: (defaultActions, parameters, webContents) => {
+    append: async (defaultActions, parameters, webContents) => {
       const pageUrl = parameters.pageURL || ''
       let visible = false
       const urlParts = parameters.linkURL.split('#')
@@ -704,6 +728,35 @@ function runApp() {
 
       const selectionText = parameters.selectionText.trim()
       const textShortEnoughForSearch = selectionText.length <= SEARCH_CHAR_LIMIT
+      const searchEnginesSetting = (await baseHandlers.settings._findOne('contextMenuSearchEngines'))?.value ??
+        DEFAULT_SEARCH_ENGINES_SETTING
+      const activeSearchEngines = parseSearchEngines(searchEnginesSetting)
+        .filter(engine => engine.enabled)
+      const externalSearchItems = activeSearchEngines.map(engine => ({
+        label: engine.name,
+        icon: getFaviconUrl(engine.url),
+        faviconSource: engine.url,
+        click: async () => {
+          try {
+            await shell.openExternal(buildSearchUrl(engine.url, selectionText))
+          } catch (error) {
+            console.error(`Failed to search with ${engine.name}:`, error)
+          }
+        }
+      }))
+      const externalSearch = activeSearchEngines.length === 1
+        ? {
+            label: `Search with ${activeSearchEngines[0].name}`,
+            icon: getFaviconUrl(activeSearchEngines[0].url),
+            faviconSource: activeSearchEngines[0].url,
+            visible: selectionText.length > 0,
+            click: externalSearchItems[0].click
+          }
+        : {
+            label: 'Search with...',
+            visible: selectionText.length > 0 && activeSearchEngines.length > 1,
+            submenu: externalSearchItems
+          }
 
       return [
         {
@@ -774,6 +827,7 @@ function runApp() {
             })
           }
         },
+        externalSearch,
       ]
     },
   }
@@ -863,13 +917,15 @@ function runApp() {
         refreshingLabel: item.refreshingLabel != null ? String(item.refreshingLabel) : undefined,
         enabled: item.enabled !== false,
         checked: item.checked === true,
+        icon: typeof item.icon === 'string' ? item.icon : undefined,
+        faviconSource: typeof item.faviconSource === 'string' ? item.faviconSource : undefined,
         actionId: hasAction ? actionId : undefined,
         submenu
       }
     })
   }
 
-  ipcMain.handle(IpcChannels.CONTEXT_MENU_OPEN, (event, rawParameters = {}) => {
+  ipcMain.handle(IpcChannels.CONTEXT_MENU_OPEN, async (event, rawParameters = {}) => {
     const webContents = event.sender
     const parameters = {
       x: Number.isFinite(rawParameters.x) ? rawParameters.x : 0,
@@ -902,7 +958,7 @@ function runApp() {
     const items = [
       ...contextMenuOptions.prepend(defaultActions, parameters, webContents),
       ...defaultItems,
-      ...contextMenuOptions.append(defaultActions, parameters, webContents)
+      ...await contextMenuOptions.append(defaultActions, parameters, webContents)
     ]
     const actions = new Map()
     const sessionId = ++contextMenuSessionId
@@ -918,6 +974,16 @@ function runApp() {
 
     const action = session.actions.get(payload?.actionId)
     if (action) await action()
+  })
+
+  ipcMain.handle(IpcChannels.RESOLVE_FAVICON, async (event, url) => {
+    if (!isOpenTubeXUrl(event.senderFrame.url) || typeof url !== 'string') return ''
+
+    const setting = (await baseHandlers.settings._findOne('contextMenuSearchEngines'))?.value ??
+      DEFAULT_SEARCH_ENGINES_SETTING
+    if (!parseSearchEngines(setting).some(engine => engine.url === url)) return ''
+
+    return resolveSearchEngineFavicon(url)
   })
 
   if (process.platform === 'win32') {

--- a/src/main/index.js
+++ b/src/main/index.js
@@ -306,6 +306,14 @@ function runApp() {
 
   // Registered per-webContents in 'web-contents-created' so the shared
   // BrowserWindow renderer can resolve native menu targets through TabManager.
+  function contextMenuLabel(key, parameters = {}, fallback = key) {
+    return {
+      key: `Context Menu.${key}`,
+      parameters,
+      fallback
+    }
+  }
+
   /** @type {Record<string, Function | boolean>} */
   const contextMenuOptions = {
     showSearchWithGoogle: false,
@@ -331,12 +339,12 @@ function runApp() {
       const subscriptionFeedTab = manager?.contextMenuSurface === 'subscriptionFeedTab'
         ? manager.contextMenuSubscriptionFeedTab
         : null
-      const subscriptionFeedLabels = {
-        videos: 'Videos',
-        shorts: 'Shorts',
-        live: 'Live',
-        posts: 'Posts',
-        all: 'All Feeds'
+      const subscriptionFeedLabelKeys = {
+        videos: 'Reload Videos',
+        shorts: 'Reload Shorts',
+        live: 'Reload Live',
+        posts: 'Reload Posts',
+        all: 'Reload All Feeds'
       }
       const contextMenuTabYouTubeUrls = contextMenuTabs.map(tab => {
         const route = getOpenTubeXRouteFromUrl(tab.url)
@@ -415,8 +423,8 @@ function runApp() {
       return [
         {
           // While a refresh runs, the same entry cancels it
-          label: `Reload ${subscriptionFeedLabels[subscriptionFeedTab] ?? 'Feed'}`,
-          refreshingLabel: 'Cancel Refresh',
+          label: contextMenuLabel(subscriptionFeedLabelKeys[subscriptionFeedTab] ?? 'Reload Videos'),
+          refreshingLabel: contextMenuLabel('Cancel Refresh'),
           visible: subscriptionFeedTab != null,
           click: () => {
             if (!manager || !subscriptionFeedTab) return
@@ -439,7 +447,13 @@ function runApp() {
           visible: subscriptionFeedTab != null
         },
         {
-          label: isBulkTabAction ? `Close ${contextMenuTabs.length} Tabs` : 'Close Tab',
+          label: isBulkTabAction
+            ? contextMenuLabel(
+                'Close Multiple Tabs',
+                { count: contextMenuTabs.length },
+                `Close ${contextMenuTabs.length} Tabs`
+              )
+            : contextMenuLabel('Close Tab'),
           visible: contextMenuTab != null,
           click: async () => {
             if (!manager || !contextMenuTab) return
@@ -448,7 +462,13 @@ function runApp() {
           }
         },
         {
-          label: isBulkTabAction ? `Duplicate ${contextMenuTabs.length} Tabs` : 'Duplicate Tab',
+          label: isBulkTabAction
+            ? contextMenuLabel(
+                'Duplicate Multiple Tabs',
+                { count: contextMenuTabs.length },
+                `Duplicate ${contextMenuTabs.length} Tabs`
+              )
+            : contextMenuLabel('Duplicate Tab'),
           visible: contextMenuTab != null,
           click: () => {
             if (!manager || !contextMenuTab) return
@@ -457,11 +477,11 @@ function runApp() {
           }
         },
         {
-          label: isBulkTabAction ? 'Move Tabs' : 'Move Tab',
+          label: contextMenuLabel(isBulkTabAction ? 'Move Tabs' : 'Move Tab'),
           visible: contextMenuTab != null,
           submenu: [
             {
-              label: 'To Beginning',
+              label: contextMenuLabel('To Beginning'),
               enabled: canMoveContextMenuTabsToBeginning,
               click: () => {
                 if (!manager || !contextMenuTab) return
@@ -476,7 +496,7 @@ function runApp() {
               }
             },
             {
-              label: 'To End',
+              label: contextMenuLabel('To End'),
               enabled: canMoveContextMenuTabsToEnd,
               click: () => {
                 if (!manager || !contextMenuTab) return
@@ -497,25 +517,25 @@ function runApp() {
           visible: contextMenuTab != null
         },
         {
-          label: 'Close Tabs',
+          label: contextMenuLabel('Close Tabs'),
           visible: contextMenuTab != null,
           submenu: [
             {
-              label: manager?.contextMenuTabBarVertical ? 'To the Top' : 'To the Left',
+              label: contextMenuLabel(manager?.contextMenuTabBarVertical ? 'To the Top' : 'To the Left'),
               enabled: firstSelectedTabIndex > 0,
               click: () => {
                 closeContextMenuTabs(contextMenuTabIds.slice(0, firstSelectedTabIndex))
               }
             },
             {
-              label: manager?.contextMenuTabBarVertical ? 'To the Bottom' : 'To the Right',
+              label: contextMenuLabel(manager?.contextMenuTabBarVertical ? 'To the Bottom' : 'To the Right'),
               enabled: lastSelectedTabIndex < contextMenuTabIds.length - 1,
               click: () => {
                 closeContextMenuTabs(contextMenuTabIds.slice(lastSelectedTabIndex + 1))
               }
             },
             {
-              label: 'Other Tabs',
+              label: contextMenuLabel('Other Tabs'),
               enabled: contextMenuTabIds.length > contextMenuTabs.length,
               click: () => {
                 const selectedIds = new Set(contextMenuTabs.map(tab => tab.id))
@@ -529,7 +549,7 @@ function runApp() {
           visible: contextMenuTab != null
         },
         {
-          label: isBulkTabAction ? 'Copy YouTube Links' : 'Copy YouTube Link',
+          label: contextMenuLabel(isBulkTabAction ? 'Copy YouTube Links' : 'Copy YouTube Link'),
           visible: contextMenuTabYouTubeUrls.length > 0 && contextMenuTabYouTubeUrls.every(Boolean),
           click: () => {
             if (!contextMenuTabYouTubeUrls.every(Boolean)) return
@@ -542,9 +562,9 @@ function runApp() {
           visible: contextMenuTabYouTubeUrls.length > 0 && contextMenuTabYouTubeUrls.every(Boolean)
         },
         {
-          label: allSelectedTabsPinned
+          label: contextMenuLabel(allSelectedTabsPinned
             ? isBulkTabAction ? 'Unpin Tabs' : 'Unpin Tab'
-            : isBulkTabAction ? 'Pin Tabs' : 'Pin Tab',
+            : isBulkTabAction ? 'Pin Tabs' : 'Pin Tab'),
           visible: contextMenuTab != null,
           click: () => {
             if (!manager || !contextMenuTab) return
@@ -555,18 +575,18 @@ function runApp() {
           }
         },
         {
-          label: 'Tab Color',
+          label: contextMenuLabel('Tab Color'),
           visible: contextMenuTab != null,
           submenu: [
-            { label: 'Default', color: null },
-            { label: 'Red', color: 'red' },
-            { label: 'Orange', color: 'orange' },
-            { label: 'Yellow', color: 'yellow' },
-            { label: 'Green', color: 'green' },
-            { label: 'Blue', color: 'blue' },
-            { label: 'Purple', color: 'purple' }
-          ].map(({ label, color }) => ({
-            label,
+            { key: 'Default', color: null },
+            { key: 'Red', color: 'red' },
+            { key: 'Orange', color: 'orange' },
+            { key: 'Yellow', color: 'yellow' },
+            { key: 'Green', color: 'green' },
+            { key: 'Blue', color: 'blue' },
+            { key: 'Purple', color: 'purple' }
+          ].map(({ key, color }) => ({
+            label: contextMenuLabel(key),
             type: 'radio',
             checked: selectedTabColor === color,
             click: () => {
@@ -581,7 +601,7 @@ function runApp() {
           visible: contextMenuTab != null
         },
         {
-          label: 'New Tab',
+          label: contextMenuLabel('New Tab'),
           visible: isTabBarContextMenu && contextMenuTab == null,
           click: () => {
             manager?.createTabWithPreference({ makeActive: true }).catch(error => {
@@ -590,7 +610,7 @@ function runApp() {
           }
         },
         {
-          label: 'Reopen Closed Tab',
+          label: contextMenuLabel('Reopen Closed Tab'),
           visible: isTabBarContextMenu && contextMenuTab == null,
           enabled: manager?.closedTabs.length > 0,
           click: () => {
@@ -598,7 +618,7 @@ function runApp() {
           }
         },
         {
-          label: isBulkTabAction ? 'Reload Tabs' : 'Reload Tab',
+          label: contextMenuLabel(isBulkTabAction ? 'Reload Tabs' : 'Reload Tab'),
           visible: contextMenuTab != null,
           click: () => {
             if (!manager || !contextMenuTab) return
@@ -607,7 +627,7 @@ function runApp() {
           }
         },
         {
-          label: 'Load Tabs',
+          label: contextMenuLabel('Load Tabs'),
           visible: contextMenuTab != null && isBulkTabAction,
           enabled: hasSelectedUnloadedTab,
           click: () => {
@@ -617,7 +637,9 @@ function runApp() {
           }
         },
         {
-          label: isBulkTabAction ? 'Unload Tabs' : isContextMenuTabUnloaded ? 'Load Tab' : 'Unload Tab',
+          label: contextMenuLabel(
+            isBulkTabAction ? 'Unload Tabs' : isContextMenuTabUnloaded ? 'Load Tab' : 'Unload Tab'
+          ),
           visible: contextMenuTab != null,
           enabled: isBulkTabAction
             ? hasSelectedLoadedTab
@@ -646,7 +668,7 @@ function runApp() {
           visible: contextMenuTab != null && moveTargets.length > 0
         },
         {
-          label: isBulkTabAction ? 'Move Tabs to Window' : 'Move Tab to Window',
+          label: contextMenuLabel(isBulkTabAction ? 'Move Tabs to Window' : 'Move Tab to Window'),
           visible: contextMenuTab != null && moveTargets.length > 0,
           submenu: moveTargets.map(({ windowId, label }) => ({
             label,
@@ -665,7 +687,7 @@ function runApp() {
           visible: contextMenuTab != null
         },
         {
-          label: 'Open in a New Tab',
+          label: contextMenuLabel('Open in a New Tab'),
           // Only show the option for in-app URLs and not external ones
           visible: isInAppUrl,
           click: () => {
@@ -681,7 +703,7 @@ function runApp() {
           }
         },
         {
-          label: 'Open in a New Window',
+          label: contextMenuLabel('Open in a New Window'),
           // Only show the option for in-app URLs and not external ones
           visible: isInAppUrl,
           click: () => {
@@ -690,7 +712,7 @@ function runApp() {
         },
         // Only show select all in text fields
         {
-          label: 'Select All',
+          label: contextMenuLabel('Select All'),
           enabled: parameters.editFlags.canSelectAll,
           visible: parameters.isEditable,
           click: () => {
@@ -746,35 +768,39 @@ function runApp() {
       }))
       const externalSearch = activeSearchEngines.length === 1
         ? {
-            label: `Search with ${activeSearchEngines[0].name}`,
+            label: contextMenuLabel(
+              'Search With',
+              { engine: activeSearchEngines[0].name },
+              `Search with ${activeSearchEngines[0].name}`
+            ),
             icon: getFaviconUrl(activeSearchEngines[0].url),
             faviconSource: activeSearchEngines[0].url,
             visible: selectionText.length > 0,
             click: externalSearchItems[0].click
           }
         : {
-            label: 'Search with...',
+            label: contextMenuLabel('Search With Multiple', {}, 'Search with...'),
             visible: selectionText.length > 0 && activeSearchEngines.length > 1,
             submenu: externalSearchItems
           }
 
       return [
         {
-          label: 'Copy Link',
+          label: contextMenuLabel('Copy Link'),
           visible: visible && !isInAppUrl,
           click: () => {
             copy(parameters.linkURL)
           }
         },
         {
-          label: 'Copy YouTube Link',
+          label: contextMenuLabel('Copy YouTube Link'),
           visible: visible && isInAppUrl,
           click: () => {
             copy(transformOpenTubeXRouteUrl(urlParts[1], true))
           }
         },
         {
-          label: 'Copy Invidious Link',
+          label: contextMenuLabel('Copy Invidious Link'),
           visible: visible && isInAppUrl && (backendPreference === 'invidious' || backendFallback),
           click: () => {
             copy(transformOpenTubeXRouteUrl(urlParts[1], false))
@@ -786,7 +812,17 @@ function runApp() {
         // NOT link with no customized link text
         // NOT link for timestamp
         {
-          label: textShortEnoughForSearch ? `Search "${selectionText}" in a New Tab` : `"${selectionText}" is too long for search (> ${SEARCH_CHAR_LIMIT} chars)`,
+          label: textShortEnoughForSearch
+            ? contextMenuLabel(
+                'Search Selection in New Tab',
+                { selection: selectionText },
+                `Search "${selectionText}" in a New Tab`
+              )
+            : contextMenuLabel(
+                'Selection Too Long',
+                { count: SEARCH_CHAR_LIMIT },
+                `"${selectionText}" is too long for search (> ${SEARCH_CHAR_LIMIT} chars)`
+              ),
           enabled: textShortEnoughForSearch,
           visible: (
             !isInAppUrl &&
@@ -810,7 +846,17 @@ function runApp() {
           }
         },
         {
-          label: textShortEnoughForSearch ? `Search "${selectionText}" in a New Window` : `"${selectionText}" is too long for search (> ${SEARCH_CHAR_LIMIT} chars)`,
+          label: textShortEnoughForSearch
+            ? contextMenuLabel(
+                'Search Selection in New Window',
+                { selection: selectionText },
+                `Search "${selectionText}" in a New Window`
+              )
+            : contextMenuLabel(
+                'Selection Too Long',
+                { count: SEARCH_CHAR_LIMIT },
+                `"${selectionText}" is too long for search (> ${SEARCH_CHAR_LIMIT} chars)`
+              ),
           enabled: textShortEnoughForSearch,
           visible: (
             !isInAppUrl &&
@@ -845,39 +891,39 @@ function runApp() {
     return {
       separator: () => ({ type: 'separator' }),
       cut: () => ({
-        label: 'Cut',
+        label: contextMenuLabel('Cut'),
         visible: parameters.isEditable,
         enabled: can('Cut') && hasSelection,
         click: () => webContents.cut()
       }),
       copy: () => ({
-        label: 'Copy',
+        label: contextMenuLabel('Copy'),
         visible: parameters.isEditable || hasSelection,
         enabled: can('Copy') && hasSelection,
         click: () => webContents.copy()
       }),
       paste: () => ({
-        label: 'Paste',
+        label: contextMenuLabel('Paste'),
         visible: parameters.isEditable,
         enabled: can('Paste'),
         click: () => webContents.paste()
       }),
       selectAll: () => ({
-        label: 'Select All',
+        label: contextMenuLabel('Select All'),
         click: () => webContents.selectAll()
       }),
       saveImageAs: () => ({
-        label: 'Save Image As…',
+        label: contextMenuLabel('Save Image As…'),
         visible: parameters.mediaType === 'image',
         click: () => webContents.downloadURL(parameters.srcURL)
       }),
       copyImage: () => ({
-        label: 'Copy Image',
+        label: contextMenuLabel('Copy Image'),
         visible: parameters.mediaType === 'image',
         click: () => webContents.copyImageAt(parameters.x, parameters.y)
       }),
       copyImageAddress: () => ({
-        label: 'Copy Image Address',
+        label: contextMenuLabel('Copy Image Address'),
         visible: parameters.mediaType === 'image',
         click: () => clipboard.writeText(parameters.srcURL)
       })
@@ -899,6 +945,27 @@ function runApp() {
     return cleanedItems
   }
 
+  function serializeContextMenuLabel(label) {
+    if (
+      label != null &&
+      typeof label === 'object' &&
+      typeof label.key === 'string' &&
+      typeof label.fallback === 'string'
+    ) {
+      return {
+        text: label.fallback,
+        key: label.key,
+        parameters: label.parameters
+      }
+    }
+
+    return {
+      text: String(label ?? ''),
+      key: undefined,
+      parameters: undefined
+    }
+  }
+
   function serializeContextMenuItems(items, actions, actionPrefix = 'item') {
     return removeUnusedContextMenuItems(items).map((item, index) => {
       if (item.type === 'separator') return { type: 'separator' }
@@ -910,13 +977,21 @@ function runApp() {
       const submenu = Array.isArray(item.submenu)
         ? serializeContextMenuItems(item.submenu, actions, actionId)
         : undefined
+      const label = serializeContextMenuLabel(item.label)
+      const refreshingLabel = item.refreshingLabel == null
+        ? null
+        : serializeContextMenuLabel(item.refreshingLabel)
 
       return {
         type: item.type ?? 'normal',
-        label: String(item.label ?? ''),
+        label: label.text,
+        labelKey: label.key,
+        labelParameters: label.parameters,
         // Shown instead of the label while a subscription refresh is running,
         // so that an open menu doesn't go stale when the refresh ends
-        refreshingLabel: item.refreshingLabel != null ? String(item.refreshingLabel) : undefined,
+        refreshingLabel: refreshingLabel?.text,
+        refreshingLabelKey: refreshingLabel?.key,
+        refreshingLabelParameters: refreshingLabel?.parameters,
         enabled: item.enabled !== false,
         checked: item.checked === true,
         icon: typeof item.icon === 'string' ? item.icon : undefined,

--- a/src/main/index.js
+++ b/src/main/index.js
@@ -119,6 +119,19 @@ function runApp() {
   let ipBlockRecoveryScriptPromise = null
   const faviconPromises = new Map()
 
+  /**
+   * @returns {Promise<ReturnType<typeof parseSearchEngines>>}
+   */
+  async function getConfiguredSearchEngines() {
+    const setting = (await baseHandlers.settings._findOne('contextMenuSearchEngines'))?.value ??
+      DEFAULT_SEARCH_ENGINES_SETTING
+    return parseSearchEngines(setting)
+  }
+
+  /**
+   * @param {string} searchUrl
+   * @returns {Promise<string>}
+   */
   function resolveSearchEngineFavicon(searchUrl) {
     const fallback = getFaviconUrl(searchUrl)
     if (!fallback) return Promise.resolve('')
@@ -306,6 +319,12 @@ function runApp() {
 
   // Registered per-webContents in 'web-contents-created' so the shared
   // BrowserWindow renderer can resolve native menu targets through TabManager.
+  /**
+   * @param {string} key
+   * @param {Record<string, string | number>} [parameters]
+   * @param {string} [fallback]
+   * @returns {{ key: string, parameters: Record<string, string | number>, fallback: string }}
+   */
   function contextMenuLabel(key, parameters = {}, fallback = key) {
     return {
       key: `Context Menu.${key}`,
@@ -750,9 +769,7 @@ function runApp() {
 
       const selectionText = parameters.selectionText.trim()
       const textShortEnoughForSearch = selectionText.length <= SEARCH_CHAR_LIMIT
-      const searchEnginesSetting = (await baseHandlers.settings._findOne('contextMenuSearchEngines'))?.value ??
-        DEFAULT_SEARCH_ENGINES_SETTING
-      const activeSearchEngines = parseSearchEngines(searchEnginesSetting)
+      const activeSearchEngines = (await getConfiguredSearchEngines())
         .filter(engine => engine.enabled)
       const externalSearchItems = activeSearchEngines.map(engine => ({
         label: engine.name,
@@ -945,6 +962,10 @@ function runApp() {
     return cleanedItems
   }
 
+  /**
+   * @param {unknown} label
+   * @returns {{ text: string, key: string | undefined, parameters: unknown }}
+   */
   function serializeContextMenuLabel(label) {
     if (
       label != null &&
@@ -1059,9 +1080,7 @@ function runApp() {
   ipcMain.handle(IpcChannels.RESOLVE_FAVICON, async (event, url) => {
     if (!isOpenTubeXUrl(event.senderFrame.url) || typeof url !== 'string') return ''
 
-    const setting = (await baseHandlers.settings._findOne('contextMenuSearchEngines'))?.value ??
-      DEFAULT_SEARCH_ENGINES_SETTING
-    if (!parseSearchEngines(setting).some(engine => engine.url === url)) return ''
+    if (!(await getConfiguredSearchEngines()).some(engine => engine.url === url)) return ''
 
     return resolveSearchEngineFavicon(url)
   })

--- a/src/main/index.js
+++ b/src/main/index.js
@@ -835,6 +835,8 @@ function runApp() {
   let contextMenuSessionId = 0
   /** @type {Map<number, { sessionId: number, actions: Map<string, Function> }>} */
   const contextMenuSessions = new Map()
+  /** @type {Map<number, number>} */
+  const latestContextMenuRequests = new Map()
 
   function createDefaultContextMenuActions(parameters, webContents) {
     const hasSelection = parameters.selectionText.length > 0
@@ -927,6 +929,8 @@ function runApp() {
 
   ipcMain.handle(IpcChannels.CONTEXT_MENU_OPEN, async (event, rawParameters = {}) => {
     const webContents = event.sender
+    const sessionId = ++contextMenuSessionId
+    latestContextMenuRequests.set(webContents.id, sessionId)
     const parameters = {
       x: Number.isFinite(rawParameters.x) ? rawParameters.x : 0,
       y: Number.isFinite(rawParameters.y) ? rawParameters.y : 0,
@@ -961,10 +965,11 @@ function runApp() {
       ...await contextMenuOptions.append(defaultActions, parameters, webContents)
     ]
     const actions = new Map()
-    const sessionId = ++contextMenuSessionId
     const serializedItems = serializeContextMenuItems(items, actions)
 
-    contextMenuSessions.set(webContents.id, { sessionId, actions })
+    if (latestContextMenuRequests.get(webContents.id) === sessionId) {
+      contextMenuSessions.set(webContents.id, { sessionId, actions })
+    }
     return { sessionId, items: serializedItems }
   })
 
@@ -3914,6 +3919,7 @@ function runApp() {
 
     webContents.once('destroyed', () => {
       contextMenuSessions.delete(webContents.id)
+      latestContextMenuRequests.delete(webContents.id)
       pendingOpenUrlsByWebContentsId.delete(webContents.id)
       openUrlReadyWebContentsIds.delete(webContents.id)
       invidiousAuthorizations.delete(webContents.id)

--- a/src/preload/interface.js
+++ b/src/preload/interface.js
@@ -338,6 +338,14 @@ export default {
   },
 
   /**
+   * @param {string} url
+   * @returns {Promise<string>}
+   */
+  resolveFavicon: (url) => {
+    return ipcRenderer.invoke(IpcChannels.RESOLVE_FAVICON, url)
+  },
+
+  /**
    * @param {number} action
    * @param {any} [data]
    */

--- a/src/renderer/components/ContextMenuSearchSettings/ContextMenuSearchSettings.css
+++ b/src/renderer/components/ContextMenuSearchSettings/ContextMenuSearchSettings.css
@@ -1,0 +1,85 @@
+.description,
+.hint {
+  text-align: center;
+}
+
+.engineList {
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+}
+
+.engineRow {
+  display: grid;
+  grid-template-columns: minmax(160px, 1fr) minmax(240px, 2fr);
+  gap: 12px;
+  align-items: center;
+}
+
+.engineRow:has(.removeEngine) {
+  grid-template-columns: minmax(160px, 1fr) minmax(140px, 1fr) minmax(240px, 2fr) auto;
+}
+
+:deep(.engineRow .ft-input),
+:deep(.addEngine .ft-input) {
+  margin-block-end: 0;
+}
+
+.engineRow code {
+  overflow-wrap: anywhere;
+}
+
+.engineToggle {
+  display: flex;
+  gap: 10px;
+  align-items: center;
+}
+
+.engineIcon {
+  flex: 0 0 auto;
+  inline-size: 24px;
+  block-size: 24px;
+  object-fit: contain;
+}
+
+.fallbackIcon {
+  color: var(--secondary-text-color);
+}
+
+.removeEngine {
+  display: grid;
+  place-items: center;
+  align-self: center;
+  inline-size: 36px;
+  block-size: 36px;
+  color: var(--text-color);
+  background: none;
+  border: 0;
+  cursor: pointer;
+  font-size: 1rem;
+  padding: 0;
+  line-height: 1;
+}
+
+.addEngine {
+  display: grid;
+  grid-template-columns: minmax(140px, 1fr) minmax(240px, 2fr) auto;
+  gap: 12px;
+  align-items: center;
+}
+
+h3 {
+  text-align: center;
+}
+
+@container settings-page (width <= 800px) {
+  .engineRow,
+  .engineRow:has(.removeEngine),
+  .addEngine {
+    grid-template-columns: 1fr;
+  }
+
+  .removeEngine {
+    justify-self: end;
+  }
+}

--- a/src/renderer/components/ContextMenuSearchSettings/ContextMenuSearchSettings.vue
+++ b/src/renderer/components/ContextMenuSearchSettings/ContextMenuSearchSettings.vue
@@ -35,12 +35,14 @@
         </div>
         <template v-if="engine.id.startsWith('custom-')">
           <FtInput
+            :key="inputKey(engine.id, 'name')"
             :placeholder="t('Settings.Context Menu Search Settings.Engine Name')"
             :value="engine.name"
             :show-action-button="false"
             @blur="updateCustomEngine(engine.id, 'name', $event)"
           />
           <FtInput
+            :key="inputKey(engine.id, 'url')"
             input-type="url"
             :placeholder="t('Settings.Context Menu Search Settings.Search URL')"
             :value="engine.url"
@@ -107,6 +109,7 @@ const customName = ref('')
 const customUrl = ref('')
 const failedFavicons = ref(new Set())
 const resolvedFavicons = ref(new Map())
+const inputRevisions = ref(new Map())
 
 const configuredSearchEngines = computed(() => {
   return parseSearchEngines(store.getters.getContextMenuSearchEngines)
@@ -165,6 +168,18 @@ function showInvalidEngineToast() {
   })
 }
 
+function inputKey(id, field) {
+  return `${id}:${field}:${inputRevisions.value.get(`${id}:${field}`) ?? 0}`
+}
+
+function resetCustomEngineInput(id, field) {
+  const key = `${id}:${field}`
+  inputRevisions.value = new Map([
+    ...inputRevisions.value,
+    [key, (inputRevisions.value.get(key) ?? 0) + 1]
+  ])
+}
+
 function updateCustomEngine(id, field, value) {
   const trimmedValue = value.trim()
   if (
@@ -172,6 +187,7 @@ function updateCustomEngine(id, field, value) {
     (field === 'url' && !isValidSearchUrl(trimmedValue))
   ) {
     showInvalidEngineToast()
+    resetCustomEngineInput(id, field)
     return
   }
 

--- a/src/renderer/components/ContextMenuSearchSettings/ContextMenuSearchSettings.vue
+++ b/src/renderer/components/ContextMenuSearchSettings/ContextMenuSearchSettings.vue
@@ -1,0 +1,209 @@
+<template>
+  <FtSettingsSection
+    :title="t('Settings.Context Menu Search Settings.Context Menu Search Settings')"
+  >
+    <p class="description">
+      {{ t('Settings.Context Menu Search Settings.Description') }}
+    </p>
+
+    <div class="engineList">
+      <div
+        v-for="engine in searchEngines"
+        :key="engine.id"
+        class="engineRow"
+      >
+        <div class="engineToggle">
+          <img
+            v-if="hasFavicon(engine)"
+            class="engineIcon"
+            :src="engine.icon"
+            alt=""
+            referrerpolicy="no-referrer"
+            @error="handleFaviconError(engine)"
+          >
+          <FontAwesomeIcon
+            v-else
+            class="engineIcon fallbackIcon"
+            :icon="['fas', 'search']"
+          />
+          <FtToggleSwitch
+            :label="engine.name"
+            :default-value="engine.enabled"
+            :compact="true"
+            @change="updateEnabled(engine.id, $event)"
+          />
+        </div>
+        <template v-if="engine.id.startsWith('custom-')">
+          <FtInput
+            :placeholder="t('Settings.Context Menu Search Settings.Engine Name')"
+            :value="engine.name"
+            :show-action-button="false"
+            @blur="updateCustomEngine(engine.id, 'name', $event)"
+          />
+          <FtInput
+            input-type="url"
+            :placeholder="t('Settings.Context Menu Search Settings.Search URL')"
+            :value="engine.url"
+            :show-action-button="false"
+            @blur="updateCustomEngine(engine.id, 'url', $event)"
+          />
+          <button
+            class="removeEngine"
+            :aria-label="t('Settings.Context Menu Search Settings.Remove Engine', { engine: engine.name })"
+            :title="t('Settings.Context Menu Search Settings.Remove Engine', { engine: engine.name })"
+            @click="removeEngine(engine.id)"
+          >
+            <FontAwesomeIcon :icon="['fas', 'trash']" />
+          </button>
+        </template>
+        <code v-else>{{ engine.url }}</code>
+      </div>
+    </div>
+
+    <h3>{{ t('Settings.Context Menu Search Settings.Add Custom Engine') }}</h3>
+    <div class="addEngine">
+      <FtInput
+        :placeholder="t('Settings.Context Menu Search Settings.Engine Name')"
+        :value="customName"
+        :show-action-button="false"
+        @input="customName = $event"
+      />
+      <FtInput
+        input-type="url"
+        :placeholder="t('Settings.Context Menu Search Settings.Search URL')"
+        :value="customUrl"
+        :show-action-button="false"
+        @input="customUrl = $event"
+        @keydown.enter="addCustomEngine"
+      />
+      <FtButton
+        :label="t('Settings.Context Menu Search Settings.Add Engine')"
+        :icon="['fas', 'plus']"
+        @click="addCustomEngine"
+      />
+    </div>
+    <p class="hint">
+      {{ t('Settings.Context Menu Search Settings.URL Hint') }}
+    </p>
+  </FtSettingsSection>
+</template>
+
+<script setup>
+import { FontAwesomeIcon } from '@fortawesome/vue-fontawesome'
+import { computed, ref, watch } from 'vue'
+import { useI18n } from 'vue-i18n'
+
+import FtButton from '../FtButton/FtButton.vue'
+import FtInput from '../FtInput/FtInput.vue'
+import FtSettingsSection from '../FtSettingsSection/FtSettingsSection.vue'
+import FtToggleSwitch from '../FtToggleSwitch/FtToggleSwitch.vue'
+
+import store from '../../store/index'
+import { showToast } from '../../helpers/utils'
+import { parseSearchEngines } from '../../../searchEngines'
+
+const { t } = useI18n()
+const customName = ref('')
+const customUrl = ref('')
+const failedFavicons = ref(new Set())
+const resolvedFavicons = ref(new Map())
+
+const configuredSearchEngines = computed(() => {
+  return parseSearchEngines(store.getters.getContextMenuSearchEngines)
+})
+
+const searchEngines = computed(() => {
+  return configuredSearchEngines.value.map(engine => ({
+    ...engine,
+    icon: resolvedFavicons.value.get(engine.url) ?? ''
+  }))
+})
+
+function saveSearchEngines(engines) {
+  const settings = engines.map(({ id, name, url, enabled }) => ({ id, name, url, enabled }))
+  store.dispatch('updateContextMenuSearchEngines', JSON.stringify(settings))
+}
+
+function hasFavicon(engine) {
+  return engine.icon.length > 0 && !failedFavicons.value.has(`${engine.id}:${engine.icon}`)
+}
+
+function handleFaviconError(engine) {
+  failedFavicons.value = new Set([...failedFavicons.value, `${engine.id}:${engine.icon}`])
+}
+
+watch(configuredSearchEngines, (engines) => {
+  for (const engine of engines) {
+    if (resolvedFavicons.value.has(engine.url)) continue
+
+    window.ftElectron.resolveFavicon(engine.url).then(icon => {
+      resolvedFavicons.value = new Map([...resolvedFavicons.value, [engine.url, icon]])
+    })
+  }
+}, { immediate: true })
+
+function updateEnabled(id, enabled) {
+  saveSearchEngines(searchEngines.value.map(engine => (
+    engine.id === id ? { ...engine, enabled } : engine
+  )))
+}
+
+function isValidSearchUrl(url) {
+  if (!url.includes('%s')) return false
+
+  try {
+    return ['https:', 'http:'].includes(new URL(url.replace('%s', 'query')).protocol)
+  } catch {
+    return false
+  }
+}
+
+function showInvalidEngineToast() {
+  showToast({
+    message: t('Settings.Context Menu Search Settings.Invalid Engine'),
+    icon: ['fas', 'circle-exclamation']
+  })
+}
+
+function updateCustomEngine(id, field, value) {
+  const trimmedValue = value.trim()
+  if (
+    (field === 'name' && (trimmedValue.length === 0 || trimmedValue.length > 50)) ||
+    (field === 'url' && !isValidSearchUrl(trimmedValue))
+  ) {
+    showInvalidEngineToast()
+    return
+  }
+
+  saveSearchEngines(searchEngines.value.map(engine => (
+    engine.id === id ? { ...engine, [field]: trimmedValue } : engine
+  )))
+}
+
+function addCustomEngine() {
+  const name = customName.value.trim()
+  const url = customUrl.value.trim()
+  if (name.length === 0 || name.length > 50 || !isValidSearchUrl(url)) {
+    showInvalidEngineToast()
+    return
+  }
+
+  saveSearchEngines([
+    ...searchEngines.value,
+    {
+      id: `custom-${crypto.randomUUID()}`,
+      name,
+      url,
+      enabled: true
+    }
+  ])
+  customName.value = ''
+  customUrl.value = ''
+}
+
+function removeEngine(id) {
+  saveSearchEngines(searchEngines.value.filter(engine => engine.id !== id))
+}
+</script>
+
+<style scoped src="./ContextMenuSearchSettings.css" />

--- a/src/renderer/components/ContextMenuSearchSettings/ContextMenuSearchSettings.vue
+++ b/src/renderer/components/ContextMenuSearchSettings/ContextMenuSearchSettings.vue
@@ -102,7 +102,11 @@ import FtToggleSwitch from '../FtToggleSwitch/FtToggleSwitch.vue'
 
 import store from '../../store/index'
 import { showToast } from '../../helpers/utils'
-import { parseSearchEngines } from '../../../searchEngines'
+import {
+  isValidSearchUrlTemplate,
+  MAX_CUSTOM_SEARCH_ENGINES,
+  parseSearchEngines
+} from '../../../searchEngines'
 
 const { t } = useI18n()
 const customName = ref('')
@@ -141,7 +145,7 @@ watch(configuredSearchEngines, (engines) => {
 
     window.ftElectron.resolveFavicon(engine.url).then(icon => {
       resolvedFavicons.value = new Map([...resolvedFavicons.value, [engine.url, icon]])
-    })
+    }).catch(() => {})
   }
 }, { immediate: true })
 
@@ -151,19 +155,18 @@ function updateEnabled(id, enabled) {
   )))
 }
 
-function isValidSearchUrl(url) {
-  if (!url.includes('%s')) return false
-
-  try {
-    return ['https:', 'http:'].includes(new URL(url.replace('%s', 'query')).protocol)
-  } catch {
-    return false
-  }
-}
-
 function showInvalidEngineToast() {
   showToast({
     message: t('Settings.Context Menu Search Settings.Invalid Engine'),
+    icon: ['fas', 'circle-exclamation']
+  })
+}
+
+function showEngineLimitToast() {
+  showToast({
+    message: t('Settings.Context Menu Search Settings.Engine Limit', {
+      count: MAX_CUSTOM_SEARCH_ENGINES
+    }),
     icon: ['fas', 'circle-exclamation']
   })
 }
@@ -184,7 +187,7 @@ function updateCustomEngine(id, field, value) {
   const trimmedValue = value.trim()
   if (
     (field === 'name' && (trimmedValue.length === 0 || trimmedValue.length > 50)) ||
-    (field === 'url' && !isValidSearchUrl(trimmedValue))
+    (field === 'url' && !isValidSearchUrlTemplate(trimmedValue))
   ) {
     showInvalidEngineToast()
     resetCustomEngineInput(id, field)
@@ -199,8 +202,15 @@ function updateCustomEngine(id, field, value) {
 function addCustomEngine() {
   const name = customName.value.trim()
   const url = customUrl.value.trim()
-  if (name.length === 0 || name.length > 50 || !isValidSearchUrl(url)) {
+  if (name.length === 0 || name.length > 50 || !isValidSearchUrlTemplate(url)) {
     showInvalidEngineToast()
+    return
+  }
+  const customEngineCount = searchEngines.value
+    .filter(engine => engine.id.startsWith('custom-'))
+    .length
+  if (customEngineCount >= MAX_CUSTOM_SEARCH_ENGINES) {
+    showEngineLimitToast()
     return
   }
 

--- a/src/renderer/components/FtContextMenu/FtContextMenu.css
+++ b/src/renderer/components/FtContextMenu/FtContextMenu.css
@@ -73,6 +73,12 @@
   text-align: center;
 }
 
+.itemImageIcon {
+  inline-size: 16px;
+  block-size: 16px;
+  object-fit: contain;
+}
+
 .menuItem:hover .itemIcon:not(.colorIcon),
 .menuItem:focus-visible .itemIcon:not(.colorIcon),
 .submenuContainer:hover > .menuItem .itemIcon:not(.colorIcon) {

--- a/src/renderer/components/FtContextMenu/FtContextMenu.vue
+++ b/src/renderer/components/FtContextMenu/FtContextMenu.vue
@@ -366,7 +366,12 @@ async function execute(item) {
 }
 
 function translateLabel(label) {
-  let match = /^Close (\d+) Tabs$/.exec(label)
+  if (label === 'Search with...') return t('Context Menu.Search With Multiple')
+
+  let match = /^Search with (.+)$/.exec(label)
+  if (match) return t('Context Menu.Search With', { engine: match[1] })
+
+  match = /^Close (\d+) Tabs$/.exec(label)
   if (match) return t('Context Menu.Close Multiple Tabs', { count: Number(match[1]) })
 
   match = /^Duplicate (\d+) Tabs$/.exec(label)

--- a/src/renderer/components/FtContextMenu/FtContextMenu.vue
+++ b/src/renderer/components/FtContextMenu/FtContextMenu.vue
@@ -285,7 +285,7 @@ function resolveItemFavicons(menuItems) {
       const source = item.faviconSource
       window.ftElectron.resolveFavicon(source).then(icon => {
         if (item.faviconSource === source && icon) item.icon = icon
-      })
+      }).catch(() => {})
     }
     if (Array.isArray(item.submenu)) resolveItemFavicons(item.submenu)
   }

--- a/src/renderer/components/FtContextMenu/FtContextMenu.vue
+++ b/src/renderer/components/FtContextMenu/FtContextMenu.vue
@@ -54,7 +54,7 @@
                   :icon="getItemIcon(item)"
                 />
               </span>
-              <span>{{ translateLabel(item.label) }}</span>
+              <span>{{ localizedLabel(item) }}</span>
               <span
                 class="submenuArrow"
                 aria-hidden="true"
@@ -107,7 +107,7 @@
                       :icon="['fas', 'check']"
                     />
                   </span>
-                  <span>{{ translateLabel(child.label) }}</span>
+                  <span>{{ localizedLabel(child) }}</span>
                 </button>
               </template>
             </div>
@@ -146,7 +146,7 @@
                 :icon="['fas', 'check']"
               />
             </span>
-            <span>{{ translateLabel(item.label) }}</span>
+            <span>{{ localizedLabel(item) }}</span>
           </button>
         </template>
       </div>
@@ -161,7 +161,7 @@ import { useI18n } from 'vue-i18n'
 
 import store from '../../store/index'
 
-const { t, te } = useI18n()
+const { t } = useI18n()
 const menuRef = useTemplateRef('menuRef')
 const fullscreenTarget = ref(null)
 const isOpen = ref(false)
@@ -188,7 +188,12 @@ const displayedItems = computed(() => {
   }
 
   return items.value.map(item => item.refreshingLabel
-    ? { ...item, label: item.refreshingLabel }
+    ? {
+        ...item,
+        label: item.refreshingLabel,
+        labelKey: item.refreshingLabelKey,
+        labelParameters: item.refreshingLabelParameters
+      }
     : item)
 })
 
@@ -365,32 +370,11 @@ async function execute(item) {
   await window.ftElectron.contextMenu.execute(currentSessionId, item.actionId)
 }
 
-function translateLabel(label) {
-  if (label === 'Search with...') return t('Context Menu.Search With Multiple')
+function localizedLabel(item) {
+  if (!item.labelKey) return item.label
 
-  let match = /^Search with (.+)$/.exec(label)
-  if (match) return t('Context Menu.Search With', { engine: match[1] })
-
-  match = /^Close (\d+) Tabs$/.exec(label)
-  if (match) return t('Context Menu.Close Multiple Tabs', { count: Number(match[1]) })
-
-  match = /^Duplicate (\d+) Tabs$/.exec(label)
-  if (match) return t('Context Menu.Duplicate Multiple Tabs', { count: Number(match[1]) })
-
-  match = /^Search "(.+)" in a New (Tab|Window)$/.exec(label)
-  if (match) {
-    return match[2] === 'Tab'
-      ? t('Context Menu.Search Selection in New Tab', { selection: match[1] })
-      : t('Context Menu.Search Selection in New Window', { selection: match[1] })
-  }
-
-  match = /^".+" is too long for search \(> (\d+) chars\)$/.exec(label)
-  if (match) return t('Context Menu.Selection Too Long', { count: Number(match[1]) })
-
-  const key = `Context Menu.${label}`
-  // Labels are validated against this namespace before being translated.
   // eslint-disable-next-line @intlify/vue-i18n/no-dynamic-keys
-  return te(key) ? t(key) : label
+  return t(item.labelKey, item.labelParameters ?? {})
 }
 
 function handleKeydown(event) {

--- a/src/renderer/components/FtContextMenu/FtContextMenu.vue
+++ b/src/renderer/components/FtContextMenu/FtContextMenu.vue
@@ -41,7 +41,18 @@
                 class="itemIcon"
                 aria-hidden="true"
               >
-                <FontAwesomeIcon :icon="getItemIcon(item)" />
+                <img
+                  v-if="hasImageIcon(item)"
+                  class="itemImageIcon"
+                  :src="item.icon"
+                  alt=""
+                  referrerpolicy="no-referrer"
+                  @error="handleImageIconError(item.icon)"
+                >
+                <FontAwesomeIcon
+                  v-else
+                  :icon="getItemIcon(item)"
+                />
               </span>
               <span>{{ translateLabel(item.label) }}</span>
               <span
@@ -78,7 +89,18 @@
                     :class="getItemIconClass(child)"
                     aria-hidden="true"
                   >
-                    <FontAwesomeIcon :icon="getItemIcon(child, item.label)" />
+                    <img
+                      v-if="hasImageIcon(child)"
+                      class="itemImageIcon"
+                      :src="child.icon"
+                      alt=""
+                      referrerpolicy="no-referrer"
+                      @error="handleImageIconError(child.icon)"
+                    >
+                    <FontAwesomeIcon
+                      v-else
+                      :icon="getItemIcon(child, item.label)"
+                    />
                     <FontAwesomeIcon
                       v-if="child.checked"
                       class="checkedMark"
@@ -106,7 +128,18 @@
               :class="getItemIconClass(item)"
               aria-hidden="true"
             >
-              <FontAwesomeIcon :icon="getItemIcon(item)" />
+              <img
+                v-if="hasImageIcon(item)"
+                class="itemImageIcon"
+                :src="item.icon"
+                alt=""
+                referrerpolicy="no-referrer"
+                @error="handleImageIconError(item.icon)"
+              >
+              <FontAwesomeIcon
+                v-else
+                :icon="getItemIcon(item)"
+              />
               <FontAwesomeIcon
                 v-if="item.checked"
                 class="checkedMark"
@@ -137,6 +170,7 @@ const sessionId = ref(null)
 const position = ref({ x: 0, y: 0 })
 const submenusOpenStart = ref(false)
 const verticalTabLayout = ref(false)
+const failedImageIcons = ref(new Set())
 let openRequest = 0
 
 const menuStyle = computed(() => ({
@@ -230,6 +264,28 @@ function getItemIconClass(item) {
     : undefined
 }
 
+function hasImageIcon(item) {
+  return typeof item.icon === 'string' &&
+    item.icon.length > 0 &&
+    !failedImageIcons.value.has(item.icon)
+}
+
+function handleImageIconError(icon) {
+  failedImageIcons.value = new Set([...failedImageIcons.value, icon])
+}
+
+function resolveItemFavicons(menuItems) {
+  for (const item of menuItems) {
+    if (typeof item.faviconSource === 'string') {
+      const source = item.faviconSource
+      window.ftElectron.resolveFavicon(source).then(icon => {
+        if (item.faviconSource === source && icon) item.icon = icon
+      })
+    }
+    if (Array.isArray(item.submenu)) resolveItemFavicons(item.submenu)
+  }
+}
+
 function getSelectionText(target) {
   if (target instanceof HTMLInputElement || target instanceof HTMLTextAreaElement) {
     const start = target.selectionStart ?? 0
@@ -276,6 +332,7 @@ async function open(event) {
   if (request !== openRequest || result.items.length === 0) return
 
   items.value = result.items
+  resolveItemFavicons(items.value)
   sessionId.value = result.sessionId
   position.value = { x: event.clientX, y: event.clientY }
   submenusOpenStart.value = event.clientX > window.innerWidth / 2

--- a/src/renderer/store/modules/settings.js
+++ b/src/renderer/store/modules/settings.js
@@ -13,6 +13,7 @@ import { getTabNavigationService } from '../../tabs/TabNavigationService'
 import { getSystemLocale, showToast } from '../../helpers/utils'
 import { DEFAULT_THUMBNAIL_SIZE } from '../../constants/thumbnailSize'
 import { setReducedMotionPreference } from '../../helpers/reducedMotion'
+import { DEFAULT_SEARCH_ENGINES_SETTING } from '../../../searchEngines'
 
 /*
  * Due to the complexity of the settings module in FreeTube, a more
@@ -205,6 +206,7 @@ const state = {
   enableWatchStats: true,
   statsWeekStartsOn: '1',
   enableSearchSuggestions: true,
+  contextMenuSearchEngines: DEFAULT_SEARCH_ENGINES_SETTING,
   enableSubtitlesByDefault: false,
   enterFullscreenOnDisplayRotate: false,
   externalLinkHandling: '',

--- a/src/renderer/views/Settings/Settings.vue
+++ b/src/renderer/views/Settings/Settings.vue
@@ -101,6 +101,7 @@ import ParentalControlSettings from '../../components/ParentalControlSettings.vu
 import ExperimentalSettings from '../../components/ExperimentalSettings/ExperimentalSettings.vue'
 import PasswordSettings from '../../components/PasswordSettings/PasswordSettings.vue'
 import PasswordDialog from '../../components/PasswordDialog/PasswordDialog.vue'
+import ContextMenuSearchSettings from '../../components/ContextMenuSearchSettings/ContextMenuSearchSettings.vue'
 import FtToggleSwitch from '../../components/FtToggleSwitch/FtToggleSwitch.vue'
 import FtButton from '../../components/FtButton/FtButton.vue'
 import FtSyncedSettingIndicator from '../../components/FtSyncedSettingIndicator/FtSyncedSettingIndicator.vue'
@@ -217,6 +218,14 @@ const settingsComponentsData = computed(() => {
       icon: ['fas', 'thumbs-down'],
       component: RydSettings
     },
+    ...(process.env.IS_ELECTRON
+      ? [{
+          type: 'context-menu-search',
+          title: t('Settings.Context Menu Search Settings.Context Menu Search Settings'),
+          icon: ['fas', 'magnifying-glass'],
+          component: ContextMenuSearchSettings
+        }]
+      : []),
     {
       type: 'password',
       title: t('Settings.Password Settings.Password Settings'),

--- a/src/searchEngines.js
+++ b/src/searchEngines.js
@@ -1,0 +1,124 @@
+export const DEFAULT_SEARCH_ENGINES = Object.freeze([
+  {
+    id: 'duckduckgo',
+    name: 'DuckDuckGo',
+    url: 'https://duckduckgo.com/?q=%s',
+    enabled: true
+  },
+  {
+    id: 'startpage',
+    name: 'Startpage',
+    url: 'https://www.startpage.com/sp/search?query=%s',
+    enabled: true
+  },
+  {
+    id: 'qwant',
+    name: 'Qwant',
+    url: 'https://www.qwant.com/?q=%s',
+    enabled: true
+  },
+  {
+    id: 'brave',
+    name: 'Brave Search',
+    url: 'https://search.brave.com/search?q=%s',
+    enabled: true
+  }
+])
+
+export const DEFAULT_SEARCH_ENGINES_SETTING = JSON.stringify(DEFAULT_SEARCH_ENGINES)
+
+/**
+ * @param {unknown} value
+ * @returns {value is { id: string, name: string, url: string, enabled: boolean }}
+ */
+function isValidCustomEngine(value) {
+  if (value == null || typeof value !== 'object') return false
+
+  const engine = /** @type {Record<string, unknown>} */ (value)
+  if (
+    typeof engine.id !== 'string' ||
+    !engine.id.startsWith('custom-') ||
+    typeof engine.name !== 'string' ||
+    engine.name.trim().length === 0 ||
+    engine.name.length > 50 ||
+    typeof engine.url !== 'string' ||
+    !engine.url.includes('%s') ||
+    typeof engine.enabled !== 'boolean'
+  ) {
+    return false
+  }
+
+  try {
+    const url = new URL(engine.url.replace('%s', 'query'))
+    return url.protocol === 'https:' || url.protocol === 'http:'
+  } catch {
+    return false
+  }
+}
+
+/**
+ * Keep built-in engine details canonical while preserving enabled states and
+ * accepting valid custom engines.
+ *
+ * @param {unknown} setting
+ * @returns {{ id: string, name: string, url: string, icon: string, enabled: boolean }[]}
+ */
+export function parseSearchEngines(setting) {
+  let entries
+  try {
+    entries = typeof setting === 'string' ? JSON.parse(setting) : setting
+  } catch {
+    entries = []
+  }
+
+  if (!Array.isArray(entries)) entries = []
+
+  const storedById = new Map(entries
+    .filter(entry => entry != null && typeof entry === 'object' && typeof entry.id === 'string')
+    .map(entry => [entry.id, entry]))
+
+  const builtIns = DEFAULT_SEARCH_ENGINES.map(engine => ({
+    ...engine,
+    icon: '',
+    enabled: typeof storedById.get(engine.id)?.enabled === 'boolean'
+      ? storedById.get(engine.id).enabled
+      : engine.enabled
+  }))
+
+  const custom = entries
+    .filter(isValidCustomEngine)
+    .slice(0, 20)
+    .map(engine => ({
+      id: engine.id,
+      name: engine.name.trim(),
+      url: engine.url,
+      icon: '',
+      enabled: engine.enabled
+    }))
+
+  return [...builtIns, ...custom]
+}
+
+/**
+ * Resolve favicons directly from the search provider instead of sharing the
+ * custom engine's hostname with a third-party favicon service.
+ *
+ * @param {string} searchUrl
+ * @returns {string}
+ */
+export function getFaviconUrl(searchUrl) {
+  try {
+    return new URL('/favicon.ico', new URL(searchUrl.replaceAll('%s', 'query')).origin).href
+  } catch {
+    return ''
+  }
+}
+
+/**
+ * @param {string} template
+ * @param {string} query
+ * @returns {string}
+ */
+export function buildSearchUrl(template, query) {
+  return template.replaceAll('%s', encodeURIComponent(query))
+}

--- a/src/searchEngines.js
+++ b/src/searchEngines.js
@@ -26,6 +26,22 @@ export const DEFAULT_SEARCH_ENGINES = Object.freeze([
 ])
 
 export const DEFAULT_SEARCH_ENGINES_SETTING = JSON.stringify(DEFAULT_SEARCH_ENGINES)
+export const MAX_CUSTOM_SEARCH_ENGINES = 20
+
+/**
+ * @param {unknown} value
+ * @returns {value is string}
+ */
+export function isValidSearchUrlTemplate(value) {
+  if (typeof value !== 'string' || !value.includes('%s')) return false
+
+  try {
+    const url = new URL(value.replace('%s', 'query'))
+    return url.protocol === 'https:' || url.protocol === 'http:'
+  } catch {
+    return false
+  }
+}
 
 /**
  * @param {unknown} value
@@ -41,19 +57,12 @@ function isValidCustomEngine(value) {
     typeof engine.name !== 'string' ||
     engine.name.trim().length === 0 ||
     engine.name.length > 50 ||
-    typeof engine.url !== 'string' ||
-    !engine.url.includes('%s') ||
+    !isValidSearchUrlTemplate(engine.url) ||
     typeof engine.enabled !== 'boolean'
   ) {
     return false
   }
-
-  try {
-    const url = new URL(engine.url.replace('%s', 'query'))
-    return url.protocol === 'https:' || url.protocol === 'http:'
-  } catch {
-    return false
-  }
+  return true
 }
 
 /**
@@ -87,7 +96,7 @@ export function parseSearchEngines(setting) {
 
   const custom = entries
     .filter(isValidCustomEngine)
-    .slice(0, 20)
+    .slice(0, MAX_CUSTOM_SEARCH_ENGINES)
     .map(engine => ({
       id: engine.id,
       name: engine.name.trim(),

--- a/static/locales/de-DE.yaml
+++ b/static/locales/de-DE.yaml
@@ -1591,6 +1591,8 @@ Context Menu:
   Copy Invidious Link: Invidious-Link kopieren
   Search Selection in New Tab: '"{selection}" in einem neuen Tab suchen'
   Search Selection in New Window: '"{selection}" in einem neuen Fenster suchen'
+  Search With: Mit {engine} suchen
+  Search With Multiple: Suchen mit …
   Selection Too Long: 'Auswahl ist zu lang für die Suche (> {count} Zeichen)'
 Stats:
   Stats: Statistik

--- a/static/locales/en-US.yaml
+++ b/static/locales/en-US.yaml
@@ -1547,6 +1547,8 @@ Context Menu:
   Copy Invidious Link: Copy Invidious Link
   Search Selection in New Tab: 'Search "{selection}" in a New Tab'
   Search Selection in New Window: 'Search "{selection}" in a New Window'
+  Search With: Search with {engine}
+  Search With Multiple: Search with...
   Selection Too Long: 'Selection is too long for search (> {count} characters)'
 
 Chapters:

--- a/static/locales/en-US.yaml
+++ b/static/locales/en-US.yaml
@@ -446,6 +446,7 @@ Settings:
     Add Engine: Add engine
     Remove Engine: Remove {engine}
     Invalid Engine: Enter a name and a valid HTTP or HTTPS search URL containing %s.
+    Engine Limit: You can add up to {count} custom search engines.
   Theme Settings:
     Theme Settings: Theme
     Match Top Bar with Main Color: Match Top Bar with Main Color

--- a/static/locales/en-US.yaml
+++ b/static/locales/en-US.yaml
@@ -436,6 +436,16 @@ Settings:
       Open Link: Open Link
       Ask Before Opening Link: Ask Before Opening Link
       No Action: No Action
+  Context Menu Search Settings:
+    Context Menu Search Settings: Context Menu Search
+    Description: Choose which search engines appear when you right-click selected text. Searches open in your default browser.
+    Engine Name: Engine name
+    Search URL: Search URL
+    URL Hint: Use %s where the URL should contain the encoded selected text.
+    Add Custom Engine: Add a custom engine
+    Add Engine: Add engine
+    Remove Engine: Remove {engine}
+    Invalid Engine: Enter a name and a valid HTTP or HTTPS search URL containing %s.
   Theme Settings:
     Theme Settings: Theme
     Match Top Bar with Main Color: Match Top Bar with Main Color

--- a/tests/unit/favicon.test.mjs
+++ b/tests/unit/favicon.test.mjs
@@ -1,0 +1,60 @@
+import assert from 'node:assert/strict'
+import test from 'node:test'
+
+import {
+  extractFaviconUrl,
+  fetchFaviconDataUrl,
+  resolveFaviconUrl
+} from '../../src/main/favicon.js'
+
+test('discovers relative favicons and prefers exact-size menu icons', () => {
+  const html = `
+    <link rel="shortcut icon" href="/favicon.ico" type="image/x-icon">
+    <link rel="icon" sizes="32x32" href="/assets/favicon.png" type="image/png">
+    <link rel="icon" href="https://cdn.example.com/icon.svg" type="image/svg+xml">
+  `
+
+  assert.equal(
+    extractFaviconUrl(html, 'https://search.example.com/'),
+    'https://search.example.com/assets/favicon.png'
+  )
+})
+
+test('resolves a declared favicon from the engine homepage', async () => {
+  const icon = await resolveFaviconUrl(
+    'https://search.example.com/find?q=%s',
+    async () => ({
+      ok: false,
+      status: 429,
+      headers: new Headers({ 'content-type': 'text/html' }),
+      // Electron net.fetch can omit Response.url even for successful requests.
+      url: '',
+      text: async () => '<link rel="icon" sizes="32x32" href="/favicon-32.png" type="image/png">'
+    })
+  )
+
+  assert.equal(icon, 'https://search.example.com/favicon-32.png')
+})
+
+test('falls back to the conventional favicon URL when discovery fails', async () => {
+  const icon = await resolveFaviconUrl(
+    'https://search.example.com/find?q=%s',
+    async () => {
+      throw new Error('offline')
+    }
+  )
+
+  assert.equal(icon, 'https://search.example.com/favicon.ico')
+})
+
+test('fetches discovered icons as renderer-safe data URLs', async () => {
+  const icon = await fetchFaviconDataUrl(
+    'https://cdn.example.com/favicon.png',
+    async () => new Response(Uint8Array.from([137, 80, 78, 71]), {
+      status: 200,
+      headers: { 'content-type': 'image/png' }
+    })
+  )
+
+  assert.equal(icon, 'data:image/png;base64,iVBORw==')
+})

--- a/tests/unit/search-engines.test.mjs
+++ b/tests/unit/search-engines.test.mjs
@@ -1,0 +1,62 @@
+import assert from 'node:assert/strict'
+import test from 'node:test'
+
+import {
+  buildSearchUrl,
+  DEFAULT_SEARCH_ENGINES,
+  getFaviconUrl,
+  parseSearchEngines
+} from '../../src/searchEngines.js'
+
+test('uses canonical built-ins and preserves their enabled states', () => {
+  const engines = parseSearchEngines(JSON.stringify([
+    { id: 'duckduckgo', name: 'Changed', url: 'https://example.com/?q=%s', enabled: false }
+  ]))
+
+  assert.equal(engines.length, DEFAULT_SEARCH_ENGINES.length)
+  assert.deepEqual(engines[0], {
+    ...DEFAULT_SEARCH_ENGINES[0],
+    icon: '',
+    enabled: false
+  })
+})
+
+test('accepts valid custom engines and rejects unsafe templates', () => {
+  const engines = parseSearchEngines([
+    {
+      id: 'custom-valid',
+      name: 'Example',
+      url: 'https://example.com/search?q=%s',
+      enabled: true
+    },
+    {
+      id: 'custom-unsafe',
+      name: 'Unsafe',
+      url: 'javascript:alert(%s)',
+      enabled: true
+    }
+  ])
+
+  assert.deepEqual(engines.at(-1), {
+    id: 'custom-valid',
+    name: 'Example',
+    url: 'https://example.com/search?q=%s',
+    icon: '',
+    enabled: true
+  })
+  assert.equal(engines.some(engine => engine.id === 'custom-unsafe'), false)
+})
+
+test('resolves custom favicons directly from the engine origin', () => {
+  assert.equal(
+    getFaviconUrl('https://search.example.com/find?q=%s'),
+    'https://search.example.com/favicon.ico'
+  )
+})
+
+test('encodes selected text when building the search URL', () => {
+  assert.equal(
+    buildSearchUrl('https://example.com/?q=%s', 'privacy & cats'),
+    'https://example.com/?q=privacy%20%26%20cats'
+  )
+})

--- a/tests/unit/search-engines.test.mjs
+++ b/tests/unit/search-engines.test.mjs
@@ -5,6 +5,8 @@ import {
   buildSearchUrl,
   DEFAULT_SEARCH_ENGINES,
   getFaviconUrl,
+  isValidSearchUrlTemplate,
+  MAX_CUSTOM_SEARCH_ENGINES,
   parseSearchEngines
 } from '../../src/searchEngines.js'
 
@@ -45,6 +47,27 @@ test('accepts valid custom engines and rejects unsafe templates', () => {
     enabled: true
   })
   assert.equal(engines.some(engine => engine.id === 'custom-unsafe'), false)
+})
+
+test('validates reusable HTTP search URL templates', () => {
+  assert.equal(isValidSearchUrlTemplate('https://example.com/search?q=%s'), true)
+  assert.equal(isValidSearchUrlTemplate('https://example.com/search'), false)
+  assert.equal(isValidSearchUrlTemplate('javascript:alert(%s)'), false)
+})
+
+test('caps parsed custom engines at the supported limit', () => {
+  const customEngines = Array.from({ length: MAX_CUSTOM_SEARCH_ENGINES + 1 }, (_, index) => ({
+    id: `custom-${index}`,
+    name: `Engine ${index}`,
+    url: `https://example${index}.com/search?q=%s`,
+    enabled: true
+  }))
+  const engines = parseSearchEngines(customEngines)
+
+  assert.equal(
+    engines.filter(engine => engine.id.startsWith('custom-')).length,
+    MAX_CUSTOM_SEARCH_ENGINES
+  )
 })
 
 test('resolves custom favicons directly from the engine origin', () => {


### PR DESCRIPTION
## Summary

- add privacy-respecting web search engines to the selected-text context menu
- show one enabled engine directly or multiple engines under a “Search with...” submenu
- add settings for enabling built-ins and adding, editing, or removing custom HTTP(S) `%s` search templates
- discover and cache favicon results for the app lifetime, including custom engines, and render them in settings and context menus
- open searches through the operating system’s default browser

## Why

Electron can open the default browser but cannot delegate selected text to that browser’s configured search provider. Configurable URL templates provide predictable cross-platform behavior while keeping engine choice under the user’s control.

## Impact

Users can search selected text externally without copying and pasting it, choose which engines appear, and add their own providers. Existing in-app search actions are unchanged.

## Validation

- `pnpm run lint-all`
- `pnpm run test:unit` (111 passed)
- `pnpm run test:e2e:pack`
- `xvfb-run -a -s "-screen 0 1920x1080x24" pnpm exec playwright test -c e2e/playwright.config.mjs --project=offline e2e/tests/offline/search-context-menu.spec.mjs --workers=1` (5 passed)