### PR TITLE
fix: discard unresolved watch history entries

### DIFF
--- a/e2e/tests/offline/navigation.spec.mjs
+++ b/e2e/tests/offline/navigation.spec.mjs
@@ -47,7 +47,7 @@ test.describe('navigation history titles', () => {
       history: [{
         _id: 'jNQXAC9IVRw',
         videoId: 'jNQXAC9IVRw',
-        title: 'Me at the zoo',
+        title: 'Watch',
         author: 'jawed',
         authorId: 'UC4QobU6STFB0P71PMvOGN5A',
         published: 0,
@@ -60,7 +60,7 @@ test.describe('navigation history titles', () => {
     }
   })
 
-  test('keeps a known video title when navigating away before it loads', async ({ page }) => {
+  test('keeps a known video titled Watch when navigating away before it loads', async ({ page }) => {
     await goTo(page, 'history')
     await page.locator('.ft-list-video .title').click()
     await expect(page).toHaveURL(/#\/watch\/jNQXAC9IVRw/)
@@ -70,7 +70,7 @@ test.describe('navigation history titles', () => {
     await page.locator(sel.forwardButton).click({ button: 'right' })
 
     const options = page.locator('.topNav .iconDropdown [role="option"]')
-    await expect(options.filter({ hasText: 'Me at the zoo' })).toHaveCount(1)
+    await expect(options.filter({ hasText: 'Watch' })).toHaveCount(1)
     await expect(options.filter({ hasText: '/watch/jNQXAC9IVRw' })).toHaveCount(0)
   })
 
@@ -82,11 +82,49 @@ test.describe('navigation history titles', () => {
     await page.evaluate((backButtonSelector) => {
       const store = document.querySelector('#app').__vue_app__.config.globalProperties.$store
       const tabId = store.getters.getActiveTabId
-      store.commit('setTabContentTitle', { tabId, title: 'Watch' })
+      store.commit('setTabContentTitle', {
+        tabId,
+        title: 'Watch',
+        resolveHistoryEntry: false
+      })
       document.querySelector(backButtonSelector).click()
     }, sel.backButton)
     await expect(page).toHaveURL(/#\/subscriptions/)
     await expect(page.locator(sel.forwardButton)).toBeDisabled()
+  })
+
+  test('removes an untitled watch entry when navigating forward past it', async ({ page }) => {
+    await page.locator(sel.searchInput).fill('https://www.youtube.com/watch?v=jNQXAC9IVRw')
+    await page.locator(sel.searchInput).press('Enter')
+    await expect(page).toHaveURL(/#\/watch\/jNQXAC9IVRw/)
+
+    await page.evaluate(() => {
+      const store = document.querySelector('#app').__vue_app__.config.globalProperties.$store
+      const tab = store.getters.getActiveTab
+      tab.history[tab.historyIndex].titlePending = false
+    })
+    await page.locator(sel.sideNavLink('settings')).first().evaluate(link => link.click())
+    await expect(page).toHaveURL(/#\/settings/)
+    await page.locator(sel.backButton).click()
+    await expect(page).toHaveURL(/#\/watch\/jNQXAC9IVRw/)
+
+    await page.evaluate((forwardButtonSelector) => {
+      const store = document.querySelector('#app').__vue_app__.config.globalProperties.$store
+      const tab = store.getters.getActiveTab
+      tab.history[tab.historyIndex].titlePending = true
+      store.commit('setTabContentTitle', {
+        tabId: tab.id,
+        title: 'Watch',
+        resolveHistoryEntry: false
+      })
+      document.querySelector(forwardButtonSelector).click()
+    }, sel.forwardButton)
+    await expect(page).toHaveURL(/#\/settings/)
+
+    await page.locator(sel.backButton).click({ button: 'right' })
+    const options = page.locator('.topNav .iconDropdown [role="option"]')
+    await expect(options).toHaveCount(2)
+    await expect(options.filter({ hasText: 'Watch' })).toHaveCount(0)
   })
 
   test('removes an untitled watch entry when navigating to another page', async ({ page }) => {

--- a/e2e/tests/offline/navigation.spec.mjs
+++ b/e2e/tests/offline/navigation.spec.mjs
@@ -73,4 +73,28 @@ test.describe('navigation history titles', () => {
     await expect(options.filter({ hasText: 'Me at the zoo' })).toHaveCount(1)
     await expect(options.filter({ hasText: '/watch/jNQXAC9IVRw' })).toHaveCount(0)
   })
+
+  test('removes an untitled watch entry when navigating back before it loads', async ({ page }) => {
+    await page.locator(sel.searchInput).fill('https://www.youtube.com/watch?v=jNQXAC9IVRw')
+    await page.locator(sel.searchInput).press('Enter')
+    await expect(page).toHaveURL(/#\/watch\/jNQXAC9IVRw/)
+
+    await page.locator(sel.backButton).click()
+    await expect(page).toHaveURL(/#\/subscriptions/)
+    await expect(page.locator(sel.forwardButton)).toBeDisabled()
+  })
+
+  test('removes an untitled watch entry when navigating to another page', async ({ page }) => {
+    await page.locator(sel.searchInput).fill('https://www.youtube.com/watch?v=jNQXAC9IVRw')
+    await page.locator(sel.searchInput).press('Enter')
+    await expect(page).toHaveURL(/#\/watch\/jNQXAC9IVRw/)
+
+    await page.getByRole('link', { name: 'Go to Subscriptions' }).click()
+    await expect(page).toHaveURL(/#\/subscriptions/)
+    await page.locator(sel.backButton).click({ button: 'right' })
+
+    const options = page.locator('.topNav .iconDropdown [role="option"]')
+    await expect(options).toHaveCount(2)
+    await expect(options.filter({ hasText: 'Watch' })).toHaveCount(0)
+  })
 })

--- a/e2e/tests/offline/navigation.spec.mjs
+++ b/e2e/tests/offline/navigation.spec.mjs
@@ -79,7 +79,12 @@ test.describe('navigation history titles', () => {
     await page.locator(sel.searchInput).press('Enter')
     await expect(page).toHaveURL(/#\/watch\/jNQXAC9IVRw/)
 
-    await page.locator(sel.backButton).click()
+    await page.evaluate((backButtonSelector) => {
+      const store = document.querySelector('#app').__vue_app__.config.globalProperties.$store
+      const tabId = store.getters.getActiveTabId
+      store.commit('setTabContentTitle', { tabId, title: 'Watch' })
+      document.querySelector(backButtonSelector).click()
+    }, sel.backButton)
     await expect(page).toHaveURL(/#\/subscriptions/)
     await expect(page.locator(sel.forwardButton)).toBeDisabled()
   })

--- a/src/main/tabs/TabManager.js
+++ b/src/main/tabs/TabManager.js
@@ -72,6 +72,7 @@ const MAX_PERSISTED_NAV_HISTORY_ENTRIES = 25
  * @typedef {object} NavigationHistoryEntry
  * @property {ReturnType<typeof normalizeRoute>} route
  * @property {string} title
+ * @property {boolean} titlePending
  * @property {{left: number, top: number}} scroll
  */
 
@@ -222,6 +223,7 @@ export class TabManager {
         return {
           route: normalizeRoute(route),
           title: typeof entry.title === 'string' ? entry.title : route.fullPath,
+          titlePending: entry.titlePending === true,
           scroll: {
             left: Number.isFinite(entry.scroll?.left) ? entry.scroll.left : 0,
             top: Number.isFinite(entry.scroll?.top) ? entry.scroll.top : 0

--- a/src/renderer/router/index.js
+++ b/src/renderer/router/index.js
@@ -149,7 +149,8 @@ export const routes = [
   {
     path: '/watch/:id',
     meta: {
-      title: 'Watch'
+      title: 'Watch',
+      hasDynamicTitle: true
     },
     component: Watch
   },

--- a/src/renderer/store/modules/tabs.js
+++ b/src/renderer/store/modules/tabs.js
@@ -153,7 +153,12 @@ const mutations = {
     }
   },
 
-  setTabContentTitle(state, { tabId, title, skipHistoryEntry = false }) {
+  setTabContentTitle(state, {
+    tabId,
+    title,
+    skipHistoryEntry = false,
+    resolveHistoryEntry = true
+  }) {
     const tab = state.tabs.find(candidate => candidate.id === tabId)
     if (!tab) {
       return
@@ -165,6 +170,9 @@ const mutations = {
     }
     const entry = tab.history[tab.historyIndex]
     if (entry) {
+      if (resolveHistoryEntry) {
+        entry.titlePending = false
+      }
       const resolvedTitle = title || entry.route.fullPath
       // A caller can provide a title it already knows before a dynamic page
       // finishes loading. Do not replace that useful history label with the
@@ -400,6 +408,7 @@ function normalizeHistoryEntry(entry) {
   return {
     route: cloneRoute(entry?.route),
     title: typeof entry?.title === 'string' ? entry.title : entry?.route?.fullPath || '/',
+    titlePending: entry?.titlePending === true,
     scroll: normalizeScroll(entry?.scroll)
   }
 }

--- a/src/renderer/tabs/TabContext.js
+++ b/src/renderer/tabs/TabContext.js
@@ -23,13 +23,13 @@ export function useTabTitle() {
     isMounted = false
   })
 
-  return (title) => {
+  return (title, options) => {
     if (!isMounted) {
       return
     }
 
     if (process.env.IS_ELECTRON && tabId) {
-      getTabNavigationService().setTitle(tabId, title)
+      getTabNavigationService().setTitle(tabId, title, options)
     } else {
       store.commit('setAppTitle', title)
     }

--- a/src/renderer/tabs/TabNavigationService.js
+++ b/src/renderer/tabs/TabNavigationService.js
@@ -243,6 +243,7 @@ export class TabNavigationService {
     const sameRoute = route.fullPath === tab.route.fullPath
     const preserveContentTitle = location?.state?.skipTabRouteLoading === true
     const preserveScroll = location?.state?.preserveScroll === true
+    const discardCurrentEntry = !sameRoute && isUnresolvedWatchEntry(tab, from)
 
     if (mode === 'push' && sameRoute) {
       return
@@ -281,6 +282,12 @@ export class TabNavigationService {
       if (mode === 'history') {
         history = tab.history.map(cloneHistoryEntry)
         historyIndex = historyTargetIndex
+        if (discardCurrentEntry) {
+          history.splice(tab.historyIndex, 1)
+          if (historyIndex > tab.historyIndex) {
+            historyIndex--
+          }
+        }
       } else if (mode === 'replace') {
         history = tab.history.map(cloneHistoryEntry)
         historyIndex = tab.historyIndex
@@ -292,7 +299,8 @@ export class TabNavigationService {
             : { left: 0, top: 0 }
         }
       } else {
-        history = tab.history.slice(0, tab.historyIndex + 1).map(cloneHistoryEntry)
+        const historyEnd = discardCurrentEntry ? tab.historyIndex : tab.historyIndex + 1
+        history = tab.history.slice(0, historyEnd).map(cloneHistoryEntry)
         history.push({
           route: cloneRoute(route),
           title: initialTitle || routeTitle(to),
@@ -615,6 +623,16 @@ function routeTitle(route) {
   return typeof route.meta?.title === 'string'
     ? translateWindowTitle(route.meta.title) ?? route.meta.title
     : route.fullPath
+}
+
+function isUnresolvedWatchEntry(tab, route) {
+  if (!route.path.startsWith('/watch/')) {
+    return false
+  }
+
+  const entry = tab.history[tab.historyIndex]
+  const hasPlaceholderTitle = entry?.title === route.fullPath || entry?.title === routeTitle(route)
+  return hasPlaceholderTitle && tab.contentTitle === route.fullPath
 }
 
 function getDeepestRouteComponent(route) {

--- a/src/renderer/tabs/TabNavigationService.js
+++ b/src/renderer/tabs/TabNavigationService.js
@@ -243,6 +243,7 @@ export class TabNavigationService {
     const sameRoute = route.fullPath === tab.route.fullPath
     const preserveContentTitle = location?.state?.skipTabRouteLoading === true
     const preserveScroll = location?.state?.preserveScroll === true
+    const titlePending = initialTitle === null && route.path.startsWith('/watch/')
     const discardCurrentEntry = !sameRoute && isUnresolvedWatchEntry(tab, from)
 
     if (mode === 'push' && sameRoute) {
@@ -294,6 +295,9 @@ export class TabNavigationService {
         history[historyIndex] = {
           route: cloneRoute(route),
           title: history[historyIndex]?.title || routeTitle(to),
+          titlePending: sameRoute
+            ? history[historyIndex]?.titlePending === true
+            : titlePending,
           scroll: sameRoute || preserveScroll
             ? { ...history[historyIndex]?.scroll }
             : { left: 0, top: 0 }
@@ -304,6 +308,7 @@ export class TabNavigationService {
         history.push({
           route: cloneRoute(route),
           title: initialTitle || routeTitle(to),
+          titlePending,
           scroll: { left: 0, top: 0 }
         })
         if (history.length > MAX_LOGICAL_HISTORY_ENTRIES) {
@@ -319,7 +324,7 @@ export class TabNavigationService {
         if (initialTitle) {
           this.setTitle(tabId, initialTitle)
         } else if (typeof to.name === 'string') {
-          this.setTitle(tabId, routeTitle(to))
+          this.setTitle(tabId, routeTitle(to), { resolveHistoryEntry: false })
         }
         this.publishRoute(tabId, route)
 
@@ -461,13 +466,25 @@ export class TabNavigationService {
     }
   }
 
-  setTitle(tabId, title, { skipHistoryEntry = false } = {}) {
+  setTitle(tabId, title, { skipHistoryEntry = false, resolveHistoryEntry = true } = {}) {
     if (typeof title !== 'string') {
       return
     }
 
-    this.store.commit('setTabContentTitle', { tabId, title, skipHistoryEntry })
+    const tab = this.store.getters.getTabById(tabId)
+    const resolvedPendingEntry = !skipHistoryEntry &&
+      resolveHistoryEntry &&
+      tab?.history[tab.historyIndex]?.titlePending === true
+    this.store.commit('setTabContentTitle', {
+      tabId,
+      title,
+      skipHistoryEntry,
+      resolveHistoryEntry
+    })
     window.ftElectron?.tabs?.updateTitle?.(formatDocumentTitle(title), tabId)
+    if (resolvedPendingEntry) {
+      this.publishHistory(tabId)
+    }
 
     if (this.store.getters.getPresentedTabId === tabId) {
       this.store.commit('setAppTitle', title)
@@ -615,6 +632,7 @@ function cloneHistoryEntry(entry) {
   return {
     route: cloneRoute(entry.route),
     title: entry.title,
+    titlePending: entry.titlePending === true,
     scroll: { ...entry.scroll }
   }
 }
@@ -626,16 +644,8 @@ function routeTitle(route) {
 }
 
 function isUnresolvedWatchEntry(tab, route) {
-  if (!route.path.startsWith('/watch/')) {
-    return false
-  }
-
-  const entry = tab.history[tab.historyIndex]
-  const placeholderTitle = routeTitle(route)
-  const hasPlaceholderTitle = entry?.title === route.fullPath || entry?.title === placeholderTitle
-  const hasPlaceholderContentTitle =
-    tab.contentTitle === route.fullPath || tab.contentTitle === placeholderTitle
-  return hasPlaceholderTitle && hasPlaceholderContentTitle
+  return route.path.startsWith('/watch/') &&
+    tab.history[tab.historyIndex]?.titlePending === true
 }
 
 function getDeepestRouteComponent(route) {

--- a/src/renderer/tabs/TabNavigationService.js
+++ b/src/renderer/tabs/TabNavigationService.js
@@ -631,8 +631,11 @@ function isUnresolvedWatchEntry(tab, route) {
   }
 
   const entry = tab.history[tab.historyIndex]
-  const hasPlaceholderTitle = entry?.title === route.fullPath || entry?.title === routeTitle(route)
-  return hasPlaceholderTitle && tab.contentTitle === route.fullPath
+  const placeholderTitle = routeTitle(route)
+  const hasPlaceholderTitle = entry?.title === route.fullPath || entry?.title === placeholderTitle
+  const hasPlaceholderContentTitle =
+    tab.contentTitle === route.fullPath || tab.contentTitle === placeholderTitle
+  return hasPlaceholderTitle && hasPlaceholderContentTitle
 }
 
 function getDeepestRouteComponent(route) {

--- a/src/renderer/views/Watch/Watch.js
+++ b/src/renderer/views/Watch/Watch.js
@@ -168,6 +168,7 @@ export default defineComponent({
       thumbnail: '',
       videoId: '',
       videoTitle: '',
+      hasResolvedVideoTitle: false,
       videoDescription: '',
       videoDescriptionHtml: '',
       videoCategory: '',
@@ -908,6 +909,9 @@ export default defineComponent({
     resetVideoState: function ({ preserveTitle = false, placeholderTitle = '' } = {}) {
       const previousVideoTitle = this.videoTitle
 
+      if (!preserveTitle) {
+        this.hasResolvedVideoTitle = false
+      }
       this.playlistScrollPositions.sidebar = null
       this.playlistScrollPositions.fullscreen = null
       this.isLoading = true
@@ -1094,6 +1098,7 @@ export default defineComponent({
           // extract localised title first and fall back to the not localised one
           this.videoTitle = result.primary_info?.title?.text?.trim() ?? result.basic_info.title?.trim() ?? ''
         }
+        this.hasResolvedVideoTitle = this.videoTitle.length > 0
         this.videoViewCount = result.basic_info.view_count ?? (result.primary_info.view_count ? extractNumberFromString(result.primary_info.view_count.text) : null)
         this.license = result.secondary_info.metadata.rows.find(element => element.title?.text === 'License')?.contents[0]?.text
 
@@ -1575,6 +1580,7 @@ export default defineComponent({
           }
 
           this.videoTitle = result.title
+          this.hasResolvedVideoTitle = this.videoTitle.length > 0
           this.videoViewCount = result.viewCount
 
           const subCount = parseLocalSubscriberCount(result.subCountText)
@@ -3001,7 +3007,10 @@ export default defineComponent({
     },
 
     updateTitle: function () {
-      this.setTabTitle(this.videoTitle || this.getRoutePlaceholderTitle())
+      this.setTabTitle(
+        this.videoTitle || this.getRoutePlaceholderTitle(),
+        { resolveHistoryEntry: this.hasResolvedVideoTitle }
+      )
     },
 
     isHiddenVideo: function (forbiddenTitles, channelsHidden, video) {


### PR DESCRIPTION
## Summary

- remove unresolved watch pages from tab history when navigation happens before their title loads
- preserve watch entries that already have a real or pre-known video title
- cover both Back navigation and direct navigation away from the watch page

## Why

Follow-up to #337. A rapidly abandoned watch page could still be saved with the generic `Watch` route title, leaving unusable placeholder entries in the history menu. The navigation service now recognizes that unresolved state and removes the entry rather than retaining it.

## User impact

Rapidly switching away from a video no longer leaves generic `Watch` entries in tab history, while valid titled video entries remain available.

## Validation

- `pnpm run test:e2e:pack`
- `xvfb-run -a -s "-screen 0 1920x1080x24" pnpm exec playwright test -c e2e/playwright.config.mjs --project=offline e2e/tests/offline/navigation.spec.mjs --workers=1` (10 passed)
- ESLint for `src/renderer/tabs/TabNavigationService.js`
- Node syntax check for `e2e/tests/offline/navigation.spec.mjs`
- `git diff --check`