### PR TITLE
Add toast timeout indicators

### DIFF
--- a/e2e/tests/offline/settings.spec.mjs
+++ b/e2e/tests/offline/settings.spec.mjs
@@ -254,7 +254,7 @@ test.describe('settings', () => {
 
     await page.mouse.move(800, 300)
     await page.evaluate(() => {
-      window.ftElectron.showToastOnAllTabs('Hover toast', 500)
+      window.ftElectron.showToastOnAllTabs('Hover toast', 2000)
     })
 
     const toast = page.locator('.toast', { hasText: 'Hover toast' })
@@ -264,14 +264,14 @@ test.describe('settings', () => {
       const animation = element.getAnimations()[0]
       return animation ? animation.playState : null
     })).toBe('paused')
-    await page.waitForTimeout(700)
+    await page.waitForTimeout(2200)
     await expect(toast).toBeVisible()
 
     await page.mouse.move(800, 300)
     await expect(toast).toHaveCount(0)
 
     await page.evaluate(() => {
-      window.ftElectron.showToastOnAllTabs('Dragged hover toast', 500)
+      window.ftElectron.showToastOnAllTabs('Dragged hover toast', 2000)
     })
     const draggedToast = page.locator('.toast', { hasText: 'Dragged hover toast' })
     const draggedToastBounds = await draggedToast.boundingBox()
@@ -314,12 +314,12 @@ test.describe('settings', () => {
     await expect(indicatorToggle).not.toBeChecked()
 
     await page.evaluate(() => {
-      window.ftElectron.showToastOnAllTabs('No indicator toast', 500)
+      window.ftElectron.showToastOnAllTabs('No indicator toast', 2000)
     })
     const toastWithoutIndicator = page.locator('.toast', { hasText: 'No indicator toast' })
     await toastWithoutIndicator.hover()
     await expect(toastWithoutIndicator.locator('..').locator('.timeout-indicator')).toHaveCount(0)
-    await page.waitForTimeout(700)
+    await page.waitForTimeout(2200)
     await expect(toastWithoutIndicator).toBeVisible()
 
     await page.mouse.move(800, 300)

--- a/e2e/tests/offline/settings.spec.mjs
+++ b/e2e/tests/offline/settings.spec.mjs
@@ -117,7 +117,8 @@ test.describe('settings', () => {
   test('positions toasts and dismisses them towards the configured edge', async ({ page }) => {
     await goTo(page, 'settings')
 
-    const positionSelect = page.locator('.select')
+    const themeSection = page.locator('[data-section="theme"]')
+    const positionSelect = themeSection.locator('.select')
       .filter({ hasText: 'Toast Position' })
       .locator('select')
     const holder = page.locator('.toast-holder')
@@ -243,8 +244,13 @@ test.describe('settings', () => {
   test('configures the toast timeout indicator and pauses toasts on hover', async ({ page }) => {
     await goTo(page, 'settings')
 
-    const indicatorToggle = page.getByRole('checkbox', { name: 'Show toast timeout indicator' })
+    const themeSection = page.locator('[data-section="theme"]')
+    const indicatorToggle = themeSection.getByRole('checkbox', { name: 'Show toast timeout indicator' })
     await expect(indicatorToggle).toBeChecked()
+    await expect(themeSection.getByRole('checkbox', { name: 'Show Tab Icons' })).toBeVisible()
+    await expect(page.locator('[data-section="general"]').getByRole('checkbox', {
+      name: /Show (toast timeout indicator|Tab Icons)/
+    })).toHaveCount(0)
 
     await page.mouse.move(800, 300)
     await page.evaluate(() => {
@@ -488,7 +494,7 @@ test.describe('invalid toast position', () => {
   test('falls back to bottom left', async ({ page }) => {
     await goTo(page, 'settings')
 
-    const positionSelect = page.locator('.select')
+    const positionSelect = page.locator('[data-section="theme"] .select')
       .filter({ hasText: 'Toast Position' })
       .locator('select')
     await expect(positionSelect).toHaveValue('bottom-left')

--- a/e2e/tests/offline/settings.spec.mjs
+++ b/e2e/tests/offline/settings.spec.mjs
@@ -131,6 +131,7 @@ test.describe('settings', () => {
       await expect(toast).toBeVisible()
       await expect(toast).toHaveCSS('transform', 'none')
       await expect(toast.locator('..')).toHaveCSS('transform', 'none')
+      await expect(toast.locator('..').locator('.timeout-indicator')).toHaveCSS('animation-duration', '10s')
       return toast
     }
 
@@ -144,6 +145,13 @@ test.describe('settings', () => {
       await page.mouse.move(x, y)
       await page.mouse.down()
       await page.mouse.move(x + distance, y, { steps: 5 })
+
+      const indicatorTrack = toast.locator('..').locator('.timeout-indicator-track')
+      const transforms = await Promise.all([
+        toast.evaluate(element => getComputedStyle(element).transform),
+        indicatorTrack.evaluate(element => getComputedStyle(element).transform)
+      ])
+      expect(transforms[1]).toBe(transforms[0])
     }
 
     function viewportSize () {
@@ -230,6 +238,86 @@ test.describe('settings', () => {
     await dragToast(toast, dismissDragDistance)
     await page.mouse.up()
     await expect(toast).toHaveCount(0)
+  })
+
+  test('configures the toast timeout indicator and pauses toasts on hover', async ({ page }) => {
+    await goTo(page, 'settings')
+
+    const indicatorToggle = page.getByRole('checkbox', { name: 'Show toast timeout indicator' })
+    await expect(indicatorToggle).toBeChecked()
+
+    await page.mouse.move(800, 300)
+    await page.evaluate(() => {
+      window.ftElectron.showToastOnAllTabs('Hover toast', 500)
+    })
+
+    const toast = page.locator('.toast', { hasText: 'Hover toast' })
+    const indicator = toast.locator('..').locator('.timeout-indicator')
+    await toast.hover()
+    await expect.poll(() => indicator.evaluate((element) => {
+      const animation = element.getAnimations()[0]
+      return animation ? animation.playState : null
+    })).toBe('paused')
+    await page.waitForTimeout(700)
+    await expect(toast).toBeVisible()
+
+    await page.mouse.move(800, 300)
+    await expect(toast).toHaveCount(0)
+
+    await page.evaluate(() => {
+      window.ftElectron.showToastOnAllTabs('Dragged hover toast', 500)
+    })
+    const draggedToast = page.locator('.toast', { hasText: 'Dragged hover toast' })
+    const draggedToastBounds = await draggedToast.boundingBox()
+    await page.mouse.move(
+      draggedToastBounds.x + draggedToastBounds.width / 2,
+      draggedToastBounds.y + draggedToastBounds.height / 2
+    )
+    await page.mouse.down()
+    await page.mouse.move(
+      draggedToastBounds.x + draggedToastBounds.width / 2 + 40,
+      draggedToastBounds.y + draggedToastBounds.height / 2
+    )
+    await page.mouse.up()
+    await page.mouse.move(800, 300)
+    await expect(draggedToast).toHaveCount(0)
+
+    await page.evaluate(() => {
+      window.ftElectron.showToastOnAllTabs('First alternating toast', 2000)
+      window.ftElectron.showToastOnAllTabs('Second alternating toast', 2000)
+    })
+    const firstAlternatingToast = page.locator('.toast', { hasText: 'First alternating toast' })
+    const secondAlternatingToast = page.locator('.toast', { hasText: 'Second alternating toast' })
+    await page.waitForTimeout(400)
+    await firstAlternatingToast.hover()
+    await secondAlternatingToast.hover()
+    await page.waitForTimeout(300)
+    await firstAlternatingToast.hover()
+
+    const firstIndicatorScale = await firstAlternatingToast
+      .locator('..')
+      .locator('.timeout-indicator')
+      .evaluate((element) => new DOMMatrixReadOnly(getComputedStyle(element).transform).a)
+    expect(firstIndicatorScale).toBeLessThan(0.85)
+
+    await page.mouse.move(800, 300)
+
+    await page.locator('label.switch-label')
+      .filter({ hasText: 'Show toast timeout indicator' })
+      .click()
+    await expect(indicatorToggle).not.toBeChecked()
+
+    await page.evaluate(() => {
+      window.ftElectron.showToastOnAllTabs('No indicator toast', 500)
+    })
+    const toastWithoutIndicator = page.locator('.toast', { hasText: 'No indicator toast' })
+    await toastWithoutIndicator.hover()
+    await expect(toastWithoutIndicator.locator('..').locator('.timeout-indicator')).toHaveCount(0)
+    await page.waitForTimeout(700)
+    await expect(toastWithoutIndicator).toBeVisible()
+
+    await page.mouse.move(800, 300)
+    await expect(toastWithoutIndicator).toHaveCount(0)
   })
 })
 

--- a/src/renderer/components/FtToast/FtToast.css
+++ b/src/renderer/components/FtToast/FtToast.css
@@ -104,6 +104,10 @@
   animation-fill-mode: forwards;
 }
 
+.timeout-indicator:dir(rtl) {
+  transform-origin: right;
+}
+
 @keyframes toast-timeout {
   to {
     transform: scaleX(0);

--- a/src/renderer/components/FtToast/FtToast.css
+++ b/src/renderer/components/FtToast/FtToast.css
@@ -47,6 +47,10 @@
   z-index: 1002;
 }
 
+.toast-slot {
+  position: relative;
+}
+
 .toast {
   display: flex;
   align-items: center;
@@ -73,6 +77,37 @@
   /* Let the component own horizontal drag gestures instead of the browser */
   touch-action: pan-y;
   transition: transform 300ms ease, opacity 300ms ease;
+}
+
+.timeout-indicator-track {
+  position: absolute;
+  inset-block-end: 5px;
+  inset-inline: 10px;
+  block-size: 2px;
+  pointer-events: none;
+  transition: transform 300ms ease, opacity 300ms ease;
+}
+
+.timeout-indicator-track.dragging {
+  transition: none;
+}
+
+.timeout-indicator {
+  inline-size: 100%;
+  block-size: 100%;
+  border-radius: calc(999px * var(--ui-roundness));
+  background-color: var(--primary-color);
+  box-shadow: 0 0 4px color-mix(in srgb, var(--primary-color) 70%, transparent);
+  transform-origin: left;
+  animation-name: toast-timeout;
+  animation-timing-function: linear;
+  animation-fill-mode: forwards;
+}
+
+@keyframes toast-timeout {
+  to {
+    transform: scaleX(0);
+  }
 }
 
 /* Follow the pointer instantly while dragging */

--- a/src/renderer/components/FtToast/FtToast.vue
+++ b/src/renderer/components/FtToast/FtToast.vue
@@ -15,6 +15,8 @@
         :key="toast.id"
         class="toast-slot"
         :class="toast.dismissDirection && `dismiss-${toast.dismissDirection}`"
+        @pointerenter="pause(toast)"
+        @pointerleave="resume(toast)"
       >
         <div
           v-overlay-scrollbars
@@ -29,8 +31,8 @@
           @keydown.esc.prevent="dismiss(toast)"
           @pointerdown="onPointerDown(toast, $event)"
           @pointermove="onPointerMove(toast, $event)"
-          @pointerup="onPointerUp(toast)"
-          @pointercancel="onPointerUp(toast)"
+          @pointerup="onPointerUp(toast, $event)"
+          @pointercancel="onPointerUp(toast, $event)"
         >
           <img
             v-if="toast.image"
@@ -48,6 +50,19 @@
           <p class="message">
             {{ toast.message }}
           </p>
+        </div>
+        <div
+          v-if="showTimeoutIndicator"
+          class="timeout-indicator-track"
+          :class="{ dragging: toast.dragging }"
+          :style="dragStyle(toast)"
+          aria-hidden="true"
+        >
+          <div
+            class="timeout-indicator"
+            :style="{ animationDuration: `${toast.duration}ms` }"
+            @animationstart="onIndicatorAnimationStart(toast, $event)"
+          />
         </div>
       </div>
     </TransitionGroup>
@@ -73,7 +88,10 @@ let removeShowToastListener = null
  * @property {NodeJS.Timeout | number} timeout
  * @property {NodeJS.Timeout | number} interval
  * @property {number} id
+ * @property {number} duration lifetime of the toast in milliseconds
+ * @property {number} remainingMs lifetime remaining when the toast was paused
  * @property {number} expiresAt timestamp the toast is due to auto-dismiss at, used to reschedule after a drag
+ * @property {boolean} hovered
  * @property {boolean} dragging
  * @property {boolean} pointerMoved whether the pointer moved enough to count as a drag (suppresses the click action)
  * @property {number} dragOffset current horizontal drag offset in px
@@ -86,12 +104,16 @@ const DRAG_DISMISS_THRESHOLD = 80
 
 /** @type {import('vue').Reactive<Toast[]>} */
 const toasts = reactive([])
+/** @type {Map<number, Animation>} */
+const indicatorAnimations = new Map()
 /** @type {import('vue').Ref<Element|null>} */
 const fullscreenTarget = ref(null)
 /** @type {import('vue').ComputedRef<'bottom-left' | 'bottom-center' | 'bottom-right' | 'top-left' | 'top-center' | 'top-right'>} */
 const toastPosition = computed(() => {
   return normalizeToastPosition(store.getters.getToastPosition)
 })
+/** @type {import('vue').ComputedRef<boolean>} */
+const showTimeoutIndicator = computed(() => store.getters.getShowToastTimeoutIndicator)
 
 function updateFullscreenTarget() {
   fullscreenTarget.value = document.fullscreenElement
@@ -114,7 +136,10 @@ function open({ detail: { message, time, action, abortSignal, image, icon } }) {
     icon: icon ?? null,
     timeout: 0,
     interval: 0,
+    duration: time,
+    remainingMs: time,
     expiresAt: Date.now() + time,
+    hovered: false,
     dragging: false,
     pointerMoved: false,
     dragOffset: 0,
@@ -188,6 +213,35 @@ function onClick(toast) {
 }
 
 /**
+ * Pauses auto-dismiss while a toast is hovered.
+ * @param {Toast} toast
+ */
+function pause(toast) {
+  if (toast.hovered) { return }
+
+  toast.hovered = true
+  toast.remainingMs = Math.max(0, toast.expiresAt - Date.now())
+  clearTimeout(toast.timeout)
+  indicatorAnimations.get(toast.id)?.pause()
+}
+
+/**
+ * Resumes auto-dismiss once the toast is no longer hovered.
+ * @param {Toast} toast
+ */
+function resume(toast) {
+  if (!toast.hovered) { return }
+
+  toast.hovered = false
+  toast.expiresAt = Date.now() + toast.remainingMs
+  indicatorAnimations.get(toast.id)?.play()
+
+  if (!toast.dragging) {
+    toast.timeout = setTimeout(remove, toast.remainingMs, toast)
+  }
+}
+
+/**
  * @param {Toast} toast
  * @param {PointerEvent} event
  */
@@ -231,8 +285,9 @@ function onPointerMove(toast, event) {
 
 /**
  * @param {Toast} toast
+ * @param {PointerEvent} event
  */
-function onPointerUp(toast) {
+function onPointerUp(toast, event) {
   if (!toast.dragging) { return }
 
   toast.dragging = false
@@ -245,8 +300,23 @@ function onPointerUp(toast) {
     // for toasts whose action expires on its own schedule (e.g. the playlist
     // undo toast), which must not stay clickable after that deadline passes.
     toast.dragOffset = 0
-    toast.timeout = setTimeout(remove, Math.max(0, toast.expiresAt - Date.now()), toast)
+    if (!toast.hovered) {
+      toast.timeout = setTimeout(remove, Math.max(0, toast.expiresAt - Date.now()), toast)
+    }
   }
+
+  // Pointer capture can suppress the leave event when a drag ends outside the
+  // toast. Recheck after capture is released so hover cannot remain stuck.
+  const element = event.currentTarget
+  requestAnimationFrame(() => {
+    if (!toasts.includes(toast)) { return }
+
+    if (element.matches(':hover')) {
+      pause(toast)
+    } else {
+      resume(toast)
+    }
+  })
 }
 
 /**
@@ -281,6 +351,28 @@ function dragStyle(toast) {
 }
 
 /**
+ * Associates the browser-managed animation with its toast and seeks it to the
+ * true remaining lifetime. Seeking matters if the indicator is enabled while
+ * an existing toast is already partway through its lifetime.
+ * @param {Toast} toast
+ * @param {AnimationEvent} event
+ */
+function onIndicatorAnimationStart(toast, event) {
+  const animation = event.target.getAnimations()[0]
+  if (!animation) { return }
+
+  const remainingMs = toast.hovered
+    ? toast.remainingMs
+    : Math.max(0, toast.expiresAt - Date.now())
+
+  animation.currentTime = toast.duration - remainingMs
+  if (toast.hovered) {
+    animation.pause()
+  }
+  indicatorAnimations.set(toast.id, animation)
+}
+
+/**
  * @param {Toast} toast
  */
 function remove(toast) {
@@ -288,6 +380,7 @@ function remove(toast) {
 
   if (index !== -1) {
     toasts.splice(index, 1)
+    indicatorAnimations.delete(toast.id)
     cleanup(toast)
   }
 }

--- a/src/renderer/components/FtToast/FtToast.vue
+++ b/src/renderer/components/FtToast/FtToast.vue
@@ -15,7 +15,7 @@
         :key="toast.id"
         class="toast-slot"
         :class="toast.dismissDirection && `dismiss-${toast.dismissDirection}`"
-        @pointerenter="pause(toast)"
+        @pointerenter="pause(toast, $event.currentTarget)"
         @pointerleave="resume(toast)"
       >
         <div
@@ -215,14 +215,22 @@ function onClick(toast) {
 /**
  * Pauses auto-dismiss while a toast is hovered.
  * @param {Toast} toast
+ * @param {HTMLElement} element
  */
-function pause(toast) {
+function pause(toast, element) {
   if (toast.hovered) { return }
 
   toast.hovered = true
   toast.remainingMs = Math.max(0, toast.expiresAt - Date.now())
   clearTimeout(toast.timeout)
-  indicatorAnimations.get(toast.id)?.pause()
+
+  const animation = indicatorAnimations.get(toast.id) ??
+    element.querySelector('.timeout-indicator')?.getAnimations()[0]
+  if (animation) {
+    animation.currentTime = toast.duration - toast.remainingMs
+    animation.pause()
+    indicatorAnimations.set(toast.id, animation)
+  }
 }
 
 /**
@@ -307,12 +315,12 @@ function onPointerUp(toast, event) {
 
   // Pointer capture can suppress the leave event when a drag ends outside the
   // toast. Recheck after capture is released so hover cannot remain stuck.
-  const element = event.currentTarget
+  const element = event.currentTarget.parentElement
   requestAnimationFrame(() => {
     if (!toasts.includes(toast)) { return }
 
     if (element.matches(':hover')) {
-      pause(toast)
+      pause(toast, element)
     } else {
       resume(toast)
     }

--- a/src/renderer/components/GeneralSettings/GeneralSettings.vue
+++ b/src/renderer/components/GeneralSettings/GeneralSettings.vue
@@ -35,6 +35,13 @@
           :tooltip="t('Tooltips.General Settings.Remember Tab Navigation History')"
           @change="updateRememberTabNavigationHistory"
         />
+        <FtToggleSwitch
+          :label="t('Settings.General Settings.Show Toast Timeout Indicator')"
+          :default-value="showToastTimeoutIndicator"
+          setting-key="showToastTimeoutIndicator"
+          :compact="true"
+          @change="updateShowToastTimeoutIndicator"
+        />
       </div>
       <div class="switchColumn">
         <FtToggleSwitch
@@ -392,6 +399,16 @@ const showTabIcons = computed(() => store.getters.getShowTabIcons)
  */
 function updateShowTabIcons(value) {
   store.dispatch('updateShowTabIcons', value)
+}
+
+/** @type {import('vue').ComputedRef<boolean>} */
+const showToastTimeoutIndicator = computed(() => store.getters.getShowToastTimeoutIndicator)
+
+/**
+ * @param {boolean} value
+ */
+function updateShowToastTimeoutIndicator(value) {
+  store.dispatch('updateShowToastTimeoutIndicator', value)
 }
 
 const BACKEND_VALUES = process.env.SUPPORTS_LOCAL_API

--- a/src/renderer/components/GeneralSettings/GeneralSettings.vue
+++ b/src/renderer/components/GeneralSettings/GeneralSettings.vue
@@ -35,13 +35,6 @@
           :tooltip="t('Tooltips.General Settings.Remember Tab Navigation History')"
           @change="updateRememberTabNavigationHistory"
         />
-        <FtToggleSwitch
-          :label="t('Settings.General Settings.Show Toast Timeout Indicator')"
-          :default-value="showToastTimeoutIndicator"
-          setting-key="showToastTimeoutIndicator"
-          :compact="true"
-          @change="updateShowToastTimeoutIndicator"
-        />
       </div>
       <div class="switchColumn">
         <FtToggleSwitch
@@ -73,14 +66,6 @@
           setting-key="confirmCloseApp"
           :compact="true"
           @change="updateConfirmCloseApp"
-        />
-        <FtToggleSwitch
-          v-if="USING_ELECTRON"
-          :label="t('Settings.General Settings.Show Tab Icons')"
-          :default-value="showTabIcons"
-          setting-key="showTabIcons"
-          :compact="true"
-          @change="updateShowTabIcons"
         />
       </div>
     </div>
@@ -182,15 +167,6 @@
         @change="updateReducedMotion"
       />
       <FtSelect
-        :placeholder="t('Settings.General Settings.Toast Position.Toast Position')"
-        :value="toastPosition"
-        setting-key="toastPosition"
-        :select-names="toastPositionNames"
-        :select-values="TOAST_POSITION_VALUES"
-        :icon="['fas', 'message']"
-        @change="updateToastPosition"
-      />
-      <FtSelect
         v-if="SUPPORTS_LOCAL_API && (backendPreference === 'local' || backendFallback)"
         :placeholder="t('Settings.General Settings.Avoid translation.Avoid translation')"
         :value="avoidTranslation"
@@ -289,7 +265,6 @@ import FtButton from '../FtButton/FtButton.vue'
 import store from '../../store/index'
 
 import allLocales from '../../../../static/locales/activeLocales.json'
-import { normalizeToastPosition, TOAST_POSITION_VALUES } from '../../constants/toastPosition'
 import { debounce, randomArrayItem, showToast } from '../../helpers/utils'
 import { translateWindowTitle } from '../../helpers/strings'
 
@@ -389,26 +364,6 @@ const rememberTabNavigationHistory = computed(() => store.getters.getRememberTab
  */
 function updateRememberTabNavigationHistory(value) {
   store.dispatch('updateRememberTabNavigationHistory', value)
-}
-
-/** @type {import('vue').ComputedRef<boolean>} */
-const showTabIcons = computed(() => store.getters.getShowTabIcons)
-
-/**
- * @param {boolean} value
- */
-function updateShowTabIcons(value) {
-  store.dispatch('updateShowTabIcons', value)
-}
-
-/** @type {import('vue').ComputedRef<boolean>} */
-const showToastTimeoutIndicator = computed(() => store.getters.getShowToastTimeoutIndicator)
-
-/**
- * @param {boolean} value
- */
-function updateShowToastTimeoutIndicator(value) {
-  store.dispatch('updateShowToastTimeoutIndicator', value)
 }
 
 const BACKEND_VALUES = process.env.SUPPORTS_LOCAL_API
@@ -642,25 +597,6 @@ const reducedMotion = computed(() => store.getters.getReducedMotion)
  */
 function updateReducedMotion(value) {
   store.dispatch('updateReducedMotion', value)
-}
-
-const toastPositionNames = computed(() => [
-  t('Settings.General Settings.Toast Position.Bottom Left'),
-  t('Settings.General Settings.Toast Position.Bottom Center'),
-  t('Settings.General Settings.Toast Position.Bottom Right'),
-  t('Settings.General Settings.Toast Position.Top Left'),
-  t('Settings.General Settings.Toast Position.Top Center'),
-  t('Settings.General Settings.Toast Position.Top Right')
-])
-
-/** @type {import('vue').ComputedRef<'bottom-left' | 'bottom-center' | 'bottom-right' | 'top-left' | 'top-center' | 'top-right'>} */
-const toastPosition = computed(() => normalizeToastPosition(store.getters.getToastPosition))
-
-/**
- * @param {'bottom-left' | 'bottom-center' | 'bottom-right' | 'top-left' | 'top-center' | 'top-right'} value
- */
-function updateToastPosition(value) {
-  store.dispatch('updateToastPosition', value)
 }
 
 /** @type {import('vue').ComputedRef<'disabled' | 'watch_only' | 'entire_app'>} */

--- a/src/renderer/components/ThemeSettings.vue
+++ b/src/renderer/components/ThemeSettings.vue
@@ -40,6 +40,13 @@
           setting-key="alwaysShowScrollbars"
           @change="updateAlwaysShowScrollbars"
         />
+        <FtToggleSwitch
+          :label="$t('Settings.Theme Settings.Show Toast Timeout Indicator')"
+          compact
+          :default-value="showToastTimeoutIndicator"
+          setting-key="showToastTimeoutIndicator"
+          @change="updateShowToastTimeoutIndicator"
+        />
       </div>
       <div class="switchColumn">
         <FtToggleSwitch
@@ -70,6 +77,14 @@
           :default-value="hideProfileSelectorInHeader"
           setting-key="hideProfileSelectorInHeader"
           @change="updateHideProfileSelectorInHeader"
+        />
+        <FtToggleSwitch
+          v-if="usingElectron"
+          :label="$t('Settings.Theme Settings.Show Tab Icons')"
+          compact
+          :default-value="showTabIcons"
+          setting-key="showTabIcons"
+          @change="updateShowTabIcons"
         />
       </div>
     </div>
@@ -114,6 +129,15 @@
     </FtFlexBox>
     <br>
     <FtFlexBox>
+      <FtSelect
+        :placeholder="$t('Settings.Theme Settings.Toast Position.Toast Position')"
+        :value="toastPosition"
+        setting-key="toastPosition"
+        :select-names="toastPositionNames"
+        :select-values="TOAST_POSITION_VALUES"
+        :icon="['fas', 'message']"
+        @change="updateToastPosition"
+      />
       <FtSelect
         :placeholder="$t('Settings.Theme Settings.Base Theme.Base Theme')"
         :value="baseTheme"
@@ -176,6 +200,7 @@ import {
   MIN_THUMBNAIL_SIZE,
   THUMBNAIL_SIZE_STEP
 } from '../constants/thumbnailSize'
+import { normalizeToastPosition, TOAST_POSITION_VALUES } from '../constants/toastPosition'
 
 const { t } = useI18n()
 
@@ -380,6 +405,45 @@ const showThumbnailSizeButtonInHeader = computed(() => {
  */
 function updateShowThumbnailSizeButtonInHeader(value) {
   store.dispatch('updateShowThumbnailSizeButtonInHeader', value)
+}
+
+/** @type {import('vue').ComputedRef<boolean>} */
+const showToastTimeoutIndicator = computed(() => store.getters.getShowToastTimeoutIndicator)
+
+/**
+ * @param {boolean} value
+ */
+function updateShowToastTimeoutIndicator(value) {
+  store.dispatch('updateShowToastTimeoutIndicator', value)
+}
+
+/** @type {import('vue').ComputedRef<boolean>} */
+const showTabIcons = computed(() => store.getters.getShowTabIcons)
+
+/**
+ * @param {boolean} value
+ */
+function updateShowTabIcons(value) {
+  store.dispatch('updateShowTabIcons', value)
+}
+
+const toastPositionNames = computed(() => [
+  t('Settings.Theme Settings.Toast Position.Bottom Left'),
+  t('Settings.Theme Settings.Toast Position.Bottom Center'),
+  t('Settings.Theme Settings.Toast Position.Bottom Right'),
+  t('Settings.Theme Settings.Toast Position.Top Left'),
+  t('Settings.Theme Settings.Toast Position.Top Center'),
+  t('Settings.Theme Settings.Toast Position.Top Right')
+])
+
+/** @type {import('vue').ComputedRef<'bottom-left' | 'bottom-center' | 'bottom-right' | 'top-left' | 'top-center' | 'top-right'>} */
+const toastPosition = computed(() => normalizeToastPosition(store.getters.getToastPosition))
+
+/**
+ * @param {'bottom-left' | 'bottom-center' | 'bottom-right' | 'top-left' | 'top-center' | 'top-right'} value
+ */
+function updateToastPosition(value) {
+  store.dispatch('updateToastPosition', value)
 }
 
 /** @type {import('vue').ComputedRef<number>} */

--- a/src/renderer/store/modules/settings.js
+++ b/src/renderer/store/modules/settings.js
@@ -351,6 +351,7 @@ const state = {
   thumbnailSize: DEFAULT_THUMBNAIL_SIZE,
   uiRoundness: 100,
   showThumbnailSizeButtonInHeader: true,
+  showToastTimeoutIndicator: true,
   toastPosition: 'bottom-left',
   extraThumbnailAction: '',
   blurThumbnails: false,

--- a/static/locales/en-US.yaml
+++ b/static/locales/en-US.yaml
@@ -386,6 +386,7 @@ Settings:
       System: System
       Force On: Force on
       Force Off: Force off
+    Show Toast Timeout Indicator: Show toast timeout indicator
     Toast Position:
       Toast Position: Toast Position
       Bottom Left: Bottom left

--- a/static/locales/en-US.yaml
+++ b/static/locales/en-US.yaml
@@ -361,7 +361,6 @@ Settings:
     Open Deep Links In New Window: Open URLs Passed to OpenTubeX in a New Window
     Minimize to system tray: Minimize to system tray
     Remember Tab Navigation History: Remember Tab Navigation History
-    Show Tab Icons: Show Tab Icons
     Auto Load Next Page:
       Label: Auto Load Next Page
       Tooltip: Load additional pages and comments automatically.
@@ -386,15 +385,6 @@ Settings:
       System: System
       Force On: Force on
       Force Off: Force off
-    Show Toast Timeout Indicator: Show toast timeout indicator
-    Toast Position:
-      Toast Position: Toast Position
-      Bottom Left: Bottom left
-      Bottom Center: Bottom center
-      Bottom Right: Bottom right
-      Top Left: Top left
-      Top Center: Top center
-      Top Right: Top right
     System Default: System Default
     Avoid translation:
       Avoid translation: Keep original text
@@ -447,6 +437,16 @@ Settings:
     UI Roundness: UI Roundness
     Thumbnail Size: Thumbnail Size
     Show Thumbnail Size Button in Header: Show Thumbnail Size Button in Header
+    Show Tab Icons: Show Tab Icons
+    Show Toast Timeout Indicator: Show toast timeout indicator
+    Toast Position:
+      Toast Position: Toast Position
+      Bottom Left: Bottom left
+      Bottom Center: Bottom center
+      Bottom Right: Bottom right
+      Top Left: Top left
+      Top Center: Top center
+      Top Right: Top right
     Always Show Scrollbars: Always Show Scrollbars
     Hide Side Bar Labels: Hide Side Bar Labels
     Hide OpenTubeX Header Logo: Hide OpenTubeX Header Logo


### PR DESCRIPTION
## Summary

- add a slim countdown indicator to toast notifications
- pause toast dismissal and the countdown while the pointer hovers a notification
- add a General setting to hide the visual indicator without disabling hover pause
- keep the indicator aligned with dragged notifications and synchronized across repeated hover/drag interactions

## Why

Toasts previously gave no visual indication of their remaining lifetime. The countdown needs to share the dismissal timer rather than maintain an independent deadline, and pointer capture during dragging must not leave hover pause stuck.

## User impact

Toast lifetime is now visible at a glance, notifications stay available while hovered, and users can opt out of the indicator in General settings. Dragging continues to dismiss or snap back as before.

## Validation

- ESLint
- Stylelint
- 22 unit tests
- Electron/Playwright toast positioning and drag test
- Electron/Playwright countdown setting, hover switching, drag-release, and opt-out test