### PR TITLE
fix(tabs): prefer loaded close fallback

### DIFF
--- a/e2e/tests/offline/tabs.spec.mjs
+++ b/e2e/tests/offline/tabs.spec.mjs
@@ -597,6 +597,7 @@ test.describe('tab close focus set to the next tab', () => {
     await expect(page.locator(sel.tabs)).toHaveCount(2)
     await expect(page.locator(sel.tabs).nth(1)).toHaveClass(/active/)
     const previousTabId = await page.locator(sel.tabs).first().getAttribute('data-tab-id')
+    await expect(page.locator(`.tab[data-tab-id="${previousTabId}"]`)).not.toHaveClass(/unloaded/)
     const unloadedTab = await page.evaluate(() => window.ftElectron.tabs.create({
       makeActive: false,
       lazyLoad: true

--- a/e2e/tests/offline/tabs.spec.mjs
+++ b/e2e/tests/offline/tabs.spec.mjs
@@ -591,6 +591,22 @@ test.describe('tab close focus set to the next tab', () => {
     await page.locator(sel.activeTab).locator('.closeButton').click()
     await expect(page.locator(sel.activeTab)).toHaveAttribute('data-tab-id', tabIds[1])
   })
+
+  test('selects the loaded previous tab when the next tab is unloaded', async ({ page }) => {
+    await page.locator(sel.newTabButton).click()
+    await expect(page.locator(sel.tabs)).toHaveCount(2)
+    await expect(page.locator(sel.tabs).nth(1)).toHaveClass(/active/)
+    const previousTabId = await page.locator(sel.tabs).first().getAttribute('data-tab-id')
+    const unloadedTab = await page.evaluate(() => window.ftElectron.tabs.create({
+      makeActive: false,
+      lazyLoad: true
+    }))
+    await expect(page.locator(`.tab[data-tab-id="${unloadedTab.id}"]`)).toHaveClass(/unloaded/)
+
+    await page.locator(sel.activeTab).locator('.closeButton').click()
+    await expect(page.locator(sel.activeTab)).toHaveAttribute('data-tab-id', previousTabId)
+    await expect(page.locator(`.tab[data-tab-id="${unloadedTab.id}"]`)).toHaveClass(/unloaded/)
+  })
 })
 
 test.describe('tab icons disabled', () => {

--- a/src/main/tabs/TabManager.js
+++ b/src/main/tabs/TabManager.js
@@ -1079,20 +1079,33 @@ export class TabManager {
 
     const previousTabIds = orderedTabIds.slice(0, tabIndex).reverse()
     const nextTabIds = orderedTabIds.slice(tabIndex + 1)
-    // The preferred side wins, the other one is the fallback when that side has
-    // no selectable tab left.
-    const candidates = tabCloseFocus === 'nextTab'
-      ? [...nextTabIds, ...previousTabIds]
-      : [...previousTabIds, ...nextTabIds]
     // A tab already queued for deferred close/unload must never be selected as
     // the replacement, otherwise a rapid second close/unload would leave the
     // window with no selectable tab.
-    return candidates.find(candidateId =>
+    const isSelectable = candidateId =>
       this.tabs.get(candidateId)?.isTransferStaged !== true &&
       (!loadedOnly || this.tabs.get(candidateId)?.loadState === 'loaded') &&
       !this._deferredCloseTabIds.has(candidateId) &&
       !this._deferredUnloadTabIds.has(candidateId)
-    ) ?? null
+
+    const [preferredTabIds, fallbackTabIds] = tabCloseFocus === 'nextTab'
+      ? [nextTabIds, previousTabIds]
+      : [previousTabIds, nextTabIds]
+    const preferredTabId = preferredTabIds.find(isSelectable)
+    const fallbackTabId = fallbackTabIds.find(isSelectable)
+
+    // Prefer an already-loaded tab on the other side over mounting an unloaded
+    // tab on the configured side.
+    if (
+      preferredTabId != null &&
+      fallbackTabId != null &&
+      this.tabs.get(preferredTabId)?.loadState !== 'loaded' &&
+      this.tabs.get(fallbackTabId)?.loadState === 'loaded'
+    ) {
+      return fallbackTabId
+    }
+
+    return preferredTabId ?? fallbackTabId ?? null
   }
 
   _prepareNeighborActivation(tabId) {


### PR DESCRIPTION
## Summary

- prefer an already-loaded tab on the opposite side when the configured post-close neighbor is unloaded
- preserve the configured previous/next direction when candidate load states are equivalent
- add an offline Electron regression test for the `nextTab` preference

## Root cause

The close-neighbor selection helper ordered candidates only by the configured direction. As a result, an unloaded next tab was activated even when the previous tab was already loaded, causing an unnecessary mount and inconsistent behavior with the inverse case.

## User impact

Closing an active tab with **After closing a tab** set to **Next tab** now immediately selects the loaded previous tab when the next tab is unloaded.

## Validation

- `xvfb-run -a -s "-screen 0 1920x1080x24" pnpm exec playwright test -c e2e/playwright.config.mjs --project=offline e2e/tests/offline/tabs.spec.mjs --grep "closing the active tab selects|falls back to the (next|previous) tab|selects the loaded previous tab"` (5 passed)
- `pnpm exec eslint --config eslint.config.mjs src/main/tabs/TabManager.js`
- `git diff --check`