### PR TITLE
Categorize generated release notes

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -51,7 +51,7 @@
 <!-- Please complete the following information-->
 - **OS:**
 - **OS Version:**
-- **FreeTube version:**
+- **OpenTubeX version:**
 
 ## Additional context
 <!-- Add any other context about the pull request here. -->

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -20,9 +20,18 @@
 ## Screenshots <!-- If appropriate -->
 <!-- Please add before and after screenshots if there is a visible change. -->
 
+## Release note category
+<!-- Select exactly one category. Every pull request must select one. -->
+<!-- release-note-category:start -->
+- [ ] Not noteworthy
+- [ ] Highlights
+- [ ] More improvements
+- [ ] Fixed bugs
+<!-- release-note-category:end -->
+
 ## Release note
-<!-- Required when the PR has the `noteworthy-for-release` label. -->
-<!-- Write one concise, user-facing highlight without a leading bullet. -->
+<!-- Required unless "Not noteworthy" is selected. -->
+<!-- Write one concise, user-facing entry without a leading bullet. -->
 <!-- release-note:start -->
 
 <!-- release-note:end -->

--- a/_scripts/releaseNotes.mjs
+++ b/_scripts/releaseNotes.mjs
@@ -338,10 +338,15 @@ export async function renderReleaseNotes(pullRequests, loadImage = downloadImage
   const sections = new Map([...RELEASE_NOTE_CATEGORIES.keys()].map((category) => [category, []]))
 
   for (const pullRequest of pullRequests) {
+    const body = pullRequest.body ?? ''
+
+    // Pull requests merged before categories were introduced have no marker and are not release-note candidates.
+    if (extractMarkedSection(body, RELEASE_NOTE_CATEGORY_MARKER) === null) { continue }
+
     let parsed
 
     try {
-      parsed = parsePullRequestReleaseNote(pullRequest.body ?? '')
+      parsed = parsePullRequestReleaseNote(body)
     } catch (error) {
       throw new Error(`PR #${pullRequest.number}: ${error.message}`, { cause: error })
     }

--- a/_scripts/releaseNotes.mjs
+++ b/_scripts/releaseNotes.mjs
@@ -25,6 +25,29 @@ const ALLOWED_IMAGE_DOWNLOAD_HOSTS = new Set([
   ...ALLOWED_IMAGE_HOSTS,
   'github-production-user-asset-6210df.s3.amazonaws.com',
 ])
+const MERGED_PULL_REQUESTS_QUERY = `
+query($owner: String!, $repo: String!, $base: String!, $endCursor: String) {
+  repository(owner: $owner, name: $repo) {
+    pullRequests(
+      first: 100
+      after: $endCursor
+      states: MERGED
+      baseRefName: $base
+      orderBy: { field: CREATED_AT, direction: DESC }
+    ) {
+      nodes {
+        body
+        mergeCommit { oid }
+        mergedAt
+        number
+        title
+        url
+      }
+      pageInfo { hasNextPage endCursor }
+    }
+  }
+}
+`
 
 function extractMarkedSection(body, marker) {
   const startMarker = `<!-- ${marker}:start -->`
@@ -311,23 +334,31 @@ export function selectPullRequests(pullRequests, previousTag, target) {
     .sort((left, right) => left.mergedAt.localeCompare(right.mergedAt))
 }
 
-function listMergedPullRequests(repository, target) {
+export function normalizePullRequestPages(pages) {
+  return pages.flatMap((page) => page.data.repository.pullRequests.nodes)
+}
+
+export function listMergedPullRequests(repository, target) {
+  const [owner, repo] = repository.split('/')
+
+  if (!owner || !repo) { throw new Error(`Invalid GitHub repository: ${repository}.`) }
+
   const output = execFileSync('gh', [
-    'pr',
-    'list',
-    '--repo',
-    repository,
-    '--state',
-    'merged',
-    '--base',
-    target,
-    '--limit',
-    '1000',
-    '--json',
-    'body,mergeCommit,mergedAt,number,title,url',
+    'api',
+    'graphql',
+    '--paginate',
+    '--slurp',
+    '-f',
+    `query=${MERGED_PULL_REQUESTS_QUERY}`,
+    '-F',
+    `owner=${owner}`,
+    '-F',
+    `repo=${repo}`,
+    '-F',
+    `base=${target}`,
   ], { encoding: 'utf8' })
 
-  return JSON.parse(output)
+  return normalizePullRequestPages(JSON.parse(output))
 }
 
 function indentContinuationLines(value) {

--- a/_scripts/releaseNotes.mjs
+++ b/_scripts/releaseNotes.mjs
@@ -4,7 +4,13 @@ import path from 'node:path'
 import process from 'node:process'
 import { fileURLToPath } from 'node:url'
 
-const NOTEWORTHY_LABEL = 'noteworthy-for-release'
+const NOT_NOTEWORTHY_CATEGORY = 'Not noteworthy'
+const RELEASE_NOTE_CATEGORIES = new Map([
+  ['Highlights', '# Highlights'],
+  ['More improvements', '## More improvements'],
+  ['Fixed bugs', '## Fixed bugs'],
+])
+const RELEASE_NOTE_CATEGORY_MARKER = 'release-note-category'
 const RELEASE_NOTE_MARKER = 'release-note'
 const RELEASE_IMAGE_MARKER = 'release-note-image'
 const MAX_IMAGE_HEIGHT = 300
@@ -105,16 +111,42 @@ export function parseReleaseNote(body) {
   return { image, note }
 }
 
+export function parseReleaseNoteCategory(body) {
+  const section = extractMarkedSection(body, RELEASE_NOTE_CATEGORY_MARKER)
+
+  if (!section) { throw new Error('Select one release note category.') }
+
+  const selected = [...section.matchAll(/^\s*-\s*\[[xX]\]\s+(.+?)\s*$/gm)]
+    .map((match) => match[1])
+
+  if (selected.length !== 1) { throw new Error('Select exactly one release note category.') }
+
+  const category = selected[0]
+
+  if (category !== NOT_NOTEWORTHY_CATEGORY && !RELEASE_NOTE_CATEGORIES.has(category)) {
+    throw new Error(`Unknown release note category: ${category}.`)
+  }
+
+  return category
+}
+
+function parsePullRequestReleaseNote(body) {
+  const category = parseReleaseNoteCategory(body)
+
+  if (category === NOT_NOTEWORTHY_CATEGORY) { return { category } }
+
+  return {
+    category,
+    ...parseReleaseNote(body),
+  }
+}
+
 export function validatePullRequestEvent(event) {
   const pullRequest = event.pull_request
 
   if (!pullRequest) { throw new Error('The event does not contain a pull request.') }
 
-  const isNoteworthy = pullRequest.labels.some(({ name }) => name === NOTEWORTHY_LABEL)
-
-  if (!isNoteworthy) { return null }
-
-  return parseReleaseNote(pullRequest.body ?? '')
+  return parsePullRequestReleaseNote(pullRequest.body ?? '')
 }
 
 function readUInt24LE(buffer, offset) {
@@ -279,7 +311,7 @@ export function selectPullRequests(pullRequests, previousTag, target) {
     .sort((left, right) => left.mergedAt.localeCompare(right.mergedAt))
 }
 
-function listNoteworthyPullRequests(repository, target) {
+function listMergedPullRequests(repository, target) {
   const output = execFileSync('gh', [
     'pr',
     'list',
@@ -289,8 +321,6 @@ function listNoteworthyPullRequests(repository, target) {
     'merged',
     '--base',
     target,
-    '--label',
-    NOTEWORTHY_LABEL,
     '--limit',
     '1000',
     '--json',
@@ -305,40 +335,48 @@ function indentContinuationLines(value) {
 }
 
 export async function renderReleaseNotes(pullRequests, loadImage = downloadImage) {
-  if (pullRequests.length === 0) { throw new Error('No noteworthy pull requests were found between the selected refs.') }
-
-  const highlights = []
+  const sections = new Map([...RELEASE_NOTE_CATEGORIES.keys()].map((category) => [category, []]))
 
   for (const pullRequest of pullRequests) {
     let parsed
 
     try {
-      parsed = parseReleaseNote(pullRequest.body ?? '')
+      parsed = parsePullRequestReleaseNote(pullRequest.body ?? '')
     } catch (error) {
       throw new Error(`PR #${pullRequest.number}: ${error.message}`, { cause: error })
     }
 
-    let highlight = `- ${indentContinuationLines(parsed.note)}`
+    if (parsed.category === NOT_NOTEWORTHY_CATEGORY) { continue }
+
+    let releaseNote = `- ${indentContinuationLines(parsed.note)}`
 
     if (parsed.image) {
       try {
-        highlight += `\n  ${await normalizeReleaseImage(parsed.image, pullRequest.title, loadImage)}`
+        releaseNote += `\n  ${await normalizeReleaseImage(parsed.image, pullRequest.title, loadImage)}`
       } catch (error) {
         throw new Error(`PR #${pullRequest.number}: ${error.message}`, { cause: error })
       }
     }
 
-    highlights.push(highlight)
+    sections.get(parsed.category).push(releaseNote)
   }
 
-  return `# Highlights\n\n${highlights.join('\n\n')}\n`
+  const renderedSections = [...RELEASE_NOTE_CATEGORIES]
+    .filter(([category]) => sections.get(category).length > 0)
+    .map(([category, heading]) => `${heading}\n\n${sections.get(category).join('\n')}`)
+
+  if (renderedSections.length === 0) {
+    throw new Error('No noteworthy pull requests were found between the selected refs.')
+  }
+
+  return `${renderedSections.join('\n\n')}\n`
 }
 
 async function validateEvent(eventPath) {
   const event = JSON.parse(fs.readFileSync(eventPath, 'utf8'))
   const releaseNote = validatePullRequestEvent(event)
 
-  if (releaseNote) { console.log('Release note is valid.') } else { console.log(`PR does not have the ${NOTEWORTHY_LABEL} label.`) }
+  console.log(`Release note category is valid: ${releaseNote.category}.`)
 }
 
 async function generate(outputPath) {
@@ -351,12 +389,12 @@ async function generate(outputPath) {
     throw new Error('GITHUB_REPOSITORY, PREVIOUS_TAG, TARGET_BRANCH, and TARGET_SHA are required.')
   }
 
-  const pullRequests = listNoteworthyPullRequests(repository, targetBranch)
+  const pullRequests = listMergedPullRequests(repository, targetBranch)
   const selectedPullRequests = selectPullRequests(pullRequests, previousTag, targetSha)
   const releaseNotes = await renderReleaseNotes(selectedPullRequests)
 
   fs.writeFileSync(outputPath, releaseNotes)
-  console.log(`Wrote ${selectedPullRequests.length} highlights to ${outputPath}.`)
+  console.log(`Processed ${selectedPullRequests.length} pull requests and wrote ${outputPath}.`)
 }
 
 async function main() {

--- a/tests/unit/release-notes.test.mjs
+++ b/tests/unit/release-notes.test.mjs
@@ -4,6 +4,7 @@ import test from 'node:test'
 import {
   normalizeReleaseImage,
   parseReleaseNote,
+  parseReleaseNoteCategory,
   probeImageSize,
   renderReleaseNotes,
   validateDownloadedImageUrl,
@@ -14,6 +15,15 @@ const NOTE_MARKERS = `
 <!-- release-note:start -->
 Adds a compact player.
 <!-- release-note:end -->
+`
+
+const categoryMarkers = (category) => `
+<!-- release-note-category:start -->
+- [${category === 'Not noteworthy' ? 'x' : ' '}] Not noteworthy
+- [${category === 'Highlights' ? 'x' : ' '}] Highlights
+- [${category === 'More improvements' ? 'x' : ' '}] More improvements
+- [${category === 'Fixed bugs' ? 'x' : ' '}] Fixed bugs
+<!-- release-note-category:end -->
 `
 
 function png(width, height) {
@@ -60,18 +70,33 @@ function webp(type, width, height) {
   return buffer
 }
 
-test('release notes are required only for noteworthy pull requests', () => {
-  assert.equal(validatePullRequestEvent({
+test('every pull request requires exactly one release note category', () => {
+  assert.deepEqual(validatePullRequestEvent({
     pull_request: {
-      body: '',
-      labels: [],
+      body: categoryMarkers('Not noteworthy'),
     },
-  }), null)
+  }), {
+    category: 'Not noteworthy',
+  })
 
   assert.throws(() => validatePullRequestEvent({
     pull_request: {
       body: '',
-      labels: [{ name: 'noteworthy-for-release' }],
+    },
+  }), /Select one release note category/)
+
+  assert.throws(() => parseReleaseNoteCategory(`
+<!-- release-note-category:start -->
+- [x] Highlights
+- [x] Fixed bugs
+<!-- release-note-category:end -->
+`), /Select exactly one release note category/)
+})
+
+test('release notes are required for noteworthy categories', () => {
+  assert.throws(() => validatePullRequestEvent({
+    pull_request: {
+      body: categoryMarkers('Highlights'),
     },
   }), /Fill in the release note section/)
 })
@@ -197,10 +222,11 @@ test('images up to 300 pixels have no dimensions', async () => {
   )
 })
 
-test('release notes render as highlights with normalized image tags', async () => {
+test('release notes render under their selected categories', async () => {
   const result = await renderReleaseNotes([
     {
       body: `
+${categoryMarkers('Highlights')}
 ${NOTE_MARKERS}
 <!-- release-note-image:start -->
 <img src="https://github.com/user-attachments/assets/example" alt="Screenshot" width="800" height="600">
@@ -211,12 +237,28 @@ ${NOTE_MARKERS}
     },
     {
       body: `
+${categoryMarkers('More improvements')}
 <!-- release-note:start -->
 Adds keyboard shortcuts.
 <!-- release-note:end -->
 `,
       number: 43,
       title: 'Keyboard shortcuts',
+    },
+    {
+      body: `
+${categoryMarkers('Fixed bugs')}
+<!-- release-note:start -->
+Fixed videos failing to load.
+<!-- release-note:end -->
+`,
+      number: 44,
+      title: 'Fix video loading',
+    },
+    {
+      body: categoryMarkers('Not noteworthy'),
+      number: 45,
+      title: 'Refactor tests',
     },
   ], async () => png(800, 600))
 
@@ -225,6 +267,41 @@ Adds keyboard shortcuts.
 - Adds a compact player.
   <img src="https://github.com/user-attachments/assets/example" alt="Screenshot" height="300">
 
+## More improvements
+
 - Adds keyboard shortcuts.
+
+## Fixed bugs
+
+- Fixed videos failing to load.
 `)
+})
+
+test('empty release note categories are omitted', async () => {
+  const result = await renderReleaseNotes([
+    {
+      body: `
+${categoryMarkers('Fixed bugs')}
+${NOTE_MARKERS}
+`,
+      number: 42,
+      title: 'Compact player',
+    },
+  ])
+
+  assert.equal(result, `## Fixed bugs
+
+- Adds a compact player.
+`)
+})
+
+test('a release with only non-noteworthy pull requests is rejected', async () => {
+  await assert.rejects(
+    renderReleaseNotes([{
+      body: categoryMarkers('Not noteworthy'),
+      number: 42,
+      title: 'Refactor tests',
+    }]),
+    /No noteworthy pull requests/,
+  )
 })

--- a/tests/unit/release-notes.test.mjs
+++ b/tests/unit/release-notes.test.mjs
@@ -260,6 +260,11 @@ Fixed videos failing to load.
       number: 45,
       title: 'Refactor tests',
     },
+    {
+      body: 'Legacy pull request body',
+      number: 46,
+      title: 'Legacy change',
+    },
   ], async () => png(800, 600))
 
   assert.equal(result, `# Highlights

--- a/tests/unit/release-notes.test.mjs
+++ b/tests/unit/release-notes.test.mjs
@@ -3,6 +3,7 @@ import test from 'node:test'
 
 import {
   normalizeReleaseImage,
+  normalizePullRequestPages,
   parseReleaseNote,
   parseReleaseNoteCategory,
   probeImageSize,
@@ -99,6 +100,57 @@ test('release notes are required for noteworthy categories', () => {
       body: categoryMarkers('Highlights'),
     },
   }), /Fill in the release note section/)
+})
+
+test('paginated pull request results are flattened', () => {
+  assert.deepEqual(normalizePullRequestPages([
+    {
+      data: {
+        repository: {
+          pullRequests: {
+            nodes: [{
+              body: 'First',
+              mergeCommit: { oid: 'first' },
+              mergedAt: '2026-01-01T00:00:00Z',
+              number: 1,
+              title: 'First PR',
+              url: 'https://github.com/OpenTubeX/OpenTubeX/pull/1',
+            }],
+          },
+        },
+      },
+    },
+    {
+      data: {
+        repository: {
+          pullRequests: {
+            nodes: [{
+              body: 'Second',
+              mergeCommit: { oid: 'second' },
+              mergedAt: '2026-02-01T00:00:00Z',
+              number: 2,
+              title: 'Second PR',
+              url: 'https://github.com/OpenTubeX/OpenTubeX/pull/2',
+            }],
+          },
+        },
+      },
+    },
+  ]), [{
+    body: 'First',
+    mergeCommit: { oid: 'first' },
+    mergedAt: '2026-01-01T00:00:00Z',
+    number: 1,
+    title: 'First PR',
+    url: 'https://github.com/OpenTubeX/OpenTubeX/pull/1',
+  }, {
+    body: 'Second',
+    mergeCommit: { oid: 'second' },
+    mergedAt: '2026-02-01T00:00:00Z',
+    number: 2,
+    title: 'Second PR',
+    url: 'https://github.com/OpenTubeX/OpenTubeX/pull/2',
+  }])
 })
 
 test('a release note and optional Markdown image are parsed', () => {


### PR DESCRIPTION
## Pull Request Type
- [ ] Bugfix
- [x] Feature Implementation
- [ ] Documentation
- [ ] Other

## Related issue

## Description
Extends the release-draft workflow so every pull request selects exactly one release-note category

The generator now reads all merged pull requests, skips entries marked as not noteworthy, and groups the remaining notes under Highlights, More improvements, or Fixed bugs

## Screenshots

Not applicable

## Release note category
<!-- release-note-category:start -->
- [x] Not noteworthy
- [ ] Highlights
- [ ] More improvements
- [ ] Fixed bugs
<!-- release-note-category:end -->

## Release note
<!-- release-note:start -->
Release notes are now categorized as highlights, more improvements, or fixed bugs
<!-- release-note:end -->

## Release note image
<!-- release-note-image:start -->

<!-- release-note-image:end -->

## Testing
- `pnpm run test:unit`
- `pnpm run eslint-lint`
- `git diff --check`

## Desktop
- **OS:** Linux
- **OS Version:** N/A
- **OpenTubeX version:** 0.29.0

## Additional context

The existing `noteworthy-for-release` label is no longer required by draft generation