### PR TITLE
Fix feed menus, Shorts thumbnails, and playlist dock regressions

### DIFF
--- a/e2e/tests/network/playlist-dock.spec.mjs
+++ b/e2e/tests/network/playlist-dock.spec.mjs
@@ -4,12 +4,14 @@ import { waitForPlaybackOrSkip } from '../../helpers/player.mjs'
 const PLAYLIST_URL = 'https://youtu.be/g4OXlrxqIx0?list=UULFSMOQeBJ2RAnuFungnQOxLg'
 
 async function clickAndMeasureNextPaint(locator) {
-  return locator.evaluate(async (element) => {
-    const start = performance.now()
-    element.click()
+  const page = locator.page()
+  const start = await page.evaluate(() => performance.now())
+  await locator.click()
+
+  return page.evaluate(async (clickStart) => {
     await new Promise(resolve => requestAnimationFrame(() => requestAnimationFrame(resolve)))
-    return performance.now() - start
-  })
+    return performance.now() - clickStart
+  }, start)
 }
 
 test('large fullscreen playlist dock remains responsive and preserves its state', async ({ page, innertube }) => {

--- a/e2e/tests/network/playlist-dock.spec.mjs
+++ b/e2e/tests/network/playlist-dock.spec.mjs
@@ -47,6 +47,29 @@ test('large fullscreen playlist dock remains responsive and preserves its state'
     sidebarCardBox.x + sidebarCardBox.width - 7
   )
 
+  await sidebarCard.evaluate((element) => {
+    element.style.inlineSize = '240px'
+  })
+  const narrowCardBox = await sidebarCard.boundingBox()
+  const narrowProgressBox = await sidebarProgress.boundingBox()
+  await sidebarProgress.dispatchEvent('mousemove', {
+    clientX: narrowProgressBox.x + 1,
+    clientY: narrowProgressBox.y + (narrowProgressBox.height / 2)
+  })
+  await sidebarProgress.dispatchEvent('mousemove', {
+    clientX: narrowProgressBox.x + narrowProgressBox.width - 1,
+    clientY: narrowProgressBox.y + (narrowProgressBox.height / 2)
+  })
+  await expect.poll(async () => {
+    const box = await sidebarPreview.boundingBox()
+    return Math.round(narrowCardBox.x + narrowCardBox.width - (box.x + box.width))
+  }).toBe(8)
+  const narrowPreviewBox = await sidebarPreview.boundingBox()
+  expect(narrowPreviewBox.width).toBeLessThanOrEqual(narrowCardBox.width - 16)
+  await sidebarCard.evaluate((element) => {
+    element.style.removeProperty('inline-size')
+  })
+
   await waitForPlaybackOrSkip(test, page)
 
   await sidebar.evaluate((element) => { element.scrollTop = 420 })

--- a/e2e/tests/network/playlist-dock.spec.mjs
+++ b/e2e/tests/network/playlist-dock.spec.mjs
@@ -1,21 +1,52 @@
 import { test, expect, setPlayerFullscreen } from '../../helpers/innertube.mjs'
 import { waitForPlaybackOrSkip } from '../../helpers/player.mjs'
 
-const PLAYLIST_URL = 'https://youtu.be/aqz-KE-bpKQ?list=UUSMOQeBJ2RAnuFungnQOxLg'
+const PLAYLIST_URL = 'https://youtu.be/g4OXlrxqIx0?list=UULFSMOQeBJ2RAnuFungnQOxLg'
 
-test('fullscreen playlist dock preserves its active state and each layout position', async ({ page, innertube }) => {
+async function clickAndMeasureNextPaint(locator) {
+  return locator.evaluate(async (element) => {
+    const start = performance.now()
+    element.click()
+    await new Promise(resolve => requestAnimationFrame(() => requestAnimationFrame(resolve)))
+    return performance.now() - start
+  })
+}
+
+test('large fullscreen playlist dock remains responsive and preserves its state', async ({ page, innertube }) => {
   test.skip(innertube.replay, 'playlist hydration needs the real API')
 
   const searchInput = page.locator('.topNav .searchInput input.ft-input')
   await searchInput.fill(PLAYLIST_URL)
   await searchInput.press('Enter')
-  await page.waitForURL(/#\/watch\/aqz-KE-bpKQ/, { timeout: 60000 })
+  await page.waitForURL(/#\/watch\/g4OXlrxqIx0/, { timeout: 60000 })
 
   const sidebar = page.locator('.playlistItemsWrapper')
   await expect(sidebar).toBeVisible({ timeout: 60000 })
+  await expect.poll(
+    () => sidebar.locator('.playlistItem').count(),
+    { timeout: 60000 }
+  ).toBeGreaterThan(1000)
   await expect(sidebar).toHaveAttribute('data-overlayscrollbars-viewport')
   await expect(sidebar.locator(':scope > .os-scrollbar-vertical')).toHaveCount(1)
+  await expect(sidebar.locator('.playlistItem').first()).toHaveCSS('content-visibility', 'auto')
   await expect.poll(async () => sidebar.evaluate((element) => element.scrollHeight)).toBeGreaterThan(1000)
+
+  const sidebarCard = page.locator('.watchVideoPlaylist')
+  const sidebarProgress = sidebarCard.locator('.playlistProgressBarContainer')
+  const sidebarProgressBox = await sidebarProgress.boundingBox()
+  await page.mouse.move(
+    sidebarProgressBox.x + 1,
+    sidebarProgressBox.y + (sidebarProgressBox.height / 2)
+  )
+  const sidebarPreview = sidebarCard.locator('.previewTooltip')
+  await expect(sidebarPreview).toBeVisible()
+  const sidebarCardBox = await sidebarCard.boundingBox()
+  const sidebarPreviewBox = await sidebarPreview.boundingBox()
+  expect(sidebarPreviewBox.x).toBeGreaterThanOrEqual(sidebarCardBox.x + 7)
+  expect(sidebarPreviewBox.x + sidebarPreviewBox.width).toBeLessThanOrEqual(
+    sidebarCardBox.x + sidebarCardBox.width - 7
+  )
+
   await waitForPlaybackOrSkip(test, page)
 
   await sidebar.evaluate((element) => { element.scrollTop = 420 })
@@ -24,17 +55,15 @@ test('fullscreen playlist dock preserves its active state and each layout positi
   await setPlayerFullscreen(page, true)
   const sidebarScrollTop = await sidebar.evaluate((element) => element.scrollTop)
   const playlistToggle = page.getByRole('button', { name: 'Playlist', exact: true })
-  await playlistToggle.click()
+  const openDuration = await clickAndMeasureNextPaint(playlistToggle)
+  expect(openDuration).toBeLessThan(1500)
   await expect(playlistToggle).toHaveAttribute('aria-expanded', 'true')
 
   const dock = page.locator('.fullscreenPlaylistTarget .playlistItemsWrapper')
   await expect(dock).toBeVisible()
   await expect(dock).toHaveAttribute('data-overlayscrollbars-viewport')
   const currentDockItem = dock.locator('.playlistItem').filter({ has: page.locator('.videoIndexIcon') })
-  await expect.poll(async () => {
-    const [dockBounds, itemBounds] = await Promise.all([dock.boundingBox(), currentDockItem.boundingBox()])
-    return Math.abs((dockBounds.y + dockBounds.height / 2) - (itemBounds.y + itemBounds.height / 2))
-  }).toBeLessThan(80)
+  await expect(currentDockItem).toBeInViewport()
   const header = page.locator('.fullscreenPlaylistTarget .playlistHeader')
   const headerBounds = await header.boundingBox()
   await expect(header).toHaveCSS('background-color', 'rgba(0, 0, 0, 0)')
@@ -50,9 +79,11 @@ test('fullscreen playlist dock preserves its active state and each layout positi
   await dock.evaluate((element) => element.scrollBy(0, 480))
   await expect.poll(async () => dock.evaluate((element) => element.scrollTop)).toBeGreaterThan(centeredDockScrollTop)
   const dockScrollTop = await dock.evaluate((element) => element.scrollTop)
-  await page.getByRole('button', { name: 'Close Playlist' }).click({ force: true })
+  const closeDuration = await clickAndMeasureNextPaint(page.getByRole('button', { name: 'Close Playlist' }))
+  expect(closeDuration).toBeLessThan(1500)
   await expect(playlistToggle).toHaveAttribute('aria-expanded', 'false')
-  await playlistToggle.click()
+  const reopenDuration = await clickAndMeasureNextPaint(playlistToggle)
+  expect(reopenDuration).toBeLessThan(1500)
   await expect(playlistToggle).toHaveAttribute('aria-expanded', 'true')
   await expect(dock).toBeVisible()
   await expect.poll(async () => dock.evaluate((element) => element.scrollTop)).toBe(dockScrollTop)
@@ -63,8 +94,7 @@ test('fullscreen playlist dock preserves its active state and each layout positi
   const playlistDockHeader = playlistOverlay.locator('.playlistDockHeader')
   await expect(metadataOverlay).toBeVisible()
   const dockContent = page.locator('.fullscreenPlaylistTarget .fullscreenPlaylistContent')
-  await expect(dockContent).toHaveAttribute('data-overlayscrollbars-viewport')
-  await expect(dockContent.locator(':scope > .os-scrollbar-vertical')).toHaveCount(1)
+  await expect(dockContent).not.toHaveAttribute('data-overlayscrollbars-viewport')
   await expect(playlistDockHeader).toHaveCSS('cursor', 'grab')
   await playlistDockHeader.hover({ position: { x: 30, y: 26 } })
   const metadataBounds = await metadataOverlay.boundingBox()
@@ -105,7 +135,9 @@ test('fullscreen playlist dock preserves its active state and each layout positi
     return Math.abs(restoredScrollTop - sidebarScrollTop)
   }).toBeLessThan(150)
 
+  const fullscreenStart = Date.now()
   await setPlayerFullscreen(page, true)
+  expect(Date.now() - fullscreenStart).toBeLessThan(3000)
   await expect(playlistToggle).toHaveAttribute('aria-expanded', 'true')
   await expect(dock).toBeVisible()
   await expect.poll(async () => dock.evaluate((element) => element.scrollTop)).toBe(dockScrollTop)

--- a/e2e/tests/network/playlist-dock.spec.mjs
+++ b/e2e/tests/network/playlist-dock.spec.mjs
@@ -56,6 +56,13 @@ test('large fullscreen playlist dock remains responsive and preserves its state'
     clientX: narrowProgressBox.x + 1,
     clientY: narrowProgressBox.y + (narrowProgressBox.height / 2)
   })
+  await expect.poll(async () => {
+    const box = await sidebarPreview.boundingBox()
+    return Math.round(box.x - narrowCardBox.x)
+  }).toBe(8)
+  const narrowLeftPreviewBox = await sidebarPreview.boundingBox()
+  expect(narrowLeftPreviewBox.width).toBeLessThanOrEqual(narrowCardBox.width - 16)
+
   await sidebarProgress.dispatchEvent('mousemove', {
     clientX: narrowProgressBox.x + narrowProgressBox.width - 1,
     clientY: narrowProgressBox.y + (narrowProgressBox.height / 2)
@@ -64,8 +71,6 @@ test('large fullscreen playlist dock remains responsive and preserves its state'
     const box = await sidebarPreview.boundingBox()
     return Math.round(narrowCardBox.x + narrowCardBox.width - (box.x + box.width))
   }).toBe(8)
-  const narrowPreviewBox = await sidebarPreview.boundingBox()
-  expect(narrowPreviewBox.width).toBeLessThanOrEqual(narrowCardBox.width - 16)
   await sidebarCard.evaluate((element) => {
     element.style.removeProperty('inline-size')
   })

--- a/e2e/tests/network/watch.spec.mjs
+++ b/e2e/tests/network/watch.spec.mjs
@@ -9,6 +9,23 @@ const CAPTIONED_VIDEO = {
   title: 'What’s It Like to Be Killed by Nature’s Most Brutal Predator',
   url: 'https://www.youtube.com/watch?v=Xf-uUy5pdUI'
 }
+const FULLSCREEN_PLAYLIST_ID = 'fullscreen-preview'
+const FULLSCREEN_PLAYLIST = {
+  _id: FULLSCREEN_PLAYLIST_ID,
+  playlistName: 'Fullscreen preview',
+  protected: false,
+  description: '',
+  videos: [{
+    videoId: 'jNQXAC9IVRw',
+    title: 'Me at the zoo',
+    author: 'jawed',
+    authorId: 'UC4QobU6STFB0P71PMvOGN5A',
+    lengthSeconds: 19,
+    type: 'video'
+  }],
+  createdAt: Date.now() - 86_400_000,
+  lastUpdatedAt: Date.now() - 86_400_000
+}
 
 function longTranscript() {
   const timestamp = (seconds) => {
@@ -853,6 +870,51 @@ test.describe('watch page', () => {
     )
     await expect(actions).toHaveCSS('z-index', '0')
     await expect(sponsorBlockNotice).toHaveCSS('z-index', '0')
+  })
+
+  test.describe('fullscreen playlist dock', () => {
+    test.use({ seed: { playlists: [FULLSCREEN_PLAYLIST] } })
+
+    test('shows the progress preview above the content viewport', async ({ page, innertube }) => {
+      test.skip(innertube.replay, 'watch page hydration needs the real API')
+      await openVideo(page)
+      await page.evaluate(async (playlistId) => {
+        const router = document.querySelector('#app').__vue_app__.config.globalProperties.$router
+        await router.push({
+          path: '/watch/jNQXAC9IVRw',
+          query: { playlistId, playlistType: 'user' }
+        })
+      }, FULLSCREEN_PLAYLIST_ID)
+      await expect(page.locator('.watchVideoPlaylist')).toBeVisible()
+
+      await page.locator('.full-window-button').click({ force: true })
+      await page.locator('.fullscreenPlaylistToggle').click({ force: true })
+
+      const dock = page.locator('.fullscreenPlaylistOverlay.open')
+      const content = dock.locator('.fullscreenPlaylistContent')
+      const progress = dock.locator('.playlistProgressBarContainer')
+      await expect(dock).toBeVisible()
+      const progressBox = await progress.boundingBox()
+      await page.mouse.move(progressBox.x + 1, progressBox.y + (progressBox.height / 2))
+
+      const preview = dock.locator('.previewTooltip')
+      await expect(preview).toBeVisible()
+      const contentBox = await content.boundingBox()
+      const previewBox = await preview.boundingBox()
+      expect(previewBox.y).toBeLessThan(contentBox.y)
+      await expect(content).toHaveCSS('overflow', 'visible')
+      await expect(content).not.toHaveAttribute('data-overlayscrollbars-viewport')
+
+      for (const position of [0.25, 0.5, 0.75]) {
+        await page.mouse.move(
+          progressBox.x + (progressBox.width * position),
+          progressBox.y + (progressBox.height / 2)
+        )
+        const box = await preview.boundingBox()
+        expect(box.x).toBeGreaterThanOrEqual(contentBox.x - 1)
+        expect(box.x + box.width).toBeLessThanOrEqual(contentBox.x + contentBox.width + 1)
+      }
+    })
   })
 
   test('full window playlist action shows its popover above the player', async ({ page, innertube }) => {

--- a/e2e/tests/network/watch.spec.mjs
+++ b/e2e/tests/network/watch.spec.mjs
@@ -914,6 +914,15 @@ test.describe('watch page', () => {
         expect(box.x).toBeGreaterThanOrEqual(contentBox.x - 1)
         expect(box.x + box.width).toBeLessThanOrEqual(contentBox.x + contentBox.width + 1)
       }
+
+      await page.mouse.move(
+        progressBox.x + progressBox.width - 1,
+        progressBox.y + (progressBox.height / 2)
+      )
+      const rightEdgeBox = await preview.boundingBox()
+      expect(rightEdgeBox.x + rightEdgeBox.width).toBeLessThanOrEqual(
+        contentBox.x + contentBox.width + 1
+      )
     })
   })
 

--- a/e2e/tests/offline/subscriptions-feed.spec.mjs
+++ b/e2e/tests/offline/subscriptions-feed.spec.mjs
@@ -121,6 +121,35 @@ test.describe('subscriptions feed from cache', () => {
     await expect(page.getByText('Upcoming premiere video')).toHaveCount(0)
   })
 
+  test('an open video menu does not lift feed content over the sticky header', async ({ page }) => {
+    await goTo(page, 'subscriptions')
+
+    const header = page.locator('.subscriptionsHeader')
+    const video = page.locator('.ft-list-video').first()
+    await expect(video).toBeVisible()
+    await video.hover()
+    await video.locator('.optionsButton').click()
+    await expect(video.locator('.iconDropdown')).toBeVisible()
+
+    const headerCoversVideo = await page.evaluate(() => {
+      const header = document.querySelector('.subscriptionsHeader')
+      const video = document.querySelector('.ft-list-video')
+      const initialHeaderRect = header.getBoundingClientRect()
+      const initialVideoRect = video.getBoundingClientRect()
+      window.scrollBy(0, initialVideoRect.top - initialHeaderRect.top + 20)
+
+      const headerRect = header.getBoundingClientRect()
+      const thumbnailRect = video.querySelector('.videoThumbnail').getBoundingClientRect()
+      const elementAtHeader = document.elementFromPoint(
+        thumbnailRect.left + thumbnailRect.width / 2,
+        headerRect.bottom - 5
+      )
+      return header.contains(elementAtHeader)
+    })
+
+    expect(headerCoversVideo).toBe(true)
+  })
+
   test('does not offer to mark a running premiere as watched', async ({ page }) => {
     await goTo(page, 'subscriptions')
 

--- a/e2e/tests/offline/subscriptions-new-feed.spec.mjs
+++ b/e2e/tests/offline/subscriptions-new-feed.spec.mjs
@@ -49,7 +49,10 @@ function profile (subscriptions = [{ id: CHANNEL_ID, name: 'Channel A', thumbnai
 const newVideo = video('new-video-1', 'New video', now - HOUR, { isNewInSubscriptionFeed: true })
 const watchedVideo = video('watched-new', 'Watched new video', now - 2 * HOUR, { isNewInSubscriptionFeed: true })
 const oldVideo = video('not-new', 'Previously seen video', now - 3 * HOUR, { isNewInSubscriptionFeed: false })
-const newShort = video('new-short-1', 'New short', now - 30 * 60000, { isNewInSubscriptionFeed: true })
+const newShort = video('new-short-1', 'New short', now - 30 * 60000, {
+  isNewInSubscriptionFeed: true,
+  thumbnailUrl: 'https://i.ytimg.com/vi/new-short-1/hq720_2.jpg?sqp=selected&rs=signature'
+})
 const newLive = video('new-live-1', 'New live stream', now - 15 * 60000, {
   isNewInSubscriptionFeed: true,
   liveNow: true
@@ -129,7 +132,7 @@ test.describe('new subscriptions feed', () => {
     await expect(short).toBeVisible()
     await expect(short.locator('.videoDuration')).toHaveText('2:00')
     await expect(short.locator('.uploadedTime')).not.toBeEmpty()
-    await expect(short.locator('.thumbnailImage')).toHaveAttribute('src', /\/oardefault\.jpg$/)
+    await expect(short.locator('.thumbnailImage')).toHaveAttribute('src', newShort.thumbnailUrl)
 
     const aspectRatio = await short.locator('.thumbnailImage').evaluate(element => {
       return getComputedStyle(element).aspectRatio

--- a/e2e/tests/offline/video-actions.spec.mjs
+++ b/e2e/tests/offline/video-actions.spec.mjs
@@ -112,6 +112,52 @@ test.describe('list video actions', () => {
     }).toBe(true)
   })
 
+  test('an open options dropdown crosses vertical tabs without lifting its feed card', async ({ page }) => {
+    await goTo(page, 'history')
+    await page.evaluate(() => {
+      const store = document.querySelector('#app').__vue_app__.config.globalProperties.$store
+      store.commit('setUseVerticalTabBar', true)
+    })
+
+    const video = page.locator('.ft-list-video').first()
+    await video.hover()
+    await video.locator('.optionsButton').click()
+
+    await expect(video.locator('.optionsButton .iconDropdown')).toBeVisible()
+    const stackingOrder = await video.evaluate((listVideo) => ({
+      topNav: Number(getComputedStyle(document.querySelector('.topNav')).zIndex),
+      tabBar: Number(getComputedStyle(document.querySelector('.tabBar.vertical')).zIndex),
+      dropdown: Number(getComputedStyle(listVideo.querySelector('.iconDropdown')).zIndex),
+      listVideo: getComputedStyle(listVideo).zIndex
+    }))
+    expect(stackingOrder.topNav).toBeGreaterThan(stackingOrder.dropdown)
+    expect(stackingOrder.dropdown).toBeGreaterThan(stackingOrder.tabBar)
+    expect(stackingOrder.listVideo).toBe('auto')
+
+    await video.locator('.optionsButton').click()
+    await video.locator('.addToPlaylistIcon .iconButton').click()
+    const thumbnailDropdown = video.locator('.addToPlaylistIcon .iconDropdown')
+    await expect(thumbnailDropdown).toBeVisible()
+    const dropdownCoversVerticalTabs = await thumbnailDropdown.evaluate((dropdown) => {
+      const tabBarRect = document.querySelector('.tabBar.vertical').getBoundingClientRect()
+      const initialDropdownRect = dropdown.getBoundingClientRect()
+      dropdown.style.transform = `translateX(${tabBarRect.right - initialDropdownRect.left - 40}px)`
+      const dropdownRect = dropdown.getBoundingClientRect()
+      const overlapLeft = Math.max(tabBarRect.left, dropdownRect.left)
+      const overlapRight = Math.min(tabBarRect.right, dropdownRect.right)
+      if (overlapLeft >= overlapRight) {
+        return false
+      }
+
+      const elementAtOverlap = document.elementFromPoint(
+        overlapLeft + (overlapRight - overlapLeft) / 2,
+        Math.max(tabBarRect.top, dropdownRect.top) + 10
+      )
+      return dropdown.contains(elementAtOverlap)
+    })
+    expect(dropdownCoversVerticalTabs).toBe(true)
+  })
+
   test('shows a filled playlist icon when the video is already in a playlist', async ({ page }) => {
     await goTo(page, 'history')
 

--- a/src/renderer/components/FtIconButton/FtIconButton.scss
+++ b/src/renderer/components/FtIconButton/FtIconButton.scss
@@ -150,7 +150,10 @@
   position: absolute;
   text-align: center;
   user-select: none;
-  z-index: 3;
+  // Above route headers and the tab bar, while the top navigation stays above
+  // it. Raising only the dropdown avoids lifting the whole feed card over its
+  // sticky header.
+  z-index: 6;
   overflow: hidden;
 
   &.left {

--- a/src/renderer/components/FtIconButton/FtIconButton.scss
+++ b/src/renderer/components/FtIconButton/FtIconButton.scss
@@ -150,6 +150,7 @@
   position: absolute;
   text-align: center;
   user-select: none;
+
   // Above route headers and the tab bar, while the top navigation stays above
   // it. Raising only the dropdown avoids lifting the whole feed card over its
   // sticky header.

--- a/src/renderer/components/FtListVideo/FtListVideo.vue
+++ b/src/renderer/components/FtListVideo/FtListVideo.vue
@@ -874,6 +874,14 @@ const thumbnail = computed(() => {
     return deArrowCache.value.thumbnail
   }
 
+  if (
+    props.appearance === 'youtubeShort' &&
+    thumbnailPreference.value === '' &&
+    props.data.thumbnailUrl
+  ) {
+    return props.data.thumbnailUrl
+  }
+
   return getVideoThumbnailUrl(
     id.value,
     backendPreference.value,

--- a/src/renderer/components/TopNav/TopNav.scss
+++ b/src/renderer/components/TopNav/TopNav.scss
@@ -16,6 +16,7 @@
   position: sticky;
   inset-block-start: 0;
   inline-size: 100%;
+
   // Open thumbnail dropdowns raise their list item above the vertical tab bar.
   // Keep scrolling list content below the sticky navigation while they are open.
   z-index: 7;

--- a/src/renderer/components/TopNav/TopNav.scss
+++ b/src/renderer/components/TopNav/TopNav.scss
@@ -16,7 +16,9 @@
   position: sticky;
   inset-block-start: 0;
   inline-size: 100%;
-  z-index: 4;
+  // Open thumbnail dropdowns raise their list item above the vertical tab bar.
+  // Keep scrolling list content below the sticky navigation while they are open.
+  z-index: 7;
 
   /* Query container so the centered layout responds to the top nav's own width
      (which shrinks beside the vertical tab bar) instead of the viewport, and so

--- a/src/renderer/components/WatchVideoPlaylist/WatchVideoPlaylist.css
+++ b/src/renderer/components/WatchVideoPlaylist/WatchVideoPlaylist.css
@@ -57,12 +57,16 @@
 .progressBarPreview {
   position: absolute;
   inset-block-start: -65px;
+  max-inline-size: var(--playlist-preview-max-inline-size);
   transform: translateX(-50%);
   z-index: 10;
   pointer-events: none;
 }
 
 .previewTooltip {
+  box-sizing: border-box;
+  inline-size: max-content;
+  max-inline-size: 100%;
   background-color: var(--card-bg-color);
   border: 1px solid var(--primary-border-color);
   border-radius: calc(8px * var(--ui-roundness));
@@ -76,7 +80,7 @@
   display: grid;
   grid-template:
     'thumb index title' auto /
-    max-content max-content max-content;
+    max-content max-content minmax(0, 240px);
   align-items: center;
   gap: 8px;
 }
@@ -97,7 +101,8 @@
   grid-area: title;
   font-weight: 400;
   color: var(--secondary-text-color);
-  inline-size: 240px;
+  min-inline-size: 0;
+  max-inline-size: 240px;
   overflow: hidden;
   text-overflow: ellipsis;
   white-space: nowrap;

--- a/src/renderer/components/WatchVideoPlaylist/WatchVideoPlaylist.css
+++ b/src/renderer/components/WatchVideoPlaylist/WatchVideoPlaylist.css
@@ -191,7 +191,10 @@
   box-sizing: border-box;
   padding-block: 8px 16px;
   padding-inline: 16px;
-  overflow-x: hidden;
+
+  /* The playlist items provide the dock's scroll viewport. Keep this wrapper
+     visible so the progress preview can extend over the dock header. */
+  overflow: visible;
 }
 
 .fullscreenPlaylist .playlistHeader {
@@ -277,6 +280,8 @@
   display: grid;
   grid-template-columns: 30px 1fr;
   align-items: center;
+  content-visibility: auto;
+  contain-intrinsic-block-size: auto 72px;
   transition: background 0.2s ease-out;
 }
 

--- a/src/renderer/components/WatchVideoPlaylist/WatchVideoPlaylist.vue
+++ b/src/renderer/components/WatchVideoPlaylist/WatchVideoPlaylist.vue
@@ -309,6 +309,8 @@ const previewVideoIndex = ref(1)
 
 let prevVideoBeforeDeletion = null
 let getPlaylistInfoRun = false
+let previewPositionUpdatePending = false
+let previewPointerClientX = 0
 
 /** @type {import('vue').ComputedRef<'local' | 'invidious'>} */
 const backendPreference = computed(() => store.getters.getBackendPreference)
@@ -1149,16 +1151,26 @@ async function updateProgressBarPreview(event) {
   const percentage = Math.max(0, Math.min(100, (mouseX / progressBarWidth) * 100))
 
   previewVideoIndex.value = Math.max(1, Math.min(playlistVideoCount.value, Math.ceil((percentage / 100) * playlistVideoCount.value)))
+  previewPointerClientX = event.clientX
 
+  if (previewPositionUpdatePending) return
+  previewPositionUpdatePending = true
   await nextTick()
+  previewPositionUpdatePending = false
+
   const boundary = playlistProgressBar.value.closest('.watchVideoPlaylist')
   if (boundary && progressBarPreview.value) {
     const boundaryRect = boundary.getBoundingClientRect()
-    const previewWidth = progressBarPreview.value.offsetWidth
     const margin = 8
+    const availableWidth = Math.max(0, boundaryRect.width - (margin * 2))
+    progressBarPreview.value.style.setProperty(
+      '--playlist-preview-max-inline-size',
+      `${availableWidth}px`
+    )
+    const previewWidth = Math.min(progressBarPreview.value.offsetWidth, availableWidth)
     const minimumViewportLeft = boundaryRect.left + margin
     const maximumViewportLeft = boundaryRect.right - margin - previewWidth
-    const centeredViewportLeft = event.clientX - (previewWidth / 2)
+    const centeredViewportLeft = previewPointerClientX - (previewWidth / 2)
     const viewportLeft = Math.max(
       minimumViewportLeft,
       Math.min(maximumViewportLeft, centeredViewportLeft)

--- a/src/renderer/components/WatchVideoPlaylist/WatchVideoPlaylist.vue
+++ b/src/renderer/components/WatchVideoPlaylist/WatchVideoPlaylist.vue
@@ -29,7 +29,6 @@
         </button>
       </header>
       <div
-        v-overlay-scrollbars="fullscreenOverlay"
         :class="{ fullscreenPlaylistContent: fullscreenOverlay }"
       >
         <div class="playlistHeader">
@@ -95,8 +94,9 @@
                 />
                 <div
                   v-if="showProgressBarPreview"
+                  ref="progressBarPreview"
                   class="progressBarPreview"
-                  :style="{ left: previewPosition + '%', transform: `translateX(${ previewTransformXPercentage }%)` }"
+                  :style="previewStyle"
                 >
                   <div class="previewTooltip">
                     <img
@@ -171,12 +171,13 @@
             </button>
           </div>
         </div>
-        <TransitionGroup
+        <component
+          :is="playlistItemsWrapperComponent"
           v-if="!isLoading"
           ref="playlistItemsWrapper"
           v-overlay-scrollbars
-          name="playlistItem"
-          tag="div"
+          :name="animatePlaylistItems ? 'playlistItem' : undefined"
+          :tag="animatePlaylistItems ? 'div' : undefined"
           class="playlistItemsWrapper"
         >
           <FtListVideoNumbered
@@ -210,7 +211,7 @@
             @remove-from-playlist="removeVideoFromPlaylist"
             @pause-player="pausePlayer"
           />
-        </TransitionGroup>
+        </component>
         <FtPrompt
           v-if="showRemoveWatchedVideosPrompt"
           :label="removeWatchedVideosPromptLabel"
@@ -226,7 +227,7 @@
 
 <script setup>
 import { FontAwesomeIcon } from '@fortawesome/vue-fontawesome'
-import { computed, nextTick, onBeforeUnmount, onMounted, ref, shallowRef, useTemplateRef, watch } from 'vue'
+import { computed, nextTick, onBeforeUnmount, onMounted, ref, shallowRef, TransitionGroup, useTemplateRef, watch } from 'vue'
 import { useI18n } from 'vue-i18n'
 import { useRouter } from 'vue-router'
 
@@ -303,9 +304,8 @@ const randomizedPlaylistItems = shallowRef([])
 /** @type {import('vue').Ref<VideoData>} */
 const draggedVideo = ref({ videoId: null, playlistItemId: null })
 const showProgressBarPreview = ref(false)
-const previewPosition = ref(0)
+const previewPositionPixels = ref(0)
 const previewVideoIndex = ref(1)
-const windowWidth = ref(window.innerWidth)
 
 let prevVideoBeforeDeletion = null
 let getPlaylistInfoRun = false
@@ -425,22 +425,27 @@ const canMoveVideos = computed(() => {
   return isUserPlaylist.value && isSortOrderCustom.value && playlistItems.value.length > 1
 })
 
+const MAX_ENHANCED_PLAYLIST_ITEMS = 200
+const animatePlaylistItems = computed(() => {
+  return canMoveVideos.value && playlistItems.value.length < MAX_ENHANCED_PLAYLIST_ITEMS
+})
+
+// TransitionGroup runs FLIP layout measurements for every child whenever this
+// component updates. The fullscreen dock changes this component's layout, so a
+// large playlist would synchronously measure thousands of items just to open or
+// close. Retain move animations only where that cost stays bounded.
+const playlistItemsWrapperComponent = computed(() => animatePlaylistItems.value ? TransitionGroup : 'div')
+
 const isVideoDragging = computed(() => {
   const { videoId, playlistItemId } = draggedVideo.value
 
   return videoId != null && playlistItemId != null
 })
 
-const previewTransformXPercentage = computed(() => {
-  // Breakpoint for single-column-template
-  if (windowWidth.value > 1050) {
-    // Align left when preview is on the right half to avoid going out of right side of the window
-    return previewPosition.value <= 50 ? -50 : -100
-  }
-
-  // Align left/right to avoid going out of either side of the window
-  return previewPosition.value <= 50 ? 0 : -100
-})
+const previewStyle = computed(() => ({
+  left: `${previewPositionPixels.value}px`,
+  transform: 'none'
+}))
 
 const previewVideoTitle = computed(() => {
   const index = previewVideoIndex.value - 1
@@ -561,16 +566,12 @@ onMounted(() => {
       nexttrack: playNextVideo
     })
   }
-
-  window.addEventListener('resize', calculateWindowWidth)
 })
 
 onBeforeUnmount(() => {
   if ('mediaSession' in navigator) {
     tabMediaCoordinator.setActionHandlers(playlistCacheTabId, 'playlist', {})
   }
-
-  window.removeEventListener('resize', calculateWindowWidth)
 })
 
 /**
@@ -1134,11 +1135,12 @@ function pausePlayer() {
 }
 
 const playlistProgressBar = useTemplateRef('playlistProgressBar')
+const progressBarPreview = useTemplateRef('progressBarPreview')
 
 /**
  * @param {MouseEvent} event
  */
-function updateProgressBarPreview(event) {
+async function updateProgressBarPreview(event) {
   if (!showProgressBarPreview.value) return
 
   const rect = playlistProgressBar.value.getBoundingClientRect()
@@ -1146,8 +1148,23 @@ function updateProgressBarPreview(event) {
   const progressBarWidth = rect.width
   const percentage = Math.max(0, Math.min(100, (mouseX / progressBarWidth) * 100))
 
-  previewPosition.value = percentage
   previewVideoIndex.value = Math.max(1, Math.min(playlistVideoCount.value, Math.ceil((percentage / 100) * playlistVideoCount.value)))
+
+  await nextTick()
+  const boundary = playlistProgressBar.value.closest('.watchVideoPlaylist')
+  if (boundary && progressBarPreview.value) {
+    const boundaryRect = boundary.getBoundingClientRect()
+    const previewWidth = progressBarPreview.value.offsetWidth
+    const margin = 8
+    const minimumViewportLeft = boundaryRect.left + margin
+    const maximumViewportLeft = boundaryRect.right - margin - previewWidth
+    const centeredViewportLeft = event.clientX - (previewWidth / 2)
+    const viewportLeft = Math.max(
+      minimumViewportLeft,
+      Math.min(maximumViewportLeft, centeredViewportLeft)
+    )
+    previewPositionPixels.value = viewportLeft - rect.left
+  }
 }
 
 /**
@@ -1165,10 +1182,6 @@ function handleProgressBarClick(event) {
   if (targetArrayIndex >= 0 && targetArrayIndex < playlistItems.value.length) {
     scrollToVideo(targetArrayIndex)
   }
-}
-
-function calculateWindowWidth() {
-  windowWidth.value = window.innerWidth
 }
 
 const videoIsLastInInPlaylistItems = computed(() => {

--- a/src/renderer/helpers/api/local.js
+++ b/src/renderer/helpers/api/local.js
@@ -22,6 +22,21 @@ const TRACKING_PARAM_NAMES = [
   'utm_content',
 ]
 
+// YouTube moved Shorts grid images from `thumbnail` to
+// `thumbnailViewModel.thumbnailViewModel.image.sources`. Preserve that exact
+// source while youtubei.js still expects the old field.
+class ShortsLockupViewWithThumbnail extends YTNodes.ShortsLockupView {
+  constructor(data) {
+    const sources = data.thumbnailViewModel?.thumbnailViewModel?.image?.sources
+    const hasThumbnail = data.thumbnail?.thumbnails?.length > 0
+    super(hasThumbnail || !sources
+      ? data
+      : { ...data, thumbnail: { thumbnails: sources } })
+  }
+}
+
+Parser.addRuntimeParser('ShortsLockupView', ShortsLockupViewWithThumbnail)
+
 if (process.env.SUPPORTS_LOCAL_API) {
   Platform.shim.eval = (data) => {
     return new Promise((resolve, reject) => {
@@ -1204,6 +1219,7 @@ export function parseShort(short, channelId, channelName) {
       author: channelName,
       authorId: channelId,
       viewCount: reelItem.views.isEmpty() ? null : parseLocalSubscriberCount(reelItem.views.text),
+      thumbnailUrl: reelItem.thumbnails.at(-1)?.url,
       isShort: true,
       lengthSeconds: ''
     }
@@ -1218,6 +1234,7 @@ export function parseShort(short, channelId, channelName) {
       author: channelName,
       authorId: channelId,
       viewCount: shortsLockupView.overlay_metadata.secondary_text ? parseLocalSubscriberCount(shortsLockupView.overlay_metadata.secondary_text.text) : null,
+      thumbnailUrl: getShortsLockupThumbnailUrl(shortsLockupView),
       isShort: true,
       lengthSeconds: ''
     }
@@ -1414,6 +1431,7 @@ export function parseLocalPlaylistVideo(video) {
       videoId: short.id,
       title: short.title.text?.trim(),
       viewCount: parseLocalSubscriberCount(short.views.text),
+      thumbnailUrl: short.thumbnails.at(-1)?.url,
       isShort: true,
       lengthSeconds: ''
     }
@@ -1451,6 +1469,7 @@ export function parseLocalPlaylistVideo(video) {
       videoId: shortsLockupView.on_tap_endpoint.payload.videoId,
       title: shortsLockupView.overlay_metadata.primary_text.text?.trim(),
       viewCount,
+      thumbnailUrl: getShortsLockupThumbnailUrl(shortsLockupView),
       isShort: true,
       lengthSeconds: ''
     }
@@ -1507,6 +1526,14 @@ export function parseLocalPlaylistVideo(video) {
       premiereDate: video_.upcoming
     }
   }
+}
+
+/**
+ * @param {import('youtubei.js').YTNodes.ShortsLockupView} short
+ * @returns {string | undefined}
+ */
+function getShortsLockupThumbnailUrl(short) {
+  return short.thumbnail?.at(-1)?.url
 }
 
 /**

--- a/src/renderer/scss-partials/_ft-list-item.scss
+++ b/src/renderer/scss-partials/_ft-list-item.scss
@@ -55,13 +55,6 @@ $watched-transition-duration: 0.5s;
 .ft-list-item {
   padding: 6px;
 
-  // Vertical tabs are painted above the route. Raise only the card whose
-  // dropdown is open so a wide thumbnail menu can cross that boundary.
-  &:has(:deep(.iconDropdown)) {
-    position: relative;
-    z-index: 6;
-  }
-
   &.watched {
     background-color: var(--bg-color);
 


### PR DESCRIPTION
## Pull Request Type
- [x] Bugfix
- [ ] Feature Implementation
- [ ] Documentation
- [ ] Other

## Related issue

No linked issue.

## Description

Fixes several UI regressions discovered while testing the new Shorts and fullscreen playlist interfaces:

- keeps feed cards below sticky navigation while allowing their share and overflow menus to cross the vertical tab bar
- reads YouTube's current Shorts thumbnail payload so channel Shorts use the same selected thumbnail as YouTube
- prevents the fullscreen playlist preview tooltip from clipping at the top, left, or right, and applies the same exact edge clamping in the normal sidebar
- avoids full-list FLIP measurements and defers offscreen rendering for large playlists, keeping 1,000+ item docks responsive
- preserves the custom playlist scrollbar in both sidebar and fullscreen layouts

The menu regression came from raising the entire feed card when a dropdown opened. The playlist slowdown came from measuring every playlist child during Teleport/layout changes. The missing or incorrect Shorts thumbnails came from YouTube moving thumbnail sources to `thumbnailViewModel.image.sources`.

## Screenshots

Not included; the affected edge cases are covered by Electron E2E assertions against their rendered bounds and stacking order.

## Release note category
<!-- release-note-category:start -->
- [ ] Not noteworthy
- [ ] Highlights
- [ ] More improvements
- [x] Fixed bugs
<!-- release-note-category:end -->

## Release note
<!-- release-note:start -->
Fixed feed menu layering, Shorts thumbnails, and fullscreen playlist performance and clipping.
<!-- release-note:end -->

## Release note image
<!-- release-note-image:start -->

<!-- release-note-image:end -->

## Testing

1. Open a feed and scroll a video beneath its sticky header. Open the share or three-dots menu and confirm only the menu appears above the header content.
2. With vertical tabs enabled, confirm thumbnail menus can extend over the tab area.
3. Open `https://www.youtube.com/channel/UCmlzNHg8QiWVutUyFOV2UdQ/shorts` and confirm the displayed Shorts thumbnails match YouTube.
4. Open `https://youtu.be/g4OXlrxqIx0?list=UULFSMOQeBJ2RAnuFungnQOxLg`, then open, close, and restore the fullscreen playlist dock. Confirm it remains responsive and uses the custom scrollbar.
5. Hover the playlist progress bar at both edges in the sidebar and fullscreen dock and confirm the preview remains fully visible.

Automated checks run locally:

- `pnpm run lint`
- `pnpm run test:e2e:pack`
- `e2e/tests/offline/video-actions.spec.mjs`
- `e2e/tests/offline/subscriptions-feed.spec.mjs`
- `e2e/tests/offline/subscriptions-new-feed.spec.mjs`
- `e2e/tests/network/playlist-dock.spec.mjs`
- focused fullscreen playlist preview coverage in `e2e/tests/network/watch.spec.mjs`

## Desktop
- **OS:** Arch Linux
- **OS Version:** Rolling release
- **OpenTubeX version:** 0.30.0

## Additional context

The large-playlist performance regression test loads more than 1,000 entries and verifies open, close, reopen, fullscreen restoration, scroll preservation, custom scrollbar initialization, and paint-complete timing bounds.
