### PR TITLE
Group new feed content by category

### DIFF
--- a/e2e/tests/offline/subscriptions-new-feed.spec.mjs
+++ b/e2e/tests/offline/subscriptions-new-feed.spec.mjs
@@ -322,6 +322,15 @@ test.describe('new feed display filters', () => {
 })
 
 test.describe('new feed latest-per-channel limit', () => {
+  const publishedTimeShort = video('published-time-short', 'New short by published time', undefined, {
+    isNewInSubscriptionFeed: true,
+    publishedTime: now + HOUR
+  })
+  const latestLimitCache = [{
+    ...populatedCache[0],
+    shorts: [publishedTimeShort]
+  }]
+
   test.use({
     seed: {
       settings: {
@@ -330,7 +339,7 @@ test.describe('new feed latest-per-channel limit', () => {
         onlyShowLatestFromChannelNumber: 1
       },
       profiles: [profile()],
-      subscriptionCache: populatedCache
+      subscriptionCache: latestLimitCache
     }
   })
 
@@ -338,11 +347,11 @@ test.describe('new feed latest-per-channel limit', () => {
     await goTo(page, 'subscriptions')
     await page.locator('[data-subscription-feed-tab="all"]').click()
 
-    await expect(page.getByText('New live stream', { exact: true })).toBeVisible()
+    await expect(page.getByText('New short by published time', { exact: true })).toBeVisible()
     await expect(page.getByText('New video', { exact: true })).toHaveCount(0)
-    await expect(page.getByText('New short', { exact: true })).toHaveCount(0)
+    await expect(page.getByText('New live stream', { exact: true })).toHaveCount(0)
     await expect(page.getByRole('heading', { name: 'Videos', exact: true })).toHaveCount(0)
-    await expect(page.getByRole('heading', { name: 'Shorts', exact: true })).toHaveCount(0)
+    await expect(page.getByRole('heading', { name: 'Live', exact: true })).toHaveCount(0)
   })
 })
 

--- a/e2e/tests/offline/subscriptions-new-feed.spec.mjs
+++ b/e2e/tests/offline/subscriptions-new-feed.spec.mjs
@@ -102,11 +102,13 @@ test.describe('new subscriptions feed', () => {
     }
   })
 
-  test('combines new content without mixing posts into the media grid', async ({ page }) => {
+  test('groups new content by feed category', async ({ page }) => {
     await goTo(page, 'subscriptions')
     await page.locator('[data-subscription-feed-tab="all"]').click()
 
     await expect(page.getByRole('heading', { name: 'Videos', exact: true })).toBeVisible()
+    await expect(page.getByRole('heading', { name: 'Shorts', exact: true })).toBeVisible()
+    await expect(page.getByRole('heading', { name: 'Live', exact: true })).toBeVisible()
     await expect(page.getByRole('heading', { name: 'Posts', exact: true })).toBeVisible()
     await expect(page.getByText('New video', { exact: true })).toHaveCount(1)
     await expect(page.getByText('New short', { exact: true })).toBeVisible()
@@ -116,6 +118,8 @@ test.describe('new subscriptions feed', () => {
     await expect(page.getByText('Previously seen video', { exact: true })).toHaveCount(0)
 
     await expect(page.locator('.ft-list-video').filter({ hasText: 'New video' })).toHaveClass(/grid/)
+    await expect(page.locator('.ft-list-video').filter({ hasText: 'New short' })).toHaveClass(/youtubeShort/)
+    await expect(page.locator('.ft-list-video').filter({ hasText: 'New live stream' })).not.toHaveClass(/youtubeShort/)
     await expect(page.locator('.ft-list-post').filter({ hasText: 'New community post' })).toHaveClass(/list/)
     await expect(page.locator('.newContentDot')).toHaveCount(0)
     await expect(page.locator('.headerRefreshWidget .lastRefreshTimestamp')).toHaveCount(0)

--- a/e2e/tests/offline/subscriptions-new-feed.spec.mjs
+++ b/e2e/tests/offline/subscriptions-new-feed.spec.mjs
@@ -321,6 +321,31 @@ test.describe('new feed display filters', () => {
   })
 })
 
+test.describe('new feed latest-per-channel limit', () => {
+  test.use({
+    seed: {
+      settings: {
+        ...commonSettings,
+        onlyShowLatestFromChannel: true,
+        onlyShowLatestFromChannelNumber: 1
+      },
+      profiles: [profile()],
+      subscriptionCache: populatedCache
+    }
+  })
+
+  test('applies the limit across media categories', async ({ page }) => {
+    await goTo(page, 'subscriptions')
+    await page.locator('[data-subscription-feed-tab="all"]').click()
+
+    await expect(page.getByText('New live stream', { exact: true })).toBeVisible()
+    await expect(page.getByText('New video', { exact: true })).toHaveCount(0)
+    await expect(page.getByText('New short', { exact: true })).toHaveCount(0)
+    await expect(page.getByRole('heading', { name: 'Videos', exact: true })).toHaveCount(0)
+    await expect(page.getByRole('heading', { name: 'Shorts', exact: true })).toHaveCount(0)
+  })
+})
+
 test.describe('independent new feed setting', () => {
   test.use({
     seed: {

--- a/src/renderer/components/SubscriptionsNew.vue
+++ b/src/renderer/components/SubscriptionsNew.vue
@@ -154,7 +154,8 @@ const newMediaByCategory = computed(() => {
   }))
 
   mediaEntries.sort((a, b) => {
-    return (b.entry.published ?? 0) - (a.entry.published ?? 0)
+    return (b.entry.published ?? b.entry.publishedTime ?? 0) -
+      (a.entry.published ?? a.entry.publishedTime ?? 0)
   })
 
   if (store.getters.getOnlyShowLatestFromChannel) {

--- a/src/renderer/components/SubscriptionsNew.vue
+++ b/src/renderer/components/SubscriptionsNew.vue
@@ -3,11 +3,11 @@
     ref="tabUi"
     class="newFeed"
     :is-loading="isLoading"
-    :video-list="newMedia"
+    :video-list="newVideos"
     :error-channels="errorChannels"
     :attempted-fetch="attemptedFetch"
     :only-show-new="true"
-    :has-additional-content="newPosts.length > 0"
+    :has-additional-content="hasAdditionalContent"
     :track-global-refresh="false"
     stable-item-keys
     @refresh="refresh"
@@ -17,6 +17,33 @@
         {{ $t('Global.Videos') }}
       </h3>
     </template>
+    <Transition name="new-feed-section">
+      <section
+        v-if="newShorts.length > 0"
+        class="mediaSection"
+      >
+        <h3>{{ $t('Global.Shorts') }}</h3>
+        <FtElementList
+          :data="newShorts"
+          stable-item-keys
+          :youtube-style-shorts="useCustomShortsPlayer"
+          :use-channels-hidden-preference="false"
+        />
+      </section>
+    </Transition>
+    <Transition name="new-feed-section">
+      <section
+        v-if="newLive.length > 0"
+        class="mediaSection"
+      >
+        <h3>{{ $t('Global.Live') }}</h3>
+        <FtElementList
+          :data="newLive"
+          stable-item-keys
+          :use-channels-hidden-preference="false"
+        />
+      </section>
+    </Transition>
     <Transition name="new-feed-section">
       <section
         v-if="newPosts.length > 0"
@@ -55,6 +82,7 @@ import store from '../store/index'
 
 import { useRefreshAllSubscriptionFeeds } from '../composables/useRefreshAllSubscriptionFeeds'
 import { isHistoryEntryWatched } from '../helpers/history'
+import { isVideoHiddenByPreferences } from '../helpers/subscriptions'
 
 const { t } = useI18n()
 const tabUi = useTemplateRef('tabUi')
@@ -69,11 +97,16 @@ const {
   showRefreshWarning
 } = useRefreshAllSubscriptionFeeds()
 
-const newContent = computed(() => {
-  const entries = []
+const newContentByCategory = computed(() => {
+  const entries = {
+    videos: [],
+    shorts: [],
+    live: [],
+    posts: []
+  }
   const seenIds = new Set()
 
-  enabledFeeds.value.forEach(({ cache, entriesKey }) => {
+  enabledFeeds.value.forEach(({ category, cache, entriesKey }) => {
     Object.entries(cache).forEach(([channelId, cacheEntry]) => {
       if (!activeSubscriptionIds.value.has(channelId)) {
         return
@@ -94,31 +127,71 @@ const newContent = computed(() => {
         }
 
         seenIds.add(id)
-        entries.push({ ...entry, hideNewSubscriptionFeedIndicator: true })
+        entries[category].push({ ...entry, hideNewSubscriptionFeedIndicator: true })
       })
     })
   })
 
-  return entries.sort((a, b) => {
-    return (b.published ?? b.publishedTime ?? 0) - (a.published ?? a.publishedTime ?? 0)
+  Object.values(entries).forEach(categoryEntries => {
+    categoryEntries.sort((a, b) => {
+      return (b.published ?? b.publishedTime ?? 0) - (a.published ?? a.publishedTime ?? 0)
+    })
   })
+
+  return entries
 })
 
-const newMedia = computed(() => newContent.value.filter(entry => entry.videoId != null))
 const forbiddenTitles = computed(() => store.getters.getForbiddenTitlesParsed)
-const newPosts = computed(() => newContent.value.filter(entry => {
+const newVideos = computed(() => newContentByCategory.value.videos)
+const newShorts = computed(() => filterNewMedia(newContentByCategory.value.shorts))
+const newLive = computed(() => filterNewMedia(newContentByCategory.value.live))
+const newPosts = computed(() => newContentByCategory.value.posts.filter(entry => {
   const lowerCaseAuthor = entry.author?.toLowerCase()
 
   return entry.postId != null &&
     !forbiddenTitles.value.some(text => lowerCaseAuthor?.includes(text))
 }))
+const useCustomShortsPlayer = computed(() => store.getters.getUseCustomShortsPlayer)
+
+const hasAdditionalContent = computed(() => {
+  return newShorts.value.length > 0 || newLive.value.length > 0 || newPosts.value.length > 0
+})
+
+function filterNewMedia(entries) {
+  const filteredEntries = entries.filter(entry => !isVideoHiddenByPreferences(entry, {
+    hideLiveStreams: store.getters.getHideLiveStreams,
+    hideUpcomingPremieres: store.getters.getHideUpcomingPremieres,
+    forbiddenTitles: forbiddenTitles.value
+  }))
+
+  if (!store.getters.getOnlyShowLatestFromChannel) {
+    return filteredEntries
+  }
+
+  const authorCounts = new Map()
+  const limit = store.getters.getOnlyShowLatestFromChannelNumber
+
+  return filteredEntries.filter(entry => {
+    if (!entry.videoId || !entry.authorId) {
+      return true
+    }
+
+    const count = authorCounts.get(entry.authorId) ?? 0
+    if (count >= limit) {
+      return false
+    }
+
+    authorCounts.set(entry.authorId, count + 1)
+    return true
+  })
+}
 
 const isLoading = computed(() => {
   return !store.getters.getSubscriptionCacheReady || isRefreshing.value
 })
 
 const hasNewContent = computed(() => {
-  return newPosts.value.length > 0 || tabUi.value?.hasNewContent === true
+  return hasAdditionalContent.value || tabUi.value?.hasNewContent === true
 })
 
 defineExpose({
@@ -133,8 +206,14 @@ defineExpose({
 </script>
 
 <style scoped>
+.mediaSection,
 .postsSection {
-  margin-block-start: 32px;
+  margin-block-start: 8px;
+}
+
+.mediaSection h3,
+.postsSection h3 {
+  margin-block-start: 0;
 }
 
 .newFeed :deep(.autoGrid) {

--- a/src/renderer/components/SubscriptionsNew.vue
+++ b/src/renderer/components/SubscriptionsNew.vue
@@ -142,9 +142,53 @@ const newContentByCategory = computed(() => {
 })
 
 const forbiddenTitles = computed(() => store.getters.getForbiddenTitlesParsed)
-const newVideos = computed(() => newContentByCategory.value.videos)
-const newShorts = computed(() => filterNewMedia(newContentByCategory.value.shorts))
-const newLive = computed(() => filterNewMedia(newContentByCategory.value.live))
+const newMediaByCategory = computed(() => {
+  let mediaEntries = ['videos', 'shorts', 'live'].flatMap(category => {
+    return newContentByCategory.value[category].map(entry => ({ category, entry }))
+  })
+
+  mediaEntries = mediaEntries.filter(({ entry }) => !isVideoHiddenByPreferences(entry, {
+    hideLiveStreams: store.getters.getHideLiveStreams,
+    hideUpcomingPremieres: store.getters.getHideUpcomingPremieres,
+    forbiddenTitles: forbiddenTitles.value
+  }))
+
+  mediaEntries.sort((a, b) => {
+    return (b.entry.published ?? 0) - (a.entry.published ?? 0)
+  })
+
+  if (store.getters.getOnlyShowLatestFromChannel) {
+    const authorCounts = new Map()
+    const limit = store.getters.getOnlyShowLatestFromChannelNumber
+
+    mediaEntries = mediaEntries.filter(({ entry }) => {
+      if (!entry.videoId || !entry.authorId) {
+        return true
+      }
+
+      const count = authorCounts.get(entry.authorId) ?? 0
+      if (count >= limit) {
+        return false
+      }
+
+      authorCounts.set(entry.authorId, count + 1)
+      return true
+    })
+  }
+
+  return mediaEntries.reduce((entries, { category, entry }) => {
+    entries[category].push(entry)
+    return entries
+  }, {
+    videos: [],
+    shorts: [],
+    live: []
+  })
+})
+
+const newVideos = computed(() => newMediaByCategory.value.videos)
+const newShorts = computed(() => newMediaByCategory.value.shorts)
+const newLive = computed(() => newMediaByCategory.value.live)
 const newPosts = computed(() => newContentByCategory.value.posts.filter(entry => {
   const lowerCaseAuthor = entry.author?.toLowerCase()
 
@@ -156,35 +200,6 @@ const useCustomShortsPlayer = computed(() => store.getters.getUseCustomShortsPla
 const hasAdditionalContent = computed(() => {
   return newShorts.value.length > 0 || newLive.value.length > 0 || newPosts.value.length > 0
 })
-
-function filterNewMedia(entries) {
-  const filteredEntries = entries.filter(entry => !isVideoHiddenByPreferences(entry, {
-    hideLiveStreams: store.getters.getHideLiveStreams,
-    hideUpcomingPremieres: store.getters.getHideUpcomingPremieres,
-    forbiddenTitles: forbiddenTitles.value
-  }))
-
-  if (!store.getters.getOnlyShowLatestFromChannel) {
-    return filteredEntries
-  }
-
-  const authorCounts = new Map()
-  const limit = store.getters.getOnlyShowLatestFromChannelNumber
-
-  return filteredEntries.filter(entry => {
-    if (!entry.videoId || !entry.authorId) {
-      return true
-    }
-
-    const count = authorCounts.get(entry.authorId) ?? 0
-    if (count >= limit) {
-      return false
-    }
-
-    authorCounts.set(entry.authorId, count + 1)
-    return true
-  })
-}
 
 const isLoading = computed(() => {
   return !store.getters.getSubscriptionCacheReady || isRefreshing.value

--- a/src/renderer/composables/useRefreshAllSubscriptionFeeds.js
+++ b/src/renderer/composables/useRefreshAllSubscriptionFeeds.js
@@ -27,16 +27,36 @@ export function useRefreshAllSubscriptionFeeds() {
     const feeds = []
 
     if (!store.getters.getHideSubscriptionsVideos) {
-      feeds.push({ cache: store.getters.getVideoCache, entriesKey: 'videos', refresh: refreshSubscriptionVideosFromRemote })
+      feeds.push({
+        category: 'videos',
+        cache: store.getters.getVideoCache,
+        entriesKey: 'videos',
+        refresh: refreshSubscriptionVideosFromRemote
+      })
     }
     if (!store.getters.getHideSubscriptionsShorts) {
-      feeds.push({ cache: store.getters.getShortsCache, entriesKey: 'videos', refresh: refreshSubscriptionShortsFromRemote })
+      feeds.push({
+        category: 'shorts',
+        cache: store.getters.getShortsCache,
+        entriesKey: 'videos',
+        refresh: refreshSubscriptionShortsFromRemote
+      })
     }
     if (!store.getters.getHideLiveStreams && !store.getters.getHideSubscriptionsLive) {
-      feeds.push({ cache: store.getters.getLiveCache, entriesKey: 'videos', refresh: refreshSubscriptionLiveFromRemote })
+      feeds.push({
+        category: 'live',
+        cache: store.getters.getLiveCache,
+        entriesKey: 'videos',
+        refresh: refreshSubscriptionLiveFromRemote
+      })
     }
     if (!store.getters.getHideSubscriptionsCommunity && !store.getters.getUseRssFeeds) {
-      feeds.push({ cache: store.getters.getPostsCache, entriesKey: 'posts', refresh: refreshSubscriptionPostsFromRemote })
+      feeds.push({
+        category: 'posts',
+        cache: store.getters.getPostsCache,
+        entriesKey: 'posts',
+        refresh: refreshSubscriptionPostsFromRemote
+      })
     }
 
     return feeds


### PR DESCRIPTION
## Pull Request Type

- [ ] Bugfix
- [x] Feature Implementation
- [ ] Documentation
- [ ] Other

## Related issue

None.

## Description

Groups the New subscriptions feed into separate Videos, Shorts, Live, and Posts sections instead of combining every media type under Videos.

The Shorts section uses the YouTube-style portrait card layout when that setting is enabled, while preserving feed deduplication, visibility preferences, seen-state handling, and compact spacing between sections.

## Screenshots

Not included.

## Release note category

<!-- release-note-category:start -->
- [ ] Not noteworthy
- [ ] Highlights
- [x] More improvements
- [ ] Fixed bugs
<!-- release-note-category:end -->

## Release note

<!-- release-note:start -->
The New subscriptions feed now separates Videos, Shorts, and Live content into dedicated sections.
<!-- release-note:end -->

## Release note image

<!-- release-note-image:start -->
<img width="986" height="970" alt="image" src="https://github.com/user-attachments/assets/36e73dcf-ab41-4cef-b798-59593cfa4b30" />
<!-- release-note-image:end -->

## Testing

1. Enable the New subscriptions feed and ensure cached new Videos, Shorts, Live streams, and Posts are available.
2. Open Subscriptions and select the New tab.
3. Confirm each content type appears under its matching heading.
4. Enable YouTube-style Shorts and confirm the Shorts section uses portrait cards.
5. Disable YouTube-style Shorts and confirm Shorts use the standard card layout.

Automated checks:

- `pnpm exec eslint --config eslint.config.mjs src/renderer/components/SubscriptionsNew.vue src/renderer/composables/useRefreshAllSubscriptionFeeds.js e2e/tests/offline/subscriptions-new-feed.spec.mjs`
- `xvfb-run -a -s "-screen 0 1920x1080x24" pnpm exec playwright test -c e2e/playwright.config.mjs --project=offline e2e/tests/offline/subscriptions-new-feed.spec.mjs --workers=1` (10 passed)

## Desktop

- **OS:** Arch Linux
- **OS Version:** Rolling release
- **OpenTubeX version:** 0.30.0

## Additional context

The section spacing is intentionally compact so each category remains distinct without creating a large visual break.
