### PR TITLE
Fix subscription Shorts thumbnails and UI overlays

### DIFF
--- a/e2e/tests/network/subscriptions-shorts.spec.mjs
+++ b/e2e/tests/network/subscriptions-shorts.spec.mjs
@@ -1,0 +1,43 @@
+import { goTo } from '../../helpers/app.mjs'
+import { test, expect } from '../../helpers/innertube.mjs'
+
+const CHANNEL_ID = 'UCmlzNHg8QiWVutUyFOV2UdQ'
+
+test.use({
+  seed: {
+    settings: {
+      backendPreference: 'local',
+      fetchSubscriptionsAutomatically: false,
+      hideSubscriptionsVideos: true,
+      hideSubscriptionsLive: true,
+      hideSubscriptionsCommunity: true,
+      useCustomShortsPlayer: true
+    },
+    profiles: [{
+      _id: 'allChannels',
+      name: 'All Channels',
+      bgColor: '#000000',
+      textColor: '#FFFFFF',
+      subscriptions: [{
+        id: CHANNEL_ID,
+        name: 'The Stock Pot',
+        thumbnail: ''
+      }]
+    }]
+  }
+})
+
+test('subscription refresh uses YouTube selected Shorts thumbnails', async ({ page, innertube }) => {
+  test.skip(innertube.replay, 'subscription refresh needs the real API')
+
+  await goTo(page, 'subscriptions')
+  await page.locator('[data-subscription-feed-tab="shorts"]').click()
+  await page.getByRole('button', { name: /Refresh Shorts/ }).click()
+
+  const short = page.locator('.ft-list-video.youtubeShort').first()
+  await expect(short).toBeVisible({ timeout: 60_000 })
+  const thumbnailUrl = await short.locator('.thumbnailImage').getAttribute('src')
+
+  expect(thumbnailUrl).toMatch(/^https:\/\/i\.ytimg\.com\/vi\//)
+  expect(thumbnailUrl).not.toMatch(/oardefault\.jpg|thumbnail_placeholder/)
+})

--- a/e2e/tests/network/watch.spec.mjs
+++ b/e2e/tests/network/watch.spec.mjs
@@ -976,6 +976,8 @@ test.describe('watch page', () => {
 
 test.describe('custom Shorts player', () => {
   const SHORTS_CHANNEL = 'UCshortsfeed000000000000'
+  const FIRST_SHORT_THUMBNAIL = 'https://i.ytimg.com/vi/w1WKmSqwM8I/frame0.jpg?selected=1'
+  const SECOND_SHORT_THUMBNAIL = 'https://i.ytimg.com/vi/RZ6PG5QATg4/frame0.jpg?selected=1'
 
   test.use({
     seed: {
@@ -1005,7 +1007,8 @@ test.describe('custom Shorts player', () => {
             authorId: SHORTS_CHANNEL,
             published: 2,
             isShort: true,
-            lengthSeconds: ''
+            lengthSeconds: '',
+            thumbnailUrl: FIRST_SHORT_THUMBNAIL
           },
           {
             type: 'video',
@@ -1015,7 +1018,8 @@ test.describe('custom Shorts player', () => {
             authorId: SHORTS_CHANNEL,
             published: 1,
             isShort: true,
-            lengthSeconds: ''
+            lengthSeconds: '',
+            thumbnailUrl: SECOND_SHORT_THUMBNAIL
           }
         ],
         shortsTimestamp: new Date().toISOString()
@@ -1059,14 +1063,19 @@ test.describe('custom Shorts player', () => {
     await expect(page.locator('.shortsActionRail')).toBeVisible()
     await expect(page.locator('.shortsNavigation')).toBeVisible()
     await expect(page.locator('.infoArea')).toBeHidden()
-    await expect(player.locator('video')).toHaveAttribute('loop', '')
-    await expect(player.locator('video')).toHaveCSS('object-fit', 'cover')
+    const video = player.locator('video')
+    await expect(video).toHaveAttribute('loop', '')
+    await expect(video).toHaveAttribute('poster', FIRST_SHORT_THUMBNAIL)
+    await expect(video).toHaveCSS('object-fit', 'cover')
+    await expect(player.locator('.shortsTopControl').first()).toHaveCSS(
+      'backdrop-filter',
+      /blur\(8px\)/
+    )
     expect(await player.evaluate(element => {
       return element.ui.getConfiguration().doubleClickForFullscreen
     })).toBe(false)
     expect(await page.evaluate(() => window.__shortsSeekBarFlashedWhileLoading)).toBe(false)
 
-    const video = player.locator('video')
     const seekBar = player.locator('.shaka-seek-bar-container')
     await video.evaluate(async element => {
       if (element.paused) await element.play()
@@ -1185,7 +1194,10 @@ test.describe('custom Shorts player', () => {
     await expect(previous).toBeDisabled()
     await expect(next).toBeEnabled()
     await expect(page.locator('.shortsNextPreview')).toBeVisible()
-    await expect(page.locator('.shortsNextPreview')).toHaveAttribute('style', /oardefault\.jpg/)
+    await expect(page.locator('.shortsNextPreview')).toHaveAttribute(
+      'style',
+      /RZ6PG5QATg4\/frame0\.jpg\?selected=1/
+    )
     await expect(page.locator('.shortsExternalMetadata')).toBeVisible()
     await expect(page.locator('.shortsActionRail')).toBeVisible()
 

--- a/e2e/tests/offline/ui-bugfixes.spec.mjs
+++ b/e2e/tests/offline/ui-bugfixes.spec.mjs
@@ -1,4 +1,6 @@
-import { test, expect, goTo } from '../../helpers/app.mjs'
+import path from 'node:path'
+
+import { test, expect, goTo, repoRoot } from '../../helpers/app.mjs'
 
 function historyEntry(videoId, title, timeWatched) {
   return {
@@ -18,6 +20,82 @@ function historyEntry(videoId, title, timeWatched) {
     type: 'video'
   }
 }
+
+test('collapsed description paints the More control above its text', async ({ page }) => {
+  await page.addStyleTag({
+    path: path.join(
+      repoRoot,
+      'src/renderer/components/WatchVideoDescription/WatchVideoDescription.css'
+    )
+  })
+  await page.evaluate(() => {
+    const card = document.createElement('div')
+    const more = document.createElement('span')
+    const scroll = document.createElement('div')
+    const description = document.createElement('div')
+
+    card.className = 'videoDescription short'
+    card.style.backgroundColor = 'var(--card-bg-color)'
+    card.style.inset = '300px auto auto 300px'
+    card.style.padding = '16px'
+    card.style.position = 'fixed'
+    card.style.width = '300px'
+    card.style.zIndex = '10000'
+    more.className = 'descriptionStatus'
+    more.textContent = 'More'
+    scroll.className = 'descriptionScroll'
+    description.className = 'description'
+    description.textContent = Array.from(
+      { length: 20 },
+      (_, index) => `Long description segment ${index + 1}`
+    ).join(' ')
+
+    scroll.append(description)
+    card.append(more, scroll)
+    document.body.append(card)
+  })
+
+  const description = page.locator('.videoDescription.short').first()
+  const more = description.locator('.descriptionStatus')
+  await expect(more).toBeVisible()
+  await expect.poll(async () => more.evaluate((element) => {
+    const bounds = element.getBoundingClientRect()
+    return document.elementFromPoint(
+      bounds.left + bounds.width / 2,
+      bounds.top + bounds.height / 2
+    ) === element
+  })).toBe(true)
+})
+
+test('Shorts top controls stay visible over white video content', async ({ page }) => {
+  await goTo(page, 'history')
+  await page.addStyleTag({
+    path: path.join(
+      repoRoot,
+      'src/renderer/components/ft-shaka-video-player/ft-shaka-video-player.css'
+    )
+  })
+  await page.evaluate(() => {
+    const player = document.createElement('div')
+    const control = document.createElement('button')
+
+    player.className = 'ftVideoPlayer shortsPlayer'
+    player.style.backgroundColor = '#fff'
+    player.style.inset = '300px auto auto 300px'
+    player.style.padding = '16px'
+    player.style.position = 'fixed'
+    player.style.zIndex = '10000'
+    control.className = 'shortsTopControl'
+    control.textContent = '⋮'
+    player.append(control)
+    document.body.append(player)
+  })
+
+  const control = page.locator('.shortsTopControl')
+  await expect(control).toHaveCSS('backdrop-filter', /blur\(8px\)/)
+  await control.hover()
+  await expect(control).toHaveCSS('background-color', 'rgba(0, 0, 0, 0.68)')
+})
 
 test.describe('history reorder animation', () => {
   test.use({

--- a/src/renderer/components/FtListVideo/FtListVideo.vue
+++ b/src/renderer/components/FtListVideo/FtListVideo.vue
@@ -333,6 +333,7 @@ import {
   getCachedOembedTitle,
   getOembedTitle,
   getRelativeTimeFromDate,
+  getShortThumbnailUrl,
   getVideoThumbnailUrl,
   openExternalLink,
   openInternalPath,
@@ -874,20 +875,20 @@ const thumbnail = computed(() => {
     return deArrowCache.value.thumbnail
   }
 
-  if (
-    props.appearance === 'youtubeShort' &&
-    thumbnailPreference.value === '' &&
-    props.data.thumbnailUrl
-  ) {
-    return props.data.thumbnailUrl
+  if (props.appearance === 'youtubeShort') {
+    return getShortThumbnailUrl(
+      props.data,
+      backendPreference.value,
+      currentInvidiousInstanceUrl.value,
+      thumbnailPreference.value
+    ) ?? thumbnailPlaceholder
   }
 
   return getVideoThumbnailUrl(
     id.value,
     backendPreference.value,
     currentInvidiousInstanceUrl.value,
-    thumbnailPreference.value,
-    props.appearance === 'youtubeShort'
+    thumbnailPreference.value
   ) ?? thumbnailPlaceholder
 })
 

--- a/src/renderer/components/WatchVideoDescription/WatchVideoDescription.css
+++ b/src/renderer/components/WatchVideoDescription/WatchVideoDescription.css
@@ -34,12 +34,21 @@
 
 .videoDescription.short .descriptionStatus {
   position: absolute;
+  z-index: 1;
   inset-block-end: calc(1lh + 12px);
   padding-block: 2px;
   inset-inline-end: 16px;
-  padding-inline-start: 40px;
-  background: linear-gradient(270deg, var(--card-bg-color) 75%, transparent 100%);
+  background-color: var(--card-bg-color);
   text-decoration: none;
+}
+
+.videoDescription.short .descriptionStatus::before {
+  position: absolute;
+  inset-block: 0;
+  inset-inline-end: 100%;
+  inline-size: 40px;
+  background: linear-gradient(90deg, transparent, var(--card-bg-color));
+  content: '';
 }
 
 .videoDescription:not(.short) .descriptionStatus {
@@ -47,8 +56,8 @@
   margin-block-start: 1em;
 }
 
-.videoDescription.short .descriptionStatus:dir(rtl) {
-  background: linear-gradient(270deg, transparent 0%, var(--card-bg-color) 25%);
+.videoDescription.short .descriptionStatus:dir(rtl)::before {
+  background: linear-gradient(270deg, transparent, var(--card-bg-color));
 }
 
 .videoDescription.short .description {

--- a/src/renderer/components/ft-shaka-video-player/ft-shaka-video-player.css
+++ b/src/renderer/components/ft-shaka-video-player/ft-shaka-video-player.css
@@ -78,16 +78,18 @@
   border: 0;
   border-radius: 50%;
   color: inherit;
-  background-color: rgb(0 0 0 / 42%);
+  background-color: rgb(0 0 0 / 48%);
+  backdrop-filter: blur(8px) saturate(120%);
   cursor: pointer;
   font-size: 19px;
   pointer-events: auto;
+  transition: background-color 150ms ease;
 }
 
 .shortsTopControl:hover,
 .shortsTopControl:focus-visible,
 .shortsTopControl.active {
-  background-color: rgb(255 255 255 / 24%);
+  background-color: rgb(0 0 0 / 68%);
 }
 
 .shortsVolumeControl {
@@ -95,7 +97,8 @@
   align-items: center;
   min-inline-size: 46px;
   border-radius: 24px;
-  background-color: rgb(0 0 0 / 42%);
+  background-color: rgb(0 0 0 / 48%);
+  backdrop-filter: blur(8px) saturate(120%);
   pointer-events: auto;
   transition: background-color 150ms ease;
 }

--- a/src/renderer/helpers/player/shorts.js
+++ b/src/renderer/helpers/player/shorts.js
@@ -3,6 +3,20 @@ const MAX_CHANNEL_SHORTS_CONTEXTS = 20
 const channelShortsNavigationContexts = new Map()
 
 /**
+ * Prefers YouTube's selected portrait thumbnail only when the user has not
+ * explicitly chosen another frame.
+ * @param {{ thumbnailUrl?: string } | null | undefined} video
+ * @param {'' | 'hidden' | 'start' | 'middle' | 'end'} thumbnailPreference
+ * @param {string | null} fallbackUrl
+ * @returns {string | null}
+ */
+export function getPreferredShortThumbnailUrl(video, thumbnailPreference, fallbackUrl) {
+  return thumbnailPreference === '' && video?.thumbnailUrl
+    ? video.thumbnailUrl
+    : fallbackUrl
+}
+
+/**
  * Keeps a channel page's visible Shorts sequence available while its Watch
  * route replaces the channel component in the same tab.
  *

--- a/src/renderer/helpers/subscription-entries.js
+++ b/src/renderer/helpers/subscription-entries.js
@@ -5,6 +5,25 @@ import { isHistoryEntryWatched } from '../../history.js'
 const NEW_CONTENT_PUBLICATION_TOLERANCE_MS = 60 * 60 * 1000
 
 /**
+ * Adds YouTube's selected portrait thumbnails to dated Shorts entries without
+ * replacing the exact publication and view metadata supplied by RSS.
+ * @param {object[]} entries
+ * @param {object[]} thumbnailEntries
+ */
+export function mergeSubscriptionShortThumbnails(entries, thumbnailEntries) {
+  const thumbnailsByVideoId = new Map(
+    thumbnailEntries
+      .filter(entry => entry.videoId && entry.thumbnailUrl)
+      .map(entry => [entry.videoId, entry.thumbnailUrl])
+  )
+
+  return entries.map(entry => {
+    const thumbnailUrl = thumbnailsByVideoId.get(entry.videoId)
+    return thumbnailUrl ? { ...entry, thumbnailUrl } : entry
+  })
+}
+
+/**
  * Scraped publication dates are derived from relative texts ("3 days ago") and
  * are therefore recalculated against the current time on every fetch. Entries
  * of already fetched channels would drift forwards past entries of channels

--- a/src/renderer/helpers/subscriptions.js
+++ b/src/renderer/helpers/subscriptions.js
@@ -5,7 +5,13 @@ import {
   invidiousFetch,
   invidiousGetCommunityPosts
 } from './api/invidious'
-import { getLocalChannelCommunity, getLocalChannelLiveStreams, getLocalChannelVideos } from './api/local'
+import {
+  getLocalChannelCommunity,
+  getLocalChannelLiveStreams,
+  getLocalChannelVideos,
+  getLocalPlaylist,
+  parseLocalPlaylistVideo
+} from './api/local'
 import {
   fetchWithTimeout,
   getChannelPlaylistId,
@@ -14,7 +20,10 @@ import {
   showToastOnAllTabs,
 } from './utils'
 import { getValidSubscriptionChannels } from './subscription-channels'
-import { reconcileFetchedSubscriptionEntries } from './subscription-entries'
+import {
+  mergeSubscriptionShortThumbnails,
+  reconcileFetchedSubscriptionEntries
+} from './subscription-entries'
 import { mapConcurrently } from './concurrent-map'
 
 const AUTO_REFRESH_TOAST_DURATION = 5000
@@ -1137,7 +1146,11 @@ async function getChannelShortsLocal(channel, t, errorChannels, failedAttempts =
       return { videos: [] }
     }
 
-    const result = await parseYouTubeRSSFeed(await response.text(), channel.id)
+    const [result, thumbnailEntries] = await Promise.all([
+      parseYouTubeRSSFeed(await response.text(), channel.id),
+      getLocalShortThumbnailEntries(playlistId)
+    ])
+    result.videos = mergeSubscriptionShortThumbnails(result.videos, thumbnailEntries)
     result.videos.forEach(video => { video.isShort = true })
     return result
   } catch (error) {
@@ -1149,6 +1162,16 @@ async function getChannelShortsLocal(channel, t, errorChannels, failedAttempts =
     }
 
     return { videos: null }
+  }
+}
+
+async function getLocalShortThumbnailEntries(playlistId) {
+  try {
+    const playlist = await getLocalPlaylist(playlistId)
+    return playlist.items.map(parseLocalPlaylistVideo)
+  } catch (error) {
+    console.warn(`Failed to load selected Shorts thumbnails for ${playlistId}`, error)
+    return []
   }
 }
 

--- a/src/renderer/helpers/utils.js
+++ b/src/renderer/helpers/utils.js
@@ -3,6 +3,7 @@ import i18n from '../i18n/index'
 import router from '../router/index'
 import { getTabNavigationService } from '../tabs/TabNavigationService'
 import { UnsupportedPlayerActions } from '../../constants'
+import { getPreferredShortThumbnailUrl } from './player/shorts'
 
 // allowed characters in channel handle: A-Z, a-z, 0-9, -, _, .
 // https://support.google.com/youtube/answer/11585688#change_handle
@@ -222,6 +223,32 @@ export function getVideoThumbnailUrl(videoId, backendPreference, currentInvidiou
     default:
       return `${baseUrl}/vi/${videoId}/${portrait ? 'oardefault' : 'mqdefault'}.jpg`
   }
+}
+
+/**
+ * Resolves a Shorts thumbnail consistently for cards, navigation previews, and
+ * the player poster. YouTube's selected portrait image wins for the default
+ * preference; explicit frame preferences still use their generated URLs.
+ * @param {{ videoId: string, thumbnailUrl?: string } | null | undefined} video
+ * @param {'local' | 'invidious'} backendPreference
+ * @param {string} currentInvidiousInstanceUrl
+ * @param {'' | 'hidden' | 'start' | 'middle' | 'end'} thumbnailPreference
+ * @returns {string | null}
+ */
+export function getShortThumbnailUrl(video, backendPreference, currentInvidiousInstanceUrl, thumbnailPreference = '') {
+  if (!video?.videoId) {
+    return null
+  }
+
+  const fallbackUrl = getVideoThumbnailUrl(
+    video.videoId,
+    backendPreference,
+    currentInvidiousInstanceUrl,
+    thumbnailPreference,
+    true
+  )
+
+  return getPreferredShortThumbnailUrl(video, thumbnailPreference, fallbackUrl)
 }
 
 export const ToastEventBus = new EventTarget()

--- a/src/renderer/store/modules/subscription-cache.js
+++ b/src/renderer/store/modules/subscription-cache.js
@@ -382,6 +382,7 @@ const mutations = {
 
           cachedVideo.title = channelVideo.title
           cachedVideo.author = channelVideo.author
+          cachedVideo.thumbnailUrl = channelVideo.thumbnailUrl ?? cachedVideo.thumbnailUrl
 
           // as the channel shorts page only has compact view counts for numbers above 1000 e.g. 12k
           // and the RSS feeds include an exact value, we only want to overwrite it when the number is larger than the cached value

--- a/src/renderer/views/Watch/Watch.js
+++ b/src/renderer/views/Watch/Watch.js
@@ -31,7 +31,7 @@ import {
   formatNumber,
   getCachedOembedTitle,
   getOembedTitle,
-  getVideoThumbnailUrl,
+  getShortThumbnailUrl,
   showApiErrorToast,
   showToast,
   showToastOnAllTabs
@@ -510,17 +510,21 @@ export default defineComponent({
         ? this.subscriptionShortsFeed[this.subscriptionShortsFeedIndex + 1]
         : null
     },
+    currentSubscriptionShort: function () {
+      return this.subscriptionShortsFeedIndex >= 0
+        ? this.subscriptionShortsFeed[this.subscriptionShortsFeedIndex]
+        : null
+    },
     nextSubscriptionShortThumbnail: function () {
       if (!this.nextSubscriptionShort) {
         return ''
       }
 
-      return getVideoThumbnailUrl(
-        this.nextSubscriptionShort.videoId,
+      return getShortThumbnailUrl(
+        this.nextSubscriptionShort,
         this.backendPreference,
         this.currentInvidiousInstanceUrl,
-        this.thumbnailPreference,
-        true
+        this.thumbnailPreference
       ) ?? ''
     },
     shortsCommentsPanelOpen: function () {
@@ -1319,12 +1323,11 @@ export default defineComponent({
       this.shortsCommentsOpen = false
 
       this.shortsTransitionDirection = Math.sign(offset)
-      this.shortsTransitionPreview = getVideoThumbnailUrl(
-        target.videoId,
+      this.shortsTransitionPreview = getShortThumbnailUrl(
+        target,
         this.backendPreference,
         this.currentInvidiousInstanceUrl,
-        this.thumbnailPreference,
-        true
+        this.thumbnailPreference
       ) ?? ''
       this.shortsNavigationLockedUntil = Date.now() + 300
       const shortSource = this.tabRoute.query.shortSource === 'channel'
@@ -2013,12 +2016,11 @@ export default defineComponent({
           result.streaming_data?.adaptive_formats
         )
         if (this.customShortsPlayerActive) {
-          this.thumbnail = getVideoThumbnailUrl(
-            this.videoId,
+          this.thumbnail = getShortThumbnailUrl(
+            this.currentSubscriptionShort ?? { videoId: this.videoId },
             this.backendPreference,
             this.currentInvidiousInstanceUrl,
-            this.thumbnailPreference,
-            true
+            this.thumbnailPreference
           ) ?? this.thumbnail
         }
         if (this.isShort) {
@@ -2236,12 +2238,11 @@ export default defineComponent({
 
           this.updateShortsPlayerState(result.lengthSeconds, result.adaptiveFormats)
           if (this.customShortsPlayerActive) {
-            this.thumbnail = getVideoThumbnailUrl(
-              this.videoId,
+            this.thumbnail = getShortThumbnailUrl(
+              this.currentSubscriptionShort ?? { videoId: this.videoId },
               this.backendPreference,
               this.currentInvidiousInstanceUrl,
-              this.thumbnailPreference,
-              true
+              this.thumbnailPreference
             ) ?? this.thumbnail
           }
           this.updateTitle()

--- a/tests/unit/shorts-player.test.mjs
+++ b/tests/unit/shorts-player.test.mjs
@@ -4,11 +4,28 @@ import test from 'node:test'
 import {
   buildSubscriptionShortsFeed,
   getChannelShortsNavigationContext,
+  getPreferredShortThumbnailUrl,
   getVideoAspectRatio,
   isYouTubeShort,
   parseLocalShortLinkedVideo,
   setChannelShortsNavigationContext,
 } from '../../src/renderer/helpers/player/shorts.js'
+
+test('prefers YouTube selected Shorts thumbnails only for the default preference', () => {
+  const video = {
+    thumbnailUrl: 'https://i.ytimg.com/vi/short/frame0.jpg'
+  }
+
+  assert.equal(
+    getPreferredShortThumbnailUrl(video, '', 'https://i.ytimg.com/vi/short/oardefault.jpg'),
+    video.thumbnailUrl
+  )
+  assert.equal(
+    getPreferredShortThumbnailUrl(video, 'middle', 'https://i.ytimg.com/vi/short/oar2.jpg'),
+    'https://i.ytimg.com/vi/short/oar2.jpg'
+  )
+  assert.equal(getPreferredShortThumbnailUrl(video, 'hidden', null), null)
+})
 
 test('reads aspect ratios from local and Invidious formats', () => {
   assert.equal(getVideoAspectRatio([{ width: 1080, height: 1920 }]), 9 / 16)

--- a/tests/unit/subscription-entries.test.mjs
+++ b/tests/unit/subscription-entries.test.mjs
@@ -3,6 +3,7 @@ import test from 'node:test'
 
 import {
   ensureSubscriptionFeedEntryState,
+  mergeSubscriptionShortThumbnails,
   reconcileFetchedSubscriptionEntries
 } from '../../src/renderer/helpers/subscription-entries.js'
 
@@ -12,6 +13,28 @@ const now = Date.now()
 function video(videoId, published, extra = {}) {
   return { videoId, published, type: 'video', ...extra }
 }
+
+test('adds selected Shorts thumbnails without replacing RSS metadata', () => {
+  const entries = [
+    video('matched', 10, { viewCount: 1234, isRSS: true }),
+    video('unmatched', 20, { isRSS: true })
+  ]
+  const merged = mergeSubscriptionShortThumbnails(entries, [
+    video('matched', 999, {
+      thumbnailUrl: 'https://i.ytimg.com/vi/matched/frame0.jpg',
+      viewCount: 1200
+    })
+  ])
+
+  assert.deepEqual(merged, [
+    video('matched', 10, {
+      thumbnailUrl: 'https://i.ytimg.com/vi/matched/frame0.jpg',
+      viewCount: 1234,
+      isRSS: true
+    }),
+    entries[1]
+  ])
+})
 
 test('keeps the cached publication date of entries that were already fetched', () => {
   const previousEntries = [


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Make sure to follow the contributing guidelines. -->
<!-- Important note, we may remove your pull request if you do not use this provided PR template correctly. -->
<!-- Do not create PR's with AI! (PRs created mainly with AI will be closed. They waste our team's time. We ban repeat offenders.) -->

## Pull Request Type
<!-- Please select what type of pull request this is: [x] -->
- [x] Bugfix
- [ ] Feature Implementation
- [ ] Documentation
- [ ] Other

## Related issue
<!-- Please link the issue your pull request is referring to. -->
<!-- If this pull request fully resolves the relevant issue, put "closes" before the issue number. -->
<!-- Example: "closes #123456". -->

Follow-up to #346.

## Description
<!-- Please write a clear and concise description of what the pull request does. -->

Fixes the remaining Shorts thumbnail path and two related overlay regressions:

- merges YouTube's selected portrait thumbnails from each channel's Shorts playlist into the dated subscription RSS entries
- uses one Shorts thumbnail resolver for channel/subscription cards, navigation previews, transitions, and the player poster
- preserves explicit start/middle/end and hidden thumbnail preferences
- updates cached subscription Shorts when a channel page supplies newer thumbnail metadata
- gives the Shorts player's top controls a dark frosted backdrop so they stay visible over white video content
- keeps collapsed description text below the solid More control and its directional fade

## Screenshots <!-- If appropriate -->
<!-- Please add before and after screenshots if there is a visible change. -->

Not included. The thumbnail, frosted-control, and description stacking changes have rendered-bound and computed-style E2E coverage.

## Release note category
<!-- Select exactly one category. Every pull request must select one. -->
<!-- release-note-category:start -->
- [ ] Not noteworthy
- [ ] Highlights
- [ ] More improvements
- [x] Fixed bugs
<!-- release-note-category:end -->

## Release note
<!-- Required unless "Not noteworthy" is selected. -->
<!-- Write one concise, user-facing entry without a leading bullet. -->
<!-- release-note:start -->
Fixed missing subscription Shorts thumbnails, washed-out Shorts controls, and collapsed description overlap.
<!-- release-note:end -->

## Release note image
<!-- Optional. Paste one Markdown image or HTML image tag here. -->
<!-- The release notes will use an HTML image tag and limit images taller than 300 pixels. -->
<!-- release-note-image:start -->

<!-- release-note-image:end -->

## Testing
<!-- How can reviewers verify that the PR produces correct results? -->
<!-- Please provide instructions so that others can ensure that your pull request would produce correct results. For examples see, https://github.com/FreeTubeApp/FreeTube/pull/5743, https://github.com/FreeTubeApp/FreeTube/pull/7349, https://github.com/FreeTubeApp/FreeTube/pull/5125, https://github.com/FreeTubeApp/FreeTube/pull/7338 -->

1. Subscribe to `UCmlzNHg8QiWVutUyFOV2UdQ`, refresh the subscription Shorts feed, and confirm its portrait images match the channel Shorts page instead of showing placeholders.
2. Open a Short from the subscription or channel feed and confirm its player poster and next preview use those same selected images.
3. Hover the Shorts player's top controls over white video content and confirm the controls remain clearly visible.
4. Open a video with a long collapsed description and confirm text does not paint over the More control.

Automated checks:

- `pnpm run lint`
- `pnpm run test:unit`
- `pnpm run test:e2e:pack`
- `e2e/tests/offline/subscriptions-new-feed.spec.mjs`
- `e2e/tests/offline/ui-bugfixes.spec.mjs`
- `e2e/tests/network/subscriptions-shorts.spec.mjs`

## Desktop
<!-- Please complete the following information-->
- **OS:** Arch Linux
- **OS Version:** Rolling release
- **OpenTubeX version:** 0.30.0

## Additional context
<!-- Add any other context about the pull request here. -->

RSS remains the source of exact publication dates and view counts. The local Shorts playlist response is used only to add YouTube's selected portrait thumbnail by video ID, so subscription ordering and metadata remain unchanged.
