### PR TITLE
test: settle icon fade before vertical tab stacking check

### DIFF
--- a/e2e/tests/offline/video-actions.spec.mjs
+++ b/e2e/tests/offline/video-actions.spec.mjs
@@ -138,22 +138,34 @@ test.describe('list video actions', () => {
     await video.locator('.addToPlaylistIcon .iconButton').click()
     const thumbnailDropdown = video.locator('.addToPlaylistIcon .iconDropdown')
     await expect(thumbnailDropdown).toBeVisible()
+    // A mid-flight opacity fade on the icon would make it a stacking context and
+    // trap the dropdown below the tab bar, so let the hover transition settle first
+    await expect(video.locator('.addToPlaylistIcon')).toHaveCSS('opacity', '1')
     const dropdownCoversVerticalTabs = await thumbnailDropdown.evaluate((dropdown) => {
-      const tabBarRect = document.querySelector('.tabBar.vertical').getBoundingClientRect()
-      const initialDropdownRect = dropdown.getBoundingClientRect()
-      dropdown.style.transform = `translateX(${tabBarRect.right - initialDropdownRect.left - 40}px)`
+      // Stretch the (fixed, so reflow-free) tab bar over the dropdown instead of
+      // moving the dropdown: its inline transform belongs to FtIconButton's
+      // viewport keeping, which would overwrite ours on its next frame
+      const tabBar = document.querySelector('.tabBar.vertical')
       const dropdownRect = dropdown.getBoundingClientRect()
-      const overlapLeft = Math.max(tabBarRect.left, dropdownRect.left)
-      const overlapRight = Math.min(tabBarRect.right, dropdownRect.right)
-      if (overlapLeft >= overlapRight) {
-        return false
-      }
+      const previousInlineSize = tabBar.style.inlineSize
+      tabBar.style.inlineSize = `${dropdownRect.left + dropdownRect.width / 2}px`
 
-      const elementAtOverlap = document.elementFromPoint(
-        overlapLeft + (overlapRight - overlapLeft) / 2,
-        Math.max(tabBarRect.top, dropdownRect.top) + 10
-      )
-      return dropdown.contains(elementAtOverlap)
+      try {
+        const tabBarRect = tabBar.getBoundingClientRect()
+        const overlapLeft = Math.max(tabBarRect.left, dropdownRect.left)
+        const overlapRight = Math.min(tabBarRect.right, dropdownRect.right)
+        if (overlapLeft >= overlapRight) {
+          return false
+        }
+
+        const elementAtOverlap = document.elementFromPoint(
+          overlapLeft + (overlapRight - overlapLeft) / 2,
+          Math.max(tabBarRect.top, dropdownRect.top) + 10
+        )
+        return dropdown.contains(elementAtOverlap)
+      } finally {
+        tabBar.style.inlineSize = previousInlineSize
+      }
     })
     expect(dropdownCoversVerticalTabs).toBe(true)
   })


### PR DESCRIPTION
## Pull Request Type
- [ ] Bugfix
- [ ] Feature Implementation
- [ ] Documentation
- [x] Other

## Related issue
None.

## Description
The e2e test `an open options dropdown crosses vertical tabs without lifting its feed card` was flaky: run in isolation with a single worker it failed 4 out of 5 times, while it passed when the whole spec file ran with the default parallel workers.

The cause is a mid-flight CSS opacity transition, not the dropdown position. `.addToPlaylistIcon` starts at `opacity: 0` with `transition: opacity 0.2s linear` and fades to `1` on hover (`src/renderer/scss-partials/_ft-list-item.scss`). While that fade is running, the fractional opacity makes the icon button a **stacking context**, so the dropdown's `z-index: 6` is confined inside a parent that participates at `z-index: auto` and therefore paints *below* the vertical tab bar's `z-index: 5`:

```
DIV.iconDropdown                    z=6     position=absolute
DIV.ftIconButton addToPlaylistIcon  z=auto  opacity=0.833475   <- stacking context
...
DIV.tabBar vertical                 z=5     position=fixed
```

`document.elementFromPoint()` at the overlap then returned `.tabsContainer` instead of the dropdown and the last assertion failed. Once the fade completes no stacking context is created, `6 > 5` wins, and the assertion holds. Running the file in parallel adds enough scheduling slack for the transition to finish, which is why it only failed in isolation.

Note that `.playlistIcons:has(.iconDropdown) { opacity: 1 }` already guards the *container* against exactly this problem; the per-icon fade simply isn't covered by it. The rendering settles on its own, so no product code is changed here — this is purely a test-timing fix.

Two changes to the test:

1. Wait for `.addToPlaylistIcon` to reach `opacity: 1` before measuring, via `toHaveCSS`. This is an auto-waiting assertion on the specific condition that has to settle, not a retry or an arbitrary timeout.
2. Create the overlap by temporarily stretching the tab bar over the dropdown instead of writing `dropdown.style.transform`. The tab bar is `position: fixed`, so widening it causes no reflow, and its `inline-size` is restored in a `finally`. This also removes a latent second race: `keepDropdownInViewport()` in `FtIconButton.vue` owns that same inline `transform` and rewrites it from a `requestAnimationFrame` scheduled by its `resize`/`scroll` listeners, so a frame landing after the test's assignment would have undone it. (That race was not what was failing here — the hand-written `translateX` was verified to survive two animation frames intact — but the test should not be competing for the property either way.)

## Release note category
<!-- release-note-category:start -->
- [x] Not noteworthy
- [ ] Highlights
- [ ] More improvements
- [ ] Fixed bugs
<!-- release-note-category:end -->

## Release note
<!-- release-note:start -->

<!-- release-note:end -->

## Testing
```
pnpm run test:e2e:pack
xvfb-run -a -s "-screen 0 1920x1080x24" npx playwright test --config e2e/playwright.config.mjs --workers=1 e2e/tests/offline/video-actions.spec.mjs -g "crosses vertical tabs"
```

Results on this branch:

- The command above, 5 consecutive runs: **5/5 passed** (4/5 failed before the change).
- Full spec file with default parallel workers: 14/14 passed.
- Full spec file with `--workers=1`: 14/14 passed.

The assertion is still meaningful rather than vacuous: while instrumenting the failure I confirmed it returns `false` (hitting `.tabsContainer`) whenever the stacking context is present.

## Desktop
- **OS:** Linux
- **OS Version:** Kernel 7.1.3
- **OpenTubeX version:** 0.30.0

## Additional context
None.
