### PR TITLE
ci: require every trusted bot approval for auto-merge

### DIFF
--- a/.github/workflows/autoMerge.yml
+++ b/.github/workflows/autoMerge.yml
@@ -63,6 +63,14 @@ jobs:
           return 1
         }
 
+        # A COMMENTED review does not supersede an approval, so only APPROVED and
+        # CHANGES_REQUESTED count when deciding where a reviewer currently stands.
+        latest_decisive_review() {
+          LOGIN="$1" jq -c \
+            '[.[] | select(.user.login == env.LOGIN and .commit_id == env.HEAD_SHA and (.state == "APPROVED" or .state == "CHANGES_REQUESTED"))] | sort_by(.submitted_at) | last // {}' \
+            <<< "$reviews"
+        }
+
         reviewer_permission="$(gh api "repos/$REPOSITORY/collaborators/$REVIEWER/permission" --jq '.permission' 2>/dev/null || true)"
 
         if [[ "$reviewer_permission" == "admin" ]]; then
@@ -76,9 +84,7 @@ jobs:
           missing_bots=()
 
           for bot in "${TRUSTED_BOTS[@]}"; do
-            bot_review_state="$(BOT="$bot" jq -r \
-              '[.[] | select(.user.login == env.BOT and .commit_id == env.HEAD_SHA)] | sort_by(.submitted_at) | last | .state // empty' \
-              <<< "$reviews")"
+            bot_review_state="$(latest_decisive_review "$bot" | jq -r '.state // empty')"
 
             if [[ "$bot_review_state" != "APPROVED" ]]; then
               missing_bots+=("$bot")

--- a/.github/workflows/autoMerge.yml
+++ b/.github/workflows/autoMerge.yml
@@ -48,7 +48,21 @@ jobs:
         REVIEWER: ${{ github.event.review.user.login }}
         REVIEWER_TYPE: ${{ github.event.review.user.type }}
         AUTHOR: ${{ github.event.pull_request.user.login }}
+        PR_NUMBER: ${{ github.event.pull_request.number }}
+        HEAD_SHA: ${{ github.event.pull_request.head.sha }}
       run: |
+        TRUSTED_BOTS=('coderabbitai[bot]' 'greptile-apps[bot]')
+
+        is_trusted_bot() {
+          local candidate
+          for candidate in "${TRUSTED_BOTS[@]}"; do
+            if [[ "$1" == "$candidate" ]]; then
+              return 0
+            fi
+          done
+          return 1
+        }
+
         reviewer_permission="$(gh api "repos/$REPOSITORY/collaborators/$REVIEWER/permission" --jq '.permission' 2>/dev/null || true)"
 
         if [[ "$reviewer_permission" == "admin" ]]; then
@@ -57,10 +71,26 @@ jobs:
         fi
 
         author_permission="$(gh api "repos/$REPOSITORY/collaborators/$AUTHOR/permission" --jq '.permission' 2>/dev/null || true)"
-        if [[ "$REVIEWER_TYPE" == "Bot" &&
-          ( "$REVIEWER" == "coderabbitai[bot]" || "$REVIEWER" == "greptile-apps[bot]" ) &&
-          "$author_permission" == "admin" ]]; then
-          echo "Trusted bot approval for admin author $AUTHOR authorized."
+        if [[ "$REVIEWER_TYPE" == "Bot" ]] && is_trusted_bot "$REVIEWER" && [[ "$author_permission" == "admin" ]]; then
+          reviews="$(gh api --paginate "repos/$REPOSITORY/pulls/$PR_NUMBER/reviews" | jq -cs '[.[][]]')"
+          missing_bots=()
+
+          for bot in "${TRUSTED_BOTS[@]}"; do
+            bot_review_state="$(BOT="$bot" jq -r \
+              '[.[] | select(.user.login == env.BOT and .commit_id == env.HEAD_SHA)] | sort_by(.submitted_at) | last | .state // empty' \
+              <<< "$reviews")"
+
+            if [[ "$bot_review_state" != "APPROVED" ]]; then
+              missing_bots+=("$bot")
+            fi
+          done
+
+          if [[ ${#missing_bots[@]} -gt 0 ]]; then
+            echo "Bot approvals only authorize auto-merge once every trusted bot has approved $HEAD_SHA. Still waiting for: ${missing_bots[*]}."
+            exit 0
+          fi
+
+          echo "Trusted bot approvals for admin author $AUTHOR authorized."
           exit 0
         fi
 

--- a/.github/workflows/enableAutoMerge.yml
+++ b/.github/workflows/enableAutoMerge.yml
@@ -39,6 +39,14 @@ jobs:
           return 1
         }
 
+        # A COMMENTED review does not supersede an approval, so only APPROVED and
+        # CHANGES_REQUESTED count when deciding where a reviewer currently stands.
+        latest_decisive_review() {
+          LOGIN="$1" jq -c \
+            '[.[] | select(.user.login == env.LOGIN and .commit_id == env.HEAD_SHA and (.state == "APPROVED" or .state == "CHANGES_REQUESTED"))] | sort_by(.submitted_at) | last // {}' \
+            <<< "$reviews"
+        }
+
         job_name="$(gh api "repos/$REPOSITORY/actions/runs/$RUN_ID/jobs" \
           --jq '.jobs[] | select(.name | startswith("authorize-auto-merge-")) | select(.conclusion == "success") | .name')"
         pr_number="${job_name#authorize-auto-merge-}"
@@ -68,9 +76,7 @@ jobs:
         fi
 
         reviews="$(gh api --paginate "repos/$REPOSITORY/pulls/$pr_number/reviews" | jq -cs '[.[][]]')"
-        latest_review="$(jq -c \
-          '[.[] | select(.user.login == env.REVIEWER and .commit_id == env.HEAD_SHA)] | sort_by(.submitted_at) | last // {}' \
-          <<< "$reviews")"
+        latest_review="$(latest_decisive_review "$REVIEWER")"
         latest_review_state="$(jq -r '.state // empty' <<< "$latest_review")"
         if [[ "$latest_review_state" != "APPROVED" ]]; then
           echo "The latest review from $REVIEWER for $HEAD_SHA is not an approval."
@@ -87,9 +93,7 @@ jobs:
           missing_bots=()
 
           for bot in "${TRUSTED_BOTS[@]}"; do
-            bot_review_state="$(BOT="$bot" jq -r \
-              '[.[] | select(.user.login == env.BOT and .commit_id == env.HEAD_SHA)] | sort_by(.submitted_at) | last | .state // empty' \
-              <<< "$reviews")"
+            bot_review_state="$(latest_decisive_review "$bot" | jq -r '.state // empty')"
 
             if [[ "$bot_review_state" != "APPROVED" ]]; then
               missing_bots+=("$bot")

--- a/.github/workflows/enableAutoMerge.yml
+++ b/.github/workflows/enableAutoMerge.yml
@@ -27,6 +27,18 @@ jobs:
         REVIEWER: ${{ github.event.workflow_run.actor.login }}
         HEAD_SHA: ${{ github.event.workflow_run.head_sha }}
       run: |
+        TRUSTED_BOTS=('coderabbitai[bot]' 'greptile-apps[bot]')
+
+        is_trusted_bot() {
+          local candidate
+          for candidate in "${TRUSTED_BOTS[@]}"; do
+            if [[ "$1" == "$candidate" ]]; then
+              return 0
+            fi
+          done
+          return 1
+        }
+
         job_name="$(gh api "repos/$REPOSITORY/actions/runs/$RUN_ID/jobs" \
           --jq '.jobs[] | select(.name | startswith("authorize-auto-merge-")) | select(.conclusion == "success") | .name')"
         pr_number="${job_name#authorize-auto-merge-}"
@@ -55,8 +67,10 @@ jobs:
           exit 0
         fi
 
-        latest_review="$(gh api --paginate "repos/$REPOSITORY/pulls/$pr_number/reviews" | \
-          jq -cs '[.[][] | select(.user.login == env.REVIEWER and .commit_id == env.HEAD_SHA)] | sort_by(.submitted_at) | last // {}')"
+        reviews="$(gh api --paginate "repos/$REPOSITORY/pulls/$pr_number/reviews" | jq -cs '[.[][]]')"
+        latest_review="$(jq -c \
+          '[.[] | select(.user.login == env.REVIEWER and .commit_id == env.HEAD_SHA)] | sort_by(.submitted_at) | last // {}' \
+          <<< "$reviews")"
         latest_review_state="$(jq -r '.state // empty' <<< "$latest_review")"
         if [[ "$latest_review_state" != "APPROVED" ]]; then
           echo "The latest review from $REVIEWER for $HEAD_SHA is not an approval."
@@ -69,10 +83,25 @@ jobs:
 
         if [[ "$reviewer_permission" == "admin" ]]; then
           echo "Admin approval by $REVIEWER authorized."
-        elif [[ "$reviewer_type" == "Bot" &&
-          ( "$REVIEWER" == "coderabbitai[bot]" || "$REVIEWER" == "greptile-apps[bot]" ) &&
-          "$author_permission" == "admin" ]]; then
-          echo "Trusted bot approval for admin author $author authorized."
+        elif [[ "$reviewer_type" == "Bot" ]] && is_trusted_bot "$REVIEWER" && [[ "$author_permission" == "admin" ]]; then
+          missing_bots=()
+
+          for bot in "${TRUSTED_BOTS[@]}"; do
+            bot_review_state="$(BOT="$bot" jq -r \
+              '[.[] | select(.user.login == env.BOT and .commit_id == env.HEAD_SHA)] | sort_by(.submitted_at) | last | .state // empty' \
+              <<< "$reviews")"
+
+            if [[ "$bot_review_state" != "APPROVED" ]]; then
+              missing_bots+=("$bot")
+            fi
+          done
+
+          if [[ ${#missing_bots[@]} -gt 0 ]]; then
+            echo "Bot approvals only authorize auto-merge once every trusted bot has approved $HEAD_SHA. Still waiting for: ${missing_bots[*]}."
+            exit 0
+          fi
+
+          echo "Trusted bot approvals for admin author $author authorized."
         else
           echo "Approval by $REVIEWER does not authorize auto-merge."
           exit 0


### PR DESCRIPTION
## Pull Request Type
- [x] Bugfix
- [ ] Feature Implementation
- [ ] Documentation
- [ ] Other

## Related issue
None. Fallout from #352, which merged itself before it had been fully reviewed.

## Description
Auto-merge could be authorized by a **single** trusted bot approval. In #352 that meant Greptile approved, auto-merge was enabled, and the PR merged while CodeRabbit had not reviewed it at all — it had posted a "review limit reached, next review available in 8 minutes" comment and never got the chance.

Both `authorize-auto-merge` (`autoMerge.yml`) and the authoritative `enable-auto-merge` gate (`enableAutoMerge.yml`) accepted the approval as soon as the reviewer was *one of* the trusted bots:

```bash
if [[ "$reviewer_type" == "Bot" &&
  ( "$REVIEWER" == "coderabbitai[bot]" || "$REVIEWER" == "greptile-apps[bot]" ) &&
  "$author_permission" == "admin" ]]; then
```

Bot-authorized auto-merge now requires an approval from **every** trusted bot on the current head commit. Concretely:

- The trusted bot list moves into a `TRUSTED_BOTS` bash array with an `is_trusted_bot` helper, so it is declared once per workflow instead of being spelled out inline.
- Before authorizing, each trusted bot's latest review for `HEAD_SHA` must be `APPROVED`. Any bot that has not approved is named in the log, and the job exits without enabling auto-merge.
- Reviews are fetched once and reused for both the existing "latest review from the triggering reviewer" check and the new per-bot check, so this adds no extra API calls.

Admin approvals are unaffected and still authorize on their own. Nothing stalls permanently either: a bot approving later fires `pull_request_review` again, so auto-merge is enabled as soon as the last bot signs off.

Note that the bot names contain `[bot]`, which is a valid glob pattern, so the list is kept in a quoted array and compared with quoted `[[ ... == ... ]]` operands. An unquoted `for bot in $TRUSTED_BOTS` would be subject to pathname expansion.

## Screenshots
N/A

## Release note category
<!-- release-note-category:start -->
- [x] Not noteworthy
- [ ] Highlights
- [ ] More improvements
- [ ] Fixed bugs
<!-- release-note-category:end -->

## Release note
<!-- release-note:start -->

<!-- release-note:end -->

## Testing
CI-only change, so I extracted the gate into a standalone script and ran it against the real review data that caused the bad merge (`gh api repos/OpenTubeX/OpenTubeX/pulls/352/reviews`) plus synthetic variants:

| Case | Result |
|---|---|
| PR #352 real data — only Greptile approved head `7058a7a7` | `BLOCKED waiting for: coderabbitai[bot]` (previously merged) |
| Both bots approved head `7058a7a7` | `AUTHORIZED` |
| Both approved, then CodeRabbit requested changes on the same SHA | `BLOCKED waiting for: coderabbitai[bot]` |
| Both approved, but on an older SHA than `HEAD_SHA` | `BLOCKED waiting for: coderabbitai[bot] greptile-apps[bot]` |

`is_trusted_bot` membership, with a file named `coderabbitaib` present in the working directory to catch glob expansion:

```
trusted: coderabbitai[bot]
trusted: greptile-apps[bot]
NOT trusted: coderabbitaib
NOT trusted: evil[bot]
NOT trusted: c
```

Both workflow files were also verified to still parse as YAML.

## Desktop
- **OS:** Linux
- **OS Version:** Kernel 7.1.3
- **OpenTubeX version:** 0.30.0

## Additional context
This PR is itself a good end-to-end check: it should sit unmerged until both bots have approved it.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Strengthened automatic merge approval validation.
  * Auto-merge now requires approval from all trusted review bots for the current commit.
  * Improved handling of review history to prevent outdated approvals from authorizing merges.
  * Added clearer reporting when trusted bot approvals are still pending.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->