### PR TITLE
Fix Shorts controls and scrolling

### DIFF
--- a/e2e/tests/network/watch.spec.mjs
+++ b/e2e/tests/network/watch.spec.mjs
@@ -1201,12 +1201,24 @@ test.describe('custom Shorts player', () => {
     await expect(page.locator('.shortsExternalMetadata')).toBeVisible()
     await expect(page.locator('.shortsActionRail')).toBeVisible()
 
-    const commentsButton = page.getByRole('button', { name: 'Show Comments' })
+    const commentsButton = page.locator('.shortsCommentsAction').getByRole('button')
     await commentsButton.click()
     const commentsPanel = page.locator('.shortsCommentsPanel')
     await expect(commentsPanel).toHaveClass(/shortsCommentsPanelOpen/)
+    const commentsScroller = commentsPanel.locator('.commentsContentWrapper')
+    await commentsScroller.evaluate(element => {
+      const overflowProbe = document.createElement('div')
+      overflowProbe.style.blockSize = '2000px'
+      element.append(overflowProbe)
+    })
+    await expect.poll(() => commentsScroller.evaluate(element => {
+      return element.scrollHeight > element.clientHeight
+    })).toBe(true)
+    const commentsScrollTop = await commentsScroller.evaluate(element => element.scrollTop)
     await commentsPanel.hover()
     await page.mouse.wheel(0, 120)
+    await expect.poll(() => commentsScroller.evaluate(element => element.scrollTop))
+      .toBeGreaterThan(commentsScrollTop)
     await expect(page).toHaveURL(
       /#\/watch\/w1WKmSqwM8I\?short=true&shortSource=subscriptions/
     )
@@ -1214,7 +1226,7 @@ test.describe('custom Shorts player', () => {
     await expect(page).toHaveURL(
       /#\/watch\/w1WKmSqwM8I\?short=true&shortSource=subscriptions/
     )
-    await page.getByRole('button', { name: 'Hide Comments' }).click()
+    await commentsPanel.getByRole('button', { name: 'Hide Comments' }).click()
 
     const [playerBounds, videoAreaBounds, metadataBounds, actionBounds, previewBounds, navigationBounds] =
       await Promise.all([
@@ -1249,6 +1261,22 @@ test.describe('custom Shorts player', () => {
       /#\/watch\/RZ6PG5QATg4\?short=true&shortSource=subscriptions/
     )
     expect(await page.evaluate(() => window.__shortsNavigationDisappeared)).toBe(false)
+
+    await page.waitForTimeout(500)
+    await page.keyboard.press('ArrowUp')
+    await expect(page).toHaveURL(
+      /#\/watch\/w1WKmSqwM8I\?short=true&shortSource=subscriptions/
+    )
+
+    await page.waitForTimeout(500)
+    // Browser middle-button autoscroll moves the window instead of emitting a
+    // wheel event, so window scrolling must navigate Shorts too.
+    await page.evaluate(() => window.scrollTo({
+      top: document.documentElement.scrollHeight
+    }))
+    await expect(page).toHaveURL(
+      /#\/watch\/RZ6PG5QATg4\?short=true&shortSource=subscriptions/
+    )
 
     await page.waitForTimeout(500)
     await page.keyboard.press('ArrowUp')

--- a/e2e/tests/network/watch.spec.mjs
+++ b/e2e/tests/network/watch.spec.mjs
@@ -983,6 +983,7 @@ test.describe('custom Shorts player', () => {
     seed: {
       settings: {
         useCustomShortsPlayer: true,
+        useSponsorBlock: true,
         fetchSubscriptionsAutomatically: false
       },
       profiles: [{
@@ -1206,11 +1207,13 @@ test.describe('custom Shorts player', () => {
     const commentsPanel = page.locator('.shortsCommentsPanel')
     await expect(commentsPanel).toHaveClass(/shortsCommentsPanelOpen/)
     const commentsScroller = commentsPanel.locator('.commentsContentWrapper')
-    await commentsScroller.evaluate(element => {
-      const overflowProbe = document.createElement('div')
-      overflowProbe.style.blockSize = '2000px'
-      element.append(overflowProbe)
-    })
+    const firstComment = commentsPanel.locator('.comment').first()
+    const loadComments = commentsPanel.locator('.getCommentsTitle')
+    await expect(firstComment.or(loadComments)).toBeVisible()
+    if (await loadComments.isVisible()) {
+      await loadComments.click()
+    }
+    await expect(firstComment).toBeVisible({ timeout: 30_000 })
     await expect.poll(() => commentsScroller.evaluate(element => {
       return element.scrollHeight > element.clientHeight
     })).toBe(true)
@@ -1242,6 +1245,83 @@ test.describe('custom Shorts player', () => {
     )
     await expect(commentsPanel).toHaveClass(/shortsCommentsPanelOpen/)
     await commentsPanel.getByRole('button', { name: 'Hide Comments' }).click()
+
+    const auxPanel = page.locator('.shortsAuxPanel')
+    const sponsorBlockButton = page.getByRole('button', { name: 'Open SponsorBlock info' })
+    await sponsorBlockButton.click()
+    await expect(sponsorBlockButton).toHaveAttribute('aria-pressed', 'true')
+    await expect(auxPanel).toHaveClass(/shortsAuxPanelOpen/)
+    const sponsorBlockContent = auxPanel.locator('.sponsorBlockContent')
+    await expect(sponsorBlockContent).toHaveCSS('overscroll-behavior', 'contain')
+    await sponsorBlockContent.hover()
+    await page.mouse.wheel(0, 2000)
+    await expect(page).toHaveURL(
+      /#\/watch\/w1WKmSqwM8I\?short=true&shortSource=subscriptions/
+    )
+
+    await page.waitForTimeout(500)
+    await page.evaluate(() => window.scrollTo({
+      top: document.documentElement.scrollHeight
+    }))
+    await expect(page).toHaveURL(
+      /#\/watch\/RZ6PG5QATg4\?short=true&shortSource=subscriptions/
+    )
+    await expect(auxPanel).toHaveClass(/shortsAuxPanelOpen/)
+    await expect(sponsorBlockButton).toHaveAttribute('aria-pressed', 'true')
+
+    await page.waitForTimeout(500)
+    await previous.click()
+    await expect(page).toHaveURL(
+      /#\/watch\/w1WKmSqwM8I\?short=true&shortSource=subscriptions/
+    )
+    await expect(auxPanel).toHaveClass(/shortsAuxPanelOpen/)
+    await expect(sponsorBlockButton).toHaveAttribute('aria-pressed', 'true')
+    await auxPanel.locator('.sponsorBlockHeader').getByRole('button', { name: 'Close' }).click()
+
+    const transcriptButton = page.locator('.shortsComponentAction')
+      .filter({ hasText: 'Transcript' })
+      .getByRole('button')
+    await transcriptButton.click()
+    const transcriptCard = auxPanel.locator('.watchVideoTranscript')
+    const transcriptTarget = auxPanel.locator('.shortsAuxPanelTarget')
+    await expect(transcriptCard).toBeVisible()
+    await expect(transcriptTarget).toHaveCSS('overscroll-behavior', 'contain')
+    await expect.poll(async () => {
+      const [cardHeight, targetHeight] = await Promise.all([
+        transcriptCard.evaluate(element => element.offsetHeight),
+        transcriptTarget.evaluate(element => element.clientHeight),
+      ])
+      return Math.abs(cardHeight - targetHeight)
+    }).toBeLessThanOrEqual(32)
+    await transcriptTarget.hover()
+    await page.mouse.wheel(0, 2000)
+    await expect(page).toHaveURL(
+      /#\/watch\/w1WKmSqwM8I\?short=true&shortSource=subscriptions/
+    )
+
+    await page.waitForTimeout(500)
+    await page.evaluate(() => window.scrollTo({
+      top: document.documentElement.scrollHeight
+    }))
+    await expect(page).toHaveURL(
+      /#\/watch\/RZ6PG5QATg4\?short=true&shortSource=subscriptions/
+    )
+    await expect(auxPanel).toHaveClass(/shortsAuxPanelOpen/)
+    await expect(transcriptButton).toHaveAttribute('aria-pressed', 'true')
+    await expect.poll(async () => {
+      const [cardHeight, targetHeight] = await Promise.all([
+        transcriptCard.evaluate(element => element.offsetHeight),
+        transcriptTarget.evaluate(element => element.clientHeight),
+      ])
+      return Math.abs(cardHeight - targetHeight)
+    }).toBeLessThanOrEqual(32)
+
+    await page.waitForTimeout(500)
+    await previous.click()
+    await expect(page).toHaveURL(
+      /#\/watch\/w1WKmSqwM8I\?short=true&shortSource=subscriptions/
+    )
+    await auxPanel.getByRole('button', { name: 'Close transcript' }).click()
 
     const [playerBounds, videoAreaBounds, metadataBounds, actionBounds, previewBounds, navigationBounds] =
       await Promise.all([

--- a/e2e/tests/network/watch.spec.mjs
+++ b/e2e/tests/network/watch.spec.mjs
@@ -1226,6 +1226,21 @@ test.describe('custom Shorts player', () => {
     await expect(page).toHaveURL(
       /#\/watch\/w1WKmSqwM8I\?short=true&shortSource=subscriptions/
     )
+
+    await page.evaluate(() => window.scrollTo({
+      top: document.documentElement.scrollHeight
+    }))
+    await expect(page).toHaveURL(
+      /#\/watch\/RZ6PG5QATg4\?short=true&shortSource=subscriptions/
+    )
+    await expect(commentsPanel).toHaveClass(/shortsCommentsPanelOpen/)
+
+    await page.waitForTimeout(500)
+    await previous.click()
+    await expect(page).toHaveURL(
+      /#\/watch\/w1WKmSqwM8I\?short=true&shortSource=subscriptions/
+    )
+    await expect(commentsPanel).toHaveClass(/shortsCommentsPanelOpen/)
     await commentsPanel.getByRole('button', { name: 'Hide Comments' }).click()
 
     const [playerBounds, videoAreaBounds, metadataBounds, actionBounds, previewBounds, navigationBounds] =

--- a/e2e/tests/offline/subscriptions-refresh.spec.mjs
+++ b/e2e/tests/offline/subscriptions-refresh.spec.mjs
@@ -119,6 +119,48 @@ test.describe('incremental subscription feed refresh', () => {
   })
 })
 
+test.describe('subscription feed refresh controls', () => {
+  const cachedShort = {
+    videoId: 'cached-short',
+    title: 'Cached short',
+    author: 'Channel 0',
+    authorId: channelId(0),
+    published: now - HOUR,
+    viewCount: 1000,
+    lengthSeconds: 30,
+    liveNow: false,
+    isUpcoming: false,
+    type: 'video',
+    isNewInSubscriptionFeed: true
+  }
+
+  test.use({
+    seed: {
+      settings: {
+        ...commonSettings,
+        hideSubscriptionsShorts: false,
+        showNewSubscriptionFeedIndicators: true
+      },
+      profiles: [profileWith(1)],
+      subscriptionCache: [{
+        ...cachedChannel(0),
+        shorts: [cachedShort],
+        shortsTimestamp: new Date(now - 2 * HOUR).toISOString()
+      }]
+    }
+  })
+
+  test('keeps Mark all as seen enabled while another feed refreshes', async ({ page }) => {
+    await routeFeeds(page, () => 8_000)
+    await goTo(page, 'subscriptions')
+
+    await page.getByRole('button', { name: /Refresh Videos/ }).click()
+    await page.locator('[data-subscription-feed-tab="shorts"]').click()
+
+    await expect(page.getByRole('button', { name: 'Mark all as seen' })).toBeEnabled()
+  })
+})
+
 test.describe('cancelling a subscription feed refresh', () => {
   // More channels than are fetched at once, so that the cancellation can skip
   // the ones that haven't started yet

--- a/e2e/tests/offline/subscriptions-refresh.spec.mjs
+++ b/e2e/tests/offline/subscriptions-refresh.spec.mjs
@@ -155,6 +155,7 @@ test.describe('subscription feed refresh controls', () => {
     await goTo(page, 'subscriptions')
 
     await page.getByRole('button', { name: /Refresh Videos/ }).click()
+    await expect(page.getByRole('button', { name: 'Cancel refresh' })).toBeVisible()
     await page.locator('[data-subscription-feed-tab="shorts"]').click()
 
     await expect(page.getByRole('button', { name: 'Mark all as seen' })).toBeEnabled()

--- a/e2e/tests/offline/ui-bugfixes.spec.mjs
+++ b/e2e/tests/offline/ui-bugfixes.spec.mjs
@@ -78,6 +78,9 @@ test('Shorts top controls stay visible over white video content', async ({ page 
   await page.evaluate(() => {
     const player = document.createElement('div')
     const control = document.createElement('button')
+    const volume = document.createElement('div')
+    const volumeButton = document.createElement('button')
+    const volumeSlider = document.createElement('input')
 
     player.className = 'ftVideoPlayer shortsPlayer'
     player.style.backgroundColor = '#fff'
@@ -87,14 +90,27 @@ test('Shorts top controls stay visible over white video content', async ({ page 
     player.style.zIndex = '10000'
     control.className = 'shortsTopControl'
     control.textContent = '⋮'
-    player.append(control)
+    volume.className = 'shortsVolumeControl'
+    volumeButton.className = 'shortsTopControl'
+    volumeButton.textContent = '🔊'
+    volumeSlider.className = 'shortsVolumeSlider'
+    volumeSlider.type = 'range'
+    volume.append(volumeButton, volumeSlider)
+    player.append(control, volume)
     document.body.append(player)
   })
 
-  const control = page.locator('.shortsTopControl')
+  const control = page.locator('.shortsTopControl').first()
   await expect(control).toHaveCSS('backdrop-filter', /blur\(8px\)/)
   await control.hover()
   await expect(control).toHaveCSS('background-color', 'rgba(0, 0, 0, 0.68)')
+
+  const volume = page.locator('.shortsVolumeControl')
+  const volumeButton = volume.locator('.shortsTopControl')
+  await volume.hover()
+  await expect(volume).toHaveCSS('background-color', 'rgba(0, 0, 0, 0.58)')
+  await expect(volumeButton).toHaveCSS('background-color', 'rgba(0, 0, 0, 0)')
+  await expect(volumeButton).toHaveCSS('backdrop-filter', 'none')
 })
 
 test.describe('history reorder animation', () => {

--- a/e2e/tests/offline/ui-bugfixes.spec.mjs
+++ b/e2e/tests/offline/ui-bugfixes.spec.mjs
@@ -102,7 +102,7 @@ test('Shorts top controls stay visible over white video content', async ({ page 
 
   const control = page.locator('.shortsTopControl').first()
   await expect(control).toHaveCSS('backdrop-filter', /blur\(8px\)/)
-  await control.hover()
+  await control.evaluate(element => element.classList.add('active'))
   await expect(control).toHaveCSS('background-color', 'rgba(0, 0, 0, 0.68)')
 
   const volume = page.locator('.shortsVolumeControl')
@@ -110,7 +110,7 @@ test('Shorts top controls stay visible over white video content', async ({ page 
   const volumeSlider = volume.locator('.shortsVolumeSlider')
   await expect(volumeSlider).toHaveCSS('inline-size', '0px')
   await expect(volumeSlider).toHaveCSS('opacity', '0')
-  await volume.hover()
+  await volumeButton.focus()
   await expect(volume).toHaveCSS('background-color', 'rgba(0, 0, 0, 0.58)')
   await expect(volumeButton).toHaveCSS('background-color', 'rgba(0, 0, 0, 0)')
   await expect(volumeButton).toHaveCSS('backdrop-filter', 'none')

--- a/e2e/tests/offline/ui-bugfixes.spec.mjs
+++ b/e2e/tests/offline/ui-bugfixes.spec.mjs
@@ -107,10 +107,15 @@ test('Shorts top controls stay visible over white video content', async ({ page 
 
   const volume = page.locator('.shortsVolumeControl')
   const volumeButton = volume.locator('.shortsTopControl')
+  const volumeSlider = volume.locator('.shortsVolumeSlider')
+  await expect(volumeSlider).toHaveCSS('inline-size', '0px')
+  await expect(volumeSlider).toHaveCSS('opacity', '0')
   await volume.hover()
   await expect(volume).toHaveCSS('background-color', 'rgba(0, 0, 0, 0.58)')
   await expect(volumeButton).toHaveCSS('background-color', 'rgba(0, 0, 0, 0)')
   await expect(volumeButton).toHaveCSS('backdrop-filter', 'none')
+  await expect(volumeSlider).toHaveCSS('inline-size', '96px')
+  await expect(volumeSlider).toHaveCSS('opacity', '1')
 })
 
 test.describe('history reorder animation', () => {

--- a/src/renderer/components/ft-shaka-video-player/ft-shaka-video-player.css
+++ b/src/renderer/components/ft-shaka-video-player/ft-shaka-video-player.css
@@ -106,6 +106,7 @@
 .shortsVolumeControl .shortsTopControl {
   flex: none;
   background-color: transparent;
+  backdrop-filter: none;
 }
 
 .shortsVolumeSlider {

--- a/src/renderer/components/ft-shaka-video-player/ft-shaka-video-player.js
+++ b/src/renderer/components/ft-shaka-video-player/ft-shaka-video-player.js
@@ -345,6 +345,10 @@ export default defineComponent({
       type: Boolean,
       default: false
     },
+    sponsorBlockInfoOpen: {
+      type: Boolean,
+      default: false
+    },
     videoGenreIsMusic: {
       type: Boolean,
       default: false
@@ -1434,7 +1438,7 @@ export default defineComponent({
      */
     let sponsorBlockSegments = []
     const sponsorBlockInfoSegments = ref([])
-    const sponsorBlockInfoOpen = ref(false)
+    const sponsorBlockInfoOpen = ref(props.sponsorBlockInfoOpen)
     const sponsorBlockInfoLoading = ref(false)
     const sponsorBlockVotePending = ref(null)
     const sponsorBlockUserVotes = reactive({})
@@ -3489,7 +3493,9 @@ export default defineComponent({
         shortsCaptionsEnabled.value = false
       }
       closeChaptersOverlay()
-      closeSponsorBlockInfo()
+      if (!props.shortsPlayer) {
+        closeSponsorBlockInfo()
+      }
       resetSponsorBlockHighlightLabel()
       loadSponsorBlockDrafts()
       sponsorBlockSubmissionError.value = ''

--- a/src/renderer/views/Subscriptions/Subscriptions.vue
+++ b/src/renderer/views/Subscriptions/Subscriptions.vue
@@ -168,7 +168,7 @@
             v-if="currentTabHasNewContent"
             class="markAllSeenButton"
             type="button"
-            :disabled="markingSeenTab !== null || subscriptionFeedRefreshInProgress"
+            :disabled="markingSeenTab !== null || currentTabRefreshing"
             @click="markAllAsSeen(currentTab)"
           >
             <FontAwesomeIcon :icon="['fas', 'check']" />

--- a/src/renderer/views/Watch/Watch.js
+++ b/src/renderer/views/Watch/Watch.js
@@ -1110,9 +1110,13 @@ export default defineComponent({
         this.sabrErrorRecoveryPlayedSeconds = 0
       }
       this.ipBlockDetectedInCurrentChain = false
+      const preserveShortsPanels = videoIdChanged &&
+        this.customShortsPlayerActive &&
+        this.tabRoute.query.short === 'true'
       this.resetVideoState({
         preserveTitle,
-        placeholderTitle: videoIdChanged ? this.getRoutePlaceholderTitle() : ''
+        placeholderTitle: videoIdChanged ? this.getRoutePlaceholderTitle() : '',
+        preserveShortsPanels,
       })
 
       this.firstLoad = true
@@ -1141,13 +1145,19 @@ export default defineComponent({
       return this.tabRoute.fullPath
     },
 
-    resetVideoState: function ({ preserveTitle = false, placeholderTitle = '' } = {}) {
+    resetVideoState: function ({
+      preserveTitle = false,
+      placeholderTitle = '',
+      preserveShortsPanels = false,
+    } = {}) {
       const previousVideoTitle = this.videoTitle
 
       if (!preserveTitle) {
         this.hasResolvedVideoTitle = false
       }
-      this.shortsCommentsOpen = false
+      if (!preserveShortsPanels) {
+        this.shortsCommentsOpen = false
+      }
       this.playlistScrollPositions.sidebar = null
       this.playlistScrollPositions.fullscreen = null
       this.isLoading = true
@@ -1192,8 +1202,10 @@ export default defineComponent({
       this.legacyFormats = []
       this.captions = []
       this.currentTime = 0
-      this.showTranscript = false
-      this.shortsMetadataOpen = false
+      if (!preserveShortsPanels) {
+        this.showTranscript = false
+        this.shortsMetadataOpen = false
+      }
       this.showSidebarChapters = false
       this.videoChapterThumbnails = []
       this.vrProjection = null
@@ -1313,8 +1325,6 @@ export default defineComponent({
         return
       }
 
-      this.shortsCommentsOpen = false
-
       this.shortsTransitionDirection = Math.sign(offset)
       this.shortsTransitionPreview = getShortThumbnailUrl(
         target,
@@ -1351,7 +1361,6 @@ export default defineComponent({
       if (
         !this.subscriptionShortsFeedActive ||
         !this.isCurrentlyPresented() ||
-        this.shortsNavigationPanelOpen ||
         Math.abs(scrollY - this.shortsLastWindowScrollY) < 4
       ) {
         this.shortsLastWindowScrollY = scrollY
@@ -1372,10 +1381,16 @@ export default defineComponent({
       }
     },
 
+    isShortsPanelEvent: function (event) {
+      return Boolean(event.target?.closest?.(
+        '.shortsCommentsPanel, .shortsAuxPanel, .shaka-no-propagation'
+      ))
+    },
+
     handleShortsWheel: function (event) {
       if (
         !this.subscriptionShortsFeedActive ||
-        this.shortsNavigationPanelOpen ||
+        this.isShortsPanelEvent(event) ||
         Math.abs(event.deltaY) < 20
       ) {
         return
@@ -1388,7 +1403,7 @@ export default defineComponent({
     handleShortsPointerDown: function (event) {
       if (
         this.subscriptionShortsFeedActive &&
-        !this.shortsNavigationPanelOpen &&
+        !this.isShortsPanelEvent(event) &&
         event.pointerType === 'touch'
       ) {
         this.shortsTouchStartY = event.clientY
@@ -1399,8 +1414,8 @@ export default defineComponent({
 
     handleShortsPointerUp: function (event) {
       if (
-        this.shortsNavigationPanelOpen ||
         this.shortsTouchStartY === null ||
+        this.isShortsPanelEvent(event) ||
         event.pointerType !== 'touch'
       ) {
         this.shortsTouchStartY = null

--- a/src/renderer/views/Watch/Watch.js
+++ b/src/renderer/views/Watch/Watch.js
@@ -184,7 +184,6 @@ export default defineComponent({
       shortsNavigationLockedUntil: 0,
       shortsLastWindowScrollY: window.scrollY,
       shortsScrollResetPending: false,
-      shortsScrollbarDragging: false,
       shortsTransitionPreview: '',
       shortsTransitionDirection: 0,
       shortsViewportHeight: window.innerHeight,
@@ -768,9 +767,6 @@ export default defineComponent({
   },
   mounted: function () {
     document.addEventListener('keydown', this.handleShortsNavigationKeydown, true)
-    document.addEventListener('pointerdown', this.handleShortsScrollbarPointerDown, true)
-    document.addEventListener('pointerup', this.handleShortsScrollbarPointerUp, true)
-    document.addEventListener('pointercancel', this.handleShortsScrollbarPointerUp, true)
     window.addEventListener('resize', this.updateShortsViewportHeight)
     window.addEventListener('scroll', this.handleShortsWindowScroll, { passive: true })
     this.removeTabLifecycle = this.tabLifecycle?.register(this.tabId, {
@@ -784,9 +780,6 @@ export default defineComponent({
   },
   beforeUnmount: function () {
     document.removeEventListener('keydown', this.handleShortsNavigationKeydown, true)
-    document.removeEventListener('pointerdown', this.handleShortsScrollbarPointerDown, true)
-    document.removeEventListener('pointerup', this.handleShortsScrollbarPointerUp, true)
-    document.removeEventListener('pointercancel', this.handleShortsScrollbarPointerUp, true)
     window.removeEventListener('resize', this.updateShortsViewportHeight)
     window.removeEventListener('scroll', this.handleShortsWindowScroll)
     this.theatreModeAnimations.forEach(animation => animation.cancel())
@@ -1359,7 +1352,6 @@ export default defineComponent({
         !this.subscriptionShortsFeedActive ||
         !this.isCurrentlyPresented() ||
         this.shortsNavigationPanelOpen ||
-        !this.shortsScrollbarDragging ||
         Math.abs(scrollY - this.shortsLastWindowScrollY) < 4
       ) {
         this.shortsLastWindowScrollY = scrollY
@@ -1371,25 +1363,13 @@ export default defineComponent({
       this.navigateSubscriptionShort(offset)
 
       // The short preview deliberately gives the document a small scroll range
-      // so the page scrollbar remains draggable. Reset it after interpreting
-      // the drag; otherwise the next drag at the end of the range cannot emit
-      // another scroll event.
+      // so the page scrollbar and middle-button autoscroll can navigate. Reset
+      // it after interpreting the movement; otherwise the next movement at the
+      // end of the range cannot emit another scroll event.
       if (window.scrollY !== 0) {
         this.shortsScrollResetPending = true
         window.scrollTo({ top: 0 })
       }
-    },
-
-    handleShortsScrollbarPointerDown: function (event) {
-      this.shortsScrollbarDragging = Boolean(
-        !this.shortsNavigationPanelOpen &&
-        event.target?.closest?.('.os-scrollbar-handle')
-      )
-      this.shortsLastWindowScrollY = window.scrollY
-    },
-
-    handleShortsScrollbarPointerUp: function () {
-      this.shortsScrollbarDragging = false
     },
 
     handleShortsWheel: function (event) {

--- a/src/renderer/views/Watch/Watch.scss
+++ b/src/renderer/views/Watch/Watch.scss
@@ -643,6 +643,7 @@
       flex: 1 1 auto;
       min-block-size: 0;
       overflow: hidden;
+      overscroll-behavior: contain;
     }
 
     .shortsAuxPanelTarget :deep(.watchVideo) {
@@ -652,6 +653,25 @@
       margin-inline: 0;
       border-radius: 0;
       box-shadow: none;
+    }
+
+    .shortsAuxPanelTarget :deep(.watchVideoTranscript) {
+      display: flex;
+      flex-direction: column;
+      block-size: 100%;
+      max-block-size: none;
+      overflow: hidden;
+    }
+
+    .shortsAuxPanelTarget :deep(.transcriptSegments) {
+      flex: 1 1 auto;
+      min-block-size: 0;
+      max-block-size: none;
+      overscroll-behavior: contain;
+    }
+
+    .shortsAuxPanelTarget :deep(.sponsorBlockContent) {
+      overscroll-behavior: contain;
     }
 
     .shortsAuxPanelTarget :deep(.watchVideoInfo),

--- a/src/renderer/views/Watch/Watch.scss
+++ b/src/renderer/views/Watch/Watch.scss
@@ -606,6 +606,10 @@
       transform: translateX(0);
     }
 
+    .shortsCommentsPanel :deep(.fullscreenCommentCard) {
+      block-size: 100%;
+    }
+
     .shortsAuxPanelOpen {
       display: flex;
       opacity: 1;

--- a/src/renderer/views/Watch/Watch.vue
+++ b/src/renderer/views/Watch/Watch.vue
@@ -107,6 +107,7 @@
           :is-live="isLive"
           :is-upcoming="isUpcoming"
           :transcript-open="showTranscript"
+          :sponsor-block-info-open="showSidebarSponsorBlock"
           :video-genre-is-music="videoGenreIsMusic"
           :current-playback-rate="currentPlaybackRate"
           :current-video-quality="currentVideoQuality"


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Make sure to follow the contributing guidelines. -->
<!-- Important note, we may remove your pull request if you do not use this provided PR template correctly. -->
<!-- Do not create PR's with AI! (PRs created mainly with AI will be closed. They waste our team's time. We ban repeat offenders.) -->

## Pull Request Type
<!-- Please select what type of pull request this is: [x] -->
- [x] Bugfix
- [ ] Feature Implementation
- [ ] Documentation
- [ ] Other

## Related issue
<!-- Please link the issue your pull request is referring to. -->
<!-- If this pull request fully resolves the relevant issue, put "closes" before the issue number. -->
<!-- Example: "closes #123456". -->

Follow-up to #349.

## Description
<!-- Please write a clear and concise description of what the pull request does. -->

Fixes regressions in the custom Shorts player:

- keeps the expanded volume control on one uniform frosted surface instead of applying a darker second backdrop behind the icon
- gives the non-fullscreen comments card the panel's full height so its contents scroll within the panel
- handles document scroll events from the page scrollbar and middle-button autoscroll as Shorts navigation, rather than limiting document-scroll navigation to scrollbar dragging
- preserves open comments, metadata, transcript, SponsorBlock, and other docks while navigating between Shorts
- keeps transcript and SponsorBlock scrolling sized and contained within their panel instead of chaining wheel input to the Shorts page

The regression coverage verifies the expanded volume styling, real-comments overflow scrolling, page-scroll navigation behind an open dock, SponsorBlock/transcript persistence, transcript sizing, and contained aux-panel scrolling.

## Screenshots <!-- If appropriate -->
<!-- Please add before and after screenshots if there is a visible change. -->

Not included.

## Release note category
<!-- Select exactly one category. Every pull request must select one. -->
<!-- release-note-category:start -->
- [ ] Not noteworthy
- [ ] Highlights
- [ ] More improvements
- [x] Fixed bugs
<!-- release-note-category:end -->

## Release note
<!-- Required unless "Not noteworthy" is selected. -->
<!-- Write one concise, user-facing entry without a leading bullet. -->
<!-- release-note:start -->
Fixed Shorts volume styling, panel scrolling, page navigation, and dock persistence between videos.
<!-- release-note:end -->

## Release note image
<!-- Optional. Paste one Markdown image or HTML image tag here. -->
<!-- The release notes will use an HTML image tag and limit images taller than 300 pixels. -->
<!-- release-note-image:start -->

<!-- release-note-image:end -->

## Testing
<!-- How can reviewers verify that the PR produces correct results? -->
<!-- Please provide instructions so that others can ensure that your pull request would produce correct results. For examples see, https://github.com/FreeTubeApp/FreeTube/pull/5743, https://github.com/FreeTubeApp/FreeTube/pull/7349, https://github.com/FreeTubeApp/FreeTube/pull/5125, https://github.com/FreeTubeApp/FreeTube/pull/7338 -->

1. Open a Short and hover the volume control. Confirm the expanded pill uses one uniform background behind both the icon and slider.
2. Outside fullscreen, open Shorts comments with enough content to overflow. Confirm the comments scroll within the panel without navigating away.
3. Keep the comments panel open and scroll the page scrollbar or use middle-button autoscroll. Confirm the next Short opens behind the panel and the panel remains open.
4. Scroll inside the comments, transcript, and SponsorBlock panels. Confirm panel scrolling does not move the Shorts page.
5. Keep SponsorBlock or transcript open while changing Shorts. Confirm it remains open and the transcript scroll area fills the panel after the new video loads.
6. Automated checks:
   - `pnpm run lint`
   - `pnpm run test:unit`
   - `pnpm run test:e2e:pack`
   - `xvfb-run -a -s "-screen 0 1920x1080x24" pnpm exec playwright test -c e2e/playwright.config.mjs e2e/tests/offline/ui-bugfixes.spec.mjs --project=offline --grep "Shorts top controls"`
   - `xvfb-run -a -s "-screen 0 1920x1080x24" pnpm exec playwright test -c e2e/playwright.config.mjs e2e/tests/network/watch.spec.mjs --project=network --grep "scrolls through the cached subscriptions Shorts feed"`

## Desktop
<!-- Please complete the following information-->
- **OS:** Arch Linux
- **OS Version:** Rolling release
- **OpenTubeX version:** development

## Additional context
<!-- Add any other context about the pull request here. -->

The Shorts player and thumbnail work from #349 has already been merged, so this is intentionally a separate follow-up PR.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Shorts navigation and scroll handling, including more reliable next/previous movement and consistent auxiliary panel behavior (comments, SponsorBlock, transcript).
  * Fixed Shorts comments panel scrolling reliability and ensured fullscreen comment cards fill the available space.
  * Refined Shorts volume control UI over light video content, including backdrop-filter behavior.
  * Corrected the “Mark All as Seen” button disabled state to depend only on the currently active tab’s refresh.

* **Tests**
  * Expanded Playwright coverage for Shorts navigation, comments/auxiliary panel interactions, volume control visibility, and subscription feed refresh controls.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->