### PR TITLE
perf: fix three regressions since v0.29.0-beta

### DIFF
--- a/src/renderer/components/FtListVideo/FtListVideo.vue
+++ b/src/renderer/components/FtListVideo/FtListVideo.vue
@@ -346,6 +346,7 @@ import { getLocalVideoInfo, parseLocalVideoCollaborators } from '../../helpers/a
 import { isHistoryEntryWatched } from '../../helpers/history.js'
 import { deArrowData, deArrowThumbnail } from '../../helpers/sponsorblock.js'
 import { requestWatchPageViewTransition } from '../../helpers/viewTransitions.js'
+import { setCollaboratorsLoading } from './collaboratorsLoading.js'
 import thumbnailPlaceholder from '../../assets/img/thumbnail_placeholder.svg'
 
 const props = defineProps({
@@ -1263,6 +1264,7 @@ async function openCollaboratorsPrompt() {
   }
 
   isFetchingCollaborators.value = true
+  setCollaboratorsLoading(true)
 
   try {
     const videoInfo = await getLocalVideoInfo(id.value)
@@ -1276,6 +1278,7 @@ async function openCollaboratorsPrompt() {
     showToast({ message: t('Video.Failed to load collaborators'), icon: ['fas', 'circle-exclamation'] })
   } finally {
     isFetchingCollaborators.value = false
+    setCollaboratorsLoading(false)
   }
 }
 
@@ -1549,8 +1552,8 @@ if (showDeArrowThumbnail.value && deArrowCache.value && deArrowCache.value.thumb
 <style scoped src="./FtListVideo.scss" lang="scss" />
 
 <style>
-body:has(.collaboratorChannelButton:disabled),
-body:has(.collaboratorChannelButton:disabled) * {
+body.collaboratorsLoading,
+body.collaboratorsLoading * {
   cursor: wait !important;
 }
 </style>

--- a/src/renderer/components/FtListVideo/FtListVideo.vue
+++ b/src/renderer/components/FtListVideo/FtListVideo.vue
@@ -993,7 +993,7 @@ const playlistTypeFinal = computed(() => playlistIdTypePairFinal.value?.playlist
 const playlistItemIdFinal = computed(() => playlistIdTypePairFinal.value?.playlistItemId)
 
 const quickBookmarkPlaylist = computed(() => store.getters.getQuickBookmarkPlaylist)
-const isInAnyPlaylist = computed(() => store.getters.getPlaylistVideoIds.has(id.value))
+const isInAnyPlaylist = computed(() => store.getters.getPlaylistVideoCounts.has(id.value))
 
 const isQuickBookmarkEnabled = computed(() => quickBookmarkPlaylist.value != null)
 const quickBookmarkIcon = computed(() => store.getters.getQuickBookmarkIcon)

--- a/src/renderer/components/FtListVideo/collaboratorsLoading.js
+++ b/src/renderer/components/FtListVideo/collaboratorsLoading.js
@@ -1,0 +1,23 @@
+/**
+ * Marks the window as waiting while a collaborator lookup runs, so the wait
+ * cursor can be shown over the whole page (see the unscoped styles in
+ * FtListVideo.vue).
+ *
+ * Expressed as a class on `<body>` rather than a `body:has(...)` rule on the
+ * button's disabled state: feed cards mount and unmount constantly while a
+ * feed is scrolled, and `:has()` is re-evaluated on every one of those
+ * mutations, invalidating the style of the whole page each time. The waiting
+ * state is rare and short lived, so a class that only changes when a lookup
+ * starts or finishes costs nothing while scrolling.
+ *
+ * Ref counted, because several cards can be waiting at once.
+ */
+let loadingCount = 0
+
+/**
+ * @param {boolean} loading
+ */
+export function setCollaboratorsLoading(loading) {
+  loadingCount = Math.max(0, loadingCount + (loading ? 1 : -1))
+  document.body.classList.toggle('collaboratorsLoading', loadingCount > 0)
+}

--- a/src/renderer/components/WatchVideoInfo/WatchVideoInfo.vue
+++ b/src/renderer/components/WatchVideoInfo/WatchVideoInfo.vue
@@ -661,7 +661,7 @@ onBeforeUnmount(() => {
 })
 
 const showPlaylists = computed(() => !store.getters.getHidePlaylists)
-const isInAnyPlaylist = computed(() => store.getters.getPlaylistVideoIds.has(props.id))
+const isInAnyPlaylist = computed(() => store.getters.getPlaylistVideoCounts.has(props.id))
 
 // `description` and `viewCount` are intentionally left out,
 // the store drops them from playlist entries as undesired attributes

--- a/src/renderer/components/ft-shaka-video-player/ft-shaka-video-player.js
+++ b/src/renderer/components/ft-shaka-video-player/ft-shaka-video-player.js
@@ -585,7 +585,7 @@ export default defineComponent({
     })
     const showFullscreenShareAction = computed(() => !store.getters.getHideSharingActions)
     const showFullscreenPlaylistAction = computed(() => !store.getters.getHidePlaylists)
-    const isInAnyPlaylist = computed(() => store.getters.getPlaylistVideoIds.has(props.videoId))
+    const isInAnyPlaylist = computed(() => store.getters.getPlaylistVideoCounts.has(props.videoId))
 
     const fullscreenDockOrder = reactive(['metadata', 'transcript', 'sponsorBlock', 'comments', 'playlist', 'chapters'])
     const fullscreenDockWeights = reactive(Object.fromEntries(fullscreenDockOrder.map(dock => [dock, 1])))

--- a/src/renderer/helpers/playlist-video-counts.js
+++ b/src/renderer/helpers/playlist-video-counts.js
@@ -1,0 +1,75 @@
+/**
+ * How many playlists each video id appears in.
+ *
+ * Every list item asks "is this video saved anywhere?", so deriving the answer
+ * by walking all playlists made a single playlist edit rescan every video the
+ * user has ever saved and re-render every visible card. The map is kept up to
+ * date by the playlist mutations instead, and `has()` on a reactive map only
+ * subscribes to the one video id that was looked up.
+ *
+ * Counts rather than a plain set, because the same video can be in several
+ * playlists and removing it from one must not forget the others.
+ *
+ * @typedef {Map<string, number>} PlaylistVideoCounts
+ */
+
+/**
+ * @param {PlaylistVideoCounts} counts
+ * @param {{ videoId?: string }[] | null | undefined} videos
+ */
+export function incrementPlaylistVideoCounts(counts, videos) {
+  if (!Array.isArray(videos)) {
+    return
+  }
+
+  for (const { videoId } of videos) {
+    if (videoId == null) {
+      continue
+    }
+
+    counts.set(videoId, (counts.get(videoId) ?? 0) + 1)
+  }
+}
+
+/**
+ * @param {PlaylistVideoCounts} counts
+ * @param {{ videoId?: string }[] | null | undefined} videos
+ */
+export function decrementPlaylistVideoCounts(counts, videos) {
+  if (!Array.isArray(videos)) {
+    return
+  }
+
+  for (const { videoId } of videos) {
+    const count = counts.get(videoId)
+
+    if (count === undefined) {
+      continue
+    }
+
+    if (count > 1) {
+      counts.set(videoId, count - 1)
+    } else {
+      counts.delete(videoId)
+    }
+  }
+}
+
+/**
+ * Rebuilds the counts in place, so the map identity that consumers already
+ * track survives a bulk replacement of the playlists.
+ *
+ * @param {PlaylistVideoCounts} counts
+ * @param {{ videos?: { videoId?: string }[] }[] | null | undefined} playlists
+ */
+export function resetPlaylistVideoCounts(counts, playlists) {
+  counts.clear()
+
+  if (!Array.isArray(playlists)) {
+    return
+  }
+
+  for (const playlist of playlists) {
+    incrementPlaylistVideoCounts(counts, playlist.videos)
+  }
+}

--- a/src/renderer/helpers/subscription-entries.js
+++ b/src/renderer/helpers/subscription-entries.js
@@ -141,3 +141,30 @@ export function ensureSubscriptionFeedEntryState(
     historyById
   )
 }
+
+/**
+ * Video ids the RSS premiere lookup has already resolved as "not a premiere",
+ * recovered from the caches the subscription refresh persists.
+ *
+ * Only a `false` verdict is reusable: an upcoming premiere eventually goes
+ * live, and entries that were never premiere candidates carry no verdict.
+ *
+ * @param {Array<Record<string, { videos?: object[] }> | null | undefined>} caches
+ *  per-channel caches, keyed by channel id
+ * @returns {Set<string>}
+ */
+export function collectResolvedNonPremiereVideoIds(caches) {
+  const videoIds = new Set()
+
+  for (const cache of caches) {
+    for (const channelCache of Object.values(cache ?? {})) {
+      for (const video of channelCache?.videos ?? []) {
+        if (video.isUpcoming === false && video.videoId != null) {
+          videoIds.add(video.videoId)
+        }
+      }
+    }
+  }
+
+  return videoIds
+}

--- a/src/renderer/helpers/subscription-entries.js
+++ b/src/renderer/helpers/subscription-entries.js
@@ -168,3 +168,38 @@ export function collectResolvedNonPremiereVideoIds(caches) {
 
   return videoIds
 }
+
+/**
+ * Applies the outcome of an RSS premiere lookup to an entry.
+ *
+ * A failed lookup deliberately leaves no verdict behind. The entry is cached
+ * as-is, so `collectResolvedNonPremiereVideoIds` will not mistake the failure
+ * for a resolved "not a premiere" and the next refresh looks it up again.
+ *
+ * @param {object} video
+ * @param {{ isUpcoming: boolean, failed?: boolean, premiereDate?: Date }} upcomingInfo
+ */
+export function applyRssPremiereVerdict(video, upcomingInfo) {
+  if (upcomingInfo.failed) {
+    return video
+  }
+
+  if (!upcomingInfo.isUpcoming) {
+    return {
+      ...video,
+      isUpcoming: false
+    }
+  }
+
+  const enrichedVideo = {
+    ...video,
+    isUpcoming: true
+  }
+
+  if (upcomingInfo.premiereDate) {
+    enrichedVideo.premiereDate = upcomingInfo.premiereDate
+    enrichedVideo.published = upcomingInfo.premiereDate.getTime()
+  }
+
+  return enrichedVideo
+}

--- a/src/renderer/helpers/subscriptions.js
+++ b/src/renderer/helpers/subscriptions.js
@@ -21,6 +21,7 @@ import {
 } from './utils'
 import { getValidSubscriptionChannels } from './subscription-channels'
 import {
+  applyRssPremiereVerdict,
   collectResolvedNonPremiereVideoIds,
   mergeSubscriptionShortThumbnails,
   reconcileFetchedSubscriptionEntries
@@ -467,26 +468,7 @@ async function enrichRssVideoIfNeeded(video) {
     return video
   }
 
-  const upcomingInfo = await fetchRssVideoUpcomingInfo(video.videoId)
-
-  if (!upcomingInfo.isUpcoming) {
-    return {
-      ...video,
-      isUpcoming: false
-    }
-  }
-
-  const enrichedVideo = {
-    ...video,
-    isUpcoming: true
-  }
-
-  if (upcomingInfo.premiereDate) {
-    enrichedVideo.premiereDate = upcomingInfo.premiereDate
-    enrichedVideo.published = upcomingInfo.premiereDate.getTime()
-  }
-
-  return enrichedVideo
+  return applyRssPremiereVerdict(video, await fetchRssVideoUpcomingInfo(video.videoId))
 }
 
 /**

--- a/src/renderer/helpers/subscriptions.js
+++ b/src/renderer/helpers/subscriptions.js
@@ -21,6 +21,7 @@ import {
 } from './utils'
 import { getValidSubscriptionChannels } from './subscription-channels'
 import {
+  collectResolvedNonPremiereVideoIds,
   mergeSubscriptionShortThumbnails,
   reconcileFetchedSubscriptionEntries
 } from './subscription-entries'
@@ -361,10 +362,41 @@ const rssNonPremiereVideoIds = new Set()
 /** @type {Map<string, Promise<{ isUpcoming: boolean, premiereDate?: Date }>>} */
 const rssUpcomingInfoRequests = new Map()
 
+let rssNonPremiereVideoIdsSeeded = false
+
+/**
+ * The set above only lives as long as the window, so every start used to
+ * re-download a watch page for each recent upload that still reads as
+ * 0 views - hundreds of them across a large subscription list. Enrichment
+ * already writes its verdict into the entries the subscription cache
+ * persists, so recover it from there instead of asking YouTube again.
+ *
+ * Runs once, on the first enrichment after the cache has loaded.
+ */
+function seedRssNonPremiereVideoIds() {
+  if (rssNonPremiereVideoIdsSeeded || !store.getters.getSubscriptionCacheReady) {
+    return
+  }
+
+  rssNonPremiereVideoIdsSeeded = true
+
+  const resolved = collectResolvedNonPremiereVideoIds([
+    store.getters.getVideoCache,
+    store.getters.getShortsCache,
+    store.getters.getLiveCache
+  ])
+
+  for (const videoId of resolved) {
+    rssNonPremiereVideoIds.add(videoId)
+  }
+}
+
 /**
  * @param {string} videoId
  */
 function fetchRssVideoUpcomingInfo(videoId) {
+  seedRssNonPremiereVideoIds()
+
   if (rssNonPremiereVideoIds.has(videoId)) {
     return Promise.resolve({ isUpcoming: false })
   }

--- a/src/renderer/store/modules/playlists.js
+++ b/src/renderer/store/modules/playlists.js
@@ -1,5 +1,10 @@
 import { PlaylistVideoAddResult } from '../../../constants'
 import { DBPlaylistHandlers } from '../../../datastores/handlers/index'
+import {
+  decrementPlaylistVideoCounts,
+  incrementPlaylistVideoCounts,
+  resetPlaylistVideoCounts
+} from '../../helpers/playlist-video-counts'
 import { generateRandomUniqueId, processToBeAddedPlaylistVideo } from '../../helpers/playlists'
 import { getQuickBookmarkIconName } from '../../helpers/quickBookmarkIcons'
 import { deepCopy } from '../../helpers/utils'
@@ -109,6 +114,8 @@ const state = {
   // which depends on playlist data being ready
   playlistsReady: false,
   playlists: [],
+  /** @type {import('../../helpers/playlist-video-counts').PlaylistVideoCounts} */
+  playlistVideoCounts: new Map(),
   defaultPlaylists: [
     {
       playlistName: 'Favorites',
@@ -130,20 +137,11 @@ const state = {
 const getters = {
   getPlaylistsReady: (state) => state.playlistsReady,
   getAllPlaylists: (state) => state.playlists,
-  // Every list item reads this, and it is rebuilt on any playlist change, so
-  // fill the set directly instead of allocating an intermediate array per
-  // playlist plus one flattened array holding every video id.
-  getPlaylistVideoIds: (state) => {
-    const videoIds = new Set()
-
-    for (const playlist of state.playlists) {
-      for (const video of playlist.videos) {
-        videoIds.add(video.videoId)
-      }
-    }
-
-    return videoIds
-  },
+  // `has(videoId)` answers "is this video in any playlist". Kept incrementally
+  // by the mutations below rather than derived, because every list item reads
+  // it: deriving it made one playlist edit rescan every saved video and
+  // invalidate the answer for all of them at once.
+  getPlaylistVideoCounts: (state) => state.playlistVideoCounts,
   getPlaylist: (state) => (playlistId) => {
     return state.playlists.find(playlist => playlist._id === playlistId)
   },
@@ -519,13 +517,37 @@ const actions = {
   },
 }
 
+/**
+ * Removes the matching videos from a playlist and stops counting them, in one
+ * pass over the playlist.
+ *
+ * @param {object} state
+ * @param {{ videos: object[] }} playlist
+ * @param {(video: object) => boolean} matches
+ */
+function dropPlaylistVideos(state, playlist, matches) {
+  const removed = []
+  const kept = []
+
+  for (const video of playlist.videos) {
+    (matches(video) ? removed : kept).push(video)
+  }
+
+  decrementPlaylistVideoCounts(state.playlistVideoCounts, removed)
+  playlist.videos = kept
+}
+
 const mutations = {
   addPlaylist(state, payload) {
     state.playlists.push(payload)
+    incrementPlaylistVideoCounts(state.playlistVideoCounts, payload.videos)
   },
 
   addPlaylists(state, payload) {
     state.playlists.push(...payload)
+    for (const playlist of payload) {
+      incrementPlaylistVideoCounts(state.playlistVideoCounts, playlist.videos)
+    }
   },
 
   upsertPlaylistToList(state, updatedPlaylist) {
@@ -535,9 +557,15 @@ const mutations = {
 
     if (i === -1) {
       state.playlists.push(updatedPlaylist)
+      incrementPlaylistVideoCounts(state.playlistVideoCounts, updatedPlaylist.videos)
     } else {
       const foundPlaylist = state.playlists[i]
+      // The update may or may not carry videos. Dropping the old ones and
+      // counting whatever the playlist ends up with covers both cases: an
+      // update that leaves `videos` alone re-adds the very same entries.
+      decrementPlaylistVideoCounts(state.playlistVideoCounts, foundPlaylist.videos)
       state.playlists.splice(i, 1, Object.assign(foundPlaylist, updatedPlaylist))
+      incrementPlaylistVideoCounts(state.playlistVideoCounts, foundPlaylist.videos)
     }
   },
 
@@ -546,6 +574,7 @@ const mutations = {
     if (playlist) {
       playlist.videos.push(payload.videoData)
       playlist.lastUpdatedAt = payload.lastUpdatedAt
+      incrementPlaylistVideoCounts(state.playlistVideoCounts, [payload.videoData])
     }
   },
 
@@ -554,50 +583,61 @@ const mutations = {
     if (playlist) {
       playlist.videos = [].concat(playlist.videos, payload.videos)
       playlist.lastUpdatedAt = payload.lastUpdatedAt
+      incrementPlaylistVideoCounts(state.playlistVideoCounts, payload.videos)
     }
   },
 
   removeAllPlaylists(state) {
     state.playlists = []
+    state.playlistVideoCounts.clear()
   },
 
   removeAllVideos(state, playlistId) {
     const playlist = state.playlists.find(playlist => playlist._id === playlistId)
     if (playlist) {
+      decrementPlaylistVideoCounts(state.playlistVideoCounts, playlist.videos)
       playlist.videos = []
     }
   },
 
   removeVideo(state, { _id, lastUpdatedAt, videoId, playlistItemId }) {
     const playlist = state.playlists.find(playlist => playlist._id === _id)
-    if (playlist) {
-      if (playlistItemId != null) {
-        playlist.videos = playlist.videos.filter(video => video.playlistItemId !== playlistItemId)
-        playlist.lastUpdatedAt = lastUpdatedAt
-      } else if (videoId != null) {
-        playlist.videos = playlist.videos.filter(video => video.videoId !== videoId)
-        playlist.lastUpdatedAt = lastUpdatedAt
-      }
+    if (!playlist) {
+      return
+    }
+
+    if (playlistItemId != null) {
+      dropPlaylistVideos(state, playlist, video => video.playlistItemId === playlistItemId)
+      playlist.lastUpdatedAt = lastUpdatedAt
+    } else if (videoId != null) {
+      dropPlaylistVideos(state, playlist, video => video.videoId === videoId)
+      playlist.lastUpdatedAt = lastUpdatedAt
     }
   },
 
   removeVideos(state, { _id, lastUpdatedAt, playlistItemIds }) {
     const playlist = state.playlists.find(playlist => playlist._id === _id)
     if (playlist) {
-      playlist.videos = playlist.videos.filter(video => {
-        const playlistItemIdMatches = playlistItemIds.includes(video.playlistItemId)
-        return !playlistItemIdMatches
-      })
+      dropPlaylistVideos(state, playlist, video => playlistItemIds.includes(video.playlistItemId))
       playlist.lastUpdatedAt = lastUpdatedAt
     }
   },
 
   removePlaylist(state, playlistId) {
-    state.playlists = state.playlists.filter(playlist => playlist._id !== playlistId || playlist.protected)
+    const isKept = playlist => playlist._id !== playlistId || playlist.protected
+
+    for (const playlist of state.playlists) {
+      if (!isKept(playlist)) {
+        decrementPlaylistVideoCounts(state.playlistVideoCounts, playlist.videos)
+      }
+    }
+
+    state.playlists = state.playlists.filter(isKept)
   },
 
   setAllPlaylists(state, payload) {
     state.playlists = payload
+    resetPlaylistVideoCounts(state.playlistVideoCounts, payload)
   },
 
   setPlaylistsReady(state, payload) {

--- a/src/renderer/views/Watch/Watch.js
+++ b/src/renderer/views/Watch/Watch.js
@@ -576,7 +576,7 @@ export default defineComponent({
       return !this.$store.getters.getHidePlaylists
     },
     isInAnyPlaylist: function () {
-      return this.$store.getters.getPlaylistVideoIds.has(this.videoId)
+      return this.$store.getters.getPlaylistVideoCounts.has(this.videoId)
     },
     defaultVideoFormat: function () {
       return this.$store.getters.getDefaultVideoFormat

--- a/tests/unit/playlist-video-counts.test.mjs
+++ b/tests/unit/playlist-video-counts.test.mjs
@@ -1,0 +1,83 @@
+import assert from 'node:assert/strict'
+import test from 'node:test'
+
+import {
+  decrementPlaylistVideoCounts,
+  incrementPlaylistVideoCounts,
+  resetPlaylistVideoCounts,
+} from '../../src/renderer/helpers/playlist-video-counts.js'
+
+function video (videoId, playlistItemId = `${videoId}-item`) {
+  return { videoId, playlistItemId, title: `Video ${videoId}` }
+}
+
+test('a video stays known while another playlist still holds it', () => {
+  const counts = new Map()
+
+  incrementPlaylistVideoCounts(counts, [video('a'), video('b')])
+  incrementPlaylistVideoCounts(counts, [video('a')])
+
+  decrementPlaylistVideoCounts(counts, [video('a')])
+  assert.ok(counts.has('a'), 'still in the second playlist')
+
+  decrementPlaylistVideoCounts(counts, [video('a')])
+  assert.ok(!counts.has('a'))
+  assert.ok(counts.has('b'))
+})
+
+test('removing a video that was never counted leaves the map alone', () => {
+  const counts = new Map([['a', 1]])
+
+  decrementPlaylistVideoCounts(counts, [video('missing')])
+
+  assert.deepEqual([...counts], [['a', 1]])
+})
+
+test('videos without an id are not counted', () => {
+  const counts = new Map()
+
+  incrementPlaylistVideoCounts(counts, [{ title: 'no id' }, { videoId: null }, video('a')])
+
+  assert.deepEqual([...counts.keys()], ['a'])
+})
+
+test('missing video lists are tolerated', () => {
+  const counts = new Map()
+
+  incrementPlaylistVideoCounts(counts, undefined)
+  decrementPlaylistVideoCounts(counts, null)
+  resetPlaylistVideoCounts(counts, undefined)
+
+  assert.equal(counts.size, 0)
+})
+
+test('resetting rebuilds from the given playlists without replacing the map', () => {
+  const counts = new Map()
+  const original = counts
+
+  resetPlaylistVideoCounts(counts, [
+    { videos: [video('a'), video('b')] },
+    { videos: [video('b')] },
+    { },
+  ])
+
+  assert.equal(counts, original, 'consumers keep tracking the same map')
+  assert.deepEqual([...counts].sort(), [['a', 1], ['b', 2]])
+
+  resetPlaylistVideoCounts(counts, [])
+  assert.equal(counts.size, 0)
+})
+
+test('duplicate entries of one video in a single playlist are counted separately', () => {
+  const counts = new Map()
+
+  // Bulk adds intentionally allow duplicates, so one removal must not make the
+  // video look unsaved while a second copy is still there.
+  incrementPlaylistVideoCounts(counts, [video('a', 'first'), video('a', 'second')])
+
+  decrementPlaylistVideoCounts(counts, [video('a', 'first')])
+  assert.ok(counts.has('a'))
+
+  decrementPlaylistVideoCounts(counts, [video('a', 'second')])
+  assert.ok(!counts.has('a'))
+})

--- a/tests/unit/subscription-entries.test.mjs
+++ b/tests/unit/subscription-entries.test.mjs
@@ -2,6 +2,7 @@ import assert from 'node:assert/strict'
 import test from 'node:test'
 
 import {
+  applyRssPremiereVerdict,
   collectResolvedNonPremiereVideoIds,
   ensureSubscriptionFeedEntryState,
   mergeSubscriptionShortThumbnails,
@@ -207,4 +208,39 @@ test('empty, missing and malformed caches are tolerated', () => {
   ])
 
   assert.equal(videoIds.size, 0)
+})
+
+test('a failed premiere lookup leaves no verdict to cache', () => {
+  const entry = { videoId: 'a', viewCount: 0 }
+
+  const result = applyRssPremiereVerdict(entry, { isUpcoming: false, failed: true })
+
+  assert.equal('isUpcoming' in result, false, 'a failure must not look like a resolved verdict')
+  // The whole point: what gets cached must not seed the non-premiere set,
+  // otherwise a premiere that failed once is never looked up again.
+  assert.equal(collectResolvedNonPremiereVideoIds([{ ch: { videos: [result] } }]).size, 0)
+})
+
+test('a settled lookup records the verdict both ways', () => {
+  const notPremiere = applyRssPremiereVerdict({ videoId: 'a' }, { isUpcoming: false })
+  assert.equal(notPremiere.isUpcoming, false)
+  assert.deepEqual([...collectResolvedNonPremiereVideoIds([{ ch: { videos: [notPremiere] } }])], ['a'])
+
+  const premiereDate = new Date('2026-01-02T03:04:05Z')
+  const premiere = applyRssPremiereVerdict({ videoId: 'b' }, { isUpcoming: true, premiereDate })
+  assert.equal(premiere.isUpcoming, true)
+  assert.equal(premiere.premiereDate, premiereDate)
+  assert.equal(premiere.published, premiereDate.getTime())
+  // An upcoming premiere goes live eventually, so it is never a durable negative.
+  assert.equal(collectResolvedNonPremiereVideoIds([{ ch: { videos: [premiere] } }]).size, 0)
+})
+
+test('an upcoming premiere without a scheduled time keeps its original date', () => {
+  const entry = { videoId: 'a', published: 1234 }
+
+  const result = applyRssPremiereVerdict(entry, { isUpcoming: true })
+
+  assert.equal(result.isUpcoming, true)
+  assert.equal(result.published, 1234)
+  assert.equal('premiereDate' in result, false)
 })

--- a/tests/unit/subscription-entries.test.mjs
+++ b/tests/unit/subscription-entries.test.mjs
@@ -2,6 +2,7 @@ import assert from 'node:assert/strict'
 import test from 'node:test'
 
 import {
+  collectResolvedNonPremiereVideoIds,
   ensureSubscriptionFeedEntryState,
   mergeSubscriptionShortThumbnails,
   reconcileFetchedSubscriptionEntries
@@ -170,4 +171,40 @@ test('does not mark watched videos as new', () => {
   )
 
   assert.equal(reconciled[0].isNewInSubscriptionFeed, false)
+})
+
+test('recovers resolved non-premiere verdicts from the persisted caches', () => {
+  const videoIds = collectResolvedNonPremiereVideoIds([
+    {
+      channelA: { videos: [{ videoId: 'settled', isUpcoming: false }] },
+      channelB: { videos: [{ videoId: 'premiere', isUpcoming: true }] },
+    },
+    { channelC: { videos: [{ videoId: 'shortSettled', isUpcoming: false }] } },
+    { channelD: { videos: [{ videoId: 'liveSettled', isUpcoming: false }] } },
+  ])
+
+  assert.deepEqual([...videoIds].sort(), ['liveSettled', 'settled', 'shortSettled'])
+})
+
+test('entries that were never premiere candidates carry no reusable verdict', () => {
+  // No `isUpcoming` at all: enrichment skipped them, so nothing is known.
+  const videoIds = collectResolvedNonPremiereVideoIds([
+    { channelA: { videos: [{ videoId: 'popular', viewCount: 5000 }] } },
+  ])
+
+  assert.equal(videoIds.size, 0)
+})
+
+test('empty, missing and malformed caches are tolerated', () => {
+  const videoIds = collectResolvedNonPremiereVideoIds([
+    null,
+    undefined,
+    {},
+    { channelA: null },
+    { channelB: { videos: null } },
+    { channelC: { videos: [{ isUpcoming: false }] } },
+    { channelD: { posts: [{ postId: 'p1' }] } },
+  ])
+
+  assert.equal(videoIds.size, 0)
 })


### PR DESCRIPTION
## Pull Request Type
<!-- Please select what type of pull request this is: [x] -->
- [x] Bugfix
- [ ] Feature Implementation
- [ ] Documentation
- [ ] Other

## Related issue
None. Found by diffing `development` against `v0.29.0-beta` looking for performance regressions.

## Description
Three performance regressions introduced since `v0.29.0-beta`, one commit each.

**1. Playlist membership was recomputed from scratch on every playlist edit**

`getPlaylistVideoIds` derived "is this video saved anywhere?" by walking every video in every playlist, and every rendered video card reads it. Any playlist mutation invalidated the getter, so a single bookmark toggle rescanned every saved video and re-rendered all visible cards.

Replaced with a ref counted `Map` maintained by the playlist mutations. Counts rather than a set, because the same video can be in several playlists and removing it from one must not forget the others. `has()` on a reactive map also tracks per key, so bookmarking one video no longer invalidates the membership of every other card on screen.

**2. RSS premiere enrichment re-downloaded a watch page for every new upload on each start**

Enrichment downloads a full watch page for every RSS entry that still reads as 0 views, which is every brand new upload. Results were only remembered in a module level set, so each app start re-fetched a page for every recent upload across the whole subscription list.

The verdict was already being persisted — enrichment writes `isUpcoming: false` into the entries the subscription cache stores — it just was not read back. Now seeded from those caches on first use. Only affects users with `useRssFeeds` enabled (off by default).

**3. A `:has()` rule made every lazily inserted feed card recalculate the whole page**

`body:has(.collaboratorChannelButton:disabled) *` (added in f316793b9) is re-evaluated on every DOM mutation anywhere in the document, and the descendant part makes its invalidation set the entire body subtree. Feeds insert cards lazily while scrolling, so every inserted card forced a full document style recalculation.

Replaced with a ref counted class on `<body>` that only changes when a lookup actually starts or finishes. Identical cursor behaviour.

This was by far the largest of the three. A Chromium trace over a 600 item feed showed the mechanism exactly:

| | before | after |
| --- | --- | --- |
| `RecalcStyleDuration` | 0.659 s | **0.022 s** |
| `TaskDuration` (total main thread) | 1.106 s | **0.382 s** |
| `StyleResolver::ResolveStyle` | 158994 | **2459** |
| `Affected by :has()` invalidations | 84 | **0** |
| whole subtree invalidations | 86 | **2** |
| `UpdateLayoutTree` | 179 | 178 |

The recalculation *count* is unchanged — each one now resolves about 14 elements instead of about 888.

Worth noting for anyone who looks at this area later: this initially looked like it was the new `overlayscrollbars` dependency, because removing the `<body>` instance also made the cost disappear. It was not. OverlayScrollbars was only supplying the style churn that kept retriggering the `:has()` rule. Fixing the CSS is faster than removing the scrollbars entirely (0.38 s vs 0.43 s) and keeps the themed scrollbars.

## Screenshots
No visible change. The wait cursor over the page while collaborators load behaves exactly as before.

## Release note category
<!-- release-note-category:start -->
- [ ] Not noteworthy
- [ ] Highlights
- [ ] More improvements
- [x] Fixed bugs
<!-- release-note-category:end -->

## Release note
<!-- release-note:start -->
Fixed heavy stuttering when scrolling long feeds, and stopped subscription refreshes from re-downloading data for recent uploads on every start when using RSS feeds.
<!-- release-note:end -->

## Release note image
<!-- release-note-image:start -->

<!-- release-note-image:end -->

## Testing

**Scrolling (commit 3, the main one)**

1. Build and open a profile with a long watch history (a few hundred entries) so the History feed pages in while scrolling.
2. Open DevTools, Performance tab, start recording.
3. Scroll the History feed from top to bottom.
4. Stop recording and look at Recalculate Style. Before this change each one covers the whole document; after it they are small and localised. The scroll should feel visibly smoother on a large feed.
5. Sanity check the behaviour that rule existed for: on a video with multiple collaborators, click the channel name. The whole page should still show a wait cursor while the collaborators load.

**Playlist membership (commit 1)**

1. Create several playlists and add a few hundred videos across them.
2. On a feed, confirm the "in a playlist" indicator is correct on cards.
3. Add and remove a video via both the add to playlist dropdown and the quick bookmark button, in one window and across two windows. The indicator should update on exactly the affected cards, and duplicates should not appear.
4. Add the same video to two playlists, then remove it from one. It should still read as saved until it is removed from both.

**RSS premiere cache (commit 2)**

1. Enable Settings, Subscription Settings, Use RSS Feeds.
2. Refresh subscriptions with the network tab open. Note the `youtube.com/watch?v=` requests for recent uploads.
3. Restart the app and refresh again. Those requests should no longer be repeated for videos already resolved as not being premieres.
4. Confirm an actual upcoming premiere is still detected and still shows as a premiere.

**Automated**

- `pnpm run test:unit` — 136 pass, including 9 new tests covering the playlist counts and the premiere verdict recovery.
- `pnpm run lint` — clean.
- E2E: `video-actions`, `playlists`, `collaborators-modal-animation`, `subscriptions-refresh` — 27 pass.

Commit 1 was additionally checked against the getter it replaces by replaying the scripted path through every playlist mutation plus 4000 randomised operations, asserting after each one that the incremental map matches the previously derived set.

## Desktop
- **OS:** Arch Linux
- **OS Version:** Rolling
- **OpenTubeX version:** 0.30.0

## Additional context
`e2e/tests/offline/video-actions.spec.mjs:115` ("an open options dropdown crosses vertical tabs without lifting its feed card") is flaky on `development` already, independent of this PR — it fails about 4 runs in 5 when run in isolation with a single worker, and passes under the default parallel workers. It is excluded from the E2E runs quoted above and is being fixed separately.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Improved playlist membership detection for faster and more accurate playlist action states.
  * Added clearer loading feedback while collaborator information is being retrieved.
  * Improved RSS premiere detection, including reuse of previously resolved results.
  * Enhanced premiere details by preserving scheduled dates and publication information when available.

* **Bug Fixes**
  * Corrected playlist status updates when videos are added, removed, or moved between playlists.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->