### PR TITLE
Support multiple release note images

### DIFF
--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -1,4 +1,5 @@
 # yaml-language-server: $schema=https://coderabbit.ai/integrations/schema.v2.json
 
 reviews:
+  high_level_summary: false
   request_changes_workflow: true

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -36,8 +36,8 @@
 
 <!-- release-note:end -->
 
-## Release note image
-<!-- Optional. Paste one Markdown image or HTML image tag here. -->
+## Release note images
+<!-- Optional. Paste one or more Markdown images or HTML image tags here. -->
 <!-- The release notes will use an HTML image tag and limit images taller than 300 pixels. -->
 <!-- release-note-image:start -->
 

--- a/_scripts/releaseNotes.mjs
+++ b/_scripts/releaseNotes.mjs
@@ -77,30 +77,33 @@ function extractHtmlAttribute(tag, attribute) {
   return match?.[1] ?? match?.[2] ?? null
 }
 
-export function parseReleaseImage(section) {
-  if (!section) { return null }
+export function parseReleaseImages(section) {
+  if (!section) { return [] }
 
-  const markdownImage = section.match(/!\[([^\]]*)\]\((https:\/\/[^\s)]+)(?:\s+["'][^"']*["'])?\)/)
+  const images = [...section.matchAll(/!\[([^\]]*)\]\(([^\s)]+)(?:\s+["'][^"']*["'])?\)|<img\b[^>]*>/gi)]
+    .map((match) => {
+      if (match[1] !== undefined) {
+        return {
+          alt: match[1].trim(),
+          url: match[2],
+        }
+      }
 
-  if (markdownImage) {
-    return {
-      alt: markdownImage[1].trim(),
-      url: markdownImage[2],
-    }
+      const url = extractHtmlAttribute(match[0], 'src')
+
+      if (!url) { throw new Error('A release note image is missing its src attribute.') }
+
+      return {
+        alt: decodeHtml(extractHtmlAttribute(match[0], 'alt') ?? ''),
+        url: decodeHtml(url),
+      }
+    })
+
+  if (images.length === 0) {
+    throw new Error('Release note images must be Markdown images or <img> tags.')
   }
 
-  const htmlImage = section.match(/<img\b[^>]*>/i)
-
-  if (!htmlImage) { throw new Error('The release note image must be a Markdown image or an <img> tag.') }
-
-  const url = extractHtmlAttribute(htmlImage[0], 'src')
-
-  if (!url) { throw new Error('The release note image is missing its src attribute.') }
-
-  return {
-    alt: decodeHtml(extractHtmlAttribute(htmlImage[0], 'alt') ?? ''),
-    url: decodeHtml(url),
-  }
+  return images
 }
 
 function validateImageUrl(value, allowedHosts = ALLOWED_IMAGE_HOSTS) {
@@ -127,11 +130,11 @@ export function parseReleaseNote(body) {
   if (!note) { throw new Error('Fill in the release note section before merging this noteworthy PR.') }
 
   const imageSection = extractMarkedSection(body, RELEASE_IMAGE_MARKER)
-  const image = parseReleaseImage(imageSection)
+  const images = parseReleaseImages(imageSection)
 
-  if (image) { validateImageUrl(image.url) }
+  for (const image of images) { validateImageUrl(image.url) }
 
-  return { image, note }
+  return { images, note }
 }
 
 export function parseReleaseNoteCategory(body) {
@@ -386,9 +389,9 @@ export async function renderReleaseNotes(pullRequests, loadImage = downloadImage
 
     let releaseNote = `- ${indentContinuationLines(parsed.note)}`
 
-    if (parsed.image) {
+    for (const image of parsed.images) {
       try {
-        releaseNote += `\n  ${await normalizeReleaseImage(parsed.image, pullRequest.title, loadImage)}`
+        releaseNote += `\n  ${await normalizeReleaseImage(image, pullRequest.title, loadImage)}`
       } catch (error) {
         throw new Error(`PR #${pullRequest.number}: ${error.message}`, { cause: error })
       }

--- a/_scripts/releaseNotes.mjs
+++ b/_scripts/releaseNotes.mjs
@@ -80,7 +80,22 @@ function extractHtmlAttribute(tag, attribute) {
 export function parseReleaseImages(section) {
   if (!section) { return [] }
 
-  const images = [...section.matchAll(/!\[([^\]]*)\]\(([^\s)]+)(?:\s+["'][^"']*["'])?\)|<img\b[^>]*>/gi)]
+  const matches = [...section.matchAll(/!\[([^\]]*)\]\(([^\s)]+)(?:\s+["'][^"']*["'])?\)|<img\b[^>]*>/gi)]
+  let end = 0
+
+  for (const match of matches) {
+    if (section.slice(end, match.index).trim()) {
+      throw new Error('Release note images must be Markdown images or <img> tags.')
+    }
+
+    end = match.index + match[0].length
+  }
+
+  if (section.slice(end).trim()) {
+    throw new Error('Release note images must be Markdown images or <img> tags.')
+  }
+
+  const images = matches
     .map((match) => {
       if (match[1] !== undefined) {
         return {

--- a/tests/unit/release-notes.test.mjs
+++ b/tests/unit/release-notes.test.mjs
@@ -220,6 +220,18 @@ ${NOTE_MARKERS}
   )
 })
 
+test('malformed image entries are rejected after valid images', () => {
+  for (const malformedImage of ['![Broken image](', '<img src="https://github.com/user-attachments/assets/broken"']) {
+    assert.throws(() => parseReleaseNote(`
+${NOTE_MARKERS}
+<!-- release-note-image:start -->
+![Screenshot](https://github.com/user-attachments/assets/example)
+${malformedImage}
+<!-- release-note-image:end -->
+`), /must be Markdown images or <img> tags/)
+  }
+})
+
 test('GitHub user attachment storage redirects are accepted narrowly', () => {
   assert.equal(
     validateDownloadedImageUrl('https://github-production-user-asset-6210df.s3.amazonaws.com/image.png').hostname,

--- a/tests/unit/release-notes.test.mjs
+++ b/tests/unit/release-notes.test.mjs
@@ -153,19 +153,23 @@ test('paginated pull request results are flattened', () => {
   }])
 })
 
-test('a release note and optional Markdown image are parsed', () => {
+test('a release note and optional Markdown images are parsed', () => {
   const result = parseReleaseNote(`
 ${NOTE_MARKERS}
 <!-- release-note-image:start -->
 ![Compact player](https://github.com/user-attachments/assets/example)
+![Queue and player](https://github.com/user-attachments/assets/second)
 <!-- release-note-image:end -->
 `)
 
   assert.deepEqual(result, {
-    image: {
+    images: [{
       alt: 'Compact player',
       url: 'https://github.com/user-attachments/assets/example',
-    },
+    }, {
+      alt: 'Queue and player',
+      url: 'https://github.com/user-attachments/assets/second',
+    }],
     note: 'Adds a compact player.',
   })
 })
@@ -178,10 +182,10 @@ ${NOTE_MARKERS}
 <!-- release-note-image:end -->
 `)
 
-  assert.deepEqual(result.image, {
+  assert.deepEqual(result.images, [{
     alt: 'A & B',
     url: 'https://github.com/user-attachments/assets/example?name=a&amp;b',
-  })
+  }])
 })
 
 test('HTML image parsing ignores data attributes', () => {
@@ -192,10 +196,10 @@ ${NOTE_MARKERS}
 <!-- release-note-image:end -->
 `)
 
-  assert.deepEqual(result.image, {
+  assert.deepEqual(result.images, [{
     alt: 'Right',
     url: 'https://github.com/user-attachments/assets/right',
-  })
+  }])
 })
 
 test('initial image URLs must use HTTPS and a GitHub host', () => {
@@ -282,6 +286,7 @@ ${categoryMarkers('Highlights')}
 ${NOTE_MARKERS}
 <!-- release-note-image:start -->
 <img src="https://github.com/user-attachments/assets/example" alt="Screenshot" width="800" height="600">
+![Settings](https://github.com/user-attachments/assets/second)
 <!-- release-note-image:end -->
 `,
       number: 42,
@@ -323,6 +328,7 @@ Fixed videos failing to load.
 
 - Adds a compact player.
   <img src="https://github.com/user-attachments/assets/example" alt="Screenshot" height="300">
+  <img src="https://github.com/user-attachments/assets/second" alt="Settings" height="300">
 
 ## More improvements
 


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Make sure to follow the contributing guidelines. -->
<!-- Important note, we may remove your pull request if you do not use this provided PR template correctly. -->
<!-- Do not create PR's with AI! (PRs created mainly with AI will be closed. They waste our team's time. We ban repeat offenders.) -->

## Pull Request Type
<!-- Please select what type of pull request this is: [x] -->
- [ ] Bugfix
- [x] Feature Implementation
- [ ] Documentation
- [ ] Other

## Related issue
<!-- Please link the issue your pull request is referring to. -->
<!-- If this pull request fully resolves the relevant issue, put "closes" before the issue number. -->
<!-- Example: "closes #123456". -->

## Description
<!-- Please write a clear and concise description of what the pull request does. -->
Supports multiple Markdown or HTML images in a pull request's release note image section. The draft release workflow now validates, sizes, and renders every pasted image in order instead of silently using only the first.

Also disables CodeRabbit's automatic summary in the pull request body so it does not modify the structured release note fields.

## Screenshots <!-- If appropriate -->
<!-- Please add before and after screenshots if there is a visible change. -->
Not applicable.

## Release note category
<!-- Select exactly one category. Every pull request must select one. -->
<!-- release-note-category:start -->
- [x] Not noteworthy
- [ ] Highlights
- [ ] More improvements
- [ ] Fixed bugs
<!-- release-note-category:end -->

## Release note
<!-- Required unless "Not noteworthy" is selected. -->
<!-- Write one concise, user-facing entry without a leading bullet. -->
<!-- release-note:start -->

<!-- release-note:end -->

## Release note images
<!-- Optional. Paste one or more Markdown images or HTML image tags here. -->
<!-- The release notes will use an HTML image tag and limit images taller than 300 pixels. -->
<!-- release-note-image:start -->

<!-- release-note-image:end -->

## Testing
<!-- How can reviewers verify that the PR produces correct results? -->
<!-- Please provide instructions so that others can ensure that your pull request would produce correct results. For examples see, https://github.com/FreeTubeApp/FreeTube/pull/5743, https://github.com/FreeTubeApp/FreeTube/pull/7349, https://github.com/FreeTubeApp/FreeTube/pull/5125, https://github.com/FreeTubeApp/FreeTube/pull/7338 -->
- `node --test tests/unit/*.test.mjs`
- `pnpm exec eslint --config eslint.config.mjs _scripts/releaseNotes.mjs .coderabbit.yaml`
- `git diff --check`

## Desktop
<!-- Please complete the following information-->
- **OS:** Arch Linux
- **OS Version:** Rolling release
- **OpenTubeX version:** development

## Additional context
Desktop environment: KDE Plasma on Wayland.
