### PR TITLE
Prevent ghost tab restores and improve startup responsiveness

### DIFF
--- a/e2e/tests/offline/tabs.spec.mjs
+++ b/e2e/tests/offline/tabs.spec.mjs
@@ -574,6 +574,23 @@ test.describe('tab bar', () => {
 })
 
 test.describe('closed tabs', () => {
+  test('does not restore a tab whose deferred close is interrupted by shutdown', async ({ app }) => {
+    let page = app.page
+    const closedTabId = await page.locator(sel.activeTab).getAttribute('data-tab-id')
+
+    await page.evaluate(() => window.ftElectron.tabs.create({
+      route: '/about',
+      makeActive: false,
+      lazyLoad: true
+    }))
+
+    await page.locator(sel.activeTab).locator('.closeButton').evaluate(element => element.click())
+    ;({ page } = await app.relaunch())
+    await expect(page.locator(sel.tabs)).toHaveCount(1)
+    await expect(page.locator(sel.tabs)).not.toHaveAttribute('data-tab-id', closedTabId)
+    await expect(page).toHaveURL(/#\/about/)
+  })
+
   test('restoring a closed tab restores its navigation history', async ({ page }) => {
     await goTo(page, 'settings')
     await goTo(page, 'history')

--- a/src/main/index.js
+++ b/src/main/index.js
@@ -2068,11 +2068,14 @@ function runApp() {
       // Load the shared Vue shell exactly once. Logical tab routes are projected
       // by the renderer after it reconciles the main-owned metadata.
       await newWindow.loadURL(ROOT_APP_URL)
+      // The shared shell has finished loading and can paint its themed frame.
+      // Do not keep the whole native window hidden while the initial logical
+      // route finishes mounting; that made startup feel substantially slower.
+      showWindow()
       await tabManager.waitForInitialPresentation()
       if (typeof searchQueryText === 'string' && searchQueryText.length > 0) {
         newWindow.webContents.send(IpcChannels.UPDATE_SEARCH_INPUT_TEXT, searchQueryText)
       }
-      showWindow()
     }
 
     // Kick off tab initialization (errors are logged but shouldn't crash the app)

--- a/src/main/tabs/TabManager.js
+++ b/src/main/tabs/TabManager.js
@@ -1152,6 +1152,7 @@ export class TabManager {
             this.activateTab(nextTabId)
           }
         }
+        this._saveSession()
         return true
       }
       return true
@@ -2162,7 +2163,12 @@ export class TabManager {
     this.sessionUpdatedAt = Date.now()
 
     const tabs = Array.from(this.tabs.values())
-      .filter(tab => tab.isTransferStaged !== true)
+      // A presented tab stays mounted until its replacement is ready, but a
+      // shutdown during that handoff must not resurrect the already-closed tab.
+      .filter(tab => (
+        tab.isTransferStaged !== true &&
+        !this._deferredCloseTabIds.has(tab.id)
+      ))
       .map(tab => {
         const tabData = {
           id: tab.id,
@@ -2170,7 +2176,7 @@ export class TabManager {
           title: tab.title,
           isPinned: tab.isPinned,
           color: TabManager.normalizeTabColor(tab.color),
-          isUnloaded: tab.loadState === 'unloaded'
+          isUnloaded: tab.loadState === 'unloaded' || this._deferredUnloadTabIds.has(tab.id)
         }
 
         const previewFileName = TabManager.normalizePreviewFileName(tab.previewFileName)
@@ -2186,10 +2192,13 @@ export class TabManager {
 
         return tabData
       })
+    const activeTabId = tabs.some(tab => tab.id === this.activeTabId)
+      ? this.activeTabId
+      : tabs[0]?.id ?? null
 
     await saveTabSession(this.sessionId, {
       tabs,
-      activeTabId: this.activeTabId,
+      activeTabId,
       bounds: this._getCurrentBounds(),
       updatedAt: this.sessionUpdatedAt
     })
@@ -2201,21 +2210,28 @@ export class TabManager {
    */
   getSyncSession() {
     const state = this.getState()
-    return {
-      sessionId: this.sessionId,
-      tabs: state.tabs.map(tab => ({
+    const tabs = state.tabs
+      .filter(tab => !this._deferredCloseTabIds.has(tab.id))
+      .map(tab => ({
         id: tab.id,
         url: TabManager.stripOneTimeTimestampFromUrl(tab.url),
         title: tab.title,
         isPinned: tab.isPinned,
         color: tab.color,
-        isUnloaded: tab.isUnloaded,
+        isUnloaded: tab.isUnloaded || this._deferredUnloadTabIds.has(tab.id),
         ...(this.tabs.get(tab.id)?.persistNavigationHistory && tab.history != null && {
           history: tab.history,
           historyIndex: tab.historyIndex
         })
-      })),
-      activeTabId: state.activeTabId,
+      }))
+    const activeTabId = tabs.some(tab => tab.id === state.activeTabId)
+      ? state.activeTabId
+      : tabs[0]?.id ?? null
+
+    return {
+      sessionId: this.sessionId,
+      tabs,
+      activeTabId,
       updatedAt: this.sessionUpdatedAt
     }
   }
@@ -2300,7 +2316,6 @@ export class TabManager {
         const makeActive = tabData.id === sessionData.activeTabId
         const hasSavedTitle = typeof tabData.title === 'string' && tabData.title.trim().length > 0
         const previewFileName = TabManager.normalizePreviewFileName(tabData.previewFileName)
-        const previewDataUrl = await this._loadTabPreviewDataUrl(previewFileName)
         const loadInBackground = loadInactiveTabs || (restoreTabLoadState && tabData.isUnloaded === false)
         const restoreAsUnloaded = !loadInactiveTabs && !makeActive && (
           (restoreTabLoadState && tabData.isUnloaded === true) ||
@@ -2314,8 +2329,10 @@ export class TabManager {
           title: hasSavedTitle ? tabData.title : undefined,
           isPinned: tabData.isPinned === true,
           color: tabData.color,
-          previewDataUrl,
-          previewCapturedAt: previewDataUrl != null && Number.isFinite(tabData.previewCapturedAt)
+          // Preview images are only needed when the switcher asks for them.
+          // Keep the cache reference and let getTabPreview load it on demand
+          // instead of serially reading every restored tab before first paint.
+          previewCapturedAt: previewFileName != null && Number.isFinite(tabData.previewCapturedAt)
             ? tabData.previewCapturedAt
             : 0,
           previewFileName,

--- a/src/main/tabs/TabManager.js
+++ b/src/main/tabs/TabManager.js
@@ -1812,6 +1812,7 @@ export class TabManager {
             this.activateTab(nextTabId)
           }
         }
+        this._saveSession()
         return true
       }
       return true


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Make sure to follow the contributing guidelines. -->
<!-- Important note, we may remove your pull request if you do not use this provided PR template correctly. -->

## Pull Request Type
<!-- Please select what type of pull request this is: [x] -->
- [x] Bugfix
- [ ] Feature Implementation
- [ ] Documentation
- [ ] Other

## Related issue
<!-- Please link the issue your pull request is referring to. -->
<!-- If this pull request fully resolves the relevant issue, put "closes" before the issue number. -->
<!-- Example: "closes #123456". -->

Follow-up to #364 and #366.

## Description
<!-- Please write a clear and concise description of what the pull request does. -->

Prevents a tab whose close is still being finalized from being written back into local or synced session state. This stops the closed tab from reappearing when the app shuts down before its replacement finishes mounting.

It also restores faster perceived startup by showing the loaded application shell before logical-tab presentation completes, and avoids serially reading every cached tab preview during session restoration. Preview images continue to load on demand when the tab switcher requests them.

## Screenshots <!-- If appropriate -->
<!-- Please add before and after screenshots if there is a visible change. -->

Not applicable.

## Release note category
<!-- Select exactly one category. Every pull request must select one. -->
<!-- release-note-category:start -->
- [ ] Not noteworthy
- [ ] Highlights
- [ ] More improvements
- [x] Fixed bugs
<!-- release-note-category:end -->

## Release note
<!-- Required unless "Not noteworthy" is selected. -->
<!-- Write one concise, user-facing entry without a leading bullet. -->
<!-- release-note:start -->
Prevented closed tabs from reappearing after shutdown and made the app window appear sooner on startup.
<!-- release-note:end -->

## Release note images
<!-- Optional. Paste one or more Markdown images or HTML image tags here. -->
<!-- The release notes will use an HTML image tag and limit images taller than 300 pixels. -->
<!-- release-note-image:start -->

<!-- release-note-image:end -->

## Testing
<!-- How can reviewers verify that the PR produces correct results? -->
<!-- Please provide instructions so that others can ensure that your pull request would produce correct results. For examples see, https://github.com/FreeTubeApp/FreeTube/pull/5743, https://github.com/FreeTubeApp/FreeTube/pull/7349, https://github.com/FreeTubeApp/FreeTube/pull/5125, https://github.com/FreeTubeApp/FreeTube/pull/7338 -->

- `pnpm run lint`
- `xvfb-run -a -s "-screen 0 1920x1080x24" pnpm exec playwright test -c e2e/playwright.config.mjs --project=offline e2e/tests/offline/tabs.spec.mjs e2e/tests/offline/session-restore.spec.mjs e2e/tests/offline/app-launch.spec.mjs` (39 passed)

To reproduce the ghost-tab regression manually, close the presented tab while its unloaded replacement is mounting, immediately quit the app, then relaunch it. Only the replacement tab should be restored.

## Desktop
<!-- Please complete the following information-->
- **OS:** Arch Linux
- **OS Version:** Rolling release
- **OpenTubeX version:** development (`0a65db317` base)

## Additional context
<!-- Add any other context about the pull request here. -->

The previous session serializer treated deferred close/unload transitions as ordinary live tabs. The app also hid the native window until the initial logical route reported presentation and eagerly loaded cached tab previews before first paint.