### PR TITLE
fix(toast): hold the timeout indicator full while the toast appears

### DIFF
--- a/e2e/tests/offline/settings.spec.mjs
+++ b/e2e/tests/offline/settings.spec.mjs
@@ -145,12 +145,14 @@ test.describe('settings', () => {
       await expect(toast).toBeVisible()
       await expect(toast).toHaveCSS('transform', 'none')
       await expect(toast.locator('..')).toHaveCSS('transform', 'none')
+      // The drain waits out the enter transition and then uses up the rest of
+      // the toast's lifetime, so it empties just as the toast is dismissed
       await expect(
         toast.locator('..').locator('.timeout-indicator .embeddedProgressPath')
-      ).toHaveCSS('animation-duration', '10s')
+      ).toHaveCSS('animation-duration', '9.7s')
       await expect(
         toast.locator('..').locator('.timeout-indicator .embeddedProgressPath')
-      ).toHaveCSS('animation-delay', '0s')
+      ).toHaveCSS('animation-delay', '0.3s')
       return toast
     }
 

--- a/e2e/tests/offline/ui-bugfixes.spec.mjs
+++ b/e2e/tests/offline/ui-bugfixes.spec.mjs
@@ -271,6 +271,55 @@ test.describe('toast timeout progress', () => {
     expect(Math.abs(indicatorBounds.y - toastBounds.y)).toBeLessThanOrEqual(1)
     expect(Math.abs(indicatorBounds.height - toastBounds.height)).toBeLessThanOrEqual(1)
   })
+
+  test('stays wrapped around both corners until the toast has animated in', async ({ page }) => {
+    await goTo(page, 'history')
+    await page.evaluate(() => {
+      window.ftElectron.showToastOnAllTabs('Held timeout progress', 6000)
+    })
+
+    const indicatorPath = page.locator('.toast-slot .embeddedProgressPath').first()
+    await indicatorPath.waitFor()
+
+    // Pausing removes the wall clock from the picture, so the sampled lengths
+    // below depend only on the delay/duration the stylesheet asks for
+    const timing = await indicatorPath.evaluate(element => {
+      const animation = element.getAnimations()[0]
+      animation.pause()
+      window.__toastTimeout = animation
+      return animation.effect.getComputedTiming()
+    })
+    // The drain has to wait out the enter transition, then use up the rest of
+    // the toast's lifetime so it empties exactly as the toast is dismissed
+    expect(timing.delay).toBe(300)
+    expect(timing.duration).toBe(5700)
+
+    /** @returns {Promise<{ full: number, visible: number, offset: number }>} */
+    const sampleAt = time => indicatorPath.evaluate(async (element, time) => {
+      window.__toastTimeout.currentTime = time
+      await window.__toastTimeout.ready
+      const style = getComputedStyle(element)
+      return {
+        full: Number.parseFloat(element.style.strokeDasharray),
+        visible: Number.parseFloat(style.strokeDasharray),
+        offset: Number.parseFloat(style.strokeDashoffset),
+      }
+    }, time)
+
+    // Both bottom corner arcs are only a few percent of the path, so any drain
+    // during the enter transition already eats the trailing one
+    for (const time of [0, 150, 299]) {
+      const held = await sampleAt(time)
+      expect(held.visible, `held at ${time}ms`).toBeCloseTo(held.full, 3)
+      expect(held.offset, `held at ${time}ms`).toBe(0)
+    }
+
+    const midway = await sampleAt(300 + 5700 / 2)
+    expect(midway.visible).toBeCloseTo(midway.full / 2, 1)
+
+    const finished = await sampleAt(6000)
+    expect(finished.visible).toBeCloseTo(0, 3)
+  })
 })
 
 test.describe('history reorder animation', () => {

--- a/src/renderer/components/FtToast/FtToast.css
+++ b/src/renderer/components/FtToast/FtToast.css
@@ -1,6 +1,10 @@
 .toast-holder {
   position: fixed;
 
+  /* Drives the enter/leave transitions and the matching hold before the timeout
+     indicator starts draining */
+  --toast-transition-duration: 300ms;
+
   /* Higher than any prompt */
   z-index: 300;
   display: flex;
@@ -98,8 +102,14 @@
 
 .timeout-indicator :deep(.embeddedProgressPath) {
   filter: drop-shadow(0 0 2px color-mix(in srgb, var(--primary-color) 70%, transparent));
-  animation-delay: 0s;
-  animation-duration: var(--toast-duration);
+
+  /* Hold the line at its full length until the toast has finished animating in,
+     so it always appears wrapped around both bottom corners. The corner arcs are
+     only a few percent of the path, so without this the trailing arc is already
+     gone by the time the toast has finished sliding in. Draining over the
+     remaining time keeps it empty exactly when the toast is dismissed. */
+  animation-delay: var(--toast-transition-duration);
+  animation-duration: calc(var(--toast-duration) - var(--toast-transition-duration));
   animation-name: toast-timeout;
   animation-timing-function: linear;
   animation-fill-mode: forwards;
@@ -167,7 +177,9 @@
 }
 
 .toast-enter-active {
-  transition: opacity 300ms, transform 300ms cubic-bezier(0.34, 1.56, 0.64, 1);
+  transition:
+    opacity var(--toast-transition-duration),
+    transform var(--toast-transition-duration) cubic-bezier(0.34, 1.56, 0.64, 1);
 }
 
 .toast-leave-active {


### PR DESCRIPTION
## Pull Request Type
<!-- Please select what type of pull request this is: [x] -->
- [x] Bugfix
- [ ] Feature Implementation
- [ ] Documentation
- [ ] Other

## Related issue
Follow-up to #366, which introduced the embedded toast timeout indicator.

## Description
The toast timeout indicator started draining the moment the toast was inserted into the DOM, but the toast's enter transition runs for 300 ms. Each bottom corner arc is only about 3 % of the total path length (8.6 px of 281 px on a default toast), so on a 6 s toast roughly 5 % of the line was already gone by the time the toast had finished sliding in — the trailing corner arc never got to be seen. The result was a blunt cut sitting on the straight bottom edge while the leading end kept its curve, so the two ends never matched and the line was never actually wrapped around both rounded corners on screen.

The line is now held at its full length for the duration of the enter transition and drains over the remaining lifetime, so it is fully wrapped around both bottom corners when the toast appears and still empties exactly when the toast is dismissed.

Both durations are derived from a single `--toast-transition-duration` custom property, which also drives the enter transition, so the hold and the transition cannot drift apart.

`pause()` needed no change: `animation-delay` is part of the animation timeline, so the existing `currentTime = duration - remainingMs` mapping stays correct when a toast is hovered.

## Screenshots <!-- If appropriate -->
Sadly I cannot attach images from the CLI, so here are the numbers instead (see Testing for how to reproduce them). For a 6000 ms toast with a path length of 281.48 px. The "after" column is measured by pinning `currentTime`; the "before" column follows from the old timing (linear, no delay, full 6000 ms):

| Elapsed | Before (visible length) | After (visible length) |
| --- | --- | --- |
| 0 ms | 281.48 (full) | 281.48 (full) |
| 150 ms | 274.44 | 281.48 (full) |
| 299 ms | 267.45 — trailing arc already gone | 281.48 (full) |
| 301 ms | 267.36 | 281.43 |
| 3150 ms | 133.70 | 140.74 (exactly half) |
| 6000 ms | 0 | 0 |

The whole corner arc measures 8.63 px, so before this change it was fully consumed after 184 ms — i.e. before the 300 ms enter transition had finished.

## Release note category
<!-- release-note-category:start -->
- [ ] Not noteworthy
- [ ] Highlights
- [x] More improvements
- [ ] Fixed bugs
<!-- release-note-category:end -->

## Release note
<!-- release-note:start -->
The thumbnail progress and toast timeout indicator is now wrapped around both rounded corners
<!-- release-note:end -->

## Release note images
<!-- release-note-image:start -->
<img width="587" height="310" alt="Screencast_20260730_062922" src="https://github.com/user-attachments/assets/0468140e-752b-4048-91e0-67850b93d2d4" />
<!-- release-note-image:end -->

## Testing
Enable **Settings → General → Show toast timeout indicator**, then trigger a toast (for example "Mark as watched" from a video's options menu) and watch the line along the bottom edge as the toast slides in. It should be curved around both bottom corners for the whole enter animation, then shorten, and finally sweep out through the corner arc just as the toast disappears. Worth checking with a few **UI roundness** values and with each **Toast position** setting, since toasts anchored to the right drain the other way (`toast-timeout-away`).

Automated coverage, run with `pnpm run test:e2e:pack && pnpm run test:e2e:offline`:

- `e2e/tests/offline/ui-bugfixes.spec.mjs` — new `stays wrapped around both corners until the toast has animated in`. It pauses the animation so wall-clock timing cannot skew the samples, asserts the 300 ms delay / 5700 ms duration split for a 6000 ms toast, and asserts the visible dash length still equals the full path length at 0/150/299 ms, is half at the midpoint, and is 0 at 6000 ms.
- `e2e/tests/offline/settings.spec.mjs` — this test pinned `animation-duration: 10s` / `animation-delay: 0s`, i.e. exactly the behaviour being fixed, so those two assertions were updated to `9.7s` / `0.3s`.

Full offline suite: 200 passed. `pnpm run lint` is clean.

## Desktop
- **OS:** Arch Linux
- **OS Version:** Rolling
- **OpenTubeX version:** 0.30.0

## Additional context
The geometry side of this was already correct after #366 (the viewBox is measured from the layout box rather than `getBoundingClientRect()`, so the arcs line up with the toast's real corners). This PR only changes *when* the drain starts.
