### PR TITLE
fix(settings): keep scroll position when switching tabs

### DIFF
--- a/e2e/tests/offline/settings.spec.mjs
+++ b/e2e/tests/offline/settings.spec.mjs
@@ -44,6 +44,8 @@ test.describe('settings', () => {
     await expect(page.locator(sel.tabs)).toHaveCount(2)
     await page.locator(sel.tabs).first().click()
     await expect(page.locator(sel.tabs).first()).toHaveClass(/active/)
+    await expect(page).toHaveURL(/#\/settings#player$/)
+    await expect(playerSectionLink).toHaveClass(/active/)
 
     await expect.poll(() => page.evaluate(() => window.scrollY)).toBe(scrollPosition)
   })

--- a/e2e/tests/offline/settings.spec.mjs
+++ b/e2e/tests/offline/settings.spec.mjs
@@ -1,7 +1,7 @@
 import { readFile } from 'node:fs/promises'
 import path from 'node:path'
 
-import { test, expect, goTo, latestSettings } from '../../helpers/app.mjs'
+import { test, expect, goTo, latestSettings, sel } from '../../helpers/app.mjs'
 
 test.describe('settings', () => {
   test('settings page renders its sections', async ({ page }) => {
@@ -23,6 +23,29 @@ test.describe('settings', () => {
     const playerScrollPosition = await page.evaluate(() => window.scrollY)
     await page.mouse.wheel(0, 1200)
     await expect.poll(() => page.evaluate(() => window.scrollY)).toBeGreaterThan(playerScrollPosition)
+  })
+
+  test('keeps the scroll position when switching tabs', async ({ page }) => {
+    await goTo(page, 'settings')
+
+    const playerSectionLink = page.locator('.settingsMenu [data-section="player"]')
+    await playerSectionLink.click()
+    await expect(page).toHaveURL(/#\/settings#player$/)
+
+    // Scroll within the section, so the active section (and therefore the hash)
+    // stays the same.
+    const sectionScrollPosition = await page.evaluate(() => window.scrollY)
+    await page.mouse.wheel(0, 200)
+    await expect.poll(() => page.evaluate(() => window.scrollY)).toBeGreaterThan(sectionScrollPosition)
+    const scrollPosition = await page.evaluate(() => window.scrollY)
+    await expect(playerSectionLink).toHaveClass(/active/)
+
+    await page.locator(sel.newTabButton).click()
+    await expect(page.locator(sel.tabs)).toHaveCount(2)
+    await page.locator(sel.tabs).first().click()
+    await expect(page.locator(sel.tabs).first()).toHaveClass(/active/)
+
+    await expect.poll(() => page.evaluate(() => window.scrollY)).toBe(scrollPosition)
   })
 
   test('configures the watched percentage threshold', async ({ page }) => {

--- a/src/renderer/views/Settings/Settings.vue
+++ b/src/renderer/views/Settings/Settings.vue
@@ -417,6 +417,13 @@ function markScrolledToSectionAsActive() {
 }
 
 function handleResize(width = settingsPageRef.value?.clientWidth ?? window.innerWidth) {
+  // A hidden tab reports a width of 0. Treating that as the mobile layout would
+  // scroll back to the active section once the tab is presented again, undoing
+  // the tab's restored scroll position.
+  if (width === 0) {
+    return
+  }
+
   const wasNotInDesktopView = !isInDesktopView.value
 
   if (!hasMeasuredSettingsWidth) {


### PR DESCRIPTION
## Pull Request Type
- [x] Bugfix
- [ ] Feature Implementation
- [ ] Documentation
- [ ] Other

## Related issue
None

## Description
When a settings tab was scrolled past the start of a section (so the section highlighted in the menu was still the previous one), switching to another tab and back reset the scroll to the top of that highlighted section.

The cause is not the section hash in the URL but the `ResizeObserver` in `Settings.vue`. Tabs stay mounted and are hidden with `v-show`, so hiding the settings tab makes the observer report a width of `0`. `handleResize` read that as the mobile layout and stashed the active section in `settingsSectionTypeOpenInMobile`. When the tab was presented again the width jumped back up, so it took the "returned to desktop view" branch and called `navigateToSection()` → `scrollIntoView()`, snapping to the top of the active section and clobbering the scroll position `TabNavigationService` had just restored.

`handleResize` now ignores zero-width observations, so a hidden tab can no longer flip the layout mode.

## Release note category
<!-- release-note-category:start -->
- [ ] Not noteworthy
- [ ] Highlights
- [ ] More improvements
- [x] Fixed bugs
<!-- release-note-category:end -->

## Release note
<!-- release-note:start -->
Fixed the settings page jumping back to the highlighted section after switching tabs
<!-- release-note:end -->

## Release note images
<!-- release-note-image:start -->
<!-- release-note-image:end -->

## Testing
1. Open the settings page and click a section in the menu, e.g. "Player".
2. Scroll down a little, but not far enough for the next section to become active in the menu (the highlight and the URL hash stay on the clicked section).
3. Open a second tab, then switch back to the settings tab.
4. The scroll position is unchanged. Before this fix it snapped back to the top of the highlighted section.

Automated: `e2e/tests/offline/settings.spec.mjs` gained "keeps the scroll position when switching tabs", which fails without the fix and passes with it.

## Desktop
- **OS:** Arch Linux
- **OS Version:** rolling (KDE Plasma 6, Wayland)
- **OpenTubeX version:** 0.30.0 (development)

## Additional context
None
