### PR TITLE
perf(ui): keep thumbnail size changes out of the render path

### DIFF
--- a/e2e/tests/offline/thumbnail-size-slider.spec.mjs
+++ b/e2e/tests/offline/thumbnail-size-slider.spec.mjs
@@ -1,0 +1,109 @@
+import { test, expect, goTo } from '../../helpers/app.mjs'
+
+const now = Date.now()
+const CHANNEL_ID = 'UCaaaaaaaaaaaaaaaaaaaaaa'
+
+const videos = Array.from({ length: 80 }, (_, index) => ({
+  videoId: `video${String(index).padStart(6, '0')}`,
+  title: `Feed video ${String(index).padStart(2, '0')}`,
+  author: 'Channel A',
+  authorId: CHANNEL_ID,
+  published: now - index * 3600000,
+  viewCount: 1000,
+  lengthSeconds: 120,
+  liveNow: false,
+  isUpcoming: false,
+  type: 'video'
+}))
+
+test.use({
+  seed: {
+    settings: {
+      fetchSubscriptionsAutomatically: false,
+      showThumbnailSizeButtonInHeader: true,
+      thumbnailSize: 100
+    },
+    profiles: [
+      {
+        _id: 'allChannels',
+        name: 'All Channels',
+        bgColor: '#000000',
+        textColor: '#FFFFFF',
+        subscriptions: [{ id: CHANNEL_ID, name: 'Channel A', thumbnail: '' }]
+      }
+    ],
+    subscriptionCache: [
+      {
+        _id: CHANNEL_ID,
+        videos,
+        videosTimestamp: new Date(now).toISOString()
+      }
+    ]
+  }
+})
+
+/**
+ * Emit the `input` events a real drag produces, without going through the mouse
+ * so the number of steps is deterministic. Each step gets its own frame,
+ * otherwise Vue batches the whole drag into a single update.
+ *
+ * @param {import('@playwright/test').Page} page
+ * @param {number[]} values
+ */
+async function dragSlider(page, values) {
+  for (const value of values) {
+    await page.evaluate((size) => {
+      const slider = document.querySelector('.thumbnailSizeSlider .input')
+      slider.value = String(size)
+      slider.dispatchEvent(new Event('input', { bubbles: true }))
+
+      return new Promise((resolve) => requestAnimationFrame(() => resolve()))
+    }, value)
+  }
+}
+
+test.describe('thumbnail size slider', () => {
+  test('resizes the feed without re-measuring every card', async ({ page }) => {
+    await goTo(page, 'subscriptions')
+    await expect(page.getByText('Feed video 00')).toBeVisible()
+
+    const grid = page.locator('.autoGrid')
+    const initialSize = await grid.evaluate((element) => {
+      return element.style.getPropertyValue('--thumbnail-grid-size')
+    })
+    expect(initialSize).not.toBe('')
+
+    await page.locator('.thumbnailSizeButton').click()
+    await expect(page.locator('.thumbnailSizeSlider')).toBeVisible()
+
+    // TransitionGroup measures every child whenever it re-renders, so a
+    // reactive thumbnail size would cost one getBoundingClientRect per card per
+    // slider step. Counting the calls catches that without timing anything.
+    const cardCount = await page.locator('.autoGrid > *').count()
+    expect(cardCount).toBeGreaterThan(15)
+
+    await page.evaluate(() => {
+      window.__rectCalls = 0
+      const original = Element.prototype.getBoundingClientRect
+      Element.prototype.getBoundingClientRect = function () {
+        window.__rectCalls++
+        return original.call(this)
+      }
+    })
+
+    const steps = [110, 120, 130, 140, 150, 160, 170, 180]
+    await dragSlider(page, steps)
+
+    const rectCalls = await page.evaluate(() => window.__rectCalls)
+    expect(rectCalls).toBeLessThan(cardCount)
+
+    // The resize still has to happen, on both the grid and the list variables.
+    await expect
+      .poll(() => grid.evaluate((element) => element.style.getPropertyValue('--thumbnail-grid-size')))
+      .not.toBe(initialSize)
+    const listSize = await page.evaluate(() => {
+      return document.body.style.getPropertyValue('--thumbnail-list-size')
+    })
+    expect(Number.parseFloat(listSize)).toBeCloseTo(336 * 1.8)
+  })
+})

--- a/src/renderer/App.vue
+++ b/src/renderer/App.vue
@@ -306,6 +306,7 @@ import {
 } from './helpers/subscriptions'
 import { translateWindowTitle } from './helpers/strings'
 import { getTabAccentColor } from './constants/tabColors'
+import { getThumbnailListStyles } from './constants/thumbnailSize'
 import { getTabNavigationService } from './tabs/TabNavigationService'
 import { tabRuntimeRegistry } from './tabs/TabRuntimeRegistry'
 import { getTabPreviewFallbackUrl } from './tabs/tabPreview'
@@ -1639,6 +1640,11 @@ const uiRoundness = computed(() => store.getters.getUiRoundness)
 
 watch(uiRoundness, updateUiRoundness)
 
+/** @type {import('vue').ComputedRef<number>} */
+const thumbnailSize = computed(() => store.getters.getThumbnailSize)
+
+watch(thumbnailSize, updateThumbnailListSize)
+
 function updateTheme() {
   document.body.className = `${baseTheme.value || 'system'} main${mainColor.value || 'Red'} sec${secColor.value || 'Blue'}`
   document.body.dataset.systemTheme = window.matchMedia('(prefers-color-scheme: dark)').matches ? 'dark' : 'light'
@@ -1648,8 +1654,17 @@ function updateUiRoundness() {
   document.body.style.setProperty('--ui-roundness', String(uiRoundness.value / 100))
 }
 
+// Setting these once on the body keeps a thumbnail size change from
+// re-rendering every list that shows thumbnails.
+function updateThumbnailListSize() {
+  for (const [property, value] of Object.entries(getThumbnailListStyles(thumbnailSize.value))) {
+    document.body.style.setProperty(property, value)
+  }
+}
+
 updateTheme()
 updateUiRoundness()
+updateThumbnailListSize()
 
 const showUpdatesBanner = ref(false)
 const latestVersionNumber = ref('')

--- a/src/renderer/components/FtAutoGrid/FtAutoGrid.vue
+++ b/src/renderer/components/FtAutoGrid/FtAutoGrid.vue
@@ -9,10 +9,9 @@
       autoGrid: true,
       grid: grid,
       list: !grid,
-      thumbnailSizeReady: grid && gridWidth > 0,
+      thumbnailSizeReady: grid && thumbnailSizeReady,
       youtubeStyleShorts
     }"
-    :style="gridStyle"
     @before-leave="captureLeavingItemLayout"
   >
     <slot />
@@ -20,9 +19,11 @@
 </template>
 
 <script setup>
-import { computed, onBeforeUnmount, onMounted, ref, useTemplateRef } from 'vue'
+import { computed, onBeforeUnmount, onMounted, ref, useTemplateRef, watch } from 'vue'
 
-import { DEFAULT_THUMBNAIL_SIZE, getThumbnailSizeStyles } from '../../constants/thumbnailSize'
+import store from '../../store/index'
+
+import { getThumbnailGridStyles } from '../../constants/thumbnailSize'
 import { measureStableGridWidth } from './gridWidth'
 
 const props = defineProps({
@@ -33,10 +34,6 @@ const props = defineProps({
   grid: {
     type: Boolean,
     required: true
-  },
-  thumbnailSize: {
-    type: Number,
-    default: DEFAULT_THUMBNAIL_SIZE
   },
   itemCount: {
     type: Number,
@@ -55,7 +52,18 @@ const props = defineProps({
 const MOVE_TRANSITION_MAX_ITEMS = 50
 
 const gridElement = useTemplateRef('gridElement')
-const gridWidth = ref(0)
+
+// The thumbnail size custom properties are written straight to the element
+// instead of through a reactive `:style` binding, and the measured width is
+// kept out of the reactive graph: TransitionGroup's render function calls
+// getBoundingClientRect() on every child, so any re-render of this component
+// costs a layout pass over the whole feed. Dragging the thumbnail size slider
+// emits an event per step, which turned that into hundreds of forced layouts.
+let gridWidth = 0
+
+// Only whether the width is known needs to reach the template, and that flips
+// just once, right after mount.
+const thumbnailSizeReady = ref(false)
 
 // While the container itself is being sized or resized (initial layout,
 // window resize, or a modal's
@@ -84,9 +92,21 @@ const moveClass = computed(() => {
   return suppressed ? 'feed-move-suppressed' : undefined
 })
 
-const gridStyle = computed(() => {
-  return getThumbnailSizeStyles(props.thumbnailSize, gridWidth.value)
-})
+function applyThumbnailSizeStyles() {
+  const element = gridElement.value?.$el
+
+  if (!element) {
+    return
+  }
+
+  const styles = getThumbnailGridStyles(store.getters.getThumbnailSize, gridWidth)
+
+  for (const [property, value] of Object.entries(styles)) {
+    element.style.setProperty(property, value)
+  }
+}
+
+watch(() => store.getters.getThumbnailSize, applyThumbnailSizeStyles)
 
 function captureLeavingItemLayout(element) {
   const itemRect = element.getBoundingClientRect()
@@ -121,15 +141,17 @@ onMounted(() => {
     observedScrollbarWidth = measurement.scrollbarWidth
     observedViewportWidth = measurement.viewportWidth
 
-    if (measurement.gridWidth !== gridWidth.value) {
+    if (measurement.gridWidth !== gridWidth) {
       suppressMoveTransition.value = true
       clearTimeout(suppressResetTimeout)
       suppressResetTimeout = setTimeout(() => {
         suppressMoveTransition.value = false
       }, 100)
-    }
 
-    gridWidth.value = measurement.gridWidth
+      gridWidth = measurement.gridWidth
+      applyThumbnailSizeStyles()
+      thumbnailSizeReady.value = gridWidth > 0
+    }
   })
 
   resizeObserver.observe(gridElement.value.$el)

--- a/src/renderer/components/FtElementList/FtElementList.vue
+++ b/src/renderer/components/FtElementList/FtElementList.vue
@@ -2,7 +2,6 @@
   <FtAutoGrid
     :appear="appear"
     :grid="effectiveDisplayValue !== 'list'"
-    :thumbnail-size="thumbnailSize"
     :item-count="data.length"
     :youtube-style-shorts="youtubeStyleShorts"
   >
@@ -177,9 +176,6 @@ const displayValue = computed(() => {
 const effectiveDisplayValue = computed(() => {
   return props.youtubeStyleShorts ? 'grid' : displayValue.value
 })
-
-/** @type {import('vue').ComputedRef<number>} */
-const thumbnailSize = computed(() => store.getters.getThumbnailSize)
 
 function getResultKey(result, index) {
   const type = props.dataType || result.type

--- a/src/renderer/components/FtSkeletonGrid/FtSkeletonGrid.vue
+++ b/src/renderer/components/FtSkeletonGrid/FtSkeletonGrid.vue
@@ -1,7 +1,6 @@
 <template>
   <FtAutoGrid
     :grid="youtubeStyleShorts || displayValue !== 'list'"
-    :thumbnail-size="thumbnailSize"
     :youtube-style-shorts="youtubeStyleShorts"
     aria-hidden="true"
     data-tab-loading-indicator
@@ -44,9 +43,6 @@ defineProps({
 
 /** @type {import('vue').ComputedRef<'grid' | 'list'>} */
 const displayValue = computed(() => store.getters.getListType)
-
-/** @type {import('vue').ComputedRef<number>} */
-const thumbnailSize = computed(() => store.getters.getThumbnailSize)
 </script>
 
 <style scoped src="./FtSkeletonGrid.css" />

--- a/src/renderer/constants/thumbnailSize.js
+++ b/src/renderer/constants/thumbnailSize.js
@@ -21,16 +21,30 @@ function getDefaultGridItemSize(gridWidth) {
 }
 
 /**
+ * Grid columns depend on the measured width of the grid, so these have to be
+ * set on each grid element.
  * @param {number} thumbnailSize
  * @param {number} [gridWidth]
  */
-export function getThumbnailSizeStyles(thumbnailSize, gridWidth = 0) {
+export function getThumbnailGridStyles(thumbnailSize, gridWidth = 0) {
   const scale = thumbnailSize / DEFAULT_THUMBNAIL_SIZE
   const defaultGridItemSize = getDefaultGridItemSize(gridWidth)
 
   return {
     '--thumbnail-grid-size': `${defaultGridItemSize * scale}px`,
-    '--shorts-thumbnail-grid-min-size': `${DEFAULT_SHORTS_GRID_ITEM_MIN_SIZE * scale}px`,
+    '--shorts-thumbnail-grid-min-size': `${DEFAULT_SHORTS_GRID_ITEM_MIN_SIZE * scale}px`
+  }
+}
+
+/**
+ * List thumbnails scale off fixed values only, so these are set once on the
+ * document body instead of per list.
+ * @param {number} thumbnailSize
+ */
+export function getThumbnailListStyles(thumbnailSize) {
+  const scale = thumbnailSize / DEFAULT_THUMBNAIL_SIZE
+
+  return {
     '--thumbnail-list-size': `${336 * scale}px`,
     '--thumbnail-list-max-size': `${25 * scale}vw`,
     '--thumbnail-list-mobile-max-size': `${30 * scale}vw`

--- a/src/renderer/views/Playlist/Playlist.vue
+++ b/src/renderer/views/Playlist/Playlist.vue
@@ -54,7 +54,6 @@
     <FtCard
       v-if="!isLoading"
       class="playlistItemsCard"
-      :style="thumbnailSizeStyles"
     >
       <template
         v-if="shownPlaylistItems.length > 0"
@@ -211,7 +210,6 @@ import {
 } from '../../helpers/utils'
 import { invidiousGetPlaylistInfo, youtubeImageUrlToInvidious } from '../../helpers/api/invidious'
 import { getSortedPlaylistItems, videoDurationPresent, videoDurationWithFallback, SORT_BY_VALUES } from '../../helpers/playlists'
-import { getThumbnailSizeStyles } from '../../constants/thumbnailSize'
 import { MOBILE_WIDTH_THRESHOLD, PLAYLIST_HEIGHT_FORCE_LIST_THRESHOLD } from '../../../constants'
 import { useTabContext, useTabLifecycle, useTabTitle } from '../../tabs/TabContext'
 import { useTabToast } from '../../composables/useTabToast'
@@ -279,10 +277,6 @@ const playlistId = computed(() => route.params.id)
 
 /** @type {import('vue').ComputedRef<'grid' | 'list'>} */
 const listType = computed(() => isUserPlaylistRequested.value && !forceListView.value ? store.getters.getListType : 'list')
-
-const thumbnailSizeStyles = computed(() => {
-  return getThumbnailSizeStyles(store.getters.getThumbnailSize)
-})
 
 /** @type {import('vue').ComputedRef<boolean>} */
 const userPlaylistsReady = computed(() => store.getters.getPlaylistsReady)

--- a/tests/unit/thumbnail-size.test.mjs
+++ b/tests/unit/thumbnail-size.test.mjs
@@ -2,20 +2,35 @@ import assert from 'node:assert/strict'
 import test from 'node:test'
 
 import {
-  getThumbnailSizeStyles
+  getThumbnailGridStyles,
+  getThumbnailListStyles
 } from '../../src/renderer/constants/thumbnailSize.js'
 
 test('scales YouTube-style Shorts cards with the thumbnail size setting', () => {
   assert.equal(
-    getThumbnailSizeStyles(60)['--shorts-thumbnail-grid-min-size'],
+    getThumbnailGridStyles(60)['--shorts-thumbnail-grid-min-size'],
     '114px'
   )
   assert.equal(
-    getThumbnailSizeStyles(100)['--shorts-thumbnail-grid-min-size'],
+    getThumbnailGridStyles(100)['--shorts-thumbnail-grid-min-size'],
     '190px'
   )
   assert.equal(
-    getThumbnailSizeStyles(180)['--shorts-thumbnail-grid-min-size'],
+    getThumbnailGridStyles(180)['--shorts-thumbnail-grid-min-size'],
     '342px'
   )
+})
+
+// Only the grid properties depend on the measured grid width; keeping the list
+// ones separate is what lets them live on the document body.
+test('keeps the grid and list properties separate', () => {
+  assert.deepEqual(Object.keys(getThumbnailGridStyles(100, 800)), [
+    '--thumbnail-grid-size',
+    '--shorts-thumbnail-grid-min-size'
+  ])
+  assert.deepEqual(getThumbnailListStyles(50), {
+    '--thumbnail-list-size': '168px',
+    '--thumbnail-list-max-size': '12.5vw',
+    '--thumbnail-list-mobile-max-size': '15vw'
+  })
 })


### PR DESCRIPTION
## Pull Request Type
<!-- Please select what type of pull request this is: [x] -->
- [ ] Bugfix
- [ ] Feature Implementation
- [ ] Documentation
- [x] Other

## Related issue
None.

## Description
Dragging the thumbnail size slider on a page with a large grid (subscriptions, trending, a channel tab) was very laggy. It was smooth when the control was first added.

`FtAutoGrid` became a `TransitionGroup` after the thumbnail size control landed. `TransitionGroup`'s render function calls `getBoundingClientRect()` on **every** child to seed its FLIP position map, so any re-render of the grid costs a layout pass over the whole feed. The size was routed through the store getter → `FtElementList` computed → `:thumbnail-size` prop → `:style` binding, so every single slider step re-rendered the grid and forced one measurement per card. Measured on an 80 card feed: **640 forced `getBoundingClientRect()` calls for eight slider steps**. Before the grid was a `TransitionGroup`, the same change was just a cheap CSS variable write.

This takes the setting out of the render path:

- `FtAutoGrid` reads the size from the store in a `watch` and writes the grid custom properties directly via `style.setProperty()`. The measured `gridWidth` is a plain variable now, so a resize no longer re-renders either; only a one-shot `thumbnailSizeReady` flag reaches the template.
- The list properties (`--thumbnail-list-size` and friends) scale off fixed values and need no measurement, so they are set once on `document.body` in `App.vue`, right next to the existing `--ui-roundness` handling. That also drops the per-render `:style` on the playlist card.
- `getThumbnailSizeStyles` splits into `getThumbnailGridStyles` / `getThumbnailListStyles`, and the `thumbnailSize` prop is gone from `FtElementList` and `FtSkeletonGrid`.

No visual or behavioural change intended - only when the work happens.

## Screenshots <!-- If appropriate -->
None, there is no visible change.

## Release note category
<!-- release-note-category:start -->
- [ ] Not noteworthy
- [ ] Highlights
- [ ] More improvements
- [x] Fixed bugs
<!-- release-note-category:end -->

## Release note
<!-- release-note:start -->
Dragging the thumbnail size slider is smooth again on pages with many videos
<!-- release-note:end -->

## Release note images
<!-- release-note-image:start -->

<!-- release-note-image:end -->

## Testing
Automated:

- `e2e/tests/offline/thumbnail-size-slider.spec.mjs` (new) counts `getBoundingClientRect()` calls across eight slider steps on an 80 card cached subscription feed and asserts they stay below one call per card, plus that the grid and list custom properties still update. On the pre-fix build the same test reports 640 calls.
- `pnpm run test:e2e:offline` (200 passed), the `subscriptions-shorts` and `trending` network specs, `pnpm run test:unit` (150 passed) and `pnpm run lint` all pass.

Manual:

1. Open Subscriptions (or Trending) with a feed of at least ~60 videos.
2. Drag the thumbnail size slider in the header from end to end - the cards should follow the drag without stuttering.
3. Switch the list type to List and repeat, then check a playlist page and a channel tab: thumbnails must still resize with the setting, and the value must survive a restart.

## Desktop
- **OS:** Arch Linux
- **OS Version:** rolling, KDE Plasma 6 on Wayland
- **OpenTubeX version:** 0.30.0

## Additional context
The `MOVE_TRANSITION_MAX_ITEMS` guard in `FtAutoGrid` did not help here: it only makes `TransitionGroup` bail out of the `onUpdated` FLIP work, while the per-child `getBoundingClientRect()` in the render function runs regardless.
