### PR TITLE
fix(toast): resolve the timeout indicator animation reliably

### DIFF
--- a/e2e/tests/offline/settings.spec.mjs
+++ b/e2e/tests/offline/settings.spec.mjs
@@ -280,10 +280,14 @@ test.describe('settings', () => {
     const toast = page.locator('.toast', { hasText: 'Hover toast' })
     const indicator = toast.locator('..').locator('.timeout-indicator .embeddedProgressPath')
     await toast.hover()
+    // Reported as a list so a failure says which animations were on the element
+    // and what state they were in, instead of just "expected paused"
     await expect.poll(() => indicator.evaluate((element) => {
-      const animation = element.getAnimations()[0]
-      return animation ? animation.playState : null
-    })).toBe('paused')
+      return element.getAnimations().map(animation => [
+        animation.animationName ?? animation.transitionProperty ?? animation.constructor.name,
+        animation.playState,
+      ].join(':'))
+    })).toEqual([expect.stringMatching(/^toast-timeout[\w-]*:paused$/)])
     await page.waitForTimeout(2200)
     await expect(toast).toBeVisible()
 

--- a/e2e/tests/offline/settings.spec.mjs
+++ b/e2e/tests/offline/settings.spec.mjs
@@ -287,7 +287,9 @@ test.describe('settings', () => {
         animation.animationName ?? animation.transitionProperty ?? animation.constructor.name,
         animation.playState,
       ].join(':'))
-    })).toEqual([expect.stringMatching(/^toast-timeout[\w-]*:paused$/)])
+    })).toEqual(expect.arrayContaining([
+      expect.stringMatching(/^toast-timeout[\w-]*:paused$/),
+    ]))
     await page.waitForTimeout(2200)
     await expect(toast).toBeVisible()
 

--- a/e2e/tests/offline/ui-bugfixes.spec.mjs
+++ b/e2e/tests/offline/ui-bugfixes.spec.mjs
@@ -278,13 +278,18 @@ test.describe('toast timeout progress', () => {
       window.ftElectron.showToastOnAllTabs('Held timeout progress', 6000)
     })
 
-    const indicatorPath = page.locator('.toast-slot .embeddedProgressPath').first()
+    // Scoped to this toast's own slot: any other toast on screen would bring its
+    // own indicator, and picking the first one would sample the wrong duration
+    const indicatorPath = page.locator('.toast', { hasText: 'Held timeout progress' })
+      .locator('..')
+      .locator('.timeout-indicator .embeddedProgressPath')
     await indicatorPath.waitFor()
 
     // Pausing removes the wall clock from the picture, so the sampled lengths
     // below depend only on the delay/duration the stylesheet asks for
     const timing = await indicatorPath.evaluate(element => {
-      const animation = element.getAnimations()[0]
+      const animation = element.getAnimations()
+        .find(candidate => candidate.animationName?.startsWith('toast-timeout'))
       animation.pause()
       window.__toastTimeout = animation
       return animation.effect.getComputedTiming()

--- a/src/renderer/components/FtToast/FtToast.css
+++ b/src/renderer/components/FtToast/FtToast.css
@@ -109,7 +109,11 @@
      gone by the time the toast has finished sliding in. Draining over the
      remaining time keeps it empty exactly when the toast is dismissed. */
   animation-delay: var(--toast-transition-duration);
-  animation-duration: calc(var(--toast-duration) - var(--toast-transition-duration));
+
+  /* A toast shorter than the hold would give a negative, and therefore invalid,
+     duration. Such a toast is gone before the hold is over, so it just keeps the
+     full line for its whole lifetime. */
+  animation-duration: max(0s, var(--toast-duration) - var(--toast-transition-duration));
   animation-name: toast-timeout;
   animation-timing-function: linear;
   animation-fill-mode: forwards;

--- a/src/renderer/components/FtToast/FtToast.vue
+++ b/src/renderer/components/FtToast/FtToast.vue
@@ -231,13 +231,43 @@ function pause(toast, element) {
   toast.remainingMs = Math.max(0, toast.expiresAt - Date.now())
   clearTimeout(toast.timeout)
 
-  const animation = indicatorAnimations.get(toast.id) ??
-    element.querySelector('.timeout-indicator .embeddedProgressPath')?.getAnimations()[0]
-  if (animation) {
-    animation.currentTime = toast.duration - toast.remainingMs
-    animation.pause()
-    indicatorAnimations.set(toast.id, animation)
+  // `hovered` is already set, so this is the only chance to freeze the line: a
+  // second pointerenter returns early. Retry next frame if the indicator was not
+  // resolvable yet, rather than leaving it draining for the rest of the hover.
+  if (!freezeIndicator(toast, element)) {
+    requestAnimationFrame(() => {
+      if (toast.hovered) { freezeIndicator(toast, element) }
+    })
   }
+}
+
+/**
+ * Finds the drain animation on a toast's timeout indicator. Matched by name
+ * rather than taken by index, because `getAnimations()` also reports
+ * transitions and orders them before animations.
+ * @param {HTMLElement} element the toast's slot
+ * @returns {Animation | undefined}
+ */
+function findIndicatorAnimation(element) {
+  return element.querySelector('.timeout-indicator .embeddedProgressPath')
+    ?.getAnimations()
+    .find(animation => animation.animationName?.startsWith('toast-timeout'))
+}
+
+/**
+ * Seeks a toast's indicator to its true remaining lifetime and holds it there.
+ * @param {Toast} toast
+ * @param {HTMLElement} element the toast's slot
+ * @returns {boolean} whether the animation could be resolved
+ */
+function freezeIndicator(toast, element) {
+  const animation = indicatorAnimations.get(toast.id) ?? findIndicatorAnimation(element)
+  if (!animation) { return false }
+
+  animation.currentTime = toast.duration - toast.remainingMs
+  animation.pause()
+  indicatorAnimations.set(toast.id, animation)
+  return true
 }
 
 /**
@@ -373,7 +403,8 @@ function dragStyle(toast) {
  * @param {AnimationEvent} event
  */
 function onIndicatorAnimationStart(toast, event) {
-  const animation = event.target.getAnimations()[0]
+  const animation = event.target.getAnimations()
+    .find(candidate => candidate.animationName === event.animationName)
   if (!animation) { return }
 
   const remainingMs = toast.hovered


### PR DESCRIPTION
## Pull Request Type
<!-- Please select what type of pull request this is: [x] -->
- [x] Bugfix
- [ ] Feature Implementation
- [ ] Documentation
- [ ] Other

## Related issue
Follow-up to #370, whose `e2e` run failed. It was merged anyway because `development` has no required status checks, so nothing gated on the failure.

## Description
Two `e2e` failures on #370 that did not reproduce locally (I ran the hover test 22 times, including 8-way parallel to slow the machine down, and the full offline suite twice).

**1. The new indicator test sampled the wrong toast.** It located its path with `page.locator('.toast-slot .embeddedProgressPath').first()`, which is not scoped to the toast it had just shown. On CI it matched a toast with the default 3000 ms lifetime, so the timing assertion read `2700` instead of `5700`. Now scoped through the toast with its own message, the way the sibling test already does.

**2. A hover that cannot resolve the animation leaves the line draining.** The hover test saw the drain still `running`. Since the test and `pause()` read the very same node, `running` means `pause()` never froze it — its lookup came up empty. `pause()` sets `toast.hovered = true` before looking the animation up, so a second `pointerenter` returns early and the failed lookup is never retried: the line keeps draining for the rest of the hover even though auto-dismiss is paused. It now retries on the next frame while still hovered.

The lookup itself was `getAnimations()[0]`. Index 0 is not a safe way to pick the drain: `getAnimations()` also reports transitions, and orders them *before* animations. Both call sites now match by animation name (`animationName` is undefined on transitions, so they drop out). Adding the 300 ms hold in #370 is what made this reachable — the drain no longer starts when the toast is created, so `animationstart` populates the cache 300 ms late and the fallback lookup carries the hover cases it previously never had to.

The assertion now reports the whole animation list rather than a bare `playState`, so if my reading of this is wrong the next CI run says what was actually on the element instead of just `expected paused`.

**3. `max()` guard on the drain duration.** A toast shorter than the enter transition would compute a negative `animation-duration`, which is invalid and would drop the declaration. Such a toast is gone before the hold ends, so it now just keeps the full line for its whole lifetime. Raised by Greptile on #370.

## Screenshots <!-- If appropriate -->
No visible change to the fixed behaviour from #370. The user-visible fix here is that hovering a toast now reliably freezes the line instead of occasionally letting it keep draining while auto-dismiss is paused.

## Release note category
<!-- release-note-category:start -->
- [ ] Not noteworthy
- [ ] Highlights
- [ ] More improvements
- [x] Fixed bugs
<!-- release-note-category:end -->

## Release note
<!-- release-note:start -->
Hovering a toast now reliably freezes its timeout indicator instead of sometimes letting the line keep draining.
<!-- release-note:end -->

## Release note images
<!-- release-note-image:start -->

<!-- release-note-image:end -->

## Testing
Enable **Settings → General → Show toast timeout indicator**, trigger a toast, and hover it: the line must stop where it is and stay there for as long as the pointer is on the toast, and resume from that point when you leave. Worth hovering immediately as the toast slides in, which is the window this fixes.

`pnpm run test:e2e:pack && pnpm run test:e2e:offline` → 201 passed. `pnpm run lint` clean.

The two specs that failed on #370 are the ones changed here, so CI will exercise both.

## Desktop
- **OS:** Arch Linux
- **OS Version:** Rolling
- **OpenTubeX version:** 0.30.0

## Additional context
I could not reproduce either failure locally, so #2 is reasoned from what the failure proves rather than from a local repro — hence the richer assertion output as a fallback. Failure #1 is fully understood and deterministic.

Separately, the reason a red `e2e` did not block #370 is that branch protection on `development` sets no required status checks; auto-merge therefore only waits for the one required approval. That wants fixing in the repository settings, not in this PR.
