### PR TITLE
fix: improve subscription feeds and Shorts layouts

### DIFF
--- a/e2e/tests/network/watch.spec.mjs
+++ b/e2e/tests/network/watch.spec.mjs
@@ -1589,6 +1589,39 @@ test.describe('custom Shorts player', () => {
     await expect(overflowMenu).toBeVisible()
     await expect(overflowMenu.getByRole('button', { name: /Autoplay/ })).toHaveCount(0)
 
+    const video = player.locator('video')
+    await expect.poll(() => video.evaluate(element => element.duration))
+      .toBeGreaterThan(0)
+    const duration = await video.evaluate(element => element.duration)
+    await video.evaluate((element, completedAt) => {
+      element.currentTime = completedAt
+      element.dispatchEvent(new Event('timeupdate'))
+      element.currentTime = 0.1
+      element.dispatchEvent(new Event('timeupdate'))
+    }, duration - 0.75)
+
+    await expect.poll(() => page.evaluate(() => {
+      const store = document.querySelector('#app').__vue_app__.config.globalProperties.$store
+      const entry = store.getters.getHistoryCacheById.w1WKmSqwM8I
+      return {
+        watched: entry?.isWatched,
+        fullProgress: entry?.watchProgress === entry?.lengthSeconds
+      }
+    })).toEqual({ watched: true, fullProgress: true })
+
+    // Ticks from the next automatic loop must not replace completed progress
+    // with a resume point near the beginning.
+    await video.evaluate(element => {
+      element.currentTime = 0.2
+      element.dispatchEvent(new Event('timeupdate'))
+      element.dispatchEvent(new Event('pause'))
+    })
+    await expect.poll(() => page.evaluate(() => {
+      const store = document.querySelector('#app').__vue_app__.config.globalProperties.$store
+      const entry = store.getters.getHistoryCacheById.w1WKmSqwM8I
+      return entry.watchProgress === entry.lengthSeconds
+    })).toBe(true)
+
     await player.locator('video').dispatchEvent('ended')
     await page.waitForTimeout(500)
 

--- a/e2e/tests/network/watch.spec.mjs
+++ b/e2e/tests/network/watch.spec.mjs
@@ -1593,12 +1593,31 @@ test.describe('custom Shorts player', () => {
     await expect.poll(() => video.evaluate(element => element.duration))
       .toBeGreaterThan(0)
     const duration = await video.evaluate(element => element.duration)
-    await video.evaluate((element, completedAt) => {
-      element.currentTime = completedAt
-      element.dispatchEvent(new Event('timeupdate'))
-      element.currentTime = 0.1
-      element.dispatchEvent(new Event('timeupdate'))
-    }, duration - 0.75)
+    await video.evaluate(async (element, scrubbedTo) => {
+      element.pause()
+      element.currentTime = scrubbedTo
+      if (element.seeking) {
+        await new Promise(resolve => element.addEventListener('seeked', resolve, { once: true }))
+      }
+    }, duration - 0.25)
+
+    // Scrubbing to the end must not count as completing the Short.
+    await expect.poll(() => page.evaluate((expectedDuration) => {
+      const store = document.querySelector('#app').__vue_app__.config.globalProperties.$store
+      const entry = store.getters.getHistoryCacheById.w1WKmSqwM8I
+      return {
+        nearEnd: entry?.watchProgress >= expectedDuration - 0.5,
+        full: entry?.watchProgress === entry?.lengthSeconds
+      }
+    }, duration)).toEqual({ nearEnd: true, full: false })
+
+    await video.evaluate(async (element, playbackStart) => {
+      element.currentTime = playbackStart
+      if (element.seeking) {
+        await new Promise(resolve => element.addEventListener('seeked', resolve, { once: true }))
+      }
+      await element.play()
+    }, duration - 2)
 
     await expect.poll(() => page.evaluate(() => {
       const store = document.querySelector('#app').__vue_app__.config.globalProperties.$store

--- a/e2e/tests/network/watch.spec.mjs
+++ b/e2e/tests/network/watch.spec.mjs
@@ -1763,6 +1763,40 @@ test.describe('custom Shorts player', () => {
       .toBeCloseTo(videoAreaBounds.x + videoAreaBounds.width / 2, 0)
     expect(navigationBounds.x).toBeGreaterThan(actionBounds.x)
 
+    // Narrow layouts move the rail over the player and grow it upwards, so the
+    // navigation joins the same column above the actions instead of landing on
+    // top of them.
+    await page.setViewportSize({ width: 900, height: 700 })
+    await expect(page.locator('.shortsExternalChannel')).toHaveCSS('opacity', '1')
+    expect(await page.locator('.shortsExternalChannel').evaluate(element => {
+      return getComputedStyle(element).color === getComputedStyle(document.body).color
+    })).toBe(true)
+    await expect.poll(async () => {
+      const [rail, navigation, firstAction] = await Promise.all([
+        page.locator('.shortsActionRail').boundingBox(),
+        page.locator('.shortsNavigation').boundingBox(),
+        page.locator('.shortsAction').first().boundingBox()
+      ])
+
+      return {
+        navigationAboveActions: navigation.y + navigation.height <= firstAction.y,
+        centeredInRail: Math.abs(
+          (navigation.x + navigation.width / 2) - (rail.x + rail.width / 2)
+        ) <= 1,
+        insideRail: navigation.x >= rail.x && navigation.x + navigation.width <= rail.x + rail.width
+      }
+    }).toEqual({ navigationAboveActions: true, centeredInRail: true, insideRail: true })
+
+    await page.setViewportSize({ width: 1280, height: 900 })
+    await expect.poll(async () => {
+      const [rail, navigation] = await Promise.all([
+        page.locator('.shortsActionRail').boundingBox(),
+        page.locator('.shortsNavigation').boundingBox()
+      ])
+
+      return navigation.x > rail.x + rail.width
+    }).toBe(true)
+
     await page.evaluate(() => {
       window.__shortsNavigationDisappeared = false
       const observer = new MutationObserver(() => {

--- a/e2e/tests/offline/subscriptions-new-feed.spec.mjs
+++ b/e2e/tests/offline/subscriptions-new-feed.spec.mjs
@@ -173,6 +173,18 @@ test.describe('new subscriptions feed', () => {
 })
 
 test.describe('new feed settings and seen state', () => {
+  const videoPost = {
+    ...post('new-post-2', 'New video post', now - 40 * 60000),
+    postContent: {
+      type: 'video',
+      content: video('post-video-1', 'Attached video', now - 40 * 60000)
+    }
+  }
+  const cacheWithVideoPost = [{
+    ...populatedCache[0],
+    communityPosts: [...populatedCache[0].communityPosts, videoPost]
+  }]
+
   test.use({
     seed: {
       settings: {
@@ -181,7 +193,7 @@ test.describe('new feed settings and seen state', () => {
         showNewSubscriptionFeedIndicators: false
       },
       profiles: [profile()],
-      subscriptionCache: populatedCache
+      subscriptionCache: cacheWithVideoPost
     }
   })
 
@@ -207,6 +219,78 @@ test.describe('new feed settings and seen state', () => {
     await goTo(relaunched.page, 'subscriptions')
     await relaunched.page.locator('[data-subscription-feed-tab="all"]').click()
     await expect(relaunched.page.getByText('There is no new content.')).toBeVisible()
+  })
+
+  test('keeps YouTube-style Shorts as portrait grid cards in list display mode', async ({ page }) => {
+    await goTo(page, 'subscriptions')
+    await page.locator('[data-subscription-feed-tab="shorts"]').click()
+
+    const short = page.locator('.ft-list-video.youtubeShort').filter({ hasText: 'New short' })
+    await expect(short).toBeVisible()
+    // The list layout squeezes the portrait card into a row and drops the
+    // portrait thumbnail rule, which the grid class must prevent.
+    await expect(short).toContainClass('grid')
+    await expect(short).not.toContainClass('list')
+
+    const aspectRatio = await short.locator('.thumbnailImage').evaluate(element => {
+      return getComputedStyle(element).aspectRatio
+    })
+    expect(aspectRatio).toBe('2 / 3')
+  })
+
+  test('stacks community post sections in list display mode', async ({ page }) => {
+    await goTo(page, 'subscriptions')
+    await page.locator('[data-subscription-feed-tab="posts"]').click()
+
+    const post = page.locator('.ft-list-post').filter({ hasText: 'New community post' })
+    await expect(post).toBeVisible()
+
+    // The video list template placed the author, the text and the bottom
+    // section into its three columns instead of stacking them.
+    const layout = await post.evaluate(element => {
+      const author = element.querySelector('.author-div').getBoundingClientRect()
+      const text = element.querySelector('.postText').getBoundingClientRect()
+
+      return {
+        postWidth: element.getBoundingClientRect().width,
+        authorBottom: author.bottom,
+        textTop: text.top,
+        textWidth: text.width
+      }
+    })
+
+    expect(layout.textTop).toBeGreaterThanOrEqual(layout.authorBottom)
+    expect(layout.textWidth).toBeGreaterThan(layout.postWidth * 0.8)
+  })
+
+  test('keeps an attached video inside a post as a full width card in list display mode', async ({ page }) => {
+    await goTo(page, 'subscriptions')
+    await page.locator('[data-subscription-feed-tab="posts"]').click()
+
+    const attachedVideo = page.locator('.ft-list-post .ft-list-video').filter({ hasText: 'Attached video' })
+    await expect(attachedVideo).toBeVisible()
+    // The list layout put the thumbnail beside the title and left the duration
+    // badge stranded outside the shrunken thumbnail.
+    await expect(attachedVideo).toContainClass('grid')
+
+    const layout = await attachedVideo.evaluate(element => {
+      const thumbnail = element.querySelector('.videoThumbnail').getBoundingClientRect()
+      const title = element.querySelector('.title').getBoundingClientRect()
+      const duration = element.querySelector('.videoDuration').getBoundingClientRect()
+
+      return {
+        cardWidth: element.getBoundingClientRect().width,
+        thumbnailWidth: thumbnail.width,
+        thumbnailRight: thumbnail.right,
+        titleTop: title.top,
+        thumbnailBottom: thumbnail.bottom,
+        durationRight: duration.right
+      }
+    })
+
+    expect(layout.thumbnailWidth).toBeGreaterThan(layout.cardWidth * 0.8)
+    expect(layout.titleTop).toBeGreaterThanOrEqual(layout.thumbnailBottom - 12)
+    expect(layout.durationRight).toBeLessThanOrEqual(layout.thumbnailRight)
   })
 
   test('persists a post as seen when its comments are opened', async ({ app, page }) => {

--- a/e2e/tests/offline/subscriptions-new-feed.spec.mjs
+++ b/e2e/tests/offline/subscriptions-new-feed.spec.mjs
@@ -212,29 +212,25 @@ test.describe('new feed settings and seen state', () => {
     const markAllAsSeen = page.getByRole('button', { name: 'Mark all as seen' })
     await expect(markAllAsSeen).toBeVisible()
     await page.evaluate(() => {
-      window.__firstFeedLeaveAt = null
-
-      const observer = new MutationObserver(() => {
-        if (
-          window.__firstFeedLeaveAt === null &&
-          document.querySelector(
-            '.newFeed .feed-leave-active, .newFeed .new-feed-section-leave-active'
-          )
-        ) {
-          window.__firstFeedLeaveAt = performance.now()
-          observer.disconnect()
+      const store = document.querySelector('#app').__vue_app__.config.globalProperties.$store
+      window.__markSeenMutations = []
+      window.__unsubscribeMarkSeen = store.subscribe((mutation) => {
+        if (mutation.type === 'markSubscriptionEntriesAsSeenInCache') {
+          window.__markSeenMutations.push(mutation.payload)
         }
-      })
-      observer.observe(document.querySelector('.newFeed'), {
-        attributes: true,
-        attributeFilter: ['class'],
-        subtree: true
       })
     })
     await markAllAsSeen.click()
     await expect(page.getByText('There is no new content.')).toBeVisible()
-    expect(await page.evaluate(() => performance.now() - window.__firstFeedLeaveAt))
-      .toBeLessThan(350)
+    expect(await page.evaluate(() => {
+      window.__unsubscribeMarkSeen()
+      return window.__markSeenMutations
+    })).toEqual([[
+      { tab: 'videos', channelId: CHANNEL_ID },
+      { tab: 'shorts', channelId: CHANNEL_ID },
+      { tab: 'live', channelId: CHANNEL_ID },
+      { tab: 'posts', channelId: CHANNEL_ID }
+    ]])
     await expect(markAllAsSeen).toHaveCount(0)
 
     const relaunched = await app.relaunch()

--- a/e2e/tests/offline/subscriptions-new-feed.spec.mjs
+++ b/e2e/tests/offline/subscriptions-new-feed.spec.mjs
@@ -211,8 +211,30 @@ test.describe('new feed settings and seen state', () => {
 
     const markAllAsSeen = page.getByRole('button', { name: 'Mark all as seen' })
     await expect(markAllAsSeen).toBeVisible()
+    await page.evaluate(() => {
+      window.__firstFeedLeaveAt = null
+
+      const observer = new MutationObserver(() => {
+        if (
+          window.__firstFeedLeaveAt === null &&
+          document.querySelector(
+            '.newFeed .feed-leave-active, .newFeed .new-feed-section-leave-active'
+          )
+        ) {
+          window.__firstFeedLeaveAt = performance.now()
+          observer.disconnect()
+        }
+      })
+      observer.observe(document.querySelector('.newFeed'), {
+        attributes: true,
+        attributeFilter: ['class'],
+        subtree: true
+      })
+    })
     await markAllAsSeen.click()
     await expect(page.getByText('There is no new content.')).toBeVisible()
+    expect(await page.evaluate(() => performance.now() - window.__firstFeedLeaveAt))
+      .toBeLessThan(350)
     await expect(markAllAsSeen).toHaveCount(0)
 
     const relaunched = await app.relaunch()

--- a/e2e/tests/offline/video-actions.spec.mjs
+++ b/e2e/tests/offline/video-actions.spec.mjs
@@ -112,6 +112,45 @@ test.describe('list video actions', () => {
     }).toBe(true)
   })
 
+  test('a tall options dropdown stays below the horizontal tab bar', async ({ page }) => {
+    await goTo(page, 'history')
+    await page.setViewportSize({ width: 1200, height: 400 })
+
+    const video = page.locator('.ft-list-video').first()
+    await video.hover()
+    await video.locator('.optionsButton').click()
+
+    const dropdown = video.locator('.optionsButton .iconDropdown')
+    await expect(dropdown).toBeVisible()
+
+    // Clamping to the viewport edge let a menu that is too tall for the space
+    // below it cover the tabs and the top navigation instead of scrolling.
+    const [dropdownBounds, chromeBottom] = await Promise.all([
+      dropdown.boundingBox(),
+      page.evaluate(() => {
+        return Math.max(
+          document.querySelector('.topNav').getBoundingClientRect().bottom,
+          document.querySelector('.tabBar:not(.vertical)').getBoundingClientRect().bottom
+        )
+      })
+    ])
+
+    expect(chromeBottom).toBeGreaterThan(0)
+    expect(dropdownBounds.y).toBeGreaterThanOrEqual(chromeBottom)
+    expect(dropdownBounds.y + dropdownBounds.height).toBeLessThanOrEqual(400)
+    expect(await dropdown.evaluate((element) => element.scrollHeight > element.clientHeight)).toBe(true)
+
+    // Repositioning alone cannot keep up with a fast scroll, so the chrome also
+    // has to paint above the dropdown.
+    const stackingOrder = await dropdown.evaluate((element) => ({
+      dropdown: Number(getComputedStyle(element).zIndex),
+      tabBar: Number(getComputedStyle(document.querySelector('.tabBar:not(.vertical)')).zIndex),
+      topNav: Number(getComputedStyle(document.querySelector('.topNav')).zIndex)
+    }))
+    expect(stackingOrder.tabBar).toBeGreaterThan(stackingOrder.dropdown)
+    expect(stackingOrder.topNav).toBeGreaterThan(stackingOrder.dropdown)
+  })
+
   test('an open options dropdown crosses vertical tabs without lifting its feed card', async ({ page }) => {
     await goTo(page, 'history')
     await page.evaluate(() => {

--- a/src/renderer/components/FtCommunityPost/FtCommunityPost.scss
+++ b/src/renderer/components/FtCommunityPost/FtCommunityPost.scss
@@ -152,6 +152,13 @@
   padding-block-end: 20px;
 }
 
+// The shared list layout is a 'grabBar thumbnail info' column grid meant for
+// video cards. A post has none of those areas, so its sections would get
+// auto-placed into those columns side by side instead of stacking.
+.ft-list-item.list {
+  display: block;
+}
+
 .sliderContainer {
   display: grid;
 }

--- a/src/renderer/components/FtCommunityPost/FtCommunityPost.vue
+++ b/src/renderer/components/FtCommunityPost/FtCommunityPost.vue
@@ -94,6 +94,7 @@
         v-if="!hideVideo"
         :data="data.postContent.content"
         appearance=""
+        force-list-type="grid"
       />
       <p
         v-else

--- a/src/renderer/components/FtIconButton/FtIconButton.vue
+++ b/src/renderer/components/FtIconButton/FtIconButton.vue
@@ -330,13 +330,50 @@ function handleIconPointerDown(event) {
   }
 }
 
+/**
+ * The bottom edge of the sticky app chrome (the horizontal tab bar and the top
+ * navigation). Dropdowns must not cover it, so it is their upper boundary
+ * instead of the viewport edge. The vertical tab bar is a side column, so it
+ * never sits above the content.
+ * @returns {number}
+ */
+function getTopChromeBottom() {
+  // In fullscreen the chrome is not on screen, even though it keeps its layout.
+  if (document.fullscreenElement != null) {
+    return 0
+  }
+
+  let bottom = 0
+
+  for (const selector of ['.topNav', '.tabBar:not(.vertical)']) {
+    const element = document.querySelector(selector)
+
+    if (element != null) {
+      bottom = Math.max(bottom, element.getBoundingClientRect().bottom)
+    }
+  }
+
+  return bottom
+}
+
 function keepDropdownInViewport() {
   if (dropdown.value == null) {
     return
   }
 
   const viewportMargin = 8
+  const minTop = Math.max(viewportMargin, getTopChromeBottom() + 4)
   dropdown.value.style.removeProperty('transform')
+  dropdown.value.style.removeProperty('max-block-size')
+  dropdown.value.style.removeProperty('overflow-y')
+
+  // A menu that is too tall for the space below the chrome has to scroll,
+  // otherwise clamping it would just push it past the viewport bottom instead.
+  const availableHeight = window.innerHeight - minTop - viewportMargin
+  if (dropdown.value.getBoundingClientRect().height > availableHeight) {
+    dropdown.value.style.maxBlockSize = `${availableHeight}px`
+    dropdown.value.style.overflowY = 'auto'
+  }
 
   if (props.dropdownPortal) {
     const button = ftIconButton.value?.querySelector('.iconButton')
@@ -363,13 +400,13 @@ function keepDropdownInViewport() {
 
     dropdown.value.style.inset = 'auto'
     dropdown.value.style.left = `${Math.max(viewportMargin, Math.min(left, maxLeft))}px`
-    dropdown.value.style.top = `${Math.max(viewportMargin, Math.min(top, maxTop))}px`
+    dropdown.value.style.top = `${Math.max(minTop, Math.min(top, maxTop))}px`
     return
   }
 
   const rect = dropdown.value.getBoundingClientRect()
   const offsetX = Math.max(viewportMargin - rect.left, Math.min(0, window.innerWidth - viewportMargin - rect.right))
-  const offsetY = Math.max(viewportMargin - rect.top, Math.min(0, window.innerHeight - viewportMargin - rect.bottom))
+  const offsetY = Math.max(minTop - rect.top, Math.min(0, window.innerHeight - viewportMargin - rect.bottom))
 
   dropdown.value.style.transform = `translate(${offsetX}px, ${offsetY}px)`
 }

--- a/src/renderer/components/FtListLazyWrapper/FtListLazyWrapper.vue
+++ b/src/renderer/components/FtListLazyWrapper/FtListLazyWrapper.vue
@@ -30,7 +30,7 @@
         :can-move-video-up="canMoveVideoUp"
         :can-move-video-down="canMoveVideoDown"
         :can-remove-from-playlist="canRemoveFromPlaylist"
-        :layout="layout"
+        :force-list-type="layout"
         :show-grab-bar="isDraggable && layout === 'grid'"
         @move-video-up="moveVideoUp"
         @move-video-down="moveVideoDown"

--- a/src/renderer/components/FtListVideo/FtListVideo.vue
+++ b/src/renderer/components/FtListVideo/FtListVideo.vue
@@ -438,10 +438,6 @@ const props = defineProps({
     type: Boolean,
     default: false,
   },
-  layout: {
-    type: String,
-    default: 'list',
-  },
   showGrabBar: {
     type: Boolean,
     default: false,

--- a/src/renderer/components/TabBar/TabBar.css
+++ b/src/renderer/components/TabBar/TabBar.css
@@ -16,6 +16,14 @@
   overflow: hidden;
 }
 
+/* The horizontal bar shares the top edge with the sticky top navigation, so it
+   is chrome: it stays above open dropdowns (z-index 6), which would otherwise
+   paint over the tabs while a fast scroll outruns their repositioning. The
+   vertical bar is a side column that dropdowns are allowed to cross. */
+.tabBar:not(.vertical) {
+  z-index: 8;
+}
+
 .tabsViewport {
   position: relative;
   flex: 1;

--- a/src/renderer/components/ft-shaka-video-player/ft-shaka-video-player.css
+++ b/src/renderer/components/ft-shaka-video-player/ft-shaka-video-player.css
@@ -232,41 +232,6 @@
   --shorts-dock-width: var(--side-panel-width);
 }
 
-.shortsNavigation {
-  position: fixed;
-  z-index: 12;
-  inset-inline-end: 24px;
-  inset-block-start: 50%;
-  display: flex;
-  flex-direction: column;
-  gap: 12px;
-  transform: translateY(-50%);
-}
-
-.shortsNavigationButton {
-  display: grid;
-  place-items: center;
-  inline-size: 48px;
-  block-size: 48px;
-  padding: 0;
-  border: 0;
-  border-radius: 50%;
-  color: var(--primary-text-color);
-  background-color: var(--side-nav-hover-color);
-  cursor: pointer;
-  font-size: 18px;
-}
-
-.shortsNavigationButton:hover,
-.shortsNavigationButton:focus-visible {
-  background-color: var(--side-nav-active-color);
-}
-
-.shortsNavigationButton:disabled {
-  cursor: default;
-  opacity: 0.35;
-}
-
 .ftVideoPlayer :deep(.videoAnnotations) {
   transition: inset-inline-end 250ms ease;
 }
@@ -2795,25 +2760,6 @@
 
 .ftVideoPlayerHost {
   position: relative;
-}
-
-@media only screen and (width <= 760px) {
-  .shortsNavigation {
-    inset-inline-end: 12px;
-  }
-
-  .shortsNavigationButton {
-    inline-size: 42px;
-    block-size: 42px;
-    color: #fff;
-    background-color: rgb(0 0 0 / 55%);
-  }
-}
-
-@media only screen and (width <= 900px) {
-  .shortsNavigation {
-    inset-block-start: 30%;
-  }
 }
 
 .ambientCanvas {

--- a/src/renderer/components/ft-shaka-video-player/ft-shaka-video-player.js
+++ b/src/renderer/components/ft-shaka-video-player/ft-shaka-video-player.js
@@ -428,6 +428,7 @@ export default defineComponent({
     'chapter-thumbnails-change',
     'sponsorblock-info-change',
     'toggle-shorts-metadata',
+    'seeking',
   ],
   setup: function (props, { emit, expose }) {
     const { locale, t } = useI18n()
@@ -4185,6 +4186,11 @@ export default defineComponent({
       }
 
       emit('ended', sleepTimerEnded)
+    }
+
+    function handleSeeking() {
+      syncPlayPauseControlIcons()
+      emit('seeking')
     }
 
     function applyPendingPresentationModes() {
@@ -8468,6 +8474,7 @@ export default defineComponent({
       syncPlayPauseControlIcons,
       handleCanPlay,
       handleEnded,
+      handleSeeking,
       updateVolume,
       handleTimeupdate,
       handleEnterPictureInPicture,

--- a/src/renderer/components/ft-shaka-video-player/ft-shaka-video-player.js
+++ b/src/renderer/components/ft-shaka-video-player/ft-shaka-video-player.js
@@ -252,14 +252,6 @@ export default defineComponent({
       type: Number,
       default: null
     },
-    shortsHasPrevious: {
-      type: Boolean,
-      default: false
-    },
-    shortsHasNext: {
-      type: Boolean,
-      default: false
-    },
     theatrePossible: {
       type: Boolean,
       default: false
@@ -436,15 +428,11 @@ export default defineComponent({
     'chapter-thumbnails-change',
     'sponsorblock-info-change',
     'toggle-shorts-metadata',
-    'shorts-previous',
-    'shorts-next',
   ],
   setup: function (props, { emit, expose }) {
     const { locale, t } = useI18n()
     const { tabId, isTabPresented } = useTabContext()
     const mediaTabId = tabId ?? 'web'
-    const emitShortsPrevious = () => emit('shorts-previous')
-    const emitShortsNext = () => emit('shorts-next')
     // Shorts request autoplay, so do not render their paused-only controls
     // while the media element is still preparing its first `play` event.
     const shortsPaused = ref(false)
@@ -8340,8 +8328,6 @@ export default defineComponent({
     }
 
     return {
-      emitShortsPrevious,
-      emitShortsNext,
       shortsPaused,
       shortsMuted,
       shortsCaptionsAvailable,

--- a/src/renderer/components/ft-shaka-video-player/ft-shaka-video-player.vue
+++ b/src/renderer/components/ft-shaka-video-player/ft-shaka-video-player.vue
@@ -89,7 +89,7 @@
         @playing="handlePlaying"
         @pause="handlePause"
         @ended="handleEnded"
-        @seeking="syncPlayPauseControlIcons"
+        @seeking="handleSeeking"
         @canplay="handleCanPlay"
         @volumechange="updateVolume"
         @timeupdate="handleTimeupdate"

--- a/src/renderer/components/ft-shaka-video-player/ft-shaka-video-player.vue
+++ b/src/renderer/components/ft-shaka-video-player/ft-shaka-video-player.vue
@@ -1124,31 +1124,6 @@
         />
       </div>
     </div>
-    <div
-      v-if="shortsPlayer && (shortsHasPrevious || shortsHasNext)"
-      class="shortsNavigation"
-    >
-      <button
-        type="button"
-        class="shortsNavigationButton"
-        :disabled="!shortsHasPrevious"
-        :aria-label="$t('Video.Previous')"
-        :title="$t('Video.Previous')"
-        @click="emitShortsPrevious"
-      >
-        <font-awesome-icon :icon="['fas', 'arrow-up']" />
-      </button>
-      <button
-        type="button"
-        class="shortsNavigationButton"
-        :disabled="!shortsHasNext"
-        :aria-label="$t('Video.Next')"
-        :title="$t('Video.Next')"
-        @click="emitShortsNext"
-      >
-        <font-awesome-icon :icon="['fas', 'arrow-down']" />
-      </button>
-    </div>
   </div>
 </template>
 

--- a/src/renderer/helpers/player/shorts.js
+++ b/src/renderer/helpers/player/shorts.js
@@ -1,6 +1,49 @@
 const MAX_SHORT_DURATION_SECONDS = 3 * 60
 const MAX_CHANNEL_SHORTS_CONTEXTS = 20
+const SHORTS_COMPLETION_END_MARGIN_SECONDS = 0.5
+const SHORTS_COMPLETION_MAX_PLAYBACK_TICK_SECONDS = 2
+const SHORTS_COMPLETION_MIN_PLAYBACK_AFTER_SEEK_SECONDS = 1
 const channelShortsNavigationContexts = new Map()
+
+/**
+ * Keeps seek jumps from completing a Short. After a seek, only continuous
+ * forward playback can re-enable completion detection.
+ *
+ * @param {object} options
+ * @param {boolean} options.blockedBySeek
+ * @param {number} options.playbackAfterSeekSeconds
+ * @param {number} options.elapsedSeconds
+ * @param {number} options.currentSeconds
+ * @param {number} options.durationSeconds
+ * @returns {{blockedBySeek: boolean, playbackAfterSeekSeconds: number, reachedEnd: boolean}}
+ */
+export function getShortsCompletionState({
+  blockedBySeek,
+  playbackAfterSeekSeconds,
+  elapsedSeconds,
+  currentSeconds,
+  durationSeconds,
+}) {
+  let playedSeconds = playbackAfterSeekSeconds
+  let blocked = blockedBySeek
+
+  if (
+    blocked &&
+    elapsedSeconds > 0 &&
+    elapsedSeconds <= SHORTS_COMPLETION_MAX_PLAYBACK_TICK_SECONDS
+  ) {
+    playedSeconds += elapsedSeconds
+    blocked = playedSeconds < SHORTS_COMPLETION_MIN_PLAYBACK_AFTER_SEEK_SECONDS
+  }
+
+  return {
+    blockedBySeek: blocked,
+    playbackAfterSeekSeconds: playedSeconds,
+    reachedEnd: !blocked &&
+      durationSeconds > 0 &&
+      currentSeconds >= durationSeconds - SHORTS_COMPLETION_END_MARGIN_SECONDS
+  }
+}
 
 /**
  * Prefers YouTube's selected portrait thumbnail only when the user has not

--- a/src/renderer/store/modules/subscription-cache.js
+++ b/src/renderer/store/modules/subscription-cache.js
@@ -180,60 +180,66 @@ const actions = {
     }
   },
 
-  async markSubscriptionEntriesAsSeen({ commit, state }, { tab, channelIds }) {
-    let cache
-    let entriesKey
-    let updateEntries
-
-    switch (tab) {
-      case 'videos':
-        cache = state.videoCache
-        entriesKey = 'videos'
-        updateEntries = DBSubscriptionCacheHandlers.updateVideosByChannelId
-        break
-      case 'shorts':
-        cache = state.shortsCache
-        entriesKey = 'videos'
-        updateEntries = DBSubscriptionCacheHandlers.updateShortsByChannelId
-        break
-      case 'live':
-        cache = state.liveCache
-        entriesKey = 'videos'
-        updateEntries = DBSubscriptionCacheHandlers.updateLiveStreamsByChannelId
-        break
-      case 'posts':
-        cache = state.postsCache
-        entriesKey = 'posts'
-        updateEntries = DBSubscriptionCacheHandlers.updateCommunityPostsByChannelId
-        break
-      default:
-        return
+  async markSubscriptionEntriesAsSeen({ commit, state }, { tab, tabs = [tab], channelIds }) {
+    const channelIdSet = new Set(channelIds)
+    const cacheConfigs = {
+      videos: {
+        cache: state.videoCache,
+        entriesKey: 'videos',
+        updateEntries: DBSubscriptionCacheHandlers.updateVideosByChannelId
+      },
+      shorts: {
+        cache: state.shortsCache,
+        entriesKey: 'videos',
+        updateEntries: DBSubscriptionCacheHandlers.updateShortsByChannelId
+      },
+      live: {
+        cache: state.liveCache,
+        entriesKey: 'videos',
+        updateEntries: DBSubscriptionCacheHandlers.updateLiveStreamsByChannelId
+      },
+      posts: {
+        cache: state.postsCache,
+        entriesKey: 'posts',
+        updateEntries: DBSubscriptionCacheHandlers.updateCommunityPostsByChannelId
+      }
     }
 
-    const channelIdSet = new Set(channelIds)
-
-    await Promise.all(Object.entries(cache).map(async ([channelId, cacheEntry]) => {
-      if (!channelIdSet.has(channelId)) {
-        return
+    const writes = tabs.flatMap(feedTab => {
+      const config = cacheConfigs[feedTab]
+      if (config == null) {
+        return []
       }
 
-      const entries = cacheEntry?.[entriesKey]
-      if (!entries?.some(entry => entry.isNewInSubscriptionFeed === true)) {
-        return
-      }
+      return Object.entries(config.cache).map(async ([channelId, cacheEntry]) => {
+        if (!channelIdSet.has(channelId)) {
+          return null
+        }
 
-      const seenEntries = entries.map(entry => ({
-        ...entry,
-        isNewInSubscriptionFeed: false
-      }))
+        const entries = cacheEntry?.[config.entriesKey]
+        if (!entries?.some(entry => entry.isNewInSubscriptionFeed === true)) {
+          return null
+        }
 
-      try {
-        await updateEntries(channelId, seenEntries, cacheEntry.timestamp)
-        commit('markSubscriptionEntriesAsSeenByChannel', { tab, channelId })
-      } catch (errMessage) {
-        console.error(errMessage)
-      }
-    }))
+        const seenEntries = entries.map(entry => ({
+          ...entry,
+          isNewInSubscriptionFeed: false
+        }))
+
+        try {
+          await config.updateEntries(channelId, seenEntries, cacheEntry.timestamp)
+          return { tab: feedTab, channelId }
+        } catch (errMessage) {
+          console.error(errMessage)
+          return null
+        }
+      })
+    })
+
+    // Updating every successful cache entry in one mutation gives Vue one
+    // render, so all cards leave together regardless of feed size.
+    commit('markSubscriptionEntriesAsSeenInCache', (await Promise.all(writes))
+      .filter(cacheEntry => cacheEntry != null))
   },
 
   async markSubscriptionVideoAsSeen({ commit, state }, videoId) {
@@ -341,19 +347,22 @@ const mutations = {
     }
   },
 
-  markSubscriptionEntriesAsSeenByChannel(state, { tab, channelId }) {
-    const cacheEntry = tab === 'videos'
-      ? state.videoCache[channelId]
-      : tab === 'shorts'
-        ? state.shortsCache[channelId]
-        : tab === 'live'
-          ? state.liveCache[channelId]
-          : state.postsCache[channelId]
-    const entries = tab === 'posts' ? cacheEntry?.posts : cacheEntry?.videos
+  markSubscriptionEntriesAsSeenInCache(state, cacheEntries) {
+    for (const { tab, channelId } of cacheEntries) {
+      const cache = tab === 'videos'
+        ? state.videoCache
+        : tab === 'shorts'
+          ? state.shortsCache
+          : tab === 'live'
+            ? state.liveCache
+            : state.postsCache
+      const cacheEntry = cache[channelId]
+      const entries = tab === 'posts' ? cacheEntry?.posts : cacheEntry?.videos
 
-    entries?.forEach(entry => {
-      entry.isNewInSubscriptionFeed = false
-    })
+      entries?.forEach(entry => {
+        entry.isNewInSubscriptionFeed = false
+      })
+    }
   },
 
   updateVideoCacheByChannel(state, { channelId, entries, timestamp = new Date() }) {

--- a/src/renderer/views/Subscriptions/Subscriptions.vue
+++ b/src/renderer/views/Subscriptions/Subscriptions.vue
@@ -557,15 +557,12 @@ async function markAllAsSeen(tab) {
       ? visibleTabs.value.filter(visibleTab => visibleTab !== 'new')
       : [tab]
 
-    for (const feedTab of feedTabs) {
-      await store.dispatch(
-        'markSubscriptionEntriesAsSeen',
-        {
-          tab: feedTab === 'community' ? 'posts' : feedTab,
-          channelIds: activeSubscriptionList.value.map(channel => channel.id)
-        }
-      )
-    }
+    const channelIds = activeSubscriptionList.value.map(channel => channel.id)
+
+    await store.dispatch('markSubscriptionEntriesAsSeen', {
+      tabs: feedTabs.map(feedTab => feedTab === 'community' ? 'posts' : feedTab),
+      channelIds
+    })
   } finally {
     markingSeenTab.value = null
   }

--- a/src/renderer/views/Watch/Watch.js
+++ b/src/renderer/views/Watch/Watch.js
@@ -188,6 +188,7 @@ export default defineComponent({
       shortsTransitionPreview: '',
       shortsTransitionDirection: 0,
       shortsViewportHeight: window.innerHeight,
+      shortsPlaybackCompleted: false,
       videoLoadGeneration: 0,
       hasAiGeneratedContent: false,
       upcomingTimestamp: null,
@@ -1178,6 +1179,7 @@ export default defineComponent({
       this.isShort = this.tabRoute.query.short === 'true'
       this.videoAspectRatio = this.isShort ? 9 / 16 : null
       this.shortsLinkedVideo = null
+      this.shortsPlaybackCompleted = false
       this.hasAiGeneratedContent = false
       this.upcomingTimestamp = null
       this.upcomingTimeLeft = null
@@ -2526,7 +2528,34 @@ export default defineComponent({
         }
       }
 
+      // A looping media element does not fire `ended`. Persist the completed
+      // state just before a Short wraps to zero, then keep that full progress
+      // from being replaced by later ticks from the next loop.
+      const shortReachedEnd = currentSeconds >= this.videoLengthSeconds - 0.5 ||
+        (
+          currentSeconds < 0.5 &&
+          this.currentTime >= this.videoLengthSeconds - 1
+        )
+
       this.updateCurrentTime(currentSeconds)
+
+      if (
+        this.rememberHistory &&
+        this.customShortsPlayerActive &&
+        !this.shortsPlaybackCompleted &&
+        !this.isUpcoming &&
+        !this.isLive &&
+        this.videoLengthSeconds > 0 &&
+        shortReachedEnd
+      ) {
+        this.shortsPlaybackCompleted = true
+        const watchProgress = this.watchedProgressSavingEnabled
+          ? this.videoLengthSeconds
+          : (this.historyEntry?.watchProgress ?? 0)
+
+        this.addToHistory(watchProgress, true)
+      }
+
       this.updateCurrentChapter(currentSeconds)
       this.$store.commit('setCurrentWatchTimestamp', {
         tabId: this.tabId,
@@ -2711,7 +2740,9 @@ export default defineComponent({
       if (process.env.IS_ELECTRON && !this.hasBeenPresented) { return }
       if (!this.$refs.player?.hasLoaded) { return }
 
-      const currentTime = this.getWatchedProgress()
+      const currentTime = this.shortsPlaybackCompleted && this.watchedProgressSavingEnabled
+        ? this.videoLengthSeconds
+        : this.getWatchedProgress()
       const payload = {
         videoId: this.videoId,
         watchProgress: currentTime

--- a/src/renderer/views/Watch/Watch.js
+++ b/src/renderer/views/Watch/Watch.js
@@ -61,6 +61,7 @@ import { selectSponsorBlockFullVideoLabel } from '../../helpers/player/sponsorBl
 import {
   buildSubscriptionShortsFeed,
   getChannelShortsNavigationContext,
+  getShortsCompletionState,
   getVideoAspectRatio,
   isYouTubeShort
 } from '../../helpers/player/shorts'
@@ -189,6 +190,8 @@ export default defineComponent({
       shortsTransitionDirection: 0,
       shortsViewportHeight: window.innerHeight,
       shortsPlaybackCompleted: false,
+      shortsCompletionBlockedBySeek: false,
+      shortsPlaybackAfterSeekSeconds: 0,
       videoLoadGeneration: 0,
       hasAiGeneratedContent: false,
       upcomingTimestamp: null,
@@ -1180,6 +1183,8 @@ export default defineComponent({
       this.videoAspectRatio = this.isShort ? 9 / 16 : null
       this.shortsLinkedVideo = null
       this.shortsPlaybackCompleted = false
+      this.shortsCompletionBlockedBySeek = false
+      this.shortsPlaybackAfterSeekSeconds = 0
       this.hasAiGeneratedContent = false
       this.upcomingTimestamp = null
       this.upcomingTimeLeft = null
@@ -2528,14 +2533,21 @@ export default defineComponent({
         }
       }
 
+      const elapsedSeconds = currentSeconds - this.currentTime
+      const shortsCompletion = getShortsCompletionState({
+        blockedBySeek: this.shortsCompletionBlockedBySeek,
+        playbackAfterSeekSeconds: this.shortsPlaybackAfterSeekSeconds,
+        elapsedSeconds,
+        currentSeconds,
+        durationSeconds: this.videoLengthSeconds
+      })
+      this.shortsCompletionBlockedBySeek = shortsCompletion.blockedBySeek
+      this.shortsPlaybackAfterSeekSeconds = shortsCompletion.playbackAfterSeekSeconds
+
       // A looping media element does not fire `ended`. Persist the completed
-      // state just before a Short wraps to zero, then keep that full progress
-      // from being replaced by later ticks from the next loop.
-      const shortReachedEnd = currentSeconds >= this.videoLengthSeconds - 0.5 ||
-        (
-          currentSeconds < 0.5 &&
-          this.currentTime >= this.videoLengthSeconds - 1
-        )
+      // state just before a Short wraps to zero, but never from a seek-driven
+      // time update.
+      const shortReachedEnd = shortsCompletion.reachedEnd
 
       this.updateCurrentTime(currentSeconds)
 
@@ -2672,6 +2684,14 @@ export default defineComponent({
       this.watchTimeLastTick = null
       this.flushWatchTime()
       this.handleWatchProgressAutoSaveWhenProgressEnabled()
+    },
+    handlePlayerSeeking() {
+      if (!this.customShortsPlayerActive) {
+        return
+      }
+
+      this.shortsCompletionBlockedBySeek = true
+      this.shortsPlaybackAfterSeekSeconds = 0
     },
     clearPendingWatchTime() {
       this.watchTimeLastTick = null

--- a/src/renderer/views/Watch/Watch.scss
+++ b/src/renderer/views/Watch/Watch.scss
@@ -543,7 +543,7 @@
       transform: scale(1.1);
     }
 
-    .shortsLoadingNavigation {
+    .shortsNavigation {
       position: fixed;
       z-index: 12;
       inset-inline-end: 24px;
@@ -554,7 +554,7 @@
       transform: translateY(-50%);
     }
 
-    .shortsLoadingNavigationButton {
+    .shortsNavigationButton {
       display: grid;
       place-items: center;
       inline-size: 48px;
@@ -568,12 +568,12 @@
       font-size: 18px;
     }
 
-    .shortsLoadingNavigationButton:hover,
-    .shortsLoadingNavigationButton:focus-visible {
+    .shortsNavigationButton:hover,
+    .shortsNavigationButton:focus-visible {
       background-color: var(--side-nav-active-color);
     }
 
-    .shortsLoadingNavigationButton:disabled {
+    .shortsNavigationButton:disabled {
       cursor: default;
       opacity: 0.35;
     }
@@ -813,6 +813,11 @@
         min-inline-size: 0;
       }
 
+      .shortsExternalChannel {
+        color: var(--primary-text-color);
+        opacity: 1;
+      }
+
       .shortsExternalTitle {
         display: -webkit-box;
         max-block-size: 2.6em;
@@ -836,24 +841,23 @@
       .shortsNextPreview {
         grid-row: 3;
       }
+
+      // The rail overlays the player here and grows upwards from its bottom, so
+      // a viewport-anchored nav ends up on the action buttons. Let it flow as
+      // the top of the same column instead, which lines it up with them.
+      .shortsNavigation {
+        position: static;
+        gap: inherit;
+        transform: none;
+      }
     }
 
     @media only screen and (width <= 760px) {
-      .shortsLoadingNavigation {
-        inset-inline-end: 12px;
-      }
-
-      .shortsLoadingNavigationButton {
+      .shortsNavigationButton {
         inline-size: 42px;
         block-size: 42px;
         color: #fff;
         background-color: rgb(0 0 0 / 55%);
-      }
-    }
-
-    @media only screen and (width <= 900px) {
-      .shortsLoadingNavigation {
-        inset-block-start: 30%;
       }
     }
   }

--- a/src/renderer/views/Watch/Watch.vue
+++ b/src/renderer/views/Watch/Watch.vue
@@ -123,8 +123,6 @@
           :sabr-reload-playback-rate="sabrReloadPlaybackRate"
           :shorts-player="customShortsPlayerActive"
           :shorts-aspect-ratio="videoAspectRatio"
-          :shorts-has-previous="hasPreviousSubscriptionShort"
-          :shorts-has-next="hasNextSubscriptionShort"
           class="videoPlayer"
           @error="handlePlayerError"
           @loaded="handleVideoLoaded"
@@ -156,8 +154,6 @@
           @chapter-thumbnails-change="handleChapterThumbnailsChange"
           @sponsorblock-info-change="handleSponsorBlockInfoChange"
           @toggle-shorts-metadata="toggleShortsMetadata"
-          @shorts-previous="navigateSubscriptionShort(-1)"
-          @shorts-next="navigateSubscriptionShort(1)"
         />
         <div
           v-if="!isLoading && (isUpcoming || errorMessage)"
@@ -284,6 +280,31 @@
           class="shortsActionRail"
           :class="{ shortsActionRailSkeleton: isLoading }"
         >
+          <div
+            v-if="hasPreviousSubscriptionShort || hasNextSubscriptionShort"
+            class="shortsNavigation"
+          >
+            <button
+              type="button"
+              class="shortsNavigationButton"
+              :disabled="!hasPreviousSubscriptionShort"
+              :aria-label="$t('Video.Previous')"
+              :title="$t('Video.Previous')"
+              @click="navigateSubscriptionShort(-1)"
+            >
+              <font-awesome-icon :icon="['fas', 'arrow-up']" />
+            </button>
+            <button
+              type="button"
+              class="shortsNavigationButton"
+              :disabled="!hasNextSubscriptionShort"
+              :aria-label="$t('Video.Next')"
+              :title="$t('Video.Next')"
+              @click="navigateSubscriptionShort(1)"
+            >
+              <font-awesome-icon :icon="['fas', 'arrow-down']" />
+            </button>
+          </div>
           <template v-if="isLoading">
             <div
               v-for="index in shortsActionSkeletonCount"
@@ -400,32 +421,6 @@
           :aria-label="$t('Video.Next')"
           @click="navigateSubscriptionShort(1)"
         />
-        <div
-          v-if="isLoading && customShortsPlayerActive &&
-            (hasPreviousSubscriptionShort || hasNextSubscriptionShort)"
-          class="shortsNavigation shortsLoadingNavigation"
-        >
-          <button
-            type="button"
-            class="shortsNavigationButton shortsLoadingNavigationButton"
-            :disabled="!hasPreviousSubscriptionShort"
-            :aria-label="$t('Video.Previous')"
-            :title="$t('Video.Previous')"
-            @click="navigateSubscriptionShort(-1)"
-          >
-            <font-awesome-icon :icon="['fas', 'arrow-up']" />
-          </button>
-          <button
-            type="button"
-            class="shortsNavigationButton shortsLoadingNavigationButton"
-            :disabled="!hasNextSubscriptionShort"
-            :aria-label="$t('Video.Next')"
-            :title="$t('Video.Next')"
-            @click="navigateSubscriptionShort(1)"
-          >
-            <font-awesome-icon :icon="['fas', 'arrow-down']" />
-          </button>
-        </div>
       </div>
       <div
         v-if="customShortsPlayerActive"

--- a/src/renderer/views/Watch/Watch.vue
+++ b/src/renderer/views/Watch/Watch.vue
@@ -130,6 +130,7 @@
           @terminal-outro-started="handleTerminalOutroStarted"
           @ended="handlePlayerEnded"
           @pause="handleVideoPause"
+          @seeking="handlePlayerSeeking"
           @toggle-theatre-mode="toggleTheatreMode"
           @toggle-autoplay="toggleAutoplay"
           @autoplay-cancel="abortAutoplayCountdown"

--- a/tests/unit/shorts-player.test.mjs
+++ b/tests/unit/shorts-player.test.mjs
@@ -5,11 +5,54 @@ import {
   buildSubscriptionShortsFeed,
   getChannelShortsNavigationContext,
   getPreferredShortThumbnailUrl,
+  getShortsCompletionState,
   getVideoAspectRatio,
   isYouTubeShort,
   parseLocalShortLinkedVideo,
   setChannelShortsNavigationContext,
 } from '../../src/renderer/helpers/player/shorts.js'
+
+test('only completes Shorts after continuous playback following a seek', () => {
+  const seekToEnd = getShortsCompletionState({
+    blockedBySeek: true,
+    playbackAfterSeekSeconds: 0,
+    elapsedSeconds: 59.75,
+    currentSeconds: 59.75,
+    durationSeconds: 60,
+  })
+  assert.deepEqual(seekToEnd, {
+    blockedBySeek: true,
+    playbackAfterSeekSeconds: 0,
+    reachedEnd: false
+  })
+
+  const seekBackToStart = getShortsCompletionState({
+    ...seekToEnd,
+    elapsedSeconds: -59.75,
+    currentSeconds: 0,
+    durationSeconds: 60,
+  })
+  assert.equal(seekBackToStart.reachedEnd, false)
+
+  const firstPlaybackTick = getShortsCompletionState({
+    ...seekBackToStart,
+    elapsedSeconds: 0.5,
+    currentSeconds: 59,
+    durationSeconds: 60,
+  })
+  const completed = getShortsCompletionState({
+    ...firstPlaybackTick,
+    elapsedSeconds: 0.5,
+    currentSeconds: 59.5,
+    durationSeconds: 60,
+  })
+
+  assert.deepEqual(completed, {
+    blockedBySeek: false,
+    playbackAfterSeekSeconds: 1,
+    reachedEnd: true
+  })
+})
 
 test('prefers YouTube selected Shorts thumbnails only for the default preference', () => {
   const video = {


### PR DESCRIPTION
## Pull Request Type

- [x] Bugfix
- [ ] Feature Implementation
- [ ] Documentation
- [ ] Other

## Related issue

None.

## Description

Fixes several UI regressions around subscription feeds, menus, and the custom Shorts player:

- keeps Shorts portrait cards and community posts intact in list mode
- constrains tall three-dot menus below the horizontal tab bar and top navigation
- marks all new subscription entries as seen in one render so the animation duration does not grow with the feed
- aligns Shorts navigation with the action rail at narrow widths and restores full channel-name opacity below the video
- records looping Shorts as watched at full progress and prevents later loop ticks from overwriting that state

## Screenshots

Not included; the layout regressions are covered by viewport-specific E2E assertions.

## Release note category

<!-- release-note-category:start -->
- [ ] Not noteworthy
- [ ] Highlights
- [ ] More improvements
- [x] Fixed bugs
<!-- release-note-category:end -->

## Release note

<!-- release-note:start -->
Fixed subscription feed layouts and animations, Shorts controls and watch progress, and menu layering near the tab bar.
<!-- release-note:end -->

## Release note images

<!-- release-note-image:start -->

<!-- release-note-image:end -->

## Testing

- `pnpm run lint`
- `pnpm run test:unit`
- `pnpm run test:e2e:pack`
- `xvfb-run -a -s "-screen 0 1920x1080x24" pnpm exec playwright test -c e2e/playwright.config.mjs --project=offline e2e/tests/offline/subscriptions-new-feed.spec.mjs`
- `xvfb-run -a -s "-screen 0 1920x1080x24" pnpm exec playwright test -c e2e/playwright.config.mjs --project=network e2e/tests/network/watch.spec.mjs --grep "only exposes applicable controls|scrolls through the cached subscriptions Shorts feed"`

## Desktop

- **OS:** Arch Linux
- **OS Version:** Rolling release
- **OpenTubeX version:** 0.30.0

## Additional context

The commits are split by fix area to keep review focused.