### PR TITLE
fix(modals): keep app header visible during scroll lock

### DIFF
--- a/e2e/tests/offline/collaborators-modal-animation.spec.mjs
+++ b/e2e/tests/offline/collaborators-modal-animation.spec.mjs
@@ -63,6 +63,32 @@ test.use({
 })
 
 function defineCase () {
+  test('opening the collaborators prompt keeps the sticky app header visible', async ({ page }) => {
+    await goTo(page, 'subscriptions')
+
+    await expect(page.getByText('Filler video 9')).toBeAttached()
+    await page.evaluate(() => window.scrollTo(0, 300))
+    await expect.poll(() => page.evaluate(() => window.scrollY)).toBeGreaterThan(0)
+
+    const topNav = page.locator('.topNav')
+    const topBefore = await topNav.evaluate(element => element.getBoundingClientRect().top)
+    await page.locator('.collaboratorChannelButton').evaluate(element => element.click())
+    await expect(page.locator('.prompt')).toBeVisible()
+
+    await expect.poll(() => topNav.evaluate(element => element.getBoundingClientRect().top))
+      .toBeCloseTo(topBefore, 0)
+    await expect(topNav).toBeInViewport()
+
+    const scrollBefore = await page.evaluate(() => window.scrollY)
+    await page.mouse.move(10, 200)
+    await page.mouse.wheel(0, 500)
+    await expect.poll(() => page.evaluate(() => window.scrollY)).toBe(scrollBefore)
+
+    await page.keyboard.press('Escape')
+    await expect(page.locator('.prompt')).toHaveCount(0)
+    await expect.poll(() => page.evaluate(() => document.documentElement.style.overflow)).toBe('')
+  })
+
   test('opening the collaborators prompt does not animate the feed behind it', async ({ page }) => {
     await goTo(page, 'subscriptions')
 

--- a/e2e/tests/offline/collaborators-modal-animation.spec.mjs
+++ b/e2e/tests/offline/collaborators-modal-animation.spec.mjs
@@ -67,7 +67,11 @@ function defineCase () {
     await goTo(page, 'subscriptions')
 
     await expect(page.getByText('Filler video 9')).toBeAttached()
-    await page.evaluate(() => window.scrollTo(0, 300))
+    const rootOverflowBefore = await page.evaluate(() => {
+      document.documentElement.style.overflow = 'auto'
+      window.scrollTo(0, 300)
+      return document.documentElement.style.overflow
+    })
     await expect.poll(() => page.evaluate(() => window.scrollY)).toBeGreaterThan(0)
 
     const topNav = page.locator('.topNav')
@@ -86,7 +90,8 @@ function defineCase () {
 
     await page.keyboard.press('Escape')
     await expect(page.locator('.prompt')).toHaveCount(0)
-    await expect.poll(() => page.evaluate(() => document.documentElement.style.overflow)).toBe('')
+    await expect.poll(() => page.evaluate(() => document.documentElement.style.overflow))
+      .toBe(rootOverflowBefore)
   })
 
   test('opening the collaborators prompt does not animate the feed behind it', async ({ page }) => {

--- a/src/renderer/components/FtAutoGrid/FtAutoGrid.vue
+++ b/src/renderer/components/FtAutoGrid/FtAutoGrid.vue
@@ -128,7 +128,7 @@ onMounted(() => {
   reducedMotionQuery.addEventListener('change', handleReducedMotionChange)
 
   resizeObserver = new ResizeObserver(([entry]) => {
-    const scrollbarCompensated = document.body.style.overflow === 'hidden' &&
+    const scrollbarCompensated = document.documentElement.style.overflow === 'hidden' &&
       document.body.style.paddingInlineEnd !== ''
     const measurement = measureStableGridWidth(
       entry.contentRect.width,

--- a/src/renderer/components/FtPrompt/FtPrompt.vue
+++ b/src/renderer/components/FtPrompt/FtPrompt.vue
@@ -67,7 +67,7 @@ import FtFlexBox from '../ft-flex-box/ft-flex-box.vue'
 import FtButton from '../FtButton/FtButton.vue'
 
 let scrollLockCount = 0
-let originalBodyOverflow = ''
+let originalDocumentOverflow = ''
 let originalBodyPaddingInlineEnd = ''
 
 const props = defineProps({
@@ -149,10 +149,12 @@ function lockBodyScroll() {
   if (scrollLockCount === 0) {
     const scrollbarWidth = window.innerWidth - document.documentElement.clientWidth
 
-    originalBodyOverflow = document.body.style.overflow
+    originalDocumentOverflow = document.documentElement.style.overflow
     originalBodyPaddingInlineEnd = document.body.style.paddingInlineEnd
 
-    document.body.style.overflow = 'hidden'
+    // Lock the root viewport rather than turning the body into an overflow
+    // container, which would make its sticky app chrome scroll out of view.
+    document.documentElement.style.overflow = 'hidden'
 
     if (scrollbarWidth > 0) {
       document.body.style.paddingInlineEnd = `calc(${originalBodyPaddingInlineEnd || '0px'} + ${scrollbarWidth}px)`
@@ -166,7 +168,7 @@ function unlockBodyScroll() {
   scrollLockCount = Math.max(0, scrollLockCount - 1)
 
   if (scrollLockCount === 0) {
-    document.body.style.overflow = originalBodyOverflow
+    document.documentElement.style.overflow = originalDocumentOverflow
     document.body.style.paddingInlineEnd = originalBodyPaddingInlineEnd
   }
 }

--- a/src/renderer/components/FtPrompt/FtPrompt.vue
+++ b/src/renderer/components/FtPrompt/FtPrompt.vue
@@ -65,10 +65,7 @@ import store from '../../store/index'
 import FtCard from '../ft-card/ft-card.vue'
 import FtFlexBox from '../ft-flex-box/ft-flex-box.vue'
 import FtButton from '../FtButton/FtButton.vue'
-
-let scrollLockCount = 0
-let originalDocumentOverflow = ''
-let originalBodyPaddingInlineEnd = ''
+import { lockBodyScroll, unlockBodyScroll } from './scrollLock'
 
 const props = defineProps({
   label: {
@@ -144,34 +141,6 @@ onBeforeUnmount(() => {
   }
   nextTick(() => lastActiveElement?.focus())
 })
-
-function lockBodyScroll() {
-  if (scrollLockCount === 0) {
-    const scrollbarWidth = window.innerWidth - document.documentElement.clientWidth
-
-    originalDocumentOverflow = document.documentElement.style.overflow
-    originalBodyPaddingInlineEnd = document.body.style.paddingInlineEnd
-
-    // Lock the root viewport rather than turning the body into an overflow
-    // container, which would make its sticky app chrome scroll out of view.
-    document.documentElement.style.overflow = 'hidden'
-
-    if (scrollbarWidth > 0) {
-      document.body.style.paddingInlineEnd = `calc(${originalBodyPaddingInlineEnd || '0px'} + ${scrollbarWidth}px)`
-    }
-  }
-
-  scrollLockCount += 1
-}
-
-function unlockBodyScroll() {
-  scrollLockCount = Math.max(0, scrollLockCount - 1)
-
-  if (scrollLockCount === 0) {
-    document.documentElement.style.overflow = originalDocumentOverflow
-    document.body.style.paddingInlineEnd = originalBodyPaddingInlineEnd
-  }
-}
 
 /**
  * @param {number} index

--- a/src/renderer/components/FtPrompt/scrollLock.js
+++ b/src/renderer/components/FtPrompt/scrollLock.js
@@ -1,0 +1,35 @@
+let scrollLockCount = 0
+let originalDocumentOverflow = ''
+let originalBodyPaddingInlineEnd = ''
+
+export function lockBodyScroll() {
+  if (scrollLockCount === 0) {
+    const scrollbarWidth = window.innerWidth - document.documentElement.clientWidth
+
+    originalDocumentOverflow = document.documentElement.style.overflow
+    originalBodyPaddingInlineEnd = document.body.style.paddingInlineEnd
+
+    // Lock the root viewport rather than turning the body into an overflow
+    // container, which would make its sticky app chrome scroll out of view.
+    document.documentElement.style.overflow = 'hidden'
+
+    if (scrollbarWidth > 0) {
+      document.body.style.paddingInlineEnd = `calc(${originalBodyPaddingInlineEnd || '0px'} + ${scrollbarWidth}px)`
+    }
+  }
+
+  scrollLockCount += 1
+}
+
+export function unlockBodyScroll() {
+  if (scrollLockCount === 0) {
+    return
+  }
+
+  scrollLockCount -= 1
+
+  if (scrollLockCount === 0) {
+    document.documentElement.style.overflow = originalDocumentOverflow
+    document.body.style.paddingInlineEnd = originalBodyPaddingInlineEnd
+  }
+}

--- a/tests/unit/prompt-scroll-lock.test.mjs
+++ b/tests/unit/prompt-scroll-lock.test.mjs
@@ -1,0 +1,32 @@
+import assert from 'node:assert/strict'
+import test from 'node:test'
+
+import {
+  lockBodyScroll,
+  unlockBodyScroll
+} from '../../src/renderer/components/FtPrompt/scrollLock.js'
+
+test('overlapping prompts restore document styles after the final unlock', () => {
+  globalThis.window = { innerWidth: 1200 }
+  globalThis.document = {
+    documentElement: {
+      clientWidth: 1184,
+      style: { overflow: 'auto' }
+    },
+    body: {
+      style: { paddingInlineEnd: '4px' }
+    }
+  }
+
+  lockBodyScroll()
+  lockBodyScroll()
+  unlockBodyScroll()
+
+  assert.equal(document.documentElement.style.overflow, 'hidden')
+  assert.equal(document.body.style.paddingInlineEnd, 'calc(4px + 16px)')
+
+  unlockBodyScroll()
+
+  assert.equal(document.documentElement.style.overflow, 'auto')
+  assert.equal(document.body.style.paddingInlineEnd, '4px')
+})

--- a/tests/unit/prompt-scroll-lock.test.mjs
+++ b/tests/unit/prompt-scroll-lock.test.mjs
@@ -7,6 +7,11 @@ import {
 } from '../../src/renderer/components/FtPrompt/scrollLock.js'
 
 test('overlapping prompts restore document styles after the final unlock', () => {
+  const hadWindow = Object.hasOwn(globalThis, 'window')
+  const hadDocument = Object.hasOwn(globalThis, 'document')
+  const previousWindow = globalThis.window
+  const previousDocument = globalThis.document
+
   globalThis.window = { innerWidth: 1200 }
   globalThis.document = {
     documentElement: {
@@ -18,15 +23,32 @@ test('overlapping prompts restore document styles after the final unlock', () =>
     }
   }
 
-  lockBodyScroll()
-  lockBodyScroll()
-  unlockBodyScroll()
+  try {
+    lockBodyScroll()
+    lockBodyScroll()
+    unlockBodyScroll()
 
-  assert.equal(document.documentElement.style.overflow, 'hidden')
-  assert.equal(document.body.style.paddingInlineEnd, 'calc(4px + 16px)')
+    assert.equal(document.documentElement.style.overflow, 'hidden')
+    assert.equal(document.body.style.paddingInlineEnd, 'calc(4px + 16px)')
 
-  unlockBodyScroll()
+    unlockBodyScroll()
 
-  assert.equal(document.documentElement.style.overflow, 'auto')
-  assert.equal(document.body.style.paddingInlineEnd, '4px')
+    assert.equal(document.documentElement.style.overflow, 'auto')
+    assert.equal(document.body.style.paddingInlineEnd, '4px')
+  } finally {
+    unlockBodyScroll()
+    unlockBodyScroll()
+
+    if (hadWindow) {
+      globalThis.window = previousWindow
+    } else {
+      delete globalThis.window
+    }
+
+    if (hadDocument) {
+      globalThis.document = previousDocument
+    } else {
+      delete globalThis.document
+    }
+  }
 })


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Make sure to follow the contributing guidelines. -->
<!-- Important note, we may remove your pull request if you do not use this provided PR template correctly. -->

## Pull Request Type
<!-- Please select what type of pull request this is: [x] -->
- [x] Bugfix
- [ ] Feature Implementation
- [ ] Documentation
- [ ] Other

## Related issue
<!-- Please link the issue your pull request is referring to. -->
<!-- If this pull request fully resolves the relevant issue, put "closes" before the issue number. -->
<!-- Example: "closes #123456". -->

## Description
<!-- Please write a clear and concise description of what the pull request does. -->

Modal scroll locking set `overflow: hidden` on the body. This made the body an overflow container, so sticky app chrome was treated as scrolled content and disappeared when a modal opened after the page had been scrolled.

Lock the root viewport instead, keeping the body and its sticky header in the same layout context. Update auto-grid scrollbar compensation to recognize the root lock. This fixes every modal built on `FtPrompt`, including the collaborators and download prompts.

## Screenshots <!-- If appropriate -->
<!-- Please add before and after screenshots if there is a visible change. -->

Not included; automated coverage verifies the sticky header position before and after opening the modal.

## Release note category
<!-- Select exactly one category. Every pull request must select one. -->
<!-- release-note-category:start -->
- [ ] Not noteworthy
- [ ] Highlights
- [ ] More improvements
- [x] Fixed bugs
<!-- release-note-category:end -->

## Release note
<!-- Required unless "Not noteworthy" is selected. -->
<!-- Write one concise, user-facing entry without a leading bullet. -->
<!-- release-note:start -->
Fixed the app header disappearing when opening a modal on a scrolled page.
<!-- release-note:end -->

## Release note images
<!-- Optional. Paste one or more Markdown images or HTML image tags here. -->
<!-- The release notes will use an HTML image tag and limit images taller than 300 pixels. -->
<!-- release-note-image:start -->

<!-- release-note-image:end -->

## Testing
<!-- How can reviewers verify that the PR produces correct results? -->
<!-- Please provide instructions so that others can ensure that your pull request would produce correct results. For examples see, https://github.com/FreeTubeApp/FreeTube/pull/5743, https://github.com/FreeTubeApp/FreeTube/pull/7349, https://github.com/FreeTubeApp/FreeTube/pull/5125, https://github.com/FreeTubeApp/FreeTube/pull/7338 -->

1. Open a page long enough to scroll, such as Subscriptions or a watch page.
2. Scroll until the top navigation is sticky.
3. Open any `FtPrompt` modal, such as Collaborators or Download.
4. Confirm the top navigation remains visible and the page cannot scroll behind the modal.
5. Close the modal and confirm normal page scrolling is restored.

Automated validation:

- `pnpm run test:e2e:pack`
- `xvfb-run -a -s "-screen 0 1920x1080x24" pnpm exec playwright test -c e2e/playwright.config.mjs --project=offline e2e/tests/offline/collaborators-modal-animation.spec.mjs`
- `pnpm run test:unit`
- `pnpm exec eslint src/renderer/components/FtPrompt/FtPrompt.vue src/renderer/components/FtAutoGrid/FtAutoGrid.vue e2e/tests/offline/collaborators-modal-animation.spec.mjs`

## Desktop
<!-- Please complete the following information-->
- **OS:** Arch Linux with KDE Plasma (Wayland)
- **OS Version:** Rolling release
- **OpenTubeX version:** development

## Additional context
<!-- Add any other context about the pull request here. -->

The regression test covers 100%, 125%, and 150% display scaling and verifies header positioning, scroll locking, and overflow restoration.
