### PR TITLE
fix(release): link issues and pull requests in notes

### DIFF
--- a/.github/workflows/create-draft-release.yml
+++ b/.github/workflows/create-draft-release.yml
@@ -25,6 +25,7 @@ jobs:
 
     permissions:
       contents: write
+      issues: read
       pull-requests: read
 
     steps:

--- a/_scripts/releaseNotes.mjs
+++ b/_scripts/releaseNotes.mjs
@@ -37,6 +37,9 @@ query($owner: String!, $repo: String!, $base: String!, $endCursor: String) {
     ) {
       nodes {
         body
+        closingIssuesReferences(first: 100) {
+          nodes { number }
+        }
         mergeCommit { oid }
         mergedAt
         number
@@ -402,7 +405,11 @@ export async function renderReleaseNotes(pullRequests, loadImage = downloadImage
 
     if (parsed.category === NOT_NOTEWORTHY_CATEGORY) { continue }
 
-    let releaseNote = `- ${indentContinuationLines(parsed.note)}`
+    const references = [
+      ...(pullRequest.closingIssuesReferences?.nodes ?? []).map((issue) => issue.number),
+      pullRequest.number,
+    ].map((number) => `#${number}`).join(', ')
+    let releaseNote = `- ${indentContinuationLines(parsed.note)} (${references})`
 
     for (const image of parsed.images) {
       try {

--- a/tests/unit/release-notes.test.mjs
+++ b/tests/unit/release-notes.test.mjs
@@ -110,6 +110,7 @@ test('paginated pull request results are flattened', () => {
           pullRequests: {
             nodes: [{
               body: 'First',
+              closingIssuesReferences: { nodes: [{ number: 10 }] },
               mergeCommit: { oid: 'first' },
               mergedAt: '2026-01-01T00:00:00Z',
               number: 1,
@@ -138,6 +139,7 @@ test('paginated pull request results are flattened', () => {
     },
   ]), [{
     body: 'First',
+    closingIssuesReferences: { nodes: [{ number: 10 }] },
     mergeCommit: { oid: 'first' },
     mergedAt: '2026-01-01T00:00:00Z',
     number: 1,
@@ -301,6 +303,9 @@ ${NOTE_MARKERS}
 ![Settings](https://github.com/user-attachments/assets/second)
 <!-- release-note-image:end -->
 `,
+      closingIssuesReferences: {
+        nodes: [{ number: 40 }, { number: 41 }],
+      },
       number: 42,
       title: 'Compact player',
     },
@@ -338,17 +343,17 @@ Fixed videos failing to load.
 
   assert.equal(result, `# Highlights
 
-- Adds a compact player.
+- Adds a compact player. (#40, #41, #42)
   <img src="https://github.com/user-attachments/assets/example" alt="Screenshot" height="300">
   <img src="https://github.com/user-attachments/assets/second" alt="Settings" height="300">
 
 ## More improvements
 
-- Adds keyboard shortcuts.
+- Adds keyboard shortcuts. (#43)
 
 ## Fixed bugs
 
-- Fixed videos failing to load.
+- Fixed videos failing to load. (#44)
 `)
 })
 
@@ -366,7 +371,7 @@ ${NOTE_MARKERS}
 
   assert.equal(result, `## Fixed bugs
 
-- Adds a compact player.
+- Adds a compact player. (#42)
 `)
 })
 


### PR DESCRIPTION
## Pull Request Type

- [x] Bugfix
- [ ] Feature Implementation
- [ ] Documentation
- [ ] Other

## Related issue

None.

## Description

Restore issue and pull request references in generated draft release notes. The release-note generator now fetches each PR's closing issues and appends those issue numbers followed by the PR number, matching the format used in previous releases.

The workflow also receives read access to issues so the closing references can be queried.

## Screenshots

Not applicable.

## Release note category

<!-- release-note-category:start -->
- [x] Not noteworthy
- [ ] Highlights
- [ ] More improvements
- [ ] Fixed bugs
<!-- release-note-category:end -->

## Release note

<!-- release-note:start -->

<!-- release-note:end -->

## Release note images

<!-- release-note-image:start -->

<!-- release-note-image:end -->

## Testing

- `node --test tests/unit/release-notes.test.mjs`
- `pnpm exec eslint --config eslint.config.mjs _scripts/releaseNotes.mjs .github/workflows/create-draft-release.yml`
- Verified PR #275 exposes closing issue #272 through GitHub's closing-issue metadata.

## Desktop

- **OS:** Arch Linux
- **OS Version:** Rolling release
- **OpenTubeX version:** 0.30.1

## Additional context

The generated suffix orders closing issues first and the implementing PR last, for example `(#272, #275)`.
