### PR TITLE
perf(subscriptions): keep the feed tab indicator smooth on large feeds

### DIFF
--- a/e2e/tests/offline/subscriptions-tab-indicator.spec.mjs
+++ b/e2e/tests/offline/subscriptions-tab-indicator.spec.mjs
@@ -1,0 +1,139 @@
+import { test, expect, goTo } from '../../helpers/app.mjs'
+
+const now = Date.now()
+const CHANNEL_ID = 'UCaaaaaaaaaaaaaaaaaaaaaa'
+
+function video (index, kind) {
+  return {
+    videoId: `${kind}${String(index).padStart(6, '0')}`,
+    title: `${kind} video ${String(index).padStart(3, '0')}`,
+    author: 'Channel A',
+    authorId: CHANNEL_ID,
+    published: now - index * 3600000,
+    viewCount: 1000,
+    lengthSeconds: 120,
+    liveNow: false,
+    isUpcoming: false,
+    type: 'video'
+  }
+}
+
+// Large feeds so that rendering a panel is expensive enough to stall the
+// indicator animation when both happen in the same frame
+const videos = Array.from({ length: 150 }, (_, index) => video(index, 'video'))
+const shorts = Array.from({ length: 150 }, (_, index) => ({
+  ...video(index, 'short'),
+  thumbnailUrl: `https://i.ytimg.com/vi/short${index}/hq720_2.jpg?sqp=selected&rs=signature`
+}))
+
+test.use({
+  seed: {
+    settings: {
+      fetchSubscriptionsAutomatically: false,
+      hideSubscriptionsVideos: false,
+      hideSubscriptionsShorts: false
+    },
+    profiles: [
+      {
+        _id: 'allChannels',
+        name: 'All Channels',
+        bgColor: '#000000',
+        textColor: '#FFFFFF',
+        subscriptions: [{ id: CHANNEL_ID, name: 'Channel A', thumbnail: '' }]
+      }
+    ],
+    subscriptionCache: [
+      {
+        _id: CHANNEL_ID,
+        videos,
+        videosTimestamp: new Date(now).toISOString(),
+        shorts,
+        shortsTimestamp: new Date(now).toISOString()
+      }
+    ]
+  }
+})
+
+test.describe('subscriptions feed tab indicator', () => {
+  test('only animates the transform, so it runs on the compositor', async ({ page }) => {
+    await goTo(page, 'subscriptions')
+
+    await expect(page.locator('.tabsIndicator')).toBeVisible()
+
+    // The initial placement is intentionally not animated
+    await page.locator('[data-subscription-feed-tab="shorts"]').click()
+
+    await expect(page.locator('.tabsIndicator')).toHaveCSS('transition-property', 'transform')
+  })
+
+  test('starts moving before the new feed is rendered', async ({ page }) => {
+    await goTo(page, 'subscriptions')
+
+    await expect(page.getByText('video video 000')).toBeVisible()
+    await expect(page.locator('.tabsIndicator')).toBeVisible()
+
+    // Record whether the indicator is repositioned before or after the panel
+    // with the new feed is put into the DOM
+    await page.evaluate(() => {
+      window.__mutations = []
+
+      const observer = new MutationObserver((mutations) => {
+        for (const mutation of mutations) {
+          if (mutation.type === 'attributes') {
+            if (mutation.target.classList.contains('tabsIndicator')) {
+              window.__mutations.push('indicator')
+            }
+          } else if ([...mutation.addedNodes, ...mutation.removedNodes].some((node) => {
+            return node.nodeType === Node.ELEMENT_NODE &&
+              (node.id === 'subscriptionsPanel' || node.classList.contains('ft-list-video'))
+          })) {
+            window.__mutations.push('panel')
+          }
+        }
+      })
+
+      observer.observe(document.querySelector('.subscriptionsPage'), {
+        subtree: true,
+        childList: true,
+        attributes: true,
+        attributeFilter: ['style']
+      })
+    })
+
+    await page.locator('[data-subscription-feed-tab="shorts"]').click()
+    await expect(page.getByText('short video 000')).toBeVisible()
+
+    const mutations = await page.evaluate(() => window.__mutations)
+
+    expect(mutations.indexOf('indicator')).toBeGreaterThanOrEqual(0)
+    expect(
+      mutations.indexOf('indicator'),
+      `mutation order: ${mutations.slice(0, 5).join(', ')}`
+    ).toBeLessThan(mutations.indexOf('panel'))
+  })
+
+  test('ends up aligned with the selected tab', async ({ page }) => {
+    await goTo(page, 'subscriptions')
+
+    await page.locator('[data-subscription-feed-tab="shorts"]').click()
+    await expect(page.locator('.tab.selectedTab')).toHaveText(/Shorts/)
+
+    // Wait out the 200ms transition
+    await page.waitForTimeout(400)
+
+    const { indicator, tab } = await page.evaluate(() => {
+      const toBox = (element) => {
+        const rect = element.getBoundingClientRect()
+        return { x: rect.x, width: rect.width, top: rect.top }
+      }
+
+      return {
+        indicator: toBox(document.querySelector('.tabsIndicator')),
+        tab: toBox(document.querySelector('[data-subscription-feed-tab="shorts"]'))
+      }
+    })
+
+    expect(Math.abs(indicator.x - tab.x)).toBeLessThan(1)
+    expect(Math.abs(indicator.width - tab.width)).toBeLessThan(1)
+  })
+})

--- a/e2e/tests/offline/subscriptions-tab-indicator.spec.mjs
+++ b/e2e/tests/offline/subscriptions-tab-indicator.spec.mjs
@@ -124,7 +124,7 @@ test.describe('subscriptions feed tab indicator', () => {
     const { indicator, tab } = await page.evaluate(() => {
       const toBox = (element) => {
         const rect = element.getBoundingClientRect()
-        return { x: rect.x, width: rect.width, top: rect.top }
+        return { x: rect.x, width: rect.width, top: rect.top, bottom: rect.bottom }
       }
 
       return {
@@ -135,5 +135,35 @@ test.describe('subscriptions feed tab indicator', () => {
 
     expect(Math.abs(indicator.x - tab.x)).toBeLessThan(1)
     expect(Math.abs(indicator.width - tab.width)).toBeLessThan(1)
+    expect(Math.abs(indicator.top - tab.bottom)).toBeLessThan(1)
+  })
+
+  test('keeps the last clicked tab when switching back and forth quickly', async ({ page }) => {
+    await goTo(page, 'subscriptions')
+
+    await expect(page.getByText('video video 000')).toBeVisible()
+
+    // Both clicks happen in the same task, so the second one lands while the
+    // first tab change is still deferred
+    await page.evaluate(() => {
+      document.querySelector('[data-subscription-feed-tab="shorts"]').click()
+      document.querySelector('[data-subscription-feed-tab="videos"]').click()
+    })
+
+    await page.waitForTimeout(400)
+
+    await expect(page.locator('.tab.selectedTab')).toHaveText(/Videos/)
+    await expect(page.getByText('video video 000')).toBeVisible()
+
+    const { indicator, tab } = await page.evaluate(() => {
+      const toX = (element) => element.getBoundingClientRect().x
+
+      return {
+        indicator: toX(document.querySelector('.tabsIndicator')),
+        tab: toX(document.querySelector('[data-subscription-feed-tab="videos"]'))
+      }
+    })
+
+    expect(Math.abs(indicator - tab)).toBeLessThan(1)
   })
 })

--- a/src/renderer/views/Subscriptions/Subscriptions.css
+++ b/src/renderer/views/Subscriptions/Subscriptions.css
@@ -103,12 +103,24 @@
 
 .tabsIndicator {
   position: absolute;
+
+  /* stylelint-disable-next-line liberty/use-logical-spec -- matches the physical transform set inline */
+  top: 0;
+
+  /* stylelint-disable-next-line liberty/use-logical-spec -- matches the physical transform set inline */
+  left: 0;
   block-size: 3px;
+
+  /* scaled up to the tab width via the inline transform */
+  inline-size: 1px;
   background-color: var(--primary-color);
   pointer-events: none;
+  transform-origin: left top;
 
-  /* stylelint-disable-next-line liberty/use-logical-spec -- matches the physical offset measurements set inline */
-  transition: left 0.2s ease, top 0.2s ease, width 0.2s ease;
+  /* animating only the transform keeps this on the compositor, so it stays
+     smooth while the main thread renders a large feed */
+  transition: transform 0.2s ease;
+  will-change: transform;
 }
 
 .tab {

--- a/src/renderer/views/Subscriptions/Subscriptions.vue
+++ b/src/renderer/views/Subscriptions/Subscriptions.vue
@@ -406,6 +406,8 @@ function nextAnimationFrame() {
 
 let isMounted = false
 let removeFeedReloadRequestListener = null
+/** @type {number | null} */
+let pendingTabChangeFrame = null
 
 onMounted(() => {
   isMounted = true
@@ -418,6 +420,11 @@ onMounted(() => {
 onBeforeUnmount(() => {
   isMounted = false
   removeFeedReloadRequestListener?.()
+
+  if (pendingTabChangeFrame !== null) {
+    window.cancelAnimationFrame(pendingTabChangeFrame)
+    pendingTabChangeFrame = null
+  }
 })
 
 watch(currentTab, async (value, previousValue) => {
@@ -496,12 +503,30 @@ function changeTab(tab) {
     return
   }
 
-  if (visibleTabs.value.includes(tab)) {
-    currentTab.value = tab
-  } else {
-    // First visible tab or no tab
-    currentTab.value = visibleTabs.value.length > 0 ? visibleTabs.value[0] : null
+  // First visible tab or no tab as fallback
+  const target = visibleTabs.value.includes(tab)
+    ? tab
+    : (visibleTabs.value.length > 0 ? visibleTabs.value[0] : null)
+
+  if (pendingTabChangeFrame !== null) {
+    window.cancelAnimationFrame(pendingTabChangeFrame)
+    pendingTabChangeFrame = null
   }
+
+  // Move the indicator first and let it paint before the panel is swapped,
+  // otherwise rendering a feed with a lot of videos in the same frame delays
+  // the start of the animation and it appears to jump
+  if (target !== null && moveTabsIndicatorTo(target)) {
+    pendingTabChangeFrame = window.requestAnimationFrame(() => {
+      pendingTabChangeFrame = window.requestAnimationFrame(() => {
+        pendingTabChangeFrame = null
+        currentTab.value = target
+      })
+    })
+    return
+  }
+
+  currentTab.value = target
 }
 
 const videosTab = useTemplateRef('videosTab')
@@ -703,6 +728,42 @@ let tabsResizeObserver = null
 // otherwise it visibly flies in from the stale position.
 let tabsIndicatorWasHidden = true
 
+const tabElementRefs = {
+  videos: videosTab,
+  shorts: shortsTab,
+  live: liveTab,
+  community: communityTab,
+  new: newTab
+}
+
+/**
+ * @param {HTMLElement} tabElement
+ * @returns {boolean} whether the indicator was positioned on the tab
+ */
+function placeTabsIndicator(tabElement) {
+  if (tabElement.getClientRects().length === 0) {
+    tabsIndicatorWasHidden = true
+    return false
+  }
+
+  // Physical values to match the physical offset measurements (RTL-safe).
+  // The indicator sits just below the tab, like the old selectedTab border
+  // (which extended past the box through its -3px margin).
+  // Only the transform is animated, so the movement runs on the compositor and
+  // doesn't stutter while the main thread renders a large feed.
+  const style = {
+    transform: `translate(${tabElement.offsetLeft}px, ${tabElement.offsetTop + tabElement.offsetHeight}px) scaleX(${tabElement.offsetWidth})`
+  }
+
+  if (tabsIndicatorWasHidden) {
+    style.transition = 'none'
+    tabsIndicatorWasHidden = false
+  }
+
+  tabsIndicatorStyle.value = style
+  return true
+}
+
 function updateTabsIndicator() {
   const container = tabsContainerRef.value?.$el
   const selected = container?.querySelector('.tab.selectedTab')
@@ -713,26 +774,23 @@ function updateTabsIndicator() {
     return
   }
 
-  if (selected.getClientRects().length === 0) {
-    tabsIndicatorWasHidden = true
-    return
+  placeTabsIndicator(selected)
+}
+
+/**
+ * Moves the indicator onto a tab before it becomes the selected one, so the
+ * animation can start before the new panel is rendered.
+ * @param {'videos' | 'shorts' | 'live' | 'community' | 'new'} tab
+ * @returns {boolean} whether the indicator was moved
+ */
+function moveTabsIndicatorTo(tab) {
+  if (!isMounted || tabsIndicatorStyle.value === null || tabsIndicatorWasHidden) {
+    return false
   }
 
-  // Physical values to match the physical offset measurements (RTL-safe).
-  // The indicator sits just below the tab, like the old selectedTab border
-  // (which extended past the box through its -3px margin).
-  const style = {
-    left: `${selected.offsetLeft}px`,
-    top: `${selected.offsetTop + selected.offsetHeight}px`,
-    width: `${selected.offsetWidth}px`
-  }
+  const tabElement = tabElementRefs[tab]?.value
 
-  if (tabsIndicatorWasHidden) {
-    style.transition = 'none'
-    tabsIndicatorWasHidden = false
-  }
-
-  tabsIndicatorStyle.value = style
+  return tabElement instanceof HTMLElement && placeTabsIndicator(tabElement)
 }
 
 watch([currentTab, visibleTabs, refreshingFeedTab], () => nextTick(updateTabsIndicator))

--- a/src/renderer/views/Subscriptions/Subscriptions.vue
+++ b/src/renderer/views/Subscriptions/Subscriptions.vue
@@ -499,7 +499,21 @@ if (visibleTabs.value.length === 0) {
  * @param {'videos' | 'shorts' | 'live' | 'community' | 'new'} tab
  */
 function changeTab(tab) {
+  // A pending change from a previous click is always dropped, its indicator
+  // placement included, so the last clicked tab wins
+  const hadPendingChange = pendingTabChangeFrame !== null
+
+  if (hadPendingChange) {
+    window.cancelAnimationFrame(pendingTabChangeFrame)
+    pendingTabChangeFrame = null
+  }
+
   if (tab === currentTab.value) {
+    if (hadPendingChange) {
+      // Put the indicator back onto the tab that stays selected
+      updateTabsIndicator()
+    }
+
     return
   }
 
@@ -507,11 +521,6 @@ function changeTab(tab) {
   const target = visibleTabs.value.includes(tab)
     ? tab
     : (visibleTabs.value.length > 0 ? visibleTabs.value[0] : null)
-
-  if (pendingTabChangeFrame !== null) {
-    window.cancelAnimationFrame(pendingTabChangeFrame)
-    pendingTabChangeFrame = null
-  }
 
   // Move the indicator first and let it paint before the panel is swapped,
   // otherwise rendering a feed with a lot of videos in the same frame delays
@@ -765,6 +774,13 @@ function placeTabsIndicator(tabElement) {
 }
 
 function updateTabsIndicator() {
+  // While a tab change is pending the indicator already sits on the tab that is
+  // about to be selected, so re-measuring the still selected one (e.g. from the
+  // ResizeObserver when a refresh loader appears) would move it back
+  if (pendingTabChangeFrame !== null) {
+    return
+  }
+
   const container = tabsContainerRef.value?.$el
   const selected = container?.querySelector('.tab.selectedTab')
 


### PR DESCRIPTION
## Pull Request Type
- [ ] Bugfix
- [ ] Feature Implementation
- [ ] Documentation
- [x] Other

## Related issue
<!-- none -->

## Description
The sliding indicator under the subscription feed tabs stuttered when the feeds contained a lot of videos. Two reasons:

1. It animated `left`/`top`/`width`, which forces a layout on the main thread every frame — the same thread that is busy mounting hundreds of video cards during the tab switch.
2. It was repositioned *after* the panel swap (in the `nextTick` watcher), so the animation could only start once the new feed had been laid out, making it appear to jump.

Now it animates a single `transform: translate(...) scaleX(...)` on a 1px wide bar, so the transition is driven by the compositor and keeps running while the main thread is busy, and `changeTab` moves the indicator first, deferring the actual tab change by two animation frames so the move gets painted before the expensive render starts.

## Screenshots
<!-- no visual change, only the smoothness of the existing animation -->

## Release note category
<!-- release-note-category:start -->
- [ ] Not noteworthy
- [ ] Highlights
- [ ] More improvements
- [x] Fixed bugs
<!-- release-note-category:end -->

## Release note
<!-- release-note:start -->
The animation of the subscription feed tab indicator no longer stutters when the feeds contain a lot of videos
<!-- release-note:end -->

## Release note images
<!-- release-note-image:start -->

<!-- release-note-image:end -->

## Testing
Automated: `e2e/tests/offline/subscriptions-tab-indicator.spec.mjs` (new, seeds 150 videos + 150 shorts) checks that

- only `transform` is transitioned,
- the indicator is repositioned *before* the new panel enters the DOM (via a `MutationObserver`),
- the indicator ends up aligned with the selected tab (guards the scale-based sizing).

The first two fail without the change. `pnpm exec playwright test -c e2e/playwright.config.mjs --project=offline subscriptions tabs.spec navigation.spec` passes.

Manually: subscribe to enough channels that a feed has a few hundred entries, then switch between the feed tabs — the indicator should slide smoothly instead of freezing/jumping. Also worth checking with an RTL locale and with only a single visible feed tab.

## Desktop
- **OS:** Arch Linux
- **OS Version:** rolling (KDE Plasma 6, Wayland)
- **OpenTubeX version:** 0.30.1

## Additional context
The indicator is now a 1px wide bar scaled horizontally via `scaleX`, with `transform-origin: left top` and physical `top`/`left: 0`, matching the physical offset measurements that were already used for RTL safety.
