### PR TITLE
fix(release): create draft releases atomically

### DIFF
--- a/.github/workflows/create-draft-release.yml
+++ b/.github/workflows/create-draft-release.yml
@@ -55,12 +55,19 @@ jobs:
       run: |
         set -euo pipefail
 
-        release_url="$(gh release create "$TAG" \
-          --draft \
-          --target "$TARGET_SHA" \
-          --title "OpenTubeX ${TAG#v}" \
-          --notes-file release-notes.md)"
-        release_id="$(gh api "repos/${GITHUB_REPOSITORY}/releases/tags/${TAG}" --jq .id)"
+        release_title="$TAG"
+        if [[ "$release_title" == *-beta ]]; then
+          release_title="${release_title%-beta} Beta"
+        fi
+
+        release="$(gh api --method POST "repos/${GITHUB_REPOSITORY}/releases" \
+          -f tag_name="$TAG" \
+          -f target_commitish="$TARGET_SHA" \
+          -f name="$release_title" \
+          -F draft=true \
+          -F body=@release-notes.md)"
+        release_id="$(jq --raw-output .id <<< "$release")"
+        release_url="$(jq --raw-output .html_url <<< "$release")"
 
         {
           echo "## Draft release created"


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Make sure to follow the contributing guidelines. -->
<!-- Important note, we may remove your pull request if you do not use this provided PR template correctly. -->

## Pull Request Type
<!-- Please select what type of pull request this is: [x] -->
- [x] Bugfix
- [ ] Feature Implementation
- [ ] Documentation
- [ ] Other

## Related issue
<!-- Please link the issue your pull request is referring to. -->
<!-- If this pull request fully resolves the relevant issue, put "closes" before the issue number. -->
<!-- Example: "closes #123456". -->

None.

## Description
<!-- Please write a clear and concise description of what the pull request does. -->

Creates draft releases through the GitHub API and reads the release ID and URL directly from the creation response. This avoids the immediate follow-up tag lookup that returned HTTP 404 after the draft had already been created.

Release titles now follow the existing naming convention (`v0.30.1 Beta`) instead of adding an `OpenTubeX` prefix.

## Screenshots <!-- If appropriate -->
<!-- Please add before and after screenshots if there is a visible change. -->

Not applicable.

## Release note category
<!-- Select exactly one category. Every pull request must select one. -->
<!-- release-note-category:start -->
- [x] Not noteworthy
- [ ] Highlights
- [ ] More improvements
- [ ] Fixed bugs
<!-- release-note-category:end -->

## Release note
<!-- Required unless "Not noteworthy" is selected. -->
<!-- Write one concise, user-facing entry without a leading bullet. -->
<!-- release-note:start -->

<!-- release-note:end -->

## Release note images
<!-- Optional. Paste one or more Markdown images or HTML image tags here. -->
<!-- The release notes will use an HTML image tag and limit images taller than 300 pixels. -->
<!-- release-note-image:start -->

<!-- release-note-image:end -->

## Testing
<!-- How can reviewers verify that the PR produces correct results? -->
<!-- Please provide instructions so that others can ensure that your pull request would produce correct results. For examples see, https://github.com/FreeTubeApp/FreeTube/pull/5743, https://github.com/FreeTubeApp/FreeTube/pull/7349, https://github.com/FreeTubeApp/FreeTube/pull/5125, https://github.com/FreeTubeApp/FreeTube/pull/7338 -->

- Run ESLint against `.github/workflows/create-draft-release.yml`.
- Parse the workflow with `js-yaml`.
- Run `bash -n` against the changed shell block.
- Run `git diff --check`.

## Desktop
<!-- Please complete the following information-->
- **OS:** Arch Linux
- **OS Version:** Rolling release
- **OpenTubeX version:** development

## Additional context
<!-- Add any other context about the pull request here. -->

Failed workflow run: https://github.com/OpenTubeX/OpenTubeX/actions/runs/30537279340/job/90853474630

The failed run still created draft release `v0.30.1-beta`; its release ID is `362369725`.