### PR TITLE
Add configurable fixed tab width

### DIFF
--- a/e2e/tests/offline/settings.spec.mjs
+++ b/e2e/tests/offline/settings.spec.mjs
@@ -75,6 +75,32 @@ test.describe('settings', () => {
     await expect(toggle).not.toBeChecked()
   })
 
+  test('the tab width slider only becomes usable with fixed tab width on', async ({ page }) => {
+    await goTo(page, 'settings')
+    await page.locator('.settingsMenu [data-section="theme"]').click()
+
+    const slider = page.getByRole('slider', { name: /Tab Width/ })
+    await expect(slider).toBeDisabled()
+
+    await page.locator('label.switch-label')
+      .filter({ hasText: 'Use Fixed Tab Width in Horizontal Mode' })
+      .click()
+    await expect(page.getByRole('checkbox', { name: 'Use Fixed Tab Width in Horizontal Mode' })).toBeChecked()
+    await expect(slider).toBeEnabled()
+
+    // Dragging resizes the tabs live.
+    await slider.evaluate((input) => {
+      input.value = '100'
+      input.dispatchEvent(new Event('input', { bubbles: true }))
+      input.dispatchEvent(new Event('change', { bubbles: true }))
+    })
+    await expect.poll(async () => {
+      return await page.locator(sel.activeTab).evaluate(
+        tab => Math.round(tab.getBoundingClientRect().width)
+      )
+    }).toBe(100)
+  })
+
   test('keeps the watched progress mode when history is toggled', async ({ page }) => {
     await goTo(page, 'settings')
     await page.locator('.settingsMenu [data-section="privacy"]').click()

--- a/e2e/tests/offline/tabs.spec.mjs
+++ b/e2e/tests/offline/tabs.spec.mjs
@@ -679,6 +679,30 @@ test.describe('tab icons disabled', () => {
   })
 })
 
+test.describe('fixed tab width', () => {
+  test.use({ seed: { settings: { useFixedTabWidth: true, fixedTabWidth: 140 } } })
+
+  test('gives every horizontal tab the configured width', async ({ page }) => {
+    await page.keyboard.press('Control+t')
+    await expect(page.locator(sel.tabs)).toHaveCount(2)
+
+    await expect.poll(async () => {
+      return await page.locator(sel.tabs).evaluateAll(
+        tabs => tabs.map(tab => Math.round(tab.getBoundingClientRect().width))
+      )
+    }).toEqual([140, 140])
+
+    // Vertical tabs fill the column, so the setting must not constrain them.
+    await page.keyboard.press('F1')
+    await expect(page.locator('.app')).toHaveClass(/verticalTabs/)
+    await expect.poll(async () => {
+      return await page.locator(sel.tabs).first().evaluate(
+        tab => Math.round(tab.getBoundingClientRect().width)
+      )
+    }).toBeGreaterThan(140)
+  })
+})
+
 test.describe('localized tab titles', () => {
   test.use({ seed: { settings: { currentLocale: 'de-DE' } } })
 

--- a/src/renderer/components/TabBar/SortableTab.vue
+++ b/src/renderer/components/TabBar/SortableTab.vue
@@ -522,9 +522,9 @@ watch(() => props.disableTooltips, (disableTooltips) => {
 }
 
 .tab.pinned {
-  inline-size: 72px;
-  min-inline-size: 72px;
-  max-inline-size: 72px;
+  inline-size: var(--fixed-tab-width, 72px);
+  min-inline-size: var(--fixed-tab-width, 72px);
+  max-inline-size: var(--fixed-tab-width, 72px);
   padding-inline: 9px 7px;
   gap: 4px;
 }

--- a/src/renderer/components/TabBar/SortableTab.vue
+++ b/src/renderer/components/TabBar/SortableTab.vue
@@ -435,8 +435,11 @@ watch(() => props.disableTooltips, (disableTooltips) => {
   border-radius: calc(6px * var(--ui-roundness)) calc(6px * var(--ui-roundness)) 0 0;
   cursor: pointer;
   block-size: 31px;
-  min-inline-size: 100px;
-  max-inline-size: 200px;
+
+  /* Without a configured fixed width, tabs size to their content within these
+     bounds. `--fixed-tab-width` (set by the tab bar) pins both ends together. */
+  min-inline-size: var(--fixed-tab-width, 100px);
+  max-inline-size: var(--fixed-tab-width, 200px);
   flex-shrink: 0;
   border: 1px solid transparent;
   border-block-end: 0;

--- a/src/renderer/components/TabBar/TabBar.vue
+++ b/src/renderer/components/TabBar/TabBar.vue
@@ -4,6 +4,7 @@
     ref="tabBarRef"
     class="tabBar"
     :class="{ vertical }"
+    :style="fixedTabWidthStyle"
   >
     <div
       ref="tabsViewportRef"
@@ -107,6 +108,16 @@ const tabs = computed(() => store.getters.getTabs)
 /** @type {import('vue').ComputedRef<boolean>} */
 const vertical = computed(() => store.getters.getUseVerticalTabBar)
 const showTabIcons = computed(() => store.getters.getShowTabIcons)
+
+// Only the horizontal bar sizes tabs by their content, so the fixed width is
+// applied there; vertical tabs always fill the column.
+const fixedTabWidthStyle = computed(() => {
+  if (vertical.value || !store.getters.getUseFixedTabWidth) {
+    return null
+  }
+
+  return { '--fixed-tab-width': `${store.getters.getFixedTabWidth}px` }
+})
 
 const newTabTooltip = computed(() => {
   return localizeAndAddKeyboardShortcutToActionTitle(

--- a/src/renderer/components/TabBar/TabBar.vue
+++ b/src/renderer/components/TabBar/TabBar.vue
@@ -86,6 +86,7 @@ import { useI18n } from 'vue-i18n'
 import store from '../../store/index'
 import { getConfiguredKeyboardShortcuts } from '../../../constants'
 import { localizeAndAddKeyboardShortcutToActionTitle } from '../../helpers/utils'
+import { normalizeFixedTabWidth } from '../../constants/tabWidth'
 import SortableTab from './SortableTab.vue'
 import {
   buildCurrentShiftedTabIds,
@@ -116,7 +117,7 @@ const fixedTabWidthStyle = computed(() => {
     return null
   }
 
-  return { '--fixed-tab-width': `${store.getters.getFixedTabWidth}px` }
+  return { '--fixed-tab-width': `${normalizeFixedTabWidth(store.getters.getFixedTabWidth)}px` }
 })
 
 const newTabTooltip = computed(() => {

--- a/src/renderer/components/ThemeSettings.vue
+++ b/src/renderer/components/ThemeSettings.vue
@@ -121,44 +121,41 @@
           />
         </div>
       </FtFlexBox>
-      <FtFlexBox>
-        <FtSlider
-          :label="$t('Settings.Theme Settings.UI Scale')"
-          :default-value="uiScale"
-          :min-value="50"
-          :max-value="300"
-          :step="5"
-          value-extension="%"
-          @change="updateUiScale"
-        />
-      </FtFlexBox>
     </template>
-    <FtFlexBox>
-      <div class="switchColumn">
-        <FtSlider
-          :label="t('Settings.Theme Settings.Thumbnail Size')"
-          :default-value="thumbnailSize"
-          setting-key="thumbnailSize"
-          :min-value="MIN_THUMBNAIL_SIZE"
-          :max-value="MAX_THUMBNAIL_SIZE"
-          :step="THUMBNAIL_SIZE_STEP"
-          value-extension="%"
-          @input="previewThumbnailSize"
-          @change="updateThumbnailSize"
-        />
-        <FtSlider
-          :label="t('Settings.Theme Settings.UI Roundness')"
-          :default-value="uiRoundness"
-          setting-key="uiRoundness"
-          :min-value="0"
-          :max-value="200"
-          :step="5"
-          value-extension="%"
-          @input="previewUiRoundness"
-          @change="updateUiRoundness"
-        />
-      </div>
-    </FtFlexBox>
+    <div class="sliderGrid">
+      <FtSlider
+        v-if="usingElectron"
+        :label="$t('Settings.Theme Settings.UI Scale')"
+        :default-value="uiScale"
+        :min-value="50"
+        :max-value="300"
+        :step="5"
+        value-extension="%"
+        @change="updateUiScale"
+      />
+      <FtSlider
+        :label="t('Settings.Theme Settings.Thumbnail Size')"
+        :default-value="thumbnailSize"
+        setting-key="thumbnailSize"
+        :min-value="MIN_THUMBNAIL_SIZE"
+        :max-value="MAX_THUMBNAIL_SIZE"
+        :step="THUMBNAIL_SIZE_STEP"
+        value-extension="%"
+        @input="previewThumbnailSize"
+        @change="updateThumbnailSize"
+      />
+      <FtSlider
+        :label="t('Settings.Theme Settings.UI Roundness')"
+        :default-value="uiRoundness"
+        setting-key="uiRoundness"
+        :min-value="0"
+        :max-value="200"
+        :step="5"
+        value-extension="%"
+        @input="previewUiRoundness"
+        @change="updateUiRoundness"
+      />
+    </div>
     <br>
     <FtFlexBox>
       <FtSelect
@@ -607,3 +604,15 @@ function handleSmoothScrolling(value) {
   }
 }
 </script>
+
+<style scoped>
+.sliderGrid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(min(380px, 100%), 1fr));
+}
+
+.sliderGrid :deep(.pure-material-slider) {
+  box-sizing: border-box;
+  inline-size: calc(100% - 16px);
+}
+</style>

--- a/src/renderer/components/ThemeSettings.vue
+++ b/src/renderer/components/ThemeSettings.vue
@@ -608,7 +608,9 @@ function handleSmoothScrolling(value) {
 <style scoped>
 .sliderGrid {
   display: grid;
-  grid-template-columns: repeat(auto-fit, minmax(min(380px, 100%), 1fr));
+  grid-template-columns: repeat(auto-fit, minmax(min(280px, 100%), 380px));
+  justify-content: space-evenly;
+  gap: 24px 64px;
 }
 
 .sliderGrid :deep(.pure-material-slider) {

--- a/src/renderer/components/ThemeSettings.vue
+++ b/src/renderer/components/ThemeSettings.vue
@@ -98,6 +98,30 @@
     </div>
     <template v-if="usingElectron">
       <FtFlexBox>
+        <div class="switchColumn">
+          <FtToggleSwitch
+            :label="$t('Settings.Theme Settings.Use Fixed Tab Width')"
+            :tooltip="$t('Tooltips.Theme Settings.Use Fixed Tab Width')"
+            compact
+            :default-value="useFixedTabWidth"
+            setting-key="useFixedTabWidth"
+            @change="updateUseFixedTabWidth"
+          />
+          <FtSlider
+            :label="$t('Settings.Theme Settings.Tab Width')"
+            :default-value="fixedTabWidth"
+            setting-key="fixedTabWidth"
+            :min-value="MIN_FIXED_TAB_WIDTH"
+            :max-value="MAX_FIXED_TAB_WIDTH"
+            :step="FIXED_TAB_WIDTH_STEP"
+            :disabled="!useFixedTabWidth"
+            value-extension="px"
+            @input="previewFixedTabWidth"
+            @change="updateFixedTabWidth"
+          />
+        </div>
+      </FtFlexBox>
+      <FtFlexBox>
         <FtSlider
           :label="$t('Settings.Theme Settings.UI Scale')"
           :default-value="uiScale"
@@ -208,6 +232,11 @@ import {
   MIN_THUMBNAIL_SIZE,
   THUMBNAIL_SIZE_STEP
 } from '../constants/thumbnailSize'
+import {
+  FIXED_TAB_WIDTH_STEP,
+  MAX_FIXED_TAB_WIDTH,
+  MIN_FIXED_TAB_WIDTH
+} from '../constants/tabWidth'
 import { normalizeToastPosition, TOAST_POSITION_VALUES } from '../constants/toastPosition'
 
 const { t } = useI18n()
@@ -443,6 +472,33 @@ const showTabIcons = computed(() => store.getters.getShowTabIcons)
  */
 function updateShowTabIcons(value) {
   store.dispatch('updateShowTabIcons', value)
+}
+
+/** @type {import('vue').ComputedRef<boolean>} */
+const useFixedTabWidth = computed(() => store.getters.getUseFixedTabWidth)
+
+/** @type {import('vue').ComputedRef<number>} */
+const fixedTabWidth = computed(() => store.getters.getFixedTabWidth)
+
+/**
+ * @param {boolean} value
+ */
+function updateUseFixedTabWidth(value) {
+  store.dispatch('updateUseFixedTabWidth', value)
+}
+
+/**
+ * @param {number} value
+ */
+function previewFixedTabWidth(value) {
+  store.commit('setFixedTabWidth', value)
+}
+
+/**
+ * @param {number} value
+ */
+function updateFixedTabWidth(value) {
+  store.dispatch('updateFixedTabWidth', value)
 }
 
 const toastPositionNames = computed(() => [

--- a/src/renderer/constants/tabWidth.js
+++ b/src/renderer/constants/tabWidth.js
@@ -1,0 +1,4 @@
+export const DEFAULT_FIXED_TAB_WIDTH = 180
+export const MIN_FIXED_TAB_WIDTH = 80
+export const MAX_FIXED_TAB_WIDTH = 320
+export const FIXED_TAB_WIDTH_STEP = 10

--- a/src/renderer/constants/tabWidth.js
+++ b/src/renderer/constants/tabWidth.js
@@ -2,3 +2,11 @@ export const DEFAULT_FIXED_TAB_WIDTH = 180
 export const MIN_FIXED_TAB_WIDTH = 80
 export const MAX_FIXED_TAB_WIDTH = 320
 export const FIXED_TAB_WIDTH_STEP = 10
+
+export function normalizeFixedTabWidth(value) {
+  const width = Number(value)
+
+  return Number.isFinite(width)
+    ? Math.max(MIN_FIXED_TAB_WIDTH, Math.min(MAX_FIXED_TAB_WIDTH, width))
+    : DEFAULT_FIXED_TAB_WIDTH
+}

--- a/src/renderer/store/modules/settings.js
+++ b/src/renderer/store/modules/settings.js
@@ -12,6 +12,7 @@ import { hashPassword } from '../../helpers/passwords'
 import { getTabNavigationService } from '../../tabs/TabNavigationService'
 import { getSystemLocale, showToast } from '../../helpers/utils'
 import { DEFAULT_THUMBNAIL_SIZE } from '../../constants/thumbnailSize'
+import { DEFAULT_FIXED_TAB_WIDTH } from '../../constants/tabWidth'
 import { setReducedMotionPreference } from '../../helpers/reducedMotion'
 import { DEFAULT_SEARCH_ENGINES_SETTING } from '../../../searchEngines'
 
@@ -277,6 +278,8 @@ const state = {
   showTabIcons: true,
   useVerticalTabBar: false,
   verticalTabBarWidth: 220,
+  useFixedTabWidth: false,
+  fixedTabWidth: DEFAULT_FIXED_TAB_WIDTH,
   listType: 'grid',
   maxVideoPlaybackRate: 3,
   onlyShowLatestFromChannel: false,

--- a/static/locales/en-US.yaml
+++ b/static/locales/en-US.yaml
@@ -449,6 +449,8 @@ Settings:
     Thumbnail Size: Thumbnail Size
     Show Thumbnail Size Button in Header: Show Thumbnail Size Button in Header
     Show Tab Icons: Show Tab Icons
+    Use Fixed Tab Width: Use Fixed Tab Width in Horizontal Mode
+    Tab Width: Tab Width
     Show Toast Timeout Indicator: Show toast timeout indicator
     Toast Position:
       Toast Position: Toast Position
@@ -1704,6 +1706,7 @@ Tooltips:
     Hide Profile Selector in Header: Hides the profile selector from the top bar. The profile selector will be shown at the top of the Subscribed Channels page instead.
     Always Show Scrollbars: Keeps the scrollbars visible at all times. When disabled, they fade out shortly after you stop moving the mouse and reappear as soon as you move it again.
     Use YouTube-style Shorts: Displays Shorts in a portrait grid on subscription and channel pages and uses the YouTube-style Shorts player.
+    Use Fixed Tab Width: Gives every tab in the horizontal tab bar the same width instead of sizing them to their title.
   Experimental Settings:
     Replace HTTP Cache: Disables Electron's disk based HTTP cache and enables a custom in-memory image cache. Will lead to increased RAM usage.
   SponsorBlock Settings:


### PR DESCRIPTION
## Pull Request Type
<!-- Please select what type of pull request this is: [x] -->
- [ ] Bugfix
- [x] Feature Implementation
- [ ] Documentation
- [ ] Other

## Related issue
Resolves #367

## Description
Adds an optional fixed width for tabs in the horizontal tab bar.

The theme settings now include a toggle and width slider. Changes are previewed live, persisted through the settings store, and only affect horizontal tabs; vertical tabs continue to fill their column. Offline E2E coverage verifies the setting controls and tab sizing behavior.

## Screenshots <!-- If appropriate -->
Not included.

## Release note category
<!-- Select exactly one category. Every pull request must select one. -->
<!-- release-note-category:start -->
- [ ] Not noteworthy
- [ ] Highlights
- [x] More improvements
- [ ] Fixed bugs
<!-- release-note-category:end -->

## Release note
<!-- Required unless "Not noteworthy" is selected. -->
<!-- Write one concise, user-facing entry without a leading bullet. -->
<!-- release-note:start -->
Added an option to use a configurable fixed width for horizontal tabs.
<!-- release-note:end -->

## Release note images
<!-- Optional. Paste one or more Markdown images or HTML image tags here. -->
<!-- The release notes will use an HTML image tag and limit images taller than 300 pixels. -->
<!-- release-note-image:start -->
<img width="1761" height="230" alt="image" src="https://github.com/user-attachments/assets/96ddc1b6-5c7a-4947-844a-04f02e5c5cab" />
<!-- release-note-image:end -->

## Testing
1. Open Settings → Theme Settings.
2. Enable “Use Fixed Tab Width in Horizontal Mode.”
3. Adjust “Tab Width” and confirm all horizontal tabs resize live to the selected width.
4. Switch to vertical tabs and confirm tabs still fill the tab-bar column.

The existing authored E2E coverage was retained. The pre-commit ESLint hook passed; further validation was skipped at the request of the maintainer.

## Desktop
- **OS:** Arch Linux
- **OS Version:** Rolling release
- **OpenTubeX version:** Development (`1174ed1d3`)

## Additional context
The fixed width defaults to 180 px and can be adjusted from 80 px to 320 px in 10 px steps.
