### PR TITLE
fix(ci): accept Greptile confidence for auto-merge

### DIFF
--- a/.github/workflows/autoMerge.yml
+++ b/.github/workflows/autoMerge.yml
@@ -29,7 +29,13 @@ jobs:
     name: authorize-auto-merge-${{ github.event.pull_request.number }}
     if: |
       github.event_name == 'pull_request_review' &&
-      github.event.review.state == 'approved' &&
+      (
+        github.event.review.state == 'approved' ||
+        (
+          github.event.review.state == 'commented' &&
+          github.event.review.user.login == 'greptile-apps[bot]'
+        )
+      ) &&
       github.event.pull_request.state == 'open' &&
       !github.event.pull_request.draft &&
       (github.event.pull_request.base.ref == 'development' || startsWith(github.event.pull_request.base.ref, 'RC'))
@@ -78,6 +84,10 @@ jobs:
 
           if [[ "$review_state" == "APPROVED" ]]; then
             return 0
+          fi
+
+          if [[ "$review_state" == "CHANGES_REQUESTED" ]]; then
+            return 1
           fi
 
           if [[ "$bot" == "greptile-apps[bot]" ]]; then

--- a/.github/workflows/autoMerge.yml
+++ b/.github/workflows/autoMerge.yml
@@ -71,6 +71,25 @@ jobs:
             <<< "$reviews"
         }
 
+        bot_approved() {
+          local bot="$1"
+          local review_state
+          review_state="$(latest_decisive_review "$bot" | jq -r '.state // empty')"
+
+          if [[ "$review_state" == "APPROVED" ]]; then
+            return 0
+          fi
+
+          if [[ "$bot" == "greptile-apps[bot]" ]]; then
+            jq -e --arg head_sha "$HEAD_SHA" \
+              '[.[] | select(.user.login == "greptile-apps[bot]")] | sort_by(.updated_at) | last |
+              ((.body // "") | contains("<h3>Confidence Score: 5/5</h3>") and contains("/commit/" + $head_sha))' \
+              <<< "$comments" > /dev/null
+          else
+            return 1
+          fi
+        }
+
         reviewer_permission="$(gh api "repos/$REPOSITORY/collaborators/$REVIEWER/permission" --jq '.permission' 2>/dev/null || true)"
 
         if [[ "$reviewer_permission" == "admin" ]]; then
@@ -81,22 +100,21 @@ jobs:
         author_permission="$(gh api "repos/$REPOSITORY/collaborators/$AUTHOR/permission" --jq '.permission' 2>/dev/null || true)"
         if [[ "$REVIEWER_TYPE" == "Bot" ]] && is_trusted_bot "$REVIEWER" && [[ "$author_permission" == "admin" ]]; then
           reviews="$(gh api --paginate "repos/$REPOSITORY/pulls/$PR_NUMBER/reviews" | jq -cs '[.[][]]')"
+          comments="$(gh api --paginate "repos/$REPOSITORY/issues/$PR_NUMBER/comments" | jq -cs '[.[][]]')"
           missing_bots=()
 
           for bot in "${TRUSTED_BOTS[@]}"; do
-            bot_review_state="$(latest_decisive_review "$bot" | jq -r '.state // empty')"
-
-            if [[ "$bot_review_state" != "APPROVED" ]]; then
+            if ! bot_approved "$bot"; then
               missing_bots+=("$bot")
             fi
           done
 
           if [[ ${#missing_bots[@]} -gt 0 ]]; then
-            echo "Bot approvals only authorize auto-merge once every trusted bot has approved $HEAD_SHA. Still waiting for: ${missing_bots[*]}."
+            echo "Trusted bot reviews do not authorize auto-merge yet for $HEAD_SHA. Still waiting for: ${missing_bots[*]}."
             exit 0
           fi
 
-          echo "Trusted bot approvals for admin author $AUTHOR authorized."
+          echo "Trusted bot reviews for admin author $AUTHOR authorized."
           exit 0
         fi
 

--- a/.github/workflows/enableAutoMerge.yml
+++ b/.github/workflows/enableAutoMerge.yml
@@ -47,6 +47,25 @@ jobs:
             <<< "$reviews"
         }
 
+        bot_approved() {
+          local bot="$1"
+          local review_state
+          review_state="$(latest_decisive_review "$bot" | jq -r '.state // empty')"
+
+          if [[ "$review_state" == "APPROVED" ]]; then
+            return 0
+          fi
+
+          if [[ "$bot" == "greptile-apps[bot]" ]]; then
+            jq -e --arg head_sha "$HEAD_SHA" \
+              '[.[] | select(.user.login == "greptile-apps[bot]")] | sort_by(.updated_at) | last |
+              ((.body // "") | contains("<h3>Confidence Score: 5/5</h3>") and contains("/commit/" + $head_sha))' \
+              <<< "$comments" > /dev/null
+          else
+            return 1
+          fi
+        }
+
         job_name="$(gh api "repos/$REPOSITORY/actions/runs/$RUN_ID/jobs" \
           --jq '.jobs[] | select(.name | startswith("authorize-auto-merge-")) | select(.conclusion == "success") | .name')"
         pr_number="${job_name#authorize-auto-merge-}"
@@ -76,6 +95,7 @@ jobs:
         fi
 
         reviews="$(gh api --paginate "repos/$REPOSITORY/pulls/$pr_number/reviews" | jq -cs '[.[][]]')"
+        comments="$(gh api --paginate "repos/$REPOSITORY/issues/$pr_number/comments" | jq -cs '[.[][]]')"
         latest_review="$(latest_decisive_review "$REVIEWER")"
         latest_review_state="$(jq -r '.state // empty' <<< "$latest_review")"
         if [[ "$latest_review_state" != "APPROVED" ]]; then
@@ -93,19 +113,17 @@ jobs:
           missing_bots=()
 
           for bot in "${TRUSTED_BOTS[@]}"; do
-            bot_review_state="$(latest_decisive_review "$bot" | jq -r '.state // empty')"
-
-            if [[ "$bot_review_state" != "APPROVED" ]]; then
+            if ! bot_approved "$bot"; then
               missing_bots+=("$bot")
             fi
           done
 
           if [[ ${#missing_bots[@]} -gt 0 ]]; then
-            echo "Bot approvals only authorize auto-merge once every trusted bot has approved $HEAD_SHA. Still waiting for: ${missing_bots[*]}."
+            echo "Trusted bot reviews do not authorize auto-merge yet for $HEAD_SHA. Still waiting for: ${missing_bots[*]}."
             exit 0
           fi
 
-          echo "Trusted bot approvals for admin author $author authorized."
+          echo "Trusted bot reviews for admin author $author authorized."
         else
           echo "Approval by $REVIEWER does not authorize auto-merge."
           exit 0

--- a/.github/workflows/enableAutoMerge.yml
+++ b/.github/workflows/enableAutoMerge.yml
@@ -56,6 +56,10 @@ jobs:
             return 0
           fi
 
+          if [[ "$review_state" == "CHANGES_REQUESTED" ]]; then
+            return 1
+          fi
+
           if [[ "$bot" == "greptile-apps[bot]" ]]; then
             jq -e --arg head_sha "$HEAD_SHA" \
               '[.[] | select(.user.login == "greptile-apps[bot]")] | sort_by(.updated_at) | last |
@@ -98,18 +102,13 @@ jobs:
         comments="$(gh api --paginate "repos/$REPOSITORY/issues/$pr_number/comments" | jq -cs '[.[][]]')"
         latest_review="$(latest_decisive_review "$REVIEWER")"
         latest_review_state="$(jq -r '.state // empty' <<< "$latest_review")"
-        if [[ "$latest_review_state" != "APPROVED" ]]; then
-          echo "The latest review from $REVIEWER for $HEAD_SHA is not an approval."
-          exit 0
-        fi
 
         reviewer_permission="$(gh api "repos/$REPOSITORY/collaborators/$REVIEWER/permission" --jq '.permission' 2>/dev/null || true)"
-        reviewer_type="$(jq -r '.user.type // empty' <<< "$latest_review")"
         author_permission="$(gh api "repos/$REPOSITORY/collaborators/$author/permission" --jq '.permission' 2>/dev/null || true)"
 
-        if [[ "$reviewer_permission" == "admin" ]]; then
+        if [[ "$reviewer_permission" == "admin" && "$latest_review_state" == "APPROVED" ]]; then
           echo "Admin approval by $REVIEWER authorized."
-        elif [[ "$reviewer_type" == "Bot" ]] && is_trusted_bot "$REVIEWER" && [[ "$author_permission" == "admin" ]]; then
+        elif is_trusted_bot "$REVIEWER" && [[ "$author_permission" == "admin" ]] && bot_approved "$REVIEWER"; then
           missing_bots=()
 
           for bot in "${TRUSTED_BOTS[@]}"; do


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Make sure to follow the contributing guidelines. -->
<!-- Important note, we may remove your pull request if you do not use this provided PR template correctly. -->

## Pull Request Type
<!-- Please select what type of pull request this is: [x] -->
- [x] Bugfix
- [ ] Feature Implementation
- [ ] Documentation
- [ ] Other

## Related issue
<!-- Please link the issue your pull request is referring to. -->
<!-- If this pull request fully resolves the relevant issue, put "closes" before the issue number. -->
<!-- Example: "closes #123456". -->

Observed on #380.

## Description
<!-- Please write a clear and concise description of what the pull request does. -->

Treats Greptile's latest 5/5 confidence summary as an approval-equivalent result when authorizing auto-merge. The summary must reference the pull request's exact head commit, preventing a score for an older revision from authorizing a newer one. Regular GitHub approvals remain supported for both trusted review bots.

Greptile currently submits a `COMMENTED` review even when its confidence score is 5/5, so the existing workflow waits forever for an `APPROVED` state.

## Screenshots <!-- If appropriate -->
<!-- Please add before and after screenshots if there is a visible change. -->

Not applicable; this changes GitHub Actions behavior only.

## Release note category
<!-- Select exactly one category. Every pull request must select one. -->
<!-- release-note-category:start -->
- [x] Not noteworthy
- [ ] Highlights
- [ ] More improvements
- [ ] Fixed bugs
<!-- release-note-category:end -->

## Release note
<!-- Required unless "Not noteworthy" is selected. -->
<!-- Write one concise, user-facing entry without a leading bullet. -->
<!-- release-note:start -->

<!-- release-note:end -->

## Release note images
<!-- Optional. Paste one or more Markdown images or HTML image tags here. -->
<!-- The release notes will use an HTML image tag and limit images taller than 300 pixels. -->
<!-- release-note-image:start -->

<!-- release-note-image:end -->

## Testing
<!-- How can reviewers verify that the PR produces correct results? -->
<!-- Please provide instructions so that others can ensure that your pull request would produce correct results. For examples see, https://github.com/FreeTubeApp/FreeTube/pull/5743, https://github.com/FreeTubeApp/FreeTube/pull/7349, https://github.com/FreeTubeApp/FreeTube/pull/5125, https://github.com/FreeTubeApp/FreeTube/pull/7338 -->

- Parsed both workflow files as YAML.
- Parsed every embedded Bash `run` block with `bash -n`.
- Evaluated the Greptile predicate against #380: the current 5/5 summary authorizes its exact head SHA, while a different SHA is rejected.
- Simulated both trusted-bot checks against #380; CodeRabbit's approval and Greptile's 5/5 summary both authorize auto-merge.

## Desktop
<!-- Please complete the following information-->
- **OS:** Arch Linux
- **OS Version:** Rolling release
- **OpenTubeX version:** development

## Additional context
<!-- Add any other context about the pull request here. -->

The Greptile summary is fetched from the trusted bot's latest pull request issue comment in both authorization stages, so the privileged follow-up workflow independently revalidates it before enabling auto-merge.