### PR TITLE
Fix update notifications for nightly builds

### DIFF
--- a/src/renderer/helpers/releaseUpdates.js
+++ b/src/renderer/helpers/releaseUpdates.js
@@ -39,7 +39,9 @@ function compareVersionParts(left, right) {
 }
 
 /**
- * Finds the newest update on the installed build's release channel.
+ * Finds the newest update available to the installed build.
+ * Stable builds stay on stable releases, while nightly builds can update to a
+ * newer nightly or fall back to a newer stable version.
  *
  * @param {Array<{ draft?: boolean, prerelease?: boolean, tag_name?: string }>} releases
  * @param {string} installedVersion
@@ -61,8 +63,8 @@ export function findUpdateRelease(releases, installedVersion) {
     if (
       release.draft === true ||
       releaseVersion === null ||
-      releaseVersion.channel !== installed.channel ||
-      isNightlyRelease !== (installed.channel === 'nightly') ||
+      isNightlyRelease !== (releaseVersion.channel === 'nightly') ||
+      (installed.channel === 'stable' && releaseVersion.channel === 'nightly') ||
       compareVersionParts(releaseVersion.parts, latestVersion.parts) <= 0
     ) {
       continue

--- a/tests/unit/release-updates.test.mjs
+++ b/tests/unit/release-updates.test.mjs
@@ -22,7 +22,7 @@ test('stable builds only update from normal GitHub releases', () => {
   )
 })
 
-test('nightly builds only update from nightly prereleases', () => {
+test('nightly builds update to newer nightly prereleases', () => {
   const nightlyRelease = {
     name: 'OpenTubeX nightly 101',
     prerelease: true,
@@ -30,8 +30,59 @@ test('nightly builds only update from nightly prereleases', () => {
   }
 
   assert.equal(
-    findUpdateRelease([stableRelease, nightlyRelease], '0.29.0-nightly-100'),
+    findUpdateRelease([nightlyRelease], '0.29.0-nightly-100'),
     nightlyRelease
+  )
+})
+
+test('nightly builds fall back to a newer stable release', () => {
+  const newerStableRelease = {
+    name: 'OpenTubeX 0.30.1',
+    prerelease: false,
+    tag_name: 'v0.30.1-beta'
+  }
+
+  assert.equal(
+    findUpdateRelease([newerStableRelease], '0.30.0-nightly-595'),
+    newerStableRelease
+  )
+})
+
+test('nightly builds prefer a newer stable version over an older-version nightly', () => {
+  const newerNightlyRelease = {
+    prerelease: true,
+    tag_name: 'v0.30.0-nightly-596'
+  }
+  const newerStableRelease = {
+    prerelease: false,
+    tag_name: 'v0.30.1-beta'
+  }
+
+  assert.equal(
+    findUpdateRelease(
+      [newerNightlyRelease, newerStableRelease],
+      '0.30.0-nightly-595'
+    ),
+    newerStableRelease
+  )
+})
+
+test('nightly builds prefer a newer nightly over stable for the same version', () => {
+  const newerStableRelease = {
+    prerelease: false,
+    tag_name: 'v0.30.1-beta'
+  }
+  const newerNightlyRelease = {
+    prerelease: true,
+    tag_name: 'v0.30.1-nightly-600'
+  }
+
+  assert.equal(
+    findUpdateRelease(
+      [newerStableRelease, newerNightlyRelease],
+      '0.30.0-nightly-595'
+    ),
+    newerNightlyRelease
   )
 })
 


### PR DESCRIPTION
## Pull Request Type
- [x] Bugfix
- [ ] Feature Implementation
- [ ] Documentation
- [ ] Other

## Related issue
None.

## Description
Nightly installations now consider both nightly and stable releases when checking for updates. A newer nightly remains eligible, while a stable release with a newer application version is used as the fallback when no nightly exists for that version.

Stable installations remain restricted to stable releases.

The previous channel check required the candidate release channel to exactly match the installed channel, so nightly users could miss a newer stable release.

## Screenshots
Not applicable; the existing update notification UI is unchanged.

## Release note category
<!-- release-note-category:start -->
- [ ] Not noteworthy
- [ ] Highlights
- [ ] More improvements
- [x] Fixed bugs
<!-- release-note-category:end -->

## Release note
<!-- release-note:start -->
Nightly builds now notify users about newer nightly builds and newer stable releases.
<!-- release-note:end -->

## Release note images
<!-- release-note-image:start -->
<!-- release-note-image:end -->

## Testing
1. Run `pnpm test:unit`.
2. Confirm the release-update tests cover a newer nightly, a newer stable fallback, and candidate priority regardless of API order.

Also validated the changed files with ESLint.

## Desktop
- **OS:** Arch Linux
- **OS Version:** Rolling release
- **OpenTubeX version:** 0.30.0-nightly-595

## Additional context
None.