### PR TITLE
fix(settings): reset grouped settings individually

### DIFF
--- a/e2e/tests/offline/settings.spec.mjs
+++ b/e2e/tests/offline/settings.spec.mjs
@@ -178,6 +178,72 @@ test.describe('settings', () => {
     await expect(resetButton).toHaveCount(0)
   })
 
+  test('highlights and resets caption appearance settings individually', async ({ page }) => {
+    await goTo(page, 'settings')
+
+    await page.locator('label.switch-label')
+      .filter({ hasText: 'Highlight settings changed from defaults' })
+      .click()
+    await page.locator('.settingsMenu [data-section="caption-appearance"]').click()
+
+    const backgroundOpacity = page.getByRole('slider', { name: /Background Opacity/ })
+    await backgroundOpacity.fill('50')
+
+    const changedControl = page.locator('.pure-material-slider')
+      .filter({ has: backgroundOpacity })
+    const resetButton = changedControl.getByRole('button', {
+      name: 'Reset this setting to its default'
+    })
+
+    await expect(resetButton).toBeVisible()
+    await expect(changedControl).toHaveCSS('border-left-width', '3px')
+    await expect(page.locator('.captionControls').getByRole('button', {
+      name: 'Reset this setting to its default'
+    })).toHaveCount(1)
+
+    await resetButton.click()
+    await expect(backgroundOpacity).toHaveValue('80')
+    await expect(resetButton).toHaveCount(0)
+  })
+
+  test('highlights and resets SponsorBlock category values individually', async ({ page }) => {
+    await goTo(page, 'settings')
+
+    await page.locator('label.switch-label')
+      .filter({ hasText: 'Highlight settings changed from defaults' })
+      .click()
+    await page.locator('.settingsMenu [data-section="sponsor-block"]').click()
+    await page.locator('label.switch-label')
+      .filter({ hasText: 'Enable SponsorBlock' })
+      .click()
+
+    const sponsorCategory = page.locator('.sponsorBlockCategory')
+      .filter({ has: page.locator('.sponsorTitle', { hasText: /^Sponsor$/ }) })
+    const color = sponsorCategory.locator('select').nth(0)
+    const skipOption = sponsorCategory.locator('select').nth(1)
+
+    await color.selectOption('Red')
+
+    const resetButton = sponsorCategory.getByRole('button', {
+      name: 'Reset this setting to its default'
+    })
+    await expect(resetButton).toHaveCount(1)
+    await expect(color).toHaveValue('Red')
+    await expect(skipOption).toHaveValue('autoSkip')
+
+    await resetButton.click()
+    await expect(color).toHaveValue('Green')
+    await expect(skipOption).toHaveValue('autoSkip')
+    await expect(resetButton).toHaveCount(0)
+
+    await skipOption.selectOption('promptToSkip')
+    await expect(resetButton).toHaveCount(1)
+    await resetButton.click()
+    await expect(color).toHaveValue('Green')
+    await expect(skipOption).toHaveValue('autoSkip')
+    await expect(resetButton).toHaveCount(0)
+  })
+
   test('positions toasts and dismisses them towards the configured edge', async ({ page }) => {
     await goTo(page, 'settings')
 

--- a/e2e/tests/offline/settings.spec.mjs
+++ b/e2e/tests/offline/settings.spec.mjs
@@ -475,6 +475,49 @@ test.describe('settings', () => {
   })
 })
 
+test.describe('SponsorBlock highlight settings', () => {
+  test.use({
+    seed: {
+      settings: {
+        highlightChangedSettings: true,
+        sponsorBlockHighlight: {
+          color: 'Blue',
+          skip: 'autoSkip'
+        },
+        useSponsorBlock: true
+      }
+    }
+  })
+
+  test('preserves the stored skip option when resetting only the color', async ({ app }) => {
+    const { page } = app
+    await goTo(page, 'settings')
+    await page.locator('.settingsMenu [data-section="sponsor-block"]').click()
+
+    const highlightCategory = page.locator('.sponsorBlockCategory')
+      .filter({ has: page.locator('.sponsorTitle', { hasText: /^Highlight$/ }) })
+    const color = highlightCategory.locator('select').nth(0)
+    const skipOption = highlightCategory.locator('select').nth(1)
+
+    await expect(color).toHaveValue('Blue')
+    await expect(skipOption).toHaveValue('promptToSkip')
+    await highlightCategory.getByRole('button', {
+      name: 'Reset this setting to its default'
+    }).click()
+    await expect(color).toHaveValue('Red')
+
+    await expect.poll(async () => {
+      const settings = latestSettings(
+        await readFile(path.join(app.userDataDir, 'settings.db'), 'utf8')
+      )
+      return settings.sponsorBlockHighlight
+    }).toEqual({
+      color: 'Red',
+      skip: 'autoSkip'
+    })
+  })
+})
+
 test.describe('sync settings', () => {
   test.use({
     seed: {

--- a/src/renderer/components/CaptionSettings/CaptionSettings.vue
+++ b/src/renderer/components/CaptionSettings/CaptionSettings.vue
@@ -35,7 +35,11 @@
         <label class="captionControl captionColorControl">
           <span>
             {{ t('Settings.Player Settings.Caption Appearance.Text Color') }}
-            <FtSyncedSettingIndicator setting-key="defaultCaptionSettings" />
+            <FtSyncedSettingIndicator
+              setting-key="defaultCaptionSettings"
+              :is-changed="isCaptionSettingChanged('textColor')"
+              @reset="resetCaptionSetting('textColor')"
+            />
           </span>
           <input
             type="color"
@@ -46,7 +50,11 @@
         <label class="captionControl captionColorControl">
           <span>
             {{ t('Settings.Player Settings.Caption Appearance.Background Color') }}
-            <FtSyncedSettingIndicator setting-key="defaultCaptionSettings" />
+            <FtSyncedSettingIndicator
+              setting-key="defaultCaptionSettings"
+              :is-changed="isCaptionSettingChanged('backgroundColor')"
+              @reset="resetCaptionSetting('backgroundColor')"
+            />
           </span>
           <input
             type="color"
@@ -59,11 +67,13 @@
             :label="t('Settings.Player Settings.Caption Appearance.Background Opacity')"
             :default-value="Math.round(captionSettings.backgroundOpacity * 100)"
             setting-key="defaultCaptionSettings"
+            :is-changed="isCaptionSettingChanged('backgroundOpacity')"
             :min-value="0"
             :max-value="100"
             :step="5"
             value-extension="%"
             @input="updateCaptionSetting('backgroundOpacity', $event / 100)"
+            @reset="resetCaptionSetting('backgroundOpacity')"
           />
         </div>
         <div class="captionControl">
@@ -71,11 +81,13 @@
             :label="t('Settings.Player Settings.Caption Appearance.Font Size')"
             :default-value="Math.round(captionSettings.fontScale * 100)"
             setting-key="defaultCaptionSettings"
+            :is-changed="isCaptionSettingChanged('fontScale')"
             :min-value="50"
             :max-value="200"
             :step="10"
             value-extension="%"
             @input="updateCaptionSetting('fontScale', $event / 100)"
+            @reset="resetCaptionSetting('fontScale')"
           />
         </div>
         <div class="captionControl">
@@ -83,10 +95,12 @@
             :placeholder="t('Settings.Player Settings.Caption Appearance.Anchor.Anchor')"
             :value="captionSettings.anchor"
             setting-key="defaultCaptionSettings"
+            :is-changed="isCaptionSettingChanged('anchor')"
             :select-names="captionAnchorNames"
             :select-values="CAPTION_ANCHORS"
             :icon="['fas', 'border-all']"
             @change="updateCaptionSetting('anchor', $event)"
+            @reset="resetCaptionSetting('anchor')"
           />
         </div>
         <div class="captionControl">
@@ -94,11 +108,13 @@
             :label="t('Settings.Player Settings.Caption Appearance.Vertical Position')"
             :default-value="Math.round(captionSettings.verticalPosition * 100)"
             setting-key="defaultCaptionSettings"
+            :is-changed="isCaptionSettingChanged('verticalPosition')"
             :min-value="0"
             :max-value="50"
             :step="1"
             value-extension="%"
             @input="updateCaptionSetting('verticalPosition', $event / 100)"
+            @reset="resetCaptionSetting('verticalPosition')"
           />
         </div>
         <div class="captionControl">
@@ -106,10 +122,12 @@
             :placeholder="t('Settings.Player Settings.Caption Appearance.Edge Style.Edge Style')"
             :value="captionSettings.edgeStyle"
             setting-key="defaultCaptionSettings"
+            :is-changed="isCaptionSettingChanged('edgeStyle')"
             :select-names="captionEdgeStyleNames"
             :select-values="CAPTION_EDGE_STYLES"
             :icon="['fas', 'palette']"
             @change="updateCaptionSetting('edgeStyle', $event)"
+            @reset="resetCaptionSetting('edgeStyle')"
           />
         </div>
         <label
@@ -118,7 +136,11 @@
         >
           <span>
             {{ t('Settings.Player Settings.Caption Appearance.Edge Color') }}
-            <FtSyncedSettingIndicator setting-key="defaultCaptionSettings" />
+            <FtSyncedSettingIndicator
+              setting-key="defaultCaptionSettings"
+              :is-changed="isCaptionSettingChanged('edgeColor')"
+              @reset="resetCaptionSetting('edgeColor')"
+            />
           </span>
           <input
             type="color"
@@ -194,6 +216,21 @@ function updateCaptionSetting(setting, value) {
     ...captionSettings.value,
     [setting]: value,
   }))
+}
+
+/**
+ * @param {'textColor' | 'backgroundColor' | 'backgroundOpacity' | 'fontScale' | 'verticalPosition' | 'anchor' | 'edgeStyle' | 'edgeColor'} setting
+ * @returns {boolean}
+ */
+function isCaptionSettingChanged(setting) {
+  return !Object.is(captionSettings.value[setting], DEFAULT_CAPTION_SETTINGS[setting])
+}
+
+/**
+ * @param {'textColor' | 'backgroundColor' | 'backgroundOpacity' | 'fontScale' | 'verticalPosition' | 'anchor' | 'edgeStyle' | 'edgeColor'} setting
+ */
+function resetCaptionSetting(setting) {
+  updateCaptionSetting(setting, DEFAULT_CAPTION_SETTINGS[setting])
 }
 
 /** @param {string} value */

--- a/src/renderer/components/FtSelect/FtSelect.vue
+++ b/src/renderer/components/FtSelect/FtSelect.vue
@@ -43,6 +43,8 @@
         <FtSyncedSettingIndicator
           v-if="tooltip === ''"
           :setting-key="settingKey"
+          :is-changed="isChanged"
+          @reset="emit('reset')"
         />
       </span>
     </label>
@@ -54,7 +56,11 @@
         class="selectTooltip"
         :tooltip="tooltip"
       />
-      <FtSyncedSettingIndicator :setting-key="settingKey" />
+      <FtSyncedSettingIndicator
+        :setting-key="settingKey"
+        :is-changed="isChanged"
+        @reset="emit('reset')"
+      />
     </span>
   </div>
 </template>
@@ -110,10 +116,14 @@ defineProps({
   settingKey: {
     type: String,
     default: ''
+  },
+  isChanged: {
+    type: Boolean,
+    default: null
   }
 })
 
-const emit = defineEmits(['change'])
+const emit = defineEmits(['change', 'reset'])
 
 const id = useId()
 

--- a/src/renderer/components/FtSlider/FtSlider.vue
+++ b/src/renderer/components/FtSlider/FtSlider.vue
@@ -23,7 +23,11 @@
       class="selectTooltip"
       :tooltip="tooltip"
     />
-    <FtSyncedSettingIndicator :setting-key="settingKey" />
+    <FtSyncedSettingIndicator
+      :setting-key="settingKey"
+      :is-changed="isChanged"
+      @reset="emit('reset')"
+    />
   </label>
 </template>
 
@@ -69,10 +73,14 @@ const props = defineProps({
   settingKey: {
     type: String,
     default: ''
+  },
+  isChanged: {
+    type: Boolean,
+    default: null
   }
 })
 
-const emit = defineEmits(['change', 'input'])
+const emit = defineEmits(['change', 'input', 'reset'])
 
 const id = useId()
 const currentValue = ref(props.defaultValue)

--- a/src/renderer/components/FtSponsorBlockCategory/FtSponsorBlockCategory.vue
+++ b/src/renderer/components/FtSponsorBlockCategory/FtSponsorBlockCategory.vue
@@ -88,7 +88,7 @@ const colorNames = useColorTranslations()
 const id = useId()
 
 /** @type {import('vue').ComputedRef<{ color: string, skip: string }>} */
-const sponsorBlockValues = computed(() => {
+const storedSponsorBlockValues = computed(() => {
   switch (props.categoryName) {
     case 'sponsor':
       return store.getters.getSponsorBlockSponsor
@@ -108,17 +108,20 @@ const sponsorBlockValues = computed(() => {
       return store.getters.getSponsorBlockMusicOffTopic
     case 'filler':
       return store.getters.getSponsorBlockFiller
-    case 'highlight': {
-      const highlightValues = store.getters.getSponsorBlockHighlight
-      return {
-        ...highlightValues,
-        skip: highlightValues.skip === 'autoSkip' ? 'promptToSkip' : highlightValues.skip
-      }
-    }
+    case 'highlight':
+      return store.getters.getSponsorBlockHighlight
     default:
       return ''
   }
 })
+
+/** @type {import('vue').ComputedRef<{ color: string, skip: string }>} */
+const sponsorBlockValues = computed(() => ({
+  ...storedSponsorBlockValues.value,
+  skip: props.categoryName === 'highlight' && storedSponsorBlockValues.value.skip === 'autoSkip'
+    ? 'promptToSkip'
+    : storedSponsorBlockValues.value.skip
+}))
 
 const translatedCategoryName = computed(() => {
   switch (props.categoryName) {
@@ -179,7 +182,7 @@ function isValueChanged(property) {
  */
 function resetValue(property) {
   updateSponsorCategory({
-    ...sponsorBlockValues.value,
+    ...storedSponsorBlockValues.value,
     [property]: DEFAULT_SETTINGS[settingKey.value][property]
   })
 }
@@ -189,8 +192,8 @@ function resetValue(property) {
  */
 function updateColor(color) {
   updateSponsorCategory({
+    ...storedSponsorBlockValues.value,
     color,
-    skip: sponsorBlockValues.value.skip
   })
 }
 
@@ -199,7 +202,7 @@ function updateColor(color) {
  */
 function updateSkipOption(skipOption) {
   updateSponsorCategory({
-    color: sponsorBlockValues.value.color,
+    ...storedSponsorBlockValues.value,
     skip: skipOption
   })
 }
@@ -208,40 +211,36 @@ function updateSkipOption(skipOption) {
  * @param {{ color: string, skip: string }} payload
  */
 function updateSponsorCategory(payload) {
-  const nextPayload = props.categoryName === 'highlight' && payload.skip === 'autoSkip'
-    ? { ...payload, skip: 'promptToSkip' }
-    : payload
-
   switch (props.categoryName) {
     case 'sponsor':
-      store.dispatch('updateSponsorBlockSponsor', nextPayload)
+      store.dispatch('updateSponsorBlockSponsor', payload)
       break
     case 'self-promotion':
-      store.dispatch('updateSponsorBlockSelfPromo', nextPayload)
+      store.dispatch('updateSponsorBlockSelfPromo', payload)
       break
     case 'interaction':
-      store.dispatch('updateSponsorBlockInteraction', nextPayload)
+      store.dispatch('updateSponsorBlockInteraction', payload)
       break
     case 'intro':
-      store.dispatch('updateSponsorBlockIntro', nextPayload)
+      store.dispatch('updateSponsorBlockIntro', payload)
       break
     case 'outro':
-      store.dispatch('updateSponsorBlockOutro', nextPayload)
+      store.dispatch('updateSponsorBlockOutro', payload)
       break
     case 'recap':
-      store.dispatch('updateSponsorBlockRecap', nextPayload)
+      store.dispatch('updateSponsorBlockRecap', payload)
       break
     case 'hook':
-      store.dispatch('updateSponsorBlockHook', nextPayload)
+      store.dispatch('updateSponsorBlockHook', payload)
       break
     case 'music offtopic':
-      store.dispatch('updateSponsorBlockMusicOffTopic', nextPayload)
+      store.dispatch('updateSponsorBlockMusicOffTopic', payload)
       break
     case 'filler':
-      store.dispatch('updateSponsorBlockFiller', nextPayload)
+      store.dispatch('updateSponsorBlockFiller', payload)
       break
     case 'highlight':
-      store.dispatch('updateSponsorBlockHighlight', nextPayload)
+      store.dispatch('updateSponsorBlockHighlight', payload)
       break
   }
 }

--- a/src/renderer/components/FtSponsorBlockCategory/FtSponsorBlockCategory.vue
+++ b/src/renderer/components/FtSponsorBlockCategory/FtSponsorBlockCategory.vue
@@ -11,22 +11,26 @@
       :placeholder="$t('Settings.SponsorBlock Settings.Category Color')"
       :value="sponsorBlockValues.color"
       :setting-key="settingKey"
+      :is-changed="isValueChanged('color')"
       :select-names="colorNames"
       :select-values="COLOR_VALUES"
       :icon="['fas', 'palette']"
       :class="'sec' + sponsorBlockValues.color"
       icon-color="rgb(var(--accent-color-rgb))"
       @change="updateColor"
+      @reset="resetValue('color')"
     />
     <FtSelect
       :describe-by-id="id"
       :placeholder="$t('Settings.SponsorBlock Settings.Skip Options.Skip Option')"
       :value="sponsorBlockValues.skip"
       :setting-key="settingKey"
+      :is-changed="isValueChanged('skip')"
       :select-names="skipNames"
       :select-values="selectableSkipValues"
       :icon="['fas', 'forward']"
       @change="updateSkipOption"
+      @reset="resetValue('skip')"
     />
   </div>
 </template>
@@ -38,6 +42,7 @@ import { useI18n } from 'vue-i18n'
 import FtSelect from '../FtSelect/FtSelect.vue'
 
 import store from '../../store/index'
+import { DEFAULT_SETTINGS } from '../../store/modules/settings'
 
 import { colors } from '../../helpers/colors'
 import { useColorTranslations } from '../../composables/colors'
@@ -157,6 +162,27 @@ const settingKey = computed(() => {
   }
   return `sponsorBlock${suffixes[props.categoryName]}`
 })
+
+/**
+ * @param {'color' | 'skip'} property
+ * @returns {boolean}
+ */
+function isValueChanged(property) {
+  return !Object.is(
+    sponsorBlockValues.value[property],
+    DEFAULT_SETTINGS[settingKey.value][property]
+  )
+}
+
+/**
+ * @param {'color' | 'skip'} property
+ */
+function resetValue(property) {
+  updateSponsorCategory({
+    ...sponsorBlockValues.value,
+    [property]: DEFAULT_SETTINGS[settingKey.value][property]
+  })
+}
 
 /**
  * @param {string} color

--- a/src/renderer/components/FtSyncedSettingIndicator/FtSyncedSettingIndicator.vue
+++ b/src/renderer/components/FtSyncedSettingIndicator/FtSyncedSettingIndicator.vue
@@ -45,8 +45,14 @@ const props = defineProps({
   settingKey: {
     type: String,
     default: ''
+  },
+  isChanged: {
+    type: Boolean,
+    default: null
   }
 })
+
+const emit = defineEmits(['reset'])
 
 const { t } = useI18n()
 
@@ -64,8 +70,10 @@ const isSynced = computed(() => {
 const showReset = computed(() => {
   return store.state.settings.highlightChangedSettings === true &&
     props.settingKey !== 'highlightChangedSettings' &&
-    Object.prototype.hasOwnProperty.call(DEFAULT_SETTINGS, props.settingKey) &&
-    !settingsValuesEqual(store.state.settings[props.settingKey], DEFAULT_SETTINGS[props.settingKey])
+    (props.isChanged ?? (
+      Object.prototype.hasOwnProperty.call(DEFAULT_SETTINGS, props.settingKey) &&
+      !settingsValuesEqual(store.state.settings[props.settingKey], DEFAULT_SETTINGS[props.settingKey])
+    ))
 })
 
 const label = computed(() => isSynced.value
@@ -88,7 +96,11 @@ function settingsValuesEqual(currentValue, defaultValue) {
 }
 
 function resetToDefault() {
-  store.dispatch('resetSettingToDefault', props.settingKey)
+  if (props.isChanged !== null) {
+    emit('reset')
+  } else {
+    store.dispatch('resetSettingToDefault', props.settingKey)
+  }
 }
 
 async function toggleSync() {


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Make sure to follow the contributing guidelines. -->
<!-- Important note, we may remove your pull request if you do not use this provided PR template correctly. -->

## Pull Request Type
<!-- Please select what type of pull request this is: [x] -->
- [x] Bugfix
- [ ] Feature Implementation
- [ ] Documentation
- [ ] Other

## Related issue
<!-- Please link the issue your pull request is referring to. -->
<!-- If this pull request fully resolves the relevant issue, put "closes" before the issue number. -->
<!-- Example: "closes #123456". -->

None.

## Description
<!-- Please write a clear and concise description of what the pull request does. -->

Changed-setting indicators previously compared and reset an entire grouped setting object. As a result, changing one caption appearance value marked every appearance control as changed, and changing one SponsorBlock category property marked both its color and skip option as changed. Using either per-setting reset also reset the whole group.

This adds optional per-control changed state and reset handling to the shared setting indicator. Caption appearance controls and SponsorBlock category controls now compare and reset only their own property while retaining the parent setting key for sync behavior.

## Screenshots <!-- If appropriate -->
<!-- Please add before and after screenshots if there is a visible change. -->

Not applicable.

## Release note category
<!-- Select exactly one category. Every pull request must select one. -->
<!-- release-note-category:start -->
- [ ] Not noteworthy
- [ ] Highlights
- [ ] More improvements
- [x] Fixed bugs
<!-- release-note-category:end -->

## Release note
<!-- Required unless "Not noteworthy" is selected. -->
<!-- Write one concise, user-facing entry without a leading bullet. -->
<!-- release-note:start -->
Fixed changed-setting highlights and individual resets for caption appearance and SponsorBlock category options.
<!-- release-note:end -->

## Release note images
<!-- Optional. Paste one or more Markdown images or HTML image tags here. -->
<!-- The release notes will use an HTML image tag and limit images taller than 300 pixels. -->
<!-- release-note-image:start -->

<!-- release-note-image:end -->

## Testing
<!-- How can reviewers verify that the PR produces correct results? -->
<!-- Please provide instructions so that others can ensure that your pull request would produce correct results. For examples see, https://github.com/FreeTubeApp/FreeTube/pull/5743, https://github.com/FreeTubeApp/FreeTube/pull/7349, https://github.com/FreeTubeApp/FreeTube/pull/5125, https://github.com/FreeTubeApp/FreeTube/pull/7338 -->

- Enable “Highlight settings changed from defaults.”
- Change one caption appearance value and verify only that control is highlighted and reset.
- Change either a SponsorBlock category color or skip option and verify only that select is highlighted and reset.
- Run `pnpm run test:unit`.
- Build the E2E bundle with `pnpm run test:e2e:pack`.
- Run the changed-setting E2E tests under Xvfb; all three pass.

## Desktop
<!-- Please complete the following information-->
- **OS:** Arch Linux
- **OS Version:** Rolling release
- **OpenTubeX version:** 0.30.1

## Additional context
<!-- Add any other context about the pull request here. -->

None.
