### PR TITLE
Add generated changelogs to nightly releases

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -442,10 +442,13 @@ jobs:
     permissions:
       actions: read
       contents: write
+      issues: read
+      pull-requests: read
 
     steps:
     - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
       with:
+        fetch-depth: 0
         persist-credentials: false
 
     - name: Download build artifacts
@@ -472,6 +475,49 @@ jobs:
           cp "${files[0]}" "release-assets/$artifact_name"
         done
 
+    - name: Generate nightly release notes
+      env:
+        GH_TOKEN: ${{ github.token }}
+        TARGET_BRANCH: development
+        TARGET_SHA: ${{ github.sha }}
+      shell: bash
+      run: |
+        set -euo pipefail
+
+        releases="$(
+          gh release list --limit 100 \
+            --json isDraft,isPrerelease,tagName
+        )"
+
+        previous_tag=''
+        while IFS= read -r tag; do
+          if git merge-base --is-ancestor "$tag" "$TARGET_SHA"; then
+            previous_tag="$tag"
+            break
+          fi
+        done < <(
+          jq --raw-output '.[] | select(
+            .isDraft == false and .isPrerelease == false
+          ) | .tagName' <<< "$releases"
+        )
+
+        if [[ -z "$previous_tag" ]]; then
+          echo 'Could not find a previous release tag.' >&2
+          exit 1
+        fi
+
+        PREVIOUS_TAG="$previous_tag" \
+          node _scripts/releaseNotes.mjs generate-nightly nightly-changelog.md
+
+        {
+          printf '> [!WARNING]\n'
+          printf '> This nightly build is intended for testing only and may be unstable. Regular users should use the [latest non-prerelease](https://github.com/OpenTubeX/OpenTubeX/releases/latest).\n\n'
+          printf 'Automated development build from commit %s.\n\n' "$TARGET_SHA"
+          printf '<details>\n<summary>Changelog since the latest stable release (%s)</summary>\n\n' "$previous_tag"
+          cat nightly-changelog.md
+          printf '\n</details>\n'
+        } > release-notes.md
+
     - name: Create nightly release
       id: release
       env:
@@ -482,15 +528,12 @@ jobs:
         base_version="$(jq --raw-output .version package.json)"
         version="${base_version}-nightly-${GITHUB_RUN_NUMBER}"
         tag="v${version}"
-        printf -v notes \
-          '> [!WARNING]\n> This nightly build is intended for testing only and may be unstable. Regular users should use the [latest non-prerelease](https://github.com/OpenTubeX/OpenTubeX/releases/latest).\n\nAutomated development build from commit %s.' \
-          "$GITHUB_SHA"
 
         gh release create "$tag" release-assets/* \
           --prerelease \
           --target "$GITHUB_SHA" \
           --title "v${version}" \
-          --notes "$notes"
+          --notes-file release-notes.md
 
         {
           echo "tag=$tag"

--- a/_scripts/releaseNotes.mjs
+++ b/_scripts/releaseNotes.mjs
@@ -386,7 +386,11 @@ function indentContinuationLines(value) {
   return value.split('\n').map((line, index) => index === 0 ? line : `  ${line}`).join('\n')
 }
 
-export async function renderReleaseNotes(pullRequests, loadImage = downloadImage, emptyMessage = null) {
+export async function renderReleaseNotes(pullRequests, {
+  emptyMessage = null,
+  loadImage = downloadImage,
+  onImageError = null,
+} = {}) {
   const sections = new Map([...RELEASE_NOTE_CATEGORIES.keys()].map((category) => [category, []]))
 
   for (const pullRequest of pullRequests) {
@@ -415,7 +419,14 @@ export async function renderReleaseNotes(pullRequests, loadImage = downloadImage
       try {
         releaseNote += `\n  ${await normalizeReleaseImage(image, pullRequest.title, loadImage)}`
       } catch (error) {
-        throw new Error(`PR #${pullRequest.number}: ${error.message}`, { cause: error })
+        const imageError = new Error(`PR #${pullRequest.number}: ${error.message}`, { cause: error })
+
+        if (onImageError) {
+          onImageError(imageError)
+          continue
+        }
+
+        throw imageError
       }
     }
 
@@ -442,7 +453,7 @@ async function validateEvent(eventPath) {
   console.log(`Release note category is valid: ${releaseNote.category}.`)
 }
 
-async function generate(outputPath, emptyMessage = null) {
+async function generate(outputPath, options) {
   const repository = process.env.GITHUB_REPOSITORY
   const previousTag = process.env.PREVIOUS_TAG
   const targetBranch = process.env.TARGET_BRANCH
@@ -454,7 +465,7 @@ async function generate(outputPath, emptyMessage = null) {
 
   const pullRequests = listMergedPullRequests(repository, targetBranch)
   const selectedPullRequests = selectPullRequests(pullRequests, previousTag, targetSha)
-  const releaseNotes = await renderReleaseNotes(selectedPullRequests, downloadImage, emptyMessage)
+  const releaseNotes = await renderReleaseNotes(selectedPullRequests, options)
 
   fs.writeFileSync(outputPath, releaseNotes)
   console.log(`Processed ${selectedPullRequests.length} pull requests and wrote ${outputPath}.`)
@@ -468,7 +479,10 @@ async function main() {
   if (command === 'generate' && argument) { return generate(argument) }
 
   if (command === 'generate-nightly' && argument) {
-    return generate(argument, 'No noteworthy changes since the latest stable release.')
+    return generate(argument, {
+      emptyMessage: 'No noteworthy changes since the latest stable release.',
+      onImageError: (error) => console.warn(`${error.message} The image will be omitted from this nightly.`),
+    })
   }
 
   throw new Error('Usage: releaseNotes.mjs <validate-event EVENT_PATH | generate OUTPUT_PATH | generate-nightly OUTPUT_PATH>')

--- a/_scripts/releaseNotes.mjs
+++ b/_scripts/releaseNotes.mjs
@@ -386,7 +386,7 @@ function indentContinuationLines(value) {
   return value.split('\n').map((line, index) => index === 0 ? line : `  ${line}`).join('\n')
 }
 
-export async function renderReleaseNotes(pullRequests, loadImage = downloadImage) {
+export async function renderReleaseNotes(pullRequests, loadImage = downloadImage, emptyMessage = null) {
   const sections = new Map([...RELEASE_NOTE_CATEGORIES.keys()].map((category) => [category, []]))
 
   for (const pullRequest of pullRequests) {
@@ -427,6 +427,8 @@ export async function renderReleaseNotes(pullRequests, loadImage = downloadImage
     .map(([category, heading]) => `${heading}\n\n${sections.get(category).join('\n')}`)
 
   if (renderedSections.length === 0) {
+    if (emptyMessage !== null) { return `${emptyMessage}\n` }
+
     throw new Error('No noteworthy pull requests were found between the selected refs.')
   }
 
@@ -440,7 +442,7 @@ async function validateEvent(eventPath) {
   console.log(`Release note category is valid: ${releaseNote.category}.`)
 }
 
-async function generate(outputPath) {
+async function generate(outputPath, emptyMessage = null) {
   const repository = process.env.GITHUB_REPOSITORY
   const previousTag = process.env.PREVIOUS_TAG
   const targetBranch = process.env.TARGET_BRANCH
@@ -452,7 +454,7 @@ async function generate(outputPath) {
 
   const pullRequests = listMergedPullRequests(repository, targetBranch)
   const selectedPullRequests = selectPullRequests(pullRequests, previousTag, targetSha)
-  const releaseNotes = await renderReleaseNotes(selectedPullRequests)
+  const releaseNotes = await renderReleaseNotes(selectedPullRequests, downloadImage, emptyMessage)
 
   fs.writeFileSync(outputPath, releaseNotes)
   console.log(`Processed ${selectedPullRequests.length} pull requests and wrote ${outputPath}.`)
@@ -465,7 +467,11 @@ async function main() {
 
   if (command === 'generate' && argument) { return generate(argument) }
 
-  throw new Error('Usage: releaseNotes.mjs <validate-event EVENT_PATH | generate OUTPUT_PATH>')
+  if (command === 'generate-nightly' && argument) {
+    return generate(argument, 'No noteworthy changes since the latest stable release.')
+  }
+
+  throw new Error('Usage: releaseNotes.mjs <validate-event EVENT_PATH | generate OUTPUT_PATH | generate-nightly OUTPUT_PATH>')
 }
 
 const isMainModule = process.argv[1] &&

--- a/tests/unit/release-notes.test.mjs
+++ b/tests/unit/release-notes.test.mjs
@@ -385,3 +385,13 @@ test('a release with only non-noteworthy pull requests is rejected', async () =>
     /No noteworthy pull requests/,
   )
 })
+
+test('nightly releases can render a fallback when there are no noteworthy changes', async () => {
+  const result = await renderReleaseNotes([{
+    body: categoryMarkers('Not noteworthy'),
+    number: 42,
+    title: 'Refactor tests',
+  }], undefined, 'No noteworthy changes since the latest stable release.')
+
+  assert.equal(result, 'No noteworthy changes since the latest stable release.\n')
+})

--- a/tests/unit/release-notes.test.mjs
+++ b/tests/unit/release-notes.test.mjs
@@ -339,7 +339,9 @@ Fixed videos failing to load.
       number: 46,
       title: 'Legacy change',
     },
-  ], async () => png(800, 600))
+  ], {
+    loadImage: async () => png(800, 600),
+  })
 
   assert.equal(result, `# Highlights
 
@@ -391,7 +393,34 @@ test('nightly releases can render a fallback when there are no noteworthy change
     body: categoryMarkers('Not noteworthy'),
     number: 42,
     title: 'Refactor tests',
-  }], undefined, 'No noteworthy changes since the latest stable release.')
+  }], {
+    emptyMessage: 'No noteworthy changes since the latest stable release.',
+  })
 
   assert.equal(result, 'No noteworthy changes since the latest stable release.\n')
+})
+
+test('nightly releases omit images that cannot be processed', async () => {
+  const imageErrors = []
+  const result = await renderReleaseNotes([{
+    body: `
+${categoryMarkers('More improvements')}
+${NOTE_MARKERS}
+<!-- release-note-image:start -->
+![Screenshot](https://github.com/user-attachments/assets/example)
+<!-- release-note-image:end -->
+`,
+    number: 42,
+    title: 'Compact player',
+  }], {
+    loadImage: async () => { throw new Error('Image unavailable.') },
+    onImageError: (error) => imageErrors.push(error),
+  })
+
+  assert.equal(result, `## More improvements
+
+- Adds a compact player. (#42)
+`)
+  assert.equal(imageErrors.length, 1)
+  assert.match(imageErrors[0].message, /PR #42: Image unavailable/)
 })


### PR DESCRIPTION
## Pull Request Type
<!-- Please select what type of pull request this is: [x] -->
- [ ] Bugfix
- [x] Feature Implementation
- [ ] Documentation
- [ ] Other

## Related issue
<!-- Please link the issue your pull request is referring to. -->
<!-- If this pull request fully resolves the relevant issue, put "closes" before the issue number. -->
<!-- Example: "closes #123456". -->

N/A

## Description
<!-- Please write a clear and concise description of what the pull request does. -->

Nightly releases now reuse the draft release-note generator to collect noteworthy pull requests since the latest stable release. The generated changelog is placed in a collapsed `<details>` block below the existing nightly warning and commit reference.

The workflow selects the latest stable release tag that is an ancestor of the nightly commit. A nightly-specific empty state allows publishing to continue when there are no noteworthy changes, while draft release generation remains strict.

## Screenshots <!-- If appropriate -->
<!-- Please add before and after screenshots if there is a visible change. -->

N/A

## Release note category
<!-- Select exactly one category. Every pull request must select one. -->
<!-- release-note-category:start -->
- [x] Not noteworthy
- [ ] Highlights
- [ ] More improvements
- [ ] Fixed bugs
<!-- release-note-category:end -->

## Release note
<!-- Required unless "Not noteworthy" is selected. -->
<!-- Write one concise, user-facing entry without a leading bullet. -->
<!-- release-note:start -->
Nightly release pages now include a collapsed changelog of noteworthy changes since the latest stable release.
<!-- release-note:end -->

## Release note images
<!-- Optional. Paste one or more Markdown images or HTML image tags here. -->
<!-- The release notes will use an HTML image tag and limit images taller than 300 pixels. -->
<!-- release-note-image:start -->

<!-- release-note-image:end -->

## Testing
<!-- How can reviewers verify that the PR produces correct results? -->
<!-- Please provide instructions so that others can ensure that your pull request would produce correct results. For examples see, https://github.com/FreeTubeApp/FreeTube/pull/5743, https://github.com/FreeTubeApp/FreeTube/pull/7349, https://github.com/FreeTubeApp/FreeTube/pull/5125, https://github.com/FreeTubeApp/FreeTube/pull/7338 -->

- Run `pnpm test:unit`.
- Run `pnpm exec eslint --config eslint.config.mjs _scripts/releaseNotes.mjs .github/workflows/build.yml`.
- Generate nightly notes against an existing stable tag and confirm the resulting changelog contains the expected categorized pull requests.
- Confirm the generated release body keeps the changelog inside a `<details>` element without the `open` attribute.

## Desktop
<!-- Please complete the following information-->
- **OS:** Arch Linux
- **OS Version:** Rolling release
- **OpenTubeX version:** development

## Additional context
<!-- Add any other context about the pull request here. -->

The release warning and commit reference remain visible when the changelog is collapsed.