### PR TITLE
Fix tab title and loading placeholder transitions

### DIFF
--- a/e2e/tests/offline/subscriptions-refresh.spec.mjs
+++ b/e2e/tests/offline/subscriptions-refresh.spec.mjs
@@ -107,6 +107,7 @@ test.describe('incremental subscription feed refresh', () => {
     await expect(page.getByText('Cached video 0', { exact: true })).toBeVisible()
 
     await page.getByRole('button', { name: /Refresh Videos/ }).click()
+    await expect(page.locator('.tab.active .loadingDot')).toBeVisible()
 
     // Channel 0 is done well before the pending channel 1, which keeps its
     // cached entry in the meantime
@@ -116,6 +117,7 @@ test.describe('incremental subscription feed refresh', () => {
     await expect(page.locator('.tabsProgressBar')).toBeVisible()
 
     await expect(page.getByText('Fresh video 1', { exact: true })).toBeVisible({ timeout: 30_000 })
+    await expect(page.locator('.tab.active .loadingDot')).toHaveCount(0)
   })
 })
 

--- a/e2e/tests/offline/tabs.spec.mjs
+++ b/e2e/tests/offline/tabs.spec.mjs
@@ -140,8 +140,10 @@ test.describe('tab bar', () => {
       })
     }, { videoId })
 
-    await expect(page.locator(`.tab[data-tab-id="${watchTab.id}"] .loadingDot`)).toBeVisible()
-    await page.waitForTimeout(500)
+    const tab = page.locator(`.tab[data-tab-id="${watchTab.id}"]`)
+    await expect(tab.locator('.loadingDot')).toBeVisible()
+    await expect(tab.locator('.loadingDot')).toHaveCount(0)
+    await expect(tab.locator('.tabAvatar')).toBeVisible()
 
     const states = await page.evaluate(
       tabId => window.__watchTabIconStates.filter(state => state.id === tabId),

--- a/e2e/tests/offline/tabs.spec.mjs
+++ b/e2e/tests/offline/tabs.spec.mjs
@@ -55,8 +55,40 @@ test.describe('tab bar', () => {
     await expect(page.locator(sel.tabs).nth(1).locator('[data-icon="rss"]')).toBeVisible()
   })
 
+  test('fixed internal routes use their page title before mounting', async ({ page }) => {
+    const fixedRoutes = [
+      ['/subscriptions', 'Subscriptions'],
+      ['/subscribedchannels', 'Channel List'],
+      ['/trending', 'Trending'],
+      ['/popular', 'Most Popular'],
+      ['/userplaylists', 'Your Playlists'],
+      ['/history', 'History'],
+      ['/stats', 'Stats'],
+      ['/settings', 'Settings'],
+      ['/about', 'About'],
+      ['/settings/profile', 'Profile Manager']
+    ]
+    const tabs = await page.evaluate(async (routes) => {
+      return await Promise.all(routes.map(route => (
+        window.ftElectron.tabs.create({
+          route,
+          makeActive: false,
+          lazyLoad: true
+        })
+      )))
+    }, [...fixedRoutes.map(([route]) => route), '/channel/channel-id', '/'])
+
+    expect(tabs.map(tab => tab.title)).toEqual([
+      ...fixedRoutes.map(([, title]) => title),
+      '/channel/channel-id',
+      '/'
+    ])
+  })
+
   test('uses the matching app icon when the route changes', async ({ page }) => {
     await goTo(page, 'settings')
+    await page.waitForTimeout(100)
+    expect(await page.locator(`${sel.activeTab} .loadingDot`).count()).toBe(0)
     await expect(page.locator(sel.activeTab).locator('[data-icon="sliders"]')).toBeVisible()
 
     await goTo(page, 'history')
@@ -73,6 +105,52 @@ test.describe('tab bar', () => {
 
     await expect(tab.locator('[data-icon="clapperboard"]')).toBeVisible()
     await expect(tab.locator('[data-icon="play"]')).toHaveCount(0)
+  })
+
+  test('does not show a cached watch avatar before its loading indicator settles', async ({ page }) => {
+    const videoId = 'jNQXAC9IVRw'
+    await page.evaluate(({ videoId }) => {
+      const store = document.querySelector('#app').__vue_app__.config.globalProperties.$store
+      store.commit('setVideoAvatar', {
+        videoId,
+        avatar: 'data:image/png;base64,iVBORw0KGgo='
+      })
+
+      window.__watchTabIconStates = []
+      const recordIconStates = () => {
+        for (const tab of document.querySelectorAll('.tab')) {
+          window.__watchTabIconStates.push({
+            id: tab.dataset.tabId,
+            loading: tab.querySelector('.loadingDot') != null,
+            avatar: tab.querySelector('.tabAvatar') != null
+          })
+        }
+      }
+      new MutationObserver(recordIconStates).observe(
+        document.querySelector('.tabsContainer'),
+        { childList: true, subtree: true }
+      )
+    }, { videoId })
+
+    const watchTab = await page.evaluate(({ videoId }) => {
+      return window.ftElectron.tabs.create({
+        route: `/watch/${videoId}`,
+        title: 'Cached video',
+        makeActive: true
+      })
+    }, { videoId })
+
+    await expect(page.locator(`.tab[data-tab-id="${watchTab.id}"] .loadingDot`)).toBeVisible()
+    await page.waitForTimeout(500)
+
+    const states = await page.evaluate(
+      tabId => window.__watchTabIconStates.filter(state => state.id === tabId),
+      watchTab.id
+    )
+    const lastLoadingIndex = states.findLastIndex(state => state.loading)
+
+    expect(lastLoadingIndex).toBeGreaterThanOrEqual(0)
+    expect(states.slice(0, lastLoadingIndex + 1).some(state => state.avatar)).toBe(false)
   })
 
   test('Ctrl+T opens and Ctrl+W closes a tab', async ({ page }) => {
@@ -713,6 +791,22 @@ test.describe('localized tab titles', () => {
     await expect(page.locator(sel.tabs)).toHaveCount(2)
     await expect(page.locator(sel.activeTab)).toContainText('Abos')
     await expect(page.locator(sel.activeTab)).not.toContainText(/\/subscriptions|Subscriptions\.Subscriptions/)
+  })
+})
+
+test.describe('custom default page', () => {
+  test.use({ seed: { settings: { landingPage: 'history' } } })
+
+  test('uses the configured route and title for a new tab', async ({ page }) => {
+    const tab = await page.evaluate(async () => {
+      return await window.ftElectron.tabs.create({
+        makeActive: false,
+        lazyLoad: true
+      })
+    })
+
+    expect(tab.route.fullPath).toBe('/history')
+    expect(tab.title).toBe('History')
   })
 })
 

--- a/e2e/tests/offline/watch-error-navigation.spec.mjs
+++ b/e2e/tests/offline/watch-error-navigation.spec.mjs
@@ -205,6 +205,36 @@ test('an IP-block error keeps the title passed to a background watch tab', async
   await expect(backgroundTab).not.toContainText('/watch/jNQXAC9IVRw')
 })
 
+test('an unresolved generic Watch title falls back to the route placeholder', async ({ app, page }) => {
+  await mockBlockedVideo({
+    app,
+    page,
+    omitVideoMetadata: true
+  })
+
+  await page.locator(sel.searchInput).fill('https://www.youtube.com/watch?v=jNQXAC9IVRw')
+  await page.locator(sel.searchInput).press('Enter')
+  await expect(page).toHaveURL(/#\/watch\/jNQXAC9IVRw/)
+  await expect(page.locator('.errorMessage')).toContainText('blocked', { timeout: 30_000 })
+
+  const activeTab = page.locator('.tabBar .tab.active')
+  await page.evaluate(() => {
+    const store = document.querySelector('#app').__vue_app__.config.globalProperties.$store
+    const tab = store.getters.getActiveTab
+    store.commit('setTabContentTitle', {
+      tabId: tab.id,
+      title: 'Watch',
+      resolveHistoryEntry: false
+    })
+  })
+  await expect(activeTab).toContainText('Watch')
+
+  await page.keyboard.press('Control+R')
+  await expect(page.locator('.errorMessage')).toContainText('blocked', { timeout: 30_000 })
+  await expect(activeTab).toContainText('/watch/jNQXAC9IVRw')
+  await expect(activeTab).not.toContainText('Watch')
+})
+
 test('a late video response cannot replace the title after going back', async ({ app, page }) => {
   let releaseMetadataResponse
   let notifyMetadataRequested

--- a/e2e/tests/offline/watch-error-navigation.spec.mjs
+++ b/e2e/tests/offline/watch-error-navigation.spec.mjs
@@ -187,6 +187,24 @@ test('watch page IP-block error does not break later navigation', async ({ app, 
   }
 })
 
+test('an IP-block error keeps the title passed to a background watch tab', async ({ app, page }) => {
+  await mockBlockedVideo({
+    app,
+    page,
+    omitVideoMetadata: true
+  })
+
+  await goTo(page, 'history')
+  await page.getByText('Blocked test video').click({ button: 'middle' })
+
+  const backgroundTab = page.locator(sel.tabs).nth(1)
+  const backgroundContent = page.locator('.tabContent[aria-hidden="true"]').first()
+  await expect(backgroundTab).toContainText('Blocked test video')
+  await expect(backgroundContent.locator('.errorMessage')).toContainText('blocked', { timeout: 30_000 })
+  await expect(backgroundTab).toContainText('Blocked test video')
+  await expect(backgroundTab).not.toContainText('/watch/jNQXAC9IVRw')
+})
+
 test('a late video response cannot replace the title after going back', async ({ app, page }) => {
   let releaseMetadataResponse
   let notifyMetadataRequested

--- a/src/internalRoutes.js
+++ b/src/internalRoutes.js
@@ -1,0 +1,23 @@
+const FIXED_INTERNAL_ROUTE_TITLES = Object.freeze({
+  '/subscriptions': 'Subscriptions',
+  '/subscribedchannels': 'Channel List',
+  '/trending': 'Trending',
+  '/popular': 'Most Popular',
+  '/userplaylists': 'Your Playlists',
+  '/history': 'History',
+  '/stats': 'Stats',
+  '/settings': 'Settings',
+  '/about': 'About',
+  '/settings/profile': 'Profile Manager'
+})
+
+/**
+ * Returns the title used while a fixed internal route is loading.
+ * Parameterized routes intentionally keep their URL as the placeholder.
+ *
+ * @param {string} path
+ * @returns {string | null}
+ */
+export function getFixedInternalRouteTitle(path) {
+  return FIXED_INTERNAL_ROUTE_TITLES[path] ?? null
+}

--- a/src/main/index.js
+++ b/src/main/index.js
@@ -2061,7 +2061,7 @@ function runApp() {
         if (windowStartupUrl != null) {
           tabManager.createTab({ url: windowStartupUrl, makeActive: true })
         } else {
-          tabManager.createTab({ url: ROOT_APP_URL, makeActive: true })
+          await tabManager.createTabWithPreference({ makeActive: true })
         }
       }
 

--- a/src/main/tabs/TabManager.js
+++ b/src/main/tabs/TabManager.js
@@ -4,6 +4,7 @@ import { mkdir, readFile, unlink, writeFile } from 'fs/promises'
 import { join } from 'path'
 import { IpcChannels } from '../../constants.js'
 import * as baseHandlers from '../../datastores/handlers/base.js'
+import { getFixedInternalRouteTitle } from '../../internalRoutes.js'
 import {
   clearTabSession,
   replaceAllTabSessions,
@@ -250,8 +251,8 @@ export class TabManager {
    * @returns {string}
    */
   static formatDefaultTabTitle(url) {
-    const route = TabManager.getOpenTubeXRoute(url)
-    return route || '/'
+    const route = TabManager.getRouteFromUrl(url)
+    return getFixedInternalRouteTitle(route.path) ?? route.fullPath
   }
 
   /**
@@ -777,7 +778,7 @@ export class TabManager {
       lastActiveAt: Date.now(),
       isPlaying: false,
       isPinned: Boolean(isPinned),
-      isLoading: shouldMount,
+      isLoading: shouldMount && getFixedInternalRouteTitle(location.route.path) === null,
       loadingSources: new Set(shouldMount ? [TAB_LOADING_SOURCE_MOUNT] : []),
       color: TabManager.normalizeTabColor(color),
       previewDataUrl: restoredPreviewDataUrl,
@@ -1312,7 +1313,11 @@ export class TabManager {
    * @returns {boolean}
    */
   _getTabLoadingState(tab) {
-    return this._getTabLoadingSources(tab).size > 0 || tab.loadState === 'mounting'
+    const loadingSources = this._getTabLoadingSources(tab)
+    if (getFixedInternalRouteTitle(tab.route.path) !== null) {
+      return loadingSources.has(TAB_LOADING_SOURCE_RENDERER)
+    }
+    return loadingSources.size > 0 || tab.loadState === 'mounting'
   }
 
   /**
@@ -1983,7 +1988,7 @@ export class TabManager {
       lastActiveAt: Date.now(),
       isPlaying: false,
       isPinned: snapshot.isPinned === true,
-      isLoading: true,
+      isLoading: getFixedInternalRouteTitle(snapshot.route.path) === null,
       loadingSources: new Set([TAB_LOADING_SOURCE_MOUNT]),
       color: TabManager.normalizeTabColor(snapshot.color),
       previewDataUrl: snapshot.previewDataUrl ?? null,

--- a/src/renderer/components/TabContent/TabContent.vue
+++ b/src/renderer/components/TabContent/TabContent.vue
@@ -149,6 +149,7 @@ watch(
     disposalNotified = false
     pictureInPictureExitRequested = false
     await nextTick()
+    updateLoaderState()
     if (mountRevision > acknowledgedMountRevision) {
       acknowledgedMountRevision = mountRevision
       tabRuntimeRegistry.markMounted(props.tab.id, mountRevision)
@@ -214,12 +215,16 @@ function scheduleLoaderUpdate() {
 
   loaderAnimationFrameId = window.requestAnimationFrame(() => {
     loaderAnimationFrameId = null
-    navigation.setLoadingSource(
-      props.tab.id,
-      TAB_LOADER_LOADING_SOURCE,
-      tabContentRef.value?.querySelector(TAB_LOADER_SELECTOR) != null
-    )
+    updateLoaderState()
   })
+}
+
+function updateLoaderState() {
+  navigation.setLoadingSource(
+    props.tab.id,
+    TAB_LOADER_LOADING_SOURCE,
+    tabContentRef.value?.querySelector(TAB_LOADER_SELECTOR) != null
+  )
 }
 </script>
 

--- a/src/renderer/helpers/strings.js
+++ b/src/renderer/helpers/strings.js
@@ -2,7 +2,7 @@ import i18n from '../i18n/index'
 
 const WINDOW_TITLE_TRANSLATION_KEYS = {
   Subscriptions: 'Subscriptions.Subscriptions',
-  Channels: 'Channels.Title',
+  'Channel List': 'Channels.Title',
   Trending: 'Trending.Trending',
   'Most Popular': 'Most Popular',
   'Your Playlists': 'User Playlists.Your Playlists',
@@ -10,7 +10,7 @@ const WINDOW_TITLE_TRANSLATION_KEYS = {
   Stats: 'Stats.Stats',
   Settings: 'Settings.Settings',
   About: 'About.About',
-  'Profile Settings': 'Profile.Profile Settings',
+  'Profile Manager': 'Profile.Profile Manager',
   Playlist: 'Playlist.Playlist'
 }
 

--- a/src/renderer/router/index.js
+++ b/src/renderer/router/index.js
@@ -1,5 +1,6 @@
-import { defineAsyncComponent } from 'vue'
+import { defineAsyncComponent, h } from 'vue'
 import { createRouter, createWebHashHistory } from 'vue-router'
+import { getFixedInternalRouteTitle } from '../../internalRoutes'
 import Subscriptions from '../views/Subscriptions/Subscriptions.vue'
 import SubscribedChannels from '../views/SubscribedChannels/SubscribedChannels.vue'
 import Trending from '../views/Trending/Trending.vue'
@@ -18,7 +19,17 @@ import Post from '../views/Post.vue'
 // instead of `RouterView` resolving them during navigation, so they must be
 // wrapped in `defineAsyncComponent` rather than passing the raw import function
 // to `component`.
-const Watch = defineAsyncComponent(() => import('../views/Watch/Watch.vue'))
+const AsyncRouteLoadingIndicator = {
+  render: () => h('span', {
+    hidden: true,
+    'data-tab-loading-indicator': ''
+  })
+}
+const Watch = defineAsyncComponent({
+  loader: () => import('../views/Watch/Watch.vue'),
+  loadingComponent: AsyncRouteLoadingIndicator,
+  delay: 0
+})
 const Settings = defineAsyncComponent(() => import('../views/Settings/Settings.vue'))
 const ProfileSettings = defineAsyncComponent(() => import('../views/ProfileSettings/ProfileSettings.vue'))
 const About = defineAsyncComponent(() => import('../views/About/About.vue'))
@@ -38,7 +49,7 @@ export const routes = [
     path: '/subscriptions',
     name: 'subscriptions',
     meta: {
-      title: 'Subscriptions',
+      title: getFixedInternalRouteTitle('/subscriptions'),
       hasResizableThumbnails: true
     },
     component: Subscriptions
@@ -47,7 +58,7 @@ export const routes = [
     path: '/subscribedchannels',
     name: 'subscribedChannels',
     meta: {
-      title: 'Channels'
+      title: getFixedInternalRouteTitle('/subscribedchannels')
     },
     component: SubscribedChannels
   },
@@ -56,7 +67,7 @@ export const routes = [
         path: '/trending',
         name: 'trending',
         meta: {
-          title: 'Trending',
+          title: getFixedInternalRouteTitle('/trending'),
           hasResizableThumbnails: true
         },
         component: Trending
@@ -66,7 +77,7 @@ export const routes = [
     path: '/popular',
     name: 'popular',
     meta: {
-      title: 'Most Popular',
+      title: getFixedInternalRouteTitle('/popular'),
       hasResizableThumbnails: true
     },
     component: Popular
@@ -75,7 +86,7 @@ export const routes = [
     path: '/userplaylists',
     name: 'userPlaylists',
     meta: {
-      title: 'Your Playlists',
+      title: getFixedInternalRouteTitle('/userplaylists'),
       hasResizableThumbnails: true
     },
     component: UserPlaylists
@@ -84,7 +95,7 @@ export const routes = [
     path: '/history',
     name: 'history',
     meta: {
-      title: 'History',
+      title: getFixedInternalRouteTitle('/history'),
       hasResizableThumbnails: true
     },
     component: History
@@ -93,7 +104,7 @@ export const routes = [
     path: '/stats',
     name: 'stats',
     meta: {
-      title: 'Stats'
+      title: getFixedInternalRouteTitle('/stats')
     },
     component: Stats
   },
@@ -101,7 +112,7 @@ export const routes = [
     path: '/settings',
     name: 'settings',
     meta: {
-      title: 'Settings'
+      title: getFixedInternalRouteTitle('/settings')
     },
     component: Settings
   },
@@ -109,7 +120,7 @@ export const routes = [
     path: '/about',
     name: 'about',
     meta: {
-      title: 'About'
+      title: getFixedInternalRouteTitle('/about')
     },
     component: About
   },
@@ -117,7 +128,7 @@ export const routes = [
     path: '/settings/profile',
     name: 'profileSettings',
     meta: {
-      title: 'Profile Settings'
+      title: getFixedInternalRouteTitle('/settings/profile')
     },
     component: ProfileSettings
   },

--- a/src/renderer/tabs/TabNavigationService.js
+++ b/src/renderer/tabs/TabNavigationService.js
@@ -2,6 +2,7 @@ import { computed, nextTick } from 'vue'
 import { START_LOCATION } from 'vue-router'
 
 import packageDetails from '../../../package.json'
+import { getFixedInternalRouteTitle } from '../../internalRoutes'
 import { translateWindowTitle } from '../helpers/strings'
 import { runPendingViewTransition } from '../helpers/viewTransitions'
 import { cloneRoute, normalizeRoute } from '../store/modules/tabs'
@@ -256,11 +257,11 @@ export class TabNavigationService {
       // pages replace this route placeholder once their content has loaded.
       // historyIndex still points at the outgoing entry here, so don't let the
       // placeholder overwrite that entry's title.
-      this.setTitle(tabId, to.fullPath, { skipHistoryEntry: true })
+      this.setTitle(tabId, routePlaceholderTitle(to), { skipHistoryEntry: true })
     }
 
     this.saveScroll(tabId)
-    const loadingToken = preserveContentTitle
+    const loadingToken = preserveContentTitle || getFixedInternalRouteTitle(route.path) !== null
       ? null
       : this.startRouteLoading(tabId)
     let navigationCommitted = false
@@ -472,9 +473,23 @@ export class TabNavigationService {
     }
 
     const tab = this.store.getters.getTabById(tabId)
+    const entry = tab?.history[tab.historyIndex]
+    // Watch publishes its URL while metadata is unresolved. Keep a title that
+    // the opener already supplied (or that an earlier response resolved),
+    // especially when a background request ends in an IP-block error.
+    if (
+      tab?.route.path.startsWith('/watch/') &&
+      title === tab.route.fullPath &&
+      entry?.titlePending !== true &&
+      typeof tab.contentTitle === 'string' &&
+      tab.contentTitle.length > 0 &&
+      tab.contentTitle !== title
+    ) {
+      return
+    }
     const resolvedPendingEntry = !skipHistoryEntry &&
       resolveHistoryEntry &&
-      tab?.history[tab.historyIndex]?.titlePending === true
+      entry?.titlePending === true
     this.store.commit('setTabContentTitle', {
       tabId,
       title,
@@ -641,6 +656,13 @@ function routeTitle(route) {
   return typeof route.meta?.title === 'string'
     ? translateWindowTitle(route.meta.title) ?? route.meta.title
     : route.fullPath
+}
+
+function routePlaceholderTitle(route) {
+  const title = getFixedInternalRouteTitle(route.path)
+  return title === null
+    ? route.fullPath
+    : translateWindowTitle(title) ?? title
 }
 
 function isUnresolvedWatchEntry(tab, route) {

--- a/src/renderer/views/Subscriptions/Subscriptions.vue
+++ b/src/renderer/views/Subscriptions/Subscriptions.vue
@@ -178,6 +178,7 @@
         <div
           v-if="currentTabRefreshing"
           class="tabsProgressBar"
+          data-tab-loading-indicator
           :style="{ inlineSize: refreshProgressPercentage + '%' }"
         />
       </div>

--- a/src/renderer/views/Watch/Watch.js
+++ b/src/renderer/views/Watch/Watch.js
@@ -1126,7 +1126,7 @@ export default defineComponent({
         this.tabRoute.query.short === 'true'
       this.resetVideoState({
         preserveTitle,
-        placeholderTitle: videoIdChanged ? this.getRoutePlaceholderTitle() : '',
+        placeholderTitle: videoIdChanged ? this.getPendingVideoTitle() : '',
         preserveShortsPanels,
       })
 
@@ -1152,8 +1152,12 @@ export default defineComponent({
       }
     },
 
-    getRoutePlaceholderTitle: function () {
-      return this.tabRoute.fullPath
+    getPendingVideoTitle: function () {
+      const tab = this.$store.getters.getTabById(this.tabId)
+      const title = tab?.contentTitle
+      return typeof title === 'string' && title.length > 0 && title !== this.tabRoute.fullPath
+        ? title
+        : this.tabRoute.fullPath
     },
 
     resetVideoState: function ({
@@ -3566,7 +3570,7 @@ export default defineComponent({
 
     updateTitle: function () {
       this.setTabTitle(
-        this.videoTitle || this.getRoutePlaceholderTitle(),
+        this.videoTitle || this.getPendingVideoTitle(),
         { resolveHistoryEntry: this.hasResolvedVideoTitle }
       )
     },

--- a/src/renderer/views/Watch/Watch.js
+++ b/src/renderer/views/Watch/Watch.js
@@ -1154,8 +1154,12 @@ export default defineComponent({
 
     getPendingVideoTitle: function () {
       const tab = this.$store.getters.getTabById(this.tabId)
+      const entry = tab?.history[tab.historyIndex]
       const title = tab?.contentTitle
-      return typeof title === 'string' && title.length > 0 && title !== this.tabRoute.fullPath
+      return entry?.titlePending !== true &&
+        typeof title === 'string' &&
+        title.length > 0 &&
+        title !== this.tabRoute.fullPath
         ? title
         : this.tabRoute.fullPath
     },


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Make sure to follow the contributing guidelines. -->
<!-- Important note, we may remove your pull request if you do not use this provided PR template correctly. -->

## Pull Request Type
<!-- Please select what type of pull request this is: [x] -->
- [x] Bugfix
- [ ] Feature Implementation
- [ ] Documentation
- [ ] Other

## Related issue
<!-- Please link the issue your pull request is referring to. -->
<!-- If this pull request fully resolves the relevant issue, put "closes" before the issue number. -->
<!-- Example: "closes #123456". -->

None.

## Description
<!-- Please write a clear and concise description of what the pull request does. -->

Fixed internal tabs now receive their page title and icon immediately instead of briefly displaying route URLs or synthetic loading indicators. Fixed-route metadata is shared between the main and renderer processes, including the corrected Channel List and Profile Manager titles, while real page loaders such as subscription refreshes remain visible in the tab bar.

Watch tabs now publish their loader before completing the mount handshake, preventing cached channel avatars from flickering before the loading indicator. Background Watch tabs also retain caller-provided video titles through successful loading races and IP-block/error responses instead of reverting to `/watch/...`.

Startup now creates the configured landing route directly, while the bare `/` route remains unmapped.

## Screenshots <!-- If appropriate -->
<!-- Please add before and after screenshots if there is a visible change. -->

Not applicable; these fixes remove brief transitional states.

## Release note category
<!-- Select exactly one category. Every pull request must select one. -->
<!-- release-note-category:start -->
- [ ] Not noteworthy
- [ ] Highlights
- [ ] More improvements
- [x] Fixed bugs
<!-- release-note-category:end -->

## Release note
<!-- Required unless "Not noteworthy" is selected. -->
<!-- Write one concise, user-facing entry without a leading bullet. -->
<!-- release-note:start -->
Fixed tab titles, icons, and loading indicators briefly showing incorrect placeholder states.
<!-- release-note:end -->

## Release note images
<!-- Optional. Paste one or more Markdown images or HTML image tags here. -->
<!-- The release notes will use an HTML image tag and limit images taller than 300 pixels. -->
<!-- release-note-image:start -->

<!-- release-note-image:end -->

## Testing
<!-- How can reviewers verify that the PR produces correct results? -->
<!-- Please provide instructions so that others can ensure that your pull request would produce correct results. For examples see, https://github.com/FreeTubeApp/FreeTube/pull/5743, https://github.com/FreeTubeApp/FreeTube/pull/7349, https://github.com/FreeTubeApp/FreeTube/pull/5125, https://github.com/FreeTubeApp/FreeTube/pull/7338 -->

- `pnpm run test:unit`
- `xvfb-run -a -s "-screen 0 1920x1080x24" pnpm exec playwright test -c e2e/playwright.config.mjs --project=offline e2e/tests/offline/tabs.spec.mjs e2e/tests/offline/watch-error-navigation.spec.mjs`
- `xvfb-run -a -s "-screen 0 1920x1080x24" pnpm exec playwright test -c e2e/playwright.config.mjs --project=offline e2e/tests/offline/tabs.spec.mjs e2e/tests/offline/subscriptions-refresh.spec.mjs`
- ESLint and the E2E production package completed successfully.

To verify manually:
1. Open fixed internal pages and confirm their title and page icon appear immediately.
2. Refresh subscription feeds and confirm the real loading indicator remains visible.
3. Middle-click a known video and confirm its background tab retains the video title during loading and IP-block errors.
4. Open a previously visited video and confirm its cached channel avatar does not flicker before the Watch loading indicator.

## Desktop
<!-- Please complete the following information-->
- **OS:** Arch Linux with KDE Plasma (Wayland)
- **OS Version:** Rolling release
- **OpenTubeX version:** 0.30.1 / development

## Additional context
<!-- Add any other context about the pull request here. -->

The branch contains one GPG-signed commit. Review requests are managed externally and are intentionally not triggered from this task.