### PR TITLE
Show subscription refresh progress in a toast

### DIFF
--- a/e2e/tests/offline/subscriptions-refresh.spec.mjs
+++ b/e2e/tests/offline/subscriptions-refresh.spec.mjs
@@ -271,6 +271,11 @@ test.describe('cancelling an automatic subscription feed refresh', () => {
     const refreshToast = page.getByTestId('subscription-refresh-toast')
     await expect(refreshToast).toContainText('Refreshing subscription videos', { timeout: 10_000 })
     await expect(page.locator('.app > .progressBar')).toHaveCount(0)
+    expect(await refreshToast.evaluate((toast) => {
+      const { left, top, width, height } = toast.getBoundingClientRect()
+      const hit = document.elementFromPoint(left + width / 2, top + height / 2)
+      return hit !== null && !toast.contains(hit)
+    })).toBe(true)
 
     const indicator = refreshToast.locator('.progress-indicator')
     await expect(indicator).toBeVisible()

--- a/e2e/tests/offline/subscriptions-refresh.spec.mjs
+++ b/e2e/tests/offline/subscriptions-refresh.spec.mjs
@@ -117,6 +117,23 @@ test.describe('incremental subscription feed refresh', () => {
 
     await expect(page.getByText('Fresh video 1', { exact: true })).toBeVisible({ timeout: 30_000 })
   })
+
+  test('keeps a manual refresh in the progress toast after navigation', async ({ page }) => {
+    await routeFeeds(page, () => 8_000)
+    await goTo(page, 'subscriptions')
+
+    await page.getByRole('button', { name: /Refresh Videos/ }).click()
+    await expect(page.getByTestId('subscription-refresh-toast')).toHaveCount(0)
+    await goTo(page, 'settings')
+
+    const refreshToast = page.getByTestId('subscription-refresh-toast')
+    await expect(refreshToast).toContainText('Refreshing subscription videos')
+    await expect(page.locator('.app > .progressBar')).toHaveCount(0)
+
+    await page.keyboard.press('Escape')
+    await expect(refreshToast).toBeVisible()
+    await expect(refreshToast).toHaveCount(0, { timeout: 30_000 })
+  })
 })
 
 test.describe('subscription feed refresh controls', () => {
@@ -239,11 +256,36 @@ test.describe('cancelling an automatic subscription feed refresh', () => {
     seed: {
       settings: {
         ...commonSettings,
-        subscriptionFeedAutoRefreshInterval: '5000'
+        subscriptionFeedAutoRefreshInterval: '5000',
+        showToastTimeoutIndicator: false
       },
       profiles: [profileWith(channelCount)],
       subscriptionCache: Array.from({ length: channelCount }, (_, index) => cachedChannel(index))
     }
+  })
+
+  test('shows persistent progress in a toast without the global progress bar', async ({ page }) => {
+    await routeFeeds(page, (index) => index === 0 ? 0 : 8_000)
+    await goTo(page, 'settings')
+
+    const refreshToast = page.getByTestId('subscription-refresh-toast')
+    await expect(refreshToast).toContainText('Refreshing subscription videos', { timeout: 10_000 })
+    await expect(page.locator('.app > .progressBar')).toHaveCount(0)
+
+    const indicator = refreshToast.locator('.progress-indicator')
+    await expect(indicator).toBeVisible()
+    await expect.poll(async () => Number(await indicator.getAttribute('data-progress'))).toBeGreaterThan(0)
+    expect(Number(await indicator.getAttribute('data-progress'))).toBeLessThan(100)
+
+    await page.keyboard.press('Escape')
+    await expect(refreshToast).toBeVisible()
+
+    await page.evaluate(() => document.documentElement.requestFullscreen())
+    await expect(refreshToast).toHaveCount(0)
+    await page.evaluate(() => document.exitFullscreen())
+    await expect(refreshToast).toBeVisible()
+
+    await expect(refreshToast).toHaveCount(0, { timeout: 30_000 })
   })
 
   test('resets the timer instead of immediately refreshing again', async ({ page }) => {

--- a/src/preload/interface.js
+++ b/src/preload/interface.js
@@ -504,7 +504,7 @@ export default {
 
     /**
      * Listen for app-wide subscription refresh ownership changes.
-     * @param {(state: {inProgress: boolean, percentage: number}) => void} handler
+     * @param {(state: {inProgress: boolean, percentage: number, tab: string | null}) => void} handler
      * @returns {() => void}
      */
     onStateChanged: (handler) => {

--- a/src/renderer/App.vue
+++ b/src/renderer/App.vue
@@ -636,9 +636,6 @@ async function initializeManagedDownloadTools() {
   let toolProgressPercentage = 0
 
   function showToolProgress() {
-    if (subscriptionRefreshInProgress.value) {
-      return
-    }
     store.commit('setProgressBarPercentage', toolProgressPercentage)
     store.commit('setShowProgressBar', true)
   }
@@ -651,18 +648,6 @@ async function initializeManagedDownloadTools() {
     })
     showToolProgress()
   }
-
-  const stopWatchingSubscriptionRefresh = watch(subscriptionRefreshInProgress, inProgress => {
-    if (!downloadStarted) {
-      return
-    }
-
-    if (inProgress) {
-      store.commit('setShowProgressBar', false)
-    } else {
-      showToolProgress()
-    }
-  })
 
   const progressByBinary = {}
   const removeProgressListener = window.ftElectron.addYtDlpBinaryDownloadProgressListener(({ binary, percent, inProgress }) => {
@@ -683,9 +668,7 @@ async function initializeManagedDownloadTools() {
     const percentages = Object.values(progressByBinary)
     const combinedPercentage = percentages.reduce((sum, value) => sum + value, 0) / percentages.length
     toolProgressPercentage = Math.max(toolProgressPercentage, combinedPercentage)
-    if (!subscriptionRefreshInProgress.value) {
-      store.commit('setProgressBarPercentage', toolProgressPercentage)
-    }
+    store.commit('setProgressBarPercentage', toolProgressPercentage)
   })
 
   try {
@@ -703,9 +686,7 @@ async function initializeManagedDownloadTools() {
 
     if (failures.length === 0 && updatedBinaries.length > 0) {
       toolProgressPercentage = 100
-      if (!subscriptionRefreshInProgress.value) {
-        store.commit('setProgressBarPercentage', toolProgressPercentage)
-      }
+      store.commit('setProgressBarPercentage', toolProgressPercentage)
       const updatedTools = updatedBinaries.join(' and ')
       showToast({
         message: missingBinaries.length > 0
@@ -723,13 +704,10 @@ async function initializeManagedDownloadTools() {
       }
     }
   } finally {
-    stopWatchingSubscriptionRefresh()
     removeProgressListener()
     if (downloadStarted) {
       store.commit('setShowProgressBar', false)
-      if (!subscriptionRefreshInProgress.value) {
-        store.commit('setProgressBarPercentage', 0)
-      }
+      store.commit('setProgressBarPercentage', 0)
     }
   }
 }

--- a/src/renderer/App.vue
+++ b/src/renderer/App.vue
@@ -124,9 +124,12 @@
       v-if="showCreatePlaylistPrompt"
     />
     <FtContextMenu v-if="isElectron" />
-    <FtToast />
+    <FtToast
+      :show-subscription-refresh="presentedRoutePath !== '/subscriptions'"
+    />
     <FtProgressBar
       v-if="showProgressBar"
+      :progress="displayedProgressBarPercentage"
     />
     <div
       v-if="findbarVisible"
@@ -467,6 +470,9 @@ const localProgressBarVisible = computed(() => store.getters.getShowProgressBar)
 
 /** @type {import('vue').ComputedRef<boolean>} */
 const subscriptionRefreshInProgress = computed(() => store.getters.getSubscriptionFeedRefreshInProgress)
+const subscriptionRefreshUsesToast = computed(() => {
+  return store.getters.getShowSubscriptionRefreshToast
+})
 
 const presentedRoutePath = computed(() => {
   if (isElectron) {
@@ -478,7 +484,14 @@ const presentedRoutePath = computed(() => {
 const showProgressBar = computed(() => {
   // The Subscriptions view shows its own progress bar below the tab bar
   return localProgressBarVisible.value ||
-    (subscriptionRefreshInProgress.value && presentedRoutePath.value !== '/subscriptions')
+    (subscriptionRefreshInProgress.value &&
+      !subscriptionRefreshUsesToast.value &&
+      presentedRoutePath.value !== '/subscriptions')
+})
+const displayedProgressBarPercentage = computed(() => {
+  return localProgressBarVisible.value
+    ? store.getters.getProgressBarPercentage
+    : store.getters.getSubscriptionFeedRefreshProgress
 })
 
 const landingPage = computed(() => '/' + store.getters.getLandingPage)
@@ -1432,7 +1445,11 @@ function handleSubscriptionRefreshStarted(event) {
       // The owner still has its renderer-local progress state.
     }
   }
-  applySubscriptionAutoRefreshState({ inProgress: true, percentage: 0, tab: event.detail.tab })
+  applySubscriptionAutoRefreshState({
+    inProgress: true,
+    percentage: 0,
+    tab: event.detail.tab
+  })
 }
 
 /**
@@ -1440,7 +1457,7 @@ function handleSubscriptionRefreshStarted(event) {
  */
 function handleSubscriptionRefreshProgress(event) {
   const percentage = normalizeSubscriptionRefreshProgress(event.detail.percentage)
-  store.commit('setProgressBarPercentage', percentage)
+  store.commit('setSubscriptionFeedRefreshProgress', percentage)
 
   if (process.env.IS_ELECTRON) {
     window.ftElectron.subscriptionAutoRefresh.setProgress(
@@ -1534,12 +1551,12 @@ function applySubscriptionAutoRefreshState(state) {
   // it to every renderer. An older broadcast can therefore arrive after a newer
   // local update, so keep progress monotonic for the duration of this refresh.
   if (state.inProgress && wasInProgress && nextTab === previousTab) {
-    percentage = Math.max(store.getters.getProgressBarPercentage, percentage)
+    percentage = Math.max(store.getters.getSubscriptionFeedRefreshProgress, percentage)
   }
 
   store.commit('setSubscriptionFeedRefreshInProgress', state.inProgress)
   store.commit('setSubscriptionFeedRefreshTab', nextTab)
-  store.commit('setProgressBarPercentage', percentage)
+  store.commit('setSubscriptionFeedRefreshProgress', percentage)
 }
 
 /**

--- a/src/renderer/components/FtProgressBar/FtProgressBar.vue
+++ b/src/renderer/components/FtProgressBar/FtProgressBar.vue
@@ -13,11 +13,14 @@
 <script setup>
 import { computed } from 'vue'
 
-import store from '../../store/index'
-
-const progressBarPercentage = computed(() => {
-  return store.getters.getProgressBarPercentage
+const props = defineProps({
+  progress: {
+    type: Number,
+    required: true
+  }
 })
+
+const progressBarPercentage = computed(() => props.progress)
 </script>
 
 <style scoped src="./FtProgressBar.css" />

--- a/src/renderer/components/FtToast/FtToast.css
+++ b/src/renderer/components/FtToast/FtToast.css
@@ -55,6 +55,10 @@
   position: relative;
 }
 
+.toast-slot.persistent-slot {
+  pointer-events: none;
+}
+
 .toast {
   display: flex;
   align-items: center;

--- a/src/renderer/components/FtToast/FtToast.css
+++ b/src/renderer/components/FtToast/FtToast.css
@@ -157,6 +157,15 @@
   transition: none;
 }
 
+.toast.persistent {
+  cursor: progress;
+  pointer-events: none;
+}
+
+.progress-indicator :deep(.embeddedProgressPath) {
+  animation: none;
+}
+
 /* Tighten the leading padding so the thumbnail sits closer to the edge */
 .toast.hasImage {
   padding-inline-start: 10px;

--- a/src/renderer/components/FtToast/FtToast.vue
+++ b/src/renderer/components/FtToast/FtToast.vue
@@ -69,6 +69,39 @@
           />
         </div>
       </div>
+      <div
+        v-if="showSubscriptionRefreshToast"
+        key="subscription-refresh"
+        class="toast-slot"
+        data-testid="subscription-refresh-toast"
+      >
+        <div
+          class="toast persistent"
+          role="status"
+        >
+          <FontAwesomeIcon
+            :icon="['fas', 'sync']"
+            class="icon"
+            fixed-width
+          />
+          <p class="message">
+            {{ subscriptionRefreshMessage }}
+          </p>
+        </div>
+        <div
+          class="timeout-indicator-track"
+          aria-hidden="true"
+        >
+          <FtEmbeddedProgress
+            class="timeout-indicator progress-indicator"
+            :corner-radius="toastProgressRadius"
+            :end-arc-fraction="0.5"
+            :line-width="toastProgressLineWidth"
+            :progress="subscriptionRefreshProgress"
+            :start-arc-fraction="0.5"
+          />
+        </div>
+      </div>
     </TransitionGroup>
   </Teleport>
 </template>
@@ -76,6 +109,7 @@
 <script setup>
 import { FontAwesomeIcon } from '@fortawesome/vue-fontawesome'
 import { computed, nextTick, onBeforeUnmount, onMounted, reactive, ref } from 'vue'
+import { useI18n } from 'vue-i18n'
 import { normalizeToastPosition } from '../../constants/toastPosition'
 import { showToast, ToastEventBus } from '../../helpers/utils'
 import store from '../../store'
@@ -83,6 +117,14 @@ import FtEmbeddedProgress from '../FtEmbeddedProgress/FtEmbeddedProgress.vue'
 
 let idCounter = 0
 let removeShowToastListener = null
+const { t } = useI18n()
+
+const props = defineProps({
+  showSubscriptionRefresh: {
+    type: Boolean,
+    default: false
+  }
+})
 
 /**
  * @typedef Toast
@@ -119,6 +161,25 @@ const toastPosition = computed(() => {
 })
 /** @type {import('vue').ComputedRef<boolean>} */
 const showTimeoutIndicator = computed(() => store.getters.getShowToastTimeoutIndicator)
+const showSubscriptionRefreshToast = computed(() => {
+  return fullscreenTarget.value === null &&
+    props.showSubscriptionRefresh &&
+    store.getters.getShowSubscriptionRefreshToast &&
+    store.getters.getSubscriptionFeedRefreshInProgress
+})
+const subscriptionRefreshProgress = computed(() => store.getters.getSubscriptionFeedRefreshProgress)
+const subscriptionRefreshMessage = computed(() => {
+  switch (store.getters.getSubscriptionFeedRefreshTab) {
+    case 'shorts':
+      return t('Subscriptions.Refreshing Subscription Shorts')
+    case 'live':
+      return t('Subscriptions.Refreshing Subscription Live Streams')
+    case 'posts':
+      return t('Subscriptions.Refreshing Subscription Posts')
+    default:
+      return t('Subscriptions.Refreshing Subscription Videos')
+  }
+})
 const toastProgressRadius = computed(() => 12 * store.getters.getUiRoundness / 100)
 const toastProgressLineWidth = computed(() => Math.min(4, Math.max(2, 2 * store.getters.getUiRoundness / 100)))
 

--- a/src/renderer/components/FtToast/FtToast.vue
+++ b/src/renderer/components/FtToast/FtToast.vue
@@ -72,7 +72,7 @@
       <div
         v-if="showSubscriptionRefreshToast"
         key="subscription-refresh"
-        class="toast-slot"
+        class="toast-slot persistent-slot"
         data-testid="subscription-refresh-toast"
       >
         <div

--- a/src/renderer/components/FtTooltip/FtTooltip.css
+++ b/src/renderer/components/FtTooltip/FtTooltip.css
@@ -8,7 +8,7 @@
 }
 
 .text {
-  background-color: color-mix(in srgb, var(--primary-text-color) 80%, transparent);
+  background-color: color-mix(in srgb, var(--primary-text-color) 80%, var(--card-bg-color));
   border-radius: calc(20px * var(--ui-roundness));
   color: var(--card-bg-color);
   font-size: 1rem;
@@ -16,14 +16,13 @@
   margin: 0;
   max-inline-size: max-content;
   min-inline-size: 15em;
-  opacity: 0;
   padding-block: 10px;
   padding-inline: 8px;
   pointer-events: none;
   position: absolute;
   text-align: center;
   transition-duration: 275ms;
-  transition-property: opacity, transform, visibility;
+  transition-property: transform;
   visibility: hidden;
   z-index: 2;
 }
@@ -65,7 +64,6 @@
 
 .button:focus + .text,
 .button:hover + .text {
-  opacity: 1;
   visibility: visible;
 }
 
@@ -94,4 +92,9 @@
 .tooltip {
   display: inline-block;
   position: relative;
+}
+
+.tooltip:hover,
+.tooltip:focus-within {
+  z-index: 10;
 }

--- a/src/renderer/components/SubscriptionSettings/SubscriptionSettings.vue
+++ b/src/renderer/components/SubscriptionSettings/SubscriptionSettings.vue
@@ -12,6 +12,14 @@
           compact
           @change="updateFetchSubscriptionsAutomatically"
         />
+        <FtToggleSwitch
+          :label="$t('Settings.Subscription Settings.Show Feed Refresh Progress Notification')"
+          :default-value="showSubscriptionRefreshToast"
+          setting-key="showSubscriptionRefreshToast"
+          :tooltip="$t('Tooltips.Subscription Settings.Show Feed Refresh Progress Notification')"
+          compact
+          @change="updateShowSubscriptionRefreshToast"
+        />
         <FtSelect
           :placeholder="$t('Settings.Subscription Settings.Videos Auto Refresh Interval')"
           :value="subscriptionFeedAutoRefreshInterval"
@@ -125,6 +133,9 @@ const { t } = useI18n()
 /** @type {import('vue').ComputedRef<boolean>} */
 const fetchSubscriptionsAutomatically = computed(() => store.getters.getFetchSubscriptionsAutomatically)
 
+/** @type {import('vue').ComputedRef<boolean>} */
+const showSubscriptionRefreshToast = computed(() => store.getters.getShowSubscriptionRefreshToast)
+
 const subscriptionFeedAutoRefreshIntervalNames = computed(() => [
   t('Settings.General Settings.Avoid translation.Disabled'),
   '30 min',
@@ -150,6 +161,13 @@ const subscriptionFeedAutoRefreshIntervalValues = [
  */
 function updateFetchSubscriptionsAutomatically(value) {
   store.dispatch('updateFetchSubscriptionsAutomatically', value)
+}
+
+/**
+ * @param {boolean} value
+ */
+function updateShowSubscriptionRefreshToast(value) {
+  store.dispatch('updateShowSubscriptionRefreshToast', value)
 }
 
 /** @type {import('vue').ComputedRef<string>} */

--- a/src/renderer/helpers/subscriptions.js
+++ b/src/renderer/helpers/subscriptions.js
@@ -569,7 +569,7 @@ async function refreshSubscriptionVideosFromRemoteUnlocked({
   store.commit('setSubscriptionFeedRefreshInProgress', true)
   setSubscriptionRefreshProgress(0)
 
-  if (showStartToast) {
+  if (showStartToast && !store.getters.getShowSubscriptionRefreshToast) {
     showToastOnAllTabs(t('Subscriptions.Refreshing Subscription Videos'), AUTO_REFRESH_TOAST_DURATION, ['fas', 'sync'])
   }
 
@@ -673,7 +673,7 @@ async function refreshSubscriptionShortsFromRemoteUnlocked({
   store.commit('setSubscriptionFeedRefreshInProgress', true)
   setSubscriptionRefreshProgress(0)
 
-  if (showStartToast) {
+  if (showStartToast && !store.getters.getShowSubscriptionRefreshToast) {
     showToastOnAllTabs(t('Subscriptions.Refreshing Subscription Shorts'), AUTO_REFRESH_TOAST_DURATION, ['fas', 'sync'])
   }
 
@@ -763,7 +763,7 @@ async function refreshSubscriptionLiveFromRemoteUnlocked({
   store.commit('setSubscriptionFeedRefreshInProgress', true)
   setSubscriptionRefreshProgress(0)
 
-  if (showStartToast) {
+  if (showStartToast && !store.getters.getShowSubscriptionRefreshToast) {
     showToastOnAllTabs(t('Subscriptions.Refreshing Subscription Live Streams'), AUTO_REFRESH_TOAST_DURATION, ['fas', 'sync'])
   }
 
@@ -867,7 +867,7 @@ async function refreshSubscriptionPostsFromRemoteUnlocked({
   store.commit('setSubscriptionFeedRefreshInProgress', true)
   setSubscriptionRefreshProgress(0)
 
-  if (showStartToast) {
+  if (showStartToast && !store.getters.getShowSubscriptionRefreshToast) {
     showToastOnAllTabs(t('Subscriptions.Refreshing Subscription Posts'), AUTO_REFRESH_TOAST_DURATION, ['fas', 'sync'])
   }
 

--- a/src/renderer/store/modules/settings.js
+++ b/src/renderer/store/modules/settings.js
@@ -416,6 +416,7 @@ const state = {
   subscriptionShortsAutoRefreshInterval: '0',
   subscriptionLiveAutoRefreshInterval: '0',
   subscriptionPostsAutoRefreshInterval: '0',
+  showSubscriptionRefreshToast: true,
   settingsPassword: '',
   useDeArrowTitles: false,
   useDeArrowThumbnails: false,

--- a/src/renderer/store/modules/subscription-cache.js
+++ b/src/renderer/store/modules/subscription-cache.js
@@ -22,6 +22,7 @@ const state = {
   subscriptionCacheReady: false,
   subscriptionFeedRefreshInProgress: false,
   subscriptionFeedRefreshTab: null,
+  subscriptionFeedRefreshProgress: 0,
   subscriptionFeedLastRefreshTimestamp: null,
   subscriptionFeedNextAutoRefreshTimestamp: null,
   subscriptionShortsLastRefreshTimestamp: null,
@@ -36,6 +37,7 @@ const getters = {
   getSubscriptionCacheReady: (state) => state.subscriptionCacheReady,
   getSubscriptionFeedRefreshInProgress: (state) => state.subscriptionFeedRefreshInProgress,
   getSubscriptionFeedRefreshTab: (state) => state.subscriptionFeedRefreshTab,
+  getSubscriptionFeedRefreshProgress: (state) => state.subscriptionFeedRefreshProgress,
   getSubscriptionFeedLastRefreshTimestamp: (state) => state.subscriptionFeedLastRefreshTimestamp,
   getSubscriptionFeedNextAutoRefreshTimestamp: (state) => state.subscriptionFeedNextAutoRefreshTimestamp,
   getSubscriptionShortsLastRefreshTimestamp: (state) => state.subscriptionShortsLastRefreshTimestamp,
@@ -451,6 +453,9 @@ const mutations = {
   },
   setSubscriptionFeedRefreshTab(state, payload) {
     state.subscriptionFeedRefreshTab = payload
+  },
+  setSubscriptionFeedRefreshProgress(state, payload) {
+    state.subscriptionFeedRefreshProgress = payload
   },
   setSubscriptionFeedLastRefreshTimestamp(state, payload) {
     state.subscriptionFeedLastRefreshTimestamp = payload

--- a/src/renderer/views/Subscriptions/Subscriptions.vue
+++ b/src/renderer/views/Subscriptions/Subscriptions.vue
@@ -336,7 +336,7 @@ const currentTabRefreshing = computed(() => {
 
 /** @type {import('vue').ComputedRef<number>} */
 const refreshProgressPercentage = computed(() => {
-  return store.getters.getProgressBarPercentage
+  return store.getters.getSubscriptionFeedRefreshProgress
 })
 
 /** @type {import('vue').Ref<'videos' | 'shorts' | 'live' | 'community' | 'new' | null>} */

--- a/static/locales/en-US.yaml
+++ b/static/locales/en-US.yaml
@@ -798,6 +798,7 @@ Settings:
     Shorts Auto Refresh Interval: Shorts Auto Refresh Interval
     Live Auto Refresh Interval: Live Auto Refresh Interval
     Posts Auto Refresh Interval: Posts Auto Refresh Interval
+    Show Feed Refresh Progress Notification: Show feed refresh progress notification
     'Limit the number of videos displayed for each channel': 'Limit the number of videos displayed for each channel'
     To: To
     Confirm Before Unsubscribing: Confirm Before Unsubscribing
@@ -1702,6 +1703,7 @@ Tooltips:
     Show New Content Feed: Shows a New tab containing subscription feed items that were not present during the previous fetch.
     Show New Content Indicators: Shows a small dot beside subscription feed items that were not present during the previous fetch.
     Auto Refresh Interval: How often OpenTubeX automatically refreshes your subscription feed while the app is open.
+    Show Feed Refresh Progress Notification: Shows a persistent notification with live progress during subscription feed refreshes instead of using the global progress bar.
   Theme Settings:
     Hide Profile Selector in Header: Hides the profile selector from the top bar. The profile selector will be shown at the top of the Subscribed Channels page instead.
     Always Show Scrollbars: Keeps the scrollbars visible at all times. When disabled, they fade out shortly after you stop moving the mouse and reappear as soon as you move it again.


### PR DESCRIPTION
## Pull Request Type
- [ ] Bugfix
- [x] Feature Implementation
- [ ] Documentation
- [ ] Other

## Related issue

No related issue.

## Description

Adds a default-on subscription setting that shows feed refresh progress in a persistent notification when the user is outside the Subscriptions page. The notification uses the toast border as a live progress indicator, remains available even when normal toast timeout indicators are disabled, cannot be dismissed, is click-through, and stays hidden in fullscreen.

The Subscriptions page keeps its existing in-page progress indicator. Feed refresh progress is now stored separately from the global tool progress so yt-dlp, FFmpeg, and other operations can continue using the global progress bar independently. Settings help tooltips also receive an opaque, consistently raised surface so neighboring controls cannot affect readability.

## Screenshots

Not included.

## Release note category
<!-- release-note-category:start -->
- [ ] Not noteworthy
- [ ] Highlights
- [x] More improvements
- [ ] Fixed bugs
<!-- release-note-category:end -->

## Release note
<!-- release-note:start -->
Show subscription feed refresh progress in a persistent notification while browsing outside the Subscriptions page.
<!-- release-note:end -->

## Release note images
<!-- release-note-image:start -->
<img width="295" height="56" alt="image" src="https://github.com/user-attachments/assets/91f59166-c42d-49fe-8704-93c68ffa113d" />
<!-- release-note-image:end -->

## Testing

1. Configure a subscription feed auto-refresh interval.
2. Stay on the Subscriptions page and confirm refresh progress uses the in-page indicator without a notification.
3. Navigate to another page during either a manual or automatic feed refresh and confirm a persistent notification shows live border progress without the global progress bar.
4. Disable normal toast timeout indicators and confirm the refresh progress border remains visible.
5. Enter fullscreen and confirm the refresh notification hides, then exits fullscreen and reappears if the refresh is still running.
6. Confirm tool downloads can still display their independent global progress bar.

Automated checks run:

- ESLint and Stylelint
- 152 unit tests
- Production E2E packaging
- 27 focused Electron/Playwright E2E tests under Xvfb (`settings.spec.mjs` and `subscriptions-refresh.spec.mjs`)

## Desktop
- **OS:** Arch Linux
- **OS Version:** Rolling release, KDE Plasma on Wayland
- **OpenTubeX version:** 0.30.1

## Additional context

The notification mode is enabled by default and can be disabled from Subscription settings. Regular actionable toasts retain their existing fullscreen behavior.