### PR TITLE
Animate scroll mini player transitions

### DIFF
--- a/e2e/tests/network/watch.spec.mjs
+++ b/e2e/tests/network/watch.spec.mjs
@@ -160,6 +160,57 @@ test.describe('watch page', () => {
       .toBeGreaterThan(1)
   })
 
+  test('animates into and out of the scroll mini player', async ({ page, innertube }) => {
+    test.skip(!innertube.playback, 'needs real media streams')
+    await openVideo(page)
+
+    const video = await waitForPlaybackOrSkip(test, page)
+    await video.evaluate(element => element.pause())
+    await page.evaluate(() => {
+      document.documentElement.dataset.reducedMotion = 'no-preference'
+      window.scrollMiniPlayerAnimations = []
+      const nativeAnimate = Element.prototype.animate
+
+      Element.prototype.animate = function (keyframes, options) {
+        if (this.classList.contains('ftVideoPlayer')) {
+          const style = getComputedStyle(this)
+          window.scrollMiniPlayerAnimations.push({
+            className: this.className,
+            keyframes,
+            options,
+            position: style.position,
+            zIndex: style.zIndex
+          })
+        }
+        return nativeAnimate.call(this, keyframes, options)
+      }
+    })
+
+    const player = page.locator('.ftVideoPlayer')
+    await player.evaluate(element => {
+      const rect = element.getBoundingClientRect()
+      window.scrollTo(0, window.scrollY + rect.bottom)
+    })
+    await expect(player).toHaveClass(/scrollMiniPlayer/)
+    await expect.poll(() => page.evaluate(() => window.scrollMiniPlayerAnimations.length)).toBe(1)
+
+    await page.evaluate(() => window.scrollTo(0, 0))
+    await expect(player).not.toHaveClass(/scrollMiniPlayer/)
+    await expect.poll(() => page.evaluate(() => window.scrollMiniPlayerAnimations.length)).toBe(2)
+
+    const animations = await page.evaluate(() => window.scrollMiniPlayerAnimations)
+    for (const animation of animations) {
+      expect(animation.options.duration).toBe(300)
+      expect(animation.options.easing).toBe('cubic-bezier(0.4, 0, 0.2, 1)')
+      expect(animation.keyframes[0].transform).toContain('translate(')
+      expect(animation.keyframes[0].transform).toContain('scale(')
+      expect(animation.keyframes[1].transform).toBe('none')
+    }
+    expect(animations[1].className).toContain('scrollMiniPlayerAnimating')
+    expect(animations[1].position).toBe('relative')
+    expect(animations[1].zIndex).toBe('150')
+  })
+
   test('keeps the context menu open when the pointer leaves a playing video', async ({ page, innertube }) => {
     test.skip(!innertube.playback, 'needs real media streams')
     await openVideo(page)

--- a/src/renderer/components/ft-shaka-video-player/ft-shaka-video-player.css
+++ b/src/renderer/components/ft-shaka-video-player/ft-shaka-video-player.css
@@ -2810,6 +2810,11 @@
   isolation: isolate;
 }
 
+.ftVideoPlayer.scrollMiniPlayerAnimating {
+  position: relative;
+  z-index: 150;
+}
+
 .ftVideoPlayer.scrollMiniPlayer > .player,
 .ftVideoPlayer.scrollMiniPlayer > .vrCanvas {
   border-radius: calc(10px * var(--ui-roundness));

--- a/src/renderer/components/ft-shaka-video-player/ft-shaka-video-player.js
+++ b/src/renderer/components/ft-shaka-video-player/ft-shaka-video-player.js
@@ -4369,6 +4369,7 @@ export default defineComponent({
       scrollMiniPlaceholder,
       scrollMiniPlaceholderHeight,
       scrollMiniPlayerActive,
+      scrollMiniPlayerAnimating,
       scrollMiniPlayerStyle,
       scrollMiniPlayPauseVisible,
       scrollMiniResizeCorner,
@@ -8490,6 +8491,7 @@ export default defineComponent({
       silenceSkippingIndicatorMessage,
 
       scrollMiniPlayerActive,
+      scrollMiniPlayerAnimating,
       scrollMiniPlaceholderHeight,
       scrollMiniPlayerStyle,
       scrollMiniIsPaused,

--- a/src/renderer/components/ft-shaka-video-player/ft-shaka-video-player.vue
+++ b/src/renderer/components/ft-shaka-video-player/ft-shaka-video-player.vue
@@ -47,6 +47,7 @@
         shortsPaused: shortsPaused && hasLoaded,
         sixteenByNine: forceAspectRatio && !fullWindowEnabled && !scrollMiniPlayerActive,
         scrollMiniPlayer: scrollMiniPlayerActive,
+        scrollMiniPlayerAnimating,
         fullscreenMetadataOpen: showFullscreenMetadata,
         fullscreenTranscriptOpen: showFullscreenTranscript,
         fullscreenSponsorBlockOpen: showFullscreenSponsorBlock,

--- a/src/renderer/components/ft-shaka-video-player/opentubex/useScrollMiniPlayer.js
+++ b/src/renderer/components/ft-shaka-video-player/opentubex/useScrollMiniPlayer.js
@@ -414,7 +414,10 @@ export function useScrollMiniPlayer({ container, fullWindowEnabled, getUi, isAct
     ) return
 
     const nextRect = playerContainer.getBoundingClientRect()
-    if (nextRect.width === 0 || nextRect.height === 0) return
+    if (nextRect.width === 0 || nextRect.height === 0) {
+      scrollMiniPlayerAnimating.value = false
+      return
+    }
 
     const animation = playerContainer.animate([
       {

--- a/src/renderer/components/ft-shaka-video-player/opentubex/useScrollMiniPlayer.js
+++ b/src/renderer/components/ft-shaka-video-player/opentubex/useScrollMiniPlayer.js
@@ -1,6 +1,7 @@
 import { computed, nextTick, ref, watch } from 'vue'
 
 import store from '../../../store/index'
+import { isReducedMotionEnabled } from '../../../helpers/reducedMotion'
 import {
   animateScrollMiniPlayerBounce,
   clampScrollMiniPlayerRect,
@@ -32,6 +33,7 @@ const SCROLL_MINI_VOLUME_HIDE_MS = 1000
 const SCROLL_MINI_DRAG_HANDLE_CONTRAST_MS = 400
 const SCROLL_MINI_POINTER_REVEAL_SUPPRESS_MS = 250
 const SCROLL_MINI_POINTER_REVEAL_MIN_DISTANCE = 8
+const SCROLL_MINI_LAYOUT_ANIMATION_DURATION_MS = 300
 
 /**
  * OpenTubeX's scroll mini-player integration. Keeping this composable outside the
@@ -50,6 +52,7 @@ export function useScrollMiniPlayer({ container, fullWindowEnabled, getUi, isAct
   const scrollMiniVideoAspectRatio = ref(DEFAULT_ASPECT_RATIO)
   const scrollMiniPlayerEnabled = computed(() => store.getters.getScrollMiniPlayerEnabled)
   const scrollMiniPlayerActive = ref(false)
+  const scrollMiniPlayerAnimating = ref(false)
   const scrollMiniPlaceholderHeight = ref(0)
   /** @type {import('vue').Ref<import('../../../helpers/scrollMiniPlayer').ScrollMiniPlayerRect>} */
   const scrollMiniPlayerRect = ref(getDefaultScrollMiniPlayerRect())
@@ -84,6 +87,9 @@ export function useScrollMiniPlayer({ container, fullWindowEnabled, getUi, isAct
   let scrollMiniVolumeHideTimeout = null
   /** @type {(() => void) | null} */
   let scrollMiniBounceCancel = null
+  /** @type {Animation | null} */
+  let scrollMiniLayoutAnimation = null
+  let scrollMiniLayoutAnimationSequence = 0
   let scrollMiniPlayPauseHiddenByTimer = false
   let scrollMiniDragHandleContrastLastUpdate = 0
   let scrollMiniPointerRevealSuppressedUntil = 0
@@ -383,6 +389,56 @@ export function useScrollMiniPlayer({ container, fullWindowEnabled, getUi, isAct
     scrollMiniBounceCancel = null
   }
 
+  function cancelScrollMiniPlayerLayoutAnimation() {
+    scrollMiniLayoutAnimationSequence++
+    scrollMiniLayoutAnimation?.cancel()
+    scrollMiniLayoutAnimation = null
+    scrollMiniPlayerAnimating.value = false
+  }
+
+  /**
+   * Animate the player from its bounds before a layout switch to its new ones.
+   *
+   * @param {DOMRect} previousRect
+   * @param {boolean} expectedActive
+   * @param {number} sequence
+   */
+  async function animateScrollMiniPlayerLayout(previousRect, expectedActive, sequence) {
+    const playerContainer = container.value
+    if (!playerContainer) return
+
+    await nextTick()
+    if (
+      scrollMiniLayoutAnimationSequence !== sequence ||
+      scrollMiniPlayerActive.value !== expectedActive
+    ) return
+
+    const nextRect = playerContainer.getBoundingClientRect()
+    if (nextRect.width === 0 || nextRect.height === 0) return
+
+    const animation = playerContainer.animate([
+      {
+        transform: `translate(${previousRect.left - nextRect.left}px, ${previousRect.top - nextRect.top}px) scale(${previousRect.width / nextRect.width}, ${previousRect.height / nextRect.height})`,
+        transformOrigin: 'top left'
+      },
+      {
+        transform: 'none',
+        transformOrigin: 'top left'
+      }
+    ], {
+      duration: SCROLL_MINI_LAYOUT_ANIMATION_DURATION_MS,
+      easing: 'cubic-bezier(0.4, 0, 0.2, 1)'
+    })
+
+    scrollMiniLayoutAnimation = animation
+    animation.addEventListener('finish', () => {
+      if (scrollMiniLayoutAnimation === animation) {
+        scrollMiniLayoutAnimation = null
+        scrollMiniPlayerAnimating.value = false
+      }
+    })
+  }
+
   function loadScrollMiniPlayerSavedRectFromSettings() {
     const savedRect = parseScrollMiniPlayerSavedRect(store.getters.getScrollMiniPlayerSavedRect)
     if (savedRect) {
@@ -484,6 +540,8 @@ export function useScrollMiniPlayer({ container, fullWindowEnabled, getUi, isAct
 
     const playerContainer = container.value
     if (!playerContainer) return
+    const shouldAnimate = !isReducedMotionEnabled()
+    const previousRect = shouldAnimate ? playerContainer.getBoundingClientRect() : null
 
     const layoutHeight = getScrollMiniPlaceholderLayoutHeight()
     if (layoutHeight < SCROLL_MINI_MIN_INLINE_LAYOUT_HEIGHT) {
@@ -501,6 +559,10 @@ export function useScrollMiniPlayer({ container, fullWindowEnabled, getUi, isAct
 
     lastKnownInlinePlayerHeight = layoutHeight
     scrollMiniPlaceholderHeight.value = placeholderHeight
+
+    cancelScrollMiniPlayerLayoutAnimation()
+    const animationSequence = scrollMiniLayoutAnimationSequence
+    scrollMiniPlayerAnimating.value = previousRect !== null
 
     const savedRect = getSavedScrollMiniPlayerRect()
     scrollMiniPlayerActive.value = true
@@ -523,9 +585,22 @@ export function useScrollMiniPlayer({ container, fullWindowEnabled, getUi, isAct
       updateScrollMiniVolumeBarFill()
       updateScrollMiniDragHandleContrast(true)
     })
+
+    if (previousRect) {
+      animateScrollMiniPlayerLayout(previousRect, true, animationSequence)
+    }
   }
 
-  function deactivateScrollMiniPlayer() {
+  /** @param {boolean} [animate] */
+  function deactivateScrollMiniPlayer(animate = false) {
+    const playerContainer = container.value
+    const shouldAnimate = animate && playerContainer !== null && !isReducedMotionEnabled()
+    const previousRect = shouldAnimate ? playerContainer.getBoundingClientRect() : null
+
+    cancelScrollMiniPlayerLayoutAnimation()
+    const animationSequence = scrollMiniLayoutAnimationSequence
+    scrollMiniPlayerAnimating.value = previousRect !== null
+
     scrollMiniPlayerActive.value = false
     scrollMiniPlaceholderHeight.value = 0
     scrollMiniDragHandleOnLightBg.value = false
@@ -536,6 +611,10 @@ export function useScrollMiniPlayer({ container, fullWindowEnabled, getUi, isAct
     scrollMiniVolumeExpanded.value = false
 
     cancelScrollMiniPlayerBounce()
+
+    if (previousRect) {
+      animateScrollMiniPlayerLayout(previousRect, false, animationSequence)
+    }
   }
 
   function updateScrollMiniPlayer() {
@@ -560,7 +639,7 @@ export function useScrollMiniPlayer({ container, fullWindowEnabled, getUi, isAct
 
     if (scrollMiniPlayerActive.value) {
       if (ratio >= EXIT_MINI_RATIO) {
-        deactivateScrollMiniPlayer()
+        deactivateScrollMiniPlayer(true)
       } else {
         syncScrollMiniPlayerState()
         updateScrollMiniDragHandleContrast()
@@ -821,6 +900,7 @@ export function useScrollMiniPlayer({ container, fullWindowEnabled, getUi, isAct
     clearScrollMiniVolumeHideTimeout()
 
     cancelScrollMiniPlayerBounce()
+    cancelScrollMiniPlayerLayoutAnimation()
     cancelPendingScrollMiniScrollFrame()
 
     endScrollMiniPointerSession()
@@ -884,6 +964,7 @@ export function useScrollMiniPlayer({ container, fullWindowEnabled, getUi, isAct
     scrollMiniPlaceholder,
     scrollMiniPlaceholderHeight,
     scrollMiniPlayerActive,
+    scrollMiniPlayerAnimating,
     scrollMiniPlayerStyle,
     scrollMiniPlayPauseVisible,
     scrollMiniResizeCorner,


### PR DESCRIPTION
## Pull Request Type
<!-- Please select what type of pull request this is: [x] -->
- [ ] Bugfix
- [x] Feature Implementation
- [ ] Documentation
- [ ] Other

## Related issue
<!-- Please link the issue your pull request is referring to. -->
<!-- If this pull request fully resolves the relevant issue, put "closes" before the issue number. -->
<!-- Example: "closes #123456". -->

None.

## Description
<!-- Please write a clear and concise description of what the pull request does. -->

Smoothly animates the video between its inline position and the scroll mini player using the same FLIP-style movement as full-window mode. The 300 ms transition respects reduced-motion preferences, handles interrupted transitions, and keeps the player elevated above page content while it animates back into the page.

Previously, switching between fixed and inline positioning happened immediately. During the new exit animation, dropping the mini-player positioning also dropped its stacking order, so later page content could cover the moving video; a temporary animation state now preserves the required stacking layer until the transition finishes.

## Screenshots <!-- If appropriate -->
<!-- Please add before and after screenshots if there is a visible change. -->

Not included; the change is best observed while scrolling a playing video.

## Release note category
<!-- Select exactly one category. Every pull request must select one. -->
<!-- release-note-category:start -->
- [ ] Not noteworthy
- [ ] Highlights
- [x] More improvements
- [ ] Fixed bugs
<!-- release-note-category:end -->

## Release note
<!-- Required unless "Not noteworthy" is selected. -->
<!-- Write one concise, user-facing entry without a leading bullet. -->
<!-- release-note:start -->
Smoothly animate videos into and out of the scroll mini player.
<!-- release-note:end -->

## Release note images
<!-- Optional. Paste one or more Markdown images or HTML image tags here. -->
<!-- The release notes will use an HTML image tag and limit images taller than 300 pixels. -->
<!-- release-note-image:start -->

<!-- release-note-image:end -->

## Testing
<!-- How can reviewers verify that the PR produces correct results? -->

1. Play a video and scroll until the mini player activates; verify that the video smoothly moves and resizes into its docked position.
2. Scroll back to the top; verify that the video smoothly returns to its inline position and remains above the page content throughout the animation.
3. Enable reduced motion and verify that both layout changes occur without animation.

Automated checks run:

- `pnpm run test:unit` (155 passed)
- ESLint and Stylelint on the changed source files
- `xvfb-run -a -s "-screen 0 1920x1080x24" pnpm exec playwright test -c e2e/playwright.config.mjs --project=network e2e/tests/network/watch.spec.mjs --grep "animates into and out of the scroll mini player"` (1 passed)
- E2E production pack

## Desktop
<!-- Please complete the following information-->
- **OS:** Arch Linux
- **OS Version:** Rolling release
- **OpenTubeX version:** 0.30.1

## Additional context

The E2E regression test verifies both animation directions, the 300 ms timing/easing, and the temporary exit stacking state.