### PR TITLE
fix(icons): center side nav Iconify glyphs

### DIFF
--- a/src/renderer/components/FtIcon/FtIcon.vue
+++ b/src/renderer/components/FtIcon/FtIcon.vue
@@ -243,6 +243,8 @@ const iconifyGlyphStyle = computed(() => cssFromFaTransform(props.transform))
 
 .ft-icon__glyph {
   display: block;
+  /* Center when callers stretch .ft-icon wider than 1em (e.g. SideNav .navIcon). */
+  margin-inline: auto;
 }
 
 .ft-icon--fw {

--- a/src/renderer/components/SideNav/SideNav.css
+++ b/src/renderer/components/SideNav/SideNav.css
@@ -83,8 +83,9 @@
 
 .navIcon {
   block-size: 1em;
-  inline-size: 100%;
+  inline-size: 1em;
   display: block;
+  margin-inline: auto;
 }
 
 .navIcon.fa-user-check {

--- a/src/renderer/components/SideNavMoreOptions/SideNavMoreOptions.css
+++ b/src/renderer/components/SideNavMoreOptions/SideNavMoreOptions.css
@@ -63,10 +63,10 @@
   }
 
   .navIcon {
-    margin-inline-start: 0;
-    inline-size: 100%;
+    inline-size: 1em;
     display: block;
     margin-block-start: 0.5em;
+    margin-inline: auto;
   }
 
   .navIcon.fa-user-check {


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Make sure to follow the contributing guidelines. -->
<!-- Important note, we may remove your pull request if you do not use this provided PR template correctly. -->

## Pull Request Type
<!-- Please select what type of pull request this is: [x] -->
- [x] Bugfix
- [ ] Feature Implementation
- [ ] Documentation
- [ ] Other

## Related issue
Follow-up to #394 — compact side nav icons drifted left under Iconify packs.

## Description
Iconify glyphs are 1em wide, but SideNav stretched `.navIcon` to 100% of the thumbnail container, so icons sat left of their centered labels. Size nav icons to 1em, center them, and center FtIcon glyphs when the wrapper is wider than the glyph.

## Screenshots <!-- If appropriate -->
Before: icons left-aligned above centered labels in the compact sidebar.
After: icons centered above their labels.

## Release note category
<!-- Select exactly one category. Every pull request must select one. -->
<!-- release-note-category:start -->
- [x] Not noteworthy
- [ ] Highlights
- [ ] More improvements
- [ ] Fixed bugs
<!-- release-note-category:end -->

## Release note
<!-- Required unless "Not noteworthy" is selected. -->
<!-- Write one concise, user-facing entry without a leading bullet. -->
<!-- release-note:start -->
Fixed side navigation icons not lining up with their labels when using non–Font Awesome icon packs
<!-- release-note:end -->

## Release note images
<!-- Optional. Paste one or more Markdown images or HTML image tags here. -->
<!-- The release notes will use an HTML image tag and limit images taller than 300 pixels. -->
<!-- release-note-image:start -->

<!-- release-note-image:end -->

## Testing
1. Open the app with a non–Font Awesome icon pack (e.g. Material) selected in Theme Settings.
2. Collapse the side nav (compact 80px width with labels under icons).
3. Confirm each icon sits centered above its label.
4. Expand the side nav and confirm horizontal icon+label layout still looks correct.
5. Optionally switch back to Font Awesome and spot-check the same layouts.
6. On a narrow viewport (≤680px), open the mobile more-options menu and confirm icons are centered.

## Desktop
<!-- Please complete the following information-->
- **OS:** Linux
- **OS Version:** Arch
- **OpenTubeX version:** development

## Additional context
Regression from the Iconify wrapper in #394: Font Awesome SVGs filled the stretched `.navIcon` box, while Iconify glyphs stayed 1em and left-aligned.