### PR TITLE
feat(privacy): opt into sync and context-menu search by default

### DIFF
--- a/e2e/tests/network/sync-server.spec.mjs
+++ b/e2e/tests/network/sync-server.spec.mjs
@@ -41,6 +41,7 @@ test.describe('OpenTubeX sync server', () => {
     seed: {
       settings: {
         baseTheme: 'dark',
+        syncServerEnabled: true,
         channelPlaybackSpeeds: JSON.stringify({ [channelId]: 1.5 })
       },
       profiles: [{

--- a/e2e/tests/offline/search-context-menu.spec.mjs
+++ b/e2e/tests/offline/search-context-menu.spec.mjs
@@ -165,11 +165,15 @@ test('adds a custom search engine from settings', async ({ page }) => {
   const contextMenu = await page.evaluate(() => window.ftElectron.contextMenu.open({
     selectionText: 'custom search'
   }))
-  const searchWith = contextMenu.items.find(item => item.label === 'Search with...')
+  // Built-ins are disabled by default, so a single custom engine is a direct action.
+  const searchWith = contextMenu.items.find(item => item.label === 'Search with Example Search')
 
-  expect(searchWith.submenu.map(item => item.label)).toContain('Example Search')
-  expect(searchWith.submenu.find(item => item.label === 'Example Search').icon)
-    .toBe('https://example.com/favicon.ico')
+  expect(searchWith).toMatchObject({
+    labelKey: 'Context Menu.Search With',
+    labelParameters: { engine: 'Example Search' }
+  })
+  expect(searchWith.submenu).toBeUndefined()
+  expect(searchWith.icon).toBe('https://example.com/favicon.ico')
 })
 
 test.describe('with one external search engine enabled', () => {

--- a/e2e/tests/offline/search-context-menu.spec.mjs
+++ b/e2e/tests/offline/search-context-menu.spec.mjs
@@ -1,4 +1,9 @@
 import { test, expect, goTo, sel } from '../../helpers/app.mjs'
+import { DEFAULT_SEARCH_ENGINES } from '../../../src/searchEngines.js'
+
+const allExternalSearchEnginesEnabled = JSON.stringify(
+  DEFAULT_SEARCH_ENGINES.map(engine => ({ ...engine, enabled: true }))
+)
 
 test('searching selected text in a new tab uses the default filters', async ({ page }) => {
   const contextMenu = await page.evaluate(() => window.ftElectron.contextMenu.open({
@@ -27,50 +32,68 @@ test('searching selected text in a new tab uses the default filters', async ({ p
   await expect(page.locator('.searchRadio', { hasText: 'Duration' }).locator('input[value=""]')).toBeChecked()
 })
 
-test('offers enabled external search engines in a submenu', async ({ page }) => {
+test('does not offer external search engines when they are disabled by default', async ({ page }) => {
   const contextMenu = await page.evaluate(() => window.ftElectron.contextMenu.open({
     selectionText: 'private search'
   }))
-  const searchWith = contextMenu.items.find(item => item.label === 'Search with...')
 
-  expect(searchWith).toMatchObject({
-    labelKey: 'Context Menu.Search With Multiple',
-    labelParameters: {}
-  })
-  expect(searchWith.submenu.map(item => item.label)).toEqual([
-    'DuckDuckGo',
-    'Startpage',
-    'Qwant',
-    'Brave Search'
-  ])
-  expect(searchWith.submenu.map(item => item.icon)).toEqual([
-    'https://duckduckgo.com/favicon.ico',
-    'https://www.startpage.com/favicon.ico',
-    'https://www.qwant.com/favicon.ico',
-    'https://search.brave.com/favicon.ico'
-  ])
-  expect(searchWith.submenu.map(item => item.faviconSource)).toEqual([
-    'https://duckduckgo.com/?q=%s',
-    'https://www.startpage.com/sp/search?query=%s',
-    'https://www.qwant.com/?q=%s',
-    'https://search.brave.com/search?q=%s'
-  ])
-  expect(searchWith.submenu.every(item => item.labelKey == null)).toBe(true)
+  expect(contextMenu.items.some(item => typeof item.label === 'string' && item.label.startsWith('Search with'))).toBe(false)
 })
 
-test('keeps web search enabled and below in-app search for long selections', async ({ page }) => {
-  const contextMenu = await page.evaluate(() => window.ftElectron.contextMenu.open({
-    selectionText: 'x'.repeat(101)
-  }))
-  const webSearchIndex = contextMenu.items.findIndex(item => item.label === 'Search with...')
-  const inAppSearchIndices = contextMenu.items
-    .map((item, index) => typeof item.label === 'string' && item.label.includes('is too long for search')
-      ? index
-      : -1)
-    .filter(index => index !== -1)
+test.describe('with all built-in external search engines enabled', () => {
+  test.use({
+    seed: {
+      settings: {
+        contextMenuSearchEngines: allExternalSearchEnginesEnabled
+      }
+    }
+  })
 
-  expect(contextMenu.items[webSearchIndex].enabled).toBe(true)
-  expect(webSearchIndex).toBeGreaterThan(Math.max(...inAppSearchIndices))
+  test('offers enabled external search engines in a submenu', async ({ page }) => {
+    const contextMenu = await page.evaluate(() => window.ftElectron.contextMenu.open({
+      selectionText: 'private search'
+    }))
+    const searchWith = contextMenu.items.find(item => item.label === 'Search with...')
+
+    expect(searchWith).toMatchObject({
+      labelKey: 'Context Menu.Search With Multiple',
+      labelParameters: {}
+    })
+    expect(searchWith.submenu.map(item => item.label)).toEqual([
+      'DuckDuckGo',
+      'Startpage',
+      'Qwant',
+      'Brave Search'
+    ])
+    expect(searchWith.submenu.map(item => item.icon)).toEqual([
+      'https://duckduckgo.com/favicon.ico',
+      'https://www.startpage.com/favicon.ico',
+      'https://www.qwant.com/favicon.ico',
+      'https://search.brave.com/favicon.ico'
+    ])
+    expect(searchWith.submenu.map(item => item.faviconSource)).toEqual([
+      'https://duckduckgo.com/?q=%s',
+      'https://www.startpage.com/sp/search?query=%s',
+      'https://www.qwant.com/?q=%s',
+      'https://search.brave.com/search?q=%s'
+    ])
+    expect(searchWith.submenu.every(item => item.labelKey == null)).toBe(true)
+  })
+
+  test('keeps web search enabled and below in-app search for long selections', async ({ page }) => {
+    const contextMenu = await page.evaluate(() => window.ftElectron.contextMenu.open({
+      selectionText: 'x'.repeat(101)
+    }))
+    const webSearchIndex = contextMenu.items.findIndex(item => item.label === 'Search with...')
+    const inAppSearchIndices = contextMenu.items
+      .map((item, index) => typeof item.label === 'string' && item.label.includes('is too long for search')
+        ? index
+        : -1)
+      .filter(index => index !== -1)
+
+    expect(contextMenu.items[webSearchIndex].enabled).toBe(true)
+    expect(webSearchIndex).toBeGreaterThan(Math.max(...inAppSearchIndices))
+  })
 })
 
 test('keeps the newest overlapping context menu session executable', async ({ page }) => {
@@ -247,7 +270,14 @@ test.describe('with the maximum custom search engines configured', () => {
 })
 
 test.describe('German locale', () => {
-  test.use({ seed: { settings: { currentLocale: 'de-DE' } } })
+  test.use({
+    seed: {
+      settings: {
+        currentLocale: 'de-DE',
+        contextMenuSearchEngines: allExternalSearchEnginesEnabled
+      }
+    }
+  })
 
   test('translates external search labels from explicit menu metadata', async ({ page }) => {
     const searchInput = page.locator('.searchInput input')

--- a/e2e/tests/offline/settings.spec.mjs
+++ b/e2e/tests/offline/settings.spec.mjs
@@ -127,6 +127,8 @@ test.describe('settings', () => {
     await goTo(page, 'settings')
 
     const syncSection = page.locator('[data-section="sync"]')
+    await syncSection.getByLabel('Enable Sync').click()
+
     const privacyPolicy = syncSection.getByRole('link', {
       name: 'Privacy policy for this server'
     })
@@ -138,6 +140,21 @@ test.describe('settings', () => {
 
     await syncSection.getByLabel('Server URL').fill('https://sync.libretube.dev')
     await expect(privacyPolicy).toHaveCount(0)
+  })
+
+  test('keeps the sync server idle until sync is enabled', async ({ page }) => {
+    const syncRequests = []
+    await page.route('https://sync.d3sox.me/**', async (route) => {
+      syncRequests.push(route.request().url())
+      await route.fulfill({ status: 200, body: 'OK' })
+    })
+    await goTo(page, 'settings')
+
+    const syncSection = page.locator('[data-section="sync"]')
+    await expect(syncSection.getByLabel('Enable Sync')).not.toBeChecked()
+    await expect(syncSection.getByLabel('Server URL')).toHaveCount(0)
+    await page.waitForTimeout(500)
+    expect(syncRequests).toEqual([])
   })
 
   test('a toggled setting persists across restarts', async ({ app }) => {
@@ -522,6 +539,7 @@ test.describe('sync settings', () => {
   test.use({
     seed: {
       settings: {
+        syncServerEnabled: true,
         syncServerAutoSync: false,
         syncServerPrivacyKey: 'e2e-privacy-key',
         syncServerPrivacyMode: 'legacy',
@@ -705,6 +723,7 @@ test.describe('synced setting indicators', () => {
     seed: {
       settings: {
         reducedMotion: 'on',
+        syncServerEnabled: true,
         syncServerAutoSync: false,
         syncServerSyncSettings: true,
         syncServerToken: 'e2e-sync-token'

--- a/e2e/tests/offline/settings.spec.mjs
+++ b/e2e/tests/offline/settings.spec.mjs
@@ -127,7 +127,7 @@ test.describe('settings', () => {
     await goTo(page, 'settings')
 
     const syncSection = page.locator('[data-section="sync"]')
-    await syncSection.getByLabel('Enable Sync').click()
+    await syncSection.locator('label.switch-label').filter({ hasText: 'Enable Sync' }).click()
 
     const privacyPolicy = syncSection.getByRole('link', {
       name: 'Privacy policy for this server'

--- a/e2e/tests/offline/settings.spec.mjs
+++ b/e2e/tests/offline/settings.spec.mjs
@@ -591,6 +591,44 @@ test.describe('sync settings', () => {
     }
   })
 
+  test('stops an active sync when sync is disabled', async ({ page }) => {
+    let finishSyncRequest
+    let syncRequestStarted
+    const syncRequestPending = new Promise((resolve) => {
+      finishSyncRequest = resolve
+    })
+    const syncRequestRequested = new Promise((resolve) => {
+      syncRequestStarted = resolve
+    })
+    const syncRequests = []
+
+    await page.route('https://sync.d3sox.me/**', async (route) => {
+      const pathname = new URL(route.request().url()).pathname
+      if (pathname === '/health') {
+        await route.fulfill({ status: 200, body: 'OK' })
+        return
+      }
+
+      syncRequests.push(pathname)
+      syncRequestStarted()
+      await syncRequestPending
+      await route.fulfill({ status: 200, json: [] })
+    })
+    await goTo(page, 'settings')
+
+    const syncSection = page.locator('[data-section="sync"]')
+    await syncSection.getByRole('button', { name: 'Sync now' }).click()
+    await syncRequestRequested
+    await syncSection.getByText('Enable Sync', { exact: true }).click()
+    finishSyncRequest()
+
+    await expect(syncSection.getByLabel('Enable Sync')).not.toBeChecked()
+    await expect(syncSection.locator('.syncProgress')).toBeHidden()
+    await expect(syncSection.locator('.error')).toHaveCount(0)
+    await page.waitForTimeout(500)
+    expect(syncRequests).toHaveLength(1)
+  })
+
   test('disables credentials while authentication is pending', async ({ page }) => {
     let finishAuthentication
     const authenticationPending = new Promise((resolve) => {

--- a/src/renderer/components/ContextMenuSearchSettings/ContextMenuSearchSettings.vue
+++ b/src/renderer/components/ContextMenuSearchSettings/ContextMenuSearchSettings.vue
@@ -5,6 +5,9 @@
     <p class="description">
       {{ t('Settings.Context Menu Search Settings.Description') }}
     </p>
+    <p class="hint">
+      {{ t('Settings.Context Menu Search Settings.Icon Hint') }}
+    </p>
 
     <div class="engineList">
       <div
@@ -141,7 +144,7 @@ function handleFaviconError(engine) {
 
 watch(configuredSearchEngines, (engines) => {
   for (const engine of engines) {
-    if (resolvedFavicons.value.has(engine.url)) continue
+    if (!engine.enabled || resolvedFavicons.value.has(engine.url)) continue
 
     window.ftElectron.resolveFavicon(engine.url).then(icon => {
       resolvedFavicons.value = new Map([...resolvedFavicons.value, [engine.url, icon]])

--- a/src/renderer/components/ExperimentalSettings/ExperimentalSettings.vue
+++ b/src/renderer/components/ExperimentalSettings/ExperimentalSettings.vue
@@ -16,6 +16,8 @@
         @change="handleRestartPrompt"
       />
     </FtFlexBox>
+    <br>
+    <FtIconPackSwitcher />
     <FtPrompt
       v-if="showRestartPrompt"
       :label="$t('Settings[\'The app needs to restart for changes to take effect. Restart and apply change?\']')"
@@ -32,6 +34,7 @@ import { onMounted, ref } from 'vue'
 import FtSettingsSection from '../FtSettingsSection/FtSettingsSection.vue'
 import FtFlexBox from '../ft-flex-box/ft-flex-box.vue'
 import FtToggleSwitch from '../FtToggleSwitch/FtToggleSwitch.vue'
+import FtIconPackSwitcher from '../FtIconPackSwitcher/FtIconPackSwitcher.vue'
 import FtPrompt from '../FtPrompt/FtPrompt.vue'
 
 const replaceHttpCacheLoading = ref(true)

--- a/src/renderer/components/FtSyncedSettingIndicator/FtSyncedSettingIndicator.vue
+++ b/src/renderer/components/FtSyncedSettingIndicator/FtSyncedSettingIndicator.vue
@@ -58,7 +58,8 @@ const { t } = useI18n()
 
 const canConfigureSync = computed(() => {
   const settings = store.state.settings
-  return settings.syncServerToken !== '' &&
+  return settings.syncServerEnabled &&
+    settings.syncServerToken !== '' &&
     settings.syncServerSyncSettings &&
     isSettingSyncable(props.settingKey)
 })

--- a/src/renderer/components/SyncSettings/SyncSettings.vue
+++ b/src/renderer/components/SyncSettings/SyncSettings.vue
@@ -7,7 +7,6 @@
       <FtToggleSwitch
         :label="t('Settings.Sync Settings.Enable Sync')"
         :default-value="syncEnabled"
-        :disabled="busy"
         compact
         @change="setSyncEnabled"
       />

--- a/src/renderer/components/SyncSettings/SyncSettings.vue
+++ b/src/renderer/components/SyncSettings/SyncSettings.vue
@@ -3,328 +3,338 @@
     <p class="description">
       {{ t('Settings.Sync Settings.Description') }}
     </p>
-    <FtFlexBox class="fields">
-      <FtInput
-        :placeholder="t('Settings.Sync Settings.Server URL')"
-        :show-action-button="false"
-        :data-list="syncServerInstances"
-        :value="serverUrl"
-        :disabled="connected || authenticating"
-        show-label
-        @input="serverUrl = $event"
-        @blur="saveServerUrl"
-      />
-      <FtInput
-        :placeholder="t('Settings.Sync Settings.Username')"
-        :show-action-button="false"
-        :value="username"
-        :disabled="connected || serverCredentialsDisabled"
-        show-label
-        @input="username = $event"
-      />
-      <FtInput
-        v-if="!connected"
-        :placeholder="t('Settings.Sync Settings.Password')"
-        :show-action-button="false"
-        :value="password"
-        :disabled="serverCredentialsDisabled"
-        input-type="password"
-        show-label
-        @input="password = $event"
-        @keydown.enter="authenticate('login')"
-      />
-      <FtInput
-        v-if="!connected && serverPrivacySupported !== false"
-        :placeholder="t('Settings.Sync Settings.Privacy Passphrase')"
-        :show-action-button="false"
-        :value="privacyPassphrase"
-        :disabled="serverCredentialsDisabled"
-        input-type="password"
-        show-label
-        @input="privacyPassphrase = $event"
-        @keydown.enter="authenticate('login')"
+    <FtFlexBox class="toggles">
+      <FtToggleSwitch
+        :label="t('Settings.Sync Settings.Enable Sync')"
+        :default-value="syncEnabled"
+        compact
+        @change="setSyncEnabled"
       />
     </FtFlexBox>
-    <p
-      v-if="privacyPolicyUrl"
-      class="privacyPolicy"
-    >
-      <a :href="privacyPolicyUrl">
-        {{ t('Settings.Sync Settings.Privacy Policy') }}
-      </a>
-    </p>
-    <p
-      v-if="!connected && serverPrivacySupported !== false"
-      class="privacyHint"
-    >
-      {{ t('Settings.Sync Settings.Privacy Passphrase Hint') }}
-    </p>
-    <p
-      v-if="!connected && serverCheckStatus === 'checking'"
-      class="serverCheckStatus"
-      aria-live="polite"
-    >
-      {{ t('Settings.Sync Settings.Checking Server') }}
-    </p>
-    <p
-      v-if="!connected && serverPrivacySupported === false"
-      class="privacyWarning"
-      role="status"
-    >
-      {{ t('Settings.Sync Settings.Enhanced Privacy Unsupported') }}
-    </p>
-
-    <div
-      v-if="busy && syncProgress"
-      class="syncProgress"
-      aria-live="polite"
-    >
-      <div class="syncProgressLabel">
-        <span>{{ syncProgressLabel }}</span>
-        <span>
-          {{ t('Settings.Sync Settings.Sync progress percentage', {
-            percentage: syncProgress.percentage,
-          }) }}
-        </span>
-      </div>
-      <div
-        class="syncProgressTrack"
-        role="progressbar"
-        :aria-label="syncProgressLabel"
-        :aria-valuenow="syncProgress.percentage"
-        aria-valuemin="0"
-        aria-valuemax="100"
-      >
-        <div
-          class="syncProgressFill"
-          :style="{ inlineSize: `${syncProgress.percentage}%` }"
+    <template v-if="syncEnabled">
+      <FtFlexBox class="fields">
+        <FtInput
+          :placeholder="t('Settings.Sync Settings.Server URL')"
+          :show-action-button="false"
+          :data-list="syncServerInstances"
+          :value="serverUrl"
+          :disabled="connected || authenticating"
+          show-label
+          @input="serverUrl = $event"
+          @blur="saveServerUrl"
         />
-      </div>
-    </div>
-    <FtLoader v-else-if="busy" />
-    <p
-      v-if="errorMessage"
-      class="error"
-      role="alert"
-    >
-      {{ errorMessage }}
-    </p>
-
-    <template v-if="connected">
-      <p class="connectionStatus">
-        {{ t('Settings.Sync Settings.Connected as', { username: savedUsername }) }}
-      </p>
+        <FtInput
+          :placeholder="t('Settings.Sync Settings.Username')"
+          :show-action-button="false"
+          :value="username"
+          :disabled="connected || serverCredentialsDisabled"
+          show-label
+          @input="username = $event"
+        />
+        <FtInput
+          v-if="!connected"
+          :placeholder="t('Settings.Sync Settings.Password')"
+          :show-action-button="false"
+          :value="password"
+          :disabled="serverCredentialsDisabled"
+          input-type="password"
+          show-label
+          @input="password = $event"
+          @keydown.enter="authenticate('login')"
+        />
+        <FtInput
+          v-if="!connected && serverPrivacySupported !== false"
+          :placeholder="t('Settings.Sync Settings.Privacy Passphrase')"
+          :show-action-button="false"
+          :value="privacyPassphrase"
+          :disabled="serverCredentialsDisabled"
+          input-type="password"
+          show-label
+          @input="privacyPassphrase = $event"
+          @keydown.enter="authenticate('login')"
+        />
+      </FtFlexBox>
       <p
-        v-if="privacyMode === 'enhanced'"
-        class="privacyStatus"
+        v-if="privacyPolicyUrl"
+        class="privacyPolicy"
       >
-        {{ t('Settings.Sync Settings.Enhanced Privacy Enabled') }}
+        <a :href="privacyPolicyUrl">
+          {{ t('Settings.Sync Settings.Privacy Policy') }}
+        </a>
       </p>
       <p
-        v-else-if="privacyMode === 'legacy'"
+        v-if="!connected && serverPrivacySupported !== false"
+        class="privacyHint"
+      >
+        {{ t('Settings.Sync Settings.Privacy Passphrase Hint') }}
+      </p>
+      <p
+        v-if="!connected && serverCheckStatus === 'checking'"
+        class="serverCheckStatus"
+        aria-live="polite"
+      >
+        {{ t('Settings.Sync Settings.Checking Server') }}
+      </p>
+      <p
+        v-if="!connected && serverPrivacySupported === false"
         class="privacyWarning"
-        role="alert"
+        role="status"
       >
         {{ t('Settings.Sync Settings.Enhanced Privacy Unsupported') }}
       </p>
-      <FtFlexBox class="toggles">
-        <FtToggleSwitch
-          :label="t('Settings.Sync Settings.Automatic Sync')"
-          :default-value="autoSync"
-          compact
-          @change="setAutoSync"
-        />
-        <FtToggleSwitch
-          :label="t('Subscriptions.Subscriptions')"
-          :default-value="syncSubscriptionsEnabled"
-          :disabled="busy"
-          compact
-          @change="store.dispatch('updateSyncServerSyncSubscriptions', $event)"
-        />
-        <FtToggleSwitch
-          :label="t('Playlists')"
-          :default-value="syncPlaylistsEnabled"
-          :disabled="busy"
-          compact
-          @change="store.dispatch('updateSyncServerSyncPlaylists', $event)"
-        />
-        <FtToggleSwitch
-          :label="t('History.History')"
-          :default-value="syncHistoryEnabled"
-          :disabled="busy || historySupported === false"
-          compact
-          @change="store.dispatch('updateSyncServerSyncHistory', $event)"
-        />
-        <FtToggleSwitch
-          :label="t('Settings.Sync Settings.Channel Playback Speeds')"
-          :default-value="syncPlaybackSpeedsEnabled"
-          :disabled="busy || playbackSpeedsSupported === false"
-          compact
-          @change="store.dispatch('updateSyncServerSyncPlaybackSpeeds', $event)"
-        />
-        <FtToggleSwitch
-          :label="t('Settings.Sync Settings.Profiles')"
-          :default-value="syncProfilesEnabled"
-          :disabled="busy"
-          compact
-          @change="store.dispatch('updateSyncServerSyncProfiles', $event)"
-        />
-        <FtToggleSwitch
-          v-if="sessionsSupported"
-          :label="t('Settings.Sync Settings.Open Tabs')"
-          :default-value="syncSessionsEnabled"
-          :disabled="busy"
-          compact
-          @change="store.dispatch('updateSyncServerSyncSessions', $event)"
-        />
-        <FtToggleSwitch
-          :label="t('Settings.Sync Settings.Settings')"
-          :default-value="syncSettingsEnabled"
-          :disabled="busy || settingsSupported === false"
-          compact
-          @change="store.dispatch('updateSyncServerSyncSettings', $event)"
-        />
-      </FtFlexBox>
-      <p
-        v-if="lastSyncLabel"
-        class="lastSync"
+
+      <div
+        v-if="busy && syncProgress"
+        class="syncProgress"
+        aria-live="polite"
       >
-        {{ t('Settings.Sync Settings.Last synced', { date: lastSyncLabel }) }}
-      </p>
-      <p
-        v-if="historySupported === false"
-        class="compatibilityWarning"
-      >
-        {{ t('Settings.Sync Settings.History not supported') }}
-      </p>
-      <p
-        v-if="playbackSpeedsSupported === false && settingsSupported"
-        class="compatibilityWarning"
-      >
-        {{ t('Settings.Sync Settings.Playback speeds not supported') }}
-      </p>
-      <p
-        v-else-if="playbackSpeedsSupported === false"
-        class="compatibilityWarning"
-      >
-        {{ t('Settings.Sync Settings.Playback speeds and settings not supported') }}
-      </p>
-      <p
-        v-else-if="settingsSupported === false"
-        class="compatibilityWarning"
-      >
-        {{ t('Settings.Sync Settings.Settings not supported') }}
-      </p>
-      <FtFlexBox class="actions">
-        <FtButton
-          :label="t('Settings.Sync Settings.Sync Now')"
-          :icon="['fas', 'sync']"
-          :disabled="busy"
-          @click="syncNow"
-        />
-        <FtButton
-          :label="t('Settings.Sync Settings.Disconnect')"
-          :icon="['fas', 'right-from-bracket']"
-          :disabled="busy"
-          @click="disconnect"
-        />
-        <FtButton
-          :label="t('Settings.Sync Settings.Delete Account')"
-          text-color="var(--destructive-text-color)"
-          background-color="var(--destructive-color)"
-          :icon="['fas', 'trash']"
-          :disabled="busy"
-          @click="showDeleteAccountPrompt = true"
-        />
-      </FtFlexBox>
-    </template>
-    <FtFlexBox
-      v-else-if="!busy"
-      class="actions"
-    >
-      <FtButton
-        :label="t('Settings.Sync Settings.Log In')"
-        :icon="['fas', 'right-to-bracket']"
-        :disabled="serverCredentialsDisabled"
-        @click="authenticate('login')"
-      />
-      <FtButton
-        :label="t('Settings.Sync Settings.Register')"
-        :icon="['fas', 'user-plus']"
-        :disabled="serverCredentialsDisabled"
-        @click="authenticate('register')"
-      />
-    </FtFlexBox>
-    <FtPrompt
-      v-if="dataLossWarning"
-      :label="t('Settings.Sync Settings.Data Loss Confirmation')"
-      theme="readable-width"
-      @click="dataLossWarning = null"
-    >
-      <div class="deleteAccountContent">
-        <p class="deleteAccountWarning">
-          {{ t('Settings.Sync Settings.Data Loss Warning', {
-            deleted: dataLossWarning.deleted,
-            previous: dataLossWarning.previous,
-            collection: dataLossWarning.collection,
-          }) }}
-        </p>
-        <FtFlexBox class="actions">
-          <FtButton
-            :label="t('Settings.Sync Settings.Confirm Data Loss')"
-            text-color="var(--destructive-text-color)"
-            background-color="var(--destructive-color)"
-            :icon="['fas', 'triangle-exclamation']"
-            @click="confirmDataLossSync"
+        <div class="syncProgressLabel">
+          <span>{{ syncProgressLabel }}</span>
+          <span>
+            {{ t('Settings.Sync Settings.Sync progress percentage', {
+              percentage: syncProgress.percentage,
+            }) }}
+          </span>
+        </div>
+        <div
+          class="syncProgressTrack"
+          role="progressbar"
+          :aria-label="syncProgressLabel"
+          :aria-valuenow="syncProgress.percentage"
+          aria-valuemin="0"
+          aria-valuemax="100"
+        >
+          <div
+            class="syncProgressFill"
+            :style="{ inlineSize: `${syncProgress.percentage}%` }"
           />
-          <FtButton
-            :label="t('Cancel')"
-            @click="dataLossWarning = null"
-          />
-        </FtFlexBox>
+        </div>
       </div>
-    </FtPrompt>
-    <FtPrompt
-      v-if="showDeleteAccountPrompt"
-      :label="t('Settings.Sync Settings.Delete Account Confirmation')"
-      theme="readable-width"
-      @click="closeDeleteAccountPrompt"
-    >
-      <div class="deleteAccountContent">
-        <p class="deleteAccountWarning">
-          {{ t('Settings.Sync Settings.Delete Account Warning') }}
+      <FtLoader v-else-if="busy" />
+      <p
+        v-if="errorMessage"
+        class="error"
+        role="alert"
+      >
+        {{ errorMessage }}
+      </p>
+
+      <template v-if="connected">
+        <p class="connectionStatus">
+          {{ t('Settings.Sync Settings.Connected as', { username: savedUsername }) }}
         </p>
-        <FtInput
-          :placeholder="t('Settings.Sync Settings.Password')"
-          :show-action-button="false"
-          :value="deleteAccountPassword"
-          input-type="password"
-          show-label
-          @input="deleteAccountPassword = $event"
-          @keydown.enter="deleteAccount"
-        />
         <p
-          v-if="deleteAccountError"
-          class="error"
+          v-if="privacyMode === 'enhanced'"
+          class="privacyStatus"
+        >
+          {{ t('Settings.Sync Settings.Enhanced Privacy Enabled') }}
+        </p>
+        <p
+          v-else-if="privacyMode === 'legacy'"
+          class="privacyWarning"
           role="alert"
         >
-          {{ deleteAccountError }}
+          {{ t('Settings.Sync Settings.Enhanced Privacy Unsupported') }}
+        </p>
+        <FtFlexBox class="toggles">
+          <FtToggleSwitch
+            :label="t('Settings.Sync Settings.Automatic Sync')"
+            :default-value="autoSync"
+            compact
+            @change="setAutoSync"
+          />
+          <FtToggleSwitch
+            :label="t('Subscriptions.Subscriptions')"
+            :default-value="syncSubscriptionsEnabled"
+            :disabled="busy"
+            compact
+            @change="store.dispatch('updateSyncServerSyncSubscriptions', $event)"
+          />
+          <FtToggleSwitch
+            :label="t('Playlists')"
+            :default-value="syncPlaylistsEnabled"
+            :disabled="busy"
+            compact
+            @change="store.dispatch('updateSyncServerSyncPlaylists', $event)"
+          />
+          <FtToggleSwitch
+            :label="t('History.History')"
+            :default-value="syncHistoryEnabled"
+            :disabled="busy || historySupported === false"
+            compact
+            @change="store.dispatch('updateSyncServerSyncHistory', $event)"
+          />
+          <FtToggleSwitch
+            :label="t('Settings.Sync Settings.Channel Playback Speeds')"
+            :default-value="syncPlaybackSpeedsEnabled"
+            :disabled="busy || playbackSpeedsSupported === false"
+            compact
+            @change="store.dispatch('updateSyncServerSyncPlaybackSpeeds', $event)"
+          />
+          <FtToggleSwitch
+            :label="t('Settings.Sync Settings.Profiles')"
+            :default-value="syncProfilesEnabled"
+            :disabled="busy"
+            compact
+            @change="store.dispatch('updateSyncServerSyncProfiles', $event)"
+          />
+          <FtToggleSwitch
+            v-if="sessionsSupported"
+            :label="t('Settings.Sync Settings.Open Tabs')"
+            :default-value="syncSessionsEnabled"
+            :disabled="busy"
+            compact
+            @change="store.dispatch('updateSyncServerSyncSessions', $event)"
+          />
+          <FtToggleSwitch
+            :label="t('Settings.Sync Settings.Settings')"
+            :default-value="syncSettingsEnabled"
+            :disabled="busy || settingsSupported === false"
+            compact
+            @change="store.dispatch('updateSyncServerSyncSettings', $event)"
+          />
+        </FtFlexBox>
+        <p
+          v-if="lastSyncLabel"
+          class="lastSync"
+        >
+          {{ t('Settings.Sync Settings.Last synced', { date: lastSyncLabel }) }}
+        </p>
+        <p
+          v-if="historySupported === false"
+          class="compatibilityWarning"
+        >
+          {{ t('Settings.Sync Settings.History not supported') }}
+        </p>
+        <p
+          v-if="playbackSpeedsSupported === false && settingsSupported"
+          class="compatibilityWarning"
+        >
+          {{ t('Settings.Sync Settings.Playback speeds not supported') }}
+        </p>
+        <p
+          v-else-if="playbackSpeedsSupported === false"
+          class="compatibilityWarning"
+        >
+          {{ t('Settings.Sync Settings.Playback speeds and settings not supported') }}
+        </p>
+        <p
+          v-else-if="settingsSupported === false"
+          class="compatibilityWarning"
+        >
+          {{ t('Settings.Sync Settings.Settings not supported') }}
         </p>
         <FtFlexBox class="actions">
           <FtButton
-            :label="t('Settings.Sync Settings.Confirm Delete Account')"
+            :label="t('Settings.Sync Settings.Sync Now')"
+            :icon="['fas', 'sync']"
+            :disabled="busy"
+            @click="syncNow"
+          />
+          <FtButton
+            :label="t('Settings.Sync Settings.Disconnect')"
+            :icon="['fas', 'right-from-bracket']"
+            :disabled="busy"
+            @click="disconnect"
+          />
+          <FtButton
+            :label="t('Settings.Sync Settings.Delete Account')"
             text-color="var(--destructive-text-color)"
             background-color="var(--destructive-color)"
             :icon="['fas', 'trash']"
-            @click="deleteAccount"
-          />
-          <FtButton
-            :label="t('Cancel')"
-            @click="closeDeleteAccountPrompt"
+            :disabled="busy"
+            @click="showDeleteAccountPrompt = true"
           />
         </FtFlexBox>
-      </div>
-    </FtPrompt>
+      </template>
+      <FtFlexBox
+        v-else-if="!busy"
+        class="actions"
+      >
+        <FtButton
+          :label="t('Settings.Sync Settings.Log In')"
+          :icon="['fas', 'right-to-bracket']"
+          :disabled="serverCredentialsDisabled"
+          @click="authenticate('login')"
+        />
+        <FtButton
+          :label="t('Settings.Sync Settings.Register')"
+          :icon="['fas', 'user-plus']"
+          :disabled="serverCredentialsDisabled"
+          @click="authenticate('register')"
+        />
+      </FtFlexBox>
+      <FtPrompt
+        v-if="dataLossWarning"
+        :label="t('Settings.Sync Settings.Data Loss Confirmation')"
+        theme="readable-width"
+        @click="dataLossWarning = null"
+      >
+        <div class="deleteAccountContent">
+          <p class="deleteAccountWarning">
+            {{ t('Settings.Sync Settings.Data Loss Warning', {
+              deleted: dataLossWarning.deleted,
+              previous: dataLossWarning.previous,
+              collection: dataLossWarning.collection,
+            }) }}
+          </p>
+          <FtFlexBox class="actions">
+            <FtButton
+              :label="t('Settings.Sync Settings.Confirm Data Loss')"
+              text-color="var(--destructive-text-color)"
+              background-color="var(--destructive-color)"
+              :icon="['fas', 'triangle-exclamation']"
+              @click="confirmDataLossSync"
+            />
+            <FtButton
+              :label="t('Cancel')"
+              @click="dataLossWarning = null"
+            />
+          </FtFlexBox>
+        </div>
+      </FtPrompt>
+      <FtPrompt
+        v-if="showDeleteAccountPrompt"
+        :label="t('Settings.Sync Settings.Delete Account Confirmation')"
+        theme="readable-width"
+        @click="closeDeleteAccountPrompt"
+      >
+        <div class="deleteAccountContent">
+          <p class="deleteAccountWarning">
+            {{ t('Settings.Sync Settings.Delete Account Warning') }}
+          </p>
+          <FtInput
+            :placeholder="t('Settings.Sync Settings.Password')"
+            :show-action-button="false"
+            :value="deleteAccountPassword"
+            input-type="password"
+            show-label
+            @input="deleteAccountPassword = $event"
+            @keydown.enter="deleteAccount"
+          />
+          <p
+            v-if="deleteAccountError"
+            class="error"
+            role="alert"
+          >
+            {{ deleteAccountError }}
+          </p>
+          <FtFlexBox class="actions">
+            <FtButton
+              :label="t('Settings.Sync Settings.Confirm Delete Account')"
+              text-color="var(--destructive-text-color)"
+              background-color="var(--destructive-color)"
+              :icon="['fas', 'trash']"
+              @click="deleteAccount"
+            />
+            <FtButton
+              :label="t('Cancel')"
+              @click="closeDeleteAccountPrompt"
+            />
+          </FtFlexBox>
+        </div>
+      </FtPrompt>
+    </template>
   </FtSettingsSection>
 </template>
 
@@ -373,6 +383,7 @@ const deleteAccountError = ref('')
 const dataLossWarning = ref(null)
 
 const savedUsername = computed(() => store.getters.getSyncServerUsername)
+const syncEnabled = computed(() => store.getters.getSyncServerEnabled)
 const connected = computed(() => store.getters.getSyncServerToken !== '')
 const privacyPolicyUrl = computed(() => {
   try {
@@ -438,14 +449,14 @@ const lastSyncLabel = computed(() => {
 let serverCheckTimer = null
 let serverCheckSequence = 0
 
-watch([serverUrl, connected], ([value, isConnected], [previousValue, wasConnected] = []) => {
+watch([serverUrl, connected, syncEnabled], ([value, isConnected, isEnabled], [previousValue, wasConnected] = []) => {
   clearTimeout(serverCheckTimer)
   const sequence = ++serverCheckSequence
   const disconnected = wasConnected && !isConnected && value === previousValue
   serverPrivacySupported.value = null
   serverCheckStatus.value = disconnected ? 'valid' : 'idle'
   serverCheckError.value = ''
-  if (isConnected || !value.trim()) return
+  if (!isEnabled || isConnected || !value.trim()) return
 
   serverCheckTimer = setTimeout(async () => {
     if (!disconnected) serverCheckStatus.value = 'checking'
@@ -536,6 +547,11 @@ async function disconnect() {
 
 function setAutoSync(enabled) {
   store.dispatch('setSyncServerAutoSync', enabled)
+}
+
+function setSyncEnabled(enabled) {
+  localError.value = ''
+  store.dispatch('setSyncServerEnabled', enabled)
 }
 
 function closeDeleteAccountPrompt() {

--- a/src/renderer/components/SyncSettings/SyncSettings.vue
+++ b/src/renderer/components/SyncSettings/SyncSettings.vue
@@ -7,6 +7,7 @@
       <FtToggleSwitch
         :label="t('Settings.Sync Settings.Enable Sync')"
         :default-value="syncEnabled"
+        :disabled="busy"
         compact
         @change="setSyncEnabled"
       />

--- a/src/renderer/components/ThemeSettings.vue
+++ b/src/renderer/components/ThemeSettings.vue
@@ -200,7 +200,6 @@
       />
     </FtFlexBox>
     <br>
-    <FtIconPackSwitcher />
     <FtPrompt
       v-if="showRestartPrompt"
       :label="$t('Settings[\'The app needs to restart for changes to take effect. Restart and apply change?\']')"
@@ -220,7 +219,6 @@ import FtSelect from './FtSelect/FtSelect.vue'
 import FtToggleSwitch from './FtToggleSwitch/FtToggleSwitch.vue'
 import FtSlider from './FtSlider/FtSlider.vue'
 import FtFlexBox from './ft-flex-box/ft-flex-box.vue'
-import FtIconPackSwitcher from './FtIconPackSwitcher/FtIconPackSwitcher.vue'
 import FtPrompt from './FtPrompt/FtPrompt.vue'
 
 import store from '../store/index'

--- a/src/renderer/helpers/sync-server-errors.js
+++ b/src/renderer/helpers/sync-server-errors.js
@@ -14,6 +14,13 @@ export class SyncServerError extends Error {
   }
 }
 
+export class SyncServerCancelledError extends Error {
+  constructor() {
+    super('Sync cancelled')
+    this.name = 'SyncServerCancelledError'
+  }
+}
+
 export class SyncServerDataLossError extends Error {
   constructor(collection, deleted, previous) {
     super(

--- a/src/renderer/helpers/sync-server.js
+++ b/src/renderer/helpers/sync-server.js
@@ -1,6 +1,7 @@
 import { MAIN_PROFILE_ID } from '../../constants'
 import {
   SyncServerDataLossError,
+  SyncServerCancelledError,
   SyncServerError,
   SYNC_SERVER_SESSION_EXPIRED_MESSAGE,
   isExpiredSessionReauthentication,
@@ -22,6 +23,7 @@ const YOUTUBE_VIDEO_THUMBNAIL_REGEX = /^https?:\/\/i\.ytimg\.com\/vi(?:_webp)?\/
 
 export {
   SyncServerDataLossError,
+  SyncServerCancelledError,
   SyncServerError,
   SYNC_SERVER_SESSION_EXPIRED_MESSAGE,
   isExpiredSessionReauthentication,
@@ -57,10 +59,19 @@ export class SyncServerClient {
     this.token = token
     this.apiPrefix = null
     this.capabilitiesPromise = null
+    this.requestControllers = new Set()
+    this.cancelled = false
+  }
+
+  cancel() {
+    this.cancelled = true
+    for (const controller of this.requestControllers) controller.abort()
   }
 
   async request(path, { timeoutMs = REQUEST_TIMEOUT_MS, ...options } = {}) {
+    if (this.cancelled) throw new SyncServerCancelledError()
     const controller = new AbortController()
+    this.requestControllers.add(controller)
     const timeout = setTimeout(() => controller.abort(), timeoutMs)
     const headers = { Accept: 'application/json', ...options.headers }
 
@@ -96,11 +107,13 @@ export class SyncServerClient {
         throw error
       }
       if (error?.name === 'AbortError') {
+        if (this.cancelled) throw new SyncServerCancelledError()
         throw new SyncServerError('Sync server request timed out')
       }
       throw new SyncServerError(error?.message || 'Unable to reach sync server')
     } finally {
       clearTimeout(timeout)
+      this.requestControllers.delete(controller)
     }
   }
 

--- a/src/renderer/icons/iconPackState.js
+++ b/src/renderer/icons/iconPackState.js
@@ -1,8 +1,8 @@
 import { computed, ref } from 'vue'
 
 export const ICON_PACKS = /** @type {const} */ ([
-  { id: 'material', label: 'Material Symbols' },
   { id: 'fontawesome', label: 'Font Awesome (legacy)' },
+  { id: 'material', label: 'Material Symbols' },
   { id: 'tabler', label: 'Tabler' },
   { id: 'phosphor', label: 'Phosphor' },
   { id: 'lucide', label: 'Lucide' },
@@ -28,7 +28,7 @@ function readStoredPack() {
   } catch {
     // ignore (private mode / unavailable storage)
   }
-  return 'material'
+  return 'fontawesome'
 }
 
 /** @type {import('vue').Ref<IconPackId>} */

--- a/src/renderer/store/modules/settings.js
+++ b/src/renderer/store/modules/settings.js
@@ -361,6 +361,7 @@ const state = {
   toastPosition: 'bottom-left',
   extraThumbnailAction: '',
   blurThumbnails: false,
+  syncServerEnabled: false,
   syncServerUrl: 'https://sync.d3sox.me',
   syncServerUsername: '',
   syncServerToken: '',
@@ -591,6 +592,7 @@ export const NON_TRANSFERABLE_SETTINGS = new Set([
   'settingsPassword',
   'screenshotAskPath',
   'screenshotFolderPath',
+  'syncServerEnabled',
   'syncServerUrl',
   'syncServerUsername',
   'syncServerToken',
@@ -757,6 +759,14 @@ const customActions = {
 
       if (legacyAutoPipModeEntry && !hasScrollMiniSetting) {
         await dispatch('updateScrollMiniPlayerEnabled', legacyAutoPipModeEntry.value !== 'never')
+      }
+
+      // Existing logged-in sync users keep sync enabled; everyone else starts off
+      // so the default server is not contacted until the user opts in.
+      const hasSyncServerEnabledSetting = userSettings.some(entry => entry._id === 'syncServerEnabled')
+      if (!hasSyncServerEnabledSetting) {
+        const token = typeof state.syncServerToken === 'string' ? state.syncServerToken : ''
+        await dispatch('updateSyncServerEnabled', token !== '')
       }
 
       for (const _id of settingsWithSideEffects) {

--- a/src/renderer/store/modules/settings.js
+++ b/src/renderer/store/modules/settings.js
@@ -763,11 +763,10 @@ const customActions = {
 
       // Existing logged-in sync users keep sync enabled; everyone else starts off
       // so the default server is not contacted until the user opts in.
-      // Use setSyncServerEnabled so enablement also starts the sync lifecycle.
       const hasSyncServerEnabledSetting = userSettings.some(entry => entry._id === 'syncServerEnabled')
       if (!hasSyncServerEnabledSetting) {
         const token = typeof state.syncServerToken === 'string' ? state.syncServerToken : ''
-        await dispatch('setSyncServerEnabled', token !== '', { root: true })
+        await dispatch('updateSyncServerEnabled', token !== '')
       }
 
       for (const _id of settingsWithSideEffects) {

--- a/src/renderer/store/modules/settings.js
+++ b/src/renderer/store/modules/settings.js
@@ -763,10 +763,11 @@ const customActions = {
 
       // Existing logged-in sync users keep sync enabled; everyone else starts off
       // so the default server is not contacted until the user opts in.
+      // Use setSyncServerEnabled so enablement also starts the sync lifecycle.
       const hasSyncServerEnabledSetting = userSettings.some(entry => entry._id === 'syncServerEnabled')
       if (!hasSyncServerEnabledSetting) {
         const token = typeof state.syncServerToken === 'string' ? state.syncServerToken : ''
-        await dispatch('updateSyncServerEnabled', token !== '')
+        await dispatch('setSyncServerEnabled', token !== '', { root: true })
       }
 
       for (const _id of settingsWithSideEffects) {

--- a/src/renderer/store/modules/sync-server.js
+++ b/src/renderer/store/modules/sync-server.js
@@ -361,6 +361,9 @@ const actions = {
     if (mode !== 'login' && mode !== 'register') {
       throw new Error('Invalid authentication mode')
     }
+    if (!rootState.settings.syncServerEnabled) {
+      throw new Error('Enable sync first')
+    }
 
     const normalizedUrl = normalizeSyncServerUrl(serverUrl)
     const trimmedUsername = username.trim()
@@ -484,6 +487,9 @@ const actions = {
   },
 
   syncWithSyncServer(context, options = {}) {
+    if (!context.rootState.settings.syncServerEnabled) {
+      return Promise.reject(new Error('Enable sync first'))
+    }
     if (!context.rootState.settings.syncServerToken) {
       return Promise.reject(new Error('Connect to a sync server first'))
     }
@@ -509,7 +515,7 @@ const actions = {
   },
 
   async initializeSyncServer({ commit, dispatch, rootState }) {
-    if (!rootState.settings.syncServerToken) return
+    if (!rootState.settings.syncServerEnabled || !rootState.settings.syncServerToken) return
 
     try {
       const client = new SyncServerClient(
@@ -548,6 +554,7 @@ const actions = {
 
   startSyncServerAutoSync({ dispatch, rootState }) {
     if (autoSyncTimer ||
+        !rootState.settings.syncServerEnabled ||
         !rootState.settings.syncServerAutoSync ||
         !rootState.settings.syncServerToken ||
         !isSyncReasonEnabled(rootState.settings, 'automatic')) {
@@ -576,7 +583,8 @@ const actions = {
   },
 
   scheduleSyncServer({ dispatch, rootState }, reason = 'data') {
-    if (!rootState.settings.syncServerAutoSync ||
+    if (!rootState.settings.syncServerEnabled ||
+        !rootState.settings.syncServerAutoSync ||
         !rootState.settings.syncServerToken ||
         !isSyncReasonEnabled(rootState.settings, reason) ||
         rootState.syncServer.syncServerStatus === 'syncing') {
@@ -596,6 +604,17 @@ const actions = {
   async setSyncServerAutoSync({ dispatch }, enabled) {
     await dispatch('updateSyncServerAutoSync', enabled, { root: true })
     await dispatch(enabled ? 'startSyncServerAutoSync' : 'stopSyncServerAutoSync')
+  },
+
+  async setSyncServerEnabled({ dispatch, rootState }, enabled) {
+    await dispatch('updateSyncServerEnabled', enabled, { root: true })
+    if (!enabled) {
+      await dispatch('stopSyncServerAutoSync')
+      return
+    }
+    if (rootState.settings.syncServerToken) {
+      await dispatch('initializeSyncServer')
+    }
   },
 }
 

--- a/src/renderer/store/modules/sync-server.js
+++ b/src/renderer/store/modules/sync-server.js
@@ -43,6 +43,14 @@ let activeSyncPromise = null
 let autoSyncTimer = null
 let eventSyncTimer = null
 let lifecycleSyncStarted = false
+let syncGeneration = 0
+
+class SyncServerCancelledError extends Error {
+  constructor() {
+    super('Sync cancelled')
+    this.name = 'SyncServerCancelledError'
+  }
+}
 
 const state = {
   syncServerStatus: 'idle',
@@ -82,6 +90,7 @@ function withSyncLock(callback) {
 async function runSync(context, { allowDataLoss = false } = {}) {
   const { commit, dispatch, rootState } = context
   const settings = rootState.settings
+  const runId = syncGeneration
   const networkClient = new SyncServerClient(settings.syncServerUrl, settings.syncServerToken)
   let client = networkClient
   let encryptedCollections = null
@@ -109,12 +118,20 @@ async function runSync(context, { allowDataLoss = false } = {}) {
   ]
   let completedStages = 0
 
+  function assertSyncStillActive() {
+    if (runId !== syncGeneration || !rootState.settings.syncServerEnabled) {
+      throw new SyncServerCancelledError()
+    }
+  }
+
   async function runStage(stage, callback) {
+    assertSyncStillActive()
     commit('setSyncServerProgress', {
       stage,
       percentage: Math.round((completedStages / stages.length) * 100),
     })
     const value = await callback()
+    assertSyncStillActive()
     completedStages++
     commit('setSyncServerProgress', {
       stage,
@@ -277,6 +294,7 @@ async function runSync(context, { allowDataLoss = false } = {}) {
     if (encryptedCollections) {
       await runStage('upload', async () => {
         for (const collection of encryptedCollections.upload) {
+          assertSyncStillActive()
           let revision = encryptedCollections.remote[collection].revision
           let data = client.document[collection]
           if (revision > 0 &&
@@ -336,6 +354,12 @@ async function runSync(context, { allowDataLoss = false } = {}) {
     commit('setSyncServerStatus', 'success')
     return result
   } catch (error) {
+    if (error instanceof SyncServerCancelledError) {
+      commit('setSyncServerProgress', null)
+      commit('setSyncServerError', '')
+      commit('setSyncServerStatus', 'idle')
+      return null
+    }
     if (error instanceof SyncServerDataLossError) {
       await dispatch('setSyncServerAutoSync', false)
     }
@@ -606,10 +630,15 @@ const actions = {
     await dispatch(enabled ? 'startSyncServerAutoSync' : 'stopSyncServerAutoSync')
   },
 
-  async setSyncServerEnabled({ dispatch, rootState }, enabled) {
+  async setSyncServerEnabled({ commit, dispatch, rootState }, enabled) {
     await dispatch('updateSyncServerEnabled', enabled, { root: true })
     if (!enabled) {
+      // Invalidate any in-flight run so later stages/uploads stop contacting the server.
+      syncGeneration++
       await dispatch('stopSyncServerAutoSync')
+      commit('setSyncServerProgress', null)
+      commit('setSyncServerError', '')
+      commit('setSyncServerStatus', 'idle')
       return
     }
     if (rootState.settings.syncServerToken) {

--- a/src/renderer/store/modules/sync-server.js
+++ b/src/renderer/store/modules/sync-server.js
@@ -1,5 +1,6 @@
 import {
   SyncServerClient,
+  SyncServerCancelledError,
   SyncServerDataLossError,
   SYNC_SERVER_SESSION_EXPIRED_MESSAGE,
   isExpiredSessionReauthentication,
@@ -40,17 +41,10 @@ const LEGACY_ENCRYPTED_COLLECTIONS = [
 ]
 
 let activeSyncPromise = null
+let activeSyncClient = null
 let autoSyncTimer = null
 let eventSyncTimer = null
 let lifecycleSyncStarted = false
-let syncGeneration = 0
-
-class SyncServerCancelledError extends Error {
-  constructor() {
-    super('Sync cancelled')
-    this.name = 'SyncServerCancelledError'
-  }
-}
 
 const state = {
   syncServerStatus: 'idle',
@@ -90,8 +84,8 @@ function withSyncLock(callback) {
 async function runSync(context, { allowDataLoss = false } = {}) {
   const { commit, dispatch, rootState } = context
   const settings = rootState.settings
-  const runId = syncGeneration
   const networkClient = new SyncServerClient(settings.syncServerUrl, settings.syncServerToken)
+  activeSyncClient = networkClient
   let client = networkClient
   let encryptedCollections = null
   const previous = parseSnapshot(settings.syncServerSnapshot)
@@ -119,7 +113,7 @@ async function runSync(context, { allowDataLoss = false } = {}) {
   let completedStages = 0
 
   function assertSyncStillActive() {
-    if (runId !== syncGeneration || !rootState.settings.syncServerEnabled) {
+    if (networkClient.cancelled || !rootState.settings.syncServerEnabled) {
       throw new SyncServerCancelledError()
     }
   }
@@ -374,6 +368,8 @@ async function runSync(context, { allowDataLoss = false } = {}) {
     commit('setSyncServerError', error.message)
     commit('setSyncServerStatus', 'error')
     throw error
+  } finally {
+    if (activeSyncClient === networkClient) activeSyncClient = null
   }
 }
 
@@ -522,6 +518,7 @@ const actions = {
       clearTimeout(eventSyncTimer)
       eventSyncTimer = null
       activeSyncPromise = withSyncLock(() => {
+        if (!context.rootState.settings.syncServerEnabled) return null
         if (options.skipIfRecent &&
             isRecentSync(context.rootState.settings.syncServerLastSyncAt)) {
           return null
@@ -631,10 +628,9 @@ const actions = {
   },
 
   async setSyncServerEnabled({ commit, dispatch, rootState }, enabled) {
+    if (!enabled) activeSyncClient?.cancel()
     await dispatch('updateSyncServerEnabled', enabled, { root: true })
     if (!enabled) {
-      // Invalidate any in-flight run so later stages/uploads stop contacting the server.
-      syncGeneration++
       await dispatch('stopSyncServerAutoSync')
       commit('setSyncServerProgress', null)
       commit('setSyncServerError', '')

--- a/src/searchEngines.js
+++ b/src/searchEngines.js
@@ -3,25 +3,25 @@ export const DEFAULT_SEARCH_ENGINES = Object.freeze([
     id: 'duckduckgo',
     name: 'DuckDuckGo',
     url: 'https://duckduckgo.com/?q=%s',
-    enabled: true
+    enabled: false
   },
   {
     id: 'startpage',
     name: 'Startpage',
     url: 'https://www.startpage.com/sp/search?query=%s',
-    enabled: true
+    enabled: false
   },
   {
     id: 'qwant',
     name: 'Qwant',
     url: 'https://www.qwant.com/?q=%s',
-    enabled: true
+    enabled: false
   },
   {
     id: 'brave',
     name: 'Brave Search',
     url: 'https://search.brave.com/search?q=%s',
-    enabled: true
+    enabled: false
   }
 ])
 

--- a/static/locales/en-US.yaml
+++ b/static/locales/en-US.yaml
@@ -430,6 +430,7 @@ Settings:
   Context Menu Search Settings:
     Context Menu Search Settings: Context Menu Search
     Description: Choose which search engines appear when you right-click selected text. Searches open in your default browser.
+    Icon Hint: Enabling an engine contacts its website to load the favicon.
     Engine Name: Engine name
     Search URL: Search URL
     URL Hint: Use %s where the URL should contain the encoded selected text.
@@ -917,6 +918,7 @@ Settings:
     Manage Subscriptions: Manage Subscriptions
   Sync Settings:
     Sync Settings: Sync
+    Enable Sync: Enable Sync
     Privacy Passphrase: Privacy passphrase
     Privacy Passphrase Hint: Use a separate passphrase from your account password. It never leaves this device and is required on every device; losing it makes encrypted sync data unrecoverable.
     Privacy Policy: Privacy policy for this server

--- a/tests/unit/search-engines.test.mjs
+++ b/tests/unit/search-engines.test.mjs
@@ -10,6 +10,16 @@ import {
   parseSearchEngines
 } from '../../src/searchEngines.js'
 
+test('defaults built-in engines to disabled', () => {
+  const engines = parseSearchEngines(undefined)
+
+  assert.equal(engines.every(engine => engine.enabled === false), true)
+  assert.deepEqual(
+    engines.map(({ id, enabled }) => ({ id, enabled })),
+    DEFAULT_SEARCH_ENGINES.map(({ id, enabled }) => ({ id, enabled }))
+  )
+})
+
 test('uses canonical built-ins and preserves their enabled states', () => {
   const engines = parseSearchEngines(JSON.stringify([
     { id: 'duckduckgo', name: 'Changed', url: 'https://example.com/?q=%s', enabled: false }

--- a/tests/unit/sync-server-session.test.mjs
+++ b/tests/unit/sync-server-session.test.mjs
@@ -2,10 +2,17 @@ import assert from 'node:assert/strict'
 import test from 'node:test'
 
 import {
+  SyncServerCancelledError,
   SyncServerError,
   isExpiredSessionReauthentication,
   isSessionExpiredError,
 } from '../../src/renderer/helpers/sync-server-errors.js'
+
+test('sync cancellation has a distinct error type', () => {
+  const error = new SyncServerCancelledError()
+  assert.equal(error.name, 'SyncServerCancelledError')
+  assert.equal(error.message, 'Sync cancelled')
+})
 
 test('treats 401 as an expired session', () => {
   assert.equal(


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Make sure to follow the contributing guidelines. -->
<!-- Important note, we may remove your pull request if you do not use this provided PR template correctly. -->

## Pull Request Type
<!-- Please select what type of pull request this is: [x] -->
- [ ] Bugfix
- [x] Feature Implementation
- [ ] Documentation
- [ ] Other

## Related issue
<!-- Please link the issue your pull request is referring to. -->
<!-- If this pull request fully resolves the relevant issue, put "closes" before the issue number. -->
<!-- Example: "closes #123456". -->
Resolves #423

## Description
<!-- Please write a clear and concise description of what the pull request does. -->
Stop contacting remote sync and search-engine endpoints until the user opts in.

- Add an **Enable Sync** toggle (off by default). Opening Settings no longer probes the sync server `/health` until sync is enabled. Existing users who already have a sync token are migrated to keep sync enabled.
- Disable built-in context-menu search engines by default so favicon resolution does not contact search providers. Settings only fetch favicons for enabled engines, with a short hint that enabling contacts the site for the favicon.
- Move the icon pack preview to Experimental and restore Font Awesome as the default pack.

## Screenshots <!-- If appropriate -->
<!-- Please add before and after screenshots if there is a visible change. -->

## Release note category
<!-- Select exactly one category. Every pull request must select one. -->
<!-- release-note-category:start -->
- [ ] Not noteworthy
- [ ] Highlights
- [x] More improvements
- [ ] Fixed bugs
<!-- release-note-category:end -->

## Release note
<!-- Required unless "Not noteworthy" is selected. -->
<!-- Write one concise, user-facing entry without a leading bullet. -->
<!-- release-note:start -->
We’re sorry: OpenTubeX could contact the default sync server and search providers before you explicitly opted in. Sync and context-menu search engines are now off by default, and no related requests are made until you enable them.
<!-- release-note:end -->

## Release note images
<!-- Optional. Paste one or more Markdown images or HTML image tags here. -->
<!-- The release notes will use an HTML image tag and limit images taller than 300 pixels. -->
<!-- release-note-image:start -->

<!-- release-note-image:end -->

## Testing
<!-- How can reviewers verify that the PR produces correct results? -->
1. Fresh profile: open Settings → Sync and confirm Enable Sync is off and no request goes to the default sync URL until it is turned on.
2. Profile with an existing sync token from before this change: confirm Enable Sync is on after upgrade and sync still works.
3. Fresh profile: right-click selected text and confirm there is no Search with… entry until engines are enabled under Context Menu Search.
4. Enable a search engine and confirm its favicon loads; confirm the favicon hint is shown in that settings section.
5. Confirm Icon Pack is under Experimental and defaults to Font Awesome on a fresh profile.

## Desktop
<!-- Please complete the following information-->
- **OS:** Linux
- **OS Version:** Arch
- **OpenTubeX version:** development

## Additional context
<!-- Add any other context about the pull request here. -->