### PR TITLE
fix(e2e): stabilize scheduled test run

### DIFF
--- a/e2e/playwright.config.mjs
+++ b/e2e/playwright.config.mjs
@@ -11,7 +11,9 @@ export default defineConfig({
   expect: {
     timeout: 15_000
   },
-  workers: process.env.CI ? 2 : undefined,
+  // Electron windows share the CI X server, so parallel pointer input can
+  // move another test's cursor and interrupt drags or auto-hide timers.
+  workers: process.env.CI ? 1 : undefined,
   reporter: [['list'], ['html', { outputFolder: 'report', open: 'never' }]],
   use: {
     trace: 'retain-on-failure'

--- a/e2e/tests/offline/subscriptions-new-feed.spec.mjs
+++ b/e2e/tests/offline/subscriptions-new-feed.spec.mjs
@@ -153,7 +153,9 @@ test.describe('new subscriptions feed', () => {
     await goTo(page, 'subscriptions')
     await page.locator('[data-subscription-feed-tab="all"]').click()
 
-    const video = page.locator('.ft-list-video').filter({ hasText: 'New video' })
+    const video = page.locator('.ft-list-video').filter({
+      has: page.getByRole('heading', { name: 'New video', exact: true })
+    })
     await video.locator('.thumbnailLink').click({ button: 'right' })
 
     await expect(page.getByRole('menu', { name: 'Context menu' })).toBeVisible()

--- a/src/renderer/components/FtIcon/FtIcon.vue
+++ b/src/renderer/components/FtIcon/FtIcon.vue
@@ -12,6 +12,8 @@
   <span
     v-else
     v-bind="forwardedAttrs"
+    :data-prefix="semanticIcon?.[0]"
+    :data-icon="semanticIcon?.[1]"
     class="ft-icon"
     :class="[{ 'ft-icon--fw': fixedWidth }, iconClass]"
     :style="iconifyWrapperStyle"
@@ -32,8 +34,9 @@ import { computed, normalizeStyle, useAttrs } from 'vue'
 import { Icon } from '@iconify/vue/offline'
 import { FontAwesomeIcon } from '@fortawesome/vue-fontawesome-original'
 
+import faAliasToCanon from '../../icons/faAliasToCanon.json'
 import { currentIconPack } from '../../icons/iconPackState'
-import { resolveIconifyId } from '../../icons/resolveIconifyId'
+import { normalizeFaIcon, resolveIconifyId } from '../../icons/resolveIconifyId'
 
 defineOptions({
   inheritAttrs: false
@@ -83,6 +86,17 @@ const attrs = useAttrs()
 const useFontAwesome = computed(() => currentIconPack.value === 'fontawesome')
 
 const iconifyId = computed(() => resolveIconifyId(props.icon))
+
+// Preserve Font Awesome's semantic metadata when a different pack renders the
+// glyph. Existing styling and consumers can then identify an icon independently
+// of the active pack's visual name.
+const semanticIcon = computed(() => {
+  const normalized = normalizeFaIcon(props.icon)
+  if (!normalized) {
+    return null
+  }
+  return [normalized[0], faAliasToCanon[normalized[1]] || normalized[1]]
+})
 
 const iconClass = computed(() => attrs.class)
 


### PR DESCRIPTION
## Pull Request Type
<!-- Please select what type of pull request this is: [x] -->
- [x] Bugfix
- [ ] Feature Implementation
- [ ] Documentation
- [ ] Other

## Related issue
<!-- Please link the issue your pull request is referring to. -->
<!-- If this pull request fully resolves the relevant issue, put "closes" before the issue number. -->
<!-- Example: "closes #123456". -->

Scheduled E2E run: https://github.com/OpenTubeX/OpenTubeX/actions/runs/30687291116

## Description
<!-- Please write a clear and concise description of what the pull request does. -->

Restores Font Awesome-compatible semantic metadata on Iconify-rendered icons so existing E2E assertions and RTL selectors continue to identify icons independently of the active visual pack. Canonical Font Awesome aliases are preserved, such as `sliders-h` rendering as `data-icon="sliders"`.

The scheduled run also exposed pointer interference between Electron windows sharing one CI X server. CI E2E tests now use one worker so a test cannot move another test's cursor during a drag or auto-hide timer. A New-feed test selector is narrowed to an exact heading to avoid matching both "New video" and "Watched new video".

## Screenshots <!-- If appropriate -->
<!-- Please add before and after screenshots if there is a visible change. -->

Not applicable; there is no intended visual change.

## Release note category
<!-- Select exactly one category. Every pull request must select one. -->
<!-- release-note-category:start -->
- [x] Not noteworthy
- [ ] Highlights
- [ ] More improvements
- [ ] Fixed bugs
<!-- release-note-category:end -->

## Release note
<!-- Required unless "Not noteworthy" is selected. -->
<!-- Write one concise, user-facing entry without a leading bullet. -->
<!-- release-note:start -->

<!-- release-note:end -->

## Release note images
<!-- Optional. Paste one or more Markdown images or HTML image tags here. -->
<!-- The release notes will use an HTML image tag and limit images taller than 300 pixels. -->
<!-- release-note-image:start -->

<!-- release-note-image:end -->

## Testing
<!-- How can reviewers verify that the PR produces correct results? -->
<!-- Please provide instructions so that others can ensure that your pull request would produce correct results. For examples see, https://github.com/FreeTubeApp/FreeTube/pull/5743, https://github.com/FreeTubeApp/FreeTube/pull/7349, https://github.com/FreeTubeApp/FreeTube/pull/5125, https://github.com/FreeTubeApp/FreeTube/pull/7338 -->

- `pnpm run lint`
- `pnpm run test:unit` (157 passed)
- `pnpm run test:e2e:pack`
- `CI=1 xvfb-run -a -s "-screen 0 1920x1080x24" pnpm run test:e2e:offline` (226 passed)
- Scheduled scrollbar drag regression repeated 5 times successfully

## Desktop
<!-- Please complete the following information-->
- **OS:** Arch Linux
- **OS Version:** Rolling release
- **OpenTubeX version:** development at f7d30963a401653fe2b408c0df60bb9a1ade400a

## Additional context
<!-- Add any other context about the pull request here. -->

The CI worker reduction trades some runtime for deterministic Electron pointer input on the shared X server.