### PR TITLE
fix(player): keep PiP media controls on source tab

### DIFF
--- a/src/renderer/components/ft-shaka-video-player/ft-shaka-video-player.js
+++ b/src/renderer/components/ft-shaka-video-player/ft-shaka-video-player.js
@@ -4434,6 +4434,7 @@ export default defineComponent({
      */
     function handleEnterPictureInPicture(event) {
       pipWindow = event.pictureInPictureWindow
+      tabMediaCoordinator.setPictureInPicture(mediaTabId, true)
       handlePictureInPictureResize()
       pipWindow.addEventListener('resize', handlePictureInPictureResize)
 
@@ -4443,6 +4444,8 @@ export default defineComponent({
     }
 
     function handleLeavePictureInPicture() {
+      tabMediaCoordinator.setPictureInPicture(mediaTabId, false)
+
       if (pipWindow) {
         pipWindow.removeEventListener('resize', handlePictureInPictureResize)
       }

--- a/src/renderer/tabs/TabMediaCoordinator.js
+++ b/src/renderer/tabs/TabMediaCoordinator.js
@@ -121,7 +121,7 @@ export const tabMediaCoordinator = {
 
   setPictureInPicture(tabId, active) {
     if (active) {
-      if (!getEntry(tabId)) {
+      if (!mediaByTabId.has(tabId)) {
         return
       }
       pictureInPictureTabId = tabId

--- a/src/renderer/tabs/TabMediaCoordinator.js
+++ b/src/renderer/tabs/TabMediaCoordinator.js
@@ -13,6 +13,7 @@ const MEDIA_SESSION_ACTIONS = [
 const mediaByTabId = new Map()
 let presentedTabId = null
 let ownerTabId = null
+let pictureInPictureTabId = null
 let playSequence = 0
 let powerSaveBlocked = false
 
@@ -35,6 +36,10 @@ function getEntry(tabId) {
 }
 
 function chooseOwner() {
+  if (pictureInPictureTabId && mediaByTabId.has(pictureInPictureTabId)) {
+    return pictureInPictureTabId
+  }
+
   const presented = mediaByTabId.get(presentedTabId)
   if (presented?.playbackState === 'playing') {
     return presentedTabId
@@ -114,6 +119,18 @@ export const tabMediaCoordinator = {
     applyOwner()
   },
 
+  setPictureInPicture(tabId, active) {
+    if (active) {
+      if (!getEntry(tabId)) {
+        return
+      }
+      pictureInPictureTabId = tabId
+    } else if (pictureInPictureTabId === tabId) {
+      pictureInPictureTabId = null
+    }
+    applyOwner()
+  },
+
   setPlaybackState(tabId, playbackState) {
     const entry = getEntry(tabId)
     if (!entry) {
@@ -166,6 +183,9 @@ export const tabMediaCoordinator = {
 
   unregister(tabId) {
     mediaByTabId.delete(tabId)
+    if (pictureInPictureTabId === tabId) {
+      pictureInPictureTabId = null
+    }
     if (ownerTabId === tabId) {
       ownerTabId = null
     }

--- a/tests/unit/tab-media-coordinator.test.mjs
+++ b/tests/unit/tab-media-coordinator.test.mjs
@@ -52,4 +52,10 @@ test('keeps media controls associated with a paused PiP video', (t) => {
   handlers.get('play')()
 
   assert.deepEqual(played, ['pip-tab', 'active-tab'])
+
+  tabMediaCoordinator.unregister('pip-tab')
+  tabMediaCoordinator.setPictureInPicture('pip-tab', true)
+  handlers.get('play')()
+
+  assert.deepEqual(played, ['pip-tab', 'active-tab', 'active-tab'])
 })

--- a/tests/unit/tab-media-coordinator.test.mjs
+++ b/tests/unit/tab-media-coordinator.test.mjs
@@ -1,0 +1,55 @@
+import assert from 'node:assert/strict'
+import test from 'node:test'
+
+import { tabMediaCoordinator } from '../../src/renderer/tabs/TabMediaCoordinator.js'
+
+test('keeps media controls associated with a paused PiP video', (t) => {
+  const handlers = new Map()
+  const played = []
+  const navigatorDescriptor = Object.getOwnPropertyDescriptor(globalThis, 'navigator')
+
+  Object.defineProperty(globalThis, 'navigator', {
+    configurable: true,
+    value: {
+      mediaSession: {
+        metadata: null,
+        playbackState: 'none',
+        setActionHandler (action, handler) {
+          handlers.set(action, handler)
+        }
+      }
+    }
+  })
+  t.after(() => {
+    tabMediaCoordinator.unregister('pip-tab')
+    tabMediaCoordinator.unregister('active-tab')
+    if (navigatorDescriptor) {
+      Object.defineProperty(globalThis, 'navigator', navigatorDescriptor)
+    } else {
+      delete globalThis.navigator
+    }
+  })
+
+  tabMediaCoordinator.setActionHandlers('pip-tab', 'player', {
+    play: () => played.push('pip-tab')
+  })
+  tabMediaCoordinator.setMetadata('pip-tab', { title: 'PiP video' })
+  tabMediaCoordinator.setPlaybackState('pip-tab', 'playing')
+
+  tabMediaCoordinator.setActionHandlers('active-tab', 'player', {
+    play: () => played.push('active-tab')
+  })
+  tabMediaCoordinator.setMetadata('active-tab', { title: 'Active video' })
+  tabMediaCoordinator.setPresented('active-tab')
+
+  tabMediaCoordinator.setPictureInPicture('pip-tab', true)
+  tabMediaCoordinator.setPlaybackState('pip-tab', 'paused')
+  handlers.get('play')()
+
+  assert.deepEqual(played, ['pip-tab'])
+
+  tabMediaCoordinator.setPictureInPicture('pip-tab', false)
+  handlers.get('play')()
+
+  assert.deepEqual(played, ['pip-tab', 'active-tab'])
+})


### PR DESCRIPTION
## Pull Request Type
- [x] Bugfix
- [ ] Feature Implementation
- [ ] Documentation
- [ ] Other

## Related issue
Closes #389.

## Description
Tracks the tab whose video is currently presented in Picture-in-Picture and keeps that tab as the Media Session owner until PiP closes. Previously, pausing the PiP video allowed ownership to fall back to the active tab, so the native PiP Play control could start the wrong video. PiP ownership is also cleared when its source tab is unregistered.

## Screenshots
Not applicable; this changes native media-control routing without changing the UI.

## Release note category
<!-- release-note-category:start -->
- [ ] Not noteworthy
- [ ] Highlights
- [ ] More improvements
- [x] Fixed bugs
<!-- release-note-category:end -->

## Release note
<!-- release-note:start -->
Fixed Picture-in-Picture controls resuming the video in the active tab instead of the PiP video.
<!-- release-note:end -->

## Release note images
<!-- release-note-image:start -->

<!-- release-note-image:end -->

## Testing
1. Enable automatic Picture-in-Picture when switching tabs.
2. Play a video in one tab, then switch to a tab containing another paused video.
3. Pause and resume the first video with the native PiP controls.
4. Confirm the PiP video resumes and the active tab remains paused.

Automated checks:
- `pnpm test:unit` (158 tests)
- ESLint on the changed production files and regression test
- `pnpm run test:e2e:pack`

## Desktop
- **OS:** Arch Linux
- **OS Version:** Rolling release
- **OpenTubeX version:** v0.30.1 nightly

## Additional context
The regression test directly exercises Media Session ownership while the PiP source is paused and verifies ownership returns to the presented tab after PiP exits.