### PR TITLE
fix: load member-only playlists and preserve caption size

### DIFF
--- a/e2e/tests/network/playlist.spec.mjs
+++ b/e2e/tests/network/playlist.spec.mjs
@@ -1,0 +1,24 @@
+import { sel } from '../../helpers/app.mjs'
+import { test, expect } from '../../helpers/innertube.mjs'
+
+const MEMBERS_ONLY_PLAYLIST = {
+  id: 'PLIwiAebpd5CK-T-TP6lnpLI5heKC9zDlc',
+  title: 'Baba Is You',
+  url: 'https://www.youtube.com/playlist?list=PLIwiAebpd5CK-T-TP6lnpLI5heKC9zDlc'
+}
+
+test('loads playlists containing members-only videos', async ({ page, innertube }) => {
+  test.skip(innertube.replay, 'playlist hydration needs the real API')
+
+  await page.locator(sel.searchInput).fill(MEMBERS_ONLY_PLAYLIST.url)
+  await page.locator(sel.searchInput).press('Enter')
+
+  await expect(page).toHaveURL(new RegExp(`#\\/playlist\\/${MEMBERS_ONLY_PLAYLIST.id}`))
+  await expect(page.locator('.playlistTitle')).toContainText(MEMBERS_ONLY_PLAYLIST.title, {
+    timeout: 30_000
+  })
+  await expect.poll(
+    () => page.locator('.playlistItems .playlistItem').count(),
+    { timeout: 30_000 }
+  ).toBeGreaterThan(20)
+})

--- a/e2e/tests/network/watch.spec.mjs
+++ b/e2e/tests/network/watch.spec.mjs
@@ -1150,8 +1150,9 @@ test.describe('watch page', () => {
       }
     })
 
-    test('keeps the configured caption size in fullscreen', async ({ page, innertube }) => {
+    test('keeps the configured caption size in fullscreen', async ({ app, innertube }) => {
       test.skip(innertube.replay, 'watch page hydration needs the real API')
+      const { page } = app
       await openVideo(page)
 
       const player = page.locator('.ftVideoPlayer')
@@ -1174,10 +1175,16 @@ test.describe('watch page', () => {
       })
       expect(windowedFontSizes).toEqual(['30px', '30px'])
 
+      await setWindowWidth(app, 400)
+      const narrowFontSizes = ['24px', '24px']
+      await expect.poll(async () => captionContainers.evaluateAll(elements => {
+        return elements.map(element => getComputedStyle(element).fontSize)
+      })).toEqual(narrowFontSizes)
+
       await setPlayerFullscreen(page, true)
       await expect.poll(async () => captionContainers.evaluateAll(elements => {
         return elements.map(element => getComputedStyle(element).fontSize)
-      })).toEqual(windowedFontSizes)
+      })).toEqual(narrowFontSizes)
     })
   })
 

--- a/e2e/tests/network/watch.spec.mjs
+++ b/e2e/tests/network/watch.spec.mjs
@@ -1141,6 +1141,46 @@ test.describe('watch page', () => {
     await expect(sponsorBlockNotice).toHaveCSS('z-index', '0')
   })
 
+  test.describe('fullscreen captions', () => {
+    test.use({
+      seed: {
+        settings: {
+          defaultCaptionSettings: JSON.stringify({ fontScale: 1.5 })
+        }
+      }
+    })
+
+    test('keeps the configured caption size in fullscreen', async ({ page, innertube }) => {
+      test.skip(innertube.replay, 'watch page hydration needs the real API')
+      await openVideo(page)
+
+      const player = page.locator('.ftVideoPlayer')
+      await player.evaluate(element => {
+        for (const className of ['shaka-text-container', 'shaka-speech-to-text-container']) {
+          if (element.querySelector(`.${className}`)) continue
+
+          const captions = document.createElement('div')
+          captions.className = className
+          element.append(captions)
+        }
+      })
+
+      const captionContainers = player.locator(
+        '.shaka-text-container, .shaka-speech-to-text-container'
+      )
+      await expect(captionContainers).toHaveCount(2)
+      const windowedFontSizes = await captionContainers.evaluateAll(elements => {
+        return elements.map(element => getComputedStyle(element).fontSize)
+      })
+      expect(windowedFontSizes).toEqual(['30px', '30px'])
+
+      await setPlayerFullscreen(page, true)
+      await expect.poll(async () => captionContainers.evaluateAll(elements => {
+        return elements.map(element => getComputedStyle(element).fontSize)
+      })).toEqual(windowedFontSizes)
+    })
+  })
+
   test.describe('fullscreen playlist dock', () => {
     test.use({
       seed: {

--- a/src/renderer/components/WatchVideoPlaylist/WatchVideoPlaylist.vue
+++ b/src/renderer/components/WatchVideoPlaylist/WatchVideoPlaylist.vue
@@ -243,7 +243,7 @@ import { deepCopy, getVideoThumbnailUrl, showApiErrorToast, showToast, throttle 
 import {
   getLocalCachedFeedContinuation,
   getLocalPlaylist,
-  parseLocalPlaylistVideo,
+  parseLocalPlaylistVideos,
   untilEndOfLocalPlayList,
 } from '../../helpers/api/local'
 import { invidiousGetPlaylistInfo } from '../../helpers/api/invidious'
@@ -941,10 +941,10 @@ async function loadCachedPlaylistInformation(cachedPlaylist) {
     const videos = cachedPlaylist.items
 
     const continuationData = await getLocalCachedFeedContinuation('playlist', cachedPlaylist.continuationData)
-    videos.push(...continuationData.items.map(parseLocalPlaylistVideo))
+    videos.push(...parseLocalPlaylistVideos(continuationData.items))
 
     await untilEndOfLocalPlayList(continuationData, (p) => {
-      videos.push(...p.items.map(parseLocalPlaylistVideo))
+      videos.push(...parseLocalPlaylistVideos(p.items))
     }, { runCallbackOnceFirst: false })
 
     playlistItems.value = applyReversePlaylistState(videos)
@@ -976,7 +976,7 @@ async function getPlaylistInformationLocal() {
 
     const videos = []
     await untilEndOfLocalPlayList(playlist, (p) => {
-      videos.push(...p.items.map(parseLocalPlaylistVideo))
+      videos.push(...parseLocalPlaylistVideos(p.items))
     })
 
     playlistItems.value = applyReversePlaylistState(videos)

--- a/src/renderer/components/ft-shaka-video-player/ft-shaka-video-player.css
+++ b/src/renderer/components/ft-shaka-video-player/ft-shaka-video-player.css
@@ -2724,7 +2724,8 @@
 }
 
 @media only screen and (width <=400px) {
-  :deep(.shaka-text-container) {
+  :deep(.shaka-text-container),
+  :deep(.shaka-speech-to-text-container) {
     /* make subtitles take up slightly less space when a mobile phone is in portrait orientation */
     font-size: calc(16px * var(--caption-font-scale)) !important;
   }

--- a/src/renderer/components/ft-shaka-video-player/ft-shaka-video-player.css
+++ b/src/renderer/components/ft-shaka-video-player/ft-shaka-video-player.css
@@ -2106,12 +2106,6 @@
   }
 }
 
-:deep(.shaka-text-container),
-:deep(.shaka-speech-to-text-container) {
-  /* Keep shaka's caption raise animation alongside the panel push. */
-  transition: inset-inline-end 250ms ease, bottom cubic-bezier(0.4, 0, 0.6, 1) 0.1s;
-}
-
 /* Keep the floating fullscreen actions next to the video instead of under the panel. */
 .ftVideoPlayer:fullscreen:is(.fullscreenMetadataOpen, .fullscreenTranscriptOpen, .fullscreenSponsorBlockOpen, .fullscreenCommentsOpen, .fullscreenPlaylistOpen, .chaptersOverlayOpen) .fullscreenActions,
 .ftVideoPlayer.fullWindow:is(.fullscreenMetadataOpen, .fullscreenTranscriptOpen, .fullscreenSponsorBlockOpen, .fullscreenCommentsOpen, .fullscreenPlaylistOpen, .chaptersOverlayOpen) .fullscreenActions {
@@ -2328,7 +2322,8 @@
   color: #fff;
 }
 
-:deep(.shaka-text-container) {
+:deep(.shaka-text-container),
+:deep(.shaka-speech-to-text-container) {
   box-sizing: border-box;
   align-items: var(--caption-align-items) !important;
   justify-content: var(--caption-justify-content) !important;
@@ -2337,6 +2332,9 @@
   font-size: calc(20px * var(--caption-font-scale)) !important;
   text-align: var(--caption-text-align) !important;
   transform: translateY(var(--caption-vertical-transform));
+
+  /* Keep shaka's caption raise animation alongside the panel push. */
+  transition: inset-inline-end 250ms ease, bottom cubic-bezier(0.4, 0, 0.6, 1) 0.1s;
 }
 
 :deep(.shaka-controls-container:not([shown='true'], [casting='true']) ~ .shaka-text-container) {
@@ -2354,13 +2352,16 @@
 }
 
 :deep(.shaka-text-container div),
-:deep(.shaka-text-container span) {
+:deep(.shaka-text-container span),
+:deep(.shaka-speech-to-text-container div),
+:deep(.shaka-speech-to-text-container span) {
   background-color: transparent !important;
   font-size: inherit !important;
   text-align: var(--caption-text-align) !important;
 }
 
-:deep(.shaka-text-container [translate='no']) {
+:deep(.shaka-text-container [translate='no']),
+:deep(.shaka-speech-to-text-container [translate='no']) {
   background-color: var(--caption-background-color) !important;
   color: var(--caption-text-color) !important;
   -webkit-font-smoothing: antialiased;

--- a/src/renderer/helpers/api/local.js
+++ b/src/renderer/helpers/api/local.js
@@ -854,7 +854,7 @@ export async function getLocalChannelVideos(id) {
       try {
         const playlist = await innertube.getPlaylist(getChannelPlaylistId(channelId, 'videos', 'newest'))
 
-        videos = playlist.items.map(parseLocalPlaylistVideo)
+        videos = parseLocalPlaylistVideos(playlist.items)
       } catch (error) {
         // If the channel doesn't exist, the API call to channel page above would have already failed,
         // so if we get an error that the playlist doesn't exist here, it just means that this artist topic channel
@@ -1526,6 +1526,14 @@ export function parseLocalPlaylistVideo(video) {
       premiereDate: video_.upcoming
     }
   }
+}
+
+/**
+ * Parses playlist entries and removes videos that cannot be played, such as members-only videos.
+ * @param {(import('youtubei.js').YTNodes.PlaylistVideo|import('youtubei.js').YTNodes.ReelItem|import('youtubei.js').YTNodes.ShortsLockupView|import('youtubei.js').YTNodes.LockupView)[]} videos
+ */
+export function parseLocalPlaylistVideos(videos) {
+  return videos.map(parseLocalPlaylistVideo).filter(video => video != null)
 }
 
 /**

--- a/src/renderer/helpers/subscriptions.js
+++ b/src/renderer/helpers/subscriptions.js
@@ -10,7 +10,7 @@ import {
   getLocalChannelLiveStreams,
   getLocalChannelVideos,
   getLocalPlaylist,
-  parseLocalPlaylistVideo
+  parseLocalPlaylistVideos
 } from './api/local'
 import {
   fetchWithTimeout,
@@ -1182,7 +1182,7 @@ async function getChannelShortsLocal(channel, t, errorChannels, failedAttempts =
 async function getLocalShortThumbnailEntries(playlistId) {
   try {
     const playlist = await getLocalPlaylist(playlistId)
-    return playlist.items.map(parseLocalPlaylistVideo)
+    return parseLocalPlaylistVideos(playlist.items)
   } catch (error) {
     console.warn(`Failed to load selected Shorts thumbnails for ${playlistId}`, error)
     return []

--- a/src/renderer/views/Channel/Channel.vue
+++ b/src/renderer/views/Channel/Channel.vue
@@ -347,7 +347,7 @@ import {
   getLocalArtistTopicChannelReleasesContinuation,
   getLocalPlaylist,
   getLocalPlaylistContinuation,
-  parseLocalPlaylistVideo,
+  parseLocalPlaylistVideos,
   parseChannelHomeTab
 } from '../../helpers/api/local'
 import { useTabTitle } from '../../tabs/TabContext'
@@ -1198,7 +1198,7 @@ async function getChannelVideosLocal() {
         return
       }
 
-      latestVideos.value = playlist.items.map(parseLocalPlaylistVideo)
+      latestVideos.value = parseLocalPlaylistVideos(playlist.items)
       videoContinuationData.value = playlist.has_continuation ? playlist : null
       isElementListLoading.value = false
     } else {
@@ -1253,7 +1253,7 @@ async function getChannelVideosLocalMore() {
       const continuation = await getLocalPlaylistContinuation(videoContinuationData.value)
 
       if (continuation) {
-        latestVideos.value = latestVideos.value.concat(continuation.items.map(parseLocalPlaylistVideo))
+        latestVideos.value = latestVideos.value.concat(parseLocalPlaylistVideos(continuation.items))
         videoContinuationData.value = continuation.has_continuation ? continuation : null
       } else {
         videoContinuationData.value = null

--- a/src/renderer/views/Playlist/Playlist.vue
+++ b/src/renderer/views/Playlist/Playlist.vue
@@ -508,7 +508,7 @@ async function getPlaylistLocal() {
     let shouldGetNextPage = false
     if (result.has_continuation) {
       continuationData.value = result
-      shouldGetNextPage = playlistItems.value.length < 100
+      shouldGetNextPage = result.items.length < 100 && playlistItems.value.length < 100
     }
     // To workaround the effect of useless continuation data
     // auto load next page again when no. of parsed items < page size
@@ -704,7 +704,7 @@ async function getNextPageLocal() {
 
       // To workaround the effect of useless continuation data
       // auto load next page again when no. of parsed items < page size
-      shouldGetNextPage = parsedVideos.length < 100
+      shouldGetNextPage = result.items.length < 100 && parsedVideos.length < 100
     } else {
       continuationData.value = null
     }

--- a/src/renderer/views/Playlist/Playlist.vue
+++ b/src/renderer/views/Playlist/Playlist.vue
@@ -197,7 +197,7 @@ import {
   extractLocalCacheablePlaylistContinuation,
   getLocalPlaylist,
   getLocalPlaylistContinuation,
-  parseLocalPlaylistVideo,
+  parseLocalPlaylistVideos,
 } from '../../helpers/api/local'
 import {
   debounce,
@@ -483,7 +483,7 @@ async function getPlaylistLocal() {
       }
     }
 
-    const playlistItems_ = result.items.map(parseLocalPlaylistVideo)
+    const playlistItems_ = parseLocalPlaylistVideos(result.items)
 
     playlistTitle.value = result.info.title
     playlistDescription.value = result.info.description ?? ''
@@ -696,7 +696,7 @@ async function getNextPageLocal() {
   let shouldGetNextPage = false
 
   if (result) {
-    const parsedVideos = result.items.map(parseLocalPlaylistVideo)
+    const parsedVideos = parseLocalPlaylistVideos(result.items)
     playlistItems.value = playlistItems.value.concat(parsedVideos)
 
     if (result.has_continuation) {


### PR DESCRIPTION
## Pull Request Type
- [x] Bugfix
- [ ] Feature Implementation
- [ ] Documentation
- [ ] Other

## Related issue
Closes #399
Closes #412

## Description
Filters unplayable local playlist entries, including members-only videos, before they reach playlist consumers. This prevents null entries from breaking playlist pages, continuations, watch-page playlists, channel playlists, and subscription thumbnail selection.

Applies the configured caption appearance to both Shaka caption renderers so fullscreen mode cannot replace the configured font size with viewport-relative sizing.

## Screenshots
Not applicable.

## Release note category
<!-- release-note-category:start -->
- [ ] Not noteworthy
- [ ] Highlights
- [ ] More improvements
- [x] Fixed bugs
<!-- release-note-category:end -->

## Release note
<!-- release-note:start -->
Playlists containing members-only videos now load correctly, and captions keep their configured size in fullscreen.
<!-- release-note:end -->

## Release note images
<!-- release-note-image:start -->
<!-- release-note-image:end -->

## Testing
- `pnpm run test:unit`
- Targeted ESLint and Stylelint checks
- `pnpm run test:e2e:pack`
- `xvfb-run -a -s "-screen 0 1920x1080x24" pnpm exec playwright test -c e2e/playwright.config.mjs --project=network e2e/tests/network/playlist.spec.mjs`
- `xvfb-run -a -s "-screen 0 1920x1080x24" pnpm exec playwright test -c e2e/playwright.config.mjs --project=network e2e/tests/network/watch.spec.mjs --grep "keeps the configured caption size in fullscreen"`

## Desktop
- **OS:** Arch Linux
- **OS Version:** Rolling release
- **OpenTubeX version:** v0.30.1

## Additional context
The playlist regression uses the exact playlist reported in #399 and verifies that playable entries render. The caption regression uses a non-default 150% font size and verifies identical computed sizing before and after fullscreen.