### PR TITLE
fix(downloads): use standalone yt-dlp on Linux

### DIFF
--- a/src/main/ytDlp.js
+++ b/src/main/ytDlp.js
@@ -8,6 +8,7 @@ import { app, BrowserWindow } from 'electron'
 import { settings } from '../datastores/handlers/base'
 import { isOpenTubeXUrl } from './utils'
 import { IpcChannels } from '../constants'
+import { getYtDlpAssetName } from './ytDlpAsset'
 
 const execFileAsync = promisify(execFile)
 
@@ -354,17 +355,7 @@ async function installBinary(data, destinationPath) {
 async function downloadManagedYtDlp(onProgress, onDownloadStart) {
   const configuredChannel = (await settings._findOne('ytDlpChannel'))?.value
   const channel = Object.hasOwn(YT_DLP_RELEASE_REPOSITORIES, configuredChannel) ? configuredChannel : 'stable'
-  let assetName
-  switch (process.platform) {
-    case 'win32':
-      assetName = 'yt-dlp.exe'
-      break
-    case 'darwin':
-      assetName = 'yt-dlp_macos'
-      break
-    default:
-      assetName = 'yt-dlp'
-  }
+  const assetName = getYtDlpAssetName(process.platform, process.arch)
 
   const managedPath = getManagedBinaryPath('yt-dlp')
   let download

--- a/src/main/ytDlpAsset.js
+++ b/src/main/ytDlpAsset.js
@@ -1,0 +1,21 @@
+/**
+ * @param {NodeJS.Platform} platform
+ * @param {NodeJS.Architecture} arch
+ * @returns {string}
+ */
+export function getYtDlpAssetName(platform, arch) {
+  switch (platform) {
+    case 'win32':
+      return 'yt-dlp.exe'
+    case 'darwin':
+      return 'yt-dlp_macos'
+    default:
+      if (arch === 'x64') {
+        return 'yt-dlp_linux'
+      }
+      if (arch === 'arm64') {
+        return 'yt-dlp_linux_aarch64'
+      }
+      return 'yt-dlp'
+  }
+}

--- a/tests/unit/yt-dlp-asset.test.mjs
+++ b/tests/unit/yt-dlp-asset.test.mjs
@@ -1,0 +1,12 @@
+import assert from 'node:assert/strict'
+import test from 'node:test'
+
+import { getYtDlpAssetName } from '../../src/main/ytDlpAsset.js'
+
+test('uses self-contained yt-dlp executables where available', () => {
+  assert.equal(getYtDlpAssetName('win32', 'x64'), 'yt-dlp.exe')
+  assert.equal(getYtDlpAssetName('darwin', 'arm64'), 'yt-dlp_macos')
+  assert.equal(getYtDlpAssetName('linux', 'x64'), 'yt-dlp_linux')
+  assert.equal(getYtDlpAssetName('linux', 'arm64'), 'yt-dlp_linux_aarch64')
+  assert.equal(getYtDlpAssetName('linux', 'arm'), 'yt-dlp')
+})


### PR DESCRIPTION
## Pull Request Type
- [x] Bugfix
- [ ] Feature Implementation
- [ ] Documentation
- [ ] Other

## Related issue
Closes #400.

## Description
Linux managed downloads now use yt-dlp's architecture-specific standalone executables on x64 and arm64. Other Linux architectures retain the generic Python-based asset fallback.

The generic `yt-dlp` asset depends on packages from the host Python environment. Flatpak isolates that environment and does not provide `mutagen`, so audio extraction completed but thumbnail/metadata postprocessing failed. The standalone executables bundle `mutagen`, matching the self-contained assets already used on Windows and macOS.

## Screenshots
Not applicable; this changes managed download tool selection.

## Release note category
<!-- release-note-category:start -->
- [ ] Not noteworthy
- [ ] Highlights
- [ ] More improvements
- [x] Fixed bugs
<!-- release-note-category:end -->

## Release note
<!-- release-note:start -->
Fixed audio downloads being reported as failed in Flatpak after the media file completed.
<!-- release-note:end -->

## Release note images
<!-- release-note-image:start -->

<!-- release-note-image:end -->

## Testing
- Run `pnpm test:unit`.
- Run ESLint on `src/main/ytDlp.js`, `src/main/ytDlpAsset.js`, and `tests/unit/yt-dlp-asset.test.mjs`.
- Confirm the x64 standalone yt-dlp executable runs inside the Flatpak runtime and bundles `mutagen`.
- Confirm stable, nightly, and master yt-dlp channels publish both x64 and arm64 standalone Linux assets.

## Desktop
- **OS:** Arch Linux
- **OS Version:** Rolling release
- **OpenTubeX version:** development

## Additional context
The missing JavaScript runtime message from yt-dlp is a warning. The failed status in #400 was caused by the subsequent missing-`mutagen` postprocessor error.
