### PR TITLE
fix(player): keep seek thumbnails above annotations

### DIFF
--- a/e2e/tests/network/watch.spec.mjs
+++ b/e2e/tests/network/watch.spec.mjs
@@ -1109,6 +1109,7 @@ test.describe('watch page', () => {
     await setPlayerFullscreen(page, true)
     const actions = page.locator('.fullscreenActions')
     const seekBar = page.locator('.shaka-seek-bar-container')
+    const controls = page.locator('.shaka-controls-container')
     const fullscreenButton = page.locator('.shaka-fullscreen-button')
     await actions.evaluate((element) => {
       const sponsorBlockNotice = element.cloneNode(false)
@@ -1137,6 +1138,9 @@ test.describe('watch page', () => {
       seekBarBounds.x + (seekBarBounds.width / 2),
       seekBarBounds.y + (seekBarBounds.height / 2)
     )
+    // End-screen annotations use z-index 2, so the controls stacking context
+    // must rise above them for its seek preview to be visible.
+    await expect(controls).toHaveCSS('z-index', '3')
     await expect(actions).toHaveCSS('z-index', '0')
     await expect(sponsorBlockNotice).toHaveCSS('z-index', '0')
   })

--- a/src/renderer/components/ft-shaka-video-player/ft-shaka-video-player.css
+++ b/src/renderer/components/ft-shaka-video-player/ft-shaka-video-player.css
@@ -1531,7 +1531,11 @@
   display: flex;
 }
 
-/* Let Shaka's seek preview and control tooltips pass in front of the fullscreen action pill. */
+/* Let Shaka's seek preview pass in front of annotations and the fullscreen action pill. */
+.ftVideoPlayer:has(:deep(.shaka-seek-bar-container:hover)) :deep(.shaka-controls-container) {
+  z-index: 3;
+}
+
 .ftVideoPlayer:has(:deep(.shaka-seek-bar-container:hover)) :is(.fullscreenActions, .skippedSegmentsWrapper),
   .ftVideoPlayer:has(:deep(
     .shaka-controls-button-panel > :is(.shaka-tooltip, .shaka-tooltip-status):is(:hover, :focus-visible, :active)


### PR DESCRIPTION
## Pull Request Type
- [x] Bugfix
- [ ] Feature Implementation
- [ ] Documentation
- [ ] Other

## Related issue
N/A

## Description
Raises the Shaka controls stacking context while the seek bar is hovered so the hover thumbnail appears above end-screen annotations. The layer returns to its normal stacking order as soon as the pointer leaves the seek bar.

Adds an end-to-end regression assertion for the seek-hover stacking state.

## Screenshots
N/A

## Release note category
<!-- release-note-category:start -->
- [ ] Not noteworthy
- [ ] Highlights
- [ ] More improvements
- [x] Fixed bugs
<!-- release-note-category:end -->

## Release note
<!-- release-note:start -->
Fixed seek bar hover thumbnails appearing behind end-screen annotations.
<!-- release-note:end -->

## Release note images
<!-- release-note-image:start -->

<!-- release-note-image:end -->

## Testing
1. Open a video with end-screen annotations and enter fullscreen.
2. Move the pointer over the seek bar while the annotations are visible.
3. Confirm the hover thumbnail renders above the annotations.

Automated checks:
- `pnpm exec stylelint src/renderer/components/ft-shaka-video-player/ft-shaka-video-player.css`
- `xvfb-run -a -s "-screen 0 1920x1080x24" pnpm test:e2e:network e2e/tests/network/watch.spec.mjs --grep "fullscreen player overlays appear above the action pill"`

## Desktop
- **OS:** Arch Linux
- **OS Version:** Rolling release
- **OpenTubeX version:** 0.30.1 development

## Additional context
The annotation overlay uses `z-index: 2`. The seek preview is nested inside Shaka’s controls stacking context, so raising only the thumbnail cannot place it above the annotation overlay.