### PR TITLE
fix: hide tab play indicator while buffering

### DIFF
--- a/e2e/tests/network/watch.spec.mjs
+++ b/e2e/tests/network/watch.spec.mjs
@@ -160,6 +160,21 @@ test.describe('watch page', () => {
       .toBeGreaterThan(1)
   })
 
+  test('hides the tab play indicator while buffering', async ({ page, innertube }) => {
+    test.skip(!innertube.playback, 'needs real media streams')
+    await openVideo(page)
+
+    const video = await waitForPlaybackOrSkip(test, page)
+    const activeTab = page.locator(sel.activeTab)
+    await expect(activeTab.locator('.playingIcon')).toBeVisible()
+
+    await video.dispatchEvent('waiting')
+    await expect(activeTab.locator('.playingIcon')).toHaveCount(0)
+
+    await video.dispatchEvent('playing')
+    await expect(activeTab.locator('.playingIcon')).toBeVisible()
+  })
+
   test('animates into and out of the scroll mini player', async ({ page, innertube }) => {
     test.skip(!innertube.playback, 'needs real media streams')
     await openVideo(page)

--- a/src/renderer/components/ft-shaka-video-player/ft-shaka-video-player.js
+++ b/src/renderer/components/ft-shaka-video-player/ft-shaka-video-player.js
@@ -4122,10 +4122,6 @@ export default defineComponent({
 
       tabMediaCoordinator.setPlaybackState(mediaTabId, 'playing')
 
-      if (process.env.IS_ELECTRON && window.ftElectron?.tabs?.setPlaybackState) {
-        window.ftElectron.tabs.setPlaybackState('playing', tabId)
-      }
-
       updateAutoPip()
       updateScrollMiniPlayer()
 
@@ -4140,6 +4136,16 @@ export default defineComponent({
       // frame is available the poster is no longer needed, so remove it before
       // a later blur-triggered PiP transition.
       showPoster.value = false
+
+      if (process.env.IS_ELECTRON && window.ftElectron?.tabs?.setPlaybackState) {
+        window.ftElectron.tabs.setPlaybackState('playing', tabId)
+      }
+    }
+
+    function handleWaiting() {
+      if (process.env.IS_ELECTRON && window.ftElectron?.tabs?.setPlaybackState) {
+        window.ftElectron.tabs.setPlaybackState('paused', tabId)
+      }
     }
 
     function handlePause() {
@@ -8344,6 +8350,7 @@ export default defineComponent({
       toggleShortsMuted,
       toggleShortsCaptions,
       handlePlaying,
+      handleWaiting,
       openShortsOverflowMenu,
       toggleShortsFullscreen,
       handlePlayerControlDoubleClick,

--- a/src/renderer/components/ft-shaka-video-player/ft-shaka-video-player.vue
+++ b/src/renderer/components/ft-shaka-video-player/ft-shaka-video-player.vue
@@ -88,6 +88,7 @@
         :poster="showPoster ? thumbnail : null"
         @play="handlePlay"
         @playing="handlePlaying"
+        @waiting="handleWaiting"
         @pause="handlePause"
         @ended="handleEnded"
         @seeking="handleSeeking"


### PR DESCRIPTION
## Pull Request Type

- [x] Bugfix
- [ ] Feature Implementation
- [ ] Documentation
- [ ] Other

## Related issue

N/A

## Description

Hide the tab play indicator while a video is buffering and restore it when playback resumes.

The indicator was previously enabled by the `play` event and only disabled by `pause` or `ended`. Since buffering emits neither event, the tab incorrectly remained marked as playing. The indicator now follows `playing` and `waiting` events while media-session playback state remains unchanged.

## Screenshots

N/A

## Release note category

<!-- release-note-category:start -->
- [ ] Not noteworthy
- [ ] Highlights
- [ ] More improvements
- [x] Fixed bugs
<!-- release-note-category:end -->

## Release note

<!-- release-note:start -->
The tab play indicator is now hidden while a video is buffering.
<!-- release-note:end -->

## Release note images

<!-- release-note-image:start -->

<!-- release-note-image:end -->

## Testing

- Run `pnpm run test:unit`.
- Run `pnpm run test:e2e:pack`.
- Run `xvfb-run -a -s "-screen 0 1920x1080x24" pnpm exec playwright test -c e2e/playwright.config.mjs --project=network e2e/tests/network/watch.spec.mjs --grep "hides the tab play indicator while buffering"`.

The regression test verifies that the tab indicator is visible during playback, hidden on `waiting`, and restored on `playing`.

## Desktop

- **OS:** Arch Linux
- **OS Version:** Rolling release
- **OpenTubeX version:** 0.30.1

## Additional context

N/A
