### PR TITLE
Fix tab range selection anchor after deselection

### DIFF
--- a/e2e/tests/offline/tabs.spec.mjs
+++ b/e2e/tests/offline/tabs.spec.mjs
@@ -204,6 +204,23 @@ test.describe('tab bar', () => {
     await expect(tabs.nth(1)).toHaveClass(/active/)
   })
 
+  test('uses the only selected tab as the shift-selection anchor', async ({ page }) => {
+    await page.locator(sel.newTabButton).click()
+    await page.locator(sel.newTabButton).click()
+    await page.locator(sel.newTabButton).click()
+
+    const tabs = page.locator(sel.tabs)
+    await tabs.first().click()
+    await tabs.nth(2).click({ modifiers: ['Control'] })
+    await tabs.first().click({ modifiers: ['Control'] })
+    await tabs.nth(3).click({ modifiers: ['Shift'] })
+
+    await expect(tabs.first()).toHaveAttribute('aria-pressed', 'false')
+    await expect(tabs.nth(1)).toHaveAttribute('aria-pressed', 'false')
+    await expect(tabs.nth(2)).toHaveAttribute('aria-pressed', 'true')
+    await expect(tabs.nth(3)).toHaveAttribute('aria-pressed', 'true')
+  })
+
   test('clears multi-selection when a shortcut activates another tab', async ({ page }) => {
     const tabIds = await openThreeTabsAndActivate(page, 0)
     const tabs = page.locator(sel.tabs)

--- a/src/renderer/components/TabBar/TabBar.vue
+++ b/src/renderer/components/TabBar/TabBar.vue
@@ -674,7 +674,7 @@ function handleActivate(event, tabId) {
       nextSelection.add(tabId)
     }
     setTabSelection([...nextSelection])
-    selectionAnchorId = tabId
+    selectionAnchorId = nextSelection.size === 1 ? [...nextSelection][0] : tabId
     return
   }
 


### PR DESCRIPTION
## Pull Request Type
- [x] Bugfix
- [ ] Feature Implementation
- [ ] Documentation
- [ ] Other

## Related issue
None.

## Description
Keeps Shift range selection anchored to the only selected tab after Ctrl/Cmd-deselecting another tab.

Previously, the deselected tab became the stored range anchor, so the next Shift-click selected from that stale tab instead of from the remaining selection. The toggle path now uses the remaining tab as the anchor when exactly one tab stays selected.

## Screenshots
Not applicable; this fixes selection behavior without changing the visual design.

## Release note category
<!-- release-note-category:start -->
- [ ] Not noteworthy
- [ ] Highlights
- [ ] More improvements
- [x] Fixed bugs
<!-- release-note-category:end -->

## Release note
<!-- release-note:start -->
Fixed Shift range selection starting from a tab that had already been deselected.
<!-- release-note:end -->

## Release note images
<!-- release-note-image:start -->
<!-- release-note-image:end -->

## Testing
1. Open four tabs.
2. Activate the first tab.
3. Ctrl-click the third tab so the first and third tabs are selected.
4. Ctrl-click the first tab to leave only the third tab selected.
5. Shift-click the fourth tab.
6. Confirm only the third and fourth tabs are selected.

Automated validation:
- `pnpm exec eslint --config eslint.config.mjs src/renderer/components/TabBar/TabBar.vue`
- Relevant offline Electron/Playwright tests under Xvfb (2 passed)
- `git diff --check`

## Desktop
- **OS:** Arch Linux
- **OS Version:** Rolling release
- **OpenTubeX version:** 0.30.1

## Additional context
Includes an Electron/Playwright regression test for the stale-anchor interaction.