### PR TITLE
fix: align end screen annotations with video content

### DIFF
--- a/e2e/tests/network/watch.spec.mjs
+++ b/e2e/tests/network/watch.spec.mjs
@@ -9,11 +9,6 @@ const CAPTIONED_VIDEO = {
   title: 'What’s It Like to Be Killed by Nature’s Most Brutal Predator',
   url: 'https://www.youtube.com/watch?v=Xf-uUy5pdUI'
 }
-const WIDE_END_SCREEN_VIDEO = {
-  id: 'f6qZElzRBpg',
-  title: 'Top 15 Best Android Apps - August 2026!',
-  url: 'https://www.youtube.com/watch?v=f6qZElzRBpg'
-}
 const FULLSCREEN_PLAYLIST_ID = 'fullscreen-preview'
 const FULLSCREEN_PLAYLIST = {
   _id: FULLSCREEN_PLAYLIST_ID,
@@ -134,43 +129,6 @@ test.describe('background watch tab', () => {
 })
 
 test.describe('watch page', () => {
-  test('keeps wide-video end screens aligned when a fullscreen dock is open', async ({ page, innertube }) => {
-    test.skip(innertube.replay, 'watch page hydration needs the real API')
-    await openVideo(page, WIDE_END_SCREEN_VIDEO)
-    await waitForPlaybackOrSkip(test, page)
-
-    const video = page.locator('.ftVideoPlayer video.player')
-    await video.evaluate((element) => {
-      element.currentTime = Math.max(0, element.duration - 5)
-      element.dispatchEvent(new Event('timeupdate'))
-    })
-    await expect(page.locator('.annotationSurface .annotation').first()).toBeVisible({ timeout: 30_000 })
-
-    await setPlayerFullscreen(page, true)
-    await page.locator('.playerFullscreenTitleOverlay').click({ force: true })
-    await expect(page.locator('.fullscreenMetadataOverlay.open')).toBeVisible()
-    await expect.poll(() => video.evaluate((element) => element.videoWidth / element.videoHeight)).toBeCloseTo(2)
-
-    await expect.poll(async () => page.evaluate(() => {
-      const videoElement = document.querySelector('.ftVideoPlayer video.player')
-      const surface = document.querySelector('.annotationSurface')
-      const videoBounds = videoElement.getBoundingClientRect()
-      const surfaceBounds = surface.getBoundingClientRect()
-      const videoAspectRatio = videoElement.videoWidth / videoElement.videoHeight
-      const expectedHeight = Math.min(videoBounds.height, videoBounds.width / videoAspectRatio)
-      const expectedWidth = expectedHeight * videoAspectRatio
-      const expectedLeft = videoBounds.left + (videoBounds.width - expectedWidth) / 2
-      const expectedTop = videoBounds.top + (videoBounds.height - expectedHeight) / 2
-
-      return Math.max(
-        Math.abs(surfaceBounds.left - expectedLeft),
-        Math.abs(surfaceBounds.top - expectedTop),
-        Math.abs(surfaceBounds.width - expectedWidth),
-        Math.abs(surfaceBounds.height - expectedHeight)
-      )
-    })).toBeLessThanOrEqual(1)
-  })
-
   test('shows video metadata', async ({ page, innertube }) => {
     test.skip(innertube.replay, 'watch page hydration needs the real API')
     await openVideo(page)

--- a/e2e/tests/network/watch.spec.mjs
+++ b/e2e/tests/network/watch.spec.mjs
@@ -9,6 +9,11 @@ const CAPTIONED_VIDEO = {
   title: 'What’s It Like to Be Killed by Nature’s Most Brutal Predator',
   url: 'https://www.youtube.com/watch?v=Xf-uUy5pdUI'
 }
+const WIDE_END_SCREEN_VIDEO = {
+  id: 'f6qZElzRBpg',
+  title: 'Top 15 Best Android Apps - August 2026!',
+  url: 'https://www.youtube.com/watch?v=f6qZElzRBpg'
+}
 const FULLSCREEN_PLAYLIST_ID = 'fullscreen-preview'
 const FULLSCREEN_PLAYLIST = {
   _id: FULLSCREEN_PLAYLIST_ID,
@@ -129,6 +134,43 @@ test.describe('background watch tab', () => {
 })
 
 test.describe('watch page', () => {
+  test('keeps wide-video end screens aligned when a fullscreen dock is open', async ({ page, innertube }) => {
+    test.skip(innertube.replay, 'watch page hydration needs the real API')
+    await openVideo(page, WIDE_END_SCREEN_VIDEO)
+    await waitForPlaybackOrSkip(test, page)
+
+    const video = page.locator('.ftVideoPlayer video.player')
+    await video.evaluate((element) => {
+      element.currentTime = Math.max(0, element.duration - 5)
+      element.dispatchEvent(new Event('timeupdate'))
+    })
+    await expect(page.locator('.annotationSurface .annotation').first()).toBeVisible({ timeout: 30_000 })
+
+    await setPlayerFullscreen(page, true)
+    await page.locator('.playerFullscreenTitleOverlay').click({ force: true })
+    await expect(page.locator('.fullscreenMetadataOverlay.open')).toBeVisible()
+    await expect.poll(() => video.evaluate((element) => element.videoWidth / element.videoHeight)).toBeCloseTo(2)
+
+    await expect.poll(async () => page.evaluate(() => {
+      const videoElement = document.querySelector('.ftVideoPlayer video.player')
+      const surface = document.querySelector('.annotationSurface')
+      const videoBounds = videoElement.getBoundingClientRect()
+      const surfaceBounds = surface.getBoundingClientRect()
+      const videoAspectRatio = videoElement.videoWidth / videoElement.videoHeight
+      const expectedHeight = Math.min(videoBounds.height, videoBounds.width / videoAspectRatio)
+      const expectedWidth = expectedHeight * videoAspectRatio
+      const expectedLeft = videoBounds.left + (videoBounds.width - expectedWidth) / 2
+      const expectedTop = videoBounds.top + (videoBounds.height - expectedHeight) / 2
+
+      return Math.max(
+        Math.abs(surfaceBounds.left - expectedLeft),
+        Math.abs(surfaceBounds.top - expectedTop),
+        Math.abs(surfaceBounds.width - expectedWidth),
+        Math.abs(surfaceBounds.height - expectedHeight)
+      )
+    })).toBeLessThanOrEqual(1)
+  })
+
   test('shows video metadata', async ({ page, innertube }) => {
     test.skip(innertube.replay, 'watch page hydration needs the real API')
     await openVideo(page)

--- a/src/renderer/components/FtVideoAnnotations/FtVideoAnnotations.css
+++ b/src/renderer/components/FtVideoAnnotations/FtVideoAnnotations.css
@@ -6,6 +6,13 @@
   pointer-events: none;
 }
 
+.annotationSurface {
+  position: absolute;
+  inset: 0;
+  container-type: inline-size;
+  pointer-events: none;
+}
+
 .annotationToggle {
   position: absolute;
   inset-block-start: max(8px, 1.5%);

--- a/src/renderer/components/FtVideoAnnotations/FtVideoAnnotations.vue
+++ b/src/renderer/components/FtVideoAnnotations/FtVideoAnnotations.vue
@@ -106,7 +106,7 @@ import { computed, onBeforeUnmount, ref, useTemplateRef, watch } from 'vue'
 import { useI18n } from 'vue-i18n'
 
 import FtSubscribeButton from '../FtSubscribeButton/FtSubscribeButton.vue'
-import { getContainedVideoRect } from './annotationSurface'
+import { getVideoRect } from './annotationSurface'
 
 const props = defineProps({
   annotations: {
@@ -117,9 +117,18 @@ const props = defineProps({
     type: Number,
     default: 0
   },
+  active: {
+    type: Boolean,
+    default: true
+  },
   videoAspectRatio: {
     type: Number,
     default: null
+  },
+  videoFit: {
+    type: String,
+    default: 'contain',
+    validator: (value) => ['contain', 'cover'].includes(value)
   }
 })
 
@@ -129,6 +138,16 @@ const annotationRoot = useTemplateRef('annotationRoot')
 const containerWidth = ref(0)
 const containerHeight = ref(0)
 
+function measureAnnotationRoot() {
+  if (!annotationRoot.value) {
+    return
+  }
+
+  const { width, height } = annotationRoot.value.getBoundingClientRect()
+  containerWidth.value = width
+  containerHeight.value = height
+}
+
 const resizeObserver = new ResizeObserver((entries) => {
   const { width, height } = entries[0].contentRect
   containerWidth.value = width
@@ -136,7 +155,7 @@ const resizeObserver = new ResizeObserver((entries) => {
 })
 
 const annotationSurfaceStyle = computed(() => {
-  const rect = getContainedVideoRect(containerWidth.value, containerHeight.value, props.videoAspectRatio)
+  const rect = getVideoRect(containerWidth.value, containerHeight.value, props.videoAspectRatio, props.videoFit)
 
   if (!rect) {
     return undefined
@@ -156,6 +175,13 @@ watch(annotationRoot, (newRoot, oldRoot) => {
   }
   if (newRoot) {
     resizeObserver.observe(newRoot)
+    measureAnnotationRoot()
+  }
+}, { flush: 'post' })
+
+watch(() => props.active, (active) => {
+  if (active) {
+    measureAnnotationRoot()
   }
 }, { flush: 'post' })
 

--- a/src/renderer/components/FtVideoAnnotations/FtVideoAnnotations.vue
+++ b/src/renderer/components/FtVideoAnnotations/FtVideoAnnotations.vue
@@ -1,6 +1,7 @@
 <template>
   <div
     v-if="activeAnnotations.length > 0"
+    ref="annotationRoot"
     class="videoAnnotations"
   >
     <button
@@ -15,18 +16,66 @@
       <span>{{ buttonLabel }}</span>
     </button>
 
-    <template
-      v-for="annotation in annotationsHidden ? [] : activeAnnotations"
-      :key="annotation.id"
+    <div
+      class="annotationSurface"
+      :style="annotationSurfaceStyle"
     >
-      <div
-        v-if="annotation.type === 'CHANNEL'"
-        class="channelAnnotation"
-        :class="{ channelAnnotationAlignStart: annotation.left < 0.5 }"
-        :style="getAnnotationStyle(annotation)"
+      <template
+        v-for="annotation in annotationsHidden ? [] : activeAnnotations"
+        :key="annotation.id"
       >
+        <div
+          v-if="annotation.type === 'CHANNEL'"
+          class="channelAnnotation"
+          :class="{ channelAnnotationAlignStart: annotation.left < 0.5 }"
+          :style="getAnnotationStyle(annotation)"
+        >
+          <RouterLink
+            class="channelAvatarLink"
+            :to="annotation.route"
+            :title="annotation.title"
+            :aria-label="annotation.title"
+          >
+            <img
+              :src="annotation.thumbnail"
+              class="annotationThumbnail"
+              alt=""
+            >
+          </RouterLink>
+          <div class="channelHovercard">
+            <div class="channelHovercardInfo">
+              <RouterLink
+                class="channelHovercardTitle"
+                :to="annotation.route"
+                dir="auto"
+              >
+                {{ annotation.title }}
+              </RouterLink>
+              <FtSubscribeButton
+                v-if="annotation.channelId"
+                class="annotationSubscribeButton"
+                :channel-id="annotation.channelId"
+                :channel-name="annotation.title"
+                :channel-thumbnail="annotation.thumbnail"
+                :hide-profile-dropdown-toggle="true"
+                :open-dropdown-on-subscribe="false"
+              />
+              <p
+                v-if="annotation.description"
+                class="channelHovercardDescription"
+                dir="auto"
+              >
+                {{ annotation.description }}
+              </p>
+            </div>
+          </div>
+        </div>
+
         <RouterLink
-          class="channelAvatarLink"
+          v-else
+          class="annotation"
+          :class="`annotation-${annotation.type.toLowerCase()}`"
+          :style="getAnnotationStyle(annotation)"
           :to="annotation.route"
           :title="annotation.title"
           :aria-label="annotation.title"
@@ -36,70 +85,28 @@
             class="annotationThumbnail"
             alt=""
           >
+          <span
+            class="annotationTitle"
+            dir="auto"
+          >
+            <span class="annotationTitleText">{{ annotation.title }}</span>
+          </span>
+          <span
+            v-if="annotation.badge"
+            class="annotationBadge"
+          >{{ annotation.badge }}</span>
         </RouterLink>
-        <div class="channelHovercard">
-          <div class="channelHovercardInfo">
-            <RouterLink
-              class="channelHovercardTitle"
-              :to="annotation.route"
-              dir="auto"
-            >
-              {{ annotation.title }}
-            </RouterLink>
-            <FtSubscribeButton
-              v-if="annotation.channelId"
-              class="annotationSubscribeButton"
-              :channel-id="annotation.channelId"
-              :channel-name="annotation.title"
-              :channel-thumbnail="annotation.thumbnail"
-              :hide-profile-dropdown-toggle="true"
-              :open-dropdown-on-subscribe="false"
-            />
-            <p
-              v-if="annotation.description"
-              class="channelHovercardDescription"
-              dir="auto"
-            >
-              {{ annotation.description }}
-            </p>
-          </div>
-        </div>
-      </div>
-
-      <RouterLink
-        v-else
-        class="annotation"
-        :class="`annotation-${annotation.type.toLowerCase()}`"
-        :style="getAnnotationStyle(annotation)"
-        :to="annotation.route"
-        :title="annotation.title"
-        :aria-label="annotation.title"
-      >
-        <img
-          :src="annotation.thumbnail"
-          class="annotationThumbnail"
-          alt=""
-        >
-        <span
-          class="annotationTitle"
-          dir="auto"
-        >
-          <span class="annotationTitleText">{{ annotation.title }}</span>
-        </span>
-        <span
-          v-if="annotation.badge"
-          class="annotationBadge"
-        >{{ annotation.badge }}</span>
-      </RouterLink>
-    </template>
+      </template>
+    </div>
   </div>
 </template>
 
 <script setup>
-import { computed, ref } from 'vue'
+import { computed, onBeforeUnmount, ref, useTemplateRef, watch } from 'vue'
 import { useI18n } from 'vue-i18n'
 
 import FtSubscribeButton from '../FtSubscribeButton/FtSubscribeButton.vue'
+import { getContainedVideoRect } from './annotationSurface'
 
 const props = defineProps({
   annotations: {
@@ -109,11 +116,50 @@ const props = defineProps({
   currentTime: {
     type: Number,
     default: 0
+  },
+  videoAspectRatio: {
+    type: Number,
+    default: null
   }
 })
 
 const { t } = useI18n()
 const annotationsHidden = ref(false)
+const annotationRoot = useTemplateRef('annotationRoot')
+const containerWidth = ref(0)
+const containerHeight = ref(0)
+
+const resizeObserver = new ResizeObserver((entries) => {
+  const { width, height } = entries[0].contentRect
+  containerWidth.value = width
+  containerHeight.value = height
+})
+
+const annotationSurfaceStyle = computed(() => {
+  const rect = getContainedVideoRect(containerWidth.value, containerHeight.value, props.videoAspectRatio)
+
+  if (!rect) {
+    return undefined
+  }
+
+  return {
+    insetInlineStart: `${rect.left}px`,
+    top: `${rect.top}px`,
+    width: `${rect.width}px`,
+    height: `${rect.height}px`
+  }
+})
+
+watch(annotationRoot, (newRoot, oldRoot) => {
+  if (oldRoot) {
+    resizeObserver.unobserve(oldRoot)
+  }
+  if (newRoot) {
+    resizeObserver.observe(newRoot)
+  }
+}, { flush: 'post' })
+
+onBeforeUnmount(() => resizeObserver.disconnect())
 
 const activeAnnotations = computed(() => props.annotations.filter((annotation) => {
   return props.currentTime >= annotation.startTime && props.currentTime <= annotation.endTime

--- a/src/renderer/components/FtVideoAnnotations/annotationSurface.js
+++ b/src/renderer/components/FtVideoAnnotations/annotationSurface.js
@@ -1,16 +1,22 @@
 /**
- * Return the rectangle occupied by contained video content inside its element.
+ * Return the rectangle occupied by fitted video content inside its element.
  *
  * @param {number} containerWidth
  * @param {number} containerHeight
  * @param {number} videoAspectRatio
+ * @param {'contain' | 'cover'} [fit]
  */
-export function getContainedVideoRect(containerWidth, containerHeight, videoAspectRatio) {
+export function getVideoRect(containerWidth, containerHeight, videoAspectRatio, fit = 'contain') {
   if (containerWidth <= 0 || containerHeight <= 0 || !Number.isFinite(videoAspectRatio) || videoAspectRatio <= 0) {
     return null
   }
 
-  if (containerWidth / containerHeight > videoAspectRatio) {
+  const containerAspectRatio = containerWidth / containerHeight
+  const fitToHeight = fit === 'cover'
+    ? containerAspectRatio < videoAspectRatio
+    : containerAspectRatio > videoAspectRatio
+
+  if (fitToHeight) {
     const width = containerHeight * videoAspectRatio
 
     return {

--- a/src/renderer/components/FtVideoAnnotations/annotationSurface.js
+++ b/src/renderer/components/FtVideoAnnotations/annotationSurface.js
@@ -1,0 +1,32 @@
+/**
+ * Return the rectangle occupied by contained video content inside its element.
+ *
+ * @param {number} containerWidth
+ * @param {number} containerHeight
+ * @param {number} videoAspectRatio
+ */
+export function getContainedVideoRect(containerWidth, containerHeight, videoAspectRatio) {
+  if (containerWidth <= 0 || containerHeight <= 0 || !Number.isFinite(videoAspectRatio) || videoAspectRatio <= 0) {
+    return null
+  }
+
+  if (containerWidth / containerHeight > videoAspectRatio) {
+    const width = containerHeight * videoAspectRatio
+
+    return {
+      left: (containerWidth - width) / 2,
+      top: 0,
+      width,
+      height: containerHeight
+    }
+  }
+
+  const height = containerWidth / videoAspectRatio
+
+  return {
+    left: 0,
+    top: (containerHeight - height) / 2,
+    width: containerWidth,
+    height
+  }
+}

--- a/src/renderer/components/ft-shaka-video-player/ft-shaka-video-player.js
+++ b/src/renderer/components/ft-shaka-video-player/ft-shaka-video-player.js
@@ -883,6 +883,11 @@ export default defineComponent({
     const activeLegacyFormat = shallowRef(null)
 
     const fullWindowEnabled = ref(false)
+    const annotationVideoFit = computed(() => {
+      return props.shortsPlayer && !isFullscreen.value && !fullWindowEnabled.value
+        ? 'cover'
+        : 'contain'
+    })
     const fullWindowPlaceholderHeight = ref(0)
     /** @type {Animation|null} */
     let fullWindowAnimation = null
@@ -8366,6 +8371,7 @@ export default defineComponent({
       captionCssVariables,
       captionAppearanceSampleBottom,
       showCaptionAppearanceSample,
+      isActiveTab,
       container,
       video,
       vrCanvas,
@@ -8427,6 +8433,7 @@ export default defineComponent({
       playerDimensions,
       annotationCurrentTime,
       annotationVideoAspectRatio,
+      annotationVideoFit,
 
       autoplayVideos,
       sponsorBlockShowSkippedToast,

--- a/src/renderer/components/ft-shaka-video-player/ft-shaka-video-player.js
+++ b/src/renderer/components/ft-shaka-video-player/ft-shaka-video-player.js
@@ -841,6 +841,7 @@ export default defineComponent({
 
     const hasLoaded = ref(false)
     const annotationCurrentTime = ref(0)
+    const annotationVideoAspectRatio = ref(null)
 
     const hasMultipleAudioTracks = ref(false)
     const isLive = ref(props.isLive)
@@ -4226,6 +4227,7 @@ export default defineComponent({
       // Re-evaluate auto-PiP now that PiP is actually allowed (the video was possibly
       // in a hidden tab / scrolled out of view while still loading).
       updateAutoPip()
+      updateAnnotationVideoAspectRatio()
       updateScrollMiniVideoAspectRatio()
       updateScrollMiniPlayer()
     }
@@ -4346,6 +4348,14 @@ export default defineComponent({
 
     const videoElementWidth = ref(0)
     const videoElementHeight = ref(0)
+
+    function updateAnnotationVideoAspectRatio() {
+      const video_ = video.value
+
+      annotationVideoAspectRatio.value = video_?.videoWidth > 0 && video_.videoHeight > 0
+        ? video_.videoWidth / video_.videoHeight
+        : null
+    }
     const {
       deactivateScrollMiniPlayer,
       handleFullscreenButtonClick,
@@ -4420,6 +4430,7 @@ export default defineComponent({
 
         videoElementWidth.value = video_.clientWidth * devicePixelRatio
         videoElementHeight.value = video_.clientHeight * devicePixelRatio
+        updateAnnotationVideoAspectRatio()
         updateScrollMiniVideoAspectRatio()
       }
     })
@@ -7664,6 +7675,7 @@ export default defineComponent({
 
       player.addEventListener('loading', () => {
         hasLoaded.value = false
+        annotationVideoAspectRatio.value = null
         if (props.shortsPlayer) {
           shortsPaused.value = false
           shortsCaptionsAvailable.value = false
@@ -8414,6 +8426,7 @@ export default defineComponent({
       stats,
       playerDimensions,
       annotationCurrentTime,
+      annotationVideoAspectRatio,
 
       autoplayVideos,
       sponsorBlockShowSkippedToast,

--- a/src/renderer/components/ft-shaka-video-player/ft-shaka-video-player.vue
+++ b/src/renderer/components/ft-shaka-video-player/ft-shaka-video-player.vue
@@ -345,6 +345,7 @@
         v-if="!hideAnnotations"
         :annotations="annotations"
         :current-time="annotationCurrentTime"
+        :video-aspect-ratio="annotationVideoAspectRatio"
       />
       <div
         v-if="showCaptionAppearanceSample"

--- a/src/renderer/components/ft-shaka-video-player/ft-shaka-video-player.vue
+++ b/src/renderer/components/ft-shaka-video-player/ft-shaka-video-player.vue
@@ -343,9 +343,11 @@
       />
       <FtVideoAnnotations
         v-if="!hideAnnotations"
+        :active="isActiveTab"
         :annotations="annotations"
         :current-time="annotationCurrentTime"
         :video-aspect-ratio="annotationVideoAspectRatio"
+        :video-fit="annotationVideoFit"
       />
       <div
         v-if="showCaptionAppearanceSample"

--- a/tests/unit/video-annotations.test.mjs
+++ b/tests/unit/video-annotations.test.mjs
@@ -1,0 +1,38 @@
+import assert from 'node:assert/strict'
+import test from 'node:test'
+
+import {
+  getContainedVideoRect
+} from '../../src/renderer/components/FtVideoAnnotations/annotationSurface.js'
+
+test('uses the full player for video with the same aspect ratio', () => {
+  assert.deepEqual(getContainedVideoRect(1600, 900, 16 / 9), {
+    left: 0,
+    top: 0,
+    width: 1600,
+    height: 900
+  })
+})
+
+test('keeps annotations inside the pillarboxes of a 4:3 video', () => {
+  assert.deepEqual(getContainedVideoRect(1600, 900, 4 / 3), {
+    left: 200,
+    top: 0,
+    width: 1200,
+    height: 900
+  })
+})
+
+test('keeps annotations inside the letterboxes of an ultrawide video', () => {
+  assert.deepEqual(getContainedVideoRect(1600, 900, 32 / 9), {
+    left: 0,
+    top: 225,
+    width: 1600,
+    height: 450
+  })
+})
+
+test('falls back until valid video dimensions are available', () => {
+  assert.equal(getContainedVideoRect(1600, 900, null), null)
+  assert.equal(getContainedVideoRect(0, 900, 4 / 3), null)
+})

--- a/tests/unit/video-annotations.test.mjs
+++ b/tests/unit/video-annotations.test.mjs
@@ -32,6 +32,15 @@ test('keeps annotations inside the letterboxes of an ultrawide video', () => {
   })
 })
 
+test('centers annotations when a fullscreen dock narrows the video viewport', () => {
+  assert.deepEqual(getVideoRect(1440, 1080, 16 / 9), {
+    left: 0,
+    top: 135,
+    width: 1440,
+    height: 810
+  })
+})
+
 test('extends the annotation surface through cropped cover content', () => {
   assert.deepEqual(getVideoRect(1600, 900, 4 / 3, 'cover'), {
     left: 0,

--- a/tests/unit/video-annotations.test.mjs
+++ b/tests/unit/video-annotations.test.mjs
@@ -2,11 +2,11 @@ import assert from 'node:assert/strict'
 import test from 'node:test'
 
 import {
-  getContainedVideoRect
+  getVideoRect
 } from '../../src/renderer/components/FtVideoAnnotations/annotationSurface.js'
 
 test('uses the full player for video with the same aspect ratio', () => {
-  assert.deepEqual(getContainedVideoRect(1600, 900, 16 / 9), {
+  assert.deepEqual(getVideoRect(1600, 900, 16 / 9), {
     left: 0,
     top: 0,
     width: 1600,
@@ -15,7 +15,7 @@ test('uses the full player for video with the same aspect ratio', () => {
 })
 
 test('keeps annotations inside the pillarboxes of a 4:3 video', () => {
-  assert.deepEqual(getContainedVideoRect(1600, 900, 4 / 3), {
+  assert.deepEqual(getVideoRect(1600, 900, 4 / 3), {
     left: 200,
     top: 0,
     width: 1200,
@@ -24,7 +24,7 @@ test('keeps annotations inside the pillarboxes of a 4:3 video', () => {
 })
 
 test('keeps annotations inside the letterboxes of an ultrawide video', () => {
-  assert.deepEqual(getContainedVideoRect(1600, 900, 32 / 9), {
+  assert.deepEqual(getVideoRect(1600, 900, 32 / 9), {
     left: 0,
     top: 225,
     width: 1600,
@@ -32,7 +32,23 @@ test('keeps annotations inside the letterboxes of an ultrawide video', () => {
   })
 })
 
+test('extends the annotation surface through cropped cover content', () => {
+  assert.deepEqual(getVideoRect(1600, 900, 4 / 3, 'cover'), {
+    left: 0,
+    top: -150,
+    width: 1600,
+    height: 1200
+  })
+
+  assert.deepEqual(getVideoRect(1600, 900, 32 / 9, 'cover'), {
+    left: -800,
+    top: 0,
+    width: 3200,
+    height: 900
+  })
+})
+
 test('falls back until valid video dimensions are available', () => {
-  assert.equal(getContainedVideoRect(1600, 900, null), null)
-  assert.equal(getContainedVideoRect(0, 900, 4 / 3), null)
+  assert.equal(getVideoRect(1600, 900, null), null)
+  assert.equal(getVideoRect(0, 900, 4 / 3), null)
 })


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Make sure to follow the contributing guidelines. -->
<!-- Important note, we may remove your pull request if you do not use this provided PR template correctly. -->

## Pull Request Type
<!-- Please select what type of pull request this is: [x] -->
- [x] Bugfix
- [ ] Feature Implementation
- [ ] Documentation
- [ ] Other

## Related issue
<!-- Please link the issue your pull request is referring to. -->
<!-- If this pull request fully resolves the relevant issue, put "closes" before the issue number. -->
<!-- Example: "closes #123456". -->

No related issue.

## Description
<!-- Please write a clear and concise description of what the pull request does. -->

End-screen annotations were positioned against the complete player box. For videos whose intrinsic aspect ratio differs from the player, this stretched annotations into the letterbox or pillarbox area.

This change reads the video's intrinsic aspect ratio and places annotations on a contained surface matching the rendered video content. The surface is recalculated when playback sources or player dimensions change, including fullscreen and docked layouts.

## Screenshots <!-- If appropriate -->
<!-- Please add before and after screenshots if there is a visible change. -->

Reproduction video: https://youtu.be/EuVcfJLxmcI

## Release note category
<!-- Select exactly one category. Every pull request must select one. -->
<!-- release-note-category:start -->
- [ ] Not noteworthy
- [ ] Highlights
- [ ] More improvements
- [x] Fixed bugs
<!-- release-note-category:end -->

## Release note
<!-- Required unless "Not noteworthy" is selected. -->
<!-- Write one concise, user-facing entry without a leading bullet. -->
<!-- release-note:start -->
Fixed end-screen annotation positioning and sizing on non-16:9 videos.
<!-- release-note:end -->

## Release note images
<!-- Optional. Paste one or more Markdown images or HTML image tags here. -->
<!-- The release notes will use an HTML image tag and limit images taller than 300 pixels. -->
<!-- release-note-image:start -->

<!-- release-note-image:end -->

## Testing
<!-- How can reviewers verify that the PR produces correct results? -->
<!-- Please provide instructions so that others can ensure that your pull request would produce correct results. For examples see, https://github.com/FreeTubeApp/FreeTube/pull/5743, https://github.com/FreeTubeApp/FreeTube/pull/7349, https://github.com/FreeTubeApp/FreeTube/pull/5125, https://github.com/FreeTubeApp/FreeTube/pull/7338 -->

1. Play the reproduction video and seek to 3:20.
2. Confirm that the channel and video annotations align with the 4:3 video content rather than the side pillarboxes.
3. Resize the player and verify that the annotations continue to align.
4. Run `pnpm run test:unit`.
5. Run `pnpm run lint`.
6. Run `pnpm run test:e2e:pack:renderer`.

## Desktop
<!-- Please complete the following information-->
- **OS:** Arch Linux (KDE Plasma, Wayland)
- **OS Version:** Rolling release
- **OpenTubeX version:** 0.30.1

## Additional context

The new geometry tests cover matching 16:9 content, 4:3 pillarboxing, ultrawide letterboxing, and the pre-metadata fallback.