### PR TITLE
Improve subscription refresh progress toast

### DIFF
--- a/e2e/tests/offline/subscriptions-refresh.spec.mjs
+++ b/e2e/tests/offline/subscriptions-refresh.spec.mjs
@@ -296,7 +296,7 @@ test.describe('cancelling an automatic subscription feed refresh', () => {
 
     const minimizedBounds = await refreshToast.boundingBox()
     expect(minimizedBounds.x).toBeLessThan(expandedBounds.x)
-    expect(minimizedBounds.y).toBeLessThan(expandedBounds.y)
+    expect(minimizedBounds.y).toBeCloseTo(expandedBounds.y, 0)
     expect(minimizedBounds.y).toBeGreaterThanOrEqual(tabBarBounds.y + tabBarBounds.height)
 
     const viewport = await page.evaluate(() => ({ width: innerWidth, height: innerHeight }))

--- a/e2e/tests/offline/subscriptions-refresh.spec.mjs
+++ b/e2e/tests/offline/subscriptions-refresh.spec.mjs
@@ -259,7 +259,8 @@ test.describe('cancelling an automatic subscription feed refresh', () => {
       settings: {
         ...commonSettings,
         subscriptionFeedAutoRefreshInterval: '5000',
-        showToastTimeoutIndicator: false
+        showToastTimeoutIndicator: false,
+        toastPosition: 'top-left'
       },
       profiles: [profileWith(channelCount)],
       subscriptionCache: Array.from({ length: channelCount }, (_, index) => cachedChannel(index))
@@ -272,6 +273,7 @@ test.describe('cancelling an automatic subscription feed refresh', () => {
 
     const refreshToast = page.getByTestId('subscription-refresh-toast')
     await expect(refreshToast).toContainText('Refreshing subscription videos', { timeout: 10_000 })
+    await expect(refreshToast.locator('.icon')).toHaveAttribute('data-icon', 'video')
     await expect(page.locator('.app > .progressBar')).toHaveCount(0)
     expect(await refreshToast.evaluate((toast) => {
       const { left, top, width, height } = toast.getBoundingClientRect()
@@ -283,6 +285,24 @@ test.describe('cancelling an automatic subscription feed refresh', () => {
     await expect(indicator).toBeVisible()
     await expect.poll(async () => Number(await indicator.getAttribute('data-progress'))).toBeGreaterThan(0)
     expect(Number(await indicator.getAttribute('data-progress'))).toBeLessThan(100)
+
+    const expandedBounds = await refreshToast.boundingBox()
+    const tabBarBounds = await page.locator('.tabBar:not(.vertical)').boundingBox()
+    expect(expandedBounds.y).toBeGreaterThanOrEqual(tabBarBounds.y + tabBarBounds.height)
+
+    await page.mouse.move(expandedBounds.x + expandedBounds.width / 2, expandedBounds.y + expandedBounds.height / 2)
+    await expect(refreshToast).toHaveClass(/minimized/)
+    await expect.poll(async () => (await refreshToast.boundingBox()).width).toBeLessThan(expandedBounds.width * 0.6)
+
+    const minimizedBounds = await refreshToast.boundingBox()
+    expect(minimizedBounds.x).toBeLessThan(expandedBounds.x)
+    expect(minimizedBounds.y).toBeLessThan(expandedBounds.y)
+    expect(minimizedBounds.y).toBeGreaterThanOrEqual(tabBarBounds.y + tabBarBounds.height)
+
+    const viewport = await page.evaluate(() => ({ width: innerWidth, height: innerHeight }))
+    await page.mouse.move(viewport.width / 2, viewport.height / 2)
+    await expect(refreshToast).not.toHaveClass(/minimized/)
+    await expect.poll(async () => (await refreshToast.boundingBox()).width).toBeGreaterThan(expandedBounds.width * 0.9)
 
     await page.keyboard.press('Escape')
     await expect(refreshToast).toBeVisible()

--- a/src/renderer/components/FtToast/FtToast.css
+++ b/src/renderer/components/FtToast/FtToast.css
@@ -47,6 +47,13 @@
 }
 /* stylelint-enable liberty/use-logical-spec */
 
+/* Keep top-positioned toasts below the horizontal tab bar. */
+.toast-holder.horizontal-tabs.position-top-left,
+.toast-holder.horizontal-tabs.position-top-center,
+.toast-holder.horizontal-tabs.position-top-right {
+  inset-block-start: 56px;
+}
+
 :global(body.playerFullWindow .toast-holder) {
   z-index: 1002;
 }
@@ -57,6 +64,55 @@
 
 .toast-slot.persistent-slot {
   pointer-events: none;
+  transition: transform 250ms cubic-bezier(0.4, 0, 0.2, 1);
+}
+
+.position-bottom-left .persistent-slot {
+  transform-origin: bottom left;
+}
+
+.position-bottom-center .persistent-slot {
+  transform-origin: bottom center;
+}
+
+.position-bottom-right .persistent-slot {
+  transform-origin: bottom right;
+}
+
+.position-top-left .persistent-slot {
+  transform-origin: top left;
+}
+
+.position-top-center .persistent-slot {
+  transform-origin: top center;
+}
+
+.position-top-right .persistent-slot {
+  transform-origin: top right;
+}
+
+.position-bottom-left .persistent-slot.minimized {
+  transform: translate(-18px, 18px) scale(0.5);
+}
+
+.position-bottom-center .persistent-slot.minimized {
+  transform: translateY(18px) scale(0.5);
+}
+
+.position-bottom-right .persistent-slot.minimized {
+  transform: translate(18px, 18px) scale(0.5);
+}
+
+.position-top-left .persistent-slot.minimized {
+  transform: translate(-18px, -18px) scale(0.5);
+}
+
+.position-top-center .persistent-slot.minimized {
+  transform: translateY(-18px) scale(0.5);
+}
+
+.position-top-right .persistent-slot.minimized {
+  transform: translate(18px, -18px) scale(0.5);
 }
 
 .toast {
@@ -247,4 +303,10 @@
 /* stack reflow when a toast is removed */
 .toast-move {
   transition: transform 300ms ease;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .toast-slot.persistent-slot {
+    transition-duration: 1ms;
+  }
 }

--- a/src/renderer/components/FtToast/FtToast.css
+++ b/src/renderer/components/FtToast/FtToast.css
@@ -115,6 +115,18 @@
   transform: translate(18px, -18px) scale(0.5);
 }
 
+.toast-holder.horizontal-tabs.position-top-left .persistent-slot.minimized {
+  transform: translateX(-18px) scale(0.5);
+}
+
+.toast-holder.horizontal-tabs.position-top-center .persistent-slot.minimized {
+  transform: scale(0.5);
+}
+
+.toast-holder.horizontal-tabs.position-top-right .persistent-slot.minimized {
+  transform: translateX(18px) scale(0.5);
+}
+
 .toast {
   display: flex;
   align-items: center;

--- a/src/renderer/components/FtToast/FtToast.vue
+++ b/src/renderer/components/FtToast/FtToast.vue
@@ -7,7 +7,7 @@
       tag="div"
       name="toast"
       class="toast-holder"
-      :class="`position-${toastPosition}`"
+      :class="[`position-${toastPosition}`, { 'horizontal-tabs': hasHorizontalTabBar }]"
       @before-leave="onBeforeLeave"
     >
       <div
@@ -71,8 +71,10 @@
       </div>
       <div
         v-if="showSubscriptionRefreshToast"
+        ref="subscriptionRefreshToast"
         key="subscription-refresh"
         class="toast-slot persistent-slot"
+        :class="{ minimized: subscriptionRefreshMinimized }"
         data-testid="subscription-refresh-toast"
       >
         <div
@@ -80,7 +82,7 @@
           role="status"
         >
           <FontAwesomeIcon
-            :icon="['fas', 'sync']"
+            :icon="subscriptionRefreshIcon"
             class="icon"
             fixed-width
           />
@@ -108,7 +110,7 @@
 
 <script setup>
 import { FontAwesomeIcon } from '@fortawesome/vue-fontawesome'
-import { computed, nextTick, onBeforeUnmount, onMounted, reactive, ref } from 'vue'
+import { computed, nextTick, onBeforeUnmount, onMounted, reactive, ref, useTemplateRef } from 'vue'
 import { useI18n } from 'vue-i18n'
 import { normalizeToastPosition } from '../../constants/toastPosition'
 import { showToast, ToastEventBus } from '../../helpers/utils'
@@ -148,6 +150,10 @@ const props = defineProps({
 
 /** Distance in px a toast must be dragged before it slides away instead of snapping back */
 const DRAG_DISMISS_THRESHOLD = 80
+/** Distance in px at which the persistent refresh toast gets out of the pointer's way */
+const REFRESH_TOAST_PROXIMITY = 32
+/** Extra distance required before restoring the toast, to avoid flicker around the boundary */
+const REFRESH_TOAST_PROXIMITY_HYSTERESIS = 20
 
 /** @type {import('vue').Reactive<Toast[]>} */
 const toasts = reactive([])
@@ -155,9 +161,23 @@ const toasts = reactive([])
 const indicatorAnimations = new Map()
 /** @type {import('vue').Ref<Element|null>} */
 const fullscreenTarget = ref(null)
+/** @type {import('vue').Ref<HTMLElement|null>} */
+const subscriptionRefreshToast = useTemplateRef('subscriptionRefreshToast')
+const subscriptionRefreshMinimized = ref(false)
+/** @type {DOMRect|null} */
+let subscriptionRefreshBounds = null
+/** @type {HTMLElement|null} */
+let measuredSubscriptionRefreshToast = null
+/** @type {number|null} */
+let subscriptionRefreshPointerFrame = null
+let subscriptionRefreshPointerX = 0
+let subscriptionRefreshPointerY = 0
 /** @type {import('vue').ComputedRef<'bottom-left' | 'bottom-center' | 'bottom-right' | 'top-left' | 'top-center' | 'top-right'>} */
 const toastPosition = computed(() => {
   return normalizeToastPosition(store.getters.getToastPosition)
+})
+const hasHorizontalTabBar = computed(() => {
+  return process.env.IS_ELECTRON && !store.getters.getUseVerticalTabBar
 })
 /** @type {import('vue').ComputedRef<boolean>} */
 const showTimeoutIndicator = computed(() => store.getters.getShowToastTimeoutIndicator)
@@ -168,6 +188,18 @@ const showSubscriptionRefreshToast = computed(() => {
     store.getters.getSubscriptionFeedRefreshInProgress
 })
 const subscriptionRefreshProgress = computed(() => store.getters.getSubscriptionFeedRefreshProgress)
+const subscriptionRefreshIcon = computed(() => {
+  switch (store.getters.getSubscriptionFeedRefreshTab) {
+    case 'shorts':
+      return ['fa', 'clapperboard']
+    case 'live':
+      return ['fa', 'tower-broadcast']
+    case 'posts':
+      return ['fa', 'message']
+    default:
+      return ['fa', 'video']
+  }
+})
 const subscriptionRefreshMessage = computed(() => {
   switch (store.getters.getSubscriptionFeedRefreshTab) {
     case 'shorts':
@@ -185,6 +217,56 @@ const toastProgressLineWidth = computed(() => Math.min(4, Math.max(2, 2 * store.
 
 function updateFullscreenTarget() {
   fullscreenTarget.value = document.fullscreenElement
+}
+
+/**
+ * Keeps the non-interactive refresh toast readable until the mouse approaches,
+ * then tucks it into its configured edge of the screen. The expanded bounds
+ * remain the hit area while minimized so scaling cannot make the state flicker.
+ * @param {MouseEvent} event
+ */
+function onSubscriptionRefreshPointerMove(event) {
+  subscriptionRefreshPointerX = event.clientX
+  subscriptionRefreshPointerY = event.clientY
+  if (subscriptionRefreshPointerFrame !== null) { return }
+
+  subscriptionRefreshPointerFrame = requestAnimationFrame(updateSubscriptionRefreshProximity)
+}
+
+function updateSubscriptionRefreshProximity() {
+  subscriptionRefreshPointerFrame = null
+  const element = subscriptionRefreshToast.value
+
+  if (!element) {
+    measuredSubscriptionRefreshToast = null
+    subscriptionRefreshBounds = null
+    subscriptionRefreshMinimized.value = false
+    return
+  }
+
+  if (element !== measuredSubscriptionRefreshToast) {
+    measuredSubscriptionRefreshToast = element
+    subscriptionRefreshBounds = null
+    subscriptionRefreshMinimized.value = false
+  }
+
+  if (!subscriptionRefreshMinimized.value || subscriptionRefreshBounds === null) {
+    subscriptionRefreshBounds = element.getBoundingClientRect()
+  }
+
+  const bounds = subscriptionRefreshBounds
+  const horizontalDistance = Math.max(bounds.left - subscriptionRefreshPointerX, 0, subscriptionRefreshPointerX - bounds.right)
+  const verticalDistance = Math.max(bounds.top - subscriptionRefreshPointerY, 0, subscriptionRefreshPointerY - bounds.bottom)
+  const distance = Math.hypot(horizontalDistance, verticalDistance)
+  const threshold = REFRESH_TOAST_PROXIMITY +
+    (subscriptionRefreshMinimized.value ? REFRESH_TOAST_PROXIMITY_HYSTERESIS : 0)
+
+  subscriptionRefreshMinimized.value = distance <= threshold
+}
+
+function resetSubscriptionRefreshProximity() {
+  subscriptionRefreshBounds = null
+  subscriptionRefreshMinimized.value = false
 }
 
 /**
@@ -504,6 +586,8 @@ function cleanup(toast) {
 onMounted(() => {
   ToastEventBus.addEventListener('toast-open', open)
   document.addEventListener('fullscreenchange', updateFullscreenTarget)
+  window.addEventListener('mousemove', onSubscriptionRefreshPointerMove)
+  window.addEventListener('resize', resetSubscriptionRefreshProximity)
   updateFullscreenTarget()
 
   if (process.env.IS_ELECTRON) {
@@ -516,6 +600,11 @@ onMounted(() => {
 onBeforeUnmount(() => {
   ToastEventBus.removeEventListener('toast-open', open)
   document.removeEventListener('fullscreenchange', updateFullscreenTarget)
+  window.removeEventListener('mousemove', onSubscriptionRefreshPointerMove)
+  window.removeEventListener('resize', resetSubscriptionRefreshProximity)
+  if (subscriptionRefreshPointerFrame !== null) {
+    cancelAnimationFrame(subscriptionRefreshPointerFrame)
+  }
   removeShowToastListener?.()
   toasts.forEach(cleanup)
 })


### PR DESCRIPTION
## Pull Request Type
- [ ] Bugfix
- [x] Feature Implementation
- [ ] Documentation
- [ ] Other

## Related issue

None.

## Description

Makes the persistent subscription refresh progress toast move out of the mouse pointer's way. When the pointer approaches, the toast animates toward its configured screen edge at half size and restores after the pointer moves away. The activation and restoration distances use hysteresis to avoid flicker.

The toast now uses the icon for the feed being refreshed (videos, shorts, live streams, or posts). Top-positioned toasts also stay below the horizontal tab bar in both their expanded and minimized states.

## Screenshots

Not included; the positions and dimensions are covered by the E2E test.

## Release note category
<!-- release-note-category:start -->
- [ ] Not noteworthy
- [ ] Highlights
- [x] More improvements
- [ ] Fixed bugs
<!-- release-note-category:end -->

## Release note
<!-- release-note:start -->
Subscription refresh progress toasts now move out of the pointer's way and show the corresponding feed icon.
<!-- release-note:end -->

## Release note images
<!-- release-note-image:start -->

<!-- release-note-image:end -->

## Testing

- Run `pnpm exec eslint --config eslint.config.mjs src/renderer/components/FtToast/FtToast.vue`.
- Run `pnpm exec stylelint src/renderer/components/FtToast/FtToast.css`.
- Run `xvfb-run -a -s "-screen 0 1920x1080x24" pnpm exec playwright test -c e2e/playwright.config.mjs --project=offline e2e/tests/offline/subscriptions-refresh.spec.mjs`.
- Start a subscription feed refresh, navigate away from Subscriptions, and move the pointer near the progress toast. Verify that it shrinks toward the configured toast position and restores after the pointer moves away.
- With horizontal tabs and a top toast position, verify that both toast states stay below the tab bar.

## Desktop

- **OS:** Arch Linux
- **OS Version:** Rolling release
- **OpenTubeX version:** 0.30.1

## Additional context

None.
