### PR TITLE
Show Shorts channel metadata in fullscreen

### DIFF
--- a/src/renderer/components/ft-shaka-video-player/ft-shaka-video-player.css
+++ b/src/renderer/components/ft-shaka-video-player/ft-shaka-video-player.css
@@ -206,12 +206,20 @@
 
 .ftVideoPlayer.shortsPlayer:fullscreen .shortsFullscreenMetadata,
 .ftVideoPlayer.shortsPlayer.fullWindow .shortsFullscreenMetadata {
+  --shorts-metadata-min-width: min(
+    220px,
+    calc((100vw - var(--shorts-dock-width, 0px)) / 3)
+  );
+
   position: absolute;
   z-index: 5;
   inset-block: 0;
   inset-inline-start: 0;
   display: grid;
-  grid-template-columns: minmax(0, 1fr) auto minmax(0, 1fr);
+  grid-template-columns:
+    minmax(var(--shorts-metadata-min-width), 1fr)
+    auto
+    minmax(0, 1fr);
   box-sizing: border-box;
   block-size: 100%;
   inline-size: calc(100% - var(--shorts-dock-width, 0px));
@@ -231,6 +239,13 @@
 .shortsFullscreenVideoSpace {
   grid-column: 2;
   block-size: 100%;
+  inline-size: min(
+    calc(100dvh * var(--shorts-aspect-ratio)),
+    calc(
+      100vw - var(--shorts-dock-width, 0px) -
+      var(--shorts-metadata-min-width)
+    )
+  );
   aspect-ratio: var(--shorts-aspect-ratio);
 }
 

--- a/src/renderer/components/ft-shaka-video-player/ft-shaka-video-player.css
+++ b/src/renderer/components/ft-shaka-video-player/ft-shaka-video-player.css
@@ -200,17 +200,43 @@
     max-inline-size 250ms ease;
 }
 
-.ftVideoPlayer.shortsPlayer:fullscreen :deep(.playerFullscreenTitleOverlay),
-.ftVideoPlayer.shortsPlayer.fullWindow :deep(.playerFullscreenTitleOverlay) {
-  top: auto;
-  bottom: 70px;
-  max-inline-size: min(36vw, 560px);
+.shortsFullscreenMetadata {
+  display: none;
 }
 
-.ftVideoPlayer.shortsPlayer:fullscreen :deep(.playerFullscreenTitleOverlay:dir(rtl)),
-.ftVideoPlayer.shortsPlayer.fullWindow :deep(.playerFullscreenTitleOverlay:dir(rtl)) {
-  right: 5px;
-  left: auto;
+.ftVideoPlayer.shortsPlayer:fullscreen .shortsFullscreenMetadata,
+.ftVideoPlayer.shortsPlayer.fullWindow .shortsFullscreenMetadata {
+  position: absolute;
+  z-index: 5;
+  inset-block: 0;
+  inset-inline-start: 0;
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) auto minmax(0, 1fr);
+  box-sizing: border-box;
+  block-size: 100%;
+  inline-size: calc(100% - var(--shorts-dock-width, 0px));
+  color: #fff;
+  pointer-events: none;
+  transition: inline-size 250ms ease;
+}
+
+.shortsFullscreenMetadataSide {
+  grid-column: 1;
+  align-self: end;
+  min-inline-size: 0;
+  padding-block-end: 24px;
+  padding-inline: 16px;
+}
+
+.shortsFullscreenVideoSpace {
+  grid-column: 2;
+  block-size: 100%;
+  aspect-ratio: var(--shorts-aspect-ratio);
+}
+
+.ftVideoPlayer.shortsPlayer:fullscreen :deep(.playerFullscreenTitleOverlay),
+.ftVideoPlayer.shortsPlayer.fullWindow :deep(.playerFullscreenTitleOverlay) {
+  display: none;
 }
 
 .ftVideoPlayer.shortsPlayer:fullscreen:is(

--- a/src/renderer/components/ft-shaka-video-player/ft-shaka-video-player.js
+++ b/src/renderer/components/ft-shaka-video-player/ft-shaka-video-player.js
@@ -8279,6 +8279,7 @@ export default defineComponent({
       getCurrentTime,
       setCurrentTime,
       getSabrReloadState,
+      setFullscreenMetadata,
       closeFullscreenMetadata,
       setFullscreenTranscript,
       closeFullscreenTranscript,

--- a/src/renderer/components/ft-shaka-video-player/ft-shaka-video-player.vue
+++ b/src/renderer/components/ft-shaka-video-player/ft-shaka-video-player.vue
@@ -165,6 +165,20 @@
           </button>
         </div>
       </div>
+      <div
+        v-if="shortsPlayer"
+        class="shortsFullscreenMetadata shaka-no-propagation"
+        @click.stop
+        @dblclick.stop
+      >
+        <div class="shortsFullscreenMetadataSide">
+          <slot name="shorts-fullscreen-metadata" />
+        </div>
+        <div
+          class="shortsFullscreenVideoSpace"
+          aria-hidden="true"
+        />
+      </div>
       <Transition name="fade">
         <div
           v-if="autoplayCountdown"

--- a/src/renderer/views/Watch/Watch.js
+++ b/src/renderer/views/Watch/Watch.js
@@ -825,6 +825,9 @@ export default defineComponent({
         })
       }
     },
+    toggleFullscreenMetadata() {
+      this.$refs.player?.setFullscreenMetadata(!this.fullscreenMetadataOpen)
+    },
     handleFullscreenTranscriptChange({ open, target }) {
       this.fullscreenTranscriptTarget = target
       this.fullscreenTranscriptOpen = open && target !== null

--- a/src/renderer/views/Watch/Watch.scss
+++ b/src/renderer/views/Watch/Watch.scss
@@ -311,6 +311,87 @@
       flex: none;
     }
 
+    .shortsFullscreenMetadataContent {
+      min-inline-size: 0;
+      inline-size: min(100%, 560px);
+      pointer-events: auto;
+    }
+
+    .shortsFullscreenChannelRow {
+      display: flex;
+      flex-wrap: wrap;
+      align-items: center;
+      gap: 10px;
+      min-inline-size: 0;
+    }
+
+    .shortsFullscreenChannelRow :deep(.ftSubscribeButton) {
+      flex: none;
+    }
+
+    .shortsFullscreenChannel {
+      display: flex;
+      align-items: center;
+      gap: 8px;
+      min-inline-size: 0;
+      max-inline-size: 100%;
+      padding: 0;
+      border: 0;
+      color: inherit;
+      background: transparent;
+      cursor: pointer;
+      font: inherit;
+      text-shadow: 0 1px 2px #000, 0 2px 8px rgb(0 0 0 / 85%);
+    }
+
+    .shortsFullscreenChannel span {
+      overflow: hidden;
+      font-weight: 600;
+      text-overflow: ellipsis;
+      white-space: nowrap;
+    }
+
+    .shortsFullscreenChannelThumbnail {
+      inline-size: 36px;
+      block-size: 36px;
+      flex: none;
+      border-radius: 50%;
+      object-fit: cover;
+    }
+
+    .shortsFullscreenTitle {
+      margin-block: 12px 0;
+      margin-inline: -12px 0;
+    }
+
+    .shortsFullscreenTitleButton {
+      max-inline-size: 100%;
+      padding-block: 8px;
+      padding-inline: 12px;
+      border: 0;
+      border-radius: calc(12px * var(--ui-roundness));
+      color: inherit;
+      background: transparent;
+      cursor: pointer;
+      overflow-wrap: anywhere;
+      font: inherit;
+      font-size: 20px;
+      font-weight: 600;
+      line-height: 1.3;
+      text-align: start;
+      text-shadow: 0 1px 2px #000, 0 2px 8px rgb(0 0 0 / 85%);
+    }
+
+    .shortsFullscreenTitleButton:hover,
+    .shortsFullscreenTitleButton:focus-visible {
+      background-color: rgb(255 255 255 / 14%);
+    }
+
+    .shortsFullscreenTitleButton:focus-visible {
+      outline: 2px solid #fff;
+      outline-offset: 2px;
+    }
+
     .shortsExternalChannel {
       display: flex;
       align-items: center;

--- a/src/renderer/views/Watch/Watch.vue
+++ b/src/renderer/views/Watch/Watch.vue
@@ -155,7 +155,48 @@
           @chapter-thumbnails-change="handleChapterThumbnailsChange"
           @sponsorblock-info-change="handleSponsorBlockInfoChange"
           @toggle-shorts-metadata="toggleShortsMetadata"
-        />
+        >
+          <template #shorts-fullscreen-metadata>
+            <div class="shortsFullscreenMetadataContent">
+              <div class="shortsFullscreenChannelRow">
+                <button
+                  v-if="!hideUploader"
+                  type="button"
+                  class="shortsFullscreenChannel"
+                  @click="openShortsChannel"
+                >
+                  <img
+                    v-if="channelThumbnail"
+                    :src="channelThumbnail"
+                    class="shortsFullscreenChannelThumbnail"
+                    alt=""
+                  >
+                  <span dir="auto">{{ channelName }}</span>
+                </button>
+                <FtSubscribeButton
+                  v-if="!hideUnsubscribeButton"
+                  :channel-id="channelId"
+                  :channel-name="channelName"
+                  :channel-thumbnail="channelThumbnail"
+                  :subscription-count-text="channelSubscriptionCountText"
+                  :hide-profile-dropdown-toggle="true"
+                />
+              </div>
+              <h1 class="shortsFullscreenTitle">
+                <button
+                  type="button"
+                  class="shortsFullscreenTitleButton"
+                  dir="auto"
+                  :aria-label="`${$t('Video.Metadata')}: ${videoTitle}`"
+                  :aria-expanded="fullscreenMetadataOpen"
+                  @click="toggleFullscreenMetadata"
+                >
+                  {{ videoTitle }}
+                </button>
+              </h1>
+            </div>
+          </template>
+        </ft-shaka-video-player>
         <div
           v-if="!isLoading && (isUpcoming || errorMessage)"
           class="videoPlayer"


### PR DESCRIPTION
## Pull Request Type
<!-- Please select what type of pull request this is: [x] -->
- [ ] Bugfix
- [x] Feature Implementation
- [ ] Documentation
- [ ] Other

## Related issue
<!-- Please link the issue your pull request is referring to. -->
<!-- If this pull request fully resolves the relevant issue, put "closes" before the issue number. -->
<!-- Example: "closes #123456". -->

## Description
Show the channel avatar, channel name, subscribe button, and video title beside the YouTube-style Shorts player in fullscreen and full-window modes.

The metadata uses the same visibility preferences as the non-fullscreen layout. Its fullscreen grid stays aligned when a dock opens, and the title retains the existing clickable video-information behavior and hover treatment.

## Screenshots <!-- If appropriate -->
<!-- Please add before and after screenshots if there is a visible change. -->

## Release note category
<!-- Select exactly one category. Every pull request must select one. -->
<!-- release-note-category:start -->
- [ ] Not noteworthy
- [ ] Highlights
- [x] More improvements
- [ ] Fixed bugs
<!-- release-note-category:end -->

## Release note
<!-- Required unless "Not noteworthy" is selected. -->
<!-- Write one concise, user-facing entry without a leading bullet. -->
<!-- release-note:start -->
Show channel details and subscription controls beside Shorts in fullscreen.
<!-- release-note:end -->

## Release note images
<!-- Optional. Paste one or more Markdown images or HTML image tags here. -->
<!-- The release notes will use an HTML image tag and limit images taller than 300 pixels. -->
<!-- release-note-image:start -->

<!-- release-note-image:end -->

## Testing
<!-- How can reviewers verify that the PR produces correct results? -->
<!-- Please provide instructions so that others can ensure that your pull request produces correct results. -->

1. Open a Short with the YouTube-style Shorts player enabled.
2. Enter fullscreen and confirm the avatar, channel name, subscribe button, and title appear beside the portrait video.
3. Click the title and confirm the video-information dock opens without clipping the metadata.
4. Close the dock and confirm the metadata returns to its original position.
5. Confirm fullscreen exit and full-window mode behave the same way.

Automated checks:

- ESLint
- Stylelint
- Renderer production compilation
- Unit tests (159 passing)

## Desktop
<!-- Please complete the following information-->
- **OS:** Arch Linux
- **OS Version:** Rolling release
- **OpenTubeX version:** development

## Additional context
The fullscreen browser only includes descendants of the fullscreen player element. The non-fullscreen metadata therefore needs a player slot and fullscreen-specific layout rather than reusing the adjacent DOM node directly.
