### PR TITLE
Fix alternative icon pack sizing

### DIFF
--- a/src/renderer/components/FtIcon/FtIcon.vue
+++ b/src/renderer/components/FtIcon/FtIcon.vue
@@ -250,8 +250,10 @@ const iconifyGlyphStyle = computed(() => cssFromFaTransform(props.transform))
 .ft-icon {
   display: inline-block;
   flex-shrink: 0;
+  inline-size: var(--fa-width, 1.25em);
   line-height: 1;
   overflow: visible;
+  text-align: center;
   vertical-align: -0.125em;
 }
 
@@ -259,10 +261,11 @@ const iconifyGlyphStyle = computed(() => cssFromFaTransform(props.transform))
   display: block;
   /* Center when callers stretch .ft-icon wider than 1em (e.g. SideNav .navIcon). */
   margin-inline: auto;
+  /* Iconify packs leave more padding in their view boxes than Font Awesome. */
+  scale: 1.2;
 }
 
 .ft-icon--fw {
   inline-size: 1.25em;
-  text-align: center;
 }
 </style>

--- a/src/renderer/components/FtIcon/FtIcon.vue
+++ b/src/renderer/components/FtIcon/FtIcon.vue
@@ -14,6 +14,7 @@
     v-bind="forwardedAttrs"
     :data-prefix="semanticIcon?.[0]"
     :data-icon="semanticIcon?.[1]"
+    :data-icon-pack="currentIconPack"
     class="ft-icon"
     :class="[{ 'ft-icon--fw': fixedWidth }, iconClass]"
     :style="iconifyWrapperStyle"

--- a/src/renderer/components/SideNav/SideNav.css
+++ b/src/renderer/components/SideNav/SideNav.css
@@ -93,6 +93,17 @@
   transform: translateX(0.2em);
 }
 
+.navIcon[data-icon='user-check']:is(
+  [data-icon-pack='lucide'],
+  [data-icon-pack='material']
+) {
+  transform: translateX(0.15em);
+}
+
+.navIcon[data-icon='user-check'][data-icon-pack='phosphor'] {
+  transform: translateX(0.1em);
+}
+
 .navLabel {
   text-align: center;
   inset-inline-start: 0;
@@ -187,7 +198,7 @@
     margin-inline-start: 10px;
   }
 
-  .expanded .navIcon.fa-user-check {
+  .expanded .navIcon[data-icon='user-check'] {
     block-size: 1em;
   }
 

--- a/src/renderer/components/SideNavMoreOptions/SideNavMoreOptions.css
+++ b/src/renderer/components/SideNavMoreOptions/SideNavMoreOptions.css
@@ -74,6 +74,17 @@
     transform: translateX(0.2em);
   }
 
+  .navIcon[data-icon='user-check']:is(
+    [data-icon-pack='lucide'],
+    [data-icon-pack='material']
+  ) {
+    transform: translateX(0.15em);
+  }
+
+  .navIcon[data-icon='user-check'][data-icon-pack='phosphor'] {
+    transform: translateX(0.1em);
+  }
+
   .moreOption {
     display: block;
   }


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Make sure to follow the contributing guidelines. -->
<!-- Important note, we may remove your pull request if you do not use this provided PR template correctly. -->

## Pull Request Type
<!-- Please select what type of pull request this is: [x] -->
- [x] Bugfix
- [ ] Feature Implementation
- [ ] Documentation
- [ ] Other

## Related issue
<!-- Please link the issue your pull request is referring to. -->
<!-- If this pull request fully resolves the relevant issue, put "closes" before the issue number. -->
<!-- Example: "closes #123456". -->
Related to #388

## Description
<!-- Please write a clear and concise description of what the pull request does. -->
Alternative Iconify packs used a narrower layout box than Font Awesome and their padded view boxes made glyphs appear smaller, most noticeably on small controls such as the reload-comments button.

This aligns the wrapper with Font Awesome's default width and scales only the inner Iconify glyph to compensate for the replacement packs' additional view-box padding. The outer layout size and Font Awesome-style power transforms remain unchanged.

## Screenshots <!-- If appropriate -->
<!-- Please add before and after screenshots if there is a visible change. -->

## Release note category
<!-- Select exactly one category. Every pull request must select one. -->
<!-- release-note-category:start -->
- [x] Not noteworthy
- [ ] Highlights
- [ ] More improvements
- [ ] Fixed bugs
<!-- release-note-category:end -->

## Release note
<!-- Required unless "Not noteworthy" is selected. -->
<!-- Write one concise, user-facing entry without a leading bullet. -->
<!-- release-note:start -->
Alternative icon packs now render icons at a consistent size with Font Awesome.
<!-- release-note:end -->

## Release note images
<!-- Optional. Paste one or more Markdown images or HTML image tags here. -->
<!-- The release notes will use an HTML image tag and limit images taller than 300 pixels. -->
<!-- release-note-image:start -->

<!-- release-note-image:end -->

## Testing
<!-- How can reviewers verify that the PR produces correct results? -->
<!-- Please provide instructions so that others can ensure that your pull request would produce correct results. For examples see, https://github.com/FreeTubeApp/FreeTube/pull/5743, https://github.com/FreeTubeApp/FreeTube/pull/7349, https://github.com/FreeTubeApp/FreeTube/pull/5125, https://github.com/FreeTubeApp/FreeTube/pull/7338 -->
- `pnpm run test:unit`
- `pnpm run lint`
- Switch between Font Awesome, Material, Tabler, Phosphor, Lucide, and Remix in Theme Settings and compare small icon buttons, especially Reload Comments.

## Desktop
<!-- Please complete the following information-->
- **OS:** Arch Linux
- **OS Version:** Rolling release
- **OpenTubeX version:** development

## Additional context
<!-- Add any other context to the pull request here. -->
Visual confirmation across every supported pack is still requested as part of #388 review.
