### PR TITLE
perf: defer hidden subscription feed renders

### DIFF
--- a/e2e/tests/offline/subscriptions-refresh.spec.mjs
+++ b/e2e/tests/offline/subscriptions-refresh.spec.mjs
@@ -125,10 +125,16 @@ test.describe('incremental subscription feed refresh', () => {
     await goTo(page, 'subscriptions')
     await expect(page.getByText('Cached video 0', { exact: true })).toBeVisible()
 
+    const firstChannelResponse = page.waitForResponse((response) => {
+      return response.url().includes('/feeds/videos.xml') &&
+        channelIndexFromUrl(response.url()) === 0 &&
+        response.ok()
+    })
     await page.getByRole('button', { name: /Refresh Videos/ }).click()
     await page.locator(sel.newTabButton).click()
     await goTo(page, 'history')
 
+    await firstChannelResponse
     const refreshProgress = page.getByTestId('subscription-refresh-toast')
       .locator('.progress-indicator')
     await expect.poll(async () => Number(await refreshProgress.getAttribute('data-progress')))

--- a/e2e/tests/offline/subscriptions-refresh.spec.mjs
+++ b/e2e/tests/offline/subscriptions-refresh.spec.mjs
@@ -1,4 +1,4 @@
-import { test, expect, goTo } from '../../helpers/app.mjs'
+import { test, expect, goTo, sel } from '../../helpers/app.mjs'
 
 const HOUR = 3_600_000
 const now = Date.now()
@@ -118,6 +118,28 @@ test.describe('incremental subscription feed refresh', () => {
 
     await expect(page.getByText('Fresh video 1', { exact: true })).toBeVisible({ timeout: 30_000 })
     await expect(page.locator('.tab.active .loadingDot')).toHaveCount(0)
+  })
+
+  test('defers incremental feed renders while its app tab is hidden', async ({ page }) => {
+    await routeFeeds(page, (index) => index === 1 ? 8_000 : 2_000)
+    await goTo(page, 'subscriptions')
+    await expect(page.getByText('Cached video 0', { exact: true })).toBeVisible()
+
+    await page.getByRole('button', { name: /Refresh Videos/ }).click()
+    await page.locator(sel.newTabButton).click()
+    await goTo(page, 'history')
+
+    const refreshProgress = page.getByTestId('subscription-refresh-toast')
+      .locator('.progress-indicator')
+    await expect.poll(async () => Number(await refreshProgress.getAttribute('data-progress')))
+      .toBeGreaterThan(0)
+
+    const hiddenSubscriptions = page.locator('.tabContent[aria-hidden="true"]')
+    await expect(hiddenSubscriptions.getByText('Fresh video 0', { exact: true })).toHaveCount(0)
+    await expect(hiddenSubscriptions.getByText('Cached video 0', { exact: true })).toHaveCount(1)
+
+    await page.locator(sel.tabs).first().click()
+    await expect(page.getByText('Fresh video 0', { exact: true })).toBeVisible({ timeout: 3_000 })
   })
 
   test('keeps a manual refresh in the progress toast after navigation', async ({ page }) => {

--- a/src/renderer/composables/useSubscriptionChannelUpdates.js
+++ b/src/renderer/composables/useSubscriptionChannelUpdates.js
@@ -1,6 +1,7 @@
-import { onBeforeUnmount, onMounted } from 'vue'
+import { onBeforeUnmount, onMounted, watch } from 'vue'
 
 import { SUBSCRIPTION_REFRESH_CHANNEL_EVENT } from '../helpers/subscriptions'
+import { useTabContext } from '../tabs/TabContext'
 
 // Rebuilding and sorting the whole feed for every channel would be wasteful
 // with hundreds of subscriptions, so updates are coalesced.
@@ -13,34 +14,70 @@ const FEED_UPDATE_INTERVAL_MS = 500
  * @param {() => void} onChannelsRefreshed
  */
 export function useSubscriptionChannelUpdates(tab, onChannelsRefreshed) {
+  const { isTabPresented } = useTabContext()
   let timeout = null
   let lastRun = 0
+  let updatePending = false
+
+  function isPresented() {
+    return isTabPresented?.value !== false
+  }
 
   function run() {
     timeout = null
+
+    if (!isPresented()) {
+      return
+    }
+
+    updatePending = false
     lastRun = Date.now()
     onChannelsRefreshed()
+  }
+
+  function schedule() {
+    if (!isPresented() || timeout !== null) {
+      return
+    }
+
+    const remaining = FEED_UPDATE_INTERVAL_MS - (Date.now() - lastRun)
+    timeout = setTimeout(run, Math.max(remaining, 0))
   }
 
   /**
    * @param {CustomEvent<{tab: string}>} event
    */
   function handleChannelRefreshed(event) {
-    if (event.detail.tab !== tab || timeout !== null) {
+    if (event.detail.tab !== tab) {
       return
     }
 
-    const remaining = FEED_UPDATE_INTERVAL_MS - (Date.now() - lastRun)
+    updatePending = true
+    schedule()
+  }
 
-    if (remaining <= 0) {
-      run()
-    } else {
-      timeout = setTimeout(run, remaining)
-    }
+  if (isTabPresented !== null) {
+    watch(isTabPresented, (presented) => {
+      if (!presented) {
+        if (timeout !== null) {
+          clearTimeout(timeout)
+          timeout = null
+        }
+        return
+      }
+
+      if (updatePending) {
+        schedule()
+      }
+    })
   }
 
   onMounted(() => {
     window.addEventListener(SUBSCRIPTION_REFRESH_CHANNEL_EVENT, handleChannelRefreshed)
+
+    if (updatePending) {
+      schedule()
+    }
   })
 
   onBeforeUnmount(() => {


### PR DESCRIPTION
## Pull Request Type
- [ ] Bugfix
- [ ] Feature Implementation
- [ ] Documentation
- [x] Other

## Related issue

N/A

## Description

Subscription feed refreshes progressively rebuild and sort the visible feed as channels finish. Those same render updates continued in a hidden app tab even though the user could not see them.

This change defers incremental feed renders while the owning app tab is hidden. Network requests, cache persistence, progress reporting, cancellation, and progressive updates in a visible tab continue unchanged. When the tab becomes visible again, one coalesced update catches it up with the latest cache.

## Screenshots

Not applicable; there is no visible UI change.

## Release note category
<!-- release-note-category:start -->
- [ ] Not noteworthy
- [ ] Highlights
- [x] More improvements
- [ ] Fixed bugs
<!-- release-note-category:end -->

## Release note
<!-- release-note:start -->
Reduced background work while subscription feeds refresh in another app tab.
<!-- release-note:end -->

## Release note images
<!-- release-note-image:start -->

<!-- release-note-image:end -->

## Testing

- `pnpm run test:unit` (154 passed)
- `pnpm exec eslint --config eslint.config.mjs src/renderer/composables/useSubscriptionChannelUpdates.js`
- `pnpm run test:e2e:pack`
- `xvfb-run -a -s "-screen 0 1920x1080x24" pnpm exec playwright test -c e2e/playwright.config.mjs --project=offline e2e/tests/offline/subscriptions-refresh.spec.mjs` (9 passed)

The added regression test starts a subscription refresh, hides its app tab before a channel completes, confirms the hidden feed is not incrementally rerendered, and confirms it catches up when presented again.

## Desktop
- **OS:** Arch Linux
- **OS Version:** Rolling release
- **OpenTubeX version:** 0.30.1

## Additional context

No functionality or visible refresh feedback is removed; only hidden incremental rendering is deferred.