### PR TITLE
Handle unavailable comment replies

### DIFF
--- a/src/renderer/components/CommentSection/CommentSection.vue
+++ b/src/renderer/components/CommentSection/CommentSection.vue
@@ -1162,7 +1162,8 @@ async function getCommentRepliesLocal(index, commentId = null) {
       }
 
       showToast({
-        message: t('Comments.YouTube did not return these replies'),
+        message: t('Comments.YouTube did not provide advertised replies'),
+        time: 10000,
         icon: ['fas', 'comment']
       })
       return

--- a/src/renderer/components/CommentSection/CommentSection.vue
+++ b/src/renderer/components/CommentSection/CommentSection.vue
@@ -427,7 +427,7 @@ import { useTabContext } from '../../tabs/TabContext'
 import { copyToClipboard, formatNumber, showApiErrorToast, showToast } from '../../helpers/utils'
 import {
   getReplyLoadState,
-  isUnavailableReplyError,
+  isMissingReplyResponseError,
   shouldLoadInitialReplies
 } from '../../helpers/comment-replies'
 import { getYoutubeCommunityPostCommentUrl, getYoutubeVideoCommentUrl } from '../../helpers/share'
@@ -1073,10 +1073,11 @@ async function getCommentDataLocal(more = false, preserveSort = false) {
  * @param {string | null} commentId
  */
 async function getCommentRepliesLocal(index, commentId = null) {
-  try {
-    const comment = findComment(commentData.value[index], commentId)
-    const continuation = comment && replyTokens.get(comment.id)
+  const rootComment = commentData.value[index]
+  const comment = rootComment ? findComment(rootComment, commentId) : null
+  const continuation = comment && replyTokens.get(comment.id)
 
+  try {
     if (!comment || continuation == null || typeof continuation === 'string') {
       if (comment) {
         replyTokens.delete(comment.id)
@@ -1129,9 +1130,14 @@ async function getCommentRepliesLocal(index, commentId = null) {
   } catch (err) {
     console.error(err)
 
-    if (isUnavailableReplyError(err)) {
-      const comment = findComment(commentData.value[index], commentId)
-      if (comment) {
+    if (isMissingReplyResponseError(err)) {
+      if (backendFallback.value && backendPreference.value === 'local') {
+        showToast({ message: t('Falling back to Invidious API'), icon: ['fas', 'exchange-alt'] })
+        getCommentDataInvidious()
+        return
+      }
+
+      if (comment && replyTokens.get(comment.id) === continuation) {
         replyTokens.delete(comment.id)
         comment.hasReplyToken = false
         comment.numReplies = comment.replies.length
@@ -1139,7 +1145,7 @@ async function getCommentRepliesLocal(index, commentId = null) {
       }
 
       showToast({
-        message: t('Comments.These replies are no longer available on YouTube'),
+        message: t('Comments.YouTube did not return these replies'),
         icon: ['fas', 'comment']
       })
       return

--- a/src/renderer/components/CommentSection/CommentSection.vue
+++ b/src/renderer/components/CommentSection/CommentSection.vue
@@ -426,6 +426,7 @@ import { useTabContext } from '../../tabs/TabContext'
 
 import { copyToClipboard, formatNumber, showApiErrorToast, showToast } from '../../helpers/utils'
 import {
+  getReplyContinuationToken,
   getReplyLoadState,
   isMissingReplyResponseError,
   shouldLoadInitialReplies
@@ -920,9 +921,15 @@ async function getCommentReplies(index, commentId = null) {
   loadingReplyIds.value = new Set(loadingReplyIds.value).add(replyId)
 
   try {
-    if (!process.env.SUPPORTS_LOCAL_API || commentData.value[index].dataType === 'invidious') {
+    const comment = findComment(commentData.value[index], commentId)
+    const replyToken = comment && replyTokens.get(comment.id)
+    const useInvidious = !process.env.SUPPORTS_LOCAL_API ||
+      commentData.value[index].dataType === 'invidious' ||
+      typeof replyToken === 'string'
+
+    if (useInvidious) {
       if (!props.isPostComments) {
-        await getCommentRepliesInvidious(index)
+        await getCommentRepliesInvidious(index, commentId)
       } else {
         await getPostCommentRepliesInvidious(index)
       }
@@ -1076,6 +1083,9 @@ async function getCommentRepliesLocal(index, commentId = null) {
   const rootComment = commentData.value[index]
   const comment = rootComment ? findComment(rootComment, commentId) : null
   const continuation = comment && replyTokens.get(comment.id)
+  const invidiousReplyToken = continuation && typeof continuation !== 'string'
+    ? getReplyContinuationToken(continuation)
+    : null
 
   try {
     if (!comment || continuation == null || typeof continuation === 'string') {
@@ -1131,9 +1141,16 @@ async function getCommentRepliesLocal(index, commentId = null) {
     console.error(err)
 
     if (isMissingReplyResponseError(err)) {
-      if (backendFallback.value && backendPreference.value === 'local') {
+      if (
+        !props.isPostComments &&
+        backendFallback.value &&
+        backendPreference.value === 'local' &&
+        invidiousReplyToken &&
+        comment &&
+        replyTokens.get(comment.id) === continuation
+      ) {
         showToast({ message: t('Falling back to Invidious API'), icon: ['fas', 'exchange-alt'] })
-        getCommentDataInvidious()
+        await getCommentRepliesInvidious(index, commentId, invidiousReplyToken, comment, continuation)
         return
       }
 
@@ -1216,13 +1233,32 @@ async function getCommentDataInvidious() {
 
 /**
  * @param {number} index
+ * @param {string | null} commentId
+ * @param {string | null} replyTokenOverride
+ * @param {Comment | null} commentOverride
+ * @param {import('youtubei.js').YTNodes.CommentThread | null} expectedReplyToken
  */
-async function getCommentRepliesInvidious(index) {
-  const comment = commentData.value[index]
-  const replyToken = replyTokens.get(comment.id)
+async function getCommentRepliesInvidious(
+  index,
+  commentId = null,
+  replyTokenOverride = null,
+  commentOverride = null,
+  expectedReplyToken = null
+) {
+  const rootComment = commentData.value[index]
+  const comment = commentOverride ?? (rootComment ? findComment(rootComment, commentId) : null)
+  if (!comment) {
+    return
+  }
+
+  const replyToken = replyTokenOverride ?? replyTokens.get(comment.id)
 
   try {
     const { commentData, continuation } = await invidiousGetCommentReplies({ id: props.id, replyToken })
+
+    if (expectedReplyToken && replyTokens.get(comment.id) !== expectedReplyToken) {
+      return
+    }
 
     comment.replies = comment.replies.concat(commentData)
     const replyLoadState = getReplyLoadState(

--- a/src/renderer/components/CommentSection/CommentSection.vue
+++ b/src/renderer/components/CommentSection/CommentSection.vue
@@ -425,7 +425,11 @@ import store from '../../store/index'
 import { useTabContext } from '../../tabs/TabContext'
 
 import { copyToClipboard, formatNumber, showApiErrorToast, showToast } from '../../helpers/utils'
-import { getReplyLoadState, shouldLoadInitialReplies } from '../../helpers/comment-replies'
+import {
+  getReplyLoadState,
+  isUnavailableReplyError,
+  shouldLoadInitialReplies
+} from '../../helpers/comment-replies'
 import { getYoutubeCommunityPostCommentUrl, getYoutubeVideoCommentUrl } from '../../helpers/share'
 import {
   getLocalCommunityPostComments,
@@ -1124,6 +1128,23 @@ async function getCommentRepliesLocal(index, commentId = null) {
     comment.showReplies = replyLoadState.showReplies
   } catch (err) {
     console.error(err)
+
+    if (isUnavailableReplyError(err)) {
+      const comment = findComment(commentData.value[index], commentId)
+      if (comment) {
+        replyTokens.delete(comment.id)
+        comment.hasReplyToken = false
+        comment.numReplies = comment.replies.length
+        comment.showReplies = comment.replies.length > 0
+      }
+
+      showToast({
+        message: t('Comments.These replies are no longer available on YouTube'),
+        icon: ['fas', 'comment']
+      })
+      return
+    }
+
     const errorMessage = t('Local API Error (Click to copy)')
     showApiErrorToast(errorMessage, err)
     if (backendFallback.value && backendPreference.value === 'local') {

--- a/src/renderer/helpers/comment-replies.js
+++ b/src/renderer/helpers/comment-replies.js
@@ -24,8 +24,9 @@ export function shouldLoadInitialReplies(hasLoadedBatch, hasUsableReplies, hasCo
 }
 
 /**
- * youtubei.js reports this when a reply continuation response does not contain
- * the expected reply endpoint structure.
+ * Matches the error thrown by our patched youtubei.js 17.2.0
+ * CommentThread.getReplies() when the reply endpoint structure is missing.
+ * Keep this in sync with patches/youtubei.js@17.2.0.patch.
  * @param {unknown} error
  */
 export function isMissingReplyResponseError(error) {
@@ -39,7 +40,7 @@ export function isMissingReplyResponseError(error) {
  */
 export function getReplyContinuationToken(commentThread) {
   const continuation = commentThread.comment_replies_data?.sub_threads
-    .find(item => item.type === 'ContinuationItem')
+    ?.find(item => item.type === 'ContinuationItem')
 
   return continuation?.button?.endpoint?.payload?.token ??
     continuation?.endpoint?.payload?.token ??

--- a/src/renderer/helpers/comment-replies.js
+++ b/src/renderer/helpers/comment-replies.js
@@ -24,10 +24,12 @@ export function shouldLoadInitialReplies(hasLoadedBatch, hasUsableReplies, hasCo
 }
 
 /**
- * YouTube can advertise replies that have already been removed from the reply
- * continuation. youtubei.js reports that stale continuation with this error.
+ * youtubei.js reports this when a reply continuation response does not contain
+ * the expected reply endpoint structure.
  * @param {unknown} error
  */
-export function isUnavailableReplyError(error) {
-  return error instanceof Error && error.message === 'Unexpected response'
+export function isMissingReplyResponseError(error) {
+  return error instanceof Error &&
+    error.message === 'Unexpected response' &&
+    'info' in error
 }

--- a/src/renderer/helpers/comment-replies.js
+++ b/src/renderer/helpers/comment-replies.js
@@ -33,3 +33,15 @@ export function isMissingReplyResponseError(error) {
     error.message === 'Unexpected response' &&
     'info' in error
 }
+
+/**
+ * @param {import('youtubei.js').YTNodes.CommentThread} commentThread
+ */
+export function getReplyContinuationToken(commentThread) {
+  const continuation = commentThread.comment_replies_data?.sub_threads
+    .find(item => item.type === 'ContinuationItem')
+
+  return continuation?.button?.endpoint?.payload?.token ??
+    continuation?.endpoint?.payload?.token ??
+    null
+}

--- a/src/renderer/helpers/comment-replies.js
+++ b/src/renderer/helpers/comment-replies.js
@@ -22,3 +22,12 @@ export function getReplyLoadState(parsedReplyCount, loadedReplyCount, expectedRe
 export function shouldLoadInitialReplies(hasLoadedBatch, hasUsableReplies, hasContinuation) {
   return !hasLoadedBatch || (!hasUsableReplies && !hasContinuation)
 }
+
+/**
+ * YouTube can advertise replies that have already been removed from the reply
+ * continuation. youtubei.js reports that stale continuation with this error.
+ * @param {unknown} error
+ */
+export function isUnavailableReplyError(error) {
+  return error instanceof Error && error.message === 'Unexpected response'
+}

--- a/static/locales/en-US.yaml
+++ b/static/locales/en-US.yaml
@@ -1596,7 +1596,7 @@ Comments:
   There are no comments available for this video: There are no comments available
     for this video
   There are no comments available for this post: There are no comments available for this post
-  These replies are no longer available on YouTube: These replies are no longer available on YouTube
+  YouTube did not return these replies: YouTube did not return these replies
   Load More Comments: Load More Comments
   Pinned by: Pinned by
   Member: Member

--- a/static/locales/en-US.yaml
+++ b/static/locales/en-US.yaml
@@ -1596,6 +1596,7 @@ Comments:
   There are no comments available for this video: There are no comments available
     for this video
   There are no comments available for this post: There are no comments available for this post
+  These replies are no longer available on YouTube: These replies are no longer available on YouTube
   Load More Comments: Load More Comments
   Pinned by: Pinned by
   Member: Member

--- a/static/locales/en-US.yaml
+++ b/static/locales/en-US.yaml
@@ -1596,7 +1596,7 @@ Comments:
   There are no comments available for this video: There are no comments available
     for this video
   There are no comments available for this post: There are no comments available for this post
-  YouTube did not return these replies: YouTube did not return these replies
+  YouTube did not provide advertised replies: YouTube showed that this comment has replies, but did not provide them. They may have been deleted or hidden, so the reply button was removed.
   Load More Comments: Load More Comments
   Pinned by: Pinned by
   Member: Member

--- a/tests/unit/comment-replies.test.mjs
+++ b/tests/unit/comment-replies.test.mjs
@@ -3,7 +3,7 @@ import test from 'node:test'
 
 import {
   getReplyLoadState,
-  isUnavailableReplyError,
+  isMissingReplyResponseError,
   shouldLoadInitialReplies
 } from '../../src/renderer/helpers/comment-replies.js'
 
@@ -47,8 +47,11 @@ test('advances after an unusable initial batch when it has a continuation', () =
   assert.equal(shouldLoadInitialReplies(true, false, true), false)
 })
 
-test('recognizes a stale reply continuation response', () => {
-  assert.equal(isUnavailableReplyError(new Error('Unexpected response')), true)
-  assert.equal(isUnavailableReplyError(new Error('Network error')), false)
-  assert.equal(isUnavailableReplyError('Unexpected response'), false)
+test('recognizes a missing reply continuation response', () => {
+  const missingResponseError = Object.assign(new Error('Unexpected response'), { info: {} })
+
+  assert.equal(isMissingReplyResponseError(missingResponseError), true)
+  assert.equal(isMissingReplyResponseError(new Error('Unexpected response')), false)
+  assert.equal(isMissingReplyResponseError(Object.assign(new Error('Network error'), { info: {} })), false)
+  assert.equal(isMissingReplyResponseError('Unexpected response'), false)
 })

--- a/tests/unit/comment-replies.test.mjs
+++ b/tests/unit/comment-replies.test.mjs
@@ -3,6 +3,7 @@ import test from 'node:test'
 
 import {
   getReplyLoadState,
+  isUnavailableReplyError,
   shouldLoadInitialReplies
 } from '../../src/renderer/helpers/comment-replies.js'
 
@@ -44,4 +45,10 @@ test('retries an unusable initial batch when it has no continuation', () => {
 
 test('advances after an unusable initial batch when it has a continuation', () => {
   assert.equal(shouldLoadInitialReplies(true, false, true), false)
+})
+
+test('recognizes a stale reply continuation response', () => {
+  assert.equal(isUnavailableReplyError(new Error('Unexpected response')), true)
+  assert.equal(isUnavailableReplyError(new Error('Network error')), false)
+  assert.equal(isUnavailableReplyError('Unexpected response'), false)
 })

--- a/tests/unit/comment-replies.test.mjs
+++ b/tests/unit/comment-replies.test.mjs
@@ -2,6 +2,7 @@ import assert from 'node:assert/strict'
 import test from 'node:test'
 
 import {
+  getReplyContinuationToken,
   getReplyLoadState,
   isMissingReplyResponseError,
   shouldLoadInitialReplies
@@ -54,4 +55,35 @@ test('recognizes a missing reply continuation response', () => {
   assert.equal(isMissingReplyResponseError(new Error('Unexpected response')), false)
   assert.equal(isMissingReplyResponseError(Object.assign(new Error('Network error'), { info: {} })), false)
   assert.equal(isMissingReplyResponseError('Unexpected response'), false)
+})
+
+test('gets a reply continuation token from its endpoint', () => {
+  const commentThread = {
+    comment_replies_data: {
+      sub_threads: [
+        { type: 'CommentThread' },
+        { type: 'ContinuationItem', endpoint: { payload: { token: 'reply-token' } } }
+      ]
+    }
+  }
+
+  assert.equal(getReplyContinuationToken(commentThread), 'reply-token')
+})
+
+test('prefers a reply continuation button token', () => {
+  const commentThread = {
+    comment_replies_data: {
+      sub_threads: [{
+        type: 'ContinuationItem',
+        button: { endpoint: { payload: { token: 'button-token' } } },
+        endpoint: { payload: { token: 'endpoint-token' } }
+      }]
+    }
+  }
+
+  assert.equal(getReplyContinuationToken(commentThread), 'button-token')
+})
+
+test('returns null when a reply continuation is unavailable', () => {
+  assert.equal(getReplyContinuationToken({ comment_replies_data: null }), null)
 })

--- a/tests/unit/comment-replies.test.mjs
+++ b/tests/unit/comment-replies.test.mjs
@@ -86,4 +86,6 @@ test('prefers a reply continuation button token', () => {
 
 test('returns null when a reply continuation is unavailable', () => {
   assert.equal(getReplyContinuationToken({ comment_replies_data: null }), null)
+  assert.equal(getReplyContinuationToken({ comment_replies_data: {} }), null)
+  assert.equal(getReplyContinuationToken({ comment_replies_data: { sub_threads: undefined } }), null)
 })


### PR DESCRIPTION
## Pull Request Type
- [x] Bugfix
- [ ] Feature Implementation
- [ ] Documentation
- [ ] Other

## Related issue
N/A

## Description
YouTube can temporarily advertise replies whose continuation no longer returns a reply list, for example after a reply is removed or moderated. In that case, youtubei.js throws `Unexpected response`, and OpenTubeX previously displayed a generic local API error while leaving the unusable reply button visible.

This change recognizes that reply-loading error, removes the stale continuation and reply count, preserves any replies that were already loaded, and shows a clear notice that the replies are no longer available on YouTube. Other reply-loading failures continue to use the normal API error handling.

## Screenshots
Not included because the YouTube response that reproduces this state is transient.

## Release note category
<!-- release-note-category:start -->
- [ ] Not noteworthy
- [ ] Highlights
- [ ] More improvements
- [x] Fixed bugs
<!-- release-note-category:end -->

## Release note
<!-- release-note:start -->
Show a clear notice and remove stale reply controls when YouTube no longer makes advertised comment replies available.
<!-- release-note:end -->

## Release note images
<!-- release-note-image:start -->

<!-- release-note-image:end -->

## Testing
- Run `pnpm run test:unit`.
- Run ESLint against the changed Vue, JavaScript, test, and locale files.
- Open a video while YouTube advertises a stale reply continuation and select the reply control; verify that the unavailable notice appears and the unusable control is removed.

## Desktop
- **OS:** Arch Linux
- **OS Version:** Rolling release
- **OpenTubeX version:** Development (`a4ad046b7`)

## Additional context
The supplied console log confirmed the failure originated from `CommentThread.getReplies()`; unrelated SponsorBlock 404 responses were ignored.