### PR TITLE
Improve settings and channel list rendering

### DIFF
--- a/e2e/tests/offline/settings.spec.mjs
+++ b/e2e/tests/offline/settings.spec.mjs
@@ -4,10 +4,68 @@ import path from 'node:path'
 import { test, expect, goTo, latestSettings, sel } from '../../helpers/app.mjs'
 
 test.describe('settings', () => {
+  test('renders without flashing native scrollbars', async ({ page }) => {
+    const renderFrames = await page.evaluate(() => {
+      return new Promise((resolve) => {
+        const settingsLink = Array.from(document.querySelectorAll('.sideNav a[href="#/settings"]'))
+          .find(link => link instanceof HTMLElement && link.offsetParent !== null)
+        const frames = []
+
+        settingsLink.click()
+
+        const captureFrame = () => {
+          const sectionCount = document.querySelectorAll('.settingsSections > .section').length
+          const menuSectionCount = document.querySelectorAll('.settingsMenu [data-section]').length
+          frames.push({
+            menuSectionCount,
+            sectionCount,
+            settingsRendered: document.querySelector('.settingsPage') !== null,
+            nativeScrollbarsHidden: [document.documentElement, document.body]
+              .every(element => getComputedStyle(element).scrollbarWidth === 'none'),
+            pageOverlayScrollbars: Array.from(document.body.children)
+              .filter(element => element.classList.contains('os-scrollbar-vertical')).length
+          })
+
+          if (menuSectionCount > 0 && sectionCount === menuSectionCount) {
+            resolve(frames)
+          } else {
+            window.requestAnimationFrame(captureFrame)
+          }
+        }
+
+        window.requestAnimationFrame(captureFrame)
+      })
+    })
+
+    expect(renderFrames[0].settingsRendered).toBe(true)
+    expect(renderFrames.map(({ sectionCount }) => sectionCount))
+      .toEqual([1, renderFrames[0].menuSectionCount])
+    expect(renderFrames.every(({ nativeScrollbarsHidden }) => nativeScrollbarsHidden)).toBe(true)
+    expect(renderFrames.every(({ pageOverlayScrollbars }) => pageOverlayScrollbars === 1)).toBe(true)
+  })
+
   test('settings page renders its sections', async ({ page }) => {
     await goTo(page, 'settings')
     await expect(page).toHaveURL(/#\/settings/)
     await expect(page.locator('.settingsMenu, .ftSettingsMenu, [class*="settings"]').first()).toBeVisible()
+  })
+
+  test('retains the mounted page when switching to About and back', async ({ page }) => {
+    await goTo(page, 'settings')
+    const settingsPage = page.locator('.settingsPage')
+    await settingsPage.evaluate(element => {
+      element.dataset.cacheTest = 'mounted'
+    })
+
+    await goTo(page, 'about')
+    await expect(page.locator('.about-chunks')).toBeVisible()
+    await expect(settingsPage).toHaveCount(0)
+
+    await goTo(page, 'settings')
+
+    await expect(page.locator('.about-chunks')).toHaveCount(0)
+    await expect(settingsPage).toBeVisible()
+    await expect(settingsPage).toHaveAttribute('data-cache-test', 'mounted')
   })
 
   test('the current section persists in the URL', async ({ page }) => {

--- a/e2e/tests/offline/subscribed-channels.spec.mjs
+++ b/e2e/tests/offline/subscribed-channels.spec.mjs
@@ -80,3 +80,39 @@ test.describe('subscribed channels', () => {
     await expect(page.locator('.channel', { hasText: 'Alpha Channel' })).toHaveCount(0)
   })
 })
+
+test.describe('large subscribed channel lists', () => {
+  test.use({
+    seed: {
+      profiles: [
+        {
+          _id: 'allChannels',
+          name: 'All Channels',
+          bgColor: '#000000',
+          textColor: '#FFFFFF',
+          subscriptions: Array.from({ length: 900 }, (_, index) => ({
+            id: `UC${index.toString().padStart(22, '0')}`,
+            name: `Channel ${index.toString().padStart(3, '0')}`,
+            thumbnail: ''
+          }))
+        }
+      ]
+    }
+  })
+
+  test('renders large lists incrementally while keeping every channel searchable', async ({ page }) => {
+    await goTo(page, 'subscribedchannels')
+
+    await expect(page.getByText('900 channel(s) found.')).toBeVisible()
+    await expect(page.locator('.channel')).toHaveCount(50)
+    await expect(page.locator('.navChannel')).toHaveCount(50)
+
+    await page.getByPlaceholder('Search Channels').fill('Channel 899')
+    expect(await page.locator('.count').textContent()).toContain('1 channel(s) found.')
+    await expect(page.locator('.channel', { hasText: 'Channel 899' })).toBeVisible()
+
+    await page.getByPlaceholder('Search Channels').fill('')
+    await page.getByRole('button', { name: 'Load more channels' }).click()
+    await expect(page.locator('.channel')).toHaveCount(100)
+  })
+})

--- a/e2e/tests/offline/subscribed-channels.spec.mjs
+++ b/e2e/tests/offline/subscribed-channels.spec.mjs
@@ -107,6 +107,20 @@ test.describe('large subscribed channel lists', () => {
     await expect(page.locator('.channel')).toHaveCount(50)
     await expect(page.locator('.navChannel')).toHaveCount(50)
 
+    await page.locator('.sideNav .inner').evaluate((element) => {
+      element.scrollTop = element.scrollHeight
+    })
+    await expect(page.locator('.navChannel')).toHaveCount(100)
+
+    await page.evaluate(() => {
+      const store = document.querySelector('#app').__vue_app__.config.globalProperties.$store
+      store.commit('removeChannelFromProfiles', {
+        channelId: 'UC0000000000000000000000',
+        profileIds: ['allChannels']
+      })
+    })
+    await expect(page.locator('.navChannel')).toHaveCount(50)
+
     await page.getByPlaceholder('Search Channels').fill('Channel 899')
     expect(await page.locator('.count').textContent()).toContain('1 channel(s) found.')
     await expect(page.locator('.channel', { hasText: 'Channel 899' })).toBeVisible()
@@ -114,5 +128,17 @@ test.describe('large subscribed channel lists', () => {
     await page.getByPlaceholder('Search Channels').fill('')
     await page.getByRole('button', { name: 'Load more channels' }).click()
     await expect(page.locator('.channel')).toHaveCount(100)
+  })
+
+  test('uses the first repeated channel search query value', async ({ page }) => {
+    const channelTab = await page.evaluate(() => window.ftElectron.tabs.create({
+      route: '/subscribedchannels?searchQueryText=Channel%20899&searchQueryText=Channel%20898',
+      makeActive: false
+    }))
+    await page.locator(`.tab[data-tab-id="${channelTab.id}"]`).click()
+
+    await expect(page.getByPlaceholder('Search Channels')).toHaveValue('Channel 899')
+    await expect(page.locator('.count')).toContainText('1 channel(s) found.')
+    await expect(page.locator('.channel', { hasText: 'Channel 899' })).toBeVisible()
   })
 })

--- a/src/renderer/App.vue
+++ b/src/renderer/App.vue
@@ -313,6 +313,7 @@ import { getThumbnailListStyles } from './constants/thumbnailSize'
 import { getTabNavigationService } from './tabs/TabNavigationService'
 import { tabRuntimeRegistry } from './tabs/TabRuntimeRegistry'
 import { getTabPreviewFallbackUrl } from './tabs/tabPreview'
+import { preloadUtilityRoutes } from './router/index'
 
 const GITHUB_ISSUE_URL_PATTERN = /^https:\/\/github\.com\/([\w.-]+)\/([\w.-]+)\/issues\/(\d+)\/?$/i
 const LOCAL_REPOSITORY = 'opentubex/opentubex'
@@ -713,6 +714,8 @@ async function initializeManagedDownloadTools() {
 }
 
 onMounted(async () => {
+  preloadUtilityRoutes()
+
   if (isElectron) {
     removeTabsStateListener = await store.dispatch('initializeTabs')
     window.ftElectron.tabs.rendererReady()

--- a/src/renderer/components/SideNav/SideNav.css
+++ b/src/renderer/components/SideNav/SideNav.css
@@ -138,6 +138,10 @@
   vertical-align: middle;
 }
 
+.subscriptionLoadSentinel {
+  block-size: 1px;
+}
+
 .noThumbnail {
   /* font-size is used for font-icon */
   font-size: 35px;

--- a/src/renderer/components/SideNav/SideNav.vue
+++ b/src/renderer/components/SideNav/SideNav.vue
@@ -213,7 +213,7 @@
         class="mobileHidden"
       >
         <router-link
-          v-for="channel in activeSubscriptions"
+          v-for="channel in displayedActiveSubscriptions"
           :key="channel.id"
           :to="`/channel/${channel.id}`"
           class="navChannel channelLink mobileHidden"
@@ -246,6 +246,15 @@
             {{ channel.name }}
           </p>
         </router-link>
+        <div
+          v-if="hasMoreActiveSubscriptions"
+          :key="activeSubscriptionLimit"
+          v-observe-visibility="{
+            callback: onActiveSubscriptionsVisibilityChanged
+          }"
+          class="subscriptionLoadSentinel"
+          aria-hidden="true"
+        />
       </div>
     </div>
   </FtFlexBox>
@@ -272,6 +281,7 @@ const appKeyboardShortcuts = computed(() => getConfiguredKeyboardShortcuts(
 ).APP.GENERAL)
 
 const SUPPORTS_LOCAL_API = process.env.SUPPORTS_LOCAL_API
+const activeSubscriptionsPerPage = 50
 
 const props = defineProps({
   forceExpanded: {
@@ -330,6 +340,22 @@ const activeSubscriptions = computed(() => {
 
   return subscriptions
 })
+
+const activeSubscriptionLimit = ref(activeSubscriptionsPerPage)
+
+const displayedActiveSubscriptions = computed(() => {
+  return activeSubscriptions.value.slice(0, activeSubscriptionLimit.value)
+})
+
+const hasMoreActiveSubscriptions = computed(() => {
+  return displayedActiveSubscriptions.value.length < activeSubscriptions.value.length
+})
+
+function onActiveSubscriptionsVisibilityChanged(isVisible) {
+  if (isVisible) {
+    activeSubscriptionLimit.value += activeSubscriptionsPerPage
+  }
+}
 
 /** @type {import('vue').ComputedRef<boolean>} */
 const hidePopularVideos = computed(() => {
@@ -428,7 +454,11 @@ function updateIndicatorAfterResize() {
 }
 
 watch(() => route.fullPath, () => nextTick(updateIndicator))
-watch([isOpen, hideText, activeSubscriptions], () => {
+watch(() => activeProfile.value._id, () => {
+  activeSubscriptionLimit.value = activeSubscriptionsPerPage
+})
+
+watch([isOpen, hideText, displayedActiveSubscriptions], () => {
   nextTick(updateIndicator)
   updateIndicatorAfterResize()
 })

--- a/src/renderer/components/SideNav/SideNav.vue
+++ b/src/renderer/components/SideNav/SideNav.vue
@@ -454,7 +454,10 @@ function updateIndicatorAfterResize() {
 }
 
 watch(() => route.fullPath, () => nextTick(updateIndicator))
-watch(() => activeProfile.value._id, () => {
+watch([
+  () => activeProfile.value._id,
+  () => activeProfile.value.subscriptions.length
+], () => {
   activeSubscriptionLimit.value = activeSubscriptionsPerPage
 })
 

--- a/src/renderer/components/TabContent/TabContent.vue
+++ b/src/renderer/components/TabContent/TabContent.vue
@@ -7,12 +7,17 @@
     :inert="!isPresented"
     :aria-hidden="String(!isPresented)"
   >
-    <component
-      :is="resolvedComponent"
-      v-if="initialized && resolvedComponent"
-      :key="tab.refreshKey || 0"
-      class="routerView"
-    />
+    <KeepAlive
+      include="SettingsRoute,AboutRoute"
+      :max="2"
+    >
+      <component
+        :is="resolvedComponent"
+        v-if="initialized && resolvedComponent"
+        :key="resolvedComponentKey"
+        class="routerView"
+      />
+    </KeepAlive>
   </div>
 </template>
 
@@ -40,6 +45,7 @@ import { tabIdKey, tabLifecycleKey, tabPresentedKey } from '../../tabs/TabContex
 
 const TAB_LOADER_SELECTOR = '[data-tab-loading-indicator]'
 const TAB_LOADER_LOADING_SOURCE = 'loader'
+const CACHED_ROUTE_NAMES = new Set(['about', 'settings'])
 
 const props = defineProps({
   tab: {
@@ -60,6 +66,12 @@ const routerFacade = navigation.createRouterFacade(props.tab.id)
 // every deep route watcher in the mounted page.
 const routeFullPath = computed(() => props.tab.route?.fullPath || '/')
 const resolvedRoute = computed(() => navigation.resolve(routeFullPath.value))
+const resolvedComponentKey = computed(() => {
+  const refreshKey = props.tab.refreshKey || 0
+  return CACHED_ROUTE_NAMES.has(resolvedRoute.value.name)
+    ? `${resolvedRoute.value.name}:${refreshKey}`
+    : refreshKey
+})
 const injectedRoute = reactive({})
 const resolvedComponent = computed(() => resolveRouteComponent(resolvedRoute.value))
 

--- a/src/renderer/router/index.js
+++ b/src/renderer/router/index.js
@@ -1,4 +1,4 @@
-import { defineAsyncComponent, h } from 'vue'
+import { defineAsyncComponent, h, markRaw, shallowRef } from 'vue'
 import { createRouter, createWebHashHistory } from 'vue-router'
 import { getFixedInternalRouteTitle } from '../../internalRoutes'
 import Subscriptions from '../views/Subscriptions/Subscriptions.vue'
@@ -30,10 +30,36 @@ const Watch = defineAsyncComponent({
   loadingComponent: AsyncRouteLoadingIndicator,
   delay: 0
 })
-const Settings = defineAsyncComponent(() => import('../views/Settings/Settings.vue'))
+
+function createPreloadedRoute(name, loader) {
+  const loadedComponent = shallowRef(defineAsyncComponent(loader))
+
+  return {
+    component: {
+      name,
+      setup: () => () => h(loadedComponent.value)
+    },
+    preload: () => loader().then(({ default: component }) => {
+      loadedComponent.value = markRaw(component)
+    }).catch((error) => {
+      console.error(`Failed to preload ${name}`, error)
+    })
+  }
+}
+
+const settingsRoute = createPreloadedRoute('SettingsRoute', () => import('../views/Settings/Settings.vue'))
+const aboutRoute = createPreloadedRoute('AboutRoute', () => import('../views/About/About.vue'))
+const Settings = settingsRoute.component
+const About = aboutRoute.component
 const ProfileSettings = defineAsyncComponent(() => import('../views/ProfileSettings/ProfileSettings.vue'))
-const About = defineAsyncComponent(() => import('../views/About/About.vue'))
 const Stats = defineAsyncComponent(() => import('../views/Stats/Stats.vue'))
+
+// Keep Settings in its own chunk so its styles retain their established load
+// order, but allow the app to evaluate it before the UI can be interacted with.
+// Otherwise the first Settings navigation has to wait for this large chunk.
+export function preloadUtilityRoutes() {
+  return Promise.all([settingsRoute.preload(), aboutRoute.preload()])
+}
 
 export const routes = [
   {

--- a/src/renderer/views/Settings/Settings.vue
+++ b/src/renderer/views/Settings/Settings.vue
@@ -60,7 +60,7 @@
         <div class="settingsSections">
           <component
             :is="section.component"
-            v-for="section in settingsSectionComponents"
+            v-for="section in renderedSettingsSectionComponents"
             :key="section.type"
             ref="sectionRefs"
             class="section"
@@ -79,7 +79,16 @@
 
 <script setup>
 import { FontAwesomeIcon } from '@fortawesome/vue-fontawesome'
-import { computed, nextTick, onBeforeUnmount, onMounted, ref, useTemplateRef } from 'vue'
+import {
+  computed,
+  nextTick,
+  onActivated,
+  onBeforeUnmount,
+  onDeactivated,
+  onMounted,
+  ref,
+  useTemplateRef
+} from 'vue'
 import { useI18n } from 'vue-i18n'
 import { useRoute, useRouter } from 'vue-router'
 
@@ -269,6 +278,11 @@ const settingsSectionComponents = computed(() => {
   return [generalSettingsEntry, ...settingsSections]
 })
 
+const renderedSectionCount = ref(1)
+const renderedSettingsSectionComponents = computed(() => {
+  return settingsSectionComponents.value.slice(0, renderedSectionCount.value)
+})
+
 const unlocked = ref(store.getters.getSettingsPassword === '')
 
 if (unlocked.value) {
@@ -283,10 +297,21 @@ function handleUnlock() {
   })
 }
 
-onBeforeUnmount(() => {
+function stopObservingSettingsPage() {
   document.removeEventListener('scroll', markScrolledToSectionAsActive)
   settingsResizeObserver?.disconnect()
+  settingsResizeObserver = null
+  window.cancelAnimationFrame(renderSectionsAnimationFrameId)
+}
+
+onActivated(() => {
+  if (unlocked.value && settingsResizeObserver == null) {
+    observeSettingsPage()
+    scheduleRemainingSettingsSections()
+  }
 })
+onDeactivated(stopObservingSettingsPage)
+onBeforeUnmount(stopObservingSettingsPage)
 
 function showKeyboardShortcutPrompt() {
   store.dispatch('showKeyboardShortcutPrompt')
@@ -307,12 +332,9 @@ function updateHighlightChangedSettings(value) {
 }
 
 function handleMounted() {
-  handleResize()
-  settingsResizeObserver = new ResizeObserver(([entry]) => {
-    handleResize(entry.contentRect.width)
-  })
-  settingsResizeObserver.observe(settingsPageRef.value)
-  document.addEventListener('scroll', markScrolledToSectionAsActive)
+  if (settingsResizeObserver == null) {
+    observeSettingsPage()
+  }
 
   const sectionFromHash = route.hash.slice(1)
   const initialSection = settingsSectionComponents.value.some(({ type }) => type === sectionFromHash)
@@ -326,18 +348,48 @@ function handleMounted() {
   } else if (isInDesktopView.value) {
     updateSectionHash(initialSection)
   }
+
+  scheduleRemainingSettingsSections()
+}
+
+function observeSettingsPage() {
+  handleResize()
+  settingsResizeObserver = new ResizeObserver(([entry]) => {
+    handleResize(entry.contentRect.width)
+  })
+  settingsResizeObserver.observe(settingsPageRef.value)
+  document.addEventListener('scroll', markScrolledToSectionAsActive)
 }
 
 const sectionRefs = useTemplateRef('sectionRefs')
 const settingsPageRef = useTemplateRef('settingsPageRef')
 let settingsResizeObserver = null
 let hasMeasuredSettingsWidth = false
+let renderSectionsAnimationFrameId = 0
+
+function scheduleRemainingSettingsSections() {
+  if (renderedSectionCount.value >= settingsSectionComponents.value.length) {
+    return
+  }
+
+  renderSectionsAnimationFrameId = window.requestAnimationFrame(() => {
+    // Mount below-the-fold sections together after the Settings shell paints.
+    // Growing the document over several frames makes the page scrollbar update
+    // repeatedly and exposes scrollbar flicker while opening Settings.
+    renderedSectionCount.value = settingsSectionComponents.value.length
+  })
+}
 
 /**
  * @param {string} sectionType
  * @param {boolean} updateHash
  */
 function navigateToSection(sectionType, updateHash = true) {
+  const sectionIndex = settingsSectionComponents.value.findIndex(({ type }) => type === sectionType)
+  if (sectionIndex >= renderedSectionCount.value) {
+    renderedSectionCount.value = sectionIndex + 1
+  }
+
   if (updateHash) {
     updateSectionHash(sectionType)
   }
@@ -347,6 +399,9 @@ function navigateToSection(sectionType, updateHash = true) {
       const sectionElement = sectionRefs.value.find(sectionRef => {
         return sectionRef.$el.dataset.section === sectionType
       })?.$el
+      if (!sectionElement) {
+        return
+      }
       sectionElement.scrollIntoView()
 
       const sectionHeading = sectionElement.firstChild.firstChild

--- a/src/renderer/views/SubscribedChannels/SubscribedChannels.vue
+++ b/src/renderer/views/SubscribedChannels/SubscribedChannels.vue
@@ -314,8 +314,9 @@ watch(activeSubscriptionList, () => {
 
 getSubscription()
 
-const oldQuery = route.query.searchQueryText ?? ''
-if (oldQuery !== null && oldQuery !== '') {
+const rawQuery = route.query.searchQueryText
+const oldQuery = Array.isArray(rawQuery) ? rawQuery[0] ?? '' : rawQuery ?? ''
+if (oldQuery !== '') {
   handleQueryChange(oldQuery)
 }
 

--- a/src/renderer/views/SubscribedChannels/SubscribedChannels.vue
+++ b/src/renderer/views/SubscribedChannels/SubscribedChannels.vue
@@ -38,7 +38,7 @@
         </ft-flex-box>
         <ft-flex-box class="channels">
           <div
-            v-for="channel in channelList"
+            v-for="channel in displayedChannels"
             :key="channel.id"
             class="channel"
           >
@@ -81,6 +81,20 @@
             </div>
           </div>
         </ft-flex-box>
+        <FtAutoLoadNextPageWrapper
+          v-if="hasMoreChannels"
+          :key="channelLimit"
+          @load-next-page="loadMoreChannels"
+        >
+          <ft-flex-box>
+            <FtButton
+              :label="$t('Channels.Load More Channels')"
+              background-color="var(--primary-color)"
+              text-color="var(--text-with-main-color)"
+              @click="loadMoreChannels"
+            />
+          </ft-flex-box>
+        </FtAutoLoadNextPageWrapper>
       </template>
     </ft-card>
   </div>
@@ -90,6 +104,8 @@
 import { FontAwesomeIcon } from '@fortawesome/vue-fontawesome'
 import { computed, onMounted, onBeforeUnmount, ref, watch, useTemplateRef } from 'vue'
 import { isNavigationFailure, NavigationFailureType, useRoute, useRouter } from 'vue-router'
+import FtAutoLoadNextPageWrapper from '../../components/FtAutoLoadNextPageWrapper.vue'
+import FtButton from '../../components/FtButton/FtButton.vue'
 import FtCard from '../../components/ft-card/ft-card.vue'
 import FtFlexBox from '../../components/ft-flex-box/ft-flex-box.vue'
 import FtInput from '../../components/FtInput/FtInput.vue'
@@ -97,7 +113,7 @@ import FtProfileSelector from '../../components/FtProfileSelector/FtProfileSelec
 import FtSubscribeButton from '../../components/FtSubscribeButton/FtSubscribeButton.vue'
 import { invidiousGetChannelInfo, youtubeImageUrlToInvidious, invidiousImageUrlToInvidious } from '../../helpers/api/invidious'
 import { getLocalChannel, parseLocalChannelHeader } from '../../helpers/api/local'
-import { ctrlFHandler, debounce } from '../../helpers/utils'
+import { ctrlFHandler } from '../../helpers/utils'
 import { useI18n } from 'vue-i18n'
 import store from '../../store/index'
 
@@ -111,9 +127,11 @@ const re = {
 }
 const ytBaseURL = 'https://yt3.ggpht.com'
 const thumbnailSize = 176
+const channelsPerPage = 50
 let errorCount = 0
 
 const query = ref('')
+const channelLimit = ref(channelsPerPage)
 const subscribedChannels = ref([])
 const filteredChannels = ref([])
 
@@ -141,6 +159,14 @@ const channelList = computed(() => {
   } else {
     return subscribedChannels.value
   }
+})
+
+const displayedChannels = computed(() => {
+  return channelList.value.slice(0, channelLimit.value)
+})
+
+const hasMoreChannels = computed(() => {
+  return displayedChannels.value.length < channelList.value.length
 })
 
 /** @type {import('vue').ComputedRef<boolean>} */
@@ -181,8 +207,6 @@ function filterChannels() {
     return re.test(channel.name)
   })
 }
-
-const filterChannelsDebounce = debounce(filterChannels, 500)
 
 function thumbnailURL(originalURL) {
   if (originalURL == null) { return null }
@@ -235,16 +259,20 @@ function updateThumbnail(channel) {
   }
 }
 
-function handleQueryChange(val, filterNow = false) {
+function handleQueryChange(val) {
   query.value = val
+  channelLimit.value = channelsPerPage
+  filterChannels()
 
   saveStateInRouter(val)
+}
 
-  filterNow ? filterChannels() : filterChannelsDebounce()
+function loadMoreChannels() {
+  channelLimit.value += channelsPerPage
 }
 
 async function saveStateInRouter(query) {
-  if (query.value === '') {
+  if (query === '') {
     await router.replace({ name: 'subscribedChannels' }).catch(failure => {
       if (isNavigationFailure(failure, NavigationFailureType.duplicated)) {
         return
@@ -273,6 +301,7 @@ function keyboardShortcutHandler(event) {
 
 watch(activeProfileId, () => {
   query.value = ''
+  channelLimit.value = channelsPerPage
   getSubscription()
 })
 
@@ -287,8 +316,7 @@ getSubscription()
 
 const oldQuery = route.query.searchQueryText ?? ''
 if (oldQuery !== null && oldQuery !== '') {
-  // `handleQueryChange` must be called after `filterHistoryDebounce` assigned
-  handleQueryChange(oldQuery, true)
+  handleQueryChange(oldQuery)
 }
 
 // endregion created

--- a/static/locales/en-GB.yaml
+++ b/static/locales/en-GB.yaml
@@ -1020,6 +1020,7 @@ Screenshot Success: Saved screenshot
 New Window: New window
 Channels:
   Empty: Your channel list is currently empty.
+  Load More Channels: Load more channels
   Unsubscribe Prompt: Are you sure you want to Unsubscribe from ‘{channelName}’?
   Title: Channel list
   Search bar placeholder: Search channels


### PR DESCRIPTION
## Pull Request Type
- [x] Bugfix
- [ ] Feature Implementation
- [ ] Documentation
- [ ] Other

## Related issue

None.

## Description

Improves rendering performance for two heavy utility views:

- renders subscribed channels and sidebar subscriptions in batches of 50 instead of mounting every channel at once
- keeps channel filtering synchronous across the complete subscription list, avoiding a temporary zero-results state
- re-evaluates pagination sentinels after each batch so auto-loading continues while the scrollbar remains at the bottom
- preloads the Settings and About routes, retains them across navigation, and defers below-the-fold Settings sections until after the initial shell paints

The channel-list slowdown came from eagerly mounting hundreds of profile-aware channel controls and sidebar links. The Settings delay came from loading and mounting the complete route and every section during first navigation.

## Screenshots

Not applicable; behavior and performance changes only.

## Release note category
<!-- release-note-category:start -->
- [ ] Not noteworthy
- [ ] Highlights
- [ ] More improvements
- [x] Fixed bugs
<!-- release-note-category:end -->

## Release note
<!-- release-note:start -->
Channel lists with many subscriptions and the Settings page now open without long rendering delays.
<!-- release-note:end -->

## Release note images
<!-- release-note-image:start -->
<!-- release-note-image:end -->

## Testing

- `pnpm run test:unit` — 154 passed
- `pnpm run test:e2e:pack`
- `xvfb-run -a -s "-screen 0 1920x1080x24" pnpm exec playwright test -c e2e/playwright.config.mjs e2e/tests/offline/subscribed-channels.spec.mjs e2e/tests/offline/settings.spec.mjs --project=offline --workers=1` — 30 passed
- ESLint on all changed renderer files
- Stylelint on the changed sidebar stylesheet
- The channel-list E2E fixture includes 900 subscriptions and verifies immediate search plus incremental rendering

## Desktop
- **OS:** Arch Linux
- **OS Version:** Rolling release
- **OpenTubeX version:** 0.30.1

## Additional context

The Settings changes include the work from the `93c2` worktree.