### PR TITLE
fix: render rich release note elements

### DIFF
--- a/src/renderer/App.css
+++ b/src/renderer/App.css
@@ -113,6 +113,57 @@
   block-size: auto;
 }
 
+.changeLogText :deep(details) {
+  margin-block: 1em;
+  padding-block: 0.75em;
+  padding-inline: 1em;
+  background-color: color-mix(in srgb, var(--card-bg-color) 88%, var(--primary-text-color));
+  border: 1px solid var(--tertiary-text-color);
+  border-radius: calc(6px * var(--ui-roundness));
+}
+
+.changeLogText :deep(summary) {
+  cursor: pointer;
+  font-weight: bold;
+}
+
+.changeLogText :deep(blockquote[data-alert]) {
+  --change-log-alert-color: #0969da;
+
+  margin-inline: 0;
+  padding-block: 0.75em;
+  padding-inline: 1em;
+  background-color: color-mix(in srgb, var(--change-log-alert-color) 12%, var(--card-bg-color));
+  border-inline-start: 4px solid var(--change-log-alert-color);
+  border-radius: 0 calc(6px * var(--ui-roundness)) calc(6px * var(--ui-roundness)) 0;
+}
+
+.changeLogText :deep(blockquote[data-alert]::before) {
+  display: block;
+  margin-block-end: 0.5em;
+  color: var(--change-log-alert-color);
+  content: attr(data-alert);
+  font-size: 0.8em;
+  font-weight: bold;
+  text-transform: uppercase;
+}
+
+.changeLogText :deep(blockquote[data-alert='tip']) {
+  --change-log-alert-color: #1a7f37;
+}
+
+.changeLogText :deep(blockquote[data-alert='important']) {
+  --change-log-alert-color: #8250df;
+}
+
+.changeLogText :deep(blockquote[data-alert='warning']) {
+  --change-log-alert-color: #9a6700;
+}
+
+.changeLogText :deep(blockquote[data-alert='caution']) {
+  --change-log-alert-color: #cf222e;
+}
+
 .findbar {
   position: fixed;
   inset-block-start: 102px;

--- a/src/renderer/App.vue
+++ b/src/renderer/App.vue
@@ -83,7 +83,7 @@
           {{ changeLogTitle }}
         </h1>
       </template>
-      <bdo
+      <div
         v-safer-html.lenient="updateChangelog"
         v-overlay-scrollbars
         class="changeLogText"
@@ -264,7 +264,6 @@
 
 <script setup>
 import { FontAwesomeIcon } from '@fortawesome/vue-fontawesome'
-import { Marked } from 'marked'
 import { computed, nextTick, onBeforeUnmount, onMounted, provide, ref, useTemplateRef, watch } from 'vue'
 import { useI18n } from 'vue-i18n'
 import { routerKey, useRoute, useRouter } from 'vue-router'
@@ -292,6 +291,7 @@ import packageDetails from '../../package.json'
 import { KeyboardShortcuts } from '../constants'
 import { matchesKeyboardShortcut } from './helpers/keyboardShortcuts'
 import { findUpdateRelease } from './helpers/releaseUpdates'
+import { createReleaseNotesMarkdown } from './helpers/releaseNotesMarkdown'
 import { openExternalLink, openInternalPath, showToast } from './helpers/utils'
 import {
   cancelSubscriptionRefresh,
@@ -318,7 +318,7 @@ const GITHUB_ISSUE_URL_PATTERN = /^https:\/\/github\.com\/([\w.-]+)\/([\w.-]+)\/
 const LOCAL_REPOSITORY = 'opentubex/opentubex'
 const UPSTREAM_REPOSITORY = 'freetubeapp/freetube'
 
-const releaseNotesMarkdown = new Marked({
+const releaseNotesMarkdown = createReleaseNotesMarkdown({
   extensions: [{
     name: 'issueReference',
     level: 'inline',
@@ -339,26 +339,24 @@ const releaseNotesMarkdown = new Marked({
       return `<a href="https://github.com/OpenTubeX/OpenTubeX/issues/${issueNumber}">#${issueNumber}</a>`
     }
   }],
-  renderer: {
-    link(token) {
-      const match = GITHUB_ISSUE_URL_PATTERN.exec(token.href)
+  renderLink(token) {
+    const match = GITHUB_ISSUE_URL_PATTERN.exec(token.href)
 
-      if (!match) {
-        return false
-      }
-
-      const [, owner, repository, issueNumber] = match
-      const repositoryName = `${owner}/${repository}`
-      let label = `${repositoryName}#${issueNumber}`
-
-      if (repositoryName.toLowerCase() === LOCAL_REPOSITORY) {
-        label = `#${issueNumber}`
-      } else if (repositoryName.toLowerCase() === UPSTREAM_REPOSITORY) {
-        label = `${owner}#${issueNumber}`
-      }
-
-      return `<a href="${token.href}">${label}</a>`
+    if (!match) {
+      return false
     }
+
+    const [, owner, repository, issueNumber] = match
+    const repositoryName = `${owner}/${repository}`
+    let label = `${repositoryName}#${issueNumber}`
+
+    if (repositoryName.toLowerCase() === LOCAL_REPOSITORY) {
+      label = `#${issueNumber}`
+    } else if (repositoryName.toLowerCase() === UPSTREAM_REPOSITORY) {
+      label = `${owner}#${issueNumber}`
+    }
+
+    return `<a href="${token.href}">${label}</a>`
   }
 })
 

--- a/src/renderer/directives/vSaferHtml.js
+++ b/src/renderer/directives/vSaferHtml.js
@@ -16,7 +16,7 @@ export const vSaferHtml = (element, { value, oldValue, modifiers }) => {
           lenientSanitizer = new Sanitizer({
             comments: false,
             elements: [
-              'blockquote', 'br', 'code', 'del', 'details', 'em',
+              'br', 'code', 'del', 'details', 'em',
               'h1', 'h2', 'h3', 'h4', 'h5', 'h6', 'hr', 'kbd',
               'p', 'pre', 's', 'strong', 'summary',
               'table', 'tbody', 'td', 'th', 'thead', 'tr',
@@ -24,6 +24,10 @@ export const vSaferHtml = (element, { value, oldValue, modifiers }) => {
               {
                 name: 'a',
                 attributes: ['href', 'title']
+              },
+              {
+                name: 'blockquote',
+                attributes: ['data-alert']
               },
               {
                 name: 'img',

--- a/src/renderer/helpers/releaseNotesMarkdown.js
+++ b/src/renderer/helpers/releaseNotesMarkdown.js
@@ -1,0 +1,46 @@
+import { Marked } from 'marked'
+
+const GITHUB_ALERT_TYPES = /NOTE|TIP|IMPORTANT|WARNING|CAUTION/i
+
+/**
+ * Creates the Markdown renderer used for update release notes.
+ *
+ * @param {object} options
+ * @param {import('marked').MarkedExtension[]} [options.extensions]
+ * @param {(token: import('marked').Tokens.Link) => string | false} options.renderLink
+ * @returns {Marked}
+ */
+export function createReleaseNotesMarkdown({ extensions = [], renderLink }) {
+  return new Marked({
+    extensions: [{
+      name: 'githubAlert',
+      level: 'block',
+      start: (source) => source.match(new RegExp(`^>\\s*\\[!(${GITHUB_ALERT_TYPES.source})\\]`, 'im'))?.index,
+      tokenizer(source) {
+        const match = new RegExp(`^(?:>\\s*\\[!(${GITHUB_ALERT_TYPES.source})\\][ \\t]*([^\\n]*)(?:\\n|$))((?:>[^\\n]*(?:\\n|$))*)`, 'i').exec(source)
+        if (!match) {
+          return undefined
+        }
+
+        const firstLine = match[2]
+        const remainingLines = match[3].replaceAll(/^> ?/gm, '')
+        const text = firstLine.length > 0 && remainingLines.length > 0
+          ? `${firstLine}\n${remainingLines}`
+          : firstLine + remainingLines
+
+        return {
+          type: 'githubAlert',
+          raw: match[0],
+          alertType: match[1].toLowerCase(),
+          tokens: this.lexer.blockTokens(text)
+        }
+      },
+      renderer(token) {
+        return `<blockquote data-alert="${token.alertType}">\n${this.parser.parse(token.tokens)}</blockquote>\n`
+      }
+    }, ...extensions],
+    renderer: {
+      link: renderLink
+    }
+  })
+}

--- a/tests/unit/release-notes-markdown.test.mjs
+++ b/tests/unit/release-notes-markdown.test.mjs
@@ -1,0 +1,21 @@
+import assert from 'node:assert/strict'
+import test from 'node:test'
+
+import { createReleaseNotesMarkdown } from '../../src/renderer/helpers/releaseNotesMarkdown.js'
+
+const markdown = createReleaseNotesMarkdown({ renderLink: () => false })
+
+test('renders GitHub alerts without showing their marker', () => {
+  const html = markdown.parse('> [!WARNING] This nightly build may be unstable.')
+
+  assert.match(html, /<blockquote data-alert="warning">/)
+  assert.match(html, /This nightly build may be unstable\./)
+  assert.doesNotMatch(html, /\[!WARNING\]/)
+})
+
+test('preserves details and summary elements', () => {
+  const html = markdown.parse('<details>\n<summary>Show changes</summary>\n\n- A change\n</details>')
+
+  assert.match(html, /<details>/)
+  assert.match(html, /<summary>Show changes<\/summary>/)
+})


### PR DESCRIPTION
## Pull Request Type
- [x] Bugfix
- [ ] Feature Implementation
- [ ] Documentation
- [ ] Other

## Related issue

## Description
Render GitHub-style note, tip, important, warning, and caution alerts in the in-app update changelog.

Allow `<details>` and `<summary>` release-note content to remain interactive after sanitization, and use a valid block container for the rendered changelog. Alert metadata remains restricted by the sanitizer.

## Screenshots

Not included.

## Release note category
<!-- release-note-category:start -->
- [ ] Not noteworthy
- [ ] Highlights
- [ ] More improvements
- [x] Fixed bugs
<!-- release-note-category:end -->

## Release note
<!-- release-note:start -->
Fixed GitHub-style alerts and collapsible details in the in-app update changelog.
<!-- release-note:end -->

## Release note images
<!-- release-note-image:start -->

<!-- release-note-image:end -->

## Testing
- Run `pnpm run test:unit`.
- Run ESLint against the changed Vue, JavaScript, and test files.
- Run Stylelint against `src/renderer/App.css`.
- Open update release notes containing GitHub alert syntax and a `<details>` block; verify the alert is styled and the disclosure can be expanded and collapsed.

## Desktop
- **OS:** Arch Linux
- **OS Version:** Rolling release
- **OpenTubeX version:** 0.30.1

## Additional context
The updater previously rendered GitHub alert markers as plain text. Although the sanitizer allowed `details` and `summary`, the changelog used an inline `bdo` element as the container for block-level Markdown output.