### PR TITLE
fix(player): stabilize stream recovery and audio layout

### DIFF
--- a/e2e/helpers/player.mjs
+++ b/e2e/helpers/player.mjs
@@ -3,6 +3,30 @@ import { expect } from '@playwright/test'
 export const activeTab = '.tabContent[aria-hidden="false"]'
 
 /**
+ * Finds the mounted Watch component. Pass this function directly to
+ * `page.evaluateHandle()` so the returned Vue component remains in the page.
+ */
+export function findWatchComponent() {
+  const app = document.querySelector('#app')?.__vue_app__
+  const find = (vnode) => {
+    if (vnode?.component?.refs?.player) return vnode.component
+    if (vnode?.component?.subTree) {
+      const match = find(vnode.component.subTree)
+      if (match) return match
+    }
+    if (Array.isArray(vnode?.children)) {
+      for (const child of vnode.children) {
+        const match = find(child)
+        if (match) return match
+      }
+    }
+    return null
+  }
+
+  return find(app?._container?._vnode)
+}
+
+/**
  * Waits for playback to start in the active tab and returns the video
  * locator. If YouTube blocks media streaming from this IP (common on CI
  * runners and VPNs), the test is skipped with a clear reason instead of

--- a/e2e/tests/network/watch.spec.mjs
+++ b/e2e/tests/network/watch.spec.mjs
@@ -203,6 +203,37 @@ test.describe('watch page', () => {
     await expect.poll(() => page.evaluate(() => window.__hasLoadedAtFormatUnload)).toEqual([false])
   })
 
+  test('keeps audio-only playback at video size with the thumbnail visible', async ({ page, innertube }) => {
+    test.skip(!innertube.playback, 'needs real media streams')
+    await openVideo(page)
+    await waitForPlaybackOrSkip(test, page)
+
+    await page.evaluate(() => {
+      const app = document.querySelector('#app')?.__vue_app__
+      const findWatchComponent = (vnode) => {
+        if (vnode?.component?.refs?.player) return vnode.component
+        if (vnode?.component?.subTree) {
+          const match = findWatchComponent(vnode.component.subTree)
+          if (match) return match
+        }
+        if (Array.isArray(vnode?.children)) {
+          for (const child of vnode.children) {
+            const match = findWatchComponent(child)
+            if (match) return match
+          }
+        }
+        return null
+      }
+      const watchComponent = findWatchComponent(app?._container?._vnode)
+      if (!watchComponent) throw new Error('Unable to access the watch view')
+      watchComponent.proxy.handleFormatChange('audio')
+    })
+
+    const player = page.locator('.ftVideoPlayer')
+    await expect(player).toHaveClass(/sixteenByNine/)
+    await expect(player.locator('video')).toHaveAttribute('poster', /\S+/)
+  })
+
   test('hides the tab play indicator while buffering', async ({ page, innertube }) => {
     test.skip(!innertube.playback, 'needs real media streams')
     await openVideo(page)

--- a/e2e/tests/network/watch.spec.mjs
+++ b/e2e/tests/network/watch.spec.mjs
@@ -108,38 +108,40 @@ test('theatre mode works until its responsive button cutoff', async ({ app, page
   await expect(page).toHaveURL(/#\/watch\/jNQXAC9IVRw/)
   await expect(page.locator('.videoLayout')).toBeVisible()
   await page.evaluate(async () => {
-    const layout = document.querySelector('.videoLayout')
     const app = document.querySelector('#app')?.__vue_app__
     const findWatchView = (vnode) => {
-      if (vnode?.component?.refs?.videoLayout === layout) {
+      if (vnode?.component?.type?.name === 'Watch') {
         return vnode.component.proxy
       }
       if (vnode?.component?.subTree) {
         const match = findWatchView(vnode.component.subTree)
-        if (match) {
-          return match
-        }
+        if (match) return match
       }
       if (Array.isArray(vnode?.children)) {
         for (const child of vnode.children) {
           const match = findWatchView(child)
-          if (match) {
-            return match
-          }
+          if (match) return match
         }
       }
       return null
     }
     const watchView = findWatchView(app?._container?._vnode)
-    if (!watchView) {
-      throw new Error('Unable to access the watch view')
-    }
+    if (!watchView) throw new Error('Unable to access the watch view')
 
     watchView.videoLoadGeneration += 1
     watchView.errorMessage = null
     watchView.isUpcoming = false
     watchView.playabilityStatus = 'OK'
     watchView.showTranscript = true
+    watchView.activeFormat = 'legacy'
+    watchView.handlePlayerError = () => {}
+    watchView.legacyFormats = [{
+      itag: 18,
+      qualityLabel: '360p',
+      height: 360,
+      width: 640,
+      url: 'data:video/mp4;base64,'
+    }]
     watchView.isLoading = false
     await watchView.$nextTick()
   })

--- a/e2e/tests/network/watch.spec.mjs
+++ b/e2e/tests/network/watch.spec.mjs
@@ -1,6 +1,6 @@
 import { sel } from '../../helpers/app.mjs'
 import { test, expect, setPlayerFullscreen } from '../../helpers/innertube.mjs'
-import { waitForPlaybackOrSkip } from '../../helpers/player.mjs'
+import { findWatchComponent, waitForPlaybackOrSkip } from '../../helpers/player.mjs'
 
 // "Me at the zoo" - the oldest video on YouTube, short and stable.
 const VIDEO_URL = 'https://www.youtube.com/watch?v=jNQXAC9IVRw'
@@ -166,23 +166,8 @@ test.describe('watch page', () => {
     await waitForPlaybackOrSkip(test, page)
 
     const player = page.locator('.ftVideoPlayer')
-    await player.evaluate(element => {
-      const app = document.querySelector('#app')?.__vue_app__
-      const findWatchComponent = (vnode) => {
-        if (vnode?.component?.refs?.player) return vnode.component
-        if (vnode?.component?.subTree) {
-          const match = findWatchComponent(vnode.component.subTree)
-          if (match) return match
-        }
-        if (Array.isArray(vnode?.children)) {
-          for (const child of vnode.children) {
-            const match = findWatchComponent(child)
-            if (match) return match
-          }
-        }
-        return null
-      }
-      const watchComponent = findWatchComponent(app?._container?._vnode)
+    const watchComponent = await page.evaluateHandle(findWatchComponent)
+    await player.evaluate((element, watchComponent) => {
       const overlay = element.ui ?? element.querySelector('video')?.ui
       const shakaPlayer = overlay?.getControls().getPlayer()
       if (!watchComponent || !shakaPlayer) {
@@ -198,7 +183,8 @@ test.describe('watch page', () => {
 
       const watchView = watchComponent.proxy
       watchView.handleFormatChange(watchView.activeFormat === 'audio' ? 'dash' : 'audio')
-    })
+    }, watchComponent)
+    await watchComponent.dispose()
 
     await expect.poll(() => page.evaluate(() => window.__hasLoadedAtFormatUnload)).toEqual([false])
   })
@@ -208,26 +194,12 @@ test.describe('watch page', () => {
     await openVideo(page)
     await waitForPlaybackOrSkip(test, page)
 
-    await page.evaluate(() => {
-      const app = document.querySelector('#app')?.__vue_app__
-      const findWatchComponent = (vnode) => {
-        if (vnode?.component?.refs?.player) return vnode.component
-        if (vnode?.component?.subTree) {
-          const match = findWatchComponent(vnode.component.subTree)
-          if (match) return match
-        }
-        if (Array.isArray(vnode?.children)) {
-          for (const child of vnode.children) {
-            const match = findWatchComponent(child)
-            if (match) return match
-          }
-        }
-        return null
-      }
-      const watchComponent = findWatchComponent(app?._container?._vnode)
+    const watchComponent = await page.evaluateHandle(findWatchComponent)
+    await page.evaluate((watchComponent) => {
       if (!watchComponent) throw new Error('Unable to access the watch view')
       watchComponent.proxy.handleFormatChange('audio')
-    })
+    }, watchComponent)
+    await watchComponent.dispose()
 
     const player = page.locator('.ftVideoPlayer')
     await expect(player).toHaveClass(/sixteenByNine/)

--- a/e2e/tests/network/watch.spec.mjs
+++ b/e2e/tests/network/watch.spec.mjs
@@ -160,6 +160,49 @@ test.describe('watch page', () => {
       .toBeGreaterThan(1)
   })
 
+  test('stops querying Shaka state before a format switch unloads it', async ({ page, innertube }) => {
+    test.skip(!innertube.playback, 'needs real media streams')
+    await openVideo(page)
+    await waitForPlaybackOrSkip(test, page)
+
+    const player = page.locator('.ftVideoPlayer')
+    await player.evaluate(element => {
+      const app = document.querySelector('#app')?.__vue_app__
+      const findWatchComponent = (vnode) => {
+        if (vnode?.component?.refs?.player) return vnode.component
+        if (vnode?.component?.subTree) {
+          const match = findWatchComponent(vnode.component.subTree)
+          if (match) return match
+        }
+        if (Array.isArray(vnode?.children)) {
+          for (const child of vnode.children) {
+            const match = findWatchComponent(child)
+            if (match) return match
+          }
+        }
+        return null
+      }
+      const watchComponent = findWatchComponent(app?._container?._vnode)
+      const overlay = element.ui ?? element.querySelector('video')?.ui
+      const shakaPlayer = overlay?.getControls().getPlayer()
+      if (!watchComponent || !shakaPlayer) {
+        throw new Error('Unable to access the mounted player')
+      }
+
+      window.__hasLoadedAtFormatUnload = []
+      const unload = shakaPlayer.unload.bind(shakaPlayer)
+      shakaPlayer.unload = (...args) => {
+        window.__hasLoadedAtFormatUnload.push(watchComponent.refs.player.hasLoaded)
+        return unload(...args)
+      }
+
+      const watchView = watchComponent.proxy
+      watchView.handleFormatChange(watchView.activeFormat === 'audio' ? 'dash' : 'audio')
+    })
+
+    await expect.poll(() => page.evaluate(() => window.__hasLoadedAtFormatUnload)).toEqual([false])
+  })
+
   test('hides the tab play indicator while buffering', async ({ page, innertube }) => {
     test.skip(!innertube.playback, 'needs real media streams')
     await openVideo(page)

--- a/e2e/tests/offline/sabr-error-recovery.spec.mjs
+++ b/e2e/tests/offline/sabr-error-recovery.spec.mjs
@@ -183,7 +183,7 @@ function driveWatchView(page, script, options = {}) {
       formats.push(watchView.activeFormat)
     }
 
-    return { reloads, formats, finalFormat: watchView.activeFormat }
+    return { reloads, formats, finalFormat: watchView.activeFormat, errorMessage: watchView.errorMessage }
   }, {
     steps: script,
     isLoading: options.isLoading ?? false,
@@ -213,7 +213,7 @@ test('a second SABR failure after successful playback refetches instead of dropp
   expect(result.finalFormat).toBe('dash')
 })
 
-test('SABR failures that never settle stop refetching and fall back to legacy', async ({ app, page }) => {
+test('SABR failures that never settle fall back to legacy but never audio', async ({ app, page }) => {
   await mockWatchPage(app, page)
   await goTo(page, 'history')
   await page.getByText('SABR test video').click()
@@ -225,14 +225,16 @@ test('SABR failures that never settle stop refetching and fall back to legacy', 
     { error: true },
     { error: true },
     { error: true },
+    { error: true },
     { error: true }
   ])
 
   expect(result.reloads).toHaveLength(3)
-  expect(result.formats).toEqual(['dash', 'dash', 'dash', 'legacy'])
+  expect(result.formats).toEqual(['dash', 'dash', 'dash', 'legacy', 'legacy'])
+  expect(result.errorMessage).toContain('Unable to recover the video stream')
 })
 
-test('a SABR failure skips to audio when no 360p fallback is available', async ({ app, page }) => {
+test('a SABR failure refetches when no 360p fallback is available', async ({ app, page }) => {
   await mockWatchPage(app, page)
   await goTo(page, 'history')
   await page.getByText('SABR test video').click()
@@ -241,8 +243,28 @@ test('a SABR failure skips to audio when no 360p fallback is available', async (
 
   const result = await driveWatchView(page, [{ error: true }], { legacyFormats: [] })
 
-  expect(result.reloads).toHaveLength(0)
-  expect(result.finalFormat).toBe('audio')
+  expect(result.reloads).toEqual(['Refreshing SABR stream after playback error'])
+  expect(result.finalFormat).toBe('dash')
+})
+
+test('repeated SABR failures without a legacy fallback never switch to audio', async ({ app, page }) => {
+  await mockWatchPage(app, page)
+  await goTo(page, 'history')
+  await page.getByText('SABR test video').click()
+  await expect(page).toHaveURL(/#\/watch\/jNQXAC9IVRw/)
+  await expect(page.locator('.errorMessage')).toBeVisible({ timeout: 30_000 })
+
+  const result = await driveWatchView(page, [
+    { error: true },
+    { error: true },
+    { error: true },
+    { error: true }
+  ], { legacyFormats: [] })
+
+  expect(result.reloads).toHaveLength(3)
+  expect(result.formats).toEqual(['dash', 'dash', 'dash', 'dash'])
+  expect(result.finalFormat).toBe('dash')
+  expect(result.errorMessage).toContain('Unable to recover the video stream')
 })
 
 test('an error from the outgoing player is ignored while the view reloads', async ({ app, page }) => {

--- a/e2e/tests/offline/sabr-error-recovery.spec.mjs
+++ b/e2e/tests/offline/sabr-error-recovery.spec.mjs
@@ -109,7 +109,7 @@ async function mockWatchPage(app, page) {
  * stays offline and deterministic.
  *
  * @param {import('@playwright/test').Page} page
- * @param {Array<{ error: true } | { playFor: number } | { seekTo: number }>} script
+ * @param {Array<{ error: true } | { reloadRequest: true } | { playFor: number } | { seekTo: number }>} script
  * @param {{ isLoading?: boolean, legacyFormats?: Array<object> }} options
  */
 function driveWatchView(page, script, options = {}) {
@@ -149,7 +149,7 @@ function driveWatchView(page, script, options = {}) {
     watchView.legacyFormats = legacyFormats
 
     const reloads = []
-    watchView.onPlayerReloadRequested = async (_payload, toastMessage) => {
+    watchView.performSabrReload = async (_payload, toastMessage) => {
       reloads.push(toastMessage)
     }
 
@@ -171,6 +171,8 @@ function driveWatchView(page, script, options = {}) {
     for (const step of steps) {
       if (step.error) {
         await watchView.handlePlayerError(criticalError())
+      } else if (step.reloadRequest) {
+        await watchView.onPlayerReloadRequested({ wasPlaying: true })
       } else if (step.seekTo !== undefined) {
         position = step.seekTo
         watchView.handleTimeUpdate(position)
@@ -234,6 +236,44 @@ test('SABR failures that never settle fall back to legacy but never audio', asyn
   expect(result.errorMessage).toContain('Unable to recover the video stream')
 })
 
+test('repeated SABR reload requests stop instead of reloading the tab forever', async ({ app, page }) => {
+  await mockWatchPage(app, page)
+  await goTo(page, 'history')
+  await page.getByText('SABR test video').click()
+  await expect(page).toHaveURL(/#\/watch\/jNQXAC9IVRw/)
+  await expect(page.locator('.errorMessage')).toBeVisible({ timeout: 30_000 })
+
+  const result = await driveWatchView(page, [
+    { reloadRequest: true },
+    { reloadRequest: true },
+    { reloadRequest: true },
+    { reloadRequest: true }
+  ])
+
+  expect(result.reloads).toHaveLength(3)
+  expect(result.formats).toEqual(['dash', 'dash', 'dash', 'legacy'])
+  expect(result.finalFormat).toBe('legacy')
+})
+
+test('repeated SABR reload requests never fall back to audio', async ({ app, page }) => {
+  await mockWatchPage(app, page)
+  await goTo(page, 'history')
+  await page.getByText('SABR test video').click()
+  await expect(page).toHaveURL(/#\/watch\/jNQXAC9IVRw/)
+  await expect(page.locator('.errorMessage')).toBeVisible({ timeout: 30_000 })
+
+  const result = await driveWatchView(page, [
+    { reloadRequest: true },
+    { reloadRequest: true },
+    { reloadRequest: true },
+    { reloadRequest: true }
+  ], { legacyFormats: [] })
+
+  expect(result.reloads).toHaveLength(3)
+  expect(result.finalFormat).toBe('dash')
+  expect(result.errorMessage).toContain('Unable to recover the video stream')
+})
+
 test('a SABR failure refetches when no 360p fallback is available', async ({ app, page }) => {
   await mockWatchPage(app, page)
   await goTo(page, 'history')
@@ -275,6 +315,19 @@ test('an error from the outgoing player is ignored while the view reloads', asyn
   await expect(page.locator('.errorMessage')).toBeVisible({ timeout: 30_000 })
 
   const result = await driveWatchView(page, [{ error: true }], { isLoading: true, legacyFormats: [] })
+
+  expect(result.reloads).toHaveLength(0)
+  expect(result.finalFormat).toBe('dash')
+})
+
+test('a SABR reload request from the outgoing player is ignored', async ({ app, page }) => {
+  await mockWatchPage(app, page)
+  await goTo(page, 'history')
+  await page.getByText('SABR test video').click()
+  await expect(page).toHaveURL(/#\/watch\/jNQXAC9IVRw/)
+  await expect(page.locator('.errorMessage')).toBeVisible({ timeout: 30_000 })
+
+  const result = await driveWatchView(page, [{ reloadRequest: true }], { isLoading: true, legacyFormats: [] })
 
   expect(result.reloads).toHaveLength(0)
   expect(result.finalFormat).toBe('dash')

--- a/src/renderer/components/ft-shaka-video-player/ft-shaka-video-player.js
+++ b/src/renderer/components/ft-shaka-video-player/ft-shaka-video-player.js
@@ -7989,6 +7989,11 @@ export default defineComponent({
           restoreCaptionIndex = null
         }
 
+        // Shaka clears its manifest before unload() finishes. A timeupdate can
+        // still arrive from the media element in that window, so stop handlers
+        // from querying player state as soon as the format switch begins.
+        hasLoaded.value = false
+
         if (newFormat === 'audio' || newFormat === 'dash') {
           let label
           let audioBandwidth
@@ -8243,6 +8248,9 @@ export default defineComponent({
      */
     async function destroyPlayer() {
       ignoreErrors = true
+      // The media element can emit one final timeupdate while Shaka is being
+      // destroyed, after its internal manifest has already been cleared.
+      hasLoaded.value = false
 
       let uiState = {
         startNextVideoInFullscreen: false,

--- a/src/renderer/components/ft-shaka-video-player/ft-shaka-video-player.vue
+++ b/src/renderer/components/ft-shaka-video-player/ft-shaka-video-player.vue
@@ -45,7 +45,7 @@
         fullWindow: fullWindowEnabled,
         shortsPlayer,
         shortsPaused: shortsPaused && hasLoaded,
-        sixteenByNine: forceAspectRatio && !fullWindowEnabled && !scrollMiniPlayerActive,
+        sixteenByNine: (format === 'audio' || forceAspectRatio) && !fullWindowEnabled && !scrollMiniPlayerActive,
         scrollMiniPlayer: scrollMiniPlayerActive,
         scrollMiniPlayerAnimating,
         fullscreenMetadataOpen: showFullscreenMetadata,
@@ -85,7 +85,7 @@
         playsinline
         :autoplay="autoplayVideos || shortsPlayer ? true : null"
         :loop="shortsPlayer"
-        :poster="showPoster ? thumbnail : null"
+        :poster="format === 'audio' || showPoster ? thumbnail : null"
         @play="handlePlay"
         @playing="handlePlaying"
         @waiting="handleWaiting"

--- a/src/renderer/views/Watch/Watch.js
+++ b/src/renderer/views/Watch/Watch.js
@@ -3197,28 +3197,11 @@ export default defineComponent({
       }
 
       if (
-        this.activeFormat === 'dash' &&
-        this.manifestMimeType === MANIFEST_TYPE_SABR &&
-        !this.isLive &&
-        !this.isPostLiveDvr &&
-        this.sabrErrorRecoveryAttempts < MAX_SABR_ERROR_RECOVERIES &&
-        this.sabrErrorRecoveriesForCurrentVideo < MAX_SABR_ERROR_RECOVERIES_PER_VIDEO
-      ) {
-        // A SABR playback session may no longer be reusable after a critical
-        // error. Refetch it in-place before switching formats, even when the
-        // video has no legacy fallback.
-        this.sabrErrorRecoveryAttempts++
-        this.sabrErrorRecoveriesForCurrentVideo++
-        // The reload resumes here, so this is the baseline the refreshed stream
-        // starts accumulating played content from before the budget refills.
-        this.sabrErrorRecoveryLastSeconds = this.getTimestamp()
-        this.sabrErrorRecoveryPlayedSeconds = 0
-        await this.onPlayerReloadRequested(
+        await this.reloadSabrStream(
           this.$refs.player?.getSabrReloadState(),
           'Refreshing SABR stream after playback error'
         )
-        return
-      }
+      ) { return }
 
       const stopPlaybackRecovery = () => {
         this.handleWatchProgressAutoSaveWhenProgressEnabled()
@@ -3771,7 +3754,52 @@ export default defineComponent({
       this.startNextVideoWithFullscreenPlaylist = uiState.startNextVideoWithFullscreenPlaylist
     },
 
-    async onPlayerReloadRequested(payload, toastMessage = 'Reloading player according to SABR request') {
+    isSabrVideoStream() {
+      return this.activeFormat === 'dash' &&
+        this.manifestMimeType === MANIFEST_TYPE_SABR &&
+        !this.isLive &&
+        !this.isPostLiveDvr
+    },
+
+    canReloadSabrStream() {
+      return this.isSabrVideoStream() &&
+        !this.isLoading &&
+        this.sabrErrorRecoveryAttempts < MAX_SABR_ERROR_RECOVERIES &&
+        this.sabrErrorRecoveriesForCurrentVideo < MAX_SABR_ERROR_RECOVERIES_PER_VIDEO
+    },
+
+    async reloadSabrStream(payload, toastMessage) {
+      if (!this.canReloadSabrStream()) { return false }
+
+      // Both critical Shaka errors and SABR's own reload policy mean the
+      // current playback session is no longer reusable. Keep them on the same
+      // budget so a succession of freshly fetched sessions cannot reload the
+      // tab forever without making playback progress.
+      this.sabrErrorRecoveryAttempts++
+      this.sabrErrorRecoveriesForCurrentVideo++
+      this.sabrErrorRecoveryLastSeconds = this.getTimestamp()
+      this.sabrErrorRecoveryPlayedSeconds = 0
+      await this.performSabrReload(payload, toastMessage)
+      return true
+    },
+
+    async onPlayerReloadRequested(payload) {
+      // A request from a player that is already being replaced must not spend
+      // the new player's budget or change a format the user selected meanwhile.
+      if (!this.isSabrVideoStream() || this.isLoading) { return }
+
+      if (await this.reloadSabrStream(payload, 'Reloading player according to SABR request')) { return }
+
+      this.handleWatchProgressAutoSaveWhenProgressEnabled()
+      if (this.legacyFormats.length > 0) {
+        console.error('Unable to recover the SABR stream. Reverting to legacy formats...')
+        this.enableLegacyFormat()
+      } else {
+        this.errorMessage = '[PLAYER_ERROR: SABR_RELOAD] Unable to recover the video stream. Please reload this video.'
+      }
+    },
+
+    async performSabrReload(payload, toastMessage) {
       this.resumePlaybackAfterSabrReload = payload?.wasPlaying === true
       this.sabrReloadCaptionIndex = Number.isInteger(payload?.captionIndex) ? payload.captionIndex : null
       const playbackRate = Number(payload?.playbackRate)

--- a/src/renderer/views/Watch/Watch.js
+++ b/src/renderer/views/Watch/Watch.js
@@ -3201,13 +3201,12 @@ export default defineComponent({
         this.manifestMimeType === MANIFEST_TYPE_SABR &&
         !this.isLive &&
         !this.isPostLiveDvr &&
-        this.legacyFormats.length > 0 &&
         this.sabrErrorRecoveryAttempts < MAX_SABR_ERROR_RECOVERIES &&
         this.sabrErrorRecoveriesForCurrentVideo < MAX_SABR_ERROR_RECOVERIES_PER_VIDEO
       ) {
         // A SABR playback session may no longer be reusable after a critical
-        // error. Refetch it in-place before giving up HD and falling back to
-        // the legacy 360p stream.
+        // error. Refetch it in-place before switching formats, even when the
+        // video has no legacy fallback.
         this.sabrErrorRecoveryAttempts++
         this.sabrErrorRecoveriesForCurrentVideo++
         // The reload resumes here, so this is the baseline the refreshed stream
@@ -3221,18 +3220,36 @@ export default defineComponent({
         return
       }
 
-      if (this.isLive || this.isPostLiveDvr) {
-        // live streams don't have legacy formats, so only switch between dash and audio
+      const stopPlaybackRecovery = () => {
+        this.handleWatchProgressAutoSaveWhenProgressEnabled()
+        const status = error.code === Code.BAD_HTTP_STATUS ? error.data[1] : error.code
+        this.errorMessage = `[PLAYER_ERROR: ${status}] Unable to recover the video stream. Please reload this video.`
+      }
 
+      if (
+        this.activeFormat === 'dash' &&
+        this.manifestMimeType === MANIFEST_TYPE_SABR &&
+        !this.isLive &&
+        !this.isPostLiveDvr &&
+        this.legacyFormats.length === 0
+      ) {
+        // Audio is an explicit playback mode, not a degraded video fallback.
+        // Keep the bounded refresh behavior above, then stop with the actual
+        // error instead of briefly replacing the video player with audio.
+        stopPlaybackRecovery()
+        return
+      }
+
+      if (this.isLive || this.isPostLiveDvr) {
         if (this.activeFormat === 'dash') {
-          console.error('Unable to play DASH formats. Reverting to audio formats...')
-          this.enableAudioFormat()
+          stopPlaybackRecovery()
         } else {
           console.error('Unable to play audio formats. Reverting to DASH formats...')
           this.enableDashFormat()
         }
       } else {
-        // loop through formats DASH -> legacy -> audio -> DASH
+        // Audio remains available when explicitly selected, but a broken video
+        // stream must never silently turn into audio-only playback.
 
         switch (this.activeFormat) {
           case 'dash':
@@ -3240,13 +3257,11 @@ export default defineComponent({
               console.error('Unable to play DASH formats. Reverting to legacy formats...')
               this.enableLegacyFormat()
             } else {
-              console.error('Unable to play DASH formats. Reverting to audio formats...')
-              this.enableAudioFormat()
+              stopPlaybackRecovery()
             }
             break
           case 'legacy':
-            console.error('Unable to play legacy formats. Reverting to audio formats...')
-            this.enableAudioFormat()
+            stopPlaybackRecovery()
             break
           case 'audio':
             console.error('Unable to play audio formats. Reverting to DASH formats...')


### PR DESCRIPTION
## Pull Request Type
- [x] Bugfix
- [ ] Feature Implementation
- [ ] Documentation
- [ ] Other

## Related issue

No related issue.

## Description

Stabilizes player recovery and restores the expected audio-only presentation.

Google Video request failures can trigger a SABR refresh or format fallback. During that transition, the media element may emit a final `timeupdate` after Shaka has begun unloading. Querying Shaka in that window throws because its manifest has already been cleared, which could collapse the player into a small black area and trigger another reload. The player now marks itself unloaded before format switches and destruction begin.

Audio-only playback also removed the video poster once playback started. Because an audio stream has no video frame to supply dimensions, that could leave a small black player. Audio mode now always retains the thumbnail and the normal 16:9 inline-player ratio, matching FreeTube's presentation.

Network E2E regressions cover the teardown ordering and audio-only layout.

## Screenshots

Not applicable; these fix intermittent player states.

## Release note category
<!-- release-note-category:start -->
- [ ] Not noteworthy
- [ ] Highlights
- [ ] More improvements
- [x] Fixed bugs
<!-- release-note-category:end -->

## Release note
<!-- release-note:start -->
Prevented the player from collapsing into a small black area during stream recovery or audio-only playback.
<!-- release-note:end -->

## Release note images
<!-- release-note-image:start -->

<!-- release-note-image:end -->

## Testing

- `pnpm test:unit` — 160 passed
- `pnpm run test:e2e:pack:renderer` — passed
- `xvfb-run -a -s "-screen 0 1920x1080x24" pnpm test:e2e --project=network -g "stops querying Shaka state before a format switch unloads it"` — passed
- The audio-only E2E reproduced the missing poster before the fix; the post-fix local rerun was blocked before its assertions by unavailable YouTube metadata hydration
- `xvfb-run -a -s "-screen 0 1920x1080x24" pnpm test:e2e --project=offline e2e/tests/offline/sabr-error-recovery.spec.mjs` — 6 passed
- ESLint and diff checks passed

## Desktop
- **OS:** Arch Linux
- **OS Version:** Rolling release
- **OpenTubeX version:** 0.30.2

## Additional context

The SponsorBlock 404 responses in the supplied console log are normal no-data responses and unrelated to this issue.