### PR TITLE
Fix custom playlist removal reordering

### DIFF
--- a/e2e/tests/offline/playlists.spec.mjs
+++ b/e2e/tests/offline/playlists.spec.mjs
@@ -144,3 +144,55 @@ test.describe('seeded playlists', () => {
     await expect(page.getByTitle('Quick Bookmark Enabled').locator('[data-icon="clock"]')).toBeVisible()
   })
 })
+
+test.describe('custom playlist order', () => {
+  test.use({
+    seed: {
+      settings: {
+        listType: 'grid',
+        userPlaylistSortOrder: 'custom'
+      },
+      playlists: [
+        {
+          _id: 'large-custom-playlist',
+          playlistName: 'Large custom playlist',
+          protected: false,
+          description: '',
+          videos: Array.from({ length: 101 }, (_, index) => ({
+            videoId: String(index).padStart(11, '0'),
+            title: `Custom playlist video ${index + 1}`,
+            author: 'Test Channel',
+            authorId: 'UC-test-channel-id',
+            lengthSeconds: 120,
+            published: Date.now() - 86_400_000,
+            timeAdded: Date.now() - index,
+            playlistItemId: `custom-playlist-item-${index}`,
+            type: 'video'
+          })),
+          createdAt: Date.now() - 86_400_000,
+          lastUpdatedAt: Date.now()
+        }
+      ]
+    }
+  })
+
+  test('keeps the grid grab bars in place during the removal undo period', async ({ page }) => {
+    await goTo(page, 'userplaylists')
+    await page.getByText('Large custom playlist').click()
+
+    const secondVideo = page.locator('.ft-list-video').filter({
+      has: page.getByText('Custom playlist video 2', { exact: true })
+    })
+    await expect(secondVideo.locator('.grabBar')).toBeVisible()
+    await secondVideo.getByTitle('Remove from Playlist').click()
+
+    await expect(secondVideo).toHaveCount(0)
+    await expect(page.locator('.playlistItemsCard .grid.draggable .grabBar').first()).toBeVisible()
+
+    const thirdVideo = page.locator('.ft-list-video').filter({
+      has: page.getByText('Custom playlist video 3', { exact: true })
+    })
+    await thirdVideo.getByTitle('Move Video Up').click()
+    await expect(page.locator('.playlistItemsCard .h3Title').first()).toHaveText('Custom playlist video 3')
+  })
+})

--- a/src/renderer/components/FtElementList/FtElementList.vue
+++ b/src/renderer/components/FtElementList/FtElementList.vue
@@ -28,8 +28,8 @@
       :playlist-type="playlistType"
       :playlist-item-id="result.playlistItemId"
       :dragged-video="draggedVideo"
-      :is-sort-order-custom="isSortOrderCustom"
       :is-video-dragging="isVideoDragging"
+      :video-dragging-possible="videoDraggingPossible"
       @drag-video="dragVideo"
       @move-dragged-video="moveDraggedVideo"
       @drag-video-end="afterDrag"
@@ -137,11 +137,11 @@ const props = defineProps({
     type: Object,
     default: () => ({ videoId: null, playlistItemId: null }),
   },
-  isSortOrderCustom: {
+  isVideoDragging: {
     type: Boolean,
     default: false,
   },
-  isVideoDragging: {
+  videoDraggingPossible: {
     type: Boolean,
     default: false,
   },

--- a/src/renderer/components/FtListLazyWrapper/FtListLazyWrapper.vue
+++ b/src/renderer/components/FtListLazyWrapper/FtListLazyWrapper.vue
@@ -31,7 +31,8 @@
         :can-move-video-down="canMoveVideoDown"
         :can-remove-from-playlist="canRemoveFromPlaylist"
         :force-list-type="layout"
-        :show-grab-bar="isDraggable && layout === 'grid'"
+        :show-grab-bar="showGrabBar && layout === 'grid'"
+        :grab-bar-enabled="isDraggable && layout === 'grid'"
         @move-video-up="moveVideoUp"
         @move-video-down="moveVideoDown"
         @move-video-to-the-top="moveVideoToTheTop"
@@ -160,11 +161,11 @@ const props = defineProps({
     type: Object,
     default: () => ({ videoId: null, playlistItemId: null }),
   },
-  isSortOrderCustom: {
+  isVideoDragging: {
     type: Boolean,
     default: false,
   },
-  isVideoDragging: {
+  videoDraggingPossible: {
     type: Boolean,
     default: false,
   },
@@ -182,7 +183,8 @@ const emit = defineEmits([
 ])
 
 const inUserPlaylist = props.playlistType === 'user'
-const isDraggable = computed(() => inUserPlaylist && props.isSortOrderCustom && (props.canMoveVideoUp || props.canMoveVideoDown))
+const showGrabBar = computed(() => inUserPlaylist && props.videoDraggingPossible)
+const isDraggable = computed(() => showGrabBar.value && (props.canMoveVideoUp || props.canMoveVideoDown))
 const { dragVideo, moveDraggedVideo, afterDrag } = handleDragAndDrop(emit)
 const draggableEventHandlers = {
   dragstart: onDragVideo,

--- a/src/renderer/components/FtListVideo/FtListVideo.scss
+++ b/src/renderer/components/FtListVideo/FtListVideo.scss
@@ -14,6 +14,11 @@
   padding-block: 1em;
 }
 
+.grabBar.grabBarDisabled {
+  cursor: not-allowed;
+  opacity: 0.3;
+}
+
 .draggable:not(.draggable:only-child):focus .grabBar,
 .draggable:not(.draggable:only-child):hover .grabBar {
   display: revert;

--- a/src/renderer/components/FtListVideo/FtListVideo.vue
+++ b/src/renderer/components/FtListVideo/FtListVideo.vue
@@ -11,6 +11,9 @@
     <div
       v-if="showGrabBar"
       class="grabBar"
+      :class="{
+        grabBarDisabled: !grabBarEnabled,
+      }"
     >
       <FontAwesomeIcon
         :icon="['fas', 'bars']"
@@ -439,6 +442,10 @@ const props = defineProps({
     default: false,
   },
   showGrabBar: {
+    type: Boolean,
+    default: false,
+  },
+  grabBarEnabled: {
     type: Boolean,
     default: false,
   },

--- a/src/renderer/store/modules/playlists.js
+++ b/src/renderer/store/modules/playlists.js
@@ -501,19 +501,15 @@ const actions = {
   },
 
   async removeVideos({ commit }, payload) {
-    try {
-      const { _id, playlistItemIds } = payload
+    const { _id, playlistItemIds } = payload
 
-      const lastUpdatedAt = Date.now()
+    const lastUpdatedAt = Date.now()
 
-      await DBPlaylistHandlers.deleteVideoIdsByPlaylistId(_id, lastUpdatedAt, playlistItemIds)
+    await DBPlaylistHandlers.deleteVideoIdsByPlaylistId(_id, lastUpdatedAt, playlistItemIds)
 
-      payload.lastUpdatedAt = lastUpdatedAt
+    payload.lastUpdatedAt = lastUpdatedAt
 
-      commit('removeVideos', payload)
-    } catch (errMessage) {
-      console.error(errMessage)
-    }
+    commit('removeVideos', payload)
   },
 }
 

--- a/src/renderer/views/Playlist/Playlist.vue
+++ b/src/renderer/views/Playlist/Playlist.vue
@@ -726,7 +726,8 @@ const canMoveVideos = computed(() => {
 })
 
 const videoDraggingPossible = computed(() => {
-  return isUserPlaylistRequested.value && isSortOrderCustom.value && shownPlaylistItems.value.length >= 2
+  return isUserPlaylistRequested.value && !playlistInVideoSearchMode.value && isSortOrderCustom.value &&
+    !pendingDeletionRemovalInProgress.value && shownPlaylistItems.value.length >= 2
 })
 
 /**
@@ -1047,12 +1048,17 @@ async function removeToBeDeletedVideosSometimes() {
         // Create a new non-reactive array to avoid Electron erroring about Proxy objects not being clonable
         playlistItemIds: [...toBeDeletedPlaylistItemIds.value],
       })
-
+    } catch (e) {
+      showToast({
+        message: t('User Playlists.SinglePlaylistView.Toast.There was a problem with removing this video'),
+        icon: ['fas', 'circle-exclamation'],
+      })
+      console.error(e)
+    } finally {
+      pendingDeletionRemovalInProgress.value = false
       toBeDeletedPlaylistItemIds.value = []
       undoToastAbortController?.abort()
       undoToastAbortController = null
-    } finally {
-      pendingDeletionRemovalInProgress.value = false
     }
   }
 }

--- a/src/renderer/views/Playlist/Playlist.vue
+++ b/src/renderer/views/Playlist/Playlist.vue
@@ -89,8 +89,8 @@
             :playlist-items-length="shownPlaylistItems.length"
             :can-remove-from-playlist="true"
             :dragged-video="draggedVideo"
-            :is-sort-order-custom="isSortOrderCustom"
             :is-video-dragging="isVideoDragging"
+            :video-dragging-possible="videoDraggingPossible"
             @drag-video="setDraggedVideo"
             @drag-video-end="onDragVideoEnd"
             @move-dragged-video="moveDraggedVideoTemporarilyThrottled"
@@ -254,8 +254,10 @@ const videoSearchQuery = ref('')
 const promptOpen = ref(false)
 /** @type {import('vue').Ref<string[]>} */
 const toBeDeletedPlaylistItemIds = ref([])
+const pendingDeletionRemovalInProgress = ref(false)
 /** @type {AbortController | null} */
 let undoToastAbortController = null
+let removePendingVideosAfterDrag = false
 
 /** @type {import('vue').ComputedRef<'local' | 'invidious'>} */
 const backendPreference = computed(() => store.getters.getBackendPreference)
@@ -720,7 +722,11 @@ async function getNextPageLocal() {
 }
 
 const canMoveVideos = computed(() => {
-  return !playlistInVideoSearchMode.value && isSortOrderCustom.value && noPlaylistItemsPendingDeletion.value
+  return isUserPlaylistRequested.value && !playlistInVideoSearchMode.value && isSortOrderCustom.value && !pendingDeletionRemovalInProgress.value
+})
+
+const videoDraggingPossible = computed(() => {
+  return isUserPlaylistRequested.value && isSortOrderCustom.value && shownPlaylistItems.value.length >= 2
 })
 
 /**
@@ -729,16 +735,15 @@ const canMoveVideos = computed(() => {
  */
 function moveVideoUp(videoId, playlistItemId) {
   const playlistItems_ = playlistItems.value.slice()
-
-  const index = playlistItems_.findIndex((video) => {
+  const shownIndex = shownPlaylistItems.value.findIndex((video) => {
     return video.videoId === videoId && video.playlistItemId === playlistItemId
   })
 
-  if (index === -1) {
+  if (shownIndex === -1) {
     return
   }
 
-  if (index === 0) {
+  if (shownIndex === 0) {
     showToast({
       message: t('User Playlists.SinglePlaylistView.Toast["This video cannot be moved up."]'),
       icon: ['fas', 'circle-exclamation'],
@@ -746,7 +751,13 @@ function moveVideoUp(videoId, playlistItemId) {
     return
   }
 
-  [playlistItems_[index], playlistItems_[index - 1]] = [playlistItems_[index - 1], playlistItems_[index]]
+  const previousPlaylistItemId = shownPlaylistItems.value[shownIndex - 1].playlistItemId
+  const index = playlistItems_.findIndex(video => video.playlistItemId === playlistItemId)
+  const previousIndex = playlistItems_.findIndex(video => video.playlistItemId === previousPlaylistItemId)
+  const video = playlistItems_[index]
+
+  playlistItems_[index] = playlistItems_[previousIndex]
+  playlistItems_[previousIndex] = video
 
   const playlist = {
     playlistName: playlistTitle.value,
@@ -774,16 +785,15 @@ function moveVideoUp(videoId, playlistItemId) {
  */
 function moveVideoDown(videoId, playlistItemId) {
   const playlistItems_ = playlistItems.value.slice()
-
-  const index = playlistItems_.findIndex((video) => {
+  const shownIndex = shownPlaylistItems.value.findIndex((video) => {
     return video.videoId === videoId && video.playlistItemId === playlistItemId
   })
 
-  if (index === -1) {
+  if (shownIndex === -1) {
     return
   }
 
-  if (index + 1 >= playlistItems_.length) {
+  if (shownIndex + 1 >= shownPlaylistItems.value.length) {
     showToast({
       message: t('User Playlists.SinglePlaylistView.Toast["This video cannot be moved down."]'),
       icon: ['fas', 'circle-exclamation'],
@@ -791,7 +801,13 @@ function moveVideoDown(videoId, playlistItemId) {
     return
   }
 
-  [playlistItems_[index], playlistItems_[index + 1]] = [playlistItems_[index + 1], playlistItems_[index]]
+  const nextPlaylistItemId = shownPlaylistItems.value[shownIndex + 1].playlistItemId
+  const index = playlistItems_.findIndex(video => video.playlistItemId === playlistItemId)
+  const nextIndex = playlistItems_.findIndex(video => video.playlistItemId === nextPlaylistItemId)
+  const video = playlistItems_[index]
+
+  playlistItems_[index] = playlistItems_[nextIndex]
+  playlistItems_[nextIndex] = video
 
   const playlist = {
     playlistName: playlistTitle.value,
@@ -902,7 +918,7 @@ function setDraggedVideo(video) {
   draggedVideo.value = video
 }
 
-function onDragVideoEnd() {
+async function onDragVideoEnd() {
   if (tempShownPlaylistItems.value != null) {
     // Save on drag end ONLY
     const playlist = {
@@ -915,7 +931,7 @@ function onDragVideoEnd() {
     }
 
     try {
-      store.dispatch('updatePlaylist', playlist)
+      await store.dispatch('updatePlaylist', playlist)
       playlistItems.value = tempShownPlaylistItems.value
     } catch (e) {
       showToast({
@@ -934,6 +950,11 @@ function onDragVideoEnd() {
     videoId: null,
     playlistItemId: null,
   })
+
+  if (removePendingVideosAfterDrag) {
+    removePendingVideosAfterDrag = false
+    await removeToBeDeletedVideosSometimes()
+  }
 }
 
 /** @type {import('vue').ComputedRef<boolean>} */
@@ -1012,17 +1033,27 @@ function removeVideoFromPlaylist(videoId, playlistItemId) {
 
 async function removeToBeDeletedVideosSometimes() {
   if (isLoading.value) { return }
+  if (isVideoDragging.value) {
+    removePendingVideosAfterDrag = true
+    return
+  }
 
   if (toBeDeletedPlaylistItemIds.value.length > 0) {
-    await store.dispatch('removeVideos', {
-      _id: playlistId.value,
-      // Create a new non-reactive array to avoid Electron erroring about Proxy objects not being clonable
-      playlistItemIds: [...toBeDeletedPlaylistItemIds.value],
-    })
+    pendingDeletionRemovalInProgress.value = true
 
-    toBeDeletedPlaylistItemIds.value = []
-    undoToastAbortController?.abort()
-    undoToastAbortController = null
+    try {
+      await store.dispatch('removeVideos', {
+        _id: playlistId.value,
+        // Create a new non-reactive array to avoid Electron erroring about Proxy objects not being clonable
+        playlistItemIds: [...toBeDeletedPlaylistItemIds.value],
+      })
+
+      toBeDeletedPlaylistItemIds.value = []
+      undoToastAbortController?.abort()
+      undoToastAbortController = null
+    } finally {
+      pendingDeletionRemovalInProgress.value = false
+    }
   }
 }
 


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Make sure to follow the contributing guidelines. -->
<!-- Important note, we may remove your pull request if you do not use this provided PR template correctly. -->

## Pull Request Type
<!-- Please select what type of pull request this is: [x] -->
- [x] Bugfix
- [ ] Feature Implementation
- [ ] Documentation
- [ ] Other

## Related issue
<!-- Please link the issue your pull request is referring to. -->
<!-- If this pull request fully resolves the relevant issue, put "closes" before the issue number. -->
<!-- Example: "closes #123456". -->

Closes #461

## Description
<!-- Please write a clear and concise description of what the pull request does. -->

Keeps custom-order playlist controls stable and responsive while a removed video is still within its undo period.

Previously, every playlist item lost its draggable area for five seconds because reordering was disabled until the pending deletion was committed. The grab bars now remain in place, reordering stays available during the undo window, move-up/down actions skip hidden pending items, and final deletion waits for an active drag to finish.

## Screenshots <!-- If appropriate -->
<!-- Please add before and after screenshots if there is a visible change. -->

Not applicable.

## Release note category
<!-- Select exactly one category. Every pull request must select one. -->
<!-- release-note-category:start -->
- [ ] Not noteworthy
- [ ] Highlights
- [ ] More improvements
- [x] Fixed bugs
<!-- release-note-category:end -->

## Release note
<!-- Required unless "Not noteworthy" is selected. -->
<!-- Write one concise, user-facing entry without a leading bullet. -->
<!-- release-note:start -->
Keep custom playlist ordering responsive while videos are pending removal.
<!-- release-note:end -->

## Release note images
<!-- Optional. Paste one or more Markdown images or HTML image tags here. -->
<!-- The release notes will use an HTML image tag and limit images taller than 300 pixels. -->
<!-- release-note-image:start -->

<!-- release-note-image:end -->

## Testing
<!-- How can reviewers verify that the PR produces correct results? -->
<!-- Please provide instructions so that others can ensure that your pull request would produce correct results. For examples see, https://github.com/FreeTubeApp/FreeTube/pull/5743, https://github.com/FreeTubeApp/FreeTube/pull/7349, https://github.com/FreeTubeApp/FreeTube/pull/5125, https://github.com/FreeTubeApp/FreeTube/pull/7338 -->

Automated:
- `xvfb-run -a -s "-screen 0 1920x1080x24" pnpm exec playwright test -c e2e/playwright.config.mjs --project=offline e2e/tests/offline/playlists.spec.mjs --workers=1` (6 passed)
- `pnpm test:unit` (162 passed)
- ESLint and Stylelint checks passed.

Manual verification:
1. Open a user playlist with more than 100 videos in grid view.
2. Select the Custom sort order.
3. Remove a video and leave the undo toast open.
4. Confirm grab bars stay in place and videos can be reordered immediately.
5. Confirm undo still restores the video, or allow the timeout to remove it permanently.

## Desktop
<!-- Please complete the following information-->
- **OS:** Arch Linux
- **OS Version:** Rolling release
- **OpenTubeX version:** development

## Additional context
<!-- Add any other context about the pull request here. -->

The five-second undo period remains unchanged; it no longer blocks playlist ordering.