### PR TITLE
fix(transcript): search across caption segments

### DIFF
--- a/src/renderer/components/WatchVideoTranscript/WatchVideoTranscript.vue
+++ b/src/renderer/components/WatchVideoTranscript/WatchVideoTranscript.vue
@@ -168,6 +168,7 @@ import FtInput from '../FtInput/FtInput.vue'
 import FtLoader from '../FtLoader/FtLoader.vue'
 import FtSelect from '../FtSelect/FtSelect.vue'
 import { getTranscriptPreScrollTop } from './transcriptScroll.js'
+import { filterTranscriptSegments } from './transcriptSearch.js'
 
 import {
   copyToClipboard,
@@ -217,11 +218,7 @@ let hasAlignedActiveSegment = false
 
 const normalizedSearchQuery = computed(() => searchQuery.value.trim().toLocaleLowerCase())
 const filteredSegments = computed(() => {
-  if (normalizedSearchQuery.value === '') {
-    return segments.value
-  }
-
-  return segments.value.filter(segment => segment.text.toLocaleLowerCase().includes(normalizedSearchQuery.value))
+  return filterTranscriptSegments(segments.value, normalizedSearchQuery.value)
 })
 const activeSegmentIndex = computed(() => {
   return segments.value.findLastIndex(segment => (

--- a/src/renderer/components/WatchVideoTranscript/transcriptSearch.js
+++ b/src/renderer/components/WatchVideoTranscript/transcriptSearch.js
@@ -1,0 +1,43 @@
+function normalizeSearchText(text) {
+  return text.trim().replaceAll(/\s+/g, ' ').toLocaleLowerCase()
+}
+
+export function filterTranscriptSegments(segments, query) {
+  const normalizedQuery = normalizeSearchText(query)
+  if (normalizedQuery === '') {
+    return segments
+  }
+
+  const ranges = []
+  let transcript = ''
+
+  for (const [index, segment] of segments.entries()) {
+    if (index > 0) {
+      transcript += ' '
+    }
+
+    const start = transcript.length
+    transcript += normalizeSearchText(segment.text)
+    ranges.push({ start, end: transcript.length })
+  }
+
+  const matches = []
+  let matchStart = transcript.indexOf(normalizedQuery)
+
+  while (matchStart !== -1) {
+    matches.push({ start: matchStart, end: matchStart + normalizedQuery.length })
+    matchStart = transcript.indexOf(normalizedQuery, matchStart + 1)
+  }
+
+  let matchIndex = 0
+  return segments.filter((_, index) => {
+    const range = ranges[index]
+
+    while (matches[matchIndex]?.end <= range.start) {
+      matchIndex++
+    }
+
+    const match = matches[matchIndex]
+    return match !== undefined && match.start < range.end && match.end > range.start
+  })
+}

--- a/tests/unit/transcript-search.test.mjs
+++ b/tests/unit/transcript-search.test.mjs
@@ -17,9 +17,14 @@ test('returns every segment containing part of a cross-segment match', () => {
 })
 
 test('normalizes whitespace and case across segment boundaries', () => {
+  const irregularSegments = [
+    { ...segments[0], text: 'Hello this  is\njust a' },
+    ...segments.slice(1)
+  ]
+
   assert.deepEqual(
-    filterTranscriptSegments(segments, 'IS  JUST A\nTEST TO'),
-    segments.slice(0, 2)
+    filterTranscriptSegments(irregularSegments, 'IS  JUST A\nTEST TO'),
+    irregularSegments.slice(0, 2)
   )
 })
 

--- a/tests/unit/transcript-search.test.mjs
+++ b/tests/unit/transcript-search.test.mjs
@@ -1,0 +1,29 @@
+import assert from 'node:assert/strict'
+import test from 'node:test'
+
+import { filterTranscriptSegments } from '../../src/renderer/components/WatchVideoTranscript/transcriptSearch.js'
+
+const segments = [
+  { index: 0, text: 'Hello this is just a' },
+  { index: 1, text: 'test to demonstrate' },
+  { index: 2, text: 'Another caption' }
+]
+
+test('returns every segment containing part of a cross-segment match', () => {
+  assert.deepEqual(
+    filterTranscriptSegments(segments, 'just a test'),
+    segments.slice(0, 2)
+  )
+})
+
+test('normalizes whitespace and case across segment boundaries', () => {
+  assert.deepEqual(
+    filterTranscriptSegments(segments, 'IS  JUST A\nTEST TO'),
+    segments.slice(0, 2)
+  )
+})
+
+test('keeps existing single-segment and empty-query behavior', () => {
+  assert.deepEqual(filterTranscriptSegments(segments, 'another caption'), [segments[2]])
+  assert.equal(filterTranscriptSegments(segments, '  '), segments)
+})


### PR DESCRIPTION
## Pull Request Type

- [x] Bugfix
- [ ] Feature Implementation
- [ ] Documentation
- [ ] Other

## Related issue

N/A

## Description

Transcript search now treats adjacent caption segments as continuous text. When a search phrase starts in one timestamped segment and ends in the next, every segment touched by the match remains visible.

Previously, each segment was searched independently, so phrases split at a caption boundary produced no results. The new search helper normalizes case and whitespace, searches the complete transcript, and maps each match back to its source segments.

## Screenshots

N/A

## Release note category

<!-- release-note-category:start -->
- [ ] Not noteworthy
- [ ] Highlights
- [ ] More improvements
- [x] Fixed bugs
<!-- release-note-category:end -->

## Release note

<!-- release-note:start -->
Transcript searches now find phrases that span multiple caption lines.
<!-- release-note:end -->

## Release note images

<!-- release-note-image:start -->

<!-- release-note-image:end -->

## Testing

- Run `pnpm run test:unit`.
- Search a transcript containing adjacent lines such as `Hello this is just a` and `test to demonstrate` for `just a test`; both lines should be shown.

## Desktop

- **OS:** Linux
- **OS Version:** Arch Linux
- **OpenTubeX version:** 0.30.2

## Additional context

The regression tests also cover case-insensitive matching and normalized whitespace across caption boundaries.
