### PR TITLE
fix(player): show open state on compact chapters button

### DIFF
--- a/e2e/tests/offline/ui-bugfixes.spec.mjs
+++ b/e2e/tests/offline/ui-bugfixes.spec.mjs
@@ -1,3 +1,4 @@
+import { readFile } from 'node:fs/promises'
 import path from 'node:path'
 
 import { test, expect, goTo, repoRoot } from '../../helpers/app.mjs'
@@ -135,6 +136,46 @@ test('Shorts top controls stay visible over white video content', async ({ page 
   await expect(volumeButton).toHaveCSS('backdrop-filter', 'none')
   await expect(volumeSlider).toHaveCSS('inline-size', '96px')
   await expect(volumeSlider).toHaveCSS('opacity', '1')
+})
+
+test('compact chapters button marks its open state', async ({ page }) => {
+  await goTo(page, 'history')
+  const playerStyles = await readFile(
+    path.join(
+      repoRoot,
+      'src/renderer/components/ft-shaka-video-player/ft-shaka-video-player.css'
+    ),
+    'utf8'
+  )
+  // The component scopes these rules with :deep(), which the browser cannot parse on its own
+  await page.addStyleTag({
+    content: playerStyles.replaceAll(/:deep\(((?:[^()]|\([^()]*\))*)\)/g, '$1')
+  })
+  await page.evaluate(() => {
+    const panel = document.createElement('div')
+    const button = document.createElement('button')
+    const icon = document.createElement('span')
+
+    panel.className = 'shaka-controls-button-panel ft-controls-compact-chapters'
+    panel.style.inset = '300px auto auto 300px'
+    panel.style.position = 'fixed'
+    panel.style.zIndex = '10000'
+    button.className = 'ft-chapters-button'
+    icon.className = 'ft-chapters-icon'
+    button.append(icon)
+    panel.append(button)
+    document.body.append(panel)
+  })
+
+  const button = page.locator('.ft-controls-compact-chapters > .ft-chapters-button')
+  const highlightColor = () => button.evaluate((element) => {
+    return getComputedStyle(element, '::before').backgroundColor
+  })
+
+  await expect(button).toBeVisible()
+  await expect.poll(highlightColor).toBe('rgba(0, 0, 0, 0)')
+  await button.evaluate(element => element.classList.add('open'))
+  await expect.poll(highlightColor).toBe('rgba(255, 255, 255, 0.2)')
 })
 
 test.describe('autosized prompts', () => {

--- a/src/renderer/components/ft-shaka-video-player/ft-shaka-video-player.css
+++ b/src/renderer/components/ft-shaka-video-player/ft-shaka-video-player.css
@@ -724,6 +724,20 @@
   display: block;
 }
 
+/* The compact button only shows the icon, so mark the open state with a highlight */
+:deep(.shaka-controls-button-panel.ft-controls-compact-chapters > .ft-chapters-button)::before {
+  position: absolute;
+  inset: 6px;
+  border-radius: calc(50% * var(--ui-roundness));
+  background-color: transparent;
+  content: '';
+  pointer-events: none;
+}
+
+:deep(.shaka-controls-button-panel.ft-controls-compact-chapters > .ft-chapters-button.open)::before {
+  background-color: rgb(255 255 255 / 20%);
+}
+
 :deep(.shaka-controls-button-panel.ft-controls-compact-chapters > .ft-chapters-button .ft-chapters-current-title),
 :deep(.shaka-controls-button-panel.ft-controls-compact-chapters > .ft-chapters-button .ft-chapters-chevron) {
   display: none;


### PR DESCRIPTION
## Pull Request Type
- [x] Bugfix
- [ ] Feature Implementation
- [ ] Documentation
- [ ] Other

## Related issue
<!-- No issue -->

## Description
When the player controls run out of room, the chapters button collapses to its icon-only (compact) form. In that form the current chapter title and the chevron are hidden, and the button was explicitly excluded from the highlight rule (`:not(.ft-controls-compact-chapters)`), so it looked exactly the same whether the chapters overlay was open or closed.

The compact button now gets its own highlight that fills in while the overlay is open. It uses `--ui-roundness` so it follows the roundness setting, and it complements the `aria-expanded` state the button already exposes.

## Screenshots
<!-- Not included -->

## Release note category
<!-- release-note-category:start -->
- [ ] Not noteworthy
- [ ] Highlights
- [ ] More improvements
- [x] Fixed bugs
<!-- release-note-category:end -->

## Release note
<!-- release-note:start -->
The icon-only chapters button in the player controls now shows whether the chapters overlay is open.
<!-- release-note:end -->

## Release note images
<!-- release-note-image:start -->

<!-- release-note-image:end -->

## Testing
1. Open a video that has chapters.
2. Shrink the player (or the window) until the chapters button in the control bar collapses to just its icon.
3. Toggle the chapters overlay: the button now shows a filled highlight while the overlay is open and none while it is closed.

Automated: a new offline E2E regression test covers this.

```
xvfb-run -a -s "-screen 0 1920x1080x24" npx playwright test -c e2e/playwright.config.mjs --project=offline -g "compact chapters button marks its open state"
```

It injects the player stylesheet onto a synthetic compact button and asserts the highlight is transparent when closed and `rgba(255, 255, 255, 0.2)` when open. Verified that it fails without the CSS change and passes with it.

## Desktop
- **OS:** Arch Linux
- **OS Version:** KDE Plasma (Wayland)
- **OpenTubeX version:** 0.30.2

## Additional context
CSS-only fix; no behaviour or markup changes. The `open` class it hooks into was already toggled by `ChapterOverlayButton`.
