### PR TITLE
feat(about): display nightly build commit

### DIFF
--- a/_scripts/webpack.renderer.config.js
+++ b/_scripts/webpack.renderer.config.js
@@ -146,6 +146,7 @@ const config = {
       'process.env.IS_ELECTRON': true,
       'process.env.IS_ELECTRON_MAIN': false,
       'process.env.SUPPORTS_LOCAL_API': true,
+      'process.env.BUILD_COMMIT': JSON.stringify(process.env.GITHUB_SHA ?? ''),
       __VUE_OPTIONS_API__: 'true',
       __VUE_PROD_DEVTOOLS__: 'false',
       __VUE_PROD_HYDRATION_MISMATCH_DETAILS__: 'false',

--- a/_scripts/webpack.web.config.js
+++ b/_scripts/webpack.web.config.js
@@ -135,6 +135,7 @@ const config = {
       'process.env.IS_ELECTRON': false,
       'process.env.IS_ELECTRON_MAIN': false,
       'process.env.SUPPORTS_LOCAL_API': false,
+      'process.env.BUILD_COMMIT': JSON.stringify(process.env.GITHUB_SHA ?? ''),
       __VUE_OPTIONS_API__: 'true',
       __VUE_PROD_DEVTOOLS__: 'false',
       __VUE_PROD_HYDRATION_MISMATCH_DETAILS__: 'false',

--- a/src/renderer/helpers/versionDisplay.js
+++ b/src/renderer/helpers/versionDisplay.js
@@ -1,0 +1,12 @@
+const NIGHTLY_VERSION_PATTERN = /^\d+\.\d+\.\d+-nightly-\d+$/
+
+/**
+ * @param {string} version
+ * @param {string} commit
+ * @returns {string}
+ */
+export function getNightlyCommit(version, commit) {
+  return NIGHTLY_VERSION_PATTERN.test(version) && commit.length > 0
+    ? commit.slice(0, 7)
+    : ''
+}

--- a/src/renderer/views/About/About.css
+++ b/src/renderer/views/About/About.css
@@ -18,6 +18,10 @@
   font-size: 2em;
 }
 
+.commit {
+  margin-block-start: 4px;
+}
+
 .runtimeVersions {
   display: flex;
   flex-wrap: wrap;

--- a/src/renderer/views/About/About.vue
+++ b/src/renderer/views/About/About.vue
@@ -13,6 +13,16 @@
         <div class="version">
           {{ versionNumber }} {{ $t("About.Beta") }}
         </div>
+        <div
+          v-if="commitId"
+          class="commit"
+        >
+          {{ commitLabel }}
+          <a
+            :href="commitUrl"
+            :title="buildCommit"
+          >{{ commitId }}</a>
+        </div>
         <dl
           v-if="runtimeVersions"
           class="runtimeVersions"
@@ -58,12 +68,17 @@ import { useI18n } from 'vue-i18n'
 import FtCard from '../../components/ft-card/ft-card.vue'
 import FtLogoFull from '../../components/FtLogoFull/FtLogoFull.vue'
 import { vSaferHtml } from '../../directives/vSaferHtml.js'
+import { getNightlyCommit } from '../../helpers/versionDisplay.js'
 
 import packageDetails from '../../../../package.json'
 
 const { t } = useI18n()
 
 const versionNumber = `v${packageDetails.version}`
+const buildCommit = process.env.BUILD_COMMIT
+const commitId = getNightlyCommit(packageDetails.version, buildCommit)
+const commitLabel = `${t('About.Commit')}:`
+const commitUrl = `https://github.com/OpenTubeX/OpenTubeX/commit/${buildCommit}`
 const runtimeVersions = process.env.IS_ELECTRON
   ? [
       { name: 'Electron', version: window.ftElectron.runtimeVersions.electron },

--- a/static/locales/en-US.yaml
+++ b/static/locales/en-US.yaml
@@ -1043,6 +1043,7 @@ About:
   #On About page
   About: About
   Beta: Beta
+  Commit: Commit
   Source code: Source code
   Licensed under the {licenseLink}: Licensed under the {licenseLink}
   AGPLv3: AGPLv3

--- a/tests/unit/version-display.test.mjs
+++ b/tests/unit/version-display.test.mjs
@@ -1,0 +1,22 @@
+import assert from 'node:assert/strict'
+import test from 'node:test'
+
+import { getNightlyCommit } from '../../src/renderer/helpers/versionDisplay.js'
+
+test('nightly versions include the short build commit', () => {
+  assert.equal(
+    getNightlyCommit('0.30.2-nightly-625', '7d649ede2b6241065e8793e5cc92819e95610a16'),
+    '7d649ed'
+  )
+})
+
+test('stable versions do not include the build commit', () => {
+  assert.equal(
+    getNightlyCommit('0.30.2', '7d649ede2b6241065e8793e5cc92819e95610a16'),
+    ''
+  )
+})
+
+test('nightly versions without build metadata keep their current display', () => {
+  assert.equal(getNightlyCommit('0.30.2-nightly-625', ''), '')
+})


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Make sure to follow the contributing guidelines. -->
<!-- Important note, we may remove your pull request if you do not use this provided PR template correctly. -->

## Pull Request Type
<!-- Please select what type of pull request this is: [x] -->
- [ ] Bugfix
- [x] Feature Implementation
- [ ] Documentation
- [ ] Other

## Related issue
<!-- Please link the issue your pull request is referring to. -->
<!-- If this pull request fully resolves the relevant issue, put "closes" before the issue number. -->
<!-- Example: "closes #123456". -->

Closes #464.

## Description
<!-- Please write a clear and concise description of what the pull request does. -->

Display the source commit below the version on the About page for nightly builds. The short SHA links to the corresponding full commit on GitHub. Stable builds and builds without commit metadata keep the existing About page.

The GitHub Actions SHA is injected at build time, and the renderer only exposes it when the package version matches the nightly version format.

## Screenshots <!-- If appropriate -->
<!-- Please add before and after screenshots if there is a visible change. -->

Not included.

## Release note category
<!-- Select exactly one category. Every pull request must select one. -->
<!-- release-note-category:start -->
- [x] Not noteworthy
- [ ] Highlights
- [ ] More improvements
- [ ] Fixed bugs
<!-- release-note-category:end -->

## Release note
<!-- Required unless "Not noteworthy" is selected. -->
<!-- Write one concise, user-facing entry without a leading bullet. -->
<!-- release-note:start -->
Nightly builds now show a link to their source commit on the About page.
<!-- release-note:end -->

## Release note images
<!-- Optional. Paste one or more Markdown images or HTML image tags here. -->
<!-- The release notes will use an HTML image tag and limit images taller than 300 pixels. -->
<!-- release-note-image:start -->

<!-- release-note-image:end -->

## Testing
<!-- How can reviewers verify that the PR produces correct results? -->
<!-- Please provide instructions so that others can ensure that your pull request produces correct results. -->

Completed:

- `pnpm run lint`
- `pnpm run test:unit` (165 tests)
- Production renderer pack with an injected test SHA

To verify manually:

1. Set the package version to a nightly version such as `0.30.2-nightly-999`.
2. Pack with `GITHUB_SHA="$(git rev-parse HEAD)" pnpm run pack`.
3. Launch with an isolated profile using `OPENTUBEX_E2E_USER_DATA_DIR`.
4. Confirm the About page shows `Commit: <short SHA>` below the version.
5. Click the SHA and confirm the matching GitHub commit opens.

## Desktop
<!-- Please complete the following information-->
- **OS:** Arch Linux
- **OS Version:** Rolling release
- **OpenTubeX version:** 0.30.2-nightly-999

## Additional context
<!-- Add any other context about the pull request here. -->

The commit is shown only for nightly versions and is shortened to seven characters for readability.
