### PR TITLE
fix(tabs): rework tab preview capture and storage

### DIFF
--- a/e2e/tests/offline/tab-preview.spec.mjs
+++ b/e2e/tests/offline/tab-preview.spec.mjs
@@ -1,0 +1,81 @@
+import { test, expect, sel } from '../../helpers/app.mjs'
+
+const CAPTURE_CLASS = 'opentubex-tab-preview-capturing'
+const CAPTURE_STYLE_ID = 'opentubex-tab-preview-capture-style'
+
+/**
+ * Reads the pixel size out of a PNG data URL (IHDR is always the first chunk).
+ * @param {string} dataUrl
+ * @returns {{ width: number, height: number }}
+ */
+function pngSize(dataUrl) {
+  const buffer = Buffer.from(dataUrl.slice(dataUrl.indexOf(',') + 1), 'base64')
+  return { width: buffer.readUInt32BE(16), height: buffer.readUInt32BE(20) }
+}
+
+/**
+ * Hovers the given tab and resolves once its tooltip shows a captured preview.
+ * @param {import('@playwright/test').Page} page
+ * @param {number} index
+ * @returns {Promise<string>} the preview data URL
+ */
+async function hoverTabForPreview(page, index) {
+  await page.locator(sel.tabs).nth(index).hover()
+  const preview = page.locator('.tabTooltip .tabTooltipPreview img')
+  await expect(preview).toBeVisible()
+  await expect.poll(async () => (await preview.getAttribute('src'))?.startsWith('data:image/png'))
+    .toBe(true)
+  return await preview.getAttribute('src')
+}
+
+test.describe('tab previews', () => {
+  test('captures the page content without the tab bar and header', async ({ page }) => {
+    const dataUrl = await hoverTabForPreview(page, 0)
+
+    const expectedRatio = await page.evaluate(() => {
+      const bottomOf = (selector) => document.querySelector(selector)?.getBoundingClientRect().bottom ?? 0
+      const contentTop = Math.max(bottomOf('.tabBar'), bottomOf('.topNav'))
+      return window.innerWidth / (window.innerHeight - contentTop)
+    })
+
+    const { width, height } = pngSize(dataUrl)
+    // The capture is downscaled to fit the tooltip, so only the shape of the
+    // cropped region survives. Leaving the 60px header in would visibly change
+    // it (~1.84 instead of ~1.98 at the default test window size).
+    expect(width / height).toBeGreaterThan(expectedRatio - 0.03)
+    expect(width / height).toBeLessThan(expectedRatio + 0.03)
+  })
+
+  test('stores more pixels than the tooltip displays', async ({ page }) => {
+    const dataUrl = await hoverTabForPreview(page, 0)
+
+    const displayed = await page.locator('.tabTooltip .tabTooltipPreview').boundingBox()
+    const { width } = pngSize(dataUrl)
+    // Displaying a page-sized screenshot at 1:1 after a ~5x downscale is what
+    // made previews look blurry; the capture has to keep headroom so the
+    // browser does the final reduction itself.
+    expect(width).toBeGreaterThanOrEqual(Math.round(displayed.width * 2))
+  })
+
+  test('hides tab previews from the page while capturing', async ({ page }) => {
+    await page.locator(sel.newTabButton).click()
+    await expect(page.locator(sel.tabs)).toHaveCount(2)
+    await hoverTabForPreview(page, 1)
+
+    // The capture stylesheet is injected by the main process on the first
+    // capture; applying its class reproduces what a capture sees.
+    await expect(page.locator(`#${CAPTURE_STYLE_ID}`)).toHaveCount(1)
+    const hiddenWhileCapturing = await page.evaluate((captureClass) => {
+      document.documentElement.classList.add(captureClass)
+      const visibilities = Array.from(
+        document.querySelectorAll('[data-tab-preview-overlay]'),
+        (element) => getComputedStyle(element).visibility
+      )
+      document.documentElement.classList.remove(captureClass)
+      return visibilities
+    }, CAPTURE_CLASS)
+
+    expect(hiddenWhileCapturing.length).toBeGreaterThan(0)
+    expect(hiddenWhileCapturing.every((visibility) => visibility === 'hidden')).toBe(true)
+  })
+})

--- a/e2e/tests/offline/tab-preview.spec.mjs
+++ b/e2e/tests/offline/tab-preview.spec.mjs
@@ -64,15 +64,13 @@ test.describe('tab previews', () => {
     expect(width / height).toBeLessThan(expectedRatio + 0.03)
   })
 
-  test('stores more pixels than the tooltip displays', async ({ page }) => {
+  test('never stores fewer pixels than the tooltip displays', async ({ page }) => {
     const dataUrl = await hoverTabForPreview(page, 0)
 
     const displayed = await page.locator('.tabTooltip .tabTooltipPreview').boundingBox()
     const { width } = imageSize(dataUrl)
-    // Displaying a page-sized screenshot at 1:1 after a ~5x downscale is what
-    // made previews look blurry; the capture has to keep headroom so the
-    // browser does the final reduction itself.
-    expect(width).toBeGreaterThanOrEqual(Math.round(displayed.width * 2))
+    // Anything below the displayed width would be upscaled by the browser.
+    expect(width).toBeGreaterThanOrEqual(Math.round(displayed.width))
   })
 
   test('hides tab previews from the page while capturing', async ({ page }) => {

--- a/e2e/tests/offline/tab-preview.spec.mjs
+++ b/e2e/tests/offline/tab-preview.spec.mjs
@@ -4,13 +4,31 @@ const CAPTURE_CLASS = 'opentubex-tab-preview-capturing'
 const CAPTURE_STYLE_ID = 'opentubex-tab-preview-capture-style'
 
 /**
- * Reads the pixel size out of a PNG data URL (IHDR is always the first chunk).
+ * Reads the pixel size out of a preview data URL. Previews are JPEG, but a
+ * cache written by an older version can still hand back a PNG.
  * @param {string} dataUrl
  * @returns {{ width: number, height: number }}
  */
-function pngSize(dataUrl) {
+function imageSize(dataUrl) {
   const buffer = Buffer.from(dataUrl.slice(dataUrl.indexOf(',') + 1), 'base64')
-  return { width: buffer.readUInt32BE(16), height: buffer.readUInt32BE(20) }
+  if (buffer.readUInt32BE(0) === 0x89504e47) {
+    return { width: buffer.readUInt32BE(16), height: buffer.readUInt32BE(20) }
+  }
+
+  // Walk the JPEG segments to the start-of-frame, which carries the size.
+  for (let offset = 2; offset < buffer.length - 9;) {
+    if (buffer[offset] !== 0xff) {
+      throw new Error(`not a JPEG segment at offset ${offset}`)
+    }
+    const marker = buffer[offset + 1]
+    const isStartOfFrame = marker >= 0xc0 && marker <= 0xcf &&
+      marker !== 0xc4 && marker !== 0xc8 && marker !== 0xcc
+    if (isStartOfFrame) {
+      return { width: buffer.readUInt16BE(offset + 7), height: buffer.readUInt16BE(offset + 5) }
+    }
+    offset += 2 + buffer.readUInt16BE(offset + 2)
+  }
+  throw new Error('no JPEG start-of-frame found')
 }
 
 /**
@@ -23,7 +41,7 @@ async function hoverTabForPreview(page, index) {
   await page.locator(sel.tabs).nth(index).hover()
   const preview = page.locator('.tabTooltip .tabTooltipPreview img')
   await expect(preview).toBeVisible()
-  await expect.poll(async () => (await preview.getAttribute('src'))?.startsWith('data:image/png'))
+  await expect.poll(async () => (await preview.getAttribute('src'))?.startsWith('data:image/jpeg'))
     .toBe(true)
   return await preview.getAttribute('src')
 }
@@ -38,7 +56,7 @@ test.describe('tab previews', () => {
       return window.innerWidth / (window.innerHeight - contentTop)
     })
 
-    const { width, height } = pngSize(dataUrl)
+    const { width, height } = imageSize(dataUrl)
     // The capture is downscaled to fit the tooltip, so only the shape of the
     // cropped region survives. Leaving the 60px header in would visibly change
     // it (~1.84 instead of ~1.98 at the default test window size).
@@ -50,7 +68,7 @@ test.describe('tab previews', () => {
     const dataUrl = await hoverTabForPreview(page, 0)
 
     const displayed = await page.locator('.tabTooltip .tabTooltipPreview').boundingBox()
-    const { width } = pngSize(dataUrl)
+    const { width } = imageSize(dataUrl)
     // Displaying a page-sized screenshot at 1:1 after a ~5x downscale is what
     // made previews look blurry; the capture has to keep headroom so the
     // browser does the final reduction itself.

--- a/src/main/index.js
+++ b/src/main/index.js
@@ -1588,6 +1588,15 @@ function runApp() {
       await clearAllTabSessions()
     }
 
+    // Before any window can capture a preview, drop cache entries that no
+    // restored tab points at. Without this, previews orphaned by a crash or a
+    // forced quit stay on disk forever.
+    await TabManager.pruneTabPreviewCache(
+      savedSessions.flatMap(session => (
+        Array.isArray(session?.tabs) ? session.tabs.map(tab => tab?.previewFileName) : []
+      ))
+    )
+
     let firstWindow
 
     const directStartupUrl = getDirectOpenUrl(startupUrl)

--- a/src/main/tabs/TabManager.js
+++ b/src/main/tabs/TabManager.js
@@ -1,6 +1,6 @@
 import { BrowserWindow, ipcMain, app, shell } from 'electron'
 import { randomUUID } from 'crypto'
-import { mkdir, readFile, unlink, writeFile } from 'fs/promises'
+import { mkdir, readdir, readFile, unlink, writeFile } from 'fs/promises'
 import { join } from 'path'
 import { IpcChannels } from '../../constants.js'
 import * as baseHandlers from '../../datastores/handlers/base.js'
@@ -12,6 +12,15 @@ import {
 } from './TabSessionStore.js'
 import { TabRendererBridge } from './TabRendererBridge.js'
 import { buildReorderedTabMap } from './tabOrder.js'
+import {
+  createTabPreviewFileName,
+  isReusableTabPreviewFileName,
+  isTabPreviewDataUrl,
+  normalizeTabPreviewFileName,
+  selectOrphanedTabPreviews,
+  TAB_PREVIEW_JPEG_QUALITY,
+  tabPreviewBufferToDataUrl
+} from './tabPreviewCache.js'
 import {
   cropTabPreviewToContent,
   getTabPreviewTargetSize,
@@ -34,7 +43,6 @@ const TAB_PREVIEW_REFRESH_DELAY_MS = 700
 const TAB_PREVIEW_CAPTURE_STYLE_ID = 'opentubex-tab-preview-capture-style'
 const TAB_PREVIEW_CAPTURE_CLASS = 'opentubex-tab-preview-capturing'
 const TAB_PREVIEW_CACHE_DIR_NAME = 'tab-previews'
-const TAB_PREVIEW_FILE_PATTERN = /^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}\.png$/i
 const TAB_TRANSFER_MOUNT_TIMEOUT_MS = 8000
 const transferringTabIds = new Set()
 const TAB_LOADING_SOURCE_MOUNT = 'mount'
@@ -128,16 +136,6 @@ export class TabManager {
   }
 
   /**
-   * @param {unknown} value
-   * @returns {string | null}
-   */
-  static normalizePreviewFileName(value) {
-    return typeof value === 'string' && TAB_PREVIEW_FILE_PATTERN.test(value)
-      ? value
-      : null
-  }
-
-  /**
    * @returns {string}
    */
   static getTabPreviewCacheDirectory() {
@@ -145,24 +143,41 @@ export class TabManager {
   }
 
   /**
-   * @param {string} dataUrl
-   * @returns {Buffer | null}
+   * Deletes cached previews that no restored session refers to. Tabs delete
+   * their own preview when they close, but a crash or a forced quit leaves the
+   * file behind with nothing left to point at it.
+   *
+   * Must run before any window exists: a capture racing this would write a file
+   * that is not in `referencedFileNames` yet and would be deleted right away.
+   * @param {Iterable<string | null | undefined>} referencedFileNames
+   * @returns {Promise<number>} how many files were deleted
    */
-  static tabPreviewDataUrlToBuffer(dataUrl) {
-    if (typeof dataUrl !== 'string') {
-      return null
+  static async pruneTabPreviewCache(referencedFileNames) {
+    const cacheDirectory = TabManager.getTabPreviewCacheDirectory()
+    /** @type {string[]} */
+    let fileNames
+    try {
+      fileNames = await readdir(cacheDirectory)
+    } catch (error) {
+      if (error?.code !== 'ENOENT') {
+        console.error('Failed to read the tab preview cache:', error)
+      }
+      return 0
     }
 
-    const match = dataUrl.match(/^data:image\/png;base64,([A-Za-z0-9+/=]+)$/)
-    return match ? Buffer.from(match[1], 'base64') : null
-  }
-
-  /**
-   * @param {Buffer} buffer
-   * @returns {string}
-   */
-  static tabPreviewBufferToDataUrl(buffer) {
-    return 'data:image/png;base64,' + buffer.toString('base64')
+    const orphans = selectOrphanedTabPreviews(fileNames, referencedFileNames)
+    const results = await Promise.all(orphans.map(async fileName => {
+      try {
+        await unlink(join(cacheDirectory, fileName))
+        return true
+      } catch (error) {
+        if (error?.code !== 'ENOENT') {
+          console.error('Failed to delete an orphaned tab preview:', error)
+        }
+        return false
+      }
+    }))
+    return results.filter(Boolean).length
   }
 
   /**
@@ -763,10 +778,10 @@ export class TabManager {
     const location = this._resolveTabLocation(url, route, query)
     const startsUnloaded = (Boolean(lazyLoad) || Boolean(isUnloaded)) && !makeActive && !preloadInBackground
     const shouldMount = !startsUnloaded
-    const restoredPreviewDataUrl = typeof previewDataUrl === 'string' && previewDataUrl.startsWith('data:image/png;base64,')
+    const restoredPreviewDataUrl = isTabPreviewDataUrl(previewDataUrl)
       ? previewDataUrl
       : null
-    const restoredPreviewFileName = TabManager.normalizePreviewFileName(previewFileName)
+    const restoredPreviewFileName = normalizeTabPreviewFileName(previewFileName)
     const restoredPreviewCapturedAt = (restoredPreviewDataUrl != null || restoredPreviewFileName != null) && Number.isFinite(previewCapturedAt)
       ? previewCapturedAt
       : 0
@@ -1394,7 +1409,7 @@ export class TabManager {
    * @returns {string | null}
    */
   _getTabPreviewFilePath(fileName) {
-    const normalizedFileName = TabManager.normalizePreviewFileName(fileName)
+    const normalizedFileName = normalizeTabPreviewFileName(fileName)
     return normalizedFileName == null
       ? null
       : join(TabManager.getTabPreviewCacheDirectory(), normalizedFileName)
@@ -1402,20 +1417,27 @@ export class TabManager {
 
   /**
    * @param {TabInfo} tab
-   * @param {string} dataUrl
+   * @param {Buffer} buffer
    * @returns {Promise<void>}
    */
-  async _persistTabPreview(tab, dataUrl) {
-    const buffer = TabManager.tabPreviewDataUrlToBuffer(dataUrl)
+  async _persistTabPreview(tab, buffer) {
     if (buffer == null || buffer.length === 0) {
       return
     }
 
-    const fileName = TabManager.normalizePreviewFileName(tab.previewFileName) ?? randomUUID() + '.png'
+    const existingFileName = normalizeTabPreviewFileName(tab.previewFileName)
+    // A cache entry left by an older version is a PNG; writing JPEG bytes into
+    // it would leave the extension lying about the contents, so start a new file.
+    const reusableFileName = isReusableTabPreviewFileName(existingFileName) ? existingFileName : null
+    const fileName = reusableFileName ?? createTabPreviewFileName()
     const cacheDirectory = TabManager.getTabPreviewCacheDirectory()
     await mkdir(cacheDirectory, { recursive: true })
     await writeFile(join(cacheDirectory, fileName), buffer)
     tab.previewFileName = fileName
+
+    if (reusableFileName == null && existingFileName != null) {
+      await this._deleteTabPreviewFile(existingFileName)
+    }
   }
 
   /**
@@ -1430,7 +1452,7 @@ export class TabManager {
 
     try {
       const buffer = await readFile(filePath)
-      return buffer.length > 0 ? TabManager.tabPreviewBufferToDataUrl(buffer) : null
+      return buffer.length > 0 ? tabPreviewBufferToDataUrl(buffer) : null
     } catch (error) {
       if (error?.code !== 'ENOENT') {
         console.error('Failed to load tab preview:', error)
@@ -1616,10 +1638,15 @@ export class TabManager {
         const preview = targetSize == null
           ? contentImage
           : contentImage.resize({ ...targetSize, quality: 'best' })
-        const dataUrl = preview.toDataURL()
+        const previewBuffer = preview.toJPEG(TAB_PREVIEW_JPEG_QUALITY)
+        if (previewBuffer.length === 0) {
+          return await this._getCachedTabPreviewDataUrl(tab)
+        }
+
+        const dataUrl = tabPreviewBufferToDataUrl(previewBuffer)
         tab.previewDataUrl = dataUrl
         tab.previewCapturedAt = Date.now()
-        await this._persistTabPreview(tab, dataUrl)
+        await this._persistTabPreview(tab, previewBuffer)
         await this._saveSession()
         return dataUrl
       } catch (error) {
@@ -1937,7 +1964,7 @@ export class TabManager {
       color: TabManager.normalizeTabColor(snapshot.color),
       previewDataUrl: snapshot.previewDataUrl ?? null,
       previewCapturedAt: snapshot.previewCapturedAt ?? 0,
-      previewFileName: TabManager.normalizePreviewFileName(snapshot.previewFileName),
+      previewFileName: normalizeTabPreviewFileName(snapshot.previewFileName),
       previewCaptureTimeoutId: null,
       previewCapturePromise: null,
       loadState: 'mounting',
@@ -2129,7 +2156,7 @@ export class TabManager {
           isUnloaded: tab.loadState === 'unloaded' || this._deferredUnloadTabIds.has(tab.id)
         }
 
-        const previewFileName = TabManager.normalizePreviewFileName(tab.previewFileName)
+        const previewFileName = normalizeTabPreviewFileName(tab.previewFileName)
         if (previewFileName != null && tab.previewCapturedAt > 0) {
           tabData.previewFileName = previewFileName
           tabData.previewCapturedAt = tab.previewCapturedAt
@@ -2265,7 +2292,7 @@ export class TabManager {
       for (const tabData of sessionData.tabs) {
         const makeActive = tabData.id === sessionData.activeTabId
         const hasSavedTitle = typeof tabData.title === 'string' && tabData.title.trim().length > 0
-        const previewFileName = TabManager.normalizePreviewFileName(tabData.previewFileName)
+        const previewFileName = normalizeTabPreviewFileName(tabData.previewFileName)
         const loadInBackground = loadInactiveTabs || (restoreTabLoadState && tabData.isUnloaded === false)
         const restoreAsUnloaded = !loadInactiveTabs && !makeActive && (
           (restoreTabLoadState && tabData.isUnloaded === true) ||

--- a/src/main/tabs/TabManager.js
+++ b/src/main/tabs/TabManager.js
@@ -12,6 +12,11 @@ import {
 } from './TabSessionStore.js'
 import { TabRendererBridge } from './TabRendererBridge.js'
 import { buildReorderedTabMap } from './tabOrder.js'
+import {
+  cropTabPreviewToContent,
+  getTabPreviewTargetSize,
+  measureTabPreviewContentBounds
+} from './tabPreviewGeometry.js'
 import { isOpenTubeXUrl } from '../utils.js'
 
 /** @type {Map<number, TabManager>} windowId -> TabManager */
@@ -25,8 +30,6 @@ const VALID_TAB_CLOSE_FOCUS = new Set(['previousTab', 'nextTab'])
 // cached here instead of being read from the settings store on every close.
 let tabCloseFocus = DEFAULT_TAB_CLOSE_FOCUS
 const VALID_TAB_COLORS = new Set(['red', 'orange', 'yellow', 'green', 'blue', 'purple'])
-const TAB_PREVIEW_MAX_WIDTH = 360
-const TAB_PREVIEW_MAX_HEIGHT = 220
 const TAB_PREVIEW_REFRESH_DELAY_MS = 700
 const TAB_PREVIEW_CAPTURE_STYLE_ID = 'opentubex-tab-preview-capture-style'
 const TAB_PREVIEW_CAPTURE_CLASS = 'opentubex-tab-preview-capturing'
@@ -1604,20 +1607,15 @@ export class TabManager {
         }
 
         const contentBounds = await this._getTabPreviewContentBounds()
-        const contentImage = contentBounds == null ? image : this._cropTabPreviewToContent(image, contentBounds)
+        const contentImage = contentBounds == null ? image : cropTabPreviewToContent(image, contentBounds)
         if (contentImage == null || contentImage.isEmpty()) {
           return await this._getCachedTabPreviewDataUrl(tab)
         }
 
-        const { width, height } = contentImage.getSize()
-        const ratio = Math.min(TAB_PREVIEW_MAX_WIDTH / width, TAB_PREVIEW_MAX_HEIGHT / height, 1)
-        const preview = ratio < 1
-          ? contentImage.resize({
-              width: Math.max(1, Math.round(width * ratio)),
-              height: Math.max(1, Math.round(height * ratio)),
-              quality: 'good'
-            })
-          : contentImage
+        const targetSize = getTabPreviewTargetSize(contentImage.getSize(), contentBounds)
+        const preview = targetSize == null
+          ? contentImage
+          : contentImage.resize({ ...targetSize, quality: 'best' })
         const dataUrl = preview.toDataURL()
         tab.previewDataUrl = dataUrl
         tab.previewCapturedAt = Date.now()
@@ -1636,76 +1634,17 @@ export class TabManager {
   }
 
   /**
-   * @returns {Promise<{contentTop: number, contentLeft: number, contentRight: number, viewportWidth: number, viewportHeight: number} | null>}
+   * @returns {Promise<import('./tabPreviewGeometry.js').TabPreviewContentBounds | null>}
    */
   async _getTabPreviewContentBounds() {
     try {
-      return await this.browserWindow.webContents.executeJavaScript(`
-        (() => {
-          const viewportWidth = Math.max(
-            window.visualViewport?.width || 0,
-            window.innerWidth || 0,
-            document.documentElement?.clientWidth || 0
-          )
-          const viewportHeight = Math.max(
-            window.visualViewport?.height || 0,
-            window.innerHeight || 0,
-            document.documentElement?.clientHeight || 0
-          )
-          const tabBar = document.querySelector('.tabBar')
-          let contentTop = 0
-          let contentLeft = 0
-          let contentRight = viewportWidth
-          if (tabBar instanceof HTMLElement) {
-            const rect = tabBar.getBoundingClientRect()
-            if (tabBar.classList.contains('vertical')) {
-              // Full-height side column: crop it off horizontally. It sits at
-              // whichever inline edge matches the text direction.
-              if (rect.left <= viewportWidth - rect.right) {
-                contentLeft = Math.min(viewportWidth, Math.max(0, rect.right))
-              } else {
-                contentRight = Math.min(viewportWidth, Math.max(0, rect.left))
-              }
-            } else {
-              contentTop = Math.min(viewportHeight, Math.max(0, rect.bottom))
-            }
-          }
-          return { contentTop, contentLeft, contentRight, viewportWidth, viewportHeight }
-        })()
-      `, true)
+      return await this.browserWindow.webContents.executeJavaScript(
+        `(${measureTabPreviewContentBounds.toString()})(window, document)`,
+        true
+      )
     } catch {
       return null
     }
-  }
-
-  /**
-   * @param {import('electron').NativeImage} image
-   * @param {{contentTop: number, contentLeft: number, contentRight: number, viewportWidth: number, viewportHeight: number}} contentBounds
-   * @returns {import('electron').NativeImage | null}
-   */
-  _cropTabPreviewToContent(image, contentBounds) {
-    const { contentTop = 0, contentLeft = 0, viewportWidth, viewportHeight } = contentBounds
-    const contentRight = contentBounds.contentRight ?? viewportWidth
-
-    if (contentTop <= 0 && contentLeft <= 0 && contentRight >= viewportWidth) {
-      return image
-    }
-
-    const { width, height } = image.getSize()
-    if (width <= 0 || height <= 0 || viewportWidth <= 0 || viewportHeight <= 0) {
-      return null
-    }
-
-    const scaleX = width / viewportWidth
-    const scaleY = height / viewportHeight
-    const cropX = Math.min(width, Math.max(0, Math.ceil(contentLeft * scaleX)))
-    const cropRight = Math.min(width, Math.max(0, Math.floor(contentRight * scaleX)))
-    const cropY = Math.min(height, Math.max(0, Math.ceil(contentTop * scaleY)))
-    const cropWidth = cropRight - cropX
-    const cropHeight = height - cropY
-    return cropWidth <= 0 || cropHeight <= 0
-      ? null
-      : image.crop({ x: cropX, y: cropY, width: cropWidth, height: cropHeight })
   }
 
   /**
@@ -1723,11 +1662,16 @@ export class TabManager {
           if (!style) {
             style = document.createElement('style')
             style.id = ${JSON.stringify(TAB_PREVIEW_CAPTURE_STYLE_ID)}
-            style.textContent = 'html.${TAB_PREVIEW_CAPTURE_CLASS} .tabTooltip, html.${TAB_PREVIEW_CAPTURE_CLASS} [data-tab-preview-overlay] { visibility: hidden !important; }'
+            style.textContent = 'html.${TAB_PREVIEW_CAPTURE_CLASS} [data-tab-preview-overlay] { visibility: hidden !important; }'
             document.head.appendChild(style)
           }
           document.documentElement.classList.add(${JSON.stringify(TAB_PREVIEW_CAPTURE_CLASS)})
-          return new Promise(resolve => requestAnimationFrame(() => resolve(true)))
+          // Two frames: the first callback runs before the frame that applies
+          // the class is painted, so resolving there can still capture a
+          // visible overlay and put one tab's preview inside another's.
+          return new Promise(resolve => {
+            requestAnimationFrame(() => requestAnimationFrame(() => resolve(true)))
+          })
         })()
       `
       : `document.documentElement.classList.remove(${JSON.stringify(TAB_PREVIEW_CAPTURE_CLASS)})`

--- a/src/main/tabs/TabManager.js
+++ b/src/main/tabs/TabManager.js
@@ -1,6 +1,6 @@
 import { BrowserWindow, ipcMain, app, shell } from 'electron'
 import { randomUUID } from 'crypto'
-import { mkdir, readdir, readFile, unlink, writeFile } from 'fs/promises'
+import { mkdir, readdir, readFile, rename, unlink, writeFile } from 'fs/promises'
 import { join } from 'path'
 import { IpcChannels } from '../../constants.js'
 import * as baseHandlers from '../../datastores/handlers/base.js'
@@ -14,6 +14,7 @@ import { TabRendererBridge } from './TabRendererBridge.js'
 import { buildReorderedTabMap } from './tabOrder.js'
 import {
   createTabPreviewFileName,
+  createTabPreviewTempFileName,
   isReusableTabPreviewFileName,
   isTabPreviewDataUrl,
   normalizeTabPreviewFileName,
@@ -1432,7 +1433,17 @@ export class TabManager {
     const fileName = reusableFileName ?? createTabPreviewFileName()
     const cacheDirectory = TabManager.getTabPreviewCacheDirectory()
     await mkdir(cacheDirectory, { recursive: true })
-    await writeFile(join(cacheDirectory, fileName), buffer)
+    // Writing straight to the target would truncate it first, so a failed write
+    // (a full disk, a kill) would destroy a preview that was perfectly good.
+    // A rename within the directory swaps it in atomically instead.
+    const tempPath = join(cacheDirectory, createTabPreviewTempFileName())
+    try {
+      await writeFile(tempPath, buffer)
+      await rename(tempPath, join(cacheDirectory, fileName))
+    } catch (error) {
+      await unlink(tempPath).catch(() => {})
+      throw error
+    }
     tab.previewFileName = fileName
 
     if (reusableFileName == null && existingFileName != null) {

--- a/src/main/tabs/tabPreviewCache.js
+++ b/src/main/tabs/tabPreviewCache.js
@@ -7,6 +7,10 @@ export const TAB_PREVIEW_FILE_EXTENSION = '.jpg'
 // `.png` is still accepted so caches written by older versions keep working.
 const TAB_PREVIEW_FILE_PATTERN = /^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}\.(?:jpg|png)$/i
 const TAB_PREVIEW_DATA_URL_PATTERN = /^data:image\/(?:jpeg|png);base64,([A-Za-z0-9+/=]+)$/
+// Previews are written to a temporary name and renamed into place, so a failed
+// write cannot truncate the entry that is already there.
+const TAB_PREVIEW_TEMP_SUFFIX = '.tmp'
+const TAB_PREVIEW_TEMP_PATTERN = /^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}\.(?:jpg|png)\.tmp$/i
 const PNG_MAGIC = 0x89504e47
 
 /**
@@ -24,6 +28,22 @@ export function normalizeTabPreviewFileName(value) {
  */
 export function createTabPreviewFileName() {
   return randomUUID() + TAB_PREVIEW_FILE_EXTENSION
+}
+
+/**
+ * A scratch name to write to before renaming over the real entry.
+ * @returns {string}
+ */
+export function createTabPreviewTempFileName() {
+  return createTabPreviewFileName() + TAB_PREVIEW_TEMP_SUFFIX
+}
+
+/**
+ * @param {unknown} value
+ * @returns {boolean}
+ */
+export function isTabPreviewTempFileName(value) {
+  return typeof value === 'string' && TAB_PREVIEW_TEMP_PATTERN.test(value)
 }
 
 /**
@@ -73,8 +93,11 @@ export function tabPreviewBufferToDataUrl(buffer) {
  * own preview when they close, so these are the ones left behind by a crash or
  * a forced quit, with nothing left to point at them.
  *
- * Anything that is not a preview file name is left alone rather than deleted,
- * so an unrelated file that ends up in the directory survives.
+ * Scratch files are always stale here: this runs before any window exists, so
+ * one can only be left over from a write that never finished.
+ *
+ * Anything else that is not a preview file name is left alone rather than
+ * deleted, so an unrelated file that ends up in the directory survives.
  * @param {Iterable<string>} fileNames directory listing
  * @param {Iterable<unknown>} referencedFileNames names still in use
  * @returns {string[]}
@@ -89,6 +112,7 @@ export function selectOrphanedTabPreviews(fileNames, referencedFileNames) {
   }
 
   return Array.from(fileNames).filter(fileName => (
-    normalizeTabPreviewFileName(fileName) != null && !referenced.has(fileName.toLowerCase())
+    isTabPreviewTempFileName(fileName) ||
+    (normalizeTabPreviewFileName(fileName) != null && !referenced.has(fileName.toLowerCase()))
   ))
 }

--- a/src/main/tabs/tabPreviewCache.js
+++ b/src/main/tabs/tabPreviewCache.js
@@ -1,0 +1,94 @@
+import { randomUUID } from 'crypto'
+
+// Previews are lossy tolerant screenshots, and JPEG stores them at roughly a
+// third of the PNG size, which pays for capturing them at a sharp resolution.
+export const TAB_PREVIEW_JPEG_QUALITY = 82
+export const TAB_PREVIEW_FILE_EXTENSION = '.jpg'
+// `.png` is still accepted so caches written by older versions keep working.
+const TAB_PREVIEW_FILE_PATTERN = /^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}\.(?:jpg|png)$/i
+const TAB_PREVIEW_DATA_URL_PATTERN = /^data:image\/(?:jpeg|png);base64,([A-Za-z0-9+/=]+)$/
+const PNG_MAGIC = 0x89504e47
+
+/**
+ * @param {unknown} value
+ * @returns {string | null} the file name, or null when it is not one of ours
+ */
+export function normalizeTabPreviewFileName(value) {
+  return typeof value === 'string' && TAB_PREVIEW_FILE_PATTERN.test(value)
+    ? value
+    : null
+}
+
+/**
+ * @returns {string}
+ */
+export function createTabPreviewFileName() {
+  return randomUUID() + TAB_PREVIEW_FILE_EXTENSION
+}
+
+/**
+ * Whether a cached file can be overwritten in place, which is only true when
+ * its extension matches what this version writes.
+ * @param {string | null} fileName
+ * @returns {boolean}
+ */
+export function isReusableTabPreviewFileName(fileName) {
+  return typeof fileName === 'string' && fileName.toLowerCase().endsWith(TAB_PREVIEW_FILE_EXTENSION)
+}
+
+/**
+ * @param {unknown} value
+ * @returns {boolean}
+ */
+export function isTabPreviewDataUrl(value) {
+  return typeof value === 'string' && TAB_PREVIEW_DATA_URL_PATTERN.test(value)
+}
+
+/**
+ * @param {unknown} dataUrl
+ * @returns {Buffer | null}
+ */
+export function tabPreviewDataUrlToBuffer(dataUrl) {
+  if (typeof dataUrl !== 'string') {
+    return null
+  }
+
+  const match = dataUrl.match(TAB_PREVIEW_DATA_URL_PATTERN)
+  return match ? Buffer.from(match[1], 'base64') : null
+}
+
+/**
+ * @param {Buffer} buffer
+ * @returns {string}
+ */
+export function tabPreviewBufferToDataUrl(buffer) {
+  // Caches can hold PNGs written by older versions, so the type comes from the
+  // file's magic bytes rather than from what this version writes.
+  const isPng = buffer.length >= 4 && buffer.readUInt32BE(0) === PNG_MAGIC
+  return `data:image/${isPng ? 'png' : 'jpeg'};base64,` + buffer.toString('base64')
+}
+
+/**
+ * Picks the cached previews that no tab refers to any more. Tabs delete their
+ * own preview when they close, so these are the ones left behind by a crash or
+ * a forced quit, with nothing left to point at them.
+ *
+ * Anything that is not a preview file name is left alone rather than deleted,
+ * so an unrelated file that ends up in the directory survives.
+ * @param {Iterable<string>} fileNames directory listing
+ * @param {Iterable<unknown>} referencedFileNames names still in use
+ * @returns {string[]}
+ */
+export function selectOrphanedTabPreviews(fileNames, referencedFileNames) {
+  const referenced = new Set()
+  for (const fileName of referencedFileNames) {
+    const normalized = normalizeTabPreviewFileName(fileName)
+    if (normalized != null) {
+      referenced.add(normalized.toLowerCase())
+    }
+  }
+
+  return Array.from(fileNames).filter(fileName => (
+    normalizeTabPreviewFileName(fileName) != null && !referenced.has(fileName.toLowerCase())
+  ))
+}

--- a/src/main/tabs/tabPreviewGeometry.js
+++ b/src/main/tabs/tabPreviewGeometry.js
@@ -79,12 +79,7 @@ export function measureTabPreviewContentBounds(window, document) {
 // so these are a CSS pixel budget, not a device pixel one.
 export const TAB_PREVIEW_MAX_CSS_WIDTH = 360
 export const TAB_PREVIEW_MAX_CSS_HEIGHT = 220
-// A preview is a whole page shrunk to thumbnail size (a 5x reduction at 1080p),
-// which destroys detail no matter how good the resampler is. Storing twice the
-// displayed size lets the browser do the last step of the downscale with its
-// own filtering, which is what makes small text read as text instead of mush.
-export const TAB_PREVIEW_SUPERSAMPLE = 2
-// Bounds the stored file when supersampling stacks with HiDPI or page zoom.
+// Bounds the stored file on displays that report a very high pixel ratio.
 export const TAB_PREVIEW_MAX_PIXEL_RATIO = 3
 
 /**
@@ -92,8 +87,8 @@ export const TAB_PREVIEW_MAX_PIXEL_RATIO = 3
  *
  * `NativeImage` measures and exports in logical pixels: `getSize()` reports the
  * 1x representation and `toDataURL()` writes it out, so on a scaled display the
- * capture silently loses resolution. The stored size therefore follows both the
- * window's device pixel ratio and a supersampling factor on top of it.
+ * capture would silently lose resolution. Following the window's device pixel
+ * ratio keeps the stored image at the pixel count the preview is drawn with.
  * @param {{width: number, height: number}} imageSize logical size of the crop
  * @param {TabPreviewContentBounds | null} contentBounds
  * @returns {{width: number, height: number} | null} null when it already fits
@@ -105,7 +100,7 @@ export function getTabPreviewTargetSize({ width, height }, contentBounds) {
 
   const pixelRatio = Math.min(
     TAB_PREVIEW_MAX_PIXEL_RATIO,
-    Math.max(1, contentBounds?.devicePixelRatio || 1) * TAB_PREVIEW_SUPERSAMPLE
+    Math.max(1, contentBounds?.devicePixelRatio || 1)
   )
 
   const ratio = Math.min(

--- a/src/main/tabs/tabPreviewGeometry.js
+++ b/src/main/tabs/tabPreviewGeometry.js
@@ -1,0 +1,152 @@
+/**
+ * @typedef {object} TabPreviewContentBounds
+ * @property {number} contentTop
+ * @property {number} contentLeft
+ * @property {number} contentRight
+ * @property {number} viewportWidth
+ * @property {number} viewportHeight
+ * @property {number} devicePixelRatio
+ */
+
+/**
+ * Measures the page region a tab preview should show: everything except the
+ * window chrome (the tab bar and the header), so previews only ever contain
+ * page content.
+ *
+ * This runs inside the renderer via `executeJavaScript(fn.toString())`, so it
+ * must stay self-contained: no imports, no closure variables, only the passed
+ * in `window`/`document` and their own APIs.
+ * @param {Window} window
+ * @param {Document} document
+ * @returns {TabPreviewContentBounds}
+ */
+export function measureTabPreviewContentBounds(window, document) {
+  const viewportWidth = Math.max(
+    window.visualViewport?.width || 0,
+    window.innerWidth || 0,
+    document.documentElement?.clientWidth || 0
+  )
+  const viewportHeight = Math.max(
+    window.visualViewport?.height || 0,
+    window.innerHeight || 0,
+    document.documentElement?.clientHeight || 0
+  )
+  const clampX = value => Math.min(viewportWidth, Math.max(0, value))
+  const clampY = value => Math.min(viewportHeight, Math.max(0, value))
+
+  const tabBar = document.querySelector('.tabBar')
+  const topNav = document.querySelector('.topNav')
+  let contentTop = 0
+  let contentLeft = 0
+  let contentRight = viewportWidth
+
+  if (tabBar != null) {
+    const rect = tabBar.getBoundingClientRect()
+    if (tabBar.classList.contains('vertical')) {
+      // Full-height side column: crop it off horizontally. It sits at
+      // whichever inline edge matches the text direction.
+      if (rect.left <= viewportWidth - rect.right) {
+        contentLeft = clampX(rect.right)
+      } else {
+        contentRight = clampX(rect.left)
+      }
+    } else {
+      contentTop = clampY(rect.bottom)
+    }
+  }
+
+  if (topNav != null) {
+    // The sticky header sits below a horizontal tab bar, so its bottom edge is
+    // where the page content actually starts. It collapses to a zero rect when
+    // it is hidden (e.g. fullscreen), which leaves the bounds untouched.
+    const rect = topNav.getBoundingClientRect()
+    contentTop = Math.max(contentTop, clampY(rect.bottom))
+  }
+
+  return {
+    contentTop,
+    contentLeft,
+    contentRight,
+    viewportWidth,
+    viewportHeight,
+    // Display scaling times page zoom. NativeImage reports and exports sizes in
+    // logical pixels, so this is the only place the real pixel count is known.
+    devicePixelRatio: window.devicePixelRatio || 1
+  }
+}
+
+// The tooltip lays its preview out in CSS pixels (~324px wide at the widest),
+// so these are a CSS pixel budget, not a device pixel one.
+export const TAB_PREVIEW_MAX_CSS_WIDTH = 360
+export const TAB_PREVIEW_MAX_CSS_HEIGHT = 220
+// A preview is a whole page shrunk to thumbnail size (a 5x reduction at 1080p),
+// which destroys detail no matter how good the resampler is. Storing twice the
+// displayed size lets the browser do the last step of the downscale with its
+// own filtering, which is what makes small text read as text instead of mush.
+export const TAB_PREVIEW_SUPERSAMPLE = 2
+// Bounds the stored file when supersampling stacks with HiDPI or page zoom.
+export const TAB_PREVIEW_MAX_PIXEL_RATIO = 3
+
+/**
+ * Picks the size a cropped capture should be stored at.
+ *
+ * `NativeImage` measures and exports in logical pixels: `getSize()` reports the
+ * 1x representation and `toDataURL()` writes it out, so on a scaled display the
+ * capture silently loses resolution. The stored size therefore follows both the
+ * window's device pixel ratio and a supersampling factor on top of it.
+ * @param {{width: number, height: number}} imageSize logical size of the crop
+ * @param {TabPreviewContentBounds | null} contentBounds
+ * @returns {{width: number, height: number} | null} null when it already fits
+ */
+export function getTabPreviewTargetSize({ width, height }, contentBounds) {
+  if (width <= 0 || height <= 0) {
+    return null
+  }
+
+  const pixelRatio = Math.min(
+    TAB_PREVIEW_MAX_PIXEL_RATIO,
+    Math.max(1, contentBounds?.devicePixelRatio || 1) * TAB_PREVIEW_SUPERSAMPLE
+  )
+
+  const ratio = Math.min(
+    TAB_PREVIEW_MAX_CSS_WIDTH * pixelRatio / width,
+    TAB_PREVIEW_MAX_CSS_HEIGHT * pixelRatio / height,
+    1
+  )
+  return ratio < 1
+    ? { width: Math.max(1, Math.round(width * ratio)), height: Math.max(1, Math.round(height * ratio)) }
+    : null
+}
+
+/**
+ * Crops a full window screenshot down to the measured content region. The
+ * bounds are in CSS pixels while the image is in device pixels, so they are
+ * rescaled by the ratio between them.
+ * @param {import('electron').NativeImage} image
+ * @param {TabPreviewContentBounds} contentBounds
+ * @returns {import('electron').NativeImage | null}
+ */
+export function cropTabPreviewToContent(image, contentBounds) {
+  const { contentTop = 0, contentLeft = 0, viewportWidth, viewportHeight } = contentBounds
+  const contentRight = contentBounds.contentRight ?? viewportWidth
+
+  if (contentTop <= 0 && contentLeft <= 0 && contentRight >= viewportWidth) {
+    return image
+  }
+
+  const { width, height } = image.getSize()
+  if (width <= 0 || height <= 0 || viewportWidth <= 0 || viewportHeight <= 0) {
+    return null
+  }
+
+  const scaleX = width / viewportWidth
+  const scaleY = height / viewportHeight
+  const cropX = Math.min(width, Math.max(0, Math.ceil(contentLeft * scaleX)))
+  const cropRight = Math.min(width, Math.max(0, Math.floor(contentRight * scaleX)))
+  const cropY = Math.min(height, Math.max(0, Math.ceil(contentTop * scaleY)))
+  const cropWidth = cropRight - cropX
+  const cropHeight = height - cropY
+  return cropWidth <= 0 || cropHeight <= 0
+    ? null
+    : image.crop({ x: cropX, y: cropY, width: cropWidth, height: cropHeight })
+}

--- a/src/renderer/components/TabBar/SortableTab.vue
+++ b/src/renderer/components/TabBar/SortableTab.vue
@@ -72,6 +72,7 @@
         v-if="isTooltipVisible"
         :id="tooltipId"
         class="tabTooltip"
+        data-tab-preview-overlay
         :style="tooltipStyle"
         role="tooltip"
       >

--- a/tests/unit/tab-preview-cache.test.mjs
+++ b/tests/unit/tab-preview-cache.test.mjs
@@ -1,0 +1,82 @@
+import assert from 'node:assert/strict'
+import test from 'node:test'
+
+import {
+  createTabPreviewFileName,
+  isReusableTabPreviewFileName,
+  isTabPreviewDataUrl,
+  normalizeTabPreviewFileName,
+  selectOrphanedTabPreviews,
+  TAB_PREVIEW_FILE_EXTENSION,
+  tabPreviewBufferToDataUrl,
+  tabPreviewDataUrlToBuffer
+} from '../../src/main/tabs/tabPreviewCache.js'
+
+const JPEG = Buffer.from([0xff, 0xd8, 0xff, 0xe0, 0x00, 0x10])
+const PNG = Buffer.from([0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a])
+
+test('writes new previews as jpeg', () => {
+  const fileName = createTabPreviewFileName()
+
+  assert.ok(fileName.endsWith(TAB_PREVIEW_FILE_EXTENSION))
+  assert.equal(normalizeTabPreviewFileName(fileName), fileName)
+  assert.equal(isReusableTabPreviewFileName(fileName), true)
+})
+
+test('keeps reading caches written by older versions', () => {
+  const legacy = '1c2f1f8e-4c9c-4f0e-8f1a-2b3c4d5e6f70.png'
+
+  assert.equal(normalizeTabPreviewFileName(legacy), legacy)
+  // A PNG entry cannot be overwritten with jpeg bytes, so it is replaced.
+  assert.equal(isReusableTabPreviewFileName(legacy), false)
+})
+
+test('rejects file names that are not previews', () => {
+  for (const value of ['../escape.jpg', 'notauuid.jpg', 'x.svg', '', null, 42]) {
+    assert.equal(normalizeTabPreviewFileName(value), null)
+  }
+})
+
+test('tags the data URL from the buffer contents, not the current format', () => {
+  assert.ok(tabPreviewBufferToDataUrl(JPEG).startsWith('data:image/jpeg;base64,'))
+  assert.ok(tabPreviewBufferToDataUrl(PNG).startsWith('data:image/png;base64,'))
+})
+
+test('round trips a preview through its data URL', () => {
+  assert.deepEqual(tabPreviewDataUrlToBuffer(tabPreviewBufferToDataUrl(JPEG)), JPEG)
+  assert.deepEqual(tabPreviewDataUrlToBuffer(tabPreviewBufferToDataUrl(PNG)), PNG)
+})
+
+test('accepts both preview data URL types and nothing else', () => {
+  assert.equal(isTabPreviewDataUrl(tabPreviewBufferToDataUrl(JPEG)), true)
+  assert.equal(isTabPreviewDataUrl(tabPreviewBufferToDataUrl(PNG)), true)
+  assert.equal(isTabPreviewDataUrl('data:image/svg+xml;base64,PHN2Zy8+'), false)
+  assert.equal(isTabPreviewDataUrl('https://i.ytimg.com/vi/x/mqdefault.jpg'), false)
+  assert.equal(isTabPreviewDataUrl(null), false)
+  assert.equal(tabPreviewDataUrlToBuffer('data:image/svg+xml;base64,PHN2Zy8+'), null)
+})
+
+test('deletes only previews no tab refers to', () => {
+  const kept = '1c2f1f8e-4c9c-4f0e-8f1a-2b3c4d5e6f70.jpg'
+  const legacyKept = '2c2f1f8e-4c9c-4f0e-8f1a-2b3c4d5e6f71.png'
+  const orphan = '3c2f1f8e-4c9c-4f0e-8f1a-2b3c4d5e6f72.jpg'
+
+  const orphans = selectOrphanedTabPreviews(
+    [kept, legacyKept, orphan],
+    [kept, legacyKept, null, undefined, 'not-a-preview.jpg']
+  )
+
+  assert.deepEqual(orphans, [orphan])
+})
+
+test('leaves unrelated files in the cache directory alone', () => {
+  const orphans = selectOrphanedTabPreviews(['README.md', '.keep', 'thumbs.db'], [])
+
+  assert.deepEqual(orphans, [])
+})
+
+test('treats everything as orphaned when no session was restored', () => {
+  const files = ['1c2f1f8e-4c9c-4f0e-8f1a-2b3c4d5e6f70.jpg', '2c2f1f8e-4c9c-4f0e-8f1a-2b3c4d5e6f71.png']
+
+  assert.deepEqual(selectOrphanedTabPreviews(files, []), files)
+})

--- a/tests/unit/tab-preview-cache.test.mjs
+++ b/tests/unit/tab-preview-cache.test.mjs
@@ -3,8 +3,10 @@ import test from 'node:test'
 
 import {
   createTabPreviewFileName,
+  createTabPreviewTempFileName,
   isReusableTabPreviewFileName,
   isTabPreviewDataUrl,
+  isTabPreviewTempFileName,
   normalizeTabPreviewFileName,
   selectOrphanedTabPreviews,
   TAB_PREVIEW_FILE_EXTENSION,
@@ -79,4 +81,23 @@ test('treats everything as orphaned when no session was restored', () => {
   const files = ['1c2f1f8e-4c9c-4f0e-8f1a-2b3c4d5e6f70.jpg', '2c2f1f8e-4c9c-4f0e-8f1a-2b3c4d5e6f71.png']
 
   assert.deepEqual(selectOrphanedTabPreviews(files, []), files)
+})
+
+test('scratch names are not mistaken for finished previews', () => {
+  const temp = createTabPreviewTempFileName()
+
+  assert.ok(isTabPreviewTempFileName(temp))
+  assert.equal(normalizeTabPreviewFileName(temp), null)
+  assert.equal(isReusableTabPreviewFileName(temp), false)
+  assert.equal(isTabPreviewTempFileName('1c2f1f8e-4c9c-4f0e-8f1a-2b3c4d5e6f70.jpg'), false)
+  assert.equal(isTabPreviewTempFileName('notes.tmp'), false)
+})
+
+test('sweeps up scratch files left by an interrupted write', () => {
+  const kept = '1c2f1f8e-4c9c-4f0e-8f1a-2b3c4d5e6f70.jpg'
+  const temp = createTabPreviewTempFileName()
+
+  // Pruning runs before any window exists, so a scratch file can only be
+  // left over from a write that never finished - even for a referenced tab.
+  assert.deepEqual(selectOrphanedTabPreviews([kept, temp], [kept]), [temp])
 })

--- a/tests/unit/tab-preview-geometry.test.mjs
+++ b/tests/unit/tab-preview-geometry.test.mjs
@@ -6,8 +6,7 @@ import {
   getTabPreviewTargetSize,
   measureTabPreviewContentBounds,
   TAB_PREVIEW_MAX_CSS_WIDTH,
-  TAB_PREVIEW_MAX_PIXEL_RATIO,
-  TAB_PREVIEW_SUPERSAMPLE
+  TAB_PREVIEW_MAX_PIXEL_RATIO
 } from '../../src/main/tabs/tabPreviewGeometry.js'
 
 const VIEWPORT_WIDTH = 1200
@@ -170,9 +169,9 @@ test('keeps the device pixel ratio so HiDPI previews stay sharp', () => {
   const standard = getTabPreviewTargetSize({ width: 1200, height: 600 }, boundsForRatio(1))
   const hiDpi = getTabPreviewTargetSize({ width: 1200, height: 600 }, boundsForRatio(2))
 
-  assert.equal(standard.width, TAB_PREVIEW_MAX_CSS_WIDTH * TAB_PREVIEW_SUPERSAMPLE)
-  assert.equal(hiDpi.width, TAB_PREVIEW_MAX_CSS_WIDTH * TAB_PREVIEW_MAX_PIXEL_RATIO)
-  assert.ok(hiDpi.height > standard.height)
+  assert.equal(standard.width, TAB_PREVIEW_MAX_CSS_WIDTH)
+  assert.equal(hiDpi.width, TAB_PREVIEW_MAX_CSS_WIDTH * 2)
+  assert.equal(hiDpi.height, standard.height * 2)
 })
 
 test('caps the stored pixel ratio so previews stay small', () => {
@@ -189,13 +188,13 @@ test('leaves captures that already fit untouched', () => {
 test('falls back to a single pixel ratio when bounds are unavailable', () => {
   const target = getTabPreviewTargetSize({ width: 1200, height: 600 }, null)
 
-  assert.equal(target.width, TAB_PREVIEW_MAX_CSS_WIDTH * TAB_PREVIEW_SUPERSAMPLE)
+  assert.equal(target.width, TAB_PREVIEW_MAX_CSS_WIDTH)
 })
 
-test('stores more pixels than the preview is displayed at', () => {
-  // 1080p content cropped below the chrome, on an unscaled display.
+test('never stores fewer pixels than the preview is displayed at', () => {
+  // 1080p content cropped below the chrome, on an unscaled display. The tooltip
+  // draws it ~322px wide, so anything below that would be an upscale.
   const target = getTabPreviewTargetSize({ width: 1920, height: 950 }, boundsForRatio(1))
-  const displayedCssWidth = 322
 
-  assert.ok(target.width >= displayedCssWidth * 2)
+  assert.ok(target.width >= 322)
 })

--- a/tests/unit/tab-preview-geometry.test.mjs
+++ b/tests/unit/tab-preview-geometry.test.mjs
@@ -1,0 +1,201 @@
+import assert from 'node:assert/strict'
+import test from 'node:test'
+
+import {
+  cropTabPreviewToContent,
+  getTabPreviewTargetSize,
+  measureTabPreviewContentBounds,
+  TAB_PREVIEW_MAX_CSS_WIDTH,
+  TAB_PREVIEW_MAX_PIXEL_RATIO,
+  TAB_PREVIEW_SUPERSAMPLE
+} from '../../src/main/tabs/tabPreviewGeometry.js'
+
+const VIEWPORT_WIDTH = 1200
+const VIEWPORT_HEIGHT = 800
+
+function createElement(rect, classNames = []) {
+  return {
+    classList: { contains: name => classNames.includes(name) },
+    getBoundingClientRect: () => rect
+  }
+}
+
+function createEnvironment({ tabBar = null, topNav = null, devicePixelRatio = 1 } = {}) {
+  const window = { innerWidth: VIEWPORT_WIDTH, innerHeight: VIEWPORT_HEIGHT, devicePixelRatio }
+  const document = {
+    documentElement: { clientWidth: VIEWPORT_WIDTH, clientHeight: VIEWPORT_HEIGHT },
+    querySelector: selector => {
+      if (selector === '.tabBar') return tabBar
+      if (selector === '.topNav') return topNav
+      return null
+    }
+  }
+  return { window, document }
+}
+
+function createImage(width, height) {
+  return {
+    getSize: () => ({ width, height }),
+    crop: rect => ({ ...rect, cropped: true })
+  }
+}
+
+test('excludes both the horizontal tab bar and the header', () => {
+  const { window, document } = createEnvironment({
+    tabBar: createElement({ left: 0, right: VIEWPORT_WIDTH, top: 0, bottom: 32 }),
+    topNav: createElement({ left: 0, right: VIEWPORT_WIDTH, top: 32, bottom: 92 })
+  })
+
+  assert.deepEqual(measureTabPreviewContentBounds(window, document), {
+    contentTop: 92,
+    contentLeft: 0,
+    contentRight: VIEWPORT_WIDTH,
+    viewportWidth: VIEWPORT_WIDTH,
+    viewportHeight: VIEWPORT_HEIGHT,
+    devicePixelRatio: 1
+  })
+})
+
+test('excludes the vertical tab bar column and the header', () => {
+  const { window, document } = createEnvironment({
+    tabBar: createElement({ left: 0, right: 220, top: 0, bottom: VIEWPORT_HEIGHT }, ['vertical']),
+    topNav: createElement({ left: 220, right: VIEWPORT_WIDTH, top: 0, bottom: 60 })
+  })
+
+  assert.deepEqual(measureTabPreviewContentBounds(window, document), {
+    contentTop: 60,
+    contentLeft: 220,
+    contentRight: VIEWPORT_WIDTH,
+    viewportWidth: VIEWPORT_WIDTH,
+    viewportHeight: VIEWPORT_HEIGHT,
+    devicePixelRatio: 1
+  })
+})
+
+test('crops the inline-end vertical tab bar for right-to-left layouts', () => {
+  const { window, document } = createEnvironment({
+    tabBar: createElement(
+      { left: VIEWPORT_WIDTH - 220, right: VIEWPORT_WIDTH, top: 0, bottom: VIEWPORT_HEIGHT },
+      ['vertical']
+    ),
+    topNav: createElement({ left: 0, right: VIEWPORT_WIDTH - 220, top: 0, bottom: 60 })
+  })
+
+  const bounds = measureTabPreviewContentBounds(window, document)
+  assert.equal(bounds.contentLeft, 0)
+  assert.equal(bounds.contentRight, VIEWPORT_WIDTH - 220)
+  assert.equal(bounds.contentTop, 60)
+})
+
+test('keeps the full viewport when the chrome is missing or collapsed', () => {
+  const hidden = createEnvironment({
+    topNav: createElement({ left: 0, right: 0, top: 0, bottom: 0 })
+  })
+  assert.deepEqual(measureTabPreviewContentBounds(hidden.window, hidden.document), {
+    contentTop: 0,
+    contentLeft: 0,
+    contentRight: VIEWPORT_WIDTH,
+    viewportWidth: VIEWPORT_WIDTH,
+    viewportHeight: VIEWPORT_HEIGHT,
+    devicePixelRatio: 1
+  })
+
+  const empty = createEnvironment()
+  assert.equal(measureTabPreviewContentBounds(empty.window, empty.document).contentTop, 0)
+})
+
+test('crops device pixels using the viewport scale', () => {
+  const image = createImage(VIEWPORT_WIDTH * 2, VIEWPORT_HEIGHT * 2)
+  const cropped = cropTabPreviewToContent(image, {
+    contentTop: 92,
+    contentLeft: 220,
+    contentRight: VIEWPORT_WIDTH,
+    viewportWidth: VIEWPORT_WIDTH,
+    viewportHeight: VIEWPORT_HEIGHT
+  })
+
+  assert.deepEqual(cropped, {
+    x: 440,
+    y: 184,
+    width: VIEWPORT_WIDTH * 2 - 440,
+    height: VIEWPORT_HEIGHT * 2 - 184,
+    cropped: true
+  })
+})
+
+test('returns the original image when there is nothing to crop', () => {
+  const image = createImage(VIEWPORT_WIDTH, VIEWPORT_HEIGHT)
+  const bounds = {
+    contentTop: 0,
+    contentLeft: 0,
+    contentRight: VIEWPORT_WIDTH,
+    viewportWidth: VIEWPORT_WIDTH,
+    viewportHeight: VIEWPORT_HEIGHT
+  }
+
+  assert.equal(cropTabPreviewToContent(image, bounds), image)
+})
+
+test('rejects degenerate crops instead of returning an empty preview', () => {
+  const bounds = {
+    contentTop: VIEWPORT_HEIGHT,
+    contentLeft: 0,
+    contentRight: VIEWPORT_WIDTH,
+    viewportWidth: VIEWPORT_WIDTH,
+    viewportHeight: VIEWPORT_HEIGHT
+  }
+
+  assert.equal(cropTabPreviewToContent(createImage(VIEWPORT_WIDTH, VIEWPORT_HEIGHT), bounds), null)
+  assert.equal(cropTabPreviewToContent(createImage(0, 0), bounds), null)
+})
+
+/**
+ * Bounds reported by a window with the given device pixel ratio.
+ * @param {number} devicePixelRatio
+ */
+function boundsForRatio(devicePixelRatio) {
+  return {
+    contentTop: 92,
+    contentLeft: 0,
+    contentRight: VIEWPORT_WIDTH,
+    viewportWidth: VIEWPORT_WIDTH,
+    viewportHeight: VIEWPORT_HEIGHT,
+    devicePixelRatio
+  }
+}
+
+test('keeps the device pixel ratio so HiDPI previews stay sharp', () => {
+  // NativeImage reports logical pixels, so the same capture arrives at the same
+  // size on a 1x and a 2x display - only the ratio says how much detail is there.
+  const standard = getTabPreviewTargetSize({ width: 1200, height: 600 }, boundsForRatio(1))
+  const hiDpi = getTabPreviewTargetSize({ width: 1200, height: 600 }, boundsForRatio(2))
+
+  assert.equal(standard.width, TAB_PREVIEW_MAX_CSS_WIDTH * TAB_PREVIEW_SUPERSAMPLE)
+  assert.equal(hiDpi.width, TAB_PREVIEW_MAX_CSS_WIDTH * TAB_PREVIEW_MAX_PIXEL_RATIO)
+  assert.ok(hiDpi.height > standard.height)
+})
+
+test('caps the stored pixel ratio so previews stay small', () => {
+  const target = getTabPreviewTargetSize({ width: 4800, height: 2400 }, boundsForRatio(6))
+
+  assert.equal(target.width, TAB_PREVIEW_MAX_CSS_WIDTH * TAB_PREVIEW_MAX_PIXEL_RATIO)
+})
+
+test('leaves captures that already fit untouched', () => {
+  assert.equal(getTabPreviewTargetSize({ width: 320, height: 180 }, boundsForRatio(1)), null)
+  assert.equal(getTabPreviewTargetSize({ width: 0, height: 0 }, boundsForRatio(2)), null)
+})
+
+test('falls back to a single pixel ratio when bounds are unavailable', () => {
+  const target = getTabPreviewTargetSize({ width: 1200, height: 600 }, null)
+
+  assert.equal(target.width, TAB_PREVIEW_MAX_CSS_WIDTH * TAB_PREVIEW_SUPERSAMPLE)
+})
+
+test('stores more pixels than the preview is displayed at', () => {
+  // 1080p content cropped below the chrome, on an unscaled display.
+  const target = getTabPreviewTargetSize({ width: 1920, height: 950 }, boundsForRatio(1))
+  const displayedCssWidth = 322
+
+  assert.ok(target.width >= displayedCssWidth * 2)
+})


### PR DESCRIPTION
## Pull Request Type
<!-- Please select what type of pull request this is: [x] -->
- [x] Bugfix
- [ ] Feature Implementation
- [ ] Documentation
- [ ] Other

## Related issue
<!-- Please link the issue your pull request is referring to. -->
None.

## Description
Tab preview screenshots had two visible bugs, and fixing them exposed that the way previews are stored was wasteful.

1. **The captured region was wrong.** Only the tab bar was cropped off, so every preview kept the 60px top navigation bar in frame. The preview now always shows the app region below the header and beside/below the tab bar. Both the horizontal and the vertical tab bar layouts are handled, including the inline-end column in right-to-left locales.

2. **A tab's preview could end up inside another tab's preview.** The hover tooltip that shows the preview is on screen while the capture runs. It was hidden by CSS class name, and the capture resolved after a single `requestAnimationFrame` — which fires *before* the frame applying that class is painted, so the still-visible tooltip could be photographed. Overlays are now marked with a `data-tab-preview-overlay` attribute (contract instead of class name) and the capture waits two frames.

3. **Previews are stored as JPEG (quality 82) instead of PNG.** A preview is a screenshot viewed at thumbnail size, so lossy compression costs nothing visible, while PNG pays full price for lossless detail nobody can see. Measured on a real cache, entries went from 53-76 KiB to **16 KiB**. Quality 82 is the point where compression artifacts stop being visible at this size. Existing PNG caches stay readable — the data URL type comes from the file's magic bytes — and a legacy `.png` entry is replaced rather than overwritten with JPEG bytes.

4. **Orphaned cache entries are pruned at startup.** Previews were only deleted when a tab closed or the session was cleared, so a crash or a forced quit left files behind with nothing pointing at them; a test machine had accumulated 101 files for a handful of tabs. Entries that no restored session refers to are now deleted before any window exists, which also avoids racing a fresh capture.

The stored size also follows the window's device pixel ratio now. `NativeImage` measures and exports in logical pixels, so on a scaled display a preview was exported at a fraction of the resolution it is drawn with. Unscaled displays are unaffected.

The logic moved out of `TabManager` into two focused modules: `src/main/tabs/tabPreviewGeometry.js` (measuring, cropping, target size) and `src/main/tabs/tabPreviewCache.js` (file naming, encoding, orphan selection). The measuring function is injected into the renderer via `fn.toString()`, which keeps it a plain, unit-testable function instead of a string blob.

## Screenshots <!-- If appropriate -->

## Release note category
<!-- Select exactly one category. Every pull request must select one. -->
<!-- release-note-category:start -->
- [ ] Not noteworthy
- [ ] Highlights
- [ ] More improvements
- [x] Fixed bugs
<!-- release-note-category:end -->

## Release note
<!-- release-note:start -->
Tab previews now show only the page content, no longer capture another tab's preview popup, and take up roughly a third of the disk space they used to, with leftover preview files cleaned up on startup.
<!-- release-note:end -->

## Release note images
<!-- release-note-image:start -->

<!-- release-note-image:end -->

## Testing
Automated:

- `node --test tests/unit/tab-preview-geometry.test.mjs` — 12 tests covering the measured region (horizontal, vertical and RTL tab bars, hidden/absent chrome), the device-pixel crop math, and the stored size (pixel ratio, cap, no-upscale floor, degenerate input).
- `node --test tests/unit/tab-preview-cache.test.mjs` — 9 tests covering file naming, legacy `.png` handling, data URL round trips and type sniffing, and orphan selection (including that unrelated files in the directory are left alone).
- `xvfb-run -a -s "-screen 0 1920x1080x24" pnpm exec playwright test -c e2e/playwright.config.mjs --project=offline tab-preview.spec.mjs --workers=1` — new spec asserting the preview's aspect ratio matches the content region below the header, that the stored image is never smaller than the tooltip draws it, and that overlays compute to `visibility: hidden` under the capture class.
- `tabs.spec.mjs` (39 tests) passes unchanged.

Manual:

1. Open a few tabs, hover one and look at the preview: it starts below the top navigation bar, with no header or tab strip visible.
2. Hover a tab while its own tooltip is open — the preview never contains a picture-in-picture of another preview.
3. Switch the tab bar to vertical in the settings and repeat; the tab column is cropped off the side.
4. Check `<userData>/tab-previews`: entries are `.jpg` and roughly 16 KiB each. Delete the directory first if it still holds `.png` entries from an earlier version.
5. Kill the app (`kill -9`) with several tabs open, remove some tabs from the restored session, restart — the entries those tabs used are gone.

## Desktop
- **OS:** Arch Linux
- **OS Version:** rolling, KDE Plasma (Wayland)
- **OpenTubeX version:** 0.30.2

## Additional context
Measured disk impact per preview, on a real cache:

| | pixels | average file |
| --- | --- | --- |
| before | 360x215 | 53-76 KiB (PNG) |
| after | 360x205 | 16 KiB (JPEG) |

Steady state is one file per open tab, so 20 tabs is roughly 300 KiB.

An intermediate version of this branch stored previews at twice their displayed size, on the theory that letting the browser perform the final downscale preserves more detail than one large reduction by Electron. That was tested side by side and the difference was not visible at preview size, so it was dropped rather than pay four times the pixels for it.

Tabs that have never been presented still fall back to the YouTube `mqdefault.jpg` thumbnail (320x180), which is smaller than the ~322px box it is displayed in. That fallback is untouched here and could be bumped to a larger variant separately.
