### PR TITLE
feat(settings): show translation progress in themed select menus

### DIFF
--- a/_scripts/ProcessLocalesPlugin.js
+++ b/_scripts/ProcessLocalesPlugin.js
@@ -29,6 +29,7 @@ class ProcessLocalesPlugin {
     /** @type {Map<string, any>} */
     this.locales = new Map()
     this.localeNames = []
+    this.localeTranslationPercentages = []
 
     /** @type {Map<string, any>} */
     this.cache = new Map()
@@ -154,6 +155,39 @@ class ProcessLocalesPlugin {
 
       this.localeNames.push(data['Locale Name'] ?? locale)
     }
+
+    const sourceLocale = this.locales.get('en-US')
+    const sourceTranslationCount = this.countTranslations(sourceLocale)
+
+    for (const locale of activeLocales) {
+      const translationCount = this.countTranslations(this.locales.get(locale), sourceLocale)
+      this.localeTranslationPercentages.push(Math.floor(translationCount / sourceTranslationCount * 100))
+    }
+  }
+
+  /**
+   * Count non-empty translation values. When a reference locale is provided, only values
+   * which correspond to a source translation are counted.
+   * @param {object|string} data
+   * @param {object|string|null} reference
+   * @returns {number}
+   */
+  countTranslations(data, reference = null) {
+    if (typeof data !== 'object' || data === null) {
+      return data ? 1 : 0
+    }
+
+    const keys = reference && typeof reference === 'object'
+      ? Object.keys(reference)
+      : Object.keys(data)
+
+    return keys.reduce((count, key) => {
+      if (key === 'Locale Name') {
+        return count
+      }
+
+      return count + this.countTranslations(data[key], reference?.[key] ?? null)
+    }, 0)
   }
 
   async compressLocale(data) {

--- a/_scripts/ProcessLocalesPlugin.js
+++ b/_scripts/ProcessLocalesPlugin.js
@@ -30,6 +30,8 @@ class ProcessLocalesPlugin {
     this.locales = new Map()
     this.localeNames = []
     this.localeTranslationPercentages = []
+    this.localeTranslationKeys = new Map()
+    this.activeLocales = []
 
     /** @type {Map<string, any>} */
     this.cache = new Map()
@@ -38,7 +40,7 @@ class ProcessLocalesPlugin {
     this.previousTimestamps = new Map()
     this.startTime = Date.now()
 
-    /** @type {(updatedLocales: [string, string][]) => void|null} */
+    /** @type {(update: { locales: [string, string][], translationPercentages: number[] }) => void|null} */
     this.notifyLocaleChange = null
 
     this.loadLocales()
@@ -75,7 +77,11 @@ class ProcessLocalesPlugin {
         await Promise.all(promises)
 
         if (this.hotReload && this.notifyLocaleChange && updatedLocales.length > 0) {
-          this.notifyLocaleChange(updatedLocales)
+          this.updateTranslationPercentages()
+          this.notifyLocaleChange({
+            locales: updatedLocales,
+            translationPercentages: this.localeTranslationPercentages
+          })
         }
       })
     })
@@ -114,6 +120,7 @@ class ProcessLocalesPlugin {
     }
 
     this.removeEmptyValues(data)
+    this.localeTranslationKeys.set(locale, this.getTranslationKeys(data))
 
     let filename = `${this.outputDir}/${locale}.json`
     let output = JSON.stringify(data)
@@ -142,9 +149,9 @@ class ProcessLocalesPlugin {
   }
 
   loadLocales() {
-    const activeLocales = JSON.parse(readFileSync(`${this.inputDir}/activeLocales.json`))
+    this.activeLocales = JSON.parse(readFileSync(`${this.inputDir}/activeLocales.json`))
 
-    for (const locale of activeLocales) {
+    for (const locale of this.activeLocales) {
       const filePath = join(this.inputDir, `${locale}.yaml`)
 
       this.filePaths.push(filePath)
@@ -152,42 +159,54 @@ class ProcessLocalesPlugin {
       const contents = readFileSync(filePath, 'utf-8')
       const data = loadYaml(contents)
       this.locales.set(locale, data)
+      this.localeTranslationKeys.set(locale, this.getTranslationKeys(data))
 
       this.localeNames.push(data['Locale Name'] ?? locale)
     }
 
-    const sourceLocale = this.locales.get('en-US')
-    const sourceTranslationCount = this.countTranslations(sourceLocale)
-
-    for (const locale of activeLocales) {
-      const translationCount = this.countTranslations(this.locales.get(locale), sourceLocale)
-      this.localeTranslationPercentages.push(Math.floor(translationCount / sourceTranslationCount * 100))
-    }
+    this.updateTranslationPercentages()
   }
 
   /**
-   * Count non-empty translation values. When a reference locale is provided, only values
-   * which correspond to a source translation are counted.
    * @param {object|string} data
-   * @param {object|string|null} reference
-   * @returns {number}
+   * @param {string[]} path
+   * @param {Set<string>} keys
+   * @returns {Set<string>}
    */
-  countTranslations(data, reference = null) {
+  getTranslationKeys(data, path = [], keys = new Set()) {
     if (typeof data !== 'object' || data === null) {
-      return data ? 1 : 0
+      if (data) {
+        keys.add(path.join('\0'))
+      }
+      return keys
     }
 
-    const keys = reference && typeof reference === 'object'
-      ? Object.keys(reference)
-      : Object.keys(data)
-
-    return keys.reduce((count, key) => {
-      if (key === 'Locale Name') {
-        return count
+    for (const key of Object.keys(data)) {
+      if (path.length === 0 && key === 'Locale Name') {
+        continue
       }
 
-      return count + this.countTranslations(data[key], reference?.[key] ?? null)
-    }, 0)
+      this.getTranslationKeys(data[key], [...path, key], keys)
+    }
+
+    return keys
+  }
+
+  updateTranslationPercentages() {
+    const sourceKeys = this.localeTranslationKeys.get('en-US')
+
+    this.localeTranslationPercentages = this.activeLocales.map((locale) => {
+      const translatedKeys = this.localeTranslationKeys.get(locale)
+      let translationCount = 0
+
+      for (const key of sourceKeys) {
+        if (translatedKeys.has(key)) {
+          translationCount += 1
+        }
+      }
+
+      return Math.floor(translationCount / sourceKeys.size * 100)
+    })
   }
 
   async compressLocale(data) {

--- a/_scripts/dev-runner.js
+++ b/_scripts/dev-runner.js
@@ -127,8 +127,8 @@ function scheduleElectronRestart() {
  * @param {WebpackDevServer} devServer
  */
 function setupNotifyLocaleUpdate(compiler, devServer) {
-  const notifyLocaleChange = (updatedLocales) => {
-    devServer.sendMessage(devServer.webSocketServer.clients, 'freetube-locale-update', updatedLocales)
+  const notifyLocaleChange = (update) => {
+    devServer.sendMessage(devServer.webSocketServer.clients, 'freetube-locale-update', update)
   }
 
   compiler.options.plugins

--- a/_scripts/webpack.renderer.config.js
+++ b/_scripts/webpack.renderer.config.js
@@ -154,6 +154,7 @@ const config = {
       __VUE_I18N_FULL_INSTALL__: 'false',
       __INTLIFY_PROD_DEVTOOLS__: 'false',
       'process.env.LOCALE_NAMES': JSON.stringify(processLocalesPlugin.localeNames),
+      'process.env.LOCALE_TRANSLATION_PERCENTAGES': JSON.stringify(processLocalesPlugin.localeTranslationPercentages),
       'process.env.GEOLOCATION_NAMES': JSON.stringify(readdirSync(path.join(__dirname, '..', 'static', 'geolocations')).map(filename => filename.replace('.json', ''))),
       'process.env.SWIPER_VERSION': `'${swiperVersion}'`,
       'process.env.SHAKA_LOCALE_MAPPINGS': JSON.stringify(SHAKA_LOCALE_MAPPINGS),

--- a/_scripts/webpack.web.config.js
+++ b/_scripts/webpack.web.config.js
@@ -201,6 +201,7 @@ config.plugins.push(
   processLocalesPlugin,
   new webpack.DefinePlugin({
     'process.env.LOCALE_NAMES': JSON.stringify(processLocalesPlugin.localeNames),
+    'process.env.LOCALE_TRANSLATION_PERCENTAGES': JSON.stringify(processLocalesPlugin.localeTranslationPercentages),
     'process.env.GEOLOCATION_NAMES': JSON.stringify(fs.readdirSync(path.join(__dirname, '..', 'static', 'geolocations')).map(filename => filename.replace('.json', ''))),
     'process.env.SHAKA_LOCALE_MAPPINGS': JSON.stringify(SHAKA_LOCALE_MAPPINGS),
     'process.env.SHAKA_LOCALES_PREBUNDLED': JSON.stringify(SHAKA_LOCALES_PREBUNDLED)

--- a/e2e/tests/offline/settings.spec.mjs
+++ b/e2e/tests/offline/settings.spec.mjs
@@ -50,6 +50,24 @@ test.describe('settings', () => {
     await expect(page.locator('.settingsMenu, .ftSettingsMenu, [class*="settings"]').first()).toBeVisible()
   })
 
+  test('select dropdowns use overlay scrollbars', async ({ page }) => {
+    await goTo(page, 'settings')
+
+    const combobox = page.getByRole('combobox', { name: /Language preference|Locale Preference/ })
+    await combobox.click()
+
+    const dropdown = page.locator('.selectDropdown')
+    await expect(dropdown).toBeVisible()
+    await expect(dropdown).toContainText('English (US) (100%)')
+    await expect(dropdown.locator('.os-scrollbar-vertical')).toHaveCount(1)
+    await expect(dropdown).toHaveCSS('scrollbar-width', 'none')
+
+    await combobox.press('ArrowDown')
+    await combobox.press('Enter')
+    await expect(combobox).toContainText('English (US) (100%)')
+    await expect(dropdown).toHaveCount(0)
+  })
+
   test('retains the mounted page when switching to About and back', async ({ page }) => {
     await goTo(page, 'settings')
     const settingsPage = page.locator('.settingsPage')

--- a/e2e/tests/offline/settings.spec.mjs
+++ b/e2e/tests/offline/settings.spec.mjs
@@ -78,13 +78,32 @@ test.describe('settings', () => {
     })
 
     expect(appearance.fontFamily).toContain('Roboto')
-    expect(appearance.cursor).not.toBe('pointer')
+    expect(appearance.cursor).toBe('default')
     expect(appearance.menuTop).toBeGreaterThanOrEqual(appearance.chromeBottom)
 
+    const scrollbarHandle = dropdown.locator('.os-scrollbar-vertical .os-scrollbar-handle')
+    const handleBounds = await scrollbarHandle.boundingBox()
+    await page.mouse.move(
+      handleBounds.x + handleBounds.width / 2,
+      handleBounds.y + handleBounds.height / 2
+    )
+    await page.mouse.down()
+    await page.mouse.move(
+      handleBounds.x + handleBounds.width / 2,
+      handleBounds.y + handleBounds.height / 2 + 30
+    )
+    await expect(dropdown).toBeVisible()
+    await page.mouse.up()
+
+    await combobox.press('Home')
     await combobox.press('ArrowDown')
     await combobox.press('Enter')
     await expect(combobox).toContainText('English (US) (100%)')
     await expect(dropdown).toHaveCount(0)
+
+    await page.getByRole('combobox', { name: 'Preferred API backend' }).click()
+    await expect(dropdown).toBeVisible()
+    expect(await dropdown.evaluate(menu => menu.scrollHeight <= menu.clientHeight)).toBe(true)
   })
 
   test('retains the mounted page when switching to About and back', async ({ page }) => {

--- a/e2e/tests/offline/settings.spec.mjs
+++ b/e2e/tests/offline/settings.spec.mjs
@@ -62,6 +62,25 @@ test.describe('settings', () => {
     await expect(dropdown.locator('.os-scrollbar-vertical')).toHaveCount(1)
     await expect(dropdown).toHaveCSS('scrollbar-width', 'none')
 
+    const appearance = await dropdown.evaluate((menu) => {
+      const menuStyle = getComputedStyle(menu)
+      const chromeBottom = Math.max(
+        ...Array.from(document.querySelectorAll('.topNav, .tabBar:not(.vertical)'))
+          .map(element => element.getBoundingClientRect().bottom)
+      )
+
+      return {
+        chromeBottom,
+        cursor: getComputedStyle(menu.querySelector('.selectOption')).cursor,
+        fontFamily: menuStyle.fontFamily,
+        menuTop: menu.getBoundingClientRect().top
+      }
+    })
+
+    expect(appearance.fontFamily).toContain('Roboto')
+    expect(appearance.cursor).not.toBe('pointer')
+    expect(appearance.menuTop).toBeGreaterThanOrEqual(appearance.chromeBottom)
+
     await combobox.press('ArrowDown')
     await combobox.press('Enter')
     await expect(combobox).toContainText('English (US) (100%)')

--- a/src/renderer/components/FtSelect/FtSelect.css
+++ b/src/renderer/components/FtSelect/FtSelect.css
@@ -75,7 +75,7 @@
 
 .selectDropdown {
   position: fixed;
-  z-index: 1000;
+  z-index: 6;
   box-sizing: border-box;
   overflow-y: auto;
   padding-block: 4px;
@@ -96,8 +96,10 @@
   min-block-size: 34px;
   padding-block: 7px;
   padding-inline: 16px;
+  cursor: default;
   overflow: hidden;
   text-overflow: ellipsis;
+  user-select: none;
   white-space: nowrap;
 }
 

--- a/src/renderer/components/FtSelect/FtSelect.css
+++ b/src/renderer/components/FtSelect/FtSelect.css
@@ -42,11 +42,17 @@
   font-size: 16px;
   border-radius: calc(5px * var(--ui-roundness));
   border: 0;
+  cursor: pointer;
+  text-align: start;
 }
 
-.select option {
-  color: var(--secondary-text-color);
-  background-color: var(--card-bg-color);
+.nativeSelect {
+  position: absolute;
+  inset: 0;
+  inline-size: 100%;
+  block-size: 45px;
+  opacity: 0;
+  pointer-events: none;
 }
 
 /* stylelint-disable-next-line a11y/no-outline-none */
@@ -59,6 +65,49 @@
   appearance: none;
   text-overflow: ellipsis;
   padding-inline-end: 1.5rem;
+}
+
+.selectedValue {
+  display: block;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.selectDropdown {
+  position: fixed;
+  z-index: 10000;
+  box-sizing: border-box;
+  overflow-y: auto;
+  padding-block: 4px;
+  padding-inline: 0;
+  margin: 0;
+  list-style: none;
+  color: var(--secondary-text-color);
+  background-color: var(--card-bg-color);
+  border: 1px solid var(--tertiary-text-color);
+  border-radius: calc(5px * var(--ui-roundness));
+  box-shadow: 0 2px 8px rgb(0 0 0 / 35%);
+}
+
+.selectOption {
+  box-sizing: border-box;
+  min-block-size: 34px;
+  padding-block: 7px;
+  padding-inline: 16px;
+  cursor: pointer;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.selectOption.active {
+  color: var(--side-nav-hover-text-color);
+  background-color: var(--side-nav-hover-color);
+}
+
+.selectOption.selected {
+  box-shadow: inset 3px 0 var(--accent-color);
 }
 
 .iconSelect {
@@ -138,9 +187,7 @@
 }
 
 /* active state */
-.select-text:focus ~ .select-label,
-.select-text:valid ~ .select-label,
-.select-text:disabled ~ .select-label {
+.select-text ~ .select-label {
   color: var(--accent-color);
   inset-block-start: -20px;
   transition: 0.2s ease all;

--- a/src/renderer/components/FtSelect/FtSelect.css
+++ b/src/renderer/components/FtSelect/FtSelect.css
@@ -42,7 +42,6 @@
   font-size: 16px;
   border-radius: calc(5px * var(--ui-roundness));
   border: 0;
-  cursor: pointer;
   text-align: start;
 }
 
@@ -76,13 +75,15 @@
 
 .selectDropdown {
   position: fixed;
-  z-index: 10000;
+  z-index: 1000;
   box-sizing: border-box;
   overflow-y: auto;
   padding-block: 4px;
   padding-inline: 0;
   margin: 0;
   list-style: none;
+  font-family: Roboto, sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol', 'Noto Color Emoji';
+  font-size: 16px;
   color: var(--secondary-text-color);
   background-color: var(--card-bg-color);
   border: 1px solid var(--tertiary-text-color);
@@ -95,7 +96,6 @@
   min-block-size: 34px;
   padding-block: 7px;
   padding-inline: 16px;
-  cursor: pointer;
   overflow: hidden;
   text-overflow: ellipsis;
   white-space: nowrap;

--- a/src/renderer/components/FtSelect/FtSelect.vue
+++ b/src/renderer/components/FtSelect/FtSelect.vue
@@ -245,27 +245,54 @@ function closeDropdown() {
 
 function updateDropdownPosition() {
   const button = selectButton.value
-  if (button === null) {
+  const menu = dropdown.value
+  if (button === null || menu === null) {
     return
   }
 
   const viewportMargin = 8
   const menuGap = 4
   const maximumHeight = 400
+  const minimumTop = Math.max(viewportMargin, getTopChromeBottom() + menuGap)
+  const maximumBottom = window.innerHeight - viewportMargin
   const buttonRect = button.getBoundingClientRect()
-  const spaceBelow = window.innerHeight - buttonRect.bottom - menuGap - viewportMargin
-  const spaceAbove = buttonRect.top - menuGap - viewportMargin
-  const openAbove = spaceBelow < 200 && spaceAbove > spaceBelow
+  const spaceBelow = Math.max(0, maximumBottom - buttonRect.bottom - menuGap)
+  const spaceAbove = Math.max(0, buttonRect.top - menuGap - minimumTop)
+  const desiredHeight = Math.min(maximumHeight, menu.scrollHeight)
+  const openAbove = desiredHeight > spaceBelow && spaceAbove > spaceBelow
   const availableHeight = Math.max(0, openAbove ? spaceAbove : spaceBelow)
+  const menuHeight = Math.min(desiredHeight, availableHeight)
+  const menuWidth = Math.min(buttonRect.width, window.innerWidth - viewportMargin * 2)
+  const left = Math.max(
+    viewportMargin,
+    Math.min(buttonRect.left, window.innerWidth - viewportMargin - menuWidth)
+  )
+  const top = openAbove
+    ? Math.max(minimumTop, buttonRect.top - menuGap - menuHeight)
+    : Math.min(buttonRect.bottom + menuGap, maximumBottom - menuHeight)
 
   dropdownStyle.value = {
-    inlineSize: `${buttonRect.width}px`,
-    left: `${Math.max(viewportMargin, Math.min(buttonRect.left, window.innerWidth - viewportMargin - buttonRect.width))}px`,
-    maxBlockSize: `${Math.min(maximumHeight, availableHeight)}px`,
-    ...(openAbove
-      ? { bottom: `${window.innerHeight - buttonRect.top + menuGap}px` }
-      : { top: `${buttonRect.bottom + menuGap}px` })
+    inlineSize: `${menuWidth}px`,
+    left: `${left}px`,
+    top: `${top}px`,
+    maxBlockSize: `${menuHeight}px`
   }
+}
+
+function getTopChromeBottom() {
+  if (document.fullscreenElement !== null) {
+    return 0
+  }
+
+  let bottom = 0
+  for (const selector of ['.topNav', '.tabBar:not(.vertical)']) {
+    const element = document.querySelector(selector)
+    if (element !== null) {
+      bottom = Math.max(bottom, element.getBoundingClientRect().bottom)
+    }
+  }
+
+  return bottom
 }
 
 function moveActiveIndex(offset) {

--- a/src/renderer/components/FtSelect/FtSelect.vue
+++ b/src/renderer/components/FtSelect/FtSelect.vue
@@ -97,6 +97,7 @@
         role="listbox"
         :aria-labelledby="`${id}-label`"
         :style="dropdownStyle"
+        @pointerdown="handleDropdownPointerDown"
       >
         <li
           v-for="(name, index) in selectNames"
@@ -193,6 +194,7 @@ const activeIndex = ref(0)
 const dropdownStyle = ref({})
 let typeahead = ''
 let typeaheadTimer = null
+let pointerDownInDropdown = false
 
 const selectedIndex = computed(() => props.selectValues.indexOf(props.value))
 const selectedName = computed(() => props.selectNames[selectedIndex.value] ?? '')
@@ -258,7 +260,8 @@ function updateDropdownPosition() {
   const buttonRect = button.getBoundingClientRect()
   const spaceBelow = Math.max(0, maximumBottom - buttonRect.bottom - menuGap)
   const spaceAbove = Math.max(0, buttonRect.top - menuGap - minimumTop)
-  const desiredHeight = Math.min(maximumHeight, menu.scrollHeight)
+  const naturalHeight = menu.scrollHeight + menu.offsetHeight - menu.clientHeight
+  const desiredHeight = Math.min(maximumHeight, naturalHeight)
   const openAbove = desiredHeight > spaceBelow && spaceAbove > spaceBelow
   const availableHeight = Math.max(0, openAbove ? spaceAbove : spaceBelow)
   const menuHeight = Math.min(desiredHeight, availableHeight)
@@ -269,13 +272,16 @@ function updateDropdownPosition() {
   )
   const top = openAbove
     ? Math.max(minimumTop, buttonRect.top - menuGap - menuHeight)
-    : Math.min(buttonRect.bottom + menuGap, maximumBottom - menuHeight)
+    : Math.max(
+        minimumTop,
+        Math.min(buttonRect.bottom + menuGap, maximumBottom - menuHeight)
+      )
 
   dropdownStyle.value = {
     inlineSize: `${menuWidth}px`,
     left: `${left}px`,
     top: `${top}px`,
-    maxBlockSize: `${menuHeight}px`
+    maxBlockSize: naturalHeight > menuHeight ? `${menuHeight}px` : null
   }
 }
 
@@ -406,9 +412,25 @@ function handleOutsidePointerDown(event) {
 }
 
 function handleFocusOut(event) {
-  if (!(event.relatedTarget instanceof Node) || !selectRoot.value?.contains(event.relatedTarget)) {
+  if (pointerDownInDropdown) {
+    return
+  }
+
+  const nextTarget = event.relatedTarget
+  const focusStaysInControl = nextTarget instanceof Node && (
+    selectRoot.value?.contains(nextTarget) || dropdown.value?.contains(nextTarget)
+  )
+
+  if (!focusStaysInControl) {
     closeDropdown()
   }
+}
+
+function handleDropdownPointerDown() {
+  pointerDownInDropdown = true
+  setTimeout(() => {
+    pointerDownInDropdown = false
+  }, 0)
 }
 
 function removeDropdownListeners() {

--- a/src/renderer/components/FtSelect/FtSelect.vue
+++ b/src/renderer/components/FtSelect/FtSelect.vue
@@ -1,16 +1,20 @@
 <template>
   <div
+    ref="selectRoot"
     class="select"
-    :class="{ containsTooltip: tooltip !== '' }"
+    :class="{ containsTooltip: tooltip !== '', open: dropdownShown }"
+    @focusout="handleFocusOut"
   >
     <select
-      :id="id"
+      :id="`${id}-native`"
       :aria-describedby="describeById"
-      class="select-text"
-      :class="{ disabled }"
+      aria-hidden="true"
+      class="nativeSelect"
       :value="value"
       :name="id"
       :disabled="disabled"
+      inert
+      tabindex="-1"
       @change="change"
     >
       <option
@@ -23,6 +27,26 @@
         {{ name }}
       </option>
     </select>
+    <button
+      :id="id"
+      ref="selectButton"
+      type="button"
+      role="combobox"
+      aria-haspopup="listbox"
+      class="select-text"
+      :class="{ disabled }"
+      :aria-controls="`${id}-listbox`"
+      :aria-describedby="describeById"
+      :aria-expanded="dropdownShown"
+      :aria-activedescendant="dropdownShown ? `${id}-option-${activeIndex}` : null"
+      :disabled="disabled"
+      :dir="isLocaleSelector ? 'auto' : null"
+      :lang="selectedLocale"
+      @click="toggleDropdown"
+      @keydown="handleButtonKeydown"
+    >
+      <span class="selectedValue">{{ selectedName }}</span>
+    </button>
     <FontAwesomeIcon
       :icon="['fas', 'angle-down']"
       class="iconSelect"
@@ -30,6 +54,7 @@
     <span class="select-highlight" />
     <span class="select-bar" />
     <label
+      :id="`${id}-label`"
       class="select-label"
       :for="id"
     >
@@ -62,17 +87,49 @@
         @reset="emit('reset')"
       />
     </span>
+    <Teleport to="body">
+      <ul
+        v-if="dropdownShown"
+        :id="`${id}-listbox`"
+        ref="dropdown"
+        v-overlay-scrollbars
+        class="selectDropdown"
+        role="listbox"
+        :aria-labelledby="`${id}-label`"
+        :style="dropdownStyle"
+      >
+        <li
+          v-for="(name, index) in selectNames"
+          :id="`${id}-option-${index}`"
+          :key="selectValues[index]"
+          ref="options"
+          class="selectOption"
+          :class="{ active: index === activeIndex, selected: selectValues[index] === value }"
+          role="option"
+          tabindex="-1"
+          :aria-selected="selectValues[index] === value"
+          :dir="isLocaleSelector ? 'auto' : null"
+          :lang="isLocaleSelector && selectValues[index] !== 'system' && selectValues[index] !== '' ? selectValues[index] : null"
+          @mousedown.prevent
+          @pointermove="activeIndex = index"
+          @click="selectOption(index)"
+          @keydown.enter.space.prevent="selectOption(index)"
+        >
+          {{ name }}
+        </li>
+      </ul>
+    </Teleport>
   </div>
 </template>
 
 <script setup>
 import { FontAwesomeIcon } from '@fortawesome/vue-fontawesome'
-import { useId } from 'vue'
+import { computed, nextTick, onBeforeUnmount, ref, useId, useTemplateRef, watch } from 'vue'
 
 import FtTooltip from '../FtTooltip/FtTooltip.vue'
 import FtSyncedSettingIndicator from '../FtSyncedSettingIndicator/FtSyncedSettingIndicator.vue'
 
-defineProps({
+const props = defineProps({
   placeholder: {
     type: String,
     required: true
@@ -126,6 +183,212 @@ defineProps({
 const emit = defineEmits(['change', 'reset'])
 
 const id = useId()
+const selectRoot = useTemplateRef('selectRoot')
+const selectButton = useTemplateRef('selectButton')
+const dropdown = useTemplateRef('dropdown')
+const options = useTemplateRef('options')
+
+const dropdownShown = ref(false)
+const activeIndex = ref(0)
+const dropdownStyle = ref({})
+let typeahead = ''
+let typeaheadTimer = null
+
+const selectedIndex = computed(() => props.selectValues.indexOf(props.value))
+const selectedName = computed(() => props.selectNames[selectedIndex.value] ?? '')
+const selectedLocale = computed(() => {
+  if (!props.isLocaleSelector || props.value === 'system' || props.value === '') {
+    return null
+  }
+
+  return props.value
+})
+
+watch(dropdownShown, (shown) => {
+  if (shown) {
+    document.addEventListener('pointerdown', handleOutsidePointerDown, true)
+    window.addEventListener('resize', updateDropdownPosition)
+    window.addEventListener('scroll', updateDropdownPosition, true)
+  } else {
+    removeDropdownListeners()
+  }
+})
+
+onBeforeUnmount(() => {
+  removeDropdownListeners()
+  if (typeaheadTimer !== null) {
+    clearTimeout(typeaheadTimer)
+  }
+})
+
+function toggleDropdown() {
+  if (dropdownShown.value) {
+    closeDropdown()
+  } else {
+    openDropdown()
+  }
+}
+
+function openDropdown() {
+  activeIndex.value = Math.max(0, selectedIndex.value)
+  dropdownShown.value = true
+
+  nextTick(() => {
+    updateDropdownPosition()
+    scrollActiveOptionIntoView()
+  })
+}
+
+function closeDropdown() {
+  dropdownShown.value = false
+}
+
+function updateDropdownPosition() {
+  const button = selectButton.value
+  if (button === null) {
+    return
+  }
+
+  const viewportMargin = 8
+  const menuGap = 4
+  const maximumHeight = 400
+  const buttonRect = button.getBoundingClientRect()
+  const spaceBelow = window.innerHeight - buttonRect.bottom - menuGap - viewportMargin
+  const spaceAbove = buttonRect.top - menuGap - viewportMargin
+  const openAbove = spaceBelow < 200 && spaceAbove > spaceBelow
+  const availableHeight = Math.max(0, openAbove ? spaceAbove : spaceBelow)
+
+  dropdownStyle.value = {
+    inlineSize: `${buttonRect.width}px`,
+    left: `${Math.max(viewportMargin, Math.min(buttonRect.left, window.innerWidth - viewportMargin - buttonRect.width))}px`,
+    maxBlockSize: `${Math.min(maximumHeight, availableHeight)}px`,
+    ...(openAbove
+      ? { bottom: `${window.innerHeight - buttonRect.top + menuGap}px` }
+      : { top: `${buttonRect.bottom + menuGap}px` })
+  }
+}
+
+function moveActiveIndex(offset) {
+  activeIndex.value = Math.max(0, Math.min(props.selectValues.length - 1, activeIndex.value + offset))
+  scrollActiveOptionIntoView()
+}
+
+function scrollActiveOptionIntoView() {
+  nextTick(() => options.value?.[activeIndex.value]?.scrollIntoView({ block: 'nearest' }))
+}
+
+/**
+ * @param {KeyboardEvent} event
+ */
+function handleButtonKeydown(event) {
+  if (event.key === 'ArrowDown' || event.key === 'ArrowUp') {
+    event.preventDefault()
+    if (!dropdownShown.value) {
+      openDropdown()
+    } else {
+      moveActiveIndex(event.key === 'ArrowDown' ? 1 : -1)
+    }
+    return
+  }
+
+  if (event.key === 'Home' || event.key === 'End') {
+    event.preventDefault()
+    if (!dropdownShown.value) {
+      openDropdown()
+    }
+    activeIndex.value = event.key === 'Home' ? 0 : props.selectValues.length - 1
+    scrollActiveOptionIntoView()
+    return
+  }
+
+  if (event.key === 'PageDown' || event.key === 'PageUp') {
+    event.preventDefault()
+    if (!dropdownShown.value) {
+      openDropdown()
+    } else {
+      moveActiveIndex(event.key === 'PageDown' ? 10 : -10)
+    }
+    return
+  }
+
+  if (event.key === 'Enter' || event.key === ' ') {
+    event.preventDefault()
+    if (dropdownShown.value) {
+      selectOption(activeIndex.value)
+    } else {
+      openDropdown()
+    }
+    return
+  }
+
+  if (event.key === 'Escape' && dropdownShown.value) {
+    event.preventDefault()
+    closeDropdown()
+    return
+  }
+
+  if (event.key === 'Tab') {
+    closeDropdown()
+    return
+  }
+
+  if (event.key.length === 1 && !event.ctrlKey && !event.metaKey && !event.altKey) {
+    handleTypeahead(event.key)
+  }
+}
+
+function handleTypeahead(character) {
+  typeahead += character.toLocaleLowerCase()
+  if (typeaheadTimer !== null) {
+    clearTimeout(typeaheadTimer)
+  }
+  typeaheadTimer = setTimeout(() => {
+    typeahead = ''
+    typeaheadTimer = null
+  }, 700)
+
+  const match = props.selectNames.findIndex(name => name.toLocaleLowerCase().startsWith(typeahead))
+  if (match === -1) {
+    return
+  }
+
+  if (dropdownShown.value) {
+    activeIndex.value = match
+    scrollActiveOptionIntoView()
+  } else {
+    selectOption(match)
+  }
+}
+
+function selectOption(index) {
+  const selectedValue = props.selectValues[index]
+  if (selectedValue !== props.value) {
+    emit('change', selectedValue)
+  }
+  closeDropdown()
+  selectButton.value?.focus()
+}
+
+function handleOutsidePointerDown(event) {
+  const target = event.target
+  if (target instanceof Node && (selectRoot.value?.contains(target) || dropdown.value?.contains(target))) {
+    return
+  }
+
+  closeDropdown()
+}
+
+function handleFocusOut(event) {
+  if (!(event.relatedTarget instanceof Node) || !selectRoot.value?.contains(event.relatedTarget)) {
+    closeDropdown()
+  }
+}
+
+function removeDropdownListeners() {
+  document.removeEventListener('pointerdown', handleOutsidePointerDown, true)
+  window.removeEventListener('resize', updateDropdownPosition)
+  window.removeEventListener('scroll', updateDropdownPosition, true)
+}
 
 /**
  * @param {Event} event

--- a/src/renderer/components/GeneralSettings/GeneralSettings.vue
+++ b/src/renderer/components/GeneralSettings/GeneralSettings.vue
@@ -568,7 +568,7 @@ const LOCALE_VALUES = ['system', ...allLocales]
 
 const localeNames = computed(() => [
   t('Settings.General Settings.System Default'),
-  ...process.env.LOCALE_NAMES
+  ...process.env.LOCALE_NAMES.map((name, index) => `${name} (${process.env.LOCALE_TRANSLATION_PERCENTAGES[index]}%)`)
 ])
 
 /** @type {import('vue').ComputedRef<string>} */

--- a/src/renderer/components/GeneralSettings/GeneralSettings.vue
+++ b/src/renderer/components/GeneralSettings/GeneralSettings.vue
@@ -263,6 +263,7 @@ import FtFlexBox from '../ft-flex-box/ft-flex-box.vue'
 import FtButton from '../FtButton/FtButton.vue'
 
 import store from '../../store/index'
+import { localeTranslationPercentages } from '../../i18n/index'
 
 import allLocales from '../../../../static/locales/activeLocales.json'
 import { debounce, randomArrayItem, showToast } from '../../helpers/utils'
@@ -568,7 +569,7 @@ const LOCALE_VALUES = ['system', ...allLocales]
 
 const localeNames = computed(() => [
   t('Settings.General Settings.System Default'),
-  ...process.env.LOCALE_NAMES.map((name, index) => `${name} (${process.env.LOCALE_TRANSLATION_PERCENTAGES[index]}%)`)
+  ...process.env.LOCALE_NAMES.map((name, index) => `${name} (${localeTranslationPercentages.value[index]}%)`)
 ])
 
 /** @type {import('vue').ComputedRef<string>} */

--- a/src/renderer/i18n/index.js
+++ b/src/renderer/i18n/index.js
@@ -1,7 +1,10 @@
 import { createI18n } from 'vue-i18n'
+import { ref } from 'vue'
 import { createWebURL } from '../helpers/utils'
 // List of locales approved for use
 import activeLocales from '../../../static/locales/activeLocales.json'
+
+export const localeTranslationPercentages = ref(process.env.LOCALE_TRANSLATION_PERCENTAGES)
 
 const i18n = createI18n({
   locale: 'en-US',
@@ -57,7 +60,9 @@ if (process.env.HOT_RELOAD_LOCALES) {
     const message = JSON.parse(event.data)
 
     if (message.type === 'freetube-locale-update') {
-      for (const [locale, data] of message.data) {
+      localeTranslationPercentages.value = message.data.translationPercentages
+
+      for (const [locale, data] of message.data.locales) {
         // Only update locale data if it was already loaded
         if (i18n.global.availableLocales.includes(locale) &&
           Object.keys(i18n.global.messages.value[locale]).length > 0) {


### PR DESCRIPTION
## Pull Request Type
- [ ] Bugfix
- [x] Feature Implementation
- [ ] Documentation
- [ ] Other

## Related issue
Resolves #420.

## Description
Calculates each locale’s translation completion percentage against the English source locale during the build and displays it beside the language name in General Settings.

Select menus now use the app’s themed OverlayScrollbars instead of Chromium’s native popup scrollbar. The shared `FtSelect` control retains keyboard navigation, typeahead, RTL locale direction, disabled states, and an inert native form control for compatibility.

Locale hot reloads also recalculate and send updated percentages without performing translation counting in the renderer.

## Screenshots
Not included.

## Release note category
<!-- release-note-category:start -->
- [ ] Not noteworthy
- [ ] Highlights
- [x] More improvements
- [ ] Fixed bugs
<!-- release-note-category:end -->

## Release note
<!-- release-note:start -->
Show translation completion percentages and theme select menus.
<!-- release-note:end -->

## Release note images
<!-- release-note-image:start -->
<img width="362" height="444" alt="image" src="https://github.com/user-attachments/assets/49a4f244-20bf-4b64-afa4-7102cd3d5888" />
<!-- release-note-image:end -->

## Testing
- `pnpm test:unit` — 204 passed.
- Focused ESLint and stylelint — passed.
- `pnpm test:e2e:pack` — passed.
- Settings E2E suite under Xvfb — 31 passed before adding the focused regression.
- Overlay scrollbar and native-select compatibility E2E tests under Xvfb — 2 passed.

## Desktop
- **OS:** Arch Linux
- **OS Version:** Rolling release
- **OpenTubeX version:** 0.30.2

## Additional context
Translation percentages are generated by `ProcessLocalesPlugin` during builds and locale hot-reload rebuilds; the renderer only displays the injected or updated values.