### PR TITLE
feat(subscriptions): merge the title and tab bars when they fit

### DIFF
--- a/e2e/tests/offline/subscriptions-header-layout.spec.mjs
+++ b/e2e/tests/offline/subscriptions-header-layout.spec.mjs
@@ -13,7 +13,9 @@ const videos = Array.from({ length: 5 }, (_, index) => ({
   lengthSeconds: 120,
   liveNow: false,
   isUpcoming: false,
-  type: 'video'
+  type: 'video',
+  // So that the header also carries the Mark all as seen button
+  isNewInSubscriptionFeed: true
 }))
 
 test.use({
@@ -21,7 +23,8 @@ test.use({
     settings: {
       fetchSubscriptionsAutomatically: false,
       hideSubscriptionsVideos: false,
-      hideSubscriptionsShorts: false
+      hideSubscriptionsShorts: false,
+      showNewSubscriptionFeedIndicators: true
     },
     profiles: [
       {
@@ -118,6 +121,36 @@ test.describe('subscriptions header layout', () => {
 
     expect(new Set(heights).size).toBe(1)
     await expect(page.locator('.subscriptionsHeader')).toHaveClass(/singleRow/)
+  })
+
+  test('merges the rows when the Mark all as seen button is what did not fit', async ({ app, page }) => {
+    await goTo(page, 'subscriptions')
+
+    const header = page.locator('.subscriptionsHeader')
+    const markAllSeen = page.locator('.markAllSeenButton')
+    await expect(markAllSeen).toBeVisible()
+
+    // Narrow the window step by step until the button is what pushes the tabs
+    // onto their own line
+    let width = 1920
+    while (width > 900) {
+      width -= 20
+      await setWindowWidth(app, width)
+
+      if (!await header.evaluate(element => element.classList.contains('singleRow'))) {
+        break
+      }
+    }
+
+    await expect(header).not.toHaveClass(/singleRow/)
+
+    // Removing the button frees far more space than the last step took away, so
+    // the tabs fit next to the title again. The button leaves without resizing
+    // the tabs row, which keeps its full width while it has its own line.
+    await markAllSeen.click()
+    await expect(markAllSeen).toBeHidden()
+
+    await expect(header).toHaveClass(/singleRow/)
   })
 
   test('saves vertical space compared to the two line layout', async ({ app, page }) => {

--- a/e2e/tests/offline/subscriptions-header-layout.spec.mjs
+++ b/e2e/tests/offline/subscriptions-header-layout.spec.mjs
@@ -45,12 +45,24 @@ test.use({
   }
 })
 
-async function setWindowWidth (app, width) {
+// The bounds are set in the main process, while the header layout follows a
+// ResizeObserver in the renderer, so the renderer has to catch up before the
+// layout may be read back
+async function setWindowWidth (app, page, width) {
+  const previousWidth = await page.evaluate(() => window.innerWidth)
+
   await app.electronApp.evaluate(({ BrowserWindow }, targetWidth) => {
     const browserWindow = BrowserWindow.getAllWindows()[0]
     const bounds = browserWindow.getBounds()
     browserWindow.setBounds({ ...bounds, width: targetWidth })
   }, width)
+
+  await page.waitForFunction(previous => window.innerWidth !== previous, previousWidth)
+
+  // One frame for the ResizeObserver, one for the class it ends up setting
+  await page.evaluate(() => new Promise(resolve => {
+    requestAnimationFrame(() => requestAnimationFrame(resolve))
+  }))
 }
 
 function headerBoxes (page) {
@@ -88,7 +100,7 @@ test.describe('subscriptions header layout', () => {
     await goTo(page, 'subscriptions')
     await expect(page.locator('.subscriptionsHeader')).toHaveClass(/singleRow/)
 
-    await setWindowWidth(app, 800)
+    await setWindowWidth(app, page, 800)
 
     await expect(page.locator('.subscriptionsHeader')).not.toHaveClass(/singleRow/)
 
@@ -104,10 +116,10 @@ test.describe('subscriptions header layout', () => {
   test('merges the rows again when the window grows back', async ({ app, page }) => {
     await goTo(page, 'subscriptions')
 
-    await setWindowWidth(app, 800)
+    await setWindowWidth(app, page, 800)
     await expect(page.locator('.subscriptionsHeader')).not.toHaveClass(/singleRow/)
 
-    await setWindowWidth(app, 1600)
+    await setWindowWidth(app, page, 1600)
     await expect(page.locator('.subscriptionsHeader')).toHaveClass(/singleRow/)
 
     // The layout has to settle instead of flipping between the two
@@ -135,7 +147,7 @@ test.describe('subscriptions header layout', () => {
     let width = 1920
     while (width > 900) {
       width -= 20
-      await setWindowWidth(app, width)
+      await setWindowWidth(app, page, width)
 
       if (!await header.evaluate(element => element.classList.contains('singleRow'))) {
         break
@@ -153,6 +165,30 @@ test.describe('subscriptions header layout', () => {
     await expect(header).toHaveClass(/singleRow/)
   })
 
+  test('stays split while the tabs themselves have to wrap', async ({ app, page }) => {
+    await goTo(page, 'subscriptions')
+
+    // Narrow enough that the tabs no longer fit on one line inside their own
+    // row, so their rendered width is the shrunken one rather than the width
+    // they would need. That must not be mistaken for fitting next to the title.
+    await setWindowWidth(app, page, 700)
+
+    const wrapped = await page.evaluate(() => {
+      const tabs = [...document.querySelectorAll('.tab')]
+      return new Set(tabs.map(tab => tab.getBoundingClientRect().top)).size > 1
+    })
+    expect(wrapped, 'the tabs are expected to wrap at this width').toBe(true)
+
+    await expect(page.locator('.subscriptionsHeader')).not.toHaveClass(/singleRow/)
+
+    // A wrong measurement here would merge the rows, which widens the tabs and
+    // makes the next measurement split them again
+    for (let index = 0; index < 3; index++) {
+      await page.waitForTimeout(150)
+      await expect(page.locator('.subscriptionsHeader')).not.toHaveClass(/singleRow/)
+    }
+  })
+
   test('saves vertical space compared to the two line layout', async ({ app, page }) => {
     await goTo(page, 'subscriptions')
 
@@ -162,7 +198,7 @@ test.describe('subscriptions header layout', () => {
 
     const merged = await headerHeight()
 
-    await setWindowWidth(app, 800)
+    await setWindowWidth(app, page, 800)
     await expect(page.locator('.subscriptionsHeader')).not.toHaveClass(/singleRow/)
 
     expect(merged).toBeLessThan(await headerHeight())

--- a/e2e/tests/offline/subscriptions-header-layout.spec.mjs
+++ b/e2e/tests/offline/subscriptions-header-layout.spec.mjs
@@ -1,0 +1,137 @@
+import { test, expect, goTo } from '../../helpers/app.mjs'
+
+const now = Date.now()
+const CHANNEL_ID = 'UCaaaaaaaaaaaaaaaaaaaaaa'
+
+const videos = Array.from({ length: 5 }, (_, index) => ({
+  videoId: `video${String(index).padStart(6, '0')}`,
+  title: `video ${String(index).padStart(3, '0')}`,
+  author: 'Channel A',
+  authorId: CHANNEL_ID,
+  published: now - index * 3600000,
+  viewCount: 1000,
+  lengthSeconds: 120,
+  liveNow: false,
+  isUpcoming: false,
+  type: 'video'
+}))
+
+test.use({
+  seed: {
+    settings: {
+      fetchSubscriptionsAutomatically: false,
+      hideSubscriptionsVideos: false,
+      hideSubscriptionsShorts: false
+    },
+    profiles: [
+      {
+        _id: 'allChannels',
+        name: 'All Channels',
+        bgColor: '#000000',
+        textColor: '#FFFFFF',
+        subscriptions: [{ id: CHANNEL_ID, name: 'Channel A', thumbnail: '' }]
+      }
+    ],
+    subscriptionCache: [
+      {
+        _id: CHANNEL_ID,
+        videos,
+        videosTimestamp: new Date(now).toISOString()
+      }
+    ]
+  }
+})
+
+async function setWindowWidth (app, width) {
+  await app.electronApp.evaluate(({ BrowserWindow }, targetWidth) => {
+    const browserWindow = BrowserWindow.getAllWindows()[0]
+    const bounds = browserWindow.getBounds()
+    browserWindow.setBounds({ ...bounds, width: targetWidth })
+  }, width)
+}
+
+function headerBoxes (page) {
+  return page.evaluate(() => {
+    const toBox = (selector) => {
+      const rect = document.querySelector(selector).getBoundingClientRect()
+      return { start: rect.left, end: rect.right, top: rect.top, bottom: rect.bottom }
+    }
+
+    return {
+      title: toBox('.pageTitle'),
+      tabs: toBox('.tabs'),
+      refreshWidget: toBox('.headerRefreshWidget'),
+      header: toBox('.subscriptionsHeader')
+    }
+  })
+}
+
+test.describe('subscriptions header layout', () => {
+  test('puts the tabs beside the title when they fit', async ({ page }) => {
+    await goTo(page, 'subscriptions')
+
+    await expect(page.locator('.subscriptionsHeader')).toHaveClass(/singleRow/)
+
+    const { title, tabs, refreshWidget } = await headerBoxes(page)
+
+    // One line: the tabs follow the title and the refresh widget stays last
+    expect(tabs.start).toBeGreaterThanOrEqual(title.end)
+    expect(refreshWidget.start).toBeGreaterThanOrEqual(tabs.end)
+    expect(tabs.top).toBeLessThan(title.bottom)
+    expect(refreshWidget.top).toBeLessThan(tabs.bottom)
+  })
+
+  test('drops the tabs onto their own line when the window is too narrow', async ({ app, page }) => {
+    await goTo(page, 'subscriptions')
+    await expect(page.locator('.subscriptionsHeader')).toHaveClass(/singleRow/)
+
+    await setWindowWidth(app, 800)
+
+    await expect(page.locator('.subscriptionsHeader')).not.toHaveClass(/singleRow/)
+
+    const { title, tabs, refreshWidget } = await headerBoxes(page)
+
+    // Two lines: title and refresh widget above, the tabs below both
+    expect(refreshWidget.top).toBeLessThan(title.bottom)
+    expect(refreshWidget.end).toBeGreaterThan(title.end)
+    expect(tabs.top).toBeGreaterThanOrEqual(title.bottom)
+    expect(tabs.top).toBeGreaterThanOrEqual(refreshWidget.bottom)
+  })
+
+  test('merges the rows again when the window grows back', async ({ app, page }) => {
+    await goTo(page, 'subscriptions')
+
+    await setWindowWidth(app, 800)
+    await expect(page.locator('.subscriptionsHeader')).not.toHaveClass(/singleRow/)
+
+    await setWindowWidth(app, 1600)
+    await expect(page.locator('.subscriptionsHeader')).toHaveClass(/singleRow/)
+
+    // The layout has to settle instead of flipping between the two
+    const heights = []
+    for (let index = 0; index < 3; index++) {
+      await page.waitForTimeout(150)
+      heights.push(await page.evaluate(() => {
+        return document.querySelector('.subscriptionsHeader').getBoundingClientRect().height
+      }))
+    }
+
+    expect(new Set(heights).size).toBe(1)
+    await expect(page.locator('.subscriptionsHeader')).toHaveClass(/singleRow/)
+  })
+
+  test('saves vertical space compared to the two line layout', async ({ app, page }) => {
+    await goTo(page, 'subscriptions')
+
+    const headerHeight = () => page.evaluate(() => {
+      return document.querySelector('.subscriptionsHeader').getBoundingClientRect().height
+    })
+
+    const merged = await headerHeight()
+
+    await setWindowWidth(app, 800)
+    await expect(page.locator('.subscriptionsHeader')).not.toHaveClass(/singleRow/)
+
+    expect(merged).toBeLessThan(await headerHeight())
+  })
+})

--- a/src/renderer/views/Subscriptions/Subscriptions.css
+++ b/src/renderer/views/Subscriptions/Subscriptions.css
@@ -27,7 +27,7 @@
   box-shadow: 0 1px 0 var(--primary-shadow-color);
 }
 
-.titleRow {
+.headerRow {
   display: flex;
   align-items: center;
   justify-content: space-between;
@@ -69,7 +69,7 @@
 }
 
 .headerRefreshWidget {
-  /* Size to its content so the title row positions the whole widget: tucked to
+  /* Size to its content so the header row positions the whole widget: tucked to
      the inline-end while it fits beside the title, and flush to the inline-start
      once it wraps onto its own line. */
   max-inline-size: 100%;
@@ -94,6 +94,36 @@
   margin-block: 0;
   position: relative;
   color: var(--tertiary-text-color);
+}
+
+/* Two line layout: the tabs are moved past the refresh widget, so that they end
+   up on the line below the one with the title */
+.subscriptionsHeader:not(.singleRow) .tabsRow {
+  order: 1;
+  flex-basis: 100%;
+}
+
+.subscriptionsHeader.singleRow .headerRow {
+  justify-content: flex-start;
+}
+
+/* Deciding whether everything fits onto one line relies on the natural widths,
+   so nothing may shrink or wrap while it does */
+.subscriptionsHeader.singleRow .headerRow > * {
+  flex-shrink: 0;
+}
+
+.subscriptionsHeader.singleRow .tabsRow,
+.subscriptionsHeader.singleRow .tabs {
+  flex-wrap: nowrap;
+}
+
+.subscriptionsHeader.singleRow .tabsRow {
+  margin-block-start: 0;
+}
+
+.subscriptionsHeader.singleRow .headerRefreshWidget {
+  margin-inline-start: auto;
 }
 
 .selectedTab {
@@ -173,7 +203,7 @@
     padding-block-end: 10px;
   }
 
-  .titleRow {
+  .headerRow {
     align-items: flex-start;
   }
 

--- a/src/renderer/views/Subscriptions/Subscriptions.vue
+++ b/src/renderer/views/Subscriptions/Subscriptions.vue
@@ -4,8 +4,14 @@
     :class="{ hasTabBar: hasHorizontalTabBar }"
   >
     <FtCard class="card">
-      <div class="subscriptionsHeader">
-        <div class="titleRow">
+      <div
+        class="subscriptionsHeader"
+        :class="{ singleRow: headerFitsOneRow }"
+      >
+        <div
+          ref="headerRowRef"
+          class="headerRow"
+        >
           <h2 class="pageTitle">
             <FontAwesomeIcon
               :icon="['fas', 'rss']"
@@ -13,6 +19,155 @@
             />
             {{ $t("Subscriptions.Subscriptions") }}
           </h2>
+          <div
+            ref="tabsRowRef"
+            class="tabsRow"
+          >
+            <FtFlexBox
+              ref="tabsContainerRef"
+              class="tabs"
+              role="tablist"
+              :aria-label="$t('Subscriptions.Subscriptions Tabs')"
+            >
+              <div
+                v-if="tabsIndicatorStyle"
+                class="tabsIndicator"
+                :style="tabsIndicatorStyle"
+                aria-hidden="true"
+              />
+              <!-- eslint-disable-next-line vuejs-accessibility/interactive-supports-focus -->
+              <div
+                v-if="!hideSubscriptionsVideos"
+                ref="videosTab"
+                class="tab"
+                role="tab"
+                :aria-selected="currentTab === 'videos'"
+                aria-controls="subscriptionsPanel"
+                data-subscription-feed-tab="videos"
+                :tabindex="currentTab === 'videos' ? 0 : -1"
+                :class="{ selectedTab: currentTab === 'videos' }"
+                @click="changeTab('videos')"
+                @keydown.space.enter.prevent="changeTab('videos')"
+                @keydown.left.right="focusTab($event, 'videos')"
+              >
+                <FontAwesomeIcon
+                  :icon="['fa', 'video']"
+                  class="subscriptionIcon"
+                />
+                {{ $t("Global.Videos") }}
+                <FtLoader
+                  v-if="refreshingFeedTab === 'videos'"
+                  class="tabLoadingIndicator"
+                />
+              </div>
+              <!-- eslint-disable-next-line vuejs-accessibility/interactive-supports-focus -->
+              <div
+                v-if="!hideSubscriptionsShorts"
+                ref="shortsTab"
+                class="tab"
+                role="tab"
+                :aria-selected="currentTab === 'shorts'"
+                aria-controls="subscriptionsPanel"
+                data-subscription-feed-tab="shorts"
+                :tabindex="currentTab === 'shorts' ? 0 : -1"
+                :class="{ selectedTab: currentTab === 'shorts' }"
+                @click="changeTab('shorts')"
+                @keydown.space.enter.prevent="changeTab('shorts')"
+                @keydown.left.right="focusTab($event, 'shorts')"
+              >
+                <FontAwesomeIcon
+                  :icon="['fa', 'clapperboard']"
+                  class="subscriptionIcon"
+                />
+                {{ $t("Global.Shorts") }}
+                <FtLoader
+                  v-if="refreshingFeedTab === 'shorts'"
+                  class="tabLoadingIndicator"
+                />
+              </div>
+              <!-- eslint-disable-next-line vuejs-accessibility/interactive-supports-focus -->
+              <div
+                v-if="!hideSubscriptionsLive"
+                ref="liveTab"
+                class="tab"
+                role="tab"
+                :aria-selected="currentTab === 'live'"
+                aria-controls="subscriptionsPanel"
+                data-subscription-feed-tab="live"
+                :tabindex="currentTab === 'live' ? 0 : -1"
+                :class="{ selectedTab: currentTab === 'live' }"
+                @click="changeTab('live')"
+                @keydown.space.enter.prevent="changeTab('live')"
+                @keydown.left.right="focusTab($event, 'live')"
+              >
+                <FontAwesomeIcon
+                  :icon="['fa', 'tower-broadcast']"
+                  class="subscriptionIcon"
+                />
+                {{ $t("Global.Live") }}
+                <FtLoader
+                  v-if="refreshingFeedTab === 'live'"
+                  class="tabLoadingIndicator"
+                />
+              </div>
+              <!-- eslint-disable-next-line vuejs-accessibility/interactive-supports-focus -->
+              <div
+                v-if="visibleTabs.includes('community')"
+                ref="communityTab"
+                class="tab"
+                role="tab"
+                :aria-selected="currentTab === 'community'"
+                aria-controls="subscriptionsPanel"
+                data-subscription-feed-tab="posts"
+                :tabindex="currentTab === 'community' ? 0 : -1"
+                :class="{ selectedTab: currentTab === 'community' }"
+                @click="changeTab('community')"
+                @keydown.space.enter.prevent="changeTab('community')"
+                @keydown.left.right="focusTab($event, 'community')"
+              >
+                <FontAwesomeIcon
+                  :icon="['fa', 'message']"
+                  class="subscriptionIcon"
+                />
+                {{ $t("Global.Posts") }}
+                <FtLoader
+                  v-if="refreshingFeedTab === 'posts'"
+                  class="tabLoadingIndicator"
+                />
+              </div>
+              <!-- eslint-disable-next-line vuejs-accessibility/interactive-supports-focus -->
+              <div
+                v-if="visibleTabs.includes('new')"
+                ref="newTab"
+                class="tab"
+                role="tab"
+                :aria-selected="currentTab === 'new'"
+                aria-controls="subscriptionsPanel"
+                data-subscription-feed-tab="all"
+                :tabindex="currentTab === 'new' ? 0 : -1"
+                :class="{ selectedTab: currentTab === 'new' }"
+                @click="changeTab('new')"
+                @keydown.space.enter.prevent="changeTab('new')"
+                @keydown.left.right="focusTab($event, 'new')"
+              >
+                <FontAwesomeIcon
+                  :icon="['fa', 'fire']"
+                  class="subscriptionIcon"
+                />
+                {{ $t("Global.New") }}
+              </div>
+            </FtFlexBox>
+            <button
+              v-if="currentTabHasNewContent"
+              class="markAllSeenButton"
+              type="button"
+              :disabled="markingSeenTab !== null || currentTabRefreshing"
+              @click="markAllAsSeen(currentTab)"
+            >
+              <FontAwesomeIcon :icon="['fas', 'check']" />
+              {{ $t('Subscriptions.Mark All as Seen') }}
+            </button>
+          </div>
           <FtRefreshWidget
             v-if="currentTabPanel !== null"
             embedded
@@ -28,152 +183,6 @@
             @click="refreshCurrentTab"
             @cancel="cancelRefresh"
           />
-        </div>
-        <div class="tabsRow">
-          <FtFlexBox
-            ref="tabsContainerRef"
-            class="tabs"
-            role="tablist"
-            :aria-label="$t('Subscriptions.Subscriptions Tabs')"
-          >
-            <div
-              v-if="tabsIndicatorStyle"
-              class="tabsIndicator"
-              :style="tabsIndicatorStyle"
-              aria-hidden="true"
-            />
-            <!-- eslint-disable-next-line vuejs-accessibility/interactive-supports-focus -->
-            <div
-              v-if="!hideSubscriptionsVideos"
-              ref="videosTab"
-              class="tab"
-              role="tab"
-              :aria-selected="currentTab === 'videos'"
-              aria-controls="subscriptionsPanel"
-              data-subscription-feed-tab="videos"
-              :tabindex="currentTab === 'videos' ? 0 : -1"
-              :class="{ selectedTab: currentTab === 'videos' }"
-              @click="changeTab('videos')"
-              @keydown.space.enter.prevent="changeTab('videos')"
-              @keydown.left.right="focusTab($event, 'videos')"
-            >
-              <FontAwesomeIcon
-                :icon="['fa', 'video']"
-                class="subscriptionIcon"
-              />
-              {{ $t("Global.Videos") }}
-              <FtLoader
-                v-if="refreshingFeedTab === 'videos'"
-                class="tabLoadingIndicator"
-              />
-            </div>
-            <!-- eslint-disable-next-line vuejs-accessibility/interactive-supports-focus -->
-            <div
-              v-if="!hideSubscriptionsShorts"
-              ref="shortsTab"
-              class="tab"
-              role="tab"
-              :aria-selected="currentTab === 'shorts'"
-              aria-controls="subscriptionsPanel"
-              data-subscription-feed-tab="shorts"
-              :tabindex="currentTab === 'shorts' ? 0 : -1"
-              :class="{ selectedTab: currentTab === 'shorts' }"
-              @click="changeTab('shorts')"
-              @keydown.space.enter.prevent="changeTab('shorts')"
-              @keydown.left.right="focusTab($event, 'shorts')"
-            >
-              <FontAwesomeIcon
-                :icon="['fa', 'clapperboard']"
-                class="subscriptionIcon"
-              />
-              {{ $t("Global.Shorts") }}
-              <FtLoader
-                v-if="refreshingFeedTab === 'shorts'"
-                class="tabLoadingIndicator"
-              />
-            </div>
-            <!-- eslint-disable-next-line vuejs-accessibility/interactive-supports-focus -->
-            <div
-              v-if="!hideSubscriptionsLive"
-              ref="liveTab"
-              class="tab"
-              role="tab"
-              :aria-selected="currentTab === 'live'"
-              aria-controls="subscriptionsPanel"
-              data-subscription-feed-tab="live"
-              :tabindex="currentTab === 'live' ? 0 : -1"
-              :class="{ selectedTab: currentTab === 'live' }"
-              @click="changeTab('live')"
-              @keydown.space.enter.prevent="changeTab('live')"
-              @keydown.left.right="focusTab($event, 'live')"
-            >
-              <FontAwesomeIcon
-                :icon="['fa', 'tower-broadcast']"
-                class="subscriptionIcon"
-              />
-              {{ $t("Global.Live") }}
-              <FtLoader
-                v-if="refreshingFeedTab === 'live'"
-                class="tabLoadingIndicator"
-              />
-            </div>
-            <!-- eslint-disable-next-line vuejs-accessibility/interactive-supports-focus -->
-            <div
-              v-if="visibleTabs.includes('community')"
-              ref="communityTab"
-              class="tab"
-              role="tab"
-              :aria-selected="currentTab === 'community'"
-              aria-controls="subscriptionsPanel"
-              data-subscription-feed-tab="posts"
-              :tabindex="currentTab === 'community' ? 0 : -1"
-              :class="{ selectedTab: currentTab === 'community' }"
-              @click="changeTab('community')"
-              @keydown.space.enter.prevent="changeTab('community')"
-              @keydown.left.right="focusTab($event, 'community')"
-            >
-              <FontAwesomeIcon
-                :icon="['fa', 'message']"
-                class="subscriptionIcon"
-              />
-              {{ $t("Global.Posts") }}
-              <FtLoader
-                v-if="refreshingFeedTab === 'posts'"
-                class="tabLoadingIndicator"
-              />
-            </div>
-            <!-- eslint-disable-next-line vuejs-accessibility/interactive-supports-focus -->
-            <div
-              v-if="visibleTabs.includes('new')"
-              ref="newTab"
-              class="tab"
-              role="tab"
-              :aria-selected="currentTab === 'new'"
-              aria-controls="subscriptionsPanel"
-              data-subscription-feed-tab="all"
-              :tabindex="currentTab === 'new' ? 0 : -1"
-              :class="{ selectedTab: currentTab === 'new' }"
-              @click="changeTab('new')"
-              @keydown.space.enter.prevent="changeTab('new')"
-              @keydown.left.right="focusTab($event, 'new')"
-            >
-              <FontAwesomeIcon
-                :icon="['fa', 'fire']"
-                class="subscriptionIcon"
-              />
-              {{ $t("Global.New") }}
-            </div>
-          </FtFlexBox>
-          <button
-            v-if="currentTabHasNewContent"
-            class="markAllSeenButton"
-            type="button"
-            :disabled="markingSeenTab !== null || currentTabRefreshing"
-            @click="markAllAsSeen(currentTab)"
-          >
-            <FontAwesomeIcon :icon="['fas', 'check']" />
-            {{ $t('Subscriptions.Mark All as Seen') }}
-          </button>
         </div>
         <div
           v-if="currentTabRefreshing"
@@ -728,6 +737,73 @@ async function handleFeedReloadRequest(payload) {
   await refreshers[payload.feedTab]?.(options)
 }
 
+// ===== Single row header =====
+const headerRowRef = useTemplateRef('headerRowRef')
+const tabsRowRef = useTemplateRef('tabsRowRef')
+/** @type {import('vue').Ref<boolean>} */
+const headerFitsOneRow = ref(false)
+let headerResizeObserver = null
+
+/**
+ * How much inline space the children of a flex container need next to each
+ * other, which isn't the same as the container's own width when it stretches or
+ * its content wraps.
+ * @param {HTMLElement} container
+ * @param {(child: Element) => number} [childWidth]
+ */
+function singleLineWidth(container, childWidth = child => child.getBoundingClientRect().width) {
+  const children = Array.from(container.children)
+  const columnGap = Number.parseFloat(getComputedStyle(container).columnGap) || 0
+
+  return children.reduce((total, child) => total + childWidth(child), 0) +
+    columnGap * Math.max(children.length - 1, 0)
+}
+
+/**
+ * The tabs sit next to the page title while the title, the tabs and the refresh
+ * widget fit onto one line together, otherwise the tabs drop onto a line of
+ * their own. The single row layout doesn't let its children shrink and the tabs
+ * are measured through their content, so the measurement is the same in both
+ * layouts and they can't flip back and forth.
+ */
+function updateHeaderFitsOneRow() {
+  const row = headerRowRef.value
+  const tabsRow = tabsRowRef.value
+
+  if (!(row instanceof HTMLElement) || row.getClientRects().length === 0) {
+    return
+  }
+
+  const requiredWidth = singleLineWidth(row, child => {
+    // The tabs stretch across the whole header while they have their own line
+    return child === tabsRow ? singleLineWidth(child) : child.getBoundingClientRect().width
+  })
+
+  // Fractional widths throughout, as rounding the available space up would let
+  // the single row layout overflow, which puts the tabs onto a second line again
+  headerFitsOneRow.value = requiredWidth <= row.getBoundingClientRect().width
+}
+
+function observeHeaderRow() {
+  const row = headerRowRef.value
+
+  if (headerResizeObserver === null || !(row instanceof HTMLElement)) {
+    return
+  }
+
+  // The children are observed as well, because text inside them (the refresh
+  // timestamps above all) changes their widths without resizing the row
+  headerResizeObserver.disconnect()
+  headerResizeObserver.observe(row)
+
+  for (const child of row.children) {
+    headerResizeObserver.observe(child)
+  }
+}
+
+// The refresh widget is only rendered once the current panel is mounted
+watch(currentTabPanel, () => nextTick(observeHeaderRow))
+
 // ===== Sliding feed tab indicator =====
 const tabsContainerRef = useTemplateRef('tabsContainerRef')
 /** @type {import('vue').Ref<Record<string, string> | null>} */
@@ -821,13 +897,20 @@ onMounted(() => {
     if (tabsContainerRef.value?.$el instanceof HTMLElement) {
       tabsResizeObserver.observe(tabsContainerRef.value.$el)
     }
+
+    headerResizeObserver = new ResizeObserver(() => updateHeaderFitsOneRow())
+    observeHeaderRow()
   }
 
-  nextTick(updateTabsIndicator)
+  nextTick(() => {
+    updateHeaderFitsOneRow()
+    updateTabsIndicator()
+  })
 })
 
 onBeforeUnmount(() => {
   tabsResizeObserver?.disconnect()
+  headerResizeObserver?.disconnect()
 })
 </script>
 

--- a/src/renderer/views/Subscriptions/Subscriptions.vue
+++ b/src/renderer/views/Subscriptions/Subscriptions.vue
@@ -791,18 +791,28 @@ function observeHeaderRow() {
     return
   }
 
-  // The children are observed as well, because text inside them (the refresh
-  // timestamps above all) changes their widths without resizing the row
+  // Everything the measurement reads is observed, not just the row: text inside
+  // the children (the refresh timestamps above all) changes their widths without
+  // resizing the row, and the tabs row keeps its full width while it has a line
+  // of its own, so its children have to be watched instead of it
   headerResizeObserver.disconnect()
   headerResizeObserver.observe(row)
 
   for (const child of row.children) {
     headerResizeObserver.observe(child)
   }
+
+  for (const child of tabsRowRef.value?.children ?? []) {
+    headerResizeObserver.observe(child)
+  }
 }
 
-// The refresh widget is only rendered once the current panel is mounted
-watch(currentTabPanel, () => nextTick(observeHeaderRow))
+// Which elements exist changes with the panel (the refresh widget is only
+// rendered once it is mounted) and with the Mark all as seen button
+watch([currentTabPanel, currentTabHasNewContent], () => nextTick(() => {
+  observeHeaderRow()
+  updateHeaderFitsOneRow()
+}))
 
 // ===== Sliding feed tab indicator =====
 const tabsContainerRef = useTemplateRef('tabsContainerRef')


### PR DESCRIPTION
## Pull Request Type
<!-- Please select what type of pull request this is: [x] -->
- [ ] Bugfix
- [x] Feature Implementation
- [ ] Documentation
- [ ] Other

## Related issue
closes #410

## Description
The Subscriptions page had two stacked bars: the page title with the refresh widget, and the feed tabs below them. The tabs now share the line with the title while the title, the tabs and the refresh widget fit onto it together, which gives the feed itself back roughly 60 pixels of vertical space.

Whether they fit is measured instead of hardcoded as a breakpoint, so long translations, a hidden tab or an appearing "Mark all as seen" button are all taken into account: a `ResizeObserver` on the header row and its children compares the sum of the children's natural widths plus the gaps against the available width. When they no longer fit, the tabs drop back onto a line of their own and the header looks exactly like it does today.

Two details that make the toggle stable:

- The single row layout doesn't let its children shrink or wrap, and the tabs are measured through their content (they stretch across the whole header while they have their own line). The measurement is therefore the same in both layouts, so the two can't flip back and forth.
- Both sides of the comparison use fractional widths. Rounding the available space up (`clientWidth`) would let the single row layout overflow by a fraction of a pixel, which puts the tabs onto a second line while the header still considers itself merged.

The DOM order is now title → tabs → refresh widget, so in the two line layout the tabs come before the refresh widget in the focus order while the widget is displayed above them. CSS can't reorder based on available space, so one of the two layouts has to carry that mismatch; the merged one is the consistent one.

## Screenshots <!-- If appropriate -->

## Release note category
<!-- Select exactly one category. Every pull request must select one. -->
<!-- release-note-category:start -->
- [ ] Not noteworthy
- [ ] Highlights
- [x] More improvements
- [ ] Fixed bugs
<!-- release-note-category:end -->

## Release note
<!-- release-note:start -->
The Subscriptions page now shows the feed tabs next to the page title whenever they fit, leaving more room for the feed itself.
<!-- release-note:end -->

## Release note images
<!-- release-note-image:start -->
<img width="1627" height="58" alt="image" src="https://github.com/user-attachments/assets/48308e7c-9514-4ac7-80ec-312ea135c42b" />
<!-- release-note-image:end -->

## Testing
New offline E2E spec `e2e/tests/offline/subscriptions-header-layout.spec.mjs` covers the layout:

- the tabs follow the title and the refresh widget stays last when everything fits
- the tabs drop onto their own line, below the title and the refresh widget, at a window width of 800 px
- the rows merge again when the window grows back, and the header height stays put over 450 ms afterwards (the failure mode of a measure-and-toggle layout is a flip-flop loop)
- the merged header is shorter than the two line one

```
xvfb-run -a -s "-screen 0 1920x1080x24" npx playwright test -c e2e/playwright.config.mjs --project=offline --workers=2 subscriptions
```

40 passed, which includes the existing `subscriptions-tab-indicator` specs — the sliding tab underline still lands on the selected tab in the merged row.

Manually: open Subscriptions on a wide window and drag it narrower; the tabs jump to their own line as soon as the header runs out of room and back up when it has room again.

## Desktop
- **OS:** Arch Linux
- **OS Version:** Rolling (KDE Plasma, Wayland)
- **OpenTubeX version:** 0.30.2 (development)

## Additional context
The two line fallback is unchanged, including the "Mark all as seen" button staying next to the tabs.
