### PR TITLE
feat: make hashtags and handles in video titles and descriptions clickable

### DIFF
--- a/e2e/tests/offline/description-links.spec.mjs
+++ b/e2e/tests/offline/description-links.spec.mjs
@@ -1,0 +1,172 @@
+import crypto from 'node:crypto'
+import { readFile, readdir } from 'node:fs/promises'
+import path from 'node:path'
+import { gunzipSync } from 'node:zlib'
+
+import { goTo, repoRoot, test, expect } from '../../helpers/app.mjs'
+import { fixtureKey } from '../../helpers/innertube.mjs'
+
+const fixtureDir = path.join(repoRoot, 'e2e', 'fixtures', 'innertube', 'watch', 'shows-video-metadata')
+const sharedDir = path.join(repoRoot, 'e2e', 'fixtures', 'innertube', 'shared')
+
+const VIDEO_TITLE = 'Sketching again #ShiorinSketch'
+const VIDEO_DESCRIPTION = 'Follow @SomeCreator for more #ShiorinSketch clips'
+
+async function fixture(dir, name) {
+  try {
+    return gunzipSync(await readFile(path.join(dir, name)))
+  } catch {
+    return null
+  }
+}
+
+/**
+ * Serves the watch page from the recorded fixtures with an unplayable video,
+ * so the Watch view mounts without a real player, and replaces the recorded
+ * title and description with ones that contain a hashtag and a handle that
+ * YouTube did not link itself.
+ */
+async function mockWatchPage(app, page) {
+  await app.electronApp.evaluate(({ ipcMain }) => {
+    ipcMain.removeHandler('generate-po-token')
+    ipcMain.handle('generate-po-token', () => 'test-po-token')
+  })
+
+  await page.route(/^https?:\/\//, (route) => route.abort())
+  await page.route(/^https?:\/\//, async (route, request) => {
+    const url = request.url()
+
+    if (url === 'https://www.youtube.com/iframe_api') {
+      return route.fulfill({ status: 200, contentType: 'text/javascript', body: 'player\\/test-player\\/' })
+    }
+
+    if (url.includes('/img/desktop/unavailable/')) {
+      return route.fulfill({ status: 200, contentType: 'image/png', body: '' })
+    }
+
+    if (/\/s\/player\//.test(url) || /\/sw\.js_data/.test(url)) {
+      const { pathname } = new URL(url)
+      const name = `shared-${crypto.createHash('sha1').update(pathname).digest('hex').slice(0, 12)}.gz`
+      const body = await fixture(sharedDir, name) ??
+        (url.includes('/s/player/') ? await fixture(sharedDir, 'shared-99c4a5c04897.gz') : null)
+      if (body) {
+        return route.fulfill({
+          status: 200,
+          contentType: url.includes('/s/player/') ? 'text/javascript' : 'application/json',
+          body
+        })
+      }
+      return route.abort()
+    }
+
+    if (url.includes('/youtubei/v1/player')) {
+      const files = await readdir(fixtureDir)
+      const body = await fixture(fixtureDir, files.find((file) => file.startsWith('player-')))
+      const json = JSON.parse(body.toString())
+      json.playabilityStatus = { status: 'UNPLAYABLE', reason: 'Video unavailable' }
+      delete json.streamingData
+      return route.fulfill({ status: 200, contentType: 'application/json', body: JSON.stringify(json) })
+    }
+
+    if (url.includes('/youtubei/v1/')) {
+      const key = fixtureKey(url, request.postData())
+      let body = await fixture(fixtureDir, `${key}.0.json.gz`)
+      if (!body) {
+        const endpoint = key.replace(/-[0-9a-f]{12}$/, '')
+        const files = (await readdir(fixtureDir)).filter((file) => file.startsWith(`${endpoint}-`))
+        if (files.length > 0) body = await fixture(fixtureDir, files[0])
+      }
+      if (body) {
+        if (url.includes('/youtubei/v1/next')) {
+          const json = JSON.parse(body.toString())
+          const contents = json.contents?.twoColumnWatchNextResults?.results?.results?.contents ?? []
+          const primaryInfo = contents.find((entry) => entry.videoPrimaryInfoRenderer)?.videoPrimaryInfoRenderer
+          const secondaryInfo = contents.find((entry) => entry.videoSecondaryInfoRenderer)?.videoSecondaryInfoRenderer
+          primaryInfo.title = { runs: [{ text: VIDEO_TITLE }] }
+          // YouTube links the hashtags and handles it recognised via `commandRuns`,
+          // an empty list is what an unrecognised one looks like
+          secondaryInfo.attributedDescription = { content: VIDEO_DESCRIPTION, commandRuns: [] }
+          body = Buffer.from(JSON.stringify(json))
+        }
+        return route.fulfill({ status: 200, contentType: 'application/json', body })
+      }
+      return route.abort()
+    }
+
+    return route.fallback()
+  })
+}
+
+test.describe('unlinked hashtags and handles', () => {
+  test.use({
+    seed: {
+      history: [{
+        _id: 'jNQXAC9IVRw',
+        videoId: 'jNQXAC9IVRw',
+        title: 'Hashtag test video',
+        author: 'Test Channel',
+        authorId: 'UC-test-channel-id',
+        published: Date.now() - 86_400_000,
+        description: '',
+        viewCount: 1234,
+        lengthSeconds: 60,
+        watchProgress: 10,
+        isWatched: false,
+        timeWatched: Date.now(),
+        isLive: false,
+        type: 'video'
+      }]
+    }
+  })
+
+  test('are clickable in the video title and description', async ({ app, page }) => {
+    await mockWatchPage(app, page)
+
+    await goTo(page, 'history')
+    await page.getByText('Hashtag test video').click()
+    await expect(page).toHaveURL(/#\/watch\/jNQXAC9IVRw/)
+
+    const titleLink = page.locator('.videoTitle a')
+    await expect(titleLink).toHaveText('#ShiorinSketch')
+    await expect(titleLink).toHaveAttribute('href', 'https://youtube.com/hashtag/ShiorinSketch')
+    await expect(page.locator('.videoTitle')).toHaveText(VIDEO_TITLE)
+
+    const description = page.locator('.videoDescription .description')
+    await expect(description.locator('a', { hasText: '#ShiorinSketch' }))
+      .toHaveAttribute('href', 'https://youtube.com/hashtag/ShiorinSketch')
+    await expect(description.locator('a', { hasText: '@SomeCreator' }))
+      .toHaveAttribute('href', 'https://youtube.com/@SomeCreator')
+
+    await titleLink.click()
+    await expect(page).toHaveURL(/#\/hashtag\/ShiorinSketch/)
+  })
+})
+
+test.describe('hashtag page', () => {
+  test.use({
+    seed: {
+      settings: {
+        backendPreference: 'invidious'
+      }
+    }
+  })
+
+  test('is requested in lowercase, whatever casing the link used', async ({ page }) => {
+    const requestedUrls = []
+    await page.route('**/api/v1/hashtag/**', async (route, request) => {
+      requestedUrls.push(request.url())
+      await route.fulfill({ json: { results: [] } })
+    })
+
+    const hashtagTab = await page.evaluate(() => window.ftElectron.tabs.create({
+      route: '/hashtag/ShiorinSketch',
+      makeActive: false
+    }))
+    await page.locator(`.tab[data-tab-id="${hashtagTab.id}"]`).click()
+
+    await expect(page).toHaveURL(/#\/hashtag\/ShiorinSketch/)
+    await expect(page.locator('.tabContent[aria-hidden="false"] h2 bdi')).toHaveText('shiorinsketch')
+    await expect.poll(() => requestedUrls.length).toBe(1)
+    expect(requestedUrls[0]).toContain('/api/v1/hashtag/shiorinsketch')
+  })
+})

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -284,6 +284,11 @@ export default defineConfig([
       'object-shorthand': 'off',
       'vue/multi-word-component-names': 'off',
 
+      // `v-safer-html` fills the element with sanitized HTML, just like `v-html` does
+      'vuejs-accessibility/heading-has-content': ['error', {
+        accessibleDirectives: ['safer-html'],
+      }],
+
       'vuejs-accessibility/label-has-for': ['error', {
         required: {
           some: ['nesting', 'id'],

--- a/src/renderer/App.vue
+++ b/src/renderer/App.vue
@@ -742,10 +742,14 @@ onMounted(async () => {
     store.dispatch('grabAllSubscriptions')
     store.dispatch('grabSearchHistoryEntries')
 
+    // YouTube links have to be caught in both builds, otherwise the browser
+    // navigates away from the app instead of opening the linked video,
+    // channel, playlist or hashtag in it
+    document.addEventListener('click', handleClick)
+    document.addEventListener('auxclick', handleAuxClick)
+
     if (process.env.IS_ELECTRON) {
       store.dispatch('setupListenersToSyncWindows')
-      document.addEventListener('click', handleClick)
-      document.addEventListener('auxclick', handleAuxClick)
       removeOpenUrlListener = enableOpenUrl()
       store.dispatch('getExternalPlayerCmdArgumentsData')
       removeReloadRequestListener = window.ftElectron.tabs.onRequestReload(prepareAndReloadTab)
@@ -2376,7 +2380,9 @@ function handleAuxClick(event) {
   // navigate anything. Route buttons 3 (back) and 4 (forward) through the tab
   // navigation service instead. auxclick fires once per click, avoiding the
   // double dispatch seen with mousedown/mouseup for these buttons.
-  if (event.button === 3 || event.button === 4) {
+  // The web build has no logical tabs and the browser's own history still
+  // works there, so those buttons are left alone.
+  if (process.env.IS_ELECTRON && (event.button === 3 || event.button === 4)) {
     event.preventDefault()
 
     const tabId = activeTabId.value
@@ -2397,9 +2403,12 @@ function handleLinkClick(event) {
   const youtubeUrlPattern = /^https?:\/\/((www\.)?youtube\.com(\/embed)?|youtu\.be)\/(?!.*live_chat).*$/
   const isYoutubeLink = youtubeUrlPattern.test(href)
 
-  // Determine if we should open in new tab or new window
-  const ctrlOrCmdPressed = (process.platform !== 'darwin' && event.ctrlKey) ||
-    (process.platform === 'darwin' && event.metaKey)
+  // Determine if we should open in new tab or new window.
+  // `process.platform` is `undefined` in the web build, where the app can be
+  // opened from any OS, so both modifiers count there.
+  const ctrlOrCmdPressed = process.env.IS_ELECTRON
+    ? ((process.platform !== 'darwin' && event.ctrlKey) || (process.platform === 'darwin' && event.metaKey))
+    : (event.ctrlKey || event.metaKey)
   const isMiddleClick = event.type === 'auxclick' && event.button === 1
   const doCreateNewTab = ctrlOrCmdPressed || isMiddleClick
   const doCreateNewWindow = event.shiftKey

--- a/src/renderer/components/WatchVideoDescription/WatchVideoDescription.vue
+++ b/src/renderer/components/WatchVideoDescription/WatchVideoDescription.vue
@@ -51,12 +51,11 @@
 </template>
 
 <script setup>
-import autolinker from 'autolinker'
-
 import { onMounted, ref, computed, nextTick, useTemplateRef, watch } from 'vue'
 import FtCard from '../ft-card/ft-card.vue'
 import FtTimestampCatcher from '../FtTimestampCatcher.vue'
 
+import { linkifyDescription, linkifyHashtagsAndHandles } from '../../helpers/descriptionLinks'
 import { useTabContext } from '../../tabs/TabContext'
 
 const props = defineProps({
@@ -98,11 +97,11 @@ if (props.descriptionHtml !== '') {
   testDiv.innerHTML = parsed
 
   if (!/^\s*$/.test(testDiv.innerText)) {
-    shownDescription = parsed
+    shownDescription = linkifyHashtagsAndHandles(parsed)
   }
 } else {
   if (!/^\s*$/.test(props.description)) {
-    shownDescription = autolinker.link(props.description)
+    shownDescription = linkifyDescription(props.description)
   }
 }
 

--- a/src/renderer/components/WatchVideoInfo/WatchVideoInfo.vue
+++ b/src/renderer/components/WatchVideoInfo/WatchVideoInfo.vue
@@ -1,12 +1,12 @@
 <template>
   <FtCard class="watchVideoInfo">
     <div>
+      <!-- rendered as HTML so that the hashtags and handles in the title are clickable -->
       <h1
+        v-safer-html="titleHtml"
         class="videoTitle"
         dir="auto"
-      >
-        {{ title }}
-      </h1>
+      />
       <div
         v-if="isUnlisted || hasAiGeneratedContent || sponsorBlockFullVideoCategory"
         class="videoBadges"
@@ -281,7 +281,10 @@ import WatchVideoFormatPrompt from '../WatchVideoFormatPrompt/WatchVideoFormatPr
 
 import store from '../../store'
 
-import { formatNumber, getRelativeTimeFromDate, getVideoThumbnailUrl, openInternalPath, showToast } from '../../helpers/utils'
+import { vSaferHtml } from '../../directives/vSaferHtml'
+
+import { linkifyHashtagsAndHandles } from '../../helpers/descriptionLinks'
+import { escapeHTML, formatNumber, getRelativeTimeFromDate, getVideoThumbnailUrl, openInternalPath, showToast } from '../../helpers/utils'
 import { translateSponsorBlockCategory } from '../../helpers/player/utils'
 import { useTabContext } from '../../tabs/TabContext'
 import { tabMediaCoordinator } from '../../tabs/TabMediaCoordinator'
@@ -464,6 +467,10 @@ const { locale, t } = useI18n()
 const showCollaboratorsPrompt = ref(false)
 const showDownloadPrompt = ref(false)
 const showFormatPrompt = ref(false)
+
+// the title is plain text, so it has to be escaped before the hashtags and handles are linked
+/** @type {import('vue').ComputedRef<string>} */
+const titleHtml = computed(() => linkifyHashtagsAndHandles(escapeHTML(props.title)))
 
 /** @type {import('vue').ComputedRef<boolean>} */
 const hideSharingActions = computed(() => store.getters.getHideSharingActions)

--- a/src/renderer/helpers/api/local.js
+++ b/src/renderer/helpers/api/local.js
@@ -25,17 +25,19 @@ const TRACKING_PARAM_NAMES = [
 // YouTube moved Shorts grid images from `thumbnail` to
 // `thumbnailViewModel.thumbnailViewModel.image.sources`. Preserve that exact
 // source while youtubei.js still expects the old field.
-class ShortsLockupViewWithThumbnail extends YTNodes.ShortsLockupView {
-  constructor(data) {
-    const sources = data.thumbnailViewModel?.thumbnailViewModel?.image?.sources
-    const hasThumbnail = data.thumbnail?.thumbnails?.length > 0
-    super(hasThumbnail || !sources
-      ? data
-      : { ...data, thumbnail: { thumbnails: sources } })
+if (process.env.SUPPORTS_LOCAL_API) {
+  class ShortsLockupViewWithThumbnail extends YTNodes.ShortsLockupView {
+    constructor(data) {
+      const sources = data.thumbnailViewModel?.thumbnailViewModel?.image?.sources
+      const hasThumbnail = data.thumbnail?.thumbnails?.length > 0
+      super(hasThumbnail || !sources
+        ? data
+        : { ...data, thumbnail: { thumbnails: sources } })
+    }
   }
-}
 
-Parser.addRuntimeParser('ShortsLockupView', ShortsLockupViewWithThumbnail)
+  Parser.addRuntimeParser('ShortsLockupView', ShortsLockupViewWithThumbnail)
+}
 
 if (process.env.SUPPORTS_LOCAL_API) {
   Platform.shim.eval = (data) => {

--- a/src/renderer/helpers/descriptionLinks.js
+++ b/src/renderer/helpers/descriptionLinks.js
@@ -1,0 +1,34 @@
+import autolinker from 'autolinker'
+
+// YouTube only links the `#hashtags` and `@handles` that it recognised itself,
+// the rest stays plain text, so we link those ourselves.
+// Autolinker skips text inside existing links and HTML attributes,
+// so the ones that came linked from the backend are left untouched.
+const HASHTAG_AND_HANDLE_OPTIONS = {
+  hashtag: 'youtube',
+  mention: 'youtube'
+}
+
+/**
+ * Links URLs, e-mail addresses, `#hashtags` and `@handles` in a plain text description.
+ * @param {string} description
+ * @returns {string}
+ */
+export function linkifyDescription(description) {
+  return autolinker.link(description, HASHTAG_AND_HANDLE_OPTIONS)
+}
+
+/**
+ * Links only the `#hashtags` and `@handles` in text that is already HTML,
+ * e.g. a description where the backend linked everything else already.
+ * @param {string} html
+ * @returns {string}
+ */
+export function linkifyHashtagsAndHandles(html) {
+  return autolinker.link(html, {
+    ...HASHTAG_AND_HANDLE_OPTIONS,
+    urls: false,
+    email: false,
+    phone: false
+  })
+}

--- a/src/renderer/helpers/utils.js
+++ b/src/renderer/helpers/utils.js
@@ -432,6 +432,19 @@ export function openInternalPath({ path, query = undefined, doCreateNewWindow = 
       })
     }
   } else {
+    // The web build has no tabs or windows of its own, so a Ctrl/middle/Shift+click
+    // is handed to the browser, pointed at this app's route for the destination
+    // instead of the external URL the click started from.
+    if (doCreateNewTab || doCreateNewWindow) {
+      const { href } = router.resolve({ path, query })
+
+      // `window.open` returns null when a popup blocker steps in,
+      // navigating in place is better than doing nothing at all
+      if (window.open(href, '_blank', doCreateNewWindow ? 'popup' : undefined) != null) {
+        return
+      }
+    }
+
     router.push({
       path,
       query,

--- a/src/renderer/views/Hashtag/Hashtag.vue
+++ b/src/renderer/views/Hashtag/Hashtag.vue
@@ -116,7 +116,9 @@ function resetData() {
 }
 
 async function getHashtag() {
-  hashtag.value = decodeURIComponent(route.params.hashtag)
+  // Hashtag pages only exist in lowercase, querying them with the casing used in
+  // a video description (e.g. `#ShiorinSketch`) returns no videos at all
+  hashtag.value = decodeURIComponent(route.params.hashtag).toLowerCase()
   if (process.env.SUPPORTS_LOCAL_API && backendPreference.value === 'local') {
     await getLocalHashtag()
   } else {

--- a/tests/unit/description-links.test.mjs
+++ b/tests/unit/description-links.test.mjs
@@ -1,0 +1,54 @@
+import assert from 'node:assert/strict'
+import test from 'node:test'
+
+import { linkifyDescription, linkifyHashtagsAndHandles } from '../../src/renderer/helpers/descriptionLinks.js'
+
+test('links hashtags and handles in plain text descriptions', () => {
+  const html = linkifyDescription('Follow @SomeCreator #Deutsch')
+
+  assert.match(html, /<a href="https:\/\/youtube\.com\/@SomeCreator"[^>]*>@SomeCreator<\/a>/)
+  assert.match(html, /<a href="https:\/\/youtube\.com\/hashtag\/Deutsch"[^>]*>#Deutsch<\/a>/)
+})
+
+test('still links URLs and email addresses in plain text descriptions', () => {
+  const html = linkifyDescription('Visit https://example.com or mail me at someone@example.com')
+
+  assert.match(html, /<a href="https:\/\/example\.com"[^>]*>example\.com<\/a>/)
+  assert.match(html, /<a href="mailto:someone@example\.com"[^>]*>someone@example\.com<\/a>/)
+})
+
+test('leaves hashtags and handles that the backend linked already untouched', () => {
+  const html = linkifyHashtagsAndHandles('<a href="https://www.youtube.com/hashtag/linked">#linked</a> #plain')
+
+  assert.match(html, /^<a href="https:\/\/www\.youtube\.com\/hashtag\/linked">#linked<\/a> /)
+  assert.match(html, /<a href="https:\/\/youtube\.com\/hashtag\/plain"[^>]*>#plain<\/a>$/)
+})
+
+test('leaves the URLs in an HTML description to the backend', () => {
+  const html = linkifyHashtagsAndHandles('Visit https://example.com about #tag')
+
+  assert.match(html, /^Visit https:\/\/example\.com about /)
+  assert.match(html, /<a href="https:\/\/youtube\.com\/hashtag\/tag"[^>]*>#tag<\/a>$/)
+})
+
+test('does not link things that only look like hashtags or handles', () => {
+  // `#` in `C#` and `@` in an email address are not tags/handles,
+  // neither are handles that are too short to exist on YouTube
+  const html = linkifyHashtagsAndHandles('C# is not F#, foo@bar.com is an address and @ab is too short')
+
+  assert.doesNotMatch(html, /<a/)
+})
+
+test('keeps the escaped HTML of a title escaped', () => {
+  // titles are plain text, so they get escaped before their hashtags and handles are linked
+  const html = linkifyHashtagsAndHandles('&lt;b&gt;Bold&lt;/b&gt; #Tag')
+
+  assert.match(html, /^&lt;b&gt;Bold&lt;\/b&gt; /)
+  assert.match(html, /<a href="https:\/\/youtube\.com\/hashtag\/Tag"[^>]*>#Tag<\/a>$/)
+})
+
+test('does not link inside HTML attributes', () => {
+  const html = linkifyHashtagsAndHandles('<img src="https://example.com/emoji.png" alt="#emoji">')
+
+  assert.strictEqual(html, '<img src="https://example.com/emoji.png" alt="#emoji">')
+})


### PR DESCRIPTION
## Pull Request Type
<!-- Please select what type of pull request this is: [x] -->
- [ ] Bugfix
- [x] Feature Implementation
- [ ] Documentation
- [ ] Other

## Related issue
closes #437

## Description
YouTube only links the `#hashtags` and `@handles` that it recognised itself, everything else stays plain text and is not clickable. This links the leftovers in both the video title and the video description, using Autolinker's YouTube service (Autolinker is already a dependency). Because Autolinker skips text inside existing links and HTML attributes, the ones that already came linked from the backend are left untouched, so nothing gets double linked.

The links point at `youtube.com/hashtag/<tag>` and `youtube.com/@<handle>`, which the existing in-app link handling already routes to the Hashtag view and the channel resolver, so no new plumbing was needed.

While testing this, a related bug turned up: hashtag pages only exist in lowercase. Requesting one with the casing used in a description returns no videos at all (verified against the API: `getHashtag('ShiorinSketch')` → 0 videos, `getHashtag('shiorinsketch')` → 36). Clicking `#ShiorinSketch` therefore landed on an empty page, while searching for the same tag worked, because search results already carry the canonical lowercase title. The tag is now normalized in the Hashtag view, which covers every entry point into it (description links, search results, pasted URLs).

Notes on the implementation:

- The video title is now rendered with the existing `v-safer-html` directive instead of text interpolation. The title is plain text, so it is escaped before the hashtags and handles are linked, and the directive's strict sanitizer only lets `<a href>` through.
- `vuejs-accessibility/heading-has-content` does not know that `v-safer-html` fills the heading, so the directive is registered via the rule's `accessibleDirectives` option rather than with a disable comment.

### Also in here

Two web build fixes came out of the Greptile review on this PR:

- The delegated `click`/`auxclick` handlers were only registered in Electron, so on the web every absolute `youtube.com` link in a description, comment or community post navigated the browser away from the app. They are now registered in both builds. The web build has no tabs or windows of its own, so a Ctrl/middle/Shift+click hands the browser this app's route for the destination rather than the YouTube URL, falling back to navigating in place when a popup blocker refuses the `window.open`. Mouse buttons 3/4 keep using the browser's own history there.
- While verifying that, it turned out the web build has not started at all since 2026-07-29 (`2062a63a4`): `local.js` declares `class ShortsLockupViewWithThumbnail extends YTNodes.ShortsLockupView` at import time, while the web config resolves `youtubei.js` to the `{}` external, so the module threw and Vue never mounted. The class is now guarded by the local API flag.

Happy to split either of those into their own PR if you would rather they had their own release note.

## Screenshots
<!-- Please add before and after screenshots if there is a visible change. -->

## Release note category
<!-- release-note-category:start -->
- [ ] Not noteworthy
- [ ] Highlights
- [x] More improvements
- [ ] Fixed bugs
<!-- release-note-category:end -->

## Release note
<!-- release-note:start -->
Hashtags and handles in video titles and descriptions are now clickable, even when YouTube did not link them itself
<!-- release-note:end -->

## Release note images
<!-- release-note-image:start -->

<!-- release-note-image:end -->

## Testing
Automated:

- `pnpm run test:unit` — `tests/unit/description-links.test.mjs` covers the linking helper: hashtags/handles get linked, URLs and e-mail addresses keep working, already linked tags are left alone, escaped HTML in a title stays escaped, and `C#`/`foo@bar.com`/too-short handles are not linked.
- `pnpm run test:e2e:offline` — `e2e/tests/offline/description-links.spec.mjs` asserts the rendered links on the watch page and that clicking the hashtag in the title opens the hashtag page, plus that the hashtag page is requested in lowercase regardless of the casing in the link. It reuses the committed watch fixture with a patched title/description, so no new recordings were needed.

Manual:

1. Open a video whose description contains a hashtag or a handle that YouTube did not link (plain text, not blue on YouTube itself).
2. The tag and handle are now links in both the title and the description.
3. Click a hashtag with mixed casing, e.g. `#ShiorinSketch` — the hashtag page opens and lists videos instead of "This hashtag does not currently have any videos".

Web build (`pnpm run dev:web`, checked in a browser):

1. A plain click on a `#ShiorinSketch` and on a `@SomeCreator` link stays on `localhost` and routes to `#/hashtag/shiorinsketch` and `#/channel/@SomeCreator/videos`.
2. Ctrl+click and Shift+click call `window.open` with `#/hashtag/…`, this app's own route, instead of the youtube.com URL, and leave the current page where it is.
3. The app mounts at all again, which it did not before the `local.js` fix.

## Desktop
- **OS:** Linux
- **OS Version:** Arch Linux (KDE Plasma, Wayland)
- **OpenTubeX version:** development branch, commit cef45bc2c

## Additional context
The hashtag lowercase fix is intentionally in the Hashtag view rather than in the link generation, so that it also applies to hashtag links coming from YouTube itself and to URLs opened from outside the app.

