### PR TITLE
feat(watch): show games in the video description

### DIFF
--- a/patches/youtubei.js@17.2.0.patch
+++ b/patches/youtubei.js@17.2.0.patch
@@ -1,3 +1,35 @@
+diff --git a/dist/src/parser/classes/VideoAttributeView.d.ts b/dist/src/parser/classes/VideoAttributeView.d.ts
+index fe90c6fe53ec4428d9a55c60902da64771541c60..f02b34a6727688b0dc21c800d96277b8151e9272 100644
+--- a/dist/src/parser/classes/VideoAttributeView.d.ts
++++ b/dist/src/parser/classes/VideoAttributeView.d.ts
+@@ -14,6 +14,7 @@ export default class VideoAttributeView extends YTNode {
+     };
+     orientation: string;
+     sizing_rule: string;
++    on_tap: NavigationEndpoint;
+     overflow_menu_on_tap: NavigationEndpoint;
+     overflow_menu_a11y_label: string;
+     constructor(data: RawNode);
+diff --git a/dist/src/parser/classes/VideoAttributeView.js b/dist/src/parser/classes/VideoAttributeView.js
+index f310e850d6f41c9e85457d6bfad62c4dc80af605..f1c1acb6b21af0d33cd153b058b3ec0957cc3c1a 100644
+--- a/dist/src/parser/classes/VideoAttributeView.js
++++ b/dist/src/parser/classes/VideoAttributeView.js
+@@ -12,6 +12,7 @@ export default class VideoAttributeView extends YTNode {
+     secondary_subtitle;
+     orientation;
+     sizing_rule;
++    on_tap;
+     overflow_menu_on_tap;
+     overflow_menu_a11y_label;
+     constructor(data) {
+@@ -32,6 +33,7 @@ export default class VideoAttributeView extends YTNode {
+         }
+         this.orientation = data.orientation;
+         this.sizing_rule = data.sizingRule;
++        this.on_tap = new NavigationEndpoint(data.onTap?.innertubeCommand);
+         this.overflow_menu_on_tap = new NavigationEndpoint(data.overflowMenuOnTap);
+         this.overflow_menu_a11y_label = data.overflowMenuA11yLabel;
+     }
 diff --git a/dist/src/parser/classes/comments/CommentReplies.d.ts b/dist/src/parser/classes/comments/CommentReplies.d.ts
 index 3a48b70d187b2f854452d56ce292d2548b660f27..4b5ea214f8ae2a208b0d00191473012e4d4aaa75 100644
 --- a/dist/src/parser/classes/comments/CommentReplies.d.ts

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -10,7 +10,7 @@ overrides:
 
 patchedDependencies:
   shaka-player@5.1.12: 17d85e267c8958999207ce9d6c29a2ddf18734d0499fb30870ac8a55d90303fa
-  youtubei.js@17.2.0: d6bc7c51e55711aa228bc7958a1b254742daec8aaed75d92bb35a2b27b3012c0
+  youtubei.js@17.2.0: f14e5ed4f8363dc2b71831fc93c43f1f9ed1b760786d710e55ade93df94f7a3c
 
 importers:
 
@@ -81,7 +81,7 @@ importers:
         version: 4.1.0(vue@3.5.40)
       youtubei.js:
         specifier: ^17.2.0
-        version: 17.2.0(patch_hash=d6bc7c51e55711aa228bc7958a1b254742daec8aaed75d92bb35a2b27b3012c0)
+        version: 17.2.0(patch_hash=f14e5ed4f8363dc2b71831fc93c43f1f9ed1b760786d710e55ade93df94f7a3c)
     devDependencies:
       '@babel/core':
         specifier: ^8.0.1
@@ -10609,7 +10609,7 @@ snapshots:
 
   yocto-queue@0.1.0: {}
 
-  youtubei.js@17.2.0(patch_hash=d6bc7c51e55711aa228bc7958a1b254742daec8aaed75d92bb35a2b27b3012c0):
+  youtubei.js@17.2.0(patch_hash=f14e5ed4f8363dc2b71831fc93c43f1f9ed1b760786d710e55ade93df94f7a3c):
     dependencies:
       '@bufbuild/protobuf': 2.1.0
       fflate: 0.8.3

--- a/src/renderer/components/WatchVideoDescription/WatchVideoDescription.css
+++ b/src/renderer/components/WatchVideoDescription/WatchVideoDescription.css
@@ -85,8 +85,8 @@
 
 .game {
   display: flex;
-  align-items: center;
-  gap: 12px;
+  align-items: flex-start;
+  gap: 16px;
   padding-block: 6px;
   color: inherit;
   text-decoration: none;
@@ -97,9 +97,11 @@
   text-decoration: underline;
 }
 
+/* YouTube renders the box art at 164x230, the source image is 160x224 */
 .gameBoxArt {
-  inline-size: 40px;
-  block-size: 56px;
+  inline-size: 160px;
+  block-size: 224px;
+  max-inline-size: 40%;
   object-fit: cover;
   border-radius: calc(5px * var(--ui-roundness));
 }

--- a/src/renderer/components/WatchVideoDescription/WatchVideoDescription.css
+++ b/src/renderer/components/WatchVideoDescription/WatchVideoDescription.css
@@ -70,3 +70,50 @@
   display: block;
   margin-block: 1em;
 }
+
+.gamesHeading {
+  margin-block: 1em 0.5em;
+  font-size: 17px;
+  color: var(--primary-text-color);
+}
+
+.gameList {
+  margin: 0;
+  padding: 0;
+  list-style: none;
+}
+
+.game {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  padding-block: 6px;
+  color: inherit;
+  text-decoration: none;
+}
+
+.gameLink:hover,
+.gameLink:focus {
+  text-decoration: underline;
+}
+
+.gameBoxArt {
+  inline-size: 40px;
+  block-size: 56px;
+  object-fit: cover;
+  border-radius: calc(5px * var(--ui-roundness));
+}
+
+.gameText {
+  display: flex;
+  flex-direction: column;
+}
+
+.gameTitle {
+  color: var(--primary-text-color);
+}
+
+.gameSubtitle {
+  font-size: 14px;
+  color: var(--secondary-text-color);
+}

--- a/src/renderer/components/WatchVideoDescription/WatchVideoDescription.css
+++ b/src/renderer/components/WatchVideoDescription/WatchVideoDescription.css
@@ -85,6 +85,9 @@
 
 .game {
   display: flex;
+
+  /* shrink wrap, so that the empty space next to the game isn't clickable too */
+  inline-size: fit-content;
   align-items: flex-start;
   gap: 16px;
   padding-block: 6px;
@@ -96,7 +99,6 @@
 .gameBoxArt {
   inline-size: 160px;
   block-size: 224px;
-  max-inline-size: 40%;
   object-fit: cover;
   border-radius: calc(5px * var(--ui-roundness));
 }

--- a/src/renderer/components/WatchVideoDescription/WatchVideoDescription.css
+++ b/src/renderer/components/WatchVideoDescription/WatchVideoDescription.css
@@ -92,11 +92,6 @@
   text-decoration: none;
 }
 
-.gameLink:hover,
-.gameLink:focus {
-  text-decoration: underline;
-}
-
 /* YouTube renders the box art at 164x230, the source image is 160x224 */
 .gameBoxArt {
   inline-size: 160px;

--- a/src/renderer/components/WatchVideoDescription/WatchVideoDescription.vue
+++ b/src/renderer/components/WatchVideoDescription/WatchVideoDescription.vue
@@ -50,7 +50,6 @@
               :to="`/channel/${game.channelId}`"
               :tabindex="game.channelId ? linkTabIndex : null"
               class="game"
-              :class="{ gameLink: !!game.channelId }"
             >
               <img
                 v-if="game.thumbnail"

--- a/src/renderer/components/WatchVideoDescription/WatchVideoDescription.vue
+++ b/src/renderer/components/WatchVideoDescription/WatchVideoDescription.vue
@@ -126,7 +126,9 @@ const descriptionScroll = useTemplateRef('descriptionScroll')
 const descriptionContainer = useTemplateRef('descriptionContainer')
 const showFullDescription = ref(false)
 const showControls = ref(false)
-const isExpanded = computed(() => props.alwaysExpanded || showFullDescription.value)
+// a video can have games but no description, and there is nothing to expand or collapse then,
+// so treat it as expanded. `measureDescription` can't do it, it bails out on a zero height element.
+const isExpanded = computed(() => props.alwaysExpanded || shownDescription === '' || showFullDescription.value)
 
 if (props.descriptionHtml !== '') {
   const parsed = parseDescriptionHtml(props.descriptionHtml)

--- a/src/renderer/components/WatchVideoDescription/WatchVideoDescription.vue
+++ b/src/renderer/components/WatchVideoDescription/WatchVideoDescription.vue
@@ -1,6 +1,6 @@
 <template>
   <FtCard
-    v-if="shownDescription.length > 0"
+    v-if="shownDescription.length > 0 || games.length > 0"
     :class="{
       videoDescription: true,
       short: !isExpanded,
@@ -36,6 +36,40 @@
       >
         {{ license }}
       </bdi>
+      <template v-if="games.length > 0 && isExpanded">
+        <h3 class="gamesHeading">
+          {{ $t("Description.Games") }}
+        </h3>
+        <ul class="gameList">
+          <li
+            v-for="(game, index) in shownGames"
+            :key="game.channelId ?? index"
+          >
+            <component
+              :is="game.channelId ? 'RouterLink' : 'div'"
+              :to="`/channel/${game.channelId}`"
+              :tabindex="game.channelId ? linkTabIndex : null"
+              class="game"
+              :class="{ gameLink: !!game.channelId }"
+            >
+              <img
+                v-if="game.thumbnail"
+                :src="game.thumbnail"
+                class="gameBoxArt"
+                alt=""
+                loading="lazy"
+              >
+              <span class="gameText">
+                <bdi class="gameTitle">{{ game.title }}</bdi>
+                <bdi
+                  v-if="game.subtitle"
+                  class="gameSubtitle"
+                >{{ game.subtitle }}</bdi>
+              </span>
+            </component>
+          </li>
+        </ul>
+      </template>
     </div>
     <span
       v-if="showControls && isExpanded && !alwaysExpanded"
@@ -59,6 +93,8 @@ import FtTimestampCatcher from '../FtTimestampCatcher.vue'
 
 import { useTabContext } from '../../tabs/TabContext'
 
+import store from '../../store/index'
+
 const props = defineProps({
   description: {
     type: String,
@@ -71,6 +107,11 @@ const props = defineProps({
   license: {
     type: String,
     default: null,
+  },
+  /** @type {import('vue').PropType<import('../../helpers/video-games').LocalVideoGame[]>} */
+  games: {
+    type: Array,
+    default: () => [],
   },
   alwaysExpanded: {
     type: Boolean,
@@ -114,6 +155,15 @@ const processedShownDescription = computed(() => {
 
 const linkTabIndex = computed(() => {
   return isExpanded.value ? '0' : '-1'
+})
+
+// drop the channel ids when channel links are disabled, so that the games render as plain text
+const shownGames = computed(() => {
+  if (!store.getters.getDisableChannelLinks) {
+    return props.games
+  }
+
+  return props.games.map(game => ({ ...game, channelId: undefined }))
 })
 
 /**

--- a/src/renderer/helpers/video-games.js
+++ b/src/renderer/helpers/video-games.js
@@ -1,0 +1,48 @@
+import { YTNodes } from 'youtubei.js'
+
+/**
+ * @typedef {object} LocalVideoGame
+ * @property {string} title
+ * @property {string} subtitle the release year, can be empty
+ * @property {string} thumbnail the box art, can be empty
+ * @property {string|undefined} channelId the game's YouTube channel, undefined when it doesn't have one
+ */
+
+/**
+ * Extracts the games that YouTube lists in the description of gaming videos.
+ * @param {import('youtubei.js').YT.VideoInfo} videoInfo
+ * @returns {LocalVideoGame[]}
+ */
+export function parseLocalVideoGames(videoInfo) {
+  // `VideoAttributesSectionView` is a generic section, so only trust it to contain games on gaming videos.
+  // The category is always in English, no matter which language the rest of the response is in.
+  if (videoInfo.basic_info?.category !== 'Gaming') {
+    return []
+  }
+
+  /** @type {import('youtubei.js').YTNodes.StructuredDescriptionContent | undefined} */
+  const structuredDescription = videoInfo.page[1]?.engagement_panels
+    ?.find(panel => panel.panel_identifier === 'engagement-panel-structured-description')?.content
+
+  const games = []
+
+  for (const section of structuredDescription?.items ?? []) {
+    if (!section.is(YTNodes.VideoAttributesSectionView)) {
+      continue
+    }
+
+    for (const attribute of section.video_attributes) {
+      // `image` is a `ContentPreviewImageView` instead of an array, when YouTube doesn't have any box art
+      const boxArt = Array.isArray(attribute.image) ? attribute.image[0]?.url : undefined
+
+      games.push({
+        title: attribute.title,
+        subtitle: attribute.subtitle ?? '',
+        thumbnail: boxArt?.replace(/^\/\//, 'https://') ?? '',
+        channelId: attribute.on_tap?.payload?.browseId
+      })
+    }
+  }
+
+  return games
+}

--- a/src/renderer/views/Watch/Watch.js
+++ b/src/renderer/views/Watch/Watch.js
@@ -23,6 +23,7 @@ import { calculateColorLuminance } from '../../helpers/colors'
 import { isReducedMotionEnabled } from '../../helpers/reducedMotion'
 import { hasReachedWatchedThreshold, isHistoryEntryWatched } from '../../helpers/history'
 import { isVideoHiddenByPreferences } from '../../helpers/subscriptions'
+import { parseLocalVideoGames } from '../../helpers/video-games'
 import {
   buildChaptersVttFile,
   buildVTTFileLocally,
@@ -212,6 +213,8 @@ export default defineComponent({
       videoDescription: '',
       videoDescriptionHtml: '',
       videoCategory: '',
+      /** @type {import('../../helpers/video-games').LocalVideoGame[]} */
+      videoGames: [],
       license: '',
       videoViewCount: 0,
       videoLikeCount: 0,
@@ -1261,6 +1264,7 @@ export default defineComponent({
       this.videoDescription = ''
       this.videoDescriptionHtml = ''
       this.videoCategory = ''
+      this.videoGames = []
       this.license = ''
       this.videoViewCount = 0
       this.videoLikeCount = 0
@@ -1644,6 +1648,7 @@ export default defineComponent({
         this.hasResolvedVideoTitle = this.videoTitle.length > 0
         this.videoViewCount = result.basic_info.view_count ?? (result.primary_info.view_count ? extractNumberFromString(result.primary_info.view_count.text) : null)
         this.license = result.secondary_info.metadata.rows.find(element => element.title?.text === 'License')?.contents[0]?.text
+        this.videoGames = parseLocalVideoGames(result)
 
         this.channelCollaborators = parseLocalVideoCollaborators(result)
         const primaryCollaborator = this.channelCollaborators[0]

--- a/src/renderer/views/Watch/Watch.vue
+++ b/src/renderer/views/Watch/Watch.vue
@@ -550,6 +550,7 @@
             :description="videoDescription"
             :description-html="videoDescriptionHtml"
             :license="license"
+            :games="videoGames"
             always-expanded
             class="watchVideo"
             @timestamp-event="changeTimestamp"
@@ -663,6 +664,7 @@
           :description="videoDescription"
           :description-html="videoDescriptionHtml"
           :license="license"
+          :games="videoGames"
           :always-expanded="fullscreenMetadataOpen"
           class="watchVideo"
           :class="{ theatreWatchVideo: useTheatreMode }"

--- a/static/locales/en-US.yaml
+++ b/static/locales/en-US.yaml
@@ -1632,6 +1632,7 @@ Description:
   Expand Description: ...more
   Collapse Description: Show less
   Video Category: 'Video Category:'
+  Games: Games
 
 #Tooltips
 Tooltips:

--- a/tests/unit/video-games.test.mjs
+++ b/tests/unit/video-games.test.mjs
@@ -1,0 +1,130 @@
+import assert from 'node:assert/strict'
+import test from 'node:test'
+
+import { YTNodes } from 'youtubei.js'
+
+import { parseLocalVideoGames } from '../../src/renderer/helpers/video-games.js'
+
+/**
+ * Shape captured from a real `/next` response (video PzHN73RQPQs).
+ * @param {object} [overrides]
+ */
+function rawGamesSection(overrides = {}) {
+  return {
+    headerTitle: 'Games',
+    videoAttributeViewModels: [
+      {
+        videoAttributeViewModel: {
+          image: {
+            sources: [
+              { url: 'https://yt3.ggpht.com/boxart=s112-w80-h112', width: 80, height: 112 },
+              { url: 'https://yt3.ggpht.com/boxart=s224-w160-h224', width: 160, height: 224 }
+            ]
+          },
+          imageStyle: 'VIDEO_ATTRIBUTE_IMAGE_STYLE_PORTRAIT',
+          title: 'Hytale',
+          subtitle: '2026',
+          orientation: 'VIDEO_ATTRIBUTE_ORIENTATION_HORIZONTAL',
+          onTap: {
+            innertubeCommand: {
+              browseEndpoint: { browseId: 'UCgQN2C6x-1AobLFMpewpAZw' }
+            }
+          },
+          ...overrides
+        }
+      }
+    ]
+  }
+}
+
+/**
+ * @param {object} options
+ * @param {string} [options.category]
+ * @param {import('youtubei.js').Helpers.YTNode[]} [options.items]
+ * @param {string} [options.panelIdentifier]
+ */
+function videoInfo(options) {
+  const { items = [], panelIdentifier = 'engagement-panel-structured-description' } = options
+
+  // an explicit `category: undefined` has to survive, so it can't be a destructuring default
+  const category = 'category' in options ? options.category : 'Gaming'
+
+  return {
+    basic_info: { category },
+    page: [
+      {},
+      {
+        engagement_panels: [
+          { panel_identifier: 'engagement-panel-comments-section', content: { items: [] } },
+          { panel_identifier: panelIdentifier, content: { items } }
+        ]
+      }
+    ]
+  }
+}
+
+test('extracts the game, its release year, box art and channel', () => {
+  const section = new YTNodes.VideoAttributesSectionView(rawGamesSection())
+
+  assert.deepEqual(parseLocalVideoGames(videoInfo({ items: [section] })), [
+    {
+      title: 'Hytale',
+      subtitle: '2026',
+      // the largest box art, youtubei.js sorts the thumbnails descending
+      thumbnail: 'https://yt3.ggpht.com/boxart=s224-w160-h224',
+      channelId: 'UCgQN2C6x-1AobLFMpewpAZw'
+    }
+  ])
+})
+
+test('ignores the games section on videos that are not categorised as gaming', () => {
+  const section = new YTNodes.VideoAttributesSectionView(rawGamesSection())
+
+  assert.deepEqual(parseLocalVideoGames(videoInfo({ category: 'Music', items: [section] })), [])
+  assert.deepEqual(parseLocalVideoGames(videoInfo({ category: undefined, items: [section] })), [])
+})
+
+test('skips the sections that do not list games', () => {
+  const transcriptSection = new YTNodes.VideoDescriptionTranscriptSection({})
+
+  assert.deepEqual(parseLocalVideoGames(videoInfo({ items: [transcriptSection] })), [])
+})
+
+test('handles a video without a structured description', () => {
+  assert.deepEqual(parseLocalVideoGames(videoInfo({ panelIdentifier: 'engagement-panel-searchable-transcript' })), [])
+  assert.deepEqual(parseLocalVideoGames({ basic_info: { category: 'Gaming' }, page: [{}, {}] }), [])
+})
+
+test('keeps a game that has no box art or channel', () => {
+  const section = new YTNodes.VideoAttributesSectionView(rawGamesSection({
+    image: { contentPreviewImageViewModel: {} },
+    subtitle: undefined,
+    onTap: undefined
+  }))
+
+  assert.deepEqual(parseLocalVideoGames(videoInfo({ items: [section] })), [
+    {
+      title: 'Hytale',
+      subtitle: '',
+      thumbnail: '',
+      channelId: undefined
+    }
+  ])
+})
+
+test('extracts every game of a video that lists more than one', () => {
+  const raw = rawGamesSection()
+  raw.videoAttributeViewModels.push({
+    videoAttributeViewModel: {
+      image: { sources: [{ url: 'https://yt3.ggpht.com/other=s224', width: 160, height: 224 }] },
+      title: 'Minecraft',
+      subtitle: '2011',
+      onTap: { innertubeCommand: { browseEndpoint: { browseId: 'UCq6aw03lNILzV96UvEAASfQ' } } }
+    }
+  })
+
+  const games = parseLocalVideoGames(videoInfo({ items: [new YTNodes.VideoAttributesSectionView(raw)] }))
+
+  assert.deepEqual(games.map(game => game.title), ['Hytale', 'Minecraft'])
+  assert.equal(games[1].channelId, 'UCq6aw03lNILzV96UvEAASfQ')
+})


### PR DESCRIPTION
## Pull Request Type
<!-- Please select what type of pull request this is: [x] -->
- [ ] Bugfix
- [x] Feature Implementation
- [ ] Documentation
- [ ] Other

## Related issue
closes #456

## Description
YouTube lists the games a video is about below the description (e.g. https://www.youtube.com/watch?v=PzHN73RQPQs). This adds the same to the watch page: the box art, the game's title and its release year, rendered below the description once it is expanded, linking to the game's channel.

Some implementation notes:

- The data is **not** where youtubei.js' `game_info` looks for it anymore. That property reads `RichMetadataRow` out of `secondary_info.metadata.rows`, which is empty for every gaming video I tried, so `game_info` is always `undefined`. The games now live in the structured description engagement panel as a `VideoAttributesSectionView`.
- `VideoAttributesSectionView` is a generic section, so it is only trusted to contain games on videos categorised as `Gaming`. Worth noting that `basic_info.category` stays the English `Gaming` regardless of `hl` (verified against `de`/`fr`/`ja`/`es`) — it is the section's own `header_title` that gets localised, which is why the heading uses our own translated string instead.
- youtubei.js parses `overflowMenuOnTap` for `VideoAttributeView` but not `onTap`, which is where the link to the game's channel lives, so the patch adds it. This is worth upstreaming.
- Games are local API only. Invidious does not return them, so nothing changes there.

## Screenshots <!-- If appropriate -->
<!-- Please add before and after screenshots if there is a visible change. -->

## Release note category
<!-- Select exactly one category. Every pull request must select one. -->
<!-- release-note-category:start -->
- [ ] Not noteworthy
- [ ] Highlights
- [x] More improvements
- [ ] Fixed bugs
<!-- release-note-category:end -->

## Release note
<!-- release-note:start -->
Videos about a game now show the game's box art, title and release year in the description
<!-- release-note:end -->

## Release note images
<!-- release-note-image:start -->
<img width="283" height="308" alt="image" src="https://github.com/user-attachments/assets/0c147b10-c2de-4560-898d-ae80223418c0" />
<!-- release-note-image:end -->

## Testing
Automated: `pnpm run test:unit` — `tests/unit/video-games.test.mjs` builds real `YTNodes.VideoAttributesSectionView` instances from a captured `/next` payload shape and covers extraction, the `Gaming` gate, non-game sections, a missing panel, a game without box art or channel, and multiple games per video. It also covers the patch: the `channelId` assertion fails against unpatched youtubei.js.

Manual:

1. Open https://www.youtube.com/watch?v=PzHN73RQPQs (`PzHN73RQPQs`) with the local API and expand the description — a "Games" section should show Hytale, 2026 and its box art.
2. Click it, it should open the game's channel (`UCgQN2C6x-1AobLFMpewpAZw`).
3. Enable "Hide Channel Links" in the distraction free settings, the entry should stay visible but stop being a link.
4. Open any non-gaming video, no "Games" section should appear.

Note that I have not exercised this through the E2E suite — the games section only exists in a real `/next` response, so it would need a newly recorded network fixture. The extraction itself was verified against live YouTube.

## Desktop
- **OS:** Arch Linux (KDE Plasma, Wayland)
- **OS Version:** rolling
- **OpenTubeX version:** 0.30.2

## Additional context
The heading string `Description.Games` was added to `en-US.yaml` only, the rest comes from Weblate.
