### PR TITLE
feat: show global progress in notifications

### DIFF
--- a/e2e/tests/offline/appearance.spec.mjs
+++ b/e2e/tests/offline/appearance.spec.mjs
@@ -57,6 +57,32 @@ test.describe('default appearance', () => {
   })
 })
 
+test.describe('global progress presentation', () => {
+  test('uses a persistent notification or the global bar based on the theme setting', async ({ page }) => {
+    await page.evaluate(() => {
+      const store = document.querySelector('#app').__vue_app__.config.globalProperties.$store
+      store.commit('setProgressBarMessage', 'Downloading yt-dlp and ffmpeg')
+      store.commit('setProgressBarIcon', ['fas', 'download'])
+      store.commit('setProgressBarPercentage', 42)
+      store.commit('setShowProgressBar', true)
+    })
+
+    const progressToast = page.getByTestId('progress-toast')
+    await expect(progressToast).toContainText('Downloading yt-dlp and ffmpeg')
+    await expect(progressToast.locator('.icon')).toHaveAttribute('data-icon', 'download')
+    await expect(progressToast.locator('.progress-indicator')).toHaveAttribute('data-progress', '42')
+    await expect(page.locator('.app > .progressBar')).toHaveCount(0)
+
+    await page.evaluate(() => {
+      const store = document.querySelector('#app').__vue_app__.config.globalProperties.$store
+      store.commit('setShowProgressBarToast', false)
+    })
+
+    await expect(progressToast).toHaveCount(0)
+    await expect(page.locator('.app > .progressBar')).toBeVisible()
+  })
+})
+
 test.describe('UI roundness', () => {
   test.use({ seed: { settings: { uiRoundness: 0 } } })
 

--- a/e2e/tests/offline/appearance.spec.mjs
+++ b/e2e/tests/offline/appearance.spec.mjs
@@ -79,7 +79,18 @@ test.describe('global progress presentation', () => {
     })
 
     await expect(progressToast).toHaveCount(0)
-    await expect(page.locator('.app > .progressBar')).toBeVisible()
+    await expect(page.locator('.app > .progressBar')).toHaveCount(1)
+
+    await page.evaluate(() => {
+      const store = document.querySelector('#app').__vue_app__.config.globalProperties.$store
+      store.commit('setShowProgressBarToast', true)
+    })
+    await expect(progressToast).toBeVisible()
+
+    await page.evaluate(() => document.querySelector('.app').requestFullscreen())
+    await expect.poll(() => page.evaluate(() => document.fullscreenElement !== null)).toBe(true)
+    await expect(progressToast).toBeVisible()
+    await page.evaluate(() => document.exitFullscreen())
   })
 })
 

--- a/e2e/tests/offline/settings.spec.mjs
+++ b/e2e/tests/offline/settings.spec.mjs
@@ -520,6 +520,26 @@ test.describe('settings', () => {
     await expect(toast).toHaveCount(0)
   })
 
+  test('does not dismiss non-actionable toasts when clicked', async ({ page }) => {
+    await page.evaluate(() => {
+      window.ftElectron.showToastOnAllTabs('Swipe-only dismissal', 10000)
+    })
+
+    const toast = page.locator('.toast', { hasText: 'Swipe-only dismissal' })
+    await expect(toast).toBeVisible()
+    await expect(toast).not.toHaveAttribute('tabindex')
+
+    await toast.click()
+    await expect(toast).toBeVisible()
+
+    const bounds = await toast.boundingBox()
+    await page.mouse.move(bounds.x + bounds.width - 5, bounds.y + bounds.height / 2)
+    await page.mouse.down()
+    await page.mouse.move(bounds.x - 120, bounds.y + bounds.height / 2, { steps: 5 })
+    await page.mouse.up()
+    await expect(toast).toHaveCount(0)
+  })
+
   test('configures the toast timeout indicator and pauses toasts on hover', async ({ page }) => {
     await goTo(page, 'settings')
 

--- a/src/renderer/App.vue
+++ b/src/renderer/App.vue
@@ -650,7 +650,9 @@ async function initializeManagedDownloadTools() {
     showToolProgress(message)
   }
 
-  const progressByBinary = {}
+  const progressByBinary = Object.fromEntries(
+    binariesToUpdate.map(binary => [binary, 0])
+  )
   const removeProgressListener = window.ftElectron.addYtDlpBinaryDownloadProgressListener(({ binary, percent, inProgress }) => {
     if (!binariesToUpdate.includes(binary) || !inProgress || percent === null) {
       return

--- a/src/renderer/App.vue
+++ b/src/renderer/App.vue
@@ -469,8 +469,8 @@ const localProgressBarVisible = computed(() => store.getters.getShowProgressBar)
 
 /** @type {import('vue').ComputedRef<boolean>} */
 const subscriptionRefreshInProgress = computed(() => store.getters.getSubscriptionFeedRefreshInProgress)
-const subscriptionRefreshUsesToast = computed(() => {
-  return store.getters.getShowSubscriptionRefreshToast
+const progressUsesToast = computed(() => {
+  return store.getters.getShowProgressBarToast
 })
 
 const presentedRoutePath = computed(() => {
@@ -482,9 +482,9 @@ const presentedRoutePath = computed(() => {
 
 const showProgressBar = computed(() => {
   // The Subscriptions view shows its own progress bar below the tab bar
-  return localProgressBarVisible.value ||
+  return (localProgressBarVisible.value && !progressUsesToast.value) ||
     (subscriptionRefreshInProgress.value &&
-      !subscriptionRefreshUsesToast.value &&
+      !progressUsesToast.value &&
       presentedRoutePath.value !== '/subscriptions')
 })
 const displayedProgressBarPercentage = computed(() => {
@@ -634,18 +634,20 @@ async function initializeManagedDownloadTools() {
   let downloadStarted = missingBinaries.length > 0
   let toolProgressPercentage = 0
 
-  function showToolProgress() {
+  function showToolProgress(message) {
+    store.commit('setProgressBarMessage', message)
+    store.commit('setProgressBarIcon', ['fas', 'download'])
     store.commit('setProgressBarPercentage', toolProgressPercentage)
     store.commit('setShowProgressBar', true)
   }
 
   if (downloadStarted) {
-    const missingTools = missingBinaries.join(' and ')
-    showToast({
-      message: t('Settings.Download Settings.Managed Tools Download Started Template', { tools: missingTools }),
-      icon: ['fas', 'download'],
-    })
-    showToolProgress()
+    const tools = binariesToUpdate.join(' and ')
+    const message = t('Settings.Download Settings.Managed Tools Download Started Template', { tools })
+    if (!progressUsesToast.value) {
+      showToast({ message, icon: ['fas', 'download'] })
+    }
+    showToolProgress(message)
   }
 
   const progressByBinary = {}
@@ -656,11 +658,12 @@ async function initializeManagedDownloadTools() {
 
     if (!downloadStarted) {
       downloadStarted = true
-      showToast({
-        message: t('Settings.Download Settings.Managed Tools Update Started Template', { tools: binary }),
-        icon: ['fas', 'download'],
-      })
-      showToolProgress()
+      const tools = binariesToUpdate.join(' and ')
+      const message = t('Settings.Download Settings.Managed Tools Update Started Template', { tools })
+      if (!progressUsesToast.value) {
+        showToast({ message, icon: ['fas', 'download'] })
+      }
+      showToolProgress(message)
     }
 
     progressByBinary[binary] = Math.max(progressByBinary[binary] ?? 0, percent)
@@ -707,6 +710,8 @@ async function initializeManagedDownloadTools() {
     if (downloadStarted) {
       store.commit('setShowProgressBar', false)
       store.commit('setProgressBarPercentage', 0)
+      store.commit('setProgressBarMessage', '')
+      store.commit('setProgressBarIcon', ['fas', 'sync'])
     }
   }
 }

--- a/src/renderer/components/DataSettings/DataSettings.vue
+++ b/src/renderer/components/DataSettings/DataSettings.vue
@@ -132,6 +132,7 @@ import FtTooltip from '../FtTooltip/FtTooltip.vue'
 
 import store from '../../store/index'
 import { defaultUpdaterId, NON_TRANSFERABLE_SETTINGS } from '../../store/modules/settings'
+import { migrateLegacySettings } from '../../helpers/settings-migrations'
 
 import { MAIN_PROFILE_ID } from '../../../constants'
 import { calculateColorLuminance, getRandomColor } from '../../helpers/colors'
@@ -1710,6 +1711,8 @@ async function importSettings() {
       }).filter((entry) => entry.length > 0)
     )
   }
+
+  importedSettings = migrateLegacySettings(importedSettings)
 
   const currentTransferableSettings = transferableSettings.value
   const currentSettings = store.state.settings

--- a/src/renderer/components/FtToast/FtToast.css
+++ b/src/renderer/components/FtToast/FtToast.css
@@ -144,15 +144,16 @@
   color: #fff;
   border-radius: calc(12px * var(--ui-roundness));
   box-shadow: 0 4px 16px rgb(0 0 0 / 35%);
-
-  /* Many toasts are clickable, so keep the click affordance until a drag starts */
-  cursor: pointer;
   pointer-events: auto;
   user-select: none;
 
   /* Let the component own horizontal drag gestures instead of the browser */
   touch-action: pan-y;
   transition: transform 300ms ease, opacity 300ms ease;
+}
+
+.toast.actionable {
+  cursor: pointer;
 }
 
 .timeout-indicator-track {

--- a/src/renderer/components/FtToast/FtToast.vue
+++ b/src/renderer/components/FtToast/FtToast.vue
@@ -21,9 +21,9 @@
         <div
           v-overlay-scrollbars
           class="toast"
-          :class="{ hasImage: toast.image, dragging: toast.dragging }"
+          :class="{ hasImage: toast.image, actionable: toast.action, dragging: toast.dragging }"
           :style="dragStyle(toast)"
-          tabindex="0"
+          :tabindex="toast.action ? 0 : null"
           role="status"
           @click="onClick(toast)"
           @keydown.enter.prevent="performAction(toast)"
@@ -348,7 +348,11 @@ function open({ detail: { message, time, action, abortSignal, image, icon } }) {
  * @param {Toast} toast
  */
 function performAction(toast) {
-  toast.action?.()
+  if (!toast.action) {
+    return
+  }
+
+  toast.action()
   remove(toast)
 }
 
@@ -366,8 +370,8 @@ function dismiss(toast, direction = toastPosition.value.endsWith('right') ? 'rig
 }
 
 /**
- * Runs the toast action on click, unless the pointer was dragged (in which case
- * the click is the tail end of a drag gesture and should be ignored).
+ * Runs an available toast action on click, unless the pointer was dragged (in
+ * which case the click is the tail end of a drag gesture and should be ignored).
  * @param {Toast} toast
  */
 function onClick(toast) {

--- a/src/renderer/components/FtToast/FtToast.vue
+++ b/src/renderer/components/FtToast/FtToast.vue
@@ -70,24 +70,24 @@
         </div>
       </div>
       <div
-        v-if="showSubscriptionRefreshToast"
-        ref="subscriptionRefreshToast"
-        key="subscription-refresh"
+        v-if="showProgressToast"
+        ref="progressToast"
+        key="progress"
         class="toast-slot persistent-slot"
-        :class="{ minimized: subscriptionRefreshMinimized }"
-        data-testid="subscription-refresh-toast"
+        :class="{ minimized: progressToastMinimized }"
+        :data-testid="store.getters.getShowProgressBar ? 'progress-toast' : 'subscription-refresh-toast'"
       >
         <div
           class="toast persistent"
           role="status"
         >
           <FontAwesomeIcon
-            :icon="subscriptionRefreshIcon"
+            :icon="progressToastIcon"
             class="icon"
             fixed-width
           />
           <p class="message">
-            {{ subscriptionRefreshMessage }}
+            {{ progressToastMessage }}
           </p>
         </div>
         <div
@@ -99,7 +99,7 @@
             :corner-radius="toastProgressRadius"
             :end-arc-fraction="0.5"
             :line-width="toastProgressLineWidth"
-            :progress="subscriptionRefreshProgress"
+            :progress="progressToastPercentage"
             :start-arc-fraction="0.5"
           />
         </div>
@@ -151,9 +151,9 @@ const props = defineProps({
 /** Distance in px a toast must be dragged before it slides away instead of snapping back */
 const DRAG_DISMISS_THRESHOLD = 80
 /** Distance in px at which the persistent refresh toast gets out of the pointer's way */
-const REFRESH_TOAST_PROXIMITY = 32
+const PROGRESS_TOAST_PROXIMITY = 32
 /** Extra distance required before restoring the toast, to avoid flicker around the boundary */
-const REFRESH_TOAST_PROXIMITY_HYSTERESIS = 20
+const PROGRESS_TOAST_PROXIMITY_HYSTERESIS = 20
 
 /** @type {import('vue').Reactive<Toast[]>} */
 const toasts = reactive([])
@@ -162,16 +162,16 @@ const indicatorAnimations = new Map()
 /** @type {import('vue').Ref<Element|null>} */
 const fullscreenTarget = ref(null)
 /** @type {import('vue').Ref<HTMLElement|null>} */
-const subscriptionRefreshToast = useTemplateRef('subscriptionRefreshToast')
-const subscriptionRefreshMinimized = ref(false)
+const progressToast = useTemplateRef('progressToast')
+const progressToastMinimized = ref(false)
 /** @type {DOMRect|null} */
-let subscriptionRefreshBounds = null
+let progressToastBounds = null
 /** @type {HTMLElement|null} */
-let measuredSubscriptionRefreshToast = null
+let measuredProgressToast = null
 /** @type {number|null} */
-let subscriptionRefreshPointerFrame = null
-let subscriptionRefreshPointerX = 0
-let subscriptionRefreshPointerY = 0
+let progressToastPointerFrame = null
+let progressToastPointerX = 0
+let progressToastPointerY = 0
 /** @type {import('vue').ComputedRef<'bottom-left' | 'bottom-center' | 'bottom-right' | 'top-left' | 'top-center' | 'top-right'>} */
 const toastPosition = computed(() => {
   return normalizeToastPosition(store.getters.getToastPosition)
@@ -181,13 +181,17 @@ const hasHorizontalTabBar = computed(() => {
 })
 /** @type {import('vue').ComputedRef<boolean>} */
 const showTimeoutIndicator = computed(() => store.getters.getShowToastTimeoutIndicator)
-const showSubscriptionRefreshToast = computed(() => {
+const showProgressToast = computed(() => {
   return fullscreenTarget.value === null &&
-    props.showSubscriptionRefresh &&
-    store.getters.getShowSubscriptionRefreshToast &&
-    store.getters.getSubscriptionFeedRefreshInProgress
+    store.getters.getShowProgressBarToast &&
+    (store.getters.getShowProgressBar ||
+      (props.showSubscriptionRefresh && store.getters.getSubscriptionFeedRefreshInProgress))
 })
-const subscriptionRefreshProgress = computed(() => store.getters.getSubscriptionFeedRefreshProgress)
+const progressToastPercentage = computed(() => {
+  return store.getters.getShowProgressBar
+    ? store.getters.getProgressBarPercentage
+    : store.getters.getSubscriptionFeedRefreshProgress
+})
 const subscriptionRefreshIcon = computed(() => {
   switch (store.getters.getSubscriptionFeedRefreshTab) {
     case 'shorts':
@@ -212,6 +216,18 @@ const subscriptionRefreshMessage = computed(() => {
       return t('Subscriptions.Refreshing Subscription Videos')
   }
 })
+const progressToastIcon = computed(() => {
+  return store.getters.getShowProgressBar
+    ? store.getters.getProgressBarIcon
+    : subscriptionRefreshIcon.value
+})
+const progressToastMessage = computed(() => {
+  if (!store.getters.getShowProgressBar) {
+    return subscriptionRefreshMessage.value
+  }
+
+  return store.getters.getProgressBarMessage || t('Settings.Theme Settings.Operation in Progress')
+})
 const toastProgressRadius = computed(() => 12 * store.getters.getUiRoundness / 100)
 const toastProgressLineWidth = computed(() => Math.min(4, Math.max(2, 2 * store.getters.getUiRoundness / 100)))
 
@@ -225,48 +241,48 @@ function updateFullscreenTarget() {
  * remain the hit area while minimized so scaling cannot make the state flicker.
  * @param {MouseEvent} event
  */
-function onSubscriptionRefreshPointerMove(event) {
-  subscriptionRefreshPointerX = event.clientX
-  subscriptionRefreshPointerY = event.clientY
-  if (subscriptionRefreshPointerFrame !== null) { return }
+function onProgressToastPointerMove(event) {
+  progressToastPointerX = event.clientX
+  progressToastPointerY = event.clientY
+  if (progressToastPointerFrame !== null) { return }
 
-  subscriptionRefreshPointerFrame = requestAnimationFrame(updateSubscriptionRefreshProximity)
+  progressToastPointerFrame = requestAnimationFrame(updateProgressToastProximity)
 }
 
-function updateSubscriptionRefreshProximity() {
-  subscriptionRefreshPointerFrame = null
-  const element = subscriptionRefreshToast.value
+function updateProgressToastProximity() {
+  progressToastPointerFrame = null
+  const element = progressToast.value
 
   if (!element) {
-    measuredSubscriptionRefreshToast = null
-    subscriptionRefreshBounds = null
-    subscriptionRefreshMinimized.value = false
+    measuredProgressToast = null
+    progressToastBounds = null
+    progressToastMinimized.value = false
     return
   }
 
-  if (element !== measuredSubscriptionRefreshToast) {
-    measuredSubscriptionRefreshToast = element
-    subscriptionRefreshBounds = null
-    subscriptionRefreshMinimized.value = false
+  if (element !== measuredProgressToast) {
+    measuredProgressToast = element
+    progressToastBounds = null
+    progressToastMinimized.value = false
   }
 
-  if (!subscriptionRefreshMinimized.value || subscriptionRefreshBounds === null) {
-    subscriptionRefreshBounds = element.getBoundingClientRect()
+  if (!progressToastMinimized.value || progressToastBounds === null) {
+    progressToastBounds = element.getBoundingClientRect()
   }
 
-  const bounds = subscriptionRefreshBounds
-  const horizontalDistance = Math.max(bounds.left - subscriptionRefreshPointerX, 0, subscriptionRefreshPointerX - bounds.right)
-  const verticalDistance = Math.max(bounds.top - subscriptionRefreshPointerY, 0, subscriptionRefreshPointerY - bounds.bottom)
+  const bounds = progressToastBounds
+  const horizontalDistance = Math.max(bounds.left - progressToastPointerX, 0, progressToastPointerX - bounds.right)
+  const verticalDistance = Math.max(bounds.top - progressToastPointerY, 0, progressToastPointerY - bounds.bottom)
   const distance = Math.hypot(horizontalDistance, verticalDistance)
-  const threshold = REFRESH_TOAST_PROXIMITY +
-    (subscriptionRefreshMinimized.value ? REFRESH_TOAST_PROXIMITY_HYSTERESIS : 0)
+  const threshold = PROGRESS_TOAST_PROXIMITY +
+    (progressToastMinimized.value ? PROGRESS_TOAST_PROXIMITY_HYSTERESIS : 0)
 
-  subscriptionRefreshMinimized.value = distance <= threshold
+  progressToastMinimized.value = distance <= threshold
 }
 
-function resetSubscriptionRefreshProximity() {
-  subscriptionRefreshBounds = null
-  subscriptionRefreshMinimized.value = false
+function resetProgressToastProximity() {
+  progressToastBounds = null
+  progressToastMinimized.value = false
 }
 
 /**
@@ -586,8 +602,8 @@ function cleanup(toast) {
 onMounted(() => {
   ToastEventBus.addEventListener('toast-open', open)
   document.addEventListener('fullscreenchange', updateFullscreenTarget)
-  window.addEventListener('mousemove', onSubscriptionRefreshPointerMove)
-  window.addEventListener('resize', resetSubscriptionRefreshProximity)
+  window.addEventListener('mousemove', onProgressToastPointerMove)
+  window.addEventListener('resize', resetProgressToastProximity)
   updateFullscreenTarget()
 
   if (process.env.IS_ELECTRON) {
@@ -600,10 +616,10 @@ onMounted(() => {
 onBeforeUnmount(() => {
   ToastEventBus.removeEventListener('toast-open', open)
   document.removeEventListener('fullscreenchange', updateFullscreenTarget)
-  window.removeEventListener('mousemove', onSubscriptionRefreshPointerMove)
-  window.removeEventListener('resize', resetSubscriptionRefreshProximity)
-  if (subscriptionRefreshPointerFrame !== null) {
-    cancelAnimationFrame(subscriptionRefreshPointerFrame)
+  window.removeEventListener('mousemove', onProgressToastPointerMove)
+  window.removeEventListener('resize', resetProgressToastProximity)
+  if (progressToastPointerFrame !== null) {
+    cancelAnimationFrame(progressToastPointerFrame)
   }
   removeShowToastListener?.()
   toasts.forEach(cleanup)

--- a/src/renderer/components/FtToast/FtToast.vue
+++ b/src/renderer/components/FtToast/FtToast.vue
@@ -182,8 +182,7 @@ const hasHorizontalTabBar = computed(() => {
 /** @type {import('vue').ComputedRef<boolean>} */
 const showTimeoutIndicator = computed(() => store.getters.getShowToastTimeoutIndicator)
 const showProgressToast = computed(() => {
-  return fullscreenTarget.value === null &&
-    store.getters.getShowProgressBarToast &&
+  return store.getters.getShowProgressBarToast &&
     (store.getters.getShowProgressBar ||
       (props.showSubscriptionRefresh && store.getters.getSubscriptionFeedRefreshInProgress))
 })

--- a/src/renderer/components/SubscriptionSettings/SubscriptionSettings.vue
+++ b/src/renderer/components/SubscriptionSettings/SubscriptionSettings.vue
@@ -12,14 +12,6 @@
           compact
           @change="updateFetchSubscriptionsAutomatically"
         />
-        <FtToggleSwitch
-          :label="$t('Settings.Subscription Settings.Show Feed Refresh Progress Notification')"
-          :default-value="showSubscriptionRefreshToast"
-          setting-key="showSubscriptionRefreshToast"
-          :tooltip="$t('Tooltips.Subscription Settings.Show Feed Refresh Progress Notification')"
-          compact
-          @change="updateShowSubscriptionRefreshToast"
-        />
         <FtSelect
           :placeholder="$t('Settings.Subscription Settings.Videos Auto Refresh Interval')"
           :value="subscriptionFeedAutoRefreshInterval"
@@ -133,9 +125,6 @@ const { t } = useI18n()
 /** @type {import('vue').ComputedRef<boolean>} */
 const fetchSubscriptionsAutomatically = computed(() => store.getters.getFetchSubscriptionsAutomatically)
 
-/** @type {import('vue').ComputedRef<boolean>} */
-const showSubscriptionRefreshToast = computed(() => store.getters.getShowSubscriptionRefreshToast)
-
 const subscriptionFeedAutoRefreshIntervalNames = computed(() => [
   t('Settings.General Settings.Avoid translation.Disabled'),
   '30 min',
@@ -161,13 +150,6 @@ const subscriptionFeedAutoRefreshIntervalValues = [
  */
 function updateFetchSubscriptionsAutomatically(value) {
   store.dispatch('updateFetchSubscriptionsAutomatically', value)
-}
-
-/**
- * @param {boolean} value
- */
-function updateShowSubscriptionRefreshToast(value) {
-  store.dispatch('updateShowSubscriptionRefreshToast', value)
 }
 
 /** @type {import('vue').ComputedRef<string>} */

--- a/src/renderer/components/ThemeSettings.vue
+++ b/src/renderer/components/ThemeSettings.vue
@@ -47,6 +47,14 @@
           setting-key="showToastTimeoutIndicator"
           @change="updateShowToastTimeoutIndicator"
         />
+        <FtToggleSwitch
+          :label="$t('Settings.Theme Settings.Show Progress as Notification')"
+          :tooltip="$t('Tooltips.Theme Settings.Show Progress as Notification')"
+          compact
+          :default-value="showProgressBarToast"
+          setting-key="showProgressBarToast"
+          @change="updateShowProgressBarToast"
+        />
       </div>
       <div class="switchColumn">
         <FtToggleSwitch
@@ -460,6 +468,16 @@ const showToastTimeoutIndicator = computed(() => store.getters.getShowToastTimeo
  */
 function updateShowToastTimeoutIndicator(value) {
   store.dispatch('updateShowToastTimeoutIndicator', value)
+}
+
+/** @type {import('vue').ComputedRef<boolean>} */
+const showProgressBarToast = computed(() => store.getters.getShowProgressBarToast)
+
+/**
+ * @param {boolean} value
+ */
+function updateShowProgressBarToast(value) {
+  store.dispatch('updateShowProgressBarToast', value)
 }
 
 /** @type {import('vue').ComputedRef<boolean>} */

--- a/src/renderer/helpers/settings-migrations.js
+++ b/src/renderer/helpers/settings-migrations.js
@@ -1,0 +1,18 @@
+/**
+ * Replaces setting keys that were renamed between exported settings formats.
+ * Current keys take precedence when an import contains both versions.
+ * @param {Record<string, unknown>} settings
+ * @returns {Record<string, unknown>}
+ */
+export function migrateLegacySettings(settings) {
+  const migratedSettings = { ...settings }
+
+  if (Object.hasOwn(migratedSettings, 'showSubscriptionRefreshToast')) {
+    if (!Object.hasOwn(migratedSettings, 'showProgressBarToast')) {
+      migratedSettings.showProgressBarToast = migratedSettings.showSubscriptionRefreshToast === true
+    }
+    delete migratedSettings.showSubscriptionRefreshToast
+  }
+
+  return migratedSettings
+}

--- a/src/renderer/helpers/subscriptions.js
+++ b/src/renderer/helpers/subscriptions.js
@@ -569,7 +569,7 @@ async function refreshSubscriptionVideosFromRemoteUnlocked({
   store.commit('setSubscriptionFeedRefreshInProgress', true)
   setSubscriptionRefreshProgress(0)
 
-  if (showStartToast && !store.getters.getShowSubscriptionRefreshToast) {
+  if (showStartToast && !store.getters.getShowProgressBarToast) {
     showToastOnAllTabs(t('Subscriptions.Refreshing Subscription Videos'), AUTO_REFRESH_TOAST_DURATION, ['fas', 'sync'])
   }
 
@@ -673,7 +673,7 @@ async function refreshSubscriptionShortsFromRemoteUnlocked({
   store.commit('setSubscriptionFeedRefreshInProgress', true)
   setSubscriptionRefreshProgress(0)
 
-  if (showStartToast && !store.getters.getShowSubscriptionRefreshToast) {
+  if (showStartToast && !store.getters.getShowProgressBarToast) {
     showToastOnAllTabs(t('Subscriptions.Refreshing Subscription Shorts'), AUTO_REFRESH_TOAST_DURATION, ['fas', 'sync'])
   }
 
@@ -763,7 +763,7 @@ async function refreshSubscriptionLiveFromRemoteUnlocked({
   store.commit('setSubscriptionFeedRefreshInProgress', true)
   setSubscriptionRefreshProgress(0)
 
-  if (showStartToast && !store.getters.getShowSubscriptionRefreshToast) {
+  if (showStartToast && !store.getters.getShowProgressBarToast) {
     showToastOnAllTabs(t('Subscriptions.Refreshing Subscription Live Streams'), AUTO_REFRESH_TOAST_DURATION, ['fas', 'sync'])
   }
 
@@ -867,7 +867,7 @@ async function refreshSubscriptionPostsFromRemoteUnlocked({
   store.commit('setSubscriptionFeedRefreshInProgress', true)
   setSubscriptionRefreshProgress(0)
 
-  if (showStartToast && !store.getters.getShowSubscriptionRefreshToast) {
+  if (showStartToast && !store.getters.getShowProgressBarToast) {
     showToastOnAllTabs(t('Subscriptions.Refreshing Subscription Posts'), AUTO_REFRESH_TOAST_DURATION, ['fas', 'sync'])
   }
 

--- a/src/renderer/store/modules/settings.js
+++ b/src/renderer/store/modules/settings.js
@@ -418,7 +418,7 @@ const state = {
   subscriptionShortsAutoRefreshInterval: '0',
   subscriptionLiveAutoRefreshInterval: '0',
   subscriptionPostsAutoRefreshInterval: '0',
-  showSubscriptionRefreshToast: true,
+  showProgressBarToast: true,
   settingsPassword: '',
   useDeArrowTitles: false,
   useDeArrowThumbnails: false,
@@ -743,6 +743,12 @@ const customActions = {
       const legacyAutoPipTabEntry = userSettings.find(entry => entry._id === 'autoPictureInPictureOnTabChange')
       const hasPipTriggersSetting = userSettings.some(entry => entry._id === 'autoPictureInPictureTriggers')
       const hasScrollMiniSetting = userSettings.some(entry => entry._id === 'scrollMiniPlayerEnabled')
+      const legacyProgressToastEntry = userSettings.find(entry => entry._id === 'showSubscriptionRefreshToast')
+      const hasProgressToastSetting = userSettings.some(entry => entry._id === 'showProgressBarToast')
+
+      if (legacyProgressToastEntry && !hasProgressToastSetting) {
+        await dispatch('updateShowProgressBarToast', legacyProgressToastEntry.value === true)
+      }
 
       // Migrate the legacy auto Picture-in-Picture setting to the combinable triggers array.
       // The old behavior fired on both in-app tab changes and window minimize, so preserve both.

--- a/src/renderer/store/modules/utils.js
+++ b/src/renderer/store/modules/utils.js
@@ -43,6 +43,8 @@ const state = {
   channelThumbnailCache: loadChannelThumbnailCache(),
   videoAvatarCache: loadVideoAvatarCache(),
   showProgressBar: false,
+  progressBarMessage: '',
+  progressBarIcon: ['fas', 'sync'],
   showAddToPlaylistPrompt: false,
   showCreatePlaylistPrompt: false,
   isKeyboardShortcutPromptShown: false,
@@ -159,6 +161,14 @@ const getters = {
 
   getProgressBarPercentage(state) {
     return state.progressBarPercentage
+  },
+
+  getProgressBarMessage(state) {
+    return state.progressBarMessage
+  },
+
+  getProgressBarIcon(state) {
+    return state.progressBarIcon
   },
 
   getRegionNames(state) {
@@ -662,6 +672,14 @@ const mutations = {
 
   setProgressBarPercentage (state, value) {
     state.progressBarPercentage = value
+  },
+
+  setProgressBarMessage (state, value) {
+    state.progressBarMessage = value
+  },
+
+  setProgressBarIcon (state, value) {
+    state.progressBarIcon = value
   },
 
   setSessionSearchHistory (state, history) {

--- a/static/locales/en-US.yaml
+++ b/static/locales/en-US.yaml
@@ -453,6 +453,8 @@ Settings:
     Use Fixed Tab Width: Use Fixed Tab Width in Horizontal Mode
     Tab Width: Tab Width
     Show Toast Timeout Indicator: Show toast timeout indicator
+    Show Progress as Notification: Show progress as notification
+    Operation in Progress: Operation in progress
     Toast Position:
       Toast Position: Toast Position
       Bottom Left: Bottom left
@@ -802,7 +804,6 @@ Settings:
     Shorts Auto Refresh Interval: Shorts Auto Refresh Interval
     Live Auto Refresh Interval: Live Auto Refresh Interval
     Posts Auto Refresh Interval: Posts Auto Refresh Interval
-    Show Feed Refresh Progress Notification: Show feed refresh progress notification
     'Limit the number of videos displayed for each channel': 'Limit the number of videos displayed for each channel'
     To: To
     Confirm Before Unsubscribing: Confirm Before Unsubscribing
@@ -1729,8 +1730,8 @@ Tooltips:
     Show New Content Feed: Shows a New tab containing subscription feed items that were not present during the previous fetch.
     Show New Content Indicators: Shows a small dot beside subscription feed items that were not present during the previous fetch.
     Auto Refresh Interval: How often OpenTubeX automatically refreshes your subscription feed while the app is open.
-    Show Feed Refresh Progress Notification: Shows a persistent notification with live progress during subscription feed refreshes instead of using the global progress bar.
   Theme Settings:
+    Show Progress as Notification: Shows a persistent notification with live progress for background operations, such as subscription refreshes and managed tool downloads, instead of using the global progress bar.
     Hide Profile Selector in Header: Hides the profile selector from the top bar. The profile selector will be shown at the top of the Subscribed Channels page instead.
     Always Show Scrollbars: Keeps the scrollbars visible at all times. When disabled, they fade out shortly after you stop moving the mouse and reappear as soon as you move it again.
     Use YouTube-style Shorts: Displays Shorts in a portrait grid on subscription and channel pages and uses the YouTube-style Shorts player.

--- a/tests/unit/settings-migrations.test.mjs
+++ b/tests/unit/settings-migrations.test.mjs
@@ -1,0 +1,19 @@
+import assert from 'node:assert/strict'
+import test from 'node:test'
+
+import { migrateLegacySettings } from '../../src/renderer/helpers/settings-migrations.js'
+
+test('migrates the legacy subscription progress notification preference', () => {
+  assert.deepEqual(migrateLegacySettings({ showSubscriptionRefreshToast: false }), {
+    showProgressBarToast: false,
+  })
+})
+
+test('prefers the current progress notification preference', () => {
+  assert.deepEqual(migrateLegacySettings({
+    showSubscriptionRefreshToast: false,
+    showProgressBarToast: true,
+  }), {
+    showProgressBarToast: true,
+  })
+})

--- a/tests/unit/settings-migrations.test.mjs
+++ b/tests/unit/settings-migrations.test.mjs
@@ -3,6 +3,12 @@ import test from 'node:test'
 
 import { migrateLegacySettings } from '../../src/renderer/helpers/settings-migrations.js'
 
+test('migrates an enabled legacy subscription progress notification preference', () => {
+  assert.deepEqual(migrateLegacySettings({ showSubscriptionRefreshToast: true }), {
+    showProgressBarToast: true,
+  })
+})
+
 test('migrates the legacy subscription progress notification preference', () => {
   assert.deepEqual(migrateLegacySettings({ showSubscriptionRefreshToast: false }), {
     showProgressBarToast: false,


### PR DESCRIPTION
## Pull Request Type
- [ ] Bugfix
- [x] Feature Implementation
- [ ] Documentation
- [ ] Other

## Related issue

None.

## Description

Moves the progress-notification preference from Subscription settings to Theme settings and generalizes it to cover every use of the global progress bar.

Subscription refreshes keep their existing persistent notification, while managed yt-dlp and FFmpeg downloads and updates now show the same live-progress presentation. Disabling the preference restores the global progress bar. Progress notifications remain visible in fullscreen, and both stored and imported `showSubscriptionRefreshToast` preferences migrate to the new `showProgressBarToast` setting.

Non-actionable toast notifications also no longer disappear when clicked. Clicking remains available for toasts with an action, while ordinary toasts can be dismissed by swiping or by waiting for their timeout.

## Screenshots

Not included.

## Release note category
<!-- release-note-category:start -->
- [ ] Not noteworthy
- [ ] Highlights
- [x] More improvements
- [ ] Fixed bugs
<!-- release-note-category:end -->

## Release note
<!-- release-note:start -->
Also show managed tool download progress in persistent notifications (like subscription refresh).
<!-- release-note:end -->

## Release note images
<!-- release-note-image:start -->
<img width="286" height="44" alt="image" src="https://github.com/user-attachments/assets/2e97a369-e6ea-412f-b139-5a428c6dd120" />
<!-- release-note-image:end -->

## Testing

- `pnpm run test:unit` (200 passed before follow-ups)
- Legacy settings migration unit tests (2 passed)
- Focused subscription refresh Electron E2E suite under Xvfb (9 passed)
- Global progress presentation and fullscreen Electron E2E test under Xvfb (1 passed)
- Non-actionable toast click/swipe Electron E2E test under Xvfb (1 passed)
- ESLint and stylelint on changed source files
- `node --check e2e/tests/offline/settings.spec.mjs`
- `git diff --check`

## Desktop
- **OS:** Arch Linux
- **OS Version:** Rolling release
- **OpenTubeX version:** 0.30.2

## Additional context

The template checker still reports unrelated pre-existing placeholder mismatches in other locale files.