### PR TITLE
fix: auto-update upcoming premieres

### DIFF
--- a/e2e/tests/offline/subscriptions-feed.spec.mjs
+++ b/e2e/tests/offline/subscriptions-feed.spec.mjs
@@ -121,6 +121,22 @@ test.describe('subscriptions feed from cache', () => {
     await expect(page.getByText('Upcoming premiere video')).toHaveCount(0)
   })
 
+  test('shows a hidden upcoming premiere when its scheduled time arrives', async ({ page }) => {
+    // The app opens on Subscriptions, so leave it before installing the clock;
+    // timers created before installation cannot be advanced by Playwright.
+    await goTo(page, 'trending')
+    await page.clock.install({ time: now })
+    await goTo(page, 'subscriptions')
+
+    await expect(page.getByText('Upcoming premiere video')).toHaveCount(0)
+
+    await page.clock.fastForward(24 * HOUR + 1000)
+
+    const premiere = page.locator('.ft-list-video').filter({ hasText: 'Upcoming premiere video' })
+    await expect(premiere).toBeVisible()
+    await expect(premiere.locator('.videoDuration')).not.toHaveText('Upcoming')
+  })
+
   test('an open video menu does not lift feed content over the sticky header', async ({ page }) => {
     await goTo(page, 'subscriptions')
 

--- a/e2e/tests/offline/subscriptions-feed.spec.mjs
+++ b/e2e/tests/offline/subscriptions-feed.spec.mjs
@@ -54,9 +54,9 @@ test.use({
             liveNow: true
           }),
           feedVideo('aaaaaaaaaa2', 'Video A older', CHANNEL_A, now - 3 * HOUR),
-          feedVideo('aaaaaaaaaa3', 'Upcoming premiere video', CHANNEL_A, now + 24 * HOUR, {
+          feedVideo('aaaaaaaaaa3', 'Upcoming premiere video', CHANNEL_A, now + 30 * 24 * HOUR, {
             isUpcoming: true,
-            premiereDate: new Date(now + 24 * HOUR).toISOString()
+            premiereDate: new Date(now + 30 * 24 * HOUR).toISOString()
           })
         ],
         videosTimestamp: new Date(now - 2 * HOUR).toISOString()
@@ -130,7 +130,8 @@ test.describe('subscriptions feed from cache', () => {
 
     await expect(page.getByText('Upcoming premiere video')).toHaveCount(0)
 
-    await page.clock.fastForward(24 * HOUR + 1000)
+    await page.clock.fastForward(24 * 24 * HOUR)
+    await page.clock.fastForward(6 * 24 * HOUR + 1000)
 
     const premiere = page.locator('.ft-list-video').filter({ hasText: 'Upcoming premiere video' })
     await expect(premiere).toBeVisible()

--- a/src/renderer/components/SubscriptionsVideos.vue
+++ b/src/renderer/components/SubscriptionsVideos.vue
@@ -112,6 +112,7 @@ function scheduleNextPremiereUpdate(timestamp) {
     premiereUpdateTimer = null
     premiereUpdateNow.value = Date.now()
     loadVideosFromCacheForAllActiveProfileChannels()
+    scheduleNextPremiereUpdate(nextUpcomingPremiereTimestamp.value)
   }, Math.min(Math.max(timestamp - Date.now(), 0), MAX_TIMEOUT_MS))
 }
 

--- a/src/renderer/components/SubscriptionsVideos.vue
+++ b/src/renderer/components/SubscriptionsVideos.vue
@@ -11,7 +11,7 @@
 </template>
 
 <script setup>
-import { computed, onMounted, ref, shallowRef, useTemplateRef, watch } from 'vue'
+import { computed, onBeforeUnmount, onMounted, ref, shallowRef, useTemplateRef, watch } from 'vue'
 import { useI18n } from 'vue-i18n'
 
 import SubscriptionsTabUi from './SubscriptionsTabUi/SubscriptionsTabUi.vue'
@@ -20,6 +20,7 @@ import store from '../store/index'
 
 import { useAutoRefreshClock } from '../composables/useAutoRefreshClock'
 import { useSubscriptionChannelUpdates } from '../composables/useSubscriptionChannelUpdates'
+import { getUpcomingPremiereTimestamp } from '../helpers/subscription-entries'
 import { getCachedRelativeTimeFormat, getCachedShortDateTimeFormat, getRelativeTimeFromDate } from '../helpers/utils'
 import {
   refreshSubscriptionVideosFromRemote,
@@ -44,6 +45,10 @@ const hasPendingAutoRefresh = computed(() => {
 })
 
 const now = useAutoRefreshClock(hasPendingAutoRefresh)
+const premiereUpdateNow = ref(Date.now())
+const MAX_TIMEOUT_MS = 2 ** 31 - 1
+/** @type {ReturnType<typeof setTimeout> | null} */
+let premiereUpdateTimer = null
 
 let alreadyLoadedRemotely = false
 
@@ -68,6 +73,52 @@ const cacheEntriesForAllActiveProfileChannels = computed(() => {
   })
 
   return entries
+})
+
+const nextUpcomingPremiereTimestamp = computed(() => {
+  let nextTimestamp = null
+
+  for (const cacheEntry of cacheEntriesForAllActiveProfileChannels.value) {
+    for (const video of cacheEntry.videos ?? []) {
+      const timestamp = getUpcomingPremiereTimestamp(video)
+
+      if (
+        timestamp != null &&
+        timestamp > premiereUpdateNow.value &&
+        (video.isUpcoming || video.premiere) &&
+        (nextTimestamp == null || timestamp < nextTimestamp)
+      ) {
+        nextTimestamp = timestamp
+      }
+    }
+  }
+
+  return nextTimestamp
+})
+
+watch(nextUpcomingPremiereTimestamp, scheduleNextPremiereUpdate, { immediate: true })
+
+function scheduleNextPremiereUpdate(timestamp) {
+  if (premiereUpdateTimer !== null) {
+    clearTimeout(premiereUpdateTimer)
+    premiereUpdateTimer = null
+  }
+
+  if (timestamp == null) {
+    return
+  }
+
+  premiereUpdateTimer = setTimeout(() => {
+    premiereUpdateTimer = null
+    premiereUpdateNow.value = Date.now()
+    loadVideosFromCacheForAllActiveProfileChannels()
+  }, Math.min(Math.max(timestamp - Date.now(), 0), MAX_TIMEOUT_MS))
+}
+
+onBeforeUnmount(() => {
+  if (premiereUpdateTimer !== null) {
+    clearTimeout(premiereUpdateTimer)
+  }
 })
 
 const videoCacheForAllActiveProfileChannelsPresent = computed(() => {
@@ -226,7 +277,7 @@ function loadVideosFromCacheForAllActiveProfileChannels() {
     return cacheEntry.videos ?? []
   })
 
-  videoList.value = updateVideoListAfterProcessing(videoList_)
+  videoList.value = updateVideoListAfterProcessing(videoList_, premiereUpdateNow.value)
   isLoading.value = false
 }
 

--- a/src/renderer/helpers/subscription-entries.js
+++ b/src/renderer/helpers/subscription-entries.js
@@ -5,6 +5,47 @@ import { isHistoryEntryWatched } from '../../history.js'
 const NEW_CONTENT_PUBLICATION_TOLERANCE_MS = 60 * 60 * 1000
 
 /**
+ * @param {object} video
+ * @returns {number | null}
+ */
+export function getUpcomingPremiereTimestamp(video) {
+  if (video.premiereDate != null) {
+    const timestamp = new Date(video.premiereDate).getTime()
+    return Number.isNaN(timestamp) ? null : timestamp
+  }
+
+  if (video.premiereTimestamp != null) {
+    const timestamp = Number(video.premiereTimestamp) * 1000
+    return Number.isFinite(timestamp) ? timestamp : null
+  }
+
+  return null
+}
+
+/**
+ * Clears stale upcoming flags once a premiere's scheduled time has arrived.
+ * @param {object} video
+ * @param {number} now
+ */
+export function updateUpcomingPremiereState(video, now) {
+  const premiereTimestamp = getUpcomingPremiereTimestamp(video)
+
+  if (
+    premiereTimestamp != null &&
+    premiereTimestamp <= now &&
+    (video.isUpcoming || video.premiere)
+  ) {
+    return {
+      ...video,
+      isUpcoming: false,
+      premiere: false
+    }
+  }
+
+  return video
+}
+
+/**
  * Adds YouTube's selected portrait thumbnails to dated Shorts entries without
  * replacing the exact publication and view metadata supplied by RSS.
  * @param {object[]} entries

--- a/src/renderer/helpers/subscriptions.js
+++ b/src/renderer/helpers/subscriptions.js
@@ -23,8 +23,10 @@ import { getValidSubscriptionChannels } from './subscription-channels'
 import {
   applyRssPremiereVerdict,
   collectResolvedNonPremiereVideoIds,
+  getUpcomingPremiereTimestamp,
   mergeSubscriptionShortThumbnails,
-  reconcileFetchedSubscriptionEntries
+  reconcileFetchedSubscriptionEntries,
+  updateUpcomingPremiereState
 } from './subscription-entries'
 import { mapConcurrently } from './concurrent-map'
 
@@ -311,6 +313,20 @@ export function isRssUpcomingPremiere(video) {
 
 /**
  * @param {object} video
+ * @param {number} [now]
+ */
+export function isUpcomingPremiere(video, now = Date.now()) {
+  const premiereTimestamp = getUpcomingPremiereTimestamp(video)
+
+  if (premiereTimestamp != null) {
+    return premiereTimestamp > now
+  }
+
+  return isRssUpcomingPremiere(video)
+}
+
+/**
+ * @param {object} video
  * @param {{
  *  hideLiveStreams?: boolean,
  *  hideUpcomingPremieres?: boolean,
@@ -330,11 +346,7 @@ export function isVideoHiddenByPreferences(video, {
 
   if (
     hideUpcomingPremieres &&
-    (
-      video.premiereDate != null ||
-      video.premiereTimestamp != null ||
-      isRssUpcomingPremiere(video)
-    )
+    isUpcomingPremiere(video)
   ) {
     return true
   }
@@ -475,8 +487,8 @@ async function enrichRssVideoIfNeeded(video) {
  * Filtering and sort based on user preferences
  * @param {any[]} videos
  */
-export function updateVideoListAfterProcessing(videos) {
-  let videoList = videos
+export function updateVideoListAfterProcessing(videos, now = Date.now()) {
+  let videoList = videos.map(video => updateUpcomingPremiereState(video, now))
 
   if (store.getters.getHideLiveStreams) {
     videoList = videoList.filter(item => {
@@ -485,19 +497,7 @@ export function updateVideoListAfterProcessing(videos) {
   }
 
   if (store.getters.getHideUpcomingPremieres) {
-    videoList = videoList.filter(item => {
-      if (isRssUpcomingPremiere(item)) {
-        return false
-      }
-
-      // Observed for premieres in Local API Subscriptions.
-      return (item.premiereDate == null ||
-        // Invidious API
-        // `premiereTimestamp` only available on premiered videos
-        // https://docs.invidious.io/api/common_types/#videoobject
-        item.premiereTimestamp == null
-      )
-    })
+    videoList = videoList.filter(item => !isUpcomingPremiere(item, now))
   }
 
   videoList.sort((a, b) => {

--- a/tests/unit/subscription-entries.test.mjs
+++ b/tests/unit/subscription-entries.test.mjs
@@ -5,8 +5,10 @@ import {
   applyRssPremiereVerdict,
   collectResolvedNonPremiereVideoIds,
   ensureSubscriptionFeedEntryState,
+  getUpcomingPremiereTimestamp,
   mergeSubscriptionShortThumbnails,
-  reconcileFetchedSubscriptionEntries
+  reconcileFetchedSubscriptionEntries,
+  updateUpcomingPremiereState
 } from '../../src/renderer/helpers/subscription-entries.js'
 
 const HOUR = 3_600_000
@@ -15,6 +17,31 @@ const now = Date.now()
 function video(videoId, published, extra = {}) {
   return { videoId, published, type: 'video', ...extra }
 }
+
+test('reads premiere times from Local API dates and Invidious timestamps', () => {
+  assert.equal(
+    getUpcomingPremiereTimestamp({ premiereDate: '2026-08-03T12:00:00.000Z' }),
+    Date.parse('2026-08-03T12:00:00.000Z')
+  )
+  assert.equal(getUpcomingPremiereTimestamp({ premiereTimestamp: 1_785_758_400 }), 1_785_758_400_000)
+  assert.equal(getUpcomingPremiereTimestamp({ premiereDate: 'invalid' }), null)
+})
+
+test('clears upcoming premiere state when its scheduled time arrives', () => {
+  const scheduledTime = now + HOUR
+  const upcoming = video('premiere', scheduledTime, {
+    isUpcoming: true,
+    premiere: true,
+    premiereDate: new Date(scheduledTime)
+  })
+
+  assert.equal(updateUpcomingPremiereState(upcoming, scheduledTime - 1), upcoming)
+  assert.deepEqual(updateUpcomingPremiereState(upcoming, scheduledTime), {
+    ...upcoming,
+    isUpcoming: false,
+    premiere: false
+  })
+})
 
 test('adds selected Shorts thumbnails without replacing RSS metadata', () => {
   const entries = [


### PR DESCRIPTION
## Pull Request Type
- [x] Bugfix
- [ ] Feature Implementation
- [ ] Documentation
- [ ] Other

## Related issue
N/A

## Description
Upcoming premieres in the subscription feed previously kept their cached upcoming state until the feed was manually refreshed. This adds a timer for the next scheduled premiere and reprocesses the cached feed when that time arrives.

Premiere timestamps are normalized for Local API and Invidious data. Once the scheduled time passes, stale upcoming flags are cleared so the card updates automatically. When "Hide upcoming premieres" is enabled, the premiere appears automatically at its scheduled time without a refresh. RSS premieres with a known scheduled time use the same path.

## Screenshots
N/A

## Release note category
<!-- release-note-category:start -->
- [ ] Not noteworthy
- [ ] Highlights
- [ ] More improvements
- [x] Fixed bugs
<!-- release-note-category:end -->

## Release note
<!-- release-note:start -->
Upcoming premieres now update automatically in the subscription feed when their scheduled time arrives.
<!-- release-note:end -->

## Release note images
<!-- release-note-image:start -->
<!-- release-note-image:end -->

## Testing
- Run `pnpm run test:unit`.
- Run the offline subscription feed E2E spec under Xvfb:
  `xvfb-run -a -s "-screen 0 1920x1080x24" pnpm exec playwright test -c e2e/playwright.config.mjs --project=offline e2e/tests/offline/subscriptions-feed.spec.mjs`
- Enable "Hide upcoming premieres", open a subscription feed containing a scheduled premiere, and confirm it appears automatically when the scheduled time passes without refreshing.

## Desktop
- **OS:** Arch Linux
- **OS Version:** Rolling release
- **OpenTubeX version:** 0.30.2

## Additional context
The E2E test uses Playwright's fake clock to verify the transition at the scheduled time without waiting in real time.