### PR TITLE
fix: improve premiere behavior and live chat

### DIFF
--- a/e2e/tests/offline/subscriptions-feed.spec.mjs
+++ b/e2e/tests/offline/subscriptions-feed.spec.mjs
@@ -121,6 +121,22 @@ test.describe('subscriptions feed from cache', () => {
     await expect(page.getByText('Upcoming premiere video')).toHaveCount(0)
   })
 
+  test('shows a hidden upcoming premiere when its scheduled time arrives', async ({ page }) => {
+    // The app opens on Subscriptions, so leave it before installing the clock;
+    // timers created before installation cannot be advanced by Playwright.
+    await goTo(page, 'trending')
+    await page.clock.install({ time: now })
+    await goTo(page, 'subscriptions')
+
+    await expect(page.getByText('Upcoming premiere video')).toHaveCount(0)
+
+    await page.clock.fastForward(24 * HOUR + 1000)
+
+    const premiere = page.locator('.ft-list-video').filter({ hasText: 'Upcoming premiere video' })
+    await expect(premiere).toBeVisible()
+    await expect(premiere.locator('.videoDuration')).not.toHaveText('Upcoming')
+  })
+
   test('an open video menu does not lift feed content over the sticky header', async ({ page }) => {
     await goTo(page, 'subscriptions')
 

--- a/e2e/tests/offline/subscriptions-feed.spec.mjs
+++ b/e2e/tests/offline/subscriptions-feed.spec.mjs
@@ -16,7 +16,6 @@ function feedVideo(videoId, title, authorId, published, extra = {}) {
     viewCount: 1000,
     lengthSeconds: 120,
     liveNow: false,
-    isUpcoming: false,
     type: 'video',
     ...extra
   }
@@ -55,7 +54,6 @@ test.use({
           }),
           feedVideo('aaaaaaaaaa2', 'Video A older', CHANNEL_A, now - 3 * HOUR),
           feedVideo('aaaaaaaaaa3', 'Upcoming premiere video', CHANNEL_A, now + 30 * 24 * HOUR, {
-            isUpcoming: true,
             premiereDate: new Date(now + 30 * 24 * HOUR).toISOString()
           })
         ],

--- a/e2e/tests/offline/subscriptions-feed.spec.mjs
+++ b/e2e/tests/offline/subscriptions-feed.spec.mjs
@@ -54,9 +54,9 @@ test.use({
             liveNow: true
           }),
           feedVideo('aaaaaaaaaa2', 'Video A older', CHANNEL_A, now - 3 * HOUR),
-          feedVideo('aaaaaaaaaa3', 'Upcoming premiere video', CHANNEL_A, now + 24 * HOUR, {
+          feedVideo('aaaaaaaaaa3', 'Upcoming premiere video', CHANNEL_A, now + 30 * 24 * HOUR, {
             isUpcoming: true,
-            premiereDate: new Date(now + 24 * HOUR).toISOString()
+            premiereDate: new Date(now + 30 * 24 * HOUR).toISOString()
           })
         ],
         videosTimestamp: new Date(now - 2 * HOUR).toISOString()
@@ -130,7 +130,8 @@ test.describe('subscriptions feed from cache', () => {
 
     await expect(page.getByText('Upcoming premiere video')).toHaveCount(0)
 
-    await page.clock.fastForward(24 * HOUR + 1000)
+    await page.clock.fastForward(24 * 24 * HOUR)
+    await page.clock.fastForward(6 * 24 * HOUR + 1000)
 
     const premiere = page.locator('.ft-list-video').filter({ hasText: 'Upcoming premiere video' })
     await expect(premiere).toBeVisible()

--- a/src/renderer/components/SubscriptionsVideos.vue
+++ b/src/renderer/components/SubscriptionsVideos.vue
@@ -85,7 +85,6 @@ const nextUpcomingPremiereTimestamp = computed(() => {
       if (
         timestamp != null &&
         timestamp > premiereUpdateNow.value &&
-        (video.isUpcoming || video.premiere) &&
         (nextTimestamp == null || timestamp < nextTimestamp)
       ) {
         nextTimestamp = timestamp

--- a/src/renderer/components/SubscriptionsVideos.vue
+++ b/src/renderer/components/SubscriptionsVideos.vue
@@ -112,6 +112,7 @@ function scheduleNextPremiereUpdate(timestamp) {
     premiereUpdateTimer = null
     premiereUpdateNow.value = Date.now()
     loadVideosFromCacheForAllActiveProfileChannels()
+    scheduleNextPremiereUpdate(nextUpcomingPremiereTimestamp.value)
   }, Math.min(Math.max(timestamp - Date.now(), 0), MAX_TIMEOUT_MS))
 }
 

--- a/src/renderer/components/SubscriptionsVideos.vue
+++ b/src/renderer/components/SubscriptionsVideos.vue
@@ -11,7 +11,7 @@
 </template>
 
 <script setup>
-import { computed, onMounted, ref, shallowRef, useTemplateRef, watch } from 'vue'
+import { computed, onBeforeUnmount, onMounted, ref, shallowRef, useTemplateRef, watch } from 'vue'
 import { useI18n } from 'vue-i18n'
 
 import SubscriptionsTabUi from './SubscriptionsTabUi/SubscriptionsTabUi.vue'
@@ -20,6 +20,7 @@ import store from '../store/index'
 
 import { useAutoRefreshClock } from '../composables/useAutoRefreshClock'
 import { useSubscriptionChannelUpdates } from '../composables/useSubscriptionChannelUpdates'
+import { getUpcomingPremiereTimestamp } from '../helpers/subscription-entries'
 import { getCachedRelativeTimeFormat, getCachedShortDateTimeFormat, getRelativeTimeFromDate } from '../helpers/utils'
 import {
   refreshSubscriptionVideosFromRemote,
@@ -44,6 +45,10 @@ const hasPendingAutoRefresh = computed(() => {
 })
 
 const now = useAutoRefreshClock(hasPendingAutoRefresh)
+const premiereUpdateNow = ref(Date.now())
+const MAX_TIMEOUT_MS = 2 ** 31 - 1
+/** @type {ReturnType<typeof setTimeout> | null} */
+let premiereUpdateTimer = null
 
 let alreadyLoadedRemotely = false
 
@@ -68,6 +73,52 @@ const cacheEntriesForAllActiveProfileChannels = computed(() => {
   })
 
   return entries
+})
+
+const nextUpcomingPremiereTimestamp = computed(() => {
+  let nextTimestamp = null
+
+  for (const cacheEntry of cacheEntriesForAllActiveProfileChannels.value) {
+    for (const video of cacheEntry.videos ?? []) {
+      const timestamp = getUpcomingPremiereTimestamp(video)
+
+      if (
+        timestamp != null &&
+        timestamp > premiereUpdateNow.value &&
+        (video.isUpcoming || video.premiere) &&
+        (nextTimestamp == null || timestamp < nextTimestamp)
+      ) {
+        nextTimestamp = timestamp
+      }
+    }
+  }
+
+  return nextTimestamp
+})
+
+watch(nextUpcomingPremiereTimestamp, scheduleNextPremiereUpdate, { immediate: true })
+
+function scheduleNextPremiereUpdate(timestamp) {
+  if (premiereUpdateTimer !== null) {
+    clearTimeout(premiereUpdateTimer)
+    premiereUpdateTimer = null
+  }
+
+  if (timestamp == null) {
+    return
+  }
+
+  premiereUpdateTimer = setTimeout(() => {
+    premiereUpdateTimer = null
+    premiereUpdateNow.value = Date.now()
+    loadVideosFromCacheForAllActiveProfileChannels()
+  }, Math.min(Math.max(timestamp - Date.now(), 0), MAX_TIMEOUT_MS))
+}
+
+onBeforeUnmount(() => {
+  if (premiereUpdateTimer !== null) {
+    clearTimeout(premiereUpdateTimer)
+  }
 })
 
 const videoCacheForAllActiveProfileChannelsPresent = computed(() => {
@@ -226,7 +277,7 @@ function loadVideosFromCacheForAllActiveProfileChannels() {
     return cacheEntry.videos ?? []
   })
 
-  videoList.value = updateVideoListAfterProcessing(videoList_)
+  videoList.value = updateVideoListAfterProcessing(videoList_, premiereUpdateNow.value)
   isLoading.value = false
 }
 

--- a/src/renderer/components/WatchVideoLiveChat/WatchVideoLiveChat.css
+++ b/src/renderer/components/WatchVideoLiveChat/WatchVideoLiveChat.css
@@ -92,6 +92,13 @@
   text-decoration: none;
 }
 
+.liveChatTimestamp {
+  color: var(--tertiary-text-color);
+  font-weight: normal;
+  margin-inline-end: 5px;
+  white-space: nowrap;
+}
+
 .superChat .channelThumbnail {
   margin-block-start: 3px;
   margin-inline-start: 3px;
@@ -158,12 +165,22 @@
   margin-block-start: 5px;
 }
 
-.upperSuperChatMessage .channelName {
-  color: var(--text-with-main-color);
-  opacity: 0.7;
+.upperSuperChatMessage .superChatAuthor {
+  display: flex;
+  align-items: center;
   position: absolute;
   inset-block-start: -20px;
   margin-inline-start: 65px;
+}
+
+.upperSuperChatMessage .channelName {
+  color: var(--text-with-main-color);
+  opacity: 0.7;
+}
+
+.upperSuperChatMessage .liveChatTimestamp {
+  color: var(--text-with-main-color);
+  opacity: 0.7;
 }
 
 .upperSuperChatMessage .donationAmount {
@@ -239,11 +256,14 @@
 }
 
 .title,
-.popoutChatButton {
+.liveChatActionButton {
   padding: 10px;
 }
 
-.popoutChatButton {
+.liveChatActionButton {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
   border-radius: 50%;
   border-style: none;
   background-color: transparent;
@@ -254,21 +274,45 @@
   transition: background 0.2s ease-out;
 }
 
-.popoutChatButton:hover {
+.liveChatActionButton:hover,
+.liveChatActionButton:focus-visible,
+.liveChatActionButton.active {
   background-color: var(--side-nav-hover-color);
   color: var(--side-nav-hover-text-color);
   transition: background 0.2s ease-in;
 }
 
-.popoutChatButton:active {
+.liveChatActionButton:active {
   background-color: var(--tertiary-text-color);
   color: var(--side-nav-active-text-color);
   transition: background 0.2s ease-in;
 }
 
-.popoutChatIcon {
+.liveChatActionButton svg {
   inline-size: 1em;
   pointer-events: none;
+}
+
+.liveChatActions {
+  position: relative;
+  display: flex;
+  align-items: center;
+}
+
+.liveChatSettingsMenu {
+  position: absolute;
+  z-index: 3;
+  inset-block-start: calc(100% + 8px);
+  inset-inline-end: 0;
+  inline-size: max-content;
+  max-inline-size: calc(100vw - 48px);
+  padding-block: 10px;
+  padding-inline: 12px;
+  color: var(--primary-text-color);
+  background-color: var(--side-nav-color);
+  border: 1px solid var(--side-nav-hover-color);
+  border-radius: calc(10px * var(--ui-roundness));
+  box-shadow: 0 6px 20px rgb(0 0 0 / 35%);
 }
 
 .titleContainer {

--- a/src/renderer/components/WatchVideoLiveChat/WatchVideoLiveChat.vue
+++ b/src/renderer/components/WatchVideoLiveChat/WatchVideoLiveChat.vue
@@ -147,8 +147,10 @@
         v-overlay-scrollbars
         class="liveChatComments"
         :style="{ blockSize: chatHeight }"
-        @mousewheel.passive="onScroll"
-        @scrollend="e => onScroll(e, true)"
+        @pointerdown="stopScrollingToBottom"
+        @scroll.passive="onScroll"
+        @scrollend="onScrollEnd"
+        @wheel.passive="stopScrollingToBottom"
       >
         <div
           v-for="comment in comments"
@@ -236,8 +238,8 @@
         :aria-label="t('Video.Scroll to Bottom')"
         role="button"
         tabindex="0"
-        @click="scrollToBottom"
-        @keydown.enter.space.prevent="scrollToBottom"
+        @click="scrollToBottom()"
+        @keydown.enter.space.prevent="scrollToBottom()"
       >
         <FontAwesomeIcon
           class="icon"
@@ -286,7 +288,8 @@ const { t } = useI18n()
 /** @type {import('youtubei.js').YT.LiveChat|null} */
 let liveChatInstance = null
 let hasEnded = false
-let stayAtBottom = false
+let stayAtBottom = true
+let isScrollingToBottom = false
 
 const isLoading = ref(true)
 const hasError = ref(false)
@@ -417,10 +420,7 @@ function handleStart(initialData) {
   isLoading.value = false
 
   nextTick(() => {
-    commentsRef.value?.scrollTo({
-      top: commentsRef.value.scrollHeight,
-      behavior: 'instant'
-    })
+    scrollToBottom('instant')
   })
 }
 
@@ -537,10 +537,7 @@ function pushComment(comment) {
 
   if (!isLoading.value && stayAtBottom) {
     nextTick(() => {
-      commentsRef.value?.scrollTo({
-        top: commentsRef.value.scrollHeight,
-        behavior: scrollingBehaviour.value
-      })
+      scrollToBottom()
     })
   }
 
@@ -570,35 +567,50 @@ function showSuperChatComment(comment) {
   }
 }
 
-/**
- * @param {any} event
- * @param {boolean} [isScrollEnd]
- */
-function onScroll(event, isScrollEnd = false) {
+function onScroll() {
   const liveChatComments = commentsRef.value
-  if (event.wheelDelta >= 0 && stayAtBottom) {
-    stayAtBottom = false
+  const isAtBottom = liveChatComments.scrollHeight - liveChatComments.scrollTop - liveChatComments.clientHeight <= 1
 
-    if (liveChatComments.scrollHeight > liveChatComments.clientHeight) {
-      showScrollToBottom.value = true
-    }
-  } else if ((isScrollEnd || event.wheelDelta < 0) && !stayAtBottom && (liveChatComments.scrollHeight - liveChatComments.scrollTop) === liveChatComments.clientHeight) {
-    scrollToBottom()
+  if (isAtBottom) {
+    stayAtBottom = true
+    isScrollingToBottom = false
+    showScrollToBottom.value = false
+  } else if (!isScrollingToBottom) {
+    stayAtBottom = false
+    showScrollToBottom.value = liveChatComments.scrollHeight > liveChatComments.clientHeight
   }
+}
+
+function onScrollEnd() {
+  isScrollingToBottom = false
+  onScroll()
+}
+
+function stopScrollingToBottom() {
+  isScrollingToBottom = false
 }
 
 function hideSuperChat() {
   showSuperChat.value = false
 }
 
-function scrollToBottom() {
-  commentsRef.value.scrollTo({
-    top: commentsRef.value.scrollHeight,
-    behavior: scrollingBehaviour.value
-  })
+/**
+ * @param {ScrollBehavior | 'instant'} [behavior]
+ */
+function scrollToBottom(behavior = scrollingBehaviour.value) {
+  const liveChatComments = commentsRef.value
+  if (!liveChatComments) {
+    return
+  }
 
   stayAtBottom = true
+  isScrollingToBottom = true
   showScrollToBottom.value = false
+
+  liveChatComments.scrollTo({
+    top: liveChatComments.scrollHeight,
+    behavior
+  })
 }
 
 </script>

--- a/src/renderer/components/WatchVideoLiveChat/WatchVideoLiveChat.vue
+++ b/src/renderer/components/WatchVideoLiveChat/WatchVideoLiveChat.vue
@@ -55,18 +55,45 @@
             {{ t('Global.Counts.Watching Count', { count: formattedWatchingCount }, watchingCount) }}
           </span>
         </h4>
-        <a
-          :href="`https://www.youtube.com/live_chat?is_popout=1&v=${props.videoId}`"
-          :aria-label="t('Video.Popout Live Chat')"
-          :title="t('Video.Popout Live Chat')"
-          target="_blank"
-          class="popoutChatButton"
+        <div
+          ref="liveChatActionsRef"
+          class="liveChatActions"
+          @keydown.esc.stop.prevent="settingsMenuOpen = false"
         >
-          <FontAwesomeIcon
-            class="popoutChatIcon"
-            :icon="['fas', 'arrow-up-right-from-square']"
-          />
-        </a>
+          <button
+            type="button"
+            class="liveChatActionButton"
+            :class="{ active: settingsMenuOpen }"
+            :aria-label="t('Video.Live Chat Settings')"
+            :title="t('Video.Live Chat Settings')"
+            :aria-expanded="String(settingsMenuOpen)"
+            @click="settingsMenuOpen = !settingsMenuOpen"
+          >
+            <FontAwesomeIcon :icon="['fas', 'sliders-h']" />
+          </button>
+          <a
+            :href="`https://www.youtube.com/live_chat?is_popout=1&v=${props.videoId}`"
+            :aria-label="t('Video.Popout Live Chat')"
+            :title="t('Video.Popout Live Chat')"
+            target="_blank"
+            class="liveChatActionButton"
+          >
+            <FontAwesomeIcon
+              :icon="['fas', 'arrow-up-right-from-square']"
+            />
+          </a>
+          <div
+            v-if="settingsMenuOpen"
+            class="liveChatSettingsMenu"
+          >
+            <FtToggleSwitch
+              :label="t('Video.Show Live Chat Timestamps')"
+              :default-value="showLiveChatTimestamps"
+              :compact="true"
+              @change="updateShowLiveChatTimestamps"
+            />
+          </div>
+        </div>
       </div>
       <div
         v-if="superChatComments.length > 0"
@@ -121,13 +148,21 @@
               class="channelThumbnail"
               alt=""
             >
-            <RouterLink
-              class="channelName"
-              dir="auto"
-              :to="`/channel/${superChat.author.id}`"
-            >
-              {{ superChat.author.name }}
-            </RouterLink>
+            <div class="superChatAuthor">
+              <span
+                v-if="showLiveChatTimestamps"
+                class="liveChatTimestamp"
+              >
+                {{ superChat.timestampText }}
+              </span>
+              <RouterLink
+                class="channelName"
+                dir="auto"
+                :to="`/channel/${superChat.author.id}`"
+              >
+                {{ superChat.author.name }}
+              </RouterLink>
+            </div>
             <p
               class="donationAmount"
               dir="auto"
@@ -169,13 +204,21 @@
                 class="channelThumbnail"
                 alt=""
               >
-              <RouterLink
-                class="channelName"
-                dir="auto"
-                :to="`/channel/${comment.author.id}`"
-              >
-                {{ comment.author.name }}
-              </RouterLink>
+              <div class="superChatAuthor">
+                <span
+                  v-if="showLiveChatTimestamps"
+                  class="liveChatTimestamp"
+                >
+                  {{ comment.timestampText }}
+                </span>
+                <RouterLink
+                  class="channelName"
+                  dir="auto"
+                  :to="`/channel/${comment.author.id}`"
+                >
+                  {{ comment.author.name }}
+                </RouterLink>
+              </div>
               <p
                 class="donationAmount"
                 dir="auto"
@@ -201,6 +244,12 @@
             <p
               class="chatContent"
             >
+              <span
+                v-if="showLiveChatTimestamps"
+                class="liveChatTimestamp"
+              >
+                {{ comment.timestampText }}
+              </span>
               <RouterLink
                 class="channelName"
                 :class="{
@@ -253,13 +302,14 @@
 <script setup>
 import { FontAwesomeIcon } from '@fortawesome/vue-fontawesome'
 import autolinker from 'autolinker'
-import { computed, nextTick, onBeforeUnmount, ref, shallowReactive, useTemplateRef } from 'vue'
+import { computed, nextTick, onBeforeUnmount, onMounted, ref, shallowReactive, useTemplateRef } from 'vue'
 import { useI18n } from 'vue-i18n'
 import { YTNodes } from 'youtubei.js'
 
 import FtLoader from '../FtLoader/FtLoader.vue'
 import FtCard from '../ft-card/ft-card.vue'
 import FtButton from '../FtButton/FtButton.vue'
+import FtToggleSwitch from '../FtToggleSwitch/FtToggleSwitch.vue'
 import { vSaferHtml } from '../../directives/vSaferHtml.js'
 
 import store from '../../store/index'
@@ -283,7 +333,7 @@ const props = defineProps({
   }
 })
 
-const { t } = useI18n()
+const { locale, t } = useI18n()
 
 /** @type {import('youtubei.js').YT.LiveChat|null} */
 let liveChatInstance = null
@@ -297,6 +347,8 @@ const showEnableChat = ref(false)
 const errorMessage = ref('')
 const showSuperChat = ref(false)
 const showScrollToBottom = ref(false)
+const settingsMenuOpen = ref(false)
+const liveChatActionsRef = useTemplateRef('liveChatActionsRef')
 const comments = shallowReactive([])
 const superChatComments = shallowReactive([])
 const superChat = ref({
@@ -326,6 +378,7 @@ const scrollingBehaviour = computed(() => {
 
 /** @type {import('vue').ComputedRef<boolean>} */
 const hideVideoViews = computed(() => store.getters.getHideVideoViews)
+const showLiveChatTimestamps = computed(() => store.getters.getShowLiveChatTimestamps)
 
 /** @type {import('vue').Ref<number | null>} */
 const watchingCount = ref(null)
@@ -335,7 +388,12 @@ const formattedWatchingCount = computed(() => {
 })
 
 onBeforeUnmount(() => {
+  document.removeEventListener('pointerdown', handleChatSettingsClickOutside)
   handleEnd()
+})
+
+onMounted(() => {
+  document.addEventListener('pointerdown', handleChatSettingsClickOutside)
 })
 
 if (!process.env.SUPPORTS_LOCAL_API) {
@@ -481,6 +539,7 @@ function parseLiveChatComment(comment) {
 
   const parsedComment = {
     id: comment.id,
+    timestampText: formatLiveChatTimestamp(comment),
     message: autolinker.link(parseLocalTextRuns(comment.message.runs, 20)),
     author: {
       id: comment.author.id,
@@ -508,6 +567,7 @@ function parseLiveChatComment(comment) {
 function parseLiveChatSuperChat(superChat) {
   const parsedComment = {
     id: superChat.id,
+    timestampText: formatLiveChatTimestamp(superChat),
     message: autolinker.link(parseLocalTextRuns(superChat.message.runs, 20)),
     author: {
       id: superChat.author.id,
@@ -565,6 +625,28 @@ function showSuperChatComment(comment) {
     superChat.value = comment
     showSuperChat.value = true
   }
+}
+
+function formatLiveChatTimestamp(comment) {
+  if (comment.timestamp_text) {
+    return comment.timestamp_text
+  }
+
+  if (Number.isFinite(comment.timestamp)) {
+    return new Intl.DateTimeFormat([locale.value, 'en'], { timeStyle: 'short' }).format(comment.timestamp)
+  }
+
+  return ''
+}
+
+function handleChatSettingsClickOutside(event) {
+  if (settingsMenuOpen.value && !liveChatActionsRef.value?.contains(event.target)) {
+    settingsMenuOpen.value = false
+  }
+}
+
+function updateShowLiveChatTimestamps(value) {
+  store.dispatch('updateShowLiveChatTimestamps', value)
 }
 
 function onScroll() {

--- a/src/renderer/helpers/api/local.js
+++ b/src/renderer/helpers/api/local.js
@@ -6,6 +6,7 @@ import { PlayerCache } from './PlayerCache'
 import { loadSearchContinuation } from '../search-continuation'
 import { parseLocalShortLinkedVideo } from '../player/shorts'
 import { getPaidPromotionDurationMs } from '../player/paidPromotion'
+import { getLocalPremiereState } from '../premiere'
 import {
   CHANNEL_HANDLE_REGEX,
   calculatePublishedDate,
@@ -409,13 +410,15 @@ export async function getLocalSearchContinuation(continuationData) {
  *     osVersion: string
  *   },
  *   adEndTimeUnixMs: number,
- *   paidPromotionDurationMs: number | null
+ *   paidPromotionDurationMs: number | null,
+ *   isPremiere: boolean | undefined
  * }>}
  */
 export async function getLocalVideoInfo(id) {
   let responseTime = Date.now()
   let totalAdTimeMilliseconds = 0
   let paidPromotionDurationMs = null
+  let isPremiere
 
   const webInnertube = await createInnertube({
     withPlayer: true,
@@ -434,6 +437,7 @@ export async function getLocalVideoInfo(id) {
       const json = JSON.parse(responseText)
 
       paidPromotionDurationMs ??= getPaidPromotionDurationMs(json)
+      isPremiere ??= getLocalPremiereState(json.videoDetails)
 
       if (Array.isArray(json.adSlots)) {
         for (const adSlot of json.adSlots) {
@@ -548,7 +552,7 @@ export async function getLocalVideoInfo(id) {
 
   if ((info.playability_status.status === 'UNPLAYABLE' && (!hasTrailer || trailerIsAgeRestricted)) ||
     info.playability_status.status === 'LOGIN_REQUIRED') {
-    return { info, poToken: undefined, clientInfo, paidPromotionDurationMs }
+    return { info, poToken: undefined, clientInfo, paidPromotionDurationMs, isPremiere }
   }
 
   if (hasTrailer && info.playability_status.status !== 'OK') {
@@ -616,6 +620,7 @@ export async function getLocalVideoInfo(id) {
     clientInfo,
     adEndTimeUnixMs,
     paidPromotionDurationMs,
+    isPremiere,
   }
 }
 

--- a/src/renderer/helpers/premiere.js
+++ b/src/renderer/helpers/premiere.js
@@ -1,0 +1,15 @@
+/**
+ * Reads premiere state before YouTube.js coerces a missing isLiveContent value
+ * to false.
+ * @param {object | null | undefined} videoDetails
+ * @returns {boolean | undefined}
+ */
+export function getLocalPremiereState(videoDetails) {
+  if (videoDetails?.isLive !== true) {
+    return false
+  }
+
+  return typeof videoDetails.isLiveContent === 'boolean'
+    ? !videoDetails.isLiveContent
+    : undefined
+}

--- a/src/renderer/helpers/subscription-entries.js
+++ b/src/renderer/helpers/subscription-entries.js
@@ -5,6 +5,47 @@ import { isHistoryEntryWatched } from '../../history.js'
 const NEW_CONTENT_PUBLICATION_TOLERANCE_MS = 60 * 60 * 1000
 
 /**
+ * @param {object} video
+ * @returns {number | null}
+ */
+export function getUpcomingPremiereTimestamp(video) {
+  if (video.premiereDate != null) {
+    const timestamp = new Date(video.premiereDate).getTime()
+    return Number.isNaN(timestamp) ? null : timestamp
+  }
+
+  if (video.premiereTimestamp != null) {
+    const timestamp = Number(video.premiereTimestamp) * 1000
+    return Number.isFinite(timestamp) ? timestamp : null
+  }
+
+  return null
+}
+
+/**
+ * Clears stale upcoming flags once a premiere's scheduled time has arrived.
+ * @param {object} video
+ * @param {number} now
+ */
+export function updateUpcomingPremiereState(video, now) {
+  const premiereTimestamp = getUpcomingPremiereTimestamp(video)
+
+  if (
+    premiereTimestamp != null &&
+    premiereTimestamp <= now &&
+    (video.isUpcoming || video.premiere)
+  ) {
+    return {
+      ...video,
+      isUpcoming: false,
+      premiere: false
+    }
+  }
+
+  return video
+}
+
+/**
  * Adds YouTube's selected portrait thumbnails to dated Shorts entries without
  * replacing the exact publication and view metadata supplied by RSS.
  * @param {object[]} entries

--- a/src/renderer/helpers/subscriptions.js
+++ b/src/renderer/helpers/subscriptions.js
@@ -23,8 +23,10 @@ import { getValidSubscriptionChannels } from './subscription-channels'
 import {
   applyRssPremiereVerdict,
   collectResolvedNonPremiereVideoIds,
+  getUpcomingPremiereTimestamp,
   mergeSubscriptionShortThumbnails,
-  reconcileFetchedSubscriptionEntries
+  reconcileFetchedSubscriptionEntries,
+  updateUpcomingPremiereState
 } from './subscription-entries'
 import { mapConcurrently } from './concurrent-map'
 
@@ -311,6 +313,20 @@ export function isRssUpcomingPremiere(video) {
 
 /**
  * @param {object} video
+ * @param {number} [now]
+ */
+export function isUpcomingPremiere(video, now = Date.now()) {
+  const premiereTimestamp = getUpcomingPremiereTimestamp(video)
+
+  if (premiereTimestamp != null) {
+    return premiereTimestamp > now
+  }
+
+  return isRssUpcomingPremiere(video)
+}
+
+/**
+ * @param {object} video
  * @param {{
  *  hideLiveStreams?: boolean,
  *  hideUpcomingPremieres?: boolean,
@@ -330,11 +346,7 @@ export function isVideoHiddenByPreferences(video, {
 
   if (
     hideUpcomingPremieres &&
-    (
-      video.premiereDate != null ||
-      video.premiereTimestamp != null ||
-      isRssUpcomingPremiere(video)
-    )
+    isUpcomingPremiere(video)
   ) {
     return true
   }
@@ -475,8 +487,8 @@ async function enrichRssVideoIfNeeded(video) {
  * Filtering and sort based on user preferences
  * @param {any[]} videos
  */
-export function updateVideoListAfterProcessing(videos) {
-  let videoList = videos
+export function updateVideoListAfterProcessing(videos, now = Date.now()) {
+  let videoList = videos.map(video => updateUpcomingPremiereState(video, now))
 
   if (store.getters.getHideLiveStreams) {
     videoList = videoList.filter(item => {
@@ -485,19 +497,7 @@ export function updateVideoListAfterProcessing(videos) {
   }
 
   if (store.getters.getHideUpcomingPremieres) {
-    videoList = videoList.filter(item => {
-      if (isRssUpcomingPremiere(item)) {
-        return false
-      }
-
-      // Observed for premieres in Local API Subscriptions.
-      return (item.premiereDate == null ||
-        // Invidious API
-        // `premiereTimestamp` only available on premiered videos
-        // https://docs.invidious.io/api/common_types/#videoobject
-        item.premiereTimestamp == null
-      )
-    })
+    videoList = videoList.filter(item => !isUpcomingPremiere(item, now))
   }
 
   videoList.sort((a, b) => {

--- a/src/renderer/store/modules/settings.js
+++ b/src/renderer/store/modules/settings.js
@@ -275,6 +275,7 @@ const state = {
   hideLabelsSideBar: false,
   hideChapters: false,
   showDistractionFreeTitles: false,
+  showLiveChatTimestamps: false,
   landingPage: 'subscriptions',
   newTabPosition: 'afterCurrent',
   tabCloseFocus: 'previousTab',

--- a/src/renderer/views/Watch/Watch.js
+++ b/src/renderer/views/Watch/Watch.js
@@ -81,6 +81,7 @@ import { MANIFEST_TYPE_SABR } from '../../helpers/player/SabrManifestParser'
 import { useI18n } from 'vue-i18n'
 import { useTabAvatar, useTabContext, useTabTitle } from '../../tabs/TabContext'
 import { useTabToast } from '../../composables/useTabToast'
+import { areCommentsAvailable } from './watchComments'
 
 /**
  * @typedef {{
@@ -189,6 +190,7 @@ export default defineComponent({
       isFamilyFriendly: false,
       commentsDisabled: false,
       isLive: false,
+      isPremiere: false,
       liveChat: null,
       isLiveContent: false,
       isUpcoming: false,
@@ -682,6 +684,9 @@ export default defineComponent({
     },
     hideComments: function () {
       return this.$store.getters.getHideComments
+    },
+    commentsAvailable: function () {
+      return areCommentsAvailable(this)
     },
     hideVideoDescription: function () {
       return this.$store.getters.getHideVideoDescription
@@ -1257,6 +1262,7 @@ export default defineComponent({
       this.isFamilyFriendly = false
       this.commentsDisabled = false
       this.isLive = false
+      this.isPremiere = false
       this.liveChat = null
       this.isLiveContent = false
       this.isUpcoming = false
@@ -1746,6 +1752,7 @@ export default defineComponent({
         this.isLive = !!result.basic_info.is_live
         this.isUpcoming = !!result.basic_info.is_upcoming
         this.isLiveContent = !!result.basic_info.is_live_content
+        this.isPremiere = this.isLive && !this.isLiveContent
         this.isPostLiveDvr = !!result.basic_info.is_post_live_dvr
         this.isUnlisted = !!result.basic_info.is_unlisted
         this.hasAiGeneratedContent = result.primary_info?.badges.some(badge => badge.label === 'AI') ?? false
@@ -2227,6 +2234,7 @@ export default defineComponent({
           this.recommendedVideos = recommendedVideos.sort(this.sortWatchedVideosLast)
 
           this.isLive = result.liveNow
+          this.isPremiere = this.isLive && result.premiereTimestamp > 0
           this.isFamilyFriendly = result.isFamilyFriendly
           this.isPostLiveDvr = !!result.isPostLiveDvr
           this.isUnlisted = !result.isListed

--- a/src/renderer/views/Watch/Watch.js
+++ b/src/renderer/views/Watch/Watch.js
@@ -1621,7 +1621,7 @@ export default defineComponent({
         const videoInfo = await getLocalVideoInfo(videoId)
         if (!this.isCurrentVideoLoad(loadGeneration, videoId)) { return }
 
-        const { info: result, poToken, clientInfo, adEndTimeUnixMs, paidPromotionDurationMs } = videoInfo
+        const { info: result, poToken, clientInfo, adEndTimeUnixMs, paidPromotionDurationMs, isPremiere } = videoInfo
 
         const playabilityStatus = result.playability_status
         this.playabilityStatus = playabilityStatus.status
@@ -1752,7 +1752,7 @@ export default defineComponent({
         this.isLive = !!result.basic_info.is_live
         this.isUpcoming = !!result.basic_info.is_upcoming
         this.isLiveContent = !!result.basic_info.is_live_content
-        this.isPremiere = this.isLive && !this.isLiveContent
+        this.isPremiere = isPremiere === true
         this.isPostLiveDvr = !!result.basic_info.is_post_live_dvr
         this.isUnlisted = !!result.basic_info.is_unlisted
         this.hasAiGeneratedContent = result.primary_info?.badges.some(badge => badge.label === 'AI') ?? false

--- a/src/renderer/views/Watch/Watch.vue
+++ b/src/renderer/views/Watch/Watch.vue
@@ -114,7 +114,7 @@
           :current-video-quality="currentVideoQuality"
           :delay-load-until-unix="adEndTimeUnixMs"
           :sponsor-block-auto-skip-disabled="sponsorBlockAutoSkipDisabled"
-          :comments-available="!isLive && !hideComments"
+          :comments-available="commentsAvailable"
           :quick-bookmark-enabled="isQuickBookmarkEnabled"
           :quick-bookmarked="isCurrentVideoQuickBookmarked"
           :quick-bookmark-title="quickBookmarkIconText"
@@ -372,7 +372,7 @@
             <span class="shortsSkeletonSound ft-shimmer" />
           </template>
           <div
-            v-if="!isLoading && !isLive && !hideComments"
+            v-if="!isLoading && commentsAvailable"
             class="shortsAction shortsComponentAction shortsCommentsAction"
             :class="{ active: shortsCommentsPanelOpen }"
           >
@@ -877,7 +877,7 @@
         :disabled="!fullscreenCommentsOpen && !shortsCommentsOpen"
       >
         <CommentSection
-          v-if="!isLoading && !isLive && !hideComments"
+          v-if="!isLoading && commentsAvailable"
           :id="videoId"
           class="watchVideo"
           :class="{ theatreWatchVideo: useTheatreMode }"

--- a/src/renderer/views/Watch/watchComments.js
+++ b/src/renderer/views/Watch/watchComments.js
@@ -1,0 +1,6 @@
+/**
+ * @param {{ isLive: boolean, isPremiere: boolean, hideComments: boolean }} state
+ */
+export function areCommentsAvailable({ isLive, isPremiere, hideComments }) {
+  return (!isLive || isPremiere) && !hideComments
+}

--- a/static/locales/en-US.yaml
+++ b/static/locales/en-US.yaml
@@ -1283,6 +1283,8 @@ Video:
   Live: Live
   Live Now: Live Now
   Live Chat: Live Chat
+  Live Chat Settings: Live chat settings
+  Show Live Chat Timestamps: Show timestamps
   Enable Live Chat: Enable Live Chat
   Popout Live Chat: Popout Chat
   Live Chat is currently not supported in this build.: Live Chat is currently not

--- a/tests/unit/subscription-entries.test.mjs
+++ b/tests/unit/subscription-entries.test.mjs
@@ -5,8 +5,10 @@ import {
   applyRssPremiereVerdict,
   collectResolvedNonPremiereVideoIds,
   ensureSubscriptionFeedEntryState,
+  getUpcomingPremiereTimestamp,
   mergeSubscriptionShortThumbnails,
-  reconcileFetchedSubscriptionEntries
+  reconcileFetchedSubscriptionEntries,
+  updateUpcomingPremiereState
 } from '../../src/renderer/helpers/subscription-entries.js'
 
 const HOUR = 3_600_000
@@ -15,6 +17,31 @@ const now = Date.now()
 function video(videoId, published, extra = {}) {
   return { videoId, published, type: 'video', ...extra }
 }
+
+test('reads premiere times from Local API dates and Invidious timestamps', () => {
+  assert.equal(
+    getUpcomingPremiereTimestamp({ premiereDate: '2026-08-03T12:00:00.000Z' }),
+    Date.parse('2026-08-03T12:00:00.000Z')
+  )
+  assert.equal(getUpcomingPremiereTimestamp({ premiereTimestamp: 1_785_758_400 }), 1_785_758_400_000)
+  assert.equal(getUpcomingPremiereTimestamp({ premiereDate: 'invalid' }), null)
+})
+
+test('clears upcoming premiere state when its scheduled time arrives', () => {
+  const scheduledTime = now + HOUR
+  const upcoming = video('premiere', scheduledTime, {
+    isUpcoming: true,
+    premiere: true,
+    premiereDate: new Date(scheduledTime)
+  })
+
+  assert.equal(updateUpcomingPremiereState(upcoming, scheduledTime - 1), upcoming)
+  assert.deepEqual(updateUpcomingPremiereState(upcoming, scheduledTime), {
+    ...upcoming,
+    isUpcoming: false,
+    premiere: false
+  })
+})
 
 test('adds selected Shorts thumbnails without replacing RSS metadata', () => {
   const entries = [

--- a/tests/unit/watch-comments.test.mjs
+++ b/tests/unit/watch-comments.test.mjs
@@ -1,7 +1,15 @@
 import assert from 'node:assert/strict'
 import test from 'node:test'
 
+import { getLocalPremiereState } from '../../src/renderer/helpers/premiere.js'
 import { areCommentsAvailable } from '../../src/renderer/views/Watch/watchComments.js'
+
+test('only identifies a Local API livestream as a premiere from an explicit marker', () => {
+  assert.equal(getLocalPremiereState({ isLive: true, isLiveContent: false }), true)
+  assert.equal(getLocalPremiereState({ isLive: true, isLiveContent: true }), false)
+  assert.equal(getLocalPremiereState({ isLive: true }), undefined)
+  assert.equal(getLocalPremiereState({ isLive: false }), false)
+})
 
 test('shows comments for videos and active premieres but not live streams', () => {
   assert.equal(areCommentsAvailable({ isLive: false, isPremiere: false, hideComments: false }), true)

--- a/tests/unit/watch-comments.test.mjs
+++ b/tests/unit/watch-comments.test.mjs
@@ -1,0 +1,14 @@
+import assert from 'node:assert/strict'
+import test from 'node:test'
+
+import { areCommentsAvailable } from '../../src/renderer/views/Watch/watchComments.js'
+
+test('shows comments for videos and active premieres but not live streams', () => {
+  assert.equal(areCommentsAvailable({ isLive: false, isPremiere: false, hideComments: false }), true)
+  assert.equal(areCommentsAvailable({ isLive: true, isPremiere: true, hideComments: false }), true)
+  assert.equal(areCommentsAvailable({ isLive: true, isPremiere: false, hideComments: false }), false)
+})
+
+test('respects the hide comments preference for premieres', () => {
+  assert.equal(areCommentsAvailable({ isLive: true, isPremiere: true, hideComments: true }), false)
+})


### PR DESCRIPTION
## Pull Request Type
- [x] Bugfix
- [x] Feature Implementation
- [ ] Documentation
- [ ] Other

## Related issue
N/A

## Description
Improves premiere behavior in both the subscription feed and watch page.

Upcoming premieres in the subscription feed now update automatically when their scheduled time arrives. Premiere timestamps are normalized for Local API and Invidious data, stale upcoming flags are cleared after the scheduled time, and long timers are rearmed safely. This also makes hidden upcoming premieres appear at their scheduled time without a manual refresh.

On the watch page, active premieres now show the regular comment section while ordinary livestreams continue to hide it. The same availability rule is used by the page, Shorts panel, and fullscreen player.

Also improves live-chat behavior:
- keeps new messages pinned to the bottom until the user interrupts scrolling
- reliably resumes through the scroll-to-bottom action
- adds a settings popover beside the popout action
- provides a persistent option to show YouTube's localized timestamps between each avatar and username, including Super Chats

## Screenshots
N/A

## Release note category
<!-- release-note-category:start -->
- [ ] Not noteworthy
- [x] Highlights
- [ ] More improvements
- [ ] Fixed bugs
<!-- release-note-category:end -->

## Release note
<!-- release-note:start -->
Upcoming premieres now refresh automatically, comments appear during premieres, and live chat has improved scrolling with optional timestamps and choosing between top chat or all messages. The chat can now be opened as a full-screen dock. Chat replays are also supported.
<!-- release-note:end -->

## Release note images
<!-- release-note-image:start -->
<img width="551" height="233" alt="image" src="https://github.com/user-attachments/assets/7605cabd-8b2d-428d-a04f-207f9f24cf55" />
<!-- release-note-image:end -->

## Testing
- `pnpm run test:unit` (263 passed)
- `xvfb-run -a -s "-screen 0 1920x1080x24" pnpm exec playwright test -c e2e/playwright.config.mjs --project=offline e2e/tests/offline/subscriptions-feed.spec.mjs`
- Open an active premiere and confirm the regular comments are available.
- Open an ordinary livestream and confirm the regular comments remain hidden.
- Enable "Hide upcoming premieres" and confirm a scheduled premiere appears automatically when its start time passes.
- In live chat, confirm auto-scroll pauses after user interaction and resumes through the scroll-to-bottom action.
- Toggle timestamps in the live-chat settings popover and confirm the menu remains open, the timestamps appear between avatars and usernames, and the preference persists.

## Desktop
- **OS:** Arch Linux
- **OS Version:** Rolling release
- **OpenTubeX version:** 0.30.2 development

## Additional context
This supersedes #489 by including its subscription-feed premiere refresh commits in this PR.

