### PR TITLE
Add animation speed setting

### DIFF
--- a/e2e/tests/offline/settings.spec.mjs
+++ b/e2e/tests/offline/settings.spec.mjs
@@ -215,6 +215,33 @@ test.describe('settings', () => {
     }).toBe(100)
   })
 
+  test('configures animation speed and disables it with reduced motion', async ({ page }) => {
+    await goTo(page, 'settings')
+    await page.locator('.settingsMenu [data-section="theme"]').click()
+
+    const slider = page.getByRole('slider', { name: /Animation Speed/ })
+    await expect(slider).toHaveValue('100')
+    await expect(slider).toBeEnabled()
+
+    await slider.fill('200')
+    await expect.poll(() => page.evaluate(() => {
+      const store = document.querySelector('#app').__vue_app__.config.globalProperties.$store
+      return store.getters.getAnimationSpeed
+    })).toBe(200)
+
+    await page.evaluate(() => {
+      const store = document.querySelector('#app').__vue_app__.config.globalProperties.$store
+      return store.dispatch('updateReducedMotion', 'on')
+    })
+    await expect(slider).toBeDisabled()
+
+    await page.evaluate(() => {
+      const store = document.querySelector('#app').__vue_app__.config.globalProperties.$store
+      return store.dispatch('updateReducedMotion', 'off')
+    })
+    await expect(slider).toBeEnabled()
+  })
+
   test('keeps the watched progress mode when history is toggled', async ({ page }) => {
     await goTo(page, 'settings')
     await page.locator('.settingsMenu [data-section="privacy"]').click()

--- a/e2e/tests/offline/settings.spec.mjs
+++ b/e2e/tests/offline/settings.spec.mjs
@@ -230,6 +230,15 @@ test.describe('settings', () => {
     })).toBe(200)
 
     await page.evaluate(() => {
+      window.ftElectron.showToastOnAllTabs('Wall-clock animation', 2000)
+    })
+    const timeoutIndicator = page.locator('.toast', { hasText: 'Wall-clock animation' })
+      .locator('..').locator('.timeout-indicator .embeddedProgressPath')
+    await expect.poll(() => timeoutIndicator.evaluate((element) => {
+      return element.getAnimations()[0]?.playbackRate
+    })).toBe(1)
+
+    await page.evaluate(() => {
       const store = document.querySelector('#app').__vue_app__.config.globalProperties.$store
       return store.dispatch('updateReducedMotion', 'on')
     })

--- a/e2e/tests/offline/subscriptions-tab-indicator.spec.mjs
+++ b/e2e/tests/offline/subscriptions-tab-indicator.spec.mjs
@@ -166,4 +166,20 @@ test.describe('subscriptions feed tab indicator', () => {
 
     expect(Math.abs(indicator - tab)).toBeLessThan(1)
   })
+
+  test('completes a pending switch when the selected tab is clicked again', async ({ page }) => {
+    await goTo(page, 'subscriptions')
+
+    await expect(page.getByText('video video 000')).toBeVisible()
+    await page.locator('[data-subscription-feed-tab="shorts"]').click()
+
+    // Let the deferred swap reach its first animation frame, then activate the
+    // visually selected tab again before the second frame replaces the panel.
+    await page.evaluate(() => new Promise(resolve => requestAnimationFrame(resolve)))
+    await page.locator('[data-subscription-feed-tab="shorts"]').click()
+
+    await expect(page.locator('.tab.selectedTab')).toHaveText(/Shorts/)
+    await expect(page.getByText('short video 000')).toBeVisible()
+    await expect(page.getByText('video video 000')).toHaveCount(0)
+  })
 })

--- a/e2e/tests/offline/subscriptions-tab-indicator.spec.mjs
+++ b/e2e/tests/offline/subscriptions-tab-indicator.spec.mjs
@@ -182,4 +182,29 @@ test.describe('subscriptions feed tab indicator', () => {
     await expect(page.getByText('short video 000')).toBeVisible()
     await expect(page.getByText('video video 000')).toHaveCount(0)
   })
+
+  test('does not restore a pending feed after every tab is hidden', async ({ page }) => {
+    await goTo(page, 'subscriptions')
+
+    await expect(page.getByText('video video 000')).toBeVisible()
+    await page.evaluate(async () => {
+      const store = document.querySelector('#app').__vue_app__.config.globalProperties.$store
+
+      document.querySelector('[data-subscription-feed-tab="shorts"]').click()
+      await Promise.all([
+        store.dispatch('updateHideSubscriptionsVideos', true),
+        store.dispatch('updateHideSubscriptionsShorts', true),
+        store.dispatch('updateHideSubscriptionsLive', true),
+        store.dispatch('updateHideSubscriptionsCommunity', true)
+      ])
+    })
+
+    // Wait long enough that the stale second animation frame would have put
+    // the shorts panel back after the all-tabs-hidden state was selected.
+    await page.waitForTimeout(100)
+
+    await expect(page.locator('.tabs [role="tab"]')).toHaveCount(0)
+    await expect(page.locator('#subscriptionsPanel')).toHaveCount(0)
+    await expect(page.getByText('All subscription tabs are hidden', { exact: false })).toBeVisible()
+  })
 })

--- a/src/renderer/components/FtAutoGrid/FtAutoGrid.vue
+++ b/src/renderer/components/FtAutoGrid/FtAutoGrid.vue
@@ -5,6 +5,7 @@
     name="feed"
     :appear="appear"
     :move-class="moveClass"
+    :style="{ '--feed-transition-duration': feedTransitionDuration }"
     :class="{
       autoGrid: true,
       grid: grid,
@@ -52,6 +53,14 @@ const props = defineProps({
 const MOVE_TRANSITION_MAX_ITEMS = 50
 
 const gridElement = useTemplateRef('gridElement')
+const feedTransitionDuration = computed(() => {
+  const animationSpeed = store.getters.getAnimationSpeed
+  const speedMultiplier = Number.isFinite(animationSpeed) && animationSpeed > 0
+    ? animationSpeed / 100
+    : 1
+
+  return `${300 / speedMultiplier}ms`
+})
 
 // The thumbnail size custom properties are written straight to the element
 // instead of through a reactive `:style` binding, and the measured width is

--- a/src/renderer/components/FtAutoGrid/FtAutoGrid.vue
+++ b/src/renderer/components/FtAutoGrid/FtAutoGrid.vue
@@ -25,6 +25,7 @@ import { computed, onBeforeUnmount, onMounted, ref, useTemplateRef, watch } from
 import store from '../../store/index'
 
 import { getThumbnailGridStyles } from '../../constants/thumbnailSize'
+import { getAnimationSpeedMultiplier } from '../../helpers/animationSpeed'
 import { measureStableGridWidth } from './gridWidth'
 
 const props = defineProps({
@@ -54,12 +55,7 @@ const MOVE_TRANSITION_MAX_ITEMS = 50
 
 const gridElement = useTemplateRef('gridElement')
 const feedTransitionDuration = computed(() => {
-  const animationSpeed = store.getters.getAnimationSpeed
-  const speedMultiplier = Number.isFinite(animationSpeed) && animationSpeed > 0
-    ? animationSpeed / 100
-    : 1
-
-  return `${300 / speedMultiplier}ms`
+  return `${300 / getAnimationSpeedMultiplier(store.getters.getAnimationSpeed)}ms`
 })
 
 // The thumbnail size custom properties are written straight to the element

--- a/src/renderer/components/FtElementList/FtElementList.css
+++ b/src/renderer/components/FtElementList/FtElementList.css
@@ -5,11 +5,13 @@
 /* applied by the TransitionGroup in FtAutoGrid: existing items glide to
    their new position while newly inserted items fade in */
 .feed-move {
-  transition: transform 300ms ease;
+  transition: transform var(--feed-transition-duration, 300ms) ease;
 }
 
 .feed-enter-active {
-  transition: opacity 300ms ease, transform 300ms ease;
+  transition:
+    opacity var(--feed-transition-duration, 300ms) ease,
+    transform var(--feed-transition-duration, 300ms) ease;
 }
 
 .feed-enter-from {

--- a/src/renderer/components/FtNotificationBanner/FtNotificationBanner.css
+++ b/src/renderer/components/FtNotificationBanner/FtNotificationBanner.css
@@ -9,6 +9,7 @@
   margin: 4px;
   padding-block: 3px 5px;
   padding-inline: 16px;
+  border-radius: calc(8px * var(--ui-roundness));
   box-shadow: 0 1px 2px rgb(0 0 0 / 10%);
   position: relative;
   cursor: pointer;

--- a/src/renderer/components/ThemeSettings.vue
+++ b/src/renderer/components/ThemeSettings.vue
@@ -163,6 +163,18 @@
         @input="previewUiRoundness"
         @change="updateUiRoundness"
       />
+      <FtSlider
+        :label="t('Settings.Theme Settings.Animation Speed')"
+        :default-value="animationSpeed"
+        setting-key="animationSpeed"
+        :min-value="25"
+        :max-value="200"
+        :step="5"
+        :disabled="reducedMotionEnabled"
+        value-extension="%"
+        @input="previewAnimationSpeed"
+        @change="updateAnimationSpeed"
+      />
     </div>
     <br>
     <FtFlexBox>
@@ -219,7 +231,7 @@
 </template>
 
 <script setup>
-import { computed, ref } from 'vue'
+import { computed, onMounted, onUnmounted, ref } from 'vue'
 import { useI18n } from 'vue-i18n'
 
 import FtSettingsSection from './FtSettingsSection/FtSettingsSection.vue'
@@ -244,6 +256,7 @@ import {
   MIN_FIXED_TAB_WIDTH
 } from '../constants/tabWidth'
 import { normalizeToastPosition, TOAST_POSITION_VALUES } from '../constants/toastPosition'
+import { setAnimationSpeed } from '../helpers/animationSpeed'
 
 const { t } = useI18n()
 
@@ -549,6 +562,20 @@ function updateUiScale(value) {
 /** @type {import('vue').ComputedRef<number>} */
 const thumbnailSize = computed(() => store.getters.getThumbnailSize)
 const uiRoundness = computed(() => store.getters.getUiRoundness)
+const animationSpeed = computed(() => store.getters.getAnimationSpeed)
+
+const systemReducedMotion = window.matchMedia('(prefers-reduced-motion: reduce)')
+const systemReducedMotionEnabled = ref(systemReducedMotion.matches)
+const reducedMotion = computed(() => store.getters.getReducedMotion)
+const reducedMotionEnabled = computed(() => reducedMotion.value === 'on' ||
+  (reducedMotion.value === 'system' && systemReducedMotionEnabled.value))
+
+function updateSystemReducedMotion(event) {
+  systemReducedMotionEnabled.value = event.matches
+}
+
+onMounted(() => systemReducedMotion.addEventListener('change', updateSystemReducedMotion))
+onUnmounted(() => systemReducedMotion.removeEventListener('change', updateSystemReducedMotion))
 
 /**
  * @param {number} value
@@ -576,6 +603,20 @@ function previewUiRoundness(value) {
  */
 function updateUiRoundness(value) {
   store.dispatch('updateUiRoundness', value)
+}
+
+/**
+ * @param {number} value
+ */
+function previewAnimationSpeed(value) {
+  setAnimationSpeed(value)
+}
+
+/**
+ * @param {number} value
+ */
+function updateAnimationSpeed(value) {
+  store.dispatch('updateAnimationSpeed', value)
 }
 
 /** @type {boolean} */
@@ -626,14 +667,16 @@ function handleSmoothScrolling(value) {
 
 <style scoped>
 .sliderGrid {
-  display: grid;
-  grid-template-columns: repeat(auto-fit, minmax(min(280px, 100%), 380px));
-  justify-content: space-evenly;
-  gap: 24px 64px;
+  display: flex;
+  flex-wrap: wrap;
+  justify-content: center;
+  gap: 24px;
 }
 
 .sliderGrid :deep(.pure-material-slider) {
   box-sizing: border-box;
-  inline-size: calc(100% - 16px);
+  flex: 1 1 180px;
+  max-inline-size: 380px;
+  inline-size: auto;
 }
 </style>

--- a/src/renderer/components/ft-shaka-video-player/ft-shaka-video-player.js
+++ b/src/renderer/components/ft-shaka-video-player/ft-shaka-video-player.js
@@ -51,6 +51,7 @@ import {
   copyToClipboard,
 } from '../../helpers/utils'
 import { colors } from '../../helpers/colors'
+import { applyAnimationSpeed } from '../../helpers/animationSpeed'
 import {
   FULLSCREEN_DOCK_GAP,
   FULLSCREEN_DOCK_OUTER_INSET,
@@ -5735,7 +5736,7 @@ export default defineComponent({
 
         await nextTick()
         const nextRect = playerContainer.getBoundingClientRect()
-        const animation = playerContainer.animate([
+        const animation = applyAnimationSpeed(playerContainer.animate([
           {
             transform: `translate(${previousRect.left - nextRect.left}px, ${previousRect.top - nextRect.top}px) scale(${previousRect.width / nextRect.width}, ${previousRect.height / nextRect.height})`,
             transformOrigin: 'top left'
@@ -5747,7 +5748,7 @@ export default defineComponent({
         ], {
           duration: FULL_WINDOW_ANIMATION_DURATION_MS,
           easing: 'cubic-bezier(0.4, 0, 0.2, 1)'
-        })
+        }))
 
         fullWindowAnimation = animation
         animation.addEventListener('finish', () => {

--- a/src/renderer/components/ft-shaka-video-player/ft-shaka-video-player.js
+++ b/src/renderer/components/ft-shaka-video-player/ft-shaka-video-player.js
@@ -51,7 +51,7 @@ import {
   copyToClipboard,
 } from '../../helpers/utils'
 import { colors } from '../../helpers/colors'
-import { applyAnimationSpeed } from '../../helpers/animationSpeed'
+import { applyAnimationSpeed, getAnimationSpeedMultiplier } from '../../helpers/animationSpeed'
 import {
   FULLSCREEN_DOCK_GAP,
   FULLSCREEN_DOCK_OUTER_INSET,
@@ -5705,10 +5705,13 @@ export default defineComponent({
 
         fullWindowAnimation?.cancel()
         fullWindowAnimation = null
-        suppressPanelTransitions(FULL_WINDOW_ANIMATION_DURATION_MS + 50)
 
         const playerContainer = container.value
         const shouldAnimate = playerContainer !== null && !isReducedMotionEnabled()
+        const animationDuration = shouldAnimate
+          ? FULL_WINDOW_ANIMATION_DURATION_MS / getAnimationSpeedMultiplier(store.getters.getAnimationSpeed)
+          : FULL_WINDOW_ANIMATION_DURATION_MS
+        suppressPanelTransitions(animationDuration + 50)
         const previousRect = shouldAnimate ? playerContainer.getBoundingClientRect() : null
 
         if (event.detail) {

--- a/src/renderer/components/ft-shaka-video-player/opentubex/useScrollMiniPlayer.js
+++ b/src/renderer/components/ft-shaka-video-player/opentubex/useScrollMiniPlayer.js
@@ -1,6 +1,7 @@
 import { computed, nextTick, ref, watch } from 'vue'
 
 import store from '../../../store/index'
+import { applyAnimationSpeed } from '../../../helpers/animationSpeed'
 import { isReducedMotionEnabled } from '../../../helpers/reducedMotion'
 import {
   animateScrollMiniPlayerBounce,
@@ -419,7 +420,7 @@ export function useScrollMiniPlayer({ container, fullWindowEnabled, getUi, isAct
       return
     }
 
-    const animation = playerContainer.animate([
+    const animation = applyAnimationSpeed(playerContainer.animate([
       {
         transform: `translate(${previousRect.left - nextRect.left}px, ${previousRect.top - nextRect.top}px) scale(${previousRect.width / nextRect.width}, ${previousRect.height / nextRect.height})`,
         transformOrigin: 'top left'
@@ -431,7 +432,7 @@ export function useScrollMiniPlayer({ container, fullWindowEnabled, getUi, isAct
     ], {
       duration: SCROLL_MINI_LAYOUT_ANIMATION_DURATION_MS,
       easing: 'cubic-bezier(0.4, 0, 0.2, 1)'
-    })
+    }))
 
     scrollMiniLayoutAnimation = animation
     animation.addEventListener('finish', () => {

--- a/src/renderer/helpers/animationSpeed.js
+++ b/src/renderer/helpers/animationSpeed.js
@@ -1,0 +1,52 @@
+const DEFAULT_ANIMATION_SPEED = 100
+
+let animationPlaybackRate = 1
+
+/**
+ * Applies the configured playback rate to animations which are currently
+ * attached to the document.
+ */
+function updateActiveAnimations() {
+  document.getAnimations({ subtree: true }).forEach(animation => {
+    applyAnimationSpeed(animation)
+  })
+}
+
+function updateTargetAnimations(event) {
+  queueMicrotask(() => {
+    if (!(event.target instanceof Element)) { return }
+    if (event.target.matches('.feed-enter-active, .feed-move') ||
+      event.target.closest('[data-animation-speed-managed]')) { return }
+
+    event.target.getAnimations({ subtree: false }).forEach(animation => {
+      applyAnimationSpeed(animation)
+    })
+  })
+}
+
+document.addEventListener('animationstart', updateTargetAnimations, true)
+document.addEventListener('transitionrun', updateTargetAnimations, true)
+
+/**
+ * @param {number} value percentage of the default animation speed
+ */
+export function setAnimationSpeed(value) {
+  const speed = Number.isFinite(value) && value > 0
+    ? value
+    : DEFAULT_ANIMATION_SPEED
+
+  animationPlaybackRate = speed / DEFAULT_ANIMATION_SPEED
+  updateActiveAnimations()
+}
+
+/**
+ * Applies the configured speed to an animation created through the Web
+ * Animations API and returns it for convenient assignment.
+ *
+ * @param {Animation} animation
+ * @returns {Animation}
+ */
+export function applyAnimationSpeed(animation) {
+  animation.updatePlaybackRate(animationPlaybackRate)
+  return animation
+}

--- a/src/renderer/helpers/animationSpeed.js
+++ b/src/renderer/helpers/animationSpeed.js
@@ -1,4 +1,6 @@
 const DEFAULT_ANIMATION_SPEED = 100
+const MIN_ANIMATION_SPEED = 25
+const MAX_ANIMATION_SPEED = 200
 
 let animationPlaybackRate = 1
 
@@ -8,29 +10,31 @@ let animationPlaybackRate = 1
  */
 function updateActiveAnimations() {
   document.getAnimations({ subtree: true })
-    .filter(animation => !isWallClockAnimation(animation))
+    .filter(animation => !isAnimationSpeedManaged(animation.effect?.target))
     .forEach(animation => {
       applyAnimationSpeed(animation)
     })
 }
 
 /**
- * Some animations visualize a separate wall-clock timer and must stay in sync
- * with that timer rather than the UI animation preference.
+ * Some animations already incorporate the configured speed in their duration
+ * or visualize a separate wall-clock timer, so their playback rate must stay
+ * unchanged.
  *
- * @param {Animation} animation
+ * @param {EventTarget | null | undefined} target
  * @returns {boolean}
  */
-function isWallClockAnimation(animation) {
-  const target = animation.effect?.target
-  return target instanceof Element && target.closest('.timeout-indicator') !== null
+function isAnimationSpeedManaged(target) {
+  return target instanceof Element && (
+    target.matches('.feed-enter-active, .feed-move') ||
+    target.closest('[data-animation-speed-managed], .timeout-indicator') !== null
+  )
 }
 
 function updateTargetAnimations(event) {
   queueMicrotask(() => {
+    if (isAnimationSpeedManaged(event.target)) { return }
     if (!(event.target instanceof Element)) { return }
-    if (event.target.matches('.feed-enter-active, .feed-move') ||
-      event.target.closest('[data-animation-speed-managed], .timeout-indicator')) { return }
 
     event.target.getAnimations({ subtree: false }).forEach(animation => {
       applyAnimationSpeed(animation)
@@ -45,12 +49,20 @@ document.addEventListener('transitionrun', updateTargetAnimations, true)
  * @param {number} value percentage of the default animation speed
  */
 export function setAnimationSpeed(value) {
+  animationPlaybackRate = getAnimationSpeedMultiplier(value)
+  updateActiveAnimations()
+}
+
+/**
+ * @param {number} value percentage of the default animation speed
+ * @returns {number}
+ */
+export function getAnimationSpeedMultiplier(value) {
   const speed = Number.isFinite(value) && value > 0
-    ? value
+    ? Math.min(Math.max(value, MIN_ANIMATION_SPEED), MAX_ANIMATION_SPEED)
     : DEFAULT_ANIMATION_SPEED
 
-  animationPlaybackRate = speed / DEFAULT_ANIMATION_SPEED
-  updateActiveAnimations()
+  return speed / DEFAULT_ANIMATION_SPEED
 }
 
 /**

--- a/src/renderer/helpers/animationSpeed.js
+++ b/src/renderer/helpers/animationSpeed.js
@@ -7,16 +7,30 @@ let animationPlaybackRate = 1
  * attached to the document.
  */
 function updateActiveAnimations() {
-  document.getAnimations({ subtree: true }).forEach(animation => {
-    applyAnimationSpeed(animation)
-  })
+  document.getAnimations({ subtree: true })
+    .filter(animation => !isWallClockAnimation(animation))
+    .forEach(animation => {
+      applyAnimationSpeed(animation)
+    })
+}
+
+/**
+ * Some animations visualize a separate wall-clock timer and must stay in sync
+ * with that timer rather than the UI animation preference.
+ *
+ * @param {Animation} animation
+ * @returns {boolean}
+ */
+function isWallClockAnimation(animation) {
+  const target = animation.effect?.target
+  return target instanceof Element && target.closest('.timeout-indicator') !== null
 }
 
 function updateTargetAnimations(event) {
   queueMicrotask(() => {
     if (!(event.target instanceof Element)) { return }
     if (event.target.matches('.feed-enter-active, .feed-move') ||
-      event.target.closest('[data-animation-speed-managed]')) { return }
+      event.target.closest('[data-animation-speed-managed], .timeout-indicator')) { return }
 
     event.target.getAnimations({ subtree: false }).forEach(animation => {
       applyAnimationSpeed(animation)

--- a/src/renderer/store/modules/settings.js
+++ b/src/renderer/store/modules/settings.js
@@ -14,6 +14,7 @@ import { getSystemLocale, showToast } from '../../helpers/utils'
 import { DEFAULT_THUMBNAIL_SIZE } from '../../constants/thumbnailSize'
 import { DEFAULT_FIXED_TAB_WIDTH } from '../../constants/tabWidth'
 import { setReducedMotionPreference } from '../../helpers/reducedMotion'
+import { setAnimationSpeed } from '../../helpers/animationSpeed'
 import { DEFAULT_SEARCH_ENGINES_SETTING } from '../../../searchEngines'
 
 const YT_DLP_PLAYBACK_ENGINE_MIGRATION_SETTING = 'ytDlpPlaybackEngineDefaultMigration'
@@ -359,6 +360,7 @@ const state = {
   thumbnailPreference: '',
   thumbnailSize: DEFAULT_THUMBNAIL_SIZE,
   uiRoundness: 100,
+  animationSpeed: 100,
   showThumbnailSizeButtonInHeader: true,
   showToastTimeoutIndicator: true,
   toastPosition: 'bottom-left',
@@ -452,6 +454,10 @@ const sideEffectHandlers = {
 
   reducedMotion: (store, value) => {
     setReducedMotionPreference(value)
+  },
+
+  animationSpeed: (_store, value) => {
+    setAnimationSpeed(value)
   },
 
   currentLocale: async ({ dispatch }, value) => {

--- a/src/renderer/views/Subscriptions/Subscriptions.vue
+++ b/src/renderer/views/Subscriptions/Subscriptions.vue
@@ -32,7 +32,8 @@
               <div
                 v-if="tabsIndicatorStyle"
                 class="tabsIndicator"
-                :style="tabsIndicatorStyle"
+                data-animation-speed-managed
+                :style="[tabsIndicatorStyle, { transitionDuration: tabsIndicatorTransitionDuration }]"
                 aria-hidden="true"
               />
               <!-- eslint-disable-next-line vuejs-accessibility/interactive-supports-focus -->
@@ -45,7 +46,7 @@
                 aria-controls="subscriptionsPanel"
                 data-subscription-feed-tab="videos"
                 :tabindex="currentTab === 'videos' ? 0 : -1"
-                :class="{ selectedTab: currentTab === 'videos' }"
+                :class="{ selectedTab: selectedTab === 'videos' }"
                 @click="changeTab('videos')"
                 @keydown.space.enter.prevent="changeTab('videos')"
                 @keydown.left.right="focusTab($event, 'videos')"
@@ -70,7 +71,7 @@
                 aria-controls="subscriptionsPanel"
                 data-subscription-feed-tab="shorts"
                 :tabindex="currentTab === 'shorts' ? 0 : -1"
-                :class="{ selectedTab: currentTab === 'shorts' }"
+                :class="{ selectedTab: selectedTab === 'shorts' }"
                 @click="changeTab('shorts')"
                 @keydown.space.enter.prevent="changeTab('shorts')"
                 @keydown.left.right="focusTab($event, 'shorts')"
@@ -95,7 +96,7 @@
                 aria-controls="subscriptionsPanel"
                 data-subscription-feed-tab="live"
                 :tabindex="currentTab === 'live' ? 0 : -1"
-                :class="{ selectedTab: currentTab === 'live' }"
+                :class="{ selectedTab: selectedTab === 'live' }"
                 @click="changeTab('live')"
                 @keydown.space.enter.prevent="changeTab('live')"
                 @keydown.left.right="focusTab($event, 'live')"
@@ -120,7 +121,7 @@
                 aria-controls="subscriptionsPanel"
                 data-subscription-feed-tab="posts"
                 :tabindex="currentTab === 'community' ? 0 : -1"
-                :class="{ selectedTab: currentTab === 'community' }"
+                :class="{ selectedTab: selectedTab === 'community' }"
                 @click="changeTab('community')"
                 @keydown.space.enter.prevent="changeTab('community')"
                 @keydown.left.right="focusTab($event, 'community')"
@@ -145,7 +146,7 @@
                 aria-controls="subscriptionsPanel"
                 data-subscription-feed-tab="all"
                 :tabindex="currentTab === 'new' ? 0 : -1"
-                :class="{ selectedTab: currentTab === 'new' }"
+                :class="{ selectedTab: selectedTab === 'new' }"
                 @click="changeTab('new')"
                 @keydown.space.enter.prevent="changeTab('new')"
                 @keydown.left.right="focusTab($event, 'new')"
@@ -261,6 +262,7 @@ import SubscriptionsLive from '../../components/SubscriptionsLive.vue'
 import SubscriptionsShorts from '../../components/SubscriptionsShorts.vue'
 import SubscriptionsPosts from '../../components/SubscriptionsPosts.vue'
 
+import { getAnimationSpeedMultiplier } from '../../helpers/animationSpeed'
 import store from '../../store/index'
 import { useTabContext } from '../../tabs/TabContext'
 import { getTabNavigationService } from '../../tabs/TabNavigationService'
@@ -351,6 +353,7 @@ const refreshProgressPercentage = computed(() => {
 
 /** @type {import('vue').Ref<'videos' | 'shorts' | 'live' | 'community' | 'new' | null>} */
 const currentTab = ref('videos')
+const selectedTab = ref('videos')
 
 const tabScrollPositions = {
   videos: 0,
@@ -418,6 +421,7 @@ let isMounted = false
 let removeFeedReloadRequestListener = null
 /** @type {number | null} */
 let pendingTabChangeFrame = null
+let tabChangeSequence = 0
 
 onMounted(() => {
   isMounted = true
@@ -429,6 +433,7 @@ onMounted(() => {
 
 onBeforeUnmount(() => {
   isMounted = false
+  tabChangeSequence++
   removeFeedReloadRequestListener?.()
 
   if (pendingTabChangeFrame !== null) {
@@ -487,13 +492,15 @@ const visibleTabs = computed(() => {
 
 watch(visibleTabs, (value) => {
   if (value.length === 0) {
+    selectedTab.value = null
     currentTab.value = null
-  } else if (!value.includes(currentTab.value)) {
-    currentTab.value = value[0]
+  } else if (!value.includes(selectedTab.value)) {
+    changeTab(value[0])
   }
 })
 
 if (visibleTabs.value.length === 0) {
+  selectedTab.value = null
   currentTab.value = null
 } else {
   // Restore currentTab
@@ -501,6 +508,7 @@ if (visibleTabs.value.length === 0) {
   if (lastCurrentTabId !== null) {
     changeTab(lastCurrentTabId)
   } else if (!visibleTabs.value.includes(currentTab.value)) {
+    selectedTab.value = visibleTabs.value[0]
     currentTab.value = visibleTabs.value[0]
   }
 }
@@ -518,9 +526,11 @@ function changeTab(tab) {
     pendingTabChangeFrame = null
   }
 
-  if (tab === currentTab.value) {
+  if (tab === selectedTab.value) {
     if (hadPendingChange) {
-      // Put the indicator back onto the tab that stays selected
+      // Complete the cancelled panel swap so the highlighted tab and its
+      // content cannot get separated by a repeated activation.
+      currentTab.value = tab
       updateTabsIndicator()
     }
 
@@ -532,20 +542,30 @@ function changeTab(tab) {
     ? tab
     : (visibleTabs.value.length > 0 ? visibleTabs.value[0] : null)
 
-  // Move the indicator first and let it paint before the panel is swapped,
-  // otherwise rendering a feed with a lot of videos in the same frame delays
-  // the start of the animation and it appears to jump
-  if (target !== null && moveTabsIndicatorTo(target)) {
+  selectedTab.value = target
+  const sequence = ++tabChangeSequence
+
+  if (!isMounted || target === null) {
+    currentTab.value = target
+    return
+  }
+
+  // Let the selected label reach its final bold width before measuring the
+  // indicator. The content is swapped two frames later, after the compositor
+  // has started moving the indicator toward that stable target.
+  nextTick(() => {
+    if (sequence !== tabChangeSequence) { return }
+
+    moveTabsIndicatorTo(target)
     pendingTabChangeFrame = window.requestAnimationFrame(() => {
       pendingTabChangeFrame = window.requestAnimationFrame(() => {
+        if (sequence !== tabChangeSequence) { return }
+
         pendingTabChangeFrame = null
         currentTab.value = target
       })
     })
-    return
-  }
-
-  currentTab.value = target
+  })
 }
 
 const videosTab = useTemplateRef('videosTab')
@@ -818,6 +838,9 @@ watch([currentTabPanel, currentTabHasNewContent], () => nextTick(() => {
 const tabsContainerRef = useTemplateRef('tabsContainerRef')
 /** @type {import('vue').Ref<Record<string, string> | null>} */
 const tabsIndicatorStyle = ref(null)
+const tabsIndicatorTransitionDuration = computed(() => {
+  return `${200 / getAnimationSpeedMultiplier(store.getters.getAnimationSpeed)}ms`
+})
 let tabsResizeObserver = null
 // Place the indicator without animating when it was last measured while
 // hidden (e.g. in a background browser tab, where all offsets read 0),
@@ -896,7 +919,7 @@ function moveTabsIndicatorTo(tab) {
   return tabElement instanceof HTMLElement && placeTabsIndicator(tabElement)
 }
 
-watch([currentTab, visibleTabs, refreshingFeedTab], () => nextTick(updateTabsIndicator))
+watch([selectedTab, visibleTabs, refreshingFeedTab], () => nextTick(updateTabsIndicator))
 
 onMounted(() => {
   if (typeof ResizeObserver === 'function') {

--- a/src/renderer/views/Subscriptions/Subscriptions.vue
+++ b/src/renderer/views/Subscriptions/Subscriptions.vue
@@ -492,6 +492,14 @@ const visibleTabs = computed(() => {
 
 watch(visibleTabs, (value) => {
   if (value.length === 0) {
+    // Invalidate both scheduled nextTick work and an already queued frame so a
+    // deferred switch cannot restore a feed after its final tab is hidden.
+    tabChangeSequence++
+    if (pendingTabChangeFrame !== null) {
+      window.cancelAnimationFrame(pendingTabChangeFrame)
+      pendingTabChangeFrame = null
+    }
+
     selectedTab.value = null
     currentTab.value = null
   } else if (!value.includes(selectedTab.value)) {

--- a/src/renderer/views/Watch/Watch.js
+++ b/src/renderer/views/Watch/Watch.js
@@ -21,6 +21,7 @@ import FtIconButton from '../../components/FtIconButton/FtIconButton.vue'
 import FtAddToPlaylistDropdown from '../../components/FtAddToPlaylistDropdown/FtAddToPlaylistDropdown.vue'
 import FtPaidPromotionBadge from '../../components/FtPaidPromotionBadge/FtPaidPromotionBadge.vue'
 import { calculateColorLuminance } from '../../helpers/colors'
+import { applyAnimationSpeed } from '../../helpers/animationSpeed'
 import { isReducedMotionEnabled } from '../../helpers/reducedMotion'
 import { hasReachedWatchedThreshold, isHistoryEntryWatched } from '../../helpers/history'
 import { isVideoHiddenByPreferences } from '../../helpers/subscriptions'
@@ -1113,7 +1114,7 @@ export default defineComponent({
         const isVideoPlayer = element.classList.contains('videoPlayer')
         const scaleX = isVideoPlayer ? previousRect.width / nextRect.width : 1
         const scaleY = isVideoPlayer ? previousRect.height / nextRect.height : 1
-        const animation = element.animate([
+        const animation = applyAnimationSpeed(element.animate([
           {
             transform: `translate(${translateX}px, ${translateY}px) scale(${scaleX}, ${scaleY})`,
             transformOrigin: 'top left'
@@ -1125,7 +1126,7 @@ export default defineComponent({
         ], {
           duration: THEATRE_MODE_ANIMATION_DURATION,
           easing: 'cubic-bezier(0.4, 0, 0.2, 1)'
-        })
+        }))
 
         animation.addEventListener('finish', () => {
           this.theatreModeAnimations = this.theatreModeAnimations.filter(item => item !== animation)

--- a/static/locales/en-US.yaml
+++ b/static/locales/en-US.yaml
@@ -451,6 +451,7 @@ Settings:
     Disable Smooth Scrolling: Disable Smooth Scrolling
     UI Scale: UI Scale
     UI Roundness: UI Roundness
+    Animation Speed: Animation Speed
     Thumbnail Size: Thumbnail Size
     Show Thumbnail Size Button in Header: Show Thumbnail Size Button in Header
     Show Tab Icons: Show Tab Icons

--- a/tests/unit/animation-speed.test.mjs
+++ b/tests/unit/animation-speed.test.mjs
@@ -1,0 +1,64 @@
+import assert from 'node:assert/strict'
+import test from 'node:test'
+
+class FakeElement {
+  constructor ({ feed = false, managed = false, timeout = false } = {}) {
+    this.feed = feed
+    this.managed = managed
+    this.timeout = timeout
+  }
+
+  matches () {
+    return this.feed
+  }
+
+  closest () {
+    return this.managed || this.timeout ? this : null
+  }
+}
+
+globalThis.Element = FakeElement
+
+const activeAnimations = []
+globalThis.document = {
+  addEventListener () {},
+  getAnimations () {
+    return activeAnimations
+  }
+}
+
+const {
+  getAnimationSpeedMultiplier,
+  setAnimationSpeed
+} = await import('../../src/renderer/helpers/animationSpeed.js')
+
+test('clamps animation speed to the supported range', () => {
+  assert.equal(getAnimationSpeedMultiplier(10), 0.25)
+  assert.equal(getAnimationSpeedMultiplier(25), 0.25)
+  assert.equal(getAnimationSpeedMultiplier(100), 1)
+  assert.equal(getAnimationSpeedMultiplier(200), 2)
+  assert.equal(getAnimationSpeedMultiplier(300), 2)
+  assert.equal(getAnimationSpeedMultiplier(0), 1)
+  assert.equal(getAnimationSpeedMultiplier(Number.NaN), 1)
+})
+
+test('does not rescale animations with speed-managed timing', () => {
+  const playbackRates = []
+  const animation = target => ({
+    effect: { target },
+    updatePlaybackRate (rate) {
+      playbackRates.push(rate)
+    }
+  })
+
+  activeAnimations.push(
+    animation(new FakeElement()),
+    animation(new FakeElement({ feed: true })),
+    animation(new FakeElement({ managed: true })),
+    animation(new FakeElement({ timeout: true }))
+  )
+
+  setAnimationSpeed(300)
+
+  assert.deepEqual(playbackRates, [2])
+})

--- a/tests/unit/animation-speed.test.mjs
+++ b/tests/unit/animation-speed.test.mjs
@@ -2,7 +2,8 @@ import assert from 'node:assert/strict'
 import test from 'node:test'
 
 class FakeElement {
-  constructor ({ feed = false, managed = false, timeout = false } = {}) {
+  constructor ({ animations = [], feed = false, managed = false, timeout = false } = {}) {
+    this.animations = animations
     this.feed = feed
     this.managed = managed
     this.timeout = timeout
@@ -15,13 +16,20 @@ class FakeElement {
   closest () {
     return this.managed || this.timeout ? this : null
   }
+
+  getAnimations () {
+    return this.animations
+  }
 }
 
 globalThis.Element = FakeElement
 
 const activeAnimations = []
+const listeners = new Map()
 globalThis.document = {
-  addEventListener () {},
+  addEventListener (type, listener) {
+    listeners.set(type, listener)
+  },
   getAnimations () {
     return activeAnimations
   }
@@ -61,4 +69,25 @@ test('does not rescale animations with speed-managed timing', () => {
   setAnimationSpeed(300)
 
   assert.deepEqual(playbackRates, [2])
+  activeAnimations.length = 0
+})
+
+test('applies speed to newly started unmanaged animations', async () => {
+  const playbackRates = []
+  const animation = {
+    updatePlaybackRate (rate) {
+      playbackRates.push(rate)
+    }
+  }
+  const unmanagedTarget = new FakeElement({ animations: [animation] })
+  const managedTarget = new FakeElement({ animations: [animation], managed: true })
+
+  setAnimationSpeed(200)
+  listeners.get('animationstart')({ target: unmanagedTarget })
+  listeners.get('animationstart')({ target: managedTarget })
+  listeners.get('transitionrun')({ target: unmanagedTarget })
+  listeners.get('transitionrun')({ target: managedTarget })
+  await Promise.resolve()
+
+  assert.deepEqual(playbackRates, [2, 2])
 })

--- a/tests/unit/release-notes.test.mjs
+++ b/tests/unit/release-notes.test.mjs
@@ -129,14 +129,6 @@ test('pull request bodies have to keep every release note marker', () => {
       new RegExp(`Keep the ${marker} markers`),
       `removing the ${marker} markers has to be rejected`,
     )
-
-    const withoutEndMarker = body.replace(`<!-- ${marker}:end -->`, '')
-
-    assert.throws(
-      () => validatePullRequestEvent({ pull_request: { body: withoutEndMarker } }),
-      new RegExp(`Keep the ${marker} markers`),
-      `removing the ${marker} end marker has to be rejected`,
-    )
   }
 
   assert.throws(

--- a/tests/unit/release-notes.test.mjs
+++ b/tests/unit/release-notes.test.mjs
@@ -122,13 +122,15 @@ test('pull request bodies have to keep every release note marker', () => {
   const markers = ['release-note-category', 'release-note', 'release-note-image']
 
   for (const marker of markers) {
-    const withoutMarker = body.replace(`<!-- ${marker}:start -->`, '')
+    for (const side of ['start', 'end']) {
+      const withoutMarker = body.replace(`<!-- ${marker}:${side} -->`, '')
 
-    assert.throws(
-      () => validatePullRequestEvent({ pull_request: { body: withoutMarker } }),
-      new RegExp(`Keep the ${marker} markers`),
-      `removing the ${marker} markers has to be rejected`,
-    )
+      assert.throws(
+        () => validatePullRequestEvent({ pull_request: { body: withoutMarker } }),
+        new RegExp(`Keep the ${marker} markers`),
+        `removing the ${marker}:${side} marker has to be rejected`,
+      )
+    }
   }
 
   assert.throws(


### PR DESCRIPTION
## Pull Request Type
- [ ] Bugfix
- [x] Feature Implementation
- [ ] Documentation
- [ ] Other

## Related issue
None.

## Description
Adds a persisted Animation Speed slider to Theme settings with a range of 25–200% and a default of 100%. The control is disabled whenever reduced motion is active, including when inherited from the operating system.

The selected speed applies to CSS transitions and animations as well as the Web Animations API used by the player. Subscription feed and tab-indicator transitions use their scaled duration from the start to avoid flicker and retargeting while switching large feeds. The theme slider layout now keeps all four controls on one row when space allows and centers wrapped rows.

Also makes the update notification banner follow the UI Roundness setting.

## Screenshots
Not included.

## Release note category
<!-- release-note-category:start -->
- [ ] Not noteworthy
- [ ] Highlights
- [x] More improvements
- [ ] Fixed bugs
<!-- release-note-category:end -->

## Release note
<!-- release-note:start -->
Added an animation speed control to Theme settings.
<!-- release-note:end -->

## Release note images
<!-- release-note-image:start -->
<img width="307" height="76" alt="image" src="https://github.com/user-attachments/assets/f1047c65-3665-4382-ade1-edc9f5a434d6" />
<!-- release-note-image:end -->

## Testing
1. Open Settings → Theme and change Animation Speed between 25% and 200%.
2. Verify UI animations, subscription feed item transitions, and the subscription tab indicator follow the selected speed.
3. Enable reduced motion in General settings and verify the Animation Speed slider becomes disabled.
4. Change UI Roundness and verify the update notification banner follows it.

Automated checks:
- `pnpm run lint`
- `pnpm run test:unit` (204 passed)
- Focused settings E2E test under Xvfb (1 passed)
- Subscription tab indicator E2E suite under Xvfb (4 passed)

## Desktop
- **OS:** Arch Linux
- **OS Version:** Rolling release
- **OpenTubeX version:** 0.30.2

## Additional context
The animation speed is implemented as a playback-rate multiplier while transitions that are sensitive to start-time retargeting use a precomputed scaled duration.