### PR TITLE
fix(tabs): persist tab avatars across restarts

### DIFF
--- a/src/constants.js
+++ b/src/constants.js
@@ -56,6 +56,8 @@ const IpcChannels = {
   TABS_UPDATE_ROUTE: 'tabs-update-route',
   TABS_UPDATE_NAV_HISTORY: 'tabs-update-nav-history',
   TABS_UPDATE_TITLE: 'tabs-update-title',
+  TABS_UPDATE_AVATAR: 'tabs-update-avatar',
+  TABS_SET_AVATARS_ENABLED: 'tabs-set-avatars-enabled',
   TABS_EXIT_FULLSCREEN: 'tabs-exit-fullscreen',
   TABS_ACTIVE_CHANGED: 'tabs-active-changed',
   TABS_IS_ACTIVE: 'tabs-is-active',

--- a/src/main/index.js
+++ b/src/main/index.js
@@ -1595,7 +1595,9 @@ function runApp() {
     // forced quit stay on disk forever.
     await TabManager.pruneTabPreviewCache(
       savedSessions.flatMap(session => (
-        Array.isArray(session?.tabs) ? session.tabs.map(tab => tab?.previewFileName) : []
+        Array.isArray(session?.tabs)
+          ? session.tabs.flatMap(tab => [tab?.previewFileName, tab?.avatarFileName])
+          : []
       ))
     )
 

--- a/src/main/tabs/TabManager.js
+++ b/src/main/tabs/TabManager.js
@@ -1,4 +1,4 @@
-import { BrowserWindow, ipcMain, app, nativeImage, net, shell } from 'electron'
+import { BrowserWindow, ipcMain, app, nativeImage, shell } from 'electron'
 import { randomUUID } from 'crypto'
 import { mkdir, readdir, readFile, rename, unlink, writeFile } from 'fs/promises'
 import { join } from 'path'
@@ -64,7 +64,6 @@ const TAB_AVATAR_SIZE = 64
  * @property {string} title
  * @property {string | null} avatarDataUrl
  * @property {string | null} avatarFileName
- * @property {string | null} avatarRequestUrl
  * @property {number} lastActiveAt
  * @property {boolean} isPlaying
  * @property {boolean} isPinned
@@ -698,45 +697,23 @@ export class TabManager {
   }
 
   /**
-   * Keep tab-session avatars small, portable, and safe to render as images.
-   * @param {unknown} value
-   * @returns {string | null}
-   */
-  static normalizeTabAvatarUrl(value) {
-    if (typeof value !== 'string' || value.length > 4096) return null
-
-    try {
-      const url = new URL(value)
-      return url.protocol === 'https:' || url.protocol === 'http:' ? url.href : null
-    } catch {
-      return null
-    }
-  }
-
-  /**
    * @param {TabInfo} tab
-   * @param {string | null} avatarUrl
+   * @param {unknown} avatarBytes
+   * @param {string} routePath
    * @returns {Promise<boolean>}
    */
-  async applyTabAvatar(tab, avatarUrl) {
-    const nextAvatarUrl = TabManager.normalizeTabAvatarUrl(avatarUrl)
-    if (!this._avatarsEnabled || nextAvatarUrl == null || nextAvatarUrl === tab.avatarRequestUrl) {
+  async applyTabAvatar(tab, avatarBytes, routePath) {
+    if (!this._avatarsEnabled || tab.route.path !== routePath) {
       return false
     }
 
-    tab.avatarRequestUrl = nextAvatarUrl
     try {
-      const response = await net.fetch(nextAvatarUrl)
-      const contentLength = Number(response.headers.get('content-length'))
-      if (
-        !response.ok ||
-        !response.headers.get('content-type')?.startsWith('image/') ||
-        (Number.isFinite(contentLength) && contentLength > MAX_TAB_AVATAR_DOWNLOAD_BYTES)
-      ) {
-        return false
-      }
-
-      const sourceBuffer = Buffer.from(await response.arrayBuffer())
+      const sourceBuffer = avatarBytes instanceof ArrayBuffer
+        ? Buffer.from(avatarBytes)
+        : ArrayBuffer.isView(avatarBytes)
+          ? Buffer.from(avatarBytes.buffer, avatarBytes.byteOffset, avatarBytes.byteLength)
+          : null
+      if (sourceBuffer == null) return false
       if (sourceBuffer.length === 0 || sourceBuffer.length > MAX_TAB_AVATAR_DOWNLOAD_BYTES) {
         return false
       }
@@ -758,14 +735,14 @@ export class TabManager {
       if (
         !this._avatarsEnabled ||
         !this.tabs.has(tab.id) ||
-        tab.avatarRequestUrl !== nextAvatarUrl ||
+        tab.route.path !== routePath ||
         buffer.length === 0
       ) {
         return false
       }
 
       await this._persistTabAvatar(tab, buffer)
-      if (!this._avatarsEnabled || tab.avatarRequestUrl !== nextAvatarUrl) {
+      if (!this._avatarsEnabled || tab.route.path !== routePath) {
         const fileName = tab.avatarFileName
         tab.avatarFileName = null
         await this._deleteTabPreviewFile(fileName)
@@ -778,10 +755,6 @@ export class TabManager {
     } catch (error) {
       console.error('Failed to cache tab avatar:', error)
       return false
-    } finally {
-      if (tab.avatarRequestUrl === nextAvatarUrl) {
-        tab.avatarRequestUrl = null
-      }
     }
   }
 
@@ -796,7 +769,6 @@ export class TabManager {
     if (enabled) return
 
     await Promise.all(Array.from(this.tabs.values(), async tab => {
-      tab.avatarRequestUrl = null
       tab.avatarDataUrl = null
       const fileName = tab.avatarFileName
       tab.avatarFileName = null
@@ -916,7 +888,6 @@ export class TabManager {
       title: title || TabManager.formatDefaultTabTitle(location.url),
       avatarDataUrl: isTabPreviewDataUrl(avatarDataUrl) ? avatarDataUrl : null,
       avatarFileName: restoredAvatarFileName,
-      avatarRequestUrl: null,
       lastActiveAt: Date.now(),
       isPlaying: false,
       isPinned: Boolean(isPinned),
@@ -2124,7 +2095,6 @@ export class TabManager {
       title: snapshot.title,
       avatarDataUrl: isTabPreviewDataUrl(snapshot.avatarDataUrl) ? snapshot.avatarDataUrl : null,
       avatarFileName: normalizeTabPreviewFileName(snapshot.avatarFileName),
-      avatarRequestUrl: null,
       lastActiveAt: Date.now(),
       isPlaying: false,
       isPinned: snapshot.isPinned === true,
@@ -2185,7 +2155,6 @@ export class TabManager {
       const avatarFileName = tab.avatarFileName
       tab.avatarDataUrl = null
       tab.avatarFileName = null
-      tab.avatarRequestUrl = null
       this._deleteTabPreviewFile(avatarFileName).catch(error => {
         console.error('Failed to delete stale tab avatar:', error)
       })
@@ -2865,11 +2834,11 @@ export async function setupTabsIPC(options = {}) {
     }
   })
 
-  ipcMain.handle(IpcChannels.TABS_UPDATE_AVATAR, async (event, avatarUrl, tabId) => {
+  ipcMain.handle(IpcChannels.TABS_UPDATE_AVATAR, async (event, avatarBytes, tabId, routePath) => {
     const manager = getManager(event)
     const tab = typeof tabId === 'string' ? manager?.tabs.get(tabId) : null
-    if (manager && tab && (typeof avatarUrl === 'string' || avatarUrl === null)) {
-      return await manager.applyTabAvatar(tab, avatarUrl)
+    if (manager && tab && typeof routePath === 'string') {
+      return await manager.applyTabAvatar(tab, avatarBytes, routePath)
     }
     return false
   })

--- a/src/main/tabs/TabManager.js
+++ b/src/main/tabs/TabManager.js
@@ -719,7 +719,10 @@ export class TabManager {
       }
 
       let image = nativeImage.createFromBuffer(sourceBuffer)
-      if (image.isEmpty()) return false
+      if (image.isEmpty()) {
+        console.warn('Failed to decode tab avatar image data')
+        return false
+      }
 
       const size = image.getSize()
       if (size.width > TAB_AVATAR_SIZE || size.height > TAB_AVATAR_SIZE) {
@@ -742,7 +745,11 @@ export class TabManager {
       }
 
       await this._persistTabAvatar(tab, buffer)
-      if (!this._avatarsEnabled || tab.route.path !== routePath) {
+      if (
+        !this._avatarsEnabled ||
+        !this.tabs.has(tab.id) ||
+        tab.route.path !== routePath
+      ) {
         const fileName = tab.avatarFileName
         tab.avatarFileName = null
         await this._deleteTabPreviewFile(fileName)

--- a/src/main/tabs/TabManager.js
+++ b/src/main/tabs/TabManager.js
@@ -1,4 +1,4 @@
-import { BrowserWindow, ipcMain, app, shell } from 'electron'
+import { BrowserWindow, ipcMain, app, nativeImage, net, shell } from 'electron'
 import { randomUUID } from 'crypto'
 import { mkdir, readdir, readFile, rename, unlink, writeFile } from 'fs/promises'
 import { join } from 'path'
@@ -49,6 +49,8 @@ const transferringTabIds = new Set()
 const TAB_LOADING_SOURCE_MOUNT = 'mount'
 const TAB_LOADING_SOURCE_RENDERER = 'renderer'
 const MAX_PERSISTED_NAV_HISTORY_ENTRIES = 25
+const MAX_TAB_AVATAR_DOWNLOAD_BYTES = 2 * 1024 * 1024
+const TAB_AVATAR_SIZE = 64
 
 /**
  * @typedef {'unloaded' | 'mounting' | 'loaded' | 'unloading'} TabLoadState
@@ -60,6 +62,9 @@ const MAX_PERSISTED_NAV_HISTORY_ENTRIES = 25
  * @property {string} url
  * @property {{name?: string | null, path: string, params: Record<string, string>, query: Record<string, string>, hash: string, fullPath: string}} route
  * @property {string} title
+ * @property {string | null} avatarDataUrl
+ * @property {string | null} avatarFileName
+ * @property {string | null} avatarRequestUrl
  * @property {number} lastActiveAt
  * @property {boolean} isPlaying
  * @property {boolean} isPinned
@@ -144,9 +149,9 @@ export class TabManager {
   }
 
   /**
-   * Deletes cached previews that no restored session refers to. Tabs delete
-   * their own preview when they close, but a crash or a forced quit leaves the
-   * file behind with nothing left to point at it.
+   * Deletes cached previews and avatars that no restored session refers to.
+   * Tabs delete their own files when they close, but a crash or a forced quit
+   * can leave a file behind with nothing left to point at it.
    *
    * Must run before any window exists: a capture racing this would write a file
    * that is not in `referencedFileNames` yet and would be deleted right away.
@@ -529,6 +534,8 @@ export class TabManager {
       // source state before activating. (url/route stay as mounted; isPinned is
       // fixed by insertion order and must not change here.)
       stagedTab.title = detached.title
+      stagedTab.avatarDataUrl = detached.avatarDataUrl
+      stagedTab.avatarFileName = detached.avatarFileName
       stagedTab.color = detached.color
       stagedTab.previewDataUrl = detached.previewDataUrl
       stagedTab.previewCapturedAt = detached.previewCapturedAt
@@ -590,6 +597,7 @@ export class TabManager {
     /** @type {Promise<void>} */
     this._previewCaptureLock = Promise.resolve()
     this._previewCapturePaused = false
+    this._avatarsEnabled = true
     /** Tabs whose navigation history the renderer has already been sent. */
     this._historyAnnouncedTabIds = new Set()
     this.bridge = new TabRendererBridge(browserWindow)
@@ -690,6 +698,115 @@ export class TabManager {
   }
 
   /**
+   * Keep tab-session avatars small, portable, and safe to render as images.
+   * @param {unknown} value
+   * @returns {string | null}
+   */
+  static normalizeTabAvatarUrl(value) {
+    if (typeof value !== 'string' || value.length > 4096) return null
+
+    try {
+      const url = new URL(value)
+      return url.protocol === 'https:' || url.protocol === 'http:' ? url.href : null
+    } catch {
+      return null
+    }
+  }
+
+  /**
+   * @param {TabInfo} tab
+   * @param {string | null} avatarUrl
+   * @returns {Promise<boolean>}
+   */
+  async applyTabAvatar(tab, avatarUrl) {
+    const nextAvatarUrl = TabManager.normalizeTabAvatarUrl(avatarUrl)
+    if (!this._avatarsEnabled || nextAvatarUrl == null || nextAvatarUrl === tab.avatarRequestUrl) {
+      return false
+    }
+
+    tab.avatarRequestUrl = nextAvatarUrl
+    try {
+      const response = await net.fetch(nextAvatarUrl)
+      const contentLength = Number(response.headers.get('content-length'))
+      if (
+        !response.ok ||
+        !response.headers.get('content-type')?.startsWith('image/') ||
+        (Number.isFinite(contentLength) && contentLength > MAX_TAB_AVATAR_DOWNLOAD_BYTES)
+      ) {
+        return false
+      }
+
+      const sourceBuffer = Buffer.from(await response.arrayBuffer())
+      if (sourceBuffer.length === 0 || sourceBuffer.length > MAX_TAB_AVATAR_DOWNLOAD_BYTES) {
+        return false
+      }
+
+      let image = nativeImage.createFromBuffer(sourceBuffer)
+      if (image.isEmpty()) return false
+
+      const size = image.getSize()
+      if (size.width > TAB_AVATAR_SIZE || size.height > TAB_AVATAR_SIZE) {
+        const scale = TAB_AVATAR_SIZE / Math.max(size.width, size.height)
+        image = image.resize({
+          width: Math.max(1, Math.round(size.width * scale)),
+          height: Math.max(1, Math.round(size.height * scale)),
+          quality: 'best'
+        })
+      }
+
+      const buffer = image.toJPEG(TAB_PREVIEW_JPEG_QUALITY)
+      if (
+        !this._avatarsEnabled ||
+        !this.tabs.has(tab.id) ||
+        tab.avatarRequestUrl !== nextAvatarUrl ||
+        buffer.length === 0
+      ) {
+        return false
+      }
+
+      await this._persistTabAvatar(tab, buffer)
+      if (!this._avatarsEnabled || tab.avatarRequestUrl !== nextAvatarUrl) {
+        const fileName = tab.avatarFileName
+        tab.avatarFileName = null
+        await this._deleteTabPreviewFile(fileName)
+        return false
+      }
+      tab.avatarDataUrl = tabPreviewBufferToDataUrl(buffer)
+      this._broadcastStateUpdate()
+      await this._saveSession()
+      return true
+    } catch (error) {
+      console.error('Failed to cache tab avatar:', error)
+      return false
+    } finally {
+      if (tab.avatarRequestUrl === nextAvatarUrl) {
+        tab.avatarRequestUrl = null
+      }
+    }
+  }
+
+  /**
+   * @param {boolean} enabled
+   * @returns {Promise<void>}
+   */
+  async setTabAvatarsEnabled(enabled) {
+    if (this._avatarsEnabled === enabled) return
+
+    this._avatarsEnabled = enabled
+    if (enabled) return
+
+    await Promise.all(Array.from(this.tabs.values(), async tab => {
+      tab.avatarRequestUrl = null
+      tab.avatarDataUrl = null
+      const fileName = tab.avatarFileName
+      tab.avatarFileName = null
+      await this._deleteTabPreviewFile(fileName)
+    }))
+    this._broadcastStateUpdate()
+    await this._saveSession()
+  }
+
+  /**
    * @param {string | undefined} url
    * @param {string | undefined} route
    * @param {object | undefined} query
@@ -753,6 +870,8 @@ export class TabManager {
       route,
       query,
       title,
+      avatarDataUrl = null,
+      avatarFileName = null,
       isPinned = false,
       color = null,
       previewDataUrl = null,
@@ -783,6 +902,7 @@ export class TabManager {
       ? previewDataUrl
       : null
     const restoredPreviewFileName = normalizeTabPreviewFileName(previewFileName)
+    const restoredAvatarFileName = normalizeTabPreviewFileName(avatarFileName)
     const restoredPreviewCapturedAt = (restoredPreviewDataUrl != null || restoredPreviewFileName != null) && Number.isFinite(previewCapturedAt)
       ? previewCapturedAt
       : 0
@@ -794,6 +914,9 @@ export class TabManager {
       url: location.url,
       route: location.route,
       title: title || TabManager.formatDefaultTabTitle(location.url),
+      avatarDataUrl: isTabPreviewDataUrl(avatarDataUrl) ? avatarDataUrl : null,
+      avatarFileName: restoredAvatarFileName,
+      avatarRequestUrl: null,
       lastActiveAt: Date.now(),
       isPlaying: false,
       isPinned: Boolean(isPinned),
@@ -1217,6 +1340,9 @@ export class TabManager {
     this._deleteTabPreviewFile(tab.previewFileName).catch(error => {
       console.error('Failed to delete closed tab preview:', error)
     })
+    this._deleteTabPreviewFile(tab.avatarFileName).catch(error => {
+      console.error('Failed to delete closed tab avatar:', error)
+    })
 
     if (nextTabId) {
       this.activeTabId = null
@@ -1247,6 +1373,7 @@ export class TabManager {
     return this.createTab({
       url: tab.url,
       title: tab.title,
+      avatarDataUrl: tab.avatarDataUrl,
       isPinned: tab.isPinned,
       color: tab.color,
       makeActive: true
@@ -1445,6 +1572,32 @@ export class TabManager {
       throw error
     }
     tab.previewFileName = fileName
+
+    if (reusableFileName == null && existingFileName != null) {
+      await this._deleteTabPreviewFile(existingFileName)
+    }
+  }
+
+  /**
+   * @param {TabInfo} tab
+   * @param {Buffer} buffer
+   * @returns {Promise<void>}
+   */
+  async _persistTabAvatar(tab, buffer) {
+    const existingFileName = normalizeTabPreviewFileName(tab.avatarFileName)
+    const reusableFileName = isReusableTabPreviewFileName(existingFileName) ? existingFileName : null
+    const fileName = reusableFileName ?? createTabPreviewFileName()
+    const cacheDirectory = TabManager.getTabPreviewCacheDirectory()
+    await mkdir(cacheDirectory, { recursive: true })
+    const tempPath = join(cacheDirectory, createTabPreviewTempFileName())
+    try {
+      await writeFile(tempPath, buffer)
+      await rename(tempPath, join(cacheDirectory, fileName))
+    } catch (error) {
+      await unlink(tempPath).catch(() => {})
+      throw error
+    }
+    tab.avatarFileName = fileName
 
     if (reusableFileName == null && existingFileName != null) {
       await this._deleteTabPreviewFile(existingFileName)
@@ -1900,6 +2053,8 @@ export class TabManager {
       url: tab.url,
       route: cloneRoute(tab.route),
       title: tab.title,
+      avatarDataUrl: tab.avatarDataUrl,
+      avatarFileName: tab.avatarFileName,
       isPinned: tab.isPinned,
       color: tab.color,
       previewDataUrl: tab.previewDataUrl,
@@ -1967,6 +2122,9 @@ export class TabManager {
       url: snapshot.url,
       route: cloneRoute(snapshot.route),
       title: snapshot.title,
+      avatarDataUrl: isTabPreviewDataUrl(snapshot.avatarDataUrl) ? snapshot.avatarDataUrl : null,
+      avatarFileName: normalizeTabPreviewFileName(snapshot.avatarFileName),
+      avatarRequestUrl: null,
       lastActiveAt: Date.now(),
       isPlaying: false,
       isPinned: snapshot.isPinned === true,
@@ -2022,7 +2180,17 @@ export class TabManager {
     const tab = this.tabs.get(tabId)
     if (!tab) return
 
-    tab.route = normalizeRoute(route)
+    const nextRoute = normalizeRoute(route)
+    if (nextRoute.path !== tab.route.path) {
+      const avatarFileName = tab.avatarFileName
+      tab.avatarDataUrl = null
+      tab.avatarFileName = null
+      tab.avatarRequestUrl = null
+      this._deleteTabPreviewFile(avatarFileName).catch(error => {
+        console.error('Failed to delete stale tab avatar:', error)
+      })
+    }
+    tab.route = nextRoute
     tab.url = url || this._urlFromRoute(tab.route)
     this._scheduleTabPreviewRefresh(tab)
     this._saveSession()
@@ -2086,6 +2254,7 @@ export class TabManager {
         url: tab.url,
         route: cloneRoute(tab.route),
         title: tab.title,
+        avatarUrl: tab.avatarDataUrl,
         isActive: tab.id === this.activeTabId,
         isUnloaded: tab.loadState === 'unloaded',
         isLoading: this._getTabLoadingState(tab),
@@ -2171,6 +2340,11 @@ export class TabManager {
         if (previewFileName != null && tab.previewCapturedAt > 0) {
           tabData.previewFileName = previewFileName
           tabData.previewCapturedAt = tab.previewCapturedAt
+        }
+
+        const avatarFileName = normalizeTabPreviewFileName(tab.avatarFileName)
+        if (avatarFileName != null) {
+          tabData.avatarFileName = avatarFileName
         }
 
         if (tab.persistNavigationHistory && tab.navigationHistory != null) {
@@ -2274,13 +2448,14 @@ export class TabManager {
     await Promise.all(
       Array.from(this.tabs.values())
         .filter(tab => tab.isTransferStaged !== true)
-        .map(tab => this._deleteTabPreviewFile(tab.previewFileName))
+        .flatMap(tab => [tab.previewFileName, tab.avatarFileName])
+        .map(fileName => this._deleteTabPreviewFile(fileName))
     )
     await clearTabSession(this.sessionId)
   }
 
   /**
-   * @param {{ tabs?: Array<{id?: string, url: string, title?: string, isPinned?: boolean, color?: string | null, isUnloaded?: boolean, previewFileName?: string | null, previewCapturedAt?: number, history?: object[], historyIndex?: number}>, activeTabId?: string }} sessionData
+   * @param {{ tabs?: Array<{id?: string, url: string, title?: string, avatarFileName?: string | null, isPinned?: boolean, color?: string | null, isUnloaded?: boolean, previewFileName?: string | null, previewCapturedAt?: number, history?: object[], historyIndex?: number}>, activeTabId?: string }} sessionData
    * @param {{ loadInactiveTabs?: boolean, restoreTabLoadState?: boolean }} [options]
    * @returns {Promise<boolean>}
    */
@@ -2304,6 +2479,8 @@ export class TabManager {
         const makeActive = tabData.id === sessionData.activeTabId
         const hasSavedTitle = typeof tabData.title === 'string' && tabData.title.trim().length > 0
         const previewFileName = normalizeTabPreviewFileName(tabData.previewFileName)
+        const avatarFileName = normalizeTabPreviewFileName(tabData.avatarFileName)
+        const avatarDataUrl = await this._loadTabPreviewDataUrl(avatarFileName)
         const loadInBackground = loadInactiveTabs || (restoreTabLoadState && tabData.isUnloaded === false)
         const restoreAsUnloaded = !loadInactiveTabs && !makeActive && (
           (restoreTabLoadState && tabData.isUnloaded === true) ||
@@ -2315,6 +2492,8 @@ export class TabManager {
           // Strip here as well to heal sessions persisted before the strip on save existed
           url: TabManager.stripOneTimeTimestampFromUrl(tabData.url),
           title: hasSavedTitle ? tabData.title : undefined,
+          avatarDataUrl,
+          avatarFileName: avatarDataUrl == null ? null : avatarFileName,
           isPinned: tabData.isPinned === true,
           color: tabData.color,
           // Preview images are only needed when the switcher asks for them.
@@ -2684,6 +2863,22 @@ export async function setupTabsIPC(options = {}) {
     if (manager && tab && typeof title === 'string') {
       manager.applyTabTitle(tab, title)
     }
+  })
+
+  ipcMain.handle(IpcChannels.TABS_UPDATE_AVATAR, async (event, avatarUrl, tabId) => {
+    const manager = getManager(event)
+    const tab = typeof tabId === 'string' ? manager?.tabs.get(tabId) : null
+    if (manager && tab && (typeof avatarUrl === 'string' || avatarUrl === null)) {
+      return await manager.applyTabAvatar(tab, avatarUrl)
+    }
+    return false
+  })
+
+  ipcMain.on(IpcChannels.TABS_SET_AVATARS_ENABLED, (event, enabled) => {
+    const manager = getManager(event)
+    manager?.setTabAvatarsEnabled(enabled === true).catch(error => {
+      console.error('Failed to update tab avatar caching:', error)
+    })
   })
 
   ipcMain.on(IpcChannels.TABS_UPDATE_ROUTE, (event, payload) => {

--- a/src/main/tabs/TabSessionStore.js
+++ b/src/main/tabs/TabSessionStore.js
@@ -19,7 +19,7 @@ import * as baseHandlers from '../../datastores/handlers/base.js'
 
 /**
  * @typedef {object} TabSessionData
- * @property {Array<{id: string, url: string, title: string, isPinned?: boolean, color?: string | null, isUnloaded?: boolean, previewFileName?: string | null, previewCapturedAt?: number, history?: object[], historyIndex?: number}>} tabs
+ * @property {Array<{id: string, url: string, title: string, avatarFileName?: string | null, isPinned?: boolean, color?: string | null, isUnloaded?: boolean, previewFileName?: string | null, previewCapturedAt?: number, history?: object[], historyIndex?: number}>} tabs
  * @property {string} activeTabId
  * @property {TabSessionBounds} [bounds]
  * @property {number} [updatedAt]

--- a/src/preload/interface.js
+++ b/src/preload/interface.js
@@ -863,6 +863,24 @@ export default {
     },
 
     /**
+     * Persist the resolved profile picture for a logical tab.
+     * @param {string | null} avatarUrl
+     * @param {string} tabId
+     * @returns {Promise<boolean>}
+     */
+    updateAvatar: (avatarUrl, tabId) => {
+      return ipcRenderer.invoke(IpcChannels.TABS_UPDATE_AVATAR, avatarUrl, tabId)
+    },
+
+    /**
+     * Enable or disable avatar caching for this window's tabs.
+     * @param {boolean} enabled
+     */
+    setAvatarsEnabled: (enabled) => {
+      ipcRenderer.send(IpcChannels.TABS_SET_AVATARS_ENABLED, enabled === true)
+    },
+
+    /**
      * Set loading state for a logical tab.
      * @param {boolean} isLoading
      * @param {string} tabId

--- a/src/preload/interface.js
+++ b/src/preload/interface.js
@@ -864,12 +864,13 @@ export default {
 
     /**
      * Persist the resolved profile picture for a logical tab.
-     * @param {string | null} avatarUrl
+     * @param {ArrayBuffer} avatarBytes
      * @param {string} tabId
+     * @param {string} routePath
      * @returns {Promise<boolean>}
      */
-    updateAvatar: (avatarUrl, tabId) => {
-      return ipcRenderer.invoke(IpcChannels.TABS_UPDATE_AVATAR, avatarUrl, tabId)
+    updateAvatar: (avatarBytes, tabId, routePath) => {
+      return ipcRenderer.invoke(IpcChannels.TABS_UPDATE_AVATAR, avatarBytes, tabId, routePath)
     },
 
     /**

--- a/src/renderer/components/TabBar/TabBar.vue
+++ b/src/renderer/components/TabBar/TabBar.vue
@@ -87,6 +87,8 @@ import store from '../../store/index'
 import { getConfiguredKeyboardShortcuts } from '../../../constants'
 import { localizeAndAddKeyboardShortcutToActionTitle } from '../../helpers/utils'
 import { normalizeFixedTabWidth } from '../../constants/tabWidth'
+import { getTabAvatarUrl } from '../../tabs/tabPreview'
+import { removeLegacyTabAvatar } from '../../helpers/channelThumbnailStorage'
 import SortableTab from './SortableTab.vue'
 import {
   buildCurrentShiftedTabIds,
@@ -109,6 +111,30 @@ const tabs = computed(() => store.getters.getTabs)
 /** @type {import('vue').ComputedRef<boolean>} */
 const vertical = computed(() => store.getters.getUseVerticalTabBar)
 const showTabIcons = computed(() => store.getters.getShowTabIcons)
+const migratingAvatarTabIds = new Set()
+
+watch([showTabIcons, tabs], ([enabled, currentTabs]) => {
+  if (!isElectron) return
+
+  window.ftElectron.tabs.setAvatarsEnabled(enabled)
+  if (!enabled) return
+
+  for (const tab of currentTabs) {
+    const avatarUrl = getTabAvatarUrl(tab)
+    if (!avatarUrl?.startsWith('http') || migratingAvatarTabIds.has(tab.id)) continue
+
+    migratingAvatarTabIds.add(tab.id)
+    window.ftElectron.tabs.updateAvatar(avatarUrl, tab.id).then(migrated => {
+      if (migrated) {
+        removeLegacyTabAvatar(tab.route)
+      }
+    }).catch(error => {
+      console.error('Failed to migrate tab avatar:', error)
+    }).finally(() => {
+      migratingAvatarTabIds.delete(tab.id)
+    })
+  }
+}, { immediate: true })
 
 // Only the horizontal bar sizes tabs by their content, so the fixed width is
 // applied there; vertical tabs always fill the column.

--- a/src/renderer/components/TabBar/TabBar.vue
+++ b/src/renderer/components/TabBar/TabBar.vue
@@ -89,6 +89,7 @@ import { localizeAndAddKeyboardShortcutToActionTitle } from '../../helpers/utils
 import { normalizeFixedTabWidth } from '../../constants/tabWidth'
 import { getTabAvatarUrl } from '../../tabs/tabPreview'
 import { removeLegacyTabAvatar } from '../../helpers/channelThumbnailStorage'
+import { fetchTabAvatarBytes } from '../../helpers/tabAvatar'
 import SortableTab from './SortableTab.vue'
 import {
   buildCurrentShiftedTabIds,
@@ -124,17 +125,25 @@ watch([showTabIcons, tabs], ([enabled, currentTabs]) => {
     if (!avatarUrl?.startsWith('http') || migratingAvatarTabIds.has(tab.id)) continue
 
     migratingAvatarTabIds.add(tab.id)
-    window.ftElectron.tabs.updateAvatar(avatarUrl, tab.id).then(migrated => {
-      if (migrated) {
-        removeLegacyTabAvatar(tab.route)
-      }
-    }).catch(error => {
-      console.error('Failed to migrate tab avatar:', error)
-    }).finally(() => {
-      migratingAvatarTabIds.delete(tab.id)
-    })
+    migrateTabAvatar(tab, avatarUrl)
   }
 }, { immediate: true })
+
+async function migrateTabAvatar(tab, avatarUrl) {
+  try {
+    const avatarBytes = await fetchTabAvatarBytes(avatarUrl)
+    if (avatarBytes == null) return
+
+    const migrated = await window.ftElectron.tabs.updateAvatar(avatarBytes, tab.id, tab.route.path)
+    if (migrated) {
+      removeLegacyTabAvatar(tab.route)
+    }
+  } catch (error) {
+    console.error('Failed to migrate tab avatar:', error)
+  } finally {
+    migratingAvatarTabIds.delete(tab.id)
+  }
+}
 
 // Only the horizontal bar sizes tabs by their content, so the fixed width is
 // applied there; vertical tabs always fill the column.

--- a/src/renderer/helpers/channelThumbnailStorage.js
+++ b/src/renderer/helpers/channelThumbnailStorage.js
@@ -1,50 +1,43 @@
 const CHANNEL_THUMBNAIL_CACHE_KEY = 'channelThumbnailCache'
 const VIDEO_AVATAR_CACHE_KEY = 'videoAvatarCache'
 
-// Cap the persisted cache so it can't grow without bound across sessions. The
-// cache is only a best-effort tab preview fallback, so an approximate FIFO
-// eviction of the oldest entries is good enough.
-export const CHANNEL_THUMBNAIL_CACHE_LIMIT = 200
-export const VIDEO_AVATAR_CACHE_LIMIT = 200
-
-function loadThumbnailCache(key) {
+function loadLegacyThumbnailCache(key) {
   try {
-    const raw = localStorage.getItem(key)
-    if (!raw) return {}
-
-    const parsed = JSON.parse(raw)
+    const parsed = JSON.parse(localStorage.getItem(key) ?? '{}')
     return parsed !== null && typeof parsed === 'object' ? parsed : {}
   } catch {
     return {}
   }
 }
 
-/**
- * @returns {Record<string, string>}
- */
-export function loadChannelThumbnailCache() {
-  return loadThumbnailCache(CHANNEL_THUMBNAIL_CACHE_KEY)
+export function loadLegacyChannelThumbnailCache() {
+  return loadLegacyThumbnailCache(CHANNEL_THUMBNAIL_CACHE_KEY)
 }
 
-export function loadVideoAvatarCache() {
-  return loadThumbnailCache(VIDEO_AVATAR_CACHE_KEY)
+export function loadLegacyVideoAvatarCache() {
+  return loadLegacyThumbnailCache(VIDEO_AVATAR_CACHE_KEY)
 }
 
-/**
- * @param {Record<string, string>} cache
- */
-export function persistChannelThumbnailCache(cache) {
-  persistThumbnailCache(CHANNEL_THUMBNAIL_CACHE_KEY, cache)
+export function removeLegacyTabAvatar(route) {
+  const path = route?.path ?? ''
+  const channelId = path.match(/^\/channel\/([^/]+)/)?.[1]
+  const videoId = path.match(/^\/watch\/([^/]+)/)?.[1]
+  if (channelId) removeLegacyThumbnail(CHANNEL_THUMBNAIL_CACHE_KEY, channelId)
+  if (videoId) removeLegacyThumbnail(VIDEO_AVATAR_CACHE_KEY, videoId)
 }
 
-export function persistVideoAvatarCache(cache) {
-  persistThumbnailCache(VIDEO_AVATAR_CACHE_KEY, cache)
-}
-
-function persistThumbnailCache(key, cache) {
+function removeLegacyThumbnail(key, id) {
   try {
-    localStorage.setItem(key, JSON.stringify(cache))
+    const cache = loadLegacyThumbnailCache(key)
+    if (!(id in cache)) return
+
+    delete cache[id]
+    if (Object.keys(cache).length === 0) {
+      localStorage.removeItem(key)
+    } else {
+      localStorage.setItem(key, JSON.stringify(cache))
+    }
   } catch {
-    // Ignore quota/serialization errors — the cache is a best-effort fallback.
+    // Migration is best-effort; a later page load can populate the file cache.
   }
 }

--- a/src/renderer/helpers/tabAvatar.js
+++ b/src/renderer/helpers/tabAvatar.js
@@ -1,4 +1,5 @@
 const MAX_TAB_AVATAR_DOWNLOAD_BYTES = 2 * 1024 * 1024
+const TAB_AVATAR_FETCH_TIMEOUT_MS = 5000
 
 /**
  * Download an avatar inside the sandboxed renderer, where normal web-origin
@@ -15,7 +16,9 @@ export async function fetchTabAvatarBytes(avatarUrl) {
   }
   if (url.protocol !== 'https:' && url.protocol !== 'http:') return null
 
-  const response = await fetch(url.href)
+  const response = await fetch(url.href, {
+    signal: AbortSignal.timeout(TAB_AVATAR_FETCH_TIMEOUT_MS)
+  })
   const contentLength = Number(response.headers.get('content-length'))
   if (
     !response.ok ||
@@ -25,8 +28,31 @@ export async function fetchTabAvatarBytes(avatarUrl) {
     return null
   }
 
-  const buffer = await response.arrayBuffer()
-  return buffer.byteLength > 0 && buffer.byteLength <= MAX_TAB_AVATAR_DOWNLOAD_BYTES
-    ? buffer
-    : null
+  if (response.body == null) return null
+
+  const reader = response.body.getReader()
+  const chunks = []
+  let byteLength = 0
+
+  while (true) {
+    const { done, value } = await reader.read()
+    if (done) break
+
+    byteLength += value.byteLength
+    if (byteLength > MAX_TAB_AVATAR_DOWNLOAD_BYTES) {
+      await reader.cancel()
+      return null
+    }
+    chunks.push(value)
+  }
+
+  if (byteLength === 0) return null
+
+  const bytes = new Uint8Array(byteLength)
+  let offset = 0
+  for (const chunk of chunks) {
+    bytes.set(chunk, offset)
+    offset += chunk.byteLength
+  }
+  return bytes.buffer
 }

--- a/src/renderer/helpers/tabAvatar.js
+++ b/src/renderer/helpers/tabAvatar.js
@@ -1,0 +1,32 @@
+const MAX_TAB_AVATAR_DOWNLOAD_BYTES = 2 * 1024 * 1024
+
+/**
+ * Download an avatar inside the sandboxed renderer, where normal web-origin
+ * and CORS restrictions apply, before passing only its bytes to main.
+ * @param {string} avatarUrl
+ * @returns {Promise<ArrayBuffer | null>}
+ */
+export async function fetchTabAvatarBytes(avatarUrl) {
+  let url
+  try {
+    url = new URL(avatarUrl)
+  } catch {
+    return null
+  }
+  if (url.protocol !== 'https:' && url.protocol !== 'http:') return null
+
+  const response = await fetch(url.href)
+  const contentLength = Number(response.headers.get('content-length'))
+  if (
+    !response.ok ||
+    !response.headers.get('content-type')?.startsWith('image/') ||
+    (Number.isFinite(contentLength) && contentLength > MAX_TAB_AVATAR_DOWNLOAD_BYTES)
+  ) {
+    return null
+  }
+
+  const buffer = await response.arrayBuffer()
+  return buffer.byteLength > 0 && buffer.byteLength <= MAX_TAB_AVATAR_DOWNLOAD_BYTES
+    ? buffer
+    : null
+}

--- a/src/renderer/store/modules/utils.js
+++ b/src/renderer/store/modules/utils.js
@@ -9,13 +9,12 @@ import {
   searchFiltersMatch,
 } from '../../helpers/utils'
 import {
-  CHANNEL_THUMBNAIL_CACHE_LIMIT,
-  VIDEO_AVATAR_CACHE_LIMIT,
-  loadChannelThumbnailCache,
-  loadVideoAvatarCache,
-  persistChannelThumbnailCache,
-  persistVideoAvatarCache,
+  loadLegacyChannelThumbnailCache,
+  loadLegacyVideoAvatarCache,
 } from '../../helpers/channelThumbnailStorage'
+
+const CHANNEL_THUMBNAIL_CACHE_LIMIT = 200
+const VIDEO_AVATAR_CACHE_LIMIT = 200
 
 function getOrCreateSearchSettings(state, tabId) {
   state.searchSettingsByTabId[tabId] ??= {
@@ -40,8 +39,10 @@ const state = {
   },
   cachedPlaylists: {},
   deArrowCache: {},
-  channelThumbnailCache: loadChannelThumbnailCache(),
-  videoAvatarCache: loadVideoAvatarCache(),
+  // Seed the in-memory fallback once so upgraded sessions can migrate unloaded
+  // tabs to image files without opening every tab first.
+  channelThumbnailCache: loadLegacyChannelThumbnailCache(),
+  videoAvatarCache: loadLegacyVideoAvatarCache(),
   showProgressBar: false,
   progressBarMessage: '',
   progressBarIcon: ['fas', 'sync'],
@@ -718,7 +719,6 @@ const mutations = {
     }
 
     cache[channelId] = thumbnail
-    persistChannelThumbnailCache(cache)
   },
 
   setVideoAvatar (state, { videoId, avatar }) {
@@ -733,7 +733,6 @@ const mutations = {
     }
 
     cache[videoId] = avatar
-    persistVideoAvatarCache(cache)
   },
 
   removeFromSessionSearchHistory (state, query) {

--- a/src/renderer/tabs/TabContext.js
+++ b/src/renderer/tabs/TabContext.js
@@ -3,6 +3,7 @@ import { inject, onBeforeUnmount } from 'vue'
 import store from '../store/index'
 import { getTabNavigationService } from './TabNavigationService'
 import { removeLegacyTabAvatar } from '../helpers/channelThumbnailStorage'
+import { fetchTabAvatarBytes } from '../helpers/tabAvatar'
 
 export const tabIdKey = Symbol('logical-tab-id')
 export const tabPresentedKey = Symbol('logical-tab-presented')
@@ -45,15 +46,20 @@ export function useTabAvatar() {
     isMounted = false
   })
 
-  return (avatarUrl) => {
-    if (isMounted && process.env.IS_ELECTRON && tabId && store.getters.getShowTabIcons) {
-      window.ftElectron.tabs.updateAvatar(avatarUrl, tabId).then(cached => {
-        if (cached) {
-          removeLegacyTabAvatar(store.getters.getTabById(tabId)?.route)
-        }
-      }).catch(error => {
-        console.error('Failed to cache tab avatar:', error)
-      })
+  return async (avatarUrl) => {
+    if (!isMounted || !process.env.IS_ELECTRON || !tabId || !store.getters.getShowTabIcons) return
+
+    try {
+      const route = store.getters.getTabById(tabId)?.route
+      const avatarBytes = await fetchTabAvatarBytes(avatarUrl)
+      if (!isMounted || avatarBytes == null || route?.path == null) return
+
+      const cached = await window.ftElectron.tabs.updateAvatar(avatarBytes, tabId, route.path)
+      if (cached) {
+        removeLegacyTabAvatar(route)
+      }
+    } catch (error) {
+      console.error('Failed to cache tab avatar:', error)
     }
   }
 }

--- a/src/renderer/tabs/TabContext.js
+++ b/src/renderer/tabs/TabContext.js
@@ -2,6 +2,7 @@ import { inject, onBeforeUnmount } from 'vue'
 
 import store from '../store/index'
 import { getTabNavigationService } from './TabNavigationService'
+import { removeLegacyTabAvatar } from '../helpers/channelThumbnailStorage'
 
 export const tabIdKey = Symbol('logical-tab-id')
 export const tabPresentedKey = Symbol('logical-tab-presented')
@@ -32,6 +33,27 @@ export function useTabTitle() {
       getTabNavigationService().setTitle(tabId, title, options)
     } else {
       store.commit('setAppTitle', title)
+    }
+  }
+}
+
+export function useTabAvatar() {
+  const { tabId } = useTabContext()
+  let isMounted = true
+
+  onBeforeUnmount(() => {
+    isMounted = false
+  })
+
+  return (avatarUrl) => {
+    if (isMounted && process.env.IS_ELECTRON && tabId && store.getters.getShowTabIcons) {
+      window.ftElectron.tabs.updateAvatar(avatarUrl, tabId).then(cached => {
+        if (cached) {
+          removeLegacyTabAvatar(store.getters.getTabById(tabId)?.route)
+        }
+      }).catch(error => {
+        console.error('Failed to cache tab avatar:', error)
+      })
     }
   }
 }

--- a/src/renderer/tabs/tabPreview.js
+++ b/src/renderer/tabs/tabPreview.js
@@ -14,6 +14,8 @@ export function getTabPreviewFallbackUrl(tab) {
 }
 
 export function getTabAvatarUrl(tab) {
+  if (tab?.avatarUrl) return tab.avatarUrl
+
   const path = tab?.route?.path ?? ''
   const channelId = path.match(/^\/channel\/([^/]+)/)?.[1]
   if (channelId) return store.getters.getChannelThumbnail(channelId)

--- a/src/renderer/views/Channel/Channel.vue
+++ b/src/renderer/views/Channel/Channel.vue
@@ -350,7 +350,7 @@ import {
   parseLocalPlaylistVideos,
   parseChannelHomeTab
 } from '../../helpers/api/local'
-import { useTabTitle } from '../../tabs/TabContext'
+import { useTabAvatar, useTabTitle } from '../../tabs/TabContext'
 import { setChannelShortsNavigationContext } from '../../helpers/player/shorts'
 import {
   CHANNEL_SEARCH_FILTERS,
@@ -363,6 +363,7 @@ const { t } = useI18n()
 const route = useRoute()
 const router = useRouter()
 const setTabTitle = useTabTitle()
+const setTabAvatar = useTabAvatar()
 
 let skipRouteChangeWatcherOnce = false
 let autoRefreshOnSortByChangeEnabled = false
@@ -411,6 +412,7 @@ watch([channelName, isLoading], ([name, loading]) => {
 watch(thumbnailUrl, (thumbnail) => {
   if (id.value && thumbnail) {
     store.commit('setChannelThumbnail', { channelId: id.value, thumbnail })
+    setTabAvatar(thumbnail)
   }
 })
 

--- a/src/renderer/views/Watch/Watch.js
+++ b/src/renderer/views/Watch/Watch.js
@@ -75,7 +75,7 @@ import {
 } from '../../helpers/player/shorts'
 import { MANIFEST_TYPE_SABR } from '../../helpers/player/SabrManifestParser'
 import { useI18n } from 'vue-i18n'
-import { useTabContext, useTabTitle } from '../../tabs/TabContext'
+import { useTabAvatar, useTabContext, useTabTitle } from '../../tabs/TabContext'
 import { useTabToast } from '../../composables/useTabToast'
 
 /**
@@ -144,6 +144,7 @@ export default defineComponent({
     const tabRouter = useRouter()
     const { tabId, isTabPresented, lifecycle: tabLifecycle } = useTabContext()
     const setTabTitle = useTabTitle()
+    const setTabAvatar = useTabAvatar()
     const showTabToast = useTabToast()
 
     return {
@@ -155,6 +156,7 @@ export default defineComponent({
       tabRoute,
       tabRouter,
       setTabTitle,
+      setTabAvatar,
       showTabToast
     }
   },
@@ -1655,6 +1657,7 @@ export default defineComponent({
           videoId: this.videoId,
           avatar: this.channelThumbnail
         })
+        this.setTabAvatar(this.channelThumbnail)
 
         this.videoCategory = result.basic_info.category ?? ''
         this.videoGenreIsMusic = this.videoCategory === 'Music'
@@ -2177,6 +2180,7 @@ export default defineComponent({
             videoId: this.videoId,
             avatar: this.channelThumbnail
           })
+          this.setTabAvatar(this.channelThumbnail)
           this.updateSubscriptionDetails({
             channelThumbnailUrl: channelThumb?.url,
             channelName: result.author,

--- a/tests/unit/channel-thumbnail-storage.test.mjs
+++ b/tests/unit/channel-thumbnail-storage.test.mjs
@@ -1,0 +1,55 @@
+import assert from 'node:assert/strict'
+import test from 'node:test'
+
+import {
+  loadLegacyChannelThumbnailCache,
+  loadLegacyVideoAvatarCache,
+  removeLegacyTabAvatar
+} from '../../src/renderer/helpers/channelThumbnailStorage.js'
+
+function useLocalStorage(entries = {}) {
+  const values = new Map(Object.entries(entries))
+  globalThis.localStorage = {
+    getItem: key => values.get(key) ?? null,
+    setItem: (key, value) => values.set(key, value),
+    removeItem: key => values.delete(key)
+  }
+  return values
+}
+
+test('loads valid legacy avatar caches and ignores malformed data', () => {
+  useLocalStorage({
+    channelThumbnailCache: JSON.stringify({ UC123: 'https://example.com/channel.jpg' }),
+    videoAvatarCache: '{broken'
+  })
+
+  assert.deepEqual(loadLegacyChannelThumbnailCache(), {
+    UC123: 'https://example.com/channel.jpg'
+  })
+  assert.deepEqual(loadLegacyVideoAvatarCache(), {})
+})
+
+test('removes only the migrated channel avatar', () => {
+  const values = useLocalStorage({
+    channelThumbnailCache: JSON.stringify({
+      UC123: 'https://example.com/first.jpg',
+      UC456: 'https://example.com/second.jpg'
+    })
+  })
+
+  removeLegacyTabAvatar({ path: '/channel/UC123' })
+
+  assert.deepEqual(JSON.parse(values.get('channelThumbnailCache')), {
+    UC456: 'https://example.com/second.jpg'
+  })
+})
+
+test('removes the legacy storage key after its last video avatar migrates', () => {
+  const values = useLocalStorage({
+    videoAvatarCache: JSON.stringify({ abc123: 'https://example.com/video.jpg' })
+  })
+
+  removeLegacyTabAvatar({ path: '/watch/abc123' })
+
+  assert.equal(values.has('videoAvatarCache'), false)
+})

--- a/tests/unit/tab-avatar.test.mjs
+++ b/tests/unit/tab-avatar.test.mjs
@@ -16,13 +16,18 @@ test('rejects non-web avatar URLs before fetching', async () => {
 })
 
 test('returns bytes from a valid image response', async () => {
-  globalThis.fetch = async () => new Response(Uint8Array.from([1, 2, 3]), {
-    headers: { 'content-type': 'image/png' }
-  })
+  let fetchOptions
+  globalThis.fetch = async (_url, options) => {
+    fetchOptions = options
+    return new Response(Uint8Array.from([1, 2, 3]), {
+      headers: { 'content-type': 'image/png' }
+    })
+  }
 
   const bytes = await fetchTabAvatarBytes('https://example.com/avatar.png')
 
   assert.deepEqual(new Uint8Array(bytes), Uint8Array.from([1, 2, 3]))
+  assert.ok(fetchOptions.signal instanceof AbortSignal)
 })
 
 test('rejects non-images and oversized responses', async () => {
@@ -38,4 +43,24 @@ test('rejects non-images and oversized responses', async () => {
     }
   })
   assert.equal(await fetchTabAvatarBytes('https://example.com/avatar.jpg'), null)
+})
+
+test('cancels an avatar response as soon as its streamed bytes exceed the limit', async () => {
+  let canceled = false
+  const chunk = new Uint8Array(1024 * 1024)
+  globalThis.fetch = async () => new Response(new ReadableStream({
+    start(controller) {
+      controller.enqueue(chunk)
+      controller.enqueue(chunk)
+      controller.enqueue(Uint8Array.of(1))
+    },
+    cancel() {
+      canceled = true
+    }
+  }), {
+    headers: { 'content-type': 'image/jpeg' }
+  })
+
+  assert.equal(await fetchTabAvatarBytes('https://example.com/avatar.jpg'), null)
+  assert.equal(canceled, true)
 })

--- a/tests/unit/tab-avatar.test.mjs
+++ b/tests/unit/tab-avatar.test.mjs
@@ -1,0 +1,41 @@
+import assert from 'node:assert/strict'
+import test from 'node:test'
+
+import { fetchTabAvatarBytes } from '../../src/renderer/helpers/tabAvatar.js'
+
+test('rejects non-web avatar URLs before fetching', async () => {
+  let fetched = false
+  globalThis.fetch = async () => {
+    fetched = true
+    throw new Error('unexpected fetch')
+  }
+
+  assert.equal(await fetchTabAvatarBytes('file:///etc/passwd'), null)
+  assert.equal(await fetchTabAvatarBytes('not a URL'), null)
+  assert.equal(fetched, false)
+})
+
+test('returns bytes from a valid image response', async () => {
+  globalThis.fetch = async () => new Response(Uint8Array.from([1, 2, 3]), {
+    headers: { 'content-type': 'image/png' }
+  })
+
+  const bytes = await fetchTabAvatarBytes('https://example.com/avatar.png')
+
+  assert.deepEqual(new Uint8Array(bytes), Uint8Array.from([1, 2, 3]))
+})
+
+test('rejects non-images and oversized responses', async () => {
+  globalThis.fetch = async () => new Response('not an image', {
+    headers: { 'content-type': 'text/plain' }
+  })
+  assert.equal(await fetchTabAvatarBytes('https://example.com/avatar'), null)
+
+  globalThis.fetch = async () => new Response(null, {
+    headers: {
+      'content-length': String(2 * 1024 * 1024 + 1),
+      'content-type': 'image/jpeg'
+    }
+  })
+  assert.equal(await fetchTabAvatarBytes('https://example.com/avatar.jpg'), null)
+})


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Make sure to follow the contributing guidelines. -->
<!-- Important note, we may remove your pull request if you do not use this provided PR template correctly. -->

## Pull Request Type
<!-- Please select what type of pull request this is: [x] -->
- [x] Bugfix
- [ ] Feature Implementation
- [ ] Documentation
- [ ] Other

## Related issue
<!-- Please link the issue your pull request is referring to. -->
<!-- If this pull request fully resolves the relevant issue, put "closes" before the issue number. -->
<!-- Example: "closes #123456". -->

N/A

## Description
<!-- Please write a clear and concise description of what the pull request does. -->

Persist channel and video tab avatars as resized image files in the existing `tab-previews` cache and store only their generated filenames in tab-session records.

Previously, avatar URLs were kept separately in renderer `localStorage`. An interrupted shutdown could restore the main-process tab session without a matching renderer cache entry, leaving unloaded restored tabs without their channel icons.

The new cache writes are atomic, stale and orphaned avatar files are cleaned up with tab previews, and disabling tab icons cancels pending avatar work and removes cached avatar files. Existing installations migrate legacy URL entries one at a time after each image is cached successfully.

## Release note category
<!-- Select exactly one category. Every pull request must select one. -->
<!-- release-note-category:start -->
- [ ] Not noteworthy
- [ ] Highlights
- [ ] More improvements
- [x] Fixed bugs
<!-- release-note-category:end -->

## Release note
<!-- Required unless "Not noteworthy" is selected. -->
<!-- Write one concise, user-facing entry without a leading bullet. -->
<!-- release-note:start -->
Fixed channel icons disappearing from restored tabs after restarting the app.
<!-- release-note:end -->

## Release note images
<!-- Human-only: Agents must leave this section empty. -->
<!-- Optional. Paste one or more Markdown images or HTML image tags here. -->
<!-- The release notes will use an HTML image tag and limit images taller than 300 pixels. -->
<!-- release-note-image:start -->

<!-- release-note-image:end -->

## Testing
<!-- How can reviewers verify that the PR produces correct results? -->
<!-- Please provide instructions so that others can ensure that your pull request would produce correct results. For examples see, https://github.com/FreeTubeApp/FreeTube/pull/5743, https://github.com/FreeTubeApp/FreeTube/pull/7349, https://github.com/FreeTubeApp/FreeTube/pull/5125, https://github.com/FreeTubeApp/FreeTube/pull/7338 -->
<!-- Agent instructions: Always write human-facing steps that explain how to verify the change while running this branch in dev mode. Include expected results and, when applicable, helpful console snippets. -->

1. Run the app in dev mode with tab icons enabled.
2. Open several channel and video tabs and wait for their channel icons to appear.
3. Restart or forcibly terminate and reopen the app.
4. Confirm restored tabs show their channel icons before unloaded tabs are activated.
5. Disable **Show Tab Icons** in Theme settings and confirm icons disappear and no avatar files remain referenced by the saved tab session.
6. Re-enable the setting and confirm loaded or legacy-cached icons are cached again.

Automated verification completed:
- `pnpm test:unit` (210 passed)
- `pnpm eslint-lint`
- `pnpm test:e2e:pack`
- 43 offline tab, session restore, and tab preview Playwright tests under Xvfb

## Additional context
<!-- Add any other context about the pull request here. -->

Avatar downloads are limited to HTTP(S) images up to 2 MiB and are resized to at most 64×64 before being stored as JPEG.