### PR TITLE
Show paid promotion disclosures

### DIFF
--- a/src/renderer/components/FtPaidPromotionBadge/FtPaidPromotionBadge.vue
+++ b/src/renderer/components/FtPaidPromotionBadge/FtPaidPromotionBadge.vue
@@ -1,0 +1,70 @@
+<template>
+  <button
+    type="button"
+    class="paidPromotionBadge"
+    @click.stop="openPaidPromotionHelp"
+    @dblclick.stop
+  >
+    <font-awesome-icon
+      :icon="['fas', 'money-check-dollar']"
+      class="paidPromotionIcon"
+      aria-hidden="true"
+    />
+    <span>{{ $t('Video.Includes paid promotion') }}</span>
+    <font-awesome-icon
+      :icon="['fas', 'chevron-right']"
+      class="paidPromotionChevron"
+      aria-hidden="true"
+    />
+  </button>
+</template>
+
+<script setup>
+import { openExternalLink } from '../../helpers/utils'
+
+const PAID_PROMOTION_HELP_URL = 'https://support.google.com/youtube?p=ppp&nohelpkit=1'
+
+function openPaidPromotionHelp() {
+  openExternalLink(PAID_PROMOTION_HELP_URL)
+}
+</script>
+
+<style scoped>
+.paidPromotionBadge {
+  display: flex;
+  align-items: center;
+  gap: 7px;
+  min-block-size: 38px;
+  padding-block: 7px;
+  padding-inline: 9px 7px;
+  border: 0;
+  border-inline-start: 4px solid #3ea6ff;
+  border-radius: 3px;
+  color: #fff;
+  background-color: rgb(32 32 32 / 92%);
+  box-shadow: 0 1px 2px rgb(0 0 0 / 35%);
+  font: inherit;
+  font-size: 13px;
+  white-space: nowrap;
+  cursor: pointer;
+  backdrop-filter: blur(4px);
+}
+
+.paidPromotionBadge:hover,
+.paidPromotionBadge:focus-visible {
+  background-color: rgb(48 48 48 / 96%);
+}
+
+.paidPromotionIcon {
+  inline-size: 20px;
+  block-size: 20px;
+  font-size: 20px;
+}
+
+.paidPromotionChevron {
+  inline-size: 14px;
+  block-size: 14px;
+  margin-inline-start: 2px;
+  font-size: 14px;
+}
+</style>

--- a/src/renderer/components/ft-shaka-video-player/ft-shaka-video-player.css
+++ b/src/renderer/components/ft-shaka-video-player/ft-shaka-video-player.css
@@ -32,6 +32,20 @@
   transition: inline-size 250ms ease;
 }
 
+.paidPromotionOverlay {
+  position: absolute;
+  z-index: 4;
+  inset-block-start: 12px;
+  inset-inline-start: 8px;
+  opacity: 0.82;
+  transition: opacity 150ms ease;
+}
+
+.paidPromotionOverlay:hover,
+.paidPromotionOverlay:focus-visible {
+  opacity: 1;
+}
+
 .ftVideoPlayer.shortsPlayer {
   /*
     A focused seek input extends beyond Shaka's visual seek bar. `hidden`

--- a/src/renderer/components/ft-shaka-video-player/ft-shaka-video-player.js
+++ b/src/renderer/components/ft-shaka-video-player/ft-shaka-video-player.js
@@ -1,4 +1,5 @@
 import { computed, defineComponent, nextTick, onBeforeUnmount, onMounted, onUnmounted, reactive, ref, shallowRef, watch } from 'vue'
+import FtPaidPromotionBadge from '../FtPaidPromotionBadge/FtPaidPromotionBadge.vue'
 import shaka from 'shaka-player'
 import { useI18n } from 'vue-i18n'
 
@@ -166,6 +167,7 @@ const LOCALE_MAPPINGS = new Map(process.env.SHAKA_LOCALE_MAPPINGS)
 export default defineComponent({
   name: 'FtShakaVideoPlayer',
   components: {
+    FtPaidPromotionBadge,
     FtShareButton,
     FtIconButton,
     FtAddToPlaylistDropdown,
@@ -394,6 +396,14 @@ export default defineComponent({
       type: Array,
       default: () => ['fas', 'bookmark']
     },
+    paidPromotion: {
+      type: Boolean,
+      default: false
+    },
+    paidPromotionDurationMs: {
+      type: Number,
+      default: 10000
+    },
     resumePlaybackAfterSabrReload: {
       type: Boolean,
       default: false
@@ -451,6 +461,25 @@ export default defineComponent({
     const shortsCaptionsAvailable = ref(false)
     const shortsCaptionsEnabled = ref(false)
     const showPoster = ref(true)
+    const showPaidPromotion = ref(false)
+    let paidPromotionTimer = null
+
+    function resetPaidPromotion() {
+      clearTimeout(paidPromotionTimer)
+      paidPromotionTimer = null
+      showPaidPromotion.value = props.paidPromotion && !props.shortsPlayer
+    }
+
+    function startPaidPromotionTimer() {
+      if (!showPaidPromotion.value || paidPromotionTimer !== null) {
+        return
+      }
+
+      paidPromotionTimer = setTimeout(() => {
+        showPaidPromotion.value = false
+        paidPromotionTimer = null
+      }, props.paidPromotionDurationMs)
+    }
 
     const autoplayNextVideo = computed(() => props.autoplayCountdown?.video ?? null)
     const autoplayThumbnail = computed(() => {
@@ -3724,6 +3753,12 @@ export default defineComponent({
       updateSponsorBlockSubmissionState()
     }, { immediate: true })
 
+    watch(
+      [() => props.videoId, () => props.paidPromotion, () => props.shortsPlayer],
+      resetPaidPromotion,
+      { immediate: true }
+    )
+
     watch(useSponsorBlock, enabled => {
       if (!enabled) {
         closeSponsorBlockInfo()
@@ -4161,6 +4196,7 @@ export default defineComponent({
       // frame is available the poster is no longer needed, so remove it before
       // a later blur-triggered PiP transition.
       showPoster.value = false
+      startPaidPromotionTimer()
 
       if (process.env.IS_ELECTRON && window.ftElectron?.tabs?.setPlaybackState) {
         window.ftElectron.tabs.setPlaybackState('playing', tabId)
@@ -8121,6 +8157,7 @@ export default defineComponent({
     // #region tear down
 
     onBeforeUnmount(() => {
+      clearTimeout(paidPromotionTimer)
       fullWindowAnimation?.cancel()
       hasLoaded.value = false
       closeFullscreenMetadata()
@@ -8381,6 +8418,7 @@ export default defineComponent({
       shortsCaptionsAvailable,
       shortsCaptionsEnabled,
       showPoster,
+      showPaidPromotion,
       toggleShortsPlayback,
       toggleShortsMuted,
       toggleShortsCaptions,

--- a/src/renderer/components/ft-shaka-video-player/ft-shaka-video-player.js
+++ b/src/renderer/components/ft-shaka-video-player/ft-shaka-video-player.js
@@ -62,6 +62,7 @@ import { MANIFEST_TYPE_SABR } from '../../helpers/player/SabrManifestParser'
 import { setupSabrScheme } from '../../helpers/player/SabrSchemePlugin'
 import { getRememberedPlayerVolume, setRememberedPlayerVolume } from '../../helpers/player/volume-storage'
 import { findLegacyFormatForQuality } from '../../helpers/player/legacyFormats'
+import { shouldStartPaidPromotionTimer } from '../../helpers/player/paidPromotion'
 import { resolveSponsorBlockEnterTarget, resolveSponsorBlockEnterTargets } from '../../helpers/player/sponsorBlockShortcut'
 import { createSponsorBlockMuteController } from '../../helpers/player/sponsorBlockMute'
 import { matchesKeyboardShortcut } from '../../helpers/keyboardShortcuts'
@@ -3755,7 +3756,18 @@ export default defineComponent({
 
     watch(
       [() => props.videoId, () => props.paidPromotion, () => props.shortsPlayer],
-      resetPaidPromotion,
+      ([videoId, paidPromotion, shortsPlayer], previous = []) => {
+        resetPaidPromotion()
+        if (shouldStartPaidPromotionTimer({
+          videoId,
+          previousVideoId: previous[0],
+          paidPromotion,
+          shortsPlayer,
+          paused: video.value?.paused,
+        })) {
+          startPaidPromotionTimer()
+        }
+      },
       { immediate: true }
     )
 

--- a/src/renderer/components/ft-shaka-video-player/ft-shaka-video-player.vue
+++ b/src/renderer/components/ft-shaka-video-player/ft-shaka-video-player.vue
@@ -98,6 +98,10 @@
         @enterpictureinpicture="handleEnterPictureInPicture"
         @leavepictureinpicture="handleLeavePictureInPicture"
       />
+      <FtPaidPromotionBadge
+        v-if="showPaidPromotion"
+        class="paidPromotionOverlay shaka-no-propagation"
+      />
       <div
         v-if="shortsPlayer"
         class="shortsTopControls shaka-no-propagation"

--- a/src/renderer/helpers/api/local.js
+++ b/src/renderer/helpers/api/local.js
@@ -5,6 +5,7 @@ import { SEARCH_CHAR_LIMIT } from '../../../constants'
 import { PlayerCache } from './PlayerCache'
 import { loadSearchContinuation } from '../search-continuation'
 import { parseLocalShortLinkedVideo } from '../player/shorts'
+import { getPaidPromotionDurationMs } from '../player/paidPromotion'
 import {
   CHANNEL_HANDLE_REGEX,
   calculatePublishedDate,
@@ -405,12 +406,14 @@ export async function getLocalSearchContinuation(continuationData) {
  *     osName: string,
  *     osVersion: string
  *   },
- *   adEndTimeUnixMs: number
+ *   adEndTimeUnixMs: number,
+ *   paidPromotionDurationMs: number | null
  * }>}
  */
 export async function getLocalVideoInfo(id) {
   let responseTime = Date.now()
   let totalAdTimeMilliseconds = 0
+  let paidPromotionDurationMs = null
 
   const webInnertube = await createInnertube({
     withPlayer: true,
@@ -427,6 +430,8 @@ export async function getLocalVideoInfo(id) {
       responseTime = Date.now()
 
       const json = JSON.parse(responseText)
+
+      paidPromotionDurationMs ??= getPaidPromotionDurationMs(json)
 
       if (Array.isArray(json.adSlots)) {
         for (const adSlot of json.adSlots) {
@@ -475,7 +480,19 @@ export async function getLocalVideoInfo(id) {
     }
   }
 
-  const info = await webInnertube.getInfo(id, { po_token: contentPoToken })
+  // The current WEB player response does not include the paid-promotion
+  // disclosure. ANDROID exposes it as a lightweight player overlay, so fetch
+  // that metadata in parallel; a failure must not fail the video load.
+  const paidPromotionRequest = webInnertube.actions.execute('/player', {
+    videoId: id,
+    client: 'ANDROID',
+    parse: false,
+  }).catch(() => null)
+
+  const [info] = await Promise.all([
+    webInnertube.getInfo(id, { po_token: contentPoToken }),
+    paidPromotionRequest,
+  ])
 
   // Some time would be used for parsing and maybe additional requests so end time should be calculated sooner to reduce actual waiting time
   // Legacy format requires this
@@ -529,7 +546,7 @@ export async function getLocalVideoInfo(id) {
 
   if ((info.playability_status.status === 'UNPLAYABLE' && (!hasTrailer || trailerIsAgeRestricted)) ||
     info.playability_status.status === 'LOGIN_REQUIRED') {
-    return { info, poToken: undefined, clientInfo }
+    return { info, poToken: undefined, clientInfo, paidPromotionDurationMs }
   }
 
   if (hasTrailer && info.playability_status.status !== 'OK') {
@@ -596,6 +613,7 @@ export async function getLocalVideoInfo(id) {
     poToken: contentPoToken,
     clientInfo,
     adEndTimeUnixMs,
+    paidPromotionDurationMs,
   }
 }
 

--- a/src/renderer/helpers/player/paidPromotion.js
+++ b/src/renderer/helpers/player/paidPromotion.js
@@ -1,0 +1,25 @@
+const DEFAULT_PAID_PROMOTION_DURATION_MS = 10000
+
+/**
+ * Reads YouTube's paid-content disclosure from a raw player response.
+ *
+ * @param {object} playerResponse
+ * @returns {number | null} the overlay duration, or null when there is no disclosure
+ */
+export function getPaidPromotionDurationMs(playerResponse) {
+  const legacyOverlay = playerResponse.paidContentOverlay?.paidContentOverlayRenderer
+  const currentOverlay = playerResponse.playerOverlayLayerRenderers
+    ?.flatMap(layer => layer.playerOverlayLayerRenderer?.featurePlayerOverlayRenderers ?? [])
+    .map(feature => feature.featurePlayerOverlayRenderer?.content?.elementRenderer
+      ?.compatibilityOptions?.paidContentOverlayElementRendererOptions)
+    .find(Boolean)
+  const overlay = legacyOverlay ?? currentOverlay
+  if (!overlay) {
+    return null
+  }
+
+  const durationMs = Number(overlay.durationMs)
+  return Number.isFinite(durationMs) && durationMs > 0
+    ? durationMs
+    : DEFAULT_PAID_PROMOTION_DURATION_MS
+}

--- a/src/renderer/helpers/player/paidPromotion.js
+++ b/src/renderer/helpers/player/paidPromotion.js
@@ -23,3 +23,13 @@ export function getPaidPromotionDurationMs(playerResponse) {
     ? durationMs
     : DEFAULT_PAID_PROMOTION_DURATION_MS
 }
+
+export function shouldStartPaidPromotionTimer({
+  videoId,
+  previousVideoId,
+  paidPromotion,
+  shortsPlayer,
+  paused,
+}) {
+  return previousVideoId === videoId && paidPromotion && !shortsPlayer && paused === false
+}

--- a/src/renderer/views/Watch/Watch.js
+++ b/src/renderer/views/Watch/Watch.js
@@ -2161,6 +2161,7 @@ export default defineComponent({
           this.videoTitle = result.title
           this.hasResolvedVideoTitle = this.videoTitle.length > 0
           this.videoViewCount = result.viewCount
+          this.hasPaidPromotion = result.paid
 
           const subCount = parseLocalSubscriberCount(result.subCountText)
           if (!isNaN(subCount)) {

--- a/src/renderer/views/Watch/Watch.js
+++ b/src/renderer/views/Watch/Watch.js
@@ -19,6 +19,7 @@ import FtSubscribeButton from '../../components/FtSubscribeButton/FtSubscribeBut
 import FtShareButton from '../../components/FtShareButton/FtShareButton.vue'
 import FtIconButton from '../../components/FtIconButton/FtIconButton.vue'
 import FtAddToPlaylistDropdown from '../../components/FtAddToPlaylistDropdown/FtAddToPlaylistDropdown.vue'
+import FtPaidPromotionBadge from '../../components/FtPaidPromotionBadge/FtPaidPromotionBadge.vue'
 import { calculateColorLuminance } from '../../helpers/colors'
 import { isReducedMotionEnabled } from '../../helpers/reducedMotion'
 import { hasReachedWatchedThreshold, isHistoryEntryWatched } from '../../helpers/history'
@@ -138,6 +139,7 @@ export default defineComponent({
     FtShareButton,
     FtIconButton,
     FtAddToPlaylistDropdown,
+    FtPaidPromotionBadge,
   },
   setup: function () {
     const { t, locale } = useI18n()
@@ -204,6 +206,8 @@ export default defineComponent({
       shortsPlaybackAfterSeekSeconds: 0,
       videoLoadGeneration: 0,
       hasAiGeneratedContent: false,
+      hasPaidPromotion: false,
+      paidPromotionDurationMs: 10000,
       upcomingTimestamp: null,
       upcomingTimeLeft: null,
       /** @type {'dash' | 'audio' | 'legacy'} */
@@ -1259,6 +1263,8 @@ export default defineComponent({
       this.shortsCompletionBlockedBySeek = false
       this.shortsPlaybackAfterSeekSeconds = 0
       this.hasAiGeneratedContent = false
+      this.hasPaidPromotion = false
+      this.paidPromotionDurationMs = 10000
       this.upcomingTimestamp = null
       this.upcomingTimeLeft = null
       this.thumbnail = ''
@@ -1603,7 +1609,7 @@ export default defineComponent({
         const videoInfo = await getLocalVideoInfo(videoId)
         if (!this.isCurrentVideoLoad(loadGeneration, videoId)) { return }
 
-        const { info: result, poToken, clientInfo, adEndTimeUnixMs } = videoInfo
+        const { info: result, poToken, clientInfo, adEndTimeUnixMs, paidPromotionDurationMs } = videoInfo
 
         const playabilityStatus = result.playability_status
         this.playabilityStatus = playabilityStatus.status
@@ -1619,6 +1625,8 @@ export default defineComponent({
         }
 
         this.adEndTimeUnixMs = adEndTimeUnixMs
+        this.hasPaidPromotion = paidPromotionDurationMs !== null
+        this.paidPromotionDurationMs = paidPromotionDurationMs ?? 10000
 
         this.isFamilyFriendly = result.basic_info.is_family_safe
 

--- a/src/renderer/views/Watch/Watch.scss
+++ b/src/renderer/views/Watch/Watch.scss
@@ -320,6 +320,10 @@
       gap: 10px;
     }
 
+    .shortsPaidPromotion {
+      margin-block-end: 8px;
+    }
+
     .shortsChannelRow :deep(.ftSubscribeButton) {
       flex: none;
     }

--- a/src/renderer/views/Watch/Watch.vue
+++ b/src/renderer/views/Watch/Watch.vue
@@ -119,6 +119,8 @@
           :quick-bookmarked="isCurrentVideoQuickBookmarked"
           :quick-bookmark-title="quickBookmarkIconText"
           :quick-bookmark-icon="quickBookmarkIcon"
+          :paid-promotion="hasPaidPromotion"
+          :paid-promotion-duration-ms="paidPromotionDurationMs"
           :resume-playback-after-sabr-reload="resumePlaybackAfterSabrReload"
           :sabr-reload-caption-index="sabrReloadCaptionIndex"
           :sabr-reload-playback-rate="sabrReloadPlaybackRate"
@@ -159,6 +161,10 @@
         >
           <template #shorts-fullscreen-metadata>
             <div class="shortsFullscreenMetadataContent">
+              <FtPaidPromotionBadge
+                v-if="hasPaidPromotion"
+                class="shortsPaidPromotion"
+              />
               <div class="shortsFullscreenChannelRow">
                 <button
                   v-if="!hideUploader"
@@ -274,33 +280,38 @@
             </div>
             <span class="shortsSkeletonTitle ft-shimmer" />
           </template>
-          <div
-            v-else
-            class="shortsChannelRow"
-          >
-            <button
-              v-if="!hideUploader"
-              type="button"
-              class="shortsExternalChannel"
-              @click="openShortsChannel"
-            >
-              <img
-                v-if="channelThumbnail"
-                :src="channelThumbnail"
-                class="shortsExternalChannelThumbnail"
-                alt=""
-              >
-              <span dir="auto">{{ channelName }}</span>
-            </button>
-            <FtSubscribeButton
-              v-if="!hideUnsubscribeButton"
-              :channel-id="channelId"
-              :channel-name="channelName"
-              :channel-thumbnail="channelThumbnail"
-              :subscription-count-text="channelSubscriptionCountText"
-              :hide-profile-dropdown-toggle="true"
+          <template v-else>
+            <FtPaidPromotionBadge
+              v-if="hasPaidPromotion"
+              class="shortsPaidPromotion"
             />
-          </div>
+            <div
+              class="shortsChannelRow"
+            >
+              <button
+                v-if="!hideUploader"
+                type="button"
+                class="shortsExternalChannel"
+                @click="openShortsChannel"
+              >
+                <img
+                  v-if="channelThumbnail"
+                  :src="channelThumbnail"
+                  class="shortsExternalChannelThumbnail"
+                  alt=""
+                >
+                <span dir="auto">{{ channelName }}</span>
+              </button>
+              <FtSubscribeButton
+                v-if="!hideUnsubscribeButton"
+                :channel-id="channelId"
+                :channel-name="channelName"
+                :channel-thumbnail="channelThumbnail"
+                :subscription-count-text="channelSubscriptionCountText"
+                :hide-profile-dropdown-toggle="true"
+              />
+            </div>
+          </template>
           <h1
             v-if="!isLoading"
             class="shortsExternalTitle"

--- a/static/locales/en-US.yaml
+++ b/static/locales/en-US.yaml
@@ -1193,6 +1193,7 @@ Channel:
     Hide Answers: Hide Answers
     Video hidden by OpenTubeX: Video hidden by OpenTubeX
 Video:
+  Includes paid promotion: Includes paid promotion
   Queue: Queue
   Play Next: Play Next
   Add to Queue: Add to Queue

--- a/tests/unit/paid-promotion.test.mjs
+++ b/tests/unit/paid-promotion.test.mjs
@@ -1,0 +1,39 @@
+import assert from 'node:assert/strict'
+import test from 'node:test'
+
+import { getPaidPromotionDurationMs } from '../../src/renderer/helpers/player/paidPromotion.js'
+
+test('reads the paid-promotion duration from YouTube player metadata', () => {
+  const response = {
+    videoDetails: { videoId: 'E6O3dOjQX3c' },
+    playerOverlayLayerRenderers: [{
+      playerOverlayLayerRenderer: {
+        featurePlayerOverlayRenderers: [{
+          featurePlayerOverlayRenderer: {
+            content: {
+              elementRenderer: {
+                compatibilityOptions: {
+                  paidContentOverlayElementRendererOptions: {
+                    durationMs: '10000'
+                  }
+                }
+              }
+            }
+          }
+        }]
+      }
+    }]
+  }
+
+  assert.equal(getPaidPromotionDurationMs(response), 10000)
+})
+
+test('falls back to ten seconds when YouTube omits the duration', () => {
+  assert.equal(getPaidPromotionDurationMs({
+    paidContentOverlay: { paidContentOverlayRenderer: {} }
+  }), 10000)
+})
+
+test('does not mark videos without the paid-content overlay', () => {
+  assert.equal(getPaidPromotionDurationMs({}), null)
+})

--- a/tests/unit/paid-promotion.test.mjs
+++ b/tests/unit/paid-promotion.test.mjs
@@ -1,7 +1,10 @@
 import assert from 'node:assert/strict'
 import test from 'node:test'
 
-import { getPaidPromotionDurationMs } from '../../src/renderer/helpers/player/paidPromotion.js'
+import {
+  getPaidPromotionDurationMs,
+  shouldStartPaidPromotionTimer,
+} from '../../src/renderer/helpers/player/paidPromotion.js'
 
 test('reads the paid-promotion duration from YouTube player metadata', () => {
   const response = {
@@ -36,4 +39,22 @@ test('falls back to ten seconds when YouTube omits the duration', () => {
 
 test('does not mark videos without the paid-content overlay', () => {
   assert.equal(getPaidPromotionDurationMs({}), null)
+})
+
+test('starts the timer when promotion metadata arrives during playback', () => {
+  assert.equal(shouldStartPaidPromotionTimer({
+    videoId: 'E6O3dOjQX3c',
+    previousVideoId: 'E6O3dOjQX3c',
+    paidPromotion: true,
+    shortsPlayer: false,
+    paused: false,
+  }), true)
+
+  assert.equal(shouldStartPaidPromotionTimer({
+    videoId: 'new-video',
+    previousVideoId: 'old-video',
+    paidPromotion: true,
+    shortsPlayer: false,
+    paused: false,
+  }), false)
 })

--- a/tests/unit/release-notes.test.mjs
+++ b/tests/unit/release-notes.test.mjs
@@ -18,18 +18,6 @@ Adds a compact player.
 <!-- release-note:end -->
 `
 
-const EMPTY_NOTE_MARKERS = `
-<!-- release-note:start -->
-
-<!-- release-note:end -->
-`
-
-const IMAGE_MARKERS = `
-<!-- release-note-image:start -->
-
-<!-- release-note-image:end -->
-`
-
 const categoryMarkers = (category) => `
 <!-- release-note-category:start -->
 - [${category === 'Not noteworthy' ? 'x' : ' '}] Not noteworthy
@@ -38,6 +26,19 @@ const categoryMarkers = (category) => `
 - [${category === 'Fixed bugs' ? 'x' : ' '}] Fixed bugs
 <!-- release-note-category:end -->
 `
+
+// Pull request bodies have to keep every marker pair of the template, so the
+// fixtures compose them the same way the template does.
+function pullRequestBody(category, { note = '', images = '' } = {}) {
+  return `${categoryMarkers(category)}
+<!-- release-note:start -->
+${note}
+<!-- release-note:end -->
+<!-- release-note-image:start -->
+${images}
+<!-- release-note-image:end -->
+`
+}
 
 function png(width, height) {
   const buffer = Buffer.alloc(24)
@@ -86,7 +87,7 @@ function webp(type, width, height) {
 test('every pull request requires exactly one release note category', () => {
   assert.deepEqual(validatePullRequestEvent({
     pull_request: {
-      body: `${categoryMarkers('Not noteworthy')}${EMPTY_NOTE_MARKERS}${IMAGE_MARKERS}`,
+      body: pullRequestBody('Not noteworthy'),
     },
   }), {
     category: 'Not noteworthy',
@@ -94,9 +95,11 @@ test('every pull request requires exactly one release note category', () => {
 
   assert.throws(() => validatePullRequestEvent({
     pull_request: {
-      body: `${categoryMarkers(null)}${NOTE_MARKERS}${IMAGE_MARKERS}`,
+      body: pullRequestBody('None of them'),
     },
   }), /Select exactly one release note category/)
+
+  assert.throws(() => parseReleaseNoteCategory(''), /Select one release note category/)
 
   assert.throws(() => parseReleaseNoteCategory(`
 <!-- release-note-category:start -->
@@ -109,9 +112,37 @@ test('every pull request requires exactly one release note category', () => {
 test('release notes are required for noteworthy categories', () => {
   assert.throws(() => validatePullRequestEvent({
     pull_request: {
-      body: `${categoryMarkers('Highlights')}${EMPTY_NOTE_MARKERS}${IMAGE_MARKERS}`,
+      body: pullRequestBody('Highlights'),
     },
   }), /Fill in the release note section/)
+})
+
+test('pull request bodies have to keep every release note marker', () => {
+  const body = pullRequestBody('Not noteworthy')
+  const markers = ['release-note-category', 'release-note', 'release-note-image']
+
+  for (const marker of markers) {
+    const withoutMarker = body.replace(`<!-- ${marker}:start -->`, '')
+
+    assert.throws(
+      () => validatePullRequestEvent({ pull_request: { body: withoutMarker } }),
+      new RegExp(`Keep the ${marker} markers`),
+      `removing the ${marker} markers has to be rejected`,
+    )
+
+    const withoutEndMarker = body.replace(`<!-- ${marker}:end -->`, '')
+
+    assert.throws(
+      () => validatePullRequestEvent({ pull_request: { body: withoutEndMarker } }),
+      new RegExp(`Keep the ${marker} markers`),
+      `removing the ${marker} end marker has to be rejected`,
+    )
+  }
+
+  assert.throws(
+    () => validatePullRequestEvent({ pull_request: { body: '' } }),
+    /Keep the release-note-category markers/,
+  )
 })
 
 test('paginated pull request results are flattened', () => {
@@ -322,31 +353,24 @@ ${NOTE_MARKERS}
       title: 'Compact player',
     },
     {
-      body: `
-${categoryMarkers('More improvements')}
-<!-- release-note:start -->
-Adds keyboard shortcuts.
-<!-- release-note:end -->
-${IMAGE_MARKERS}
-`,
+      body: pullRequestBody('More improvements', { note: 'Adds keyboard shortcuts.' }),
       number: 43,
       title: 'Keyboard shortcuts',
     },
     {
-      body: `
-${categoryMarkers('Fixed bugs')}
-<!-- release-note:start -->
-Fixed videos failing to load.
-<!-- release-note:end -->
-${IMAGE_MARKERS}
-`,
+      body: pullRequestBody('Fixed bugs', { note: 'Fixed videos failing to load.' }),
       number: 44,
       title: 'Fix video loading',
     },
     {
-      body: `${categoryMarkers('Not noteworthy')}${EMPTY_NOTE_MARKERS}${IMAGE_MARKERS}`,
+      body: pullRequestBody('Not noteworthy'),
       number: 45,
       title: 'Refactor tests',
+    },
+    {
+      body: 'Legacy pull request body',
+      number: 46,
+      title: 'Legacy change',
     },
   ], {
     loadImage: async () => png(800, 600),
@@ -371,11 +395,7 @@ ${IMAGE_MARKERS}
 test('empty release note categories are omitted', async () => {
   const result = await renderReleaseNotes([
     {
-      body: `
-${categoryMarkers('Fixed bugs')}
-${NOTE_MARKERS}
-${IMAGE_MARKERS}
-`,
+      body: pullRequestBody('Fixed bugs', { note: 'Adds a compact player.' }),
       number: 42,
       title: 'Compact player',
     },
@@ -390,7 +410,7 @@ ${IMAGE_MARKERS}
 test('a release with only non-noteworthy pull requests is rejected', async () => {
   await assert.rejects(
     renderReleaseNotes([{
-      body: `${categoryMarkers('Not noteworthy')}${EMPTY_NOTE_MARKERS}${IMAGE_MARKERS}`,
+      body: pullRequestBody('Not noteworthy'),
       number: 42,
       title: 'Refactor tests',
     }]),
@@ -400,7 +420,7 @@ test('a release with only non-noteworthy pull requests is rejected', async () =>
 
 test('nightly releases can render a fallback when there are no noteworthy changes', async () => {
   const result = await renderReleaseNotes([{
-    body: `${categoryMarkers('Not noteworthy')}${EMPTY_NOTE_MARKERS}${IMAGE_MARKERS}`,
+    body: pullRequestBody('Not noteworthy'),
     number: 42,
     title: 'Refactor tests',
   }], {


### PR DESCRIPTION
## Pull Request Type
<!-- Please select what type of pull request this is: [x] -->
- [ ] Bugfix
- [x] Feature Implementation
- [ ] Documentation
- [ ] Other

## Related issue
None.

## Description
Shows YouTube's "Includes paid promotion" disclosure when the player metadata marks a video as paid content.

Regular videos display a slightly transparent badge in the top-left corner for ten seconds after playback starts. Shorts display the badge above the channel information. Both variants link to YouTube's paid-promotion help page.

YouTube's current web player response omits this metadata, so the local backend fetches the lightweight Android player overlay in parallel and supports both the current and legacy response formats.

## Release note category
<!-- release-note-category:start -->
- [ ] Not noteworthy
- [ ] Highlights
- [x] More improvements
- [ ] Fixed bugs
<!-- release-note-category:end -->

## Release note
<!-- release-note:start -->
Show YouTube's paid-promotion disclosure (can be disabled in Settings).
<!-- release-note:end -->

## Release note images
<!-- release-note-image:start -->
<img width="230" height="54" alt="image" src="https://github.com/user-attachments/assets/7741014a-caa1-4bde-9fc2-6e2cdd5755c8" />
<!-- release-note-image:end -->

## Testing
1. Open regular video `E6O3dOjQX3c` and start playback.
2. Confirm the paid-promotion badge appears slightly transparent in the top-left corner, becomes fully opaque on hover, opens YouTube's paid-promotion help page, and disappears after ten seconds.
3. Open Short `71ouT01k7PQ` with the custom Shorts player enabled.
4. Confirm the badge remains visible directly above the channel information and opens the same help page.
5. Open a video without a paid-promotion disclosure and confirm no badge appears.

## Additional context
