### PR TITLE
fix(player): keep auto PiP from reopening after restore

### DIFF
--- a/e2e/tests/network/auto-picture-in-picture.spec.mjs
+++ b/e2e/tests/network/auto-picture-in-picture.spec.mjs
@@ -143,6 +143,21 @@ test.describe('automatic Picture-in-Picture', () => {
     await expect.poll(() => pictureInPictureActive(page)).toBe(false)
   })
 
+  test('does not reopen a PiP window that the user closed', async ({ app, page }) => {
+    await setMinimized(app, true)
+    await expect.poll(() => pictureInPictureActive(page)).toBe(true)
+
+    await page.evaluate(() => document.exitPictureInPicture())
+    await expect.poll(() => pictureInPictureActive(page)).toBe(false)
+
+    // Re-evaluating the triggers while the window is still minimized must not
+    // undo the manual dismissal.
+    await setFocused(page, false)
+    await setFocused(page, true)
+    await page.waitForTimeout(2000)
+    expect(await pictureInPictureActive(page)).toBe(false)
+  })
+
   test('does not close a PiP window that the user opened', async ({ app, page }) => {
     await page.locator(`${activeTab} video`).evaluate(element => element.requestPictureInPicture())
     await expect.poll(() => pictureInPictureActive(page)).toBe(true)

--- a/e2e/tests/network/auto-picture-in-picture.spec.mjs
+++ b/e2e/tests/network/auto-picture-in-picture.spec.mjs
@@ -41,16 +41,42 @@ function pictureInPictureActive(page) {
   return page.evaluate(() => document.pictureInPictureElement !== null)
 }
 
+/**
+ * Opens the watch page, or skips when the live API refuses to serve it (bot
+ * checks on CI runners and VPNs), which leaves the page shell without any
+ * video data instead of producing an error message.
+ */
 async function openVideo(page) {
   await page.locator(sel.searchInput).fill(VIDEO.url)
   await page.locator(sel.searchInput).press('Enter')
   await expect(page).toHaveURL(new RegExp(`#\\/watch\\/${VIDEO.id}`))
-  await expect(page.locator('.videoTitle')).toContainText(VIDEO.title, { timeout: 30_000 })
+
+  const title = page.locator(`${activeTab} .videoTitle`)
+  const errorMessage = page.locator(`${activeTab} .errorMessage`)
+  let state = 'waiting'
+  const settled = await expect
+    .poll(async () => {
+      const titleText = await title.textContent().catch(() => '') ?? ''
+      if (titleText.includes(VIDEO.title)) {
+        state = 'loaded'
+      } else if (await errorMessage.isVisible().catch(() => false)) {
+        state = (await errorMessage.textContent())?.trim() ?? 'unavailable'
+      }
+      return state === 'waiting' ? 'waiting' : 'done'
+    }, { timeout: 30_000, message: 'waiting for the watch page to load' })
+    .toBe('done')
+    .then(() => true, () => false)
+
+  test.skip(!settled || state !== 'loaded', `watch page unavailable from the live API: ${state}`)
   await expect(page.locator(`${activeTab} .ftVideoPlayer`)).toBeVisible({ timeout: 30_000 })
 }
 
 test.describe('automatic Picture-in-Picture', () => {
-  test.beforeEach(async ({ page }) => {
+  test.beforeEach(async ({ page, innertube }) => {
+    // Auto PiP only applies to a playing video, and recorded fixtures cannot
+    // hydrate a watch page or serve media streams.
+    test.skip(!innertube.playback, 'needs real media streams')
+
     await stubFocus(page)
     await openVideo(page)
     await waitForPlaybackOrSkip(test, page)

--- a/e2e/tests/network/auto-picture-in-picture.spec.mjs
+++ b/e2e/tests/network/auto-picture-in-picture.spec.mjs
@@ -1,0 +1,129 @@
+import { sel } from '../../helpers/app.mjs'
+import { test, expect } from '../../helpers/innertube.mjs'
+import { activeTab, waitForPlaybackOrSkip } from '../../helpers/player.mjs'
+
+// "Me at the zoo" - the oldest video on YouTube, short and stable.
+const VIDEO = { id: 'jNQXAC9IVRw', title: 'Me at the zoo', url: 'https://www.youtube.com/watch?v=jNQXAC9IVRw' }
+
+test.use({ seed: { settings: { autoPictureInPictureTriggers: ['tab', 'minimize', 'blur'] } } })
+
+/**
+ * The renderer derives the focus part of the auto PiP triggers from
+ * `document.hasFocus()`, which is not controllable from the test (and is
+ * unreliable without a window manager), so it is driven explicitly here.
+ */
+async function stubFocus(page) {
+  await page.evaluate(() => {
+    window.__e2eFocused = true
+    document.hasFocus = () => window.__e2eFocused
+  })
+}
+
+async function setFocused(page, focused) {
+  await page.evaluate((value) => {
+    window.__e2eFocused = value
+    window.dispatchEvent(new Event(value ? 'focus' : 'blur'))
+  }, focused)
+}
+
+/**
+ * Emits the native window event on the real BrowserWindow, so the main
+ * process forwards the minimized state the same way it does in production.
+ * Xvfb has no window manager, so `minimize()` itself would never be honoured.
+ */
+async function setMinimized(app, minimized) {
+  await app.electronApp.evaluate(({ BrowserWindow }, event) => {
+    BrowserWindow.getAllWindows()[0].emit(event)
+  }, minimized ? 'minimize' : 'restore')
+}
+
+function pictureInPictureActive(page) {
+  return page.evaluate(() => document.pictureInPictureElement !== null)
+}
+
+async function openVideo(page) {
+  await page.locator(sel.searchInput).fill(VIDEO.url)
+  await page.locator(sel.searchInput).press('Enter')
+  await expect(page).toHaveURL(new RegExp(`#\\/watch\\/${VIDEO.id}`))
+  await expect(page.locator('.videoTitle')).toContainText(VIDEO.title, { timeout: 30_000 })
+  await expect(page.locator(`${activeTab} .ftVideoPlayer`)).toBeVisible({ timeout: 30_000 })
+}
+
+test.describe('automatic Picture-in-Picture', () => {
+  test.beforeEach(async ({ page }) => {
+    await stubFocus(page)
+    await openVideo(page)
+    await waitForPlaybackOrSkip(test, page)
+    // The blur trigger would fire on its own if the harness window never
+    // gained focus, so start from a known focused state.
+    await setFocused(page, true)
+    await expect.poll(() => pictureInPictureActive(page)).toBe(false)
+  })
+
+  // Regression (#492, #265): with several triggers enabled, restoring the
+  // window left the video stranded in the PiP window.
+  test('restoring the window re-embeds the video', async ({ app, page }) => {
+    await setMinimized(app, true)
+    await expect.poll(() => pictureInPictureActive(page)).toBe(true)
+
+    await setMinimized(app, false)
+    await expect.poll(() => pictureInPictureActive(page)).toBe(false)
+  })
+
+  // Regression (#492): the blur the window manager delivers while the closing
+  // PiP window hands focus back reopened PiP right after the restore closed it.
+  test('a stale blur after restoring does not reopen PiP', async ({ app, page }) => {
+    await setMinimized(app, true)
+    await expect.poll(() => pictureInPictureActive(page)).toBe(true)
+
+    await setMinimized(app, false)
+    await expect.poll(() => pictureInPictureActive(page)).toBe(false)
+
+    await setFocused(page, false)
+    // Longer than the delay after which the blur trigger is re-checked, so a
+    // reopen would have happened by now.
+    await page.waitForTimeout(2000)
+    expect(await pictureInPictureActive(page)).toBe(false)
+  })
+
+  test('losing focus after a real focus still enters PiP', async ({ app, page }) => {
+    await setMinimized(app, true)
+    await expect.poll(() => pictureInPictureActive(page)).toBe(true)
+    await setMinimized(app, false)
+    await expect.poll(() => pictureInPictureActive(page)).toBe(false)
+
+    await setFocused(page, true)
+    await setFocused(page, false)
+    await expect.poll(() => pictureInPictureActive(page)).toBe(true)
+
+    await setFocused(page, true)
+    await expect.poll(() => pictureInPictureActive(page)).toBe(false)
+  })
+
+  // Regression (#492): blur and minimize fire within the same window
+  // transition, and PiP toggling is asynchronous, so the second trigger used
+  // to request a toggle that cancelled out the first one.
+  test('blur and minimize together open PiP exactly once', async ({ app, page }) => {
+    // Deliberately not awaiting the PiP state in between, so the second
+    // trigger lands while the PiP request is still in flight.
+    await setFocused(page, false)
+    await setMinimized(app, true)
+
+    await expect.poll(() => pictureInPictureActive(page)).toBe(true)
+    await page.waitForTimeout(2000)
+    expect(await pictureInPictureActive(page)).toBe(true)
+
+    await setMinimized(app, false)
+    await expect.poll(() => pictureInPictureActive(page)).toBe(false)
+  })
+
+  test('does not close a PiP window that the user opened', async ({ app, page }) => {
+    await page.locator(`${activeTab} video`).evaluate(element => element.requestPictureInPicture())
+    await expect.poll(() => pictureInPictureActive(page)).toBe(true)
+
+    await setMinimized(app, true)
+    await setMinimized(app, false)
+    await page.waitForTimeout(2000)
+    expect(await pictureInPictureActive(page)).toBe(true)
+  })
+})

--- a/src/renderer/components/ft-shaka-video-player/ft-shaka-video-player.js
+++ b/src/renderer/components/ft-shaka-video-player/ft-shaka-video-player.js
@@ -958,7 +958,7 @@ export default defineComponent({
     const {
       initializeActiveTab,
       isActiveTab,
-      resetAutoPictureInPictureOwnership,
+      notifyPictureInPictureState,
       setupAutoPictureInPicture,
       teardownAutoPictureInPicture,
       updateAutoPip,
@@ -4481,6 +4481,8 @@ export default defineComponent({
       if (scrollMiniPlayerActive.value) {
         deactivateScrollMiniPlayer()
       }
+
+      notifyPictureInPictureState(true)
     }
 
     function handleLeavePictureInPicture() {
@@ -4494,7 +4496,7 @@ export default defineComponent({
       pipWindowWidth.value = null
       pipWindowHeight.value = null
 
-      resetAutoPictureInPictureOwnership()
+      notifyPictureInPictureState(false)
 
       updateScrollMiniPlayer()
     }

--- a/src/renderer/components/ft-shaka-video-player/opentubex/autoPictureInPictureState.js
+++ b/src/renderer/components/ft-shaka-video-player/opentubex/autoPictureInPictureState.js
@@ -16,7 +16,8 @@ export const BLUR_TRIGGER_RECHECK_DELAY_MS = 750
  *   windowFocused: boolean,
  *   autoPipActive: boolean,
  *   pendingPipTarget: boolean | null,
- *   blurTriggerArmed: boolean
+ *   blurTriggerArmed: boolean,
+ *   pictureInPictureDismissed: boolean
  * }} AutoPictureInPictureState
  */
 

--- a/src/renderer/components/ft-shaka-video-player/opentubex/autoPictureInPictureState.js
+++ b/src/renderer/components/ft-shaka-video-player/opentubex/autoPictureInPictureState.js
@@ -1,0 +1,161 @@
+/**
+ * Pure state machine behind the automatic Picture-in-Picture triggers.
+ *
+ * Toggling PiP is asynchronous (in Electron it round-trips through the main
+ * process) and several triggers can fire within the same window transition, so
+ * the decisions live here instead of being derived ad-hoc from the DOM.
+ */
+
+// How long a restore may still produce a stale blur before the blur trigger is
+// re-evaluated, in case the window never emits a focus event afterwards.
+export const BLUR_TRIGGER_RECHECK_DELAY_MS = 750
+
+/**
+ * @typedef {{
+ *   windowMinimized: boolean,
+ *   windowFocused: boolean,
+ *   autoPipActive: boolean,
+ *   pendingPipTarget: boolean | null,
+ *   blurTriggerArmed: boolean
+ * }} AutoPictureInPictureState
+ */
+
+/**
+ * @param {{ minimized?: boolean, focused?: boolean }} [initial]
+ * @returns {AutoPictureInPictureState}
+ */
+export function createAutoPictureInPictureState({ minimized = false, focused = true } = {}) {
+  return {
+    windowMinimized: minimized,
+    windowFocused: focused,
+    // Whether the current PiP window was opened automatically. Only then may it
+    // be closed again automatically, so a manually opened one is left alone.
+    autoPipActive: false,
+    // Desired PiP state of a toggle that was requested but not observed yet.
+    pendingPipTarget: null,
+    // A blur only counts as a trigger once the document has been focused since
+    // the last restore, see `applyMinimizedState`.
+    blurTriggerArmed: true
+  }
+}
+
+/**
+ * @param {AutoPictureInPictureState} state
+ * @param {{
+ *   canAutoPip: boolean,
+ *   isActiveTab: boolean,
+ *   triggerOnTabChange: boolean,
+ *   triggerOnMinimize: boolean,
+ *   triggerOnBlur: boolean
+ * }} options
+ */
+export function shouldAutoPictureInPicture(state, {
+  canAutoPip,
+  isActiveTab,
+  triggerOnTabChange,
+  triggerOnMinimize,
+  triggerOnBlur
+}) {
+  if (!canAutoPip) {
+    return false
+  }
+
+  // An in-app tab change is handled by the 'tab' trigger. Window minimize / blur only
+  // apply while this is the presented tab, so background tabs don't spuriously enter PiP.
+  const tabHidden = triggerOnTabChange && !isActiveTab
+  const minimized = isActiveTab && triggerOnMinimize && state.windowMinimized
+  const blurred = isActiveTab && triggerOnBlur && !state.windowFocused && state.blurTriggerArmed
+
+  return tabHidden || minimized || blurred
+}
+
+/**
+ * @param {AutoPictureInPictureState} state
+ * @param {{ wantPip: boolean, inPip: boolean }} status
+ * @returns {'enter' | 'exit' | 'wait' | 'none'}
+ */
+export function resolveAutoPictureInPictureAction(state, { wantPip, inPip }) {
+  if (state.pendingPipTarget !== null) {
+    // Requesting another toggle before the previous one landed would cancel it
+    // out, e.g. when blur and minimize both fire while minimizing the window.
+    if (state.pendingPipTarget !== inPip) {
+      return 'wait'
+    }
+    state.pendingPipTarget = null
+  }
+
+  if (wantPip && !inPip) {
+    return 'enter'
+  }
+
+  if (!wantPip && inPip && state.autoPipActive) {
+    return 'exit'
+  }
+
+  return 'none'
+}
+
+/**
+ * @param {AutoPictureInPictureState} state
+ * @param {boolean} target
+ */
+export function markPictureInPictureRequested(state, target) {
+  state.pendingPipTarget = target
+  state.autoPipActive = target
+}
+
+/**
+ * @param {AutoPictureInPictureState} state
+ */
+export function markPictureInPictureRequestFailed(state) {
+  state.pendingPipTarget = null
+  state.autoPipActive = false
+}
+
+/**
+ * @param {AutoPictureInPictureState} state
+ * @param {boolean} focused
+ */
+export function applyFocusState(state, focused) {
+  state.windowFocused = focused
+  if (focused) {
+    state.blurTriggerArmed = true
+  }
+}
+
+/**
+ * @param {AutoPictureInPictureState} state
+ * @param {boolean} minimized
+ */
+export function applyMinimizedState(state, minimized) {
+  state.windowMinimized = minimized
+  if (!minimized) {
+    // Restoring/showing the app makes its document the active application surface.
+    // Keep the stale blur emitted while minimizing (or while the PiP window that is
+    // being closed hands focus back) from holding an automatically opened PiP window
+    // open forever, or from reopening it right after the restore closed it.
+    state.windowFocused = true
+    state.blurTriggerArmed = false
+  }
+}
+
+/**
+ * Records an observed PiP transition.
+ *
+ * @param {AutoPictureInPictureState} state
+ * @param {boolean} inPip
+ * @returns {boolean} whether the triggers should be re-evaluated
+ */
+export function applyPictureInPictureState(state, inPip) {
+  const wasRequested = state.pendingPipTarget === inPip
+  state.pendingPipTarget = null
+
+  if (!inPip) {
+    state.autoPipActive = false
+    // A PiP window closed by the user must not be reopened by a trigger that is
+    // still active, so only a close that was requested here settles the state.
+    return wasRequested
+  }
+
+  return true
+}

--- a/src/renderer/components/ft-shaka-video-player/opentubex/autoPictureInPictureState.js
+++ b/src/renderer/components/ft-shaka-video-player/opentubex/autoPictureInPictureState.js
@@ -35,7 +35,10 @@ export function createAutoPictureInPictureState({ minimized = false, focused = t
     pendingPipTarget: null,
     // A blur only counts as a trigger once the document has been focused since
     // the last restore, see `applyMinimizedState`.
-    blurTriggerArmed: true
+    blurTriggerArmed: true,
+    // Whether the user closed an automatically opened PiP window while its
+    // trigger still applies, see `applyPictureInPictureState`.
+    pictureInPictureDismissed: false
   }
 }
 
@@ -84,8 +87,13 @@ export function resolveAutoPictureInPictureAction(state, { wantPip, inPip }) {
     state.pendingPipTarget = null
   }
 
+  // Once the trigger stops applying, a dismissal from that trigger is spent.
+  if (!wantPip) {
+    state.pictureInPictureDismissed = false
+  }
+
   if (wantPip && !inPip) {
-    return 'enter'
+    return state.pictureInPictureDismissed ? 'none' : 'enter'
   }
 
   if (!wantPip && inPip && state.autoPipActive) {
@@ -153,9 +161,14 @@ export function applyPictureInPictureState(state, inPip) {
   if (!inPip) {
     state.autoPipActive = false
     // A PiP window closed by the user must not be reopened by a trigger that is
-    // still active, so only a close that was requested here settles the state.
+    // still active, so remember the dismissal until that trigger stops applying
+    // and let only a requested close settle the state right away.
+    state.pictureInPictureDismissed = !wasRequested
+
     return wasRequested
   }
+
+  state.pictureInPictureDismissed = false
 
   return true
 }

--- a/src/renderer/components/ft-shaka-video-player/opentubex/useAutoPictureInPicture.js
+++ b/src/renderer/components/ft-shaka-video-player/opentubex/useAutoPictureInPicture.js
@@ -1,6 +1,17 @@
 import { computed, watch } from 'vue'
 
 import store from '../../../store/index'
+import {
+  applyFocusState,
+  applyMinimizedState,
+  applyPictureInPictureState,
+  BLUR_TRIGGER_RECHECK_DELAY_MS,
+  createAutoPictureInPictureState,
+  markPictureInPictureRequested,
+  markPictureInPictureRequestFailed,
+  resolveAutoPictureInPictureAction,
+  shouldAutoPictureInPicture
+} from './autoPictureInPictureState'
 
 /**
  * OpenTubeX tab-awareness and automatic Picture-in-Picture behavior.
@@ -24,29 +35,32 @@ export function useAutoPictureInPicture({ getUi, props, video, tabId = null, isT
   const triggerOnBlur = computed(() => autoPictureInPictureTriggers.value.includes('blur'))
   const autoPipEnabled = computed(() => autoPictureInPictureTriggers.value.length > 0)
 
-  let autoPipActive = false
   // In Electron the minimized state is driven by native window events (see setup below),
   // because `document.hidden` doesn't fire on minimize on Wayland. On the web we fall back
   // to `document.hidden`, which also covers browser-tab switches.
-  let windowMinimized = process.env.IS_ELECTRON ? false : document.hidden
-  let windowFocused = document.hasFocus()
+  const state = createAutoPictureInPictureState({
+    minimized: process.env.IS_ELECTRON ? false : document.hidden,
+    focused: document.hasFocus()
+  })
   let stopActiveTabWatch = null
   let removeMinimizedListener = null
+  let blurTriggerRecheckTimeout = null
 
-  function shouldAutoPipNow() {
+  function canAutoPipNow() {
     if (!autoPipEnabled.value || props.format === 'audio') return false
 
     const videoElement = video.value
-    if (!videoElement || videoElement.ended || (videoElement.paused && !autoPipActive)) return false
+    return !!videoElement && !videoElement.ended && (!videoElement.paused || state.autoPipActive)
+  }
 
-    // An in-app tab change is handled by the 'tab' trigger. Window minimize / blur only
-    // apply while this is the presented tab, so background tabs don't spuriously enter PiP.
-    const active = isActiveTab.value
-    const tabHidden = triggerOnTabChange.value && !active
-    const minimized = active && triggerOnMinimize.value && windowMinimized
-    const blurred = active && triggerOnBlur.value && !windowFocused
-
-    return tabHidden || minimized || blurred
+  function shouldAutoPipNow() {
+    return shouldAutoPictureInPicture(state, {
+      canAutoPip: canAutoPipNow(),
+      isActiveTab: isActiveTab.value,
+      triggerOnTabChange: triggerOnTabChange.value,
+      triggerOnMinimize: triggerOnMinimize.value,
+      triggerOnBlur: triggerOnBlur.value
+    })
   }
 
   function triggerPipToggle() {
@@ -74,48 +88,62 @@ export function useAutoPictureInPicture({ getUi, props, video, tabId = null, isT
     const controls = ui.getControls?.()
     if (!controls) return
 
-    const wantPip = shouldAutoPipNow()
-    const inPip = controls.isPiPEnabled()
+    const action = resolveAutoPictureInPictureAction(state, {
+      wantPip: shouldAutoPipNow(),
+      inPip: controls.isPiPEnabled()
+    })
 
-    if (wantPip && !inPip) {
+    if (action === 'enter') {
       if (!controls.isPiPAllowed()) return
 
-      autoPipActive = true
+      markPictureInPictureRequested(state, true)
       if (!triggerPipToggle()) {
-        autoPipActive = false
+        markPictureInPictureRequestFailed(state)
       }
-    } else if (!wantPip && inPip && autoPipActive) {
-      triggerPipToggle()
-      autoPipActive = false
+    } else if (action === 'exit') {
+      markPictureInPictureRequested(state, false)
+      if (!triggerPipToggle()) {
+        markPictureInPictureRequestFailed(state)
+      }
     }
   }
 
   function refreshFocusState() {
-    windowFocused = document.hasFocus()
+    applyFocusState(state, document.hasFocus())
     updateAutoPip()
   }
 
   function refreshVisibilityState() {
-    windowMinimized = document.hidden
-    windowFocused = document.hasFocus()
+    state.windowMinimized = document.hidden
+    applyFocusState(state, document.hasFocus())
     updateAutoPip()
   }
 
   function handleMinimizedState(minimized) {
-    windowMinimized = minimized
-    // Restoring/showing the app makes its document the active application surface.
-    // Keep the stale blur emitted while minimizing (or while PiP had focus) from
-    // holding an automatically opened PiP window open forever.
+    applyMinimizedState(state, minimized)
     if (!minimized) {
-      windowFocused = true
+      // The blur trigger stays disarmed until the document is focused again. Re-check
+      // shortly after in case the restore doesn't emit a focus event at all.
+      clearBlurTriggerRecheck()
+      blurTriggerRecheckTimeout = setTimeout(() => {
+        blurTriggerRecheckTimeout = null
+        refreshFocusState()
+      }, BLUR_TRIGGER_RECHECK_DELAY_MS)
     }
     updateAutoPip()
   }
 
+  function clearBlurTriggerRecheck() {
+    if (blurTriggerRecheckTimeout != null) {
+      clearTimeout(blurTriggerRecheckTimeout)
+      blurTriggerRecheckTimeout = null
+    }
+  }
+
   function initializeActiveTab() {
-    windowFocused = document.hasFocus()
+    applyFocusState(state, document.hasFocus())
     if (!process.env.IS_ELECTRON) {
-      windowMinimized = document.hidden
+      state.windowMinimized = document.hidden
     }
     updateAutoPip()
   }
@@ -131,8 +159,15 @@ export function useAutoPictureInPicture({ getUi, props, video, tabId = null, isT
     stopActiveTabWatch = watch(isActiveTab, updateAutoPip)
   }
 
-  function resetAutoPictureInPictureOwnership() {
-    autoPipActive = false
+  /**
+   * Reports an observed Picture-in-Picture transition of this player.
+   *
+   * @param {boolean} inPip
+   */
+  function notifyPictureInPictureState(inPip) {
+    if (applyPictureInPictureState(state, inPip)) {
+      updateAutoPip()
+    }
   }
 
   function teardownAutoPictureInPicture() {
@@ -144,6 +179,7 @@ export function useAutoPictureInPicture({ getUi, props, video, tabId = null, isT
     }
     window.removeEventListener('focus', refreshFocusState)
     window.removeEventListener('blur', refreshFocusState)
+    clearBlurTriggerRecheck()
     stopActiveTabWatch?.()
     stopActiveTabWatch = null
   }
@@ -153,7 +189,7 @@ export function useAutoPictureInPicture({ getUi, props, video, tabId = null, isT
   return {
     initializeActiveTab,
     isActiveTab,
-    resetAutoPictureInPictureOwnership,
+    notifyPictureInPictureState,
     setupAutoPictureInPicture,
     teardownAutoPictureInPicture,
     updateAutoPip,

--- a/tests/unit/auto-picture-in-picture.test.mjs
+++ b/tests/unit/auto-picture-in-picture.test.mjs
@@ -1,0 +1,185 @@
+import assert from 'node:assert/strict'
+import test from 'node:test'
+
+import {
+  applyFocusState,
+  applyMinimizedState,
+  applyPictureInPictureState,
+  createAutoPictureInPictureState,
+  markPictureInPictureRequested,
+  resolveAutoPictureInPictureAction,
+  shouldAutoPictureInPicture
+} from '../../src/renderer/components/ft-shaka-video-player/opentubex/autoPictureInPictureState.js'
+
+const ALL_TRIGGERS = {
+  canAutoPip: true,
+  isActiveTab: true,
+  triggerOnTabChange: true,
+  triggerOnMinimize: true,
+  triggerOnBlur: true
+}
+
+/**
+ * Mirrors the composable: resolve an action, request the matching toggle and
+ * report which toggles the player would have been asked to perform.
+ */
+function createPlayer(state, options = ALL_TRIGGERS) {
+  const toggles = []
+  let inPip = false
+
+  return {
+    get inPip () { return inPip },
+    toggles,
+    update () {
+      const wantPip = shouldAutoPictureInPicture(state, options)
+      const action = resolveAutoPictureInPictureAction(state, { wantPip, inPip })
+
+      if (action === 'enter' || action === 'exit') {
+        markPictureInPictureRequested(state, action === 'enter')
+        toggles.push(action)
+      }
+
+      return action
+    },
+    // Applies a previously requested toggle, as the async PiP transition would.
+    settle () {
+      inPip = !inPip
+      if (applyPictureInPictureState(state, inPip)) {
+        this.update()
+      }
+      return inPip
+    },
+    closedByUser () {
+      inPip = false
+      if (applyPictureInPictureState(state, false)) {
+        this.update()
+      }
+    }
+  }
+}
+
+// Regression (#492, #265): with the blur trigger enabled, restoring the window
+// closed the PiP window but a stale blur reopened it right away.
+test('restoring the window does not let a stale blur reopen PiP', () => {
+  const state = createAutoPictureInPictureState()
+  const player = createPlayer(state)
+
+  // Minimizing blurs the window first, which opens PiP.
+  applyFocusState(state, false)
+  player.update()
+  applyMinimizedState(state, true)
+  player.update()
+  player.settle()
+  assert.equal(player.inPip, true)
+  assert.deepEqual(player.toggles, ['enter'])
+
+  // Restoring closes it again.
+  applyMinimizedState(state, false)
+  player.update()
+  player.settle()
+  assert.equal(player.inPip, false)
+  assert.deepEqual(player.toggles, ['enter', 'exit'])
+
+  // A blur delivered while the window manager hands focus back must not count.
+  applyFocusState(state, false)
+  player.update()
+  assert.equal(player.inPip, false)
+  assert.deepEqual(player.toggles, ['enter', 'exit'])
+})
+
+test('the blur trigger works again once the window was really focused', () => {
+  const state = createAutoPictureInPictureState()
+  const player = createPlayer(state)
+
+  applyMinimizedState(state, true)
+  player.update()
+  player.settle()
+  applyMinimizedState(state, false)
+  player.update()
+  player.settle()
+  assert.equal(player.inPip, false)
+
+  applyFocusState(state, true)
+  applyFocusState(state, false)
+  player.update()
+  player.settle()
+  assert.equal(player.inPip, true)
+  assert.deepEqual(player.toggles, ['enter', 'exit', 'enter'])
+})
+
+// Regression (#492): blur and minimize fire within the same window transition,
+// and PiP toggling is asynchronous, so both triggers used to request a toggle.
+test('a second trigger does not cancel out the requested toggle', () => {
+  const state = createAutoPictureInPictureState()
+  const player = createPlayer(state)
+
+  applyFocusState(state, false)
+  assert.equal(player.update(), 'enter')
+
+  // The window is reported as minimized before the PiP window has opened.
+  applyMinimizedState(state, true)
+  assert.equal(player.update(), 'wait')
+  assert.deepEqual(player.toggles, ['enter'])
+
+  player.settle()
+  assert.equal(player.inPip, true)
+  assert.deepEqual(player.toggles, ['enter'])
+})
+
+test('a restore while the PiP request is still in flight closes PiP once', () => {
+  const state = createAutoPictureInPictureState()
+  const player = createPlayer(state)
+
+  applyMinimizedState(state, true)
+  assert.equal(player.update(), 'enter')
+
+  applyMinimizedState(state, false)
+  assert.equal(player.update(), 'wait')
+
+  // The pending enter lands, so the settled state re-evaluates and closes it.
+  player.settle()
+  assert.equal(player.inPip, true)
+  assert.deepEqual(player.toggles, ['enter', 'exit'])
+
+  player.settle()
+  assert.equal(player.inPip, false)
+})
+
+test('PiP closed by the user is not reopened by an active trigger', () => {
+  const state = createAutoPictureInPictureState()
+  const player = createPlayer(state)
+
+  applyMinimizedState(state, true)
+  player.update()
+  player.settle()
+  assert.equal(player.inPip, true)
+
+  player.closedByUser()
+  assert.equal(player.inPip, false)
+  assert.deepEqual(player.toggles, ['enter'])
+})
+
+test('PiP opened by the user is not closed on restore', () => {
+  const state = createAutoPictureInPictureState()
+  const player = createPlayer(state)
+
+  // A manual PiP transition arrives without a matching request.
+  player.settle()
+  assert.equal(player.inPip, true)
+  assert.deepEqual(player.toggles, [])
+
+  applyMinimizedState(state, true)
+  player.update()
+  applyMinimizedState(state, false)
+  player.update()
+  assert.equal(player.inPip, true)
+  assert.deepEqual(player.toggles, [])
+})
+
+test('window minimize and blur only trigger for the presented tab', () => {
+  const state = createAutoPictureInPictureState({ minimized: true, focused: false })
+  const options = { ...ALL_TRIGGERS, isActiveTab: false, triggerOnTabChange: false }
+
+  assert.equal(shouldAutoPictureInPicture(state, options), false)
+  assert.equal(shouldAutoPictureInPicture(state, { ...options, triggerOnTabChange: true }), true)
+})

--- a/tests/unit/auto-picture-in-picture.test.mjs
+++ b/tests/unit/auto-picture-in-picture.test.mjs
@@ -157,6 +157,21 @@ test('PiP closed by the user is not reopened by an active trigger', () => {
   player.closedByUser()
   assert.equal(player.inPip, false)
   assert.deepEqual(player.toggles, ['enter'])
+
+  // A later re-evaluation (the player refreshes on `canplay`, focus changes and
+  // tab switches) must not reopen what the user just closed.
+  player.update()
+  assert.equal(player.inPip, false)
+  assert.deepEqual(player.toggles, ['enter'])
+
+  // Restoring ends the trigger, so the next one may open PiP again.
+  applyMinimizedState(state, false)
+  player.update()
+  applyMinimizedState(state, true)
+  player.update()
+  player.settle()
+  assert.equal(player.inPip, true)
+  assert.deepEqual(player.toggles, ['enter', 'enter'])
 })
 
 test('PiP opened by the user is not closed on restore', () => {

--- a/tests/unit/release-notes.test.mjs
+++ b/tests/unit/release-notes.test.mjs
@@ -27,6 +27,19 @@ const categoryMarkers = (category) => `
 <!-- release-note-category:end -->
 `
 
+// Pull request bodies have to keep every marker pair of the template, so the
+// fixtures compose them the same way the template does.
+function pullRequestBody(category, { note = '', images = '' } = {}) {
+  return `${categoryMarkers(category)}
+<!-- release-note:start -->
+${note}
+<!-- release-note:end -->
+<!-- release-note-image:start -->
+${images}
+<!-- release-note-image:end -->
+`
+}
+
 function png(width, height) {
   const buffer = Buffer.alloc(24)
 
@@ -74,7 +87,7 @@ function webp(type, width, height) {
 test('every pull request requires exactly one release note category', () => {
   assert.deepEqual(validatePullRequestEvent({
     pull_request: {
-      body: categoryMarkers('Not noteworthy'),
+      body: pullRequestBody('Not noteworthy'),
     },
   }), {
     category: 'Not noteworthy',
@@ -82,9 +95,11 @@ test('every pull request requires exactly one release note category', () => {
 
   assert.throws(() => validatePullRequestEvent({
     pull_request: {
-      body: '',
+      body: pullRequestBody('None of them'),
     },
-  }), /Select one release note category/)
+  }), /Select exactly one release note category/)
+
+  assert.throws(() => parseReleaseNoteCategory(''), /Select one release note category/)
 
   assert.throws(() => parseReleaseNoteCategory(`
 <!-- release-note-category:start -->
@@ -97,9 +112,29 @@ test('every pull request requires exactly one release note category', () => {
 test('release notes are required for noteworthy categories', () => {
   assert.throws(() => validatePullRequestEvent({
     pull_request: {
-      body: categoryMarkers('Highlights'),
+      body: pullRequestBody('Highlights'),
     },
   }), /Fill in the release note section/)
+})
+
+test('pull request bodies have to keep every release note marker', () => {
+  const body = pullRequestBody('Not noteworthy')
+  const markers = ['release-note-category', 'release-note', 'release-note-image']
+
+  for (const marker of markers) {
+    const withoutMarker = body.replace(`<!-- ${marker}:start -->`, '')
+
+    assert.throws(
+      () => validatePullRequestEvent({ pull_request: { body: withoutMarker } }),
+      new RegExp(`Keep the ${marker} markers`),
+      `removing the ${marker} markers has to be rejected`,
+    )
+  }
+
+  assert.throws(
+    () => validatePullRequestEvent({ pull_request: { body: '' } }),
+    /Keep the release-note-category markers/,
+  )
 })
 
 test('paginated pull request results are flattened', () => {
@@ -310,27 +345,17 @@ ${NOTE_MARKERS}
       title: 'Compact player',
     },
     {
-      body: `
-${categoryMarkers('More improvements')}
-<!-- release-note:start -->
-Adds keyboard shortcuts.
-<!-- release-note:end -->
-`,
+      body: pullRequestBody('More improvements', { note: 'Adds keyboard shortcuts.' }),
       number: 43,
       title: 'Keyboard shortcuts',
     },
     {
-      body: `
-${categoryMarkers('Fixed bugs')}
-<!-- release-note:start -->
-Fixed videos failing to load.
-<!-- release-note:end -->
-`,
+      body: pullRequestBody('Fixed bugs', { note: 'Fixed videos failing to load.' }),
       number: 44,
       title: 'Fix video loading',
     },
     {
-      body: categoryMarkers('Not noteworthy'),
+      body: pullRequestBody('Not noteworthy'),
       number: 45,
       title: 'Refactor tests',
     },
@@ -362,10 +387,7 @@ Fixed videos failing to load.
 test('empty release note categories are omitted', async () => {
   const result = await renderReleaseNotes([
     {
-      body: `
-${categoryMarkers('Fixed bugs')}
-${NOTE_MARKERS}
-`,
+      body: pullRequestBody('Fixed bugs', { note: 'Adds a compact player.' }),
       number: 42,
       title: 'Compact player',
     },
@@ -380,7 +402,7 @@ ${NOTE_MARKERS}
 test('a release with only non-noteworthy pull requests is rejected', async () => {
   await assert.rejects(
     renderReleaseNotes([{
-      body: categoryMarkers('Not noteworthy'),
+      body: pullRequestBody('Not noteworthy'),
       number: 42,
       title: 'Refactor tests',
     }]),
@@ -390,7 +412,7 @@ test('a release with only non-noteworthy pull requests is rejected', async () =>
 
 test('nightly releases can render a fallback when there are no noteworthy changes', async () => {
   const result = await renderReleaseNotes([{
-    body: categoryMarkers('Not noteworthy'),
+    body: pullRequestBody('Not noteworthy'),
     number: 42,
     title: 'Refactor tests',
   }], {


### PR DESCRIPTION
## Pull Request Type
- [x] Bugfix
- [ ] Feature Implementation
- [ ] Documentation
- [ ] Other

## Related issue
closes #492

## Description
With more than one "Automatically enter PiP mode" trigger enabled, minimizing and then restoring the window left the video stranded in the PiP window while the main window stayed empty. Two races caused this, both of which need a second trigger to be active, which is why the earlier fix for #265 did not close it:

- **Cancelling toggles.** Requesting PiP is asynchronous (in Electron it round-trips through the main process). Minimizing fires `blur` and `minimize` milliseconds apart, and the second trigger still saw `isPiPEnabled() === false`, so it requested another toggle that undid the first one.
- **Stale blur after restore.** Restoring requested the PiP exit and released ownership. The blur that the window manager delivers right afterwards (while the closing PiP window hands focus back) then looked like a fresh trigger and reopened PiP, with auto PiP no longer owning it — so nothing closed it again.

The trigger decisions now live in a small state machine (`autoPictureInPictureState.js`) instead of being derived ad-hoc from the DOM:

- an in-flight toggle is tracked, so further triggers wait for the real PiP transition instead of requesting another toggle; the player reports `enterpictureinpicture` / `leavepictureinpicture` back to it, which then settles the state
- the blur trigger is disarmed by a restore and only armed again once the document is genuinely focused (with a short re-check, in case no focus event follows the restore)

Unchanged on purpose: a PiP window the user opened manually is still never closed automatically, and one the user closed manually is not reopened while a trigger is still active.

## Release note category
<!-- release-note-category:start -->
- [ ] Not noteworthy
- [ ] Highlights
- [ ] More improvements
- [x] Fixed bugs
<!-- release-note-category:end -->

## Release note
<!-- release-note:start -->
Fixed the player staying in Picture-in-Picture after restoring the window when several automatic PiP triggers were enabled
<!-- release-note:end -->

## Release note images
<!-- Human-only: Agents must leave this section empty. -->
<!-- Optional. Paste one or more Markdown images or HTML image tags here. -->
<!-- The release notes will use an HTML image tag and limit images taller than 300 pixels. -->
<!-- release-note-image:start -->

<!-- release-note-image:end -->

## Testing
Run the app in dev mode and go to Settings > Player > Automatically enter PiP mode, then enable **all three** options ("When switching tabs", "When minimizing the window", "When the window loses focus or is switched away").

1. Play a video, minimize the window. → The video moves into the PiP window (and stays there — it must not flicker back out).
2. Restore the window from the taskbar. → PiP closes and the video is embedded in the main window again. Previously it stayed in the PiP window with the main window empty.
3. Click another application so OpenTubeX loses focus. → PiP opens again; focusing OpenTubeX closes it again. This confirms the blur trigger is re-armed after a restore.
4. Play a video, open PiP manually via the player button, minimize and restore. → PiP stays open, since automatic PiP must not close a window the user opened.
5. Play a video, minimize, then close the PiP window yourself while still minimized. → It stays closed and is not reopened.

Automated:

- `pnpm run test:unit` — new `tests/unit/auto-picture-in-picture.test.mjs` replays both failing sequences (verified to fail against the previous logic) plus the manual-PiP and background-tab behaviour.
- New `e2e/tests/network/auto-picture-in-picture.spec.mjs` drives the real player: the main process emits its native `minimize` / `restore` events, and the assertions check Chromium's actual `document.pictureInPictureElement`. Reverting only the source fix makes "a stale blur after restoring does not reopen PiP" fail with the exact symptom from the issue.
- `pnpm run test:e2e:offline` (`tabs.spec.mjs`, 39 passed) covers the existing PiP regressions, and the network `watch.spec.mjs` still passes with the new wiring.

## Additional context
Xvfb has no window manager, so the E2E test emits the window events on the `BrowserWindow` (which is what the main process forwards to the renderer in production) and drives `document.hasFocus()` explicitly, rather than relying on a real `minimize()` being honoured.

