### PR TITLE
fix(player): keep the preferred quality when falling back to legacy formats

### DIFF
--- a/src/renderer/components/ft-shaka-video-player/ft-shaka-video-player.js
+++ b/src/renderer/components/ft-shaka-video-player/ft-shaka-video-player.js
@@ -60,6 +60,7 @@ import { appendTimestamp, getInvidiousVideoUrl, getYoutubeVideoShareUrl } from '
 import { MANIFEST_TYPE_SABR } from '../../helpers/player/SabrManifestParser'
 import { setupSabrScheme } from '../../helpers/player/SabrSchemePlugin'
 import { getRememberedPlayerVolume, setRememberedPlayerVolume } from '../../helpers/player/volume-storage'
+import { findLegacyFormatForQuality } from '../../helpers/player/legacyFormats'
 import { resolveSponsorBlockEnterTarget, resolveSponsorBlockEnterTargets } from '../../helpers/player/sponsorBlockShortcut'
 import { createSponsorBlockMuteController } from '../../helpers/player/sponsorBlockMute'
 import { matchesKeyboardShortcut } from '../../helpers/keyboardShortcuts'
@@ -4901,32 +4902,13 @@ export default defineComponent({
         previousQuality = preferredVideoQuality.value
       }
 
-      /** @type {object[]} */
-      const legacyFormats = props.legacyFormats
-
-      const isPortrait = legacyFormats[0].height > legacyFormats[0].width
-
-      let matches = legacyFormats.filter(variant => {
-        return previousQuality === isPortrait ? variant.width : variant.height
-      })
-
-      if (matches.length === 0) {
-        matches = legacyFormats.filter(variant => {
-          return previousQuality > isPortrait ? variant.width : variant.height
-        })
-
-        if (matches.length > 0) {
-          matches.sort((a, b) => b.bitrate - a.bitrate)
-        } else {
-          matches = legacyFormats.sort((a, b) => a.bitrate - b.bitrate)
-        }
-      }
+      const format = findLegacyFormatForQuality(props.legacyFormats, previousQuality)
 
       hasMultipleAudioTracks.value = false
 
       events.dispatchEvent(new CustomEvent('setLegacyFormat', {
         detail: {
-          format: matches[0],
+          format,
           playbackPosition,
           playbackRate
         }
@@ -5779,11 +5761,11 @@ export default defineComponent({
         activeLegacyFormat.value = event.detail.format
         const quality = getQualityFromDimensions(format.width, format.height)
 
-        if (quality !== null) {
-          emit('video-quality-updated', quality)
-        }
-
+        // Only remember the quality when the user picked it themselves. The legacy formats top out
+        // at 360p, so remembering an automatically chosen one would downgrade the preferred quality
+        // when switching back to the DASH formats.
         if (userSelected && quality !== null) {
+          emit('video-quality-updated', quality)
           emit('video-quality-user-set', quality)
         }
 
@@ -8018,10 +8000,10 @@ export default defineComponent({
           let dimension
 
           if (oldFormat === 'legacy' && newFormat === 'dash') {
-            const legacyFormat = activeLegacyFormat.value
-
             if (!useAutoQuality) {
-              dimension = legacyFormat.height > legacyFormat.width ? legacyFormat.width : legacyFormat.height
+              // Use the preferred quality instead of the active legacy format's dimensions, as the
+              // legacy formats top out at 360p and the user may never have chosen that themselves
+              dimension = preferredVideoQuality.value
             }
           } else if (oldFormat !== 'legacy') {
             const track = player.getVariantTracks().find(track => track.active)

--- a/src/renderer/helpers/player/legacyFormats.js
+++ b/src/renderer/helpers/player/legacyFormats.js
@@ -1,0 +1,35 @@
+/**
+ * @typedef {{ width: number, height: number, bitrate: number }} LegacyFormat
+ */
+
+/**
+ * Picks the legacy format that matches the preferred quality the closest.
+ *
+ * The legacy formats usually top out at 360p, so the preferred quality is often unavailable,
+ * in that case the highest quality below it is used.
+ * @param {LegacyFormat[]} legacyFormats
+ * @param {number} preferredQuality
+ * @returns {LegacyFormat}
+ */
+export function findLegacyFormatForQuality(legacyFormats, preferredQuality) {
+  const isPortrait = legacyFormats[0].height > legacyFormats[0].width
+
+  /** @param {LegacyFormat} format */
+  const resolutionOf = (format) => isPortrait ? format.width : format.height
+
+  const exactMatches = legacyFormats.filter(format => resolutionOf(format) === preferredQuality)
+
+  if (exactMatches.length > 0) {
+    return exactMatches[0]
+  }
+
+  const lowerQualityMatches = legacyFormats.filter(format => resolutionOf(format) < preferredQuality)
+
+  if (lowerQualityMatches.length > 0) {
+    // highest quality below the preferred one
+    return lowerQualityMatches.sort((a, b) => b.bitrate - a.bitrate)[0]
+  }
+
+  // everything is above the preferred quality, so use the lowest quality one
+  return legacyFormats.toSorted((a, b) => a.bitrate - b.bitrate)[0]
+}

--- a/tests/unit/legacy-format-quality.test.mjs
+++ b/tests/unit/legacy-format-quality.test.mjs
@@ -1,0 +1,50 @@
+import assert from 'node:assert/strict'
+import test from 'node:test'
+
+import { findLegacyFormatForQuality } from '../../src/renderer/helpers/player/legacyFormats.js'
+
+const LANDSCAPE_FORMATS = [
+  { width: 640, height: 360, bitrate: 500_000 },
+  { width: 426, height: 240, bitrate: 250_000 },
+  { width: 256, height: 144, bitrate: 100_000 }
+]
+
+const PORTRAIT_FORMATS = [
+  { width: 360, height: 640, bitrate: 500_000 },
+  { width: 240, height: 426, bitrate: 250_000 }
+]
+
+test('an exactly matching legacy format is used', () => {
+  const format = findLegacyFormatForQuality(LANDSCAPE_FORMATS, 240)
+
+  assert.equal(format.height, 240)
+})
+
+test('the highest legacy format below the preferred quality is used', () => {
+  // regression: an operator precedence bug made the filters match every format,
+  // so the first one in the list was always used, no matter the preferred quality
+  const format = findLegacyFormatForQuality(LANDSCAPE_FORMATS, 240)
+
+  assert.equal(findLegacyFormatForQuality(LANDSCAPE_FORMATS, 1080).height, 360)
+  assert.equal(format.height, 240)
+  assert.equal(findLegacyFormatForQuality(LANDSCAPE_FORMATS, 200).height, 144)
+})
+
+test('the lowest legacy format is used when they are all above the preferred quality', () => {
+  const format = findLegacyFormatForQuality(LANDSCAPE_FORMATS, 100)
+
+  assert.equal(format.height, 144)
+})
+
+test('portrait videos are matched on their width', () => {
+  assert.equal(findLegacyFormatForQuality(PORTRAIT_FORMATS, 240).width, 240)
+  assert.equal(findLegacyFormatForQuality(PORTRAIT_FORMATS, 1080).width, 360)
+})
+
+test('the passed in formats are not reordered', () => {
+  const formats = [...LANDSCAPE_FORMATS]
+
+  findLegacyFormatForQuality(formats, 100)
+
+  assert.deepEqual(formats, LANDSCAPE_FORMATS)
+})


### PR DESCRIPTION
## Pull Request Type
- [x] Bugfix
- [ ] Feature Implementation
- [ ] Documentation
- [ ] Other

## Related issue
<!-- No related issue. -->

## Description
When a video has no usable DASH streams, the player silently falls back to the legacy formats, which top out at 360p. That automatic fallback was treated like a deliberate quality choice, so it overwrote the remembered video quality. Switching back to the DASH formats afterwards then stayed at 360p instead of returning to the quality that was playing before.

Three changes:

- An automatically picked legacy format no longer updates the remembered quality. Only a quality the user picks themselves from the legacy quality menu does.
- Switching from the legacy formats back to DASH now targets the preferred quality instead of deriving it from the active legacy format's dimensions. When nothing was ever selected, this falls through to the default quality setting.
- Fixed an operator precedence bug in the legacy format matching (`quality === isPortrait ? width : height` parsed as `(quality === isPortrait) ? ... : ...`). Both filters matched every format, so the preferred quality was ignored entirely and the first format in the list always won. The matching moved into a small helper so it can be covered by a unit test.

## Release note category
<!-- release-note-category:start -->
- [ ] Not noteworthy
- [ ] Highlights
- [ ] More improvements
- [x] Fixed bugs
<!-- release-note-category:end -->

## Release note
<!-- release-note:start -->
Fixed the video quality staying at 360p after the player fell back to the legacy formats and was switched back to the DASH formats
<!-- release-note:end -->

## Release note images
<!-- release-note-image:start -->

<!-- release-note-image:end -->

## Testing
Switching the format by hand goes through the same code as the automatic fallback, so there is no need to find a video that actually falls back.

1. Open a video that offers 1080p and select **1080p** in the player's quality menu.
2. In the video info bar, use the **Change Media Formats** button and choose **Use Legacy Formats**. The video plays at 360p, which is the highest the legacy formats offer.
3. Use **Change Media Formats** again and choose **Use DASH Formats**.
   - Expected: playback returns to 1080p. On the development branch it stays at 360p.

Also worth checking:

- **A manual legacy choice is still respected:** while on the legacy formats, open the quality menu and pick 144p, then switch back to the DASH formats. Expected: 144p, not 1080p.
- **No previous choice:** open a fresh video, do not touch the quality menu, switch to the legacy formats and back. Expected: the quality from Settings → Player → Default Quality.
- **The legacy choice follows the preferred quality:** set the default quality to 240p and switch a video to the legacy formats. Expected: the 240p legacy format, not 360p. This was broken before this PR regardless of any format switching.

Press `d` with the player focused (or use the stats entry in the overflow menu) to see the active resolution instead of reading it off the quality menu.

## Additional context
<!-- None. -->
