### PR TITLE
fix(watch): keep the scroll mini player docked after a window resize

### DIFF
--- a/e2e/tests/network/watch.spec.mjs
+++ b/e2e/tests/network/watch.spec.mjs
@@ -1,6 +1,6 @@
 import { sel } from '../../helpers/app.mjs'
 import { test, expect, setPlayerFullscreen } from '../../helpers/innertube.mjs'
-import { findWatchComponent, waitForPlaybackOrSkip } from '../../helpers/player.mjs'
+import { activeTab, findWatchComponent, waitForPlaybackOrSkip } from '../../helpers/player.mjs'
 
 // "Me at the zoo" - the oldest video on YouTube, short and stable.
 const VIDEO_URL = 'https://www.youtube.com/watch?v=jNQXAC9IVRw'
@@ -40,23 +40,34 @@ function longTranscript() {
   )).join('\n\n')}\n`
 }
 
+/**
+ * Opens the watch page, or skips when the live API refuses to serve it (bot
+ * checks on CI runners and VPNs), which leaves the page shell without any
+ * video data instead of producing an error message.
+ */
 async function openVideo(page, video = { id: 'jNQXAC9IVRw', title: 'Me at the zoo', url: VIDEO_URL }) {
   await page.locator(sel.searchInput).fill(video.url)
   await page.locator(sel.searchInput).press('Enter')
   await expect(page).toHaveURL(new RegExp(`#\\/watch\\/${video.id}`))
-  await expect(page.locator('.videoTitle')).toContainText(video.title, { timeout: 30_000 })
 
-  const player = page.locator('.ftVideoPlayer')
-  const errorMessage = page.locator('.errorMessage')
-  await expect(player.or(errorMessage)).toBeVisible({ timeout: 30_000 })
+  const title = page.locator(`${activeTab} .videoTitle`)
+  const errorMessage = page.locator(`${activeTab} .errorMessage`)
+  let state = 'waiting'
+  const settled = await expect
+    .poll(async () => {
+      const titleText = await title.textContent().catch(() => '') ?? ''
+      if (titleText.includes(video.title)) {
+        state = 'loaded'
+      } else if (await errorMessage.isVisible().catch(() => false)) {
+        state = (await errorMessage.textContent())?.trim() ?? 'unavailable'
+      }
+      return state === 'waiting' ? 'waiting' : 'done'
+    }, { timeout: 30_000, message: 'waiting for the watch page to load' })
+    .toBe('done')
+    .then(() => true, () => false)
 
-  const errorText = await errorMessage.isVisible()
-    ? (await errorMessage.textContent())?.trim() ?? ''
-    : ''
-  test.skip(
-    /blocked your IP|Ratelimited|IP block/i.test(errorText),
-    `watch page unavailable from the live API: ${errorText}`
-  )
+  test.skip(!settled || state !== 'loaded', `watch page unavailable from the live API: ${state}`)
+  await expect(page.locator(`${activeTab} .ftVideoPlayer`)).toBeVisible({ timeout: 30_000 })
 }
 
 async function openCaptionedVideoOrSkip(page) {
@@ -329,14 +340,14 @@ test.describe('watch page', () => {
     await openVideo(page)
 
     const video = await waitForPlaybackOrSkip(test, page)
-    const activeTab = page.locator(sel.activeTab)
-    await expect(activeTab.locator('.playingIcon')).toBeVisible()
+    const tabBarTab = page.locator(sel.activeTab)
+    await expect(tabBarTab.locator('.playingIcon')).toBeVisible()
 
     await video.dispatchEvent('waiting')
-    await expect(activeTab.locator('.playingIcon')).toHaveCount(0)
+    await expect(tabBarTab.locator('.playingIcon')).toHaveCount(0)
 
     await video.dispatchEvent('playing')
-    await expect(activeTab.locator('.playingIcon')).toBeVisible()
+    await expect(tabBarTab.locator('.playingIcon')).toBeVisible()
   })
 
   test('animates into and out of the scroll mini player', async ({ page, innertube }) => {

--- a/e2e/tests/network/watch.spec.mjs
+++ b/e2e/tests/network/watch.spec.mjs
@@ -101,6 +101,45 @@ async function setWindowWidth(app, width) {
   }, width)
 }
 
+/** Resize the window and wait for the renderer to have laid out at the new size. */
+async function setWindowSize(app, page, { width, height }) {
+  const before = await getViewport(page)
+
+  await app.electronApp.evaluate(({ BrowserWindow }, size) => {
+    const browserWindow = BrowserWindow.getAllWindows()[0]
+    const bounds = browserWindow.getBounds()
+    browserWindow.setBounds({ ...bounds, ...size })
+  }, { width, height })
+
+  await expect.poll(async () => {
+    const viewport = await getViewport(page)
+    return viewport.width !== before.width && viewport.height !== before.height
+  }).toBe(true)
+
+  return await getViewport(page)
+}
+
+function getViewport(page) {
+  return page.evaluate(() => ({
+    width: document.documentElement.clientWidth,
+    height: window.innerHeight
+  }))
+}
+
+/** @param {{ width: number, height: number }} viewport */
+async function expectDockedToBottomRight(player, viewport, margin = 16) {
+  // Polled because the layout animation skews the box for its first 300ms.
+  await expect.poll(async () => {
+    const box = await player.boundingBox()
+    if (!box) return null
+
+    return {
+      right: Math.round(viewport.width - (box.x + box.width)),
+      bottom: Math.round(viewport.height - (box.y + box.height))
+    }
+  }).toEqual({ right: margin, bottom: margin })
+}
+
 test('theatre mode works until its responsive button cutoff', async ({ app, page }) => {
   await setWindowWidth(app, 1500)
   await page.locator(sel.searchInput).fill(VIDEO_URL)
@@ -349,6 +388,39 @@ test.describe('watch page', () => {
     expect(animations[1].className).toContain('scrollMiniPlayerAnimating')
     expect(animations[1].position).toBe('relative')
     expect(animations[1].zIndex).toBe('150')
+  })
+
+  test('keeps the scroll mini player docked across window resizes', async ({ app, page, innertube }) => {
+    test.skip(!innertube.playback, 'needs real media streams')
+    await setWindowSize(app, page, { width: 1200, height: 850 })
+    await openVideo(page)
+
+    const video = await waitForPlaybackOrSkip(test, page)
+    await video.evaluate(element => element.pause())
+
+    const player = page.locator('.ftVideoPlayer')
+    const scrollBelowPlayer = () => player.evaluate(element => {
+      const rect = element.getBoundingClientRect()
+      window.scrollTo(0, window.scrollY + rect.bottom)
+    })
+
+    // Docked bottom-right in the small window.
+    await scrollBelowPlayer()
+    await expect(player).toHaveClass(/scrollMiniPlayer/)
+
+    // Growing the window used to leave the player where the old bottom edge
+    // was, i.e. floating in the middle of the screen.
+    const grown = await setWindowSize(app, page, { width: 1600, height: 1050 })
+    await expectDockedToBottomRight(player, grown)
+
+    // ...and the stale position outlived a trip back to the inline player.
+    await page.evaluate(() => window.scrollTo(0, 0))
+    await expect(player).not.toHaveClass(/scrollMiniPlayer/)
+
+    const shrunk = await setWindowSize(app, page, { width: 1300, height: 900 })
+    await scrollBelowPlayer()
+    await expect(player).toHaveClass(/scrollMiniPlayer/)
+    await expectDockedToBottomRight(player, shrunk)
   })
 
   test('keeps the context menu open when the pointer leaves a playing video', async ({ page, innertube }) => {

--- a/src/renderer/components/ft-shaka-video-player/opentubex/useScrollMiniPlayer.js
+++ b/src/renderer/components/ft-shaka-video-player/opentubex/useScrollMiniPlayer.js
@@ -12,7 +12,9 @@ import {
   getSavedScrollMiniPlayerRect,
   getViewportInsets,
   getScrollMiniInlineLayoutHeight,
+  getScrollMiniVerticalAnchor,
   parseScrollMiniPlayerSavedRect,
+  reanchorScrollMiniPlayerRect,
   resizeScrollMiniPlayerFromCorner,
   resolveScrollMiniDragHandleOnLightBg,
   sampleScrollMiniDragHandleLuminance,
@@ -371,9 +373,13 @@ export function useScrollMiniPlayer({ container, fullWindowEnabled, getUi, isAct
    * @param {boolean} [persist]
    */
   function applyScrollMiniPlayerRect(rect, persist = false) {
+    const insets = getViewportInsets()
     const clamped = clampScrollMiniPlayerRect(rect, scrollMiniVideoAspectRatio.value)
+    // Remember the edge the player is parked at, so a later resize can put it
+    // back against that edge instead of leaving it where the old viewport was.
+    Object.assign(clamped, getScrollMiniVerticalAnchor(clamped, insets))
     scrollMiniPlayerRect.value = clamped
-    scrollMiniResizeCorner.value = getResizeHandleCorner(clamped, getViewportInsets())
+    scrollMiniResizeCorner.value = getResizeHandleCorner(clamped, insets)
 
     if (persist) {
       // Drag and bounce frames can be interrupted, so only remember settled positions.
@@ -571,10 +577,11 @@ export function useScrollMiniPlayer({ container, fullWindowEnabled, getUi, isAct
     scrollMiniPlayerActive.value = true
     updateScrollMiniVideoAspectRatio()
     applyScrollMiniPlayerRect(
-      clampScrollMiniPlayerRect(
-        savedRect ?? getDefaultScrollMiniPlayerRect(scrollMiniVideoAspectRatio.value),
-        scrollMiniVideoAspectRatio.value
-      )
+      savedRect
+        // The window may have changed size since the rect was saved, so replay
+        // it against the edges it was docked to rather than its old coordinates.
+        ? reanchorScrollMiniPlayerRect(savedRect, scrollMiniVideoAspectRatio.value)
+        : getDefaultScrollMiniPlayerRect(scrollMiniVideoAspectRatio.value)
     )
     syncScrollMiniPlayerState()
 
@@ -675,9 +682,9 @@ export function useScrollMiniPlayer({ container, fullWindowEnabled, getUi, isAct
   }
 
   /**
-   * Re-dock to the current insets. Needed whenever the usable area changes
-   * (window resize, or the vertical tab bar being toggled/resized), otherwise
-   * the player is stranded mid-screen at its old edge.
+   * Re-dock to the current insets, horizontally and vertically. Needed whenever
+   * the usable area changes (window resize, or the vertical tab bar being
+   * toggled/resized), otherwise the player is stranded mid-screen at its old edge.
    */
   function resnapScrollMiniPlayerToEdge() {
     if (!scrollMiniPlayerActive.value) return
@@ -686,8 +693,10 @@ export function useScrollMiniPlayer({ container, fullWindowEnabled, getUi, isAct
     if (scrollMiniPointerSession?.type === 'drag' || scrollMiniPointerSession?.type === 'resize') return
 
     cancelScrollMiniPlayerBounce()
-    const clamped = clampScrollMiniPlayerRect(scrollMiniPlayerRect.value, scrollMiniVideoAspectRatio.value)
-    applyScrollMiniPlayerRect(snapScrollMiniPlayerToEdge(clamped, getViewportInsets()), true)
+    applyScrollMiniPlayerRect(
+      reanchorScrollMiniPlayerRect(scrollMiniPlayerRect.value, scrollMiniVideoAspectRatio.value),
+      true
+    )
   }
 
   function handleScrollMiniWindowResize() {

--- a/src/renderer/components/ft-shaka-video-player/opentubex/useScrollMiniPlayer.js
+++ b/src/renderer/components/ft-shaka-video-player/opentubex/useScrollMiniPlayer.js
@@ -116,7 +116,9 @@ export function useScrollMiniPlayer({ container, fullWindowEnabled, getUi, isAct
     scrollMiniVideoAspectRatio.value = videoElement.videoWidth / videoElement.videoHeight
 
     if (scrollMiniPlayerActive.value) {
-      applyScrollMiniPlayerRect(scrollMiniPlayerRect.value)
+      // Resizing to the video's aspect ratio is not the user moving the player,
+      // so it must not turn a temporarily clamped position into its anchor.
+      applyScrollMiniPlayerRect(scrollMiniPlayerRect.value, false, true)
     }
   }
 

--- a/src/renderer/components/ft-shaka-video-player/opentubex/useScrollMiniPlayer.js
+++ b/src/renderer/components/ft-shaka-video-player/opentubex/useScrollMiniPlayer.js
@@ -14,6 +14,7 @@ import {
   getScrollMiniInlineLayoutHeight,
   getScrollMiniVerticalAnchor,
   parseScrollMiniPlayerSavedRect,
+  pickScrollMiniVerticalAnchor,
   reanchorScrollMiniPlayerRect,
   resizeScrollMiniPlayerFromCorner,
   resolveScrollMiniDragHandleOnLightBg,
@@ -371,13 +372,18 @@ export function useScrollMiniPlayer({ container, fullWindowEnabled, getUi, isAct
   /**
    * @param {import('../../../helpers/scrollMiniPlayer').ScrollMiniPlayerRect} rect
    * @param {boolean} [persist]
+   * @param {boolean} [keepAnchor] trust the rect's own anchor over its geometry
    */
-  function applyScrollMiniPlayerRect(rect, persist = false) {
+  function applyScrollMiniPlayerRect(rect, persist = false, keepAnchor = false) {
     const insets = getViewportInsets()
     const clamped = clampScrollMiniPlayerRect(rect, scrollMiniVideoAspectRatio.value)
     // Remember the edge the player is parked at, so a later resize can put it
     // back against that edge instead of leaving it where the old viewport was.
-    Object.assign(clamped, getScrollMiniVerticalAnchor(clamped, insets))
+    // Dragging makes the geometry authoritative, but a re-anchored rect brings
+    // the distance it is meant to keep: a viewport too short to honour it clamps
+    // the rect, and re-deriving from that would forget the distance for good.
+    Object.assign(clamped, (keepAnchor && pickScrollMiniVerticalAnchor(rect)) ||
+      getScrollMiniVerticalAnchor(clamped, insets))
     scrollMiniPlayerRect.value = clamped
     scrollMiniResizeCorner.value = getResizeHandleCorner(clamped, insets)
 
@@ -581,7 +587,9 @@ export function useScrollMiniPlayer({ container, fullWindowEnabled, getUi, isAct
         // The window may have changed size since the rect was saved, so replay
         // it against the edges it was docked to rather than its old coordinates.
         ? reanchorScrollMiniPlayerRect(savedRect, scrollMiniVideoAspectRatio.value)
-        : getDefaultScrollMiniPlayerRect(scrollMiniVideoAspectRatio.value)
+        : getDefaultScrollMiniPlayerRect(scrollMiniVideoAspectRatio.value),
+      false,
+      true
     )
     syncScrollMiniPlayerState()
 
@@ -695,6 +703,7 @@ export function useScrollMiniPlayer({ container, fullWindowEnabled, getUi, isAct
     cancelScrollMiniPlayerBounce()
     applyScrollMiniPlayerRect(
       reanchorScrollMiniPlayerRect(scrollMiniPlayerRect.value, scrollMiniVideoAspectRatio.value),
+      true,
       true
     )
   }

--- a/src/renderer/helpers/scrollMiniPlayer.js
+++ b/src/renderer/helpers/scrollMiniPlayer.js
@@ -86,9 +86,7 @@ export function parseScrollMiniPlayerSavedRect(value) {
       width: parsed.width,
       height: parsed.height,
       dock: parsed.dock === 'left' ? 'left' : 'right',
-      ...(hasVerticalAnchor(parsed)
-        ? { verticalDock: parsed.verticalDock, verticalOffset: parsed.verticalOffset }
-        : {}),
+      ...pickScrollMiniVerticalAnchor(parsed),
     }
   } catch {
     return null
@@ -96,12 +94,20 @@ export function parseScrollMiniPlayerSavedRect(value) {
 }
 
 /**
+ * The anchor a rect already carries, if any. Reading it back beats re-deriving
+ * one from the geometry: a viewport too short to honour the remembered distance
+ * has to clamp the rect, and inferring from that would forget the distance for
+ * good, instead of restoring it once the window grows again.
+ *
  * @param {Partial<ScrollMiniPlayerRect> | null | undefined} rect
- * @returns {boolean}
+ * @returns {{ verticalDock: 'top' | 'bottom', verticalOffset: number } | null}
  */
-function hasVerticalAnchor(rect) {
-  return (rect?.verticalDock === 'top' || rect?.verticalDock === 'bottom') &&
-    Number.isFinite(rect.verticalOffset)
+export function pickScrollMiniVerticalAnchor(rect) {
+  const parked = rect?.verticalDock === 'top' || rect?.verticalDock === 'bottom'
+
+  return parked && Number.isFinite(rect.verticalOffset)
+    ? { verticalDock: rect.verticalDock, verticalOffset: rect.verticalOffset }
+    : null
 }
 
 /**
@@ -155,9 +161,7 @@ function getLegacyVerticalAnchor(rect, insets) {
 export function reanchorScrollMiniPlayerRect(rect, aspectRatio = DEFAULT_ASPECT_RATIO) {
   const insets = getViewportInsets()
   const sized = clampScrollMiniPlayerRect(rect, aspectRatio)
-  const anchor = hasVerticalAnchor(rect)
-    ? { verticalDock: rect.verticalDock, verticalOffset: rect.verticalOffset }
-    : getLegacyVerticalAnchor(sized, insets)
+  const anchor = pickScrollMiniVerticalAnchor(rect) ?? getLegacyVerticalAnchor(sized, insets)
 
   const top = anchor.verticalDock === 'top'
     ? insets.top + anchor.verticalOffset
@@ -174,9 +178,7 @@ export function reanchorScrollMiniPlayerRect(rect, aspectRatio = DEFAULT_ASPECT_
  * @returns {string}
  */
 export function serializeScrollMiniPlayerSavedRect(rect) {
-  const anchor = hasVerticalAnchor(rect)
-    ? { verticalDock: rect.verticalDock, verticalOffset: rect.verticalOffset }
-    : getScrollMiniVerticalAnchor(rect)
+  const anchor = pickScrollMiniVerticalAnchor(rect) ?? getScrollMiniVerticalAnchor(rect)
 
   return JSON.stringify({
     left: rect.left,

--- a/src/renderer/helpers/scrollMiniPlayer.js
+++ b/src/renderer/helpers/scrollMiniPlayer.js
@@ -35,7 +35,7 @@ export function getScrollMiniInlineLayoutHeight(container, lastKnownHeight = 0) 
   return Math.max(measuredHeight, expectedHeight, lastKnownHeight)
 }
 
-/** @typedef {{ left: number, top: number, width: number, height: number, dock: 'left' | 'right' }} ScrollMiniPlayerRect */
+/** @typedef {{ left: number, top: number, width: number, height: number, dock: 'left' | 'right', verticalDock?: 'top' | 'bottom', verticalOffset?: number }} ScrollMiniPlayerRect */
 
 /** @type {ScrollMiniPlayerRect | null} */
 let savedScrollMiniPlayerRect = null
@@ -86,9 +86,66 @@ export function parseScrollMiniPlayerSavedRect(value) {
       width: parsed.width,
       height: parsed.height,
       dock: parsed.dock === 'left' ? 'left' : 'right',
+      ...(hasVerticalAnchor(parsed)
+        ? { verticalDock: parsed.verticalDock, verticalOffset: parsed.verticalOffset }
+        : {}),
     }
   } catch {
     return null
+  }
+}
+
+/**
+ * @param {Partial<ScrollMiniPlayerRect> | null | undefined} rect
+ * @returns {boolean}
+ */
+function hasVerticalAnchor(rect) {
+  return (rect?.verticalDock === 'top' || rect?.verticalDock === 'bottom') &&
+    Number.isFinite(rect.verticalOffset)
+}
+
+/**
+ * Which vertical edge the rect is parked at, and how far from it. Absolute
+ * coordinates go stale the moment the window is resized, so the anchor is what
+ * gets remembered and replayed against the new viewport.
+ *
+ * @param {ScrollMiniPlayerRect} rect
+ * @param {{ top: number, bottom: number }} [insets]
+ * @returns {{ verticalDock: 'top' | 'bottom', verticalOffset: number }}
+ */
+export function getScrollMiniVerticalAnchor(rect, insets = getViewportInsets()) {
+  const topOffset = rect.top - insets.top
+  const bottomOffset = window.innerHeight - insets.bottom - (rect.top + rect.height)
+
+  return bottomOffset <= topOffset
+    ? { verticalDock: 'bottom', verticalOffset: Math.max(0, bottomOffset) }
+    : { verticalDock: 'top', verticalOffset: Math.max(0, topOffset) }
+}
+
+/**
+ * Re-place a rect against the current viewport, keeping it the same distance
+ * from the edges it was docked to. Without this a window that grew while the
+ * player was docked (or closed) strands it mid-screen, because its remembered
+ * left/top were only edge-aligned for the old viewport.
+ *
+ * @param {ScrollMiniPlayerRect} rect
+ * @param {number} [aspectRatio]
+ * @returns {ScrollMiniPlayerRect}
+ */
+export function reanchorScrollMiniPlayerRect(rect, aspectRatio = DEFAULT_ASPECT_RATIO) {
+  const insets = getViewportInsets()
+  const sized = clampScrollMiniPlayerRect(rect, aspectRatio)
+  const anchor = hasVerticalAnchor(rect)
+    ? { verticalDock: rect.verticalDock, verticalOffset: rect.verticalOffset }
+    : getScrollMiniVerticalAnchor(sized, insets)
+
+  const top = anchor.verticalDock === 'top'
+    ? insets.top + anchor.verticalOffset
+    : window.innerHeight - insets.bottom - sized.height - anchor.verticalOffset
+
+  return {
+    ...clampScrollMiniPlayerRect(snapScrollMiniPlayerToEdge({ ...sized, top }, insets), aspectRatio),
+    ...anchor,
   }
 }
 
@@ -97,12 +154,17 @@ export function parseScrollMiniPlayerSavedRect(value) {
  * @returns {string}
  */
 export function serializeScrollMiniPlayerSavedRect(rect) {
+  const anchor = hasVerticalAnchor(rect)
+    ? { verticalDock: rect.verticalDock, verticalOffset: rect.verticalOffset }
+    : getScrollMiniVerticalAnchor(rect)
+
   return JSON.stringify({
     left: rect.left,
     top: rect.top,
     width: rect.width,
     height: rect.height,
     dock: rect.dock,
+    ...anchor,
   })
 }
 

--- a/src/renderer/helpers/scrollMiniPlayer.js
+++ b/src/renderer/helpers/scrollMiniPlayer.js
@@ -105,7 +105,9 @@ export function parseScrollMiniPlayerSavedRect(value) {
 export function pickScrollMiniVerticalAnchor(rect) {
   const parked = rect?.verticalDock === 'top' || rect?.verticalDock === 'bottom'
 
-  return parked && Number.isFinite(rect.verticalOffset)
+  // The offset is a distance from an inset, so anything negative is corrupt
+  // rather than a position, and inferring one from the geometry beats replaying it.
+  return parked && Number.isFinite(rect.verticalOffset) && rect.verticalOffset >= 0
     ? { verticalDock: rect.verticalDock, verticalOffset: rect.verticalOffset }
     : null
 }

--- a/src/renderer/helpers/scrollMiniPlayer.js
+++ b/src/renderer/helpers/scrollMiniPlayer.js
@@ -123,6 +123,26 @@ export function getScrollMiniVerticalAnchor(rect, insets = getViewportInsets()) 
 }
 
 /**
+ * Anchor for rects saved before the anchor was recorded. Their coordinates were
+ * measured against a viewport we no longer know, so they are only worth reading
+ * while they still put the player at an edge: after a big enough resize the
+ * stale position can be nearest the opposite edge, which would keep the player
+ * stranded in the middle. Falling back to the bottom matches a fresh player, and
+ * only ever happens once, since activation persists a real anchor.
+ *
+ * @param {ScrollMiniPlayerRect} rect
+ * @param {{ top: number, bottom: number }} insets
+ * @returns {{ verticalDock: 'top' | 'bottom', verticalOffset: number }}
+ */
+function getLegacyVerticalAnchor(rect, insets) {
+  const anchor = getScrollMiniVerticalAnchor(rect, insets)
+
+  return anchor.verticalOffset <= EDGE_SNAP
+    ? anchor
+    : { verticalDock: 'bottom', verticalOffset: 0 }
+}
+
+/**
  * Re-place a rect against the current viewport, keeping it the same distance
  * from the edges it was docked to. Without this a window that grew while the
  * player was docked (or closed) strands it mid-screen, because its remembered
@@ -137,7 +157,7 @@ export function reanchorScrollMiniPlayerRect(rect, aspectRatio = DEFAULT_ASPECT_
   const sized = clampScrollMiniPlayerRect(rect, aspectRatio)
   const anchor = hasVerticalAnchor(rect)
     ? { verticalDock: rect.verticalDock, verticalOffset: rect.verticalOffset }
-    : getScrollMiniVerticalAnchor(sized, insets)
+    : getLegacyVerticalAnchor(sized, insets)
 
   const top = anchor.verticalDock === 'top'
     ? insets.top + anchor.verticalOffset

--- a/tests/unit/release-notes.test.mjs
+++ b/tests/unit/release-notes.test.mjs
@@ -27,6 +27,19 @@ const categoryMarkers = (category) => `
 <!-- release-note-category:end -->
 `
 
+// Pull request bodies have to keep every marker pair of the template, so the
+// fixtures compose them the same way the template does.
+function pullRequestBody(category, { note = '', images = '' } = {}) {
+  return `${categoryMarkers(category)}
+<!-- release-note:start -->
+${note}
+<!-- release-note:end -->
+<!-- release-note-image:start -->
+${images}
+<!-- release-note-image:end -->
+`
+}
+
 function png(width, height) {
   const buffer = Buffer.alloc(24)
 
@@ -74,7 +87,7 @@ function webp(type, width, height) {
 test('every pull request requires exactly one release note category', () => {
   assert.deepEqual(validatePullRequestEvent({
     pull_request: {
-      body: categoryMarkers('Not noteworthy'),
+      body: pullRequestBody('Not noteworthy'),
     },
   }), {
     category: 'Not noteworthy',
@@ -82,9 +95,11 @@ test('every pull request requires exactly one release note category', () => {
 
   assert.throws(() => validatePullRequestEvent({
     pull_request: {
-      body: '',
+      body: pullRequestBody('None of them'),
     },
-  }), /Select one release note category/)
+  }), /Select exactly one release note category/)
+
+  assert.throws(() => parseReleaseNoteCategory(''), /Select one release note category/)
 
   assert.throws(() => parseReleaseNoteCategory(`
 <!-- release-note-category:start -->
@@ -97,9 +112,29 @@ test('every pull request requires exactly one release note category', () => {
 test('release notes are required for noteworthy categories', () => {
   assert.throws(() => validatePullRequestEvent({
     pull_request: {
-      body: categoryMarkers('Highlights'),
+      body: pullRequestBody('Highlights'),
     },
   }), /Fill in the release note section/)
+})
+
+test('pull request bodies have to keep every release note marker', () => {
+  const body = pullRequestBody('Not noteworthy')
+  const markers = ['release-note-category', 'release-note', 'release-note-image']
+
+  for (const marker of markers) {
+    const withoutMarker = body.replace(`<!-- ${marker}:start -->`, '')
+
+    assert.throws(
+      () => validatePullRequestEvent({ pull_request: { body: withoutMarker } }),
+      new RegExp(`Keep the ${marker} markers`),
+      `removing the ${marker} markers has to be rejected`,
+    )
+  }
+
+  assert.throws(
+    () => validatePullRequestEvent({ pull_request: { body: '' } }),
+    /Keep the release-note-category markers/,
+  )
 })
 
 test('paginated pull request results are flattened', () => {
@@ -310,27 +345,17 @@ ${NOTE_MARKERS}
       title: 'Compact player',
     },
     {
-      body: `
-${categoryMarkers('More improvements')}
-<!-- release-note:start -->
-Adds keyboard shortcuts.
-<!-- release-note:end -->
-`,
+      body: pullRequestBody('More improvements', { note: 'Adds keyboard shortcuts.' }),
       number: 43,
       title: 'Keyboard shortcuts',
     },
     {
-      body: `
-${categoryMarkers('Fixed bugs')}
-<!-- release-note:start -->
-Fixed videos failing to load.
-<!-- release-note:end -->
-`,
+      body: pullRequestBody('Fixed bugs', { note: 'Fixed videos failing to load.' }),
       number: 44,
       title: 'Fix video loading',
     },
     {
-      body: categoryMarkers('Not noteworthy'),
+      body: pullRequestBody('Not noteworthy'),
       number: 45,
       title: 'Refactor tests',
     },
@@ -362,10 +387,7 @@ Fixed videos failing to load.
 test('empty release note categories are omitted', async () => {
   const result = await renderReleaseNotes([
     {
-      body: `
-${categoryMarkers('Fixed bugs')}
-${NOTE_MARKERS}
-`,
+      body: pullRequestBody('Fixed bugs', { note: 'Adds a compact player.' }),
       number: 42,
       title: 'Compact player',
     },
@@ -380,7 +402,7 @@ ${NOTE_MARKERS}
 test('a release with only non-noteworthy pull requests is rejected', async () => {
   await assert.rejects(
     renderReleaseNotes([{
-      body: categoryMarkers('Not noteworthy'),
+      body: pullRequestBody('Not noteworthy'),
       number: 42,
       title: 'Refactor tests',
     }]),
@@ -390,7 +412,7 @@ test('a release with only non-noteworthy pull requests is rejected', async () =>
 
 test('nightly releases can render a fallback when there are no noteworthy changes', async () => {
   const result = await renderReleaseNotes([{
-    body: categoryMarkers('Not noteworthy'),
+    body: pullRequestBody('Not noteworthy'),
     number: 42,
     title: 'Refactor tests',
   }], {

--- a/tests/unit/scroll-mini-player-insets.test.mjs
+++ b/tests/unit/scroll-mini-player-insets.test.mjs
@@ -8,6 +8,8 @@ import {
   clampScrollMiniPlayerRect,
   parseScrollMiniPlayerSavedRect,
   serializeScrollMiniPlayerSavedRect,
+  getScrollMiniVerticalAnchor,
+  reanchorScrollMiniPlayerRect,
   MARGIN
 } from '../../src/renderer/helpers/scrollMiniPlayer.js'
 
@@ -16,9 +18,10 @@ import {
  * @param {{ left: number, right: number } | null} [options.verticalTabBarRect]
  * @param {number} options.clientWidth usable width (excludes the scrollbar)
  * @param {number} [options.scrollbarWidth]
+ * @param {number} [options.clientHeight]
  */
-function stubViewport ({ verticalTabBarRect = null, clientWidth, scrollbarWidth = 0 }) {
-  global.window = { innerWidth: clientWidth + scrollbarWidth, innerHeight: 800 }
+function stubViewport ({ verticalTabBarRect = null, clientWidth, scrollbarWidth = 0, clientHeight = 800 }) {
+  global.window = { innerWidth: clientWidth + scrollbarWidth, innerHeight: clientHeight }
   global.document = {
     querySelector (selector) {
       if (selector === '.tabBar.vertical' && verticalTabBarRect) {
@@ -96,8 +99,17 @@ test('the left dock edge follows the tab rail width', () => {
 })
 
 // Exactly 16:9 and fits the 800px-tall stub viewport, so activation must
-// preserve it verbatim (including the height, which is derived from the width).
-const SAVED_RECT = { left: 1000, top: 400, width: 512, height: 288, dock: 'right' }
+// preserve its size (the height is derived from the width) and its distance
+// from the edges it is docked to.
+const SAVED_RECT = {
+  left: 1000,
+  top: 400,
+  width: 512,
+  height: 288,
+  dock: 'right',
+  verticalDock: 'bottom',
+  verticalOffset: 96
+}
 
 test('parsing a saved rect round-trips it without consulting the viewport', () => {
   const saved = serializeScrollMiniPlayerSavedRect(SAVED_RECT)
@@ -112,22 +124,52 @@ test('parsing a saved rect round-trips it without consulting the viewport', () =
   assert.deepEqual(parseScrollMiniPlayerSavedRect(saved), SAVED_RECT)
 })
 
-test('restoring while unsized then activating keeps the saved position and size', () => {
+test('the vertical anchor is measured from the nearer edge', () => {
+  stubViewport({ clientWidth: 1585 })
+
+  assert.deepEqual(
+    getScrollMiniVerticalAnchor({ left: 0, top: 400, width: 512, height: 288, dock: 'right' }),
+    { verticalDock: 'bottom', verticalOffset: 96 }
+  )
+  assert.deepEqual(
+    getScrollMiniVerticalAnchor({ left: 0, top: 40, width: 512, height: 288, dock: 'right' }),
+    { verticalDock: 'top', verticalOffset: 24 }
+  )
+})
+
+test('restoring while unsized then activating keeps the saved size and edges', () => {
   const saved = serializeScrollMiniPlayerSavedRect(SAVED_RECT)
 
   // The restore/activation sequence: parse while the tab is still loading...
   stubViewport({ clientWidth: 0 })
   const restored = parseScrollMiniPlayerSavedRect(saved)
 
-  // ...then activation clamps it, once layout has settled.
+  // ...then activation re-anchors it, once layout has settled.
   stubViewport({ clientWidth: 1585, scrollbarWidth: 15 })
-  const activated = clampScrollMiniPlayerRect(restored)
+  const activated = reanchorScrollMiniPlayerRect(restored)
 
   assert.equal(activated.width, SAVED_RECT.width)
   assert.equal(activated.height, SAVED_RECT.height)
-  assert.equal(activated.left, SAVED_RECT.left)
-  assert.equal(activated.top, SAVED_RECT.top)
+  assert.equal(activated.left + activated.width, 1585 - MARGIN)
+  assert.equal(800 - (activated.top + activated.height), MARGIN + SAVED_RECT.verticalOffset)
   assert.equal(activated.dock, 'right')
+})
+
+test('a window that grew while the player was away still docks it to the edge', () => {
+  // Saved against a small window...
+  stubViewport({ clientWidth: 1188, clientHeight: 894 })
+  const saved = serializeScrollMiniPlayerSavedRect(
+    // Parked in the bottom-right corner.
+    { left: 1188 - 16 - 512, top: 894 - 16 - 288, width: 512, height: 288, dock: 'right' }
+  )
+
+  // ...then reopened after the window was maximised. Regression: the stale
+  // absolute left/top left the player floating in the middle of the screen.
+  stubViewport({ clientWidth: 1744, clientHeight: 1041 })
+  const activated = reanchorScrollMiniPlayerRect(parseScrollMiniPlayerSavedRect(saved))
+
+  assert.equal(activated.left + activated.width, 1744 - MARGIN)
+  assert.equal(activated.top + activated.height, 1041 - MARGIN)
 })
 
 test('a restored rect that no longer fits is pulled back into view on activation', () => {

--- a/tests/unit/scroll-mini-player-insets.test.mjs
+++ b/tests/unit/scroll-mini-player-insets.test.mjs
@@ -9,6 +9,7 @@ import {
   parseScrollMiniPlayerSavedRect,
   serializeScrollMiniPlayerSavedRect,
   getScrollMiniVerticalAnchor,
+  pickScrollMiniVerticalAnchor,
   reanchorScrollMiniPlayerRect,
   MARGIN
 } from '../../src/renderer/helpers/scrollMiniPlayer.js'
@@ -170,6 +171,28 @@ test('a window that grew while the player was away still docks it to the edge', 
 
   assert.equal(activated.left + activated.width, 1744 - MARGIN)
   assert.equal(activated.top + activated.height, 1041 - MARGIN)
+})
+
+test('a viewport too short for the saved distance does not forget it', () => {
+  const parked = { ...SAVED_RECT, verticalDock: 'bottom', verticalOffset: 600 }
+
+  // 600px above the bottom does not fit in an 800px-tall viewport, so the rect
+  // has to be clamped...
+  stubViewport({ clientWidth: 1585, clientHeight: 800 })
+  const squeezed = reanchorScrollMiniPlayerRect(parked)
+
+  assert.equal(squeezed.top, MARGIN, 'clamped against the top inset')
+  assert.deepEqual(
+    pickScrollMiniVerticalAnchor(squeezed),
+    { verticalDock: 'bottom', verticalOffset: 600 },
+    'but the distance it should keep survives the clamp'
+  )
+
+  // ...and is restored once there is room for it again.
+  stubViewport({ clientWidth: 1585, clientHeight: 1200 })
+  const restored = reanchorScrollMiniPlayerRect(squeezed)
+
+  assert.equal(1200 - (restored.top + restored.height), MARGIN + 600)
 })
 
 test('a legacy rect without an anchor is docked to the bottom once it is adrift', () => {

--- a/tests/unit/scroll-mini-player-insets.test.mjs
+++ b/tests/unit/scroll-mini-player-insets.test.mjs
@@ -252,3 +252,21 @@ test('a malformed saved rect is rejected', () => {
     null
   )
 })
+
+test('a corrupt anchor is dropped instead of replayed', () => {
+  stubViewport({ clientWidth: 1585 })
+
+  // An offset is a distance from an inset, so these cannot describe a position.
+  for (const verticalOffset of [-100, NaN, 'nope']) {
+    const saved = JSON.stringify({ ...SAVED_RECT, verticalDock: 'top', verticalOffset })
+
+    assert.equal(pickScrollMiniVerticalAnchor(parseScrollMiniPlayerSavedRect(saved)), null)
+  }
+
+  // The rect itself still survives, with an anchor inferred from its geometry.
+  const saved = JSON.stringify({ ...SAVED_RECT, verticalDock: 'bottom', verticalOffset: -100 })
+  const activated = reanchorScrollMiniPlayerRect(parseScrollMiniPlayerSavedRect(saved))
+
+  assert.equal(activated.top + activated.height, 800 - MARGIN)
+  assert.equal(activated.verticalOffset, 0)
+})

--- a/tests/unit/scroll-mini-player-insets.test.mjs
+++ b/tests/unit/scroll-mini-player-insets.test.mjs
@@ -172,6 +172,35 @@ test('a window that grew while the player was away still docks it to the edge', 
   assert.equal(activated.top + activated.height, 1041 - MARGIN)
 })
 
+test('a legacy rect without an anchor is docked to the bottom once it is adrift', () => {
+  // Saved before the anchor existed: bottom-right in an 894-tall window.
+  const legacy = JSON.stringify(
+    { left: 660, top: 590, width: 512, height: 288, dock: 'right' }
+  )
+
+  // Its stale top is now nearer the top edge than the bottom one, so reading the
+  // position at face value would leave the player floating mid-screen.
+  stubViewport({ clientWidth: 1744, clientHeight: 2000 })
+  const activated = reanchorScrollMiniPlayerRect(parseScrollMiniPlayerSavedRect(legacy))
+
+  assert.equal(activated.verticalDock, 'bottom')
+  assert.equal(activated.top + activated.height, 2000 - MARGIN)
+})
+
+test('a legacy rect still parked at an edge keeps its offset', () => {
+  // Within EDGE_SNAP of the top inset, so it still reads as parked up there.
+  const legacy = JSON.stringify(
+    { left: 16, top: 60, width: 512, height: 288, dock: 'left' }
+  )
+
+  stubViewport({ clientWidth: 1744, clientHeight: 900 })
+  const activated = reanchorScrollMiniPlayerRect(parseScrollMiniPlayerSavedRect(legacy))
+
+  assert.equal(activated.verticalDock, 'top')
+  assert.equal(activated.top, 60)
+  assert.equal(activated.left, MARGIN)
+})
+
 test('a restored rect that no longer fits is pulled back into view on activation', () => {
   const saved = serializeScrollMiniPlayerSavedRect(SAVED_RECT)
 


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Make sure to follow the contributing guidelines. -->
<!-- Important note, we may remove your pull request if you do not use this provided PR template correctly. -->
<!-- Agent instructions: Preserve every heading, comment, and marker in this template. Never remove or rewrite the release-note-category:start/end, release-note:start/end, or release-note-image:start/end marker pairs. Never remove or rewrite the Release note images section; leave its contents for a human. -->

## Pull Request Type
<!-- Please select what type of pull request this is: [x] -->
- [x] Bugfix
- [ ] Feature Implementation
- [ ] Documentation
- [ ] Other

## Related issue
<!-- Please link the issue your pull request is referring to. -->
<!-- If this pull request fully resolves the relevant issue, put "closes" before the issue number. -->
<!-- Example: "closes #123456". -->

## Description
<!-- Please write a clear and concise description of what the pull request does. -->
The scroll mini player's position was remembered as absolute `left`/`top` coordinates. Those are only edge-aligned for the window size they were saved in, so resizing the window left the player stranded where the old edge used to be — floating in the middle of the screen instead of docked in a corner.

Two paths were affected:

- Resizing while the mini player was open re-docked it horizontally only, so growing the window height left a growing gap below it.
- Resizing while the mini player was inline (scrolled up, or on another tab) re-docked it on neither axis, because activation only clamped the saved rect — and a small rect still fits inside a bigger viewport.

The player now remembers which edges it is docked to and how far it sits from them, and replays that against the current viewport on activation and on every resize. Saved positions from older versions still load and are re-docked on first use.

## Release note category
<!-- Select exactly one category. Every pull request must select one. -->
<!-- release-note-category:start -->
- [ ] Not noteworthy
- [ ] Highlights
- [ ] More improvements
- [x] Fixed bugs
<!-- release-note-category:end -->

## Release note
<!-- Required unless "Not noteworthy" is selected. -->
<!-- Write one concise, user-facing entry without a leading bullet. -->
<!-- release-note:start -->
Fixed the scroll mini player floating in the middle of the screen instead of staying docked in its corner after the window was resized
<!-- release-note:end -->

## Release note images
<!-- Human-only: Agents must preserve this entire section and leave it empty. -->
<!-- Optional. Paste one or more Markdown images or HTML image tags here. -->
<!-- The release notes will use an HTML image tag and limit images taller than 300 pixels. -->
<!-- release-note-image:start -->

<!-- release-note-image:end -->

## Testing
<!-- How can reviewers verify that the PR produces correct results? -->
<!-- Please provide instructions so that others can ensure that your pull request would produce correct results. For examples see, https://github.com/FreeTubeApp/FreeTube/pull/5743, https://github.com/FreeTubeApp/FreeTube/pull/7349, https://github.com/FreeTubeApp/FreeTube/pull/5125, https://github.com/FreeTubeApp/FreeTube/pull/7338 -->
<!-- Agent instructions: Only write human-facing steps that explain how to verify the change while running this branch in dev mode. Include expected results and, when applicable, helpful console snippets for interactive verification. Do not include automated checks, commands, results, pass counts, or CI status. -->
Make sure the scroll mini player is enabled in the player settings, then start a video in a **non-maximised** window.

1. Scroll down past the player until the mini player appears — it docks in the bottom corner.
2. Resize the window larger (or maximise it) while the mini player is showing. It should stay flush in the corner, 16px from the bottom and side edges. Before this change it stayed where the old bottom edge was, leaving a large gap.
3. Scroll back up so the player returns inline, resize the window again, then scroll down. The mini player should reappear docked in the corner, not floating mid-screen.
4. Drag the mini player to another position (e.g. the top-left), then repeat steps 2–3: it should keep that corner and its distance from those edges instead of drifting.
5. Toggling or resizing the vertical tab bar while the mini player is showing should also keep it docked clear of the rail.

## Additional context
<!-- Add any other context about the pull request here. -->
Horizontal re-docking on resize already existed; the vertical axis and the re-activation path were missing, which is why the player could end up offset on both axes after a maximise.
