### PR TITLE
test: cover the required release note markers

### DIFF
--- a/tests/unit/release-notes.test.mjs
+++ b/tests/unit/release-notes.test.mjs
@@ -27,6 +27,19 @@ const categoryMarkers = (category) => `
 <!-- release-note-category:end -->
 `
 
+// Pull request bodies have to keep every marker pair of the template, so the
+// fixtures compose them the same way the template does.
+function pullRequestBody(category, { note = '', images = '' } = {}) {
+  return `${categoryMarkers(category)}
+<!-- release-note:start -->
+${note}
+<!-- release-note:end -->
+<!-- release-note-image:start -->
+${images}
+<!-- release-note-image:end -->
+`
+}
+
 function png(width, height) {
   const buffer = Buffer.alloc(24)
 
@@ -74,7 +87,7 @@ function webp(type, width, height) {
 test('every pull request requires exactly one release note category', () => {
   assert.deepEqual(validatePullRequestEvent({
     pull_request: {
-      body: categoryMarkers('Not noteworthy'),
+      body: pullRequestBody('Not noteworthy'),
     },
   }), {
     category: 'Not noteworthy',
@@ -82,9 +95,11 @@ test('every pull request requires exactly one release note category', () => {
 
   assert.throws(() => validatePullRequestEvent({
     pull_request: {
-      body: '',
+      body: pullRequestBody('None of them'),
     },
-  }), /Select one release note category/)
+  }), /Select exactly one release note category/)
+
+  assert.throws(() => parseReleaseNoteCategory(''), /Select one release note category/)
 
   assert.throws(() => parseReleaseNoteCategory(`
 <!-- release-note-category:start -->
@@ -97,9 +112,29 @@ test('every pull request requires exactly one release note category', () => {
 test('release notes are required for noteworthy categories', () => {
   assert.throws(() => validatePullRequestEvent({
     pull_request: {
-      body: categoryMarkers('Highlights'),
+      body: pullRequestBody('Highlights'),
     },
   }), /Fill in the release note section/)
+})
+
+test('pull request bodies have to keep every release note marker', () => {
+  const body = pullRequestBody('Not noteworthy')
+  const markers = ['release-note-category', 'release-note', 'release-note-image']
+
+  for (const marker of markers) {
+    const withoutMarker = body.replace(`<!-- ${marker}:start -->`, '')
+
+    assert.throws(
+      () => validatePullRequestEvent({ pull_request: { body: withoutMarker } }),
+      new RegExp(`Keep the ${marker} markers`),
+      `removing the ${marker} markers has to be rejected`,
+    )
+  }
+
+  assert.throws(
+    () => validatePullRequestEvent({ pull_request: { body: '' } }),
+    /Keep the release-note-category markers/,
+  )
 })
 
 test('paginated pull request results are flattened', () => {
@@ -310,27 +345,17 @@ ${NOTE_MARKERS}
       title: 'Compact player',
     },
     {
-      body: `
-${categoryMarkers('More improvements')}
-<!-- release-note:start -->
-Adds keyboard shortcuts.
-<!-- release-note:end -->
-`,
+      body: pullRequestBody('More improvements', { note: 'Adds keyboard shortcuts.' }),
       number: 43,
       title: 'Keyboard shortcuts',
     },
     {
-      body: `
-${categoryMarkers('Fixed bugs')}
-<!-- release-note:start -->
-Fixed videos failing to load.
-<!-- release-note:end -->
-`,
+      body: pullRequestBody('Fixed bugs', { note: 'Fixed videos failing to load.' }),
       number: 44,
       title: 'Fix video loading',
     },
     {
-      body: categoryMarkers('Not noteworthy'),
+      body: pullRequestBody('Not noteworthy'),
       number: 45,
       title: 'Refactor tests',
     },
@@ -362,10 +387,7 @@ Fixed videos failing to load.
 test('empty release note categories are omitted', async () => {
   const result = await renderReleaseNotes([
     {
-      body: `
-${categoryMarkers('Fixed bugs')}
-${NOTE_MARKERS}
-`,
+      body: pullRequestBody('Fixed bugs', { note: 'Adds a compact player.' }),
       number: 42,
       title: 'Compact player',
     },
@@ -380,7 +402,7 @@ ${NOTE_MARKERS}
 test('a release with only non-noteworthy pull requests is rejected', async () => {
   await assert.rejects(
     renderReleaseNotes([{
-      body: categoryMarkers('Not noteworthy'),
+      body: pullRequestBody('Not noteworthy'),
       number: 42,
       title: 'Refactor tests',
     }]),
@@ -390,7 +412,7 @@ test('a release with only non-noteworthy pull requests is rejected', async () =>
 
 test('nightly releases can render a fallback when there are no noteworthy changes', async () => {
   const result = await renderReleaseNotes([{
-    body: categoryMarkers('Not noteworthy'),
+    body: pullRequestBody('Not noteworthy'),
     number: 42,
     title: 'Refactor tests',
   }], {


### PR DESCRIPTION
## Pull Request Type
- [x] Bugfix
- [ ] Feature Implementation
- [ ] Documentation
- [ ] Other

## Related issue
<!-- Please link the issue your pull request is referring to. -->
None — follow-up to c485d6794.

## Description
c485d6794 made all three release note marker pairs mandatory, but the unit test fixtures only carried the markers each case needed, so `pnpm run test:unit` fails on `development` and therefore on every pull request based on it (for example the `lint` job of #499).

The fixtures now compose a complete pull request body the way the template does, which keeps the stricter parser behaviour intact instead of relaxing it:

- `pullRequestBody(category, { note, images })` builds a body with all three marker pairs
- the missing-category assertion moved to `parseReleaseNoteCategory`, since `validatePullRequestEvent` now reports the absent markers first
- a new case asserts that removing any single marker pair is rejected, which is the behaviour c485d6794 introduced

## Release note category
<!-- Select exactly one category. Every pull request must select one. -->
<!-- release-note-category:start -->
- [x] Not noteworthy
- [ ] Highlights
- [ ] More improvements
- [ ] Fixed bugs
<!-- release-note-category:end -->

## Release note
<!-- release-note:start -->

<!-- release-note:end -->

## Release note images
<!-- release-note-image:start -->

<!-- release-note-image:end -->

## Testing
Run `pnpm run test:unit` on `development` and see six failures in `tests/unit/release-notes.test.mjs`, all reporting "Keep the ... markers in the pull request body". On this branch the same command passes (20 tests in that file).

To check the enforcement itself, open a pull request whose body has one of the marker pairs removed: the Release Note check has to fail with "Keep the &lt;marker&gt; markers in the pull request body".

## Additional context
The alternative would have been to relax the parser so that only the pull request check requires every marker while release note rendering tolerates missing ones. I kept the strict behaviour, since the template now instructs contributors and agents to preserve the markers, and every body carrying a category marker came from a template that had all three. Happy to flip it around if rendering historical pull requests should stay lenient.

