### PR TITLE
Default playback to yt-dlp

### DIFF
--- a/PRIVACY.md
+++ b/PRIVACY.md
@@ -25,7 +25,7 @@ Rows for optional services apply only when the feature is enabled. An IP address
 | Return YouTube Dislike | Configured Return YouTube Dislike operator | IP address, video identifiers, and timing |
 | Enhanced-privacy sync | Configured sync operator | IP address, account identifier, authentication data, encrypted payloads, collection names, payload sizes, revisions, and timing; not the decrypted selected data |
 | Legacy sync | Configured sync operator | IP address, account identifier, authentication data, selected synced data, and timing |
-| `yt-dlp` downloads | YouTube and any proxy configured through custom `yt-dlp` arguments | IP address, requested page and media resources, video identifier, formats, and timing. OpenTubeX's own proxy setting is not automatically passed to `yt-dlp` |
+| `yt-dlp` playback and downloads | YouTube and any proxy configured for `yt-dlp` | IP address, requested page and media resources, video identifier, formats, and timing. OpenTubeX's own proxy setting is not automatically passed to `yt-dlp` |
 
 HTTPS encrypts request paths and payloads in transit, but DNS providers and network operators may still learn destination hostnames and traffic patterns. A VPN or Tor changes which parties see your direct IP address; it does not prevent the destination service from seeing the request itself.
 
@@ -34,4 +34,4 @@ HTTPS encrypts request paths and payloads in transit, but DNS providers and netw
 - To keep app data local, leave synchronization disabled.
 - To prevent a sync operator from reading synced data, use a server that supports enhanced-privacy sync and use a separate, strong privacy passphrase.
 - To avoid sending requests to optional services, leave SponsorBlock, DeArrow, Return YouTube Dislike, and synchronization disabled.
-- To hide your direct IP address from YouTube or optional services, route the relevant requests through a trusted VPN or Tor and verify the proxy configuration. Configure `yt-dlp` separately when downloading.
+- To hide your direct IP address from YouTube or optional services, route the relevant requests through a trusted VPN or Tor and verify the proxy configuration. Configure `yt-dlp` separately when using it for playback or downloads.

--- a/README.md
+++ b/README.md
@@ -185,7 +185,7 @@ experience. Some of its major areas of focus are:
 - Caption appearance controls and a preferred caption language setting
 <img height="250" alt="image" src="https://github.com/user-attachments/assets/0098caa1-ccd6-40d5-bcb8-5daed8e0e15a" />
 
-- Download videos with yt-dlp
+- Reliable video playback and downloads with yt-dlp
 <img width="510" height="273" alt="image" src="https://github.com/user-attachments/assets/cbc33197-d6df-4619-a040-c28fb8a3ba42" />
 
 - Full-screen docks for video info, comments, playlists and chapters

--- a/e2e/tests/offline/settings.spec.mjs
+++ b/e2e/tests/offline/settings.spec.mjs
@@ -697,6 +697,46 @@ test.describe('settings', () => {
   })
 })
 
+test.describe('playback engine migration', () => {
+  test.use({ seed: { settings: { videoPlaybackEngine: 'built-in' } } })
+
+  test('switches existing users to yt-dlp only once', async ({ app }) => {
+    await expect.poll(async () => {
+      const settings = latestSettings(
+        await readFile(path.join(app.userDataDir, 'settings.db'), 'utf8')
+      )
+      return {
+        engine: settings.videoPlaybackEngine,
+        migrated: settings.ytDlpPlaybackEngineDefaultMigration
+      }
+    }).toEqual({ engine: 'yt-dlp', migrated: true })
+
+    await goTo(app.page, 'settings')
+    const generalSection = app.page.locator('[data-section="general"]')
+    const playbackEngine = generalSection.locator('.select').filter({ hasText: 'Playback Engine' })
+    await expect(playbackEngine.locator('select')).toHaveValue('yt-dlp')
+    await expect(
+      app.page.locator('[data-section="experimental"] .select').filter({ hasText: 'Playback Engine' })
+    ).toHaveCount(0)
+
+    await playbackEngine.locator('select').selectOption('built-in')
+    await expect.poll(async () => {
+      const settings = latestSettings(
+        await readFile(path.join(app.userDataDir, 'settings.db'), 'utf8')
+      )
+      return settings.videoPlaybackEngine
+    }).toBe('built-in')
+
+    const { page } = await app.relaunch()
+    await goTo(page, 'settings')
+    await expect(
+      page.locator('[data-section="general"] .select')
+        .filter({ hasText: 'Playback Engine' })
+        .locator('select')
+    ).toHaveValue('built-in')
+  })
+})
+
 test.describe('SponsorBlock highlight settings', () => {
   test.use({
     seed: {

--- a/e2e/tests/offline/settings.spec.mjs
+++ b/e2e/tests/offline/settings.spec.mjs
@@ -737,6 +737,30 @@ test.describe('playback engine migration', () => {
   })
 })
 
+test.describe('playback engine proxy migration', () => {
+  test.use({
+    seed: {
+      settings: {
+        proxyVideos: true,
+        useProxy: false,
+        videoPlaybackEngine: 'built-in'
+      }
+    }
+  })
+
+  test('preserves Invidious media proxying for existing users', async ({ app }) => {
+    await expect.poll(async () => {
+      const settings = latestSettings(
+        await readFile(path.join(app.userDataDir, 'settings.db'), 'utf8')
+      )
+      return {
+        engine: settings.videoPlaybackEngine,
+        migrated: settings.ytDlpPlaybackEngineDefaultMigration
+      }
+    }).toEqual({ engine: 'built-in', migrated: true })
+  })
+})
+
 test.describe('SponsorBlock highlight settings', () => {
   test.use({
     seed: {

--- a/src/renderer/App.vue
+++ b/src/renderer/App.vue
@@ -587,10 +587,10 @@ const tabSwitcherSelectedTabId = computed(() => {
 })
 
 /**
- * Falls back to OpenTubeX-managed download tools when the configured system
+ * Falls back to OpenTubeX-managed external software when the configured system
  * executables are unavailable and updates every selected managed executable.
  */
-async function initializeManagedDownloadTools() {
+async function initializeManagedExternalSoftware() {
   if (!isElectron) {
     return
   }
@@ -766,7 +766,7 @@ onMounted(async () => {
     dataReady.value = true
 
     await nextTick()
-    initializeManagedDownloadTools().catch(error => console.error('Failed to initialize managed download tools', error))
+    initializeManagedExternalSoftware().catch(error => console.error('Failed to initialize managed external software', error))
 
     setTimeout(() => {
       checkForNewUpdates()

--- a/src/renderer/components/ExperimentalSettings/ExperimentalSettings.css
+++ b/src/renderer/components/ExperimentalSettings/ExperimentalSettings.css
@@ -3,13 +3,3 @@
   font-weight: bold;
   padding-inline: 4%;
 }
-
-.playbackEngineSelect {
-  inline-size: 250px;
-}
-
-@media only screen and (width <= 800px) {
-  .playbackEngineSelect {
-    inline-size: calc(100% - 28px);
-  }
-}

--- a/src/renderer/components/ExperimentalSettings/ExperimentalSettings.vue
+++ b/src/renderer/components/ExperimentalSettings/ExperimentalSettings.vue
@@ -5,19 +5,6 @@
     <p class="experimental-warning">
       {{ $t('Settings.Experimental Settings.Warning') }}
     </p>
-    <FtFlexBox v-if="USING_ELECTRON">
-      <FtSelect
-        class="playbackEngineSelect"
-        :placeholder="$t('Settings.Experimental Settings.Playback Engine.Playback Engine')"
-        :value="videoPlaybackEngine"
-        setting-key="videoPlaybackEngine"
-        :select-names="playbackEngineNames"
-        :select-values="PLAYBACK_ENGINE_VALUES"
-        :tooltip="$t('Tooltips.Experimental Settings.Playback Engine')"
-        :icon="['fas', 'circle-play']"
-        @change="updateVideoPlaybackEngine"
-      />
-    </FtFlexBox>
     <FtFlexBox>
       <FtToggleSwitch
         tooltip-position="top"
@@ -42,37 +29,13 @@
 </template>
 
 <script setup>
-import { computed, onMounted, ref } from 'vue'
-import { useI18n } from 'vue-i18n'
+import { onMounted, ref } from 'vue'
 
 import FtSettingsSection from '../FtSettingsSection/FtSettingsSection.vue'
 import FtFlexBox from '../ft-flex-box/ft-flex-box.vue'
-import FtSelect from '../FtSelect/FtSelect.vue'
 import FtToggleSwitch from '../FtToggleSwitch/FtToggleSwitch.vue'
 import FtIconPackSwitcher from '../FtIconPackSwitcher/FtIconPackSwitcher.vue'
 import FtPrompt from '../FtPrompt/FtPrompt.vue'
-
-import store from '../../store/index'
-
-const { t } = useI18n()
-
-const USING_ELECTRON = !!process.env.IS_ELECTRON
-const PLAYBACK_ENGINE_VALUES = ['yt-dlp', 'built-in']
-
-const playbackEngineNames = computed(() => [
-  t('Settings.Experimental Settings.Playback Engine.yt-dlp'),
-  t('Settings.Experimental Settings.Playback Engine.Built-in')
-])
-
-/** @type {import('vue').ComputedRef<'yt-dlp' | 'built-in'>} */
-const videoPlaybackEngine = computed(() => store.getters.getVideoPlaybackEngine)
-
-/**
- * @param {'yt-dlp' | 'built-in'} value
- */
-function updateVideoPlaybackEngine(value) {
-  store.dispatch('updateVideoPlaybackEngine', value)
-}
 
 const replaceHttpCacheLoading = ref(true)
 const replaceHttpCache = ref(false)

--- a/src/renderer/components/GeneralSettings/GeneralSettings.vue
+++ b/src/renderer/components/GeneralSettings/GeneralSettings.vue
@@ -71,6 +71,17 @@
     </div>
     <div class="switchGrid">
       <FtSelect
+        v-if="USING_ELECTRON"
+        :placeholder="t('Settings.General Settings.Playback Engine.Playback Engine')"
+        :value="videoPlaybackEngine"
+        setting-key="videoPlaybackEngine"
+        :select-names="playbackEngineNames"
+        :select-values="PLAYBACK_ENGINE_VALUES"
+        :tooltip="t('Tooltips.General Settings.Playback Engine')"
+        :icon="['fas', 'circle-play']"
+        @change="updateVideoPlaybackEngine"
+      />
+      <FtSelect
         :placeholder="t('Settings.General Settings.Preferred API Backend.Preferred API Backend')"
         :value="backendPreference"
         :select-names="backendNames"
@@ -272,9 +283,25 @@ import { translateWindowTitle } from '../../helpers/strings'
 const USING_ELECTRON = !!process.env.IS_ELECTRON
 const SUPPORTS_LOCAL_API = !!process.env.SUPPORTS_LOCAL_API
 const IS_MAC = process.platform === 'darwin'
+const PLAYBACK_ENGINE_VALUES = ['yt-dlp', 'built-in']
 
 const { t } = useI18n()
 const router = useRouter()
+
+const playbackEngineNames = computed(() => [
+  t('Settings.General Settings.Playback Engine.yt-dlp'),
+  t('Settings.General Settings.Playback Engine.Built-in')
+])
+
+/** @type {import('vue').ComputedRef<'yt-dlp' | 'built-in'>} */
+const videoPlaybackEngine = computed(() => store.getters.getVideoPlaybackEngine)
+
+/**
+ * @param {'yt-dlp' | 'built-in'} value
+ */
+function updateVideoPlaybackEngine(value) {
+  store.dispatch('updateVideoPlaybackEngine', value)
+}
 
 // The 'minimize' event doesn't fire on wayland
 // https://github.com/electron/electron/issues/51766

--- a/src/renderer/store/modules/settings.js
+++ b/src/renderer/store/modules/settings.js
@@ -754,8 +754,20 @@ const customActions = {
         entry => entry._id === YT_DLP_PLAYBACK_ENGINE_MIGRATION_SETTING
       )
       if (!hasMigratedPlaybackEngine) {
-        await dispatch('updateVideoPlaybackEngine', 'yt-dlp')
-        await DBSettingHandlers.upsert(YT_DLP_PLAYBACK_ENGINE_MIGRATION_SETTING, true)
+        try {
+          // Invidious media proxying cannot be passed to yt-dlp. Keep the built-in
+          // engine when it is the user's only protection against direct requests.
+          if (!state.proxyVideos || state.useProxy) {
+            await DBSettingHandlers.upsert('videoPlaybackEngine', 'yt-dlp')
+            commit('setVideoPlaybackEngine', 'yt-dlp')
+          }
+
+          // Persist this only after the engine update above succeeds, so a failed
+          // write is retried on the next launch.
+          await DBSettingHandlers.upsert(YT_DLP_PLAYBACK_ENGINE_MIGRATION_SETTING, true)
+        } catch (error) {
+          console.error('Failed to migrate the playback engine to yt-dlp', error)
+        }
       }
 
       if (legacyProgressToastEntry && !hasProgressToastSetting) {

--- a/src/renderer/store/modules/settings.js
+++ b/src/renderer/store/modules/settings.js
@@ -16,6 +16,8 @@ import { DEFAULT_FIXED_TAB_WIDTH } from '../../constants/tabWidth'
 import { setReducedMotionPreference } from '../../helpers/reducedMotion'
 import { DEFAULT_SEARCH_ENGINES_SETTING } from '../../../searchEngines'
 
+const YT_DLP_PLAYBACK_ENGINE_MIGRATION_SETTING = 'ytDlpPlaybackEngineDefaultMigration'
+
 /*
  * Due to the complexity of the settings module in FreeTube, a more
  * in-depth explanation for adding new settings is required.
@@ -218,7 +220,7 @@ const state = {
   externalPlayerIgnoreDefaultArgs: false,
   externalPlayerCustomArgs: '[]',
   showAddedExternalPlayerCustomArgs: true,
-  videoPlaybackEngine: 'built-in',
+  videoPlaybackEngine: 'yt-dlp',
   ytDlpSource: 'system',
   ytDlpChannel: 'stable',
   ytDlpPath: '',
@@ -745,6 +747,16 @@ const customActions = {
       const hasScrollMiniSetting = userSettings.some(entry => entry._id === 'scrollMiniPlayerEnabled')
       const legacyProgressToastEntry = userSettings.find(entry => entry._id === 'showSubscriptionRefreshToast')
       const hasProgressToastSetting = userSettings.some(entry => entry._id === 'showProgressBarToast')
+
+      // Switch every existing installation to the new default once, while allowing
+      // users to select the built-in engine again afterwards.
+      const hasMigratedPlaybackEngine = userSettings.some(
+        entry => entry._id === YT_DLP_PLAYBACK_ENGINE_MIGRATION_SETTING
+      )
+      if (!hasMigratedPlaybackEngine) {
+        await dispatch('updateVideoPlaybackEngine', 'yt-dlp')
+        await DBSettingHandlers.upsert(YT_DLP_PLAYBACK_ENGINE_MIGRATION_SETTING, true)
+      }
 
       if (legacyProgressToastEntry && !hasProgressToastSetting) {
         await dispatch('updateShowProgressBarToast', legacyProgressToastEntry.value === true)

--- a/static/locales/de-DE.yaml
+++ b/static/locales/de-DE.yaml
@@ -234,6 +234,10 @@ Settings:
   Settings: Einstellungen
   General Settings:
     General Settings: Allgemein
+    Playback Engine:
+      Playback Engine: Wiedergabe-Engine
+      yt-dlp: yt-dlp
+      Built-in: Integriert
     Fallback to Non-Preferred Backend on Failure: Bei Ausfall auf nicht bevorzugtes Backend zurückgreifen
     Enable Search Suggestions: Suchvorschläge aktivieren
     Default Landing Page: Standard-Startseite
@@ -761,7 +765,7 @@ Settings:
     Ignore Default Arguments: Standardargumente ignorieren
   Download Settings:
     Download Settings: Downloads
-    Managed Tools Download Started Template: 'Für das Herunterladen von Videos erforderliche Tools wurden nicht gefunden: {tools}. Verwaltete Kopien werden heruntergeladen…'
+    Managed Tools Download Started Template: 'Erforderliche externe Software wurde nicht gefunden: {tools}. Verwaltete Kopien werden heruntergeladen…'
     Managed Tools Download Finished Template: 'Herunterladen von {tools} abgeschlossen'
     Managed Tools Update Started Template: 'Für {tools} wurde ein Update gefunden. Es wird heruntergeladen…'
     Managed Tools Update Finished Template: 'Aktualisierung von {tools} abgeschlossen'
@@ -809,10 +813,6 @@ Settings:
   Experimental Settings:
     Experimental Settings: Experimentell
     Warning: Diese Einstellungen sind experimentell und können zu Abstürzen führen, wenn sie aktiviert sind. Es wird dringend empfohlen, Backups zu erstellen. Verwendung auf eigene Gefahr!
-    Playback Engine:
-      Playback Engine: Wiedergabe-Engine
-      yt-dlp: yt-dlp
-      Built-in: Integriert
     Replace HTTP Cache: HTTP-Cache ersetzen
   Password Dialog:
     Password: Passwort
@@ -1312,6 +1312,7 @@ Download From Site: Von der Website herunterladen
 Version {versionNumber} is now available!  Click for more details: Version {versionNumber} ist jetzt verfügbar!  Für mehr Details klicken
 Tooltips:
   General Settings:
+    Playback Engine: Legt fest, welche Engine die Videostreams ermittelt. yt-dlp muss verfügbar sein, wenn es ausgewählt ist.
     Thumbnail Preference: Alle Vorschaubilder in OpenTubeX werden verpixelt, versteckt oder durch ein Einzelbild aus dem Video ersetzt, anstatt das Standard-Vorschaubild anzuzeigen.
     Invidious Instance: Die Invidious-Instanz, mit der sich OpenTubeX für API-Aufrufe verbinden wird.
     Fallback to Non-Preferred Backend on Failure: Wenn deine bevorzugte API ein Problem hat, wird OpenTubeX automatisch versuchen, deine nicht-bevorzugte API als Ausweichmethode zu verwenden, wenn sie aktiviert ist.
@@ -1368,7 +1369,6 @@ Tooltips:
     yt-dlp Executable Path: Standardmäßig nimmt OpenTubeX an, dass yt-dlp über die PATH-Umgebungsvariable gefunden werden kann. Falls nötig, kann hier ein benutzerdefinierter Pfad festgelegt werden.
     FFmpeg Executable Path: FFmpeg wird zum Zusammenführen von getrennten Video- und Audiospuren sowie zur Audiokonvertierung benötigt. Standardmäßig nimmt OpenTubeX an, dass FFmpeg über die PATH-Umgebungsvariable gefunden werden kann. Falls nötig, kann hier ein benutzerdefinierter Pfad festgelegt werden.
   Experimental Settings:
-    Playback Engine: Womit die Videostreams ermittelt werden. Für yt-dlp muss dieses verfügbar sein.
     Replace HTTP Cache: Deaktiviert den festplattenbasierten HTTP-Cache von Electron und aktiviert einen benutzerdefinierten In-Memory-Image-Cache. Dies führt zu einer erhöhten RAM-Auslastung.
   Distraction Free Settings:
     Hide Channels: Gib eine Kanal-ID ein, um zu verhindern, dass alle Videos, Playlists und der Kanal selbst in der Suche, den Trends, den beliebtesten und den empfohlenen Videos angezeigt werden. Die eingegebene Kanal-ID muss vollständig übereinstimmen, und es wird zwischen Groß- und Kleinschreibung unterschieden.

--- a/static/locales/en-US.yaml
+++ b/static/locales/en-US.yaml
@@ -353,6 +353,10 @@ Settings:
     app needs to restart for changes to take effect. Restart and apply change?
   General Settings:
     General Settings: General
+    Playback Engine:
+      Playback Engine: Playback Engine
+      yt-dlp: yt-dlp
+      Built-in: Built-in
     Check for Updates: Check for Updates
     Confirm Before Closing App: Confirm before closing OpenTubeX
     Fallback to Non-Preferred Backend on Failure: Fallback to Non-Preferred Backend
@@ -718,7 +722,7 @@ Settings:
         Name: None
   Download Settings:
     Download Settings: Downloads
-    Managed Tools Download Started Template: 'Tools required to download videos were not found: {tools}. Downloading managed copies…'
+    Managed Tools Download Started Template: 'Required external software was not found: {tools}. Downloading managed copies…'
     Managed Tools Download Finished Template: 'Finished downloading {tools}'
     Managed Tools Update Started Template: 'An update was found for {tools}. Downloading…'
     Managed Tools Update Finished Template: 'Finished updating {tools}'
@@ -1034,10 +1038,6 @@ Settings:
   Experimental Settings:
     Experimental Settings: Experimental
     Warning: These settings are experimental, they may cause crashes while enabled. Making backups is highly recommended. Use at your own risk!
-    Playback Engine:
-      Playback Engine: Playback Engine
-      yt-dlp: yt-dlp
-      Built-in: Built-in
     Replace HTTP Cache: Replace HTTP Cache
   Password Dialog:
     Password: Password
@@ -1638,6 +1638,7 @@ Description:
 #Tooltips
 Tooltips:
   General Settings:
+    Playback Engine: Which engine obtains the video streams. yt-dlp must be available when selected.
     Avoid translation: |
       Disable YouTube's autotranslation of title, description and chapters of a video.
       Too many requests, such as fetching video titles across lists, may temporarily
@@ -1738,7 +1739,6 @@ Tooltips:
     Use YouTube-style Shorts: Displays Shorts in a portrait grid on subscription and channel pages and uses the YouTube-style Shorts player.
     Use Fixed Tab Width: Gives every tab in the horizontal tab bar the same width instead of sizing them to their title.
   Experimental Settings:
-    Playback Engine: Which tool the video streams are obtained with. yt-dlp needs to be available to be used.
     Replace HTTP Cache: Disables Electron's disk based HTTP cache and enables a custom in-memory image cache. Will lead to increased RAM usage.
   SponsorBlock Settings:
     UseDeArrowTitles: Replace video titles with user-submitted titles from DeArrow.

--- a/static/locales/pl.yaml
+++ b/static/locales/pl.yaml
@@ -798,7 +798,7 @@ Settings:
     Return YouTube Dislike Url: 'Adres URL do API wyświetlania łapek w dół z YouTube (Domyślnie: https://ryd-proxy.kavin.rocks)'
   Download Settings:
     Download Settings: Pobieranie
-    Managed Tools Download Started Template: 'Nie znaleziono narzędzi potrzebnych do pobierania filmów: {tools}. Pobieranie zarządzanych kopii…'
+    Managed Tools Download Started Template: 'Nie znaleziono wymaganego oprogramowania zewnętrznego: {tools}. Pobieranie zarządzanych kopii…'
     Managed Tools Download Finished Template: Zakończono pobieranie {tools}
     Managed Tools Update Started Template: Znaleziono aktualizację dla {tools}. Pobieranie…
     Managed Tools Update Finished Template: Zakończono aktualizację {tools}

--- a/tests/unit/release-notes.test.mjs
+++ b/tests/unit/release-notes.test.mjs
@@ -18,6 +18,18 @@ Adds a compact player.
 <!-- release-note:end -->
 `
 
+const EMPTY_NOTE_MARKERS = `
+<!-- release-note:start -->
+
+<!-- release-note:end -->
+`
+
+const IMAGE_MARKERS = `
+<!-- release-note-image:start -->
+
+<!-- release-note-image:end -->
+`
+
 const categoryMarkers = (category) => `
 <!-- release-note-category:start -->
 - [${category === 'Not noteworthy' ? 'x' : ' '}] Not noteworthy
@@ -74,7 +86,7 @@ function webp(type, width, height) {
 test('every pull request requires exactly one release note category', () => {
   assert.deepEqual(validatePullRequestEvent({
     pull_request: {
-      body: categoryMarkers('Not noteworthy'),
+      body: `${categoryMarkers('Not noteworthy')}${EMPTY_NOTE_MARKERS}${IMAGE_MARKERS}`,
     },
   }), {
     category: 'Not noteworthy',
@@ -82,9 +94,9 @@ test('every pull request requires exactly one release note category', () => {
 
   assert.throws(() => validatePullRequestEvent({
     pull_request: {
-      body: '',
+      body: `${categoryMarkers(null)}${NOTE_MARKERS}${IMAGE_MARKERS}`,
     },
-  }), /Select one release note category/)
+  }), /Select exactly one release note category/)
 
   assert.throws(() => parseReleaseNoteCategory(`
 <!-- release-note-category:start -->
@@ -97,7 +109,7 @@ test('every pull request requires exactly one release note category', () => {
 test('release notes are required for noteworthy categories', () => {
   assert.throws(() => validatePullRequestEvent({
     pull_request: {
-      body: categoryMarkers('Highlights'),
+      body: `${categoryMarkers('Highlights')}${EMPTY_NOTE_MARKERS}${IMAGE_MARKERS}`,
     },
   }), /Fill in the release note section/)
 })
@@ -315,6 +327,7 @@ ${categoryMarkers('More improvements')}
 <!-- release-note:start -->
 Adds keyboard shortcuts.
 <!-- release-note:end -->
+${IMAGE_MARKERS}
 `,
       number: 43,
       title: 'Keyboard shortcuts',
@@ -325,19 +338,15 @@ ${categoryMarkers('Fixed bugs')}
 <!-- release-note:start -->
 Fixed videos failing to load.
 <!-- release-note:end -->
+${IMAGE_MARKERS}
 `,
       number: 44,
       title: 'Fix video loading',
     },
     {
-      body: categoryMarkers('Not noteworthy'),
+      body: `${categoryMarkers('Not noteworthy')}${EMPTY_NOTE_MARKERS}${IMAGE_MARKERS}`,
       number: 45,
       title: 'Refactor tests',
-    },
-    {
-      body: 'Legacy pull request body',
-      number: 46,
-      title: 'Legacy change',
     },
   ], {
     loadImage: async () => png(800, 600),
@@ -365,6 +374,7 @@ test('empty release note categories are omitted', async () => {
       body: `
 ${categoryMarkers('Fixed bugs')}
 ${NOTE_MARKERS}
+${IMAGE_MARKERS}
 `,
       number: 42,
       title: 'Compact player',
@@ -380,7 +390,7 @@ ${NOTE_MARKERS}
 test('a release with only non-noteworthy pull requests is rejected', async () => {
   await assert.rejects(
     renderReleaseNotes([{
-      body: categoryMarkers('Not noteworthy'),
+      body: `${categoryMarkers('Not noteworthy')}${EMPTY_NOTE_MARKERS}${IMAGE_MARKERS}`,
       number: 42,
       title: 'Refactor tests',
     }]),
@@ -390,7 +400,7 @@ test('a release with only non-noteworthy pull requests is rejected', async () =>
 
 test('nightly releases can render a fallback when there are no noteworthy changes', async () => {
   const result = await renderReleaseNotes([{
-    body: categoryMarkers('Not noteworthy'),
+    body: `${categoryMarkers('Not noteworthy')}${EMPTY_NOTE_MARKERS}${IMAGE_MARKERS}`,
     number: 42,
     title: 'Refactor tests',
   }], {


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Make sure to follow the contributing guidelines. -->
<!-- Important note, we may remove your pull request if you do not use this provided PR template correctly. -->
<!-- Agent instructions: Preserve every heading, comment, and marker in this template. Never remove or rewrite the release-note-category:start/end, release-note:start/end, or release-note-image:start/end marker pairs. Never remove or rewrite the Release note images section; leave its contents for a human. -->

## Pull Request Type
<!-- Please select what type of pull request this is: [x] -->
- [ ] Bugfix
- [x] Feature Implementation
- [ ] Documentation
- [ ] Other

## Related issue
<!-- Please link the issue your pull request is referring to. -->
<!-- If this pull request fully resolves the relevant issue, put "closes" before the issue number. -->
<!-- Example: "closes #123456". -->

## Description
<!-- Please write a clear and concise description of what the pull request does. -->
Makes yt-dlp the default playback engine and migrates existing installations to it once. The playback engine selector is promoted from Experimental to General settings, while repository and startup messaging now describes yt-dlp as playback and download software instead of only a downloader.

## Release note category
<!-- Select exactly one category. Every pull request must select one. -->
<!-- release-note-category:start -->
- [ ] Not noteworthy
- [ ] Highlights
- [x] More improvements
- [ ] Fixed bugs
<!-- release-note-category:end -->

## Release note
<!-- Required unless "Not noteworthy" is selected. -->
<!-- Write one concise, user-facing entry without a leading bullet. -->
<!-- release-note:start -->
yt-dlp is now the default stream extraction method and can be selected from General settings.
<!-- release-note:end -->

## Release note images
<!-- Human-only: Agents must preserve this entire section and leave it empty. -->
<!-- Optional. Paste one or more Markdown images or HTML image tags here. -->
<!-- The release notes will use an HTML image tag and limit images taller than 300 pixels. -->
<!-- release-note-image:start -->
<img width="295" height="87" alt="image" src="https://github.com/user-attachments/assets/5e71a518-c5bc-45ce-aa6e-9ebbddfa7919" />
<!-- release-note-image:end -->

## Testing
<!-- How can reviewers verify that the PR produces correct results? -->
<!-- Please provide instructions so that others can ensure that your pull request would produce correct results. For examples see, https://github.com/FreeTubeApp/FreeTube/pull/5743, https://github.com/FreeTubeApp/FreeTube/pull/7349, https://github.com/FreeTubeApp/FreeTube/pull/5125, https://github.com/FreeTubeApp/FreeTube/pull/7338 -->
<!-- Agent instructions: Only write human-facing steps that explain how to verify the change while running this branch in dev mode. Include expected results and, when applicable, helpful console snippets for interactive verification. Do not include automated checks, commands, results, pass counts, or CI status. -->
1. Start from an existing profile whose playback engine is set to Built-in, then launch this branch. Confirm playback uses yt-dlp and General settings shows yt-dlp as the selected playback engine.
2. Select Built-in, restart the app, and confirm Built-in remains selected so the migration is not repeated.
3. Open Experimental settings and confirm the playback engine selector is no longer present there.
4. Start with a fresh profile and confirm yt-dlp is selected by default.

## Additional context
<!-- Add any other context about the pull request here. -->
The migration marker is local to each installation so synced or imported settings do not repeatedly override the users later engine choice.