### PR TITLE
fix(comments): handle unavailable comments and replies

### DIFF
--- a/e2e/tests/network/watch.spec.mjs
+++ b/e2e/tests/network/watch.spec.mjs
@@ -9,6 +9,11 @@ const CAPTIONED_VIDEO = {
   title: 'What’s It Like to Be Killed by Nature’s Most Brutal Predator',
   url: 'https://www.youtube.com/watch?v=Xf-uUy5pdUI'
 }
+const COMMENTS_DISABLED_VIDEO = {
+  id: 'Mapn4dhcFlc',
+  title: 'Public Works - How to turn your water on and off',
+  url: 'https://www.youtube.com/watch?v=Mapn4dhcFlc'
+}
 const FULLSCREEN_PLAYLIST_ID = 'fullscreen-preview'
 const FULLSCREEN_PLAYLIST = {
   _id: FULLSCREEN_PLAYLIST_ID,
@@ -734,6 +739,28 @@ test.describe('watch page', () => {
     await expect(comment.locator('.commentMoreRepliesSpinner')).toHaveCount(0)
     await expect(comment.locator('.commentMoreReplies')).toHaveCount(0)
     await expect(comment.locator('.commentReplyBranch')).toHaveCount(0)
+  })
+
+  test('reports comments as turned off instead of empty', async ({ page, innertube }) => {
+    test.skip(innertube.replay, 'watch page hydration needs the real API')
+    await openVideo(page, COMMENTS_DISABLED_VIDEO)
+
+    const commentSection = page.locator('.commentsArea')
+    await expect(commentSection.locator('.noCommentMsg')).toHaveText(
+      'Comments are turned off',
+      { timeout: 30_000 }
+    )
+    // Nothing to load, sort or reload, so those affordances stay hidden.
+    await expect(commentSection.locator('.getCommentsTitle')).toHaveCount(0)
+    await expect(commentSection.locator('.noCommentActions')).toHaveCount(0)
+    await expect(commentSection.locator('.comment')).toHaveCount(0)
+
+    // Losing the actions must not collapse the card into a cramped strip.
+    const [messageBox, cardBox] = await Promise.all([
+      commentSection.locator('.noCommentMsg').boundingBox(),
+      commentSection.locator('.card').boundingBox()
+    ])
+    expect(cardBox.height).toBeGreaterThanOrEqual(messageBox.height + 40)
   })
 
   test('fullscreen comments dock preserves its active state and scroll position', async ({ page, innertube }) => {

--- a/e2e/tests/network/watch.spec.mjs
+++ b/e2e/tests/network/watch.spec.mjs
@@ -699,6 +699,43 @@ test.describe('watch page', () => {
     await expect(replies.first()).toBeVisible()
   })
 
+  test('stale reply controls disappear after an empty final reply page', async ({ page, innertube }) => {
+    test.skip(innertube.replay, 'watch page hydration needs the real API')
+    await openVideo(page)
+
+    const loadComments = page.locator('.getCommentsTitle')
+    await loadComments.scrollIntoViewIfNeeded()
+    await loadComments.click()
+    await expect(page.locator('.commentsTitle')).toBeVisible({ timeout: 30_000 })
+
+    const comments = page.locator('.comment')
+    const commentIndex = await comments.evaluateAll(elements => (
+      elements.findIndex(element => element.querySelector('.commentMoreReplies'))
+    ))
+    expect(commentIndex).toBeGreaterThanOrEqual(0)
+    const comment = comments.nth(commentIndex)
+    const replyToggle = comment.locator('.commentMoreReplies')
+    await expect(replyToggle).toBeVisible()
+
+    await page.route(/\/youtubei\/v1\/next/, route => route.fulfill({
+      status: 200,
+      contentType: 'application/json',
+      body: JSON.stringify({
+        onResponseReceivedEndpoints: [{
+          appendContinuationItemsAction: {
+            targetId: 'comment-replies-item-stale'
+          }
+        }]
+      })
+    }), { times: 1 })
+
+    await replyToggle.click()
+
+    await expect(comment.locator('.commentMoreRepliesSpinner')).toHaveCount(0)
+    await expect(comment.locator('.commentMoreReplies')).toHaveCount(0)
+    await expect(comment.locator('.commentReplyBranch')).toHaveCount(0)
+  })
+
   test('fullscreen comments dock preserves its active state and scroll position', async ({ page, innertube }) => {
     test.skip(innertube.replay, 'watch page hydration needs the real API')
     await openVideo(page)

--- a/src/renderer/components/CommentSection/CommentSection.css
+++ b/src/renderer/components/CommentSection/CommentSection.css
@@ -159,6 +159,12 @@
   padding-block: 8px;
 }
 
+/* The sort/reload actions normally give the card its height. Without them the
+   lone message would sit in a cramped strip, so pad it out instead. */
+.noCommentsMessageOnly {
+  padding-block: 24px;
+}
+
 .noCommentActions {
   display: flex;
   flex: 0 0 auto;

--- a/src/renderer/components/CommentSection/CommentSection.vue
+++ b/src/renderer/components/CommentSection/CommentSection.vue
@@ -17,7 +17,7 @@
         @keydown.esc.stop.prevent="sortMenuOpen = false"
       >
         <button
-          v-if="showSortBy"
+          v-if="showSortBy && !commentsDisabled"
           type="button"
           class="fullscreenCommentAction"
           :class="{ active: sortMenuOpen }"
@@ -29,6 +29,7 @@
           <FontAwesomeIcon :icon="['fas', 'arrow-down-short-wide']" />
         </button>
         <button
+          v-if="!commentsDisabled"
           type="button"
           class="fullscreenCommentAction"
           :aria-label="$t('Comments.Reload Comments')"
@@ -336,11 +337,18 @@
         </div>
       </div>
       <div
-        v-else-if="showComments && !isLoading"
+        v-else-if="commentsDisabled || (showComments && !isLoading)"
         class="noComments"
+        :class="{ noCommentsMessageOnly: commentsDisabled || fullscreenOverlay }"
       >
         <h3
-          v-if="isPostComments"
+          v-if="commentsDisabled"
+          class="noCommentMsg"
+        >
+          {{ $t("Comments.Comments are turned off") }}
+        </h3>
+        <h3
+          v-else-if="isPostComments"
           class="noCommentMsg"
         >
           {{ $t("Comments.There are no comments available for this post") }}
@@ -352,7 +360,7 @@
           {{ $t("Comments.There are no comments available for this video") }}
         </h3>
         <div
-          v-if="!fullscreenOverlay"
+          v-if="!fullscreenOverlay && !commentsDisabled"
           class="noCommentActions"
         >
           <FtSelect
@@ -463,6 +471,10 @@ const props = defineProps({
     required: true
   },
   isPostComments: {
+    type: Boolean,
+    default: false,
+  },
+  commentsDisabled: {
     type: Boolean,
     default: false,
   },
@@ -656,7 +668,7 @@ const generalAutoLoadMorePaginatedItemsEnabled = computed(() => {
 })
 
 const canPerformInitialCommentLoading = computed(() => {
-  return commentData.value.length === 0 && !isLoading.value && !showComments.value
+  return !props.commentsDisabled && commentData.value.length === 0 && !isLoading.value && !showComments.value
 })
 
 watch(

--- a/src/renderer/components/CommentSection/CommentSection.vue
+++ b/src/renderer/components/CommentSection/CommentSection.vue
@@ -1153,6 +1153,10 @@ async function getCommentRepliesLocal(index, commentId = null) {
       comment.hasReplyToken = false
     }
 
+    if (replyLoadState.hasMissingReplies) {
+      comment.numReplies = comment.replies.length
+    }
+
     comment.showReplies = replyLoadState.showReplies
   } catch (err) {
     console.error(err)
@@ -1295,6 +1299,10 @@ async function getCommentRepliesInvidious(
       comment.hasReplyToken = false
     }
 
+    if (replyLoadState.hasMissingReplies) {
+      comment.numReplies = comment.replies.length
+    }
+
     isLoading.value = false
   } catch (error) {
     console.error(error)
@@ -1365,6 +1373,10 @@ async function getPostCommentRepliesInvidious(index) {
     } else {
       replyTokens.delete(comment.id)
       comment.hasReplyToken = false
+    }
+
+    if (replyLoadState.hasMissingReplies) {
+      comment.numReplies = comment.replies.length
     }
 
     isLoading.value = false

--- a/src/renderer/components/CommentSection/CommentSection.vue
+++ b/src/renderer/components/CommentSection/CommentSection.vue
@@ -1139,7 +1139,6 @@ async function getCommentRepliesLocal(index, commentId = null) {
     comment.replies = comment.replies.concat(parsedReplies)
 
     const replyLoadState = getReplyLoadState(
-      parsedReplies.length,
       comment.replies.length,
       comment.numReplies,
       nextContinuation !== null
@@ -1284,7 +1283,6 @@ async function getCommentRepliesInvidious(
 
     comment.replies = comment.replies.concat(commentData)
     const replyLoadState = getReplyLoadState(
-      commentData.length,
       comment.replies.length,
       comment.numReplies,
       continuation !== null
@@ -1360,7 +1358,6 @@ async function getPostCommentRepliesInvidious(index) {
     })
     comment.replies = comment.replies.concat(comments)
     const replyLoadState = getReplyLoadState(
-      comments.length,
       comment.replies.length,
       comment.numReplies,
       continuation !== null

--- a/src/renderer/helpers/api/local.js
+++ b/src/renderer/helpers/api/local.js
@@ -669,6 +669,27 @@ export async function getLocalComments(id) {
   return innertube.getComments(id)
 }
 
+/**
+ * When the uploader turns comments off, YouTube replaces the comment section's
+ * continuation with a message ("Comments are turned off."), so requesting the
+ * comments would only ever return an empty page.
+ *
+ * @param {import('youtubei.js').YT.VideoInfo} videoInfo
+ */
+export function areLocalCommentsDisabled(videoInfo) {
+  const itemSections = videoInfo.page[1]?.contents_memo?.get('ItemSection') ?? []
+
+  const commentSection = itemSections.find(itemSection => {
+    return itemSection.target_id === 'comments-section' || itemSection.target_id === 'comment-item-section'
+  })
+
+  if (!commentSection) {
+    return false
+  }
+
+  return !commentSection.contents.some(node => node.type === 'ContinuationItem')
+}
+
 // I know `type & type` is typescript syntax and not valid jsdoc but I couldn't get @extends or @augments to work
 
 /**

--- a/src/renderer/helpers/comment-replies.js
+++ b/src/renderer/helpers/comment-replies.js
@@ -1,12 +1,10 @@
 /**
- * @param {number} parsedReplyCount
  * @param {number} loadedReplyCount
  * @param {number} expectedReplyCount
  * @param {boolean} hasNextContinuation
  */
-export function getReplyLoadState(parsedReplyCount, loadedReplyCount, expectedReplyCount, hasNextContinuation) {
-  const hasMissingReplies = parsedReplyCount === 0 &&
-    loadedReplyCount < expectedReplyCount &&
+export function getReplyLoadState(loadedReplyCount, expectedReplyCount, hasNextContinuation) {
+  const hasMissingReplies = loadedReplyCount < expectedReplyCount &&
     !hasNextContinuation
 
   return {

--- a/src/renderer/helpers/comment-replies.js
+++ b/src/renderer/helpers/comment-replies.js
@@ -5,12 +5,14 @@
  * @param {boolean} hasNextContinuation
  */
 export function getReplyLoadState(parsedReplyCount, loadedReplyCount, expectedReplyCount, hasNextContinuation) {
-  const shouldRetry = parsedReplyCount === 0 && loadedReplyCount < expectedReplyCount
+  const hasMissingReplies = parsedReplyCount === 0 &&
+    loadedReplyCount < expectedReplyCount &&
+    !hasNextContinuation
 
   return {
-    hasMore: hasNextContinuation || shouldRetry,
+    hasMore: hasNextContinuation,
+    hasMissingReplies,
     showReplies: loadedReplyCount > 0,
-    shouldRetry
   }
 }
 

--- a/src/renderer/views/Watch/Watch.js
+++ b/src/renderer/views/Watch/Watch.js
@@ -38,6 +38,7 @@ import {
   showToastOnAllTabs
 } from '../../helpers/utils'
 import {
+  areLocalCommentsDisabled,
   generateAudioTrackField,
   getLocalShortLinkedVideo,
   getLocalVideoInfo,
@@ -183,6 +184,7 @@ export default defineComponent({
       theatreLayoutAvailable: window.innerWidth > RESPONSIVE_THEATRE_MODE_MAX_WIDTH,
       videoPlayerLoaded: false,
       isFamilyFriendly: false,
+      commentsDisabled: false,
       isLive: false,
       liveChat: null,
       isLiveContent: false,
@@ -1246,6 +1248,7 @@ export default defineComponent({
       this.playlistScrollPositions.fullscreen = null
       this.isLoading = true
       this.isFamilyFriendly = false
+      this.commentsDisabled = false
       this.isLive = false
       this.liveChat = null
       this.isLiveContent = false
@@ -1621,6 +1624,7 @@ export default defineComponent({
         this.adEndTimeUnixMs = adEndTimeUnixMs
 
         this.isFamilyFriendly = result.basic_info.is_family_safe
+        this.commentsDisabled = areLocalCommentsDisabled(result)
 
         this.recommendedVideos = result.watch_next_feed
           ?.filter((item) => {

--- a/src/renderer/views/Watch/Watch.vue
+++ b/src/renderer/views/Watch/Watch.vue
@@ -872,6 +872,7 @@
           :class="{ theatreWatchVideo: useTheatreMode }"
           :channel-thumbnail="channelThumbnail"
           :channel-name="channelName"
+          :comments-disabled="commentsDisabled"
           :fullscreen-overlay="fullscreenCommentsOpen || shortsCommentsOpen"
           @close-comments="closeFullscreenComments"
           @timestamp-event="changeTimestamp"

--- a/static/locales/en-US.yaml
+++ b/static/locales/en-US.yaml
@@ -1619,6 +1619,7 @@ Comments:
   There are no comments available for this video: There are no comments available
     for this video
   There are no comments available for this post: There are no comments available for this post
+  Comments are turned off: Comments are turned off
   YouTube did not provide advertised replies: YouTube showed that this comment has replies, but did not provide them. They may have been deleted or hidden, so the reply button was removed.
   Load More Comments: Load More Comments
   Pinned by: Pinned by

--- a/tests/unit/comment-replies.test.mjs
+++ b/tests/unit/comment-replies.test.mjs
@@ -9,7 +9,7 @@ import {
 } from '../../src/renderer/helpers/comment-replies.js'
 
 test('exhausts a stale advertised reply without opening the reply panel', () => {
-  assert.deepEqual(getReplyLoadState(0, 0, 1, false), {
+  assert.deepEqual(getReplyLoadState(0, 1, false), {
     hasMore: false,
     hasMissingReplies: true,
     showReplies: false
@@ -17,7 +17,7 @@ test('exhausts a stale advertised reply without opening the reply panel', () => 
 })
 
 test('marks a completed reply load as exhausted', () => {
-  assert.deepEqual(getReplyLoadState(1, 1, 1, false), {
+  assert.deepEqual(getReplyLoadState(1, 1, false), {
     hasMore: false,
     hasMissingReplies: false,
     showReplies: true
@@ -25,7 +25,7 @@ test('marks a completed reply load as exhausted', () => {
 })
 
 test('keeps a loaded reply panel open while its continuation is available', () => {
-  assert.deepEqual(getReplyLoadState(1, 3, 4, true), {
+  assert.deepEqual(getReplyLoadState(3, 4, true), {
     hasMore: true,
     hasMissingReplies: false,
     showReplies: true
@@ -33,7 +33,15 @@ test('keeps a loaded reply panel open while its continuation is available', () =
 })
 
 test('exhausts a zero-progress continuation after earlier replies loaded', () => {
-  assert.deepEqual(getReplyLoadState(0, 3, 4, false), {
+  assert.deepEqual(getReplyLoadState(3, 4, false), {
+    hasMore: false,
+    hasMissingReplies: true,
+    showReplies: true
+  })
+})
+
+test('reconciles an underfilled final reply page', () => {
+  assert.deepEqual(getReplyLoadState(2, 3, false), {
     hasMore: false,
     hasMissingReplies: true,
     showReplies: true

--- a/tests/unit/comment-replies.test.mjs
+++ b/tests/unit/comment-replies.test.mjs
@@ -8,35 +8,35 @@ import {
   shouldLoadInitialReplies
 } from '../../src/renderer/helpers/comment-replies.js'
 
-test('keeps an empty reply load retryable without opening the reply panel', () => {
+test('exhausts a stale advertised reply without opening the reply panel', () => {
   assert.deepEqual(getReplyLoadState(0, 0, 1, false), {
-    hasMore: true,
-    showReplies: false,
-    shouldRetry: true
+    hasMore: false,
+    hasMissingReplies: true,
+    showReplies: false
   })
 })
 
 test('marks a completed reply load as exhausted', () => {
   assert.deepEqual(getReplyLoadState(1, 1, 1, false), {
     hasMore: false,
-    showReplies: true,
-    shouldRetry: false
+    hasMissingReplies: false,
+    showReplies: true
   })
 })
 
 test('keeps a loaded reply panel open while its continuation is available', () => {
   assert.deepEqual(getReplyLoadState(1, 3, 4, true), {
     hasMore: true,
-    showReplies: true,
-    shouldRetry: false
+    hasMissingReplies: false,
+    showReplies: true
   })
 })
 
-test('keeps a zero-progress continuation retryable after earlier replies loaded', () => {
+test('exhausts a zero-progress continuation after earlier replies loaded', () => {
   assert.deepEqual(getReplyLoadState(0, 3, 4, false), {
-    hasMore: true,
-    showReplies: true,
-    shouldRetry: true
+    hasMore: false,
+    hasMissingReplies: true,
+    showReplies: true
   })
 })
 


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Make sure to follow the contributing guidelines. -->
<!-- Important note, we may remove your pull request if you do not use this provided PR template correctly. -->
<!-- Agent instructions: Preserve every heading, comment, and marker in this template. Never remove or rewrite the release-note-category:start/end, release-note:start/end, or release-note-image:start/end marker pairs. Never remove or rewrite the Release note images section; leave its contents for a human. -->

## Pull Request Type
<!-- Please select what type of pull request this is: [x] -->
- [x] Bugfix
- [ ] Feature Implementation
- [ ] Documentation
- [ ] Other

## Related issue
<!-- Please link the issue your pull request is referring to. -->
<!-- If this pull request fully resolves the relevant issue, put "closes" before the issue number. -->
<!-- Example: "closes #123456". -->
None.

## Description
<!-- Please write a clear and concise description of what the pull request does. -->
Improve two misleading comment states returned by YouTube.

When a reply continuation returns an empty final response, stop retrying it and reconcile the stale advertised reply count with the replies actually loaded. This removes the unusable reply button just as YouTube does.

When an uploader has disabled comments, detect the missing comment continuation in the watch-next response and show a dedicated “Comments are turned off” state. Since there is nothing to load, sort, or reload, those controls stay hidden while the empty-state card retains comfortable spacing.

The comments-disabled work was incorporated from #512 so both closely related fixes can ship and be reviewed together.

## Release note category
<!-- Select exactly one category. Every pull request must select one. -->
<!-- release-note-category:start -->
- [ ] Not noteworthy
- [ ] Highlights
- [ ] More improvements
- [x] Fixed bugs
<!-- release-note-category:end -->

## Release note
<!-- Required unless "Not noteworthy" is selected. -->
<!-- Write one concise, user-facing entry without a leading bullet. -->
<!-- release-note:start -->
Comment sections now correctly report disabled comments and hide unavailable reply controls.
<!-- release-note:end -->

## Release note images
<!-- Human-only: Agents must preserve this entire section and leave it empty. -->
<!-- Optional. Paste one or more Markdown images or HTML image tags here. -->
<!-- The release notes will use an HTML image tag and limit images taller than 300 pixels. -->
<!-- release-note-image:start -->

<!-- release-note-image:end -->

## Testing
<!-- How can reviewers verify that the PR produces correct results? -->
<!-- Please provide instructions so that others can ensure that your pull request would produce correct results. For examples see, https://github.com/FreeTubeApp/FreeTube/pull/5743, https://github.com/FreeTubeApp/FreeTube/pull/7349, https://github.com/FreeTubeApp/FreeTube/pull/5125, https://github.com/FreeTubeApp/FreeTube/pull/7338 -->
<!-- Agent instructions: Only write human-facing steps that explain how to verify the change while running this branch in dev mode. Include expected results and, when applicable, helpful console snippets for interactive verification. Do not include automated checks, commands, results, pass counts, or CI status. -->
**Unavailable replies**

1. Open a video containing a comment whose displayed reply count is stale and whose reply request returns no items or continuation.
2. Click the “View 1 reply” link.
3. Confirm the loading indicator stops and the stale reply link disappears instead of allowing the same empty request to be repeated.

**Comments turned off**

1. Select the local API backend and open https://www.youtube.com/watch?v=Mapn4dhcFlc.
2. Scroll to the comment area.
3. Confirm it says “Comments are turned off” immediately, with no load, sort, or reload controls and comfortable padding around the message.
4. Enter fullscreen and open the comments dock. Confirm the same message appears and only the close button remains in its header.

**Normal comments**

1. Open https://www.youtube.com/watch?v=jNQXAC9IVRw and scroll to the comment area.
2. Confirm comments still load normally and sorting and reloading remain available.

## Additional context
<!-- Add any other context about the pull request here. -->
The network E2E coverage exercises both the empty final reply page and the comments-disabled watch response.
