### PR TITLE
fix(ui): make animated select dropdowns work in modals

### DIFF
--- a/e2e/tests/offline/history.spec.mjs
+++ b/e2e/tests/offline/history.spec.mjs
@@ -193,6 +193,23 @@ test.describe('history cleanup', () => {
       return records.filter((record) => record._id === 'ooooooooooo').at(-1)?.$$deleted
     }).toBe(true)
   })
+
+  test('selects a history cutoff from the modal dropdown', async ({ page }) => {
+    await goTo(page, 'history')
+    await page.getByRole('button', { name: 'Delete Old History' }).click()
+
+    const dialog = page.getByRole('dialog')
+    const combobox = dialog.getByRole('combobox', { name: /Delete entries older than/i })
+    await combobox.click()
+
+    const dropdown = page.getByRole('listbox', { name: /Delete entries older than/i })
+    await expect(dropdown).toBeVisible()
+    await expect(dropdown.locator('xpath=..')).toHaveClass(/prompt/)
+    await dropdown.getByRole('option', { name: '1 month' }).click()
+
+    await expect(combobox).toContainText('1 month')
+    await expect(dialog).toBeVisible()
+  })
 })
 
 test.describe('legacy watch history', () => {

--- a/src/renderer/components/FtSelect/FtSelect.css
+++ b/src/renderer/components/FtSelect/FtSelect.css
@@ -91,6 +91,29 @@
   box-shadow: 0 2px 8px rgb(0 0 0 / 35%);
 }
 
+.selectDropdown.above {
+  transform-origin: bottom;
+}
+
+.selectDropdown.below {
+  transform-origin: top;
+}
+
+.select-dropdown-enter-active {
+  transition: opacity 120ms ease, transform 120ms ease;
+}
+
+.select-dropdown-leave-active {
+  pointer-events: none;
+  transition: opacity 120ms ease, transform 120ms ease;
+}
+
+.select-dropdown-enter-from,
+.select-dropdown-leave-to {
+  opacity: 0;
+  transform: scaleY(0.96);
+}
+
 .selectOption {
   box-sizing: border-box;
   min-block-size: 34px;
@@ -128,6 +151,7 @@
   border-inline-end: 6px solid transparent;
   pointer-events: none;
   color: var(--tertiary-text-color);
+  transition: transform 120ms ease;
 }
 
 .iconSelect.ft-icon,
@@ -140,6 +164,10 @@
 .disabled + .iconSelect {
   opacity: 0.4;
   cursor: not-allowed;
+}
+
+.select.open .iconSelect {
+  transform: translateY(-50%) rotate(180deg);
 }
 
 .selectIndicators {
@@ -245,5 +273,13 @@
 
   .select.containsTooltip {
     inline-size: calc(100% - 28px);
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .select-dropdown-enter-active,
+  .select-dropdown-leave-active,
+  .iconSelect {
+    transition: none;
   }
 }

--- a/src/renderer/components/FtSelect/FtSelect.vue
+++ b/src/renderer/components/FtSelect/FtSelect.vue
@@ -88,37 +88,40 @@
       />
     </span>
     <Teleport :to="dropdownTarget">
-      <ul
-        v-if="dropdownShown"
-        :id="`${id}-listbox`"
-        ref="dropdown"
-        v-overlay-scrollbars
-        class="selectDropdown"
-        role="listbox"
-        :aria-labelledby="`${id}-label`"
-        :style="dropdownStyle"
-        @pointerdown="handleDropdownPointerDown"
-      >
-        <li
-          v-for="(name, index) in selectNames"
-          :id="`${id}-option-${index}`"
-          :key="selectValues[index]"
-          ref="options"
-          class="selectOption"
-          :class="{ active: index === activeIndex, selected: selectValues[index] === value }"
-          role="option"
-          tabindex="-1"
-          :aria-selected="selectValues[index] === value"
-          :dir="isLocaleSelector ? 'auto' : null"
-          :lang="isLocaleSelector && selectValues[index] !== 'system' && selectValues[index] !== '' ? selectValues[index] : null"
-          @mousedown.prevent
-          @pointermove="activeIndex = index"
-          @click="selectOption(index)"
-          @keydown.enter.space.prevent="selectOption(index)"
+      <Transition name="select-dropdown">
+        <ul
+          v-if="dropdownShown"
+          :id="`${id}-listbox`"
+          ref="dropdown"
+          v-overlay-scrollbars
+          class="selectDropdown"
+          :class="dropdownPlacement"
+          role="listbox"
+          :aria-labelledby="`${id}-label`"
+          :style="dropdownStyle"
+          @pointerdown="handleDropdownPointerDown"
         >
-          {{ name }}
-        </li>
-      </ul>
+          <li
+            v-for="(name, index) in selectNames"
+            :id="`${id}-option-${index}`"
+            :key="selectValues[index]"
+            ref="options"
+            class="selectOption"
+            :class="{ active: index === activeIndex, selected: selectValues[index] === value }"
+            role="option"
+            tabindex="-1"
+            :aria-selected="selectValues[index] === value"
+            :dir="isLocaleSelector ? 'auto' : null"
+            :lang="isLocaleSelector && selectValues[index] !== 'system' && selectValues[index] !== '' ? selectValues[index] : null"
+            @mousedown.prevent
+            @pointermove="activeIndex = index"
+            @click="selectOption(index)"
+            @keydown.enter.space.prevent="selectOption(index)"
+          >
+            {{ name }}
+          </li>
+        </ul>
+      </Transition>
     </Teleport>
   </div>
 </template>
@@ -193,6 +196,7 @@ const dropdownShown = ref(false)
 const activeIndex = ref(0)
 const dropdownStyle = ref({})
 const dropdownTarget = shallowRef(document.fullscreenElement ?? document.body)
+const dropdownPlacement = ref('below')
 let typeahead = ''
 let typeaheadTimer = null
 let pointerDownInDropdown = false
@@ -279,6 +283,7 @@ function updateDropdownPosition() {
         Math.min(buttonRect.bottom + menuGap, maximumBottom - menuHeight)
       )
 
+  dropdownPlacement.value = openAbove ? 'above' : 'below'
   dropdownStyle.value = {
     inlineSize: `${menuWidth}px`,
     left: `${left}px`,

--- a/src/renderer/components/FtSelect/FtSelect.vue
+++ b/src/renderer/components/FtSelect/FtSelect.vue
@@ -87,7 +87,7 @@
         @reset="emit('reset')"
       />
     </span>
-    <Teleport to="body">
+    <Teleport :to="dropdownTarget">
       <ul
         v-if="dropdownShown"
         :id="`${id}-listbox`"
@@ -125,7 +125,7 @@
 
 <script setup>
 import { FontAwesomeIcon } from '@fortawesome/vue-fontawesome'
-import { computed, nextTick, onBeforeUnmount, ref, useId, useTemplateRef, watch } from 'vue'
+import { computed, nextTick, onBeforeUnmount, ref, shallowRef, useId, useTemplateRef, watch } from 'vue'
 
 import FtTooltip from '../FtTooltip/FtTooltip.vue'
 import FtSyncedSettingIndicator from '../FtSyncedSettingIndicator/FtSyncedSettingIndicator.vue'
@@ -192,6 +192,7 @@ const options = useTemplateRef('options')
 const dropdownShown = ref(false)
 const activeIndex = ref(0)
 const dropdownStyle = ref({})
+const dropdownTarget = shallowRef(document.fullscreenElement ?? document.body)
 let typeahead = ''
 let typeaheadTimer = null
 let pointerDownInDropdown = false
@@ -233,6 +234,7 @@ function toggleDropdown() {
 
 function openDropdown() {
   activeIndex.value = Math.max(0, selectedIndex.value)
+  dropdownTarget.value = selectRoot.value?.closest('.prompt') ?? document.fullscreenElement ?? document.body
   dropdownShown.value = true
 
   nextTick(() => {


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Make sure to follow the contributing guidelines. -->
<!-- Important note, we may remove your pull request if you do not use this provided PR template correctly. -->
<!-- Agent instructions: Preserve every heading, comment, and marker in this template. Never remove or rewrite the release-note-category:start/end, release-note:start/end, or release-note-image:start/end marker pairs. Never remove or rewrite the Release note images section; leave its contents for a human. -->

## Pull Request Type
<!-- Please select what type of pull request this is: [x] -->
- [x] Bugfix
- [x] Feature Implementation
- [ ] Documentation
- [ ] Other

## Related issue
<!-- Please link the issue your pull request is referring to. -->
<!-- If this pull request fully resolves the relevant issue, put "closes" before the issue number. -->
<!-- Example: "closes #123456". -->

## Description
<!-- Please write a clear and concise description of what the pull request does. -->
Select dropdowns inside prompts were teleported to the document body, placing them below the modal backdrop's stacking layer and preventing pointer interaction. Dropdowns now target their owning prompt overlay while retaining the portal behavior that prevents clipping. Dropdowns outside prompts continue to target the fullscreen element or document body as appropriate.

Custom select dropdowns now also animate as they open and close with a short fade and vertical scale transition. The transform origin follows whether the menu opens above or below its control, the select arrow rotates to reflect the open state, and transitions are disabled when reduced motion is preferred.

The leave transition disables pointer events immediately so a fading option cannot change the selection after the menu has been dismissed. Regression coverage verifies option selection from inside the history cleanup prompt.

## Release note category
<!-- Select exactly one category. Every pull request must select one. -->
<!-- release-note-category:start -->
- [x] Not noteworthy
- [ ] Highlights
- [ ] More improvements
- [ ] Fixed bugs
<!-- release-note-category:end -->

## Release note
<!-- Required unless "Not noteworthy" is selected. -->
<!-- Write one concise, user-facing entry without a leading bullet. -->
<!-- release-note:start -->
Fixed select dropdowns not working inside dialogs and added smooth open and close animations.
<!-- release-note:end -->

## Release note images
<!-- Human-only: Agents must preserve this entire section and leave it empty. -->
<!-- Optional. Paste one or more Markdown images or HTML image tags here. -->
<!-- The release notes will use an HTML image tag and limit images taller than 300 pixels. -->
<!-- release-note-image:start -->

<!-- release-note-image:end -->

## Testing
<!-- How can reviewers verify that the PR produces correct results? -->
<!-- Please provide instructions so that others can ensure that your pull request would produce correct results. For examples see, https://github.com/FreeTubeApp/FreeTube/pull/5743, https://github.com/FreeTubeApp/FreeTube/pull/7349, https://github.com/FreeTubeApp/FreeTube/pull/5125, https://github.com/FreeTubeApp/FreeTube/pull/7338 -->
<!-- Agent instructions: Only write human-facing steps that explain how to verify the change while running this branch in dev mode. Include expected results and, when applicable, helpful console snippets for interactive verification. Do not include automated checks, commands, results, pass counts, or CI status. -->
1. Open a video and show the download dialog.
2. Open the Download Type dropdown and select a different option. Confirm it appears above the modal backdrop, accepts pointer input, animates from the edge nearest the control, and leaves the dialog open after selection.
3. Open History, select Delete Old History, and confirm its age dropdown behaves the same way.
4. Open and dismiss selects by selecting an option, clicking the control again, pressing Escape, and clicking outside. Confirm the dropdown animates closed without accepting input after dismissal and the arrow rotates with the open state.
5. Test a control near the bottom of the viewport and confirm a dropdown opening above it expands upward from its bottom edge.
6. Enable reduced motion at the system level and confirm the menu and arrow change state without animation.

## Additional context
<!-- Add any other context about the pull request here. -->
Includes and supersedes #506. The pointer-event behavior during the leave transition incorporates Greptile's review feedback from that PR.
