### PR TITLE
fix(player): reset SABR state on format changes

### DIFF
--- a/e2e/tests/network/watch.spec.mjs
+++ b/e2e/tests/network/watch.spec.mjs
@@ -244,9 +244,10 @@ test.describe('watch page', () => {
     await openVideo(page)
     await waitForPlaybackOrSkip(test, page)
 
+    const initialUrl = page.url()
     const player = page.locator('.ftVideoPlayer')
     const watchComponent = await page.evaluateHandle(findWatchComponent)
-    await player.evaluate((element, watchComponent) => {
+    const formats = await player.evaluate((element, watchComponent) => {
       const overlay = element.ui ?? element.querySelector('video')?.ui
       const shakaPlayer = overlay?.getControls().getPlayer()
       if (!watchComponent || !shakaPlayer) {
@@ -261,11 +262,27 @@ test.describe('watch page', () => {
       }
 
       const watchView = watchComponent.proxy
-      watchView.handleFormatChange(watchView.activeFormat === 'audio' ? 'dash' : 'audio')
+      const oldFormat = watchView.activeFormat
+      const newFormat = oldFormat === 'audio' ? 'dash' : 'audio'
+      watchView.handleFormatChange(newFormat)
+      return { oldFormat, newFormat }
     }, watchComponent)
-    await watchComponent.dispose()
 
     await expect.poll(() => page.evaluate(() => window.__hasLoadedAtFormatUnload)).toEqual([false])
+    await expect.poll(() => watchComponent.evaluate((component) => ({
+      format: component.proxy.activeFormat,
+      loaded: component.refs.player.hasLoaded
+    }))).toEqual({ format: formats.newFormat, loaded: true })
+    expect(page.url()).toBe(initialUrl)
+
+    await watchComponent.evaluate((component, format) => component.proxy.handleFormatChange(format), formats.oldFormat)
+    await expect.poll(() => watchComponent.evaluate((component) => ({
+      format: component.proxy.activeFormat,
+      loaded: component.refs.player.hasLoaded
+    }))).toEqual({ format: formats.oldFormat, loaded: true })
+    expect(page.url()).toBe(initialUrl)
+
+    await watchComponent.dispose()
   })
 
   test('keeps audio-only playback at video size with the thumbnail visible', async ({ page, innertube }) => {

--- a/src/renderer/components/ft-shaka-video-player/ft-shaka-video-player.js
+++ b/src/renderer/components/ft-shaka-video-player/ft-shaka-video-player.js
@@ -7933,6 +7933,18 @@ export default defineComponent({
       }
     }
 
+    async function unloadForFormatSwitch() {
+      try {
+        await player.unload()
+      } catch { }
+
+      // A manual format change starts a new playback session. Reusing the
+      // previous SABR contexts can make YouTube request an immediate player
+      // reload for the newly selected format.
+      clearSabrBackoffTimer()
+      sabrStream?.reset()
+    }
+
     watch(
       () => props.format,
       /**
@@ -7952,9 +7964,7 @@ export default defineComponent({
         // format switch happened before the player loaded, probably because of an error
         // as there are no previous player settings to restore, we should treat it like this was the original format
         if (!hasLoaded.value) {
-          try {
-            await player.unload()
-          } catch { }
+          await unloadForFormatSwitch()
 
           ignoreErrors = false
 
@@ -8021,9 +8031,7 @@ export default defineComponent({
             dimension = preferredVideoQuality.value
           }
 
-          try {
-            await player.unload()
-          } catch { }
+          await unloadForFormatSwitch()
 
           ignoreErrors = false
           queuePlaybackRateRestore(playbackRate)
@@ -8087,9 +8095,7 @@ export default defineComponent({
             previousQuality = previousTrack.height > previousTrack.width ? previousTrack.width : previousTrack.height
           }
 
-          try {
-            await player.unload()
-          } catch { }
+          await unloadForFormatSwitch()
 
           ignoreErrors = false
 

--- a/src/renderer/helpers/player/SabrSchemePlugin.js
+++ b/src/renderer/helpers/player/SabrSchemePlugin.js
@@ -17,6 +17,7 @@ import {
 import shaka from 'shaka-player'
 
 import { deepCopy } from '../utils'
+import { resetSabrSessionState } from './sabrSession'
 
 const AbortableOperation = shaka.util.AbortableOperation
 const ShakaError = shaka.util.Error
@@ -77,6 +78,7 @@ const ShakaError = shaka.util.Error
  * @type {object}
  * @property {(cb: ({backoffMs: number}) => void) => void} onBackoffRequested
  * @property {(cb: () => void) => void} onReloadOnce
+ * @property {() => void} reset
  * @property {() => void | undefined} cleanup
  */
 
@@ -869,6 +871,9 @@ export function setupSabrScheme(sabrData, getPlayer, getManifest, playerWidth, p
     },
     onReloadOnce(callback) {
       eventEmitter.once('reload', callback)
+    },
+    reset() {
+      resetSabrSessionState(sabrStreamState)
     },
     cleanup,
   }

--- a/src/renderer/helpers/player/sabrSession.js
+++ b/src/renderer/helpers/player/sabrSession.js
@@ -1,0 +1,16 @@
+/**
+ * @param {{
+ *   activeSabrContextTypes: Set<number>,
+ *   sabrContexts: Map<number, object>,
+ *   nextRequestPolicy: object | undefined,
+ *   playerReloadRequested: boolean,
+ *   requestNumber: number
+ * }} state
+ */
+export function resetSabrSessionState(state) {
+  state.activeSabrContextTypes.clear()
+  state.sabrContexts.clear()
+  state.nextRequestPolicy = undefined
+  state.playerReloadRequested = false
+  state.requestNumber = 0
+}

--- a/tests/unit/sabr-session.test.mjs
+++ b/tests/unit/sabr-session.test.mjs
@@ -1,0 +1,24 @@
+import assert from 'node:assert/strict'
+import test from 'node:test'
+
+import { resetSabrSessionState } from '../../src/renderer/helpers/player/sabrSession.js'
+
+test('a format switch starts a fresh SABR session', () => {
+  const state = {
+    sabrUrl: 'https://example.invalid/sabr',
+    activeSabrContextTypes: new Set([1]),
+    sabrContexts: new Map([[1, { value: 'stale' }]]),
+    nextRequestPolicy: { backoffTimeMs: 2_000 },
+    playerReloadRequested: true,
+    requestNumber: 42
+  }
+
+  resetSabrSessionState(state)
+
+  assert.equal(state.sabrUrl, 'https://example.invalid/sabr')
+  assert.equal(state.activeSabrContextTypes.size, 0)
+  assert.equal(state.sabrContexts.size, 0)
+  assert.equal(state.nextRequestPolicy, undefined)
+  assert.equal(state.playerReloadRequested, false)
+  assert.equal(state.requestNumber, 0)
+})


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Make sure to follow the contributing guidelines. -->
<!-- Important note, we may remove your pull request if you do not use this provided PR template correctly. -->
<!-- Agent instructions: Preserve every heading, comment, and marker in this template. Never remove or rewrite the release-note-category:start/end, release-note:start/end, or release-note-image:start/end marker pairs. Never remove or rewrite the Release note images section; leave its contents for a human. -->

## Pull Request Type
<!-- Please select what type of pull request this is: [x] -->
- [x] Bugfix
- [ ] Feature Implementation
- [ ] Documentation
- [ ] Other

## Related issue
<!-- Please link the issue your pull request is referring to. -->
<!-- If this pull request fully resolves the relevant issue, put "closes" before the issue number. -->
<!-- Example: "closes #123456". -->

Follow-up to #460.

## Description
<!-- Please write a clear and concise description of what the pull request does. -->

Format changes unloaded and reloaded Shaka while retaining the previous SABR session's contexts, playback policy, request counter, and reload state. YouTube could consequently request an immediate player reload for the newly selected format, recreating the black-player and reload behavior addressed in #460.

Format switches now clear the old backoff timer and start a fresh SABR session after Shaka finishes unloading. The init-segment cache remains intact, so switching formats does not needlessly refetch reusable initialization data.

The format-switch playback regression now switches away and back, requiring both formats to finish loading without changing the watch route. A unit regression covers the exact SABR state reset.

## Release note category
<!-- Select exactly one category. Every pull request must select one. -->
<!-- release-note-category:start -->
- [ ] Not noteworthy
- [ ] Highlights
- [ ] More improvements
- [x] Fixed bugs
<!-- release-note-category:end -->

## Release note
<!-- Required unless "Not noteworthy" is selected. -->
<!-- Write one concise, user-facing entry without a leading bullet. -->
<!-- release-note:start -->
Prevented format changes from causing the player to turn black or unexpectedly reload.
<!-- release-note:end -->

## Release note images
<!-- Human-only: Agents must preserve this entire section and leave it empty. -->
<!-- Optional. Paste one or more Markdown images or HTML image tags here. -->
<!-- The release notes will use an HTML image tag and limit images taller than 300 pixels. -->
<!-- release-note-image:start -->

<!-- release-note-image:end -->

## Testing
<!-- How can reviewers verify that the PR produces correct results? -->
<!-- Please provide instructions so that others can ensure that your pull request would produce correct results. For examples see, https://github.com/FreeTubeApp/FreeTube/pull/5743, https://github.com/FreeTubeApp/FreeTube/pull/7349, https://github.com/FreeTubeApp/FreeTube/pull/5125, https://github.com/FreeTubeApp/FreeTube/pull/7338 -->
<!-- Agent instructions: Only write human-facing steps that explain how to verify the change while running this branch in dev mode. Include expected results and, when applicable, helpful console snippets for interactive verification. Do not include automated checks, commands, results, pass counts, or CI status. -->

1. Start the app in dev mode with the built-in playback engine selected and play a video that uses SABR.
2. Let it play briefly, then switch from DASH to audio and back to DASH. Repeat with the legacy format when it is available.
3. Confirm each selected format resumes at the current position without reloading the watch route, showing a stale SABR backoff timer, or leaving a small black player.

## Additional context
<!-- Add any other context about the pull request here. -->

This is a focused follow-up to the player recovery work merged in #460.
