### PR TITLE
fix(player): show thumbnail while switching formats

### DIFF
--- a/e2e/tests/network/watch.spec.mjs
+++ b/e2e/tests/network/watch.spec.mjs
@@ -239,14 +239,15 @@ test.describe('watch page', () => {
       .toBeGreaterThan(1)
   })
 
-  test('stops querying Shaka state before a format switch unloads it', async ({ page, innertube }) => {
+  test('keeps the thumbnail visible while switching formats', async ({ page, innertube }) => {
     test.skip(!innertube.playback, 'needs real media streams')
     await openVideo(page)
     await waitForPlaybackOrSkip(test, page)
 
+    const initialUrl = page.url()
     const player = page.locator('.ftVideoPlayer')
     const watchComponent = await page.evaluateHandle(findWatchComponent)
-    await player.evaluate((element, watchComponent) => {
+    const formats = await player.evaluate((element, watchComponent) => {
       const overlay = element.ui ?? element.querySelector('video')?.ui
       const shakaPlayer = overlay?.getControls().getPlayer()
       if (!watchComponent || !shakaPlayer) {
@@ -254,18 +255,47 @@ test.describe('watch page', () => {
       }
 
       window.__hasLoadedAtFormatUnload = []
+      window.__blockNextFormatUnload = false
+      window.__formatUnloadBlocked = false
       const unload = shakaPlayer.unload.bind(shakaPlayer)
-      shakaPlayer.unload = (...args) => {
+      shakaPlayer.unload = async (...args) => {
         window.__hasLoadedAtFormatUnload.push(watchComponent.refs.player.hasLoaded)
-        return unload(...args)
+        await unload(...args)
+
+        if (window.__blockNextFormatUnload) {
+          await new Promise(resolve => {
+            window.__finishFormatUnload = resolve
+            window.__formatUnloadBlocked = true
+          })
+        }
       }
 
       const watchView = watchComponent.proxy
-      watchView.handleFormatChange(watchView.activeFormat === 'audio' ? 'dash' : 'audio')
+      const oldFormat = watchView.activeFormat
+      const newFormat = oldFormat === 'audio' ? 'dash' : 'audio'
+      watchView.handleFormatChange(newFormat)
+      return { oldFormat, newFormat }
     }, watchComponent)
-    await watchComponent.dispose()
 
     await expect.poll(() => page.evaluate(() => window.__hasLoadedAtFormatUnload)).toEqual([false])
+    await expect.poll(() => watchComponent.evaluate((component) => ({
+      format: component.proxy.activeFormat,
+      loaded: component.refs.player.hasLoaded
+    }))).toEqual({ format: formats.newFormat, loaded: true })
+    expect(page.url()).toBe(initialUrl)
+
+    await page.evaluate(() => { window.__blockNextFormatUnload = true })
+    await watchComponent.evaluate((component, format) => component.proxy.handleFormatChange(format), formats.oldFormat)
+    await expect.poll(() => page.evaluate(() => window.__formatUnloadBlocked)).toBe(true)
+    await expect(player.locator('video')).toHaveAttribute('poster', /\S+/)
+    await page.evaluate(() => window.__finishFormatUnload())
+    await expect.poll(() => watchComponent.evaluate((component) => ({
+      format: component.proxy.activeFormat,
+      loaded: component.refs.player.hasLoaded
+    }))).toEqual({ format: formats.oldFormat, loaded: true })
+    expect(page.url()).toBe(initialUrl)
+
+    await watchComponent.dispose()
   })
 
   test('keeps audio-only playback at video size with the thumbnail visible', async ({ page, innertube }) => {

--- a/src/renderer/components/ft-shaka-video-player/ft-shaka-video-player.js
+++ b/src/renderer/components/ft-shaka-video-player/ft-shaka-video-player.js
@@ -7933,6 +7933,17 @@ export default defineComponent({
       }
     }
 
+    async function unloadForFormatSwitch() {
+      // The previous frame disappears when Shaka unloads. Keep the normal
+      // player dimensions filled with the thumbnail until the new format has
+      // produced a frame of its own.
+      showPoster.value = true
+
+      try {
+        await player.unload()
+      } catch { }
+    }
+
     watch(
       () => props.format,
       /**
@@ -7952,9 +7963,7 @@ export default defineComponent({
         // format switch happened before the player loaded, probably because of an error
         // as there are no previous player settings to restore, we should treat it like this was the original format
         if (!hasLoaded.value) {
-          try {
-            await player.unload()
-          } catch { }
+          await unloadForFormatSwitch()
 
           ignoreErrors = false
 
@@ -8021,9 +8030,7 @@ export default defineComponent({
             dimension = preferredVideoQuality.value
           }
 
-          try {
-            await player.unload()
-          } catch { }
+          await unloadForFormatSwitch()
 
           ignoreErrors = false
           queuePlaybackRateRestore(playbackRate)
@@ -8087,9 +8094,7 @@ export default defineComponent({
             previousQuality = previousTrack.height > previousTrack.width ? previousTrack.width : previousTrack.height
           }
 
-          try {
-            await player.unload()
-          } catch { }
+          await unloadForFormatSwitch()
 
           ignoreErrors = false
 


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Make sure to follow the contributing guidelines. -->
<!-- Important note, we may remove your pull request if you do not use this provided PR template correctly. -->
<!-- Agent instructions: Preserve every heading, comment, and marker in this template. Never remove or rewrite the release-note-category:start/end, release-note:start/end, or release-note-image:start/end marker pairs. Never remove or rewrite the Release note images section; leave its contents for a human. -->

## Pull Request Type
<!-- Please select what type of pull request this is: [x] -->
- [x] Bugfix
- [ ] Feature Implementation
- [ ] Documentation
- [ ] Other

## Related issue
<!-- Please link the issue your pull request is referring to. -->
<!-- If this pull request fully resolves the relevant issue, put "closes" before the issue number. -->
<!-- Example: "closes #123456". -->

Follow-up to #460.

## Description
<!-- Please write a clear and concise description of what the pull request does. -->

Once playback starts, the player removes its poster so Chromium can display video frames normally. During a manual format switch, Shaka unloads the current stream and removes its final frame, but the poster previously remained disabled. This left the normal player surface black until the replacement format produced a frame.

The player now restores the thumbnail immediately before a format-switch unload. The existing playing handler removes it again after the newly selected video format produces a frame; audio mode continues displaying the thumbnail throughout playback.

The playback regression deliberately pauses between Shaka unload and reload, verifies that the thumbnail remains visible during that interval, then confirms both format changes finish without reloading the watch route.

## Release note category
<!-- Select exactly one category. Every pull request must select one. -->
<!-- release-note-category:start -->
- [ ] Not noteworthy
- [ ] Highlights
- [ ] More improvements
- [x] Fixed bugs
<!-- release-note-category:end -->

## Release note
<!-- Required unless "Not noteworthy" is selected. -->
<!-- Write one concise, user-facing entry without a leading bullet. -->
<!-- release-note:start -->
Show the video thumbnail instead of a black player while switching playback formats.
<!-- release-note:end -->

## Release note images
<!-- Human-only: Agents must preserve this entire section and leave it empty. -->
<!-- Optional. Paste one or more Markdown images or HTML image tags here. -->
<!-- The release notes will use an HTML image tag and limit images taller than 300 pixels. -->
<!-- release-note-image:start -->

<!-- release-note-image:end -->

## Testing
<!-- How can reviewers verify that the PR produces correct results? -->
<!-- Please provide instructions so that others can ensure that your pull request would produce correct results. For examples see, https://github.com/FreeTubeApp/FreeTube/pull/5743, https://github.com/FreeTubeApp/FreeTube/pull/7349, https://github.com/FreeTubeApp/FreeTube/pull/5125, https://github.com/FreeTubeApp/FreeTube/pull/7338 -->
<!-- Agent instructions: Only write human-facing steps that explain how to verify the change while running this branch in dev mode. Include expected results and, when applicable, helpful console snippets for interactive verification. Do not include automated checks, commands, results, pass counts, or CI status. -->

1. Start the app in dev mode and play a video.
2. Switch from DASH to audio or legacy, then switch back to DASH.
3. Confirm the thumbnail fills the normally sized player while each new format loads, then disappears when video playback resumes. The player should not show an empty black surface or reload the watch route.

## Additional context
<!-- Add any other context about the pull request here. -->

This replaces the closed #504 with the corrected, locally verified fix.
