### PR TITLE
feat(ui): animate custom select dropdowns

### DIFF
--- a/src/renderer/components/FtSelect/FtSelect.css
+++ b/src/renderer/components/FtSelect/FtSelect.css
@@ -91,6 +91,25 @@
   box-shadow: 0 2px 8px rgb(0 0 0 / 35%);
 }
 
+.selectDropdown.above {
+  transform-origin: bottom;
+}
+
+.selectDropdown.below {
+  transform-origin: top;
+}
+
+.select-dropdown-enter-active,
+.select-dropdown-leave-active {
+  transition: opacity 120ms ease, transform 120ms ease;
+}
+
+.select-dropdown-enter-from,
+.select-dropdown-leave-to {
+  opacity: 0;
+  transform: scaleY(0.96);
+}
+
 .selectOption {
   box-sizing: border-box;
   min-block-size: 34px;
@@ -128,6 +147,7 @@
   border-inline-end: 6px solid transparent;
   pointer-events: none;
   color: var(--tertiary-text-color);
+  transition: transform 120ms ease;
 }
 
 .iconSelect.ft-icon,
@@ -140,6 +160,10 @@
 .disabled + .iconSelect {
   opacity: 0.4;
   cursor: not-allowed;
+}
+
+.select.open .iconSelect {
+  transform: translateY(-50%) rotate(180deg);
 }
 
 .selectIndicators {
@@ -245,5 +269,13 @@
 
   .select.containsTooltip {
     inline-size: calc(100% - 28px);
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .select-dropdown-enter-active,
+  .select-dropdown-leave-active,
+  .iconSelect {
+    transition: none;
   }
 }

--- a/src/renderer/components/FtSelect/FtSelect.vue
+++ b/src/renderer/components/FtSelect/FtSelect.vue
@@ -88,37 +88,40 @@
       />
     </span>
     <Teleport to="body">
-      <ul
-        v-if="dropdownShown"
-        :id="`${id}-listbox`"
-        ref="dropdown"
-        v-overlay-scrollbars
-        class="selectDropdown"
-        role="listbox"
-        :aria-labelledby="`${id}-label`"
-        :style="dropdownStyle"
-        @pointerdown="handleDropdownPointerDown"
-      >
-        <li
-          v-for="(name, index) in selectNames"
-          :id="`${id}-option-${index}`"
-          :key="selectValues[index]"
-          ref="options"
-          class="selectOption"
-          :class="{ active: index === activeIndex, selected: selectValues[index] === value }"
-          role="option"
-          tabindex="-1"
-          :aria-selected="selectValues[index] === value"
-          :dir="isLocaleSelector ? 'auto' : null"
-          :lang="isLocaleSelector && selectValues[index] !== 'system' && selectValues[index] !== '' ? selectValues[index] : null"
-          @mousedown.prevent
-          @pointermove="activeIndex = index"
-          @click="selectOption(index)"
-          @keydown.enter.space.prevent="selectOption(index)"
+      <Transition name="select-dropdown">
+        <ul
+          v-if="dropdownShown"
+          :id="`${id}-listbox`"
+          ref="dropdown"
+          v-overlay-scrollbars
+          class="selectDropdown"
+          :class="dropdownPlacement"
+          role="listbox"
+          :aria-labelledby="`${id}-label`"
+          :style="dropdownStyle"
+          @pointerdown="handleDropdownPointerDown"
         >
-          {{ name }}
-        </li>
-      </ul>
+          <li
+            v-for="(name, index) in selectNames"
+            :id="`${id}-option-${index}`"
+            :key="selectValues[index]"
+            ref="options"
+            class="selectOption"
+            :class="{ active: index === activeIndex, selected: selectValues[index] === value }"
+            role="option"
+            tabindex="-1"
+            :aria-selected="selectValues[index] === value"
+            :dir="isLocaleSelector ? 'auto' : null"
+            :lang="isLocaleSelector && selectValues[index] !== 'system' && selectValues[index] !== '' ? selectValues[index] : null"
+            @mousedown.prevent
+            @pointermove="activeIndex = index"
+            @click="selectOption(index)"
+            @keydown.enter.space.prevent="selectOption(index)"
+          >
+            {{ name }}
+          </li>
+        </ul>
+      </Transition>
     </Teleport>
   </div>
 </template>
@@ -192,6 +195,7 @@ const options = useTemplateRef('options')
 const dropdownShown = ref(false)
 const activeIndex = ref(0)
 const dropdownStyle = ref({})
+const dropdownPlacement = ref('below')
 let typeahead = ''
 let typeaheadTimer = null
 let pointerDownInDropdown = false
@@ -277,6 +281,7 @@ function updateDropdownPosition() {
         Math.min(buttonRect.bottom + menuGap, maximumBottom - menuHeight)
       )
 
+  dropdownPlacement.value = openAbove ? 'above' : 'below'
   dropdownStyle.value = {
     inlineSize: `${menuWidth}px`,
     left: `${left}px`,


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Make sure to follow the contributing guidelines. -->
<!-- Important note, we may remove your pull request if you do not use this provided PR template correctly. -->
<!-- Agent instructions: Preserve every heading, comment, and marker in this template. Never remove or rewrite the release-note-category:start/end, release-note:start/end, or release-note-image:start/end marker pairs. Never remove or rewrite the Release note images section; leave its contents for a human. -->

## Pull Request Type
<!-- Please select what type of pull request this is: [x] -->
- [ ] Bugfix
- [x] Feature Implementation
- [ ] Documentation
- [ ] Other

## Related issue
<!-- Please link the issue your pull request is referring to. -->
<!-- If this pull request fully resolves the relevant issue, put "closes" before the issue number. -->
<!-- Example: "closes #123456". -->

## Description
<!-- Please write a clear and concise description of what the pull request does. -->
Animates custom select dropdowns as they open and close with a short fade and vertical scale transition. The transform origin follows whether the menu opens above or below its control, and the select arrow rotates to reflect the open state. The transitions are disabled when reduced motion is preferred.

## Release note category
<!-- Select exactly one category. Every pull request must select one. -->
<!-- release-note-category:start -->
- [x] Not noteworthy
- [ ] Highlights
- [ ] More improvements
- [ ] Fixed bugs
<!-- release-note-category:end -->

## Release note
<!-- Required unless "Not noteworthy" is selected. -->
<!-- Write one concise, user-facing entry without a leading bullet. -->
<!-- release-note:start -->
Custom select menus now animate smoothly when opening and closing.
<!-- release-note:end -->

## Release note images
<!-- Human-only: Agents must preserve this entire section and leave it empty. -->
<!-- Optional. Paste one or more Markdown images or HTML image tags here. -->
<!-- The release notes will use an HTML image tag and limit images taller than 300 pixels. -->
<!-- release-note-image:start -->

<!-- release-note-image:end -->

## Testing
<!-- How can reviewers verify that the PR produces correct results? -->
<!-- Please provide instructions so that others can ensure that your pull request would produce correct results. For examples see, https://github.com/FreeTubeApp/FreeTube/pull/5743, https://github.com/FreeTubeApp/FreeTube/pull/7349, https://github.com/FreeTubeApp/FreeTube/pull/5125, https://github.com/FreeTubeApp/FreeTube/pull/7338 -->
<!-- Agent instructions: Only write human-facing steps that explain how to verify the change while running this branch in dev mode. Include expected results and, when applicable, helpful console snippets for interactive verification. Do not include automated checks, commands, results, pass counts, or CI status. -->
1. Open Settings and click any select control. Confirm the dropdown fades and expands from the edge nearest the control while the arrow rotates upward.
2. Select an option, click the control again, press Escape, and click outside the menu. Confirm the dropdown animates closed for each closing method.
3. Test controls near the bottom of the viewport so a dropdown opens above its control. Confirm it expands upward from its bottom edge.
4. Enable reduced motion at the system level and reopen a select. Confirm the menu and arrow change state without animation.

## Additional context
<!-- Add any other context about the pull request here. -->
This follows the custom select menu implementation merged in #482.
