### PR TITLE
fix(yt-dlp): respect the proxy settings

### DIFF
--- a/PRIVACY.md
+++ b/PRIVACY.md
@@ -25,7 +25,7 @@ Rows for optional services apply only when the feature is enabled. An IP address
 | Return YouTube Dislike | Configured Return YouTube Dislike operator | IP address, video identifiers, and timing |
 | Enhanced-privacy sync | Configured sync operator | IP address, account identifier, authentication data, encrypted payloads, collection names, payload sizes, revisions, and timing; not the decrypted selected data |
 | Legacy sync | Configured sync operator | IP address, account identifier, authentication data, selected synced data, and timing |
-| `yt-dlp` playback and downloads | YouTube and any proxy configured for `yt-dlp` | IP address, requested page and media resources, video identifier, formats, and timing. OpenTubeX's own proxy setting is not automatically passed to `yt-dlp` |
+| `yt-dlp` playback and downloads | YouTube and the configured proxy, if any | IP address, requested page and media resources, video identifier, formats, and timing. OpenTubeX's proxy setting is passed to `yt-dlp`, and is also used for downloading the managed `yt-dlp` and FFmpeg binaries |
 
 HTTPS encrypts request paths and payloads in transit, but DNS providers and network operators may still learn destination hostnames and traffic patterns. A VPN or Tor changes which parties see your direct IP address; it does not prevent the destination service from seeing the request itself.
 
@@ -34,4 +34,4 @@ HTTPS encrypts request paths and payloads in transit, but DNS providers and netw
 - To keep app data local, leave synchronization disabled.
 - To prevent a sync operator from reading synced data, use a server that supports enhanced-privacy sync and use a separate, strong privacy passphrase.
 - To avoid sending requests to optional services, leave SponsorBlock, DeArrow, Return YouTube Dislike, and synchronization disabled.
-- To hide your direct IP address from YouTube or optional services, route the relevant requests through a trusted VPN or Tor and verify the proxy configuration. Configure `yt-dlp` separately when using it for playback or downloads.
+- To hide your direct IP address from YouTube or optional services, route the relevant requests through a trusted VPN or Tor and verify the proxy configuration. This includes `yt-dlp` when it is used for playback or downloads, unless custom `yt-dlp` arguments override the proxy.

--- a/PRIVACY.md
+++ b/PRIVACY.md
@@ -34,4 +34,4 @@ HTTPS encrypts request paths and payloads in transit, but DNS providers and netw
 - To keep app data local, leave synchronization disabled.
 - To prevent a sync operator from reading synced data, use a server that supports enhanced-privacy sync and use a separate, strong privacy passphrase.
 - To avoid sending requests to optional services, leave SponsorBlock, DeArrow, Return YouTube Dislike, and synchronization disabled.
-- To hide your direct IP address from YouTube or optional services, route the relevant requests through a trusted VPN or Tor and verify the proxy configuration. This includes `yt-dlp` when it is used for playback or downloads, unless custom `yt-dlp` arguments override the proxy.
+- To hide your direct IP address from YouTube or optional services, route the relevant requests through a trusted VPN or Tor and verify the proxy configuration.

--- a/src/main/utils.js
+++ b/src/main/utils.js
@@ -1,4 +1,28 @@
 /**
+ * Builds a proxy URL from the app's proxy settings,
+ * for tools that take the proxy as a single URL (e.g. yt-dlp's `--proxy`).
+ * @param {{
+ *   protocol?: string,
+ *   hostname?: string,
+ *   port?: string | number,
+ *   username?: string,
+ *   password?: string
+ * }} proxySettings
+ * @returns {string | null} null when the settings are incomplete
+ */
+export function buildProxyUrl({ protocol, hostname, port, username, password }) {
+  if (!protocol || !hostname || !port) {
+    return null
+  }
+
+  const credentials = username
+    ? `${encodeURIComponent(username)}:${encodeURIComponent(password ?? '')}@`
+    : ''
+
+  return `${protocol}://${credentials}${hostname}:${port}`
+}
+
+/**
  * @param {string | URL} url
  */
 export function isOpenTubeXUrl(url) {

--- a/src/main/utils.js
+++ b/src/main/utils.js
@@ -19,7 +19,12 @@ export function buildProxyUrl({ protocol, hostname, port, username, password }) 
     ? `${encodeURIComponent(username)}:${encodeURIComponent(password ?? '')}@`
     : ''
 
-  return `${protocol}://${credentials}${hostname}:${port}`
+  // IPv6 addresses have to be wrapped in brackets to separate them from the port
+  const host = hostname.includes(':') && !hostname.startsWith('[')
+    ? `[${hostname}]`
+    : hostname
+
+  return `${protocol}://${credentials}${host}:${port}`
 }
 
 /**

--- a/src/main/ytDlp.js
+++ b/src/main/ytDlp.js
@@ -4,9 +4,9 @@ import { chmod, mkdir, readFile, rename, writeFile } from 'node:fs/promises'
 import { join } from 'node:path'
 import { promisify } from 'node:util'
 import { inflateRawSync } from 'node:zlib'
-import { app, BrowserWindow } from 'electron'
+import { app, BrowserWindow, net } from 'electron'
 import { settings } from '../datastores/handlers/base'
-import { isOpenTubeXUrl } from './utils'
+import { buildProxyUrl, isOpenTubeXUrl } from './utils'
 import { IpcChannels } from '../constants'
 import { getMatchingDownloadValidators, getYtDlpAssetName } from './ytDlpAsset'
 
@@ -128,6 +128,35 @@ async function resolveExecutable(sourceSettingId, pathSettingId, binaryName, sou
 }
 
 /**
+ * Builds the proxy URL for yt-dlp's `--proxy` argument from the app's proxy settings.
+ * @returns {Promise<string | null>} null when no proxy is configured
+ */
+async function getProxyUrl() {
+  if (!(await settings._findOne('useProxy'))?.value) {
+    return null
+  }
+
+  return buildProxyUrl({
+    protocol: (await settings._findOne('proxyProtocol'))?.value,
+    hostname: (await settings._findOne('proxyHostname'))?.value,
+    port: (await settings._findOne('proxyPort'))?.value,
+    username: (await settings._findOne('proxyUsername'))?.value,
+    password: (await settings._findOne('proxyPassword'))?.value
+  })
+}
+
+/**
+ * @param {string[]} args
+ */
+async function pushProxyArgument(args) {
+  const proxyUrl = await getProxyUrl()
+
+  if (proxyUrl !== null) {
+    args.push('--proxy', proxyUrl)
+  }
+}
+
+/**
  * @param {string} executable
  * @returns {Promise<string | null>} the version, or null if the executable doesn't work
  */
@@ -184,7 +213,9 @@ async function downloadFile(url, onProgress, onDownloadStart, validators) {
     headers['If-Modified-Since'] = validators.lastModified
   }
 
-  const response = await fetch(url, { headers })
+  // use Electron's net module instead of fetch, so that the download
+  // goes through the configured proxy (including its authentication)
+  const response = await net.fetch(url, { headers })
 
   if (response.status === 304) {
     return { data: null, validators }
@@ -681,15 +712,7 @@ export async function handleYtDlpGetPlaybackInfo(event, videoId) {
 
   const args = ['--dump-single-json', '--no-playlist', '--no-warnings', '--no-progress', '--socket-timeout', '15']
 
-  if ((await settings._findOne('useProxy'))?.value) {
-    const protocol = (await settings._findOne('proxyProtocol'))?.value
-    const hostname = (await settings._findOne('proxyHostname'))?.value
-    const port = (await settings._findOne('proxyPort'))?.value
-
-    if (protocol && hostname && port) {
-      args.push('--proxy', `${protocol}://${hostname}:${port}`)
-    }
-  }
+  await pushProxyArgument(args)
 
   args.push(`https://www.youtube.com/watch?v=${videoId}`)
 
@@ -766,6 +789,8 @@ export async function handleYtDlpDownload(event, payload) {
   }
 
   const args = ['--newline', '--no-playlist']
+
+  await pushProxyArgument(args)
 
   const ffmpeg = await resolveExecutable('ytDlpFfmpegSource', 'ytDlpFfmpegPath', 'ffmpeg')
 

--- a/tests/unit/proxy-url.test.mjs
+++ b/tests/unit/proxy-url.test.mjs
@@ -17,6 +17,29 @@ test('builds a proxy URL from the proxy settings', () => {
   }), 'http://proxy.example.com:8080')
 })
 
+test('wraps IPv6 hosts in brackets', () => {
+  assert.equal(buildProxyUrl({
+    protocol: 'socks5',
+    hostname: '::1',
+    port: '9050'
+  }), 'socks5://[::1]:9050')
+
+  assert.equal(buildProxyUrl({
+    protocol: 'http',
+    hostname: '2001:db8::1',
+    port: '8080',
+    username: 'user',
+    password: 'pass'
+  }), 'http://user:pass@[2001:db8::1]:8080')
+
+  // already bracketed hosts are left alone
+  assert.equal(buildProxyUrl({
+    protocol: 'socks5',
+    hostname: '[::1]',
+    port: '9050'
+  }), 'socks5://[::1]:9050')
+})
+
 test('includes escaped proxy credentials', () => {
   assert.equal(buildProxyUrl({
     protocol: 'socks5',

--- a/tests/unit/proxy-url.test.mjs
+++ b/tests/unit/proxy-url.test.mjs
@@ -1,0 +1,51 @@
+import assert from 'node:assert/strict'
+import test from 'node:test'
+
+import { buildProxyUrl } from '../../src/main/utils.js'
+
+test('builds a proxy URL from the proxy settings', () => {
+  assert.equal(buildProxyUrl({
+    protocol: 'socks5',
+    hostname: '127.0.0.1',
+    port: '9050'
+  }), 'socks5://127.0.0.1:9050')
+
+  assert.equal(buildProxyUrl({
+    protocol: 'http',
+    hostname: 'proxy.example.com',
+    port: 8080
+  }), 'http://proxy.example.com:8080')
+})
+
+test('includes escaped proxy credentials', () => {
+  assert.equal(buildProxyUrl({
+    protocol: 'socks5',
+    hostname: '127.0.0.1',
+    port: '9050',
+    username: 'user',
+    password: 'p@ss:word'
+  }), 'socks5://user:p%40ss%3Aword@127.0.0.1:9050')
+
+  assert.equal(buildProxyUrl({
+    protocol: 'socks5',
+    hostname: '127.0.0.1',
+    port: '9050',
+    username: 'user'
+  }), 'socks5://user:@127.0.0.1:9050')
+
+  // a password without a username can't be represented, so it is ignored
+  assert.equal(buildProxyUrl({
+    protocol: 'socks5',
+    hostname: '127.0.0.1',
+    port: '9050',
+    password: 'secret'
+  }), 'socks5://127.0.0.1:9050')
+})
+
+test('returns null for incomplete proxy settings', () => {
+  assert.equal(buildProxyUrl({ hostname: '127.0.0.1', port: '9050' }), null)
+  assert.equal(buildProxyUrl({ protocol: 'socks5', port: '9050' }), null)
+  assert.equal(buildProxyUrl({ protocol: 'socks5', hostname: '127.0.0.1' }), null)
+  assert.equal(buildProxyUrl({ protocol: 'socks5', hostname: '', port: '9050' }), null)
+  assert.equal(buildProxyUrl({}), null)
+})


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Make sure to follow the contributing guidelines. -->
<!-- Important note, we may remove your pull request if you do not use this provided PR template correctly. -->
<!-- Agent instructions: Preserve every heading, comment, and marker in this template. Never remove or rewrite the release-note-category:start/end, release-note:start/end, or release-note-image:start/end marker pairs. Never remove or rewrite the Release note images section; leave its contents for a human. -->

## Pull Request Type
<!-- Please select what type of pull request this is: [x] -->
- [x] Bugfix
- [ ] Feature Implementation
- [ ] Documentation
- [ ] Other

## Related issue
<!-- Please link the issue your pull request is referring to. -->
<!-- If this pull request fully resolves the relevant issue, put "closes" before the issue number. -->
<!-- Example: "closes #123456". -->
closes #413

## Description
<!-- Please write a clear and concise description of what the pull request does. -->
The proxy settings were only passed to yt-dlp when extracting playback information, and even there the proxy username and password were ignored. Downloads went out directly, as did the downloads of the managed yt-dlp and FFmpeg binaries.

- The proxy URL is now built in one shared place, including the (URL-encoded) proxy credentials, and is passed to yt-dlp as `--proxy` for both playback extraction and downloads. yt-dlp forwards it to FFmpeg where relevant. It is added before the custom arguments, so a custom `--proxy` still wins.
- The managed yt-dlp and FFmpeg binary downloads now use Electron's `net` module instead of the global `fetch`, so they go through the session proxy and its existing authentication handling.
- `PRIVACY.md` claimed that the proxy setting is not passed to yt-dlp and told users to configure yt-dlp separately, which is no longer accurate.

## Release note category
<!-- Select exactly one category. Every pull request must select one. -->
<!-- release-note-category:start -->
- [ ] Not noteworthy
- [ ] Highlights
- [x] More improvements
- [ ] Fixed bugs
<!-- release-note-category:end -->

## Release note
<!-- Required unless "Not noteworthy" is selected. -->
<!-- Write one concise, user-facing entry without a leading bullet. -->
<!-- release-note:start -->
yt-dlp downloads and playback now use the configured proxy, as do the downloads of the managed yt-dlp and FFmpeg binaries
<!-- release-note:end -->

## Release note images
<!-- Human-only: Agents must preserve this entire section and leave it empty. -->
<!-- Optional. Paste one or more Markdown images or HTML image tags here. -->
<!-- The release notes will use an HTML image tag and limit images taller than 300 pixels. -->
<!-- release-note-image:start -->

<!-- release-note-image:end -->

## Testing
<!-- How can reviewers verify that the PR produces correct results? -->
<!-- Please provide instructions so that others can ensure that your pull request would produce correct results. For examples see, https://github.com/FreeTubeApp/FreeTube/pull/5743, https://github.com/FreeTubeApp/FreeTube/pull/7349, https://github.com/FreeTubeApp/FreeTube/pull/5125, https://github.com/FreeTubeApp/FreeTube/pull/7338 -->
<!-- Agent instructions: Only write human-facing steps that explain how to verify the change while running this branch in dev mode. Include expected results and, when applicable, helpful console snippets for interactive verification. Do not include automated checks, commands, results, pass counts, or CI status. -->
1. Start a proxy you can watch, e.g. Tor on `socks5://127.0.0.1:9050`, or an HTTP proxy with logging such as `mitmproxy` on `http://127.0.0.1:8080`.
2. In Settings > Proxy, enable "Enable Tor / Proxy", enter the protocol, host and port, and confirm that "Test Proxy" reports the proxy's IP address.
3. In Settings > External Software, set yt-dlp and FFmpeg to "Managed" and delete the previously downloaded binaries from the `yt-dlp` folder in your user data directory, then trigger a download of both. They should download successfully, and the proxy log should show the requests to GitHub / ffmpeg.martin-riedl.de.
4. Play a video with yt-dlp playback enabled. It should play, and the proxy log should show yt-dlp's requests to YouTube.
5. Download a video from the video page. The download should complete, and the proxy log should show the media requests.
6. Turn the proxy off again and confirm that playback and downloads still work without a proxy.
7. Optionally, point the proxy setting at a port where nothing is listening: playback and downloads should then fail instead of silently going out directly.
8. If your proxy requires a username and password, fill those in as well and confirm that the requests are accepted.

## Additional context
<!-- Add any other context about the pull request here. -->
Custom yt-dlp arguments are appended after the proxy argument, so a user-supplied `--proxy` continues to take precedence. This is noted in `PRIVACY.md` as well.
