### PR TITLE
fix(updates): clean up the release notes in the update prompt

### DIFF
--- a/e2e/tests/offline/update-modal.spec.mjs
+++ b/e2e/tests/offline/update-modal.spec.mjs
@@ -1,0 +1,84 @@
+import { test, expect, goTo, waitForAppReady } from '../../helpers/app.mjs'
+
+const RELEASES_URL = /^https:\/\/api\.github\.com\/repos\/OpenTubeX\/OpenTubeX\/releases/
+const COMMIT_HASH = '3904e64f503cde6be8793606a04ad69c5d57cef0'
+
+function release(name, tagName, body) {
+  return { name, tag_name: tagName, body, draft: false, prerelease: false }
+}
+
+const NEWEST_NOTES = [
+  '> [!WARNING]',
+  '> Test alert.',
+  '',
+  `Automated development build from commit ${COMMIT_HASH}.`,
+  '',
+  '<details>',
+  '<summary>Show changes</summary>',
+  '',
+  '- Fixed something (#499)',
+  '',
+  '</details>'
+].join('\n')
+
+/**
+ * Serves the given releases to the in-app update check and restarts the
+ * renderer so that it runs with the stub in place.
+ */
+async function showUpdatePrompt(page, releases) {
+  await page.route(RELEASES_URL, (route) => route.fulfill({
+    contentType: 'application/json',
+    body: JSON.stringify(releases)
+  }))
+
+  // The update check only runs at startup, so enable it and reload. The route
+  // above stays installed across the reload, so no request ever leaves.
+  await goTo(page, 'settings')
+  const updateToggle = page.locator('.switch-ctn', { hasText: 'Check for Updates' })
+  await updateToggle.locator('.switch-label').click()
+  await expect(updateToggle.locator('input')).toBeChecked()
+  await page.reload()
+  await waitForAppReady(page)
+
+  await page.locator('.banner-wrapper .banner').click()
+  await expect(page.locator('.changeLogTitle')).toBeVisible()
+}
+
+test('a single update shows its version once and renders the release notes', async ({ page }) => {
+  await showUpdatePrompt(page, [
+    release('OpenTubeX 0.31.0', 'v0.31.0-beta', NEWEST_NOTES)
+  ])
+
+  await expect(page.locator('.changeLogTitle')).toHaveText('Update to OpenTubeX 0.31.0')
+  // The title already names the release, so the notes must not repeat it.
+  await expect(page.locator('.changeLogText h2')).toHaveCount(0)
+
+  const summary = page.locator('.changeLogText summary')
+  const details = page.locator('.changeLogText details')
+  await expect(summary).toBeVisible()
+  // Collapsible sections start expanded, but can still be collapsed.
+  await expect(details).toHaveAttribute('open', '')
+  await expect(page.locator('.changeLogText details li')).toHaveText(/Fixed something/)
+  await summary.click()
+  await expect(details).not.toHaveAttribute('open', '')
+
+  const commitLink = page.locator(`.changeLogText a[href$="${COMMIT_HASH}"]`)
+  await expect(commitLink).toHaveText('3904e64')
+  await expect(commitLink).toHaveAttribute(
+    'href',
+    `https://github.com/OpenTubeX/OpenTubeX/commit/${COMMIT_HASH}`
+  )
+})
+
+test('skipped updates keep a heading per release', async ({ page }) => {
+  await showUpdatePrompt(page, [
+    release('OpenTubeX 0.31.0', 'v0.31.0-beta', 'Newest notes'),
+    release('OpenTubeX 0.30.3', 'v0.30.3-beta', 'Older notes')
+  ])
+
+  await expect(page.locator('.changeLogTitle')).toHaveText('Update to OpenTubeX 0.31.0')
+  await expect(page.locator('.changeLogText h2')).toHaveText([
+    'OpenTubeX 0.31.0',
+    'OpenTubeX 0.30.3'
+  ])
+})

--- a/src/renderer/App.vue
+++ b/src/renderer/App.vue
@@ -78,7 +78,6 @@
         <h1
           :id="labelId"
           class="changeLogTitle"
-          dir="ltr"
         >
           {{ changeLogTitle }}
         </h1>
@@ -315,51 +314,7 @@ import { tabRuntimeRegistry } from './tabs/TabRuntimeRegistry'
 import { getTabPreviewFallbackUrl } from './tabs/tabPreview'
 import { preloadUtilityRoutes } from './router/index'
 
-const GITHUB_ISSUE_URL_PATTERN = /^https:\/\/github\.com\/([\w.-]+)\/([\w.-]+)\/issues\/(\d+)\/?$/i
-const LOCAL_REPOSITORY = 'opentubex/opentubex'
-const UPSTREAM_REPOSITORY = 'freetubeapp/freetube'
-
-const releaseNotesMarkdown = createReleaseNotesMarkdown({
-  extensions: [{
-    name: 'issueReference',
-    level: 'inline',
-    start: (source) => source.search(/#\d+\b/),
-    tokenizer(source, tokens) {
-      const match = /^#(\d+)\b/.exec(source)
-      const previousToken = tokens.at(-1)
-
-      if (match && !this.lexer.state.inLink && !/[\w/]$/.test(previousToken?.raw ?? '')) {
-        return {
-          type: 'issueReference',
-          raw: match[0],
-          issueNumber: match[1]
-        }
-      }
-    },
-    renderer({ issueNumber }) {
-      return `<a href="https://github.com/OpenTubeX/OpenTubeX/issues/${issueNumber}">#${issueNumber}</a>`
-    }
-  }],
-  renderLink(token) {
-    const match = GITHUB_ISSUE_URL_PATTERN.exec(token.href)
-
-    if (!match) {
-      return false
-    }
-
-    const [, owner, repository, issueNumber] = match
-    const repositoryName = `${owner}/${repository}`
-    let label = `${repositoryName}#${issueNumber}`
-
-    if (repositoryName.toLowerCase() === LOCAL_REPOSITORY) {
-      label = `#${issueNumber}`
-    } else if (repositoryName.toLowerCase() === UPSTREAM_REPOSITORY) {
-      label = `${owner}#${issueNumber}`
-    }
-
-    return `<a href="${token.href}">${label}</a>`
-  }
-})
+const releaseNotesMarkdown = createReleaseNotesMarkdown()
 
 const route = useRoute()
 const router = useRouter()
@@ -1709,7 +1664,7 @@ async function checkForNewUpdates() {
       .replaceAll(/https:\/\/github\.com\/OpenTubeX\/OpenTubeX\/pull\/(\d+)/g, '[#$1]($&)')
 
     updateChangelog.value = releaseNotesMarkdown.parse(changelog)
-    changeLogTitle.value = release.name
+    changeLogTitle.value = t('Update to {version}', { version: release.name ?? tagName })
     latestVersionNumber.value = versionNumber
     showUpdatesBanner.value = true
   } catch (error) {

--- a/src/renderer/directives/vSaferHtml.js
+++ b/src/renderer/directives/vSaferHtml.js
@@ -16,7 +16,7 @@ export const vSaferHtml = (element, { value, oldValue, modifiers }) => {
           lenientSanitizer = new Sanitizer({
             comments: false,
             elements: [
-              'br', 'code', 'del', 'details', 'em',
+              'br', 'code', 'del', 'em',
               'h1', 'h2', 'h3', 'h4', 'h5', 'h6', 'hr', 'kbd',
               'p', 'pre', 's', 'strong', 'summary',
               'table', 'tbody', 'td', 'th', 'thead', 'tr',
@@ -28,6 +28,10 @@ export const vSaferHtml = (element, { value, oldValue, modifiers }) => {
               {
                 name: 'blockquote',
                 attributes: ['data-alert']
+              },
+              {
+                name: 'details',
+                attributes: ['open']
               },
               {
                 name: 'img',
@@ -46,6 +50,16 @@ export const vSaferHtml = (element, { value, oldValue, modifiers }) => {
         }
 
         element.setHTML(value, { sanitizer: lenientSanitizer })
+
+        // Chromium doesn't set up the internal disclosure widget for details elements
+        // that setHTML creates, so their summary stays invisible and they can't be
+        // expanded. Recreating the elements makes them behave as expected.
+        for (const details of element.querySelectorAll('details')) {
+          const replacement = document.createElement('details')
+          replacement.toggleAttribute('open', details.hasAttribute('open'))
+          replacement.append(...details.childNodes)
+          details.replaceWith(replacement)
+        }
       } else {
         element.innerHTML = DOMPurify.sanitize(value, { RETURN_TRUSTED_TYPE: false })
       }

--- a/src/renderer/helpers/releaseNotesMarkdown.js
+++ b/src/renderer/helpers/releaseNotesMarkdown.js
@@ -1,16 +1,97 @@
 import { Marked } from 'marked'
 
 const GITHUB_ALERT_TYPES = /NOTE|TIP|IMPORTANT|WARNING|CAUTION/i
+const GITHUB_ISSUE_URL_PATTERN = /^https:\/\/github\.com\/([\w.-]+)\/([\w.-]+)\/issues\/(\d+)\/?$/i
+const LOCAL_REPOSITORY = 'opentubex/opentubex'
+const UPSTREAM_REPOSITORY = 'freetubeapp/freetube'
+
+/**
+ * Shortens links to GitHub issues to a reference like #1234.
+ *
+ * @param {import('marked').Tokens.Link} token
+ * @returns {string | false}
+ */
+function renderIssueLink(token) {
+  const match = GITHUB_ISSUE_URL_PATTERN.exec(token.href)
+
+  if (!match) {
+    return false
+  }
+
+  const [, owner, repository, issueNumber] = match
+  const repositoryName = `${owner}/${repository}`
+  let label = `${repositoryName}#${issueNumber}`
+
+  if (repositoryName.toLowerCase() === LOCAL_REPOSITORY) {
+    label = `#${issueNumber}`
+  } else if (repositoryName.toLowerCase() === UPSTREAM_REPOSITORY) {
+    label = `${owner}#${issueNumber}`
+  }
+
+  return `<a href="${token.href}">${label}</a>`
+}
+
+/**
+ * Whether a reference starts here instead of in the middle of a word or URL.
+ *
+ * @param {import('marked').Token[]} tokens
+ * @returns {boolean}
+ */
+function startsNewReference(tokens) {
+  return !/[\w/]$/.test(tokens.at(-1)?.raw ?? '')
+}
+
+/** @type {import('marked').TokenizerAndRendererExtension} */
+const issueReferenceExtension = {
+  name: 'issueReference',
+  level: 'inline',
+  start: (source) => source.search(/#\d+\b/),
+  tokenizer(source, tokens) {
+    const match = /^#(\d+)\b/.exec(source)
+
+    if (match && !this.lexer.state.inLink && startsNewReference(tokens)) {
+      return {
+        type: 'issueReference',
+        raw: match[0],
+        issueNumber: match[1]
+      }
+    }
+  },
+  renderer({ issueNumber }) {
+    return `<a href="https://github.com/OpenTubeX/OpenTubeX/issues/${issueNumber}">#${issueNumber}</a>`
+  }
+}
+
+/** @type {import('marked').TokenizerAndRendererExtension} */
+const commitReferenceExtension = {
+  name: 'commitReference',
+  level: 'inline',
+  start: (source) => source.search(/\b[\da-f]{40}\b/),
+  tokenizer(source, tokens) {
+    const match = /^[\da-f]{40}\b/.exec(source)
+
+    if (match && !this.lexer.state.inLink && startsNewReference(tokens)) {
+      return {
+        type: 'commitReference',
+        raw: match[0],
+        commitHash: match[0]
+      }
+    }
+  },
+  renderer({ commitHash }) {
+    return `<a href="https://github.com/OpenTubeX/OpenTubeX/commit/${commitHash}"><code>${commitHash.slice(0, 7)}</code></a>`
+  }
+}
 
 /**
  * Creates the Markdown renderer used for update release notes.
  *
- * @param {object} options
+ * @param {object} [options]
  * @param {import('marked').MarkedExtension[]} [options.extensions]
- * @param {(token: import('marked').Tokens.Link) => string | false} options.renderLink
+ * @param {(token: import('marked').Tokens.Link) => string | false} [options.renderLink]
  * @returns {Marked}
  */
-export function createReleaseNotesMarkdown({ extensions = [], renderLink }) {
+export function createReleaseNotesMarkdown({ extensions = [], renderLink = renderIssueLink } = {}) {
   return new Marked({
     extensions: [{
       name: 'githubAlert',
@@ -38,9 +119,12 @@ export function createReleaseNotesMarkdown({ extensions = [], renderLink }) {
       renderer(token) {
         return `<blockquote data-alert="${token.alertType}">\n${this.parser.parse(token.tokens)}</blockquote>\n`
       }
-    }, ...extensions],
+    }, issueReferenceExtension, commitReferenceExtension, ...extensions],
     renderer: {
-      link: renderLink
+      link: renderLink,
+      // Release notes are the only thing in the prompt, so show collapsible
+      // sections expanded instead of making them a second click.
+      html: ({ text }) => text.replace(/^<details(?=[\s>])/i, '<details open')
     }
   })
 }

--- a/src/renderer/helpers/releaseUpdates.js
+++ b/src/renderer/helpers/releaseUpdates.js
@@ -112,11 +112,16 @@ export function findUpdateRelease(releases, installedVersion) {
 
 /**
  * Combines release notes into a changelog with a heading for each release.
+ * A single release gets no heading, as the prompt title already names it.
  *
  * @param {Array<{ body?: string | null, name?: string | null, tag_name?: string }>} releases
  * @returns {string}
  */
 export function formatReleaseChangelog(releases) {
+  if (releases.length === 1) {
+    return releases[0].body ?? ''
+  }
+
   return releases.map((release) => {
     const title = release.name ?? release.tag_name ?? ''
     return `## ${title}\n\n${release.body ?? ''}`

--- a/static/locales/en-US.yaml
+++ b/static/locales/en-US.yaml
@@ -48,6 +48,7 @@ No matches: No matches
 
 Version {versionNumber} is now available!  Click for more details: Version {versionNumber} is now available!  Click
   for more details
+Update to {version}: Update to {version}
 Download From Site: Download From Site
 Are you sure you want to open this link?: Are you sure you want to open this link?
 

--- a/tests/unit/release-notes-markdown.test.mjs
+++ b/tests/unit/release-notes-markdown.test.mjs
@@ -3,7 +3,8 @@ import test from 'node:test'
 
 import { createReleaseNotesMarkdown } from '../../src/renderer/helpers/releaseNotesMarkdown.js'
 
-const markdown = createReleaseNotesMarkdown({ renderLink: () => false })
+const markdown = createReleaseNotesMarkdown()
+const COMMIT_HASH = '3904e64f503cde6be8793606a04ad69c5d57cef0'
 
 test('renders GitHub alerts without showing their marker', () => {
   const html = markdown.parse('> [!WARNING] This nightly build may be unstable.')
@@ -13,9 +14,33 @@ test('renders GitHub alerts without showing their marker', () => {
   assert.doesNotMatch(html, /\[!WARNING\]/)
 })
 
-test('preserves details and summary elements', () => {
+test('preserves details and summary elements and expands them', () => {
   const html = markdown.parse('<details>\n<summary>Show changes</summary>\n\n- A change\n</details>')
 
-  assert.match(html, /<details>/)
+  assert.match(html, /<details open>/)
   assert.match(html, /<summary>Show changes<\/summary>/)
+})
+
+test('links commit hashes to their commit page', () => {
+  const html = markdown.parse(`Automated development build from commit ${COMMIT_HASH}.`)
+
+  assert.match(html, new RegExp(`<a href="https://github\\.com/OpenTubeX/OpenTubeX/commit/${COMMIT_HASH}"><code>3904e64</code></a>`))
+})
+
+test('leaves commit hashes that are already part of a link or code span alone', () => {
+  const commitUrl = `https://github.com/OpenTubeX/OpenTubeX/commit/${COMMIT_HASH}`
+
+  assert.doesNotMatch(markdown.parse(`See ${commitUrl}`), /<a[^>]*><a/)
+  assert.match(markdown.parse(`\`${COMMIT_HASH}\``), new RegExp(`<code>${COMMIT_HASH}</code>`))
+})
+
+test('shortens issue links and references', () => {
+  assert.match(
+    markdown.parse('Fixed in #499'),
+    /<a href="https:\/\/github\.com\/OpenTubeX\/OpenTubeX\/issues\/499">#499<\/a>/
+  )
+  assert.match(
+    markdown.parse('Fixed in [x](https://github.com/freetubeapp/freetube/issues/499)'),
+    /<a href="https:\/\/github\.com\/freetubeapp\/freetube\/issues\/499">freetubeapp#499<\/a>/
+  )
 })

--- a/tests/unit/release-updates.test.mjs
+++ b/tests/unit/release-updates.test.mjs
@@ -212,3 +212,15 @@ test('release changelogs contain the notes for every update', () => {
     '## OpenTubeX 0.30.1\n\nPatch release notes\n\n## OpenTubeX 0.30.0\n\nMinor release notes'
   )
 })
+
+test('a single release changelog has no heading', () => {
+  const releases = [
+    {
+      name: 'OpenTubeX 0.30.1',
+      tag_name: 'v0.30.1-beta',
+      body: 'Patch release notes'
+    }
+  ]
+
+  assert.equal(formatReleaseChangelog(releases), 'Patch release notes')
+})


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Make sure to follow the contributing guidelines. -->
<!-- Important note, we may remove your pull request if you do not use this provided PR template correctly. -->
<!-- Agent instructions: Preserve every heading, comment, and marker in this template. Never remove or rewrite the release-note-category:start/end, release-note:start/end, or release-note-image:start/end marker pairs. Never remove or rewrite the Release note images section; leave its contents for a human. -->

## Pull Request Type
<!-- Please select what type of pull request this is: [x] -->
- [x] Bugfix
- [ ] Feature Implementation
- [ ] Documentation
- [ ] Other

## Related issue
<!-- Please link the issue your pull request is referring to. -->
<!-- If this pull request fully resolves the relevant issue, put "closes" before the issue number. -->
<!-- Example: "closes #123456". -->
Follow-up to #459, where the collapsible sections were only fixed on paper.

## Description
<!-- Please write a clear and concise description of what the pull request does. -->
Three fixes for the in-app update prompt:

- **No more duplicate version heading.** The changelog added a `## <release name>` heading per release, which repeated the prompt title when only one update was available. A single release now renders without a heading; several skipped releases still get one each. The title also changed from the bare version to `Update to <version>`.
- **Collapsible sections actually work.** `<details>` blocks rendered as an empty box: the markup survived sanitizing fine, but Chromium doesn't set up the disclosure widget for `details` elements created by `Element.setHTML()`, so the `summary` computed to `display: block` with a zero-height box and couldn't be expanded. The identical markup via `innerHTML` renders correctly, so the elements are recreated after sanitizing. They now also render expanded, since the release notes are the only content of the prompt.
- **Commit hashes are clickable.** A commit hash in the notes (nightly builds mention one) now links to its commit page, shortened to seven characters. Hashes inside an existing link or a code span are left alone.

The `issueReference` extension and the issue-link renderer moved from `App.vue` into `helpers/releaseNotesMarkdown.js` alongside the new commit reference, so the whole Markdown setup lives in one place and is covered by unit tests.

## Release note category
<!-- Select exactly one category. Every pull request must select one. -->
<!-- release-note-category:start -->
- [ ] Not noteworthy
- [ ] Highlights
- [ ] More improvements
- [x] Fixed bugs
<!-- release-note-category:end -->

## Release note
<!-- Required unless "Not noteworthy" is selected. -->
<!-- Write one concise, user-facing entry without a leading bullet. -->
<!-- release-note:start -->
The update prompt no longer repeats the version it is offering, shows collapsible sections of the release notes expanded instead of as an empty box, and links commit hashes to their commit page.
<!-- release-note:end -->

## Release note images
<!-- Human-only: Agents must preserve this entire section and leave it empty. -->
<!-- Optional. Paste one or more Markdown images or HTML image tags here. -->
<!-- The release notes will use an HTML image tag and limit images taller than 300 pixels. -->
<!-- release-note-image:start -->

<!-- release-note-image:end -->

## Testing
<!-- How can reviewers verify that the PR produces correct results? -->
<!-- Please provide instructions so that others can ensure that your pull request would produce correct results. For examples see, https://github.com/FreeTubeApp/FreeTube/pull/5743, https://github.com/FreeTubeApp/FreeTube/pull/7349, https://github.com/FreeTubeApp/FreeTube/pull/5125, https://github.com/FreeTubeApp/FreeTube/pull/7338 -->
<!-- Agent instructions: Only write human-facing steps that explain how to verify the change while running this branch in dev mode. Include expected results and, when applicable, helpful console snippets for interactive verification. Do not include automated checks, commands, results, pass counts, or CI status. -->
The update banner only appears when GitHub has a release newer than the version in `package.json`, so pick a version that leaves exactly one newer release.

**Single update**

1. Set `"version": "0.30.2-nightly-655"` in `package.json`.
2. Make sure *Settings → General → Check for Updates* is enabled (it is by default).
3. Run `pnpm dev` and click the update banner once it appears.

Expected: the title reads `Update to v0.30.2-nightly-656` and the version is not repeated as a heading below it. The *Changelog since the latest stable release* section is already expanded and collapses when clicked, instead of showing an empty rounded box. The commit hash in "Automated development build from commit …" is a link labelled with the short hash and opens the commit page.

**Several skipped updates**

Set `"version": "0.29.0"` instead and reopen the prompt. Expected: every release that was skipped still has its own heading in the changelog, with the newest one first.

Revert the `package.json` change afterwards.

## Additional context
<!-- Add any other context about the pull request here. -->
The `open` attribute needs to survive both the sanitizer allow list and the element recreation, so `details` is now listed with an explicit attribute list in `vSaferHtml`.
