### PR TITLE
fix(toast): hide progress notifications in fullscreen again

### DIFF
--- a/e2e/tests/offline/appearance.spec.mjs
+++ b/e2e/tests/offline/appearance.spec.mjs
@@ -93,6 +93,11 @@ test.describe('global progress presentation', () => {
     await expect(progressToast).toHaveCount(0)
     await expect(page.locator('.app > .progressBar')).toHaveCount(0)
 
+    // Only the progress notification is suppressed: a regular toast still has
+    // something to say that the fullscreen player can't tell the user itself
+    await page.evaluate(() => window.ftElectron.showToastOnAllTabs('Copied to clipboard', 10000))
+    await expect(page.locator('.toast', { hasText: 'Copied to clipboard' })).toBeVisible()
+
     await page.evaluate(() => document.exitFullscreen())
     await expect(progressToast).toBeVisible()
   })

--- a/e2e/tests/offline/appearance.spec.mjs
+++ b/e2e/tests/offline/appearance.spec.mjs
@@ -87,10 +87,14 @@ test.describe('global progress presentation', () => {
     })
     await expect(progressToast).toBeVisible()
 
+    // Fullscreen is for watching, so the progress notification steps aside
     await page.evaluate(() => document.querySelector('.app').requestFullscreen())
     await expect.poll(() => page.evaluate(() => document.fullscreenElement !== null)).toBe(true)
-    await expect(progressToast).toBeVisible()
+    await expect(progressToast).toHaveCount(0)
+    await expect(page.locator('.app > .progressBar')).toHaveCount(0)
+
     await page.evaluate(() => document.exitFullscreen())
+    await expect(progressToast).toBeVisible()
   })
 })
 

--- a/src/renderer/components/FtToast/FtToast.vue
+++ b/src/renderer/components/FtToast/FtToast.vue
@@ -182,7 +182,11 @@ const hasHorizontalTabBar = computed(() => {
 /** @type {import('vue').ComputedRef<boolean>} */
 const showTimeoutIndicator = computed(() => store.getters.getShowToastTimeoutIndicator)
 const showProgressToast = computed(() => {
-  return store.getters.getShowProgressBarToast &&
+  // The toast holder is teleported into the fullscreen element, so a progress
+  // toast would sit on top of the fullscreen player. Hide it until fullscreen
+  // is left, as progress updates aren't urgent enough to interrupt playback.
+  return fullscreenTarget.value === null &&
+    store.getters.getShowProgressBarToast &&
     (store.getters.getShowProgressBar ||
       (props.showSubscriptionRefresh && store.getters.getSubscriptionFeedRefreshInProgress))
 })


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Make sure to follow the contributing guidelines. -->
<!-- Important note, we may remove your pull request if you do not use this provided PR template correctly. -->
<!-- Agent instructions: Preserve every heading, comment, and marker in this template. Never remove or rewrite the release-note-category:start/end, release-note:start/end, or release-note-image:start/end marker pairs. Never remove or rewrite the Release note images section; leave its contents for a human. -->

## Pull Request Type
<!-- Please select what type of pull request this is: [x] -->
- [x] Bugfix
- [ ] Feature Implementation
- [ ] Documentation
- [ ] Other

## Related issue
<!-- Please link the issue your pull request is referring to. -->
<!-- If this pull request fully resolves the relevant issue, put "closes" before the issue number. -->
<!-- Example: "closes #123456". -->
Regression from #487.

## Description
<!-- Please write a clear and concise description of what the pull request does. -->
Progress notifications (the subscription refresh toast and the global progress toast) used to stay hidden while the player is fullscreen. #487 generalized the subscription refresh toast into a shared progress toast and the `fullscreenTarget === null` condition was dropped in that rewrite.

Because the toast holder is teleported into the fullscreen element so that regular toasts can show on top of the player, losing that condition didn't merely stop hiding the progress toast — it made it render over the fullscreen video.

This restores the guard, now covering both progress toasts. Regular transient toasts still show in fullscreen, as they always did.

## Release note category
<!-- Select exactly one category. Every pull request must select one. -->
<!-- release-note-category:start -->
- [ ] Not noteworthy
- [ ] Highlights
- [ ] More improvements
- [x] Fixed bugs
<!-- release-note-category:end -->

## Release note
<!-- Required unless "Not noteworthy" is selected. -->
<!-- Write one concise, user-facing entry without a leading bullet. -->
<!-- release-note:start -->
Progress notifications such as the subscription refresh no longer cover the video while watching in fullscreen
<!-- release-note:end -->

## Release note images
<!-- Human-only: Agents must preserve this entire section and leave it empty. -->
<!-- Optional. Paste one or more Markdown images or HTML image tags here. -->
<!-- The release notes will use an HTML image tag and limit images taller than 300 pixels. -->
<!-- release-note-image:start -->

<!-- release-note-image:end -->

## Testing
<!-- How can reviewers verify that the PR produces correct results? -->
<!-- Agent instructions: Only write human-facing steps that explain how to verify the change while running this branch in dev mode. Include expected results and, when applicable, helpful console snippets for interactive verification. Do not include automated checks, commands, results, pass counts, or CI status. -->
Subscription refresh toast:
1. In Settings, make sure the progress notification is enabled (Theme Settings → show progress in a notification) and set the subscription feed auto refresh interval to a short value.
2. Open a video and go fullscreen, then wait for the automatic refresh to kick in.
3. Expected: no refresh notification appears over the video. Leave fullscreen while the refresh is still running and the notification is there.

Global progress toast:
1. Trigger a long-running operation that uses the global progress (e.g. the managed yt-dlp/ffmpeg download in External Software Settings).
2. Go fullscreen on a video while it runs.
3. Expected: the progress notification disappears for the duration of fullscreen and comes back on exit. The global progress bar must not appear in its place while fullscreen.

Regression check: a normal toast (e.g. "Copied to clipboard" via the video's share menu) should still show while fullscreen.

## Additional context
<!-- Add any other context about the pull request here. -->
The e2e assertion for the subscription refresh case was already in the suite and untouched by #487, but it depends on the auto refresh timer and passes vacuously when the refresh has already finished under parallel load, so the regression slipped through. The global progress case had a test asserting the opposite, which is updated here.
