### PR TITLE
fix(comments): show when comments are turned off

### DIFF
--- a/e2e/tests/network/watch.spec.mjs
+++ b/e2e/tests/network/watch.spec.mjs
@@ -9,6 +9,11 @@ const CAPTIONED_VIDEO = {
   title: 'What’s It Like to Be Killed by Nature’s Most Brutal Predator',
   url: 'https://www.youtube.com/watch?v=Xf-uUy5pdUI'
 }
+const COMMENTS_DISABLED_VIDEO = {
+  id: 'Mapn4dhcFlc',
+  title: 'Public Works - How to turn your water on and off',
+  url: 'https://www.youtube.com/watch?v=Mapn4dhcFlc'
+}
 const FULLSCREEN_PLAYLIST_ID = 'fullscreen-preview'
 const FULLSCREEN_PLAYLIST = {
   _id: FULLSCREEN_PLAYLIST_ID,
@@ -697,6 +702,28 @@ test.describe('watch page', () => {
     ])
     expect(continuationResponse.ok()).toBe(true)
     await expect(replies.first()).toBeVisible()
+  })
+
+  test('reports comments as turned off instead of empty', async ({ page, innertube }) => {
+    test.skip(innertube.replay, 'watch page hydration needs the real API')
+    await openVideo(page, COMMENTS_DISABLED_VIDEO)
+
+    const commentSection = page.locator('.commentsArea')
+    await expect(commentSection.locator('.noCommentMsg')).toHaveText(
+      'Comments are turned off',
+      { timeout: 30_000 }
+    )
+    // Nothing to load, sort or reload, so those affordances stay hidden.
+    await expect(commentSection.locator('.getCommentsTitle')).toHaveCount(0)
+    await expect(commentSection.locator('.noCommentActions')).toHaveCount(0)
+    await expect(commentSection.locator('.comment')).toHaveCount(0)
+
+    // Losing the actions must not collapse the card into a cramped strip.
+    const [messageBox, cardBox] = await Promise.all([
+      commentSection.locator('.noCommentMsg').boundingBox(),
+      commentSection.locator('.card').boundingBox()
+    ])
+    expect(cardBox.height).toBeGreaterThanOrEqual(messageBox.height + 40)
   })
 
   test('fullscreen comments dock preserves its active state and scroll position', async ({ page, innertube }) => {

--- a/src/renderer/components/CommentSection/CommentSection.css
+++ b/src/renderer/components/CommentSection/CommentSection.css
@@ -159,6 +159,12 @@
   padding-block: 8px;
 }
 
+/* The sort/reload actions normally give the card its height. Without them the
+   lone message would sit in a cramped strip, so pad it out instead. */
+.noCommentsMessageOnly {
+  padding-block: 24px;
+}
+
 .noCommentActions {
   display: flex;
   flex: 0 0 auto;

--- a/src/renderer/components/CommentSection/CommentSection.vue
+++ b/src/renderer/components/CommentSection/CommentSection.vue
@@ -17,7 +17,7 @@
         @keydown.esc.stop.prevent="sortMenuOpen = false"
       >
         <button
-          v-if="showSortBy"
+          v-if="showSortBy && !commentsDisabled"
           type="button"
           class="fullscreenCommentAction"
           :class="{ active: sortMenuOpen }"
@@ -29,6 +29,7 @@
           <FontAwesomeIcon :icon="['fas', 'arrow-down-short-wide']" />
         </button>
         <button
+          v-if="!commentsDisabled"
           type="button"
           class="fullscreenCommentAction"
           :aria-label="$t('Comments.Reload Comments')"
@@ -336,11 +337,18 @@
         </div>
       </div>
       <div
-        v-else-if="showComments && !isLoading"
+        v-else-if="commentsDisabled || (showComments && !isLoading)"
         class="noComments"
+        :class="{ noCommentsMessageOnly: commentsDisabled || fullscreenOverlay }"
       >
         <h3
-          v-if="isPostComments"
+          v-if="commentsDisabled"
+          class="noCommentMsg"
+        >
+          {{ $t("Comments.Comments are turned off") }}
+        </h3>
+        <h3
+          v-else-if="isPostComments"
           class="noCommentMsg"
         >
           {{ $t("Comments.There are no comments available for this post") }}
@@ -352,7 +360,7 @@
           {{ $t("Comments.There are no comments available for this video") }}
         </h3>
         <div
-          v-if="!fullscreenOverlay"
+          v-if="!fullscreenOverlay && !commentsDisabled"
           class="noCommentActions"
         >
           <FtSelect
@@ -463,6 +471,10 @@ const props = defineProps({
     required: true
   },
   isPostComments: {
+    type: Boolean,
+    default: false,
+  },
+  commentsDisabled: {
     type: Boolean,
     default: false,
   },
@@ -656,7 +668,7 @@ const generalAutoLoadMorePaginatedItemsEnabled = computed(() => {
 })
 
 const canPerformInitialCommentLoading = computed(() => {
-  return commentData.value.length === 0 && !isLoading.value && !showComments.value
+  return !props.commentsDisabled && commentData.value.length === 0 && !isLoading.value && !showComments.value
 })
 
 watch(

--- a/src/renderer/helpers/api/local.js
+++ b/src/renderer/helpers/api/local.js
@@ -669,6 +669,27 @@ export async function getLocalComments(id) {
   return innertube.getComments(id)
 }
 
+/**
+ * When the uploader turns comments off, YouTube replaces the comment section's
+ * continuation with a message ("Comments are turned off."), so requesting the
+ * comments would only ever return an empty page.
+ *
+ * @param {import('youtubei.js').YT.VideoInfo} videoInfo
+ */
+export function areLocalCommentsDisabled(videoInfo) {
+  const itemSections = videoInfo.page[1]?.contents_memo?.get('ItemSection') ?? []
+
+  const commentSection = itemSections.find(itemSection => {
+    return itemSection.target_id === 'comments-section' || itemSection.target_id === 'comment-item-section'
+  })
+
+  if (!commentSection) {
+    return false
+  }
+
+  return !commentSection.contents.some(node => node.type === 'ContinuationItem')
+}
+
 // I know `type & type` is typescript syntax and not valid jsdoc but I couldn't get @extends or @augments to work
 
 /**

--- a/src/renderer/views/Watch/Watch.js
+++ b/src/renderer/views/Watch/Watch.js
@@ -38,6 +38,7 @@ import {
   showToastOnAllTabs
 } from '../../helpers/utils'
 import {
+  areLocalCommentsDisabled,
   generateAudioTrackField,
   getLocalShortLinkedVideo,
   getLocalVideoInfo,
@@ -183,6 +184,7 @@ export default defineComponent({
       theatreLayoutAvailable: window.innerWidth > RESPONSIVE_THEATRE_MODE_MAX_WIDTH,
       videoPlayerLoaded: false,
       isFamilyFriendly: false,
+      commentsDisabled: false,
       isLive: false,
       liveChat: null,
       isLiveContent: false,
@@ -1246,6 +1248,7 @@ export default defineComponent({
       this.playlistScrollPositions.fullscreen = null
       this.isLoading = true
       this.isFamilyFriendly = false
+      this.commentsDisabled = false
       this.isLive = false
       this.liveChat = null
       this.isLiveContent = false
@@ -1621,6 +1624,7 @@ export default defineComponent({
         this.adEndTimeUnixMs = adEndTimeUnixMs
 
         this.isFamilyFriendly = result.basic_info.is_family_safe
+        this.commentsDisabled = areLocalCommentsDisabled(result)
 
         this.recommendedVideos = result.watch_next_feed
           ?.filter((item) => {

--- a/src/renderer/views/Watch/Watch.vue
+++ b/src/renderer/views/Watch/Watch.vue
@@ -872,6 +872,7 @@
           :class="{ theatreWatchVideo: useTheatreMode }"
           :channel-thumbnail="channelThumbnail"
           :channel-name="channelName"
+          :comments-disabled="commentsDisabled"
           :fullscreen-overlay="fullscreenCommentsOpen || shortsCommentsOpen"
           @close-comments="closeFullscreenComments"
           @timestamp-event="changeTimestamp"

--- a/static/locales/en-US.yaml
+++ b/static/locales/en-US.yaml
@@ -1619,6 +1619,7 @@ Comments:
   There are no comments available for this video: There are no comments available
     for this video
   There are no comments available for this post: There are no comments available for this post
+  Comments are turned off: Comments are turned off
   YouTube did not provide advertised replies: YouTube showed that this comment has replies, but did not provide them. They may have been deleted or hidden, so the reply button was removed.
   Load More Comments: Load More Comments
   Pinned by: Pinned by


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Make sure to follow the contributing guidelines. -->
<!-- Important note, we may remove your pull request if you do not use this provided PR template correctly. -->
<!-- Agent instructions: Preserve every heading, comment, and marker in this template. Never remove or rewrite the release-note-category:start/end, release-note:start/end, or release-note-image:start/end marker pairs. Never remove or rewrite the Release note images section; leave its contents for a human. -->

## Pull Request Type
<!-- Please select what type of pull request this is: [x] -->
- [x] Bugfix
- [ ] Feature Implementation
- [ ] Documentation
- [ ] Other

## Related issue
<!-- Please link the issue your pull request is referring to. -->
<!-- If this pull request fully resolves the relevant issue, put "closes" before the issue number. -->
<!-- Example: "closes #123456". -->
None.

## Description
<!-- Please write a clear and concise description of what the pull request does. -->
When an uploader turns comments off, YouTube replaces the comment section's continuation in the watch-next response with a message ("Comments are turned off.") instead of a continuation token:

| | section id | contents |
|---|---|---|
| comments on | `comments-section` | `ContinuationItem` |
| comments off | `comment-item-section` | `Message` |

Without a continuation there is nothing to request, so `getComments()` received a body containing only `responseContext` and threw. That error was already caught, but it fell through to the generic "There are no comments available for this video" empty state — indistinguishable from a video that simply has no comments yet.

This detects the case up front from the watch-next page that is already fetched for every video, so it costs no extra request, and shows a dedicated "Comments are turned off" message instead. The sort and reload buttons are hidden along with it, since there is nothing to sort or reload.

Two details worth noting for review:

- The check keys off the *absence of a `ContinuationItem`* rather than matching the message text, so it does not depend on the interface language.
- If no comment section is present at all, it returns `false` and the previous behaviour is kept, so unusual responses degrade to the old empty state rather than wrongly claiming comments are off.

Dropping the action buttons left the lone message in a cramped strip, so the empty state now pads itself out when it renders without them. That also applies to the fullscreen comments dock, which hides those actions too and had the same squashed look.

This covers the local API. Invidious returns the same `Comments not found.` for disabled and empty alike, so that backend keeps showing the generic message.

## Release note category
<!-- Select exactly one category. Every pull request must select one. -->
<!-- release-note-category:start -->
- [ ] Not noteworthy
- [ ] Highlights
- [ ] More improvements
- [x] Fixed bugs
<!-- release-note-category:end -->

## Release note
<!-- Required unless "Not noteworthy" is selected. -->
<!-- Write one concise, user-facing entry without a leading bullet. -->
<!-- release-note:start -->
Videos with comments turned off now say so instead of showing an empty comment section
<!-- release-note:end -->

## Release note images
<!-- Human-only: Agents must preserve this entire section and leave it empty. -->
<!-- Optional. Paste one or more Markdown images or HTML image tags here. -->
<!-- The release notes will use an HTML image tag and limit images taller than 300 pixels. -->
<!-- release-note-image:start -->

<!-- release-note-image:end -->

## Testing
<!-- How can reviewers verify that the PR produces correct results? -->
<!-- Please provide instructions so that others can ensure that your pull request would produce correct results. For examples see, https://github.com/FreeTubeApp/FreeTube/pull/5743, https://github.com/FreeTubeApp/FreeTube/pull/7349, https://github.com/FreeTubeApp/FreeTube/pull/5125, https://github.com/FreeTubeApp/FreeTube/pull/7338 -->
<!-- Agent instructions: Only write human-facing steps that explain how to verify the change while running this branch in dev mode. Include expected results and, when applicable, helpful console snippets for interactive verification. Do not include automated checks, commands, results, pass counts, or CI status. -->
Make sure the local API is selected as the backend (Settings → General → Preferred API Backend → Local API).

**Comments turned off**

1. Open https://www.youtube.com/watch?v=Mapn4dhcFlc.
2. Scroll down to the comment area.

Expected: it reads "Comments are turned off" straight away, with no "Click to View Comments" link and no sort or reload buttons. The card should have comfortable padding around the message rather than being a thin strip.

3. Play the video, enter fullscreen and open the comments dock.

Expected: the dock shows the same message, and only the close button remains in its header.

**No regression on a normal video**

4. Open https://www.youtube.com/watch?v=jNQXAC9IVRw and scroll to the comment area.

Expected: unchanged — "Click to View Comments" appears, comments load on click, and sorting and reloading still work.

**A video that genuinely has no comments**

5. Open any video whose comments are enabled but empty.

Expected: unchanged — still "There are no comments available for this video", with the sort and reload buttons present.

## Additional context
<!-- Add any other context about the pull request here. -->
Covered by a new network E2E test in `e2e/tests/network/watch.spec.mjs`, which also asserts the empty-state card keeps its padding once the action buttons are gone.
