### PR TITLE
fix(yt-dlp): use the default proxy settings when they were never changed

### DIFF
--- a/src/main/index.js
+++ b/src/main/index.js
@@ -29,7 +29,7 @@ import packageDetails from '../../package.json'
 import { handleOpenInExternalPlayer } from './externalPlayer'
 import { handleYtDlpCancelDownload, handleYtDlpDownload, handleYtDlpDownloadBinary, handleYtDlpGetInfo, handleYtDlpGetPlaybackInfo } from './ytDlp'
 import { generatePoToken } from './poTokenGenerator'
-import { isOpenTubeXUrl } from './utils'
+import { buildProxyUrl, DEFAULT_PROXY_SETTINGS, isOpenTubeXUrl } from './utils'
 import { TabManager, setupTabsIPC } from './tabs/TabManager'
 import { clearAllTabSessions, loadAllTabSessions } from './tabs/TabSessionStore'
 import { isShareableOpenTubeXRoute, transformOpenTubeXRouteUrl } from '../renderer/helpers/share'
@@ -1326,9 +1326,9 @@ function runApp() {
 
     let disableSmoothScrolling = false
     let useProxy = false
-    let proxyProtocol = 'socks5'
-    let proxyHostname = '127.0.0.1'
-    let proxyPort = '9050'
+    let proxyProtocol = DEFAULT_PROXY_SETTINGS.protocol
+    let proxyHostname = DEFAULT_PROXY_SETTINGS.hostname
+    let proxyPort = DEFAULT_PROXY_SETTINGS.port
 
     if (docArray?.length > 0) {
       docArray.forEach((doc) => {
@@ -1370,7 +1370,7 @@ function runApp() {
     }
 
     if (useProxy) {
-      proxyUrl = `${proxyProtocol}://${proxyHostname}:${proxyPort}`
+      proxyUrl = buildProxyUrl({ protocol: proxyProtocol, hostname: proxyHostname, port: proxyPort })
 
       session.defaultSession.setProxy({
         proxyRules: proxyUrl

--- a/src/main/utils.js
+++ b/src/main/utils.js
@@ -1,6 +1,15 @@
+export const DEFAULT_PROXY_SETTINGS = {
+  protocol: 'socks5',
+  hostname: '127.0.0.1',
+  port: '9050'
+}
+
 /**
  * Builds a proxy URL from the app's proxy settings,
  * for tools that take the proxy as a single URL (e.g. yt-dlp's `--proxy`).
+ *
+ * Settings are only written to the database once they get changed,
+ * so missing values mean that the default is still in use.
  * @param {{
  *   protocol?: string,
  *   hostname?: string,
@@ -8,12 +17,12 @@
  *   username?: string,
  *   password?: string
  * }} proxySettings
- * @returns {string | null} null when the settings are incomplete
+ * @returns {string}
  */
 export function buildProxyUrl({ protocol, hostname, port, username, password }) {
-  if (!protocol || !hostname || !port) {
-    return null
-  }
+  protocol ||= DEFAULT_PROXY_SETTINGS.protocol
+  hostname ||= DEFAULT_PROXY_SETTINGS.hostname
+  port ||= DEFAULT_PROXY_SETTINGS.port
 
   const credentials = username
     ? `${encodeURIComponent(username)}:${encodeURIComponent(password ?? '')}@`

--- a/src/main/ytDlp.js
+++ b/src/main/ytDlp.js
@@ -129,7 +129,7 @@ async function resolveExecutable(sourceSettingId, pathSettingId, binaryName, sou
 
 /**
  * Builds the proxy URL for yt-dlp's `--proxy` argument from the app's proxy settings.
- * @returns {Promise<string | null>} null when no proxy is configured
+ * @returns {Promise<string | null>} null when the proxy is disabled
  */
 async function getProxyUrl() {
   if (!(await settings._findOne('useProxy'))?.value) {

--- a/tests/unit/proxy-url.test.mjs
+++ b/tests/unit/proxy-url.test.mjs
@@ -65,10 +65,12 @@ test('includes escaped proxy credentials', () => {
   }), 'socks5://127.0.0.1:9050')
 })
 
-test('returns null for incomplete proxy settings', () => {
-  assert.equal(buildProxyUrl({ hostname: '127.0.0.1', port: '9050' }), null)
-  assert.equal(buildProxyUrl({ protocol: 'socks5', port: '9050' }), null)
-  assert.equal(buildProxyUrl({ protocol: 'socks5', hostname: '127.0.0.1' }), null)
-  assert.equal(buildProxyUrl({ protocol: 'socks5', hostname: '', port: '9050' }), null)
-  assert.equal(buildProxyUrl({}), null)
+// settings are only written to the database once they get changed,
+// so unchanged proxy settings are missing entirely
+test('falls back to the default proxy settings', () => {
+  assert.equal(buildProxyUrl({}), 'socks5://127.0.0.1:9050')
+  assert.equal(buildProxyUrl({ hostname: 'proxy.example.com' }), 'socks5://proxy.example.com:9050')
+  assert.equal(buildProxyUrl({ protocol: 'http', port: '8080' }), 'http://127.0.0.1:8080')
+  assert.equal(buildProxyUrl({ protocol: '', hostname: '', port: '' }), 'socks5://127.0.0.1:9050')
+  assert.equal(buildProxyUrl({ username: 'user', password: 'pass' }), 'socks5://user:pass@127.0.0.1:9050')
 })


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Make sure to follow the contributing guidelines. -->
<!-- Important note, we may remove your pull request if you do not use this provided PR template correctly. -->
<!-- Agent instructions: Preserve every heading, comment, and marker in this template. Never remove or rewrite the release-note-category:start/end, release-note:start/end, or release-note-image:start/end marker pairs. Never remove or rewrite the Release note images section; leave its contents for a human. -->

## Pull Request Type
<!-- Please select what type of pull request this is: [x] -->
- [x] Bugfix
- [ ] Feature Implementation
- [ ] Documentation
- [ ] Other

## Related issue
<!-- Please link the issue your pull request is referring to. -->
<!-- If this pull request fully resolves the relevant issue, put "closes" before the issue number. -->
<!-- Example: "closes #123456". -->
closes #515

Follow-up to #507.

## Description
<!-- Please write a clear and concise description of what the pull request does. -->
Settings are only written to the database once they get changed, so the defaults only exist in the renderer's settings store. Someone who enables the proxy and keeps the default SOCKS5 proxy on `127.0.0.1:9050` — a plain Tor setup — has no `proxyProtocol`, `proxyHostname` or `proxyPort` entry at all. The proxy URL was only built when all three were present, so yt-dlp was started without `--proxy`. This affected the playback extraction from before #507 as well.

The main process already worked around this with its own hardcoded defaults for the Chromium proxy. Those defaults now live in one place and are applied when building the proxy URL, so both the Chromium proxy and yt-dlp behave the same.

## Release note category
<!-- Select exactly one category. Every pull request must select one. -->
<!-- release-note-category:start -->
- [x] Not noteworthy
- [ ] Highlights
- [ ] More improvements
- [ ] Fixed bugs
<!-- release-note-category:end -->

## Release note
<!-- Required unless "Not noteworthy" is selected. -->
<!-- Write one concise, user-facing entry without a leading bullet. -->
<!-- release-note:start -->
Fixed yt-dlp ignoring the proxy when the proxy protocol, host and port were left at their default values
<!-- release-note:end -->

## Release note images
<!-- Human-only: Agents must preserve this entire section and leave it empty. -->
<!-- Optional. Paste one or more Markdown images or HTML image tags here. -->
<!-- The release notes will use an HTML image tag and limit images taller than 300 pixels. -->
<!-- release-note-image:start -->

<!-- release-note-image:end -->

## Testing
<!-- How can reviewers verify that the PR produces correct results? -->
<!-- Please provide instructions so that others can ensure that your pull request would produce correct results. For examples see, https://github.com/FreeTubeApp/FreeTube/pull/5743, https://github.com/FreeTubeApp/FreeTube/pull/7349, https://github.com/FreeTubeApp/FreeTube/pull/5125, https://github.com/FreeTubeApp/FreeTube/pull/7338 -->
<!-- Agent instructions: Only write human-facing steps that explain how to verify the change while running this branch in dev mode. Include expected results and, when applicable, helpful console snippets for interactive verification. Do not include automated checks, commands, results, pass counts, or CI status. -->
1. Start with a fresh profile, or delete the `proxyProtocol`, `proxyHostname` and `proxyPort` entries from `settings.db` in your user data directory, so that the proxy settings are at their defaults.
2. Run Tor locally so that a SOCKS5 proxy listens on `127.0.0.1:9050`.
3. In Settings > Proxy, only enable "Enable Tor / Proxy" and change nothing else. "Test Proxy" should report the Tor exit node's IP address.
4. Play a video with yt-dlp playback enabled, and start a download from the video page. While either runs, check the yt-dlp process arguments, e.g. `pgrep -af yt-dlp`. They should now contain `--proxy socks5://127.0.0.1:9050`, and Tor's log should show the connections.
5. Change the host or port to a wrong value and confirm that playback and downloads fail rather than going out directly.
6. Set the fields back to non-default values (e.g. another host and port) and confirm that those are used instead of the defaults.

## Additional context
<!-- Add any other context about the pull request here. -->
Reported on the nightly that already included #507.
