### PR TITLE
fix(watch): reload once before running the IP block recovery script

### DIFF
--- a/e2e/helpers/watch.mjs
+++ b/e2e/helpers/watch.mjs
@@ -1,0 +1,131 @@
+import crypto from 'node:crypto'
+import { readFile, readdir } from 'node:fs/promises'
+import path from 'node:path'
+import { gunzipSync } from 'node:zlib'
+
+import { repoRoot } from './app.mjs'
+import { fixtureKey } from './innertube.mjs'
+
+const fixtureDir = path.join(repoRoot, 'e2e', 'fixtures', 'innertube', 'watch', 'shows-video-metadata')
+const sharedDir = path.join(repoRoot, 'e2e', 'fixtures', 'innertube', 'shared')
+
+/** The history entry the fixtures below belong to. */
+export const watchHistoryEntry = {
+  _id: 'jNQXAC9IVRw',
+  videoId: 'jNQXAC9IVRw',
+  title: 'Player error test video',
+  author: 'Test Channel',
+  authorId: 'UC-test-channel-id',
+  published: Date.now() - 86_400_000,
+  description: '',
+  viewCount: 1234,
+  lengthSeconds: 600,
+  watchProgress: 10,
+  isWatched: false,
+  timeWatched: Date.now(),
+  isLive: false,
+  type: 'video'
+}
+
+async function fixture(dir, name) {
+  try {
+    return gunzipSync(await readFile(path.join(dir, name)))
+  } catch {
+    return null
+  }
+}
+
+/**
+ * Serves the watch page from fixtures with an unplayable video, so the Watch
+ * view mounts without a real player emitting errors of its own.
+ *
+ * @param {import('./app.mjs').ElectronAppFixture} app
+ * @param {import('@playwright/test').Page} page
+ */
+export async function mockUnplayableWatchPage(app, page) {
+  await app.electronApp.evaluate(({ ipcMain }) => {
+    ipcMain.removeHandler('generate-po-token')
+    ipcMain.handle('generate-po-token', () => 'test-po-token')
+  })
+
+  await page.route(/^https?:\/\//, (route) => route.abort())
+  await page.route(/^https?:\/\//, async (route, request) => {
+    const url = request.url()
+
+    if (url.includes('/img/desktop/unavailable/')) {
+      return route.fulfill({ status: 200, contentType: 'image/png', body: '' })
+    }
+
+    if (/\/s\/player\//.test(url) || /\/sw\.js_data/.test(url)) {
+      const { pathname } = new URL(url)
+      const name = `shared-${crypto.createHash('sha1').update(pathname).digest('hex').slice(0, 12)}.gz`
+      const body = await fixture(sharedDir, name) ??
+        (url.includes('/s/player/') ? await fixture(sharedDir, 'shared-99c4a5c04897.gz') : null)
+      if (body) {
+        return route.fulfill({
+          status: 200,
+          contentType: url.includes('/s/player/') ? 'text/javascript' : 'application/json',
+          body
+        })
+      }
+      return route.abort()
+    }
+
+    if (url.includes('/youtubei/v1/player')) {
+      const files = await readdir(fixtureDir)
+      const body = await fixture(fixtureDir, files.find((file) => file.startsWith('player-')))
+      const json = JSON.parse(body.toString())
+      json.playabilityStatus = { status: 'UNPLAYABLE', reason: 'Video unavailable' }
+      delete json.streamingData
+      return route.fulfill({ status: 200, contentType: 'application/json', body: JSON.stringify(json) })
+    }
+
+    if (url.includes('/youtubei/v1/')) {
+      const key = fixtureKey(url, request.postData())
+      let body = await fixture(fixtureDir, `${key}.0.json.gz`)
+      if (!body) {
+        const endpoint = key.replace(/-[0-9a-f]{12}$/, '')
+        const files = (await readdir(fixtureDir)).filter((file) => file.startsWith(`${endpoint}-`))
+        if (files.length > 0) body = await fixture(fixtureDir, files[0])
+      }
+      if (body) {
+        return route.fulfill({ status: 200, contentType: 'application/json', body })
+      }
+      return route.abort()
+    }
+
+    return route.fallback()
+  })
+}
+
+/**
+ * Returns a handle to the mounted Watch view, so tests can drive its methods
+ * directly instead of going through a real player.
+ *
+ * @param {import('@playwright/test').Page} page
+ */
+export function watchViewHandle(page) {
+  return page.evaluateHandle(() => {
+    const app = document.querySelector('#app')?.__vue_app__
+    const find = (vnode) => {
+      if (vnode?.component?.type?.name === 'Watch') return vnode.component.proxy
+      if (vnode?.component?.subTree) {
+        const match = find(vnode.component.subTree)
+        if (match) return match
+      }
+      if (Array.isArray(vnode?.children)) {
+        for (const child of vnode.children) {
+          const match = find(child)
+          if (match) return match
+        }
+      }
+      return null
+    }
+
+    const watchView = find(app?._container?._vnode)
+    if (!watchView) {
+      throw new Error('Unable to access the watch view')
+    }
+    return watchView
+  })
+}

--- a/e2e/tests/offline/ip-block-recovery.spec.mjs
+++ b/e2e/tests/offline/ip-block-recovery.spec.mjs
@@ -1,7 +1,90 @@
 import { chmod, writeFile } from 'node:fs/promises'
 import path from 'node:path'
 
-import { test, expect } from '../../helpers/app.mjs'
+import { goTo, test, expect } from '../../helpers/app.mjs'
+import { mockUnplayableWatchPage, watchHistoryEntry, watchViewHandle } from '../../helpers/watch.mjs'
+
+test.use({
+  seed: {
+    history: [{ ...watchHistoryEntry, title: 'IP block test video' }]
+  }
+})
+
+/**
+ * Replays streaming URL 403s against the mounted Watch view, recording whether
+ * each one reloaded the video or escalated to the IP block recovery script.
+ *
+ * @param {import('@playwright/test').Page} page
+ * @param {number} errorCount
+ */
+async function replayStreamForbiddenErrors(page, errorCount) {
+  const watchView = await watchViewHandle(page)
+
+  return await watchView.evaluate(async (view, count) => {
+    view.errorMessage = ''
+    view.isLoading = false
+    view.isLive = false
+    view.isPostLiveDvr = false
+    view.activeFormat = 'dash'
+    view.manifestMimeType = 'application/dash+xml'
+    // Not expired, so the 403 isn't attributed to a stale watch session.
+    view.streamingDataExpiryDate = new Date(Date.now() + 3_600_000)
+
+    const reloads = []
+    const recoveries = []
+    view.reloadView = async () => { reloads.push(view.videoId) }
+    view.runIpBlockRecoveryScriptAndReload = async () => {
+      recoveries.push(view.ipBlockDetectedInCurrentChain)
+      return true
+    }
+
+    // 1001 = BAD_HTTP_STATUS, category 1 = NETWORK.
+    const forbiddenError = () => ({
+      severity: 2,
+      category: 1,
+      code: 1001,
+      data: ['https://example.invalid/videoplayback', 403]
+    })
+
+    const steps = []
+    for (let index = 0; index < count; index++) {
+      await view.handlePlayerError(forbiddenError())
+      steps.push({ reloads: reloads.length, recoveries: recoveries.length })
+    }
+
+    return { steps, reloads, recoveries }
+  }, errorCount)
+}
+
+async function openWatchPage(app, page) {
+  await mockUnplayableWatchPage(app, page)
+  await goTo(page, 'history')
+  await page.getByText('IP block test video').click()
+  await expect(page).toHaveURL(/#\/watch\/jNQXAC9IVRw/)
+  await expect(page.locator('.errorMessage')).toBeVisible({ timeout: 30_000 })
+}
+
+test('a streaming URL 403 reloads the video before blaming the IP', async ({ app, page }) => {
+  await openWatchPage(app, page)
+
+  const result = await replayStreamForbiddenErrors(page, 1)
+
+  // Our own IP changing invalidates the issued streaming URLs the same way an
+  // IP block does, so the first 403 must only fetch fresh URLs.
+  expect(result.steps).toEqual([{ reloads: 1, recoveries: 0 }])
+})
+
+test('a streaming URL 403 that survives the reload runs the recovery script', async ({ app, page }) => {
+  await openWatchPage(app, page)
+
+  const result = await replayStreamForbiddenErrors(page, 2)
+
+  expect(result.steps).toEqual([
+    { reloads: 1, recoveries: 0 },
+    { reloads: 1, recoveries: 1 }
+  ])
+  expect(result.recoveries).toEqual([true])
+})
 
 test('subscription refresh waits for an active IP block recovery', async ({ app, page }) => {
   const isWindows = process.platform === 'win32'

--- a/e2e/tests/offline/ip-block-recovery.spec.mjs
+++ b/e2e/tests/offline/ip-block-recovery.spec.mjs
@@ -21,20 +21,35 @@ async function replayStreamForbiddenErrors(page, errorCount) {
   const watchView = await watchViewHandle(page)
 
   return await watchView.evaluate(async (view, count) => {
-    view.errorMessage = ''
-    view.isLoading = false
-    view.isLive = false
-    view.isPostLiveDvr = false
-    view.activeFormat = 'dash'
-    view.manifestMimeType = 'application/dash+xml'
-    // Not expired, so the 403 isn't attributed to a stale watch session.
-    view.streamingDataExpiryDate = new Date(Date.now() + 3_600_000)
+    // The state a video that is playing a DASH stream is in.
+    const enterPlayingState = () => {
+      view.errorMessage = ''
+      view.isLoading = false
+      view.isLive = false
+      view.isPostLiveDvr = false
+      view.activeFormat = 'dash'
+      view.manifestMimeType = 'application/dash+xml'
+      // Not expired, so the 403 isn't attributed to a stale watch session.
+      view.streamingDataExpiryDate = new Date(Date.now() + 3_600_000)
+    }
+
+    enterPlayingState()
 
     const reloads = []
     const recoveries = []
-    view.reloadView = async () => { reloads.push(view.videoId) }
+    // The real reload runs, so that a reset of the one-shot reload state during
+    // a same-video reload would show up here as an extra reload.
+    const reloadView = view.reloadView.bind(view)
+    view.reloadView = async (options) => {
+      reloads.push(view.videoId)
+      await reloadView(options)
+      enterPlayingState()
+    }
+    // Same no-op guard as the real method, so the loads that happen during a
+    // reload don't count as recovery runs.
     view.runIpBlockRecoveryScriptAndReload = async () => {
-      recoveries.push(view.ipBlockDetectedInCurrentChain)
+      if (!view.ipBlockDetectedInCurrentChain) { return false }
+      recoveries.push(view.videoId)
       return true
     }
 
@@ -83,7 +98,7 @@ test('a streaming URL 403 that survives the reload runs the recovery script', as
     { reloads: 1, recoveries: 0 },
     { reloads: 1, recoveries: 1 }
   ])
-  expect(result.recoveries).toEqual([true])
+  expect(result.recoveries).toEqual(['jNQXAC9IVRw'])
 })
 
 test('subscription refresh waits for an active IP block recovery', async ({ app, page }) => {

--- a/e2e/tests/offline/sabr-error-recovery.spec.mjs
+++ b/e2e/tests/offline/sabr-error-recovery.spec.mjs
@@ -1,13 +1,5 @@
-import crypto from 'node:crypto'
-import { readFile, readdir } from 'node:fs/promises'
-import path from 'node:path'
-import { gunzipSync } from 'node:zlib'
-
-import { goTo, repoRoot, test, expect } from '../../helpers/app.mjs'
-import { fixtureKey } from '../../helpers/innertube.mjs'
-
-const fixtureDir = path.join(repoRoot, 'e2e', 'fixtures', 'innertube', 'watch', 'shows-video-metadata')
-const sharedDir = path.join(repoRoot, 'e2e', 'fixtures', 'innertube', 'shared')
+import { goTo, test, expect } from '../../helpers/app.mjs'
+import { mockUnplayableWatchPage, watchHistoryEntry } from '../../helpers/watch.mjs'
 
 // Mirror the module-level Watch constants, which cannot be imported here.
 const MAX_SABR_ERROR_RECOVERIES = 3
@@ -15,92 +7,9 @@ const MAX_SABR_ERROR_RECOVERIES_PER_VIDEO = 8
 
 test.use({
   seed: {
-    history: [{
-      _id: 'jNQXAC9IVRw',
-      videoId: 'jNQXAC9IVRw',
-      title: 'SABR test video',
-      author: 'Test Channel',
-      authorId: 'UC-test-channel-id',
-      published: Date.now() - 86_400_000,
-      description: '',
-      viewCount: 1234,
-      lengthSeconds: 600,
-      watchProgress: 10,
-      isWatched: false,
-      timeWatched: Date.now(),
-      isLive: false,
-      type: 'video'
-    }]
+    history: [{ ...watchHistoryEntry, title: 'SABR test video' }]
   }
 })
-
-async function fixture(dir, name) {
-  try {
-    return gunzipSync(await readFile(path.join(dir, name)))
-  } catch {
-    return null
-  }
-}
-
-/**
- * Serves the watch page from fixtures with an unplayable video, so the Watch
- * view mounts without a real player emitting errors of its own.
- */
-async function mockWatchPage(app, page) {
-  await app.electronApp.evaluate(({ ipcMain }) => {
-    ipcMain.removeHandler('generate-po-token')
-    ipcMain.handle('generate-po-token', () => 'test-po-token')
-  })
-
-  await page.route(/^https?:\/\//, (route) => route.abort())
-  await page.route(/^https?:\/\//, async (route, request) => {
-    const url = request.url()
-
-    if (url.includes('/img/desktop/unavailable/')) {
-      return route.fulfill({ status: 200, contentType: 'image/png', body: '' })
-    }
-
-    if (/\/s\/player\//.test(url) || /\/sw\.js_data/.test(url)) {
-      const { pathname } = new URL(url)
-      const name = `shared-${crypto.createHash('sha1').update(pathname).digest('hex').slice(0, 12)}.gz`
-      const body = await fixture(sharedDir, name) ??
-        (url.includes('/s/player/') ? await fixture(sharedDir, 'shared-99c4a5c04897.gz') : null)
-      if (body) {
-        return route.fulfill({
-          status: 200,
-          contentType: url.includes('/s/player/') ? 'text/javascript' : 'application/json',
-          body
-        })
-      }
-      return route.abort()
-    }
-
-    if (url.includes('/youtubei/v1/player')) {
-      const files = await readdir(fixtureDir)
-      const body = await fixture(fixtureDir, files.find((file) => file.startsWith('player-')))
-      const json = JSON.parse(body.toString())
-      json.playabilityStatus = { status: 'UNPLAYABLE', reason: 'Video unavailable' }
-      delete json.streamingData
-      return route.fulfill({ status: 200, contentType: 'application/json', body: JSON.stringify(json) })
-    }
-
-    if (url.includes('/youtubei/v1/')) {
-      const key = fixtureKey(url, request.postData())
-      let body = await fixture(fixtureDir, `${key}.0.json.gz`)
-      if (!body) {
-        const endpoint = key.replace(/-[0-9a-f]{12}$/, '')
-        const files = (await readdir(fixtureDir)).filter((file) => file.startsWith(`${endpoint}-`))
-        if (files.length > 0) body = await fixture(fixtureDir, files[0])
-      }
-      if (body) {
-        return route.fulfill({ status: 200, contentType: 'application/json', body })
-      }
-      return route.abort()
-    }
-
-    return route.fallback()
-  })
-}
 
 /**
  * Puts the mounted Watch view into "playing a SABR stream on DASH" state, then
@@ -196,7 +105,7 @@ function driveWatchView(page, script, options = {}) {
 }
 
 test('a second SABR failure after successful playback refetches instead of dropping to legacy', async ({ app, page }) => {
-  await mockWatchPage(app, page)
+  await mockUnplayableWatchPage(app, page)
   await goTo(page, 'history')
   await page.getByText('SABR test video').click()
   await expect(page).toHaveURL(/#\/watch\/jNQXAC9IVRw/)
@@ -218,7 +127,7 @@ test('a second SABR failure after successful playback refetches instead of dropp
 })
 
 test('SABR failures that never settle fall back to legacy but never audio', async ({ app, page }) => {
-  await mockWatchPage(app, page)
+  await mockUnplayableWatchPage(app, page)
   await goTo(page, 'history')
   await page.getByText('SABR test video').click()
   await expect(page).toHaveURL(/#\/watch\/jNQXAC9IVRw/)
@@ -239,7 +148,7 @@ test('SABR failures that never settle fall back to legacy but never audio', asyn
 })
 
 test('repeated SABR reload requests stop instead of reloading the tab forever', async ({ app, page }) => {
-  await mockWatchPage(app, page)
+  await mockUnplayableWatchPage(app, page)
   await goTo(page, 'history')
   await page.getByText('SABR test video').click()
   await expect(page).toHaveURL(/#\/watch\/jNQXAC9IVRw/)
@@ -258,7 +167,7 @@ test('repeated SABR reload requests stop instead of reloading the tab forever', 
 })
 
 test('repeated SABR reload requests never fall back to audio', async ({ app, page }) => {
-  await mockWatchPage(app, page)
+  await mockUnplayableWatchPage(app, page)
   await goTo(page, 'history')
   await page.getByText('SABR test video').click()
   await expect(page).toHaveURL(/#\/watch\/jNQXAC9IVRw/)
@@ -277,7 +186,7 @@ test('repeated SABR reload requests never fall back to audio', async ({ app, pag
 })
 
 test('a SABR failure refetches when no 360p fallback is available', async ({ app, page }) => {
-  await mockWatchPage(app, page)
+  await mockUnplayableWatchPage(app, page)
   await goTo(page, 'history')
   await page.getByText('SABR test video').click()
   await expect(page).toHaveURL(/#\/watch\/jNQXAC9IVRw/)
@@ -290,7 +199,7 @@ test('a SABR failure refetches when no 360p fallback is available', async ({ app
 })
 
 test('repeated SABR failures without a legacy fallback never switch to audio', async ({ app, page }) => {
-  await mockWatchPage(app, page)
+  await mockUnplayableWatchPage(app, page)
   await goTo(page, 'history')
   await page.getByText('SABR test video').click()
   await expect(page).toHaveURL(/#\/watch\/jNQXAC9IVRw/)
@@ -321,7 +230,7 @@ test('repeated SABR failures without a legacy fallback never switch to audio', a
 })
 
 test('an error from the outgoing player is ignored while the view reloads', async ({ app, page }) => {
-  await mockWatchPage(app, page)
+  await mockUnplayableWatchPage(app, page)
   await goTo(page, 'history')
   await page.getByText('SABR test video').click()
   await expect(page).toHaveURL(/#\/watch\/jNQXAC9IVRw/)
@@ -335,7 +244,7 @@ test('an error from the outgoing player is ignored while the view reloads', asyn
 })
 
 test('a SABR reload request from the outgoing player is ignored', async ({ app, page }) => {
-  await mockWatchPage(app, page)
+  await mockUnplayableWatchPage(app, page)
   await goTo(page, 'history')
   await page.getByText('SABR test video').click()
   await expect(page).toHaveURL(/#\/watch\/jNQXAC9IVRw/)
@@ -349,7 +258,7 @@ test('a SABR reload request from the outgoing player is ignored', async ({ app, 
 })
 
 test('a rejected SABR reload request reports terminal recovery', async ({ app, page }) => {
-  await mockWatchPage(app, page)
+  await mockUnplayableWatchPage(app, page)
   await goTo(page, 'history')
   await page.getByText('SABR test video').click()
   await expect(page).toHaveURL(/#\/watch\/jNQXAC9IVRw/)
@@ -366,7 +275,7 @@ test('a rejected SABR reload request reports terminal recovery', async ({ app, p
 })
 
 test('seeking around a stream that never plays does not refill the budget', async ({ app, page }) => {
-  await mockWatchPage(app, page)
+  await mockUnplayableWatchPage(app, page)
   await goTo(page, 'history')
   await page.getByText('SABR test video').click()
   await expect(page).toHaveURL(/#\/watch\/jNQXAC9IVRw/)
@@ -389,7 +298,7 @@ test('seeking around a stream that never plays does not refill the budget', asyn
 })
 
 test('a video that keeps breaking after settling still stops reloading eventually', async ({ app, page }) => {
-  await mockWatchPage(app, page)
+  await mockUnplayableWatchPage(app, page)
   await goTo(page, 'history')
   await page.getByText('SABR test video').click()
   await expect(page).toHaveURL(/#\/watch\/jNQXAC9IVRw/)

--- a/src/renderer/views/Watch/Watch.js
+++ b/src/renderer/views/Watch/Watch.js
@@ -334,6 +334,7 @@ export default defineComponent({
       preserveTitleOnNextReload: false,
       ipBlockDetectedInCurrentChain: false,
       ipBlockRecoveryAttemptedForCurrentVideo: false,
+      stream403ReloadAttemptedForCurrentVideo: false,
       sabrErrorRecoveryAttempts: 0,
       sabrErrorRecoveriesForCurrentVideo: 0,
       /** @type {number|null} */
@@ -1185,6 +1186,7 @@ export default defineComponent({
       const videoIdChanged = this.videoId !== previousVideoId
       if (videoIdChanged) {
         this.ipBlockRecoveryAttemptedForCurrentVideo = false
+        this.stream403ReloadAttemptedForCurrentVideo = false
         this.sabrErrorRecoveryAttempts = 0
         this.sabrErrorRecoveriesForCurrentVideo = 0
         this.sabrErrorRecoveryLastSeconds = null
@@ -3263,6 +3265,20 @@ export default defineComponent({
               this.errorMessage = '[BAD_HTTP_STATUS: 403] Potential causes: IP block, streaming URL deciphering failed or music video geo-block'
             } else {
               this.errorMessage = '[BAD_HTTP_STATUS: 403] Potential causes: IP block or streaming URL deciphering failed'
+            }
+
+            // Streaming URLs are bound to the IP they were issued to, so they also
+            // start returning 403 when our own IP changes (reconnect, prefix rotation,
+            // VPN switch). That looks exactly like an IP block, but fresh URLs fix it,
+            // so reload once before assuming the IP is blocked and running the script.
+            if (!this.stream403ReloadAttemptedForCurrentVideo) {
+              this.stream403ReloadAttemptedForCurrentVideo = true
+              this.showTabToast({
+                message: this.t('Video.Reloading video after streaming URL error'),
+                icon: ['fas', 'sync'],
+              })
+              await this.reloadView()
+              return
             }
 
             this.ipBlockDetectedInCurrentChain = true

--- a/static/locales/en-US.yaml
+++ b/static/locales/en-US.yaml
@@ -1224,6 +1224,7 @@ Video:
     Empty: This transcript does not contain any text.
     No Results: No transcript segments match your search.
   IP block: 'YouTube has blocked your IP address from watching videos. Please try switching to a different VPN or proxy.'
+  Reloading video after streaming URL error: Reloading video after streaming URL error
   MembersOnly: Members-only videos cannot be watched with OpenTubeX as they require Google login and paid membership to the uploader's channel.
   AgeRestricted: Age-restricted videos cannot be watched with OpenTubeX as they require Google login and using an age-verified YouTube account.
   DRMProtected: DRM protected videos cannot be played in OpenTubeX, as they require proprietary, closed source components. If you want to watch this video please watch it on the official YouTube website in a DRM enabled web browser.


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Make sure to follow the contributing guidelines. -->
<!-- Important note, we may remove your pull request if you do not use this provided PR template correctly. -->
<!-- Agent instructions: Preserve every heading, comment, and marker in this template. Never remove or rewrite the release-note-category:start/end, release-note:start/end, or release-note-image:start/end marker pairs. Never remove or rewrite the Release note images section; leave its contents for a human. -->

## Pull Request Type
<!-- Please select what type of pull request this is: [x] -->
- [x] Bugfix
- [ ] Feature Implementation
- [ ] Documentation
- [ ] Other

## Related issue
<!-- Please link the issue your pull request is referring to. -->
<!-- If this pull request fully resolves the relevant issue, put "closes" before the issue number. -->
<!-- Example: "closes #123456". -->
None

## Description
<!-- Please write a clear and concise description of what the pull request does. -->
YouTube binds streaming URLs to the IP they were issued to (they carry an `ip=` parameter). When our own IP changes while a video is open — reconnect, IPv6 prefix rotation, VPN switch — every already issued URL starts returning 403, which looks exactly like an IP block at the player error handler. The IP block recovery script was therefore run even though the IP was already fresh, which is both pointless and disruptive.

A streaming URL 403 now reloads the video once to get URLs bound to the current IP. Only when the freshly issued URLs are rejected as well does it flag an IP block and run the recovery script, so the genuine block path is unchanged apart from the extra reload before it.

The reload happens at most once per video (the flag is reset when the video changes), so this cannot loop.

## Release note category
<!-- Select exactly one category. Every pull request must select one. -->
<!-- release-note-category:start -->
- [ ] Not noteworthy
- [ ] Highlights
- [ ] More improvements
- [x] Fixed bugs
<!-- release-note-category:end -->

## Release note
<!-- Required unless "Not noteworthy" is selected. -->
<!-- Write one concise, user-facing entry without a leading bullet. -->
<!-- release-note:start -->
Stopped running the IP block recovery script when a changed IP address, rather than an IP block, made the video's streaming URLs fail
<!-- release-note:end -->

## Release note images
<!-- Human-only: Agents must preserve this entire section and leave it empty. -->
<!-- Optional. Paste one or more Markdown images or HTML image tags here. -->
<!-- The release notes will use an HTML image tag and limit images taller than 300 pixels. -->
<!-- release-note-image:start -->

<!-- release-note-image:end -->

## Testing
<!-- How can reviewers verify that the PR produces correct results? -->
<!-- Please provide instructions so that others can ensure that your pull request would produce correct results. For examples see, https://github.com/FreeTubeApp/FreeTube/pull/5743, https://github.com/FreeTubeApp/FreeTube/pull/7349, https://github.com/FreeTubeApp/FreeTube/pull/5125, https://github.com/FreeTubeApp/FreeTube/pull/7338 -->
<!-- Agent instructions: Only write human-facing steps that explain how to verify the change while running this branch in dev mode. Include expected results and, when applicable, helpful console snippets for interactive verification. Do not include automated checks, commands, results, pass counts, or CI status. -->
Set an IP block recovery script in Settings > Proxy (any script that logs something is enough to see when it runs), then:

1. Start a video and let it play.
2. Force your IP to change while it plays: reconnect your router/modem, toggle your VPN to another endpoint, or run `nmcli connection down <name> && nmcli connection up <name>`.
3. The playing stream fails with 403s. Expected: a "Reloading video after streaming URL error" toast and the video coming back on its own, **without** the "Running IP block recovery script" toast and without your script being executed.

To confirm the genuine block path still works, simulate a persistent 403 instead. With the video playing and the dev tools console open on the watch tab:

```js
// grab the Watch view
const find = (v) => v?.component?.type?.name === 'Watch' ? v.component.proxy
  : (v?.component?.subTree && find(v.component.subTree)) || (Array.isArray(v?.children) && v.children.map(find).find(Boolean)) || null
const watch = find(document.querySelector('#app').__vue_app__._container._vnode)

const forbidden = { severity: 2, category: 1, code: 1001, data: ['https://example.invalid/videoplayback', 403] }
await watch.handlePlayerError(forbidden) // first one: reloads the video only
await watch.handlePlayerError(forbidden) // second one: runs the recovery script
```

Expected: the first call only reloads, the second one shows the "Running IP block recovery script" toast and executes your script.

## Additional context
<!-- Add any other context about the pull request here. -->
The watch page mock used by the SABR player error tests moved into a shared e2e helper so the IP block recovery tests can reuse it; the SABR tests themselves are unchanged in behaviour.
