### PR TITLE
fix(ui): restore native select keys and icon pack colouring

### DIFF
--- a/src/renderer/components/FtIcon/FtIcon.vue
+++ b/src/renderer/components/FtIcon/FtIcon.vue
@@ -5,6 +5,8 @@
     :icon="icon"
     :fixed-width="fixedWidth"
     :size="size"
+    :color="color"
+    :spin="spin"
     :transform="transform"
     :class="iconClass"
     :style="fontAwesomeStyle"
@@ -16,7 +18,7 @@
     :data-icon="semanticIcon?.[1]"
     :data-icon-pack="currentIconPack"
     class="ft-icon"
-    :class="[{ 'ft-icon--fw': fixedWidth }, iconClass]"
+    :class="[{ 'ft-icon--fw': fixedWidth, 'ft-icon--spin': spin }, iconClass]"
     :style="iconifyWrapperStyle"
   >
     <Icon
@@ -59,6 +61,14 @@ const props = defineProps({
   transform: {
     type: [String, Object],
     default: null
+  },
+  color: {
+    type: String,
+    default: null
+  },
+  spin: {
+    type: Boolean,
+    default: false
   }
 })
 
@@ -157,6 +167,10 @@ const iconifyWrapperStyle = computed(() => {
   const fontSize = cssFontSizeFromFaSize(props.size)
   if (fontSize != null) {
     style.fontSize = fontSize
+  }
+  // Iconify glyphs paint with currentColor, so Font Awesome's `color` prop has to become CSS
+  if (props.color != null && props.color !== '') {
+    style.color = props.color
   }
   return style
 })
@@ -268,5 +282,26 @@ const iconifyGlyphStyle = computed(() => cssFromFaTransform(props.transform))
 
 .ft-icon--fw {
   inline-size: 1.25em;
+}
+
+/* Mirrors Font Awesome's `spin` prop, which only applies to its own SVGs. */
+.ft-icon--spin .ft-icon__glyph {
+  animation: ft-icon-spin 2s linear infinite;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .ft-icon--spin .ft-icon__glyph {
+    animation-duration: 10s;
+  }
+}
+
+@keyframes ft-icon-spin {
+  from {
+    rotate: 0deg;
+  }
+
+  to {
+    rotate: 360deg;
+  }
 }
 </style>

--- a/src/renderer/components/FtSelect/FtSelect.css
+++ b/src/renderer/components/FtSelect/FtSelect.css
@@ -63,7 +63,9 @@
 .select .select-text {
   appearance: none;
   text-overflow: ellipsis;
-  padding-inline-end: 1.5rem;
+
+  /* leave room for .iconSelect so the arrow never overlaps the selected value */
+  padding-inline-end: 2.5rem;
 }
 
 .selectedValue {
@@ -143,12 +145,7 @@
   display: block;
   line-height: 0;
   vertical-align: 0;
-
-  /* Styling the down arrow */
   padding: 0;
-  content: '';
-  border-inline-start: 6px solid transparent;
-  border-inline-end: 6px solid transparent;
   pointer-events: none;
   color: var(--tertiary-text-color);
   transition: transform 120ms ease;

--- a/src/renderer/components/FtSelect/FtSelect.vue
+++ b/src/renderer/components/FtSelect/FtSelect.vue
@@ -321,32 +321,48 @@ function scrollActiveOptionIntoView() {
  * @param {KeyboardEvent} event
  */
 function handleButtonKeydown(event) {
+  // Alt+Arrow is the platform shortcut for opening/closing a select
+  if ((event.key === 'ArrowDown' || event.key === 'ArrowUp') && event.altKey) {
+    event.preventDefault()
+    if (dropdownShown.value) {
+      closeDropdown()
+    } else {
+      openDropdown()
+    }
+    return
+  }
+
   if (event.key === 'ArrowDown' || event.key === 'ArrowUp') {
     event.preventDefault()
-    if (!dropdownShown.value) {
-      openDropdown()
+    const offset = event.key === 'ArrowDown' ? 1 : -1
+    if (dropdownShown.value) {
+      moveActiveIndex(offset)
     } else {
-      moveActiveIndex(event.key === 'ArrowDown' ? 1 : -1)
+      // Native selects change the value straight away while closed
+      selectOffset(offset)
     }
     return
   }
 
   if (event.key === 'Home' || event.key === 'End') {
     event.preventDefault()
-    if (!dropdownShown.value) {
-      openDropdown()
+    const index = event.key === 'Home' ? 0 : props.selectValues.length - 1
+    if (dropdownShown.value) {
+      activeIndex.value = index
+      scrollActiveOptionIntoView()
+    } else {
+      selectOption(index)
     }
-    activeIndex.value = event.key === 'Home' ? 0 : props.selectValues.length - 1
-    scrollActiveOptionIntoView()
     return
   }
 
   if (event.key === 'PageDown' || event.key === 'PageUp') {
     event.preventDefault()
-    if (!dropdownShown.value) {
-      openDropdown()
+    const offset = event.key === 'PageDown' ? 10 : -10
+    if (dropdownShown.value) {
+      moveActiveIndex(offset)
     } else {
-      moveActiveIndex(event.key === 'PageDown' ? 10 : -10)
+      selectOffset(offset)
     }
     return
   }
@@ -398,6 +414,15 @@ function handleTypeahead(character) {
   } else {
     selectOption(match)
   }
+}
+
+/**
+ * Moves the selection relative to the currently selected option, like a closed native select does.
+ * @param {number} offset
+ */
+function selectOffset(offset) {
+  const index = Math.max(0, Math.min(props.selectValues.length - 1, Math.max(0, selectedIndex.value) + offset))
+  selectOption(index)
 }
 
 function selectOption(index) {

--- a/src/renderer/components/FtSelect/FtSelect.vue
+++ b/src/renderer/components/FtSelect/FtSelect.vue
@@ -418,10 +418,12 @@ function handleTypeahead(character) {
 
 /**
  * Moves the selection relative to the currently selected option, like a closed native select does.
+ * Clamping happens after the offset is applied, so that moving down from a value that isn't in
+ * the list (`selectedIndex` is -1) lands on the first option instead of skipping it.
  * @param {number} offset
  */
 function selectOffset(offset) {
-  const index = Math.max(0, Math.min(props.selectValues.length - 1, Math.max(0, selectedIndex.value) + offset))
+  const index = Math.max(0, Math.min(props.selectValues.length - 1, selectedIndex.value + offset))
   selectOption(index)
 }
 


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Make sure to follow the contributing guidelines. -->
<!-- Important note, we may remove your pull request if you do not use this provided PR template correctly. -->
<!-- Agent instructions: Preserve every heading, comment, and marker in this template. Never remove or rewrite the release-note-category:start/end, release-note:start/end, or release-note-image:start/end marker pairs. Never remove or rewrite the Release note images section; leave its contents for a human. -->

## Pull Request Type
<!-- Please select what type of pull request this is: [x] -->
- [x] Bugfix
- [ ] Feature Implementation
- [ ] Documentation
- [ ] Other

## Related issue
<!-- Please link the issue your pull request is referring to. -->
<!-- If this pull request fully resolves the relevant issue, put "closes" before the issue number. -->
<!-- Example: "closes #123456". -->
Follow-up to the custom select dropdowns added in #503.

## Description
<!-- Please write a clear and concise description of what the pull request does. -->
Three fixes to the custom `FtSelect` and to `FtIcon`.

**Arrow keys no longer open the dropdown.** The native `<select>` that `FtSelect` replaced moves through the options directly when the control is focused but closed. The custom one opened the dropdown instead, which is a behaviour regression for keyboard users. Arrow, Page and Home/End now change the value while the dropdown is closed, and move the active option while it is open. <kbd>Alt</kbd>+<kbd>Arrow</kbd> is wired up as the platform shortcut for opening and closing.

**The arrow no longer sits on top of the selected value.** `.iconSelect` still carried the `6px` transparent side borders from back when it was a CSS triangle. Those made it wider than the `1.5rem` of padding the button reserved for it, so long labels ran underneath it. The leftover borders are gone and the reserved padding is now `2.5rem`.

**`color` and `spin` work in every icon pack.** `FtIcon` is what `@fortawesome/vue-fontawesome` resolves to via the webpack alias, but it never declared Font Awesome's `color` and `spin` props. Undeclared props fall through to `attrs`, so on the Iconify branch they landed as inert attributes on the wrapper `<span>` and did nothing. Both are now declared, forwarded to Font Awesome as before, and translated to CSS (`style.color`, which Iconify glyphs pick up through `currentColor`, and a spin animation) for the other packs.

The visible effect of the last one is the SponsorBlock category colour selector, whose palette icon stayed grey in every pack except Font Awesome. The SponsorBlock segment refresh button had the same problem with its spinning icon.

## Release note category
<!-- Select exactly one category. Every pull request must select one. -->
<!-- release-note-category:start -->
- [x] Not noteworthy
- [ ] Highlights
- [ ] More improvements
- [ ] Fixed bugs
<!-- release-note-category:end -->

## Release note
<!-- Required unless "Not noteworthy" is selected. -->
<!-- Write one concise, user-facing entry without a leading bullet. -->
<!-- release-note:start -->
Fixed the dropdown arrow overlapping long option labels, restored the native arrow key behaviour on dropdowns, and fixed coloured and spinning icons staying grey or still outside the Font Awesome icon pack
<!-- release-note:end -->

## Release note images
<!-- Human-only: Agents must preserve this entire section and leave it empty. -->
<!-- Optional. Paste one or more Markdown images or HTML image tags here. -->
<!-- The release notes will use an HTML image tag and limit images taller than 300 pixels. -->
<!-- release-note-image:start -->

<!-- release-note-image:end -->

## Testing
<!-- How can reviewers verify that the PR produces correct results? -->
<!-- Please provide instructions so that others can ensure that your pull request would produce correct results. For examples see, https://github.com/FreeTubeApp/FreeTube/pull/5743, https://github.com/FreeTubeApp/FreeTube/pull/7349, https://github.com/FreeTubeApp/FreeTube/pull/5125, https://github.com/FreeTubeApp/FreeTube/pull/7338 -->
<!-- Agent instructions: Only write human-facing steps that explain how to verify the change while running this branch in dev mode. Include expected results and, when applicable, helpful console snippets for interactive verification. Do not include automated checks, commands, results, pass counts, or CI status. -->
**Keyboard behaviour**

1. Go to Settings > General Settings and press <kbd>Tab</kbd> until the "On Startup" dropdown has focus, without clicking it open.
2. Press <kbd>↓</kbd> and <kbd>↑</kbd>. The selected value should change one option at a time and the dropdown should stay closed, the same way it did before the dropdowns were made custom.
3. Press <kbd>Home</kbd> and <kbd>End</kbd>. They should jump to the first and last option, still without opening.
4. Press <kbd>Alt</kbd>+<kbd>↓</kbd>. The dropdown should open. With it open, <kbd>↓</kbd>/<kbd>↑</kbd> should move the highlight rather than the value, and <kbd>Enter</kbd> should commit it.
5. Type the first few letters of an option while the dropdown is closed. Typeahead should still jump straight to that option.

**Arrow overlap**

6. Set "On Startup" to "Load previously loaded tabs", one of the longer labels. The label should be truncated with an ellipsis before the arrow rather than running underneath it. Worth a look in a narrow window too, and in a right-to-left locale such as Arabic.

**Icon colouring**

7. Go to Settings > SponsorBlock Settings and change the "Category Color" of any category.
8. The palette icon on that dropdown's label should take on the chosen colour. Repeat with each icon pack in Settings > Theme Settings (Material, Tabler, Phosphor, Lucide, Remix and Font Awesome) — it should be coloured in all of them, where before only Font Awesome worked.
9. Open a video with SponsorBlock segments, open the SponsorBlock sidebar and press the refresh button. Its icon should spin while loading in every pack.

## Additional context
<!-- Add any other context about the pull request here. -->
Branched off `2c719ef1f`, so it is a few commits behind `development`. None of the three files have changed upstream in the meantime.
