### PR TITLE
feat: add live chat replay for stream VODs

### DIFF
--- a/patches/youtubei.js@17.2.0.patch
+++ b/patches/youtubei.js@17.2.0.patch
@@ -409,10 +409,10 @@ index 371f753a780be9c927a767ad844c3b071e9707c8..f9b97e606e787462c85e50510e01d0e9
       * Sends a message.
       * @param text - Text to send.
 diff --git a/dist/src/parser/youtube/LiveChat.js b/dist/src/parser/youtube/LiveChat.js
-index 90faaabfaf9e2f80d08d410bb272f708ceea94b7..b69419313f75371956073e485d2aac42076cac11 100644
+index 90faaabfaf9e2f80d08d410bb272f708ceea94b7..80b0f3996e424c794f4eb08d768715dc7603ef43 100644
 --- a/dist/src/parser/youtube/LiveChat.js
 +++ b/dist/src/parser/youtube/LiveChat.js
-@@ -18,8 +18,13 @@ export default class LiveChat extends EventEmitter {
+@@ -18,8 +18,14 @@ export default class LiveChat extends EventEmitter {
      #video_id;
      #channel_id;
      #continuation;
@@ -422,11 +422,12 @@ index 90faaabfaf9e2f80d08d410bb272f708ceea94b7..b69419313f75371956073e485d2aac42
 +    #player_offset_ms = null;
 +    #seek_generation = 0;
 +    #polling = false;
++    #poll_promise = null;
 +    #filter = 'TOP_CHAT';
      smoothed_queue;
      initial_info;
      metadata;
-@@ -31,6 +36,7 @@ export default class LiveChat extends EventEmitter {
+@@ -31,6 +37,7 @@ export default class LiveChat extends EventEmitter {
          this.#channel_id = video_info.basic_info.channel_id;
          this.#actions = video_info.actions;
          this.#continuation = video_info.livechat?.continuation;
@@ -434,7 +435,7 @@ index 90faaabfaf9e2f80d08d410bb272f708ceea94b7..b69419313f75371956073e485d2aac42
          this.is_replay = video_info.livechat?.is_replay || false;
          this.smoothed_queue = new SmoothedQueue();
          this.smoothed_queue.callback = async (actions) => {
-@@ -42,14 +48,6 @@ export default class LiveChat extends EventEmitter {
+@@ -42,14 +49,6 @@ export default class LiveChat extends EventEmitter {
                  // If there are less than 10 actions, wait until all of them are emitted.
                  await this.#emitSmoothedActions(actions);
              }
@@ -449,7 +450,7 @@ index 90faaabfaf9e2f80d08d410bb272f708ceea94b7..b69419313f75371956073e485d2aac42
              else {
                  // There are more than 10 actions, emit them asynchronously so we can request the next incremental continuation.
                  this.#emitSmoothedActions(actions);
-@@ -69,17 +67,96 @@ export default class LiveChat extends EventEmitter {
+@@ -69,17 +68,102 @@ export default class LiveChat extends EventEmitter {
          if (!this.running) {
              this.running = true;
              this.#pollLivechat();
@@ -466,6 +467,7 @@ index 90faaabfaf9e2f80d08d410bb272f708ceea94b7..b69419313f75371956073e485d2aac42
 +        // later start() isn't blocked by a poll that nobody is listening for anymore.
 +        this.#seek_generation++;
 +        this.#polling = false;
++        this.#poll_promise = null;
 +    }
 +    /**
 +     * Jumps the replay to the given player position, so that the next
@@ -479,6 +481,7 @@ index 90faaabfaf9e2f80d08d410bb272f708ceea94b7..b69419313f75371956073e485d2aac42
 +        // Invalidates the responses of any requests that are still in flight.
 +        this.#seek_generation++;
 +        this.#polling = false;
++        this.#poll_promise = null;
 +        this.#continuation = this.#initial_continuation;
 +        this.#player_offset_ms = Math.max(0, Math.round(offset_ms));
 +    }
@@ -509,6 +512,7 @@ index 90faaabfaf9e2f80d08d410bb272f708ceea94b7..b69419313f75371956073e485d2aac42
 +        // hold the messages of the view being switched away from.
 +        this.#seek_generation++;
 +        this.#polling = false;
++        this.#poll_promise = null;
 +        this.smoothed_queue.clear();
 +        this.#continuation = continuation;
 +        // Seeking a replay has to stay on the view that is selected now.
@@ -529,11 +533,13 @@ index 90faaabfaf9e2f80d08d410bb272f708ceea94b7..b69419313f75371956073e485d2aac42
      }
      #pollLivechat() {
 -        (async () => {
++        // Concurrent callers await the batch that is already on its way, rather than
++        // a resolved promise that would claim its actions have been emitted.
 +        if (this.#polling)
-+            return Promise.resolve();
++            return this.#poll_promise ?? Promise.resolve();
 +        this.#polling = true;
 +        const seek_generation = this.#seek_generation;
-+        return (async () => {
++        this.#poll_promise = (async () => {
              try {
 -                const response = await this.#actions.execute(this.is_replay ? 'live_chat/get_live_chat_replay' : 'live_chat/get_live_chat', { continuation: this.#continuation, parse: true });
 +                const args = { continuation: this.#continuation, parse: true };
@@ -546,10 +552,11 @@ index 90faaabfaf9e2f80d08d410bb272f708ceea94b7..b69419313f75371956073e485d2aac42
 +                if (seek_generation !== this.#seek_generation)
 +                    return;
 +                this.#polling = false;
++                this.#poll_promise = null;
                  const contents = response.continuation_contents;
                  if (!contents) {
                      this.emit('error', new InnertubeError('Unexpected live chat incremental continuation response', response));
-@@ -91,24 +168,39 @@ export default class LiveChat extends EventEmitter {
+@@ -91,24 +175,40 @@ export default class LiveChat extends EventEmitter {
                      this.emit('end');
                      return;
                  }
@@ -584,6 +591,7 @@ index 90faaabfaf9e2f80d08d410bb272f708ceea94b7..b69419313f75371956073e485d2aac42
 +                if (seek_generation !== this.#seek_generation)
 +                    return;
 +                this.#polling = false;
++                this.#poll_promise = null;
                  this.emit('error', err);
                  if (this.#retry_count++ < 10) {
                      await this.#wait(2000);
@@ -593,3 +601,11 @@ index 90faaabfaf9e2f80d08d410bb272f708ceea94b7..b69419313f75371956073e485d2aac42
                  }
                  else {
                      this.emit('error', new InnertubeError('Reached retry limit for incremental continuation requests', err));
+@@ -117,6 +217,7 @@ export default class LiveChat extends EventEmitter {
+                 }
+             }
+         })();
++        return this.#poll_promise;
+     }
+     /**
+      * Ensures actions are emitted at the right speed.

--- a/patches/youtubei.js@17.2.0.patch
+++ b/patches/youtubei.js@17.2.0.patch
@@ -374,10 +374,10 @@ index 8b6d412c79178ed9786c6ab143a6f0822c3b13c3..101063c7c348d941814b4122b36f6eb4
          }));
          this.#continuation = body_node?.contents?.firstOfType(ContinuationItem);
 diff --git a/dist/src/parser/youtube/LiveChat.d.ts b/dist/src/parser/youtube/LiveChat.d.ts
-index 371f753a780be9c927a767ad844c3b071e9707c8..a3bb55c260682cfd12013e84f43d42d2bdf75c44 100644
+index 371f753a780be9c927a767ad844c3b071e9707c8..f9b97e606e787462c85e50510e01d0e991d9ebc3 100644
 --- a/dist/src/parser/youtube/LiveChat.d.ts
 +++ b/dist/src/parser/youtube/LiveChat.d.ts
-@@ -57,6 +57,19 @@ export default class LiveChat extends EventEmitter {
+@@ -57,6 +57,30 @@ export default class LiveChat extends EventEmitter {
      once(type: 'end', listener: () => void): void;
      start(): void;
      stop(): void;
@@ -389,6 +389,17 @@ index 371f753a780be9c927a767ad844c3b071e9707c8..a3bb55c260682cfd12013e84f43d42d2
 +     */
 +    seekTo(offset_ms: number): void;
 +    /**
++     * The view the chat is currently on.
++     */
++    get filter(): 'TOP_CHAT' | 'LIVE_CHAT';
++    /**
++     * Switches between the chat's "Top chat" and "Live chat" views. Unlike
++     * {@link applyFilter} this tracks the selected view itself, rather than reading it
++     * back off the initial info, whose selection flags go stale as soon as it is used.
++     * @param filter - The view to switch to.
++     */
++    setFilter(filter: 'TOP_CHAT' | 'LIVE_CHAT'): void;
++    /**
 +     * Requests the next batch of replay actions. Replays don't poll on their own,
 +     * as only the consumer knows how far ahead of the player it wants to buffer.
 +     * Resolves once the actions of that batch have been emitted.
@@ -398,10 +409,10 @@ index 371f753a780be9c927a767ad844c3b071e9707c8..a3bb55c260682cfd12013e84f43d42d2
       * Sends a message.
       * @param text - Text to send.
 diff --git a/dist/src/parser/youtube/LiveChat.js b/dist/src/parser/youtube/LiveChat.js
-index 90faaabfaf9e2f80d08d410bb272f708ceea94b7..943e1eb8540774700f7d635eb1af45f90410c422 100644
+index 90faaabfaf9e2f80d08d410bb272f708ceea94b7..b69419313f75371956073e485d2aac42076cac11 100644
 --- a/dist/src/parser/youtube/LiveChat.js
 +++ b/dist/src/parser/youtube/LiveChat.js
-@@ -18,8 +18,12 @@ export default class LiveChat extends EventEmitter {
+@@ -18,8 +18,13 @@ export default class LiveChat extends EventEmitter {
      #video_id;
      #channel_id;
      #continuation;
@@ -411,10 +422,11 @@ index 90faaabfaf9e2f80d08d410bb272f708ceea94b7..943e1eb8540774700f7d635eb1af45f9
 +    #player_offset_ms = null;
 +    #seek_generation = 0;
 +    #polling = false;
++    #filter = 'TOP_CHAT';
      smoothed_queue;
      initial_info;
      metadata;
-@@ -31,6 +35,7 @@ export default class LiveChat extends EventEmitter {
+@@ -31,6 +36,7 @@ export default class LiveChat extends EventEmitter {
          this.#channel_id = video_info.basic_info.channel_id;
          this.#actions = video_info.actions;
          this.#continuation = video_info.livechat?.continuation;
@@ -422,7 +434,7 @@ index 90faaabfaf9e2f80d08d410bb272f708ceea94b7..943e1eb8540774700f7d635eb1af45f9
          this.is_replay = video_info.livechat?.is_replay || false;
          this.smoothed_queue = new SmoothedQueue();
          this.smoothed_queue.callback = async (actions) => {
-@@ -42,14 +47,6 @@ export default class LiveChat extends EventEmitter {
+@@ -42,14 +48,6 @@ export default class LiveChat extends EventEmitter {
                  // If there are less than 10 actions, wait until all of them are emitted.
                  await this.#emitSmoothedActions(actions);
              }
@@ -437,7 +449,7 @@ index 90faaabfaf9e2f80d08d410bb272f708ceea94b7..943e1eb8540774700f7d635eb1af45f9
              else {
                  // There are more than 10 actions, emit them asynchronously so we can request the next incremental continuation.
                  this.#emitSmoothedActions(actions);
-@@ -69,17 +66,60 @@ export default class LiveChat extends EventEmitter {
+@@ -69,17 +67,96 @@ export default class LiveChat extends EventEmitter {
          if (!this.running) {
              this.running = true;
              this.#pollLivechat();
@@ -471,6 +483,42 @@ index 90faaabfaf9e2f80d08d410bb272f708ceea94b7..943e1eb8540774700f7d635eb1af45f9
 +        this.#player_offset_ms = Math.max(0, Math.round(offset_ms));
 +    }
 +    /**
++     * The view the chat is currently on.
++     * @returns {'TOP_CHAT' | 'LIVE_CHAT'}
++     */
++    get filter() {
++        return this.#filter;
++    }
++    /**
++     * Switches between the chat's "Top chat" and "Live chat" views. Unlike
++     * {@link applyFilter} this tracks the selected view itself, rather than reading it
++     * back off the initial info, whose selection flags go stale as soon as it is used.
++     * @param filter - The view to switch to.
++     */
++    setFilter(filter) {
++        if (filter === this.#filter)
++            return;
++        const menu_items = this.initial_info?.header?.view_selector?.sub_menu_items;
++        if (!menu_items)
++            throw new InnertubeError('Cannot change the filter before initial info is retrieved.');
++        const continuation = menu_items.at(filter === 'TOP_CHAT' ? 0 : 1)?.continuation;
++        if (!continuation)
++            throw new InnertubeError(`This live chat has no '${filter}' view.`);
++        this.#filter = filter;
++        // Invalidates the responses of any requests that are still in flight, as they
++        // hold the messages of the view being switched away from.
++        this.#seek_generation++;
++        this.#polling = false;
++        this.smoothed_queue.clear();
++        this.#continuation = continuation;
++        // Seeking a replay has to stay on the view that is selected now.
++        this.#initial_continuation = continuation;
++        // Live chats poll on their own, but discarding the in-flight response above broke
++        // that chain, so it needs restarting. Replays are polled by the consumer instead.
++        if (this.running && !this.is_replay)
++            this.#pollLivechat();
++    }
++    /**
 +     * Requests the next batch of replay actions. Replays don't poll on their own,
 +     * as only the consumer knows how far ahead of the player it wants to buffer.
 +     * Resolves once the actions of that batch have been emitted.
@@ -501,7 +549,7 @@ index 90faaabfaf9e2f80d08d410bb272f708ceea94b7..943e1eb8540774700f7d635eb1af45f9
                  const contents = response.continuation_contents;
                  if (!contents) {
                      this.emit('error', new InnertubeError('Unexpected live chat incremental continuation response', response));
-@@ -91,24 +131,39 @@ export default class LiveChat extends EventEmitter {
+@@ -91,24 +168,39 @@ export default class LiveChat extends EventEmitter {
                      this.emit('end');
                      return;
                  }

--- a/patches/youtubei.js@17.2.0.patch
+++ b/patches/youtubei.js@17.2.0.patch
@@ -373,3 +373,175 @@ index 8b6d412c79178ed9786c6ab143a6f0822c3b13c3..101063c7c348d941814b4122b36f6eb4
              return thread;
          }));
          this.#continuation = body_node?.contents?.firstOfType(ContinuationItem);
+diff --git a/dist/src/parser/youtube/LiveChat.d.ts b/dist/src/parser/youtube/LiveChat.d.ts
+index 371f753a780be9c927a767ad844c3b071e9707c8..a3bb55c260682cfd12013e84f43d42d2bdf75c44 100644
+--- a/dist/src/parser/youtube/LiveChat.d.ts
++++ b/dist/src/parser/youtube/LiveChat.d.ts
+@@ -57,6 +57,19 @@ export default class LiveChat extends EventEmitter {
+     once(type: 'end', listener: () => void): void;
+     start(): void;
+     stop(): void;
++    /**
++     * Jumps the replay to the given player position, so that the next
++     * {@link pollNext} starts at (or shortly before) that position.
++     * Safe to call before {@link start}, in which case the replay begins there.
++     * @param offset_ms - Player position to seek to, in milliseconds.
++     */
++    seekTo(offset_ms: number): void;
++    /**
++     * Requests the next batch of replay actions. Replays don't poll on their own,
++     * as only the consumer knows how far ahead of the player it wants to buffer.
++     * Resolves once the actions of that batch have been emitted.
++     */
++    pollNext(): Promise<void>;
+     /**
+      * Sends a message.
+      * @param text - Text to send.
+diff --git a/dist/src/parser/youtube/LiveChat.js b/dist/src/parser/youtube/LiveChat.js
+index 90faaabfaf9e2f80d08d410bb272f708ceea94b7..943e1eb8540774700f7d635eb1af45f90410c422 100644
+--- a/dist/src/parser/youtube/LiveChat.js
++++ b/dist/src/parser/youtube/LiveChat.js
+@@ -18,8 +18,12 @@ export default class LiveChat extends EventEmitter {
+     #video_id;
+     #channel_id;
+     #continuation;
++    #initial_continuation;
+     #mcontinuation;
+     #retry_count = 0;
++    #player_offset_ms = null;
++    #seek_generation = 0;
++    #polling = false;
+     smoothed_queue;
+     initial_info;
+     metadata;
+@@ -31,6 +35,7 @@ export default class LiveChat extends EventEmitter {
+         this.#channel_id = video_info.basic_info.channel_id;
+         this.#actions = video_info.actions;
+         this.#continuation = video_info.livechat?.continuation;
++        this.#initial_continuation = this.#continuation;
+         this.is_replay = video_info.livechat?.is_replay || false;
+         this.smoothed_queue = new SmoothedQueue();
+         this.smoothed_queue.callback = async (actions) => {
+@@ -42,14 +47,6 @@ export default class LiveChat extends EventEmitter {
+                 // If there are less than 10 actions, wait until all of them are emitted.
+                 await this.#emitSmoothedActions(actions);
+             }
+-            else if (this.is_replay) {
+-                /**
+-                 * NOTE: Live chat replays require data from the video player for actions to be emitted timely
+-                 * and as we don't have that, this ends up being quite innacurate.
+-                 */
+-                this.#emitSmoothedActions(actions);
+-                await this.#wait(2000);
+-            }
+             else {
+                 // There are more than 10 actions, emit them asynchronously so we can request the next incremental continuation.
+                 this.#emitSmoothedActions(actions);
+@@ -69,17 +66,60 @@ export default class LiveChat extends EventEmitter {
+         if (!this.running) {
+             this.running = true;
+             this.#pollLivechat();
+-            this.#pollMetadata();
++            // Replays are of videos that already ended, so there is no live metadata to poll for.
++            if (!this.is_replay)
++                this.#pollMetadata();
+         }
+     }
+     stop() {
+         this.smoothed_queue.clear();
+         this.running = false;
++        // Discards the responses of any requests that are still in flight, so that a
++        // later start() isn't blocked by a poll that nobody is listening for anymore.
++        this.#seek_generation++;
++        this.#polling = false;
++    }
++    /**
++     * Jumps the replay to the given player position, so that the next
++     * {@link pollNext} starts at (or shortly before) that position.
++     * Safe to call before {@link start}, in which case the replay begins there.
++     * @param offset_ms - Player position to seek to, in milliseconds.
++     */
++    seekTo(offset_ms) {
++        if (!this.is_replay)
++            return;
++        // Invalidates the responses of any requests that are still in flight.
++        this.#seek_generation++;
++        this.#polling = false;
++        this.#continuation = this.#initial_continuation;
++        this.#player_offset_ms = Math.max(0, Math.round(offset_ms));
++    }
++    /**
++     * Requests the next batch of replay actions. Replays don't poll on their own,
++     * as only the consumer knows how far ahead of the player it wants to buffer.
++     * Resolves once the actions of that batch have been emitted.
++     */
++    async pollNext() {
++        if (this.is_replay && this.running && this.#continuation)
++            await this.#pollLivechat();
+     }
+     #pollLivechat() {
+-        (async () => {
++        if (this.#polling)
++            return Promise.resolve();
++        this.#polling = true;
++        const seek_generation = this.#seek_generation;
++        return (async () => {
+             try {
+-                const response = await this.#actions.execute(this.is_replay ? 'live_chat/get_live_chat_replay' : 'live_chat/get_live_chat', { continuation: this.#continuation, parse: true });
++                const args = { continuation: this.#continuation, parse: true };
++                // The player offset only applies to the initial continuation, which is the one
++                // a seek resets us to. Sending it alongside a later continuation would keep
++                // pulling us back to the seek position instead of advancing through the chat.
++                if (this.is_replay && this.#player_offset_ms !== null && this.#continuation === this.#initial_continuation)
++                    args.currentPlayerState = { playerOffsetMs: this.#player_offset_ms.toString() };
++                const response = await this.#actions.execute(this.is_replay ? 'live_chat/get_live_chat_replay' : 'live_chat/get_live_chat', args);
++                if (seek_generation !== this.#seek_generation)
++                    return;
++                this.#polling = false;
+                 const contents = response.continuation_contents;
+                 if (!contents) {
+                     this.emit('error', new InnertubeError('Unexpected live chat incremental continuation response', response));
+@@ -91,24 +131,39 @@ export default class LiveChat extends EventEmitter {
+                     this.emit('end');
+                     return;
+                 }
+-                this.#continuation = contents.continuation.token;
+-                // Header only exists in the first request
++                // Replays run out of continuations once the end of the chat is reached.
++                this.#continuation = contents.continuation?.token;
++                // Header only exists in the first request, and in the first request after a seek
+                 if (contents.header) {
+                     this.initial_info = contents;
+                     this.emit('start', contents);
+-                    if (this.running)
++                    if (this.running && !this.is_replay)
+                         this.#pollLivechat();
+                 }
++                else if (this.is_replay) {
++                    // Replay actions carry their own player offsets, so instead of pacing them
++                    // ourselves we hand them over right away and let the consumer decide when
++                    // to display them.
++                    for (const action of contents.actions) {
++                        this.emit('chat-update', action);
++                    }
++                    // Once the end of the chat is reached there is no continuation left, which
++                    // makes pollNext() a no-op until a seek puts us back into the chat's range.
++                }
+                 else {
+                     this.smoothed_queue.enqueueActionGroup(contents.actions);
+                 }
+                 this.#retry_count = 0;
+             }
+             catch (err) {
++                if (seek_generation !== this.#seek_generation)
++                    return;
++                this.#polling = false;
+                 this.emit('error', err);
+                 if (this.#retry_count++ < 10) {
+                     await this.#wait(2000);
+-                    this.#pollLivechat();
++                    if (seek_generation === this.#seek_generation)
++                        this.#pollLivechat();
+                 }
+                 else {
+                     this.emit('error', new InnertubeError('Reached retry limit for incremental continuation requests', err));

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -10,7 +10,7 @@ overrides:
 
 patchedDependencies:
   shaka-player@5.1.12: 17d85e267c8958999207ce9d6c29a2ddf18734d0499fb30870ac8a55d90303fa
-  youtubei.js@17.2.0: a2906d1a8ffdd86682ec16cce4e436640add7ad09b203b3d4b7cf39e836c3118
+  youtubei.js@17.2.0: 82a17ea1894879fa26c1d70226541120697508f90730bda238d7cbe2c20c3ee0
 
 importers:
 
@@ -81,7 +81,7 @@ importers:
         version: 4.1.0(vue@3.5.40)
       youtubei.js:
         specifier: ^17.2.0
-        version: 17.2.0(patch_hash=a2906d1a8ffdd86682ec16cce4e436640add7ad09b203b3d4b7cf39e836c3118)
+        version: 17.2.0(patch_hash=82a17ea1894879fa26c1d70226541120697508f90730bda238d7cbe2c20c3ee0)
     devDependencies:
       '@babel/core':
         specifier: ^8.0.1
@@ -10609,7 +10609,7 @@ snapshots:
 
   yocto-queue@0.1.0: {}
 
-  youtubei.js@17.2.0(patch_hash=a2906d1a8ffdd86682ec16cce4e436640add7ad09b203b3d4b7cf39e836c3118):
+  youtubei.js@17.2.0(patch_hash=82a17ea1894879fa26c1d70226541120697508f90730bda238d7cbe2c20c3ee0):
     dependencies:
       '@bufbuild/protobuf': 2.1.0
       fflate: 0.8.3

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -10,7 +10,7 @@ overrides:
 
 patchedDependencies:
   shaka-player@5.1.12: 17d85e267c8958999207ce9d6c29a2ddf18734d0499fb30870ac8a55d90303fa
-  youtubei.js@17.2.0: f14e5ed4f8363dc2b71831fc93c43f1f9ed1b760786d710e55ade93df94f7a3c
+  youtubei.js@17.2.0: 84aef35d8df9833280fe2fd4dcc28534e7b740cf2fa68a53605e727cd48d0309
 
 importers:
 
@@ -81,7 +81,7 @@ importers:
         version: 4.1.0(vue@3.5.40)
       youtubei.js:
         specifier: ^17.2.0
-        version: 17.2.0(patch_hash=f14e5ed4f8363dc2b71831fc93c43f1f9ed1b760786d710e55ade93df94f7a3c)
+        version: 17.2.0(patch_hash=84aef35d8df9833280fe2fd4dcc28534e7b740cf2fa68a53605e727cd48d0309)
     devDependencies:
       '@babel/core':
         specifier: ^8.0.1
@@ -10609,7 +10609,7 @@ snapshots:
 
   yocto-queue@0.1.0: {}
 
-  youtubei.js@17.2.0(patch_hash=f14e5ed4f8363dc2b71831fc93c43f1f9ed1b760786d710e55ade93df94f7a3c):
+  youtubei.js@17.2.0(patch_hash=84aef35d8df9833280fe2fd4dcc28534e7b740cf2fa68a53605e727cd48d0309):
     dependencies:
       '@bufbuild/protobuf': 2.1.0
       fflate: 0.8.3

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -10,7 +10,7 @@ overrides:
 
 patchedDependencies:
   shaka-player@5.1.12: 17d85e267c8958999207ce9d6c29a2ddf18734d0499fb30870ac8a55d90303fa
-  youtubei.js@17.2.0: 84aef35d8df9833280fe2fd4dcc28534e7b740cf2fa68a53605e727cd48d0309
+  youtubei.js@17.2.0: a2906d1a8ffdd86682ec16cce4e436640add7ad09b203b3d4b7cf39e836c3118
 
 importers:
 
@@ -81,7 +81,7 @@ importers:
         version: 4.1.0(vue@3.5.40)
       youtubei.js:
         specifier: ^17.2.0
-        version: 17.2.0(patch_hash=84aef35d8df9833280fe2fd4dcc28534e7b740cf2fa68a53605e727cd48d0309)
+        version: 17.2.0(patch_hash=a2906d1a8ffdd86682ec16cce4e436640add7ad09b203b3d4b7cf39e836c3118)
     devDependencies:
       '@babel/core':
         specifier: ^8.0.1
@@ -10609,7 +10609,7 @@ snapshots:
 
   yocto-queue@0.1.0: {}
 
-  youtubei.js@17.2.0(patch_hash=84aef35d8df9833280fe2fd4dcc28534e7b740cf2fa68a53605e727cd48d0309):
+  youtubei.js@17.2.0(patch_hash=a2906d1a8ffdd86682ec16cce4e436640add7ad09b203b3d4b7cf39e836c3118):
     dependencies:
       '@bufbuild/protobuf': 2.1.0
       fflate: 0.8.3

--- a/src/renderer/components/WatchVideoLiveChat/WatchVideoLiveChat.css
+++ b/src/renderer/components/WatchVideoLiveChat/WatchVideoLiveChat.css
@@ -315,6 +315,12 @@
   box-shadow: 0 6px 20px rgb(0 0 0 / 35%);
 }
 
+.liveChatFilter {
+  margin-block-start: 12px;
+  padding-block-start: 10px;
+  border-block-start: 1px solid var(--side-nav-hover-color);
+}
+
 .titleContainer {
   display: flex;
   justify-content: space-between;

--- a/src/renderer/components/WatchVideoLiveChat/WatchVideoLiveChat.vue
+++ b/src/renderer/components/WatchVideoLiveChat/WatchVideoLiveChat.vue
@@ -331,6 +331,7 @@ import { formatNumber } from '../../helpers/utils'
 import { getRandomColorClass } from '../../helpers/colors'
 import { getLocalVideoInfo, parseLocalTextRuns } from '../../helpers/api/local'
 import {
+  createCoalescingPoller,
   isReplaySeek,
   parseReplayOffsetMs,
   shouldPrefetchReplay,
@@ -377,7 +378,17 @@ let lastCurrentTime = props.currentTime
  * without any chat activity don't look like an empty buffer.
  */
 let replayFetchedUntilMs = 0
-let replayPollInFlight = false
+
+/**
+ * Tops the replay buffer back up once it no longer reaches far enough ahead of the player.
+ */
+const requestMoreReplayComments = createCoalescingPoller(async () => {
+  if (liveChatInstance === null || !shouldPrefetchReplay(replayFetchedUntilMs, props.currentTime)) {
+    return
+  }
+
+  await liveChatInstance.pollNext()
+})
 
 const isLoading = ref(true)
 const isReplay = ref(false)
@@ -628,27 +639,6 @@ watch(liveChatFilter, applyChatFilter)
 function releaseReplayComments() {
   for (const { comment } of takeDueReplayComments(pendingReplayComments, props.currentTime)) {
     deliverComment(comment)
-  }
-}
-
-/**
- * Tops the replay buffer back up once it no longer reaches far enough ahead of the player.
- */
-async function requestMoreReplayComments() {
-  if (replayPollInFlight || liveChatInstance === null) {
-    return
-  }
-
-  if (!shouldPrefetchReplay(replayFetchedUntilMs, props.currentTime)) {
-    return
-  }
-
-  replayPollInFlight = true
-
-  try {
-    await liveChatInstance.pollNext()
-  } finally {
-    replayPollInFlight = false
   }
 }
 

--- a/src/renderer/components/WatchVideoLiveChat/WatchVideoLiveChat.vue
+++ b/src/renderer/components/WatchVideoLiveChat/WatchVideoLiveChat.vue
@@ -34,7 +34,9 @@
       <p
         class="message"
       >
-        {{ t("Video['Live chat is enabled. Chat messages will appear here once sent.']") }}
+        {{ isReplay
+          ? t("Video['Live chat replay is enabled. Chat messages will appear here as the video plays.']")
+          : t("Video['Live chat is enabled. Chat messages will appear here once sent.']") }}
       </p>
     </div>
     <div
@@ -47,7 +49,7 @@
         <h4
           class="title"
         >
-          {{ t("Video.Live Chat") }}
+          {{ isReplay ? t('Video.Live Chat Replay') : t('Video.Live Chat') }}
           <span
             v-if="!hideVideoViews && watchingCount !== null"
             class="watchingCount"
@@ -72,7 +74,7 @@
             <FontAwesomeIcon :icon="['fas', 'sliders-h']" />
           </button>
           <a
-            :href="`https://www.youtube.com/live_chat?is_popout=1&v=${props.videoId}`"
+            :href="popoutUrl"
             :aria-label="t('Video.Popout Live Chat')"
             :title="t('Video.Popout Live Chat')"
             target="_blank"
@@ -302,7 +304,7 @@
 <script setup>
 import { FontAwesomeIcon } from '@fortawesome/vue-fontawesome'
 import autolinker from 'autolinker'
-import { computed, nextTick, onBeforeUnmount, onMounted, ref, shallowReactive, useTemplateRef } from 'vue'
+import { computed, nextTick, onBeforeUnmount, onMounted, ref, shallowReactive, useTemplateRef, watch } from 'vue'
 import { useI18n } from 'vue-i18n'
 import { YTNodes } from 'youtubei.js'
 
@@ -317,6 +319,12 @@ import store from '../../store/index'
 import { formatNumber } from '../../helpers/utils'
 import { getRandomColorClass } from '../../helpers/colors'
 import { getLocalVideoInfo, parseLocalTextRuns } from '../../helpers/api/local'
+import {
+  isReplaySeek,
+  parseReplayOffsetMs,
+  shouldPrefetchReplay,
+  takeDueReplayComments
+} from './liveChatReplay.js'
 
 const props = defineProps({
   liveChat: {
@@ -330,6 +338,10 @@ const props = defineProps({
   channelId: {
     type: String,
     required: true
+  },
+  currentTime: {
+    type: Number,
+    default: 0
   }
 })
 
@@ -341,7 +353,23 @@ let hasEnded = false
 let stayAtBottom = true
 let isScrollingToBottom = false
 
+/**
+ * Replay messages that were fetched but that the player hasn't reached yet.
+ * @type {{ offsetMs: number, comment: any }[]}
+ */
+let pendingReplayComments = []
+let lastCurrentTime = props.currentTime
+
+/**
+ * The player position the replay has been fetched up to. Unlike the pending
+ * messages this doesn't shrink as messages are shown, so stretches of the stream
+ * without any chat activity don't look like an empty buffer.
+ */
+let replayFetchedUntilMs = 0
+let replayPollInFlight = false
+
 const isLoading = ref(true)
+const isReplay = ref(false)
 const hasError = ref(false)
 const showEnableChat = ref(false)
 const errorMessage = ref('')
@@ -371,6 +399,12 @@ const backendPreference = computed(() => store.getters.getBackendPreference)
 const backendFallback = computed(() => store.getters.getBackendFallback)
 
 const chatHeight = computed(() => superChatComments.length > 0 ? '390px' : '445px')
+
+const popoutUrl = computed(() => {
+  const path = isReplay.value ? 'live_chat_replay' : 'live_chat'
+
+  return `https://www.youtube.com/${path}?is_popout=1&v=${props.videoId}`
+})
 
 const scrollingBehaviour = computed(() => {
   return store.getters.getDisableSmoothScrolling ? 'auto' : 'smooth'
@@ -450,11 +484,19 @@ function showLiveChatUnavailable() {
 }
 
 function startLiveChatLocal() {
-  liveChatInstance.once('start', handleStart)
+  isReplay.value = liveChatInstance.is_replay
+
+  // Replays emit `start` again after every seek, so this can't be a `once` listener.
+  liveChatInstance.on('start', handleStart)
   liveChatInstance.on('chat-update', handleChatUpdate)
   liveChatInstance.on('metadata-update', handleMetadataUpdate)
   liveChatInstance.once('error', handleError)
   liveChatInstance.once('end', handleEnd)
+
+  // Videos opened at a saved watch progress start midway through the replay.
+  if (isReplay.value && props.currentTime > 0) {
+    liveChatInstance.seekTo(props.currentTime * 1000)
+  }
 
   liveChatInstance.start()
 }
@@ -465,17 +507,16 @@ const commentsRef = useTemplateRef('commentsRef')
  * @param {import ('youtubei.js/dist/src/parser/continuations').LiveChatContinuation} initialData
  */
 function handleStart(initialData) {
-  const actions = initialData.actions.filterType(YTNodes.AddChatItemAction)
-
-  for (const { item } of actions) {
-    if (item.is(YTNodes.LiveChatTextMessage)) {
-      parseLiveChatComment(item)
-    } else if (item.is(YTNodes.LiveChatPaidMessage)) {
-      parseLiveChatSuperChat(item)
-    }
+  for (const action of initialData.actions) {
+    handleChatAction(action)
   }
 
   isLoading.value = false
+
+  if (isReplay.value) {
+    releaseReplayComments()
+    requestMoreReplayComments()
+  }
 
   nextTick(() => {
     scrollToBottom('instant')
@@ -486,14 +527,104 @@ function handleStart(initialData) {
  * @param {import('youtubei.js/dist/src/parser/youtube/LiveChat').ChatAction} action
  */
 function handleChatUpdate(action) {
-  if (!hasEnded && action.is(YTNodes.AddChatItemAction)) {
-    if (action.item.is(YTNodes.LiveChatTextMessage)) {
-      parseLiveChatComment(action.item)
-    } else if (action.item.is(YTNodes.LiveChatPaidMessage)) {
-      parseLiveChatSuperChat(action.item)
-    }
+  if (!hasEnded) {
+    handleChatAction(action)
   }
 }
+
+/**
+ * @param {import('youtubei.js/dist/src/parser/youtube/LiveChat').ChatAction} action
+ * @param {number} [offsetMs] the player position this action belongs to, for replays
+ */
+function handleChatAction(action, offsetMs) {
+  if (action.is(YTNodes.ReplayChatItemAction)) {
+    const actionOffsetMs = parseReplayOffsetMs(action.video_offset_time_msec)
+
+    replayFetchedUntilMs = Math.max(replayFetchedUntilMs, actionOffsetMs)
+
+    for (const replayedAction of action.actions) {
+      handleChatAction(replayedAction, actionOffsetMs)
+    }
+
+    return
+  }
+
+  if (!action.is(YTNodes.AddChatItemAction)) {
+    return
+  }
+
+  let comment = null
+
+  if (action.item.is(YTNodes.LiveChatTextMessage)) {
+    comment = parseLiveChatComment(action.item)
+  } else if (action.item.is(YTNodes.LiveChatPaidMessage)) {
+    comment = parseLiveChatSuperChat(action.item)
+  }
+
+  if (comment === null) {
+    return
+  }
+
+  if (offsetMs === undefined) {
+    deliverComment(comment)
+  } else {
+    pendingReplayComments.push({ offsetMs, comment })
+  }
+}
+
+/**
+ * Shows every buffered replay message that the player has reached by now.
+ */
+function releaseReplayComments() {
+  for (const { comment } of takeDueReplayComments(pendingReplayComments, props.currentTime)) {
+    deliverComment(comment)
+  }
+}
+
+/**
+ * Tops the replay buffer back up once it no longer reaches far enough ahead of the player.
+ */
+async function requestMoreReplayComments() {
+  if (replayPollInFlight || liveChatInstance === null) {
+    return
+  }
+
+  if (!shouldPrefetchReplay(replayFetchedUntilMs, props.currentTime)) {
+    return
+  }
+
+  replayPollInFlight = true
+
+  try {
+    await liveChatInstance.pollNext()
+  } finally {
+    replayPollInFlight = false
+  }
+}
+
+watch(() => props.currentTime, (currentTime) => {
+  if (!isReplay.value || liveChatInstance === null) {
+    return
+  }
+
+  const seeked = isReplaySeek(lastCurrentTime, currentTime)
+  lastCurrentTime = currentTime
+
+  if (seeked) {
+    // Everything on screen and in the buffer belongs to the position we just left.
+    comments.splice(0, comments.length)
+    superChatComments.splice(0, superChatComments.length)
+    showSuperChat.value = false
+    pendingReplayComments = []
+    replayFetchedUntilMs = 0
+
+    liveChatInstance.seekTo(currentTime * 1000)
+  } else {
+    releaseReplayComments()
+  }
+
+  requestMoreReplayComments()
+})
 
 /**
  * @param {import('youtubei.js/dist/src/parser/youtube/LiveChat').LiveMetadata} metadata
@@ -558,7 +689,7 @@ function parseLiveChatComment(comment) {
     }
   }
 
-  pushComment(parsedComment)
+  return parsedComment
 }
 
 /**
@@ -580,13 +711,24 @@ function parseLiveChatSuperChat(superChat) {
     }
   }
 
-  superChatComments.unshift(parsedComment)
+  return parsedComment
+}
 
-  setTimeout(() => {
-    removeFromSuperChat(parsedComment)
-  }, 120000)
+/**
+ * Adds a parsed message to the chat. For replays this happens once the player
+ * reaches the position the message was sent at, rather than as soon as it is fetched.
+ * @param {any} comment
+ */
+function deliverComment(comment) {
+  if (comment.superChat) {
+    superChatComments.unshift(comment)
 
-  pushComment(parsedComment)
+    setTimeout(() => {
+      removeFromSuperChat(comment)
+    }, 120000)
+  }
+
+  pushComment(comment)
 }
 
 /**
@@ -612,7 +754,10 @@ function pushComment(comment) {
 function removeFromSuperChat(comment) {
   const index = superChatComments.indexOf(comment)
 
-  superChatComments.splice(index, 1)
+  // Seeking a replay clears the ticker while the removal timeouts are still pending.
+  if (index !== -1) {
+    superChatComments.splice(index, 1)
+  }
 }
 
 /**

--- a/src/renderer/components/WatchVideoLiveChat/WatchVideoLiveChat.vue
+++ b/src/renderer/components/WatchVideoLiveChat/WatchVideoLiveChat.vue
@@ -95,6 +95,15 @@
               :compact="true"
               @change="updateShowLiveChatTimestamps"
             />
+            <FtRadioButton
+              v-if="canFilter"
+              class="liveChatFilter"
+              :title="t('Video.Chat Filter')"
+              :labels="[t('Video.Top Chat'), t('Video.All Messages')]"
+              :values="['TOP_CHAT', 'LIVE_CHAT']"
+              :model-value="liveChatFilter"
+              @update:model-value="updateLiveChatFilter"
+            />
           </div>
         </div>
       </div>
@@ -313,6 +322,7 @@ import FtLoader from '../FtLoader/FtLoader.vue'
 import FtCard from '../ft-card/ft-card.vue'
 import FtButton from '../FtButton/FtButton.vue'
 import FtToggleSwitch from '../FtToggleSwitch/FtToggleSwitch.vue'
+import FtRadioButton from '../FtRadioButton/FtRadioButton.vue'
 import { vSaferHtml } from '../../directives/vSaferHtml.js'
 
 import store from '../../store/index'
@@ -371,6 +381,7 @@ let replayPollInFlight = false
 
 const isLoading = ref(true)
 const isReplay = ref(false)
+const canFilter = ref(false)
 const hasError = ref(false)
 const showEnableChat = ref(false)
 const errorMessage = ref('')
@@ -408,6 +419,9 @@ const scrollingBehaviour = computed(() => {
 /** @type {import('vue').ComputedRef<boolean>} */
 const hideVideoViews = computed(() => store.getters.getHideVideoViews)
 const showLiveChatTimestamps = computed(() => store.getters.getShowLiveChatTimestamps)
+
+/** @type {import('vue').ComputedRef<'TOP_CHAT' | 'LIVE_CHAT'>} */
+const liveChatFilter = computed(() => store.getters.getLiveChatFilter)
 
 /** @type {import('vue').Ref<number | null>} */
 const watchingCount = ref(null)
@@ -502,6 +516,15 @@ const commentsRef = useTemplateRef('commentsRef')
  * @param {import ('youtubei.js/dist/src/parser/continuations').LiveChatContinuation} initialData
  */
 function handleStart(initialData) {
+  canFilter.value = (initialData.header?.view_selector?.sub_menu_items?.length ?? 0) > 1
+
+  // A chat always starts on YouTube's default view, so switch away from it before
+  // showing anything if the other one is the view that is wanted.
+  if (canFilter.value && liveChatInstance.filter !== liveChatFilter.value) {
+    applyChatFilter()
+    return
+  }
+
   for (const action of initialData.actions) {
     handleChatAction(action)
   }
@@ -568,6 +591,38 @@ function handleChatAction(action, offsetMs) {
 }
 
 /**
+ * Drops everything on screen, which is what switching to a different part of the
+ * video or to a different view of the chat leaves behind.
+ */
+function clearChat() {
+  comments.splice(0, comments.length)
+  superChatComments.splice(0, superChatComments.length)
+  showSuperChat.value = false
+  pendingReplayComments = []
+  replayFetchedUntilMs = 0
+}
+
+/**
+ * Moves the chat onto the currently selected view, keeping a replay at the
+ * position the player is at.
+ */
+function applyChatFilter() {
+  if (liveChatInstance === null || !canFilter.value || liveChatInstance.filter === liveChatFilter.value) {
+    return
+  }
+
+  clearChat()
+  liveChatInstance.setFilter(liveChatFilter.value)
+
+  if (isReplay.value) {
+    liveChatInstance.seekTo(props.currentTime * 1000)
+    requestMoreReplayComments()
+  }
+}
+
+watch(liveChatFilter, applyChatFilter)
+
+/**
  * Shows every buffered replay message that the player has reached by now.
  */
 function releaseReplayComments() {
@@ -607,12 +662,7 @@ watch(() => props.currentTime, (currentTime) => {
 
   if (seeked) {
     // Everything on screen and in the buffer belongs to the position we just left.
-    comments.splice(0, comments.length)
-    superChatComments.splice(0, superChatComments.length)
-    showSuperChat.value = false
-    pendingReplayComments = []
-    replayFetchedUntilMs = 0
-
+    clearChat()
     liveChatInstance.seekTo(currentTime * 1000)
   } else {
     releaseReplayComments()
@@ -787,6 +837,10 @@ function handleChatSettingsClickOutside(event) {
 
 function updateShowLiveChatTimestamps(value) {
   store.dispatch('updateShowLiveChatTimestamps', value)
+}
+
+function updateLiveChatFilter(value) {
+  store.dispatch('updateLiveChatFilter', value)
 }
 
 function onScroll() {

--- a/src/renderer/components/WatchVideoLiveChat/WatchVideoLiveChat.vue
+++ b/src/renderer/components/WatchVideoLiveChat/WatchVideoLiveChat.vue
@@ -74,7 +74,8 @@
             <FontAwesomeIcon :icon="['fas', 'sliders-h']" />
           </button>
           <a
-            :href="popoutUrl"
+            v-if="!isReplay"
+            :href="`https://www.youtube.com/live_chat?is_popout=1&v=${props.videoId}`"
             :aria-label="t('Video.Popout Live Chat')"
             :title="t('Video.Popout Live Chat')"
             target="_blank"
@@ -399,12 +400,6 @@ const backendPreference = computed(() => store.getters.getBackendPreference)
 const backendFallback = computed(() => store.getters.getBackendFallback)
 
 const chatHeight = computed(() => superChatComments.length > 0 ? '390px' : '445px')
-
-const popoutUrl = computed(() => {
-  const path = isReplay.value ? 'live_chat_replay' : 'live_chat'
-
-  return `https://www.youtube.com/${path}?is_popout=1&v=${props.videoId}`
-})
 
 const scrollingBehaviour = computed(() => {
   return store.getters.getDisableSmoothScrolling ? 'auto' : 'smooth'

--- a/src/renderer/components/WatchVideoLiveChat/liveChatReplay.js
+++ b/src/renderer/components/WatchVideoLiveChat/liveChatReplay.js
@@ -1,0 +1,63 @@
+/**
+ * How far ahead of the player replay messages are fetched, in milliseconds.
+ */
+export const REPLAY_PREFETCH_MS = 20_000
+
+/**
+ * A jump of more than this many seconds between two player position updates is
+ * treated as a seek rather than as normal playback.
+ */
+export const REPLAY_SEEK_TOLERANCE_SECONDS = 5
+
+/**
+ * @param {string|undefined} videoOffsetTimeMsec the raw offset of a replay action
+ * @returns {number} the player position the action belongs to, in milliseconds
+ */
+export function parseReplayOffsetMs(videoOffsetTimeMsec) {
+  const offsetMs = Number.parseInt(videoOffsetTimeMsec)
+
+  return Number.isFinite(offsetMs) && offsetMs > 0 ? offsetMs : 0
+}
+
+/**
+ * Playback moves the position forward in small steps, so anything else is the
+ * player having jumped somewhere, which the replay has to be re-anchored to.
+ * @param {number} previousSeconds the previously seen player position
+ * @param {number} currentSeconds the current player position
+ * @returns {boolean}
+ */
+export function isReplaySeek(previousSeconds, currentSeconds) {
+  const elapsedSeconds = currentSeconds - previousSeconds
+
+  return elapsedSeconds < 0 || elapsedSeconds > REPLAY_SEEK_TOLERANCE_SECONDS
+}
+
+/**
+ * Removes the buffered messages that the player has reached from `pending`
+ * and returns them, oldest first.
+ * @param {{ offsetMs: number, comment: any }[]} pending buffered messages, oldest first
+ * @param {number} currentSeconds the current player position
+ * @returns {{ offsetMs: number, comment: any }[]}
+ */
+export function takeDueReplayComments(pending, currentSeconds) {
+  const currentOffsetMs = currentSeconds * 1000
+
+  let dueCount = 0
+  while (dueCount < pending.length && pending[dueCount].offsetMs <= currentOffsetMs) {
+    dueCount++
+  }
+
+  return pending.splice(0, dueCount)
+}
+
+/**
+ * Unlike the pending messages, the position the replay has been fetched up to
+ * doesn't shrink as messages are shown, so stretches of the stream without any
+ * chat activity don't look like an empty buffer.
+ * @param {number} fetchedUntilMs the player position the replay has been fetched up to
+ * @param {number} currentSeconds the current player position
+ * @returns {boolean}
+ */
+export function shouldPrefetchReplay(fetchedUntilMs, currentSeconds) {
+  return fetchedUntilMs < currentSeconds * 1000 + REPLAY_PREFETCH_MS
+}

--- a/src/renderer/components/WatchVideoLiveChat/liveChatReplay.js
+++ b/src/renderer/components/WatchVideoLiveChat/liveChatReplay.js
@@ -61,3 +61,39 @@ export function takeDueReplayComments(pending, currentSeconds) {
 export function shouldPrefetchReplay(fetchedUntilMs, currentSeconds) {
   return fetchedUntilMs < currentSeconds * 1000 + REPLAY_PREFETCH_MS
 }
+
+/**
+ * Wraps a poll so that only one runs at a time, and a request made while one is
+ * already running re-runs it afterwards instead of being dropped.
+ *
+ * Dropping it is not safe: a seek discards the response of the poll that is in
+ * flight, so the request that follows the seek is the only thing that would fetch
+ * the new position. Losing it leaves the chat empty until something else happens
+ * to trigger a poll, which never comes while the video is paused.
+ * @param {() => Promise<void>} poll
+ * @returns {() => Promise<void>}
+ */
+export function createCoalescingPoller(poll) {
+  let inFlight = false
+  let pending = false
+
+  return async function request() {
+    if (inFlight) {
+      pending = true
+      return
+    }
+
+    inFlight = true
+
+    try {
+      await poll()
+    } finally {
+      inFlight = false
+    }
+
+    if (pending) {
+      pending = false
+      await request()
+    }
+  }
+}

--- a/src/renderer/store/modules/settings.js
+++ b/src/renderer/store/modules/settings.js
@@ -276,6 +276,7 @@ const state = {
   hideChapters: false,
   showDistractionFreeTitles: false,
   showLiveChatTimestamps: false,
+  liveChatFilter: 'TOP_CHAT',
   landingPage: 'subscriptions',
   newTabPosition: 'afterCurrent',
   tabCloseFocus: 'previousTab',

--- a/src/renderer/views/Watch/Watch.js
+++ b/src/renderer/views/Watch/Watch.js
@@ -686,6 +686,12 @@ export default defineComponent({
     showLiveChat: function () {
       return !this.hideLiveChat && (this.isLive || this.isUpcoming || this.liveChatIsReplay)
     },
+    // The player reports its position about four times a second, but a chat replay
+    // buffers 20 seconds ahead and only cares about jumps of more than a few seconds.
+    // Rounding keeps the chat from re-rendering its message list on every tick.
+    liveChatCurrentTime: function () {
+      return Math.floor(this.currentTime)
+    },
     hideComments: function () {
       return this.$store.getters.getHideComments
     },

--- a/src/renderer/views/Watch/Watch.js
+++ b/src/renderer/views/Watch/Watch.js
@@ -192,6 +192,7 @@ export default defineComponent({
       isLive: false,
       isPremiere: false,
       liveChat: null,
+      liveChatIsReplay: false,
       isLiveContent: false,
       isUpcoming: false,
       isPostLiveDvr: false,
@@ -682,6 +683,9 @@ export default defineComponent({
     hideLiveChat: function () {
       return this.$store.getters.getHideLiveChat
     },
+    showLiveChat: function () {
+      return !this.hideLiveChat && (this.isLive || this.isUpcoming || this.liveChatIsReplay)
+    },
     hideComments: function () {
       return this.$store.getters.getHideComments
     },
@@ -702,7 +706,7 @@ export default defineComponent({
     },
     theatrePossible: function () {
       return this.showTranscript || !this.hideRecommendedVideos ||
-        (!this.hideLiveChat && this.isLive) || this.watchingPlaylist || !!this.nextQueuedVideo ||
+        this.showLiveChat || this.watchingPlaylist || !!this.nextQueuedVideo ||
         this.showSidebarChapters || this.showSidebarSponsorBlock
     },
     theatreTogglePossible: function () {
@@ -1264,6 +1268,7 @@ export default defineComponent({
       this.isLive = false
       this.isPremiere = false
       this.liveChat = null
+      this.liveChatIsReplay = false
       this.isLiveContent = false
       this.isUpcoming = false
       this.isPostLiveDvr = false
@@ -1880,10 +1885,14 @@ export default defineComponent({
           }
         }
 
-        if (!this.hideLiveChat && (this.isLive || this.isUpcoming) && result.livechat) {
+        // Streams that have ended keep their chat around as a replay, which is played back
+        // in sync with the video instead of in real time.
+        if (!this.hideLiveChat && result.livechat && (this.isLive || this.isUpcoming || result.livechat.is_replay)) {
           this.liveChat = result.getLiveChat()
+          this.liveChatIsReplay = this.liveChat.is_replay
         } else {
           this.liveChat = null
+          this.liveChatIsReplay = false
         }
 
         if ((this.isLive || this.isPostLiveDvr) && !this.isUpcoming) {

--- a/src/renderer/views/Watch/Watch.vue
+++ b/src/renderer/views/Watch/Watch.vue
@@ -828,7 +828,7 @@
         :live-chat="liveChat"
         :video-id="videoId"
         :channel-id="channelId"
-        :current-time="currentTime"
+        :current-time="liveChatCurrentTime"
         class="watchVideoSideBar watchVideoPlaylist"
         :class="{ theatrePlaylist: useTheatreMode }"
       />

--- a/src/renderer/views/Watch/Watch.vue
+++ b/src/renderer/views/Watch/Watch.vue
@@ -824,10 +824,11 @@
         </transition>
       </Teleport>
       <watch-video-live-chat
-        v-if="!isLoading && !hideLiveChat && (isLive || isUpcoming)"
+        v-if="!isLoading && showLiveChat"
         :live-chat="liveChat"
         :video-id="videoId"
         :channel-id="channelId"
+        :current-time="currentTime"
         class="watchVideoSideBar watchVideoPlaylist"
         :class="{ theatrePlaylist: useTheatreMode }"
       />

--- a/static/locales/en-US.yaml
+++ b/static/locales/en-US.yaml
@@ -1286,6 +1286,9 @@ Video:
   Live Chat Replay: Live Chat Replay
   Live Chat Settings: Live chat settings
   Show Live Chat Timestamps: Show timestamps
+  Chat Filter: Chat filter
+  Top Chat: Top chat
+  All Messages: All messages
   Enable Live Chat: Enable Live Chat
   Popout Live Chat: Popout Chat
   Live Chat is currently not supported in this build.: Live Chat is currently not

--- a/static/locales/en-US.yaml
+++ b/static/locales/en-US.yaml
@@ -1283,6 +1283,7 @@ Video:
   Live: Live
   Live Now: Live Now
   Live Chat: Live Chat
+  Live Chat Replay: Live Chat Replay
   Live Chat Settings: Live chat settings
   Show Live Chat Timestamps: Show timestamps
   Enable Live Chat: Enable Live Chat
@@ -1291,6 +1292,8 @@ Video:
     supported in this build.
   Live chat is enabled. Chat messages will appear here once sent.: Live chat is enabled.  Chat
     messages will appear here once sent.
+  'Live chat replay is enabled. Chat messages will appear here as the video plays.': Live
+    chat replay is enabled.  Chat messages will appear here as the video plays.
   'Live Chat is currently not supported with the Invidious API. A direct connection to YouTube is required.': Live
     Chat is currently not supported with the Invidious API.  A direct connection to
     YouTube is required.

--- a/tests/unit/live-chat-replay-polling.test.mjs
+++ b/tests/unit/live-chat-replay-polling.test.mjs
@@ -392,3 +392,47 @@ test('the view cannot be switched before the chat has started', () => {
 
   assert.throws(() => liveChat.setFilter('LIVE_CHAT'), /before initial info is retrieved/)
 })
+
+test('a collapsed poll resolves only once the batch it joined has emitted', async () => {
+  const pendingResponses = []
+
+  const { liveChat, updates } = createReplay((args, callIndex) => {
+    if (callIndex === 1) {
+      return new Promise((resolve) => pendingResponses.push(resolve))
+    }
+
+    return {
+      continuation_contents: fakeContinuation({
+        continuation: `AFTER_${callIndex}`,
+        header: callIndex === 0 ? {} : null,
+      }),
+    }
+  })
+
+  liveChat.start()
+  await flush()
+
+  const first = liveChat.pollNext()
+  await flush()
+  // Collapsed into the request that is already on its way.
+  const second = liveChat.pollNext()
+
+  let secondResolved = false
+  second.then(() => { secondResolved = true })
+  await flush()
+
+  // pollNext() promises that the batch's actions have been emitted once it resolves,
+  // so the collapsed caller must not resolve ahead of the batch it joined.
+  assert.equal(secondResolved, false)
+
+  pendingResponses[0]({
+    continuation_contents: fakeContinuation({
+      continuation: 'AFTER_1',
+      actions: [fakeReplayAction('5000')],
+    }),
+  })
+  await Promise.all([first, second])
+
+  assert.equal(secondResolved, true)
+  assert.deepEqual(updates, [fakeReplayAction('5000')])
+})

--- a/tests/unit/live-chat-replay-polling.test.mjs
+++ b/tests/unit/live-chat-replay-polling.test.mjs
@@ -24,6 +24,22 @@ function fakeContinuation({ actions = [], continuation = 'NEXT', header = null }
   })
 }
 
+/**
+ * The two views a chat offers, in the order YouTube returns them. `selected` is
+ * deliberately left pointing at the default view even after a switch, which is how
+ * the real thing behaves for as long as the initial info isn't refreshed.
+ */
+function fakeViewSelector() {
+  return {
+    view_selector: {
+      sub_menu_items: [
+        { title: 'Top chat', selected: true, continuation: 'TOP_CHAT_CONTINUATION' },
+        { title: 'Live chat', selected: false, continuation: 'LIVE_CHAT_CONTINUATION' },
+      ],
+    },
+  }
+}
+
 function fakeReplayAction(videoOffsetTimeMsec) {
   return { video_offset_time_msec: videoOffsetTimeMsec }
 }
@@ -31,12 +47,12 @@ function fakeReplayAction(videoOffsetTimeMsec) {
 /**
  * @param {((args: any, callIndex: number) => any)} respond
  */
-function createReplay(respond) {
+function createReplay(respond, { isReplay = true } = {}) {
   const requests = []
 
   const videoInfo = {
     basic_info: { id: 'dQw4w9WgXcQ', channel_id: 'UC38IQsAvIsxxjztdMZQtwHA' },
-    livechat: { continuation: INITIAL_CONTINUATION, is_replay: true },
+    livechat: { continuation: INITIAL_CONTINUATION, is_replay: isReplay },
     actions: {
       execute(endpoint, args) {
         requests.push({ endpoint, args })
@@ -239,4 +255,140 @@ test('concurrent polls are collapsed into one request', async () => {
   await flush()
 
   assert.equal(requests.length, 2)
+})
+
+test('switching views moves the chat onto the other continuation', async () => {
+  const { liveChat, requests } = createReplay((args, callIndex) => ({
+    continuation_contents: fakeContinuation({
+      continuation: `AFTER_${callIndex}`,
+      header: callIndex === 0 ? fakeViewSelector() : null,
+    }),
+  }))
+
+  liveChat.start()
+  await flush()
+  assert.equal(liveChat.filter, 'TOP_CHAT')
+
+  liveChat.setFilter('LIVE_CHAT')
+  assert.equal(liveChat.filter, 'LIVE_CHAT')
+
+  await liveChat.pollNext()
+  await flush()
+  assert.equal(requests[1].args.continuation, 'LIVE_CHAT_CONTINUATION')
+})
+
+test('switching back to the default view works', async () => {
+  const { liveChat, requests } = createReplay((args, callIndex) => ({
+    continuation_contents: fakeContinuation({
+      continuation: `AFTER_${callIndex}`,
+      // Only the very first response refreshes the initial info, so the selection
+      // flags on it still say the default view is the selected one.
+      header: callIndex === 0 ? fakeViewSelector() : null,
+    }),
+  }))
+
+  liveChat.start()
+  await flush()
+
+  liveChat.setFilter('LIVE_CHAT')
+  await liveChat.pollNext()
+  await flush()
+
+  liveChat.setFilter('TOP_CHAT')
+  await liveChat.pollNext()
+  await flush()
+
+  // applyFilter() would have bailed out here, because it reads the stale selection
+  // flags rather than tracking the view it last switched to.
+  assert.equal(liveChat.filter, 'TOP_CHAT')
+  assert.equal(requests[2].args.continuation, 'TOP_CHAT_CONTINUATION')
+})
+
+test('seeking a replay stays on the selected view', async () => {
+  const { liveChat, requests } = createReplay((args, callIndex) => ({
+    continuation_contents: fakeContinuation({
+      continuation: `AFTER_${callIndex}`,
+      header: callIndex === 0 ? fakeViewSelector() : null,
+    }),
+  }))
+
+  liveChat.start()
+  await flush()
+
+  liveChat.setFilter('LIVE_CHAT')
+  liveChat.seekTo(600_000)
+  await liveChat.pollNext()
+  await flush()
+
+  // Seeking must not drop back to the view the chat happened to start on.
+  assert.equal(requests[1].args.continuation, 'LIVE_CHAT_CONTINUATION')
+  assert.deepEqual(requests[1].args.currentPlayerState, { playerOffsetMs: '600000' })
+})
+
+test('switching views discards the messages already on their way', async () => {
+  const pendingResponses = []
+
+  const { liveChat, updates } = createReplay((args, callIndex) => {
+    if (callIndex === 1) {
+      return new Promise((resolve) => pendingResponses.push(resolve))
+    }
+
+    return {
+      continuation_contents: fakeContinuation({
+        continuation: `AFTER_${callIndex}`,
+        header: callIndex === 0 ? fakeViewSelector() : null,
+      }),
+    }
+  })
+
+  liveChat.start()
+  await flush()
+
+  liveChat.pollNext()
+  await flush()
+  liveChat.setFilter('LIVE_CHAT')
+
+  pendingResponses[0]({
+    continuation_contents: fakeContinuation({
+      continuation: 'STALE',
+      actions: [fakeReplayAction('120000')],
+    }),
+  })
+  await flush()
+
+  // Those messages belong to the view that was switched away from.
+  assert.deepEqual(updates, [])
+})
+
+test('a live chat keeps polling after its view is switched', async (t) => {
+  const { liveChat, requests } = createReplay((args, callIndex) => ({
+    continuation_contents: fakeContinuation({
+      continuation: `AFTER_${callIndex}`,
+      header: callIndex === 0 ? fakeViewSelector() : null,
+    }),
+  }), { isReplay: false })
+
+  // A live chat polls itself, so it has to be stopped even if an assertion below
+  // fails, otherwise it keeps the process alive and the run hangs instead of failing.
+  t.after(() => liveChat.stop())
+
+  liveChat.start()
+  await flush()
+
+  const before = requests.length
+  liveChat.setFilter('LIVE_CHAT')
+  await flush()
+
+  // Discarding the in-flight response breaks the self-sustaining poll chain that a
+  // live chat runs on, so switching has to restart it.
+  assert.ok(requests.length > before, `expected a new request, got ${requests.length} vs ${before}`)
+  assert.equal(requests[before].args.continuation, 'LIVE_CHAT_CONTINUATION')
+})
+
+test('the view cannot be switched before the chat has started', () => {
+  const { liveChat } = createReplay(() => ({
+    continuation_contents: fakeContinuation({ header: fakeViewSelector() }),
+  }))
+
+  assert.throws(() => liveChat.setFilter('LIVE_CHAT'), /before initial info is retrieved/)
 })

--- a/tests/unit/live-chat-replay-polling.test.mjs
+++ b/tests/unit/live-chat-replay-polling.test.mjs
@@ -1,0 +1,242 @@
+import assert from 'node:assert/strict'
+import test from 'node:test'
+
+// Loads the platform shim that youtubei.js' event emitter needs.
+import 'youtubei.js'
+
+// Imported by path because youtubei.js doesn't export its internals, and because
+// these cover behaviour that only exists thanks to patches/youtubei.js@17.2.0.patch.
+import LiveChat from '../../node_modules/youtubei.js/dist/src/parser/youtube/LiveChat.js'
+import { LiveChatContinuation } from '../../node_modules/youtubei.js/dist/src/parser/continuations.js'
+
+const INITIAL_CONTINUATION = 'INITIAL_CONTINUATION'
+
+/**
+ * The real continuations come out of the parser, which needs far more of a response
+ * than these tests care about, so the prototype is borrowed for the `instanceof`
+ * check that LiveChat does and only the fields it reads are filled in.
+ */
+function fakeContinuation({ actions = [], continuation = 'NEXT', header = null }) {
+  return Object.assign(Object.create(LiveChatContinuation.prototype), {
+    actions,
+    continuation: continuation === null ? undefined : { token: continuation },
+    header,
+  })
+}
+
+function fakeReplayAction(videoOffsetTimeMsec) {
+  return { video_offset_time_msec: videoOffsetTimeMsec }
+}
+
+/**
+ * @param {((args: any, callIndex: number) => any)} respond
+ */
+function createReplay(respond) {
+  const requests = []
+
+  const videoInfo = {
+    basic_info: { id: 'dQw4w9WgXcQ', channel_id: 'UC38IQsAvIsxxjztdMZQtwHA' },
+    livechat: { continuation: INITIAL_CONTINUATION, is_replay: true },
+    actions: {
+      execute(endpoint, args) {
+        requests.push({ endpoint, args })
+        return Promise.resolve(respond(args, requests.length - 1))
+      },
+    },
+  }
+
+  const liveChat = new LiveChat(videoInfo)
+
+  const started = []
+  const updates = []
+  liveChat.on('start', (contents) => started.push(contents))
+  liveChat.on('chat-update', (action) => updates.push(action))
+
+  return { liveChat, requests, started, updates }
+}
+
+/** Lets the polling promise chain settle. */
+function flush() {
+  return new Promise((resolve) => setTimeout(resolve, 0))
+}
+
+test('replays wait for the consumer instead of polling on their own', async () => {
+  const { liveChat, requests, started } = createReplay((args, callIndex) => ({
+    continuation_contents: fakeContinuation({
+      continuation: `AFTER_${callIndex}`,
+      header: callIndex === 0 ? {} : null,
+      actions: [fakeReplayAction('1000')],
+    }),
+  }))
+
+  liveChat.start()
+  await flush()
+
+  assert.equal(started.length, 1)
+  // A live chat would have kept polling here, and would also have started polling
+  // /updated_metadata, which a video that already ended has nothing to report for.
+  assert.equal(requests.length, 1)
+  assert.equal(requests[0].endpoint, 'live_chat/get_live_chat_replay')
+
+  await liveChat.pollNext()
+  await flush()
+
+  assert.equal(requests.length, 2)
+  assert.equal(requests[1].args.continuation, 'AFTER_0')
+})
+
+test('replays hand their actions over without pacing them', async () => {
+  const { liveChat, updates } = createReplay((args, callIndex) => ({
+    continuation_contents: fakeContinuation({
+      continuation: `AFTER_${callIndex}`,
+      header: callIndex === 0 ? {} : null,
+      actions: [fakeReplayAction('60000'), fakeReplayAction('61000')],
+    }),
+  }))
+
+  liveChat.start()
+  await flush()
+  await liveChat.pollNext()
+
+  // The smoothed queue would have spread these out over the next few seconds,
+  // which is the wrong pacing for messages that carry their own player offsets.
+  assert.deepEqual(updates, [fakeReplayAction('60000'), fakeReplayAction('61000')])
+})
+
+test('seeking re-anchors the replay to the given player position', async () => {
+  const { liveChat, requests } = createReplay((args, callIndex) => ({
+    continuation_contents: fakeContinuation({
+      continuation: `AFTER_${callIndex}`,
+      header: callIndex === 0 ? {} : null,
+    }),
+  }))
+
+  liveChat.start()
+  await flush()
+  assert.equal(requests[0].args.currentPlayerState, undefined)
+
+  liveChat.seekTo(1_800_000)
+  await liveChat.pollNext()
+  await flush()
+
+  assert.equal(requests[1].args.continuation, INITIAL_CONTINUATION)
+  assert.deepEqual(requests[1].args.currentPlayerState, { playerOffsetMs: '1800000' })
+
+  await liveChat.pollNext()
+  await flush()
+
+  // Sending the offset again would keep pulling the replay back to the seek position.
+  assert.equal(requests[2].args.continuation, 'AFTER_1')
+  assert.equal(requests[2].args.currentPlayerState, undefined)
+})
+
+test('seeking before the replay is started begins it at that position', async () => {
+  const { liveChat, requests } = createReplay(() => ({
+    continuation_contents: fakeContinuation({ header: {} }),
+  }))
+
+  liveChat.seekTo(90_000)
+  liveChat.start()
+  await flush()
+
+  assert.equal(requests.length, 1)
+  assert.deepEqual(requests[0].args.currentPlayerState, { playerOffsetMs: '90000' })
+})
+
+test('a response that a seek has overtaken is discarded', async () => {
+  /** @type {((value: any) => void)[]} */
+  const pendingResponses = []
+
+  const { liveChat, requests, updates } = createReplay((args, callIndex) => {
+    if (callIndex === 1) {
+      return new Promise((resolve) => pendingResponses.push(resolve))
+    }
+
+    return {
+      continuation_contents: fakeContinuation({
+        continuation: `AFTER_${callIndex}`,
+        header: callIndex === 0 ? {} : null,
+        actions: [fakeReplayAction(callIndex === 0 ? '0' : '600000')],
+      }),
+    }
+  })
+
+  liveChat.start()
+  await flush()
+  updates.length = 0
+
+  // Fetch a batch, then seek away before it comes back.
+  liveChat.pollNext()
+  await flush()
+  assert.equal(requests.length, 2)
+
+  liveChat.seekTo(60_000)
+
+  pendingResponses[0]({
+    continuation_contents: fakeContinuation({
+      continuation: 'STALE',
+      actions: [fakeReplayAction('900000')],
+    }),
+  })
+  await flush()
+
+  // The overtaken batch belongs to the position that was left behind.
+  assert.deepEqual(updates, [])
+
+  await liveChat.pollNext()
+  await flush()
+
+  // The stale response must not have advanced the continuation either.
+  assert.equal(requests[2].args.continuation, INITIAL_CONTINUATION)
+  assert.deepEqual(updates, [fakeReplayAction('600000')])
+})
+
+test('the end of the replay stops further fetching without ending the chat', async () => {
+  let ended = false
+
+  const { liveChat, requests } = createReplay((args, callIndex) => ({
+    continuation_contents: fakeContinuation({
+      continuation: callIndex === 0 ? 'AFTER_0' : null,
+      header: callIndex === 0 ? {} : null,
+      actions: [fakeReplayAction('7200000')],
+    }),
+  }))
+  liveChat.on('end', () => { ended = true })
+
+  liveChat.start()
+  await flush()
+  await liveChat.pollNext()
+  await flush()
+  assert.equal(requests.length, 2)
+
+  await liveChat.pollNext()
+  await flush()
+
+  assert.equal(requests.length, 2)
+  // Running out of chat is not an error, and seeking back has to keep working.
+  assert.equal(ended, false)
+
+  liveChat.seekTo(60_000)
+  await liveChat.pollNext()
+  await flush()
+
+  assert.equal(requests.length, 3)
+  assert.equal(requests[2].args.continuation, INITIAL_CONTINUATION)
+})
+
+test('concurrent polls are collapsed into one request', async () => {
+  const { liveChat, requests } = createReplay((args, callIndex) => ({
+    continuation_contents: fakeContinuation({
+      continuation: `AFTER_${callIndex}`,
+      header: callIndex === 0 ? {} : null,
+    }),
+  }))
+
+  liveChat.start()
+  await flush()
+
+  await Promise.all([liveChat.pollNext(), liveChat.pollNext(), liveChat.pollNext()])
+  await flush()
+
+  assert.equal(requests.length, 2)
+})

--- a/tests/unit/live-chat-replay.test.mjs
+++ b/tests/unit/live-chat-replay.test.mjs
@@ -1,0 +1,69 @@
+import assert from 'node:assert/strict'
+import test from 'node:test'
+
+import {
+  isReplaySeek,
+  parseReplayOffsetMs,
+  shouldPrefetchReplay,
+  takeDueReplayComments,
+} from '../../src/renderer/components/WatchVideoLiveChat/liveChatReplay.js'
+
+test('reads the player position a replay action belongs to', () => {
+  assert.equal(parseReplayOffsetMs('90000'), 90_000)
+  assert.equal(parseReplayOffsetMs('0'), 0)
+})
+
+test('falls back to the start of the video for unusable replay offsets', () => {
+  assert.equal(parseReplayOffsetMs(undefined), 0)
+  assert.equal(parseReplayOffsetMs(''), 0)
+  assert.equal(parseReplayOffsetMs('not a number'), 0)
+  // Messages sent before the stream went live carry a negative offset.
+  assert.equal(parseReplayOffsetMs('-4000'), 0)
+})
+
+test('treats small forward steps as playback rather than as a seek', () => {
+  assert.equal(isReplaySeek(0, 0), false)
+  assert.equal(isReplaySeek(10, 10.25), false)
+  assert.equal(isReplaySeek(10, 15), false)
+})
+
+test('treats jumps in either direction as a seek', () => {
+  assert.equal(isReplaySeek(10, 15.5), true)
+  assert.equal(isReplaySeek(3600, 60), true)
+  // Restarting a finished video seeks back to the beginning.
+  assert.equal(isReplaySeek(600, 0), true)
+})
+
+test('shows only the buffered messages the player has reached', () => {
+  const pending = [
+    { offsetMs: 1000, comment: 'a' },
+    { offsetMs: 2000, comment: 'b' },
+    { offsetMs: 9000, comment: 'c' },
+  ]
+
+  assert.deepEqual(takeDueReplayComments(pending, 2), [
+    { offsetMs: 1000, comment: 'a' },
+    { offsetMs: 2000, comment: 'b' },
+  ])
+  assert.deepEqual(pending, [{ offsetMs: 9000, comment: 'c' }])
+
+  assert.deepEqual(takeDueReplayComments(pending, 2), [])
+  assert.deepEqual(pending, [{ offsetMs: 9000, comment: 'c' }])
+
+  assert.deepEqual(takeDueReplayComments(pending, 30), [{ offsetMs: 9000, comment: 'c' }])
+  assert.deepEqual(pending, [])
+  assert.deepEqual(takeDueReplayComments(pending, 30), [])
+})
+
+test('keeps fetching while the replay does not reach far enough ahead of the player', () => {
+  assert.equal(shouldPrefetchReplay(0, 0), true)
+  assert.equal(shouldPrefetchReplay(19_000, 0), true)
+  assert.equal(shouldPrefetchReplay(20_000, 0), false)
+
+  // A quiet stretch of the stream leaves nothing pending, but the replay has
+  // still been fetched past the player, so it must not be refetched.
+  assert.equal(shouldPrefetchReplay(3_600_000, 3000), false)
+
+  // Seeking ahead of everything fetched so far has to refill the buffer.
+  assert.equal(shouldPrefetchReplay(60_000, 3000), true)
+})

--- a/tests/unit/live-chat-replay.test.mjs
+++ b/tests/unit/live-chat-replay.test.mjs
@@ -2,6 +2,7 @@ import assert from 'node:assert/strict'
 import test from 'node:test'
 
 import {
+  createCoalescingPoller,
   isReplaySeek,
   parseReplayOffsetMs,
   shouldPrefetchReplay,
@@ -66,4 +67,78 @@ test('keeps fetching while the replay does not reach far enough ahead of the pla
 
   // Seeking ahead of everything fetched so far has to refill the buffer.
   assert.equal(shouldPrefetchReplay(60_000, 3000), true)
+})
+
+test('runs one poll at a time', async () => {
+  let running = 0
+  let overlapped = false
+  let calls = 0
+
+  const poll = createCoalescingPoller(async () => {
+    calls++
+    running++
+    overlapped ||= running > 1
+    await new Promise((resolve) => setTimeout(resolve, 5))
+    running--
+  })
+
+  await Promise.all([poll(), poll(), poll()])
+
+  assert.equal(overlapped, false)
+  // The two requests made while the first was running collapse into one re-run.
+  assert.equal(calls, 2)
+})
+
+test('re-runs a poll that was requested while one was already in flight', async () => {
+  // The scenario this exists for: a poll is in flight, the player seeks, the seek
+  // discards that poll's response, and the request that follows it is the only thing
+  // left that would fetch the new position.
+  const positions = []
+  let currentPosition = 0
+  let releaseFirst
+
+  const poll = createCoalescingPoller(async () => {
+    const position = currentPosition
+    if (position === 0) {
+      await new Promise((resolve) => { releaseFirst = resolve })
+    }
+    positions.push(position)
+  })
+
+  poll()
+  await Promise.resolve()
+
+  // Seek while that first poll is still in flight.
+  currentPosition = 3600
+  poll()
+
+  releaseFirst()
+  await new Promise((resolve) => setTimeout(resolve, 0))
+
+  // Without the re-run the chat would sit empty at 3600 until playback resumed.
+  assert.deepEqual(positions, [0, 3600])
+})
+
+test('stops re-running once nothing further was requested', async () => {
+  let calls = 0
+  const poll = createCoalescingPoller(async () => { calls++ })
+
+  await poll()
+  assert.equal(calls, 1)
+
+  await poll()
+  assert.equal(calls, 2)
+})
+
+test('a failing poll does not wedge the poller', async () => {
+  let calls = 0
+  const poll = createCoalescingPoller(async () => {
+    calls++
+    throw new Error('network down')
+  })
+
+  await assert.rejects(poll(), /network down/)
+  // The in-flight flag has to be released, or nothing would ever poll again.
+  await assert.rejects(poll(), /network down/)
+  assert.equal(calls, 2)
 })


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Make sure to follow the contributing guidelines. -->
<!-- Important note, we may remove your pull request if you do not use this provided PR template correctly. -->
<!-- Agent instructions: Preserve every heading, comment, and marker in this template. Never remove or rewrite the release-note-category:start/end, release-note:start/end, or release-note-image:start/end marker pairs. Never remove or rewrite the Release note images section; leave its contents for a human. -->

## Pull Request Type
<!-- Please select what type of pull request this is: [x] -->
- [ ] Bugfix
- [x] Feature Implementation
- [ ] Documentation
- [ ] Other

## Related issue
<!-- Please link the issue your pull request is referring to. -->
<!-- If this pull request fully resolves the relevant issue, put "closes" before the issue number. -->
<!-- Example: "closes #123456". -->
None

## Description
<!-- Please write a clear and concise description of what the pull request does. -->
Streams that have ended keep their chat around as a replay, but we only ever showed the live chat panel for streams that were live or upcoming. This plays that replay back in sync with the video.

Messages are buffered against the video offset they were sent at and only shown once the player reaches them, ~20s of chat is fetched ahead of playback, and seeking re-anchors the chat to the new position (in either direction).

This needs a change to youtubei.js, so `patches/youtubei.js@17.2.0.patch` grows a section for it. Upstream's replay mode paces messages by wall clock and notes in a comment that this ends up "quite innacurate" without data from the video player. Replays now:

- hand their actions over unpaced, since the actions carry their own player offsets and the consumer is in a better position to decide when to show them
- expose `seekTo(offsetMs)`, which re-requests the initial continuation with `currentPlayerState.playerOffsetMs`. The offset is only sent while we are still on that initial continuation — sending it alongside a later one keeps dragging the chat back to the seek position instead of advancing
- expose `pollNext()`, because only the consumer knows how far ahead of the player it wants to buffer
- carry a seek generation counter, so responses that a seek (or a `stop()`) has overtaken are discarded rather than emitting messages for the position that was just left, or a spurious `error`
- skip polling `/updated_metadata`, which a video that already ended has nothing to report for

The scheduling logic lives in a separate `liveChatReplay.js` module next to the component, following the pattern already used for `transcriptScroll.js`.

### Top chat / all messages

Separately, the chat's settings menu gains a selector between YouTube's two chat views — "Top chat", which hides potential spam, and "All messages", which is YouTube's "Live chat" view. This applies to live streams, premieres and replays alike; previously we always took whichever view YouTube defaults to. The choice is remembered across videos, alongside the existing timestamps setting.

youtubei.js has an `applyFilter()` for this, but it reads the selected view back off `initial_info`, whose `selected` flags go stale the moment it is used — so switching *back* to the default view silently did nothing. The patch adds `setFilter()` instead, which tracks the selected view itself, points replay seeks at the newly selected view so seeking doesn't revert it, discards the in-flight messages of the view being left behind, and restarts the self-sustaining poll chain that live chats run on.

The selector is hidden for chats that don't offer both views.

Two smaller things included:

- `removeFromSuperChat()` called `splice(index, 1)` without checking for `-1`, so a missing entry silently removed the last one instead. Harmless before, but seeking clears the ticker while the removal timeouts are still pending, which makes it reachable.
- `theatrePossible` open-coded the live chat condition; it now shares the `showLiveChat` computed. As a side effect theatre mode becomes available for upcoming streams, which already render the chat panel.

Replay is local-API only. Under Invidious the component can discover the replay itself when backend fallback is on, but the Watch view has no reliable "was live" flag to gate rendering on, so it stays hidden there. Live and upcoming streams are unaffected on either backend.

## Release note category
<!-- Select exactly one category. Every pull request must select one. -->
<!-- release-note-category:start -->
- [x] Not noteworthy
- [ ] Highlights
- [ ] More improvements
- [ ] Fixed bugs
<!-- release-note-category:end -->

## Release note
<!-- Required unless "Not noteworthy" is selected. -->
<!-- Write one concise, user-facing entry without a leading bullet. -->
<!-- release-note:start -->
Live chat replay is now shown for streams that have ended, played back in sync with the video, and live chat can be switched between top chat and all messages
<!-- release-note:end -->

## Release note images
<!-- Human-only: Agents must preserve this entire section and leave it empty. -->
<!-- Optional. Paste one or more Markdown images or HTML image tags here. -->
<!-- The release notes will use an HTML image tag and limit images taller than 300 pixels. -->
<!-- release-note-image:start -->

<!-- release-note-image:end -->

## Testing
<!-- How can reviewers verify that the PR produces correct results? -->
<!-- Agent instructions: Only write human-facing steps that explain how to verify the change while running this branch in dev mode. Include expected results and, when applicable, helpful console snippets for interactive verification. Do not include automated checks, commands, results, pass counts, or CI status. -->
Make sure the local API is selected as the backend and that "Hide Live Chat" is off in Distraction Free Settings.

Open a VOD of a stream that has ended and had chat enabled, for example `https://www.youtube.com/watch?v=nfhDuOHMp0A` (NASA, ~3.9h).

1. The sidebar shows a chat panel titled **Live Chat Replay** (not "Live Chat"), with no watching count next to it.
2. Let it play. Messages appear gradually, roughly in time with what is happening in the video, rather than all at once or at a pace unrelated to playback.
3. Drag the seek bar to somewhere far ahead, e.g. around the two hour mark. The chat clears and within a moment refills with the messages from that part of the stream. Turning on **Show timestamps** in the chat's settings menu makes this easy to confirm — the timestamps should match the position you seeked to.
4. Seek backwards to an earlier point. The chat re-anchors there too.
5. Reload the page so the video resumes from your saved watch progress. The chat starts at that position rather than at the beginning of the stream.
6. The popout chat button is not shown, since YouTube has no popout for chat replays.

Then check the chat view selector, which applies to live streams, premieres and replays:

7. Open the chat's settings menu (the sliders icon). Under **Chat filter**, switch from **Top chat** to **All messages**. The chat clears and refills, and shows more messages than before — including ones that were previously hidden.
8. Switch back to **Top chat**. It should actually switch back, not silently stay on all messages.
9. On a replay, seek somewhere else after switching. The chat should stay on the view you picked rather than reverting to Top chat.
10. Open a different video. Your choice should still be applied.

Then check nothing regressed for genuinely live content: open a stream that is currently live and confirm messages still arrive in real time and the panel is still titled "Live Chat" with a watching count.

A stream whose chat the uploader disabled (for example `https://www.youtube.com/watch?v=Tf_UjBMIzNo`) should show no chat panel at all.

## Additional context
<!-- Add any other context about the pull request here. -->
Some things worth knowing when reviewing the replay responses, since they are easy to misread:

- The batch YouTube returns after a seek is backfill — it includes a `LiveChatViewerEngagementMessage` at offset 0 ("welcome to live chat replay") and an `AddBannerToLiveChatCommand` from early in the stream, alongside the messages actually near the seek position. The offset 0 entry makes the batch look like the seek was ignored when it was not. Only `LiveChatTextMessage` and `LiveChatPaidMessage` are rendered, so both are dropped.
- `LiveChatPlaceholderItem` shows up frequently among the real messages; those are withheld or deleted messages and are also dropped.
- The response to a seek does contain a header, so `start` fires again. The listener is registered with `on` rather than `once` for that reason.
- The popout chat button is hidden for replays. YouTube's replay chat popout is keyed on a continuation token rather than a video id, so there is no equivalent URL to link to.
