### PR TITLE
ci: keep the GitLab mirror off pull requests and out of its own race

### DIFF
--- a/.github/GITLAB_MIRRORING.md
+++ b/.github/GITLAB_MIRRORING.md
@@ -5,10 +5,17 @@ GitHub (`OpenTubeX/OpenTubeX`) is the authoritative repository. GitLab
 upstream source. Direct commits, branches, or tags created on GitLab may be
 overwritten or deleted by the next synchronization.
 
-The `Mirror to GitLab` workflow synchronizes every GitHub branch and tag after
-pushes and deletions. It also runs nightly to reconcile failed attempts. Force
-updates preserve exact synchronization after rewritten GitHub history, and
-branch or tag deletions on GitHub are propagated to GitLab.
+The `Mirror to GitLab` workflow synchronizes every GitHub branch and tag in a
+single run. It starts after pushes to `development`, after tag pushes, after
+branch or tag deletions, and nightly to reconcile failed attempts. Pushes to
+other branches do not start a run of their own, so a new feature branch reaches
+GitLab with the next run rather than immediately. Force updates preserve exact
+synchronization after rewritten GitHub history, and branch or tag deletions on
+GitHub are propagated to GitLab.
+
+Verification compares GitLab against the snapshot the run itself fetched and
+pushed. Refs that appear or disappear on GitHub while a run is in flight are
+therefore not reported as mirroring failures; the next run picks them up.
 
 Only Git refs are mirrored. Issues, merge requests, pull requests, releases,
 CI variables, project settings, packages, and other platform-specific metadata

--- a/.github/workflows/mirror-to-gitlab.yml
+++ b/.github/workflows/mirror-to-gitlab.yml
@@ -1,9 +1,12 @@
 name: Mirror to GitLab
 
+# Every run mirrors all refs, so there is nothing to gain from starting one per
+# pushed branch. Listening on '**' only made the mirror a check on every pull
+# request, because GitHub reports push runs against the head commit.
 on:
   push:
     branches:
-      - '**'
+      - development
     tags:
       - '**'
   delete:
@@ -80,16 +83,26 @@ jobs:
             'refs/heads/*:refs/heads/*' \
             'refs/tags/*:refs/tags/*'
 
-          git ls-remote --heads --tags "${SOURCE_URL}" \
-            | LC_ALL=C sort > "${mirror_dir}/source-refs.txt"
+          # Verify against the snapshot that was just pushed, not against a
+          # fresh look at GitHub: branches are deleted there while the mirror
+          # runs (auto-delete on merge), and re-reading the source made those
+          # deletions look like refs the mirror had failed to prune. The next
+          # run reconciles whatever moved in the meantime.
+          git -C "${mirror_dir}/repository.git" for-each-ref \
+            --format='%(objectname) %(refname)' refs/heads refs/tags \
+            | LC_ALL=C sort > "${mirror_dir}/expected-refs.txt"
 
+          # ls-remote reports an extra '^{}' line per annotated tag, which
+          # for-each-ref does not, so drop the peeled entries on both sides.
           git ls-remote --heads --tags "${TARGET_URL}" \
+            | sed '/\^{}$/d' \
+            | awk '{ print $1, $2 }' \
             | LC_ALL=C sort > "${mirror_dir}/target-refs.txt"
 
           if ! diff --unified \
-            "${mirror_dir}/source-refs.txt" \
+            "${mirror_dir}/expected-refs.txt" \
             "${mirror_dir}/target-refs.txt"; then
-            echo "::error::GitLab branch or tag refs do not match GitHub."
+            echo "::error::GitLab branch or tag refs do not match the mirrored GitHub snapshot."
             exit 1
           fi
 


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Make sure to follow the contributing guidelines. -->
<!-- Important note, we may remove your pull request if you do not use this provided PR template correctly. -->
<!-- Agent instructions: Preserve every heading, comment, and marker in this template. Never remove or rewrite the release-note-category:start/end, release-note:start/end, or release-note-image:start/end marker pairs. Never remove or rewrite the Release note images section; leave its contents for a human. -->

## Pull Request Type
<!-- Please select what type of pull request this is: [x] -->
- [x] Bugfix
- [ ] Feature Implementation
- [ ] Documentation
- [ ] Other

## Related issue
<!-- Please link the issue your pull request is referring to. -->
<!-- If this pull request fully resolves the relevant issue, put "closes" before the issue number. -->
<!-- Example: "closes #123456". -->
Follow-up to f1dd94ede. Failing runs: https://github.com/OpenTubeX/OpenTubeX/actions/runs/30985605612 (on #530) and https://github.com/OpenTubeX/OpenTubeX/actions/runs/30985620870 (on `development`).

## Description
<!-- Please write a clear and concise description of what the pull request does. -->
**The mirror showed up as a check on every pull request.** The workflow listened for pushes on `branches: '**'`, so every branch push started a run, and GitHub reports push-triggered runs against the head commit — which is what a PR's check list displays. A run mirrors *all* refs regardless of which one was pushed, so starting one per branch never bought anything. Pushes to `development` and to tags now cover it, alongside the existing delete, nightly and manual triggers.

The trade-off: a new feature branch now reaches GitLab with the next run (the next `development` push, deletion, or the nightly cron) instead of within a minute of being pushed. Given GitLab is a read-only mirror, that seemed like the right side to err on, but say the word if you want feature branches mirrored eagerly and I will find another way to keep the check off PRs.

**Verification raced itself.** After pushing, the run compared a fresh `git ls-remote` of GitHub against GitLab. Branches get deleted on GitHub while a run is in flight (auto-delete on merge), so the mirror would faithfully push a branch that the source no longer listed a few seconds later, and the comparison blamed the mirror for not pruning it. That is exactly the `development` failure above:

```
+548fa45d5bfbc04f037280debd33e2cd4327807f	refs/heads/fix-select-keyboard-and-icon-color
```

That branch was gone from GitHub by the time the run reached the comparison — the mirror had done nothing wrong. Verification now compares GitLab against the snapshot the run itself fetched and pushed, so it only reports real mirroring gaps and the next run reconciles whatever moved. `ls-remote` emits an extra `^{}` line per annotated tag that `for-each-ref` does not, so those peeled entries are dropped to keep both sides in the same shape.

## Release note category
<!-- Select exactly one category. Every pull request must select one. -->
<!-- release-note-category:start -->
- [x] Not noteworthy
- [ ] Highlights
- [ ] More improvements
- [ ] Fixed bugs
<!-- release-note-category:end -->

## Release note
<!-- Required unless "Not noteworthy" is selected. -->
<!-- Write one concise, user-facing entry without a leading bullet. -->
<!-- release-note:start -->

<!-- release-note:end -->

## Release note images
<!-- Human-only: Agents must preserve this entire section and leave it empty. -->
<!-- Optional. Paste one or more Markdown images or HTML image tags here. -->
<!-- The release notes will use an HTML image tag and limit images taller than 300 pixels. -->
<!-- release-note-image:start -->

<!-- release-note-image:end -->

## Testing
<!-- How can reviewers verify that the PR produces correct results? -->
<!-- Agent instructions: Only write human-facing steps that explain how to verify the change while running this branch in dev mode. Include expected results and, when applicable, helpful console snippets for interactive verification. Do not include automated checks, commands, results, pass counts, or CI status. -->
CI-only change, nothing to run in the app.

This pull request demonstrates the first half of itself: no `mirror` check should appear in its own check list, because the workflow version on this branch is the one GitHub evaluates for the push that created it.

For the second half, open **Actions** → **Mirror to GitLab** → **Run workflow** on this branch after merging, and confirm the run ends with `GitLab mirror matches GitHub.` while a pull request is being merged with branch auto-delete enabled. Previously that overlap could end the run with `GitLab branch or tag refs do not match GitHub.` naming the just-deleted branch.

## Additional context
<!-- Add any other context about the pull request here. -->
The comparison still fails on a genuine gap — a ref missing from or stale on GitLab is reported the same as before. Only the "GitHub moved underneath us" case stops being an error.
