### PR TITLE
fix(captions): scale captions with the player and raise the maximum size

### DIFF
--- a/e2e/tests/network/watch.spec.mjs
+++ b/e2e/tests/network/watch.spec.mjs
@@ -436,6 +436,96 @@ test.describe('watch page', () => {
     expect(animations[1].zIndex).toBe('150')
   })
 
+  test('scales the captions down with the scroll mini player', async ({ page, innertube }) => {
+    test.skip(!innertube.playback, 'needs real media streams')
+    await openVideo(page)
+
+    const video = await waitForPlaybackOrSkip(test, page)
+    await video.evaluate(element => element.pause())
+
+    const player = page.locator('.ftVideoPlayer')
+    await player.evaluate(element => {
+      if (element.querySelector('.shaka-text-container')) return
+
+      const captions = document.createElement('div')
+      captions.className = 'shaka-text-container'
+      element.append(captions)
+    })
+
+    const captions = player.locator('.shaka-text-container')
+    const getFontSize = () => captions.evaluate(element => {
+      return Number.parseFloat(getComputedStyle(element).fontSize)
+    })
+    const inlineFontSize = await getFontSize()
+    expect(inlineFontSize).toBe(20)
+
+    await player.evaluate(element => {
+      const rect = element.getBoundingClientRect()
+      window.scrollTo(0, window.scrollY + rect.bottom)
+    })
+    await expect(player).toHaveClass(/scrollMiniPlayer/)
+
+    // The mini player is only a couple of hundred pixels tall, so inline sized captions covered all of it.
+    await expect.poll(getFontSize).toBeLessThan(inlineFontSize * 0.8)
+
+    await page.evaluate(() => window.scrollTo(0, 0))
+    await expect(player).not.toHaveClass(/scrollMiniPlayer/)
+    await expect.poll(getFontSize).toBe(inlineFontSize)
+  })
+
+  test.describe('large captions in the scroll mini player', () => {
+    test.use({
+      seed: {
+        settings: {
+          defaultCaptionSettings: JSON.stringify({ fontScale: 4 })
+        }
+      }
+    })
+
+    test('keeps the captions inside the scroll mini player', async ({ page, innertube }) => {
+      test.skip(!innertube.playback, 'needs real media streams')
+      await openVideo(page)
+
+      const video = await waitForPlaybackOrSkip(test, page)
+      await video.evaluate(element => element.pause())
+
+      const player = page.locator('.ftVideoPlayer')
+      await player.evaluate(element => {
+        if (element.querySelector('.shaka-text-container')) return
+
+        const captions = document.createElement('div')
+        captions.className = 'shaka-text-container'
+        const cue = document.createElement('div')
+        const text = document.createElement('span')
+        text.setAttribute('translate', 'no')
+        text.textContent = 'a caption long enough to wrap over several lines in a small player, '
+          .repeat(3)
+        cue.append(text)
+        captions.append(cue)
+        element.append(captions)
+      })
+
+      await player.evaluate(element => {
+        const rect = element.getBoundingClientRect()
+        window.scrollTo(0, window.scrollY + rect.bottom)
+      })
+      await expect(player).toHaveClass(/scrollMiniPlayer/)
+
+      // The maximum font size used to overflow the mini player in every direction.
+      await expect.poll(() => player.evaluate(element => {
+        const playerRect = element.getBoundingClientRect()
+        const captionRect = element.querySelector('.shaka-text-container').getBoundingClientRect()
+
+        return {
+          top: captionRect.top >= playerRect.top,
+          bottom: captionRect.bottom <= playerRect.bottom,
+          left: captionRect.left >= playerRect.left,
+          right: captionRect.right <= playerRect.right
+        }
+      })).toEqual({ top: true, bottom: true, left: true, right: true })
+    })
+  })
+
   test('keeps the scroll mini player docked across window resizes', async ({ app, page, innertube }) => {
     test.skip(!innertube.playback, 'needs real media streams')
     await setWindowSize(app, page, { width: 1200, height: 850 })
@@ -1531,16 +1621,25 @@ test.describe('watch page', () => {
       })
       expect(windowedFontSizes).toEqual(['30px', '30px'])
 
+      // The player is only a few hundred pixels tall here, so the captions scale down with it.
       await setWindowWidth(app, 400)
-      const narrowFontSizes = ['24px', '24px']
       await expect.poll(async () => captionContainers.evaluateAll(elements => {
         return elements.map(element => getComputedStyle(element).fontSize)
-      })).toEqual(narrowFontSizes)
+      })).not.toEqual(windowedFontSizes)
 
+      const narrowFontSizes = await captionContainers.evaluateAll(elements => {
+        return elements.map(element => Number.parseFloat(getComputedStyle(element).fontSize))
+      })
+      for (const fontSize of narrowFontSizes) {
+        expect(fontSize).toBeGreaterThan(30 * 0.45)
+        expect(fontSize).toBeLessThan(30 * 0.75)
+      }
+
+      // Fullscreen makes the player tall again, so the configured size comes back.
       await setPlayerFullscreen(page, true)
       await expect.poll(async () => captionContainers.evaluateAll(elements => {
         return elements.map(element => getComputedStyle(element).fontSize)
-      })).toEqual(narrowFontSizes)
+      })).toEqual(windowedFontSizes)
     })
   })
 

--- a/src/renderer/components/CaptionSettings/CaptionSettings.css
+++ b/src/renderer/components/CaptionSettings/CaptionSettings.css
@@ -1,7 +1,9 @@
 .captionPreview {
   position: relative;
   box-sizing: border-box;
-  min-block-size: 120px;
+
+  /* grows with the font size, so large captions still have room in the preview */
+  min-block-size: max(120px, 3em);
   margin-block-end: 1rem;
   border-radius: calc(5px * var(--ui-roundness));
   background: linear-gradient(135deg, #576574, #222f3e);

--- a/src/renderer/components/CaptionSettings/CaptionSettings.vue
+++ b/src/renderer/components/CaptionSettings/CaptionSettings.vue
@@ -82,8 +82,8 @@
             :default-value="Math.round(captionSettings.fontScale * 100)"
             setting-key="defaultCaptionSettings"
             :is-changed="isCaptionSettingChanged('fontScale')"
-            :min-value="50"
-            :max-value="200"
+            :min-value="MIN_CAPTION_FONT_SCALE * 100"
+            :max-value="MAX_CAPTION_FONT_SCALE * 100"
             :step="10"
             value-extension="%"
             @input="updateCaptionSetting('fontScale', $event / 100)"
@@ -176,6 +176,8 @@ import {
   CAPTION_EDGE_STYLES,
   DEFAULT_CAPTION_SETTINGS,
   getCaptionCssVariables,
+  MAX_CAPTION_FONT_SCALE,
+  MIN_CAPTION_FONT_SCALE,
   parseCaptionSettings,
 } from '../../helpers/player/caption-settings'
 import store from '../../store/index'

--- a/src/renderer/components/ft-shaka-video-player/ft-shaka-video-player.css
+++ b/src/renderer/components/ft-shaka-video-player/ft-shaka-video-player.css
@@ -2403,7 +2403,17 @@
   justify-content: var(--caption-justify-content) !important;
   padding-top: var(--caption-top-padding);
   padding-inline: var(--caption-edge-gap);
-  font-size: calc(20px * var(--caption-font-scale)) !important;
+
+  /*
+    The player is the only space the captions get. Subtracting the gap accounts for the offset
+    they are anchored at, so that they can't grow out of the top of the player either.
+  */
+  max-block-size: calc(100% - var(--caption-edge-gap));
+  overflow: hidden;
+  font-size: min(
+    calc(20px * var(--caption-font-scale) * var(--caption-player-scale, 1)),
+    var(--caption-max-font-size, 100vb)
+  ) !important;
   text-align: var(--caption-text-align) !important;
   transform: translateY(var(--caption-vertical-transform));
 
@@ -2482,7 +2492,10 @@
   padding-top: var(--caption-top-padding);
   padding-inline: var(--caption-edge-gap);
   color: var(--caption-text-color);
-  font-size: calc(20px * var(--caption-font-scale));
+  font-size: min(
+    calc(20px * var(--caption-font-scale) * var(--caption-player-scale, 1)),
+    var(--caption-max-font-size, 100vb)
+  );
   line-height: 1.4;
   text-align: var(--caption-text-align);
   text-shadow: var(--caption-text-shadow);
@@ -2798,12 +2811,10 @@
 }
 
 @media only screen and (width <=400px) {
-  :deep(.shaka-text-container),
-  :deep(.shaka-speech-to-text-container) {
-    /* make subtitles take up slightly less space when a mobile phone is in portrait orientation */
-    font-size: calc(16px * var(--caption-font-scale)) !important;
-  }
-
+  /*
+    Captions don't need a rule here: --caption-player-scale already shrinks them
+    for the small player that a narrow window results in.
+  */
   .sponsorBlockSubmissionWrapper {
     right: 8px;
     left: 8px;
@@ -2881,7 +2892,9 @@
 .ftVideoPlayer.scrollMiniPlayer {
   box-shadow: 0 8px 28px rgb(0 0 0 / 45%);
   border-radius: calc(10px * var(--ui-roundness));
-  overflow: visible;
+
+  /* The mini player floats over the page, so nothing of it may be painted outside its frame. */
+  overflow: clip;
   touch-action: none;
   isolation: isolate;
 }

--- a/src/renderer/components/ft-shaka-video-player/ft-shaka-video-player.js
+++ b/src/renderer/components/ft-shaka-video-player/ft-shaka-video-player.js
@@ -71,6 +71,7 @@ import { voteOnSponsorBlockSegment } from '../../helpers/sponsorblock'
 import {
   DEFAULT_CAPTION_SETTINGS,
   getCaptionCssVariables,
+  getCaptionPlayerVariables,
   parseCaptionSettings,
 } from '../../helpers/player/caption-settings'
 import { useAmbientMode } from './opentubex/useAmbientMode'
@@ -4427,6 +4428,12 @@ export default defineComponent({
 
     const videoElementWidth = ref(0)
     const videoElementHeight = ref(0)
+    /** Height of the video element in CSS pixels, used to scale the captions with the player. */
+    const videoElementLayoutHeight = ref(0)
+
+    const captionPlayerVariables = computed(() => {
+      return getCaptionPlayerVariables(videoElementLayoutHeight.value)
+    })
 
     function updateAnnotationVideoAspectRatio() {
       const video_ = video.value
@@ -4509,6 +4516,7 @@ export default defineComponent({
 
         videoElementWidth.value = video_.clientWidth * devicePixelRatio
         videoElementHeight.value = video_.clientHeight * devicePixelRatio
+        videoElementLayoutHeight.value = video_.clientHeight
         updateAnnotationVideoAspectRatio()
         updateScrollMiniVideoAspectRatio()
       }
@@ -8450,6 +8458,7 @@ export default defineComponent({
       ambientLayoutCanvas,
       ambientModeVisible,
       captionCssVariables,
+      captionPlayerVariables,
       captionAppearanceSampleBottom,
       showCaptionAppearanceSample,
       isActiveTab,

--- a/src/renderer/components/ft-shaka-video-player/ft-shaka-video-player.vue
+++ b/src/renderer/components/ft-shaka-video-player/ft-shaka-video-player.vue
@@ -60,6 +60,7 @@
       }"
       :style="[
         captionCssVariables,
+        captionPlayerVariables,
         scrollMiniPlayerActive ? scrollMiniPlayerStyle : undefined,
         shortsPlayer ? { '--shorts-aspect-ratio': shortsAspectRatio } : undefined
       ]"

--- a/src/renderer/components/ft-shaka-video-player/player-components/CaptionSelection.js
+++ b/src/renderer/components/ft-shaka-video-player/player-components/CaptionSelection.js
@@ -5,6 +5,8 @@ import {
   CAPTION_ANCHORS,
   CAPTION_EDGE_STYLES,
   DEFAULT_CAPTION_SETTINGS,
+  MAX_CAPTION_FONT_SCALE,
+  MIN_CAPTION_FONT_SCALE,
 } from '../../../helpers/player/caption-settings'
 
 const CAPTION_COLOR_PALETTE = Object.freeze([
@@ -64,7 +66,7 @@ export class CaptionSelection extends shaka.ui.TextSelection {
     this.textColor_ = this.createColorControl_('textColor')
     this.backgroundColor_ = this.createColorControl_('backgroundColor')
     this.backgroundOpacity_ = this.createRangeControl_('backgroundOpacity', 0, 1, 0.05)
-    this.fontScale_ = this.createRangeControl_('fontScale', 0.5, 2, 0.1)
+    this.fontScale_ = this.createRangeControl_('fontScale', MIN_CAPTION_FONT_SCALE, MAX_CAPTION_FONT_SCALE, 0.1)
     this.anchor_ = this.createAnchorControl_()
     this.verticalPosition_ = this.createRangeControl_('verticalPosition', 0, 0.5, 0.01)
     this.edgeStyle_ = this.createEdgeStyleControl_()

--- a/src/renderer/helpers/player/caption-settings.js
+++ b/src/renderer/helpers/player/caption-settings.js
@@ -13,6 +13,22 @@ export const CAPTION_ANCHORS = Object.freeze([
   'bottom-right',
 ])
 
+export const MIN_CAPTION_FONT_SCALE = 0.5
+export const MAX_CAPTION_FONT_SCALE = 4
+
+/**
+ * Player height from which on captions get their full configured size (a 16:9 player at 711px wide).
+ * Deliberately smaller than a regular watch page player, so only players that are actually small
+ * scale their captions down.
+ */
+const REFERENCE_PLAYER_HEIGHT = 400
+
+/** Keeps captions legible in tiny players, where a purely proportional size would be unreadable. */
+const MIN_CAPTION_PLAYER_SCALE = 0.45
+
+/** Share of the player height a single line of captions may take up at most. */
+const MAX_CAPTION_FONT_SIZE_RATIO = 0.1
+
 export const DEFAULT_CAPTION_SETTINGS = Object.freeze({
   textColor: '#ffffff',
   backgroundColor: '#000000',
@@ -122,8 +138,8 @@ export function parseCaptionSettings(value) {
     fontScale: normalizeNumber(
       settings.fontScale ?? settings.fontPercent,
       DEFAULT_CAPTION_SETTINGS.fontScale,
-      0.5,
-      2
+      MIN_CAPTION_FONT_SCALE,
+      MAX_CAPTION_FONT_SCALE
     ),
     verticalPosition: normalizeNumber(
       settings.verticalPosition,
@@ -159,6 +175,39 @@ function getContrastingEdgeColor(color) {
   const blue = Number.parseInt(color.slice(5, 7), 16)
   const luminance = red * 0.299 + green * 0.587 + blue * 0.114
   return luminance > 150 ? '#000000' : '#ffffff'
+}
+
+/**
+ * Captions are sized in pixels, so without this they stay just as big when the player shrinks
+ * (e.g. the scroll mini player), where they would cover the entire video.
+ * Only ever scales down, so that regular and fullscreen players keep their configured size.
+ * @param {number} playerHeight height of the player in CSS pixels
+ * @returns {number}
+ */
+export function getCaptionPlayerScale(playerHeight) {
+  if (!Number.isFinite(playerHeight) || playerHeight <= 0) {
+    return 1
+  }
+
+  return Math.min(1, Math.max(MIN_CAPTION_PLAYER_SCALE, playerHeight / REFERENCE_PLAYER_HEIGHT))
+}
+
+/**
+ * A large font size can outgrow a small player even after it was scaled down, so cap it at a
+ * share of the player height that always leaves room for a couple of lines of captions.
+ * @param {number} playerHeight height of the player in CSS pixels
+ * @returns {Record<string, string>}
+ */
+export function getCaptionPlayerVariables(playerHeight) {
+  const variables = {
+    '--caption-player-scale': getCaptionPlayerScale(playerHeight).toString(),
+  }
+
+  if (Number.isFinite(playerHeight) && playerHeight > 0) {
+    variables['--caption-max-font-size'] = `${Math.round(playerHeight * MAX_CAPTION_FONT_SIZE_RATIO)}px`
+  }
+
+  return variables
 }
 
 /**

--- a/tests/unit/caption-settings.test.mjs
+++ b/tests/unit/caption-settings.test.mjs
@@ -1,0 +1,57 @@
+import assert from 'node:assert/strict'
+import test from 'node:test'
+
+import {
+  getCaptionPlayerScale,
+  getCaptionPlayerVariables,
+  MAX_CAPTION_FONT_SCALE,
+  MIN_CAPTION_FONT_SCALE,
+  parseCaptionSettings,
+} from '../../src/renderer/helpers/player/caption-settings.js'
+
+test('keeps captions at their configured size in regular and fullscreen players', () => {
+  // regular watch page player
+  assert.equal(getCaptionPlayerScale(562), 1)
+
+  // fullscreen must not blow the captions up
+  assert.equal(getCaptionPlayerScale(1080), 1)
+})
+
+test('shrinks captions in small players', () => {
+  // half the reference height means half sized captions
+  assert.equal(getCaptionPlayerScale(200), 0.5)
+
+  // the scroll mini player (360x202 by default)
+  assert.equal(getCaptionPlayerScale(202), 0.505)
+
+  // the smallest possible mini player is below the floor, which keeps captions legible
+  assert.equal(getCaptionPlayerScale(135), 0.45)
+})
+
+test('falls back to the configured size when the player has not been measured yet', () => {
+  assert.equal(getCaptionPlayerScale(0), 1)
+  assert.equal(getCaptionPlayerScale(Number.NaN), 1)
+  assert.equal(getCaptionPlayerScale(undefined), 1)
+})
+
+test('clamps the font size to the range the settings offer', () => {
+  assert.equal(parseCaptionSettings({ fontScale: 10 }).fontScale, MAX_CAPTION_FONT_SCALE)
+  assert.equal(parseCaptionSettings({ fontScale: 0 }).fontScale, MIN_CAPTION_FONT_SCALE)
+
+  // the maximum was raised from 200%, previously saved settings are unaffected
+  assert.equal(parseCaptionSettings({ fontScale: 2 }).fontScale, 2)
+  assert.equal(parseCaptionSettings({ fontScale: 4 }).fontScale, 4)
+})
+
+test('caps the font size at a share of the player height', () => {
+  // a regular player has room for the configured size, even at the maximum
+  assert.equal(getCaptionPlayerVariables(562)['--caption-max-font-size'], '56px')
+
+  // 400% would be 40px in a mini player that is only 202px tall
+  assert.equal(getCaptionPlayerVariables(202)['--caption-max-font-size'], '20px')
+})
+
+test('leaves the font size uncapped until the player has been measured', () => {
+  assert.equal(getCaptionPlayerVariables(0)['--caption-max-font-size'], undefined)
+  assert.deepEqual(getCaptionPlayerVariables(0), { '--caption-player-scale': '1' })
+})


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Make sure to follow the contributing guidelines. -->
<!-- Important note, we may remove your pull request if you do not use this provided PR template correctly. -->
<!-- Agent instructions: Preserve every heading, comment, and marker in this template. Never remove or rewrite the release-note-category:start/end, release-note:start/end, or release-note-image:start/end marker pairs. Never remove or rewrite the Release note images section; leave its contents for a human. -->

## Pull Request Type
<!-- Please select what type of pull request this is: [x] -->
- [x] Bugfix
- [ ] Feature Implementation
- [ ] Documentation
- [ ] Other

## Related issue
<!-- Please link the issue your pull request is referring to. -->
<!-- If this pull request fully resolves the relevant issue, put "closes" before the issue number. -->
<!-- Example: "closes #123456". -->
closes #527

## Description
<!-- Please write a clear and concise description of what the pull request does. -->
Captions were sized in absolute pixels (`20px * font size setting`), independent of how big the player actually is. In the scroll mini player they therefore kept their full size, covering the whole video and even growing out of it.

- Captions now scale down with the player. A player that is at least 400px tall (a 16:9 player at ~711px wide) keeps the configured size, so regular and fullscreen players look exactly as before, and only genuinely small players shrink.
- The font size is additionally capped at 10% of the player height. Scaling alone is not enough when a very large font meets a very small player.
- The caption box can no longer grow past the top of the player, and the scroll mini player clips its content again. It explicitly set `overflow: visible`, which is why captions painted over the page, while a regular player would have clipped them.
- The maximum configurable font size goes from 200% to 400%, so captions can be made large enough for visually impaired users. The settings preview grows along with it.
- The `@media (width <= 400px)` caption override is gone. It used the window size as a proxy for the player size, which the player-relative scaling now does properly.

Captions in native picture-in-picture (point 2 of the issue) are not fixable for now: Chromium does not render text tracks in the PiP window at all ([crbug 40581723](https://issues.chromium.org/issues/40581723)) and the only alternative, Document Picture-in-Picture, is not supported by Electron ([electron#39633](https://github.com/electron/electron/issues/39633)). The player already carries a TODO for enabling it once it lands.

## Release note category
<!-- Select exactly one category. Every pull request must select one. -->
<!-- release-note-category:start -->
- [ ] Not noteworthy
- [ ] Highlights
- [ ] More improvements
- [x] Fixed bugs
<!-- release-note-category:end -->

## Release note
<!-- Required unless "Not noteworthy" is selected. -->
<!-- Write one concise, user-facing entry without a leading bullet. -->
<!-- release-note:start -->
Captions now scale with the player instead of covering the whole scroll mini player, and their maximum size can be set up to 400%
<!-- release-note:end -->

## Release note images
<!-- Human-only: Agents must preserve this entire section and leave it empty. -->
<!-- Optional. Paste one or more Markdown images or HTML image tags here. -->
<!-- The release notes will use an HTML image tag and limit images taller than 300 pixels. -->
<!-- release-note-image:start -->

<!-- release-note-image:end -->

## Testing
<!-- How can reviewers verify that the PR produces correct results? -->
<!-- Please provide instructions so that others can ensure that your pull request would produce correct results. For examples see, https://github.com/FreeTubeApp/FreeTube/pull/5743, https://github.com/FreeTubeApp/FreeTube/pull/7349, https://github.com/FreeTubeApp/FreeTube/pull/5125, https://github.com/FreeTubeApp/FreeTube/pull/7338 -->
<!-- Agent instructions: Only write human-facing steps that explain how to verify the change while running this branch in dev mode. Include expected results and, when applicable, helpful console snippets for interactive verification. Do not include automated checks, commands, results, pass counts, or CI status. -->
1. Open a video with captions and turn them on.
2. Scroll down until the scroll mini player appears. The captions should shrink along with it and stay inside its frame, instead of staying at their inline size and spilling over the page.
3. Scroll back up. The captions should return to their previous size.
4. Set the caption font size to its new maximum of 400% (Settings > Player > Captions, or the caption appearance menu in the player) and repeat steps 2 and 3. Even at that size the captions must stay within the mini player.
5. Resize the mini player by dragging one of its corners. The captions should keep scaling with it.
6. Go fullscreen and check that the captions are the same size as before this change, i.e. they do not suddenly grow.
7. Check a Shorts video and a narrow window as well, since both used to be handled by a separate rule.

## Additional context
<!-- Add any other context about the pull request here. -->
Behaviour at the default settings is unchanged: a 562px tall player still renders captions at 20px, and its cap sits at 56px.
