### PR TITLE
fix(history): exclude upcoming premieres from watched

### DIFF
--- a/e2e/tests/offline/history.spec.mjs
+++ b/e2e/tests/offline/history.spec.mjs
@@ -3,7 +3,7 @@ import path from 'node:path'
 
 import { test, expect, sel, goTo } from '../../helpers/app.mjs'
 
-function historyEntry(videoId, title, timeWatched, isWatched = false, isLive = false) {
+function historyEntry(videoId, title, timeWatched, isWatched = false, extra = {}) {
   return {
     _id: videoId,
     videoId,
@@ -17,8 +17,9 @@ function historyEntry(videoId, title, timeWatched, isWatched = false, isLive = f
     watchProgress: 10,
     isWatched,
     timeWatched,
-    isLive,
-    type: 'video'
+    isLive: false,
+    type: 'video',
+    ...extra
   }
 }
 
@@ -27,7 +28,8 @@ test.use({
     history: [
       historyEntry('aaaaaaaaaaa', 'First test video', Date.now() - 1000, true),
       historyEntry('bbbbbbbbbbb', 'Second test video', Date.now() - 2000),
-      historyEntry('ccccccccccc', 'Active live stream', Date.now() - 3000, false, true)
+      historyEntry('ccccccccccc', 'Active live stream', Date.now() - 3000, false, { isLive: true }),
+      historyEntry('eeeeeeeeeee', 'Upcoming premiere', Date.now() - 4000, false, { isUpcoming: true })
     ]
   }
 })
@@ -110,6 +112,18 @@ test.describe('watch history', () => {
     await expect(page.getByRole('option', { name: 'Remove From History' })).toBeVisible()
   })
 
+  test('does not offer watched actions for an upcoming premiere history entry', async ({ page }) => {
+    await goTo(page, 'history')
+
+    const upcomingPremiere = page.locator('.ft-list-video').filter({ hasText: 'Upcoming premiere' })
+    await upcomingPremiere.hover()
+    await upcomingPremiere.locator('.optionsButton').click()
+
+    await expect(page.getByRole('option', { name: 'Mark As Watched' })).toHaveCount(0)
+    await expect(page.getByRole('option', { name: 'Unmark As Watched' })).toHaveCount(0)
+    await expect(page.getByRole('option', { name: 'Remove From History' })).toBeVisible()
+  })
+
   test('marks every history entry as watched', async ({ app, page }) => {
     await goTo(page, 'history')
 
@@ -131,8 +145,11 @@ test.describe('watch history', () => {
       const latestRecords = Object.values(Object.fromEntries(
         records.filter(record => record.videoId).map(record => [record.videoId, record])
       ))
-      return latestRecords.every(record => record.isLive === true || record.isWatched === true) &&
-        latestRecords.find(record => record.videoId === 'ccccccccccc')?.isWatched === false
+      return latestRecords.every(record => {
+        return record.isLive === true || record.isUpcoming === true || record.isWatched === true
+      }) &&
+        latestRecords.find(record => record.videoId === 'ccccccccccc')?.isWatched === false &&
+        latestRecords.find(record => record.videoId === 'eeeeeeeeeee')?.isWatched === false
     }).toBe(true)
   })
 })

--- a/e2e/tests/offline/history.spec.mjs
+++ b/e2e/tests/offline/history.spec.mjs
@@ -3,6 +3,9 @@ import path from 'node:path'
 
 import { test, expect, sel, goTo } from '../../helpers/app.mjs'
 
+const now = Date.now()
+const DAY = 86_400_000
+
 function historyEntry(videoId, title, timeWatched, isWatched = false, extra = {}) {
   return {
     _id: videoId,
@@ -26,10 +29,17 @@ function historyEntry(videoId, title, timeWatched, isWatched = false, extra = {}
 test.use({
   seed: {
     history: [
-      historyEntry('aaaaaaaaaaa', 'First test video', Date.now() - 1000, true),
-      historyEntry('bbbbbbbbbbb', 'Second test video', Date.now() - 2000),
-      historyEntry('ccccccccccc', 'Active live stream', Date.now() - 3000, false, { isLive: true }),
-      historyEntry('eeeeeeeeeee', 'Upcoming premiere', Date.now() - 4000, false, { isUpcoming: true })
+      historyEntry('aaaaaaaaaaa', 'First test video', now - 1000, true),
+      historyEntry('bbbbbbbbbbb', 'Second test video', now - 2000),
+      historyEntry('ccccccccccc', 'Active live stream', now - 3000, false, { isLive: true }),
+      historyEntry('eeeeeeeeeee', 'Upcoming premiere', now - 4000, false, {
+        isUpcoming: true,
+        premiereTimestamp: Math.floor((now + 30 * DAY) / 1000)
+      }),
+      historyEntry('fffffffffff', 'Started premiere with stale flag', now - 5000, false, {
+        isUpcoming: true,
+        premiereTimestamp: Math.floor((now - DAY) / 1000)
+      })
     ]
   }
 })
@@ -124,6 +134,23 @@ test.describe('watch history', () => {
     await expect(page.getByRole('option', { name: 'Remove From History' })).toBeVisible()
   })
 
+  test('enables watched actions when a mounted premiere reaches its scheduled time', async ({ page }) => {
+    await goTo(page, 'trending')
+    await page.clock.install({ time: now })
+    await goTo(page, 'history')
+
+    const upcomingPremiere = page.locator('.ft-list-video').filter({ hasText: 'Upcoming premiere' })
+    await upcomingPremiere.hover()
+    await upcomingPremiere.locator('.optionsButton').click()
+    await expect(page.getByRole('option', { name: 'Mark As Watched' })).toHaveCount(0)
+
+    // Split the jump so timers beyond Chromium's maximum timeout are rescheduled.
+    await page.clock.fastForward(24 * DAY)
+    await page.clock.fastForward(6 * DAY + 1000)
+
+    await expect(page.getByRole('option', { name: 'Mark As Watched' })).toBeVisible()
+  })
+
   test('marks every history entry as watched', async ({ app, page }) => {
     await goTo(page, 'history')
 
@@ -149,7 +176,8 @@ test.describe('watch history', () => {
         return record.isLive === true || record.isUpcoming === true || record.isWatched === true
       }) &&
         latestRecords.find(record => record.videoId === 'ccccccccccc')?.isWatched === false &&
-        latestRecords.find(record => record.videoId === 'eeeeeeeeeee')?.isWatched === false
+        latestRecords.find(record => record.videoId === 'eeeeeeeeeee')?.isWatched === false &&
+        latestRecords.find(record => record.videoId === 'fffffffffff')?.isWatched === true
     }).toBe(true)
   })
 })

--- a/e2e/tests/offline/subscriptions-feed.spec.mjs
+++ b/e2e/tests/offline/subscriptions-feed.spec.mjs
@@ -24,51 +24,51 @@ function feedVideo(videoId, title, authorId, published, extra = {}) {
 // Auto-fetch is disabled so the feed must come entirely from the seeded
 // cache — this is exactly the offline startup path the app uses before
 // any refresh (53caa4084, 7ad96d185).
-test.use({
-  seed: {
-    settings: {
-      fetchSubscriptionsAutomatically: false,
-      hideUpcomingPremieres: true,
-      thumbnailSize: 180
+const seed = {
+  settings: {
+    fetchSubscriptionsAutomatically: false,
+    hideUpcomingPremieres: true,
+    thumbnailSize: 180
+  },
+  profiles: [
+    {
+      _id: 'allChannels',
+      name: 'All Channels',
+      bgColor: '#000000',
+      textColor: '#FFFFFF',
+      subscriptions: [
+        { id: CHANNEL_A, name: 'Channel A', thumbnail: '' },
+        { id: CHANNEL_B, name: 'Channel B', thumbnail: '' }
+      ]
+    }
+  ],
+  subscriptionCache: [
+    {
+      _id: CHANNEL_A,
+      videos: [
+        feedVideo('aaaaaaaaaa1', 'Video A newer', CHANNEL_A, now - 1 * HOUR),
+        feedVideo('aaaaaaaaaa4', 'Running premiere video', CHANNEL_A, now - 2 * HOUR, {
+          isPremiere: true,
+          liveNow: true
+        }),
+        feedVideo('aaaaaaaaaa2', 'Video A older', CHANNEL_A, now - 3 * HOUR),
+        feedVideo('aaaaaaaaaa3', 'Upcoming premiere video', CHANNEL_A, now + 30 * 24 * HOUR, {
+          premiereDate: new Date(now + 30 * 24 * HOUR).toISOString()
+        })
+      ],
+      videosTimestamp: new Date(now - 2 * HOUR).toISOString()
     },
-    profiles: [
-      {
-        _id: 'allChannels',
-        name: 'All Channels',
-        bgColor: '#000000',
-        textColor: '#FFFFFF',
-        subscriptions: [
-          { id: CHANNEL_A, name: 'Channel A', thumbnail: '' },
-          { id: CHANNEL_B, name: 'Channel B', thumbnail: '' }
-        ]
-      }
-    ],
-    subscriptionCache: [
-      {
-        _id: CHANNEL_A,
-        videos: [
-          feedVideo('aaaaaaaaaa1', 'Video A newer', CHANNEL_A, now - 1 * HOUR),
-          feedVideo('aaaaaaaaaa4', 'Running premiere video', CHANNEL_A, now - 2 * HOUR, {
-            isPremiere: true,
-            liveNow: true
-          }),
-          feedVideo('aaaaaaaaaa2', 'Video A older', CHANNEL_A, now - 3 * HOUR),
-          feedVideo('aaaaaaaaaa3', 'Upcoming premiere video', CHANNEL_A, now + 30 * 24 * HOUR, {
-            premiereDate: new Date(now + 30 * 24 * HOUR).toISOString()
-          })
-        ],
-        videosTimestamp: new Date(now - 2 * HOUR).toISOString()
-      },
-      {
-        _id: CHANNEL_B,
-        videos: [
-          feedVideo('bbbbbbbbbb1', 'Video B newest', CHANNEL_B, now - 0.5 * HOUR)
-        ],
-        videosTimestamp: new Date(now - 1 * HOUR).toISOString()
-      }
-    ]
-  }
-})
+    {
+      _id: CHANNEL_B,
+      videos: [
+        feedVideo('bbbbbbbbbb1', 'Video B newest', CHANNEL_B, now - 0.5 * HOUR)
+      ],
+      videosTimestamp: new Date(now - 1 * HOUR).toISOString()
+    }
+  ]
+}
+
+test.use({ seed })
 
 test.describe('subscriptions feed from cache', () => {
   test('does not animate cards while calculating the initial grid size', async ({ page }) => {
@@ -186,5 +186,27 @@ test.describe('subscriptions feed from cache', () => {
     const lastRefresh = page.locator('.lastRefreshTimestamp').first()
     await expect(lastRefresh).toBeVisible()
     await expect(lastRefresh).toContainText('2 hours ago')
+  })
+})
+
+test.describe('subscriptions feed with upcoming premieres shown', () => {
+  test.use({
+    seed: {
+      ...seed,
+      settings: { ...seed.settings, hideUpcomingPremieres: false }
+    }
+  })
+
+  test('does not offer to mark an upcoming premiere as watched', async ({ page }) => {
+    await goTo(page, 'subscriptions')
+
+    const upcomingPremiere = page.locator('.ft-list-video').filter({ hasText: 'Upcoming premiere video' })
+    await expect(upcomingPremiere).toBeVisible()
+    await upcomingPremiere.hover()
+    await upcomingPremiere.locator('.optionsButton').click()
+
+    await expect(page.getByRole('option', { name: 'Mark As Watched' })).toHaveCount(0)
+    await expect(page.getByRole('option', { name: 'Unmark As Watched' })).toHaveCount(0)
+    await expect(page.getByRole('option', { name: 'Add to Queue' })).toBeVisible()
   })
 })

--- a/src/history.js
+++ b/src/history.js
@@ -10,7 +10,20 @@ export { DEFAULT_WATCHED_PERCENTAGE_THRESHOLD, WATCHED_MAX_REMAINING_SECONDS }
  * @returns {boolean}
  */
 export function canMarkHistoryEntryAsWatched(historyEntry) {
-  return historyEntry?.isLive !== true && historyEntry?.isUpcoming !== true
+  if (historyEntry?.isLive === true) {
+    return false
+  }
+
+  if (historyEntry?.isUpcoming !== true) {
+    return true
+  }
+
+  if (historyEntry.premiereTimestamp == null) {
+    return false
+  }
+
+  const premiereTimestamp = Number(historyEntry.premiereTimestamp) * 1000
+  return Number.isFinite(premiereTimestamp) && premiereTimestamp <= Date.now()
 }
 
 /**

--- a/src/history.js
+++ b/src/history.js
@@ -10,7 +10,7 @@ export { DEFAULT_WATCHED_PERCENTAGE_THRESHOLD, WATCHED_MAX_REMAINING_SECONDS }
  * @returns {boolean}
  */
 export function canMarkHistoryEntryAsWatched(historyEntry) {
-  return historyEntry?.isLive !== true
+  return historyEntry?.isLive !== true && historyEntry?.isUpcoming !== true
 }
 
 /**

--- a/src/renderer/components/FtListVideo/FtListVideo.vue
+++ b/src/renderer/components/FtListVideo/FtListVideo.vue
@@ -335,7 +335,7 @@
 
 <script setup>
 import { FontAwesomeIcon } from '@fortawesome/vue-fontawesome'
-import { computed, ref, watch } from 'vue'
+import { computed, onBeforeUnmount, ref, watch } from 'vue'
 import { useI18n } from 'vue-i18n'
 import { useRoute } from 'vue-router'
 
@@ -502,6 +502,11 @@ const historyEntryExists = computed(() => historyEntry.value !== undefined)
 
 const isWatched = computed(() => isHistoryEntryWatched(historyEntry.value))
 
+const premiereTimestamp = computed(() => getUpcomingPremiereTimestamp(props.data))
+const premiereNow = ref(Date.now())
+const MAX_TIMEOUT_DELAY = 2_147_483_647
+let premiereStartTimer = null
+
 const canMarkAsWatched = computed(() => {
   if (isLive.value) {
     return false
@@ -509,13 +514,35 @@ const canMarkAsWatched = computed(() => {
 
   // A scheduled premiere can only be watched once its start time has passed,
   // even if a cached entry still carries a stale upcoming flag.
-  const premiereTimestamp = getUpcomingPremiereTimestamp(props.data)
-  if (premiereTimestamp != null) {
-    return premiereTimestamp <= Date.now()
+  if (premiereTimestamp.value != null) {
+    return premiereTimestamp.value <= premiereNow.value
   }
 
   return !isUpcoming.value
 })
+
+function clearPremiereStartTimer() {
+  if (premiereStartTimer != null) {
+    clearTimeout(premiereStartTimer)
+    premiereStartTimer = null
+  }
+}
+
+function schedulePremiereStartInvalidation() {
+  clearPremiereStartTimer()
+
+  const timestamp = premiereTimestamp.value
+  const now = Date.now()
+  premiereNow.value = now
+  if (timestamp == null || timestamp <= now) {
+    return
+  }
+
+  premiereStartTimer = setTimeout(() => {
+    premiereStartTimer = null
+    schedulePremiereStartInvalidation()
+  }, Math.min(timestamp - now + 1, MAX_TIMEOUT_DELAY))
+}
 
 const watchProgress = computed(() => {
   if (!historyEntryExists.value || !watchedProgressSavingEnabled.value) {
@@ -1630,6 +1657,9 @@ if ((showDeArrowTitle.value || showDeArrowThumbnail.value) && !deArrowCache.valu
 if (showDeArrowThumbnail.value && deArrowCache.value && deArrowCache.value.thumbnail == null) {
   debounceGetDeArrowThumbnail()
 }
+
+watch(premiereTimestamp, schedulePremiereStartInvalidation, { immediate: true })
+onBeforeUnmount(clearPremiereStartTimer)
 
 watch([useSponsorBlock, id], ([enabled, videoId]) => {
   sponsorBlockFullVideoCategory.value = null

--- a/src/renderer/components/FtListVideo/FtListVideo.vue
+++ b/src/renderer/components/FtListVideo/FtListVideo.vue
@@ -367,6 +367,7 @@ import {
 } from '../../helpers/utils.js'
 import { getLocalVideoInfo, parseLocalVideoCollaborators } from '../../helpers/api/local.js'
 import { isHistoryEntryWatched } from '../../helpers/history.js'
+import { getUpcomingPremiereTimestamp } from '../../helpers/subscription-entries.js'
 import { deArrowData, deArrowThumbnail, getSponsorBlockVideoLabel } from '../../helpers/sponsorblock.js'
 import { requestWatchPageViewTransition } from '../../helpers/viewTransitions.js'
 import { setCollaboratorsLoading } from './collaboratorsLoading.js'
@@ -501,7 +502,20 @@ const historyEntryExists = computed(() => historyEntry.value !== undefined)
 
 const isWatched = computed(() => isHistoryEntryWatched(historyEntry.value))
 
-const canMarkAsWatched = computed(() => !isLive.value)
+const canMarkAsWatched = computed(() => {
+  if (isLive.value) {
+    return false
+  }
+
+  // A scheduled premiere can only be watched once its start time has passed,
+  // even if a cached entry still carries a stale upcoming flag.
+  const premiereTimestamp = getUpcomingPremiereTimestamp(props.data)
+  if (premiereTimestamp != null) {
+    return premiereTimestamp <= Date.now()
+  }
+
+  return !isUpcoming.value
+})
 
 const watchProgress = computed(() => {
   if (!historyEntryExists.value || !watchedProgressSavingEnabled.value) {
@@ -1447,6 +1461,7 @@ function markAsWatched() {
     isWatched: true,
     timeWatched: historyEntry.value?.timeWatched ?? Date.now(),
     isLive: false,
+    isUpcoming: false,
     type: 'video'
   }
 

--- a/src/renderer/views/History/History.vue
+++ b/src/renderer/views/History/History.vue
@@ -189,6 +189,7 @@ import FtToggleSwitch from '../../components/FtToggleSwitch/FtToggleSwitch.vue'
 
 import store from '../../store'
 
+import { canMarkHistoryEntryAsWatched } from '../../helpers/history'
 import { ctrlFHandler, debounce, getIconForSortPreference, showToast } from '../../helpers/utils'
 import { useTabContext } from '../../tabs/TabContext'
 
@@ -284,7 +285,7 @@ const historyCacheSorted = computed(() => {
 })
 
 const hasUnwatchedHistory = computed(() => {
-  return historyCacheSorted.value.some(record => record.isWatched !== true && record.isLive !== true)
+  return historyCacheSorted.value.some(record => record.isWatched !== true && canMarkHistoryEntryAsWatched(record))
 })
 
 async function markAllAsWatched() {

--- a/src/renderer/views/Watch/Watch.js
+++ b/src/renderer/views/Watch/Watch.js
@@ -2758,6 +2758,7 @@ export default defineComponent({
         isWatched,
         timeWatched: now,
         isLive: this.isLive,
+        isUpcoming: this.isUpcoming,
         type: 'video',
       }
 

--- a/tests/unit/history.test.mjs
+++ b/tests/unit/history.test.mjs
@@ -47,9 +47,33 @@ test('active live content cannot be marked as watched', () => {
   }), true)
 })
 
-test('upcoming premieres cannot be marked as watched', () => {
+test('upcoming premieres become markable after their scheduled time', () => {
+  const now = Math.floor(Date.now() / 1000)
+
   assert.equal(canMarkHistoryEntryAsWatched({ isUpcoming: true }), false)
-  assert.equal(isHistoryEntryWatched({ isUpcoming: true, isWatched: true }), false)
+  assert.equal(canMarkHistoryEntryAsWatched({
+    isUpcoming: true,
+    premiereTimestamp: now + 60,
+  }), false)
+  assert.equal(isHistoryEntryWatched({
+    isUpcoming: true,
+    premiereTimestamp: now + 60,
+    isWatched: true,
+  }), false)
+  assert.equal(canMarkHistoryEntryAsWatched({
+    isUpcoming: true,
+    premiereTimestamp: now - 60,
+  }), true)
+  assert.equal(isHistoryEntryWatched({
+    isUpcoming: true,
+    premiereTimestamp: now - 60,
+    isWatched: true,
+  }), true)
+  assert.equal(canMarkHistoryEntryAsWatched({
+    isLive: true,
+    isUpcoming: true,
+    premiereTimestamp: now - 60,
+  }), false)
   assert.equal(canMarkHistoryEntryAsWatched({ isUpcoming: false }), true)
   assert.equal(isHistoryEntryWatched({ isUpcoming: false, isWatched: true }), true)
 })

--- a/tests/unit/history.test.mjs
+++ b/tests/unit/history.test.mjs
@@ -46,3 +46,10 @@ test('active live content cannot be marked as watched', () => {
     lengthSeconds: 10 * 60,
   }), true)
 })
+
+test('upcoming premieres cannot be marked as watched', () => {
+  assert.equal(canMarkHistoryEntryAsWatched({ isUpcoming: true }), false)
+  assert.equal(isHistoryEntryWatched({ isUpcoming: true, isWatched: true }), false)
+  assert.equal(canMarkHistoryEntryAsWatched({ isUpcoming: false }), true)
+  assert.equal(isHistoryEntryWatched({ isUpcoming: false, isWatched: true }), true)
+})


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Make sure to follow the contributing guidelines. -->
<!-- Important note, we may remove your pull request if you do not use this provided PR template correctly. -->
<!-- Agent instructions: Preserve every heading, comment, and marker in this template. Never remove or rewrite the release-note-category:start/end, release-note:start/end, or release-note-image:start/end marker pairs. Never remove or rewrite the Release note images section; leave its contents for a human. -->

## Pull Request Type
<!-- Please select what type of pull request this is: [x] -->
- [x] Bugfix
- [ ] Feature Implementation
- [ ] Documentation
- [ ] Other

## Related issue
<!-- Please link the issue your pull request is referring to. -->
<!-- If this pull request fully resolves the relevant issue, put "closes" before the issue number. -->
<!-- Example: "closes #123456". -->
Follow-up to #327, see #222

## Description
<!-- Please write a clear and concise description of what the pull request does. -->
Upcoming premieres could still be marked as watched even though they cannot be watched until they air — the same situation as active live content, which #327 already excluded.

This mirrors that handling for premieres:
- `canMarkHistoryEntryAsWatched` also rejects entries flagged as upcoming, so they are skipped by "Mark All As Watched" and never report as watched.
- The watched actions (thumbnail action and dropdown entry) are hidden for upcoming premieres, and the external player no longer auto-marks them.
- History entries persist `isUpcoming`, which is cleared again once the premiere has started, so a premiere behaves normally after it airs.
- The list check uses the premiere timestamp when one is available, so cached feed entries that only carry a `premiereDate` are covered too, and a premiere whose start time has passed becomes markable again even with a stale flag.

## Release note category
<!-- Select exactly one category. Every pull request must select one. -->
<!-- release-note-category:start -->
- [ ] Not noteworthy
- [ ] Highlights
- [ ] More improvements
- [x] Fixed bugs
<!-- release-note-category:end -->

## Release note
<!-- Required unless "Not noteworthy" is selected. -->
<!-- Write one concise, user-facing entry without a leading bullet. -->
<!-- release-note:start -->
Upcoming premieres can no longer be marked as watched until they have aired
<!-- release-note:end -->

## Release note images
<!-- Human-only: Agents must preserve this entire section and leave it empty. -->
<!-- Optional. Paste one or more Markdown images or HTML image tags here. -->
<!-- The release notes will use an HTML image tag and limit images taller than 300 pixels. -->
<!-- release-note-image:start -->

<!-- release-note-image:end -->

## Testing
<!-- How can reviewers verify that the PR produces correct results? -->
<!-- Please provide instructions so that others can ensure that your pull request would produce correct results. For examples see, https://github.com/FreeTubeApp/FreeTube/pull/5743, https://github.com/FreeTubeApp/FreeTube/pull/7349, https://github.com/FreeTubeApp/FreeTube/pull/5125, https://github.com/FreeTubeApp/FreeTube/pull/7338 -->
<!-- Agent instructions: Only write human-facing steps that explain how to verify the change while running this branch in dev mode. Include expected results and, when applicable, helpful console snippets for interactive verification. Do not include automated checks, commands, results, pass counts, or CI status. -->
1. Subscribe to a channel that has an upcoming premiere scheduled and make sure "Hide Upcoming Premieres" is off in Settings > Distraction Free Settings.
2. Open the Subscriptions feed, hover the upcoming premiere and open its `⋮` menu.
   - Expected: there is no "Mark As Watched" entry, while the other entries (e.g. "Add to Queue") are still there. Hovering the thumbnail shows no watched toggle either.
3. Open the premiere's watch page, go back to History and open the entry's `⋮` menu.
   - Expected: no "Mark As Watched" / "Unmark As Watched", but "Remove From History" is still offered.
4. On the History page press "Mark All As Watched".
   - Expected: normal videos become watched, the upcoming premiere stays unwatched. If the premiere is the only unwatched entry, the button stays disabled.
5. Repeat step 2 with a premiere that is currently running or has already aired.
   - Expected: the watched actions are available again as usual.

## Additional context
<!-- Add any other context about the pull request here. -->
