### PR TITLE
fix: select option text nudging on hover and clipped context menu labels

### DIFF
--- a/e2e/tests/offline/search-context-menu.spec.mjs
+++ b/e2e/tests/offline/search-context-menu.spec.mjs
@@ -55,6 +55,47 @@ test('truncates long selections so the rest of the label is never cut off', asyn
   await expect.poll(() => page.url()).toContain(`#/search/${encodeURIComponent(selectionText)}`)
 })
 
+test('truncates long selections without splitting emoji', async ({ page }) => {
+  // The 30th UTF-16 code unit lands inside the family emoji's ZWJ sequence
+  const selectionText = 'Cafe rules ok yes indeed 👨‍👩‍👧‍👦 and more text'
+  const label = await page.evaluate((selection) => window.ftElectron.contextMenu.open({
+    selectionText: selection
+  }).then(menu => menu.items
+    .find(item => item.labelKey === 'Context Menu.Search Selection in New Tab')
+    .labelParameters.selection), selectionText)
+
+  expect(label.endsWith('…')).toBe(true)
+  // A cut inside the sequence would leave an unpaired surrogate behind
+  expect(label).not.toMatch(/[\uD800-\uDBFF](?![\uDC00-\uDFFF])|(?<![\uD800-\uDBFF])[\uDC00-\uDFFF]/)
+  expect(label).toBe('Cafe rules ok yes indeed 👨‍👩‍👧‍👦 and…')
+})
+
+test('keeps a tall context menu inside the window', async ({ page }) => {
+  await page.evaluate(() => {
+    const paragraph = document.createElement('p')
+    paragraph.textContent = 'OpenTubeX is a privacy respecting YouTube client for the desktop'
+    paragraph.style.cssText = 'position:fixed;top:8px;left:40px;width:300px;z-index:19000;background:#000'
+    document.body.append(paragraph)
+
+    const range = document.createRange()
+    range.selectNodeContents(paragraph)
+    const selection = window.getSelection()
+    selection.removeAllRanges()
+    selection.addRange(range)
+  })
+  await page.mouse.click(60, 20, { button: 'right' })
+
+  const menu = page.getByRole('menu', { name: 'Context Menu' })
+  await expect(menu).toBeVisible()
+
+  const bounds = await menu.evaluate((element) => {
+    const rect = element.getBoundingClientRect()
+    return { top: rect.top, bottom: rect.bottom, viewport: window.innerHeight }
+  })
+  expect(bounds.top).toBeGreaterThanOrEqual(0)
+  expect(bounds.bottom).toBeLessThanOrEqual(bounds.viewport)
+})
+
 test('renders long selection labels without clipping them', async ({ page }) => {
   const point = await page.evaluate(() => {
     const paragraph = document.createElement('p')

--- a/e2e/tests/offline/search-context-menu.spec.mjs
+++ b/e2e/tests/offline/search-context-menu.spec.mjs
@@ -32,6 +32,59 @@ test('searching selected text in a new tab uses the default filters', async ({ p
   await expect(page.locator('.searchRadio', { hasText: 'Duration' }).locator('input[value=""]')).toBeChecked()
 })
 
+test('truncates long selections so the rest of the label is never cut off', async ({ page }) => {
+  const selectionText = 'OpenTubeX is a privacy respecting YouTube client for the desktop'
+  const contextMenu = await page.evaluate((selection) => window.ftElectron.contextMenu.open({
+    selectionText: selection
+  }), selectionText)
+
+  const newTab = contextMenu.items.find(item => item.labelKey === 'Context Menu.Search Selection in New Tab')
+  const newWindow = contextMenu.items.find(item => item.labelKey === 'Context Menu.Search Selection in New Window')
+
+  for (const item of [newTab, newWindow]) {
+    expect(item.labelParameters.selection).toBe('OpenTubeX is a privacy respect…')
+  }
+  expect(newTab.label).toBe('Search "OpenTubeX is a privacy respect…" in a New Tab')
+  expect(newWindow.label).toBe('Search "OpenTubeX is a privacy respect…" in a New Window')
+
+  // Searching still uses the full selection, only the label is shortened
+  await page.evaluate(({ sessionId, actionId }) => {
+    return window.ftElectron.contextMenu.execute(sessionId, actionId)
+  }, { sessionId: contextMenu.sessionId, actionId: newTab.actionId })
+
+  await expect.poll(() => page.url()).toContain(`#/search/${encodeURIComponent(selectionText)}`)
+})
+
+test('renders long selection labels without clipping them', async ({ page }) => {
+  const point = await page.evaluate(() => {
+    const paragraph = document.createElement('p')
+    paragraph.textContent = 'OpenTubeX is a privacy respecting YouTube client for the desktop'
+    paragraph.style.cssText = 'position:fixed;top:120px;left:40px;width:300px;z-index:19000;background:#000'
+    document.body.append(paragraph)
+
+    const range = document.createRange()
+    range.selectNodeContents(paragraph)
+    const selection = window.getSelection()
+    selection.removeAllRanges()
+    selection.addRange(range)
+
+    const bounds = paragraph.getBoundingClientRect()
+    return { x: bounds.left + 10, y: bounds.top + 5 }
+  })
+  await page.mouse.click(point.x, point.y, { button: 'right' })
+
+  const menu = page.getByRole('menu', { name: 'Context Menu' })
+  await expect(menu).toBeVisible()
+
+  const label = menu.getByRole('menuitem', { name: /^Search ".*" in a New Tab$/ }).locator('span:not([aria-hidden])')
+  await expect(label).toHaveText('Search "OpenTubeX is a privacy respect…" in a New Tab')
+
+  const isClipped = await label.evaluate(element => {
+    return element.scrollWidth > element.clientWidth + 1 || element.scrollHeight > element.clientHeight + 1
+  })
+  expect(isClipped).toBe(false)
+})
+
 test('does not offer external search engines when they are disabled by default', async ({ page }) => {
   const contextMenu = await page.evaluate(() => window.ftElectron.contextMenu.open({
     selectionText: 'private search'

--- a/e2e/tests/offline/search-context-menu.spec.mjs
+++ b/e2e/tests/offline/search-context-menu.spec.mjs
@@ -70,30 +70,30 @@ test('truncates long selections without splitting emoji', async ({ page }) => {
   expect(label).toBe('Cafe rules ok yes indeed 👨‍👩‍👧‍👦 and…')
 })
 
-test('keeps a tall context menu inside the window', async ({ page }) => {
-  await page.evaluate(() => {
-    const paragraph = document.createElement('p')
-    paragraph.textContent = 'OpenTubeX is a privacy respecting YouTube client for the desktop'
-    paragraph.style.cssText = 'position:fixed;top:8px;left:40px;width:300px;z-index:19000;background:#000'
-    document.body.append(paragraph)
+test('does not clip fly-out submenus', async ({ page }) => {
+  await page.locator(sel.newTabButton).click()
+  await page.locator(sel.tabs).first().click({ button: 'right' })
 
-    const range = document.createRange()
-    range.selectNodeContents(paragraph)
-    const selection = window.getSelection()
-    selection.removeAllRanges()
-    selection.addRange(range)
-  })
-  await page.mouse.click(60, 20, { button: 'right' })
+  const closeTabs = page.getByRole('menuitem', { name: 'Close Tabs', exact: true })
+  await closeTabs.hover()
+  const submenu = closeTabs.locator('xpath=following-sibling::*[@role="menu"]')
+  await expect(submenu).toBeVisible()
 
-  const menu = page.getByRole('menu', { name: 'Context Menu' })
-  await expect(menu).toBeVisible()
-
-  const bounds = await menu.evaluate((element) => {
-    const rect = element.getBoundingClientRect()
-    return { top: rect.top, bottom: rect.bottom, viewport: window.innerHeight }
-  })
-  expect(bounds.top).toBeGreaterThanOrEqual(0)
-  expect(bounds.bottom).toBeLessThanOrEqual(bounds.viewport)
+  // Submenus are absolutely positioned inside the menu, so giving the menu a
+  // max height with overflow scrolling would clip them out of reach.
+  await expect.poll(() => submenu.evaluate((element) => {
+    const menu = element.closest('.contextMenu')
+    const style = getComputedStyle(menu)
+    const bounds = element.getBoundingClientRect()
+    return {
+      overflowX: style.overflowX,
+      overflowY: style.overflowY,
+      reachable: document.elementFromPoint(
+        (bounds.left + bounds.right) / 2,
+        (bounds.top + bounds.bottom) / 2
+      )?.closest('[role="menu"]') === element
+    }
+  })).toEqual({ overflowX: 'visible', overflowY: 'visible', reachable: true })
 })
 
 test('renders long selection labels without clipping them', async ({ page }) => {

--- a/e2e/tests/offline/search-context-menu.spec.mjs
+++ b/e2e/tests/offline/search-context-menu.spec.mjs
@@ -70,6 +70,37 @@ test('truncates long selections without splitting emoji', async ({ page }) => {
   expect(label).toBe('Cafe rules ok yes indeed 👨‍👩‍👧‍👦 and…')
 })
 
+test('keeps tall top-level menus inside the viewport and scrollable', async ({ page }) => {
+  await page.setViewportSize({ width: 420, height: 180 })
+  await page.locator(sel.newTabButton).click()
+  await page.locator(sel.tabs).first().click({ button: 'right' })
+
+  const menu = page.getByRole('menu', { name: 'Context Menu' })
+  await expect(menu).toBeVisible()
+
+  const geometry = await menu.evaluate(element => {
+    const bounds = element.getBoundingClientRect()
+    return {
+      top: bounds.top,
+      bottom: bounds.bottom,
+      viewportBottom: innerHeight - 8,
+      overflowY: getComputedStyle(element).overflowY,
+      scrollable: element.scrollHeight > element.clientHeight
+    }
+  })
+
+  expect(geometry.top).toBeGreaterThanOrEqual(8)
+  expect(geometry.bottom).toBeLessThanOrEqual(geometry.viewportBottom + 1)
+  expect(geometry.overflowY).toBe('auto')
+  expect(geometry.scrollable).toBe(true)
+
+  const lastTopLevelItem = menu
+    .locator(':scope > .menuItem, :scope > .submenuContainer > .menuItem')
+    .last()
+  await lastTopLevelItem.scrollIntoViewIfNeeded()
+  await expect(lastTopLevelItem).toBeInViewport()
+})
+
 test('does not clip fly-out submenus', async ({ page }) => {
   await page.locator(sel.newTabButton).click()
   await page.locator(sel.tabs).first().click({ button: 'right' })
@@ -79,8 +110,7 @@ test('does not clip fly-out submenus', async ({ page }) => {
   const submenu = closeTabs.locator('xpath=following-sibling::*[@role="menu"]')
   await expect(submenu).toBeVisible()
 
-  // Submenus are absolutely positioned inside the menu, so giving the menu a
-  // max height with overflow scrolling would clip them out of reach.
+  // Fixed-position fly-outs escape the top-level menu's scrollport.
   await expect.poll(() => submenu.evaluate((element) => {
     const menu = element.closest('.contextMenu')
     const style = getComputedStyle(menu)
@@ -88,12 +118,18 @@ test('does not clip fly-out submenus', async ({ page }) => {
     return {
       overflowX: style.overflowX,
       overflowY: style.overflowY,
+      position: getComputedStyle(element).position,
       reachable: document.elementFromPoint(
         (bounds.left + bounds.right) / 2,
         (bounds.top + bounds.bottom) / 2
       )?.closest('[role="menu"]') === element
     }
-  })).toEqual({ overflowX: 'visible', overflowY: 'visible', reachable: true })
+  })).toEqual({
+    overflowX: 'auto',
+    overflowY: 'auto',
+    position: 'fixed',
+    reachable: true
+  })
 })
 
 test('renders long selection labels without clipping them', async ({ page }) => {

--- a/e2e/tests/offline/tabs.spec.mjs
+++ b/e2e/tests/offline/tabs.spec.mjs
@@ -489,6 +489,30 @@ test.describe('tab bar', () => {
     await expect(submenu).toBeVisible()
   })
 
+  test('keeps a submenu inside the viewport for a bottom vertical tab', async ({ page }) => {
+    await page.setViewportSize({ width: 800, height: 450 })
+    await page.keyboard.press('F1')
+    await expect(page.locator('.app')).toHaveClass(/verticalTabs/)
+
+    for (let index = 0; index < 7; index++) {
+      await page.keyboard.press('Control+t')
+    }
+
+    await page.locator(sel.activeTab).click({ button: 'right' })
+    const tabColor = page.getByRole('menuitem', { name: 'Tab Color', exact: true })
+    await tabColor.hover()
+
+    const submenu = tabColor.locator('xpath=following-sibling::*[@role="menu"]')
+    await expect(submenu).toBeVisible()
+    const submenuBox = await boundingBoxWhenSettled(submenu)
+    const viewport = await page.evaluate(() => ({ width: innerWidth, height: innerHeight }))
+
+    expect(submenuBox.x).toBeGreaterThanOrEqual(8)
+    expect(submenuBox.y).toBeGreaterThanOrEqual(8)
+    expect(submenuBox.x + submenuBox.width).toBeLessThanOrEqual(viewport.width - 8)
+    expect(submenuBox.y + submenuBox.height).toBeLessThanOrEqual(viewport.height - 8)
+  })
+
   // Regression: search bar text used to leak between tabs (65f4e2e13)
   test('search bar text is independent per tab', async ({ page }) => {
     const searchInput = page.locator(sel.searchInput)

--- a/e2e/tests/offline/ui-bugfixes.spec.mjs
+++ b/e2e/tests/offline/ui-bugfixes.spec.mjs
@@ -522,3 +522,39 @@ test.describe('history reorder animation', () => {
     expect(probes).not.toContain(null)
   })
 })
+
+test.describe('select dropdown pixel grid', () => {
+  // A fractional device pixel ratio is what makes the misalignment visible.
+  test.use({ launchArgs: ['--force-device-scale-factor=1.5'] })
+
+  test('keeps option text in place when it gains a hover background', async ({ page }) => {
+    await goTo(page, 'settings')
+
+    await page.getByRole('combobox', { name: 'Default Landing Page' }).first().click()
+    const dropdown = page.locator('.selectDropdown')
+    await expect(dropdown).toBeVisible()
+    // The opening animation scales the menu, so wait for its final resting place.
+    await expect
+      .poll(() => dropdown.evaluate(menu => getComputedStyle(menu).transform))
+      .toBe('none')
+
+    // Chromium only snaps an option's text to the pixel grid once the option
+    // has a background to paint, so an option sitting at a fractional offset
+    // nudges its label the first time it is hovered.
+    const offGrid = await dropdown.evaluate((menu) => {
+      const onGrid = (value) => Math.abs(value * devicePixelRatio - Math.round(value * devicePixelRatio)) < 0.001
+      const bounds = menu.getBoundingClientRect()
+
+      return [
+        ...(onGrid(bounds.left) ? [] : [`menu left ${bounds.left}`]),
+        ...(onGrid(bounds.top) ? [] : [`menu top ${bounds.top}`]),
+        ...[...menu.querySelectorAll('.selectOption')]
+          .map(option => option.getBoundingClientRect().top)
+          .filter(top => !onGrid(top))
+          .map(top => `option top ${top}`)
+      ]
+    })
+
+    expect(offGrid).toEqual([])
+  })
+})

--- a/e2e/tests/offline/ui-bugfixes.spec.mjs
+++ b/e2e/tests/offline/ui-bugfixes.spec.mjs
@@ -538,6 +538,28 @@ test.describe('select dropdown pixel grid', () => {
       .poll(() => dropdown.evaluate(menu => getComputedStyle(menu).transform))
       .toBe('none')
 
+    const dpr = await page.evaluate(() => window.devicePixelRatio)
+    expect(Math.abs(dpr - 1.5)).toBeLessThan(0.001)
+
+    const options = dropdown.locator('.selectOption')
+    const inactiveOptionIndex = await options.evaluateAll(optionElements =>
+      optionElements.findIndex(option => !option.classList.contains('active'))
+    )
+    expect(inactiveOptionIndex).toBeGreaterThanOrEqual(0)
+    const option = options.nth(inactiveOptionIndex)
+    // The option label is a direct text node, so measure its rendered range.
+    const textPosition = () => option.evaluate(element => {
+      const range = document.createRange()
+      range.selectNodeContents(element)
+      const bounds = range.getBoundingClientRect()
+      return { x: bounds.x, y: bounds.y }
+    })
+    const beforeHover = await textPosition()
+
+    await option.hover()
+    await expect(option).toHaveClass(/active/)
+    expect(await textPosition()).toEqual(beforeHover)
+
     // Chromium only snaps an option's text to the pixel grid once the option
     // has a background to paint, so an option sitting at a fractional offset
     // nudges its label the first time it is hovered.

--- a/src/main/index.js
+++ b/src/main/index.js
@@ -333,6 +333,19 @@ function runApp() {
     }
   }
 
+  // Keep the interpolated selection short, so that the surrounding translated text
+  // (e.g. the trailing "in a New Tab") stays readable instead of being cut off
+  const SELECTION_LABEL_MAX_LENGTH = 30
+
+  /**
+   * @param {string} text
+   */
+  function truncateSelectionForLabel(text) {
+    return text.length > SELECTION_LABEL_MAX_LENGTH
+      ? `${text.slice(0, SELECTION_LABEL_MAX_LENGTH).trimEnd()}…`
+      : text
+  }
+
   /** @type {Record<string, Function | boolean>} */
   const contextMenuOptions = {
     showSearchWithGoogle: false,
@@ -768,6 +781,7 @@ function runApp() {
       }
 
       const selectionText = parameters.selectionText.trim()
+      const selectionLabelText = truncateSelectionForLabel(selectionText)
       const textShortEnoughForSearch = selectionText.length <= SEARCH_CHAR_LIMIT
       const activeSearchEngines = (await getConfiguredSearchEngines())
         .filter(engine => engine.enabled)
@@ -832,13 +846,13 @@ function runApp() {
           label: textShortEnoughForSearch
             ? contextMenuLabel(
                 'Search Selection in New Tab',
-                { selection: selectionText },
-                `Search "${selectionText}" in a New Tab`
+                { selection: selectionLabelText },
+                `Search "${selectionLabelText}" in a New Tab`
               )
             : contextMenuLabel(
                 'Selection Too Long',
                 { count: SEARCH_CHAR_LIMIT },
-                `"${selectionText}" is too long for search (> ${SEARCH_CHAR_LIMIT} chars)`
+                `"${selectionLabelText}" is too long for search (> ${SEARCH_CHAR_LIMIT} chars)`
               ),
           enabled: textShortEnoughForSearch,
           visible: (
@@ -866,13 +880,13 @@ function runApp() {
           label: textShortEnoughForSearch
             ? contextMenuLabel(
                 'Search Selection in New Window',
-                { selection: selectionText },
-                `Search "${selectionText}" in a New Window`
+                { selection: selectionLabelText },
+                `Search "${selectionLabelText}" in a New Window`
               )
             : contextMenuLabel(
                 'Selection Too Long',
                 { count: SEARCH_CHAR_LIMIT },
-                `"${selectionText}" is too long for search (> ${SEARCH_CHAR_LIMIT} chars)`
+                `"${selectionLabelText}" is too long for search (> ${SEARCH_CHAR_LIMIT} chars)`
               ),
           enabled: textShortEnoughForSearch,
           visible: (

--- a/src/main/index.js
+++ b/src/main/index.js
@@ -337,13 +337,23 @@ function runApp() {
   // (e.g. the trailing "in a New Tab") stays readable instead of being cut off
   const SELECTION_LABEL_MAX_LENGTH = 30
 
+  // Counting grapheme clusters rather than UTF-16 code units, so that the cut
+  // never lands inside an emoji or a combining character sequence
+  const selectionLabelSegmenter = new Intl.Segmenter()
+
   /**
    * @param {string} text
    */
   function truncateSelectionForLabel(text) {
-    return text.length > SELECTION_LABEL_MAX_LENGTH
-      ? `${text.slice(0, SELECTION_LABEL_MAX_LENGTH).trimEnd()}…`
-      : text
+    const graphemes = []
+    for (const { segment } of selectionLabelSegmenter.segment(text)) {
+      if (graphemes.length === SELECTION_LABEL_MAX_LENGTH) {
+        return `${graphemes.join('').trimEnd()}…`
+      }
+      graphemes.push(segment)
+    }
+
+    return text
   }
 
   /** @type {Record<string, Function | boolean>} */

--- a/src/renderer/components/FtContextMenu/FtContextMenu.css
+++ b/src/renderer/components/FtContextMenu/FtContextMenu.css
@@ -1,5 +1,6 @@
 .contextMenu,
 .submenu {
+  box-sizing: border-box;
   inline-size: max-content;
   max-inline-size: min(360px, calc(100vw - 16px));
   padding: 5px;
@@ -10,27 +11,22 @@
   box-shadow: 0 12px 32px rgb(0 0 0 / 34%);
 }
 
-/* Deliberately not a scroll container: submenus are absolutely positioned
-   inside it, so any overflow value other than visible clips them away. */
 .contextMenu {
   position: fixed;
   z-index: 20000;
-  transform-origin: top left;
-}
-
-.contextMenu.submenusOpenStart {
-  transform-origin: top right;
+  max-block-size: calc(100vh - 16px);
+  overflow: auto;
+  overscroll-behavior: contain;
 }
 
 .context-menu-enter-active,
 .context-menu-leave-active {
-  transition: opacity 120ms ease, transform 120ms ease;
+  transition: opacity 120ms ease;
 }
 
 .context-menu-enter-from,
 .context-menu-leave-to {
   opacity: 0;
-  transform: scale(0.96);
 }
 
 .menuItem {
@@ -154,12 +150,14 @@
 /* Submenu placement follows physical pointer coordinates in both text directions. */
 /* stylelint-disable liberty/use-logical-spec */
 .submenu {
-  position: absolute;
-  inset-block-start: var(--submenu-top, -5px);
+  /* Fixed positioning lets fly-outs escape the top-level menu's scrollport. */
+  position: fixed;
+  inset-block-start: var(--submenu-top, 8px);
   max-block-size: calc(100vh - 16px);
   overflow-y: auto;
+  overscroll-behavior: contain;
   right: auto;
-  left: var(--submenu-left, calc(100% - 2px));
+  left: var(--submenu-left, 8px);
   visibility: hidden;
   opacity: 0;
   pointer-events: none;

--- a/src/renderer/components/FtContextMenu/FtContextMenu.css
+++ b/src/renderer/components/FtContextMenu/FtContextMenu.css
@@ -155,13 +155,15 @@
 /* stylelint-disable liberty/use-logical-spec */
 .submenu {
   position: absolute;
-  inset-block-start: -5px;
+  inset-block-start: var(--submenu-top, -5px);
+  max-block-size: calc(100vh - 16px);
+  overflow-y: auto;
   right: auto;
-  left: calc(100% - 2px);
+  left: var(--submenu-left, calc(100% - 2px));
   visibility: hidden;
   opacity: 0;
   pointer-events: none;
-  transform: translateX(-4px) scale(0.98);
+  transform: translateX(var(--submenu-translate, -4px)) scale(0.98);
   transform-origin: top left;
   transition: opacity 100ms ease, transform 100ms ease, visibility 0s linear 100ms;
 }
@@ -176,17 +178,30 @@
   content: '';
 }
 
-.submenusOpenStart .submenu {
-  right: calc(100% - 2px);
-  left: auto;
-  transform: translateX(4px) scale(0.98);
+.submenusOpenStart .submenu,
+.submenuOpenStart .submenu {
+  --submenu-translate: 4px;
+
   transform-origin: top right;
 }
 
-.submenusOpenStart .submenu::before {
+.submenusOpenStart .submenu::before,
+.submenuOpenStart .submenu::before {
   right: auto;
   left: 100%;
   clip-path: polygon(0 0, 0 100%, 100% 16px);
+}
+
+.submenuOpenEnd .submenu {
+  --submenu-translate: -4px;
+
+  transform-origin: top left;
+}
+
+.submenuOpenEnd .submenu::before {
+  right: 100%;
+  left: auto;
+  clip-path: polygon(0 16px, 100% 0, 100% 100%);
 }
 /* stylelint-enable liberty/use-logical-spec */
 

--- a/src/renderer/components/FtContextMenu/FtContextMenu.css
+++ b/src/renderer/components/FtContextMenu/FtContextMenu.css
@@ -14,6 +14,11 @@
   position: fixed;
   z-index: 20000;
   transform-origin: top left;
+
+  /* Wrapping labels makes tall menus more likely, so keep the bottom entries
+     reachable instead of letting them run past the edge of the window */
+  max-block-size: calc(100vh - 16px);
+  overflow-y: auto;
 }
 
 .contextMenu.submenusOpenStart {

--- a/src/renderer/components/FtContextMenu/FtContextMenu.css
+++ b/src/renderer/components/FtContextMenu/FtContextMenu.css
@@ -10,15 +10,12 @@
   box-shadow: 0 12px 32px rgb(0 0 0 / 34%);
 }
 
+/* Deliberately not a scroll container: submenus are absolutely positioned
+   inside it, so any overflow value other than visible clips them away. */
 .contextMenu {
   position: fixed;
   z-index: 20000;
   transform-origin: top left;
-
-  /* Wrapping labels makes tall menus more likely, so keep the bottom entries
-     reachable instead of letting them run past the edge of the window */
-  max-block-size: calc(100vh - 16px);
-  overflow-y: auto;
 }
 
 .contextMenu.submenusOpenStart {

--- a/src/renderer/components/FtContextMenu/FtContextMenu.css
+++ b/src/renderer/components/FtContextMenu/FtContextMenu.css
@@ -49,11 +49,10 @@
   cursor: default;
 }
 
+/* Labels wrap instead of being clipped, so translations are never cut off */
 .menuItem > span:nth-child(2):last-child {
   grid-column: 2;
-  overflow: hidden;
-  text-overflow: ellipsis;
-  white-space: nowrap;
+  overflow-wrap: anywhere;
 }
 
 .menuItem.disabled {
@@ -137,9 +136,7 @@
 
 .submenuContainer > .menuItem > span:nth-child(2) {
   grid-column: 2;
-  overflow: hidden;
-  text-overflow: ellipsis;
-  white-space: nowrap;
+  overflow-wrap: anywhere;
 }
 
 .submenuArrow {

--- a/src/renderer/components/FtContextMenu/FtContextMenu.vue
+++ b/src/renderer/components/FtContextMenu/FtContextMenu.vue
@@ -27,6 +27,8 @@
           <div
             v-else-if="item.submenu"
             class="submenuContainer"
+            @pointerenter="positionSubmenu"
+            @focusin="positionSubmenu"
           >
             <button
               class="menuItem"
@@ -360,6 +362,45 @@ function close(event) {
   if (event?.target instanceof Element && event.target.closest('.contextMenu')) return
   openRequest++
   isOpen.value = false
+}
+
+function positionSubmenu(event) {
+  const container = event.currentTarget
+  if (!(container instanceof HTMLElement)) return
+
+  const submenu = container.querySelector(':scope > .submenu')
+  if (!(submenu instanceof HTMLElement)) return
+
+  const containerRect = container.getBoundingClientRect()
+  const submenuWidth = submenu.offsetWidth
+  const submenuHeight = submenu.offsetHeight
+  const viewportMargin = 8
+  const opensAtStart = submenusOpenStart.value
+  const preferredLeft = opensAtStart
+    ? containerRect.left - submenuWidth + 2
+    : containerRect.right - 2
+  const alternateLeft = opensAtStart
+    ? containerRect.right - 2
+    : containerRect.left - submenuWidth + 2
+  const fitsHorizontally = left => left >= viewportMargin &&
+    left + submenuWidth <= window.innerWidth - viewportMargin
+  const left = fitsHorizontally(preferredLeft) || !fitsHorizontally(alternateLeft)
+    ? preferredLeft
+    : alternateLeft
+  const clampedLeft = Math.max(
+    viewportMargin,
+    Math.min(left, window.innerWidth - submenuWidth - viewportMargin)
+  )
+  const top = Math.max(
+    viewportMargin,
+    Math.min(containerRect.top - 5, window.innerHeight - submenuHeight - viewportMargin)
+  )
+
+  const opensToStart = left === alternateLeft ? !opensAtStart : opensAtStart
+  container.classList.toggle('submenuOpenStart', opensToStart)
+  container.classList.toggle('submenuOpenEnd', !opensToStart)
+  container.style.setProperty('--submenu-left', `${clampedLeft - containerRect.left}px`)
+  container.style.setProperty('--submenu-top', `${top - containerRect.top}px`)
 }
 
 async function execute(item) {

--- a/src/renderer/components/FtContextMenu/FtContextMenu.vue
+++ b/src/renderer/components/FtContextMenu/FtContextMenu.vue
@@ -14,6 +14,7 @@
         :aria-label="t('Context Menu.Context Menu')"
         @contextmenu.prevent
         @pointerdown.stop
+        @scroll="positionOpenSubmenu"
       >
         <template
           v-for="(item, index) in displayedItems"
@@ -364,8 +365,10 @@ function close(event) {
   isOpen.value = false
 }
 
-function positionSubmenu(event) {
-  const container = event.currentTarget
+function positionSubmenu(eventOrContainer) {
+  const container = eventOrContainer instanceof HTMLElement
+    ? eventOrContainer
+    : eventOrContainer.currentTarget
   if (!(container instanceof HTMLElement)) return
 
   const submenu = container.querySelector(':scope > .submenu')
@@ -399,8 +402,15 @@ function positionSubmenu(event) {
   const opensToStart = left === alternateLeft ? !opensAtStart : opensAtStart
   container.classList.toggle('submenuOpenStart', opensToStart)
   container.classList.toggle('submenuOpenEnd', !opensToStart)
-  container.style.setProperty('--submenu-left', `${clampedLeft - containerRect.left}px`)
-  container.style.setProperty('--submenu-top', `${top - containerRect.top}px`)
+  container.style.setProperty('--submenu-left', `${clampedLeft}px`)
+  container.style.setProperty('--submenu-top', `${top}px`)
+}
+
+function positionOpenSubmenu() {
+  const container = menuRef.value?.querySelector(
+    '.submenuContainer:hover, .submenuContainer:focus-within'
+  )
+  if (container instanceof HTMLElement) positionSubmenu(container)
 }
 
 async function execute(item) {

--- a/src/renderer/components/FtContextMenu/FtContextMenu.vue
+++ b/src/renderer/components/FtContextMenu/FtContextMenu.vue
@@ -7,7 +7,6 @@
       <div
         v-if="isOpen"
         ref="menuRef"
-        v-overlay-scrollbars
         class="contextMenu"
         :class="{ submenusOpenStart }"
         :style="menuStyle"

--- a/src/renderer/components/FtContextMenu/FtContextMenu.vue
+++ b/src/renderer/components/FtContextMenu/FtContextMenu.vue
@@ -7,6 +7,7 @@
       <div
         v-if="isOpen"
         ref="menuRef"
+        v-overlay-scrollbars
         class="contextMenu"
         :class="{ submenusOpenStart }"
         :style="menuStyle"

--- a/src/renderer/components/FtSelect/FtSelect.vue
+++ b/src/renderer/components/FtSelect/FtSelect.vue
@@ -286,10 +286,24 @@ function updateDropdownPosition() {
   dropdownPlacement.value = openAbove ? 'above' : 'below'
   dropdownStyle.value = {
     inlineSize: `${menuWidth}px`,
-    left: `${left}px`,
-    top: `${top}px`,
+    left: `${snapToDevicePixels(left)}px`,
+    top: `${snapToDevicePixels(top)}px`,
     maxBlockSize: naturalHeight > menuHeight ? `${menuHeight}px` : null
   }
+}
+
+/**
+ * The button's bounding box rarely lands on a whole pixel, and Chromium only
+ * snaps an option's text to the pixel grid once it has a background to paint,
+ * so hovering an option at a fractional offset visibly nudges its label. Place
+ * the menu on the device pixel grid instead, which keeps every option's text
+ * where it already was.
+ *
+ * @param {number} value
+ */
+function snapToDevicePixels(value) {
+  const ratio = window.devicePixelRatio || 1
+  return Math.round(value * ratio) / ratio
 }
 
 function getTopChromeBottom() {


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Make sure to follow the contributing guidelines. -->
<!-- Important note, we may remove your pull request if you do not use this provided PR template correctly. -->
<!-- Agent instructions: Preserve every heading, comment, and marker in this template. Never remove or rewrite the release-note-category:start/end, release-note:start/end, or release-note-image:start/end marker pairs. Never remove or rewrite the Release note images section; leave its contents for a human. -->

## Pull Request Type
<!-- Please select what type of pull request this is: [x] -->
- [x] Bugfix
- [ ] Feature Implementation
- [ ] Documentation
- [ ] Other

## Related issue
<!-- Please link the issue your pull request is referring to. -->
<!-- If this pull request fully resolves the relevant issue, put "closes" before the issue number. -->
<!-- Example: "closes #123456". -->
closes #533

## Description
<!-- Please write a clear and concise description of what the pull request does. -->
Two unrelated text rendering fixes.

**Select dropdown options nudged their text on first hover**

The custom select menu was positioned straight from the button's bounding box, which rarely lands on a whole pixel (e.g. `top: 552.719px`). Chromium only snaps an option's text to the pixel grid once that option has a background to paint, so the moment `.active` added the hover background the label jumped. On fractional display scaling that was a visible ~1 device pixel shift, measured at ~0.88 device px at 150% scaling.

The menu is now placed on the device pixel grid, so an option's text is already where the snapped position would put it and hovering changes nothing but the colours.

**Context menu cut off long selection labels**

Selecting a long piece of text pushed the trailing "in a New Tab" / "in a New Window" out of the clipped label, leaving the two entries indistinguishable. The interpolated selection is now truncated for the label, and labels wrap rather than being clipped, so translations can't be cut off either. Searching still uses the full selection.

## Release note category
<!-- Select exactly one category. Every pull request must select one. -->
<!-- release-note-category:start -->
- [ ] Not noteworthy
- [ ] Highlights
- [ ] More improvements
- [x] Fixed bugs
<!-- release-note-category:end -->

## Release note
<!-- Required unless "Not noteworthy" is selected. -->
<!-- Write one concise, user-facing entry without a leading bullet. -->
<!-- release-note:start -->
Fixed long entries cutting off the context menu's text
<!-- release-note:end -->

## Release note images
<!-- Human-only: Agents must preserve this entire section and leave it empty. -->
<!-- Optional. Paste one or more Markdown images or HTML image tags here. -->
<!-- The release notes will use an HTML image tag and limit images taller than 300 pixels. -->
<!-- release-note-image:start -->

<!-- release-note-image:end -->

## Testing
<!-- How can reviewers verify that the PR produces correct results? -->
<!-- Please provide instructions so that others can ensure that your pull request would produce correct results. For examples see, https://github.com/FreeTubeApp/FreeTube/pull/5743, https://github.com/FreeTubeApp/FreeTube/pull/7349, https://github.com/FreeTubeApp/FreeTube/pull/5125, https://github.com/FreeTubeApp/FreeTube/pull/7338 -->
<!-- Agent instructions: Only write human-facing steps that explain how to verify the change while running this branch in dev mode. Include expected results and, when applicable, helpful console snippets for interactive verification. Do not include automated checks, commands, results, pass counts, or CI status. -->
**Select dropdown**

Best seen with fractional display scaling (125% or 150%), which is where the misalignment shows up.

1. Open Settings and click a select such as "Default Landing Page" to open its menu.
2. Move the mouse down over the options one by one.
3. Each option's text should stay exactly where it was, with only the background and text colour changing. Before this change the label nudged the first time an option was hovered.

You can confirm the menu now sits on the pixel grid by running this in the dev tools console while a menu is open:

```js
const menu = document.querySelector('.selectDropdown')
const bounds = menu.getBoundingClientRect()
console.log([bounds.top, bounds.left, ...[...menu.querySelectorAll('.selectOption')].map(o => o.getBoundingClientRect().top)]
  .map(v => v * devicePixelRatio))
```

Every logged value should be a whole number.

**Context menu**

1. On any page, select a long run of text, e.g. "OpenTubeX is a privacy respecting YouTube client for the desktop".
2. Right click the selection.
3. The "Search ... in a New Tab" and "Search ... in a New Window" entries should both be fully readable, with the selection shortened to `OpenTubeX is a privacy respect…` and the trailing part of each label intact.
4. Click "Search ... in a New Tab" — the search should run with the full selected text, not the shortened one.

## Additional context
<!-- Add any other context about the pull request here. -->
The context menu fix was authored in a separate worktree and folded into this branch on request.
