### PR TITLE
Add fullscreen live chat dock

### DIFF
--- a/src/renderer/components/WatchVideoLiveChat/WatchVideoLiveChat.css
+++ b/src/renderer/components/WatchVideoLiveChat/WatchVideoLiveChat.css
@@ -7,6 +7,93 @@
   position: relative;
 }
 
+.card.fullscreenChat,
+.fullscreenChat > .relative {
+  display: flex;
+  flex: 1 1 auto;
+  flex-direction: column;
+  min-block-size: 0;
+}
+
+.card.fullscreenChat {
+  block-size: 100% !important;
+  margin: 0;
+  padding: 0;
+  overflow: hidden;
+  border-radius: 0;
+  box-shadow: none;
+  color: var(--primary-text-color);
+  background: transparent;
+}
+
+.fullscreenChat > .relative {
+  box-sizing: border-box;
+  padding-block: 0 16px;
+  padding-inline: 16px;
+}
+
+.liveChatDockHeader {
+  display: flex;
+  flex: 0 0 52px;
+  align-items: center;
+  justify-content: space-between;
+  box-sizing: border-box;
+  padding-inline: 16px 8px;
+  border-block-end: 1px solid rgb(255 255 255 / 10%);
+  background-color: rgb(20 20 20 / 52%);
+}
+
+.liveChatDockHeader h3 {
+  display: flex;
+  align-items: center;
+  min-inline-size: 0;
+  margin: 0;
+  gap: 10px;
+  font-size: 18px;
+  font-weight: bold;
+  color: #fff;
+}
+
+.liveChatDockTitleIcon {
+  display: block;
+  flex: 0 0 18px;
+  inline-size: 18px;
+  block-size: 18px;
+  color: #fff;
+}
+
+.liveChatDockActions {
+  position: relative;
+  display: flex;
+  align-items: center;
+  gap: 4px;
+}
+
+.liveChatDockAction {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  inline-size: 36px;
+  block-size: 36px;
+  padding: 0;
+  color: #fff;
+  background: transparent;
+  border: 0;
+  border-radius: 50%;
+  cursor: pointer;
+  font-size: 18px;
+  line-height: 1;
+  text-decoration: none;
+}
+
+.liveChatDockAction:is(:hover, :focus-visible) {
+  background-color: rgb(255 255 255 / 20%);
+}
+
+.liveChatDockAction.active {
+  background-color: rgb(255 255 255 / 20%);
+}
+
 .messageContainer {
   inline-size: 100%;
   block-size: 100%;
@@ -199,6 +286,15 @@
 .liveChatComments {
   inline-size: 100%;
   overflow-y: auto;
+}
+
+.fullscreenChat .liveChatComments {
+  flex: 1 1 auto;
+  block-size: auto !important;
+  min-block-size: 0;
+
+  --scrollbar-color: rgb(255 255 255 / 45%);
+  --scrollbar-color-hover: rgb(255 255 255 / 65%);
 }
 
 .chatContent {

--- a/src/renderer/components/WatchVideoLiveChat/WatchVideoLiveChat.vue
+++ b/src/renderer/components/WatchVideoLiveChat/WatchVideoLiveChat.vue
@@ -1,8 +1,76 @@
 <template>
   <FtCard
     class="card relative"
-    :class="{ hasError }"
+    :class="{ hasError, fullscreenChat: fullscreenOverlay }"
   >
+    <header
+      v-if="fullscreenOverlay"
+      class="liveChatDockHeader"
+    >
+      <h3>
+        <FontAwesomeIcon
+          class="liveChatDockTitleIcon"
+          :icon="['fas', 'message']"
+        />
+        {{ isReplay ? t('Video.Live Chat Replay') : t('Video.Live Chat') }}
+      </h3>
+      <div
+        ref="liveChatActionsRef"
+        class="liveChatDockActions"
+        @keydown.esc.stop.prevent="settingsMenuOpen = false"
+      >
+        <button
+          type="button"
+          class="liveChatDockAction"
+          :class="{ active: settingsMenuOpen }"
+          :aria-label="t('Video.Live Chat Settings')"
+          :title="t('Video.Live Chat Settings')"
+          :aria-expanded="String(settingsMenuOpen)"
+          @click="settingsMenuOpen = !settingsMenuOpen"
+        >
+          <FontAwesomeIcon :icon="['fas', 'sliders-h']" />
+        </button>
+        <a
+          v-if="!isReplay"
+          :href="`https://www.youtube.com/live_chat?is_popout=1&v=${props.videoId}`"
+          :aria-label="t('Video.Popout Live Chat')"
+          :title="t('Video.Popout Live Chat')"
+          target="_blank"
+          class="liveChatDockAction"
+        >
+          <FontAwesomeIcon :icon="['fas', 'arrow-up-right-from-square']" />
+        </a>
+        <button
+          type="button"
+          class="liveChatDockAction"
+          :aria-label="t('Settings.Distraction Free Settings.Hide Live Chat')"
+          :title="t('Settings.Distraction Free Settings.Hide Live Chat')"
+          @click="emit('close')"
+        >
+          <FontAwesomeIcon :icon="['fas', 'xmark']" />
+        </button>
+        <div
+          v-if="settingsMenuOpen"
+          class="liveChatSettingsMenu"
+        >
+          <FtToggleSwitch
+            :label="t('Video.Show Live Chat Timestamps')"
+            :default-value="showLiveChatTimestamps"
+            :compact="true"
+            @change="updateShowLiveChatTimestamps"
+          />
+          <FtRadioButton
+            v-if="canFilter"
+            class="liveChatFilter"
+            :title="t('Video.Chat Filter')"
+            :labels="[t('Video.Top Chat'), t('Video.All Messages')]"
+            :values="['TOP_CHAT', 'LIVE_CHAT']"
+            :model-value="liveChatFilter"
+            @update:model-value="updateLiveChatFilter"
+          />
+        </div>
+      </div>
+    </header>
     <FtLoader
       v-if="isLoading"
     />
@@ -44,6 +112,7 @@
       class="relative"
     >
       <div
+        v-if="!fullscreenOverlay"
         class="titleContainer"
       >
         <h4
@@ -339,6 +408,10 @@ import {
 } from './liveChatReplay.js'
 
 const props = defineProps({
+  fullscreenOverlay: {
+    type: Boolean,
+    default: false
+  },
   liveChat: {
     type: EventTarget,
     default: null
@@ -356,6 +429,8 @@ const props = defineProps({
     default: 0
   }
 })
+
+const emit = defineEmits(['close'])
 
 const { locale, t } = useI18n()
 
@@ -442,12 +517,14 @@ const formattedWatchingCount = computed(() => {
 })
 
 onBeforeUnmount(() => {
-  document.removeEventListener('pointerdown', handleChatSettingsClickOutside)
+  document.removeEventListener('pointerdown', handleChatSettingsClickOutside, true)
   handleEnd()
 })
 
 onMounted(() => {
-  document.addEventListener('pointerdown', handleChatSettingsClickOutside)
+  // Fullscreen docks stop pointer events from bubbling into the player. Capture
+  // the event first so clicking another dock can still dismiss this menu.
+  document.addEventListener('pointerdown', handleChatSettingsClickOutside, true)
 })
 
 if (!process.env.SUPPORTS_LOCAL_API) {
@@ -518,16 +595,47 @@ function startLiveChatLocal() {
     liveChatInstance.seekTo(props.currentTime * 1000)
   }
 
+  // A component remount (notably Vue HMR in development) can receive the same
+  // chat instance after it has already advanced beyond its initial continuation.
+  // Restarting that instance resumes polling, but it cannot emit `start` again
+  // until a replay seek. Rehydrate from youtubei.js' cached initial payload so
+  // loading and the chat filter UI do not wait forever.
+  if (liveChatInstance.initial_info) {
+    handleStart(liveChatInstance.initial_info)
+  }
+
   liveChatInstance.start()
 }
 
 const commentsRef = useTemplateRef('commentsRef')
 
+watch(() => props.fullscreenOverlay, fullscreenOverlay => {
+  if (!fullscreenOverlay) {
+    return
+  }
+
+  scrollToLiveAfterLayout()
+})
+
+/**
+ * OverlayScrollbars measures its viewport after Vue renders. Waiting through
+ * the following frame ensures both sidebar creation and dock teleporting have
+ * their final height before the chat is anchored to the live edge.
+ */
+function scrollToLiveAfterLayout() {
+  nextTick(() => {
+    requestAnimationFrame(() => {
+      requestAnimationFrame(() => scrollToBottom('instant'))
+    })
+  })
+}
+
 /**
  * @param {import ('youtubei.js/dist/src/parser/continuations').LiveChatContinuation} initialData
  */
 function handleStart(initialData) {
-  canFilter.value = (initialData.header?.view_selector?.sub_menu_items?.length ?? 0) > 1
+  const viewSelector = initialData.header?.view_selector ?? liveChatInstance?.initial_info?.header?.view_selector
+  canFilter.value = (viewSelector?.sub_menu_items?.length ?? 0) > 1
 
   // A chat always starts on YouTube's default view, so switch away from it before
   // showing anything if the other one is the view that is wanted.
@@ -547,9 +655,7 @@ function handleStart(initialData) {
     requestMoreReplayComments()
   }
 
-  nextTick(() => {
-    scrollToBottom('instant')
-  })
+  scrollToLiveAfterLayout()
 }
 
 /**
@@ -770,11 +876,14 @@ function deliverComment(comment) {
  * @param {any} comment
  */
 function pushComment(comment) {
+  const shouldStayAtBottom = stayAtBottom
   comments.push(comment)
 
-  if (!isLoading.value && stayAtBottom) {
+  if (!isLoading.value && shouldStayAtBottom) {
     nextTick(() => {
-      scrollToBottom()
+      // Smooth scrolling can be interrupted when another message arrives or the
+      // tab is backgrounded. An instant follow-up keeps the bottom anchored.
+      scrollToBottom('instant')
     })
   }
 
@@ -854,6 +963,7 @@ function onScrollEnd() {
 
 function stopScrollingToBottom() {
   isScrollingToBottom = false
+  stayAtBottom = false
 }
 
 function hideSuperChat() {

--- a/src/renderer/components/ft-shaka-video-player/ft-shaka-video-player.css
+++ b/src/renderer/components/ft-shaka-video-player/ft-shaka-video-player.css
@@ -350,6 +350,7 @@
   .fullscreenMetadataOpen,
   .fullscreenTranscriptOpen,
   .fullscreenSponsorBlockOpen,
+  .fullscreenLiveChatOpen,
   .fullscreenCommentsOpen,
   .fullscreenPlaylistOpen,
   .chaptersOverlayOpen
@@ -358,6 +359,7 @@
   .fullscreenMetadataOpen,
   .fullscreenTranscriptOpen,
   .fullscreenSponsorBlockOpen,
+  .fullscreenLiveChatOpen,
   .fullscreenCommentsOpen,
   .fullscreenPlaylistOpen,
   .chaptersOverlayOpen
@@ -578,7 +580,7 @@
   page sidebar instead. When the comments panel is open too, chapters takes
   the available height is shared with the other open docks.
 */
-:is(.chapterOverlay, .fullscreenMetadataOverlay, .fullscreenTranscriptOverlay, .fullscreenSponsorBlockOverlay, .fullscreenCommentsOverlay, .fullscreenPlaylistOverlay) {
+:is(.chapterOverlay, .fullscreenMetadataOverlay, .fullscreenTranscriptOverlay, .fullscreenSponsorBlockOverlay, .fullscreenLiveChatOverlay, .fullscreenCommentsOverlay, .fullscreenPlaylistOverlay) {
   /* Fullscreen docks use the contrast-safe Catppuccin Mocha glass palette in
      every app theme because their background is the video, not the app page. */
   --primary-text-color: #cdd6f4;
@@ -631,6 +633,7 @@
 .fullscreenDockReorderable :is(.chapterOverlayHeader, .fullscreenMetadataHeader),
 .fullscreenDockReorderable :deep(.transcriptHeader),
 .fullscreenDockReorderable :deep(.sponsorBlockHeader),
+.fullscreenDockReorderable :deep(.liveChatDockHeader),
 .fullscreenDockReorderable :deep(.fullscreenCommentHeader),
 .fullscreenDockReorderable :deep(.playlistDockHeader) {
   cursor: grab !important;
@@ -642,6 +645,7 @@
   .fullscreenMetadataOverlay,
   .fullscreenTranscriptOverlay,
   .fullscreenSponsorBlockOverlay,
+  .fullscreenLiveChatOverlay,
   .fullscreenCommentsOverlay,
   .fullscreenPlaylistOverlay
 ) {
@@ -1707,6 +1711,7 @@
 .fullscreenMetadataOverlay,
 .fullscreenTranscriptOverlay,
 .fullscreenSponsorBlockOverlay,
+.fullscreenLiveChatOverlay,
 .fullscreenCommentsOverlay,
 .fullscreenPlaylistOverlay {
   position: absolute;
@@ -1744,6 +1749,7 @@
 .fullscreenMetadataOverlay::before,
 .fullscreenTranscriptOverlay::before,
 .fullscreenSponsorBlockOverlay::before,
+.fullscreenLiveChatOverlay::before,
 .fullscreenCommentsOverlay::before,
 .fullscreenPlaylistOverlay::before {
   content: '';
@@ -1758,6 +1764,7 @@
 .ftVideoPlayer.presentationModeChanging .fullscreenMetadataOverlay,
 .ftVideoPlayer.presentationModeChanging .fullscreenTranscriptOverlay,
 .ftVideoPlayer.presentationModeChanging .fullscreenSponsorBlockOverlay,
+.ftVideoPlayer.presentationModeChanging .fullscreenLiveChatOverlay,
 .ftVideoPlayer.presentationModeChanging .fullscreenCommentsOverlay,
 .ftVideoPlayer.presentationModeChanging .fullscreenPlaylistOverlay {
   transition: none !important;
@@ -1770,6 +1777,7 @@
 .fullscreenMetadataOverlay.open,
 .fullscreenTranscriptOverlay.open,
 .fullscreenSponsorBlockOverlay.open,
+.fullscreenLiveChatOverlay.open,
 .fullscreenCommentsOverlay.open,
 .fullscreenPlaylistOverlay.open {
   opacity: 1;
@@ -1784,6 +1792,22 @@
   block-size: 100%;
   min-block-size: 0;
   margin: 0;
+  border-radius: 0;
+  box-shadow: none;
+}
+
+.ftVideoPlayer.fullscreenLiveChatOpen .fullscreenLiveChatTarget,
+.ftVideoPlayer.fullscreenLiveChatOpen .fullscreenLiveChatTarget :deep(.watchVideoSideBar) {
+  display: flex;
+  flex: 1 1 auto;
+  min-block-size: 0;
+}
+
+.ftVideoPlayer.fullscreenLiveChatOpen .fullscreenLiveChatTarget :deep(.ft-card) {
+  box-sizing: border-box;
+  margin: 0;
+  padding: 0;
+  background-color: transparent;
   border-radius: 0;
   box-shadow: none;
 }
@@ -2063,6 +2087,7 @@
   .fullscreenMetadataTarget,
   .fullscreenTranscriptTarget,
   .fullscreenSponsorBlockTarget,
+  .fullscreenLiveChatTarget,
   .fullscreenCommentsOverlay
 ) :deep(.os-scrollbar-vertical) {
   --os-padding-axis: 0;
@@ -2104,6 +2129,7 @@
   .fullscreenMetadataOpen,
   .fullscreenTranscriptOpen,
   .fullscreenSponsorBlockOpen,
+  .fullscreenLiveChatOpen,
   .fullscreenCommentsOpen,
   .chaptersOverlayOpen
 ) .fullscreenPlaylistTarget :deep(.fullscreenPlaylistContent) {
@@ -2116,6 +2142,7 @@
   .fullscreenMetadataOpen,
   .fullscreenTranscriptOpen,
   .fullscreenSponsorBlockOpen,
+  .fullscreenLiveChatOpen,
   .fullscreenCommentsOpen,
   .chaptersOverlayOpen
 ) .fullscreenPlaylistTarget :deep(.playlistItemsWrapper) {
@@ -2150,7 +2177,7 @@
 
 .ftVideoPlayer.fullWindow .ambientFullscreenCanvas,
 .ftVideoPlayer.shortsPlayer:fullscreen .ambientFullscreenCanvas,
-.ftVideoPlayer:fullscreen:is(.fullscreenMetadataOpen, .fullscreenTranscriptOpen, .fullscreenSponsorBlockOpen, .fullscreenCommentsOpen, .fullscreenPlaylistOpen, .chaptersOverlayOpen) .ambientFullscreenCanvas {
+.ftVideoPlayer:fullscreen:is(.fullscreenMetadataOpen, .fullscreenTranscriptOpen, .fullscreenSponsorBlockOpen, .fullscreenLiveChatOpen, .fullscreenCommentsOpen, .fullscreenPlaylistOpen, .chaptersOverlayOpen) .ambientFullscreenCanvas {
   opacity: 0.42;
 }
 
@@ -2266,14 +2293,14 @@
 }
 
 /* Keep the floating fullscreen actions next to the video instead of under the panel. */
-.ftVideoPlayer:fullscreen:is(.fullscreenMetadataOpen, .fullscreenTranscriptOpen, .fullscreenSponsorBlockOpen, .fullscreenCommentsOpen, .fullscreenPlaylistOpen, .chaptersOverlayOpen) .fullscreenActions,
-.ftVideoPlayer.fullWindow:is(.fullscreenMetadataOpen, .fullscreenTranscriptOpen, .fullscreenSponsorBlockOpen, .fullscreenCommentsOpen, .fullscreenPlaylistOpen, .chaptersOverlayOpen) .fullscreenActions {
+.ftVideoPlayer:fullscreen:is(.fullscreenMetadataOpen, .fullscreenTranscriptOpen, .fullscreenSponsorBlockOpen, .fullscreenLiveChatOpen, .fullscreenCommentsOpen, .fullscreenPlaylistOpen, .chaptersOverlayOpen) .fullscreenActions,
+.ftVideoPlayer.fullWindow:is(.fullscreenMetadataOpen, .fullscreenTranscriptOpen, .fullscreenSponsorBlockOpen, .fullscreenLiveChatOpen, .fullscreenCommentsOpen, .fullscreenPlaylistOpen, .chaptersOverlayOpen) .fullscreenActions {
   inset-inline-end: calc(var(--side-panel-width) + 24px);
 }
 
 /* Keep SponsorBlock notices inside the video area when a dock is open. */
-.ftVideoPlayer:fullscreen:is(.fullscreenMetadataOpen, .fullscreenTranscriptOpen, .fullscreenSponsorBlockOpen, .fullscreenCommentsOpen, .fullscreenPlaylistOpen, .chaptersOverlayOpen) .skippedSegmentsWrapper,
-.ftVideoPlayer.fullWindow:is(.fullscreenMetadataOpen, .fullscreenTranscriptOpen, .fullscreenSponsorBlockOpen, .fullscreenCommentsOpen, .fullscreenPlaylistOpen, .chaptersOverlayOpen) .skippedSegmentsWrapper {
+.ftVideoPlayer:fullscreen:is(.fullscreenMetadataOpen, .fullscreenTranscriptOpen, .fullscreenSponsorBlockOpen, .fullscreenLiveChatOpen, .fullscreenCommentsOpen, .fullscreenPlaylistOpen, .chaptersOverlayOpen) .skippedSegmentsWrapper,
+.ftVideoPlayer.fullWindow:is(.fullscreenMetadataOpen, .fullscreenTranscriptOpen, .fullscreenSponsorBlockOpen, .fullscreenLiveChatOpen, .fullscreenCommentsOpen, .fullscreenPlaylistOpen, .chaptersOverlayOpen) .skippedSegmentsWrapper {
   inset-inline-end: calc(var(--side-panel-width) + 2%);
 }
 
@@ -3268,12 +3295,12 @@
   aside instead of covering it. Kept at the end of the file so the
   higher-specificity .player rules follow the scroll mini player ones.
 */
-.ftVideoPlayer:fullscreen:is(.fullscreenMetadataOpen, .fullscreenTranscriptOpen, .fullscreenSponsorBlockOpen, .fullscreenCommentsOpen, .fullscreenPlaylistOpen, .chaptersOverlayOpen) .player,
-.ftVideoPlayer.fullWindow:is(.fullscreenMetadataOpen, .fullscreenTranscriptOpen, .fullscreenSponsorBlockOpen, .fullscreenCommentsOpen, .fullscreenPlaylistOpen, .chaptersOverlayOpen) .player {
+.ftVideoPlayer:fullscreen:is(.fullscreenMetadataOpen, .fullscreenTranscriptOpen, .fullscreenSponsorBlockOpen, .fullscreenLiveChatOpen, .fullscreenCommentsOpen, .fullscreenPlaylistOpen, .chaptersOverlayOpen) .player,
+.ftVideoPlayer.fullWindow:is(.fullscreenMetadataOpen, .fullscreenTranscriptOpen, .fullscreenSponsorBlockOpen, .fullscreenLiveChatOpen, .fullscreenCommentsOpen, .fullscreenPlaylistOpen, .chaptersOverlayOpen) .player {
   inline-size: calc(100% - var(--side-panel-width));
 }
 
-.ftVideoPlayer:fullscreen:is(.fullscreenMetadataOpen, .fullscreenTranscriptOpen, .fullscreenSponsorBlockOpen, .fullscreenCommentsOpen, .fullscreenPlaylistOpen, .chaptersOverlayOpen) :is(
+.ftVideoPlayer:fullscreen:is(.fullscreenMetadataOpen, .fullscreenTranscriptOpen, .fullscreenSponsorBlockOpen, .fullscreenLiveChatOpen, .fullscreenCommentsOpen, .fullscreenPlaylistOpen, .chaptersOverlayOpen) :is(
   :deep(.shaka-controls-container),
   :deep(.shaka-spinner-container),
   .countdownOverlay,
@@ -3281,7 +3308,7 @@
   :deep(.shaka-text-container),
   :deep(.shaka-speech-to-text-container)
 ),
-  .ftVideoPlayer.fullWindow:is(.fullscreenMetadataOpen, .fullscreenTranscriptOpen, .fullscreenSponsorBlockOpen, .fullscreenCommentsOpen, .fullscreenPlaylistOpen, .chaptersOverlayOpen) :is(
+  .ftVideoPlayer.fullWindow:is(.fullscreenMetadataOpen, .fullscreenTranscriptOpen, .fullscreenSponsorBlockOpen, .fullscreenLiveChatOpen, .fullscreenCommentsOpen, .fullscreenPlaylistOpen, .chaptersOverlayOpen) :is(
   :deep(.shaka-controls-container),
   :deep(.shaka-spinner-container),
   .countdownOverlay,

--- a/src/renderer/components/ft-shaka-video-player/ft-shaka-video-player.js
+++ b/src/renderer/components/ft-shaka-video-player/ft-shaka-video-player.js
@@ -119,6 +119,7 @@ const FULLSCREEN_DOCK_HEADER_SELECTOR = [
   '.fullscreenMetadataHeader',
   '.transcriptHeader',
   '.sponsorBlockHeader',
+  '.liveChatDockHeader',
   '.fullscreenCommentHeader',
   '.playlistDockHeader',
 ].join(', ')
@@ -391,6 +392,10 @@ export default defineComponent({
       type: Boolean,
       default: false
     },
+    liveChatAvailable: {
+      type: Boolean,
+      default: false
+    },
     quickBookmarkEnabled: {
       type: Boolean,
       default: false
@@ -452,6 +457,7 @@ export default defineComponent({
     'fullscreen-transcript-change',
     'fullscreen-sponsorblock-change',
     'fullscreen-comments-change',
+    'fullscreen-live-chat-change',
     'fullscreen-playlist-change',
     'toggle-transcript',
     'toggle-quick-bookmark',
@@ -619,6 +625,11 @@ export default defineComponent({
     const fullscreenCommentsOverlay = ref(null)
     const showFullscreenComments = ref(false)
     /** @type {import('vue').Ref<HTMLElement | null>} */
+    const fullscreenLiveChatOverlay = ref(null)
+    /** @type {import('vue').Ref<HTMLElement | null>} */
+    const fullscreenLiveChatTarget = ref(null)
+    const showFullscreenLiveChat = ref(false)
+    /** @type {import('vue').Ref<HTMLElement | null>} */
     const fullscreenPlaylistOverlay = ref(null)
     /** @type {import('vue').Ref<HTMLElement | null>} */
     const fullscreenPlaylistTarget = ref(null)
@@ -636,7 +647,7 @@ export default defineComponent({
     const showFullscreenPlaylistAction = computed(() => !store.getters.getHidePlaylists)
     const isInAnyPlaylist = computed(() => store.getters.getPlaylistVideoCounts.has(props.videoId))
 
-    const fullscreenDockOrder = reactive(['metadata', 'transcript', 'sponsorBlock', 'comments', 'playlist', 'chapters'])
+    const fullscreenDockOrder = reactive(['metadata', 'transcript', 'sponsorBlock', 'liveChat', 'comments', 'playlist', 'chapters'])
     const fullscreenDockWeights = reactive(Object.fromEntries(fullscreenDockOrder.map(dock => [dock, 1])))
     const fullscreenDockCollapsedState = Object.fromEntries(fullscreenDockOrder.map(dock => [dock, null]))
     const fullscreenDockResizing = ref(false)
@@ -652,6 +663,7 @@ export default defineComponent({
         case 'transcript': return showFullscreenTranscript.value
         case 'sponsorBlock': return showFullscreenSponsorBlock.value
         case 'comments': return showFullscreenComments.value
+        case 'liveChat': return showFullscreenLiveChat.value
         case 'playlist': return showFullscreenPlaylist.value
         case 'chapters': return showChaptersOverlay.value && props.chapters.length > 0
         default: return false
@@ -955,6 +967,7 @@ export default defineComponent({
     let restoreFullscreenTranscript = false
     let restoreFullscreenSponsorBlock = false
     let restoreFullscreenComments = props.startWithFullscreenComments
+    let restoreFullscreenLiveChat = false
     let restoreFullscreenPlaylist = props.startWithFullscreenPlaylist
     let exitFullscreenCleanup = null
     let syncingChapterOverlayButton = false
@@ -5491,6 +5504,22 @@ export default defineComponent({
       })
     }
 
+    function setFullscreenLiveChat(shouldOpen) {
+      const open = Boolean(
+        shouldOpen && props.liveChatAvailable &&
+        (isNativeFullscreenActive() || fullWindowEnabled.value)
+      )
+      showFullscreenLiveChat.value = open
+      emit('fullscreen-live-chat-change', {
+        open,
+        target: fullscreenLiveChatTarget.value
+      })
+    }
+
+    function closeFullscreenLiveChat() {
+      setFullscreenLiveChat(false)
+    }
+
     function closeFullscreenComments() {
       setFullscreenComments(false)
     }
@@ -5587,6 +5616,7 @@ export default defineComponent({
       restoreFullscreenTranscript = showFullscreenTranscript.value
       restoreFullscreenSponsorBlock = showFullscreenSponsorBlock.value
       restoreFullscreenComments = showFullscreenComments.value
+      restoreFullscreenLiveChat = showFullscreenLiveChat.value
       restoreFullscreenPlaylist = showFullscreenPlaylist.value
     }
 
@@ -5605,6 +5635,11 @@ export default defineComponent({
       if (restoreFullscreenComments) {
         restoreFullscreenComments = false
         setFullscreenComments(true)
+      }
+
+      if (restoreFullscreenLiveChat) {
+        restoreFullscreenLiveChat = false
+        setFullscreenLiveChat(true)
       }
 
       if (restoreFullscreenMetadata) {
@@ -5634,6 +5669,10 @@ export default defineComponent({
       }
     })
 
+    watch(() => props.liveChatAvailable, available => {
+      if (!available && showFullscreenLiveChat.value) closeFullscreenLiveChat()
+    })
+
     watch(() => props.watchingPlaylist, watching => {
       if (!watching && showFullscreenPlaylist.value) {
         closeFullscreenPlaylist()
@@ -5659,6 +5698,7 @@ export default defineComponent({
         closeFullscreenMetadata()
         closeFullscreenTranscript()
         closeFullscreenSponsorBlock()
+        closeFullscreenLiveChat()
         closeFullscreenComments()
         closeFullscreenPlaylist()
       }
@@ -7591,6 +7631,7 @@ export default defineComponent({
           closeFullscreenMetadata()
           closeFullscreenTranscript()
           closeFullscreenSponsorBlock()
+          closeFullscreenLiveChat()
           closeFullscreenComments()
           closeFullscreenPlaylist()
         }
@@ -8276,6 +8317,7 @@ export default defineComponent({
       closeFullscreenMetadata()
       closeFullscreenTranscript()
       closeFullscreenSponsorBlock()
+      closeFullscreenLiveChat()
       closeFullscreenComments()
       closeFullscreenPlaylist()
       if (document.body.dataset.playerFullWindowOwner === mediaTabId) {
@@ -8476,6 +8518,7 @@ export default defineComponent({
       setFullscreenSponsorBlock,
       closeFullscreenSponsorBlock,
       closeFullscreenComments,
+      closeFullscreenLiveChat,
       closeFullscreenPlaylist,
       closeChaptersOverlay,
       toggleSponsorBlockInfo,
@@ -8596,6 +8639,11 @@ export default defineComponent({
       showFullscreenComments,
       closeFullscreenComments,
       setFullscreenComments,
+      fullscreenLiveChatOverlay,
+      fullscreenLiveChatTarget,
+      showFullscreenLiveChat,
+      closeFullscreenLiveChat,
+      setFullscreenLiveChat,
       fullscreenPlaylistOverlay,
       fullscreenPlaylistTarget,
       showFullscreenPlaylist,

--- a/src/renderer/components/ft-shaka-video-player/ft-shaka-video-player.js
+++ b/src/renderer/components/ft-shaka-video-player/ft-shaka-video-player.js
@@ -336,6 +336,10 @@ export default defineComponent({
       type: Boolean,
       default: false
     },
+    startWithFullscreenLiveChat: {
+      type: Boolean,
+      default: false
+    },
     startWithFullscreenPlaylist: {
       type: Boolean,
       default: false
@@ -967,7 +971,7 @@ export default defineComponent({
     let restoreFullscreenTranscript = false
     let restoreFullscreenSponsorBlock = false
     let restoreFullscreenComments = props.startWithFullscreenComments
-    let restoreFullscreenLiveChat = false
+    let restoreFullscreenLiveChat = props.startWithFullscreenLiveChat
     let restoreFullscreenPlaylist = props.startWithFullscreenPlaylist
     let exitFullscreenCleanup = null
     let syncingChapterOverlayButton = false
@@ -8440,6 +8444,7 @@ export default defineComponent({
      *   startNextVideoWithChapters: boolean,
      *   startNextVideoWithFullscreenMetadata: boolean,
      *   startNextVideoWithFullscreenComments: boolean,
+     *   startNextVideoWithFullscreenLiveChat: boolean,
      *   startNextVideoWithFullscreenPlaylist: boolean
      * }>}
      */
@@ -8456,6 +8461,7 @@ export default defineComponent({
         startNextVideoWithChapters: false,
         startNextVideoWithFullscreenMetadata: false,
         startNextVideoWithFullscreenComments: false,
+        startNextVideoWithFullscreenLiveChat: false,
         startNextVideoWithFullscreenPlaylist: false
       }
 
@@ -8470,6 +8476,7 @@ export default defineComponent({
             startNextVideoWithChapters: showChaptersOverlay.value,
             startNextVideoWithFullscreenMetadata: showFullscreenMetadata.value,
             startNextVideoWithFullscreenComments: showFullscreenComments.value,
+            startNextVideoWithFullscreenLiveChat: showFullscreenLiveChat.value,
             startNextVideoWithFullscreenPlaylist: showFullscreenPlaylist.value
           }
         }

--- a/src/renderer/components/ft-shaka-video-player/ft-shaka-video-player.vue
+++ b/src/renderer/components/ft-shaka-video-player/ft-shaka-video-player.vue
@@ -52,6 +52,7 @@
         fullscreenTranscriptOpen: showFullscreenTranscript,
         fullscreenSponsorBlockOpen: showFullscreenSponsorBlock,
         fullscreenCommentsOpen: showFullscreenComments,
+        fullscreenLiveChatOpen: showFullscreenLiveChat,
         fullscreenPlaylistOpen: showFullscreenPlaylist,
         chaptersOverlayOpen: showChaptersOverlay && chapters.length > 0,
         fullscreenDockResizing,
@@ -279,7 +280,7 @@
         </div>
       </Transition>
       <div
-        v-if="watchingPlaylist || commentsAvailable || useSponsorBlock || !isLive || showFullscreenShareAction || showFullscreenPlaylistAction || quickBookmarkEnabled"
+        v-if="watchingPlaylist || commentsAvailable || liveChatAvailable || useSponsorBlock || !isLive || showFullscreenShareAction || showFullscreenPlaylistAction || quickBookmarkEnabled"
         class="fullscreenActions shaka-no-propagation"
         @click.stop
         @dblclick.stop
@@ -295,6 +296,18 @@
           @click="setFullscreenPlaylist(!showFullscreenPlaylist)"
         >
           <FontAwesomeIcon :icon="['fas', 'list']" />
+        </button>
+        <button
+          v-if="liveChatAvailable"
+          type="button"
+          class="fullscreenAction fullscreenLiveChatToggle"
+          :class="{ open: showFullscreenLiveChat }"
+          :aria-label="$t('Video.Live Chat')"
+          :title="$t('Video.Live Chat')"
+          :aria-expanded="String(showFullscreenLiveChat)"
+          @click="setFullscreenLiveChat(!showFullscreenLiveChat)"
+        >
+          <FontAwesomeIcon :icon="['fas', 'message']" />
         </button>
         <button
           v-if="commentsAvailable"
@@ -582,6 +595,41 @@
         <div
           ref="fullscreenSponsorBlockTarget"
           class="fullscreenSponsorBlockTarget"
+        />
+      </aside>
+      <aside
+        ref="fullscreenLiveChatOverlay"
+        class="fullscreenLiveChatOverlay shaka-no-propagation"
+        :class="{
+          open: showFullscreenLiveChat,
+          fullscreenDockReorderable: fullscreenDockCanReorder('liveChat')
+        }"
+        :style="fullscreenDockStyle('liveChat')"
+        role="dialog"
+        :aria-label="$t('Video.Live Chat')"
+        :aria-hidden="String(!showFullscreenLiveChat)"
+        :inert="!showFullscreenLiveChat"
+        @click.stop
+        @dblclick.capture="handleFullscreenDockHeaderDoubleClick($event, 'liveChat')"
+        @dblclick.stop
+        @pointerdown.capture="handleFullscreenDockReorderPointerDown($event, 'liveChat')"
+        @pointerdown.stop
+        @wheel.stop
+        @keydown.esc.stop.prevent="closeFullscreenLiveChat"
+      >
+        <button
+          v-if="fullscreenDockCanResize('liveChat')"
+          type="button"
+          class="fullscreenDockResizeHandle"
+          :aria-label="$t('Video.Player.Resize dock', 'Resize dock')"
+          :title="$t('Video.Player.Resize dock', 'Resize dock')"
+          @pointerdown="handleFullscreenDockResizePointerDown($event, 'liveChat')"
+          @keydown="handleFullscreenDockResizeKeydown($event, 'liveChat')"
+          @dblclick.stop.prevent="resetFullscreenDockHeights"
+        />
+        <div
+          ref="fullscreenLiveChatTarget"
+          class="fullscreenLiveChatTarget"
         />
       </aside>
       <aside

--- a/src/renderer/views/Watch/Watch.js
+++ b/src/renderer/views/Watch/Watch.js
@@ -175,6 +175,7 @@ export default defineComponent({
       startNextVideoWithChapters: false,
       startNextVideoWithFullscreenMetadata: false,
       startNextVideoWithFullscreenComments: false,
+      startNextVideoWithFullscreenLiveChat: false,
       startNextVideoWithFullscreenPlaylist: false,
       isLoading: true,
       firstLoad: true,
@@ -3990,6 +3991,7 @@ export default defineComponent({
       this.startNextVideoWithChapters = uiState.startNextVideoWithChapters
       this.startNextVideoWithFullscreenMetadata = uiState.startNextVideoWithFullscreenMetadata
       this.startNextVideoWithFullscreenComments = uiState.startNextVideoWithFullscreenComments
+      this.startNextVideoWithFullscreenLiveChat = uiState.startNextVideoWithFullscreenLiveChat
       this.startNextVideoWithFullscreenPlaylist = uiState.startNextVideoWithFullscreenPlaylist
     },
 

--- a/src/renderer/views/Watch/Watch.js
+++ b/src/renderer/views/Watch/Watch.js
@@ -186,6 +186,7 @@ export default defineComponent({
       // because the instance is reused across same-tab navigation.
       hasBeenPresented: false,
       useTheatreMode: false,
+      applyDefaultTheatreModeAfterLoad: false,
       theatreLayoutAvailable: window.innerWidth > RESPONSIVE_THEATRE_MODE_MAX_WIDTH,
       videoPlayerLoaded: false,
       isFamilyFriendly: false,
@@ -285,6 +286,9 @@ export default defineComponent({
       fullscreenCommentsOpen: false,
       /** @type {HTMLElement|null} */
       fullscreenCommentsTarget: null,
+      fullscreenLiveChatOpen: false,
+      /** @type {HTMLElement|null} */
+      fullscreenLiveChatTarget: null,
       fullscreenPlaylistOpen: false,
       /** @type {HTMLElement|null} */
       fullscreenPlaylistTarget: null,
@@ -589,6 +593,7 @@ export default defineComponent({
         this.fullscreenTranscriptOpen ||
         this.fullscreenSponsorBlockOpen ||
         this.fullscreenCommentsOpen ||
+        this.fullscreenLiveChatOpen ||
         this.fullscreenPlaylistOpen
       )
     },
@@ -823,6 +828,11 @@ export default defineComponent({
       if (!loading) {
         this.shortsTransitionPreview = ''
         this.shortsTransitionDirection = 0
+
+        if (this.applyDefaultTheatreModeAfterLoad) {
+          this.applyDefaultTheatreModeAfterLoad = false
+          this.useTheatreMode = this.theatreTogglePossible
+        }
       }
     },
     isTabPresented: {
@@ -945,6 +955,13 @@ export default defineComponent({
     handleFullscreenCommentsChange({ open, target }) {
       this.fullscreenCommentsTarget = open ? target : null
       this.fullscreenCommentsOpen = open && target !== null
+    },
+    handleFullscreenLiveChatChange({ open, target }) {
+      this.fullscreenLiveChatTarget = open ? target : null
+      this.fullscreenLiveChatOpen = open && target !== null
+    },
+    closeFullscreenLiveChat() {
+      this.$refs.player?.closeFullscreenLiveChat()
     },
     closeFullscreenComments() {
       if (this.fullscreenCommentsOpen) {
@@ -1404,7 +1421,14 @@ export default defineComponent({
     setViewingModeOnFirstLoad: function () {
       switch (this.defaultViewingMode) {
         case 'theatre':
-          this.useTheatreMode = this.theatreTogglePossible
+          if (this.theatreTogglePossible) {
+            this.useTheatreMode = true
+          } else {
+            // Live chat and other sidebar panels are only known after video
+            // metadata loads. Re-evaluate once instead of permanently rejecting
+            // the configured default based on the empty loading state.
+            this.applyDefaultTheatreModeAfterLoad = true
+          }
           break
         case 'fullscreen':
         case 'fullscreen_always_on':

--- a/src/renderer/views/Watch/Watch.scss
+++ b/src/renderer/views/Watch/Watch.scss
@@ -1303,6 +1303,41 @@
   }
 }
 
+.liveChatSkeleton {
+  box-sizing: border-box;
+  block-size: 510px;
+  padding-block: 26px 16px;
+  padding-inline: 16px;
+  background: var(--card-bg-color);
+  border-radius: calc(10px * var(--ui-roundness));
+}
+
+.skeletonLiveChatTitle {
+  inline-size: 42%;
+  margin-block-end: 30px;
+}
+
+.skeletonLiveChatMessage {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  margin-block: 14px;
+}
+
+.skeletonLiveChatLine {
+  inline-size: calc(55% + var(--skeleton-offset, 0%));
+}
+
+.skeletonLiveChatMessage:nth-child(3n) .skeletonLiveChatLine {
+  inline-size: 75%;
+}
+
+.skeletonLiveChatAvatar {
+  flex: 0 0 25px;
+  block-size: 25px;
+  border-radius: 50%;
+}
+
 .recommendationsSkeleton {
   display: flex;
   flex-direction: column;

--- a/src/renderer/views/Watch/Watch.vue
+++ b/src/renderer/views/Watch/Watch.vue
@@ -117,6 +117,7 @@
           :delay-load-until-unix="adEndTimeUnixMs"
           :sponsor-block-auto-skip-disabled="sponsorBlockAutoSkipDisabled"
           :comments-available="commentsAvailable"
+          :live-chat-available="showLiveChat"
           :quick-bookmark-enabled="isQuickBookmarkEnabled"
           :quick-bookmarked="isCurrentVideoQuickBookmarked"
           :quick-bookmark-title="quickBookmarkIconText"
@@ -154,6 +155,7 @@
           @fullscreen-sponsorblock-change="handleFullscreenSponsorBlockChange"
           @toggle-transcript="toggleTranscript"
           @fullscreen-comments-change="handleFullscreenCommentsChange"
+          @fullscreen-live-chat-change="handleFullscreenLiveChatChange"
           @fullscreen-playlist-change="handleFullscreenPlaylistChange"
           @toggle-quick-bookmark="toggleCurrentVideoQuickBookmarked"
           @chapters-overlay-change="handleChaptersOverlayChange"
@@ -825,15 +827,37 @@
           />
         </transition>
       </Teleport>
-      <watch-video-live-chat
-        v-if="!isLoading && showLiveChat"
-        :live-chat="liveChat"
-        :video-id="videoId"
-        :channel-id="channelId"
-        :current-time="liveChatCurrentTime"
-        class="watchVideoSideBar watchVideoPlaylist"
-        :class="{ theatrePlaylist: useTheatreMode }"
-      />
+      <div
+        v-if="isLoading"
+        class="liveChatSkeleton watchVideoSideBar watchVideoPlaylist"
+        aria-hidden="true"
+      >
+        <div class="skeletonLine skeletonLiveChatTitle ft-shimmer" />
+        <div
+          v-for="index in 8"
+          :key="index"
+          class="skeletonLiveChatMessage"
+        >
+          <div class="skeletonLiveChatAvatar ft-shimmer" />
+          <div class="skeletonLine skeletonLiveChatLine ft-shimmer" />
+        </div>
+      </div>
+      <Teleport
+        :to="fullscreenLiveChatTarget || 'body'"
+        :disabled="!fullscreenLiveChatOpen"
+      >
+        <watch-video-live-chat
+          v-if="!isLoading && showLiveChat"
+          :live-chat="liveChat"
+          :video-id="videoId"
+          :channel-id="channelId"
+          :current-time="liveChatCurrentTime"
+          :fullscreen-overlay="fullscreenLiveChatOpen"
+          class="watchVideoSideBar watchVideoPlaylist"
+          :class="{ theatrePlaylist: useTheatreMode }"
+          @close="closeFullscreenLiveChat"
+        />
+      </Teleport>
       <watch-video-queue
         v-if="$store.getters.getWatchQueueLength > 0"
         class="watchVideoSideBar watchVideoQueue"

--- a/src/renderer/views/Watch/Watch.vue
+++ b/src/renderer/views/Watch/Watch.vue
@@ -828,7 +828,7 @@
         </transition>
       </Teleport>
       <div
-        v-if="isLoading"
+        v-if="isLoading && showLiveChat"
         class="liveChatSkeleton watchVideoSideBar watchVideoPlaylist"
         aria-hidden="true"
       >

--- a/src/renderer/views/Watch/Watch.vue
+++ b/src/renderer/views/Watch/Watch.vue
@@ -103,6 +103,7 @@
           :start-with-chapters="startNextVideoWithChapters"
           :start-with-fullscreen-metadata="startNextVideoWithFullscreenMetadata"
           :start-with-fullscreen-comments="startNextVideoWithFullscreenComments"
+          :start-with-fullscreen-live-chat="startNextVideoWithFullscreenLiveChat"
           :start-with-fullscreen-playlist="startNextVideoWithFullscreenPlaylist"
           :channel-id="channelId"
           :playlist-video-data="addToPlaylistVideoData"


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Make sure to follow the contributing guidelines. -->
<!-- Important note, we may remove your pull request if you do not use this provided PR template correctly. -->
<!-- Agent instructions: Preserve every heading, comment, and marker in this template. Never remove or rewrite the release-note-category:start/end, release-note:start/end, or release-note-image:start/end marker pairs. Never remove or rewrite the Release note images section; leave its contents for a human. -->

## Pull Request Type
<!-- Please select what type of pull request this is: [x] -->
- [ ] Bugfix
- [x] Feature Implementation
- [ ] Documentation
- [ ] Other

## Related issue
<!-- Please link the issue your pull request is referring to. -->
<!-- If this pull request fully resolves the relevant issue, put "closes" before the issue number. -->
<!-- Example: "closes #123456". -->

## Description
<!-- Please write a clear and concise description of what the pull request does. -->
Adds live and premiere chat replay to the fullscreen/full-window dock system, including stacking, resizing, reordering, standard dock controls, and a sidebar loading skeleton.

The chat now reliably follows the live edge after loading, entering fullscreen, receiving background-tab updates, or explicitly returning to live. It also restores correctly after a development hot reload and keeps the Top Chat/Live Chat filter available. Default theatre mode is reapplied after live or premiere metadata makes the chat sidebar available.

## Release note category
<!-- Select exactly one category. Every pull request must select one. -->
<!-- release-note-category:start -->
- [x] Not noteworthy
- [ ] Highlights
- [ ] More improvements
- [ ] Fixed bugs
<!-- release-note-category:end -->

## Release note
<!-- Required unless "Not noteworthy" is selected. -->
<!-- Write one concise, user-facing entry without a leading bullet. -->
<!-- release-note:start -->
Live and premiere chat can now be opened as a fullscreen dock and more reliably follows new messages.
<!-- release-note:end -->

## Release note images
<!-- Human-only: Agents must preserve this entire section and leave it empty. -->
<!-- Optional. Paste one or more Markdown images or HTML image tags here. -->
<!-- The release notes will use an HTML image tag and limit images taller than 300 pixels. -->
<!-- release-note-image:start -->

<!-- release-note-image:end -->

## Testing
<!-- How can reviewers verify that the PR produces correct results? -->
<!-- Please provide instructions so that others can ensure that your pull request would produce correct results. For examples see, https://github.com/FreeTubeApp/FreeTube/pull/5743, https://github.com/FreeTubeApp/FreeTube/pull/7349, https://github.com/FreeTubeApp/FreeTube/pull/5125, https://github.com/FreeTubeApp/FreeTube/pull/7338 -->
<!-- Agent instructions: Only write human-facing steps that explain how to verify the change while running this branch in dev mode. Include expected results and, when applicable, helpful console snippets for interactive verification. Do not include automated checks, commands, results, pass counts, or CI status. -->
1. Open a livestream or premiere replay and confirm the sidebar shows a chat skeleton while the page loads, then opens at the live edge without the down-arrow indicator.
2. Enter fullscreen or full-window mode, open the message-icon action, and confirm the chat uses the standard dock theme, shifts the video aside, and includes settings, popout (for live chat), and close actions.
3. Open another dock and verify both docks can be resized and reordered. Open chat settings, then click the other dock and confirm the settings popover closes.
4. Scroll upward to pause following, then use the down arrow and confirm subsequent messages remain anchored to the bottom, including messages received while the app tab is inactive.
5. Set theatre mode as the default viewing mode, open a livestream or premiere, and confirm theatre mode activates after the page loads.

## Additional context
<!-- Add any other context about the pull request here. -->
