### PR TITLE
fix(watch): reload once on expired YouTube watch session 403

### DIFF
--- a/e2e/tests/offline/ip-block-recovery.spec.mjs
+++ b/e2e/tests/offline/ip-block-recovery.spec.mjs
@@ -12,25 +12,30 @@ test.use({
 
 /**
  * Replays streaming URL 403s against the mounted Watch view, recording whether
- * each one reloaded the video or escalated to the IP block recovery script.
+ * each one reloaded the video, escalated to the IP block recovery script, or
+ * showed the session-expired error.
  *
  * @param {import('@playwright/test').Page} page
  * @param {number} errorCount
+ * @param {{ sessionExpired?: boolean }} [options]
  */
-async function replayStreamForbiddenErrors(page, errorCount) {
+async function replayStreamForbiddenErrors(page, errorCount, options = {}) {
   const watchView = await watchViewHandle(page)
 
-  return await watchView.evaluate(async (view, count) => {
+  return await watchView.evaluate(async (view, { count, sessionExpired }) => {
     // The state a video that is playing a DASH stream is in.
     const enterPlayingState = () => {
       view.errorMessage = ''
+      view.customErrorIcon = null
       view.isLoading = false
       view.isLive = false
       view.isPostLiveDvr = false
       view.activeFormat = 'dash'
       view.manifestMimeType = 'application/dash+xml'
-      // Not expired, so the 403 isn't attributed to a stale watch session.
-      view.streamingDataExpiryDate = new Date(Date.now() + 3_600_000)
+      // Fresh URLs for the IP-change path; past expiry for the session path.
+      view.streamingDataExpiryDate = sessionExpired
+        ? new Date(Date.now() - 60_000)
+        : new Date(Date.now() + 3_600_000)
     }
 
     enterPlayingState()
@@ -40,9 +45,9 @@ async function replayStreamForbiddenErrors(page, errorCount) {
     // The real reload runs, so that a reset of the one-shot reload state during
     // a same-video reload would show up here as an extra reload.
     const reloadView = view.reloadView.bind(view)
-    view.reloadView = async (options) => {
+    view.reloadView = async (reloadOptions) => {
       reloads.push(view.videoId)
-      await reloadView(options)
+      await reloadView(reloadOptions)
       enterPlayingState()
     }
     // Same no-op guard as the real method, so the loads that happen during a
@@ -64,11 +69,15 @@ async function replayStreamForbiddenErrors(page, errorCount) {
     const steps = []
     for (let index = 0; index < count; index++) {
       await view.handlePlayerError(forbiddenError())
-      steps.push({ reloads: reloads.length, recoveries: recoveries.length })
+      steps.push({
+        reloads: reloads.length,
+        recoveries: recoveries.length,
+        errorMessage: view.errorMessage || ''
+      })
     }
 
     return { steps, reloads, recoveries }
-  }, errorCount)
+  }, { count: errorCount, sessionExpired: !!options.sessionExpired })
 }
 
 async function openWatchPage(app, page) {
@@ -86,7 +95,7 @@ test('a streaming URL 403 reloads the video before blaming the IP', async ({ app
 
   // Our own IP changing invalidates the issued streaming URLs the same way an
   // IP block does, so the first 403 must only fetch fresh URLs.
-  expect(result.steps).toEqual([{ reloads: 1, recoveries: 0 }])
+  expect(result.steps).toEqual([{ reloads: 1, recoveries: 0, errorMessage: '' }])
 })
 
 test('a streaming URL 403 that survives the reload runs the recovery script', async ({ app, page }) => {
@@ -95,10 +104,38 @@ test('a streaming URL 403 that survives the reload runs the recovery script', as
   const result = await replayStreamForbiddenErrors(page, 2)
 
   expect(result.steps).toEqual([
-    { reloads: 1, recoveries: 0 },
-    { reloads: 1, recoveries: 1 }
+    { reloads: 1, recoveries: 0, errorMessage: '' },
+    {
+      reloads: 1,
+      recoveries: 1,
+      errorMessage: '[BAD_HTTP_STATUS: 403] Potential causes: IP block or streaming URL deciphering failed'
+    }
   ])
   expect(result.recoveries).toEqual(['jNQXAC9IVRw'])
+})
+
+test('an expired watch session 403 reloads the video before showing the error', async ({ app, page }) => {
+  await openWatchPage(app, page)
+
+  const result = await replayStreamForbiddenErrors(page, 1, { sessionExpired: true })
+
+  expect(result.steps).toEqual([{ reloads: 1, recoveries: 0, errorMessage: '' }])
+})
+
+test('an expired watch session 403 that survives the reload shows the error', async ({ app, page }) => {
+  await openWatchPage(app, page)
+
+  const result = await replayStreamForbiddenErrors(page, 2, { sessionExpired: true })
+
+  expect(result.steps).toEqual([
+    { reloads: 1, recoveries: 0, errorMessage: '' },
+    {
+      reloads: 1,
+      recoveries: 0,
+      errorMessage: '[BAD_HTTP_STATUS: 403] YouTube watch session expired. Please reopen this video.'
+    }
+  ])
+  expect(result.recoveries).toEqual([])
 })
 
 test('subscription refresh waits for an active IP block recovery', async ({ app, page }) => {

--- a/e2e/tests/offline/ip-block-recovery.spec.mjs
+++ b/e2e/tests/offline/ip-block-recovery.spec.mjs
@@ -11,26 +11,26 @@ test.use({
 })
 
 /**
- * Replays streaming URL 403s against the mounted Watch view, recording whether
- * each one reloaded the video, escalated to the IP block recovery script, or
- * showed the session-expired error.
+ * Replays streaming URL failures against the mounted Watch view, recording
+ * whether each one reloaded the video, escalated to the IP block recovery
+ * script, or showed the session-expired error.
  *
  * @param {import('@playwright/test').Page} page
  * @param {number} errorCount
- * @param {{ sessionExpired?: boolean }} [options]
+ * @param {{ sessionExpired?: boolean, legacyVideoError?: boolean }} [options]
  */
 async function replayStreamForbiddenErrors(page, errorCount, options = {}) {
   const watchView = await watchViewHandle(page)
 
-  return await watchView.evaluate(async (view, { count, sessionExpired }) => {
-    // The state a video that is playing a DASH stream is in.
+  return await watchView.evaluate(async (view, { count, sessionExpired, legacyVideoError }) => {
+    // The state a video that is playing is in for the chosen format.
     const enterPlayingState = () => {
       view.errorMessage = ''
       view.customErrorIcon = null
       view.isLoading = false
       view.isLive = false
       view.isPostLiveDvr = false
-      view.activeFormat = 'dash'
+      view.activeFormat = legacyVideoError ? 'legacy' : 'dash'
       view.manifestMimeType = 'application/dash+xml'
       // Fresh URLs for the IP-change path; past expiry for the session path.
       view.streamingDataExpiryDate = sessionExpired
@@ -58,21 +58,23 @@ async function replayStreamForbiddenErrors(page, errorCount, options = {}) {
       recoveries.push(view.videoId)
       return true
     }
-    view.showTabToast = (options) => {
-      toasts.push(typeof options === 'string' ? options : options.message)
+    view.showTabToast = (toastOptions) => {
+      toasts.push(typeof toastOptions === 'string' ? toastOptions : toastOptions.message)
     }
 
-    // 1001 = BAD_HTTP_STATUS, category 1 = NETWORK.
-    const forbiddenError = () => ({
-      severity: 2,
-      category: 1,
-      code: 1001,
-      data: ['https://example.invalid/videoplayback', 403]
-    })
+    // 1001 = BAD_HTTP_STATUS (NETWORK); 3016 = VIDEO_ERROR (MEDIA).
+    const playerError = () => legacyVideoError
+      ? { severity: 2, category: 3, code: 3016, data: [] }
+      : {
+          severity: 2,
+          category: 1,
+          code: 1001,
+          data: ['https://example.invalid/videoplayback', 403]
+        }
 
     const steps = []
     for (let index = 0; index < count; index++) {
-      await view.handlePlayerError(forbiddenError())
+      await view.handlePlayerError(playerError())
       steps.push({
         reloads: reloads.length,
         recoveries: recoveries.length,
@@ -82,7 +84,11 @@ async function replayStreamForbiddenErrors(page, errorCount, options = {}) {
     }
 
     return { steps, reloads, recoveries, toasts }
-  }, { count: errorCount, sessionExpired: !!options.sessionExpired })
+  }, {
+    count: errorCount,
+    sessionExpired: !!options.sessionExpired,
+    legacyVideoError: !!options.legacyVideoError
+  })
 }
 
 async function openWatchPage(app, page) {
@@ -171,6 +177,53 @@ test('an expired watch session 403 that survives the reload shows the error', as
       errorMessage: '[BAD_HTTP_STATUS: 403] YouTube watch session expired. Please reopen this video.',
       toasts: [
         'Reloading video after streaming URL error: [BAD_HTTP_STATUS: 403] YouTube watch session expired. Please reopen this video.'
+      ]
+    }
+  ])
+  expect(result.recoveries).toEqual([])
+})
+
+test('an expired legacy VIDEO_ERROR reloads the video before showing the error', async ({ app, page }) => {
+  await openWatchPage(app, page)
+
+  const result = await replayStreamForbiddenErrors(page, 1, {
+    sessionExpired: true,
+    legacyVideoError: true
+  })
+
+  expect(result.steps).toEqual([{
+    reloads: 1,
+    recoveries: 0,
+    errorMessage: '',
+    toasts: [
+      'Reloading video after streaming URL error: [VIDEO_ERROR] YouTube watch session expired. Please reopen this video.'
+    ]
+  }])
+})
+
+test('an expired legacy VIDEO_ERROR that survives the reload shows the error', async ({ app, page }) => {
+  await openWatchPage(app, page)
+
+  const result = await replayStreamForbiddenErrors(page, 2, {
+    sessionExpired: true,
+    legacyVideoError: true
+  })
+
+  expect(result.steps).toEqual([
+    {
+      reloads: 1,
+      recoveries: 0,
+      errorMessage: '',
+      toasts: [
+        'Reloading video after streaming URL error: [VIDEO_ERROR] YouTube watch session expired. Please reopen this video.'
+      ]
+    },
+    {
+      reloads: 1,
+      recoveries: 0,
+      errorMessage: '[VIDEO_ERROR] YouTube watch session expired. Please reopen this video.',
+      toasts: [
+        'Reloading video after streaming URL error: [VIDEO_ERROR] YouTube watch session expired. Please reopen this video.'
       ]
     }
   ])

--- a/e2e/tests/offline/ip-block-recovery.spec.mjs
+++ b/e2e/tests/offline/ip-block-recovery.spec.mjs
@@ -42,6 +42,7 @@ async function replayStreamForbiddenErrors(page, errorCount, options = {}) {
 
     const reloads = []
     const recoveries = []
+    const toasts = []
     // The real reload runs, so that a reset of the one-shot reload state during
     // a same-video reload would show up here as an extra reload.
     const reloadView = view.reloadView.bind(view)
@@ -56,6 +57,9 @@ async function replayStreamForbiddenErrors(page, errorCount, options = {}) {
       if (!view.ipBlockDetectedInCurrentChain) { return false }
       recoveries.push(view.videoId)
       return true
+    }
+    view.showTabToast = (options) => {
+      toasts.push(typeof options === 'string' ? options : options.message)
     }
 
     // 1001 = BAD_HTTP_STATUS, category 1 = NETWORK.
@@ -72,11 +76,12 @@ async function replayStreamForbiddenErrors(page, errorCount, options = {}) {
       steps.push({
         reloads: reloads.length,
         recoveries: recoveries.length,
-        errorMessage: view.errorMessage || ''
+        errorMessage: view.errorMessage || '',
+        toasts: [...toasts]
       })
     }
 
-    return { steps, reloads, recoveries }
+    return { steps, reloads, recoveries, toasts }
   }, { count: errorCount, sessionExpired: !!options.sessionExpired })
 }
 
@@ -95,7 +100,14 @@ test('a streaming URL 403 reloads the video before blaming the IP', async ({ app
 
   // Our own IP changing invalidates the issued streaming URLs the same way an
   // IP block does, so the first 403 must only fetch fresh URLs.
-  expect(result.steps).toEqual([{ reloads: 1, recoveries: 0, errorMessage: '' }])
+  expect(result.steps).toEqual([{
+    reloads: 1,
+    recoveries: 0,
+    errorMessage: '',
+    toasts: [
+      'Reloading video after streaming URL error: [BAD_HTTP_STATUS: 403] Potential causes: IP block or streaming URL deciphering failed'
+    ]
+  }])
 })
 
 test('a streaming URL 403 that survives the reload runs the recovery script', async ({ app, page }) => {
@@ -104,11 +116,21 @@ test('a streaming URL 403 that survives the reload runs the recovery script', as
   const result = await replayStreamForbiddenErrors(page, 2)
 
   expect(result.steps).toEqual([
-    { reloads: 1, recoveries: 0, errorMessage: '' },
+    {
+      reloads: 1,
+      recoveries: 0,
+      errorMessage: '',
+      toasts: [
+        'Reloading video after streaming URL error: [BAD_HTTP_STATUS: 403] Potential causes: IP block or streaming URL deciphering failed'
+      ]
+    },
     {
       reloads: 1,
       recoveries: 1,
-      errorMessage: '[BAD_HTTP_STATUS: 403] Potential causes: IP block or streaming URL deciphering failed'
+      errorMessage: '[BAD_HTTP_STATUS: 403] Potential causes: IP block or streaming URL deciphering failed',
+      toasts: [
+        'Reloading video after streaming URL error: [BAD_HTTP_STATUS: 403] Potential causes: IP block or streaming URL deciphering failed'
+      ]
     }
   ])
   expect(result.recoveries).toEqual(['jNQXAC9IVRw'])
@@ -119,7 +141,14 @@ test('an expired watch session 403 reloads the video before showing the error', 
 
   const result = await replayStreamForbiddenErrors(page, 1, { sessionExpired: true })
 
-  expect(result.steps).toEqual([{ reloads: 1, recoveries: 0, errorMessage: '' }])
+  expect(result.steps).toEqual([{
+    reloads: 1,
+    recoveries: 0,
+    errorMessage: '',
+    toasts: [
+      'Reloading video after streaming URL error: [BAD_HTTP_STATUS: 403] YouTube watch session expired. Please reopen this video.'
+    ]
+  }])
 })
 
 test('an expired watch session 403 that survives the reload shows the error', async ({ app, page }) => {
@@ -128,11 +157,21 @@ test('an expired watch session 403 that survives the reload shows the error', as
   const result = await replayStreamForbiddenErrors(page, 2, { sessionExpired: true })
 
   expect(result.steps).toEqual([
-    { reloads: 1, recoveries: 0, errorMessage: '' },
     {
       reloads: 1,
       recoveries: 0,
-      errorMessage: '[BAD_HTTP_STATUS: 403] YouTube watch session expired. Please reopen this video.'
+      errorMessage: '',
+      toasts: [
+        'Reloading video after streaming URL error: [BAD_HTTP_STATUS: 403] YouTube watch session expired. Please reopen this video.'
+      ]
+    },
+    {
+      reloads: 1,
+      recoveries: 0,
+      errorMessage: '[BAD_HTTP_STATUS: 403] YouTube watch session expired. Please reopen this video.',
+      toasts: [
+        'Reloading video after streaming URL error: [BAD_HTTP_STATUS: 403] YouTube watch session expired. Please reopen this video.'
+      ]
     }
   ])
   expect(result.recoveries).toEqual([])

--- a/src/renderer/views/Watch/Watch.js
+++ b/src/renderer/views/Watch/Watch.js
@@ -3429,6 +3429,22 @@ export default defineComponent({
           case 403:
             this.handleWatchProgressAutoSaveWhenProgressEnabled()
 
+            // Streaming URLs are bound to the IP they were issued to, so they also
+            // start returning 403 when our own IP changes (reconnect, prefix rotation,
+            // VPN switch). An expired watch session likewise needs a fresh fetch.
+            // Reload once before escalating — to the IP block recovery script, or to
+            // the session-expired error — so the genuine failure paths are unchanged
+            // apart from the extra reload before them.
+            if (!this.stream403ReloadAttemptedForCurrentVideo) {
+              this.stream403ReloadAttemptedForCurrentVideo = true
+              this.showTabToast({
+                message: this.t('Video.Reloading video after streaming URL error'),
+                icon: ['fas', 'sync'],
+              })
+              await this.reloadView()
+              return
+            }
+
             if (new Date() > this.streamingDataExpiryDate) {
               this.errorMessage = '[BAD_HTTP_STATUS: 403] YouTube watch session expired. Please reopen this video.'
               this.customErrorIcon = ['fas', 'clock']
@@ -3441,10 +3457,15 @@ export default defineComponent({
               this.errorMessage = '[BAD_HTTP_STATUS: 403] Potential causes: IP block or streaming URL deciphering failed'
             }
 
-            // Streaming URLs are bound to the IP they were issued to, so they also
-            // start returning 403 when our own IP changes (reconnect, prefix rotation,
-            // VPN switch). That looks exactly like an IP block, but fresh URLs fix it,
-            // so reload once before assuming the IP is blocked and running the script.
+            this.ipBlockDetectedInCurrentChain = true
+            await this.runIpBlockRecoveryScriptAndReload()
+            return
+        }
+      } else if (error.code === Code.VIDEO_ERROR) {
+        if (this.activeFormat === 'legacy') {
+          if (new Date() > this.streamingDataExpiryDate) {
+            this.handleWatchProgressAutoSaveWhenProgressEnabled()
+
             if (!this.stream403ReloadAttemptedForCurrentVideo) {
               this.stream403ReloadAttemptedForCurrentVideo = true
               this.showTabToast({
@@ -3454,15 +3475,6 @@ export default defineComponent({
               await this.reloadView()
               return
             }
-
-            this.ipBlockDetectedInCurrentChain = true
-            await this.runIpBlockRecoveryScriptAndReload()
-            return
-        }
-      } else if (error.code === Code.VIDEO_ERROR) {
-        if (this.activeFormat === 'legacy') {
-          if (new Date() > this.streamingDataExpiryDate) {
-            this.handleWatchProgressAutoSaveWhenProgressEnabled()
 
             this.errorMessage = '[VIDEO_ERROR] YouTube watch session expired. Please reopen this video.'
             this.customErrorIcon = ['fas', 'clock']

--- a/src/renderer/views/Watch/Watch.js
+++ b/src/renderer/views/Watch/Watch.js
@@ -3435,48 +3435,54 @@ export default defineComponent({
             // Reload once before escalating — to the IP block recovery script, or to
             // the session-expired error — so the genuine failure paths are unchanged
             // apart from the extra reload before them.
-            if (!this.stream403ReloadAttemptedForCurrentVideo) {
-              this.stream403ReloadAttemptedForCurrentVideo = true
-              this.showTabToast({
-                message: this.t('Video.Reloading video after streaming URL error'),
-                icon: ['fas', 'sync'],
-              })
-              await this.reloadView()
+            {
+              const sessionExpired = new Date() > this.streamingDataExpiryDate
+              const specificError = sessionExpired
+                ? '[BAD_HTTP_STATUS: 403] YouTube watch session expired. Please reopen this video.'
+                : this.videoGenreIsMusic
+                  ? '[BAD_HTTP_STATUS: 403] Potential causes: IP block, streaming URL deciphering failed or music video geo-block'
+                  : '[BAD_HTTP_STATUS: 403] Potential causes: IP block or streaming URL deciphering failed'
+
+              if (!this.stream403ReloadAttemptedForCurrentVideo) {
+                this.stream403ReloadAttemptedForCurrentVideo = true
+                this.showTabToast({
+                  message: `${this.t('Video.Reloading video after streaming URL error')}: ${specificError}`,
+                  icon: ['fas', 'sync'],
+                })
+                await this.reloadView()
+                return
+              }
+
+              if (sessionExpired) {
+                this.errorMessage = specificError
+                this.customErrorIcon = ['fas', 'clock']
+                return
+              }
+
+              this.errorMessage = specificError
+              this.ipBlockDetectedInCurrentChain = true
+              await this.runIpBlockRecoveryScriptAndReload()
               return
             }
-
-            if (new Date() > this.streamingDataExpiryDate) {
-              this.errorMessage = '[BAD_HTTP_STATUS: 403] YouTube watch session expired. Please reopen this video.'
-              this.customErrorIcon = ['fas', 'clock']
-              return
-            }
-
-            if (this.videoGenreIsMusic) {
-              this.errorMessage = '[BAD_HTTP_STATUS: 403] Potential causes: IP block, streaming URL deciphering failed or music video geo-block'
-            } else {
-              this.errorMessage = '[BAD_HTTP_STATUS: 403] Potential causes: IP block or streaming URL deciphering failed'
-            }
-
-            this.ipBlockDetectedInCurrentChain = true
-            await this.runIpBlockRecoveryScriptAndReload()
-            return
         }
       } else if (error.code === Code.VIDEO_ERROR) {
         if (this.activeFormat === 'legacy') {
           if (new Date() > this.streamingDataExpiryDate) {
             this.handleWatchProgressAutoSaveWhenProgressEnabled()
 
+            const specificError = '[VIDEO_ERROR] YouTube watch session expired. Please reopen this video.'
+
             if (!this.stream403ReloadAttemptedForCurrentVideo) {
               this.stream403ReloadAttemptedForCurrentVideo = true
               this.showTabToast({
-                message: this.t('Video.Reloading video after streaming URL error'),
+                message: `${this.t('Video.Reloading video after streaming URL error')}: ${specificError}`,
                 icon: ['fas', 'sync'],
               })
               await this.reloadView()
               return
             }
 
-            this.errorMessage = '[VIDEO_ERROR] YouTube watch session expired. Please reopen this video.'
+            this.errorMessage = specificError
             this.customErrorIcon = ['fas', 'clock']
             return
           }


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Make sure to follow the contributing guidelines. -->
<!-- Important note, we may remove your pull request if you do not use this provided PR template correctly. -->
<!-- Agent instructions: Preserve every heading, comment, and marker in this template. Never remove or rewrite the release-note-category:start/end, release-note:start/end, or release-note-image:start/end marker pairs. Never remove or rewrite the Release note images section; leave its contents for a human. -->

## Pull Request Type
<!-- Please select what type of pull request this is: [x] -->
- [x] Bug Fix
- [ ] Feature Implementation
- [ ] Documentation
- [ ] Other

## Related issue
<!-- Please link the issue your pull request is referring to. -->
<!-- If this pull request fully resolves the relevant issue, put "closes" before the issue number. -->
<!-- Example: "closes #123456". -->
None

## Description
<!-- Please write a clear and concise description of what the pull request does. -->
When a streaming URL returned 403 because the YouTube watch session had expired, the player showed the clock banner immediately and left the user to reopen the video by hand. The same one-shot reload already used for IP-change 403s (#523) also refreshes an expired session, so try that first.

A 403 now always reloads the video once (at most once per video). Only if that still fails do we escalate: to the session-expired error when the streaming data is past expiry, or to the IP block recovery script otherwise. The legacy `VIDEO_ERROR` session-expired path follows the same reload-once behaviour.

## Release note category
<!-- Select exactly one category. Every pull request must select one. -->
<!-- release-note-category:start -->
- [ ] Not noteworthy
- [ ] Highlights
- [ ] More improvements
- [x] Fixed bugs
<!-- release-note-category:end -->

## Release note
<!-- Required unless "Not noteworthy" is selected. -->
<!-- Write one concise, user-facing entry without a leading bullet. -->
<!-- release-note:start -->
Videos are now automatically reloaded once when the YouTube watch session expired mid-playback
<!-- release-note:end -->

## Release note images
<!-- Human-only: Agents must preserve this entire section and leave it empty. -->
<!-- Optional. Paste one or more Markdown images or HTML image tags here. -->
<!-- The release notes will use an HTML image tag and limit images taller than 300 pixels. -->
<!-- release-note-image:start -->

<!-- release-note-image:end -->

## Testing
<!-- How can reviewers verify that the PR produces correct results? -->
<!-- Please provide instructions so that others can ensure that your pull request would produce correct results. For examples see, https://github.com/FreeTubeApp/FreeTube/pull/5743, https://github.com/FreeTubeApp/FreeTube/pull/7349, https://github.com/FreeTubeApp/FreeTube/pull/5125, https://github.com/FreeTubeApp/FreeTube/pull/7338 -->
<!-- Agent instructions: Only write human-facing steps that explain how to verify the change while running this branch in dev mode. Include expected results and, when applicable, helpful console snippets for interactive verification. Do not include automated checks, commands, results, pass counts, or CI status. -->
1. Start a video and leave the watch tab open until the streaming data would normally expire (or force it from the watch-tab console as below).
2. When playback hits a 403 from the expired session, expected: a "Reloading video after streaming URL error" toast and the video coming back on its own, without the clock "YouTube watch session expired" banner.
3. To force the expired path with the watch tab's console open:

```js
const find = (v) => v?.component?.type?.name === 'Watch' ? v.component.proxy
  : (v?.component?.subTree && find(v.component.subTree)) || (Array.isArray(v?.children) && v.children.map(find).find(Boolean)) || null
const watch = find(document.querySelector('#app').__vue_app__._container._vnode)

watch.streamingDataExpiryDate = new Date(Date.now() - 60_000)
const forbidden = { severity: 2, category: 1, code: 1001, data: ['https://example.invalid/videoplayback', 403] }
await watch.handlePlayerError(forbidden) // first: reloads only
await watch.handlePlayerError(forbidden) // second: shows the session-expired banner
```

Expected: the first call only reloads; the second shows `[BAD_HTTP_STATUS: 403] YouTube watch session expired. Please reopen this video.` and does not run the IP block recovery script.

## Additional context
<!-- Add any other context about the pull request here. -->
Builds on the one-shot reload introduced in #523 for IP-change 403s.