### PR TITLE
Improve SponsorBlock UX, labels, and submission controls

### DIFF
--- a/src/renderer/components/FtSponsorBlockCategory/FtSponsorBlockCategory.css
+++ b/src/renderer/components/FtSponsorBlockCategory/FtSponsorBlockCategory.css
@@ -1,4 +1,8 @@
 .sponsorBlockCategory {
+  display: flex;
+  flex-direction: column;
+  align-items: stretch;
+  min-inline-size: 200px;
   margin-block-start: 30px;
   padding-block: 0;
   padding-inline: 10px;
@@ -6,6 +10,10 @@
 
 .sponsorTitle {
   font-size: x-large;
+}
+
+.sponsorBlockCategory :deep(.select) {
+  inline-size: 100%;
 }
 
 @media only screen and (width <= 680px) {

--- a/src/renderer/components/ft-shaka-video-player/ft-shaka-video-player.css
+++ b/src/renderer/components/ft-shaka-video-player/ft-shaka-video-player.css
@@ -1253,13 +1253,14 @@
 
 .sponsorBlockSubmissionWrapper {
   position: absolute;
-  right: 2%;
+  inset-inline-end: 2%;
   bottom: max(16%, calc(50px + 2.5% + 3%));
   z-index: 4;
   width: max-content;
   min-width: min(420px, calc(100% - 16px));
   max-width: calc(100% - 16px);
   pointer-events: auto;
+  transition: inset-inline-end 250ms ease;
 }
 
 .sponsorBlockSubmissionMenu {
@@ -1361,20 +1362,16 @@
   cursor: pointer;
 }
 
-.sponsorBlockDraftTimeInput,
-.sponsorBlockDraftCategory {
+.sponsorBlockDraftTimeInput {
+  width: 78px;
+  min-width: 78px;
   min-height: 30px;
+  box-sizing: border-box;
   padding: 4px 8px;
   border: 1px solid rgb(255 255 255 / 18%);
   border-radius: calc(4px * var(--ui-roundness));
   background-color: rgb(0 0 0 / 35%);
   color: inherit;
-}
-
-.sponsorBlockDraftTimeInput {
-  width: 78px;
-  min-width: 78px;
-  box-sizing: border-box;
 }
 
 .sponsorBlockDraftTimeText {
@@ -1393,8 +1390,36 @@
   text-align: center;
 }
 
-.sponsorBlockDraftCategory {
-  width: 100%;
+:deep(.sponsorBlockDraftCategory) {
+  inline-size: 100%;
+  margin-block-start: 16px;
+}
+
+:deep(.sponsorBlockDraftCategory .select-text),
+:deep(.sponsorBlockDraftCategory .nativeSelect) {
+  block-size: 34px;
+  padding-inline-start: 0.75rem;
+  border: 1px solid rgb(255 255 255 / 18%);
+  border-radius: calc(4px * var(--ui-roundness));
+  background-color: rgb(0 0 0 / 35%);
+  color: #fff;
+  font-size: 13px;
+}
+
+:deep(.sponsorBlockDraftCategory .select-label),
+:deep(.sponsorBlockDraftCategory .select-text ~ .select-label),
+:deep(.sponsorBlockDraftCategory .iconSelect) {
+  color: rgb(255 255 255 / 70%);
+  font-size: 12px;
+}
+
+:deep(.sponsorBlockDraftCategory .select-text ~ .select-label) {
+  inset-block-start: -16px;
+}
+
+:deep(.sponsorBlockDraftCategory .select-bar::before),
+:deep(.sponsorBlockDraftCategory .select-bar::after) {
+  background: rgb(255 255 255 / 55%);
 }
 
 .sponsorBlockDraftActions {
@@ -1526,11 +1551,16 @@
   padding: 0;
   width: 100%;
   height: 100%;
+  pointer-events: none;
 }
 
 :deep(.sponsorBlockMarker) {
+  position: absolute;
+  height: 100%;
   background-color: var(--primary-color);
-  mix-blend-mode: screen;
+
+  /* Keep category hue/saturation; use seekbar luminosity so played/buffer stay visible. */
+  mix-blend-mode: color;
 }
 
 :deep(.sponsorBlockPointMarker) {
@@ -1542,15 +1572,11 @@
 }
 
 :deep(.chapterMarker) {
-  width: 2px;
-  background-color: #000;
-}
-
-:deep(.sponsorBlockMarker),
-:deep(.chapterMarker) {
   position: absolute;
-  opacity: 0.6;
+  width: 2px;
   height: 100%;
+  background-color: #000;
+  opacity: 0.6;
 }
 
 :deep(.playerFullscreenTitleOverlay) {
@@ -2300,7 +2326,9 @@
 
 /* Keep SponsorBlock notices inside the video area when a dock is open. */
 .ftVideoPlayer:fullscreen:is(.fullscreenMetadataOpen, .fullscreenTranscriptOpen, .fullscreenSponsorBlockOpen, .fullscreenLiveChatOpen, .fullscreenCommentsOpen, .fullscreenPlaylistOpen, .chaptersOverlayOpen) .skippedSegmentsWrapper,
-.ftVideoPlayer.fullWindow:is(.fullscreenMetadataOpen, .fullscreenTranscriptOpen, .fullscreenSponsorBlockOpen, .fullscreenLiveChatOpen, .fullscreenCommentsOpen, .fullscreenPlaylistOpen, .chaptersOverlayOpen) .skippedSegmentsWrapper {
+.ftVideoPlayer.fullWindow:is(.fullscreenMetadataOpen, .fullscreenTranscriptOpen, .fullscreenSponsorBlockOpen, .fullscreenLiveChatOpen, .fullscreenCommentsOpen, .fullscreenPlaylistOpen, .chaptersOverlayOpen) .skippedSegmentsWrapper,
+.ftVideoPlayer:fullscreen:is(.fullscreenMetadataOpen, .fullscreenTranscriptOpen, .fullscreenSponsorBlockOpen, .fullscreenLiveChatOpen, .fullscreenCommentsOpen, .fullscreenPlaylistOpen, .chaptersOverlayOpen) .sponsorBlockSubmissionWrapper,
+.ftVideoPlayer.fullWindow:is(.fullscreenMetadataOpen, .fullscreenTranscriptOpen, .fullscreenSponsorBlockOpen, .fullscreenLiveChatOpen, .fullscreenCommentsOpen, .fullscreenPlaylistOpen, .chaptersOverlayOpen) .sponsorBlockSubmissionWrapper {
   inset-inline-end: calc(var(--side-panel-width) + 2%);
 }
 
@@ -2928,8 +2956,7 @@
     for the small player that a narrow window results in.
   */
   .sponsorBlockSubmissionWrapper {
-    right: 8px;
-    left: 8px;
+    inset-inline: 8px;
     width: auto;
   }
 }

--- a/src/renderer/components/ft-shaka-video-player/ft-shaka-video-player.js
+++ b/src/renderer/components/ft-shaka-video-player/ft-shaka-video-player.js
@@ -1,5 +1,6 @@
 import { computed, defineComponent, nextTick, onBeforeUnmount, onMounted, onUnmounted, reactive, ref, shallowRef, watch } from 'vue'
 import FtPaidPromotionBadge from '../FtPaidPromotionBadge/FtPaidPromotionBadge.vue'
+import FtSelect from '../FtSelect/FtSelect.vue'
 import shaka from 'shaka-player'
 import { useI18n } from 'vue-i18n'
 
@@ -173,6 +174,7 @@ export default defineComponent({
   name: 'FtShakaVideoPlayer',
   components: {
     FtPaidPromotionBadge,
+    FtSelect,
     FtShareButton,
     FtIconButton,
     FtAddToPlaylistDropdown,
@@ -1612,6 +1614,9 @@ export default defineComponent({
       sponsorBlockDraftSegments,
       sponsorBlockDraftSegmentsByVideoId,
       sponsorBlockSubmissionCategories,
+      sponsorBlockSubmissionCategoryNames,
+      getSponsorBlockActionTypeSelectNames,
+      getSponsorBlockActionTypeSelectValues,
       sponsorBlockSubmissionError,
       sponsorBlockSubmissionMenuOpen,
       sponsorBlockSubmissionPending,
@@ -8769,6 +8774,9 @@ export default defineComponent({
       sponsorBlockDraftEditValues,
       sponsorBlockDraftSegments,
       sponsorBlockSubmissionCategories,
+      sponsorBlockSubmissionCategoryNames,
+      getSponsorBlockActionTypeSelectNames,
+      getSponsorBlockActionTypeSelectValues,
       sponsorBlockSubmissionError,
       sponsorBlockSubmissionMenuOpen,
       sponsorBlockSubmissionPending,

--- a/src/renderer/components/ft-shaka-video-player/ft-shaka-video-player.vue
+++ b/src/renderer/components/ft-shaka-video-player/ft-shaka-video-player.vue
@@ -1033,46 +1033,27 @@
                   {{ sponsorBlockDraftEditValues[segment.id]?.endTime ?? '' }}
                 </span>
               </div>
-              <select
+              <FtSelect
                 class="sponsorBlockDraftCategory"
+                :placeholder="$t('Video.Player.SponsorBlock.CategoryLabel')"
                 :value="sponsorBlockDraftEditValues[segment.id]?.category ?? segment.category"
-                :aria-label="$t('Video.Player.SponsorBlock.CategoryLabel')"
-                @change="updateSponsorBlockDraftCategory(segment.id, $event.target.value)"
-              >
-                <option
-                  v-for="category in sponsorBlockSubmissionCategories"
-                  :key="category"
-                  :value="category"
-                >
-                  {{ translateSponsorBlockCategory(category) }}
-                </option>
-              </select>
-              <select
+                :select-names="sponsorBlockSubmissionCategoryNames"
+                :select-values="sponsorBlockSubmissionCategories"
+                :icon="['fas', 'list']"
+                :show-icon="false"
+                @change="updateSponsorBlockDraftCategory(segment.id, $event)"
+              />
+              <FtSelect
                 v-if="!isSponsorBlockPointSegment(segment)"
                 class="sponsorBlockDraftCategory"
+                :placeholder="$t('Video.Player.SponsorBlock.ActionTypeLabel')"
                 :value="sponsorBlockDraftEditValues[segment.id]?.actionType ?? segment.actionType"
-                :aria-label="$t('Video.Player.SponsorBlock.ActionTypeLabel')"
-                @change="updateSponsorBlockDraftActionType(segment.id, $event.target.value)"
-              >
-                <option
-                  value="skip"
-                  :disabled="(sponsorBlockDraftEditValues[segment.id]?.category ?? segment.category) === 'exclusive_access'"
-                >
-                  {{ $t('Video.Player.SponsorBlock.SkipActionType') }}
-                </option>
-                <option
-                  value="mute"
-                  :disabled="(sponsorBlockDraftEditValues[segment.id]?.category ?? segment.category) === 'exclusive_access'"
-                >
-                  {{ $t('Video.Player.SponsorBlock.MuteActionType') }}
-                </option>
-                <option
-                  value="full"
-                  :disabled="!['sponsor', 'selfpromo', 'exclusive_access'].includes(sponsorBlockDraftEditValues[segment.id]?.category ?? segment.category)"
-                >
-                  {{ $t('Video.Player.SponsorBlock.FullVideo') }}
-                </option>
-              </select>
+                :select-names="getSponsorBlockActionTypeSelectNames(sponsorBlockDraftEditValues[segment.id]?.category ?? segment.category)"
+                :select-values="getSponsorBlockActionTypeSelectValues(sponsorBlockDraftEditValues[segment.id]?.category ?? segment.category)"
+                :icon="['fas', 'forward']"
+                :show-icon="false"
+                @change="updateSponsorBlockDraftActionType(segment.id, $event)"
+              />
               <div class="sponsorBlockDraftActions">
                 <button
                   class="sponsorBlockDraftActionButton"

--- a/src/renderer/components/ft-shaka-video-player/opentubex/useSponsorBlockSubmission.js
+++ b/src/renderer/components/ft-shaka-video-player/opentubex/useSponsorBlockSubmission.js
@@ -8,6 +8,7 @@ import {
   isSponsorBlockFullVideoSegment,
   resolveSponsorBlockActionType,
 } from '../../../helpers/player/sponsorBlockFullVideo'
+import { translateSponsorBlockCategory } from '../../../helpers/player/utils'
 import { openExternalLink, showToast } from '../../../helpers/utils'
 
 const SPONSORBLOCK_SUBMISSION_CATEGORIES = Object.freeze([
@@ -696,6 +697,44 @@ export function useSponsorBlockSubmission({
     return segment.actionType === 'poi' || isSponsorBlockPointCategory(segment.category)
   }
 
+  const sponsorBlockSubmissionCategoryNames = computed(() => {
+    // Depend on i18n so labels refresh when the locale changes.
+    t('Video.Sponsor Block category.sponsor')
+    return SPONSORBLOCK_SUBMISSION_CATEGORIES.map(category => {
+      return translateSponsorBlockCategory(category, { short: false })
+    })
+  })
+
+  /**
+   * @param {string} category
+   * @returns {Array<'skip' | 'mute' | 'full'>}
+   */
+  function getSponsorBlockActionTypeSelectValues(category) {
+    if (category === 'exclusive_access') {
+      return ['full']
+    }
+
+    if (isSponsorBlockFullVideoCategory(category)) {
+      return ['skip', 'mute', 'full']
+    }
+
+    return ['skip', 'mute']
+  }
+
+  /**
+   * @param {string} category
+   * @returns {string[]}
+   */
+  function getSponsorBlockActionTypeSelectNames(category) {
+    const labels = {
+      skip: t('Video.Player.SponsorBlock.SkipActionType'),
+      mute: t('Video.Player.SponsorBlock.MuteActionType'),
+      full: t('Video.Player.SponsorBlock.FullVideo'),
+    }
+
+    return getSponsorBlockActionTypeSelectValues(category).map(value => labels[value])
+  }
+
   function isSponsorBlockDraftComplete(segment) {
     return isSponsorBlockPointSegment(segment) ||
       isSponsorBlockFullVideoSegment(segment) ||
@@ -848,6 +887,9 @@ export function useSponsorBlockSubmission({
     sponsorBlockDraftSegments,
     sponsorBlockDraftSegmentsByVideoId,
     sponsorBlockSubmissionCategories: SPONSORBLOCK_SUBMISSION_CATEGORIES,
+    sponsorBlockSubmissionCategoryNames,
+    getSponsorBlockActionTypeSelectNames,
+    getSponsorBlockActionTypeSelectValues,
     sponsorBlockSubmissionError,
     sponsorBlockSubmissionMenuOpen,
     sponsorBlockSubmissionPending,

--- a/src/renderer/helpers/player/utils.js
+++ b/src/renderer/helpers/player/utils.js
@@ -110,14 +110,20 @@ export async function getSponsorBlockSegments(videoId, categories, actionTypes) 
 }
 
 /**
+ * Map SponsorBlock API categories to locale keys under Video.Sponsor Block category.
+ * Prefer the short label (extension seekbar/skip-notice wording) when available,
+ * unless `short: false` is passed (e.g. submission / settings UI).
  * @param {SponsorBlockCategory} category
+ * @param {{ short?: boolean }} [options]
  */
-export function translateSponsorBlockCategory(category) {
+export function translateSponsorBlockCategory(category, { short = true } = {}) {
   switch (category) {
     case 'sponsor':
       return i18n.global.t('Video.Sponsor Block category.sponsor')
     case 'intro':
-      return i18n.global.t('Video.Sponsor Block category.intro')
+      return short
+        ? i18n.global.t('Video.Sponsor Block category short.intro')
+        : i18n.global.t('Video.Sponsor Block category.intro')
     case 'outro':
       return i18n.global.t('Video.Sponsor Block category.outro')
     case 'recap':
@@ -128,11 +134,17 @@ export function translateSponsorBlockCategory(category) {
     case 'selfpromo':
       return i18n.global.t('Video.Sponsor Block category.self-promotion')
     case 'interaction':
-      return i18n.global.t('Video.Sponsor Block category.interaction')
+      return short
+        ? i18n.global.t('Video.Sponsor Block category short.interaction')
+        : i18n.global.t('Video.Sponsor Block category.interaction')
     case 'music_offtopic':
-      return i18n.global.t('Video.Sponsor Block category.music offtopic')
+      return short
+        ? i18n.global.t('Video.Sponsor Block category short.music offtopic')
+        : i18n.global.t('Video.Sponsor Block category.music offtopic')
     case 'filler':
-      return i18n.global.t('Video.Sponsor Block category.filler')
+      return short
+        ? i18n.global.t('Video.Sponsor Block category short.filler')
+        : i18n.global.t('Video.Sponsor Block category.filler')
     case 'poi_highlight':
       return i18n.global.t('Video.Sponsor Block category.highlight')
     case 'exclusive_access':

--- a/src/renderer/helpers/player/utils.js
+++ b/src/renderer/helpers/player/utils.js
@@ -113,15 +113,18 @@ export async function getSponsorBlockSegments(videoId, categories, actionTypes) 
  * Map SponsorBlock API categories to locale keys under Video.Sponsor Block category.
  * Prefer the short label (extension seekbar/skip-notice wording) when available,
  * unless `short: false` is passed (e.g. submission / settings UI).
+ * Falls back to the full label when the active locale has not translated the short key yet.
  * @param {SponsorBlockCategory} category
  * @param {{ short?: boolean }} [options]
  */
 export function translateSponsorBlockCategory(category, { short = true } = {}) {
+  const locale = i18n.global.locale.value
+
   switch (category) {
     case 'sponsor':
       return i18n.global.t('Video.Sponsor Block category.sponsor')
     case 'intro':
-      return short
+      return short && i18n.global.te('Video.Sponsor Block category short.intro', locale)
         ? i18n.global.t('Video.Sponsor Block category short.intro')
         : i18n.global.t('Video.Sponsor Block category.intro')
     case 'outro':
@@ -134,15 +137,15 @@ export function translateSponsorBlockCategory(category, { short = true } = {}) {
     case 'selfpromo':
       return i18n.global.t('Video.Sponsor Block category.self-promotion')
     case 'interaction':
-      return short
+      return short && i18n.global.te('Video.Sponsor Block category short.interaction', locale)
         ? i18n.global.t('Video.Sponsor Block category short.interaction')
         : i18n.global.t('Video.Sponsor Block category.interaction')
     case 'music_offtopic':
-      return short
+      return short && i18n.global.te('Video.Sponsor Block category short.music offtopic', locale)
         ? i18n.global.t('Video.Sponsor Block category short.music offtopic')
         : i18n.global.t('Video.Sponsor Block category.music offtopic')
     case 'filler':
-      return short
+      return short && i18n.global.te('Video.Sponsor Block category short.filler', locale)
         ? i18n.global.t('Video.Sponsor Block category short.filler')
         : i18n.global.t('Video.Sponsor Block category.filler')
     case 'poi_highlight':

--- a/src/renderer/store/modules/settings.js
+++ b/src/renderer/store/modules/settings.js
@@ -327,35 +327,35 @@ const state = {
   },
   sponsorBlockSelfPromo: {
     color: 'Yellow',
-    skip: 'showInSeekBar'
+    skip: 'promptToSkip'
   },
   sponsorBlockInteraction: {
     color: 'Pink',
-    skip: 'showInSeekBar'
+    skip: 'promptToSkip'
   },
   sponsorBlockIntro: {
     color: 'Cyan',
-    skip: 'doNothing'
+    skip: 'promptToSkip'
   },
   sponsorBlockOutro: {
     color: 'Blue',
-    skip: 'doNothing'
+    skip: 'promptToSkip'
   },
   sponsorBlockRecap: {
     color: 'Indigo',
-    skip: 'doNothing'
+    skip: 'promptToSkip'
   },
   sponsorBlockHook: {
     color: 'Blue',
-    skip: 'doNothing'
+    skip: 'promptToSkip'
   },
   sponsorBlockMusicOffTopic: {
     color: 'Orange',
-    skip: 'doNothing'
+    skip: 'promptToSkip'
   },
   sponsorBlockFiller: {
     color: 'Purple',
-    skip: 'doNothing'
+    skip: 'promptToSkip'
   },
   sponsorBlockHighlight: {
     color: 'Red',

--- a/static/locales/ar.yaml
+++ b/static/locales/ar.yaml
@@ -566,7 +566,7 @@ Settings:
     Proxy Username: اسم مستخدم الوكيل
     Proxy Password: كلمة مرور الوكيل
   SponsorBlock Settings:
-    Notify when sponsor segment is skipped: تنبيه عندما يتم تخطي شريحة الراعي
+    Notify when sponsor segment is skipped: إظهار إشعار بعد تخطي فقرة ما
     'SponsorBlock API Url (Default is https://sponsor.ajay.app)': SponsorBlock API عنوان (الافتراضي هو https://sponsor.ajay.app)
     Enable SponsorBlock: تفعيل حجب الرعاة
     SponsorBlock Settings: حظر الرعاة
@@ -782,14 +782,22 @@ Video:
   Save Video: احفظ الفيديو
   Video has been removed from your saved list: تمت إزالة الفيديو من قائمتك المحفوظة
   Sponsor Block category:
-    music offtopic: موسيقى خارجة عن المألوف
-    interaction: تفاعل
-    self-promotion: الترويج الذاتي
-    outro: الخاتمة
-    intro: المقدمة
-    sponsor: الرعاة
-    filler: حشو
-    recap: الخلاصة
+    music offtopic: 'الموسيقى: مقطع لا موسيقي'
+    interaction: التذكير بالتفاعل (الاشتراك)
+    self-promotion: دعاية غير مدفوعة/ذاتية
+    outro: شاشات نهاية/الشكر و التقدير
+    intro: المقدمة/فاصل
+    sponsor: رعاية
+    filler: المتهمين/النكات
+    recap: معاينة/خلاصة
+    hook: الجذب/التحيات
+    highlight: ابراز
+    exclusive access: وصول حصري
+  Sponsor Block category short:
+    intro: انترو
+    interaction: تذكير بالتفاعل
+    music offtopic: غير موسيقي
+    filler: المتهمين
   External Player:
     Unsupported Actions:
       looping playlists: تكرار قوائم التشغيل
@@ -828,7 +836,7 @@ Video:
       Video ID: 'معرف الفيديو: {videoId}'
       Resolution: 'الدقة: {width}x{height}{''@''}{frameRate}'
       Bandwidth: 'عرض النطاق الترددي: {bandwidth} كيلوبت في الثانية'
-    Skipped segment: تم تخطي شريحة {segmentCategory}
+    Skipped segment: 'تم تخطي {segmentCategory}'
     Theatre Mode: وضع المسرح
     Exit Theatre Mode: الخروج من وضع المسرح
     Show Stats: عرض الاحصائيات

--- a/static/locales/bg.yaml
+++ b/static/locales/bg.yaml
@@ -583,7 +583,7 @@ Settings:
     Proxy Username: Потребителско име
     Proxy Password: Парола
   SponsorBlock Settings:
-    Notify when sponsor segment is skipped: Известие при пропускане на спонсориран сегмент
+    Notify when sponsor segment is skipped: Показване на известие след пропускане на сегмент
     Enable SponsorBlock: Активиране на SponsorBlock
     SponsorBlock Settings: SponsorBlock
     'SponsorBlock API Url (Default is https://sponsor.ajay.app)': SponsorBlock API адрес (по подразбиране е https://sponsor.ajay.app)
@@ -801,14 +801,22 @@ Video:
   Video has been saved: Видеото е запазено
   Save Video: Запазване на видео
   Sponsor Block category:
-    interaction: Взаимодействие
-    self-promotion: Самореклама
-    outro: Епилог
-    intro: Въведение
-    sponsor: Спонсор
-    music offtopic: Музика извън темата
-    recap: Резюме
-    filler: Запълване
+    interaction: Напомняне за действие (абониране)
+    self-promotion: Неплатена/Самореклама
+    outro: Крайни картички/Заслуги
+    intro: Антракт/Начална анимация
+    sponsor: Спонсорство
+    music offtopic: 'Музика: Част без музика'
+    recap: Кратко резюме/Обобщение
+    filler: Несвързани теми/Шеги
+    hook: Кукичка/Поздрави
+    highlight: Акцент
+    exclusive access: Ексклузивен достъп
+  Sponsor Block category short:
+    intro: Антракт
+    interaction: Напомняне за взаимодействие
+    music offtopic: Без музика
+    filler: Несвързани теми
   External Player:
     Unsupported Actions:
       looping playlists: повтаряне на плейлисти
@@ -853,7 +861,7 @@ Video:
       Dropped Frames / Total Frames: 'Изпуснати кадри: {droppedFrames} / Общо кадри: {totalFrames}'
     You appear to be offline: Изглежда, че сте офлайн.
     Playback will resume automatically when your connection comes back: Възпроизвеждането ще се възобнови автоматично, когато връзката ви се възстанови.
-    Skipped segment: Пропуснат сегмент {segmentCategory}
+    Skipped segment: '{segmentCategory} пропуснат'
     TranslatedCaptionTemplate: '{language} (преведено от "{originalLanguage}")'
     Theatre Mode: Широкоекранен режим
     Full Window: Цял прозорец
@@ -865,8 +873,8 @@ Video:
   Unlisted: Непосочен в списъка
   MembersOnly: Видеата, предназначени само за членове, не могат да се гледат с OpenTubeX, тъй като изискват вход в Google и платено членство в канала на качващия.
   DeArrow:
-    Show Original Details: Показване на оригинални данни
-    Show Modified Details: Показване на променени данни
+    Show Original Details: Показване на оригиналните детайли
+    Show Modified Details: Показване на изменените подробности
   DRMProtected: Видеата, защитени с DRM не могат да се възпроизвеждат във OpenTubeX, тъй като изискват собствени компоненти със затворен код. Ако искате да гледате това видео, моля, използвайте официалния уебсайт на YouTube в уеб браузър поддържащ DRM.
 #& Playlists
   Watched Progress Saved: Напредъка на гледането е запазен

--- a/static/locales/cs.yaml
+++ b/static/locales/cs.yaml
@@ -583,7 +583,7 @@ Settings:
     Proxy Username: Uživatelské jméno proxy
     Proxy Password: Heslo proxy
   SponsorBlock Settings:
-    Notify when sponsor segment is skipped: Upozornit při přeskočení segmentu
+    Notify when sponsor segment is skipped: Zobrazit upozornění po přeskočení segmentu
     'SponsorBlock API Url (Default is https://sponsor.ajay.app)': URL API SponsorBlock (výchozí je https://sponsor.ajay.app)
     Enable SponsorBlock: Zapnout SponsorBlock
     SponsorBlock Settings: SponsorBlock
@@ -804,14 +804,22 @@ Video:
   Save Video: Uložit video
   Video has been removed from your saved list: Video bylo odstraněno z vašeho uloženého seznamu
   Sponsor Block category:
-    music offtopic: Není hudba
-    interaction: Interakce
-    self-promotion: Sebepropagace
-    outro: Závěr
-    intro: Úvod
+    music offtopic: 'Hudba: nehudební sekce'
+    interaction: Připomenutí interakce (odběr)
+    self-promotion: Neplacená / vlastní propagace
+    outro: Koncové karty / titulky
+    intro: Přestávka / úvodní animace
     sponsor: Sponzor
-    recap: Shrnutí
-    filler: Výplň
+    recap: Náhled / shrnutí
+    filler: Mimo téma / vtipy
+    hook: Zaujetí / pozdrav
+    highlight: Zvýraznění
+    exclusive access: Exkluzivní přístup
+  Sponsor Block category short:
+    intro: Přestávka
+    interaction: Připomenutí interakce
+    music offtopic: Jiné než hudba
+    filler: Mimo téma
   External Player:
     Unsupported Actions:
       opening specific video in a playlist (falling back to opening the video): Otevření specifického videa v seznamu skladeb
@@ -849,7 +857,7 @@ Video:
       Dropped Frames / Total Frames: 'Vypuštěno snímků: {droppedFrames} / Celkem snímků: {totalFrames}'
       CodecAudio: 'Kodek: {audioCodec} ({audioItag})'
       CodecsVideoAudio: 'Kodeky: {videoCodec} ({videoItag}) / {audioCodec} ({audioItag})'
-    Skipped segment: Přeskočen segment {segmentCategory}
+    Skipped segment: 'Segment {segmentCategory} přeskočen'
     TranslatedCaptionTemplate: '{language} (přeloženo z jazyka {originalLanguage})'
     Audio Tracks: Zvukové stopy
     Theatre Mode: Režim kina

--- a/static/locales/da.yaml
+++ b/static/locales/da.yaml
@@ -559,7 +559,7 @@ Settings:
       Show In Seek Bar: Vis i statuslinje
       Do Nothing: Gør intet
     Category Color: Kategorifarve
-    Notify when sponsor segment is skipped: Underret, når et sponsorsegment springes over
+    Notify when sponsor segment is skipped: 'Vis meddelelse, når et segment er sprunget over'
     SponsorBlock Settings: SponsorBlock
     Enable SponsorBlock: Aktivér SponsorBlock
     UseDeArrowTitles: Brug DeArrow-videotitler
@@ -761,14 +761,21 @@ Video:
   Started streaming on: Begyndte at sende
   Streamed on: Sendt
   Sponsor Block category:
-    intro: Intro
+    intro: Pause-/intro-animation
     sponsor: Sponsor
     recap: Opsummering
-    music offtopic: Musik Off-topic
-    outro: Outro
-    self-promotion: Selvpromovering
-    interaction: Interaktion
-    filler: Fyldstof
+    music offtopic: 'Musik: Ikke-Musikalsk Sektion'
+    outro: Slutkort/anerkendelser
+    self-promotion: Ubetalt/selvmarkedsføring
+    interaction: Påmindelse om interaktion (abonnere)
+    filler: Sidespor/vittigheder
+    highlight: Fremhæv
+    exclusive access: Eksklusiv adgang
+  Sponsor Block category short:
+    intro: Pause
+    interaction: Påmindelse om interaktion
+    music offtopic: Ikke-Musikalsk
+    filler: Sidespor
   External Player:
     Unsupported Actions:
       opening playlists: åbner playlister
@@ -804,7 +811,7 @@ Video:
       CodecsVideoAudio: 'Codecs: {videoCodec} ({videoItag}) / {audioCodec} ({audioItag})'
       Player Dimensions: 'Afspillerens dimensioner: {width}x{height}'
       Buffered: 'Bufret: {bufferedPercentage}%'
-    Skipped segment: Sprang {segmentCategory} segment over
+    Skipped segment: '{segmentCategory} sprunget over'
     Playback will resume automatically when your connection comes back: Afspilning genoptager automatisk, når din forbindelse vender tilbage.
 #& Playlists
     Exit Full Window: Afslut fuldt vindue
@@ -828,7 +835,7 @@ Video:
   Show Super Chat Comment: Vis Super Chat-kommentar
   DeArrow:
     Show Modified Details: Vis ændrede detaljer
-    Show Original Details: Vis originale detaljer
+    Show Original Details: Vis oprindelige detaljer
   Published:
     In less than a minute: Mindre end et minut siden
   Save Watched Progress: Gem set fremskridt

--- a/static/locales/de-DE.yaml
+++ b/static/locales/de-DE.yaml
@@ -731,7 +731,7 @@ Settings:
     Failed to select IP block recovery script: Auswahl der IP-Block-Wiederherstellungsskriptdatei fehlgeschlagen
   SponsorBlock Settings:
     Notify when sponsor segment is skipped: Hinweis nach dem Überspringen eines Segments anzeigen
-    Skip notification timeout: 'Dauer der Überspringen-Meldung (Sekunden):'
+    Skip notification timeout: Timeout für Benachrichtigung bei Überspringen
     'SponsorBlock API Url (Default is https://sponsor.ajay.app)': SponsorBlock-API-URL (Standard ist https://sponsor.ajay.app)
     Enable SponsorBlock: SponsorBlock aktivieren
     Enable SponsorBlock Submission: SponsorBlock-Einreichung aktivieren

--- a/static/locales/de-DE.yaml
+++ b/static/locales/de-DE.yaml
@@ -730,8 +730,8 @@ Settings:
     Reloading video after IP block recovery: Video wird nach IP-Block-Wiederherstellung neu geladen
     Failed to select IP block recovery script: Auswahl der IP-Block-Wiederherstellungsskriptdatei fehlgeschlagen
   SponsorBlock Settings:
-    Notify when sponsor segment is skipped: Benachrichtigen, wenn ein Abschnitt übersprungen wird
-    Skip notification timeout: Timeout für Benachrichtigung bei Überspringen
+    Notify when sponsor segment is skipped: Hinweis nach dem Überspringen eines Segments anzeigen
+    Skip notification timeout: 'Dauer der Überspringen-Meldung (Sekunden):'
     'SponsorBlock API Url (Default is https://sponsor.ajay.app)': SponsorBlock-API-URL (Standard ist https://sponsor.ajay.app)
     Enable SponsorBlock: SponsorBlock aktivieren
     Enable SponsorBlock Submission: SponsorBlock-Einreichung aktivieren
@@ -982,16 +982,22 @@ Video:
   Video has been saved: Video wurde gespeichert
   Save Video: Video speichern
   Sponsor Block category:
-    music offtopic: Musik Offtopic
-    interaction: Interaktion
-    self-promotion: Eigenwerbung
-    outro: Abspann
-    intro: Intro
-    sponsor: Sponsor
+    music offtopic: 'Musik: Nicht-Musik-Abschnitt'
+    interaction: Interaktions-Erinnerung (Abonnieren usw.)
+    self-promotion: Unbezahlt/​Eigenwerbung
+    outro: Endkarten/Quellen/Anerkennungen
+    intro: Unterbrechung/Intro-Animation
+    sponsor: Gesponserte Videosegmente
     recap: Vorschau/Rückblick
-    filler: Füller
-    hook: Aufhänger/Begrüßung
+    filler: Nebensachen/Witze
+    hook: Hook/Begrüßungen
     highlight: Highlight
+    exclusive access: Exklusiver Zugriff
+  Sponsor Block category short:
+    intro: Unterbrechung
+    interaction: Interaktions-Erinnerung
+    music offtopic: Nicht-Musik
+    filler: Nebensachen
   External Player:
     OpenInTemplate: In {externalPlayer} öffnen
     Unsupported Actions:
@@ -1058,13 +1064,13 @@ Video:
       CodecsVideoAudioNoItags: 'Codecs: {videoCodec} / {audioCodec}'
     You appear to be offline: Du scheinst offline zu sein.
     Playback will resume automatically when your connection comes back: Die Wiedergabe wird automatisch fortgesetzt, wenn deine Verbindung wiederhergestellt ist.
-    Skipped segment: 'Segment {segmentCategory} übersprungen'
+    Skipped segment: '{segmentCategory} übersprungen'
     SponsorBlock:
       CancelCurrentSegment: Segmenterstellung abbrechen
-      ClearSegments: Segmente löschen
+      ClearSegments: Alle Segmente löschen
       ClearSegmentsPrompt: Bist du sicher, dass du alle entworfenen SponsorBlock-Segmente für dieses Video löschen möchtest?
       CompleteSegmentsBeforeSubmitting: Vervollständige jedes entworfene Segment, bevor du es absendest.
-      CategoryLabel: Segmentkategorie
+      CategoryLabel: Kategorie
       DeleteSegment: Löschen
       DuplicateSegments: Doppelte entworfene Segmente sind nicht erlaubt.
       EditSegment: Bearbeiten
@@ -1076,21 +1082,21 @@ Video:
       DisableAutoSkipTemporarily: SponsorBlock Überspringen vorübergehend deaktivieren
       EnableAutoSkipTemporarily: SponsorBlock Überspringen wieder aktivieren
       Guidelines: Richtlinien
-      InspectSegment: Prüfen
+      InspectSegment: Überprüfen
       InvalidStartTime: Gib eine gültige Segmentstartzeit ein.
       NoSegmentsToSubmit: Erstelle mindestens ein vollständiges Segment, bevor du es absendest.
-      NowAction: (Jetzt)
+      NowAction: (jetzt)
       CloseInfoPanel: SponsorBlock-Informationen schließen
       OpenInfoPanel: SponsorBlock-Informationen öffnen
       OpenSubmissionMenu: Einreichungsmenü öffnen
       PreviewRequired: Bitte sieh dir jedes Segment vor dem Absenden an.
       PreviewSegment: Vorschau
       SaveSegment: Speichern
-      SetSegmentEndNow: Segment jetzt beenden
+      SetSegmentEndNow: Segment endet jetzt
       StartAction: (Start)
-      StartSegmentNow: Segment jetzt starten
+      StartSegmentNow: Segment startet jetzt
       SubmissionBadRequest: SponsorBlock hat die Einreichungsanfrage abgelehnt.
-      SubmissionDuplicate: SponsorBlock sagt, dass diese Segmente bereits eingereicht wurden.
+      SubmissionDuplicate: Das wurde bereits eingereicht.
       SubmissionFailed: SponsorBlock-Segmente konnten nicht eingereicht werden.
       SubmissionForbidden: SponsorBlock hat die Einreichung abgelehnt.
       SubmissionRateLimited: SponsorBlock hat diese Einreichung rate-limitiert.
@@ -1099,16 +1105,16 @@ Video:
       SubmitSegments: Einreichen
       StartTimeLabel: Segmentstartzeit
       TimeDivider: bis
-      SkipToHighlight: Zum Highlight springen?
-      SkippedToHighlight: Zum Highlight gesprungen
+      SkipToHighlight: 'Zu Highlight springen?'
+      SkippedToHighlight: Zu Highlight gesprungen
       SkipToastUnskip: Nicht überspringen
       SkipToastReskip: Nochmal überspringen
-      SkipPrompt: '{segmentCategory} Segment überspringen?'
+      SkipPrompt: '{segmentCategory} überspringen?'
       SkipPromptAction: Überspringen
       InfoPanelTitle: SponsorBlock
-      InfoPanelLoading: Segmente werden geladen…
-      InfoPanelHasSegments: Dieses Video enthält Segmente in der Datenbank.
-      InfoPanelNoSegments: Für dieses Video wurden keine Segmente gefunden.
+      InfoPanelLoading: Segmente werden noch geladen...
+      InfoPanelHasSegments: 'Dieses Video hat Segmente in der Datenbank!'
+      InfoPanelNoSegments: Keine Segmente gefunden
       RefreshSegments: Segmente aktualisieren
       AutoSkipEnabled: Segmente automatisch überspringen
       AutoSkipOn: An
@@ -1118,10 +1124,10 @@ Video:
       RemoveChannelFromWhitelist: Kanal von der Ausnahmeliste entfernen
       SkipSegment: Segment überspringen
       CloseSegmentActions: Segmentaktionen schließen
-      FullVideo: Ganzes Video
+      FullVideo: Vollständiges Video
       LockedSegment: Gesperrtes Segment
-      UpvoteSegment: Segment positiv bewerten
-      DownvoteSegment: Segment negativ bewerten
+      UpvoteSegment: Positiv bewerten
+      DownvoteSegment: Negativ bewerten
       VoteFailed: SponsorBlock-Bewertung konnte nicht übermittelt werden.
     TranslatedCaptionTemplate: '{language} (übersetzt von {originalLanguage})'
     Exit Full Window: Vollständiges Fenster beenden
@@ -1143,7 +1149,7 @@ Video:
   AgeRestricted: Videos mit Altersbeschränkung können mit OpenTubeX nicht angesehen werden, da sie eine Google-Anmeldung und die Verwendung eines altersgeprüften YouTube-Kontos erfordern.
   DeArrow:
     Show Modified Details: Geänderte Details anzeigen
-    Show Original Details: Originaldetails anzeigen
+    Show Original Details: Originale Details anzeigen
   DRMProtected: DRM-geschützte Videos können in OpenTubeX nicht abgespielt werden, da sie proprietäre Closed-Source-Komponenten benötigen. Wenn du dieses Video ansehen möchtest, sieh es dir bitte auf der offiziellen YouTube-Website in einem DRM-fähigen Webbrowser an.
   Save Channel Playback Speed: Kanal-Wiedergabegeschwindigkeit speichern
   Channel Playback Speed Saved: Kanal-Wiedergabegeschwindigkeit gespeichert

--- a/static/locales/el.yaml
+++ b/static/locales/el.yaml
@@ -574,7 +574,7 @@ Settings:
     Ignore Default Arguments: Αγνοήστε τα προεπιλεγμένα επιχειρήματα
   SponsorBlock Settings:
     Enable SponsorBlock: Ενεργοποίηση του SponsorBlock
-    Notify when sponsor segment is skipped: Ειδοποίηση όταν παραλείπεται το τμήμα χορηγού
+    Notify when sponsor segment is skipped: Εμφάνιση ειδοποιήσεων μετά την παράλειψη κάθε τμήματος
     SponsorBlock Settings: 'SponsorBlock'
     'SponsorBlock API Url (Default is https://sponsor.ajay.app)': Διεύθυνση URL του API του SponsorBlock (Η προεπιλογή είναι https://sponsor.ajay.app)
     Skip Options:
@@ -779,14 +779,22 @@ Video:
   Video has been saved: Το βίντεο έχει αποθηκευτεί
   Save Video: Αποθήκευση βίντεο
   Sponsor Block category:
-    intro: Εισαγωγή
-    interaction: Αλληλεπίδραση
-    sponsor: Χορηγός
-    outro: Επίλογος
-    self-promotion: Αυτοπροβολή
-    music offtopic: Μουσική Εκτός θέματος
-    recap: Ανακεφαλαίωση
-    filler: Γεμιστικό
+    intro: Παύση/Εισαγωγή με Animation
+    interaction: Υπενθύμιση Αλληλεπίδρασης (Εγγραφή)
+    sponsor: Χορηγία
+    outro: Προτεινόμενα βίντεο καναλιών/Εύσημα
+    self-promotion: Αφιλοκέρδεια/Προσωπική Προώθηση
+    music offtopic: 'Μουσική: Τμήμα χωρίς μουσική'
+    recap: Προεπισκόπηση/Περίληψη
+    filler: Εφαπτόμενα/Αστεία
+    hook: Δέλεαρ/Χαιρετισμοί
+    highlight: Καλύτερη στιγμή
+    exclusive access: Αποκλειστική Πρόσβαση
+  Sponsor Block category short:
+    intro: Διάλειμμα
+    interaction: Υπενθύμιση Αλληλεπίδρασης
+    music offtopic: Χωρίς Μουσική
+    filler: Εφαπτόμενα
   External Player:
     video: βίντεο
     OpenInTemplate: Άνοιγμα σε {externalPlayer}
@@ -836,7 +844,7 @@ Video:
     Show Stats: Εμφάνιση στατιστικών στοιχείων
     Hide Stats: Απόκρυψη στατιστικών
     Audio Tracks: Κομμάτια ήχου
-    Skipped segment: Παραλείφθηκε το τμήμα {segmentCategory}
+    Skipped segment: 'Παραλείφθηκε «{segmentCategory}»'
     Playback will resume automatically when your connection comes back: Η αναπαραγωγή θα συνεχιστεί αυτόματα όταν επανέλθει η σύνδεσή σας.
     You appear to be offline: Φαίνεται ότι είστε εκτός σύνδεσης.
   MembersOnly: Τα βίντεο μόνο για μέλη δεν μπορούν να παρακολουθηθούν με το OpenTubeX, καθώς απαιτούν σύνδεση στο Google και συνδρομή επί πληρωμή στο κανάλι του μεταφορτωτή.
@@ -845,8 +853,8 @@ Video:
   IP block: Το YouTube έχει αποκλείσει τη διεύθυνση IP σας από την παρακολούθηση βίντεο. Προσπαθήστε να αλλάξετε VPN ή proxy.
   AgeRestricted: Τα βίντεο με περιορισμούς ηλικίας δεν μπορούν να παρακολουθηθούν με το OpenTubeX, καθώς απαιτούν σύνδεση στο Google και χρήση ενός λογαριασμού YouTube που έχει επαληθευτεί ως προς την ηλικία.
   DeArrow:
-    Show Original Details: Εμφάνιση αρχικών λεπτομερειών
-    Show Modified Details: Εμφάνιση τροποποιημένων λεπτομερειών
+    Show Original Details: Εμφάνιση Αρχικών Λεπτομερειών
+    Show Modified Details: Εμφάνιση Τροποποιημένων Λεπτομερειών
   More Options: Περισσότερες Επιλογές
   DRMProtected: Τα βίντεο που προστατεύονται με DRM δεν μπορούν να αναπαραχθούν στο OpenTubeX, καθώς απαιτούν ιδιόκτητα εξαρτήματα κλειστού κώδικα. Αν θέλετε να παρακολουθήσετε αυτό το βίντεο, παρακαλούμε να το παρακολουθήσετε στον επίσημο ιστότοπο του YouTube σε ένα πρόγραμμα περιήγησης ιστού με δυνατότητα DRM.
   Popout Live Chat: Αναδυόμενο παράθυρο συνομιλίας

--- a/static/locales/en-GB.yaml
+++ b/static/locales/en-GB.yaml
@@ -593,8 +593,8 @@ Settings:
     Proxy Username: Proxy Username
     Proxy Password: Proxy Password
   SponsorBlock Settings:
-    Notify when sponsor segment is skipped: Notify when sponsor segment is skipped
-    Skip notification timeout: Skip notification timeout
+    Notify when sponsor segment is skipped: Show notice after a segment is skipped
+    Skip notification timeout: 'Skip notice duration (seconds):'
     'SponsorBlock API Url (Default is https://sponsor.ajay.app)': SponsorBlock API Url (Default is https://sponsor.ajay.app)
     Enable SponsorBlock: Enable SponsorBlock
     SponsorBlock Settings: SponsorBlock
@@ -805,14 +805,22 @@ Video:
   Video has been saved: Video has been saved
   Save Video: Save Video
   Sponsor Block category:
-    music offtopic: Music offtopic
-    interaction: Interaction
-    self-promotion: Self-promotion
-    outro: Outro
-    intro: Intro
+    music offtopic: 'Music: Non-Music Section'
+    interaction: Interaction Reminder (Subscribe)
+    self-promotion: Unpaid/Self Promotion
+    outro: Endcards/Credits
+    intro: Intermission/Intro Animation
     sponsor: Sponsor
-    recap: Recap
-    filler: Filler
+    recap: Preview/Recap
+    filler: Tangents/Jokes
+    hook: Hook/Greetings
+    highlight: Highlight
+    exclusive access: Exclusive Access
+  Sponsor Block category short:
+    intro: Intermission
+    interaction: Interaction Reminder
+    music offtopic: Non-Music
+    filler: Tangents
   External Player:
     OpenInTemplate: Open in {externalPlayer}
     video: video
@@ -861,7 +869,7 @@ Video:
       CodecsVideoAudioNoItags: 'Codecs: {videoCodec} / {audioCodec}'
     You appear to be offline: You appear to be offline.
     Playback will resume automatically when your connection comes back: Playback will resume automatically when your connection comes back.
-    Skipped segment: 'Skipped {segmentCategory} segment'
+    Skipped segment: '{segmentCategory} Skipped'
     Autoplay is off: Autoplay is off
     Autoplay is on: Autoplay is on
   IP block: YouTube has blocked your IP address from watching videos. Please try switching to a different VPN or proxy.

--- a/static/locales/en-GB.yaml
+++ b/static/locales/en-GB.yaml
@@ -594,7 +594,7 @@ Settings:
     Proxy Password: Proxy Password
   SponsorBlock Settings:
     Notify when sponsor segment is skipped: Show notice after a segment is skipped
-    Skip notification timeout: 'Skip notice duration (seconds):'
+    Skip notification timeout: Skip notification timeout
     'SponsorBlock API Url (Default is https://sponsor.ajay.app)': SponsorBlock API Url (Default is https://sponsor.ajay.app)
     Enable SponsorBlock: Enable SponsorBlock
     SponsorBlock Settings: SponsorBlock

--- a/static/locales/en-US.yaml
+++ b/static/locales/en-US.yaml
@@ -1029,7 +1029,7 @@ Settings:
     Generated SponsorBlock User ID Copy Button: Copy generated SponsorBlock user ID
     Generated SponsorBlock User ID Copied: Generated SponsorBlock user ID copied to clipboard
     Notify when sponsor segment is skipped: Show notice after a segment is skipped
-    Skip notification timeout: 'Skip notice duration (seconds):'
+    Skip notification timeout: Skip notification timeout
     UseDeArrowTitles: Use DeArrow Video Titles
     UseDeArrowThumbnails: Use DeArrow for thumbnails
     'DeArrow Thumbnail Generator API Url (Default is https://dearrow-thumb.ajay.app)': 'DeArrow Thumbnail Generator API Url (Default is https://dearrow-thumb.ajay.app)'

--- a/static/locales/en-US.yaml
+++ b/static/locales/en-US.yaml
@@ -1028,8 +1028,8 @@ Settings:
     Export Generated User ID: Export Generated User ID
     Generated SponsorBlock User ID Copy Button: Copy generated SponsorBlock user ID
     Generated SponsorBlock User ID Copied: Generated SponsorBlock user ID copied to clipboard
-    Notify when sponsor segment is skipped: Notify when sponsor segment is skipped
-    Skip notification timeout: Skip notification timeout
+    Notify when sponsor segment is skipped: Show notice after a segment is skipped
+    Skip notification timeout: 'Skip notice duration (seconds):'
     UseDeArrowTitles: Use DeArrow Video Titles
     UseDeArrowThumbnails: Use DeArrow for thumbnails
     'DeArrow Thumbnail Generator API Url (Default is https://dearrow-thumb.ajay.app)': 'DeArrow Thumbnail Generator API Url (Default is https://dearrow-thumb.ajay.app)'
@@ -1337,16 +1337,22 @@ Video:
     Show Modified Details: Show Modified Details
   Sponsor Block category:
     sponsor: Sponsor
-    intro: Intro
-    outro: Outro
-    self-promotion: Self-Promotion
-    interaction: Interaction
-    music offtopic: Music Offtopic
-    recap: Recap
+    intro: Intermission/Intro Animation
+    outro: Endcards/Credits
+    self-promotion: Unpaid/Self Promotion
+    interaction: Interaction Reminder (Subscribe)
+    music offtopic: 'Music: Non-Music Section'
+    recap: Preview/Recap
     hook: Hook/Greetings
-    filler: Filler
+    filler: Tangents/Jokes
     highlight: Highlight
     exclusive access: Exclusive Access
+  # Short labels used on the seekbar / skip notices (matches SponsorBlock extension)
+  Sponsor Block category short:
+    intro: Intermission
+    interaction: Interaction Reminder
+    music offtopic: Non-Music
+    filler: Tangents
   External Player:
     OpenInTemplate: Open in {externalPlayer}
     video: video
@@ -1417,13 +1423,13 @@ Video:
       Play: Play
       Pause: Pause
       Drag Handle: Move mini player
-    Skipped segment: 'Skipped {segmentCategory} segment'
+    Skipped segment: '{segmentCategory} Skipped'
     SponsorBlock:
       CancelCurrentSegment: Cancel Creating Segment
       ClearSegments: Clear Segments
       ClearSegmentsPrompt: Are you sure you want to clear all drafted SponsorBlock segments for this video?
       CompleteSegmentsBeforeSubmitting: Complete every drafted segment before submitting.
-      CategoryLabel: Segment category
+      CategoryLabel: Category
       ActionTypeLabel: Segment type
       DeleteSegment: Delete
       DuplicateSegments: Duplicate drafted segments are not allowed.
@@ -1450,7 +1456,7 @@ Video:
       StartAction: (Start)
       StartSegmentNow: Start Segment Now
       SubmissionBadRequest: SponsorBlock rejected the submission request.
-      SubmissionDuplicate: SponsorBlock says these segments were already submitted.
+      SubmissionDuplicate: This has already been submitted before.
       SubmissionFailed: Failed to submit SponsorBlock segments.
       SubmissionForbidden: SponsorBlock rejected the submission.
       SubmissionRateLimited: SponsorBlock rate limited this submission.
@@ -1459,18 +1465,18 @@ Video:
       SubmitSegments: Submit
       StartTimeLabel: Segment start time
       TimeDivider: to
-      SkipPrompt: Skip {segmentCategory} segment?
+      SkipPrompt: 'Skip {segmentCategory}?'
       SkipPromptAction: Skip
       SkipToHighlight: Skip to Highlight?
       SkippedToHighlight: Skipped to Highlight
       SkipToastUnskip: Unskip
       SkipToastReskip: Reskip
-      MutedSegment: Muted {segmentCategory} segment
+      MutedSegment: '{segmentCategory} Muted'
       MuteToastUnmute: Unmute
       InfoPanelTitle: SponsorBlock
-      InfoPanelLoading: Loading segments…
-      InfoPanelHasSegments: This video has segments in the database.
-      InfoPanelNoSegments: No segments were found for this video.
+      InfoPanelLoading: Segments still loading...
+      InfoPanelHasSegments: 'This video has segments in the database!'
+      InfoPanelNoSegments: No segments found
       RefreshSegments: Refresh segments
       AutoSkipEnabled: Automatically skip segments
       AutoSkipOn: 'On'
@@ -1484,11 +1490,11 @@ Video:
       FullVideo: Full Video
       FullVideoLabel: '{segmentCategory} · Full Video'
       MuteActionType: Mute
-      MutePrompt: Mute {segmentCategory} segment?
+      MutePrompt: 'Mute {segmentCategory}?'
       SkipActionType: Skip
       LockedSegment: Locked segment
-      UpvoteSegment: Upvote segment
-      DownvoteSegment: Downvote segment
+      UpvoteSegment: Upvote
+      DownvoteSegment: Downvote
       VoteFailed: Failed to submit SponsorBlock vote.
   Watch:
     'Remaining preroll-ad time: {remindingTimeSeconds}s': 'Remaining preroll-ad time: {remindingTimeSeconds}s'

--- a/static/locales/es-AR.yaml
+++ b/static/locales/es-AR.yaml
@@ -474,7 +474,7 @@ Settings:
     Proxy Host: Host del Proxy
     Proxy Warning: OpenTubeX no tiene un proxy integrado, pero puede conectarse a un proxy externo, como uno que se esté ejecutando en tu máquina (como Tor) o un proxy externo, como un proxy SOCKS5 provisto por algunas VPNs. Si activás esta opción, asegurate de que tu proxy o Tor esté configurado correctamente, de lo contrario OpenTubeX no podrá obtener datos.
   SponsorBlock Settings:
-    Notify when sponsor segment is skipped: Notificar cuando el tramo publicitario es omitido
+    Notify when sponsor segment is skipped: Mostrar aviso después de que se omita un segmento
     'SponsorBlock API Url (Default is https://sponsor.ajay.app)': URL de la API de SponsorBlock (https://sponsor.ajay.app por defecto)
     Skip Options:
       Skip Option: Omitir opción

--- a/static/locales/es-MX.yaml
+++ b/static/locales/es-MX.yaml
@@ -424,7 +424,7 @@ Settings:
     SponsorBlock Settings: Configuración de SponsorBlock
     Enable SponsorBlock: Habilitar SponsorBlock
     'SponsorBlock API Url (Default is https://sponsor.ajay.app)': URL de la API de SponsorBlock (https://sponsor.ajay.app por defecto)
-    Notify when sponsor segment is skipped: Notificar cuando el tramo publicitario es omitido
+    Notify when sponsor segment is skipped: Mostrar aviso después de que se omita un segmento
   Sort Settings Sections (A-Z): Ordenar secciones de configuración (A-Z)
   Return to Settings Menu: Volver al menú de configuración
 About:
@@ -526,12 +526,22 @@ Video:
     video: video
     playlist: lista de reproducción
   Sponsor Block category:
-    interaction: interacción
-    sponsor: publicitante
-    intro: introducción
-    outro: final
-    self-promotion: auto-promoción
-    music offtopic: música irrelevante
+    interaction: Recordatorio de Interacción (Suscribir)
+    sponsor: Sponsor
+    intro: Intermisión/Animación de Introducción
+    outro: Tarjetas/Créditos
+    self-promotion: Promoción Propia/No Remunerada
+    music offtopic: 'Música: Sección sin musica'
+    recap: Vista previa/Recapitulación
+    hook: Gancho/Saludos
+    filler: Desvíos/Bromas
+    highlight: Destacado
+    exclusive access: Acceso Exclusivo
+  Sponsor Block category short:
+    intro: Intermisión
+    interaction: Recordatorio de Interacción
+    music offtopic: Sin Música
+    filler: Tangentes
   Save Video: Guardar video
   Streamed on: Transmitido en
   Open Channel in YouTube: Abrir canal en YouTube

--- a/static/locales/es.yaml
+++ b/static/locales/es.yaml
@@ -568,7 +568,7 @@ Settings:
     Proxy Password: Contraseña del proxy
     Proxy Username: Nombre de Usuario del proxy
   SponsorBlock Settings:
-    Notify when sponsor segment is skipped: Notificar cuando se salta un segmento de patrocinio
+    Notify when sponsor segment is skipped: Mostrar aviso después de que se omita un segmento
     'SponsorBlock API Url (Default is https://sponsor.ajay.app)': URL de la API de SponsorBlock (por defecto es https://sponsor.ajay.app)
     Enable SponsorBlock: Activar SponsorBlock
     SponsorBlock Settings: SponsorBlock
@@ -785,14 +785,22 @@ Video:
   Video has been saved: El vídeo ha sido guardado
   Save Video: Guardar el vídeo
   Sponsor Block category:
-    music offtopic: No relacionado con la música
-    interaction: Interacción
-    self-promotion: Auto promoción
-    outro: Epílogo
-    intro: Introducción
-    sponsor: Patrocinador
-    recap: Recapitulación
-    filler: Relleno
+    music offtopic: 'Música: Sección sin musica'
+    interaction: Recordatorio de Interacción (Suscribir)
+    self-promotion: Promoción Propia/No Remunerada
+    outro: Tarjetas/Créditos
+    intro: Intermisión/Animación de Introducción
+    sponsor: Sponsor
+    recap: Vista previa/Recapitulación
+    filler: Desvíos/Bromas
+    hook: Gancho/Saludos
+    highlight: Destacado
+    exclusive access: Acceso Exclusivo
+  Sponsor Block category short:
+    intro: Intermisión
+    interaction: Recordatorio de Interacción
+    music offtopic: Sin Música
+    filler: Tangentes
   External Player:
     playlist: lista de reproducción
     video: vídeo
@@ -837,7 +845,7 @@ Video:
       CodecsVideoAudioNoItags: 'Códecs: {videoCodec} / {audioCodec}'
     You appear to be offline: Parece que no tienes conexión.
     Playback will resume automatically when your connection comes back: La reproducción se reanudará automáticamente cuando se restablezca la conexión.
-    Skipped segment: Segmento {segmentCategory} omitido
+    Skipped segment: '{segmentCategory} Omitido/as'
     Audio Tracks: Pistas de audio
     Theatre Mode: Modo cine
     Exit Theatre Mode: Salir del modo cine
@@ -849,8 +857,8 @@ Video:
   Unlisted: No listado
   AgeRestricted: Los vídeos con restricciones de edad no se pueden ver con OpenTubeX ya que requieren iniciar sesión en Google y usar una cuenta de YouTube verificada por edad.
   DeArrow:
-    Show Original Details: Mostrar detalles originales
-    Show Modified Details: Mostrar detalles modificados
+    Show Original Details: Mostrar Detalles Originales
+    Show Modified Details: Mostrar Detalles Modificados
 #& Playlists
   DRMProtected: Los videos restringidos con DRM no pueden reproducirse en OpenTubeX, dado que requieren componentes propietarias de fuente cerrada. Si desea ver este video, por favor véalo en la página oficial de YouTube con un buscador que tenga DRM habilitado.
   Watched Progress Saved: Progreso de visualización guardado

--- a/static/locales/et.yaml
+++ b/static/locales/et.yaml
@@ -582,7 +582,7 @@ Settings:
     Proxy Password: Puhverserveri salasõna
   The app needs to restart for changes to take effect. Restart and apply change?: See rakendus vajab muudatuste jõustamiseks uuesti käivitamist. Kas teeme seda nüüd?
   SponsorBlock Settings:
-    Notify when sponsor segment is skipped: Anna teada, kui toetajate vaade jääb vahele
+    Notify when sponsor segment is skipped: Kuva segmendi vahelejätmisel teatis
     'SponsorBlock API Url (Default is https://sponsor.ajay.app)': Sponsorite blokeerija API URL (vaikimisi https://sponsor.ajay.app)
     Enable SponsorBlock: Kasuta sponsorite blokeerijat
     SponsorBlock Settings: Sponsorite blokeerija
@@ -800,14 +800,21 @@ Video:
   Started streaming on: Voogedastus algas
   Streamed on: Voogedastatud
   Sponsor Block category:
-    music offtopic: Esitatava muusika teemaväline teave
-    self-promotion: Enesereklaam
-    interaction: Suhtlus
-    intro: Sissejuhatus
-    outro: Lõputiitrid
+    music offtopic: 'Muusika: mitte-muusika jaotis'
+    self-promotion: Tasumata/enesepromo
+    interaction: Tegutsemise meeldetuletus (kanali tellimine)
+    intro: Vaheaeg/sissejuhatav animatsioon
+    outro: Lõpukaardid/-tiitrid
     sponsor: Sponsor
-    filler: Täitevideo
+    filler: Teemavahetus/Naljad
     recap: Kokkuvõte
+    highlight: Esiletõst
+    exclusive access: Eksklusiivne ligipääs
+  Sponsor Block category short:
+    intro: Vaheaeg
+    interaction: Tegutsemise meeldetuletus
+    music offtopic: Mitte-muusika
+    filler: Teemavahetused
   External Player:
     UnsupportedActionTemplate: 'Rakenduses {externalPlayer} puudub tugi: {action}'
     OpeningTemplate: Avan {videoOrPlaylist} {externalPlayer} rakendusega...
@@ -851,7 +858,7 @@ Video:
       Resolution: 'Mõõdud ja kaadrisagedus: {width}x{height}{''@''}{frameRate}'
       Player Dimensions: 'Meediamängija mõõdud: {width}x{height}'
       Dropped Frames / Total Frames: 'Vahelejäetud kaadreid: {droppedFrames} / Kaadreid kokku: {totalFrames}'
-    Skipped segment: Vahelejäetud {segmentCategory} segment
+    Skipped segment: '{segmentCategory} vahelejäetud'
     TranslatedCaptionTemplate: '{language} (algne keel „{originalLanguage}“)'
     Exit Full Window: Välju täisekraanivaatest
     Hide Stats: Peida statistika

--- a/static/locales/fa.yaml
+++ b/static/locales/fa.yaml
@@ -664,7 +664,7 @@ Video:
   Views: دیده شده ها
   Live Chat is currently not supported in this build.: گفتگوی زنده در حال حاضر در این ساخت پشتیبانی نمی شود.
   Sponsor Block category:
-    sponsor: حامی
+    sponsor: اسپانسر
     intro: معرفی
     self-promotion: خود تبلیغی
     filler: پرکننده
@@ -672,6 +672,10 @@ Video:
     music offtopic: موسیقی آف تاپیک
     interaction: تعامل
     outro: دیگر
+    highlight: برجسته
+    exclusive access: دسترسی اختصاصی
+  Sponsor Block category short:
+    music offtopic: غیر موسیقی
   Loop Playlist: حلقه پخش لیست
   Live Now: زنده هم اکنون
   Save Video: ذخیره ویدیو
@@ -725,7 +729,7 @@ Video:
       CodecsVideoAudioNoItags: 'کدک‌ها: {videoCodec} / {audioCodec}'
     Take Screenshot: گرفتن عکس صفحه
     Show Stats: نمایش اطلاعات
-    Skipped segment: بخش {segmentCategory} رد شد
+    Skipped segment: '{segmentCategory} رد شد'
     TranslatedCaptionTemplate: '{language} (ترجمه شده از "{originalLanguage}")'
     Hide Stats: مخفی کردن اطلاعات
     Full Window: تمام‌صفحه

--- a/static/locales/fi.yaml
+++ b/static/locales/fi.yaml
@@ -557,7 +557,7 @@ Settings:
     Proxy Username: Välityspalvelimen käyttäjänimi
     Proxy Password: Välityspalvelimen salasana
   SponsorBlock Settings:
-    Notify when sponsor segment is skipped: Ilmoita sponsoriosuuden yli hypättäessä
+    Notify when sponsor segment is skipped: Näytä ilmoitus ohitetun osion jälkeen
     'SponsorBlock API Url (Default is https://sponsor.ajay.app)': SponsorBlock-sponsorieston API-ohjelmointirajapinnan Url-osoite (vakio-osoite on https://sponsor.ajay.app)
     Enable SponsorBlock: Kytke SponsorBlock-sponsoriesto päälle
     SponsorBlock Settings: SponsorBlock
@@ -742,14 +742,22 @@ Video:
     video: video
     OpenInTemplate: Avaa käyttäen {externalPlayer}
   Sponsor Block category:
-    music offtopic: Musiikki aihepiirin ulkopuolelta
-    interaction: Kanssakäyminen
-    self-promotion: Itsepromootio
-    outro: Loppu
-    intro: Alku
+    music offtopic: 'Musiikki: Musiikiton osa'
+    interaction: Vuorovaikutusmuistutus (tilaaminen)
+    self-promotion: Maksamaton/Itsensä mainostus
+    outro: Loppukortit/-tekstit
+    intro: Tauko/Introanimaatio
     sponsor: Sponsori
-    recap: Kertaus
-    filler: Täyte
+    recap: Esikatselu/Kertaus
+    filler: Toissijaiset kohtaukset/Vitsit
+    hook: Koukku/Tervehdykset
+    highlight: Kohokohta
+    exclusive access: Yksinoikeudellinen ensikatsaus
+  Sponsor Block category short:
+    intro: Tauko
+    interaction: Vuorovaikutusmuistutus
+    music offtopic: Musiikiton
+    filler: Toissijaiset kohtaukset
   Video has been removed from your saved list: Video poistettiin tallennettujen videoiden luettelostasi
   Video has been saved: Video on tallennettu
   Save Video: Tallenna video
@@ -771,7 +779,7 @@ Video:
   Unlisted: Listaamaton
   DeArrow:
     Show Original Details: Näytä alkuperäiset tiedot
-    Show Modified Details: Näytä muokatut yksityiskohdat
+    Show Modified Details: Näytä muokatut tiedot
   Player:
     TranslatedCaptionTemplate: '{language} (käännetty kielestä "{originalLanguage}")'
     Autoplay is off: Automaattinen toisto on pois päältä
@@ -799,7 +807,7 @@ Video:
       Dropped Frames / Total Frames: 'Pudotetut kehykset: {droppedFrames} / Kehyksiä yhteensä: {totalFrames}'
     You appear to be offline: Näytät olevan offline-tilassa.
     Playback will resume automatically when your connection comes back: Toisto jatkuu automaattisesti, kun verkkoyhteytesi palautuu.
-    Skipped segment: Ohitettu {segmentCategory} osio
+    Skipped segment: '{segmentCategory} ohitettu'
     Audio Tracks: Ääniraitoja
   Watch:
     'Remaining preroll-ad time: {remindingTimeSeconds}s': 'Mainosta jäljellä: {remindingTimeSeconds} s'

--- a/static/locales/fr-FR.yaml
+++ b/static/locales/fr-FR.yaml
@@ -572,7 +572,7 @@ Settings:
     Proxy Password: Mot de passe du proxy
     Proxy Username: Nom d'utilisateur du proxy
   SponsorBlock Settings:
-    Notify when sponsor segment is skipped: Notification lorsqu’un segment sponsorisé est ignoré
+    Notify when sponsor segment is skipped: 'Notifier après qu''un segment a été sauté'
     'SponsorBlock API Url (Default is https://sponsor.ajay.app)': 'URL de l’API SponsorBlock (par défaut : https://sponsor.ajay.app)'
     Enable SponsorBlock: Activer SponsorBlock
     SponsorBlock Settings: SponsorBlock
@@ -753,14 +753,22 @@ Video:
   Video has been saved: La vidéo a été enregistrée
   Save Video: Enregistrer la vidéo
   Sponsor Block category:
-    music offtopic: Musique hors sujet
-    interaction: Interaction
-    sponsor: Sponsor
-    self-promotion: Autopromotion
-    outro: Conclusion
-    intro: Intro
-    filler: Bouche-trou
-    recap: Récap
+    music offtopic: 'Musique : Segment non musical'
+    interaction: 'Rappel d''interaction (abonnement)'
+    sponsor: Message sponsorisé
+    self-promotion: Non rémunéré/autopromotion
+    outro: Écrans de fin/Crédits
+    intro: 'Entracte/Animation d''introduction'
+    filler: Digressions/Blagues
+    recap: Aperçu/Résumé
+    hook: Accroche/Salutations
+    highlight: Temps fort
+    exclusive access: Accès exclusif
+  Sponsor Block category short:
+    intro: Entracte
+    interaction: 'Rappel d''interaction'
+    music offtopic: Section non musicale
+    filler: Digressions
   External Player:
     playlist: playlist
     video: vidéo
@@ -804,7 +812,7 @@ Video:
       CodecsVideoAudioNoItags: 'Codecs : {videoCodec} / {audioCodec}'
       CodecsVideoAudio: 'Codecs : {videoCodec} ({videoItag}) / {audioCodec} ({audioItag})'
       Dropped Frames / Total Frames: 'Images perdues : {droppedFrames} / Images totales : {totalFrames}'
-    Skipped segment: Segment {segmentCategory} ignoré
+    Skipped segment: '{segmentCategory} ignoré'
     TranslatedCaptionTemplate: '{language} (traduit depuis : {originalLanguage})'
     Exit Full Window: Quitter le plein écran
     Take Screenshot: Prendre une capture d'écran
@@ -817,8 +825,8 @@ Video:
   AgeRestricted: Les vidéos soumises à des restrictions d'âge ne peuvent pas être regardées avec OpenTubeX car elles nécessitent une connexion Google et l'utilisation d'un compte YouTube dont l'âge a été vérifié.
   MembersOnly: Les vidéos réservées aux membres ne peuvent pas être visionnées avec OpenTubeX, car elles nécessitent une connexion Google et une adhésion payante à la chaîne du vidéaste.
   DeArrow:
-    Show Original Details: Afficher les détails originaux
-    Show Modified Details: Afficher les détails modifiés
+    Show Original Details: 'Montrer les détails d''origine'
+    Show Modified Details: Montrer les détails modifiés
   DRMProtected: Les vidéos protégées par DRM ne peuvent pas être lues dans OpenTubeX, car elles nécessitent des composants propriétaires et à source fermée. Si vous souhaitez regarder cette vidéo, veuillez la visionner sur le site officiel de YouTube dans un navigateur Web prenant en charge le DRM.
 #& Playlists
   Save Watched Progress: Enregistrer l'état de visionnage

--- a/static/locales/he.yaml
+++ b/static/locales/he.yaml
@@ -576,7 +576,7 @@ Settings:
         Name: ללא
     Ignore Default Arguments: התעלם מפרמטרים ברירת מחדל
   SponsorBlock Settings:
-    Notify when sponsor segment is skipped: להודיע לגבי דילוג על קטע החסוּת
+    Notify when sponsor segment is skipped: הצג הודעה לאחר דילוג על מקטע
     SponsorBlock Settings: חוסם מממנים
     Enable SponsorBlock: הפעלת חוסם מממנים
     'SponsorBlock API Url (Default is https://sponsor.ajay.app)': כתובת ה־API של חוסם המממנים (ברירת המחדל היא https://sponsor.ajay.app)
@@ -783,14 +783,21 @@ Video:
   Video has been saved: סרטון נשמר
   Save Video: שמירת סרטון
   Sponsor Block category:
-    outro: סיום
-    self-promotion: קידום עצמי
-    interaction: אינטראקציה
+    outro: כרטיסי סיום/קרדיטים
+    self-promotion: קידום עצמי / לא ממומן
+    interaction: תזכורת למעקב (הירשם כמנוי)
     sponsor: נותן חסות
-    intro: פתיח
-    music offtopic: מוזיקה - לא בהקשר
-    filler: ממלא מקום
-    recap: סיכום
+    intro: אנימציית הפסקה/הקדמה
+    music offtopic: 'מוזיקה: קטעים ללא מוזיקה'
+    filler: 'טנג''נטים/בדיחות'
+    recap: תצוגה מקדימה/סיכום
+    highlight: קטע חשוב
+    exclusive access: גישה אקסקלוסיבית
+  Sponsor Block category short:
+    intro: הפסקה
+    interaction: תזכורת לפעולה
+    music offtopic: ללא מוזיקה
+    filler: טנגנטים
   External Player:
     video: סרטון
     playlist: רשימת נגינה
@@ -836,7 +843,7 @@ Video:
     Hide Stats: הסתר נתונים
     You appear to be offline: נראה שהחיבור שלך נקטע.
     Playback will resume automatically when your connection comes back: הפלייבק יחודש אוטומטית כאשר החיבור שלך יחזור.
-    Skipped segment: דילגתי על {segmentCategory}
+    Skipped segment: '{segmentCategory} דולג'
     Autoplay is off: הפעלה אוטומטית כבויה
     Autoplay is on: הניגון האוטומטי פעיל
   Hide Channel: הסתר ערוץ
@@ -847,8 +854,8 @@ Video:
   AgeRestricted: אי אפשר לצפות בסרטונים שמוגבלים בגיל עם OpenTubeX כיוון שהם דורשים כניסה עם Google ושימוש בחשבון YouTube עם גיל מאומת.
   Unlisted: לא מופיע
   DeArrow:
-    Show Modified Details: הצגת פרטים לאחר שינוי
-    Show Original Details: הצגת פרטים מקוריים
+    Show Modified Details: הצג פרטים ערוכים
+    Show Original Details: הצג פרטים מקוריים
 #& Playlists
   Save Watched Progress: שמור התקדמות נצפית
   DRMProtected: סרטונים המוגנים ב-DRM אינם יכולים להתנגן ב-OpenTubeX, מכיוון שהם דורשים רכיבים סגורים ובעלים. אם אתה רוצה לצפות בסרטון הזה, אנא צפה בו באתר הרשמי של YouTube בדפדפן אינטרנט עם תמיכה ב-DRM.

--- a/static/locales/hr.yaml
+++ b/static/locales/hr.yaml
@@ -580,7 +580,7 @@ Settings:
     Proxy Username: Proxy korisničko ime
     Proxy Password: Proxy lozinka
   SponsorBlock Settings:
-    Notify when sponsor segment is skipped: Obavijesti kad se preskoči segment sponzora
+    Notify when sponsor segment is skipped: Pokaži obavijest nakon preskakanja isječka
     'SponsorBlock API Url (Default is https://sponsor.ajay.app)': URL API-a za blokiranja sponzora (standardno je https://sponsor.ajay.app)
     Enable SponsorBlock: Aktiviraj blokiranja sponzora
     SponsorBlock Settings: Blokiranja sponzora
@@ -798,14 +798,20 @@ Video:
   Video has been saved: Video je spremljen
   Save Video: Spremi video
   Sponsor Block category:
-    music offtopic: Druga vrsta glazbe
-    interaction: Interakcija
-    self-promotion: Samopromocija
-    outro: Kraj
-    intro: Uvod
+    music offtopic: 'Glazba: Ne-glazbeni dio'
+    interaction: Podsjetnik interakcije (Pretplati se)
+    self-promotion: Neplaćena promocija ili samopromocija
+    outro: Završni kadrovi/Zasluge
+    intro: Stanka/Uvodna animacija
     sponsor: Sponzor
     recap: Rekapitulacija
     filler: Dodatni materijal
+    highlight: Istaknuto
+    exclusive access: Eksluzivni pristup
+  Sponsor Block category short:
+    intro: Stanka
+    interaction: Podsjetnik interakcije
+    music offtopic: Ne-glazbeni
   External Player:
     Unsupported Actions:
       starting video at offset: pokretanje videa pri odmaku
@@ -844,7 +850,7 @@ Video:
       Player Dimensions: 'Veličina playera: {width}x{height}'
       Buffered: 'Učitano: {bufferedPercentage}%'
     You appear to be offline: Čini se da ne postoji veza s internetom.
-    Skipped segment: Preskočen segment „{segmentCategory}”
+    Skipped segment: 'Preskočeno: {segmentCategory}'
     Take Screenshot: Snimi snimku ekrana
     Show Stats: Prikaži statistiku
     Hide Stats: Sakrij statistiku
@@ -862,7 +868,7 @@ Video:
   IP block: YouTube je blokirao tvoju IP adresu za gledanje videa. Pokušaj se prebaciti na jedan drugi VPN ili proxy.
   AgeRestricted: Videa s dobnim ograničenjem se ne mogu gledati s OpenTubeXom jer zahtijevaju prijavu na Google i korištenje YouTube računa s dobnom provjerom.
   DeArrow:
-    Show Original Details: Prikaži detalje originala
+    Show Original Details: Prikaži izvorne detalje
     Show Modified Details: Prikaži detalje promjena
   DRMProtected: DRM-om zaštićena videa ne mogu se reproducirati u OpenTubeXu jer zahtijevaju vlasničke komponente zatvorenog koda. Ako želiš gledati ovaj video, gledaj ga na službenoj YouTube web stranici u web pregledniku s aktiviranim DRM-om.
 #& Playlists

--- a/static/locales/hu.yaml
+++ b/static/locales/hu.yaml
@@ -586,7 +586,7 @@ Settings:
     Proxy Username: Proxy felhasználónév
     Proxy Password: Proxy jelszó
   SponsorBlock Settings:
-    Notify when sponsor segment is skipped: Értesítés a szponzorált szakasz kihagyásáról
+    Notify when sponsor segment is skipped: 'Jelezzen, ha egy szegmens át lett ugorva'
     'SponsorBlock API Url (Default is https://sponsor.ajay.app)': 'SponsorBlock API webcíme (Alapértelmezett: https://sponsor.ajay.app)'
     Enable SponsorBlock: SponsorBlock engedélyezése
     SponsorBlock Settings: SponsorBlock
@@ -807,14 +807,22 @@ Video:
   Video has been saved: Videó mentve
   Save Video: Videó mentése
   Sponsor Block category:
-    music offtopic: Témán kívüli zene
-    interaction: Interakció
-    self-promotion: Önreklámozás
-    outro: Utójáték
-    intro: Bevezető
+    music offtopic: 'Zene: nem-zene szegmens'
+    interaction: Emlékeztető (Feliratkozás)
+    self-promotion: Nem fizetett/önpromóció
+    outro: Záróképernyő/ Stáblista
+    intro: Megszakítás/Intro animáció
     sponsor: Szponzor
-    filler: Kitöltő
-    recap: Összegzés
+    filler: Kitérők/viccek
+    recap: Előzetes/Ismétlés
+    hook: Horog/Köszöntés
+    highlight: Kiemelés
+    exclusive access: Exkluzív hozzáférés
+  Sponsor Block category short:
+    intro: Megszakítás
+    interaction: Emlékeztető
+    music offtopic: Nem-Zene
+    filler: Kitérők
   External Player:
     Unsupported Actions:
       looping playlists: lejátszási lista folyamatos lejátszása
@@ -860,7 +868,7 @@ Video:
       Resolution: 'Felbontás: {width}x{height}{''@''}{frameRate}'
       CodecsVideoAudio: 'Kodekek: {videoCodec} ({videoItag}) / {audioCodec} ({audioItag})'
     You appear to be offline: Úgy tűnik, hogy jelenleg nem kapcsolódik a hálózathoz.
-    Skipped segment: Kihagyott {segmentCategory} szakasz
+    Skipped segment: '{segmentCategory} átugorva'
     TranslatedCaptionTemplate: '{language} (fordítva erről: „{originalLanguage}”)'
     Show Stats: Statisztika megjelenítése
     Playback will resume automatically when your connection comes back: A lejátszás automatikusan folytatódik, amikor a kapcsolat helyreáll.
@@ -871,8 +879,8 @@ Video:
   AgeRestricted: A OpenTubeX-on nem lehet korhatáros videókat megtekinteni, mivel ezekhez Google-bejelentkezés és korhatár-ellenőrzött YouTube-fiók használata szükséges.
   MembersOnly: A csak tagoknak szóló videók nem tekinthetők meg a OpenTubeX-on, mivel ezekhez Google-bejelentkezés és fizetett tagság szükséges a feltöltő csatornájához.
   DeArrow:
-    Show Modified Details: Módosított részletek megjelenítése
-    Show Original Details: Eredeti részletek megjelenítése
+    Show Modified Details: Módosított adatok mutatása
+    Show Original Details: Eredeti adatok megjelenítése
   DRMProtected: A DRM-védelemmel ellátott videók nem játszhatók le a OpenTubeX-ban, mivel ezekhez zárt forráskódú, tulajdonosi komponensekre van szükség. Ha meg szeretné nézni ezt a videót, akkor tekintse meg a YouTube hivatalos weboldalán egy DRM-képes böngészőben.
 #& Playlists
   Save Watched Progress: Megtekintett videó folyamatának mentése

--- a/static/locales/id.yaml
+++ b/static/locales/id.yaml
@@ -569,7 +569,7 @@ Settings:
     Proxy Username: Nama pengguna proksi
     Proxy Password: Kata sandi proksi
   SponsorBlock Settings:
-    Notify when sponsor segment is skipped: Beri tahu saat segmen sponsor dilewati
+    Notify when sponsor segment is skipped: Tampilkan pemberitahuan setelah melewati segmen
     'SponsorBlock API Url (Default is https://sponsor.ajay.app)': Url SponsorBlock API (Default is https://sponsor.ajay.app)
     Enable SponsorBlock: Aktifkan SponsorBlock
     SponsorBlock Settings: SponsorBlok
@@ -784,14 +784,21 @@ Video:
   Video has been saved: Video telah disimpan
   Save Video: Simpan Video
   Sponsor Block category:
-    interaction: Interaksi
-    music offtopic: Musik Non-Topik
-    self-promotion: Promosi Diri Sendiri
-    outro: outro
-    intro: Intro
+    interaction: Pengingat Interaksi (Berlangganan)
+    music offtopic: 'Musik: Bagian Non-Musik'
+    self-promotion: Promosi Diri Sendiri/Tidak Dibayar
+    outro: Kartu Akhir/Kredit
+    intro: Jeda/Animasi Intro
     sponsor: Sponsor
     recap: Rekap
-    filler: Pengisi
+    filler: Candaan atau bagian yang menyimpang dari isi cerita
+    highlight: Sorotan
+    exclusive access: Akses Eksklusif
+  Sponsor Block category short:
+    intro: Jeda
+    interaction: Pengingat Interaksi
+    music offtopic: Non-Musik
+    filler: Penyimpangan cerita
   External Player:
     Unsupported Actions:
       starting video at offset: memulai video pada offset
@@ -814,8 +821,8 @@ Video:
   Published:
     In less than a minute: Dalam waktu kurang dari satu menit
   DeArrow:
-    Show Original Details: Tampilkan Detail Asli
-    Show Modified Details: Tampilkan Detail yang Dimodifikasi
+    Show Original Details: Lihat Detail Original
+    Show Modified Details: Perlihatkan detail yang dimodifikasi
   Player:
     TranslatedCaptionTemplate: '{language} (diterjemahkan dari "{originalLanguage}")'
     Audio Tracks: Trek Audio
@@ -844,7 +851,7 @@ Video:
     Take Screenshot: Ambil Tangkapan Layar
     You appear to be offline: Anda tampaknya sedang offline.
     Playback will resume automatically when your connection comes back: Pemutaran ulang akan dilanjutkan secara otomatis ketika koneksi Anda kembali.
-    Skipped segment: Melewati segmen {segmentCategory}
+    Skipped segment: '{segmentCategory} dilewati'
   More Options: Lebih Banyak Pilihan
   'Live Chat is unavailable for this stream. It may have been disabled by the uploader.': Obrolan Langsung tidak tersedia untuk streaming ini. Mungkin telah dinonaktifkan oleh pengunggah.
   Show Super Chat Comment: Tampilkan Komentar Super Chat

--- a/static/locales/it.yaml
+++ b/static/locales/it.yaml
@@ -580,7 +580,7 @@ Settings:
     Proxy Username: Nome utente proxy
     Proxy Password: Password proxy
   SponsorBlock Settings:
-    Notify when sponsor segment is skipped: Notifica quando un segmento sponsor viene saltato
+    Notify when sponsor segment is skipped: Mostra Avviso Dopo Aver Saltato un Segmento
     'SponsorBlock API Url (Default is https://sponsor.ajay.app)': URL dell'API di SponsorBlock (l'impostazione predefinita è https://sponsor.ajay.app)
     Enable SponsorBlock: Abilita SponsorBlock
     SponsorBlock Settings: SponsorBlock
@@ -771,14 +771,22 @@ Video:
     video: video
     OpenInTemplate: Apri con {externalPlayer}
   Sponsor Block category:
-    music offtopic: Musica fuori tema
-    interaction: Interazione
-    self-promotion: Autopromozione
-    outro: Conclusione
-    intro: Introduzione
-    sponsor: Sponsor
-    recap: Ricapitolazione
-    filler: Riempitivo
+    music offtopic: 'Musica: Sezione Non-Musicale'
+    interaction: 'Promemoria d''Interazione (Iscrizione)'
+    self-promotion: Promozione non pagata/Autopromozione
+    outro: Conclusioni/Titoli di Coda
+    intro: Intermezzo/Intro Animata
+    sponsor: Sponsorizzazione
+    recap: Anteprima/Riepilogo
+    filler: Intermezzi/Scherzi
+    hook: Gancio/Saluti
+    highlight: Highlight
+    exclusive access: Accesso Esclusivo
+  Sponsor Block category short:
+    intro: Intermezzo
+    interaction: 'Promemoria d''Interazione'
+    music offtopic: Non-Musicale
+    filler: Intermezzi
   Premieres: Première
   Scroll to Bottom: Scorri fino in fondo
   Show Super Chat Comment: Mostra commento Super Chat
@@ -813,7 +821,7 @@ Video:
     Take Screenshot: Acquisisci screenshot
     You appear to be offline: Sembra che tu sia offline.
     Playback will resume automatically when your connection comes back: La riproduzione riprenderà automaticamente quando verrà ripristinata la connessione.
-    Skipped segment: Segmento {segmentCategory} saltato
+    Skipped segment: '{segmentCategory} Saltato'
     Autoplay is off: La riproduzione automatica è disattivata
     Autoplay is on: La riproduzione automatica è attivata
   IP block: YouTube ha bloccato il tuo indirizzo IP impedendogli di guardare i video. Prova a passare a una VPN o a un proxy diverso.
@@ -821,8 +829,8 @@ Video:
   MembersOnly: I video riservati agli abbonati non possono essere guardati con OpenTubeX, poiché richiedono l'accesso a Google e l'iscrizione a pagamento al canale dell'utente che li ha caricati.
   AgeRestricted: I video con limiti di età non possono essere guardati con OpenTubeX poiché richiedono l'accesso a Google e l'utilizzo di un account YouTube con età verificata.
   DeArrow:
-    Show Original Details: Mostra dettagli originali
-    Show Modified Details: Mostra dettagli modificati
+    Show Original Details: Mostra Dettagli Originali
+    Show Modified Details: Mostra i dettagli modificati
   DRMProtected: I video protetti da DRM non possono essere riprodotti in OpenTubeX, poiché richiedono componenti proprietari e closed source. Se vuoi guardare questo video, guardalo sul sito Web ufficiale di YouTube in un browser Web abilitato DRM.
 #& Playlists
   Watched Progress Saved: Progresso guardato salvato

--- a/static/locales/ja.yaml
+++ b/static/locales/ja.yaml
@@ -576,7 +576,7 @@ Settings:
     Proxy Username: プロキシのユーザー名
     Proxy Password: プロキシのパスワード
   SponsorBlock Settings:
-    Notify when sponsor segment is skipped: スポンサーセグメントがスキップされたときに通知する
+    Notify when sponsor segment is skipped: セグメントがスキップされた後に通知を表示する
     'SponsorBlock API Url (Default is https://sponsor.ajay.app)': スポンサーブロック APIのURL（デフォルト https://sponsor.ajay.app）
     Enable SponsorBlock: スポンサーブロックの有効化
     SponsorBlock Settings: スポンサーブロック
@@ -753,14 +753,22 @@ Video:
   Video has been saved: 動画を保存しました
   Save Video: 動画の保存
   Sponsor Block category:
-    sponsor: スポンサー
-    music offtopic: 音楽以外
-    interaction: インタラクション
-    self-promotion: 自己紹介
-    outro: アウトロ（末尾）
-    intro: イントロ（冒頭）
-    recap: 要約
-    filler: フィラー（穴埋め）
+    sponsor: 広告
+    music offtopic: '音楽: 音楽ではない区間'
+    interaction: 行動のお願い (登録/寄付など)
+    self-promotion: 無報酬 / 自己の宣伝
+    outro: 終了画面 / クレジット
+    intro: 合間 / 導入アニメ
+    recap: 予告/あらすじ
+    filler: 脱線/冗談
+    hook: 掴み/挨拶
+    highlight: ハイライト
+    exclusive access: 独占的な広告
+  Sponsor Block category short:
+    intro: 合間
+    interaction: 行動のお願い
+    music offtopic: 音楽以外の部分
+    filler: 脱線
   External Player:
     OpeningTemplate: '{externalPlayer} で {videoOrPlaylist} を開く...'
     Unsupported Actions:
@@ -800,7 +808,7 @@ Video:
       Stats: 統計
     You appear to be offline: オフラインのようです。
     Playback will resume automatically when your connection comes back: ネットワーク接続が回復すると再生が自動的に再開されます。
-    Skipped segment: '{segmentCategory} 区分をスキップしました'
+    Skipped segment: '{segmentCategory}を飛ばしました'
     TranslatedCaptionTemplate: '{language}（「{originalLanguage}」から翻訳）'
     Audio Tracks: オーディオ トラック
     Theatre Mode: シアターモード
@@ -817,8 +825,8 @@ Video:
   MembersOnly: メンバー限定動画は Google にログインし、投稿チャンネルに課金する必要があるので OpenTubeX から直接見ることはできません。
   AgeRestricted: 年齢制限がかかっている 動画 は Google にログインしておりかつ年齢確認を済ましている YouTube アカウントが必要なため、OpenTubeX から直接見ることはできません。
   DeArrow:
-    Show Original Details: 元の情報を表示
-    Show Modified Details: 変更された詳細を表示
+    Show Original Details: 元の詳細を表示
+    Show Modified Details: 改善の詳細を表示
   DRMProtected: DRM保護された動画はOpenTubeXでは再生できません。これらの動画には、独自の非オープンソースのコンポーネントが必要です。この動画を視聴したい場合は、DRM対応のウェブブラウザで公式のYouTubeウェブサイトでご覧ください。
 #& Playlists
   Save Watched Progress: 視聴進捗を保存

--- a/static/locales/ko.yaml
+++ b/static/locales/ko.yaml
@@ -355,7 +355,7 @@ Settings:
   SponsorBlock Settings:
     SponsorBlock Settings: SponsorBlock 설정
     Enable SponsorBlock: SponsorBlock 사용
-    Notify when sponsor segment is skipped: 스폰서 구간을 건너뛸 경우 알림
+    Notify when sponsor segment is skipped: 구간을 건너뛴 후 알림 표시
     'SponsorBlock API Url (Default is https://sponsor.ajay.app)': SponsorBlock API 주소 (기본 주소는 https://sponsor.ajay.app 입니다)
     Skip Options:
       Auto Skip: 자동 건너뛰기
@@ -532,14 +532,22 @@ Video:
     video: 비디오
     playlist: 재생목록
   Sponsor Block category:
-    music offtopic: 음악 주제에서 벗어나기
-    recap: 씌우기
-    filler: 필터
-    sponsor: 스폰서
-    intro: 도입부
-    outro: 결말부
-    self-promotion: 자기 홍보
-    interaction: 상호 작용
+    music offtopic: 음악이 아닌 구간
+    recap: 미리보기/요약 구간
+    filler: 잡담/농담
+    sponsor: 후원이나 협찬 구간
+    intro: 인트로/무음 구간
+    outro: 최종 화면 구간
+    self-promotion: 무대가 홍보 구간
+    interaction: 상호작용 알림 구간
+    hook: 후킹/인사말
+    highlight: 하이라이트
+    exclusive access: 홍보 동영상
+  Sponsor Block category short:
+    intro: 인트로/무음 구간
+    interaction: 상호작용 알림 구간
+    music offtopic: 음악이 아닌 구간
+    filler: 잡담
   Premieres: 프리미어
   Upcoming: 공개 예정
   Show Super Chat Comment: 슈퍼채팅 댓글 보이기

--- a/static/locales/lv.yaml
+++ b/static/locales/lv.yaml
@@ -694,6 +694,7 @@ Video:
     music offtopic: ''
     recap: ''
     filler: ''
+    exclusive access: Ekskluzīva Piekļuve
   External Player:
     OpenInTemplate: ''
     video: 'video'

--- a/static/locales/ms.yaml
+++ b/static/locales/ms.yaml
@@ -624,7 +624,7 @@ Settings:
     SponsorBlock Settings: ''
     Enable SponsorBlock: ''
     'SponsorBlock API Url (Default is https://sponsor.ajay.app)': ''
-    Notify when sponsor segment is skipped: ''
+    Notify when sponsor segment is skipped: Tunjukkan Makluman Setelah Segmen Dilangkau
     UseDeArrowTitles: ''
     UseDeArrowThumbnails: ''
     'DeArrow Thumbnail Generator API Url (Default is https://dearrow-thumb.ajay.app)': ''
@@ -838,14 +838,20 @@ Video:
     Show Original Details: ''
     Show Modified Details: ''
   Sponsor Block category:
-    sponsor: ''
-    intro: ''
-    outro: ''
-    self-promotion: ''
-    interaction: ''
-    music offtopic: ''
+    sponsor: Penaja
+    intro: Intermission / Pengenalan Animasi
+    outro: Kad Akhir / Kredit
+    self-promotion: Promosi Tanpa Bayaran / Diri
+    interaction: Peringatan Interaksi (Langgan)
+    music offtopic: 'Muzik: Bahagian Bukan Muzik'
     recap: ''
     filler: ''
+    highlight: Sorotan
+    exclusive access: Akses Eksklusif
+  Sponsor Block category short:
+    intro: Selang
+    interaction: Peringatan Interaksi
+    music offtopic: Bukan Muzik
   External Player:
     OpenInTemplate: ''
     video: ''
@@ -888,7 +894,7 @@ Video:
       CodecsVideoAudioNoItags: ''
     You appear to be offline: ''
     Playback will resume automatically when your connection comes back: ''
-    Skipped segment: ''
+    Skipped segment: '{segmentCategory} Melangkau'
 #& Playlists
 Playlist:
   #& About

--- a/static/locales/nb-NO.yaml
+++ b/static/locales/nb-NO.yaml
@@ -563,7 +563,7 @@ Settings:
     Hide Channel Posts: Skjul «Innlegg»-fanen i kanaler
   The app needs to restart for changes to take effect. Restart and apply change?: Start programmet på nytt for å ta i bruk endringene?
   SponsorBlock Settings:
-    Notify when sponsor segment is skipped: Gi beskjed når sponsordelen blir hoppet over
+    Notify when sponsor segment is skipped: Vis varsel etter at et segment har blitt hoppet over
     'SponsorBlock API Url (Default is https://sponsor.ajay.app)': SponsorBlock-API-nettadresse (standard er https://sponsor.ajay.app)
     Enable SponsorBlock: Skru på SponsorBlock
     SponsorBlock Settings: SponsorBlock
@@ -738,14 +738,20 @@ Video:
   Previous: 'Forrige'
   Next: 'Neste'
   Sponsor Block category:
-    interaction: Samhandling
-    outro: Outro
-    intro: Intro
+    interaction: Samhandlingspåminnelse (Abonner)
+    outro: Rulletekster
+    intro: Midtpause-/Introanimasjon
     sponsor: Sponsor
-    music offtopic: Musikkfritt segment
-    self-promotion: Egenpromotering
+    music offtopic: 'Musikk: Seksjon uten musikk'
+    self-promotion: Ubetalt/Selvpromotering
     recap: Oppsummering
     filler: Fyllstoff
+    highlight: Høydepunkt
+    exclusive access: Ekslusiv tilgang
+  Sponsor Block category short:
+    intro: Midtpause
+    interaction: Samhandlingspåminnelse
+    music offtopic: Ikke-musikk
   External Player:
     Unsupported Actions:
       shuffling playlists: spiller av spillelister i tilfeldig rekkefølge
@@ -788,7 +794,7 @@ Video:
     Hide Stats: Skjul statistikk
     Full Window: Fullt vindu
     TranslatedCaptionTemplate: '{language} (Oversatt fra "{originalLanguage}")'
-    Skipped segment: Hoppet over {segmentCategory}-segment
+    Skipped segment: '{segmentCategory} hoppet over'
     Autoplay is on: Automatisk avspilling er slått på
     Exit Full Window: Avslutt fullskjerm
     Autoplay is off: Automatisk avspilling er slått av
@@ -807,7 +813,7 @@ Video:
   Watched Progress Saved: Sted i videoen lagret
   DeArrow:
     Show Modified Details: Vis endrede detaljer
-    Show Original Details: Vis originaldetaljer
+    Show Original Details: Vis opprinnelige detaljer
   Popout Live Chat: Chat i eget vindu
   Watch:
     'Remaining preroll-ad time: {remindingTimeSeconds}s': 'Tid før reklamen før videoen kan hoppes over: {remindingTimeSeconds}s'

--- a/static/locales/nl.yaml
+++ b/static/locales/nl.yaml
@@ -563,7 +563,7 @@ Settings:
     Proxy Username: Proxy-gebruikers­naam
     Proxy Password: Proxy-wacht­woord
   SponsorBlock Settings:
-    Notify when sponsor segment is skipped: Mij informeren wanneer een gesponsord segment wordt overgeslagen
+    Notify when sponsor segment is skipped: Melding weergeven nadat een segment is overgeslagen
     'SponsorBlock API Url (Default is https://sponsor.ajay.app)': URL naar API van SponsorBlock (Standaard is https://sponsor.ajay.app)
     Enable SponsorBlock: SponsorBlock inschakelen
     SponsorBlock Settings: SponsorBlock
@@ -736,14 +736,20 @@ Video:
   Video has been saved: Video is opgeslagen
   Save Video: Video opslaan
   Sponsor Block category:
-    music offtopic: Niet-muziek
-    interaction: Interactie
-    self-promotion: Zelfpromotie
-    outro: Outro
-    intro: Intro
+    music offtopic: 'Muziek: sectie niet-muziek'
+    interaction: Interactieherinnering (abonneren)
+    self-promotion: Onbetaalde promotie of zelfpromotie
+    outro: Eindkaarten/aftiteling
+    intro: Onderbreking/intro-animatie
     sponsor: Sponsor
-    recap: Samenvatting
+    recap: Voorbeeld/samenvatting
     filler: Opvulling
+    highlight: Hoogtepunt
+    exclusive access: Exclusieve toegang
+  Sponsor Block category short:
+    intro: Onderbreking
+    interaction: Interactieherinnering
+    music offtopic: Niet-muziek
   External Player:
     Unsupported Actions:
       shuffling playlists: afspeellijsten shufflen
@@ -787,7 +793,7 @@ Video:
     Audio Tracks: Audiosporen
     TranslatedCaptionTemplate: '{language} (vertaald vanuit "{originalLanguage}")'
     Playback will resume automatically when your connection comes back: Het afspelen hervat automatisch wanneer u weer verbonden bent.
-    Skipped segment: '{segmentCategory} segment overgeslagen'
+    Skipped segment: '{segmentCategory} overgeslagen'
     Full Window: Volledig Venster
     Exit Full Window: Volledig Venster Sluiten
     You appear to be offline: Het lijkt erop dat u offline bent.
@@ -800,8 +806,8 @@ Video:
   DRMProtected: Videos die beschermd worden door DRM (Digital Rights Management) kunnen niet worden afgespeeld in OpenTubeX omdat ze beschermde closed source onderdelen vereisen. Als u deze video wilt bekijken, probeer het dan via de officiële YouTube website met een web browser die DRM ondersteund.
   Unlisted: Verborgen
   DeArrow:
-    Show Original Details: Oorspronkelijke Details Weergeven
-    Show Modified Details: Aangepaste Details Weergeven
+    Show Original Details: Originele details weergeven
+    Show Modified Details: Gewijzigde details weergeven
   MembersOnly: Members-only videos kunnen niet bekeken worden via OpenTubeX omdat ze een Google login en betaald abonnement op het kanaal van de uploader vereisen.
   AgeRestricted: Videos met een leeftijdsbeperking kunnen niet via OpenTubeX bekeken worden omdat ze een Google login en een YouTube account met bevestigde leeftijd vereisen.
   Save Watched Progress: Kĳk­voortgang opslaan

--- a/static/locales/nn.yaml
+++ b/static/locales/nn.yaml
@@ -332,7 +332,7 @@ Settings:
     'SponsorBlock API Url (Default is https://sponsor.ajay.app)': SponsorBlock-API-nettadresse (standard er https://sponsor.ajay.app)
     Enable SponsorBlock: Skru på SponsorBlock
     SponsorBlock Settings: SponsorBlock-innstillingar
-    Notify when sponsor segment is skipped: Gi beskjed når sponsordelen blir hoppa over
+    Notify when sponsor segment is skipped: Vis varsel etter at et segment har blitt hoppet over
     Skip Options:
       Skip Option: Alternativ for å hoppe over
       Auto Skip: Hopp over automatisk
@@ -492,14 +492,20 @@ Video:
   Started streaming on: 'Begynte å straume på'
 #& Videos
   Sponsor Block category:
-    outro: Avslutting
-    interaction: Samhandling
-    intro: Introduksjon
+    outro: Rulletekster
+    interaction: Samhandlingspåminnelse (Abonner)
+    intro: Midtpause-/Introanimasjon
     sponsor: Sponsor
-    music offtopic: Musikk utanfor tema
-    self-promotion: Eigenpromotering
+    music offtopic: 'Musikk: Seksjon uten musikk'
+    self-promotion: Ubetalt/Selvpromotering
     recap: Oppsummering
     filler: Fyllstoff
+    highlight: Høydepunkt
+    exclusive access: Ekslusiv tilgang
+  Sponsor Block category short:
+    intro: Midtpause
+    interaction: Samhandlingspåminnelse
+    music offtopic: Ikke-musikk
   External Player:
     video: video
     playlist: speleliste

--- a/static/locales/pl.yaml
+++ b/static/locales/pl.yaml
@@ -757,7 +757,7 @@ Settings:
     Export Generated User ID: Wyeksportuj wygenerowany ID
     Generated SponsorBlock User ID Copy Button: Skopiuj wygenerowany ID użytkownika SponsorBlock
     Generated SponsorBlock User ID Copied: Wygenerowany ID użytkownika SponsorBlock został skopiowany do schowka
-    Skip notification timeout: 'Czas trwania powiadomienia pominięcia (sekundy):'
+    Skip notification timeout: Czas trwania powiadomienia o cofnięciu pominięcia
   External Player Settings:
     Custom External Player Arguments: Niestandardowe argumenty zewnętrznego odtwarzacza
     Custom External Player Executable: Niestandardowy plik wykonywalny zewnętrznego odtwarzacza

--- a/static/locales/pl.yaml
+++ b/static/locales/pl.yaml
@@ -735,7 +735,7 @@ Settings:
     Reloading video after IP block recovery: Przeładuj wideo po ominięciu blokady IP
     Failed to select IP block recovery script: Nie udało się wybrać skryptu omijania blokady IP
   SponsorBlock Settings:
-    Notify when sponsor segment is skipped: Powiadamiaj, kiedy segment sponsorowany zostanie pominięty
+    Notify when sponsor segment is skipped: Pokaż informację po pominięciu segmentu
     'SponsorBlock API Url (Default is https://sponsor.ajay.app)': Adres URL interfejsu API SponsorBlock (Domyślnie jest https://sponsor.ajay.app)
     Enable SponsorBlock: Włącz SponsorBlock
     SponsorBlock Settings: SponsorBlock
@@ -757,7 +757,7 @@ Settings:
     Export Generated User ID: Wyeksportuj wygenerowany ID
     Generated SponsorBlock User ID Copy Button: Skopiuj wygenerowany ID użytkownika SponsorBlock
     Generated SponsorBlock User ID Copied: Wygenerowany ID użytkownika SponsorBlock został skopiowany do schowka
-    Skip notification timeout: Czas trwania powiadomienia o cofnięciu pominięcia
+    Skip notification timeout: 'Czas trwania powiadomienia pominięcia (sekundy):'
   External Player Settings:
     Custom External Player Arguments: Niestandardowe argumenty zewnętrznego odtwarzacza
     Custom External Player Executable: Niestandardowy plik wykonywalny zewnętrznego odtwarzacza
@@ -1021,15 +1021,21 @@ Video:
   Save Video: Zapisz film
   Sponsor Block category:
     music offtopic: 'Muzyka: Sekcja niemuzyczna'
-    interaction: Interakcja (subskrybuj)
-    self-promotion: Nieodpłatna/Autopromocja
-    outro: Napisy końcowe (Outro)
-    intro: Przerwa/Intro
-    sponsor: Sponsorowany
+    interaction: Przypomnienie o interakcji (Subskrybuj)
+    self-promotion: Nieopłacona/Własna promocja
+    outro: Ekran końcowy/Napisy
+    intro: Przerwa/Animowane intro
+    sponsor: Sponsor
     filler: Wypełniacze/Żarty
     recap: Zapowiedź/Podsumowanie
-    hook: Zachęty/Pozdrowienia
-    highlight: Ważny moment
+    hook: Zaczepka/Powitanie
+    highlight: Wyróżnione
+    exclusive access: Dostęp na wyłączność
+  Sponsor Block category short:
+    intro: Przerwa
+    interaction: Przypomnienie o interakcji
+    music offtopic: Bez muzyki
+    filler: Wypełniacze
   External Player:
     Unsupported Actions:
       reversing playlists: odwracania playlist
@@ -1077,7 +1083,7 @@ Video:
       Resolution: 'Rozdzielczość: {width}x{height}{''@''}{frameRate}'
     You appear to be offline: Zdaje się, że jesteś rozłączony.
     Playback will resume automatically when your connection comes back: Odtwarzanie zostanie wznowione, jak tylko połączenie zostanie odzyskane.
-    Skipped segment: Pominięto segment „{segmentCategory}”
+    Skipped segment: '{segmentCategory} — pominięto'
     Full Window: Pełne okno
     Autoplay is off: Autoodtwarzanie jest wyłączone
     Autoplay is on: Autoodtwarzanie jest włączone
@@ -1088,10 +1094,10 @@ Video:
       ClearSegments: Wyczyść segmenty
       ClearSegmentsPrompt: Czy na pewno chcesz wyczyścić wszystkie utworzone segmenty SponsorBlock dla tego filmu?
       CompleteSegmentsBeforeSubmitting: Przed wysłaniem należy dokończyć tworzenie każdego segmentu.
-      CategoryLabel: Kategoria segmentu
+      CategoryLabel: Kategoria
       DeleteSegment: Usuń
       DuplicateSegments: Duplikowanie segmentów roboczych jest niedozwolone.
-      EditSegment: Edycja
+      EditSegment: Edytuj
       EndAction: (Koniec)
       EndActionLabel: Koniec
       EndTimeAfterStart: Czas zakończenia segmentu musi przypadać po czasie rozpoczęcia.
@@ -1100,39 +1106,39 @@ Video:
       DisableAutoSkipTemporarily: Tymczasowo wyłącz automatyczne pomijanie SponsorBlock
       EnableAutoSkipTemporarily: Włącz ponownie automatyczne pomijanie SponsorBlock
       Guidelines: Wytyczne
-      InspectSegment: Zweryfikuj
+      InspectSegment: Sprawdź
       InvalidStartTime: Wprowadź prawidłowy czas rozpoczęcia segmentu.
       NoSegmentsToSubmit: Przed wysłaniem utwórz co najmniej jeden kompletny segment.
       NowAction: (Teraz)
       OpenSubmissionMenu: Otwórz menu zgłoszenia
       PreviewRequired: Przed wysłaniem należy przejrzeć każdy segment.
-      PreviewSegment: Przejrzyj
+      PreviewSegment: Podgląd
       SaveSegment: Zapisz
-      SetSegmentEndNow: Zakończ segment tutaj
+      SetSegmentEndNow: Koniec segmentu
       StartAction: (Początek)
-      StartSegmentNow: Rozpocznij segment tutaj
+      StartSegmentNow: Początek segmentu
       SubmissionBadRequest: SponsorBlock odrzucił prośbę o przesłanie zgłoszenia.
-      SubmissionDuplicate: SponsorBlock twierdzi, że te segmenty zostały już przesłane.
+      SubmissionDuplicate: To już zostało przesłane wcześniej.
       SubmissionFailed: Nie udało się przesłać segmentów SponsorBlock.
       SubmissionForbidden: SponsorBlock odrzucił zgłoszenie.
       SubmissionRateLimited: SponsorBlock ograniczył liczbę zgłoszeń.
       SubmissionSuccess: Segmenty SponsorBlock zostały zgłoszone.
       SubmitSegment: Zgłoś segment
-      SubmitSegments: Zgłoś
+      SubmitSegments: Wyślij
       StartTimeLabel: Czas rozpoczęcia segmentu
       TimeDivider: do
-      SkipPrompt: Pominąć segment „{segmentCategory}”?
+      SkipPrompt: '{segmentCategory} — pominąć?'
       SkipPromptAction: Pomiń
-      SkipToastUnskip: Anuluj pominięcie
-      SkipToastReskip: Wznów pominięcie
-      SkipToHighlight: Przeskocz do „Ważny moment”
-      SkippedToHighlight: Przeskoczono do „Ważny moment”
+      SkipToastUnskip: Cofnij
+      SkipToastReskip: Pomiń
+      SkipToHighlight: 'Przejść do Wyróżnione?'
+      SkippedToHighlight: Przewinięto do Wyróżnione
       CloseInfoPanel: Zamknij panel SponsorBlock
       OpenInfoPanel: Otwórz panel SponsorBlock
       InfoPanelTitle: SponsorBlock
-      InfoPanelLoading: Ładowanie segmentów…
-      InfoPanelHasSegments: Ten film ma segmenty w bazie danych.
-      InfoPanelNoSegments: Nie znaleziono żadnych segmentów dla tego filmu.
+      InfoPanelLoading: Segmenty nadal się ładują...
+      InfoPanelHasSegments: 'Ten film ma segmenty w bazie danych!'
+      InfoPanelNoSegments: Nie znaleziono segmentów
       RefreshSegments: Odśwież segmenty
       AutoSkipEnabled: Automatyczne pomijanie segmentów
       AutoSkipOn: włączone
@@ -1144,8 +1150,8 @@ Video:
       CloseSegmentActions: Zamknij działania segmentu
       FullVideo: Cały film
       LockedSegment: Zablokowany segment
-      DownvoteSegment: Oceń segment negatywnie
-      UpvoteSegment: Oceń segment pozytywnie
+      DownvoteSegment: Głos przeciw
+      UpvoteSegment: Głos za
       VoteFailed: Nie udało się przesłać oceny segmentu do SponsorBlock.
     Scroll Mini Player:
       Back to Top: Powrót na górę
@@ -1178,8 +1184,8 @@ Video:
   MembersOnly: Filmy tylko dla wspierających nie mogą być odtwarzane przez OpenTubeX, ponieważ wymagają danych logowania do konta Googla oraz płatną subskrypcje kanału.
   Unlisted: Niepubliczny
   DeArrow:
-    Show Original Details: Pokaż szczegóły oryginału
-    Show Modified Details: Pokaż zmodyfikowane szczegóły
+    Show Original Details: Pokaż oryginał
+    Show Modified Details: Pokaż zmienione szczegóły
   DRMProtected: OpenTubeX nie może odtwarzać filmów chronionych przez DRM, ponieważ wymagają one obsługi zastrzeżonych prawnie komponentów o zamkniętym kodzie. By obejrzeć ten film, możesz odwiedzić oficjalną stronę YouTube, korzystając z przeglądarki z włączoną obsługą DRM.
 #& Playlists
   Watched Progress Saved: Postęp odtwarzania zapisany

--- a/static/locales/pt-BR.yaml
+++ b/static/locales/pt-BR.yaml
@@ -577,7 +577,7 @@ Settings:
     Proxy Username: Nome de usuário do Proxy
     Proxy Password: Senha do Proxy
   SponsorBlock Settings:
-    Notify when sponsor segment is skipped: Notificar quando vídeos publicitários for ignorado
+    Notify when sponsor segment is skipped: Mostrar aviso após um segmento ser ignorado
     'SponsorBlock API Url (Default is https://sponsor.ajay.app)': URL da API SponsorBlock (o padrão é https://sponsor.ajay.app)
     Enable SponsorBlock: Habilitar SponsorBlock
     SponsorBlock Settings: SponsorBlock
@@ -754,14 +754,22 @@ Video:
   Video has been saved: O vídeo foi salvo
   Save Video: Salvar vídeo
   Sponsor Block category:
-    music offtopic: Música fora do contexto
-    interaction: Interação
-    self-promotion: Auto-promoção
-    outro: Cartões finais e créditos
-    intro: Introdução
+    music offtopic: 'Música: trecho sem música'
+    interaction: Lembrete de interação (inscrever-se)
+    self-promotion: Não-pago/Autopromoção
+    outro: Finalização/Créditos
+    intro: Intervalo/Vinheta de abertura
     sponsor: Patrocinador
-    filler: Preenchimento
-    recap: Recapitulação
+    filler: Enrolação/Piadas
+    recap: Prévia/Recapitulação
+    hook: Gancho/Saudações
+    highlight: Destaques
+    exclusive access: Acesso exclusivo
+  Sponsor Block category short:
+    intro: Intervalo
+    interaction: Lembrete de interação
+    music offtopic: Sem música
+    filler: Tangentes
   External Player:
     Unsupported Actions:
       shuffling playlists: Playlists aleatórias
@@ -806,7 +814,7 @@ Video:
       CodecsVideoAudio: 'Codecs: {videoCodec} ({videoItag}) / {audioCodec} ({audioItag})'
     You appear to be offline: Parece que você está offline.
     Playback will resume automatically when your connection comes back: A reprodução será retomada automaticamente quando a conexão for restabelecida.
-    Skipped segment: Segmento {segmentCategory} ignorado
+    Skipped segment: '{segmentCategory} pulado'
     Full Window: Preencher janela
     TranslatedCaptionTemplate: '{language} (traduzido do "{originalLanguage}")'
     Show Stats: Mostrar estatísticas
@@ -819,7 +827,7 @@ Video:
   AgeRestricted: Vídeos com restrição de idade não podem ser assistidos com o OpenTubeX, pois exigem login do Google e uso de uma conta do YouTube com verificação de idade.
   DeArrow:
     Show Original Details: Mostrar detalhes originais
-    Show Modified Details: Mostrar detalhes modificados
+    Show Modified Details: Mostrar Detalhes Modificados
   DRMProtected: Os vídeos protegidos por DRM não podem ser reproduzidos no OpenTubeX, pois exigem componentes proprietários e de código fechado. Se quiser assistir a esse vídeo, acesse o site oficial do YouTube em um navegador da Web habilitado para DRM.
 #& Playlists
   Watched Progress Saved: Progresso de reprodução salvo

--- a/static/locales/pt-PT.yaml
+++ b/static/locales/pt-PT.yaml
@@ -568,7 +568,7 @@ Settings:
     Proxy Username: Nome de Utilizador da Proxy
     Proxy Password: Palavra-passe da Proxy
   SponsorBlock Settings:
-    Notify when sponsor segment is skipped: Notificar se um anúncio for ignorado
+    Notify when sponsor segment is skipped: Mostrar aviso após um segmento ser ignorado
     'SponsorBlock API Url (Default is https://sponsor.ajay.app)': URL da API SponsorBlock (padrão é https://sponsor.ajay.app)
     Enable SponsorBlock: Ativar bloqueio da publicidade SponsorBlock
     SponsorBlock Settings: SponsorBlock
@@ -799,14 +799,22 @@ Video:
     video: vídeo
     OpenInTemplate: Abrir com {externalPlayer}
   Sponsor Block category:
-    music offtopic: Música fora de tópico
-    interaction: Interação
-    self-promotion: Auto-promoção
-    outro: Outro
-    intro: Introdução
+    music offtopic: 'Música: trecho sem música'
+    interaction: Lembrete de interação (inscrever-se)
+    self-promotion: Não-pago/Autopromoção
+    outro: Finalização/Créditos
+    intro: Intervalo/Vinheta de abertura
     sponsor: Patrocinador
-    recap: Recapitulação
-    filler: Preenchimento
+    recap: Previa/Recapitulação/Gancho Narrativo
+    filler: Tangentes/Piadas
+    hook: Ganho/Saudações
+    highlight: Destaques
+    exclusive access: Acesso exclusivo
+  Sponsor Block category short:
+    intro: Intervalo
+    interaction: Lembrete de interação
+    music offtopic: Sem música
+    filler: Tangentes
   Premieres: Estreias
   Show Super Chat Comment: Mostrar comentário do Super Chat
   Scroll to Bottom: Deslocar para baixo
@@ -837,7 +845,7 @@ Video:
     TranslatedCaptionTemplate: '{language} (traduzido de "{originalLanguage}")'
     Full Window: Ecrã completo
     Exit Full Window: Sair de ecrã completo
-    Skipped segment: Segmento {segmentCategory} ignorado
+    Skipped segment: '{segmentCategory} pulado'
     You appear to be offline: Parece que não tem conexão à Internet.
     Theatre Mode: Modo teatro
     Exit Theatre Mode: Sair do modo teatro
@@ -850,7 +858,7 @@ Video:
   AgeRestricted: Os vídeos com restrições de idade não podem ser vistos com o OpenTubeX, uma vez que requerem o início de sessão no Google e a utilização de uma conta YouTube com idade verificada.
   Unlisted: Não listado
   DeArrow:
-    Show Modified Details: Mostrar detalhes modificados
+    Show Modified Details: Mostrar Detalhes Modificados
     Show Original Details: Mostrar detalhes originais
   DRMProtected: Os vídeos protegidos por DRM não podem ser reproduzidos no OpenTubeX, uma vez que requerem componentes proprietários e de código fechado. Se quiser ver este vídeo, veja-o no sítio Web oficial do YouTube num navegador Web com DRM.
   Save Watched Progress: Gravar progresso de visualização

--- a/static/locales/pt.yaml
+++ b/static/locales/pt.yaml
@@ -498,7 +498,7 @@ Settings:
     All search history has been successfully imported: Histórico de pesquisa importado com sucesso
     All search history has been successfully exported: Histórico de pesquisa exportado com sucesso
   SponsorBlock Settings:
-    Notify when sponsor segment is skipped: Notificar se um anúncio for ignorado
+    Notify when sponsor segment is skipped: Mostrar aviso após um segmento ser ignorado
     'SponsorBlock API Url (Default is https://sponsor.ajay.app)': URL da API SponsorBlock (padrão é https://sponsor.ajay.app)
     Enable SponsorBlock: Ativar bloqueio da publicidade SponsorBlock
     SponsorBlock Settings: SponsorBlock
@@ -786,14 +786,22 @@ Video:
     video: vídeo
     OpenInTemplate: Abrir com {externalPlayer}
   Sponsor Block category:
-    music offtopic: Música fora de tópico
-    interaction: Interação
-    self-promotion: Auto-promoção
-    outro: Outro
-    intro: Introdução
+    music offtopic: 'Música: trecho sem música'
+    interaction: Lembrete de interação (inscrever-se)
+    self-promotion: Não-pago/Autopromoção
+    outro: Finalização/Créditos
+    intro: Intervalo/Vinheta de abertura
     sponsor: Patrocinador
-    recap: Recapitulação
-    filler: Preenchimento
+    recap: Previa/Recapitulação/Gancho Narrativo
+    filler: Tangentes/Piadas
+    hook: Ganho/Saudações
+    highlight: Destaques
+    exclusive access: Acesso exclusivo
+  Sponsor Block category short:
+    intro: Intervalo
+    interaction: Lembrete de interação
+    music offtopic: Sem música
+    filler: Tangentes
   Started streaming on: Transmissão iniciada em
   Streamed on: Transmitido a
   Audio:
@@ -842,7 +850,7 @@ Video:
     Hide Stats: Ocultar estatísticas
     You appear to be offline: Parece que não tem conexão à Internet.
     Playback will resume automatically when your connection comes back: A reprodução será retomada automaticamente quando a conexão for restabelecida.
-    Skipped segment: Segmento {segmentCategory} ignorado
+    Skipped segment: '{segmentCategory} pulado'
     Autoplay is on: A reprodução automática está ativada
     Autoplay is off: A reprodução automática está desativada
   MembersOnly: Os vídeos só para membros não podem ser reproduzidos no OpenTubeX pois requerem um início de sessão Google e uma subscrição paga no canal do autor.
@@ -852,7 +860,7 @@ Video:
 #& Playlists
   DeArrow:
     Show Original Details: Mostrar detalhes originais
-    Show Modified Details: Mostrar detalhes modificados
+    Show Modified Details: Mostrar Detalhes Modificados
   DRMProtected: Os vídeos protegidos por DRM não podem ser reproduzidos no OpenTubeX pois requerem componentes proprietários e de código fechado. Se quiser ver este vídeo, veja-o no site oficial do YouTube num navegador Web com reprodução DRM.
   Save Watched Progress: Guardar progresso de reprodução
   Watched Progress Saved: Progresso guardado

--- a/static/locales/ro.yaml
+++ b/static/locales/ro.yaml
@@ -547,7 +547,7 @@ Settings:
     Hide Channel Posts: Ascunde tab-ul "Postări" al canalului
     Hide Subscriptions Posts: Ascunde postările din abonații
   SponsorBlock Settings:
-    Notify when sponsor segment is skipped: Notificare atunci când segmentul sponsorului este sărit
+    Notify when sponsor segment is skipped: Afișați o notificare după omiterea unui segment
     'SponsorBlock API Url (Default is https://sponsor.ajay.app)': URL-ul API-ului SponsorBlock (Cel implicit este https://sponsor.ajay.app)
     Enable SponsorBlock: Activați SponsorBlock
     SponsorBlock Settings: SponsorBlock
@@ -771,14 +771,22 @@ Video:
     video: video
     OpenInTemplate: Deschideți în {externalPlayer}
   Sponsor Block category:
-    music offtopic: Muzică offtopic
-    interaction: Interacțiune
-    self-promotion: Autopromovare
-    outro: Outro
-    intro: Introducere
+    music offtopic: 'Muzică: Scene non-muzicale'
+    interaction: Cerere de interacțiune sau de abonare
+    self-promotion: Promovare gratuită / auto-promovare
+    outro: Generic de final
+    intro: Tranziție / introducere
     sponsor: Sponsor
-    recap: Recapitulare
-    filler: Filler
+    recap: Previzualizare / Recapitulare
+    filler: Subiecte tangențiale și glume
+    hook: Laitmotiv / Salutări
+    highlight: Punct culminant
+    exclusive access: Acces exclusiv
+  Sponsor Block category short:
+    intro: Tranziție
+    interaction: Reamintire de Interacțiune
+    music offtopic: Scene non-muzicale
+    filler: Subiecte tangențiale
   Started streaming on: A început să transmită pe
   Streamed on: Difuzat pe
   Copy Invidious Channel Link: Copiați linkul canalului Invidious
@@ -821,7 +829,7 @@ Video:
     Hide Stats: ascunde statistici
     You appear to be offline: Pari a fi offline.
     Playback will resume automatically when your connection comes back: Redarea se va relua automat când se reia conexiunea.
-    Skipped segment: Segment {segmentCategory} omis
+    Skipped segment: 'S-a(u) omis {segmentCategory}'
     TranslatedCaptionTemplate: '{language} (tradus din „{originalLanguage}”)'
     Full Window: Fereastra plină
     Exit Full Window: Ieșiți din fereastra completă
@@ -831,8 +839,8 @@ Video:
   MembersOnly: Videoclipurile destinate exclusiv membrilor nu pot fi vizionate cu OpenTubeX, deoarece necesită autentificare Google și abonament plătit la canalul persoanei care a încărcat.
   DRMProtected: Videoclipurile protejate DRM nu pot fi redate în OpenTubeX, deoarece necesită componente proprietare, cu sursă închisă. Dacă doriți să vizionați acest videoclip, vizionați-l pe site-ul oficial YouTube într-un browser web compatibil DRM.
   DeArrow:
-    Show Original Details: Afișați detaliile originale
-    Show Modified Details: Afișați detaliile modificate
+    Show Original Details: Arată Detaliile Originale
+    Show Modified Details: Arată Detaliile Modificate
   IP block: YouTube a blocat adresa dvs. IP pentru a nu viziona videoclipuri. Vă rugăm să încercați să comutați la un alt VPN sau proxy.
   Save Watched Progress: Salvează progresul vizionat
   Watched Progress Saved: Progresul vizionat a fost salvat

--- a/static/locales/ru.yaml
+++ b/static/locales/ru.yaml
@@ -564,7 +564,7 @@ Settings:
     Proxy Username: Имя пользователя прокси
     Proxy Password: Пароль прокси
   SponsorBlock Settings:
-    Notify when sponsor segment is skipped: Уведомлять о пропущенном сегменте
+    Notify when sponsor segment is skipped: Показывать уведомление после пропуска сегмента
     'SponsorBlock API Url (Default is https://sponsor.ajay.app)': Адрес SponsorBlock API (По умолчанию https://sponsor.ajay.app)
     Enable SponsorBlock: Включить SponsorBlock
     SponsorBlock Settings: SponsorBlock
@@ -742,14 +742,22 @@ Video:
   Video has been saved: Видео было добавлено в сохранённые
   Save Video: Добавить видео в сохранённые
   Sponsor Block category:
-    music offtopic: Сегмент без музыки
-    interaction: Напоминание
-    self-promotion: Самореклама
-    outro: Концовка
-    intro: Вступление
+    music offtopic: 'Музыка: Сегмент без музыки'
+    interaction: Напоминание о взаимодействии (подписка)
+    self-promotion: Безвозмездная или самореклама
+    outro: Конечная заставка/титры
+    intro: Пауза/интро
     sponsor: Спонсор
-    recap: Краткое содержание
-    filler: Отвлечение
+    recap: Предпросмотр/краткое содержание
+    filler: Отвлечённые темы/шутки
+    hook: Завязка/приветствие
+    highlight: Важное
+    exclusive access: Эксклюзивный доступ
+  Sponsor Block category short:
+    intro: Заставка
+    interaction: Напоминание о взаимодействии
+    music offtopic: Без музыки
+    filler: Отвлечённые темы
   External Player:
     Unsupported Actions:
       looping playlists: повторение плейлистов
@@ -789,7 +797,7 @@ Video:
       Volume: 'Громкость: {volumePercentage}%'
       Bandwidth: 'Пропускная способность: {bandwidth} кбит/с'
     You appear to be offline: Похоже, вы Оффлайн.
-    Skipped segment: Пропущен {segmentCategory} сегмент
+    Skipped segment: 'Пропущено: {segmentCategory}'
     Playback will resume automatically when your connection comes back: Воспроизведение будет возобновлено автоматически, когда соединение будет восстановлено.
     Audio Tracks: Аудиодорожки
     Theatre Mode: Широкий экран
@@ -806,8 +814,8 @@ Video:
   Unlisted: Отсутствует в списках
   AgeRestricted: Видео с возрастными ограничениями нельзя смотреть через OpenTubeX, так как для этого требуется вход в Google и использование подтвержденной учетной записи YouTube.
   DeArrow:
-    Show Original Details: Показать стандартные свойства
-    Show Modified Details: Показать модифицированные свойства
+    Show Original Details: Показать изначальные сведения
+    Show Modified Details: Показать изменённые сведения
 #& Playlists
   DRMProtected: Видео, защищенное DRM, не может быть воспроизведено в OpenTubeX, так как оно требует использования проприетарных компонентов с закрытым исходным кодом. Если вы хотите посмотреть это видео, пожалуйста, смотрите его на официальном сайте YouTube в веб-браузере с поддержкой DRM.
   Save Watched Progress: Сохранение прогресса просмотренного видео

--- a/static/locales/sk.yaml
+++ b/static/locales/sk.yaml
@@ -574,7 +574,7 @@ Settings:
     Proxy Username: Používateľský názov proxy
     Proxy Warning: OpenTubeX nemá vstavaný proxy server, ale môže sa pripojiť k externému proxy serveru, napríklad k serveru bežiacemu na vašom počítači, ako je Tor, alebo k externému proxy serveru, ako je SOCKS5 proxy server poskytovaný niektorými VPN. Ak je táto funkcia povolená, uistite sa, že je váš proxy server/Tor správne nakonfigurovaný, inak OpenTubeX nebude môcť načítať žiadne údaje.
   SponsorBlock Settings:
-    Notify when sponsor segment is skipped: Upozorniť, keď bude segment sponzora preskočený
+    Notify when sponsor segment is skipped: Zobraziť upozornenie pri preskočení segmentu
     'SponsorBlock API Url (Default is https://sponsor.ajay.app)': URL API SponsorBlock (predvolená adresa je https://sponsor.ajay.app)
     Enable SponsorBlock: Zapnúť SponsorBlock
     SponsorBlock Settings: SponsorBlock
@@ -749,14 +749,22 @@ Video:
   Video has been saved: Video bolo uložené
   Save Video: Uložiť video
   Sponsor Block category:
-    music offtopic: Hudba offtopic
-    interaction: Interakcia
-    self-promotion: Sebapropagácia
-    outro: Záver
-    intro: Úvod
+    music offtopic: 'Hudba: časť bez hudby'
+    interaction: Pripomienka interakcie (Prihlásiť sa na odber)
+    self-promotion: Neplatená/Vlastná propagácia
+    outro: Koncové karty / titulky
+    intro: Prerušenie/Úvodná animácia
     sponsor: Sponzor
-    filler: Výplň
-    recap: Zhrnutie
+    filler: Mimo tému/vtipy
+    recap: Náhľad / zhrnutie
+    hook: Zaujatie / Pozdravy
+    highlight: Hlavný obsah videa
+    exclusive access: Exkluzívny Prístup
+  Sponsor Block category short:
+    intro: Prerušenie
+    interaction: Pripomienka interakcie
+    music offtopic: Bez hudby
+    filler: Mimo tému
   External Player:
     OpenInTemplate: Otvoriť v {externalPlayer}
     Unsupported Actions:
@@ -773,7 +781,7 @@ Video:
     OpeningTemplate: Otvára sa {videoOrPlaylist} v {externalPlayer}...
 #& Playlists
   Player:
-    Skipped segment: Preskočený segment {segmentCategory}
+    Skipped segment: '{segmentCategory} preskočené'
     Playback will resume automatically when your connection comes back: Prehrávanie bude automaticky pokračovať, keď sa obnoví pripojenie.
     You appear to be offline: Zdá sa, že ste offline.
     Stats:
@@ -802,7 +810,7 @@ Video:
     Audio Tracks: Zvukové stopy
     TranslatedCaptionTemplate: '{language} (preložené z "{originalLanguage}")'
   DeArrow:
-    Show Modified Details: Zobraziť upravené detaily
+    Show Modified Details: Zobraziť upravené podrobnosti
     Show Original Details: Zobraziť pôvodné detaily
   Published:
     In less than a minute: Za menej ako minútu

--- a/static/locales/sr.yaml
+++ b/static/locales/sr.yaml
@@ -558,7 +558,7 @@ Settings:
     Experimental Settings: Експериментално
     Warning: Ова подешавања су експериментална, могу да доведу до отказивања док су омогућена. Прављење резервних копија је веома препоручљиво. Користите на властиту одговорност!
   SponsorBlock Settings:
-    Notify when sponsor segment is skipped: Обавештење када се спонзор сегмент прескочи
+    Notify when sponsor segment is skipped: Прикажи обавештење након што је сегмент прескочен
     'SponsorBlock API Url (Default is https://sponsor.ajay.app)': URL API-ја SponsorBlock-а (Подразумевано је https://sponsor.ajay.app)
     Skip Options:
       Skip Option: Опција прескакања
@@ -762,14 +762,22 @@ Video:
     In less than a minute: За мање од једног минута
   Upcoming: Предстојеће
   Sponsor Block category:
-    interaction: Интеракција
-    filler: Попуњавање
-    music offtopic: Сегмент без музике
-    outro: Завршна анимација
-    self-promotion: Самопромоција
+    interaction: Подсетник о интеракцији (праћење)
+    filler: Дигресије/Шале
+    music offtopic: 'Музика: Сегмент без музике'
+    outro: Завршне картице/Заслуге
+    self-promotion: Неплаћена промоција/Самопромоција
     sponsor: Спонзор
-    recap: Рекапитулација
-    intro: Уводна анимација
+    recap: Преглед/Рекапитулација
+    intro: Пауза/Уводна анимација
+    hook: Мамац/Поздрави
+    highlight: Истакнуто
+    exclusive access: Ексклузивни приступ
+  Sponsor Block category short:
+    intro: Пауза
+    interaction: Подсетник за интеракцију
+    music offtopic: Без музике
+    filler: Дигресије
   External Player:
     Unsupported Actions:
       opening playlists: отварање плејлиста
@@ -822,7 +830,7 @@ Video:
     Full Window: Цео прозор
     You appear to be offline: Изгледа да сте офлајн.
     Playback will resume automatically when your connection comes back: Репродукција ће се аутоматски наставити када се ваша интернет веза врати.
-    Skipped segment: Прескочен сегмент „{segmentCategory}“
+    Skipped segment: 'Прескочен сегмент: {segmentCategory}'
     Autoplay is off: Аутоматско пуштање је искључено
     Autoplay is on: Аутоматско пуштање је укључено
   IP block: YouTube је блокирао вашу IP адресу за гледање видео снимака. Покушајте прећи на други VPN или прокси.

--- a/static/locales/sv.yaml
+++ b/static/locales/sv.yaml
@@ -584,7 +584,7 @@ Settings:
     Proxy Username: Proxyanvändarnamn
     Proxy Password: Proxylösenord
   SponsorBlock Settings:
-    Notify when sponsor segment is skipped: Avisera när ett sponsorsegment hoppas över
+    Notify when sponsor segment is skipped: Visa ett meddelande efter att ett segment har hoppats över
     'SponsorBlock API Url (Default is https://sponsor.ajay.app)': 'URL till SponsorBlock-API:t (förvald: https://sponsor.ajay.app)'
     Enable SponsorBlock: Använd sponsorblockering (SponsorBlock)
     SponsorBlock Settings: SponsorBlock
@@ -802,14 +802,22 @@ Video:
   Video has been saved: Videon har sparats
   Save Video: Spara videon
   Sponsor Block category:
-    music offtopic: Musik utanför ämnet
-    interaction: Interaktion
-    self-promotion: Självmarknadsföring
-    outro: Avslut
-    intro: Intro
-    sponsor: Sponsring
-    recap: Sammanfattning
-    filler: Utfyllnad
+    music offtopic: 'Musik: Icke-musikavsnitt'
+    interaction: Interaktionspåminnelse (prenumerera)
+    self-promotion: Obetald reklam​/egenreklam
+    outro: Slutkort/eftertexter
+    intro: Uppehåll/introduktion
+    sponsor: Sponsor
+    recap: Förhandstitt/Sammanfattning
+    filler: Ämnesavvikelse/skämt
+    hook: Hook/Hälsningar
+    highlight: Höjdpunkt
+    exclusive access: Exklusiv tillgång
+  Sponsor Block category short:
+    intro: Uppehåll
+    interaction: Interaktions­påminnelse
+    music offtopic: Icke-musik
+    filler: Ämnesavvikelse
   External Player:
     Unsupported Actions:
       shuffling playlists: blanda spellistor
@@ -852,7 +860,7 @@ Video:
     Hide Stats: Dölj statistik
     You appear to be offline: Du verkar vara offline.
     Playback will resume automatically when your connection comes back: Uppspelningen återupptas automatiskt när anslutningen återkommer.
-    Skipped segment: Hoppade över {segmentCategory}-segmentet
+    Skipped segment: '{segmentCategory} hoppades över'
     Audio Tracks: Ljudspår
     Autoplay is off: Automatisk uppspelning är inaktiverad
     Autoplay is on: Automatisk uppspelning är aktiverad
@@ -867,7 +875,7 @@ Video:
   DRMProtected: DRM-skyddade videor kan inte spelas upp i OpenTubeX eftersom de kräver proprietära komponenter med sluten källkod. Öppna videon på YouTubes officiella webbplats i en DRM-kompatibel webbläsare.
   DeArrow:
     Show Original Details: Visa originaldetaljer
-    Show Modified Details: Visa ändrade detaljer
+    Show Modified Details: Visa ändrade uppgifter
   Unlisted: Olistad
   MembersOnly: Videor endast för medlemmar kan inte ses med OpenTubeX eftersom de kräver Google-inloggning och betalt medlemskap på uppladdarens kanal.
   Watched Progress Saved: Visningspositionen har sparats

--- a/static/locales/ta.yaml
+++ b/static/locales/ta.yaml
@@ -637,7 +637,7 @@ Settings:
     SponsorBlock Settings: 'ஒப்புரவாளர் தொகுதி'
     Enable SponsorBlock: 'ஒப்புரவாளர் பிளாக் இயக்கவும்'
     'SponsorBlock API Url (Default is https://sponsor.ajay.app)': 'ஒப்புரவாளர் பிளாக் பநிஇ முகவரி (இயல்புநிலை https://sponsor.ajay.app)'
-    Notify when sponsor segment is skipped: 'ஒப்புரவாளர் பிரிவு தவிர்க்கப்படும்போது அறிவிக்கவும்'
+    Notify when sponsor segment is skipped: ஒரு பிரிவு தவிர்க்கப்பட்ட பிறகு அறிவிப்பைக் காட்டு
     UseDeArrowTitles: 'அன்புள்ள வீடியோ தலைப்புகளைப் பயன்படுத்தவும்'
     UseDeArrowThumbnails: 'சிறுபடங்களுக்கு டியர்ரோவைப் பயன்படுத்தவும்'
     'DeArrow Thumbnail Generator API Url (Default is https://dearrow-thumb.ajay.app)': 'அன்புள்ள சிறு செனரேட்டர் பநிஇ முகவரி (இயல்புநிலை https://dearrow-thumb.ajay.app)'
@@ -878,14 +878,20 @@ Video:
   Started streaming on: 'ச்ட்ரீமிங் செய்யத் தொடங்கியது'
   Publicationtemplate: ''
   Sponsor Block category:
-    sponsor: 'ஒப்புரவாளர்'
-    intro: 'அறிமுகம்'
-    outro: 'மற்றொன்று'
-    self-promotion: 'தன்வய ஊக்குவிப்பு'
-    interaction: 'உள்வினை'
-    music offtopic: 'மியூசிக் ஆஃப் டோபிக்'
+    sponsor: ஸ்பான்சர்
+    intro: இடைமறிப்பு / அறிமுக அனிமேஷன்
+    outro: எண்ட்கார்டுகள் / வரவு
+    self-promotion: செலுத்தப்படாத / சுய ஊக்குவிப்பு
+    interaction: தொடர்பு நினைவூட்டல் (குழுசேர்)
+    music offtopic: 'இசை: இசை அல்லாத பிரிவு'
     recap: 'மறுபரிசீலனை செய்யுங்கள்'
     filler: 'தடி'
+    highlight: முன்னிலைப்படுத்த
+    exclusive access: பிரத்யேக அணுகல்
+  Sponsor Block category short:
+    intro: இடைமறிப்பு
+    interaction: தொடர்பு நினைவூட்டல்
+    music offtopic: இசை அல்லாதது
   External Player:
     OpenInTemplate: '{externalPlayer} இல் திறக்கவும்'
     video: 'ஒளிதோற்றம்'
@@ -926,7 +932,7 @@ Video:
       CodecsVideoAudioNoItags: 'கோடெக்குகள்: {videoCodec} / {audioCodec}'
     You appear to be offline: 'நீங்கள் ஆஃப்லைனில் இருப்பதாகத் தெரிகிறது.'
     Playback will resume automatically when your connection comes back: 'உங்கள் இணைப்பு மீண்டும் வரும்போது பிளேபேக் தானாகவே மீண்டும் தொடங்கும்.'
-    Skipped segment: '{segmentCategory} பிரிவு தவிர்க்கப்பட்டது'
+    Skipped segment: '{segmentCategory} தவிர்க்கப்பட்டது'
 #& Videos
     Autoplay is off: ஆட்டோபிளே முடக்கப்பட்டுள்ளது
     Autoplay is on: ஆட்டோபிளே இயக்கத்தில் உள்ளது

--- a/static/locales/tr.yaml
+++ b/static/locales/tr.yaml
@@ -583,7 +583,7 @@ Settings:
     Proxy Username: Vekil Kullanıcı Adı
     Proxy Password: Vekil Parolası
   SponsorBlock Settings:
-    Notify when sponsor segment is skipped: Sponsor bölümü atlandığında bildir
+    Notify when sponsor segment is skipped: Bir Kısmı Atladıktan Sonra Uyarı Göster
     'SponsorBlock API Url (Default is https://sponsor.ajay.app)': SponsorBlock API bağlantısı (Varsayılan https://sponsor.ajay.app)
     Enable SponsorBlock: SponsorBlock'u Etkinleştir
     SponsorBlock Settings: SponsorBlock
@@ -804,14 +804,22 @@ Video:
   Video has been saved: Video kaydedildi
   Save Video: Videoyu Kaydet
   Sponsor Block category:
-    music offtopic: Müzik Konu Dışı
-    interaction: Etkileşim
-    self-promotion: Kendini Tanıtma
-    outro: Çıkış
-    intro: Giriş
+    music offtopic: 'Müzik: Müzik Olmayan Bölüm'
+    interaction: Etkileşim Hatırlatıcısı (Abonelik)
+    self-promotion: Karşılıksız/Kendi Reklamı
+    outro: Bitiş Ekranı/Jenerik
+    intro: Aralık/Giriş Animasyonu
     sponsor: Sponsor
-    recap: Özet
-    filler: Dolgu
+    recap: Ön İzleme/Özet
+    filler: Geyik Muhabbeti / Şakalar
+    hook: Açılış/Selamlama
+    highlight: Vurgu
+    exclusive access: Özel Erişim
+  Sponsor Block category short:
+    intro: Aralık
+    interaction: Etkileşim Hatırlatıcısı
+    music offtopic: Müzik Olmayan Bölüm
+    filler: Alâkasız
   External Player:
     Unsupported Actions:
       looping playlists: döngüsel oynatma listeleri
@@ -860,7 +868,7 @@ Video:
     Hide Stats: İstatistikleri Gizle
     You appear to be offline: Çevrim dışı görünüyorsunuz.
     Playback will resume automatically when your connection comes back: Bağlantınız geri geldiğinde oynatma otomatik olarak devam edecektir.
-    Skipped segment: '{segmentCategory} bölümü atlandı'
+    Skipped segment: '{segmentCategory} Atlandı'
     Autoplay is off: Otomatik Oynat Kapalı
     Autoplay is on: Otomatik Oynat Açık
   IP block: YouTube, IP adresinizin video izlemesini engelledi. Lütfen farklı bir VPN veya vekil sunucuya geçmeyi deneyin.
@@ -868,8 +876,8 @@ Video:
   AgeRestricted: Yaş sınırlamalı videolar, Google hesabına giriş ve yaş doğrulaması yapılmış bir YouTube hesabının kullanımını gerektirdiği için OpenTubeX üzerinden izlenemez.
   MembersOnly: Sadece üyelere özel videolar, Google hesabına giriş ve yükleyicinin kanalına ücretli abonelik gerektirdiği için OpenTubeX üzerinden izlenemez.
   DeArrow:
-    Show Original Details: Düzenlenmemiş Detayları Göster
-    Show Modified Details: Düzenlenmiş Detayları Göster
+    Show Original Details: Orijinal Ayrıntıları Göster
+    Show Modified Details: Değiştirilmiş Ayrıntıları Göster
 #& Playlists
   DRMProtected: DRM korumalı videolar, özel kapalı kaynak bileşenleri gerektirdiğinden OpenTubeX ile oynatılamaz. Bu videoyu izlemek istiyorsanız lütfen resmi YouTube web sitesinde DRM etkinleştirilmiş bir web tarayıcısında izleyin.
   Watched Progress Saved: İzlenen İlerleme Kaydedildi

--- a/static/locales/uk.yaml
+++ b/static/locales/uk.yaml
@@ -568,7 +568,7 @@ Settings:
     Proxy Username: Ім'я користувача проксі-сервера
     Proxy Password: Пароль проксі-сервера
   SponsorBlock Settings:
-    Notify when sponsor segment is skipped: Сповіщати про пропуск спонсорованого відтинка
+    Notify when sponsor segment is skipped: Показувати сповіщення після пропуску сегмента
     'SponsorBlock API Url (Default is https://sponsor.ajay.app)': URL-адреса API SponsorBlock (типово https://sponsor.ajay.app)
     Enable SponsorBlock: Увімкнути SponsorBlock
     SponsorBlock Settings: SponsorBlock
@@ -784,14 +784,22 @@ Video:
   Video has been saved: Відео збережено
   Save Video: Зберегти відео
   Sponsor Block category:
-    music offtopic: Музика поза темою
-    interaction: Взаємодія
-    self-promotion: Самореклама
-    outro: Кінцівка
-    intro: Вступ
+    music offtopic: 'Музика: Немузичний фрагмент'
+    interaction: Нагадування про взаємодію (підписка)
+    self-promotion: Неоплачена / самореклама
+    outro: Кінцеві заставки / Титри
+    intro: Перебивка / Заставка
     sponsor: Спонсор
-    recap: Підсумок
-    filler: Заповнювач
+    recap: Анонс / Повтор
+    filler: Відступи / Жарти
+    hook: Зачіпка / Привітання
+    highlight: Найцікавіший момент
+    exclusive access: Ексклюзивний доступ
+  Sponsor Block category short:
+    intro: Заставка
+    interaction: Нагадування про взаємодію
+    music offtopic: Без музики
+    filler: Відступи
   External Player:
     Unsupported Actions:
       looping playlists: зациклювання добірок
@@ -839,7 +847,7 @@ Video:
     Audio Tracks: Аудіотреки
     Theatre Mode: Режим кінотеатру
     Hide Stats: Приховати статистику
-    Skipped segment: Пропущено сегмент {segmentCategory}
+    Skipped segment: 'Пропущено: {segmentCategory}'
     Autoplay is off: Автовідтворення вимкнено
     Autoplay is on: Автовідтворення увімкнено
   IP block: YouTube заблокував вашу IP-адресу для перегляду відео. Будь ласка, спробуйте змінити VPN або проксі.
@@ -847,8 +855,8 @@ Video:
   AgeRestricted: Відео з віковими обмеженнями не можна переглядати за допомогою OpenTubeX, оскільки вони вимагають входу через Google та використання відео-аккаунту YouTube з підтвердженням віку.
   More Options: Більше опцій
   DeArrow:
-    Show Original Details: Показати оригінальні деталі
-    Show Modified Details: Показати змінені деталі
+    Show Original Details: Показати оригінальну інформацію
+    Show Modified Details: Показати змінену інформацію
   MembersOnly: Відео, доступні лише для учасників, не можна переглядати за допомогою OpenTubeX, оскільки вони вимагають входу через Google та платної підписки на канал завантажувача.
   DRMProtected: Відео, захищені DRM, неможливо відтворити у OpenTubeX, оскільки для цього потрібні пропрієтарні компоненти з закритим вихідним кодом. Щоб переглянути це відео, скористайтеся офіційним сайтом YouTube у веб-браузері з підтримкою DRM.
 #& Playlists

--- a/static/locales/vi.yaml
+++ b/static/locales/vi.yaml
@@ -572,7 +572,7 @@ Settings:
       Auto Skip: Tự động bỏ qua
       Prompt To Skip: Nhắc nhở bỏ qua
       Do Nothing: Không làm gì
-    Notify when sponsor segment is skipped: Thông báo khi đoạn quảng cáo bị bỏ qua
+    Notify when sponsor segment is skipped: Hiển thị thông báo sau khi bỏ qua phân đoạn
     Category Color: Bản màu
     SponsorBlock Settings: SponsorBlock
     'DeArrow Thumbnail Generator API Url (Default is https://dearrow-thumb.ajay.app)': URL API ảnh xem trước DeArrow (Mặc định là https://dearrow-thumb.ajay.app)
@@ -735,13 +735,21 @@ Video:
   Copy YouTube Channel Link: Sao chép liên kết của kênh
   Sponsor Block category:
     sponsor: Nhà tài trợ
-    intro: Giới thiệu
-    self-promotion: Tự thúc đẩy
-    interaction: Tương tác
-    music offtopic: Nhạc ngoại tuyến
-    outro: Kết thúc
-    recap: Tóm tắt
-    filler: Bộ lọc
+    intro: Tạm dừng/Giới thiệu
+    self-promotion: Quảng cáo không trả công/Tự quảng cáo
+    interaction: Nhắc tương tác (Đăng ký)
+    music offtopic: 'Nhạc: Phần không nhạc'
+    outro: Màn hình kết thúc/Danh đề
+    recap: Xem trước/Tóm tắt
+    filler: 'Lạc đề, nhảm nhí/Câu đùa'
+    hook: Gây chú ý/Lời chào
+    highlight: Điểm/Khoảnh khắc quan trọng
+    exclusive access: Truy cập riêng
+  Sponsor Block category short:
+    intro: Tạm ngừng
+    interaction: Nhắc nhở tương tác
+    music offtopic: Không có nhạc
+    filler: 'Các đoạn lạc đề, nhảm nhí'
   Streamed on: Phát trực tiếp vào lúc
   Started streaming on: Bắt đầu phát trực tiếp vào lúc
   External Player:
@@ -788,7 +796,7 @@ Video:
       Stats: Thông tin nâng cao
       Media Formats: 'Định dạng: {formats}'
       Dropped Frames / Total Frames: 'Khung bị bỏ: {droppedFrames} / tổng số khung: {totalFrames}'
-    Skipped segment: Đã bỏ qua phân đoạn {segmentCategory}
+    Skipped segment: '{segmentCategory} đã bỏ qua'
     You appear to be offline: Bạn có vẻ đang offline.
     Playback will resume automatically when your connection comes back: Trình phát sẽ tự động tiếp tục khi bạn kết nối trở lại.
     TranslatedCaptionTemplate: '{language} (được dịch từ "{originalLanguage}")'
@@ -804,8 +812,8 @@ Video:
   AgeRestricted: Các video giới hạn độ tuổi không thể được xem qua OpenTubeX vì chúng yêu cầu đăng nhập qua Google và sử dụng một tài khoản YouTube đã được xác minh độ tuổi.
   IP block: YouTube đang chặn địa chị IP của bạn khỏi việc xem video. Hãy thử sử dụng một VPN hoặc proxy khác.
   DeArrow:
-    Show Modified Details: Hiện thông tin đã sửa đổi
-    Show Original Details: Hiện thông tin gốc
+    Show Modified Details: Hiện chi tiết đã sửa đổi
+    Show Original Details: Hiện chi tiết gốc
 #& Playlists
   Unlisted: Không liệt kê
   DRMProtected: Không thể phát video được bảo vệ DRM trong OpenTubeX vì chúng yêu cầu các thành phần nguồn đóng độc quyền. Nếu bạn muốn xem video này, vui lòng xem trên trang web chính thức của YouTube trong trình duyệt web hỗ trợ DRM.

--- a/static/locales/zh-CN.yaml
+++ b/static/locales/zh-CN.yaml
@@ -577,7 +577,7 @@ Settings:
     Proxy Username: 代理用户名
     Proxy Password: 代理密码
   SponsorBlock Settings:
-    Notify when sponsor segment is skipped: 当赞助商时间被跳过时通知
+    Notify when sponsor segment is skipped: 在跳过片段后显示通知
     'SponsorBlock API Url (Default is https://sponsor.ajay.app)': 赞助商区域调用的API地址（默认是 https://sponsor.ajay.app）
     Enable SponsorBlock: 开启赞助商区域
     SponsorBlock Settings: SponsorBlock
@@ -771,14 +771,22 @@ Video:
       starting video at offset: 在偏移处开始视频
       opening playlists: 打开播放列表
   Sponsor Block category:
-    outro: 结尾部分
-    self-promotion: 自我推销
-    interaction: 互动
-    music offtopic: 无关音乐
-    intro: 介绍
-    sponsor: 赞助者
-    recap: 回顾
-    filler: 过滤器
+    outro: 结束画面/结尾职员表
+    self-promotion: 无偿的/自我推广
+    interaction: 互动提醒（订阅）
+    music offtopic: 音乐：非音乐部分
+    intro: 过场/开场动画
+    sponsor: 赞助商广告
+    recap: 预览/概要
+    filler: 偏题/笑话
+    hook: 引子/问候
+    highlight: 精彩时刻
+    exclusive access: 独家限定
+  Sponsor Block category short:
+    intro: 过场
+    interaction: 互动提醒
+    music offtopic: 非音乐
+    filler: 偏题
   Premieres: 首映
   Scroll to Bottom: 滚动到底部
   Show Super Chat Comment: 显示超级聊天评论
@@ -813,7 +821,7 @@ Video:
     Playback will resume automatically when your connection comes back: 网络连接恢复时，将自动继续播放。
     TranslatedCaptionTemplate: '{language} (翻译自 "{originalLanguage}")'
     Exit Theatre Mode: 推出影院模式
-    Skipped segment: 跳过了 {segmentCategory} 部分
+    Skipped segment: '已跳过{segmentCategory}个片段'
     Autoplay is off: 自动播放关闭
     Autoplay is on: 自动播放开启
   IP block: 你的 IP 地址被 Youtube 禁止观看视频。请试着切换到不同的 VPN 或代理。
@@ -821,8 +829,8 @@ Video:
   AgeRestricted: 无法用 OpenTubeX 观看受限年龄的视频，因这些视频需要 Google 登录并使用验证过年龄的 YouTube 账户。
   Unlisted: 不公开列出的视频
   DeArrow:
-    Show Modified Details: 显示修改过的详情
-    Show Original Details: 显示原始详情
+    Show Modified Details: 显示修改后的详细信息
+    Show Original Details: 显示原始详细信息
   DRMProtected: OpenTubeX 无法播放受 DRM 保护的视频，因它们需要专有的、闭源的部件。如果要观看此视频，，请在启用了 DRM 的网页浏览器中在官方 YouTube 网站上观看。
 #& Playlists
   Watched Progress Saved: 保存了已观看进度

--- a/static/locales/zh-TW.yaml
+++ b/static/locales/zh-TW.yaml
@@ -563,7 +563,7 @@ Settings:
     Proxy Username: 代理伺服器使用者名稱
     Proxy Password: 代理伺服器密碼
   SponsorBlock Settings:
-    Notify when sponsor segment is skipped: 當贊助商片段被跳過時通知
+    Notify when sponsor segment is skipped: 在跳過片段後顯示通知
     'SponsorBlock API Url (Default is https://sponsor.ajay.app)': SponsorBlock API 網址（預設為 https://sponsor.ajay.app）
     Enable SponsorBlock: 啟用 SponsorBlock
     SponsorBlock Settings: SponsorBlock
@@ -742,14 +742,21 @@ Video:
   Video has been saved: 影片已儲存
   Save Video: 儲存影片至播放清單
   Sponsor Block category:
-    music offtopic: 音樂離題
-    interaction: 互動
-    self-promotion: 自我推廣
-    outro: 其他
-    intro: 介紹
-    sponsor: 贊助商
+    music offtopic: 音樂：非音樂部分
+    interaction: 互動提醒（訂閱）
+    self-promotion: 非付費/自我推廣
+    outro: 片尾畫面/鳴謝
+    intro: 過場/開頭動畫
+    sponsor: 贊助廣告
     recap: 回顧
-    filler: 填充
+    filler: 離題/笑話
+    highlight: 精華
+    exclusive access: 獨家限定
+  Sponsor Block category short:
+    intro: 過場
+    interaction: 互動提醒
+    music offtopic: 非音樂片段
+    filler: 離題
   External Player:
     Unsupported Actions:
       looping playlists: 循環播放清單
@@ -798,7 +805,7 @@ Video:
       CodecsVideoAudioNoItags: 編解碼器：{videoCodec} / {audioCodec}
     You appear to be offline: 您似乎已離線。
     Playback will resume automatically when your connection comes back: 當您的連線恢復時，將會自動繼續播放。
-    Skipped segment: 已跳過 {segmentCategory} 段
+    Skipped segment: '已跳過 {segmentCategory}'
     Autoplay is on: 自動播放已開啟
     Autoplay is off: 自動播放已關閉
   IP block: YouTube 已封鎖您的 IP 位址，因此無法觀看影片。請嘗試切換到其他 VPN 或代理伺服器。


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Make sure to follow the contributing guidelines. -->
<!-- Important note, we may remove your pull request if you do not use this provided PR template correctly. -->
<!-- Agent instructions: Preserve every heading, comment, and marker in this template. Never remove or rewrite the release-note-category:start/end, release-note:start/end, or release-note-image:start/end marker pairs. Never remove or rewrite the Release note images section; leave its contents for a human. -->

## Pull Request Type
<!-- Please select what type of pull request this is: [x] -->
- [ ] Bugfix
- [x] Feature Implementation
- [ ] Documentation
- [ ] Other

## Related issue
<!-- Please link the issue your pull request is referring to. -->
<!-- If this pull request fully resolves the relevant issue, put "closes" before the issue number. -->
<!-- Example: "closes #123456". -->

## Description
<!-- Please write a clear and concise description of what the pull request does. -->
Improves SponsorBlock presentation and submission UX:

- Use custom `FtSelect` dropdowns in the segment submission panel instead of native selects
- Keep the submission panel inside the video area when a fullscreen/full-window dock is open
- Align category names and several player/settings strings with SponsorBlock extension wording, including short seekbar/skip-notice labels
- Default more categories to Prompt to Skip
- Make seekbar segment markers keep their category colors more clearly
- Let SponsorBlock settings category cards grow with longer translated titles

## Release note category
<!-- Select exactly one category. Every pull request must select one. -->
<!-- release-note-category:start -->
- [ ] Not noteworthy
- [ ] Highlights
- [x] More improvements
- [ ] Fixed bugs
<!-- release-note-category:end -->

## Release note
<!-- Required unless "Not noteworthy" is selected. -->
<!-- Write one concise, user-facing entry without a leading bullet. -->
<!-- release-note:start -->
Improved SponsorBlock labels (they now match the official browser extension), submission controls, and default skip prompts
<!-- release-note:end -->

## Release note images
<!-- Human-only: Agents must preserve this entire section and leave it empty. -->
<!-- Optional. Paste one or more Markdown images or HTML image tags here. -->
<!-- The release notes will use an HTML image tag and limit images taller than 300 pixels. -->
<!-- release-note-image:start -->

<!-- release-note-image:end -->

## Testing
<!-- How can reviewers verify that the PR produces correct results? -->
<!-- Please provide instructions so that others can ensure that your pull request would produce correct results. For examples see, https://github.com/FreeTubeApp/FreeTube/pull/5743, https://github.com/FreeTubeApp/FreeTube/pull/7349, https://github.com/FreeTubeApp/FreeTube/pull/5125, https://github.com/FreeTubeApp/FreeTube/pull/7338 -->
<!-- Agent instructions: Only write human-facing steps that explain how to verify the change while running this branch in dev mode. Include expected results and, when applicable, helpful console snippets for interactive verification. Do not include automated checks, commands, results, pass counts, or CI status. -->
1. Open a video with SponsorBlock enabled and create a draft segment, then open the submission panel.
2. Confirm category and segment type use the custom dropdowns, and that Exclusive Access only offers Full Video while other categories hide unavailable action types.
3. Enter fullscreen, open a side dock (chapters/comments/etc.), and confirm the submission panel stays over the video instead of under the dock.
4. Skip a segment with a short-named category (intro/interaction/music offtopic/filler) and confirm the toast/seekbar wording uses the short labels while Settings > SponsorBlock still shows the full names.
5. Reset SponsorBlock category skip options (or use a fresh profile) and confirm Intro/Outro/Recap/Hook/Music Off-Topic/Filler/Self Promo/Interaction default to Prompt to Skip.
6. Check that seekbar markers keep a clear category color over the played/buffered bar.

## Additional context
<!-- Add any other context about the pull request here. -->
Locale updates are value-only alignments with SponsorBlock extension strings where applicable. Skip option labels and Category Color were left as existing OpenTubeX wording.