### PR TITLE
Keep the current chapter centered in chapter lists

### DIFF
--- a/e2e/tests/network/watch.spec.mjs
+++ b/e2e/tests/network/watch.spec.mjs
@@ -730,6 +730,71 @@ test.describe('watch page', () => {
     )
   })
 
+  test('keeps the current chapter centered in the sidebar and fullscreen dock', async ({ page, innertube }) => {
+    test.skip(innertube.replay, 'watch page hydration needs the real API')
+    await openVideo(page)
+
+    const currentChapterIndex = 20
+    const watchComponent = await page.evaluateHandle(findWatchComponent)
+    await page.evaluate(async ({ component, chapterIndex }) => {
+      const watchView = component.proxy
+      if (!watchView) {
+        throw new Error('Unable to access the watch view')
+      }
+
+      watchView.videoChapters = Array.from({ length: 40 }, (_, index) => ({
+        title: `Test chapter ${index + 1}`,
+        timestamp: `${index}:00`,
+        startSeconds: index * 60,
+        endSeconds: (index + 1) * 60
+      }))
+      watchView.videoCurrentChapterIndex = chapterIndex
+      watchView.showSidebarChapters = true
+      await watchView.$nextTick()
+    }, { component: watchComponent, chapterIndex: currentChapterIndex })
+
+    const panel = page.locator('.watchVideoChaptersPanel')
+    await expect(panel).toBeVisible()
+    await expect.poll(() => panel.evaluate((element) => {
+      const container = element.querySelector('.chaptersWrapper')
+      const currentChapter = container?.querySelector('.chapter.current')
+      if (!container || !currentChapter) {
+        return Number.POSITIVE_INFINITY
+      }
+
+      const containerBounds = container.getBoundingClientRect()
+      const chapterBounds = currentChapter.getBoundingClientRect()
+      const containerMid = containerBounds.top + containerBounds.height / 2
+      const chapterMid = chapterBounds.top + chapterBounds.height / 2
+      return Math.abs(containerMid - chapterMid)
+    })).toBeLessThan(40)
+
+    await panel.getByRole('button', { name: 'Close Chapters' }).click()
+    await expect(panel).toHaveCount(0)
+
+    await setPlayerFullscreen(page, true)
+    await page.evaluate(async (component) => {
+      component.refs.player.showChaptersOverlay = true
+      await component.proxy.$nextTick()
+    }, watchComponent)
+
+    const overlay = page.locator('.chapterOverlay')
+    await expect(overlay).toBeVisible()
+    await expect.poll(() => overlay.evaluate((element) => {
+      const container = element.querySelector('.chaptersWrapper')
+      const currentChapter = container?.querySelector('.chapter.current')
+      if (!container || !currentChapter) {
+        return Number.POSITIVE_INFINITY
+      }
+
+      const containerBounds = container.getBoundingClientRect()
+      const chapterBounds = currentChapter.getBoundingClientRect()
+      const containerMid = containerBounds.top + containerBounds.height / 2
+      const chapterMid = chapterBounds.top + chapterBounds.height / 2
+      return Math.abs(containerMid - chapterMid)
+    })).toBeLessThan(40)
+  })
+
   test('comments load on request', async ({ app, page, innertube }) => {
     test.skip(innertube.replay, 'watch page hydration needs the real API')
     await openVideo(page)

--- a/src/renderer/components/WatchVideoChapters/WatchVideoChapters.vue
+++ b/src/renderer/components/WatchVideoChapters/WatchVideoChapters.vue
@@ -215,6 +215,9 @@ function scrollToCurrentChapter(remainingAttempts = 5) {
   )
 
   if (top == null) {
+    if (remainingAttempts > 0) {
+      requestAnimationFrame(() => scrollToCurrentChapter(remainingAttempts - 1))
+    }
     return
   }
 

--- a/src/renderer/components/WatchVideoChapters/WatchVideoChapters.vue
+++ b/src/renderer/components/WatchVideoChapters/WatchVideoChapters.vue
@@ -57,6 +57,8 @@
 import { computed, ref, useTemplateRef, watch } from 'vue'
 import { FontAwesomeIcon } from '@fortawesome/vue-fontawesome'
 
+import { getCenteredChapterScrollTop } from './chapterScroll'
+
 const props = defineProps({
   chapters: {
     type: Array,
@@ -141,7 +143,9 @@ function getThumbnailStyle(thumbnail) {
 const observeVisibilityOptions = {
   callback: (isVisible, _entry) => {
     if (isVisible) {
-      scrollToCurrentChapter()
+      // Wait for the panel/dock layout to settle; centering with a zero-height
+      // container would scroll by half a row and clip the first chapter.
+      requestAnimationFrame(() => scrollToCurrentChapter())
     }
   },
   intersection: {
@@ -185,10 +189,11 @@ function navigateChapters(direction) {
 }
 
 /**
+ * @param {number} [remainingAttempts]
  */
-function scrollToCurrentChapter() {
+function scrollToCurrentChapter(remainingAttempts = 5) {
   const container = chaptersWrapper.value
-  const currentItem = container?.children[currentIndex.value]
+  const currentItem = container?.querySelectorAll(':scope > .chapter')[currentIndex.value]
 
   if (!container || !currentItem) {
     return
@@ -197,11 +202,23 @@ function scrollToCurrentChapter() {
   const containerRect = container.getBoundingClientRect()
   const currentItemRect = currentItem.getBoundingClientRect()
 
-  if (currentItemRect.top < containerRect.top) {
-    container.scrollTop += currentItemRect.top - containerRect.top
-  } else if (currentItemRect.bottom > containerRect.bottom) {
-    container.scrollTop += currentItemRect.bottom - containerRect.bottom
+  if (containerRect.height < currentItemRect.height && remainingAttempts > 0) {
+    requestAnimationFrame(() => scrollToCurrentChapter(remainingAttempts - 1))
+    return
   }
+
+  const top = getCenteredChapterScrollTop(
+    container.scrollTop + (currentItemRect.top - containerRect.top),
+    currentItemRect.height,
+    containerRect.height,
+    container.scrollHeight - container.clientHeight
+  )
+
+  if (top == null) {
+    return
+  }
+
+  container.scrollTo({ top, behavior: 'smooth' })
 }
 
 </script>

--- a/src/renderer/components/WatchVideoChapters/chapterScroll.js
+++ b/src/renderer/components/WatchVideoChapters/chapterScroll.js
@@ -1,0 +1,23 @@
+/**
+ * Scroll offset that places an item at the vertical center of its container.
+ * Returns `null` when the container is not laid out yet so callers can retry.
+ *
+ * @param {number} itemOffsetTop
+ * @param {number} itemHeight
+ * @param {number} containerHeight
+ * @param {number} [maxScrollTop]
+ * @returns {number | null}
+ */
+export function getCenteredChapterScrollTop(
+  itemOffsetTop,
+  itemHeight,
+  containerHeight,
+  maxScrollTop = Infinity
+) {
+  if (!(containerHeight > 0) || !(itemHeight > 0)) {
+    return null
+  }
+
+  const top = itemOffsetTop - containerHeight / 2 + itemHeight / 2
+  return Math.min(Math.max(0, top), Math.max(0, maxScrollTop))
+}

--- a/tests/unit/chapter-scroll.test.mjs
+++ b/tests/unit/chapter-scroll.test.mjs
@@ -1,0 +1,19 @@
+import assert from 'node:assert/strict'
+import test from 'node:test'
+
+import { getCenteredChapterScrollTop } from '../../src/renderer/components/WatchVideoChapters/chapterScroll.js'
+
+test('centers a chapter within its scroll container', () => {
+  assert.equal(getCenteredChapterScrollTop(1480, 74, 480, 5000), 1277)
+  assert.equal(getCenteredChapterScrollTop(200, 80, 400, 5000), 40)
+})
+
+test('clamps to the scroll range so the first and last chapters stay fully visible', () => {
+  assert.equal(getCenteredChapterScrollTop(0, 74, 480, 2000), 0)
+  assert.equal(getCenteredChapterScrollTop(3000, 74, 480, 2000), 2000)
+})
+
+test('skips scrolling when the container is not laid out yet', () => {
+  assert.equal(getCenteredChapterScrollTop(0, 74, 0, 2000), null)
+  assert.equal(getCenteredChapterScrollTop(0, 0, 480, 2000), null)
+})


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Make sure to follow the contributing guidelines. -->
<!-- Important note, we may remove your pull request if you do not use this provided PR template correctly. -->
<!-- Agent instructions: Preserve every heading, comment, and marker in this template. Never remove or rewrite the release-note-category:start/end, release-note:start/end, or release-note-image:start/end marker pairs. Never remove or rewrite the Release note images section; leave its contents for a human. -->

## Pull Request Type
<!-- Please select what type of pull request this is: [x] -->
- [ ] Bugfix
- [x] Feature Implementation
- [ ] Documentation
- [ ] Other

## Related issue
<!-- Please link the issue your pull request is referring to. -->
<!-- If this pull request fully resolves the relevant issue, put "closes" before the issue number. -->
<!-- Example: "closes #123456". -->

## Description
<!-- Please write a clear and concise description of what the pull request does. -->
Keep the active chapter vertically centered in the chapters sidebar and fullscreen dock as playback advances. Wait for the list layout before scrolling and clamp the offset so the first/last chapters are not clipped when they cannot be centered.

## Release note category
<!-- Select exactly one category. Every pull request must select one. -->
<!-- release-note-category:start -->
- [ ] Not noteworthy
- [ ] Highlights
- [x] More improvements
- [ ] Fixed bugs
<!-- release-note-category:end -->

## Release note
<!-- Required unless "Not noteworthy" is selected. -->
<!-- Write one concise, user-facing entry without a leading bullet. -->
<!-- release-note:start -->
The chapters sidebar and fullscreen dock keep the current chapter centered while you watch
<!-- release-note:end -->

## Release note images
<!-- Human-only: Agents must preserve this entire section and leave it empty. -->
<!-- Optional. Paste one or more Markdown images or HTML image tags here. -->
<!-- The release notes will use an HTML image tag and limit images taller than 300 pixels. -->
<!-- release-note-image:start -->

<!-- release-note-image:end -->

## Testing
<!-- How can reviewers verify that the PR produces correct results? -->
<!-- Please provide instructions so that others can ensure that your pull request would produce correct results. For examples see, https://github.com/FreeTubeApp/FreeTube/pull/5743, https://github.com/FreeTubeApp/FreeTube/pull/7349, https://github.com/FreeTubeApp/FreeTube/pull/5125, https://github.com/FreeTubeApp/FreeTube/pull/7338 -->
<!-- Agent instructions: Only write human-facing steps that explain how to verify the change while running this branch in dev mode. Include expected results and, when applicable, helpful console snippets for interactive verification. Do not include automated checks, commands, results, pass counts, or CI status. -->
1. Open a long video with many chapters and show the chapters sidebar.
2. Seek near the middle of the video so a mid-list chapter is current — that chapter should sit near the vertical center of the list.
3. Seek back to the start — the first chapter should be fully visible at the top (not clipped under the header).
4. Enter fullscreen, open the chapters dock, and repeat steps 2–3 — the same centering and clamping should apply.

## Additional context
<!-- Add any other context about the pull request here. -->