### PR TITLE
fix(ui): align channel settings quality select with slider

### DIFF
--- a/src/renderer/components/ChannelSettings/ChannelSettings.css
+++ b/src/renderer/components/ChannelSettings/ChannelSettings.css
@@ -98,9 +98,7 @@
   display: grid;
   grid-template-columns: repeat(auto-fit, minmax(210px, 1fr));
   gap: 0.5em 1em;
-
-  /* Room for FtSelect's absolutely positioned floating label above the control */
-  margin-block-start: 1.5em;
+  margin-block-start: 0.75em;
 }
 
 .channelPreference {
@@ -110,6 +108,10 @@
 
   /* Keeps the rows level even though the controls have different natural heights */
   min-block-size: 56px;
+
+  /* Per-row room for FtSelect's floating label so wrapped auto-fit rows stay clear.
+     Applied to every preference so side-by-side controls keep a shared centre line. */
+  padding-block-start: 30px;
 }
 
 /* Each control ships its own spacing for use in a settings page, which would

--- a/src/renderer/components/ChannelSettings/ChannelSettings.css
+++ b/src/renderer/components/ChannelSettings/ChannelSettings.css
@@ -98,7 +98,9 @@
   display: grid;
   grid-template-columns: repeat(auto-fit, minmax(210px, 1fr));
   gap: 0.5em 1em;
-  margin-block-start: 0.75em;
+
+  /* Room for FtSelect's absolutely positioned floating label above the control */
+  margin-block-start: 1.5em;
 }
 
 .channelPreference {
@@ -111,7 +113,8 @@
 }
 
 /* Each control ships its own spacing for use in a settings page, which would
-   leave the rows here indented by different amounts. */
+   leave the rows here indented by different amounts. Drop FtSelect's top margin
+   too so the select box centres with the slider instead of sitting below it. */
 .channelPreference :deep(.pure-material-slider) {
   inline-size: auto;
   margin: 0;
@@ -120,6 +123,7 @@
 
 .channelPreference :deep(.select) {
   inline-size: auto;
+  margin-block-start: 0;
 }
 
 .preferenceIcon {
@@ -131,12 +135,4 @@
 .channelPreference > :nth-child(2) {
   flex: 1;
   min-inline-size: 0;
-}
-
-/* FtSelect reserves space above itself for its floating label, which pushes the
-   select box below the row's centre. Reserve the same space for the row's other
-   items, so they line up with the box instead of the label. */
-.channelPreference:has(.select) > .preferenceIcon,
-.channelPreference:has(.select) > :last-child {
-  margin-block-start: 30px;
 }


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Make sure to follow the contributing guidelines. -->
<!-- Important note, we may remove your pull request if you do not use this provided PR template correctly. -->
<!-- Agent instructions: Preserve every heading, comment, and marker in this template. Never remove or rewrite the release-note-category:start/end, release-note:start/end, or release-note-image:start/end marker pairs. Never remove or rewrite the Release note images section; leave its contents for a human. -->

## Pull Request Type
<!-- Please select what type of pull request this is: [x] -->
- [x] Bugfix
- [ ] Feature Implementation
- [ ] Documentation
- [ ] Other

## Related issue
<!-- Please link the issue your pull request is referring to. -->
<!-- If this pull request fully resolves the relevant issue, put "closes" before the issue number. -->
<!-- Example: "closes #123456". -->

## Description
<!-- Please write a clear and concise description of what the pull request does. -->
In the channel settings manager, the video quality select sat below the playback speed slider because `FtSelect`'s top margin for its floating label was included in flex centering. Remove that margin in this layout and give the preferences block a bit more top space so the floating label still fits.

## Release note category
<!-- Select exactly one category. Every pull request must select one. -->
<!-- release-note-category:start -->
- [x] Not noteworthy
- [ ] Highlights
- [ ] More improvements
- [ ] Fixed bugs
<!-- release-note-category:end -->

## Release note
<!-- Required unless "Not noteworthy" is selected. -->
<!-- Write one concise, user-facing entry without a leading bullet. -->
<!-- release-note:start -->
Fixed the video quality dropdown not lining up with the playback speed slider in channel settings
<!-- release-note:end -->

## Release note images
<!-- Human-only: Agents must preserve this entire section and leave it empty. -->
<!-- Optional. Paste one or more Markdown images or HTML image tags here. -->
<!-- The release notes will use an HTML image tag and limit images taller than 300 pixels. -->
<!-- release-note-image:start -->

<!-- release-note-image:end -->

## Testing
<!-- How can reviewers verify that the PR produces correct results? -->
<!-- Please provide instructions so that others can ensure that your pull request would produce correct results. For examples see, https://github.com/FreeTubeApp/FreeTube/pull/5743, https://github.com/FreeTubeApp/FreeTube/pull/7349, https://github.com/FreeTubeApp/FreeTube/pull/5125, https://github.com/FreeTubeApp/FreeTube/pull/7338 -->
<!-- Agent instructions: Only write human-facing steps that explain how to verify the change while running this branch in dev mode. Include expected results and, when applicable, helpful console snippets for interactive verification. Do not include automated checks, commands, results, pass counts, or CI status. -->
1. Open Settings → Channel Settings and open the channel settings manager.
2. Add playback speed and video quality overrides for the same channel so both controls appear side by side.
3. Confirm the quality select box is vertically centered with the playback speed slider (and with the row icons / clear buttons).
4. Confirm the "Video Quality" floating label still sits clearly above the select and is not clipped.

## Additional context
<!-- Add any other context about the pull request here. -->