### PR TITLE
feat(ui): morph video thumbnails into newly opened tabs

### DIFF
--- a/e2e/helpers/app.mjs
+++ b/e2e/helpers/app.mjs
@@ -88,6 +88,10 @@ export async function launchApp(userDataDir, extraArgs = []) {
     ELECTRON_OZONE_PLATFORM_HINT: 'x11'
   }
   delete env.WAYLAND_DISPLAY
+  // Cursor / some agent shells set this, which turns Electron into plain Node
+  // and breaks require('electron') / Playwright's Electron launcher.
+  delete env.ELECTRON_RUN_AS_NODE
+  delete env.ELECTRON_NO_ATTACH_CONSOLE
 
   // The E2E build lives in its own directory so a running `pnpm dev`
   // (which rebuilds dist/ in development mode) can't clobber it.

--- a/e2e/helpers/app.mjs
+++ b/e2e/helpers/app.mjs
@@ -88,10 +88,6 @@ export async function launchApp(userDataDir, extraArgs = []) {
     ELECTRON_OZONE_PLATFORM_HINT: 'x11'
   }
   delete env.WAYLAND_DISPLAY
-  // Cursor / some agent shells set this, which turns Electron into plain Node
-  // and breaks require('electron') / Playwright's Electron launcher.
-  delete env.ELECTRON_RUN_AS_NODE
-  delete env.ELECTRON_NO_ATTACH_CONSOLE
 
   // The E2E build lives in its own directory so a running `pnpm dev`
   // (which rebuilds dist/ in development mode) can't clobber it.

--- a/e2e/tests/offline/subscriptions-new-feed.spec.mjs
+++ b/e2e/tests/offline/subscriptions-new-feed.spec.mjs
@@ -1,4 +1,4 @@
-import { test, expect, goTo } from '../../helpers/app.mjs'
+import { test, expect, goTo, sel } from '../../helpers/app.mjs'
 
 const now = Date.now()
 const HOUR = 3600000
@@ -364,6 +364,56 @@ test.describe('classic Shorts watch layout', () => {
     const morphClasses = await page.evaluate(() => window.__watchMorphClasses)
     expect(morphClasses.some(value => value.includes('viewTransitionMorphActive'))).toBe(true)
     expect(morphClasses.some(value => value.includes('viewTransitionShortMorphActive'))).toBe(false)
+  })
+})
+
+test.describe('new tab thumbnail morph', () => {
+  test.use({
+    seed: {
+      settings: {
+        ...commonSettings,
+        listType: 'grid',
+        reducedMotion: 'off',
+        thumbnailSize: 180
+      },
+      profiles: [profile()],
+      history: watchedHistory,
+      subscriptionCache: populatedCache
+    }
+  })
+
+  test('middle-click flies the thumbnail into the new background tab', async ({ page }) => {
+    await goTo(page, 'subscriptions')
+    await page.locator('[data-subscription-feed-tab="all"]').click()
+
+    const video = page.locator('.ft-list-video').filter({
+      has: page.getByRole('heading', { name: 'New video', exact: true })
+    })
+    await expect(video).toBeVisible()
+    await expect(page.locator(sel.tabs)).toHaveCount(1)
+
+    await page.evaluate(() => {
+      window.__sawTabThumbnailMorph = false
+      const observer = new MutationObserver((mutations) => {
+        for (const mutation of mutations) {
+          for (const node of mutation.addedNodes) {
+            if (node instanceof HTMLElement && node.classList.contains('tabThumbnailMorph')) {
+              window.__sawTabThumbnailMorph = true
+            }
+          }
+        }
+      })
+      observer.observe(document.body, { childList: true })
+    })
+
+    const currentUrl = page.url()
+    await video.locator('.thumbnailLink').click({ button: 'middle' })
+
+    await expect(page.locator(sel.tabs)).toHaveCount(2)
+    // Background open keeps the current tab on subscriptions
+    await expect(page).toHaveURL(currentUrl)
+    await expect(page.locator(sel.tabs).first()).toHaveClass(/active/)
+    await expect.poll(() => page.evaluate(() => window.__sawTabThumbnailMorph)).toBe(true)
   })
 })
 

--- a/src/renderer/components/FtListVideo/FtListVideo.vue
+++ b/src/renderer/components/FtListVideo/FtListVideo.vue
@@ -1204,7 +1204,15 @@ function handleWatchPageLinkClick(event) {
     return
   }
 
-  if (process.env.IS_ELECTRON && event?.button === 1) {
+  const isMiddleClick = process.env.IS_ELECTRON && event?.button === 1
+  const isModifierNewTabClick = process.env.IS_ELECTRON &&
+    event?.button === 0 &&
+    (event.ctrlKey || event.metaKey) &&
+    !event.altKey
+
+  // Middle-click and Ctrl/Cmd(+Shift)+click open a new tab/window so we can
+  // morph the thumbnail into the new tab (native window.open cannot).
+  if (isMiddleClick || isModifierNewTabClick) {
     event.preventDefault()
 
     openInternalPath({
@@ -1213,7 +1221,9 @@ function handleWatchPageLinkClick(event) {
       title: title.value,
       doCreateNewWindow: event.shiftKey,
       doCreateNewTab: !event.shiftKey,
-      makeActive: false
+      // Middle-click opens in the background; Ctrl/Cmd+click activates the tab
+      makeActive: !isMiddleClick,
+      morphSource: event.currentTarget
     })
     return
   }

--- a/src/renderer/helpers/tabMorph.js
+++ b/src/renderer/helpers/tabMorph.js
@@ -1,0 +1,227 @@
+import { nextTick } from 'vue'
+import { applyAnimationSpeed } from './animationSpeed.js'
+import { isReducedMotionEnabled } from './reducedMotion.js'
+
+const MORPH_DURATION_MS = 320
+const TAB_ICON_SIZE_PX = 16
+const TAB_WAIT_TIMEOUT_MS = 1000
+
+/**
+ * @typedef {object} TabMorphSnapshot
+ * @property {string} src
+ * @property {DOMRect} from
+ * @property {string} fromBorderRadius
+ */
+
+/**
+ * Capture the thumbnail's on-screen geometry before a new tab is created.
+ * Must run while the source tab is still presented: activating the new tab
+ * hides the old content (`v-show`), which would zero out the rect.
+ *
+ * @param {EventTarget | null | undefined} sourceEl clicked link or thumbnail
+ * @returns {TabMorphSnapshot | null}
+ */
+export function captureTabMorphSnapshot(sourceEl) {
+  if (!process.env.IS_ELECTRON || isReducedMotionEnabled()) {
+    return null
+  }
+
+  const thumbnail = findThumbnailImage(sourceEl)
+  if (!(thumbnail instanceof HTMLImageElement)) {
+    return null
+  }
+
+  const src = thumbnail.currentSrc || thumbnail.src
+  if (!src) {
+    return null
+  }
+
+  const from = thumbnail.getBoundingClientRect()
+  if (from.width < 1 || from.height < 1) {
+    return null
+  }
+
+  return {
+    src,
+    from: DOMRect.fromRect(from),
+    fromBorderRadius: getComputedStyle(thumbnail).borderRadius || '0px'
+  }
+}
+
+/**
+ * Morph a previously captured video thumbnail into the new tab's icon slot.
+ *
+ * @param {TabMorphSnapshot | null | undefined} snapshot
+ * @param {string} tabId id of the tab that was just created
+ * @returns {Promise<void>}
+ */
+export async function morphThumbnailIntoTab(snapshot, tabId) {
+  if (!snapshot || typeof tabId !== 'string' || tabId.length === 0) {
+    return
+  }
+
+  const { src, from, fromBorderRadius } = snapshot
+
+  const tabEl = await waitForTabElement(tabId)
+  if (!tabEl) {
+    return
+  }
+
+  tabEl.scrollIntoView({ block: 'nearest', inline: 'nearest' })
+  await nextTick()
+  await waitForAnimationFrame()
+
+  // Re-measure after scroll / layout settling
+  const { rect: to, borderRadius: toBorderRadius, hideEl } = resolveTabMorphTarget(tabEl)
+  if (to.width < 1 || to.height < 1) {
+    return
+  }
+
+  const clone = document.createElement('img')
+  clone.src = src
+  clone.alt = ''
+  clone.className = 'tabThumbnailMorph'
+  clone.draggable = false
+  Object.assign(clone.style, {
+    left: `${from.left}px`,
+    top: `${from.top}px`,
+    width: `${from.width}px`,
+    height: `${from.height}px`,
+    borderRadius: fromBorderRadius
+  })
+  document.body.appendChild(clone)
+
+  if (hideEl) {
+    hideEl.style.visibility = 'hidden'
+  }
+
+  const animation = applyAnimationSpeed(clone.animate([
+    {
+      left: `${from.left}px`,
+      top: `${from.top}px`,
+      width: `${from.width}px`,
+      height: `${from.height}px`,
+      borderRadius: fromBorderRadius,
+      opacity: 1
+    },
+    {
+      left: `${to.left}px`,
+      top: `${to.top}px`,
+      width: `${to.width}px`,
+      height: `${to.height}px`,
+      borderRadius: toBorderRadius,
+      opacity: 1
+    }
+  ], {
+    duration: MORPH_DURATION_MS,
+    easing: 'cubic-bezier(0.4, 0, 0.2, 1)',
+    fill: 'forwards'
+  }))
+
+  try {
+    await animation.finished
+  } catch {
+    // Animation was cancelled (e.g. document torn down)
+  }
+
+  clone.remove()
+  if (hideEl) {
+    hideEl.style.visibility = ''
+  }
+}
+
+/**
+ * @param {EventTarget | null | undefined} sourceEl
+ * @returns {HTMLImageElement | null}
+ */
+function findThumbnailImage(sourceEl) {
+  if (!(sourceEl instanceof HTMLElement)) {
+    return null
+  }
+
+  if (sourceEl.classList.contains('thumbnailImage') && sourceEl instanceof HTMLImageElement) {
+    return sourceEl
+  }
+
+  const nested = sourceEl.querySelector('.thumbnailImage')
+  if (nested instanceof HTMLImageElement) {
+    return nested
+  }
+
+  const inCard = sourceEl.closest('.ft-list-video, .ft-list-item')?.querySelector('.thumbnailImage')
+  return inCard instanceof HTMLImageElement ? inCard : null
+}
+
+/**
+ * @param {string} tabId
+ * @returns {Promise<HTMLElement | null>}
+ */
+function waitForTabElement(tabId) {
+  const selector = `.tab[data-tab-id="${CSS.escape(tabId)}"]`
+  const existing = document.querySelector(selector)
+  if (existing instanceof HTMLElement) {
+    return Promise.resolve(existing)
+  }
+
+  return new Promise((resolve) => {
+    const timeoutId = window.setTimeout(() => {
+      observer.disconnect()
+      const late = document.querySelector(selector)
+      resolve(late instanceof HTMLElement ? late : null)
+    }, TAB_WAIT_TIMEOUT_MS)
+
+    const observer = new MutationObserver(() => {
+      const el = document.querySelector(selector)
+      if (el instanceof HTMLElement) {
+        window.clearTimeout(timeoutId)
+        observer.disconnect()
+        resolve(el)
+      }
+    })
+
+    observer.observe(document.body, { childList: true, subtree: true })
+  })
+}
+
+/**
+ * Prefer the real tab icon when present; otherwise aim at a 16×16 circle in the
+ * icon slot so the morph still lands cleanly while the loading dot is showing.
+ *
+ * @param {HTMLElement} tabEl
+ * @returns {{ rect: DOMRect, borderRadius: string, hideEl: HTMLElement | null }}
+ */
+function resolveTabMorphTarget(tabEl) {
+  const avatar = tabEl.querySelector('.tabAvatar')
+  if (avatar instanceof HTMLElement) {
+    return {
+      rect: avatar.getBoundingClientRect(),
+      borderRadius: '50%',
+      hideEl: avatar
+    }
+  }
+
+  const title = tabEl.querySelector('.tabTitle')
+  const anchor = (title instanceof HTMLElement ? title : tabEl).getBoundingClientRect()
+  const size = TAB_ICON_SIZE_PX
+  const top = anchor.top + (anchor.height - size) / 2
+  const isRtl = getComputedStyle(tabEl).direction === 'rtl'
+  const left = isRtl ? anchor.right - size : anchor.left
+  const icon = tabEl.querySelector('.loadingDot, .playingIcon, .tabPageIcon')
+
+  return {
+    rect: new DOMRect(left, top, size, size),
+    borderRadius: '50%',
+    hideEl: icon instanceof HTMLElement ? icon : null
+  }
+}
+
+/**
+ * @returns {Promise<void>}
+ */
+function waitForAnimationFrame() {
+  return new Promise((resolve) => {
+    requestAnimationFrame(() => {
+      requestAnimationFrame(() => resolve())
+    })
+  })
+}

--- a/src/renderer/helpers/utils.js
+++ b/src/renderer/helpers/utils.js
@@ -4,6 +4,7 @@ import router from '../router/index'
 import { getTabNavigationService } from '../tabs/TabNavigationService'
 import { UnsupportedPlayerActions } from '../../constants'
 import { getPreferredShortThumbnailUrl } from './player/shorts'
+import { captureTabMorphSnapshot, morphThumbnailIntoTab } from './tabMorph'
 
 // allowed characters in channel handle: A-Z, a-z, 0-9, -, _, .
 // https://support.google.com/youtube/answer/11585688#change_handle
@@ -402,8 +403,19 @@ export async function openExternalLink(url) {
  * @param {string} [params.title] initial title for the destination
  * @param {object} [params.query] the query params to use (optional)
  * @param {string} [params.searchQueryText] the text to show in the search bar in the new window (optional)
+ * @param {EventTarget | null} [params.morphSource] thumbnail/link to morph into the new tab (watch tabs only)
+ * @returns {Promise<{ id: string } | null | undefined>}
  */
-export function openInternalPath({ path, query = undefined, doCreateNewWindow = false, doCreateNewTab = false, makeActive = true, title = undefined, searchQueryText = null }) {
+export async function openInternalPath({
+  path,
+  query = undefined,
+  doCreateNewWindow = false,
+  doCreateNewTab = false,
+  makeActive = true,
+  title = undefined,
+  searchQueryText = null,
+  morphSource = null
+}) {
   if (process.env.IS_ELECTRON) {
     if (doCreateNewTab) {
       // Open in new tab
@@ -411,7 +423,12 @@ export function openInternalPath({ path, query = undefined, doCreateNewWindow = 
       if (route.startsWith('/')) {
         route = route.substring(1)
       }
-      window.ftElectron.tabs.create({
+      // Capture before create: activating the tab hides this view via v-show
+      const morphSnapshot = morphSource != null && path.startsWith('/watch/')
+        ? captureTabMorphSnapshot(morphSource)
+        : null
+
+      const created = await window.ftElectron.tabs.create({
         route,
         query,
         title,
@@ -420,6 +437,13 @@ export function openInternalPath({ path, query = undefined, doCreateNewWindow = 
         openerTabId: getTabNavigationService().getPresentedTabId(),
         preloadInBackground: !makeActive && path.startsWith('/watch/')
       })
+
+      if (morphSnapshot && created?.id) {
+        // Fire-and-forget so tab creation isn't blocked on the animation
+        morphThumbnailIntoTab(morphSnapshot, created.id)
+      }
+
+      return created
     } else if (doCreateNewWindow) {
       // Open in new window
       window.ftElectron.openInNewWindow(path, query, searchQueryText)
@@ -431,6 +455,7 @@ export function openInternalPath({ path, query = undefined, doCreateNewWindow = 
         state: title ? { tabTitle: title } : undefined
       })
     }
+    return null
   } else {
     // The web build has no tabs or windows of its own, so a Ctrl/middle/Shift+click
     // is handed to the browser, pointed at this app's route for the destination
@@ -441,7 +466,7 @@ export function openInternalPath({ path, query = undefined, doCreateNewWindow = 
       // `window.open` returns null when a popup blocker steps in,
       // navigating in place is better than doing nothing at all
       if (window.open(href, '_blank', doCreateNewWindow ? 'popup' : undefined) != null) {
-        return
+        return null
       }
     }
 
@@ -450,6 +475,7 @@ export function openInternalPath({ path, query = undefined, doCreateNewWindow = 
       query,
       state: title ? { tabTitle: title } : undefined
     })
+    return null
   }
 }
 

--- a/src/renderer/themes.css
+++ b/src/renderer/themes.css
@@ -2155,6 +2155,18 @@ a:visited {
   animation-timing-function: cubic-bezier(0.4, 0, 0.2, 1);
 }
 
+/* Flying thumbnail clone used when opening a watch page in a new tab
+   (see helpers/tabMorph.js). Kept out of layout and above the tab bar. */
+.tabThumbnailMorph {
+  position: fixed;
+  z-index: 10000;
+  margin: 0;
+  padding: 0;
+  pointer-events: none;
+  object-fit: cover;
+  box-sizing: border-box;
+}
+
 ::view-transition-old(root),
 ::view-transition-new(root) {
   animation-duration: 200ms;

--- a/tests/unit/tab-morph.test.mjs
+++ b/tests/unit/tab-morph.test.mjs
@@ -1,0 +1,312 @@
+import assert from 'node:assert/strict'
+import test from 'node:test'
+
+process.env.IS_ELECTRON = 'true'
+
+const matchMediaListeners = []
+const documentListeners = new Map()
+const appended = []
+const removed = []
+const animations = []
+
+class FakeDOMRect {
+  constructor(x = 0, y = 0, width = 0, height = 0) {
+    this.x = x
+    this.y = y
+    this.width = width
+    this.height = height
+    this.left = x
+    this.top = y
+    this.right = x + width
+    this.bottom = y + height
+  }
+
+  static fromRect(rect) {
+    return new FakeDOMRect(rect.x, rect.y, rect.width, rect.height)
+  }
+}
+
+class FakeAnimation {
+  constructor(keyframes, options) {
+    this.keyframes = keyframes
+    this.options = options
+    this.finished = Promise.resolve()
+    this.playbackRate = 1
+    animations.push(this)
+  }
+
+  updatePlaybackRate(rate) {
+    this.playbackRate = rate
+  }
+}
+
+function createFakeElement(tagName, { className = '', rect = null, children = [] } = {}) {
+  const classList = {
+    values: new Set(className.split(/\s+/).filter(Boolean)),
+    contains(name) {
+      return this.values.has(name)
+    },
+    add(name) {
+      this.values.add(name)
+    }
+  }
+
+  const style = {}
+  const el = {
+    tagName: tagName.toUpperCase(),
+    className,
+    classList,
+    style,
+    children: [...children],
+    dataset: {},
+    scrollIntoView() {},
+    getBoundingClientRect() {
+      return rect ?? new FakeDOMRect()
+    },
+    querySelector(selector) {
+      const match = (node) => {
+        if (selector.startsWith('.') && node.classList.contains(selector.slice(1))) {
+          return node
+        }
+        if (selector.includes(',')) {
+          return selector.split(',').map(part => part.trim()).some(part => match({
+            ...node,
+            matches: () => false
+          }) || (part.startsWith('.') && node.classList.contains(part.slice(1))))
+            ? node
+            : null
+        }
+        return null
+      }
+
+      for (const child of el.children) {
+        if (selector.startsWith('.') && child.classList.contains(selector.slice(1))) {
+          return child
+        }
+        if (selector.includes(',')) {
+          for (const part of selector.split(',').map(part => part.trim())) {
+            if (part.startsWith('.') && child.classList.contains(part.slice(1))) {
+              return child
+            }
+          }
+        }
+        const nested = child.querySelector?.(selector)
+        if (nested) {
+          return nested
+        }
+      }
+      return null
+    },
+    closest(selector) {
+      if (selector.split(',').some(part => {
+        const trimmed = part.trim()
+        return trimmed.startsWith('.') && classList.contains(trimmed.slice(1))
+      })) {
+        return el
+      }
+      return null
+    },
+    animate(keyframes, options) {
+      return new FakeAnimation(keyframes, options)
+    },
+    remove() {
+      removed.push(el)
+    }
+  }
+
+  if (tagName === 'img') {
+    el.src = ''
+    el.currentSrc = ''
+    el.alt = ''
+    el.draggable = true
+  }
+
+  return el
+}
+
+const body = createFakeElement('body')
+body.appendChild = (node) => {
+  appended.push(node)
+  body.children.push(node)
+}
+
+globalThis.DOMRect = FakeDOMRect
+globalThis.CSS = { escape: (value) => value }
+globalThis.HTMLElement = class HTMLElement {}
+globalThis.HTMLImageElement = class HTMLImageElement extends globalThis.HTMLElement {}
+globalThis.Element = class Element {}
+globalThis.requestAnimationFrame = (cb) => {
+  queueMicrotask(() => cb(0))
+  return 1
+}
+
+globalThis.window = {
+  matchMedia() {
+    return {
+      matches: false,
+      addEventListener(_type, listener) {
+        matchMediaListeners.push(listener)
+      }
+    }
+  },
+  setTimeout: globalThis.setTimeout.bind(globalThis),
+  clearTimeout: globalThis.clearTimeout.bind(globalThis)
+}
+
+globalThis.document = {
+  documentElement: {
+    dataset: {}
+  },
+  body,
+  addEventListener(type, listener) {
+    documentListeners.set(type, listener)
+  },
+  getAnimations() {
+    return []
+  },
+  querySelector(selector) {
+    if (selector.startsWith('.tab[data-tab-id=')) {
+      const id = selector.match(/data-tab-id="([^"]+)"/)?.[1]
+      return tabsById.get(id) ?? null
+    }
+    return null
+  },
+  createElement(tagName) {
+    const el = createFakeElement(tagName)
+    // Instances created through document.createElement need to pass instanceof checks
+    Object.setPrototypeOf(el, tagName === 'img' ? globalThis.HTMLImageElement.prototype : globalThis.HTMLElement.prototype)
+    return el
+  }
+}
+
+const tabsById = new Map()
+
+const {
+  setReducedMotionPreference
+} = await import('../../src/renderer/helpers/reducedMotion.js')
+
+const {
+  captureTabMorphSnapshot,
+  morphThumbnailIntoTab
+} = await import('../../src/renderer/helpers/tabMorph.js')
+
+function makeThumbnail({ x = 40, y = 80, width = 320, height = 180 } = {}) {
+  const thumbnail = createFakeElement('img', {
+    className: 'thumbnailImage',
+    rect: new FakeDOMRect(x, y, width, height)
+  })
+  Object.setPrototypeOf(thumbnail, globalThis.HTMLImageElement.prototype)
+  thumbnail.src = 'https://example.com/thumb.jpg'
+  thumbnail.currentSrc = thumbnail.src
+  thumbnail.style.borderRadius = '8px'
+
+  const link = createFakeElement('a', {
+    className: 'thumbnailLink',
+    children: [thumbnail]
+  })
+  Object.setPrototypeOf(link, globalThis.HTMLElement.prototype)
+  thumbnail.closest = (selector) => {
+    if (selector.includes('ft-list-video') || selector.includes('ft-list-item')) {
+      return createFakeElement('div', { className: 'ft-list-video', children: [link] })
+    }
+    return null
+  }
+
+  // getComputedStyle for the thumbnail
+  return { link, thumbnail }
+}
+
+globalThis.getComputedStyle = (el) => ({
+  borderRadius: el.style?.borderRadius || '0px',
+  direction: 'ltr',
+  paddingInlineStart: '10px'
+})
+
+test('captureTabMorphSnapshot reads the thumbnail geometry from a watch link', () => {
+  setReducedMotionPreference('off')
+  const { link, thumbnail } = makeThumbnail()
+
+  const snapshot = captureTabMorphSnapshot(link)
+
+  assert.deepEqual(snapshot, {
+    src: thumbnail.src,
+    from: new FakeDOMRect(40, 80, 320, 180),
+    fromBorderRadius: '8px'
+  })
+})
+
+test('captureTabMorphSnapshot is a no-op when reduced motion is enabled', () => {
+  setReducedMotionPreference('on')
+  const { link } = makeThumbnail()
+
+  assert.equal(captureTabMorphSnapshot(link), null)
+
+  setReducedMotionPreference('off')
+})
+
+test('morphThumbnailIntoTab animates a clone into the tab icon slot', async () => {
+  setReducedMotionPreference('off')
+  appended.length = 0
+  removed.length = 0
+  animations.length = 0
+
+  const tabTitle = createFakeElement('span', {
+    className: 'tabTitle',
+    rect: new FakeDOMRect(900, 10, 120, 16)
+  })
+  Object.setPrototypeOf(tabTitle, globalThis.HTMLElement.prototype)
+  const loadingDot = createFakeElement('span', { className: 'loadingDot' })
+  Object.setPrototypeOf(loadingDot, globalThis.HTMLElement.prototype)
+  tabTitle.children.push(loadingDot)
+
+  const tab = createFakeElement('div', {
+    className: 'tab',
+    children: [tabTitle]
+  })
+  Object.setPrototypeOf(tab, globalThis.HTMLElement.prototype)
+  tab.dataset.tabId = 'tab-1'
+  tabsById.set('tab-1', tab)
+
+  const snapshot = {
+    src: 'https://example.com/thumb.jpg',
+    from: new FakeDOMRect(40, 80, 320, 180),
+    fromBorderRadius: '8px'
+  }
+
+  await morphThumbnailIntoTab(snapshot, 'tab-1')
+
+  assert.equal(appended.length, 1)
+  assert.equal(appended[0].className, 'tabThumbnailMorph')
+  assert.equal(appended[0].src, snapshot.src)
+  assert.equal(animations.length, 1)
+  assert.equal(animations[0].options.duration, 320)
+  assert.deepEqual(animations[0].keyframes[0], {
+    left: '40px',
+    top: '80px',
+    width: '320px',
+    height: '180px',
+    borderRadius: '8px',
+    opacity: 1
+  })
+  assert.deepEqual(animations[0].keyframes[1], {
+    left: '900px',
+    top: '10px',
+    width: '16px',
+    height: '16px',
+    borderRadius: '50%',
+    opacity: 1
+  })
+  assert.equal(removed.length, 1)
+  assert.equal(loadingDot.style.visibility, '')
+})
+
+test('morphThumbnailIntoTab skips work without a snapshot or tab id', async () => {
+  appended.length = 0
+  await morphThumbnailIntoTab(null, 'tab-1')
+  await morphThumbnailIntoTab({
+    src: 'https://example.com/thumb.jpg',
+    from: new FakeDOMRect(0, 0, 10, 10),
+    fromBorderRadius: '0px'
+  }, '')
+  assert.equal(appended.length, 0)
+})


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Make sure to follow the contributing guidelines. -->
<!-- Important note, we may remove your pull request if you do not use this provided PR template correctly. -->
<!-- Agent instructions: Preserve every heading, comment, and marker in this template. Never remove or rewrite the release-note-category:start/end, release-note:start/end, or release-note-image:start/end marker pairs. Never remove or rewrite the Release note images section; leave its contents for a human. -->

## Pull Request Type
<!-- Please select what type of pull request this is: [x] -->
- [ ] Bugfix
- [x] Feature Implementation
- [ ] Documentation
- [ ] Other

## Related issue
<!-- Please link the issue your pull request is referring to. -->
<!-- If this pull request fully resolves the relevant issue, put "closes" before the issue number. -->
<!-- Example: "closes #123456". -->

## Description
<!-- Please write a clear and concise description of what the pull request does. -->
When opening a video in a new tab (middle-click or Ctrl/Cmd+click), the thumbnail now flies into the new tab's icon slot, matching the same-tab morph into the player.

Ctrl/Cmd+click on video cards goes through `openInternalPath` instead of native `window.open`, so the morph can run. The thumbnail geometry is captured before tab creation because activating the new tab hides the source view.

## Release note category
<!-- Select exactly one category. Every pull request must select one. -->
<!-- release-note-category:start -->
- [ ] Not noteworthy
- [ ] Highlights
- [x] More improvements
- [ ] Fixed bugs
<!-- release-note-category:end -->

## Release note
<!-- Required unless "Not noteworthy" is selected. -->
<!-- Write one concise, user-facing entry without a leading bullet. -->
<!-- release-note:start -->
Opening a video in a new tab now morphs its thumbnail into the tab
<!-- release-note:end -->

## Release note images
<!-- Human-only: Agents must preserve this entire section and leave it empty. -->
<!-- Optional. Paste one or more Markdown images or HTML image tags here. -->
<!-- The release notes will use an HTML image tag and limit images taller than 300 pixels. -->
<!-- release-note-image:start -->

<!-- release-note-image:end -->

## Testing
<!-- How can reviewers verify that the PR produces correct results? -->
<!-- Please provide instructions so that others can ensure that your pull request would produce correct results. For examples see, https://github.com/FreeTubeApp/FreeTube/pull/5743, https://github.com/FreeTubeApp/FreeTube/pull/7349, https://github.com/FreeTubeApp/FreeTube/pull/5125, https://github.com/FreeTubeApp/FreeTube/pull/7338 -->
<!-- Agent instructions: Only write human-facing steps that explain how to verify the change while running this branch in dev mode. Include expected results and, when applicable, helpful console snippets for interactive verification. Do not include automated checks, commands, results, pass counts, or CI status. -->
1. Open a feed with video cards (e.g. Subscriptions).
2. Middle-click a video thumbnail: a background tab opens and the thumbnail should fly into that tab's icon area; you stay on the current page.
3. Ctrl/Cmd+click a video thumbnail: a new active tab opens with the same flying morph.
4. With reduced motion enabled, the tab still opens but without the flying animation.

## Additional context
<!-- Add any other context about the pull request here. -->