### PR TITLE
fix(tabs): show full page content in tab previews

### DIFF
--- a/src/renderer/App.css
+++ b/src/renderer/App.css
@@ -316,9 +316,6 @@
 .tabSwitcherPreview img {
   inline-size: 100%;
   block-size: 100%;
-
-  /* Same as the tab tooltip: page captures are often wider than this box after
-     the chrome is cropped, so cover would clip the sides. */
   object-fit: contain;
 }
 

--- a/src/renderer/App.css
+++ b/src/renderer/App.css
@@ -316,7 +316,10 @@
 .tabSwitcherPreview img {
   inline-size: 100%;
   block-size: 100%;
-  object-fit: cover;
+
+  /* Same as the tab tooltip: page captures are often wider than this box after
+     the chrome is cropped, so cover would clip the sides. */
+  object-fit: contain;
 }
 
 .tabSwitcherPreview .tabSwitcherPreviewAvatar {

--- a/src/renderer/components/TabBar/SortableTab.vue
+++ b/src/renderer/components/TabBar/SortableTab.vue
@@ -739,9 +739,6 @@ watch(() => props.disableTooltips, (disableTooltips) => {
   display: block;
   inline-size: 100%;
   block-size: 100%;
-
-  /* Captures are the page content region (often wider than 16:9 after the
-     chrome is cropped). Cover would clip the sides; contain shows the full page. */
   object-fit: contain;
 }
 

--- a/src/renderer/components/TabBar/SortableTab.vue
+++ b/src/renderer/components/TabBar/SortableTab.vue
@@ -739,7 +739,10 @@ watch(() => props.disableTooltips, (disableTooltips) => {
   display: block;
   inline-size: 100%;
   block-size: 100%;
-  object-fit: cover;
+
+  /* Captures are the page content region (often wider than 16:9 after the
+     chrome is cropped). Cover would clip the sides; contain shows the full page. */
+  object-fit: contain;
 }
 
 .tabTooltipPreview .tabTooltipPreviewAvatar {


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Make sure to follow the contributing guidelines. -->
<!-- Important note, we may remove your pull request if you do not use this provided PR template correctly. -->
<!-- Agent instructions: Preserve every heading, comment, and marker in this template. Never remove or rewrite the release-note-category:start/end, release-note:start/end, or release-note-image:start/end marker pairs. Never remove or rewrite the Release note images section; leave its contents for a human. -->

## Pull Request Type
<!-- Please select what type of pull request this is: [x] -->
- [x] Bugfix
- [ ] Feature Implementation
- [ ] Documentation
- [ ] Other

## Related issue
<!-- Please link the issue your pull request is referring to. -->
<!-- If this pull request fully resolves the relevant issue, put "closes" before the issue number. -->
<!-- Example: "closes #123456". -->

## Description
<!-- Please write a clear and concise description of what the pull request does. -->
After #469 cropped the tab bar and header out of tab preview captures, horizontal-tab screenshots are often wider than 16:9. The tooltip and Ctrl+Tab switcher still used `object-fit: cover` in a fixed preview frame, which clipped the left and right edges.

Switch those screenshot previews to `object-fit: contain` so the full page content stays visible (avatars still use cover).

## Release note category
<!-- Select exactly one category. Every pull request must select one. -->
<!-- release-note-category:start -->
- [ ] Not noteworthy
- [ ] Highlights
- [ ] More improvements
- [x] Fixed bugs
<!-- release-note-category:end -->

## Release note
<!-- Required unless "Not noteworthy" is selected. -->
<!-- Write one concise, user-facing entry without a leading bullet. -->
<!-- release-note:start -->
Fixed tab previews being cropped on the left and right when using the horizontal tab bar
<!-- release-note:end -->

## Release note images
<!-- Human-only: Agents must preserve this entire section and leave it empty. -->
<!-- Optional. Paste one or more Markdown images or HTML image tags here. -->
<!-- The release notes will use an HTML image tag and limit images taller than 300 pixels. -->
<!-- release-note-image:start -->

<!-- release-note-image:end -->

## Testing
<!-- How can reviewers verify that the PR produces correct results? -->
<!-- Please provide instructions so that others can ensure that your pull request would produce correct results. For examples see, https://github.com/FreeTubeApp/FreeTube/pull/5743, https://github.com/FreeTubeApp/FreeTube/pull/7349, https://github.com/FreeTubeApp/FreeTube/pull/5125, https://github.com/FreeTubeApp/FreeTube/pull/7338 -->
<!-- Agent instructions: Only write human-facing steps that explain how to verify the change while running this branch in dev mode. Include expected results and, when applicable, helpful console snippets for interactive verification. Do not include automated checks, commands, results, pass counts, or CI status. -->
1. Use the horizontal tab bar (not the vertical layout).
2. Open a couple of tabs with page content wider than tall (home, subscriptions, a watch page).
3. Hover a tab until the preview tooltip appears — the full page content should be visible, with no left/right clipping (small letterboxing top/bottom is fine).
4. Press Ctrl+Tab and check the same for the switcher thumbnails.
5. Optionally switch to the vertical tab bar and confirm previews still look complete.

## Additional context
<!-- Add any other context about the pull request here. -->