### PR TITLE
fix: use runtime OS for managed tools and polish tab chrome

### DIFF
--- a/_scripts/webpack.main.config.js
+++ b/_scripts/webpack.main.config.js
@@ -53,7 +53,9 @@ const config = {
   },
   plugins: [
     new webpack.DefinePlugin({
-      'process.platform': `'${process.platform}'`,
+      // Do not bake process.platform here. Cross-compiling (e.g. macOS
+      // builds on Linux) would otherwise hardcode the build host OS and
+      // download the wrong managed yt-dlp/ffmpeg binaries at runtime.
       'process.env.IS_ELECTRON_MAIN': true
     })
   ],

--- a/_scripts/webpack.renderer.config.js
+++ b/_scripts/webpack.renderer.config.js
@@ -142,7 +142,9 @@ const config = {
   plugins: [
     processLocalesPlugin,
     new webpack.DefinePlugin({
-      'process.platform': `'${process.platform}'`,
+      // OTX_PLATFORM overrides the build host when cross-packing (e.g.
+      // OTX_PLATFORM=darwin while building a macOS zip on Linux).
+      'process.platform': JSON.stringify(process.env.OTX_PLATFORM || process.platform),
       'process.env.IS_ELECTRON': true,
       'process.env.IS_ELECTRON_MAIN': false,
       'process.env.SUPPORTS_LOCAL_API': true,

--- a/src/main/ytDlp.js
+++ b/src/main/ytDlp.js
@@ -12,32 +12,20 @@ import { getMatchingDownloadValidators, getYtDlpAssetName } from './ytDlpAsset'
 
 const execFileAsync = promisify(execFile)
 
-/** @type {Set<import('node:child_process').ChildProcess>} */
-const activeVersionProbes = new Set()
-
-function cancelActiveVersionProbes() {
-  for (const child of activeVersionProbes) {
-    child.kill()
-  }
-}
+/** @type {Map<string, AbortController>} */
+const getInfoAbortControllers = new Map()
 
 /**
- * @param {string} executable
- * @param {string[]} args
- * @returns {Promise<string | null>}
+ * Supersede an earlier ytDlpGetInfo for the same probe key. System and managed
+ * refreshes use different keys so they can run in parallel on mount.
+ * @param {string} key
+ * @returns {AbortSignal}
  */
-function runVersionProbe(executable, args) {
-  return new Promise((resolve) => {
-    const child = execFile(executable, args, { timeout: 60_000, windowsHide: true }, (error, stdout) => {
-      activeVersionProbes.delete(child)
-      if (error) {
-        resolve(null)
-        return
-      }
-      resolve(typeof stdout === 'string' ? stdout : stdout.toString())
-    })
-    activeVersionProbes.add(child)
-  })
+function takeGetInfoAbortSignal(key) {
+  getInfoAbortControllers.get(key)?.abort()
+  const controller = new AbortController()
+  getInfoAbortControllers.set(key, controller)
+  return controller.signal
 }
 
 /**
@@ -186,26 +174,41 @@ async function pushProxyArgument(args) {
 
 /**
  * @param {string} executable
+ * @param {AbortSignal} [signal] aborts a superseded ytDlpGetInfo probe
  * @returns {Promise<string | null>} the version, or null if the executable doesn't work
  */
-async function getYtDlpVersion(executable) {
-  // PyInstaller onefile builds extract on first launch; allow time for that on slow disks/VMs
-  const stdout = await runVersionProbe(executable, ['--version'])
-  return stdout?.trim() ?? null
+async function getYtDlpVersion(executable, signal) {
+  try {
+    // PyInstaller onefile builds extract on first launch; allow time for that on slow disks/VMs
+    const { stdout } = await execFileAsync(executable, ['--version'], {
+      timeout: 60_000,
+      windowsHide: true,
+      signal
+    })
+    return stdout.trim()
+  } catch {
+    return null
+  }
 }
 
 /**
  * @param {string} executable
+ * @param {AbortSignal} [signal] aborts a superseded ytDlpGetInfo probe
  * @returns {Promise<string | null>} the version, or null if the executable doesn't work
  */
-async function getFfmpegVersion(executable) {
-  const stdout = await runVersionProbe(executable, ['-version'])
-  if (stdout == null) {
+async function getFfmpegVersion(executable, signal) {
+  try {
+    const { stdout } = await execFileAsync(executable, ['-version'], {
+      timeout: 60_000,
+      windowsHide: true,
+      signal
+    })
+    const version = /^ffmpeg version (\S+)/.exec(stdout)?.[1] ?? null
+    // the martin-riedl.de builds embed their website URL in the version string
+    return version?.replace(/-https?:.*$/, '') ?? null
+  } catch {
     return null
   }
-  const version = /^ffmpeg version (\S+)/.exec(stdout)?.[1] ?? null
-  // the martin-riedl.de builds embed their website URL in the version string
-  return version?.replace(/-https?:.*$/, '') ?? null
 }
 
 /**
@@ -523,6 +526,23 @@ async function getBinaryInfo(resolved, getVersion) {
 }
 
 /**
+ * @param {{
+ *   ytDlpSource: 'system' | 'managed',
+ *   ytDlpPath: string,
+ *   ffmpegSource: 'system' | 'managed',
+ *   ffmpegPath: string
+ * } | undefined} options
+ * @returns {string}
+ */
+function getInfoProbeKey(options) {
+  if (options === undefined) {
+    return 'startup'
+  }
+
+  return `${options.ytDlpSource}:${options.ffmpegSource}`
+}
+
+/**
  * @param {import('electron').IpcMainInvokeEvent} event
  * @param {{
  *   ytDlpSource: 'system' | 'managed',
@@ -559,24 +579,36 @@ export async function handleYtDlpGetInfo(event, options) {
     return null
   }
 
-  // Drop in-flight probes from a superseded ytDlpGetInfo (e.g. rapid path edits)
-  // so the longer PyInstaller cold-start timeout cannot accumulate children.
-  cancelActiveVersionProbes()
+  // Abort superseded probes for this key (e.g. rapid path edits) so the longer
+  // PyInstaller cold-start timeout cannot accumulate children. System vs managed
+  // use different keys and stay concurrent.
+  const probeKey = getInfoProbeKey(options)
+  const signal = takeGetInfoAbortSignal(probeKey)
 
-  const [ytDlp, ffmpeg] = await Promise.all([
-    getBinaryInfo(
-      await resolveExecutable('ytDlpSource', 'ytDlpPath', 'yt-dlp', options?.ytDlpSource, options?.ytDlpPath),
-      getYtDlpVersion
-    ),
-    getBinaryInfo(
-      await resolveExecutable('ytDlpFfmpegSource', 'ytDlpFfmpegPath', 'ffmpeg', options?.ffmpegSource, options?.ffmpegPath),
-      getFfmpegVersion
-    )
-  ])
+  try {
+    const [ytDlp, ffmpeg] = await Promise.all([
+      getBinaryInfo(
+        await resolveExecutable('ytDlpSource', 'ytDlpPath', 'yt-dlp', options?.ytDlpSource, options?.ytDlpPath),
+        (executable) => getYtDlpVersion(executable, signal)
+      ),
+      getBinaryInfo(
+        await resolveExecutable('ytDlpFfmpegSource', 'ytDlpFfmpegPath', 'ffmpeg', options?.ffmpegSource, options?.ffmpegPath),
+        (executable) => getFfmpegVersion(executable, signal)
+      )
+    ])
 
-  return {
-    ytDlp,
-    ffmpeg
+    if (signal.aborted) {
+      return null
+    }
+
+    return {
+      ytDlp,
+      ffmpeg
+    }
+  } finally {
+    if (getInfoAbortControllers.get(probeKey)?.signal === signal) {
+      getInfoAbortControllers.delete(probeKey)
+    }
   }
 }
 

--- a/src/main/ytDlp.js
+++ b/src/main/ytDlp.js
@@ -162,7 +162,8 @@ async function pushProxyArgument(args) {
  */
 async function getYtDlpVersion(executable) {
   try {
-    const { stdout } = await execFileAsync(executable, ['--version'], { timeout: 10_000, windowsHide: true })
+    // PyInstaller onefile builds extract on first launch; allow time for that on slow disks/VMs
+    const { stdout } = await execFileAsync(executable, ['--version'], { timeout: 60_000, windowsHide: true })
     return stdout.trim()
   } catch {
     return null
@@ -175,7 +176,7 @@ async function getYtDlpVersion(executable) {
  */
 async function getFfmpegVersion(executable) {
   try {
-    const { stdout } = await execFileAsync(executable, ['-version'], { timeout: 10_000, windowsHide: true })
+    const { stdout } = await execFileAsync(executable, ['-version'], { timeout: 60_000, windowsHide: true })
     const version = /^ffmpeg version (\S+)/.exec(stdout)?.[1] ?? null
     // the martin-riedl.de builds embed their website URL in the version string
     return version?.replace(/-https?:.*$/, '') ?? null

--- a/src/main/ytDlp.js
+++ b/src/main/ytDlp.js
@@ -12,6 +12,34 @@ import { getMatchingDownloadValidators, getYtDlpAssetName } from './ytDlpAsset'
 
 const execFileAsync = promisify(execFile)
 
+/** @type {Set<import('node:child_process').ChildProcess>} */
+const activeVersionProbes = new Set()
+
+function cancelActiveVersionProbes() {
+  for (const child of activeVersionProbes) {
+    child.kill()
+  }
+}
+
+/**
+ * @param {string} executable
+ * @param {string[]} args
+ * @returns {Promise<string | null>}
+ */
+function runVersionProbe(executable, args) {
+  return new Promise((resolve) => {
+    const child = execFile(executable, args, { timeout: 60_000, windowsHide: true }, (error, stdout) => {
+      activeVersionProbes.delete(child)
+      if (error) {
+        resolve(null)
+        return
+      }
+      resolve(typeof stdout === 'string' ? stdout : stdout.toString())
+    })
+    activeVersionProbes.add(child)
+  })
+}
+
 /**
  * @typedef YtDlpDownloadPayload
  * @property {string} videoId
@@ -161,13 +189,9 @@ async function pushProxyArgument(args) {
  * @returns {Promise<string | null>} the version, or null if the executable doesn't work
  */
 async function getYtDlpVersion(executable) {
-  try {
-    // PyInstaller onefile builds extract on first launch; allow time for that on slow disks/VMs
-    const { stdout } = await execFileAsync(executable, ['--version'], { timeout: 60_000, windowsHide: true })
-    return stdout.trim()
-  } catch {
-    return null
-  }
+  // PyInstaller onefile builds extract on first launch; allow time for that on slow disks/VMs
+  const stdout = await runVersionProbe(executable, ['--version'])
+  return stdout?.trim() ?? null
 }
 
 /**
@@ -175,14 +199,13 @@ async function getYtDlpVersion(executable) {
  * @returns {Promise<string | null>} the version, or null if the executable doesn't work
  */
 async function getFfmpegVersion(executable) {
-  try {
-    const { stdout } = await execFileAsync(executable, ['-version'], { timeout: 60_000, windowsHide: true })
-    const version = /^ffmpeg version (\S+)/.exec(stdout)?.[1] ?? null
-    // the martin-riedl.de builds embed their website URL in the version string
-    return version?.replace(/-https?:.*$/, '') ?? null
-  } catch {
+  const stdout = await runVersionProbe(executable, ['-version'])
+  if (stdout == null) {
     return null
   }
+  const version = /^ffmpeg version (\S+)/.exec(stdout)?.[1] ?? null
+  // the martin-riedl.de builds embed their website URL in the version string
+  return version?.replace(/-https?:.*$/, '') ?? null
 }
 
 /**
@@ -535,6 +558,10 @@ export async function handleYtDlpGetInfo(event, options) {
   if (!await waitForFirstWindowShow(event.sender)) {
     return null
   }
+
+  // Drop in-flight probes from a superseded ytDlpGetInfo (e.g. rapid path edits)
+  // so the longer PyInstaller cold-start timeout cannot accumulate children.
+  cancelActiveVersionProbes()
 
   const [ytDlp, ffmpeg] = await Promise.all([
     getBinaryInfo(

--- a/src/renderer/components/ExternalSoftwareSettings.vue
+++ b/src/renderer/components/ExternalSoftwareSettings.vue
@@ -274,6 +274,16 @@ async function refreshSystemBinariesInfo() {
 
 async function refreshManagedBinariesInfo() {
   const requestId = ++managedInfoRequestId
+
+  // Stale "not downloaded" must not stick around while we re-probe after a
+  // download — null means the UI shows "Checking…".
+  if (binariesInfoCache.value.ytDlp.managed?.available === false) {
+    binariesInfoCache.value.ytDlp.managed = null
+  }
+  if (binariesInfoCache.value.ffmpeg.managed?.available === false) {
+    binariesInfoCache.value.ffmpeg.managed = null
+  }
+
   const info = await getBinariesInfo({
     ytDlpSource: 'managed',
     ytDlpPath: '',
@@ -424,6 +434,9 @@ async function downloadBinary(binary) {
     const result = await window.ftElectron.ytDlpDownloadBinary(binary)
 
     if (result != null && 'version' in result) {
+      const key = binary === 'yt-dlp' ? 'ytDlp' : 'ffmpeg'
+      binariesInfoCache.value[key].managed = { source: 'managed', available: true, version: result.version }
+
       if (result.updated) {
         showToast({
           message: binary === 'yt-dlp'

--- a/src/renderer/components/TabBar/SortableTab.vue
+++ b/src/renderer/components/TabBar/SortableTab.vue
@@ -435,7 +435,7 @@ watch(() => props.disableTooltips, (disableTooltips) => {
   background-color: var(--tab-surface-color, var(--bg-color));
   border-radius: calc(6px * var(--ui-roundness)) calc(6px * var(--ui-roundness)) 0 0;
   cursor: pointer;
-  block-size: 31px;
+  block-size: 30px;
 
   /* Without a configured fixed width, tabs size to their content within these
      bounds. `--fixed-tab-width` (set by the tab bar) pins both ends together. */

--- a/src/renderer/components/TabBar/TabBar.css
+++ b/src/renderer/components/TabBar/TabBar.css
@@ -8,12 +8,14 @@
   min-block-size: 32px;
   padding-inline: 4px;
   gap: 2px;
-  -webkit-app-region: drag;
   position: sticky;
   inset-block-start: 0;
   z-index: 5;
   inline-size: 100%;
-  overflow: hidden;
+
+  /* Horizontal scrolling is handled by .tabsContainer. A non-visible overflow-x
+     value would force overflow-y to clip too, which flattens the tab top radii. */
+  overflow: visible;
 }
 
 /* The horizontal bar shares the top edge with the sticky top navigation, so it

--- a/src/renderer/components/TopNav/TopNav.scss
+++ b/src/renderer/components/TopNav/TopNav.scss
@@ -71,8 +71,9 @@
   }
 }
 
-.menuButton {
-  @media only screen and (width <= 680px) {
+@media only screen and (width <= 680px) {
+  /* Beat .navButton { display: inline-flex } from the icon-pack styles. */
+  .menuButton.navButton {
     display: none;
   }
 }


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Make sure to follow the contributing guidelines. -->
<!-- Important note, we may remove your pull request if you do not use this provided PR template correctly. -->
<!-- Agent instructions: Preserve every heading, comment, and marker in this template. Never remove or rewrite the release-note-category:start/end, release-note:start/end, or release-note-image:start/end marker pairs. Never remove or rewrite the Release note images section; leave its contents for a human. -->

## Pull Request Type
<!-- Please select what type of pull request this is: [x] -->
- [x] Bugfix
- [ ] Feature Implementation
- [ ] Documentation
- [ ] Other

## Related issue
<!-- Please link the issue your pull request is referring to. -->
<!-- If this pull request fully resolves the relevant issue, put "closes" before the issue number. -->
<!-- Example: "closes #123456". -->

## Description
<!-- Please write a clear and concise description of what the pull request does. -->

Cross-compiled macOS builds were baking the Linux build host into `process.platform`, so managed yt-dlp/ffmpeg downloads installed Linux ELFs and failed with `exec format error`.

- Main: stop DefinePlugin-baking `process.platform` so downloads use the runtime OS
- Renderer: allow `OTX_PLATFORM` when cross-packing (e.g. `OTX_PLATFORM=darwin`)
- Managed tools UI: longer version-probe timeout for PyInstaller cold starts; show Checking… / version immediately after download
- Tab bar: remove `-webkit-app-region: drag` (content under the macOS title bar), keep top radii visible without extra top padding
- Narrow layout: hide the hamburger again when the bottom nav is active (specificity vs `.navButton { display: inline-flex }`)

## Release note category
<!-- Select exactly one category. Every pull request must select one. -->
<!-- release-note-category:start -->
- [ ] Not noteworthy
- [ ] Highlights
- [ ] More improvements
- [x] Fixed bugs
<!-- release-note-category:end -->

## Release note
<!-- Required unless "Not noteworthy" is selected. -->
<!-- Write one concise, user-facing entry without a leading bullet. -->
<!-- release-note:start -->
FIxed tab bar clipping on macOS plus the hamburger still showing with the bottom nav
<!-- release-note:end -->

## Release note images
<!-- Human-only: Agents must preserve this entire section and leave it empty. -->
<!-- Optional. Paste one or more Markdown images or HTML image tags here. -->
<!-- The release notes will use an HTML image tag and limit images taller than 300 pixels. -->
<!-- release-note-image:start -->

<!-- release-note-image:end -->

## Testing
<!-- How can reviewers verify that the PR produces correct results? -->
<!-- Please provide instructions so that others can ensure that your pull request would produce correct results. For examples see, https://github.com/FreeTubeApp/FreeTube/pull/5743, https://github.com/FreeTubeApp/FreeTube/pull/7349, https://github.com/FreeTubeApp/FreeTube/pull/5125, https://github.com/FreeTubeApp/FreeTube/pull/7338 -->
<!-- Agent instructions: Only write human-facing steps that explain how to verify the change while running this branch in dev mode. Include expected results and, when applicable, helpful console snippets for interactive verification. Do not include automated checks, commands, results, pass counts, or CI status. -->

1. On macOS (or a macOS VM), open Settings → External software and download managed yt-dlp/ffmpeg. Expect success and a version string (not “not downloaded” / exec format error). After download, the row should show Checking… then the version.
2. With a horizontal tab bar, confirm tabs sit flush under the title bar with visible top rounded corners and a centered +. Narrow the window below 680px and confirm the hamburger disappears while the bottom nav is shown; expanding the window brings the hamburger back.
3. When cross-packing a mac zip from Linux, run the renderer pack with `OTX_PLATFORM=darwin` so shortcut labels stay Mac-correct.

## Additional context
<!-- Add any other context about the pull request here. -->

Verified on a Monterey Intel VM with a Linux-cross-built macOS zip.