### PR TITLE
feat(player): show indicator when toggling skip silence via shortcut

### DIFF
--- a/e2e/tests/network/watch.spec.mjs
+++ b/e2e/tests/network/watch.spec.mjs
@@ -563,6 +563,44 @@ test.describe('watch page', () => {
     await expect.poll(async () => await video.evaluate((el) => el.playbackRate)).toBeLessThan(raisedRate)
   })
 
+  test.describe('fast-forward through silence shortcut', () => {
+    test.use({
+      seed: {
+        settings: {
+          keyboardShortcuts: JSON.stringify({
+            VIDEO_PLAYER: {
+              PLAYBACK: {
+                TOGGLE_SKIP_SILENCE: 'h'
+              }
+            }
+          })
+        }
+      }
+    })
+
+    test('shows an on-screen indicator when toggled', async ({ page, innertube }) => {
+      test.skip(!innertube.playback, 'needs real media streams')
+      await openVideo(page)
+      await waitForPlaybackOrSkip(test, page)
+
+      const popup = page.locator(`${activeTab} .valueChangePopup`)
+      const skipSilence = () => page.evaluate(() => {
+        const store = document.querySelector('#app').__vue_app__.config.globalProperties.$store
+        return store.getters.getSkipSilence
+      })
+
+      await page.locator('body').press('h')
+      await expect(popup).toBeVisible()
+      await expect(popup).toHaveText(/On/)
+      await expect.poll(skipSilence).toBe(true)
+
+      await page.locator('body').press('h')
+      await expect(popup).toBeVisible()
+      await expect(popup).toHaveText(/Off/)
+      await expect.poll(skipSilence).toBe(false)
+    })
+  })
+
   test('long transcripts quickly align with the current cue', async ({ page, innertube }) => {
     test.skip(innertube.replay, 'watch page hydration needs the real API')
     await page.route(/\/api\/timedtext/, route => route.fulfill({

--- a/src/renderer/components/ft-shaka-video-player/ft-shaka-video-player.js
+++ b/src/renderer/components/ft-shaka-video-player/ft-shaka-video-player.js
@@ -7314,7 +7314,12 @@ export default defineComponent({
         case matches(KeyboardShortcuts.VIDEO_PLAYER.PLAYBACK.TOGGLE_SKIP_SILENCE): {
           event.preventDefault()
           const enabled = !skipSilence.value
-          await updateSkipSilence(enabled)
+          try {
+            await updateSkipSilence(enabled)
+          } catch (error) {
+            console.error('Failed to update skip-silence setting:', error)
+            break
+          }
 
           // Only confirm the state that was actually persisted.
           if (skipSilence.value !== enabled) {

--- a/src/renderer/components/ft-shaka-video-player/ft-shaka-video-player.js
+++ b/src/renderer/components/ft-shaka-video-player/ft-shaka-video-player.js
@@ -1182,7 +1182,7 @@ export default defineComponent({
 
     /** @param {boolean} value */
     function updateSkipSilence(value) {
-      store.dispatch('updateSkipSilence', value)
+      return store.dispatch('updateSkipSilence', value)
     }
 
     watch(displayVideoPlayButton, (newValue) => {
@@ -7204,7 +7204,7 @@ export default defineComponent({
     /**
      * @param {KeyboardEvent} event
      */
-    function keyboardShortcutHandler(event) {
+    async function keyboardShortcutHandler(event) {
       if (!player || !isActiveTab.value) {
         return
       }
@@ -7314,7 +7314,12 @@ export default defineComponent({
         case matches(KeyboardShortcuts.VIDEO_PLAYER.PLAYBACK.TOGGLE_SKIP_SILENCE): {
           event.preventDefault()
           const enabled = !skipSilence.value
-          updateSkipSilence(enabled)
+          await updateSkipSilence(enabled)
+
+          // Only confirm the state that was actually persisted.
+          if (skipSilence.value !== enabled) {
+            break
+          }
 
           const localization = ui.getControls().getLocalization()
           const message = localization.resolve(enabled ? 'ON' : 'OFF')

--- a/src/renderer/components/ft-shaka-video-player/ft-shaka-video-player.js
+++ b/src/renderer/components/ft-shaka-video-player/ft-shaka-video-player.js
@@ -7311,10 +7311,17 @@ export default defineComponent({
           blurTooltipButtons()
           break
         }
-        case matches(KeyboardShortcuts.VIDEO_PLAYER.PLAYBACK.TOGGLE_SKIP_SILENCE):
+        case matches(KeyboardShortcuts.VIDEO_PLAYER.PLAYBACK.TOGGLE_SKIP_SILENCE): {
           event.preventDefault()
-          updateSkipSilence(!skipSilence.value)
+          const enabled = !skipSilence.value
+          updateSkipSilence(enabled)
+
+          const localization = ui.getControls().getLocalization()
+          const message = localization.resolve(enabled ? 'ON' : 'OFF')
+          showValueChange(message, 'forward-fast', true)
+          blurTooltipButtons()
           break
+        }
       }
 
       if (event.defaultPrevented) {

--- a/src/renderer/components/ft-shaka-video-player/ft-shaka-video-player.vue
+++ b/src/renderer/components/ft-shaka-video-player/ft-shaka-video-player.vue
@@ -740,30 +740,31 @@
       </div>
       <Transition name="fade">
         <div
-          v-if="showTemporaryPlaybackRateIndicator || silenceSkippingActive || showValueChangePopup"
+          v-if="showTemporaryPlaybackRateIndicator || showValueChangePopup || silenceSkippingActive"
           class="valueChangePopup"
           :class="{
             'invert-content-order':
-              showTemporaryPlaybackRateIndicator || silenceSkippingActive || invertValueChangeContentOrder
+              showTemporaryPlaybackRateIndicator ||
+              (showValueChangePopup ? invertValueChangeContentOrder : silenceSkippingActive)
           }"
         >
           <font-awesome-icon
-            v-if="showTemporaryPlaybackRateIndicator || silenceSkippingActive || valueChangeIcon"
+            v-if="showTemporaryPlaybackRateIndicator || (showValueChangePopup ? valueChangeIcon : silenceSkippingActive)"
             :icon="[
               'fas',
               showTemporaryPlaybackRateIndicator
                 ? 'forward'
-                : silenceSkippingActive
-                  ? 'forward-fast'
-                  : valueChangeIcon
+                : showValueChangePopup
+                  ? valueChangeIcon
+                  : 'forward-fast'
             ]"
           />
           <span>{{
             showTemporaryPlaybackRateIndicator
               ? temporaryPlaybackRateIndicatorMessage
-              : silenceSkippingActive
-                ? silenceSkippingIndicatorMessage
-                : valueChangeMessage
+              : showValueChangePopup
+                ? valueChangeMessage
+                : silenceSkippingIndicatorMessage
           }}</span>
         </div>
       </Transition>


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Make sure to follow the contributing guidelines. -->
<!-- Important note, we may remove your pull request if you do not use this provided PR template correctly. -->
<!-- Agent instructions: Preserve every heading, comment, and marker in this template. Never remove or rewrite the release-note-category:start/end, release-note:start/end, or release-note-image:start/end marker pairs. Never remove or rewrite the Release note images section; leave its contents for a human. -->

## Pull Request Type
<!-- Please select what type of pull request this is: [x] -->
- [ ] Bugfix
- [x] Feature Implementation
- [ ] Documentation
- [ ] Other

## Related issue
<!-- Please link the issue your pull request is referring to. -->
<!-- If this pull request fully resolves the relevant issue, put "closes" before the issue number. -->
<!-- Example: "closes #123456". -->
closes #528

## Description
<!-- Please write a clear and concise description of what the pull request does. -->
Shows the existing player value-change overlay when Fast-Forward Through Silence is toggled with a keyboard shortcut, so users get the same On/Off confirmation they already get for mute and playback rate.

Also prefers that temporary overlay over the active silence-acceleration rate display, so disable-while-accelerating still shows Off.

## Release note category
<!-- Select exactly one category. Every pull request must select one. -->
<!-- release-note-category:start -->
- [ ] Not noteworthy
- [ ] Highlights
- [x] More improvements
- [ ] Fixed bugs
<!-- release-note-category:end -->

## Release note
<!-- Required unless "Not noteworthy" is selected. -->
<!-- Write one concise, user-facing entry without a leading bullet. -->
<!-- release-note:start -->
Show an on-screen indicator when toggling Fast-Forward Through Silence with a keyboard shortcut
<!-- release-note:end -->

## Release note images
<!-- Human-only: Agents must preserve this entire section and leave it empty. -->
<!-- Optional. Paste one or more Markdown images or HTML image tags here. -->
<!-- The release notes will use an HTML image tag and limit images taller than 300 pixels. -->
<!-- release-note-image:start -->
<img width="125" height="51" alt="image" src="https://github.com/user-attachments/assets/61d0c53b-26fb-4588-8ec7-c37a7218627a" />
<img width="123" height="47" alt="image" src="https://github.com/user-attachments/assets/05c7862b-6167-4444-b467-580b9911cb43" />
<!-- release-note-image:end -->

## Testing
<!-- How can reviewers verify that the PR produces correct results? -->
<!-- Please provide instructions so that others can ensure that your pull request would produce correct results. For examples see, https://github.com/FreeTubeApp/FreeTube/pull/5743, https://github.com/FreeTubeApp/FreeTube/pull/7349, https://github.com/FreeTubeApp/FreeTube/pull/5125, https://github.com/FreeTubeApp/FreeTube/pull/7338 -->
<!-- Agent instructions: Only write human-facing steps that explain how to verify the change while running this branch in dev mode. Include expected results and, when applicable, helpful console snippets for interactive verification. Do not include automated checks, commands, results, pass counts, or CI status. -->
1. Open Settings → Keyboard Shortcuts and assign a key to Toggle Fast-Forward Through Silence (it has no default binding).
2. Open any non-live video and press that shortcut.
3. Confirm a brief center overlay appears with the fast-forward icon and **On**.
4. Press the shortcut again and confirm the overlay shows **Off**.
5. Optional: enable the feature, wait until it accelerates through silence, then press the shortcut again — the overlay should still show **Off** instead of only the accelerated rate.

## Additional context
<!-- Add any other context about the pull request here. -->