### PR TITLE
feat(tabs): wrap the Ctrl+Tab switcher into multiple rows

### DIFF
--- a/e2e/tests/offline/tabs.spec.mjs
+++ b/e2e/tests/offline/tabs.spec.mjs
@@ -1023,10 +1023,14 @@ test.describe('tab switcher', () => {
     try {
       await openTabSwitcher(page)
 
-      const rowTops = await page.locator('.tabSwitcherItem').evaluateAll((items) => {
-        return [...new Set(items.map((item) => Math.round(item.getBoundingClientRect().top)))]
+      const gridPositions = await page.locator('.tabSwitcherItem').evaluateAll((items) => {
+        return {
+          rows: new Set(items.map((item) => Math.round(item.getBoundingClientRect().top))).size,
+          columns: new Set(items.map((item) => Math.round(item.getBoundingClientRect().left))).size
+        }
       })
-      expect(rowTops.length).toBeGreaterThan(1)
+      expect(gridPositions.rows).toBeGreaterThan(1)
+      expect(gridPositions.columns).toBeGreaterThan(1)
     } finally {
       await page.keyboard.up('Control')
     }

--- a/e2e/tests/offline/tabs.spec.mjs
+++ b/e2e/tests/offline/tabs.spec.mjs
@@ -996,3 +996,73 @@ test.describe('background tab shortcuts', () => {
     expect(externalRequests).toEqual([])
   })
 })
+
+/**
+ * Opens the Ctrl+Tab switcher and keeps Control held so the overlay stays up.
+ * Callers must release Control (or Escape) when finished.
+ * @param {import('@playwright/test').Page} page
+ */
+async function openTabSwitcher(page) {
+  await page.keyboard.down('Control')
+  await page.keyboard.press('Tab')
+  await expect(page.locator('.tabSwitcher')).toBeVisible()
+}
+
+test.describe('tab switcher', () => {
+  test('wraps into multiple rows when there are many tabs', async ({ page }) => {
+    await page.evaluate(async () => {
+      for (let i = 0; i < 9; i++) {
+        await window.ftElectron.tabs.create({
+          makeActive: false,
+          lazyLoad: true
+        })
+      }
+    })
+    await expect(page.locator(sel.tabs)).toHaveCount(10)
+
+    try {
+      await openTabSwitcher(page)
+
+      const rowTops = await page.locator('.tabSwitcherItem').evaluateAll((items) => {
+        return [...new Set(items.map((item) => Math.round(item.getBoundingClientRect().top)))]
+      })
+      expect(rowTops.length).toBeGreaterThan(1)
+    } finally {
+      await page.keyboard.up('Control')
+    }
+
+    await expect(page.locator('.tabSwitcher')).toHaveCount(0)
+  })
+
+  test('shows page icons when tab icons are enabled', async ({ page }) => {
+    await page.locator(sel.newTabButton).click()
+    await expect(page.locator(sel.tabs)).toHaveCount(2)
+
+    try {
+      await openTabSwitcher(page)
+      await expect(page.locator('.tabSwitcherItem .tabSwitcherTitleIcon')).toHaveCount(2)
+      await expect(page.locator('.tabSwitcherItem .tabSwitcherTitleIcon').first())
+        .toHaveAttribute('data-icon', 'rss')
+    } finally {
+      await page.keyboard.up('Control')
+    }
+  })
+})
+
+test.describe('tab switcher without icons', () => {
+  test.use({ seed: { settings: { showTabIcons: false } } })
+
+  test('hides title icons when tab icons are disabled', async ({ page }) => {
+    await page.locator(sel.newTabButton).click()
+    await expect(page.locator(sel.tabs)).toHaveCount(2)
+
+    try {
+      await openTabSwitcher(page)
+      await expect(
+        page.locator('.tabSwitcherItem .tabSwitcherTitleIcon, .tabSwitcherItem .tabSwitcherTitleAvatar')
+      ).toHaveCount(0)
+    } finally {
+      await page.keyboard.up('Control')
+    }
+  })
+})

--- a/src/renderer/App.css
+++ b/src/renderer/App.css
@@ -265,11 +265,12 @@
 
 .tabSwitcher {
   display: grid;
-  grid-auto-flow: column;
-  grid-auto-columns: minmax(160px, 220px);
+  grid-template-columns: repeat(auto-fit, minmax(160px, 220px));
+  justify-content: center;
   gap: 10px;
+  inline-size: fit-content;
   max-inline-size: min(88vw, 980px);
-  max-block-size: min(48vh, 300px);
+  max-block-size: min(80vh, 720px);
   overflow: auto;
   padding: 12px;
   background-color: color-mix(in srgb, var(--bg-color) 92%, #000);
@@ -341,10 +342,35 @@
 }
 
 .tabSwitcherTitle {
-  overflow: hidden;
+  display: flex;
+  align-items: start;
+  gap: 6px;
   min-inline-size: 0;
+  overflow: hidden;
   font-size: 13px;
   line-height: 1.3;
+}
+
+.tabSwitcherTitleAvatar {
+  inline-size: 16px;
+  block-size: 16px;
+  margin-block-start: 1px;
+  border-radius: 50%;
+  object-fit: cover;
+  flex-shrink: 0;
+}
+
+.tabSwitcherTitleIcon {
+  inline-size: 14px;
+  margin-block-start: 2px;
+  font-size: 13px;
+  color: var(--secondary-text-color);
+  flex-shrink: 0;
+}
+
+.tabSwitcherTitleText {
+  min-inline-size: 0;
+  overflow: hidden;
   overflow-wrap: anywhere;
   display: -webkit-box;
   -webkit-line-clamp: 2;
@@ -381,7 +407,7 @@
   }
 
   .tabSwitcher {
-    grid-auto-columns: minmax(138px, 176px);
+    grid-template-columns: repeat(auto-fit, minmax(138px, 176px));
     gap: 8px;
     max-inline-size: 94vw;
     padding: 10px;

--- a/src/renderer/App.vue
+++ b/src/renderer/App.vue
@@ -254,7 +254,22 @@
             </span>
           </span>
           <span class="tabSwitcherTitle">
-            {{ formatTabSwitcherTitle(tab.title) }}
+            <img
+              v-if="showTabIcons && getTabAvatarUrl(tab)"
+              :src="getTabAvatarUrl(tab)"
+              class="tabSwitcherTitleAvatar"
+              alt=""
+              draggable="false"
+            >
+            <FontAwesomeIcon
+              v-else-if="showTabIcons && getTabPageIcon(tab)"
+              :icon="getTabPageIcon(tab)"
+              class="tabSwitcherTitleIcon"
+              aria-hidden="true"
+            />
+            <span class="tabSwitcherTitleText">
+              {{ formatTabSwitcherTitle(tab.title) }}
+            </span>
           </span>
         </button>
       </div>
@@ -312,7 +327,7 @@ import { getTabAccentColor } from './constants/tabColors'
 import { getThumbnailListStyles } from './constants/thumbnailSize'
 import { getTabNavigationService } from './tabs/TabNavigationService'
 import { tabRuntimeRegistry } from './tabs/TabRuntimeRegistry'
-import { getTabPreviewFallbackUrl } from './tabs/tabPreview'
+import { getTabAvatarUrl, getTabPageIcon, getTabPreviewFallbackUrl } from './tabs/tabPreview'
 import { preloadUtilityRoutes } from './router/index'
 
 const releaseNotesMarkdown = createReleaseNotesMarkdown()
@@ -526,6 +541,7 @@ let findbarMatches = []
 const findbarStateByTabId = new Map()
 
 const tabSwitcherTabs = computed(() => store.getters.getTabs)
+const showTabIcons = computed(() => store.getters.getShowTabIcons)
 const findbarStatus = computed(() => {
   if (findbarQuery.value.trim().length === 0) {
     return ''
@@ -2171,7 +2187,13 @@ function handleTabSwitcherWheel(event) {
     return
   }
 
-  switcher.scrollLeft += delta
+  // Prefer vertical scrolling when the switcher wraps into multiple rows;
+  // fall back to horizontal when that is the only overflow axis.
+  if (switcher.scrollHeight > switcher.clientHeight) {
+    switcher.scrollTop += delta
+  } else {
+    switcher.scrollLeft += delta
+  }
 }
 
 function scrollTabSwitcherSelectionIntoView() {


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Make sure to follow the contributing guidelines. -->
<!-- Important note, we may remove your pull request if you do not use this provided PR template correctly. -->
<!-- Agent instructions: Preserve every heading, comment, and marker in this template. Never remove or rewrite the release-note-category:start/end, release-note:start/end, or release-note-image:start/end marker pairs. Never remove or rewrite the Release note images section; leave its contents for a human. -->

## Pull Request Type
<!-- Please select what type of pull request this is: [x] -->
- [ ] Bugfix
- [x] Feature Implementation
- [ ] Documentation
- [ ] Other

## Related issue
<!-- Please link the issue your pull request is referring to. -->
<!-- If this pull request fully resolves the relevant issue, put "closes" before the issue number. -->
<!-- Example: "closes #123456". -->

## Description
<!-- Please write a clear and concise description of what the pull request does. -->
Lets the Ctrl+Tab switcher wrap tab previews into multiple rows when many tabs are open, instead of staying on a single horizontally scrolling row. When tab icons are enabled, each switcher entry also shows the same page/avatar icon used in the tab bar.

## Release note category
<!-- Select exactly one category. Every pull request must select one. -->
<!-- release-note-category:start -->
- [ ] Not noteworthy
- [ ] Highlights
- [x] More improvements
- [ ] Fixed bugs
<!-- release-note-category:end -->

## Release note
<!-- Required unless "Not noteworthy" is selected. -->
<!-- Write one concise, user-facing entry without a leading bullet. -->
<!-- release-note:start -->
The Ctrl+Tab switcher now wraps into multiple rows and shows tab icons when they are enabled
<!-- release-note:end -->

## Release note images
<!-- Human-only: Agents must preserve this entire section and leave it empty. -->
<!-- Optional. Paste one or more Markdown images or HTML image tags here. -->
<!-- The release notes will use an HTML image tag and limit images taller than 300 pixels. -->
<!-- release-note-image:start -->
<img width="895" height="367" alt="image" src="https://github.com/user-attachments/assets/c86924e2-e02f-4908-b140-9eaafe702506" />
<!-- release-note-image:end -->

## Testing
<!-- How can reviewers verify that the PR produces correct results? -->
<!-- Please provide instructions so that others can ensure that your pull request would produce correct results. For examples see, https://github.com/FreeTubeApp/FreeTube/pull/5743, https://github.com/FreeTubeApp/FreeTube/pull/7349, https://github.com/FreeTubeApp/FreeTube/pull/5125, https://github.com/FreeTubeApp/FreeTube/pull/7338 -->
<!-- Agent instructions: Only write human-facing steps that explain how to verify the change while running this branch in dev mode. Include expected results and, when applicable, helpful console snippets for interactive verification. Do not include automated checks, commands, results, pass counts, or CI status. -->
1. Open enough tabs that they would previously overflow the Ctrl+Tab row.
2. Hold Ctrl and press Tab to open the switcher.
3. Confirm the previews wrap onto a second (or further) row instead of only scrolling sideways.
4. With **Show tab icons** enabled in Theme settings, confirm each switcher title shows the matching page/avatar icon.
5. Disable **Show tab icons** and open the switcher again; confirm those title icons are gone.

## Additional context
<!-- Add any other context about the pull request here. -->