### PR TITLE
fix: make channel and Shorts linked-video links openable

### DIFF
--- a/e2e/tests/offline/channel-settings.spec.mjs
+++ b/e2e/tests/offline/channel-settings.spec.mjs
@@ -1,0 +1,45 @@
+import { test, expect, goTo } from '../../helpers/app.mjs'
+
+const CHANNEL_ID = 'UCaaaaaaaaaaaaaaaaaaaaaa'
+const CHANNEL_NAME = 'Alpha Channel'
+
+test.use({
+  seed: {
+    settings: {
+      channelPlaybackSpeeds: JSON.stringify({
+        [CHANNEL_ID]: 1.5
+      })
+    },
+    profiles: [
+      {
+        _id: 'allChannels',
+        name: 'All Channels',
+        bgColor: '#000000',
+        textColor: '#FFFFFF',
+        subscriptions: [
+          { id: CHANNEL_ID, name: CHANNEL_NAME, thumbnail: '' }
+        ]
+      }
+    ]
+  }
+})
+
+test.describe('channel settings', () => {
+  test('saved channels in the manager open their channel page', async ({ page }) => {
+    await goTo(page, 'settings')
+    await page.locator('.settingsMenu [data-section="channel"]').click()
+
+    await page.getByRole('button', { name: 'Manage Saved Channels (1)' }).click()
+
+    const dialog = page.getByRole('dialog', { name: 'Saved Channel Settings' })
+    await expect(dialog).toBeVisible()
+
+    const channelLink = dialog.getByRole('link', { name: CHANNEL_NAME })
+    await expect(channelLink).toHaveAttribute('href', `#/channel/${CHANNEL_ID}`)
+
+    await channelLink.click()
+
+    await expect(dialog).toHaveCount(0)
+    await expect(page).toHaveURL(new RegExp(`#/channel/${CHANNEL_ID}`))
+  })
+})

--- a/src/renderer/components/ChannelSettings/ChannelSettings.css
+++ b/src/renderer/components/ChannelSettings/ChannelSettings.css
@@ -66,6 +66,16 @@
   gap: 0.75em;
 }
 
+.channelLink {
+  display: flex;
+  align-items: center;
+  flex: 1;
+  min-inline-size: 0;
+  gap: 0.75em;
+  color: inherit;
+  text-decoration: none;
+}
+
 .channelThumbnail {
   inline-size: 40px;
   block-size: 40px;

--- a/src/renderer/components/ChannelSettings/ChannelSettings.vue
+++ b/src/renderer/components/ChannelSettings/ChannelSettings.vue
@@ -74,21 +74,30 @@
             class="channelEntry"
           >
             <div class="channelHeader">
-              <img
-                v-if="channel.thumbnail"
-                class="channelThumbnail"
-                :src="channel.thumbnail"
-                alt=""
+              <router-link
+                class="channelLink"
+                :to="`/channel/${channel.id}`"
+                @click="showManager = false"
               >
-              <span
-                v-else
-                class="channelThumbnail channelThumbnailPlaceholder"
-              >
-                <FontAwesomeIcon :icon="['fas', 'circle-user']" />
-              </span>
-              <p class="channelName">
-                {{ channel.name }}
-              </p>
+                <img
+                  v-if="channel.thumbnail"
+                  class="channelThumbnail"
+                  :src="channel.thumbnail"
+                  alt=""
+                >
+                <span
+                  v-else
+                  class="channelThumbnail channelThumbnailPlaceholder"
+                >
+                  <FontAwesomeIcon :icon="['fas', 'circle-user']" />
+                </span>
+                <p
+                  class="channelName"
+                  dir="auto"
+                >
+                  {{ channel.name }}
+                </p>
+              </router-link>
               <FtIconButton
                 v-if="channel.addableOptions.length > 0"
                 :title="t('Settings.Channel Settings.Add Setting')"

--- a/src/renderer/views/Watch/Watch.js
+++ b/src/renderer/views/Watch/Watch.js
@@ -1669,25 +1669,9 @@ export default defineComponent({
         return
       }
 
-      // Plain left clicks are handled by the router-link. Electron needs help
-      // for middle-click / modifier-click so those open a tab or window.
-      if (!process.env.IS_ELECTRON) {
-        return
-      }
-
-      const isMiddleClick = event?.type === 'auxclick' && event.button === 1
-      const isModifiedClick = event?.type === 'click' && (event.ctrlKey || event.metaKey)
-      if (!isMiddleClick && !isModifiedClick) {
-        return
-      }
-
-      event.preventDefault()
-      openInternalPath({
+      this.openShortsInternalPath(event, {
         path: `/channel/${this.channelId}`,
-        title: this.channelName,
-        doCreateNewWindow: event.shiftKey,
-        doCreateNewTab: !event.shiftKey,
-        makeActive: !isMiddleClick
+        title: this.channelName
       })
     },
 
@@ -1696,22 +1680,34 @@ export default defineComponent({
         return
       }
 
-      // Plain left clicks are handled by the router-link. Electron needs help
-      // for middle-click / modifier-click so those open a tab or window.
+      this.openShortsInternalPath(event, {
+        path: `/watch/${this.shortsLinkedVideo.videoId}`,
+        title: this.shortsLinkedVideo.title
+      })
+    },
+
+    /**
+     * Plain left clicks stay on the router-link. Electron needs this for
+     * middle-click / Ctrl–Cmd / Shift so those open a tab or window.
+     * @param {MouseEvent} event
+     * @param {{ path: string, title: string }} destination
+     */
+    openShortsInternalPath: function (event, { path, title }) {
       if (!process.env.IS_ELECTRON) {
         return
       }
 
       const isMiddleClick = event?.type === 'auxclick' && event.button === 1
-      const isModifiedClick = event?.type === 'click' && (event.ctrlKey || event.metaKey)
+      const isModifiedClick = event?.type === 'click' &&
+        (event.ctrlKey || event.metaKey || event.shiftKey)
       if (!isMiddleClick && !isModifiedClick) {
         return
       }
 
       event.preventDefault()
       openInternalPath({
-        path: `/watch/${this.shortsLinkedVideo.videoId}`,
-        title: this.shortsLinkedVideo.title,
+        path,
+        title,
         doCreateNewWindow: event.shiftKey,
         doCreateNewTab: !event.shiftKey,
         makeActive: !isMiddleClick

--- a/src/renderer/views/Watch/Watch.js
+++ b/src/renderer/views/Watch/Watch.js
@@ -36,6 +36,7 @@ import {
   getCachedOembedTitle,
   getOembedTitle,
   getShortThumbnailUrl,
+  openInternalPath,
   showApiErrorToast,
   showToast,
   showToastOnAllTabs
@@ -1663,16 +1664,58 @@ export default defineComponent({
       }
     },
 
-    openShortsChannel: function () {
-      if (this.channelId) {
-        this.tabRouter.push({ path: `/channel/${this.channelId}` })
+    openShortsChannel: function (event) {
+      if (!this.channelId) {
+        return
       }
+
+      // Plain left clicks are handled by the router-link. Electron needs help
+      // for middle-click / modifier-click so those open a tab or window.
+      if (!process.env.IS_ELECTRON) {
+        return
+      }
+
+      const isMiddleClick = event?.type === 'auxclick' && event.button === 1
+      const isModifiedClick = event?.type === 'click' && (event.ctrlKey || event.metaKey)
+      if (!isMiddleClick && !isModifiedClick) {
+        return
+      }
+
+      event.preventDefault()
+      openInternalPath({
+        path: `/channel/${this.channelId}`,
+        title: this.channelName,
+        doCreateNewWindow: event.shiftKey,
+        doCreateNewTab: !event.shiftKey,
+        makeActive: !isMiddleClick
+      })
     },
 
-    openShortsLinkedVideo: function () {
-      if (this.shortsLinkedVideo?.videoId) {
-        this.tabRouter.push({ path: `/watch/${this.shortsLinkedVideo.videoId}` })
+    openShortsLinkedVideo: function (event) {
+      if (!this.shortsLinkedVideo?.videoId) {
+        return
       }
+
+      // Plain left clicks are handled by the router-link. Electron needs help
+      // for middle-click / modifier-click so those open a tab or window.
+      if (!process.env.IS_ELECTRON) {
+        return
+      }
+
+      const isMiddleClick = event?.type === 'auxclick' && event.button === 1
+      const isModifiedClick = event?.type === 'click' && (event.ctrlKey || event.metaKey)
+      if (!isMiddleClick && !isModifiedClick) {
+        return
+      }
+
+      event.preventDefault()
+      openInternalPath({
+        path: `/watch/${this.shortsLinkedVideo.videoId}`,
+        title: this.shortsLinkedVideo.title,
+        doCreateNewWindow: event.shiftKey,
+        doCreateNewTab: !event.shiftKey,
+        makeActive: !isMiddleClick
+      })
     },
 
     toggleShortsComments: function () {

--- a/src/renderer/views/Watch/Watch.scss
+++ b/src/renderer/views/Watch/Watch.scss
@@ -358,6 +358,7 @@
       background: transparent;
       cursor: pointer;
       font: inherit;
+      text-decoration: none;
       text-shadow: 0 1px 2px #000, 0 2px 8px rgb(0 0 0 / 85%);
     }
 
@@ -422,6 +423,7 @@
       font: inherit;
       flex: 0 0 auto;
       max-inline-size: 100%;
+      text-decoration: none;
     }
 
     .shortsExternalChannel span {
@@ -484,7 +486,7 @@
     }
 
     .shortsLinkedVideo {
-      display: flex;
+      display: inline-flex;
       align-items: center;
       gap: 7px;
       max-inline-size: 100%;
@@ -498,6 +500,7 @@
       cursor: pointer;
       font: inherit;
       font-size: 12px;
+      text-decoration: none;
     }
 
     .shortsLinkedVideo span {
@@ -542,6 +545,7 @@
       margin-block-start: 2px;
       overflow: hidden;
       border-radius: calc(8px * var(--ui-roundness));
+      text-decoration: none;
     }
 
     .shortsComponentAction :deep(.iconButton) {

--- a/src/renderer/views/Watch/Watch.vue
+++ b/src/renderer/views/Watch/Watch.vue
@@ -176,7 +176,7 @@
               />
               <div class="shortsFullscreenChannelRow">
                 <RouterLink
-                  v-if="!hideUploader"
+                  v-if="!hideUploader && channelId"
                   class="shortsFullscreenChannel"
                   :to="`/channel/${channelId}`"
                   @click="openShortsChannel"
@@ -299,7 +299,7 @@
               class="shortsChannelRow"
             >
               <RouterLink
-                v-if="!hideUploader"
+                v-if="!hideUploader && channelId"
                 class="shortsExternalChannel"
                 :to="`/channel/${channelId}`"
                 @click="openShortsChannel"
@@ -331,7 +331,7 @@
             {{ videoTitle }}
           </h1>
           <RouterLink
-            v-if="!isLoading && shortsLinkedVideo"
+            v-if="!isLoading && shortsLinkedVideo?.videoId"
             class="shortsLinkedVideo"
             :to="`/watch/${shortsLinkedVideo.videoId}`"
             :title="shortsLinkedVideo.title"
@@ -468,7 +468,7 @@
             <span>{{ quickBookmarkIconText }}</span>
           </div>
           <RouterLink
-            v-if="!isLoading && channelThumbnail"
+            v-if="!isLoading && channelId && channelThumbnail"
             class="shortsSoundThumbnail"
             :to="`/channel/${channelId}`"
             :title="channelName"

--- a/src/renderer/views/Watch/Watch.vue
+++ b/src/renderer/views/Watch/Watch.vue
@@ -175,11 +175,12 @@
                 class="shortsPaidPromotion"
               />
               <div class="shortsFullscreenChannelRow">
-                <button
+                <RouterLink
                   v-if="!hideUploader"
-                  type="button"
                   class="shortsFullscreenChannel"
+                  :to="`/channel/${channelId}`"
                   @click="openShortsChannel"
+                  @auxclick="openShortsChannel"
                 >
                   <img
                     v-if="channelThumbnail"
@@ -188,7 +189,7 @@
                     alt=""
                   >
                   <span dir="auto">{{ channelName }}</span>
-                </button>
+                </RouterLink>
                 <FtSubscribeButton
                   v-if="!hideUnsubscribeButton"
                   :channel-id="channelId"
@@ -297,11 +298,12 @@
             <div
               class="shortsChannelRow"
             >
-              <button
+              <RouterLink
                 v-if="!hideUploader"
-                type="button"
                 class="shortsExternalChannel"
+                :to="`/channel/${channelId}`"
                 @click="openShortsChannel"
+                @auxclick="openShortsChannel"
               >
                 <img
                   v-if="channelThumbnail"
@@ -310,7 +312,7 @@
                   alt=""
                 >
                 <span dir="auto">{{ channelName }}</span>
-              </button>
+              </RouterLink>
               <FtSubscribeButton
                 v-if="!hideUnsubscribeButton"
                 :channel-id="channelId"
@@ -328,16 +330,17 @@
           >
             {{ videoTitle }}
           </h1>
-          <button
+          <RouterLink
             v-if="!isLoading && shortsLinkedVideo"
-            type="button"
             class="shortsLinkedVideo"
+            :to="`/watch/${shortsLinkedVideo.videoId}`"
             :title="shortsLinkedVideo.title"
             @click="openShortsLinkedVideo"
+            @auxclick="openShortsLinkedVideo"
           >
             <font-awesome-icon :icon="['fas', 'play']" />
             <span dir="auto">{{ shortsLinkedVideo.title }}</span>
-          </button>
+          </RouterLink>
         </div>
         <div
           v-if="customShortsPlayerActive"
@@ -464,18 +467,19 @@
             />
             <span>{{ quickBookmarkIconText }}</span>
           </div>
-          <button
+          <RouterLink
             v-if="!isLoading && channelThumbnail"
-            type="button"
             class="shortsSoundThumbnail"
+            :to="`/channel/${channelId}`"
             :title="channelName"
             @click="openShortsChannel"
+            @auxclick="openShortsChannel"
           >
             <img
               :src="channelThumbnail"
               alt=""
             >
-          </button>
+          </RouterLink>
         </div>
         <button
           v-if="customShortsPlayerActive && nextSubscriptionShortThumbnail"


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Make sure to follow the contributing guidelines. -->
<!-- Important note, we may remove your pull request if you do not use this provided PR template correctly. -->
<!-- Agent instructions: Preserve every heading, comment, and marker in this template. Never remove or rewrite the release-note-category:start/end, release-note:start/end, or release-note-image:start/end marker pairs. Never remove or rewrite the Release note images section; leave its contents for a human. -->

## Pull Request Type
<!-- Please select what type of pull request this is: [x] -->
- [x] Bugfix
- [ ] Feature Implementation
- [ ] Documentation
- [ ] Other

## Related issue
<!-- Please link the issue your pull request is referring to. -->
<!-- If this pull request fully resolves the relevant issue, put "closes" before the issue number. -->
<!-- Example: "closes #123456". -->

## Description
<!-- Please write a clear and concise description of what the pull request does. -->
Makes channels in the saved channel manager modal clickable so they open the channel page.

On the YouTube-style Shorts player, channel controls and the suggested video under the title are real links again, including middle-click / Ctrl–Cmd to open in a new tab (or Shift for a new window), matching the regular watch page.

## Release note category
<!-- Select exactly one category. Every pull request must select one. -->
<!-- release-note-category:start -->
- [ ] Not noteworthy
- [ ] Highlights
- [ ] More improvements
- [x] Fixed bugs
<!-- release-note-category:end -->

## Release note
<!-- Required unless "Not noteworthy" is selected. -->
<!-- Write one concise, user-facing entry without a leading bullet. -->
<!-- release-note:start -->
Channels and suggested videos on Shorts are now actual links (so you can open them in a new tab)
<!-- release-note:end -->

## Release note images
<!-- Human-only: Agents must preserve this entire section and leave it empty. -->
<!-- Optional. Paste one or more Markdown images or HTML image tags here. -->
<!-- The release notes will use an HTML image tag and limit images taller than 300 pixels. -->
<!-- release-note-image:start -->

<!-- release-note-image:end -->

## Testing
<!-- How can reviewers verify that the PR produces correct results? -->
<!-- Please provide instructions so that others can ensure that your pull request would produce correct results. For examples see, https://github.com/FreeTubeApp/FreeTube/pull/5743, https://github.com/FreeTubeApp/FreeTube/pull/7349, https://github.com/FreeTubeApp/FreeTube/pull/5125, https://github.com/FreeTubeApp/FreeTube/pull/7338 -->
<!-- Agent instructions: Only write human-facing steps that explain how to verify the change while running this branch in dev mode. Include expected results and, when applicable, helpful console snippets for interactive verification. Do not include automated checks, commands, results, pass counts, or CI status. -->
1. Open Settings → Channel Settings → Manage Saved Channels with at least one saved channel.
2. Click a channel name/thumbnail: the modal closes and the channel page opens.
3. Open a Short with the YouTube-style Shorts player.
4. Left-click the channel name, channel thumbnail on the action rail, and (if present) the suggested video pill under the title: each navigates in the current tab.
5. Middle-click those same controls: each opens in a new background tab. Ctrl/Cmd-click should open a new foreground tab; Shift+click a new window.
6. Confirm the suggested video pill still shrink-wraps around its text instead of stretching full width.

## Additional context
<!-- Add any other context about the pull request here. -->