### PR TITLE
fix(tabs): keep tab top radii clear of the scroll clip

### DIFF
--- a/src/renderer/components/TabBar/SortableTab.vue
+++ b/src/renderer/components/TabBar/SortableTab.vue
@@ -486,6 +486,9 @@ watch(() => props.disableTooltips, (disableTooltips) => {
 .tab::after {
   content: '';
   position: absolute;
+
+  /* Sits in .tabsContainer's padding-block-end, covering the tab bar's inset
+     separator under the active tab without leaving the overflow clip. */
   inset-block-end: -1px;
   inset-inline: 0;
   block-size: 1px;

--- a/src/renderer/components/TabBar/TabBar.css
+++ b/src/renderer/components/TabBar/TabBar.css
@@ -9,6 +9,10 @@
   border-block-end: 1px solid var(--tertiary-text-color);
   block-size: 32px;
   min-block-size: 32px;
+
+  /* Keep top radii off the title-bar edge without growing .tabsContainer, so the
+     active tab's ::after connector can still cover the 1px bottom separator. */
+  padding-block-start: 1px;
   padding-inline: 4px;
   gap: 2px;
   position: sticky;
@@ -40,10 +44,6 @@
 .tabsContainer {
   display: flex;
   min-inline-size: 0;
-
-  /* 1px keeps top radii/borders off the overflow-y clip edge (CSS cannot do
-     overflow-x: auto with overflow-y: visible). */
-  padding-block-start: 1px;
   overflow: auto hidden;
 
   /* The horizontal layout draws its own scrollbar below (.tabsScrollbar). The

--- a/src/renderer/components/TabBar/TabBar.css
+++ b/src/renderer/components/TabBar/TabBar.css
@@ -1,7 +1,10 @@
 .tabBar {
   box-sizing: border-box;
   display: flex;
-  align-items: center;
+
+  /* Sit tabs on the bottom edge so the top radii clear the window chrome and
+     the scrollport clip (overflow-y cannot stay visible while overflow-x scrolls). */
+  align-items: flex-end;
   background-color: var(--side-nav-color);
   border-block-end: 1px solid var(--tertiary-text-color);
   block-size: 32px;
@@ -12,10 +15,7 @@
   inset-block-start: 0;
   z-index: 5;
   inline-size: 100%;
-
-  /* Horizontal scrolling is handled by .tabsContainer. A non-visible overflow-x
-     value would force overflow-y to clip too, which flattens the tab top radii. */
-  overflow: visible;
+  overflow: hidden;
 }
 
 /* The horizontal bar shares the top edge with the sticky top navigation, so it
@@ -40,6 +40,10 @@
 .tabsContainer {
   display: flex;
   min-inline-size: 0;
+
+  /* 1px keeps top radii/borders off the overflow-y clip edge (CSS cannot do
+     overflow-x: auto with overflow-y: visible). */
+  padding-block-start: 1px;
   overflow: auto hidden;
 
   /* The horizontal layout draws its own scrollbar below (.tabsScrollbar). The
@@ -90,6 +94,7 @@
   display: flex;
   align-items: center;
   justify-content: center;
+  align-self: center;
   background: none;
   border: 0;
   cursor: pointer;
@@ -132,6 +137,7 @@
 }
 
 .tabBar.vertical .newTabButton {
+  align-self: stretch;
   padding-block-end: 10px;
 }
 

--- a/src/renderer/components/TabBar/TabBar.css
+++ b/src/renderer/components/TabBar/TabBar.css
@@ -6,12 +6,15 @@
      the scrollport clip (overflow-y cannot stay visible while overflow-x scrolls). */
   align-items: flex-end;
   background-color: var(--side-nav-color);
-  border-block-end: 1px solid var(--tertiary-text-color);
+
+  /* Draw the separator inside the padding box. A border-block-end sits in the
+     border region, and overflow:hidden clips ::after before it can cover it. */
+  box-shadow: inset 0 -1px 0 var(--tertiary-text-color);
   block-size: 32px;
   min-block-size: 32px;
 
-  /* Keep top radii off the title-bar edge without growing .tabsContainer, so the
-     active tab's ::after connector can still cover the 1px bottom separator. */
+  /* Keep top radii off the title-bar edge. Content is then 31px: 30px tab +
+     1px tabsContainer padding-block-end for the active connector. */
   padding-block-start: 1px;
   padding-inline: 4px;
   gap: 2px;
@@ -44,6 +47,9 @@
 .tabsContainer {
   display: flex;
   min-inline-size: 0;
+
+  /* Room for .tab::after (inset-block-end: -1px) inside this scrollport's clip. */
+  padding-block-end: 1px;
   overflow: auto hidden;
 
   /* The horizontal layout draws its own scrollbar below (.tabsScrollbar). The
@@ -129,6 +135,7 @@
   inline-size: var(--vertical-tab-bar-width, 220px);
   block-size: auto;
   min-block-size: 0;
+  box-shadow: none;
 
   /* No bottom padding: the new-tab button reaches the screen edge, so clicks
      at the very bottom still land on it */
@@ -149,6 +156,7 @@
 .tabBar.vertical .tabsContainer {
   flex-direction: column;
   block-size: 100%;
+  padding-block-end: 0;
   overflow: hidden auto;
   overscroll-behavior: contain;
 }


### PR DESCRIPTION
Follow-up to #551: put the horizontal tab bar back on the stable
`overflow: hidden` path, bottom-align the tabs, and add a 1px pad so
top radii stay clear of the scrollport clip edge.

## Pull Request Type
- [x] Bugfix
- [ ] Feature Implementation
- [ ] Documentation
- [ ] Other

## Related issue
Follow-up to #551

## Description
#551 switched the tab bar to `overflow: visible` so top radii would not
be flattened by CSS overflow coupling. That helped in some cases, but
left tabs flush against `.tabsContainer`'s unavoidable `overflow-y`
clip while horizontal scrolling stays enabled.

This restores `overflow: hidden` on the bar (the previously stable
approach), aligns tabs to the bottom edge, and adds `padding-block-start:
1px` on the scroll container so radii and the active top border clear
the clip. The new-tab control stays vertically centered.

Verified on Linux and macOS (Monterey Intel zip).

## Release note category
<!-- release-note-category:start -->
- [x] Not noteworthy
- [ ] Highlights
- [ ] More improvements
- [ ] Fixed bugs
<!-- release-note-category:end -->

## Release note
<!-- release-note:start -->
Fixed tab top corners looking cut off against the title bar on some displays
<!-- release-note:end -->

## Release note images
<!-- release-note-image:start -->

<!-- release-note-image:end -->

## Testing
1. Enable the horizontal tab bar and open several tabs (active + inactive).
2. Confirm the top rounded corners and the active tab's top border are fully visible under the window title bar, with no flattened tops.
3. Confirm the `+` button stays vertically centered in the strip.
4. Overflow the bar with many tabs and scroll horizontally; corners should stay intact and scrolling should still work.

## Additional context
Also checked that an older Linux build could look fine again after a full restart, so some of the earlier clipping may have been compositor/scale flakiness; this still hardens the layout against the overflow clip edge.