### PR TITLE
fix: polish live chat dock layout and scroll behavior

### DIFF
--- a/src/renderer/components/WatchVideoLiveChat/WatchVideoLiveChat.css
+++ b/src/renderer/components/WatchVideoLiveChat/WatchVideoLiveChat.css
@@ -3,6 +3,10 @@
   padding: 16px;
 }
 
+.card {
+  overscroll-behavior: contain;
+}
+
 .relative {
   position: relative;
 }
@@ -28,8 +32,10 @@
 
 .fullscreenChat > .relative {
   box-sizing: border-box;
-  padding-block: 0 16px;
+  min-inline-size: 0;
+  padding-block: 12px 16px;
   padding-inline: 16px;
+  overflow: hidden;
 }
 
 .liveChatDockHeader {
@@ -144,27 +150,44 @@
 }
 
 .superChatComments {
+  position: relative;
+
+  /* Keep chips above the opened-donation scrim. */
+  z-index: 3;
+  display: flex;
+  flex: 0 0 auto;
+  align-items: center;
+  box-sizing: border-box;
   inline-size: 100%;
-  block-size: 50px;
-  overflow-x: auto;
+  block-size: 38px;
+  margin-block-end: 8px;
+
+  /* Horizontal chips only — overflow-y:auto (implied by overflow-x) was
+     clipping the pills under the dock header and drawing a stray scrollbar. */
+  overflow: auto hidden;
+  overscroll-behavior: contain;
   white-space: nowrap;
 }
 
 .superChat {
-  display: inline-block;
-  padding: 1px;
-  padding-inline-end: 10px;
-  margin-inline: 2px;
+  display: inline-flex;
+  align-items: center;
+  box-sizing: border-box;
   block-size: 30px;
+  padding-block: 0;
+  padding-inline: 3px 10px;
+  margin-inline: 2px;
+  gap: 6px;
   cursor: pointer;
   background-color: var(--primary-color);
   border-radius: 200px;
+  vertical-align: middle;
 }
 
 .superChatContent {
-  margin-inline-start: 32px;
-  margin-block-start: -25px;
+  margin: 0;
   color: var(--text-with-main-color);
+  line-height: 1;
 }
 
 .channelThumbnail {
@@ -187,105 +210,225 @@
 }
 
 .superChat .channelThumbnail {
-  margin-block-start: 3px;
-  margin-inline-start: 3px;
-  block-size: 25px;
+  flex: 0 0 24px;
+  inline-size: 24px;
+  block-size: 24px;
+  margin: 0;
 }
 
 .donationAmount {
   color: var(--text-with-main-color);
 }
 
+.liveChatBody {
+  position: relative;
+  display: flex;
+  flex: 1 1 auto;
+  flex-direction: column;
+  min-block-size: 0;
+  min-inline-size: 0;
+}
+
+/* Scrim + popup sit over the message list only, so the chip row stays above. */
 .openedSuperChat {
-  background-color: rgb(0 0 0 / 70%);
-  inline-size: 100%;
-  block-size: 415px;
   position: absolute;
-  margin-inline-start: -16px;
-  padding-inline-end: 32px;
-  inset-block-end: -15px;
-  cursor: auto;
-  z-index: 1;
+  z-index: 2;
+  inset: 0;
+  box-sizing: border-box;
+  display: flex;
+  flex-direction: column;
+
+  /* Bleed the dimming into the card/dock padding; the popup keeps its own inset. */
+  margin-inline: -16px;
+  padding-block: 12px;
+  padding-inline: 0;
+  overflow: auto;
+  overscroll-behavior: contain;
+  color: var(--text-with-main-color);
+  background-color: rgb(0 0 0 / 70%);
+  cursor: pointer;
+}
+
+.fullscreenChat .openedSuperChat {
+  /* Bleed into .fullscreenChat > .relative bottom padding. */
+  margin-block-end: -16px;
+  padding-block-end: 28px;
+
+  /* Match .fullscreenLiveChatOverlay */
+  border-radius: calc(12px * var(--ui-roundness));
+}
+
+/* Reach the FtCard bottom padding so the scrim is not clipped short. */
+.card:not(.fullscreenChat) .openedSuperChat {
+  margin-block-end: -16px;
+  padding-block-end: 28px;
+  border-radius: calc(8px * var(--ui-roundness));
 }
 
 .superChatMessage {
+  box-sizing: border-box;
   inline-size: 90%;
-  grid-template-columns: auto;
+  margin-block: 10px;
   margin-inline: 5%;
-  margin-block: 25px 10px;
+  overflow: hidden;
   background-color: var(--primary-color);
   border-radius: calc(5px * var(--ui-roundness));
   position: relative;
 }
 
+/* Header + body stack. Absolute positioning used to float the author above the
+   card and park the amount over the body; that collided with .comment's
+   two-column grid and spilled sideways (horizontal scrollbar in the dock). */
 .upperSuperChatMessage {
-  margin-block-start: -15px;
+  display: grid;
+  grid-template-columns: auto minmax(0, 1fr);
+  grid-template-areas:
+    'thumb author'
+    'thumb amount';
+  gap: 2px 10px;
+  align-items: center;
+  box-sizing: border-box;
   inline-size: 100%;
-  block-size: 55px;
+  padding-block: 8px;
+  padding-inline: 10px;
   background-color: var(--primary-color-hover);
   border-radius: calc(5px * var(--ui-roundness)) calc(5px * var(--ui-roundness)) 0 0;
 }
 
 .openedSuperChat .superChatMessage {
-  position: absolute;
-}
-
-.comment .superChatMessage {
-  padding: 5px;
-}
-
-.comment .upperSuperChatMessage {
-  padding: 0;
+  position: relative;
+  box-sizing: border-box;
+  flex: 0 0 auto;
+  inline-size: auto;
+  max-inline-size: none;
+  margin-block: 0;
+  margin-inline: 16px;
+  cursor: auto;
 }
 
 .comment {
   inline-size: 100%;
+  min-inline-size: 0;
   padding-block: 5px 7px;
   display: grid;
-  grid-template-columns: min-content auto;
+  grid-template-columns: min-content minmax(0, 1fr);
   gap: 5px;
 }
 
+/* Donations are a single card, not avatar | text columns. */
+.comment.superChatMessage {
+  display: flex;
+  flex-direction: column;
+  gap: 0;
+  inline-size: 100%;
+  margin-block: 8px;
+  margin-inline: 0;
+  padding: 0;
+}
+
 .upperSuperChatMessage .channelThumbnail {
-  inline-size: 45px;
-  margin-inline-start: 10px;
-  margin-block-start: 5px;
+  grid-area: thumb;
+  inline-size: 36px;
+  block-size: 36px;
+  margin: 0;
+  border-radius: 50%;
 }
 
 .upperSuperChatMessage .superChatAuthor {
+  grid-area: author;
   display: flex;
+  flex-wrap: wrap;
   align-items: center;
-  position: absolute;
-  inset-block-start: -20px;
-  margin-inline-start: 65px;
+  gap: 0 6px;
+  min-inline-size: 0;
 }
 
 .upperSuperChatMessage .channelName {
   color: var(--text-with-main-color);
-  opacity: 0.7;
+  opacity: 0.85;
+  overflow-wrap: anywhere;
 }
 
 .upperSuperChatMessage .liveChatTimestamp {
   color: var(--text-with-main-color);
-  opacity: 0.7;
+  opacity: 0.85;
 }
 
 .upperSuperChatMessage .donationAmount {
+  grid-area: amount;
+  margin: 0;
   color: var(--text-with-main-color);
   font-weight: bold;
-  margin-inline-start: 65px;
-  position: absolute;
-  inset-block-start: 0;
 }
 
 .superChatMessage .chatMessage {
+  margin: 0;
+  padding-block: 8px 10px;
+  padding-inline: 10px;
   color: var(--text-with-main-color);
-  margin-inline-start: 20px;
+  overflow-wrap: anywhere;
 }
 
 .liveChatComments {
+  --live-chat-fade-size: 16px;
+
+  /* OverlayScrollbars float over the inline-end edge; keep that strip unmasked. */
+  --live-chat-scrollbar-reserve: 14px;
+
   inline-size: 100%;
-  overflow-y: auto;
+  min-inline-size: 0;
+  overflow: hidden auto;
+  overscroll-behavior: contain;
+
+  /* Viewport fade for messages, plus a solid strip so the scrollbar stays sharp. */
+  mask-image:
+    linear-gradient(
+      to bottom,
+      transparent,
+      #000 var(--live-chat-fade-size),
+      #000 calc(100% - var(--live-chat-fade-size)),
+      transparent
+    ),
+    linear-gradient(#000 0 0);
+  mask-size:
+    calc(100% - var(--live-chat-scrollbar-reserve)) 100%,
+    var(--live-chat-scrollbar-reserve) 100%;
+  mask-position: 0 0, 100% 0;
+  mask-repeat: no-repeat;
+  mask-composite: add;
+}
+
+.liveChatComments:dir(rtl) {
+  mask-position: 100% 0, 0 0;
+}
+
+.liveChatCommentList {
+  display: flow-root;
+}
+
+.live-chat-message-enter-active {
+  transition: opacity 180ms ease-out, transform 180ms ease-out;
+}
+
+.live-chat-message-enter-from {
+  opacity: 0;
+  transform: translateY(0.6em);
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .live-chat-message-enter-active {
+    transition: none;
+  }
+
+  .live-chat-message-enter-from {
+    opacity: 1;
+    transform: none;
+  }
+}
+
+.fullscreenChat .liveChatBody {
+  flex: 1 1 auto;
+  min-block-size: 0;
 }
 
 .fullscreenChat .liveChatComments {

--- a/src/renderer/components/WatchVideoLiveChat/WatchVideoLiveChat.vue
+++ b/src/renderer/components/WatchVideoLiveChat/WatchVideoLiveChat.vue
@@ -2,6 +2,7 @@
   <FtCard
     class="card relative"
     :class="{ hasError, fullscreenChat: fullscreenOverlay }"
+    @wheel.stop
   >
     <header
       v-if="fullscreenOverlay"
@@ -208,80 +209,25 @@
           </p>
         </div>
       </div>
-      <div
-        v-if="showSuperChat"
-        class="openedSuperChat"
-        :class="superChat.superChat.colorClass"
-        role="button"
-        tabindex="0"
-        @click="hideSuperChat"
-        @keydown.enter.space.prevent="hideSuperChat"
-      >
+      <div class="liveChatBody">
         <div
-          class="superChatMessage"
-          @click.stop.prevent
+          v-if="showSuperChat"
+          class="openedSuperChat"
+          :class="superChat.superChat.colorClass"
+          role="button"
+          tabindex="0"
+          @click="hideSuperChat"
+          @keydown.enter.space.prevent="hideSuperChat"
         >
           <div
-            class="upperSuperChatMessage"
-          >
-            <img
-              :src="superChat.author.thumbnailUrl"
-              class="channelThumbnail"
-              alt=""
-            >
-            <div class="superChatAuthor">
-              <span
-                v-if="showLiveChatTimestamps"
-                class="liveChatTimestamp"
-              >
-                {{ superChat.timestampText }}
-              </span>
-              <RouterLink
-                class="channelName"
-                dir="auto"
-                :to="`/channel/${superChat.author.id}`"
-              >
-                {{ superChat.author.name }}
-              </RouterLink>
-            </div>
-            <p
-              class="donationAmount"
-              dir="auto"
-            >
-              {{ superChat.superChat.amount }}
-            </p>
-          </div>
-          <p
-            v-safer-html="superChat.message"
-            class="chatMessage"
-            dir="auto"
-          />
-        </div>
-      </div>
-      <div
-        ref="commentsRef"
-        v-overlay-scrollbars
-        class="liveChatComments"
-        :style="{ blockSize: chatHeight }"
-        @pointerdown="stopScrollingToBottom"
-        @scroll.passive="onScroll"
-        @scrollend="onScrollEnd"
-        @wheel.passive="stopScrollingToBottom"
-      >
-        <div
-          v-for="comment in comments"
-          :key="comment.id"
-          class="comment"
-          :class="comment.superChat ? `superChatMessage ${comment.superChat.colorClass}` : ''"
-        >
-          <template
-            v-if="comment.superChat"
+            class="superChatMessage"
+            @click.stop.prevent
           >
             <div
               class="upperSuperChatMessage"
             >
               <img
-                :src="comment.author.thumbnailUrl"
+                :src="superChat.author.thumbnailUrl"
                 class="channelThumbnail"
                 alt=""
               >
@@ -290,76 +236,140 @@
                   v-if="showLiveChatTimestamps"
                   class="liveChatTimestamp"
                 >
-                  {{ comment.timestampText }}
+                  {{ superChat.timestampText }}
                 </span>
                 <RouterLink
                   class="channelName"
                   dir="auto"
-                  :to="`/channel/${comment.author.id}`"
+                  :to="`/channel/${superChat.author.id}`"
                 >
-                  {{ comment.author.name }}
+                  {{ superChat.author.name }}
                 </RouterLink>
               </div>
               <p
                 class="donationAmount"
                 dir="auto"
               >
-                {{ comment.superChat.amount }}
+                {{ superChat.superChat.amount }}
               </p>
             </div>
             <p
-              v-if="comment.message"
-              v-safer-html="comment.message"
+              v-safer-html="superChat.message"
               class="chatMessage"
               dir="auto"
             />
-          </template>
-          <template
-            v-else
+          </div>
+        </div>
+        <div
+          ref="commentsRef"
+          v-overlay-scrollbars
+          class="liveChatComments"
+          :style="{ blockSize: chatHeight }"
+          @pointerdown="stopScrollingToBottom"
+          @scroll.passive="onScroll"
+          @scrollend="onScrollEnd"
+          @wheel.passive="stopScrollingToBottom"
+        >
+          <TransitionGroup
+            name="live-chat-message"
+            tag="div"
+            class="liveChatCommentList"
+            @after-enter="onLiveChatMessageEntered"
           >
-            <img
-              :src="comment.author.thumbnailUrl"
-              class="channelThumbnail"
-              alt=""
+            <div
+              v-for="comment in comments"
+              :key="comment.id"
+              class="comment"
+              :class="comment.superChat ? `superChatMessage ${comment.superChat.colorClass}` : ''"
             >
-            <p
-              class="chatContent"
-            >
-              <span
-                v-if="showLiveChatTimestamps"
-                class="liveChatTimestamp"
+              <template
+                v-if="comment.superChat"
               >
-                {{ comment.timestampText }}
-              </span>
-              <RouterLink
-                class="channelName"
-                :class="{
-                  member: comment.author.isMember,
-                  moderator: comment.author.isModerator,
-                  owner: comment.author.isOwner
-                }"
-                dir="auto"
-                :to="`/channel/${comment.author.id}`"
-              >
-                {{ comment.author.name }}
-              </RouterLink>
-              <span
-                v-if="comment.author.badge"
-                class="badge"
+                <div
+                  class="upperSuperChatMessage"
+                >
+                  <img
+                    :src="comment.author.thumbnailUrl"
+                    class="channelThumbnail"
+                    alt=""
+                  >
+                  <div class="superChatAuthor">
+                    <span
+                      v-if="showLiveChatTimestamps"
+                      class="liveChatTimestamp"
+                    >
+                      {{ comment.timestampText }}
+                    </span>
+                    <RouterLink
+                      class="channelName"
+                      dir="auto"
+                      :to="`/channel/${comment.author.id}`"
+                    >
+                      {{ comment.author.name }}
+                    </RouterLink>
+                  </div>
+                  <p
+                    class="donationAmount"
+                    dir="auto"
+                  >
+                    {{ comment.superChat.amount }}
+                  </p>
+                </div>
+                <p
+                  v-if="comment.message"
+                  v-safer-html="comment.message"
+                  class="chatMessage"
+                  dir="auto"
+                />
+              </template>
+              <template
+                v-else
               >
                 <img
-                  :src="comment.author.badge.url"
+                  :src="comment.author.thumbnailUrl"
+                  class="channelThumbnail"
                   alt=""
-                  :title="comment.author.badge.tooltip"
-                  class="badgeImage"
                 >
-              </span>
-              <bdi
-                v-safer-html="comment.message"
-                class="chatMessage"
-              />
-            </p>
-          </template>
+                <p
+                  class="chatContent"
+                >
+                  <span
+                    v-if="showLiveChatTimestamps"
+                    class="liveChatTimestamp"
+                  >
+                    {{ comment.timestampText }}
+                  </span>
+                  <RouterLink
+                    class="channelName"
+                    :class="{
+                      member: comment.author.isMember,
+                      moderator: comment.author.isModerator,
+                      owner: comment.author.isOwner
+                    }"
+                    dir="auto"
+                    :to="`/channel/${comment.author.id}`"
+                  >
+                    {{ comment.author.name }}
+                  </RouterLink>
+                  <span
+                    v-if="comment.author.badge"
+                    class="badge"
+                  >
+                    <img
+                      :src="comment.author.badge.url"
+                      alt=""
+                      :title="comment.author.badge.tooltip"
+                      class="badgeImage"
+                    >
+                  </span>
+                  <bdi
+                    v-safer-html="comment.message"
+                    class="chatMessage"
+                  />
+                </p>
+              </template>
+            </div>
+          </TransitionGroup>
         </div>
       </div>
       <div
@@ -399,6 +409,7 @@ import store from '../../store/index'
 import { formatNumber } from '../../helpers/utils'
 import { getRandomColorClass } from '../../helpers/colors'
 import { getLocalVideoInfo, parseLocalTextRuns } from '../../helpers/api/local'
+import { restoreOverlayScrollTop } from '../../helpers/overlayScrollbars'
 import {
   createCoalescingPoller,
   isReplaySeek,
@@ -439,6 +450,11 @@ let liveChatInstance = null
 let hasEnded = false
 let stayAtBottom = true
 let isScrollingToBottom = false
+/** @type {ReturnType<typeof setTimeout> | null} */
+let scrollToLiveHoldTimer = null
+
+/** Hold auto-follow through the message enter animation (~180ms). */
+const SCROLL_TO_LIVE_HOLD_MS = 220
 
 /**
  * Replay messages that were fetched but that the player hasn't reached yet.
@@ -518,6 +534,10 @@ const formattedWatchingCount = computed(() => {
 
 onBeforeUnmount(() => {
   document.removeEventListener('pointerdown', handleChatSettingsClickOutside, true)
+  if (scrollToLiveHoldTimer !== null) {
+    clearTimeout(scrollToLiveHoldTimer)
+    scrollToLiveHoldTimer = null
+  }
   handleEnd()
 })
 
@@ -609,13 +629,37 @@ function startLiveChatLocal() {
 
 const commentsRef = useTemplateRef('commentsRef')
 
-watch(() => props.fullscreenOverlay, fullscreenOverlay => {
-  if (!fullscreenOverlay) {
+watch(() => props.fullscreenOverlay, () => {
+  // Entering and leaving the dock both change the viewport height; OverlayScrollbars
+  // can keep an obsolete end offset and leave the list parked on empty space.
+  if (stayAtBottom) {
+    scrollToLiveAfterLayout()
+  }
+})
+
+/**
+ * Keep the live edge glued across dock open/close animations and height shares.
+ * OverlayScrollbars otherwise restores a stale scrollTop past the content end —
+ * empty view until the user scrolls up (same failure mode as the comments dock).
+ */
+watch(commentsRef, (element, _previous, onCleanup) => {
+  if (element == null) {
     return
   }
 
-  scrollToLiveAfterLayout()
-})
+  const resizeObserver = new ResizeObserver(() => {
+    if (!stayAtBottom) {
+      return
+    }
+
+    scrollToBottom('instant')
+  })
+
+  resizeObserver.observe(element)
+  onCleanup(() => {
+    resizeObserver.disconnect()
+  })
+}, { flush: 'post' })
 
 /**
  * OverlayScrollbars measures its viewport after Vue renders. Waiting through
@@ -879,16 +923,18 @@ function pushComment(comment) {
   const shouldStayAtBottom = stayAtBottom
   comments.push(comment)
 
+  // Trim before re-anchoring so OverlayScrollbars does not restore a scrollTop
+  // that pointed past messages that were just removed from the top.
+  if (comments.length > 150 && shouldStayAtBottom) {
+    comments.splice(0, comments.length - 150)
+  }
+
   if (!isLoading.value && shouldStayAtBottom) {
     nextTick(() => {
       // Smooth scrolling can be interrupted when another message arrives or the
       // tab is backgrounded. An instant follow-up keeps the bottom anchored.
       scrollToBottom('instant')
     })
-  }
-
-  if (comments.length > 150 && stayAtBottom) {
-    comments.splice(0, comments.length - 150)
   }
 }
 
@@ -901,6 +947,11 @@ function removeFromSuperChat(comment) {
   // Seeking a replay clears the ticker while the removal timeouts are still pending.
   if (index !== -1) {
     superChatComments.splice(index, 1)
+  }
+
+  // The ticker chip is gone; don't leave its expanded card floating over chat.
+  if (showSuperChat.value && superChat.value.id === comment.id) {
+    showSuperChat.value = false
   }
 }
 
@@ -948,7 +999,10 @@ function onScroll() {
 
   if (isAtBottom) {
     stayAtBottom = true
-    isScrollingToBottom = false
+    // Keep the programmatic follow flag for the enter-animation hold window.
+    if (scrollToLiveHoldTimer === null) {
+      isScrollingToBottom = false
+    }
     showScrollToBottom.value = false
   } else if (!isScrollingToBottom) {
     stayAtBottom = false
@@ -957,17 +1011,38 @@ function onScroll() {
 }
 
 function onScrollEnd() {
+  // Programmatic follow uses a hold timer through the enter animation; don't let
+  // an intermediate scrollend drop stayAtBottom early.
+  if (scrollToLiveHoldTimer !== null) {
+    return
+  }
+
   isScrollingToBottom = false
   onScroll()
 }
 
 function stopScrollingToBottom() {
+  if (scrollToLiveHoldTimer !== null) {
+    clearTimeout(scrollToLiveHoldTimer)
+    scrollToLiveHoldTimer = null
+  }
+
   isScrollingToBottom = false
   stayAtBottom = false
 }
 
 function hideSuperChat() {
   showSuperChat.value = false
+}
+
+/**
+ * Enter animation can leave the viewport short of the live edge for a frame;
+ * re-pin once the new message has finished sliding in.
+ */
+function onLiveChatMessageEntered() {
+  if (stayAtBottom) {
+    scrollToBottom('instant')
+  }
 }
 
 /**
@@ -983,8 +1058,35 @@ function scrollToBottom(behavior = scrollingBehaviour.value) {
   isScrollingToBottom = true
   showScrollToBottom.value = false
 
+  if (scrollToLiveHoldTimer !== null) {
+    clearTimeout(scrollToLiveHoldTimer)
+    scrollToLiveHoldTimer = null
+  }
+
+  const top = liveChatComments.scrollHeight
+
+  if (behavior === 'instant' || behavior === 'auto') {
+    // Force OverlayScrollbars to accept the new end offset; a plain scrollTo can
+    // lose to its restored pre-teleport / pre-trim position.
+    restoreOverlayScrollTop(liveChatComments, top)
+    scrollToLiveHoldTimer = setTimeout(() => {
+      scrollToLiveHoldTimer = null
+      if (commentsRef.value !== liveChatComments) {
+        return
+      }
+
+      if (stayAtBottom) {
+        restoreOverlayScrollTop(liveChatComments, liveChatComments.scrollHeight)
+      }
+
+      isScrollingToBottom = false
+      onScroll()
+    }, SCROLL_TO_LIVE_HOLD_MS)
+    return
+  }
+
   liveChatComments.scrollTo({
-    top: liveChatComments.scrollHeight,
+    top,
     behavior
   })
 }

--- a/src/renderer/components/WatchVideoLiveChat/WatchVideoLiveChat.vue
+++ b/src/renderer/components/WatchVideoLiveChat/WatchVideoLiveChat.vue
@@ -217,7 +217,7 @@
           role="button"
           tabindex="0"
           @click="hideSuperChat"
-          @keydown.enter.space.prevent="hideSuperChat"
+          @keydown.enter.space.self.prevent="hideSuperChat"
         >
           <div
             class="superChatMessage"
@@ -352,13 +352,13 @@
                     {{ comment.author.name }}
                   </RouterLink>
                   <span
-                    v-if="comment.author.badge"
+                    v-if="comment.badge"
                     class="badge"
                   >
                     <img
-                      :src="comment.author.badge.url"
+                      :src="comment.badge.url"
                       alt=""
-                      :title="comment.author.badge.tooltip"
+                      :title="comment.badge.tooltip"
                       class="badgeImage"
                     >
                   </span>

--- a/src/renderer/helpers/overlayScrollbars.js
+++ b/src/renderer/helpers/overlayScrollbars.js
@@ -86,6 +86,16 @@ function reconcileScrollbarOnResize(element, instance) {
       const height = element.clientHeight
       const scrollTop = element.scrollTop
       const maximumScrollTop = Math.max(0, element.scrollHeight - height)
+      // Content can shrink (trimmed live chat) or the viewport can grow after a
+      // dock transition while an obsolete end offset is still applied — that
+      // parks the view on empty space until the user scrolls up.
+      if (scrollTop > maximumScrollTop + 1) {
+        element.scrollTop = maximumScrollTop
+        instance.update(true)
+        previousHeight = height
+        return
+      }
+
       const grewAtOldEnd = height > previousHeight &&
         scrollTop > 0 &&
         scrollTop >= maximumScrollTop - 1


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Make sure to follow the contributing guidelines. -->
<!-- Important note, we may remove your pull request if you do not use this provided PR template correctly. -->
<!-- Agent instructions: Preserve every heading, comment, and marker in this template. Never remove or rewrite the release-note-category:start/end, release-note:start/end, or release-note-image:start/end marker pairs. Never remove or rewrite the Release note images section; leave its contents for a human. -->

## Pull Request Type
<!-- Please select what type of pull request this is: [x] -->
- [x] Bugfix
- [ ] Feature Implementation
- [ ] Documentation
- [ ] Other

## Related issue
<!-- Please link the issue your pull request is referring to. -->
<!-- If this pull request fully resolves the relevant issue, put "closes" before the issue number. -->
<!-- Example: "closes #123456". -->

## Description
<!-- Please write a clear and concise description of what the pull request does. -->
Polishes live chat in the sidebar and fullscreen dock:

- Fix Super Chat / donation card layout (no more side-by-side header/message collision or horizontal scrollbar from overflow)
- Keep donation chips above the opened-detail scrim, with correct spacing and rounded scrim edges
- Close the opened donation popup when its chip leaves the ticker
- Contain wheel scrolling while the pointer is over live chat
- Fade message list overflow at the viewport edges without fading the scrollbar
- Slide new messages in without dropping live-edge auto-follow
- Clamp stale OverlayScrollbars offsets after dock resizes / teleports

## Release note category
<!-- Select exactly one category. Every pull request must select one. -->
<!-- release-note-category:start -->
- [ ] Not noteworthy
- [ ] Highlights
- [ ] More improvements
- [x] Fixed bugs
<!-- release-note-category:end -->

## Release note
<!-- Required unless "Not noteworthy" is selected. -->
<!-- Write one concise, user-facing entry without a leading bullet. -->
<!-- release-note:start -->
Improved live chat layout and scrolling in the sidebar and fullscreen dock, including Super Chat presentation
<!-- release-note:end -->

## Release note images
<!-- Human-only: Agents must preserve this entire section and leave it empty. -->
<!-- Optional. Paste one or more Markdown images or HTML image tags here. -->
<!-- The release notes will use an HTML image tag and limit images taller than 300 pixels. -->
<!-- release-note-image:start -->

<!-- release-note-image:end -->

## Testing
<!-- How can reviewers verify that the PR produces correct results? -->
<!-- Please provide instructions so that others can ensure that your pull request would produce correct results. For examples see, https://github.com/FreeTubeApp/FreeTube/pull/5743, https://github.com/FreeTubeApp/FreeTube/pull/7349, https://github.com/FreeTubeApp/FreeTube/pull/5125, https://github.com/FreeTubeApp/FreeTube/pull/7338 -->
<!-- Agent instructions: Only write human-facing steps that explain how to verify the change while running this branch in dev mode. Include expected results and, when applicable, helpful console snippets for interactive verification. Do not include automated checks, commands, results, pass counts, or CI status. -->
1. Open a livestream VOD with chat replay (or a live stream with chat).
2. In the sidebar chat, confirm donation cards stack cleanly (avatar / name / amount above the message) with no horizontal scrollbar.
3. Click a Super Chat chip: the detail popup should sit below the chip row, with side margins, a sharp darkened scrim that matches card/dock roundness, and the popup should close when the chip expires.
4. Enter fullscreen and open the live chat dock: chips should not be clipped under the header; message overflow should fade at the top/bottom while the scrollbar stays sharp.
5. Stay at the live edge and wait for new messages: they should slide in and the view should remain pinned to the bottom. Scroll up, then re-enter fullscreen: you should not land on empty space past the last message.
6. With the pointer over live chat, scrolling should not move the page behind it.

## Additional context
<!-- Add any other context about the pull request here. -->
Also clamps overscrolled OverlayScrollbars viewports in the shared helper, which is the same failure mode previously seen on the fullscreen comments dock.