### PR TITLE
fix(posts): stop stretching community images

### DIFF
--- a/e2e/helpers/app.mjs
+++ b/e2e/helpers/app.mjs
@@ -88,6 +88,9 @@ export async function launchApp(userDataDir, extraArgs = []) {
     ELECTRON_OZONE_PLATFORM_HINT: 'x11'
   }
   delete env.WAYLAND_DISPLAY
+  // Cursor/agent shells may set this, which makes Electron act as Node and
+  // reject Chromium launch flags used by Playwright.
+  delete env.ELECTRON_RUN_AS_NODE
 
   // The E2E build lives in its own directory so a running `pnpm dev`
   // (which rebuilds dist/ in development mode) can't clobber it.

--- a/e2e/tests/offline/community-post-images.spec.mjs
+++ b/e2e/tests/offline/community-post-images.spec.mjs
@@ -1,0 +1,204 @@
+import { deflateSync } from 'node:zlib'
+
+import { test, expect, goTo } from '../../helpers/app.mjs'
+
+const now = Date.now()
+const CHANNEL_ID = 'UCbbbbbbbbbbbbbbbbbbbbbb'
+const FCROP = 'c-fcrop64=1,38000000c7ffffff'
+
+function crc32(buf) {
+  let c = ~0
+  for (let i = 0; i < buf.length; i++) {
+    c ^= buf[i]
+    for (let k = 0; k < 8; k++) {
+      c = (c >>> 1) ^ (0xedb88320 & -(c & 1))
+    }
+  }
+  return ~c >>> 0
+}
+
+function pngChunk(type, data) {
+  const length = Buffer.alloc(4)
+  length.writeUInt32BE(data.length)
+  const typeBuf = Buffer.from(type)
+  const crc = Buffer.alloc(4)
+  crc.writeUInt32BE(crc32(Buffer.concat([typeBuf, data])))
+  return Buffer.concat([length, typeBuf, data, crc])
+}
+
+/** Solid RGB PNG of the requested size for aspect-ratio assertions. */
+function solidPng(width, height, rgb = [40, 120, 200]) {
+  const row = Buffer.alloc(1 + width * 3)
+  for (let x = 0; x < width; x++) {
+    row[1 + x * 3] = rgb[0]
+    row[2 + x * 3] = rgb[1]
+    row[3 + x * 3] = rgb[2]
+  }
+  const raw = Buffer.concat(Array.from({ length: height }, () => row))
+  const ihdr = Buffer.alloc(13)
+  ihdr.writeUInt32BE(width, 0)
+  ihdr.writeUInt32BE(height, 4)
+  ihdr[8] = 8
+  ihdr[9] = 2
+  return Buffer.concat([
+    Buffer.from([137, 80, 78, 71, 13, 10, 26, 10]),
+    pngChunk('IHDR', ihdr),
+    pngChunk('IDAT', deflateSync(raw, { level: 9 })),
+    pngChunk('IEND', Buffer.alloc(0))
+  ])
+}
+
+function imageUrl(id, size) {
+  return `https://yt3.ggpht.com/e2e-post-${id}=s${size}-${FCROP}-rw-nd-v1`
+}
+
+function thumbnails(id, width, height) {
+  return [
+    { width, height, url: imageUrl(id, width) },
+    { width: Math.round(width / 2), height: Math.round(height / 2), url: imageUrl(id, Math.round(width / 2)) }
+  ]
+}
+
+function multiImagePost() {
+  return {
+    postId: 'multi-image-post',
+    postText: 'Multi image community post',
+    author: 'Channel B',
+    authorId: CHANNEL_ID,
+    authorThumbnails: [],
+    publishedTime: now - 30 * 60000,
+    voteCount: 12,
+    commentCount: 3,
+    postContent: {
+      type: 'multiImage',
+      content: [
+        thumbnails('square-a', 640, 640),
+        thumbnails('square-b', 640, 640)
+      ]
+    },
+    type: 'community',
+    isNewInSubscriptionFeed: true
+  }
+}
+
+function singleImagePost() {
+  return {
+    postId: 'single-image-post',
+    postText: 'Single image community post',
+    author: 'Channel B',
+    authorId: CHANNEL_ID,
+    authorThumbnails: [],
+    publishedTime: now - 20 * 60000,
+    voteCount: 4,
+    commentCount: 1,
+    postContent: {
+      type: 'image',
+      content: thumbnails('wide', 800, 450)
+    },
+    type: 'community',
+    isNewInSubscriptionFeed: true
+  }
+}
+
+async function stubPostImages(page) {
+  await page.route(/yt3\.ggpht\.com\/e2e-post-/, async (route) => {
+    const url = route.request().url()
+    const sizeMatch = url.match(/=s(\d+)/)
+    const size = Number.parseInt(sizeMatch?.[1] ?? '640', 10)
+    const isWide = url.includes('e2e-post-wide')
+    const width = size
+    const height = isWide ? Math.round(size * 450 / 800) : size
+    await route.fulfill({
+      status: 200,
+      contentType: 'image/png',
+      body: solidPng(width, height)
+    })
+  })
+}
+
+test.describe('community post images', () => {
+  test.use({
+    seed: {
+      settings: {
+        fetchSubscriptionsAutomatically: false,
+        hideSubscriptionsCommunity: false,
+        showNewSubscriptionFeed: true,
+        useRssFeeds: false,
+        listType: 'list',
+        uiRoundness: 200
+      },
+      profiles: [{
+        _id: 'allChannels',
+        name: 'All Channels',
+        bgColor: '#000000',
+        textColor: '#FFFFFF',
+        subscriptions: [{ id: CHANNEL_ID, name: 'Channel B', thumbnail: '' }]
+      }],
+      subscriptionCache: [{
+        _id: CHANNEL_ID,
+        communityPosts: [multiImagePost(), singleImagePost()],
+        communityPostsTimestamp: new Date(now - 3600000).toISOString()
+      }]
+    }
+  })
+
+  test('keeps YouTube crops, aspect ratio, and UI roundness', async ({ page }) => {
+    await stubPostImages(page)
+
+    await goTo(page, 'subscriptions')
+    await page.locator('[data-subscription-feed-tab="posts"]').click()
+
+    const multiPost = page.locator('.ft-list-post').filter({ hasText: 'Multi image community post' })
+    const singlePost = page.locator('.ft-list-post').filter({ hasText: 'Single image community post' })
+    await expect(multiPost).toBeVisible()
+    await expect(singlePost).toBeVisible()
+
+    const multiImage = multiPost.locator('img.communityImage').first()
+    const singleImage = singlePost.locator('img.communityImage').first()
+    await expect(multiImage).toBeVisible()
+    await expect(singleImage).toBeVisible()
+
+    await expect(multiImage).toHaveAttribute('src', new RegExp(FCROP))
+    await expect(singleImage).toHaveAttribute('src', new RegExp(FCROP))
+
+    await expect.poll(async () => multiImage.evaluate((img) => img.naturalWidth)).toBeGreaterThan(0)
+    await expect.poll(async () => singleImage.evaluate((img) => img.naturalWidth)).toBeGreaterThan(0)
+
+    const multiMetrics = await multiImage.evaluate((img) => {
+      const style = getComputedStyle(img)
+      return {
+        naturalRatio: img.naturalWidth / img.naturalHeight,
+        displayRatio: img.clientWidth / img.clientHeight,
+        borderRadius: style.borderRadius
+      }
+    })
+    const singleMetrics = await singleImage.evaluate((img) => {
+      return {
+        naturalRatio: img.naturalWidth / img.naturalHeight,
+        displayRatio: img.clientWidth / img.clientHeight
+      }
+    })
+
+    // uiRoundness 200 → --ui-roundness: 2 → 8px * 2 = 16px
+    expect(multiMetrics.borderRadius).toBe('16px')
+    expect(multiMetrics.displayRatio).toBeCloseTo(multiMetrics.naturalRatio, 2)
+    expect(singleMetrics.displayRatio).toBeCloseTo(singleMetrics.naturalRatio, 2)
+
+    // Carousel chrome should sit on the image, not in a tall empty gap below it.
+    const carouselLayout = await multiPost.locator('swiper-container.sliderContainer').evaluate((container) => {
+      const image = container.querySelector('img.communityImage')
+      const pagination = container.shadowRoot?.querySelector('.swiper-pagination')
+      return {
+        containerHeight: container.getBoundingClientRect().height,
+        imageHeight: image.getBoundingClientRect().height,
+        paginationBottom: pagination?.getBoundingClientRect().bottom ?? null,
+        containerBottom: container.getBoundingClientRect().bottom
+      }
+    })
+
+    expect(carouselLayout.containerHeight).toBeLessThan(carouselLayout.imageHeight * 1.35)
+    if (carouselLayout.paginationBottom != null) {
+      expect(carouselLayout.paginationBottom).toBeLessThanOrEqual(carouselLayout.containerBottom + 1)
+    }
+  })
+})

--- a/src/renderer/components/FtCommunityPost/FtCommunityPost.scss
+++ b/src/renderer/components/FtCommunityPost/FtCommunityPost.scss
@@ -21,8 +21,10 @@
 }
 
 .communityImage {
-  block-size: 100%;
+  display: block;
   inline-size: 100%;
+  block-size: auto;
+  border-radius: calc(8px * var(--ui-roundness));
 }
 
 .communityThumbnail {

--- a/src/renderer/components/FtCommunityPost/FtCommunityPost.vue
+++ b/src/renderer/components/FtCommunityPost/FtCommunityPost.vue
@@ -305,8 +305,9 @@ function getBestQualityImage(imageArray) {
     return Number.parseInt(b.width) - Number.parseInt(a.width)
   })
 
-  // Remove cropping directives when applicable
-  return imageArrayCopy[0]?.url?.replace(/-c-fcrop64=[^-]+/i, '') ?? ''
+  // Keep YouTube's fcrop64 directive so the CDN returns the same
+  // pre-cropped image YouTube shows (stripping it softens/mismatches).
+  return imageArrayCopy[0]?.url ?? ''
 }
 
 const swiperContainerRef = useTemplateRef('swiperContainerRef')


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Make sure to follow the contributing guidelines. -->
<!-- Important note, we may remove your pull request if you do not use this provided PR template correctly. -->
<!-- Agent instructions: Preserve every heading, comment, and marker in this template. Never remove or rewrite the release-note-category:start/end, release-note:start/end, or release-note-image:start/end marker pairs. Never remove or rewrite the Release note images section; leave its contents for a human. -->

## Pull Request Type
<!-- Please select what type of pull request this is: [x] -->
- [x] Bug Fix
- [ ] Feature Implementation
- [ ] Documentation
- [ ] Other

## Related issue
<!-- Please link the issue your pull request is referring to. -->
<!-- If this pull request fully resolves the relevant issue, put "closes" before the issue number. -->
<!-- Example: "closes #123456". -->

## Description
<!-- Please write a clear and concise description of what the pull request does. -->
Community post images (especially multi-image carousels) were stretched because `.communityImage` forced both axes to `100%` with the default `object-fit: fill`. We were also stripping YouTube's `fcrop64` CDN crop, so the app loaded the full uncropped frame and rescaled it in CSS — softer and differently framed than YouTube.

This keeps the `fcrop64` URL YouTube uses, sizes images by their natural aspect ratio, and applies the UI roundness setting to post image corners.

## Release note category
<!-- Select exactly one category. Every pull request must select one. -->
<!-- release-note-category:start -->
- [ ] Not noteworthy
- [ ] Highlights
- [ ] More improvements
- [x] Fixed bugs
<!-- release-note-category:end -->

## Release note
<!-- Required unless "Not noteworthy" is selected. -->
<!-- Write one concise, user-facing entry without a leading bullet. -->
<!-- release-note:start -->
Fixed stretched and soft-looking images in community posts
<!-- release-note:end -->

## Release note images
<!-- Human-only: Agents must preserve this entire section and leave it empty. -->
<!-- Optional. Paste one or more Markdown images or HTML image tags here. -->
<!-- The release notes will use an HTML image tag and limit images taller than 300 pixels. -->
<!-- release-note-image:start -->

<!-- release-note-image:end -->

## Testing
<!-- How can reviewers verify that the PR produces correct results? -->
<!-- Please provide instructions so that others can ensure that your pull request would produce correct results. For examples see, https://github.com/FreeTubeApp/FreeTube/pull/5743, https://github.com/FreeTubeApp/FreeTube/pull/7349, https://github.com/FreeTubeApp/FreeTube/pull/5125, https://github.com/FreeTubeApp/FreeTube/pull/7338 -->
<!-- Agent instructions: Only write human-facing steps that explain how to verify the change while running this branch in dev mode. Include expected results and, when applicable, helpful console snippets for interactive verification. Do not include automated checks, commands, results, pass counts, or CI status. -->
1. Open https://www.youtube.com/post/UgkxAU0g4ZDiZCBtREO-TnvfuqYnDgFMNaEZ in a browser and note the square crop and sharpness.
2. In the app, open the same post (or Trilogy Media → Posts).
3. Confirm the carousel images are not stretched, match YouTube's crop, and look sharp.
4. Swipe through all images and confirm navigation/pagination stay aligned with the image (no large empty gap under the photo).
5. Change Settings → UI Roundness and confirm post image corner radius updates.

## Additional context
<!-- Add any other context about the pull request here. -->
Related upstream FreeTube discussion: https://github.com/FreeTubeApp/FreeTube/issues/4852