### PR TITLE
fix(posts): show full frames for single-image community posts

### DIFF
--- a/e2e/tests/offline/community-post-images.spec.mjs
+++ b/e2e/tests/offline/community-post-images.spec.mjs
@@ -142,7 +142,7 @@ test.describe('community post images', () => {
     }
   })
 
-  test('keeps YouTube crops, aspect ratio, and UI roundness', async ({ page }) => {
+  test('keeps carousel crops, shows full single images, and applies UI roundness', async ({ page }) => {
     await stubPostImages(page)
 
     await goTo(page, 'subscriptions')
@@ -158,8 +158,9 @@ test.describe('community post images', () => {
     await expect(multiImage).toBeVisible()
     await expect(singleImage).toBeVisible()
 
+    // Carousels keep YouTube's square CDN crop; single images drop it.
     await expect(multiImage).toHaveAttribute('src', new RegExp(FCROP))
-    await expect(singleImage).toHaveAttribute('src', new RegExp(FCROP))
+    await expect(singleImage).not.toHaveAttribute('src', new RegExp(FCROP))
 
     await expect.poll(async () => multiImage.evaluate((img) => img.naturalWidth)).toBeGreaterThan(0)
     await expect.poll(async () => singleImage.evaluate((img) => img.naturalWidth)).toBeGreaterThan(0)
@@ -182,7 +183,9 @@ test.describe('community post images', () => {
     // uiRoundness 200 → --ui-roundness: 2 → 8px * 2 = 16px
     expect(multiMetrics.borderRadius).toBe('16px')
     expect(multiMetrics.displayRatio).toBeCloseTo(multiMetrics.naturalRatio, 2)
+    expect(multiMetrics.naturalRatio).toBeCloseTo(1, 2)
     expect(singleMetrics.displayRatio).toBeCloseTo(singleMetrics.naturalRatio, 2)
+    expect(singleMetrics.naturalRatio).toBeCloseTo(800 / 450, 2)
 
     // Carousel chrome should sit on the image, not in a tall empty gap below it.
     const carouselLayout = await multiPost.locator('swiper-container.sliderContainer').evaluate((container) => {

--- a/src/renderer/components/FtCommunityPost/FtCommunityPost.vue
+++ b/src/renderer/components/FtCommunityPost/FtCommunityPost.vue
@@ -71,7 +71,7 @@
         lazy="true"
       >
         <img
-          :src="getBestQualityImage(img)"
+          :src="getBestQualityImage(img, { preserveYouTubeCrop: true })"
           class="communityImage"
           alt=""
           loading="lazy"
@@ -298,16 +298,23 @@ function parseCommunityData() {
 
 /**
  * @param {{ width: number, height: number, url: string }[]} imageArray
+ * @param {{ preserveYouTubeCrop?: boolean }} [options]
  */
-function getBestQualityImage(imageArray) {
+function getBestQualityImage(imageArray, options = {}) {
   const imageArrayCopy = Array.from(imageArray)
   imageArrayCopy.sort((a, b) => {
     return Number.parseInt(b.width) - Number.parseInt(a.width)
   })
 
-  // Keep YouTube's fcrop64 directive so the CDN returns the same
-  // pre-cropped image YouTube shows (stripping it softens/mismatches).
-  return imageArrayCopy[0]?.url ?? ''
+  const url = imageArrayCopy[0]?.url ?? ''
+
+  // Multi-image carousels match YouTube's square CDN crops. Single-image
+  // posts show the full frame (YouTube omits fcrop64 for those).
+  if (options.preserveYouTubeCrop) {
+    return url
+  }
+
+  return url.replace(/-c-fcrop64=[^-]+/i, '')
 }
 
 const swiperContainerRef = useTemplateRef('swiperContainerRef')


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Make sure to follow the contributing guidelines. -->
<!-- Important note, we may remove your pull request if you do not use this provided PR template correctly. -->
<!-- Agent instructions: Preserve every heading, comment, and marker in this template. Never remove or rewrite the release-note-category:start/end, release-note:start/end, or release-note-image:start/end marker pairs. Never remove or rewrite the Release note images section; leave its contents for a human. -->

## Pull Request Type
<!-- Please select what type of pull request this is: [x] -->
- [x] Bug Fix
- [ ] Feature Implementation
- [ ] Documentation
- [ ] Other

## Related issue
<!-- Please link the issue your pull request is referring to. -->
<!-- If this pull request fully resolves the relevant issue, put "closes" before the issue number. -->
<!-- Example: "closes #123456". -->

Follow-up to #561.

## Description
<!-- Please write a clear and concise description of what the pull request does. -->
#561 kept YouTube's `fcrop64` CDN crop for all community post images so multi-image carousels matched YouTube. That also side-cropped single-image posts, which YouTube shows as the full uncropped frame.

This keeps `fcrop64` only for multi-image carousels and strips it again for single-image posts.

## Release note category
<!-- Select exactly one category. Every pull request must select one. -->
<!-- release-note-category:start -->
- [x] Not noteworthy
- [ ] Highlights
- [ ] More improvements
- [ ] Fixed bugs
<!-- release-note-category:end -->

## Release note
<!-- Required unless "Not noteworthy" is selected. -->
<!-- Write one concise, user-facing entry without a leading bullet. -->
<!-- release-note:start -->
Fixed single-image community posts being cropped too tightly
<!-- release-note:end -->

## Release note images
<!-- Human-only: Agents must preserve this entire section and leave it empty. -->
<!-- Optional. Paste one or more Markdown images or HTML image tags here. -->
<!-- The release notes will use an HTML image tag and limit images taller than 300 pixels. -->
<!-- release-note-image:start -->

<!-- release-note-image:end -->

## Testing
<!-- How can reviewers verify that the PR produces correct results? -->
<!-- Please provide instructions so that others can ensure that your pull request would produce correct results. For examples see, https://github.com/FreeTubeApp/FreeTube/pull/5743, https://github.com/FreeTubeApp/FreeTube/pull/7349, https://github.com/FreeTubeApp/FreeTube/pull/5125, https://github.com/FreeTubeApp/FreeTube/pull/7338 -->
<!-- Agent instructions: Only write human-facing steps that explain how to verify the change while running this branch in dev mode. Include expected results and, when applicable, helpful console snippets for interactive verification. Do not include automated checks, commands, results, pass counts, or CI status. -->
1. Open a multi-image community post and confirm the carousel still uses the square crop and looks sharp (same as after #561).
2. Open a single-image community post that previously looked side-cropped and confirm the full frame is visible (no missing left/right content).
3. Confirm both image types still use the UI roundness setting for corner radius.
4. Offline e2e: `offline/community-post-images.spec.mjs` asserts carousel URLs keep `fcrop64`, single-image URLs drop it, and both preserve aspect ratio.

## Additional context
<!-- Add any other context about the pull request here. -->
There is no official YouTube Data API documentation for community-post image crops; `fcrop64` is an undocumented CDN URL parameter observed from YouTube's own page rendering.