### PR TITLE
fix: respect channel links and stabilize live chat scrolling

### DIFF
--- a/_scripts/webpack.renderer.config.js
+++ b/_scripts/webpack.renderer.config.js
@@ -15,6 +15,17 @@ const {
 const { sigFrameTemplateParameters } = require('./sigFrameConfig')
 
 const isDevMode = process.env.NODE_ENV === 'development'
+const requestedPlatform = process.env.npm_config_platform
+
+if (!process.env.OTX_PLATFORM && requestedPlatform && requestedPlatform !== process.platform) {
+  throw new Error(`Cross-packing for ${requestedPlatform} requires OTX_PLATFORM=${requestedPlatform}`)
+}
+
+const rendererPlatform = process.env.OTX_PLATFORM || process.platform
+
+if (!['darwin', 'linux', 'win32'].includes(rendererPlatform)) {
+  throw new Error(`Unsupported OTX_PLATFORM: ${rendererPlatform}`)
+}
 
 const { version: swiperVersion } = JSON.parse(readFileSync(path.join(__dirname, '../node_modules/swiper/package.json')))
 
@@ -142,9 +153,9 @@ const config = {
   plugins: [
     processLocalesPlugin,
     new webpack.DefinePlugin({
-      // OTX_PLATFORM overrides the build host when cross-packing (e.g.
-      // OTX_PLATFORM=darwin while building a macOS zip on Linux).
-      'process.platform': JSON.stringify(process.env.OTX_PLATFORM || process.platform),
+      // Cross-pack callers must declare the target through OTX_PLATFORM because
+      // renderer platform checks are compiled into the bundle.
+      'process.platform': JSON.stringify(rendererPlatform),
       'process.env.IS_ELECTRON': true,
       'process.env.IS_ELECTRON_MAIN': false,
       'process.env.SUPPORTS_LOCAL_API': true,

--- a/_scripts/webpack.renderer.config.js
+++ b/_scripts/webpack.renderer.config.js
@@ -15,16 +15,15 @@ const {
 const { sigFrameTemplateParameters } = require('./sigFrameConfig')
 
 const isDevMode = process.env.NODE_ENV === 'development'
-const requestedPlatform = process.env.npm_config_platform
+const rendererPlatform = process.platform
 
-if (!process.env.OTX_PLATFORM && requestedPlatform && requestedPlatform !== process.platform) {
-  throw new Error(`Cross-packing for ${requestedPlatform} requires OTX_PLATFORM=${requestedPlatform}`)
-}
-
-const rendererPlatform = process.env.OTX_PLATFORM || process.platform
-
-if (!['darwin', 'linux', 'win32'].includes(rendererPlatform)) {
-  throw new Error(`Unsupported OTX_PLATFORM: ${rendererPlatform}`)
+for (const [name, requestedPlatform] of [
+  ['OTX_PLATFORM', process.env.OTX_PLATFORM],
+  ['npm_config_platform', process.env.npm_config_platform]
+]) {
+  if (requestedPlatform && requestedPlatform !== rendererPlatform) {
+    throw new Error(`${name}=${requestedPlatform} does not match the packager platform ${rendererPlatform}`)
+  }
 }
 
 const { version: swiperVersion } = JSON.parse(readFileSync(path.join(__dirname, '../node_modules/swiper/package.json')))
@@ -153,8 +152,8 @@ const config = {
   plugins: [
     processLocalesPlugin,
     new webpack.DefinePlugin({
-      // Cross-pack callers must declare the target through OTX_PLATFORM because
-      // renderer platform checks are compiled into the bundle.
+      // build.mjs packages for the host OS, so reject mismatched target hints
+      // above instead of compiling renderer behavior for a different platform.
       'process.platform': JSON.stringify(rendererPlatform),
       'process.env.IS_ELECTRON': true,
       'process.env.IS_ELECTRON_MAIN': false,

--- a/e2e/tests/offline/channel-settings.spec.mjs
+++ b/e2e/tests/offline/channel-settings.spec.mjs
@@ -42,4 +42,21 @@ test.describe('channel settings', () => {
     await expect(dialog).toHaveCount(0)
     await expect(page).toHaveURL(new RegExp(`#/channel/${CHANNEL_ID}`))
   })
+
+  test('saved channels are not links when channel links are disabled', async ({ page }) => {
+    await page.evaluate(async () => {
+      const store = document.querySelector('#app').__vue_app__.config.globalProperties.$store
+      await store.dispatch('updateDisableChannelLinks', true)
+    })
+
+    await goTo(page, 'settings')
+    await page.locator('.settingsMenu [data-section="channel"]').click()
+    await page.getByRole('button', { name: 'Manage Saved Channels (1)' }).click()
+
+    const dialog = page.getByRole('dialog', { name: 'Saved Channel Settings' })
+    const channel = dialog.locator('.channelLink', { hasText: CHANNEL_NAME })
+    await expect(channel).toBeVisible()
+    await expect(channel).not.toHaveAttribute('href')
+    await expect(channel).toHaveJSProperty('tagName', 'SPAN')
+  })
 })

--- a/src/renderer/components/ChannelSettings/ChannelSettings.vue
+++ b/src/renderer/components/ChannelSettings/ChannelSettings.vue
@@ -74,10 +74,11 @@
             class="channelEntry"
           >
             <div class="channelHeader">
-              <router-link
+              <component
+                :is="disableChannelLinks ? 'span' : 'router-link'"
                 class="channelLink"
-                :to="`/channel/${channel.id}`"
-                @click="showManager = false"
+                :to="disableChannelLinks ? undefined : `/channel/${channel.id}`"
+                @click="handleChannelLinkClick"
               >
                 <img
                   v-if="channel.thumbnail"
@@ -97,7 +98,7 @@
                 >
                   {{ channel.name }}
                 </p>
-              </router-link>
+              </component>
               <FtIconButton
                 v-if="channel.addableOptions.length > 0"
                 :title="t('Settings.Channel Settings.Add Setting')"
@@ -208,6 +209,7 @@ import {
 const { locale, t } = useI18n()
 
 const PREFERENCES = CHANNEL_PREFERENCE_TYPES
+const disableChannelLinks = computed(() => store.getters.getDisableChannelLinks)
 
 /** Only offer the search field once scanning the list by eye gets tedious */
 const SEARCH_THRESHOLD = 5
@@ -286,6 +288,28 @@ const backendOptions = computed(() => ({
 }))
 
 const showManager = ref(false)
+
+/**
+ * Close the manager only when the current tab is navigating. Modified clicks
+ * may open another tab or window and should leave this dialog untouched.
+ * @param {MouseEvent} event
+ */
+function handleChannelLinkClick(event) {
+  if (disableChannelLinks.value) {
+    event.preventDefault()
+    return
+  }
+
+  if (
+    event.button === 0 &&
+    !event.ctrlKey &&
+    !event.metaKey &&
+    !event.shiftKey &&
+    !event.altKey
+  ) {
+    showManager.value = false
+  }
+}
 const searchQuery = ref('')
 
 /**

--- a/src/renderer/components/WatchVideoLiveChat/WatchVideoLiveChat.vue
+++ b/src/renderer/components/WatchVideoLiveChat/WatchVideoLiveChat.vue
@@ -2,7 +2,6 @@
   <FtCard
     class="card relative"
     :class="{ hasError, fullscreenChat: fullscreenOverlay }"
-    @wheel.stop
   >
     <header
       v-if="fullscreenOverlay"
@@ -265,9 +264,11 @@
           v-overlay-scrollbars
           class="liveChatComments"
           :style="{ blockSize: chatHeight }"
+          tabindex="0"
           @pointerdown="stopScrollingToBottom"
           @scroll.passive="onScroll"
           @scrollend="onScrollEnd"
+          @keydown="handleLiveChatScrollKeydown"
           @wheel.passive="stopScrollingToBottom"
         >
           <TransitionGroup
@@ -1029,6 +1030,18 @@ function stopScrollingToBottom() {
 
   isScrollingToBottom = false
   stayAtBottom = false
+}
+
+/**
+ * Keyboard scrolling does not emit pointer or wheel events. Cancel the
+ * auto-follow hold before the browser moves the viewport so it is not snapped
+ * back to the live edge on a busy chat.
+ * @param {KeyboardEvent} event
+ */
+function handleLiveChatScrollKeydown(event) {
+  if (['ArrowUp', 'ArrowDown', 'PageUp', 'PageDown', 'Home', 'End', ' '].includes(event.key)) {
+    stopScrollingToBottom()
+  }
 }
 
 function hideSuperChat() {

--- a/src/renderer/components/ft-shaka-video-player/opentubex/useSponsorBlockSubmission.js
+++ b/src/renderer/components/ft-shaka-video-player/opentubex/useSponsorBlockSubmission.js
@@ -698,8 +698,6 @@ export function useSponsorBlockSubmission({
   }
 
   const sponsorBlockSubmissionCategoryNames = computed(() => {
-    // Depend on i18n so labels refresh when the locale changes.
-    t('Video.Sponsor Block category.sponsor')
     return SPONSORBLOCK_SUBMISSION_CATEGORIES.map(category => {
       return translateSponsorBlockCategory(category, { short: false })
     })

--- a/src/renderer/views/Watch/Watch.js
+++ b/src/renderer/views/Watch/Watch.js
@@ -352,7 +352,7 @@ export default defineComponent({
       preserveTitleOnNextReload: false,
       ipBlockDetectedInCurrentChain: false,
       ipBlockRecoveryAttemptedForCurrentVideo: false,
-      stream403ReloadAttemptedForCurrentVideo: false,
+      streamErrorReloadAttemptedForCurrentVideo: false,
       sabrErrorRecoveryAttempts: 0,
       sabrErrorRecoveriesForCurrentVideo: 0,
       /** @type {number|null} */
@@ -616,6 +616,9 @@ export default defineComponent({
     },
     hideUploader: function () {
       return this.$store.getters.getHideUploader
+    },
+    disableChannelLinks: function () {
+      return this.$store.getters.getDisableChannelLinks
     },
     hideUnsubscribeButton: function () {
       return this.$store.getters.getHideUnsubscribeButton
@@ -1264,7 +1267,7 @@ export default defineComponent({
       const videoIdChanged = this.videoId !== previousVideoId
       if (videoIdChanged) {
         this.ipBlockRecoveryAttemptedForCurrentVideo = false
-        this.stream403ReloadAttemptedForCurrentVideo = false
+        this.streamErrorReloadAttemptedForCurrentVideo = false
         this.sabrErrorRecoveryAttempts = 0
         this.sabrErrorRecoveriesForCurrentVideo = 0
         this.sabrErrorRecoveryLastSeconds = null
@@ -1665,7 +1668,8 @@ export default defineComponent({
     },
 
     openShortsChannel: function (event) {
-      if (!this.channelId) {
+      if (!this.channelId || this.disableChannelLinks) {
+        event?.preventDefault()
         return
       }
 
@@ -3438,6 +3442,26 @@ export default defineComponent({
     },
 
     /**
+     * Reload once for a playback error that may be fixed by fetching fresh
+     * streaming data.
+     * @param {string} specificError
+     * @returns {Promise<boolean>} whether a reload was started
+     */
+    reloadAfterStreamErrorOnce: async function (specificError) {
+      if (this.streamErrorReloadAttemptedForCurrentVideo) {
+        return false
+      }
+
+      this.streamErrorReloadAttemptedForCurrentVideo = true
+      this.showTabToast({
+        message: `${this.t('Video.Reloading video after streaming URL error')}: ${specificError}`,
+        icon: ['fas', 'sync'],
+      })
+      await this.reloadView()
+      return true
+    },
+
+    /**
      * @param {import('shaka-player/dist/shaka-player.ui').default.util.Error} error
      */
     handlePlayerError: async function (error) {
@@ -3482,13 +3506,7 @@ export default defineComponent({
                   ? '[BAD_HTTP_STATUS: 403] Potential causes: IP block, streaming URL deciphering failed or music video geo-block'
                   : '[BAD_HTTP_STATUS: 403] Potential causes: IP block or streaming URL deciphering failed'
 
-              if (!this.stream403ReloadAttemptedForCurrentVideo) {
-                this.stream403ReloadAttemptedForCurrentVideo = true
-                this.showTabToast({
-                  message: `${this.t('Video.Reloading video after streaming URL error')}: ${specificError}`,
-                  icon: ['fas', 'sync'],
-                })
-                await this.reloadView()
+              if (await this.reloadAfterStreamErrorOnce(specificError)) {
                 return
               }
 
@@ -3511,13 +3529,7 @@ export default defineComponent({
 
             const specificError = '[VIDEO_ERROR] YouTube watch session expired. Please reopen this video.'
 
-            if (!this.stream403ReloadAttemptedForCurrentVideo) {
-              this.stream403ReloadAttemptedForCurrentVideo = true
-              this.showTabToast({
-                message: `${this.t('Video.Reloading video after streaming URL error')}: ${specificError}`,
-                icon: ['fas', 'sync'],
-              })
-              await this.reloadView()
+            if (await this.reloadAfterStreamErrorOnce(specificError)) {
               return
             }
 

--- a/src/renderer/views/Watch/Watch.vue
+++ b/src/renderer/views/Watch/Watch.vue
@@ -175,10 +175,11 @@
                 class="shortsPaidPromotion"
               />
               <div class="shortsFullscreenChannelRow">
-                <RouterLink
+                <component
+                  :is="disableChannelLinks ? 'span' : 'router-link'"
                   v-if="!hideUploader && channelId"
                   class="shortsFullscreenChannel"
-                  :to="`/channel/${channelId}`"
+                  :to="disableChannelLinks ? undefined : `/channel/${channelId}`"
                   @click="openShortsChannel"
                   @auxclick="openShortsChannel"
                 >
@@ -189,7 +190,7 @@
                     alt=""
                   >
                   <span dir="auto">{{ channelName }}</span>
-                </RouterLink>
+                </component>
                 <FtSubscribeButton
                   v-if="!hideUnsubscribeButton"
                   :channel-id="channelId"
@@ -298,10 +299,11 @@
             <div
               class="shortsChannelRow"
             >
-              <RouterLink
+              <component
+                :is="disableChannelLinks ? 'span' : 'router-link'"
                 v-if="!hideUploader && channelId"
                 class="shortsExternalChannel"
-                :to="`/channel/${channelId}`"
+                :to="disableChannelLinks ? undefined : `/channel/${channelId}`"
                 @click="openShortsChannel"
                 @auxclick="openShortsChannel"
               >
@@ -312,7 +314,7 @@
                   alt=""
                 >
                 <span dir="auto">{{ channelName }}</span>
-              </RouterLink>
+              </component>
               <FtSubscribeButton
                 v-if="!hideUnsubscribeButton"
                 :channel-id="channelId"
@@ -467,10 +469,11 @@
             />
             <span>{{ quickBookmarkIconText }}</span>
           </div>
-          <RouterLink
+          <component
+            :is="disableChannelLinks ? 'span' : 'router-link'"
             v-if="!isLoading && channelId && channelThumbnail"
             class="shortsSoundThumbnail"
-            :to="`/channel/${channelId}`"
+            :to="disableChannelLinks ? undefined : `/channel/${channelId}`"
             :title="channelName"
             @click="openShortsChannel"
             @auxclick="openShortsChannel"
@@ -479,7 +482,7 @@
               :src="channelThumbnail"
               alt=""
             >
-          </RouterLink>
+          </component>
         </div>
         <button
           v-if="customShortsPlayerActive && nextSubscriptionShortThumbnail"


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Make sure to follow the contributing guidelines. -->
<!-- Important note, we may remove your pull request if you do not use this provided PR template correctly. -->
<!-- Agent instructions: Preserve every heading, comment, and marker in this template. Never remove or rewrite the release-note-category:start/end, release-note:start/end, or release-note-image:start/end marker pairs. Never remove or rewrite the Release note images section; leave its contents for a human. -->

## Pull Request Type
<!-- Please select what type of pull request this is: [x] -->
- [x] Bugfix
- [ ] Feature Implementation
- [ ] Documentation
- [ ] Other

## Related issue
<!-- Please link the issue your pull request is referring to. -->
<!-- If this pull request fully resolves the relevant issue, put "closes" before the issue number. -->
<!-- Example: "closes #123456". -->

## Description
<!-- Please write a clear and concise description of what the pull request does. -->

Polishes several recent fork-specific changes after a focused follow-up review.

- respects the Disable Channel Links setting in Shorts and saved channel settings
- keeps modified channel clicks from closing the settings manager
- avoids trapping page scrolling over live chat and lets keyboard input cancel auto-follow
- validates renderer platform overrides used by cross-packs
- consolidates the one-shot stream error reload path
- removes a redundant SponsorBlock translation dependency

## Release note category
<!-- Select exactly one category. Every pull request must select one. -->
<!-- release-note-category:start -->
- [x] Not noteworthy
- [ ] Highlights
- [ ] More improvements
- [ ] Fixed bugs
<!-- release-note-category:end -->

## Release note
<!-- Required unless "Not noteworthy" is selected. -->
<!-- Write one concise, user-facing entry without a leading bullet. -->
<!-- release-note:start -->
Improved channel-link controls, live chat scrolling, and playback error recovery.
<!-- release-note:end -->

## Release note images
<!-- Human-only: Agents must preserve this entire section and leave it empty. -->
<!-- Optional. Paste one or more Markdown images or HTML image tags here. -->
<!-- The release notes will use an HTML image tag and limit images taller than 300 pixels. -->
<!-- release-note-image:start -->

<!-- release-note-image:end -->

## Testing
<!-- How can reviewers verify that the PR produces correct results? -->
<!-- Please provide instructions so that others can ensure that your pull request would produce correct results. For examples see, https://github.com/FreeTubeApp/FreeTube/pull/5743, https://github.com/FreeTubeApp/FreeTube/pull/7349, https://github.com/FreeTubeApp/FreeTube/pull/5125, https://github.com/FreeTubeApp/FreeTube/pull/7338 -->
<!-- Agent instructions: Only write human-facing steps that explain how to verify the change while running this branch in dev mode. Include expected results and, when applicable, helpful console snippets for interactive verification. Do not include automated checks, commands, results, pass counts, or CI status. -->

1. Enable **Disable Channel Links**, open a Short and the saved channel settings manager, and confirm channel names and thumbnails no longer navigate.
2. Disable that setting and confirm normal clicks navigate in the current tab while modified clicks keep the manager open.
3. Open live chat, scroll the surrounding page while pointing at the chat header, then focus the chat list and use Page Up. The page and chat should scroll respectively without snapping back to the live edge.
4. Trigger a recoverable streaming URL error and confirm the video reloads only once before the existing error recovery behavior takes over.

## Additional context
<!-- Add any other context about the pull request here. -->

This is a follow-up review of recent OpenTubeX-only pull requests and does not intentionally change inherited upstream behavior.
