### PR TITLE
fix: size select dropdowns to their content

### DIFF
--- a/src/renderer/components/FtSelect/FtSelect.vue
+++ b/src/renderer/components/FtSelect/FtSelect.vue
@@ -276,10 +276,16 @@ function updateDropdownPosition() {
   const openAbove = desiredHeight > spaceBelow && spaceAbove > spaceBelow
   const availableHeight = Math.max(0, openAbove ? spaceAbove : spaceBelow)
   const menuHeight = Math.min(desiredHeight, availableHeight)
-  const menuWidth = Math.min(buttonRect.width, window.innerWidth - viewportMargin * 2)
+  const menuChromeWidth = menu.offsetWidth - menu.clientWidth
+  const widestOption = Math.max(
+    buttonRect.width,
+    ...(options.value ?? []).map(option => option.scrollWidth + menuChromeWidth)
+  )
+  const menuWidth = Math.min(widestOption, window.innerWidth - viewportMargin * 2)
+  const centeredLeft = buttonRect.left + (buttonRect.width - menuWidth) / 2
   const left = Math.max(
     viewportMargin,
-    Math.min(buttonRect.left, window.innerWidth - viewportMargin - menuWidth)
+    Math.min(centeredLeft, window.innerWidth - viewportMargin - menuWidth)
   )
   const top = openAbove
     ? Math.max(minimumTop, buttonRect.top - menuGap - menuHeight)


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Make sure to follow the contributing guidelines. -->
<!-- Important note, we may remove your pull request if you do not use this provided PR template correctly. -->
<!-- Agent instructions: Preserve every heading, comment, and marker in this template. Never remove or rewrite the release-note-category:start/end, release-note:start/end, or release-note-image:start/end marker pairs. Never remove or rewrite the Release note images section; leave its contents for a human. -->

## Pull Request Type
<!-- Please select what type of pull request this is: [x] -->
- [x] Bugfix
- [ ] Feature Implementation
- [ ] Documentation
- [ ] Other

## Related issue
<!-- Please link the issue your pull request is referring to. -->
<!-- If this pull request fully resolves the relevant issue, put "closes" before the issue number. -->
<!-- Example: "closes #123456". -->

None.

## Description
<!-- Please write a clear and concise description of what the pull request does. -->

Select dropdowns were constrained to the width of their input, which truncated long options and made similarly named choices difficult to distinguish.

This sizes each dropdown to its widest rendered option, up to the available viewport width. Wider dropdowns are centered over their input and shift only when needed to remain within the viewport.

## Release note category
<!-- Select exactly one category. Every pull request must select one. -->
<!-- release-note-category:start -->
- [ ] Not noteworthy
- [ ] Highlights
- [ ] More improvements
- [x] Fixed bugs
<!-- release-note-category:end -->

## Release note
<!-- Required unless "Not noteworthy" is selected. -->
<!-- Write one concise, user-facing entry without a leading bullet. -->
<!-- release-note:start -->

Long options in select dropdowns are no longer unnecessarily truncated.

<!-- release-note:end -->

## Release note images
<!-- Human-only: Agents must preserve this entire section and leave it empty. -->
<!-- Optional. Paste one or more Markdown images or HTML image tags here. -->
<!-- The release notes will use an HTML image tag and limit images taller than 300 pixels. -->
<!-- release-note-image:start -->

<!-- release-note-image:end -->

## Testing
<!-- How can reviewers verify that the PR produces correct results? -->
<!-- Please provide instructions so that others can ensure that your pull request would produce correct results. For examples see, https://github.com/FreeTubeApp/FreeTube/pull/5743, https://github.com/FreeTubeApp/FreeTube/pull/7349, https://github.com/FreeTubeApp/FreeTube/pull/5125, https://github.com/FreeTubeApp/FreeTube/pull/7338 -->
<!-- Agent instructions: Only write human-facing steps that explain how to verify the change while running this branch in dev mode. Include expected results and, when applicable, helpful console snippets for interactive verification. Do not include automated checks, commands, results, pass counts, or CI status. -->

1. Open Theme Settings while running this branch in dev mode.
2. Open the Base Theme, Main Color Theme, or Secondary Color Theme dropdown.
3. Confirm the dropdown expands enough to show the full Catppuccin option names and remains centered over the select input.
4. Narrow the window and confirm the dropdown remains within the viewport.

## Additional context
<!-- Add any other context about the pull request here. -->

The selected value remains constrained to the input width; only the open dropdown expands.
