### PR TITLE
fix(player): avoid replaying mini player animation

### DIFF
--- a/e2e/tests/network/watch.spec.mjs
+++ b/e2e/tests/network/watch.spec.mjs
@@ -410,6 +410,48 @@ test.describe('watch page', () => {
     expect(animations[1].zIndex).toBe('150')
   })
 
+  test('does not replay the scroll mini player animation after switching tabs', async ({ page, innertube }) => {
+    test.skip(!innertube.playback, 'needs real media streams')
+    await openVideo(page)
+
+    const video = await waitForPlaybackOrSkip(test, page)
+    await video.evaluate(element => element.pause())
+    await page.evaluate(() => {
+      document.documentElement.dataset.reducedMotion = 'no-preference'
+      window.scrollMiniPlayerAnimationCount = 0
+      const nativeAnimate = Element.prototype.animate
+
+      Element.prototype.animate = function (keyframes, options) {
+        if (this.classList.contains('ftVideoPlayer')) {
+          window.scrollMiniPlayerAnimationCount++
+        }
+        return nativeAnimate.call(this, keyframes, options)
+      }
+    })
+
+    const player = page.locator(`${activeTab} .ftVideoPlayer`)
+    await player.evaluate(element => {
+      const rect = element.getBoundingClientRect()
+      window.scrollTo(0, window.scrollY + rect.bottom)
+    })
+    await expect(player).toHaveClass(/scrollMiniPlayer/)
+    await expect.poll(() => page.evaluate(() => window.scrollMiniPlayerAnimationCount)).toBe(1)
+
+    await page.locator(sel.newTabButton).click()
+    await expect(page.locator(sel.tabs)).toHaveCount(2)
+    const animationCountBeforeReturn = await page.evaluate(
+      () => window.scrollMiniPlayerAnimationCount
+    )
+    await page.locator(sel.tabs).first().click()
+    await expect(player).toHaveClass(/scrollMiniPlayer/)
+
+    // The old behavior scheduled the restored entrance animation on the next
+    // Vue tick, so wait past its duration before checking that none was added.
+    await page.waitForTimeout(350)
+    expect(await page.evaluate(() => window.scrollMiniPlayerAnimationCount))
+      .toBe(animationCountBeforeReturn)
+  })
+
   test('scales the captions down with the scroll mini player', async ({ page, innertube }) => {
     test.skip(!innertube.playback, 'needs real media streams')
     await openVideo(page)

--- a/src/renderer/components/ft-shaka-video-player/ft-shaka-video-player.js
+++ b/src/renderer/components/ft-shaka-video-player/ft-shaka-video-player.js
@@ -6,7 +6,7 @@ import { useI18n } from 'vue-i18n'
 
 import store from '../../store/index'
 import { KeyboardShortcuts } from '../../../constants'
-import { useTabContext } from '../../tabs/TabContext'
+import { useTabContext, useTabLifecycle } from '../../tabs/TabContext'
 import { tabMediaCoordinator } from '../../tabs/TabMediaCoordinator'
 import { AmbientModeButton } from './player-components/AmbientModeButton'
 import { AudioTrackSelection } from './player-components/AudioTrackSelection'
@@ -1074,7 +1074,7 @@ export default defineComponent({
         })
         // An already-scrolled tab that was inactive never got to reevaluate its
         // scroll position, so restore the mini-player state now that it is active.
-        updateScrollMiniPlayer()
+        updateScrollMiniPlayer({ animateActivation: false })
       } else {
         if (controlPanelLayoutFrame !== null) {
           cancelAnimationFrame(controlPanelLayoutFrame)
@@ -4613,6 +4613,13 @@ export default defineComponent({
       isActiveTab,
       props,
       video,
+    })
+
+    // Logical tabs restore their saved scroll position after becoming active.
+    // Refresh once that restoration is complete so an already-active mini player
+    // is placed directly at its saved bounds instead of replaying its entrance.
+    useTabLifecycle({
+      activate: () => updateScrollMiniPlayer({ animateActivation: false })
     })
 
     const ambientModeVisible = computed(() => {

--- a/src/renderer/components/ft-shaka-video-player/opentubex/useScrollMiniPlayer.js
+++ b/src/renderer/components/ft-shaka-video-player/opentubex/useScrollMiniPlayer.js
@@ -553,12 +553,13 @@ export function useScrollMiniPlayer({ container, fullWindowEnabled, getUi, isAct
     scrollMiniIntersectionObserver.observe(anchor)
   }
 
-  function activateScrollMiniPlayer() {
+  /** @param {boolean} [animate] */
+  function activateScrollMiniPlayer(animate = true) {
     if (scrollMiniPlayerActive.value) return
 
     const playerContainer = container.value
     if (!playerContainer) return
-    const shouldAnimate = !isReducedMotionEnabled()
+    const shouldAnimate = animate && !isReducedMotionEnabled()
     const previousRect = shouldAnimate ? playerContainer.getBoundingClientRect() : null
 
     const layoutHeight = getScrollMiniPlaceholderLayoutHeight()
@@ -638,7 +639,8 @@ export function useScrollMiniPlayer({ container, fullWindowEnabled, getUi, isAct
     }
   }
 
-  function updateScrollMiniPlayer() {
+  /** @param {{ animateActivation?: boolean }} [options] */
+  function updateScrollMiniPlayer({ animateActivation = true } = {}) {
     // Check first: everything below reads layout, which forces a synchronous
     // reflow. Measuring before knowing whether the mini player can run at all
     // would do that on every scroll event even with the feature turned off.
@@ -666,7 +668,7 @@ export function useScrollMiniPlayer({ container, fullWindowEnabled, getUi, isAct
         updateScrollMiniDragHandleContrast()
       }
     } else if (ratio < ENTER_MINI_RATIO && canActivateScrollMiniPlayer()) {
-      activateScrollMiniPlayer()
+      activateScrollMiniPlayer(animateActivation)
     }
   }
 
@@ -954,8 +956,8 @@ export function useScrollMiniPlayer({ container, fullWindowEnabled, getUi, isAct
     { immediate: true }
   )
 
-  watch(scrollMiniPlayerEnabled, updateScrollMiniPlayer)
-  watch(fullWindowEnabled, updateScrollMiniPlayer)
+  watch(scrollMiniPlayerEnabled, () => updateScrollMiniPlayer())
+  watch(fullWindowEnabled, () => updateScrollMiniPlayer())
 
   // Toggling or resizing the vertical tab bar changes the usable area without
   // firing a window resize, so re-dock explicitly (after the DOM updates, so the


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Make sure to follow the contributing guidelines. -->
<!-- Important note, we may remove your pull request if you do not use this provided PR template correctly. -->
<!-- Agent instructions: Preserve every heading, comment, and marker in this template. Never remove or rewrite the release-note-category:start/end, release-note:start/end, or release-note-image:start/end marker pairs. Never remove or rewrite the Release note images section; leave its contents for a human. -->

## Pull Request Type
<!-- Please select what type of pull request this is: [x] -->
- [x] Bugfix
- [ ] Feature Implementation
- [ ] Documentation
- [ ] Other

## Related issue
<!-- Please link the issue your pull request is referring to. -->
<!-- If this pull request fully resolves the relevant issue, put "closes" before the issue number. -->
<!-- Example: "closes #123456". -->

## Description
<!-- Please write a clear and concise description of what the pull request does. -->
Restores an active scroll mini player without replaying its entrance animation when returning to a tab.

The active-tab watcher ran before the tab's saved scroll position was restored. The subsequent scroll restoration therefore activated the mini player through the normal animated path. The player now performs a non-animated refresh from the logical-tab activation lifecycle after scroll restoration, while preserving animations caused by normal scrolling.

A focused regression test covers switching away from and back to an active scroll mini player.

## Release note category
<!-- Select exactly one category. Every pull request must select one. -->
<!-- release-note-category:start -->
- [ ] Not noteworthy
- [ ] Highlights
- [ ] More improvements
- [x] Fixed bugs
<!-- release-note-category:end -->

## Release note
<!-- Required unless "Not noteworthy" is selected. -->
<!-- Write one concise, user-facing entry without a leading bullet. -->
<!-- release-note:start -->
Fixed the scroll mini player replaying its entrance animation when returning to a tab.
<!-- release-note:end -->

## Release note images
<!-- Human-only: Agents must preserve this entire section and leave it empty. -->
<!-- Optional. Paste one or more Markdown images or HTML image tags here. -->
<!-- The release notes will use an HTML image tag and limit images taller than 300 pixels. -->
<!-- release-note-image:start -->

<!-- release-note-image:end -->

## Testing
<!-- How can reviewers verify that the PR produces correct results? -->
<!-- Please provide instructions so that others can ensure that your pull request would produce correct results. For examples see, https://github.com/FreeTubeApp/FreeTube/pull/5743, https://github.com/FreeTubeApp/FreeTube/pull/7349, https://github.com/FreeTubeApp/FreeTube/pull/5125, https://github.com/FreeTubeApp/FreeTube/pull/7338 -->
<!-- Agent instructions: Only write human-facing steps that explain how to verify the change while running this branch in dev mode. Include expected results and, when applicable, helpful console snippets for interactive verification. Do not include automated checks, commands, results, pass counts, or CI status. -->
1. Run the app in dev mode and make sure the scroll mini player setting is enabled.
2. Play a video and scroll down until the scroll mini player is active.
3. Switch to another tab, then return to the video tab.
4. Confirm the mini player appears immediately at its saved position without replaying the entrance animation.
5. Scroll back to the inline player and down again, and confirm normal scroll-triggered entrance and exit animations still play.

## Additional context
<!-- Add any other context about the pull request here. -->