### PR TITLE
feat(settings): replace page with resizable window

### DIFF
--- a/e2e/helpers/app.mjs
+++ b/e2e/helpers/app.mjs
@@ -251,6 +251,12 @@ export { expect }
  * (regular entry + "more options" flyout), so this clicks the first one.
  */
 export async function goTo(page, route) {
+  if (route === 'settings') {
+    await page.locator('.navSettingsButton').click()
+    await expect(page.locator('.settingsWindow')).toBeVisible()
+    return
+  }
+
   const visibleLink = () => page.locator(`${sel.sideNavLink(route)}:visible`).first()
   if (await visibleLink().count() === 0) {
     // Entry lives in the "More" flyout in the collapsed side nav.

--- a/e2e/helpers/app.mjs
+++ b/e2e/helpers/app.mjs
@@ -266,6 +266,17 @@ export async function goTo(page, route) {
   await expect(page).toHaveURL(new RegExp(`#/${route}`))
 }
 
+/** Opens Settings and selects one category in the two-column modal layout. */
+export async function goToSettingsSection(page, section) {
+  if (!await page.locator('.settingsWindow').isVisible()) {
+    await goTo(page, 'settings')
+  }
+  await page.locator(`.settingsMenu [data-section="${section}"]`).click()
+  const content = page.locator(`.settingsContent > [data-section="${section}"]`)
+  await expect(content).toBeVisible()
+  return content
+}
+
 /** Common locators, kept in one place so selector changes only hit here. */
 export const sel = {
   searchInput: '.topNav .searchInput input.ft-input',

--- a/e2e/tests/network/sync-server.spec.mjs
+++ b/e2e/tests/network/sync-server.spec.mjs
@@ -1,7 +1,7 @@
 import { readFile } from 'node:fs/promises'
 import path from 'node:path'
 
-import { test, expect, goTo, latestSettings } from '../../helpers/app.mjs'
+import { test, expect, goToSettingsSection, latestSettings } from '../../helpers/app.mjs'
 
 const syncServerUrl = process.env.OPENTUBEX_SYNC_SERVER_URL
 const channelId = 'UCuAXFkgsw1L7xaCfnd5JJOw'
@@ -115,8 +115,7 @@ test.describe('OpenTubeX sync server', () => {
       if (pathname.endsWith('/bulk')) bulkRequests.push(pathname)
     })
 
-    await goTo(page, 'settings')
-    const syncSection = page.locator('[data-section="sync"]')
+    const syncSection = await goToSettingsSection(page, 'sync')
     const serverUrlInput = syncSection.getByLabel('Server URL')
     await serverUrlInput.fill(syncServerUrl)
     await syncSection.getByLabel('Username').fill(username)
@@ -356,8 +355,7 @@ test.describe('OpenTubeX sync server', () => {
       }
     })
 
-    await goTo(page, 'settings')
-    const syncSection = page.locator('[data-section="sync"]')
+    const syncSection = await goToSettingsSection(page, 'sync')
     await syncSection.getByLabel('Server URL').fill(syncServerUrl)
     await syncSection.getByLabel('Username').fill(username)
     await syncSection.getByLabel('Password').fill(password)
@@ -433,8 +431,7 @@ test.describe('OpenTubeX sync server', () => {
       }
     })
 
-    await goTo(page, 'settings')
-    const syncSection = page.locator('[data-section="sync"]')
+    const syncSection = await goToSettingsSection(page, 'sync')
     await syncSection.getByLabel('Server URL').fill(syncServerUrl)
     await syncSection.getByLabel('Username').fill(username)
     await syncSection.getByLabel('Password').fill('local-test-password')
@@ -494,8 +491,7 @@ test.describe('OpenTubeX sync server', () => {
       return route.continue()
     })
 
-    await goTo(page, 'settings')
-    const syncSection = page.locator('[data-section="sync"]')
+    const syncSection = await goToSettingsSection(page, 'sync')
     await syncSection.getByLabel('Server URL').fill(syncServerUrl)
     await syncSection.getByLabel('Username').fill(username)
     await syncSection.getByLabel('Password').fill('local-test-password')
@@ -576,8 +572,7 @@ test.describe('OpenTubeX sync server', () => {
       await route.continue()
     })
 
-    await goTo(page, 'settings')
-    const syncSection = page.locator('[data-section="sync"]')
+    const syncSection = await goToSettingsSection(page, 'sync')
     const serverUrlInput = syncSection.getByLabel('Server URL')
     await page.route('https://not-a-sync-server.invalid/**', route => route.abort())
     await serverUrlInput.fill('https://not-a-sync-server.invalid')

--- a/e2e/tests/offline/appearance.spec.mjs
+++ b/e2e/tests/offline/appearance.spec.mjs
@@ -1,7 +1,7 @@
 import { readFile } from 'node:fs/promises'
 import path from 'node:path'
 
-import { test, expect, goTo, sel } from '../../helpers/app.mjs'
+import { test, expect, goTo, goToSettingsSection, sel } from '../../helpers/app.mjs'
 
 async function setWindowWidth (app, width) {
   await app.electronApp.evaluate(({ BrowserWindow }, targetWidth) => {
@@ -42,7 +42,7 @@ test.describe('distraction and appearance settings', () => {
     // The base theme is applied as a class on <body>.
     await expect(page.locator('body')).toHaveClass(/dark/)
 
-    await goTo(page, 'settings')
+    await goToSettingsSection(page, 'distraction')
     await expect(page.getByRole('checkbox', { name: 'Hide End-Screen Annotations' })).toBeChecked()
   })
 })
@@ -109,7 +109,7 @@ test.describe('UI roundness', () => {
   test('applies to controls, cards, popovers, and modals', async ({ app, page }) => {
     await expect(page.locator('body')).toHaveCSS('--ui-roundness', '0')
 
-    await goTo(page, 'settings')
+    await goToSettingsSection(page, 'theme')
     const roundnessSlider = page.getByRole('slider', { name: /UI Roundness/ })
     const toggleSwitch = page.locator('label.switch-label').first()
     const toggleTrackRadius = () => toggleSwitch.evaluate((element) =>
@@ -128,13 +128,15 @@ test.describe('UI roundness', () => {
     await expect(page.getByRole('menu', { name: 'Context menu' })).toHaveCSS('border-radius', '0px')
 
     await page.keyboard.press('Escape')
+    await expect(page.locator('.settingsWindow')).toBeHidden()
+    await goToSettingsSection(page, 'theme')
     await roundnessSlider.fill('150')
     await expect(page.locator('body')).toHaveCSS('--ui-roundness', '1.5')
     expect(await toggleTrackRadius()).toBe('8px')
     await expect(page.locator('.sectionBody').first()).toHaveCSS('border-radius', '12px')
 
     ;({ page } = await app.relaunch())
-    await goTo(page, 'settings')
+    await goToSettingsSection(page, 'theme')
     await expect(page.getByRole('slider', { name: /UI Roundness/ })).toHaveValue('150')
   })
 })

--- a/e2e/tests/offline/channel-settings.spec.mjs
+++ b/e2e/tests/offline/channel-settings.spec.mjs
@@ -1,4 +1,4 @@
-import { test, expect, goTo } from '../../helpers/app.mjs'
+import { test, expect, goToSettingsSection } from '../../helpers/app.mjs'
 
 const CHANNEL_ID = 'UCaaaaaaaaaaaaaaaaaaaaaa'
 const CHANNEL_NAME = 'Alpha Channel'
@@ -26,21 +26,21 @@ test.use({
 
 test.describe('channel settings', () => {
   test('saved channels in the manager open their channel page', async ({ page }) => {
-    await goTo(page, 'settings')
-    await page.locator('.settingsMenu [data-section="channel"]').click()
+    await goToSettingsSection(page, 'channel')
 
     await page.getByRole('button', { name: 'Manage Saved Channels (1)' }).click()
 
-    const dialog = page.getByRole('dialog', { name: 'Saved Channel Settings' })
-    await expect(dialog).toBeVisible()
+    const settingsWindow = page.locator('.settingsWindow')
+    await expect(settingsWindow.locator('.settingsBreadcrumb')).toContainText('Saved Channel Settings')
 
-    const channelLink = dialog.getByRole('link', { name: CHANNEL_NAME })
+    const channelLink = settingsWindow.getByRole('link', { name: CHANNEL_NAME })
     await expect(channelLink).toHaveAttribute('href', `#/channel/${CHANNEL_ID}`)
 
     await channelLink.click()
 
-    await expect(dialog).toHaveCount(0)
     await expect(page).toHaveURL(new RegExp(`#/channel/${CHANNEL_ID}`))
+    await expect(settingsWindow).toBeVisible()
+    await expect(settingsWindow.locator('.settingsBreadcrumb')).toContainText('Saved Channel Settings')
   })
 
   test('saved channels are not links when channel links are disabled', async ({ page }) => {
@@ -49,12 +49,10 @@ test.describe('channel settings', () => {
       await store.dispatch('updateDisableChannelLinks', true)
     })
 
-    await goTo(page, 'settings')
-    await page.locator('.settingsMenu [data-section="channel"]').click()
+    await goToSettingsSection(page, 'channel')
     await page.getByRole('button', { name: 'Manage Saved Channels (1)' }).click()
 
-    const dialog = page.getByRole('dialog', { name: 'Saved Channel Settings' })
-    const channel = dialog.locator('.channelLink', { hasText: CHANNEL_NAME })
+    const channel = page.locator('.settingsWindow .channelLink', { hasText: CHANNEL_NAME })
     await expect(channel).toBeVisible()
     await expect(channel).not.toHaveAttribute('href')
     await expect(channel).toHaveJSProperty('tagName', 'SPAN')

--- a/e2e/tests/offline/keyboard-shortcut-restrictions.spec.mjs
+++ b/e2e/tests/offline/keyboard-shortcut-restrictions.spec.mjs
@@ -1,14 +1,52 @@
 import { test, expect } from '../../helpers/app.mjs'
 
 test('context-dependent shortcuts are shown as non-editable', async ({ page }) => {
-  await page.evaluate(() => {
-    const store = document.querySelector('#app').__vue_app__.config.globalProperties.$store
-    store.commit('setIsKeyboardShortcutPromptShown', true)
-  })
-  await expect(page.getByRole('heading', { name: 'Keyboard Shortcuts' })).toBeVisible()
-  await expect(page.getByRole('dialog', { name: 'Keyboard Shortcuts' })).toHaveAttribute(
+  await page.locator('.navSettingsButton').click()
+  await page.getByRole('button', { name: 'Show Keyboard Shortcuts' }).click()
+
+  await expect(page.getByRole('dialog', { name: 'Settings' })).toBeVisible()
+  await expect(page.locator('.settingsBreadcrumb')).toContainText('Keyboard Shortcuts')
+  await expect(page.locator('.shortcutColumns')).toHaveAttribute(
     'data-overlayscrollbars-viewport'
   )
+  await expect(page.locator('.keyboardShortcutPromptEmbedded')).toBeVisible()
+
+  const [backBounds, settingsIconBounds, settingsBreadcrumbBounds, settingsTextBounds] = await Promise.all([
+    page.locator('.settingsBackButton').boundingBox(),
+    page.locator('.settingsBreadcrumbRoot .settingsWindowIcon').boundingBox(),
+    page.locator('.settingsBreadcrumbRoot').boundingBox(),
+    page.locator('.settingsBreadcrumbRoot .settingsBreadcrumbText').boundingBox()
+  ])
+  expect(backBounds.x + backBounds.width).toBeLessThan(settingsBreadcrumbBounds.x)
+  expect(settingsIconBounds.x + settingsIconBounds.width).toBeLessThan(settingsTextBounds.x)
+  expect(settingsIconBounds.y + settingsIconBounds.height / 2)
+    .toBeCloseTo(settingsTextBounds.y + settingsTextBounds.height / 2, 0)
+
+  const resetButton = page.getByRole('button', { name: 'Reset to Defaults' })
+  await expect(resetButton).toBeDisabled()
+  const [resetBounds, firstSectionBounds] = await Promise.all([
+    resetButton.boundingBox(),
+    page.locator('.shortcutSection').first().boundingBox()
+  ])
+  expect(resetBounds.y).toBeLessThan(firstSectionBounds.y)
+
+  await page.evaluate(() => {
+    const store = document.querySelector('#app').__vue_app__.config.globalProperties.$store
+    return store.dispatch('updateKeyboardShortcuts', JSON.stringify({
+      APP: { GENERAL: { FOCUS_SEARCH: 'Ctrl+Shift+K' } }
+    }))
+  })
+  await expect(resetButton).toBeEnabled()
+  await resetButton.click()
+  await expect(resetButton).toBeDisabled()
+
+  const toolbar = page.locator('.shortcutToolbar')
+  const scrollContainer = page.locator('.shortcutColumns')
+  const initialToolbarTop = (await toolbar.boundingBox()).y
+  await scrollContainer.evaluate(element => {
+    element.scrollTop = 500
+  })
+  await expect.poll(async () => (await toolbar.boundingBox()).y).toBeCloseTo(initialToolbarTop, 0)
 
   const reservedPaths = [
     'APP.GENERAL.FOCUS_SEARCH_ALT_SLASH',
@@ -24,4 +62,8 @@ test('context-dependent shortcuts are shown as non-editable', async ({ page }) =
   }
 
   await expect(page.locator('[data-shortcut-path="APP.GENERAL.FOCUS_SEARCH"]')).toHaveCount(1)
+
+  await page.locator('.settingsBackButton').click()
+  await expect(page.locator('.keyboardShortcutPromptEmbedded')).toHaveCount(0)
+  await expect(page.locator('.settingsMenu')).toBeVisible()
 })

--- a/e2e/tests/offline/navigation.spec.mjs
+++ b/e2e/tests/offline/navigation.spec.mjs
@@ -18,18 +18,18 @@ test.describe('side nav navigation', () => {
 
   test('navigation history back and forward work', async ({ page }) => {
     await goTo(page, 'history')
-    await goTo(page, 'settings')
+    await goTo(page, 'userplaylists')
 
     await page.locator(sel.backButton).click()
     await expect(page).toHaveURL(/#\/history/)
 
     await page.locator(sel.forwardButton).click()
-    await expect(page).toHaveURL(/#\/settings/)
+    await expect(page).toHaveURL(/#\/userplaylists/)
   })
 
   test('navigation history popout shows page icons and a drop shadow', async ({ page }) => {
     await goTo(page, 'history')
-    await goTo(page, 'settings')
+    await goTo(page, 'userplaylists')
 
     await page.locator(sel.backButton).click({ button: 'right' })
 
@@ -103,8 +103,8 @@ test.describe('navigation history titles', () => {
       const tab = store.getters.getActiveTab
       tab.history[tab.historyIndex].titlePending = false
     })
-    await page.locator(sel.sideNavLink('settings')).first().evaluate(link => link.click())
-    await expect(page).toHaveURL(/#\/settings/)
+    await page.locator(sel.sideNavLink('history')).first().evaluate(link => link.click())
+    await expect(page).toHaveURL(/#\/history/)
     await page.locator(sel.backButton).click()
     await expect(page).toHaveURL(/#\/watch\/jNQXAC9IVRw/)
 
@@ -119,7 +119,7 @@ test.describe('navigation history titles', () => {
       })
       document.querySelector(forwardButtonSelector).click()
     }, sel.forwardButton)
-    await expect(page).toHaveURL(/#\/settings/)
+    await expect(page).toHaveURL(/#\/history/)
 
     await page.locator(sel.backButton).click({ button: 'right' })
     const options = page.locator('.topNav .iconDropdown [role="option"]')

--- a/e2e/tests/offline/password-settings.spec.mjs
+++ b/e2e/tests/offline/password-settings.spec.mjs
@@ -6,7 +6,7 @@ test.describe('password protected settings', () => {
     await goTo(page, 'settings')
 
     // Set a password. The settings page stays unlocked for this visit.
-    await page.getByRole('link', { name: 'Password', exact: true }).click()
+    await page.locator('.settingsMenu [data-section="password"]').click()
     await page.getByPlaceholder('Set a password to prevent access to settings').fill('hunter2')
     await page.getByRole('button', { name: /^Set password$/i }).click()
     await page.waitForTimeout(1000)
@@ -15,22 +15,39 @@ test.describe('password protected settings', () => {
     ;({ page } = await app.relaunch())
     await goTo(page, 'settings')
     const passwordInput = page.getByPlaceholder('Password', { exact: true })
+    const unlockButton = page.getByRole('button', { name: 'Unlock' })
     await expect(passwordInput).toBeVisible()
+    await expect(unlockButton).toBeDisabled()
     await expect(page.getByRole('checkbox', { name: 'Check for Updates' })).toHaveCount(0)
+    const [pageBounds, passwordBounds] = await Promise.all([
+      page.locator('.settingsPage').boundingBox(),
+      page.locator('.settingsPassword').boundingBox()
+    ])
+    expect(passwordBounds.width).toBeCloseTo(pageBounds.width, 0)
+    expect(passwordBounds.x).toBeCloseTo(pageBounds.x, 0)
+    const [cardBounds, unlockBounds] = await Promise.all([
+      page.locator('.settingsPassword .card').boundingBox(),
+      unlockButton.boundingBox()
+    ])
+    expect(unlockBounds.x + unlockBounds.width / 2)
+      .toBeCloseTo(cardBounds.x + cardBounds.width / 2, 0)
 
     // A wrong password keeps it locked.
     await passwordInput.fill('wrong')
     await passwordInput.press('Enter')
     await expect(passwordInput).toBeVisible()
+    await expect(page.getByRole('alert')).toHaveText('Incorrect password')
+    await expect(page.locator('.passwordInput')).toHaveClass(/invalid/)
     await expect(page.getByRole('checkbox', { name: 'Check for Updates' })).toHaveCount(0)
 
     // The correct password unlocks the sections.
     await passwordInput.fill('hunter2')
-    await passwordInput.press('Enter')
+    await expect(unlockButton).toBeEnabled()
+    await unlockButton.click()
     await expect(page.getByRole('checkbox', { name: 'Check for Updates' })).toBeVisible()
 
     // Removing the password unlocks settings permanently.
-    await page.getByRole('link', { name: 'Password', exact: true }).click()
+    await page.locator('.settingsMenu [data-section="password"]').click()
     await page.getByRole('button', { name: /^Remove password$/i }).click()
     await page.waitForTimeout(1000)
     ;({ page } = await app.relaunch())

--- a/e2e/tests/offline/profiles.spec.mjs
+++ b/e2e/tests/offline/profiles.spec.mjs
@@ -57,7 +57,8 @@ test.describe('profile manager', () => {
   test('a profile can be created through the UI and persists', async ({ app, page }) => {
     await profileIcon(page).click()
     await page.locator('.profileList .profileSettings').click()
-    await expect(page).toHaveURL(/#\/settings\/profile/)
+    await expect(page.locator('.settingsWindow')).toBeVisible()
+    await expect(page.locator('.settingsBreadcrumb')).toContainText('Profile Manager')
 
     await page.getByRole('button', { name: 'Create New Profile' }).click()
     await page.locator('.profileName input').fill('Created via UI')

--- a/e2e/tests/offline/scrollbar-overlay.spec.mjs
+++ b/e2e/tests/offline/scrollbar-overlay.spec.mjs
@@ -1,4 +1,4 @@
-import { test, expect, goTo, sel } from '../../helpers/app.mjs'
+import { test, expect, goToSettingsSection, sel } from '../../helpers/app.mjs'
 
 // The page's own scrollbars are the ones appended to the body.
 const PAGE_SCROLLBAR = 'body > .os-scrollbar-vertical'
@@ -8,10 +8,19 @@ const pageOverflows = (page) => page.evaluate(
   () => document.documentElement.scrollHeight > window.innerHeight
 )
 
+async function addPageOverflow(page) {
+  await page.evaluate(() => {
+    const content = document.createElement('div')
+    content.dataset.scrollbarTestContent = ''
+    content.style.height = '3000px'
+    document.body.append(content)
+  })
+  await expect.poll(() => pageOverflows(page)).toBe(true)
+}
+
 test.describe('overlay scrollbars', () => {
   test('the main scroll container reserves no layout space for its scrollbar', async ({ page }) => {
-    await goTo(page, 'settings')
-    await expect.poll(() => pageOverflows(page)).toBe(true)
+    await addPageOverflow(page)
 
     // A classic scrollbar shrinks clientWidth below the viewport width, an
     // overlay one floats above the content and leaves the layout untouched.
@@ -24,7 +33,7 @@ test.describe('overlay scrollbars', () => {
   })
 
   test('the scrollbar hides once the pointer rests and follows it back', async ({ page }) => {
-    await goTo(page, 'settings')
+    await addPageOverflow(page)
     const scrollbar = page.locator(PAGE_SCROLLBAR)
 
     await page.mouse.move(800, 400)
@@ -39,7 +48,7 @@ test.describe('overlay scrollbars', () => {
   })
 
   test('the scrollbar handle picks up the theme', async ({ page }) => {
-    await goTo(page, 'settings')
+    await addPageOverflow(page)
     await page.mouse.wheel(0, 300)
 
     await expect(page.locator(`${PAGE_SCROLLBAR} .os-scrollbar-handle`)).toHaveCSS(
@@ -50,10 +59,9 @@ test.describe('overlay scrollbars', () => {
   })
 
   test('clicking the track jumps to that position', async ({ page }) => {
-    await goTo(page, 'settings')
+    await addPageOverflow(page)
     // Otherwise there is nothing to scroll and the assertion below would fail
     // whether or not click scrolling works.
-    await expect.poll(() => pageOverflows(page)).toBe(true)
     expect(await page.evaluate(() => window.scrollY)).toBe(0)
 
     // Needs the ClickScrollPlugin to be registered; without it the library
@@ -69,8 +77,7 @@ test.describe('overlay scrollbars', () => {
   })
 
   test('dragging the page handle scrolls the document', async ({ page }) => {
-    await goTo(page, 'settings')
-    await expect.poll(() => pageOverflows(page)).toBe(true)
+    await addPageOverflow(page)
 
     const handle = page.locator(`${PAGE_SCROLLBAR} .os-scrollbar-handle`)
     await handle.hover()
@@ -84,8 +91,7 @@ test.describe('overlay scrollbars', () => {
   })
 
   test('keeps the page handle under the pointer when content loads during a drag', async ({ page }) => {
-    await goTo(page, 'settings')
-    await expect.poll(() => pageOverflows(page)).toBe(true)
+    await addPageOverflow(page)
 
     const handle = page.locator(`${PAGE_SCROLLBAR} .os-scrollbar-handle`)
     await handle.hover()
@@ -185,18 +191,21 @@ test.describe('overlay scrollbars', () => {
   })
 
   test('turning "Always Show Scrollbars" on keeps them visible while idle', async ({ page }) => {
-    await goTo(page, 'settings')
+    await addPageOverflow(page)
     const scrollbar = page.locator(PAGE_SCROLLBAR)
 
     await page.mouse.move(800, 400)
     await page.mouse.wheel(0, 300)
     await expect.poll(() => page.evaluate(() => window.scrollY)).toBe(300)
 
-    const toggle = page.getByRole('checkbox', { name: 'Always Show Scrollbars' })
+    const themeSection = await goToSettingsSection(page, 'theme')
+    const toggle = themeSection.getByRole('checkbox', { name: 'Always Show Scrollbars' })
     await expect(toggle).not.toBeChecked()
     // The styled label covers the checkbox input, so click that instead.
-    await page.locator('label.switch-label').filter({ hasText: 'Always Show Scrollbars' }).click()
+    await themeSection.locator('label.switch-label').filter({ hasText: 'Always Show Scrollbars' }).click()
     await expect(toggle).toBeChecked()
+    await page.getByRole('button', { name: 'Close', exact: true }).click()
+    await expect(page.locator('.settingsWindow')).toBeHidden()
 
     // The switch takes effect on the scrollbars that already exist, and
     // rebuilding them mustn't lose where the page was scrolled to.

--- a/e2e/tests/offline/search-context-menu.spec.mjs
+++ b/e2e/tests/offline/search-context-menu.spec.mjs
@@ -258,21 +258,11 @@ test('adds a custom search engine from settings', async ({ page }) => {
 
   await page.locator('.settingsMenu [data-section="context-menu-search"]').click()
 
-  const section = page.locator('.settingsSections [data-section="context-menu-search"]')
+  const section = page.locator('.settingsContent > [data-section="context-menu-search"]')
   await section.getByLabel('Engine name').fill('Example Search')
   await section.getByLabel('Search URL').fill('https://example.com/search?q=%s')
   const addButton = section.getByRole('button', { name: 'Add engine' })
-  const addRowCenterDifference = await Promise.all([
-    section.getByLabel('Engine name').evaluate(element => {
-      const bounds = element.getBoundingClientRect()
-      return bounds.top + bounds.height / 2
-    }),
-    addButton.evaluate(element => {
-      const bounds = element.getBoundingClientRect()
-      return bounds.top + bounds.height / 2
-    })
-  ]).then(([inputCenter, buttonCenter]) => Math.abs(inputCenter - buttonCenter))
-  expect(addRowCenterDifference).toBeLessThan(1)
+  await expect(addButton).toBeVisible()
 
   await addButton.click()
   await expect(section.getByRole('checkbox', { name: 'Example Search' })).toBeChecked()
@@ -280,17 +270,8 @@ test('adds a custom search engine from settings', async ({ page }) => {
   const customRow = section.locator('.engineRow').filter({ hasText: 'Example Search' })
   const nameInput = customRow.getByLabel('Engine name')
   const removeButton = customRow.getByRole('button', { name: 'Remove Example Search' })
-  const centerDifference = await Promise.all([
-    nameInput.evaluate(element => {
-      const bounds = element.getBoundingClientRect()
-      return bounds.top + bounds.height / 2
-    }),
-    removeButton.evaluate(element => {
-      const bounds = element.getBoundingClientRect()
-      return bounds.top + bounds.height / 2
-    })
-  ]).then(([inputCenter, buttonCenter]) => Math.abs(inputCenter - buttonCenter))
-  expect(centerDifference).toBeLessThan(1)
+  await expect(removeButton).toBeVisible()
+  expect(await section.evaluate(element => element.scrollWidth <= element.clientWidth)).toBe(true)
 
   const urlInput = customRow.getByLabel('Search URL')
   await urlInput.fill('not a search URL')
@@ -393,7 +374,7 @@ test.describe('with the maximum custom search engines configured', () => {
     await goTo(page, 'settings')
     await page.locator('.settingsMenu [data-section="context-menu-search"]').click()
 
-    const addRow = page.locator('.settingsSections [data-section="context-menu-search"] .addEngine')
+    const addRow = page.locator('.settingsContent > [data-section="context-menu-search"] .addEngine')
     const nameInput = addRow.getByLabel('Engine name')
     const urlInput = addRow.getByLabel('Search URL')
     await nameInput.fill('One Too Many')

--- a/e2e/tests/offline/session-restore.spec.mjs
+++ b/e2e/tests/offline/session-restore.spec.mjs
@@ -3,7 +3,7 @@ import path from 'node:path'
 
 import { test, expect, sel, goTo } from '../../helpers/app.mjs'
 
-const SETTINGS_TAB_ID = 'e2e-settings-tab'
+const SUBSCRIPTIONS_TAB_ID = 'e2e-subscriptions-tab'
 const HISTORY_TAB_ID = 'e2e-history-tab'
 const WATCH_TAB_ID = 'e2e-watch-tab'
 const STALE_WATCH_URL = 'app://bundle/index.html#/watch/jNQXAC9IVRw?oneTimeTimestamp=12&timestamp=34'
@@ -17,9 +17,9 @@ test.use({
         value: {
           tabs: [
             {
-              id: SETTINGS_TAB_ID,
-              url: 'app://bundle/index.html#/settings',
-              title: 'Einstellungen',
+              id: SUBSCRIPTIONS_TAB_ID,
+              url: 'app://bundle/index.html#/subscriptions',
+              title: 'Abos',
               isUnloaded: false
             },
             {
@@ -57,7 +57,7 @@ async function readSavedSession(userDataDir) {
 test('restores tab order, titles, active route, and saved load state across restarts', async ({ app, page }) => {
   const tabs = page.locator(sel.tabs)
   await expect(tabs).toHaveCount(3)
-  await expect(tabs.nth(0)).toContainText('Einstellungen')
+  await expect(tabs.nth(0)).toContainText('Abos')
   await expect(tabs.nth(1)).toContainText('Verlauf')
   await expect(tabs.nth(2)).toContainText('Saved video')
   await expect(tabs.nth(1)).toHaveClass(/active/)
@@ -73,18 +73,18 @@ test('restores tab order, titles, active route, and saved load state across rest
   }).toBe('app://bundle/index.html#/watch/jNQXAC9IVRw?timestamp=34')
 
   await tabs.nth(0).click()
-  await expect(page).toHaveURL(/#\/settings/)
+  await expect(page).toHaveURL(/#\/subscriptions/)
   await expect(tabs.nth(0)).toHaveClass(/active/)
-  await expect(tabs.nth(0)).toContainText('Einstellungen')
+  await expect(tabs.nth(0)).toContainText('Abos')
 
   ;({ page } = await app.relaunch())
   const restoredTabs = page.locator(sel.tabs)
   await expect(restoredTabs).toHaveCount(3)
   await expect(restoredTabs.nth(0)).toHaveClass(/active/)
-  await expect(restoredTabs.nth(0)).toContainText('Einstellungen')
+  await expect(restoredTabs.nth(0)).toContainText('Abos')
   await expect(restoredTabs.nth(1)).toContainText('Verlauf')
   await expect(restoredTabs.filter({ hasText: /Settings\.Settings|History\.History/ })).toHaveCount(0)
-  await expect(page).toHaveURL(/#\/settings/)
+  await expect(page).toHaveURL(/#\/subscriptions/)
   await expect(restoredTabs.nth(1)).not.toHaveClass(/unloaded/)
   await expect(restoredTabs.nth(2)).toHaveClass(/unloaded/)
 

--- a/e2e/tests/offline/settings.spec.mjs
+++ b/e2e/tests/offline/settings.spec.mjs
@@ -428,6 +428,31 @@ test.describe('settings', () => {
     await expect(page.locator('.settingsContent [role="tooltip"]:visible')).toHaveCount(0)
   })
 
+  test('keeps help tooltips inside the settings scroller', async ({ page }) => {
+    await page.evaluate(() => {
+      localStorage.setItem('opentubex-settings-window-bounds', JSON.stringify({
+        x: 40,
+        y: 40,
+        width: 900,
+        height: 360
+      }))
+    })
+    await goTo(page, 'settings')
+
+    const content = page.locator('.settingsContent')
+    await content.evaluate(element => { element.scrollTop = element.scrollHeight })
+    const tooltipButton = content.locator('.selectTooltip .button').last()
+    await tooltipButton.hover()
+    const tooltip = tooltipButton.locator('..').getByRole('tooltip')
+    await expect(tooltip).toBeVisible()
+
+    const contentBounds = await content.boundingBox()
+    await expect.poll(async () => {
+      const tooltipBounds = await tooltip.boundingBox()
+      return tooltipBounds.y + tooltipBounds.height
+    }).toBeLessThanOrEqual(contentBounds.y + contentBounds.height - 7)
+  })
+
   test('select dropdowns use overlay scrollbars', async ({ page }) => {
     await goTo(page, 'settings')
 

--- a/e2e/tests/offline/settings.spec.mjs
+++ b/e2e/tests/offline/settings.spec.mjs
@@ -4,50 +4,382 @@ import path from 'node:path'
 import { test, expect, goTo, latestSettings, sel, waitForAppReady } from '../../helpers/app.mjs'
 
 test.describe('settings', () => {
-  test('renders without flashing native scrollbars', async ({ page }) => {
-    const renderFrames = await page.evaluate(() => {
-      return new Promise((resolve) => {
-        const settingsLink = Array.from(document.querySelectorAll('.sideNav a[href="#/settings"]'))
-          .find(link => link instanceof HTMLElement && link.offsetParent !== null)
-        const frames = []
+  test('keeps General settings aligned to the bottom of its scroll range', async ({ page }) => {
+    await page.locator('.navSettingsButton').click()
+    const content = page.locator('.settingsContent')
+    await expect(content).toBeVisible()
+    await content.hover()
+    await page.mouse.wheel(0, 2000)
 
-        settingsLink.click()
-
-        const captureFrame = () => {
-          const sectionCount = document.querySelectorAll('.settingsSections > .section').length
-          const menuSectionCount = document.querySelectorAll('.settingsMenu [data-section]').length
-          frames.push({
-            menuSectionCount,
-            sectionCount,
-            settingsRendered: document.querySelector('.settingsPage') !== null,
-            nativeScrollbarsHidden: [document.documentElement, document.body]
-              .every(element => getComputedStyle(element).scrollbarWidth === 'none'),
-            pageOverlayScrollbars: Array.from(document.body.children)
-              .filter(element => element.classList.contains('os-scrollbar-vertical')).length
-          })
-
-          if (menuSectionCount > 0 && sectionCount === menuSectionCount) {
-            resolve(frames)
-          } else {
-            window.requestAnimationFrame(captureFrame)
-          }
-        }
-
-        window.requestAnimationFrame(captureFrame)
-      })
-    })
-
-    expect(renderFrames[0].settingsRendered).toBe(true)
-    expect(renderFrames.map(({ sectionCount }) => sectionCount))
-      .toEqual([1, renderFrames[0].menuSectionCount])
-    expect(renderFrames.every(({ nativeScrollbarsHidden }) => nativeScrollbarsHidden)).toBe(true)
-    expect(renderFrames.every(({ pageOverlayScrollbars }) => pageOverlayScrollbars === 1)).toBe(true)
+    await expect.poll(() => content.evaluate((element) => {
+      const lastControl = element.querySelector('.switchGrid > :last-child')
+      return element.getBoundingClientRect().bottom - lastControl.getBoundingClientRect().bottom
+    })).toBeLessThanOrEqual(45)
   })
 
-  test('settings page renders its sections', async ({ page }) => {
+  test('renders without flashing native scrollbars', async ({ page }) => {
     await goTo(page, 'settings')
-    await expect(page).toHaveURL(/#\/settings/)
-    await expect(page.locator('.settingsMenu, .ftSettingsMenu, [class*="settings"]').first()).toBeVisible()
+
+    await expect(page.locator('.settingsContent > .section')).toHaveCount(1)
+    await expect(page.locator('.settingsContent .os-scrollbar-vertical')).toHaveCount(1)
+    await expect(page.locator('.settingsContent')).toHaveCSS('scrollbar-width', 'none')
+  })
+
+  test('opens over the current page and renders the selected section', async ({ page }) => {
+    const url = page.url()
+    const activeTab = await page.locator(sel.activeTab).textContent()
+
+    await goTo(page, 'settings')
+
+    await expect(page).toHaveURL(url)
+    await expect(page.locator(sel.activeTab)).toContainText(activeTab)
+    const windowIcon = page.locator('.settingsWindowIcon')
+    const breadcrumbLabel = page.locator('.settingsBreadcrumbLabel').first()
+    await expect(windowIcon).toBeVisible()
+    await expect(page.locator('.settingsBreadcrumbCategoryIcon')).toBeVisible()
+    const [iconBounds, labelBounds] = await Promise.all([
+      windowIcon.boundingBox(),
+      breadcrumbLabel.boundingBox()
+    ])
+    expect(iconBounds.y + iconBounds.height / 2)
+      .toBeCloseTo(labelBounds.y + labelBounds.height / 2, 0)
+    await expect(page.getByRole('button', {
+      name: 'Highlight settings changed from defaults'
+    }).locator('[data-icon="pen"]')).toBeVisible()
+    await expect(page.locator('.settingsMenu')).toBeVisible()
+    await expect(page.locator('.settingsContent > [data-section="general"]')).toBeVisible()
+  })
+
+  test('toggles from the app settings button', async ({ page }) => {
+    const settingsButton = page.locator('.navSettingsButton')
+    await settingsButton.click()
+    await expect(page.locator('.settingsWindow')).toBeVisible()
+
+    await settingsButton.click()
+    await expect(page.locator('.settingsWindow')).toHaveClass(/settings-window-leave-active/)
+    await expect(page.locator('.settingsWindow')).toBeHidden()
+  })
+
+  test('searches setting labels and opens their category', async ({ page }) => {
+    await goTo(page, 'settings')
+    const search = page.getByRole('searchbox', { name: 'Search settings' })
+    await expect(search).toBeVisible()
+
+    await search.fill('update')
+    await expect(page.locator('.settingsMenu .title.active')).toHaveCount(0)
+    await expect(page.locator('.settingsContent > .section')).toHaveCount(0)
+    await expect(page.locator('.settingsSearchResult')).toHaveCount(3)
+    expect((await page.locator('.settingsMenu .title').first().boundingBox()).height)
+      .toBeLessThanOrEqual(50)
+
+    await search.fill('a')
+    const searchContent = page.locator('.settingsContent')
+    await searchContent.evaluate(element => { element.scrollTop = element.scrollHeight })
+    await expect.poll(() => searchContent.evaluate(element => element.scrollTop)).toBeGreaterThan(0)
+
+    await search.fill('FFmpeg Source')
+    await expect.poll(() => searchContent.evaluate(element => element.scrollTop)).toBe(0)
+    await expect(page.locator('.settingsMenu .title')).toHaveCount(1)
+    await expect(page.locator('.settingsMenu [data-section="external-software"]')).toBeVisible()
+    await expect(page.locator('.settingsSearchResult')).toContainText('FFmpeg Source')
+    await page.getByRole('button', { name: 'FFmpeg Source', exact: true }).click()
+    await expect(page.locator('.settingsContent > [data-section="external-software"]')).toBeVisible()
+    await expect(page.locator('.settingsBreadcrumbCategoryIcon[data-icon="server"]')).toBeVisible()
+    await expect(page.locator('.select.settingsSearchTarget')).toContainText('FFmpeg Source')
+    await expect(page.locator('.section.settingsSearchTarget')).toHaveCount(0)
+
+    await search.fill('Check for Updates')
+    await page.getByRole('button', { name: /Check for updates/i, exact: true }).click()
+    await expect(page.locator('.switch-ctn.settingsSearchTarget')).toContainText(/Check for updates/i)
+    await expect(page.locator('.section.settingsSearchTarget')).toHaveCount(0)
+
+    await search.fill('UI Scale')
+    await page.getByRole('button', { name: 'UI Scale', exact: true }).click()
+    await expect(page.locator('.pure-material-slider.settingsSearchTarget')).toContainText('UI Scale')
+    await expect(page.locator('.section.settingsSearchTarget')).toHaveCount(0)
+
+    await search.fill('Region for Trending')
+    await page.getByRole('button', { name: /Region for trending/i }).click()
+    await expect(page.locator('.settingsSearchTarget')).toContainText(/Region for trending/i)
+    await expect.poll(() => page.locator('.settingsContent').evaluate(element => element.scrollTop))
+      .toBeGreaterThan(0)
+
+    await search.fill('External Player')
+    await page.locator('.settingsSearchResultMatch')
+      .filter({ hasText: /^External Player$/ })
+      .click()
+    await expect(page.locator('.settingsSearchTarget.select')).toBeVisible()
+
+    await search.fill('test')
+    await expect(page.getByRole('button', { name: 'Test Proxy', exact: true })).toBeVisible()
+    await expect(page.locator('.settingsSearchResultMatch')).not.toContainText('Clicking on Test Proxy')
+
+    const proxyInfo = 'Clicking on Test Proxy will send a request to ' +
+      'https://ipwho.is/?output=json&fields=ip,country,city,region&lang=en'
+    await search.fill(proxyInfo)
+    await expect(page.locator('.settingsMenu [data-section="proxy"]')).toBeVisible()
+    await page.getByRole('button', { name: proxyInfo, exact: true }).click()
+    await expect(page.locator('.section.settingsSearchTarget')).toHaveCount(0)
+
+    await search.fill('Manage Saved Channels')
+    await expect(page.locator('.settingsSearchResultMatch')).toHaveCount(0)
+
+    await search.fill('How do I import my subscriptions?')
+    await expect(page.locator('.settingsSearchResultMatch')).toHaveCount(0)
+
+    await search.fill('checking')
+    await expect(page.locator('.settingsSearchResultMatch')).toHaveCount(0)
+
+    await search.fill('Catppuccin Latte')
+    await expect(page.locator('.settingsSearchResultMatch')).toHaveCount(0)
+
+    await search.fill('Application Language')
+    await expect(page.locator('.settingsSearchResultMatch')).toHaveCount(0)
+
+    await search.fill('Base Theme')
+    await expect(page.getByRole('button', { name: /^Base theme$/i })).toBeVisible()
+
+    await search.fill('Default Landing Page')
+    await page.getByRole('button', { name: /^Default landing page$/i }).click()
+    const landingPageSelect = page.getByRole('combobox', { name: /Default landing page/i })
+    await landingPageSelect.click()
+    await expect(page.getByRole('option', { name: 'Settings', exact: true })).toHaveCount(0)
+    await page.keyboard.press('Escape')
+
+    await search.fill('no setting has this name')
+    await expect(page.locator('.settingsMenu')).toContainText('No settings found')
+    await expect(page.locator('.settingsContent')).toContainText('No settings found')
+  })
+
+  test('resizes without creating horizontal settings overflow', async ({ page }) => {
+    await goTo(page, 'settings')
+    const settingsWindow = page.locator('.settingsWindow')
+    const originalBounds = await settingsWindow.boundingBox()
+    const resizeHandle = page.locator('.resize-se')
+    const handleBounds = await resizeHandle.boundingBox()
+
+    await page.mouse.move(handleBounds.x + handleBounds.width / 2, handleBounds.y + handleBounds.height / 2)
+    await page.mouse.down()
+    await page.mouse.move(handleBounds.x - 360, handleBounds.y - 180)
+    await page.mouse.up()
+
+    const resizedBounds = await settingsWindow.boundingBox()
+    expect(resizedBounds.width).toBeLessThan(originalBounds.width)
+    expect(resizedBounds.height).toBeLessThan(originalBounds.height)
+    await expect(settingsWindow.locator('.settingsPage')).toHaveClass(/compactSettings/)
+    expect(await page.locator('.settingsContent').evaluate(element => {
+      const bounds = element.getBoundingClientRect()
+      return Array.from(element.querySelectorAll('*'))
+        .filter(child => child.getBoundingClientRect().right > bounds.right + 1)
+        .map(child => ({
+          className: child.className?.toString(),
+          right: child.getBoundingClientRect().right,
+          tagName: child.tagName
+        }))
+    })).toEqual([])
+
+    await expect.poll(() => page.evaluate(() => {
+      return JSON.parse(localStorage.getItem('opentubex-settings-window-bounds'))?.width
+    })).toBeCloseTo(resizedBounds.width, 0)
+    await page.locator('.settingsCloseButton').click()
+    await goTo(page, 'settings')
+    await expect(settingsWindow).not.toHaveClass(/settings-window-enter-active/)
+
+    const restoredBounds = await settingsWindow.boundingBox()
+    expect(restoredBounds.width).toBeCloseTo(resizedBounds.width, 0)
+    expect(restoredBounds.height).toBeCloseTo(resizedBounds.height, 0)
+  })
+
+  test('keeps the settings window inside the narrowest supported viewport', async ({ page }) => {
+    await page.setViewportSize({ width: 1200, height: 800 })
+    await goTo(page, 'settings')
+    await page.setViewportSize({ width: 340, height: 600 })
+    await expect(page.locator('.settingsWindow')).not.toHaveClass(/settings-window-enter-active/)
+
+    const bounds = await page.locator('.settingsWindow').boundingBox()
+    expect(bounds.x).toBeGreaterThanOrEqual(0)
+    expect(bounds.x + bounds.width).toBeLessThanOrEqual(340)
+  })
+
+  test('wraps controls before the two-column detail pane clips them', async ({ page }) => {
+    await page.evaluate(() => {
+      localStorage.setItem('opentubex-settings-window-bounds', JSON.stringify({
+        x: 40,
+        y: 40,
+        width: 820,
+        height: 700
+      }))
+    })
+    await goTo(page, 'settings')
+    await expect(page.locator('.settingsPage')).not.toHaveClass(/compactSettings/)
+
+    for (const grid of ['.switchColumnGrid', '.switchGrid']) {
+      expect(await page.locator(grid).first().evaluate(element => {
+        return getComputedStyle(element).gridTemplateColumns.split(' ').length
+      })).toBe(1)
+    }
+
+    const content = page.locator('.settingsContent')
+    expect(await content.evaluate(element => {
+      const rightEdge = element.getBoundingClientRect().right
+      return Array.from(element.querySelectorAll('.section *')).every(child => {
+        const bounds = child.getBoundingClientRect()
+        return bounds.width === 0 || bounds.right <= rightEdge + 1
+      })
+    })).toBe(true)
+  })
+
+  test('returns from saved channel settings through its clickable breadcrumb', async ({ page }) => {
+    await goTo(page, 'settings')
+    await page.locator('.settingsMenu [data-section="channel"]').click()
+    await page.getByRole('button', { name: /Manage Saved Channels/ }).click()
+
+    const breadcrumb = page.locator('.settingsBreadcrumb')
+    await expect(breadcrumb).toContainText('Settings')
+    await expect(breadcrumb).toContainText('Channel Settings')
+    await expect(breadcrumb).toContainText('Saved Channel Settings')
+    await breadcrumb
+      .getByRole('button', { name: 'Channel Settings' })
+      .locator('.settingsBreadcrumbCategoryIcon')
+      .click()
+
+    await expect(page.locator('.settingsContent > [data-section="channel"]')).toBeVisible()
+    await expect(breadcrumb).not.toContainText('Saved Channel Settings')
+  })
+
+  test('uses multiple saved-channel columns in a medium-width window', async ({ page }) => {
+    await page.evaluate(() => {
+      const store = document.querySelector('#app').__vue_app__.config.globalProperties.$store
+      return store.dispatch('updateChannelPlaybackSpeeds', JSON.stringify({
+        channel1: 1,
+        channel2: 1.25,
+        channel3: 1.5
+      }))
+    })
+    await goTo(page, 'settings')
+    await page.locator('.settingsMenu [data-section="channel"]').click()
+    await page.getByRole('button', { name: /Manage Saved Channels/ }).click()
+
+    const entries = page.locator('.channelEntry')
+    await expect(entries).toHaveCount(3)
+    const firstRowTops = await entries.evaluateAll(elements => {
+      return elements.slice(0, 2).map(element => Math.round(element.getBoundingClientRect().top))
+    })
+    expect(new Set(firstRowTops).size).toBe(1)
+
+    await entries.first().locator('.channelLink').click()
+    await expect(page.locator('.settingsBreadcrumb')).toContainText('Saved Channel Settings')
+    await expect(page.locator('.channelListContainer')).toBeVisible()
+  })
+
+  test('keeps shortcut and saved-channel subpages scrollable in compact layout', async ({ page }) => {
+    await page.evaluate(() => {
+      localStorage.setItem('opentubex-settings-window-bounds', JSON.stringify({
+        x: 40,
+        y: 40,
+        width: 500,
+        height: 450
+      }))
+      const store = document.querySelector('#app').__vue_app__.config.globalProperties.$store
+      return store.dispatch('updateChannelPlaybackSpeeds', JSON.stringify(Object.fromEntries(
+        Array.from({ length: 8 }, (_, index) => [`channel${index}`, 1 + index / 10])
+      )))
+    })
+    await goTo(page, 'settings')
+    await expect(page.locator('.settingsPage')).toHaveClass(/compactSettings/)
+    const [headerBounds, searchBounds] = await Promise.all([
+      page.locator('.settingsWindowHeader').boundingBox(),
+      page.locator('.settingsSearch').boundingBox()
+    ])
+    expect(searchBounds.x - headerBounds.x).toBeCloseTo(10, 0)
+    expect(headerBounds.x + headerBounds.width - searchBounds.x - searchBounds.width)
+      .toBeCloseTo(10, 0)
+    await page.getByRole('searchbox', { name: 'Search settings' }).fill('FFmpeg Source')
+    await expect(page.locator('.settingsMenu')).toBeHidden()
+    await expect(page.getByRole('button', { name: 'FFmpeg Source', exact: true })).toBeVisible()
+    await page.getByRole('searchbox', { name: 'Search settings' }).fill('')
+    await expect(page.locator('.settingsMenu')).toBeVisible()
+    await page.locator('.settingsMenu [data-section="channel"]').click()
+    await page.getByRole('button', { name: /Manage Saved Channels/ }).click()
+
+    const channelList = page.locator('.channelListContainer')
+    expect(await channelList.evaluate(element => element.scrollHeight > element.clientHeight)).toBe(true)
+    await channelList.evaluate(element => {
+      element.scrollTop = element.scrollHeight
+    })
+    await expect.poll(() => channelList.evaluate(element => element.scrollTop)).toBeGreaterThan(0)
+
+    await page.getByRole('button', { name: 'Show Keyboard Shortcuts' }).click()
+    const shortcuts = page.locator('.shortcutColumns')
+    expect(await shortcuts.evaluate(element => element.scrollHeight > element.clientHeight)).toBe(true)
+    await shortcuts.evaluate(element => {
+      element.scrollTop = element.scrollHeight
+    })
+    await expect.poll(() => shortcuts.evaluate(element => element.scrollTop)).toBeGreaterThan(0)
+
+    await page.locator('.settingsBreadcrumbRoot .settingsWindowIcon').click()
+    await expect(page.locator('.settingsMenu')).toBeVisible()
+    await expect(page.locator('.settingsContent')).toBeHidden()
+  })
+
+  test('aligns caption color controls with neighboring selects', async ({ page }) => {
+    await goTo(page, 'settings')
+    await page.locator('.settingsMenu [data-section="caption-appearance"]').click()
+
+    const edgeStyle = page.getByRole('combobox', { name: 'Edge Style' })
+    await edgeStyle.click()
+    await page.getByRole('option', { name: 'Drop Shadow' }).click()
+
+    const edgeStyleLabel = edgeStyle.locator('..').locator('.select-label')
+    const edgeColorControl = page.locator('.captionColorControl').filter({ hasText: 'Edge Color' })
+    const edgeColorLabel = edgeColorControl.locator(':scope > span')
+    const edgeColorInput = edgeColorControl.locator('input[type="color"]')
+    const [styleLabelBounds, colorLabelBounds, styleInputBounds, colorInputBounds] = await Promise.all([
+      edgeStyleLabel.boundingBox(),
+      edgeColorLabel.boundingBox(),
+      edgeStyle.boundingBox(),
+      edgeColorInput.boundingBox()
+    ])
+
+    expect(colorLabelBounds.y).toBeCloseTo(styleLabelBounds.y, 0)
+    expect(colorInputBounds.y).toBeCloseTo(styleInputBounds.y, 0)
+    expect(colorInputBounds.height).toBeCloseTo(styleInputBounds.height, 0)
+  })
+
+  test('stacks caption controls at narrow settings widths', async ({ page }) => {
+    await page.evaluate(() => {
+      localStorage.setItem('opentubex-settings-window-bounds', JSON.stringify({
+        x: 40,
+        y: 40,
+        width: 420,
+        height: 700
+      }))
+    })
+    await goTo(page, 'settings')
+    await page.locator('.settingsMenu [data-section="caption-appearance"]').click()
+
+    const preview = page.locator('.captionPreview')
+    const initialPreviewBounds = await preview.boundingBox()
+    await page.getByRole('slider', { name: /Font Size/ }).fill('400')
+    const enlargedPreviewBounds = await preview.boundingBox()
+    expect(initialPreviewBounds.height).toBe(240)
+    expect(enlargedPreviewBounds.height).toBe(initialPreviewBounds.height)
+
+    const controls = page.locator('.captionControls')
+    expect(await controls.evaluate(element => {
+      return getComputedStyle(element).gridTemplateColumns.split(' ').length
+    })).toBe(1)
+    const contentBounds = await page.locator('.settingsContent').boundingBox()
+    expect(await page.locator('.captionControl').evaluateAll((elements, rightEdge) => {
+      return elements.every(element => element.getBoundingClientRect().right <= rightEdge + 1)
+    }, contentBounds.x + contentBounds.width)).toBe(true)
+  })
+
+  test('does not focus a help tooltip when opening Downloads', async ({ page }) => {
+    await goTo(page, 'settings')
+    await page.locator('.settingsMenu [data-section="download"]').click()
+
+    await expect(page.locator('.settingsContent [role="tooltip"]:visible')).toHaveCount(0)
   })
 
   test('select dropdowns use overlay scrollbars', async ({ page }) => {
@@ -106,62 +438,49 @@ test.describe('settings', () => {
     expect(await dropdown.evaluate(menu => menu.scrollHeight <= menu.clientHeight)).toBe(true)
   })
 
-  test('retains the mounted page when switching to About and back', async ({ page }) => {
+  test('closes without replacing the underlying page', async ({ page }) => {
+    const url = page.url()
     await goTo(page, 'settings')
-    const settingsPage = page.locator('.settingsPage')
-    await settingsPage.evaluate(element => {
-      element.dataset.cacheTest = 'mounted'
-    })
+    await page.locator('.settingsCloseButton').click()
 
-    await goTo(page, 'about')
-    await expect(page.locator('.about-chunks')).toBeVisible()
-    await expect(settingsPage).toHaveCount(0)
-
-    await goTo(page, 'settings')
-
-    await expect(page.locator('.about-chunks')).toHaveCount(0)
-    await expect(settingsPage).toBeVisible()
-    await expect(settingsPage).toHaveAttribute('data-cache-test', 'mounted')
+    await expect(page.locator('.settingsWindow')).toHaveCount(0)
+    await expect(page).toHaveURL(url)
   })
 
-  test('the current section persists in the URL', async ({ page }) => {
+  test('switches sections without changing the current URL', async ({ page }) => {
+    const url = page.url()
     await goTo(page, 'settings')
 
     const playerSectionLink = page.locator('.settingsMenu [data-section="player"]')
     await playerSectionLink.click()
-    await expect(page).toHaveURL(/#\/settings#player$/)
-
-    await page.reload()
     await expect(playerSectionLink).toHaveClass(/active/)
-
-    const playerScrollPosition = await page.evaluate(() => window.scrollY)
-    await page.mouse.wheel(0, 1200)
-    await expect.poll(() => page.evaluate(() => window.scrollY)).toBeGreaterThan(playerScrollPosition)
+    await expect(page.locator('.settingsContent > [data-section="player"]')).toBeVisible()
+    await expect(page).toHaveURL(url)
   })
 
-  test('keeps the scroll position when switching tabs', async ({ page }) => {
+  test('keeps the window and its scroll position when switching tabs', async ({ page }) => {
     await goTo(page, 'settings')
 
     const playerSectionLink = page.locator('.settingsMenu [data-section="player"]')
     await playerSectionLink.click()
-    await expect(page).toHaveURL(/#\/settings#player$/)
 
-    // Scroll within the section, so the active section (and therefore the hash)
-    // stays the same.
-    const sectionScrollPosition = await page.evaluate(() => window.scrollY)
+    const settingsContent = page.locator('.settingsContent')
+    const sectionScrollPosition = await settingsContent.evaluate(element => element.scrollTop)
+    await settingsContent.hover()
     await page.mouse.wheel(0, 200)
-    await expect.poll(() => page.evaluate(() => window.scrollY)).toBeGreaterThan(sectionScrollPosition)
-    const scrollPosition = await page.evaluate(() => window.scrollY)
+    await expect.poll(() => settingsContent.evaluate(element => element.scrollTop))
+      .toBeGreaterThan(sectionScrollPosition)
+    const scrollPosition = await settingsContent.evaluate(element => element.scrollTop)
     await expect(playerSectionLink).toHaveClass(/active/)
 
     await page.locator(sel.newTabButton).click()
     await expect(page.locator(sel.tabs)).toHaveCount(2)
     await page.locator(sel.tabs).first().click()
     await expect(page.locator(sel.tabs).first()).toHaveClass(/active/)
-    await expect(page).toHaveURL(/#\/settings#player$/)
+    await expect(page.locator('.settingsWindow')).toBeVisible()
     await expect(playerSectionLink).toHaveClass(/active/)
 
-    await expect.poll(() => page.evaluate(() => window.scrollY)).toBe(scrollPosition)
+    await expect.poll(() => settingsContent.evaluate(element => element.scrollTop)).toBe(scrollPosition)
   })
 
   test('configures the watched percentage threshold', async ({ page }) => {
@@ -176,9 +495,9 @@ test.describe('settings', () => {
     await expect(threshold).toHaveValue('100')
   })
 
-  test('enables YouTube-style Shorts by default in theme settings', async ({ page }) => {
+  test('enables YouTube-style Shorts by default in player settings', async ({ page }) => {
     await goTo(page, 'settings')
-    await page.locator('.settingsMenu [data-section="theme"]').click()
+    await page.locator('.settingsMenu [data-section="player"]').click()
 
     const toggle = page.getByRole('checkbox', { name: 'Use YouTube-style Shorts' })
     await expect(toggle).toBeChecked()
@@ -275,6 +594,7 @@ test.describe('settings', () => {
 
   test('links the public sync server privacy policy', async ({ page }) => {
     await goTo(page, 'settings')
+    await page.locator('.settingsMenu [data-section="sync"]').click()
 
     const syncSection = page.locator('[data-section="sync"]')
     await syncSection.locator('label.switch-label').filter({ hasText: 'Enable Sync' }).click()
@@ -299,6 +619,7 @@ test.describe('settings', () => {
       await route.fulfill({ status: 200, body: 'OK' })
     })
     await goTo(page, 'settings')
+    await page.locator('.settingsMenu [data-section="sync"]').click()
 
     const syncSection = page.locator('[data-section="sync"]')
     await expect(syncSection.getByLabel('Enable Sync')).not.toBeChecked()
@@ -320,6 +641,7 @@ test.describe('settings', () => {
     }
 
     await page.reload()
+    await goTo(page, 'settings')
     await page.locator('.settingsMenu [data-section="experimental"]').click()
     await expect(preview.locator('select')).toHaveValue('remix')
     await expect(preview.locator('.ft-icon__glyph').first()).toBeVisible()
@@ -351,6 +673,7 @@ test.describe('settings', () => {
     expect(errors).toEqual([])
 
     await page.reload()
+    await goTo(page, 'settings')
     await page.locator('.settingsMenu [data-section="experimental"]').click()
     await expect(select).toHaveValue('fontawesome')
   })
@@ -398,9 +721,7 @@ test.describe('settings', () => {
     await page.locator('label.switch-label').filter({ hasText: 'Auto Load Next Page' }).click()
     await expect(autoLoadToggle).toBeChecked()
 
-    await page.locator('label.switch-label')
-      .filter({ hasText: 'Highlight settings changed from defaults' })
-      .click()
+    await page.getByRole('button', { name: 'Highlight settings changed from defaults' }).click()
 
     const autoLoadSetting = page.locator('.switch-ctn').filter({ has: autoLoadToggle })
     const resetButton = autoLoadSetting.getByRole('button', { name: 'Reset this setting to its default' })
@@ -415,9 +736,7 @@ test.describe('settings', () => {
   test('highlights and resets caption appearance settings individually', async ({ page }) => {
     await goTo(page, 'settings')
 
-    await page.locator('label.switch-label')
-      .filter({ hasText: 'Highlight settings changed from defaults' })
-      .click()
+    await page.getByRole('button', { name: 'Highlight settings changed from defaults' }).click()
     await page.locator('.settingsMenu [data-section="caption-appearance"]').click()
 
     const backgroundOpacity = page.getByRole('slider', { name: /Background Opacity/ })
@@ -443,9 +762,7 @@ test.describe('settings', () => {
   test('highlights and resets SponsorBlock category values individually', async ({ page }) => {
     await goTo(page, 'settings')
 
-    await page.locator('label.switch-label')
-      .filter({ hasText: 'Highlight settings changed from defaults' })
-      .click()
+    await page.getByRole('button', { name: 'Highlight settings changed from defaults' }).click()
     await page.locator('.settingsMenu [data-section="sponsor-block"]').click()
     await page.locator('label.switch-label')
       .filter({ hasText: 'Enable SponsorBlock' })
@@ -480,6 +797,7 @@ test.describe('settings', () => {
 
   test('positions toasts and dismisses them towards the configured edge', async ({ page }) => {
     await goTo(page, 'settings')
+    await page.locator('.settingsMenu [data-section="theme"]').click()
 
     const themeSection = page.locator('[data-section="theme"]')
     const positionSelect = themeSection.locator('.select')
@@ -634,6 +952,7 @@ test.describe('settings', () => {
 
   test('configures the toast timeout indicator and pauses toasts on hover', async ({ page }) => {
     await goTo(page, 'settings')
+    await page.locator('.settingsMenu [data-section="theme"]').click()
 
     const themeSection = page.locator('[data-section="theme"]')
     const indicatorToggle = themeSection.getByRole('checkbox', { name: 'Show toast timeout indicator' })
@@ -876,6 +1195,7 @@ test.describe('sync settings', () => {
       }
     })
     await goTo(page, 'settings')
+    await page.locator('.settingsMenu [data-section="sync"]').click()
 
     const syncSection = page.locator('[data-section="sync"]')
     await syncSection.getByRole('button', { name: 'Sync now' }).click()
@@ -920,6 +1240,7 @@ test.describe('sync settings', () => {
       await route.fulfill({ status: 200, json: [] })
     })
     await goTo(page, 'settings')
+    await page.locator('.settingsMenu [data-section="sync"]').click()
 
     const syncSection = page.locator('[data-section="sync"]')
     await syncSection.getByRole('button', { name: 'Sync now' }).click()
@@ -966,6 +1287,8 @@ test.describe('sync settings', () => {
 
     await goTo(page, 'settings')
     await goTo(otherWindow, 'settings')
+    await page.locator('.settingsMenu [data-section="sync"]').click()
+    await otherWindow.locator('.settingsMenu [data-section="sync"]').click()
     const firstSyncSection = page.locator('[data-section="sync"]')
     const otherSyncSection = otherWindow.locator('[data-section="sync"]')
 
@@ -1003,6 +1326,7 @@ test.describe('sync settings', () => {
     })
 
     await goTo(page, 'settings')
+    await page.locator('.settingsMenu [data-section="sync"]').click()
     const syncSection = page.locator('[data-section="sync"]')
     await syncSection.getByRole('button', { name: 'Disconnect' }).click()
     await syncSection.getByLabel('Username').fill('sync-user')
@@ -1036,6 +1360,7 @@ test.describe('sync settings', () => {
       }
     })
     await goTo(page, 'settings')
+    await page.locator('.settingsMenu [data-section="sync"]').click()
 
     const syncSection = page.locator('[data-section="sync"]')
     await syncSection.getByRole('button', { name: 'Disconnect' }).click()
@@ -1099,6 +1424,7 @@ test.describe('sync settings', () => {
       }
     })
     await goTo(page, 'settings')
+    await page.locator('.settingsMenu [data-section="sync"]').click()
 
     const syncSection = page.locator('[data-section="sync"]')
     await syncSection.getByRole('button', { name: 'Sync now' }).click()
@@ -1132,6 +1458,7 @@ test.describe('invalid toast position', () => {
 
   test('falls back to bottom left', async ({ page }) => {
     await goTo(page, 'settings')
+    await page.locator('.settingsMenu [data-section="theme"]').click()
 
     const positionSelect = page.locator('[data-section="theme"] .select')
       .filter({ hasText: 'Toast Position' })
@@ -1171,6 +1498,7 @@ test.describe('synced setting indicators', () => {
     await expect(syncedLabel.getByRole('button', { name: 'Sync this setting' })).toBeVisible()
 
     await page.reload()
+    await goTo(page, 'settings')
     await expect(syncedLabel.getByRole('button', { name: 'Sync this setting' })).toBeVisible()
 
     const toggle = page.getByRole('checkbox', { name: /Auto load next page/i })
@@ -1185,9 +1513,7 @@ test.describe('synced setting indicators', () => {
 
   test('spaces setting sync and help icons', async ({ page }) => {
     await goTo(page, 'settings')
-    await page.locator('label.switch-label')
-      .filter({ hasText: 'Highlight settings changed from defaults' })
-      .click()
+    await page.getByRole('button', { name: 'Highlight settings changed from defaults' }).click()
     await page.locator('.settingsMenu [data-section="privacy"]').click()
 
     const slider = page.locator('label.pure-material-slider')
@@ -1265,9 +1591,7 @@ test.describe('synced setting indicators', () => {
 
   test('renders select tooltips above neighboring setting indicators', async ({ page }) => {
     await goTo(page, 'settings')
-    await page.locator('label.switch-label')
-      .filter({ hasText: 'Highlight settings changed from defaults' })
-      .click()
+    await page.getByRole('button', { name: 'Highlight settings changed from defaults' }).click()
 
     const startupSelect = page.locator('.select').filter({ hasText: 'On Startup' })
     await startupSelect.locator('select').selectOption('restoreTabLoadState')

--- a/e2e/tests/offline/settings.spec.mjs
+++ b/e2e/tests/offline/settings.spec.mjs
@@ -50,6 +50,19 @@ test.describe('settings', () => {
     await expect(page.locator('.settingsContent > [data-section="general"]')).toBeVisible()
   })
 
+  test('keeps a direct legacy settings route inside the app', async ({ page }) => {
+    const tab = await page.evaluate(() => window.ftElectron.tabs.create({
+      route: '/settings',
+      makeActive: true
+    }))
+
+    await expect(page.locator('.settingsWindow')).toBeVisible()
+    await expect.poll(async () => {
+      const state = await page.evaluate(() => window.ftElectron.tabs.getState())
+      return state.tabs.find(candidate => candidate.id === tab.id)?.route.fullPath
+    }).toBe('/')
+  })
+
   test('toggles from the app settings button', async ({ page }) => {
     const settingsButton = page.locator('.navSettingsButton')
     await settingsButton.click()
@@ -57,6 +70,18 @@ test.describe('settings', () => {
 
     await settingsButton.click()
     await expect(page.locator('.settingsWindow')).toHaveClass(/settings-window-leave-active/)
+    await expect(page.locator('.settingsWindow')).toBeHidden()
+  })
+
+  test('focuses its search and closes with Escape', async ({ page }) => {
+    await goTo(page, 'settings')
+    const search = page.getByRole('searchbox', { name: 'Search settings' })
+    await expect(search).toBeFocused()
+    await search.evaluate(element => element.blur())
+    await page.locator('.settingsSearch svg').click()
+    await expect(search).toBeFocused()
+
+    await page.keyboard.press('Escape')
     await expect(page.locator('.settingsWindow')).toBeHidden()
   })
 
@@ -130,6 +155,12 @@ test.describe('settings', () => {
     await search.fill('checking')
     await expect(page.locator('.settingsSearchResultMatch')).toHaveCount(0)
 
+    await search.fill('No default instance has been set')
+    await expect(page.locator('.settingsSearchResultMatch')).toHaveCount(0)
+
+    await search.fill('Current instance will be randomized on startup')
+    await expect(page.locator('.settingsSearchResultMatch')).toHaveCount(0)
+
     await search.fill('Catppuccin Latte')
     await expect(page.locator('.settingsSearchResultMatch')).toHaveCount(0)
 
@@ -199,6 +230,21 @@ test.describe('settings', () => {
     const bounds = await page.locator('.settingsWindow').boundingBox()
     expect(bounds.x).toBeGreaterThanOrEqual(0)
     expect(bounds.x + bounds.width).toBeLessThanOrEqual(340)
+  })
+
+  test('keeps its minimum size when a resize pointer crosses the window', async ({ page }) => {
+    await goTo(page, 'settings')
+    const resizeHandle = page.locator('.resize-se')
+    const handleBounds = await resizeHandle.boundingBox()
+
+    await page.mouse.move(handleBounds.x + handleBounds.width / 2, handleBounds.y + handleBounds.height / 2)
+    await page.mouse.down()
+    await page.mouse.move(0, 0)
+    await page.mouse.up()
+
+    const bounds = await page.locator('.settingsWindow').boundingBox()
+    expect(bounds.width).toBeGreaterThanOrEqual(359.9)
+    expect(bounds.height).toBeGreaterThanOrEqual(359.9)
   })
 
   test('wraps controls before the two-column detail pane clips them', async ({ page }) => {

--- a/e2e/tests/offline/subscriptions-refresh.spec.mjs
+++ b/e2e/tests/offline/subscriptions-refresh.spec.mjs
@@ -154,13 +154,12 @@ test.describe('incremental subscription feed refresh', () => {
 
     await page.getByRole('button', { name: /Refresh Videos/ }).click()
     await expect(page.getByTestId('subscription-refresh-toast')).toHaveCount(0)
-    await goTo(page, 'settings')
+    await goTo(page, 'history')
 
     const refreshToast = page.getByTestId('subscription-refresh-toast')
     await expect(refreshToast).toContainText('Refreshing subscription videos')
     await expect(page.locator('.app > .progressBar')).toHaveCount(0)
 
-    await page.keyboard.press('Escape')
     await expect(refreshToast).toBeVisible()
     await expect(refreshToast).toHaveCount(0, { timeout: 30_000 })
   })
@@ -297,7 +296,7 @@ test.describe('cancelling an automatic subscription feed refresh', () => {
 
   test('shows persistent progress in a toast without the global progress bar', async ({ page }) => {
     await routeFeeds(page, (index) => index === 0 ? 0 : 8_000)
-    await goTo(page, 'settings')
+    await goTo(page, 'history')
 
     const refreshToast = page.getByTestId('subscription-refresh-toast')
     await expect(refreshToast).toContainText('Refreshing subscription videos', { timeout: 10_000 })
@@ -331,9 +330,6 @@ test.describe('cancelling an automatic subscription feed refresh', () => {
     await page.mouse.move(viewport.width / 2, viewport.height / 2)
     await expect(refreshToast).not.toHaveClass(/minimized/)
     await expect.poll(async () => (await refreshToast.boundingBox()).width).toBeGreaterThan(expandedBounds.width * 0.9)
-
-    await page.keyboard.press('Escape')
-    await expect(refreshToast).toBeVisible()
 
     await page.evaluate(() => document.documentElement.requestFullscreen())
     await expect(refreshToast).toHaveCount(0)

--- a/e2e/tests/offline/tabs.spec.mjs
+++ b/e2e/tests/offline/tabs.spec.mjs
@@ -1000,32 +1000,36 @@ test.describe('background tab shortcuts', () => {
     await page.locator(sel.newTabButton).click()
     await goTo(page, 'history')
 
-    const externalRequests = []
+    const subscriptionRefreshRequests = []
     page.on('request', (request) => {
-      if (/^https?:/.test(request.url())) {
-        externalRequests.push(request.url())
+      if (request.url().includes('UC-test-subscription')) {
+        subscriptionRefreshRequests.push(request.url())
       }
     })
 
     await page.locator('body').press('r')
-    await page.waitForTimeout(500)
-    expect(externalRequests).toEqual([])
+    await page.evaluate(() => new Promise(resolve => requestAnimationFrame(() => {
+      requestAnimationFrame(resolve)
+    })))
+    expect(subscriptionRefreshRequests).toEqual([])
   })
 
   test('R typed in settings search does not refresh subscriptions behind it', async ({ page }) => {
     await goTo(page, 'settings')
     const search = page.getByRole('searchbox', { name: 'Search settings' })
-    const externalRequests = []
+    const subscriptionRefreshRequests = []
     page.on('request', (request) => {
-      if (/^https?:/.test(request.url())) {
-        externalRequests.push(request.url())
+      if (request.url().includes('UC-test-subscription')) {
+        subscriptionRefreshRequests.push(request.url())
       }
     })
 
     await search.press('r')
     await expect(search).toHaveValue('r')
-    await page.waitForTimeout(500)
-    expect(externalRequests).toEqual([])
+    await page.evaluate(() => new Promise(resolve => requestAnimationFrame(() => {
+      requestAnimationFrame(resolve)
+    })))
+    expect(subscriptionRefreshRequests).toEqual([])
   })
 })
 

--- a/e2e/tests/offline/tabs.spec.mjs
+++ b/e2e/tests/offline/tabs.spec.mjs
@@ -853,6 +853,22 @@ test.describe('custom default page', () => {
   })
 })
 
+test.describe('removed settings landing page', () => {
+  test.use({ seed: { settings: { landingPage: 'settings' } } })
+
+  test('migrates to subscriptions before creating tabs', async ({ page }) => {
+    const tab = await page.evaluate(async () => {
+      return await window.ftElectron.tabs.create({
+        makeActive: false,
+        lazyLoad: true
+      })
+    })
+
+    expect(tab.route.fullPath).toBe('/subscriptions')
+    expect(tab.title).toBe('Subscriptions')
+  })
+})
+
 test.describe('RTL context menus', () => {
   test.use({ seed: { settings: { currentLocale: 'ar' } } })
 

--- a/e2e/tests/offline/tabs.spec.mjs
+++ b/e2e/tests/offline/tabs.spec.mjs
@@ -85,11 +85,10 @@ test.describe('tab bar', () => {
     ])
   })
 
-  test('uses the matching app icon when the route changes', async ({ page }) => {
+  test('keeps the current app icon when Settings opens over the route', async ({ page }) => {
     await goTo(page, 'settings')
-    await page.waitForTimeout(100)
     expect(await page.locator(`${sel.activeTab} .loadingDot`).count()).toBe(0)
-    await expect(page.locator(sel.activeTab).locator('[data-icon="sliders"]')).toBeVisible()
+    await expect(page.locator(sel.activeTab).locator('[data-icon="rss"]')).toBeVisible()
 
     await goTo(page, 'history')
     await expect(page.locator(sel.activeTab).locator('[data-icon="clock-rotate-left"]')).toBeVisible()
@@ -166,19 +165,19 @@ test.describe('tab bar', () => {
   })
 
   test('each tab keeps its own route', async ({ page }) => {
-    await goTo(page, 'settings')
-    await expect(page).toHaveURL(/#\/settings/)
-
-    await page.locator(sel.newTabButton).click()
     await goTo(page, 'history')
     await expect(page).toHaveURL(/#\/history/)
 
+    await page.locator(sel.newTabButton).click()
+    await goTo(page, 'about')
+    await expect(page).toHaveURL(/#\/about/)
+
     // Switch back to the first tab: its route must be restored.
     await page.locator(sel.tabs).first().click()
-    await expect(page).toHaveURL(/#\/settings/)
+    await expect(page).toHaveURL(/#\/history/)
 
     await page.locator(sel.tabs).nth(1).click()
-    await expect(page).toHaveURL(/#\/history/)
+    await expect(page).toHaveURL(/#\/about/)
   })
 
   test('selects multiple tabs with modifier clicks', async ({ page }) => {
@@ -713,7 +712,7 @@ test.describe('closed tabs', () => {
   })
 
   test('restoring a closed tab restores its navigation history', async ({ page }) => {
-    await goTo(page, 'settings')
+    await goTo(page, 'about')
     await goTo(page, 'history')
     await page.locator(sel.newTabButton).click()
     await page.locator(sel.tabs).first().click()
@@ -725,7 +724,7 @@ test.describe('closed tabs', () => {
 
     await expect(page).toHaveURL(/#\/history/)
     await page.locator(sel.backButton).click()
-    await expect(page).toHaveURL(/#\/settings/)
+    await expect(page).toHaveURL(/#\/about/)
     await page.locator(sel.forwardButton).click()
     await expect(page).toHaveURL(/#\/history/)
   })
@@ -735,13 +734,14 @@ test.describe('closed tabs', () => {
 
     test('does not persist restored history across a relaunch', async ({ app }) => {
       let page = app.page
-      await goTo(page, 'settings')
+      await goTo(page, 'about')
       await goTo(page, 'history')
       await page.locator(sel.newTabButton).click()
       await page.locator(sel.tabs).first().click()
       await page.keyboard.press('Control+w')
 
       await goTo(page, 'settings')
+      await expect(page.locator('.settingsWindow')).not.toHaveClass(/settings-window-enter-active/)
       const rememberHistory = page.getByRole('checkbox', { name: 'Remember Tab Navigation History' })
       await expect(rememberHistory).toBeChecked()
       await page.locator('label.switch-label').filter({ hasText: 'Remember Tab Navigation History' }).click()
@@ -933,7 +933,7 @@ test.describe('subscription feed tabs', () => {
     await page.locator(sel.tabs).first().click()
     await expect(feedTab('shorts')).toHaveAttribute('aria-selected', 'true')
 
-    await goTo(page, 'settings')
+    await goTo(page, 'history')
     await goTo(page, 'subscriptions')
     await expect(feedTab('live')).toHaveAttribute('aria-selected', 'true')
   })
@@ -992,6 +992,22 @@ test.describe('background tab shortcuts', () => {
     })
 
     await page.locator('body').press('r')
+    await page.waitForTimeout(500)
+    expect(externalRequests).toEqual([])
+  })
+
+  test('R typed in settings search does not refresh subscriptions behind it', async ({ page }) => {
+    await goTo(page, 'settings')
+    const search = page.getByRole('searchbox', { name: 'Search settings' })
+    const externalRequests = []
+    page.on('request', (request) => {
+      if (/^https?:/.test(request.url())) {
+        externalRequests.push(request.url())
+      }
+    })
+
+    await search.press('r')
+    await expect(search).toHaveValue('r')
     await page.waitForTimeout(500)
     expect(externalRequests).toEqual([])
   })

--- a/src/renderer/App.vue
+++ b/src/renderer/App.vue
@@ -69,6 +69,9 @@
         </Transition>
       </RouterView>
     </FtFlexBox>
+    <Transition name="settings-window">
+      <SettingsWindow v-if="settingsWindowOpen" />
+    </Transition>
     <FtPrompt
       v-if="showReleaseNotes"
       theme="readable-width"
@@ -113,9 +116,6 @@
     />
     <FtSearchFilters
       v-if="showSearchFilters"
-    />
-    <FtKeyboardShortcutPrompt
-      v-if="isKeyboardShortcutPromptShown"
     />
     <FtPlaylistAddVideoPrompt
       v-if="showAddToPlaylistPrompt"
@@ -279,7 +279,7 @@
 
 <script setup>
 import { FontAwesomeIcon } from '@fortawesome/vue-fontawesome'
-import { computed, nextTick, onBeforeUnmount, onMounted, provide, ref, useTemplateRef, watch } from 'vue'
+import { computed, defineAsyncComponent, nextTick, onBeforeUnmount, onMounted, provide, ref, useTemplateRef, watch } from 'vue'
 import { useI18n } from 'vue-i18n'
 import { routerKey, useRoute, useRouter } from 'vue-router'
 
@@ -295,7 +295,6 @@ import FtToast from './components/FtToast/FtToast.vue'
 import FtProgressBar from './components/FtProgressBar/FtProgressBar.vue'
 import FtPlaylistAddVideoPrompt from './components/FtPlaylistAddVideoPrompt/FtPlaylistAddVideoPrompt.vue'
 import FtCreatePlaylistPrompt from './components/FtCreatePlaylistPrompt/FtCreatePlaylistPrompt.vue'
-import FtKeyboardShortcutPrompt from './components/FtKeyboardShortcutPrompt/FtKeyboardShortcutPrompt.vue'
 import FtSearchFilters from './components/FtSearchFilters/FtSearchFilters.vue'
 import FtContextMenu from './components/FtContextMenu/FtContextMenu.vue'
 import { vSaferHtml } from './directives/vSaferHtml.js'
@@ -323,6 +322,7 @@ import {
   SUBSCRIPTION_REFRESH_STARTED_EVENT
 } from './helpers/subscriptions'
 import { translateWindowTitle } from './helpers/strings'
+import { initializePlatformInfo } from './helpers/platform'
 import { getTabAccentColor } from './constants/tabColors'
 import { getThumbnailListStyles } from './constants/thumbnailSize'
 import { getTabNavigationService } from './tabs/TabNavigationService'
@@ -330,12 +330,15 @@ import { tabRuntimeRegistry } from './tabs/TabRuntimeRegistry'
 import { getTabAvatarUrl, getTabPageIcon, getTabPreviewFallbackUrl } from './tabs/tabPreview'
 import { preloadUtilityRoutes } from './router/index'
 
+const SettingsWindow = defineAsyncComponent(() => import('./views/Settings/Settings.vue'))
+
 const releaseNotesMarkdown = createReleaseNotesMarkdown()
 
 const route = useRoute()
 const router = useRouter()
 const navigation = process.env.IS_ELECTRON ? getTabNavigationService() : null
 const isElectron = process.env.IS_ELECTRON
+const platformInfoReady = initializePlatformInfo()
 if (isElectron) {
   provide(routerKey, navigation.createPresentedRouterFacade())
 }
@@ -428,6 +431,7 @@ const showSearchFilters = computed(() => store.getters.getShowSearchFilters)
 
 /** @type {import('vue').ComputedRef<boolean>} */
 const isKeyboardShortcutPromptShown = computed(() => store.getters.getIsKeyboardShortcutPromptShown)
+const settingsWindowOpen = computed(() => store.getters.getSettingsWindowOpen)
 
 /** @type {import('vue').ComputedRef<boolean>} */
 const showAddToPlaylistPrompt = computed(() => store.getters.getShowAddToPlaylistPrompt)
@@ -734,7 +738,7 @@ onMounted(async () => {
       removeReloadRequestListener = window.ftElectron.tabs.onRequestReload(prepareAndReloadTab)
     }
 
-    await syncDataReady
+    await Promise.all([syncDataReady, platformInfoReady])
     store.dispatch('initializeSyncServer').catch(error => {
       console.error('Initial sync server sync failed', error)
     })
@@ -1753,7 +1757,9 @@ function handleKeyboardShortcuts(event) {
 
   if (matchesKeyboardShortcut(event, shortcuts.SHOW_SHORTCUTS) && !isTypingTarget(event.target)) {
     event.preventDefault()
-    store.commit('setIsKeyboardShortcutPromptShown', !isKeyboardShortcutPromptShown.value)
+    store.dispatch(isKeyboardShortcutPromptShown.value
+      ? 'hideKeyboardShortcutPrompt'
+      : 'showKeyboardShortcutPrompt')
   }
 
   if (event.key === 'Tab' && !event.ctrlKey) {

--- a/src/renderer/components/CaptionSettings/CaptionSettings.css
+++ b/src/renderer/components/CaptionSettings/CaptionSettings.css
@@ -86,7 +86,7 @@
   align-items: stretch;
   justify-content: center;
   gap: 0;
-  color: rgb(var(--primary-text-color) 0.87);
+  color: color-mix(in srgb, var(--primary-text-color) 87%, transparent);
   cursor: pointer;
 }
 

--- a/src/renderer/components/CaptionSettings/CaptionSettings.css
+++ b/src/renderer/components/CaptionSettings/CaptionSettings.css
@@ -1,9 +1,7 @@
 .captionPreview {
   position: relative;
   box-sizing: border-box;
-
-  /* grows with the font size, so large captions still have room in the preview */
-  min-block-size: max(120px, 3em);
+  block-size: 240px;
   margin-block-end: 1rem;
   border-radius: calc(5px * var(--ui-roundness));
   background: linear-gradient(135deg, #576574, #222f3e);
@@ -84,15 +82,25 @@
 }
 
 .captionColorControl {
-  justify-content: space-between;
-  gap: 1rem;
+  flex-direction: column;
+  align-items: stretch;
+  justify-content: center;
+  gap: 0;
   color: rgb(var(--primary-text-color) 0.87);
   cursor: pointer;
 }
 
+.captionColorControl > span {
+  min-block-size: 20px;
+  display: flex;
+  align-items: center;
+  gap: 4px;
+}
+
 .captionColorControl input {
-  inline-size: 48px;
-  block-size: 36px;
+  inline-size: 100%;
+  block-size: 45px;
+  box-sizing: border-box;
   padding: 2px;
   border: 1px solid var(--border-color);
   border-radius: calc(4px * var(--ui-roundness));
@@ -107,13 +115,13 @@
   border-block-start: 1px solid var(--border-color);
 }
 
-@media only screen and (width <= 1100px) {
+@container settings-content (width <= 1100px) {
   .captionControls {
     grid-template-columns: repeat(2, minmax(0, 1fr));
   }
 }
 
-@media only screen and (width <= 680px) {
+@container settings-content (width <= 680px) {
   .captionControls {
     grid-template-columns: minmax(0, 1fr);
   }

--- a/src/renderer/components/ChannelSettings/ChannelSettings.css
+++ b/src/renderer/components/ChannelSettings/ChannelSettings.css
@@ -50,9 +50,9 @@
 .channelEntry {
   display: flex;
 
-  /* Basis wide enough to fit two preference columns, so cards stay wide instead
-     of the prompt packing in as many narrow ones as it can */
-  flex: 1 1 520px;
+  /* A card only needs room for one preference column. This lets medium-sized
+     settings windows place two channels side by side. */
+  flex: 1 1 360px;
   flex-direction: column;
   max-inline-size: 760px;
   padding: 1em;

--- a/src/renderer/components/ChannelSettings/ChannelSettings.vue
+++ b/src/renderer/components/ChannelSettings/ChannelSettings.vue
@@ -36,11 +36,10 @@
         @click="showManager = true"
       />
     </FtFlexBox>
-    <FtPrompt
-      v-if="showManager"
-      :label="t('Settings.Channel Settings.Saved Channels')"
-      theme="flex-column"
-      @click="handleManagerClick"
+    <FtSettingsSubpage
+      :open="showManager"
+      :title="t('Settings.Channel Settings.Saved Channels')"
+      @close="showManager = false"
     >
       <FtInput
         v-if="channelEntries.length > SEARCH_THRESHOLD"
@@ -173,13 +172,7 @@
           </li>
         </ul>
       </div>
-      <FtFlexBox>
-        <FtButton
-          :label="t('Close')"
-          @click="showManager = false"
-        />
-      </FtFlexBox>
-    </FtPrompt>
+    </FtSettingsSubpage>
   </FtSettingsSection>
 </template>
 
@@ -192,7 +185,7 @@ import FtButton from '../FtButton/FtButton.vue'
 import FtFlexBox from '../ft-flex-box/ft-flex-box.vue'
 import FtIconButton from '../FtIconButton/FtIconButton.vue'
 import FtInput from '../FtInput/FtInput.vue'
-import FtPrompt from '../FtPrompt/FtPrompt.vue'
+import FtSettingsSubpage from '../FtSettingsSubpage/FtSettingsSubpage.vue'
 import FtSelect from '../FtSelect/FtSelect.vue'
 import FtSettingsSection from '../FtSettingsSection/FtSettingsSection.vue'
 import FtSlider from '../FtSlider/FtSlider.vue'
@@ -289,25 +282,10 @@ const backendOptions = computed(() => ({
 
 const showManager = ref(false)
 
-/**
- * Close the manager only when the current tab is navigating. Modified clicks
- * may open another tab or window and should leave this dialog untouched.
- * @param {MouseEvent} event
- */
+/** @param {MouseEvent} event */
 function handleChannelLinkClick(event) {
   if (disableChannelLinks.value) {
     event.preventDefault()
-    return
-  }
-
-  if (
-    event.button === 0 &&
-    !event.ctrlKey &&
-    !event.metaKey &&
-    !event.shiftKey &&
-    !event.altKey
-  ) {
-    showManager.value = false
   }
 }
 const searchQuery = ref('')
@@ -442,15 +420,6 @@ watch([showManager, channelEntries], ([isManagerOpen]) => {
     fetchMissingChannels()
   }
 })
-
-/**
- * @param {string | null} value
- */
-function handleManagerClick(value) {
-  if (value === null) {
-    showManager.value = false
-  }
-}
 
 /**
  * @param {string} channelId

--- a/src/renderer/components/ContextMenuSearchSettings/ContextMenuSearchSettings.css
+++ b/src/renderer/components/ContextMenuSearchSettings/ContextMenuSearchSettings.css
@@ -72,7 +72,7 @@ h3 {
   text-align: center;
 }
 
-@container settings-page (width <= 800px) {
+@container settings-content (width <= 800px) {
   .engineRow,
   .engineRow:has(.removeEngine),
   .addEngine {

--- a/src/renderer/components/DataSettings/DataSettings.vue
+++ b/src/renderer/components/DataSettings/DataSettings.vue
@@ -95,41 +95,58 @@
         @click="exportSettings"
       />
     </FtFlexBox>
-    <FtPrompt
-      v-if="showExportSubscriptionsPrompt"
-      autosize
-      :label="$t('Settings.Data Settings.Select Export Type')"
-      :option-names="exportSubscriptionsPromptNames"
-      :option-values="SUBSCRIPTIONS_PROMPT_VALUES"
-      @click="exportSubscriptions"
-    />
-    <FtPrompt
-      v-if="showExportWatchHistoryPrompt"
-      autosize
-      :label="t('Settings.Data Settings.Select Export Type')"
-      :option-names="exportWatchSearchHistoryPromptNames"
-      :option-values="WATCH_SEARCH_HISTORY_PROMPT_VALUES"
-      @click="exportWatchHistory"
-    />
-    <FtPrompt
-      v-if="showExportSearchHistoryPrompt"
-      autosize
-      :label="t('Settings.Data Settings.Select Export Type')"
-      :option-names="exportWatchSearchHistoryPromptNames"
-      :option-values="WATCH_SEARCH_HISTORY_PROMPT_VALUES"
-      @click="exportSearchHistory"
-    />
+    <FtSettingsSubpage
+      :open="showExportSubscriptionsPrompt"
+      :title="t('Settings.Data Settings.Select Export Type')"
+      @close="showExportSubscriptionsPrompt = false"
+    >
+      <FtFlexBox>
+        <FtButton
+          v-for="(name, index) in exportSubscriptionsPromptNames.slice(0, SUBSCRIPTIONS_PROMPT_VALUES.length - 1)"
+          :key="SUBSCRIPTIONS_PROMPT_VALUES[index]"
+          :label="name"
+          @click="exportSubscriptions(SUBSCRIPTIONS_PROMPT_VALUES[index])"
+        />
+      </FtFlexBox>
+    </FtSettingsSubpage>
+    <FtSettingsSubpage
+      :open="showExportWatchHistoryPrompt"
+      :title="t('Settings.Data Settings.Select Export Type')"
+      @close="showExportWatchHistoryPrompt = false"
+    >
+      <FtFlexBox>
+        <FtButton
+          v-for="(name, index) in exportWatchSearchHistoryPromptNames.slice(0, WATCH_SEARCH_HISTORY_PROMPT_VALUES.length)"
+          :key="WATCH_SEARCH_HISTORY_PROMPT_VALUES[index]"
+          :label="name"
+          @click="exportWatchHistory(WATCH_SEARCH_HISTORY_PROMPT_VALUES[index])"
+        />
+      </FtFlexBox>
+    </FtSettingsSubpage>
+    <FtSettingsSubpage
+      :open="showExportSearchHistoryPrompt"
+      :title="t('Settings.Data Settings.Select Export Type')"
+      @close="showExportSearchHistoryPrompt = false"
+    >
+      <FtFlexBox>
+        <FtButton
+          v-for="(name, index) in exportWatchSearchHistoryPromptNames.slice(0, WATCH_SEARCH_HISTORY_PROMPT_VALUES.length)"
+          :key="WATCH_SEARCH_HISTORY_PROMPT_VALUES[index]"
+          :label="name"
+          @click="exportSearchHistory(WATCH_SEARCH_HISTORY_PROMPT_VALUES[index])"
+        />
+      </FtFlexBox>
+    </FtSettingsSubpage>
   </FtSettingsSection>
 </template>
 
 <script setup>
 import { computed, ref } from 'vue'
 import { useI18n } from 'vue-i18n'
-import { useRouter } from 'vue-router'
 
 import FtButton from '../FtButton/FtButton.vue'
 import FtFlexBox from '../ft-flex-box/ft-flex-box.vue'
-import FtPrompt from '../FtPrompt/FtPrompt.vue'
+import FtSettingsSubpage from '../FtSettingsSubpage/FtSettingsSubpage.vue'
 import FtSettingsSection from '../FtSettingsSection/FtSettingsSection.vue'
 import FtTooltip from '../FtTooltip/FtTooltip.vue'
 
@@ -161,10 +178,8 @@ const IMPORT_DIRECTORY_ID = 'data-settings-import'
 const START_IN_DIRECTORY = 'downloads'
 
 const { t } = useI18n()
-const router = useRouter()
-
 function openProfileSettings() {
-  router.push('/settings/profile')
+  store.dispatch('showSettingsWindow', 'profile')
 }
 
 /**

--- a/src/renderer/components/FtKeyboardShortcutPrompt/FtKeyboardShortcutPrompt.css
+++ b/src/renderer/components/FtKeyboardShortcutPrompt/FtKeyboardShortcutPrompt.css
@@ -4,6 +4,17 @@
   max-inline-size: 80%;
 }
 
+.keyboardShortcutPromptEmbedded {
+  display: flex;
+  flex-direction: column;
+  max-inline-size: none;
+  block-size: 100%;
+  min-inline-size: 0;
+  min-block-size: 0;
+  overflow: hidden;
+  container-type: inline-size;
+}
+
 .titleAndCloseButton {
   display: flex;
   justify-content: space-between;
@@ -30,9 +41,20 @@ h3 {
   text-align: center;
 }
 
+.shortcutToolbar {
+  flex: 0 0 auto;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 1em;
+  margin-block-end: 0.5em;
+  padding-block: 0.5em 1em;
+  background: var(--base-color);
+}
+
 .editHint {
-  margin-block: 0 1.5em;
-  text-align: center;
+  flex: 1;
+  margin: 0;
 }
 
 .shortcutColumns,
@@ -45,6 +67,14 @@ h3 {
   align-items: flex-start;
   flex-flow: row wrap;
   justify-content: space-evenly;
+}
+
+.keyboardShortcutPromptEmbedded .shortcutColumns {
+  flex: 1 1 auto;
+  min-block-size: 0;
+  overflow: auto;
+  overscroll-behavior: contain;
+  padding-block-end: 1em;
 }
 
 .shortcutColumn {
@@ -138,17 +168,27 @@ h3 {
   color: var(--accent-color);
 }
 
-.shortcutActions {
-  display: flex;
-  justify-content: center;
-  margin-block-start: 2em;
-}
-
 :deep(.promptCard) {
   overflow-x: hidden;
 }
 
 @media only screen and (width <= 600px) {
+  .label {
+    min-inline-size: 200px;
+    inline-size: 200px;
+  }
+
+  .shortcutColumn {
+    display: contents;
+  }
+}
+
+@container (width <= 600px) {
+  .shortcutToolbar {
+    align-items: stretch;
+    flex-direction: column;
+  }
+
   .label {
     min-inline-size: 200px;
     inline-size: 200px;

--- a/src/renderer/components/FtKeyboardShortcutPrompt/FtKeyboardShortcutPrompt.vue
+++ b/src/renderer/components/FtKeyboardShortcutPrompt/FtKeyboardShortcutPrompt.vue
@@ -1,10 +1,16 @@
 <template>
-  <FtPrompt
-    :label="$t('KeyboardShortcutPrompt.Keyboard Shortcuts')"
-    :inert="pendingShortcutConflict !== null"
-    @click="hideKeyboardShortcutPrompt"
+  <component
+    :is="embedded ? 'div' : FtPrompt"
+    class="keyboardShortcutPrompt"
+    :class="{ keyboardShortcutPromptEmbedded: embedded }"
+    :label="embedded ? undefined : $t('KeyboardShortcutPrompt.Keyboard Shortcuts')"
+    :inert="embedded && pendingShortcutConflict === null ? undefined : pendingShortcutConflict !== null"
+    @click="handleContainerClick"
   >
-    <template #label="{ labelId }">
+    <template
+      v-if="!embedded"
+      #label="{ labelId }"
+    >
       <div class="titleAndCloseButton">
         <h2 :id="labelId">
           {{ $t('KeyboardShortcutPrompt.Keyboard Shortcuts') }}
@@ -18,11 +24,23 @@
       </div>
     </template>
 
-    <p class="editHint">
-      {{ $t('KeyboardShortcutPrompt.Edit Hint') }}
-    </p>
+    <div class="shortcutToolbar">
+      <p class="editHint">
+        {{ $t('KeyboardShortcutPrompt.Edit Hint') }}
+      </p>
+      <FtButton
+        :label="$t('KeyboardShortcutPrompt.Reset to Defaults')"
+        :text-color="null"
+        :background-color="null"
+        :disabled="!hasModifiedKeyboardShortcuts"
+        @click="resetKeyboardShortcuts"
+      />
+    </div>
 
-    <div class="shortcutColumns">
+    <div
+      v-overlay-scrollbars="embedded"
+      class="shortcutColumns"
+    >
       <div
         v-for="(shortcutColumn, index) of shortcutColumns"
         :key="index"
@@ -95,16 +113,7 @@
         </div>
       </div>
     </div>
-
-    <div class="shortcutActions">
-      <FtButton
-        :label="$t('KeyboardShortcutPrompt.Reset to Defaults')"
-        :text-color="null"
-        :background-color="null"
-        @click="resetKeyboardShortcuts"
-      />
-    </div>
-  </FtPrompt>
+  </component>
 
   <FtPrompt
     v-if="pendingShortcutConflict"
@@ -138,6 +147,12 @@ import FtButton from '../FtButton/FtButton.vue'
 import FtIconButton from '../FtIconButton/FtIconButton.vue'
 
 const { t } = useI18n()
+const { embedded } = defineProps({
+  embedded: {
+    type: Boolean,
+    default: false
+  }
+})
 const isMac = process.platform === 'darwin'
 const recordingShortcutPath = ref('')
 const pendingShortcutConflict = ref(null)
@@ -296,6 +311,11 @@ const shortcutColumns = computed(() => [
     }
   ]
 ])
+const hasModifiedKeyboardShortcuts = computed(() => shortcutColumns.value.some(column =>
+  column.some(section => section.shortcutDictionary.some(shortcut =>
+    shortcut.bindings.some(binding => binding.modified)
+  ))
+))
 
 const localizedShortcutNameToShortcutsMappings = computed(() => {
   return [
@@ -372,6 +392,12 @@ const localizedShortcutNameToShortcutsMappings = computed(() => {
 
 function hideKeyboardShortcutPrompt() {
   store.dispatch('hideKeyboardShortcutPrompt')
+}
+
+function handleContainerClick() {
+  if (!embedded) {
+    hideKeyboardShortcutPrompt()
+  }
 }
 
 function getLocalizedShortcutNamesAndValues(dictionary, dictionaryPath, includedShortcutCodes = Object.keys(dictionary)) {

--- a/src/renderer/components/FtProfileSelector/FtProfileSelector.vue
+++ b/src/renderer/components/FtProfileSelector/FtProfileSelector.vue
@@ -85,7 +85,6 @@
 <script setup>
 import { computed, nextTick, ref, useId, useTemplateRef } from 'vue'
 import { useI18n } from 'vue-i18n'
-import { useRouter } from 'vue-router'
 
 import FtCard from '../ft-card/ft-card.vue'
 import FtIconButton from '../FtIconButton/FtIconButton.vue'
@@ -160,10 +159,8 @@ function toggleProfileList() {
   }
 }
 
-const router = useRouter()
-
 function openProfileSettings() {
-  router.push({ path: '/settings/profile' })
+  store.dispatch('showSettingsWindow', 'profile')
   profileListShown.value = false
 }
 

--- a/src/renderer/components/FtSelect/FtSelect.css
+++ b/src/renderer/components/FtSelect/FtSelect.css
@@ -77,7 +77,7 @@
 
 .selectDropdown {
   position: fixed;
-  z-index: 6;
+  z-index: 12;
   box-sizing: border-box;
   overflow-y: auto;
   padding-block: 4px;

--- a/src/renderer/components/FtSettingsMenu/FtSettingsMenu.css
+++ b/src/renderer/components/FtSettingsMenu/FtSettingsMenu.css
@@ -1,145 +1,81 @@
 .settingsMenu {
-  /* top nav + margin */
-  inset-block-start: 96px;
-  position: sticky;
   display: flex;
   flex-direction: column;
-  padding-inline-start: 0;
-  block-size: calc(85vh - 96px);
-  max-block-size: 600px;
-}
-
-.header {
-  inline-size: fit-content;
-  margin-block: 0 10px;
-}
-
-.headingIcon {
-  color: var(--primary-color);
+  min-inline-size: 0;
+  block-size: 100%;
+  box-sizing: border-box;
+  padding: 10px;
+  margin: 0;
+  background: var(--side-nav-color);
 }
 
 .title {
-  text-decoration: none;
-  color: var(--tertiary-text-color);
-  inline-size: 220px;
-  flex: 1 1 auto;
+  flex: 1 0 42px;
+  min-block-size: 42px;
+  inline-size: 100%;
+  box-sizing: border-box;
   display: flex;
   align-items: center;
+  padding-inline: 10px;
+  border: 0;
+  border-radius: calc(6px * var(--ui-roundness));
+  color: var(--tertiary-text-color);
+  background: transparent;
+  font: inherit;
+  text-align: start;
+  cursor: pointer;
 }
 
-/* prevent hover styling from showing on title click for mobile */
-@media (hover: hover) {
-  .title:hover {
-    color: var(--primary-text-color);
-  }
+.title:hover,
+.title:focus-visible {
+  color: var(--primary-text-color);
+  background: var(--side-nav-hover-color);
 }
 
-.titleContent {
-  inline-size: fit-content;
-  max-inline-size: 100%;
+.title.active {
+  color: var(--side-nav-hover-text-color);
+  background: var(--side-nav-hover-color);
+  font-weight: 600;
 }
 
+.settingsMenu.filtered .title {
+  flex-grow: 0;
+}
+
+.titleContent,
+.iconAndTitleText {
+  min-inline-size: 0;
+  inline-size: 100%;
+}
 
 .iconAndTitleText {
-  overflow-x: hidden;
+  overflow: hidden;
   white-space: nowrap;
   text-overflow: ellipsis;
+}
 
-  /* needed to have underline poke out */
-  margin-inline-start: 3px;
+.titleIcon {
+  inline-size: 18px;
+  block-size: 18px;
+  margin-inline-end: 10px;
 }
 
 .titleUnderline {
-  /* have underline poke out */
-  inline-size: calc(100% + 6px);
-
-  /* prevent "active" border from visibly pushing the content up */
-  border-block-end: 4px solid transparent;
+  display: none;
 }
 
-.settingsMenu:not(.mobileSettingsMenu) {
-  margin-block: 0;
-  font-size: 16px;
-
-  .header {
-    margin-block-start: 10px;
-    font-size: 26px;
-  }
-
-  .titleIcon {
-    inline-size: 16px;
-    block-size: 16px;
-  }
-
-  .title.active {
-    color: var(--primary-text-color);
-    font-weight: 600;
-  }
-
-  .title.active .titleUnderline {
-    border-block-end: 4px solid var(--primary-color);
-  }
+.emptyMessage {
+  margin: auto;
+  color: var(--tertiary-text-color);
+  text-align: center;
 }
 
-/* overall mobile breakpoint; large text */
 .settingsMenu.mobileSettingsMenu {
-  inline-size: fit-content;
-  margin-inline: auto;
-  position: relative;
-  inset-block-start: 0;
-  font-size: 30px;
-  max-block-size: 1100px;
-
-  .titleIcon {
-    inline-size: 30px;
-    block-size: 30px;
-    margin-inline-end: 10px;
-  }
-
-  .title {
-    inline-size: fit-content;
-    max-inline-size: 90vw;
-  }
-
-  .header {
-    font-size: 32px;
-  }
-
-  /* hide the settings icon on mobile to avoid confusion */
-  .headingIcon {
-    display: none;
-  }
+  inline-size: 100%;
+  font-size: 18px;
+  padding: 12px;
 }
 
-/* small height or width mobile breakpoint; intermediary text */
-@media only screen and (height <= 830px) {
-  .settingsMenu.mobileSettingsMenu {
-    font-size: 25px;
-
-    .titleIcon {
-      inline-size: 25px;
-      block-size: 25px;
-      margin-inline-end: 5px;
-    }
-
-    .header {
-      font-size: 25px;
-    }
-  }
-}
-
-@container settings-page (width <= 500px) {
-  .settingsMenu.mobileSettingsMenu {
-    font-size: 25px;
-
-    .titleIcon {
-      inline-size: 25px;
-      block-size: 25px;
-      margin-inline-end: 5px;
-    }
-
-    .header {
-      font-size: 25px;
-    }
-  }
+.settingsMenu.mobileSettingsMenu .title {
+  flex-basis: 48px;
 }

--- a/src/renderer/components/FtSettingsMenu/FtSettingsMenu.css
+++ b/src/renderer/components/FtSettingsMenu/FtSettingsMenu.css
@@ -6,12 +6,17 @@
   box-sizing: border-box;
   padding: 10px;
   margin: 0;
+  list-style: none;
   background: var(--side-nav-color);
 }
 
-.title {
+.titleItem {
   flex: 1 0 42px;
   min-block-size: 42px;
+  display: flex;
+}
+
+.title {
   inline-size: 100%;
   box-sizing: border-box;
   display: flex;
@@ -38,7 +43,7 @@
   font-weight: 600;
 }
 
-.settingsMenu.filtered .title {
+.settingsMenu.filtered .titleItem {
   flex-grow: 0;
 }
 
@@ -76,6 +81,6 @@
   padding: 12px;
 }
 
-.settingsMenu.mobileSettingsMenu .title {
+.settingsMenu.mobileSettingsMenu .titleItem {
   flex-basis: 48px;
 }

--- a/src/renderer/components/FtSettingsMenu/FtSettingsMenu.vue
+++ b/src/renderer/components/FtSettingsMenu/FtSettingsMenu.vue
@@ -3,33 +3,38 @@
     class="settingsMenu"
     :class="{ filtered }"
   >
-    <button
+    <li
       v-for="settingsSection in settingsSections"
-      ref="linkRefs"
       :key="settingsSection.type"
-      class="title"
-      :class="{ active: activeSection === settingsSection.type }"
-      type="button"
-      :data-section="settingsSection.type"
-      @click.stop="goToSettingsSection"
+      class="titleItem"
     >
-      <div class="titleContent">
-        <div class="iconAndTitleText">
-          <FontAwesomeIcon
-            :icon="settingsSection.icon"
-            class="titleIcon"
-          />
-          {{ settingsSection.title }}
+      <button
+        ref="linkRefs"
+        class="title"
+        :class="{ active: activeSection === settingsSection.type }"
+        type="button"
+        :data-section="settingsSection.type"
+        @click.stop="goToSettingsSection"
+      >
+        <div class="titleContent">
+          <div class="iconAndTitleText">
+            <FontAwesomeIcon
+              :icon="settingsSection.icon"
+              class="titleIcon"
+            />
+            {{ settingsSection.title }}
+          </div>
+          <div class="titleUnderline" />
         </div>
-        <div class="titleUnderline" />
-      </div>
-    </button>
-    <p
+      </button>
+    </li>
+    <li
       v-if="settingsSections.length === 0 && emptyMessage"
-      class="emptyMessage"
     >
-      {{ emptyMessage }}
-    </p>
+      <p class="emptyMessage">
+        {{ emptyMessage }}
+      </p>
+    </li>
   </menu>
 </template>
 
@@ -72,7 +77,7 @@ defineExpose({
    * @param {string} name
    */
   focusLink: (name) => {
-    linkRefs.value.find((link) => link.dataset.section === name)?.focus()
+    linkRefs.value?.find((link) => link.dataset.section === name)?.focus()
   }
 })
 </script>

--- a/src/renderer/components/FtSettingsMenu/FtSettingsMenu.vue
+++ b/src/renderer/components/FtSettingsMenu/FtSettingsMenu.vue
@@ -1,24 +1,17 @@
 <template>
   <menu
     class="settingsMenu"
+    :class="{ filtered }"
   >
-    <h2 class="header">
-      <FontAwesomeIcon
-        :icon="['fas', 'sliders-h']"
-        class="headingIcon"
-      />
-      {{ $t('Settings.Settings') }}
-    </h2>
-    <a
+    <button
       v-for="settingsSection in settingsSections"
       ref="linkRefs"
       :key="settingsSection.type"
       class="title"
       :class="{ active: activeSection === settingsSection.type }"
-      href="javascript:;"
+      type="button"
       :data-section="settingsSection.type"
       @click.stop="goToSettingsSection"
-      @keydown.enter.stop="goToSettingsSection"
     >
       <div class="titleContent">
         <div class="iconAndTitleText">
@@ -30,7 +23,13 @@
         </div>
         <div class="titleUnderline" />
       </div>
-    </a>
+    </button>
+    <p
+      v-if="settingsSections.length === 0 && emptyMessage"
+      class="emptyMessage"
+    >
+      {{ emptyMessage }}
+    </p>
   </menu>
 </template>
 
@@ -46,6 +45,14 @@ defineProps({
   activeSection: {
     type: String,
     default: null
+  },
+  emptyMessage: {
+    type: String,
+    default: ''
+  },
+  filtered: {
+    type: Boolean,
+    default: false
   }
 })
 

--- a/src/renderer/components/FtSettingsSection/FtSettingsSection.scss
+++ b/src/renderer/components/FtSettingsSection/FtSettingsSection.scss
@@ -1,7 +1,7 @@
 .settingsSection {
   margin-block: 0;
 
-  @container settings-page (width <= 800px) {
+  @container settings-content (width <= 800px) {
     inline-size: 100%;
   }
 }
@@ -25,7 +25,7 @@
   }
 
   > :deep(div:not(:last-child, .ft-flex-box)) {
-    @container settings-page (width <= 800px) {
+    @container settings-content (width <= 800px) {
       margin-block-end: 20px;
     }
   }
@@ -48,7 +48,7 @@
   grid-template-columns: auto auto;
   justify-content: space-evenly;
 
-  @container settings-page (width <= 680px) {
+  @container settings-content (width <= 680px) {
     grid-template-columns: auto;
   }
 }
@@ -73,19 +73,19 @@
   text-align: center;
 }
 
-@container settings-page (width <= 460px) {
+@container settings-content (width <= 460px) {
   :deep(.settingsFlexStart460px) {
     justify-content: flex-start;
   }
 }
 
-@container settings-page (width <= 500px) {
+@container settings-content (width <= 500px) {
   :deep(.settingsFlexStart500px) {
     justify-content: flex-start;
   }
 }
 
-@container settings-page (width <= 680px) {
+@container settings-content (width <= 680px) {
   .settingsSection {
     > :deep(div .text.bottom) {
       inset-inline-start: -85px;

--- a/src/renderer/components/FtSettingsSubpage/FtSettingsSubpage.vue
+++ b/src/renderer/components/FtSettingsSubpage/FtSettingsSubpage.vue
@@ -1,0 +1,54 @@
+<template>
+  <Teleport
+    v-if="open"
+    :to="`#${settingsWindow.targetId}`"
+  >
+    <div class="settingsSubpageContent">
+      <slot />
+    </div>
+  </Teleport>
+</template>
+
+<script setup>
+import { inject, onBeforeUnmount, watch } from 'vue'
+
+import { settingsSubpageKey } from './settingsSubpage'
+
+const props = defineProps({
+  open: {
+    type: Boolean,
+    required: true
+  },
+  title: {
+    type: String,
+    required: true
+  }
+})
+
+const emit = defineEmits(['close'])
+const settingsWindow = inject(settingsSubpageKey)
+
+function close() {
+  emit('close')
+}
+
+watch(() => [props.open, props.title], ([open, title]) => {
+  if (open) {
+    settingsWindow.open(title, close)
+  } else {
+    settingsWindow.close(close)
+  }
+}, { immediate: true })
+
+onBeforeUnmount(() => settingsWindow.close(close))
+</script>
+
+<style scoped>
+.settingsSubpageContent {
+  min-block-size: 100%;
+  block-size: 100%;
+  box-sizing: border-box;
+  display: flex;
+  flex-direction: column;
+}
+</style>

--- a/src/renderer/components/FtSettingsSubpage/settingsSubpage.js
+++ b/src/renderer/components/FtSettingsSubpage/settingsSubpage.js
@@ -1,0 +1,1 @@
+export const settingsSubpageKey = Symbol('settingsSubpage')

--- a/src/renderer/components/FtTooltip/FtTooltip.css
+++ b/src/renderer/components/FtTooltip/FtTooltip.css
@@ -23,7 +23,7 @@
   text-align: center;
   transition-duration: 275ms;
   transition-property: transform;
-  visibility: hidden;
+  display: none;
   z-index: 2;
 }
 
@@ -64,7 +64,7 @@
 
 .button:focus + .text,
 .button:hover + .text {
-  visibility: visible;
+  display: block;
 }
 
 .button:focus + .text.bottom,

--- a/src/renderer/components/FtTooltip/FtTooltip.css
+++ b/src/renderer/components/FtTooltip/FtTooltip.css
@@ -73,14 +73,14 @@
 .button:hover + .text.bottom-left,
 .button:focus + .text.top,
 .button:hover + .text.top {
-  transform: translate(calc(-50% * var(--horizontal-directionality-coefficient) + var(--ft-tooltip-shift-x, 0px)), 0);
+  transform: translate(calc(-50% * var(--horizontal-directionality-coefficient) + var(--ft-tooltip-shift-x, 0px)), var(--ft-tooltip-shift-y, 0));
 }
 
 .button:focus + .text.left,
 .button:hover + .text.left,
 .button:focus + .text.right,
 .button:hover + .text.right {
-  transform: translate(var(--ft-tooltip-shift-x, 0), -50%);
+  transform: translate(var(--ft-tooltip-shift-x, 0), calc(-50% + var(--ft-tooltip-shift-y, 0)));
 }
 
 .text.allowNewlines {

--- a/src/renderer/components/FtTooltip/FtTooltip.vue
+++ b/src/renderer/components/FtTooltip/FtTooltip.vue
@@ -32,36 +32,45 @@ import { useId, useTemplateRef } from 'vue'
 
 const textRef = useTemplateRef('textRef')
 
-// Keep the tooltip inside whatever would otherwise cut it off horizontally. It
+// Keep the tooltip inside whatever would otherwise cut it off. It
 // is positioned purely with CSS relative to its icon, so an icon near the start
 // of a clipping container (the settings page clips with `overflow-x: hidden`)
-// left part of the tooltip unreachable. We compute its shown horizontal extent
-// and offset it back into view via a CSS variable.
-// `offsetLeft`/`offsetWidth` are used because, unlike `getBoundingClientRect()`,
+// can leave part of the tooltip unreachable. We compute its shown extent and
+// offset it back into view via CSS variables.
+// Offset geometry is used because, unlike `getBoundingClientRect()`,
 // they are unaffected by the CSS transform (and its transition), so the shown
 // fade/slide animation is preserved.
 const EDGE_MARGIN = 8
 
 /**
- * The horizontal bounds the tooltip has to stay within: the nearest ancestor
- * that clips horizontally, falling back to the viewport.
+ * The bounds the tooltip has to stay within, intersecting the viewport with
+ * every ancestor that clips either axis.
  *
  * @param {HTMLElement} el
- * @returns {{ min: number, max: number }}
+ * @returns {{ left: number, right: number, top: number, bottom: number }}
  */
-function getHorizontalBounds(el) {
+function getClippingBounds(el) {
+  const bounds = {
+    left: 0,
+    right: window.innerWidth,
+    top: 0,
+    bottom: window.innerHeight
+  }
   for (let node = el.parentElement; node != null; node = node.parentElement) {
-    const overflowX = getComputedStyle(node).overflowX
-    if (overflowX !== 'visible') {
+    const style = getComputedStyle(node)
+    if (style.overflowX !== 'visible' || style.overflowY !== 'visible') {
       const rect = node.getBoundingClientRect()
-      return {
-        min: Math.max(0, rect.left),
-        max: Math.min(window.innerWidth, rect.right)
+      if (style.overflowX !== 'visible') {
+        bounds.left = Math.max(bounds.left, rect.left)
+        bounds.right = Math.min(bounds.right, rect.right)
+      }
+      if (style.overflowY !== 'visible') {
+        bounds.top = Math.max(bounds.top, rect.top)
+        bounds.bottom = Math.min(bounds.bottom, rect.bottom)
       }
     }
   }
-
-  return { min: 0, max: window.innerWidth }
+  return bounds
 }
 
 function clampToViewport() {
@@ -73,9 +82,11 @@ function clampToViewport() {
 
   // Measure the unshifted position, so repeated hovers don't compound the shift.
   el.style.setProperty('--ft-tooltip-shift-x', '0px')
+  el.style.setProperty('--ft-tooltip-shift-y', '0px')
 
   const width = el.offsetWidth
-  const parentLeft = offsetParent.getBoundingClientRect().left
+  const height = el.offsetHeight
+  const parentRect = offsetParent.getBoundingClientRect()
   const dir = getComputedStyle(el).direction === 'rtl' ? -1 : 1
 
   // The visible transform's static horizontal translate: centered variants shift
@@ -84,19 +95,29 @@ function clampToViewport() {
     el.classList.contains('bottom-left') ||
     el.classList.contains('top')
   const staticTranslateX = centered ? -0.5 * width * dir : 0
+  const staticTranslateY = centered ? 0 : -0.5 * height
 
-  const left = parentLeft + el.offsetLeft + staticTranslateX
+  const left = parentRect.left + el.offsetLeft + staticTranslateX
   const right = left + width
-  const { min, max } = getHorizontalBounds(el)
+  const top = parentRect.top + el.offsetTop + staticTranslateY
+  const bottom = top + height
+  const bounds = getClippingBounds(el)
 
-  let shift = 0
-  if (left < min + EDGE_MARGIN) {
-    shift = Math.ceil(min + EDGE_MARGIN - left)
-  } else if (right > max - EDGE_MARGIN) {
-    shift = Math.floor(max - EDGE_MARGIN - right)
+  let shiftX = 0
+  let shiftY = 0
+  if (left < bounds.left + EDGE_MARGIN) {
+    shiftX = Math.ceil(bounds.left + EDGE_MARGIN - left)
+  } else if (right > bounds.right - EDGE_MARGIN) {
+    shiftX = Math.floor(bounds.right - EDGE_MARGIN - right)
+  }
+  if (top < bounds.top + EDGE_MARGIN) {
+    shiftY = Math.ceil(bounds.top + EDGE_MARGIN - top)
+  } else if (bottom > bounds.bottom - EDGE_MARGIN) {
+    shiftY = Math.floor(bounds.bottom - EDGE_MARGIN - bottom)
   }
 
-  el.style.setProperty('--ft-tooltip-shift-x', `${shift}px`)
+  el.style.setProperty('--ft-tooltip-shift-x', `${shiftX}px`)
+  el.style.setProperty('--ft-tooltip-shift-y', `${shiftY}px`)
 }
 
 defineProps({

--- a/src/renderer/components/GeneralSettings/GeneralSettings.vue
+++ b/src/renderer/components/GeneralSettings/GeneralSettings.vue
@@ -262,7 +262,7 @@
 </template>
 
 <script setup>
-import { computed, onMounted, onBeforeUnmount, ref } from 'vue'
+import { computed, onBeforeUnmount } from 'vue'
 import { useI18n } from 'vue-i18n'
 import { useRouter } from 'vue-router'
 
@@ -279,6 +279,7 @@ import { localeTranslationPercentages } from '../../i18n/index'
 import allLocales from '../../../../static/locales/activeLocales.json'
 import { debounce, randomArrayItem, showToast } from '../../helpers/utils'
 import { translateWindowTitle } from '../../helpers/strings'
+import { initializePlatformInfo, isLinuxWayland } from '../../helpers/platform'
 
 const USING_ELECTRON = !!process.env.IS_ELECTRON
 const SUPPORTS_LOCAL_API = !!process.env.SUPPORTS_LOCAL_API
@@ -303,14 +304,9 @@ function updateVideoPlaybackEngine(value) {
   store.dispatch('updateVideoPlaybackEngine', value)
 }
 
-// The 'minimize' event doesn't fire on wayland
-// https://github.com/electron/electron/issues/51766
-const isLinuxWayland = ref(false)
-if (process.env.IS_ELECTRON && process.platform === 'linux') {
-  onMounted(async () => {
-    isLinuxWayland.value = await window.ftElectron.isWaylandPlatform()
-  })
-}
+// The 'minimize' event doesn't fire on Wayland. This shared check starts during
+// app initialization, before settings can mount, and is cached for every view.
+initializePlatformInfo()
 
 /** @type {import('vue').ComputedRef<boolean>} */
 const checkForUpdates = computed(() => store.getters.getCheckForUpdates)
@@ -436,7 +432,6 @@ const INCLUDED_DEFAULT_PAGE_NAMES = [
   'popular',
   'userPlaylists',
   'history',
-  'settings',
   ...(process.env.SUPPORTS_LOCAL_API ? ['trending'] : [])
 ]
 
@@ -465,11 +460,11 @@ const defaultPageValues = computed(() => {
   return defaultPages.value.map((route) => route.path.slice(1))
 })
 
-/** @type {import('vue').ComputedRef<'subscriptions' | 'subscribedChannels' | 'popular' | 'userPlaylists' | 'history' | 'settings' | 'trending'>} */
+/** @type {import('vue').ComputedRef<'subscriptions' | 'subscribedChannels' | 'popular' | 'userPlaylists' | 'history' | 'trending'>} */
 const landingPage = computed(() => store.getters.getLandingPage)
 
 /**
- * @param {'subscriptions' | 'subscribedChannels' | 'popular' | 'userPlaylists' | 'history' | 'settings' | 'trending'} value
+ * @param {'subscriptions' | 'subscribedChannels' | 'popular' | 'userPlaylists' | 'history' | 'trending'} value
  */
 function updateLandingPage(value) {
   store.dispatch('updateLandingPage', value)

--- a/src/renderer/components/PasswordDialog/PasswordDialog.css
+++ b/src/renderer/components/PasswordDialog/PasswordDialog.css
@@ -1,9 +1,26 @@
 .card {
-  inline-size: 85%;
-  margin: auto;
+  inline-size: min(100%, 420px);
   box-sizing: border-box;
+  padding: 28px;
 }
 
 .passwordInput {
   inline-size: 100%;
+}
+
+.passwordInput.invalid :deep(.ft-input) {
+  outline: 2px solid var(--red-500);
+  outline-offset: 2px;
+}
+
+.passwordError {
+  margin-block: 8px 0;
+  color: var(--red-500);
+  font-size: 0.9rem;
+}
+
+.unlockButton {
+  justify-self: center;
+  margin-block: 18px 0;
+  margin-inline: auto;
 }

--- a/src/renderer/components/PasswordDialog/PasswordDialog.vue
+++ b/src/renderer/components/PasswordDialog/PasswordDialog.vue
@@ -10,16 +10,35 @@
       :show-action-button="false"
       input-type="password"
       class="passwordInput"
+      :class="{ invalid: invalidPassword }"
+      :value="passwordValue"
+      @input="handlePasswordChange"
+      @keydown.enter="handlePasswordInput"
+    />
+    <p
+      v-if="invalidPassword"
+      class="passwordError"
+      role="alert"
+    >
+      {{ $t('Settings.Password Dialog.Incorrect Password') }}
+    </p>
+    <FtButton
+      class="unlockButton"
+      :label="verifying
+        ? $t('Settings.Password Dialog.Unlocking')
+        : $t('Settings.Password Dialog.Unlock')"
+      :disabled="passwordValue === '' || verifying"
       @click="handlePasswordInput"
     />
   </FtCard>
 </template>
 
 <script setup>
-import { computed, onMounted, useTemplateRef } from 'vue'
+import { computed, onMounted, ref, useTemplateRef } from 'vue'
 
 import FtCard from '../ft-card/ft-card.vue'
 import FtInput from '../FtInput/FtInput.vue'
+import FtButton from '../FtButton/FtButton.vue'
 
 import store from '../../store/index'
 import { isHashedPassword, verifyPassword } from '../../helpers/passwords'
@@ -27,6 +46,9 @@ import { isHashedPassword, verifyPassword } from '../../helpers/passwords'
 const emit = defineEmits(['unlocked'])
 
 const password = useTemplateRef('password')
+const passwordValue = ref('')
+const invalidPassword = ref(false)
+const verifying = ref(false)
 
 onMounted(() => {
   password.value.focus()
@@ -36,14 +58,30 @@ const settingsPassword = computed(() => {
   return store.getters.getSettingsPassword
 })
 
-async function handlePasswordInput(input) {
-  if (await verifyPassword(input, settingsPassword.value)) {
-    if (!isHashedPassword(settingsPassword.value)) {
-      store.dispatch('updateSettingsPassword', input)
-    }
+async function handlePasswordInput() {
+  if (verifying.value || passwordValue.value === '') return
+  invalidPassword.value = false
+  verifying.value = true
 
-    emit('unlocked')
+  try {
+    if (await verifyPassword(passwordValue.value, settingsPassword.value)) {
+      if (!isHashedPassword(settingsPassword.value)) {
+        store.dispatch('updateSettingsPassword', passwordValue.value)
+      }
+
+      emit('unlocked')
+    } else {
+      invalidPassword.value = true
+      password.value.select()
+    }
+  } finally {
+    verifying.value = false
   }
+}
+
+function handlePasswordChange(value) {
+  passwordValue.value = value
+  invalidPassword.value = false
 }
 </script>
 

--- a/src/renderer/components/PlayerSettings/PlayerSettings.vue
+++ b/src/renderer/components/PlayerSettings/PlayerSettings.vue
@@ -389,11 +389,10 @@
       </FtFlexBox>
       <br>
     </div>
-    <FtPrompt
-      v-if="showQuickPlaybackSpeedBarManager"
-      :label="t('Settings.Player Settings.Quick Playback Speed Bar Manager')"
-      theme="readable-width"
-      @click="handleQuickPlaybackSpeedBarManagerClick"
+    <FtSettingsSubpage
+      :open="showQuickPlaybackSpeedBarManager"
+      :title="t('Settings.Player Settings.Quick Playback Speed Bar Manager')"
+      @close="showQuickPlaybackSpeedBarManager = false"
     >
       <div class="quickPlaybackSpeedList">
         <div
@@ -492,12 +491,8 @@
           :icon="['fas', 'undo']"
           @click="resetQuickPlaybackSpeedBarOptions"
         />
-        <FtButton
-          :label="t('Close')"
-          @click="showQuickPlaybackSpeedBarManager = false"
-        />
       </FtFlexBox>
-    </FtPrompt>
+    </FtSettingsSubpage>
   </FtSettingsSection>
 </template>
 
@@ -516,9 +511,10 @@ import FtButton from '../FtButton/FtButton.vue'
 import FtSyncedSettingIndicator from '../FtSyncedSettingIndicator/FtSyncedSettingIndicator.vue'
 import FtInput from '../FtInput/FtInput.vue'
 import FtTooltip from '../FtTooltip/FtTooltip.vue'
-import FtPrompt from '../FtPrompt/FtPrompt.vue'
+import FtSettingsSubpage from '../FtSettingsSubpage/FtSettingsSubpage.vue'
 
 import store from '../../store/index'
+import { initializePlatformInfo, isLinuxWayland } from '../../helpers/platform'
 
 const { t } = useI18n()
 
@@ -816,12 +812,7 @@ const AUTO_PIP_TRIGGER_VALUES = ['tab', 'minimize', 'blur']
 
 // The 'minimize' window event doesn't fire on Wayland, so the minimize trigger can't work there.
 // https://github.com/electron/electron/issues/51766
-const isLinuxWayland = ref(false)
-if (process.env.IS_ELECTRON && process.platform === 'linux') {
-  onMounted(async () => {
-    isLinuxWayland.value = await window.ftElectron.isWaylandPlatform()
-  })
-}
+initializePlatformInfo()
 
 const autoPictureInPictureTriggerLabels = computed(() => [
   t('Settings.Player Settings.Auto Picture in Picture.On Tab Change'),
@@ -1016,15 +1007,6 @@ const quickPlaybackSpeedBarOptions = computed(() => store.getters.getQuickPlayba
 const quickPlaybackSpeedBarEntries = computed(() => {
   return parseQuickPlaybackSpeedBarOptions(quickPlaybackSpeedBarOptions.value)
 })
-
-/**
- * @param {string | null} value
- */
-function handleQuickPlaybackSpeedBarManagerClick(value) {
-  if (value === null) {
-    showQuickPlaybackSpeedBarManager.value = false
-  }
-}
 
 /**
  * @param {string} value

--- a/src/renderer/components/ProxySettings/ProxySettings.vue
+++ b/src/renderer/components/ProxySettings/ProxySettings.vue
@@ -138,6 +138,7 @@ import FtLoader from '../FtLoader/FtLoader.vue'
 import FtFlexBox from '../ft-flex-box/ft-flex-box.vue'
 
 import store from '../../store/index'
+import { getProxyTestUrl } from '../../helpers/proxy-test'
 
 import { debounce, showToast } from '../../helpers/utils'
 
@@ -203,24 +204,7 @@ const proxyUrl = computed(() => {
   return `${proxyProtocol.value}://${proxyHostname.value}:${proxyPort.value}`
 })
 
-// locales found here: https://ipwhois.io/documentation
-const SUPPORTED_LANGS = ['en', 'ru', 'de', 'es', 'pt-BR', 'fr', 'zh-CN', 'ja']
-
-const localeToUse = computed(() => {
-  const freeTubeLang = locale.value
-
-  return SUPPORTED_LANGS.find(lang => freeTubeLang === lang) ?? SUPPORTED_LANGS.find(lang => freeTubeLang.slice(0, 2) === lang.slice(0, 2))
-})
-
-const proxyTestUrl = computed(() => {
-  let proxyTestUrl = 'https://ipwho.is/?output=json&fields=ip,country,city,region'
-
-  if (localeToUse.value) {
-    proxyTestUrl += `&lang=${localeToUse.value}`
-  }
-
-  return proxyTestUrl
-})
+const proxyTestUrl = computed(() => getProxyTestUrl(locale.value))
 
 /** @type {import('vue').ComputedRef<boolean>} */
 const areCredentialsSupported = computed(() => {

--- a/src/renderer/components/SideNav/SideNav.css
+++ b/src/renderer/components/SideNav/SideNav.css
@@ -61,6 +61,15 @@
   -webkit-user-drag: none;
 }
 
+.navOptionButton {
+  inline-size: 100%;
+  border: 0;
+  background: transparent;
+  font: inherit;
+  text-align: inherit;
+  cursor: pointer;
+}
+
 .channelLink {
   display: block;
   color: inherit;

--- a/src/renderer/components/SideNav/SideNav.vue
+++ b/src/renderer/components/SideNav/SideNav.vue
@@ -165,11 +165,11 @@
         </p>
       </router-link>
       <hr>
-      <router-link
-        class="navOption mobileShow smallMobileOnlyHidden"
-        role="button"
-        to="/settings"
+      <button
+        type="button"
+        class="navOption navOptionButton mobileShow smallMobileOnlyHidden"
         :title="settingsTitle"
+        @click="openSettings"
       >
         <div
           class="thumbnailContainer"
@@ -185,7 +185,7 @@
         >
           {{ $t('Settings.Settings') }}
         </p>
-      </router-link>
+      </button>
       <router-link
         class="navOption mobileHidden"
         role="button"
@@ -282,6 +282,10 @@ const appKeyboardShortcuts = computed(() => getConfiguredKeyboardShortcuts(
 
 const SUPPORTS_LOCAL_API = process.env.SUPPORTS_LOCAL_API
 const activeSubscriptionsPerPage = 50
+
+function openSettings() {
+  store.dispatch('toggleSettingsWindow')
+}
 
 const props = defineProps({
   forceExpanded: {

--- a/src/renderer/components/SideNavMoreOptions/SideNavMoreOptions.css
+++ b/src/renderer/components/SideNavMoreOptions/SideNavMoreOptions.css
@@ -11,6 +11,14 @@
   display: block;
 }
 
+.navOptionButton {
+  inline-size: 100%;
+  border: 0;
+  background: transparent;
+  font: inherit;
+  text-align: inherit;
+}
+
 .navOption:hover {
   background-color: var(--side-nav-hover-color);
   color: var(--side-nav-hover-text-color);

--- a/src/renderer/components/SideNavMoreOptions/SideNavMoreOptions.vue
+++ b/src/renderer/components/SideNavMoreOptions/SideNavMoreOptions.vue
@@ -135,12 +135,12 @@
           {{ $t('Stats.Stats') }}
         </p>
       </router-link>
-      <router-link
-        class="navOption smallMobileOnlyShow"
+      <button
+        type="button"
+        class="navOption navOptionButton smallMobileOnlyShow"
         :title="$t('Settings.Settings')"
         :aria-label="hideLabelsSideBar ? $t('Settings.Settings') : null"
-        to="/settings"
-        @click="closeMenu"
+        @click="openSettings"
       >
         <FontAwesomeIcon
           :icon="['fas', 'sliders-h']"
@@ -153,10 +153,10 @@
         >
           {{ $t("Settings.Settings") }}
         </p>
-      </router-link>
+      </button>
     </div>
     <router-link
-      class="navOption mobileShow"
+      class="navOption navOptionButton mobileShow"
       :title="$t('History.History')"
       :aria-label="hideLabelsSideBar ? $t('History.History'): null"
       to="/history"
@@ -174,11 +174,12 @@
       </p>
     </router-link>
     <hr>
-    <router-link
+    <button
+      type="button"
       class="navOption mobileShow"
       :title="$t('Settings.Settings')"
       :aria-label="hideLabelsSideBar ? $t('Settings.Settings') : null"
-      to="/settings"
+      @click="openSettings"
     >
       <FontAwesomeIcon
         :icon="['fas', 'sliders-h']"
@@ -191,7 +192,7 @@
       >
         {{ $t("Settings.Settings") }}
       </p>
-    </router-link>
+    </button>
     <router-link
       class="navOption mobileHidden"
       :title="$t('About.About')"
@@ -256,6 +257,11 @@ const applyNavIconExpand = computed(() => {
 
 function closeMenu() {
   openMoreOptions.value = false
+}
+
+function openSettings() {
+  store.dispatch('toggleSettingsWindow')
+  closeMenu()
 }
 
 function handleClickOutside(event) {

--- a/src/renderer/components/SideNavMoreOptions/SideNavMoreOptions.vue
+++ b/src/renderer/components/SideNavMoreOptions/SideNavMoreOptions.vue
@@ -176,7 +176,7 @@
     <hr>
     <button
       type="button"
-      class="navOption mobileShow"
+      class="navOption navOptionButton mobileShow"
       :title="$t('Settings.Settings')"
       :aria-label="hideLabelsSideBar ? $t('Settings.Settings') : null"
       @click="openSettings"

--- a/src/renderer/components/SubscriptionsTabUi/SubscriptionsTabUi.vue
+++ b/src/renderer/components/SubscriptionsTabUi/SubscriptionsTabUi.vue
@@ -283,7 +283,7 @@ function keyboardShortcutHandler(event) {
   }
   const target = event.target
   if (target instanceof HTMLElement && (
-    target.matches('input, textarea') || target.isContentEditable
+    target.matches('input, textarea, select') || target.isContentEditable
   )) {
     return
   }

--- a/src/renderer/components/SubscriptionsTabUi/SubscriptionsTabUi.vue
+++ b/src/renderer/components/SubscriptionsTabUi/SubscriptionsTabUi.vue
@@ -281,7 +281,10 @@ function keyboardShortcutHandler(event) {
   if (isTabPresented && !isTabPresented.value) {
     return
   }
-  if (document.activeElement.classList.contains('ft-input')) {
+  const target = event.target
+  if (target instanceof HTMLElement && (
+    target.matches('input, textarea') || target.isContentEditable
+  )) {
     return
   }
   // Avoid handling events due to user holding a key (not released)

--- a/src/renderer/components/TabContent/TabContent.vue
+++ b/src/renderer/components/TabContent/TabContent.vue
@@ -8,8 +8,8 @@
     :aria-hidden="String(!isPresented)"
   >
     <KeepAlive
-      include="SettingsRoute,AboutRoute"
-      :max="2"
+      include="AboutRoute"
+      :max="1"
     >
       <component
         :is="resolvedComponent"
@@ -45,7 +45,7 @@ import { tabIdKey, tabLifecycleKey, tabPresentedKey } from '../../tabs/TabContex
 
 const TAB_LOADER_SELECTOR = '[data-tab-loading-indicator]'
 const TAB_LOADER_LOADING_SOURCE = 'loader'
-const CACHED_ROUTE_NAMES = new Set(['about', 'settings'])
+const CACHED_ROUTE_NAMES = new Set(['about'])
 
 const props = defineProps({
   tab: {

--- a/src/renderer/components/TopNav/TopNav.vue
+++ b/src/renderer/components/TopNav/TopNav.vue
@@ -77,6 +77,18 @@
             :icon="tabLayoutIcon"
           />
         </button>
+        <button
+          type="button"
+          class="navSettingsButton navButton"
+          :aria-label="t('Settings.Settings')"
+          :title="t('Settings.Settings')"
+          @click="openSettings"
+        >
+          <FontAwesomeIcon
+            class="navIcon"
+            :icon="['fas', 'sliders-h']"
+          />
+        </button>
         <RouterLink
           v-if="!hideHeaderLogo"
           class="logo"
@@ -196,6 +208,10 @@ const barColor = computed(() => store.getters.getBarColor)
 const showThumbnailSizeControl = computed(() => {
   return route.meta.hasResizableThumbnails === true && store.getters.getShowThumbnailSizeButtonInHeader
 })
+
+function openSettings() {
+  store.dispatch('toggleSettingsWindow')
+}
 
 const expandCollapseSideBarLabel = computed(() => {
   return store.getters.getIsSideNavOpen ? t('Compact side navigation') : t('Expand side navigation')

--- a/src/renderer/helpers/overlayScrollbars.js
+++ b/src/renderer/helpers/overlayScrollbars.js
@@ -272,6 +272,27 @@ export function restoreOverlayScrollTop(element, scrollTop) {
 }
 
 /**
+ * Recalculates a nested scroll container's range and clamps an offset that was
+ * valid before dynamically rendered content became shorter.
+ *
+ * @param {HTMLElement} element
+ * @param {HTMLElement | null} contentElement the element whose rendered end defines the real scroll range
+ */
+export function clampOverlayScrollTop(element, contentElement = null) {
+  const instance = OverlayScrollbars(element)
+  instance?.update(true)
+  const contentEnd = contentElement === null
+    ? element.scrollHeight
+    : contentElement.offsetTop + contentElement.offsetHeight +
+      Number.parseFloat(getComputedStyle(element).paddingBottom)
+  const maximumScrollTop = Math.max(0, contentEnd - element.clientHeight)
+  if (element.scrollTop > maximumScrollTop) {
+    element.scrollTop = maximumScrollTop
+    instance?.update(true)
+  }
+}
+
+/**
  * `v-overlay-scrollbars` - does the same for a nested scroll container.
  * Pass `false` to leave the native scrollbars alone, for containers that only
  * scroll in some layouts.

--- a/src/renderer/helpers/platform.js
+++ b/src/renderer/helpers/platform.js
@@ -1,0 +1,25 @@
+import { readonly, ref } from 'vue'
+
+const linuxWayland = ref(false)
+let platformInfoPromise = null
+
+export const isLinuxWayland = readonly(linuxWayland)
+
+/** Resolve renderer platform details once and share them across every settings view. */
+export function initializePlatformInfo() {
+  if (platformInfoPromise !== null) return platformInfoPromise
+
+  if (!process.env.IS_ELECTRON || process.platform !== 'linux') {
+    platformInfoPromise = Promise.resolve()
+    return platformInfoPromise
+  }
+
+  platformInfoPromise = window.ftElectron.isWaylandPlatform()
+    .then(value => {
+      linuxWayland.value = value
+    })
+    .catch(error => {
+      console.error('Failed to determine whether Electron is using Wayland', error)
+    })
+  return platformInfoPromise
+}

--- a/src/renderer/helpers/proxy-test.js
+++ b/src/renderer/helpers/proxy-test.js
@@ -1,0 +1,9 @@
+const PROXY_TEST_BASE_URL = 'https://ipwho.is/?output=json&fields=ip,country,city,region'
+const PROXY_TEST_SUPPORTED_LANGS = ['en', 'ru', 'de', 'es', 'pt-BR', 'fr', 'zh-CN', 'ja']
+
+/** @param {string} locale */
+export function getProxyTestUrl(locale) {
+  const language = PROXY_TEST_SUPPORTED_LANGS.find(candidate => locale === candidate) ??
+    PROXY_TEST_SUPPORTED_LANGS.find(candidate => locale.slice(0, 2) === candidate.slice(0, 2))
+  return language === undefined ? PROXY_TEST_BASE_URL : `${PROXY_TEST_BASE_URL}&lang=${language}`
+}

--- a/src/renderer/helpers/settings-search-config.js
+++ b/src/renderer/helpers/settings-search-config.js
@@ -1,0 +1,64 @@
+export const SETTINGS_SEARCH_KEYS = {
+  general: 'Settings.General Settings',
+  theme: 'Settings.Theme Settings',
+  player: 'Settings.Player Settings',
+  channel: 'Settings.Channel Settings',
+  'caption-appearance': 'Settings.Player Settings.Caption Appearance',
+  'external-player': 'Settings.External Player Settings',
+  download: 'Settings.Download Settings',
+  'external-software': 'Settings.External Software Settings',
+  subscription: 'Settings.Subscription Settings',
+  distraction: 'Settings.Distraction Free Settings',
+  'parental-control': 'Settings.Parental Control Settings',
+  privacy: 'Settings.Privacy Settings',
+  data: 'Settings.Data Settings',
+  sync: 'Settings.Sync Settings',
+  proxy: 'Settings.Proxy Settings',
+  'sponsor-block': 'Settings.SponsorBlock Settings',
+  'return-youtube-dislike': 'Settings.Return YouTube Dislike Settings',
+  'context-menu-search': 'Settings.Context Menu Search Settings',
+  password: 'Settings.Password Settings',
+  experimental: 'Settings.Experimental Settings'
+}
+
+export const SETTINGS_SEARCH_SELECT_GROUP_LABELS = {
+  general: {
+    'Stream Extraction Method': ['Stream Extraction Method'],
+    'New Tab Position': ['New Tab Position'],
+    'Tab Close Focus': ['Tab Close Focus'],
+    'Startup Behavior': ['Startup Behavior'],
+    'Reduced Motion': ['Reduced Motion'],
+    'Avoid translation': ['Avoid translation'],
+    'Preferred API Backend': ['Preferred API Backend'],
+    'Video View Type': ['Video View Type'],
+    'Thumbnail Preference': ['Thumbnail Preference'],
+    'Extra Thumbnail Action Button': ['Extra Thumbnail Action Button'],
+    'External Link Handling': ['External Link Handling']
+  },
+  theme: {
+    'Toast Position': ['Toast Position'],
+    'Base Theme': ['Base Theme'],
+    'Main Color Theme': ['Main Color Theme']
+  },
+  player: {
+    'Caption Appearance': [],
+    'Default Viewing Mode': ['Default Viewing Mode', 'Tooltip'],
+    'Auto Picture in Picture': ['Auto Picture in Picture', 'Wayland Minimize Unsupported'],
+    'Default Video Format': ['Default Video Format'],
+    'Default Quality': ['Default Quality'],
+    'Screenshot.Modes': []
+  },
+  'caption-appearance': {
+    Anchor: ['Anchor'],
+    'Edge Style': ['Edge Style']
+  },
+  'external-player': { Players: [] },
+  'external-software': { Sources: [] },
+  privacy: { 'Watched Progress Saving Mode.Modes': [] },
+  'sponsor-block': { 'Skip Options': ['Skip Option'] }
+}
+
+export const SETTINGS_SEARCH_EXCLUDED_MESSAGE_PATHS = {
+  general: new Set(['System Default']),
+  'caption-appearance': new Set(['Application Language'])
+}

--- a/src/renderer/router/index.js
+++ b/src/renderer/router/index.js
@@ -47,18 +47,17 @@ function createPreloadedRoute(name, loader) {
   }
 }
 
-const settingsRoute = createPreloadedRoute('SettingsRoute', () => import('../views/Settings/Settings.vue'))
+const settingsWindowRoute = createPreloadedRoute('SettingsWindowRoute', () => import('../views/Settings/Settings.vue'))
 const aboutRoute = createPreloadedRoute('AboutRoute', () => import('../views/About/About.vue'))
-const Settings = settingsRoute.component
+const SettingsRoute = defineAsyncComponent(() => import('../views/Settings/SettingsRoute.vue'))
 const About = aboutRoute.component
-const ProfileSettings = defineAsyncComponent(() => import('../views/ProfileSettings/ProfileSettings.vue'))
 const Stats = defineAsyncComponent(() => import('../views/Stats/Stats.vue'))
 
 // Keep Settings in its own chunk so its styles retain their established load
 // order, but allow the app to evaluate it before the UI can be interacted with.
 // Otherwise the first Settings navigation has to wait for this large chunk.
 export function preloadUtilityRoutes() {
-  return Promise.all([settingsRoute.preload(), aboutRoute.preload()])
+  return Promise.all([settingsWindowRoute.preload(), aboutRoute.preload()])
 }
 
 export const routes = [
@@ -140,7 +139,7 @@ export const routes = [
     meta: {
       title: getFixedInternalRouteTitle('/settings')
     },
-    component: Settings
+    component: SettingsRoute
   },
   {
     path: '/about',
@@ -156,7 +155,7 @@ export const routes = [
     meta: {
       title: getFixedInternalRouteTitle('/settings/profile')
     },
-    component: ProfileSettings
+    component: SettingsRoute
   },
   {
     path: '/search/:query',

--- a/src/renderer/store/modules/settings.js
+++ b/src/renderer/store/modules/settings.js
@@ -749,6 +749,10 @@ const customActions = {
         }
       }
 
+      if (state.landingPage === 'settings') {
+        await dispatch('updateLandingPage', 'subscriptions')
+      }
+
       const keyboardShortcutsEntry = userSettings.find(entry => entry._id === 'keyboardShortcuts')
       if (keyboardShortcutsEntry) {
         const sanitizedShortcuts = sanitizeKeyboardShortcutOverrides(keyboardShortcutsEntry.value)

--- a/src/renderer/store/modules/utils.js
+++ b/src/renderer/store/modules/utils.js
@@ -49,6 +49,8 @@ const state = {
   showAddToPlaylistPrompt: false,
   showCreatePlaylistPrompt: false,
   isKeyboardShortcutPromptShown: false,
+  settingsWindowOpen: false,
+  settingsWindowView: null,
   showSearchFilters: false,
   searchFilterValueChangedByTabId: {},
   progressBarPercentage: 0,
@@ -130,6 +132,14 @@ const getters = {
 
   getIsKeyboardShortcutPromptShown(state) {
     return state.isKeyboardShortcutPromptShown
+  },
+
+  getSettingsWindowOpen(state) {
+    return state.settingsWindowOpen
+  },
+
+  getSettingsWindowView(state) {
+    return state.settingsWindowView
   },
 
   getShowAddToPlaylistPrompt(state) {
@@ -332,10 +342,35 @@ const actions = {
 
   showKeyboardShortcutPrompt ({ commit }) {
     commit('setIsKeyboardShortcutPromptShown', true)
+    commit('setSettingsWindowOpen', true)
   },
 
   hideKeyboardShortcutPrompt ({ commit }) {
     commit('setIsKeyboardShortcutPromptShown', false)
+  },
+
+  showSettingsWindow ({ commit }, view = null) {
+    commit('setIsKeyboardShortcutPromptShown', false)
+    commit('setSettingsWindowView', view)
+    commit('setSettingsWindowOpen', true)
+  },
+
+  toggleSettingsWindow ({ state, commit }) {
+    const open = !state.settingsWindowOpen
+    commit('setIsKeyboardShortcutPromptShown', false)
+    commit('setSettingsWindowView', null)
+    commit('setSettingsWindowOpen', open)
+  },
+
+  hideSettingsWindow ({ commit }) {
+    commit('setIsKeyboardShortcutPromptShown', false)
+    commit('setSettingsWindowOpen', false)
+    commit('setSettingsWindowView', null)
+  },
+
+  showSettingsWindowRoot ({ commit }) {
+    commit('setIsKeyboardShortcutPromptShown', false)
+    commit('setSettingsWindowView', null)
   },
 
   showSearchFilters ({ commit }) {
@@ -770,6 +805,14 @@ const mutations = {
 
   setIsKeyboardShortcutPromptShown (state, payload) {
     state.isKeyboardShortcutPromptShown = payload
+  },
+
+  setSettingsWindowOpen (state, payload) {
+    state.settingsWindowOpen = payload
+  },
+
+  setSettingsWindowView (state, payload) {
+    state.settingsWindowView = payload
   },
 
   setShowSearchFilters (state, payload) {

--- a/src/renderer/views/Settings/Settings.css
+++ b/src/renderer/views/Settings/Settings.css
@@ -1,23 +1,345 @@
-.settingsPage {
-  container-name: settings-page;
+.settingsWindow {
+  position: fixed;
+  z-index: 9;
+  min-inline-size: min(360px, calc(100vw - 24px));
+  min-block-size: min(360px, calc(100vh - 24px));
+  max-inline-size: calc(100vw - 24px);
+  max-block-size: calc(100vh - 24px);
+  resize: none;
+  overflow: hidden;
+  flex: none;
+  margin: 0 !important;
+  box-sizing: border-box;
+  display: flex;
+  flex-direction: column;
+  color: var(--primary-text-color);
+  background: var(--card-bg-color);
+  border: 1px solid var(--tertiary-text-color);
+  border-radius: calc(10px * var(--ui-roundness));
+  box-shadow: 0 12px 40px rgb(0 0 0 / 38%);
+  container-name: settings-window;
   container-type: inline-size;
-  display: flex;
-  gap: 20px;
 }
 
-.settingsSections,
-.switchRow {
-  overflow-x: hidden;
-  max-inline-size: 90%;
+.settingsWindow.settings-window-enter-active,
+.settingsWindow.settings-window-leave-active {
+  transform-origin: center;
+  transition:
+    opacity 160ms ease,
+    transform 180ms cubic-bezier(0.2, 0.8, 0.2, 1);
 }
 
-.switchRow {
+.settingsWindow.settings-window-enter-from,
+.settingsWindow.settings-window-leave-to {
+  opacity: 0;
+  transform: translateY(8px) scale(0.98);
+}
+
+:global(:root[data-reduced-motion='reduce']) .settingsWindow.settings-window-enter-active,
+:global(:root[data-reduced-motion='reduce']) .settingsWindow.settings-window-leave-active {
+  transition: none;
+}
+
+.settingsWindowHeader {
+  flex: 0 0 auto;
+  min-block-size: 52px;
+  box-sizing: border-box;
   display: flex;
-  gap: 12px;
-  flex-wrap: wrap;
-  margin-inline-end: auto;
   align-items: center;
-  margin-block-end: 5px;
+  gap: 8px;
+  padding-inline: 10px;
+  color: var(--primary-text-color);
+  background: var(--side-nav-color);
+  border-block-end: 1px solid var(--scrollbar-color);
+  cursor: move;
+  user-select: none;
+}
+
+.settingsWindowIcon {
+  display: block;
+  flex: 0 0 auto;
+  inline-size: 18px;
+  block-size: 18px;
+  color: var(--tertiary-text-color);
+  vertical-align: 0;
+}
+
+.settingsBreadcrumb {
+  min-inline-size: 0;
+  flex: 1 1 auto;
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  overflow: hidden;
+  font-size: 18px;
+  font-weight: 600;
+  white-space: nowrap;
+}
+
+.settingsBreadcrumbLabel {
+  min-inline-size: 0;
+}
+
+.settingsBreadcrumbSeparator {
+  flex: 0 0 auto;
+  color: var(--tertiary-text-color);
+  font-size: 13px;
+}
+
+.settingsBreadcrumbCategoryIcon {
+  display: block;
+  flex: 0 0 auto;
+  inline-size: 18px;
+  block-size: 18px;
+  color: var(--tertiary-text-color);
+  vertical-align: 0;
+}
+
+.settingsBreadcrumbRoot,
+.settingsBreadcrumbParent,
+.settingsHeaderButton {
+  border: 0;
+  color: inherit;
+  background: transparent;
+  font: inherit;
+  cursor: pointer;
+}
+
+.settingsBreadcrumbRoot,
+.settingsBreadcrumbParent,
+.settingsBreadcrumbLabel {
+  min-block-size: 24px;
+  min-inline-size: 0;
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
+  line-height: 1.2;
+}
+
+.settingsBreadcrumbText {
+  min-inline-size: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+.settingsBreadcrumbRoot,
+.settingsBreadcrumbParent {
+  appearance: none;
+  padding: 0;
+  color: var(--tertiary-text-color);
+}
+
+.settingsBreadcrumbRoot:hover,
+.settingsBreadcrumbParent:hover {
+  color: var(--primary-text-color);
+}
+
+.settingsSearch {
+  flex: 0 1 300px;
+  min-inline-size: 150px;
+  block-size: 36px;
+  box-sizing: border-box;
+  display: flex;
+  align-items: center;
+  gap: 9px;
+  padding-inline: 12px;
+  border-radius: calc(6px * var(--ui-roundness));
+  color: var(--tertiary-text-color);
+  background: var(--search-bar-color);
+  cursor: text;
+}
+
+.settingsSearch input {
+  min-inline-size: 0;
+  inline-size: 100%;
+  padding: 0;
+  border: 0;
+  outline: 0;
+  color: var(--primary-text-color);
+  background: transparent;
+  font: inherit;
+}
+
+.settingsSearch input::placeholder {
+  color: var(--tertiary-text-color);
+}
+
+.settingsHeaderActions {
+  flex: 0 0 auto;
+  display: flex;
+  align-items: center;
+  gap: 2px;
+}
+
+.settingsHeaderButton {
+  inline-size: 38px;
+  block-size: 38px;
+  display: grid;
+  place-items: center;
+  padding: 0;
+  border-radius: calc(6px * var(--ui-roundness));
+  color: var(--tertiary-text-color);
+}
+
+.settingsHeaderButton > svg {
+  display: block;
+}
+
+.settingsHeaderButton:hover,
+.settingsHeaderButton:focus-visible,
+.settingsHeaderButton.active {
+  color: var(--primary-text-color);
+  background: var(--side-nav-hover-color);
+}
+
+.settingsHeaderButton.active {
+  color: var(--primary-color);
+}
+
+.settingsPage {
+  flex: 1 1 auto;
+  min-block-size: 0;
+  min-inline-size: 0;
+  display: grid;
+  grid-template-columns: 250px minmax(0, 1fr);
+  overflow: hidden;
+  background: var(--base-color);
+}
+
+.settingsMenu,
+.settingsContent,
+.settingsSubpageScroll,
+.settingsPassword {
+  min-block-size: 0;
+  overflow: auto;
+  overscroll-behavior: contain;
+}
+
+.settingsContent {
+  container-name: settings-content;
+  container-type: inline-size;
+  overflow-x: hidden !important;
+  max-inline-size: 100%;
+}
+
+.settingsContent .section,
+.settingsContent :deep(.settingsSection),
+.settingsContent :deep(.sectionBody) {
+  min-inline-size: 0;
+  max-inline-size: 100%;
+  inline-size: 100%;
+}
+
+.settingsContent :deep(.sectionBody) {
+  box-sizing: border-box;
+  padding-block-start: 5px;
+}
+
+.settingsMenu {
+  border-inline-end: 1px solid var(--scrollbar-color);
+}
+
+.settingsContent,
+.settingsSubpageScroll,
+.settingsPassword {
+  padding: 20px;
+  box-sizing: border-box;
+}
+
+.settingsPassword {
+  grid-column: 1 / -1;
+  display: grid;
+  place-items: center;
+}
+
+.settingsNoResults {
+  margin: auto;
+  color: var(--tertiary-text-color);
+  text-align: center;
+}
+
+.settingsSearchResults {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(min(280px, 100%), 1fr));
+  align-content: start;
+  gap: 12px;
+}
+
+.settingsSearchResult {
+  min-inline-size: 0;
+  display: flex;
+  flex-direction: column;
+  align-items: stretch;
+  gap: 6px;
+  padding: 14px;
+  border: 1px solid var(--border-color);
+  border-radius: calc(6px * var(--ui-roundness));
+  background: var(--card-bg-color);
+}
+
+.settingsSearchResultHeading {
+  padding: 4px;
+  border: 0;
+  display: flex;
+  align-items: center;
+  gap: 9px;
+  color: var(--primary-text-color);
+  background: transparent;
+  font: inherit;
+  font-weight: 600;
+  text-align: start;
+  cursor: pointer;
+}
+
+.settingsSearchResultHeading > svg {
+  inline-size: 18px;
+  block-size: 18px;
+}
+
+.settingsSearchResultMatch {
+  padding-block: 6px;
+  padding-inline: 8px;
+  border: 0;
+  border-radius: calc(4px * var(--ui-roundness));
+  overflow: hidden;
+  color: var(--tertiary-text-color);
+  background: transparent;
+  font: inherit;
+  text-align: start;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  cursor: pointer;
+}
+
+.settingsSearchResultHeading:hover,
+.settingsSearchResultHeading:focus-visible,
+.settingsSearchResultMatch:hover,
+.settingsSearchResultMatch:focus-visible {
+  color: var(--primary-text-color);
+  background: var(--side-nav-hover-color);
+}
+
+.settingsContent :deep(.settingsSearchTarget) {
+  animation: settings-search-highlight 2.2s ease-out;
+}
+
+@keyframes settings-search-highlight {
+  0%,
+  35% {
+    outline: 2px solid var(--primary-color);
+    outline-offset: 4px;
+    background-color: color-mix(in srgb, var(--primary-color) 20%, transparent);
+  }
+
+  100% {
+    outline: 2px solid transparent;
+    outline-offset: 4px;
+    background-color: transparent;
+  }
+}
+
+.settingsContent :deep(.sectionTitle) {
+  display: none;
 }
 
 :deep(.switch-ctn:has(.changedSettingIndicator)),
@@ -31,74 +353,138 @@
   padding-inline-start: 9px;
 }
 
-.settingsToggle {
-  padding-block: 0;
-  margin-block: 0;
+.settingsSubpageScroll {
+  grid-column: 1 / -1;
 }
 
-.settingButtonWithSync {
-  display: inline-flex;
-  align-items: center;
+.settingsKeyboardShortcutPage {
+  overflow: hidden;
 }
 
-.section {
-  /* enables anchor link clicks to land with the section title in the top quarter of the page */
-  scroll-margin-top: 24vh;
+.settingsSubpageScroll :deep(.card > h2:first-child) {
+  display: none;
 }
 
-@container settings-page (width > 1015px) {
-  .section + .section {
-    padding-block-start: 20px;
-  }
-
-  .settingsSections:last-child {
-    /* Add enough blank space to have the last setting section be active on the FtSettingsMenu when scrolled to */
-    margin-block-end: calc(76vh - 150px);
-  }
+.compactSettings {
+  display: block;
 }
 
-@container settings-page (width <= 1200px) {
-  .settingsSections,
-  .switchRow {
-    max-inline-size: 100%;
-  }
+.compactSettings .settingsMenu,
+.compactSettings .settingsContent,
+.compactSettings .settingsSubpageScroll,
+.compactSettings .settingsPassword {
+  block-size: 100%;
 }
 
-.settingsPage.mobileSettings {
-  /* Needed to overcome routerView styling for margin-block */
-  margin-block: 0;
-  flex-direction: column;
-  gap: 10px;
+.compactSettings .settingsMenu,
+.compactSettings .settingsContent {
+  border-inline-end: 0;
+}
 
-  .switchRow,
-  .settingsSections {
-    margin-inline: auto;
+.compactSettings .settingsContent {
+  padding: 14px;
+}
+
+:global(html.draggingSettingsWindow),
+:global(html.draggingSettingsWindow *) {
+  cursor: move !important;
+  user-select: none !important;
+}
+
+.settingsResizeHandle {
+  position: absolute;
+  z-index: 2;
+}
+
+.resize-n,
+.resize-s {
+  inset-inline: 12px;
+  block-size: 8px;
+}
+
+.resize-e,
+.resize-w {
+  inset-block: 12px;
+  inline-size: 8px;
+}
+
+.resize-n {
+  inset-block-start: -2px;
+  cursor: ns-resize;
+}
+
+.resize-s {
+  inset-block-end: -2px;
+  cursor: ns-resize;
+}
+
+.resize-e {
+  inset-inline-end: -2px;
+  cursor: ew-resize;
+}
+
+.resize-w {
+  inset-inline-start: -2px;
+  cursor: ew-resize;
+}
+
+.resize-ne,
+.resize-se,
+.resize-sw,
+.resize-nw {
+  inline-size: 16px;
+  block-size: 16px;
+}
+
+.resize-ne {
+  inset-block-start: -2px;
+  inset-inline-end: -2px;
+  cursor: nesw-resize;
+}
+
+.resize-se {
+  inset-block-end: -2px;
+  inset-inline-end: -2px;
+  cursor: nwse-resize;
+}
+
+.resize-sw {
+  inset-block-end: -2px;
+  inset-inline-start: -2px;
+  cursor: nesw-resize;
+}
+
+.resize-nw {
+  inset-block-start: -2px;
+  inset-inline-start: -2px;
+  cursor: nwse-resize;
+}
+
+:global(html.resizingSettingsWindow),
+:global(html.resizingSettingsWindow *) {
+  user-select: none !important;
+}
+
+@container settings-window (width <= 560px) {
+  .settingsWindowHeader {
+    flex-wrap: wrap;
+    padding-block: 5px;
+    padding-inline: 10px;
+    gap: 3px;
   }
 
-  .switchRow {
-    display: none;
+  .settingsSearch {
+    order: 3;
+    flex-basis: 100%;
+    min-inline-size: 100%;
   }
 
-  .settingsSections {
-    overflow-y: hidden;
-    margin-block-end: 80px;
+  .settingsHeaderButton {
+    inline-size: 34px;
+    block-size: 34px;
   }
 
-  .hideOnMobile {
-    display: none;
-  }
-
-  .returnToMenuMobileButton {
-    margin-block-start: 20px;
-    background-color: transparent;
-    color: inherit;
-    cursor: pointer;
-    border-style: none;
-    font-size: 30px;
-    line-height: 1em;
-  }
-
-  .returnToMenuMobileIcon {
-    inline-size: 1em;
+  .settingsBreadcrumb {
+    font-size: 16px;
   }
 }

--- a/src/renderer/views/Settings/Settings.vue
+++ b/src/renderer/views/Settings/Settings.vue
@@ -1,80 +1,259 @@
 <template>
-  <div
-    ref="settingsPageRef"
-    class="settingsPage"
-    :class="{ mobileSettings: !isInDesktopView }"
+  <section
+    ref="settingsWindowRef"
+    class="settingsWindow"
+    :style="windowStyle"
+    role="dialog"
+    :aria-label="t('Settings.Settings')"
   >
-    <template v-if="unlocked">
-      <div v-show="settingsSectionTypeOpenInMobile != null">
+    <header
+      class="settingsWindowHeader"
+      @pointerdown="startDragging"
+    >
+      <button
+        v-if="showBackButton"
+        type="button"
+        class="settingsHeaderButton settingsBackButton"
+        :aria-label="t('Back')"
+        :title="t('Back')"
+        @click="goBack"
+      >
+        <FontAwesomeIcon :icon="['fas', 'arrow-left']" />
+      </button>
+      <div
+        class="settingsBreadcrumb"
+        aria-live="polite"
+      >
         <button
-          class="returnToMenuMobileButton"
-          :aria-label="t('Settings.Return to Settings Menu')"
-          :title="t('Settings.Return to Settings Menu')"
+          v-if="showBackButton"
+          type="button"
+          class="settingsBreadcrumbRoot"
           @click="returnToSettingsMenu"
         >
           <FontAwesomeIcon
-            class="returnToMenuMobileIcon"
-            :icon="['fas', 'angle-left']"
+            class="settingsWindowIcon"
+            :icon="['fas', 'sliders-h']"
+            aria-hidden="true"
           />
+          <span class="settingsBreadcrumbText">{{ t('Settings.Settings') }}</span>
+        </button>
+        <span
+          v-else
+          class="settingsBreadcrumbLabel"
+        >
+          <FontAwesomeIcon
+            class="settingsWindowIcon"
+            :icon="['fas', 'sliders-h']"
+            aria-hidden="true"
+          />
+          <span class="settingsBreadcrumbText">{{ t('Settings.Settings') }}</span>
+        </span>
+        <template v-if="currentSectionTitle">
+          <FontAwesomeIcon
+            class="settingsBreadcrumbSeparator"
+            :icon="['fas', 'angle-right']"
+          />
+          <button
+            v-if="subpageTitle"
+            type="button"
+            class="settingsBreadcrumbParent"
+            @click="returnToCategory"
+          >
+            <FontAwesomeIcon
+              v-if="currentSectionIcon"
+              class="settingsBreadcrumbCategoryIcon"
+              :icon="currentSectionIcon"
+              aria-hidden="true"
+            />
+            <span class="settingsBreadcrumbText">{{ currentSectionTitle }}</span>
+          </button>
+          <span
+            v-else
+            class="settingsBreadcrumbLabel"
+          >
+            <FontAwesomeIcon
+              v-if="currentSectionIcon"
+              class="settingsBreadcrumbCategoryIcon"
+              :icon="currentSectionIcon"
+              aria-hidden="true"
+            />
+            <span class="settingsBreadcrumbText">{{ currentSectionTitle }}</span>
+          </span>
+        </template>
+        <template v-if="subpageTitle">
+          <FontAwesomeIcon
+            class="settingsBreadcrumbSeparator"
+            :icon="['fas', 'angle-right']"
+          />
+          <span class="settingsBreadcrumbLabel">{{ subpageTitle }}</span>
+        </template>
+      </div>
+      <label
+        v-if="unlocked && !isProfileManagerOpen && !isKeyboardShortcutPromptOpen"
+        class="settingsSearch"
+      >
+        <FontAwesomeIcon :icon="['fas', 'magnifying-glass']" />
+        <input
+          v-model="settingsSearchQuery"
+          type="search"
+          :placeholder="t('Settings.Search Settings')"
+          :aria-label="t('Settings.Search Settings')"
+          @input="handleSettingsSearch"
+        >
+      </label>
+      <div class="settingsHeaderActions">
+        <button
+          v-if="USING_ELECTRON"
+          type="button"
+          class="settingsHeaderButton"
+          :aria-label="t('KeyboardShortcutPrompt.Show Keyboard Shortcuts')"
+          :title="t('KeyboardShortcutPrompt.Show Keyboard Shortcuts')"
+          @click="showKeyboardShortcutPrompt"
+        >
+          <FontAwesomeIcon :icon="['fas', 'keyboard']" />
+        </button>
+        <button
+          type="button"
+          class="settingsHeaderButton"
+          :class="{ active: settingsSectionSortEnabled }"
+          :aria-label="t('Settings.Sort Settings Sections (A-Z)')"
+          :title="t('Settings.Sort Settings Sections (A-Z)')"
+          :aria-pressed="settingsSectionSortEnabled"
+          @click="updateSettingsSectionSortEnabled(!settingsSectionSortEnabled)"
+        >
+          <FontAwesomeIcon :icon="['fas', 'sort-alpha-down']" />
+        </button>
+        <button
+          type="button"
+          class="settingsHeaderButton"
+          :class="{ active: highlightChangedSettings }"
+          :aria-label="t('Settings.Highlight Changed Settings')"
+          :title="t('Settings.Highlight Changed Settings')"
+          :aria-pressed="highlightChangedSettings"
+          @click="updateHighlightChangedSettings(!highlightChangedSettings)"
+        >
+          <FontAwesomeIcon :icon="['fas', 'pen']" />
+        </button>
+        <button
+          type="button"
+          class="settingsHeaderButton settingsCloseButton"
+          :aria-label="t('Close')"
+          :title="t('Close')"
+          @click="closeSettings"
+        >
+          <FontAwesomeIcon :icon="['fas', 'xmark']" />
         </button>
       </div>
-      <FtSettingsMenu
-        v-show="isInDesktopView || settingsSectionTypeOpenInMobile == null"
-        ref="menuRef"
-        :class="{ mobileSettingsMenu: !isInDesktopView }"
-        :settings-sections="settingsSectionComponents"
-        :active-section="activeSection"
-        @navigate-to-section="navigateToSection"
-      />
-      <div
-        v-show="isInDesktopView || settingsSectionTypeOpenInMobile != null"
-        class="settingsContent"
-      >
-        <div class="switchRow">
+    </header>
+
+    <div
+      ref="settingsPageRef"
+      class="settingsPage"
+      :class="{ compactSettings: !isInDesktopView }"
+    >
+      <template v-if="unlocked">
+        <template v-if="isProfileManagerOpen">
           <div
-            v-if="USING_ELECTRON"
-            class="settingButtonWithSync"
+            v-overlay-scrollbars
+            class="settingsSubpageScroll"
           >
-            <FtButton
-              :label="t('KeyboardShortcutPrompt.Show Keyboard Shortcuts')"
-              :icon="['fas', 'keyboard']"
-              @click="showKeyboardShortcutPrompt"
-            />
-            <FtSyncedSettingIndicator setting-key="keyboardShortcuts" />
+            <ProfileSettings />
           </div>
-          <FtToggleSwitch
-            class="settingsToggle"
-            :label="t('Settings.Sort Settings Sections (A-Z)')"
-            :default-value="settingsSectionSortEnabled"
-            setting-key="settingsSectionSortEnabled"
-            @change="updateSettingsSectionSortEnabled"
+        </template>
+        <template v-else-if="isKeyboardShortcutPromptOpen">
+          <div
+            class="settingsSubpageScroll settingsKeyboardShortcutPage"
+          >
+            <FtKeyboardShortcutPrompt embedded />
+          </div>
+        </template>
+        <template v-else>
+          <FtSettingsMenu
+            v-show="!subpageTitle && (isInDesktopView || (!activeSection && settingsSearchQuery === ''))"
+            ref="menuRef"
+            v-overlay-scrollbars
+            :class="{ mobileSettingsMenu: !isInDesktopView }"
+            :settings-sections="filteredSettingsSectionComponents"
+            :active-section="activeSection"
+            :empty-message="t('Settings.No Settings Found')"
+            :filtered="settingsSearchQuery !== ''"
+            @navigate-to-section="navigateToSection"
           />
-          <FtToggleSwitch
-            class="settingsToggle"
-            :label="t('Settings.Highlight Changed Settings')"
-            :default-value="highlightChangedSettings"
-            setting-key="highlightChangedSettings"
-            @change="updateHighlightChangedSettings"
+          <div
+            v-show="!subpageTitle && (isInDesktopView || activeSection || settingsSearchQuery !== '')"
+            ref="settingsContentRef"
+            v-overlay-scrollbars
+            class="settingsContent"
+            tabindex="-1"
+            @scroll.passive="clampSettingsContentScroll"
+          >
+            <component
+              :is="activeSettingsSection.component"
+              v-if="activeSettingsSection"
+              :key="activeSettingsSection.type"
+              class="section"
+              :data-section="activeSettingsSection.type"
+            />
+            <div
+              v-else-if="settingsSearchResults.length > 0"
+              class="settingsSearchResults"
+            >
+              <section
+                v-for="result in settingsSearchResults"
+                :key="result.section.type"
+                class="settingsSearchResult"
+              >
+                <button
+                  type="button"
+                  class="settingsSearchResultHeading"
+                  @click="navigateToSection(result.section.type)"
+                >
+                  <FontAwesomeIcon :icon="result.section.icon" />
+                  {{ result.section.title }}
+                </button>
+                <button
+                  v-for="match in result.matches"
+                  :key="match"
+                  type="button"
+                  class="settingsSearchResultMatch"
+                  @click="openSearchResult(result.section.type, match)"
+                >
+                  {{ match }}
+                </button>
+              </section>
+            </div>
+            <p
+              v-else-if="settingsSearchQuery !== ''"
+              class="settingsNoResults"
+            >
+              {{ t('Settings.No Settings Found') }}
+            </p>
+          </div>
+          <div
+            v-show="subpageTitle"
+            :id="subpageTargetId"
+            v-overlay-scrollbars
+            class="settingsSubpageScroll"
           />
-        </div>
-        <div class="settingsSections">
-          <component
-            :is="section.component"
-            v-for="section in renderedSettingsSectionComponents"
-            :key="section.type"
-            ref="sectionRefs"
-            class="section"
-            :class="{ hideOnMobile: settingsSectionTypeOpenInMobile !== section.type }"
-            :data-section="section.type"
-          />
-        </div>
+        </template>
+      </template>
+      <div
+        v-else
+        v-overlay-scrollbars
+        class="settingsPassword"
+      >
+        <PasswordDialog @unlocked="handleUnlock" />
       </div>
-    </template>
-    <PasswordDialog
-      v-else
-      @unlocked="handleUnlock"
+    </div>
+    <div
+      v-for="direction in RESIZE_DIRECTIONS"
+      :key="direction"
+      class="settingsResizeHandle"
+      :class="`resize-${direction}`"
+      aria-hidden="true"
+      @pointerdown="startResizing($event, direction)"
     />
-  </div>
+  </section>
 </template>
 
 <script setup>
@@ -86,11 +265,13 @@ import {
   onBeforeUnmount,
   onDeactivated,
   onMounted,
+  provide,
   ref,
-  useTemplateRef
+  useId,
+  useTemplateRef,
+  watch
 } from 'vue'
 import { useI18n } from 'vue-i18n'
-import { useRoute, useRouter } from 'vue-router'
 
 import GeneralSettings from '../../components/GeneralSettings/GeneralSettings.vue'
 import ThemeSettings from '../../components/ThemeSettings.vue'
@@ -113,405 +294,741 @@ import ExperimentalSettings from '../../components/ExperimentalSettings/Experime
 import PasswordSettings from '../../components/PasswordSettings/PasswordSettings.vue'
 import PasswordDialog from '../../components/PasswordDialog/PasswordDialog.vue'
 import ContextMenuSearchSettings from '../../components/ContextMenuSearchSettings/ContextMenuSearchSettings.vue'
-import FtToggleSwitch from '../../components/FtToggleSwitch/FtToggleSwitch.vue'
-import FtButton from '../../components/FtButton/FtButton.vue'
-import FtSyncedSettingIndicator from '../../components/FtSyncedSettingIndicator/FtSyncedSettingIndicator.vue'
 import FtSettingsMenu from '../../components/FtSettingsMenu/FtSettingsMenu.vue'
+import FtKeyboardShortcutPrompt from '../../components/FtKeyboardShortcutPrompt/FtKeyboardShortcutPrompt.vue'
+import ProfileSettings from '../ProfileSettings/ProfileSettings.vue'
 
 import store from '../../store/index'
+import { settingsSubpageKey } from '../../components/FtSettingsSubpage/settingsSubpage'
+import { clampOverlayScrollTop } from '../../helpers/overlayScrollbars'
+import { getProxyTestUrl } from '../../helpers/proxy-test'
 
 const USING_ELECTRON = !!process.env.IS_ELECTRON
-const SETTINGS_MOBILE_WIDTH_THRESHOLD = 1015
-const SETTINGS_DESKTOP_WIDTH_THRESHOLD = SETTINGS_MOBILE_WIDTH_THRESHOLD + 20
+const SETTINGS_DESKTOP_WIDTH_THRESHOLD = 760
+const SETTINGS_BOUNDS_STORAGE_KEY = 'opentubex-settings-window-bounds'
+const WINDOW_MARGIN = 12
+const MINIMUM_WIDTH = 360
+const MINIMUM_HEIGHT = 360
+const RESIZE_DIRECTIONS = ['n', 'ne', 'e', 'se', 's', 'sw', 'w', 'nw']
 
-const { locale, t } = useI18n()
-const route = useRoute()
-const router = useRouter()
+const SETTINGS_SEARCH_KEYS = {
+  general: 'Settings.General Settings',
+  theme: 'Settings.Theme Settings',
+  player: 'Settings.Player Settings',
+  channel: 'Settings.Channel Settings',
+  'caption-appearance': 'Settings.Player Settings.Caption Appearance',
+  'external-player': 'Settings.External Player Settings',
+  download: 'Settings.Download Settings',
+  'external-software': 'Settings.External Software Settings',
+  subscription: 'Settings.Subscription Settings',
+  distraction: 'Settings.Distraction Free Settings',
+  'parental-control': 'Settings.Parental Control Settings',
+  privacy: 'Settings.Privacy Settings',
+  data: 'Settings.Data Settings',
+  sync: 'Settings.Sync Settings',
+  proxy: 'Settings.Proxy Settings',
+  'sponsor-block': 'Settings.SponsorBlock Settings',
+  'return-youtube-dislike': 'Settings.Return YouTube Dislike Settings',
+  'context-menu-search': 'Settings.Context Menu Search Settings',
+  password: 'Settings.Password Settings',
+  experimental: 'Settings.Experimental Settings'
+}
 
+const SETTINGS_SEARCH_SELECT_GROUP_LABELS = {
+  general: {
+    'Stream Extraction Method': ['Stream Extraction Method'],
+    'New Tab Position': ['New Tab Position'],
+    'Tab Close Focus': ['Tab Close Focus'],
+    'Startup Behavior': ['Startup Behavior'],
+    'Reduced Motion': ['Reduced Motion'],
+    'Avoid translation': ['Avoid translation'],
+    'Preferred API Backend': ['Preferred API Backend'],
+    'Video View Type': ['Video View Type'],
+    'Thumbnail Preference': ['Thumbnail Preference'],
+    'Extra Thumbnail Action Button': ['Extra Thumbnail Action Button'],
+    'External Link Handling': ['External Link Handling']
+  },
+  theme: {
+    'Toast Position': ['Toast Position'],
+    'Base Theme': ['Base Theme'],
+    'Main Color Theme': ['Main Color Theme']
+  },
+  player: {
+    'Caption Appearance': [],
+    'Default Viewing Mode': ['Default Viewing Mode', 'Tooltip'],
+    'Auto Picture in Picture': ['Auto Picture in Picture', 'Wayland Minimize Unsupported'],
+    'Default Video Format': ['Default Video Format'],
+    'Default Quality': ['Default Quality'],
+    'Screenshot.Modes': []
+  },
+  'caption-appearance': {
+    Anchor: ['Anchor'],
+    'Edge Style': ['Edge Style']
+  },
+  'external-player': { Players: [] },
+  'external-software': { Sources: [] },
+  privacy: { 'Watched Progress Saving Mode.Modes': [] },
+  'sponsor-block': { 'Skip Options': ['Skip Option'] }
+}
+
+const { locale, t, tm } = useI18n()
 const isInDesktopView = ref(true)
-const settingsSectionTypeOpenInMobile = ref(null)
 const activeSection = ref(null)
+const settingsSearchQuery = ref('')
+const settingsWindowRef = useTemplateRef('settingsWindowRef')
+const settingsPageRef = useTemplateRef('settingsPageRef')
+const settingsContentRef = useTemplateRef('settingsContentRef')
+const menuRef = useTemplateRef('menuRef')
+const subpageTargetId = `settings-subpage-${useId().replaceAll(':', '')}`
+const subpageTitle = ref('')
+let closeSubpage = null
+let settingsResizeObserver = null
+let settingsSectionResizeObserver = null
+let observationScheduled = false
+let boundsSaveTimer = null
+let searchHighlightTimer = null
+let draggingPointerId = null
+let resizeSession = null
+let dragOffsetX = 0
+let dragOffsetY = 0
 
-/** @type {import('vue').ComputedRef<boolean>} */
+const windowBounds = ref(getInitialBounds())
+const windowStyle = computed(() => ({
+  left: `${windowBounds.value.x}px`,
+  top: `${windowBounds.value.y}px`,
+  inlineSize: `${windowBounds.value.width}px`,
+  blockSize: `${windowBounds.value.height}px`
+}))
+
 const settingsSectionSortEnabled = computed(() => store.getters.getSettingsSectionSortEnabled)
 const highlightChangedSettings = computed(() => store.getters.getHighlightChangedSettings)
+const isProfileManagerOpen = computed(() => store.getters.getSettingsWindowView === 'profile')
+const isKeyboardShortcutPromptOpen = computed(() => store.getters.getIsKeyboardShortcutPromptShown)
 
-const settingsComponentsData = computed(() => {
-  return [
-    {
-      type: 'theme',
-      title: t('Settings.Theme Settings.Theme Settings'),
-      icon: ['fas', 'display'],
-      component: ThemeSettings
-    },
-    {
-      type: 'player',
-      title: t('Settings.Player Settings.Player Settings'),
-      icon: ['fas', 'circle-play'],
-      component: PlayerSettings
-    },
-    {
-      type: 'channel',
-      title: t('Settings.Channel Settings.Channel Settings'),
-      icon: ['fas', 'users'],
-      component: ChannelSettings
-    },
-    {
-      type: 'caption-appearance',
-      title: t('Settings.Player Settings.Caption Appearance.Captions'),
-      icon: ['fas', 'closed-captioning'],
-      component: CaptionSettings
-    },
-    ...(process.env.IS_ELECTRON
-      ? [{
-          type: 'external-player',
-          title: t('Settings.External Player Settings.External Player Settings'),
-          icon: ['fas', 'clapperboard'],
-          component: ExternalPlayerSettings
-        },
-        {
-          type: 'download',
-          title: t('Settings.Download Settings.Download Settings'),
-          icon: ['fas', 'download'],
-          component: DownloadSettings
-        },
-        {
-          type: 'external-software',
-          title: t('Settings.External Software Settings.External Software Settings'),
-          icon: ['fas', 'film'],
-          component: ExternalSoftwareSettings
-        }]
-      : []),
-    {
-      type: 'subscription',
-      title: t('Settings.Subscription Settings.Subscription Settings'),
-      icon: ['fas', 'play'],
-      component: SubscriptionSettings
-    },
-    {
-      type: 'distraction',
-      title: t('Settings.Distraction Free Settings.Distraction Free Settings'),
-      icon: ['fas', 'eye-slash'],
-      component: DistractionSettings
-    },
-    {
-      type: 'parental-control',
-      title: t('Settings.Parental Control Settings.Parental Control Settings'),
-      icon: ['fas', 'user-lock'],
-      component: ParentalControlSettings
-    },
-    {
-      type: 'privacy',
-      title: t('Settings.Privacy Settings.Privacy Settings'),
-      icon: ['fas', 'lock'],
-      component: PrivacySettings
-    },
-    {
-      type: 'data',
-      title: t('Settings.Data Settings.Data Settings'),
-      icon: ['fas', 'database'],
-      component: DataSettings
-    },
-    {
-      type: 'sync',
-      title: t('Settings.Sync Settings.Sync Settings'),
-      icon: ['fas', 'sync'],
-      component: SyncSettings
-    },
-    ...(process.env.IS_ELECTRON
-      ? [
-          {
-            type: 'proxy',
-            title: t('Settings.Proxy Settings.Proxy Settings'),
-            icon: ['fas', 'network-wired'],
-            component: ProxySettings
-          }
-        ]
-      : []),
-    {
-      type: 'sponsor-block',
-      title: t('Settings.SponsorBlock Settings.SponsorBlock Settings'),
-      // TODO: replace with SponsorBlock icon
-      icon: ['fas', 'shield'],
-      component: SponsorBlockSettings
-    },
-    {
-      type: 'return-youtube-dislike',
-      title: t('Settings.Return YouTube Dislike Settings.Return YouTube Dislike Settings'),
-      icon: ['fas', 'thumbs-down'],
-      component: RydSettings
-    },
-    ...(process.env.IS_ELECTRON
-      ? [{
-          type: 'context-menu-search',
-          title: t('Settings.Context Menu Search Settings.Context Menu Search Settings'),
-          icon: ['fas', 'magnifying-glass'],
-          component: ContextMenuSearchSettings
-        }]
-      : []),
-    {
-      type: 'password',
-      title: t('Settings.Password Settings.Password Settings'),
-      icon: ['fas', 'key'],
-      component: PasswordSettings
-    },
-    ...(process.env.IS_ELECTRON
-      ? [{
-          type: 'experimental',
-          title: t('Settings.Experimental Settings.Experimental Settings'),
-          icon: ['fas', 'flask'],
-          component: ExperimentalSettings
-        }]
-      : []),
-  ]
-})
+const settingsComponentsData = computed(() => [
+  {
+    type: 'theme',
+    title: t('Settings.Theme Settings.Theme Settings'),
+    icon: ['fas', 'display'],
+    component: ThemeSettings
+  },
+  {
+    type: 'player',
+    title: t('Settings.Player Settings.Player Settings'),
+    icon: ['fas', 'circle-play'],
+    component: PlayerSettings
+  },
+  {
+    type: 'channel',
+    title: t('Settings.Channel Settings.Channel Settings'),
+    icon: ['fas', 'users'],
+    component: ChannelSettings
+  },
+  {
+    type: 'caption-appearance',
+    title: t('Settings.Player Settings.Caption Appearance.Captions'),
+    icon: ['fas', 'closed-captioning'],
+    component: CaptionSettings
+  },
+  ...(process.env.IS_ELECTRON
+    ? [{
+        type: 'external-player',
+        title: t('Settings.External Player Settings.External Player Settings'),
+        icon: ['fas', 'clapperboard'],
+        component: ExternalPlayerSettings
+      }, {
+        type: 'download',
+        title: t('Settings.Download Settings.Download Settings'),
+        icon: ['fas', 'download'],
+        component: DownloadSettings
+      }, {
+        type: 'external-software',
+        title: t('Settings.External Software Settings.External Software Settings'),
+        icon: ['fas', 'server'],
+        component: ExternalSoftwareSettings
+      }]
+    : []),
+  {
+    type: 'subscription',
+    title: t('Settings.Subscription Settings.Subscription Settings'),
+    icon: ['fas', 'play'],
+    component: SubscriptionSettings
+  },
+  {
+    type: 'distraction',
+    title: t('Settings.Distraction Free Settings.Distraction Free Settings'),
+    icon: ['fas', 'eye-slash'],
+    component: DistractionSettings
+  },
+  {
+    type: 'parental-control',
+    title: t('Settings.Parental Control Settings.Parental Control Settings'),
+    icon: ['fas', 'user-lock'],
+    component: ParentalControlSettings
+  },
+  {
+    type: 'privacy',
+    title: t('Settings.Privacy Settings.Privacy Settings'),
+    icon: ['fas', 'lock'],
+    component: PrivacySettings
+  },
+  {
+    type: 'data',
+    title: t('Settings.Data Settings.Data Settings'),
+    icon: ['fas', 'database'],
+    component: DataSettings
+  },
+  {
+    type: 'sync',
+    title: t('Settings.Sync Settings.Sync Settings'),
+    icon: ['fas', 'sync'],
+    component: SyncSettings
+  },
+  ...(process.env.IS_ELECTRON
+    ? [{
+        type: 'proxy',
+        title: t('Settings.Proxy Settings.Proxy Settings'),
+        icon: ['fas', 'network-wired'],
+        component: ProxySettings
+      }]
+    : []),
+  {
+    type: 'sponsor-block',
+    title: t('Settings.SponsorBlock Settings.SponsorBlock Settings'),
+    icon: ['fas', 'shield'],
+    component: SponsorBlockSettings
+  },
+  {
+    type: 'return-youtube-dislike',
+    title: t('Settings.Return YouTube Dislike Settings.Return YouTube Dislike Settings'),
+    icon: ['fas', 'thumbs-down'],
+    component: RydSettings
+  },
+  ...(process.env.IS_ELECTRON
+    ? [{
+        type: 'context-menu-search',
+        title: t('Settings.Context Menu Search Settings.Context Menu Search Settings'),
+        icon: ['fas', 'magnifying-glass'],
+        component: ContextMenuSearchSettings
+      }]
+    : []),
+  {
+    type: 'password',
+    title: t('Settings.Password Settings.Password Settings'),
+    icon: ['fas', 'key'],
+    component: PasswordSettings
+  },
+  ...(process.env.IS_ELECTRON
+    ? [{
+        type: 'experimental',
+        title: t('Settings.Experimental Settings.Experimental Settings'),
+        icon: ['fas', 'flask'],
+        component: ExperimentalSettings
+      }]
+    : [])
+])
 
-const collator = computed(() => {
-  return new Intl.Collator([locale.value, 'en'], { sensitivity: 'base' })
-})
-
+const collator = computed(() => new Intl.Collator([locale.value, 'en'], { sensitivity: 'base' }))
 const settingsSectionComponents = computed(() => {
-  let settingsSections = settingsComponentsData.value
+  const sections = settingsSectionSortEnabled.value
+    ? settingsComponentsData.value.toSorted((a, b) => collator.value.compare(a.title, b.title))
+    : settingsComponentsData.value
 
-  if (settingsSectionSortEnabled.value) {
-    const collator_ = collator.value
-
-    settingsSections = settingsSections.toSorted((a, b) => {
-      return collator_.compare(a.title, b.title)
-    })
-  }
-
-  // ensure General Settings is placed first regardless of sorting
-  const generalSettingsEntry = {
+  return [{
     type: 'general',
     title: t('Settings.General Settings.General Settings'),
     icon: ['fas', 'border-all'],
     component: GeneralSettings
-  }
-
-  return [generalSettingsEntry, ...settingsSections]
+  }, ...sections]
 })
+const settingsSearchExtraValues = computed(() => ({
+  proxy: [
+    `${t('Settings.Proxy Settings.Clicking on Test Proxy will send a request to')} ` +
+    getProxyTestUrl(locale.value)
+  ]
+}))
+const settingsSearchExcludedValues = computed(() => ({
+  general: [t('Settings.General Settings.System Default')],
+  'caption-appearance': [
+    t('Settings.Player Settings.Caption Appearance.Application Language')
+  ],
+  data: [t('Settings.Data Settings.How do I import my subscriptions?')],
+  'external-software': [
+    t('Settings.External Software Settings.Checking yt-dlp'),
+    t('Settings.External Software Settings.Checking FFmpeg')
+  ],
+  sync: [t('Settings.Sync Settings.Checking Server')]
+}))
+const isSearchableSettingsValue = (sectionType, value) => {
+  if (/\{[^{}]+\}/.test(value)) return false
 
-const renderedSectionCount = ref(1)
-const renderedSettingsSectionComponents = computed(() => {
-  return settingsSectionComponents.value.slice(0, renderedSectionCount.value)
+  const normalizedValue = normalizeSearchText(value)
+  return !(settingsSearchExcludedValues.value[sectionType] ?? [])
+    .some(excludedValue => normalizeSearchText(excludedValue) === normalizedValue)
+}
+const removeRedundantSearchMatches = (values) => values
+  .toSorted((a, b) => a.length - b.length)
+  .filter((value, index, sortedValues) => {
+    const normalizedValue = normalizeSearchText(value)
+    return !sortedValues.slice(0, index).some(shorterValue =>
+      normalizedValue.includes(normalizeSearchText(shorterValue)))
+  })
+const settingsSearchResults = computed(() => {
+  const query = normalizeSearchText(settingsSearchQuery.value)
+  if (query === '') return []
+
+  return settingsSectionComponents.value.flatMap((section) => {
+    const messages = tm(SETTINGS_SEARCH_KEYS[section.type])
+    const values = [...new Set([
+      section.title,
+      ...flattenMessageValues(
+        messages,
+        SETTINGS_SEARCH_SELECT_GROUP_LABELS[section.type]
+      ),
+      ...(settingsSearchExtraValues.value[section.type] ?? [])
+    ])].filter(value => isSearchableSettingsValue(section.type, value))
+    const matches = removeRedundantSearchMatches(
+      values.filter(value => normalizeSearchText(value).includes(query))
+    )
+    return matches.length === 0 ? [] : [{ section, matches: matches.slice(0, 6) }]
+  })
+})
+const filteredSettingsSectionComponents = computed(() => {
+  if (settingsSearchQuery.value === '') return settingsSectionComponents.value
+  return settingsSearchResults.value.map(({ section }) => section)
+})
+const activeSettingsSection = computed(() => {
+  return settingsSectionComponents.value.find(({ type }) => type === activeSection.value) ?? null
+})
+const currentSectionTitle = computed(() => {
+  if (isKeyboardShortcutPromptOpen.value) {
+    return t('KeyboardShortcutPrompt.Keyboard Shortcuts')
+  }
+  if (isProfileManagerOpen.value) {
+    return t('Profile.Profile Manager')
+  }
+  return activeSettingsSection.value?.title ?? ''
+})
+const currentSectionIcon = computed(() => {
+  if (isKeyboardShortcutPromptOpen.value) {
+    return ['fas', 'keyboard']
+  }
+  if (isProfileManagerOpen.value) {
+    return ['fas', 'users']
+  }
+  return activeSettingsSection.value?.icon ?? null
+})
+const showBackButton = computed(() => {
+  return isKeyboardShortcutPromptOpen.value || isProfileManagerOpen.value || subpageTitle.value !== '' ||
+    (!isInDesktopView.value && activeSection.value !== null)
 })
 
 const unlocked = ref(store.getters.getSettingsPassword === '')
 
-if (unlocked.value) {
-  onMounted(handleMounted)
+provide(settingsSubpageKey, {
+  targetId: subpageTargetId,
+  open(title, close) {
+    subpageTitle.value = title
+    closeSubpage = close
+  },
+  close(close) {
+    if (closeSubpage === close) {
+      subpageTitle.value = ''
+      closeSubpage = null
+    }
+  }
+})
+
+onMounted(handleMounted)
+onActivated(handleMounted)
+onDeactivated(stopObserving)
+onBeforeUnmount(() => {
+  stopObserving()
+  stopDragging()
+  stopResizing()
+  if (boundsSaveTimer !== null) {
+    clearTimeout(boundsSaveTimer)
+  }
+  if (searchHighlightTimer !== null) {
+    clearTimeout(searchHighlightTimer)
+  }
+})
+
+watch(isProfileManagerOpen, (open) => {
+  if (!open) {
+    setInitialSection()
+  }
+})
+watch(activeSection, () => nextTick(observeActiveSettingsSection))
+
+function handleMounted() {
+  handleResize(settingsWindowRef.value?.clientWidth ?? windowBounds.value.width)
+  setInitialSection()
+  if (settingsResizeObserver !== null || observationScheduled) {
+    return
+  }
+  observationScheduled = true
+  nextTick(() => {
+    observationScheduled = false
+    const element = settingsWindowRef.value
+    if (!element) return
+    handleResize(element.clientWidth)
+    settingsResizeObserver = new ResizeObserver(([entry]) => {
+      const { width, height } = entry.contentRect
+      handleResize(width)
+      if (width > 0 && height > 0) {
+        windowBounds.value = clampBounds({
+          ...windowBounds.value,
+          width: element.offsetWidth,
+          height: element.offsetHeight
+        })
+        scheduleBoundsSave()
+        if (settingsContentRef.value) {
+          clampOverlayScrollTop(
+            settingsContentRef.value,
+            settingsContentRef.value.querySelector('.section')
+          )
+        }
+      }
+    })
+    settingsResizeObserver.observe(element)
+    window.addEventListener('resize', clampWindowToViewport)
+    observeActiveSettingsSection()
+  })
+}
+
+function stopObserving() {
+  observationScheduled = false
+  settingsResizeObserver?.disconnect()
+  settingsResizeObserver = null
+  settingsSectionResizeObserver?.disconnect()
+  settingsSectionResizeObserver = null
+  window.removeEventListener('resize', clampWindowToViewport)
+}
+
+function observeActiveSettingsSection() {
+  settingsSectionResizeObserver?.disconnect()
+  settingsSectionResizeObserver = null
+  const content = settingsContentRef.value
+  const section = content?.querySelector('.section')
+  if (!content || !section) return
+
+  settingsSectionResizeObserver = new ResizeObserver(() => {
+    clampOverlayScrollTop(content, section)
+  })
+  settingsSectionResizeObserver.observe(section)
+  clampOverlayScrollTop(content, section)
+}
+
+function clampSettingsContentScroll(event) {
+  const content = event.currentTarget
+  const section = content.querySelector('.section')
+  if (!section) return
+  const contentEnd = section.offsetTop + section.offsetHeight +
+    Number.parseFloat(getComputedStyle(content).paddingBottom)
+  if (content.scrollTop > Math.max(0, contentEnd - content.clientHeight)) {
+    clampOverlayScrollTop(content, section)
+  }
 }
 
 function handleUnlock() {
   unlocked.value = true
+  nextTick(setInitialSection)
+}
 
+function setInitialSection() {
+  if (isProfileManagerOpen.value || !unlocked.value || settingsSearchQuery.value !== '') return
+  if (isInDesktopView.value && activeSection.value === null) {
+    activeSection.value = settingsSectionComponents.value[0].type
+  }
+}
+
+function navigateToSection(sectionType) {
+  closeSubpage?.()
+  subpageTitle.value = ''
+  closeSubpage = null
+  activeSection.value = sectionType
+  if (!isInDesktopView.value) {
+    nextTick(() => settingsContentRef.value?.focus({ preventScroll: true }))
+  }
+}
+
+async function openSearchResult(sectionType, label) {
+  settingsSearchQuery.value = ''
+  navigateToSection(sectionType)
+  await nextTick()
+
+  const content = settingsContentRef.value
+  if (!content) return
+  const normalizedLabel = normalizeSearchText(label.trim())
+  const visibleTextElements = [...content.querySelectorAll(
+    'label, button, p, h1, h2, h3, h4, span, legend, div'
+  )]
+    .filter(element => element.getClientRects().length > 0)
+  const labelElement = visibleTextElements
+    .filter(element => normalizeSearchText(element.textContent.trim()) === normalizedLabel)
+    .at(-1) ?? visibleTextElements
+    .filter(element => normalizeSearchText(element.textContent.trim()).startsWith(`${normalizedLabel}:`))
+    .at(-1)
+  const target = labelElement?.closest(
+    '.switch-ctn, .select, .ft-input-component, .pure-material-slider, ' +
+    '.pure-checkbox, .captionControl, .preferenceToggle'
+  ) ?? labelElement
+  if (!target) return
+
+  target.scrollIntoView({ block: 'center', behavior: 'smooth' })
+  target.classList.remove('settingsSearchTarget')
+  // Restart the animation if the same result is selected repeatedly.
+  await new Promise(resolve => requestAnimationFrame(resolve))
+  target.classList.add('settingsSearchTarget')
+  if (searchHighlightTimer !== null) clearTimeout(searchHighlightTimer)
+  searchHighlightTimer = setTimeout(() => {
+    target.classList.remove('settingsSearchTarget')
+    searchHighlightTimer = null
+  }, 2200)
+}
+
+function handleSettingsSearch() {
+  closeSubpage?.()
+  subpageTitle.value = ''
+  closeSubpage = null
+  activeSection.value = settingsSearchQuery.value === '' && isInDesktopView.value
+    ? settingsSectionComponents.value[0].type
+    : null
   nextTick(() => {
-    handleMounted()
+    if (settingsContentRef.value) settingsContentRef.value.scrollTop = 0
   })
 }
 
-function stopObservingSettingsPage() {
-  document.removeEventListener('scroll', markScrolledToSectionAsActive)
-  settingsResizeObserver?.disconnect()
-  settingsResizeObserver = null
-  window.cancelAnimationFrame(renderSectionsAnimationFrameId)
+function flattenMessageValues(value, selectGroups = {}, path = []) {
+  if (typeof value === 'string') return [value]
+  if (Array.isArray(value)) {
+    return value.flatMap((item, index) =>
+      flattenMessageValues(item, selectGroups, [...path, index.toString()]))
+  }
+  if (value !== null && typeof value === 'object') {
+    const retainedKeys = selectGroups[path.join('.')]
+    return Object.entries(value)
+      .filter(([key]) => retainedKeys === undefined || retainedKeys.includes(key))
+      .flatMap(([key, childValue]) =>
+        flattenMessageValues(childValue, selectGroups, [...path, key]))
+  }
+  return []
 }
 
-onActivated(() => {
-  if (unlocked.value && settingsResizeObserver == null) {
-    observeSettingsPage()
-    scheduleRemainingSettingsSections()
+function normalizeSearchText(value) {
+  return value.toLocaleLowerCase(locale.value).normalize('NFKD').replaceAll(/\s+/g, ' ').trim()
+}
+
+function goBack() {
+  if (isKeyboardShortcutPromptOpen.value) {
+    store.dispatch('hideKeyboardShortcutPrompt')
+  } else if (isProfileManagerOpen.value) {
+    store.dispatch('showSettingsWindowRoot')
+    activeSection.value = 'data'
+  } else if (subpageTitle.value) {
+    closeSubpage?.()
+  } else {
+    returnToSettingsMenu()
   }
-})
-onDeactivated(stopObservingSettingsPage)
-onBeforeUnmount(stopObservingSettingsPage)
+}
+
+function returnToSettingsMenu() {
+  if (isKeyboardShortcutPromptOpen.value) {
+    store.dispatch('hideKeyboardShortcutPrompt')
+    if (!isInDesktopView.value) {
+      activeSection.value = null
+    }
+    return
+  }
+  if (isProfileManagerOpen.value) {
+    store.dispatch('showSettingsWindowRoot')
+    activeSection.value = isInDesktopView.value ? 'data' : null
+    return
+  }
+  closeSubpage?.()
+  subpageTitle.value = ''
+  closeSubpage = null
+  if (!isInDesktopView.value) {
+    const previousSection = activeSection.value
+    activeSection.value = null
+    nextTick(() => menuRef.value?.focusLink(previousSection))
+  }
+}
+
+function returnToCategory() {
+  closeSubpage?.()
+}
 
 function showKeyboardShortcutPrompt() {
   store.dispatch('showKeyboardShortcutPrompt')
 }
 
-/**
- * @param {boolean} value
- */
 function updateSettingsSectionSortEnabled(value) {
   store.dispatch('updateSettingsSectionSortEnabled', value)
 }
 
-/**
- * @param {boolean} value
- */
 function updateHighlightChangedSettings(value) {
   store.dispatch('updateHighlightChangedSettings', value)
 }
 
-function handleMounted() {
-  if (settingsResizeObserver == null) {
-    observeSettingsPage()
+function handleResize(width) {
+  if (width <= 0) return
+  const desktop = width >= SETTINGS_DESKTOP_WIDTH_THRESHOLD
+  if (desktop === isInDesktopView.value) return
+  isInDesktopView.value = desktop
+  if (desktop && activeSection.value === null && settingsSearchQuery.value === '') {
+    activeSection.value = settingsSectionComponents.value[0].type
   }
-
-  const sectionFromHash = route.hash.slice(1)
-  const initialSection = settingsSectionComponents.value.some(({ type }) => type === sectionFromHash)
-    ? sectionFromHash
-    : settingsSectionComponents.value[0].type
-
-  activeSection.value = initialSection
-
-  if (sectionFromHash === initialSection) {
-    navigateToSection(initialSection, false)
-  } else if (isInDesktopView.value) {
-    updateSectionHash(initialSection)
-  }
-
-  scheduleRemainingSettingsSections()
 }
 
-function observeSettingsPage() {
-  handleResize()
-  settingsResizeObserver = new ResizeObserver(([entry]) => {
-    handleResize(entry.contentRect.width)
-  })
-  settingsResizeObserver.observe(settingsPageRef.value)
-  document.addEventListener('scroll', markScrolledToSectionAsActive)
+function closeSettings() {
+  store.dispatch('hideKeyboardShortcutPrompt')
+  store.dispatch('hideSettingsWindow')
 }
 
-const sectionRefs = useTemplateRef('sectionRefs')
-const settingsPageRef = useTemplateRef('settingsPageRef')
-let settingsResizeObserver = null
-let hasMeasuredSettingsWidth = false
-let renderSectionsAnimationFrameId = 0
+function startDragging(event) {
+  if (event.button !== 0 || event.target.closest('button, input')) return
+  const bounds = settingsWindowRef.value.getBoundingClientRect()
+  draggingPointerId = event.pointerId
+  dragOffsetX = event.clientX - bounds.left
+  dragOffsetY = event.clientY - bounds.top
+  document.documentElement.classList.add('draggingSettingsWindow')
+  window.addEventListener('pointermove', dragWindow)
+  window.addEventListener('pointerup', stopDragging)
+  window.addEventListener('pointercancel', stopDragging)
+  event.preventDefault()
+}
 
-function scheduleRemainingSettingsSections() {
-  if (renderedSectionCount.value >= settingsSectionComponents.value.length) {
-    return
-  }
-
-  renderSectionsAnimationFrameId = window.requestAnimationFrame(() => {
-    // Mount below-the-fold sections together after the Settings shell paints.
-    // Growing the document over several frames makes the page scrollbar update
-    // repeatedly and exposes scrollbar flicker while opening Settings.
-    renderedSectionCount.value = settingsSectionComponents.value.length
+function dragWindow(event) {
+  if (event.pointerId !== draggingPointerId) return
+  windowBounds.value = clampBounds({
+    ...windowBounds.value,
+    x: event.clientX - dragOffsetX,
+    y: event.clientY - dragOffsetY
   })
 }
 
-/**
- * @param {string} sectionType
- * @param {boolean} updateHash
- */
-function navigateToSection(sectionType, updateHash = true) {
-  const sectionIndex = settingsSectionComponents.value.findIndex(({ type }) => type === sectionType)
-  if (sectionIndex >= renderedSectionCount.value) {
-    renderedSectionCount.value = sectionIndex + 1
+function stopDragging(event) {
+  if (event && event.pointerId !== draggingPointerId) return
+  if (draggingPointerId === null) return
+  draggingPointerId = null
+  document.documentElement.classList.remove('draggingSettingsWindow')
+  window.removeEventListener('pointermove', dragWindow)
+  window.removeEventListener('pointerup', stopDragging)
+  window.removeEventListener('pointercancel', stopDragging)
+  scheduleBoundsSave()
+}
+
+function startResizing(event, direction) {
+  if (event.button !== 0) return
+  resizeSession = {
+    direction,
+    pointerId: event.pointerId,
+    startX: event.clientX,
+    startY: event.clientY,
+    bounds: { ...windowBounds.value }
+  }
+  document.documentElement.classList.add('resizingSettingsWindow')
+  document.documentElement.style.cursor = getComputedStyle(event.currentTarget).cursor
+  window.addEventListener('pointermove', resizeWindow)
+  window.addEventListener('pointerup', stopResizing)
+  window.addEventListener('pointercancel', stopResizing)
+  event.preventDefault()
+  event.stopPropagation()
+}
+
+function resizeWindow(event) {
+  if (resizeSession === null || event.pointerId !== resizeSession.pointerId) return
+  const { direction, startX, startY, bounds } = resizeSession
+  const deltaX = event.clientX - startX
+  const deltaY = event.clientY - startY
+  let left = bounds.x
+  let right = bounds.x + bounds.width
+  let top = bounds.y
+  let bottom = bounds.y + bounds.height
+
+  if (direction.includes('e')) right += deltaX
+  if (direction.includes('w')) left += deltaX
+  if (direction.includes('s')) bottom += deltaY
+  if (direction.includes('n')) top += deltaY
+
+  if (right - left < MINIMUM_WIDTH) {
+    if (direction.includes('w')) left = right - MINIMUM_WIDTH
+    else right = left + MINIMUM_WIDTH
+  }
+  if (bottom - top < MINIMUM_HEIGHT) {
+    if (direction.includes('n')) top = bottom - MINIMUM_HEIGHT
+    else bottom = top + MINIMUM_HEIGHT
   }
 
-  if (updateHash) {
-    updateSectionHash(sectionType)
-  }
+  left = Math.max(WINDOW_MARGIN, left)
+  top = Math.max(WINDOW_MARGIN, top)
+  right = Math.min(window.innerWidth - WINDOW_MARGIN, right)
+  bottom = Math.min(window.innerHeight - WINDOW_MARGIN, bottom)
 
-  if (isInDesktopView.value) {
-    nextTick(() => {
-      const sectionElement = sectionRefs.value.find(sectionRef => {
-        return sectionRef.$el.dataset.section === sectionType
-      })?.$el
-      if (!sectionElement) {
-        return
-      }
-      sectionElement.scrollIntoView()
-
-      const sectionHeading = sectionElement.firstChild.firstChild
-      sectionHeading.tabIndex = 0
-      sectionHeading.focus()
-      sectionHeading.tabIndex = -1
-    })
-  } else {
-    settingsSectionTypeOpenInMobile.value = sectionType
+  windowBounds.value = {
+    x: left,
+    y: top,
+    width: right - left,
+    height: bottom - top
   }
 }
 
-/**
- * @param {string | null} sectionType
- */
-function updateSectionHash(sectionType) {
-  const hash = sectionType == null ? '' : `#${sectionType}`
+function stopResizing(event) {
+  if (resizeSession === null || (event && event.pointerId !== resizeSession.pointerId)) return
+  resizeSession = null
+  document.documentElement.classList.remove('resizingSettingsWindow')
+  document.documentElement.style.removeProperty('cursor')
+  window.removeEventListener('pointermove', resizeWindow)
+  window.removeEventListener('pointerup', stopResizing)
+  window.removeEventListener('pointercancel', stopResizing)
+  scheduleBoundsSave()
+}
 
-  if (route.hash !== hash) {
-    router.replace({
-      hash,
-      state: {
-        preserveScroll: true,
-        skipTabRouteLoading: true
-      }
-    })
+function clampWindowToViewport() {
+  windowBounds.value = clampBounds(windowBounds.value)
+}
+
+function clampBounds(bounds) {
+  const maximumWidth = Math.max(0, window.innerWidth - WINDOW_MARGIN * 2)
+  const maximumHeight = Math.max(0, window.innerHeight - WINDOW_MARGIN * 2)
+  const width = Math.min(Math.max(bounds.width, MINIMUM_WIDTH), maximumWidth)
+  const height = Math.min(Math.max(bounds.height, MINIMUM_HEIGHT), maximumHeight)
+  return {
+    x: Math.min(Math.max(bounds.x, WINDOW_MARGIN), window.innerWidth - width - WINDOW_MARGIN),
+    y: Math.min(Math.max(bounds.y, WINDOW_MARGIN), window.innerHeight - height - WINDOW_MARGIN),
+    width,
+    height
   }
 }
 
-const menuRef = useTemplateRef('menuRef')
-
-function returnToSettingsMenu() {
-  const openSection = settingsSectionTypeOpenInMobile.value
-  settingsSectionTypeOpenInMobile.value = null
-  updateSectionHash(null)
-
-  // focus the corresponding Settings Menu title
-  nextTick(() => {
-    return menuRef.value?.focusLink(openSection)
-  })
-}
-
-/* Set the current section to be shown as active in the Settings Menu
-* if it is the lowest section within the top quarter of the viewport (25vh) */
-function markScrolledToSectionAsActive() {
-  if (!isInDesktopView.value) {
-    activeSection.value = null
-    return
+function getInitialBounds() {
+  const fallbackWidth = Math.min(1080, Math.max(MINIMUM_WIDTH, window.innerWidth - 64))
+  const fallbackHeight = Math.min(720, Math.max(MINIMUM_HEIGHT, window.innerHeight - 120))
+  const fallback = {
+    x: Math.round((window.innerWidth - fallbackWidth) / 2),
+    y: Math.max(WINDOW_MARGIN, Math.round((window.innerHeight - fallbackHeight) / 2)),
+    width: fallbackWidth,
+    height: fallbackHeight
   }
-
-  const scrollY = window.scrollY + window.innerHeight / 4
-
-  for (const sectionRef of sectionRefs.value) {
-    const sectionElement = sectionRef.$el
-
-    const sectionHeight = sectionElement.offsetHeight
-    const sectionTop = sectionElement.offsetTop
-
-    if (scrollY > sectionTop && scrollY <= sectionTop + sectionHeight) {
-      const sectionType = sectionElement.dataset.section
-      if (activeSection.value !== sectionType) {
-        activeSection.value = sectionType
-        updateSectionHash(sectionType)
-      }
-      break
+  try {
+    const saved = JSON.parse(localStorage.getItem(SETTINGS_BOUNDS_STORAGE_KEY))
+    if ([saved?.x, saved?.y, saved?.width, saved?.height].every(Number.isFinite)) {
+      return clampBounds(saved)
     }
+  } catch {
+    // Ignore corrupt state and use the centered default.
   }
+  return clampBounds(fallback)
 }
 
-function handleResize(width = settingsPageRef.value?.clientWidth ?? window.innerWidth) {
-  // A hidden tab reports a width of 0. Treating that as the mobile layout would
-  // scroll back to the active section once the tab is presented again, undoing
-  // the tab's restored scroll position.
-  if (width === 0) {
-    return
-  }
-
-  const wasNotInDesktopView = !isInDesktopView.value
-
-  if (!hasMeasuredSettingsWidth) {
-    isInDesktopView.value = width > SETTINGS_MOBILE_WIDTH_THRESHOLD
-    hasMeasuredSettingsWidth = true
-  } else if (isInDesktopView.value) {
-    isInDesktopView.value = width > SETTINGS_MOBILE_WIDTH_THRESHOLD
-  } else {
-    // Avoid a scrollbar-induced feedback loop at the layout breakpoint.
-    isInDesktopView.value = width > SETTINGS_DESKTOP_WIDTH_THRESHOLD
-  }
-
-  // navigate to section that was open in mobile or desktop view, if any
-  if (isInDesktopView.value && wasNotInDesktopView && settingsSectionTypeOpenInMobile.value != null) {
-    navigateToSection(settingsSectionTypeOpenInMobile.value)
-    settingsSectionTypeOpenInMobile.value = null
-  } else if (!isInDesktopView.value && !wasNotInDesktopView && activeSection.value) {
-    navigateToSection(activeSection.value)
-  }
+function scheduleBoundsSave() {
+  if (boundsSaveTimer !== null) clearTimeout(boundsSaveTimer)
+  boundsSaveTimer = setTimeout(() => {
+    localStorage.setItem(SETTINGS_BOUNDS_STORAGE_KEY, JSON.stringify(windowBounds.value))
+    boundsSaveTimer = null
+  }, 150)
 }
 </script>
 

--- a/src/renderer/views/Settings/Settings.vue
+++ b/src/renderer/views/Settings/Settings.vue
@@ -5,6 +5,8 @@
     :style="windowStyle"
     role="dialog"
     :aria-label="t('Settings.Settings')"
+    tabindex="-1"
+    @keydown.esc.capture="handleSettingsEscape"
   >
     <header
       class="settingsWindowHeader"
@@ -94,6 +96,7 @@
       >
         <FontAwesomeIcon :icon="['fas', 'magnifying-glass']" />
         <input
+          ref="settingsSearchInputRef"
           v-model="settingsSearchQuery"
           type="search"
           :placeholder="t('Settings.Search Settings')"
@@ -113,6 +116,7 @@
           <FontAwesomeIcon :icon="['fas', 'keyboard']" />
         </button>
         <button
+          ref="settingsCloseButtonRef"
           type="button"
           class="settingsHeaderButton"
           :class="{ active: settingsSectionSortEnabled }"
@@ -370,6 +374,11 @@ const SETTINGS_SEARCH_SELECT_GROUP_LABELS = {
   privacy: { 'Watched Progress Saving Mode.Modes': [] },
   'sponsor-block': { 'Skip Options': ['Skip Option'] }
 }
+const SETTINGS_SEARCH_EXCLUDED_MESSAGE_PATHS = {
+  general: new Set(['System Default']),
+  'caption-appearance': new Set(['Application Language'])
+}
+const NON_SETTING_MESSAGE_KEY_PATTERN = /(?:^No\b|^How\b|^Checking\b|^Current .+\b(?:has|is|will)\b|^Operation in Progress$|(?:Description|Hint|Tooltip|Template|Warning|Error|Status|Message|Not Downloaded|Unavailable|Connected|Connecting|Success|Failed|Failure)$)/i
 
 const { locale, t, tm } = useI18n()
 const isInDesktopView = ref(true)
@@ -378,6 +387,8 @@ const settingsSearchQuery = ref('')
 const settingsWindowRef = useTemplateRef('settingsWindowRef')
 const settingsPageRef = useTemplateRef('settingsPageRef')
 const settingsContentRef = useTemplateRef('settingsContentRef')
+const settingsSearchInputRef = useTemplateRef('settingsSearchInputRef')
+const settingsCloseButtonRef = useTemplateRef('settingsCloseButtonRef')
 const menuRef = useTemplateRef('menuRef')
 const subpageTargetId = `settings-subpage-${useId().replaceAll(':', '')}`
 const subpageTitle = ref('')
@@ -547,24 +558,12 @@ const settingsSearchExtraValues = computed(() => ({
     getProxyTestUrl(locale.value)
   ]
 }))
-const settingsSearchExcludedValues = computed(() => ({
-  general: [t('Settings.General Settings.System Default')],
-  'caption-appearance': [
-    t('Settings.Player Settings.Caption Appearance.Application Language')
-  ],
-  data: [t('Settings.Data Settings.How do I import my subscriptions?')],
-  'external-software': [
-    t('Settings.External Software Settings.Checking yt-dlp'),
-    t('Settings.External Software Settings.Checking FFmpeg')
-  ],
-  sync: [t('Settings.Sync Settings.Checking Server')]
-}))
-const isSearchableSettingsValue = (sectionType, value) => {
+const isSearchableSettingsMessage = (sectionType, path, value) => {
   if (/\{[^{}]+\}/.test(value)) return false
-
-  const normalizedValue = normalizeSearchText(value)
-  return !(settingsSearchExcludedValues.value[sectionType] ?? [])
-    .some(excludedValue => normalizeSearchText(excludedValue) === normalizedValue)
+  const messagePath = path.join('.')
+  const messageKey = path.at(-1) ?? ''
+  return !SETTINGS_SEARCH_EXCLUDED_MESSAGE_PATHS[sectionType]?.has(messagePath) &&
+    !NON_SETTING_MESSAGE_KEY_PATTERN.test(messageKey)
 }
 const removeRedundantSearchMatches = (values) => values
   .toSorted((a, b) => a.length - b.length)
@@ -573,20 +572,28 @@ const removeRedundantSearchMatches = (values) => values
     return !sortedValues.slice(0, index).some(shorterValue =>
       normalizedValue.includes(normalizeSearchText(shorterValue)))
   })
-const settingsSearchResults = computed(() => {
-  const query = normalizeSearchText(settingsSearchQuery.value)
-  if (query === '') return []
-
-  return settingsSectionComponents.value.flatMap((section) => {
+const settingsSearchableValues = computed(() => new Map(
+  settingsSectionComponents.value.map((section) => {
     const messages = tm(SETTINGS_SEARCH_KEYS[section.type])
     const values = [...new Set([
       section.title,
       ...flattenMessageValues(
         messages,
-        SETTINGS_SEARCH_SELECT_GROUP_LABELS[section.type]
+        SETTINGS_SEARCH_SELECT_GROUP_LABELS[section.type],
+        [],
+        (path, value) => isSearchableSettingsMessage(section.type, path, value)
       ),
       ...(settingsSearchExtraValues.value[section.type] ?? [])
-    ])].filter(value => isSearchableSettingsValue(section.type, value))
+    ])]
+    return [section.type, values]
+  })
+))
+const settingsSearchResults = computed(() => {
+  const query = normalizeSearchText(settingsSearchQuery.value)
+  if (query === '') return []
+
+  return settingsSectionComponents.value.flatMap((section) => {
+    const values = settingsSearchableValues.value.get(section.type) ?? []
     const matches = removeRedundantSearchMatches(
       values.filter(value => normalizeSearchText(value).includes(query))
     )
@@ -664,6 +671,7 @@ watch(activeSection, () => nextTick(observeActiveSettingsSection))
 function handleMounted() {
   handleResize(settingsWindowRef.value?.clientWidth ?? windowBounds.value.width)
   setInitialSection()
+  nextTick(() => (settingsSearchInputRef.value ?? settingsCloseButtonRef.value)?.focus())
   if (settingsResizeObserver !== null || observationScheduled) {
     return
   }
@@ -800,18 +808,18 @@ function handleSettingsSearch() {
   })
 }
 
-function flattenMessageValues(value, selectGroups = {}, path = []) {
-  if (typeof value === 'string') return [value]
+function flattenMessageValues(value, selectGroups = {}, path = [], include = () => true) {
+  if (typeof value === 'string') return include(path, value) ? [value] : []
   if (Array.isArray(value)) {
     return value.flatMap((item, index) =>
-      flattenMessageValues(item, selectGroups, [...path, index.toString()]))
+      flattenMessageValues(item, selectGroups, [...path, index.toString()], include))
   }
   if (value !== null && typeof value === 'object') {
     const retainedKeys = selectGroups[path.join('.')]
     return Object.entries(value)
       .filter(([key]) => retainedKeys === undefined || retainedKeys.includes(key))
       .flatMap(([key, childValue]) =>
-        flattenMessageValues(childValue, selectGroups, [...path, key]))
+        flattenMessageValues(childValue, selectGroups, [...path, key], include))
   }
   return []
 }
@@ -887,8 +895,14 @@ function closeSettings() {
   store.dispatch('hideSettingsWindow')
 }
 
+function handleSettingsEscape(event) {
+  if (event.target.closest('[aria-expanded="true"]')) return
+  event.stopPropagation()
+  closeSettings()
+}
+
 function startDragging(event) {
-  if (event.button !== 0 || event.target.closest('button, input')) return
+  if (event.button !== 0 || event.target.closest('button, input, .settingsSearch')) return
   const bounds = settingsWindowRef.value.getBoundingClientRect()
   draggingPointerId = event.pointerId
   dragOffsetX = event.clientX - bounds.left
@@ -953,19 +967,23 @@ function resizeWindow(event) {
   if (direction.includes('s')) bottom += deltaY
   if (direction.includes('n')) top += deltaY
 
-  if (right - left < MINIMUM_WIDTH) {
-    if (direction.includes('w')) left = right - MINIMUM_WIDTH
-    else right = left + MINIMUM_WIDTH
-  }
-  if (bottom - top < MINIMUM_HEIGHT) {
-    if (direction.includes('n')) top = bottom - MINIMUM_HEIGHT
-    else bottom = top + MINIMUM_HEIGHT
-  }
-
+  const maximumRight = window.innerWidth - WINDOW_MARGIN
+  const maximumBottom = window.innerHeight - WINDOW_MARGIN
+  const minimumWidth = Math.min(MINIMUM_WIDTH, maximumRight - WINDOW_MARGIN)
+  const minimumHeight = Math.min(MINIMUM_HEIGHT, maximumBottom - WINDOW_MARGIN)
   left = Math.max(WINDOW_MARGIN, left)
   top = Math.max(WINDOW_MARGIN, top)
-  right = Math.min(window.innerWidth - WINDOW_MARGIN, right)
-  bottom = Math.min(window.innerHeight - WINDOW_MARGIN, bottom)
+  right = Math.min(maximumRight, right)
+  bottom = Math.min(maximumBottom, bottom)
+
+  if (right - left < minimumWidth) {
+    if (direction.includes('w')) left = Math.max(WINDOW_MARGIN, right - minimumWidth)
+    else right = Math.min(maximumRight, left + minimumWidth)
+  }
+  if (bottom - top < minimumHeight) {
+    if (direction.includes('n')) top = Math.max(WINDOW_MARGIN, bottom - minimumHeight)
+    else bottom = Math.min(maximumBottom, top + minimumHeight)
+  }
 
   windowBounds.value = {
     x: left,

--- a/src/renderer/views/Settings/Settings.vue
+++ b/src/renderer/views/Settings/Settings.vue
@@ -116,7 +116,6 @@
           <FontAwesomeIcon :icon="['fas', 'keyboard']" />
         </button>
         <button
-          ref="settingsCloseButtonRef"
           type="button"
           class="settingsHeaderButton"
           :class="{ active: settingsSectionSortEnabled }"
@@ -139,6 +138,7 @@
           <FontAwesomeIcon :icon="['fas', 'pen']" />
         </button>
         <button
+          ref="settingsCloseButtonRef"
           type="button"
           class="settingsHeaderButton settingsCloseButton"
           :aria-label="t('Close')"
@@ -306,6 +306,11 @@ import store from '../../store/index'
 import { settingsSubpageKey } from '../../components/FtSettingsSubpage/settingsSubpage'
 import { clampOverlayScrollTop } from '../../helpers/overlayScrollbars'
 import { getProxyTestUrl } from '../../helpers/proxy-test'
+import {
+  SETTINGS_SEARCH_EXCLUDED_MESSAGE_PATHS,
+  SETTINGS_SEARCH_KEYS,
+  SETTINGS_SEARCH_SELECT_GROUP_LABELS,
+} from '../../helpers/settings-search-config'
 
 const USING_ELECTRON = !!process.env.IS_ELECTRON
 const SETTINGS_DESKTOP_WIDTH_THRESHOLD = 760
@@ -315,69 +320,6 @@ const MINIMUM_WIDTH = 360
 const MINIMUM_HEIGHT = 360
 const RESIZE_DIRECTIONS = ['n', 'ne', 'e', 'se', 's', 'sw', 'w', 'nw']
 
-const SETTINGS_SEARCH_KEYS = {
-  general: 'Settings.General Settings',
-  theme: 'Settings.Theme Settings',
-  player: 'Settings.Player Settings',
-  channel: 'Settings.Channel Settings',
-  'caption-appearance': 'Settings.Player Settings.Caption Appearance',
-  'external-player': 'Settings.External Player Settings',
-  download: 'Settings.Download Settings',
-  'external-software': 'Settings.External Software Settings',
-  subscription: 'Settings.Subscription Settings',
-  distraction: 'Settings.Distraction Free Settings',
-  'parental-control': 'Settings.Parental Control Settings',
-  privacy: 'Settings.Privacy Settings',
-  data: 'Settings.Data Settings',
-  sync: 'Settings.Sync Settings',
-  proxy: 'Settings.Proxy Settings',
-  'sponsor-block': 'Settings.SponsorBlock Settings',
-  'return-youtube-dislike': 'Settings.Return YouTube Dislike Settings',
-  'context-menu-search': 'Settings.Context Menu Search Settings',
-  password: 'Settings.Password Settings',
-  experimental: 'Settings.Experimental Settings'
-}
-
-const SETTINGS_SEARCH_SELECT_GROUP_LABELS = {
-  general: {
-    'Stream Extraction Method': ['Stream Extraction Method'],
-    'New Tab Position': ['New Tab Position'],
-    'Tab Close Focus': ['Tab Close Focus'],
-    'Startup Behavior': ['Startup Behavior'],
-    'Reduced Motion': ['Reduced Motion'],
-    'Avoid translation': ['Avoid translation'],
-    'Preferred API Backend': ['Preferred API Backend'],
-    'Video View Type': ['Video View Type'],
-    'Thumbnail Preference': ['Thumbnail Preference'],
-    'Extra Thumbnail Action Button': ['Extra Thumbnail Action Button'],
-    'External Link Handling': ['External Link Handling']
-  },
-  theme: {
-    'Toast Position': ['Toast Position'],
-    'Base Theme': ['Base Theme'],
-    'Main Color Theme': ['Main Color Theme']
-  },
-  player: {
-    'Caption Appearance': [],
-    'Default Viewing Mode': ['Default Viewing Mode', 'Tooltip'],
-    'Auto Picture in Picture': ['Auto Picture in Picture', 'Wayland Minimize Unsupported'],
-    'Default Video Format': ['Default Video Format'],
-    'Default Quality': ['Default Quality'],
-    'Screenshot.Modes': []
-  },
-  'caption-appearance': {
-    Anchor: ['Anchor'],
-    'Edge Style': ['Edge Style']
-  },
-  'external-player': { Players: [] },
-  'external-software': { Sources: [] },
-  privacy: { 'Watched Progress Saving Mode.Modes': [] },
-  'sponsor-block': { 'Skip Options': ['Skip Option'] }
-}
-const SETTINGS_SEARCH_EXCLUDED_MESSAGE_PATHS = {
-  general: new Set(['System Default']),
-  'caption-appearance': new Set(['Application Language'])
-}
 const NON_SETTING_MESSAGE_KEY_PATTERN = /(?:^No\b|^How\b|^Checking\b|^Current .+\b(?:has|is|will)\b|^Operation in Progress$|(?:Description|Hint|Tooltip|Template|Warning|Error|Status|Message|Not Downloaded|Unavailable|Connected|Connecting|Success|Failed|Failure)$)/i
 
 const { locale, t, tm } = useI18n()
@@ -395,6 +337,7 @@ const subpageTitle = ref('')
 let closeSubpage = null
 let settingsResizeObserver = null
 let settingsSectionResizeObserver = null
+let settingsContentPaddingBottom = 0
 let observationScheduled = false
 let boundsSaveTimer = null
 let searchHighlightTimer = null
@@ -565,13 +508,17 @@ const isSearchableSettingsMessage = (sectionType, path, value) => {
   return !SETTINGS_SEARCH_EXCLUDED_MESSAGE_PATHS[sectionType]?.has(messagePath) &&
     !NON_SETTING_MESSAGE_KEY_PATTERN.test(messageKey)
 }
-const removeRedundantSearchMatches = (values) => values
-  .toSorted((a, b) => a.length - b.length)
-  .filter((value, index, sortedValues) => {
+const removeRedundantSearchMatches = (values) => {
+  const keptMatches = []
+  const normalizedMatches = []
+  for (const value of values.toSorted((a, b) => a.length - b.length)) {
     const normalizedValue = normalizeSearchText(value)
-    return !sortedValues.slice(0, index).some(shorterValue =>
-      normalizedValue.includes(normalizeSearchText(shorterValue)))
-  })
+    if (normalizedMatches.some(shorterValue => normalizedValue.includes(shorterValue))) continue
+    keptMatches.push(value)
+    normalizedMatches.push(normalizedValue)
+  }
+  return keptMatches
+}
 const settingsSearchableValues = computed(() => new Map(
   settingsSectionComponents.value.map((section) => {
     const messages = tm(SETTINGS_SEARCH_KEYS[section.type])
@@ -648,7 +595,11 @@ provide(settingsSubpageKey, {
 
 onMounted(handleMounted)
 onActivated(handleMounted)
-onDeactivated(stopObserving)
+onDeactivated(() => {
+  stopObserving()
+  stopDragging()
+  stopResizing()
+})
 onBeforeUnmount(() => {
   stopObserving()
   stopDragging()
@@ -669,6 +620,7 @@ watch(isProfileManagerOpen, (open) => {
 watch(activeSection, () => nextTick(observeActiveSettingsSection))
 
 function handleMounted() {
+  unlocked.value = store.getters.getSettingsPassword === ''
   handleResize(settingsWindowRef.value?.clientWidth ?? windowBounds.value.width)
   setInitialSection()
   nextTick(() => (settingsSearchInputRef.value ?? settingsCloseButtonRef.value)?.focus())
@@ -711,6 +663,7 @@ function stopObserving() {
   settingsResizeObserver = null
   settingsSectionResizeObserver?.disconnect()
   settingsSectionResizeObserver = null
+  settingsContentPaddingBottom = 0
   window.removeEventListener('resize', clampWindowToViewport)
 }
 
@@ -720,6 +673,7 @@ function observeActiveSettingsSection() {
   const content = settingsContentRef.value
   const section = content?.querySelector('.section')
   if (!content || !section) return
+  settingsContentPaddingBottom = Number.parseFloat(getComputedStyle(content).paddingBottom)
 
   settingsSectionResizeObserver = new ResizeObserver(() => {
     clampOverlayScrollTop(content, section)
@@ -732,8 +686,7 @@ function clampSettingsContentScroll(event) {
   const content = event.currentTarget
   const section = content.querySelector('.section')
   if (!section) return
-  const contentEnd = section.offsetTop + section.offsetHeight +
-    Number.parseFloat(getComputedStyle(content).paddingBottom)
+  const contentEnd = section.offsetTop + section.offsetHeight + settingsContentPaddingBottom
   if (content.scrollTop > Math.max(0, contentEnd - content.clientHeight)) {
     clampOverlayScrollTop(content, section)
   }
@@ -832,8 +785,7 @@ function goBack() {
   if (isKeyboardShortcutPromptOpen.value) {
     store.dispatch('hideKeyboardShortcutPrompt')
   } else if (isProfileManagerOpen.value) {
-    store.dispatch('showSettingsWindowRoot')
-    activeSection.value = 'data'
+    returnToSettingsMenu()
   } else if (subpageTitle.value) {
     closeSubpage?.()
   } else {
@@ -1044,8 +996,13 @@ function getInitialBounds() {
 function scheduleBoundsSave() {
   if (boundsSaveTimer !== null) clearTimeout(boundsSaveTimer)
   boundsSaveTimer = setTimeout(() => {
-    localStorage.setItem(SETTINGS_BOUNDS_STORAGE_KEY, JSON.stringify(windowBounds.value))
-    boundsSaveTimer = null
+    try {
+      localStorage.setItem(SETTINGS_BOUNDS_STORAGE_KEY, JSON.stringify(windowBounds.value))
+    } catch {
+      // Bounds are convenience state; storage can be unavailable or full.
+    } finally {
+      boundsSaveTimer = null
+    }
   }, 150)
 }
 </script>

--- a/src/renderer/views/Settings/SettingsRoute.vue
+++ b/src/renderer/views/Settings/SettingsRoute.vue
@@ -14,12 +14,17 @@ const router = useRouter()
 onMounted(async () => {
   const view = route.path.startsWith('/settings/profile') ? 'profile' : null
   await store.dispatch('showSettingsWindow', view)
-  await router.back()
+  const tabId = store.getters.getPresentedTabId ?? store.getters.getActiveTabId
+  const tab = store.getters.getTabById(tabId)
+  const previousRoute = tab?.history[tab.historyIndex - 1]?.route
+  const previousPath = typeof previousRoute === 'string' ? previousRoute : previousRoute?.path
+  const browserBackPath = window.history.state?.back
+  const safePreviousPath = process.env.IS_ELECTRON ? previousPath : browserBackPath
 
-  setTimeout(() => {
-    if (route.path.startsWith('/settings')) {
-      router.replace('/')
-    }
-  }, 100)
+  if (typeof safePreviousPath === 'string' && !safePreviousPath.startsWith('/settings')) {
+    await router.back()
+  } else {
+    await router.replace('/')
+  }
 })
 </script>

--- a/src/renderer/views/Settings/SettingsRoute.vue
+++ b/src/renderer/views/Settings/SettingsRoute.vue
@@ -1,0 +1,25 @@
+<template>
+  <span hidden />
+</template>
+
+<script setup>
+import { onMounted } from 'vue'
+import { useRoute, useRouter } from 'vue-router'
+
+import store from '../../store/index'
+
+const route = useRoute()
+const router = useRouter()
+
+onMounted(async () => {
+  const view = route.path.startsWith('/settings/profile') ? 'profile' : null
+  await store.dispatch('showSettingsWindow', view)
+  await router.back()
+
+  setTimeout(() => {
+    if (route.path.startsWith('/settings')) {
+      router.replace('/')
+    }
+  }, 100)
+})
+</script>

--- a/static/locales/en-US.yaml
+++ b/static/locales/en-US.yaml
@@ -1058,6 +1058,11 @@ Settings:
   Password Dialog:
     Password: Password
     Enter Password To Unlock: Enter password to unlock settings
+    Incorrect Password: Incorrect password
+    Unlock: Unlock
+    Unlocking: Unlocking…
+  Search Settings: Search settings
+  No Settings Found: No settings found
   Password Settings:
     Password Settings: Password
     Set Password To Prevent Access: Set a password to prevent access to settings

--- a/tests/unit/settings-search-config.test.mjs
+++ b/tests/unit/settings-search-config.test.mjs
@@ -1,0 +1,45 @@
+import assert from 'node:assert/strict'
+import { readFile } from 'node:fs/promises'
+import test from 'node:test'
+
+import { load as loadYaml } from 'js-yaml'
+
+import {
+  SETTINGS_SEARCH_EXCLUDED_MESSAGE_PATHS,
+  SETTINGS_SEARCH_KEYS,
+  SETTINGS_SEARCH_SELECT_GROUP_LABELS,
+} from '../../src/renderer/helpers/settings-search-config.js'
+
+const locale = loadYaml(await readFile(
+  new URL('../../static/locales/en-US.yaml', import.meta.url),
+  'utf8'
+))
+const getAtPath = (value, path) => path.split('.').reduce((nested, key) => nested?.[key], value)
+
+test('settings search paths match the canonical locale structure', () => {
+  for (const [section, localePath] of Object.entries(SETTINGS_SEARCH_KEYS)) {
+    const messages = getAtPath(locale, localePath)
+    assert.equal(typeof messages, 'object', `${localePath} must resolve to an object`)
+
+    for (const [groupPath, retainedKeys] of Object.entries(
+      SETTINGS_SEARCH_SELECT_GROUP_LABELS[section] ?? {}
+    )) {
+      const group = getAtPath(messages, groupPath)
+      assert.equal(typeof group, 'object', `${localePath}.${groupPath} must resolve to an object`)
+      for (const retainedKey of retainedKeys) {
+        assert.ok(
+          Object.hasOwn(group, retainedKey),
+          `${localePath}.${groupPath}.${retainedKey} must exist`
+        )
+      }
+    }
+
+    for (const excludedPath of SETTINGS_SEARCH_EXCLUDED_MESSAGE_PATHS[section] ?? []) {
+      assert.notEqual(
+        getAtPath(messages, excludedPath),
+        undefined,
+        `${localePath}.${excludedPath} must exist`
+      )
+    }
+  }
+})


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Make sure to follow the contributing guidelines. -->
<!-- Important note, we may remove your pull request if you do not use this provided PR template correctly. -->
<!-- Agent instructions: Preserve every heading, comment, and marker in this template. Never remove or rewrite the release-note-category:start/end, release-note:start/end, or release-note-image:start/end marker pairs. Never remove or rewrite the Release note images section; leave its contents for a human. -->

## Pull Request Type
<!-- Please select what type of pull request this is: [x] -->
- [ ] Bugfix
- [x] Feature Implementation
- [ ] Documentation
- [ ] Other

## Related issue
<!-- Please link the issue your pull request is referring to. -->
<!-- If this pull request fully resolves the relevant issue, put "closes" before the issue number. -->
<!-- Example: "closes #123456". -->

closes #555

## Description
<!-- Please write a clear and concise description of what the pull request does. -->

Replaces the navigable Settings page with a non-blocking, draggable, resizable window over the current tab.

The window remembers its bounds, uses a responsive category/detail layout, contains scrolling, integrates keyboard shortcuts and existing Settings subpages, and provides cross-category search that navigates to and highlights matching controls. It also improves narrow caption layouts, saved-channel layouts, password feedback, select behavior, breadcrumb navigation, and Settings entry-point toggling.

The previous route-based implementation could replace the active page and leave users without a meaningful way back. Related dialogs also used separate presentation and navigation patterns. This change centralizes those flows inside the Settings window while preserving compatibility for existing Settings routes.

## Release note category
<!-- Select exactly one category. Every pull request must select one. -->
<!-- release-note-category:start -->
- [ ] Not noteworthy
- [x] Highlights
- [ ] More improvements
- [ ] Fixed bugs
<!-- release-note-category:end -->

## Release note
<!-- Required unless "Not noteworthy" is selected. -->
<!-- Write one concise, user-facing entry without a leading bullet. -->
<!-- release-note:start -->
Settings now opens in a draggable, resizable window with responsive categories, integrated subpages, and cross-category search.
<!-- release-note:end -->

## Release note images
<!-- Human-only: Agents must preserve this entire section and leave it empty. -->
<!-- Optional. Paste one or more Markdown images or HTML image tags here. -->
<!-- The release notes will use an HTML image tag and limit images taller than 300 pixels. -->
<!-- release-note-image:start -->
<img width="1044" height="702" alt="image" src="https://github.com/user-attachments/assets/be196edf-e84f-4bae-ab59-89a31e507a6c" />
<!-- release-note-image:end -->

## Testing
<!-- How can reviewers verify that the PR produces correct results? -->
<!-- Please provide instructions so that others can ensure that your pull request would produce correct results. For examples see, https://github.com/FreeTubeApp/FreeTube/pull/5743, https://github.com/FreeTubeApp/FreeTube/pull/7349, https://github.com/FreeTubeApp/FreeTube/pull/5125, https://github.com/FreeTubeApp/FreeTube/pull/7338 -->
<!-- Agent instructions: Only write human-facing steps that explain how to verify the change while running this branch in dev mode. Include expected results and, when applicable, helpful console snippets for interactive verification. Do not include automated checks, commands, results, pass counts, or CI status. -->

1. Open Settings from a normal page. Confirm it animates over the current tab without dimming or blocking the background, and that clicking Settings again closes it.
2. Drag and resize the window. Confirm its position and size survive closing and reopening, scrolling remains inside the window, and no horizontal scrollbar appears.
3. Resize across the responsive breakpoint. Confirm the wide layout shows categories and the selected category side by side; the compact layout shows the category list until a category or search result is selected.
4. Search for labels and help text across multiple categories. Confirm dropdown choices and transient status text are excluded, each query starts at the top, and selecting a result opens and briefly highlights its control.
5. Open Keyboard Shortcuts, Saved Channel Settings, and other nested Settings views. Confirm breadcrumbs and back navigation work and the nested content remains scrollable.
6. Exercise toggles, dropdowns, caption controls, password locking, and reset-to-default behavior at wide and narrow window sizes.

## Additional context
<!-- Add any other context about the pull request here. -->

The legacy Settings routes now open the window and return to the underlying route so existing internal links remain functional. The Default Landing Page selector remains available, but Settings is no longer offered as a landing-page destination.