### PR TITLE
fix(tabs): align vertical pinned tab close button

### DIFF
--- a/e2e/tests/offline/tabs.spec.mjs
+++ b/e2e/tests/offline/tabs.spec.mjs
@@ -513,6 +513,28 @@ test.describe('tab bar', () => {
     expect(submenuBox.y + submenuBox.height).toBeLessThanOrEqual(viewport.height - 8)
   })
 
+  test('aligns close buttons for pinned and unpinned vertical tabs', async ({ page }) => {
+    await page.keyboard.press('Control+t')
+    await page.keyboard.press('F1')
+    await expect(page.locator('.app')).toHaveClass(/verticalTabs/)
+
+    const tabs = page.locator(sel.tabs)
+    const pinnedTab = tabs.first()
+    const unpinnedTab = tabs.nth(1)
+    const pinnedTabId = await pinnedTab.getAttribute('data-tab-id')
+
+    await page.evaluate(tabId => window.ftElectron.tabs.setPinned(tabId, true), pinnedTabId)
+    await expect(pinnedTab).toHaveClass(/pinned/)
+    await pinnedTab.hover()
+
+    const pinnedCloseBox = await pinnedTab.locator('.closeButton').boundingBox()
+    const unpinnedCloseBox = await unpinnedTab.locator('.closeButton').boundingBox()
+
+    expect(pinnedCloseBox).not.toBeNull()
+    expect(unpinnedCloseBox).not.toBeNull()
+    expect(pinnedCloseBox.x).toBe(unpinnedCloseBox.x)
+  })
+
   // Regression: search bar text used to leak between tabs (65f4e2e13)
   test('search bar text is independent per tab', async ({ page }) => {
     const searchInput = page.locator(sel.searchInput)

--- a/src/renderer/components/TabBar/SortableTab.vue
+++ b/src/renderer/components/TabBar/SortableTab.vue
@@ -672,6 +672,10 @@ watch(() => props.disableTooltips, (disableTooltips) => {
   background-color: var(--tab-active-color, var(--card-bg-color));
 }
 
+.tab.vertical.pinned .closeButton {
+  inset-inline-end: 10px;
+}
+
 .tab.pinned:hover .tabTitle {
   padding-inline-end: 12px;
 }


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Make sure to follow the contributing guidelines. -->
<!-- Important note, we may remove your pull request if you do not use this provided PR template correctly. -->
<!-- Agent instructions: Preserve every heading, comment, and marker in this template. Never remove or rewrite the release-note-category:start/end, release-note:start/end, or release-note-image:start/end marker pairs. Never remove or rewrite the Release note images section; leave its contents for a human. -->

## Pull Request Type
<!-- Please select what type of pull request this is: [x] -->
- [x] Bugfix
- [ ] Feature Implementation
- [ ] Documentation
- [ ] Other

## Related issue
<!-- Please link the issue your pull request is referring to. -->
<!-- If this pull request fully resolves the relevant issue, put "closes" before the issue number. -->
<!-- Example: "closes #123456". -->

N/A

## Description
<!-- Please write a clear and concise description of what the pull request does. -->

Aligns the close button of pinned tabs with unpinned tabs in the vertical tab layout. The compact pinned-tab styling positioned the button 3px from the inline edge, bypassing the vertical tab's normal 10px inset and shifting it to the right. A vertical-only override restores the expected position without changing horizontal pinned tabs.

Includes an end-to-end regression test that pins a vertical tab and verifies both close buttons share the same horizontal coordinate.

## Release note category
<!-- Select exactly one category. Every pull request must select one. -->
<!-- release-note-category:start -->
- [ ] Not noteworthy
- [ ] Highlights
- [ ] More improvements
- [x] Fixed bugs
<!-- release-note-category:end -->

## Release note
<!-- Required unless "Not noteworthy" is selected. -->
<!-- Write one concise, user-facing entry without a leading bullet. -->
<!-- release-note:start -->
Pinned tab close buttons are aligned correctly in the vertical tab layout.
<!-- release-note:end -->

## Release note images
<!-- Human-only: Agents must preserve this entire section and leave it empty. -->
<!-- Optional. Paste one or more Markdown images or HTML image tags here. -->
<!-- The release notes will use an HTML image tag and limit images taller than 300 pixels. -->
<!-- release-note-image:start -->

<!-- release-note-image:end -->

## Testing
<!-- How can reviewers verify that the PR produces correct results? -->
<!-- Please provide instructions so that others can ensure that your pull request would produce correct results. For examples see, https://github.com/FreeTubeApp/FreeTube/pull/5743, https://github.com/FreeTubeApp/FreeTube/pull/7349, https://github.com/FreeTubeApp/FreeTube/pull/5125, https://github.com/FreeTubeApp/FreeTube/pull/7338 -->
<!-- Agent instructions: Only write human-facing steps that explain how to verify the change while running this branch in dev mode. Include expected results and, when applicable, helpful console snippets for interactive verification. Do not include automated checks, commands, results, pass counts, or CI status. -->

1. Run the app in dev mode and switch to the vertical tab layout.
2. Open at least two tabs and pin one of them.
3. Hover the pinned tab and compare its close button with the close button on the active unpinned tab.
4. Confirm both close buttons have the same horizontal position.
5. Switch back to the horizontal layout and confirm pinned tabs retain their compact appearance.

## Additional context
<!-- Add any other context about the pull request here. -->

The change uses logical CSS positioning, so the alignment also follows right-to-left layouts.
