### PR TITLE
Morph video thumbnails into newly opened tabs

### DIFF
--- a/e2e/tests/network/search.spec.mjs
+++ b/e2e/tests/network/search.spec.mjs
@@ -16,11 +16,50 @@ test.describe('search', () => {
     await page.locator(sel.searchInput).press('Enter')
     await expect(page.locator('.ft-list-video').first()).toBeVisible({ timeout: 30_000 })
 
-    await page.locator('.ft-list-video .title').first().click()
+    await page.evaluate(() => {
+      window.__viewTransitionSnapshots = []
+      const startViewTransition = document.startViewTransition.bind(document)
+      document.startViewTransition = (update) => {
+        const snapshot = {
+          sourceName: document.querySelector('.ft-list-video .thumbnailImage')?.style.viewTransitionName
+        }
+        window.__viewTransitionSnapshots.push(snapshot)
+        const transition = startViewTransition(async () => {
+          await update()
+          snapshot.targetName = getComputedStyle(document.querySelector('.tabBar .tab:last-of-type')).viewTransitionName
+        })
+        transition.ready.then(
+          () => { snapshot.ready = true },
+          error => { snapshot.readyError = String(error) }
+        )
+        return transition
+      }
+    })
+
+    await page.locator('.ft-list-video .title').first().click({ button: 'middle' })
+    await expect(page.locator(sel.tabs)).toHaveCount(2)
+    await expect(page).toHaveURL(/#\/search\//)
+    await expect(page.locator(sel.tabs).first()).toHaveClass(/active/)
+    await expect.poll(() => page.evaluate(() => window.__viewTransitionSnapshots[0]?.targetName)).toBe('new-tab-thumbnail-morph')
+    await expect.poll(() => page.evaluate(() => window.__viewTransitionSnapshots[0]?.ready)).toBe(true)
+    expect(await page.evaluate(() => window.__viewTransitionSnapshots[0])).toEqual({
+      sourceName: 'new-tab-thumbnail-morph',
+      targetName: 'new-tab-thumbnail-morph',
+      ready: true
+    })
+
+    await page.evaluate(() => {
+      document.documentElement.dataset.reducedMotion = 'reduce'
+    })
+    await page.locator('.ft-list-video .title').nth(1).click({ button: 'middle' })
+    await expect(page.locator(sel.tabs)).toHaveCount(3)
+    expect(await page.evaluate(() => window.__viewTransitionSnapshots)).toHaveLength(1)
+
+    await page.locator(sel.tabs).nth(1).click()
     await expect(page).toHaveURL(/#\/watch\//)
     if (!innertube.replay) {
       // Full watch page hydration needs the real API.
-      await expect(page.locator('.videoTitle')).toBeVisible({ timeout: 30_000 })
+      await expect(page.locator('.tabContent[aria-hidden="false"] .videoTitle')).toBeVisible({ timeout: 30_000 })
     }
   })
 })

--- a/src/renderer/components/FtListVideo/FtListVideo.vue
+++ b/src/renderer/components/FtListVideo/FtListVideo.vue
@@ -1242,7 +1242,11 @@ async function handleWatchPageLinkClick(event) {
     if (event.shiftKey) {
       openVideo()
     } else {
-      await morphThumbnailIntoNewTab(event.currentTarget, openVideo)
+      try {
+        await morphThumbnailIntoNewTab(event.currentTarget, openVideo)
+      } catch (error) {
+        console.error('Failed to open the video in a new tab:', error)
+      }
     }
     return
   }

--- a/src/renderer/components/FtListVideo/FtListVideo.vue
+++ b/src/renderer/components/FtListVideo/FtListVideo.vue
@@ -369,7 +369,10 @@ import { getLocalVideoInfo, parseLocalVideoCollaborators } from '../../helpers/a
 import { isHistoryEntryWatched } from '../../helpers/history.js'
 import { getUpcomingPremiereTimestamp } from '../../helpers/subscription-entries.js'
 import { deArrowData, deArrowThumbnail, getSponsorBlockVideoLabel } from '../../helpers/sponsorblock.js'
-import { requestWatchPageViewTransition } from '../../helpers/viewTransitions.js'
+import {
+  morphThumbnailIntoNewTab,
+  requestWatchPageViewTransition
+} from '../../helpers/viewTransitions.js'
 import { setCollaboratorsLoading } from './collaboratorsLoading.js'
 import thumbnailPlaceholder from '../../assets/img/thumbnail_placeholder.svg'
 
@@ -1189,7 +1192,7 @@ const disableChannelLinks = computed(() => store.getters.getDisableChannelLinks)
 
 const shouldShowCollaboratorsButton = computed(() => !!props.data.hasCollaborators && channelName.value !== null)
 
-function handleWatchPageLinkClick(event) {
+async function handleWatchPageLinkClick(event) {
   // `auxclick` also fires for the right mouse button after `contextmenu`.
   // Treat only middle clicks as opening the video so a new-feed entry is not
   // marked as seen (and removed) while its context menu is open.
@@ -1204,10 +1207,30 @@ function handleWatchPageLinkClick(event) {
     return
   }
 
+  const opensActiveTab = process.env.IS_ELECTRON &&
+    event?.button === 0 &&
+    (event.ctrlKey || event.metaKey) &&
+    !event.shiftKey &&
+    !event.altKey
+
+  if (opensActiveTab) {
+    event.preventDefault()
+    requestWatchPageViewTransition(event.currentTarget, {
+      isShort: props.data.isShort === true && store.getters.getUseCustomShortsPlayer
+    })
+    openInternalPath({
+      path: `/watch/${id.value}`,
+      query: watchPageLinkQuery.value,
+      title: title.value,
+      doCreateNewTab: true
+    })
+    return
+  }
+
   if (process.env.IS_ELECTRON && event?.button === 1) {
     event.preventDefault()
 
-    openInternalPath({
+    const openVideo = () => openInternalPath({
       path: `/watch/${id.value}`,
       query: watchPageLinkQuery.value,
       title: title.value,
@@ -1215,6 +1238,12 @@ function handleWatchPageLinkClick(event) {
       doCreateNewTab: !event.shiftKey,
       makeActive: false
     })
+
+    if (event.shiftKey) {
+      openVideo()
+    } else {
+      await morphThumbnailIntoNewTab(event.currentTarget, openVideo)
+    }
     return
   }
 

--- a/src/renderer/helpers/utils.js
+++ b/src/renderer/helpers/utils.js
@@ -411,7 +411,7 @@ export function openInternalPath({ path, query = undefined, doCreateNewWindow = 
       if (route.startsWith('/')) {
         route = route.substring(1)
       }
-      window.ftElectron.tabs.create({
+      return window.ftElectron.tabs.create({
         route,
         query,
         title,

--- a/src/renderer/helpers/viewTransitions.js
+++ b/src/renderer/helpers/viewTransitions.js
@@ -1,6 +1,9 @@
 import { nextTick } from 'vue'
 
+import { isReducedMotionEnabled } from './reducedMotion'
+
 export const VIDEO_MORPH_NAME = 'video-morph'
+export const NEW_TAB_THUMBNAIL_MORPH_NAME = 'new-tab-thumbnail-morph'
 
 /** @type {HTMLElement | null} */
 let morphSourceElement = null
@@ -17,7 +20,7 @@ let shortMorphRequested = false
  * @param {boolean} [options.isShort] whether the destination uses the Shorts layout
  */
 export function requestWatchPageViewTransition(linkElement, { isShort } = {}) {
-  if (typeof document.startViewTransition !== 'function') {
+  if (typeof document.startViewTransition !== 'function' || isReducedMotionEnabled()) {
     return
   }
 
@@ -34,7 +37,7 @@ export function requestWatchPageViewTransition(linkElement, { isShort } = {}) {
     return
   }
 
-  const thumbnail = linkElement.querySelector('.thumbnailImage')
+  const thumbnail = findThumbnail(linkElement)
 
   // Only name the thumbnail when nothing else on the page carries the name
   // (e.g. the current watch page's player), as duplicate view-transition-names
@@ -46,6 +49,60 @@ export function requestWatchPageViewTransition(linkElement, { isShort } = {}) {
   if (thumbnail instanceof HTMLElement && !hasVisiblePlayer) {
     morphSourceElement = thumbnail
     thumbnail.style.viewTransitionName = VIDEO_MORPH_NAME
+  }
+}
+
+/**
+ * Morph a clicked video thumbnail into a newly created background tab.
+ *
+ * @param {EventTarget | null} linkElement the clicked watch page link
+ * @param {() => Promise<{ id?: string } | null>} createTab creates the background tab
+ */
+export async function morphThumbnailIntoNewTab(linkElement, createTab) {
+  if (typeof document.startViewTransition !== 'function' || isReducedMotionEnabled()) {
+    await createTab()
+    return
+  }
+
+  const thumbnail = linkElement instanceof HTMLElement
+    ? findThumbnail(linkElement)
+    : null
+  if (!(thumbnail instanceof HTMLElement)) {
+    await createTab()
+    return
+  }
+
+  let target = null
+  thumbnail.style.viewTransitionName = NEW_TAB_THUMBNAIL_MORPH_NAME
+
+  const cleanup = () => {
+    thumbnail.style.viewTransitionName = ''
+    if (target) {
+      target.style.viewTransitionName = ''
+    }
+  }
+
+  try {
+    const transition = document.startViewTransition(async () => {
+      const tab = await createTab()
+      await nextTick()
+      // The source remains visible because this is a background-tab creation.
+      // Remove its name after the old snapshot so only the new tab owns the
+      // name when Chromium captures the new state.
+      thumbnail.style.viewTransitionName = ''
+      target = tab?.id
+        ? document.querySelector(`.tab[data-tab-id="${CSS.escape(tab.id)}"]`)
+        : null
+      if (target instanceof HTMLElement) {
+        target.style.viewTransitionName = NEW_TAB_THUMBNAIL_MORPH_NAME
+      }
+    })
+
+    transition.finished.then(cleanup, cleanup)
+    await transition.updateCallbackDone
+  } catch (error) {
+    cleanup()
+    throw error
   }
 }
 
@@ -113,15 +170,31 @@ export function installViewTransitions(router) {
  * @returns {Promise<void>}
  */
 export async function runPendingViewTransition(update) {
-  if (
-    typeof document === 'undefined' ||
-    typeof document.startViewTransition !== 'function' ||
-    navigationRequestedAt === 0 ||
-    Date.now() - navigationRequestedAt > 1000
-  ) {
+  const runTransition = takePendingViewTransition()
+  await runTransition(update)
+}
+
+export function hasPendingViewTransition(maxAge = 1000) {
+  return typeof document !== 'undefined' &&
+    typeof document.startViewTransition === 'function' &&
+    !isReducedMotionEnabled() &&
+    navigationRequestedAt !== 0 &&
+    Date.now() - navigationRequestedAt <= maxAge
+}
+
+/**
+ * Consume a pending thumbnail morph immediately and return a function that can
+ * start it after slower navigation preparation has completed.
+ *
+ * @param {number} [maxAge=1000] maximum age of the pending request in milliseconds
+ * @returns {((update: () => Promise<void> | void) => Promise<void>) & { cancel: () => void }}
+ */
+export function takePendingViewTransition(maxAge = 1000) {
+  if (!hasPendingViewTransition(maxAge)) {
     cleanupMorphSource()
-    await update()
-    return
+    const runWithoutTransition = async (update) => await update()
+    runWithoutTransition.cancel = () => {}
+    return runWithoutTransition
   }
 
   navigationRequestedAt = 0
@@ -129,26 +202,36 @@ export async function runPendingViewTransition(update) {
   morphSourceElement = null
   const shortMorph = shortMorphRequested
   shortMorphRequested = false
-  document.documentElement.classList.add('viewTransitionMorphActive')
-  document.documentElement.classList.toggle('viewTransitionShortMorphActive', shortMorph)
+  let started = false
+  const runTransition = async (update) => {
+    started = true
+    document.documentElement.classList.add('viewTransitionMorphActive')
+    document.documentElement.classList.toggle('viewTransitionShortMorphActive', shortMorph)
 
-  const cleanup = () => {
-    document.documentElement.classList.remove(
-      'viewTransitionMorphActive',
-      'viewTransitionShortMorphActive'
-    )
-    if (source) {
+    const cleanup = () => {
+      document.documentElement.classList.remove(
+        'viewTransitionMorphActive',
+        'viewTransitionShortMorphActive'
+      )
+      if (source) {
+        source.style.viewTransitionName = ''
+      }
+    }
+
+    const transition = document.startViewTransition(async () => {
+      await update()
+      await nextTick()
+    })
+
+    transition.finished.then(cleanup, cleanup)
+    await transition.updateCallbackDone
+  }
+  runTransition.cancel = () => {
+    if (!started && source) {
       source.style.viewTransitionName = ''
     }
   }
-
-  const transition = document.startViewTransition(async () => {
-    await update()
-    await nextTick()
-  })
-
-  transition.finished.then(cleanup, cleanup)
-  await transition.updateCallbackDone
+  return runTransition
 }
 
 function cleanupMorphSource() {
@@ -158,4 +241,9 @@ function cleanupMorphSource() {
     morphSourceElement.style.viewTransitionName = ''
     morphSourceElement = null
   }
+}
+
+function findThumbnail(linkElement) {
+  return linkElement.querySelector('.thumbnailImage') ??
+    linkElement.closest('.ft-list-video')?.querySelector('.thumbnailImage')
 }

--- a/src/renderer/helpers/viewTransitions.js
+++ b/src/renderer/helpers/viewTransitions.js
@@ -218,10 +218,16 @@ export function takePendingViewTransition(maxAge = 1000) {
       }
     }
 
-    const transition = document.startViewTransition(async () => {
-      await update()
-      await nextTick()
-    })
+    let transition
+    try {
+      transition = document.startViewTransition(async () => {
+        await update()
+        await nextTick()
+      })
+    } catch (error) {
+      cleanup()
+      throw error
+    }
 
     transition.finished.then(cleanup, cleanup)
     await transition.updateCallbackDone

--- a/src/renderer/tabs/TabNavigationService.js
+++ b/src/renderer/tabs/TabNavigationService.js
@@ -137,6 +137,7 @@ export class TabNavigationService {
     ) {
       await waitForTabElement(tabId, '.videoPlayer')
       if (this.isTransitionStale(tabId, revision, requestId)) {
+        takePendingViewTransition(TAB_VIEW_TRANSITION_MAX_AGE_MS).cancel()
         return false
       }
     }

--- a/src/renderer/tabs/TabNavigationService.js
+++ b/src/renderer/tabs/TabNavigationService.js
@@ -4,7 +4,11 @@ import { START_LOCATION } from 'vue-router'
 import packageDetails from '../../../package.json'
 import { getFixedInternalRouteTitle } from '../../internalRoutes'
 import { translateWindowTitle } from '../helpers/strings'
-import { runPendingViewTransition } from '../helpers/viewTransitions'
+import {
+  hasPendingViewTransition,
+  runPendingViewTransition,
+  takePendingViewTransition
+} from '../helpers/viewTransitions'
 import { cloneRoute, normalizeRoute } from '../store/modules/tabs'
 import { tabLifecycleService } from './TabLifecycleService'
 import { tabMediaCoordinator } from './TabMediaCoordinator'
@@ -12,6 +16,7 @@ import { tabRuntimeRegistry } from './TabRuntimeRegistry'
 
 const TAB_ROUTE_LOADING_MIN_MS = 450
 const TAB_ROUTE_LOADING_SOURCE = 'route'
+const TAB_VIEW_TRANSITION_MAX_AGE_MS = 10_000
 const MAX_LOGICAL_HISTORY_ENTRIES = 100
 
 let service = null
@@ -34,6 +39,7 @@ export class TabNavigationService {
     this.store = store
     this.latestTransitionRequestId = 0
     this.transitionQueue = Promise.resolve()
+    this.pendingPresentation = null
     this.staleTransitionResolvers = new Map()
     this.loadingSourcesByTabId = new Map()
     this.loadingSuppressedTabIds = new Set()
@@ -48,6 +54,13 @@ export class TabNavigationService {
       return Promise.resolve(false)
     }
 
+    if (
+      this.pendingPresentation?.tabId === tabId &&
+      this.pendingPresentation.revision === revision
+    ) {
+      return this.pendingPresentation.promise
+    }
+
     const requestId = ++this.latestTransitionRequestId
     for (const [olderRequestId, resolve] of this.staleTransitionResolvers) {
       if (olderRequestId < requestId) {
@@ -60,7 +73,16 @@ export class TabNavigationService {
       .catch(error => console.error('Logical tab transition failed:', error))
       .then(() => this.presentTab(tabId, revision, requestId))
 
-    return this.transitionQueue
+    const promise = this.transitionQueue
+    this.pendingPresentation = { tabId, revision, promise }
+    const clearPendingPresentation = () => {
+      if (this.pendingPresentation?.promise === promise) {
+        this.pendingPresentation = null
+      }
+    }
+    promise.then(clearPendingPresentation, clearPendingPresentation)
+
+    return promise
   }
 
   async presentTab(tabId, revision, requestId) {
@@ -109,30 +131,53 @@ export class TabNavigationService {
     }
     targetTab = refreshedTargetTab
 
-    await this.projectRoute(targetTab.route)
-    if (this.isTransitionStale(tabId, revision, requestId)) {
-      return false
+    if (
+      targetTab.route.path.startsWith('/watch/') &&
+      hasPendingViewTransition(TAB_VIEW_TRANSITION_MAX_AGE_MS)
+    ) {
+      await waitForTabElement(tabId, '.videoPlayer')
+      if (this.isTransitionStale(tabId, revision, requestId)) {
+        return false
+      }
     }
 
-    if (outgoingTabId && outgoingTabId !== tabId) {
-      await tabLifecycleService.run(outgoingTabId, 'deactivate', { toTabId: tabId })
+    // Mount readiness can enqueue a duplicate presentation request. Consume
+    // the morph only after that race has settled so the latest request can use
+    // it instead of the stale one cancelling it.
+    const runTransition = takePendingViewTransition(TAB_VIEW_TRANSITION_MAX_AGE_MS)
+    try {
+      await this.projectRoute(targetTab.route)
+      if (this.isTransitionStale(tabId, revision, requestId)) {
+        return false
+      }
+
+      if (outgoingTabId && outgoingTabId !== tabId) {
+        await tabLifecycleService.run(outgoingTabId, 'deactivate', { toTabId: tabId })
+      }
+
+      if (this.isTransitionStale(tabId, revision, requestId)) {
+        return false
+      }
+
+      await runTransition(async () => {
+        this.store.commit('setPresentedTab', tabId)
+        tabMediaCoordinator.setPresented(tabId)
+        this.projectTitle(tabId)
+        await nextTick()
+      })
+      await nextAnimationFrame()
+      this.restoreScroll(tabId)
+
+      await tabLifecycleService.run(tabId, 'activate', { fromTabId: outgoingTabId })
+      if (this.isTransitionStale(tabId, revision, requestId)) {
+        return false
+      }
+
+      window.ftElectron?.tabs?.presented?.(tabId, revision)
+      return true
+    } finally {
+      runTransition.cancel()
     }
-
-    this.store.commit('setPresentedTab', tabId)
-    tabMediaCoordinator.setPresented(tabId)
-    this.projectTitle(tabId)
-
-    await nextTick()
-    await nextAnimationFrame()
-    this.restoreScroll(tabId)
-
-    await tabLifecycleService.run(tabId, 'activate', { fromTabId: outgoingTabId })
-    if (this.isTransitionStale(tabId, revision, requestId)) {
-      return false
-    }
-
-    window.ftElectron?.tabs?.presented?.(tabId, revision)
-    return true
   }
 
   isTransitionStale(tabId, revision, requestId) {
@@ -695,6 +740,31 @@ function urlFromRoute(route) {
 
 function nextAnimationFrame() {
   return new Promise(resolve => window.requestAnimationFrame(() => resolve()))
+}
+
+function waitForTabElement(tabId, selector, timeout = 3000) {
+  const root = tabRuntimeRegistry.getRoot(tabId)
+  if (!root || root.querySelector(selector)) {
+    return Promise.resolve()
+  }
+
+  return new Promise(resolve => {
+    const finish = () => {
+      window.clearTimeout(timeoutId)
+      observer.disconnect()
+      resolve()
+    }
+    const observer = new MutationObserver(() => {
+      if (root.querySelector(selector)) {
+        finish()
+      }
+    })
+    const timeoutId = window.setTimeout(finish, timeout)
+    observer.observe(root, { childList: true, subtree: true })
+    if (root.querySelector(selector)) {
+      finish()
+    }
+  })
 }
 
 function formatDocumentTitle(title) {

--- a/src/renderer/themes.css
+++ b/src/renderer/themes.css
@@ -2155,6 +2155,11 @@ a:visited {
   animation-timing-function: cubic-bezier(0.4, 0, 0.2, 1);
 }
 
+::view-transition-group(new-tab-thumbnail-morph) {
+  animation-duration: 300ms;
+  animation-timing-function: cubic-bezier(0.4, 0, 0.2, 1);
+}
+
 ::view-transition-old(root),
 ::view-transition-new(root) {
   animation-duration: 200ms;


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Make sure to follow the contributing guidelines. -->
<!-- Important note, we may remove your pull request if you do not use this provided PR template correctly. -->
<!-- Agent instructions: Preserve every heading, comment, and marker in this template. Never remove or rewrite the release-note-category:start/end, release-note:start/end, or release-note-image:start/end marker pairs. Never remove or rewrite the Release note images section; leave its contents for a human. -->

## Pull Request Type
<!-- Please select what type of pull request this is: [x] -->
- [ ] Bugfix
- [x] Feature Implementation
- [ ] Documentation
- [ ] Other

## Related issue
<!-- Please link the issue your pull request is referring to. -->
<!-- If this pull request fully resolves the relevant issue, put "closes" before the issue number. -->
<!-- Example: "closes #123456". -->

N/A

## Description
<!-- Please write a clear and concise description of what the pull request does. -->

Morph video thumbnails into the tab bar when a video is middle-clicked into a new background tab. Ctrl/Cmd-clicking into a new active tab also preserves the existing thumbnail-to-player morph.

The tab presentation path now reserves pending transitions until the destination player is mounted and limits the transition callback to the final visual state swap. This avoids Chromium aborting the transition while slower tab mounting and lifecycle work is still running. Background-tab morphs remove the source transition name after the old snapshot so the source and destination do not conflict.

Reduced-motion mode bypasses the View Transition API entirely to avoid zero-duration snapshot flicker.

## Release note category
<!-- Select exactly one category. Every pull request must select one. -->
<!-- release-note-category:start -->
- [ ] Not noteworthy
- [ ] Highlights
- [x] More improvements
- [ ] Fixed bugs
<!-- release-note-category:end -->

## Release note
<!-- Required unless "Not noteworthy" is selected. -->
<!-- Write one concise, user-facing entry without a leading bullet. -->
<!-- release-note:start -->
Video thumbnails now morph into newly opened tabs.
<!-- release-note:end -->

## Release note images
<!-- Human-only: Agents must preserve this entire section and leave it empty. -->
<!-- Optional. Paste one or more Markdown images or HTML image tags here. -->
<!-- The release notes will use an HTML image tag and limit images taller than 300 pixels. -->
<!-- release-note-image:start -->
<img width="577" height="397" alt="Screencast_20260809_113235" src="https://github.com/user-attachments/assets/b5e5072a-be12-464b-8531-c17e25c2c476" />
<!-- release-note-image:end -->

## Testing
<!-- How can reviewers verify that the PR produces correct results? -->
<!-- Please provide instructions so that others can ensure that your pull request would produce correct results. For examples see, https://github.com/FreeTubeApp/FreeTube/pull/5743, https://github.com/FreeTubeApp/FreeTube/pull/7349, https://github.com/FreeTubeApp/FreeTube/pull/5125, https://github.com/FreeTubeApp/FreeTube/pull/7338 -->
<!-- Agent instructions: Only write human-facing steps that explain how to verify the change while running this branch in dev mode. Include expected results and, when applicable, helpful console snippets for interactive verification. Do not include automated checks, commands, results, pass counts, or CI status. -->

1. Open a page containing video cards and middle-click a video thumbnail or title.
2. Confirm the current page remains active while the thumbnail morphs into the newly created background tab.
3. Ctrl/Cmd-click a video and confirm the new active tab still morphs the thumbnail into the player.
4. Enable reduced motion, middle-click another video, and confirm the background tab appears without animation or flicker.
5. Confirm no duplicate view-transition-name or aborted-transition errors appear in the developer console.

## Additional context
<!-- Add any other context about the pull request here. -->

The animation falls back to ordinary tab creation when View Transitions are unavailable or reduced motion is enabled.