### PR TITLE
Show video tags and copy description

### DIFF
--- a/e2e/tests/network/watch.spec.mjs
+++ b/e2e/tests/network/watch.spec.mjs
@@ -244,6 +244,38 @@ test.describe('watch page', () => {
     await expect(page.locator(sel.activeTab).locator('.tabAvatar')).toBeVisible()
   })
 
+  test('shows tags below the description and copies the description', async ({ app, page, innertube }) => {
+    test.skip(innertube.replay, 'watch page hydration needs the real API')
+    await openVideo(page)
+
+    const watchComponent = await page.evaluateHandle(findWatchComponent)
+    await watchComponent.evaluate(async (component) => {
+      const watchView = component.proxy
+      watchView.isLoading = true
+      await watchView.$nextTick()
+      watchView.videoDescription = 'Description to copy'
+      watchView.videoDescriptionHtml = ''
+      watchView.videoTags = ['first tag', 'second tag']
+      watchView.isLoading = false
+      await watchView.$nextTick()
+    })
+
+    const description = page.locator(`${activeTab} .videoDescription`)
+    const descriptionText = description.locator('.description')
+    const tags = description.locator('.videoTags')
+    await expect(tags).toHaveText('Video Tags: first tag, second tag')
+    await expect(description.locator('.descriptionScroll')).toHaveCSS('overflow-anchor', 'none')
+    expect(await descriptionText.evaluate((element, tagsElement) => (
+      Boolean(element.compareDocumentPosition(tagsElement) & Node.DOCUMENT_POSITION_FOLLOWING)
+    ), await tags.elementHandle())).toBe(true)
+    expect(await tags.evaluate(element => element.closest('.descriptionScroll'))).not.toBeNull()
+
+    await description.locator('.descriptionCopyButton button').click()
+    await expect(page.locator('.toast', { hasText: 'Description copied to clipboard' })).toBeVisible()
+    await expect.poll(() => app.electronApp.evaluate(({ clipboard }) => clipboard.readText())).toBe('Description to copy')
+    await watchComponent.dispose()
+  })
+
   test('the sidebar panels use overlay scrollbars', async ({ page, innertube }) => {
     test.skip(innertube.replay, 'watch page hydration needs the real API')
     await openVideo(page)

--- a/src/renderer/components/WatchVideoDescription/WatchVideoDescription.css
+++ b/src/renderer/components/WatchVideoDescription/WatchVideoDescription.css
@@ -6,6 +6,7 @@
 
 .descriptionScroll {
   overflow-y: auto;
+  overflow-anchor: none;
   max-block-size: 20lh;
 
   /* stretch into the card's inline padding so the scrollbar stays anchored to the card edge */
@@ -19,6 +20,14 @@
   line-height: 1.4;
   white-space: pre-wrap;
   overflow-wrap: anywhere;
+  padding-inline-end: 40px;
+}
+
+.descriptionCopyButton {
+  position: absolute;
+  z-index: 2;
+  inset-block-start: 8px;
+  inset-inline-end: 8px;
 }
 
 .descriptionStatus {
@@ -52,6 +61,7 @@
 }
 
 .videoDescription:not(.short) .descriptionStatus {
+  display: block;
   position: relative;
   margin-block-start: 1em;
 }
@@ -69,6 +79,12 @@
   /* bdi is inline by default, block keeps the margins now that it isn't a flex item */
   display: block;
   margin-block: 1em;
+}
+
+.videoTags {
+  display: block;
+  margin-block-start: 1em;
+  overflow-wrap: anywhere;
 }
 
 .gamesHeading {

--- a/src/renderer/components/WatchVideoDescription/WatchVideoDescription.vue
+++ b/src/renderer/components/WatchVideoDescription/WatchVideoDescription.vue
@@ -1,12 +1,20 @@
 <template>
   <FtCard
-    v-if="shownDescription.length > 0 || games.length > 0"
+    v-if="shownDescription.length > 0 || tags.length > 0 || games.length > 0"
     :class="{
       videoDescription: true,
       short: !isExpanded,
       alwaysExpanded
     }"
   >
+    <FtIconButton
+      v-if="shownDescription.length > 0"
+      class="descriptionCopyButton"
+      :title="t('Description.Copy Description')"
+      :icon="['fas', 'copy']"
+      theme="base"
+      @click="copyDescription"
+    />
     <span
       v-if="showControls && !isExpanded && !alwaysExpanded"
       class="descriptionStatus"
@@ -69,26 +77,35 @@
           </li>
         </ul>
       </template>
+      <bdi
+        v-if="tags.length > 0 && isExpanded"
+        class="videoTags"
+      >
+        <strong>{{ t('Description.Video Tags') }}</strong> {{ tags.join(', ') }}
+      </bdi>
+      <span
+        v-if="showControls && isExpanded && !alwaysExpanded"
+        class="descriptionStatus"
+        role="button"
+        tabindex="0"
+        @click="collapseDescription"
+        @keydown.enter.space.prevent="collapseDescription"
+      >
+        {{ $t("Description.Collapse Description") }}
+      </span>
     </div>
-    <span
-      v-if="showControls && isExpanded && !alwaysExpanded"
-      class="descriptionStatus"
-      role="button"
-      tabindex="0"
-      @click="collapseDescription"
-      @keydown.enter.space.prevent="collapseDescription"
-    >
-      {{ $t("Description.Collapse Description") }}
-    </span>
   </FtCard>
 </template>
 
 <script setup>
 import { onMounted, ref, computed, nextTick, useTemplateRef, watch } from 'vue'
+import { useI18n } from 'vue-i18n'
 import FtCard from '../ft-card/ft-card.vue'
+import FtIconButton from '../FtIconButton/FtIconButton.vue'
 import FtTimestampCatcher from '../FtTimestampCatcher.vue'
 
 import { linkifyDescription, linkifyHashtagsAndHandles } from '../../helpers/descriptionLinks'
+import { copyToClipboard } from '../../helpers/utils'
 import { useTabContext } from '../../tabs/TabContext'
 
 import store from '../../store/index'
@@ -101,6 +118,10 @@ const props = defineProps({
   descriptionHtml: {
     type: String,
     default: ''
+  },
+  tags: {
+    type: Array,
+    default: () => [],
   },
   license: {
     type: String,
@@ -118,8 +139,10 @@ const props = defineProps({
 })
 
 const emit = defineEmits(['timestamp-event'])
+const { t } = useI18n()
 
 let shownDescription = ''
+let descriptionText = props.description
 const descriptionScroll = useTemplateRef('descriptionScroll')
 const descriptionContainer = useTemplateRef('descriptionContainer')
 const showFullDescription = ref(false)
@@ -139,6 +162,7 @@ if (props.descriptionHtml !== '') {
   testDiv.innerHTML = parsed
 
   if (!/^\s*$/.test(testDiv.innerText)) {
+    descriptionText ||= testDiv.innerText
     shownDescription = linkifyHashtagsAndHandles(parsed)
   }
 } else {
@@ -171,6 +195,12 @@ const shownGames = computed(() => {
  */
 function onTimestamp(timestamp) {
   emit('timestamp-event', timestamp)
+}
+
+async function copyDescription() {
+  await copyToClipboard(descriptionText, {
+    messageOnSuccess: t('Description.Description Copied')
+  })
 }
 
 /**

--- a/src/renderer/views/Watch/Watch.js
+++ b/src/renderer/views/Watch/Watch.js
@@ -230,6 +230,7 @@ export default defineComponent({
       videoDescription: '',
       videoDescriptionHtml: '',
       videoCategory: '',
+      videoTags: [],
       /** @type {import('../../helpers/video-games').LocalVideoGame[]} */
       videoGames: [],
       license: '',
@@ -1359,6 +1360,7 @@ export default defineComponent({
       this.videoDescription = ''
       this.videoDescriptionHtml = ''
       this.videoCategory = ''
+      this.videoTags = []
       this.videoGames = []
       this.license = ''
       this.videoViewCount = 0
@@ -1829,6 +1831,7 @@ export default defineComponent({
         this.setTabAvatar(this.channelThumbnail)
 
         this.videoCategory = result.basic_info.category ?? ''
+        this.videoTags = result.basic_info.keywords ?? []
         this.videoGenreIsMusic = this.videoCategory === 'Music'
 
         this.updateSubscriptionDetails({
@@ -2344,6 +2347,7 @@ export default defineComponent({
           }
 
           this.videoCategory = result.genre ?? ''
+          this.videoTags = result.keywords ?? []
           this.videoGenreIsMusic = this.videoCategory === 'Music'
 
           this.channelId = result.authorId
@@ -2366,6 +2370,7 @@ export default defineComponent({
           this.initializeVideoQuality()
 
           this.videoPublished = result.published * 1000
+          this.videoDescription = result.description ?? ''
           this.videoDescriptionHtml = result.descriptionHtml
           const recommendedVideos = result.recommendedVideos
 

--- a/src/renderer/views/Watch/Watch.vue
+++ b/src/renderer/views/Watch/Watch.vue
@@ -583,6 +583,7 @@
             v-if="shortsMetadataOpen && !isLoading && !hideVideoDescription"
             :description="videoDescription"
             :description-html="videoDescriptionHtml"
+            :tags="videoTags"
             :license="license"
             :games="videoGames"
             always-expanded
@@ -703,6 +704,7 @@
           v-if="!isLoading && !hideVideoDescription && (!customShortsPlayerActive || fullscreenMetadataOpen)"
           :description="videoDescription"
           :description-html="videoDescriptionHtml"
+          :tags="videoTags"
           :license="license"
           :games="videoGames"
           :always-expanded="fullscreenMetadataOpen"

--- a/static/locales/en-US.yaml
+++ b/static/locales/en-US.yaml
@@ -1673,7 +1673,10 @@ Up Next: Up Next
 Description:
   Expand Description: ...more
   Collapse Description: Show less
+  Copy Description: Copy Description
+  Description Copied: Description copied to clipboard
   Video Category: 'Video Category:'
+  Video Tags: 'Video Tags:'
   Games: Games
 
 #Tooltips


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Make sure to follow the contributing guidelines. -->
<!-- Important note, we may remove your pull request if you do not use this provided PR template correctly. -->
<!-- Agent instructions: Preserve every heading, comment, and marker in this template. Never remove or rewrite the release-note-category:start/end, release-note:start/end, or release-note-image:start/end marker pairs. Never remove or rewrite the Release note images section; leave its contents for a human. -->

## Pull Request Type
<!-- Please select what type of pull request this is: [x] -->
- [ ] Bugfix
- [x] Feature Implementation
- [ ] Documentation
- [ ] Other

## Related issue
<!-- Please link the issue your pull request is referring to. -->
<!-- If this pull request fully resolves the relevant issue, put "closes" before the issue number. -->
<!-- Example: "closes #123456". -->

Closes #558

## Description
<!-- Please write a clear and concise description of what the pull request does. -->

Shows video tags at the bottom of the expanded, scrollable description for both local and Invidious backends. It also adds a copy button pinned to the description card's top-right corner that copies the plain-text description and confirms success with a toast.

The expanded collapse control stays inside the scroll viewport so its scrollbar reaches the card bottom. Scroll anchoring is disabled for this self-contained viewport to prevent one-pixel content jumps while selecting tag text.

## Release note category
<!-- Select exactly one category. Every pull request must select one. -->
<!-- release-note-category:start -->
- [ ] Not noteworthy
- [ ] Highlights
- [x] More improvements
- [ ] Fixed bugs
<!-- release-note-category:end -->

## Release note
<!-- Required unless "Not noteworthy" is selected. -->
<!-- Write one concise, user-facing entry without a leading bullet. -->
<!-- release-note:start -->
Video tags are now shown at the bottom of video descriptions and the description can now also be copied.
<!-- release-note:end -->

## Release note images
<!-- Human-only: Agents must preserve this entire section and leave it empty. -->
<!-- Optional. Paste one or more Markdown images or HTML image tags here. -->
<!-- The release notes will use an HTML image tag and limit images taller than 300 pixels. -->
<!-- release-note-image:start -->
<img width="1147" height="370" alt="image" src="https://github.com/user-attachments/assets/38cf2ca5-21a9-453b-bceb-a1dec3bad908" />
<!-- release-note-image:end -->

## Testing
<!-- How can reviewers verify that the PR produces correct results? -->
<!-- Please provide instructions so that others can ensure that your pull request produces correct results. For examples see, https://github.com/FreeTubeApp/FreeTube/pull/5743, https://github.com/FreeTubeApp/FreeTube/pull/7349, https://github.com/FreeTubeApp/FreeTube/pull/5125, https://github.com/FreeTubeApp/FreeTube/pull/7338 -->
<!-- Agent instructions: Only write human-facing steps that explain how to verify the change while running this branch in dev mode. Include expected results and, when applicable, helpful console snippets for interactive verification. Do not include automated checks, commands, results, pass counts, or CI status. -->

1. Open a video with tags and a long description using each backend.
2. Expand the description and confirm the tags appear at its bottom and scroll naturally with the description.
3. Select text around the tags and confirm the content stays visually stable and the scrollbar reaches the card bottom.
4. Select the copy button in the card's top-right corner and confirm the plain description is copied and a success toast appears.

## Additional context
<!-- Add any other context about the pull request here. -->

The tag list is omitted when a backend does not provide keywords.
