### PR TITLE
fix(tabs): remove horizontal tab separators

### DIFF
--- a/src/renderer/components/TabBar/SortableTab.vue
+++ b/src/renderer/components/TabBar/SortableTab.vue
@@ -469,10 +469,6 @@ watch(() => props.disableTooltips, (disableTooltips) => {
   border-color: var(--tab-border-color, var(--tertiary-text-color));
 }
 
-.tab.vertical::after {
-  display: none;
-}
-
 .tab.vertical.colored {
   box-shadow: inset 2px 0 0 var(--tab-accent-color);
 }
@@ -481,20 +477,6 @@ watch(() => props.disableTooltips, (disableTooltips) => {
   inline-size: calc(100% - 1px);
   min-inline-size: 0;
   max-inline-size: none;
-}
-
-.tab::after {
-  content: '';
-  position: absolute;
-
-  /* Sits in .tabsContainer's padding-block-end, covering the tab bar's inset
-     separator under the active tab without leaving the overflow clip. */
-  inset-block-end: -1px;
-  inset-inline: 0;
-  block-size: 1px;
-  background-color: var(--tab-surface-color, var(--bg-color));
-  opacity: 0;
-  transition: opacity 0.15s ease;
 }
 
 .tab:hover {
@@ -545,10 +527,6 @@ watch(() => props.disableTooltips, (disableTooltips) => {
 .tab.unloaded:hover .tabTitle,
 .tab.unloaded.active .tabTitle,
 .tab.unloaded.loading .tabTitle {
-  opacity: 1;
-}
-
-.tab.active::after {
   opacity: 1;
 }
 

--- a/src/renderer/components/TabBar/TabBar.css
+++ b/src/renderer/components/TabBar/TabBar.css
@@ -6,15 +6,10 @@
      the scrollport clip (overflow-y cannot stay visible while overflow-x scrolls). */
   align-items: flex-end;
   background-color: var(--side-nav-color);
-
-  /* Draw the separator inside the padding box. A border-block-end sits in the
-     border region, and overflow:hidden clips ::after before it can cover it. */
-  box-shadow: inset 0 -1px 0 var(--tertiary-text-color);
   block-size: 32px;
   min-block-size: 32px;
 
-  /* Keep top radii off the title-bar edge. Content is then 31px: 30px tab +
-     1px tabsContainer padding-block-end for the active connector. */
+  /* Keep top radii off the title-bar edge. */
   padding-block-start: 1px;
   padding-inline: 4px;
   gap: 2px;
@@ -47,9 +42,6 @@
 .tabsContainer {
   display: flex;
   min-inline-size: 0;
-
-  /* Room for .tab::after (inset-block-end: -1px) inside this scrollport's clip. */
-  padding-block-end: 1px;
   overflow: auto hidden;
 
   /* The horizontal layout draws its own scrollbar below (.tabsScrollbar). The
@@ -135,7 +127,6 @@
   inline-size: var(--vertical-tab-bar-width, 220px);
   block-size: auto;
   min-block-size: 0;
-  box-shadow: none;
 
   /* No bottom padding: the new-tab button reaches the screen edge, so clicks
      at the very bottom still land on it */
@@ -156,7 +147,6 @@
 .tabBar.vertical .tabsContainer {
   flex-direction: column;
   block-size: 100%;
-  padding-block-end: 0;
   overflow: hidden auto;
   overscroll-behavior: contain;
 }


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Make sure to follow the contributing guidelines. -->
<!-- Important note, we may remove your pull request if you do not use this provided PR template correctly. -->
<!-- Agent instructions: Preserve every heading, comment, and marker in this template. Never remove or rewrite the release-note-category:start/end, release-note:start/end, or release-note-image:start/end marker pairs. Never remove or rewrite the Release note images section; leave its contents for a human. -->

## Pull Request Type
<!-- Please select what type of pull request this is: [x] -->
- [x] Bugfix
- [ ] Feature Implementation
- [ ] Documentation
- [ ] Other

## Related issue
<!-- Please link the issue your pull request is referring to. -->
<!-- If this pull request fully resolves the relevant issue, put "closes" before the issue number. -->
<!-- Example: "closes #123456". -->

Follow-up to #557.

## Description
<!-- Please write a clear and concise description of what the pull request does. -->

Remove the one-pixel horizontal tab-strip separator and active-tab connector introduced while fixing clipped tab corners.

The inset separator painted a bright line below unused tab-bar space in some themes, while the active connector used the base tab surface color and appeared as a dark seam below active tabs in others. Horizontal tabs now reach the bottom of the strip directly, while retaining the top inset, bottom alignment, and overflow clipping that prevent rounded corners from being cut off on macOS.

## Release note category
<!-- Select exactly one category. Every pull request must select one. -->
<!-- release-note-category:start -->
- [ ] Not noteworthy
- [ ] Highlights
- [x] More improvements
- [ ] Fixed bugs
<!-- release-note-category:end -->

## Release note
<!-- Required unless "Not noteworthy" is selected. -->
<!-- Write one concise, user-facing entry without a leading bullet. -->
<!-- release-note:start -->
Removed the separator line when using horizontal tabs
<!-- release-note:end -->

## Release note images
<!-- Human-only: Agents must preserve this entire section and leave it empty. -->
<!-- Optional. Paste one or more Markdown images or HTML image tags here. -->
<!-- The release notes will use an HTML image tag and limit images taller than 300 pixels. -->
<!-- release-note-image:start -->
<img width="405" height="79" alt="image" src="https://github.com/user-attachments/assets/de80313c-074a-4712-b2e3-2198d069793d" />
<!-- release-note-image:end -->

## Testing
<!-- How can reviewers verify that the PR produces correct results? -->
<!-- Please provide instructions so that others can ensure that your pull request would produce correct results. For examples see, https://github.com/FreeTubeApp/FreeTube/pull/5743, https://github.com/FreeTubeApp/FreeTube/pull/7349, https://github.com/FreeTubeApp/FreeTube/pull/5125, https://github.com/FreeTubeApp/FreeTube/pull/7338 -->
<!-- Agent instructions: Only write human-facing steps that explain how to verify the change while running this branch in dev mode. Include expected results and, when applicable, helpful console snippets for interactive verification. Do not include automated checks, commands, results, pass counts, or CI status. -->

1. Enable horizontal tabs and open multiple tabs.
2. Confirm there is no dark seam below the tabs and no light separator below unused tab-bar space or the new-tab button.
3. On macOS, confirm the rounded top corners remain fully visible and are not clipped against the title bar.
4. Switch to vertical tabs and confirm their appearance is unchanged.

## Additional context
<!-- Add any other context about the pull request here. -->

The change was visually verified with the provided themes and with an Intel macOS test package.