### PR TITLE
Add mark as seen action to subscription videos

### DIFF
--- a/e2e/tests/offline/subscriptions-new-feed.spec.mjs
+++ b/e2e/tests/offline/subscriptions-new-feed.spec.mjs
@@ -187,6 +187,7 @@ test.describe('new subscriptions feed', () => {
 
     await expect(video).toBeVisible()
     await expect(video.locator('.newContentDot')).toHaveCount(0)
+    await expect(video).not.toHaveClass(/watched/)
 
     await video.hover()
     await video.locator('.optionsButton').click()

--- a/e2e/tests/offline/subscriptions-new-feed.spec.mjs
+++ b/e2e/tests/offline/subscriptions-new-feed.spec.mjs
@@ -172,6 +172,26 @@ test.describe('new subscriptions feed', () => {
     await expect(video.locator('.optionsButton .iconDropdown')).toBeVisible()
     await expect(video).toBeVisible()
   })
+
+  test('marks a dotted video as seen from its options menu', async ({ page }) => {
+    await goTo(page, 'subscriptions')
+
+    const video = page.locator('.ft-list-video').filter({
+      has: page.getByText('New video', { exact: true })
+    })
+    await expect(video.locator('.newContentDot')).toBeVisible()
+
+    await video.hover()
+    await video.locator('.optionsButton').click()
+    await page.getByRole('option', { name: 'Mark as seen' }).click()
+
+    await expect(video).toBeVisible()
+    await expect(video.locator('.newContentDot')).toHaveCount(0)
+
+    await video.hover()
+    await video.locator('.optionsButton').click()
+    await expect(page.getByRole('option', { name: 'Mark as seen' })).toHaveCount(0)
+  })
 })
 
 test.describe('new feed settings and seen state', () => {
@@ -239,6 +259,29 @@ test.describe('new feed settings and seen state', () => {
     await goTo(relaunched.page, 'subscriptions')
     await relaunched.page.locator('[data-subscription-feed-tab="all"]').click()
     await expect(relaunched.page.getByText('There is no new content.')).toBeVisible()
+  })
+
+  test('marks a video as seen from the New feed even when dots are disabled', async ({ page }) => {
+    await goTo(page, 'subscriptions')
+
+    const regularFeedVideo = page.locator('.ft-list-video').filter({
+      has: page.getByRole('heading', { name: 'New video', exact: true })
+    })
+    await regularFeedVideo.hover()
+    await regularFeedVideo.locator('.optionsButton').click()
+    await expect(page.getByRole('option', { name: 'Mark as seen' })).toHaveCount(0)
+
+    await page.keyboard.press('Escape')
+    await page.locator('[data-subscription-feed-tab="all"]').click()
+
+    const newFeedVideo = page.locator('.ft-list-video').filter({
+      has: page.getByRole('heading', { name: 'New video', exact: true })
+    })
+    await newFeedVideo.hover()
+    await newFeedVideo.locator('.optionsButton').click()
+    await page.getByRole('option', { name: 'Mark as seen' }).click()
+
+    await expect(newFeedVideo).toHaveCount(0)
   })
 
   test('keeps YouTube-style Shorts as portrait grid cards in list display mode', async ({ page }) => {

--- a/src/renderer/components/FtListVideo/FtListVideo.vue
+++ b/src/renderer/components/FtListVideo/FtListVideo.vue
@@ -691,6 +691,13 @@ const dropdownOptions = computed(() => {
     {
       type: 'divider'
     },
+    ...showMarkAsSeen.value
+      ? [{
+          label: t('Subscriptions.Mark as Seen'),
+          value: 'markAsSeen',
+          icon: ['fas', 'check']
+        }]
+      : [],
     ...canMarkAsWatched.value
       ? [{
           label: isWatched.value
@@ -869,6 +876,9 @@ function handleOptionsClick(option) {
     case 'addToQueue':
       addToWatchQueue(false)
       break
+    case 'markAsSeen':
+      markSubscriptionVideoAsSeen()
+      break
     case 'history':
       if (isWatched.value) {
         unmarkAsWatched()
@@ -1025,6 +1035,11 @@ const showNewSubscriptionFeedIndicator = computed(() => {
     props.data.isNewInSubscriptionFeed === true &&
     props.data.hideNewSubscriptionFeedIndicator !== true &&
     !isHistoryEntryWatched(historyEntry.value)
+})
+
+const showMarkAsSeen = computed(() => {
+  return props.data.isNewInSubscriptionFeed === true &&
+    (props.data.isInNewSubscriptionFeed === true || showNewSubscriptionFeedIndicator.value)
 })
 
 /** @type {import('vue').ComputedRef<string>} */

--- a/src/renderer/components/SubscriptionsNew.vue
+++ b/src/renderer/components/SubscriptionsNew.vue
@@ -127,7 +127,11 @@ const newContentByCategory = computed(() => {
         }
 
         seenIds.add(id)
-        entries[category].push({ ...entry, hideNewSubscriptionFeedIndicator: true })
+        entries[category].push({
+          ...entry,
+          hideNewSubscriptionFeedIndicator: true,
+          isInNewSubscriptionFeed: true
+        })
       })
     })
   })

--- a/static/locales/en-US.yaml
+++ b/static/locales/en-US.yaml
@@ -192,6 +192,7 @@ Subscriptions:
   New Feed Refresh Warning Title: Refresh all subscription feeds?
   New Feed Refresh Warning: Refreshing all content types without RSS for {count} subscriptions can take a long time. Do you want to continue?
   New Since Last Refresh: New since last refresh
+  Mark as Seen: Mark as seen
   Mark All as Seen: Mark all as seen
   No New Content: There is no new content.
 More: More


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Make sure to follow the contributing guidelines. -->
<!-- Important note, we may remove your pull request if you do not use this provided PR template correctly. -->
<!-- Agent instructions: Preserve every heading, comment, and marker in this template. Never remove or rewrite the release-note-category:start/end, release-note:start/end, or release-note-image:start/end marker pairs. Never remove or rewrite the Release note images section; leave its contents for a human. -->

## Pull Request Type
<!-- Please select what type of pull request this is: [x] -->
- [ ] Bugfix
- [x] Feature Implementation
- [ ] Documentation
- [ ] Other

## Related issue
<!-- Please link the issue your pull request is referring to. -->
<!-- If this pull request fully resolves the relevant issue, put "closes" before the issue number. -->
<!-- Example: "closes #123456". -->

## Description
<!-- Please write a clear and concise description of what the pull request does. -->
Adds a “Mark as seen” action to video overflow menus. The action is always available for videos on the New subscription feed and appears on other subscription feeds when the new-content dot is visible.

Selecting the action updates the cached seen state without marking the video as watched. On the New feed the video disappears; on other feeds it remains visible while its dot and menu action disappear.

## Release note category
<!-- Select exactly one category. Every pull request must select one. -->
<!-- release-note-category:start -->
- [ ] Not noteworthy
- [ ] Highlights
- [x] More improvements
- [ ] Fixed bugs
<!-- release-note-category:end -->

## Release note
<!-- Required unless "Not noteworthy" is selected. -->
<!-- Write one concise, user-facing entry without a leading bullet. -->
<!-- release-note:start -->
You can now mark individual subscription videos as seen from their overflow menu.
<!-- release-note:end -->

## Release note images
<!-- Human-only: Agents must preserve this entire section and leave it empty. -->
<!-- Optional. Paste one or more Markdown images or HTML image tags here. -->
<!-- The release notes will use an HTML image tag and limit images taller than 300 pixels. -->
<!-- release-note-image:start -->
<img width="320" height="147" alt="image" src="https://github.com/user-attachments/assets/aadac38d-5fd0-4ae9-a39a-76dd7083909a" />
<!-- release-note-image:end -->

## Testing
<!-- How can reviewers verify that the PR produces correct results? -->
<!-- Please provide instructions so that others can ensure that your pull request would produce correct results. For examples see, https://github.com/FreeTubeApp/FreeTube/pull/5743, https://github.com/FreeTubeApp/FreeTube/pull/7349, https://github.com/FreeTubeApp/FreeTube/pull/5125, https://github.com/FreeTubeApp/FreeTube/pull/7338 -->
<!-- Agent instructions: Only write human-facing steps that explain how to verify the change while running this branch in dev mode. Include expected results and, when applicable, helpful console snippets for interactive verification. Do not include automated checks, commands, results, pass counts, or CI status. -->
1. Enable the New subscription feed and refresh subscriptions so it contains an unseen video.
2. Open the video’s overflow menu on the New feed and choose “Mark as seen”. The video should disappear from the feed.
3. Enable new-content indicators and open a regular subscription feed containing an unseen video. Its overflow menu should contain “Mark as seen”.
4. Choose the action. The video should remain in the regular feed, while its new-content dot and “Mark as seen” action disappear.
5. Disable new-content indicators. Regular subscription feed videos should no longer offer the action, while unseen videos on the New feed should continue to offer it.

## Additional context
<!-- Add any other context about the pull request here. -->
“Seen” remains separate from watch-history state.