### PR TITLE
fix(settings): polish modal interactions

### DIFF
--- a/e2e/tests/offline/password-settings.spec.mjs
+++ b/e2e/tests/offline/password-settings.spec.mjs
@@ -6,7 +6,8 @@ test.describe('password protected settings', () => {
     await goTo(page, 'settings')
 
     // Set a password. The settings page stays unlocked for this visit.
-    await page.locator('.settingsMenu [data-section="password"]').click()
+    await page.locator('.settingsMenu [data-section="privacy"]').click()
+    await expect(page.locator('.settingsMenu [data-section="password"]')).toHaveCount(0)
     await page.getByPlaceholder('Set a password to prevent access to settings').fill('hunter2')
     await page.getByRole('button', { name: /^Set password$/i }).click()
     await page.waitForTimeout(1000)
@@ -47,7 +48,7 @@ test.describe('password protected settings', () => {
     await expect(page.getByRole('checkbox', { name: 'Check for Updates' })).toBeVisible()
 
     // Removing the password unlocks settings permanently.
-    await page.locator('.settingsMenu [data-section="password"]').click()
+    await page.locator('.settingsMenu [data-section="privacy"]').click()
     await page.getByRole('button', { name: /^Remove password$/i }).click()
     await page.waitForTimeout(1000)
     ;({ page } = await app.relaunch())

--- a/e2e/tests/offline/settings.spec.mjs
+++ b/e2e/tests/offline/settings.spec.mjs
@@ -36,6 +36,7 @@ test.describe('settings', () => {
     const windowIcon = page.locator('.settingsWindowIcon')
     const breadcrumbLabel = page.locator('.settingsBreadcrumbLabel').first()
     await expect(windowIcon).toBeVisible()
+    await expect(windowIcon).toHaveAttribute('data-icon', 'gear')
     await expect(page.locator('.settingsBreadcrumbCategoryIcon')).toBeVisible()
     const [iconBounds, labelBounds] = await Promise.all([
       windowIcon.boundingBox(),
@@ -48,6 +49,26 @@ test.describe('settings', () => {
     }).locator('[data-icon="pen"]')).toBeVisible()
     await expect(page.locator('.settingsMenu')).toBeVisible()
     await expect(page.locator('.settingsContent > [data-section="general"]')).toBeVisible()
+  })
+
+  test('opens from Preferences without remounting the current feed', async ({ app, page }) => {
+    await goTo(page, 'subscriptions')
+    const subscriptionsPage = page.locator('.subscriptionsPage')
+    await subscriptionsPage.evaluate(element => {
+      element.dataset.settingsShortcutMarker = 'preserved'
+    })
+
+    await app.electronApp.evaluate(({ BrowserWindow }) => {
+      const browserWindow = BrowserWindow.getAllWindows()[0]
+      if (!browserWindow) throw new Error('Browser window was not found')
+      browserWindow.webContents.send('change-view', {
+        route: '/settings',
+        tabId: 'preferences-test'
+      })
+    })
+
+    await expect(page.locator('.settingsWindow')).toBeVisible()
+    await expect(subscriptionsPage).toHaveAttribute('data-settings-shortcut-marker', 'preserved')
   })
 
   test('keeps a direct legacy settings route inside the app', async ({ page }) => {
@@ -65,12 +86,26 @@ test.describe('settings', () => {
 
   test('toggles from the app settings button', async ({ page }) => {
     const settingsButton = page.locator('.navSettingsButton')
+    await expect(settingsButton.locator('[data-icon="gear"]')).toBeVisible()
+    await expect(page.locator('.sideNav').getByText('Settings', { exact: true })).toHaveCount(0)
     await settingsButton.click()
     await expect(page.locator('.settingsWindow')).toBeVisible()
 
     await settingsButton.click()
     await expect(page.locator('.settingsWindow')).toHaveClass(/settings-window-leave-active/)
     await expect(page.locator('.settingsWindow')).toBeHidden()
+  })
+
+  test('restores the last selected category when reopened', async ({ page }) => {
+    await goTo(page, 'settings')
+    await page.locator('.settingsMenu [data-section="privacy"]').click()
+    await expect(page.locator('.settingsContent > [data-section="privacy"]')).toBeVisible()
+
+    await page.locator('.settingsCloseButton').click()
+    await page.locator('.navSettingsButton').click()
+
+    await expect(page.locator('.settingsContent > [data-section="privacy"]')).toBeVisible()
+    await expect(page.locator('.settingsMenu [data-section="privacy"]')).toHaveClass(/active/)
   })
 
   test('focuses its search and closes with Escape', async ({ page }) => {
@@ -135,6 +170,17 @@ test.describe('settings', () => {
       .click()
     await expect(page.locator('.settingsSearchTarget.select')).toBeVisible()
 
+    await page.getByRole('combobox', { name: 'External Player', exact: true }).click()
+    await page.getByRole('option', { name: 'mpv', exact: true }).click()
+    await search.fill('Custom External Player Executable')
+    await page.getByRole('button', { name: 'Custom External Player Executable', exact: true }).click()
+    const executableHighlight = page.locator('input.settingsSearchTarget')
+    await expect(executableHighlight).toHaveAttribute('placeholder', 'Custom External Player Executable')
+    expect(await executableHighlight.evaluate(element => getComputedStyle(element).animationName))
+      .toContain('settings-search-highlight')
+    expect((await executableHighlight.boundingBox()).height).toBeLessThanOrEqual(45)
+    await expect(page.locator('.ft-input-component.settingsSearchTarget')).toHaveCount(0)
+
     await search.fill('test')
     await expect(page.getByRole('button', { name: 'Test Proxy', exact: true })).toBeVisible()
     await expect(page.locator('.settingsSearchResultMatch')).not.toContainText('Clicking on Test Proxy')
@@ -185,6 +231,7 @@ test.describe('settings', () => {
   test('resizes without creating horizontal settings overflow', async ({ page }) => {
     await goTo(page, 'settings')
     const settingsWindow = page.locator('.settingsWindow')
+    await expect(settingsWindow).not.toHaveClass(/settings-window-enter-active/)
     const originalBounds = await settingsWindow.boundingBox()
     const resizeHandle = page.locator('.resize-se')
     const handleBounds = await resizeHandle.boundingBox()
@@ -197,6 +244,8 @@ test.describe('settings', () => {
     const resizedBounds = await settingsWindow.boundingBox()
     expect(resizedBounds.width).toBeLessThan(originalBounds.width)
     expect(resizedBounds.height).toBeLessThan(originalBounds.height)
+    expect(resizedBounds.x).toBeCloseTo(originalBounds.x, 0)
+    expect(resizedBounds.y).toBeCloseTo(originalBounds.y, 0)
     await expect(settingsWindow.locator('.settingsPage')).toHaveClass(/compactSettings/)
     expect(await page.locator('.settingsContent').evaluate(element => {
       const bounds = element.getBoundingClientRect()
@@ -219,6 +268,65 @@ test.describe('settings', () => {
     const restoredBounds = await settingsWindow.boundingBox()
     expect(restoredBounds.width).toBeCloseTo(resizedBounds.width, 0)
     expect(restoredBounds.height).toBeCloseTo(resizedBounds.height, 0)
+  })
+
+  test('animates maximize and restore while preserving its floating bounds', async ({ page }) => {
+    await goTo(page, 'settings')
+    const settingsWindow = page.locator('.settingsWindow')
+    await expect(settingsWindow).not.toHaveClass(/settings-window-enter-active/)
+    const originalBounds = await settingsWindow.boundingBox()
+    await settingsWindow.evaluate(element => {
+      const animate = element.animate.bind(element)
+      element.animate = (...args) => {
+        element.dataset.boundsAnimationStarted = 'true'
+        return animate(...args)
+      }
+    })
+
+    await page.getByRole('button', { name: 'Maximize' }).click()
+    await expect(settingsWindow).toHaveClass(/maximized/)
+    await expect(settingsWindow).toHaveAttribute('data-bounds-animation-started', 'true')
+    const viewport = await page.evaluate(() => ({ width: innerWidth, height: innerHeight }))
+    await expect.poll(async () => (await settingsWindow.boundingBox()).width).toBe(viewport.width)
+    await expect.poll(async () => (await settingsWindow.boundingBox()).height).toBe(viewport.height)
+    await expect(page.locator('.settingsResizeHandle:visible')).toHaveCount(0)
+
+    await settingsWindow.getByRole('button', { name: 'Restore', exact: true }).click()
+    await expect(settingsWindow).not.toHaveClass(/maximized/)
+    await expect.poll(async () => (await settingsWindow.boundingBox()).width)
+      .toBeCloseTo(originalBounds.width, 0)
+    await expect.poll(async () => (await settingsWindow.boundingBox()).height)
+      .toBeCloseTo(originalBounds.height, 0)
+
+    const breadcrumb = page.locator('.settingsBreadcrumb')
+    const breadcrumbBounds = await breadcrumb.boundingBox()
+    await breadcrumb.dblclick({
+      position: { x: breadcrumbBounds.width - 4, y: breadcrumbBounds.height / 2 }
+    })
+    await expect(settingsWindow).toHaveClass(/maximized/)
+    await breadcrumb.dblclick({
+      position: { x: breadcrumbBounds.width - 4, y: breadcrumbBounds.height / 2 }
+    })
+    await expect(settingsWindow).not.toHaveClass(/maximized/)
+
+    await page.getByRole('button', { name: 'Maximize' }).click()
+    await expect(settingsWindow).toHaveClass(/maximized/)
+    await expect(page.locator('body > .os-scrollbar-vertical')).toHaveCSS('visibility', 'hidden')
+    await expect.poll(() => settingsWindow.evaluate(element => element.getAnimations().length)).toBe(0)
+    const dragTargetBounds = await page.locator('.settingsBreadcrumbLabel').first().boundingBox()
+    await page.mouse.move(
+      dragTargetBounds.x + dragTargetBounds.width / 2,
+      dragTargetBounds.y + dragTargetBounds.height / 2
+    )
+    await page.mouse.down()
+    await page.mouse.move(
+      dragTargetBounds.x + dragTargetBounds.width / 2 + 30,
+      dragTargetBounds.y + dragTargetBounds.height / 2 + 20
+    )
+    await expect(settingsWindow).not.toHaveClass(/maximized/)
+    await page.mouse.up()
+    await expect.poll(async () => (await settingsWindow.boundingBox()).width)
+      .toBeCloseTo(originalBounds.width, 0)
   })
 
   test('keeps the settings window inside the narrowest supported viewport', async ({ page }) => {
@@ -293,14 +401,19 @@ test.describe('settings', () => {
     await expect(breadcrumb).not.toContainText('Saved Channel Settings')
   })
 
-  test('uses multiple saved-channel columns in a medium-width window', async ({ page }) => {
+  test('keeps saved-channel controls in two columns without narrow wrapping', async ({ page }) => {
     await page.evaluate(() => {
       const store = document.querySelector('#app').__vue_app__.config.globalProperties.$store
-      return store.dispatch('updateChannelPlaybackSpeeds', JSON.stringify({
-        channel1: 1,
-        channel2: 1.25,
-        channel3: 1.5
-      }))
+      return Promise.all([
+        store.dispatch('updateChannelPlaybackSpeeds', JSON.stringify({
+          channel1: 1,
+          channel2: 1.25,
+          channel3: 1.5
+        })),
+        store.dispatch('updateChannelVideoQualities', JSON.stringify({ channel1: '1080' })),
+        store.dispatch('updateChannelSubtitlesStates', JSON.stringify({ channel1: true })),
+        store.dispatch('updateChannelVolumes', JSON.stringify({ channel1: 0.5 }))
+      ])
     })
     await goTo(page, 'settings')
     await page.locator('.settingsMenu [data-section="channel"]').click()
@@ -308,10 +421,11 @@ test.describe('settings', () => {
 
     const entries = page.locator('.channelEntry')
     await expect(entries).toHaveCount(3)
-    const firstRowTops = await entries.evaluateAll(elements => {
+    const firstEntryPreferences = entries.first().locator('.channelPreference')
+    const preferenceTops = await firstEntryPreferences.evaluateAll(elements => {
       return elements.slice(0, 2).map(element => Math.round(element.getBoundingClientRect().top))
     })
-    expect(new Set(firstRowTops).size).toBe(1)
+    expect(new Set(preferenceTops).size).toBe(1)
 
     await entries.first().locator('.channelLink').click()
     await expect(page.locator('.settingsBreadcrumb')).toContainText('Saved Channel Settings')
@@ -327,9 +441,14 @@ test.describe('settings', () => {
         height: 450
       }))
       const store = document.querySelector('#app').__vue_app__.config.globalProperties.$store
-      return store.dispatch('updateChannelPlaybackSpeeds', JSON.stringify(Object.fromEntries(
-        Array.from({ length: 8 }, (_, index) => [`channel${index}`, 1 + index / 10])
-      )))
+      return Promise.all([
+        store.dispatch('updateChannelPlaybackSpeeds', JSON.stringify(Object.fromEntries(
+          Array.from({ length: 8 }, (_, index) => [`channel${index}`, 1 + index / 10])
+        ))),
+        store.dispatch('updateChannelVideoQualities', JSON.stringify({ channel0: '1080' })),
+        store.dispatch('updateChannelSubtitlesStates', JSON.stringify({ channel0: true })),
+        store.dispatch('updateChannelVolumes', JSON.stringify({ channel0: 0.5 }))
+      ])
     })
     await goTo(page, 'settings')
     await expect(page.locator('.settingsPage')).toHaveClass(/compactSettings/)
@@ -349,6 +468,9 @@ test.describe('settings', () => {
     await page.getByRole('button', { name: /Manage Saved Channels/ }).click()
 
     const channelList = page.locator('.channelListContainer')
+    expect(await page.locator('.channelPreferences').first().evaluate(element => {
+      return getComputedStyle(element).gridTemplateColumns.split(' ').length
+    })).toBe(1)
     expect(await channelList.evaluate(element => element.scrollHeight > element.clientHeight)).toBe(true)
     await channelList.evaluate(element => {
       element.scrollTop = element.scrollHeight

--- a/src/renderer/components/ChannelSettings/ChannelSettings.css
+++ b/src/renderer/components/ChannelSettings/ChannelSettings.css
@@ -50,9 +50,9 @@
 .channelEntry {
   display: flex;
 
-  /* A card only needs room for one preference column. This lets medium-sized
-     settings windows place two channels side by side. */
-  flex: 1 1 360px;
+  /* Keep cards wide enough for two preference columns instead of packing the
+     prompt with narrow cards whose controls have to stack or wrap. */
+  flex: 1 1 520px;
   flex-direction: column;
   max-inline-size: 760px;
   padding: 1em;
@@ -106,7 +106,7 @@
 
 .channelPreferences {
   display: grid;
-  grid-template-columns: repeat(auto-fit, minmax(210px, 1fr));
+  grid-template-columns: repeat(auto-fit, minmax(250px, 1fr));
   gap: 0.5em 1em;
   margin-block-start: 0.75em;
 }

--- a/src/renderer/components/PasswordSettings/PasswordSettings.vue
+++ b/src/renderer/components/PasswordSettings/PasswordSettings.vue
@@ -1,7 +1,8 @@
 <template>
-  <FtSettingsSection
-    :title="$t('Settings.Password Settings.Password Settings')"
-  >
+  <div class="passwordSettings">
+    <h4 class="groupTitle">
+      {{ $t('Settings.Password Settings.Password Settings') }}
+    </h4>
     <FtFlexBox
       v-if="hasStoredPassword"
       class="settingsFlexStart460px"
@@ -30,13 +31,12 @@
         @click="handleSetPassword"
       />
     </FtFlexBox>
-  </FtSettingsSection>
+  </div>
 </template>
 
 <script setup>
 import { computed, ref } from 'vue'
 
-import FtSettingsSection from '../FtSettingsSection/FtSettingsSection.vue'
 import FtInput from '../FtInput/FtInput.vue'
 import FtFlexBox from '../ft-flex-box/ft-flex-box.vue'
 import FtButton from '../FtButton/FtButton.vue'

--- a/src/renderer/components/PrivacySettings.vue
+++ b/src/renderer/components/PrivacySettings.vue
@@ -129,6 +129,7 @@
         @click="showRemovePlaylistsPrompt = true"
       />
     </FtFlexBox>
+    <PasswordSettings />
     <FtPrompt
       v-if="showSearchCachePrompt"
       autosize
@@ -180,6 +181,7 @@ import FtSelect from './FtSelect/FtSelect.vue'
 import FtSettingsSection from './FtSettingsSection/FtSettingsSection.vue'
 import FtSlider from './FtSlider/FtSlider.vue'
 import FtToggleSwitch from './FtToggleSwitch/FtToggleSwitch.vue'
+import PasswordSettings from './PasswordSettings/PasswordSettings.vue'
 
 import store from '../store/index'
 

--- a/src/renderer/components/SideNav/SideNav.vue
+++ b/src/renderer/components/SideNav/SideNav.vue
@@ -165,27 +165,6 @@
         </p>
       </router-link>
       <hr>
-      <button
-        type="button"
-        class="navOption navOptionButton mobileShow smallMobileOnlyHidden"
-        :title="settingsTitle"
-        @click="openSettings"
-      >
-        <div
-          class="thumbnailContainer"
-        >
-          <FontAwesomeIcon
-            :icon="['fas', 'sliders-h']"
-            class="navIcon"
-            :class="applyNavIconExpand"
-          />
-        </div>
-        <p
-          class="navLabel"
-        >
-          {{ $t('Settings.Settings') }}
-        </p>
-      </button>
       <router-link
         class="navOption mobileHidden"
         role="button"
@@ -282,10 +261,6 @@ const appKeyboardShortcuts = computed(() => getConfiguredKeyboardShortcuts(
 
 const SUPPORTS_LOCAL_API = process.env.SUPPORTS_LOCAL_API
 const activeSubscriptionsPerPage = 50
-
-function openSettings() {
-  store.dispatch('toggleSettingsWindow')
-}
 
 const props = defineProps({
   forceExpanded: {
@@ -411,13 +386,6 @@ const historyTitle = computed(() => {
   return localizeAndAddKeyboardShortcutToActionTitle(
     t('History.History'),
     shortcut
-  )
-})
-
-const settingsTitle = computed(() => {
-  return localizeAndAddKeyboardShortcutToActionTitle(
-    t('Settings.Settings'),
-    appKeyboardShortcuts.value.NAVIGATE_TO_SETTINGS
   )
 })
 

--- a/src/renderer/components/SideNavMoreOptions/SideNavMoreOptions.vue
+++ b/src/renderer/components/SideNavMoreOptions/SideNavMoreOptions.vue
@@ -135,25 +135,6 @@
           {{ $t('Stats.Stats') }}
         </p>
       </router-link>
-      <button
-        type="button"
-        class="navOption navOptionButton smallMobileOnlyShow"
-        :title="$t('Settings.Settings')"
-        :aria-label="hideLabelsSideBar ? $t('Settings.Settings') : null"
-        @click="openSettings"
-      >
-        <FontAwesomeIcon
-          :icon="['fas', 'sliders-h']"
-          class="navIcon"
-          :class="applyNavIconExpand"
-        />
-        <p
-          id="settingsNavLabel"
-          class="navLabel"
-        >
-          {{ $t("Settings.Settings") }}
-        </p>
-      </button>
     </div>
     <router-link
       class="navOption navOptionButton mobileShow"
@@ -174,25 +155,6 @@
       </p>
     </router-link>
     <hr>
-    <button
-      type="button"
-      class="navOption navOptionButton mobileShow"
-      :title="$t('Settings.Settings')"
-      :aria-label="hideLabelsSideBar ? $t('Settings.Settings') : null"
-      @click="openSettings"
-    >
-      <FontAwesomeIcon
-        :icon="['fas', 'sliders-h']"
-        class="navIcon"
-        :class="applyNavIconExpand"
-      />
-      <p
-        id="settingsNavLabel"
-        class="navLabel"
-      >
-        {{ $t("Settings.Settings") }}
-      </p>
-    </button>
     <router-link
       class="navOption mobileHidden"
       :title="$t('About.About')"
@@ -257,11 +219,6 @@ const applyNavIconExpand = computed(() => {
 
 function closeMenu() {
   openMoreOptions.value = false
-}
-
-function openSettings() {
-  store.dispatch('toggleSettingsWindow')
-  closeMenu()
 }
 
 function handleClickOutside(event) {

--- a/src/renderer/components/TopNav/TopNav.vue
+++ b/src/renderer/components/TopNav/TopNav.vue
@@ -86,7 +86,7 @@
         >
           <FontAwesomeIcon
             class="navIcon"
-            :icon="['fas', 'sliders-h']"
+            :icon="['fas', 'cog']"
           />
         </button>
         <RouterLink

--- a/src/renderer/helpers/settings-search-config.js
+++ b/src/renderer/helpers/settings-search-config.js
@@ -17,7 +17,6 @@ export const SETTINGS_SEARCH_KEYS = {
   'sponsor-block': 'Settings.SponsorBlock Settings',
   'return-youtube-dislike': 'Settings.Return YouTube Dislike Settings',
   'context-menu-search': 'Settings.Context Menu Search Settings',
-  password: 'Settings.Password Settings',
   experimental: 'Settings.Experimental Settings'
 }
 

--- a/src/renderer/main.js
+++ b/src/renderer/main.js
@@ -87,6 +87,7 @@ import {
   faGamepad,
   faGauge,
   faGaugeHigh,
+  faGear,
   faGlobe,
   faGrip,
   faHashtag,
@@ -241,6 +242,7 @@ library.add(
   faGamepad,
   faGauge,
   faGaugeHigh,
+  faGear,
   faGlobe,
   faGrip,
   faHashtag,
@@ -370,6 +372,10 @@ router.isReady().then(async () => {
 // to avoid accessing electron api from web app build
 if (process.env.IS_ELECTRON) {
   window.ftElectron.handleChangeView((route, tabId) => {
+    if (typeof route === 'string' && (route === '/settings' || route.startsWith('/settings/profile'))) {
+      store.dispatch('showSettingsWindow', route.startsWith('/settings/profile') ? 'profile' : null)
+      return
+    }
     const targetTabId = tabId ?? store.getters.getActiveTabId
     if (route && targetTabId) {
       tabNavigation.push(targetTabId, route)

--- a/src/renderer/store/modules/utils.js
+++ b/src/renderer/store/modules/utils.js
@@ -51,6 +51,7 @@ const state = {
   isKeyboardShortcutPromptShown: false,
   settingsWindowOpen: false,
   settingsWindowView: null,
+  settingsWindowSection: null,
   showSearchFilters: false,
   searchFilterValueChangedByTabId: {},
   progressBarPercentage: 0,
@@ -140,6 +141,10 @@ const getters = {
 
   getSettingsWindowView(state) {
     return state.settingsWindowView
+  },
+
+  getSettingsWindowSection(state) {
+    return state.settingsWindowSection
   },
 
   getShowAddToPlaylistPrompt(state) {
@@ -813,6 +818,10 @@ const mutations = {
 
   setSettingsWindowView (state, payload) {
     state.settingsWindowView = payload
+  },
+
+  setSettingsWindowSection (state, payload) {
+    state.settingsWindowSection = payload
   },
 
   setShowSearchFilters (state, payload) {

--- a/src/renderer/views/Settings/Settings.css
+++ b/src/renderer/views/Settings/Settings.css
@@ -21,6 +21,19 @@
   container-type: inline-size;
 }
 
+.settingsWindow.maximized {
+  max-inline-size: 100vw;
+  max-block-size: 100vh;
+  border-width: 0;
+  border-radius: 0;
+}
+
+/* The app page keeps its own scrollbar behind the modal. Do not let it show
+   through beside the settings content while the modal covers the viewport. */
+:global(body:has(.settingsWindow.maximized) > .os-scrollbar) {
+  visibility: hidden;
+}
+
 .settingsWindow.settings-window-enter-active,
 .settingsWindow.settings-window-leave-active {
   transform-origin: center;
@@ -320,21 +333,24 @@
 }
 
 .settingsContent :deep(.settingsSearchTarget) {
-  animation: settings-search-highlight 2.2s ease-out;
+  outline: 2px solid transparent;
+  outline-offset: 4px;
+  animation: settings-search-highlight 2.2s ease-in-out;
 }
 
 @keyframes settings-search-highlight {
   0%,
-  35% {
-    outline: 2px solid var(--primary-color);
-    outline-offset: 4px;
-    background-color: color-mix(in srgb, var(--primary-color) 20%, transparent);
+  40%,
+  80%,
+  100% {
+    outline-color: transparent;
   }
 
-  100% {
-    outline: 2px solid transparent;
-    outline-offset: 4px;
-    background-color: transparent;
+  10%,
+  30%,
+  50%,
+  70% {
+    outline-color: var(--primary-color);
   }
 }
 

--- a/src/renderer/views/Settings/Settings.vue
+++ b/src/renderer/views/Settings/Settings.vue
@@ -2,6 +2,7 @@
   <section
     ref="settingsWindowRef"
     class="settingsWindow"
+    :class="{ maximized: isMaximized }"
     :style="windowStyle"
     role="dialog"
     :aria-label="t('Settings.Settings')"
@@ -11,6 +12,7 @@
     <header
       class="settingsWindowHeader"
       @pointerdown="startDragging"
+      @dblclick="handleHeaderDoubleClick"
     >
       <button
         v-if="showBackButton"
@@ -34,7 +36,7 @@
         >
           <FontAwesomeIcon
             class="settingsWindowIcon"
-            :icon="['fas', 'sliders-h']"
+            :icon="['fas', 'cog']"
             aria-hidden="true"
           />
           <span class="settingsBreadcrumbText">{{ t('Settings.Settings') }}</span>
@@ -45,7 +47,7 @@
         >
           <FontAwesomeIcon
             class="settingsWindowIcon"
-            :icon="['fas', 'sliders-h']"
+            :icon="['fas', 'cog']"
             aria-hidden="true"
           />
           <span class="settingsBreadcrumbText">{{ t('Settings.Settings') }}</span>
@@ -136,6 +138,15 @@
           @click="updateHighlightChangedSettings(!highlightChangedSettings)"
         >
           <FontAwesomeIcon :icon="['fas', 'pen']" />
+        </button>
+        <button
+          type="button"
+          class="settingsHeaderButton"
+          :aria-label="maximizeButtonLabel"
+          :title="maximizeButtonLabel"
+          @click="toggleMaximized"
+        >
+          <FontAwesomeIcon :icon="isMaximized ? ['fas', 'compress'] : ['fas', 'expand']" />
         </button>
         <button
           ref="settingsCloseButtonRef"
@@ -251,6 +262,7 @@
     </div>
     <div
       v-for="direction in RESIZE_DIRECTIONS"
+      v-show="!isMaximized"
       :key="direction"
       class="settingsResizeHandle"
       :class="`resize-${direction}`"
@@ -295,7 +307,6 @@ import SponsorBlockSettings from '../../components/SponsorBlockSettings.vue'
 import RydSettings from '../../components/RydSettings.vue'
 import ParentalControlSettings from '../../components/ParentalControlSettings.vue'
 import ExperimentalSettings from '../../components/ExperimentalSettings/ExperimentalSettings.vue'
-import PasswordSettings from '../../components/PasswordSettings/PasswordSettings.vue'
 import PasswordDialog from '../../components/PasswordDialog/PasswordDialog.vue'
 import ContextMenuSearchSettings from '../../components/ContextMenuSearchSettings/ContextMenuSearchSettings.vue'
 import FtSettingsMenu from '../../components/FtSettingsMenu/FtSettingsMenu.vue'
@@ -324,7 +335,8 @@ const NON_SETTING_MESSAGE_KEY_PATTERN = /(?:^No\b|^How\b|^Checking\b|^Current .+
 
 const { locale, t, tm } = useI18n()
 const isInDesktopView = ref(true)
-const activeSection = ref(null)
+const isMaximized = ref(false)
+const activeSection = ref(store.getters.getSettingsWindowSection)
 const settingsSearchQuery = ref('')
 const settingsWindowRef = useTemplateRef('settingsWindowRef')
 const settingsPageRef = useTemplateRef('settingsPageRef')
@@ -340,19 +352,30 @@ let settingsSectionResizeObserver = null
 let settingsContentPaddingBottom = 0
 let observationScheduled = false
 let boundsSaveTimer = null
+let boundsAnimation = null
 let searchHighlightTimer = null
 let draggingPointerId = null
 let resizeSession = null
 let dragOffsetX = 0
 let dragOffsetY = 0
+let maximizedDragSession = null
+let restoreBounds = null
 
 const windowBounds = ref(getInitialBounds())
-const windowStyle = computed(() => ({
-  left: `${windowBounds.value.x}px`,
-  top: `${windowBounds.value.y}px`,
-  inlineSize: `${windowBounds.value.width}px`,
-  blockSize: `${windowBounds.value.height}px`
-}))
+const windowStyle = computed(() => isMaximized.value
+  ? {
+      left: '0',
+      top: '0',
+      inlineSize: '100vw',
+      blockSize: '100vh'
+    }
+  : {
+      left: `${windowBounds.value.x}px`,
+      top: `${windowBounds.value.y}px`,
+      inlineSize: `${windowBounds.value.width}px`,
+      blockSize: `${windowBounds.value.height}px`
+    })
+const maximizeButtonLabel = computed(() => isMaximized.value ? t('Restore') : t('Maximize'))
 
 const settingsSectionSortEnabled = computed(() => store.getters.getSettingsSectionSortEnabled)
 const highlightChangedSettings = computed(() => store.getters.getHighlightChangedSettings)
@@ -466,12 +489,6 @@ const settingsComponentsData = computed(() => [
         component: ContextMenuSearchSettings
       }]
     : []),
-  {
-    type: 'password',
-    title: t('Settings.Password Settings.Password Settings'),
-    icon: ['fas', 'key'],
-    component: PasswordSettings
-  },
   ...(process.env.IS_ELECTRON
     ? [{
         type: 'experimental',
@@ -496,6 +513,7 @@ const settingsSectionComponents = computed(() => {
   }, ...sections]
 })
 const settingsSearchExtraValues = computed(() => ({
+  privacy: flattenMessageValues(tm('Settings.Password Settings')),
   proxy: [
     `${t('Settings.Proxy Settings.Clicking on Test Proxy will send a request to')} ` +
     getProxyTestUrl(locale.value)
@@ -607,6 +625,7 @@ onBeforeUnmount(() => {
   if (boundsSaveTimer !== null) {
     clearTimeout(boundsSaveTimer)
   }
+  boundsAnimation?.cancel()
   if (searchHighlightTimer !== null) {
     clearTimeout(searchHighlightTimer)
   }
@@ -617,7 +636,12 @@ watch(isProfileManagerOpen, (open) => {
     setInitialSection()
   }
 })
-watch(activeSection, () => nextTick(observeActiveSettingsSection))
+watch(activeSection, (section) => {
+  if (section !== null) {
+    store.commit('setSettingsWindowSection', section)
+  }
+  nextTick(observeActiveSettingsSection)
+})
 
 function handleMounted() {
   unlocked.value = store.getters.getSettingsPassword === ''
@@ -637,12 +661,19 @@ function handleMounted() {
       const { width, height } = entry.contentRect
       handleResize(width)
       if (width > 0 && height > 0) {
-        windowBounds.value = clampBounds({
-          ...windowBounds.value,
-          width: element.offsetWidth,
-          height: element.offsetHeight
-        })
-        scheduleBoundsSave()
+        if (
+          !isMaximized.value &&
+          boundsAnimation === null &&
+          draggingPointerId === null &&
+          resizeSession === null
+        ) {
+          windowBounds.value = clampBounds({
+            ...windowBounds.value,
+            width: element.offsetWidth,
+            height: element.offsetHeight
+          })
+          scheduleBoundsSave()
+        }
         if (settingsContentRef.value) {
           clampOverlayScrollTop(
             settingsContentRef.value,
@@ -700,8 +731,15 @@ function handleUnlock() {
 function setInitialSection() {
   if (isProfileManagerOpen.value || !unlocked.value || settingsSearchQuery.value !== '') return
   if (isInDesktopView.value && activeSection.value === null) {
-    activeSection.value = settingsSectionComponents.value[0].type
+    activeSection.value = getRememberedSection()
   }
+}
+
+function getRememberedSection() {
+  const rememberedSection = store.getters.getSettingsWindowSection
+  return settingsSectionComponents.value.some(({ type }) => type === rememberedSection)
+    ? rememberedSection
+    : settingsSectionComponents.value[0].type
 }
 
 function navigateToSection(sectionType) {
@@ -727,14 +765,17 @@ async function openSearchResult(sectionType, label) {
   )]
     .filter(element => element.getClientRects().length > 0)
   const labelElement = visibleTextElements
-    .filter(element => normalizeSearchText(element.textContent.trim()) === normalizedLabel)
+    .filter(element => getSearchTargetText(element) === normalizedLabel)
     .at(-1) ?? visibleTextElements
-    .filter(element => normalizeSearchText(element.textContent.trim()).startsWith(`${normalizedLabel}:`))
+    .filter(element => getSearchTargetText(element).startsWith(`${normalizedLabel}:`))
     .at(-1)
-  const target = labelElement?.closest(
+  const control = labelElement?.closest(
     '.switch-ctn, .select, .ft-input-component, .pure-material-slider, ' +
     '.pure-checkbox, .captionControl, .preferenceToggle'
   ) ?? labelElement
+  const target = control?.classList.contains('ft-input-component')
+    ? control.querySelector('.ft-input')
+    : control
   if (!target) return
 
   target.scrollIntoView({ block: 'center', behavior: 'smooth' })
@@ -749,12 +790,18 @@ async function openSearchResult(sectionType, label) {
   }, 2200)
 }
 
+function getSearchTargetText(element) {
+  const clone = element.cloneNode(true)
+  clone.querySelectorAll('.tooltip, .changedSettingIndicator').forEach(child => child.remove())
+  return normalizeSearchText(clone.textContent.trim())
+}
+
 function handleSettingsSearch() {
   closeSubpage?.()
   subpageTitle.value = ''
   closeSubpage = null
   activeSection.value = settingsSearchQuery.value === '' && isInDesktopView.value
-    ? settingsSectionComponents.value[0].type
+    ? getRememberedSection()
     : null
   nextTick(() => {
     if (settingsContentRef.value) settingsContentRef.value.scrollTop = 0
@@ -838,7 +885,7 @@ function handleResize(width) {
   if (desktop === isInDesktopView.value) return
   isInDesktopView.value = desktop
   if (desktop && activeSection.value === null && settingsSearchQuery.value === '') {
-    activeSection.value = settingsSectionComponents.value[0].type
+    activeSection.value = getRememberedSection()
   }
 }
 
@@ -847,18 +894,90 @@ function closeSettings() {
   store.dispatch('hideSettingsWindow')
 }
 
+async function toggleMaximized() {
+  cancelBoundsAnimation()
+  const element = settingsWindowRef.value
+  const from = getWindowAnimationState(element)
+  if (isMaximized.value) {
+    restoreSettingsWindow()
+  } else {
+    restoreBounds = { ...windowBounds.value }
+    isMaximized.value = true
+  }
+  await nextTick()
+  animateWindowBounds(element, from)
+}
+
+function getWindowAnimationState(element) {
+  if (!element) return null
+  const bounds = element.getBoundingClientRect()
+  const style = getComputedStyle(element)
+  return {
+    left: `${bounds.left}px`,
+    top: `${bounds.top}px`,
+    width: `${bounds.width}px`,
+    height: `${bounds.height}px`,
+    borderRadius: style.borderRadius,
+    borderWidth: style.borderWidth
+  }
+}
+
+function animateWindowBounds(element, from) {
+  if (!element || !from || document.documentElement.dataset.reducedMotion === 'reduce') return
+  const to = getWindowAnimationState(element)
+  const animation = element.animate([from, to], {
+    duration: 240,
+    easing: 'cubic-bezier(0.2, 0.8, 0.2, 1)'
+  })
+  boundsAnimation = animation
+  animation.finished.catch(() => {}).finally(() => {
+    if (boundsAnimation === animation) boundsAnimation = null
+  })
+}
+
+function cancelBoundsAnimation() {
+  boundsAnimation?.cancel()
+  boundsAnimation = null
+}
+
+function restoreSettingsWindow() {
+  if (!isMaximized.value) return
+  windowBounds.value = clampBounds(restoreBounds ?? windowBounds.value)
+  restoreBounds = null
+  isMaximized.value = false
+  scheduleBoundsSave()
+}
+
 function handleSettingsEscape(event) {
   if (event.target.closest('[aria-expanded="true"]')) return
   event.stopPropagation()
   closeSettings()
 }
 
+function handleHeaderDoubleClick(event) {
+  if (event.button !== 0 || event.target.closest('button, input, .settingsSearch')) return
+  toggleMaximized()
+}
+
 function startDragging(event) {
   if (event.button !== 0 || event.target.closest('button, input, .settingsSearch')) return
-  const bounds = settingsWindowRef.value.getBoundingClientRect()
+  cancelBoundsAnimation()
+  const renderedBounds = settingsWindowRef.value.getBoundingClientRect()
+  if (isMaximized.value) {
+    const floatingBounds = clampBounds(restoreBounds ?? windowBounds.value)
+    maximizedDragSession = {
+      floatingBounds,
+      horizontalPosition: renderedBounds.width > 0
+        ? (event.clientX - renderedBounds.left) / renderedBounds.width
+        : 0.5,
+      pointerOffsetY: event.clientY - renderedBounds.top
+    }
+  } else {
+    const bounds = windowBounds.value
+    dragOffsetX = event.clientX - bounds.x
+    dragOffsetY = event.clientY - bounds.y
+  }
   draggingPointerId = event.pointerId
-  dragOffsetX = event.clientX - bounds.left
-  dragOffsetY = event.clientY - bounds.top
   document.documentElement.classList.add('draggingSettingsWindow')
   window.addEventListener('pointermove', dragWindow)
   window.addEventListener('pointerup', stopDragging)
@@ -868,6 +987,20 @@ function startDragging(event) {
 
 function dragWindow(event) {
   if (event.pointerId !== draggingPointerId) return
+  if (maximizedDragSession !== null) {
+    const { floatingBounds, horizontalPosition, pointerOffsetY } = maximizedDragSession
+    windowBounds.value = clampBounds({
+      ...floatingBounds,
+      x: event.clientX - floatingBounds.width * horizontalPosition,
+      y: event.clientY - pointerOffsetY
+    })
+    dragOffsetX = event.clientX - windowBounds.value.x
+    dragOffsetY = event.clientY - windowBounds.value.y
+    maximizedDragSession = null
+    restoreBounds = null
+    isMaximized.value = false
+    return
+  }
   windowBounds.value = clampBounds({
     ...windowBounds.value,
     x: event.clientX - dragOffsetX,
@@ -879,6 +1012,7 @@ function stopDragging(event) {
   if (event && event.pointerId !== draggingPointerId) return
   if (draggingPointerId === null) return
   draggingPointerId = null
+  maximizedDragSession = null
   document.documentElement.classList.remove('draggingSettingsWindow')
   window.removeEventListener('pointermove', dragWindow)
   window.removeEventListener('pointerup', stopDragging)
@@ -887,7 +1021,8 @@ function stopDragging(event) {
 }
 
 function startResizing(event, direction) {
-  if (event.button !== 0) return
+  if (event.button !== 0 || isMaximized.value) return
+  cancelBoundsAnimation()
   resizeSession = {
     direction,
     pointerId: event.pointerId,
@@ -957,6 +1092,7 @@ function stopResizing(event) {
 }
 
 function clampWindowToViewport() {
+  if (isMaximized.value) return
   windowBounds.value = clampBounds(windowBounds.value)
 }
 

--- a/static/locales/en-US.yaml
+++ b/static/locales/en-US.yaml
@@ -23,6 +23,8 @@ Toggle fullscreen: Toggle fullscreen
 Window: Window
 Minimize: Minimize
 Close: Close
+Maximize: Maximize
+Restore: Restore
 Close Tab: Close Tab
 Close Confirmation:
   Title: Quit OpenTubeX?


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Make sure to follow the contributing guidelines. -->
<!-- Important note, we may remove your pull request if you do not use this provided PR template correctly. -->
<!-- Agent instructions: Preserve every heading, comment, and marker in this template. Never remove or rewrite the release-note-category:start/end, release-note:start/end, or release-note-image:start/end marker pairs. Never remove or rewrite the Release note images section; leave its contents for a human. -->

## Pull Request Type
<!-- Please select what type of pull request this is: [x] -->
- [x] Bugfix
- [ ] Feature Implementation
- [ ] Documentation
- [ ] Other

## Related issue
<!-- Please link the issue your pull request is referring to. -->
<!-- If this pull request fully resolves the relevant issue, put "closes" before the issue number. -->
<!-- Example: "closes #123456". -->

## Description
<!-- Please write a clear and concise description of what the pull request does. -->
Polishes the new Settings modal and fixes regressions introduced when Settings moved out of a dedicated page.

The modal now has responsive maximize, restore, drag, resize, and header double-click behavior without persistent size transitions. It keeps the selected category between openings, opens directly from the native Preferences action without remounting the active feed, and prevents the underlying page scrollbar from appearing beside maximized Settings content.

This also removes the obsolete sidebar Settings entries, uses the cog icon consistently, improves search-result highlighting, moves password management into Privacy Settings, and restores the saved-channel control layout across window widths.

## Release note category
<!-- Select exactly one category. Every pull request must select one. -->
<!-- release-note-category:start -->
- [x] Not noteworthy
- [ ] Highlights
- [ ] More improvements
- [ ] Fixed bugs
<!-- release-note-category:end -->

## Release note
<!-- Required unless "Not noteworthy" is selected. -->
<!-- Write one concise, user-facing entry without a leading bullet. -->
<!-- release-note:start -->
Improved the Settings modal's navigation, resizing, search highlights, and responsive layouts.
<!-- release-note:end -->

## Release note images
<!-- Human-only: Agents must preserve this entire section and leave it empty. -->
<!-- Optional. Paste one or more Markdown images or HTML image tags here. -->
<!-- The release notes will use an HTML image tag and limit images taller than 300 pixels. -->
<!-- release-note-image:start -->

<!-- release-note-image:end -->

## Testing
<!-- How can reviewers verify that the PR produces correct results? -->
<!-- Please provide instructions so that others can ensure that your pull request would produce correct results. For examples see, https://github.com/FreeTubeApp/FreeTube/pull/5743, https://github.com/FreeTubeApp/FreeTube/pull/7349, https://github.com/FreeTubeApp/FreeTube/pull/5125, https://github.com/FreeTubeApp/FreeTube/pull/7338 -->
<!-- Agent instructions: Only write human-facing steps that explain how to verify the change while running this branch in dev mode. Include expected results and, when applicable, helpful console snippets for interactive verification. Do not include automated checks, commands, results, pass counts, or CI status. -->
1. Open Settings from the header and confirm there is no duplicate Settings entry in the sidebar and that the cog icon is used in both headers.
2. From the Subscriptions feed, press Ctrl+Comma and confirm Settings opens without refreshing or replaying the feed animations.
3. Maximize and restore Settings with both the header button and a double-click on empty header space. Drag a maximized modal to restore it, then drag and resize the floating modal and confirm it stays responsive and does not move while resizing from the bottom-right edge.
4. While maximized, visit both a short Settings category and Keyboard Shortcuts. Confirm there is no inactive page scrollbar and only the content scrollbar appears when scrolling is required.
5. Open Saved Channel Settings at wide and narrow modal sizes. Confirm preference controls use two columns when space permits and stack before labels or controls wrap awkwardly.
6. Select a category, close Settings, and reopen it. Confirm the same category remains selected.
7. Search for Custom External Player Executable and a button setting. Confirm the matched control receives two outline pulses without changing the button color or outlining an oversized wrapper.
8. Open Privacy Settings and confirm password management appears there and remains functional.

## Additional context
<!-- Add any other context about the pull request here. -->
The Preferences fix handles Settings routes before tab navigation, preserving the mounted page behind the modal.
