### PR TITLE
fix(watch): restore loading visuals

### DIFF
--- a/e2e/tests/network/watch.spec.mjs
+++ b/e2e/tests/network/watch.spec.mjs
@@ -275,6 +275,19 @@ test.describe('watch page', () => {
     const collapseControl = description.locator('.descriptionScroll > .descriptionStatus')
     await expect(collapseControl).toBeVisible()
     await expect(collapseControl).toHaveCSS('position', 'sticky')
+    const collapseControlStyles = await collapseControl.evaluate(element => {
+      const style = getComputedStyle(element)
+      const fadeStyle = getComputedStyle(element, '::before')
+      return {
+        fadeBackground: fadeStyle.backgroundImage,
+        fadeHeight: Number.parseFloat(fadeStyle.height),
+        fontSize: Number.parseFloat(style.fontSize),
+        marginBlockStart: Number.parseFloat(style.marginBlockStart)
+      }
+    })
+    expect(collapseControlStyles.fadeBackground).toContain('linear-gradient')
+    expect(collapseControlStyles.fadeHeight).toBeGreaterThan(0)
+    expect(collapseControlStyles.marginBlockStart).toBeGreaterThan(collapseControlStyles.fontSize)
     const maxScrollTop = await descriptionScroll.evaluate(element =>
       element.scrollHeight - element.clientHeight
     )

--- a/e2e/tests/offline/session-restore.spec.mjs
+++ b/e2e/tests/offline/session-restore.spec.mjs
@@ -1,4 +1,5 @@
 import { readFile } from 'node:fs/promises'
+import { createServer } from 'node:http'
 import path from 'node:path'
 
 import { test, expect, sel, goTo } from '../../helpers/app.mjs'
@@ -90,4 +91,54 @@ test('restores tab order, titles, active route, and saved load state across rest
 
   await goTo(page, 'history')
   await expect(restoredTabs.nth(0)).toHaveClass(/active/)
+})
+
+test.describe('active watch tab restore', () => {
+  const watchRestoreSeed = {
+    settings: {
+      backendPreference: 'invidious',
+      defaultInvidiousInstance: '',
+      startupBehavior: 'loadLastActiveTab'
+    },
+    tabSessions: [
+      {
+        _id: 'e2e-window-session',
+        value: {
+          tabs: [
+            {
+              id: WATCH_TAB_ID,
+              url: 'app://bundle/index.html#/watch/jNQXAC9IVRw',
+              title: 'Saved video',
+              isUnloaded: false
+            }
+          ],
+          activeTabId: WATCH_TAB_ID,
+          bounds: { x: 0, y: 0, width: 1600, height: 900, maximized: false }
+        }
+      }
+    ]
+  }
+  const invidiousServer = createServer()
+
+  test.use({
+    seed: watchRestoreSeed
+  })
+
+  test.beforeAll(async () => {
+    await new Promise(resolve => invidiousServer.listen(0, '127.0.0.1', resolve))
+    const address = invidiousServer.address()
+    watchRestoreSeed.settings.defaultInvidiousInstance = `http://127.0.0.1:${address.port}`
+  })
+
+  test.afterAll(async () => {
+    invidiousServer.closeAllConnections()
+    await new Promise(resolve => invidiousServer.close(resolve))
+  })
+
+  test('presents the video player skeleton during startup', async ({ page }) => {
+    await expect(page).toHaveURL(/#\/watch\/jNQXAC9IVRw/)
+    await expect(page.locator(
+      '.tabContent[aria-hidden="false"] .videoPlayerPlaceholder.ft-shimmer'
+    )).toBeVisible()
+  })
 })

--- a/src/renderer/components/WatchVideoDescription/WatchVideoDescription.css
+++ b/src/renderer/components/WatchVideoDescription/WatchVideoDescription.css
@@ -63,9 +63,20 @@
 .videoDescription:not(.short) .descriptionStatus {
   display: block;
   position: sticky;
+  z-index: 1;
   inset-block-end: 0;
-  margin-block-start: 1em;
+  margin-block-start: 1.5em;
   background-color: var(--card-bg-color);
+}
+
+.videoDescription:not(.short) .descriptionStatus::before {
+  position: absolute;
+  inset-block-end: 100%;
+  inset-inline: 0;
+  block-size: 1.5em;
+  background: linear-gradient(transparent, var(--card-bg-color));
+  pointer-events: none;
+  content: '';
 }
 
 .videoDescription.short .descriptionStatus:dir(rtl)::before {

--- a/src/renderer/views/Watch/Watch.scss
+++ b/src/renderer/views/Watch/Watch.scss
@@ -10,11 +10,6 @@
   grid-template: 'video' auto 'info' auto 'sidebar' auto 'comments' auto / minmax(0, 1fr);
 }
 
-.videoPlayerPlaceholder {
-  aspect-ratio: 16 / 9;
-  inline-size: 100%;
-}
-
 .ageRestricted {
   @include single-column-template;
 
@@ -68,6 +63,11 @@
 
   align-items: start;
   display: grid;
+
+  .videoPlayerPlaceholder {
+    aspect-ratio: 16 / 9;
+    inline-size: 100%;
+  }
 
   .videoArea {
     grid-area: video;


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Make sure to follow the contributing guidelines. -->
<!-- Important note, we may remove your pull request if you do not use this provided PR template correctly. -->
<!-- Agent instructions: Preserve every heading, comment, and marker in this template. Never remove or rewrite the release-note-category:start/end, release-note:start/end, or release-note-image:start/end marker pairs. Never remove or rewrite the Release note images section; leave its contents for a human. -->

## Pull Request Type
<!-- Please select what type of pull request this is: [x] -->
- [x] Bugfix
- [ ] Feature Implementation
- [ ] Documentation
- [ ] Other

## Related issue
<!-- Please link the issue your pull request is referring to. -->
<!-- If this pull request fully resolves the relevant issue, put "closes" before the issue number. -->
<!-- Example: "closes #123456". -->

## Description
<!-- Please write a clear and concise description of what the pull request does. -->
Scopes the video player placeholder sizing to the watch layout so its 16:9 skeleton remains visible when an active video tab is restored at startup. The lazy Watch stylesheet's changed cascade order had left the placeholder with an automatic aspect ratio and zero height.

Also improves long expanded descriptions by fading scrolled content beneath the sticky collapse control and restoring more spacing above the control.

## Release note category
<!-- Select exactly one category. Every pull request must select one. -->
<!-- release-note-category:start -->
- [x] Not noteworthy
- [ ] Highlights
- [ ] More improvements
- [ ] Fixed bugs
<!-- release-note-category:end -->

## Release note
<!-- Required unless "Not noteworthy" is selected. -->
<!-- Write one concise, user-facing entry without a leading bullet. -->
<!-- release-note:start -->
Restored the video player loading skeleton when reopening the app on a video tab and improved the expanded description scroll treatment.
<!-- release-note:end -->

## Release note images
<!-- Human-only: Agents must preserve this entire section and leave it empty. -->
<!-- Optional. Paste one or more Markdown images or HTML image tags here. -->
<!-- The release notes will use an HTML image tag and limit images taller than 300 pixels. -->
<!-- release-note-image:start -->

<!-- release-note-image:end -->

## Testing
<!-- How can reviewers verify that the PR produces correct results? -->
<!-- Please provide instructions so that others can ensure that your pull request would produce correct results. For examples see, https://github.com/FreeTubeApp/FreeTube/pull/5743, https://github.com/FreeTubeApp/FreeTube/pull/7349, https://github.com/FreeTubeApp/FreeTube/pull/5125, https://github.com/FreeTubeApp/FreeTube/pull/7338 -->
<!-- Agent instructions: Only write human-facing steps that explain how to verify the change while running this branch in dev mode. Include expected results and, when applicable, helpful console snippets for interactive verification. Do not include automated checks, commands, results, pass counts, or CI status. -->
1. Leave a video tab active, close the app, and reopen it. Confirm that a 16:9 shimmer skeleton fills the player area while the video information is loading.
2. Expand a description long enough to scroll and move to the middle of it. Confirm that "Show less" remains pinned at the bottom, has comfortable spacing above it, and the description content fades out before passing underneath it.
3. Collapse the description and confirm it returns to the top without visual artifacts.

## Additional context
<!-- Add any other context about the pull request here. -->
The startup regression was caused by the player placeholder's base aspect-ratio rule losing in the lazy Watch stylesheet cascade after the recent thumbnail morph changes altered bundle ordering.