### PR TITLE
fix(watch): show metadata while yt-dlp extracts the streams

### DIFF
--- a/src/renderer/views/Watch/Watch.js
+++ b/src/renderer/views/Watch/Watch.js
@@ -20,6 +20,7 @@ import FtShareButton from '../../components/FtShareButton/FtShareButton.vue'
 import FtIconButton from '../../components/FtIconButton/FtIconButton.vue'
 import FtAddToPlaylistDropdown from '../../components/FtAddToPlaylistDropdown/FtAddToPlaylistDropdown.vue'
 import FtPaidPromotionBadge from '../../components/FtPaidPromotionBadge/FtPaidPromotionBadge.vue'
+import FtLoader from '../../components/FtLoader/FtLoader.vue'
 import { calculateColorLuminance } from '../../helpers/colors'
 import { applyAnimationSpeed } from '../../helpers/animationSpeed'
 import { isReducedMotionEnabled } from '../../helpers/reducedMotion'
@@ -146,6 +147,7 @@ export default defineComponent({
     FtIconButton,
     FtAddToPlaylistDropdown,
     FtPaidPromotionBadge,
+    'ft-loader': FtLoader,
   },
   setup: function () {
     const { t, locale } = useI18n()
@@ -264,6 +266,10 @@ export default defineComponent({
       activePlaybackEngine: 'built-in',
       /** @type {string | null} the yt-dlp version that extracted the current streams */
       activePlaybackEngineVersion: null,
+      // yt-dlp is a separate process that takes a while to extract the streams. The
+      // metadata is already there at that point, so the rest of the page is shown
+      // immediately and only the player waits behind a thumbnail placeholder.
+      ytDlpStreamsPending: false,
       legacyFormats: [],
       captions: [],
       currentTime: 0,
@@ -815,6 +821,14 @@ export default defineComponent({
       }
 
       return null
+    },
+
+    /**
+     * The metadata is rendered as soon as the backend responds, but the player can
+     * only be created once the streams it is supposed to play are known.
+     */
+    playerReady() {
+      return !this.isLoading && !this.ytDlpStreamsPending
     },
 
     canSaveWatchProgress() {
@@ -1384,6 +1398,7 @@ export default defineComponent({
       this.sabrData = null
       this.activePlaybackEngine = 'built-in'
       this.activePlaybackEngineVersion = null
+      this.ytDlpStreamsPending = false
       this.legacyFormats = []
       this.captions = []
       this.currentTime = 0
@@ -2261,8 +2276,9 @@ export default defineComponent({
         }
 
         if (!this.isUpcoming) {
-          await this.applyYtDlpPlaybackSource(loadGeneration, videoId)
-          if (!this.isCurrentVideoLoad(loadGeneration, videoId)) { return }
+          // Deliberately not awaited, so that the metadata (title, description,
+          // comments, recommendations, ...) is shown while yt-dlp is still extracting.
+          this.applyYtDlpPlaybackSource(loadGeneration, videoId)
         }
 
         this.updateShortsPlayerState(
@@ -2496,8 +2512,9 @@ export default defineComponent({
           }
 
           if (!this.isUpcoming) {
-            await this.applyYtDlpPlaybackSource(loadGeneration, videoId)
-            if (!this.isCurrentVideoLoad(loadGeneration, videoId)) { return }
+            // Deliberately not awaited, so that the metadata (title, description,
+            // comments, recommendations, ...) is shown while yt-dlp is still extracting.
+            this.applyYtDlpPlaybackSource(loadGeneration, videoId)
           }
 
           this.updateShortsPlayerState(result.lengthSeconds, result.adaptiveFormats)
@@ -3607,6 +3624,10 @@ export default defineComponent({
      * Replaces the streams that the backend provided with the ones yt-dlp extracts.
      * The metadata (captions, chapters, storyboards, ...) keeps coming from the backend,
      * only the playback source is swapped out, so that SABR can be avoided entirely.
+     *
+     * The callers don't await this, they only wait for the metadata. `ytDlpStreamsPending`
+     * is set synchronously here, so the player is held back (behind a thumbnail
+     * placeholder) until the streams it should play are known.
      * @param {number} loadGeneration
      * @param {string} videoId
      */
@@ -3622,6 +3643,27 @@ export default defineComponent({
         return
       }
 
+      this.ytDlpStreamsPending = true
+
+      try {
+        await this.extractYtDlpPlaybackSource(loadGeneration, videoId)
+      } catch (error) {
+        // The callers don't await this, so nothing else can handle it.
+        console.error('Applying the yt-dlp playback source failed', error)
+      } finally {
+        // A stale load has already had its state reset (and may have started its own
+        // extraction), so it must not clear the flag of the load that replaced it.
+        if (this.isCurrentVideoLoad(loadGeneration, videoId)) {
+          this.ytDlpStreamsPending = false
+        }
+      }
+    },
+
+    /**
+     * @param {number} loadGeneration
+     * @param {string} videoId
+     */
+    extractYtDlpPlaybackSource: async function (loadGeneration, videoId) {
       let source
       try {
         source = await getYtDlpPlaybackSource(videoId)

--- a/src/renderer/views/Watch/Watch.js
+++ b/src/renderer/views/Watch/Watch.js
@@ -834,8 +834,10 @@ export default defineComponent({
     canSaveWatchProgress() {
       if (this.isUpcoming || this.isLive) { return false }
 
-      // `this.$refs.player?.hasLoaded` cannot be used in computed property
-      return !this.isLoading
+      // `this.$refs.player?.hasLoaded` cannot be used in computed property.
+      // While the streams are still being extracted there is no player to read a
+      // position from, so the manual save action must not be offered yet either.
+      return this.playerReady
     },
     useSponsorBlock: function () {
       return this.$store.getters.getUseSponsorBlock

--- a/src/renderer/views/Watch/Watch.scss
+++ b/src/renderer/views/Watch/Watch.scss
@@ -15,6 +15,58 @@
   inline-size: 100%;
 }
 
+.streamPlaceholder {
+  background-color: #000;
+  display: grid;
+  overflow: hidden;
+  place-items: center;
+
+  > * {
+    grid-area: 1 / 1;
+  }
+
+  .videoThumbnail {
+    block-size: 100%;
+    object-fit: cover;
+    filter: brightness(0.55);
+  }
+}
+
+.streamPlaceholderOverlay {
+  align-items: center;
+  background-color: rgb(0 0 0 / 90%);
+  border-radius: calc(20px * var(--ui-roundness));
+  color: #fff;
+  display: flex;
+  gap: 10px;
+  max-inline-size: calc(100% - 40px);
+  padding-block: 10px;
+  padding-inline: 20px;
+  // Both are static grid items in the same cell, where the poster (a replaced
+  // element) would otherwise paint over this. A z-index establishes a stacking
+  // context for a grid item even without positioning it.
+  z-index: 1;
+}
+
+.streamPlaceholderSpinner {
+  // `inline-size`/`block-size` don't apply to inline boxes, which would leave
+  // FtLoader's `100%` container resolving against the whole pill
+  display: flex;
+  block-size: 24px;
+  flex: 0 0 auto;
+  inline-size: 24px;
+
+  :deep(.spinner) {
+    block-size: 100%;
+    inline-size: 100%;
+    margin-block: 0;
+  }
+}
+
+.streamPlaceholderText {
+  min-inline-size: 0;
+}
+
 .ageRestricted {
   @include single-column-template;
 

--- a/src/renderer/views/Watch/Watch.vue
+++ b/src/renderer/views/Watch/Watch.vue
@@ -64,8 +64,27 @@
           class="videoPlayer videoPlayerPlaceholder ft-shimmer"
           data-tab-loading-indicator
         />
+        <div
+          v-else-if="ytDlpStreamsPending && (!isUpcoming || playabilityStatus === 'OK') && !errorMessage"
+          class="videoPlayer videoPlayerPlaceholder streamPlaceholder"
+          :class="{ shortsPlayerPlaceholder: customShortsPlayerActive }"
+          data-tab-loading-indicator
+        >
+          <img
+            v-if="thumbnail"
+            :src="thumbnail"
+            class="videoThumbnail"
+            alt=""
+          >
+          <div class="streamPlaceholderOverlay">
+            <span class="streamPlaceholderSpinner">
+              <ft-loader />
+            </span>
+            <span class="streamPlaceholderText">{{ $t("Video.Fetching Streams") }}</span>
+          </div>
+        </div>
         <ft-shaka-video-player
-          v-if="!isLoading && (!isUpcoming || playabilityStatus === 'OK') && !errorMessage"
+          v-if="playerReady && (!isUpcoming || playabilityStatus === 'OK') && !errorMessage"
           ref="player"
           :manifest-src="manifestSrc"
           :manifest-mime-type="manifestMimeType"

--- a/static/locales/en-US.yaml
+++ b/static/locales/en-US.yaml
@@ -1228,6 +1228,7 @@ Video:
   Drag to Reorder Queue: 'Drag {title} to reorder queue'
   Metadata: Video information
   Close Metadata: Close video information
+  Fetching Streams: Fetching streams with yt-dlp…
   Transcript:
     Title: Transcript
     Search: Search transcript


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Make sure to follow the contributing guidelines. -->
<!-- Important note, we may remove your pull request if you do not use this provided PR template correctly. -->
<!-- Agent instructions: Preserve every heading, comment, and marker in this template. Never remove or rewrite the release-note-category:start/end, release-note:start/end, or release-note-image:start/end marker pairs. Never remove or rewrite the Release note images section; leave its contents for a human. -->

## Pull Request Type
<!-- Please select what type of pull request this is: [x] -->
- [x] Bugfix
- [ ] Feature Implementation
- [ ] Documentation
- [ ] Other

## Related issue
<!-- Please link the issue your pull request is referring to. -->
<!-- If this pull request fully resolves the relevant issue, put "closes" before the issue number. -->
<!-- Example: "closes #123456". -->
None, this follows up on the switch to yt-dlp for stream extraction.

## Description
<!-- Please write a clear and concise description of what the pull request does. -->
With the playback engine set to yt-dlp, the watch view stayed a skeleton for a long time. The yt-dlp playback source was awaited before `isLoading` was cleared, so the title, description, comments, recommendations and the whole sidebar all waited on the separate yt-dlp process, even though the backend metadata had already arrived.

The extraction is now started without awaiting it and tracked in a new `ytDlpStreamsPending` flag, which is set synchronously so the caller sees it immediately. The metadata renders as soon as the backend responds, while the player area shows the video thumbnail as a poster with a "Fetching streams with yt-dlp…" indicator until the streams are known.

The player mount is gated on a new `playerReady` computed (`!isLoading && !ytDlpStreamsPending`) instead of `!isLoading`. That matters: without it the player would briefly mount against the backend's SABR manifest before yt-dlp swaps it out, which is exactly what selecting yt-dlp is meant to avoid.

The pending flag is only cleared when `isCurrentVideoLoad` still matches, so a superseded load cannot clear the flag of the load that replaced it, and the fire-and-forget call has its own `catch` since nothing awaits it anymore.

## Release note category
<!-- Select exactly one category. Every pull request must select one. -->
<!-- release-note-category:start -->
- [ ] Not noteworthy
- [ ] Highlights
- [ ] More improvements
- [x] Fixed bugs
<!-- release-note-category:end -->

## Release note
<!-- Required unless "Not noteworthy" is selected. -->
<!-- Write one concise, user-facing entry without a leading bullet. -->
<!-- release-note:start -->
Video information is now shown immediately when using yt-dlp for stream extraction, instead of waiting for yt-dlp to finish before anything appears
<!-- release-note:end -->

## Release note images
<!-- Human-only: Agents must preserve this entire section and leave it empty. -->
<!-- Optional. Paste one or more Markdown images or HTML image tags here. -->
<!-- The release notes will use an HTML image tag and limit images taller than 300 pixels. -->
<!-- release-note-image:start -->

<!-- release-note-image:end -->

## Testing
<!-- How can reviewers verify that the PR produces correct results? -->
<!-- Please provide instructions so that others can ensure that your pull request would produce correct results. For examples see, https://github.com/FreeTubeApp/FreeTube/pull/5743, https://github.com/FreeTubeApp/FreeTube/pull/7349, https://github.com/FreeTubeApp/FreeTube/pull/5125, https://github.com/FreeTubeApp/FreeTube/pull/7338 -->
<!-- Agent instructions: Only write human-facing steps that explain how to verify the change while running this branch in dev mode. Include expected results and, when applicable, helpful console snippets for interactive verification. Do not include automated checks, commands, results, pass counts, or CI status. -->
1. In Settings > General, set the video playback engine to yt-dlp, and make sure yt-dlp is available (External Software settings).
2. Open any regular video.
3. Expected: the title, channel, description, recommendations and comments appear as soon as the metadata is loaded. The player area shows the video thumbnail with a spinner and "Fetching streams with yt-dlp…" while yt-dlp is still running, and is replaced by the player once the streams are ready.
4. Open a video while yt-dlp is slow (or temporarily point it at a non-existent yt-dlp path) to check the fallback: the toast about falling back to the built-in engine appears and the player loads with the backend streams.
5. Navigate to another video while the indicator is still showing, to confirm the placeholder follows the new video and does not get stuck.
6. Also worth checking with the playback engine set to the built-in one, where the behaviour should be unchanged, and on a Short with the custom Shorts player enabled.

## Additional context
<!-- Add any other context about the pull request here. -->
The poster placeholder needs `z-index: 1` on the overlay: the thumbnail and the indicator are stacked grid items in the same cell, and without it the replaced image paints over the indicator's background and label, leaving only the absolutely positioned spinner dots visible.
