### PR TITLE
fix(player): correct overlapping seekbar labels and overlays

### DIFF
--- a/src/renderer/components/ft-shaka-video-player/ft-shaka-video-player.css
+++ b/src/renderer/components/ft-shaka-video-player/ft-shaka-video-player.css
@@ -46,6 +46,11 @@
   opacity: 1;
 }
 
+.ftVideoPlayer:fullscreen > .paidPromotionOverlay {
+  /* Keep the badge clear of the single-line fullscreen title overlay. */
+  inset-block-start: 65px;
+}
+
 .ftVideoPlayer.shortsPlayer {
   /*
     Keep the container from becoming a focus-scroll area and let the seek

--- a/src/renderer/components/ft-shaka-video-player/ft-shaka-video-player.css
+++ b/src/renderer/components/ft-shaka-video-player/ft-shaka-video-player.css
@@ -46,7 +46,7 @@
   opacity: 1;
 }
 
-.ftVideoPlayer:fullscreen > .paidPromotionOverlay {
+.ftVideoPlayer:is(:fullscreen, .fullWindow) > .paidPromotionOverlay {
   /* Keep the badge clear of the single-line fullscreen title overlay. */
   inset-block-start: 65px;
 }

--- a/src/renderer/components/ft-shaka-video-player/ft-shaka-video-player.js
+++ b/src/renderer/components/ft-shaka-video-player/ft-shaka-video-player.js
@@ -68,6 +68,7 @@ import { findLegacyFormatForQuality } from '../../helpers/player/legacyFormats'
 import { shouldStartPaidPromotionTimer } from '../../helpers/player/paidPromotion'
 import { resolveSponsorBlockEnterTarget, resolveSponsorBlockEnterTargets } from '../../helpers/player/sponsorBlockShortcut'
 import { createSponsorBlockMuteController } from '../../helpers/player/sponsorBlockMute'
+import { findSponsorBlockSeekBarSegment } from '../../helpers/player/sponsorBlockSeekBar'
 import { matchesKeyboardShortcut } from '../../helpers/keyboardShortcuts'
 import { voteOnSponsorBlockSegment } from '../../helpers/sponsorblock'
 import {
@@ -3655,14 +3656,7 @@ export default defineComponent({
       const segments = sponsorBlockSegments.concat(
         sponsorBlockCompleteDraftSegments.value.filter(segment => !isSponsorBlockFullVideoSegment(segment))
       )
-      const pointTolerance = Math.max(secondsPerPixel, 0.5)
-      const segment = segments.find((candidate) => {
-        if (isSponsorBlockPointSegment(candidate)) {
-          return Math.abs(hoverTime - candidate.startTime) <= pointTolerance
-        }
-
-        return hoverTime >= candidate.startTime && hoverTime <= candidate.endTime
-      })
+      const segment = findSponsorBlockSeekBarSegment(segments, hoverTime, secondsPerPixel)
 
       return segment ? translateSponsorBlockCategory(segment.category) : ''
     }

--- a/src/renderer/helpers/player/sponsorBlockSeekBar.js
+++ b/src/renderer/helpers/player/sponsorBlockSeekBar.js
@@ -1,0 +1,18 @@
+/**
+ * Selects the topmost SponsorBlock marker at a seekbar time.
+ * Markers later in the array are painted above earlier markers.
+ * @param {{ category: string, actionType?: string, startTime: number, endTime: number }[]} segments
+ * @param {number} hoverTime
+ * @param {number} secondsPerPixel
+ */
+export function findSponsorBlockSeekBarSegment(segments, hoverTime, secondsPerPixel) {
+  const pointTolerance = Math.max(secondsPerPixel, 0.5)
+
+  return segments.findLast((segment) => {
+    if (segment.actionType === 'poi' || segment.category === 'poi_highlight') {
+      return Math.abs(hoverTime - segment.startTime) <= pointTolerance
+    }
+
+    return hoverTime >= segment.startTime && hoverTime <= segment.endTime
+  }) ?? null
+}

--- a/tests/unit/sponsorblock-seekbar.test.mjs
+++ b/tests/unit/sponsorblock-seekbar.test.mjs
@@ -1,0 +1,19 @@
+import assert from 'node:assert/strict'
+import test from 'node:test'
+
+import { findSponsorBlockSeekBarSegment } from '../../src/renderer/helpers/player/sponsorBlockSeekBar.js'
+
+test('selects the topmost marker when SponsorBlock segments overlap', () => {
+  const filler = { category: 'filler', actionType: 'skip', startTime: 10, endTime: 30 }
+  const selfPromotion = { category: 'selfpromo', actionType: 'skip', startTime: 20, endTime: 25 }
+
+  assert.equal(findSponsorBlockSeekBarSegment([filler, selfPromotion], 22, 0.1), selfPromotion)
+  assert.equal(findSponsorBlockSeekBarSegment([filler, selfPromotion], 15, 0.1), filler)
+})
+
+test('selects point markers within the visible hover tolerance', () => {
+  const segment = { category: 'poi_highlight', actionType: 'poi', startTime: 20, endTime: 20 }
+
+  assert.equal(findSponsorBlockSeekBarSegment([segment], 20.4, 0.1), segment)
+  assert.equal(findSponsorBlockSeekBarSegment([segment], 20.6, 0.1), null)
+})


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Make sure to follow the contributing guidelines. -->
<!-- Important note, we may remove your pull request if you do not use this provided PR template correctly. -->
<!-- Agent instructions: Preserve every heading, comment, and marker in this template. Never remove or rewrite the release-note-category:start/end, release-note:start/end, or release-note-image:start/end marker pairs. Never remove or rewrite the Release note images section; leave its contents for a human. -->

## Pull Request Type
<!-- Please select what type of pull request this is: [x] -->
- [x] Bugfix
- [ ] Feature Implementation
- [ ] Documentation
- [ ] Other

## Related issue
<!-- Please link the issue your pull request is referring to. -->
<!-- If this pull request fully resolves the relevant issue, put "closes" before the issue number. -->
<!-- Example: "closes #123456". -->

N/A

## Description
<!-- Please write a clear and concise description of what the pull request does. -->

This fixes two overlapping player UI elements:

- When SponsorBlock segments overlap, their seekbar markers are painted in array order, with later markers appearing above earlier ones. The hover tooltip previously selected the first matching segment, so its label could disagree with the visible marker. The tooltip now selects the last matching segment and has focused coverage for overlapping and point markers.
- In fullscreen, the paid-promotion badge could overlap the single-line title overlay. The badge now moves below the title while fullscreen is active.

## Release note category
<!-- Select exactly one category. Every pull request must select one. -->
<!-- release-note-category:start -->
- [ ] Not noteworthy
- [ ] Highlights
- [ ] More improvements
- [x] Fixed bugs
<!-- release-note-category:end -->

## Release note
<!-- Required unless "Not noteworthy" is selected. -->
<!-- Write one concise, user-facing entry without a leading bullet. -->
<!-- release-note:start -->

SponsorBlock hover labels now match overlapping seekbar segments.
<!-- release-note:end -->

## Release note images
<!-- Human-only: Agents must preserve this entire section and leave it empty. -->
<!-- Optional. Paste one or more Markdown images or HTML image tags here. -->
<!-- The release notes will use an HTML image tag and limit images taller than 300 pixels. -->
<!-- release-note-image:start -->

<!-- release-note-image:end -->

## Testing
<!-- How can reviewers verify that the PR produces correct results? -->
<!-- Please provide instructions so that others can ensure that your pull request produces correct results. For examples see, https://github.com/FreeTubeApp/FreeTube/pull/5743, https://github.com/FreeTubeApp/FreeTube/pull/7349, https://github.com/FreeTubeApp/FreeTube/pull/5125, https://github.com/FreeTubeApp/FreeTube/pull/7338 -->
<!-- Agent instructions: Only write human-facing steps that explain how to verify the change while running this branch in dev mode. Include expected results and, when applicable, helpful console snippets for interactive verification. Do not include automated checks, commands, results, pass counts, or CI status. -->

### SponsorBlock overlap

1. Enable SponsorBlock and configure both Unpaid/Self Promotion and Tangents/Jokes to appear on the seekbar.
2. Open https://youtu.be/44kR4ZW3fGo in the app.
3. Hover the seekbar around 5:39, where the two segments overlap.
4. Confirm the hover preview says “Unpaid/Self Promotion”, matching the topmost visible marker, instead of “Tangents”.

### Fullscreen paid-promotion badge

1. Open a video that displays the paid-promotion badge.
2. Enter fullscreen and reveal the single-line title overlay.
3. Confirm the paid-promotion badge appears below the title and does not overlap it.
4. Exit fullscreen and confirm the badge returns to its normal position.

## Additional context
<!-- Add any other context about the pull request here. -->

The SponsorBlock reproduction video is used only for manual verification; the regression test uses synthetic segment data.