### PR TITLE
fix(i18n): use plural forms for count-based strings

### DIFF
--- a/src/renderer/components/CommentSection/CommentSection.vue
+++ b/src/renderer/components/CommentSection/CommentSection.vue
@@ -823,7 +823,7 @@ const commentsTitle = computed(() => {
     return t('Comments.Comments')
   }
 
-  return `${formattedCommentCount.value} ${t('Comments.Comments')}`
+  return t('Comments.Comment Count', { count: formattedCommentCount.value }, commentCount.value)
 })
 
 watch(() => props.initialCommentCount, (value) => {

--- a/src/renderer/components/FtCommunityPoll/FtCommunityPoll.vue
+++ b/src/renderer/components/FtCommunityPoll/FtCommunityPoll.vue
@@ -4,7 +4,7 @@
       class="vote-count"
     >
       <!-- Format the votes to be split by commas ie. 1000 -> 1,000 -->
-      {{ $t('Channel.Posts.votes', {votes: formattedVotes}) }}
+      {{ $t('Channel.Posts.votes', {votes: formattedVotes}, data.totalVotes) }}
     </div>
     <div
       v-for="(choice, index) in data.content"

--- a/src/renderer/components/FtSubscribeButton/FtSubscribeButton.vue
+++ b/src/renderer/components/FtSubscribeButton/FtSubscribeButton.vue
@@ -317,7 +317,7 @@ function handleUnsubscription(profile) {
 
   if (profile._id === MAIN_PROFILE_ID && profileIds.length > 1) {
     showToast({
-      message: t('Channel.Removed subscription from {count} other channel(s)', { count: profileIds.length - 1 }),
+      message: t('Channel.Removed subscription from {count} other channel(s)', { count: profileIds.length - 1 }, profileIds.length - 1),
       icon: ['fas', 'trash'],
     })
   }

--- a/src/renderer/components/SubscriptionsNew.vue
+++ b/src/renderer/components/SubscriptionsNew.vue
@@ -61,7 +61,7 @@
     <FtPrompt
       v-if="showRefreshWarning"
       :label="$t('Subscriptions.New Feed Refresh Warning Title')"
-      :extra-labels="[$t('Subscriptions.New Feed Refresh Warning', { count: activeSubscriptionIds.size })]"
+      :extra-labels="[$t('Subscriptions.New Feed Refresh Warning', { count: activeSubscriptionIds.size }, activeSubscriptionIds.size)]"
       :option-names="[$t('Yes'), $t('No')]"
       :option-values="['refresh', 'cancel']"
       autosize

--- a/src/renderer/views/History/History.vue
+++ b/src/renderer/views/History/History.vue
@@ -247,7 +247,7 @@ async function deleteOldHistory() {
 
   await store.dispatch('removeHistoryOlderThan', days)
   closeHistoryCleanupPrompt()
-  showToast({ message: t('History.History Older Than Days Removed', { days }), icon: ['fas', 'trash'] })
+  showToast({ message: t('History.History Older Than Days Removed', { days }, days), icon: ['fas', 'trash'] })
 }
 
 const HISTORY_SORT_BY_VALUES = {

--- a/src/renderer/views/SubscribedChannels/SubscribedChannels.vue
+++ b/src/renderer/views/SubscribedChannels/SubscribedChannels.vue
@@ -34,7 +34,7 @@
       </ft-flex-box>
       <template v-else>
         <ft-flex-box class="count">
-          {{ $t('Channels.Count', { number: channelList.length }) }}
+          {{ $t('Channels.Count', { number: channelList.length }, channelList.length) }}
         </ft-flex-box>
         <ft-flex-box class="channels">
           <div

--- a/src/renderer/views/Subscriptions/Subscriptions.vue
+++ b/src/renderer/views/Subscriptions/Subscriptions.vue
@@ -236,7 +236,7 @@
       <FtPrompt
         v-if="showAllFeedsRefreshWarning"
         :label="$t('Subscriptions.New Feed Refresh Warning Title')"
-        :extra-labels="[$t('Subscriptions.New Feed Refresh Warning', { count: allFeedsActiveSubscriptionIds.size })]"
+        :extra-labels="[$t('Subscriptions.New Feed Refresh Warning', { count: allFeedsActiveSubscriptionIds.size }, allFeedsActiveSubscriptionIds.size)]"
         :option-names="[$t('Yes'), $t('No')]"
         :option-values="['refresh', 'cancel']"
         autosize

--- a/static/locales/en-US.yaml
+++ b/static/locales/en-US.yaml
@@ -192,7 +192,7 @@ Subscriptions:
   Refreshing Subscription Posts: Refreshing subscription posts
   New Content: New content
   New Feed Refresh Warning Title: Refresh all subscription feeds?
-  New Feed Refresh Warning: Refreshing all content types without RSS for {count} subscriptions can take a long time. Do you want to continue?
+  New Feed Refresh Warning: Refreshing all content types without RSS for 1 subscription can take a long time. Do you want to continue? | Refreshing all content types without RSS for {count} subscriptions can take a long time. Do you want to continue?
   New Since Last Refresh: New since last refresh
   Mark as Seen: Mark as seen
   Mark All as Seen: Mark all as seen
@@ -202,7 +202,7 @@ Channels:
   Channels: Channels
   Title: Channel List
   Search bar placeholder: Search Channels
-  Count: '{number} channel(s) found.'
+  Count: '1 channel found. | {number} channels found.'
   Empty: Your channel list is currently empty.
   Unsubscribe Prompt: Are you sure you want to unsubscribe from "{channelName}"?
 Trending:
@@ -345,7 +345,7 @@ History:
   3 Months: 3 months
   1 Year: 1 year
   Custom: Custom
-  History Older Than Days Removed: Watch history older than {days} days has been removed
+  History Older Than Days Removed: Watch history older than 1 day has been removed | Watch history older than {days} days has been removed
 Settings:
   # On Settings Page
   Settings: Settings
@@ -1139,7 +1139,7 @@ Profile:
   Select None: Select None
   Delete Selected: Delete Selected
   Add Selected To Profile: Add Selected To Profile
-  No channel(s) have been selected: No channel(s) have been selected
+  No channel(s) have been selected: No channels have been selected
   ? This is your primary profile.  Are you sure you want to delete the selected channels?  The
     same channels will be deleted in any profile they are found in.
   : This is your primary profile.  Are you sure you want to delete the selected channels?  The
@@ -1155,7 +1155,7 @@ Channel:
   Unsubscribe: Unsubscribe
   Channel has been removed from your subscriptions: Channel has been removed from
     your subscriptions
-  Removed subscription from {count} other channel(s): Removed subscription from {count} other channel(s)
+  Removed subscription from {count} other channel(s): Removed subscription from 1 other channel | Removed subscription from {count} other channels
   Added channel to your subscriptions: Added channel to your subscriptions
   Search Channel: Search Channel
   Search Result Types: Search result types
@@ -1213,7 +1213,7 @@ Channel:
     Featured Channels: Featured Channels
   Posts:
     This channel currently does not have any posts: This channel currently does not have any posts
-    votes: '{votes} votes'
+    votes: '1 vote | {votes} votes'
     View Full Post: View Full Post
     Reveal Answers: Reveal Answers
     Hide Answers: Hide Answers
@@ -1651,6 +1651,7 @@ Chapters:
 Mini Player: Mini Player
 Comments:
   Comments: Comments
+  Comment Count: 1 Comment | {count} Comments
   Show Comments: Show Comments
   Click to View Comments: Click to View Comments
   Copy YouTube Link: Copy YouTube Link

--- a/tests/unit/locale-plurals.test.mjs
+++ b/tests/unit/locale-plurals.test.mjs
@@ -1,0 +1,134 @@
+import assert from 'node:assert/strict'
+import { readdir, readFile } from 'node:fs/promises'
+import test from 'node:test'
+
+import { load as loadYaml } from 'js-yaml'
+
+const localeUrl = new URL('../../static/locales/en-US.yaml', import.meta.url)
+const sourceDirUrl = new URL('../../src/', import.meta.url)
+
+const locale = loadYaml(await readFile(localeUrl, 'utf8'))
+
+/**
+ * Collects the paths of all messages that declare vue-i18n plural forms ("singular | plural").
+ * @param {object} messages
+ * @param {string} [prefix]
+ * @returns {string[]}
+ */
+function collectPluralPaths(messages, prefix = '') {
+  const paths = []
+
+  for (const [key, value] of Object.entries(messages)) {
+    const path = prefix ? `${prefix}.${key}` : key
+
+    if (typeof value === 'string') {
+      if (value.includes(' | ')) {
+        paths.push(path)
+      }
+    } else if (value != null && typeof value === 'object') {
+      paths.push(...collectPluralPaths(value, path))
+    }
+  }
+
+  return paths
+}
+
+/**
+ * @param {URL} directory
+ * @returns {Promise<URL[]>}
+ */
+async function collectSourceFiles(directory) {
+  const files = []
+
+  for (const entry of await readdir(directory, { withFileTypes: true })) {
+    const entryUrl = new URL(entry.name + (entry.isDirectory() ? '/' : ''), directory)
+
+    if (entry.isDirectory()) {
+      files.push(...await collectSourceFiles(entryUrl))
+    } else if (/\.(js|vue)$/.test(entry.name)) {
+      files.push(entryUrl)
+    }
+  }
+
+  return files
+}
+
+/**
+ * Splits the arguments of a call, starting at the index of its opening parenthesis.
+ * @param {string} source
+ * @param {number} openingParenthesisIndex
+ * @returns {string[] | null} the arguments, or null if the call isn't terminated
+ */
+function splitCallArguments(source, openingParenthesisIndex) {
+  const args = []
+  let depth = 0
+  let quote = null
+  let start = openingParenthesisIndex + 1
+
+  for (let index = start; index < source.length; index++) {
+    const character = source[index]
+
+    if (quote) {
+      if (character === '\\') {
+        index++
+      } else if (character === quote) {
+        quote = null
+      }
+
+      continue
+    }
+
+    if (character === "'" || character === '"' || character === '`') {
+      quote = character
+    } else if (character === '(' || character === '[' || character === '{') {
+      depth++
+    } else if (character === ')' && depth === 0) {
+      args.push(source.slice(start, index))
+      return args
+    } else if (character === ')' || character === ']' || character === '}') {
+      depth--
+    } else if (character === ',' && depth === 0) {
+      args.push(source.slice(start, index))
+      start = index + 1
+    }
+  }
+
+  return null
+}
+
+const pluralPaths = collectPluralPaths(locale)
+const sourceFiles = await collectSourceFiles(sourceDirUrl)
+
+test('plural messages declare a singular and a plural form', () => {
+  for (const path of pluralPaths) {
+    const forms = path.split('.').reduce((messages, key) => messages[key], locale).split(' | ')
+
+    assert.ok(forms.length >= 2, `${path} must declare at least two plural forms`)
+
+    for (const form of forms) {
+      assert.notEqual(form.trim(), '', `${path} must not declare an empty plural form`)
+    }
+  }
+})
+
+test('plural messages are translated with a plural choice', async () => {
+  const pluralPathSet = new Set(pluralPaths)
+  const callPattern = /\$?t\(\s*(['"])(.+?)\1/gs
+
+  for (const file of sourceFiles) {
+    const source = await readFile(file, 'utf8')
+
+    for (const match of source.matchAll(callPattern)) {
+      const path = match[2]
+      if (!pluralPathSet.has(path)) { continue }
+
+      const openingParenthesisIndex = match.index + match[0].indexOf('(')
+      const args = splitCallArguments(source, openingParenthesisIndex)
+
+      assert.ok(
+        args != null && args.length >= 3 && args[2].trim() !== '',
+        `${file.pathname}: "${path}" has plural forms, so it needs a count as the third argument of t()`
+      )
+    }
+  }
+})


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Make sure to follow the contributing guidelines. -->
<!-- Important note, we may remove your pull request if you do not use this provided PR template correctly. -->
<!-- Agent instructions: Preserve every heading, comment, and marker in this template. Never remove or rewrite the release-note-category:start/end, release-note:start/end, or release-note-image:start/end marker pairs. Never remove or rewrite the Release note images section; leave its contents for a human. -->

## Pull Request Type
<!-- Please select what type of pull request this is: [x] -->
- [x] Bugfix
- [ ] Feature Implementation
- [ ] Documentation
- [ ] Other

## Related issue
<!-- Please link the issue your pull request is referring to. -->
<!-- If this pull request fully resolves the relevant issue, put "closes" before the issue number. -->
<!-- Example: "closes #123456". -->

None

## Description
<!-- Please write a clear and concise description of what the pull request does. -->

A number of strings hardcoded the plural noun or fell back to "(s)", so they read wrong whenever the count was 1 — most visibly the comments heading, which showed "1 Comments".

The project already had the right mechanism: vue-i18n plural forms (`singular | plural`) selected via `$t(key, { … }, count)`, as used by `Global.Counts.*`. These strings just weren't using it, so no new machinery was needed.

Fixed strings (locale value plus the plural choice at the call site):

| String | Before | After |
| --- | --- | --- |
| `Comments.Comments` (heading) | `{count} Comments`, built by concatenation | new key `Comments.Comment Count`: `1 Comment \| {count} Comments` |
| `Channels.Count` | `{number} channel(s) found.` | `1 channel found. \| {number} channels found.` |
| `Channel.Posts.votes` | `{votes} votes` | `1 vote \| {votes} votes` |
| `Channel.Removed subscription from {count} other channel(s)` | `… {count} other channel(s)` | `… 1 other channel \| … {count} other channels` |
| `Subscriptions.New Feed Refresh Warning` | `… for {count} subscriptions …` | singular and plural variants |
| `History.History Older Than Days Removed` | `… {days} days …` | `… 1 day … \| … {days} days …` |
| `Profile.No channel(s) have been selected` | `No channel(s) have been selected` | `No channels have been selected` |

The heading gets its own title-cased key because `Global.Counts.Comment Count` is lowercase and used inline in post metadata.

Only the message values changed — the keys are untouched, so existing translations stay attached. Translations that haven't been updated yet still have a single form; vue-i18n returns that form unchanged rather than erroring, so nothing regresses while Weblate catches up.

Deliberately left alone: `Close {count} Tabs` / `Duplicate {count} Tabs` (only shown for more than one tab), limit messages such as "up to {count} custom search engines", and `{videoCount}/{totalVideoCount} Videos Will Be Added` (two counts, no single sensible plural axis).

To stop this from creeping back in, `tests/unit/locale-plurals.test.mjs` checks that every message containing `|` declares at least two non-empty forms, and that every `t()` call referencing such a message passes a count as its third argument — without it, a plural message silently always renders the singular form.

## Release note category
<!-- Select exactly one category. Every pull request must select one. -->
<!-- release-note-category:start -->
- [ ] Not noteworthy
- [ ] Highlights
- [ ] More improvements
- [x] Fixed bugs
<!-- release-note-category:end -->

## Release note
<!-- Required unless "Not noteworthy" is selected. -->
<!-- Write one concise, user-facing entry without a leading bullet. -->
<!-- release-note:start -->
Fixed texts that showed a plural noun for a count of one, such as "1 Comments"
<!-- release-note:end -->

## Release note images
<!-- Human-only: Agents must preserve this entire section and leave it empty. -->
<!-- Optional. Paste one or more Markdown images or HTML image tags here. -->
<!-- The release notes will use an HTML image tag and limit images taller than 300 pixels. -->
<!-- release-note-image:start -->

<!-- release-note-image:end -->

## Testing
<!-- How can reviewers verify that the PR produces correct results? -->
<!-- Please provide instructions so that others can ensure that your pull request would produce correct results. For examples see, https://github.com/FreeTubeApp/FreeTube/pull/5743, https://github.com/FreeTubeApp/FreeTube/pull/7349, https://github.com/FreeTubeApp/FreeTube/pull/5125, https://github.com/FreeTubeApp/FreeTube/pull/7338 -->
<!-- Agent instructions: Only write human-facing steps that explain how to verify the change while running this branch in dev mode. Include expected results and, when applicable, helpful console snippets for interactive verification. Do not include automated checks, commands, results, pass counts, or CI status. -->

Run the app in dev mode with the interface language set to English, then:

1. Open a video that has exactly one comment. The comments heading should read "1 Comment", and "5 Comments" on a video with several. Check both the normal watch page and the fullscreen comments overlay.
2. Open a community post with a poll that has a single vote. It should read "1 vote" instead of "1 votes".
3. Go to the channel list ("Channels" in the side menu) and search until only one channel matches. It should say "1 channel found."
4. In Settings → Data, remove watch history older than a custom value of 1 day. The toast should read "Watch history older than 1 day has been removed".
5. With the main profile active, subscribe to a channel from exactly two profiles, then unsubscribe from the main profile. The second toast should read "Removed subscription from 1 other channel".
6. With exactly one subscription, refresh all subscription feeds with RSS disabled. The confirmation prompt should say "for 1 subscription".

Switching to a language whose translation hasn't been updated yet should still show that language's existing wording rather than falling back to English or showing an error.

## Additional context
<!-- Add any other context about the pull request here. -->

The new plural forms need re-translating in Weblate; the affected strings will show up as changed for translators.
