### PR TITLE
Add a setting for concurrent segment downloads

### DIFF
--- a/e2e/tests/network/segment-prefetch.spec.mjs
+++ b/e2e/tests/network/segment-prefetch.spec.mjs
@@ -1,0 +1,84 @@
+import { test, expect } from '../../helpers/innertube.mjs'
+import { activeTab, findWatchComponent, openVideoOrSkip, waitForPlaybackOrSkip } from '../../helpers/player.mjs'
+
+// "Me at the zoo" - the oldest video on YouTube, short and stable.
+const VIDEO = {
+  id: 'jNQXAC9IVRw',
+  title: 'Me at the zoo',
+  url: 'https://www.youtube.com/watch?v=jNQXAC9IVRw'
+}
+
+const CONFIGURED_LIMIT = 4
+
+/**
+ * Reads the limit shaka-player is actually running with, together with the
+ * playback engine that ended up serving the streams.
+ *
+ * @param {import('@playwright/test').Page} page
+ */
+async function readPrefetchState(page) {
+  const watchComponent = await page.evaluateHandle(findWatchComponent)
+
+  return await page.locator(`${activeTab} .ftVideoPlayer`).evaluate((element, watchComponent) => {
+    const overlay = element.ui ?? element.querySelector('video')?.ui
+    const shakaPlayer = overlay?.getControls().getPlayer()
+    if (!watchComponent || !shakaPlayer) {
+      throw new Error('Unable to access the mounted player')
+    }
+
+    return {
+      engine: watchComponent.proxy.activePlaybackEngine,
+      segmentPrefetchLimit: shakaPlayer.getConfiguration().streaming.segmentPrefetchLimit
+    }
+  }, watchComponent)
+}
+
+test.describe('concurrent segment downloads', () => {
+  test.describe('with yt-dlp', () => {
+    test.use({
+      seed: {
+        settings: {
+          segmentPrefetchLimit: CONFIGURED_LIMIT,
+          videoPlaybackEngine: 'yt-dlp'
+        }
+      }
+    })
+
+    test('applies the configured limit to shaka-player', async ({ page, innertube }) => {
+      test.skip(innertube.replay, 'needs the adaptive formats of the real API')
+      await openVideoOrSkip(test, page, VIDEO)
+      await waitForPlaybackOrSkip(test, page)
+
+      const { engine, segmentPrefetchLimit } = await readPrefetchState(page)
+      test.skip(engine !== 'yt-dlp', 'yt-dlp is unavailable, the built-in engine served the streams')
+
+      expect(segmentPrefetchLimit).toBe(CONFIGURED_LIMIT)
+    })
+  })
+
+  test.describe('with the built-in engine', () => {
+    test.use({
+      seed: {
+        settings: {
+          segmentPrefetchLimit: CONFIGURED_LIMIT,
+          videoPlaybackEngine: 'built-in',
+          // the built-in engine is migrated away from on startup otherwise
+          ytDlpPlaybackEngineDefaultMigration: true
+        }
+      }
+    })
+
+    test('keeps SABR sequential', async ({ page, innertube }) => {
+      test.skip(innertube.replay, 'needs the adaptive formats of the real API')
+      await openVideoOrSkip(test, page, VIDEO)
+      await waitForPlaybackOrSkip(test, page)
+
+      const { engine, segmentPrefetchLimit } = await readPrefetchState(page)
+      expect(engine).toBe('built-in')
+
+      // SABR requests depend on the state the server returned for the previous
+      // one, so they can't be parallelised and the setting has to be ignored
+      expect(segmentPrefetchLimit).toBe(1)
+    })
+  })
+})

--- a/e2e/tests/offline/segment-prefetch-slider.spec.mjs
+++ b/e2e/tests/offline/segment-prefetch-slider.spec.mjs
@@ -1,0 +1,36 @@
+import { readFile } from 'node:fs/promises'
+import path from 'node:path'
+
+import { test, expect, goTo, latestSettings } from '../../helpers/app.mjs'
+
+async function openPlayerSettings(page) {
+  await goTo(page, 'settings')
+  await page.locator('.settingsMenu [data-section="player"]').click()
+  await expect(page.locator('.settingsContent > [data-section="player"]')).toBeVisible()
+
+  return page.getByRole('slider', { name: /Concurrent Segment Downloads/ })
+}
+
+test.describe('concurrent segment downloads slider', () => {
+  test('persists the configured limit', async ({ app }) => {
+    const slider = await openPlayerSettings(app.page)
+
+    // shaka-player's default, so playback is sequential until the user opts in
+    await expect(slider).toHaveValue('1')
+    await expect(slider).toHaveAttribute('min', '1')
+    await expect(slider).toHaveAttribute('max', '10')
+
+    await slider.fill('4')
+    await expect(slider).toHaveValue('4')
+
+    await expect.poll(async () => {
+      const settings = latestSettings(
+        await readFile(path.join(app.userDataDir, 'settings.db'), 'utf8')
+      )
+      return settings.segmentPrefetchLimit
+    }).toBe(4)
+
+    const relaunched = await app.relaunch()
+    await expect(await openPlayerSettings(relaunched.page)).toHaveValue('4')
+  })
+})

--- a/src/renderer/components/PlayerSettings/PlayerSettings.vue
+++ b/src/renderer/components/PlayerSettings/PlayerSettings.vue
@@ -267,6 +267,16 @@
         @change="updateDefaultPlayback"
       />
       <FtSlider
+        :label="t('Settings.Player Settings.Concurrent Segment Downloads')"
+        :default-value="segmentPrefetchLimit"
+        setting-key="segmentPrefetchLimit"
+        :min-value="DEFAULT_SEGMENT_PREFETCH_LIMIT"
+        :max-value="MAX_SEGMENT_PREFETCH_LIMIT"
+        :step="1"
+        :tooltip="t('Tooltips.Player Settings.Concurrent Segment Downloads')"
+        @change="updateSegmentPrefetchLimit"
+      />
+      <FtSlider
         :label="t('Settings.Player Settings.Max Video Playback Rate')"
         :default-value="maxVideoPlaybackRate"
         setting-key="maxVideoPlaybackRate"
@@ -515,6 +525,10 @@ import FtSettingsSubpage from '../FtSettingsSubpage/FtSettingsSubpage.vue'
 
 import store from '../../store/index'
 import { initializePlatformInfo, isLinuxWayland } from '../../helpers/platform'
+import {
+  DEFAULT_SEGMENT_PREFETCH_LIMIT,
+  MAX_SEGMENT_PREFETCH_LIMIT
+} from '../../helpers/player/segmentPrefetch'
 
 const { t } = useI18n()
 
@@ -954,6 +968,16 @@ const defaultPlayback = computed(() => store.getters.getDefaultPlayback)
  */
 function updateDefaultPlayback(value) {
   store.dispatch('updateDefaultPlayback', value)
+}
+
+/** @type {import('vue').ComputedRef<number>} */
+const segmentPrefetchLimit = computed(() => store.getters.getSegmentPrefetchLimit)
+
+/**
+ * @param {number} value
+ */
+function updateSegmentPrefetchLimit(value) {
+  store.dispatch('updateSegmentPrefetchLimit', value)
 }
 
 /** @type {import('vue').ComputedRef<number>} */

--- a/src/renderer/components/ft-shaka-video-player/ft-shaka-video-player.js
+++ b/src/renderer/components/ft-shaka-video-player/ft-shaka-video-player.js
@@ -61,6 +61,7 @@ import {
 import { isReducedMotionEnabled } from '../../helpers/reducedMotion'
 import { appendTimestamp, getInvidiousVideoUrl, getYoutubeVideoShareUrl } from '../../helpers/share'
 import { MANIFEST_TYPE_SABR } from '../../helpers/player/SabrManifestParser'
+import { resolveSegmentPrefetchLimit } from '../../helpers/player/segmentPrefetch'
 import { setupSabrScheme } from '../../helpers/player/SabrSchemePlugin'
 import { getRememberedPlayerVolume, setRememberedPlayerVolume } from '../../helpers/player/volume-storage'
 import { parseChannelPreferences } from '../../helpers/channel-preferences'
@@ -2809,6 +2810,22 @@ export default defineComponent({
     })
 
     /**
+     * How many segments per stream shaka-player downloads in parallel ahead of the playhead.
+     * @type {import('vue').ComputedRef<number>}
+     */
+    const segmentPrefetchLimit = computed(() => {
+      const isSabr = !!process.env.SUPPORTS_LOCAL_API &&
+        props.format !== 'legacy' &&
+        props.manifestMimeType === MANIFEST_TYPE_SABR
+
+      return resolveSegmentPrefetchLimit(store.getters.getSegmentPrefetchLimit, isSabr)
+    })
+
+    watch(segmentPrefetchLimit, (newValue) => {
+      player?.configure('streaming.segmentPrefetchLimit', newValue)
+    })
+
+    /**
      * @param {'dash'|'audio'|'legacy'} format
      * @param {boolean} useAutoQuality
      * @returns {shaka.extern.PlayerConfiguration}
@@ -2820,7 +2837,8 @@ export default defineComponent({
         streaming: {
           bufferingGoal: 180,
           rebufferingGoal: 0.02,
-          bufferBehind: 300
+          bufferBehind: 300,
+          segmentPrefetchLimit: segmentPrefetchLimit.value
         },
         manifest: {
           disableVideo: format === 'audio',

--- a/src/renderer/helpers/player/segmentPrefetch.js
+++ b/src/renderer/helpers/player/segmentPrefetch.js
@@ -1,0 +1,27 @@
+/**
+ * shaka-player's default, which means that segments are fetched one after another.
+ */
+export const DEFAULT_SEGMENT_PREFETCH_LIMIT = 1
+
+export const MAX_SEGMENT_PREFETCH_LIMIT = 10
+
+/**
+ * How many segments per stream shaka-player may download in parallel ahead of the playhead.
+ *
+ * SABR is a stateful protocol, where every request depends on the state that the server
+ * returned for the previous one, so parallel segment requests aren't possible there
+ * and we have to stick with shaka-player's default.
+ * @param {number} configuredLimit the user's setting
+ * @param {boolean} isSabr whether the streams are served over SABR
+ * @returns {number}
+ */
+export function resolveSegmentPrefetchLimit(configuredLimit, isSabr) {
+  if (isSabr || !Number.isFinite(configuredLimit)) {
+    return DEFAULT_SEGMENT_PREFETCH_LIMIT
+  }
+
+  return Math.min(
+    Math.max(Math.trunc(configuredLimit), DEFAULT_SEGMENT_PREFETCH_LIMIT),
+    MAX_SEGMENT_PREFETCH_LIMIT
+  )
+}

--- a/src/renderer/store/modules/settings.js
+++ b/src/renderer/store/modules/settings.js
@@ -16,6 +16,7 @@ import { DEFAULT_FIXED_TAB_WIDTH } from '../../constants/tabWidth'
 import { setReducedMotionPreference } from '../../helpers/reducedMotion'
 import { setAnimationSpeed } from '../../helpers/animationSpeed'
 import { DEFAULT_SEARCH_ENGINES_SETTING } from '../../../searchEngines'
+import { DEFAULT_SEGMENT_PREFETCH_LIMIT } from '../../helpers/player/segmentPrefetch'
 
 const YT_DLP_PLAYBACK_ENGINE_MIGRATION_SETTING = 'ytDlpPlaybackEngineDefaultMigration'
 
@@ -200,6 +201,8 @@ const state = {
   defaultQuality: '720',
   defaultSkipInterval: 5,
   seekIntervalMultiplyByPlaybackRate: false,
+  // How many segments per stream shaka-player downloads in parallel ahead of the playhead
+  segmentPrefetchLimit: DEFAULT_SEGMENT_PREFETCH_LIMIT,
   showPlaybackRateAdjustedTimestamp: false,
   useCustomShortsPlayer: true,
   loopShorts: true,

--- a/static/locales/en-US.yaml
+++ b/static/locales/en-US.yaml
@@ -669,6 +669,7 @@ Settings:
     Reorder Playback Speed: Drag to reorder playback speed
     Playback Speed: Playback Speed
     Max Video Playback Rate: Max Video Playback Rate
+    Concurrent Segment Downloads: Concurrent Segment Downloads
     Video Playback Rate Interval: Video Playback Rate Interval
     Default Video Format:
       Default Video Format: Default Video Format
@@ -1747,6 +1748,10 @@ Tooltips:
     Hold to Double Playback Speed: Hold the Spacebar or left mouse button over the player to temporarily double the current playback speed.
     Ambient Mode: Blends the video's colors into the area around the player.
     Default Volume: Disabled while Remember Volume is enabled. Turn off Remember Volume to set a fixed startup volume for each video.
+    Concurrent Segment Downloads: |
+      How many video and audio segments are downloaded in parallel ahead of the current playback position.
+      Higher values can improve the download speed on slow or unstable connections, but use more bandwidth and memory.
+      This has no effect when the built-in stream extraction method is used, as it only supports one request at a time.
   External Player Settings:
     External Player: Choosing an external player will display an icon, for opening the
       video (playlist if supported) in the external player, on the thumbnail. Warning, Invidious settings do not affect external players.

--- a/static/locales/en-US.yaml
+++ b/static/locales/en-US.yaml
@@ -1751,7 +1751,7 @@ Tooltips:
     Concurrent Segment Downloads: |
       How many video and audio segments are downloaded in parallel ahead of the current playback position.
       Higher values can improve the download speed on slow or unstable connections, but use more bandwidth and memory.
-      This has no effect when the built-in stream extraction method is used, as it only supports one request at a time.
+      Streams that only allow one request at a time, which most of those from the built-in stream extraction method are, are unaffected.
   External Player Settings:
     External Player: Choosing an external player will display an icon, for opening the
       video (playlist if supported) in the external player, on the thumbnail. Warning, Invidious settings do not affect external players.

--- a/tests/unit/segment-prefetch.test.mjs
+++ b/tests/unit/segment-prefetch.test.mjs
@@ -1,0 +1,32 @@
+import assert from 'node:assert/strict'
+import test from 'node:test'
+
+import {
+  DEFAULT_SEGMENT_PREFETCH_LIMIT,
+  MAX_SEGMENT_PREFETCH_LIMIT,
+  resolveSegmentPrefetchLimit
+} from '../../src/renderer/helpers/player/segmentPrefetch.js'
+
+test('the configured limit is used for non-SABR playback', () => {
+  assert.equal(resolveSegmentPrefetchLimit(4, false), 4)
+  assert.equal(resolveSegmentPrefetchLimit(MAX_SEGMENT_PREFETCH_LIMIT, false), MAX_SEGMENT_PREFETCH_LIMIT)
+})
+
+test('SABR always falls back to sequential fetching', () => {
+  // SABR requests depend on the state returned by the previous request,
+  // so they can't be run in parallel
+  assert.equal(resolveSegmentPrefetchLimit(8, true), DEFAULT_SEGMENT_PREFETCH_LIMIT)
+})
+
+test('the configured limit is clamped to the supported range', () => {
+  assert.equal(resolveSegmentPrefetchLimit(0, false), DEFAULT_SEGMENT_PREFETCH_LIMIT)
+  assert.equal(resolveSegmentPrefetchLimit(-5, false), DEFAULT_SEGMENT_PREFETCH_LIMIT)
+  assert.equal(resolveSegmentPrefetchLimit(1000, false), MAX_SEGMENT_PREFETCH_LIMIT)
+  assert.equal(resolveSegmentPrefetchLimit(3.9, false), 3)
+})
+
+test('unusable values fall back to the default', () => {
+  assert.equal(resolveSegmentPrefetchLimit(undefined, false), DEFAULT_SEGMENT_PREFETCH_LIMIT)
+  assert.equal(resolveSegmentPrefetchLimit(NaN, false), DEFAULT_SEGMENT_PREFETCH_LIMIT)
+  assert.equal(resolveSegmentPrefetchLimit(Infinity, false), DEFAULT_SEGMENT_PREFETCH_LIMIT)
+})


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Make sure to follow the contributing guidelines. -->
<!-- Important note, we may remove your pull request if you do not use this provided PR template correctly. -->

## Pull Request Type
<!-- Please select what type of pull request this is: [x] -->
- [ ] Bugfix
- [x] Feature Implementation
- [ ] Documentation
- [ ] Other

## Related issue
<!-- Please link the issue your pull request is referring to. -->
<!-- If this pull request fully resolves the relevant issue, put "closes" before the issue number. -->
<!-- Example: "closes #123456". -->
closes #586

## Description
<!-- Please write a clear and concise description of what the pull request does. -->
shaka-player fetches one segment per stream at a time by default (`streaming.segmentPrefetchLimit: 1`), so playback is limited to what a single connection gives us. When YouTube throttles that connection, videos buffer even though the line has bandwidth to spare, which is what the issue describes: downloading the same video with several connections saturates the network.

This exposes shaka-player's segment prefetch limit as a slider in the player settings (1-10, default 1, which is shaka-player's own default, so nothing changes unless it is raised). Changing it applies to a running player, no reload needed.

SABR is stateful, every request depends on the state the server returned for the previous one, so parallel segment requests aren't possible there. The player checks the streams it actually received, so the setting is ignored for SABR no matter which extraction method is configured. It also has no effect on the legacy formats, which are single progressive files.

Note that a raised limit deflates shaka-player's bandwidth estimate: it measures each request individually, and parallel requests share the connection, so every sample looks slower. That only matters when the automatic quality selection is used, and is mentioned in the setting's tooltip.

## Release note category
<!-- Select exactly one category. Every pull request must select one. -->
<!-- release-note-category:start -->
- [ ] Not noteworthy
- [ ] Highlights
- [x] More improvements
- [ ] Fixed bugs
<!-- release-note-category:end -->

## Release note
<!-- Required unless "Not noteworthy" is selected. -->
<!-- Write one concise, user-facing entry without a leading bullet. -->
<!-- release-note:start -->
Added a player setting for downloading multiple video and audio segments at the same time, which can improve the loading speed on slow or throttled connections (only works with yt-dlp streams)
<!-- release-note:end -->

## Release note images
<!-- Human-only: Agents must preserve this entire section and leave it empty. -->
<!-- Optional. Paste one or more Markdown images or HTML image tags here. -->
<!-- The release notes will use an HTML image tag and limit images taller than 300 pixels. -->
<!-- release-note-image:start -->
<img width="374" height="67" alt="image" src="https://github.com/user-attachments/assets/c73469cc-74aa-4b08-8e8e-4e183baf6b8c" />
<!-- release-note-image:end -->

## Testing
<!-- How can reviewers verify that the PR produces correct results? -->
1. Make sure the stream extraction method is set to yt-dlp (Settings > General), as the built-in one uses SABR.
2. Open Settings > Player and check that "Concurrent Segment Downloads" is there, reads 1 and ranges from 1 to 10.
3. Play a longer, high resolution video and open the developer tools' network tab, filtered to `googlevideo`. The segment requests should form a staircase: each one starts after the previous one finished.
4. Set the slider to 4 while the video is still playing. The requests should now overlap, and each individual request takes longer, because they share the connection.
5. Optionally confirm the value the player is running with, in the developer tools' console on the watch page:
   ```js
   (() => {
     const el = document.querySelector('.tabContent[aria-hidden="false"] .ftVideoPlayer')
     const player = (el.ui ?? el.querySelector('video').ui).getControls().getPlayer()
     return player.getConfiguration().streaming.segmentPrefetchLimit
   })()
   ```
   It should print 4, and 1 when the built-in extraction method is used.
6. To judge whether it helps, compare how quickly "Buffered" climbs in the player's stats overlay (right click > Show Stats) at 1 vs 4. The "Bandwidth" row is not a valid comparison here, see the description.

## Additional context
<!-- Add any other context about the pull request here. -->
The clamping and the SABR fallback are unit tested, and there are end to end tests for the setting persisting and for the value reaching shaka-player with both extraction methods.
