### PR TITLE
Restore auto quality for stream sources without SABR

### DIFF
--- a/e2e/tests/network/auto-quality.spec.mjs
+++ b/e2e/tests/network/auto-quality.spec.mjs
@@ -1,0 +1,75 @@
+import { test, expect } from '../../helpers/innertube.mjs'
+import { activeTab, openVideoOrSkip, waitForPlaybackOrSkip } from '../../helpers/player.mjs'
+
+// "Me at the zoo" - the oldest video on YouTube, short and stable.
+const VIDEO = {
+  id: 'jNQXAC9IVRw',
+  title: 'Me at the zoo',
+  url: 'https://www.youtube.com/watch?v=jNQXAC9IVRw'
+}
+
+/**
+ * @param {import('@playwright/test').Page} page
+ */
+function readAbrState(page) {
+  return page.locator(`${activeTab} .ftVideoPlayer`).evaluate((element) => {
+    const overlay = element.ui ?? element.querySelector('video')?.ui
+    const player = overlay?.getControls().getPlayer()
+    if (!player) {
+      throw new Error('Unable to access the mounted player')
+    }
+
+    const autoButton = element.querySelector('.shaka-enable-abr-button')
+
+    return {
+      abrEnabled: player.getConfiguration().abr.enabled,
+      autoButtonVisible: autoButton != null && getComputedStyle(autoButton).display !== 'none'
+    }
+  })
+}
+
+test.describe('auto quality', () => {
+  test.describe('with yt-dlp', () => {
+    test.use({
+      seed: {
+        settings: {
+          defaultQuality: 'auto',
+          videoPlaybackEngine: 'yt-dlp'
+        }
+      }
+    })
+
+    test('is offered and used', async ({ page, innertube }) => {
+      test.skip(innertube.replay, 'needs the adaptive formats of the real API')
+      await openVideoOrSkip(test, page, VIDEO)
+      await waitForPlaybackOrSkip(test, page)
+
+      const { abrEnabled, autoButtonVisible } = await readAbrState(page)
+      expect(abrEnabled).toBe(true)
+      expect(autoButtonVisible).toBe(true)
+    })
+  })
+
+  test.describe('with the built-in engine', () => {
+    test.use({
+      seed: {
+        settings: {
+          defaultQuality: 'auto',
+          videoPlaybackEngine: 'built-in',
+          // the built-in engine is migrated away from on startup otherwise
+          ytDlpPlaybackEngineDefaultMigration: true
+        }
+      }
+    })
+
+    test('stays hidden, as it is broken with SABR', async ({ page, innertube }) => {
+      test.skip(innertube.replay, 'needs the adaptive formats of the real API')
+      await openVideoOrSkip(test, page, VIDEO)
+      await waitForPlaybackOrSkip(test, page)
+
+      const { abrEnabled, autoButtonVisible } = await readAbrState(page)
+      expect(abrEnabled).toBe(false)
+      expect(autoButtonVisible).toBe(false)
+    })
+  })
+})

--- a/e2e/tests/offline/auto-quality-settings.spec.mjs
+++ b/e2e/tests/offline/auto-quality-settings.spec.mjs
@@ -1,4 +1,7 @@
-import { test, expect, goTo } from '../../helpers/app.mjs'
+import { test, expect, goTo, goToSettingsSection } from '../../helpers/app.mjs'
+
+const CHANNEL_ID = 'UCaaaaaaaaaaaaaaaaaaaaaa'
+const CHANNEL_NAME = 'Alpha Channel'
 
 async function openDefaultQualitySelect(page) {
   await goTo(page, 'settings')
@@ -38,6 +41,39 @@ test.describe('auto quality setting', () => {
 
       await expect(defaultQuality).toHaveValue('720')
       await expect(defaultQuality.locator('option[value="auto"]')).toHaveCount(0)
+    })
+  })
+
+  test.describe('a stored channel quality of auto', () => {
+    test.use({
+      seed: {
+        settings: {
+          // a global default other than the fallback, so displaying the wrong
+          // one of the two is visible here
+          defaultQuality: '1080',
+          channelVideoQualities: JSON.stringify({ [CHANNEL_ID]: 'auto' }),
+          videoPlaybackEngine: 'built-in',
+          // the built-in engine is migrated away from on startup otherwise
+          ytDlpPlaybackEngineDefaultMigration: true
+        },
+        profiles: [
+          {
+            _id: 'allChannels',
+            name: 'All Channels',
+            bgColor: '#000000',
+            textColor: '#FFFFFF',
+            subscriptions: [{ id: CHANNEL_ID, name: CHANNEL_NAME, thumbnail: '' }]
+          }
+        ]
+      }
+    })
+
+    test('is displayed as the quality playback falls back to', async ({ page }) => {
+      await goToSettingsSection(page, 'channel')
+      await page.getByRole('button', { name: 'Manage Saved Channels (1)' }).click()
+
+      const quality = page.locator('.settingsWindow .channelPreference select')
+      await expect(quality).toHaveValue('720')
     })
   })
 })

--- a/e2e/tests/offline/auto-quality-settings.spec.mjs
+++ b/e2e/tests/offline/auto-quality-settings.spec.mjs
@@ -1,0 +1,43 @@
+import { test, expect, goTo } from '../../helpers/app.mjs'
+
+async function openDefaultQualitySelect(page) {
+  await goTo(page, 'settings')
+  await page.locator('.settingsMenu [data-section="player"]').click()
+
+  return page.locator('[data-section="player"] .select')
+    .filter({ hasText: 'Default Quality' })
+    .locator('select')
+}
+
+test.describe('auto quality setting', () => {
+  test.describe('with yt-dlp', () => {
+    test.use({ seed: { settings: { defaultQuality: 'auto', videoPlaybackEngine: 'yt-dlp' } } })
+
+    test('is offered and kept', async ({ page }) => {
+      const defaultQuality = await openDefaultQualitySelect(page)
+
+      await expect(defaultQuality).toHaveValue('auto')
+      await expect(defaultQuality.locator('option[value="auto"]')).toHaveCount(1)
+    })
+  })
+
+  test.describe('with the built-in engine', () => {
+    test.use({
+      seed: {
+        settings: {
+          defaultQuality: 'auto',
+          videoPlaybackEngine: 'built-in',
+          // the built-in engine is migrated away from on startup otherwise
+          ytDlpPlaybackEngineDefaultMigration: true
+        }
+      }
+    })
+
+    test('is hidden and falls back to 720p', async ({ page }) => {
+      const defaultQuality = await openDefaultQualitySelect(page)
+
+      await expect(defaultQuality).toHaveValue('720')
+      await expect(defaultQuality.locator('option[value="auto"]')).toHaveCount(0)
+    })
+  })
+})

--- a/src/renderer/components/ChannelSettings/ChannelSettings.vue
+++ b/src/renderer/components/ChannelSettings/ChannelSettings.vue
@@ -198,7 +198,7 @@ import {
   getCachedChannelInfo,
   parseChannelPreferences
 } from '../../helpers/channel-preferences'
-import { playbackEngineSupportsAutoQuality } from '../../helpers/player/autoQuality'
+import { AUTO_QUALITY_FALLBACK, playbackEngineSupportsAutoQuality } from '../../helpers/player/autoQuality'
 
 const { locale, t } = useI18n()
 
@@ -277,8 +277,7 @@ const settings = computed(() => store.state.settings)
 const defaultQuality = computed(() => {
   const value = store.getters.getDefaultQuality
 
-  // 720 is the default settings value
-  return value === 'auto' && !autoQualityAvailable.value ? '720' : value
+  return value === 'auto' && !autoQualityAvailable.value ? AUTO_QUALITY_FALLBACK : value
 })
 
 /** @type {import('vue').ComputedRef<number>} */
@@ -357,9 +356,10 @@ const channelEntries = computed(() => {
 
       valuesByChannel.get(channelId).set(
         type,
-        // Fall back for entries that still hold auto while it is unavailable
+        // Fall back for entries that still hold auto while it is unavailable,
+        // to the same quality that playback uses for them
         type === 'videoQuality' && String(value) === 'auto' && !autoQualityAvailable.value
-          ? defaultQuality.value
+          ? AUTO_QUALITY_FALLBACK
           : value
       )
     }

--- a/src/renderer/components/ChannelSettings/ChannelSettings.vue
+++ b/src/renderer/components/ChannelSettings/ChannelSettings.vue
@@ -140,7 +140,7 @@
                   :placeholder="t('Settings.Channel Settings.Video Quality')"
                   :value="preference.value"
                   :select-names="qualityNames"
-                  :select-values="QUALITY_VALUES"
+                  :select-values="qualityValues"
                   :icon="preference.icon"
                   :show-icon="false"
                   @change="value => setPreference(channel.id, preference.type, value)"
@@ -198,6 +198,7 @@ import {
   getCachedChannelInfo,
   parseChannelPreferences
 } from '../../helpers/channel-preferences'
+import { playbackEngineSupportsAutoQuality } from '../../helpers/player/autoQuality'
 
 const { locale, t } = useI18n()
 
@@ -207,8 +208,20 @@ const disableChannelLinks = computed(() => store.getters.getDisableChannelLinks)
 /** Only offer the search field once scanning the list by eye gets tedious */
 const SEARCH_THRESHOLD = 5
 
-// TODO: Revert when auto is fixed
-const QUALITY_VALUES = ['2160', '1440', '1080', '720', '480', '360', '240', '144']
+const RESOLUTION_VALUES = ['2160', '1440', '1080', '720', '480', '360', '240', '144']
+
+/**
+ * Auto quality is broken with SABR, so it is only offered for the
+ * stream extraction methods that don't use it.
+ * @type {import('vue').ComputedRef<boolean>}
+ */
+const autoQualityAvailable = computed(() => {
+  return playbackEngineSupportsAutoQuality(store.getters.getVideoPlaybackEngine)
+})
+
+const qualityValues = computed(() => {
+  return autoQualityAvailable.value ? [...RESOLUTION_VALUES, 'auto'] : RESOLUTION_VALUES
+})
 
 const qualityNames = computed(() => [
   t('Settings.Player Settings.Default Quality.4k'),
@@ -219,6 +232,8 @@ const qualityNames = computed(() => [
   t('Settings.Player Settings.Default Quality.360p'),
   t('Settings.Player Settings.Default Quality.240p'),
   t('Settings.Player Settings.Default Quality.144p'),
+
+  ...(autoQualityAvailable.value ? [t('Settings.Player Settings.Default Quality.Auto')] : [])
 ])
 
 const rememberLabels = computed(() => ({
@@ -262,8 +277,8 @@ const settings = computed(() => store.state.settings)
 const defaultQuality = computed(() => {
   const value = store.getters.getDefaultQuality
 
-  // TODO: Revert when auto is fixed (720 is the default settings value)
-  return value === 'auto' ? '720' : value
+  // 720 is the default settings value
+  return value === 'auto' && !autoQualityAvailable.value ? '720' : value
 })
 
 /** @type {import('vue').ComputedRef<number>} */
@@ -342,8 +357,10 @@ const channelEntries = computed(() => {
 
       valuesByChannel.get(channelId).set(
         type,
-        // TODO: Revert when auto is fixed, existing entries can still hold it
-        type === 'videoQuality' && String(value) === 'auto' ? defaultQuality.value : value
+        // Fall back for entries that still hold auto while it is unavailable
+        type === 'videoQuality' && String(value) === 'auto' && !autoQualityAvailable.value
+          ? defaultQuality.value
+          : value
       )
     }
   }

--- a/src/renderer/components/PlayerSettings/PlayerSettings.vue
+++ b/src/renderer/components/PlayerSettings/PlayerSettings.vue
@@ -529,7 +529,7 @@ import {
   DEFAULT_SEGMENT_PREFETCH_LIMIT,
   MAX_SEGMENT_PREFETCH_LIMIT
 } from '../../helpers/player/segmentPrefetch'
-import { playbackEngineSupportsAutoQuality } from '../../helpers/player/autoQuality'
+import { AUTO_QUALITY_FALLBACK, playbackEngineSupportsAutoQuality } from '../../helpers/player/autoQuality'
 
 const { t } = useI18n()
 
@@ -901,8 +901,7 @@ const qualityNames = computed(() => [
 const defaultQuality = computed(() => {
   const value = store.getters.getDefaultQuality
 
-  // 720 is the default settings value
-  if (value === 'auto' && !autoQualityAvailable.value) { return '720' }
+  if (value === 'auto' && !autoQualityAvailable.value) { return AUTO_QUALITY_FALLBACK }
 
   return value
 })

--- a/src/renderer/components/PlayerSettings/PlayerSettings.vue
+++ b/src/renderer/components/PlayerSettings/PlayerSettings.vue
@@ -199,7 +199,7 @@
         :value="defaultQuality"
         setting-key="defaultQuality"
         :select-names="qualityNames"
-        :select-values="QUALITY_VALUES"
+        :select-values="qualityValues"
         :icon="['fas', 'photo-film']"
         @change="updateDefaultQuality"
       />
@@ -529,6 +529,7 @@ import {
   DEFAULT_SEGMENT_PREFETCH_LIMIT,
   MAX_SEGMENT_PREFETCH_LIMIT
 } from '../../helpers/player/segmentPrefetch'
+import { playbackEngineSupportsAutoQuality } from '../../helpers/player/autoQuality'
 
 const { t } = useI18n()
 
@@ -868,9 +869,20 @@ function updateDefaultVideoFormat(value) {
   store.dispatch('updateDefaultVideoFormat', value)
 }
 
-// TODO: Revert when auto is fixed
-// const QUALITY_VALUES = ['2160', '1440', '1080', '720', '480', '360', '240', '144', 'auto']
-const QUALITY_VALUES = ['2160', '1440', '1080', '720', '480', '360', '240', '144']
+const RESOLUTION_VALUES = ['2160', '1440', '1080', '720', '480', '360', '240', '144']
+
+/**
+ * Auto quality is broken with SABR, so it is only offered for the
+ * stream extraction methods that don't use it.
+ * @type {import('vue').ComputedRef<boolean>}
+ */
+const autoQualityAvailable = computed(() => {
+  return playbackEngineSupportsAutoQuality(store.getters.getVideoPlaybackEngine)
+})
+
+const qualityValues = computed(() => {
+  return autoQualityAvailable.value ? [...RESOLUTION_VALUES, 'auto'] : RESOLUTION_VALUES
+})
 
 const qualityNames = computed(() => [
   t('Settings.Player Settings.Default Quality.4k'),
@@ -882,16 +894,15 @@ const qualityNames = computed(() => [
   t('Settings.Player Settings.Default Quality.240p'),
   t('Settings.Player Settings.Default Quality.144p'),
 
-  // TODO: Revert when auto is fixed
-  // t('Settings.Player Settings.Default Quality.Auto')
+  ...(autoQualityAvailable.value ? [t('Settings.Player Settings.Default Quality.Auto')] : [])
 ])
 
 /** @type {import('vue').ComputedRef<'2160' | '1440' | '1080' | '720' | '480' | '360' | '240' | '144' | 'auto'>} */
 const defaultQuality = computed(() => {
   const value = store.getters.getDefaultQuality
 
-  // TODO: Revert when auto is fixed (720 is the default setttings value)
-  if (value === 'auto') { return '720' }
+  // 720 is the default settings value
+  if (value === 'auto' && !autoQualityAvailable.value) { return '720' }
 
   return value
 })

--- a/src/renderer/components/ft-shaka-video-player/ft-shaka-video-player.css
+++ b/src/renderer/components/ft-shaka-video-player/ft-shaka-video-player.css
@@ -1,5 +1,8 @@
-/* TODO: Revert when auto is fixed */
-:deep(.shaka-enable-abr-button) {
+/*
+  Auto quality's runtime switches are broken with SABR (FreeTube#8906),
+  so it is only offered for stream sources that don't use it.
+*/
+.ftVideoPlayer.autoQualityUnavailable :deep(.shaka-enable-abr-button) {
   display: none !important;
 }
 

--- a/src/renderer/components/ft-shaka-video-player/ft-shaka-video-player.js
+++ b/src/renderer/components/ft-shaka-video-player/ft-shaka-video-player.js
@@ -62,6 +62,7 @@ import { isReducedMotionEnabled } from '../../helpers/reducedMotion'
 import { appendTimestamp, getInvidiousVideoUrl, getYoutubeVideoShareUrl } from '../../helpers/share'
 import { MANIFEST_TYPE_SABR } from '../../helpers/player/SabrManifestParser'
 import { resolveSegmentPrefetchLimit } from '../../helpers/player/segmentPrefetch'
+import { streamsSupportAutoQuality } from '../../helpers/player/autoQuality'
 import { setupSabrScheme } from '../../helpers/player/SabrSchemePlugin'
 import { getRememberedPlayerVolume, setRememberedPlayerVolume } from '../../helpers/player/volume-storage'
 import { parseChannelPreferences } from '../../helpers/channel-preferences'
@@ -1214,13 +1215,17 @@ export default defineComponent({
       events.dispatchEvent(new CustomEvent('timeDisplaySettingsChanged'))
     })
 
-    /** @type {import('vue').ComputedRef<number | 'auto'>} */
+    /**
+     * The numeric quality to start with. Auto is handled separately by
+     * `preferAutoQuality`, so that the quality selection code paths, which all
+     * work with resolutions, keep a usable value to fall back to.
+     * @type {import('vue').ComputedRef<number>}
+     */
     const defaultQuality = computed(() => {
       const value = store.getters.getDefaultQuality
 
-      // TODO: Revert when auto is fixed (720 is the default setttings value)
+      // 720 is the default settings value
       if (value === 'auto') { return 720 }
-      // if (value === 'auto') { return value }
 
       return parseInt(value)
     })
@@ -1229,6 +1234,22 @@ export default defineComponent({
     const preferredVideoQuality = computed(() => {
       const value = Number.parseInt(props.currentVideoQuality)
       return Number.isNaN(value) ? defaultQuality.value : value
+    })
+
+    /** @type {import('vue').ComputedRef<boolean>} */
+    const preferAutoQuality = computed(() => {
+      if (!autoQualitySupported.value) {
+        return false
+      }
+
+      if (props.currentVideoQuality === 'auto') {
+        return true
+      }
+
+      // Only fall back to the setting when no quality was passed in,
+      // e.g. before the watch page has resolved a channel specific one
+      return Number.isNaN(Number.parseInt(props.currentVideoQuality)) &&
+        store.getters.getDefaultQuality === 'auto'
     })
 
     /** @type {import('vue').ComputedRef<boolean>} */
@@ -2809,16 +2830,24 @@ export default defineComponent({
       return props.playbackEngine === 'yt-dlp' && props.manifestSrc.includes('/playlist_type/DVR/')
     })
 
+    /** @type {import('vue').ComputedRef<boolean>} */
+    const isSabrPlayback = computed(() => {
+      return !!process.env.SUPPORTS_LOCAL_API &&
+        props.format !== 'legacy' &&
+        props.manifestMimeType === MANIFEST_TYPE_SABR
+    })
+
+    /** @type {import('vue').ComputedRef<boolean>} */
+    const autoQualitySupported = computed(() => {
+      return streamsSupportAutoQuality(props.format, isSabrPlayback.value)
+    })
+
     /**
      * How many segments per stream shaka-player downloads in parallel ahead of the playhead.
      * @type {import('vue').ComputedRef<number>}
      */
     const segmentPrefetchLimit = computed(() => {
-      const isSabr = !!process.env.SUPPORTS_LOCAL_API &&
-        props.format !== 'legacy' &&
-        props.manifestMimeType === MANIFEST_TYPE_SABR
-
-      return resolveSegmentPrefetchLimit(store.getters.getSegmentPrefetchLimit, isSabr)
+      return resolveSegmentPrefetchLimit(store.getters.getSegmentPrefetchLimit, isSabrPlayback.value)
     })
 
     watch(segmentPrefetchLimit, (newValue) => {
@@ -7902,7 +7931,7 @@ export default defineComponent({
 
       player.addEventListener('error', event => handleError(event.detail, 'shaka error handler'))
 
-      player.configure(getPlayerConfig(props.format, false))
+      player.configure(getPlayerConfig(props.format, preferAutoQuality.value))
 
       if (process.env.SUPPORTS_LOCAL_API) {
         player.getNetworkingEngine().registerRequestFilter(requestFilter)
@@ -8107,7 +8136,10 @@ export default defineComponent({
           await player.load(props.manifestSrc, props.startTime, props.manifestMimeType)
 
           if (props.format === 'dash') {
-            setDashQuality(preferredVideoQuality.value)
+            // Let shaka-player's ABR pick the variant when auto quality is preferred
+            if (!preferAutoQuality.value) {
+              setDashQuality(preferredVideoQuality.value)
+            }
           } else {
             let variants = player.getVariantTracks()
 
@@ -8289,7 +8321,7 @@ export default defineComponent({
 
           ignoreErrors = false
 
-          player.configure(getPlayerConfig(newFormat, false))
+          player.configure(getPlayerConfig(newFormat, preferAutoQuality.value))
 
           await performFirstLoad()
           return
@@ -8300,7 +8332,11 @@ export default defineComponent({
         const wasPaused = video_.paused
         const playbackRate = getCurrentPlaybackRate()
 
-        const useAutoQuality = oldFormat === 'legacy' ? false : player.getConfiguration().abr.enabled
+        // The legacy formats don't have an ABR configuration to carry over,
+        // so fall back to the user's preference when switching away from them
+        const useAutoQuality = oldFormat === 'legacy'
+          ? preferAutoQuality.value
+          : player.getConfiguration().abr.enabled
 
         if (!wasPaused) {
           video_.pause()
@@ -8792,6 +8828,8 @@ export default defineComponent({
       useSponsorBlock,
       getShareTimestamp,
       toggleQuickBookmark,
+
+      autoQualitySupported,
 
       fullWindowEnabled,
       fullWindowPlaceholderHeight,

--- a/src/renderer/components/ft-shaka-video-player/ft-shaka-video-player.js
+++ b/src/renderer/components/ft-shaka-video-player/ft-shaka-video-player.js
@@ -62,7 +62,7 @@ import { isReducedMotionEnabled } from '../../helpers/reducedMotion'
 import { appendTimestamp, getInvidiousVideoUrl, getYoutubeVideoShareUrl } from '../../helpers/share'
 import { MANIFEST_TYPE_SABR } from '../../helpers/player/SabrManifestParser'
 import { resolveSegmentPrefetchLimit } from '../../helpers/player/segmentPrefetch'
-import { streamsSupportAutoQuality } from '../../helpers/player/autoQuality'
+import { AUTO_QUALITY_FALLBACK, streamsSupportAutoQuality } from '../../helpers/player/autoQuality'
 import { setupSabrScheme } from '../../helpers/player/SabrSchemePlugin'
 import { getRememberedPlayerVolume, setRememberedPlayerVolume } from '../../helpers/player/volume-storage'
 import { parseChannelPreferences } from '../../helpers/channel-preferences'
@@ -1224,10 +1224,7 @@ export default defineComponent({
     const defaultQuality = computed(() => {
       const value = store.getters.getDefaultQuality
 
-      // 720 is the default settings value
-      if (value === 'auto') { return 720 }
-
-      return parseInt(value)
+      return parseInt(value === 'auto' ? AUTO_QUALITY_FALLBACK : value)
     })
 
     /** @type {import('vue').ComputedRef<number>} */

--- a/src/renderer/components/ft-shaka-video-player/ft-shaka-video-player.vue
+++ b/src/renderer/components/ft-shaka-video-player/ft-shaka-video-player.vue
@@ -42,6 +42,7 @@
       ref="container"
       class="ftVideoPlayer shaka-video-container"
       :class="{
+        autoQualityUnavailable: !autoQualitySupported,
         fullWindow: fullWindowEnabled,
         shortsPlayer,
         shortsPaused: shortsPaused && hasLoaded,

--- a/src/renderer/helpers/player/autoQuality.js
+++ b/src/renderer/helpers/player/autoQuality.js
@@ -1,0 +1,29 @@
+/**
+ * The automatic quality selection (shaka-player's ABR) was hidden everywhere in
+ * FreeTube#8908, because its runtime quality switches are broken with SABR:
+ * the initial selection works, but any later switch (changing network conditions,
+ * resizing the player or the picture-in-picture window) runs into errors.
+ *
+ * Streams that don't go through SABR, like yt-dlp's and Invidious' manifests,
+ * are unaffected, so auto quality can be offered for those.
+ */
+
+/**
+ * Whether the currently playing streams support the automatic quality selection.
+ * @param {'dash'|'audio'|'legacy'} format the legacy formats have their own quality selection
+ * @param {boolean} isSabr whether the streams are served over SABR
+ * @returns {boolean}
+ */
+export function streamsSupportAutoQuality(format, isSabr) {
+  return format !== 'legacy' && !isSabr
+}
+
+/**
+ * Whether the settings should offer auto as a quality, which depends on the
+ * stream extraction method, as only the built-in one uses SABR.
+ * @param {string} videoPlaybackEngine
+ * @returns {boolean}
+ */
+export function playbackEngineSupportsAutoQuality(videoPlaybackEngine) {
+  return !process.env.SUPPORTS_LOCAL_API || videoPlaybackEngine === 'yt-dlp'
+}

--- a/src/renderer/helpers/player/autoQuality.js
+++ b/src/renderer/helpers/player/autoQuality.js
@@ -9,6 +9,14 @@
  */
 
 /**
+ * The quality that a stored `auto` falls back to while auto quality is
+ * unavailable. It is the default value of the `defaultQuality` setting, but
+ * intentionally not that setting's current value: playback uses this fallback,
+ * so anything that displays the fallback has to use it as well to agree.
+ */
+export const AUTO_QUALITY_FALLBACK = '720'
+
+/**
  * Whether the currently playing streams support the automatic quality selection.
  * @param {'dash'|'audio'|'legacy'} format the legacy formats have their own quality selection
  * @param {boolean} isSabr whether the streams are served over SABR

--- a/src/renderer/views/Watch/Watch.js
+++ b/src/renderer/views/Watch/Watch.js
@@ -81,6 +81,7 @@ import {
   isYouTubeShort
 } from '../../helpers/player/shorts'
 import { MANIFEST_TYPE_SABR } from '../../helpers/player/SabrManifestParser'
+import { playbackEngineSupportsAutoQuality } from '../../helpers/player/autoQuality'
 import { useI18n } from 'vue-i18n'
 import { useTabAvatar, useTabContext, useTabTitle } from '../../tabs/TabContext'
 import { tabMediaCoordinator } from '../../tabs/TabMediaCoordinator'
@@ -2948,8 +2949,11 @@ export default defineComponent({
 
       if (this.saveChannelVideoQuality(this.currentVideoQuality)) {
         const savedQuality = this.normalizeVideoQuality(this.currentVideoQuality)
+        const savedQualityLabel = savedQuality === 'auto'
+          ? this.t('Settings.Player Settings.Default Quality.Auto')
+          : `${savedQuality}p`
         showToast({
-          message: `${this.t('Video.Channel Video Quality Saved')}: ${savedQuality}p`,
+          message: `${this.t('Video.Channel Video Quality Saved')}: ${savedQualityLabel}`,
           icon: ['fas', 'film']
         })
       }
@@ -4120,8 +4124,10 @@ export default defineComponent({
     normalizeVideoQuality(quality) {
       const normalizedQuality = quality == null ? '' : String(quality)
 
-      // TODO: Revert when auto is fixed
-      if (normalizedQuality === 'auto') {
+      // Auto is broken with SABR, so fall back to the default quality there.
+      // The player checks the streams it actually received as well, as yt-dlp
+      // can fall back to the built-in extraction method.
+      if (normalizedQuality === 'auto' && !playbackEngineSupportsAutoQuality(this.videoPlaybackEngine)) {
         return '720'
       }
 

--- a/src/renderer/views/Watch/Watch.js
+++ b/src/renderer/views/Watch/Watch.js
@@ -81,7 +81,7 @@ import {
   isYouTubeShort
 } from '../../helpers/player/shorts'
 import { MANIFEST_TYPE_SABR } from '../../helpers/player/SabrManifestParser'
-import { playbackEngineSupportsAutoQuality } from '../../helpers/player/autoQuality'
+import { AUTO_QUALITY_FALLBACK, playbackEngineSupportsAutoQuality } from '../../helpers/player/autoQuality'
 import { useI18n } from 'vue-i18n'
 import { useTabAvatar, useTabContext, useTabTitle } from '../../tabs/TabContext'
 import { tabMediaCoordinator } from '../../tabs/TabMediaCoordinator'
@@ -4128,7 +4128,7 @@ export default defineComponent({
       // The player checks the streams it actually received as well, as yt-dlp
       // can fall back to the built-in extraction method.
       if (normalizedQuality === 'auto' && !playbackEngineSupportsAutoQuality(this.videoPlaybackEngine)) {
-        return '720'
+        return AUTO_QUALITY_FALLBACK
       }
 
       return normalizedQuality

--- a/static/locales/en-US.yaml
+++ b/static/locales/en-US.yaml
@@ -1751,6 +1751,7 @@ Tooltips:
     Concurrent Segment Downloads: |
       How many video and audio segments are downloaded in parallel ahead of the current playback position.
       Higher values can improve the download speed on slow or unstable connections, but use more bandwidth and memory.
+      As parallel downloads share the connection, each one is measured as slower, which can make the automatic quality selection pick a lower resolution.
       Streams that only allow one request at a time, which most of those from the built-in stream extraction method are, are unaffected.
   External Player Settings:
     External Player: Choosing an external player will display an icon, for opening the

--- a/tests/unit/auto-quality.test.mjs
+++ b/tests/unit/auto-quality.test.mjs
@@ -1,0 +1,40 @@
+import assert from 'node:assert/strict'
+import test from 'node:test'
+
+import {
+  playbackEngineSupportsAutoQuality,
+  streamsSupportAutoQuality
+} from '../../src/renderer/helpers/player/autoQuality.js'
+
+test.afterEach(() => {
+  delete process.env.SUPPORTS_LOCAL_API
+})
+
+test('auto quality is available for streams that do not use SABR', () => {
+  assert.equal(streamsSupportAutoQuality('dash', false), true)
+  assert.equal(streamsSupportAutoQuality('audio', false), true)
+})
+
+test('auto quality is unavailable for SABR streams', () => {
+  // ABR quality switches are broken with SABR, see FreeTube#8906
+  assert.equal(streamsSupportAutoQuality('dash', true), false)
+  assert.equal(streamsSupportAutoQuality('audio', true), false)
+})
+
+test('the legacy formats never use auto quality', () => {
+  // they are single progressive files with their own quality selection
+  assert.equal(streamsSupportAutoQuality('legacy', false), false)
+  assert.equal(streamsSupportAutoQuality('legacy', true), false)
+})
+
+test('only the built-in stream extraction method loses auto quality', () => {
+  process.env.SUPPORTS_LOCAL_API = true
+
+  assert.equal(playbackEngineSupportsAutoQuality('yt-dlp'), true)
+  assert.equal(playbackEngineSupportsAutoQuality('built-in'), false)
+})
+
+test('builds without the local API always support auto quality', () => {
+  // those never use SABR, as they get their streams from Invidious
+  assert.equal(playbackEngineSupportsAutoQuality('built-in'), true)
+})


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Make sure to follow the contributing guidelines. -->
<!-- Important note, we may remove your pull request if you do not use this provided PR template correctly. -->

## Pull Request Type
<!-- Please select what type of pull request this is: [x] -->
- [ ] Bugfix
- [x] Feature Implementation
- [ ] Documentation
- [ ] Other

## Related issue
<!-- Please link the issue your pull request is referring to. -->
<!-- If this pull request fully resolves the relevant issue, put "closes" before the issue number. -->
<!-- Example: "closes #123456". -->
closes #588

## Description
<!-- Please write a clear and concise description of what the pull request does. -->
Auto quality was hidden everywhere in FreeTubeApp/FreeTube#8908, as a stopgap: its runtime quality switches are broken with SABR. Quoting that pull request, "the initial auto quality selection works fine, the issue is when auto triggers a quality change e.g. network conditions changing or resizing the player/pip window". Fixing that needs a rewrite, so the option was hidden, the `auto` setting was overridden to 720p, and nine `TODO: Revert when auto is fixed` comments were left behind.

That breakage is specific to SABR. yt-dlp's manifests don't go through it, so auto is now gated on the stream source instead of being hidden unconditionally:

- the player decides from the streams it actually received, which matters because yt-dlp can fall back to the built-in extraction method. With SABR the Auto entry stays hidden and ABR stays off, exactly as before.
- the default quality and per-channel quality settings offer auto again when the stream extraction method is yt-dlp. A stored `auto` still falls back to 720p while it is unavailable, so switching to the built-in method can't get anyone stuck.

The quality selection code paths keep working with resolutions, `auto` is tracked separately, so it can't leak into them.

All nine `TODO: Revert when auto is fixed` comments are resolved.

Out of scope: picking Auto in the player's quality menu is still not remembered, because the player doesn't emit a quality while ABR is enabled. That is unchanged behaviour from before auto was hidden.

## Release note category
<!-- Select exactly one category. Every pull request must select one. -->
<!-- release-note-category:start -->
- [ ] Not noteworthy
- [ ] Highlights
- [x] More improvements
- [ ] Fixed bugs
<!-- release-note-category:end -->

## Release note
<!-- Required unless "Not noteworthy" is selected. -->
<!-- Write one concise, user-facing entry without a leading bullet. -->
<!-- release-note:start -->
Restored the automatic video quality selection for the yt-dlp stream extraction method, where it is unaffected by the issues that led to it being hidden
<!-- release-note:end -->

## Release note images
<!-- Human-only: Agents must preserve this entire section and leave it empty. -->
<!-- Optional. Paste one or more Markdown images or HTML image tags here. -->
<!-- The release notes will use an HTML image tag and limit images taller than 300 pixels. -->
<!-- release-note-image:start -->

<!-- release-note-image:end -->

## Testing
<!-- How can reviewers verify that the PR produces correct results? -->
1. Set the stream extraction method to yt-dlp (Settings > General).
2. Settings > Player: "Default Quality" should offer "Auto" again. Set it to Auto.
3. Play a video and open the quality menu in the player: "Auto" should be listed and marked as selected, and the quality should adapt instead of being pinned.
4. Optionally confirm it in the developer tools' console on the watch page:
   ```js
   (() => {
     const el = document.querySelector('.tabContent[aria-hidden="false"] .ftVideoPlayer')
     const player = (el.ui ?? el.querySelector('video').ui).getControls().getPlayer()
     return player.getConfiguration().abr.enabled
   })()
   ```
   It should print `true`.
5. Switch the stream extraction method to built-in and reload the video: "Auto" should be gone from both the settings and the player's quality menu, the video should play at 720p, and the console snippet should print `false`.
6. Switch the video to the legacy formats: the Auto entry should not appear there either.
7. With Settings > Player > Channel Settings > per-channel video quality enabled, the per-channel quality dropdown should offer Auto with yt-dlp, and saving it for a channel should show "Auto" in the toast rather than "autop".

## Additional context
<!-- Add any other context about the pull request here. -->
Reuses the SABR check introduced in #590, which is merged, so this now only contains the auto quality changes.

