### PR TITLE
fix(scrollbars): reset stale dynamic list positions

### DIFF
--- a/e2e/helpers/player.mjs
+++ b/e2e/helpers/player.mjs
@@ -67,7 +67,7 @@ export async function expectDockedToBottomRight(player, viewport, margin = 16) {
 export function findWatchComponent() {
   const app = document.querySelector('#app')?.__vue_app__
   const find = (vnode) => {
-    if (vnode?.component?.refs?.player) return vnode.component
+    if (vnode?.component?.type?.name === 'Watch' || vnode?.component?.refs?.player) return vnode.component
     if (vnode?.component?.subTree) {
       const match = find(vnode.component.subTree)
       if (match) return match

--- a/e2e/tests/network/watch.spec.mjs
+++ b/e2e/tests/network/watch.spec.mjs
@@ -323,6 +323,45 @@ test.describe('watch page', () => {
     await expect(player.locator('video')).toHaveAttribute('poster', /\S+/)
   })
 
+  test('resets the transcript scroll position when searching', async ({ page }) => {
+    await page.route('https://example.test/transcript.vtt', route => route.fulfill({
+      body: longTranscript(),
+      contentType: 'text/vtt'
+    }))
+    await page.locator(sel.searchInput).fill(VIDEO_URL)
+    await page.locator(sel.searchInput).press('Enter')
+    await expect(page).toHaveURL(/#\/watch\/jNQXAC9IVRw/)
+    await expect(page.locator('.videoLayout')).toBeVisible()
+
+    const watchComponent = await page.evaluateHandle(findWatchComponent)
+    await watchComponent.evaluate(async (component) => {
+      const watchView = component.proxy
+      watchView.videoLoadGeneration += 1
+      watchView.errorMessage = null
+      watchView.isLive = false
+      watchView.isUpcoming = false
+      watchView.playabilityStatus = 'OK'
+      watchView.captions = [{
+        url: 'https://example.test/transcript.vtt',
+        label: 'English',
+        language: 'en'
+      }]
+      watchView.showTranscript = true
+      watchView.isLoading = false
+      await watchView.$nextTick()
+    })
+
+    const transcriptSegments = page.locator('.transcriptSegments')
+    await expect(page.locator('.transcriptSegment').first()).toBeVisible()
+    await transcriptSegments.evaluate(element => { element.scrollTop = element.scrollHeight })
+    await expect.poll(() => transcriptSegments.evaluate(element => element.scrollTop)).toBeGreaterThan(0)
+    await page.getByPlaceholder('Search transcript').fill('Transcript line 2500.')
+    await expect(page.locator('.transcriptSegment')).toHaveCount(1)
+    await expect.poll(() => transcriptSegments.evaluate(element => element.scrollTop)).toBe(0)
+
+    await watchComponent.dispose()
+  })
+
   test('long transcripts quickly align with the current cue', async ({ page, innertube }) => {
     test.skip(innertube.replay, 'watch page hydration needs the real API')
     await page.route(/\/api\/timedtext/, route => route.fulfill({

--- a/e2e/tests/offline/search-history-limit.spec.mjs
+++ b/e2e/tests/offline/search-history-limit.spec.mjs
@@ -29,4 +29,10 @@ test('shows every saved search in a scrollable list', async ({ page }) => {
   await expect.poll(() => list.evaluate(element => {
     return element.clientWidth === element.offsetWidth
   })).toBe(true)
+
+  await list.evaluate(element => { element.scrollTop = element.scrollHeight })
+  await expect.poll(() => list.evaluate(element => element.scrollTop)).toBeGreaterThan(0)
+  await page.locator(sel.searchInput).fill(entries.at(-1)._id)
+  await expect(suggestions).toHaveCount(1)
+  await expect.poll(() => list.evaluate(element => element.scrollTop)).toBe(0)
 })

--- a/e2e/tests/offline/settings.spec.mjs
+++ b/e2e/tests/offline/settings.spec.mjs
@@ -274,6 +274,70 @@ test.describe('settings', () => {
     expect(restoredBounds.height).toBeCloseTo(resizedBounds.height, 0)
   })
 
+  test('clamps the settings scroll position after repeated resizing', async ({ page }) => {
+    await goTo(page, 'settings')
+    const settingsWindow = page.locator('.settingsWindow')
+    const content = page.locator('.settingsContent')
+    const resizeHandle = page.locator('.resize-se')
+    await expect(settingsWindow).not.toHaveClass(/settings-window-enter-active/)
+
+    const originalHandleBounds = await resizeHandle.boundingBox()
+    await page.mouse.move(
+      originalHandleBounds.x + originalHandleBounds.width / 2,
+      originalHandleBounds.y + originalHandleBounds.height / 2
+    )
+    await page.mouse.down()
+    await page.mouse.move(originalHandleBounds.x - 180, originalHandleBounds.y - 180)
+    await page.mouse.up()
+
+    await content.evaluate(element => { element.scrollTop = element.scrollHeight })
+    await expect.poll(() => content.evaluate(element => element.scrollTop)).toBeGreaterThan(0)
+
+    const smallerHandleBounds = await resizeHandle.boundingBox()
+    await page.mouse.move(
+      smallerHandleBounds.x + smallerHandleBounds.width / 2,
+      smallerHandleBounds.y + smallerHandleBounds.height / 2
+    )
+    await page.mouse.down()
+    await page.mouse.move(smallerHandleBounds.x + 180, smallerHandleBounds.y + 180)
+    await page.mouse.up()
+
+    await page.waitForTimeout(250)
+    expect(await content.evaluate(element => {
+      const section = element.querySelector('.section')
+      const contentEnd = section.offsetTop + section.offsetHeight +
+        Number.parseFloat(getComputedStyle(element).paddingBottom)
+      return element.scrollTop - Math.max(0, contentEnd - element.clientHeight)
+    })).toBeLessThanOrEqual(1)
+
+    const restoredHandleBounds = await resizeHandle.boundingBox()
+    await page.mouse.move(
+      restoredHandleBounds.x + restoredHandleBounds.width / 2,
+      restoredHandleBounds.y + restoredHandleBounds.height / 2
+    )
+    await page.mouse.down()
+    await page.mouse.move(restoredHandleBounds.x - 180, restoredHandleBounds.y - 180)
+    await page.mouse.up()
+
+    const menu = page.locator('.settingsMenu')
+    await menu.evaluate(element => { element.scrollTop = element.scrollHeight })
+    await expect.poll(() => menu.evaluate(element => element.scrollTop)).toBeGreaterThan(0)
+
+    const compactHandleBounds = await resizeHandle.boundingBox()
+    await page.mouse.move(
+      compactHandleBounds.x + compactHandleBounds.width / 2,
+      compactHandleBounds.y + compactHandleBounds.height / 2
+    )
+    await page.mouse.down()
+    await page.mouse.move(compactHandleBounds.x + 180, compactHandleBounds.y + 180)
+    await page.mouse.up()
+
+    await page.waitForTimeout(250)
+    expect(await menu.evaluate(element => (
+      element.scrollTop - Math.max(0, element.scrollHeight - element.clientHeight)
+    ))).toBeLessThanOrEqual(1)
+  })
+
   test('animates maximize and restore while preserving its floating bounds', async ({ page }) => {
     await goTo(page, 'settings')
     const settingsWindow = page.locator('.settingsWindow')

--- a/e2e/tests/offline/watch-page.spec.mjs
+++ b/e2e/tests/offline/watch-page.spec.mjs
@@ -29,8 +29,17 @@ const FULLSCREEN_PLAYLIST = {
     author: 'jawed',
     authorId: 'UC4QobU6STFB0P71PMvOGN5A',
     lengthSeconds: 19,
+    playlistItemId: 'playlist-item-0',
     type: 'video'
-  }],
+  }, ...Array.from({ length: 29 }, (_, index) => ({
+    videoId: `playlist${String(index + 1).padStart(3, '0')}`,
+    title: `Playlist video ${index + 1}`,
+    author: 'Playlist channel',
+    authorId: 'UC-playlist-channel',
+    lengthSeconds: 60,
+    playlistItemId: `playlist-item-${index + 1}`,
+    type: 'video'
+  }))],
   createdAt: Date.now() - 86_400_000,
   lastUpdatedAt: Date.now() - 86_400_000
 }
@@ -122,6 +131,40 @@ test.describe('watch page', () => {
       await expect(page.locator(`${selector}[data-overlayscrollbars-viewport]`)).toHaveCount(1)
       await expect(page.locator(`${selector} > .os-scrollbar-vertical`)).toHaveCount(1)
     }
+  })
+
+  test('resets the Shorts auxiliary viewport when switching panels', async ({ app, page }) => {
+    await mockPlayableWatchPage(app, page)
+    await openMockedVideo(page)
+
+    const watchComponent = await page.evaluateHandle(findWatchComponent)
+    await watchComponent.evaluate(async (component) => {
+      const watchView = component.proxy
+      watchView.isLoading = true
+      await watchView.$nextTick()
+      watchView.isShort = true
+      watchView.videoDescription = Array(200).fill('Long Shorts metadata').join('\n')
+      watchView.videoDescriptionHtml = ''
+      watchView.shortsMetadataOpen = true
+      watchView.isLoading = false
+      await watchView.$nextTick()
+    })
+
+    const target = page.locator('.shortsAuxPanelTarget')
+    await expect(page.locator('.shortsAuxPanel')).toHaveClass(/shortsAuxPanelOpen/)
+    await expect.poll(() => target.evaluate(element => element.scrollHeight > element.clientHeight)).toBe(true)
+    await target.evaluate(element => { element.scrollTop = element.scrollHeight })
+    await expect.poll(() => target.evaluate(element => element.scrollTop)).toBeGreaterThan(0)
+
+    await watchComponent.evaluate(async (component) => {
+      component.proxy.toggleTranscript()
+      await component.proxy.$nextTick()
+    })
+    await expect(page.locator('.shortsAuxPanelTarget .watchVideoTranscript')).toBeVisible()
+    await page.waitForTimeout(250)
+    expect(await target.evaluate(element => element.scrollTop)).toBe(0)
+
+    await watchComponent.dispose()
   })
 
   test('sidebar chapters and SponsorBlock honor roundness while closing beside the description', async ({ app, page }) => {
@@ -570,6 +613,34 @@ test.describe('fullscreen playlist dock', () => {
     await item.locator('.videoThumbnail').hover()
     await expect(item.locator('.trashIcon')).toHaveCount(1)
     await expect(item.locator('.quickBookmarkVideoIcon')).toHaveCount(0)
+  })
+
+  test('clamps the watch playlist after removing most entries', async ({ app, page }) => {
+    await mockPlayableWatchPage(app, page)
+    await openMockedVideo(page)
+    await openFullscreenPlaylistVideo(page)
+
+    await setPlayerFullscreen(page, true)
+    await page.locator('.fullscreenPlaylistToggle').click()
+    await expect(page.locator('.fullscreenPlaylistTarget .watchVideoPlaylist')).toBeVisible()
+
+    const playlist = page.locator('.fullscreenPlaylistTarget .watchVideoPlaylist')
+    const scroller = playlist.locator('.playlistItemsWrapper')
+    const items = scroller.locator('.playlistItem')
+    await expect(items).toHaveCount(FULLSCREEN_PLAYLIST.videos.length)
+    await scroller.evaluate(element => { element.scrollTop = element.scrollHeight })
+    await expect.poll(() => scroller.evaluate(element => element.scrollTop)).toBeGreaterThan(0)
+
+    await page.evaluate(async ({ playlistId, playlistItemIds }) => {
+      const store = document.querySelector('#app').__vue_app__.config.globalProperties.$store
+      await store.dispatch('removeVideos', { _id: playlistId, playlistItemIds })
+    }, {
+      playlistId: FULLSCREEN_PLAYLIST_ID,
+      playlistItemIds: FULLSCREEN_PLAYLIST.videos.slice(4).map(video => video.playlistItemId)
+    })
+    await expect(items).toHaveCount(4)
+    await page.waitForTimeout(250)
+    expect(await scroller.evaluate(element => element.scrollTop)).toBe(0)
   })
 
   test('keeps compact watched labels and playlist menus clear of other controls', async ({ app, page }) => {

--- a/e2e/tests/offline/watch-queue.spec.mjs
+++ b/e2e/tests/offline/watch-queue.spec.mjs
@@ -90,6 +90,32 @@ test('manages a temporary queue from video menus and the watch sidebar', async (
     'Queue video two'
   ])
 
+  await page.evaluate(() => {
+    const store = document.querySelector('#app').__vue_app__.config.globalProperties.$store
+    for (let index = 0; index < 20; index++) {
+      store.commit('addVideoToWatchQueue', {
+        video: {
+          videoId: `overflow${index}`,
+          title: `Overflow video ${index}`,
+          author: 'Queue Test Channel'
+        }
+      })
+    }
+  })
+  await expect(queueItems).toHaveCount(22)
+  const queueScroller = queue.locator('.queueItems')
+  await queueScroller.evaluate(element => { element.scrollTop = element.scrollHeight })
+  await expect.poll(() => queueScroller.evaluate(element => element.scrollTop)).toBeGreaterThan(0)
+  await page.evaluate(() => {
+    const store = document.querySelector('#app').__vue_app__.config.globalProperties.$store
+    const queueItemIds = store.getters.getWatchQueue.slice(4).map(item => item.queueItemId)
+    for (const queueItemId of queueItemIds) {
+      store.commit('removeVideoFromWatchQueue', queueItemId)
+    }
+  })
+  await expect(queueItems).toHaveCount(4)
+  await expect.poll(() => queueScroller.evaluate(element => element.scrollTop)).toBe(0)
+
   await queue.getByRole('button', { name: 'Clear Queue' }).click()
   await expect(queue).toBeHidden()
 })

--- a/src/renderer/components/FtInput/FtInput.css
+++ b/src/renderer/components/FtInput/FtInput.css
@@ -230,6 +230,7 @@ body[dir='rtl'] .ft-input-component.search.showClearTextButton:focus-within .inp
 
 .list {
   position: absolute;
+  overflow-anchor: none;
   inline-size: 100%;
   list-style: none;
   margin: 0;

--- a/src/renderer/components/FtInput/FtInput.vue
+++ b/src/renderer/components/FtInput/FtInput.vue
@@ -80,6 +80,7 @@
     <div class="options">
       <ul
         v-if="showOptions"
+        ref="optionsList"
         v-overlay-scrollbars
         class="list"
         @mouseenter="searchState.isPointerInList = true"
@@ -131,6 +132,7 @@ import FtSyncedSettingIndicator from '../FtSyncedSettingIndicator/FtSyncedSettin
 
 import store from '../../store/index'
 
+import { restoreOverlayScrollTop } from '../../helpers/overlayScrollbars'
 import { isKeyboardEventKeyPrintableChar, isNullOrEmpty } from '../../helpers/strings'
 import { getInputTextAscentOffset } from './inputTextMetrics'
 
@@ -216,6 +218,7 @@ const emit = defineEmits(['blur', 'clear', 'click', 'input', 'keydown', 'remove'
 const id = useId()
 
 const inputRef = useTemplateRef('inputRef')
+const optionsList = useTemplateRef('optionsList')
 
 const inputData = ref(props.value)
 const searchState = reactive({
@@ -505,6 +508,10 @@ function handleFocus() {
 }
 
 function updateVisibleDataList() {
+  if (optionsList.value != null) {
+    restoreOverlayScrollTop(optionsList.value, 0)
+  }
+
   // Reset selected option before it's updated
   // Block resetting if it was just the "Remove" button that was pressed
   if (!removalMade.value || searchState.selectedOption >= props.dataList.length) {

--- a/src/renderer/components/WatchVideoPlaylist/WatchVideoPlaylist.css
+++ b/src/renderer/components/WatchVideoPlaylist/WatchVideoPlaylist.css
@@ -197,6 +197,7 @@
 
 .playlistItemsWrapper {
   overflow-y: auto;
+  overflow-anchor: none;
   block-size: 360px;
   min-block-size: 180px;
   resize: vertical;

--- a/src/renderer/components/WatchVideoPlaylist/WatchVideoPlaylist.vue
+++ b/src/renderer/components/WatchVideoPlaylist/WatchVideoPlaylist.vue
@@ -230,7 +230,7 @@
 
 <script setup>
 import { FontAwesomeIcon } from '@fortawesome/vue-fontawesome'
-import { computed, nextTick, onMounted, ref, shallowRef, TransitionGroup, useTemplateRef, watch } from 'vue'
+import { computed, nextTick, onBeforeUnmount, onMounted, ref, shallowRef, TransitionGroup, useTemplateRef, watch } from 'vue'
 import { useI18n } from 'vue-i18n'
 import { useRouter } from 'vue-router'
 
@@ -250,7 +250,7 @@ import {
 } from '../../helpers/api/local'
 import { invidiousGetPlaylistInfo } from '../../helpers/api/invidious'
 import { isHistoryEntryWatched } from '../../helpers/history'
-import { restoreOverlayScrollTop } from '../../helpers/overlayScrollbars'
+import { clampOverlayScrollTop, restoreOverlayScrollTop } from '../../helpers/overlayScrollbars'
 import { getPlaylistSkipAvailability, getSortedPlaylistItems, SORT_BY_VALUES } from '../../helpers/playlists'
 import { useTabContext } from '../../tabs/TabContext'
 
@@ -1049,6 +1049,28 @@ function shufflePlaylistItems() {
 }
 
 const playlistItemsWrapper = useTemplateRef('playlistItemsWrapper')
+let playlistItemsObserver = null
+
+watch(playlistItemsWrapper, (wrapper) => {
+  playlistItemsObserver?.disconnect()
+  const container = wrapper?.$el ?? wrapper
+  if (container == null) {
+    return
+  }
+
+  playlistItemsObserver = new MutationObserver(() => {
+    requestAnimationFrame(() => {
+      const items = container.querySelectorAll(':scope > .playlistItem')
+      clampOverlayScrollTop(
+        container,
+        items[items.length - 1] ?? null
+      )
+    })
+  })
+  playlistItemsObserver.observe(container, { childList: true })
+}, { flush: 'post' })
+
+onBeforeUnmount(() => playlistItemsObserver?.disconnect())
 
 function getScrollTop() {
   const container = playlistItemsWrapper.value?.$el ?? playlistItemsWrapper.value

--- a/src/renderer/components/WatchVideoPlaylist/WatchVideoPlaylist.vue
+++ b/src/renderer/components/WatchVideoPlaylist/WatchVideoPlaylist.vue
@@ -1050,16 +1050,27 @@ function shufflePlaylistItems() {
 
 const playlistItemsWrapper = useTemplateRef('playlistItemsWrapper')
 let playlistItemsObserver = null
+let playlistItemsClampFrame = null
+
+function stopObservingPlaylistItems() {
+  playlistItemsObserver?.disconnect()
+  playlistItemsObserver = null
+  if (playlistItemsClampFrame !== null) {
+    cancelAnimationFrame(playlistItemsClampFrame)
+    playlistItemsClampFrame = null
+  }
+}
 
 watch(playlistItemsWrapper, (wrapper) => {
-  playlistItemsObserver?.disconnect()
+  stopObservingPlaylistItems()
   const container = wrapper?.$el ?? wrapper
   if (container == null) {
     return
   }
 
   playlistItemsObserver = new MutationObserver(() => {
-    requestAnimationFrame(() => {
+    playlistItemsClampFrame ??= requestAnimationFrame(() => {
+      playlistItemsClampFrame = null
       const items = container.querySelectorAll(':scope > .playlistItem')
       clampOverlayScrollTop(
         container,
@@ -1070,7 +1081,7 @@ watch(playlistItemsWrapper, (wrapper) => {
   playlistItemsObserver.observe(container, { childList: true })
 }, { flush: 'post' })
 
-onBeforeUnmount(() => playlistItemsObserver?.disconnect())
+onBeforeUnmount(stopObservingPlaylistItems)
 
 function getScrollTop() {
   const container = playlistItemsWrapper.value?.$el ?? playlistItemsWrapper.value

--- a/src/renderer/components/WatchVideoQueue/WatchVideoQueue.scss
+++ b/src/renderer/components/WatchVideoQueue/WatchVideoQueue.scss
@@ -31,6 +31,7 @@
 
 .queueItems {
   max-block-size: 480px;
+  overflow-anchor: none;
   margin: 0;
   padding: 0;
   overflow-y: auto;

--- a/src/renderer/components/WatchVideoQueue/WatchVideoQueue.vue
+++ b/src/renderer/components/WatchVideoQueue/WatchVideoQueue.vue
@@ -20,6 +20,7 @@
       </button>
     </header>
     <TransitionGroup
+      ref="queueItems"
       v-overlay-scrollbars
       name="queueItem"
       tag="ol"
@@ -84,11 +85,12 @@
 
 <script setup>
 import { FontAwesomeIcon } from '@fortawesome/vue-fontawesome'
-import { computed, ref } from 'vue'
+import { computed, onBeforeUnmount, onMounted, ref, useTemplateRef } from 'vue'
 import { useI18n } from 'vue-i18n'
 
 import FtCard from '../ft-card/ft-card.vue'
 import store from '../../store/index'
+import { clampOverlayScrollTop } from '../../helpers/overlayScrollbars'
 
 const emit = defineEmits(['pause-player'])
 const { t } = useI18n()
@@ -97,6 +99,23 @@ const items = computed(() => store.getters.getWatchQueue)
 const backendPreference = computed(() => store.getters.getBackendPreference)
 const invidiousUrl = computed(() => store.getters.getCurrentInvidiousInstanceUrl)
 const draggedQueueItemId = ref(null)
+const queueItems = useTemplateRef('queueItems')
+let queueObserver = null
+
+onMounted(() => {
+  const container = queueItems.value?.$el ?? queueItems.value
+  queueObserver = new MutationObserver(() => {
+    requestAnimationFrame(() => {
+      clampOverlayScrollTop(
+        container,
+        container.querySelector(':scope > .queueItem:last-of-type')
+      )
+    })
+  })
+  queueObserver.observe(container, { childList: true })
+})
+
+onBeforeUnmount(() => queueObserver?.disconnect())
 
 function thumbnailUrl(videoId) {
   const baseUrl = backendPreference.value === 'invidious' ? invidiousUrl.value : 'https://i.ytimg.com'

--- a/src/renderer/components/WatchVideoQueue/WatchVideoQueue.vue
+++ b/src/renderer/components/WatchVideoQueue/WatchVideoQueue.vue
@@ -101,11 +101,13 @@ const invidiousUrl = computed(() => store.getters.getCurrentInvidiousInstanceUrl
 const draggedQueueItemId = ref(null)
 const queueItems = useTemplateRef('queueItems')
 let queueObserver = null
+let queueClampFrame = null
 
 onMounted(() => {
   const container = queueItems.value?.$el ?? queueItems.value
   queueObserver = new MutationObserver(() => {
-    requestAnimationFrame(() => {
+    queueClampFrame ??= requestAnimationFrame(() => {
+      queueClampFrame = null
       clampOverlayScrollTop(
         container,
         container.querySelector(':scope > .queueItem:last-of-type')
@@ -115,7 +117,13 @@ onMounted(() => {
   queueObserver.observe(container, { childList: true })
 })
 
-onBeforeUnmount(() => queueObserver?.disconnect())
+onBeforeUnmount(() => {
+  queueObserver?.disconnect()
+  if (queueClampFrame !== null) {
+    cancelAnimationFrame(queueClampFrame)
+    queueClampFrame = null
+  }
+})
 
 function thumbnailUrl(videoId) {
   const baseUrl = backendPreference.value === 'invidious' ? invidiousUrl.value : 'https://i.ytimg.com'

--- a/src/renderer/components/WatchVideoTranscript/WatchVideoTranscript.vue
+++ b/src/renderer/components/WatchVideoTranscript/WatchVideoTranscript.vue
@@ -170,6 +170,7 @@ import FtSelect from '../FtSelect/FtSelect.vue'
 import { getTranscriptPreScrollTop } from './transcriptScroll.js'
 import { filterTranscriptSegments } from './transcriptSearch.js'
 
+import { restoreOverlayScrollTop } from '../../helpers/overlayScrollbars'
 import {
   copyToClipboard,
   formatDurationAsTimestamp,
@@ -297,6 +298,12 @@ watch(() => props.fullscreenOverlay, () => {
   searchOpen.value = false
   searchQuery.value = ''
   languageMenuOpen.value = false
+})
+
+watch(normalizedSearchQuery, () => {
+  if (segmentList.value != null) {
+    restoreOverlayScrollTop(segmentList.value, 0)
+  }
 })
 
 watch(activeSegmentIndex, async (index) => {

--- a/src/renderer/helpers/overlayScrollbars.js
+++ b/src/renderer/helpers/overlayScrollbars.js
@@ -283,13 +283,25 @@ export function clampOverlayScrollTop(element, contentElement = null) {
   instance?.update(true)
   const contentEnd = contentElement === null
     ? element.scrollHeight
-    : contentElement.offsetTop + contentElement.offsetHeight +
+    : offsetTopFromDocument(contentElement) - offsetTopFromDocument(element) +
+      contentElement.offsetHeight +
       Number.parseFloat(getComputedStyle(element).paddingBottom)
   const maximumScrollTop = Math.max(0, contentEnd - element.clientHeight)
   if (element.scrollTop > maximumScrollTop) {
     element.scrollTop = maximumScrollTop
     instance?.update(true)
   }
+}
+
+/** @param {HTMLElement} element */
+function offsetTopFromDocument(element) {
+  let offsetTop = 0
+  let currentElement = element
+  while (currentElement != null) {
+    offsetTop += currentElement.offsetTop
+    currentElement = currentElement.offsetParent
+  }
+  return offsetTop
 }
 
 /**

--- a/src/renderer/views/Watch/Watch.js
+++ b/src/renderer/views/Watch/Watch.js
@@ -24,6 +24,7 @@ import FtLoader from '../../components/FtLoader/FtLoader.vue'
 import { calculateColorLuminance } from '../../helpers/colors'
 import { applyAnimationSpeed } from '../../helpers/animationSpeed'
 import { isReducedMotionEnabled } from '../../helpers/reducedMotion'
+import { restoreOverlayScrollTop } from '../../helpers/overlayScrollbars'
 import { hasReachedWatchedThreshold, isHistoryEntryWatched } from '../../helpers/history'
 import { isVideoHiddenByPreferences } from '../../helpers/subscriptions'
 import { parseLocalVideoGames } from '../../helpers/video-games'
@@ -1097,6 +1098,7 @@ export default defineComponent({
     },
     toggleSponsorBlockInfo() {
       if (this.customShortsPlayerActive && !this.showSidebarSponsorBlock) {
+        this.resetShortsAuxPanelScroll()
         this.shortsMetadataOpen = false
         if (this.showTranscript) {
           this.closeTranscript()
@@ -1107,6 +1109,7 @@ export default defineComponent({
     },
     toggleTranscript() {
       if (this.customShortsPlayerActive && !this.showTranscript) {
+        this.resetShortsAuxPanelScroll()
         this.shortsMetadataOpen = false
         if (this.showSidebarSponsorBlock) {
           this.closeSidebarSponsorBlock()
@@ -1135,6 +1138,9 @@ export default defineComponent({
     },
     toggleShortsMetadata() {
       const shouldOpen = !this.shortsMetadataOpen
+      if (shouldOpen) {
+        this.resetShortsAuxPanelScroll()
+      }
       this.shortsMetadataOpen = shouldOpen
 
       if (shouldOpen) {
@@ -1145,6 +1151,15 @@ export default defineComponent({
           this.closeSidebarSponsorBlock()
         }
         this.closeShortsComments()
+      }
+    },
+    resetShortsAuxPanelScroll() {
+      const target = this.$refs.shortsAuxPanelTarget
+      if (target != null) {
+        restoreOverlayScrollTop(target, 0)
+        this.$nextTick(() => {
+          requestAnimationFrame(() => restoreOverlayScrollTop(target, 0))
+        })
       }
     },
     handleSidebarPanelBeforeLeave() {

--- a/src/renderer/views/Watch/Watch.scss
+++ b/src/renderer/views/Watch/Watch.scss
@@ -797,6 +797,7 @@
       flex: 1 1 auto;
       min-block-size: 0;
       overflow: hidden;
+      overflow-anchor: none;
       overscroll-behavior: contain;
     }
 

--- a/src/renderer/views/Watch/Watch.vue
+++ b/src/renderer/views/Watch/Watch.vue
@@ -542,6 +542,7 @@
           </button>
         </div>
         <div
+          ref="shortsAuxPanelTarget"
           v-overlay-scrollbars
           class="shortsAuxPanelTarget"
         >


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Make sure to follow the contributing guidelines. -->
<!-- Important note, we may remove your pull request if you do not use this provided PR template correctly. -->
<!-- Agent instructions: Preserve every heading, comment, and marker in this template. Never remove or rewrite the release-note-category:start/end, release-note:start/end, or release-note-image:start/end marker pairs. Never remove or rewrite the Release note images section; leave its contents for a human. -->

## Pull Request Type
<!-- Please select what type of pull request this is: [x] -->
- [x] Bugfix
- [ ] Feature Implementation
- [ ] Documentation
- [ ] Other

## Related issue
<!-- Please link the issue your pull request is referring to. -->
<!-- If this pull request fully resolves the relevant issue, put "closes" before the issue number. -->
<!-- Example: "closes #123456". -->

## Description
<!-- Please write a clear and concise description of what the pull request does. -->

Prevents OverlayScrollbars-managed views from retaining obsolete vertical offsets after their content or viewport changes.

Transcript searches and search-history filtering now start at the first result. The Shorts auxiliary panel resets when switching content, while watch queues and fullscreen playlists clamp their positions when entries are removed. The shared clamp calculation now measures content relative to the scrolling element, which also keeps resized settings panes within their real content range.

Regression coverage exercises transcript filtering, search-history filtering, repeated settings-window resizing, Shorts panel switching, queue shrinkage, and fullscreen-playlist shrinkage.

## Release note category
<!-- Select exactly one category. Every pull request must select one. -->
<!-- release-note-category:start -->
- [ ] Not noteworthy
- [ ] Highlights
- [ ] More improvements
- [x] Fixed bugs
<!-- release-note-category:end -->

## Release note
<!-- Required unless "Not noteworthy" is selected. -->
<!-- Write one concise, user-facing entry without a leading bullet. -->
<!-- release-note:start -->
Dynamic lists and panels no longer retain outdated scroll positions after searches, content changes, or resizing.
<!-- release-note:end -->

## Release note images
<!-- Human-only: Agents must preserve this entire section and leave it empty. -->
<!-- Optional. Paste one or more Markdown images or HTML image tags here. -->
<!-- The release notes will use an HTML image tag and limit images taller than 300 pixels. -->
<!-- release-note-image:start -->

<!-- release-note-image:end -->

## Testing
<!-- How can reviewers verify that the PR produces correct results? -->
<!-- Please provide instructions so that others can ensure that your pull request would produce correct results. For examples see, https://github.com/FreeTubeApp/FreeTube/pull/5743, https://github.com/FreeTubeApp/FreeTube/pull/7349, https://github.com/FreeTubeApp/FreeTube/pull/5125, https://github.com/FreeTubeApp/FreeTube/pull/7338 -->
<!-- Agent instructions: Only write human-facing steps that explain how to verify the change while running this branch in dev mode. Include expected results and, when applicable, helpful console snippets for interactive verification. Do not include automated checks, commands, results, pass counts, or CI status. -->

1. Open a long transcript, scroll down, and filter it to a small set of matches. Confirm the first match is visible.
2. Open a long search-history suggestion list, scroll down, and type enough text to leave one result. Confirm that result is visible at the top.
3. Resize the Settings window smaller, scroll its content and menu, then enlarge it. Repeat once and confirm neither pane remains beyond its available content.
4. On a Short, scroll down in the metadata panel and switch to the transcript or SponsorBlock panel. Confirm the new panel starts at the top.
5. Scroll down a long watch queue or fullscreen playlist, remove enough entries that it no longer fills the viewport, and confirm no blank scrolled area remains.

## Additional context
<!-- Add any other context about the pull request here. -->

The fix uses the existing OverlayScrollbars restoration helpers and disables native scroll anchoring only on the dynamic containers that manage their own positions.
