### PR TITLE
fix(settings): improve modal styling and interactions

### DIFF
--- a/e2e/tests/offline/settings.spec.mjs
+++ b/e2e/tests/offline/settings.spec.mjs
@@ -1258,6 +1258,19 @@ test.describe('settings', () => {
   })
 })
 
+test.describe('dark theme settings', () => {
+  test.use({ seed: { settings: { baseTheme: 'dark' } } })
+
+  test('shows the search field against the settings header', async ({ page }) => {
+    await goTo(page, 'settings')
+
+    await expect(page.locator('.settingsWindowHeader'))
+      .toHaveCSS('background-color', 'rgb(38, 38, 38)')
+    await expect(page.locator('.settingsSearch'))
+      .toHaveCSS('background-color', 'rgb(48, 48, 48)')
+  })
+})
+
 test.describe('playback engine migration', () => {
   test.use({ seed: { settings: { videoPlaybackEngine: 'built-in' } } })
 

--- a/e2e/tests/offline/settings.spec.mjs
+++ b/e2e/tests/offline/settings.spec.mjs
@@ -474,6 +474,7 @@ test.describe('settings', () => {
     await page.getByRole('searchbox', { name: 'Search settings' }).fill('')
     await expect(page.locator('.settingsMenu')).toBeVisible()
     await page.locator('.settingsMenu [data-section="channel"]').click()
+    await expect(page.locator('.settingsContent')).toHaveClass(/settingsCompactSlideForward/)
     await page.getByRole('button', { name: /Manage Saved Channels/ }).click()
 
     const channelList = page.locator('.channelListContainer')
@@ -486,6 +487,10 @@ test.describe('settings', () => {
     })
     await expect.poll(() => channelList.evaluate(element => element.scrollTop)).toBeGreaterThan(0)
 
+    await page.locator('.settingsBreadcrumbRoot .settingsWindowIcon').click()
+    await expect(page.locator('.settingsMenu')).toBeVisible()
+    await expect(page.locator('.settingsMenu')).toHaveClass(/settingsCompactSlideBackward/)
+
     await page.getByRole('button', { name: 'Show Keyboard Shortcuts' }).click()
     const shortcuts = page.locator('.shortcutColumns')
     expect(await shortcuts.evaluate(element => element.scrollHeight > element.clientHeight)).toBe(true)
@@ -497,6 +502,51 @@ test.describe('settings', () => {
     await page.locator('.settingsBreadcrumbRoot .settingsWindowIcon').click()
     await expect(page.locator('.settingsMenu')).toBeVisible()
     await expect(page.locator('.settingsContent')).toBeHidden()
+  })
+
+  test('animates category changes vertically in two-column layout', async ({ page }) => {
+    await goTo(page, 'settings')
+
+    await page.locator('.settingsMenu [data-section="player"]').click()
+    await expect(page.locator('.settingsContent')).toHaveClass(/settingsSectionSlideForward/)
+    await page.locator('.settingsMenu [data-section="theme"]').click()
+    await expect(page.locator('.settingsContent')).toHaveClass(/settingsSectionSlideBackward/)
+  })
+
+  test('keeps quick playback speed actions sticky and reflects the default state', async ({ page }) => {
+    await goTo(page, 'settings')
+    await page.locator('.settingsMenu [data-section="player"]').click()
+    await page.getByRole('button', { name: 'Customize Quick Playback Speed Bar' }).click()
+
+    const scroller = page.locator('.settingsSubpageScroll')
+    const toolbar = page.locator('.quickPlaybackSpeedToolbar')
+    const list = page.locator('.quickPlaybackSpeedList')
+    const reset = page.getByRole('button', { name: 'Reset to Defaults' })
+    await expect(reset).toBeDisabled()
+
+    const [scrollerBounds, listBounds] = await Promise.all([
+      scroller.boundingBox(),
+      list.boundingBox()
+    ])
+    expect(listBounds.width).toBeLessThanOrEqual(800)
+    expect(Math.abs(
+      listBounds.x + listBounds.width / 2 - scrollerBounds.x - scrollerBounds.width / 2
+    )).toBeLessThanOrEqual(1)
+
+    await page.getByRole('button', { name: 'Add Playback Speed' }).click()
+    await expect(reset).toBeEnabled()
+    await reset.click()
+    await expect(reset).toBeDisabled()
+
+    await scroller.evaluate(element => { element.scrollTop = element.scrollHeight })
+    await expect.poll(async () => {
+      const [currentScrollerBounds, toolbarBounds] = await Promise.all([
+        scroller.boundingBox(),
+        toolbar.boundingBox()
+      ])
+      return Math.abs(toolbarBounds.y - currentScrollerBounds.y)
+    }).toBeLessThanOrEqual(1)
+    await expect(toolbar).toBeVisible()
   })
 
   test('aligns caption color controls with neighboring selects', async ({ page }) => {
@@ -558,10 +608,10 @@ test.describe('settings', () => {
     await goTo(page, 'settings')
     await page.locator('.settingsMenu [data-section="download"]').click()
 
-    await expect(page.locator('.settingsContent [role="tooltip"]:visible')).toHaveCount(0)
+    await expect(page.locator('[role="tooltip"]:visible')).toHaveCount(0)
   })
 
-  test('keeps help tooltips inside the settings scroller', async ({ page }) => {
+  test('allows help tooltips outside the settings window', async ({ page }) => {
     await page.evaluate(() => {
       localStorage.setItem('opentubex-settings-window-bounds', JSON.stringify({
         x: 40,
@@ -576,14 +626,21 @@ test.describe('settings', () => {
     await content.evaluate(element => { element.scrollTop = element.scrollHeight })
     const tooltipButton = content.locator('.selectTooltip .button').last()
     await tooltipButton.hover()
-    const tooltip = tooltipButton.locator('..').getByRole('tooltip')
+    const tooltip = page.locator('body > [role="tooltip"]:visible')
     await expect(tooltip).toBeVisible()
 
-    const contentBounds = await content.boundingBox()
-    await expect.poll(async () => {
-      const tooltipBounds = await tooltip.boundingBox()
-      return tooltipBounds.y + tooltipBounds.height
-    }).toBeLessThanOrEqual(contentBounds.y + contentBounds.height - 7)
+    const [contentBounds, tooltipBounds, viewport, fontFamily] = await Promise.all([
+      content.boundingBox(),
+      tooltip.boundingBox(),
+      page.evaluate(() => ({ width: innerWidth, height: innerHeight })),
+      tooltip.evaluate(element => getComputedStyle(element).fontFamily)
+    ])
+    expect(tooltipBounds.y + tooltipBounds.height).toBeGreaterThan(contentBounds.y + contentBounds.height)
+    expect(tooltipBounds.x).toBeGreaterThanOrEqual(7)
+    expect(tooltipBounds.y).toBeGreaterThanOrEqual(7)
+    expect(tooltipBounds.x + tooltipBounds.width).toBeLessThanOrEqual(viewport.width - 7)
+    expect(tooltipBounds.y + tooltipBounds.height).toBeLessThanOrEqual(viewport.height - 7)
+    expect(fontFamily).toContain('Roboto')
   })
 
   test('select dropdowns use overlay scrollbars', async ({ page }) => {
@@ -1768,8 +1825,8 @@ test.describe('synced setting indicators', () => {
     expect(Math.abs(syncBox.y - resetBox.y)).toBeLessThanOrEqual(1)
     expect(resetBox.x - syncBox.x - syncBox.width).toBeGreaterThanOrEqual(6)
 
-    const tooltipText = select.locator('.selectTooltip .text')
     await select.locator('.selectTooltip button').focus()
+    const tooltipText = page.locator('body > [role="tooltip"]:visible')
     await expect(tooltipText).toBeVisible()
 
     const [tooltipTextBox, sectionBox] = await Promise.all([
@@ -1817,8 +1874,8 @@ test.describe('synced setting indicators', () => {
     const startupSelect = page.locator('.select').filter({ hasText: 'On Startup' })
     await startupSelect.locator('select').selectOption('restoreTabLoadState')
 
-    const tooltipText = startupSelect.locator('.selectTooltip .text')
     await startupSelect.locator('.selectTooltip button').focus()
+    const tooltipText = page.locator('body > [role="tooltip"]:visible')
     await expect(tooltipText).toBeVisible()
 
     const thumbnailIndicators = page.locator('.select')

--- a/e2e/tests/offline/settings.spec.mjs
+++ b/e2e/tests/offline/settings.spec.mjs
@@ -643,6 +643,40 @@ test.describe('settings', () => {
     expect(fontFamily).toContain('Roboto')
   })
 
+  test('keeps an open help tooltip aligned and visible in fullscreen', async ({ page }) => {
+    await goTo(page, 'settings')
+
+    const settingsWindow = page.locator('.settingsWindow')
+    const tooltipButton = page.locator('.settingsContent .selectTooltip .button').first()
+    await tooltipButton.focus()
+
+    const bodyTooltip = page.locator('body > [role="tooltip"]:visible')
+    await expect(bodyTooltip).toBeVisible()
+    const initialButtonBounds = await tooltipButton.boundingBox()
+    const initialTooltipBounds = await bodyTooltip.boundingBox()
+
+    await settingsWindow.evaluate(element => {
+      element.style.left = `${element.getBoundingClientRect().left + 40}px`
+    })
+    await expect.poll(async () => {
+      const [buttonBounds, tooltipBounds] = await Promise.all([
+        tooltipButton.boundingBox(),
+        bodyTooltip.boundingBox()
+      ])
+      const buttonMovement = buttonBounds.x - initialButtonBounds.x
+      const tooltipMovement = tooltipBounds.x - initialTooltipBounds.x
+      return buttonMovement > 30 && Math.abs(tooltipMovement - buttonMovement) <= 1
+    }).toBe(true)
+
+    await settingsWindow.evaluate(element => element.requestFullscreen())
+    await expect.poll(() => settingsWindow.evaluate(element => document.fullscreenElement === element)).toBe(true)
+    await expect(settingsWindow.locator(':scope > [role="tooltip"]:visible')).toBeVisible()
+
+    await page.evaluate(() => document.exitFullscreen())
+    await expect.poll(() => page.evaluate(() => document.fullscreenElement)).toBeNull()
+    await expect(bodyTooltip).toBeVisible()
+  })
+
   test('select dropdowns use overlay scrollbars', async ({ page }) => {
     await goTo(page, 'settings')
 

--- a/e2e/tests/offline/video-actions.spec.mjs
+++ b/e2e/tests/offline/video-actions.spec.mjs
@@ -408,17 +408,17 @@ test.describe('list video actions', () => {
     ])
 
     const subtitleLanguages = page.locator('.subtitleLanguages')
-    const tooltip = subtitleLanguages.locator('[role="tooltip"]')
     await expect(subtitleLanguages.locator('input')).toBeDisabled()
     await subtitleLanguages.locator('.selectTooltip button').hover()
+    const tooltip = page.locator('body > [role="tooltip"]:visible')
     await expect(tooltip).toBeVisible()
 
     const opacity = await subtitleLanguages.evaluate((field) => ({
       label: getComputedStyle(field.querySelector('.selectLabel')).opacity,
-      labelText: getComputedStyle(field.querySelector('.selectLabelText')).opacity,
-      tooltip: getComputedStyle(field.querySelector('[role="tooltip"]')).opacity
+      labelText: getComputedStyle(field.querySelector('.selectLabelText')).opacity
     }))
-    expect(opacity).toEqual({ label: '1', labelText: '0.4', tooltip: '1' })
+    expect(opacity).toEqual({ label: '1', labelText: '0.4' })
+    await expect(tooltip).toHaveCSS('opacity', '1')
   })
 
   test('the options dropdown shows readable single-column actions with icons', async ({ page }) => {

--- a/src/constants.js
+++ b/src/constants.js
@@ -571,6 +571,17 @@ const PlaylistVideoAddResult = {
 // Percentage of a video's duration that must be played before it is considered watched
 const DEFAULT_WATCHED_PERCENTAGE_THRESHOLD = 90
 const WATCHED_MAX_REMAINING_SECONDS = 120
+const DEFAULT_QUICK_PLAYBACK_SPEED_BAR_OPTIONS = Object.freeze([
+  { speed: 0.5, name: '' },
+  { speed: 1, name: '' },
+  { speed: 1.25, name: '' },
+  { speed: 1.5, name: '' },
+  { speed: 1.75, name: '' },
+  { speed: 2, name: '' },
+  { speed: 2.25, name: '' },
+  { speed: 2.5, name: '' },
+  { speed: 3, name: '' },
+])
 
 const LIGHT_BASE_THEMES = [
   'light',
@@ -620,6 +631,7 @@ export {
   SEARCH_CHAR_LIMIT,
   SEARCH_RESULTS_DISPLAY_LIMIT,
   MIXED_SEARCH_HISTORY_ENTRIES_DISPLAY_LIMIT,
+  DEFAULT_QUICK_PLAYBACK_SPEED_BAR_OPTIONS,
   DEFAULT_WATCHED_PERCENTAGE_THRESHOLD,
   WATCHED_MAX_REMAINING_SECONDS,
   LIGHT_BASE_THEMES,

--- a/src/renderer/components/FtSettingsSubpage/FtSettingsSubpage.vue
+++ b/src/renderer/components/FtSettingsSubpage/FtSettingsSubpage.vue
@@ -3,7 +3,10 @@
     v-if="open"
     :to="`#${settingsWindow.targetId}`"
   >
-    <div class="settingsSubpageContent">
+    <div
+      class="settingsSubpageContent"
+      :class="{ growWithContent }"
+    >
       <slot />
     </div>
   </Teleport>
@@ -22,6 +25,10 @@ const props = defineProps({
   title: {
     type: String,
     required: true
+  },
+  growWithContent: {
+    type: Boolean,
+    default: false
   }
 })
 
@@ -50,5 +57,9 @@ onBeforeUnmount(() => settingsWindow.close(close))
   box-sizing: border-box;
   display: flex;
   flex-direction: column;
+}
+
+.settingsSubpageContent.growWithContent {
+  block-size: auto;
 }
 </style>

--- a/src/renderer/components/FtTooltip/FtTooltip.css
+++ b/src/renderer/components/FtTooltip/FtTooltip.css
@@ -10,77 +10,22 @@
 .text {
   background-color: color-mix(in srgb, var(--primary-text-color) 80%, var(--card-bg-color));
   border-radius: calc(20px * var(--ui-roundness));
+  box-sizing: border-box;
   color: var(--card-bg-color);
+  display: block;
+  font-family: Roboto, sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol', 'Noto Color Emoji';
   font-size: 1rem;
+  inline-size: max-content;
   line-height: 120%;
   margin: 0;
-  max-inline-size: max-content;
-  min-inline-size: 15em;
+  max-inline-size: min(24em, calc(100vw - 16px));
+  min-inline-size: min(15em, calc(100vw - 16px));
   padding-block: 10px;
   padding-inline: 8px;
   pointer-events: none;
-  position: absolute;
+  position: fixed;
   text-align: center;
-  transition-duration: 275ms;
-  transition-property: transform;
-  display: none;
-  z-index: 2;
-}
-
-.text.bottom {
-  margin-block-start: 1em;
-  inset-block-start: 100%;
-  inset-inline-start: 50%;
-  transform: translate(calc(-50% * var(--horizontal-directionality-coefficient)), -1em);
-}
-
-.text.bottom-left {
-  margin-block-start: 1em;
-  inset-block-start: 100%;
-  inset-inline-start: -100px;
-  transform: translate(calc(-50% * var(--horizontal-directionality-coefficient)), -1em);
-}
-
-.text.left {
-  margin-inline-end: 1em;
-  inset-inline-end: 100%;
-  inset-block-start: 50%;
-  transform: translate(calc(1em * var(--horizontal-directionality-coefficient)), -50%);
-}
-
-.text.right {
-  inset-inline-start: 100%;
-  margin-inline-start: 1em;
-  inset-block-start: 50%;
-  transform: translate(calc(-1em * var(--horizontal-directionality-coefficient)), -50%);
-}
-
-.text.top {
-  inset-block-end: 100%;
-  inset-inline-start: 50%;
-  margin-block-end: 1em;
-  transform: translate(calc(-50% * var(--horizontal-directionality-coefficient)), 1em);
-}
-
-.button:focus + .text,
-.button:hover + .text {
-  display: block;
-}
-
-.button:focus + .text.bottom,
-.button:hover + .text.bottom,
-.button:focus + .text.bottom-left,
-.button:hover + .text.bottom-left,
-.button:focus + .text.top,
-.button:hover + .text.top {
-  transform: translate(calc(-50% * var(--horizontal-directionality-coefficient) + var(--ft-tooltip-shift-x, 0px)), var(--ft-tooltip-shift-y, 0));
-}
-
-.button:focus + .text.left,
-.button:hover + .text.left,
-.button:focus + .text.right,
-.button:hover + .text.right {
-  transform: translate(var(--ft-tooltip-shift-x, 0), calc(-50% + var(--ft-tooltip-shift-y, 0)));
+  z-index: 13;
 }
 
 .text.allowNewlines {
@@ -92,9 +37,4 @@
 .tooltip {
   display: inline-block;
   position: relative;
-}
-
-.tooltip:hover,
-.tooltip:focus-within {
-  z-index: 10;
 }

--- a/src/renderer/components/FtTooltip/FtTooltip.vue
+++ b/src/renderer/components/FtTooltip/FtTooltip.vue
@@ -44,6 +44,7 @@ const EDGE_MARGIN = 8
 const TOOLTIP_GAP = 16
 let hovered = false
 let focused = false
+let positionAnimationFrame = null
 
 /**
  * @param {boolean} value
@@ -64,7 +65,29 @@ function setFocused(value) {
 function updateVisibility() {
   visible.value = hovered || focused
   if (visible.value) {
-    nextTick(positionTooltip)
+    nextTick(() => {
+      if (!visible.value) return
+      positionTooltip()
+      startTrackingPosition()
+    })
+  } else {
+    stopTrackingPosition()
+  }
+}
+
+function startTrackingPosition() {
+  if (!visible.value || positionAnimationFrame !== null) return
+  const trackPosition = () => {
+    positionTooltip()
+    positionAnimationFrame = requestAnimationFrame(trackPosition)
+  }
+  positionAnimationFrame = requestAnimationFrame(trackPosition)
+}
+
+function stopTrackingPosition() {
+  if (positionAnimationFrame !== null) {
+    cancelAnimationFrame(positionAnimationFrame)
+    positionAnimationFrame = null
   }
 }
 
@@ -114,14 +137,25 @@ function handleViewportChange() {
   if (visible.value) positionTooltip()
 }
 
+async function handleFullscreenChange() {
+  tooltipTarget.value = document.fullscreenElement ?? document.body
+  if (visible.value) {
+    await nextTick()
+    positionTooltip()
+  }
+}
+
 onMounted(() => {
   window.addEventListener('resize', handleViewportChange)
   window.addEventListener('scroll', handleViewportChange, true)
+  document.addEventListener('fullscreenchange', handleFullscreenChange)
 })
 
 onBeforeUnmount(() => {
+  stopTrackingPosition()
   window.removeEventListener('resize', handleViewportChange)
   window.removeEventListener('scroll', handleViewportChange, true)
+  document.removeEventListener('fullscreenchange', handleFullscreenChange)
 })
 
 const props = defineProps({

--- a/src/renderer/components/FtTooltip/FtTooltip.vue
+++ b/src/renderer/components/FtTooltip/FtTooltip.vue
@@ -1,126 +1,130 @@
 <template>
-  <div
-    class="tooltip"
-    @mouseenter="clampToViewport"
-    @focusin="clampToViewport"
-  >
+  <div class="tooltip">
     <button
+      ref="buttonRef"
       :aria-labelledby="id"
       class="button"
       type="button"
+      @mouseenter="setHovered(true)"
+      @mouseleave="setHovered(false)"
+      @focus="setFocused(true)"
+      @blur="setFocused(false)"
     >
       <FontAwesomeIcon :icon="['fas', 'question-circle']" />
     </button>
-    <p
-      :id="id"
-      ref="textRef"
-      class="text"
-      :class="{
-        [position]: true,
-        allowNewlines,
-      }"
-      role="tooltip"
-    >
-      {{ tooltip }}
-    </p>
+    <Teleport :to="tooltipTarget">
+      <p
+        v-show="visible"
+        :id="id"
+        ref="textRef"
+        class="text"
+        :class="{
+          [position]: true,
+          allowNewlines,
+        }"
+        role="tooltip"
+        :style="tooltipStyle"
+      >
+        {{ tooltip }}
+      </p>
+    </Teleport>
   </div>
 </template>
 
 <script setup>
 import { FontAwesomeIcon } from '@fortawesome/vue-fontawesome'
-import { useId, useTemplateRef } from 'vue'
+import { nextTick, onBeforeUnmount, onMounted, ref, shallowRef, useId, useTemplateRef } from 'vue'
 
+const buttonRef = useTemplateRef('buttonRef')
 const textRef = useTemplateRef('textRef')
-
-// Keep the tooltip inside whatever would otherwise cut it off. It
-// is positioned purely with CSS relative to its icon, so an icon near the start
-// of a clipping container (the settings page clips with `overflow-x: hidden`)
-// can leave part of the tooltip unreachable. We compute its shown extent and
-// offset it back into view via CSS variables.
-// Offset geometry is used because, unlike `getBoundingClientRect()`,
-// they are unaffected by the CSS transform (and its transition), so the shown
-// fade/slide animation is preserved.
+const tooltipTarget = shallowRef(document.fullscreenElement ?? document.body)
+const tooltipStyle = ref({})
+const visible = ref(false)
 const EDGE_MARGIN = 8
+const TOOLTIP_GAP = 16
+let hovered = false
+let focused = false
 
 /**
- * The bounds the tooltip has to stay within, intersecting the viewport with
- * every ancestor that clips either axis.
- *
- * @param {HTMLElement} el
- * @returns {{ left: number, right: number, top: number, bottom: number }}
+ * @param {boolean} value
  */
-function getClippingBounds(el) {
-  const bounds = {
-    left: 0,
-    right: window.innerWidth,
-    top: 0,
-    bottom: window.innerHeight
-  }
-  for (let node = el.parentElement; node != null; node = node.parentElement) {
-    const style = getComputedStyle(node)
-    if (style.overflowX !== 'visible' || style.overflowY !== 'visible') {
-      const rect = node.getBoundingClientRect()
-      if (style.overflowX !== 'visible') {
-        bounds.left = Math.max(bounds.left, rect.left)
-        bounds.right = Math.min(bounds.right, rect.right)
-      }
-      if (style.overflowY !== 'visible') {
-        bounds.top = Math.max(bounds.top, rect.top)
-        bounds.bottom = Math.min(bounds.bottom, rect.bottom)
-      }
-    }
-  }
-  return bounds
+function setHovered(value) {
+  hovered = value
+  updateVisibility()
 }
 
-function clampToViewport() {
-  const el = textRef.value
-  const offsetParent = el?.offsetParent
-  if (!el || !offsetParent) {
-    return
-  }
-
-  // Measure the unshifted position, so repeated hovers don't compound the shift.
-  el.style.setProperty('--ft-tooltip-shift-x', '0px')
-  el.style.setProperty('--ft-tooltip-shift-y', '0px')
-
-  const width = el.offsetWidth
-  const height = el.offsetHeight
-  const parentRect = offsetParent.getBoundingClientRect()
-  const dir = getComputedStyle(el).direction === 'rtl' ? -1 : 1
-
-  // The visible transform's static horizontal translate: centered variants shift
-  // by -50% (times the writing-direction coefficient), edge variants by 0.
-  const centered = el.classList.contains('bottom') ||
-    el.classList.contains('bottom-left') ||
-    el.classList.contains('top')
-  const staticTranslateX = centered ? -0.5 * width * dir : 0
-  const staticTranslateY = centered ? 0 : -0.5 * height
-
-  const left = parentRect.left + el.offsetLeft + staticTranslateX
-  const right = left + width
-  const top = parentRect.top + el.offsetTop + staticTranslateY
-  const bottom = top + height
-  const bounds = getClippingBounds(el)
-
-  let shiftX = 0
-  let shiftY = 0
-  if (left < bounds.left + EDGE_MARGIN) {
-    shiftX = Math.ceil(bounds.left + EDGE_MARGIN - left)
-  } else if (right > bounds.right - EDGE_MARGIN) {
-    shiftX = Math.floor(bounds.right - EDGE_MARGIN - right)
-  }
-  if (top < bounds.top + EDGE_MARGIN) {
-    shiftY = Math.ceil(bounds.top + EDGE_MARGIN - top)
-  } else if (bottom > bounds.bottom - EDGE_MARGIN) {
-    shiftY = Math.floor(bounds.bottom - EDGE_MARGIN - bottom)
-  }
-
-  el.style.setProperty('--ft-tooltip-shift-x', `${shiftX}px`)
-  el.style.setProperty('--ft-tooltip-shift-y', `${shiftY}px`)
+/**
+ * @param {boolean} value
+ */
+function setFocused(value) {
+  focused = value
+  updateVisibility()
 }
 
-defineProps({
+function updateVisibility() {
+  visible.value = hovered || focused
+  if (visible.value) {
+    nextTick(positionTooltip)
+  }
+}
+
+function positionTooltip() {
+  const button = buttonRef.value
+  const text = textRef.value
+  if (!visible.value || !button || !text) return
+
+  const buttonRect = button.getBoundingClientRect()
+  const width = text.offsetWidth
+  const height = text.offsetHeight
+  const isRtl = getComputedStyle(button).direction === 'rtl'
+  let left
+  let top
+
+  switch (props.position) {
+    case 'left':
+      left = isRtl ? buttonRect.right + TOOLTIP_GAP : buttonRect.left - width - TOOLTIP_GAP
+      top = buttonRect.top + (buttonRect.height - height) / 2
+      break
+    case 'right':
+      left = isRtl ? buttonRect.left - width - TOOLTIP_GAP : buttonRect.right + TOOLTIP_GAP
+      top = buttonRect.top + (buttonRect.height - height) / 2
+      break
+    case 'top':
+      left = buttonRect.left + (buttonRect.width - width) / 2
+      top = buttonRect.top - height - TOOLTIP_GAP
+      break
+    case 'bottom-left':
+      left = isRtl ? buttonRect.left : buttonRect.right - width
+      top = buttonRect.bottom + TOOLTIP_GAP
+      break
+    default:
+      left = buttonRect.left + (buttonRect.width - width) / 2
+      top = buttonRect.bottom + TOOLTIP_GAP
+  }
+
+  left = Math.max(EDGE_MARGIN, Math.min(left, window.innerWidth - width - EDGE_MARGIN))
+  top = Math.max(EDGE_MARGIN, Math.min(top, window.innerHeight - height - EDGE_MARGIN))
+  tooltipStyle.value = {
+    left: `${Math.round(left)}px`,
+    top: `${Math.round(top)}px`,
+  }
+}
+
+function handleViewportChange() {
+  if (visible.value) positionTooltip()
+}
+
+onMounted(() => {
+  window.addEventListener('resize', handleViewportChange)
+  window.addEventListener('scroll', handleViewportChange, true)
+})
+
+onBeforeUnmount(() => {
+  window.removeEventListener('resize', handleViewportChange)
+  window.removeEventListener('scroll', handleViewportChange, true)
+})
+
+const props = defineProps({
   position: {
     type: String,
     default: 'bottom',

--- a/src/renderer/components/PlayerSettings/PlayerSettings.css
+++ b/src/renderer/components/PlayerSettings/PlayerSettings.css
@@ -58,11 +58,30 @@
   align-items: center;
 }
 
+.quickPlaybackSpeedToolbarActions,
+.quickPlaybackSpeedList {
+  inline-size: min(800px, 100%);
+  box-sizing: border-box;
+  margin-inline: auto;
+}
+
+.quickPlaybackSpeedToolbar {
+  position: sticky;
+  z-index: 2;
+  inset-block-start: -20px;
+  flex: 0 0 auto;
+  margin-block-start: -20px;
+  margin-inline: -20px;
+  padding-block: calc(20px + 0.5rem) 0.5rem;
+  padding-inline: 20px;
+  background-color: var(--card-bg-color);
+}
+
 .quickPlaybackSpeedList {
   display: flex;
   flex-direction: column;
   gap: 0.75rem;
-  margin-block: 1rem;
+  margin-block: 0.5rem 1rem;
 }
 
 .quickPlaybackSpeedEntry {

--- a/src/renderer/components/PlayerSettings/PlayerSettings.vue
+++ b/src/renderer/components/PlayerSettings/PlayerSettings.vue
@@ -528,6 +528,7 @@ import FtTooltip from '../FtTooltip/FtTooltip.vue'
 import FtSettingsSubpage from '../FtSettingsSubpage/FtSettingsSubpage.vue'
 
 import store from '../../store/index'
+import { DEFAULT_QUICK_PLAYBACK_SPEED_BAR_OPTIONS } from '../../../constants'
 import { initializePlatformInfo, isLinuxWayland } from '../../helpers/platform'
 import {
   DEFAULT_SEGMENT_PREFETCH_LIMIT,
@@ -535,18 +536,6 @@ import {
 } from '../../helpers/player/segmentPrefetch'
 
 const { t } = useI18n()
-
-const DEFAULT_QUICK_PLAYBACK_SPEED_BAR_OPTIONS = Object.freeze([
-  { speed: 0.5, name: '' },
-  { speed: 1, name: '' },
-  { speed: 1.25, name: '' },
-  { speed: 1.5, name: '' },
-  { speed: 1.75, name: '' },
-  { speed: 2, name: '' },
-  { speed: 2.25, name: '' },
-  { speed: 2.5, name: '' },
-  { speed: 3, name: '' },
-])
 
 const QUICK_PLAYBACK_SPEED_DRAG_THRESHOLD_PX = 5
 const QUICK_PLAYBACK_SPEED_SETTLE_DURATION_MS = 180

--- a/src/renderer/components/PlayerSettings/PlayerSettings.vue
+++ b/src/renderer/components/PlayerSettings/PlayerSettings.vue
@@ -402,8 +402,25 @@
     <FtSettingsSubpage
       :open="showQuickPlaybackSpeedBarManager"
       :title="t('Settings.Player Settings.Quick Playback Speed Bar Manager')"
+      grow-with-content
       @close="showQuickPlaybackSpeedBarManager = false"
     >
+      <div class="quickPlaybackSpeedToolbar">
+        <FtFlexBox class="quickPlaybackSpeedToolbarActions">
+          <FtButton
+            :label="t('Settings.Player Settings.Add Playback Speed')"
+            :icon="['fas', 'plus']"
+            :disabled="quickPlaybackSpeedBarEntries.length >= QUICK_PLAYBACK_SPEED_LIMIT"
+            @click="addQuickPlaybackSpeed"
+          />
+          <FtButton
+            :label="t('Settings.Player Settings.Reset Quick Playback Speed Bar')"
+            :icon="['fas', 'undo']"
+            :disabled="!hasModifiedQuickPlaybackSpeedBarOptions"
+            @click="resetQuickPlaybackSpeedBarOptions"
+          />
+        </FtFlexBox>
+      </div>
       <div class="quickPlaybackSpeedList">
         <div
           v-for="(option, index) in quickPlaybackSpeedBarEntries"
@@ -442,7 +459,7 @@
                 :aria-label="t('Settings.Player Settings.Edit Playback Speed Name')"
                 @click="editingQuickPlaybackSpeedNameId = option.id"
               >
-                <FontAwesomeIcon :icon="['fas', 'pen']" />
+                <FontAwesomeIcon :icon="['fas', 'edit']" />
               </button>
             </div>
             <div
@@ -489,19 +506,6 @@
           </button>
         </div>
       </div>
-      <FtFlexBox>
-        <FtButton
-          :label="t('Settings.Player Settings.Add Playback Speed')"
-          :icon="['fas', 'plus']"
-          :disabled="quickPlaybackSpeedBarEntries.length >= QUICK_PLAYBACK_SPEED_LIMIT"
-          @click="addQuickPlaybackSpeed"
-        />
-        <FtButton
-          :label="t('Settings.Player Settings.Reset Quick Playback Speed Bar')"
-          :icon="['fas', 'undo']"
-          @click="resetQuickPlaybackSpeedBarOptions"
-        />
-      </FtFlexBox>
     </FtSettingsSubpage>
   </FtSettingsSection>
 </template>
@@ -1030,6 +1034,15 @@ const quickPlaybackSpeedBarOptions = computed(() => store.getters.getQuickPlayba
 /** @type {import('vue').ComputedRef<Array<{id: string, speed: number, name: string}>>} */
 const quickPlaybackSpeedBarEntries = computed(() => {
   return parseQuickPlaybackSpeedBarOptions(quickPlaybackSpeedBarOptions.value)
+})
+
+/** @type {import('vue').ComputedRef<boolean>} */
+const hasModifiedQuickPlaybackSpeedBarOptions = computed(() => {
+  return quickPlaybackSpeedBarEntries.value.length !== DEFAULT_QUICK_PLAYBACK_SPEED_BAR_OPTIONS.length ||
+    quickPlaybackSpeedBarEntries.value.some((option, index) => {
+      const defaultOption = DEFAULT_QUICK_PLAYBACK_SPEED_BAR_OPTIONS[index]
+      return option.speed !== defaultOption.speed || option.name.trim() !== defaultOption.name
+    })
 })
 
 /**

--- a/src/renderer/store/modules/settings.js
+++ b/src/renderer/store/modules/settings.js
@@ -2,6 +2,7 @@ import i18n, { loadLocale } from '../../i18n/index'
 import allLocales from '../../../../static/locales/activeLocales.json'
 import {
   applyKeyboardShortcutOverrides,
+  DEFAULT_QUICK_PLAYBACK_SPEED_BAR_OPTIONS,
   DEFAULT_WATCHED_PERCENTAGE_THRESHOLD,
   MAIN_PROFILE_ID,
   sanitizeKeyboardShortcutOverrides,
@@ -410,7 +411,7 @@ const state = {
   autoUpdateChannelPlaybackSpeeds: false,
   channelPlaybackSpeeds: '{}',
   useQuickPlaybackSpeedBar: false,
-  quickPlaybackSpeedBarOptions: '[{"speed":0.5,"name":""},{"speed":1,"name":""},{"speed":1.25,"name":""},{"speed":1.5,"name":""},{"speed":1.75,"name":""},{"speed":2,"name":""},{"speed":2.25,"name":""},{"speed":2.5,"name":""},{"speed":3,"name":""}]',
+  quickPlaybackSpeedBarOptions: JSON.stringify(DEFAULT_QUICK_PLAYBACK_SPEED_BAR_OPTIONS),
   rememberVideoQualityPerChannel: false,
   autoUpdateChannelVideoQualities: false,
   channelVideoQualities: '{}',

--- a/src/renderer/themes.css
+++ b/src/renderer/themes.css
@@ -22,6 +22,7 @@ body {
   --link-color: var(--accent-color);
   --link-visited-color: var(--accent-color-visited);
   --instance-menu-color: var(--search-bar-color);
+  --settings-search-bar-color: var(--search-bar-color);
   --red-500: #f44336;
   --top-bar-push-down-adjustment-default: -35px;
 
@@ -192,6 +193,7 @@ it can be safely elided. This looks quite pleasant on this theme. */
   --side-nav-hover-color: #212121;
   --side-nav-active-color: #303030;
   --search-bar-color: #262626;
+  --settings-search-bar-color: var(--card-bg-color);
   --logo-icon: url('../../_icons/iconWhiteSmall.svg');
   --logo-text: url('../../_icons/textWhiteSmall.svg');
 }

--- a/src/renderer/views/Settings/Settings.css
+++ b/src/renderer/views/Settings/Settings.css
@@ -401,6 +401,57 @@
   padding: 14px;
 }
 
+.settingsSectionSlideForward {
+  animation: settings-section-slide-forward 180ms ease-out;
+}
+
+.settingsSectionSlideBackward {
+  animation: settings-section-slide-backward 180ms ease-out;
+}
+
+.settingsCompactSlideForward {
+  animation: settings-compact-slide-forward 200ms ease-out;
+}
+
+.settingsCompactSlideBackward {
+  animation: settings-compact-slide-backward 200ms ease-out;
+}
+
+@keyframes settings-section-slide-forward {
+  from {
+    opacity: 0;
+    transform: translateY(18px);
+  }
+}
+
+@keyframes settings-section-slide-backward {
+  from {
+    opacity: 0;
+    transform: translateY(-18px);
+  }
+}
+
+@keyframes settings-compact-slide-forward {
+  from {
+    opacity: 0;
+    transform: translateX(calc(28px * var(--horizontal-directionality-coefficient)));
+  }
+}
+
+@keyframes settings-compact-slide-backward {
+  from {
+    opacity: 0;
+    transform: translateX(calc(-28px * var(--horizontal-directionality-coefficient)));
+  }
+}
+
+:global(:root[data-reduced-motion='reduce']) .settingsSectionSlideForward,
+:global(:root[data-reduced-motion='reduce']) .settingsSectionSlideBackward,
+:global(:root[data-reduced-motion='reduce']) .settingsCompactSlideForward,
+:global(:root[data-reduced-motion='reduce']) .settingsCompactSlideBackward {
+  animation: none;
+}
+
 :global(html.draggingSettingsWindow),
 :global(html.draggingSettingsWindow *) {
   cursor: move !important;

--- a/src/renderer/views/Settings/Settings.css
+++ b/src/renderer/views/Settings/Settings.css
@@ -158,7 +158,7 @@
   padding-inline: 12px;
   border-radius: calc(6px * var(--ui-roundness));
   color: var(--tertiary-text-color);
-  background: var(--search-bar-color);
+  background: var(--settings-search-bar-color);
   cursor: text;
 }
 

--- a/src/renderer/views/Settings/Settings.vue
+++ b/src/renderer/views/Settings/Settings.vue
@@ -187,7 +187,10 @@
             v-show="!subpageTitle && (isInDesktopView || (!activeSection && settingsSearchQuery === ''))"
             ref="menuRef"
             v-overlay-scrollbars
-            :class="{ mobileSettingsMenu: !isInDesktopView }"
+            :class="[
+              { mobileSettingsMenu: !isInDesktopView },
+              settingsMenuTransitionClass
+            ]"
             :settings-sections="filteredSettingsSectionComponents"
             :active-section="activeSection"
             :empty-message="t('Settings.No Settings Found')"
@@ -199,6 +202,7 @@
             ref="settingsContentRef"
             v-overlay-scrollbars
             class="settingsContent"
+            :class="settingsContentTransitionClass"
             tabindex="-1"
             @scroll.passive="clampSettingsContentScroll"
           >
@@ -338,6 +342,8 @@ const isInDesktopView = ref(true)
 const isMaximized = ref(false)
 const activeSection = ref(store.getters.getSettingsWindowSection)
 const settingsSearchQuery = ref('')
+const settingsContentTransitionClass = ref('')
+const settingsMenuTransitionClass = ref('')
 const settingsWindowRef = useTemplateRef('settingsWindowRef')
 const settingsPageRef = useTemplateRef('settingsPageRef')
 const settingsContentRef = useTemplateRef('settingsContentRef')
@@ -743,13 +749,40 @@ function getRememberedSection() {
 }
 
 function navigateToSection(sectionType) {
+  const previousSection = activeSection.value
   closeSubpage?.()
   subpageTitle.value = ''
   closeSubpage = null
   activeSection.value = sectionType
-  if (!isInDesktopView.value) {
+  if (isInDesktopView.value && previousSection !== null && previousSection !== sectionType) {
+    const previousIndex = settingsSectionComponents.value.findIndex(({ type }) => type === previousSection)
+    const nextIndex = settingsSectionComponents.value.findIndex(({ type }) => type === sectionType)
+    animateSettingsElement(
+      settingsContentRef,
+      settingsContentTransitionClass,
+      nextIndex >= previousIndex ? 'settingsSectionSlideForward' : 'settingsSectionSlideBackward'
+    )
+  } else if (!isInDesktopView.value) {
+    animateSettingsElement(
+      settingsContentRef,
+      settingsContentTransitionClass,
+      'settingsCompactSlideForward'
+    )
     nextTick(() => settingsContentRef.value?.focus({ preventScroll: true }))
   }
+}
+
+/**
+ * @param {Readonly<import('vue').ShallowRef<HTMLElement | {$el?: HTMLElement} | null>>} elementRef
+ * @param {import('vue').Ref<string>} classRef
+ * @param {string} className
+ */
+async function animateSettingsElement(elementRef, classRef, className) {
+  classRef.value = ''
+  await nextTick()
+  const element = elementRef.value?.$el ?? elementRef.value
+  element?.getBoundingClientRect()
+  classRef.value = className
 }
 
 async function openSearchResult(sectionType, label) {
@@ -859,6 +892,7 @@ function returnToSettingsMenu() {
   if (!isInDesktopView.value) {
     const previousSection = activeSection.value
     activeSection.value = null
+    animateSettingsElement(menuRef, settingsMenuTransitionClass, 'settingsCompactSlideBackward')
     nextTick(() => menuRef.value?.focusLink(previousSection))
   }
 }


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Make sure to follow the contributing guidelines. -->
<!-- Important note, we may remove your pull request if you do not use this provided PR template correctly. -->
<!-- Agent instructions: Preserve every heading, comment, and marker in this template. Never remove or rewrite the release-note-category:start/end, release-note:start/end, or release-note-image:start/end marker pairs. Never remove or rewrite the Release note images section; leave its contents for a human. -->

## Pull Request Type
<!-- Please select what type of pull request this is: [x] -->
- [x] Bugfix
- [ ] Feature Implementation
- [ ] Documentation
- [ ] Other

## Related issue
<!-- Please link the issue your pull request is referring to. -->
<!-- If this pull request fully resolves the relevant issue, put "closes" before the issue number. -->
<!-- Example: "closes #123456". -->

None.

## Description
<!-- Please write a clear and concise description of what the pull request does. -->

Polish several settings-modal interactions:

- Give the settings search field a dedicated theme color so it remains visible in the default dark theme.
- Center and cap the quick playback speed editor, keep its actions sticky for the full scroll range, disable reset at the defaults, and use a distinct rename icon.
- Portal help tooltips outside clipping containers, position them within the viewport, and preserve the application font.
- Animate category navigation vertically in two-column mode and horizontally in compact mode, while respecting reduced-motion preferences.

The search issue came from the dark-theme settings header and search field both resolving to `#262626`. Tooltips were constrained to the settings scroller as a workaround for clipping, which made long text cover nearby controls. The quick-speed toolbar initially lived after the list and had no state-aware reset behavior.

## Release note category
<!-- Select exactly one category. Every pull request must select one. -->
<!-- release-note-category:start -->
- [ ] Not noteworthy
- [ ] Highlights
- [ ] More improvements
- [x] Fixed bugs
<!-- release-note-category:end -->

## Release note
<!-- Required unless "Not noteworthy" is selected. -->
<!-- Write one concise, user-facing entry without a leading bullet. -->
<!-- release-note:start -->
Improved settings search contrast, tooltips, navigation animations, and quick playback speed customization.
<!-- release-note:end -->

## Release note images
<!-- Human-only: Agents must preserve this entire section and leave it empty. -->
<!-- Optional. Paste one or more Markdown images or HTML image tags here. -->
<!-- The release notes will use an HTML image tag and limit images taller than 300 pixels. -->
<!-- release-note-image:start -->

<!-- release-note-image:end -->

## Testing
<!-- How can reviewers verify that the PR produces correct results? -->
<!-- Please provide instructions so that others can ensure that your pull request would produce correct results. For examples see, https://github.com/FreeTubeApp/FreeTube/pull/5743, https://github.com/FreeTubeApp/FreeTube/pull/7349, https://github.com/FreeTubeApp/FreeTube/pull/5125, https://github.com/FreeTubeApp/FreeTube/pull/7338 -->
<!-- Agent instructions: Only write human-facing steps that explain how to verify the change while running this branch in dev mode. Include expected results and, when applicable, helpful console snippets for interactive verification. Do not include automated checks, commands, results, pass counts, or CI status. -->

1. Run the app in dev mode, select the default dark theme, and open Settings. Confirm the search field is visibly lighter than the header.
2. Open Player Settings and then Quick Playback Speed Bar. Confirm the editor is centered and capped, its actions remain visible while scrolling to the bottom, and Reset to Defaults is disabled until an option changes.
3. Confirm the rename icon differs from the header's changed-settings highlight icon.
4. Open a long help tooltip near a settings-window edge. Confirm it may extend outside the modal, stays inside the app viewport, and uses the normal application font.
5. Switch categories in a wide settings window and confirm only the right pane slides vertically.
6. Resize Settings below the compact-layout threshold, open a category, and navigate back. Confirm the views slide horizontally in the expected direction.
7. Enable reduced motion and confirm the category transitions no longer animate.

## Additional context
<!-- Add any other context about the pull request here. -->

Other themes retain their existing settings search color. Tooltip positioning supports all existing placements and follows viewport scrolling and resizing.