### PR TITLE
Fix playlist action button alignment

### DIFF
--- a/e2e/tests/network/channel.spec.mjs
+++ b/e2e/tests/network/channel.spec.mjs
@@ -9,7 +9,7 @@ const CHANNEL_URL = 'https://www.youtube.com/channel/UCSMOQeBJ2RAnuFungnQOxLg'
 const CHANNEL_ID = 'UCSMOQeBJ2RAnuFungnQOxLg'
 
 test.describe('channel page', () => {
-  test.use({ seed: { settings: { uiRoundness: 200 } } })
+  test.use({ seed: { settings: { uiRoundness: 200, externalPlayer: 'mpv' } } })
 
   test('shows channel info and videos', async ({ page }) => {
     await page.locator(sel.searchInput).fill(CHANNEL_URL)
@@ -55,6 +55,13 @@ test.describe('channel page', () => {
     await expect(playlistResultsFilter).toHaveAttribute('aria-pressed', 'true')
     await expect(videoResults).toHaveCount(0)
     await expect(playlistResults.first()).toBeVisible()
+
+    const externalPlayerButton = playlistResults.first().locator('.externalPlayerButton .iconButton')
+    const downloadButton = playlistResults.first().getByTitle('Download Playlist')
+    const externalPlayerBounds = await externalPlayerButton.boundingBox()
+    const downloadBounds = await downloadButton.boundingBox()
+    expect(Math.abs(externalPlayerBounds.y - downloadBounds.y)).toBeLessThanOrEqual(2)
+    expect(externalPlayerBounds.x + externalPlayerBounds.width).toBeLessThanOrEqual(downloadBounds.x)
 
     await page.locator('.channelSearch .clearInputTextButton').click()
     await expect(page).not.toHaveURL(/searchQueryText=/)

--- a/src/renderer/components/FtListPlaylist/FtListPlaylist.scss
+++ b/src/renderer/components/FtListPlaylist/FtListPlaylist.scss
@@ -3,3 +3,8 @@
 .blur {
   filter: blur(20px);
 }
+
+.playlistButtonStack {
+  align-items: flex-start;
+  display: flex;
+}

--- a/src/renderer/components/FtListPlaylist/FtListPlaylist.vue
+++ b/src/renderer/components/FtListPlaylist/FtListPlaylist.vue
@@ -61,17 +61,17 @@
           {{ channelName }}
         </bdi>
       </div>
-      <FtIconButton
-        v-if="externalPlayer !== '' && !isUserPlaylist"
-        :title="t('Video.External Player.OpenInTemplate', { externalPlayer })"
-        :icon="['fas', 'external-link-alt']"
-        class="externalPlayerButton"
-        theme="base-no-default"
-        :size="16"
-        :use-shadow="false"
-        @click="handleExternalPlayer"
-      />
-      <span class="playlistIcons">
+      <div class="buttonStack playlistButtonStack">
+        <FtIconButton
+          v-if="externalPlayer !== '' && !isUserPlaylist"
+          :title="t('Video.External Player.OpenInTemplate', { externalPlayer })"
+          :icon="['fas', 'external-link-alt']"
+          class="externalPlayerButton"
+          theme="base-no-default"
+          :size="16"
+          :use-shadow="false"
+          @click="handleExternalPlayer"
+        />
         <FtIconButton
           v-if="IS_ELECTRON && videoCount > 0"
           :title="t('Downloads.Download Playlist')"
@@ -90,7 +90,7 @@
           @disabled-click="handleQuickBookmarkEnabledDisabledClick"
           @click="enableQuickBookmarkForThisPlaylist"
         />
-      </span>
+      </div>
     </div>
     <WatchVideoDownloadPrompt
       v-if="showDownloadPrompt"


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Make sure to follow the contributing guidelines. -->
<!-- Important note, we may remove your pull request if you do not use this provided PR template correctly. -->
<!-- Agent instructions: Preserve every heading, comment, and marker in this template. Never remove or rewrite the release-note-category:start/end, release-note:start/end, or release-note-image:start/end marker pairs. Never remove or rewrite the Release note images section; leave its contents for a human. -->

## Pull Request Type
<!-- Please select what type of pull request this is: [x] -->
- [x] Bugfix
- [ ] Feature Implementation
- [ ] Documentation
- [ ] Other

## Related issue
<!-- Please link the issue your pull request is referring to. -->
<!-- If this pull request fully resolves the relevant issue, put "closes" before the issue number. -->
<!-- Example: "closes #123456". -->

## Description
<!-- Please write a clear and concise description of what the pull request does. -->
Places the external-player and playlist download actions in one explicitly top-aligned horizontal action container.

The controls previously occupied separate grid items. When an external player was configured, the action grid stretched the external-player control while the download control was auto-placed elsewhere, causing the buttons to become misaligned or overlap playlist information.

## Release note category
<!-- Select exactly one category. Every pull request must select one. -->
<!-- release-note-category:start -->
- [ ] Not noteworthy
- [ ] Highlights
- [ ] More improvements
- [x] Fixed bugs
<!-- release-note-category:end -->

## Release note
<!-- Required unless "Not noteworthy" is selected. -->
<!-- Write one concise, user-facing entry without a leading bullet. -->
<!-- release-note:start -->
Fixed the playlist download button alignment when an external player is configured.
<!-- release-note:end -->

## Release note images
<!-- Human-only: Agents must preserve this entire section and leave it empty. -->
<!-- Optional. Paste one or more Markdown images or HTML image tags here. -->
<!-- The release notes will use an HTML image tag and limit images taller than 300 pixels. -->
<!-- release-note-image:start -->

<!-- release-note-image:end -->

## Testing
<!-- How can reviewers verify that the PR produces correct results? -->
<!-- Please provide instructions so that others can ensure that your pull request would produce correct results. For examples see, https://github.com/FreeTubeApp/FreeTube/pull/5743, https://github.com/FreeTubeApp/FreeTube/pull/7349, https://github.com/FreeTubeApp/FreeTube/pull/5125, https://github.com/FreeTubeApp/FreeTube/pull/7338 -->
<!-- Agent instructions: Only write human-facing steps that explain how to verify the change while running this branch in dev mode. Include expected results and, when applicable, helpful console snippets for interactive verification. Do not include automated checks, commands, results, pass counts, or CI status. -->
1. Configure an external player in Settings.
2. Open a channel and search for playlists.
3. Confirm the external-player and download buttons appear next to each other at the top-right of each playlist card.
4. Hover and click both controls, confirming they remain aligned and open their respective actions.

## Additional context
<!-- Add any other context about the pull request here. -->
Includes a regression test that checks the rendered button positions when mpv is configured.