### PR TITLE
Fix delayed Auto quality switches

### DIFF
--- a/e2e/tests/network/auto-quality.spec.mjs
+++ b/e2e/tests/network/auto-quality.spec.mjs
@@ -23,6 +23,8 @@ function readAbrState(page) {
 
     return {
       abrEnabled: player.getConfiguration().abr.enabled,
+      clearBufferSwitch: player.getConfiguration().abr.clearBufferSwitch,
+      safeMarginSwitch: player.getConfiguration().abr.safeMarginSwitch,
       autoButtonVisible: autoButton != null && getComputedStyle(autoButton).display !== 'none'
     }
   })
@@ -44,8 +46,10 @@ test.describe('auto quality', () => {
       await openVideoOrSkip(test, page, VIDEO)
       await waitForPlaybackOrSkip(test, page)
 
-      const { abrEnabled, autoButtonVisible } = await readAbrState(page)
+      const { abrEnabled, clearBufferSwitch, safeMarginSwitch, autoButtonVisible } = await readAbrState(page)
       expect(abrEnabled).toBe(true)
+      expect(clearBufferSwitch).toBe(true)
+      expect(safeMarginSwitch).toBe(10)
       expect(autoButtonVisible).toBe(true)
     })
   })
@@ -67,8 +71,9 @@ test.describe('auto quality', () => {
       await openVideoOrSkip(test, page, VIDEO)
       await waitForPlaybackOrSkip(test, page)
 
-      const { abrEnabled, autoButtonVisible } = await readAbrState(page)
+      const { abrEnabled, clearBufferSwitch, autoButtonVisible } = await readAbrState(page)
       expect(abrEnabled).toBe(false)
+      expect(clearBufferSwitch).toBe(false)
       expect(autoButtonVisible).toBe(false)
     })
   })

--- a/src/renderer/components/ft-shaka-video-player/ft-shaka-video-player.js
+++ b/src/renderer/components/ft-shaka-video-player/ft-shaka-video-player.js
@@ -2879,7 +2879,14 @@ export default defineComponent({
           enabled: useAutoQuality,
 
           // This only affects the "auto" quality, users can still manually select whatever quality they want.
-          restrictToElementSize: true
+          restrictToElementSize: true,
+
+          // The regular buffer can contain up to three minutes of video. Without clearing it on an
+          // automatic switch, playback can therefore stay at the initial low quality long after the
+          // quality menu and stats report the newly selected variant. Keep two typical DASH segments
+          // for a seamless switch, but replace the rest with segments from the new variant.
+          clearBufferSwitch: streamsSupportAutoQuality(format, isSabrPlayback.value),
+          safeMarginSwitch: 10
         },
 
         // Prioritise variants that are predicted to play:


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Make sure to follow the contributing guidelines. -->
<!-- Important note, we may remove your pull request if you do not use this provided PR template correctly. -->
<!-- Agent instructions: Preserve every heading, comment, and marker in this template. Never remove or rewrite the release-note-category:start/end, release-note:start/end, or release-note-image:start/end marker pairs. Never remove or rewrite the Release note images section; leave its contents for a human. -->

## Pull Request Type
<!-- Please select what type of pull request this is: [x] -->
- [x] Bugfix
- [ ] Feature Implementation
- [ ] Documentation
- [ ] Other

## Related issue
<!-- Please link the issue your pull request is referring to. -->
<!-- If this pull request fully resolves the relevant issue, put "closes" before the issue number. -->
<!-- Example: "closes #123456". -->

## Description
<!-- Please write a clear and concise description of what the pull request does. -->

Auto quality could initially buffer up to three minutes of low-resolution video before Shaka selected a higher-quality variant. Shaka reported the new variant immediately without replacing the old buffer, so the quality menu and stats could show 1080p while playback continued displaying 144p.

Enable buffer clearing for supported Auto-quality streams while retaining a 10-second safety margin. This replaces stale low-quality segments after an automatic switch without causing an avoidable playback interruption. SABR playback remains unchanged because Auto quality is disabled there.

## Release note category
<!-- Select exactly one category. Every pull request must select one. -->
<!-- release-note-category:start -->
- [x] Not noteworthy
- [ ] Highlights
- [ ] More improvements
- [ ] Fixed bugs
<!-- release-note-category:end -->

## Release note
<!-- Required unless "Not noteworthy" is selected. -->
<!-- Write one concise, user-facing entry without a leading bullet. -->
<!-- release-note:start -->
Auto video quality now applies upgrades promptly instead of continuing to display previously buffered low-resolution video.
<!-- release-note:end -->

## Release note images
<!-- Human-only: Agents must preserve this entire section and leave it empty. -->
<!-- Optional. Paste one or more Markdown images or HTML image tags here. -->
<!-- The release notes will use an HTML image tag and limit images taller than 300 pixels. -->
<!-- release-note-image:start -->

<!-- release-note-image:end -->

## Testing
<!-- How can reviewers verify that the PR produces correct results? -->
<!-- Please provide instructions so that others can ensure that your pull request would produce correct results. For examples see, https://github.com/FreeTubeApp/FreeTube/pull/5743, https://github.com/FreeTubeApp/FreeTube/pull/7349, https://github.com/FreeTubeApp/FreeTube/pull/5125, https://github.com/FreeTubeApp/FreeTube/pull/7338 -->
<!-- Agent instructions: Only write human-facing steps that explain how to verify the change while running this branch in dev mode. Include expected results and, when applicable, helpful console snippets for interactive verification. Do not include automated checks, commands, results, pass counts, or CI status. -->

1. Configure yt-dlp as the playback engine and set the default video quality to Auto.
2. Start a DASH video while the network is temporarily throttled enough to make playback begin at a low resolution.
3. Remove the throttling and open the quality menu or stats overlay.
4. Confirm playback visibly upgrades shortly after the selected Auto variant increases instead of continuing at the initial low resolution for the full buffered duration.
5. Switch to the built-in playback engine and confirm Auto remains unavailable for SABR playback.

## Additional context
<!-- Add any other context about the pull request here. -->

The 10-second safety margin retains roughly two typical DASH segments, following Shaka's guidance for avoiding hiccups during buffer-clearing switches.
