### PR TITLE
Support highlighted YouTube comment links

### DIFF
--- a/e2e/tests/network/startup.spec.mjs
+++ b/e2e/tests/network/startup.spec.mjs
@@ -1,12 +1,13 @@
 import { test, expect, sel } from '../../helpers/app.mjs'
 
-const VIDEO_URL = 'https://www.youtube.com/watch?v=jNQXAC9IVRw'
+const COMMENT_ID = 'Ugw-comment-target'
+const VIDEO_URL = `https://www.youtube.com/watch?v=jNQXAC9IVRw&lc=${COMMENT_ID}`
 
 test.use({ launchArgs: [VIDEO_URL] })
 
 // Regression: startup URLs were routed through the shared shell too late or
 // interpreted as unrelated Electron arguments (79cba985a, b96ac4baa).
 test('opens a YouTube startup URL directly in the initial tab', async ({ page }) => {
-  await expect(page).toHaveURL(/#\/watch\/jNQXAC9IVRw/)
+  await expect(page).toHaveURL(new RegExp(`#\\/watch\\/jNQXAC9IVRw\\?.*commentId=${COMMENT_ID}`))
   await expect(page.locator(sel.tabs)).toHaveCount(1)
 })

--- a/e2e/tests/network/watch.spec.mjs
+++ b/e2e/tests/network/watch.spec.mjs
@@ -211,13 +211,13 @@ test.describe('watch page metadata', () => {
 
 test.describe('watch page', () => {
   test('shows a pasted comment link as the first unpinned highlighted comment', async ({ page }) => {
-    const commentId = 'Ugwh6iFZf1tOPih3Z3J4AaABAg'
+    const commentId = 'UgxZaBRFEKqDUoZULy94AaABAg'
     await page.locator(sel.searchInput).fill(
-      `https://www.youtube.com/watch?v=QMfwMNd1mR4&lc=${commentId}&pp=0gcJCSIANpG00pGi`
+      `${VIDEO_URL}&lc=${commentId}&pp=0gcJCSIANpG00pGi`
     )
     await page.locator(sel.searchInput).press('Enter')
 
-    await expect(page).toHaveURL(new RegExp(`#\\/watch\\/QMfwMNd1mR4\\?.*commentId=${commentId}`))
+    await expect(page).toHaveURL(new RegExp(`#\\/watch\\/jNQXAC9IVRw\\?.*commentId=${commentId}`))
     const badge = page.getByText('Highlighted comment', { exact: true })
     await expect(badge).toBeVisible({ timeout: 60_000 })
 
@@ -231,9 +231,9 @@ test.describe('watch page', () => {
       })
     }).toBe(true)
 
-    const replyId = `${commentId}.A_IKgLISR5LA_IQAHGoLUG`
+    const replyId = 'UgzuC3zzpRZkjc5Qzsd4AaABAg.958xaQsh63D95AEkVnh_di'
     await page.locator(sel.searchInput).fill(
-      `https://www.youtube.com/watch?v=QMfwMNd1mR4&lc=${replyId}`
+      `${VIDEO_URL}&lc=${replyId}`
     )
     await page.locator(sel.searchInput).press('Enter')
 

--- a/e2e/tests/network/watch.spec.mjs
+++ b/e2e/tests/network/watch.spec.mjs
@@ -227,7 +227,12 @@ test.describe('watch page', () => {
         const threads = [...thread.parentElement.children]
         const highlightedIndex = threads.indexOf(thread)
         const lastPinnedIndex = threads.findLastIndex(candidate => candidate.querySelector('.commentPinned'))
-        return highlightedIndex === lastPinnedIndex + 1
+        const allPreviousThreadsArePinned = threads
+          .slice(0, highlightedIndex)
+          .every(candidate => candidate.querySelector('.commentPinned') !== null)
+        return highlightedIndex >= 0 &&
+          allPreviousThreadsArePinned &&
+          highlightedIndex === lastPinnedIndex + 1
       })
     }).toBe(true)
 

--- a/e2e/tests/network/watch.spec.mjs
+++ b/e2e/tests/network/watch.spec.mjs
@@ -210,6 +210,38 @@ test.describe('watch page metadata', () => {
 })
 
 test.describe('watch page', () => {
+  test('shows a pasted comment link as the first unpinned highlighted comment', async ({ page }) => {
+    const commentId = 'Ugwh6iFZf1tOPih3Z3J4AaABAg'
+    await page.locator(sel.searchInput).fill(
+      `https://www.youtube.com/watch?v=QMfwMNd1mR4&lc=${commentId}&pp=0gcJCSIANpG00pGi`
+    )
+    await page.locator(sel.searchInput).press('Enter')
+
+    await expect(page).toHaveURL(new RegExp(`#\\/watch\\/QMfwMNd1mR4\\?.*commentId=${commentId}`))
+    const badge = page.getByText('Highlighted comment', { exact: true })
+    await expect(badge).toBeVisible({ timeout: 60_000 })
+
+    const highlightedThread = badge.locator('..')
+    await expect.poll(async () => {
+      return highlightedThread.evaluate((thread) => {
+        const threads = [...thread.parentElement.children]
+        const highlightedIndex = threads.indexOf(thread)
+        const lastPinnedIndex = threads.findLastIndex(candidate => candidate.querySelector('.commentPinned'))
+        return highlightedIndex === lastPinnedIndex + 1
+      })
+    }).toBe(true)
+
+    const replyId = `${commentId}.A_IKgLISR5LA_IQAHGoLUG`
+    await page.locator(sel.searchInput).fill(
+      `https://www.youtube.com/watch?v=QMfwMNd1mR4&lc=${replyId}`
+    )
+    await page.locator(sel.searchInput).press('Enter')
+
+    await expect(page).toHaveURL(new RegExp(`commentId=${replyId.replace('.', '\\.')}`))
+    const replyBadge = page.getByText('Highlighted reply', { exact: true })
+    await expect(replyBadge).toBeVisible({ timeout: 60_000 })
+  })
+
   test('fullscreen comments keep auto-loading while the sentinel stays visible', async ({ page, innertube }) => {
     test.skip(innertube.replay, 'needs more comment pages than are recorded')
     await openVideo(page)

--- a/e2e/tests/offline/navigation.spec.mjs
+++ b/e2e/tests/offline/navigation.spec.mjs
@@ -143,11 +143,11 @@ test.describe('navigation history titles', () => {
 })
 
 test('preserves a pasted YouTube comment link target', async ({ page }) => {
-  const commentId = 'Ugwh6iFZf1tOPih3Z3J4AaABAg'
+  const commentId = 'UgxZaBRFEKqDUoZULy94AaABAg'
   await page.locator(sel.searchInput).fill(
-    `https://www.youtube.com/watch?v=QMfwMNd1mR4&lc=${commentId}&pp=0gcJCSIANpG00pGi`
+    `https://www.youtube.com/watch?v=jNQXAC9IVRw&lc=${commentId}&pp=0gcJCSIANpG00pGi`
   )
   await page.locator(sel.searchInput).press('Enter')
 
-  await expect(page).toHaveURL(new RegExp(`#\\/watch\\/QMfwMNd1mR4\\?.*commentId=${commentId}`))
+  await expect(page).toHaveURL(new RegExp(`#\\/watch\\/jNQXAC9IVRw\\?.*commentId=${commentId}`))
 })

--- a/e2e/tests/offline/navigation.spec.mjs
+++ b/e2e/tests/offline/navigation.spec.mjs
@@ -141,3 +141,13 @@ test.describe('navigation history titles', () => {
     await expect(options.filter({ hasText: 'Watch' })).toHaveCount(0)
   })
 })
+
+test('preserves a pasted YouTube comment link target', async ({ page }) => {
+  const commentId = 'Ugwh6iFZf1tOPih3Z3J4AaABAg'
+  await page.locator(sel.searchInput).fill(
+    `https://www.youtube.com/watch?v=QMfwMNd1mR4&lc=${commentId}&pp=0gcJCSIANpG00pGi`
+  )
+  await page.locator(sel.searchInput).press('Enter')
+
+  await expect(page).toHaveURL(new RegExp(`#\\/watch\\/QMfwMNd1mR4\\?.*commentId=${commentId}`))
+})

--- a/src/main/index.js
+++ b/src/main/index.js
@@ -2318,6 +2318,7 @@ function runApp() {
       return createAppRouteUrl(`/watch/${videoParams.videoId}`, {
         timestamp: videoParams.timestamp,
         playlistId: videoParams.playlistId,
+        commentId: videoParams.commentId,
         short: videoParams.isShort ? 'true' : null
       })
     }
@@ -2356,13 +2357,14 @@ function runApp() {
 
   /**
    * @param {URL} url
-   * @returns {{ videoId: string | null, timestamp: string | null, playlistId: string | null, isShort: boolean }}
+   * @returns {{ videoId: string | null, timestamp: string | null, playlistId: string | null, commentId: string | null, isShort: boolean }}
    */
   function getDirectVideoParams(url) {
     const params = {
       videoId: null,
       timestamp: null,
       playlistId: null,
+      commentId: null,
       isShort: false
     }
 
@@ -2372,6 +2374,7 @@ function runApp() {
         params.videoId = videoId
         params.timestamp = getDirectTimestamp(url)
         params.playlistId = url.searchParams.get('list')
+        params.commentId = url.searchParams.get('lc')
       }
     }
 

--- a/src/renderer/App.vue
+++ b/src/renderer/App.vue
@@ -2445,7 +2445,7 @@ async function handleYoutubeLink(href, {
 
   switch (result.urlType) {
     case 'video': {
-      const { videoId, timestamp, playlistId, isShort } = result
+      const { videoId, timestamp, playlistId, commentId, isShort } = result
 
       const query = {}
       if (isShort) {
@@ -2456,6 +2456,9 @@ async function handleYoutubeLink(href, {
       }
       if (playlistId && playlistId.length > 0) {
         query.playlistId = playlistId
+      }
+      if (commentId) {
+        query.commentId = commentId
       }
 
       openPath({

--- a/src/renderer/components/CommentSection/CommentReply.css
+++ b/src/renderer/components/CommentSection/CommentReply.css
@@ -16,6 +16,20 @@
   block-size: 30px;
 }
 
+.commentReplyBranch:not(.commentReplyBranchRoot).highlightedCommentBranch:last-child::before {
+  block-size: calc(30px + var(--highlighted-comment-offset));
+}
+
+.commentReplyBranchRoot.highlightedCommentBranch::before {
+  content: '';
+  position: absolute;
+  inset-block-start: 0;
+  inset-inline-start: 0;
+  block-size: calc(30px + var(--highlighted-comment-offset));
+  border-inline-start: 1px solid var(--comment-thread-line-color);
+  pointer-events: none;
+}
+
 .commentReplyConnector {
   position: absolute;
   z-index: 0;
@@ -29,9 +43,18 @@
   pointer-events: none;
 }
 
+.highlightedCommentBranch > .commentReplyConnector {
+  inset-block-start: calc(30px + var(--highlighted-comment-offset));
+}
+
 .commentReplyContent {
   position: relative;
   display: flow-root;
+}
+
+.commentReplyContent.highlightedComment {
+  /* Keep the reply's total block spacing unchanged after adding the badge. */
+  padding-block-end: 2px;
 }
 
 .commentReplyChildStem {
@@ -40,6 +63,10 @@
   inset-inline-start: 45px;
   border-inline-start: 1px solid var(--comment-thread-line-color);
   pointer-events: none;
+}
+
+.highlightedComment > .commentReplyChildStem {
+  inset-block-start: calc(75px + var(--highlighted-comment-offset));
 }
 
 .commentReplyChildren {

--- a/src/renderer/components/CommentSection/CommentReply.vue
+++ b/src/renderer/components/CommentSection/CommentReply.vue
@@ -2,13 +2,25 @@
   <div
     :id="`comment${threadIndex}-${node.index}`"
     class="commentReplyBranch"
-    :class="{ commentReplyBranchRoot: rootLevel }"
+    :class="{
+      commentReplyBranchRoot: rootLevel,
+      highlightedCommentBranch: reply.id === highlightedCommentId
+    }"
   >
     <span
       class="commentReplyConnector"
       aria-hidden="true"
     />
-    <div class="comment commentReplyContent">
+    <div
+      class="comment commentReplyContent"
+      :class="{ highlightedComment: reply.id === highlightedCommentId }"
+    >
+      <p
+        v-if="reply.id === highlightedCommentId"
+        class="highlightedCommentBadge"
+      >
+        {{ $t('Comments.Highlighted reply') }}
+      </p>
       <span
         v-if="node.children.length > 0"
         class="commentReplyChildStem"
@@ -140,6 +152,7 @@
         :subscribed-channel-ids="subscribedChannelIds"
         :channel-thumbnail="channelThumbnail"
         :loading-reply-ids="loadingReplyIds"
+        :highlighted-comment-id="highlightedCommentId"
         @copy-youtube-link="emit('copy-youtube-link', $event)"
         @get-more-replies="emit('get-more-replies', $event)"
         @timestamp-event="emit('timestamp-event', $event)"
@@ -191,6 +204,10 @@ const props = defineProps({
   loadingReplyIds: {
     type: Set,
     required: true
+  },
+  highlightedCommentId: {
+    type: String,
+    default: null
   }
 })
 

--- a/src/renderer/components/CommentSection/CommentSection.css
+++ b/src/renderer/components/CommentSection/CommentSection.css
@@ -234,10 +234,28 @@
   padding: 15px;
 }
 
+.comment.highlightedComment {
+  padding-block-start: 0;
+}
+
+.highlightedCommentBadge {
+  display: table;
+  margin-block: 0 8px;
+  padding-block: 2px;
+  padding-inline: 5px;
+  color: var(--primary-text-color);
+  background-color: var(--side-nav-hover-color);
+  border-radius: calc(2px * var(--ui-roundness));
+  font-size: 11px;
+  font-weight: normal;
+  line-height: 16px;
+}
+
 .commentThread {
   position: relative;
 
   --comment-thread-line-color: color-mix(in srgb, var(--tertiary-text-color) 55%, var(--card-bg-color));
+  --highlighted-comment-offset: 13px;
 }
 
 .commentThreadExpanded::before {
@@ -248,6 +266,10 @@
   inset-inline-start: 45px;
   border-inline-start: 1px solid var(--comment-thread-line-color);
   pointer-events: none;
+}
+
+.commentThreadExpanded.highlightedComment::before {
+  inset-block-start: calc(75px + var(--highlighted-comment-offset));
 }
 
 .commentTitleAction {

--- a/src/renderer/components/CommentSection/CommentSection.vue
+++ b/src/renderer/components/CommentSection/CommentSection.vue
@@ -522,6 +522,7 @@ const commentData = ref([])
 const commentCount = ref(props.initialCommentCount)
 const commentsContentWrapper = useTemplateRef('commentsContentWrapper')
 let fullscreenScrollTop = 0
+let highlightedTargetGeneration = 0
 const MAX_HIGHLIGHTED_REPLY_PAGES = 20
 
 watch(() => props.fullscreenOverlay, (fullscreenOverlay, wasFullscreenOverlay) => {
@@ -689,11 +690,16 @@ const canPerformInitialCommentLoading = computed(() => {
 watch(() => props.highlightedCommentId, (commentId, previousCommentId) => {
   const targetChanged = previousCommentId !== undefined && previousCommentId !== commentId
   if (targetChanged) {
+    highlightedTargetGeneration++
     isLoading.value = false
+    isLoadingMoreComments.value = false
+    loadingReplyIds.value = new Set()
+    showComments.value = false
     commentData.value = []
     nextPageToken.value = null
     localCommentsInstance = undefined
     replyTokens.clear()
+    resetCommentsScroll()
   }
 
   if ((commentId || targetChanged) && canPerformInitialCommentLoading.value) {
@@ -975,6 +981,7 @@ function toggleCommentReplies(index) {
  */
 async function getCommentReplies(index, commentId = null) {
   const replyId = commentId ?? commentData.value[index].id
+  const targetGeneration = highlightedTargetGeneration
   if (loadingReplyIds.value.has(replyId)) {
     return
   }
@@ -998,9 +1005,11 @@ async function getCommentReplies(index, commentId = null) {
       await getCommentRepliesLocal(index, commentId)
     }
   } finally {
-    const nextLoadingReplyIds = new Set(loadingReplyIds.value)
-    nextLoadingReplyIds.delete(replyId)
-    loadingReplyIds.value = nextLoadingReplyIds
+    if (targetGeneration === highlightedTargetGeneration) {
+      const nextLoadingReplyIds = new Set(loadingReplyIds.value)
+      nextLoadingReplyIds.delete(replyId)
+      loadingReplyIds.value = nextLoadingReplyIds
+    }
   }
 }
 
@@ -1229,6 +1238,7 @@ async function getCommentDataLocal(more = false, preserveSort = false) {
  * @param {string | null} commentId
  */
 async function getCommentRepliesLocal(index, commentId = null) {
+  const targetGeneration = highlightedTargetGeneration
   const rootComment = commentData.value[index]
   const comment = rootComment ? findComment(rootComment, commentId) : null
   const continuation = comment && replyTokens.get(comment.id)
@@ -1265,6 +1275,10 @@ async function getCommentRepliesLocal(index, commentId = null) {
       nextContinuation = response.has_continuation ? response : null
     }
 
+    if (targetGeneration !== highlightedTargetGeneration) {
+      return
+    }
+
     const parsedReplies = replyThreads
       .map(reply => parseLocalCommentThread(reply))
       .filter(Boolean)
@@ -1290,6 +1304,10 @@ async function getCommentRepliesLocal(index, commentId = null) {
 
     comment.showReplies = replyLoadState.showReplies
   } catch (err) {
+    if (targetGeneration !== highlightedTargetGeneration) {
+      return
+    }
+
     console.error(err)
 
     if (isMissingReplyResponseError(err)) {
@@ -1409,6 +1427,7 @@ async function getCommentRepliesInvidious(
   commentOverride = null,
   expectedReplyToken = null
 ) {
+  const targetGeneration = highlightedTargetGeneration
   const rootComment = commentData.value[index]
   const comment = commentOverride ?? (rootComment ? findComment(rootComment, commentId) : null)
   if (!comment) {
@@ -1420,7 +1439,10 @@ async function getCommentRepliesInvidious(
   try {
     const { commentData, continuation } = await invidiousGetCommentReplies({ id: props.id, replyToken })
 
-    if (expectedReplyToken && replyTokens.get(comment.id) !== expectedReplyToken) {
+    if (
+      targetGeneration !== highlightedTargetGeneration ||
+      (expectedReplyToken && replyTokens.get(comment.id) !== expectedReplyToken)
+    ) {
       return
     }
 
@@ -1446,6 +1468,10 @@ async function getCommentRepliesInvidious(
 
     isLoading.value = false
   } catch (error) {
+    if (targetGeneration !== highlightedTargetGeneration) {
+      return
+    }
+
     console.error(error)
     const errorMessage = t('Invidious API Error (Click to copy)')
     showApiErrorToast(errorMessage, error)
@@ -1490,6 +1516,7 @@ function getPostCommentsInvidious() {
 }
 
 async function getPostCommentRepliesInvidious(index) {
+  const targetGeneration = highlightedTargetGeneration
   const comment = commentData.value[index]
   const replyToken = replyTokens.get(comment.id)
 
@@ -1499,6 +1526,11 @@ async function getPostCommentRepliesInvidious(index) {
       replyToken: replyToken,
       authorId: props.postAuthorId
     })
+
+    if (targetGeneration !== highlightedTargetGeneration) {
+      return
+    }
+
     comment.replies = comment.replies.concat(comments)
     const replyLoadState = getReplyLoadState(
       comment.replies.length,
@@ -1521,6 +1553,10 @@ async function getPostCommentRepliesInvidious(index) {
 
     isLoading.value = false
   } catch (error) {
+    if (targetGeneration !== highlightedTargetGeneration) {
+      return
+    }
+
     console.error(error)
     const errorMessage = t('Invidious API Error (Click to copy)')
     showApiErrorToast(errorMessage, error)

--- a/src/renderer/components/CommentSection/CommentSection.vue
+++ b/src/renderer/components/CommentSection/CommentSection.vue
@@ -522,6 +522,7 @@ const commentData = ref([])
 const commentCount = ref(props.initialCommentCount)
 const commentsContentWrapper = useTemplateRef('commentsContentWrapper')
 let fullscreenScrollTop = 0
+const MAX_HIGHLIGHTED_REPLY_PAGES = 20
 
 watch(() => props.fullscreenOverlay, (fullscreenOverlay, wasFullscreenOverlay) => {
   if (wasFullscreenOverlay) {
@@ -686,18 +687,16 @@ const canPerformInitialCommentLoading = computed(() => {
 })
 
 watch(() => props.highlightedCommentId, (commentId, previousCommentId) => {
-  if (!commentId) {
-    return
-  }
-
-  if (previousCommentId !== undefined && previousCommentId !== commentId) {
+  const targetChanged = previousCommentId !== undefined && previousCommentId !== commentId
+  if (targetChanged) {
+    isLoading.value = false
     commentData.value = []
     nextPageToken.value = null
     localCommentsInstance = undefined
     replyTokens.clear()
   }
 
-  if (canPerformInitialCommentLoading.value) {
+  if ((commentId || targetChanged) && canPerformInitialCommentLoading.value) {
     getCommentData()
   }
 }, { immediate: true })
@@ -903,8 +902,7 @@ function copyCommentYoutubeLink(commentId) {
 function getCommentData({ preserveSort = false } = {}) {
   isLoading.value = true
 
-  const useInvidious = !process.env.SUPPORTS_LOCAL_API ||
-    (backendPreference.value === 'invidious' && !props.highlightedCommentId)
+  const useInvidious = !process.env.SUPPORTS_LOCAL_API || backendPreference.value === 'invidious'
 
   if (useInvidious) {
     if (!props.isPostComments) {
@@ -1109,10 +1107,21 @@ async function loadHighlightedReply() {
     return
   }
 
-  while (!findComment(thread, highlightedCommentId) && thread.hasReplyToken) {
+  let loadedPageCount = 0
+  while (
+    !findComment(thread, highlightedCommentId) &&
+    thread.hasReplyToken &&
+    loadedPageCount < MAX_HIGHLIGHTED_REPLY_PAGES
+  ) {
     const previousReplyCount = thread.replies.length
     const previousReplyToken = replyTokens.get(thread.id)
+
+    if (highlightedCommentId !== props.highlightedCommentId || commentData.value[threadIndex] !== thread) {
+      return
+    }
+
     await getCommentReplies(threadIndex)
+    loadedPageCount++
 
     if (thread.replies.length === previousReplyCount && replyTokens.get(thread.id) === previousReplyToken) {
       break
@@ -1125,6 +1134,8 @@ async function loadHighlightedReply() {
  * @param {boolean} preserveSort
  */
 async function getCommentDataLocal(more = false, preserveSort = false) {
+  const requestedHighlightedCommentId = props.highlightedCommentId
+
   try {
     /** @type {import('youtubei.js').YT.Comments} */
     let comments
@@ -1132,7 +1143,6 @@ async function getCommentDataLocal(more = false, preserveSort = false) {
       comments = await nextPageToken.value.getContinuation()
     } else if (localCommentsInstance && !props.highlightedCommentId) {
       comments = await localCommentsInstance.applySort(sortNewest.value ? 'NEWEST_FIRST' : 'TOP_COMMENTS')
-      localCommentsInstance = comments
     } else {
       if (props.isPostComments) {
         comments = await getLocalCommunityPostComments(props.id, props.postAuthorId)
@@ -1146,7 +1156,13 @@ async function getCommentDataLocal(more = false, preserveSort = false) {
       } else {
         sortNewest.value = comments.header?.sort_menu?.sub_menu_items?.[1].selected ?? false
       }
+    }
 
+    if (requestedHighlightedCommentId !== props.highlightedCommentId) {
+      return
+    }
+
+    if (!more) {
       localCommentsInstance = comments
     }
 
@@ -1172,6 +1188,10 @@ async function getCommentDataLocal(more = false, preserveSort = false) {
       await loadHighlightedReply()
     }
   } catch (err) {
+    if (requestedHighlightedCommentId !== props.highlightedCommentId) {
+      return
+    }
+
     // region No comment detection
     // No comment related info when video info requested earlier in parent component
     if (err.message.includes('Comments page did not have any content')) {
@@ -1190,7 +1210,7 @@ async function getCommentDataLocal(more = false, preserveSort = false) {
     console.error(err)
     const errorMessage = t('Local API Error (Click to copy)')
     showApiErrorToast(errorMessage, err)
-    if (backendFallback.value && (backendPreference.value === 'local' || props.highlightedCommentId)) {
+    if (backendFallback.value && backendPreference.value === 'local') {
       localCommentsInstance = undefined
       showToast({ message: t('Falling back to Invidious API'), icon: ['fas', 'exchange-alt'] })
       if (props.isPostComments) {
@@ -1313,12 +1333,18 @@ async function getCommentRepliesLocal(index, commentId = null) {
 }
 
 async function getCommentDataInvidious() {
+  const requestedHighlightedCommentId = props.highlightedCommentId
+
   try {
     let { response, commentData: comments } = await invidiousGetComments({
       id: props.id,
       nextPageToken: nextPageToken.value,
       sortNewest: sortNewest.value
     })
+
+    if (requestedHighlightedCommentId !== props.highlightedCommentId) {
+      return
+    }
 
     setCommentCount(response.commentCount)
 
@@ -1338,6 +1364,10 @@ async function getCommentDataInvidious() {
     isLoading.value = false
     showComments.value = true
   } catch (err) {
+    if (requestedHighlightedCommentId !== props.highlightedCommentId) {
+      return
+    }
+
     // region No comment detection
     // No comment related info when video info requested earlier in parent component
     if (err.message.includes('Comments not found')) {

--- a/src/renderer/components/CommentSection/CommentSection.vue
+++ b/src/renderer/components/CommentSection/CommentSection.vue
@@ -147,8 +147,17 @@
           :id="'comment' + index"
           :key="comment.id"
           class="comment commentThread"
-          :class="{ commentThreadExpanded: comment.showReplies }"
+          :class="{
+            commentThreadExpanded: comment.showReplies,
+            highlightedComment: comment.id === highlightedCommentId
+          }"
         >
+          <p
+            v-if="comment.id === highlightedCommentId"
+            class="highlightedCommentBadge"
+          >
+            {{ $t('Comments.Highlighted comment') }}
+          </p>
           <component
             :is="enableChannelLinks ? 'router-link' : 'div'"
             :to="`/channel/${comment.authorLink}`"
@@ -296,6 +305,7 @@
               :subscribed-channel-ids="subscribedChannelIds"
               :channel-thumbnail="channelThumbnail"
               :loading-reply-ids="loadingReplyIds"
+              :highlighted-comment-id="highlightedCommentId"
               @copy-youtube-link="copyCommentYoutubeLink"
               @get-more-replies="getCommentReplies(index, $event)"
               @timestamp-event="onTimestamp"
@@ -493,6 +503,10 @@ const props = defineProps({
   fullscreenOverlay: {
     type: Boolean,
     default: false,
+  },
+  highlightedCommentId: {
+    type: String,
+    default: null,
   }
 })
 
@@ -670,6 +684,23 @@ const generalAutoLoadMorePaginatedItemsEnabled = computed(() => {
 const canPerformInitialCommentLoading = computed(() => {
   return !props.commentsDisabled && commentData.value.length === 0 && !isLoading.value && !showComments.value
 })
+
+watch(() => props.highlightedCommentId, (commentId, previousCommentId) => {
+  if (!commentId) {
+    return
+  }
+
+  if (previousCommentId !== undefined && previousCommentId !== commentId) {
+    commentData.value = []
+    nextPageToken.value = null
+    localCommentsInstance = undefined
+    replyTokens.clear()
+  }
+
+  if (canPerformInitialCommentLoading.value) {
+    getCommentData()
+  }
+}, { immediate: true })
 
 watch(
   [generalAutoLoadMorePaginatedItemsEnabled, () => isTabPresented?.value],
@@ -872,7 +903,10 @@ function copyCommentYoutubeLink(commentId) {
 function getCommentData({ preserveSort = false } = {}) {
   isLoading.value = true
 
-  if (!process.env.SUPPORTS_LOCAL_API || backendPreference.value === 'invidious') {
+  const useInvidious = !process.env.SUPPORTS_LOCAL_API ||
+    (backendPreference.value === 'invidious' && !props.highlightedCommentId)
+
+  if (useInvidious) {
     if (!props.isPostComments) {
       getCommentDataInvidious()
     } else {
@@ -890,7 +924,7 @@ function getMoreComments() {
     isLoadingMoreComments.value = true
     let commentLoadPromise
 
-    if (!process.env.SUPPORTS_LOCAL_API || backendPreference.value === 'invidious') {
+    if (typeof nextPageToken.value === 'string') {
       if (!props.isPostComments) {
         commentLoadPromise = getCommentDataInvidious()
       } else {
@@ -993,7 +1027,11 @@ function parseLocalCommentThread(commentThread, showReplies = true) {
   comment.replies = (commentThread.replies ?? [])
     .map(reply => parseLocalCommentThread(reply))
     .filter(Boolean)
-  comment.showReplies = showReplies && comment.replies.length > 0
+  const containsHighlightedComment = props.highlightedCommentId && (
+    findComment(comment, props.highlightedCommentId) !== null ||
+    comment.id === getHighlightedRootCommentId()
+  )
+  comment.showReplies = (showReplies || containsHighlightedComment) && comment.replies.length > 0
 
   const hasReplyToken = commentThread.has_replies &&
     (!commentThread.replies || commentThread.has_continuation)
@@ -1027,6 +1065,61 @@ function findComment(comment, commentId) {
   return null
 }
 
+function getHighlightedRootCommentId() {
+  return props.highlightedCommentId?.split('.')[0] ?? null
+}
+
+/**
+ * Keep pinned comments at the top, followed by the thread containing the
+ * highlighted comment or reply.
+ *
+ * @param {Comment[]} comments
+ * @returns {Comment[]}
+ */
+function prioritizeHighlightedComment(comments) {
+  if (!props.highlightedCommentId) {
+    return comments
+  }
+
+  const pinnedComments = comments.filter(comment => comment.isPinned)
+  const unpinnedComments = comments.filter(comment => !comment.isPinned)
+  const highlightedIndex = unpinnedComments.findIndex(comment => {
+    return findComment(comment, props.highlightedCommentId) !== null ||
+      comment.id === getHighlightedRootCommentId()
+  })
+
+  if (highlightedIndex > 0) {
+    const [highlightedComment] = unpinnedComments.splice(highlightedIndex, 1)
+    unpinnedComments.unshift(highlightedComment)
+  }
+
+  return pinnedComments.concat(unpinnedComments)
+}
+
+async function loadHighlightedReply() {
+  const highlightedCommentId = props.highlightedCommentId
+  const rootCommentId = getHighlightedRootCommentId()
+  if (!highlightedCommentId?.includes('.') || !rootCommentId) {
+    return
+  }
+
+  const threadIndex = commentData.value.findIndex(comment => comment.id === rootCommentId)
+  const thread = commentData.value[threadIndex]
+  if (!thread) {
+    return
+  }
+
+  while (!findComment(thread, highlightedCommentId) && thread.hasReplyToken) {
+    const previousReplyCount = thread.replies.length
+    const previousReplyToken = replyTokens.get(thread.id)
+    await getCommentReplies(threadIndex)
+
+    if (thread.replies.length === previousReplyCount && replyTokens.get(thread.id) === previousReplyToken) {
+      break
+    }
+  }
+}
+
 /**
  * @param {boolean | undefined} more
  * @param {boolean} preserveSort
@@ -1037,17 +1130,18 @@ async function getCommentDataLocal(more = false, preserveSort = false) {
     let comments
     if (more) {
       comments = await nextPageToken.value.getContinuation()
-    } else if (localCommentsInstance) {
+    } else if (localCommentsInstance && !props.highlightedCommentId) {
       comments = await localCommentsInstance.applySort(sortNewest.value ? 'NEWEST_FIRST' : 'TOP_COMMENTS')
       localCommentsInstance = comments
     } else {
       if (props.isPostComments) {
         comments = await getLocalCommunityPostComments(props.id, props.postAuthorId)
       } else {
-        comments = await getLocalComments(props.id)
+        const sortBy = preserveSort ? (sortNewest.value ? 'NEWEST_FIRST' : 'TOP_COMMENTS') : undefined
+        comments = await getLocalComments(props.id, sortBy, getHighlightedRootCommentId() ?? undefined)
       }
 
-      if (preserveSort) {
+      if (preserveSort && (props.isPostComments || !props.highlightedCommentId)) {
         comments = await comments.applySort(sortNewest.value ? 'NEWEST_FIRST' : 'TOP_COMMENTS')
       } else {
         sortNewest.value = comments.header?.sort_menu?.sub_menu_items?.[1].selected ?? false
@@ -1058,9 +1152,11 @@ async function getCommentDataLocal(more = false, preserveSort = false) {
 
     setLocalCommentCount(comments)
 
-    const parsedComments = comments.contents
-      .map(commentThread => parseLocalCommentThread(commentThread, false))
-      .filter(Boolean)
+    const parsedComments = prioritizeHighlightedComment(
+      comments.contents
+        .map(commentThread => parseLocalCommentThread(commentThread, false))
+        .filter(Boolean)
+    )
 
     if (more) {
       commentData.value = commentData.value.concat(parsedComments)
@@ -1071,6 +1167,10 @@ async function getCommentDataLocal(more = false, preserveSort = false) {
     nextPageToken.value = comments.has_continuation ? comments : null
     isLoading.value = false
     showComments.value = true
+
+    if (!more) {
+      await loadHighlightedReply()
+    }
   } catch (err) {
     // region No comment detection
     // No comment related info when video info requested earlier in parent component
@@ -1090,7 +1190,7 @@ async function getCommentDataLocal(more = false, preserveSort = false) {
     console.error(err)
     const errorMessage = t('Local API Error (Click to copy)')
     showApiErrorToast(errorMessage, err)
-    if (backendFallback.value && backendPreference.value === 'local') {
+    if (backendFallback.value && (backendPreference.value === 'local' || props.highlightedCommentId)) {
       localCommentsInstance = undefined
       showToast({ message: t('Falling back to Invidious API'), icon: ['fas', 'exchange-alt'] })
       if (props.isPostComments) {
@@ -1231,6 +1331,7 @@ async function getCommentDataInvidious() {
 
       return comment
     })
+    comments = prioritizeHighlightedComment(comments)
 
     commentData.value = commentData.value.concat(comments)
     nextPageToken.value = response.continuation

--- a/src/renderer/components/TopNav/TopNav.vue
+++ b/src/renderer/components/TopNav/TopNav.vue
@@ -556,7 +556,7 @@ function goToSearch(queryText, { event, dataListIndex }) {
   store.dispatch('getYoutubeUrlInfo', queryText).then((result) => {
     switch (result.urlType) {
       case 'video': {
-        const { videoId, timestamp, playlistId, isShort } = result
+        const { videoId, timestamp, playlistId, commentId, isShort } = result
 
         const query = {}
         if (isShort) {
@@ -567,6 +567,9 @@ function goToSearch(queryText, { event, dataListIndex }) {
         }
         if (playlistId && playlistId.length > 0) {
           query.playlistId = playlistId
+        }
+        if (commentId) {
+          query.commentId = commentId
         }
 
         openInternalPath({

--- a/src/renderer/helpers/api/local.js
+++ b/src/renderer/helpers/api/local.js
@@ -688,10 +688,12 @@ export function parseLocalVideoCollaborators(videoInfo) {
 
 /**
  * @param {string} id
+ * @param {'TOP_COMMENTS' | 'NEWEST_FIRST' | undefined} sortBy
+ * @param {string | undefined} commentId
  */
-export async function getLocalComments(id) {
+export async function getLocalComments(id, sortBy = undefined, commentId = undefined) {
   const innertube = await createInnertube({ generateSessionLocally: false })
-  return innertube.getComments(id)
+  return innertube.getComments(id, sortBy, commentId)
 }
 
 /**

--- a/src/renderer/helpers/utils.js
+++ b/src/renderer/helpers/utils.js
@@ -797,7 +797,7 @@ export function showExternalPlayerUnsupportedActionToast(externalPlayer, action)
 export function getVideoParamsFromUrl(url) {
   /** @type {URL} */
   let urlObject
-  const paramsObject = { videoId: null, timestamp: null, playlistId: null, isShort: false }
+  const paramsObject = { videoId: null, timestamp: null, playlistId: null, commentId: null, isShort: false }
   try {
     urlObject = new URL(url)
   } catch {
@@ -806,6 +806,7 @@ export function getVideoParamsFromUrl(url) {
 
   function extractParams(videoId) {
     paramsObject.videoId = videoId
+    paramsObject.commentId = urlObject.searchParams.get('lc')
     let timestamp = urlObject.searchParams.get('t')
     if (timestamp && (timestamp.includes('h') || timestamp.includes('m') || timestamp.includes('s'))) {
       const { seconds, minutes, hours } = timestamp.match(/(?:(?<hours>(\d+))h)?(?:(?<minutes>(\d+))m)?(?:(?<seconds>(\d+))s)?/).groups

--- a/src/renderer/store/modules/utils.js
+++ b/src/renderer/store/modules/utils.js
@@ -433,13 +433,14 @@ const actions = {
       urlStr = `https://www.youtube.com/${urlStr}`
     }
 
-    const { videoId, timestamp, playlistId, isShort } = getVideoParamsFromUrl(urlStr)
+    const { videoId, timestamp, playlistId, commentId, isShort } = getVideoParamsFromUrl(urlStr)
     if (videoId) {
       return {
         urlType: 'video',
         videoId,
         playlistId,
         timestamp,
+        commentId,
         isShort
       }
     }

--- a/src/renderer/views/Watch/Watch.vue
+++ b/src/renderer/views/Watch/Watch.vue
@@ -958,6 +958,7 @@
           :channel-name="channelName"
           :comments-disabled="commentsDisabled"
           :fullscreen-overlay="fullscreenCommentsOpen || shortsCommentsOpen"
+          :highlighted-comment-id="tabRoute.query.commentId"
           @close-comments="closeFullscreenComments"
           @timestamp-event="changeTimestamp"
         />

--- a/static/locales/en-US.yaml
+++ b/static/locales/en-US.yaml
@@ -1678,6 +1678,8 @@ Comments:
   Subscribed: Subscribed
   Edited: (edited)
   Hearted: Hearted
+  Highlighted comment: Highlighted comment
+  Highlighted reply: Highlighted reply
   YouTube comment link copied to clipboard: YouTube comment link copied to clipboard
 
 Up Next: Up Next


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Make sure to follow the contributing guidelines. -->
<!-- Important note, we may remove your pull request if you do not use this provided PR template correctly. -->
<!-- Agent instructions: Preserve every heading, comment, and marker in this template. Never remove or rewrite the release-note-category:start/end, release-note:start/end, or release-note-image:start/end marker pairs. Never remove or rewrite the Release note images section; leave its contents for a human. -->

## Pull Request Type
<!-- Please select what type of pull request this is: [x] -->
- [ ] Bugfix
- [x] Feature Implementation
- [ ] Documentation
- [ ] Other

## Related issue
<!-- Please link the issue your pull request is referring to. -->
<!-- If this pull request fully resolves the relevant issue, put "closes" before the issue number. -->
<!-- Example: "closes #123456". -->

N/A

## Description
<!-- Please write a clear and concise description of what the pull request does. -->

Support opening YouTube video URLs that contain an `lc` comment target. Comment links now load automatically, keep pinned comments first, move the linked thread directly below them, and show a YouTube-style badge on the exact highlighted comment or reply.

Compound reply links focus the parent thread and load reply continuations until the linked reply is available. The target is preserved when pasting a URL, opening a clicked link, or launching the desktop app with a URL.

## Release note category
<!-- Select exactly one category. Every pull request must select one. -->
<!-- release-note-category:start -->
- [ ] Not noteworthy
- [ ] Highlights
- [x] More improvements
- [ ] Fixed bugs
<!-- release-note-category:end -->

## Release note
<!-- Required unless "Not noteworthy" is selected. -->
<!-- Write one concise, user-facing entry without a leading bullet. -->
<!-- release-note:start -->
YouTube comment links now show the linked comment or reply first with a highlighted badge.
<!-- release-note:end -->

## Release note images
<!-- Human-only: Agents must preserve this entire section and leave it empty. -->
<!-- Optional. Paste one or more Markdown images or HTML image tags here. -->
<!-- The release notes will use an HTML image tag and limit images taller than 300 pixels. -->
<!-- release-note-image:start -->
<img width="539" height="127" alt="image" src="https://github.com/user-attachments/assets/c4b903af-bf09-4dce-a7c5-86a0f5443c3c" />
<!-- release-note-image:end -->

## Testing
<!-- How can reviewers verify that the PR produces correct results? -->
<!-- Please provide instructions so that others can ensure that your pull request would produce correct results. For examples see, https://github.com/FreeTubeApp/FreeTube/pull/5743, https://github.com/FreeTubeApp/FreeTube/pull/7349, https://github.com/FreeTubeApp/FreeTube/pull/5125, https://github.com/FreeTubeApp/FreeTube/pull/7338 -->
<!-- Agent instructions: Only write human-facing steps that explain how to verify the change while running this branch in dev mode. Include expected results and, when applicable, helpful console snippets for interactive verification. Do not include automated checks, commands, results, pass counts, or CI status. -->

1. Paste `https://www.youtube.com/watch?v=jNQXAC9IVRw&lc=UgxZaBRFEKqDUoZULy94AaABAg` into the navigation bar. The linked comment should appear directly after pinned comments with a “Highlighted comment” badge.
2. Paste `https://www.youtube.com/watch?v=jNQXAC9IVRw&lc=UgzuC3zzpRZkjc5Qzsd4AaABAg.958xaQsh63D95AEkVnh_di`. The parent thread should appear after pinned comments, expand automatically, and show “Highlighted reply” on the exact reply.
3. Confirm the highlighted-reply badge does not add spacing between replies and that all thread indicator lines remain connected.

## Additional context
<!-- Add any other context about the pull request here. -->

The comments API accepts a root comment ID but does not return the body of a linked compound reply automatically, so reply links load the relevant thread continuations until the target reply is found.