### PR TITLE
fix(subscriptions): preserve reactive feed state

### DIFF
--- a/e2e/tests/offline/subscriptions-feed.spec.mjs
+++ b/e2e/tests/offline/subscriptions-feed.spec.mjs
@@ -188,6 +188,23 @@ test.describe('subscriptions feed from cache', () => {
   })
 })
 
+test.describe('subscriptions feed with a partially cached profile', () => {
+  test.use({
+    seed: {
+      ...seed,
+      subscriptionCache: [seed.subscriptionCache[0]]
+    }
+  })
+
+  test('keeps cached videos visible when automatic fetching is disabled', async ({ page }) => {
+    await goTo(page, 'subscriptions')
+
+    await expect(page.getByText('Video A newer')).toBeVisible()
+    await expect(page.getByText('Video A older')).toBeVisible()
+    await expect(page.getByText('Video B newest')).toHaveCount(0)
+  })
+})
+
 test.describe('subscriptions feed with upcoming premieres shown', () => {
   test.use({
     seed: {

--- a/e2e/tests/offline/subscriptions-refresh.spec.mjs
+++ b/e2e/tests/offline/subscriptions-refresh.spec.mjs
@@ -36,6 +36,19 @@ function rssFeed(index) {
 </feed>`
 }
 
+function rssFeedWithPreviousEntry(index) {
+  return rssFeed(index).replace('</feed>', `
+  <entry>
+    <yt:videoId>cached${index}</yt:videoId>
+    <title>Cached video ${index}</title>
+    <published>${new Date(now - 2 * HOUR).toISOString()}</published>
+    <media:group>
+      <media:statistics views="1000"/>
+    </media:group>
+  </entry>
+</feed>`)
+}
+
 function cachedChannel(index) {
   return {
     _id: channelId(index),
@@ -72,7 +85,7 @@ function profileWith(channelCount) {
 /**
  * @param {(index: number) => number} delayFor per channel response delay
  */
-async function routeFeeds(page, delayFor) {
+async function routeFeeds(page, delayFor, feedFor = rssFeed) {
   await page.route(/^https?:\/\//, (route) => route.abort())
 
   await page.route('**/feeds/videos.xml**', async (route, request) => {
@@ -87,7 +100,7 @@ async function routeFeeds(page, delayFor) {
     await route.fulfill({
       status: 200,
       contentType: 'application/xml',
-      body: rssFeed(index)
+      body: feedFor(index)
     }).catch(() => {})
   })
 }
@@ -205,6 +218,46 @@ test.describe('subscription feed refresh controls', () => {
     await page.locator('[data-subscription-feed-tab="shorts"]').click()
 
     await expect(page.getByRole('button', { name: 'Mark all as seen' })).toBeEnabled()
+  })
+
+  test('updates the Shorts feed immediately when all entries are marked as seen', async ({ page }) => {
+    await goTo(page, 'subscriptions')
+    await page.locator('[data-subscription-feed-tab="shorts"]').click()
+
+    const markAllAsSeen = page.getByRole('button', { name: 'Mark all as seen' })
+    await expect(markAllAsSeen).toBeVisible()
+    await markAllAsSeen.click()
+
+    await expect(page.locator('.newContentDot')).toHaveCount(0)
+    await expect(markAllAsSeen).toHaveCount(0)
+  })
+})
+
+test.describe('seen state after a subscription feed refresh', () => {
+  test.use({
+    seed: {
+      settings: {
+        ...commonSettings,
+        showNewSubscriptionFeedIndicators: true
+      },
+      profiles: [profileWith(1)],
+      subscriptionCache: [cachedChannel(0)]
+    }
+  })
+
+  test('updates the refreshed feed immediately when all entries are marked as seen', async ({ page }) => {
+    await routeFeeds(page, () => 0, rssFeedWithPreviousEntry)
+    await goTo(page, 'subscriptions')
+
+    await page.getByRole('button', { name: /Refresh Videos/ }).click()
+    await expect(page.getByText('Fresh video 0', { exact: true })).toBeVisible()
+
+    const markAllAsSeen = page.getByRole('button', { name: 'Mark all as seen' })
+    await expect(markAllAsSeen).toBeVisible()
+    await markAllAsSeen.click()
+
+    await expect(page.locator('.newContentDot')).toHaveCount(0)
+    await expect(markAllAsSeen).toHaveCount(0)
   })
 })
 

--- a/e2e/tests/offline/subscriptions-refresh.spec.mjs
+++ b/e2e/tests/offline/subscriptions-refresh.spec.mjs
@@ -68,6 +68,19 @@ function cachedChannel(index) {
   }
 }
 
+function cachedCollaboratorChannel(index) {
+  const channel = cachedChannel(index)
+  channel.videos[0] = {
+    ...channel.videos[0],
+    hasCollaborators: true,
+    collaborators: [
+      { id: channelId(index), name: `Channel ${index}`, thumbnail: '', subtitle: '' },
+      { id: 'UCcollaborator00000000000', name: 'Collaborator', thumbnail: '', subtitle: '' }
+    ]
+  }
+  return channel
+}
+
 function profileWith(channelCount) {
   return {
     _id: 'allChannels',
@@ -175,6 +188,29 @@ test.describe('incremental subscription feed refresh', () => {
 
     await expect(refreshToast).toBeVisible()
     await expect(refreshToast).toHaveCount(0, { timeout: 30_000 })
+  })
+})
+
+test.describe('subscription feed state during refresh', () => {
+  test.use({
+    seed: {
+      settings: commonSettings,
+      profiles: [profileWith(2)],
+      subscriptionCache: [cachedCollaboratorChannel(0), cachedChannel(1)]
+    }
+  })
+
+  test('keeps an open collaborators modal when refreshed videos reorder the feed', async ({ page }) => {
+    await routeFeeds(page, (index) => index === 0 ? 8_000 : 0)
+    await goTo(page, 'subscriptions')
+
+    const collaboratorVideo = page.locator('.ft-list-video').filter({ hasText: 'Cached video 0' })
+    await collaboratorVideo.getByRole('button', { name: 'Channel 0' }).click()
+    await expect(page.getByRole('heading', { name: 'Collaborators' })).toBeVisible()
+
+    await page.getByRole('button', { name: /Refresh Videos/ }).evaluate(button => button.click())
+    await expect(page.getByText('Fresh video 1', { exact: true })).toBeVisible({ timeout: 3_000 })
+    await expect(page.getByRole('heading', { name: 'Collaborators' })).toBeVisible()
   })
 })
 

--- a/src/renderer/components/SubscriptionsLive.vue
+++ b/src/renderer/components/SubscriptionsLive.vue
@@ -207,6 +207,7 @@ function loadVideosFromCacheSometimes() {
 
   // This method is called on view visible
   if (videoCacheForAllActiveProfileChannelsPresent.value) {
+    attemptedFetch.value = true
     loadVideosFromCacheForAllActiveProfileChannels()
     return
   }
@@ -217,10 +218,9 @@ function loadVideosFromCacheSometimes() {
     return
   }
 
-  // Auto fetch disabled, not enough cache for profile = show nothing
-  videoList.value = []
+  // Auto fetch disabled, show the cache that is available for the profile
   attemptedFetch.value = false
-  isLoading.value = false
+  loadVideosFromCacheForAllActiveProfileChannels()
 }
 
 function loadVideosFromCacheForAllActiveProfileChannels() {

--- a/src/renderer/components/SubscriptionsLive.vue
+++ b/src/renderer/components/SubscriptionsLive.vue
@@ -257,7 +257,7 @@ async function loadVideosForSubscriptionsFromRemote() {
       errorChannels: errorChannels.value
     })
     if (refreshedVideos !== null) {
-      videoList.value = refreshedVideos
+      loadVideosFromCacheForAllActiveProfileChannels()
       lastRemoteRefreshSuccessTimestamp.value = store.getters.getSubscriptionLiveLastRefreshTimestamp
     }
   } finally {

--- a/src/renderer/components/SubscriptionsPosts.vue
+++ b/src/renderer/components/SubscriptionsPosts.vue
@@ -223,9 +223,10 @@ function loadPostsFromCacheSometimes() {
 }
 
 function loadPostsFromCacheForAllActiveProfileChannels() {
-  const postList_ = cacheEntriesForAllActiveProfileChannels.value.flatMap((cacheEntry) => {
-    return cacheEntry.posts ?? []
-  })
+  const forbiddenTitles = store.getters.getForbiddenTitlesParsed
+  const postList_ = cacheEntriesForAllActiveProfileChannels.value
+    .flatMap(cacheEntry => cacheEntry.posts ?? [])
+    .filter(post => !forbiddenTitles.some(text => post.author.toLowerCase().includes(text)))
 
   postList_.sort((a, b) => {
     return b.publishedTime - a.publishedTime
@@ -260,7 +261,7 @@ async function loadPostsForSubscriptionsFromRemote() {
       errorChannels: errorChannels.value
     })
     if (refreshedPosts !== null) {
-      postList.value = refreshedPosts
+      loadPostsFromCacheForAllActiveProfileChannels()
       lastRemoteRefreshSuccessTimestamp.value = store.getters.getSubscriptionPostsLastRefreshTimestamp
     }
   } finally {

--- a/src/renderer/components/SubscriptionsPosts.vue
+++ b/src/renderer/components/SubscriptionsPosts.vue
@@ -206,6 +206,7 @@ function loadPostsFromCacheSometimes() {
 
   // This method is called on view visible
   if (postCacheForAllActiveProfileChannelsPresent.value) {
+    attemptedFetch.value = true
     loadPostsFromCacheForAllActiveProfileChannels()
     return
   }
@@ -216,10 +217,9 @@ function loadPostsFromCacheSometimes() {
     return
   }
 
-  // Auto fetch disabled, not enough cache for profile = show nothing
-  postList.value = []
+  // Auto fetch disabled, show the cache that is available for the profile
   attemptedFetch.value = false
-  isLoading.value = false
+  loadPostsFromCacheForAllActiveProfileChannels()
 }
 
 function loadPostsFromCacheForAllActiveProfileChannels() {

--- a/src/renderer/components/SubscriptionsShorts.vue
+++ b/src/renderer/components/SubscriptionsShorts.vue
@@ -2,7 +2,7 @@
   <SubscriptionsTabUi
     ref="tabUi"
     :is-loading="isLoading"
-    :video-list="videoList"
+    :video-list="shortsList"
     :error-channels="errorChannels"
     :attempted-fetch="attemptedFetch"
     :youtube-style-shorts="useCustomShortsPlayer"
@@ -32,6 +32,7 @@ const tabUi = useTemplateRef('tabUi')
 
 const isLoading = ref(true)
 const videoList = shallowRef([])
+const shortsList = computed(() => videoList.value.map(video => ({ ...video, isShort: true })))
 const errorChannels = ref([])
 const attemptedFetch = ref(false)
 const useCustomShortsPlayer = computed(() => store.getters.getUseCustomShortsPlayer)
@@ -230,7 +231,6 @@ function loadVideosFromCacheForAllActiveProfileChannels() {
   })
 
   videoList.value = updateVideoListAfterProcessing(videoList_)
-    .map(video => ({ ...video, isShort: true }))
   isLoading.value = false
 }
 
@@ -259,7 +259,7 @@ async function loadVideosForSubscriptionsFromRemote() {
       errorChannels: errorChannels.value
     })
     if (refreshedVideos !== null) {
-      videoList.value = refreshedVideos.map(video => ({ ...video, isShort: true }))
+      loadVideosFromCacheForAllActiveProfileChannels()
       lastRemoteRefreshSuccessTimestamp.value = store.getters.getSubscriptionShortsLastRefreshTimestamp
     }
   } finally {

--- a/src/renderer/components/SubscriptionsShorts.vue
+++ b/src/renderer/components/SubscriptionsShorts.vue
@@ -209,6 +209,7 @@ function loadVideosFromCacheSometimes() {
 
   // This method is called on view visible
   if (videoCacheForAllActiveProfileChannelsPresent.value) {
+    attemptedFetch.value = true
     loadVideosFromCacheForAllActiveProfileChannels()
     return
   }
@@ -219,10 +220,9 @@ function loadVideosFromCacheSometimes() {
     return
   }
 
-  // Auto fetch disabled, not enough cache for profile = show nothing
-  videoList.value = []
+  // Auto fetch disabled, show the cache that is available for the profile
   attemptedFetch.value = false
-  isLoading.value = false
+  loadVideosFromCacheForAllActiveProfileChannels()
 }
 
 function loadVideosFromCacheForAllActiveProfileChannels() {

--- a/src/renderer/components/SubscriptionsTabUi/SubscriptionsTabUi.vue
+++ b/src/renderer/components/SubscriptionsTabUi/SubscriptionsTabUi.vue
@@ -138,7 +138,7 @@ const props = defineProps({
   },
   stableItemKeys: {
     type: Boolean,
-    default: false
+    default: true
   },
   hasAdditionalContent: {
     type: Boolean,

--- a/src/renderer/components/SubscriptionsVideos.vue
+++ b/src/renderer/components/SubscriptionsVideos.vue
@@ -256,6 +256,7 @@ function loadVideosFromCacheSometimes() {
 
   // This method is called on view visible
   if (videoCacheForAllActiveProfileChannelsPresent.value) {
+    attemptedFetch.value = true
     loadVideosFromCacheForAllActiveProfileChannels()
     return
   }
@@ -266,10 +267,9 @@ function loadVideosFromCacheSometimes() {
     return
   }
 
-  // Auto fetch disabled, not enough cache for profile = show nothing
-  videoList.value = []
+  // Auto fetch disabled, show the cache that is available for the profile
   attemptedFetch.value = false
-  isLoading.value = false
+  loadVideosFromCacheForAllActiveProfileChannels()
 }
 
 function loadVideosFromCacheForAllActiveProfileChannels() {

--- a/src/renderer/components/SubscriptionsVideos.vue
+++ b/src/renderer/components/SubscriptionsVideos.vue
@@ -306,7 +306,7 @@ async function loadVideosForSubscriptionsFromRemote() {
       errorChannels: errorChannels.value
     })
     if (refreshedVideos !== null) {
-      videoList.value = refreshedVideos
+      loadVideosFromCacheForAllActiveProfileChannels()
       lastRemoteRefreshSuccessTimestamp.value = store.getters.getSubscriptionFeedLastRefreshTimestamp
     }
   } finally {


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Make sure to follow the contributing guidelines. -->
<!-- Important note, we may remove your pull request if you do not use this provided PR template correctly. -->
<!-- Agent instructions: Preserve every heading, comment, and marker in this template. Never remove or rewrite the release-note-category:start/end, release-note:start/end, or release-note-image:start/end marker pairs. Never remove or rewrite the Release note images section; leave its contents for a human. -->

## Pull Request Type
<!-- Please select what type of pull request this is: [x] -->
- [x] Bugfix
- [ ] Feature Implementation
- [ ] Documentation
- [ ] Other

## Related issue
<!-- Please link the issue your pull request is referring to. -->
<!-- If this pull request fully resolves the relevant issue, put "closes" before the issue number. -->
<!-- Example: "closes #123456". -->

Reported in a comment on #527.

## Description
<!-- Please write a clear and concise description of what the pull request does. -->

Subscription tabs retained detached refresh results, and Shorts additionally copied cached entries before rendering them. Marking entries as seen updated the database and Vuex cache, but those displayed objects did not react until the page was reloaded.

Completed refreshes now render from the reactive cache and Shorts-only display metadata is derived reactively, so Videos, Shorts, Live, and Community update immediately. Community cache reconstruction preserves its forbidden-title filtering.

The subscription feeds also:
- retain available cached entries when a newly subscribed channel has not been fetched and automatic fetching is disabled;
- distinguish a completed empty fetch from a feed that has not been fetched yet, including after switching tabs;
- use stable item keys so a refresh that reorders entries does not close an open collaborators modal.

Regression coverage exercises seen state for cached Shorts and freshly refreshed Videos, partially cached profiles, and collaborator modals during feed reordering.

## Release note category
<!-- Select exactly one category. Every pull request must select one. -->
<!-- Select "Not noteworthy" when the pull request fixes a bug in or improves functionality that has not yet appeared in a stable release. -->
<!-- release-note-category:start -->
- [ ] Not noteworthy
- [ ] Highlights
- [ ] More improvements
- [x] Fixed bugs
<!-- release-note-category:end -->

## Release note
<!-- Required unless "Not noteworthy" is selected. -->
<!-- Write one concise, user-facing entry without a leading bullet. -->
<!-- release-note:start -->
Fixed subscription feeds losing cached entries, resetting open collaborator dialogs, showing stale refresh prompts, and not immediately clearing new-content indicators.
<!-- release-note:end -->

## Release note images
<!-- Human-only: Agents must preserve this entire section and leave it empty. -->
<!-- Optional. Paste one or more Markdown images or HTML image tags here. -->
<!-- The release notes will use an HTML image tag and limit images taller than 300 pixels. -->
<!-- release-note-image:start -->

<!-- release-note-image:end -->

## Testing
<!-- How can reviewers verify that the PR produces correct results? -->
<!-- Please provide instructions so that others can ensure that your pull request would produce correct results. For examples see, https://github.com/FreeTubeApp/FreeTube/pull/5743, https://github.com/FreeTubeApp/FreeTube/pull/7349, https://github.com/FreeTubeApp/FreeTube/pull/5125, https://github.com/FreeTubeApp/FreeTube/pull/7338 -->
<!-- Agent instructions: Only write human-facing steps that explain how to verify the change while running this branch in dev mode. Include expected results and, when applicable, helpful console snippets for interactive verification. Do not include automated checks, commands, results, pass counts, or CI status. -->

1. Subscribe to a channel that is not yet present in the subscription cache while startup and automatic feed fetching are disabled.
2. Open Subscriptions and confirm previously cached entries remain visible; confirm the new channel appears after the next manual fetch.
3. Open a feed with no matching content after it has been fetched, switch to another feed tab and back, and confirm the empty-feed message remains instead of asking for a refresh again.
4. Open the collaborators modal from a subscription entry, refresh the feed so entries reorder, and confirm the modal remains open.
5. Refresh the Shorts feed, select "Mark all as seen", and confirm that the new-content dots and button disappear immediately without reloading the page.
6. Repeat the seen-state check with Videos, Live, and Community tabs when they contain new entries.

## Additional context
<!-- Add any other context about the pull request here. -->

The affected subscription feed and refresh E2E suites and targeted lint checks pass locally.