### PR TITLE
Preserve playlist thumbnail aspect ratios

### DIFF
--- a/e2e/tests/offline/playlists.spec.mjs
+++ b/e2e/tests/offline/playlists.spec.mjs
@@ -80,6 +80,22 @@ test.describe('seeded playlists', () => {
     await expect(page.getByText('Upcoming seeded premiere')).toBeVisible()
   })
 
+  test('playlist artwork keeps its native aspect ratio', async ({ page }) => {
+    await goTo(page, 'userplaylists')
+    await page.getByText('My seeded playlist').click()
+
+    const thumbnail = page.locator('.playlistThumbnail img')
+    await page.addStyleTag({ content: '.playlistThumbnail { display: block !important; }' })
+    await thumbnail.evaluate((image) => {
+      image.src = 'data:image/svg+xml,<svg xmlns="http://www.w3.org/2000/svg" width="120" height="120"/>'
+    })
+    await expect(thumbnail).toBeVisible()
+    await expect(thumbnail).toHaveJSProperty('complete', true)
+
+    const bounds = await thumbnail.boundingBox()
+    expect(bounds.width).toBe(bounds.height)
+  })
+
   test('keeps the playlist title when switching tabs', async ({ page }) => {
     await goTo(page, 'userplaylists')
     await page.getByText('My seeded playlist').click()

--- a/src/renderer/components/PlaylistInfo/PlaylistInfo.scss
+++ b/src/renderer/components/PlaylistInfo/PlaylistInfo.scss
@@ -4,8 +4,6 @@
 
 .playlistThumbnail img {
   inline-size: 100%;
-  // Ensure placeholder image displayed at same aspect ratio as most other images
-  aspect-ratio: 16/9;
 
   @media only screen and (width <= 800px) {
     display: none;


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Make sure to follow the contributing guidelines. -->
<!-- Important note, we may remove your pull request if you do not use this provided PR template correctly. -->
<!-- Agent instructions: Preserve every heading, comment, and marker in this template. Never remove or rewrite the release-note-category:start/end, release-note:start/end, or release-note-image:start/end marker pairs. Never remove or rewrite the Release note images section; leave its contents for a human. -->

## Pull Request Type
<!-- Please select what type of pull request this is: [x] -->
- [x] Bugfix
- [ ] Feature Implementation
- [ ] Documentation
- [ ] Other

## Related issue
<!-- Please link the issue your pull request is referring to. -->
<!-- If this pull request fully resolves the relevant issue, put "closes" before the issue number. -->
<!-- Example: "closes #123456". -->

## Description
<!-- Please write a clear and concise description of what the pull request does. -->
Preserves the intrinsic aspect ratio of playlist artwork in the playlist header. The image was previously forced to 16:9, which stretched square artwork supplied by YouTube. The existing placeholder remains 16:9 through its intrinsic dimensions.

Adds a regression test with self-contained square artwork.

## Release note category
<!-- Select exactly one category. Every pull request must select one. -->
<!-- Select "Not noteworthy" when the pull request fixes a bug in or improves functionality that has not yet appeared in a stable release. -->
<!-- release-note-category:start -->
- [ ] Not noteworthy
- [ ] Highlights
- [ ] More improvements
- [x] Fixed bugs
<!-- release-note-category:end -->

## Release note
<!-- Required unless "Not noteworthy" is selected. -->
<!-- Write one concise, user-facing entry without a leading bullet. -->
<!-- release-note:start -->
Playlist artwork is no longer stretched to a 16:9 aspect ratio.
<!-- release-note:end -->

## Release note images
<!-- Human-only: Agents must preserve this entire section and leave it empty. -->
<!-- Optional. Paste one or more Markdown images or HTML image tags here. -->
<!-- The release notes will use an HTML image tag and limit images taller than 300 pixels. -->
<!-- release-note-image:start -->

<!-- release-note-image:end -->

## Testing
<!-- How can reviewers verify that the PR produces correct results? -->
<!-- Please provide instructions so that others can ensure that your pull request would produce correct results. For examples see, https://github.com/FreeTubeApp/FreeTube/pull/5743, https://github.com/FreeTubeApp/FreeTube/pull/7349, https://github.com/FreeTubeApp/FreeTube/pull/5125, https://github.com/FreeTubeApp/FreeTube/pull/7338 -->
<!-- Agent instructions: Only write human-facing steps that explain how to verify the change while running this branch in dev mode. Include expected results and, when applicable, helpful console snippets for interactive verification. Do not include automated checks, commands, results, pass counts, or CI status. -->
1. Run the app in dev mode and use the list layout for playlists.
2. Open a playlist whose supplied artwork is square.
3. Verify that the header artwork remains square and is not stretched horizontally.
4. Hide thumbnails in the settings and verify that the placeholder keeps its usual 16:9 dimensions.

## Additional context
<!-- Add any other context about the pull request here. -->
The playlist header width remains unchanged; only the image's forced aspect ratio is removed.