### PR TITLE
fix(i18n): pluralize counts using each language's own rules

### DIFF
--- a/src/renderer/i18n/index.js
+++ b/src/renderer/i18n/index.js
@@ -1,6 +1,7 @@
 import { createI18n } from 'vue-i18n'
 import { ref } from 'vue'
 import { createWebURL } from '../helpers/utils'
+import { createPluralRules } from './plurals'
 // List of locales approved for use
 import activeLocales from '../../../static/locales/activeLocales.json'
 
@@ -22,7 +23,8 @@ const i18n = createI18n({
     'pt-PT': ['pt'],
     // any -> en-US
     default: ['en-US'],
-  }
+  },
+  pluralRules: createPluralRules(activeLocales)
 })
 
 export async function loadLocale(locale) {

--- a/src/renderer/i18n/plurals.js
+++ b/src/renderer/i18n/plurals.js
@@ -13,10 +13,26 @@ const PLURAL_CATEGORY_ORDER = ['zero', 'one', 'two', 'few', 'many', 'other']
 
 // Categories are collected by sampling instead of using
 // `resolvedOptions().pluralCategories`, because that also reports categories
-// that only apply to fractions, which never occur in our counts. Numbers above
-// this range can still resolve to a category that isn't in the sample (French
-// uses "many" for whole millions), which falls back to the built-in rule.
-const PLURAL_CATEGORY_SAMPLE_SIZE = 200
+// that only apply to fractions, which never occur in our counts.
+const PLURAL_CATEGORY_SAMPLES = (() => {
+  const samples = []
+
+  // Every rule that groups small numbers is covered well before 200, e.g. Welsh
+  // has a category that only applies to 6.
+  for (let count = 0; count <= 200; count++) {
+    samples.push(count)
+  }
+
+  // Some languages also have a category for large round numbers, e.g. French,
+  // Spanish, Italian, Portuguese and Breton use "many" for whole millions.
+  for (let exponent = 3; exponent <= 9; exponent++) {
+    const power = 10 ** exponent
+
+    samples.push(power, power * 2, power * 3)
+  }
+
+  return samples
+})()
 
 /**
  * The plural categories a locale uses for the counts we display, in the order translations write them.
@@ -25,11 +41,7 @@ const PLURAL_CATEGORY_SAMPLE_SIZE = 200
  */
 function getPluralCategories(locale) {
   const pluralRules = new Intl.PluralRules(locale)
-  const categories = new Set()
-
-  for (let count = 0; count <= PLURAL_CATEGORY_SAMPLE_SIZE; count++) {
-    categories.add(pluralRules.select(count))
-  }
+  const categories = new Set(PLURAL_CATEGORY_SAMPLES.map(count => pluralRules.select(count)))
 
   return PLURAL_CATEGORY_ORDER.filter(category => categories.has(category))
 }

--- a/src/renderer/i18n/plurals.js
+++ b/src/renderer/i18n/plurals.js
@@ -1,0 +1,74 @@
+// vue-i18n only knows two built-in pluralization patterns: "singular | plural"
+// and "zero | singular | plural". Neither fits languages that group numbers
+// differently, e.g. Polish needs "1 komentarz | 2 komentarze | 5 komentarzy",
+// where the second form also covers 22 and 23, but not 12 and 13.
+//
+// Intl.PluralRules knows the correct grouping for every locale, so we use it to
+// pick the form whenever a translation provides exactly one form per plural
+// category. Translations that provide a different number of forms keep using
+// vue-i18n's built-in rule, so partially updated locales are unaffected.
+
+// The order translations are written in, as used by CLDR and Weblate.
+const PLURAL_CATEGORY_ORDER = ['zero', 'one', 'two', 'few', 'many', 'other']
+
+// Categories are collected by sampling instead of using
+// `resolvedOptions().pluralCategories`, because that also reports categories
+// that only apply to fractions, which never occur in our counts. Numbers above
+// this range can still resolve to a category that isn't in the sample (French
+// uses "many" for whole millions), which falls back to the built-in rule.
+const PLURAL_CATEGORY_SAMPLE_SIZE = 200
+
+/**
+ * The plural categories a locale uses for the counts we display, in the order translations write them.
+ * @param {string} locale
+ * @returns {string[]}
+ */
+function getPluralCategories(locale) {
+  const pluralRules = new Intl.PluralRules(locale)
+  const categories = new Set()
+
+  for (let count = 0; count <= PLURAL_CATEGORY_SAMPLE_SIZE; count++) {
+    categories.add(pluralRules.select(count))
+  }
+
+  return PLURAL_CATEGORY_ORDER.filter(category => categories.has(category))
+}
+
+/**
+ * @param {string} locale
+ * @returns {import('vue-i18n').PluralizationRule}
+ */
+function createPluralRule(locale) {
+  const pluralRules = new Intl.PluralRules(locale)
+  const categories = getPluralCategories(locale)
+
+  return (choice, choicesLength, defaultRule) => {
+    // Only translations that cover every category can be mapped reliably.
+    if (choicesLength !== categories.length) {
+      return defaultRule(choice, choicesLength)
+    }
+
+    const index = categories.indexOf(pluralRules.select(Math.abs(choice)))
+
+    return index === -1 ? defaultRule(choice, choicesLength) : index
+  }
+}
+
+/**
+ * @param {string[]} locales
+ * @returns {Record<string, import('vue-i18n').PluralizationRule>}
+ */
+export function createPluralRules(locales) {
+  const rules = {}
+
+  for (const locale of locales) {
+    try {
+      rules[locale] = createPluralRule(locale)
+    } catch (error) {
+      // Intl doesn't recognise the locale, so vue-i18n's built-in rule is used.
+      console.error(`Unable to create plural rules for locale: "${locale}"`, error)
+    }
+  }
+
+  return rules
+}

--- a/static/locales/en-US.yaml
+++ b/static/locales/en-US.yaml
@@ -1824,7 +1824,6 @@ Shuffle is now enabled: Shuffle is now enabled
 The playlist has been reversed: The playlist has been reversed
 Playing Next Video: Playing Next Video
 Playing Previous Video: Playing Previous Video
-Playing Next Video Interval: Playing next video in no time. Click to cancel. | Playing next video in {nextVideoInterval} second. Click to cancel. | Playing next video in {nextVideoInterval} seconds. Click to cancel.
 Canceled next video autoplay: Canceled next video autoplay
 Autoplay Interruption Timer: Autoplay canceled due to {autoplayInterruptionIntervalHours} hours of inactivity
 

--- a/tests/unit/locale-plurals.test.mjs
+++ b/tests/unit/locale-plurals.test.mjs
@@ -4,6 +4,8 @@ import test from 'node:test'
 
 import { load as loadYaml } from 'js-yaml'
 
+import { createPluralRules } from '../../src/renderer/i18n/plurals.js'
+
 const localeUrl = new URL('../../static/locales/en-US.yaml', import.meta.url)
 const sourceDirUrl = new URL('../../src/', import.meta.url)
 
@@ -103,7 +105,10 @@ test('plural messages declare a singular and a plural form', () => {
   for (const path of pluralPaths) {
     const forms = path.split('.').reduce((messages, key) => messages[key], locale).split(' | ')
 
-    assert.ok(forms.length >= 2, `${path} must declare at least two plural forms`)
+    // English groups numbers as "one" and "other", so a third form would only
+    // ever be reachable through vue-i18n's built-in "zero | singular | plural"
+    // rule, which the translated locales can't express.
+    assert.equal(forms.length, 2, `${path} must declare exactly two plural forms`)
 
     for (const form of forms) {
       assert.notEqual(form.trim(), '', `${path} must not declare an empty plural form`)
@@ -130,5 +135,87 @@ test('plural messages are translated with a plural choice', async () => {
         `${file.pathname}: "${path}" has plural forms, so it needs a count as the third argument of t()`
       )
     }
+  }
+})
+
+/** vue-i18n's built-in rule, which our rules fall back to. */
+const builtInRule = (choice, choicesLength) => {
+  choice = Math.abs(choice)
+
+  return choicesLength === 2 ? (choice === 1 ? 0 : 1) : Math.min(choice, 2)
+}
+
+/**
+ * @param {string} locale
+ * @param {number} choicesLength
+ * @param {number[]} counts
+ * @returns {number[]}
+ */
+function selectForms(locale, choicesLength, counts) {
+  const rule = createPluralRules([locale])[locale]
+
+  return counts.map(count => rule(count, choicesLength, builtInRule))
+}
+
+test('plural rules pick the form each language groups the count under', () => {
+  const counts = [1, 2, 3, 4, 5, 11, 12, 21, 22, 25, 112]
+
+  // 1 komentarz | 2 komentarze | 5 komentarzy, where "few" also covers 22 but not 12
+  assert.deepEqual(
+    selectForms('pl', 3, counts),
+    [0, 1, 1, 1, 2, 2, 2, 2, 1, 2, 2]
+  )
+
+  // Russian additionally groups 21 and 101 with 1
+  assert.deepEqual(
+    selectForms('ru', 3, counts),
+    [0, 1, 1, 1, 2, 2, 2, 0, 1, 2, 2]
+  )
+
+  // Slovenian has a dedicated form for 2
+  assert.deepEqual(
+    selectForms('sl', 4, counts),
+    [0, 1, 2, 2, 3, 3, 3, 3, 3, 3, 3]
+  )
+
+  // Japanese doesn't inflect for number at all
+  assert.deepEqual(
+    selectForms('ja', 1, counts),
+    counts.map(() => 0)
+  )
+
+  // English is unchanged: singular for 1, plural for everything else
+  assert.deepEqual(
+    selectForms('en-US', 2, [0, ...counts]),
+    [1, 0, ...counts.slice(1).map(() => 1)]
+  )
+})
+
+test('plural rules fall back when a translation does not cover every form', () => {
+  const counts = [0, 1, 2, 5, 22]
+  const fallback = counts.map(count => builtInRule(count, 2))
+
+  // Polish and Arabic translations that only provide a singular and a plural
+  // keep behaving the way they did before the rules were introduced.
+  assert.deepEqual(selectForms('pl', 2, counts), fallback)
+  assert.deepEqual(selectForms('ar', 2, counts), fallback)
+
+  // As do messages that still use vue-i18n's "zero | singular | plural" rule.
+  assert.deepEqual(
+    selectForms('en-US', 3, [0, 1, 2, 5]),
+    [0, 1, 2, 2]
+  )
+})
+
+test('every active locale gets a plural rule', async () => {
+  const activeLocales = JSON.parse(await readFile(
+    new URL('../../static/locales/activeLocales.json', import.meta.url),
+    'utf8'
+  ))
+
+  const rules = createPluralRules(activeLocales)
+
+  for (const activeLocale of activeLocales) {
+    assert.equal(typeof rules[activeLocale], 'function', `${activeLocale} must have a plural rule`)
   }
 })

--- a/tests/unit/locale-plurals.test.mjs
+++ b/tests/unit/locale-plurals.test.mjs
@@ -191,6 +191,21 @@ test('plural rules pick the form each language groups the count under', () => {
   )
 })
 
+test('plural rules cover categories that only apply to large round numbers', () => {
+  // French, and likewise Spanish, Italian, Portuguese and Breton, has a form
+  // for whole millions on top of its singular and plural.
+  assert.deepEqual(
+    selectForms('fr', 3, [0, 1, 2, 1000, 999999, 1000000, 2000000]),
+    [0, 0, 2, 2, 2, 1, 1]
+  )
+
+  // Languages whose forms all apply to small numbers are unaffected.
+  assert.deepEqual(
+    selectForms('pl', 3, [1, 2, 5, 1000000]),
+    [0, 1, 2, 2]
+  )
+})
+
 test('plural rules fall back when a translation does not cover every form', () => {
   const counts = [0, 1, 2, 5, 22]
   const fallback = counts.map(count => builtInRule(count, 2))


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Make sure to follow the contributing guidelines. -->
<!-- Important note, we may remove your pull request if you do not use this provided PR template correctly. -->
<!-- Agent instructions: Preserve every heading, comment, and marker in this template. Never remove or rewrite the release-note-category:start/end, release-note:start/end, or release-note-image:start/end marker pairs. Never remove or rewrite the Release note images section; leave its contents for a human. -->

## Pull Request Type
<!-- Please select what type of pull request this is: [x] -->
- [x] Bugfix
- [ ] Feature Implementation
- [ ] Documentation
- [ ] Other

## Related issue
<!-- Please link the issue your pull request is referring to. -->
<!-- If this pull request fully resolves the relevant issue, put "closes" before the issue number. -->
<!-- Example: "closes #123456". -->

Follow-up to #589, prompted by a question from the Polish translator.

## Description
<!-- Please write a clear and concise description of what the pull request does. -->

vue-i18n only knows two pluralization patterns: `singular | plural`, and `zero | singular | plural` when three forms are given. Neither fits languages that group numbers differently. Polish, for example, needs three forms:

- 1 komentarz
- 2 komentarze, and the same form for 22, 23, 24
- 5 komentarzy, and the same form for 12, 13, 25, 112

There was no way for a translator to express that, so Slavic locales have been working around it with bracketed endings such as `{count} film(y/ów)`.

This derives the rules from `Intl.PluralRules`, which already knows the grouping for every language we ship, and registers them with vue-i18n. A translation can then simply provide one form per group, in the usual CLDR order, and the right one is picked.

The rule only applies when a translation provides exactly one form per group. Anything else falls back to vue-i18n's built-in rule, so the many locales that currently provide two forms behave exactly as they do today and can be migrated one string at a time. English is unaffected either way, since it has just the two groups.

The unused `Playing Next Video Interval` message is dropped in the same change. It is the only string written for the built-in `zero | singular | plural` rule, which is not a thing the translated locales can express, and nothing has referenced it since the autoplay countdown moved into its own component.

One nice side effect: the Croatian translation of `Video(s) added to {playlistCount} playlists` already provides three forms, which the built-in rule currently reads as `zero | singular | plural`, so it shows the wrong form for a count of 1. It now resolves correctly without touching the translation.

## Release note category
<!-- Select exactly one category. Every pull request must select one. -->
<!-- release-note-category:start -->
- [x] Not noteworthy
- [ ] Highlights
- [ ] More improvements
- [ ] Fixed bugs
<!-- release-note-category:end -->

## Release note
<!-- Required unless "Not noteworthy" is selected. -->
<!-- Write one concise, user-facing entry without a leading bullet. -->
<!-- release-note:start -->
Counts are now pluralized using each language's own rules, so languages such as Polish and Russian can use all of their plural forms
<!-- release-note:end -->

## Release note images
<!-- Human-only: Agents must preserve this entire section and leave it empty. -->
<!-- Optional. Paste one or more Markdown images or HTML image tags here. -->
<!-- The release notes will use an HTML image tag and limit images taller than 300 pixels. -->
<!-- release-note-image:start -->

<!-- release-note-image:end -->

## Testing
<!-- How can reviewers verify that the PR produces correct results? -->
<!-- Please provide instructions so that others can ensure that your pull request would produce correct results. For examples see, https://github.com/FreeTubeApp/FreeTube/pull/5743, https://github.com/FreeTubeApp/FreeTube/pull/7349, https://github.com/FreeTubeApp/FreeTube/pull/5125, https://github.com/FreeTubeApp/FreeTube/pull/7338 -->
<!-- Agent instructions: Only write human-facing steps that explain how to verify the change while running this branch in dev mode. Include expected results and, when applicable, helpful console snippets for interactive verification. Do not include automated checks, commands, results, pass counts, or CI status. -->

Run the app in dev mode and set the interface language to Polish.

1. Open `static/locales/pl.yaml` and give a count message three forms, for example replace the `Comments.Comment Count` entry with:

   ```yaml
   Comment Count: '{count} Komentarz | {count} Komentarze | {count} Komentarzy'
   ```

2. Open videos with different comment counts and check the heading above the comments. Expected: 1 Komentarz, 2 Komentarze, 4 Komentarze, 5 Komentarzy, 12 Komentarzy, 22 Komentarze, 25 Komentarzy.
3. Leave another count message with its current two forms, for example `Global.Counts.Video Count`, and confirm it still reads the way it does on development, singular for 1 and the second form for everything else.
4. Switch to English and confirm comment counts, view counts and the other counts are unchanged.

Russian is worth a look too, since it groups 21 and 101 with 1 rather than with the larger numbers.

## Additional context
<!-- Add any other context about the pull request here. -->

Translators can now migrate a string at a time. The forms are written in the order used by CLDR and Weblate, which for Polish and Russian is one, few, many, and for Czech, Slovak and Croatian is one, few, other. Slovenian has four, and Japanese, Chinese and Korean need only one.
