### PR TITLE
Confirm and speed up closing multiple tabs at once

### DIFF
--- a/e2e/tests/offline/tabs.spec.mjs
+++ b/e2e/tests/offline/tabs.spec.mjs
@@ -284,6 +284,93 @@ test.describe('tab bar', () => {
     await expect(tabs).toHaveAttribute('data-tab-id', unselectedId)
   })
 
+  test('confirms before closing several selected tabs at once', async ({ page }) => {
+    for (let index = 0; index < 5; index++) {
+      await page.locator(sel.newTabButton).click()
+    }
+    const tabs = page.locator(sel.tabs)
+    await expect(tabs).toHaveCount(6)
+
+    await tabs.first().click()
+    for (let index = 1; index < 5; index++) {
+      await tabs.nth(index).click({ modifiers: ['Control'] })
+    }
+
+    await page.keyboard.press('Control+w')
+    const prompt = page.locator('.prompt')
+    await expect(prompt).toBeVisible()
+    await expect(prompt).toContainText('5')
+
+    await prompt.getByRole('button', { name: 'Cancel' }).click()
+    await expect(prompt).toHaveCount(0)
+    await expect(tabs).toHaveCount(6)
+
+    await page.keyboard.press('Control+w')
+    await expect(prompt).toBeVisible()
+    await prompt.getByRole('button', { name: /Close/ }).click()
+    await expect(tabs).toHaveCount(1)
+  })
+
+  test('does not confirm when closing fewer tabs than the threshold', async ({ page }) => {
+    await page.locator(sel.newTabButton).click()
+    await page.locator(sel.newTabButton).click()
+    const tabs = page.locator(sel.tabs)
+    await expect(tabs).toHaveCount(3)
+
+    await tabs.first().click()
+    await tabs.nth(1).click({ modifiers: ['Control'] })
+
+    await page.keyboard.press('Control+w')
+    await expect(tabs).toHaveCount(1)
+    await expect(page.locator('.prompt')).toHaveCount(0)
+  })
+
+  test('closes several tabs in one state update', async ({ page }) => {
+    await page.locator(sel.newTabButton).click()
+    await page.locator(sel.newTabButton).click()
+    await page.locator(sel.newTabButton).click()
+    await expect(page.locator(sel.tabs)).toHaveCount(4)
+
+    // The first tab stays active, so no tab that is about to be closed has to
+    // be presented (and mounted) on the way out. A tab that is still presented
+    // while it closes is kept alive until its replacement paints, which is a
+    // second state update by design.
+    await page.locator(sel.tabs).first().click()
+    await expect(page.locator(sel.tabs).first()).toHaveClass(/active/)
+    await expect.poll(async () => {
+      const state = await page.evaluate(() => window.ftElectron.tabs.getState())
+      return state.presentedTabId === state.tabs[0].id
+    }).toBe(true)
+
+    const tabCounts = await page.evaluate(async () => {
+      const initialState = await window.ftElectron.tabs.getState()
+      const closingIds = initialState.tabs.slice(1).map(tab => tab.id)
+
+      return await new Promise((resolve, reject) => {
+        const counts = []
+        const timeoutId = window.setTimeout(() => {
+          removeListener()
+          reject(new Error('Timed out waiting for the tabs to close'))
+        }, 5000)
+        const removeListener = window.ftElectron.tabs.onStateUpdated((state) => {
+          if (state.tabs.length === initialState.tabs.length) return
+
+          counts.push(state.tabs.length)
+          if (state.tabs.length === 1) {
+            window.clearTimeout(timeoutId)
+            removeListener()
+            resolve(counts)
+          }
+        })
+
+        window.ftElectron.tabs.closeMultiple(closingIds)
+      })
+    })
+
+    expect(tabCounts).toEqual([1])
+    await expect(page.locator(sel.tabs)).toHaveCount(1)
+  })
+
   test('applies a complete tab reorder in one state update', async ({ page }) => {
     await page.locator(sel.newTabButton).click()
     await page.locator(sel.newTabButton).click()

--- a/e2e/tests/offline/tabs.spec.mjs
+++ b/e2e/tests/offline/tabs.spec.mjs
@@ -307,7 +307,7 @@ test.describe('tab bar', () => {
 
     await page.keyboard.press('Control+w')
     await expect(prompt).toBeVisible()
-    await prompt.getByRole('button', { name: /Close/ }).click()
+    await prompt.getByRole('button', { name: 'Close 5 Tabs', exact: true }).click()
     await expect(tabs).toHaveCount(1)
   })
 

--- a/src/constants.js
+++ b/src/constants.js
@@ -33,6 +33,7 @@ const IpcChannels = {
   TABS_APPLY_SYNC_SESSIONS: 'tabs-apply-sync-sessions',
   TABS_CREATE: 'tabs-create',
   TABS_CLOSE: 'tabs-close',
+  TABS_CLOSE_MULTIPLE: 'tabs-close-multiple',
   TABS_ACTIVATE: 'tabs-activate',
   TABS_DUPLICATE: 'tabs-duplicate',
   TABS_MOVE: 'tabs-move',
@@ -68,6 +69,8 @@ const IpcChannels = {
   TABS_REQUEST_FULLSCREEN: 'tabs-request-fullscreen',
   TABS_SET_TAB_BAR_SCROLL: 'tabs-set-tab-bar-scroll',
   TABS_SET_CONTEXT_MENU_TAB: 'tabs-set-context-menu-tab',
+  TABS_CONFIRM_CLOSE_MULTIPLE: 'tabs-confirm-close-multiple',
+  TABS_CONFIRM_CLOSE_MULTIPLE_RESPONSE: 'tabs-confirm-close-multiple-response',
   CONTEXT_MENU_OPEN: 'context-menu-open',
   CONTEXT_MENU_EXECUTE: 'context-menu-execute',
   RESOLVE_FAVICON: 'resolve-favicon',
@@ -547,6 +550,9 @@ const MOBILE_WIDTH_THRESHOLD = 680
 // Height threshold in px at which we switch to using a more heavily altered playlist view for mobile users
 const PLAYLIST_HEIGHT_FORCE_LIST_THRESHOLD = 500
 
+// Closing this many tabs at once (or more) asks for a confirmation first
+const CLOSE_MULTIPLE_TABS_CONFIRM_THRESHOLD = 5
+
 // YouTube search character limit is 100 characters
 const SEARCH_CHAR_LIMIT = 100
 
@@ -628,6 +634,7 @@ export {
   MAIN_PROFILE_ID,
   MOBILE_WIDTH_THRESHOLD,
   PLAYLIST_HEIGHT_FORCE_LIST_THRESHOLD,
+  CLOSE_MULTIPLE_TABS_CONFIRM_THRESHOLD,
   SEARCH_CHAR_LIMIT,
   SEARCH_RESULTS_DISPLAY_LIMIT,
   MIXED_SEARCH_HISTORY_ENTRIES_DISPLAY_LIMIT,

--- a/src/main/index.js
+++ b/src/main/index.js
@@ -17,6 +17,7 @@ import {
   getConfiguredKeyboardShortcuts,
   getElectronAccelerator,
   SEARCH_CHAR_LIMIT,
+  CLOSE_MULTIPLE_TABS_CONFIRM_THRESHOLD,
   LIGHT_BASE_THEMES,
   DARK_BASE_THEMES,
 } from '../constants'
@@ -312,6 +313,53 @@ function runApp() {
     return quitPromptInProgress
   }
 
+  let closeMultipleTabsRequestCount = 0
+
+  /**
+   * Ask the renderer to confirm a bulk tab close.
+   * @param {TabManager | null | undefined} manager
+   * @param {number} count the number of tabs that would be closed
+   * @returns {Promise<boolean>}
+   */
+  function confirmCloseMultipleTabs(manager, count) {
+    if (count < CLOSE_MULTIPLE_TABS_CONFIRM_THRESHOLD) {
+      return Promise.resolve(true)
+    }
+
+    const browserWindow = manager?.browserWindow
+    if (!browserWindow || browserWindow.isDestroyed()) {
+      return Promise.resolve(true)
+    }
+
+    const requestId = `close-multiple-tabs-${++closeMultipleTabsRequestCount}`
+    return new Promise(resolve => {
+      /**
+       * @param {import('electron').IpcMainEvent} _event
+       * @param {{ requestId?: string, confirmed?: boolean }} response
+       */
+      const listener = (_event, response) => {
+        if (response?.requestId !== requestId) return
+
+        finish(response.confirmed === true)
+      }
+
+      const handleWindowClosed = () => finish(false)
+
+      /**
+       * @param {boolean} confirmed
+       */
+      function finish(confirmed) {
+        ipcMain.removeListener(IpcChannels.TABS_CONFIRM_CLOSE_MULTIPLE_RESPONSE, listener)
+        browserWindow.removeListener('closed', handleWindowClosed)
+        resolve(confirmed)
+      }
+
+      ipcMain.on(IpcChannels.TABS_CONFIRM_CLOSE_MULTIPLE_RESPONSE, listener)
+      browserWindow.once('closed', handleWindowClosed)
+      manager.bridge.send(IpcChannels.TABS_CONFIRM_CLOSE_MULTIPLE, { requestId, count })
+    })
+  }
+
   // Becomes true once the user asks the app to quit (e.g. Ctrl+Q / "Quit" menu
   // item / last-window-closed on non-darwin). Window close handlers use this to
   // decide whether their persisted tab session record should be kept (so the
@@ -438,26 +486,29 @@ function runApp() {
         : undefined
       const hasSelectedUnloadedTab = contextMenuTabs.some(tab => tab.loadState === 'unloaded')
       const hasSelectedLoadedTab = contextMenuTabs.some(tab => !['unloaded', 'unloading'].includes(tab.loadState))
+      /**
+       * Apply a bulk tab action as one renderer update instead of one per tab.
+       * @param {() => void} run
+       */
+      const runBatchedTabAction = (run) => {
+        manager?.runBatched(run).catch(error => {
+          console.error('Failed to apply a bulk tab action:', error)
+        })
+      }
       const closeContextMenuTabs = async (tabIds) => {
         if (!manager) return
 
         const existingTabIds = tabIds.filter(tabId => manager.tabs.has(tabId))
         const isLastWindow = BrowserWindow.getAllWindows().length === 1
-        if (
-          existingTabIds.length === manager.tabs.size &&
-          isLastWindow &&
-          !await confirmCloseApp(manager.browserWindow)
-        ) {
+        const closesWindow = existingTabIds.length === manager.tabs.size
+        if (closesWindow && isLastWindow) {
+          // The quit confirmation already covers this case
+          if (!await confirmCloseApp(manager.browserWindow)) return
+        } else if (!await confirmCloseMultipleTabs(manager, existingTabIds.length)) {
           return
         }
 
-        // Close the presented tab last so its replacement can be shown before
-        // the composited subtree is removed.
-        existingTabIds.sort((a, b) => Number(a === manager.presentedTabId) - Number(b === manager.presentedTabId))
-        let hasRemainingTabs = true
-        for (const tabId of existingTabIds) {
-          hasRemainingTabs = manager.closeTab(tabId)
-        }
+        const hasRemainingTabs = await manager.closeTabs(existingTabIds)
         if (!hasRemainingTabs) {
           if (isLastWindow) closeConfirmedWindowIds.add(manager.browserWindow.id)
           manager.browserWindow.close()
@@ -517,7 +568,9 @@ function runApp() {
           click: () => {
             if (!manager || !contextMenuTab) return
 
-            for (const tab of contextMenuTabs) manager.duplicateTab(tab.id)
+            runBatchedTabAction(() => {
+              for (const tab of contextMenuTabs) manager.duplicateTab(tab.id)
+            })
           }
         },
         {
@@ -531,9 +584,11 @@ function runApp() {
                 if (!manager || !contextMenuTab) return
 
                 if (isBulkTabAction) {
-                  for (const tab of [...contextMenuTabs].reverse()) {
-                    manager.moveTab(tab.id, 0)
-                  }
+                  runBatchedTabAction(() => {
+                    for (const tab of [...contextMenuTabs].reverse()) {
+                      manager.moveTab(tab.id, 0)
+                    }
+                  })
                 } else {
                   manager.moveTab(contextMenuTab.id, 0)
                 }
@@ -546,9 +601,11 @@ function runApp() {
                 if (!manager || !contextMenuTab) return
 
                 if (isBulkTabAction) {
-                  for (const tab of contextMenuTabs) {
-                    manager.moveTab(tab.id, manager.tabs.size)
-                  }
+                  runBatchedTabAction(() => {
+                    for (const tab of contextMenuTabs) {
+                      manager.moveTab(tab.id, manager.tabs.size)
+                    }
+                  })
                 } else {
                   manager.moveTab(contextMenuTab.id, manager.tabs.size)
                 }
@@ -613,9 +670,11 @@ function runApp() {
           click: () => {
             if (!manager || !contextMenuTab) return
 
-            for (const tab of contextMenuTabs) {
-              manager.setTabPinned(tab.id, !allSelectedTabsPinned)
-            }
+            runBatchedTabAction(() => {
+              for (const tab of contextMenuTabs) {
+                manager.setTabPinned(tab.id, !allSelectedTabsPinned)
+              }
+            })
           }
         },
         {
@@ -636,7 +695,9 @@ function runApp() {
             click: () => {
               if (!manager || !contextMenuTab) return
 
-              for (const tab of contextMenuTabs) manager.setTabColor(tab.id, color)
+              runBatchedTabAction(() => {
+                for (const tab of contextMenuTabs) manager.setTabColor(tab.id, color)
+              })
             }
           }))
         },
@@ -677,7 +738,9 @@ function runApp() {
           click: () => {
             if (!manager || !contextMenuTab) return
 
-            for (const tab of contextMenuTabs) manager.loadTab(tab.id)
+            runBatchedTabAction(() => {
+              for (const tab of contextMenuTabs) manager.loadTab(tab.id)
+            })
           }
         },
         {
@@ -700,11 +763,7 @@ function runApp() {
               return
             }
 
-            for (const tab of contextMenuTabs) {
-              await manager.unloadTab(tab.id).catch(error => {
-                console.error('Failed to unload tab:', error)
-              })
-            }
+            await manager.unloadTabs(contextMenuTabs.map(tab => tab.id))
           }
         },
         {
@@ -4444,19 +4503,17 @@ function runApp() {
           {
             label: 'Close Tab',
             accelerator: getElectronAccelerator(keyboardShortcuts.APP.GENERAL.CLOSE_TAB),
-            click: (_menuItem, browserWindow) => {
+            click: async (_menuItem, browserWindow) => {
               if (browserWindow) {
                 const tabManager = TabManager.getForWindow(browserWindow.id)
                 if (tabManager && tabManager.activeTabId) {
                   const tabIds = tabManager.selectedTabIds.length > 1
                     ? [...tabManager.selectedTabIds]
                     : [tabManager.activeTabId]
-                  tabIds.sort((a, b) => Number(a === tabManager.activeTabId) - Number(b === tabManager.activeTabId))
-                  let hasRemainingTabs = true
-                  for (const tabId of tabIds) {
-                    hasRemainingTabs = tabManager.closeTab(tabId)
-                    if (!hasRemainingTabs) break
+                  if (!await confirmCloseMultipleTabs(tabManager, tabIds.length)) {
+                    return
                   }
+                  const hasRemainingTabs = await tabManager.closeTabs(tabIds)
                   if (!hasRemainingTabs) {
                     browserWindow.close()
                   }

--- a/src/main/index.js
+++ b/src/main/index.js
@@ -349,11 +349,13 @@ function runApp() {
        * @param {boolean} confirmed
        */
       function finish(confirmed) {
+        clearTimeout(timeoutId)
         ipcMain.removeListener(IpcChannels.TABS_CONFIRM_CLOSE_MULTIPLE_RESPONSE, listener)
         browserWindow.removeListener('closed', handleWindowClosed)
         resolve(confirmed)
       }
 
+      const timeoutId = setTimeout(() => finish(false), 30_000)
       ipcMain.on(IpcChannels.TABS_CONFIRM_CLOSE_MULTIPLE_RESPONSE, listener)
       browserWindow.once('closed', handleWindowClosed)
       manager.bridge.send(IpcChannels.TABS_CONFIRM_CLOSE_MULTIPLE, { requestId, count })
@@ -499,6 +501,8 @@ function runApp() {
         if (!manager) return
 
         const existingTabIds = tabIds.filter(tabId => manager.tabs.has(tabId))
+        if (existingTabIds.length === 0) return
+
         const isLastWindow = BrowserWindow.getAllWindows().length === 1
         const closesWindow = existingTabIds.length === manager.tabs.size
         if (closesWindow && isLastWindow) {
@@ -4510,7 +4514,9 @@ function runApp() {
                   const tabIds = tabManager.selectedTabIds.length > 1
                     ? [...tabManager.selectedTabIds]
                     : [tabManager.activeTabId]
-                  if (!await confirmCloseMultipleTabs(tabManager, tabIds.length)) {
+                  const closesLastWindow = tabIds.length === tabManager.tabs.size &&
+                    BrowserWindow.getAllWindows().length === 1
+                  if (!closesLastWindow && !await confirmCloseMultipleTabs(tabManager, tabIds.length)) {
                     return
                   }
                   const hasRemainingTabs = await tabManager.closeTabs(tabIds)

--- a/src/main/tabs/TabManager.js
+++ b/src/main/tabs/TabManager.js
@@ -1405,6 +1405,9 @@ export class TabManager {
       return
     }
 
+    const presentedTabId = this.presentedTabId
+    const batchedTabIds = unloadingTabIds.filter(tabId => tabId !== presentedTabId)
+
     await this.runBatched(async () => {
       const unloadingTabIdSet = new Set(unloadingTabIds)
       if (this.activeTabId != null && unloadingTabIdSet.has(this.activeTabId)) {
@@ -1415,15 +1418,20 @@ export class TabManager {
         }
       }
 
-      // The presented tab captures a fresh preview before it goes, so unload it
-      // last instead of holding up the cheap unloads behind that round-trip.
-      unloadingTabIds.sort((a, b) => Number(a === this.presentedTabId) - Number(b === this.presentedTabId))
-      for (const tabId of unloadingTabIds) {
+      for (const tabId of batchedTabIds) {
         await this.unloadTab(tabId).catch(error => {
           console.error('Failed to unload tab:', error)
         })
       }
     })
+
+    // The presented tab captures a fresh preview before it goes. Run it outside
+    // the manager-wide batch so the capture cannot hold back unrelated updates.
+    if (presentedTabId != null && unloadingTabIds.includes(presentedTabId)) {
+      await this.unloadTab(presentedTabId).catch(error => {
+        console.error('Failed to unload tab:', error)
+      })
+    }
   }
 
   /**
@@ -2389,7 +2397,9 @@ export class TabManager {
   /**
    * Run a bulk operation with its state broadcasts and session writes collapsed
    * into a single one, so the renderer re-renders the tab bar and the session
-   * file is written once instead of once per tab.
+   * file is written once instead of once per tab. Batching is manager-wide, so
+   * asynchronous callbacks must stay short to avoid suppressing unrelated state
+   * updates until the callback settles.
    * @template T
    * @param {() => T | Promise<T>} run
    * @returns {Promise<T>}
@@ -2931,7 +2941,13 @@ export async function setupTabsIPC(options = {}) {
       return { hasRemainingTabs: true }
     }
 
-    const hasRemainingTabs = await manager.closeTabs(closingTabIds)
+    let hasRemainingTabs
+    try {
+      hasRemainingTabs = await manager.closeTabs(closingTabIds)
+    } catch (error) {
+      console.error('Failed to close tabs:', error)
+      hasRemainingTabs = manager.tabs.size > 0
+    }
     if (!hasRemainingTabs) {
       markWindowCloseConfirmed(manager.browserWindow)
       manager.browserWindow.close()

--- a/src/main/tabs/TabManager.js
+++ b/src/main/tabs/TabManager.js
@@ -591,6 +591,11 @@ export class TabManager {
     this._pendingTabMountWaiters = new Map()
     this._deferredCloseTabIds = new Set()
     this._deferredUnloadTabIds = new Set()
+    // While a batch runs, state broadcasts and session writes are collapsed into
+    // a single one that is emitted once the batch finishes (see runBatched).
+    this._batchDepth = 0
+    this._batchedBroadcastPending = false
+    this._batchedSessionSavePending = false
     // Serializes preview captures across every tab in this window. Captures share
     // the window's single renderer, so running two at once would screenshot each
     // other's content and toggle capture mode out from under one another.
@@ -1197,7 +1202,14 @@ export class TabManager {
     }
   }
 
-  _getNeighborTabId(tabId, loadedOnly = false) {
+  /**
+   * @param {string} tabId
+   * @param {boolean} [loadedOnly]
+   * @param {Set<string> | null} [excludedTabIds] tabs that are about to be closed
+   * or unloaded as part of the same bulk operation
+   * @returns {string | null}
+   */
+  _getNeighborTabId(tabId, loadedOnly = false, excludedTabIds = null) {
     const orderedTabIds = Array.from(this.tabs.keys())
     const tabIndex = orderedTabIds.indexOf(tabId)
     if (tabIndex === -1) {
@@ -1210,6 +1222,7 @@ export class TabManager {
     // the replacement, otherwise a rapid second close/unload would leave the
     // window with no selectable tab.
     const isSelectable = candidateId =>
+      excludedTabIds?.has(candidateId) !== true &&
       this.tabs.get(candidateId)?.isTransferStaged !== true &&
       (!loadedOnly || this.tabs.get(candidateId)?.loadState === 'loaded') &&
       !this._deferredCloseTabIds.has(candidateId) &&
@@ -1342,6 +1355,75 @@ export class TabManager {
     }
 
     return this.tabs.size > 0
+  }
+
+  /**
+   * Close several tabs at once. Activating the surviving replacement up front
+   * keeps the tabs that are on their way out from being mounted just to be torn
+   * down again, and the batching collapses the per-tab renderer updates and
+   * session writes into one.
+   * @param {string[]} tabIds
+   * @returns {Promise<boolean>} whether the window still has tabs
+   */
+  async closeTabs(tabIds) {
+    const closingTabIds = tabIds.filter(tabId => this.tabs.has(tabId))
+    if (closingTabIds.length === 0) {
+      return this.tabs.size > 0
+    }
+    if (closingTabIds.length === 1) {
+      return this.closeTab(closingTabIds[0])
+    }
+
+    return await this.runBatched(() => {
+      const closingTabIdSet = new Set(closingTabIds)
+      if (this.activeTabId != null && closingTabIdSet.has(this.activeTabId)) {
+        const nextTabId = this._getNeighborTabId(this.activeTabId, false, closingTabIdSet)
+        if (nextTabId != null && this._prepareNeighborActivation(nextTabId)) {
+          this.activateTab(nextTabId)
+        }
+      }
+
+      // Close the presented tab last so its replacement can be shown before the
+      // composited subtree is removed.
+      closingTabIds.sort((a, b) => Number(a === this.presentedTabId) - Number(b === this.presentedTabId))
+      let hasRemainingTabs = this.tabs.size > 0
+      for (const tabId of closingTabIds) {
+        hasRemainingTabs = this.closeTab(tabId)
+      }
+      return hasRemainingTabs
+    })
+  }
+
+  /**
+   * Unload several tabs at once, see {@link closeTabs}.
+   * @param {string[]} tabIds
+   * @returns {Promise<void>}
+   */
+  async unloadTabs(tabIds) {
+    const unloadingTabIds = tabIds.filter(tabId => this.tabs.has(tabId))
+    if (unloadingTabIds.length === 0) {
+      return
+    }
+
+    await this.runBatched(async () => {
+      const unloadingTabIdSet = new Set(unloadingTabIds)
+      if (this.activeTabId != null && unloadingTabIdSet.has(this.activeTabId)) {
+        const nextTabId = this._getNeighborTabId(this.activeTabId, true, unloadingTabIdSet) ??
+          this._getNeighborTabId(this.activeTabId, false, unloadingTabIdSet)
+        if (nextTabId != null && this._prepareNeighborActivation(nextTabId)) {
+          this.activateTab(nextTabId)
+        }
+      }
+
+      // The presented tab captures a fresh preview before it goes, so unload it
+      // last instead of holding up the cheap unloads behind that round-trip.
+      unloadingTabIds.sort((a, b) => Number(a === this.presentedTabId) - Number(b === this.presentedTabId))
+      for (const tabId of unloadingTabIds) {
+        await this.unloadTab(tabId).catch(error => {
+          console.error('Failed to unload tab:', error)
+        })
+      }
+    })
   }
 
   /**
@@ -2304,7 +2386,41 @@ export class TabManager {
     return this.browserWindow.webContents.isDestroyed() ? null : this.browserWindow.webContents
   }
 
+  /**
+   * Run a bulk operation with its state broadcasts and session writes collapsed
+   * into a single one, so the renderer re-renders the tab bar and the session
+   * file is written once instead of once per tab.
+   * @template T
+   * @param {() => T | Promise<T>} run
+   * @returns {Promise<T>}
+   */
+  async runBatched(run) {
+    this._batchDepth += 1
+    try {
+      return await run()
+    } finally {
+      this._batchDepth -= 1
+      if (this._batchDepth === 0) {
+        const broadcastPending = this._batchedBroadcastPending
+        const sessionSavePending = this._batchedSessionSavePending
+        this._batchedBroadcastPending = false
+        this._batchedSessionSavePending = false
+        if (broadcastPending) {
+          this._broadcastStateUpdate()
+        }
+        if (sessionSavePending) {
+          await this._saveSession()
+        }
+      }
+    }
+  }
+
   _broadcastStateUpdate() {
+    if (this._batchDepth > 0) {
+      this._batchedBroadcastPending = true
+      return
+    }
+
     // Queued snapshots get coalesced down to the newest one, so while the
     // renderer is still bootstrapping every snapshot has to carry the history
     // in full — whichever one survives is the one the tabs get created from.
@@ -2335,6 +2451,11 @@ export class TabManager {
 
   async _saveSession() {
     if (this._sessionPersistenceDisabled) return
+
+    if (this._batchDepth > 0) {
+      this._batchedSessionSavePending = true
+      return
+    }
 
     this.sessionUpdatedAt = Date.now()
 
@@ -2790,6 +2911,32 @@ export async function setupTabsIPC(options = {}) {
       return { hasRemainingTabs }
     }
     return { hasRemainingTabs: false }
+  })
+
+  ipcMain.handle(IpcChannels.TABS_CLOSE_MULTIPLE, async (event, tabIds) => {
+    const manager = getManager(event)
+    if (!manager || !Array.isArray(tabIds)) {
+      return { hasRemainingTabs: false }
+    }
+
+    const closingTabIds = tabIds.filter(tabId => typeof tabId === 'string' && manager.tabs.has(tabId))
+    if (closingTabIds.length === 0) {
+      return { hasRemainingTabs: manager.tabs.size > 0 }
+    }
+
+    if (
+      closingTabIds.length === manager.tabs.size &&
+      !await confirmCloseWindow(manager.browserWindow)
+    ) {
+      return { hasRemainingTabs: true }
+    }
+
+    const hasRemainingTabs = await manager.closeTabs(closingTabIds)
+    if (!hasRemainingTabs) {
+      markWindowCloseConfirmed(manager.browserWindow)
+      manager.browserWindow.close()
+    }
+    return { hasRemainingTabs }
   })
 
   ipcMain.handle(IpcChannels.TABS_DUPLICATE, (event, tabId) => {

--- a/src/preload/interface.js
+++ b/src/preload/interface.js
@@ -765,6 +765,15 @@ export default {
     },
 
     /**
+     * Close several tabs at once
+     * @param {string[]} tabIds
+     * @returns {Promise<{hasRemainingTabs: boolean}>}
+     */
+    closeMultiple: (tabIds) => {
+      return ipcRenderer.invoke(IpcChannels.TABS_CLOSE_MULTIPLE, tabIds)
+    },
+
+    /**
      * Duplicate a tab
      * @param {string} tabId
      * @returns {Promise<{id: string, url: string, title: string}|null>}
@@ -865,6 +874,27 @@ export default {
      */
     setSelected: (tabIds) => {
       ipcRenderer.send(IpcChannels.TABS_SET_SELECTED, tabIds)
+    },
+
+    /**
+     * Listen for bulk close confirmation requests from main (e.g. the tab
+     * context menu's "Close Tabs" entries).
+     * @param {(request: { requestId: string, count: number }) => void} handler
+     * @returns {() => void}
+     */
+    onConfirmCloseMultiple: (handler) => {
+      const listener = (_event, request) => handler(request)
+      ipcRenderer.on(IpcChannels.TABS_CONFIRM_CLOSE_MULTIPLE, listener)
+      return () => ipcRenderer.removeListener(IpcChannels.TABS_CONFIRM_CLOSE_MULTIPLE, listener)
+    },
+
+    /**
+     * Answer a bulk close confirmation request from main.
+     * @param {string} requestId
+     * @param {boolean} confirmed
+     */
+    respondConfirmCloseMultiple: (requestId, confirmed) => {
+      ipcRenderer.send(IpcChannels.TABS_CONFIRM_CLOSE_MULTIPLE_RESPONSE, { requestId, confirmed })
     },
 
     /**

--- a/src/renderer/App.vue
+++ b/src/renderer/App.vue
@@ -2328,6 +2328,7 @@ const closeMultipleTabsPromptNames = computed(() => [
  */
 function confirmCloseMultipleTabs(count) {
   if (closeMultipleTabsPromptPromise) {
+    closeMultipleTabsPromptCount.value = Math.max(closeMultipleTabsPromptCount.value, count)
     return closeMultipleTabsPromptPromise
   }
 

--- a/src/renderer/App.vue
+++ b/src/renderer/App.vue
@@ -114,6 +114,15 @@
       :option-values="EXTERNAL_LINK_OPENING_PROMPT_VALUES"
       @click="handleExternalLinkOpeningPromptAnswer"
     />
+    <FtPrompt
+      v-if="closeMultipleTabsPromptCount > 0"
+      autosize
+      :label="t('Close Multiple Tabs Confirmation.Title')"
+      :extra-labels="[t('Close Multiple Tabs Confirmation.Message', { count: closeMultipleTabsPromptCount })]"
+      :option-names="closeMultipleTabsPromptNames"
+      :option-values="CLOSE_MULTIPLE_TABS_PROMPT_VALUES"
+      @click="handleCloseMultipleTabsPromptAnswer"
+    />
     <FtSearchFilters
       v-if="showSearchFilters"
     />
@@ -302,7 +311,7 @@ import { vSaferHtml } from './directives/vSaferHtml.js'
 import store from './store/index'
 
 import packageDetails from '../../package.json'
-import { KeyboardShortcuts } from '../constants'
+import { CLOSE_MULTIPLE_TABS_CONFIRM_THRESHOLD, KeyboardShortcuts } from '../constants'
 import { matchesKeyboardShortcut } from './helpers/keyboardShortcuts'
 import { fetchReleasePages, findUpdateReleases, formatReleaseChangelog } from './helpers/releaseUpdates'
 import { createReleaseNotesMarkdown } from './helpers/releaseNotesMarkdown'
@@ -535,6 +544,7 @@ let removeSubscriptionAutoRefreshCancelListener = null
 let removeSubscriptionAutoRefreshStateChangedListener = null
 let removeTabsStateListener = null
 let removeReloadRequestListener = null
+let removeConfirmCloseMultipleTabsListener = null
 let removeOpenUrlListener = null
 const pendingSubscriptionAutoRefreshes = []
 const pendingSubscriptionAutoRefreshKeys = new Set()
@@ -736,6 +746,8 @@ onMounted(async () => {
       removeOpenUrlListener = enableOpenUrl()
       store.dispatch('getExternalPlayerCmdArgumentsData')
       removeReloadRequestListener = window.ftElectron.tabs.onRequestReload(prepareAndReloadTab)
+      removeConfirmCloseMultipleTabsListener = window.ftElectron.tabs
+        .onConfirmCloseMultiple(handleConfirmCloseMultipleTabsRequest)
     }
 
     await Promise.all([syncDataReady, platformInfoReady])
@@ -826,6 +838,7 @@ onBeforeUnmount(() => {
   removeSubscriptionAutoRefreshStateChangedListener?.()
   removeTabsStateListener?.()
   removeReloadRequestListener?.()
+  removeConfirmCloseMultipleTabsListener?.()
   removeOpenUrlListener?.()
 })
 
@@ -2294,17 +2307,70 @@ function getShortcutTabIds() {
     : activeTabId.value ? [activeTabId.value] : []
 }
 
+const closeMultipleTabsPromptCount = ref(0)
+const CLOSE_MULTIPLE_TABS_PROMPT_VALUES = ['close', 'cancel']
+
+/** @type {((confirmed: boolean) => void) | null} */
+let closeMultipleTabsPromptResolve = null
+/** @type {Promise<boolean> | null} */
+let closeMultipleTabsPromptPromise = null
+
+const closeMultipleTabsPromptNames = computed(() => [
+  t('Close Multiple Tabs Confirmation.Close Tabs', { count: closeMultipleTabsPromptCount.value }),
+  t('Cancel')
+])
+
+/**
+ * Ask the user to confirm closing several tabs at once. Concurrent requests
+ * (e.g. the menu accelerator and the in-page shortcut) share one prompt.
+ * @param {number} count
+ * @returns {Promise<boolean>}
+ */
+function confirmCloseMultipleTabs(count) {
+  if (closeMultipleTabsPromptPromise) {
+    return closeMultipleTabsPromptPromise
+  }
+
+  closeMultipleTabsPromptCount.value = count
+  closeMultipleTabsPromptPromise = new Promise(resolve => {
+    closeMultipleTabsPromptResolve = resolve
+  })
+  return closeMultipleTabsPromptPromise
+}
+
+/**
+ * @param {'close' | 'cancel' | null} option
+ */
+function handleCloseMultipleTabsPromptAnswer(option) {
+  closeMultipleTabsPromptCount.value = 0
+  const resolve = closeMultipleTabsPromptResolve
+  closeMultipleTabsPromptResolve = null
+  closeMultipleTabsPromptPromise = null
+  resolve?.(option === 'close')
+}
+
+/**
+ * @param {{ requestId: string, count: number }} request
+ */
+async function handleConfirmCloseMultipleTabsRequest({ requestId, count }) {
+  const confirmed = await confirmCloseMultipleTabs(count)
+  window.ftElectron.tabs.respondConfirmCloseMultiple(requestId, confirmed)
+}
+
 async function closeShortcutTabs() {
   const tabIds = getShortcutTabIds()
-  const activeId = activeTabId.value
-  tabIds.sort((a, b) => Number(a === activeId) - Number(b === activeId))
-
-  let hasRemainingTabs = true
-  for (const tabId of tabIds) {
-    hasRemainingTabs = await store.dispatch('closeTab', tabId)
-    if (!hasRemainingTabs) break
+  if (tabIds.length >= CLOSE_MULTIPLE_TABS_CONFIRM_THRESHOLD && !await confirmCloseMultipleTabs(tabIds.length)) {
+    return true
   }
-  return hasRemainingTabs
+
+  if (tabIds.length === 0) {
+    return true
+  }
+  if (tabIds.length === 1) {
+    return await store.dispatch('closeTab', tabIds[0])
+  }
+
+  return await store.dispatch('closeTabs', tabIds)
 }
 
 function handleMouseDown() {

--- a/src/renderer/store/modules/tabs.js
+++ b/src/renderer/store/modules/tabs.js
@@ -281,6 +281,12 @@ const actions = {
     return result?.hasRemainingTabs ?? false
   },
 
+  async closeTabs(_context, tabIds) {
+    if (!process.env.IS_ELECTRON) return false
+    const result = await window.ftElectron.tabs.closeMultiple(tabIds)
+    return result?.hasRemainingTabs ?? false
+  },
+
   async closeActiveTab({ state, dispatch }) {
     return state.activeTabId ? await dispatch('closeTab', state.activeTabId) : false
   },

--- a/src/renderer/store/modules/tabs.js
+++ b/src/renderer/store/modules/tabs.js
@@ -283,8 +283,13 @@ const actions = {
 
   async closeTabs(_context, tabIds) {
     if (!process.env.IS_ELECTRON) return false
-    const result = await window.ftElectron.tabs.closeMultiple(tabIds)
-    return result?.hasRemainingTabs ?? false
+    try {
+      const result = await window.ftElectron.tabs.closeMultiple(tabIds)
+      return result?.hasRemainingTabs ?? false
+    } catch (error) {
+      console.error('Failed to close tabs:', error)
+      return true
+    }
   },
 
   async closeActiveTab({ state, dispatch }) {

--- a/static/locales/en-US.yaml
+++ b/static/locales/en-US.yaml
@@ -31,6 +31,10 @@ Close Confirmation:
   Message: Are you sure you want to quit OpenTubeX?
   Quit: Quit
   Never Ask Again: Never ask again
+Close Multiple Tabs Confirmation:
+  Title: Close multiple tabs?
+  Message: This will close {count} tabs.
+  Close Tabs: Close {count} Tabs
 Compact side navigation: Compact side navigation
 Expand side navigation: Expand side navigation
 Back: Back


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Make sure to follow the contributing guidelines. -->
<!-- Important note, we may remove your pull request if you do not use this provided PR template correctly. -->
<!-- Agent instructions: Preserve every heading, comment, and marker in this template. Never remove or rewrite the release-note-category:start/end, release-note:start/end, or release-note-image:start/end marker pairs. Never remove or rewrite the Release note images section; leave its contents for a human. -->

## Pull Request Type
<!-- Please select what type of pull request this is: [x] -->
- [ ] Bugfix
- [x] Feature Implementation
- [ ] Documentation
- [ ] Other

## Related issue
<!-- Please link the issue your pull request is referring to. -->
<!-- If this pull request fully resolves the relevant issue, put "closes" before the issue number. -->
<!-- Example: "closes #123456". -->

## Description
<!-- Please write a clear and concise description of what the pull request does. -->
Closing several tabs at once was easy to trigger by accident and slow to complete, so this adds a confirmation and makes the bulk operations far cheaper.

**Confirmation:** closing five or more tabs at once now asks first, using an in-app prompt (not a native dialog) so it fits both horizontal and vertical tab bars. It covers the tab context menu ("Close N Tabs", close to the left/right, close other tabs), the app menu's "Close Tab" with a multi-selection, and Ctrl+W with a multi-selection. Closing every tab of the last window keeps using the existing quit confirmation instead, so two dialogs never stack.

**Performance:** bulk closing and unloading previously worked strictly tab by tab. Every tab broadcast the full tab state to the renderer (one tab bar re-render each) and wrote the session file, and closing the active tab activated the next tab in the close set — mounting a tab just to tear it down again, cascading through the selection. `TabManager` now has a `runBatched` helper that collapses those broadcasts and session writes into one, plus `closeTabs`/`unloadTabs` that pick the surviving replacement tab up front so only one activation happens. The other bulk context menu entries (duplicate, move, pin, colour, load) are batched the same way, and the Ctrl+W path uses a single IPC call instead of one per tab.

## Release note category
<!-- Select exactly one category. Every pull request must select one. -->
<!-- Select "Not noteworthy" when the pull request fixes a bug in or improves functionality that has not yet appeared in a stable release. -->
<!-- release-note-category:start -->
- [ ] Not noteworthy
- [ ] Highlights
- [x] More improvements
- [ ] Fixed bugs
<!-- release-note-category:end -->

## Release note
<!-- Required unless "Not noteworthy" is selected. -->
<!-- Write one concise, user-facing entry without a leading bullet. -->
<!-- release-note:start -->
Confirmations for closing five or more tabs, windows that have them and bulk tab actions can now be configured together, while opening/closing/unloading several tabs quickly is noticeably faster.
<!-- release-note:end -->

## Release note images
<!-- Human-only: Agents must preserve this entire section and leave it empty. -->
<!-- Optional. Paste one or more Markdown images or HTML image tags here. -->
<!-- The release notes will use an HTML image tag and limit images taller than 300 pixels. -->
<!-- release-note-image:start -->
<img width="538" height="178" alt="image" src="https://github.com/user-attachments/assets/99203941-525c-406a-a0fb-b145e42100c8" />
<img width="720" height="146" alt="image" src="https://github.com/user-attachments/assets/cc44a3d4-6ae1-4dfc-b9ee-59f788376e39" />
<!-- release-note-image:end -->

## Testing
<!-- How can reviewers verify that the PR produces correct results? -->
<!-- Please provide instructions so that others can ensure that your pull request would produce correct results. For examples see, https://github.com/FreeTubeApp/FreeTube/pull/5743, https://github.com/FreeTubeApp/FreeTube/pull/7349, https://github.com/FreeTubeApp/FreeTube/pull/5125, https://github.com/FreeTubeApp/FreeTube/pull/7338 -->
<!-- Agent instructions: Only write human-facing steps that explain how to verify the change while running this branch in dev mode. Include expected results and, when applicable, helpful console snippets for interactive verification. Do not include automated checks, commands, results, pass counts, or CI status. -->
Run the app in dev mode and open around ten tabs.

**Confirmation**
1. Select five or more tabs (click one, then Ctrl+click others), right-click the selection and choose "Close N Tabs". A prompt asks whether to close them; "Cancel" leaves every tab open, the close button removes them all.
2. Repeat with Ctrl+W instead of the context menu, and with the "Close Tabs → Other Tabs / To the Left / To the Right" entries — each asks whenever five or more tabs would go.
3. Select only two or three tabs and close them the same way: they close immediately, without a prompt.
4. Switch the tab bar to vertical (Settings → General, or the tab bar's context menu) and repeat step 1: the prompt is centred over the window and fully readable in that layout too.
5. With a single window, use "Close Tabs → Other Tabs" in a way that closes every tab: only the usual quit confirmation appears, not two dialogs in a row.

**Performance**
6. Open 15–20 tabs, select most of them and close them in one go. They should all disappear together in a single step rather than vanishing one after another, and no tab that is on its way out should flash into view first.
7. Do the same with "Unload Tabs" on a large selection: the tabs should switch to their unloaded state in one update.
8. Repeat both with the *active* tab inside the selection — the tab that stays open should be one that was not selected, and it should be activated only once.

## Additional context
<!-- Add any other context about the pull request here. -->
The confirmation threshold lives in `CLOSE_MULTIPLE_TABS_CONFIRM_THRESHOLD` (`src/constants.js`) and is shared by the main and renderer sides. It is deliberately not a user setting for now.

Bulk unloading has no automated coverage because it is only reachable through the native context menu, which the E2E harness cannot drive; it shares the batching and replacement-picking code that the bulk close test does cover.
