### PR TITLE
fix: refine release validation and segment loading

### DIFF
--- a/.github/workflows/validate-release-note.yml
+++ b/.github/workflows/validate-release-note.yml
@@ -13,7 +13,16 @@ concurrency:
 jobs:
   validate-release-note:
     name: Release Note
-    if: ${{ github.head_ref != 'weblate-translations' }}
+    if: >-
+      ${{
+        github.head_ref != 'weblate-translations' &&
+        !(
+          github.event.pull_request.user.login == 'pull[bot]' &&
+          github.event.pull_request.head.repo.full_name == 'FreeTubeApp/FreeTube' &&
+          github.event.pull_request.head.ref == 'development' &&
+          github.event.pull_request.base.ref == 'development'
+        )
+      }}
     runs-on: ubuntu-latest
 
     permissions:

--- a/e2e/tests/network/auto-quality.spec.mjs
+++ b/e2e/tests/network/auto-quality.spec.mjs
@@ -23,8 +23,6 @@ function readAbrState(page) {
 
     return {
       abrEnabled: player.getConfiguration().abr.enabled,
-      clearBufferSwitch: player.getConfiguration().abr.clearBufferSwitch,
-      safeMarginSwitch: player.getConfiguration().abr.safeMarginSwitch,
       autoButtonVisible: autoButton != null && getComputedStyle(autoButton).display !== 'none'
     }
   })
@@ -46,10 +44,8 @@ test.describe('auto quality', () => {
       await openVideoOrSkip(test, page, VIDEO)
       await waitForPlaybackOrSkip(test, page)
 
-      const { abrEnabled, clearBufferSwitch, safeMarginSwitch, autoButtonVisible } = await readAbrState(page)
+      const { abrEnabled, autoButtonVisible } = await readAbrState(page)
       expect(abrEnabled).toBe(true)
-      expect(clearBufferSwitch).toBe(true)
-      expect(safeMarginSwitch).toBe(10)
       expect(autoButtonVisible).toBe(true)
     })
   })
@@ -71,9 +67,8 @@ test.describe('auto quality', () => {
       await openVideoOrSkip(test, page, VIDEO)
       await waitForPlaybackOrSkip(test, page)
 
-      const { abrEnabled, clearBufferSwitch, autoButtonVisible } = await readAbrState(page)
+      const { abrEnabled, autoButtonVisible } = await readAbrState(page)
       expect(abrEnabled).toBe(false)
-      expect(clearBufferSwitch).toBe(false)
       expect(autoButtonVisible).toBe(false)
     })
   })

--- a/e2e/tests/offline/segment-prefetch-slider.spec.mjs
+++ b/e2e/tests/offline/segment-prefetch-slider.spec.mjs
@@ -8,10 +8,10 @@ async function openPlayerSettings(page) {
   await page.locator('.settingsMenu [data-section="player"]').click()
   await expect(page.locator('.settingsContent > [data-section="player"]')).toBeVisible()
 
-  return page.getByRole('slider', { name: /Concurrent Segment Downloads/ })
+  return page.getByRole('slider', { name: /Parallel Segment Loading/ })
 }
 
-test.describe('concurrent segment downloads slider', () => {
+test.describe('parallel segment loading slider', () => {
   test('persists the configured limit', async ({ app }) => {
     const slider = await openPlayerSettings(app.page)
 

--- a/src/renderer/components/PlayerSettings/PlayerSettings.vue
+++ b/src/renderer/components/PlayerSettings/PlayerSettings.vue
@@ -267,13 +267,13 @@
         @change="updateDefaultPlayback"
       />
       <FtSlider
-        :label="t('Settings.Player Settings.Concurrent Segment Downloads')"
+        :label="t('Settings.Player Settings.Parallel Segment Loading')"
         :default-value="segmentPrefetchLimit"
         setting-key="segmentPrefetchLimit"
         :min-value="DEFAULT_SEGMENT_PREFETCH_LIMIT"
         :max-value="MAX_SEGMENT_PREFETCH_LIMIT"
         :step="1"
-        :tooltip="t('Tooltips.Player Settings.Concurrent Segment Downloads')"
+        :tooltip="t('Tooltips.Player Settings.Parallel Segment Loading')"
         @change="updateSegmentPrefetchLimit"
       />
       <FtSlider

--- a/src/renderer/components/ft-shaka-video-player/ft-shaka-video-player.js
+++ b/src/renderer/components/ft-shaka-video-player/ft-shaka-video-player.js
@@ -2879,14 +2879,7 @@ export default defineComponent({
           enabled: useAutoQuality,
 
           // This only affects the "auto" quality, users can still manually select whatever quality they want.
-          restrictToElementSize: true,
-
-          // The regular buffer can contain up to three minutes of video. Without clearing it on an
-          // automatic switch, playback can therefore stay at the initial low quality long after the
-          // quality menu and stats report the newly selected variant. Keep two typical DASH segments
-          // for a seamless switch, but replace the rest with segments from the new variant.
-          clearBufferSwitch: streamsSupportAutoQuality(format, isSabrPlayback.value),
-          safeMarginSwitch: 10
+          restrictToElementSize: true
         },
 
         // Prioritise variants that are predicted to play:

--- a/static/locales/en-US.yaml
+++ b/static/locales/en-US.yaml
@@ -673,7 +673,7 @@ Settings:
     Reorder Playback Speed: Drag to reorder playback speed
     Playback Speed: Playback Speed
     Max Video Playback Rate: Max Video Playback Rate
-    Concurrent Segment Downloads: Concurrent Segment Downloads
+    Parallel Segment Loading: Parallel Segment Loading
     Video Playback Rate Interval: Video Playback Rate Interval
     Default Video Format:
       Default Video Format: Default Video Format
@@ -1754,11 +1754,11 @@ Tooltips:
     Hold to Double Playback Speed: Hold the Spacebar or left mouse button over the player to temporarily double the current playback speed.
     Ambient Mode: Blends the video's colors into the area around the player.
     Default Volume: Disabled while Remember Volume is enabled. Turn off Remember Volume to set a fixed startup volume for each video.
-    Concurrent Segment Downloads: |
-      How many video and audio segments are downloaded in parallel ahead of the current playback position.
-      Higher values can improve the download speed on slow or unstable connections, but use more bandwidth and memory.
-      As parallel downloads share the connection, each one is measured as slower, which can make the automatic quality selection pick a lower resolution.
-      Streams that only allow one request at a time, which most of those from the built-in stream extraction method are, are unaffected.
+    Parallel Segment Loading: |
+      How many video and audio segments to load at once ahead of playback.
+      Higher values may help on slow or unstable connections, but use more bandwidth and memory.
+      They may also make Auto underestimate the connection speed and select a lower quality.
+      Streams limited to one request at a time ignore this setting.
   External Player Settings:
     External Player: Choosing an external player will display an icon, for opening the
       video (playlist if supported) in the external player, on the thumbnail. Warning, Invidious settings do not affect external players.


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Make sure to follow the contributing guidelines. -->
<!-- Important note, we may remove your pull request if you do not use this provided PR template correctly. -->
<!-- Agent instructions: Preserve every heading, comment, and marker in this template. Never remove or rewrite the release-note-category:start/end, release-note:start/end, or release-note-image:start/end marker pairs. Never remove or rewrite the Release note images section; leave its contents for a human. -->

## Pull Request Type
<!-- Please select what type of pull request this is: [x] -->
- [x] Bugfix
- [ ] Feature Implementation
- [ ] Documentation
- [ ] Other

## Related issue
<!-- Please link the issue your pull request is referring to. -->
<!-- If this pull request fully resolves the relevant issue, put "closes" before the issue number. -->
<!-- Example: "closes #123456". -->

Reverts #596.

## Description
<!-- Please write a clear and concise description of what the pull request does. -->

Skip release-note validation for the exact `pull[bot]` upstream development sync used by PRs such as #587. These generated PR bodies do not use the project template, while other cross-repository and bot-authored PRs remain validated.

Rename “Concurrent Segment Downloads” to “Parallel Segment Loading” so it is not confused with file downloads. Shorten its tooltip while retaining the bandwidth, memory, Auto quality, and single-request stream caveats.

Revert #596's automatic buffer clearing. Parallel segment loading caused the apparent quality mismatch by making Auto underestimate bandwidth and rapidly filling the buffer at the initially selected low quality. Clearing buffered content on every adaptive switch only masked that documented tradeoff while wasting bandwidth and risking playback interruptions.

## Release note category
<!-- Select exactly one category. Every pull request must select one. -->
<!-- Select "Not noteworthy" when the pull request fixes a bug in or improves functionality that has not yet appeared in a stable release. -->
<!-- release-note-category:start -->
- [x] Not noteworthy
- [ ] Highlights
- [ ] More improvements
- [ ] Fixed bugs
<!-- release-note-category:end -->

## Release note
<!-- Required unless "Not noteworthy" is selected. -->
<!-- Write one concise, user-facing entry without a leading bullet. -->
<!-- release-note:start -->

<!-- release-note:end -->

## Release note images
<!-- Human-only: Agents must preserve this entire section and leave it empty. -->
<!-- Optional. Paste one or more Markdown images or HTML image tags here. -->
<!-- The release notes will use an HTML image tag and limit images taller than 300 pixels. -->
<!-- release-note-image:start -->

<!-- release-note-image:end -->

## Testing
<!-- How can reviewers verify that the PR produces correct results? -->
<!-- Please provide instructions so that others can ensure that your pull request would produce correct results. For examples see, https://github.com/FreeTubeApp/FreeTube/pull/5743, https://github.com/FreeTubeApp/FreeTube/pull/7349, https://github.com/FreeTubeApp/FreeTube/pull/5125, https://github.com/FreeTubeApp/FreeTube/pull/7338 -->
<!-- Agent instructions: Only write human-facing steps that explain how to verify the change while running this branch in dev mode. Include expected results and, when applicable, helpful console snippets for interactive verification. Do not include automated checks, commands, results, pass counts, or CI status. -->

1. Open Settings and select Player.
2. Confirm the slider is labeled “Parallel Segment Loading.”
3. Open its help tooltip and confirm it concisely explains loading ahead, resource usage, Auto quality selection, and single-request streams.
4. Use yt-dlp DASH playback with Auto quality and confirm adaptive switches do not discard the existing playable buffer or interrupt playback.

## Additional context
<!-- Add any other context about the pull request here. -->

The release-note exemption mirrors the repository, branch, and author checks already used to choose the merge method for upstream sync PRs.
