### PR TITLE
refactor(toast): build toasts on vue-sonner

### DIFF
--- a/e2e/tests/offline/settings.spec.mjs
+++ b/e2e/tests/offline/settings.spec.mjs
@@ -1289,7 +1289,7 @@ test.describe('settings', () => {
     await expect(toastWithoutIndicator).toHaveCount(0)
   })
 
-  test('shows two toasts at a glance and the rest on hover', async ({ page }) => {
+  test('shows two toasts at a glance with the rest piled behind', async ({ page }) => {
     await page.mouse.move(800, 300)
     await page.evaluate(() => {
       for (const name of ['Alpha', 'Beta', 'Gamma', 'Delta', 'Epsilon']) {
@@ -1305,16 +1305,33 @@ test.describe('settings', () => {
       })
     }
 
-    // Collapsed the pile is the newest toast and one card peeking out behind it,
-    // however many are waiting: past that it is all sliver and no toast
-    await expect.poll(drawn).toBe(2)
+    function readable () {
+      return page.locator('.toast').evaluateAll((toasts) => {
+        return toasts.filter((toast) => {
+          return getComputedStyle(toast.querySelector('.message')).opacity !== '0'
+        }).length
+      })
+    }
 
-    // They are all still there though, and fan out with the rest on hover
-    await page.locator('.toast', { hasText: 'Epsilon toast' }).hover()
+    // Collapsed, the two newest toasts can be read and the rest are drawn behind
+    // them as cards with nothing on them, so a full stack still looks like more
+    // than a couple of toasts do
+    await expect.poll(readable).toBe(2)
     await expect.poll(drawn).toBe(5)
 
+    // Each of those peeks out past the one in front of it, or the pile would be
+    // hidden behind the toasts and there would be no sign of it
+    const tops = await page.locator('.toast').evaluateAll((toasts) => {
+      return toasts.map(toast => Math.round(toast.getBoundingClientRect().top))
+    })
+    expect(new Set(tops).size).toBe(tops.length)
+
+    // They all become readable on hover
+    await page.locator('.toast', { hasText: 'Epsilon toast' }).hover()
+    await expect.poll(readable).toBe(5)
+
     await page.mouse.move(800, 300)
-    await expect.poll(drawn).toBe(2)
+    await expect.poll(readable).toBe(2)
   })
 
   test('keeps the stack fanned out while the pointer moves between toasts', async ({ page }) => {

--- a/e2e/tests/offline/settings.spec.mjs
+++ b/e2e/tests/offline/settings.spec.mjs
@@ -1028,7 +1028,21 @@ test.describe('settings', () => {
       await expect(
         toast.locator('..').locator('.timeout-indicator .embeddedProgressPath')
       ).toHaveCSS('animation-delay', '0.3s')
+      // The row a toast sits in slides it into place, so let that settle before
+      // anything measures where the toast ended up
+      await page.waitForTimeout(400)
       return toast
+    }
+
+    async function expectToastInset (toast, edge, inset) {
+      const bounds = await toast.boundingBox()
+      const viewport = await viewportSize()
+
+      if (edge === 'top') {
+        expect(bounds.y).toBeCloseTo(inset, 0)
+      } else {
+        expect(viewport.height - (bounds.y + bounds.height)).toBeCloseTo(inset, 0)
+      }
     }
 
     async function dragToast (toast, distance) {
@@ -1042,12 +1056,18 @@ test.describe('settings', () => {
       await page.mouse.down()
       await page.mouse.move(x + distance, y, { steps: 5 })
 
+      // The timeout indicator has to follow the toast as it is dragged
       const indicatorTrack = toast.locator('..').locator('.timeout-indicator-track')
-      const transforms = await Promise.all([
-        toast.evaluate(element => getComputedStyle(element).transform),
-        indicatorTrack.evaluate(element => getComputedStyle(element).transform)
+      const [draggedBounds, indicatorBounds] = await Promise.all([
+        toast.boundingBox(),
+        indicatorTrack.boundingBox()
       ])
-      expect(transforms[1]).toBe(transforms[0])
+      expect(indicatorBounds.x).toBeCloseTo(draggedBounds.x, 0)
+      expect(indicatorBounds.y).toBeCloseTo(draggedBounds.y, 0)
+
+      // A drag is dismissed on distance or on speed, so hold still for a moment
+      // to keep these deliberate drags out of the flick-to-dismiss range
+      await page.waitForTimeout(300)
     }
 
     function viewportSize () {
@@ -1061,21 +1081,20 @@ test.describe('settings', () => {
 
     await positionSelect.selectOption('bottom-left')
     await expect(holder).toHaveClass(/position-bottom-left/)
-    await expect(holder).toHaveCSS('bottom', '24px')
     let toast = await showToast('Left toast')
     let bounds = await toast.boundingBox()
     expect(bounds.x).toBeLessThan(50)
+    await expectToastInset(toast, 'bottom', 29)
     await dragToast(toast, dismissDragDistance)
     await page.mouse.up()
     await expect(toast).toBeVisible()
-    await expect(toast).toHaveCSS('transform', 'none')
+    await expect.poll(async () => (await toast.boundingBox()).x).toBeCloseTo(bounds.x, 0)
     await dragToast(toast, -dismissDragDistance)
     await page.mouse.up()
     await expect(toast).toHaveCount(0)
 
     await positionSelect.selectOption('bottom-center')
     await expect(holder).toHaveClass(/position-bottom-center/)
-    await expect(holder).toHaveCSS('transform', 'none')
     toast = await showToast('Center toast dragged left')
     bounds = await toast.boundingBox()
     let viewport = await viewportSize()
@@ -1098,24 +1117,24 @@ test.describe('settings', () => {
     await dragToast(toast, -dismissDragDistance)
     await page.mouse.up()
     await expect(toast).toBeVisible()
-    await expect(toast).toHaveCSS('transform', 'none')
+    await expect.poll(async () => (await toast.boundingBox()).x).toBeCloseTo(bounds.x, 0)
     await dragToast(toast, dismissDragDistance)
     await page.mouse.up()
     await expect(toast).toHaveCount(0)
 
     await positionSelect.selectOption('top-left')
     await expect(holder).toHaveClass(/position-top-left/)
-    await expect(holder).toHaveCSS('top', '56px')
     toast = await showToast('Top left toast')
     bounds = await toast.boundingBox()
     expect(bounds.x).toBeLessThan(50)
+    // Below the horizontal tab bar
+    await expectToastInset(toast, 'top', 61)
     await dragToast(toast, -dismissDragDistance)
     await page.mouse.up()
     await expect(toast).toHaveCount(0)
 
     await positionSelect.selectOption('top-center')
     await expect(holder).toHaveClass(/position-top-center/)
-    await expect(holder).toHaveCSS('top', '56px')
     toast = await showToast('Top center toast')
     bounds = await toast.boundingBox()
     viewport = await viewportSize()
@@ -1126,7 +1145,6 @@ test.describe('settings', () => {
 
     await positionSelect.selectOption('top-right')
     await expect(holder).toHaveClass(/position-top-right/)
-    await expect(holder).toHaveCSS('top', '56px')
     toast = await showToast('Top right toast')
     bounds = await toast.boundingBox()
     viewport = await viewportSize()
@@ -1174,24 +1192,29 @@ test.describe('settings', () => {
     })
 
     const toast = page.locator('.toast', { hasText: 'Hover toast' })
-    const toastSlot = toast.locator('..')
     const indicator = toast.locator('..').locator('.timeout-indicator .embeddedProgressPath')
-    await expect(toastSlot).toHaveCSS('transform', 'none')
-    await toastSlot.dispatchEvent('pointerenter')
-    // Reported as a list so a failure says which animations were on the element
-    // and what state they were in, instead of just "expected paused"
-    await expect.poll(() => indicator.evaluate((element) => {
-      return element.getAnimations().map(animation => [
-        animation.animationName ?? animation.transitionProperty ?? animation.constructor.name,
-        animation.playState,
-      ].join(':'))
-    })).toEqual(expect.arrayContaining([
+
+    /**
+     * Reported as a list so a failure says which animations were on the element
+     * and what state they were in, instead of just "expected paused".
+     */
+    function indicatorStates (locator) {
+      return locator.evaluate((element) => {
+        return element.getAnimations().map(animation => [
+          animation.animationName ?? animation.transitionProperty ?? animation.constructor.name,
+          animation.playState,
+        ].join(':'))
+      })
+    }
+
+    await toast.hover()
+    await expect.poll(() => indicatorStates(indicator)).toEqual(expect.arrayContaining([
       expect.stringMatching(/^toast-timeout[\w-]*:paused$/),
     ]))
     await page.waitForTimeout(2200)
     await expect(toast).toBeVisible()
 
-    await toastSlot.dispatchEvent('pointerleave')
+    await page.mouse.move(800, 300)
     await expect(toast).toHaveCount(0)
 
     await page.evaluate(() => {
@@ -1218,24 +1241,34 @@ test.describe('settings', () => {
     })
     const firstAlternatingToast = page.locator('.toast', { hasText: 'First alternating toast' })
     const secondAlternatingToast = page.locator('.toast', { hasText: 'Second alternating toast' })
+    const firstIndicator = firstAlternatingToast.locator('..').locator('.timeout-indicator .embeddedProgressPath')
+    const secondIndicator = secondAlternatingToast.locator('..').locator('.timeout-indicator .embeddedProgressPath')
     await page.waitForTimeout(400)
-    await firstAlternatingToast.hover()
-    await secondAlternatingToast.hover()
-    await page.waitForTimeout(300)
-    await firstAlternatingToast.hover()
 
-    const firstIndicatorProgress = await firstAlternatingToast
-      .locator('..')
-      .locator('.timeout-indicator .embeddedProgressPath')
-      .evaluate((element) => ({
-        elapsedRatio: element.getAnimations()[0].currentTime /
-          element.getAnimations()[0].effect.getTiming().duration,
-        transform: getComputedStyle(element).transform,
-      }))
-    expect(firstIndicatorProgress.elapsedRatio).toBeGreaterThan(0.15)
-    expect(firstIndicatorProgress.transform).toBe('none')
+    // The stack is collapsed until it is hovered, so the toasts behind the front
+    // one are only reachable once hovering the front one has fanned it out
+    await secondAlternatingToast.hover()
+
+    // Hovering anywhere in the stack holds every toast in it, so moving between
+    // two toasts must not let either of them resume in between
+    await expect.poll(() => indicatorStates(firstIndicator)).toEqual(expect.arrayContaining([
+      expect.stringMatching(/^toast-timeout[\w-]*:paused$/),
+    ]))
+    await firstAlternatingToast.hover()
+    await page.waitForTimeout(300)
+    await secondAlternatingToast.hover()
+    await expect(indicatorStates(secondIndicator)).resolves.toEqual(expect.arrayContaining([
+      expect.stringMatching(/^toast-timeout[\w-]*:paused$/),
+    ]))
+
+    // Both toasts outlive their two second lifetime while the stack is held
+    await page.waitForTimeout(2200)
+    await expect(firstAlternatingToast).toBeVisible()
+    await expect(secondAlternatingToast).toBeVisible()
 
     await page.mouse.move(800, 300)
+    await expect(firstAlternatingToast).toHaveCount(0)
+    await expect(secondAlternatingToast).toHaveCount(0)
 
     await page.locator('label.switch-label')
       .filter({ hasText: 'Show toast timeout indicator' })
@@ -1247,14 +1280,197 @@ test.describe('settings', () => {
     })
     const toastWithoutIndicator = page.locator('.toast', { hasText: 'No indicator toast' })
     const toastWithoutIndicatorSlot = toastWithoutIndicator.locator('..')
-    await expect(toastWithoutIndicatorSlot).toHaveCSS('transform', 'none')
-    await toastWithoutIndicatorSlot.dispatchEvent('pointerenter')
+    await toastWithoutIndicator.hover()
     await expect(toastWithoutIndicatorSlot.locator('.timeout-indicator')).toHaveCount(0)
     await page.waitForTimeout(2200)
     await expect(toastWithoutIndicator).toBeVisible()
 
-    await toastWithoutIndicatorSlot.dispatchEvent('pointerleave')
+    await page.mouse.move(800, 300)
     await expect(toastWithoutIndicator).toHaveCount(0)
+  })
+
+  test('keeps the stack fanned out while the pointer moves between toasts', async ({ page }) => {
+    await page.mouse.move(800, 300)
+    await page.evaluate(() => {
+      // Deliberately mismatched widths: the toasts are only as wide as their
+      // message, so consecutive ones do not line up
+      window.ftElectron.showToastOnAllTabs('Alpha toast that is a great deal wider than the others around it', 30000)
+      window.ftElectron.showToastOnAllTabs('Beta', 30000, ['fas', 'eye'])
+      window.ftElectron.showToastOnAllTabs('Gamma toast of a middling sort of width', 30000)
+    })
+    await expect(page.locator('.toast', { hasText: 'Gamma toast' })).toBeVisible()
+    await page.waitForTimeout(700)
+
+    const rows = page.locator('[data-sonner-toast]')
+    await expect(rows.first()).toHaveAttribute('data-expanded', 'false')
+
+    await page.locator('.toast', { hasText: 'Gamma toast' }).hover()
+    await expect(rows.first()).toHaveAttribute('data-expanded', 'true')
+
+    const centres = await page.locator('.toast').evaluateAll((elements) => {
+      return elements
+        .map((element) => {
+          const { x, y, width, height } = element.getBoundingClientRect()
+          return { x: x + width / 2, y: y + height / 2 }
+        })
+        .sort((a, b) => b.y - a.y)
+    })
+
+    // Walking from one toast to the next must never drop out of the stack, or
+    // it collapses under the pointer and immediately reopens
+    for (let index = 1; index < centres.length; index++) {
+      const from = centres[index - 1]
+      const to = centres[index]
+
+      for (let step = 1; step <= 12; step++) {
+        await page.mouse.move(
+          from.x + (to.x - from.x) * step / 12,
+          from.y + (to.y - from.y) * step / 12
+        )
+        await expect(rows.first()).toHaveAttribute('data-expanded', 'true')
+      }
+    }
+
+    // and it lets go once the pointer is clear of the toasts, rather than
+    // holding on across the width of the window
+    const widest = Math.max(...(await page.locator('.toast').evaluateAll((elements) => {
+      return elements.map(element => element.getBoundingClientRect().right)
+    })))
+    await page.mouse.move(widest + 120, centres[0].y)
+    await expect(rows.first()).toHaveAttribute('data-expanded', 'false')
+
+    await page.mouse.move(800, 300)
+    await expect(rows.first()).toHaveAttribute('data-expanded', 'false')
+  })
+
+  test('reflows smoothly when a toast in the middle of the stack is dismissed', async ({ page }) => {
+    await page.mouse.move(800, 300)
+    await page.evaluate(() => {
+      window.ftElectron.showToastOnAllTabs('Alpha toast', 30000)
+      window.ftElectron.showToastOnAllTabs('Beta toast', 30000)
+      window.ftElectron.showToastOnAllTabs('Gamma toast', 30000)
+      window.ftElectron.showToastOnAllTabs('Delta toast', 30000)
+    })
+    await expect(page.locator('.toast', { hasText: 'Delta toast' })).toBeVisible()
+    await page.waitForTimeout(700)
+
+    await page.locator('.toast', { hasText: 'Delta toast' }).hover()
+    await expect(page.locator('[data-sonner-toast]').first()).toHaveAttribute('data-expanded', 'true')
+    await page.waitForTimeout(400)
+
+    // Resting on the toast that is about to go: once it stops taking input the
+    // pointer is left over nothing, which is what collapses the stack
+    await page.locator('.toast', { hasText: 'Beta toast' }).hover()
+    await page.waitForTimeout(200)
+
+    const alphaStart = (await page.locator('.toast', { hasText: 'Alpha toast' }).boundingBox()).y
+
+    // Dismiss a toast from the middle of the stack where it stands, the way one
+    // that has simply run out of time goes, and follow the stack closing the gap
+    const { samples, unreachable, collapsed } = await page.evaluate(() => {
+      const start = performance.now()
+      const samples = []
+      const unreachable = new Set()
+      const collapsed = []
+
+      const beta = [...document.querySelectorAll('.toast')].find(e => e.textContent.includes('Beta'))
+      beta.dispatchEvent(new KeyboardEvent('keydown', { key: 'Escape', bubbles: true }))
+
+      return new Promise((resolve) => {
+        function sample () {
+          const toasts = [...document.querySelectorAll('.toast')]
+          const alpha = toasts.find(e => e.textContent.includes('Alpha'))
+          if (alpha) { samples.push([performance.now() - start, alpha.getBoundingClientRect().y]) }
+
+          // The toast on its way out must not cover the ones staying behind: at
+          // every frame each of those has to answer for its own middle
+          for (const toast of toasts) {
+            if (toast.closest('[data-removed="true"]')) { continue }
+
+            const { x, y, width, height } = toast.getBoundingClientRect()
+            if (!toast.contains(document.elementFromPoint(x + width / 2, y + height / 2))) {
+              unreachable.add(toast.textContent.trim().split(' ')[0])
+            }
+          }
+
+          // The pointer is still on the stack throughout, so it must stay
+          // fanned out: collapsing and reopening around the dismissal throws
+          // every remaining toast across the screen and back
+          const row = document.querySelector('[data-sonner-toast]')
+          if (row && row.dataset.expanded !== 'true') {
+            collapsed.push(Math.round(performance.now() - start))
+          }
+
+          if (performance.now() - start < 1000) {
+            requestAnimationFrame(sample)
+          } else {
+            resolve({ samples, unreachable: [...unreachable], collapsed })
+          }
+        }
+        requestAnimationFrame(sample)
+      })
+    })
+
+    expect(unreachable).toEqual([])
+    expect(collapsed).toEqual([])
+    await expect(page.locator('.toast', { hasText: 'Beta toast' })).toHaveCount(0)
+
+    const positions = samples.map(([, y]) => y)
+    const settled = positions.at(-1)
+    expect(settled).toBeGreaterThan(alphaStart)
+
+    // The stack slides into place without springing past it and back
+    expect(Math.max(...positions)).toBeCloseTo(settled, 0)
+
+    // and it closes the gap while the dismissed toast is still animating out,
+    // rather than sitting still and then shifting once it has gone
+    const [startedAt] = samples.find(([, y]) => y > positions[0] + 1)
+    expect(startedAt).toBeLessThan(200)
+  })
+
+  test('keeps the stack open when a toast is swiped out of the middle of it', async ({ page }) => {
+    await page.mouse.move(800, 300)
+    await page.evaluate(() => {
+      window.ftElectron.showToastOnAllTabs('Alpha toast', 30000)
+      window.ftElectron.showToastOnAllTabs('Beta toast', 30000)
+      window.ftElectron.showToastOnAllTabs('Gamma toast', 30000)
+      window.ftElectron.showToastOnAllTabs('Delta toast', 30000)
+    })
+    await expect(page.locator('.toast', { hasText: 'Delta toast' })).toBeVisible()
+    await page.waitForTimeout(700)
+
+    const rows = page.locator('[data-sonner-toast]')
+    await page.locator('.toast', { hasText: 'Delta toast' }).hover()
+    await expect(rows.first()).toHaveAttribute('data-expanded', 'true')
+    await page.waitForTimeout(400)
+
+    const beta = await page.locator('.toast', { hasText: 'Beta toast' }).boundingBox()
+    const delta = await page.locator('.toast', { hasText: 'Delta toast' }).boundingBox()
+
+    // Swipe the middle toast out towards the edge the stack is anchored to
+    const swipeFrom = beta.x + beta.width - 10
+    await page.mouse.move(swipeFrom, beta.y + beta.height / 2)
+    await page.mouse.down()
+    for (let step = 1; step <= 6; step++) {
+      await page.mouse.move(swipeFrom - 90 * step / 6, beta.y + beta.height / 2)
+    }
+    await page.mouse.up()
+    await expect(page.locator('.toast', { hasText: 'Beta toast' })).toHaveCount(0)
+
+    // Only the toast that was actually swiped: a toast must never be able to
+    // take a drag aimed at one of its neighbours
+    await expect(page.locator('.toast', { hasText: 'Alpha toast' })).toBeVisible()
+    await expect(page.locator('.toast', { hasText: 'Gamma toast' })).toBeVisible()
+    await expect(page.locator('.toast', { hasText: 'Delta toast' })).toBeVisible()
+
+    // Letting go leaves the pointer beside the stack rather than on a toast, so
+    // the stack has to hold itself open until the pointer is back on one
+    const from = { x: swipeFrom - 90, y: beta.y + beta.height / 2 }
+    const to = { x: delta.x + delta.width / 2, y: delta.y + delta.height / 2 }
+    for (let step = 1; step <= 16; step++) {
+      await page.mouse.move(from.x + (to.x - from.x) * step / 16, from.y + (to.y - from.y) * step / 16)
+      await expect(rows.first()).toHaveAttribute('data-expanded', 'true')
+    }
   })
 })
 

--- a/e2e/tests/offline/settings.spec.mjs
+++ b/e2e/tests/offline/settings.spec.mjs
@@ -1289,6 +1289,34 @@ test.describe('settings', () => {
     await expect(toastWithoutIndicator).toHaveCount(0)
   })
 
+  test('shows two toasts at a glance and the rest on hover', async ({ page }) => {
+    await page.mouse.move(800, 300)
+    await page.evaluate(() => {
+      for (const name of ['Alpha', 'Beta', 'Gamma', 'Delta', 'Epsilon']) {
+        window.ftElectron.showToastOnAllTabs(`${name} toast`, 30000)
+      }
+    })
+    await expect(page.locator('.toast', { hasText: 'Epsilon toast' })).toBeVisible()
+    await page.waitForTimeout(700)
+
+    function drawn () {
+      return page.locator('[data-sonner-toast]').evaluateAll((rows) => {
+        return rows.filter(row => getComputedStyle(row).opacity !== '0').length
+      })
+    }
+
+    // Collapsed the pile is the newest toast and one card peeking out behind it,
+    // however many are waiting: past that it is all sliver and no toast
+    await expect.poll(drawn).toBe(2)
+
+    // They are all still there though, and fan out with the rest on hover
+    await page.locator('.toast', { hasText: 'Epsilon toast' }).hover()
+    await expect.poll(drawn).toBe(5)
+
+    await page.mouse.move(800, 300)
+    await expect.poll(drawn).toBe(2)
+  })
+
   test('keeps the stack fanned out while the pointer moves between toasts', async ({ page }) => {
     await page.mouse.move(800, 300)
     await page.evaluate(() => {

--- a/e2e/tests/offline/settings.spec.mjs
+++ b/e2e/tests/offline/settings.spec.mjs
@@ -1343,6 +1343,25 @@ test.describe('settings', () => {
     await expect(rows.first()).toHaveAttribute('data-expanded', 'false')
   })
 
+  test('dismisses a toast with the keyboard', async ({ page }) => {
+    await page.mouse.move(800, 300)
+    await page.evaluate(() => {
+      window.ftElectron.showToastOnAllTabs('Keyboard toast', 30000)
+    })
+
+    const toast = page.locator('.toast', { hasText: 'Keyboard toast' })
+    await expect(toast).toBeVisible()
+    await page.waitForTimeout(500)
+
+    // A toast without an action is not focusable itself, so the row it sits in
+    // is what a user reaches, both through the toaster's hotkey and by tabbing
+    await expect(toast).not.toHaveAttribute('tabindex')
+    await page.locator('[data-sonner-toast]').filter({ hasText: 'Keyboard toast' }).focus()
+    await page.keyboard.press('Escape')
+
+    await expect(toast).toHaveCount(0)
+  })
+
   test('reflows smoothly when a toast in the middle of the stack is dismissed', async ({ page }) => {
     await page.mouse.move(800, 300)
     await page.evaluate(() => {
@@ -1366,8 +1385,12 @@ test.describe('settings', () => {
     const alphaStart = (await page.locator('.toast', { hasText: 'Alpha toast' }).boundingBox()).y
 
     // Dismiss a toast from the middle of the stack where it stands, the way one
-    // that has simply run out of time goes, and follow the stack closing the gap
-    const { samples, unreachable, collapsed } = await page.evaluate(() => {
+    // that has simply run out of time goes, and follow the stack closing the gap.
+    // Raised on the toast rather than driven through the keyboard, because
+    // moving focus there takes the hover with it and closes the stack before the
+    // dismissal lands; that a toast can be reached at all is covered on its own
+    // by 'dismisses a toast with the keyboard'.
+    const settling = page.evaluate(() => {
       const start = performance.now()
       const samples = []
       const unreachable = new Set()
@@ -1411,6 +1434,8 @@ test.describe('settings', () => {
       })
     })
 
+    const { samples, unreachable, collapsed } = await settling
+
     expect(unreachable).toEqual([])
     expect(collapsed).toEqual([])
     await expect(page.locator('.toast', { hasText: 'Beta toast' })).toHaveCount(0)
@@ -1424,8 +1449,9 @@ test.describe('settings', () => {
 
     // and it closes the gap while the dismissed toast is still animating out,
     // rather than sitting still and then shifting once it has gone
-    const [startedAt] = samples.find(([, y]) => y > positions[0] + 1)
-    expect(startedAt).toBeLessThan(200)
+    const firstMove = samples.find(([, y]) => y > positions[0] + 1)
+    expect(firstMove, 'the stack never closed the gap').toBeDefined()
+    expect(firstMove[0]).toBeLessThan(200)
   })
 
   test('keeps the stack open when a toast is swiped out of the middle of it', async ({ page }) => {

--- a/package.json
+++ b/package.json
@@ -81,6 +81,7 @@
     "vue-i18n": "^11.4.8",
     "vue-observe-visibility": "^2.0.0-alpha.1",
     "vue-router": "^5.2.0",
+    "vue-sonner": "^2.0.9",
     "vuex": "^4.1.0",
     "youtubei.js": "^17.2.0"
   },

--- a/patches/vue-sonner@2.0.9.patch
+++ b/patches/vue-sonner@2.0.9.patch
@@ -1,0 +1,12 @@
+diff --git a/lib/index.js b/lib/index.js
+index cd01bb1f1563571946c1470dfdea9d009655d9cd..22f0bff49fa39788c039f07d87653585c6cc7bf5 100644
+--- a/lib/index.js
++++ b/lib/index.js
+@@ -514,6 +514,7 @@ var Toast_vue_vue_type_script_setup_true_lang_default = /* @__PURE__ */ defineCo
+ 		function deleteToast() {
+ 			removed.value = true;
+ 			offsetBeforeRemove.value = offset.value;
++			emit("update:heights", props.heights.filter((height) => height.toastId !== props.toast.id));
+ 			setTimeout(() => {
+ 				emit("removeToast", props.toast);
+ 			}, TIME_BEFORE_UNMOUNT);

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -10,6 +10,7 @@ overrides:
 
 patchedDependencies:
   shaka-player@5.1.12: 17d85e267c8958999207ce9d6c29a2ddf18734d0499fb30870ac8a55d90303fa
+  vue-sonner@2.0.9: ae94d00b3ff46bede626a25ac5a36a6cd35987f33d73c14ffc73afbd5767f95c
   youtubei.js@17.2.0: 82a17ea1894879fa26c1d70226541120697508f90730bda238d7cbe2c20c3ee0
 
 importers:
@@ -76,6 +77,9 @@ importers:
       vue-router:
         specifier: ^5.2.0
         version: 5.2.0(@vue/compiler-sfc@3.5.40)(vue@3.5.40)(webpack@5.109.2)
+      vue-sonner:
+        specifier: ^2.0.9
+        version: 2.0.9(patch_hash=ae94d00b3ff46bede626a25ac5a36a6cd35987f33d73c14ffc73afbd5767f95c)
       vuex:
         specifier: ^4.1.0
         version: 4.1.0(vue@3.5.40)
@@ -5053,6 +5057,20 @@ packages:
       pinia:
         optional: true
       vite:
+        optional: true
+
+  vue-sonner@2.0.9:
+    resolution: {integrity: sha512-i6BokNlNDL93fpzNxN/LZSn6D6MzlO+i3qXt6iVZne3x1k7R46d5HlFB4P8tYydhgqOrRbIZEsnRd3kG7qGXyw==}
+    peerDependencies:
+      '@nuxt/kit': ^4.0.3
+      '@nuxt/schema': ^4.0.3
+      nuxt: ^4.0.3
+    peerDependenciesMeta:
+      '@nuxt/kit':
+        optional: true
+      '@nuxt/schema':
+        optional: true
+      nuxt:
         optional: true
 
   vue@3.5.40:
@@ -10354,6 +10372,8 @@ snapshots:
       - rollup
       - unloader
       - webpack
+
+  vue-sonner@2.0.9(patch_hash=ae94d00b3ff46bede626a25ac5a36a6cd35987f33d73c14ffc73afbd5767f95c): {}
 
   vue@3.5.40:
     dependencies:

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -19,4 +19,5 @@ minimumReleaseAgeExclude:
 
 patchedDependencies:
   shaka-player@5.1.12: patches/shaka-player@5.1.12.patch
+  vue-sonner@2.0.9: patches/vue-sonner@2.0.9.patch
   youtubei.js@17.2.0: patches/youtubei.js@17.2.0.patch

--- a/src/renderer/components/FtToast/FtToast.css
+++ b/src/renderer/components/FtToast/FtToast.css
@@ -245,7 +245,7 @@
   inset-block-start: 56px;
 }
 
-.toast-slot {
+:is(.toast-holder, .progress-toast-holder) .toast-slot {
   position: relative;
   pointer-events: none;
 }
@@ -265,55 +265,55 @@
   transform: scale(0.95);
 }
 
-.toast-slot.persistent-slot {
+.progress-toast-holder .toast-slot.persistent-slot {
   transition: transform 250ms cubic-bezier(0.4, 0, 0.2, 1);
 }
 
-.position-bottom-left .persistent-slot {
+.progress-toast-holder.position-bottom-left .persistent-slot {
   transform-origin: bottom left;
 }
 
-.position-bottom-center .persistent-slot {
+.progress-toast-holder.position-bottom-center .persistent-slot {
   transform-origin: bottom center;
 }
 
-.position-bottom-right .persistent-slot {
+.progress-toast-holder.position-bottom-right .persistent-slot {
   transform-origin: bottom right;
 }
 
-.position-top-left .persistent-slot {
+.progress-toast-holder.position-top-left .persistent-slot {
   transform-origin: top left;
 }
 
-.position-top-center .persistent-slot {
+.progress-toast-holder.position-top-center .persistent-slot {
   transform-origin: top center;
 }
 
-.position-top-right .persistent-slot {
+.progress-toast-holder.position-top-right .persistent-slot {
   transform-origin: top right;
 }
 
-.position-bottom-left .persistent-slot.minimized {
+.progress-toast-holder.position-bottom-left .persistent-slot.minimized {
   transform: translate(-18px, 18px) scale(0.5);
 }
 
-.position-bottom-center .persistent-slot.minimized {
+.progress-toast-holder.position-bottom-center .persistent-slot.minimized {
   transform: translateY(18px) scale(0.5);
 }
 
-.position-bottom-right .persistent-slot.minimized {
+.progress-toast-holder.position-bottom-right .persistent-slot.minimized {
   transform: translate(18px, 18px) scale(0.5);
 }
 
-.position-top-left .persistent-slot.minimized {
+.progress-toast-holder.position-top-left .persistent-slot.minimized {
   transform: translate(-18px, -18px) scale(0.5);
 }
 
-.position-top-center .persistent-slot.minimized {
+.progress-toast-holder.position-top-center .persistent-slot.minimized {
   transform: translateY(-18px) scale(0.5);
 }
 
-.position-top-right .persistent-slot.minimized {
+.progress-toast-holder.position-top-right .persistent-slot.minimized {
   transform: translate(18px, -18px) scale(0.5);
 }
 
@@ -329,7 +329,7 @@
   transform: translateX(18px) scale(0.5);
 }
 
-.toast {
+:is(.toast-holder, .progress-toast-holder) .toast {
   /* Positioned so it stays above the margin of hover behind it, which would
      otherwise take the clicks and drags meant for the toast */
   position: relative;
@@ -355,23 +355,23 @@
   touch-action: pan-y;
 }
 
-.toast.actionable {
+:is(.toast-holder, .progress-toast-holder) .toast.actionable {
   cursor: pointer;
 }
 
-.timeout-indicator-track {
+:is(.toast-holder, .progress-toast-holder) .timeout-indicator-track {
   position: absolute;
   inset: 0;
   border-radius: calc(12px * var(--ui-roundness));
   pointer-events: none;
 }
 
-.timeout-indicator {
+:is(.toast-holder, .progress-toast-holder) .timeout-indicator {
   position: absolute;
   inset: 0;
 }
 
-.timeout-indicator .embeddedProgressPath {
+:is(.toast-holder, .progress-toast-holder) .timeout-indicator .embeddedProgressPath {
   filter: drop-shadow(0 0 2px color-mix(in srgb, var(--primary-color) 70%, transparent));
 
   /* Hold the line at its full length until the toast has finished animating in,
@@ -392,7 +392,7 @@
 
 /* The persistent toast reports real progress, so its line is driven by the
    `progress` prop rather than by the timeout drain. */
-.timeout-indicator.progress-indicator .embeddedProgressPath {
+:is(.toast-holder, .progress-toast-holder) .timeout-indicator.progress-indicator .embeddedProgressPath {
   animation: none;
 }
 
@@ -414,17 +414,17 @@
   }
 }
 
-.toast.persistent {
+:is(.toast-holder, .progress-toast-holder) .toast.persistent {
   cursor: progress;
   pointer-events: none;
 }
 
 /* Tighten the leading padding so the thumbnail sits closer to the edge */
-.toast.hasImage {
+:is(.toast-holder, .progress-toast-holder) .toast.hasImage {
   padding-inline-start: 10px;
 }
 
-.image {
+:is(.toast-holder, .progress-toast-holder) .image {
   flex-shrink: 0;
   inline-size: 64px;
   block-size: 36px;
@@ -432,20 +432,20 @@
   border-radius: calc(6px * var(--ui-roundness));
 }
 
-.icon {
+:is(.toast-holder, .progress-toast-holder) .icon {
   flex-shrink: 0;
   font-size: 18px;
   opacity: 0.85;
 }
 
-.message {
+:is(.toast-holder, .progress-toast-holder) .message {
   margin: 0;
 }
 
 /* Sonner holds a toast's timer while the pointer is over the stack, the stack
    has focus, or the window is in the background. The indicator tracks the same
    clock, so it stops with it. */
-.timeout-indicator-track.paused .timeout-indicator .embeddedProgressPath {
+.toast-holder .timeout-indicator-track.paused .embeddedProgressPath {
   animation-play-state: paused;
 }
 
@@ -591,7 +591,7 @@
 }
 
 @media (prefers-reduced-motion: reduce) {
-  .toast-slot.persistent-slot {
+  .progress-toast-holder .toast-slot.persistent-slot {
     transition-duration: 1ms;
   }
 }

--- a/src/renderer/components/FtToast/FtToast.css
+++ b/src/renderer/components/FtToast/FtToast.css
@@ -1,69 +1,271 @@
-.toast-holder {
-  position: fixed;
+/* The toast stack is vue-sonner's `<Toaster>`: an `ol.toast-holder` of
+   absolutely positioned `li[data-sonner-toast]` elements, each wrapping one
+   `FtToastItem`. Sonner's own stylesheet only handles positioning and stacking
+   here — `data-styled` is false for component toasts, so none of its visual
+   styling applies and the design below is ours. The overrides deliberately
+   qualify with `[data-sonner-toaster]` / `[data-sonner-toast]` so they beat
+   sonner's rules on specificity rather than on import order. */
 
+.toast-holder[data-sonner-toaster] {
   /* Drives the enter/leave transitions and the matching hold before the timeout
      indicator starts draining */
   --toast-transition-duration: 300ms;
 
   /* Higher than any prompt */
   z-index: 300;
-  display: flex;
-  flex-direction: column;
+  inline-size: var(--width);
+  font-family: inherit;
   pointer-events: none;
+
+  /* The offsets shift when the persistent progress toast appears or goes away,
+     so the stack slides across instead of jumping */
+  /* stylelint-disable-next-line liberty/use-logical-spec */
+  transition: transform 400ms ease, top 300ms ease, bottom 300ms ease;
 }
 
-.toast-holder.position-bottom-left,
-.toast-holder.position-bottom-center,
-.toast-holder.position-bottom-right {
-  inset-block-end: 24px;
+/* Each toast is a full-width row, so the toast inside it can be aligned to the
+   configured edge without the row itself catching pointer events. */
+.toast-holder[data-sonner-toaster] [data-sonner-toast] {
+  display: flex;
+  inline-size: 100%;
+  pointer-events: none;
+  transition: transform var(--toast-transition-duration) ease, opacity var(--toast-transition-duration), block-size var(--toast-transition-duration);
 }
 
-.toast-holder.position-top-left,
-.toast-holder.position-top-center,
-.toast-holder.position-top-right {
-  inset-block-start: 24px;
-  flex-direction: column-reverse;
+/* Sonner drives the enter, the leave and the reflow from the row's transform, so
+   each state carries its own curve. The reflow has to stay on a plain curve: an
+   overshoot here reads as the whole stack bouncing every time a toast in the
+   middle of it is dismissed. The overshoot that makes a toast look dropped onto
+   the stack lives on the scale instead, further down, which only the enter and
+   the leave touch. */
+.toast-holder[data-sonner-toaster] [data-sonner-toast][data-mounted='true'] {
+  transition: transform var(--toast-transition-duration) ease, opacity var(--toast-transition-duration), block-size var(--toast-transition-duration);
+}
+
+.toast-holder[data-sonner-toaster] [data-sonner-toast][data-removed='true'] {
+  transition: transform var(--toast-transition-duration) ease-in, opacity var(--toast-transition-duration), block-size var(--toast-transition-duration);
+}
+
+/* Follow the pointer instantly while swiping */
+.toast-holder[data-sonner-toaster] [data-sonner-toast][data-swiping='true'],
+.toast-holder[data-sonner-toaster] [data-sonner-toast][data-swiping='true'] > * {
+  transition: none;
+}
+
+.toast-holder.position-bottom-center [data-sonner-toast],
+.toast-holder.position-top-center [data-sonner-toast] {
+  justify-content: center;
+}
+
+/* stylelint-disable-next-line liberty/use-logical-spec -- names a physical edge */
+.toast-holder.position-bottom-right [data-sonner-toast],
+.toast-holder.position-top-right [data-sonner-toast] {
+  justify-content: flex-end;
+}
+
+/* Sonner's `position` prop is pinned (see `SONNER_POSITION`), so the configured
+   position is anchored here instead. Every rule outweighs sonner's own, both the
+   default ones and the narrow-window ones it applies below 600px, which would
+   otherwise stretch the stack across the window. */
+.toast-holder.position-top-left[data-sonner-toaster],
+.toast-holder.position-top-center[data-sonner-toaster],
+.toast-holder.position-top-right[data-sonner-toaster] {
+  inset-block: var(--offset-top) auto;
+}
+
+.toast-holder.position-bottom-left[data-sonner-toaster],
+.toast-holder.position-bottom-center[data-sonner-toaster],
+.toast-holder.position-bottom-right[data-sonner-toaster] {
+  inset-block: auto var(--offset-bottom);
+}
+
+/* Toasts stack away from the edge they are anchored to, which for the top
+   positions is the opposite of the direction sonner assumes. */
+.toast-holder.position-top-left[data-sonner-toaster] [data-sonner-toast],
+.toast-holder.position-top-center[data-sonner-toaster] [data-sonner-toast],
+.toast-holder.position-top-right[data-sonner-toaster] [data-sonner-toast] {
+  --lift: 1;
+  --lift-amount: calc(1 * var(--gap));
+
+  inset-block: 0 auto;
 }
 
 /* These settings name physical screen edges, independent of text direction. */
 /* stylelint-disable liberty/use-logical-spec */
-.toast-holder.position-bottom-left,
-.toast-holder.position-top-left {
-  left: 24px;
-  align-items: flex-start;
+.toast-holder.position-bottom-left[data-sonner-toaster],
+.toast-holder.position-top-left[data-sonner-toaster] {
+  right: auto;
+  left: var(--offset-left);
+  transform: none;
 }
 
-.toast-holder.position-bottom-center,
-.toast-holder.position-top-center {
+.toast-holder.position-bottom-right[data-sonner-toaster],
+.toast-holder.position-top-right[data-sonner-toaster] {
+  right: var(--offset-right);
+  left: auto;
+  transform: none;
+}
+
+.toast-holder.position-bottom-center[data-sonner-toaster],
+.toast-holder.position-top-center[data-sonner-toaster] {
+  right: auto;
+  left: 50%;
+  transform: translateX(-50%);
+}
+/* stylelint-enable liberty/use-logical-spec */
+
+.playerFullWindow .toast-holder[data-sonner-toaster] {
+  z-index: 1002;
+}
+
+/* The timeout indicator always retracts towards the screen corner the toast is
+   anchored to, so it drains away from the viewport rather than towards it. The
+   path is drawn from the inline start corner, which already follows the text
+   direction, so only positions anchored to the opposite physical edge need the
+   other keyframes. Centered toasts keep the reading direction. */
+/* stylelint-disable liberty/use-logical-spec */
+.toast-holder.position-bottom-right:dir(ltr),
+.toast-holder.position-top-right:dir(ltr),
+.toast-holder.position-bottom-left:dir(rtl),
+.toast-holder.position-top-left:dir(rtl) {
+  --toast-drain: toast-timeout-away;
+}
+/* stylelint-enable liberty/use-logical-spec */
+
+/* The enter and leave states keep our short slide, in place of sonner's
+   full-height one. `--y` is the only thing sonner puts in the row's
+   `transform`, so overriding it is enough. Mounted rows keep sonner's own
+   `--y`, which carries the stacking offset. The matching scale lives on the
+   toast inside the row: sonner measures the row's box to lay the stack out, and
+   it does so while the enter transition is still running, so a scale on the row
+   itself would have it record a height that is too small. */
+.toast-holder.position-bottom-left [data-sonner-toast]:not([data-mounted='true']),
+.toast-holder.position-top-left [data-sonner-toast]:not([data-mounted='true']) {
+  --y: translateX(-15px);
+}
+
+.toast-holder.position-bottom-right [data-sonner-toast]:not([data-mounted='true']),
+.toast-holder.position-top-right [data-sonner-toast]:not([data-mounted='true']) {
+  --y: translateX(15px);
+}
+
+.toast-holder.position-bottom-center [data-sonner-toast]:not([data-mounted='true']) {
+  --y: translateY(15px);
+}
+
+.toast-holder.position-top-center [data-sonner-toast]:not([data-mounted='true']) {
+  --y: translateY(-15px);
+}
+
+/* Leaving toasts drift back out the way they came in, but keep the stacking
+   offset they were removed at, so the ones above can animate into the gap.
+   Toasts swiped away are left to sonner's swipe-out animation. */
+.toast-holder.position-bottom-left [data-sonner-toast][data-removed='true']:not([data-swipe-out='true']),
+.toast-holder.position-top-left [data-sonner-toast][data-removed='true']:not([data-swipe-out='true']) {
+  --y: translateY(calc(var(--lift) * var(--offset))) translateX(-15px);
+
+  opacity: 0;
+}
+
+.toast-holder.position-bottom-right [data-sonner-toast][data-removed='true']:not([data-swipe-out='true']),
+.toast-holder.position-top-right [data-sonner-toast][data-removed='true']:not([data-swipe-out='true']) {
+  --y: translateY(calc(var(--lift) * var(--offset))) translateX(15px);
+
+  opacity: 0;
+}
+
+.toast-holder.position-bottom-center [data-sonner-toast][data-removed='true']:not([data-swipe-out='true']) {
+  --y: translateY(calc(var(--lift) * var(--offset) + 15px));
+
+  opacity: 0;
+}
+
+.toast-holder.position-top-center [data-sonner-toast][data-removed='true']:not([data-swipe-out='true']) {
+  --y: translateY(calc(var(--lift) * var(--offset) - 15px));
+
+  opacity: 0;
+}
+
+/* The persistent progress toast is not part of the toast queue: it is a status
+   readout with its own lifetime, so it is anchored to the same edge on its own
+   and the toaster is offset past it. */
+.progress-toast-holder {
+  position: fixed;
+  z-index: 300;
+  display: flex;
+
+  /* Matches the inset the toasts get from the toaster's own offset, so the
+     progress toast lines up with the stack above it */
+  padding: 5px;
+  pointer-events: none;
+}
+
+.playerFullWindow .progress-toast-holder {
+  z-index: 1002;
+}
+
+.progress-toast-holder.position-bottom-left,
+.progress-toast-holder.position-bottom-center,
+.progress-toast-holder.position-bottom-right {
+  inset-block-end: 24px;
+}
+
+.progress-toast-holder.position-top-left,
+.progress-toast-holder.position-top-center,
+.progress-toast-holder.position-top-right {
+  inset-block-start: 24px;
+}
+
+/* These settings name physical screen edges, independent of text direction. */
+/* stylelint-disable liberty/use-logical-spec */
+.progress-toast-holder.position-bottom-left,
+.progress-toast-holder.position-top-left {
+  left: 24px;
+  justify-content: flex-start;
+}
+
+.progress-toast-holder.position-bottom-center,
+.progress-toast-holder.position-top-center {
   right: 0;
   left: 0;
-  align-items: center;
+  justify-content: center;
 }
 
-.toast-holder.position-bottom-right,
-.toast-holder.position-top-right {
+.progress-toast-holder.position-bottom-right,
+.progress-toast-holder.position-top-right {
   right: 24px;
-  align-items: flex-end;
+  justify-content: flex-end;
 }
 /* stylelint-enable liberty/use-logical-spec */
 
 /* Keep top-positioned toasts below the horizontal tab bar. */
-.toast-holder.horizontal-tabs.position-top-left,
-.toast-holder.horizontal-tabs.position-top-center,
-.toast-holder.horizontal-tabs.position-top-right {
+.progress-toast-holder.horizontal-tabs.position-top-left,
+.progress-toast-holder.horizontal-tabs.position-top-center,
+.progress-toast-holder.horizontal-tabs.position-top-right {
   inset-block-start: 56px;
-}
-
-:global(body.playerFullWindow .toast-holder) {
-  z-index: 1002;
 }
 
 .toast-slot {
   position: relative;
+  pointer-events: none;
+}
+
+/* The scale half of the enter and leave animations, kept off the row itself so
+   sonner's height measurements stay accurate */
+.toast-holder[data-sonner-toaster] .toast-slot {
+  transition: transform var(--toast-transition-duration) cubic-bezier(0.34, 1.56, 0.64, 1);
+}
+
+.toast-holder[data-sonner-toaster] [data-sonner-toast][data-removed='true'] .toast-slot {
+  transition: transform var(--toast-transition-duration) ease-in;
+}
+
+.toast-holder[data-sonner-toaster] [data-sonner-toast]:not([data-mounted='true']) .toast-slot,
+.toast-holder[data-sonner-toaster] [data-sonner-toast][data-removed='true']:not([data-swipe-out='true']) .toast-slot {
+  transform: scale(0.95);
 }
 
 .toast-slot.persistent-slot {
-  pointer-events: none;
   transition: transform 250ms cubic-bezier(0.4, 0, 0.2, 1);
 }
 
@@ -115,19 +317,22 @@
   transform: translate(18px, -18px) scale(0.5);
 }
 
-.toast-holder.horizontal-tabs.position-top-left .persistent-slot.minimized {
+.progress-toast-holder.horizontal-tabs.position-top-left .persistent-slot.minimized {
   transform: translateX(-18px) scale(0.5);
 }
 
-.toast-holder.horizontal-tabs.position-top-center .persistent-slot.minimized {
+.progress-toast-holder.horizontal-tabs.position-top-center .persistent-slot.minimized {
   transform: scale(0.5);
 }
 
-.toast-holder.horizontal-tabs.position-top-right .persistent-slot.minimized {
+.progress-toast-holder.horizontal-tabs.position-top-right .persistent-slot.minimized {
   transform: translateX(18px) scale(0.5);
 }
 
 .toast {
+  /* Positioned so it stays above the margin of hover behind it, which would
+     otherwise take the clicks and drags meant for the toast */
+  position: relative;
   display: flex;
   align-items: center;
   gap: 12px;
@@ -137,7 +342,6 @@
   max-inline-size: min(400px, calc(100vw - 60px));
   padding-block: 12px;
   padding-inline: 18px;
-  margin: 5px;
   text-align: start;
   overflow-y: auto;
   background-color: rgb(28 28 28 / 92%);
@@ -147,9 +351,8 @@
   pointer-events: auto;
   user-select: none;
 
-  /* Let the component own horizontal drag gestures instead of the browser */
+  /* Let sonner own horizontal drag gestures instead of the browser */
   touch-action: pan-y;
-  transition: transform 300ms ease, opacity 300ms ease;
 }
 
 .toast.actionable {
@@ -158,14 +361,9 @@
 
 .timeout-indicator-track {
   position: absolute;
-  inset: 5px;
+  inset: 0;
   border-radius: calc(12px * var(--ui-roundness));
   pointer-events: none;
-  transition: transform 300ms ease, opacity 300ms ease;
-}
-
-.timeout-indicator-track.dragging {
-  transition: none;
 }
 
 .timeout-indicator {
@@ -173,7 +371,7 @@
   inset: 0;
 }
 
-.timeout-indicator :deep(.embeddedProgressPath) {
+.timeout-indicator .embeddedProgressPath {
   filter: drop-shadow(0 0 2px color-mix(in srgb, var(--primary-color) 70%, transparent));
 
   /* Hold the line at its full length until the toast has finished animating in,
@@ -187,24 +385,16 @@
      duration. Such a toast is gone before the hold is over, so it just keeps the
      full line for its whole lifetime. */
   animation-duration: max(0s, var(--toast-duration) - var(--toast-transition-duration));
-  animation-name: toast-timeout;
+  animation-name: var(--toast-drain, toast-timeout);
   animation-timing-function: linear;
   animation-fill-mode: forwards;
 }
 
-/* The line always retracts towards the screen corner the toast is anchored to,
-   so it drains away from the viewport rather than towards it. The path is drawn
-   from the inline start corner, which already follows the text direction, so
-   only positions anchored to the opposite physical edge need the other
-   keyframes. Centered toasts keep the reading direction. */
-/* stylelint-disable liberty/use-logical-spec */
-.position-bottom-right:dir(ltr) .timeout-indicator :deep(.embeddedProgressPath),
-.position-top-right:dir(ltr) .timeout-indicator :deep(.embeddedProgressPath),
-.position-bottom-left:dir(rtl) .timeout-indicator :deep(.embeddedProgressPath),
-.position-top-left:dir(rtl) .timeout-indicator :deep(.embeddedProgressPath) {
-  animation-name: toast-timeout-away;
+/* The persistent toast reports real progress, so its line is driven by the
+   `progress` prop rather than by the timeout drain. */
+.timeout-indicator.progress-indicator .embeddedProgressPath {
+  animation: none;
 }
-/* stylelint-enable liberty/use-logical-spec */
 
 /* Shortens the line from its far end, so it retracts into the corner it starts
    from and the trailing edge finally sweeps out through that corner's arc. */
@@ -224,19 +414,9 @@
   }
 }
 
-/* Follow the pointer instantly while dragging */
-.toast.dragging {
-  cursor: grabbing;
-  transition: none;
-}
-
 .toast.persistent {
   cursor: progress;
   pointer-events: none;
-}
-
-.progress-indicator :deep(.embeddedProgressPath) {
-  animation: none;
 }
 
 /* Tighten the leading padding so the thumbnail sits closer to the edge */
@@ -262,60 +442,132 @@
   margin: 0;
 }
 
-.toast-enter-active {
-  transition:
-    opacity var(--toast-transition-duration),
-    transform var(--toast-transition-duration) cubic-bezier(0.34, 1.56, 0.64, 1);
+/* Sonner holds a toast's timer while the pointer is over the stack, the stack
+   has focus, or the window is in the background. The indicator tracks the same
+   clock, so it stops with it. */
+.timeout-indicator-track.paused .timeout-indicator .embeddedProgressPath {
+  animation-play-state: paused;
 }
 
-.toast-leave-active {
-  /* Taken out of flow (pinned via position: fixed in the before-leave hook) so
-     the ones above animate up to fill the gap (via .toast-move) instead of
-     jumping once it is finally removed */
-  transition: opacity 300ms, transform 300ms ease-in;
+/* Fade a toast out as it is pushed towards the edge it is anchored to */
+[data-sonner-toast][data-swiping='true'] .toast,
+[data-sonner-toast][data-swiping='true'] .timeout-indicator-track {
+  /* stylelint-disable-next-line scss/no-global-function-names -- CSS abs(), not the Sass one */
+  opacity: max(0, calc(1 - abs(var(--swipe-amount-x, 0px)) / 200px));
+}
+
+[data-sonner-toast][data-swiping='true'] .toast {
+  cursor: grabbing;
+}
+
+/* Collapsed stack: the toasts behind the front one are layered underneath it,
+   each peeking out by one gap and drawn slightly smaller, and fan out while the
+   pointer is over the stack. Sonner puts both the offset and the shrink in the
+   row's `--y`, but our row spans the full width of the column while the toast
+   sits at one edge of it, so scaling the row would drag the toast towards the
+   middle of the screen. The row keeps the offset and the toast itself takes the
+   shrink, which also leaves the row's measured height alone. */
+.toast-holder[data-sonner-toaster] [data-sonner-toast][data-expanded='false'][data-front='false'] {
+  --y: translateY(calc(var(--lift-amount) * var(--toasts-before)));
+}
+
+/* While the stack is fanned out it is backed by a region that holds the hover. Without one the stack collapses the moment the pointer is
+   between two toasts, or over one that has just been dismissed, and then reopens
+   as the next toast slides under the pointer.
+
+   It has to be a single region behind the whole stack rather than something each
+   toast carries: the rows are stacked in front of one another, so anything a
+   toast held on to would reach over its neighbours and take the clicks and drags
+   meant for them. This sits behind every row instead, so it can only ever be hit
+   where no toast is. Sonner's own equivalents, which do ride along with their
+   toast, are left inert for the same reason.
+
+   It is tied to the stack being fanned out and nothing else. A toast on its way
+   out needs no backdrop of its own: the stack is open for as long as the pointer
+   is on this one, and keeping it alive past that only catches the pointer again
+   once the stack has closed, and opens it right back up. */
+.toast-holder[data-sonner-toaster]:has([data-sonner-toast][data-expanded='true'])::before {
+  position: absolute;
+  z-index: 0;
+  content: '';
+
+  /* Sized from the toasts rather than from the rows they sit in, which span the
+     whole column: a backdrop that wide would hold the stack open, and swallow
+     clicks, most of the way across the window */
+  inline-size: calc(var(--stack-width, 0px) + 80px);
+  block-size: var(--stack-height, 0);
+  pointer-events: auto;
+}
+
+.toast-holder.position-bottom-left[data-sonner-toaster]::before,
+.toast-holder.position-bottom-center[data-sonner-toaster]::before,
+.toast-holder.position-bottom-right[data-sonner-toaster]::before {
+  inset-block-end: 0;
+}
+
+.toast-holder.position-top-left[data-sonner-toaster]::before,
+.toast-holder.position-top-center[data-sonner-toaster]::before,
+.toast-holder.position-top-right[data-sonner-toaster]::before {
+  inset-block-start: 0;
+}
+
+/* Anchored to the same edge as the toasts it backs. */
+/* stylelint-disable liberty/use-logical-spec */
+.toast-holder.position-bottom-left[data-sonner-toaster]::before,
+.toast-holder.position-top-left[data-sonner-toaster]::before {
+  left: -40px;
+}
+
+.toast-holder.position-bottom-right[data-sonner-toaster]::before,
+.toast-holder.position-top-right[data-sonner-toaster]::before {
+  right: -40px;
+}
+
+.toast-holder.position-bottom-center[data-sonner-toaster]::before,
+.toast-holder.position-top-center[data-sonner-toaster]::before {
+  left: 50%;
+  transform: translateX(-50%);
+}
+/* stylelint-enable liberty/use-logical-spec */
+
+/* A drag can carry the pointer well past the backdrop, so the toast being
+   dragged keeps the widened hit area sonner gives it for exactly that. */
+.toast-holder[data-sonner-toaster] [data-sonner-toast][data-swiping='true']::before {
+  pointer-events: auto;
+}
+
+/* A toast on its way out is not worth aiming at, and it covers the one that is
+   about to take its place, so it stops taking input as soon as it is dismissed */
+.toast-holder[data-sonner-toaster] [data-sonner-toast][data-removed='true'] .toast {
   pointer-events: none;
 }
 
-.position-bottom-center .toast-enter-from,
-.position-bottom-center .toast-leave-to {
+/* Only the front toast is readable while the stack is collapsed. The ones
+   behind it are trimmed to its height so the stack reads as one pile of equally
+   sized cards rather than a ragged edge. */
+.toast-holder[data-sonner-toaster] [data-sonner-toast][data-expanded='false'][data-front='false'] .toast-slot,
+.toast-holder[data-sonner-toaster] [data-sonner-toast][data-expanded='false'][data-front='false'] .toast {
+  box-sizing: border-box;
+  inline-size: var(--front-toast-width);
+  block-size: 100%;
+}
+
+.toast-holder[data-sonner-toaster] .image,
+.toast-holder[data-sonner-toaster] .icon,
+.toast-holder[data-sonner-toaster] .message,
+.toast-holder[data-sonner-toaster] .timeout-indicator-track {
+  transition: opacity var(--toast-transition-duration);
+}
+
+.toast-holder[data-sonner-toaster] [data-sonner-toast][data-expanded='false'][data-front='false'] .image,
+.toast-holder[data-sonner-toaster] [data-sonner-toast][data-expanded='false'][data-front='false'] .icon,
+.toast-holder[data-sonner-toaster] [data-sonner-toast][data-expanded='false'][data-front='false'] .message,
+.toast-holder[data-sonner-toaster] [data-sonner-toast][data-expanded='false'][data-front='false'] .timeout-indicator-track {
   opacity: 0;
-  transform: translateY(15px) scale(0.95);
 }
 
-.position-top-center .toast-enter-from,
-.position-top-center .toast-leave-to {
-  opacity: 0;
-  transform: translateY(-15px) scale(0.95);
-}
-
-.position-bottom-left .toast-enter-from,
-.position-bottom-left .toast-leave-to,
-.position-top-left .toast-enter-from,
-.position-top-left .toast-leave-to {
-  opacity: 0;
-  transform: translateX(-15px) scale(0.95);
-}
-
-.position-bottom-right .toast-enter-from,
-.position-bottom-right .toast-leave-to,
-.position-top-right .toast-enter-from,
-.position-top-right .toast-leave-to {
-  opacity: 0;
-  transform: translateX(15px) scale(0.95);
-}
-
-/* When dismissed by a swipe, continue sliding off through that side */
-.toast-slot.dismiss-left.toast-leave-to {
-  transform: translateX(-110%);
-}
-
-.toast-slot.dismiss-right.toast-leave-to {
-  transform: translateX(110%);
-}
-
-/* stack reflow when a toast is removed */
-.toast-move {
-  transition: transform 300ms ease;
+.toast-holder[data-sonner-toaster] [data-sonner-toast][data-expanded='false'][data-front='false'][data-mounted='true']:not([data-removed='true']) .toast-slot {
+  transform: scale(calc(-1 * var(--toasts-before) * 0.05 + 1));
 }
 
 @media (prefers-reduced-motion: reduce) {

--- a/src/renderer/components/FtToast/FtToast.css
+++ b/src/renderer/components/FtToast/FtToast.css
@@ -572,6 +572,20 @@
   transform: scale(calc(-1 * var(--toasts-before) * 0.05 + 1));
 }
 
+/* A collapsed stack shows the toast at the front of it and one card peeking out
+   from behind, however many are waiting: past that the pile is all sliver and no
+   toast. The rest are still there and fan out with it on hover, so this is not
+   sonner's `visibleToasts`, which would hide them whether the stack is open or
+   not. They stop taking pointer input while they are invisible, or the sliver
+   each one would have occupied still takes the click. */
+.toast-holder[data-sonner-toaster] [data-sonner-toast][data-expanded='false']:not([data-index='0'], [data-index='1']) {
+  opacity: 0;
+}
+
+.toast-holder[data-sonner-toaster] [data-sonner-toast][data-expanded='false']:not([data-index='0'], [data-index='1']) .toast {
+  pointer-events: none;
+}
+
 @media (prefers-reduced-motion: reduce) {
   .toast-slot.persistent-slot {
     transition-duration: 1ms;

--- a/src/renderer/components/FtToast/FtToast.css
+++ b/src/renderer/components/FtToast/FtToast.css
@@ -460,20 +460,27 @@
   cursor: grabbing;
 }
 
-/* Collapsed stack: the toasts behind the front one are layered underneath it,
-   each peeking out by one gap and drawn slightly smaller, and fan out while the
-   pointer is over the stack. Sonner puts both the offset and the shrink in the
-   row's `--y`, but our row spans the full width of the column while the toast
-   sits at one edge of it, so scaling the row would drag the toast towards the
-   middle of the screen. The row keeps the offset and the toast itself takes the
-   shrink, which also leaves the row's measured height alone. */
-.toast-holder[data-sonner-toaster] [data-sonner-toast][data-expanded='false'][data-front='false'] {
-  --y: translateY(calc(var(--lift-amount) * var(--toasts-before)));
+/* Collapsed stack: the two newest toasts keep the places they would have when
+   the stack is fanned out, so both can be read at a glance, and everything older
+   is layered underneath them. The whole stack fans out while the pointer is over
+   it.
+
+   Sonner would put the second toast behind the first and leave only one
+   readable, so its place is restored here. It also puts the shrink for the ones
+   underneath in the row's `--y`, but our row spans the full width of the column
+   while the toast sits at one edge of it, so scaling the row would drag the
+   toast towards the middle of the screen. The row keeps the offset and the toast
+   itself takes the shrink, which also leaves the row's measured height alone. */
+.toast-holder[data-sonner-toaster] [data-sonner-toast][data-expanded='false'][data-index='1'] {
+  --y: translateY(calc(var(--lift) * var(--offset)));
+
+  block-size: var(--initial-height);
 }
 
-/* While the stack is fanned out it is backed by a region that holds the hover. Without one the stack collapses the moment the pointer is
-   between two toasts, or over one that has just been dismissed, and then reopens
-   as the next toast slides under the pointer.
+/* While the stack is fanned out it is backed by a region that holds the hover.
+   Without one the stack collapses the moment the pointer is between two toasts,
+   or over one that has just been dismissed, and then reopens as the next toast
+   slides under the pointer.
 
    It has to be a single region behind the whole stack rather than something each
    toast carries: the rows are stacked in front of one another, so anything a
@@ -544,11 +551,11 @@
   pointer-events: none;
 }
 
-/* Only the front toast is readable while the stack is collapsed. The ones
-   behind it are trimmed to its height so the stack reads as one pile of equally
-   sized cards rather than a ragged edge. */
-.toast-holder[data-sonner-toaster] [data-sonner-toast][data-expanded='false'][data-front='false'] .toast-slot,
-.toast-holder[data-sonner-toaster] [data-sonner-toast][data-expanded='false'][data-front='false'] .toast {
+/* The two newest toasts are readable while the stack is collapsed. The ones
+   behind them are trimmed to the front toast's size so the pile reads as one
+   run of equally sized cards rather than a ragged edge. */
+.toast-holder[data-sonner-toaster] [data-sonner-toast][data-expanded='false']:not([data-index='0'], [data-index='1']) .toast-slot,
+.toast-holder[data-sonner-toaster] [data-sonner-toast][data-expanded='false']:not([data-index='0'], [data-index='1']) .toast {
   box-sizing: border-box;
   inline-size: var(--front-toast-width);
   block-size: 100%;
@@ -561,15 +568,15 @@
   transition: opacity var(--toast-transition-duration);
 }
 
-.toast-holder[data-sonner-toaster] [data-sonner-toast][data-expanded='false'][data-front='false'] .image,
-.toast-holder[data-sonner-toaster] [data-sonner-toast][data-expanded='false'][data-front='false'] .icon,
-.toast-holder[data-sonner-toaster] [data-sonner-toast][data-expanded='false'][data-front='false'] .message,
-.toast-holder[data-sonner-toaster] [data-sonner-toast][data-expanded='false'][data-front='false'] .timeout-indicator-track {
+.toast-holder[data-sonner-toaster] [data-sonner-toast][data-expanded='false']:not([data-index='0'], [data-index='1']) .image,
+.toast-holder[data-sonner-toaster] [data-sonner-toast][data-expanded='false']:not([data-index='0'], [data-index='1']) .icon,
+.toast-holder[data-sonner-toaster] [data-sonner-toast][data-expanded='false']:not([data-index='0'], [data-index='1']) .message,
+.toast-holder[data-sonner-toaster] [data-sonner-toast][data-expanded='false']:not([data-index='0'], [data-index='1']) .timeout-indicator-track {
   opacity: 0;
 }
 
-.toast-holder[data-sonner-toaster] [data-sonner-toast][data-expanded='false'][data-front='false'][data-mounted='true']:not([data-removed='true']) .toast-slot {
-  transform: scale(calc(-1 * var(--toasts-before) * 0.05 + 1));
+.toast-holder[data-sonner-toaster] [data-sonner-toast][data-expanded='false']:not([data-index='0'], [data-index='1'])[data-mounted='true']:not([data-removed='true']) .toast-slot {
+  transform: scale(calc(-1 * (var(--toasts-before) - 1) * 0.05 + 1));
 }
 
 /* A collapsed stack shows the toast at the front of it and one card peeking out

--- a/src/renderer/components/FtToast/FtToast.css
+++ b/src/renderer/components/FtToast/FtToast.css
@@ -552,12 +552,13 @@
 }
 
 /* The two newest toasts are readable while the stack is collapsed. The ones
-   behind them are trimmed to the front toast's size so the pile reads as one
-   run of equally sized cards rather than a ragged edge. */
+   behind them are trimmed to the size of the second, which is what they are
+   stacked behind, so the pile tucks under it as one run of equally sized cards
+   rather than a ragged edge. */
 .toast-holder[data-sonner-toaster] [data-sonner-toast][data-expanded='false']:not([data-index='0'], [data-index='1']) .toast-slot,
 .toast-holder[data-sonner-toaster] [data-sonner-toast][data-expanded='false']:not([data-index='0'], [data-index='1']) .toast {
   box-sizing: border-box;
-  inline-size: var(--front-toast-width);
+  inline-size: var(--stacked-toast-width, var(--front-toast-width));
   block-size: 100%;
 }
 
@@ -579,18 +580,14 @@
   transform: scale(calc(-1 * (var(--toasts-before) - 1) * 0.05 + 1));
 }
 
-/* A collapsed stack shows the toast at the front of it and one card peeking out
-   from behind, however many are waiting: past that the pile is all sliver and no
-   toast. The rest are still there and fan out with it on hover, so this is not
-   sonner's `visibleToasts`, which would hide them whether the stack is open or
-   not. They stop taking pointer input while they are invisible, or the sliver
-   each one would have occupied still takes the click. */
+/* Everything from the third toast back piles up behind the second rather than
+   behind the front one, so the two readable toasts sit clear of it and each
+   sliver still shows there is more waiting. Measured from the front toast's slot
+   plus a gap per toast behind it, which assumes the second is about as tall as
+   the front: a taller one covers part of the pile, which costs nothing beyond a
+   shorter peek. */
 .toast-holder[data-sonner-toaster] [data-sonner-toast][data-expanded='false']:not([data-index='0'], [data-index='1']) {
-  opacity: 0;
-}
-
-.toast-holder[data-sonner-toaster] [data-sonner-toast][data-expanded='false']:not([data-index='0'], [data-index='1']) .toast {
-  pointer-events: none;
+  --y: translateY(calc(var(--lift) * (var(--front-toast-height) + var(--gap) * var(--toasts-before))));
 }
 
 @media (prefers-reduced-motion: reduce) {

--- a/src/renderer/components/FtToast/FtToast.css
+++ b/src/renderer/components/FtToast/FtToast.css
@@ -491,10 +491,12 @@
   z-index: 0;
   content: '';
 
-  /* Sized from the toasts rather than from the rows they sit in, which span the
-     whole column: a backdrop that wide would hold the stack open, and swallow
-     clicks, most of the way across the window */
-  inline-size: calc(var(--stack-width, 0px) + 80px);
+  /* Sized to the toasts, and no wider. The rows they sit in span the whole
+     column, and anything that reaches past a toast's own edge both holds the
+     stack open and takes the clicks there: the pointer resting in the margin
+     keeps the stack expanded, which keeps the margin present, so a click beside
+     a toast reaches neither the toast nor the page behind it. */
+  inline-size: var(--stack-width, 0);
   block-size: var(--stack-height, 0);
   pointer-events: auto;
 }
@@ -515,12 +517,12 @@
 /* stylelint-disable liberty/use-logical-spec */
 .toast-holder.position-bottom-left[data-sonner-toaster]::before,
 .toast-holder.position-top-left[data-sonner-toaster]::before {
-  left: -40px;
+  left: 0;
 }
 
 .toast-holder.position-bottom-right[data-sonner-toaster]::before,
 .toast-holder.position-top-right[data-sonner-toaster]::before {
-  right: -40px;
+  right: 0;
 }
 
 .toast-holder.position-bottom-center[data-sonner-toaster]::before,

--- a/src/renderer/components/FtToast/FtToast.vue
+++ b/src/renderer/components/FtToast/FtToast.vue
@@ -12,7 +12,7 @@
       :swipe-directions="swipeDirections"
       :offset="toasterOffset"
       :mobile-offset="toasterOffset"
-      :style="{ '--width': TOAST_WIDTH, '--front-toast-width': frontToastWidth, '--stack-height': stackHeight, '--stack-width': stackWidth }"
+      :style="{ '--width': TOAST_WIDTH, '--front-toast-width': frontToastWidth, '--stacked-toast-width': stackedToastWidth, '--stack-height': stackHeight, '--stack-width': stackWidth }"
     />
     <div
       v-if="showProgressToast"
@@ -150,6 +150,13 @@ const progressToastHeight = ref(0)
  * @type {import('vue').Ref<string|null>}
  */
 const frontToastWidth = ref(null)
+/**
+ * Width of the second toast, as a CSS length. The pile of older toasts sits
+ * behind that one rather than behind the front one, so it is the width they have
+ * to tuck under.
+ * @type {import('vue').Ref<string|null>}
+ */
+const stackedToastWidth = ref(null)
 /**
  * Height of the whole fanned out stack, as a CSS length, used to back it with a
  * region that holds the hover. Without one the stack collapses the moment the
@@ -318,9 +325,11 @@ function measureStack(holder) {
   const width = rows.reduce((widest, row) => {
     return Math.max(widest, row.querySelector('.toast')?.offsetWidth ?? 0)
   }, 0)
+  const stacked = rows[1]?.querySelector('.toast')?.offsetWidth
 
   stackHeight.value = `${height}px`
   stackWidth.value = `${width}px`
+  stackedToastWidth.value = stacked ? `${stacked}px` : null
 }
 
 /**

--- a/src/renderer/components/FtToast/FtToast.vue
+++ b/src/renderer/components/FtToast/FtToast.vue
@@ -129,6 +129,12 @@ const messageIntervals = new Map()
  * @type {(number | string)[]}
  */
 const liveToasts = []
+/**
+ * Removes the abort listener of each toast raised with an abort signal, by toast
+ * id.
+ * @type {Map<number | string, () => void>}
+ */
+const abortListeners = new Map()
 /** @type {import('vue').Ref<Element|null>} */
 const fullscreenTarget = ref(null)
 /** @type {import('vue').Ref<HTMLElement|null>} */
@@ -410,9 +416,13 @@ function open({ detail: { message, time, action, abortSignal, image, icon } }) {
     }, updateDelay))
   }
 
-  abortSignal?.addEventListener('abort', () => {
-    sonner.dismiss(id)
-  })
+  if (abortSignal != null) {
+    const abort = () => sonner.dismiss(id)
+    abortSignal.addEventListener('abort', abort)
+    // The signal can outlive the toast, so the listener has to come off when the
+    // toast goes rather than only when the signal fires
+    abortListeners.set(id, () => abortSignal.removeEventListener('abort', abort))
+  }
 
   liveToasts.push(id)
   while (liveToasts.length > MAX_VISIBLE_TOASTS) {
@@ -425,6 +435,8 @@ function open({ detail: { message, time, action, abortSignal, image, icon } }) {
  */
 function forgetToast(toast) {
   clearMessageInterval(toast.id)
+  abortListeners.get(toast.id)?.()
+  abortListeners.delete(toast.id)
 
   const index = liveToasts.indexOf(toast.id)
   if (index !== -1) {
@@ -498,6 +510,8 @@ onBeforeUnmount(() => {
   removeShowToastListener?.()
   messageIntervals.forEach(clearInterval)
   messageIntervals.clear()
+  abortListeners.forEach(remove => remove())
+  abortListeners.clear()
 })
 </script>
 

--- a/src/renderer/components/FtToast/FtToast.vue
+++ b/src/renderer/components/FtToast/FtToast.vue
@@ -3,76 +3,24 @@
     :to="fullscreenTarget || 'body'"
     :disabled="fullscreenTarget === null"
   >
-    <TransitionGroup
-      tag="div"
-      name="toast"
+    <Toaster
       class="toast-holder"
       :class="[`position-${toastPosition}`, { 'horizontal-tabs': hasHorizontalTabBar }]"
-      @before-leave="onBeforeLeave"
+      :position="SONNER_POSITION"
+      :gap="TOAST_GAP"
+      :visible-toasts="MAX_VISIBLE_TOASTS"
+      :swipe-directions="swipeDirections"
+      :offset="toasterOffset"
+      :mobile-offset="toasterOffset"
+      :style="{ '--width': TOAST_WIDTH, '--front-toast-width': frontToastWidth, '--stack-height': stackHeight, '--stack-width': stackWidth }"
+    />
+    <div
+      v-if="showProgressToast"
+      class="progress-toast-holder"
+      :class="[`position-${toastPosition}`, { 'horizontal-tabs': hasHorizontalTabBar }]"
     >
       <div
-        v-for="toast in toasts"
-        :key="toast.id"
-        class="toast-slot"
-        :class="toast.dismissDirection && `dismiss-${toast.dismissDirection}`"
-        @pointerenter="pause(toast, $event.currentTarget)"
-        @pointerleave="resume(toast)"
-      >
-        <div
-          v-overlay-scrollbars
-          class="toast"
-          :class="{ hasImage: toast.image, actionable: toast.action, dragging: toast.dragging }"
-          :style="dragStyle(toast)"
-          :tabindex="toast.action ? 0 : null"
-          role="status"
-          @click="onClick(toast)"
-          @keydown.enter.prevent="performAction(toast)"
-          @keydown.space.prevent="performAction(toast)"
-          @keydown.esc.prevent="dismiss(toast)"
-          @pointerdown="onPointerDown(toast, $event)"
-          @pointermove="onPointerMove(toast, $event)"
-          @pointerup="onPointerUp(toast, $event)"
-          @pointercancel="onPointerUp(toast, $event)"
-        >
-          <img
-            v-if="toast.image"
-            :src="toast.image"
-            class="image"
-            alt=""
-            draggable="false"
-          >
-          <FontAwesomeIcon
-            v-else-if="toast.icon"
-            :icon="toast.icon"
-            class="icon"
-            fixed-width
-          />
-          <p class="message">
-            {{ toast.message }}
-          </p>
-        </div>
-        <div
-          v-if="showTimeoutIndicator"
-          class="timeout-indicator-track"
-          :class="{ dragging: toast.dragging }"
-          :style="dragStyle(toast)"
-          aria-hidden="true"
-        >
-          <FtEmbeddedProgress
-            class="timeout-indicator"
-            :corner-radius="toastProgressRadius"
-            :end-arc-fraction="0.5"
-            :line-width="toastProgressLineWidth"
-            :start-arc-fraction="0.5"
-            :style="{ '--toast-duration': `${toast.duration}ms` }"
-            @animationstart="onIndicatorAnimationStart(toast, $event)"
-          />
-        </div>
-      </div>
-      <div
-        v-if="showProgressToast"
         ref="progressToast"
-        key="progress"
         class="toast-slot persistent-slot"
         :class="{ minimized: progressToastMinimized }"
         :data-testid="store.getters.getShowProgressBar ? 'progress-toast' : 'subscription-refresh-toast'"
@@ -104,20 +52,21 @@
           />
         </div>
       </div>
-    </TransitionGroup>
+    </div>
   </Teleport>
 </template>
 
 <script setup>
 import { FontAwesomeIcon } from '@fortawesome/vue-fontawesome'
-import { computed, nextTick, onBeforeUnmount, onMounted, reactive, ref, useTemplateRef } from 'vue'
+import { computed, markRaw, nextTick, onBeforeUnmount, onMounted, reactive, ref, useTemplateRef, watch } from 'vue'
 import { useI18n } from 'vue-i18n'
+import { Toaster, toast as sonner } from 'vue-sonner'
 import { normalizeToastPosition } from '../../constants/toastPosition'
 import { showToast, ToastEventBus } from '../../helpers/utils'
 import store from '../../store'
 import FtEmbeddedProgress from '../FtEmbeddedProgress/FtEmbeddedProgress.vue'
+import FtToastItem from './FtToastItem.vue'
 
-let idCounter = 0
 let removeShowToastListener = null
 const { t } = useI18n()
 
@@ -129,41 +78,93 @@ const props = defineProps({
 })
 
 /**
- * @typedef Toast
- * @property {string | (({elapsedMs: number, remainingMs: number}) => string)} message
+ * @typedef ToastState the live state handed to {@link FtToastItem}
+ * @property {string} message
  * @property {Function | null} action
  * @property {string | null} image
  * @property {[string, string] | null} icon
- * @property {NodeJS.Timeout | number} timeout
- * @property {NodeJS.Timeout | number} interval
- * @property {number} id
  * @property {number} duration lifetime of the toast in milliseconds
- * @property {number} remainingMs lifetime remaining when the toast was paused
- * @property {number} expiresAt timestamp the toast is due to auto-dismiss at, used to reschedule after a drag
- * @property {boolean} hovered
- * @property {boolean} dragging
- * @property {boolean} pointerMoved whether the pointer moved enough to count as a drag (suppresses the click action)
- * @property {number} dragOffset current horizontal drag offset in px
- * @property {'left' | 'right' | null} dismissDirection side through which the toast is being dismissed
- * @property {number} [dragStartX] pointer x position where the current drag started
  */
 
-/** Distance in px a toast must be dragged before it slides away instead of snapping back */
-const DRAG_DISMISS_THRESHOLD = 80
+/** How many toasts are on screen at once, oldest first out */
+const MAX_VISIBLE_TOASTS = 5
+/**
+ * Sonner keys its toast list by the `position` prop, so changing it tears the
+ * list down and takes every toast currently on screen with it. The prop is
+ * pinned to one value and the configured position is applied in CSS instead,
+ * off the `position-*` class on the holder.
+ */
+const SONNER_POSITION = 'bottom-left'
+/**
+ * Inline size of the toast column. It spans everything inside the viewport
+ * insets, so each toast is bounded by its own `max-inline-size` rather than by
+ * the column, and the row it sits in only decides which edge it is aligned to.
+ */
+const TOAST_WIDTH = 'calc(100vw - 60px)'
+/**
+ * Distance in px between two toasts: the spacing once the stack is fanned out,
+ * and how far each collapsed toast peeks out from behind the one in front of it.
+ * Sonner lays the stack out from the measured toast heights plus this gap, so
+ * the spacing must not come from margins on the toasts themselves.
+ */
+const TOAST_GAP = 10
+/** Distance in px from the screen edges the toasts are anchored to */
+const VIEWPORT_INSET = 29
+/** Larger top inset that keeps top-positioned toasts below the horizontal tab bar */
+const TAB_BAR_INSET = 61
 /** Distance in px at which the persistent refresh toast gets out of the pointer's way */
 const PROGRESS_TOAST_PROXIMITY = 32
 /** Extra distance required before restoring the toast, to avoid flicker around the boundary */
 const PROGRESS_TOAST_PROXIMITY_HYSTERESIS = 20
 
-/** @type {import('vue').Reactive<Toast[]>} */
-const toasts = reactive([])
-/** @type {Map<number, Animation>} */
-const indicatorAnimations = new Map()
+const toastItem = markRaw(FtToastItem)
+
+/** Intervals refreshing the messages of toasts built from a function, by toast id */
+const messageIntervals = new Map()
+/**
+ * Ids of the toasts currently on screen, oldest first. Sonner keeps everything
+ * past `visibleToasts` queued up out of sight and lets it back in as room frees
+ * up, which would have a toast the user has already seen reappear long after it
+ * was raised, so the queue is capped here instead.
+ * @type {(number | string)[]}
+ */
+const liveToasts = []
 /** @type {import('vue').Ref<Element|null>} */
 const fullscreenTarget = ref(null)
 /** @type {import('vue').Ref<HTMLElement|null>} */
 const progressToast = useTemplateRef('progressToast')
 const progressToastMinimized = ref(false)
+const progressToastHeight = ref(0)
+/**
+ * Width of the toast at the front of the stack, as a CSS length. Sonner records
+ * the front toast's height so it can lay the collapsed stack out from it, but
+ * not its width: its own toasts are all one fixed width, ours are only as wide
+ * as their message. Without this the toasts stacked behind the front one keep
+ * their own widths and stick out from underneath it.
+ * @type {import('vue').Ref<string|null>}
+ */
+const frontToastWidth = ref(null)
+/**
+ * Height of the whole fanned out stack, as a CSS length, used to back it with a
+ * region that holds the hover. Without one the stack collapses the moment the
+ * pointer is between toasts or over one that has just been dismissed, and then
+ * reopens as the next toast slides under the pointer.
+ * @type {import('vue').Ref<string|null>}
+ */
+const stackHeight = ref(null)
+/**
+ * Width of the widest toast in the stack, as a CSS length. The rows the toasts
+ * sit in span the whole column, so the backdrop has to be sized from the toasts
+ * themselves or it reaches most of the way across the window.
+ * @type {import('vue').Ref<string|null>}
+ */
+const stackWidth = ref(null)
+/** @type {ResizeObserver|null} */
+let frontToastResizeObserver = null
+/** @type {MutationObserver|null} */
+let toastListObserver = null
+/** @type {ResizeObserver|null} */
+let progressToastResizeObserver = null
 /** @type {DOMRect|null} */
 let progressToastBounds = null
 /** @type {HTMLElement|null} */
@@ -179,8 +180,34 @@ const toastPosition = computed(() => {
 const hasHorizontalTabBar = computed(() => {
   return process.env.IS_ELECTRON && !store.getters.getUseVerticalTabBar
 })
-/** @type {import('vue').ComputedRef<boolean>} */
-const showTimeoutIndicator = computed(() => store.getters.getShowToastTimeoutIndicator)
+
+/**
+ * Toasts are swiped away towards the screen edge they are anchored to, so they
+ * leave through the nearest edge rather than across the whole window. Centered
+ * toasts have no nearer edge, so they go either way.
+ */
+const swipeDirections = computed(() => {
+  if (toastPosition.value.endsWith('left')) { return ['left'] }
+  if (toastPosition.value.endsWith('right')) { return ['right'] }
+
+  return ['left', 'right']
+})
+
+/**
+ * Keeps the toast column clear of the persistent progress toast, which is
+ * anchored to the same corner but sits outside the toaster.
+ */
+const toasterOffset = computed(() => {
+  const progressInset = showProgressToast.value ? progressToastHeight.value + TOAST_GAP : 0
+
+  return {
+    left: VIEWPORT_INSET,
+    right: VIEWPORT_INSET,
+    bottom: VIEWPORT_INSET + progressInset,
+    top: (hasHorizontalTabBar.value ? TAB_BAR_INSET : VIEWPORT_INSET) + progressInset
+  }
+})
+
 const showProgressToast = computed(() => {
   // The toast holder is teleported into the fullscreen element, so a progress
   // toast would sit on top of the fullscreen player. Hide it until fullscreen
@@ -239,6 +266,58 @@ function updateFullscreenTarget() {
 }
 
 /**
+ * Follows the front toast, which changes as toasts come and go, and remeasures
+ * it whenever it or its message resizes. `offsetWidth` rather than a bounding
+ * box, so a toast measured mid animation reports its laid out width instead of
+ * its scaled one.
+ */
+function trackFrontToast() {
+  const holder = document.querySelector('.toast-holder')
+  const front = holder?.querySelector('[data-sonner-toast] .toast')
+
+  frontToastResizeObserver.disconnect()
+  toastListObserver.disconnect()
+
+  if (holder) {
+    toastListObserver.observe(holder, { childList: true, subtree: true, characterData: true })
+  }
+
+  if (front) {
+    frontToastResizeObserver.observe(front)
+  } else {
+    frontToastWidth.value = null
+  }
+
+  measureStack(holder)
+}
+
+/**
+ * The rows are laid out one gap apart when the stack is fanned out, so their own
+ * heights add up to how much room it takes. `offsetWidth` and `offsetHeight`
+ * rather than bounding boxes, so anything measured mid animation reports its
+ * laid out size instead of its scaled one.
+ * @param {Element|null|undefined} holder
+ */
+function measureStack(holder) {
+  const rows = holder ? [...holder.querySelectorAll('[data-sonner-toast]')] : []
+
+  if (rows.length === 0) {
+    stackHeight.value = null
+    stackWidth.value = null
+    return
+  }
+
+  const height = rows.reduce((total, row) => total + row.offsetHeight, 0) +
+    (rows.length - 1) * TOAST_GAP
+  const width = rows.reduce((widest, row) => {
+    return Math.max(widest, row.querySelector('.toast')?.offsetWidth ?? 0)
+  }, 0)
+
+  stackHeight.value = `${height}px`
+  stackWidth.value = `${width}px`
+}
+
+/**
  * Keeps the non-interactive refresh toast readable until the mouse approaches,
  * then tucks it into its configured edge of the screen. The expanded bounds
  * remain the hit area while minimized so scaling cannot make the state flicker.
@@ -292,321 +371,106 @@ function resetProgressToastProximity() {
  * @param {CustomEvent<{ message: string | (({elapsedMs: number, remainingMs: number}) => string), time: number | null, action: Function | null, abortSignal: AbortSignal | null, image: string | null, icon: [string, string] | null }>} event
  */
 function open({ detail: { message, time, action, abortSignal, image, icon } }) {
-  const id = idCounter++
-
   time ||= 3000
 
-  /** @type {Toast} */
-  const toast = {
-    id,
-    message,
-    action,
+  /** @type {ToastState} */
+  const state = reactive({
+    message: typeof message === 'function' ? message({ elapsedMs: 0, remainingMs: time }) : message,
+    action: action ?? null,
     image: image ?? null,
     icon: icon ?? null,
-    timeout: 0,
-    interval: 0,
+    duration: time
+  })
+
+  const id = sonner.custom(toastItem, {
     duration: time,
-    remainingMs: time,
-    expiresAt: Date.now() + time,
-    hovered: false,
-    dragging: false,
-    pointerMoved: false,
-    dragOffset: 0,
-    dismissDirection: null
-  }
-  let elapsed = 0
-  const updateDelay = 1000
+    // Stated rather than left to the toaster's default: sonner counts the
+    // toasts at a position to work out how they stack in front of one another,
+    // and a toast that names no position is left out of that count, which puts
+    // the whole stack at or below the depth of the list it sits in
+    position: SONNER_POSITION,
+    componentProps: { toast: state },
+    onDismiss: forgetToast,
+    onAutoClose: forgetToast
+  })
 
   if (typeof message === 'function') {
-    toast.message = message({ elapsedMs: elapsed, remainingMs: time - elapsed })
-    toast.interval = setInterval(() => {
+    let elapsed = 0
+    const updateDelay = 1000
+
+    messageIntervals.set(id, setInterval(() => {
       elapsed += updateDelay
-      // Skip last update
-      if (elapsed >= time) { return }
-
-      // We need to locate the object in the array so we get the reactive proxy,
-      // as modifying the original object won't trigger reactive effects such as updating the DOM
-      const toast = toasts.find(t => t.id === id)
-
-      if (toast) {
-        toast.message = message({ elapsedMs: elapsed, remainingMs: time - elapsed })
+      // Skip the last update, the toast is about to go away anyway
+      if (elapsed >= time) {
+        clearMessageInterval(id)
+        return
       }
-    }, updateDelay)
+
+      state.message = message({ elapsedMs: elapsed, remainingMs: time - elapsed })
+    }, updateDelay))
   }
 
-  toast.timeout = setTimeout(remove, time, toast)
-  if (abortSignal != null) {
-    abortSignal.addEventListener('abort', () => {
-      remove(toast)
-    })
-  }
-
-  if (toasts.length > 4) {
-    remove(toasts[0])
-  }
-  toasts.push(toast)
-}
-
-/**
- * @param {Toast} toast
- */
-function performAction(toast) {
-  if (!toast.action) {
-    return
-  }
-
-  toast.action()
-  remove(toast)
-}
-
-/**
- * Dismisses a toast without running its action, for users who want it out of
- * the way. Flags it for the appropriate horizontal leave animation, then removes
- * it on the next tick so the dismiss class is rendered before the leave starts.
- * Removing promptly (rather than after a timeout) lets the toasts above start
- * animating into the freed space without any delay.
- * @param {Toast} toast
- */
-function dismiss(toast, direction = toastPosition.value.endsWith('right') ? 'right' : 'left') {
-  toast.dismissDirection = direction
-  nextTick(() => remove(toast))
-}
-
-/**
- * Runs an available toast action on click, unless the pointer was dragged (in
- * which case the click is the tail end of a drag gesture and should be ignored).
- * @param {Toast} toast
- */
-function onClick(toast) {
-  if (toast.pointerMoved) {
-    toast.pointerMoved = false
-    return
-  }
-  performAction(toast)
-}
-
-/**
- * Pauses auto-dismiss while a toast is hovered.
- * @param {Toast} toast
- * @param {HTMLElement} element
- */
-function pause(toast, element) {
-  if (toast.hovered) { return }
-
-  toast.hovered = true
-  toast.remainingMs = Math.max(0, toast.expiresAt - Date.now())
-  clearTimeout(toast.timeout)
-
-  // `hovered` is already set, so this is the only chance to freeze the line: a
-  // second pointerenter returns early. Retry next frame if the indicator was not
-  // resolvable yet, rather than leaving it draining for the rest of the hover.
-  if (!freezeIndicator(toast, element)) {
-    requestAnimationFrame(() => {
-      if (toast.hovered) { freezeIndicator(toast, element) }
-    })
-  }
-}
-
-/**
- * Finds the drain animation on a toast's timeout indicator. Matched by name
- * rather than taken by index, because `getAnimations()` also reports
- * transitions and orders them before animations.
- * @param {HTMLElement} element the toast's slot
- * @returns {Animation | undefined}
- */
-function findIndicatorAnimation(element) {
-  return element.querySelector('.timeout-indicator .embeddedProgressPath')
-    ?.getAnimations()
-    .find(animation => animation.animationName?.startsWith('toast-timeout'))
-}
-
-/**
- * Seeks a toast's indicator to its true remaining lifetime and holds it there.
- * @param {Toast} toast
- * @param {HTMLElement} element the toast's slot
- * @returns {boolean} whether the animation could be resolved
- */
-function freezeIndicator(toast, element) {
-  const animation = indicatorAnimations.get(toast.id) ?? findIndicatorAnimation(element)
-  if (!animation) { return false }
-
-  animation.currentTime = toast.duration - toast.remainingMs
-  animation.pause()
-  indicatorAnimations.set(toast.id, animation)
-  return true
-}
-
-/**
- * Resumes auto-dismiss once the toast is no longer hovered.
- * @param {Toast} toast
- */
-function resume(toast) {
-  if (!toast.hovered) { return }
-
-  toast.hovered = false
-  toast.expiresAt = Date.now() + toast.remainingMs
-  indicatorAnimations.get(toast.id)?.play()
-
-  if (!toast.dragging) {
-    toast.timeout = setTimeout(remove, toast.remainingMs, toast)
-  }
-}
-
-/**
- * @param {Toast} toast
- * @param {PointerEvent} event
- */
-function onPointerDown(toast, event) {
-  // Only start dragging with the primary (left) mouse button or touch/pen
-  if (event.pointerType === 'mouse' && event.button !== 0) { return }
-
-  toast.dragging = true
-  toast.pointerMoved = false
-  toast.dragStartX = event.clientX
-  toast.dragOffset = 0
-
-  // Hold off auto-dismiss so the toast can't vanish mid-drag. The deadline in
-  // `expiresAt` keeps running, so this can't be used to keep a toast alive.
-  clearTimeout(toast.timeout)
-
-  event.currentTarget.setPointerCapture(event.pointerId)
-}
-
-/**
- * @param {Toast} toast
- * @param {PointerEvent} event
- */
-function onPointerMove(toast, event) {
-  if (!toast.dragging) { return }
-
-  const offset = event.clientX - toast.dragStartX
-
-  if (toastPosition.value.endsWith('left')) {
-    toast.dragOffset = Math.min(0, offset)
-  } else if (toastPosition.value.endsWith('right')) {
-    toast.dragOffset = Math.max(0, offset)
-  } else {
-    toast.dragOffset = offset
-  }
-
-  if (Math.abs(offset) > 5) {
-    toast.pointerMoved = true
-  }
-}
-
-/**
- * @param {Toast} toast
- * @param {PointerEvent} event
- */
-function onPointerUp(toast, event) {
-  if (!toast.dragging) { return }
-
-  toast.dragging = false
-
-  if (Math.abs(toast.dragOffset) > DRAG_DISMISS_THRESHOLD) {
-    dismiss(toast, toast.dragOffset < 0 ? 'left' : 'right')
-  } else {
-    // Snap back into place and resume the auto-dismiss countdown for whatever
-    // is left of the original lifetime. Keeping the deadline absolute matters
-    // for toasts whose action expires on its own schedule (e.g. the playlist
-    // undo toast), which must not stay clickable after that deadline passes.
-    toast.dragOffset = 0
-    if (!toast.hovered) {
-      toast.timeout = setTimeout(remove, Math.max(0, toast.expiresAt - Date.now()), toast)
-    }
-  }
-
-  // Pointer capture can suppress the leave event when a drag ends outside the
-  // toast. Recheck after capture is released so hover cannot remain stuck.
-  const element = event.currentTarget.parentElement
-  requestAnimationFrame(() => {
-    if (!toasts.includes(toast)) { return }
-
-    if (element.matches(':hover')) {
-      pause(toast, element)
-    } else {
-      resume(toast)
-    }
+  abortSignal?.addEventListener('abort', () => {
+    sonner.dismiss(id)
   })
-}
 
-/**
- * Pin a leaving toast to the exact viewport spot it occupied before it is taken
- * out of flow, so the remaining toasts can animate up to fill the gap without
- * the leaving one jumping. Fixed positioning keeps it put even though the
- * bottom-anchored holder shrinks as soon as this toast leaves the flow.
- * @param {HTMLElement} el the `.toast-slot` element being removed
- */
-function onBeforeLeave(el) {
-  const { top, left, width, height } = el.getBoundingClientRect()
-
-  el.style.position = 'fixed'
-  el.style.top = `${top}px`
-  el.style.left = `${left}px`
-  el.style.width = `${width}px`
-  el.style.height = `${height}px`
-  el.style.margin = '0'
-}
-
-/**
- * @param {Toast} toast
- * @returns {Record<string, string | number>}
- */
-function dragStyle(toast) {
-  if (toast.dragOffset === 0) { return {} }
-
-  return {
-    transform: `translateX(${toast.dragOffset}px)`,
-    opacity: Math.max(0, 1 - Math.abs(toast.dragOffset) / 200)
+  liveToasts.push(id)
+  while (liveToasts.length > MAX_VISIBLE_TOASTS) {
+    sonner.dismiss(liveToasts.shift())
   }
 }
 
 /**
- * Associates the browser-managed animation with its toast and seeks it to the
- * true remaining lifetime. Seeking matters if the indicator is enabled while
- * an existing toast is already partway through its lifetime.
- * @param {Toast} toast
- * @param {AnimationEvent} event
+ * @param {{ id: number | string }} toast
  */
-function onIndicatorAnimationStart(toast, event) {
-  const animation = event.target.getAnimations()
-    .find(candidate => candidate.animationName === event.animationName)
-  if (!animation) { return }
+function forgetToast(toast) {
+  clearMessageInterval(toast.id)
 
-  const remainingMs = toast.hovered
-    ? toast.remainingMs
-    : Math.max(0, toast.expiresAt - Date.now())
-
-  animation.currentTime = toast.duration - remainingMs
-  if (toast.hovered) {
-    animation.pause()
-  }
-  indicatorAnimations.set(toast.id, animation)
-}
-
-/**
- * @param {Toast} toast
- */
-function remove(toast) {
-  const index = toasts.indexOf(toast)
-
+  const index = liveToasts.indexOf(toast.id)
   if (index !== -1) {
-    toasts.splice(index, 1)
-    indicatorAnimations.delete(toast.id)
-    cleanup(toast)
+    liveToasts.splice(index, 1)
   }
 }
 
 /**
- * @param {Toast} toast
+ * @param {number | string} id
  */
-function cleanup(toast) {
-  // assumes `toasts.indexOf(toast) !== -1`
-  clearTimeout(toast.timeout)
-  clearInterval(toast.interval)
+function clearMessageInterval(id) {
+  const interval = messageIntervals.get(id)
+
+  if (interval !== undefined) {
+    clearInterval(interval)
+    messageIntervals.delete(id)
+  }
 }
+
+// The toaster is anchored past the progress toast, so its height has to be
+// known before the toasts can be laid out clear of it.
+watch(progressToast, (element) => {
+  progressToastResizeObserver?.disconnect()
+
+  if (!element) {
+    progressToastHeight.value = 0
+    return
+  }
+
+  progressToastResizeObserver ??= new ResizeObserver(([entry]) => {
+    progressToastHeight.value = entry.target.getBoundingClientRect().height
+  })
+  progressToastResizeObserver.observe(element)
+})
+
+// The holder is recreated when the toasts are teleported into or out of a
+// fullscreen element, so the observers have to be pointed at the new one.
+watch(fullscreenTarget, () => nextTick(trackFrontToast))
 
 onMounted(() => {
+  frontToastResizeObserver = new ResizeObserver(([entry]) => {
+    frontToastWidth.value = `${entry.target.offsetWidth}px`
+  })
+  toastListObserver = new MutationObserver(trackFrontToast)
+  trackFrontToast()
+
   ToastEventBus.addEventListener('toast-open', open)
   document.addEventListener('fullscreenchange', updateFullscreenTarget)
   window.addEventListener('mousemove', onProgressToastPointerMove)
@@ -628,9 +492,13 @@ onBeforeUnmount(() => {
   if (progressToastPointerFrame !== null) {
     cancelAnimationFrame(progressToastPointerFrame)
   }
+  progressToastResizeObserver?.disconnect()
+  frontToastResizeObserver?.disconnect()
+  toastListObserver?.disconnect()
   removeShowToastListener?.()
-  toasts.forEach(cleanup)
+  messageIntervals.forEach(clearInterval)
+  messageIntervals.clear()
 })
 </script>
 
-<style scoped src="./FtToast.css" />
+<style src="./FtToast.css" />

--- a/src/renderer/components/FtToast/FtToastItem.vue
+++ b/src/renderer/components/FtToast/FtToastItem.vue
@@ -1,0 +1,130 @@
+<template>
+  <div class="toast-slot">
+    <div
+      v-overlay-scrollbars
+      class="toast"
+      :class="{ hasImage: toast.image, actionable: toast.action }"
+      :tabindex="toast.action ? 0 : null"
+      role="status"
+      @click="onClick"
+      @keydown.enter.prevent="performAction"
+      @keydown.space.prevent="performAction"
+      @keydown.esc.prevent="close"
+      @pointerdown="onPointerDown"
+      @pointerup="onPointerUp"
+    >
+      <img
+        v-if="toast.image"
+        :src="toast.image"
+        class="image"
+        alt=""
+        draggable="false"
+      >
+      <FontAwesomeIcon
+        v-else-if="toast.icon"
+        :icon="toast.icon"
+        class="icon"
+        fixed-width
+      />
+      <p class="message">
+        {{ toast.message }}
+      </p>
+    </div>
+    <div
+      v-if="showTimeoutIndicator"
+      class="timeout-indicator-track"
+      :class="{ paused: isPaused }"
+      aria-hidden="true"
+    >
+      <FtEmbeddedProgress
+        class="timeout-indicator"
+        :corner-radius="toastProgressRadius"
+        :end-arc-fraction="0.5"
+        :line-width="toastProgressLineWidth"
+        :start-arc-fraction="0.5"
+        :style="{ '--toast-duration': `${toast.duration}ms` }"
+      />
+    </div>
+  </div>
+</template>
+
+<script setup>
+import { FontAwesomeIcon } from '@fortawesome/vue-fontawesome'
+import { computed } from 'vue'
+import store from '../../store'
+import FtEmbeddedProgress from '../FtEmbeddedProgress/FtEmbeddedProgress.vue'
+
+/** Distance in px the pointer may travel before a click counts as the tail end of a swipe */
+const CLICK_SLOP = 5
+
+const props = defineProps({
+  /**
+   * The toast's live state, as built by `FtToast`. Mutable so messages built
+   * from a function can be refreshed while the toast is on screen.
+   */
+  toast: {
+    type: Object,
+    required: true
+  },
+  /**
+   * Set by vue-sonner while its timer is on hold: the pointer is over the
+   * toaster, a toast has focus, or the document is hidden. The timeout
+   * indicator follows the same clock, so it freezes with it.
+   */
+  isPaused: {
+    type: Boolean,
+    default: false
+  }
+})
+
+// vue-sonner passes its dismiss handler in as `onCloseToast`
+const emit = defineEmits(['closeToast'])
+
+/** @type {number | null} */
+let pointerDownX = null
+let pointerMoved = false
+
+const showTimeoutIndicator = computed(() => store.getters.getShowToastTimeoutIndicator)
+const toastProgressRadius = computed(() => 12 * store.getters.getUiRoundness / 100)
+const toastProgressLineWidth = computed(() => Math.min(4, Math.max(2, 2 * store.getters.getUiRoundness / 100)))
+
+function close() {
+  emit('closeToast')
+}
+
+function performAction() {
+  if (!props.toast.action) { return }
+
+  props.toast.action()
+  close()
+}
+
+/**
+ * @param {PointerEvent} event
+ */
+function onPointerDown(event) {
+  pointerDownX = event.clientX
+  pointerMoved = false
+}
+
+/**
+ * @param {PointerEvent} event
+ */
+function onPointerUp(event) {
+  pointerMoved = pointerDownX !== null && Math.abs(event.clientX - pointerDownX) > CLICK_SLOP
+  pointerDownX = null
+}
+
+/**
+ * Runs an available toast action on click, unless the pointer was dragged (in
+ * which case the click is the tail end of a swipe gesture and should be ignored).
+ */
+function onClick() {
+  if (pointerMoved) {
+    pointerMoved = false
+    return
+  }
+
+  performAction()
+}
+</script>

--- a/src/renderer/components/FtToast/FtToastItem.vue
+++ b/src/renderer/components/FtToast/FtToastItem.vue
@@ -1,5 +1,8 @@
 <template>
-  <div class="toast-slot">
+  <div
+    ref="slot"
+    class="toast-slot"
+  >
     <div
       v-overlay-scrollbars
       class="toast"
@@ -9,7 +12,6 @@
       @click="onClick"
       @keydown.enter.prevent="performAction"
       @keydown.space.prevent="performAction"
-      @keydown.esc.prevent="close"
       @pointerdown="onPointerDown"
       @pointerup="onPointerUp"
     >
@@ -50,7 +52,7 @@
 
 <script setup>
 import { FontAwesomeIcon } from '@fortawesome/vue-fontawesome'
-import { computed } from 'vue'
+import { computed, onBeforeUnmount, onMounted, useTemplateRef } from 'vue'
 import store from '../../store'
 import FtEmbeddedProgress from '../FtEmbeddedProgress/FtEmbeddedProgress.vue'
 
@@ -83,6 +85,10 @@ const emit = defineEmits(['closeToast'])
 /** @type {number | null} */
 let pointerDownX = null
 let pointerMoved = false
+/** @type {HTMLElement | null} */
+let row = null
+
+const slot = useTemplateRef('slot')
 
 const showTimeoutIndicator = computed(() => store.getters.getShowToastTimeoutIndicator)
 const toastProgressRadius = computed(() => 12 * store.getters.getUiRoundness / 100)
@@ -91,6 +97,30 @@ const toastProgressLineWidth = computed(() => Math.min(4, Math.max(2, 2 * store.
 function close() {
   emit('closeToast')
 }
+
+/**
+ * Dismisses a toast the user has reached with the keyboard. The handler belongs
+ * on the row rather than on the toast: the row is what sonner makes focusable,
+ * both for its own hotkey and for tabbing, while the toast itself only takes
+ * focus when it has an action to run. Bound on the row a key press reaches every
+ * toast, and one that ran an action still bubbles up to here.
+ * @param {KeyboardEvent} event
+ */
+function onRowKeydown(event) {
+  if (event.key !== 'Escape') { return }
+
+  event.preventDefault()
+  close()
+}
+
+onMounted(() => {
+  row = slot.value?.parentElement ?? null
+  row?.addEventListener('keydown', onRowKeydown)
+})
+
+onBeforeUnmount(() => {
+  row?.removeEventListener('keydown', onRowKeydown)
+})
 
 function performAction() {
   if (!props.toast.action) { return }

--- a/src/renderer/main.js
+++ b/src/renderer/main.js
@@ -19,6 +19,8 @@ import { initializeAppScrollbars, overlayScrollbarsDirective } from './helpers/o
 // import the styles
 import '@fortawesome/fontawesome-svg-core/styles.css'
 import 'overlayscrollbars/styles/overlayscrollbars.css'
+// Only the positioning and stacking rules are used, FtToast supplies the design
+import 'vue-sonner/style.css'
 
 import { register as registerSwiper } from 'swiper/element'
 


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Make sure to follow the contributing guidelines. -->
<!-- Important note, we may remove your pull request if you do not use this provided PR template correctly. -->
<!-- Agent instructions: Preserve every heading, comment, and marker in this template. Never remove or rewrite the release-note-category:start/end, release-note:start/end, or release-note-image:start/end marker pairs. Never remove or rewrite the Release note images section; leave its contents for a human. -->

## Pull Request Type
<!-- Please select what type of pull request this is: [x] -->
- [ ] Bugfix
- [ ] Feature Implementation
- [ ] Documentation
- [x] Other

## Related issue
<!-- Please link the issue your pull request is referring to. -->
<!-- If this pull request fully resolves the relevant issue, put "closes" before the issue number. -->
<!-- Example: "closes #123456". -->

## Description
<!-- Please write a clear and concise description of what the pull request does. -->

Rebuilds the toasts on top of [vue-sonner](https://vue-sonner.robertshaw.me/) instead of the hand-rolled implementation. Sonner takes over the toast queue, the timers, the stacking, the enter and leave animations, the hover pause and swipe to dismiss, which drops roughly 250 lines of bookkeeping from `FtToast.vue`.

The design is unchanged. Sonner's own visual styling never applies, because toasts rendered from a component are unstyled, so everything you see is still ours: the dark rounded card, the wall-clock timeout indicator wrapped around it, the image and icon variants, all six positions, and the persistent progress toast. Toast geometry comes out identical to the pixel in every position.

What is new is that the stack now collapses into a pile and fans out when the pointer is over it, the way sonner does. Two things needed extra care to make that work with our toasts:

- Sonner's toasts are all one fixed width, ours are only as wide as their message, so the front toast's width is published to the ones stacked behind it. Otherwise a wide toast behind a narrow one sticks out from under the pile as a blank slab.
- The stack is backed by a region sized to the toasts that holds the hover. Without it the stack collapses the moment the pointer is between two toasts, or on one that has just been dismissed, and then reopens as the next toast slides underneath it. It sits behind every toast, so it can never take a click meant for one.

`vue-sonner` is patched in one place. It reserves a dismissed toast's height until well after the toast has gone, which leaves the gap hanging open and then snaps it shut a third of a second later. The patch releases it on dismissal, so the stack closes the gap while the toast is still animating out, which is what the previous implementation did.

Two behaviours deliberately change to match sonner:

- Hovering holds the whole stack rather than just the toast under the pointer.
- A fast flick dismisses a toast in either direction. A deliberate drag still only dismisses towards the edge the toast is anchored to, as before.

`showToast` and its callers are untouched.

## Release note category
<!-- Select exactly one category. Every pull request must select one. -->
<!-- release-note-category:start -->
- [ ] Not noteworthy
- [ ] Highlights
- [x] More improvements
- [ ] Fixed bugs
<!-- release-note-category:end -->

## Release note
<!-- Required unless "Not noteworthy" is selected. -->
<!-- Write one concise, user-facing entry without a leading bullet. -->
<!-- release-note:start -->
Toasts now stack into a pile that fans out when you move the pointer over it, and hovering anywhere on the stack holds all of them until you move away
<!-- release-note:end -->

## Release note images
<!-- Human-only: Agents must preserve this entire section and leave it empty. -->
<!-- Optional. Paste one or more Markdown images or HTML image tags here. -->
<!-- The release notes will use an HTML image tag and limit images taller than 300 pixels. -->
<!-- release-note-image:start -->
<img width="472" height="302" alt="Screencast_20260812_101741" src="https://github.com/user-attachments/assets/edd96223-5e9c-495f-9f7f-74c0ced143d0" />
<!-- release-note-image:end -->

## Testing
<!-- How can reviewers verify that the PR produces correct results? -->
<!-- Please provide instructions so that others can ensure that your pull request would produce correct results. For examples see, https://github.com/FreeTubeApp/FreeTube/pull/5743, https://github.com/FreeTubeApp/FreeTube/pull/7349, https://github.com/FreeTubeApp/FreeTube/pull/5125, https://github.com/FreeTubeApp/FreeTube/pull/7338 -->
<!-- Agent instructions: Only write human-facing steps that explain how to verify the change while running this branch in dev mode. Include expected results and, when applicable, helpful console snippets for interactive verification. Do not include automated checks, commands, results, pass counts, or CI status. -->

Run the app in dev mode. Note that this branch patches a dependency, so run an install and start the dev server fresh, otherwise the patch will not be in the bundle.

Raising a few toasts by hand from the renderer devtools console is the quickest way in:

```js
for (const name of ['First', 'Second', 'Third', 'Fourth']) {
  window.ftElectron.showToastOnAllTabs(`${name} toast`, 30000)
}
```

- **The pile.** The four toasts sit stacked on top of one another, only the newest readable, each one behind it peeking out by a few pixels and drawn slightly smaller. Move the pointer onto the pile and it fans out into a column; move away and it closes again.
- **Moving between toasts.** With the stack fanned out, run the pointer from one toast up to the next. It must stay open the whole way, including across the gaps. Move clear of the toasts and it closes.
- **Dismissing from the middle.** Fan the stack out, then swipe a middle toast sideways towards the edge it is anchored to, or press <kbd>Esc</kbd> while it is focused. Only that toast goes, the ones above slide down to close the gap in one continuous movement with no bounce, and the stack stays fanned out under the pointer rather than snapping shut and reopening. The toast you dismissed must not block the ones around it while it animates out; you should be able to grab a neighbour immediately.
- **Dragging.** Drag a toast away from the edge it is anchored to and let go: it snaps back. Drag it towards that edge past roughly a finger's width and it slides away. It fades as you push it.
- **Timers.** Raise a toast with a short lifetime, `window.ftElectron.showToastOnAllTabs('Short toast', 3000)`, and hover the stack. Everything on it stops counting down, including the ring around the toast, and resumes when you move away.
- **Positions.** Change Toast Position in Settings → Theme through all six values and raise a toast for each. It should sit in the right corner, slide in from the nearest edge, and its timeout ring should drain away towards that corner. Changing the setting while toasts are on screen must not make them disappear.
- **The rest.** Image toasts (favourite a video from a video's context menu), icon toasts (mark a video as watched), the error toast that copies to the clipboard when clicked, and the progress toast during a subscription refresh should all look and behave as they did before.

## Additional context
<!-- Add any other context about the pull request here. -->

A few notes for review:

- `showToast`, `showToastOnAllTabs`, `showApiErrorToast` and `useTabToast` keep their signatures, so no caller changed.
- Sonner keys its toast list by the `position` prop, so changing it tears the list down and takes every toast on screen with it. The prop is pinned and the configured position is applied in CSS instead.
- Sonner measures a toast's row while its enter animation is still running, so the enter and collapse scales are applied to the toast rather than to the row it sits in. A scale on the row makes it record heights that are too small and the stack drifts.
- Sonner works out how toasts stack in front of one another from the number of toasts at a position, and a toast that names no position is left out of that count, which puts the whole stack at or below depth zero. Each toast now states its position.
- The toasts kept a five toast limit. Sonner would instead queue the extras out of sight and let an old one back in when a slot frees up.
- The stylesheet deliberately qualifies its overrides with `[data-sonner-toaster]` / `[data-sonner-toast]` so they beat sonner's own rules on specificity rather than on import order.
