### PR TITLE
Shorten rounded view counts with K/M/B suffixes

### DIFF
--- a/src/renderer/components/DistractionSettings/DistractionSettings.vue
+++ b/src/renderer/components/DistractionSettings/DistractionSettings.vue
@@ -17,6 +17,15 @@
           @change="updateHideVideoViews"
         />
         <FtToggleSwitch
+          :label="t('Settings.Distraction Free Settings.Shorten View Counts')"
+          :compact="true"
+          :disabled="hideVideoViews"
+          :default-value="shortenViewCounts"
+          setting-key="shortenViewCounts"
+          :tooltip="t('Tooltips.Distraction Free Settings.Shorten View Counts')"
+          @change="updateShortenViewCounts"
+        />
+        <FtToggleSwitch
           :label="t('Settings.Distraction Free Settings.Hide Channel Subscribers')"
           :compact="true"
           :default-value="hideChannelSubscriptions"
@@ -370,6 +379,16 @@ const hideVideoViews = computed(() => store.getters.getHideVideoViews)
  */
 function updateHideVideoViews(value) {
   store.dispatch('updateHideVideoViews', value)
+}
+
+/** @type {import('vue').ComputedRef<boolean>} */
+const shortenViewCounts = computed(() => store.getters.getShortenViewCounts)
+
+/**
+ * @param {boolean} value
+ */
+function updateShortenViewCounts(value) {
+  store.dispatch('updateShortenViewCounts', value)
 }
 
 /** @type {import('vue').ComputedRef<boolean>} */

--- a/src/renderer/components/FtListVideo/FtListVideo.vue
+++ b/src/renderer/components/FtListVideo/FtListVideo.vue
@@ -474,7 +474,6 @@ const channelName = ref(null)
 const channelId = ref(null)
 const channelCollaborators = ref([])
 const viewCount = ref(0)
-const parsedViewCount = ref('')
 const uploadedTime = ref('')
 const lengthSeconds = ref(0)
 const duration = ref('')
@@ -1007,6 +1006,14 @@ const hideVideoViews = computed(() => store.getters.getHideVideoViews)
 /** @type {import('vue').ComputedRef<boolean>} */
 const shortenViewCounts = computed(() => store.getters.getShortenViewCounts)
 
+const parsedViewCount = computed(() => {
+  if (props.data.viewCount != null) {
+    return formatViewCount(props.data.viewCount, shortenViewCounts.value)
+  }
+
+  return props.data.viewCountText?.replace(' views', '') ?? ''
+})
+
 const addWatchedStyle = computed(() => {
   return isWatched.value && (!inHistory.value || props.showWatchedStyleInHistory)
 })
@@ -1497,13 +1504,7 @@ function parseVideoData() {
     }
   }
 
-  if (hideVideoViews.value) {
-    hideViews.value = true
-  } else if (props.data.viewCount !== undefined && props.data.viewCount !== null) {
-    parsedViewCount.value = formatViewCount(props.data.viewCount, shortenViewCounts.value)
-  } else if (props.data.viewCountText !== undefined) {
-    parsedViewCount.value = props.data.viewCountText.replace(' views', '')
-  } else {
+  if (hideVideoViews.value || (props.data.viewCount == null && props.data.viewCountText === undefined)) {
     hideViews.value = true
   }
 }

--- a/src/renderer/components/FtListVideo/FtListVideo.vue
+++ b/src/renderer/components/FtListVideo/FtListVideo.vue
@@ -353,7 +353,7 @@ import store from '../../store/index'
 import {
   copyToClipboard,
   formatDurationAsTimestamp,
-  formatNumber,
+  formatViewCount,
   getCachedOembedTitle,
   getOembedTitle,
   getRelativeTimeFromDate,
@@ -1004,6 +1004,9 @@ const toastThumbnail = computed(() => thumbnailPreference.value === 'hidden' ? n
 /** @type {import('vue').ComputedRef<boolean>} */
 const hideVideoViews = computed(() => store.getters.getHideVideoViews)
 
+/** @type {import('vue').ComputedRef<boolean>} */
+const shortenViewCounts = computed(() => store.getters.getShortenViewCounts)
+
 const addWatchedStyle = computed(() => {
   return isWatched.value && (!inHistory.value || props.showWatchedStyleInHistory)
 })
@@ -1497,7 +1500,7 @@ function parseVideoData() {
   if (hideVideoViews.value) {
     hideViews.value = true
   } else if (props.data.viewCount !== undefined && props.data.viewCount !== null) {
-    parsedViewCount.value = formatNumber(props.data.viewCount)
+    parsedViewCount.value = formatViewCount(props.data.viewCount, shortenViewCounts.value)
   } else if (props.data.viewCountText !== undefined) {
     parsedViewCount.value = props.data.viewCountText.replace(' views', '')
   } else {

--- a/src/renderer/components/PlaylistInfo/PlaylistInfo.vue
+++ b/src/renderer/components/PlaylistInfo/PlaylistInfo.vue
@@ -303,6 +303,7 @@ import {
   ctrlFHandler,
   debounce,
   formatNumber,
+  formatViewCount,
   showToast,
   getTodayDateStrLocalTimezone,
   writeFileWithPicker,
@@ -473,7 +474,10 @@ const allPlaylists = computed(() => store.getters.getAllPlaylists)
 
 const firstVideoIdExists = computed(() => props.firstVideoId !== '')
 
-const parsedViewCount = computed(() => formatNumber(props.viewCount))
+/** @type {import('vue').ComputedRef<boolean>} */
+const shortenViewCounts = computed(() => store.getters.getShortenViewCounts)
+
+const parsedViewCount = computed(() => formatViewCount(props.viewCount, shortenViewCounts.value))
 const parsedVideoCount = computed(() => formatNumber(props.videoCount))
 
 /** @type {import('vue').ComputedRef<string>} */

--- a/src/renderer/components/WatchVideoInfo/WatchVideoInfo.vue
+++ b/src/renderer/components/WatchVideoInfo/WatchVideoInfo.vue
@@ -290,7 +290,7 @@ import store from '../../store'
 import { vSaferHtml } from '../../directives/vSaferHtml'
 
 import { linkifyHashtagsAndHandles } from '../../helpers/descriptionLinks'
-import { escapeHTML, formatNumber, getRelativeTimeFromDate, getVideoThumbnailUrl, openInternalPath, showToast } from '../../helpers/utils'
+import { escapeHTML, formatNumber, formatViewCount, getRelativeTimeFromDate, getVideoThumbnailUrl, openInternalPath, showToast } from '../../helpers/utils'
 import { translateSponsorBlockCategory } from '../../helpers/player/utils'
 import { parseChannelPreferences } from '../../helpers/channel-preferences'
 import { useTabContext } from '../../tabs/TabContext'
@@ -563,12 +563,15 @@ const likePercentageRatio = computed(() => {
 /** @type {import('vue').ComputedRef<boolean>} */
 const hideVideoViews = computed(() => store.getters.getHideVideoViews)
 
+/** @type {import('vue').ComputedRef<boolean>} */
+const shortenViewCounts = computed(() => store.getters.getShortenViewCounts)
+
 const parsedViewCount = computed(() => {
   if (hideVideoViews.value || props.viewCount == null) {
     return null
   }
 
-  return t('Global.Counts.View Count', { count: formatNumber(props.viewCount) }, props.viewCount)
+  return t('Global.Counts.View Count', { count: formatViewCount(props.viewCount, shortenViewCounts.value) }, props.viewCount)
 })
 
 const validPublishedDate = computed(() => {

--- a/src/renderer/helpers/utils.js
+++ b/src/renderer/helpers/utils.js
@@ -4,6 +4,7 @@ import router from '../router/index'
 import { getTabNavigationService } from '../tabs/TabNavigationService'
 import { UnsupportedPlayerActions } from '../../constants'
 import { getPreferredShortThumbnailUrl } from './player/shorts'
+import { isRoundedNumber } from './viewCounts'
 
 // allowed characters in channel handle: A-Z, a-z, 0-9, -, _, .
 // https://support.google.com/youtube/answer/11585688#change_handle
@@ -919,6 +920,17 @@ export function toDistractionFreeTitle(title, minUpperCase = 3) {
  */
 export function formatNumber(number, options = undefined) {
   return Intl.NumberFormat([i18n.global.locale.value, 'en'], options).format(number)
+}
+
+/**
+ * Formats a view count, using compact notation (e.g. 14K, 3.5M) when YouTube gave us
+ * an already rounded number, as the trailing zeros just waste space in that case.
+ * @param {number} viewCount
+ * @param {boolean} shorten the user's "Shorten View Counts" setting
+ * @returns {string}
+ */
+export function formatViewCount(viewCount, shorten) {
+  return formatNumber(viewCount, shorten && isRoundedNumber(viewCount) ? { notation: 'compact' } : undefined)
 }
 
 export function getTodayDateStrLocalTimezone() {

--- a/src/renderer/helpers/viewCounts.js
+++ b/src/renderer/helpers/viewCounts.js
@@ -1,0 +1,21 @@
+/**
+ * Checks whether a number looks like it was rounded for display by YouTube,
+ * e.g. 14000 (14K) or 3500000 (3.5M), by verifying that it matches the precision
+ * that YouTube's compact numbers have: at most one decimal place for the leading
+ * digit and no decimal places from the second digit onwards.
+ * @param {number} number
+ * @returns {boolean}
+ */
+export function isRoundedNumber(number) {
+  if (!Number.isFinite(number) || number < 1000) {
+    return false
+  }
+
+  // 1000 for thousands, 1000000 for millions and so on
+  const magnitude = 10 ** (3 * Math.floor(Math.log10(number) / 3))
+
+  // e.g. 3500000 is allowed to be 3.5M, but 12300000 must be 12M, so it isn't a rounded number
+  const step = number / magnitude < 10 ? magnitude / 10 : magnitude
+
+  return number % step === 0
+}

--- a/src/renderer/store/modules/settings.js
+++ b/src/renderer/store/modules/settings.js
@@ -279,6 +279,7 @@ const state = {
   hideUpcomingPremieres: false,
   hideVideoLikesAndDislikes: false,
   hideVideoViews: false,
+  shortenViewCounts: true,
   hideWatchedSubs: false,
   hideUploader: false,
   unsubscriptionPopupStatus: false,

--- a/static/locales/en-US.yaml
+++ b/static/locales/en-US.yaml
@@ -864,6 +864,7 @@ Settings:
       Watch Page: Watch Page
       General: General
     Hide Video Views: Hide Video Views
+    Shorten View Counts: Shorten View Counts
     Hide Video Likes And Dislikes: Hide Video Likes And Dislikes
     Hide Channel Subscribers: Hide Channel Subscribers
     Hide Comment Likes: Hide Comment Likes
@@ -1808,6 +1809,7 @@ Tooltips:
       and for audio conversion. By default, OpenTubeX will assume that FFmpeg can be found
       via the PATH environment variable. If needed, a custom path can be set here.
   Distraction Free Settings:
+    Shorten View Counts: Shows view counts that YouTube has already rounded in a shortened form, e.g. 14K instead of 14,000. Exact view counts are always shown in full.
     Hide Channels: Enter a channel ID to hide all videos, playlists and the channel itself from appearing in search, trending, most popular and recommended.
        The channel ID entered must be a complete match and is case sensitive.
     Hide Subscriptions Live: 'This setting is overridden by the app-wide "{appWideSetting}" setting, in the "{subsection}" section of the "{settingsSection}"'

--- a/tests/unit/view-counts.test.mjs
+++ b/tests/unit/view-counts.test.mjs
@@ -1,0 +1,52 @@
+import assert from 'node:assert/strict'
+import test from 'node:test'
+
+import { isRoundedNumber } from '../../src/renderer/helpers/viewCounts.js'
+
+/** Mirrors `formatViewCount` in src/renderer/helpers/utils.js, which pulls in the locale from vue-i18n. */
+function formatViewCount(viewCount, shorten = true, locale = 'en') {
+  return new Intl.NumberFormat([locale], shorten && isRoundedNumber(viewCount) ? { notation: 'compact' } : undefined)
+    .format(viewCount)
+}
+
+test('shortens the view counts that YouTube already rounded', () => {
+  assert.equal(formatViewCount(1000), '1K')
+  assert.equal(formatViewCount(1400), '1.4K')
+  assert.equal(formatViewCount(14000), '14K')
+  assert.equal(formatViewCount(143000), '143K')
+  assert.equal(formatViewCount(3500000), '3.5M')
+  assert.equal(formatViewCount(1200000000), '1.2B')
+})
+
+test('keeps exact view counts as they are', () => {
+  assert.equal(formatViewCount(1234567), '1,234,567')
+  assert.equal(formatViewCount(4321), '4,321')
+  assert.equal(formatViewCount(999), '999')
+  assert.equal(formatViewCount(0), '0')
+})
+
+// Shortening these would drop digits that YouTube's own compact numbers never have,
+// so they can't have come from a rounded view count.
+test('does not shorten numbers that compact notation cannot represent exactly', () => {
+  assert.equal(formatViewCount(12300000), '12,300,000')
+  assert.equal(formatViewCount(1050000), '1,050,000')
+  assert.equal(formatViewCount(1234000), '1,234,000')
+})
+
+test('leaves the compact notation to the locale', () => {
+  // The separators are non-breaking spaces
+  assert.equal(formatViewCount(3500000, true, 'de'), '3,5\u00a0Mio.')
+  // Indian numbering groups by lakh instead of million
+  assert.equal(formatViewCount(3500000, true, 'hi'), '35\u00a0\u0932\u093e\u0916')
+})
+
+test('ignores view counts that are not usable numbers', () => {
+  assert.equal(isRoundedNumber(Number.NaN), false)
+  assert.equal(isRoundedNumber(Number.POSITIVE_INFINITY), false)
+  assert.equal(isRoundedNumber(-14000), false)
+})
+
+test('keeps the full numbers when the user opted out of shortening', () => {
+  assert.equal(formatViewCount(14000, false), '14,000')
+  assert.equal(formatViewCount(3500000, false), '3,500,000')
+})


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Make sure to follow the contributing guidelines. -->
<!-- Important note, we may remove your pull request if you do not use this provided PR template correctly. -->
<!-- Agent instructions: Preserve every heading, comment, and marker in this template. Never remove or rewrite the release-note-category:start/end, release-note:start/end, or release-note-image:start/end marker pairs. Never remove or rewrite the Release note images section; leave its contents for a human. -->

## Pull Request Type
<!-- Please select what type of pull request this is: [x] -->
- [ ] Bugfix
- [x] Feature Implementation
- [ ] Documentation
- [ ] Other

## Related issue
<!-- Please link the issue your pull request is referring to. -->
<!-- If this pull request fully resolves the relevant issue, put "closes" before the issue number. -->
<!-- Example: "closes #123456". -->
closes #608

## Description
<!-- Please write a clear and concise description of what the pull request does. -->
View counts that YouTube already rounded are now shown in shortened form, e.g. `14K` instead of `14,000` and `3.5M` instead of `3,500,000`, since the trailing zeros of an approximated number just waste space.

Exact view counts are left alone. A number is treated as rounded only when it matches the precision that YouTube's own compact numbers have: at most one decimal place for the leading digit and none from the second digit onwards. So `14,000` and `3,500,000` are shortened, while `1,234,567`, `12,300,000` and `1,050,000` stay as they are, because compact notation could not show them without dropping digits.

The shortening uses `Intl.NumberFormat`'s compact notation, so it follows the display locale, including locales that don't group by thousands (e.g. `35 लाख` in Hindi and `3,5 Mio.` in German).

Affected view counts: video lists, the watch page and playlist info.

The new "Shorten View Counts" toggle in Distraction Free Settings turns it off (enabled by default). It sits right below "Hide Video Views" and is disabled while views are hidden entirely.

## Release note category
<!-- Select exactly one category. Every pull request must select one. -->
<!-- Select "Not noteworthy" when the pull request fixes a bug in or improves functionality that has not yet appeared in a stable release. -->
<!-- release-note-category:start -->
- [ ] Not noteworthy
- [ ] Highlights
- [x] More improvements
- [ ] Fixed bugs
<!-- release-note-category:end -->

## Release note
<!-- Required unless "Not noteworthy" is selected. -->
<!-- Write one concise, user-facing entry without a leading bullet. -->
<!-- release-note:start -->
View counts that YouTube already rounded are now shortened, e.g. 14K instead of 14,000, which can be turned off with the new "Shorten View Counts" setting
<!-- release-note:end -->

## Release note images
<!-- Human-only: Agents must preserve this entire section and leave it empty. -->
<!-- Optional. Paste one or more Markdown images or HTML image tags here. -->
<!-- The release notes will use an HTML image tag and limit images taller than 300 pixels. -->
<!-- release-note-image:start -->

<!-- release-note-image:end -->

## Testing
<!-- How can reviewers verify that the PR produces correct results? -->
<!-- Please provide instructions so that others can ensure that your pull request would produce correct results. For examples see, https://github.com/FreeTubeApp/FreeTube/pull/5743, https://github.com/FreeTubeApp/FreeTube/pull/7349, https://github.com/FreeTubeApp/FreeTube/pull/5125, https://github.com/FreeTubeApp/FreeTube/pull/7338 -->
<!-- Agent instructions: Only write human-facing steps that explain how to verify the change while running this branch in dev mode. Include expected results and, when applicable, helpful console snippets for interactive verification. Do not include automated checks, commands, results, pass counts, or CI status. -->
1. Open a search, the trending page or a subscription feed and look at the view counts under the videos. Ones that YouTube rounded now read like `14K`, `143K` or `3.5M`, while videos with exact counts still show the full number, e.g. `1,234,567 views`.
2. Open a video's watch page and check the view count next to the title, it follows the same rule.
3. Open a playlist and check the view count in the playlist info.
4. Switch the display language in Settings → General to German or Hindi and reload. The shortened counts use that locale's notation (`3,5 Mio.` / `35 लाख`) instead of `3.5M`.
5. Go to Settings → Distraction Free Settings → General and turn off "Shorten View Counts". View counts are shown in full again, e.g. `14,000 views`.
6. Turn on "Hide Video Views" in the same section. The "Shorten View Counts" toggle greys out, since there are no view counts left to shorten.

## Additional context
<!-- Add any other context about the pull request here. -->
The detection of rounded numbers lives in its own helper (`src/renderer/helpers/viewCounts.js`) so it can be unit tested without pulling in the rest of `helpers/utils.js`, which is covered by `tests/unit/view-counts.test.mjs`.
