### PR TITLE
fix: prevent description controls from overlapping

### DIFF
--- a/e2e/tests/offline/watch-page.spec.mjs
+++ b/e2e/tests/offline/watch-page.spec.mjs
@@ -72,7 +72,26 @@ test.describe('watch page', () => {
     const description = page.locator(`${activeTab} .videoDescription`)
     const descriptionText = description.locator('.description')
     const tags = description.locator('.videoTags')
-    await description.locator(':scope > .descriptionStatus').click()
+    const expandControl = description.locator(':scope > .descriptionStatus')
+    await description.evaluate(element => { element.style.height = '70px' })
+    await expect(expandControl).toHaveClass(/avoidCopyButton/)
+    expect(await expandControl.evaluate((element, copyButton) => {
+      const expandRect = element.getBoundingClientRect()
+      const copyRect = copyButton.getBoundingClientRect()
+      return (
+        expandRect.top < copyRect.bottom &&
+        expandRect.bottom > copyRect.top &&
+        expandRect.left < copyRect.right &&
+        expandRect.right > copyRect.left
+      )
+    }, await description.locator('.descriptionCopyButton').elementHandle())).toBe(false)
+
+    await description.evaluate(element => { element.style.height = '160px' })
+    await expect(expandControl).not.toHaveClass(/avoidCopyButton/)
+    await expect(expandControl).toHaveCSS('inset-inline-end', '16px')
+    await description.evaluate(element => { element.style.height = '' })
+
+    await expandControl.click()
     await expect(tags.locator('.videoTagLink')).toHaveText(['first tag', 'second tag'])
     await expect(tags.locator('.videoTagLink').first()).toHaveAttribute('href', /\/search\/first%20tag/)
     await expect(description.locator('.descriptionScroll')).toHaveCSS('overflow-anchor', 'none')
@@ -121,6 +140,30 @@ test.describe('watch page', () => {
     await description.locator('.descriptionCopyButton button').click()
     await expect(page.locator('.toast', { hasText: 'Description copied to clipboard' })).toBeVisible()
     await expect.poll(() => app.electronApp.evaluate(({ clipboard }) => clipboard.readText())).toBe(videoDescription)
+    await watchComponent.dispose()
+  })
+
+  test('handles videos without a description', async ({ app, page }) => {
+    await mockPlayableWatchPage(app, page)
+    await openMockedVideo(page)
+
+    const pageErrors = []
+    page.on('pageerror', error => pageErrors.push(error.message))
+    const watchComponent = await page.evaluateHandle(findWatchComponent)
+    await watchComponent.evaluate(async component => {
+      const watchView = component.proxy
+      watchView.isLoading = true
+      await watchView.$nextTick()
+      watchView.videoDescription = ''
+      watchView.videoDescriptionHtml = ''
+      watchView.videoTags = []
+      watchView.videoGames = []
+      watchView.isLoading = false
+      await watchView.$nextTick()
+    })
+
+    await expect(page.locator(`${activeTab} .videoDescription`)).toHaveCount(0)
+    expect(pageErrors).toEqual([])
     await watchComponent.dispose()
   })
 

--- a/e2e/tests/offline/watch-page.spec.mjs
+++ b/e2e/tests/offline/watch-page.spec.mjs
@@ -73,22 +73,33 @@ test.describe('watch page', () => {
     const descriptionText = description.locator('.description')
     const tags = description.locator('.videoTags')
     const expandControl = description.locator(':scope > .descriptionStatus')
-    await description.evaluate(element => { element.style.height = '70px' })
-    await expect(expandControl).toHaveClass(/avoidCopyButton/)
-    expect(await expandControl.evaluate((element, copyButton) => {
+    const copyButton = description.locator('.descriptionCopyButton')
+    const controlsOverlap = async () => expandControl.evaluate((element, copyButtonElement) => {
       const expandRect = element.getBoundingClientRect()
-      const copyRect = copyButton.getBoundingClientRect()
+      const copyRect = copyButtonElement.getBoundingClientRect()
       return (
         expandRect.top < copyRect.bottom &&
         expandRect.bottom > copyRect.top &&
         expandRect.left < copyRect.right &&
         expandRect.right > copyRect.left
       )
-    }, await description.locator('.descriptionCopyButton').elementHandle())).toBe(false)
+    }, await copyButton.elementHandle())
+
+    await description.evaluate(element => { element.style.height = '70px' })
+    await expect(expandControl).toHaveClass(/avoidCopyButton/)
+    expect(await controlsOverlap()).toBe(false)
 
     await description.evaluate(element => { element.style.height = '160px' })
     await expect(expandControl).not.toHaveClass(/avoidCopyButton/)
     await expect(expandControl).toHaveCSS('inset-inline-end', '16px')
+
+    await description.evaluate(element => {
+      element.dir = 'rtl'
+      element.style.height = '70px'
+    })
+    await expect(expandControl).toHaveClass(/avoidCopyButton/)
+    expect(await controlsOverlap()).toBe(false)
+
     await description.evaluate(element => { element.style.height = '' })
 
     await expandControl.click()

--- a/src/renderer/components/WatchVideoDescription/WatchVideoDescription.css
+++ b/src/renderer/components/WatchVideoDescription/WatchVideoDescription.css
@@ -81,6 +81,10 @@
   text-decoration: none;
 }
 
+.videoDescription.short .descriptionStatus.avoidCopyButton {
+  inset-inline-end: 56px;
+}
+
 .videoDescription.short .descriptionStatus::before {
   position: absolute;
   inset-block: 0;

--- a/src/renderer/components/WatchVideoDescription/WatchVideoDescription.vue
+++ b/src/renderer/components/WatchVideoDescription/WatchVideoDescription.vue
@@ -1,6 +1,7 @@
 <template>
   <FtCard
     v-if="shownDescription.length > 0 || tags.length > 0 || games.length > 0"
+    ref="descriptionCard"
     :class="{
       videoDescription: true,
       short: !isExpanded,
@@ -9,6 +10,7 @@
   >
     <FtIconButton
       v-if="shownDescription.length > 0"
+      ref="descriptionCopyButton"
       class="descriptionCopyButton"
       :title="t('Description.Copy Description')"
       :icon="['fas', 'copy']"
@@ -17,7 +19,11 @@
     />
     <span
       v-if="showControls && !isExpanded && !alwaysExpanded"
-      class="descriptionStatus"
+      ref="expandDescriptionControl"
+      :class="{
+        descriptionStatus: true,
+        avoidCopyButton: copyButtonOverlapsExpandControl
+      }"
       role="button"
       tabindex="0"
       @click="expandDescription"
@@ -174,9 +180,13 @@ let shownDescription = ''
 let descriptionText = props.description
 const descriptionScroll = useTemplateRef('descriptionScroll')
 const descriptionContainer = useTemplateRef('descriptionContainer')
+const descriptionCard = useTemplateRef('descriptionCard')
+const descriptionCopyButton = useTemplateRef('descriptionCopyButton')
+const expandDescriptionControl = useTemplateRef('expandDescriptionControl')
 const showFullDescription = ref(false)
 const showControls = ref(false)
 const descriptionFadeTop = ref(false)
+const copyButtonOverlapsExpandControl = ref(false)
 // a video can have games but no description, and there is nothing to expand or collapse then,
 // so treat it as expanded. `measureDescription` can't do it, it bails out on a zero height element.
 const isExpanded = computed(() => props.alwaysExpanded || shownDescription === '' || showFullDescription.value)
@@ -295,22 +305,58 @@ function measureDescription() {
   showFullDescription.value = isShortDescription()
   showControls.value = !showFullDescription.value
   hasMeasured = true
+
+  nextTick(updateDescriptionLayout)
+}
+
+function updateExpandControlPosition() {
+  const copyButtonElement = descriptionCopyButton.value?.$el
+  const expandControlElement = expandDescriptionControl.value
+
+  if (!copyButtonElement || !expandControlElement) {
+    copyButtonOverlapsExpandControl.value = false
+    return
+  }
+
+  const copyButtonRect = copyButtonElement.getBoundingClientRect()
+  const expandControlRect = expandControlElement.getBoundingClientRect()
+  const collisionOffset = copyButtonOverlapsExpandControl.value
+    ? (getComputedStyle(expandControlElement).direction === 'rtl' ? -40 : 40)
+    : 0
+  copyButtonOverlapsExpandControl.value = (
+    expandControlRect.top < copyButtonRect.bottom &&
+    expandControlRect.bottom > copyButtonRect.top &&
+    expandControlRect.left + collisionOffset < copyButtonRect.right &&
+    expandControlRect.right + collisionOffset > copyButtonRect.left
+  )
+}
+
+function updateDescriptionLayout() {
+  updateDescriptionFadeState()
+  updateExpandControlPosition()
 }
 
 let descriptionResizeObserver = null
 
 onMounted(() => {
   measureDescription()
-  descriptionResizeObserver = new ResizeObserver(updateDescriptionFadeState)
+
+  descriptionResizeObserver = new ResizeObserver(updateDescriptionLayout)
   if (descriptionScroll.value) {
     descriptionResizeObserver.observe(descriptionScroll.value)
   }
-  nextTick(updateDescriptionFadeState)
+
+  const descriptionCardElement = descriptionCard.value?.$el
+  if (descriptionCardElement) {
+    descriptionResizeObserver.observe(descriptionCardElement)
+  }
+
+  nextTick(updateDescriptionLayout)
 })
 
 onBeforeUnmount(() => descriptionResizeObserver?.disconnect())
 
-watch(isExpanded, () => nextTick(updateDescriptionFadeState))
+watch(isExpanded, () => nextTick(updateDescriptionLayout))
 
 watch(() => props.alwaysExpanded, (alwaysExpanded, wasAlwaysExpanded) => {
   if (!alwaysExpanded && wasAlwaysExpanded) {


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Make sure to follow the contributing guidelines. -->
<!-- Important note, we may remove your pull request if you do not use this provided PR template correctly. -->
<!-- Agent instructions: Preserve every heading, comment, and marker in this template. Never remove or rewrite the release-note-category:start/end, release-note:start/end, or release-note-image:start/end marker pairs. Never remove or rewrite the Release note images section; leave its contents for a human. -->

## Pull Request Type
<!-- Please select what type of pull request this is: [x] -->
- [x] Bugfix
- [ ] Feature Implementation
- [ ] Documentation
- [ ] Other

## Related issue
<!-- Please link the issue your pull request is referring to. -->
<!-- If this pull request fully resolves the relevant issue, put "closes" before the issue number. -->
<!-- Example: "closes #123456". -->

## Description
<!-- Please write a clear and concise description of what the pull request does. -->
Prevents the copy-description button from covering the collapsed `...more` control. The controls were positioned independently at the inline end of the description card, so short cards could place them in the same space.

The description now detects an actual intersection and moves `...more` aside only while necessary, preserving its normal right alignment otherwise. The resize observer is skipped when an empty description does not render a card.

## Release note category
<!-- Select exactly one category. Every pull request must select one. -->
<!-- Select "Not noteworthy" when the pull request fixes a bug in or improves functionality that has not yet appeared in a stable release. -->
<!-- release-note-category:start -->
- [ ] Not noteworthy
- [ ] Highlights
- [ ] More improvements
- [x] Fixed bugs
<!-- release-note-category:end -->

## Release note
<!-- Required unless "Not noteworthy" is selected. -->
<!-- Write one concise, user-facing entry without a leading bullet. -->
<!-- release-note:start -->
Prevented the copy-description button from covering the description expansion control.
<!-- release-note:end -->

## Release note images
<!-- Human-only: Agents must preserve this entire section and leave it empty. -->
<!-- Optional. Paste one or more Markdown images or HTML image tags here. -->
<!-- The release notes will use an HTML image tag and limit images taller than 300 pixels. -->
<!-- release-note-image:start -->

<!-- release-note-image:end -->

## Testing
<!-- How can reviewers verify that the PR produces correct results? -->
<!-- Please provide instructions so that others can ensure that your pull request would produce correct results. For examples see, https://github.com/FreeTubeApp/FreeTube/pull/5743, https://github.com/FreeTubeApp/FreeTube/pull/7349, https://github.com/FreeTubeApp/FreeTube/pull/5125, https://github.com/FreeTubeApp/FreeTube/pull/7338 -->
<!-- Agent instructions: Only write human-facing steps that explain how to verify the change while running this branch in dev mode. Include expected results and, when applicable, helpful console snippets for interactive verification. Do not include automated checks, commands, results, pass counts, or CI status. -->
1. Open a video with a collapsible description in a narrow or short description card where the copy button would otherwise cover `...more`.
2. Confirm that `...more` moves left just enough to remain clear of the copy button.
3. Open a video whose description card places the controls on different lines and confirm that `...more` remains aligned at the right edge.
4. Open a video without a description, tags, or game metadata and confirm that the watch page renders without an error.

## Additional context
<!-- Add any other context about the pull request here. -->
The collision calculation supports both left-to-right and right-to-left layouts.
