### PR TITLE
test(e2e): assert help tooltip stays anchored to its button

### DIFF
--- a/e2e/tests/offline/settings.spec.mjs
+++ b/e2e/tests/offline/settings.spec.mjs
@@ -744,21 +744,58 @@ test.describe('settings', () => {
 
     const bodyTooltip = page.locator('body > [role="tooltip"]:visible')
     await expect(bodyTooltip).toBeVisible()
-    const initialButtonBounds = await tooltipButton.boundingBox()
-    const initialTooltipBounds = await bodyTooltip.boundingBox()
 
-    await settingsWindow.evaluate(element => {
-      element.style.left = `${element.getBoundingClientRect().left + 40}px`
+    // Read the button and the tooltip in one frame. Sampling them in separate
+    // round-trips lets a late layout change (the open transition, a font swap
+    // resizing the tooltip) land between the two reads, which offsets the
+    // baselines against each other and makes the comparison below unsatisfiable.
+    const measure = () => page.evaluate(() => {
+      const button = document.querySelector('.settingsContent .selectTooltip .button')
+      const tooltip = Array.from(document.querySelectorAll('body > [role="tooltip"]'))
+        .find(element => element.checkVisibility())
+      const buttonBounds = button.getBoundingClientRect()
+      const tooltipBounds = tooltip.getBoundingClientRect()
+      return {
+        buttonLeft: buttonBounds.left,
+        anchorOffset: tooltipBounds.left - buttonBounds.left,
+        tooltipLeft: tooltipBounds.left,
+        tooltipRight: tooltipBounds.right,
+        viewportWidth: innerWidth
+      }
     })
+
+    const EDGE_MARGIN = 8
+    // The window animates open, so wait for the button to hold still before
+    // taking the baseline.
+    let previous = null
     await expect.poll(async () => {
-      const [buttonBounds, tooltipBounds] = await Promise.all([
-        tooltipButton.boundingBox(),
-        bodyTooltip.boundingBox()
-      ])
-      const buttonMovement = buttonBounds.x - initialButtonBounds.x
-      const tooltipMovement = tooltipBounds.x - initialTooltipBounds.x
-      return buttonMovement > 30 && Math.abs(tooltipMovement - buttonMovement) <= 1
+      const current = await measure()
+      const settled = previous !== null && current.buttonLeft === previous.buttonLeft
+      previous = current
+      return settled
     }).toBe(true)
+    const initial = previous
+    // The tooltip is clamped to the viewport, so it only tracks its button
+    // while it has room. Move the window towards the side that still fits.
+    const shift = initial.tooltipRight + 40 <= initial.viewportWidth - EDGE_MARGIN
+      ? 40
+      : -40
+    expect(shift === 40 || initial.tooltipLeft - 40 >= EDGE_MARGIN).toBe(true)
+    await settingsWindow.evaluate((element, offset) => {
+      element.style.left = `${element.getBoundingClientRect().left + offset}px`
+    }, shift)
+
+    // The tooltip stays anchored to its button: it keeps the same offset from
+    // the button instead of merely moving by a similar amount.
+    await expect.poll(async () => {
+      const moved = await measure()
+      return {
+        buttonMoved: Math.abs(moved.buttonLeft - initial.buttonLeft - shift) <= 1,
+        anchored: Math.abs(moved.anchorOffset - initial.anchorOffset) <= 1,
+        withinViewport: moved.tooltipLeft >= EDGE_MARGIN &&
+          moved.tooltipRight <= moved.viewportWidth - EDGE_MARGIN
+      }
+    }).toEqual({ buttonMoved: true, anchored: true, withinViewport: true })
 
     await settingsWindow.evaluate(element => element.requestFullscreen())
     await expect.poll(() => settingsWindow.evaluate(element => document.fullscreenElement === element)).toBe(true)


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Make sure to follow the contributing guidelines. -->
<!-- Important note, we may remove your pull request if you do not use this provided PR template correctly. -->
<!-- Agent instructions: Preserve every heading, comment, and marker in this template. Never remove or rewrite the release-note-category:start/end, release-note:start/end, or release-note-image:start/end marker pairs. Never remove or rewrite the Release note images section; leave its contents for a human. -->

## Pull Request Type
<!-- Please select what type of pull request this is: [x] -->
- [ ] Bugfix
- [ ] Feature Implementation
- [ ] Documentation
- [x] Other

## Related issue
<!-- Please link the issue your pull request is referring to. -->
<!-- If this pull request fully resolves the relevant issue, put "closes" before the issue number. -->
<!-- Example: "closes #123456". -->

None — this fixes a flaky E2E test seen on unrelated branches, for example the run on #616.

## Description
<!-- Please write a clear and concise description of what the pull request does. -->

`keeps an open help tooltip aligned and visible in fullscreen` intermittently timed out in CI on branches that had nothing to do with tooltips.

The test sampled the button and the tooltip in two separate round-trips to build a baseline, moved the settings window 40px, and then required both to have moved by the same amount within 1px. Because the two baseline reads are separate round-trips, any layout change landing between them offsets one against the other — the settings window's open transition, a font swap resizing the `max-content` tooltip, or the `ResizeObserver` in `Settings.vue` writing clamped bounds back into `windowStyle`. That difference is baked in permanently, so the comparison can never become true and the poll spins until it times out.

The CI trace confirms this: at the moment the poll gave up, the window had moved the full 40px and the tooltip was exactly right-aligned to its button, 264px away from the viewport edge, so the component's clamp was never involved.

The assertion now expresses what actually matters — that the tooltip stays anchored to its button:

- both rects are read in a single `page.evaluate`, so they always come from the same frame
- the baseline is taken only after the window has stopped moving
- the window is shifted towards whichever side still has viewport room, so the component's edge clamp is not what is being measured
- the check is that the tooltip keeps the *same offset* from its button, rather than merely moving by a similar amount, and that it stays inside the viewport

The tolerance on the anchoring check is unchanged at 1px, and no retry was added. To confirm the assertion is not vacuous, the tooltip's per-frame repositioning was temporarily disabled: the test then fails on the anchoring check alone.

No application code is touched.

## Release note category
<!-- Select exactly one category. Every pull request must select one. -->
<!-- Select "Not noteworthy" when the pull request fixes a bug in or improves functionality that has not yet appeared in a stable release. -->
<!-- release-note-category:start -->
- [x] Not noteworthy
- [ ] Highlights
- [ ] More improvements
- [ ] Fixed bugs
<!-- release-note-category:end -->

## Release note
<!-- Required unless "Not noteworthy" is selected. -->
<!-- Write one concise, user-facing entry without a leading bullet. -->
<!-- release-note:start -->

<!-- release-note:end -->

## Release note images
<!-- Human-only: Agents must preserve this entire section and leave it empty. -->
<!-- Optional. Paste one or more Markdown images or HTML image tags here. -->
<!-- The release notes will use an HTML image tag and limit images taller than 300 pixels. -->
<!-- release-note-image:start -->

<!-- release-note-image:end -->

## Testing
<!-- How can reviewers verify that the PR produces correct results? -->
<!-- Please provide instructions so that others can ensure that your pull request would produce correct results. For examples see, https://github.com/FreeTubeApp/FreeTube/pull/5743, https://github.com/FreeTubeApp/FreeTube/pull/7349, https://github.com/FreeTubeApp/FreeTube/pull/5125, https://github.com/FreeTubeApp/FreeTube/pull/7338 -->
<!-- Agent instructions: Only write human-facing steps that explain how to verify the change while running this branch in dev mode. Include expected results and, when applicable, helpful console snippets for interactive verification. Do not include automated checks, commands, results, pass counts, or CI status. -->

The behaviour this test guards can be checked by hand:

1. Open Settings and hover or focus one of the round `?` help buttons so its tooltip appears.
2. Keeping the tooltip open, drag the settings window around by its title bar.
   - Expected: the tooltip follows the button exactly, staying glued to the same spot relative to it, with no lag or drift.
3. Drag the window towards the left or right edge of the screen until the tooltip reaches the edge.
   - Expected: the tooltip stops at a small margin from the edge instead of being cut off, and re-attaches itself to the button as soon as you drag back inwards.
4. With a tooltip still open, put the settings window into fullscreen and then leave fullscreen again.
   - Expected: the tooltip stays visible and correctly positioned next to its button in both states.

## Additional context
<!-- Add any other context about the pull request here. -->

While investigating this I also looked at `allows help tooltips outside the settings window`, which failed on another branch. It fails for a different reason — it has no poll and failed on its first assertion, because the last help button could not be scrolled close enough to the bottom of the settings content. I could not reproduce that one, so it is deliberately left untouched here rather than blind-fixed.
