### PR TITLE
fix(subscriptions): show started premieres as live

### DIFF
--- a/e2e/tests/offline/subscriptions-feed.spec.mjs
+++ b/e2e/tests/offline/subscriptions-feed.spec.mjs
@@ -133,7 +133,7 @@ test.describe('subscriptions feed from cache', () => {
 
     const premiere = page.locator('.ft-list-video').filter({ hasText: 'Upcoming premiere video' })
     await expect(premiere).toBeVisible()
-    await expect(premiere.locator('.videoDuration')).not.toHaveText('Upcoming')
+    await expect(premiere.locator('.videoDuration')).toHaveText('Live')
   })
 
   test('an open video menu does not lift feed content over the sticky header', async ({ page }) => {

--- a/src/renderer/helpers/subscription-entries.js
+++ b/src/renderer/helpers/subscription-entries.js
@@ -33,8 +33,12 @@ export function updateUpcomingPremiereState(video, now) {
   if (
     premiereTimestamp != null &&
     premiereTimestamp <= now &&
-    // Local API entries can carry only the scheduled date in older caches.
-    (video.isUpcoming || video.premiere || video.premiereDate != null)
+    (video.isUpcoming || video.premiere || (
+      // Local API entries can carry only the scheduled date in older caches.
+      video.premiereDate != null &&
+      video.isUpcoming == null &&
+      video.premiere == null
+    ))
   ) {
     return {
       ...video,

--- a/src/renderer/helpers/subscription-entries.js
+++ b/src/renderer/helpers/subscription-entries.js
@@ -23,7 +23,7 @@ export function getUpcomingPremiereTimestamp(video) {
 }
 
 /**
- * Clears stale upcoming flags once a premiere's scheduled time has arrived.
+ * Marks a premiere as live once its scheduled time has arrived.
  * @param {object} video
  * @param {number} now
  */
@@ -33,12 +33,14 @@ export function updateUpcomingPremiereState(video, now) {
   if (
     premiereTimestamp != null &&
     premiereTimestamp <= now &&
-    (video.isUpcoming || video.premiere)
+    // Local API entries can carry only the scheduled date in older caches.
+    (video.isUpcoming || video.premiere || video.premiereDate != null)
   ) {
     return {
       ...video,
       isUpcoming: false,
-      premiere: false
+      premiere: false,
+      liveNow: true
     }
   }
 

--- a/tests/unit/subscription-entries.test.mjs
+++ b/tests/unit/subscription-entries.test.mjs
@@ -27,7 +27,7 @@ test('reads premiere times from Local API dates and Invidious timestamps', () =>
   assert.equal(getUpcomingPremiereTimestamp({ premiereDate: 'invalid' }), null)
 })
 
-test('clears upcoming premiere state when its scheduled time arrives', () => {
+test('marks an upcoming premiere as live when its scheduled time arrives', () => {
   const scheduledTime = now + HOUR
   const upcoming = video('premiere', scheduledTime, {
     isUpcoming: true,
@@ -39,7 +39,19 @@ test('clears upcoming premiere state when its scheduled time arrives', () => {
   assert.deepEqual(updateUpcomingPremiereState(upcoming, scheduledTime), {
     ...upcoming,
     isUpcoming: false,
-    premiere: false
+    premiere: false,
+    liveNow: true
+  })
+
+  assert.deepEqual(updateUpcomingPremiereState({
+    ...upcoming,
+    isUpcoming: undefined,
+    premiere: undefined
+  }, scheduledTime), {
+    ...upcoming,
+    isUpcoming: false,
+    premiere: false,
+    liveNow: true
   })
 })
 

--- a/tests/unit/subscription-entries.test.mjs
+++ b/tests/unit/subscription-entries.test.mjs
@@ -53,6 +53,14 @@ test('marks an upcoming premiere as live when its scheduled time arrives', () =>
     premiere: false,
     liveNow: true
   })
+
+  const completed = {
+    ...upcoming,
+    isUpcoming: false,
+    premiere: false,
+    liveNow: false
+  }
+  assert.equal(updateUpcomingPremiereState(completed, scheduledTime), completed)
 })
 
 test('adds selected Shorts thumbnails without replacing RSS metadata', () => {


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Make sure to follow the contributing guidelines. -->
<!-- Important note, we may remove your pull request if you do not use this provided PR template correctly. -->
<!-- Agent instructions: Preserve every heading, comment, and marker in this template. Never remove or rewrite the release-note-category:start/end, release-note:start/end, or release-note-image:start/end marker pairs. Never remove or rewrite the Release note images section; leave its contents for a human. -->

## Pull Request Type
<!-- Please select what type of pull request this is: [x] -->
- [x] Bugfix
- [ ] Feature Implementation
- [ ] Documentation
- [ ] Other

## Related issue
<!-- Please link the issue your pull request is referring to. -->
<!-- If this pull request fully resolves the relevant issue, put "closes" before the issue number. -->
<!-- Example: "closes #123456". -->

## Description
<!-- Please write a clear and concise description of what the pull request does. -->
When an automatically refreshed upcoming premiere reached its scheduled time, the subscriptions feed removed its upcoming state but rendered it like a regular uploaded video, including the scheduled date and ordinary view count.

Mark started premieres as live when their scheduled time arrives. This also handles older Local API cache entries that contain a premiere date without an explicit upcoming flag, while retaining the guard for Invidious premiere timestamps so completed premieres are not revived as live.

## Release note category
<!-- Select exactly one category. Every pull request must select one. -->
<!-- Select "Not noteworthy" when the pull request fixes a bug in or improves functionality that has not yet appeared in a stable release. -->
<!-- release-note-category:start -->
- [ ] Not noteworthy
- [ ] Highlights
- [ ] More improvements
- [x] Fixed bugs
<!-- release-note-category:end -->

## Release note
<!-- Required unless "Not noteworthy" is selected. -->
<!-- Write one concise, user-facing entry without a leading bullet. -->
<!-- release-note:start -->
Auto-refreshed started premieres in the subscriptions feed now appear as live instead of showing their scheduled date.
<!-- release-note:end -->

## Release note images
<!-- Human-only: Agents must preserve this entire section and leave it empty. -->
<!-- Optional. Paste one or more Markdown images or HTML image tags here. -->
<!-- The release notes will use an HTML image tag and limit images taller than 300 pixels. -->
<!-- release-note-image:start -->

<!-- release-note-image:end -->

## Testing
<!-- How can reviewers verify that the PR produces correct results? -->
<!-- Please provide instructions so that others can ensure that your pull request produces correct results. For examples see, https://github.com/FreeTubeApp/FreeTube/pull/5743, https://github.com/FreeTubeApp/FreeTube/pull/7349, https://github.com/FreeTubeApp/FreeTube/pull/5125, https://github.com/FreeTubeApp/FreeTube/pull/7338 -->
<!-- Agent instructions: Only write human-facing steps that explain how to verify the change while running this branch in dev mode. Include expected results and, when applicable, helpful console snippets for interactive verification. Do not include automated checks, commands, results, pass counts, or CI status. -->
1. Enable **Hide Upcoming Premieres** and load the subscriptions feed with a premiere scheduled soon.
2. Confirm the premiere is hidden before its scheduled time.
3. Leave the subscriptions feed open until the scheduled time passes.
4. Confirm the premiere appears with a **Live** badge rather than its scheduled date and regular view count.

## Additional context
<!-- Add any other context about the pull request here. -->