### PR TITLE
feat: allow disabling downloads

### DIFF
--- a/e2e/tests/offline/video-actions.spec.mjs
+++ b/e2e/tests/offline/video-actions.spec.mjs
@@ -109,18 +109,36 @@ test.describe('video downloads', () => {
       await store.dispatch('updateExtraThumbnailAction', 'download')
     })
 
+    await goTo(page, 'history')
+    const video = page.locator('.ft-list-video').first()
+    await video.hover()
+    await video.locator('.optionsButton').click()
+    await page.getByRole('option', { name: 'Download Video' }).click()
+    await expect(page.locator('.downloadPromptCard')).toBeVisible()
+    await page.evaluate(async () => {
+      const store = document.querySelector('#app').__vue_app__.config.globalProperties.$store
+      await store.dispatch('updateEnableDownloads', false)
+    })
+    await expect(page.locator('.downloadPromptCard')).toHaveCount(0)
+    await page.evaluate(async () => {
+      const store = document.querySelector('#app').__vue_app__.config.globalProperties.$store
+      await store.dispatch('updateEnableDownloads', true)
+    })
+    await expect(page.locator('.downloadPromptCard')).toHaveCount(0)
+
     const downloadSection = await goToSettingsSection(page, 'download')
     const toggle = downloadSection.getByRole('checkbox', { name: 'Enable Downloads' })
     await expect(toggle).toBeChecked()
     await downloadSection.locator('label.switch-label').filter({ hasText: 'Enable Downloads' }).click()
     await expect(toggle).not.toBeChecked()
     await expect(downloadSection.getByLabel('Download Folder')).toHaveCount(0)
+
+    await page.locator('.settingsMenu [data-section="general"]').click()
+    const generalSection = page.locator('.settingsContent > [data-section="general"]')
+    await expect(generalSection.getByRole('combobox', { name: 'Extra Thumbnail Action Button' })).toHaveText('None')
     await page.locator('.settingsCloseButton').click()
 
     await expect(page.locator('.sideNav a[href="#/downloads"]')).toHaveCount(0)
-    await goTo(page, 'history')
-
-    const video = page.locator('.ft-list-video').first()
     await video.hover()
     await expect(video.locator('.extraThumbnailActionIcon')).toHaveCount(0)
     await video.locator('.optionsButton').click()

--- a/e2e/tests/offline/video-actions.spec.mjs
+++ b/e2e/tests/offline/video-actions.spec.mjs
@@ -1,7 +1,7 @@
 import { chmod, readFile, writeFile } from 'node:fs/promises'
 import path from 'node:path'
 
-import { test, expect, goTo, waitForAppReady } from '../../helpers/app.mjs'
+import { test, expect, goTo, goToSettingsSection, waitForAppReady } from '../../helpers/app.mjs'
 import { DBActions, PlaylistVideoAddResult } from '../../../src/constants.js'
 
 function historyEntry(videoId, title) {
@@ -101,6 +101,37 @@ test.describe('video downloads', () => {
 
     await expect(page.getByText('Download failed', { exact: true })).toBeVisible()
     await expect(page.locator('.downloadProgressBarTrack')).toHaveCount(0)
+  })
+
+  test('disables media download actions and rejects direct requests', async ({ page }) => {
+    await page.evaluate(async () => {
+      const store = document.querySelector('#app').__vue_app__.config.globalProperties.$store
+      await store.dispatch('updateExtraThumbnailAction', 'download')
+    })
+
+    const downloadSection = await goToSettingsSection(page, 'download')
+    const toggle = downloadSection.getByRole('checkbox', { name: 'Enable Downloads' })
+    await expect(toggle).toBeChecked()
+    await downloadSection.locator('label.switch-label').filter({ hasText: 'Enable Downloads' }).click()
+    await expect(toggle).not.toBeChecked()
+    await expect(downloadSection.getByLabel('Download Folder')).toHaveCount(0)
+    await page.locator('.settingsCloseButton').click()
+
+    await expect(page.locator('.sideNav a[href="#/downloads"]')).toHaveCount(0)
+    await goTo(page, 'history')
+
+    const video = page.locator('.ft-list-video').first()
+    await video.hover()
+    await expect(video.locator('.extraThumbnailActionIcon')).toHaveCount(0)
+    await video.locator('.optionsButton').click()
+    await expect(page.getByRole('option', { name: 'Download Video' })).toHaveCount(0)
+
+    await page.bringToFront()
+    const result = await page.evaluate(() => window.ftElectron.ytDlpDownload({
+      videoId: 'eeeeeeeeeee',
+      mode: 'video'
+    }))
+    expect(result).toEqual({ error: 'downloads-disabled' })
   })
 
   test('rejects custom arguments that can execute external code', async ({ page }) => {

--- a/src/main/ytDlp.js
+++ b/src/main/ytDlp.js
@@ -953,6 +953,10 @@ export async function handleYtDlpDownload(event, payload) {
     return null
   }
 
+  if ((await settings._findOne('enableDownloads'))?.value === false) {
+    return { error: 'downloads-disabled' }
+  }
+
   if (typeof payload !== 'object' || payload === null) {
     return null
   }

--- a/src/renderer/components/DownloadSettings.vue
+++ b/src/renderer/components/DownloadSettings.vue
@@ -2,7 +2,19 @@
   <FtSettingsSection
     :title="t('Settings.Download Settings.Download Settings')"
   >
-    <FtFlexBox class="downloadPathInputs settingsFlexStart460px">
+    <FtFlexBox>
+      <FtToggleSwitch
+        :label="t('Settings.Download Settings.Enable Downloads')"
+        :default-value="enableDownloads"
+        setting-key="enableDownloads"
+        :compact="true"
+        @change="updateEnableDownloads"
+      />
+    </FtFlexBox>
+    <FtFlexBox
+      v-if="enableDownloads"
+      class="downloadPathInputs settingsFlexStart460px"
+    >
       <FtInput
         :placeholder="t('Settings.Download Settings.Download Folder')"
         :show-action-button="true"
@@ -15,12 +27,12 @@
         @click="chooseDownloadFolder"
       />
     </FtFlexBox>
-    <FtFlexBox>
+    <FtFlexBox v-if="enableDownloads">
       <p class="templatesHint">
         {{ t('Settings.Download Settings.Templates Hint') }}
       </p>
     </FtFlexBox>
-    <FtFlexBox>
+    <FtFlexBox v-if="enableDownloads">
       <p class="templatesHint">
         {{ t('Settings.Download Settings.External Software Hint') }}
       </p>
@@ -35,13 +47,24 @@ import { useI18n } from 'vue-i18n'
 import FtSettingsSection from './FtSettingsSection/FtSettingsSection.vue'
 import FtInput from './FtInput/FtInput.vue'
 import FtFlexBox from './ft-flex-box/ft-flex-box.vue'
+import FtToggleSwitch from './FtToggleSwitch/FtToggleSwitch.vue'
 
 import store from '../store/index'
 
 const { t } = useI18n()
 
+/** @type {import('vue').ComputedRef<boolean>} */
+const enableDownloads = computed(() => store.getters.getEnableDownloads)
+
 /** @type {import('vue').ComputedRef<string>} */
 const ytDlpDownloadFolderPath = computed(() => store.getters.getYtDlpDownloadFolderPath)
+
+/**
+ * @param {boolean} value
+ */
+function updateEnableDownloads(value) {
+  store.dispatch('updateEnableDownloads', value)
+}
 
 /**
  * @param {string} value

--- a/src/renderer/components/FtListPlaylist/FtListPlaylist.vue
+++ b/src/renderer/components/FtListPlaylist/FtListPlaylist.vue
@@ -107,7 +107,7 @@
 
 <script setup>
 import { FontAwesomeIcon } from '@fortawesome/vue-fontawesome'
-import { computed, ref } from 'vue'
+import { computed, ref, watch } from 'vue'
 import { useI18n } from 'vue-i18n'
 
 import FtIconButton from '../FtIconButton/FtIconButton.vue'
@@ -137,6 +137,10 @@ const { t } = useI18n()
 const IS_ELECTRON = process.env.IS_ELECTRON
 const showDownloadPrompt = ref(false)
 const enableDownloads = computed(() => store.getters.getEnableDownloads)
+
+watch(enableDownloads, (enabled) => {
+  if (!enabled) showDownloadPrompt.value = false
+})
 
 let playlistId = ''
 let title = ''

--- a/src/renderer/components/FtListPlaylist/FtListPlaylist.vue
+++ b/src/renderer/components/FtListPlaylist/FtListPlaylist.vue
@@ -73,7 +73,7 @@
           @click="handleExternalPlayer"
         />
         <FtIconButton
-          v-if="IS_ELECTRON && videoCount > 0"
+          v-if="IS_ELECTRON && enableDownloads && videoCount > 0"
           :title="t('Downloads.Download Playlist')"
           :icon="['fas', 'download']"
           theme="base-no-default"
@@ -93,7 +93,7 @@
       </div>
     </div>
     <WatchVideoDownloadPrompt
-      v-if="showDownloadPrompt"
+      v-if="enableDownloads && showDownloadPrompt"
       :playlist-id="isUserPlaylist ? '' : playlistId"
       :playlist-key="playlistId"
       :video-ids="isUserPlaylist ? data.videos.map(video => video.videoId) : []"
@@ -136,6 +136,7 @@ const props = defineProps({
 const { t } = useI18n()
 const IS_ELECTRON = process.env.IS_ELECTRON
 const showDownloadPrompt = ref(false)
+const enableDownloads = computed(() => store.getters.getEnableDownloads)
 
 let playlistId = ''
 let title = ''

--- a/src/renderer/components/FtListVideo/FtListVideo.vue
+++ b/src/renderer/components/FtListVideo/FtListVideo.vue
@@ -503,6 +503,10 @@ const hasCaptions = ref(false)
 const isUpcoming = ref(false)
 const showDownloadPrompt = ref(false)
 const enableDownloads = computed(() => store.getters.getEnableDownloads)
+
+watch(enableDownloads, (enabled) => {
+  if (!enabled) showDownloadPrompt.value = false
+})
 const isPremium = ref(false)
 const hideViews = ref(false)
 const deArrowTogglePinned = ref(false)

--- a/src/renderer/components/FtListVideo/FtListVideo.vue
+++ b/src/renderer/components/FtListVideo/FtListVideo.vue
@@ -337,7 +337,7 @@
       </div>
     </div>
     <WatchVideoDownloadPrompt
-      v-if="showDownloadPrompt"
+      v-if="enableDownloads && showDownloadPrompt"
       :video-id="id"
       :title="title"
       :thumbnail="thumbnail"
@@ -502,6 +502,7 @@ const is3D = ref(false)
 const hasCaptions = ref(false)
 const isUpcoming = ref(false)
 const showDownloadPrompt = ref(false)
+const enableDownloads = computed(() => store.getters.getEnableDownloads)
 const isPremium = ref(false)
 const hideViews = ref(false)
 const deArrowTogglePinned = ref(false)
@@ -647,7 +648,7 @@ const extraThumbnailActionButton = computed(() => {
         icon: ['fab', 'youtube']
       }
     case 'download':
-      return process.env.IS_ELECTRON
+      return process.env.IS_ELECTRON && enableDownloads.value
         ? {
             title: t('Downloads.Download Video'),
             icon: ['fas', 'download']
@@ -739,7 +740,7 @@ const dropdownOptions = computed(() => {
           icon: ['fas', 'trash']
         }]
       : [],
-    ...(process.env.IS_ELECTRON && !isUpcoming.value
+    ...(process.env.IS_ELECTRON && enableDownloads.value && !isUpcoming.value
       ? [{
           label: t('Downloads.Download Video'),
           value: 'download',

--- a/src/renderer/components/GeneralSettings/GeneralSettings.vue
+++ b/src/renderer/components/GeneralSettings/GeneralSettings.vue
@@ -149,7 +149,7 @@
         :value="extraThumbnailAction"
         setting-key="extraThumbnailAction"
         :select-names="extraThumbnailActionNames"
-        :select-values="EXTRA_THUMBNAIL_ACTION_VALUES"
+        :select-values="extraThumbnailActionValues"
         :icon="['fas', 'ellipsis-v']"
         @change="updateExtraThumbnailAction"
       />
@@ -611,14 +611,22 @@ function handleThumbnailPreferenceChange(value) {
   store.dispatch('updateThumbnailPreference', value)
 }
 
-const EXTRA_THUMBNAIL_ACTION_VALUES = ['', 'history', 'copyYoutube', 'openYoutube', ...(process.env.IS_ELECTRON ? ['download'] : [])]
+const enableDownloads = computed(() => store.getters.getEnableDownloads)
+
+const extraThumbnailActionValues = computed(() => [
+  '',
+  'history',
+  'copyYoutube',
+  'openYoutube',
+  ...(process.env.IS_ELECTRON && enableDownloads.value ? ['download'] : [])
+])
 
 const extraThumbnailActionNames = computed(() => [
   t('Settings.General Settings.Extra Thumbnail Action Button.None'),
   t('Settings.General Settings.Extra Thumbnail Action Button.Mark as Watched'),
   t('Settings.General Settings.Extra Thumbnail Action Button.Copy YouTube Link'),
   t('Settings.General Settings.Extra Thumbnail Action Button.Open in YouTube'),
-  ...(process.env.IS_ELECTRON ? [t('Downloads.Download Video')] : [])
+  ...(process.env.IS_ELECTRON && enableDownloads.value ? [t('Downloads.Download Video')] : [])
 ])
 
 /** @type {import('vue').ComputedRef<'' | 'history' | 'copyYoutube' | 'openYoutube'>} */

--- a/src/renderer/components/GeneralSettings/GeneralSettings.vue
+++ b/src/renderer/components/GeneralSettings/GeneralSettings.vue
@@ -146,7 +146,7 @@
       />
       <FtSelect
         :placeholder="t('Settings.General Settings.Extra Thumbnail Action Button.Extra Thumbnail Action Button')"
-        :value="extraThumbnailAction"
+        :value="effectiveExtraThumbnailAction"
         setting-key="extraThumbnailAction"
         :select-names="extraThumbnailActionNames"
         :select-values="extraThumbnailActionValues"
@@ -613,6 +613,15 @@ function handleThumbnailPreferenceChange(value) {
 
 const enableDownloads = computed(() => store.getters.getEnableDownloads)
 
+/** @type {import('vue').ComputedRef<'' | 'history' | 'copyYoutube' | 'openYoutube' | 'download'>} */
+const extraThumbnailAction = computed(() => store.getters.getExtraThumbnailAction)
+
+const effectiveExtraThumbnailAction = computed(() => (
+  !enableDownloads.value && extraThumbnailAction.value === 'download'
+    ? ''
+    : extraThumbnailAction.value
+))
+
 const extraThumbnailActionValues = computed(() => [
   '',
   'history',
@@ -629,11 +638,8 @@ const extraThumbnailActionNames = computed(() => [
   ...(process.env.IS_ELECTRON && enableDownloads.value ? [t('Downloads.Download Video')] : [])
 ])
 
-/** @type {import('vue').ComputedRef<'' | 'history' | 'copyYoutube' | 'openYoutube'>} */
-const extraThumbnailAction = computed(() => store.getters.getExtraThumbnailAction)
-
 /**
- * @param {'' | 'history' | 'copyYoutube' | 'openYoutube'} value
+ * @param {'' | 'history' | 'copyYoutube' | 'openYoutube' | 'download'} value
  */
 function updateExtraThumbnailAction(value) {
   store.dispatch('updateExtraThumbnailAction', value)

--- a/src/renderer/components/PlaylistInfo/PlaylistInfo.vue
+++ b/src/renderer/components/PlaylistInfo/PlaylistInfo.vue
@@ -181,7 +181,7 @@
             @click="showExportPrompt = true"
           />
           <FtIconButton
-            v-if="IS_ELECTRON && !editMode && videoCount > 0"
+            v-if="IS_ELECTRON && enableDownloads && !editMode && videoCount > 0"
             :title="t('Downloads.Download Playlist')"
             :icon="['fas', 'download']"
             theme="secondary"
@@ -271,7 +271,7 @@
         @click="handleExport"
       />
       <WatchVideoDownloadPrompt
-        v-if="showDownloadPrompt"
+        v-if="enableDownloads && showDownloadPrompt"
         :playlist-id="isUserPlaylist ? '' : id"
         :playlist-key="id"
         :video-ids="isUserPlaylist ? videos.map(video => video.videoId) : []"
@@ -404,6 +404,7 @@ const emit = defineEmits(['enter-edit-mode', 'exit-edit-mode', 'search-video-que
 
 const { locale, t } = useI18n()
 const IS_ELECTRON = process.env.IS_ELECTRON
+const enableDownloads = computed(() => store.getters.getEnableDownloads)
 
 const query = ref('')
 const editMode = ref(false)

--- a/src/renderer/components/PlaylistInfo/PlaylistInfo.vue
+++ b/src/renderer/components/PlaylistInfo/PlaylistInfo.vue
@@ -582,6 +582,9 @@ watch(showDeletePlaylistPrompt, handlePromptToggle)
 watch(showRemoveVideosOnWatchPrompt, handlePromptToggle)
 watch(showExportPrompt, handlePromptToggle)
 watch(showDownloadPrompt, handlePromptToggle)
+watch(enableDownloads, (enabled) => {
+  if (!enabled) showDownloadPrompt.value = false
+})
 
 /**
  * @param {boolean} shown

--- a/src/renderer/components/SideNav/SideNav.vue
+++ b/src/renderer/components/SideNav/SideNav.vue
@@ -147,7 +147,7 @@
         </p>
       </router-link>
       <router-link
-        v-if="IS_ELECTRON"
+        v-if="IS_ELECTRON && enableDownloads"
         class="navOption mobileShow"
         role="button"
         to="/downloads"
@@ -280,6 +280,7 @@ const appKeyboardShortcuts = computed(() => getConfiguredKeyboardShortcuts(
 const SUPPORTS_LOCAL_API = process.env.SUPPORTS_LOCAL_API
 const IS_ELECTRON = process.env.IS_ELECTRON
 const activeSubscriptionsPerPage = 50
+const enableDownloads = computed(() => store.getters.getEnableDownloads)
 
 const props = defineProps({
   forceExpanded: {

--- a/src/renderer/components/WatchVideoInfo/WatchVideoInfo.vue
+++ b/src/renderer/components/WatchVideoInfo/WatchVideoInfo.vue
@@ -220,7 +220,7 @@
         </span>
         <span class="videoOptionsMobileRow">
           <FtIconButton
-            v-if="USING_ELECTRON && !isUpcoming"
+            v-if="USING_ELECTRON && enableDownloads && !isUpcoming"
             :title="t('Downloads.Download Video')"
             :icon="['fas', 'download']"
             theme="secondary"
@@ -262,7 +262,7 @@
       @close="showFormatPrompt = false"
     />
     <WatchVideoDownloadPrompt
-      v-if="showDownloadPrompt"
+      v-if="enableDownloads && showDownloadPrompt"
       :video-id="id"
       :title="title"
       :thumbnail="videoThumbnail"
@@ -492,6 +492,7 @@ const { locale, t } = useI18n()
 const showCollaboratorsPrompt = ref(false)
 const showDownloadPrompt = ref(false)
 const showFormatPrompt = ref(false)
+const enableDownloads = computed(() => store.getters.getEnableDownloads)
 
 // the title is plain text, so it has to be escaped before the hashtags and handles are linked
 /** @type {import('vue').ComputedRef<string>} */

--- a/src/renderer/components/WatchVideoInfo/WatchVideoInfo.vue
+++ b/src/renderer/components/WatchVideoInfo/WatchVideoInfo.vue
@@ -494,6 +494,10 @@ const showDownloadPrompt = ref(false)
 const showFormatPrompt = ref(false)
 const enableDownloads = computed(() => store.getters.getEnableDownloads)
 
+watch(enableDownloads, (enabled) => {
+  if (!enabled) showDownloadPrompt.value = false
+})
+
 // the title is plain text, so it has to be escaped before the hashtags and handles are linked
 /** @type {import('vue').ComputedRef<string>} */
 const titleHtml = computed(() => linkifyHashtagsAndHandles(escapeHTML(props.title)))

--- a/src/renderer/store/modules/settings.js
+++ b/src/renderer/store/modules/settings.js
@@ -238,6 +238,7 @@ const state = {
   ytDlpPath: '',
   ytDlpFfmpegSource: 'system',
   ytDlpFfmpegPath: '',
+  enableDownloads: true,
   ytDlpDownloadFolderPath: '',
   ytDlpDownloadTemplates: '[]',
   ytDlpSelectedTemplate: 'video:best',

--- a/static/locales/en-US.yaml
+++ b/static/locales/en-US.yaml
@@ -768,6 +768,7 @@ Settings:
         Name: None
   Download Settings:
     Download Settings: Downloads
+    Enable Downloads: Enable Downloads
     Managed Tools Download Started Template: 'Required external software was not found: {tools}. Downloading managed copies…'
     Managed Tools Download Finished Template: 'Finished downloading {tools}'
     Managed Tools Update Started Template: 'An update was found for {tools}. Downloading…'


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Make sure to follow the contributing guidelines. -->
<!-- Important note, we may remove your pull request if you do not use this provided PR template correctly. -->
<!-- Agent instructions: Preserve every heading, comment, and marker in this template. Never remove or rewrite the release-note-category:start/end, release-note:start/end, or release-note-image:start/end marker pairs. Never remove or rewrite the Release note images section; leave its contents for a human. -->

## Pull Request Type
<!-- Please select what type of pull request this is: [x] -->
- [ ] Bugfix
- [x] Feature Implementation
- [ ] Documentation
- [ ] Other

## Related issue
<!-- Please link the issue your pull request is referring to. -->
<!-- If this pull request fully resolves the relevant issue, put "closes" before the issue number. -->
<!-- Example: "closes #123456". -->

## Description
<!-- Please write a clear and concise description of what the pull request does. -->
Media downloads could not previously be turned off. This adds an Enable Downloads preference under Downloads settings and applies it consistently to video, playlist, sidebar, and thumbnail download actions.

The Electron download handler also enforces the preference, so disabled downloads cannot be started through a direct renderer request. Existing download records remain available, running downloads are not interrupted, and managed yt-dlp/FFmpeg updates continue to work.

## Release note category
<!-- Select exactly one category. Every pull request must select one. -->
<!-- Select "Not noteworthy" when the pull request fixes a bug in or improves functionality that has not yet appeared in a stable release. -->
<!-- release-note-category:start -->
- [ ] Not noteworthy
- [ ] Highlights
- [x] More improvements
- [ ] Fixed bugs
<!-- release-note-category:end -->

## Release note
<!-- Required unless "Not noteworthy" is selected. -->
<!-- Write one concise, user-facing entry without a leading bullet. -->
<!-- release-note:start -->
Media downloads can now be disabled from the Downloads settings.
<!-- release-note:end -->

## Release note images
<!-- Human-only: Agents must preserve this entire section and leave it empty. -->
<!-- Optional. Paste one or more Markdown images or HTML image tags here. -->
<!-- The release notes will use an HTML image tag and limit images taller than 300 pixels. -->
<!-- release-note-image:start -->
<img width="219" height="42" alt="image" src="https://github.com/user-attachments/assets/f5356645-3754-456f-8f2c-6994a122e9f3" />
<!-- release-note-image:end -->

## Testing
<!-- How can reviewers verify that the PR produces correct results? -->
<!-- Please provide instructions so that others can ensure that your pull request would produce correct results. For examples see, https://github.com/FreeTubeApp/FreeTube/pull/5743, https://github.com/FreeTubeApp/FreeTube/pull/7349, https://github.com/FreeTubeApp/FreeTube/pull/5125, https://github.com/FreeTubeApp/FreeTube/pull/7338 -->
<!-- Agent instructions: Only write human-facing steps that explain how to verify the change while running this branch in dev mode. Include expected results and, when applicable, helpful console snippets for interactive verification. Do not include automated checks, commands, results, pass counts, or CI status. -->
1. Open Settings → Downloads and turn off Enable Downloads.
2. Confirm the download folder controls disappear and the Downloads entry is removed from the sidebar.
3. Open a video, playlist, and video-card options menu. Confirm their download actions are absent.
4. Turn Enable Downloads back on and confirm the controls and actions return.

## Additional context
<!-- Add any other context about the pull request here. -->
Disabling downloads affects media downloads only. It does not delete downloaded files or prevent OpenTubeX from maintaining managed external tools.
