### PR TITLE
feat(onboarding): guide users through the new interface

### DIFF
--- a/e2e/helpers/app.mjs
+++ b/e2e/helpers/app.mjs
@@ -256,10 +256,18 @@ export async function setPlayerFullscreen(page, fullscreen) {
 export const test = base.extend({
   seed: [{}, { option: true }],
   launchArgs: [[], { option: true }],
+  showTutorial: [false, { option: true }],
 
-  app: async ({ seed, launchArgs }, use, testInfo) => {
+  app: async ({ seed, launchArgs, showTutorial }, use, testInfo) => {
     const userDataDir = await createUserDataDir(seed)
     const { electronApp, page } = await launchApp(userDataDir, launchArgs)
+
+    if (!showTutorial) {
+      const tutorial = page.locator('.tutorialOverlay')
+      await expect(tutorial).toBeVisible()
+      await tutorial.getByRole('button', { name: 'Got it' }).click()
+      await expect(tutorial).toBeHidden()
+    }
 
     const relaunch = async () => {
       // Wait until the old process has fully exited, otherwise it still owns

--- a/e2e/tests/network/channel.spec.mjs
+++ b/e2e/tests/network/channel.spec.mjs
@@ -56,10 +56,10 @@ test.describe('channel page', () => {
     await expect(videoResults).toHaveCount(0)
     await expect(playlistResults.first()).toBeVisible()
 
-    const externalPlayerButton = playlistResults.first().locator('.externalPlayerButton .iconButton')
-    const downloadButton = playlistResults.first().getByTitle('Download Playlist')
-    const externalPlayerBounds = await externalPlayerButton.boundingBox()
-    const downloadBounds = await downloadButton.boundingBox()
+    const { externalPlayerBounds, downloadBounds } = await playlistResults.first().evaluate((playlist) => ({
+      externalPlayerBounds: playlist.querySelector('.externalPlayerButton .iconButton').getBoundingClientRect().toJSON(),
+      downloadBounds: playlist.querySelector('[title="Download Playlist"]').getBoundingClientRect().toJSON()
+    }))
     expect(Math.abs(externalPlayerBounds.y - downloadBounds.y)).toBeLessThanOrEqual(2)
     expect(externalPlayerBounds.x + externalPlayerBounds.width).toBeLessThanOrEqual(downloadBounds.x)
 

--- a/e2e/tests/offline/tutorial.spec.mjs
+++ b/e2e/tests/offline/tutorial.spec.mjs
@@ -1,0 +1,64 @@
+import { test, expect } from '../../helpers/app.mjs'
+
+test.use({ showTutorial: true })
+
+async function expectHighlightCenteredOn(page, targetSelector) {
+  await expect.poll(async () => {
+    const [highlight, target] = await Promise.all([
+      page.locator('.tutorialHighlight').evaluate(element => element.getBoundingClientRect().toJSON()),
+      page.locator(targetSelector).evaluate(element => element.getBoundingClientRect().toJSON())
+    ])
+
+    return {
+      x: Math.round(Math.abs(highlight.x + highlight.width / 2 - (target.x + target.width / 2))),
+      y: Math.round(Math.abs(highlight.y + highlight.height / 2 - (target.y + target.height / 2)))
+    }
+  }).toEqual({ x: 0, y: 0 })
+}
+
+test('shows returning users only where settings moved', async ({ page }) => {
+  const tutorial = page.getByRole('dialog', { name: 'Settings have moved' })
+  await expect(tutorial).toBeVisible()
+  const lastUsedVersion = await page.evaluate(() => localStorage.getItem('opentubex.lastUsedVersion'))
+  expect(lastUsedVersion).toMatch(/^\d+\.\d+\.\d+(?:-|$)/)
+  await expect(tutorial).toContainText('The cog in that menu opens all settings.')
+  await expect(tutorial.locator('.tutorialProgress')).toHaveCount(0)
+  await expectHighlightCenteredOn(page, '[data-tutorial="quick-settings"]')
+
+  await tutorial.getByRole('button', { name: 'Got it' }).click()
+  await expect(tutorial).toBeHidden()
+
+  await page.reload()
+  await expect(page.locator('.tutorialOverlay')).toHaveCount(0)
+})
+
+test('walks new users through the essential controls', async ({ page }) => {
+  await page.evaluate(() => localStorage.setItem('opentubex.tutorial.audience', 'new'))
+  await page.reload()
+
+  const tutorial = page.locator('.tutorialCard')
+  await expect(tutorial).toHaveAccessibleName('Welcome to OpenTubeX')
+  await expect(tutorial.locator('.tutorialProgress span')).toHaveCount(5)
+
+  await tutorial.getByRole('button', { name: 'Next' }).click()
+  await expect(tutorial).toHaveAccessibleName('Your library is always nearby')
+  await expectHighlightCenteredOn(page, '[data-tutorial="navigation"]')
+
+  await tutorial.getByRole('button', { name: 'Next' }).click()
+  await expect(tutorial).toHaveAccessibleName('Search or paste a link')
+  await expectHighlightCenteredOn(page, '[data-tutorial="search"]')
+
+  await tutorial.getByRole('button', { name: 'Next' }).click()
+  await expect(tutorial).toHaveAccessibleName('Keep pages open in tabs')
+  await expectHighlightCenteredOn(page, '[data-tutorial="tabs"]')
+
+  await tutorial.getByRole('button', { name: 'Next' }).click()
+  await expect(tutorial).toHaveAccessibleName('Make it yours')
+  await expectHighlightCenteredOn(page, '[data-tutorial="quick-settings"]')
+
+  await tutorial.getByRole('button', { name: 'Finish' }).click()
+  await expect(tutorial).toBeHidden()
+
+  await page.reload()
+  await expect(page.locator('.tutorialOverlay')).toHaveCount(0)
+})

--- a/e2e/tests/offline/tutorial.spec.mjs
+++ b/e2e/tests/offline/tutorial.spec.mjs
@@ -25,11 +25,29 @@ test('shows returning users only where settings moved', async ({ page }) => {
   await expect(tutorial.locator('.tutorialProgress')).toHaveCount(0)
   await expectHighlightCenteredOn(page, '[data-tutorial="quick-settings"]')
 
-  await tutorial.getByRole('button', { name: 'Got it' }).click()
+  const tabCount = await page.locator('.tabBar .tab').count()
+  await page.keyboard.press('Control+t')
+  await expect(page.locator('.tabBar .tab')).toHaveCount(tabCount)
+
+  const primaryAction = tutorial.getByRole('button', { name: 'Got it' })
+  await expect(primaryAction).toBeFocused()
+  await page.keyboard.press('Tab')
+  await expect(primaryAction).toBeFocused()
+
+  await primaryAction.click()
   await expect(tutorial).toBeHidden()
 
   await page.reload()
   await expect(page.locator('.tutorialOverlay')).toHaveCount(0)
+})
+
+test.describe('right-to-left layout', () => {
+  test.use({ seed: { settings: { currentLocale: 'ar' } } })
+
+  test('keeps the spotlight centered on physical target coordinates', async ({ page }) => {
+    await expect(page.locator('.app')).toHaveClass(/isLocaleRightToLeft/)
+    await expectHighlightCenteredOn(page, '[data-tutorial="quick-settings"]')
+  })
 })
 
 test('walks new users through the essential controls', async ({ page }) => {

--- a/e2e/tests/offline/tutorial.spec.mjs
+++ b/e2e/tests/offline/tutorial.spec.mjs
@@ -16,12 +16,12 @@ async function expectHighlightCenteredOn(page, targetSelector) {
   }).toEqual({ x: 0, y: 0 })
 }
 
-async function clickNewTabMenu(app) {
-  await app.electronApp.evaluate(({ BrowserWindow, Menu }) => {
+async function clickAppMenuItem(app, menuLabel, itemLabel) {
+  await app.electronApp.evaluate(({ BrowserWindow, Menu }, { menuLabel, itemLabel }) => {
     const browserWindow = BrowserWindow.getAllWindows()[0]
-    const tabsMenu = Menu.getApplicationMenu().items.find(item => item.label === 'Tabs')
-    tabsMenu.submenu.items.find(item => item.label === 'New Tab').click(undefined, browserWindow)
-  })
+    const menu = Menu.getApplicationMenu().items.find(item => item.label === menuLabel)
+    menu.submenu.items.find(item => item.label === itemLabel).click(undefined, browserWindow)
+  }, { menuLabel, itemLabel })
 }
 
 test('shows returning users only where settings moved', async ({ app, page }) => {
@@ -37,8 +37,13 @@ test('shows returning users only where settings moved', async ({ app, page }) =>
   await page.keyboard.press('Control+t')
   await expect(page.locator('.tabBar .tab')).toHaveCount(tabCount)
 
-  await clickNewTabMenu(app)
+  await clickAppMenuItem(app, 'Tabs', 'New Tab')
   await expect(page.locator('.tabBar .tab')).toHaveCount(tabCount)
+
+  const currentUrl = page.url()
+  await clickAppMenuItem(app, 'File', 'Preferences')
+  await clickAppMenuItem(app, 'Navigate', 'History')
+  expect(page.url()).toBe(currentUrl)
 
   const primaryAction = tutorial.getByRole('button', { name: 'Got it' })
   await expect(primaryAction).toBeFocused()
@@ -48,7 +53,7 @@ test('shows returning users only where settings moved', async ({ app, page }) =>
   await primaryAction.click()
   await expect(tutorial).toBeHidden()
 
-  await clickNewTabMenu(app)
+  await clickAppMenuItem(app, 'Tabs', 'New Tab')
   await expect(page.locator('.tabBar .tab')).toHaveCount(tabCount + 1)
 
   await page.reload()

--- a/e2e/tests/offline/tutorial.spec.mjs
+++ b/e2e/tests/offline/tutorial.spec.mjs
@@ -16,6 +16,14 @@ async function expectHighlightCenteredOn(page, targetSelector) {
   }).toEqual({ x: 0, y: 0 })
 }
 
+async function clickNewTabMenu(app) {
+  await app.electronApp.evaluate(({ BrowserWindow, Menu }) => {
+    const browserWindow = BrowserWindow.getAllWindows()[0]
+    const tabsMenu = Menu.getApplicationMenu().items.find(item => item.label === 'Tabs')
+    tabsMenu.submenu.items.find(item => item.label === 'New Tab').click(undefined, browserWindow)
+  })
+}
+
 test('shows returning users only where settings moved', async ({ app, page }) => {
   const tutorial = page.getByRole('dialog', { name: 'Settings have moved' })
   await expect(tutorial).toBeVisible()
@@ -29,11 +37,7 @@ test('shows returning users only where settings moved', async ({ app, page }) =>
   await page.keyboard.press('Control+t')
   await expect(page.locator('.tabBar .tab')).toHaveCount(tabCount)
 
-  await app.electronApp.evaluate(({ BrowserWindow, Menu }) => {
-    const browserWindow = BrowserWindow.getAllWindows()[0]
-    const tabsMenu = Menu.getApplicationMenu().items.find(item => item.label === 'Tabs')
-    tabsMenu.submenu.items.find(item => item.label === 'New Tab').click(undefined, browserWindow)
-  })
+  await clickNewTabMenu(app)
   await expect(page.locator('.tabBar .tab')).toHaveCount(tabCount)
 
   const primaryAction = tutorial.getByRole('button', { name: 'Got it' })
@@ -43,6 +47,9 @@ test('shows returning users only where settings moved', async ({ app, page }) =>
 
   await primaryAction.click()
   await expect(tutorial).toBeHidden()
+
+  await clickNewTabMenu(app)
+  await expect(page.locator('.tabBar .tab')).toHaveCount(tabCount + 1)
 
   await page.reload()
   await expect(page.locator('.tutorialOverlay')).toHaveCount(0)

--- a/e2e/tests/offline/tutorial.spec.mjs
+++ b/e2e/tests/offline/tutorial.spec.mjs
@@ -16,7 +16,7 @@ async function expectHighlightCenteredOn(page, targetSelector) {
   }).toEqual({ x: 0, y: 0 })
 }
 
-test('shows returning users only where settings moved', async ({ page }) => {
+test('shows returning users only where settings moved', async ({ app, page }) => {
   const tutorial = page.getByRole('dialog', { name: 'Settings have moved' })
   await expect(tutorial).toBeVisible()
   const lastUsedVersion = await page.evaluate(() => localStorage.getItem('opentubex.lastUsedVersion'))
@@ -29,6 +29,13 @@ test('shows returning users only where settings moved', async ({ page }) => {
   await page.keyboard.press('Control+t')
   await expect(page.locator('.tabBar .tab')).toHaveCount(tabCount)
 
+  await app.electronApp.evaluate(({ BrowserWindow, Menu }) => {
+    const browserWindow = BrowserWindow.getAllWindows()[0]
+    const tabsMenu = Menu.getApplicationMenu().items.find(item => item.label === 'Tabs')
+    tabsMenu.submenu.items.find(item => item.label === 'New Tab').click(undefined, browserWindow)
+  })
+  await expect(page.locator('.tabBar .tab')).toHaveCount(tabCount)
+
   const primaryAction = tutorial.getByRole('button', { name: 'Got it' })
   await expect(primaryAction).toBeFocused()
   await page.keyboard.press('Tab')
@@ -39,6 +46,19 @@ test('shows returning users only where settings moved', async ({ page }) => {
 
   await page.reload()
   await expect(page.locator('.tutorialOverlay')).toHaveCount(0)
+})
+
+test('keeps the tutorial actions reachable in a short window', async ({ app, page }) => {
+  await app.electronApp.evaluate(({ BrowserWindow }) => {
+    BrowserWindow.getAllWindows()[0].setSize(800, 320)
+  })
+
+  const tutorial = page.getByRole('dialog', { name: 'Settings have moved' })
+  await expect(tutorial.getByRole('button', { name: 'Got it' })).toBeVisible()
+  await expect.poll(() => tutorial.evaluate(element => {
+    const bounds = element.getBoundingClientRect()
+    return bounds.top >= 0 && bounds.bottom <= window.innerHeight
+  })).toBe(true)
 })
 
 test.describe('right-to-left layout', () => {

--- a/e2e/tests/offline/tutorial.spec.mjs
+++ b/e2e/tests/offline/tutorial.spec.mjs
@@ -92,6 +92,7 @@ test('walks new users through the essential controls', async ({ page }) => {
 
   await tutorial.getByRole('button', { name: 'Next' }).click()
   await expect(tutorial).toHaveAccessibleName('Your library is always nearby')
+  await expect(tutorial.getByRole('heading', { name: 'Your library is always nearby' })).toBeFocused()
   await expectHighlightCenteredOn(page, '[data-tutorial="navigation"]')
 
   await tutorial.getByRole('button', { name: 'Next' }).click()

--- a/e2e/tests/offline/tutorial.spec.mjs
+++ b/e2e/tests/offline/tutorial.spec.mjs
@@ -45,6 +45,34 @@ test('shows returning users only where settings moved', async ({ app, page }) =>
   await clickAppMenuItem(app, 'Navigate', 'History')
   expect(page.url()).toBe(currentUrl)
 
+  const initialWindowState = await app.electronApp.evaluate(({ BrowserWindow }) => {
+    const browserWindow = BrowserWindow.getAllWindows()[0]
+    return {
+      count: BrowserWindow.getAllWindows().length,
+      zoom: browserWindow.webContents.getZoomLevel()
+    }
+  })
+  await clickAppMenuItem(app, 'File', 'New Window')
+  await clickAppMenuItem(app, 'View', 'Toggle Developer Tools')
+  await clickAppMenuItem(app, 'View', 'Zoom In')
+  await clickAppMenuItem(app, 'View', 'Toggle Full Screen')
+  await clickAppMenuItem(app, 'Window', 'Minimize')
+  await expect.poll(() => app.electronApp.evaluate(({ BrowserWindow }) => {
+    const browserWindow = BrowserWindow.getAllWindows()[0]
+    return {
+      count: BrowserWindow.getAllWindows().length,
+      devToolsOpen: browserWindow.webContents.isDevToolsOpened(),
+      fullscreen: browserWindow.isFullScreen(),
+      minimized: browserWindow.isMinimized(),
+      zoom: browserWindow.webContents.getZoomLevel()
+    }
+  })).toEqual({
+    ...initialWindowState,
+    devToolsOpen: false,
+    fullscreen: false,
+    minimized: false
+  })
+
   const primaryAction = tutorial.getByRole('button', { name: 'Got it' })
   await expect(primaryAction).toBeFocused()
   await page.keyboard.press('Tab')

--- a/e2e/tests/offline/tutorial.spec.mjs
+++ b/e2e/tests/offline/tutorial.spec.mjs
@@ -6,7 +6,7 @@ async function expectHighlightCenteredOn(page, targetSelector) {
   await expect.poll(async () => {
     const [highlight, target] = await Promise.all([
       page.locator('.tutorialHighlight').evaluate(element => element.getBoundingClientRect().toJSON()),
-      page.locator(targetSelector).evaluate(element => element.getBoundingClientRect().toJSON())
+      page.locator(`${targetSelector}:visible`).evaluate(element => element.getBoundingClientRect().toJSON())
     ])
 
     return {
@@ -99,4 +99,18 @@ test('walks new users through the essential controls', async ({ page }) => {
 
   await page.reload()
   await expect(page.locator('.tutorialOverlay')).toHaveCount(0)
+})
+
+test('highlights the mobile search button', async ({ app, page }) => {
+  await app.electronApp.evaluate(({ BrowserWindow }) => {
+    BrowserWindow.getAllWindows()[0].setSize(600, 700)
+  })
+  await page.evaluate(() => localStorage.setItem('opentubex.tutorial.audience', 'new'))
+  await page.reload()
+
+  const tutorial = page.locator('.tutorialCard')
+  await tutorial.getByRole('button', { name: 'Next' }).click()
+  await tutorial.getByRole('button', { name: 'Next' }).click()
+  await expect(tutorial).toHaveAccessibleName('Search or paste a link')
+  await expectHighlightCenteredOn(page, '.navSearchButton[data-tutorial="search"]')
 })

--- a/src/constants.js
+++ b/src/constants.js
@@ -50,6 +50,7 @@ const IpcChannels = {
   TABS_GET_CACHED_PREVIEWS: 'tabs-get-cached-previews',
   TABS_SET_PREVIEWS_ENABLED: 'tabs-set-previews-enabled',
   TABS_SET_PREVIEW_CAPTURE_PAUSED: 'tabs-set-preview-capture-paused',
+  TABS_SET_SHORTCUTS_BLOCKED: 'tabs-set-shortcuts-blocked',
   TABS_REQUEST_PREVIEW_REFRESH: 'tabs-request-preview-refresh',
   TABS_RESTORE_CLOSED: 'tabs-restore-closed',
   TABS_RELOAD: 'tabs-reload',

--- a/src/main/index.js
+++ b/src/main/index.js
@@ -4526,7 +4526,8 @@ function runApp() {
           {
             label: 'New Window',
             accelerator: getElectronAccelerator(keyboardShortcuts.APP.GENERAL.NEW_WINDOW),
-            click: (_menuItem, _browserWindow, _event) => {
+            click: (_menuItem, browserWindow, _event) => {
+              if (browserWindow && appShortcutBlockedWindows.has(browserWindow)) { return }
               createWindow({
                 replaceMainWindow: false,
                 showWindowNow: true
@@ -4573,12 +4574,16 @@ function runApp() {
           {
             label: 'Toggle Developer Tools',
             accelerator: getElectronAccelerator(keyboardShortcuts.APP.GENERAL.TOGGLE_DEVTOOLS),
-            click: (_menuItem, browserWindow) => browserWindow?.webContents.toggleDevTools()
+            click: (_menuItem, browserWindow) => {
+              if (browserWindow && appShortcutBlockedWindows.has(browserWindow)) { return }
+              browserWindow?.webContents.toggleDevTools()
+            }
           },
           {
             label: 'Enter Inspect Element Mode',
             accelerator: 'CmdOrCtrl+Shift+C',
             click: (_, window) => {
+              if (appShortcutBlockedWindows.has(window)) { return }
               if (window.webContents.isDevToolsOpened()) {
                 window.devToolsWebContents.executeJavaScript('DevToolsAPI.enterInspectElementMode()')
               } else {
@@ -4606,13 +4611,16 @@ function runApp() {
           {
             label: 'Actual Size',
             accelerator: getElectronAccelerator(keyboardShortcuts.APP.GENERAL.RESET_ZOOM),
-            click: (_menuItem, browserWindow) => browserWindow?.webContents.setZoomLevel(0)
+            click: (_menuItem, browserWindow) => {
+              if (browserWindow && appShortcutBlockedWindows.has(browserWindow)) { return }
+              browserWindow?.webContents.setZoomLevel(0)
+            }
           },
           {
             label: 'Zoom In',
             accelerator: getElectronAccelerator(keyboardShortcuts.APP.GENERAL.ZOOM_IN),
             click: (_menuItem, browserWindow) => {
-              if (browserWindow) {
+              if (browserWindow && !appShortcutBlockedWindows.has(browserWindow)) {
                 browserWindow.webContents.setZoomLevel(browserWindow.webContents.getZoomLevel() + 0.5)
               }
             }
@@ -4621,7 +4629,7 @@ function runApp() {
             label: 'Zoom Out',
             accelerator: getElectronAccelerator(keyboardShortcuts.APP.GENERAL.ZOOM_OUT),
             click: (_menuItem, browserWindow) => {
-              if (browserWindow) {
+              if (browserWindow && !appShortcutBlockedWindows.has(browserWindow)) {
                 browserWindow.webContents.setZoomLevel(browserWindow.webContents.getZoomLevel() - 0.5)
               }
             }
@@ -4631,6 +4639,7 @@ function runApp() {
             label: 'Toggle Full Screen',
             accelerator: getElectronAccelerator(keyboardShortcuts.APP.GENERAL.FULLSCREEN),
             click: (_menuItem, browserWindow) => {
+              if (browserWindow && appShortcutBlockedWindows.has(browserWindow)) { return }
               browserWindow?.setFullScreen(!browserWindow.isFullScreen())
             }
           },
@@ -4853,7 +4862,10 @@ function runApp() {
           {
             label: 'Minimize',
             accelerator: getElectronAccelerator(keyboardShortcuts.APP.GENERAL.MINIMIZE_WINDOW),
-            click: (_menuItem, browserWindow) => browserWindow?.minimize()
+            click: (_menuItem, browserWindow) => {
+              if (browserWindow && appShortcutBlockedWindows.has(browserWindow)) { return }
+              browserWindow?.minimize()
+            }
           },
           {
             label: 'Close Window',

--- a/src/main/index.js
+++ b/src/main/index.js
@@ -3368,7 +3368,7 @@ function runApp() {
   /** @type {Map<number, number>} */
   const activePowerSaveBlockers = new Map()
 
-  ipcMain.on(IpcChannels.TABS_SET_SHORTCUTS_BLOCKED, (event, blocked) => {
+  ipcMain.handle(IpcChannels.TABS_SET_SHORTCUTS_BLOCKED, (event, blocked) => {
     if (!isOpenTubeXUrl(event.senderFrame.url) || typeof blocked !== 'boolean') {
       return
     }
@@ -4390,6 +4390,10 @@ function runApp() {
     webContents.on('did-start-navigation', (_event, _url, isInPlace, isMainFrame) => {
       if (isMainFrame && !isInPlace) {
         openUrlReadyWebContentsIds.delete(webContents.id)
+        const browserWindow = BrowserWindow.fromWebContents(webContents)
+        if (browserWindow) {
+          appShortcutBlockedWindows.delete(browserWindow)
+        }
       }
     })
 

--- a/src/main/index.js
+++ b/src/main/index.js
@@ -4539,6 +4539,7 @@ function runApp() {
             label: 'Preferences',
             accelerator: getElectronAccelerator(keyboardShortcuts.APP.GENERAL.NAVIGATE_TO_SETTINGS),
             click: (_menuItem, browserWindow, _event) => {
+              if (browserWindow && appShortcutBlockedWindows.has(browserWindow)) { return }
               navigateTo('/settings', browserWindow)
             },
             type: 'normal'
@@ -4728,6 +4729,7 @@ function runApp() {
               ? keyboardShortcuts.APP.GENERAL.NAVIGATE_TO_HISTORY_MAC
               : keyboardShortcuts.APP.GENERAL.NAVIGATE_TO_HISTORY),
             click: (_menuItem, browserWindow, _event) => {
+              if (browserWindow && appShortcutBlockedWindows.has(browserWindow)) { return }
               navigateTo('/history', browserWindow)
             },
             type: 'normal'

--- a/src/main/index.js
+++ b/src/main/index.js
@@ -122,6 +122,7 @@ function runApp() {
   ])
   const closeConfirmedWindowIds = new Set()
   const closingWindowIds = new Set()
+  const appShortcutBlockedWindows = new WeakSet()
   let quitPromptInProgress = null
   const windowClosePromptsInProgress = new Map()
   let isQuitConfirmed = false
@@ -3367,6 +3368,21 @@ function runApp() {
   /** @type {Map<number, number>} */
   const activePowerSaveBlockers = new Map()
 
+  ipcMain.on(IpcChannels.TABS_SET_SHORTCUTS_BLOCKED, (event, blocked) => {
+    if (!isOpenTubeXUrl(event.senderFrame.url) || typeof blocked !== 'boolean') {
+      return
+    }
+
+    const browserWindow = BrowserWindow.fromWebContents(event.sender)
+    if (!browserWindow) return
+
+    if (blocked) {
+      appShortcutBlockedWindows.add(browserWindow)
+    } else {
+      appShortcutBlockedWindows.delete(browserWindow)
+    }
+  })
+
   /**
    * @param {BrowserWindow} window
    */
@@ -4728,7 +4744,7 @@ function runApp() {
             label: 'New Tab',
             accelerator: getElectronAccelerator(keyboardShortcuts.APP.GENERAL.NEW_TAB),
             click: (_menuItem, browserWindow) => {
-              if (browserWindow) {
+              if (browserWindow && !appShortcutBlockedWindows.has(browserWindow)) {
                 const tabManager = TabManager.getForWindow(browserWindow.id)
                 if (tabManager) {
                   tabManager.createTabWithPreference({ makeActive: true }).catch(error => {
@@ -4742,7 +4758,7 @@ function runApp() {
             label: 'Close Tab',
             accelerator: getElectronAccelerator(keyboardShortcuts.APP.GENERAL.CLOSE_TAB),
             click: async (_menuItem, browserWindow) => {
-              if (browserWindow) {
+              if (browserWindow && !appShortcutBlockedWindows.has(browserWindow)) {
                 const tabManager = TabManager.getForWindow(browserWindow.id)
                 if (tabManager && tabManager.activeTabId) {
                   const tabIds = tabManager.selectedTabIds.length > 1
@@ -4767,7 +4783,7 @@ function runApp() {
             label: 'Reload Tab',
             accelerator: getElectronAccelerator(keyboardShortcuts.APP.GENERAL.RELOAD_TAB),
             click: (_menuItem, browserWindow) => {
-              if (browserWindow) {
+              if (browserWindow && !appShortcutBlockedWindows.has(browserWindow)) {
                 const tabManager = TabManager.getForWindow(browserWindow.id)
                 if (tabManager) {
                   const tabIds = tabManager.selectedTabIds.length > 1
@@ -4784,7 +4800,7 @@ function runApp() {
             label: 'Reopen Closed Tab',
             accelerator: getElectronAccelerator(keyboardShortcuts.APP.GENERAL.RESTORE_CLOSED_TAB),
             click: (_menuItem, browserWindow) => {
-              if (browserWindow) {
+              if (browserWindow && !appShortcutBlockedWindows.has(browserWindow)) {
                 const tabManager = TabManager.getForWindow(browserWindow.id)
                 if (tabManager) {
                   tabManager.restoreClosedTab()
@@ -4797,7 +4813,7 @@ function runApp() {
             label: 'Next Tab',
             accelerator: getElectronAccelerator(keyboardShortcuts.APP.GENERAL.NEXT_TAB),
             click: (_menuItem, browserWindow) => {
-              if (browserWindow) {
+              if (browserWindow && !appShortcutBlockedWindows.has(browserWindow)) {
                 const tabManager = TabManager.getForWindow(browserWindow.id)
                 if (tabManager && tabManager.tabs.size > 1) {
                   const tabIds = Array.from(tabManager.tabs.keys())
@@ -4812,7 +4828,7 @@ function runApp() {
             label: 'Previous Tab',
             accelerator: getElectronAccelerator(keyboardShortcuts.APP.GENERAL.PREV_TAB),
             click: (_menuItem, browserWindow) => {
-              if (browserWindow) {
+              if (browserWindow && !appShortcutBlockedWindows.has(browserWindow)) {
                 const tabManager = TabManager.getForWindow(browserWindow.id)
                 if (tabManager && tabManager.tabs.size > 1) {
                   const tabIds = Array.from(tabManager.tabs.keys())

--- a/src/main/index.js
+++ b/src/main/index.js
@@ -4638,7 +4638,7 @@ function runApp() {
             label: 'Back',
             accelerator: getElectronAccelerator(keyboardShortcuts.APP.GENERAL.HISTORY_BACKWARD),
             click: (_menuItem, browserWindow, _event) => {
-              if (browserWindow == null) { return }
+              if (browserWindow == null || appShortcutBlockedWindows.has(browserWindow)) { return }
 
               TabManager.getForWindow(browserWindow.id)?.navigateHistory(-1)
             },
@@ -4650,7 +4650,7 @@ function runApp() {
                   label: 'Back',
                   accelerator: getElectronAccelerator(keyboardShortcuts.APP.GENERAL.HISTORY_BACKWARD_ALT_MAC),
                   click: (_menuItem, browserWindow, _event) => {
-                    if (browserWindow == null) { return }
+                    if (browserWindow == null || appShortcutBlockedWindows.has(browserWindow)) { return }
 
                     TabManager.getForWindow(browserWindow.id)?.navigateHistory(-1)
                   },
@@ -4662,7 +4662,7 @@ function runApp() {
             label: 'Forward',
             accelerator: getElectronAccelerator(keyboardShortcuts.APP.GENERAL.HISTORY_FORWARD),
             click: (_menuItem, browserWindow, _event) => {
-              if (browserWindow == null) { return }
+              if (browserWindow == null || appShortcutBlockedWindows.has(browserWindow)) { return }
 
               TabManager.getForWindow(browserWindow.id)?.navigateHistory(1)
             },
@@ -4674,7 +4674,7 @@ function runApp() {
                   label: 'Forward',
                   accelerator: getElectronAccelerator(keyboardShortcuts.APP.GENERAL.HISTORY_FORWARD_ALT_MAC),
                   click: (_menuItem, browserWindow, _event) => {
-                    if (browserWindow == null) { return }
+                    if (browserWindow == null || appShortcutBlockedWindows.has(browserWindow)) { return }
 
                     TabManager.getForWindow(browserWindow.id)?.navigateHistory(1)
                   },

--- a/src/preload/interface.js
+++ b/src/preload/interface.js
@@ -730,7 +730,7 @@ export default {
      * @param {boolean} blocked
      */
     setShortcutsBlocked: (blocked) => {
-      ipcRenderer.send(IpcChannels.TABS_SET_SHORTCUTS_BLOCKED, blocked === true)
+      return ipcRenderer.invoke(IpcChannels.TABS_SET_SHORTCUTS_BLOCKED, blocked === true)
     },
 
     /**

--- a/src/preload/interface.js
+++ b/src/preload/interface.js
@@ -726,6 +726,14 @@ export default {
     },
 
     /**
+     * Block native tab menu accelerators while a modal owns keyboard input.
+     * @param {boolean} blocked
+     */
+    setShortcutsBlocked: (blocked) => {
+      ipcRenderer.send(IpcChannels.TABS_SET_SHORTCUTS_BLOCKED, blocked === true)
+    },
+
+    /**
      * Get the current tab state
      * @returns {Promise<{tabs: Array<{id: string, url: string, title: string, isActive: boolean}>, activeTabId: string|null}>}
      */

--- a/src/renderer/App.vue
+++ b/src/renderer/App.vue
@@ -742,7 +742,14 @@ function initializeTutorial(hasExistingInstallation, lastUsedVersion) {
   }
 }
 
-function completeTutorial() {
+async function completeTutorial() {
+  if (isElectron) {
+    try {
+      await window.ftElectron.tabs.setShortcutsBlocked(false)
+    } catch (error) {
+      console.error('Failed to restore tab shortcuts', error)
+    }
+  }
   showTutorial.value = false
 
   try {
@@ -817,6 +824,13 @@ onMounted(async () => {
     dataReady.value = true
 
     await nextTick()
+    if (isElectron && tutorialPending) {
+      try {
+        await window.ftElectron.tabs.setShortcutsBlocked(true)
+      } catch (error) {
+        console.error('Failed to block tab shortcuts for tutorial', error)
+      }
+    }
     showTutorial.value = tutorialPending
     initializeManagedExternalSoftware().catch(error => console.error('Failed to initialize managed external software', error))
 
@@ -873,7 +887,7 @@ onMounted(async () => {
 onBeforeUnmount(() => {
   if (isElectron) {
     window.ftElectron.tabs.setPreviewCapturePaused(false)
-    window.ftElectron.tabs.setShortcutsBlocked(false)
+    window.ftElectron.tabs.setShortcutsBlocked(false).catch(() => {})
   }
   cancelWatchSideNavTransitionReset()
   clearSubscriptionFeedAutoRefreshTimer()
@@ -901,12 +915,6 @@ onBeforeUnmount(() => {
   removeReloadRequestListener?.()
   removeConfirmMultipleTabsActionListener?.()
   removeOpenUrlListener?.()
-})
-
-watch(showTutorial, (visible) => {
-  if (isElectron) {
-    window.ftElectron.tabs.setShortcutsBlocked(visible)
-  }
 })
 
 watch([activeTabId, selectionRevision], ([tabId, revision]) => {

--- a/src/renderer/App.vue
+++ b/src/renderer/App.vue
@@ -723,14 +723,14 @@ async function initializeManagedExternalSoftware() {
 
 const TUTORIAL_AUDIENCE_STORAGE_KEY = 'opentubex.tutorial.audience'
 
-function initializeTutorial(hasExistingSettings, lastUsedVersion) {
+function initializeTutorial(hasExistingInstallation, lastUsedVersion) {
   try {
     let audience = localStorage.getItem(TUTORIAL_AUDIENCE_STORAGE_KEY)
     if (audience !== 'new' && audience !== 'existing' && lastUsedVersion !== null) return false
-    if (hasExistingSettings === null) return false
+    if (hasExistingInstallation === null) return false
 
     if (audience !== 'new' && audience !== 'existing') {
-      audience = hasExistingSettings ? 'existing' : 'new'
+      audience = hasExistingInstallation ? 'existing' : 'new'
       localStorage.setItem(TUTORIAL_AUDIENCE_STORAGE_KEY, audience)
     }
 
@@ -762,8 +762,6 @@ onMounted(async () => {
   }
 
   const hasExistingSettings = await store.dispatch('grabUserSettings')
-  const tutorialPending = initializeTutorial(hasExistingSettings, lastUsedVersion)
-  setLastUsedVersion(packageDetails.version)
 
   updateTheme()
 
@@ -778,7 +776,17 @@ onMounted(async () => {
     }
   })
 
-  store.dispatch('grabAllProfiles', t('Profile.All Channels')).then(async () => {
+  store.dispatch('grabAllProfiles', t('Profile.All Channels')).then(async (hasExistingProfiles) => {
+    const hasExistingInstallation = hasExistingSettings === true || hasExistingProfiles === true
+      ? true
+      : hasExistingSettings === null || hasExistingProfiles === null
+        ? null
+        : false
+    const tutorialPending = initializeTutorial(hasExistingInstallation, lastUsedVersion)
+    if (hasExistingInstallation !== null || lastUsedVersion !== null) {
+      setLastUsedVersion(packageDetails.version)
+    }
+
     const syncDataReady = Promise.all([
       store.dispatch('grabHistory'),
       store.dispatch('grabAllPlaylists'),
@@ -865,6 +873,7 @@ onMounted(async () => {
 onBeforeUnmount(() => {
   if (isElectron) {
     window.ftElectron.tabs.setPreviewCapturePaused(false)
+    window.ftElectron.tabs.setShortcutsBlocked(false)
   }
   cancelWatchSideNavTransitionReset()
   clearSubscriptionFeedAutoRefreshTimer()
@@ -892,6 +901,12 @@ onBeforeUnmount(() => {
   removeReloadRequestListener?.()
   removeConfirmMultipleTabsActionListener?.()
   removeOpenUrlListener?.()
+})
+
+watch(showTutorial, (visible) => {
+  if (isElectron) {
+    window.ftElectron.tabs.setShortcutsBlocked(visible)
+  }
 })
 
 watch([activeTabId, selectionRevision], ([tabId, revision]) => {

--- a/src/renderer/App.vue
+++ b/src/renderer/App.vue
@@ -743,6 +743,9 @@ function initializeTutorial(hasExistingInstallation, lastUsedVersion) {
 }
 
 async function completeTutorial() {
+  showTutorial.value = false
+  await nextTick()
+
   if (isElectron) {
     try {
       await window.ftElectron.tabs.setShortcutsBlocked(false)
@@ -750,7 +753,6 @@ async function completeTutorial() {
       console.error('Failed to restore tab shortcuts', error)
     }
   }
-  showTutorial.value = false
 
   try {
     localStorage.removeItem(TUTORIAL_AUDIENCE_STORAGE_KEY)

--- a/src/renderer/App.vue
+++ b/src/renderer/App.vue
@@ -726,8 +726,8 @@ const TUTORIAL_AUDIENCE_STORAGE_KEY = 'opentubex.tutorial.audience'
 function initializeTutorial(hasExistingSettings, lastUsedVersion) {
   try {
     let audience = localStorage.getItem(TUTORIAL_AUDIENCE_STORAGE_KEY)
-    if (audience !== 'new' && audience !== 'existing' && lastUsedVersion !== null) return
-    if (hasExistingSettings === null) return
+    if (audience !== 'new' && audience !== 'existing' && lastUsedVersion !== null) return false
+    if (hasExistingSettings === null) return false
 
     if (audience !== 'new' && audience !== 'existing') {
       audience = hasExistingSettings ? 'existing' : 'new'
@@ -735,9 +735,10 @@ function initializeTutorial(hasExistingSettings, lastUsedVersion) {
     }
 
     tutorialIsNewInstallation.value = audience === 'new'
-    showTutorial.value = true
+    return true
   } catch (error) {
     console.error('Failed to initialize tutorial', error)
+    return false
   }
 }
 
@@ -753,7 +754,6 @@ function completeTutorial() {
 
 onMounted(async () => {
   const lastUsedVersion = getLastUsedVersion()
-  setLastUsedVersion(packageDetails.version)
   preloadUtilityRoutes()
 
   if (isElectron) {
@@ -762,6 +762,8 @@ onMounted(async () => {
   }
 
   const hasExistingSettings = await store.dispatch('grabUserSettings')
+  const tutorialPending = initializeTutorial(hasExistingSettings, lastUsedVersion)
+  setLastUsedVersion(packageDetails.version)
 
   updateTheme()
 
@@ -807,7 +809,7 @@ onMounted(async () => {
     dataReady.value = true
 
     await nextTick()
-    initializeTutorial(hasExistingSettings, lastUsedVersion)
+    showTutorial.value = tutorialPending
     initializeManagedExternalSoftware().catch(error => console.error('Failed to initialize managed external software', error))
 
     setTimeout(() => {
@@ -1801,6 +1803,8 @@ const outlinesHidden = computed(() => store.getters.getOutlinesHidden)
  * @param {KeyboardEvent} event
  */
 function handleKeyboardShortcuts(event) {
+  if (showTutorial.value) return
+
   const shortcuts = KeyboardShortcuts.APP.GENERAL
 
   if (matchesKeyboardShortcut(event, shortcuts.FIND_IN_PAGE)) {

--- a/src/renderer/App.vue
+++ b/src/renderer/App.vue
@@ -72,6 +72,11 @@
     <Transition name="settings-window">
       <SettingsWindow v-if="settingsWindowOpen" />
     </Transition>
+    <FtTutorialOverlay
+      v-if="showTutorial"
+      :new-installation="tutorialIsNewInstallation"
+      @close="completeTutorial"
+    />
     <FtPrompt
       v-if="showReleaseNotes"
       theme="readable-width"
@@ -312,6 +317,7 @@ import FtPlaylistAddVideoPrompt from './components/FtPlaylistAddVideoPrompt/FtPl
 import FtCreatePlaylistPrompt from './components/FtCreatePlaylistPrompt/FtCreatePlaylistPrompt.vue'
 import FtSearchFilters from './components/FtSearchFilters/FtSearchFilters.vue'
 import FtContextMenu from './components/FtContextMenu/FtContextMenu.vue'
+import FtTutorialOverlay from './components/FtTutorialOverlay/FtTutorialOverlay.vue'
 import { vSaferHtml } from './directives/vSaferHtml.js'
 
 import store from './store/index'
@@ -341,6 +347,7 @@ import { initializePlatformInfo } from './helpers/platform'
 import { normalizeScrollbarThumbWidth } from './constants/scrollbar'
 import { getTabAccentColor } from './constants/tabColors'
 import { getThumbnailListStyles } from './constants/thumbnailSize'
+import { getLastUsedVersion, setLastUsedVersion } from './helpers/lastUsedVersion'
 import { getTabNavigationService } from './tabs/TabNavigationService'
 import { tabRuntimeRegistry } from './tabs/TabRuntimeRegistry'
 import { getTabAvatarUrl, getTabPageIcon, getTabPreviewFallbackUrl } from './tabs/tabPreview'
@@ -520,6 +527,8 @@ const hideSubscriptionsLive = computed(() => store.getters.getHideLiveStreams ||
 const hideSubscriptionsPosts = computed(() => store.getters.getHideSubscriptionsCommunity || store.getters.getUseRssFeeds)
 
 const dataReady = ref(false)
+const showTutorial = ref(false)
+const tutorialIsNewInstallation = ref(false)
 const findbarVisible = ref(false)
 const findbarQuery = ref('')
 const findbarMatchIndex = ref(0)
@@ -712,7 +721,39 @@ async function initializeManagedExternalSoftware() {
   }
 }
 
+const TUTORIAL_AUDIENCE_STORAGE_KEY = 'opentubex.tutorial.audience'
+
+function initializeTutorial(hasExistingSettings, lastUsedVersion) {
+  try {
+    let audience = localStorage.getItem(TUTORIAL_AUDIENCE_STORAGE_KEY)
+    if (audience !== 'new' && audience !== 'existing' && lastUsedVersion !== null) return
+    if (hasExistingSettings === null) return
+
+    if (audience !== 'new' && audience !== 'existing') {
+      audience = hasExistingSettings ? 'existing' : 'new'
+      localStorage.setItem(TUTORIAL_AUDIENCE_STORAGE_KEY, audience)
+    }
+
+    tutorialIsNewInstallation.value = audience === 'new'
+    showTutorial.value = true
+  } catch (error) {
+    console.error('Failed to initialize tutorial', error)
+  }
+}
+
+function completeTutorial() {
+  showTutorial.value = false
+
+  try {
+    localStorage.removeItem(TUTORIAL_AUDIENCE_STORAGE_KEY)
+  } catch (error) {
+    console.error('Failed to save tutorial completion', error)
+  }
+}
+
 onMounted(async () => {
+  const lastUsedVersion = getLastUsedVersion()
+  setLastUsedVersion(packageDetails.version)
   preloadUtilityRoutes()
 
   if (isElectron) {
@@ -720,7 +761,7 @@ onMounted(async () => {
     window.ftElectron.tabs.rendererReady()
   }
 
-  await store.dispatch('grabUserSettings')
+  const hasExistingSettings = await store.dispatch('grabUserSettings')
 
   updateTheme()
 
@@ -766,6 +807,7 @@ onMounted(async () => {
     dataReady.value = true
 
     await nextTick()
+    initializeTutorial(hasExistingSettings, lastUsedVersion)
     initializeManagedExternalSoftware().catch(error => console.error('Failed to initialize managed external software', error))
 
     setTimeout(() => {

--- a/src/renderer/components/FtQuickSettingsMenu/FtQuickSettingsMenu.vue
+++ b/src/renderer/components/FtQuickSettingsMenu/FtQuickSettingsMenu.vue
@@ -4,6 +4,7 @@
       ref="triggerRef"
       type="button"
       class="profileTrigger"
+      data-tutorial="quick-settings"
       :aria-label="t('Settings.Quick Settings.Quick Settings')"
       :title="t('Settings.Quick Settings.Quick Settings')"
       :aria-expanded="menuOpen"

--- a/src/renderer/components/FtTutorialOverlay/FtTutorialOverlay.css
+++ b/src/renderer/components/FtTutorialOverlay/FtTutorialOverlay.css
@@ -1,7 +1,7 @@
 .tutorialOverlay {
   position: fixed;
   inset: 0;
-  z-index: 250;
+  z-index: 1001;
 }
 
 .tutorialOverlay.centered {
@@ -18,7 +18,10 @@
     0 0 0 9999px rgb(0 0 0 / 72%);
   box-sizing: border-box;
   pointer-events: none;
-  transition: inset 180ms ease-out, inline-size 180ms ease-out, block-size 180ms ease-out;
+
+  /* Physical target coordinates must not mirror in RTL layouts. */
+  /* stylelint-disable-next-line liberty/use-logical-spec */
+  transition: inset-block-start 180ms ease-out, left 180ms ease-out, inline-size 180ms ease-out, block-size 180ms ease-out;
 }
 
 .tutorialCard {

--- a/src/renderer/components/FtTutorialOverlay/FtTutorialOverlay.css
+++ b/src/renderer/components/FtTutorialOverlay/FtTutorialOverlay.css
@@ -1,0 +1,102 @@
+.tutorialOverlay {
+  position: fixed;
+  inset: 0;
+  z-index: 250;
+}
+
+.tutorialOverlay.centered {
+  background-color: rgb(0 0 0 / 72%);
+  display: grid;
+  place-items: center;
+}
+
+.tutorialHighlight {
+  position: fixed;
+  border-radius: calc(10px * var(--ui-roundness));
+  box-shadow:
+    0 0 0 2px var(--primary-color),
+    0 0 0 9999px rgb(0 0 0 / 72%);
+  box-sizing: border-box;
+  pointer-events: none;
+  transition: inset 180ms ease-out, inline-size 180ms ease-out, block-size 180ms ease-out;
+}
+
+.tutorialCard {
+  position: fixed;
+  box-sizing: border-box;
+  inline-size: min(380px, calc(100vw - 24px));
+  margin: 0;
+  padding: 24px;
+  color: var(--primary-text-color);
+  box-shadow: 0 18px 55px rgb(0 0 0 / 55%);
+  text-align: center;
+}
+
+.centered .tutorialCard {
+  position: relative;
+}
+
+.tutorialProgress {
+  display: flex;
+  justify-content: center;
+  gap: 6px;
+  margin-block-end: 20px;
+}
+
+.tutorialProgress span {
+  inline-size: 7px;
+  block-size: 7px;
+  border-radius: 50%;
+  background-color: var(--tertiary-text-color);
+  transition: inline-size 180ms ease-out, background-color 180ms ease-out;
+}
+
+.tutorialProgress .active {
+  inline-size: 22px;
+  border-radius: 4px;
+  background-color: var(--primary-color);
+}
+
+.tutorialIcon {
+  display: grid;
+  place-items: center;
+  inline-size: 48px;
+  block-size: 48px;
+  margin-inline: auto;
+  border-radius: 50%;
+  background-color: var(--primary-color);
+  color: var(--text-with-main-color);
+  font-size: 22px;
+}
+
+.tutorialCard h2 {
+  margin-block: 16px 8px;
+  font-size: 1.35rem;
+}
+
+.tutorialCard p {
+  margin-block: 0 20px;
+  color: var(--secondary-text-color);
+  line-height: 1.5;
+}
+
+.tutorialActions {
+  display: flex;
+  justify-content: flex-end;
+  gap: 4px;
+}
+
+.tutorialActions :deep(.btn) {
+  margin: 0;
+}
+
+@media only screen and (width <= 500px) {
+  .tutorialCard {
+    padding: 20px;
+  }
+}
+
+:global(:root[data-reduced-motion='reduce']) .tutorialHighlight,
+:global(:root[data-reduced-motion='reduce']) .tutorialProgress span {
+  transition: none;
+}

--- a/src/renderer/components/FtTutorialOverlay/FtTutorialOverlay.css
+++ b/src/renderer/components/FtTutorialOverlay/FtTutorialOverlay.css
@@ -28,6 +28,8 @@
   position: fixed;
   box-sizing: border-box;
   inline-size: min(380px, calc(100vw - 24px));
+  max-block-size: calc(100dvh - 24px);
+  overflow: auto;
   margin: 0;
   padding: 24px;
   color: var(--primary-text-color);

--- a/src/renderer/components/FtTutorialOverlay/FtTutorialOverlay.vue
+++ b/src/renderer/components/FtTutorialOverlay/FtTutorialOverlay.vue
@@ -39,7 +39,11 @@
         >
           <FontAwesomeIcon :icon="step.icon" />
         </div>
-        <h2 :id="titleId">
+        <h2
+          :id="titleId"
+          ref="titleRef"
+          tabindex="-1"
+        >
           {{ step.title }}
         </h2>
         <p :id="descriptionId">
@@ -91,6 +95,7 @@ const descriptionId = useId()
 const promptId = useId()
 const cardRef = useTemplateRef('cardRef')
 const primaryButtonRef = useTemplateRef('primaryButtonRef')
+const titleRef = useTemplateRef('titleRef')
 const stepIndex = ref(0)
 const targetRect = ref(null)
 const cardStyle = ref({})
@@ -264,7 +269,7 @@ function advanceTutorial() {
 
   stepIndex.value++
   updatePosition()
-  nextTick(() => primaryButtonRef.value?.$el.focus())
+  nextTick(() => titleRef.value?.focus())
 }
 
 function finishTutorial() {

--- a/src/renderer/components/FtTutorialOverlay/FtTutorialOverlay.vue
+++ b/src/renderer/components/FtTutorialOverlay/FtTutorialOverlay.vue
@@ -100,6 +100,7 @@ const stepIndex = ref(0)
 const targetRect = ref(null)
 const cardStyle = ref({})
 let updateFrame = null
+let lastActiveElement = null
 
 const newUserSteps = computed(() => [
   {
@@ -164,6 +165,7 @@ const highlightStyle = computed(() => {
 })
 
 onMounted(() => {
+  lastActiveElement = document.activeElement
   lockBodyScroll()
   store.commit('addOpenPrompt', promptId)
   window.addEventListener('resize', schedulePositionUpdate)
@@ -180,6 +182,7 @@ onBeforeUnmount(() => {
   document.removeEventListener('keydown', handleDocumentKeydown, true)
   store.commit('removeOpenPrompt', promptId)
   unlockBodyScroll()
+  nextTick(() => lastActiveElement?.focus())
 })
 
 function schedulePositionUpdate() {

--- a/src/renderer/components/FtTutorialOverlay/FtTutorialOverlay.vue
+++ b/src/renderer/components/FtTutorialOverlay/FtTutorialOverlay.vue
@@ -186,7 +186,12 @@ function schedulePositionUpdate() {
 }
 
 async function updatePosition() {
-  const target = step.value.target === null ? null : document.querySelector(step.value.target)
+  const target = step.value.target === null
+    ? null
+    : Array.from(document.querySelectorAll(step.value.target)).find(element => {
+        const rect = element.getBoundingClientRect()
+        return rect.width > 0 && rect.height > 0
+      })
   const rect = target?.getBoundingClientRect()
   targetRect.value = rect && rect.width > 0 && rect.height > 0
     ? {

--- a/src/renderer/components/FtTutorialOverlay/FtTutorialOverlay.vue
+++ b/src/renderer/components/FtTutorialOverlay/FtTutorialOverlay.vue
@@ -1,0 +1,242 @@
+<template>
+  <Teleport to=".app">
+    <div
+      class="tutorialOverlay"
+      :class="{ centered: targetRect === null }"
+      role="presentation"
+      @pointerdown.self="finishTutorial"
+    >
+      <div
+        v-if="targetRect"
+        class="tutorialHighlight"
+        :style="highlightStyle"
+        aria-hidden="true"
+      />
+      <FtCard
+        ref="cardRef"
+        class="tutorialCard"
+        :style="cardStyle"
+        role="dialog"
+        aria-modal="true"
+        :aria-labelledby="titleId"
+        :aria-describedby="descriptionId"
+        @keydown.esc.stop="finishTutorial"
+      >
+        <div
+          v-if="steps.length > 1"
+          class="tutorialProgress"
+          aria-hidden="true"
+        >
+          <span
+            v-for="(_, index) in steps"
+            :key="index"
+            :class="{ active: index === stepIndex }"
+          />
+        </div>
+        <div
+          class="tutorialIcon"
+          aria-hidden="true"
+        >
+          <FontAwesomeIcon :icon="step.icon" />
+        </div>
+        <h2 :id="titleId">
+          {{ step.title }}
+        </h2>
+        <p :id="descriptionId">
+          {{ step.description }}
+        </p>
+        <div class="tutorialActions">
+          <FtButton
+            v-if="steps.length > 1"
+            :label="t('Tutorial.Skip')"
+            :text-color="null"
+            :background-color="null"
+            @click="finishTutorial"
+          />
+          <FtButton
+            ref="primaryButtonRef"
+            :label="primaryButtonLabel"
+            :icon="isLastStep ? ['fas', 'check'] : ['fas', 'arrow-right']"
+            @click="advanceTutorial"
+          />
+        </div>
+      </FtCard>
+    </div>
+  </Teleport>
+</template>
+
+<script setup>
+import { FontAwesomeIcon } from '@fortawesome/vue-fontawesome'
+import { computed, nextTick, onBeforeUnmount, onMounted, ref, useId, useTemplateRef } from 'vue'
+import { useI18n } from 'vue-i18n'
+
+import store from '../../store/index'
+
+import FtButton from '../FtButton/FtButton.vue'
+import FtCard from '../ft-card/ft-card.vue'
+import { lockBodyScroll, unlockBodyScroll } from '../FtPrompt/scrollLock'
+
+const props = defineProps({
+  newInstallation: {
+    type: Boolean,
+    required: true
+  }
+})
+
+const emit = defineEmits(['close'])
+
+const { t } = useI18n()
+const titleId = useId()
+const descriptionId = useId()
+const promptId = useId()
+const cardRef = useTemplateRef('cardRef')
+const primaryButtonRef = useTemplateRef('primaryButtonRef')
+const stepIndex = ref(0)
+const targetRect = ref(null)
+const cardStyle = ref({})
+let updateFrame = null
+
+const newUserSteps = computed(() => [
+  {
+    icon: ['fas', 'play'],
+    title: t('Tutorial.Welcome.Title'),
+    description: t('Tutorial.Welcome.Description'),
+    target: null
+  },
+  {
+    icon: ['fas', 'rss'],
+    title: t('Tutorial.Navigation.Title'),
+    description: t('Tutorial.Navigation.Description'),
+    target: '[data-tutorial="navigation"]'
+  },
+  {
+    icon: ['fas', 'search'],
+    title: t('Tutorial.Search.Title'),
+    description: t('Tutorial.Search.Description'),
+    target: '[data-tutorial="search"]'
+  },
+  ...(process.env.IS_ELECTRON
+    ? [{
+        icon: ['fas', 'clone'],
+        title: t('Tutorial.Tabs.Title'),
+        description: t('Tutorial.Tabs.Description'),
+        target: '[data-tutorial="tabs"]'
+      }]
+    : []),
+  {
+    icon: ['fas', 'sliders-h'],
+    title: t('Tutorial.Quick Settings.Title'),
+    description: t('Tutorial.Quick Settings.Description'),
+    target: '[data-tutorial="quick-settings"]'
+  }
+])
+
+const returningUserSteps = computed(() => [{
+  icon: ['fas', 'sliders-h'],
+  title: t('Tutorial.Settings Moved.Title'),
+  description: t('Tutorial.Settings Moved.Description'),
+  target: '[data-tutorial="quick-settings"]'
+}])
+
+const steps = computed(() => props.newInstallation ? newUserSteps.value : returningUserSteps.value)
+const step = computed(() => steps.value[stepIndex.value])
+const isLastStep = computed(() => stepIndex.value === steps.value.length - 1)
+const primaryButtonLabel = computed(() => {
+  if (!props.newInstallation) return t('Tutorial.Got It')
+  return isLastStep.value ? t('Tutorial.Finish') : t('Tutorial.Next')
+})
+
+const highlightStyle = computed(() => {
+  if (targetRect.value === null) return {}
+
+  return {
+    insetBlockStart: `${targetRect.value.top}px`,
+    insetInlineStart: `${targetRect.value.left}px`,
+    inlineSize: `${targetRect.value.width}px`,
+    blockSize: `${targetRect.value.height}px`,
+    borderRadius: targetRect.value.borderRadius
+  }
+})
+
+onMounted(() => {
+  lockBodyScroll()
+  store.commit('addOpenPrompt', promptId)
+  window.addEventListener('resize', schedulePositionUpdate)
+  window.addEventListener('scroll', schedulePositionUpdate, true)
+  updatePosition()
+  nextTick(() => primaryButtonRef.value?.$el.focus())
+})
+
+onBeforeUnmount(() => {
+  if (updateFrame !== null) cancelAnimationFrame(updateFrame)
+  window.removeEventListener('resize', schedulePositionUpdate)
+  window.removeEventListener('scroll', schedulePositionUpdate, true)
+  store.commit('removeOpenPrompt', promptId)
+  unlockBodyScroll()
+})
+
+function schedulePositionUpdate() {
+  if (updateFrame !== null) cancelAnimationFrame(updateFrame)
+  updateFrame = requestAnimationFrame(() => {
+    updateFrame = null
+    updatePosition()
+  })
+}
+
+async function updatePosition() {
+  const target = step.value.target === null ? null : document.querySelector(step.value.target)
+  const rect = target?.getBoundingClientRect()
+  targetRect.value = rect && rect.width > 0 && rect.height > 0
+    ? {
+        top: rect.top,
+        left: rect.left,
+        width: rect.width,
+        height: rect.height,
+        borderRadius: getComputedStyle(target).borderRadius
+      }
+    : null
+
+  cardStyle.value = {}
+  await nextTick()
+
+  if (targetRect.value === null) return
+
+  const card = cardRef.value?.$el
+  if (!card) return
+
+  const cardRect = card.getBoundingClientRect()
+  const gap = 14
+  const cardViewportPadding = 12
+  const availableBelow = window.innerHeight - targetRect.value.top - targetRect.value.height
+  const top = availableBelow >= cardRect.height + gap
+    ? targetRect.value.top + targetRect.value.height + gap
+    : Math.max(cardViewportPadding, targetRect.value.top - cardRect.height - gap)
+  const idealLeft = targetRect.value.left + targetRect.value.width / 2 - cardRect.width / 2
+  const left = Math.min(
+    window.innerWidth - cardRect.width - cardViewportPadding,
+    Math.max(cardViewportPadding, idealLeft)
+  )
+
+  cardStyle.value = {
+    insetBlockStart: `${top}px`,
+    insetInlineStart: `${left}px`
+  }
+}
+
+function advanceTutorial() {
+  if (isLastStep.value) {
+    finishTutorial()
+    return
+  }
+
+  stepIndex.value++
+  updatePosition()
+  nextTick(() => primaryButtonRef.value?.$el.focus())
+}
+
+function finishTutorial() {
+  emit('close')
+}
+</script>
+
+<style scoped src="./FtTutorialOverlay.css" />

--- a/src/renderer/components/FtTutorialOverlay/FtTutorialOverlay.vue
+++ b/src/renderer/components/FtTutorialOverlay/FtTutorialOverlay.vue
@@ -5,6 +5,7 @@
       :class="{ centered: targetRect === null }"
       role="presentation"
       @pointerdown.self="finishTutorial"
+      @keydown.capture="handleKeydown"
     >
       <div
         v-if="targetRect"
@@ -20,7 +21,6 @@
         aria-modal="true"
         :aria-labelledby="titleId"
         :aria-describedby="descriptionId"
-        @keydown.esc.stop="finishTutorial"
       >
         <div
           v-if="steps.length > 1"
@@ -151,7 +151,7 @@ const highlightStyle = computed(() => {
 
   return {
     insetBlockStart: `${targetRect.value.top}px`,
-    insetInlineStart: `${targetRect.value.left}px`,
+    left: `${targetRect.value.left}px`,
     inlineSize: `${targetRect.value.width}px`,
     blockSize: `${targetRect.value.height}px`,
     borderRadius: targetRect.value.borderRadius
@@ -163,6 +163,7 @@ onMounted(() => {
   store.commit('addOpenPrompt', promptId)
   window.addEventListener('resize', schedulePositionUpdate)
   window.addEventListener('scroll', schedulePositionUpdate, true)
+  document.addEventListener('keydown', handleDocumentKeydown, true)
   updatePosition()
   nextTick(() => primaryButtonRef.value?.$el.focus())
 })
@@ -171,6 +172,7 @@ onBeforeUnmount(() => {
   if (updateFrame !== null) cancelAnimationFrame(updateFrame)
   window.removeEventListener('resize', schedulePositionUpdate)
   window.removeEventListener('scroll', schedulePositionUpdate, true)
+  document.removeEventListener('keydown', handleDocumentKeydown, true)
   store.commit('removeOpenPrompt', promptId)
   unlockBodyScroll()
 })
@@ -219,8 +221,34 @@ async function updatePosition() {
 
   cardStyle.value = {
     insetBlockStart: `${top}px`,
-    insetInlineStart: `${left}px`
+    left: `${left}px`
   }
+}
+
+function handleDocumentKeydown(event) {
+  if (event.key === 'Escape') {
+    event.preventDefault()
+    event.stopPropagation()
+    finishTutorial()
+  }
+}
+
+function handleKeydown(event) {
+  event.stopPropagation()
+
+  if (event.key !== 'Tab') return
+
+  const buttons = Array.from(cardRef.value?.$el.querySelectorAll('.btn') ?? [])
+  if (buttons.length === 0) return
+
+  const currentIndex = buttons.indexOf(document.activeElement)
+  const nextIndex = event.shiftKey
+    ? (currentIndex <= 0 ? buttons.length - 1 : currentIndex - 1)
+    : (currentIndex === -1 || currentIndex === buttons.length - 1 ? 0 : currentIndex + 1)
+
+  event.preventDefault()
+  buttons[nextIndex].focus()
+  store.dispatch('showOutlines')
 }
 
 function advanceTutorial() {

--- a/src/renderer/components/SideNav/SideNav.vue
+++ b/src/renderer/components/SideNav/SideNav.vue
@@ -18,6 +18,7 @@
       />
       <router-link
         class="navOption topNavOption mobileShow "
+        data-tutorial="navigation"
         role="button"
         to="/subscriptions"
         :title="$t('Subscriptions.Subscriptions')"

--- a/src/renderer/components/TabBar/TabBar.vue
+++ b/src/renderer/components/TabBar/TabBar.vue
@@ -3,6 +3,7 @@
     v-if="isElectron"
     ref="tabBarRef"
     class="tabBar"
+    data-tutorial="tabs"
     :class="{ vertical }"
     :style="fixedTabWidthStyle"
   >

--- a/src/renderer/components/TopNav/TopNav.vue
+++ b/src/renderer/components/TopNav/TopNav.vue
@@ -98,6 +98,7 @@
           v-show="showSearchContainer"
           ref="searchContainer"
           class="searchContainer"
+          data-tutorial="search"
         >
           <FtInput
             ref="searchInput"

--- a/src/renderer/components/TopNav/TopNav.vue
+++ b/src/renderer/components/TopNav/TopNav.vue
@@ -47,6 +47,7 @@
         <button
           v-if="!hideSearchBar"
           class="navSearchButton navButton"
+          data-tutorial="search"
           @click="toggleSearchContainer"
         >
           <FontAwesomeIcon

--- a/src/renderer/helpers/lastUsedVersion.js
+++ b/src/renderer/helpers/lastUsedVersion.js
@@ -1,0 +1,18 @@
+const LAST_USED_VERSION_STORAGE_KEY = 'opentubex.lastUsedVersion'
+
+export function getLastUsedVersion() {
+  try {
+    return localStorage.getItem(LAST_USED_VERSION_STORAGE_KEY)
+  } catch (error) {
+    console.error('Failed to read the last used app version', error)
+    return null
+  }
+}
+
+export function setLastUsedVersion(version) {
+  try {
+    localStorage.setItem(LAST_USED_VERSION_STORAGE_KEY, version)
+  } catch (error) {
+    console.error('Failed to save the last used app version', error)
+  }
+}

--- a/src/renderer/store/modules/profiles.js
+++ b/src/renderer/store/modules/profiles.js
@@ -70,10 +70,10 @@ const actions = {
       profiles = await DBProfileHandlers.find()
     } catch (errMessage) {
       console.error(errMessage)
-      return
+      return null
     }
 
-    if (!Array.isArray(profiles)) return
+    if (!Array.isArray(profiles)) return null
 
     if (profiles.length === 0) {
       // Create a default profile and persist it
@@ -92,9 +92,10 @@ const actions = {
         commit('setProfileList', [defaultProfile])
       } catch (errMessage) {
         console.error(errMessage)
+        return null
       }
 
-      return
+      return false
     }
 
     // We want the primary profile to always be first
@@ -112,6 +113,7 @@ const actions = {
     }
 
     commit('setProfileList', profiles)
+    return true
   },
 
   async batchUpdateSubscriptionDetails({ dispatch, state }, channels) {

--- a/src/renderer/store/modules/settings.js
+++ b/src/renderer/store/modules/settings.js
@@ -842,8 +842,10 @@ const customActions = {
       }
 
       await Promise.allSettled(sideEffectPromises)
+      return userSettings.length > 0
     } catch (errMessage) {
       console.error(errMessage)
+      return null
     }
   },
 

--- a/static/locales/en-US.yaml
+++ b/static/locales/en-US.yaml
@@ -1106,6 +1106,29 @@ Settings:
     Set Password To Prevent Access: Set a password to prevent access to settings
     Set Password: Set Password
     Remove Password: Remove Password
+Tutorial:
+  Skip: Skip
+  Next: Next
+  Finish: Finish
+  Got It: Got it
+  Welcome:
+    Title: Welcome to OpenTubeX
+    Description: Here are the few controls that will help you feel at home.
+  Navigation:
+    Title: Your library is always nearby
+    Description: Use the navigation to reach subscriptions, playlists, history, downloads, and more.
+  Search:
+    Title: Search or paste a link
+    Description: Find videos and channels, or paste a supported video URL directly into the search field.
+  Tabs:
+    Title: Keep pages open in tabs
+    Description: Open several pages at once and switch between them without losing your place.
+  Quick Settings:
+    Title: Make it yours
+    Description: Select your profile in the top-right to switch profiles, change common preferences, or open all settings.
+  Settings Moved:
+    Title: Settings have moved
+    Description: Select your profile in the top-right for quick controls. The cog in that menu opens all settings.
 About:
   #On About page
   About: About


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Make sure to follow the contributing guidelines. -->
<!-- Important note, we may remove your pull request if you do not use this provided PR template correctly. -->
<!-- Agent instructions: Preserve every heading, comment, and marker in this template. Never remove or rewrite the release-note-category:start/end, release-note:start/end, or release-note-image:start/end marker pairs. Never remove or rewrite the Release note images section; leave its contents for a human. -->

## Pull Request Type
<!-- Please select what type of pull request this is: [x] -->
- [ ] Bugfix
- [x] Feature Implementation
- [ ] Documentation
- [ ] Other

## Related issue
<!-- Please link the issue your pull request is referring to. -->
<!-- If this pull request fully resolves the relevant issue, put "closes" before the issue number. -->
<!-- Example: "closes #123456". -->

## Description
<!-- Please write a clear and concise description of what the pull request does. -->

New users currently arrive without an introduction to the main navigation, search, tabs, or the new quick-settings menu, while returning users need to know only that settings moved into the top-right profile menu.

This adds a short, spotlight-based tutorial tailored to each audience. Fresh installations receive a five-step walkthrough of the essential controls, while existing installations receive a single settings-moved notice. The spotlight follows target layout changes, stays centered on the highlighted control, supports reduced motion and keyboard dismissal, and records completion locally.

The app now also records a generic last-used application version for future migrations and one-time notices instead of coupling version tracking to this tutorial.

## Release note category
<!-- Select exactly one category. Every pull request must select one. -->
<!-- Select "Not noteworthy" when the pull request fixes a bug in or improves functionality that has not yet appeared in a stable release. -->
<!-- release-note-category:start -->
- [ ] Not noteworthy
- [ ] Highlights
- [x] More improvements
- [ ] Fixed bugs
<!-- release-note-category:end -->

## Release note
<!-- Required unless "Not noteworthy" is selected. -->
<!-- Write one concise, user-facing entry without a leading bullet. -->
<!-- release-note:start -->
New installations now include a short interface tour, while existing users are shown where settings moved.
<!-- release-note:end -->

## Release note images
<!-- Human-only: Agents must preserve this entire section and leave it empty. -->
<!-- Optional. Paste one or more Markdown images or HTML image tags here. -->
<!-- The release notes will use an HTML image tag and limit images taller than 300 pixels. -->
<!-- release-note-image:start -->
<img width="1920" height="1046" alt="Screencast_20260812_093435-github" src="https://github.com/user-attachments/assets/ad9fea5a-989f-4ef4-9fa2-680c7d254ea4" />
<!-- release-note-image:end -->

## Testing
<!-- How can reviewers verify that the PR produces correct results? -->
<!-- Please provide instructions so that others can ensure that your pull request would produce correct results. For examples see, https://github.com/FreeTubeApp/FreeTube/pull/5743, https://github.com/FreeTubeApp/FreeTube/pull/7349, https://github.com/FreeTubeApp/FreeTube/pull/5125, https://github.com/FreeTubeApp/FreeTube/pull/7338 -->
<!-- Agent instructions: Only write human-facing steps that explain how to verify the change while running this branch in dev mode. Include expected results and, when applicable, helpful console snippets for interactive verification. Do not include automated checks, commands, results, pass counts, or CI status. -->

1. Start the app with existing user data and confirm a single **Settings have moved** card highlights the profile button in the top-right.
2. Select **Got it**, reload, and confirm the notice does not return.
3. In DevTools, run `localStorage.setItem('opentubex.tutorial.audience', 'new')`, then reload and confirm the five-step new-user tour covers navigation, search, tabs, and quick settings.
4. Resize the window while moving through the tour and confirm the spotlight remains centered on each visible target and the card stays inside the viewport.
5. Confirm **Skip**, **Finish**, Escape, and clicking the backdrop close the tour and that keyboard focus starts on its primary action.

## Additional context
<!-- Add any other context about the pull request here. -->

Implemented with Codex powered by GPT-5 in the Codex desktop harness.
