### PR TITLE
feat: support custom profile icons

### DIFF
--- a/e2e/tests/offline/profiles.spec.mjs
+++ b/e2e/tests/offline/profiles.spec.mjs
@@ -87,4 +87,52 @@ test.describe('profile manager', () => {
     await openProfileList(page)
     await expect(page.locator('.profileList .profileOption').filter({ hasText: 'Created via UI' })).toBeVisible()
   })
+
+  test('customizes a profile icon with a cropped SVG or emoji', async ({ app, page }) => {
+    await openProfileList(page)
+    await page.locator('.profilePanelHeader button').last().click()
+    await page.locator('.card .profileList').getByText('All Channels').click()
+
+    const makeDefaultButton = page.getByRole('button', { name: 'Make Default Profile' })
+    await expect(makeDefaultButton).toBeDisabled()
+    await expect(page.locator('.colorOption.selected')).toHaveCount(1)
+
+    await page.locator('.imageInput').setInputFiles({
+      name: 'globe.svg',
+      mimeType: 'image/svg+xml',
+      buffer: Buffer.from('<svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24"><circle cx="12" cy="12" r="10" fill="currentColor"/></svg>')
+    })
+    await expect(page.getByRole('heading', { name: 'Crop Image' })).toBeVisible()
+    await page.getByRole('button', { name: 'Apply Crop' }).click()
+
+    const preview = page.locator('.profilePreviewIcon')
+    await expect(preview.locator('img')).toBeVisible()
+    await expect(preview).toHaveCSS('background-color', 'rgba(0, 0, 0, 0)')
+    await page.getByRole('button', { name: 'Update Profile' }).click()
+
+    await expect.poll(async () => {
+      const contents = await readFile(path.join(app.userDataDir, 'profiles.db'), 'utf8')
+      const records = contents.trim().split('\n').map(line => JSON.parse(line))
+      const profile = records.findLast(record => record._id === 'allChannels' && !record.$$deleted)
+      return profile?.icon?.type === 'image' && profile.bgColor === 'transparent'
+    }).toBe(true)
+
+    const customEmoji = page.locator('#profileEmoji')
+    await customEmoji.fill('A')
+    await expect(customEmoji).toHaveValue('')
+    await expect(preview.locator('img')).toBeVisible()
+
+    await customEmoji.fill('🌍')
+    await expect(preview.locator('img')).toHaveCount(0)
+    await expect(preview).toContainText('🌍')
+    await expect(preview).not.toHaveCSS('background-color', 'rgba(0, 0, 0, 0)')
+    await page.getByRole('button', { name: 'Update Profile' }).click()
+
+    await expect.poll(async () => {
+      const contents = await readFile(path.join(app.userDataDir, 'profiles.db'), 'utf8')
+      const records = contents.trim().split('\n').map(line => JSON.parse(line))
+      const profile = records.findLast(record => record._id === 'allChannels' && !record.$$deleted)
+      return profile?.icon?.value === '🌍' && profile.bgColor !== 'transparent'
+    }).toBe(true)
+  })
 })

--- a/e2e/tests/offline/profiles.spec.mjs
+++ b/e2e/tests/offline/profiles.spec.mjs
@@ -8,7 +8,7 @@ import { test, expect } from '../../helpers/app.mjs'
 const mainProfile = {
   _id: 'allChannels',
   name: 'All Channels',
-  bgColor: '#000000',
+  bgColor: '#d50000',
   textColor: '#FFFFFF',
   subscriptions: []
 }
@@ -121,6 +121,10 @@ test.describe('profile manager', () => {
     await customEmoji.fill('A')
     await expect(customEmoji).toHaveValue('')
     await expect(preview.locator('img')).toBeVisible()
+
+    await customEmoji.fill('❤')
+    await expect(customEmoji).toHaveValue('❤')
+    await expect(preview).toContainText('❤')
 
     await customEmoji.fill('🌍')
     await expect(preview.locator('img')).toHaveCount(0)

--- a/src/renderer/components/FtProfileBubble/FtProfileBubble.css
+++ b/src/renderer/components/FtProfileBubble/FtProfileBubble.css
@@ -4,6 +4,7 @@
   padding-block: 10px 30px;
   padding-inline: 10px;
   cursor: pointer;
+  border-radius: calc(8px * var(--ui-roundness));
   transition: background 0.2s ease-out;
 }
 
@@ -19,15 +20,7 @@
   margin-block: 20px 5px;
   margin-inline: auto;
   border-radius: 50%;
-}
-
-.initial {
   font-size: 35px;
-  line-height: 1em;
-  text-align: center;
-  padding-block: 17.5px;
-  padding-inline: 0;
-  user-select: none;
 }
 
 .profileName {

--- a/src/renderer/components/FtProfileBubble/FtProfileBubble.vue
+++ b/src/renderer/components/FtProfileBubble/FtProfileBubble.vue
@@ -7,17 +7,11 @@
     @click="click"
     @keydown.space.enter.prevent="click"
   >
-    <div
+    <FtProfileIcon
       class="bubble"
-      :style="{ background: backgroundColor, color: textColor }"
-    >
-      <div
-        class="initial"
-        dir="auto"
-      >
-        {{ profileInitial }}
-      </div>
-    </div>
+      :profile="profile"
+      :fallback="profileInitial"
+    />
     <div
       :id="id"
       class="profileName"
@@ -33,6 +27,7 @@ import { computed, useId } from 'vue'
 import { useI18n } from 'vue-i18n'
 
 import { getFirstCharacter } from '../../helpers/strings'
+import FtProfileIcon from '../FtProfileIcon/FtProfileIcon.vue'
 
 const props = defineProps({
   profileName: {
@@ -50,6 +45,10 @@ const props = defineProps({
   textColor: {
     type: String,
     required: true
+  },
+  icon: {
+    type: Object,
+    default: null
   }
 })
 
@@ -66,6 +65,12 @@ const profileInitial = computed(() => {
     ? getFirstCharacter(translatedProfileName.value, locale.value)
     : ''
 })
+
+const profile = computed(() => ({
+  bgColor: props.backgroundColor,
+  textColor: props.textColor,
+  icon: props.icon
+}))
 
 const emit = defineEmits(['click'])
 

--- a/src/renderer/components/FtProfileChannelList/FtProfileChannelList.vue
+++ b/src/renderer/components/FtProfileChannelList/FtProfileChannelList.vue
@@ -27,14 +27,17 @@
       >
         <FtButton
           :label="$t('Profile.Select All')"
+          :icon="['fas', 'check']"
           @click="selectAll"
         />
         <FtButton
           :label="$t('Profile.Select None')"
+          :icon="['fas', 'xmark']"
           @click="selectNone"
         />
         <FtButton
           :label="$t('Profile.Delete Selected')"
+          :icon="['fas', 'trash']"
           text-color="var(--destructive-text-color)"
           background-color="var(--destructive-color)"
           @click="displayDeletePrompt"

--- a/src/renderer/components/FtProfileEdit/FtProfileEdit.css
+++ b/src/renderer/components/FtProfileEdit/FtProfileEdit.css
@@ -17,6 +17,120 @@ h3 {
   inline-size: 350px;
 }
 
+.profileIconHeading {
+  margin-block-start: 24px;
+}
+
+.profileIconOptions {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 10px;
+}
+
+.emojiOptions {
+  display: flex;
+  flex-wrap: wrap;
+  justify-content: center;
+  gap: 6px;
+  max-inline-size: 350px;
+}
+
+.emojiOption {
+  background: var(--card-bg-color);
+  border: 2px solid transparent;
+  border-radius: 8px;
+  cursor: pointer;
+  font-size: 24px;
+  block-size: 42px;
+  inline-size: 42px;
+  padding: 0;
+}
+
+.emojiOption:hover,
+.emojiOption:focus-visible,
+.emojiOption.selected {
+  background: var(--side-nav-hover-color);
+  border-color: var(--primary-color);
+}
+
+.customEmojiLabel {
+  font-size: 14px;
+}
+
+.customEmojiInput {
+  background: var(--search-bar-color);
+  border: 1px solid var(--scrollbar-color);
+  border-radius: calc(4px * var(--ui-roundness));
+  color: var(--primary-text-color);
+  font-size: 24px;
+  inline-size: 80px;
+  padding: 6px;
+  text-align: center;
+}
+
+.imageInput {
+  display: none;
+}
+
+.iconActions {
+  justify-content: center;
+}
+
+.cropEditor {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 12px;
+}
+
+.cropCanvasWrapper {
+  background-color: #fff;
+  background-image:
+    linear-gradient(45deg, #bbb 25%, transparent 25%),
+    linear-gradient(-45deg, #bbb 25%, transparent 25%),
+    linear-gradient(45deg, transparent 75%, #bbb 75%),
+    linear-gradient(-45deg, transparent 75%, #bbb 75%);
+  background-position: 0 0, 0 12px, 12px -12px, -12px 0;
+  background-size: 24px 24px;
+  block-size: min(320px, calc(100vw - 80px));
+  inline-size: min(320px, calc(100vw - 80px));
+  overflow: hidden;
+  position: relative;
+}
+
+.cropCanvas {
+  block-size: 100%;
+  cursor: grab;
+  inline-size: 100%;
+  touch-action: none;
+}
+
+.cropCanvas:active {
+  cursor: grabbing;
+}
+
+.cropCircle {
+  border: 2px solid #fff;
+  border-radius: 50%;
+  box-shadow: 0 0 0 999px rgb(0 0 0 / 45%);
+  inset: 0;
+  pointer-events: none;
+  position: absolute;
+}
+
+.cropZoomLabel {
+  font-weight: bold;
+}
+
+.cropZoom {
+  inline-size: min(320px, calc(100vw - 80px));
+}
+
+.cropActions {
+  justify-content: center;
+}
+
 .profileEdit {
   flex-direction: column;
   column-gap: 10px;
@@ -48,19 +162,27 @@ h3 {
   border-radius: 50%;
 }
 
-.initial {
-  font-size: 37.5px;
-  text-align: center;
-  user-select: none;
+.colorOption.selected {
+  outline: 3px solid var(--primary-text-color);
+  outline-offset: 2px;
 }
 
-.colorOption:has(.initial) {
+.transparentColorOption {
+  background-color: #fff;
+  background-image:
+    linear-gradient(45deg, #bbb 25%, transparent 25%),
+    linear-gradient(-45deg, #bbb 25%, transparent 25%),
+    linear-gradient(45deg, transparent 75%, #bbb 75%),
+    linear-gradient(-45deg, transparent 75%, #bbb 75%);
+  background-position: 0 0, 0 10px, 10px -10px, -10px 0;
+  background-size: 20px 20px;
+  box-sizing: border-box;
+}
+
+.profilePreviewIcon {
   inline-size: 75px;
   block-size: 75px;
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  cursor: default;
+  font-size: 37.5px;
 }
 
 .profilePreviewSection {

--- a/src/renderer/components/FtProfileEdit/FtProfileEdit.vue
+++ b/src/renderer/components/FtProfileEdit/FtProfileEdit.vue
@@ -404,7 +404,7 @@ function selectCustomEmoji(event) {
 }
 
 function isEmoji(value) {
-  return /(?:\p{Emoji_Presentation}|\p{Regional_Indicator}|\uFE0F|\u20E3)/u.test(value)
+  return /(?:\p{Extended_Pictographic}|\p{Regional_Indicator}|\uFE0F|\u20E3)/u.test(value)
 }
 
 function openImagePicker() {

--- a/src/renderer/components/FtProfileEdit/FtProfileEdit.vue
+++ b/src/renderer/components/FtProfileEdit/FtProfileEdit.vue
@@ -12,6 +12,7 @@
               v-for="color in COLOR_VALUES"
               :key="color"
               class="colorOption"
+              :class="{ selected: profileBgColor.toLowerCase() === color.toLowerCase() }"
               :title="color + ' ' + $t('Profile.Custom Color')"
               :style="{ background: color }"
               tabindex="0"
@@ -19,13 +20,24 @@
               @click="profileBgColor = color"
               @keydown.enter.space.prevent="profileBgColor = color"
             />
+            <div
+              v-if="profileIcon?.type === 'image'"
+              class="colorOption transparentColorOption"
+              :class="{ selected: profileBgColor === 'transparent' }"
+              :title="$t('Profile.Transparent')"
+              tabindex="0"
+              role="button"
+              @click="profileBgColor = 'transparent'"
+              @keydown.enter.space.prevent="profileBgColor = 'transparent'"
+            />
           </FtFlexBox>
           <div class="customColorSection">
             <label for="colorPicker">{{ $t("Profile.Custom Color") }}</label>
             <input
               id="colorPicker"
-              v-model="profileBgColor"
               type="color"
+              :value="customColorPickerValue"
+              @input="profileBgColor = $event.target.value"
             >
           </div>
           <FtInput
@@ -49,25 +61,78 @@
               @input="profileName = $event"
               @keydown.enter="saveProfile"
             />
+            <h3 class="profileIconHeading">
+              {{ $t("Profile.Profile Icon") }}
+            </h3>
+            <div class="profileIconOptions">
+              <div
+                class="emojiOptions"
+                role="group"
+                :aria-label="$t('Profile.Choose an Emoji')"
+              >
+                <button
+                  v-for="emoji in EMOJI_OPTIONS"
+                  :key="emoji"
+                  type="button"
+                  class="emojiOption"
+                  :class="{ selected: profileIcon?.type === 'emoji' && profileIcon.value === emoji }"
+                  :aria-pressed="profileIcon?.type === 'emoji' && profileIcon.value === emoji"
+                  @click="selectEmoji(emoji)"
+                >
+                  {{ emoji }}
+                </button>
+              </div>
+              <label
+                class="customEmojiLabel"
+                for="profileEmoji"
+              >
+                {{ $t("Profile.Custom Emoji") }}
+              </label>
+              <input
+                id="profileEmoji"
+                class="customEmojiInput"
+                type="text"
+                inputmode="text"
+                :placeholder="$t('Profile.Emoji')"
+                :value="profileIcon?.type === 'emoji' ? profileIcon.value : ''"
+                @input="selectCustomEmoji"
+              >
+              <input
+                ref="imageInput"
+                class="imageInput"
+                type="file"
+                accept="image/*,image/svg+xml,.svg"
+                :aria-label="$t('Profile.Choose Image')"
+                @change="selectImage"
+              >
+              <FtFlexBox class="iconActions">
+                <FtButton
+                  :label="$t('Profile.Choose Image')"
+                  :icon="['fas', 'file-image']"
+                  @click="openImagePicker"
+                />
+                <FtButton
+                  v-if="profileIcon"
+                  :label="$t('Profile.Use Initial')"
+                  :icon="['fas', 'undo']"
+                  @click="clearProfileIcon"
+                />
+              </FtFlexBox>
+            </div>
           </div>
           <div>
             <h3>{{ $t("Profile.Profile Preview") }}</h3>
             <div class="profilePreviewSection">
-              <div
-                class="colorOption"
-                :style="{ background: profileBgColor, color: profileTextColor }"
-              >
-                <div
-                  class="initial"
-                  dir="auto"
-                >
-                  {{ profileInitial }}
-                </div>
-              </div>
+              <FtProfileIcon
+                class="profilePreviewIcon"
+                :profile="profilePreview"
+                :fallback="profileInitial"
+              />
               <FtFlexBox>
                 <FtButton
                   v-if="isNew"
                   :label="$t('Profile.Create Profile')"
+                  :icon="['fas', 'user-plus']"
                   @click="saveProfile"
                 />
                 <template
@@ -75,10 +140,13 @@
                 >
                   <FtButton
                     :label="$t('Profile.Update Profile')"
+                    :icon="['fas', 'user-check']"
                     @click="saveProfile"
                   />
                   <FtButton
                     :label="$t('Profile.Make Default Profile')"
+                    :disabled="defaultProfile === profileId"
+                    :icon="['fas', 'bookmark']"
                     @click="setDefaultProfile"
                   />
                   <FtButton
@@ -97,6 +165,55 @@
       </FtFlexBox>
     </FtCard>
     <FtPrompt
+      v-if="cropDialogOpen"
+      autosize
+      :label="$t('Profile.Crop Image')"
+      @click="cancelCrop"
+    >
+      <div class="cropEditor">
+        <div class="cropCanvasWrapper">
+          <canvas
+            ref="cropCanvas"
+            class="cropCanvas"
+            width="320"
+            height="320"
+            @pointerdown="startCropDrag"
+            @pointermove="moveCrop"
+            @pointerup="stopCropDrag"
+            @pointercancel="stopCropDrag"
+          />
+          <div class="cropCircle" />
+        </div>
+        <label
+          class="cropZoomLabel"
+          for="profileCropZoom"
+        >
+          {{ $t("Profile.Zoom") }}
+        </label>
+        <input
+          id="profileCropZoom"
+          v-model.number="cropZoom"
+          class="cropZoom"
+          type="range"
+          min="1"
+          max="4"
+          step="0.01"
+        >
+        <FtFlexBox class="cropActions">
+          <FtButton
+            :label="$t('Profile.Apply Crop')"
+            :icon="['fas', 'scissors']"
+            @click="applyCrop"
+          />
+          <FtButton
+            :label="$t('Cancel')"
+            :icon="['fas', 'xmark']"
+            @click="cancelCrop"
+          />
+        </FtFlexBox>
+      </div>
+    </FtPrompt>
+    <FtPrompt
       v-if="showDeletePrompt"
       autosize
       :label="deletePromptLabel"
@@ -109,7 +226,7 @@
 </template>
 
 <script setup>
-import { computed, ref, watch } from 'vue'
+import { computed, nextTick, onBeforeUnmount, ref, useTemplateRef, watch } from 'vue'
 import { useI18n } from 'vue-i18n'
 
 import FtCard from '../ft-card/ft-card.vue'
@@ -117,11 +234,12 @@ import FtPrompt from '../FtPrompt/FtPrompt.vue'
 import FtFlexBox from '../ft-flex-box/ft-flex-box.vue'
 import FtInput from '../FtInput/FtInput.vue'
 import FtButton from '../FtButton/FtButton.vue'
+import FtProfileIcon from '../FtProfileIcon/FtProfileIcon.vue'
 
 import store from '../../store/index'
 
 import { MAIN_PROFILE_ID } from '../../../constants'
-import { calculateColorLuminance, colors } from '../../helpers/colors'
+import { calculateColorLuminance, colors, getRandomColor } from '../../helpers/colors'
 import { deepCopy, showToast } from '../../helpers/utils'
 import { getFirstCharacter } from '../../helpers/strings'
 
@@ -131,6 +249,7 @@ import { getFirstCharacter } from '../../helpers/strings'
  * @property {string} name
  * @property {string} bgColor
  * @property {string} textColor
+ * @property {{type: 'emoji'|'image', value: string}|null|undefined} icon
  * @property {object[]} subscriptions
  * @property {string} subscriptions[].id
  * @property {string|undefined} subscriptions[].name
@@ -169,12 +288,43 @@ const profileName = ref(props.profile.name)
 
 /** @type {import('vue').Ref<string>} */
 const profileBgColor = ref(props.profile.bgColor)
+const lastOpaqueProfileBgColor = ref(
+  props.profile.bgColor === 'transparent' ? getRandomColor().value : props.profile.bgColor
+)
 
 /** @type {import('vue').Ref<string>} */
 const profileTextColor = ref(props.profile.textColor)
 
+const profileIcon = ref(deepCopy(props.profile.icon ?? null))
+
+const imageInput = useTemplateRef('imageInput')
+const cropCanvas = useTemplateRef('cropCanvas')
+const cropDialogOpen = ref(false)
+const cropZoom = ref(1)
+const cropOffset = { x: 0, y: 0 }
+let cropBitmap = null
+let cropPointer = null
+
+const EMOJI_OPTIONS = ['😀', '😎', '🤓', '🥳', '🤠', '👻', '🐱', '🐶', '🌈', '⭐']
+
 watch(profileBgColor, (value) => {
   profileTextColor.value = calculateColorLuminance(value)
+  if (value !== 'transparent') lastOpaqueProfileBgColor.value = value
+})
+
+watch(profileIcon, (icon) => {
+  if (icon?.type !== 'image') restoreOpaqueProfileColor()
+})
+
+watch(cropZoom, () => {
+  constrainCropOffset()
+  drawCropPreview()
+})
+
+onBeforeUnmount(() => cropBitmap?.close?.())
+
+const customColorPickerValue = computed(() => {
+  return profileBgColor.value === 'transparent' ? '#000000' : profileBgColor.value
 })
 
 const translatedProfileName = computed(() => {
@@ -186,6 +336,12 @@ const profileInitial = computed(() => {
     ? getFirstCharacter(translatedProfileName.value, locale.value)
     : ''
 })
+
+const profilePreview = computed(() => ({
+  bgColor: profileBgColor.value,
+  textColor: profileTextColor.value,
+  icon: profileIcon.value
+}))
 
 const editOrCreateProfileLabel = computed(() => {
   return props.isNew ? t('Profile.Create Profile') : t('Profile.Edit Profile')
@@ -205,6 +361,7 @@ function saveProfile() {
     name: profileName.value,
     bgColor: profileBgColor.value,
     textColor: profileTextColor.value,
+    icon: deepCopy(profileIcon.value),
     subscriptions: deepCopy(props.profile.subscriptions)
   }
 
@@ -219,6 +376,196 @@ function saveProfile() {
   } else {
     store.dispatch('updateProfile', profile)
     showToast({ message: t('Profile.Profile has been updated'), icon: ['fas', 'user-check'] })
+  }
+}
+
+function selectEmoji(emoji) {
+  profileIcon.value = { type: 'emoji', value: emoji }
+  restoreOpaqueProfileColor()
+}
+
+function selectCustomEmoji(event) {
+  const value = event.target.value
+  const candidate = value ? getFirstCharacter(value, locale.value) : ''
+  const currentEmoji = profileIcon.value?.type === 'emoji' ? profileIcon.value.value : ''
+
+  if (candidate && !isEmoji(candidate)) {
+    event.target.value = currentEmoji
+    return
+  }
+
+  event.target.value = candidate
+  profileIcon.value = candidate ? { type: 'emoji', value: candidate } : null
+  restoreOpaqueProfileColor()
+}
+
+function isEmoji(value) {
+  return /(?:\p{Emoji_Presentation}|\p{Regional_Indicator}|\uFE0F|\u20E3)/u.test(value)
+}
+
+function openImagePicker() {
+  imageInput.value?.click()
+}
+
+async function selectImage(event) {
+  const file = event.target.files?.[0]
+  event.target.value = ''
+  if (!file) return
+
+  try {
+    cropBitmap?.close?.()
+    cropBitmap = await loadCropBitmap(file)
+    cropZoom.value = 1
+    cropOffset.x = 0
+    cropOffset.y = 0
+    cropDialogOpen.value = true
+    await nextTick()
+    drawCropPreview()
+  } catch (error) {
+    console.error('Failed to load profile icon image:', error)
+    showToast({
+      message: t('Profile.The selected image could not be loaded'),
+      icon: ['fas', 'circle-exclamation']
+    })
+  }
+}
+
+async function loadCropBitmap(file) {
+  const isSvg = file.type === 'image/svg+xml' || file.name.toLowerCase().endsWith('.svg')
+  if (!isSvg) return await createImageBitmap(file)
+
+  const svg = await file.text()
+  const visibleSvg = svg.replaceAll(/\bcurrentColor\b/gi, '#FFFFFF')
+  const objectUrl = URL.createObjectURL(new Blob([visibleSvg], { type: 'image/svg+xml' }))
+
+  try {
+    const image = new Image()
+    image.src = objectUrl
+    await image.decode()
+
+    const width = image.naturalWidth || image.width
+    const height = image.naturalHeight || image.height
+    if (width === 0 || height === 0) throw new Error('SVG has no intrinsic dimensions')
+
+    const renderScale = Math.min(1024 / Math.max(width, height), 1024)
+    const canvas = document.createElement('canvas')
+    canvas.width = Math.max(1, Math.round(width * renderScale))
+    canvas.height = Math.max(1, Math.round(height * renderScale))
+    canvas.getContext('2d').drawImage(image, 0, 0, canvas.width, canvas.height)
+
+    return canvas
+  } finally {
+    URL.revokeObjectURL(objectUrl)
+  }
+}
+
+function getCropScale() {
+  if (!cropBitmap) return 1
+
+  return Math.max(320 / cropBitmap.width, 320 / cropBitmap.height) * cropZoom.value
+}
+
+function constrainCropOffset() {
+  if (!cropBitmap) return
+
+  const scale = getCropScale()
+  const maxX = Math.max(0, (cropBitmap.width * scale - 320) / 2)
+  const maxY = Math.max(0, (cropBitmap.height * scale - 320) / 2)
+  cropOffset.x = Math.min(maxX, Math.max(-maxX, cropOffset.x))
+  cropOffset.y = Math.min(maxY, Math.max(-maxY, cropOffset.y))
+}
+
+function drawCropPreview() {
+  if (!cropBitmap || !cropCanvas.value) return
+
+  const context = cropCanvas.value.getContext('2d')
+  const scale = getCropScale()
+  const width = cropBitmap.width * scale
+  const height = cropBitmap.height * scale
+  context.clearRect(0, 0, 320, 320)
+  context.drawImage(
+    cropBitmap,
+    (320 - width) / 2 + cropOffset.x,
+    (320 - height) / 2 + cropOffset.y,
+    width,
+    height
+  )
+}
+
+function startCropDrag(event) {
+  cropPointer = {
+    id: event.pointerId,
+    x: event.clientX,
+    y: event.clientY
+  }
+  event.currentTarget.setPointerCapture(event.pointerId)
+}
+
+function moveCrop(event) {
+  if (cropPointer?.id !== event.pointerId) return
+
+  const displayScale = 320 / event.currentTarget.getBoundingClientRect().width
+  cropOffset.x += (event.clientX - cropPointer.x) * displayScale
+  cropOffset.y += (event.clientY - cropPointer.y) * displayScale
+  cropPointer.x = event.clientX
+  cropPointer.y = event.clientY
+  constrainCropOffset()
+  drawCropPreview()
+}
+
+function stopCropDrag(event) {
+  if (cropPointer?.id === event.pointerId) cropPointer = null
+}
+
+function applyCrop() {
+  if (!cropBitmap) return
+
+  const scale = getCropScale()
+  const sourceSize = 320 / scale
+  const sourceX = (cropBitmap.width - sourceSize) / 2 - cropOffset.x / scale
+  const sourceY = (cropBitmap.height - sourceSize) / 2 - cropOffset.y / scale
+  const canvas = document.createElement('canvas')
+  canvas.width = 256
+  canvas.height = 256
+  canvas.getContext('2d').drawImage(
+    cropBitmap,
+    sourceX,
+    sourceY,
+    sourceSize,
+    sourceSize,
+    0,
+    0,
+    canvas.width,
+    canvas.height
+  )
+
+  profileIcon.value = {
+    type: 'image',
+    value: canvas.toDataURL('image/webp', 0.9)
+  }
+  profileBgColor.value = 'transparent'
+  closeCropEditor()
+}
+
+function cancelCrop() {
+  closeCropEditor()
+}
+
+function closeCropEditor() {
+  cropDialogOpen.value = false
+  cropPointer = null
+  cropBitmap?.close?.()
+  cropBitmap = null
+}
+
+function clearProfileIcon() {
+  profileIcon.value = null
+  restoreOpaqueProfileColor()
+}
+
+function restoreOpaqueProfileColor() {
+  if (profileBgColor.value === 'transparent') {
+    profileBgColor.value = lastOpaqueProfileBgColor.value
   }
 }
 

--- a/src/renderer/components/FtProfileEdit/FtProfileEdit.vue
+++ b/src/renderer/components/FtProfileEdit/FtProfileEdit.vue
@@ -304,6 +304,7 @@ const cropZoom = ref(1)
 const cropOffset = { x: 0, y: 0 }
 let cropBitmap = null
 let cropPointer = null
+let imageSelectionRequest = 0
 
 const EMOJI_OPTIONS = ['😀', '😎', '🤓', '🥳', '🤠', '👻', '🐱', '🐶', '🌈', '⭐']
 
@@ -321,7 +322,10 @@ watch(cropZoom, () => {
   drawCropPreview()
 })
 
-onBeforeUnmount(() => cropBitmap?.close?.())
+onBeforeUnmount(() => {
+  imageSelectionRequest++
+  cropBitmap?.close?.()
+})
 
 const customColorPickerValue = computed(() => {
   return profileBgColor.value === 'transparent' ? '#000000' : profileBgColor.value
@@ -408,13 +412,20 @@ function openImagePicker() {
 }
 
 async function selectImage(event) {
+  const request = ++imageSelectionRequest
   const file = event.target.files?.[0]
   event.target.value = ''
   if (!file) return
 
   try {
+    const bitmap = await loadCropBitmap(file)
+    if (request !== imageSelectionRequest) {
+      bitmap.close?.()
+      return
+    }
+
     cropBitmap?.close?.()
-    cropBitmap = await loadCropBitmap(file)
+    cropBitmap = bitmap
     cropZoom.value = 1
     cropOffset.x = 0
     cropOffset.y = 0
@@ -422,6 +433,8 @@ async function selectImage(event) {
     await nextTick()
     drawCropPreview()
   } catch (error) {
+    if (request !== imageSelectionRequest) return
+
     console.error('Failed to load profile icon image:', error)
     showToast({
       message: t('Profile.The selected image could not be loaded'),

--- a/src/renderer/components/FtProfileIcon/FtProfileIcon.vue
+++ b/src/renderer/components/FtProfileIcon/FtProfileIcon.vue
@@ -1,0 +1,70 @@
+<template>
+  <span
+    class="profileIcon"
+    :style="{ background: profile.bgColor, color: profile.textColor }"
+  >
+    <img
+      v-if="imageSource"
+      class="profileIconImage"
+      :src="imageSource"
+      alt=""
+    >
+    <span
+      v-else
+      class="profileIconText"
+      dir="auto"
+    >
+      {{ iconText }}
+    </span>
+  </span>
+</template>
+
+<script setup>
+import { computed } from 'vue'
+
+const props = defineProps({
+  profile: {
+    type: Object,
+    required: true
+  },
+  fallback: {
+    type: String,
+    default: ''
+  }
+})
+
+const imageSource = computed(() => {
+  const icon = props.profile.icon
+  if (icon?.type !== 'image' || typeof icon.value !== 'string') return ''
+
+  return /^data:image\/(?:gif|jpeg|png|webp);base64,/i.test(icon.value) ? icon.value : ''
+})
+
+const iconText = computed(() => {
+  const icon = props.profile.icon
+  return icon?.type === 'emoji' && typeof icon.value === 'string'
+    ? icon.value
+    : props.fallback
+})
+</script>
+
+<style scoped>
+.profileIcon {
+  align-items: center;
+  border-radius: 50%;
+  display: flex;
+  justify-content: center;
+  overflow: hidden;
+  user-select: none;
+}
+
+.profileIconImage {
+  block-size: 100%;
+  inline-size: 100%;
+  object-fit: cover;
+}
+
+.profileIconText {
+  line-height: 1;
+}
+</style>

--- a/src/renderer/components/FtQuickSettingsMenu/FtQuickSettingsMenu.css
+++ b/src/renderer/components/FtQuickSettingsMenu/FtQuickSettingsMenu.css
@@ -25,6 +25,8 @@
 }
 
 .profileInitial {
+  block-size: 100%;
+  inline-size: 100%;
   line-height: 1;
   user-select: none;
 }

--- a/src/renderer/components/FtQuickSettingsMenu/FtQuickSettingsMenu.vue
+++ b/src/renderer/components/FtQuickSettingsMenu/FtQuickSettingsMenu.vue
@@ -14,12 +14,11 @@
       @mousedown="handleTriggerMouseDown"
       @keydown.esc.stop="closeMenu"
     >
-      <span
+      <FtProfileIcon
         class="profileInitial"
-        dir="auto"
-      >
-        {{ activeProfileInitial }}
-      </span>
+        :profile="activeProfile"
+        :fallback="activeProfileInitial"
+      />
     </button>
 
     <Transition
@@ -72,12 +71,11 @@
               :aria-selected="profile._id === activeProfile._id"
               @click="setActiveProfile(profile)"
             >
-              <span
+              <FtProfileIcon
                 class="profileAvatar"
-                :style="{ background: profile.bgColor, color: profile.textColor }"
-              >
-                {{ profileInitials[profile._id] }}
-              </span>
+                :profile="profile"
+                :fallback="profileInitials[profile._id]"
+              />
               <span dir="auto">{{ translateProfileName(profile) }}</span>
               <FontAwesomeIcon
                 v-if="profile._id === activeProfile._id"
@@ -95,12 +93,11 @@
               class="profileSummary"
               @click="openProfilePanel"
             >
-              <span
+              <FtProfileIcon
                 class="profileAvatar"
-                :style="{ background: activeProfile.bgColor, color: activeProfile.textColor }"
-              >
-                {{ activeProfileInitial }}
-              </span>
+                :profile="activeProfile"
+                :fallback="activeProfileInitial"
+              />
               <span class="profileSummaryText">
                 <strong dir="auto">{{ translateProfileName(activeProfile) }}</strong>
               </span>
@@ -294,6 +291,7 @@ import FtCard from '../ft-card/ft-card.vue'
 import FtSelect from '../FtSelect/FtSelect.vue'
 import FtSlider from '../FtSlider/FtSlider.vue'
 import FtToggleSwitch from '../FtToggleSwitch/FtToggleSwitch.vue'
+import FtProfileIcon from '../FtProfileIcon/FtProfileIcon.vue'
 
 import store from '../../store/index'
 import allLocales from '../../../../static/locales/activeLocales.json'

--- a/src/renderer/components/FtSubscribeButton/FtSubscribeButton.vue
+++ b/src/renderer/components/FtSubscribeButton/FtSubscribeButton.vue
@@ -71,6 +71,7 @@
             @keydown.space.stop.prevent="handleSubscription(profile)"
           >
             <div
+              v-if="isProfileSubscribed(profile)"
               class="colorOption"
               :style="{ background: profile.bgColor, color: profile.textColor }"
             >
@@ -78,9 +79,15 @@
                 class="initial"
                 dir="auto"
               >
-                {{ isProfileSubscribed(profile) ? $t('checkmark') : profileInitials[profile._id] }}
+                {{ $t('checkmark') }}
               </div>
             </div>
+            <FtProfileIcon
+              v-else
+              class="colorOption"
+              :profile="profile"
+              :fallback="profileInitials[profile._id]"
+            />
             <p
               :id="id + '-' + index"
               class="profileName"
@@ -102,6 +109,7 @@ import { useI18n } from 'vue-i18n'
 
 import FtButton from '../FtButton/FtButton.vue'
 import FtPrompt from '../FtPrompt/FtPrompt.vue'
+import FtProfileIcon from '../FtProfileIcon/FtProfileIcon.vue'
 
 import store from '../../store/index'
 

--- a/src/renderer/components/PrivacySettings.vue
+++ b/src/renderer/components/PrivacySettings.vue
@@ -373,10 +373,7 @@ function handleRemoveSubscriptions(option) {
   profileList.value.forEach((profile) => {
     if (profile._id === MAIN_PROFILE_ID) {
       const newProfile = {
-        _id: MAIN_PROFILE_ID,
-        name: profile.name,
-        bgColor: profile.bgColor,
-        textColor: profile.textColor,
+        ...profile,
         subscriptions: []
       }
       store.dispatch('updateProfile', newProfile)

--- a/src/renderer/helpers/profile-sync.js
+++ b/src/renderer/helpers/profile-sync.js
@@ -7,9 +7,9 @@ export function getSyncProfileBackground(color, fallback = DEFAULT_PROFILE_BACKG
   return color == null || color === 'transparent' ? opaqueFallback : color
 }
 
-export function getMergedProfileBackground(local, usesLocalMetadata, syncedBackground) {
-  const preserveLocalTransparency = usesLocalMetadata &&
-    local?.icon?.type === 'image' && local.bgColor === 'transparent'
+export function getMergedProfileBackground(local, syncedBackground) {
+  const preserveLocalTransparency = local?.icon?.type === 'image' &&
+    local.bgColor === 'transparent'
 
   return preserveLocalTransparency ? 'transparent' : syncedBackground
 }

--- a/src/renderer/helpers/profile-sync.js
+++ b/src/renderer/helpers/profile-sync.js
@@ -1,0 +1,15 @@
+const DEFAULT_PROFILE_BACKGROUND = '#000000'
+
+export function getSyncProfileBackground(color, fallback = DEFAULT_PROFILE_BACKGROUND) {
+  const opaqueFallback = fallback == null || fallback === 'transparent'
+    ? DEFAULT_PROFILE_BACKGROUND
+    : fallback
+  return color == null || color === 'transparent' ? opaqueFallback : color
+}
+
+export function getMergedProfileBackground(local, usesLocalMetadata, syncedBackground) {
+  const preserveLocalTransparency = usesLocalMetadata &&
+    local?.icon?.type === 'image' && local.bgColor === 'transparent'
+
+  return preserveLocalTransparency ? 'transparent' : syncedBackground
+}

--- a/src/renderer/helpers/sync-server.js
+++ b/src/renderer/helpers/sync-server.js
@@ -947,7 +947,7 @@ export async function syncProfiles(client, store, previous = {}, options = {}) {
       name: metadata.title,
       bgColor: metadata.bgColor,
       textColor: metadata.textColor,
-      ...(local?.icon ? { icon: local.icon } : {}),
+      ...(local && Object.hasOwn(local, 'icon') ? { icon: local.icon } : {}),
       subscriptions: mergedSubscriptions,
     }
     if (!local || !metadataEquals(local, mergedProfile)) {

--- a/src/renderer/helpers/sync-server.js
+++ b/src/renderer/helpers/sync-server.js
@@ -947,6 +947,7 @@ export async function syncProfiles(client, store, previous = {}, options = {}) {
       name: metadata.title,
       bgColor: metadata.bgColor,
       textColor: metadata.textColor,
+      ...(local?.icon ? { icon: local.icon } : {}),
       subscriptions: mergedSubscriptions,
     }
     if (!local || !metadataEquals(local, mergedProfile)) {

--- a/src/renderer/helpers/sync-server.js
+++ b/src/renderer/helpers/sync-server.js
@@ -10,6 +10,7 @@ import {
 import { getSyncableSettingKeys } from '../store/modules/settings'
 import { deepCopy } from './utils'
 import { generateRandomUniqueId } from './playlists'
+import { getMergedProfileBackground, getSyncProfileBackground } from './profile-sync.js'
 
 const LEGACY_HISTORY_PAGE_SIZE = 50
 const BULK_SYNC_CHUNK_SIZE = 100
@@ -850,7 +851,7 @@ export async function syncHistory(client, store, previousIds = [], options = {})
 function profileMetadata(profile) {
   return {
     title: profile.name,
-    bgColor: profile.bgColor,
+    bgColor: getSyncProfileBackground(profile.bgColor),
     textColor: profile.textColor,
   }
 }
@@ -858,7 +859,7 @@ function profileMetadata(profile) {
 function remoteProfileMetadata(group, fallback = {}) {
   return {
     title: group.title,
-    bgColor: group.bg_color ?? fallback.bgColor ?? '#000000',
+    bgColor: getSyncProfileBackground(group.bg_color, fallback.bgColor),
     textColor: group.text_color ?? fallback.textColor ?? '#FFFFFF',
   }
 }
@@ -945,7 +946,7 @@ export async function syncProfiles(client, store, previous = {}, options = {}) {
     const mergedProfile = {
       _id: id,
       name: metadata.title,
-      bgColor: metadata.bgColor,
+      bgColor: getMergedProfileBackground(local, metadata === localMetadata, metadata.bgColor),
       textColor: metadata.textColor,
       ...(local && Object.hasOwn(local, 'icon') ? { icon: local.icon } : {}),
       subscriptions: mergedSubscriptions,

--- a/src/renderer/helpers/sync-server.js
+++ b/src/renderer/helpers/sync-server.js
@@ -946,7 +946,7 @@ export async function syncProfiles(client, store, previous = {}, options = {}) {
     const mergedProfile = {
       _id: id,
       name: metadata.title,
-      bgColor: getMergedProfileBackground(local, metadata === localMetadata, metadata.bgColor),
+      bgColor: getMergedProfileBackground(local, metadata.bgColor),
       textColor: metadata.textColor,
       ...(local && Object.hasOwn(local, 'icon') ? { icon: local.icon } : {}),
       subscriptions: mergedSubscriptions,

--- a/src/renderer/helpers/sync-server.js
+++ b/src/renderer/helpers/sync-server.js
@@ -848,10 +848,10 @@ export async function syncHistory(client, store, previousIds = [], options = {})
   return Array.from(mergedIds)
 }
 
-function profileMetadata(profile) {
+function profileMetadata(profile, fallback = {}) {
   return {
     title: profile.name,
-    bgColor: getSyncProfileBackground(profile.bgColor),
+    bgColor: getSyncProfileBackground(profile.bgColor, fallback.bgColor),
     textColor: profile.textColor,
   }
 }
@@ -896,8 +896,8 @@ export async function syncProfiles(client, store, previous = {}, options = {}) {
   for (const id of mergedIds) {
     const local = localById.get(id)
     let remote = remoteById.get(id)
-    const localMetadata = local ? profileMetadata(local) : null
     const oldMetadata = previous[id]?.metadata
+    const localMetadata = local ? profileMetadata(local, oldMetadata) : null
     const remoteMetadata = remote
       ? remoteProfileMetadata(remote.group, oldMetadata ?? localMetadata)
       : null

--- a/src/renderer/views/ProfileSettings/ProfileSettings.vue
+++ b/src/renderer/views/ProfileSettings/ProfileSettings.vue
@@ -12,6 +12,7 @@
           :profile-name="profile.name"
           :background-color="profile.bgColor"
           :text-color="profile.textColor"
+          :icon="profile.icon"
           :class="{ openedProfile: openSettingsProfile?._id === profile._id }"
           @click="openSettingsForProfileWithId(profile._id)"
         />
@@ -21,6 +22,7 @@
       >
         <FtButton
           :label="$t('Profile.Create New Profile')"
+          :icon="['fas', 'user-plus']"
           @click="openSettingsForNewProfile"
         />
       </FtFlexBox>
@@ -71,6 +73,7 @@ import { MAIN_PROFILE_ID } from '../../../constants'
  * @property {string} name
  * @property {string} bgColor
  * @property {string} textColor
+ * @property {{type: 'emoji'|'image', value: string}|null|undefined} icon
  * @property {object[]} subscriptions
  * @property {string} subscriptions[].id
  * @property {string|undefined} subscriptions[].name

--- a/static/locales/en-US.yaml
+++ b/static/locales/en-US.yaml
@@ -1172,6 +1172,17 @@ Profile:
   Edit Profile Name: Edit Profile Name
   Create Profile Name: Create Profile Name
   Profile Name: Profile Name
+  Profile Icon: Profile Icon
+  Choose an Emoji: Choose an emoji
+  Custom Emoji: Custom emoji
+  Emoji: Emoji
+  Choose Image: Choose Image
+  Crop Image: Crop Image
+  Zoom: Zoom
+  Apply Crop: Apply Crop
+  Transparent: Transparent
+  Use Initial: Use Initial
+  The selected image could not be loaded: The selected image could not be loaded
   Color Picker: Color Picker
   Custom Color: Custom Color
   Profile Preview: Profile Preview

--- a/static/locales/en-US.yaml
+++ b/static/locales/en-US.yaml
@@ -1173,8 +1173,8 @@ Profile:
   Create Profile Name: Create Profile Name
   Profile Name: Profile Name
   Profile Icon: Profile Icon
-  Choose an Emoji: Choose an emoji
-  Custom Emoji: Custom emoji
+  Choose an Emoji: Choose an Emoji
+  Custom Emoji: Custom Emoji
   Emoji: Emoji
   Choose Image: Choose Image
   Crop Image: Crop Image

--- a/tests/unit/profile-sync.test.mjs
+++ b/tests/unit/profile-sync.test.mjs
@@ -9,6 +9,7 @@ import {
 test('syncs an opaque fallback for transparent profile backgrounds', () => {
   assert.equal(getSyncProfileBackground('transparent'), '#000000')
   assert.equal(getSyncProfileBackground('transparent', 'transparent'), '#000000')
+  assert.equal(getSyncProfileBackground('transparent', '#123456'), '#123456')
   assert.equal(getSyncProfileBackground(null, null), '#000000')
   assert.equal(getSyncProfileBackground('#123456'), '#123456')
 })

--- a/tests/unit/profile-sync.test.mjs
+++ b/tests/unit/profile-sync.test.mjs
@@ -1,0 +1,25 @@
+import assert from 'node:assert/strict'
+import test from 'node:test'
+
+import {
+  getMergedProfileBackground,
+  getSyncProfileBackground
+} from '../../src/renderer/helpers/profile-sync.js'
+
+test('syncs an opaque fallback for transparent profile backgrounds', () => {
+  assert.equal(getSyncProfileBackground('transparent'), '#000000')
+  assert.equal(getSyncProfileBackground('transparent', 'transparent'), '#000000')
+  assert.equal(getSyncProfileBackground(null, null), '#000000')
+  assert.equal(getSyncProfileBackground('#123456'), '#123456')
+})
+
+test('keeps transparency only with an authoritative local image', () => {
+  const imageProfile = {
+    bgColor: 'transparent',
+    icon: { type: 'image', value: 'data:image/webp;base64,AA==' }
+  }
+
+  assert.equal(getMergedProfileBackground(imageProfile, true, '#000000'), 'transparent')
+  assert.equal(getMergedProfileBackground(imageProfile, false, '#123456'), '#123456')
+  assert.equal(getMergedProfileBackground({ bgColor: 'transparent' }, true, '#000000'), '#000000')
+})

--- a/tests/unit/profile-sync.test.mjs
+++ b/tests/unit/profile-sync.test.mjs
@@ -13,13 +13,13 @@ test('syncs an opaque fallback for transparent profile backgrounds', () => {
   assert.equal(getSyncProfileBackground('#123456'), '#123456')
 })
 
-test('keeps transparency only with an authoritative local image', () => {
+test('keeps transparency whenever the local image is retained', () => {
   const imageProfile = {
     bgColor: 'transparent',
     icon: { type: 'image', value: 'data:image/webp;base64,AA==' }
   }
 
-  assert.equal(getMergedProfileBackground(imageProfile, true, '#000000'), 'transparent')
-  assert.equal(getMergedProfileBackground(imageProfile, false, '#123456'), '#123456')
-  assert.equal(getMergedProfileBackground({ bgColor: 'transparent' }, true, '#000000'), '#000000')
+  assert.equal(getMergedProfileBackground(imageProfile, '#000000'), 'transparent')
+  assert.equal(getMergedProfileBackground(imageProfile, '#123456'), 'transparent')
+  assert.equal(getMergedProfileBackground({ bgColor: 'transparent' }, '#000000'), '#000000')
 })


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Make sure to follow the contributing guidelines. -->
<!-- Important note, we may remove your pull request if you do not use this provided PR template correctly. -->
<!-- Agent instructions: Preserve every heading, comment, and marker in this template. Never remove or rewrite the release-note-category:start/end, release-note:start/end, or release-note-image:start/end marker pairs. Never remove or rewrite the Release note images section; leave its contents for a human. -->

## Pull Request Type
<!-- Please select what type of pull request this is: [x] -->
- [ ] Bugfix
- [x] Feature Implementation
- [ ] Documentation
- [ ] Other

## Related issue
<!-- Please link the issue your pull request is referring to. -->
<!-- If this pull request fully resolves the relevant issue, put "closes" before the issue number. -->
<!-- Example: "closes #123456". -->

None.

## Description
<!-- Please write a clear and concise description of what the pull request does. -->

Profiles were limited to a generated initial and background color, which made them difficult to distinguish at a glance.

This adds reusable profile icon rendering and lets users choose a preset or custom emoji, or select and interactively crop a raster or SVG image. Image icons are resized to a compact local WebP, default to a transparent background, and preserve the last opaque color when switching back to an emoji or initial. The selected color, default-profile action, profile tile alignment, UI rounding, and profile-management button icons are also updated for clearer feedback.

## Release note category
<!-- Select exactly one category. Every pull request must select one. -->
<!-- Select "Not noteworthy" when the pull request fixes a bug in or improves functionality that has not yet appeared in a stable release. -->
<!-- release-note-category:start -->
- [ ] Not noteworthy
- [ ] Highlights
- [x] More improvements
- [ ] Fixed bugs
<!-- release-note-category:end -->

## Release note
<!-- Required unless "Not noteworthy" is selected. -->
<!-- Write one concise, user-facing entry without a leading bullet. -->
<!-- release-note:start -->
Profiles can now use emoji or interactively cropped image icons.
<!-- release-note:end -->

## Release note images
<!-- Human-only: Agents must preserve this entire section and leave it empty. -->
<!-- Optional. Paste one or more Markdown images or HTML image tags here. -->
<!-- The release notes will use an HTML image tag and limit images taller than 300 pixels. -->
<!-- release-note-image:start -->
<img width="889" height="395" alt="image" src="https://github.com/user-attachments/assets/a8e50f1b-383b-4865-a2d5-83ef18510b64" />
<!-- release-note-image:end -->

## Testing
<!-- How can reviewers verify that the PR produces correct results? -->
<!-- Please provide instructions so that others can ensure that your pull request would produce correct results. For examples see, https://github.com/FreeTubeApp/FreeTube/pull/5743, https://github.com/FreeTubeApp/FreeTube/pull/7349, https://github.com/FreeTubeApp/FreeTube/pull/5125, https://github.com/FreeTubeApp/FreeTube/pull/7338 -->
<!-- Agent instructions: Only write human-facing steps that explain how to verify the change while running this branch in dev mode. Include expected results and, when applicable, helpful console snippets for interactive verification. Do not include automated checks, commands, results, pass counts, or CI status. -->

1. Open Profile Manager and select an existing profile.
2. Choose a PNG, JPEG, WebP, GIF, or SVG image. Confirm the crop editor opens, dragging repositions the image, zoom changes the crop, and applying it previews the selected crop on a transparent background.
3. Update the profile and confirm the image appears consistently in Profile Manager, quick settings, and subscription profile menus after reopening the app.
4. Select an emoji preset or enter a custom emoji. Confirm ordinary letters and numbers are rejected, the last opaque profile color returns, and the icon persists after updating.
5. Confirm the current background-color swatch is highlighted and the Make Default Profile button is disabled for the existing default profile.
6. Confirm profile tiles remain centered and their selected backgrounds follow the configured UI roundness.

## Additional context
<!-- Add any other context about the pull request here. -->

Custom image bytes stay local and are not sent to the subscription sync server. Local icons are preserved when subscription profile metadata is synchronized.