### PR TITLE
fix: keep original end-screen video titles

### DIFF
--- a/e2e/tests/offline/watch-page.spec.mjs
+++ b/e2e/tests/offline/watch-page.spec.mjs
@@ -52,6 +52,53 @@ async function setWindowWidth(app, width) {
   }, width)
 }
 
+async function mockTranslatedEndscreen(app, page) {
+  await mockPlayableWatchPage(app, page)
+
+  await page.route(/\/youtubei\/v1\/player/, (route, request) => {
+    const videoId = JSON.parse(request.postData() ?? '{}').videoId ?? 'jNQXAC9IVRw'
+    const response = demoPlayerResponse(videoId, {
+      endscreen: {
+        endscreenRenderer: {
+          elements: [{
+            endscreenElementRenderer: {
+              style: 'VIDEO',
+              title: { simpleText: 'Translated end-screen title' },
+              endpoint: { watchEndpoint: { videoId: 'end-screen-video' } },
+              image: {
+                thumbnails: [{
+                  url: 'https://i.ytimg.com/vi/end-screen-video/hqdefault.jpg',
+                  width: 480,
+                  height: 270
+                }]
+              },
+              left: '0.1',
+              top: '0.1',
+              width: '0.3',
+              aspectRatio: '1.777',
+              startMs: '0',
+              endMs: '30000',
+              id: 'original-title-annotation'
+            }
+          }],
+          startMs: '0'
+        }
+      }
+    })
+
+    return route.fulfill({
+      status: 200,
+      contentType: 'application/json',
+      body: JSON.stringify(response)
+    })
+  })
+
+  await page.evaluate(async () => {
+    const store = document.querySelector('#app').__vue_app__.config.globalProperties.$store
+    await store.dispatch('updateAvoidTranslation', 'watch_only')
+  })
+}
+
 test.describe('watch page', () => {
   test('transitions a premiere when relative timestamp updates are disabled', async ({ app, page }) => {
     await mockPlayableWatchPage(app, page)
@@ -84,60 +131,51 @@ test.describe('watch page', () => {
   })
 
   test('keeps original video titles in end-screen annotations', async ({ app, page }) => {
-    await mockPlayableWatchPage(app, page)
-
-    await page.route(/\/youtubei\/v1\/player/, (route, request) => {
-      const videoId = JSON.parse(request.postData() ?? '{}').videoId ?? 'jNQXAC9IVRw'
-      const response = demoPlayerResponse(videoId, {
-        endscreen: {
-          endscreenRenderer: {
-            elements: [{
-              endscreenElementRenderer: {
-                style: 'VIDEO',
-                title: { simpleText: 'Translated end-screen title' },
-                endpoint: { watchEndpoint: { videoId: 'end-screen-video' } },
-                image: {
-                  thumbnails: [{
-                    url: 'https://i.ytimg.com/vi/end-screen-video/hqdefault.jpg',
-                    width: 480,
-                    height: 270
-                  }]
-                },
-                left: '0.1',
-                top: '0.1',
-                width: '0.3',
-                aspectRatio: '1.777',
-                startMs: '0',
-                endMs: '30000',
-                id: 'original-title-annotation'
-              }
-            }],
-            startMs: '0'
-          }
-        }
-      })
-
-      return route.fulfill({
-        status: 200,
-        contentType: 'application/json',
-        body: JSON.stringify(response)
-      })
-    })
+    await mockTranslatedEndscreen(app, page)
     await page.route(/\/oembed\?/, route => route.fulfill({
       status: 200,
       contentType: 'application/json',
       body: JSON.stringify({ title: 'Original end-screen title' })
     }))
 
-    await page.evaluate(async () => {
-      const store = document.querySelector('#app').__vue_app__.config.globalProperties.$store
-      await store.dispatch('updateAvoidTranslation', 'watch_only')
-    })
     await openMockedVideo(page)
     await waitForPlayback(page)
 
     await expect(page.locator(`${activeTab} .annotationTitleText`))
       .toHaveText('Original end-screen title')
+  })
+
+  test('does not replace an end-screen title after original text is disabled', async ({ app, page }) => {
+    await mockTranslatedEndscreen(app, page)
+
+    let releaseOembed
+    let markOembedRequested
+    const oembedRequested = new Promise((resolve) => { markOembedRequested = resolve })
+    await page.route(/\/oembed\?/, async (route) => {
+      markOembedRequested()
+      await new Promise((resolve) => { releaseOembed = resolve })
+      await route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: JSON.stringify({ title: 'Original end-screen title' })
+      })
+    })
+
+    await openMockedVideo(page)
+    await waitForPlayback(page)
+    await oembedRequested
+
+    await page.evaluate(async () => {
+      const store = document.querySelector('#app').__vue_app__.config.globalProperties.$store
+      await store.dispatch('updateAvoidTranslation', 'disabled')
+    })
+    const oembedResponse = page.waitForResponse(/\/oembed\?/)
+    releaseOembed()
+    await oembedResponse
+    await page.waitForTimeout(100)
+
+    await expect(page.locator(`${activeTab} .annotationTitleText`))
+      .toHaveText('Translated end-screen title')
   })
 
   test('shows tags below the description and copies the description', async ({ app, page }) => {

--- a/e2e/tests/offline/watch-page.spec.mjs
+++ b/e2e/tests/offline/watch-page.spec.mjs
@@ -1,6 +1,7 @@
 import { sel, setPlayerFullscreen, test, expect } from '../../helpers/app.mjs'
 import { activeTab, findWatchComponent, openMockedVideo, waitForPlayback } from '../../helpers/player.mjs'
 import { mockPlayableWatchPage } from '../../helpers/watch.mjs'
+import { demoPlayerResponse } from '../../helpers/media.mjs'
 
 // These used to live in the network suite, gated on the live API. They all use
 // "Me at the zoo", whose page and comment pages are recorded, so they run
@@ -80,6 +81,63 @@ test.describe('watch page', () => {
     await expect(page.locator(`${activeTab} .premiereText`)).toHaveText(
       'Starting soon, please refresh the page to check again'
     )
+  })
+
+  test('keeps original video titles in end-screen annotations', async ({ app, page }) => {
+    await mockPlayableWatchPage(app, page)
+
+    await page.route(/\/youtubei\/v1\/player/, (route, request) => {
+      const videoId = JSON.parse(request.postData() ?? '{}').videoId ?? 'jNQXAC9IVRw'
+      const response = demoPlayerResponse(videoId, {
+        endscreen: {
+          endscreenRenderer: {
+            elements: [{
+              endscreenElementRenderer: {
+                style: 'VIDEO',
+                title: { simpleText: 'Translated end-screen title' },
+                endpoint: { watchEndpoint: { videoId: 'end-screen-video' } },
+                image: {
+                  thumbnails: [{
+                    url: 'https://i.ytimg.com/vi/end-screen-video/hqdefault.jpg',
+                    width: 480,
+                    height: 270
+                  }]
+                },
+                left: '0.1',
+                top: '0.1',
+                width: '0.3',
+                aspectRatio: '1.777',
+                startMs: '0',
+                endMs: '30000',
+                id: 'original-title-annotation'
+              }
+            }],
+            startMs: '0'
+          }
+        }
+      })
+
+      return route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: JSON.stringify(response)
+      })
+    })
+    await page.route(/\/oembed\?/, route => route.fulfill({
+      status: 200,
+      contentType: 'application/json',
+      body: JSON.stringify({ title: 'Original end-screen title' })
+    }))
+
+    await page.evaluate(async () => {
+      const store = document.querySelector('#app').__vue_app__.config.globalProperties.$store
+      await store.dispatch('updateAvoidTranslation', 'watch_only')
+    })
+    await openMockedVideo(page)
+    await waitForPlayback(page)
+
+    await expect(page.locator(`${activeTab} .annotationTitleText`))
+      .toHaveText('Original end-screen title')
   })
 
   test('shows tags below the description and copies the description', async ({ app, page }) => {

--- a/src/renderer/helpers/api/local.js
+++ b/src/renderer/helpers/api/local.js
@@ -2092,6 +2092,7 @@ export function parseLocalEndscreen(endscreen) {
       id: element.id,
       type: element.style,
       title: element.title.text,
+      videoId: element.style === 'VIDEO' ? payload.videoId : undefined,
       thumbnail,
       channelId: element.style === 'CHANNEL' ? payload.browseId : undefined,
       description: element.style === 'CHANNEL' ? element.metadata?.text ?? '' : '',

--- a/src/renderer/views/Watch/Watch.js
+++ b/src/renderer/views/Watch/Watch.js
@@ -1992,7 +1992,8 @@ export default defineComponent({
             }
 
             getOembedTitle(annotation.videoId).then((title) => {
-              if (!title || !this.isCurrentVideoLoad(loadGeneration, videoId)) {
+              if (!title || this.$store.getters.getAvoidTranslation === 'disabled' ||
+                  !this.isCurrentVideoLoad(loadGeneration, videoId)) {
                 return
               }
 

--- a/src/renderer/views/Watch/Watch.js
+++ b/src/renderer/views/Watch/Watch.js
@@ -1968,6 +1968,7 @@ export default defineComponent({
 
         this.isFamilyFriendly = result.basic_info.is_family_safe
         this.commentsDisabled = areLocalCommentsDisabled(result)
+        const avoidTranslation = this.$store.getters.getAvoidTranslation !== 'disabled'
 
         this.recommendedVideos = result.watch_next_feed
           ?.filter((item) => {
@@ -1979,14 +1980,38 @@ export default defineComponent({
           .sort(this.sortWatchedVideosLast) ?? []
 
         this.videoAnnotations = parseLocalEndscreen(result.endscreen)
+        if (avoidTranslation) {
+          this.videoAnnotations = this.videoAnnotations.map((annotation) => {
+            if (!annotation.videoId) {
+              return annotation
+            }
+
+            const cachedTitle = getCachedOembedTitle(annotation.videoId)
+            if (cachedTitle !== null) {
+              return { ...annotation, title: cachedTitle }
+            }
+
+            getOembedTitle(annotation.videoId).then((title) => {
+              if (!title || !this.isCurrentVideoLoad(loadGeneration, videoId)) {
+                return
+              }
+
+              this.videoAnnotations = this.videoAnnotations.map((currentAnnotation) =>
+                currentAnnotation.id === annotation.id
+                  ? { ...currentAnnotation, title }
+                  : currentAnnotation
+              )
+            })
+
+            return annotation
+          })
+        }
 
         if (this.showFamilyFriendlyOnly && !this.isFamilyFriendly) {
           this.isLoading = false
           this.handleVideoEnded()
           return
         }
-
-        const avoidTranslation = this.$store.getters.getAvoidTranslation !== 'disabled'
 
         if (avoidTranslation) {
           this.videoTitle = result.basic_info.title?.trim() ?? ''


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Make sure to follow the contributing guidelines. -->
<!-- Important note, we may remove your pull request if you do not use this provided PR template correctly. -->
<!-- Agent instructions: Preserve every heading, comment, and marker in this template. Never remove or rewrite the release-note-category:start/end, release-note:start/end, or release-note-image:start/end marker pairs. Never remove or rewrite the Release note images section; leave its contents for a human. -->

## Pull Request Type
<!-- Please select what type of pull request this is: [x] -->
- [x] Bugfix
- [ ] Feature Implementation
- [ ] Documentation
- [ ] Other

## Related issue
<!-- Please link the issue your pull request is referring to. -->
<!-- If this pull request fully resolves the relevant issue, put "closes" before the issue number. -->
<!-- Example: "closes #123456". -->

## Description
<!-- Please write a clear and concise description of what the pull request does. -->

End-screen annotations used YouTube's localized title even when Keep original text was enabled because the parsed annotation discarded its target video ID.

Retain the video ID for video annotations and use the existing cached oEmbed title lookup to replace localized titles. Playlist and channel annotations remain unchanged, and stale lookups cannot update a newly loaded video.

## Release note category
<!-- Select exactly one category. Every pull request must select one. -->
<!-- Select "Not noteworthy" when the pull request fixes a bug in or improves functionality that has not yet appeared in a stable release. -->
<!-- release-note-category:start -->
- [ ] Not noteworthy
- [ ] Highlights
- [ ] More improvements
- [x] Fixed bugs
<!-- release-note-category:end -->

## Release note
<!-- Required unless "Not noteworthy" is selected. -->
<!-- Write one concise, user-facing entry without a leading bullet. -->
<!-- release-note:start -->
Keep original text now preserves video titles in end-screen annotations.
<!-- release-note:end -->

## Release note images
<!-- Human-only: Agents must preserve this entire section and leave it empty. -->
<!-- Optional. Paste one or more Markdown images or HTML image tags here. -->
<!-- The release notes will use an HTML image tag and limit images taller than 300 pixels. -->
<!-- release-note-image:start -->

<!-- release-note-image:end -->

## Testing
<!-- How can reviewers verify that the PR produces correct results? -->
<!-- Please provide instructions so that others can ensure that your pull request produces correct results. For examples see, https://github.com/FreeTubeApp/FreeTube/pull/5743, https://github.com/FreeTubeApp/FreeTube/pull/7349, https://github.com/FreeTubeApp/FreeTube/pull/5125, https://github.com/FreeTubeApp/FreeTube/pull/7338 -->
<!-- Agent instructions: Only write human-facing steps that explain how to verify the change while running this branch in dev mode. Include expected results and, when applicable, helpful console snippets for interactive verification. Do not include automated checks, commands, results, pass counts, or CI status. -->

1. Set Keep original text to Video UI Only or Entire App.
2. Open a video whose translated title differs from its original title and which has video end-screen annotations.
3. Seek to the end screen.
4. Confirm each video annotation shows its original title.
5. Disable Keep original text, reload the video, and confirm the translated end-screen title is shown again.

## Additional context
<!-- Add any other context about the pull request here. -->
