### PR TITLE
fix(downloads): use Flatpak trash portal

### DIFF
--- a/src/main/trashPlatform.js
+++ b/src/main/trashPlatform.js
@@ -1,0 +1,12 @@
+import { existsSync } from 'node:fs'
+
+/**
+ * @param {string} [platform]
+ * @param {boolean} [isFlatpak]
+ */
+export function shouldUseGioTrash(
+  platform = process.platform,
+  isFlatpak = existsSync('/.flatpak-info')
+) {
+  return platform === 'linux' && isFlatpak
+}

--- a/src/main/ytDlp.js
+++ b/src/main/ytDlp.js
@@ -9,6 +9,7 @@ import { settings } from '../datastores/handlers/base'
 import { buildProxyUrl, isOpenTubeXUrl } from './utils'
 import { IpcChannels } from '../constants'
 import { getMatchingDownloadValidators, getYtDlpAssetName } from './ytDlpAsset'
+import { shouldUseGioTrash } from './trashPlatform'
 
 const execFileAsync = promisify(execFile)
 
@@ -1294,6 +1295,20 @@ export function handleYtDlpCancelDownload(event, id) {
 }
 
 /**
+ * Moves a file to the operating system trash.
+ * Electron does not use the Trash portal for document portal paths, so let
+ * GIO handle the operation when running inside Flatpak.
+ * @param {string} destination
+ */
+async function moveToTrash(destination) {
+  if (shouldUseGioTrash()) {
+    await execFileAsync('gio', ['trash', destination])
+  } else {
+    await shell.trashItem(destination)
+  }
+}
+
+/**
  * @param {import('electron').IpcMainInvokeEvent} event
  * @param {number} id
  */
@@ -1335,7 +1350,7 @@ export async function handleYtDlpRemoveDownload(event, id) {
   for (const destination of destinations) {
     if (!existsSync(destination)) continue
     try {
-      await shell.trashItem(destination)
+      await moveToTrash(destination)
       trashed = true
     } catch (error) {
       console.warn('Could not move download to trash', destination, error)

--- a/tests/unit/trash-platform.test.mjs
+++ b/tests/unit/trash-platform.test.mjs
@@ -1,0 +1,13 @@
+import assert from 'node:assert/strict'
+import test from 'node:test'
+import { shouldUseGioTrash } from '../../src/main/trashPlatform.js'
+
+test('uses GIO trash inside Flatpak on Linux', () => {
+  assert.equal(shouldUseGioTrash('linux', true), true)
+})
+
+test('keeps the native trash implementation outside Linux Flatpak', () => {
+  assert.equal(shouldUseGioTrash('linux', false), false)
+  assert.equal(shouldUseGioTrash('darwin', true), false)
+  assert.equal(shouldUseGioTrash('win32', true), false)
+})


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Make sure to follow the contributing guidelines. -->
<!-- Important note, we may remove your pull request if you do not use this provided PR template correctly. -->
<!-- Agent instructions: Preserve every heading, comment, and marker in this template. Never remove or rewrite the release-note-category:start/end, release-note:start/end, or release-note-image:start/end marker pairs. Never remove or rewrite the Release note images section; leave its contents for a human. -->

## Pull Request Type
<!-- Please select what type of pull request this is: [x] -->
- [x] Bugfix
- [ ] Feature Implementation
- [ ] Documentation
- [ ] Other

## Related issue
<!-- Please link the issue your pull request is referring to. -->
<!-- If this pull request fully resolves the relevant issue, put "closes" before the issue number. -->
<!-- Example: "closes #123456". -->
Closes #625

## Description
<!-- Please write a clear and concise description of what the pull request does. -->
Flatpak document-portal paths cannot be moved to trash through Electron's native trash implementation. Use GIO inside Flatpak so the operation is routed through the XDG Trash portal, while retaining the existing Electron behavior for native packages and other platforms.

## Release note category
<!-- Select exactly one category. Every pull request must select one. -->
<!-- Select "Not noteworthy" when the pull request fixes a bug in or improves functionality that has not yet appeared in a stable release. -->
<!-- release-note-category:start -->
- [ ] Not noteworthy
- [ ] Highlights
- [ ] More improvements
- [x] Fixed bugs
<!-- release-note-category:end -->

## Release note
<!-- Required unless "Not noteworthy" is selected. -->
<!-- Write one concise, user-facing entry without a leading bullet. -->
<!-- release-note:start -->
Downloaded files can now be moved to the device trash from Flatpak installations.
<!-- release-note:end -->

## Release note images
<!-- Human-only: Agents must preserve this entire section and leave it empty. -->
<!-- Optional. Paste one or more Markdown images or HTML image tags here. -->
<!-- The release notes will use an HTML image tag and limit images taller than 300 pixels. -->
<!-- release-note-image:start -->

<!-- release-note-image:end -->

## Testing
<!-- How can reviewers verify that the PR produces correct results? -->
<!-- Please provide instructions so that others can ensure that your pull request would produce correct results. For examples see, https://github.com/FreeTubeApp/FreeTube/pull/5743, https://github.com/FreeTubeApp/FreeTube/pull/7349, https://github.com/FreeTubeApp/FreeTube/pull/5125, https://github.com/FreeTubeApp/FreeTube/pull/7338 -->
<!-- Agent instructions: Only write human-facing steps that explain how to verify the change while running this branch in dev mode. Include expected results and, when applicable, helpful console snippets for interactive verification. Do not include automated checks, commands, results, pass counts, or CI status. -->
1. Run this branch in a Flatpak development build.
2. Download a video to a folder selected through the file chooser.
3. Open the Downloads page and choose **Remove File** for the completed download.
4. Confirm that the download disappears from the list and appears in the device trash.
5. Repeat in a native development build and confirm the existing removal behavior is unchanged.

## Additional context
<!-- Add any other context about the pull request here. -->
GIO detects the Flatpak sandbox and delegates trashing to the XDG Trash portal, which accepts the document-portal-backed file without requiring broader filesystem permissions.