### PR TITLE
fix(downloads): manage FFprobe with FFmpeg

### DIFF
--- a/src/main/ytDlp.js
+++ b/src/main/ytDlp.js
@@ -565,11 +565,14 @@ async function installBinary(data, destinationPath) {
 /**
  * Replaces a related set of managed binaries as one transaction. If any
  * replacement fails, every executable that was already replaced is restored.
+ * @template T
  * @param {{ data: Buffer, path: string }[]} binaries
+ * @param {() => Promise<T>} validate
+ * @returns {Promise<T>}
  */
-async function performAtomicBinaryInstall(binaries) {
+async function performAtomicBinaryInstall(binaries, validate) {
   if (binaries.length === 0) {
-    return
+    return validate()
   }
 
   await mkdir(getManagedBinariesDirectory(), { recursive: true })
@@ -583,6 +586,7 @@ async function performAtomicBinaryInstall(binaries) {
     installed: false
   }))
 
+  let result
   try {
     for (const entry of entries) {
       await writeFile(entry.temporaryPath, entry.data)
@@ -602,6 +606,8 @@ async function performAtomicBinaryInstall(binaries) {
       await rename(entry.temporaryPath, entry.path)
       entry.installed = true
     }
+
+    result = await validate()
   } catch (error) {
     const rollbackErrors = []
     async function attemptRollback(operation) {
@@ -639,17 +645,22 @@ async function performAtomicBinaryInstall(binaries) {
   if (cleanupErrors.length > 0) {
     console.warn('Could not remove managed binary backups', cleanupErrors)
   }
+
+  return result
 }
 
 /**
  * Prevents concurrent managed downloads from interleaving transactions that
  * replace the same FFmpeg and FFprobe destinations.
+ * @template T
  * @param {{ data: Buffer, path: string }[]} binaries
+ * @param {() => Promise<T>} validate
+ * @returns {Promise<T>}
  */
-async function installBinariesAtomically(binaries) {
+async function installBinariesAtomically(binaries, validate) {
   const installation = managedBinaryInstallQueue
     .catch(() => {})
-    .then(() => performAtomicBinaryInstall(binaries))
+    .then(() => performAtomicBinaryInstall(binaries, validate))
   managedBinaryInstallQueue = installation
   return installation
 }
@@ -713,7 +724,7 @@ async function downloadManagedFfmpeg(onProgress, onDownloadStart) {
   const ffmpegPath = getManagedBinaryPath('ffmpeg')
   const ffprobePath = getManagedBinaryPath('ffprobe')
   const pendingValidatorWrites = []
-  let updated = false
+  const pendingInstalls = []
 
   if (process.platform === 'win32') {
     // yt-dlp's own FFmpeg builds, patched for use with yt-dlp,
@@ -729,11 +740,10 @@ async function downloadManagedFfmpeg(onProgress, onDownloadStart) {
       const download = await downloadFile(url, onProgress, onDownloadStart, validators)
 
       if (download.data !== null) {
-        await installBinariesAtomically([
+        pendingInstalls.push(
           { data: extractZipEntry(download.data, name => name.endsWith('/bin/ffmpeg.exe')), path: ffmpegPath },
           { data: extractZipEntry(download.data, name => name.endsWith('/bin/ffprobe.exe')), path: ffprobePath }
-        ])
-        updated = true
+        )
         pendingValidatorWrites.push(
           { path: ffmpegPath, validators: download.validators, url },
           { path: ffprobePath, validators: download.validators, url }
@@ -751,8 +761,6 @@ async function downloadManagedFfmpeg(onProgress, onDownloadStart) {
       { name: 'ffmpeg', path: ffmpegPath },
       { name: 'ffprobe', path: ffprobePath }
     ]
-    const pendingInstalls = []
-
     try {
       for (const [index, binary] of binaries.entries()) {
         const url = `https://ffmpeg.martin-riedl.de/redirect/latest/${platform}/${arch}/release/${binary.name}.zip`
@@ -771,24 +779,30 @@ async function downloadManagedFfmpeg(onProgress, onDownloadStart) {
           pendingValidatorWrites.push({ path: binary.path, validators: download.validators, url })
         }
       }
-
-      await installBinariesAtomically(pendingInstalls)
-      updated = pendingInstalls.length > 0
     } catch (error) {
       return { error: error.message }
     }
   }
 
-  const [version, ffprobeVersion] = await Promise.all([
-    getFfmpegVersion(ffmpegPath),
-    getFfprobeVersion(ffprobePath)
-  ])
+  let version
+  try {
+    version = await installBinariesAtomically(pendingInstalls, async () => {
+      const [ffmpegVersion, ffprobeVersion] = await Promise.all([
+        getFfmpegVersion(ffmpegPath),
+        getFfprobeVersion(ffprobePath)
+      ])
 
-  if (version === null) {
-    return { error: 'The downloaded FFmpeg binary does not work on this system' }
-  }
-  if (ffprobeVersion === null) {
-    return { error: 'The downloaded FFprobe binary does not work on this system' }
+      if (ffmpegVersion === null) {
+        throw new Error('The downloaded FFmpeg binary does not work on this system')
+      }
+      if (ffprobeVersion === null) {
+        throw new Error('The downloaded FFprobe binary does not work on this system')
+      }
+
+      return ffmpegVersion
+    })
+  } catch (error) {
+    return { error: error.message }
   }
 
   try {
@@ -798,7 +812,7 @@ async function downloadManagedFfmpeg(onProgress, onDownloadStart) {
     console.warn('Could not save FFmpeg and FFprobe download metadata', error)
   }
 
-  return { version, updated }
+  return { version, updated: pendingInstalls.length > 0 }
 }
 
 /**

--- a/src/main/ytDlp.js
+++ b/src/main/ytDlp.js
@@ -1,7 +1,7 @@
 import { execFile, spawn } from 'node:child_process'
 import { existsSync } from 'node:fs'
 import { chmod, mkdir, readFile, rename, writeFile } from 'node:fs/promises'
-import { join } from 'node:path'
+import { dirname, join } from 'node:path'
 import { promisify } from 'node:util'
 import { inflateRawSync } from 'node:zlib'
 import { app, BrowserWindow, net, shell } from 'electron'
@@ -226,7 +226,7 @@ function getManagedBinariesDirectory() {
 }
 
 /**
- * @param {'yt-dlp' | 'ffmpeg'} binaryName
+ * @param {'yt-dlp' | 'ffmpeg' | 'ffprobe'} binaryName
  */
 function getManagedBinaryPath(binaryName) {
   return join(getManagedBinariesDirectory(), process.platform === 'win32' ? `${binaryName}.exe` : binaryName)
@@ -252,6 +252,35 @@ async function resolveExecutable(sourceSettingId, pathSettingId, binaryName, sou
   const customPath = pathOverride ?? ((await settings._findOne(pathSettingId))?.value || '')
 
   return { source, executable: customPath === '' ? binaryName : customPath }
+}
+
+/**
+ * FFmpeg and FFprobe share one source setting because yt-dlp accepts a single
+ * `--ffmpeg-location`. A custom FFmpeg path therefore also locates FFprobe in
+ * the same directory.
+ * @param {'system' | 'managed'} [sourceOverride]
+ * @param {string} [ffmpegPathOverride]
+ * @returns {Promise<{ source: 'system' | 'managed', executable: string }>}
+ */
+async function resolveFfprobeExecutable(sourceOverride, ffmpegPathOverride) {
+  const ffmpeg = await resolveExecutable(
+    'ytDlpFfmpegSource',
+    'ytDlpFfmpegPath',
+    'ffmpeg',
+    sourceOverride,
+    ffmpegPathOverride
+  )
+
+  if (ffmpeg.source === 'managed') {
+    return { source: ffmpeg.source, executable: getManagedBinaryPath('ffprobe') }
+  }
+
+  const ffprobeName = process.platform === 'win32' ? 'ffprobe.exe' : 'ffprobe'
+  const ffmpegDirectory = dirname(ffmpeg.executable)
+  return {
+    source: ffmpeg.source,
+    executable: ffmpegDirectory === '.' ? 'ffprobe' : join(ffmpegDirectory, ffprobeName)
+  }
 }
 
 /**
@@ -316,6 +345,25 @@ async function getFfmpegVersion(executable, signal) {
     })
     const version = /^ffmpeg version (\S+)/.exec(stdout)?.[1] ?? null
     // the martin-riedl.de builds embed their website URL in the version string
+    return version?.replace(/-https?:.*$/, '') ?? null
+  } catch {
+    return null
+  }
+}
+
+/**
+ * @param {string} executable
+ * @param {AbortSignal} [signal] aborts a superseded ytDlpGetInfo probe
+ * @returns {Promise<string | null>} the version, or null if the executable doesn't work
+ */
+async function getFfprobeVersion(executable, signal) {
+  try {
+    const { stdout } = await execFileAsync(executable, ['-version'], {
+      timeout: 60_000,
+      windowsHide: true,
+      signal
+    })
+    const version = /^ffprobe version (\S+)/.exec(stdout)?.[1] ?? null
     return version?.replace(/-https?:.*$/, '') ?? null
   } catch {
     return null
@@ -560,58 +608,95 @@ async function downloadManagedYtDlp(onProgress, onDownloadStart) {
 }
 
 /**
- * Downloads an up-to-date FFmpeg build into the user data directory
+ * Downloads up-to-date FFmpeg and FFprobe builds into the user data directory.
+ * They are kept together because yt-dlp locates both through one
+ * `--ffmpeg-location` argument.
  * @param {BinaryDownloadProgressCallback} [onProgress]
  * @param {() => void} [onDownloadStart]
  * @returns {Promise<{ version: string, updated: boolean } | { error: string }>}
  */
 async function downloadManagedFfmpeg(onProgress, onDownloadStart) {
-  let url
-  /** @type {(name: string) => boolean} */
-  let matches
+  const ffmpegPath = getManagedBinaryPath('ffmpeg')
+  const ffprobePath = getManagedBinaryPath('ffprobe')
+  const pendingValidatorWrites = []
+  let updated = false
 
   if (process.platform === 'win32') {
     // yt-dlp's own FFmpeg builds, patched for use with yt-dlp,
     // unfortunately they are only extractable without extra dependencies for Windows (zip)
-    url = 'https://github.com/yt-dlp/FFmpeg-Builds/releases/latest/download/ffmpeg-master-latest-win64-gpl.zip'
-    matches = (name) => name.endsWith('/bin/ffmpeg.exe')
+    const url = 'https://github.com/yt-dlp/FFmpeg-Builds/releases/latest/download/ffmpeg-master-latest-win64-gpl.zip'
+
+    try {
+      // Existing FFmpeg-only installations must fetch the archive again so
+      // FFprobe can be added even when its validators would return 304.
+      const validators = existsSync(ffprobePath)
+        ? await readDownloadValidators(ffmpegPath, url)
+        : null
+      const download = await downloadFile(url, onProgress, onDownloadStart, validators)
+
+      if (download.data !== null) {
+        await installBinary(extractZipEntry(download.data, name => name.endsWith('/bin/ffmpeg.exe')), ffmpegPath)
+        await installBinary(extractZipEntry(download.data, name => name.endsWith('/bin/ffprobe.exe')), ffprobePath)
+        updated = true
+        pendingValidatorWrites.push(
+          { path: ffmpegPath, validators: download.validators, url },
+          { path: ffprobePath, validators: download.validators, url }
+        )
+      }
+    } catch (error) {
+      return { error: error.message }
+    }
   } else {
     // daily builds of the latest FFmpeg release for Linux and macOS
     // https://ffmpeg.martin-riedl.de
     const platform = process.platform === 'darwin' ? 'macos' : 'linux'
     const arch = process.arch === 'arm64' ? 'arm64' : 'amd64'
-    url = `https://ffmpeg.martin-riedl.de/redirect/latest/${platform}/${arch}/release/ffmpeg.zip`
-    matches = (name) => name === 'ffmpeg'
-  }
+    const binaries = [
+      { name: 'ffmpeg', path: ffmpegPath },
+      { name: 'ffprobe', path: ffprobePath }
+    ]
 
-  const managedPath = getManagedBinaryPath('ffmpeg')
-  let download
+    try {
+      for (const [index, binary] of binaries.entries()) {
+        const url = `https://ffmpeg.martin-riedl.de/redirect/latest/${platform}/${arch}/release/${binary.name}.zip`
+        const download = await downloadFile(
+          url,
+          percent => onProgress?.(percent === null ? null : Math.round((index * 100 + percent) / binaries.length)),
+          onDownloadStart,
+          await readDownloadValidators(binary.path, url)
+        )
 
-  try {
-    download = await downloadFile(url, onProgress, onDownloadStart, await readDownloadValidators(managedPath, url))
-
-    if (download.data !== null) {
-      await installBinary(extractZipEntry(download.data, matches), managedPath)
+        if (download.data !== null) {
+          await installBinary(extractZipEntry(download.data, name => name === binary.name), binary.path)
+          updated = true
+          pendingValidatorWrites.push({ path: binary.path, validators: download.validators, url })
+        }
+      }
+    } catch (error) {
+      return { error: error.message }
     }
-  } catch (error) {
-    return { error: error.message }
   }
 
-  const version = await getFfmpegVersion(managedPath)
+  const [version, ffprobeVersion] = await Promise.all([
+    getFfmpegVersion(ffmpegPath),
+    getFfprobeVersion(ffprobePath)
+  ])
 
   if (version === null) {
     return { error: 'The downloaded FFmpeg binary does not work on this system' }
   }
-
-  if (download.data !== null) {
-    try {
-      await writeDownloadValidators(managedPath, download.validators, url)
-    } catch (error) {
-      console.warn('Could not save FFmpeg download metadata', error)
-    }
+  if (ffprobeVersion === null) {
+    return { error: 'The downloaded FFprobe binary does not work on this system' }
   }
 
-  return { version, updated: download.data !== null }
+  try {
+    await Promise.all(pendingValidatorWrites.map(({ path, validators, url }) =>
+      writeDownloadValidators(path, validators, url)))
+  } catch (error) {
+    console.warn('Could not save FFmpeg and FFprobe download metadata', error)
+  }
+
+  return { version, updated }
 }
 
 /**
@@ -661,7 +746,7 @@ function getInfoProbeKey(options) {
  *   ffmpegSource: 'system' | 'managed',
  *   ffmpegPath: string
  * } | undefined} [options]
- * @returns {Promise<{ ytDlp: YtDlpBinaryInfo, ffmpeg: YtDlpBinaryInfo } | null>}
+ * @returns {Promise<{ ytDlp: YtDlpBinaryInfo, ffmpeg: YtDlpBinaryInfo, ffprobe: YtDlpBinaryInfo } | null>}
  */
 export async function handleYtDlpGetInfo(event, options) {
   if (!isOpenTubeXUrl(event.senderFrame.url)) {
@@ -697,7 +782,7 @@ export async function handleYtDlpGetInfo(event, options) {
   const signal = takeGetInfoAbortSignal(probeKey)
 
   try {
-    const [ytDlp, ffmpeg] = await Promise.all([
+    const [ytDlp, ffmpeg, ffprobe] = await Promise.all([
       getBinaryInfo(
         await resolveExecutable('ytDlpSource', 'ytDlpPath', 'yt-dlp', options?.ytDlpSource, options?.ytDlpPath),
         (executable) => getYtDlpVersion(executable, signal)
@@ -705,6 +790,10 @@ export async function handleYtDlpGetInfo(event, options) {
       getBinaryInfo(
         await resolveExecutable('ytDlpFfmpegSource', 'ytDlpFfmpegPath', 'ffmpeg', options?.ffmpegSource, options?.ffmpegPath),
         (executable) => getFfmpegVersion(executable, signal)
+      ),
+      getBinaryInfo(
+        await resolveFfprobeExecutable(options?.ffmpegSource, options?.ffmpegPath),
+        (executable) => getFfprobeVersion(executable, signal)
       )
     ])
 
@@ -714,7 +803,8 @@ export async function handleYtDlpGetInfo(event, options) {
 
     return {
       ytDlp,
-      ffmpeg
+      ffmpeg,
+      ffprobe
     }
   } finally {
     if (getInfoAbortControllers.get(probeKey)?.signal === signal) {
@@ -1005,7 +1095,8 @@ export async function handleYtDlpDownload(event, payload) {
   const ffmpeg = await resolveExecutable('ytDlpFfmpegSource', 'ytDlpFfmpegPath', 'ffmpeg')
 
   if (ffmpeg.source === 'managed') {
-    if (!existsSync(ffmpeg.executable)) {
+    const ffprobe = await resolveFfprobeExecutable()
+    if (!existsSync(ffmpeg.executable) || !existsSync(ffprobe.executable)) {
       const result = await downloadManagedFfmpeg()
 
       if ('error' in result) {

--- a/src/main/ytDlp.js
+++ b/src/main/ytDlp.js
@@ -655,6 +655,7 @@ async function downloadManagedFfmpeg(onProgress, onDownloadStart) {
       { name: 'ffmpeg', path: ffmpegPath },
       { name: 'ffprobe', path: ffprobePath }
     ]
+    const pendingInstalls = []
 
     try {
       for (const [index, binary] of binaries.entries()) {
@@ -667,11 +668,18 @@ async function downloadManagedFfmpeg(onProgress, onDownloadStart) {
         )
 
         if (download.data !== null) {
-          await installBinary(extractZipEntry(download.data, name => name === binary.name), binary.path)
-          updated = true
+          pendingInstalls.push({
+            data: extractZipEntry(download.data, name => name === binary.name),
+            path: binary.path
+          })
           pendingValidatorWrites.push({ path: binary.path, validators: download.validators, url })
         }
       }
+
+      for (const pendingInstall of pendingInstalls) {
+        await installBinary(pendingInstall.data, pendingInstall.path)
+      }
+      updated = pendingInstalls.length > 0
     } catch (error) {
       return { error: error.message }
     }

--- a/src/main/ytDlp.js
+++ b/src/main/ytDlp.js
@@ -111,6 +111,7 @@ const FINAL_PATH_PREFIX = '__OPENTUBEX_FILE__:'
 let downloadCounter = 0
 let downloadRecordsSaveQueue = Promise.resolve()
 let binaryInstallCounter = 0
+let managedBinaryInstallQueue = Promise.resolve()
 
 /** @type {Map<number, { child: import('node:child_process').ChildProcess, cancelled: boolean }>} */
 const activeDownloads = new Map()
@@ -566,7 +567,7 @@ async function installBinary(data, destinationPath) {
  * replacement fails, every executable that was already replaced is restored.
  * @param {{ data: Buffer, path: string }[]} binaries
  */
-async function installBinariesAtomically(binaries) {
+async function performAtomicBinaryInstall(binaries) {
   if (binaries.length === 0) {
     return
   }
@@ -638,6 +639,19 @@ async function installBinariesAtomically(binaries) {
   if (cleanupErrors.length > 0) {
     console.warn('Could not remove managed binary backups', cleanupErrors)
   }
+}
+
+/**
+ * Prevents concurrent managed downloads from interleaving transactions that
+ * replace the same FFmpeg and FFprobe destinations.
+ * @param {{ data: Buffer, path: string }[]} binaries
+ */
+async function installBinariesAtomically(binaries) {
+  const installation = managedBinaryInstallQueue
+    .catch(() => {})
+    .then(() => performAtomicBinaryInstall(binaries))
+  managedBinaryInstallQueue = installation
+  return installation
 }
 
 /**

--- a/src/main/ytDlp.js
+++ b/src/main/ytDlp.js
@@ -1,6 +1,6 @@
 import { execFile, spawn } from 'node:child_process'
 import { existsSync } from 'node:fs'
-import { chmod, mkdir, readFile, rename, writeFile } from 'node:fs/promises'
+import { chmod, mkdir, readFile, rename, rm, writeFile } from 'node:fs/promises'
 import { dirname, join } from 'node:path'
 import { promisify } from 'node:util'
 import { inflateRawSync } from 'node:zlib'
@@ -110,6 +110,7 @@ const FINAL_PATH_PREFIX = '__OPENTUBEX_FILE__:'
 
 let downloadCounter = 0
 let downloadRecordsSaveQueue = Promise.resolve()
+let binaryInstallCounter = 0
 
 /** @type {Map<number, { child: import('node:child_process').ChildProcess, cancelled: boolean }>} */
 const activeDownloads = new Map()
@@ -561,6 +562,85 @@ async function installBinary(data, destinationPath) {
 }
 
 /**
+ * Replaces a related set of managed binaries as one transaction. If any
+ * replacement fails, every executable that was already replaced is restored.
+ * @param {{ data: Buffer, path: string }[]} binaries
+ */
+async function installBinariesAtomically(binaries) {
+  if (binaries.length === 0) {
+    return
+  }
+
+  await mkdir(getManagedBinariesDirectory(), { recursive: true })
+
+  const transactionId = `${process.pid}-${++binaryInstallCounter}`
+  const entries = binaries.map(binary => ({
+    ...binary,
+    temporaryPath: `${binary.path}.part-${transactionId}`,
+    backupPath: `${binary.path}.backup-${transactionId}`,
+    backedUp: false,
+    installed: false
+  }))
+
+  try {
+    for (const entry of entries) {
+      await writeFile(entry.temporaryPath, entry.data)
+      if (process.platform !== 'win32') {
+        await chmod(entry.temporaryPath, 0o755)
+      }
+    }
+
+    for (const entry of entries) {
+      if (existsSync(entry.path)) {
+        await rename(entry.path, entry.backupPath)
+        entry.backedUp = true
+      }
+    }
+
+    for (const entry of entries) {
+      await rename(entry.temporaryPath, entry.path)
+      entry.installed = true
+    }
+  } catch (error) {
+    const rollbackErrors = []
+    async function attemptRollback(operation) {
+      try {
+        await operation()
+      } catch (rollbackError) {
+        rollbackErrors.push(rollbackError)
+      }
+    }
+
+    for (const entry of entries.toReversed()) {
+      if (entry.installed) {
+        await attemptRollback(() => rm(entry.path, { force: true }))
+      }
+      if (entry.backedUp) {
+        await attemptRollback(() => rename(entry.backupPath, entry.path))
+      }
+      await attemptRollback(() => rm(entry.temporaryPath, { force: true }))
+    }
+
+    if (rollbackErrors.length > 0) {
+      throw new AggregateError(
+        rollbackErrors,
+        'Installing the managed binaries failed and could not be fully rolled back',
+        { cause: error }
+      )
+    }
+    throw error
+  }
+
+  const cleanupResults = await Promise.allSettled(entries
+    .filter(entry => entry.backedUp)
+    .map(entry => rm(entry.backupPath, { force: true })))
+  const cleanupErrors = cleanupResults.filter(result => result.status === 'rejected')
+  if (cleanupErrors.length > 0) {
+    console.warn('Could not remove managed binary backups', cleanupErrors)
+  }
+}
+
+/**
  * Downloads the latest yt-dlp release into the user data directory
  * @param {BinaryDownloadProgressCallback} [onProgress]
  * @param {() => void} [onDownloadStart]
@@ -635,8 +715,10 @@ async function downloadManagedFfmpeg(onProgress, onDownloadStart) {
       const download = await downloadFile(url, onProgress, onDownloadStart, validators)
 
       if (download.data !== null) {
-        await installBinary(extractZipEntry(download.data, name => name.endsWith('/bin/ffmpeg.exe')), ffmpegPath)
-        await installBinary(extractZipEntry(download.data, name => name.endsWith('/bin/ffprobe.exe')), ffprobePath)
+        await installBinariesAtomically([
+          { data: extractZipEntry(download.data, name => name.endsWith('/bin/ffmpeg.exe')), path: ffmpegPath },
+          { data: extractZipEntry(download.data, name => name.endsWith('/bin/ffprobe.exe')), path: ffprobePath }
+        ])
         updated = true
         pendingValidatorWrites.push(
           { path: ffmpegPath, validators: download.validators, url },
@@ -676,9 +758,7 @@ async function downloadManagedFfmpeg(onProgress, onDownloadStart) {
         }
       }
 
-      for (const pendingInstall of pendingInstalls) {
-        await installBinary(pendingInstall.data, pendingInstall.path)
-      }
+      await installBinariesAtomically(pendingInstalls)
       updated = pendingInstalls.length > 0
     } catch (error) {
       return { error: error.message }

--- a/src/preload/interface.js
+++ b/src/preload/interface.js
@@ -314,7 +314,8 @@ export default {
    * } | undefined} [options]
    * @returns {Promise<{
    *   ytDlp: import('../main/ytDlp').YtDlpBinaryInfo,
-   *   ffmpeg: import('../main/ytDlp').YtDlpBinaryInfo
+   *   ffmpeg: import('../main/ytDlp').YtDlpBinaryInfo,
+   *   ffprobe: import('../main/ytDlp').YtDlpBinaryInfo
    * } | null>}
    */
   ytDlpGetInfo: (options) => {

--- a/src/renderer/App.vue
+++ b/src/renderer/App.vue
@@ -603,7 +603,7 @@ async function initializeManagedExternalSoftware() {
     return
   }
 
-  /** @type {('yt-dlp' | 'ffmpeg')[]} */
+  /** @type {('yt-dlp' | 'ffmpeg' | 'ffprobe')[]} */
   const missingBinaries = []
   /** @type {('yt-dlp' | 'ffmpeg')[]} */
   const binariesToUpdate = []

--- a/src/renderer/App.vue
+++ b/src/renderer/App.vue
@@ -614,11 +614,15 @@ async function initializeManagedExternalSoftware() {
   if (!info.ffmpeg.available) {
     missingBinaries.push('ffmpeg')
   }
+  if (!info.ffprobe.available) {
+    missingBinaries.push('ffprobe')
+  }
 
   if (store.getters.getYtDlpSource === 'managed' || missingBinaries.includes('yt-dlp')) {
     binariesToUpdate.push('yt-dlp')
   }
-  if (store.getters.getYtDlpFfmpegSource === 'managed' || missingBinaries.includes('ffmpeg')) {
+  if (store.getters.getYtDlpFfmpegSource === 'managed' ||
+    missingBinaries.includes('ffmpeg') || missingBinaries.includes('ffprobe')) {
     binariesToUpdate.push('ffmpeg')
   }
   if (binariesToUpdate.length === 0) {
@@ -629,7 +633,8 @@ async function initializeManagedExternalSoftware() {
   if (missingBinaries.includes('yt-dlp') && store.getters.getYtDlpSource !== 'managed') {
     settingUpdates.push(store.dispatch('updateYtDlpSource', 'managed'))
   }
-  if (missingBinaries.includes('ffmpeg') && store.getters.getYtDlpFfmpegSource !== 'managed') {
+  if ((missingBinaries.includes('ffmpeg') || missingBinaries.includes('ffprobe')) &&
+    store.getters.getYtDlpFfmpegSource !== 'managed') {
     settingUpdates.push(store.dispatch('updateYtDlpFfmpegSource', 'managed'))
   }
   await Promise.all(settingUpdates)

--- a/src/renderer/components/ExternalSoftwareSettings.vue
+++ b/src/renderer/components/ExternalSoftwareSettings.vue
@@ -81,6 +81,29 @@
         {{ t('Settings.External Software Settings.Detected FFmpeg Version Template', { version: ffmpegInfo.version }) }}
       </p>
     </FtFlexBox>
+    <FtFlexBox class="binaryStatusEnd">
+      <p
+        v-if="ffprobeInfo === null"
+        class="ytDlpStatus"
+      >
+        {{ t('Settings.External Software Settings.Checking FFprobe') }}
+      </p>
+      <p
+        v-else-if="!ffprobeInfo.available"
+        class="ytDlpStatus ytDlpWarning"
+      >
+        <FontAwesomeIcon :icon="['fas', 'circle-exclamation']" />
+        {{ ytDlpFfmpegSource === 'managed'
+          ? t('Settings.External Software Settings.FFprobe Managed Not Downloaded')
+          : t('Settings.External Software Settings.System FFprobe Missing Warning') }}
+      </p>
+      <p
+        v-else
+        class="ytDlpStatus"
+      >
+        {{ t('Settings.External Software Settings.Detected FFprobe Version Template', { version: ffprobeInfo.version }) }}
+      </p>
+    </FtFlexBox>
     <FtFlexBox v-if="ytDlpSource === 'managed' || ytDlpFfmpegSource === 'managed'">
       <FtButton
         v-if="ytDlpSource === 'managed'"
@@ -100,12 +123,12 @@
       <FtButton
         v-if="ytDlpFfmpegSource === 'managed'"
         :label="ffmpegBinaryDownloadInProgress
-          ? t('Settings.External Software Settings.Downloading FFmpeg')
+          ? t('Settings.External Software Settings.Downloading FFmpeg and FFprobe')
           : (ffmpegInfo === null
             ? t('Settings.External Software Settings.Checking FFmpeg')
-            : ffmpegInfo.available
-              ? t('Settings.External Software Settings.Update FFmpeg')
-              : t('Settings.External Software Settings.Download FFmpeg'))"
+            : ffmpegToolsAvailable
+              ? t('Settings.External Software Settings.Update FFmpeg and FFprobe')
+              : t('Settings.External Software Settings.Download FFmpeg and FFprobe'))"
         :icon="['fas', 'download']"
         :disabled="ffmpegBinaryDownloadInProgress || ffmpegInfo === null"
         :text-color="null"
@@ -200,14 +223,15 @@ const ytDlpFfmpegPath = computed(() => store.getters.getYtDlpFfmpegPath)
 /** @typedef {import('../../main/ytDlp').YtDlpBinaryInfo} BinaryInfo */
 
 /**
- * @type {import('vue').Ref<Record<'ytDlp' | 'ffmpeg', {
+ * @type {import('vue').Ref<Record<'ytDlp' | 'ffmpeg' | 'ffprobe', {
  *   managed: BinaryInfo | null,
  *   system: { path: string, info: BinaryInfo } | null
  * }>>}
  */
 const binariesInfoCache = ref({
   ytDlp: { managed: null, system: null },
-  ffmpeg: { managed: null, system: null }
+  ffmpeg: { managed: null, system: null },
+  ffprobe: { managed: null, system: null }
 })
 
 /** @type {import('vue').ComputedRef<BinaryInfo | null>} */
@@ -223,6 +247,15 @@ const ffmpegInfo = computed(() => ytDlpFfmpegSource.value === 'managed'
   : binariesInfoCache.value.ffmpeg.system?.path === ytDlpFfmpegPath.value
     ? binariesInfoCache.value.ffmpeg.system.info
     : null)
+
+/** @type {import('vue').ComputedRef<BinaryInfo | null>} */
+const ffprobeInfo = computed(() => ytDlpFfmpegSource.value === 'managed'
+  ? binariesInfoCache.value.ffprobe.managed
+  : binariesInfoCache.value.ffprobe.system?.path === ytDlpFfmpegPath.value
+    ? binariesInfoCache.value.ffprobe.system.info
+    : null)
+
+const ffmpegToolsAvailable = computed(() => ffmpegInfo.value?.available === true && ffprobeInfo.value?.available === true)
 
 const ytDlpBinaryDownloadInProgress = ref(false)
 const ffmpegBinaryDownloadInProgress = ref(false)
@@ -245,12 +278,13 @@ async function getBinariesInfo(options) {
   try {
     return await window.ftElectron.ytDlpGetInfo(options)
   } catch (error) {
-    console.error('Checking the yt-dlp and FFmpeg binaries failed', error)
+    console.error('Checking the yt-dlp, FFmpeg, and FFprobe binaries failed', error)
 
     /** @type {import('../../main/ytDlp').YtDlpBinaryInfo} */
     const unavailable = { source: options.ytDlpSource, available: false, version: null }
 
-    return { ytDlp: unavailable, ffmpeg: { ...unavailable, source: options.ffmpegSource } }
+    const unavailableFfmpegTool = { ...unavailable, source: options.ffmpegSource }
+    return { ytDlp: unavailable, ffmpeg: unavailableFfmpegTool, ffprobe: unavailableFfmpegTool }
   }
 }
 
@@ -269,6 +303,7 @@ async function refreshSystemBinariesInfo() {
   if (requestId === systemInfoRequestId && info !== null) {
     binariesInfoCache.value.ytDlp.system = { path: ytDlpSystemPath, info: info.ytDlp }
     binariesInfoCache.value.ffmpeg.system = { path: ffmpegSystemPath, info: info.ffmpeg }
+    binariesInfoCache.value.ffprobe.system = { path: ffmpegSystemPath, info: info.ffprobe }
   }
 }
 
@@ -283,6 +318,9 @@ async function refreshManagedBinariesInfo() {
   if (binariesInfoCache.value.ffmpeg.managed?.available === false) {
     binariesInfoCache.value.ffmpeg.managed = null
   }
+  if (binariesInfoCache.value.ffprobe.managed?.available === false) {
+    binariesInfoCache.value.ffprobe.managed = null
+  }
 
   const info = await getBinariesInfo({
     ytDlpSource: 'managed',
@@ -294,6 +332,7 @@ async function refreshManagedBinariesInfo() {
   if (requestId === managedInfoRequestId && info !== null) {
     binariesInfoCache.value.ytDlp.managed = info.ytDlp
     binariesInfoCache.value.ffmpeg.managed = info.ffmpeg
+    binariesInfoCache.value.ffprobe.managed = info.ffprobe
   }
 }
 
@@ -418,7 +457,7 @@ function showDownloadErrorToast(binary, error) {
   showToast({
     message: binary === 'yt-dlp'
       ? t('Settings.External Software Settings.yt-dlp Download Error Template', { error })
-      : t('Settings.External Software Settings.FFmpeg Download Error Template', { error }),
+      : t('Settings.External Software Settings.FFmpeg and FFprobe Download Error Template', { error }),
     icon: ['fas', 'circle-exclamation'],
   })
 }
@@ -441,11 +480,11 @@ async function downloadBinary(binary) {
         showToast({
           message: binary === 'yt-dlp'
             ? t('Settings.External Software Settings.yt-dlp Downloaded Template', { version: result.version })
-            : t('Settings.External Software Settings.FFmpeg Downloaded Template', { version: result.version }),
+            : t('Settings.External Software Settings.FFmpeg and FFprobe Downloaded Template', { version: result.version }),
           icon: ['fas', 'download'],
         })
       } else {
-        const tool = binary === 'yt-dlp' ? 'yt-dlp' : 'FFmpeg'
+        const tool = binary === 'yt-dlp' ? 'yt-dlp' : 'FFmpeg and FFprobe'
         showToast({
           message: t('Settings.External Software Settings.Managed Tool Already Current Template', {
             tool,

--- a/static/locales/de-DE.yaml
+++ b/static/locales/de-DE.yaml
@@ -771,7 +771,7 @@ Settings:
     Download Folder: Download-Ordner
     Choose Download Folder: Download-Ordner auswählen
     Templates Hint: Benutzerdefinierte Download-Vorlagen können im Download-Dialog erstellt und verwaltet werden, der sich unterhalb des Video-Players befindet.
-    External Software Hint: yt-dlp und FFmpeg werden in den Einstellungen für externe Software konfiguriert.
+    External Software Hint: yt-dlp, FFmpeg und FFprobe werden in den Einstellungen für externe Software konfiguriert.
   External Software Settings:
     External Software Settings: Externe Software
     yt-dlp Source: yt-dlp-Quelle
@@ -798,6 +798,15 @@ Settings:
     Downloading FFmpeg: FFmpeg wird heruntergeladen…
     FFmpeg Downloaded Template: FFmpeg {version} wurde heruntergeladen
     FFmpeg Download Error Template: 'Herunterladen von FFmpeg fehlgeschlagen: {error}'
+    Detected FFprobe Version Template: 'Erkannte FFprobe-Version: {version}'
+    FFprobe Managed Not Downloaded: FFprobe wurde noch nicht heruntergeladen. Klicke auf die Schaltfläche unten, um es zusammen mit FFmpeg herunterzuladen.
+    System FFprobe Missing Warning: FFprobe wurde auf deinem System nicht gefunden. Es wird zum Untersuchen von Medien während der Nachbearbeitung benötigt. Installiere es neben FFmpeg oder wechsle die Quelle auf „Von OpenTubeX verwaltet“.
+    Checking FFprobe: FFprobe wird überprüft…
+    Download FFmpeg and FFprobe: FFmpeg und FFprobe herunterladen
+    Update FFmpeg and FFprobe: FFmpeg und FFprobe aktualisieren
+    Downloading FFmpeg and FFprobe: FFmpeg und FFprobe werden heruntergeladen…
+    FFmpeg and FFprobe Downloaded Template: FFmpeg und FFprobe {version} wurden heruntergeladen
+    FFmpeg and FFprobe Download Error Template: 'Herunterladen von FFmpeg und FFprobe fehlgeschlagen: {error}'
     Managed Tool Already Current Template: '{tool} {version} ist bereits auf dem neuesten Stand'
     yt-dlp Executable Path: Pfad zur ausführbaren yt-dlp-Datei
     FFmpeg Executable Path: Pfad zur ausführbaren FFmpeg-Datei
@@ -1367,7 +1376,7 @@ Tooltips:
   External Software Settings:
     yt-dlp Source: OpenTubeX kann entweder das auf deinem System installierte yt-dlp verwenden oder eine eigene Kopie von yt-dlp herunterladen und verwalten, die im Benutzerdatenverzeichnis gespeichert wird.
     yt-dlp Channel: Wähle aus, welchen yt-dlp-Veröffentlichungskanal OpenTubeX herunterlädt und verwaltet. Für die meisten Benutzer wird „Stable“ empfohlen.
-    FFmpeg Source: OpenTubeX kann entweder das auf deinem System installierte FFmpeg verwenden oder einen eigenen statischen FFmpeg-Build herunterladen und verwalten, der im Benutzerdatenverzeichnis gespeichert wird.
+    FFmpeg Source: OpenTubeX kann entweder die auf deinem System installierten FFmpeg und FFprobe verwenden oder eigene statische Builds herunterladen und verwalten, die im Benutzerdatenverzeichnis gespeichert werden.
     yt-dlp Executable Path: Standardmäßig nimmt OpenTubeX an, dass yt-dlp über die PATH-Umgebungsvariable gefunden werden kann. Falls nötig, kann hier ein benutzerdefinierter Pfad festgelegt werden.
     FFmpeg Executable Path: FFmpeg wird zum Zusammenführen von getrennten Video- und Audiospuren sowie zur Audiokonvertierung benötigt. Standardmäßig nimmt OpenTubeX an, dass FFmpeg über die PATH-Umgebungsvariable gefunden werden kann. Falls nötig, kann hier ein benutzerdefinierter Pfad festgelegt werden.
   Experimental Settings:

--- a/static/locales/de-DE.yaml
+++ b/static/locales/de-DE.yaml
@@ -798,15 +798,6 @@ Settings:
     Downloading FFmpeg: FFmpeg wird heruntergeladen…
     FFmpeg Downloaded Template: FFmpeg {version} wurde heruntergeladen
     FFmpeg Download Error Template: 'Herunterladen von FFmpeg fehlgeschlagen: {error}'
-    Detected FFprobe Version Template: 'Detected FFprobe version: {version}'
-    FFprobe Managed Not Downloaded: FFprobe has not been downloaded yet. Click the button below to download it with FFmpeg.
-    System FFprobe Missing Warning: FFprobe was not found on your system. It is required for inspecting media during post-processing. Install it next to FFmpeg, or switch the source to "Managed by OpenTubeX".
-    Checking FFprobe: Checking FFprobe…
-    Download FFmpeg and FFprobe: Download FFmpeg and FFprobe
-    Update FFmpeg and FFprobe: Update FFmpeg and FFprobe
-    Downloading FFmpeg and FFprobe: Downloading FFmpeg and FFprobe…
-    FFmpeg and FFprobe Downloaded Template: FFmpeg and FFprobe {version} have been downloaded
-    FFmpeg and FFprobe Download Error Template: 'Downloading FFmpeg and FFprobe failed: {error}'
     Managed Tool Already Current Template: '{tool} {version} ist bereits auf dem neuesten Stand'
     yt-dlp Executable Path: Pfad zur ausführbaren yt-dlp-Datei
     FFmpeg Executable Path: Pfad zur ausführbaren FFmpeg-Datei

--- a/static/locales/de-DE.yaml
+++ b/static/locales/de-DE.yaml
@@ -771,7 +771,7 @@ Settings:
     Download Folder: Download-Ordner
     Choose Download Folder: Download-Ordner auswählen
     Templates Hint: Benutzerdefinierte Download-Vorlagen können im Download-Dialog erstellt und verwaltet werden, der sich unterhalb des Video-Players befindet.
-    External Software Hint: yt-dlp, FFmpeg und FFprobe werden in den Einstellungen für externe Software konfiguriert.
+    External Software Hint: yt-dlp und FFmpeg werden in den Einstellungen für externe Software konfiguriert.
   External Software Settings:
     External Software Settings: Externe Software
     yt-dlp Source: yt-dlp-Quelle
@@ -798,15 +798,15 @@ Settings:
     Downloading FFmpeg: FFmpeg wird heruntergeladen…
     FFmpeg Downloaded Template: FFmpeg {version} wurde heruntergeladen
     FFmpeg Download Error Template: 'Herunterladen von FFmpeg fehlgeschlagen: {error}'
-    Detected FFprobe Version Template: 'Erkannte FFprobe-Version: {version}'
-    FFprobe Managed Not Downloaded: FFprobe wurde noch nicht heruntergeladen. Klicke auf die Schaltfläche unten, um es zusammen mit FFmpeg herunterzuladen.
-    System FFprobe Missing Warning: FFprobe wurde auf deinem System nicht gefunden. Es wird zum Untersuchen von Medien während der Nachbearbeitung benötigt. Installiere es neben FFmpeg oder wechsle die Quelle auf „Von OpenTubeX verwaltet“.
-    Checking FFprobe: FFprobe wird überprüft…
-    Download FFmpeg and FFprobe: FFmpeg und FFprobe herunterladen
-    Update FFmpeg and FFprobe: FFmpeg und FFprobe aktualisieren
-    Downloading FFmpeg and FFprobe: FFmpeg und FFprobe werden heruntergeladen…
-    FFmpeg and FFprobe Downloaded Template: FFmpeg und FFprobe {version} wurden heruntergeladen
-    FFmpeg and FFprobe Download Error Template: 'Herunterladen von FFmpeg und FFprobe fehlgeschlagen: {error}'
+    Detected FFprobe Version Template: 'Detected FFprobe version: {version}'
+    FFprobe Managed Not Downloaded: FFprobe has not been downloaded yet. Click the button below to download it with FFmpeg.
+    System FFprobe Missing Warning: FFprobe was not found on your system. It is required for inspecting media during post-processing. Install it next to FFmpeg, or switch the source to "Managed by OpenTubeX".
+    Checking FFprobe: Checking FFprobe…
+    Download FFmpeg and FFprobe: Download FFmpeg and FFprobe
+    Update FFmpeg and FFprobe: Update FFmpeg and FFprobe
+    Downloading FFmpeg and FFprobe: Downloading FFmpeg and FFprobe…
+    FFmpeg and FFprobe Downloaded Template: FFmpeg and FFprobe {version} have been downloaded
+    FFmpeg and FFprobe Download Error Template: 'Downloading FFmpeg and FFprobe failed: {error}'
     Managed Tool Already Current Template: '{tool} {version} ist bereits auf dem neuesten Stand'
     yt-dlp Executable Path: Pfad zur ausführbaren yt-dlp-Datei
     FFmpeg Executable Path: Pfad zur ausführbaren FFmpeg-Datei
@@ -1376,7 +1376,7 @@ Tooltips:
   External Software Settings:
     yt-dlp Source: OpenTubeX kann entweder das auf deinem System installierte yt-dlp verwenden oder eine eigene Kopie von yt-dlp herunterladen und verwalten, die im Benutzerdatenverzeichnis gespeichert wird.
     yt-dlp Channel: Wähle aus, welchen yt-dlp-Veröffentlichungskanal OpenTubeX herunterlädt und verwaltet. Für die meisten Benutzer wird „Stable“ empfohlen.
-    FFmpeg Source: OpenTubeX kann entweder die auf deinem System installierten FFmpeg und FFprobe verwenden oder eigene statische Builds herunterladen und verwalten, die im Benutzerdatenverzeichnis gespeichert werden.
+    FFmpeg Source: OpenTubeX kann entweder das auf deinem System installierte FFmpeg verwenden oder einen eigenen statischen FFmpeg-Build herunterladen und verwalten, der im Benutzerdatenverzeichnis gespeichert wird.
     yt-dlp Executable Path: Standardmäßig nimmt OpenTubeX an, dass yt-dlp über die PATH-Umgebungsvariable gefunden werden kann. Falls nötig, kann hier ein benutzerdefinierter Pfad festgelegt werden.
     FFmpeg Executable Path: FFmpeg wird zum Zusammenführen von getrennten Video- und Audiospuren sowie zur Audiokonvertierung benötigt. Standardmäßig nimmt OpenTubeX an, dass FFmpeg über die PATH-Umgebungsvariable gefunden werden kann. Falls nötig, kann hier ein benutzerdefinierter Pfad festgelegt werden.
   Experimental Settings:

--- a/static/locales/en-US.yaml
+++ b/static/locales/en-US.yaml
@@ -783,7 +783,7 @@ Settings:
     Download Folder: Download Folder
     Choose Download Folder: Choose Download Folder
     Templates Hint: Custom download templates can be created and managed in the download prompt, which is located beneath the video player.
-    External Software Hint: yt-dlp and FFmpeg are configured in the External Software settings.
+    External Software Hint: yt-dlp, FFmpeg, and FFprobe are configured in the External Software settings.
   External Software Settings:
     External Software Settings: External Software
     yt-dlp Source: yt-dlp Source
@@ -810,6 +810,15 @@ Settings:
     Downloading FFmpeg: Downloading FFmpeg…
     FFmpeg Downloaded Template: FFmpeg {version} has been downloaded
     FFmpeg Download Error Template: 'Downloading FFmpeg failed: {error}'
+    Detected FFprobe Version Template: 'Detected FFprobe version: {version}'
+    FFprobe Managed Not Downloaded: FFprobe has not been downloaded yet. Click the button below to download it with FFmpeg.
+    System FFprobe Missing Warning: FFprobe was not found on your system. It is required for inspecting media during post-processing. Install it next to FFmpeg, or switch the source to "Managed by OpenTubeX".
+    Checking FFprobe: Checking FFprobe…
+    Download FFmpeg and FFprobe: Download FFmpeg and FFprobe
+    Update FFmpeg and FFprobe: Update FFmpeg and FFprobe
+    Downloading FFmpeg and FFprobe: Downloading FFmpeg and FFprobe…
+    FFmpeg and FFprobe Downloaded Template: FFmpeg and FFprobe {version} have been downloaded
+    FFmpeg and FFprobe Download Error Template: 'Downloading FFmpeg and FFprobe failed: {error}'
     Managed Tool Already Current Template: '{tool} {version} is already up to date'
     yt-dlp Executable Path: yt-dlp Executable Path
     FFmpeg Executable Path: FFmpeg Executable Path
@@ -1852,8 +1861,8 @@ Tooltips:
       and manage its own copy of yt-dlp, which is stored in the user data directory.
     yt-dlp Channel: Select which yt-dlp release channel OpenTubeX downloads and manages.
       Stable is recommended for most users.
-    FFmpeg Source: OpenTubeX can either use the FFmpeg installed on your system or download
-      and manage its own static FFmpeg build, which is stored in the user data directory.
+    FFmpeg Source: OpenTubeX can either use FFmpeg and FFprobe installed on your system or
+      download and manage its own static builds, which are stored in the user data directory.
     yt-dlp Executable Path: By default, OpenTubeX will assume that yt-dlp can be found via
       the PATH environment variable. If needed, a custom path can be set here.
     FFmpeg Executable Path: FFmpeg is required for merging separate video and audio streams


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Make sure to follow the contributing guidelines. -->
<!-- Important note, we may remove your pull request if you do not use this provided PR template correctly. -->
<!-- Agent instructions: Preserve every heading, comment, and marker in this template. Never remove or rewrite the release-note-category:start/end, release-note:start/end, or release-note-image:start/end marker pairs. Never remove or rewrite the Release note images section; leave its contents for a human. -->

## Pull Request Type
<!-- Please select what type of pull request this is: [x] -->
- [x] Bugfix
- [ ] Feature Implementation
- [ ] Documentation
- [ ] Other

## Related issue
<!-- Please link the issue your pull request is referring to. -->
<!-- If this pull request fully resolves the relevant issue, put "closes" before the issue number. -->
<!-- Example: "closes #123456". -->

Follow-up to #632.

## Description
<!-- Please write a clear and concise description of what the pull request does. -->

OpenTubeX-managed FFmpeg installations only contained the `ffmpeg` executable. yt-dlp also requires `ffprobe` for media inspection during post-processing, so affected downloads failed after the media had been downloaded.

Managed FFmpeg downloads now install and update FFmpeg and FFprobe together. System mode detects FFprobe from `PATH` or beside a configured custom FFmpeg executable, startup fallback accounts for either missing tool, and External Software settings show FFprobe's availability and version separately.

## Release note category
<!-- Select exactly one category. Every pull request must select one. -->
<!-- Select "Not noteworthy" when the pull request fixes a bug in or improves functionality that has not yet appeared in a stable release. -->
<!-- release-note-category:start -->
- [ ] Not noteworthy
- [ ] Highlights
- [ ] More improvements
- [x] Fixed bugs
<!-- release-note-category:end -->

## Release note
<!-- Required unless "Not noteworthy" is selected. -->
<!-- Write one concise, user-facing entry without a leading bullet. -->
<!-- release-note:start -->
Fixed downloads failing during post-processing when FFprobe was unavailable.
<!-- release-note:end -->

## Release note images
<!-- Human-only: Agents must preserve this entire section and leave it empty. -->
<!-- Optional. Paste one or more Markdown images or HTML image tags here. -->
<!-- The release notes will use an HTML image tag and limit images taller than 300 pixels. -->
<!-- release-note-image:start -->

<!-- release-note-image:end -->

## Testing
<!-- How can reviewers verify that the PR produces correct results? -->
<!-- Please provide instructions so that others can ensure that your pull request would produce correct results. For examples see, https://github.com/FreeTubeApp/FreeTube/pull/5743, https://github.com/FreeTubeApp/FreeTube/pull/7349, https://github.com/FreeTubeApp/FreeTube/pull/5125, https://github.com/FreeTubeApp/FreeTube/pull/7338 -->
<!-- Agent instructions: Only write human-facing steps that explain how to verify the change while running this branch in dev mode. Include expected results and, when applicable, helpful console snippets for interactive verification. Do not include automated checks, commands, results, pass counts, or CI status. -->

1. Open External Software settings with FFmpeg set to System and confirm FFmpeg and FFprobe each show their detected version.
2. Set FFmpeg to Managed, download or update the tools, and confirm both FFmpeg and FFprobe show detected versions afterward.
3. Download a video that requires post-processing and confirm it completes without an `ffprobe not found` error.

## Additional context
<!-- Add any other context about the pull request here. -->

Implemented with GPT-5 in the Codex desktop harness.
