### PR TITLE
feat: separate live chat replay visibility

### DIFF
--- a/e2e/tests/offline/settings.spec.mjs
+++ b/e2e/tests/offline/settings.spec.mjs
@@ -1579,6 +1579,22 @@ test.describe('playback engine migration', () => {
   })
 })
 
+test.describe('live chat replay visibility migration', () => {
+  test.use({ seed: { settings: { hideLiveChat: true } } })
+
+  test('preserves the old live chat visibility choice for replays', async ({ app }) => {
+    await expect.poll(async () => {
+      const settings = latestSettings(
+        await readFile(path.join(app.userDataDir, 'settings.db'), 'utf8')
+      )
+      return {
+        liveChat: settings.hideLiveChat,
+        replay: settings.hideLiveChatReplay
+      }
+    }).toEqual({ liveChat: true, replay: true })
+  })
+})
+
 test.describe('playback engine proxy migration', () => {
   test.use({
     seed: {

--- a/e2e/tests/offline/watch-page.spec.mjs
+++ b/e2e/tests/offline/watch-page.spec.mjs
@@ -161,7 +161,13 @@ test.describe('watch page', () => {
     })
     const activeChat = page.locator(`${activeTab} .watchVideoPlaylist`).filter({ hasText: 'Live Chat' })
     await expect(activeChat).toBeVisible()
-    await expect(activeChat.getByRole('button', { name: 'Close Live Chat' })).toBeVisible()
+    await activeChat.getByRole('button', { name: 'Close Live Chat' }).click()
+    await expect(activeChat).toHaveCount(0)
+
+    const activeChatToggle = page.getByTitle('Show Live Chat')
+    await expect(activeChatToggle).toBeVisible()
+    await activeChatToggle.click()
+    await expect(activeChat).toBeVisible()
 
     await watchView.evaluate(async (view) => {
       view.$store.commit('setHideLiveChat', true)

--- a/e2e/tests/offline/watch-page.spec.mjs
+++ b/e2e/tests/offline/watch-page.spec.mjs
@@ -1,6 +1,6 @@
 import { sel, setPlayerFullscreen, test, expect } from '../../helpers/app.mjs'
 import { activeTab, findWatchComponent, openMockedVideo, waitForPlayback } from '../../helpers/player.mjs'
-import { mockPlayableWatchPage } from '../../helpers/watch.mjs'
+import { mockPlayableWatchPage, watchViewHandle } from '../../helpers/watch.mjs'
 import { demoPlayerResponse } from '../../helpers/media.mjs'
 
 // These used to live in the network suite, gated on the live API. They all use
@@ -100,6 +100,76 @@ async function mockTranslatedEndscreen(app, page) {
 }
 
 test.describe('watch page', () => {
+  test('keeps live chat and replay visibility independent and restores a closed chat', async ({ app, page }) => {
+    await mockPlayableWatchPage(app, page)
+    await openMockedVideo(page)
+
+    const watchView = await watchViewHandle(page)
+    await watchView.evaluate(async (view) => {
+      const listeners = new Map()
+      const liveChat = new EventTarget()
+      liveChat.is_replay = true
+      liveChat.on = (event, listener) => {
+        listeners.set(listener, event)
+        liveChat.addEventListener(event, listener)
+      }
+      liveChat.once = (event, listener) => {
+        listeners.set(listener, event)
+        liveChat.addEventListener(event, listener, { once: true })
+      }
+      liveChat.off = (_event, listener) => {
+        liveChat.removeEventListener(listeners.get(listener), listener)
+        listeners.delete(listener)
+      }
+      liveChat.start = () => {}
+      liveChat.stop = () => {}
+
+      view.$store.commit('setHideLiveChat', true)
+      view.$store.commit('setHideLiveChatReplay', false)
+      view.liveChat = liveChat
+      view.liveChatIsReplay = true
+      view.liveChatOpen = true
+      view.isLive = false
+      view.isUpcoming = false
+      await view.$nextTick()
+    })
+
+    const replay = page.locator(`${activeTab} .watchVideoPlaylist`).filter({ hasText: 'Live Chat Replay' })
+    await expect(replay).toBeVisible()
+    await replay.getByRole('button', { name: 'Close Live Chat Replay' }).click()
+    await expect(replay).toHaveCount(0)
+
+    const replayToggle = page.getByTitle('Show Live Chat Replay')
+    await expect(replayToggle).toBeVisible()
+    await replayToggle.click()
+    await expect(replay).toBeVisible()
+    await expect(replay.getByRole('button', { name: 'Close Live Chat Replay' })).toBeVisible()
+
+    await watchView.evaluate(async (view) => {
+      view.$store.commit('setHideLiveChat', false)
+      view.$store.commit('setHideLiveChatReplay', true)
+      await view.$nextTick()
+    })
+    await expect(replay).toHaveCount(0)
+    await expect(page.getByTitle('Show Live Chat Replay')).toHaveCount(0)
+
+    await watchView.evaluate(async (view) => {
+      view.liveChat.is_replay = false
+      view.liveChatIsReplay = false
+      view.isLive = true
+      await view.$nextTick()
+    })
+    const activeChat = page.locator(`${activeTab} .watchVideoPlaylist`).filter({ hasText: 'Live Chat' })
+    await expect(activeChat).toBeVisible()
+    await expect(activeChat.getByRole('button', { name: 'Close Live Chat' })).toBeVisible()
+
+    await watchView.evaluate(async (view) => {
+      view.$store.commit('setHideLiveChat', true)
+      await view.$nextTick()
+    })
+    await expect(activeChat).toHaveCount(0)
+  })
+
   test('transitions a premiere when relative timestamp updates are disabled', async ({ app, page }) => {
     await mockPlayableWatchPage(app, page)
     await openMockedVideo(page)

--- a/src/renderer/components/DistractionSettings/DistractionSettings.vue
+++ b/src/renderer/components/DistractionSettings/DistractionSettings.vue
@@ -308,6 +308,13 @@
           @change="updateHideLiveChat"
         />
         <FtToggleSwitch
+          :label="t('Settings.Distraction Free Settings.Hide Live Chat Replay')"
+          :compact="true"
+          :default-value="hideLiveChatReplay"
+          setting-key="hideLiveChatReplay"
+          @change="updateHideLiveChatReplay"
+        />
+        <FtToggleSwitch
           :label="t('Settings.Distraction Free Settings.Hide Recommended Videos')"
           :compact="true"
           :default-value="hideRecommendedVideos"
@@ -476,6 +483,16 @@ const hideLiveChat = computed(() => store.getters.getHideLiveChat)
  */
 function updateHideLiveChat(value) {
   store.dispatch('updateHideLiveChat', value)
+}
+
+/** @type {import('vue').ComputedRef<boolean>} */
+const hideLiveChatReplay = computed(() => store.getters.getHideLiveChatReplay)
+
+/**
+ * @param {boolean} value
+ */
+function updateHideLiveChatReplay(value) {
+  store.dispatch('updateHideLiveChatReplay', value)
 }
 
 /** @type {import('vue').ComputedRef<boolean>} */

--- a/src/renderer/components/WatchVideoInfo/WatchVideoInfo.vue
+++ b/src/renderer/components/WatchVideoInfo/WatchVideoInfo.vue
@@ -211,6 +211,14 @@
             @click="emit('toggle-sponsorblock-info')"
           />
           <FtIconButton
+            v-if="liveChatAvailable && !hideFullscreenDockActions"
+            :title="liveChatToggleTitle"
+            :icon="['fas', 'message']"
+            :theme="liveChatOpen ? 'secondary' : 'base'"
+            :aria-pressed="liveChatOpen"
+            @click="emit('toggle-live-chat')"
+          />
+          <FtIconButton
             v-if="!isLive && !isUpcoming && !hideFullscreenDockActions"
             :title="transcriptOpen ? t('Video.Transcript.Hide') : t('Video.Transcript.Show')"
             :icon="['fas', 'file-lines']"
@@ -460,6 +468,18 @@ const props = defineProps({
     type: Boolean,
     default: false
   },
+  liveChatAvailable: {
+    type: Boolean,
+    default: false
+  },
+  liveChatOpen: {
+    type: Boolean,
+    default: false
+  },
+  liveChatReplay: {
+    type: Boolean,
+    default: false
+  },
   hideShareButton: {
     type: Boolean,
     default: false
@@ -484,6 +504,7 @@ const emit = defineEmits([
   'save-channel-volume',
   'toggle-sponsorblock-info',
   'toggle-transcript',
+  'toggle-live-chat',
 ])
 
 const USING_ELECTRON = process.env.IS_ELECTRON
@@ -495,6 +516,14 @@ const showCollaboratorsPrompt = ref(false)
 const showDownloadPrompt = ref(false)
 const showFormatPrompt = ref(false)
 const enableDownloads = computed(() => store.getters.getEnableDownloads)
+
+const liveChatToggleTitle = computed(() => {
+  if (props.liveChatReplay) {
+    return props.liveChatOpen ? t('Video.Close Live Chat Replay') : t('Video.Show Live Chat Replay')
+  }
+
+  return props.liveChatOpen ? t('Video.Close Live Chat') : t('Video.Show Live Chat')
+})
 
 watch(enableDownloads, (enabled) => {
   if (!enabled) showDownloadPrompt.value = false

--- a/src/renderer/components/WatchVideoLiveChat/WatchVideoLiveChat.vue
+++ b/src/renderer/components/WatchVideoLiveChat/WatchVideoLiveChat.vue
@@ -43,8 +43,8 @@
         <button
           type="button"
           class="liveChatDockAction"
-          :aria-label="t('Settings.Distraction Free Settings.Hide Live Chat')"
-          :title="t('Settings.Distraction Free Settings.Hide Live Chat')"
+          :aria-label="closeButtonTitle"
+          :title="closeButtonTitle"
           @click="emit('close')"
         >
           <FontAwesomeIcon :icon="['fas', 'xmark']" />
@@ -71,6 +71,76 @@
         </div>
       </div>
     </header>
+    <div
+      v-else
+      class="titleContainer"
+    >
+      <h4 class="title">
+        {{ isReplay ? t('Video.Live Chat Replay') : t('Video.Live Chat') }}
+        <span
+          v-if="!hideVideoViews && watchingCount !== null"
+          class="watchingCount"
+        >
+          {{ t('Global.Counts.Watching Count', { count: formattedWatchingCount }, watchingCount) }}
+        </span>
+      </h4>
+      <div
+        ref="liveChatActionsRef"
+        class="liveChatActions"
+        @keydown.esc.stop.prevent="settingsMenuOpen = false"
+      >
+        <button
+          type="button"
+          class="liveChatActionButton"
+          :class="{ active: settingsMenuOpen }"
+          :aria-label="t('Video.Live Chat Settings')"
+          :title="t('Video.Live Chat Settings')"
+          :aria-expanded="String(settingsMenuOpen)"
+          @click="settingsMenuOpen = !settingsMenuOpen"
+        >
+          <FontAwesomeIcon :icon="['fas', 'sliders-h']" />
+        </button>
+        <a
+          v-if="!isReplay"
+          :href="`https://www.youtube.com/live_chat?is_popout=1&v=${props.videoId}`"
+          :aria-label="t('Video.Popout Live Chat')"
+          :title="t('Video.Popout Live Chat')"
+          target="_blank"
+          class="liveChatActionButton"
+        >
+          <FontAwesomeIcon :icon="['fas', 'arrow-up-right-from-square']" />
+        </a>
+        <button
+          type="button"
+          class="liveChatActionButton"
+          :aria-label="closeButtonTitle"
+          :title="closeButtonTitle"
+          @click="emit('close')"
+        >
+          <FontAwesomeIcon :icon="['fas', 'xmark']" />
+        </button>
+        <div
+          v-if="settingsMenuOpen"
+          class="liveChatSettingsMenu"
+        >
+          <FtToggleSwitch
+            :label="t('Video.Show Live Chat Timestamps')"
+            :default-value="showLiveChatTimestamps"
+            :compact="true"
+            @change="updateShowLiveChatTimestamps"
+          />
+          <FtRadioButton
+            v-if="canFilter"
+            class="liveChatFilter"
+            :title="t('Video.Chat Filter')"
+            :labels="[t('Video.Top Chat'), t('Video.All Messages')]"
+            :values="['TOP_CHAT', 'LIVE_CHAT']"
+            :model-value="liveChatFilter"
+            @update:model-value="updateLiveChatFilter"
+          />
+        </div>
+      </div>
+    </div>
     <FtLoader
       v-if="isLoading"
     />
@@ -111,71 +181,6 @@
       v-else
       class="relative"
     >
-      <div
-        v-if="!fullscreenOverlay"
-        class="titleContainer"
-      >
-        <h4
-          class="title"
-        >
-          {{ isReplay ? t('Video.Live Chat Replay') : t('Video.Live Chat') }}
-          <span
-            v-if="!hideVideoViews && watchingCount !== null"
-            class="watchingCount"
-          >
-            {{ t('Global.Counts.Watching Count', { count: formattedWatchingCount }, watchingCount) }}
-          </span>
-        </h4>
-        <div
-          ref="liveChatActionsRef"
-          class="liveChatActions"
-          @keydown.esc.stop.prevent="settingsMenuOpen = false"
-        >
-          <button
-            type="button"
-            class="liveChatActionButton"
-            :class="{ active: settingsMenuOpen }"
-            :aria-label="t('Video.Live Chat Settings')"
-            :title="t('Video.Live Chat Settings')"
-            :aria-expanded="String(settingsMenuOpen)"
-            @click="settingsMenuOpen = !settingsMenuOpen"
-          >
-            <FontAwesomeIcon :icon="['fas', 'sliders-h']" />
-          </button>
-          <a
-            v-if="!isReplay"
-            :href="`https://www.youtube.com/live_chat?is_popout=1&v=${props.videoId}`"
-            :aria-label="t('Video.Popout Live Chat')"
-            :title="t('Video.Popout Live Chat')"
-            target="_blank"
-            class="liveChatActionButton"
-          >
-            <FontAwesomeIcon
-              :icon="['fas', 'arrow-up-right-from-square']"
-            />
-          </a>
-          <div
-            v-if="settingsMenuOpen"
-            class="liveChatSettingsMenu"
-          >
-            <FtToggleSwitch
-              :label="t('Video.Show Live Chat Timestamps')"
-              :default-value="showLiveChatTimestamps"
-              :compact="true"
-              @change="updateShowLiveChatTimestamps"
-            />
-            <FtRadioButton
-              v-if="canFilter"
-              class="liveChatFilter"
-              :title="t('Video.Chat Filter')"
-              :labels="[t('Video.Top Chat'), t('Video.All Messages')]"
-              :values="['TOP_CHAT', 'LIVE_CHAT']"
-              :model-value="liveChatFilter"
-              @update:model-value="updateLiveChatFilter"
-            />
-          </div>
-        </div>
-      </div>
       <div
         v-if="superChatComments.length > 0"
         v-overlay-scrollbars
@@ -483,7 +488,10 @@ const requestMoreReplayComments = createCoalescingPoller(async () => {
 })
 
 const isLoading = ref(true)
-const isReplay = ref(false)
+const isReplay = ref(Boolean(props.liveChat?.is_replay))
+const closeButtonTitle = computed(() => isReplay.value
+  ? t('Video.Close Live Chat Replay')
+  : t('Video.Close Live Chat'))
 const canFilter = ref(false)
 const hasError = ref(false)
 const showEnableChat = ref(false)

--- a/src/renderer/helpers/settings-migrations.js
+++ b/src/renderer/helpers/settings-migrations.js
@@ -14,5 +14,12 @@ export function migrateLegacySettings(settings) {
     delete migratedSettings.showSubscriptionRefreshToast
   }
 
+  if (
+    Object.hasOwn(migratedSettings, 'hideLiveChat') &&
+    !Object.hasOwn(migratedSettings, 'hideLiveChatReplay')
+  ) {
+    migratedSettings.hideLiveChatReplay = migratedSettings.hideLiveChat === true
+  }
+
   return migratedSettings
 }

--- a/src/renderer/store/modules/settings.js
+++ b/src/renderer/store/modules/settings.js
@@ -264,6 +264,7 @@ const state = {
   showAddedForbiddenTitles: true,
   hideVideoDescription: false,
   hideLiveChat: false,
+  hideLiveChatReplay: false,
   hideLiveStreams: false,
   hideHeaderLogo: false,
   hidePlaylists: false,
@@ -779,6 +780,8 @@ const customActions = {
       const hasScrollMiniSetting = userSettings.some(entry => entry._id === 'scrollMiniPlayerEnabled')
       const legacyProgressToastEntry = userSettings.find(entry => entry._id === 'showSubscriptionRefreshToast')
       const hasProgressToastSetting = userSettings.some(entry => entry._id === 'showProgressBarToast')
+      const legacyHideLiveChatEntry = userSettings.find(entry => entry._id === 'hideLiveChat')
+      const hasHideLiveChatReplaySetting = userSettings.some(entry => entry._id === 'hideLiveChatReplay')
 
       // Switch every existing installation to the new default once, while allowing
       // users to select the built-in engine again afterwards.
@@ -804,6 +807,12 @@ const customActions = {
 
       if (legacyProgressToastEntry && !hasProgressToastSetting) {
         await dispatch('updateShowProgressBarToast', legacyProgressToastEntry.value === true)
+      }
+
+      // Hide Live Chat covered both active chats and replays before the replay
+      // preference was split out. Preserve that choice for existing profiles.
+      if (legacyHideLiveChatEntry && !hasHideLiveChatReplaySetting) {
+        await dispatch('updateHideLiveChatReplay', legacyHideLiveChatEntry.value === true)
       }
 
       // Migrate the legacy auto Picture-in-Picture setting to the combinable triggers array.

--- a/src/renderer/views/Watch/Watch.js
+++ b/src/renderer/views/Watch/Watch.js
@@ -206,6 +206,7 @@ export default defineComponent({
       isPremiere: false,
       liveChat: null,
       liveChatIsReplay: false,
+      liveChatOpen: true,
       isLiveContent: false,
       isUpcoming: false,
       isPostLiveDvr: false,
@@ -757,8 +758,16 @@ export default defineComponent({
     hideLiveChat: function () {
       return this.$store.getters.getHideLiveChat
     },
+    hideLiveChatReplay: function () {
+      return this.$store.getters.getHideLiveChatReplay
+    },
+    liveChatAvailable: function () {
+      return this.liveChatIsReplay
+        ? !this.hideLiveChatReplay
+        : !this.hideLiveChat && (this.isLive || this.isUpcoming)
+    },
     showLiveChat: function () {
-      return !this.hideLiveChat && (this.isLive || this.isUpcoming || this.liveChatIsReplay)
+      return this.liveChatAvailable && this.liveChatOpen
     },
     // The player reports its position about four times a second, but a chat replay
     // buffers 20 seconds ahead and only cares about jumps of more than a few seconds.
@@ -1138,9 +1147,23 @@ export default defineComponent({
     handleFullscreenLiveChatChange({ open, target }) {
       this.fullscreenLiveChatTarget = open ? target : null
       this.fullscreenLiveChatOpen = open && target !== null
+      if (this.fullscreenLiveChatOpen) {
+        this.liveChatOpen = true
+      }
     },
     closeFullscreenLiveChat() {
       this.$refs.player?.closeFullscreenLiveChat()
+    },
+    closeLiveChat() {
+      this.liveChatOpen = false
+      this.closeFullscreenLiveChat()
+    },
+    toggleLiveChat() {
+      if (this.liveChatOpen) {
+        this.closeLiveChat()
+      } else {
+        this.liveChatOpen = true
+      }
     },
     closeFullscreenComments() {
       if (this.fullscreenCommentsOpen) {
@@ -1516,6 +1539,7 @@ export default defineComponent({
       this.isPremiere = false
       this.liveChat = null
       this.liveChatIsReplay = false
+      this.liveChatOpen = true
       this.isLiveContent = false
       this.isUpcoming = false
       this.isPostLiveDvr = false
@@ -2235,7 +2259,7 @@ export default defineComponent({
 
         // Streams that have ended keep their chat around as a replay, which is played back
         // in sync with the video instead of in real time.
-        if (!this.hideLiveChat && result.livechat && (this.isLive || this.isUpcoming || result.livechat.is_replay)) {
+        if (result.livechat && (this.isLive || this.isUpcoming || result.livechat.is_replay)) {
           this.liveChat = result.getLiveChat()
           this.liveChatIsReplay = this.liveChat.is_replay
         } else {

--- a/src/renderer/views/Watch/Watch.vue
+++ b/src/renderer/views/Watch/Watch.vue
@@ -137,7 +137,7 @@
           :delay-load-until-unix="adEndTimeUnixMs"
           :sponsor-block-auto-skip-disabled="sponsorBlockAutoSkipDisabled"
           :comments-available="commentsAvailable"
-          :live-chat-available="showLiveChat"
+          :live-chat-available="liveChatAvailable"
           :quick-bookmark-enabled="isQuickBookmarkEnabled"
           :quick-bookmarked="isCurrentVideoQuickBookmarked"
           :quick-bookmark-title="quickBookmarkIconText"
@@ -717,6 +717,9 @@
           :current-volume="currentVolume"
           :sponsor-block-panel-open="showSidebarSponsorBlock"
           :transcript-open="showTranscript"
+          :live-chat-available="liveChatAvailable"
+          :live-chat-open="showLiveChat"
+          :live-chat-replay="liveChatIsReplay"
           :hide-share-button="fullscreenMetadataOpen"
           :hide-playlist-actions="fullscreenMetadataOpen"
           :hide-fullscreen-dock-actions="fullscreenMetadataOpen"
@@ -731,6 +734,7 @@
           @save-channel-volume="handleChannelVolumeManualSave"
           @toggle-sponsorblock-info="toggleSponsorBlockInfo"
           @toggle-transcript="toggleTranscript"
+          @toggle-live-chat="toggleLiveChat"
         />
         <watch-video-description
           v-if="!isLoading && !hideVideoDescription && (!customShortsPlayerActive || fullscreenMetadataOpen)"
@@ -904,17 +908,24 @@
         :to="fullscreenLiveChatTarget || 'body'"
         :disabled="!fullscreenLiveChatOpen"
       >
-        <watch-video-live-chat
-          v-if="!isLoading && showLiveChat"
-          :live-chat="liveChat"
-          :video-id="videoId"
-          :channel-id="channelId"
-          :current-time="liveChatCurrentTime"
-          :fullscreen-overlay="fullscreenLiveChatOpen"
-          class="watchVideoSideBar watchVideoPlaylist"
-          :class="{ theatrePlaylist: useTheatreMode }"
-          @close="closeFullscreenLiveChat"
-        />
+        <transition
+          name="sidebar-panel"
+          @before-leave="handleSidebarPanelBeforeLeave"
+          @after-leave="handleSidebarPanelAfterLeave"
+          @leave-cancelled="handleSidebarPanelAfterLeave"
+        >
+          <watch-video-live-chat
+            v-if="!isLoading && showLiveChat"
+            :live-chat="liveChat"
+            :video-id="videoId"
+            :channel-id="channelId"
+            :current-time="liveChatCurrentTime"
+            :fullscreen-overlay="fullscreenLiveChatOpen"
+            class="watchVideoSideBar watchVideoPlaylist"
+            :class="{ theatrePlaylist: useTheatreMode }"
+            @close="closeLiveChat"
+          />
+        </transition>
       </Teleport>
       <watch-video-queue
         v-if="$store.getters.getWatchQueueLength > 0"

--- a/static/locales/en-US.yaml
+++ b/static/locales/en-US.yaml
@@ -891,6 +891,7 @@ Settings:
     Hide Popular Videos: Hide Popular Videos
     Hide Playlists: Hide Playlists
     Hide Live Chat: Hide Live Chat
+    Hide Live Chat Replay: Hide Live Chat Replay
     Hide Active Subscriptions: Hide Active Subscriptions
     Hide Video Description: Hide Video Description
     Hide Comments: Hide Comments
@@ -1402,6 +1403,10 @@ Video:
   Live Now: Live Now
   Live Chat: Live Chat
   Live Chat Replay: Live Chat Replay
+  Show Live Chat: Show Live Chat
+  Show Live Chat Replay: Show Live Chat Replay
+  Close Live Chat: Close Live Chat
+  Close Live Chat Replay: Close Live Chat Replay
   Live Chat Settings: Live chat settings
   Show Live Chat Timestamps: Show timestamps
   Chat Filter: Chat filter

--- a/tests/unit/settings-migrations.test.mjs
+++ b/tests/unit/settings-migrations.test.mjs
@@ -23,3 +23,20 @@ test('prefers the current progress notification preference', () => {
     showProgressBarToast: true,
   })
 })
+
+test('preserves the old live chat visibility choice for replays', () => {
+  assert.deepEqual(migrateLegacySettings({ hideLiveChat: true }), {
+    hideLiveChat: true,
+    hideLiveChatReplay: true,
+  })
+})
+
+test('prefers an explicit live chat replay visibility choice', () => {
+  assert.deepEqual(migrateLegacySettings({
+    hideLiveChat: true,
+    hideLiveChatReplay: false,
+  }), {
+    hideLiveChat: true,
+    hideLiveChatReplay: false,
+  })
+})


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Make sure to follow the contributing guidelines. -->
<!-- Important note, we may remove your pull request if you do not use this provided PR template correctly. -->
<!-- Agent instructions: Preserve every heading, comment, and marker in this template. Never remove or rewrite the release-note-category:start/end, release-note:start/end, or release-note-image:start/end marker pairs. Never remove or rewrite the Release note images section; leave its contents for a human. -->

## Pull Request Type
<!-- Please select what type of pull request this is: [x] -->
- [ ] Bugfix
- [x] Feature Implementation
- [ ] Documentation
- [ ] Other

## Related issue
<!-- Please link the issue your pull request is referring to. -->
<!-- If this pull request fully resolves the relevant issue, put "closes" before the issue number. -->
<!-- Example: "closes #123456". -->

Closes #617.

## Description
<!-- Please write a clear and concise description of what the pull request does. -->

Live chat replay previously shared the same distraction-free preference as active live chat, so users could not keep chat for a live event while hiding its replay afterward.

This adds an independent **Hide Live Chat Replay** preference. It also gives regular and fullscreen chat a close button that collapses the panel into the same message icon used by the fullscreen dock, allowing the chat to be restored from the actions below the player.

## Release note category
<!-- Select exactly one category. Every pull request must select one. -->
<!-- Select "Not noteworthy" when the pull request fixes a bug in or improves functionality that has not yet appeared in a stable release. -->
<!-- release-note-category:start -->
- [ ] Not noteworthy
- [ ] Highlights
- [x] More improvements
- [ ] Fixed bugs
<!-- release-note-category:end -->

## Release note
<!-- Required unless "Not noteworthy" is selected. -->
<!-- Write one concise, user-facing entry without a leading bullet. -->
<!-- release-note:start -->
Live chat and chat replay can now be hidden independently, and either chat panel can be collapsed and restored from below the player.
<!-- release-note:end -->

## Release note images
<!-- Human-only: Agents must preserve this entire section and leave it empty. -->
<!-- Optional. Paste one or more Markdown images or HTML image tags here. -->
<!-- The release notes will use an HTML image tag and limit images taller than 300 pixels. -->
<!-- release-note-image:start -->
<img width="244" height="82" alt="image" src="https://github.com/user-attachments/assets/f9dba87d-772e-43cf-89a1-b92c8007b441" />
<img width="1009" height="514" alt="Screencast_20260811_095129" src="https://github.com/user-attachments/assets/518ed977-cb4f-4197-bdcb-2278090a152f" />
<!-- release-note-image:end -->

## Testing
<!-- How can reviewers verify that the PR produces correct results? -->
<!-- Please provide instructions so that others can ensure that your pull request produces correct results. For examples see, https://github.com/FreeTubeApp/FreeTube/pull/5743, https://github.com/FreeTubeApp/FreeTube/pull/7349, https://github.com/FreeTubeApp/FreeTube/pull/5125, https://github.com/FreeTubeApp/FreeTube/pull/7338 -->
<!-- Agent instructions: Only write human-facing steps that explain how to verify the change while running this branch in dev mode. Include expected results and, when applicable, helpful console snippets for interactive verification. Do not include automated checks, commands, results, pass counts, or CI status. -->

1. Open **Settings → Distraction Free → Watch Page** and verify that **Hide Live Chat** and **Hide Live Chat Replay** are separate switches.
2. Open an active livestream or premiere. Verify that **Hide Live Chat** controls its chat while **Hide Live Chat Replay** does not.
3. Open a completed livestream or premiere with chat replay. Verify that **Hide Live Chat Replay** controls the replay while **Hide Live Chat** does not.
4. With either chat visible, click its X in the regular layout and in fullscreen. Verify that the panel closes and can be restored with the message icon below the player or in the fullscreen dock.

## Additional context
<!-- Add any other context about the pull request here. -->

Implemented with GPT-5 in the Codex desktop harness.