### PR TITLE
fix: keep Shorts information dock state across fullscreen

### DIFF
--- a/e2e/tests/offline/watch-page.spec.mjs
+++ b/e2e/tests/offline/watch-page.spec.mjs
@@ -467,7 +467,31 @@ test.describe('watch page', () => {
     await page.keyboard.press('Escape')
 
     await setPlayerFullscreen(page, true)
-    await expect(player.locator('.fullscreenMetadataOverlay.open')).toBeVisible()
+    const fullscreenMetadata = player.locator('.fullscreenMetadataOverlay.open')
+    await expect(fullscreenMetadata).toBeVisible()
+
+    await watchComponent.evaluate(component => {
+      component.proxy.$refs.player.setFullscreenTranscript(true)
+    })
+    const fullscreenTranscript = player.locator('.fullscreenTranscriptOverlay.open')
+    await expect(fullscreenTranscript).toBeVisible()
+    await fullscreenMetadata.locator('.fullscreenMetadataHeader').dblclick({
+      position: { x: 30, y: 26 }
+    })
+    await expect.poll(async () => (await fullscreenMetadata.boundingBox()).height)
+      .toBeLessThan(100)
+    await watchComponent.evaluate(component => {
+      component.proxy.$refs.player.setFullscreenTranscript(false)
+    })
+    await expect(fullscreenTranscript).toHaveCount(0)
+    await fullscreenMetadata.getByRole('button', { name: 'Close video information' }).click()
+    await player.locator('.shortsFullscreenTitleButton').click()
+    await watchComponent.evaluate(component => {
+      component.proxy.$refs.player.setFullscreenTranscript(true)
+    })
+    await expect.poll(async () => (await fullscreenMetadata.boundingBox()).height)
+      .toBeGreaterThan(150)
+
     await setPlayerFullscreen(page, false)
     await expect(auxPanel).toHaveClass(/shortsAuxPanelOpen/)
 

--- a/e2e/tests/offline/watch-page.spec.mjs
+++ b/e2e/tests/offline/watch-page.spec.mjs
@@ -428,6 +428,62 @@ test.describe('watch page', () => {
     await watchComponent.dispose()
   })
 
+  test('shares the Shorts information dock with fullscreen and keeps its settings menu visible', async ({ app, page }) => {
+    await mockPlayableWatchPage(app, page)
+    await page.locator(sel.searchInput).fill('https://www.youtube.com/shorts/jNQXAC9IVRw')
+    await page.locator(sel.searchInput).press('Enter')
+    await expect(page).toHaveURL(/#\/watch\/jNQXAC9IVRw\?short=true/)
+    await waitForPlayback(page)
+
+    const watchComponent = await page.evaluateHandle(findWatchComponent)
+    await watchComponent.evaluate(async (component) => {
+      await Promise.all([
+        component.proxy.$store.dispatch('updateRememberPlaybackSpeedPerChannel', true),
+        component.proxy.$store.dispatch('updateRememberVideoQualityPerChannel', true),
+      ])
+      await component.proxy.$nextTick()
+    })
+
+    const player = page.locator('.ftVideoPlayer.shortsPlayer')
+    const moreOptions = player.getByRole('button', { name: 'More Options' })
+    const overflowMenu = player.locator('.shaka-overflow-menu')
+    const auxPanel = page.locator('.shortsAuxPanel')
+
+    await moreOptions.click()
+    await overflowMenu.getByRole('button', { name: 'Video information' }).click()
+    await expect(auxPanel).toHaveClass(/shortsAuxPanelOpen/)
+
+    await auxPanel.getByRole('button', { name: /Save channel setting/i }).click()
+    const settingsMenu = page.locator('.app > .iconDropdown.portal')
+    await expect(settingsMenu).toBeVisible()
+    expect(await settingsMenu.evaluate(element => {
+      const bounds = element.getBoundingClientRect()
+      const hit = document.elementFromPoint(
+        bounds.left + bounds.width / 2,
+        bounds.top + bounds.height / 2
+      )
+      return element.contains(hit)
+    })).toBe(true)
+    await page.keyboard.press('Escape')
+
+    await setPlayerFullscreen(page, true)
+    await expect(player.locator('.fullscreenMetadataOverlay.open')).toBeVisible()
+    await setPlayerFullscreen(page, false)
+    await expect(auxPanel).toHaveClass(/shortsAuxPanelOpen/)
+
+    await auxPanel.getByRole('button', { name: 'Close video information' }).click()
+    await expect(auxPanel).not.toHaveClass(/shortsAuxPanelOpen/)
+
+    await setPlayerFullscreen(page, true)
+    await moreOptions.click({ force: true })
+    await overflowMenu.getByRole('button', { name: 'Video information' }).click()
+    await expect(player.locator('.fullscreenMetadataOverlay.open')).toBeVisible()
+    await setPlayerFullscreen(page, false)
+    await expect(auxPanel).toHaveClass(/shortsAuxPanelOpen/)
+
+    await watchComponent.dispose()
+  })
+
   test('sidebar chapters and SponsorBlock honor roundness while closing beside the description', async ({ app, page }) => {
     await mockPlayableWatchPage(app, page)
     await openMockedVideo(page)

--- a/src/renderer/components/WatchVideoInfo/WatchVideoInfo.vue
+++ b/src/renderer/components/WatchVideoInfo/WatchVideoInfo.vue
@@ -200,6 +200,7 @@
             :icon="['fas', 'floppy-disk']"
             :overlay-icon="channelSettingSaveActions.some(action => action.saved) ? ['fas', 'check'] : null"
             :dropdown-options="channelSettingSaveActions"
+            :dropdown-portal="channelSettingDropdownPortal"
             dropdown-position-x="left"
             @click="saveChannelSetting"
           />
@@ -489,6 +490,10 @@ const props = defineProps({
     default: false
   },
   hideFullscreenDockActions: {
+    type: Boolean,
+    default: false
+  },
+  channelSettingDropdownPortal: {
     type: Boolean,
     default: false
   },

--- a/src/renderer/components/ft-shaka-video-player/ft-shaka-video-player.js
+++ b/src/renderer/components/ft-shaka-video-player/ft-shaka-video-player.js
@@ -270,6 +270,10 @@ export default defineComponent({
       type: Boolean,
       default: false
     },
+    shortsMetadataOpen: {
+      type: Boolean,
+      default: false
+    },
     shortsAspectRatio: {
       type: Number,
       default: null
@@ -5665,8 +5669,9 @@ export default defineComponent({
     }
 
     function setFullscreenMetadata(shouldOpen) {
+      const presentationActive = isNativeFullscreenActive() || fullWindowEnabled.value
       const open = Boolean(
-        shouldOpen && (isNativeFullscreenActive() || fullWindowEnabled.value)
+        shouldOpen && presentationActive
       )
       showFullscreenMetadata.value = open
       if (fullscreenTitleOverlay) {
@@ -5674,7 +5679,8 @@ export default defineComponent({
       }
       emit('fullscreen-metadata-change', {
         open,
-        target: fullscreenMetadataTarget.value
+        target: fullscreenMetadataTarget.value,
+        presentationActive
       })
     }
 
@@ -5818,6 +5824,18 @@ export default defineComponent({
         closeFullscreenPlaylist()
       }
     })
+
+    watch(() => props.shortsMetadataOpen, open => {
+      if (!props.shortsPlayer) {
+        return
+      }
+
+      if (isNativeFullscreenActive() || fullWindowEnabled.value) {
+        setFullscreenMetadata(open)
+      } else {
+        restoreFullscreenMetadata = open
+      }
+    }, { immediate: true })
 
     watch(() => props.sidebarChaptersOpen, () => {
       if (!isNativeFullscreenActive() && !fullWindowEnabled.value) {

--- a/src/renderer/components/ft-shaka-video-player/ft-shaka-video-player.js
+++ b/src/renderer/components/ft-shaka-video-player/ft-shaka-video-player.js
@@ -5831,6 +5831,16 @@ export default defineComponent({
       }
 
       if (isNativeFullscreenActive() || fullWindowEnabled.value) {
+        const openDocks = getFullscreenOpenDocks('metadata')
+        if (open && openDocks.length === 1 && fullscreenDockCollapsedState.metadata != null) {
+          toggleFullscreenDockCollapsed(
+            openDocks,
+            'metadata',
+            fullscreenDockWeights,
+            fullscreenDockCollapsedState,
+            container.value.clientHeight
+          )
+        }
         setFullscreenMetadata(open)
       } else {
         restoreFullscreenMetadata = open

--- a/src/renderer/views/Watch/Watch.js
+++ b/src/renderer/views/Watch/Watch.js
@@ -1114,9 +1114,13 @@ export default defineComponent({
     updateShortsViewportHeight() {
       this.shortsViewportHeight = window.innerHeight
     },
-    handleFullscreenMetadataChange({ open, target }) {
+    handleFullscreenMetadataChange({ open, target, presentationActive = false }) {
       this.fullscreenMetadataTarget = target
       this.fullscreenMetadataOpen = open && target !== null
+
+      if (this.customShortsPlayerActive && presentationActive) {
+        this.shortsMetadataOpen = this.fullscreenMetadataOpen
+      }
 
       if (this.fullscreenMetadataOpen) {
         this.$nextTick(() => {

--- a/src/renderer/views/Watch/Watch.vue
+++ b/src/renderer/views/Watch/Watch.vue
@@ -148,6 +148,7 @@
           :sabr-reload-caption-index="sabrReloadCaptionIndex"
           :sabr-reload-playback-rate="sabrReloadPlaybackRate"
           :shorts-player="customShortsPlayerActive"
+          :shorts-metadata-open="shortsMetadataOpen"
           :shorts-aspect-ratio="videoAspectRatio"
           class="videoPlayer"
           @error="handlePlayerError"
@@ -226,7 +227,7 @@
                   dir="auto"
                   :aria-label="`${$t('Video.Metadata')}: ${videoTitle}`"
                   :aria-expanded="fullscreenMetadataOpen"
-                  @click="toggleFullscreenMetadata"
+                  @click="toggleShortsMetadata"
                 >
                   {{ videoTitle }}
                 </button>
@@ -599,6 +600,7 @@
             :current-volume="currentVolume"
             :sponsor-block-panel-open="showSidebarSponsorBlock"
             :transcript-open="showTranscript"
+            channel-setting-dropdown-portal
             hide-share-button
             hide-playlist-actions
             hide-fullscreen-dock-actions


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Make sure to follow the contributing guidelines. -->
<!-- Important note, we may remove your pull request if you do not use this provided PR template correctly. -->
<!-- Agent instructions: Preserve every heading, comment, and marker in this template. Never remove or rewrite the release-note-category:start/end, release-note:start/end, or release-note-image:start/end marker pairs. Never remove or rewrite the Release note images section; leave its contents for a human. -->

## Pull Request Type
<!-- Please select what type of pull request this is: [x] -->
- [x] Bugfix
- [ ] Feature Implementation
- [ ] Documentation
- [ ] Other

## Related issue
<!-- Please link the issue your pull request is referring to. -->
<!-- If this pull request fully resolves the relevant issue, put "closes" before the issue number. -->
<!-- Example: "closes #123456". -->

## Description
<!-- Please write a clear and concise description of what the pull request does. -->
The Shorts video information dock used separate normal and fullscreen state, so it could not be opened reliably in fullscreen and lost its state when presentation mode changed. Its channel-specific settings dropdown was also clipped by the non-fullscreen dock's overflow boundary.

This shares the Shorts information state with the player presentation mode, preserves it when entering or leaving fullscreen, and portals the channel-settings dropdown only from the non-fullscreen Shorts dock. A focused Electron regression test covers the state round trip and dropdown layering.

## Release note category
<!-- Select exactly one category. Every pull request must select one. -->
<!-- Select "Not noteworthy" when the pull request fixes a bug in or improves functionality that has not yet appeared in a stable release. -->
<!-- release-note-category:start -->
- [ ] Not noteworthy
- [ ] Highlights
- [ ] More improvements
- [x] Fixed bugs
<!-- release-note-category:end -->

## Release note
<!-- Required unless "Not noteworthy" is selected. -->
<!-- Write one concise, user-facing entry without a leading bullet. -->
<!-- release-note:start -->
Fixed the Shorts video information dock in fullscreen and prevented its channel-settings menu from being clipped.
<!-- release-note:end -->

## Release note images
<!-- Human-only: Agents must preserve this entire section and leave it empty. -->
<!-- Optional. Paste one or more Markdown images or HTML image tags here. -->
<!-- The release notes will use an HTML image tag and limit images taller than 300 pixels. -->
<!-- release-note-image:start -->

<!-- release-note-image:end -->

## Testing
<!-- How can reviewers verify that the PR produces correct results? -->
<!-- Please provide instructions so that others can ensure that your pull request would produce correct results. For examples see, https://github.com/FreeTubeApp/FreeTube/pull/5743, https://github.com/FreeTubeApp/FreeTube/pull/7349, https://github.com/FreeTubeApp/FreeTube/pull/5125, https://github.com/FreeTubeApp/FreeTube/pull/7338 -->
<!-- Agent instructions: Only write human-facing steps that explain how to verify the change while running this branch in dev mode. Include expected results and, when applicable, helpful console snippets for interactive verification. Do not include automated checks, commands, results, pass counts, or CI status. -->
1. Open a Short and use **More Options → Video information**. Confirm the dock opens.
2. Enable at least two manual per-channel playback settings, open the save-channel-setting menu in the dock, and confirm the whole menu remains visible above the dock card.
3. Enter fullscreen while the information dock is open. Confirm the fullscreen information dock opens automatically.
4. Leave fullscreen and confirm the non-fullscreen information dock remains open.
5. Close the dock, enter fullscreen, and open **More Options → Video information**. Confirm the fullscreen dock opens and remains open after returning to the normal view.

## Additional context
<!-- Add any other context about the pull request here. -->
