### PR TITLE
feat(profiles): let profiles follow the selected theme color

### DIFF
--- a/e2e/tests/offline/profiles.spec.mjs
+++ b/e2e/tests/offline/profiles.spec.mjs
@@ -112,10 +112,19 @@ test.describe('profile manager', () => {
 
       // switching the theme color has to repaint the profile, without touching the profile itself
       await expect(profileIconInitial(page)).toHaveCSS('background-color', 'rgb(76, 175, 80)')
-      await page.locator('.settingsBreadcrumb').getByRole('button', { name: 'Settings' }).click()
-      await page.locator('.settingsMenu [data-section="theme"]').click()
-      await page.getByRole('combobox', { name: 'Main Color Theme' }).click()
-      await page.locator('.selectDropdown').getByRole('option', { name: 'Blue', exact: true }).click()
+      // the narrow layout only shows the section menu after going back to it
+      const themeSection = page.locator('.settingsMenu [data-section="theme"]')
+      if (!await themeSection.isVisible()) await page.locator('.settingsBreadcrumbRoot').click()
+      await themeSection.click()
+
+      // the labels are translated, so find the main color select and its 'Blue'
+      // option through the values of the hidden native select instead
+      const mainColorSelect = page.locator('.settingsContent .select')
+        .filter({ has: page.locator('select option[value="Blue"]') })
+        .first()
+      const blueIndex = await mainColorSelect.locator('option[value="Blue"]').evaluate(option => option.index)
+      await mainColorSelect.getByRole('combobox').click()
+      await page.locator('.selectDropdown .selectOption').nth(blueIndex).click()
       await expect(profileIconInitial(page)).toHaveCSS('background-color', 'rgb(33, 150, 243)')
     })
   })

--- a/e2e/tests/offline/profiles.spec.mjs
+++ b/e2e/tests/offline/profiles.spec.mjs
@@ -112,7 +112,8 @@ test.describe('profile manager', () => {
 
       // switching the theme color has to repaint the profile, without touching the profile itself
       await expect(profileIconInitial(page)).toHaveCSS('background-color', 'rgb(76, 175, 80)')
-      await profileIcon(page).click()
+      await page.locator('.settingsBreadcrumb').getByRole('button', { name: 'Settings' }).click()
+      await page.locator('.settingsMenu [data-section="theme"]').click()
       await page.getByRole('combobox', { name: 'Main Color Theme' }).click()
       await page.locator('.selectDropdown').getByRole('option', { name: 'Blue', exact: true }).click()
       await expect(profileIconInitial(page)).toHaveCSS('background-color', 'rgb(33, 150, 243)')

--- a/e2e/tests/offline/profiles.spec.mjs
+++ b/e2e/tests/offline/profiles.spec.mjs
@@ -1,7 +1,7 @@
 import { readFile } from 'node:fs/promises'
 import path from 'node:path'
 
-import { test, expect } from '../../helpers/app.mjs'
+import { test, expect, goToSettingsSection } from '../../helpers/app.mjs'
 
 // The main profile ('allChannels') must exist in any seeded profiles.db,
 // otherwise the app would recreate the store with only the default profile.
@@ -110,12 +110,11 @@ test.describe('profile manager', () => {
         return profile?.bgColor
       }).toBe('var(--primary-color)')
 
-      // switching the theme color has to repaint the profile, without touching the profile itself
+      ;({ page } = await app.relaunch())
+      // the profile keeps the resolved theme color after restart
       await expect(profileIconInitial(page)).toHaveCSS('background-color', 'rgb(76, 175, 80)')
-      // the narrow layout only shows the section menu after going back to it
-      const themeSection = page.locator('.settingsMenu [data-section="theme"]')
-      if (!await themeSection.isVisible()) await page.locator('.settingsBreadcrumbRoot').click()
-      await themeSection.click()
+      // switching the theme color has to repaint the profile, without touching the profile itself
+      await goToSettingsSection(page, 'theme')
 
       // the labels are translated, so find the main color select and its 'Blue'
       // option through the values of the hidden native select instead

--- a/e2e/tests/offline/profiles.spec.mjs
+++ b/e2e/tests/offline/profiles.spec.mjs
@@ -88,6 +88,37 @@ test.describe('profile manager', () => {
     await expect(page.locator('.profileList .profileOption').filter({ hasText: 'Created via UI' })).toBeVisible()
   })
 
+  test.describe('theme color profiles', () => {
+    test.use({ seed: { settings: { mainColor: 'Green' } } })
+
+    test('follows the theme color when the theme color option is picked', async ({ app, page }) => {
+      await openProfileList(page)
+      await page.locator('.profilePanelHeader button').last().click()
+      await page.locator('.card .profileList').getByText('All Channels').click()
+
+      await page.locator('.themeColorOption').click()
+
+      // 'Green' is the seeded main color theme
+      const preview = page.locator('.profilePreviewIcon')
+      await expect(preview).toHaveCSS('background-color', 'rgb(76, 175, 80)')
+      await page.getByRole('button', { name: 'Update Profile' }).click()
+
+      await expect.poll(async () => {
+        const contents = await readFile(path.join(app.userDataDir, 'profiles.db'), 'utf8')
+        const records = contents.trim().split('\n').map(line => JSON.parse(line))
+        const profile = records.findLast(record => record._id === 'allChannels' && !record.$$deleted)
+        return profile?.bgColor
+      }).toBe('var(--primary-color)')
+
+      // switching the theme color has to repaint the profile, without touching the profile itself
+      await expect(profileIconInitial(page)).toHaveCSS('background-color', 'rgb(76, 175, 80)')
+      await profileIcon(page).click()
+      await page.getByRole('combobox', { name: 'Main Color Theme' }).click()
+      await page.locator('.selectDropdown').getByRole('option', { name: 'Blue', exact: true }).click()
+      await expect(profileIconInitial(page)).toHaveCSS('background-color', 'rgb(33, 150, 243)')
+    })
+  })
+
   test('customizes a profile icon with a cropped SVG or emoji', async ({ app, page }) => {
     await openProfileList(page)
     await page.locator('.profilePanelHeader button').last().click()

--- a/src/constants.js
+++ b/src/constants.js
@@ -550,6 +550,10 @@ const UnsupportedPlayerActions = /** @type {const} */({
 // Utils
 const MAIN_PROFILE_ID = 'allChannels'
 
+// Profile colors that follow the selected theme color instead of a fixed value
+const THEME_BG_COLOR = 'var(--primary-color)'
+const THEME_TEXT_COLOR = 'var(--text-with-main-color)'
+
 // Width threshold in px at which we switch to using a more heavily altered view for mobile users
 const MOBILE_WIDTH_THRESHOLD = 680
 
@@ -638,6 +642,8 @@ export {
   SPONSORBLOCK_ICON_VIEWBOX,
   UnsupportedPlayerActions,
   MAIN_PROFILE_ID,
+  THEME_BG_COLOR,
+  THEME_TEXT_COLOR,
   MOBILE_WIDTH_THRESHOLD,
   PLAYLIST_HEIGHT_FORCE_LIST_THRESHOLD,
   MULTIPLE_TABS_CONFIRM_THRESHOLD,

--- a/src/renderer/components/FtProfileEdit/FtProfileEdit.css
+++ b/src/renderer/components/FtProfileEdit/FtProfileEdit.css
@@ -167,6 +167,10 @@ h3 {
   outline-offset: 2px;
 }
 
+.themeColorOption {
+  background: var(--primary-color);
+}
+
 .transparentColorOption {
   background-color: #fff;
   background-image:

--- a/src/renderer/components/FtProfileEdit/FtProfileEdit.vue
+++ b/src/renderer/components/FtProfileEdit/FtProfileEdit.vue
@@ -336,8 +336,17 @@ onBeforeUnmount(() => {
   cropBitmap?.close?.()
 })
 
+// the color input can't handle a CSS variable, so it needs the resolved value,
+// which has to be refreshed whenever the theme changes the variable underneath it
+const themeColor = ref(resolveThemeColor())
+
+watch([() => store.getters.getMainColor, () => store.getters.getBaseTheme], async () => {
+  await nextTick()
+  themeColor.value = resolveThemeColor()
+})
+
 const customColorPickerValue = computed(() => {
-  if (profileBgColor.value === THEME_BG_COLOR) return resolveThemeColor()
+  if (profileBgColor.value === THEME_BG_COLOR) return themeColor.value
 
   return profileBgColor.value === 'transparent' ? '#000000' : profileBgColor.value
 })

--- a/src/renderer/components/FtProfileEdit/FtProfileEdit.vue
+++ b/src/renderer/components/FtProfileEdit/FtProfileEdit.vue
@@ -11,6 +11,7 @@
             <div
               class="colorOption themeColorOption"
               :class="{ selected: profileBgColor === THEME_BG_COLOR }"
+              :aria-pressed="profileBgColor === THEME_BG_COLOR"
               :title="$t('Profile.Theme Color')"
               tabindex="0"
               role="button"
@@ -22,6 +23,7 @@
               :key="color"
               class="colorOption"
               :class="{ selected: profileBgColor.toLowerCase() === color.toLowerCase() }"
+              :aria-pressed="profileBgColor.toLowerCase() === color.toLowerCase()"
               :title="color + ' ' + $t('Profile.Custom Color')"
               :style="{ background: color }"
               tabindex="0"
@@ -33,6 +35,7 @@
               v-if="profileIcon?.type === 'image'"
               class="colorOption transparentColorOption"
               :class="{ selected: profileBgColor === 'transparent' }"
+              :aria-pressed="profileBgColor === 'transparent'"
               :title="$t('Profile.Transparent')"
               tabindex="0"
               role="button"

--- a/src/renderer/components/FtProfileEdit/FtProfileEdit.vue
+++ b/src/renderer/components/FtProfileEdit/FtProfileEdit.vue
@@ -9,6 +9,15 @@
             class="colorOptions"
           >
             <div
+              class="colorOption themeColorOption"
+              :class="{ selected: profileBgColor === THEME_BG_COLOR }"
+              :title="$t('Profile.Theme Color')"
+              tabindex="0"
+              role="button"
+              @click="profileBgColor = THEME_BG_COLOR"
+              @keydown.enter.space.prevent="profileBgColor = THEME_BG_COLOR"
+            />
+            <div
               v-for="color in COLOR_VALUES"
               :key="color"
               class="colorOption"
@@ -43,7 +52,7 @@
           <FtInput
             class="colorSelection"
             placeholder=""
-            :value="profileBgColor"
+            :value="profileBgColorLabel"
             :show-action-button="false"
             :disabled="true"
           />
@@ -238,8 +247,8 @@ import FtProfileIcon from '../FtProfileIcon/FtProfileIcon.vue'
 
 import store from '../../store/index'
 
-import { MAIN_PROFILE_ID } from '../../../constants'
-import { calculateColorLuminance, colors, getRandomColor } from '../../helpers/colors'
+import { MAIN_PROFILE_ID, THEME_BG_COLOR, THEME_TEXT_COLOR } from '../../../constants'
+import { calculateColorLuminance, colors, resolveThemeColor } from '../../helpers/colors'
 import { deepCopy, showToast } from '../../helpers/utils'
 import { getFirstCharacter } from '../../helpers/strings'
 
@@ -289,7 +298,7 @@ const profileName = ref(props.profile.name)
 /** @type {import('vue').Ref<string>} */
 const profileBgColor = ref(props.profile.bgColor)
 const lastOpaqueProfileBgColor = ref(
-  props.profile.bgColor === 'transparent' ? getRandomColor().value : props.profile.bgColor
+  props.profile.bgColor === 'transparent' ? THEME_BG_COLOR : props.profile.bgColor
 )
 
 /** @type {import('vue').Ref<string>} */
@@ -309,7 +318,7 @@ let imageSelectionRequest = 0
 const EMOJI_OPTIONS = ['😀', '😎', '🤓', '🥳', '🤠', '👻', '🐱', '🐶', '🌈', '⭐']
 
 watch(profileBgColor, (value) => {
-  profileTextColor.value = calculateColorLuminance(value)
+  profileTextColor.value = value === THEME_BG_COLOR ? THEME_TEXT_COLOR : calculateColorLuminance(value)
   if (value !== 'transparent') lastOpaqueProfileBgColor.value = value
 })
 
@@ -328,7 +337,13 @@ onBeforeUnmount(() => {
 })
 
 const customColorPickerValue = computed(() => {
+  if (profileBgColor.value === THEME_BG_COLOR) return resolveThemeColor()
+
   return profileBgColor.value === 'transparent' ? '#000000' : profileBgColor.value
+})
+
+const profileBgColorLabel = computed(() => {
+  return profileBgColor.value === THEME_BG_COLOR ? t('Profile.Theme Color') : profileBgColor.value
 })
 
 const translatedProfileName = computed(() => {

--- a/src/renderer/helpers/colors.js
+++ b/src/renderer/helpers/colors.js
@@ -90,6 +90,15 @@ export const colors = [
   { name: 'SolarizedGreen', value: '#859900' },
 ]
 
+/**
+ * Resolves the currently selected theme color to a concrete value,
+ * for the places that can't use `THEME_BG_COLOR` directly.
+ * @returns {string}
+ */
+export function resolveThemeColor() {
+  return getComputedStyle(document.body).getPropertyValue('--primary-color').trim() || '#000000'
+}
+
 export function getRandomColorClass() {
   return 'main' + getRandomColor().name
 }

--- a/src/renderer/helpers/profile-sync.js
+++ b/src/renderer/helpers/profile-sync.js
@@ -1,15 +1,36 @@
+import { THEME_BG_COLOR, THEME_TEXT_COLOR } from '../../constants.js'
+
 const DEFAULT_PROFILE_BACKGROUND = '#000000'
+const DEFAULT_PROFILE_TEXT = '#FFFFFF'
+
+/** Backgrounds that only make sense locally, so they can't be sent to the sync server */
+function isLocalOnlyBackground(color) {
+  return color === 'transparent' || color === THEME_BG_COLOR
+}
 
 export function getSyncProfileBackground(color, fallback = DEFAULT_PROFILE_BACKGROUND) {
-  const opaqueFallback = fallback == null || fallback === 'transparent'
+  const opaqueFallback = fallback == null || isLocalOnlyBackground(fallback)
     ? DEFAULT_PROFILE_BACKGROUND
     : fallback
-  return color == null || color === 'transparent' ? opaqueFallback : color
+  return color == null || isLocalOnlyBackground(color) ? opaqueFallback : color
+}
+
+export function getSyncProfileTextColor(color, fallback = DEFAULT_PROFILE_TEXT) {
+  if (color !== THEME_TEXT_COLOR) return color
+
+  return fallback === THEME_TEXT_COLOR || fallback == null ? DEFAULT_PROFILE_TEXT : fallback
+}
+
+export function getMergedProfileTextColor(local, syncedTextColor) {
+  return local?.bgColor === THEME_BG_COLOR ? THEME_TEXT_COLOR : syncedTextColor
 }
 
 export function getMergedProfileBackground(local, syncedBackground) {
   const preserveLocalTransparency = local?.icon?.type === 'image' &&
     local.bgColor === 'transparent'
 
-  return preserveLocalTransparency ? 'transparent' : syncedBackground
+  if (preserveLocalTransparency) return 'transparent'
+
+  // the sync server can't represent the theme color, so a synced value must not overwrite it
+  return local?.bgColor === THEME_BG_COLOR ? THEME_BG_COLOR : syncedBackground
 }

--- a/src/renderer/helpers/sync-server.js
+++ b/src/renderer/helpers/sync-server.js
@@ -10,7 +10,12 @@ import {
 import { getSyncableSettingKeys } from '../store/modules/settings'
 import { deepCopy } from './utils'
 import { generateRandomUniqueId } from './playlists'
-import { getMergedProfileBackground, getSyncProfileBackground } from './profile-sync.js'
+import {
+  getMergedProfileBackground,
+  getMergedProfileTextColor,
+  getSyncProfileBackground,
+  getSyncProfileTextColor
+} from './profile-sync.js'
 
 const LEGACY_HISTORY_PAGE_SIZE = 50
 const BULK_SYNC_CHUNK_SIZE = 100
@@ -852,7 +857,7 @@ function profileMetadata(profile, fallback = {}) {
   return {
     title: profile.name,
     bgColor: getSyncProfileBackground(profile.bgColor, fallback.bgColor),
-    textColor: profile.textColor,
+    textColor: getSyncProfileTextColor(profile.textColor, fallback.textColor),
   }
 }
 
@@ -947,7 +952,7 @@ export async function syncProfiles(client, store, previous = {}, options = {}) {
       _id: id,
       name: metadata.title,
       bgColor: getMergedProfileBackground(local, metadata.bgColor),
-      textColor: metadata.textColor,
+      textColor: getMergedProfileTextColor(local, metadata.textColor),
       ...(local && Object.hasOwn(local, 'icon') ? { icon: local.icon } : {}),
       subscriptions: mergedSubscriptions,
     }

--- a/src/renderer/store/modules/profiles.js
+++ b/src/renderer/store/modules/profiles.js
@@ -1,14 +1,13 @@
-import { MAIN_PROFILE_ID } from '../../../constants'
+import { MAIN_PROFILE_ID, THEME_BG_COLOR, THEME_TEXT_COLOR } from '../../../constants'
 import { DBProfileHandlers } from '../../../datastores/handlers/index'
-import { calculateColorLuminance, getRandomColor } from '../../helpers/colors'
 import { deepCopy } from '../../helpers/utils'
 
 const state = {
   profileList: [{
     _id: MAIN_PROFILE_ID,
     name: 'All Channels',
-    bgColor: '#000000',
-    textColor: '#FFFFFF',
+    bgColor: THEME_BG_COLOR,
+    textColor: THEME_TEXT_COLOR,
     subscriptions: []
   }],
   activeProfile: MAIN_PROFILE_ID
@@ -77,13 +76,11 @@ const actions = {
 
     if (profiles.length === 0) {
       // Create a default profile and persist it
-      const randomColor = getRandomColor().value
-      const textColor = calculateColorLuminance(randomColor)
       const defaultProfile = {
         _id: MAIN_PROFILE_ID,
         name: defaultName,
-        bgColor: randomColor,
-        textColor: textColor,
+        bgColor: THEME_BG_COLOR,
+        textColor: THEME_TEXT_COLOR,
         subscriptions: []
       }
 

--- a/src/renderer/views/ProfileSettings/ProfileSettings.vue
+++ b/src/renderer/views/ProfileSettings/ProfileSettings.vue
@@ -64,8 +64,7 @@ import FtProfileFilterChannelsList from '../../components/FtProfileFilterChannel
 
 import store from '../../store/index'
 
-import { calculateColorLuminance, getRandomColor } from '../../helpers/colors'
-import { MAIN_PROFILE_ID } from '../../../constants'
+import { MAIN_PROFILE_ID, THEME_BG_COLOR, THEME_TEXT_COLOR } from '../../../constants'
 
 /**
  * @typedef {object} Profile
@@ -106,8 +105,8 @@ function openSettingsForNewProfile() {
 
   openSettingsProfile.value = {
     name: '',
-    bgColor: getRandomColor().value,
-    textColor: calculateColorLuminance(getRandomColor().value),
+    bgColor: THEME_BG_COLOR,
+    textColor: THEME_TEXT_COLOR,
     subscriptions: []
   }
 

--- a/static/locales/en-US.yaml
+++ b/static/locales/en-US.yaml
@@ -1207,6 +1207,7 @@ Profile:
   The selected image could not be loaded: The selected image could not be loaded
   Color Picker: Color Picker
   Custom Color: Custom Color
+  Theme Color: Theme Color
   Profile Preview: Profile Preview
   Create Profile: Create Profile
   Update Profile: Update Profile

--- a/tests/unit/profile-sync.test.mjs
+++ b/tests/unit/profile-sync.test.mjs
@@ -1,9 +1,12 @@
 import assert from 'node:assert/strict'
 import test from 'node:test'
 
+import { THEME_BG_COLOR, THEME_TEXT_COLOR } from '../../src/constants.js'
 import {
   getMergedProfileBackground,
-  getSyncProfileBackground
+  getMergedProfileTextColor,
+  getSyncProfileBackground,
+  getSyncProfileTextColor
 } from '../../src/renderer/helpers/profile-sync.js'
 
 test('syncs an opaque fallback for transparent profile backgrounds', () => {
@@ -23,4 +26,25 @@ test('keeps transparency whenever the local image is retained', () => {
   assert.equal(getMergedProfileBackground(imageProfile, '#000000'), 'transparent')
   assert.equal(getMergedProfileBackground(imageProfile, '#123456'), 'transparent')
   assert.equal(getMergedProfileBackground({ bgColor: 'transparent' }, '#000000'), '#000000')
+})
+
+test('syncs a concrete color instead of the theme color placeholders', () => {
+  assert.equal(getSyncProfileBackground(THEME_BG_COLOR), '#000000')
+  assert.equal(getSyncProfileBackground(THEME_BG_COLOR, THEME_BG_COLOR), '#000000')
+  assert.equal(getSyncProfileBackground(THEME_BG_COLOR, '#123456'), '#123456')
+
+  assert.equal(getSyncProfileTextColor(THEME_TEXT_COLOR), '#FFFFFF')
+  assert.equal(getSyncProfileTextColor(THEME_TEXT_COLOR, THEME_TEXT_COLOR), '#FFFFFF')
+  assert.equal(getSyncProfileTextColor(THEME_TEXT_COLOR, '#123456'), '#123456')
+  assert.equal(getSyncProfileTextColor('#123456'), '#123456')
+})
+
+test('keeps following the theme color when a synced color comes back', () => {
+  const themeProfile = { bgColor: THEME_BG_COLOR }
+
+  assert.equal(getMergedProfileBackground(themeProfile, '#123456'), THEME_BG_COLOR)
+  assert.equal(getMergedProfileTextColor(themeProfile, '#123456'), THEME_TEXT_COLOR)
+
+  assert.equal(getMergedProfileBackground({ bgColor: '#abcdef' }, '#123456'), '#123456')
+  assert.equal(getMergedProfileTextColor({ bgColor: '#abcdef' }, '#123456'), '#123456')
 })


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Make sure to follow the contributing guidelines. -->
<!-- Important note, we may remove your pull request if you do not use this provided PR template correctly. -->
<!-- Agent instructions: Preserve every heading, comment, and marker in this template. Never remove or rewrite the release-note-category:start/end, release-note:start/end, or release-note-image:start/end marker pairs. Never remove or rewrite the Release note images section; leave its contents for a human. -->

## Pull Request Type
<!-- Please select what type of pull request this is: [x] -->
- [ ] Bugfix
- [x] Feature Implementation
- [ ] Documentation
- [ ] Other

## Related issue
<!-- Please link the issue your pull request is referring to. -->
<!-- If this pull request fully resolves the relevant issue, put "closes" before the issue number. -->
<!-- Example: "closes #123456". -->
None

## Description
<!-- Please write a clear and concise description of what the pull request does. -->
Profile colors have always been a fixed value that is picked at random when the profile is created, so a profile never matches the theme color you selected, and there was no way to make it match other than manually hunting for the right hex value every time you change your theme.

This adds a "Theme Color" option to the profile color picker. Instead of copying the current theme color into the profile, it stores the CSS variable (`var(--primary-color)`, with `var(--text-with-main-color)` for the text) as the profile color. Because profile colors are already applied as inline styles, such a profile then follows the selected theme live — including when the theme color is changed later — without the profile record being touched.

Newly created profiles now default to the theme color instead of a random one. Existing profiles are deliberately left alone: nothing in the profile record says whether its color was ever user-chosen, so there is no way to tell an untouched random color apart from a deliberately picked one, and migrating them all would silently overwrite deliberate choices.

Two side notes:
- The sync server cannot represent a CSS variable, so a theme-colored profile syncs an opaque fallback color upstream (the same way a transparent profile already does), and a synced color never overwrites a locally theme-colored profile.
- This also fixes a small pre-existing bug in the first-launch profile creation, where the background color and the contrast text color were computed from two *different* random colors.

## Release note category
<!-- Select exactly one category. Every pull request must select one. -->
<!-- Select "Not noteworthy" when the pull request fixes a bug in or improves functionality that has not yet appeared in a stable release. -->
<!-- release-note-category:start -->
- [ ] Not noteworthy
- [ ] Highlights
- [x] More improvements
- [ ] Fixed bugs
<!-- release-note-category:end -->

## Release note
<!-- Required unless "Not noteworthy" is selected. -->
<!-- Write one concise, user-facing entry without a leading bullet. -->
<!-- release-note:start -->
Profiles can now use the selected theme color, which keeps them in sync whenever the theme color changes, and new profiles use it by default
<!-- release-note:end -->

## Release note images
<!-- Human-only: Agents must preserve this entire section and leave it empty. -->
<!-- Optional. Paste one or more Markdown images or HTML image tags here. -->
<!-- The release notes will use an HTML image tag and limit images taller than 300 pixels. -->
<!-- release-note-image:start -->
<img width="717" height="176" alt="image" src="https://github.com/user-attachments/assets/19b07ea5-18ff-4abc-ab69-f5c3b1458840" />
<!-- release-note-image:end -->

## Testing
<!-- How can reviewers verify that the PR produces correct results? -->
<!-- Please provide instructions so that others can ensure that your pull request would produce correct results. For examples see, https://github.com/FreeTubeApp/FreeTube/pull/5743, https://github.com/FreeTubeApp/FreeTube/pull/7349, https://github.com/FreeTubeApp/FreeTube/pull/5125, https://github.com/FreeTubeApp/FreeTube/pull/7338 -->
<!-- Agent instructions: Only write human-facing steps that explain how to verify the change while running this branch in dev mode. Include expected results and, when applicable, helpful console snippets for interactive verification. Do not include automated checks, commands, results, pass counts, or CI status. -->
1. Open Settings > Profile Manager and select any profile. The color picker now shows an extra swatch as its first entry, filled with the current theme color and titled "Theme Color". Pick it — the profile preview takes on the theme color, and the read-only color field below the picker shows "Theme Color" instead of a hex value. Save with "Update Profile".
2. Change the main color theme (quick settings menu, or Settings > Theme Settings > Main Color Theme). The profile you just saved changes color along with it, everywhere it is shown: the top-nav profile icon, the profile list, the profile manager and the subscribe button's profile dropdown. Restart the app to confirm it is still following the theme.
3. Switch the profile to any other swatch, a custom color from the color input, or (for a profile with an image icon) the transparent option. All of those still behave as before, and are unaffected by later theme color changes.
4. Create a new profile with "Create New Profile". It starts out on the theme color rather than a random one. Deleting your profile database and letting the app recreate the default "All Channels" profile also gives it the theme color.
5. Existing profiles are intentionally left untouched by this change: after updating, every profile you already had keeps exactly the color it had before, and only picks up the theme color if you select it yourself.

## Additional context
<!-- Add any other context about the pull request here. -->
For anyone with sync configured: a theme-colored profile still round-trips correctly. Because the sync server cannot store a CSS variable, an opaque fallback color is sent upstream, and syncing back does not knock the profile off the theme color.

Implemented by Claude Opus 5 (`claude-opus-5`) running in the Claude Code harness.
