### PR TITLE
fix: keep selected resolution after SABR reloads

### DIFF
--- a/e2e/tests/offline/sabr-error-recovery.spec.mjs
+++ b/e2e/tests/offline/sabr-error-recovery.spec.mjs
@@ -104,6 +104,56 @@ function driveWatchView(page, script, options = {}) {
   })
 }
 
+test('a SABR reload preserves the active video quality', async ({ app, page }) => {
+  await mockUnplayableWatchPage(app, page)
+  await goTo(page, 'history')
+  await page.getByText('SABR test video').click()
+  await expect(page).toHaveURL(/#\/watch\/jNQXAC9IVRw/)
+  await expect(page.locator('.errorMessage')).toBeVisible({ timeout: 30_000 })
+
+  const quality = await page.evaluate(async () => {
+    const app = document.querySelector('#app')?.__vue_app__
+
+    const findWatchView = (vnode) => {
+      if (vnode?.component?.type?.name === 'Watch') {
+        return vnode.component.proxy
+      }
+      if (vnode?.component?.subTree) {
+        const match = findWatchView(vnode.component.subTree)
+        if (match) return match
+      }
+      if (Array.isArray(vnode?.children)) {
+        for (const child of vnode.children) {
+          const match = findWatchView(child)
+          if (match) return match
+        }
+      }
+      return null
+    }
+
+    const watchView = findWatchView(app?._container?._vnode)
+    if (!watchView) {
+      throw new Error('Unable to access the watch view')
+    }
+
+    watchView.currentVideoQuality = '360'
+    watchView.getTimestamp = () => 0
+    watchView.reloadView = async () => {}
+    watchView.showTabToast = () => {}
+
+    await watchView.performSabrReload({ videoQuality: '720' }, 'Synthetic SABR reload')
+
+    // Metadata loading normally resets this to the configured default before
+    // initializeVideoQuality restores the state captured from the old player.
+    watchView.currentVideoQuality = '360'
+    watchView.initializeVideoQuality()
+
+    return watchView.currentVideoQuality
+  })
+
+  expect(quality).toBe('720')
+})
+
 test('a second SABR failure after successful playback refetches instead of dropping to legacy', async ({ app, page }) => {
   await mockUnplayableWatchPage(app, page)
   await goTo(page, 'history')

--- a/src/renderer/components/ft-shaka-video-player/ft-shaka-video-player.js
+++ b/src/renderer/components/ft-shaka-video-player/ft-shaka-video-player.js
@@ -67,6 +67,7 @@ import { setupSabrScheme } from '../../helpers/player/SabrSchemePlugin'
 import { getRememberedPlayerVolume, setRememberedPlayerVolume } from '../../helpers/player/volume-storage'
 import { parseChannelPreferences } from '../../helpers/channel-preferences'
 import { findLegacyFormatForQuality } from '../../helpers/player/legacyFormats'
+import { getDashQualityFromDimensions } from '../../helpers/player/videoQuality'
 import { shouldStartPaidPromotionTimer } from '../../helpers/player/paidPromotion'
 import { resolveSponsorBlockEnterTarget, resolveSponsorBlockEnterTargets } from '../../helpers/player/sponsorBlockShortcut'
 import { createSponsorBlockMuteController } from '../../helpers/player/sponsorBlockMute'
@@ -5071,7 +5072,8 @@ export default defineComponent({
         return null
       }
 
-      return getQualityFromDimensions(activeVariant.width, activeVariant.height)
+      const quality = getDashQualityFromDimensions(activeVariant.width, activeVariant.height)
+      return quality === null ? null : `${quality}`
     }
 
     /**
@@ -5096,11 +5098,7 @@ export default defineComponent({
       const isPortrait = variants[0].height > variants[0].width
 
       let matches = variants.filter(variant => {
-        const { width, height } = variant
-        const [primary, secondary] = isPortrait ? [width, height] : [height, width]
-        const aspectRatio = secondary / primary
-        const resolution = aspectRatio > 16 / 9 ? Math.round(secondary * 9 / 16) : primary
-        return quality === resolution
+        return quality === getDashQualityFromDimensions(variant.width, variant.height)
       })
 
       if (matches.length === 0) {

--- a/src/renderer/components/ft-shaka-video-player/ft-shaka-video-player.js
+++ b/src/renderer/components/ft-shaka-video-player/ft-shaka-video-player.js
@@ -5065,7 +5065,7 @@ export default defineComponent({
      * @returns {string | null}
      */
     function getActiveVariantQuality() {
-      const activeVariant = player.getVariantTracks().find(track => track.active)
+      const activeVariant = player?.getVariantTracks().find(track => track.active)
 
       if (!activeVariant) {
         return null
@@ -8618,7 +8618,8 @@ export default defineComponent({
       return {
         wasPlaying: !video.value?.paused,
         captionIndex: captionIndex >= 0 ? captionIndex : null,
-        playbackRate: getCurrentPlaybackRate()
+        playbackRate: getCurrentPlaybackRate(),
+        videoQuality: getActiveVariantQuality()
       }
     }
 

--- a/src/renderer/helpers/player/videoQuality.js
+++ b/src/renderer/helpers/player/videoQuality.js
@@ -1,0 +1,18 @@
+/**
+ * Returns the conventional resolution used to select a DASH variant.
+ * Ultrawide streams are represented by the height of their 16:9 equivalent.
+ *
+ * @param {number | undefined} width
+ * @param {number | undefined} height
+ * @returns {number | null}
+ */
+export function getDashQualityFromDimensions(width, height) {
+  if (typeof width !== 'number' || typeof height !== 'number') {
+    return null
+  }
+
+  const [primary, secondary] = height > width ? [width, height] : [height, width]
+  const aspectRatio = secondary / primary
+
+  return aspectRatio > 16 / 9 ? Math.round(secondary * 9 / 16) : primary
+}

--- a/src/renderer/views/Watch/Watch.js
+++ b/src/renderer/views/Watch/Watch.js
@@ -369,6 +369,8 @@ export default defineComponent({
       sabrReloadCaptionIndex: null,
       /** @type {number|null} */
       sabrReloadPlaybackRate: null,
+      /** @type {string|null} */
+      sabrReloadVideoQuality: null,
       preserveTitleOnNextReload: false,
       ipBlockDetectedInCurrentChain: false,
       ipBlockRecoveryAttemptedForCurrentVideo: false,
@@ -1618,6 +1620,7 @@ export default defineComponent({
       if (!preserveTitle) {
         this.sabrReloadCaptionIndex = null
         this.sabrReloadPlaybackRate = null
+        this.sabrReloadVideoQuality = null
         this.updateTitle()
       }
     },
@@ -4426,6 +4429,11 @@ export default defineComponent({
     },
 
     initializeVideoQuality() {
+      if (this.sabrReloadVideoQuality !== null) {
+        this.currentVideoQuality = this.sabrReloadVideoQuality
+        return
+      }
+
       const rememberPerChannel = this.$store.getters.getRememberVideoQualityPerChannel
       if (rememberPerChannel && this.channelId) {
         try {
@@ -4511,6 +4519,8 @@ export default defineComponent({
       this.sabrReloadPlaybackRate = Number.isFinite(playbackRate) && playbackRate > 0.07
         ? playbackRate
         : this.currentPlaybackRate
+      this.sabrReloadVideoQuality = this.normalizeVideoQuality(payload?.videoQuality) ||
+        this.normalizeVideoQuality(this.currentVideoQuality) || null
       this.preserveTitleOnNextReload = true
       this.showTabToast({ message: toastMessage, icon: ['fas', 'sync'] })
 

--- a/tests/unit/video-quality.test.mjs
+++ b/tests/unit/video-quality.test.mjs
@@ -1,0 +1,19 @@
+import assert from 'node:assert/strict'
+import test from 'node:test'
+
+import { getDashQualityFromDimensions } from '../../src/renderer/helpers/player/videoQuality.js'
+
+test('uses the shorter dimension for standard landscape and portrait streams', () => {
+  assert.equal(getDashQualityFromDimensions(1920, 1080), 1080)
+  assert.equal(getDashQualityFromDimensions(1080, 1920), 1080)
+})
+
+test('uses the 16:9-equivalent resolution for ultrawide streams', () => {
+  assert.equal(getDashQualityFromDimensions(2560, 1080), 1440)
+  assert.equal(getDashQualityFromDimensions(1080, 2560), 1440)
+})
+
+test('rejects dimensions that are not available yet', () => {
+  assert.equal(getDashQualityFromDimensions(undefined, 1080), null)
+  assert.equal(getDashQualityFromDimensions(1920, undefined), null)
+})


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Make sure to follow the contributing guidelines. -->
<!-- Important note, we may remove your pull request if you do not use this provided PR template correctly. -->
<!-- Agent instructions: Preserve every heading, comment, and marker in this template. Never remove or rewrite the release-note-category:start/end, release-note:start/end, or release-note-image:start/end marker pairs. Never remove or rewrite the Release note images section; leave its contents for a human. -->

## Pull Request Type
<!-- Please select what type of pull request this is: [x] -->
- [x] Bugfix
- [ ] Feature Implementation
- [ ] Documentation
- [ ] Other

## Related issue
<!-- Please link the issue your pull request is referring to. -->
<!-- If this pull request fully resolves the relevant issue, put "closes" before the issue number. -->
<!-- Example: "closes #123456". -->

Closes #636.

## Description
<!-- Please write a clear and concise description of what the pull request does. -->

A manually selected video resolution was replaced by the configured default whenever SABR refreshed the playback session.

The outgoing player now includes its active resolution in the SABR reload state. The Watch view retains that value while refreshed metadata loads and uses it instead of reinitializing playback from the default quality. The active-quality lookup also tolerates Shaka already being torn down.

## Release note category
<!-- Select exactly one category. Every pull request must select one. -->
<!-- Select "Not noteworthy" when the pull request fixes a bug in or improves functionality that has not yet appeared in a stable release. -->
<!-- release-note-category:start -->
- [ ] Not noteworthy
- [ ] Highlights
- [ ] More improvements
- [x] Fixed bugs
<!-- release-note-category:end -->

## Release note
<!-- Required unless "Not noteworthy" is selected. -->
<!-- Write one concise, user-facing entry without a leading bullet. -->
<!-- release-note:start -->
Manually selected video resolutions now remain selected after SABR reloads the player.
<!-- release-note:end -->

## Release note images
<!-- Human-only: Agents must preserve this entire section and leave it empty. -->
<!-- Optional. Paste one or more Markdown images or HTML image tags here. -->
<!-- The release notes will use an HTML image tag and limit images taller than 300 pixels. -->
<!-- release-note-image:start -->

<!-- release-note-image:end -->

## Testing
<!-- How can reviewers verify that the PR produces correct results? -->
<!-- Please provide instructions so that others can ensure that your pull request would produce correct results. For examples see, https://github.com/FreeTubeApp/FreeTube/pull/5743, https://github.com/FreeTubeApp/OpenTubeX/pull/7349, https://github.com/FreeTubeApp/OpenTubeX/pull/5125, https://github.com/FreeTubeApp/OpenTubeX/pull/7338 -->
<!-- Agent instructions: Only write human-facing steps that explain how to verify the change while running this branch in dev mode. Include expected results and, when applicable, helpful console snippets for interactive verification. Do not include automated checks, commands, results, pass counts, or CI status. -->

1. Start a video that uses the built-in playback engine and select a resolution different from the configured default.
2. Let SABR request a player reload.
3. Confirm the refreshed player resumes at the selected resolution rather than returning to the default.

## Additional context
<!-- Add any other context about the pull request here. -->

The resolution is preserved through the same reload-state flow that already restores playback, captions, and playback speed.
