### PR TITLE
feat(playlists): support grid layout for remote playlists

### DIFF
--- a/e2e/tests/network/playlist.spec.mjs
+++ b/e2e/tests/network/playlist.spec.mjs
@@ -17,8 +17,10 @@ test('loads playlists containing members-only videos', async ({ page, innertube 
   await expect(page.locator('.playlistTitle')).toContainText(MEMBERS_ONLY_PLAYLIST.title, {
     timeout: 30_000
   })
+  await expect(page.locator('.playlistPage')).toHaveClass(/grid/)
+  await expect(page.locator('.playlistItemsCard .autoGrid')).toHaveClass(/grid/)
   await expect.poll(
-    () => page.locator('.playlistItems .playlistItem').count(),
+    () => page.locator('.playlistItemsCard .autoGrid > .grid').count(),
     { timeout: 30_000 }
   ).toBeGreaterThan(20)
 })

--- a/src/renderer/views/Playlist/Playlist.vue
+++ b/src/renderer/views/Playlist/Playlist.vue
@@ -278,7 +278,7 @@ const sortOrder = computed(() => isUserPlaylistRequested.value ? userPlaylistSor
 const playlistId = computed(() => route.params.id)
 
 /** @type {import('vue').ComputedRef<'grid' | 'list'>} */
-const listType = computed(() => isUserPlaylistRequested.value && !forceListView.value ? store.getters.getListType : 'list')
+const listType = computed(() => !forceListView.value ? store.getters.getListType : 'list')
 
 /** @type {import('vue').ComputedRef<boolean>} */
 const userPlaylistsReady = computed(() => store.getters.getPlaylistsReady)

--- a/src/renderer/views/Playlist/Playlist.vue
+++ b/src/renderer/views/Playlist/Playlist.vue
@@ -75,6 +75,7 @@
           <FtElementList
             v-if="listType === 'grid'"
             :data="visiblePlaylistItems"
+            data-type="video"
             display="grid"
             :playlist-id="playlistId"
             :playlist-type="infoSource"


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Make sure to follow the contributing guidelines. -->
<!-- Important note, we may remove your pull request if you do not use this provided PR template correctly. -->
<!-- Agent instructions: Preserve every heading, comment, and marker in this template. Never remove or rewrite the release-note-category:start/end, release-note:start/end, or release-note-image:start/end marker pairs. Never remove or rewrite the Release note images section; leave its contents for a human. -->

## Pull Request Type
<!-- Please select what type of pull request this is: [x] -->
- [ ] Bugfix
- [x] Feature Implementation
- [ ] Documentation
- [ ] Other

## Related issue
<!-- Please link the issue your pull request is referring to. -->
<!-- If this pull request fully resolves the relevant issue, put "closes" before the issue number. -->
<!-- Example: "closes #123456". -->

Closes #545.

## Description
<!-- Please write a clear and concise description of what the pull request does. -->

Remote playlist pages were always forced into the numbered list layout, even when the global video view type was set to Grid. This change lets remote playlists follow the same Grid/List preference as user playlists while preserving the existing compact-window fallback to list view.

The network playlist regression coverage now verifies that remote playlist videos render as grid cards when Grid is selected.

## Release note category
<!-- Select exactly one category. Every pull request must select one. -->
<!-- Select "Not noteworthy" when the pull request fixes a bug in or improves functionality that has not yet appeared in a stable release. -->
<!-- release-note-category:start -->
- [ ] Not noteworthy
- [ ] Highlights
- [x] More improvements
- [ ] Fixed bugs
<!-- release-note-category:end -->

## Release note
<!-- Required unless "Not noteworthy" is selected. -->
<!-- Write one concise, user-facing entry without a leading bullet. -->
<!-- release-note:start -->
Playlist pages now support the selected grid layout.
<!-- release-note:end -->

## Release note images
<!-- Human-only: Agents must preserve this entire section and leave it empty. -->
<!-- Optional. Paste one or more Markdown images or HTML image tags here. -->
<!-- The release notes will use an HTML image tag and limit images taller than 300 pixels. -->
<!-- release-note-image:start -->
<img width="1663" height="981" alt="image" src="https://github.com/user-attachments/assets/0f299571-aeba-4eb6-912e-582459586053" />
<!-- release-note-image:end -->

## Testing
<!-- How can reviewers verify that the PR produces correct results? -->
<!-- Please provide instructions so that others can ensure that your pull request would produce correct results. For examples see, https://github.com/FreeTubeApp/FreeTube/pull/5743, https://github.com/FreeTubeApp/FreeTube/pull/7349, https://github.com/FreeTubeApp/FreeTube/pull/5125, https://github.com/FreeTubeApp/FreeTube/pull/7338 -->
<!-- Agent instructions: Only write human-facing steps that explain how to verify the change while running this branch in dev mode. Include expected results and, when applicable, helpful console snippets for interactive verification. Do not include automated checks, commands, results, pass counts, or CI status. -->

1. Set the video view type to Grid.
2. Open a remote YouTube playlist and confirm its videos render as grid cards.
3. Change the video view type to List and confirm the same playlist uses the numbered list.
4. Resize the window below the existing compact-layout threshold and confirm the playlist falls back to the list layout.

## Additional context
<!-- Add any other context about the pull request here. -->

Implemented by GPT-5 using the Codex desktop harness.