### PR TITLE
feat(settings): flag settings that cost performance

### DIFF
--- a/e2e/tests/offline/settings.spec.mjs
+++ b/e2e/tests/offline/settings.spec.mjs
@@ -2542,6 +2542,10 @@ test.describe('synced setting indicators', () => {
 })
 
 test.describe('performance impact indicators', () => {
+  // Pinned because the labels matched below are worded differently in the other
+  // English locales, which is what the runner's system locale can resolve to
+  test.use({ seed: { settings: { currentLocale: 'en-US' } } })
+
   test('only shows the badges once they are switched on', async ({ app }) => {
     const { page } = app
     const section = await goToSettingsSection(page, 'sponsor-block')
@@ -2574,6 +2578,7 @@ test.describe('performance impact indicators on selects', () => {
   test.use({
     seed: {
       settings: {
+        currentLocale: 'en-US',
         showPerformanceImpactIndicators: true
       }
     }

--- a/e2e/tests/offline/settings.spec.mjs
+++ b/e2e/tests/offline/settings.spec.mjs
@@ -2540,3 +2540,59 @@ test.describe('synced setting indicators', () => {
     })).toBe(true)
   })
 })
+
+test.describe('performance impact indicators', () => {
+  test('only shows the badges once they are switched on', async ({ app }) => {
+    const { page } = app
+    const section = await goToSettingsSection(page, 'sponsor-block')
+
+    await expect(section.locator('.performanceImpact')).toHaveCount(0)
+
+    await page.getByRole('button', { name: 'Show performance impact indicators' }).click()
+
+    const sponsorBlock = section.locator('.switch-ctn')
+      .filter({ hasText: 'Enable SponsorBlock' })
+    const deArrowThumbnails = section.locator('.switch-ctn')
+      .filter({ hasText: 'Use DeArrow for thumbnails' })
+    await expect(sponsorBlock.locator('.performanceImpact')).toHaveText('Moderate impact')
+    await expect(deArrowThumbnails.locator('.performanceImpact')).toHaveText('High impact')
+    // Settings without a notable cost stay unlabelled, so that the badges keep meaning something
+    await expect(section.locator('.switch-ctn')
+      .filter({ hasText: 'Enable SponsorBlock Submission' })
+      .locator('.performanceImpact')).toHaveCount(0)
+
+    await expect.poll(async () => {
+      const settings = latestSettings(
+        await readFile(path.join(app.userDataDir, 'settings.db'), 'utf8')
+      )
+      return settings.showPerformanceImpactIndicators
+    }).toBe(true)
+  })
+})
+
+test.describe('performance impact indicators on selects', () => {
+  test.use({
+    seed: {
+      settings: {
+        showPerformanceImpactIndicators: true
+      }
+    }
+  })
+
+  test('keeps the badge inside the select it belongs to', async ({ page }) => {
+    const section = await goToSettingsSection(page, 'player')
+
+    const defaultQuality = section.locator('.select')
+      .filter({ has: page.getByText('Default Quality', { exact: true }) })
+    const badge = defaultQuality.locator('.performanceImpact')
+    await expect(badge).toBeVisible()
+
+    // The label floats above the select and never wraps, so a badge that is too
+    // wide reaches into whichever setting sits in the next column
+    const [selectBox, badgeBox] = await Promise.all([
+      defaultQuality.boundingBox(),
+      badge.boundingBox()
+    ])
+    expect(badgeBox.x + badgeBox.width).toBeLessThanOrEqual(selectBox.x + selectBox.width)
+  })
+})

--- a/src/renderer/components/FtPerformanceImpact/FtPerformanceImpact.vue
+++ b/src/renderer/components/FtPerformanceImpact/FtPerformanceImpact.vue
@@ -1,10 +1,13 @@
 <template>
+  <!-- The role is what makes the label reach assistive technology: on a plain
+       span it would be dropped, leaving the compact badge with no text at all -->
   <span
     v-if="impact"
     class="performanceImpact"
     :class="[impact.level, { compact }]"
+    role="img"
     :title="title"
-    :aria-label="compact ? title : null"
+    :aria-label="fullText"
   >
     <FontAwesomeIcon :icon="['fas', impact.level === 'high' ? 'gauge-high' : 'gauge']" />
     <span
@@ -76,10 +79,10 @@ const description = computed(() => {
   return t('Settings.Performance Impact.Description', { resources })
 })
 
-// The level is only spelled out in the hover text when the badge doesn't show it
-const title = computed(() => props.compact
-  ? `${label.value}: ${description.value}`
-  : description.value)
+const fullText = computed(() => `${label.value}: ${description.value}`)
+
+// The level is only repeated in the hover text when the badge doesn't show it
+const title = computed(() => props.compact ? fullText.value : description.value)
 </script>
 
 <style scoped>

--- a/src/renderer/components/FtPerformanceImpact/FtPerformanceImpact.vue
+++ b/src/renderer/components/FtPerformanceImpact/FtPerformanceImpact.vue
@@ -1,0 +1,122 @@
+<template>
+  <span
+    v-if="impact"
+    class="performanceImpact"
+    :class="[impact.level, { compact }]"
+    :title="title"
+    :aria-label="compact ? title : null"
+  >
+    <FontAwesomeIcon :icon="['fas', impact.level === 'high' ? 'gauge-high' : 'gauge']" />
+    <span
+      v-if="!compact"
+      class="performanceImpactLabel"
+    >{{ label }}</span>
+  </span>
+</template>
+
+<script setup>
+import { FontAwesomeIcon } from '@fortawesome/vue-fontawesome'
+import { computed } from 'vue'
+import { useI18n } from 'vue-i18n'
+
+import { getSettingPerformanceImpact } from '../../helpers/settingsPerformanceImpact'
+import store from '../../store/index'
+
+const props = defineProps({
+  settingKey: {
+    type: String,
+    default: ''
+  },
+  /**
+   * Drops the level text and keeps only the icon, for labels that have no room
+   * to grow, such as the absolutely positioned label of a select.
+   */
+  compact: {
+    type: Boolean,
+    default: false
+  }
+})
+
+const { locale, t } = useI18n()
+
+const impact = computed(() => store.getters.getShowPerformanceImpactIndicators
+  ? getSettingPerformanceImpact(props.settingKey)
+  : null)
+
+const label = computed(() => impact.value?.level === 'high'
+  ? t('Settings.Performance Impact.High')
+  : t('Settings.Performance Impact.Moderate'))
+
+/**
+ * Spelled out instead of interpolating the key, as the linter rightly rejects
+ * dynamic translation keys.
+ * @param {import('../../helpers/settingsPerformanceImpact').PerformanceImpactResource} resource
+ */
+function resourceLabel(resource) {
+  switch (resource) {
+    case 'CPU':
+      return t('Settings.Performance Impact.Resources.CPU')
+    case 'GPU':
+      return t('Settings.Performance Impact.Resources.GPU')
+    case 'Memory':
+      return t('Settings.Performance Impact.Resources.Memory')
+    case 'Network':
+      return t('Settings.Performance Impact.Resources.Network')
+    case 'Disk':
+      return t('Settings.Performance Impact.Resources.Disk')
+  }
+}
+
+const description = computed(() => {
+  if (impact.value == null) { return '' }
+
+  const resources = new Intl.ListFormat(locale.value, { style: 'long', type: 'conjunction' })
+    .format(impact.value.resources.map(resourceLabel))
+
+  return t('Settings.Performance Impact.Description', { resources })
+})
+
+// The level is only spelled out in the hover text when the badge doesn't show it
+const title = computed(() => props.compact
+  ? `${label.value}: ${description.value}`
+  : description.value)
+</script>
+
+<style scoped>
+.performanceImpact {
+  align-items: center;
+  background-color: color-mix(in srgb, var(--impact-color) 12%, transparent);
+  border: 1px solid color-mix(in srgb, var(--impact-color) 35%, transparent);
+  border-radius: calc(10px * var(--ui-roundness));
+  color: color-mix(in srgb, var(--impact-color) 70%, var(--primary-text-color));
+  cursor: help;
+  display: inline-flex;
+  font-size: 0.7em;
+  font-weight: 600;
+  gap: 4px;
+  /* Symmetric, as the badge sits between the label and the tooltip or sync icons */
+  margin-inline: 6px;
+  padding-block: 1px;
+  padding-inline: 6px;
+  text-transform: uppercase;
+  vertical-align: middle;
+  white-space: nowrap;
+}
+
+.compact {
+  background-color: transparent;
+  border: 0;
+  color: var(--impact-color);
+  font-size: 0.85em;
+  margin-inline: 4px;
+  padding: 0;
+}
+
+.moderate {
+  --impact-color: #d98e00;
+}
+
+.high {
+  --impact-color: var(--destructive-color);
+}
+</style>

--- a/src/renderer/components/FtSelect/FtSelect.vue
+++ b/src/renderer/components/FtSelect/FtSelect.vue
@@ -66,6 +66,10 @@
       />
       <span class="select-label-text">
         {{ placeholder }}
+        <FtPerformanceImpact
+          compact
+          :setting-key="settingKey"
+        />
         <FtSyncedSettingIndicator
           v-if="tooltip === ''"
           :setting-key="settingKey"
@@ -132,6 +136,7 @@ import { FontAwesomeIcon } from '@fortawesome/vue-fontawesome'
 import { computed, nextTick, onBeforeUnmount, ref, shallowRef, useId, useTemplateRef, watch } from 'vue'
 
 import FtTooltip from '../FtTooltip/FtTooltip.vue'
+import FtPerformanceImpact from '../FtPerformanceImpact/FtPerformanceImpact.vue'
 import FtSyncedSettingIndicator from '../FtSyncedSettingIndicator/FtSyncedSettingIndicator.vue'
 
 const props = defineProps({

--- a/src/renderer/components/FtSlider/FtSlider.vue
+++ b/src/renderer/components/FtSlider/FtSlider.vue
@@ -7,6 +7,7 @@
       <span class="label">
         {{ $t('Display Label', {label: label, value: displayLabel}) }}
       </span>
+      <FtPerformanceImpact :setting-key="settingKey" />
       <FtTooltip
         v-if="tooltip !== ''"
         class="selectTooltip"
@@ -37,6 +38,7 @@
 import { computed, ref, useId, watch } from 'vue'
 
 import FtTooltip from '../FtTooltip/FtTooltip.vue'
+import FtPerformanceImpact from '../FtPerformanceImpact/FtPerformanceImpact.vue'
 import FtSyncedSettingIndicator from '../FtSyncedSettingIndicator/FtSyncedSettingIndicator.vue'
 
 const props = defineProps({

--- a/src/renderer/components/FtToggleSwitch/FtToggleSwitch.vue
+++ b/src/renderer/components/FtToggleSwitch/FtToggleSwitch.vue
@@ -24,6 +24,7 @@
       <span class="switch-label-text">
         {{ label }}
       </span>
+      <FtPerformanceImpact :setting-key="settingKey" />
       <FtTooltip
         v-if="tooltip !== ''"
         class="selectTooltip"
@@ -40,6 +41,7 @@
 import { ref, useId, watch } from 'vue'
 
 import FtTooltip from '../FtTooltip/FtTooltip.vue'
+import FtPerformanceImpact from '../FtPerformanceImpact/FtPerformanceImpact.vue'
 import FtSyncedSettingIndicator from '../FtSyncedSettingIndicator/FtSyncedSettingIndicator.vue'
 
 const props = defineProps({

--- a/src/renderer/helpers/settingsPerformanceImpact.js
+++ b/src/renderer/helpers/settingsPerformanceImpact.js
@@ -1,0 +1,53 @@
+/**
+ * Settings that noticeably add work when they are enabled, so that the UI can warn
+ * about the cost before someone turns them on. Settings that are not listed here are
+ * treated as having no impact worth mentioning, keeping the badges rare enough to
+ * still mean something.
+ *
+ * `moderate` is for extra requests or timers that most machines will not feel,
+ * `high` is for continuous work that is noticeable on weaker hardware.
+ *
+ * @typedef {'moderate' | 'high'} PerformanceImpactLevel
+ * @typedef {'CPU' | 'GPU' | 'Memory' | 'Network' | 'Disk'} PerformanceImpactResource
+ * @typedef {{ level: PerformanceImpactLevel, resources: PerformanceImpactResource[] }} PerformanceImpact
+ */
+
+/** @type {Map<string, PerformanceImpact>} */
+const SETTING_PERFORMANCE_IMPACTS = new Map([
+  // draws and blurs the video's own frames behind the player, every frame
+  ['ambientMode', { level: 'high', resources: ['GPU', 'CPU'] }],
+  // every thumbnail is fetched from the DeArrow generator instead of coming with the video's metadata
+  ['useDeArrowThumbnails', { level: 'high', resources: ['Network'] }],
+
+  ['useDeArrowTitles', { level: 'moderate', resources: ['Network'] }],
+  ['useSponsorBlock', { level: 'moderate', resources: ['Network'] }],
+  ['useReturnYouTubeDislikes', { level: 'moderate', resources: ['Network'] }],
+  ['enableSearchSuggestions', { level: 'moderate', resources: ['Network'] }],
+  ['enableCaptionTranslations', { level: 'moderate', resources: ['Network'] }],
+  ['fetchSubscriptionsAutomatically', { level: 'moderate', resources: ['Network'] }],
+  ['showNewSubscriptionFeedIndicators', { level: 'moderate', resources: ['Network'] }],
+  // keeps loading pages as you scroll, so the list in memory never stops growing
+  ['generalAutoLoadMorePaginatedItemsEnabled', { level: 'moderate', resources: ['Memory', 'Network'] }],
+  // re-renders every visible timestamp on a timer
+  ['updateRelativeTimestamps', { level: 'moderate', resources: ['CPU'] }],
+  // screenshots of the tabs are captured and cached on disk
+  ['showTabPreviews', { level: 'moderate', resources: ['Memory', 'Disk'] }],
+
+  // the feeds keep being fetched in the background while the app is open
+  ['subscriptionFeedAutoRefreshInterval', { level: 'moderate', resources: ['Network'] }],
+  ['subscriptionShortsAutoRefreshInterval', { level: 'moderate', resources: ['Network'] }],
+  ['subscriptionLiveAutoRefreshInterval', { level: 'moderate', resources: ['Network'] }],
+  ['subscriptionPostsAutoRefreshInterval', { level: 'moderate', resources: ['Network'] }],
+  // higher resolutions cost bandwidth and are more work to decode
+  ['defaultQuality', { level: 'moderate', resources: ['Network', 'CPU'] }],
+  // segments are downloaded ahead of playback and kept around until they are needed
+  ['segmentPrefetchLimit', { level: 'moderate', resources: ['Network', 'Memory'] }]
+])
+
+/**
+ * @param {string} settingKey
+ * @returns {PerformanceImpact | null}
+ */
+export function getSettingPerformanceImpact(settingKey) {
+  return SETTING_PERFORMANCE_IMPACTS.get(settingKey) ?? null
+}

--- a/src/renderer/store/modules/settings.js
+++ b/src/renderer/store/modules/settings.js
@@ -438,6 +438,7 @@ const state = {
   screenshotFilenamePattern: '%Y%M%D-%H%N%S',
   settingsSectionSortEnabled: false,
   highlightChangedSettings: false,
+  showPerformanceImpactIndicators: false,
   fetchSubscriptionsAutomatically: true,
   showNewSubscriptionFeed: true,
   showNewSubscriptionFeedIndicators: false,

--- a/src/renderer/views/Settings/Settings.vue
+++ b/src/renderer/views/Settings/Settings.vue
@@ -153,6 +153,18 @@
           <FontAwesomeIcon :icon="['fas', 'pen']" />
         </button>
         <button
+          v-if="!isAboutOpen"
+          type="button"
+          class="settingsHeaderButton"
+          :class="{ active: showPerformanceImpactIndicators }"
+          :aria-label="t('Settings.Performance Impact.Show Performance Impact')"
+          :title="t('Settings.Performance Impact.Show Performance Impact')"
+          :aria-pressed="showPerformanceImpactIndicators"
+          @click="updateShowPerformanceImpactIndicators(!showPerformanceImpactIndicators)"
+        >
+          <FontAwesomeIcon :icon="['fas', 'gauge-high']" />
+        </button>
+        <button
           type="button"
           class="settingsHeaderButton"
           :aria-label="maximizeButtonLabel"
@@ -407,6 +419,7 @@ const maximizeButtonLabel = computed(() => isMaximized.value ? t('Restore') : t(
 
 const settingsSectionSortEnabled = computed(() => store.getters.getSettingsSectionSortEnabled)
 const highlightChangedSettings = computed(() => store.getters.getHighlightChangedSettings)
+const showPerformanceImpactIndicators = computed(() => store.getters.getShowPerformanceImpactIndicators)
 const isProfileManagerOpen = computed(() => store.getters.getSettingsWindowView === 'profile')
 const isAboutOpen = computed(() => store.getters.getSettingsWindowView === 'about')
 const isKeyboardShortcutPromptOpen = computed(() => store.getters.getIsKeyboardShortcutPromptShown)
@@ -955,6 +968,10 @@ function showKeyboardShortcutPrompt() {
 
 function updateSettingsSectionSortEnabled(value) {
   store.dispatch('updateSettingsSectionSortEnabled', value)
+}
+
+function updateShowPerformanceImpactIndicators(value) {
+  store.dispatch('updateShowPerformanceImpactIndicators', value)
 }
 
 function updateHighlightChangedSettings(value) {

--- a/static/locales/en-US.yaml
+++ b/static/locales/en-US.yaml
@@ -378,6 +378,17 @@ Settings:
   Sort Settings Sections (A-Z): Sort Settings Sections (A-Z)
   Highlight Changed Settings: Highlight settings changed from defaults
   Reset Setting to Default: Reset this setting to its default
+  Performance Impact:
+    Show Performance Impact: Show performance impact indicators
+    Moderate: Moderate impact
+    High: High impact
+    Description: This setting can increase {resources} usage
+    Resources:
+      CPU: CPU
+      GPU: GPU
+      Memory: memory
+      Network: network
+      Disk: disk
   Return to Settings Menu: Return to Settings Menu
   The app needs to restart for changes to take effect. Restart and apply change?: The
     app needs to restart for changes to take effect. Restart and apply change?


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Make sure to follow the contributing guidelines. -->
<!-- Important note, we may remove your pull request if you do not use this provided PR template correctly. -->
<!-- Agent instructions: Preserve every heading, comment, and marker in this template. Never remove or rewrite the release-note-category:start/end, release-note:start/end, or release-note-image:start/end marker pairs. Never remove or rewrite the Release note images section; leave its contents for a human. -->

## Pull Request Type
<!-- Please select what type of pull request this is: [x] -->
- [ ] Bugfix
- [x] Feature Implementation
- [ ] Documentation
- [ ] Other

## Related issue
<!-- Please link the issue your pull request is referring to. -->
<!-- If this pull request fully resolves the relevant issue, put "closes" before the issue number. -->
<!-- Example: "closes #123456". -->
Part of #560

## Description
<!-- Please write a clear and concise description of what the pull request does. -->
A setting's name rarely says what it costs. Someone browsing the settings has no way to tell that DeArrow thumbnails means one extra request per tile in every grid, or that ambient mode redraws the video's own frames behind the player, so features that are noticeable on weaker hardware get switched on without any warning.

This adds a small badge next to those settings. It states the level (moderate or high) and, on hover, which resources it costs: "This setting can increase network and CPU usage".

Because that would be noise for anyone who does not care, the badges are **off by default** and are switched on with a new gauge button in the settings header, next to the A-Z sort and "highlight changed settings" buttons.

Only settings that measurably add work are listed, so the badges stay rare enough to still mean something:

| Level | Setting | Cost |
| --- | --- | --- |
| High | Ambient mode | GPU, CPU |
| High | Use DeArrow for thumbnails | Network |
| Moderate | DeArrow titles, SponsorBlock, Return YouTube Dislike, search suggestions, caption translations, automatic subscription fetching, new subscription indicators, subscription auto refresh intervals | Network |
| Moderate | Automatically load more items | Memory, Network |
| Moderate | Keep relative timestamps updated | CPU |
| Moderate | Tab previews | Memory, Disk |
| Moderate | Default quality | Network, CPU |
| Moderate | Segment prefetch limit | Network, Memory |

Implementation notes:

- The badge keys off the `settingKey` prop that the setting controls already pass, so it was a one-line addition to `FtToggleSwitch`, `FtSelect` and `FtSlider` rather than a change at every call site. Adding a setting later is one entry in `settingsPerformanceImpact.js`.
- A select's label floats above the control and never wraps, so a full badge there reaches into whichever setting sits in the next column. Selects therefore get a `compact` variant that is just the coloured icon, with the level moved into the hover text.
- The badge colours are mixed from the theme's own text colour, so they work in every theme rather than only the dark ones.

## Release note category
<!-- Select exactly one category. Every pull request must select one. -->
<!-- Select "Not noteworthy" when the pull request fixes a bug in or improves functionality that has not yet appeared in a stable release. -->
<!-- release-note-category:start -->
- [ ] Not noteworthy
- [ ] Highlights
- [x] More improvements
- [ ] Fixed bugs
<!-- release-note-category:end -->

## Release note
<!-- Required unless "Not noteworthy" is selected. -->
<!-- Write one concise, user-facing entry without a leading bullet. -->
<!-- release-note:start -->
Settings that cost noticeable performance can now be marked with an impact badge, switched on with the gauge button in the settings header
<!-- release-note:end -->

## Release note images
<!-- Human-only: Agents must preserve this entire section and leave it empty. -->
<!-- Optional. Paste one or more Markdown images or HTML image tags here. -->
<!-- The release notes will use an HTML image tag and limit images taller than 300 pixels. -->
<!-- release-note-image:start -->
<img width="225" height="82" alt="image" src="https://github.com/user-attachments/assets/3f213b72-7169-4bd9-b675-2be303ff8b64" />
<img width="348" height="32" alt="image" src="https://github.com/user-attachments/assets/9d195ab1-fb29-4770-aabf-e2c945a1bcd2" />
<!-- release-note-image:end -->

## Testing
<!-- How can reviewers verify that the PR produces correct results? -->
<!-- Please provide instructions so that others can ensure that your pull request would produce correct results. For examples see, https://github.com/FreeTubeApp/FreeTube/pull/5743, https://github.com/FreeTubeApp/FreeTube/pull/7349, https://github.com/FreeTubeApp/FreeTube/pull/5125, https://github.com/FreeTubeApp/FreeTube/pull/7338 -->
<!-- Agent instructions: Only write human-facing steps that explain how to verify the change while running this branch in dev mode. Include expected results and, when applicable, helpful console snippets for interactive verification. Do not include automated checks, commands, results, pass counts, or CI status. -->
1. Open the settings window. Nothing should look different from before: no badges anywhere.
2. Click the new gauge button in the header, between the pen and the maximize button.
3. Go to the SponsorBlock section. "Enable SponsorBlock" now carries an amber "Moderate impact" badge and "Use DeArrow for thumbnails" a red "High impact" one, while the other toggles stay bare. Hovering a badge explains which resources it costs.
4. Go to the Player section. "Default Quality" shows the compact icon-only badge inside its own label, without reaching into the setting in the next column. Hovering it names the level as well.
5. Switch themes (including a light one) and confirm the badge stays readable, then click the gauge button again and confirm every badge disappears and stays gone after a restart.

## Additional context
<!-- Add any other context about the pull request here. -->
This only covers the "performance indicators" point of #560; the navigation, layout and description points are untouched, so the issue stays open.

Two things I deliberately left out, happy to add either if wanted:
- No "improves performance" badge for the distraction-free settings that *reduce* work (hiding comments, recommended videos, live chat), even though there is a case for it.
- The badge is a property of the control, not of its current value, so "Default quality" shows it even when set to 360p. Making it value-aware needs per-setting logic.

---
*Written by Claude Opus 5 in Claude Code, driven by Nico.*
