### PR TITLE
feat(downloads): download subtitles on their own

### DIFF
--- a/e2e/tests/offline/subscriptions-feed.spec.mjs
+++ b/e2e/tests/offline/subscriptions-feed.spec.mjs
@@ -1,4 +1,5 @@
 import { test, expect, goTo } from '../../helpers/app.mjs'
+import { IpcChannels } from '../../../src/constants.js'
 
 const now = Date.now()
 const HOUR = 3_600_000
@@ -290,6 +291,30 @@ test.describe('subscriptions feed with upcoming premieres shown', () => {
     await reminderButton.click()
     await expect(upcomingPremiere.getByRole('button', { name: 'Notification on' }))
       .toHaveAttribute('aria-pressed', 'true')
+  })
+
+  test('cleans up repeated live-reminder subscriptions independently', async ({ app, page }) => {
+    await page.evaluate(() => {
+      window.liveReminderUpdates = 0
+      const handler = () => { window.liveReminderUpdates++ }
+      window.removeFirstLiveReminderSubscription = window.ftElectron.liveReminder.onUpdated(handler)
+      window.removeSecondLiveReminderSubscription = window.ftElectron.liveReminder.onUpdated(handler)
+    })
+
+    const sendUpdate = () => app.electronApp.evaluate(({ BrowserWindow }, channel) => {
+      BrowserWindow.getAllWindows()[0].webContents.send(channel, 'video-id', true)
+    }, IpcChannels.LIVE_REMINDER_UPDATED)
+
+    await sendUpdate()
+    await expect.poll(() => page.evaluate(() => window.liveReminderUpdates)).toBe(2)
+
+    await page.evaluate(() => window.removeFirstLiveReminderSubscription())
+    await sendUpdate()
+    await expect.poll(() => page.evaluate(() => window.liveReminderUpdates)).toBe(3)
+
+    await page.evaluate(() => window.removeSecondLiveReminderSubscription())
+    await sendUpdate()
+    await expect.poll(() => page.evaluate(() => window.liveReminderUpdates)).toBe(3)
   })
 
   test('does not render adjacent separators in the upcoming-video menu', async ({ page }) => {

--- a/e2e/tests/offline/video-actions.spec.mjs
+++ b/e2e/tests/offline/video-actions.spec.mjs
@@ -373,6 +373,38 @@ test.describe('video downloads', () => {
       '/tmp/subtitles.de.srt'
     ])
   })
+
+  test('keeps the source subtitle destination when conversion fails', async ({ app, page }) => {
+    const executable = path.join(app.userDataDir, 'fake-yt-dlp.sh')
+    await writeFile(executable, [
+      '#!/bin/sh',
+      'printf "[info] Writing video subtitles to: /tmp/subtitles.en.vtt\\n"',
+      'printf "Subtitle conversion failed\\n" >&2',
+      'sleep 0.2',
+      'exit 1'
+    ].join('\n'))
+    await chmod(executable, 0o755)
+    await page.evaluate(async (ytDlpPath) => {
+      const store = document.querySelector('#app').__vue_app__.config.globalProperties.$store
+      await store.dispatch('updateYtDlpPath', ytDlpPath)
+    }, executable)
+
+    await goTo(page, 'history')
+    const video = page.locator('.ft-list-video').first()
+    await video.hover()
+    await video.locator('.optionsButton').click()
+    await page.getByRole('option', { name: 'Download Video' }).click()
+    await page.getByRole('combobox', { name: 'Template' }).click()
+    await page.getByRole('listbox', { name: 'Template' })
+      .getByRole('option', { name: 'Subtitles - SRT', exact: true }).click()
+    await page.getByRole('button', { name: 'Download', exact: true }).click()
+    await expect(page.getByText('Download failed', { exact: true })).toBeVisible()
+
+    await page.getByRole('button', { name: 'Close', exact: true }).click()
+    await goTo(page, 'downloads')
+    const downloadRow = page.locator('.downloadRow').filter({ hasText: 'Bookmarkable video' })
+    await expect(downloadRow.locator('.destination')).toHaveText('/tmp/subtitles.en.vtt')
+  })
 })
 
 test('asks for confirmation before removing a downloaded file', async ({ page }) => {

--- a/e2e/tests/offline/video-actions.spec.mjs
+++ b/e2e/tests/offline/video-actions.spec.mjs
@@ -318,6 +318,61 @@ test.describe('video downloads', () => {
     await goTo(relaunchedPage, 'downloads')
     await expect(relaunchedPage.getByText('Bookmarkable video', { exact: true })).toBeVisible()
   })
+
+  test('downloads subtitles on their own and lists the files they wrote', async ({ app, page }) => {
+    const executable = path.join(app.userDataDir, 'fake-yt-dlp.sh')
+    const argumentsFile = path.join(app.userDataDir, 'yt-dlp-arguments.txt')
+    // yt-dlp announces subtitle files on stdout instead of the `--print` output
+    await writeFile(executable, [
+      '#!/bin/sh',
+      `printf '%s\\n' "$@" > ${argumentsFile}`,
+      'printf "[info] Writing video subtitles to: /tmp/subtitles.en.srt\\n"',
+      'printf "[info] Writing video subtitles to: /tmp/subtitles.de.srt\\n"'
+    ].join('\n'))
+    await chmod(executable, 0o755)
+    await page.evaluate(async (ytDlpPath) => {
+      const store = document.querySelector('#app').__vue_app__.config.globalProperties.$store
+      await store.dispatch('updateYtDlpPath', ytDlpPath)
+    }, executable)
+
+    await goTo(page, 'history')
+    const video = page.locator('.ft-list-video').first()
+    await video.hover()
+    await video.locator('.optionsButton').click()
+    await page.getByRole('option', { name: 'Download Video' }).click()
+
+    // the prompt animates in with a scale transform, so measure the layout box
+    const promptCard = page.locator('.downloadPromptCard')
+    const heightWithVideoOptions = await promptCard.evaluate(card => card.offsetHeight)
+
+    const templateSelect = page.getByRole('combobox', { name: 'Template' })
+    await templateSelect.click()
+    await page.getByRole('listbox', { name: 'Template' })
+      .getByRole('option', { name: 'Subtitles - SRT', exact: true }).click()
+    await expect(page.getByRole('combobox', { name: 'Subtitle Format' })).toContainText('SRT')
+    // hiding the options that don't apply to subtitles would resize the modal
+    expect(await promptCard.evaluate(card => card.offsetHeight)).toBe(heightWithVideoOptions)
+
+    await page.getByRole('button', { name: 'Download', exact: true }).click()
+    await expect(page.getByText('Download complete', { exact: true })).toBeVisible()
+
+    const passedArguments = (await readFile(argumentsFile, 'utf8')).split('\n')
+    expect(passedArguments).toContain('--skip-download')
+    // `--print` implies quiet mode, which would hide the written subtitle files
+    expect(passedArguments).toContain('--no-quiet')
+    expect(passedArguments).toContain('srt/best')
+    expect(passedArguments).toContain('youtube:skip=translated_subs')
+    expect(passedArguments).not.toContain('--embed-subs')
+
+    await page.getByRole('button', { name: 'Close', exact: true }).click()
+    await goTo(page, 'downloads')
+    const downloadRow = page.locator('.downloadRow').filter({ hasText: 'Bookmarkable video' })
+    await expect(downloadRow.locator('.downloadSummary')).toHaveText('Subtitles • Template: Subtitles - SRT')
+    await expect(downloadRow.locator('.destination')).toHaveText([
+      '/tmp/subtitles.en.srt',
+      '/tmp/subtitles.de.srt'
+    ])
+  })
 })
 
 test('asks for confirmation before removing a downloaded file', async ({ page }) => {

--- a/src/main/ytDlp.js
+++ b/src/main/ytDlp.js
@@ -1416,6 +1416,8 @@ export async function handleYtDlpDownload(event, payload) {
 
   /** @type {string[]} */
   const stderrLines = []
+  /** @type {Set<string>} */
+  const subtitleDestinations = new Set()
 
   /**
    * @param {string} line
@@ -1430,10 +1432,8 @@ export async function handleYtDlpDownload(event, payload) {
 
     const subtitleMatch = SUBTITLE_DESTINATION_REGEX.exec(line)
     if (subtitleMatch) {
-      // `--convert-subs` replaces the written file with one that only differs in its extension
-      const subtitlePath = subtitleFormat === ''
-        ? subtitleMatch[1]
-        : subtitleMatch[1].replace(/\.[^.]+$/, `.${subtitleFormat}`)
+      const subtitlePath = subtitleMatch[1]
+      subtitleDestinations.add(subtitlePath)
       status.destination = subtitlePath
       if (!status.destinations.includes(subtitlePath)) status.destinations.push(subtitlePath)
       sendStatus(true)
@@ -1514,6 +1514,16 @@ export async function handleYtDlpDownload(event, payload) {
     if (entry.cancelled) {
       status.status = 'cancelled'
     } else if (code === 0) {
+      if (subtitleFormat !== '') {
+        const convertedSubtitleDestinations = new Map([...subtitleDestinations].map((subtitlePath) => [
+          subtitlePath,
+          subtitlePath.replace(/\.[^.]+$/, `.${subtitleFormat}`)
+        ]))
+        status.destinations = status.destinations.map((destination) => (
+          convertedSubtitleDestinations.get(destination) ?? destination
+        ))
+        status.destination = convertedSubtitleDestinations.get(status.destination) ?? status.destination
+      }
       status.status = 'completed'
       status.percent = 100
     } else {

--- a/src/main/ytDlp.js
+++ b/src/main/ytDlp.js
@@ -38,7 +38,7 @@ function takeGetInfoAbortSignal(key) {
  * @property {boolean} [isPlaylist]
  * @property {string} [title] only used for display purposes in the renderer
  * @property {string} [thumbnail] only used for display purposes in the renderer
- * @property {'video' | 'audio' | 'custom'} mode
+ * @property {'video' | 'audio' | 'subtitles' | 'custom'} mode
  * @property {string} [quality] maximum video resolution e.g. '1080'
  * @property {string} [videoFormat] e.g. 'mp4'
  * @property {string} [audioFormat] e.g. 'mp3'
@@ -52,9 +52,11 @@ function takeGetInfoAbortSignal(key) {
  * @property {boolean} [includeSubtitles]
  * @property {boolean} [embedSubtitles]
  * @property {string} [subtitleLanguages]
+ * @property {string} [subtitleFormat] e.g. 'srt'
  * @property {boolean} [embedThumbnail]
  * @property {boolean} [embedMetadata]
  * @property {string} [customArgs] additional yt-dlp command line arguments
+ * @property {string} [template] the template the options came from, only used for display purposes
  */
 
 /**
@@ -65,6 +67,8 @@ function takeGetInfoAbortSignal(key) {
  * @property {string} playlistKey
  * @property {string} title
  * @property {string} thumbnail
+ * @property {'video' | 'audio' | 'subtitles' | 'custom'} mode
+ * @property {string} template
  * @property {'downloading' | 'processing' | 'completed' | 'failed' | 'cancelled'} status
  * @property {number} percent
  * @property {string | null} speed
@@ -80,6 +84,7 @@ const QUALITY_REGEX = /^\d{3,4}$/
 const VIDEO_FORMATS = ['mp4', 'mkv', 'webm']
 const VIDEO_CODECS = ['h264', 'h265', 'vp9', 'av1']
 const AUDIO_FORMATS = ['mp3', 'm4a', 'opus', 'flac']
+const SUBTITLE_FORMATS = ['srt', 'vtt', 'ass', 'lrc']
 const SPONSORBLOCK_CATEGORIES = ['sponsor', 'intro', 'outro', 'selfpromo', 'interaction', 'music_offtopic', 'preview', 'filler']
 // Keeps local-playlist URLs comfortably below Windows' process command-line limit.
 const MAX_LOCAL_PLAYLIST_VIDEOS = 500
@@ -106,6 +111,8 @@ const YT_DLP_RELEASE_REPOSITORIES = {
 const PROGRESS_REGEX = /^\[download\]\s+(\d+(?:\.\d+)?)%(?:.*?\bat\s+(\S+))?(?:.*?\bETA\s+(\S+))?/
 const DESTINATION_REGEX = /^\[(?:download|ExtractAudio)\] Destination: (.+)$/
 const MERGER_REGEX = /^\[Merger\] Merging formats into "(.+)"$/
+// yt-dlp doesn't include subtitle files in its `after_move:%(filepath)s` output
+const SUBTITLE_DESTINATION_REGEX = /^\[info\] Writing video subtitles to: (.+)$/
 const FINAL_PATH_PREFIX = '__OPENTUBEX_FILE__:'
 
 let downloadCounter = 0
@@ -1168,9 +1175,14 @@ export async function handleYtDlpDownload(event, payload) {
     return null
   }
 
-  if (!['video', 'audio', 'custom'].includes(payload.mode)) {
+  if (!['video', 'audio', 'subtitles', 'custom'].includes(payload.mode)) {
     return null
   }
+
+  const subtitlesOnly = payload.mode === 'subtitles'
+  const subtitleFormat = typeof payload.subtitleFormat === 'string' && SUBTITLE_FORMATS.includes(payload.subtitleFormat)
+    ? payload.subtitleFormat
+    : ''
 
   const customArgs = typeof payload.customArgs === 'string' && payload.customArgs.trim() !== ''
     ? splitArguments(payload.customArgs)
@@ -1287,36 +1299,51 @@ export async function handleYtDlpDownload(event, payload) {
         args.push('--audio-format', payload.audioFormat)
       }
       break
+    case 'subtitles':
+      // `--print` turns on quiet mode, which hides the lines naming the written
+      // subtitle files. Nothing else reports them, as only the media file yt-dlp
+      // isn't downloading here would reach the `after_move` print below.
+      args.push('--skip-download', '--no-quiet')
+      break
     case 'custom':
       break
   }
 
-  if (payload.splitChapters === true) {
+  if (!subtitlesOnly && payload.splitChapters === true) {
     args.push('--split-chapters')
   }
-  if (payload.removeSponsorblock === true) {
+  if (!subtitlesOnly && payload.removeSponsorblock === true) {
     const categories = Array.isArray(payload.sponsorBlockCategories)
       ? payload.sponsorBlockCategories.filter(category => SPONSORBLOCK_CATEGORIES.includes(category))
       : SPONSORBLOCK_CATEGORIES
     if (categories.length > 0) args.push('--sponsorblock-remove', categories.join(','))
   }
-  if (payload.includeSubtitles === true) {
-    args.push('--write-subs', '--write-auto-subs')
-    if (payload.embedSubtitles === true) {
+  if (subtitlesOnly || payload.includeSubtitles === true) {
+    // YouTube advertises a machine translation of every subtitle track into every other
+    // language, which multiplies a language selector like `de.*` into dozens of requests
+    // and runs into its rate limiting. Custom arguments can override this again.
+    args.push('--write-subs', '--write-auto-subs', '--extractor-args', 'youtube:skip=translated_subs')
+    if (!subtitlesOnly && payload.embedSubtitles === true) {
       args.push('--embed-subs')
     }
     if (typeof payload.subtitleLanguages === 'string' && payload.subtitleLanguages.trim() !== '') {
       args.push('--sub-langs', payload.subtitleLanguages.trim())
     }
+    if (subtitleFormat !== '') {
+      // YouTube serves most formats itself, so prefer downloading the requested one directly.
+      // The converter only runs once every track has downloaded, so it would otherwise leave
+      // the original files behind whenever a download fails partway through.
+      args.push('--sub-format', `${subtitleFormat}/best`, '--convert-subs', subtitleFormat)
+    }
   }
-  if (payload.embedThumbnail === true) {
+  if (!subtitlesOnly && payload.embedThumbnail === true) {
     args.push('--embed-thumbnail')
   }
-  if (payload.embedMetadata === true) {
+  if (!subtitlesOnly && payload.embedMetadata === true) {
     args.push('--embed-metadata', '--embed-chapters')
   }
-  const startTime = typeof payload.startTime === 'string' && TIME_REGEX.test(payload.startTime) ? payload.startTime : ''
-  const endTime = typeof payload.endTime === 'string' && TIME_REGEX.test(payload.endTime) ? payload.endTime : ''
+  const startTime = !subtitlesOnly && typeof payload.startTime === 'string' && TIME_REGEX.test(payload.startTime) ? payload.startTime : ''
+  const endTime = !subtitlesOnly && typeof payload.endTime === 'string' && TIME_REGEX.test(payload.endTime) ? payload.endTime : ''
   if (startTime !== '' || endTime !== '') {
     args.push('--download-sections', `*${startTime || '0'}-${endTime || 'inf'}`, '--force-keyframes-at-cuts')
   }
@@ -1357,6 +1384,8 @@ export async function handleYtDlpDownload(event, payload) {
       ? payload.title.slice(0, 255)
       : (isSingleVideo ? payload.videoId : isRemotePlaylist ? payload.playlistId : ''),
     thumbnail: typeof payload.thumbnail === 'string' ? payload.thumbnail.slice(0, 2048) : '',
+    mode: payload.mode,
+    template: typeof payload.template === 'string' ? payload.template.slice(0, 255) : '',
     status: 'downloading',
     percent: 0,
     speed: null,
@@ -1398,6 +1427,18 @@ export async function handleYtDlpDownload(event, payload) {
       sendStatus(true)
       return
     }
+
+    const subtitleMatch = SUBTITLE_DESTINATION_REGEX.exec(line)
+    if (subtitleMatch) {
+      // `--convert-subs` replaces the written file with one that only differs in its extension
+      const subtitlePath = subtitleFormat === ''
+        ? subtitleMatch[1]
+        : subtitleMatch[1].replace(/\.[^.]+$/, `.${subtitleFormat}`)
+      status.destination = subtitlePath
+      if (!status.destinations.includes(subtitlePath)) status.destinations.push(subtitlePath)
+      sendStatus(true)
+      return
+    }
     const progressMatch = PROGRESS_REGEX.exec(line)
     if (progressMatch) {
       status.status = 'downloading'
@@ -1408,7 +1449,9 @@ export async function handleYtDlpDownload(event, payload) {
       return
     }
 
-    const destinationMatch = DESTINATION_REGEX.exec(line)
+    // subtitle files are announced twice, and only the line handled above
+    // accounts for the extension a conversion gives them
+    const destinationMatch = subtitlesOnly ? null : DESTINATION_REGEX.exec(line)
     if (destinationMatch) {
       status.destination = destinationMatch[1]
 

--- a/src/preload/interface.js
+++ b/src/preload/interface.js
@@ -19,14 +19,14 @@ ipcRenderer.on(IpcChannels.YT_DLP_BINARY_DOWNLOAD_PROGRESS, (_, progress) => {
   }
 })
 
-/** @type {Set<(videoId: string, scheduled: boolean) => void>} */
+/** @type {Set<{ handler: (videoId: string, scheduled: boolean) => void }>} */
 const liveReminderUpdatedListeners = new Set()
 
 // Video lists subscribe once per row, which would exceed Node's listener
 // warning threshold on this channel, so they share a single IPC listener.
 ipcRenderer.on(IpcChannels.LIVE_REMINDER_UPDATED, (_, videoId, scheduled) => {
-  for (const listener of liveReminderUpdatedListeners) {
-    listener(videoId, scheduled)
+  for (const { handler } of liveReminderUpdatedListeners) {
+    handler(videoId, scheduled)
   }
 })
 
@@ -520,8 +520,9 @@ export default {
      * @returns {() => void}
      */
     onUpdated: (handler) => {
-      liveReminderUpdatedListeners.add(handler)
-      return () => liveReminderUpdatedListeners.delete(handler)
+      const subscription = { handler }
+      liveReminderUpdatedListeners.add(subscription)
+      return () => liveReminderUpdatedListeners.delete(subscription)
     }
   },
 

--- a/src/preload/interface.js
+++ b/src/preload/interface.js
@@ -19,6 +19,17 @@ ipcRenderer.on(IpcChannels.YT_DLP_BINARY_DOWNLOAD_PROGRESS, (_, progress) => {
   }
 })
 
+/** @type {Set<(videoId: string, scheduled: boolean) => void>} */
+const liveReminderUpdatedListeners = new Set()
+
+// Video lists subscribe once per row, which would exceed Node's listener
+// warning threshold on this channel, so they share a single IPC listener.
+ipcRenderer.on(IpcChannels.LIVE_REMINDER_UPDATED, (_, videoId, scheduled) => {
+  for (const listener of liveReminderUpdatedListeners) {
+    listener(videoId, scheduled)
+  }
+})
+
 export default {
   isFlatpak: process.env.FLATPAK_ID !== undefined,
   runtimeVersions: Object.freeze({
@@ -509,9 +520,8 @@ export default {
      * @returns {() => void}
      */
     onUpdated: (handler) => {
-      const listener = (_event, videoId, scheduled) => handler(videoId, scheduled)
-      ipcRenderer.on(IpcChannels.LIVE_REMINDER_UPDATED, listener)
-      return () => ipcRenderer.removeListener(IpcChannels.LIVE_REMINDER_UPDATED, listener)
+      liveReminderUpdatedListeners.add(handler)
+      return () => liveReminderUpdatedListeners.delete(handler)
     }
   },
 

--- a/src/renderer/components/FtSelect/FtSelect.vue
+++ b/src/renderer/components/FtSelect/FtSelect.vue
@@ -59,7 +59,7 @@
       :for="id"
     >
       <FontAwesomeIcon
-        v-if="showIcon"
+        v-if="showIcon && icon !== null"
         :icon="icon"
         class="select-icon"
         :color="iconColor"
@@ -170,7 +170,7 @@ const props = defineProps({
   },
   icon: {
     type: Array,
-    required: true
+    default: null
   },
   showIcon: {
     type: Boolean,

--- a/src/renderer/components/WatchVideoDownloadPrompt/WatchVideoDownloadPrompt.css
+++ b/src/renderer/components/WatchVideoDownloadPrompt/WatchVideoDownloadPrompt.css
@@ -187,6 +187,7 @@
 
 .downloadStatusLine {
   margin: 0;
+  text-align: center;
 }
 
 .downloadProgressBarFill {
@@ -205,8 +206,13 @@
   color: var(--destructive-color);
   font-family: monospace;
   font-size: 12px;
+  inline-size: min(600px, 100%);
+  margin-inline: auto;
   overflow-wrap: anywhere;
-  text-align: center;
+  text-align: start;
+
+  /* yt-dlp's messages are joined with newlines, which centred prose would run together */
+  white-space: pre-wrap;
 }
 
 @keyframes download-progress-indeterminate {

--- a/src/renderer/components/WatchVideoDownloadPrompt/WatchVideoDownloadPrompt.vue
+++ b/src/renderer/components/WatchVideoDownloadPrompt/WatchVideoDownloadPrompt.vue
@@ -62,8 +62,8 @@
           <FtSelect
             :placeholder="t('Downloads.Media Type')"
             :value="options.mode"
-            :select-names="[t('Downloads.Video'), t('Downloads.Audio')]"
-            :select-values="['video', 'audio']"
+            :select-names="[t('Downloads.Video'), t('Downloads.Audio'), t('Downloads.Subtitles')]"
+            :select-values="['video', 'audio', 'subtitles']"
             @change="setOption('mode', $event)"
           />
           <FtSelect
@@ -83,7 +83,7 @@
             @change="setOption('videoFormat', $event)"
           />
           <FtSelect
-            :placeholder="options.mode === 'video' ? t('Downloads.Video Codec') : t('Downloads.Audio Codec')"
+            :placeholder="formatLabel"
             :value="selectedCodec"
             :select-names="codecNames"
             :select-values="codecValues"
@@ -108,6 +108,7 @@
           <div class="optionGrid segmentGrid">
             <FtInput
               :placeholder="t('Downloads.Start Time')"
+              :disabled="subtitlesOnly"
               :show-action-button="false"
               :show-label="true"
               :value="options.startTime"
@@ -115,6 +116,7 @@
             />
             <FtInput
               :placeholder="t('Downloads.End Time')"
+              :disabled="subtitlesOnly"
               :show-action-button="false"
               :show-label="true"
               :value="options.endTime"
@@ -125,7 +127,8 @@
             <FtToggleSwitch
               compact
               :label="t('Downloads.Split by Chapters')"
-              :default-value="options.splitChapters"
+              :default-value="!subtitlesOnly && options.splitChapters"
+              :disabled="subtitlesOnly"
               @change="setOption('splitChapters', $event)"
             />
           </div>
@@ -137,14 +140,15 @@
             <FtToggleSwitch
               compact
               :label="t('Downloads.Remove Segments')"
-              :default-value="options.removeSponsorblock"
+              :default-value="!subtitlesOnly && options.removeSponsorblock"
+              :disabled="subtitlesOnly"
               @change="setOption('removeSponsorblock', $event)"
             />
           </div>
           <div
-            :class="{ disabledOptions: !options.removeSponsorblock }"
-            :inert="!options.removeSponsorblock"
-            :aria-disabled="!options.removeSponsorblock"
+            :class="{ disabledOptions: !sponsorBlockCategoriesEnabled }"
+            :inert="!sponsorBlockCategoriesEnabled"
+            :aria-disabled="!sponsorBlockCategoriesEnabled"
           >
             <FtCheckboxList
               v-model="sponsorBlockCategories"
@@ -161,26 +165,29 @@
             <FtToggleSwitch
               compact
               :label="t('Downloads.Embed Cover Art')"
-              :default-value="options.embedThumbnail"
+              :default-value="!subtitlesOnly && options.embedThumbnail"
+              :disabled="subtitlesOnly"
               @change="setOption('embedThumbnail', $event)"
             />
             <FtToggleSwitch
               compact
               :label="t('Downloads.Embed Metadata')"
-              :default-value="options.embedMetadata"
+              :default-value="!subtitlesOnly && options.embedMetadata"
+              :disabled="subtitlesOnly"
               @change="setOption('embedMetadata', $event)"
             />
             <FtToggleSwitch
               compact
               :label="t('Downloads.Include Subtitles')"
-              :default-value="options.includeSubtitles"
+              :default-value="subtitlesOnly || options.includeSubtitles"
+              :disabled="subtitlesOnly"
               @change="setOption('includeSubtitles', $event)"
             />
             <FtToggleSwitch
               compact
               :label="t('Downloads.Embed Subtitles')"
-              :default-value="options.embedSubtitles"
-              :disabled="!options.includeSubtitles"
+              :default-value="!subtitlesOnly && options.embedSubtitles"
+              :disabled="subtitlesOnly || !options.includeSubtitles"
               @change="setOption('embedSubtitles', $event)"
             />
           </div>
@@ -188,7 +195,7 @@
             class="fullWidth subtitleLanguages"
             :placeholder="t('Downloads.Subtitle Languages')"
             :tooltip="t('Downloads.Subtitle Languages Help')"
-            :disabled="!options.includeSubtitles"
+            :disabled="!subtitlesOnly && !options.includeSubtitles"
             :show-action-button="false"
             :show-label="true"
             :value="options.subtitleLanguages"
@@ -258,12 +265,14 @@
           <FtButton
             v-else-if="downloadInProgress"
             :label="t('Downloads.Cancel Download')"
+            :icon="['fas', 'times-circle']"
             text-color="var(--destructive-text-color)"
             background-color="var(--destructive-color)"
             @click="cancelDownload"
           />
           <FtButton
             :label="activeDownload === null ? t('Cancel') : t('Close')"
+            :icon="['fas', 'xmark']"
             :text-color="null"
             :background-color="null"
             @click="close"
@@ -297,6 +306,7 @@
         />
         <FtButton
           :label="t('Cancel')"
+          :icon="['fas', 'xmark']"
           :text-color="null"
           :background-color="null"
           @click="closeSaveTemplatePrompt"
@@ -320,6 +330,7 @@ import FtPrompt from '../FtPrompt/FtPrompt.vue'
 import FtSelect from '../FtSelect/FtSelect.vue'
 import FtToggleSwitch from '../FtToggleSwitch/FtToggleSwitch.vue'
 import store from '../../store/index'
+import { DEFAULT_DOWNLOAD_TEMPLATES } from '../../helpers/downloadTemplates'
 import { showToast } from '../../helpers/utils'
 
 const props = defineProps({
@@ -332,10 +343,17 @@ const props = defineProps({
   thumbnail: { type: String, default: '' }
 })
 const emit = defineEmits(['close'])
-const { t } = useI18n()
+const { t, locale } = useI18n()
 const downloadLabel = computed(() => props.isPlaylist
   ? t('Downloads.Download Playlist')
   : t('Downloads.Download Video'))
+
+// YouTube offers a machine translation of every video into a few hundred languages,
+// and yt-dlp's "all" selector requests every single one of them, which its rate
+// limiting cuts short long before it finishes.
+const DEFAULT_SUBTITLE_LANGUAGES = [...new Set([locale.value.split('-')[0], 'en'])]
+  .map(language => `${language}.*`)
+  .join(',')
 
 const BASE_OPTIONS = Object.freeze({
   mode: 'video',
@@ -351,24 +369,12 @@ const BASE_OPTIONS = Object.freeze({
   sponsorBlockCategories: ['sponsor', 'intro', 'outro', 'selfpromo', 'interaction', 'music_offtopic', 'preview', 'filler'],
   includeSubtitles: false,
   embedSubtitles: true,
-  subtitleLanguages: 'all,-live_chat',
+  subtitleLanguages: DEFAULT_SUBTITLE_LANGUAGES,
+  subtitleFormat: '',
   embedThumbnail: false,
   embedMetadata: false,
   customArgs: ''
 })
-const DEFAULT_TEMPLATES = [
-  { value: 'video:best', options: {} },
-  { value: 'video:best:mp4', options: { videoFormat: 'mp4' } },
-  { value: 'video:1080', options: { quality: '1080' } },
-  { value: 'video:1080:mp4', options: { quality: '1080', videoFormat: 'mp4' } },
-  { value: 'video:720', options: { quality: '720' } },
-  { value: 'video:720:mp4', options: { quality: '720', videoFormat: 'mp4' } },
-  { value: 'video:480', options: { quality: '480' } },
-  { value: 'video:480:mp4', options: { quality: '480', videoFormat: 'mp4' } },
-  { value: 'audio:best', options: { mode: 'audio', embedThumbnail: true, embedMetadata: true } },
-  { value: 'audio:mp3', options: { mode: 'audio', audioFormat: 'mp3', embedThumbnail: true, embedMetadata: true } }
-]
-
 const customTemplates = computed(() => JSON.parse(store.getters.getYtDlpDownloadTemplates))
 const storedSelection = store.getters.getYtDlpSelectedTemplate
 const selectedTemplate = ref(storedSelection)
@@ -393,13 +399,30 @@ const sponsorBlockCategoryLabels = computed(() => [
   t('Video.Sponsor Block category.recap'),
   t('Video.Sponsor Block category.filler')
 ])
-const selectedCodec = computed(() => options.mode === 'video' ? options.videoCodec : options.audioFormat)
-const codecNames = computed(() => options.mode === 'video'
-  ? [t('Downloads.Automatic'), 'H.264', 'H.265 / HEVC', 'VP9', 'AV1']
-  : [t('Downloads.Best Available'), 'MP3', 'M4A', 'Opus', 'FLAC'])
-const codecValues = computed(() => options.mode === 'video'
-  ? ['', 'h264', 'h265', 'vp9', 'av1']
-  : ['', 'mp3', 'm4a', 'opus', 'flac'])
+const subtitlesOnly = computed(() => options.mode === 'subtitles')
+// the codec select doubles as the subtitle format select, as neither codec applies to subtitles
+const formatOptionKey = computed(() => {
+  if (subtitlesOnly.value) return 'subtitleFormat'
+  return options.mode === 'video' ? 'videoCodec' : 'audioFormat'
+})
+const formatLabel = computed(() => {
+  if (subtitlesOnly.value) return t('Downloads.Subtitle Format')
+  return options.mode === 'video' ? t('Downloads.Video Codec') : t('Downloads.Audio Codec')
+})
+const sponsorBlockCategoriesEnabled = computed(() => !subtitlesOnly.value && options.removeSponsorblock)
+const selectedCodec = computed(() => options[formatOptionKey.value])
+const codecNames = computed(() => {
+  if (subtitlesOnly.value) return [t('Downloads.Automatic'), 'SRT', 'VTT', 'ASS', 'LRC']
+  return options.mode === 'video'
+    ? [t('Downloads.Automatic'), 'H.264', 'H.265 / HEVC', 'VP9', 'AV1']
+    : [t('Downloads.Best Available'), 'MP3', 'M4A', 'Opus', 'FLAC']
+})
+const codecValues = computed(() => {
+  if (subtitlesOnly.value) return ['', 'srt', 'vtt', 'ass', 'lrc']
+  return options.mode === 'video'
+    ? ['', 'h264', 'h265', 'vp9', 'av1']
+    : ['', 'mp3', 'm4a', 'opus', 'flac']
+})
 const fileNameTemplateHelp = computed(() => t('Downloads.File Name Template Help', {
   title: '{title}',
   author: '{author}',
@@ -411,7 +434,7 @@ const fileNameTemplateHelp = computed(() => t('Downloads.File Name Template Help
 }))
 
 function getTemplateOptions(value) {
-  const defaultTemplate = DEFAULT_TEMPLATES.find(template => template.value === value)
+  const defaultTemplate = DEFAULT_DOWNLOAD_TEMPLATES.find(template => template.value === value)
   if (defaultTemplate) return defaultTemplate.options
   const custom = customTemplates.value.find(template => `template:${template.name}` === value)
   if (custom?.options) return custom.options
@@ -434,7 +457,7 @@ function optionsMatchTemplate(value) {
 function findMatchingTemplate() {
   const candidates = [
     selectedTemplate.value,
-    ...DEFAULT_TEMPLATES.map(template => template.value),
+    ...DEFAULT_DOWNLOAD_TEMPLATES.map(template => template.value),
     ...customTemplates.value.map(template => `template:${template.name}`)
   ]
 
@@ -447,7 +470,7 @@ function loadTemplate(value) {
   isDirty.value = false
 }
 loadTemplate(
-  DEFAULT_TEMPLATES.some(template => template.value === storedSelection) || storedSelection.startsWith('template:')
+  DEFAULT_DOWNLOAD_TEMPLATES.some(template => template.value === storedSelection) || storedSelection.startsWith('template:')
     ? storedSelection
     : 'video:best'
 )
@@ -456,20 +479,13 @@ const selectedCustomTemplate = computed(() => customTemplates.value.find(
   template => `template:${template.name}` === selectedTemplate.value
 ))
 const displayedTemplate = computed(() => isDirty.value ? 'unsaved' : selectedTemplate.value)
-const defaultTemplateNames = computed(() => [
-  t('Downloads.Templates.Video Best'), `${t('Downloads.Templates.Video Best')} (MP4)`,
-  t('Downloads.Templates.Video Resolution', { resolution: '1080p' }), `${t('Downloads.Templates.Video Resolution', { resolution: '1080p' })} (MP4)`,
-  t('Downloads.Templates.Video Resolution', { resolution: '720p' }), `${t('Downloads.Templates.Video Resolution', { resolution: '720p' })} (MP4)`,
-  t('Downloads.Templates.Video Resolution', { resolution: '480p' }), `${t('Downloads.Templates.Video Resolution', { resolution: '480p' })} (MP4)`,
-  t('Downloads.Templates.Audio Best'), t('Downloads.Templates.Audio Format', { format: 'MP3' })
-])
 const templateNames = computed(() => [
-  ...defaultTemplateNames.value,
+  ...DEFAULT_DOWNLOAD_TEMPLATES.map(template => template.label(t)),
   ...customTemplates.value.map(template => template.name),
   ...(isDirty.value ? [t('Downloads.Unsaved')] : [])
 ])
 const templateValues = computed(() => [
-  ...DEFAULT_TEMPLATES.map(template => template.value),
+  ...DEFAULT_DOWNLOAD_TEMPLATES.map(template => template.value),
   ...customTemplates.value.map(template => `template:${template.name}`),
   ...(isDirty.value ? ['unsaved'] : [])
 ])
@@ -492,7 +508,7 @@ function setOption(key, value) {
   }
 }
 function setSelectedCodec(value) {
-  setOption(options.mode === 'video' ? 'videoCodec' : 'audioFormat', value)
+  setOption(formatOptionKey.value, value)
 }
 function saveTemplate() {
   const name = newTemplateName.value.trim()
@@ -554,7 +570,9 @@ async function startDownload() {
     playlistKey: props.playlistKey,
     isPlaylist: props.isPlaylist,
     title: props.title,
-    thumbnail: props.thumbnail
+    thumbnail: props.thumbnail,
+    // edited options no longer describe the template they started from
+    template: isDirty.value ? '' : selectedTemplate.value
   })
   if (result != null && 'id' in result) downloadId.value = result.id
   else if (result != null && 'error' in result) showToast({ message: t('Downloads.Download Failed'), icon: ['fas', 'circle-exclamation'] })

--- a/src/renderer/helpers/downloadTemplates.js
+++ b/src/renderer/helpers/downloadTemplates.js
@@ -1,0 +1,45 @@
+/**
+ * The download templates that ship with the app. Shared between the download
+ * prompt, which applies them, and the downloads page, which names the one a
+ * finished download was started with.
+ *
+ * @typedef DownloadTemplate
+ * @property {string} value
+ * @property {(t: (key: string, values?: object) => string) => string} label
+ * @property {object} options the options that differ from the defaults
+ */
+
+/** @type {DownloadTemplate[]} */
+export const DEFAULT_DOWNLOAD_TEMPLATES = [
+  { value: 'video:best', label: t => t('Downloads.Templates.Video Best'), options: {} },
+  { value: 'video:best:mp4', label: t => `${t('Downloads.Templates.Video Best')} (MP4)`, options: { videoFormat: 'mp4' } },
+  { value: 'video:1080', label: t => t('Downloads.Templates.Video Resolution', { resolution: '1080p' }), options: { quality: '1080' } },
+  { value: 'video:1080:mp4', label: t => `${t('Downloads.Templates.Video Resolution', { resolution: '1080p' })} (MP4)`, options: { quality: '1080', videoFormat: 'mp4' } },
+  { value: 'video:720', label: t => t('Downloads.Templates.Video Resolution', { resolution: '720p' }), options: { quality: '720' } },
+  { value: 'video:720:mp4', label: t => `${t('Downloads.Templates.Video Resolution', { resolution: '720p' })} (MP4)`, options: { quality: '720', videoFormat: 'mp4' } },
+  { value: 'video:480', label: t => t('Downloads.Templates.Video Resolution', { resolution: '480p' }), options: { quality: '480' } },
+  { value: 'video:480:mp4', label: t => `${t('Downloads.Templates.Video Resolution', { resolution: '480p' })} (MP4)`, options: { quality: '480', videoFormat: 'mp4' } },
+  { value: 'audio:best', label: t => t('Downloads.Templates.Audio Best'), options: { mode: 'audio', embedThumbnail: true, embedMetadata: true } },
+  { value: 'audio:mp3', label: t => t('Downloads.Templates.Audio Format', { format: 'MP3' }), options: { mode: 'audio', audioFormat: 'mp3', embedThumbnail: true, embedMetadata: true } },
+  { value: 'subtitles:srt', label: t => t('Downloads.Templates.Subtitles Format', { format: 'SRT' }), options: { mode: 'subtitles', subtitleFormat: 'srt' } },
+  { value: 'subtitles:vtt', label: t => t('Downloads.Templates.Subtitles Format', { format: 'VTT' }), options: { mode: 'subtitles', subtitleFormat: 'vtt' } }
+]
+
+/**
+ * @param {string} value
+ * @param {(key: string, values?: object) => string} t
+ * @returns {string} empty when the download wasn't started from a template
+ */
+export function downloadTemplateName(value, t) {
+  if (typeof value !== 'string' || value === '') {
+    return ''
+  }
+
+  const defaultTemplate = DEFAULT_DOWNLOAD_TEMPLATES.find(template => template.value === value)
+  if (defaultTemplate) {
+    return defaultTemplate.label(t)
+  }
+
+  // custom templates are stored as `template:<the name the user gave it>`
+  return value.startsWith('template:') ? value.slice('template:'.length) : ''
+}

--- a/src/renderer/views/Downloads/DownloadRow.vue
+++ b/src/renderer/views/Downloads/DownloadRow.vue
@@ -25,12 +25,31 @@
           />
         </div>
         <p
-          v-if="download.destination"
-          class="destination"
-          dir="auto"
+          v-if="summary"
+          class="downloadSummary"
         >
-          {{ download.destination }}
+          {{ summary }}
         </p>
+        <ul
+          v-if="destinations.length > 0"
+          class="destinationList"
+        >
+          <li
+            v-for="destination in destinations"
+            :key="destination"
+            class="destination"
+            dir="auto"
+            :title="destination"
+          >
+            {{ destination }}
+          </li>
+          <li
+            v-if="hiddenDestinationCount > 0"
+            class="destination"
+          >
+            {{ t('Downloads.More Files', { count: hiddenDestinationCount }, hiddenDestinationCount) }}
+          </li>
+        </ul>
       </div>
     </div>
     <div class="downloadActions">
@@ -72,11 +91,44 @@ import { computed } from 'vue'
 import { useI18n } from 'vue-i18n'
 import FtIconButton from '../../components/FtIconButton/FtIconButton.vue'
 import thumbnailPlaceholder from '../../assets/img/thumbnail_placeholder.svg'
+import { downloadTemplateName } from '../../helpers/downloadTemplates'
+
+// keeps a playlist download from filling the page with one line per video
+const MAX_VISIBLE_DESTINATIONS = 3
 
 const props = defineProps({ download: { type: Object, required: true } })
 const emit = defineEmits(['clear', 'open', 'remove'])
 const { t } = useI18n()
 const inProgress = computed(() => ['downloading', 'processing'].includes(props.download.status))
+const modeLabel = computed(() => {
+  switch (props.download.mode) {
+    case 'video':
+      return t('Downloads.Video')
+    case 'audio':
+      return t('Downloads.Audio')
+    case 'subtitles':
+      return t('Downloads.Subtitles')
+    default:
+      return ''
+  }
+})
+const summary = computed(() => {
+  const templateName = downloadTemplateName(props.download.template, t)
+
+  return [
+    modeLabel.value,
+    templateName === '' ? '' : t('Downloads.Template Used', { name: templateName })
+  ].filter(part => part !== '').join(' • ')
+})
+// downloads from before the file list was recorded only know their last file
+const allDestinations = computed(() => {
+  if (Array.isArray(props.download.destinations) && props.download.destinations.length > 0) {
+    return props.download.destinations
+  }
+  return props.download.destination ? [props.download.destination] : []
+})
+const destinations = computed(() => allDestinations.value.slice(0, MAX_VISIBLE_DESTINATIONS))
+const hiddenDestinationCount = computed(() => allDestinations.value.length - destinations.value.length)
 const statusText = computed(() => {
   if (props.download.status === 'downloading') {
     return [`${props.download.percent.toFixed(1)}%`, props.download.speed, props.download.eta ? `ETA ${props.download.eta}` : null].filter(Boolean).join(' • ')

--- a/src/renderer/views/Downloads/Downloads.css
+++ b/src/renderer/views/Downloads/Downloads.css
@@ -60,17 +60,29 @@
   min-inline-size: 0;
 }
 
-.downloadDetails h3,
-.destination {
+.downloadDetails h3 {
   overflow: hidden;
   text-overflow: ellipsis;
   white-space: nowrap;
 }
 
 .downloadStatus,
+.downloadSummary,
 .destination {
   color: var(--secondary-text-color);
   font-size: 0.9rem;
+}
+
+.destinationList {
+  list-style: none;
+  margin-block: 4px;
+  margin-inline: 0;
+  padding-inline: 0;
+}
+
+/* truncating would hide the file name, which is the interesting part of the path */
+.destination {
+  overflow-wrap: anywhere;
 }
 
 .downloadActions {

--- a/static/locales/en-US.yaml
+++ b/static/locales/en-US.yaml
@@ -2070,12 +2070,15 @@ Downloads:
   Remove File Confirmation: Remove downloaded file?
   Remove File Warning: 'This will move "{title}" to your device trash.'
   File Not Found: The downloaded file could not be found.
+  More Files: 1 more file | {count} more files
+  Template Used: 'Template: {name}'
   Download Type: Download Type
   Template: Template
   Unsaved: Unsaved
   Media Type: Media Type
   Video: Video
   Audio: Audio
+  Subtitles: Subtitles
   Maximum Resolution: Maximum Resolution
   Best Available: Best Available
   Automatic: Automatic
@@ -2093,6 +2096,7 @@ Downloads:
   Subtitles and Metadata: Subtitles and Metadata
   Include Subtitles: Include subtitles
   Embed Subtitles: Embed subtitles in the media file
+  Subtitle Format: Subtitle Format
   Subtitle Languages: Subtitle Languages
   Subtitle Languages Help: 'Comma-separated yt-dlp language selectors, for example: en.*,de.*'
   Embed Cover Art: Embed thumbnail as cover art
@@ -2120,4 +2124,5 @@ Downloads:
     Video Resolution: Video - {resolution}
     Audio Best: Audio - Best Quality
     Audio Format: Audio - {format}
+    Subtitles Format: Subtitles - {format}
     Custom Arguments: Custom yt-dlp Arguments

--- a/tests/unit/download-templates.test.mjs
+++ b/tests/unit/download-templates.test.mjs
@@ -1,0 +1,47 @@
+import assert from 'node:assert/strict'
+import test from 'node:test'
+
+import { DEFAULT_DOWNLOAD_TEMPLATES, downloadTemplateName } from '../../src/renderer/helpers/downloadTemplates.js'
+
+/** the en-US strings the template labels are built from */
+const MESSAGES = {
+  'Downloads.Templates.Video Best': 'Video - Best Quality',
+  'Downloads.Templates.Video Resolution': 'Video - {resolution}',
+  'Downloads.Templates.Audio Best': 'Audio - Best Quality',
+  'Downloads.Templates.Audio Format': 'Audio - {format}',
+  'Downloads.Templates.Subtitles Format': 'Subtitles - {format}'
+}
+
+/** stands in for vue-i18n's `t`, which the download history only has at display time */
+function t(key, values = {}) {
+  return Object.entries(values).reduce(
+    (message, [name, value]) => message.replaceAll(`{${name}}`, value),
+    MESSAGES[key] ?? key
+  )
+}
+
+test('names the template a download was started from', () => {
+  assert.equal(downloadTemplateName('subtitles:srt', t), 'Subtitles - SRT')
+  assert.equal(downloadTemplateName('video:1080', t), 'Video - 1080p')
+  assert.equal(downloadTemplateName('video:1080:mp4', t), 'Video - 1080p (MP4)')
+  assert.equal(downloadTemplateName('audio:mp3', t), 'Audio - MP3')
+  assert.equal(downloadTemplateName('template:My preset', t), 'My preset')
+})
+
+test('has no name for downloads that did not use a template', () => {
+  assert.equal(downloadTemplateName('', t), '')
+  assert.equal(downloadTemplateName(undefined, t), '')
+  // options edited after loading a template are reported as template-less
+  assert.equal(downloadTemplateName('unsaved', t), '')
+  assert.equal(downloadTemplateName('video:9999', t), '')
+})
+
+test('every template has a unique value and a translatable label', () => {
+  const values = DEFAULT_DOWNLOAD_TEMPLATES.map(template => template.value)
+  assert.equal(new Set(values).size, values.length)
+
+  for (const template of DEFAULT_DOWNLOAD_TEMPLATES) {
+    assert.equal(typeof template.label(t), 'string')
+    assert.notEqual(template.label(t), '')
+  }
+})


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Make sure to follow the contributing guidelines. -->
<!-- Important note, we may remove your pull request if you do not use this provided PR template correctly. -->
<!-- Agent instructions: Preserve every heading, comment, and marker in this template. Never remove or rewrite the release-note-category:start/end, release-note:start/end, or release-note-image:start/end marker pairs. Never remove or rewrite the Release note images section; leave its contents for a human. -->

## Pull Request Type
<!-- Please select what type of pull request this is: [x] -->
- [ ] Bugfix
- [x] Feature Implementation
- [ ] Documentation
- [ ] Other

## Related issue
<!-- Please link the issue your pull request is referring to. -->
<!-- If this pull request fully resolves the relevant issue, put "closes" before the issue number. -->
<!-- Example: "closes #123456". -->
closes #421

## Description
<!-- Please write a clear and concise description of what the pull request does. -->
There was no way to download subtitles. Captions could only be fetched as a side effect of downloading a video, and the transcript panel only saves plain text, which is not the same thing as a subtitle file.

The download prompt gains a **Subtitles** media type next to Video and Audio. It runs yt-dlp with `--skip-download`, so only the caption tracks are written, and the codec select doubles as a **Subtitle Format** picker (Automatic, SRT, VTT, ASS, LRC). Two templates ship with it, "Subtitles - SRT" and "Subtitles - VTT". The options that need a media file (time range, chapter splitting, SponsorBlock removal, embedding) stay visible but disabled, so the modal keeps its size when you switch media type.

Three things had to be solved along the way:

- **The requested format only arrived if nothing failed.** `--convert-subs` runs after every track has downloaded, so an interrupted run left the original `.vtt` files behind. Passing `--sub-format srt/best` as well makes yt-dlp fetch the requested format directly, since YouTube serves srt, ttml and json3 itself.
- **`all` languages cannot work.** YouTube advertises a machine translation of every track into every other language, around 940 entries on a normal video, so `--sub-langs all` is one HTTP request per entry and reliably ends in `HTTP Error 429`. Subtitle downloads now pass `--extractor-args youtube:skip=translated_subs` and default to the interface language plus English, which selects the handful of real tracks (`de-DE, de, en, en-orig` on a test video). Custom arguments still override this.
- **No file paths were reported.** The app passes `--print after_move:%(filepath)s`, and yt-dlp turns on quiet mode whenever `--print` is used, which hides the only lines that name subtitle files. Media downloads were unaffected because their path comes back through that print. Subtitle downloads now also pass `--no-quiet`.

The downloads page shows what a download produced: the media type, the template it was started from (a new field on the download record, so this also applies to future video and audio downloads) and every file it wrote instead of only the last one, capped at three with a "+N more files" line. Paths wrap instead of being truncated, which previously hid the file name and kept only the folder.

Two smaller fixes are included because they surfaced here: the "Download failed" status line in the prompt was left-aligned rather than centred, and `FtSelect` required an `icon` prop it only renders when `showIcon` is set, so every icon-less select logged a "Missing required prop" warning plus a Font Awesome error for `undefined`.

## Release note category
<!-- Select exactly one category. Every pull request must select one. -->
<!-- Select "Not noteworthy" when the pull request fixes a bug in or improves functionality that has not yet appeared in a stable release. -->
<!-- release-note-category:start -->
- [ ] Not noteworthy
- [x] Highlights
- [ ] More improvements
- [ ] Fixed bugs
<!-- release-note-category:end -->

## Release note
<!-- Required unless "Not noteworthy" is selected. -->
<!-- Write one concise, user-facing entry without a leading bullet. -->
<!-- release-note:start -->
Subtitles can now be downloaded on their own as SRT, VTT, ASS or LRC files, and the downloads page shows which files a download produced.
<!-- release-note:end -->

## Release note images
<!-- Human-only: Agents must preserve this entire section and leave it empty. -->
<!-- Optional. Paste one or more Markdown images or HTML image tags here. -->
<!-- The release notes will use an HTML image tag and limit images taller than 300 pixels. -->
<!-- release-note-image:start -->
<img width="801" height="256" alt="image" src="https://github.com/user-attachments/assets/2d30b0b2-10bc-4d23-9001-f534fb8e3e6a" />
<!-- release-note-image:end -->

## Testing
<!-- How can reviewers verify that the PR produces correct results? -->
<!-- Please provide instructions so that others can ensure that your pull request would produce correct results. For examples see, https://github.com/FreeTubeApp/FreeTube/pull/5743, https://github.com/FreeTubeApp/FreeTube/pull/7349, https://github.com/FreeTubeApp/FreeTube/pull/5125, https://github.com/FreeTubeApp/FreeTube/pull/7338 -->
<!-- Agent instructions: Only write human-facing steps that explain how to verify the change while running this branch in dev mode. Include expected results and, when applicable, helpful console snippets for interactive verification. Do not include automated checks, commands, results, pass counts, or CI status. -->
1. Open any video with captions, choose **Download Video**, and pick the **Subtitles - SRT** template. The modal should keep the same size as for a video download, with the time range, SponsorBlock and embedding options greyed out and a **Subtitle Format** select showing SRT.
2. Start the download. Your downloads folder should get one `.srt` file per language, named like `<title> [<id>].en.srt`, and no video or audio file.
3. Open the **Downloads** page. The entry should read `Subtitles • Template: Subtitles - SRT` and list the files it wrote. "Show in Folder" and "Remove File" should act on them.
4. Switch the media type back to Video and confirm the disabled options become editable again and the modal still does not change size.
5. Optionally set **Subtitle Format** to VTT, or widen the **Subtitle Languages** field, to confirm the format and language selectors are respected.

## Additional context
<!-- Add any other context about the pull request here. -->
Transcripts are unchanged, they remain a plain-text export of the caption text as the issue points out that they are not subtitles.

Written by Claude Opus 5 in Claude Code.
