### PR TITLE
fix(tabs): prevent stale watch loading indicators

### DIFF
--- a/e2e/tests/network/watch.spec.mjs
+++ b/e2e/tests/network/watch.spec.mjs
@@ -195,6 +195,43 @@ test.describe('background watch tab', () => {
     await backgroundTab.click()
     await expect(page.locator('.commentsTitle')).toBeVisible()
   })
+
+  test('does not show a stale loading indicator after leaving a loaded video tab', async ({ page }) => {
+    await openVideo(page)
+
+    const videoTab = page.locator(sel.tabs).first()
+    await expect(videoTab).not.toHaveClass(/loading/)
+    await videoTab.evaluate((tab) => {
+      window.__videoTabShowedLoadingAfterDeactivation = false
+      new MutationObserver(() => {
+        if (tab.classList.contains('loading')) {
+          window.__videoTabShowedLoadingAfterDeactivation = true
+        }
+      }).observe(tab, { attributes: true, attributeFilter: ['class'] })
+    })
+
+    const watchComponent = await page.evaluateHandle(findWatchComponent)
+    await watchComponent.evaluate((component) => {
+      window.setTimeout(() => {
+        component.proxy.isLoading = true
+      }, 250)
+    })
+    await watchComponent.dispose()
+
+    await page.locator(sel.newTabButton).click()
+    await expect(page.locator(sel.tabs)).toHaveCount(2)
+    await page.waitForTimeout(500)
+    expect(await page.evaluate(
+      () => window.__videoTabShowedLoadingAfterDeactivation
+    )).toBe(false)
+    await expect(videoTab).not.toHaveClass(/loading/)
+
+    await videoTab.click()
+    await expect(videoTab).toHaveClass(/loading/)
+    await expect(
+      page.locator('.tabContent[aria-hidden="false"] [data-tab-loading-indicator]')
+    ).toHaveCount(1)
+  })
 })
 
 test.describe('watch page metadata', () => {
@@ -2138,7 +2175,7 @@ test.describe('custom Shorts player', () => {
       }, 250)
     }, shortTabId)
 
-    await app.evaluate(({ BrowserWindow, Menu }) => {
+    await app.electronApp.evaluate(({ BrowserWindow, Menu }) => {
       const findMenuItem = (items, label) => {
         for (const item of items) {
           if (item.label === label) return item

--- a/e2e/tests/network/watch.spec.mjs
+++ b/e2e/tests/network/watch.spec.mjs
@@ -210,23 +210,51 @@ test.describe('background watch tab', () => {
       }).observe(tab, { attributes: true, attributeFilter: ['class'] })
     })
 
+    await page.locator(sel.newTabButton).click()
+    await expect(page.locator(sel.tabs)).toHaveCount(2)
+    const videoTabId = await videoTab.getAttribute('data-tab-id')
+    await expect(page.locator(`.tabContent[data-tab-id="${videoTabId}"]`))
+      .toHaveAttribute('aria-hidden', 'true')
+
     const watchComponent = await page.evaluateHandle(findWatchComponent)
     await watchComponent.evaluate((component) => {
       window.setTimeout(() => {
         component.proxy.isLoading = true
       }, 250)
     })
+    await expect.poll(() => watchComponent.evaluate(
+      component => component.proxy.isLoading
+    )).toBe(true)
     await watchComponent.dispose()
 
-    await page.locator(sel.newTabButton).click()
-    await expect(page.locator(sel.tabs)).toHaveCount(2)
-    await page.waitForTimeout(500)
     expect(await page.evaluate(
       () => window.__videoTabShowedLoadingAfterDeactivation
     )).toBe(false)
     await expect(videoTab).not.toHaveClass(/loading/)
 
     await videoTab.click()
+    await expect(videoTab).toHaveClass(/loading/)
+    await expect(
+      page.locator('.tabContent[aria-hidden="false"] [data-tab-loading-indicator]')
+    ).toHaveCount(1)
+  })
+
+  test('restores loading updates when tab activation is rejected', async ({ page }) => {
+    await openVideo(page)
+
+    const videoTab = page.locator(sel.tabs).first()
+    await expect(videoTab).not.toHaveClass(/loading/)
+    await page.evaluate(async () => {
+      const store = document.querySelector('#app').__vue_app__.config.globalProperties.$store
+      await store.dispatch('activateTab', 'missing-tab')
+    })
+
+    const watchComponent = await page.evaluateHandle(findWatchComponent)
+    await watchComponent.evaluate((component) => {
+      component.proxy.isLoading = true
+    })
+    await watchComponent.dispose()
+
     await expect(videoTab).toHaveClass(/loading/)
     await expect(
       page.locator('.tabContent[aria-hidden="false"] [data-tab-loading-indicator]')

--- a/src/main/tabs/TabManager.js
+++ b/src/main/tabs/TabManager.js
@@ -1071,7 +1071,7 @@ export class TabManager {
       this._deferredCloseTabIds.has(tabId) ||
       this._deferredUnloadTabIds.has(tabId)
     ) {
-      return
+      return false
     }
 
     const previousActiveId = this.activeTabId
@@ -1080,7 +1080,7 @@ export class TabManager {
       tab.pendingActivation !== true &&
       tab.loadState !== 'unloaded'
     ) {
-      return
+      return true
     }
 
     const outgoingTabId = this.presentedTabId ?? previousActiveId
@@ -1103,6 +1103,7 @@ export class TabManager {
     this.bridge.send(IpcChannels.TABS_ACTIVE_CHANGED, tabId, this.selectionRevision)
     this._broadcastStateUpdate()
     this._saveSession()
+    return true
   }
 
   /**
@@ -3006,11 +3007,12 @@ export async function setupTabsIPC(options = {}) {
     }
   })
 
-  ipcMain.on(IpcChannels.TABS_ACTIVATE, (event, tabId) => {
+  ipcMain.handle(IpcChannels.TABS_ACTIVATE, (event, tabId) => {
     const manager = getManager(event)
     if (manager && typeof tabId === 'string') {
-      manager.activateTab(tabId)
+      return manager.activateTab(tabId)
     }
+    return false
   })
 
   ipcMain.on(IpcChannels.TABS_SET_SELECTED, (event, tabIds) => {

--- a/src/preload/interface.js
+++ b/src/preload/interface.js
@@ -790,9 +790,10 @@ export default {
     /**
      * Activate a tab
      * @param {string} tabId
+     * @returns {Promise<boolean>}
      */
     activate: (tabId) => {
-      ipcRenderer.send(IpcChannels.TABS_ACTIVATE, tabId)
+      return ipcRenderer.invoke(IpcChannels.TABS_ACTIVATE, tabId)
     },
 
     /**

--- a/src/renderer/store/modules/tabs.js
+++ b/src/renderer/store/modules/tabs.js
@@ -249,7 +249,7 @@ const actions = {
     return await window.ftElectron.tabs.create(tabOptions)
   },
 
-  activateTab({ rootGetters }, tabId) {
+  async activateTab({ rootGetters }, tabId) {
     if (!process.env.IS_ELECTRON) return
 
     const activeTabId = rootGetters.getActiveTabId
@@ -266,7 +266,10 @@ const actions = {
       navigation.setLoadingSuppressed(activeTabId, true)
     }
 
-    window.ftElectron.tabs.activate(tabId)
+    const activated = await window.ftElectron.tabs.activate(tabId)
+    if (!activated && rootGetters.getActiveTabId === activeTabId) {
+      navigation.setLoadingSuppressed(activeTabId, false)
+    }
   },
 
   setTabSelection({ commit }, tabIds) {

--- a/src/renderer/store/modules/tabs.js
+++ b/src/renderer/store/modules/tabs.js
@@ -209,7 +209,7 @@ function prepareTabActivationLoading(state, payload) {
   const navigation = getTabNavigationService()
   navigation.setLoadingSuppressed(incomingTabId, false)
   const outgoingTab = state.tabs.find(tab => tab.id === outgoingTabId)
-  if (outgoingTab?.route?.query?.short !== 'true') {
+  if (!outgoingTab?.route?.path?.startsWith('/watch/')) {
     return payload
   }
 
@@ -258,10 +258,10 @@ const actions = {
     navigation.setLoadingSuppressed(tabId, false)
     if (
       activeTabId !== tabId &&
-      activeTab?.route?.query?.short === 'true'
+      activeTab?.route?.path?.startsWith('/watch/')
     ) {
       // Send this before activation so the main process cannot publish the
-      // outgoing Shorts tab as both inactive and transiently loading. The
+      // outgoing Watch tab as both inactive and transiently loading. The
       // hidden Watch view stops contributing its loader during deactivation.
       navigation.setLoadingSuppressed(activeTabId, true)
     }

--- a/src/renderer/views/Watch/Watch.vue
+++ b/src/renderer/views/Watch/Watch.vue
@@ -62,13 +62,13 @@
         <div
           v-else-if="isLoading"
           class="videoPlayer videoPlayerPlaceholder ft-shimmer"
-          data-tab-loading-indicator
+          :data-tab-loading-indicator="isTabPresented ? '' : null"
         />
         <div
           v-else-if="ytDlpStreamsPending && (!isUpcoming || playabilityStatus === 'OK') && !errorMessage"
           class="videoPlayer videoPlayerPlaceholder streamPlaceholder"
           :class="{ shortsPlayerPlaceholder: customShortsPlayerActive }"
-          data-tab-loading-indicator
+          :data-tab-loading-indicator="isTabPresented ? '' : null"
         >
           <img
             v-if="thumbnail"


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Make sure to follow the contributing guidelines. -->
<!-- Important note, we may remove your pull request if you do not use this provided PR template correctly. -->
<!-- Agent instructions: Preserve every heading, comment, and marker in this template. Never remove or rewrite the release-note-category:start/end, release-note:start/end, or release-note-image:start/end marker pairs. Never remove or rewrite the Release note images section; leave its contents for a human. -->

## Pull Request Type
<!-- Please select what type of pull request this is: [x] -->
- [x] Bugfix
- [ ] Feature Implementation
- [ ] Documentation
- [ ] Other

## Related issue
<!-- Please link the issue your pull request is referring to. -->
<!-- If this pull request fully resolves the relevant issue, put "closes" before the issue number. -->
<!-- Example: "closes #123456". -->

## Description
<!-- Please write a clear and concise description of what the pull request does. -->
Switching away from a loaded video tab could briefly show its tab as loading even though no useful work was happening. The existing protection only applied to Shorts, leaving regular Watch pages exposed to the same delayed-loader race.

This generalizes loading suppression to every `/watch/` route and makes all Watch-page loading markers presentation-aware. A hidden Watch view can no longer publish a stale loading state, while a real pending loader is restored when the user returns to the tab.

The network E2E coverage now reproduces the race for a regular video and retains the existing Shorts regression. It also fixes that Shorts test's stale Electron fixture access.

## Release note category
<!-- Select exactly one category. Every pull request must select one. -->
<!-- Select "Not noteworthy" when the pull request fixes a bug in or improves functionality that has not yet appeared in a stable release. -->
<!-- release-note-category:start -->
- [ ] Not noteworthy
- [ ] Highlights
- [ ] More improvements
- [x] Fixed bugs
<!-- release-note-category:end -->

## Release note
<!-- Required unless "Not noteworthy" is selected. -->
<!-- Write one concise, user-facing entry without a leading bullet. -->
<!-- release-note:start -->
Stopped loaded video tabs from briefly showing a loading indicator when switching away from them.
<!-- release-note:end -->

## Release note images
<!-- Human-only: Agents must preserve this entire section and leave it empty. -->
<!-- Optional. Paste one or more Markdown images or HTML image tags here. -->
<!-- The release notes will use an HTML image tag and limit images taller than 300 pixels. -->
<!-- release-note-image:start -->

<!-- release-note-image:end -->

## Testing
<!-- How can reviewers verify that the PR produces correct results? -->
<!-- Please provide instructions so that others can ensure that your pull request produces correct results. For examples see, https://github.com/FreeTubeApp/FreeTube/pull/5743, https://github.com/FreeTubeApp/FreeTube/pull/7349, https://github.com/FreeTubeApp/FreeTube/pull/5125, https://github.com/FreeTubeApp/FreeTube/pull/7338 -->
<!-- Agent instructions: Only write human-facing steps that explain how to verify the change while running this branch in dev mode. Include expected results and, when applicable, helpful console snippets for interactive verification. Do not include automated checks, commands, results, pass counts, or CI status. -->
1. Open a regular video and wait until it has fully loaded.
2. Switch to another tab while the video tab is settling or pausing.
3. Confirm that the inactive video tab does not briefly display its loading dot.
4. Repeat with a Short and confirm its tab behaves the same way.

## Additional context
<!-- Add any other context about the pull request here. -->
The loading source remains tracked while suppressed, so returning to a tab that is genuinely still loading restores the loading indicator.
