### PR TITLE
feat(settings): enable automatic pagination by default

### DIFF
--- a/e2e/tests/offline/settings.spec.mjs
+++ b/e2e/tests/offline/settings.spec.mjs
@@ -1192,7 +1192,7 @@ test.describe('settings', () => {
 
     const autoLoadToggle = page.getByRole('checkbox', { name: /Auto Load Next Page/i })
     await page.locator('label.switch-label').filter({ hasText: 'Auto Load Next Page' }).click()
-    await expect(autoLoadToggle).toBeChecked()
+    await expect(autoLoadToggle).not.toBeChecked()
 
     await page.getByRole('button', { name: 'Highlight settings changed from defaults' }).click()
 
@@ -1203,7 +1203,7 @@ test.describe('settings', () => {
     await attachScreenshot('highlighted changed setting')
 
     await resetButton.click()
-    await expect(autoLoadToggle).not.toBeChecked()
+    await expect(autoLoadToggle).toBeChecked()
     await expect(resetButton).toHaveCount(0)
   })
 
@@ -2297,7 +2297,7 @@ test.describe('synced setting indicators', () => {
     await page.locator('label').filter({ hasText: 'Auto load next page' })
       .getByRole('button', { name: 'Stop syncing this setting' })
       .click()
-    await expect(toggle).not.toBeChecked()
+    await expect(toggle).toBeChecked()
 
     const localOnlyLabel = page.locator('label').filter({ hasText: 'Check for Updates' })
     await expect(localOnlyLabel.getByRole('button', { name: /syncing this setting/i })).toHaveCount(0)

--- a/src/renderer/store/modules/settings.js
+++ b/src/renderer/store/modules/settings.js
@@ -454,7 +454,7 @@ const state = {
   // This makes the `favorites` playlist uses as quick bookmark target
   // If the playlist is removed quick bookmark is disabled
   quickBookmarkTargetPlaylistId: 'favorites',
-  generalAutoLoadMorePaginatedItemsEnabled: false,
+  generalAutoLoadMorePaginatedItemsEnabled: true,
   hideToTrayOnMinimize: false,
 
   // The settings below have side effects


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Make sure to follow the contributing guidelines. -->
<!-- Important note, we may remove your pull request if you do not use this provided PR template correctly. -->
<!-- Agent instructions: Preserve every heading, comment, and marker in this template. Never remove or rewrite the release-note-category:start/end, release-note:start/end, or release-note-image:start/end marker pairs. Never remove or rewrite the Release note images section; leave its contents for a human. -->

## Pull Request Type
<!-- Please select what type of pull request this is: [x] -->
- [ ] Bugfix
- [x] Feature Implementation
- [ ] Documentation
- [ ] Other

## Related issue
<!-- Please link the issue your pull request is referring to. -->
<!-- If this pull request fully resolves the relevant issue, put "closes" before the issue number. -->
<!-- Example: "closes #123456". -->

## Description
<!-- Please write a clear and concise description of what the pull request does. -->

Loading the next page automatically currently requires users to opt in. This enables automatic pagination by default for new profiles and default resets while preserving existing users' saved choices.

The affected settings tests now expect the enabled default.

## Release note category
<!-- Select exactly one category. Every pull request must select one. -->
<!-- Select "Not noteworthy" when the pull request fixes a bug in or improves functionality that has not yet appeared in a stable release. -->
<!-- release-note-category:start -->
- [x] Not noteworthy
- [ ] Highlights
- [ ] More improvements
- [ ] Fixed bugs
<!-- release-note-category:end -->

## Release note
<!-- Required unless "Not noteworthy" is selected. -->
<!-- Write one concise, user-facing entry without a leading bullet. -->
<!-- release-note:start -->
Automatically load the next page by default.
<!-- release-note:end -->

## Release note images
<!-- Human-only: Agents must preserve this entire section and leave it empty. -->
<!-- Optional. Paste one or more Markdown images or HTML image tags here. -->
<!-- The release notes will use an HTML image tag and limit images taller than 300 pixels. -->
<!-- release-note-image:start -->

<!-- release-note-image:end -->

## Testing
<!-- How can reviewers verify that the PR produces correct results? -->
<!-- Please provide instructions so that others can ensure that your pull request would produce correct results. For examples see, https://github.com/FreeTubeApp/FreeTube/pull/5743, https://github.com/FreeTubeApp/FreeTube/pull/7349, https://github.com/FreeTubeApp/FreeTube/pull/5125, https://github.com/FreeTubeApp/FreeTube/pull/7338 -->
<!-- Agent instructions: Only write human-facing steps that explain how to verify the change while running this branch in dev mode. Include expected results and, when applicable, helpful console snippets for interactive verification. Do not include automated checks, commands, results, pass counts, or CI status. -->

1. Start the app with a fresh profile and open General Settings.
2. Confirm that **Auto Load Next Page** is enabled.
3. Disable the setting, restart the app, and confirm it remains disabled.
4. Reset the setting to its default and confirm it becomes enabled again.

## Additional context
<!-- Add any other context about the pull request here. -->

Implemented by GPT-5.6 Codex in the Codex desktop harness.
