### PR TITLE
fix(player): fall back between playback engines

### DIFF
--- a/e2e/tests/offline/sabr-error-recovery.spec.mjs
+++ b/e2e/tests/offline/sabr-error-recovery.spec.mjs
@@ -181,15 +181,16 @@ test('terminal yt-dlp playback failure restores the built-in source once', async
     watchView.activeFormat = 'dash'
     watchView.activePlaybackEngine = 'yt-dlp'
     watchView.activePlaybackEngineVersion = 'test'
+    watchView.playbackEngineFallbackTarget = null
     watchView.manifestSrc = 'data:application/dash+xml,yt-dlp'
     watchView.manifestMimeType = 'application/dash+xml'
     watchView.legacyFormats = []
     watchView.builtInPlaybackSource = {
-      manifestSrc: 'data:application/dash+xml,built-in',
+      manifestSrc: null,
       manifestMimeType: 'application/dash+xml',
       sabrData: null,
       legacyFormats: [{ itag: 18 }],
-      streamingDataExpiryDate: null
+      streamingDataExpiryDate: Date.now() + 60_000
     }
 
     const error = { code: 1002, data: ['https://example.invalid/video', 500] }
@@ -201,6 +202,8 @@ test('terminal yt-dlp playback failure restores the built-in source once', async
       secondFallback,
       activePlaybackEngine: watchView.activePlaybackEngine,
       activePlaybackEngineVersion: watchView.activePlaybackEngineVersion,
+      activeFormat: watchView.activeFormat,
+      fallbackTarget: watchView.playbackEngineFallbackTarget,
       manifestSrc: watchView.manifestSrc,
       legacyFormatCount: watchView.legacyFormats.length
     }
@@ -211,8 +214,80 @@ test('terminal yt-dlp playback failure restores the built-in source once', async
     secondFallback: false,
     activePlaybackEngine: 'built-in',
     activePlaybackEngineVersion: null,
-    manifestSrc: 'data:application/dash+xml,built-in',
+    activeFormat: 'legacy',
+    fallbackTarget: 'built-in',
+    manifestSrc: null,
     legacyFormatCount: 1
+  })
+})
+
+test('expired built-in playback source is refreshed before yt-dlp falls back', async ({ app, page }) => {
+  await mockUnplayableWatchPage(app, page)
+  await goTo(page, 'history')
+  await page.getByText('SABR test video').click()
+  await expect(page).toHaveURL(/#\/watch\/jNQXAC9IVRw/)
+  await expect(page.locator('.errorMessage')).toBeVisible({ timeout: 30_000 })
+
+  const result = await page.evaluate(async () => {
+    const app = document.querySelector('#app')?.__vue_app__
+
+    const findWatchView = (vnode) => {
+      if (vnode?.component?.type?.name === 'Watch') return vnode.component.proxy
+      if (vnode?.component?.subTree) {
+        const match = findWatchView(vnode.component.subTree)
+        if (match) return match
+      }
+      if (Array.isArray(vnode?.children)) {
+        for (const child of vnode.children) {
+          const match = findWatchView(child)
+          if (match) return match
+        }
+      }
+      return null
+    }
+
+    const watchView = findWatchView(app?._container?._vnode)
+    if (!watchView) throw new Error('Unable to access the watch view')
+
+    watchView.errorMessage = ''
+    watchView.isPostLiveDvr = false
+    watchView.activePlaybackEngine = 'yt-dlp'
+    watchView.playbackEngineFallbackTarget = null
+    watchView.builtInPlaybackSource = {
+      manifestSrc: 'https://example.invalid/expired.mpd',
+      manifestMimeType: 'application/dash+xml',
+      sabrData: null,
+      legacyFormats: [],
+      streamingDataExpiryDate: Date.now() - 1
+    }
+
+    let reloadOptions = null
+    watchView.reloadView = async (options) => {
+      reloadOptions = options
+      watchView.activePlaybackEngine = 'built-in'
+      watchView.manifestSrc = 'https://example.invalid/refreshed.mpd'
+    }
+
+    const fallbackApplied = await watchView.tryPlaybackEngineFallback({
+      code: 1002,
+      data: ['https://example.invalid/video', 500]
+    })
+
+    return {
+      fallbackApplied,
+      reloadOptions,
+      fallbackTarget: watchView.playbackEngineFallbackTarget,
+      activePlaybackEngine: watchView.activePlaybackEngine,
+      manifestSrc: watchView.manifestSrc
+    }
+  })
+
+  expect(result).toEqual({
+    fallbackApplied: true,
+    reloadOptions: { preserveTitle: true },
+    fallbackTarget: 'built-in',
+    activePlaybackEngine: 'built-in',
+    manifestSrc: 'https://example.invalid/refreshed.mpd'
   })
 })
 

--- a/e2e/tests/offline/sabr-error-recovery.spec.mjs
+++ b/e2e/tests/offline/sabr-error-recovery.spec.mjs
@@ -190,7 +190,7 @@ test('terminal yt-dlp playback failure restores the built-in source once', async
       manifestMimeType: 'application/dash+xml',
       sabrData: null,
       legacyFormats: [{ itag: 18 }],
-      streamingDataExpiryDate: Date.now() + 60_000
+      streamingDataExpiryDate: new Date(Date.now() + 60_000)
     }
 
     const error = { code: 1002, data: ['https://example.invalid/video', 500] }
@@ -258,7 +258,7 @@ test('expired built-in playback source is refreshed before yt-dlp falls back', a
       manifestMimeType: 'application/dash+xml',
       sabrData: null,
       legacyFormats: [],
-      streamingDataExpiryDate: Date.now() - 1
+      streamingDataExpiryDate: new Date(Date.now() - 1)
     }
 
     let reloadOptions = null
@@ -273,8 +273,21 @@ test('expired built-in playback source is refreshed before yt-dlp falls back', a
       data: ['https://example.invalid/video', 500]
     })
 
+    watchView.activePlaybackEngine = 'yt-dlp'
+    watchView.playbackEngineFallbackAttemptedForCurrentVideo = false
+    watchView.playbackEngineFallbackTarget = null
+    watchView.reloadView = async () => {
+      throw new Error('Synthetic built-in source refresh rejection')
+    }
+    const rejectedFallbackApplied = await watchView.tryPlaybackEngineFallback({
+      code: 1002,
+      data: ['https://example.invalid/video', 500]
+    })
+
     return {
       fallbackApplied,
+      rejectedFallbackApplied,
+      pendingAfterRejectedRefresh: watchView.ytDlpStreamsPending,
       reloadOptions,
       fallbackTarget: watchView.playbackEngineFallbackTarget,
       activePlaybackEngine: watchView.activePlaybackEngine,
@@ -284,9 +297,11 @@ test('expired built-in playback source is refreshed before yt-dlp falls back', a
 
   expect(result).toEqual({
     fallbackApplied: true,
+    rejectedFallbackApplied: false,
+    pendingAfterRejectedRefresh: false,
     reloadOptions: { preserveTitle: true },
     fallbackTarget: 'built-in',
-    activePlaybackEngine: 'built-in',
+    activePlaybackEngine: 'yt-dlp',
     manifestSrc: 'https://example.invalid/refreshed.mpd'
   })
 })

--- a/e2e/tests/offline/sabr-error-recovery.spec.mjs
+++ b/e2e/tests/offline/sabr-error-recovery.spec.mjs
@@ -19,10 +19,15 @@ test.use({
  *
  * @param {import('@playwright/test').Page} page
  * @param {Array<{ error: true } | { reloadRequest: true } | { playFor: number } | { seekTo: number }>} script
- * @param {{ isLoading?: boolean, legacyFormats?: Array<object>, rejectReload?: boolean }} options
+ * @param {{
+ *   isLoading?: boolean,
+ *   legacyFormats?: Array<object>,
+ *   rejectReload?: boolean,
+ *   enablePlaybackEngineFallback?: boolean
+ * }} options
  */
 function driveWatchView(page, script, options = {}) {
-  return page.evaluate(async ({ steps, isLoading, legacyFormats, rejectReload }) => {
+  return page.evaluate(async ({ steps, isLoading, legacyFormats, rejectReload, enablePlaybackEngineFallback }) => {
     const app = document.querySelector('#app')?.__vue_app__
 
     const findWatchView = (vnode) => {
@@ -63,6 +68,16 @@ function driveWatchView(page, script, options = {}) {
       if (rejectReload) throw new Error('Synthetic SABR reload rejection')
     }
 
+    if (enablePlaybackEngineFallback) {
+      watchView.extractYtDlpPlaybackSource = async () => {
+        watchView.activePlaybackEngine = 'yt-dlp'
+        return true
+      }
+    } else {
+      // Existing tests exercise the in-engine recovery chain in isolation.
+      watchView.tryPlaybackEngineFallback = async () => false
+    }
+
     // A critical, non-abort shaka error: the kind that walks the format
     // fallback chain. 1002 = BAD_HTTP_STATUS, category 1 = NETWORK.
     const criticalError = () => ({
@@ -95,14 +110,111 @@ function driveWatchView(page, script, options = {}) {
       formats.push(watchView.activeFormat)
     }
 
-    return { reloads, formats, finalFormat: watchView.activeFormat, errorMessage: watchView.errorMessage }
+    return {
+      reloads,
+      formats,
+      finalFormat: watchView.activeFormat,
+      activePlaybackEngine: watchView.activePlaybackEngine,
+      playbackEngineFallbackAttempted: watchView.playbackEngineFallbackAttemptedForCurrentVideo,
+      errorMessage: watchView.errorMessage
+    }
   }, {
     steps: script,
     isLoading: options.isLoading ?? false,
     legacyFormats: options.legacyFormats ?? [{ itag: 18, qualityLabel: '360p', height: 360, width: 640, url: 'https://example.invalid/360p' }],
-    rejectReload: options.rejectReload ?? false
+    rejectReload: options.rejectReload ?? false,
+    enablePlaybackEngineFallback: options.enablePlaybackEngineFallback ?? false
   })
 }
+
+test('terminal built-in playback failure falls back to yt-dlp once', async ({ app, page }) => {
+  await mockUnplayableWatchPage(app, page)
+  await goTo(page, 'history')
+  await page.getByText('SABR test video').click()
+  await expect(page).toHaveURL(/#\/watch\/jNQXAC9IVRw/)
+  await expect(page.locator('.errorMessage')).toBeVisible({ timeout: 30_000 })
+
+  const result = await driveWatchView(page, [
+    { error: true },
+    { error: true },
+    { error: true },
+    { error: true },
+    { error: true }
+  ], { enablePlaybackEngineFallback: true })
+
+  expect(result.reloads).toHaveLength(MAX_SABR_ERROR_RECOVERIES)
+  expect(result.activePlaybackEngine).toBe('yt-dlp')
+  expect(result.playbackEngineFallbackAttempted).toBe(true)
+  expect(result.errorMessage).toBe('')
+})
+
+test('terminal yt-dlp playback failure restores the built-in source once', async ({ app, page }) => {
+  await mockUnplayableWatchPage(app, page)
+  await goTo(page, 'history')
+  await page.getByText('SABR test video').click()
+  await expect(page).toHaveURL(/#\/watch\/jNQXAC9IVRw/)
+  await expect(page.locator('.errorMessage')).toBeVisible({ timeout: 30_000 })
+
+  const result = await page.evaluate(async () => {
+    const app = document.querySelector('#app')?.__vue_app__
+
+    const findWatchView = (vnode) => {
+      if (vnode?.component?.type?.name === 'Watch') return vnode.component.proxy
+      if (vnode?.component?.subTree) {
+        const match = findWatchView(vnode.component.subTree)
+        if (match) return match
+      }
+      if (Array.isArray(vnode?.children)) {
+        for (const child of vnode.children) {
+          const match = findWatchView(child)
+          if (match) return match
+        }
+      }
+      return null
+    }
+
+    const watchView = findWatchView(app?._container?._vnode)
+    if (!watchView) throw new Error('Unable to access the watch view')
+
+    watchView.errorMessage = ''
+    watchView.isPostLiveDvr = false
+    watchView.activeFormat = 'dash'
+    watchView.activePlaybackEngine = 'yt-dlp'
+    watchView.activePlaybackEngineVersion = 'test'
+    watchView.manifestSrc = 'data:application/dash+xml,yt-dlp'
+    watchView.manifestMimeType = 'application/dash+xml'
+    watchView.legacyFormats = []
+    watchView.builtInPlaybackSource = {
+      manifestSrc: 'data:application/dash+xml,built-in',
+      manifestMimeType: 'application/dash+xml',
+      sabrData: null,
+      legacyFormats: [{ itag: 18 }],
+      streamingDataExpiryDate: null
+    }
+
+    const error = { code: 1002, data: ['https://example.invalid/video', 500] }
+    const firstFallback = await watchView.tryPlaybackEngineFallback(error)
+    const secondFallback = await watchView.tryPlaybackEngineFallback(error)
+
+    return {
+      firstFallback,
+      secondFallback,
+      activePlaybackEngine: watchView.activePlaybackEngine,
+      activePlaybackEngineVersion: watchView.activePlaybackEngineVersion,
+      manifestSrc: watchView.manifestSrc,
+      legacyFormatCount: watchView.legacyFormats.length
+    }
+  })
+
+  expect(result).toEqual({
+    firstFallback: true,
+    secondFallback: false,
+    activePlaybackEngine: 'built-in',
+    activePlaybackEngineVersion: null,
+    manifestSrc: 'data:application/dash+xml,built-in',
+    legacyFormatCount: 1
+  })
+})
 
 test('a SABR reload preserves the active video quality', async ({ app, page }) => {
   await mockUnplayableWatchPage(app, page)

--- a/src/renderer/views/Watch/Watch.js
+++ b/src/renderer/views/Watch/Watch.js
@@ -289,6 +289,8 @@ export default defineComponent({
        */
       builtInPlaybackSource: null,
       playbackEngineFallbackAttemptedForCurrentVideo: false,
+      /** @type {'built-in' | 'yt-dlp' | null} */
+      playbackEngineFallbackTarget: null,
       // yt-dlp is a separate process that takes a while to extract the streams. The
       // metadata is already there at that point, so the rest of the page is shown
       // immediately and only the player waits behind a thumbnail placeholder.
@@ -1485,6 +1487,7 @@ export default defineComponent({
         this.ipBlockRecoveryAttemptedForCurrentVideo = false
         this.streamErrorReloadAttemptedForCurrentVideo = false
         this.playbackEngineFallbackAttemptedForCurrentVideo = false
+        this.playbackEngineFallbackTarget = null
         this.sabrErrorRecoveryAttempts = 0
         this.sabrErrorRecoveriesForCurrentVideo = 0
         this.sabrErrorRecoveryLastSeconds = null
@@ -3908,6 +3911,7 @@ export default defineComponent({
         }
 
         this.playbackEngineFallbackAttemptedForCurrentVideo = true
+        this.playbackEngineFallbackTarget = 'built-in'
         this.ytDlpStreamsPending = true
         await this.$nextTick()
         if (!this.isCurrentVideoLoad(loadGeneration, videoId)) {
@@ -3915,6 +3919,14 @@ export default defineComponent({
         }
 
         const source = this.builtInPlaybackSource
+        if (
+          source.streamingDataExpiryDate !== null &&
+          new Date() > source.streamingDataExpiryDate
+        ) {
+          await this.reloadView({ preserveTitle: true })
+          return true
+        }
+
         this.manifestSrc = source.manifestSrc
         this.manifestMimeType = source.manifestMimeType
         this.sabrData = source.sabrData
@@ -3923,9 +3935,15 @@ export default defineComponent({
         this.activePlaybackEngine = 'built-in'
         this.activePlaybackEngineVersion = null
 
-        if (this.activeFormat === 'dash' && this.manifestSrc === null && this.legacyFormats.length > 0) {
+        if (
+          (this.activeFormat === 'dash' || this.activeFormat === 'audio') &&
+          this.manifestSrc === null &&
+          this.legacyFormats.length > 0
+        ) {
           this.activeFormat = 'legacy'
         } else if (this.activeFormat === 'legacy' && this.legacyFormats.length === 0 && this.manifestSrc !== null) {
+          this.activeFormat = 'dash'
+        } else if (this.activeFormat === 'audio' && !this.audioFormatAvailable) {
           this.activeFormat = 'dash'
         }
 
@@ -3938,6 +3956,7 @@ export default defineComponent({
       }
 
       this.playbackEngineFallbackAttemptedForCurrentVideo = true
+      this.playbackEngineFallbackTarget = 'yt-dlp'
       this.ytDlpStreamsPending = true
       this.showTabToast({
         message: this.t('Change Format.Built-in Fallback Template', { error: reason }),
@@ -3946,11 +3965,18 @@ export default defineComponent({
 
       try {
         const fallbackApplied = await this.extractYtDlpPlaybackSource(loadGeneration, videoId)
-        return this.isCurrentVideoLoad(loadGeneration, videoId) ? fallbackApplied : true
+        if (!this.isCurrentVideoLoad(loadGeneration, videoId)) {
+          return true
+        }
+        if (!fallbackApplied) {
+          this.playbackEngineFallbackTarget = null
+        }
+        return fallbackApplied
       } catch (fallbackError) {
         if (!this.isCurrentVideoLoad(loadGeneration, videoId)) {
           return true
         }
+        this.playbackEngineFallbackTarget = null
         console.error('Falling back to yt-dlp playback failed', fallbackError)
         return false
       } finally {
@@ -3972,7 +3998,11 @@ export default defineComponent({
      * @param {string} videoId
      */
     applyYtDlpPlaybackSource: async function (loadGeneration, videoId) {
-      if (!process.env.IS_ELECTRON || this.videoPlaybackEngine !== 'yt-dlp') {
+      if (
+        !process.env.IS_ELECTRON ||
+        this.playbackEngineFallbackTarget === 'built-in' ||
+        (this.videoPlaybackEngine !== 'yt-dlp' && this.playbackEngineFallbackTarget !== 'yt-dlp')
+      ) {
         return
       }
 

--- a/src/renderer/views/Watch/Watch.js
+++ b/src/renderer/views/Watch/Watch.js
@@ -279,6 +279,16 @@ export default defineComponent({
       activePlaybackEngine: 'built-in',
       /** @type {string | null} the yt-dlp version that extracted the current streams */
       activePlaybackEngineVersion: null,
+      /** @type {{
+       *   manifestSrc: string | null,
+       *   manifestMimeType: MANIFEST_TYPE_DASH | MANIFEST_TYPE_HLS | MANIFEST_TYPE_SABR,
+       *   sabrData: SabrData | null,
+       *   legacyFormats: object[],
+       *   streamingDataExpiryDate: Date | null
+       * } | null}
+       */
+      builtInPlaybackSource: null,
+      playbackEngineFallbackAttemptedForCurrentVideo: false,
       // yt-dlp is a separate process that takes a while to extract the streams. The
       // metadata is already there at that point, so the rest of the page is shown
       // immediately and only the player waits behind a thumbnail placeholder.
@@ -1474,6 +1484,7 @@ export default defineComponent({
       if (videoIdChanged) {
         this.ipBlockRecoveryAttemptedForCurrentVideo = false
         this.streamErrorReloadAttemptedForCurrentVideo = false
+        this.playbackEngineFallbackAttemptedForCurrentVideo = false
         this.sabrErrorRecoveryAttempts = 0
         this.sabrErrorRecoveriesForCurrentVideo = 0
         this.sabrErrorRecoveryLastSeconds = null
@@ -1594,6 +1605,7 @@ export default defineComponent({
       this.sabrData = null
       this.activePlaybackEngine = 'built-in'
       this.activePlaybackEngineVersion = null
+      this.builtInPlaybackSource = null
       this.ytDlpStreamsPending = false
       this.legacyFormats = []
       this.captions = []
@@ -3740,6 +3752,10 @@ export default defineComponent({
           case 429:
             this.handleWatchProgressAutoSaveWhenProgressEnabled()
 
+            if (await this.tryPlaybackEngineFallback(error)) {
+              return
+            }
+
             this.errorMessage = '[BAD_HTTP_STATUS: 429] Ratelimited'
             return
           case 403:
@@ -3760,6 +3776,10 @@ export default defineComponent({
                   : '[BAD_HTTP_STATUS: 403] Potential causes: IP block or streaming URL deciphering failed'
 
               if (await this.reloadAfterStreamErrorOnce(specificError)) {
+                return
+              }
+
+              if (await this.tryPlaybackEngineFallback(error)) {
                 return
               }
 
@@ -3786,6 +3806,10 @@ export default defineComponent({
               return
             }
 
+            if (await this.tryPlaybackEngineFallback(error)) {
+              return
+            }
+
             this.errorMessage = specificError
             this.customErrorIcon = ['fas', 'clock']
             return
@@ -3800,7 +3824,11 @@ export default defineComponent({
         )
       ) { return }
 
-      const stopPlaybackRecovery = () => {
+      const stopPlaybackRecovery = async () => {
+        if (await this.tryPlaybackEngineFallback(error)) {
+          return
+        }
+
         this.handleWatchProgressAutoSaveWhenProgressEnabled()
         const status = error.code === Code.BAD_HTTP_STATUS ? error.data[1] : error.code
         this.errorMessage = `[PLAYER_ERROR: ${status}] Unable to recover the video stream. Please reload this video.`
@@ -3816,13 +3844,13 @@ export default defineComponent({
         // Audio is an explicit playback mode, not a degraded video fallback.
         // Keep the bounded refresh behavior above, then stop with the actual
         // error instead of briefly replacing the video player with audio.
-        stopPlaybackRecovery()
+        await stopPlaybackRecovery()
         return
       }
 
       if (this.isLive || this.isPostLiveDvr) {
         if (this.activeFormat === 'dash') {
-          stopPlaybackRecovery()
+          await stopPlaybackRecovery()
         } else {
           console.error('Unable to play audio formats. Reverting to DASH formats...')
           this.enableDashFormat()
@@ -3837,16 +3865,97 @@ export default defineComponent({
               console.error('Unable to play DASH formats. Reverting to legacy formats...')
               this.enableLegacyFormat()
             } else {
-              stopPlaybackRecovery()
+              await stopPlaybackRecovery()
             }
             break
           case 'legacy':
-            stopPlaybackRecovery()
+            await stopPlaybackRecovery()
             break
           case 'audio':
             console.error('Unable to play audio formats. Reverting to DASH formats...')
             this.enableDashFormat()
             break
+        }
+      }
+    },
+
+    /**
+     * Tries the other playback engine once after the selected engine exhausts
+     * its own stream recovery options.
+     * @param {import('shaka-player/dist/shaka-player.ui').default.util.Error} error
+     * @returns {Promise<boolean>}
+     */
+    tryPlaybackEngineFallback: async function (error) {
+      if (
+        !process.env.IS_ELECTRON ||
+        this.playbackEngineFallbackAttemptedForCurrentVideo ||
+        this.isUpcoming ||
+        this.isPostLiveDvr
+      ) {
+        return false
+      }
+
+      const status = error.code === shaka.util.Error.Code.BAD_HTTP_STATUS
+        ? error.data[1]
+        : error.code
+      const reason = `[PLAYER_ERROR: ${status}]`
+      const loadGeneration = this.videoLoadGeneration
+      const videoId = this.videoId
+
+      if (this.activePlaybackEngine === 'yt-dlp') {
+        if (this.builtInPlaybackSource === null) {
+          return false
+        }
+
+        this.playbackEngineFallbackAttemptedForCurrentVideo = true
+        this.ytDlpStreamsPending = true
+        await this.$nextTick()
+        if (!this.isCurrentVideoLoad(loadGeneration, videoId)) {
+          return true
+        }
+
+        const source = this.builtInPlaybackSource
+        this.manifestSrc = source.manifestSrc
+        this.manifestMimeType = source.manifestMimeType
+        this.sabrData = source.sabrData
+        this.legacyFormats = source.legacyFormats
+        this.streamingDataExpiryDate = source.streamingDataExpiryDate
+        this.activePlaybackEngine = 'built-in'
+        this.activePlaybackEngineVersion = null
+
+        if (this.activeFormat === 'dash' && this.manifestSrc === null && this.legacyFormats.length > 0) {
+          this.activeFormat = 'legacy'
+        } else if (this.activeFormat === 'legacy' && this.legacyFormats.length === 0 && this.manifestSrc !== null) {
+          this.activeFormat = 'dash'
+        }
+
+        this.showTabToast({
+          message: this.t('Change Format.yt-dlp Fallback Template', { error: reason }),
+          icon: ['fas', 'exchange-alt'],
+        })
+        this.ytDlpStreamsPending = false
+        return true
+      }
+
+      this.playbackEngineFallbackAttemptedForCurrentVideo = true
+      this.ytDlpStreamsPending = true
+      this.showTabToast({
+        message: this.t('Change Format.Built-in Fallback Template', { error: reason }),
+        icon: ['fas', 'exchange-alt'],
+      })
+
+      try {
+        const fallbackApplied = await this.extractYtDlpPlaybackSource(loadGeneration, videoId)
+        return this.isCurrentVideoLoad(loadGeneration, videoId) ? fallbackApplied : true
+      } catch (fallbackError) {
+        if (!this.isCurrentVideoLoad(loadGeneration, videoId)) {
+          return true
+        }
+        console.error('Falling back to yt-dlp playback failed', fallbackError)
+        return false
+      } finally {
+        if (this.isCurrentVideoLoad(loadGeneration, videoId)) {
+          this.ytDlpStreamsPending = false
         }
       }
     },
@@ -3899,7 +4008,7 @@ export default defineComponent({
       try {
         source = await getYtDlpPlaybackSource(videoId)
       } catch (error) {
-        if (!this.isCurrentVideoLoad(loadGeneration, videoId)) { return }
+        if (!this.isCurrentVideoLoad(loadGeneration, videoId)) { return false }
 
         console.error(`yt-dlp could not provide streams for ${videoId}, falling back to the built-in engine...`, error)
         this.showTabToast({
@@ -3907,10 +4016,18 @@ export default defineComponent({
           time: 7000,
           icon: ['fas', 'circle-exclamation'],
         })
-        return
+        return false
       }
 
-      if (!this.isCurrentVideoLoad(loadGeneration, videoId)) { return }
+      if (!this.isCurrentVideoLoad(loadGeneration, videoId)) { return false }
+
+      this.builtInPlaybackSource = {
+        manifestSrc: this.manifestSrc,
+        manifestMimeType: this.manifestMimeType,
+        sabrData: this.sabrData,
+        legacyFormats: this.legacyFormats,
+        streamingDataExpiryDate: this.streamingDataExpiryDate
+      }
 
       this.manifestSrc = source.manifestSrc
       this.manifestMimeType = source.manifestMimeType
@@ -3933,6 +4050,8 @@ export default defineComponent({
       if (this.activeFormat === 'audio' && !this.audioFormatAvailable) {
         this.activeFormat = 'dash'
       }
+
+      return true
     },
 
     /**

--- a/src/renderer/views/Watch/Watch.js
+++ b/src/renderer/views/Watch/Watch.js
@@ -3923,8 +3923,16 @@ export default defineComponent({
           source.streamingDataExpiryDate !== null &&
           new Date() > source.streamingDataExpiryDate
         ) {
-          await this.reloadView({ preserveTitle: true })
-          return true
+          try {
+            await this.reloadView({ preserveTitle: true })
+            return true
+          } catch (reloadError) {
+            console.error('Refreshing the built-in playback source failed', reloadError)
+            if (this.tabRoute.params.id === videoId) {
+              this.ytDlpStreamsPending = false
+            }
+            return false
+          }
         }
 
         this.manifestSrc = source.manifestSrc
@@ -3935,17 +3943,7 @@ export default defineComponent({
         this.activePlaybackEngine = 'built-in'
         this.activePlaybackEngineVersion = null
 
-        if (
-          (this.activeFormat === 'dash' || this.activeFormat === 'audio') &&
-          this.manifestSrc === null &&
-          this.legacyFormats.length > 0
-        ) {
-          this.activeFormat = 'legacy'
-        } else if (this.activeFormat === 'legacy' && this.legacyFormats.length === 0 && this.manifestSrc !== null) {
-          this.activeFormat = 'dash'
-        } else if (this.activeFormat === 'audio' && !this.audioFormatAvailable) {
-          this.activeFormat = 'dash'
-        }
+        this.alignActiveFormatWithAvailableSources()
 
         this.showTabToast({
           message: this.t('Change Format.yt-dlp Fallback Template', { error: reason }),
@@ -3983,6 +3981,20 @@ export default defineComponent({
         if (this.isCurrentVideoLoad(loadGeneration, videoId)) {
           this.ytDlpStreamsPending = false
         }
+      }
+    },
+
+    alignActiveFormatWithAvailableSources: function () {
+      if (
+        (this.activeFormat === 'dash' || this.activeFormat === 'audio') &&
+        this.manifestSrc === null &&
+        this.legacyFormats.length > 0
+      ) {
+        this.activeFormat = 'legacy'
+      } else if (this.activeFormat === 'legacy' && this.legacyFormats.length === 0 && this.manifestSrc !== null) {
+        this.activeFormat = 'dash'
+      } else if (this.activeFormat === 'audio' && !this.audioFormatAvailable) {
+        this.activeFormat = 'dash'
       }
     },
 
@@ -4073,13 +4085,7 @@ export default defineComponent({
       this.activePlaybackEngine = 'yt-dlp'
       this.activePlaybackEngineVersion = source.version
 
-      if (this.activeFormat === 'legacy' && source.legacyFormats.length === 0) {
-        this.activeFormat = 'dash'
-      }
-
-      if (this.activeFormat === 'audio' && !this.audioFormatAvailable) {
-        this.activeFormat = 'dash'
-      }
+      this.alignActiveFormatWithAvailableSources()
 
       return true
     },

--- a/static/locales/en-US.yaml
+++ b/static/locales/en-US.yaml
@@ -1659,6 +1659,8 @@ Change Format:
     Audio: Audio only, useful for saving bandwidth or listening in the background
   yt-dlp Fallback Template: 'yt-dlp could not provide the streams, using the built-in
     engine instead: {error}'
+  Built-in Fallback Template: 'The built-in engine could not play the stream, trying
+    yt-dlp instead: {error}'
 Share:
   Share Video: Share Video
   Share Post: Share Post


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Make sure to follow the contributing guidelines. -->
<!-- Important note, we may remove your pull request if you do not use this provided PR template correctly. -->
<!-- Agent instructions: Preserve every heading, comment, and marker in this template. Never remove or rewrite the release-note-category:start/end, release-note:start/end, or release-note-image:start/end marker pairs. Never remove or rewrite the Release note images section; leave its contents for a human. -->

## Pull Request Type
<!-- Please select what type of pull request this is: [x] -->
- [x] Bugfix
- [ ] Feature Implementation
- [ ] Documentation
- [ ] Other

## Related issue
<!-- Please link the issue your pull request is referring to. -->
<!-- If this pull request fully resolves the relevant issue, put "closes" before the issue number. -->
<!-- Example: "closes #123456". -->

## Description
<!-- Please write a clear and concise description of what the pull request does. -->
Playback currently falls back to the built-in engine when yt-dlp cannot extract streams, but terminal playback failures do not switch engines in either direction. This can leave a video unplayable even though the other engine could provide a working stream.

Preserve the built-in stream source before yt-dlp replaces it, then try the alternate engine after the active engine exhausts its normal SABR and format recovery. Each video may cross engines only once, preventing a broken stream from bouncing between engines indefinitely. Upcoming and post-live-DVR videos retain their existing behavior.

## Release note category
<!-- Select exactly one category. Every pull request must select one. -->
<!-- Select "Not noteworthy" when the pull request fixes a bug in or improves functionality that has not yet appeared in a stable release. -->
<!-- release-note-category:start -->
- [ ] Not noteworthy
- [ ] Highlights
- [ ] More improvements
- [x] Fixed bugs
<!-- release-note-category:end -->

## Release note
<!-- Required unless "Not noteworthy" is selected. -->
<!-- Write one concise, user-facing entry without a leading bullet. -->
<!-- release-note:start -->
Automatically try the other playback engine when a video stream cannot be recovered.
<!-- release-note:end -->

## Release note images
<!-- Human-only: Agents must preserve this entire section and leave it empty. -->
<!-- Optional. Paste one or more Markdown images or HTML image tags here. -->
<!-- The release notes will use an HTML image tag and limit images taller than 300 pixels. -->
<!-- release-note-image:start -->

<!-- release-note-image:end -->

## Testing
<!-- How can reviewers verify that the PR produces correct results? -->
<!-- Please provide instructions so that others can ensure that your pull request would produce correct results. For examples see, https://github.com/FreeTubeApp/FreeTube/pull/5743, https://github.com/FreeTubeApp/FreeTube/pull/7349, https://github.com/FreeTubeApp/FreeTube/pull/5125, https://github.com/FreeTubeApp/FreeTube/pull/7338 -->
<!-- Agent instructions: Only write human-facing steps that explain how to verify the change while running this branch in dev mode. Include expected results and, when applicable, helpful console snippets for interactive verification. Do not include automated checks, commands, results, pass counts, or CI status. -->
1. Select the built-in playback engine and open a video whose built-in streams reach a terminal playback error. The app should show the stream-fetching placeholder, switch to yt-dlp, and continue without displaying the terminal player error.
2. Select yt-dlp and open a video, then make its extracted streams fail after the player loads. The app should restore the preserved built-in stream source and identify the built-in engine in the format prompt.
3. Make the restored or alternate engine fail as well. The app should display the terminal playback error instead of switching engines repeatedly.

## Additional context
<!-- Add any other context about the pull request here. -->
The alternate engine is attempted only after the existing in-engine retries and DASH/legacy recovery are exhausted.
