### PR TITLE
fix(invidious): handle invalid dates and unavailable videos

### DIFF
--- a/e2e/tests/offline/subscriptions-feed.spec.mjs
+++ b/e2e/tests/offline/subscriptions-feed.spec.mjs
@@ -14,6 +14,8 @@ function feedVideo(videoId, title, authorId, published, extra = {}) {
     author: authorId === CHANNEL_A ? 'Channel A' : 'Channel B',
     authorId,
     published,
+    // Invidious includes this sentinel value for videos that are not premieres.
+    premiereTimestamp: 0,
     viewCount: 1000,
     lengthSeconds: 120,
     liveNow: false,

--- a/src/renderer/components/FtListVideo/FtListVideo.vue
+++ b/src/renderer/components/FtListVideo/FtListVideo.vue
@@ -1623,7 +1623,7 @@ function parseVideoData() {
     }
     uploadedTime.value = premiereDate.toLocaleString([locale.value, 'en'])
     published.value = premiereDate.getTime()
-  } else if (props.data.premiereTimestamp !== undefined) {
+  } else if (props.data.premiereTimestamp > 0) {
     uploadedTime.value = new Date(props.data.premiereTimestamp * 1000).toLocaleString([locale.value, 'en'])
     published.value = props.data.premiereTimestamp * 1000
   } else if (typeof props.data.published === 'number' && !isLive.value) {

--- a/src/renderer/helpers/api/invidious-playlists.js
+++ b/src/renderer/helpers/api/invidious-playlists.js
@@ -1,0 +1,12 @@
+/**
+ * Invidious includes unavailable playlist videos with no usable metadata.
+ * Filtering them also prevents thumbnail requests that can stall the instance.
+ * @param {{ title: string, author: string, authorId: string | null }[]} videos
+ */
+export function filterUnavailableInvidiousPlaylistVideos(videos) {
+  return videos.filter(video => !(
+    video.title === '' &&
+    video.author === '' &&
+    video.authorId == null
+  ))
+}

--- a/src/renderer/helpers/api/invidious.js
+++ b/src/renderer/helpers/api/invidious.js
@@ -1,6 +1,7 @@
 import store from '../../store/index'
 import { calculatePublishedDate, getRelativeTimeFromDate } from '../utils'
 import { isNullOrEmpty } from '../strings'
+import { filterUnavailableInvidiousPlaylistVideos } from './invidious-playlists'
 import autolinker from 'autolinker'
 import { FormatUtils, Misc, Player } from 'youtubei.js'
 
@@ -314,6 +315,7 @@ export async function invidiousGetPlaylistInfo(playlistId) {
     id: playlistId,
   })
 
+  playlist.videos = filterUnavailableInvidiousPlaylistVideos(playlist.videos)
   normalizeManyInvidiousVideosAttributes(playlist.videos)
   setMultiplePublishedTimestamps(playlist.videos)
 

--- a/src/renderer/views/Playlist/Playlist.vue
+++ b/src/renderer/views/Playlist/Playlist.vue
@@ -557,7 +557,7 @@ async function getPlaylistInvidious() {
 
     playlistTitle.value = result.title
     playlistDescription.value = result.description
-    firstVideoId.value = result.videos[0].videoId
+    firstVideoId.value = result.videos[0]?.videoId ?? ''
     viewCount.value = result.viewCount
     videoCount.value = result.videoCount
     channelName.value = result.author

--- a/tests/unit/invidious-playlists.test.mjs
+++ b/tests/unit/invidious-playlists.test.mjs
@@ -20,6 +20,7 @@ test('filters unavailable Invidious playlist videos', () => {
     filterUnavailableInvidiousPlaylistVideos([available, unavailable]),
     [available]
   )
+  assert.deepEqual(filterUnavailableInvidiousPlaylistVideos([unavailable]), [])
 })
 
 test('keeps playlist videos when any identifying metadata is present', () => {

--- a/tests/unit/invidious-playlists.test.mjs
+++ b/tests/unit/invidious-playlists.test.mjs
@@ -1,0 +1,33 @@
+import assert from 'node:assert/strict'
+import test from 'node:test'
+
+import { filterUnavailableInvidiousPlaylistVideos } from '../../src/renderer/helpers/api/invidious-playlists.js'
+
+test('filters unavailable Invidious playlist videos', () => {
+  const available = {
+    title: 'Available video',
+    author: 'Channel',
+    authorId: 'channel-id'
+  }
+  const unavailable = {
+    title: '',
+    author: '',
+    authorId: null,
+    videoId: 'unavailable-video'
+  }
+
+  assert.deepEqual(
+    filterUnavailableInvidiousPlaylistVideos([available, unavailable]),
+    [available]
+  )
+})
+
+test('keeps playlist videos when any identifying metadata is present', () => {
+  const videos = [
+    { title: 'Untitled channel video', author: '', authorId: null },
+    { title: '', author: 'Channel', authorId: null },
+    { title: '', author: '', authorId: 'channel-id' }
+  ]
+
+  assert.deepEqual(filterUnavailableInvidiousPlaylistVideos(videos), videos)
+})


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Make sure to follow the contributing guidelines. -->
<!-- Important note, we may remove your pull request if you do not use this provided PR template correctly. -->
<!-- Agent instructions: Preserve every heading, comment, and marker in this template. Never remove or rewrite the release-note-category:start/end, release-note:start/end, or release-note-image:start/end marker pairs. Never remove or rewrite the Release note images section; leave its contents for a human. -->

## Pull Request Type
<!-- Please select what type of pull request this is: [x] -->
- [x] Bugfix
- [ ] Feature Implementation
- [ ] Documentation
- [ ] Other

## Related issue
<!-- Please link the issue your pull request is referring to. -->
<!-- If this pull request fully resolves the relevant issue, put "closes" before the issue number. -->
<!-- Example: "closes #123456". -->

Closes #647.
Also resolves FreeTubeApp/FreeTube#9606 for OpenTubeX.

## Description
<!-- Please write a clear and concise description of what the pull request does. -->

This fixes two problems caused by Invidious video metadata:

- Regular videos displayed January 1, 1970 because Invidious's `premiereTimestamp: 0` sentinel took precedence over the real `published` timestamp. Only positive premiere timestamps are now used.
- Playlists containing unavailable videos could stall further app loading because cards requested thumbnails for entries with no usable metadata. Unavailable entries are now filtered at the shared Invidious playlist API boundary, covering both the playlist page and watch-page playlist.

## Release note category
<!-- Select exactly one category. Every pull request must select one. -->
<!-- Select "Not noteworthy" when the pull request fixes a bug in or improves functionality that has not yet appeared in a stable release. -->
<!-- release-note-category:start -->
- [ ] Not noteworthy
- [ ] Highlights
- [ ] More improvements
- [x] Fixed bugs
<!-- release-note-category:end -->

## Release note
<!-- Required unless "Not noteworthy" is selected. -->
<!-- Write one concise, user-facing entry without a leading bullet. -->
<!-- release-note:start -->
Fixed incorrect publish dates and app stalls caused by unavailable playlist videos when using Invidious.
<!-- release-note:end -->

## Release note images
<!-- Human-only: Agents must preserve this entire section and leave it empty. -->
<!-- Optional. Paste one or more Markdown images or HTML image tags here. -->
<!-- The release notes will use an HTML image tag and limit images taller than 300 pixels. -->
<!-- release-note-image:start -->

<!-- release-note-image:end -->

## Testing
<!-- How can reviewers verify that the PR produces correct results? -->
<!-- Please provide instructions so that others can ensure that your pull request does produce correct results. For examples see, https://github.com/FreeTubeApp/FreeTube/pull/5743, https://github.com/FreeTubeApp/FreeTube/pull/7349, https://github.com/FreeTubeApp/FreeTube/pull/5125, https://github.com/FreeTubeApp/FreeTube/pull/7338 -->
<!-- Agent instructions: Only write human-facing steps that explain how to verify the change while running this branch in dev mode. Include expected results and, when applicable, helpful console snippets for interactive verification. Do not include automated checks, commands, results, pass counts, or CI status. -->

1. Configure a self-hosted Invidious instance as the primary API.
2. Open a channel's Videos tab and the subscriptions feed.
3. Confirm regular videos show their actual relative publish dates instead of January 1, 1970.
4. Confirm upcoming premieres still show their scheduled dates.
5. Open `https://youtube.com/playlist?list=PLvMVt4c68EeXRV2R1fdieei9HwpuUKXKL` and scroll through the playlist.
6. Confirm unavailable entries are omitted and navigating to another page still loads normally.

## Additional context
<!-- Add any other context about the pull request here. -->

Invidious returns Unix timestamps in seconds, which OpenTubeX already normalizes to milliseconds. It represents unavailable playlist entries with empty titles and authors plus a null author ID; these entries contain no useful display metadata.