### PR TITLE
feat(tabs): load missing icons without loading tabs

### DIFF
--- a/e2e/tests/offline/tab-avatar-cache.spec.mjs
+++ b/e2e/tests/offline/tab-avatar-cache.spec.mjs
@@ -1,6 +1,7 @@
 import path from 'node:path'
 import { createHash } from 'node:crypto'
 import { readdir, readFile } from 'node:fs/promises'
+import { createServer } from 'node:http'
 
 import { test, expect, goToSettingsSection } from '../../helpers/app.mjs'
 
@@ -114,8 +115,10 @@ test.describe('loading missing tab icons', () => {
     })
 
     const themeSection = await goToSettingsSection(page, 'theme')
-    await themeSection.getByRole('button', { name: 'Load Missing Tab Icons' }).click()
+    const loadButton = themeSection.getByRole('button', { name: 'Load Missing Tab Icons' })
+    await loadButton.click()
     await expect(page.locator('.toast')).toContainText('Missing tab icons loaded: 1')
+    await expect(loadButton).toBeDisabled()
 
     await expect.poll(() => page.evaluate(tabId => {
       return window.ftElectron.tabs.getState().then(state => {
@@ -131,5 +134,82 @@ test.describe('loading missing tab icons', () => {
       avatarLoaded: true,
       isUnloaded: true
     })
+  })
+})
+
+test.describe('automatic missing tab icons', () => {
+  const server = createServer()
+  const seed = {
+    settings: {
+      backendPreference: 'invidious',
+      defaultInvidiousInstance: '',
+      startupBehavior: 'restoreTabLoadState'
+    },
+    tabSessions: [{
+      _id: 'avatar-startup-session',
+      value: {
+        tabs: [{
+          id: 'active-tab',
+          url: 'app://bundle/index.html#/history',
+          title: 'History',
+          isUnloaded: false
+        }, {
+          id: 'missing-avatar-tab',
+          url: 'app://bundle/index.html#/channel/UCstartup',
+          title: 'Unloaded channel',
+          isUnloaded: true
+        }],
+        activeTabId: 'active-tab',
+        bounds: { x: 0, y: 0, width: 1600, height: 900, maximized: false }
+      }
+    }]
+  }
+
+  test.use({ seed })
+
+  test.beforeAll(async () => {
+    server.on('request', (request, response) => {
+      if (request.url?.startsWith('/api/v1/channels/UCstartup')) {
+        response.setHeader('content-type', 'application/json')
+        response.end(JSON.stringify({
+          authorThumbnails: [{ url: `${seed.settings.defaultInvidiousInstance}/avatar.png` }],
+          tabs: []
+        }))
+      } else if (request.url === '/avatar.png') {
+        response.setHeader('content-type', 'image/png')
+        response.end(Buffer.from(AVATAR_PNG, 'base64'))
+      } else {
+        response.statusCode = 404
+        response.end()
+      }
+    })
+    await new Promise(resolve => server.listen(0, '127.0.0.1', resolve))
+    const address = server.address()
+    seed.settings.defaultInvidiousInstance = `http://127.0.0.1:${address.port}`
+  })
+
+  test.afterAll(async () => {
+    server.closeAllConnections()
+    await new Promise(resolve => server.close(resolve))
+  })
+
+  test('loads restored icons on startup and disables the completed action', async ({ page }) => {
+    await expect.poll(() => page.evaluate(() => {
+      return window.ftElectron.tabs.getState().then(state => {
+        const tab = state.tabs.find(candidate => candidate.id === 'missing-avatar-tab')
+        return {
+          activeTabId: state.activeTabId,
+          avatarLoaded: tab?.avatarUrl?.startsWith('data:image/jpeg;base64,') === true,
+          isUnloaded: tab?.isUnloaded
+        }
+      })
+    })).toEqual({
+      activeTabId: 'active-tab',
+      avatarLoaded: true,
+      isUnloaded: true
+    })
+
+    const themeSection = await goToSettingsSection(page, 'theme')
+    await expect(themeSection.getByRole('button', { name: 'Load Missing Tab Icons' })).toBeDisabled()
   })
 })

--- a/e2e/tests/offline/tab-avatar-cache.spec.mjs
+++ b/e2e/tests/offline/tab-avatar-cache.spec.mjs
@@ -2,7 +2,7 @@ import path from 'node:path'
 import { createHash } from 'node:crypto'
 import { readdir, readFile } from 'node:fs/promises'
 
-import { test, expect } from '../../helpers/app.mjs'
+import { test, expect, goToSettingsSection } from '../../helpers/app.mjs'
 
 // A 1x1 PNG, small enough to stay well inside the avatar download limit
 const AVATAR_PNG = 'iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mP8z8BQDwAEhQGAhKmMIQAAAABJRU5ErkJggg=='
@@ -78,4 +78,58 @@ test('tabs of the same channel share one cached avatar file', async ({ app, page
     const files = await listCachedFiles(app.userDataDir, baseline)
     return files.some(file => file.name === sharedAvatar.name)
   }).toBe(false)
+})
+
+test.describe('loading missing tab icons', () => {
+  test.use({
+    seed: {
+      settings: {
+        backendPreference: 'invidious',
+        defaultInvidiousInstance: 'https://invidious.test'
+      }
+    }
+  })
+
+  test('caches an unloaded tab icon without activating the tab', async ({ page }) => {
+    await page.route('https://invidious.test/api/v1/channels/UCmissing?*', route => route.fulfill({
+      contentType: 'application/json',
+      body: JSON.stringify({
+        authorThumbnails: [{ url: 'https://images.test/avatar.png' }],
+        tabs: []
+      })
+    }))
+    await page.route('https://images.test/avatar.png', route => route.fulfill({
+      contentType: 'image/png',
+      body: Buffer.from(AVATAR_PNG, 'base64')
+    }))
+
+    const { tabId, activeTabId } = await page.evaluate(async () => {
+      const activeTabId = (await window.ftElectron.tabs.getState()).activeTabId
+      const tab = await window.ftElectron.tabs.create({
+        route: '/channel/UCmissing',
+        makeActive: false,
+        lazyLoad: true
+      })
+      return { tabId: tab.id, activeTabId }
+    })
+
+    const themeSection = await goToSettingsSection(page, 'theme')
+    await themeSection.getByRole('button', { name: 'Load Missing Tab Icons' }).click()
+    await expect(page.locator('.toast')).toContainText('Missing tab icons loaded: 1')
+
+    await expect.poll(() => page.evaluate(tabId => {
+      return window.ftElectron.tabs.getState().then(state => {
+        const tab = state.tabs.find(candidate => candidate.id === tabId)
+        return {
+          activeTabId: state.activeTabId,
+          avatarLoaded: tab?.avatarUrl?.startsWith('data:image/jpeg;base64,') === true,
+          isUnloaded: tab?.isUnloaded
+        }
+      })
+    }, tabId)).toEqual({
+      activeTabId,
+      avatarLoaded: true,
+      isUnloaded: true
+    })
+  })
 })

--- a/src/renderer/components/TabBar/TabBar.vue
+++ b/src/renderer/components/TabBar/TabBar.vue
@@ -92,6 +92,7 @@ import { normalizeFixedTabWidth } from '../../constants/tabWidth'
 import { getTabAvatarUrl } from '../../tabs/tabPreview'
 import { removeLegacyTabAvatar } from '../../helpers/channelThumbnailStorage'
 import { fetchTabAvatarBytes } from '../../helpers/tabAvatar'
+import { loadMissingTabAvatars } from '../../helpers/loadTabAvatars'
 import SortableTab from './SortableTab.vue'
 import {
   buildCurrentShiftedTabIds,
@@ -116,6 +117,7 @@ const vertical = computed(() => store.getters.getUseVerticalTabBar)
 const showTabIcons = computed(() => store.getters.getShowTabIcons)
 const showTabPreviews = computed(() => store.getters.getShowTabPreviews)
 const migratingAvatarTabIds = new Set()
+let attemptedAutomaticAvatarLoad = false
 
 watch(showTabPreviews, enabled => {
   if (isElectron) {
@@ -128,6 +130,11 @@ watch([showTabIcons, tabs], ([enabled, currentTabs]) => {
 
   window.ftElectron.tabs.setAvatarsEnabled(enabled)
   if (!enabled) return
+
+  if (!attemptedAutomaticAvatarLoad && currentTabs.length > 0) {
+    attemptedAutomaticAvatarLoad = true
+    loadMissingTabAvatars(currentTabs)
+  }
 
   for (const tab of currentTabs) {
     const avatarUrl = getTabAvatarUrl(tab)

--- a/src/renderer/components/ThemeSettings.vue
+++ b/src/renderer/components/ThemeSettings.vue
@@ -114,6 +114,15 @@
             @change="updateFixedTabWidth"
           />
         </div>
+        <FtButton
+          v-if="showTabIcons"
+          :label="loadingTabIcons
+            ? $t('Settings.Theme Settings.Loading Missing Tab Icons')
+            : $t('Settings.Theme Settings.Load Missing Tab Icons')"
+          :icon="['fas', 'download']"
+          :disabled="loadingTabIcons"
+          @click="loadTabIcons"
+        />
       </FtFlexBox>
     </template>
     <div class="sliderGrid">
@@ -237,6 +246,7 @@ import FtSelect from './FtSelect/FtSelect.vue'
 import FtToggleSwitch from './FtToggleSwitch/FtToggleSwitch.vue'
 import FtSlider from './FtSlider/FtSlider.vue'
 import FtFlexBox from './ft-flex-box/ft-flex-box.vue'
+import FtButton from './FtButton/FtButton.vue'
 import FtPrompt from './FtPrompt/FtPrompt.vue'
 
 import store from '../store/index'
@@ -261,6 +271,8 @@ import {
 } from '../constants/scrollbar'
 import { normalizeToastPosition, TOAST_POSITION_VALUES } from '../constants/toastPosition'
 import { setAnimationSpeed } from '../helpers/animationSpeed'
+import { loadMissingTabAvatars } from '../helpers/loadTabAvatars'
+import { showToast } from '../helpers/utils'
 
 const { t } = useI18n()
 
@@ -465,6 +477,24 @@ function updateShowProgressBarToast(value) {
 
 /** @type {import('vue').ComputedRef<boolean>} */
 const showTabIcons = computed(() => store.getters.getShowTabIcons)
+const loadingTabIcons = ref(false)
+
+async function loadTabIcons() {
+  if (loadingTabIcons.value) return
+  loadingTabIcons.value = true
+  try {
+    const { loaded, failed } = await loadMissingTabAvatars(store.getters.getTabs)
+    if (loaded === 0 && failed === 0) {
+      showToast(t('Settings.Theme Settings.No Missing Tab Icons'))
+    } else if (failed > 0) {
+      showToast(t('Settings.Theme Settings.Loaded Tab Icons With Failures', { loaded, failed }))
+    } else {
+      showToast(t('Settings.Theme Settings.Loaded Tab Icons', { count: loaded }))
+    }
+  } finally {
+    loadingTabIcons.value = false
+  }
+}
 
 /**
  * @param {boolean} value

--- a/src/renderer/components/ThemeSettings.vue
+++ b/src/renderer/components/ThemeSettings.vue
@@ -120,7 +120,7 @@
             ? $t('Settings.Theme Settings.Loading Missing Tab Icons')
             : $t('Settings.Theme Settings.Load Missing Tab Icons')"
           :icon="['fas', 'download']"
-          :disabled="loadingTabIcons"
+          :disabled="loadingTabIcons || !hasMissingTabIcons"
           @click="loadTabIcons"
         />
       </FtFlexBox>
@@ -271,7 +271,7 @@ import {
 } from '../constants/scrollbar'
 import { normalizeToastPosition, TOAST_POSITION_VALUES } from '../constants/toastPosition'
 import { setAnimationSpeed } from '../helpers/animationSpeed'
-import { loadMissingTabAvatars } from '../helpers/loadTabAvatars'
+import { getMissingTabAvatarTabs, loadMissingTabAvatars } from '../helpers/loadTabAvatars'
 import { showToast } from '../helpers/utils'
 
 const { t } = useI18n()
@@ -477,6 +477,7 @@ function updateShowProgressBarToast(value) {
 
 /** @type {import('vue').ComputedRef<boolean>} */
 const showTabIcons = computed(() => store.getters.getShowTabIcons)
+const hasMissingTabIcons = computed(() => getMissingTabAvatarTabs(store.getters.getTabs).length > 0)
 const loadingTabIcons = ref(false)
 
 async function loadTabIcons() {

--- a/src/renderer/helpers/loadTabAvatars.js
+++ b/src/renderer/helpers/loadTabAvatars.js
@@ -26,7 +26,7 @@ async function resolveLocalAvatarUrl(path) {
   const videoId = path.match(/^\/watch\/([^/]+)/)?.[1]
   if (videoId) {
     const video = await getLocalVideoInfo(videoId)
-    return normalizeAvatarUrl(video.secondary_info?.owner?.author?.best_thumbnail?.url)
+    return normalizeAvatarUrl(video.info?.secondary_info?.owner?.author?.best_thumbnail?.url)
   }
 
   return null
@@ -51,29 +51,31 @@ async function resolveInvidiousAvatarUrl(path) {
   return null
 }
 
-async function resolveAvatarUrl(path) {
-  const useLocalApi = store.getters.getBackendPreference === 'local'
-  try {
-    return useLocalApi
-      ? await resolveLocalAvatarUrl(path)
-      : await resolveInvidiousAvatarUrl(path)
-  } catch (error) {
-    if (!store.getters.getBackendFallback) throw error
-    return useLocalApi
-      ? await resolveInvidiousAvatarUrl(path)
-      : await resolveLocalAvatarUrl(path)
-  }
+async function fetchAvatarBytes(path, useLocalApi) {
+  const avatarUrl = useLocalApi
+    ? await resolveLocalAvatarUrl(path)
+    : await resolveInvidiousAvatarUrl(path)
+  return avatarUrl ? await fetchTabAvatarBytes(avatarUrl) : null
 }
 
 async function loadTabAvatar(tab) {
   const routePath = tab.route?.path
   if (typeof routePath !== 'string') return false
 
-  const avatarUrl = await resolveAvatarUrl(routePath)
-  if (!avatarUrl) return false
+  const useLocalApi = store.getters.getBackendPreference === 'local'
+  let avatarBytes
+  try {
+    avatarBytes = await fetchAvatarBytes(routePath, useLocalApi)
+  } catch (error) {
+    if (!store.getters.getBackendFallback) throw error
+  }
 
-  const avatarBytes = await fetchTabAvatarBytes(avatarUrl)
-  return avatarBytes != null && await window.ftElectron.tabs.updateAvatar(
+  if (avatarBytes == null && store.getters.getBackendFallback) {
+    avatarBytes = await fetchAvatarBytes(routePath, !useLocalApi)
+  }
+  if (avatarBytes == null) return false
+
+  return await window.ftElectron.tabs.updateAvatar(
     avatarBytes,
     tab.id,
     routePath
@@ -86,9 +88,7 @@ async function loadTabAvatar(tab) {
  * @returns {Promise<{loaded: number, failed: number}>}
  */
 export async function loadMissingTabAvatars(tabs) {
-  const missingTabs = tabs.filter(tab => {
-    return getTabAvatarUrl(tab) == null && /^\/(?:channel|watch)\//.test(tab.route?.path ?? '')
-  })
+  const missingTabs = getMissingTabAvatarTabs(tabs)
   const results = await Promise.allSettled(missingTabs.map(loadTabAvatar))
 
   return results.reduce((counts, result) => {
@@ -102,4 +102,10 @@ export async function loadMissingTabAvatars(tabs) {
     }
     return counts
   }, { loaded: 0, failed: 0 })
+}
+
+export function getMissingTabAvatarTabs(tabs) {
+  return tabs.filter(tab => {
+    return getTabAvatarUrl(tab) == null && /^\/(?:channel|watch)\//.test(tab.route?.path ?? '')
+  })
 }

--- a/src/renderer/helpers/loadTabAvatars.js
+++ b/src/renderer/helpers/loadTabAvatars.js
@@ -1,6 +1,7 @@
 import store from '../store/index'
 import { getTabAvatarUrl } from '../tabs/tabPreview'
 import { fetchTabAvatarBytes } from './tabAvatar'
+import { mapConcurrently } from './concurrent-map'
 import {
   getLocalChannel,
   getLocalVideoInfo,
@@ -11,6 +12,8 @@ import {
   invidiousGetVideoInformation,
   youtubeImageUrlToInvidious
 } from './api/invidious'
+
+const TAB_AVATAR_LOAD_CONCURRENCY = 4
 
 function normalizeAvatarUrl(url) {
   return typeof url === 'string' && url.startsWith('//') ? `https:${url}` : url
@@ -89,7 +92,17 @@ async function loadTabAvatar(tab) {
  */
 export async function loadMissingTabAvatars(tabs) {
   const missingTabs = getMissingTabAvatarTabs(tabs)
-  const results = await Promise.allSettled(missingTabs.map(loadTabAvatar))
+  const results = await mapConcurrently(
+    missingTabs,
+    TAB_AVATAR_LOAD_CONCURRENCY,
+    async tab => {
+      try {
+        return { status: 'fulfilled', value: await loadTabAvatar(tab) }
+      } catch (reason) {
+        return { status: 'rejected', reason }
+      }
+    }
+  )
 
   return results.reduce((counts, result) => {
     if (result.status === 'fulfilled' && result.value) {

--- a/src/renderer/helpers/loadTabAvatars.js
+++ b/src/renderer/helpers/loadTabAvatars.js
@@ -1,0 +1,105 @@
+import store from '../store/index'
+import { getTabAvatarUrl } from '../tabs/tabPreview'
+import { fetchTabAvatarBytes } from './tabAvatar'
+import {
+  getLocalChannel,
+  getLocalVideoInfo,
+  parseLocalChannelHeader
+} from './api/local'
+import {
+  invidiousGetChannelInfo,
+  invidiousGetVideoInformation,
+  youtubeImageUrlToInvidious
+} from './api/invidious'
+
+function normalizeAvatarUrl(url) {
+  return typeof url === 'string' && url.startsWith('//') ? `https:${url}` : url
+}
+
+async function resolveLocalAvatarUrl(path) {
+  const channelId = path.match(/^\/channel\/([^/]+)/)?.[1]
+  if (channelId) {
+    const channel = await getLocalChannel(channelId)
+    return normalizeAvatarUrl(parseLocalChannelHeader(channel, true).thumbnailUrl)
+  }
+
+  const videoId = path.match(/^\/watch\/([^/]+)/)?.[1]
+  if (videoId) {
+    const video = await getLocalVideoInfo(videoId)
+    return normalizeAvatarUrl(video.secondary_info?.owner?.author?.best_thumbnail?.url)
+  }
+
+  return null
+}
+
+async function resolveInvidiousAvatarUrl(path) {
+  const instanceUrl = store.getters.getCurrentInvidiousInstanceUrl
+  const channelId = path.match(/^\/channel\/([^/]+)/)?.[1]
+  if (channelId) {
+    const channel = await invidiousGetChannelInfo(channelId)
+    const thumbnail = channel.authorThumbnails?.at(-1)?.url
+    return thumbnail ? youtubeImageUrlToInvidious(thumbnail, instanceUrl) : null
+  }
+
+  const videoId = path.match(/^\/watch\/([^/]+)/)?.[1]
+  if (videoId) {
+    const video = await invidiousGetVideoInformation(videoId)
+    const thumbnail = video.authorThumbnails?.at(-1)?.url
+    return thumbnail ? youtubeImageUrlToInvidious(thumbnail, instanceUrl) : null
+  }
+
+  return null
+}
+
+async function resolveAvatarUrl(path) {
+  const useLocalApi = store.getters.getBackendPreference === 'local'
+  try {
+    return useLocalApi
+      ? await resolveLocalAvatarUrl(path)
+      : await resolveInvidiousAvatarUrl(path)
+  } catch (error) {
+    if (!store.getters.getBackendFallback) throw error
+    return useLocalApi
+      ? await resolveInvidiousAvatarUrl(path)
+      : await resolveLocalAvatarUrl(path)
+  }
+}
+
+async function loadTabAvatar(tab) {
+  const routePath = tab.route?.path
+  if (typeof routePath !== 'string') return false
+
+  const avatarUrl = await resolveAvatarUrl(routePath)
+  if (!avatarUrl) return false
+
+  const avatarBytes = await fetchTabAvatarBytes(avatarUrl)
+  return avatarBytes != null && await window.ftElectron.tabs.updateAvatar(
+    avatarBytes,
+    tab.id,
+    routePath
+  )
+}
+
+/**
+ * Cache avatars for icon-less channel and watch tabs without activating them.
+ * @param {Array<object>} tabs
+ * @returns {Promise<{loaded: number, failed: number}>}
+ */
+export async function loadMissingTabAvatars(tabs) {
+  const missingTabs = tabs.filter(tab => {
+    return getTabAvatarUrl(tab) == null && /^\/(?:channel|watch)\//.test(tab.route?.path ?? '')
+  })
+  const results = await Promise.allSettled(missingTabs.map(loadTabAvatar))
+
+  return results.reduce((counts, result) => {
+    if (result.status === 'fulfilled' && result.value) {
+      counts.loaded++
+    } else {
+      counts.failed++
+      if (result.status === 'rejected') {
+        console.error('Failed to load a missing tab icon:', result.reason)
+      }
+    }
+    return counts
+  }, { loaded: 0, failed: 0 })
+}

--- a/static/locales/en-US.yaml
+++ b/static/locales/en-US.yaml
@@ -503,6 +503,11 @@ Settings:
     Animation Speed: Animation Speed
     Thumbnail Size: Thumbnail Size
     Show Tab Icons: Show Tab Icons
+    Load Missing Tab Icons: Load Missing Tab Icons
+    Loading Missing Tab Icons: Loading Missing Tab Icons…
+    No Missing Tab Icons: All supported tab icons are already loaded
+    Loaded Tab Icons: 'Missing tab icons loaded: {count}'
+    Loaded Tab Icons With Failures: Loaded {loaded} tab icons; {failed} could not be loaded
     Show Tab Previews: Show Tab Previews
     Use Fixed Tab Width: Use Fixed Tab Width in Horizontal Mode
     Tab Width: Tab Width


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Make sure to follow the contributing guidelines. -->
<!-- Important note, we may remove your pull request if you do not use this provided PR template correctly. -->
<!-- Agent instructions: Preserve every heading, comment, and marker in this template. Never remove or rewrite the release-note-category:start/end, release-note:start/end, or release-note-image:start/end marker pairs. Never remove or rewrite the Release note images section; leave its contents for a human. -->

## Pull Request Type
<!-- Please select what type of pull request this is: [x] -->
- [ ] Bugfix
- [x] Feature Implementation
- [ ] Documentation
- [ ] Other

## Related issue
<!-- Please link the issue your pull request is referring to. -->
<!-- If this pull request fully resolves the relevant issue, put "closes" before the issue number. -->
<!-- Example: "closes #123456". -->

## Description
<!-- Please write a clear and concise description of what the pull request does. -->
Restored channel and watch tabs can be missing their channel icons until each tab is loaded. This adds a Theme settings action that fetches the missing avatar metadata and stores it through the existing tab avatar cache without activating or mounting those tabs.

The action follows the configured Local API or Invidious backend and its fallback preference, shows progress while it runs, and reports how many icons were loaded or could not be resolved.

## Release note category
<!-- Select exactly one category. Every pull request must select one. -->
<!-- Select "Not noteworthy" when the pull request fixes a bug in or improves functionality that has not yet appeared in a stable release. -->
<!-- release-note-category:start -->
- [ ] Not noteworthy
- [ ] Highlights
- [x] More improvements
- [ ] Fixed bugs
<!-- release-note-category:end -->

## Release note
<!-- Required unless "Not noteworthy" is selected. -->
<!-- Write one concise, user-facing entry without a leading bullet. -->
<!-- release-note:start -->
Missing tab icons now load automatically at startup without loading their tabs, with a new Theme settings action for retrying any icons that remain missing.
<!-- release-note:end -->

## Release note images
<!-- Human-only: Agents must preserve this entire section and leave it empty. -->
<!-- Optional. Paste one or more Markdown images or HTML image tags here. -->
<!-- The release notes will use an HTML image tag and limit images taller than 300 pixels. -->
<!-- release-note-image:start -->
<img width="251" height="58" alt="image" src="https://github.com/user-attachments/assets/796ffda6-be6a-43e8-ad50-dc829a2d42a8" />
<!-- release-note-image:end -->

## Testing
<!-- How can reviewers verify that the PR produces correct results? -->
<!-- Please provide instructions so that others can ensure that this pull request produces correct results. For examples see, https://github.com/FreeTubeApp/FreeTube/pull/5743, https://github.com/FreeTubeApp/FreeTube/pull/7349, https://github.com/FreeTubeApp/FreeTube/pull/5125, https://github.com/FreeTubeApp/FreeTube/pull/7338 -->
<!-- Agent instructions: Only write human-facing steps that explain how to verify the change while running this branch in dev mode. Include expected results and, when applicable, helpful console snippets for interactive verification. Do not include automated checks, commands, results, pass counts, or CI status. -->
1. Enable tab icons, create channel or watch tabs, and leave at least one of them unloaded without a cached avatar.
2. Open Settings → Theme and select **Load Missing Tab Icons**.
3. Confirm the button shows its loading state and a completion toast appears.
4. Confirm the missing channel avatars appear while the unloaded tabs remain unloaded and the active tab does not change.

## Additional context
<!-- Add any other context about the pull request here. -->
Only channel and watch tabs need remotely resolved avatars; other tab types continue using their built-in page icons.
