### PR TITLE
feat(profiles): open profile selector on right-click

### DIFF
--- a/e2e/tests/offline/profiles.spec.mjs
+++ b/e2e/tests/offline/profiles.spec.mjs
@@ -41,6 +41,10 @@ test.describe('profile selector', () => {
     await profileIcon(page).click({ button: 'right' })
 
     await expect(page.locator('.profileList')).toBeVisible()
+
+    await profileIcon(page).click({ button: 'right' })
+    await page.locator('.topNav .logo').click()
+    await expect(page.locator('.quickSettingsMenu')).toBeHidden()
   })
 
   test('lists seeded profiles and switches the active profile', async ({ page }) => {

--- a/e2e/tests/offline/profiles.spec.mjs
+++ b/e2e/tests/offline/profiles.spec.mjs
@@ -33,6 +33,16 @@ async function openProfileList(page) {
 test.describe('profile selector', () => {
   test.use({ seed: { profiles: [mainProfile, secondProfile] } })
 
+  test('opens directly from the profile button context menu', async ({ page }) => {
+    await profileIcon(page).click()
+    await expect(page.locator('.profileSummaryText')).toContainText('You can also right-click the profile icon to switch profiles')
+    await profileIcon(page).click()
+
+    await profileIcon(page).click({ button: 'right' })
+
+    await expect(page.locator('.profileList')).toBeVisible()
+  })
+
   test('lists seeded profiles and switches the active profile', async ({ page }) => {
     await expect(profileIconInitial(page)).toHaveText('A')
 

--- a/e2e/tests/offline/tutorial.spec.mjs
+++ b/e2e/tests/offline/tutorial.spec.mjs
@@ -29,6 +29,7 @@ test('shows returning users only where settings moved', async ({ app, page }) =>
   await expect(tutorial).toBeVisible()
   const lastUsedVersion = await page.evaluate(() => localStorage.getItem('opentubex.lastUsedVersion'))
   expect(lastUsedVersion).toMatch(/^\d+\.\d+\.\d+(?:-|$)/)
+  await expect(tutorial).toContainText('Right-click it to go straight to profile selection.')
   await expect(tutorial).toContainText('The cog in that menu opens all settings.')
   await expect(tutorial.locator('.tutorialProgress')).toHaveCount(0)
   await expectHighlightCenteredOn(page, '[data-tutorial="quick-settings"]')
@@ -133,6 +134,7 @@ test('walks new users through the essential controls', async ({ page }) => {
 
   await tutorial.getByRole('button', { name: 'Next' }).click()
   await expect(tutorial).toHaveAccessibleName('Make it yours')
+  await expect(tutorial).toContainText('Right-click it to go straight to profile selection.')
   await expectHighlightCenteredOn(page, '[data-tutorial="quick-settings"]')
 
   await tutorial.getByRole('button', { name: 'Finish' }).click()

--- a/src/renderer/components/FtQuickSettingsMenu/FtQuickSettingsMenu.css
+++ b/src/renderer/components/FtQuickSettingsMenu/FtQuickSettingsMenu.css
@@ -91,6 +91,11 @@
   white-space: nowrap;
 }
 
+.profileSummaryText small {
+  color: var(--secondary-text-color);
+  font-size: 12px;
+}
+
 .profilePanelHeader {
   align-items: center;
   border-block-end: 1px solid var(--scrollbar-color);

--- a/src/renderer/components/FtQuickSettingsMenu/FtQuickSettingsMenu.vue
+++ b/src/renderer/components/FtQuickSettingsMenu/FtQuickSettingsMenu.vue
@@ -11,6 +11,7 @@
       :aria-controls="id"
       :style="{ background: activeProfile.bgColor, color: activeProfile.textColor }"
       @click="toggleMenu"
+      @contextmenu.stop.prevent="openProfilePanelFromContextMenu"
       @mousedown="handleTriggerMouseDown"
       @keydown.esc.stop="closeMenu"
     >
@@ -100,6 +101,7 @@
               />
               <span class="profileSummaryText">
                 <strong dir="auto">{{ translateProfileName(activeProfile) }}</strong>
+                <small>{{ t('Settings.Quick Settings.Profile Selector Hint') }}</small>
               </span>
               <FontAwesomeIcon :icon="['fas', 'angle-right']" />
             </button>
@@ -412,12 +414,13 @@ const defaultQuality = computed(() => {
 function toggleMenu() {
   menuOpen.value = !menuOpen.value
   if (menuOpen.value) {
+    profilePanelOpen.value = false
     nextTick(() => menuRef.value?.$el?.focus())
   }
 }
 
 function handleMenuAfterLeave() {
-  profilePanelOpen.value = false
+  if (!menuOpen.value) profilePanelOpen.value = false
 }
 
 function handleTriggerMouseDown() {
@@ -468,6 +471,11 @@ onBeforeUnmount(() => {
 function openProfilePanel() {
   profilePanelOpen.value = true
   focusMenu()
+}
+
+function openProfilePanelFromContextMenu() {
+  menuOpen.value = true
+  openProfilePanel()
 }
 
 function closeProfilePanel() {

--- a/src/renderer/components/FtQuickSettingsMenu/FtQuickSettingsMenu.vue
+++ b/src/renderer/components/FtQuickSettingsMenu/FtQuickSettingsMenu.vue
@@ -423,8 +423,8 @@ function handleMenuAfterLeave() {
   if (!menuOpen.value) profilePanelOpen.value = false
 }
 
-function handleTriggerMouseDown() {
-  if (menuOpen.value) {
+function handleTriggerMouseDown(event) {
+  if (event.button === 0 && menuOpen.value) {
     mouseDownOnTrigger = true
   }
 }

--- a/static/locales/en-US.yaml
+++ b/static/locales/en-US.yaml
@@ -375,6 +375,7 @@ Settings:
     Content: Content
     Language and Region: Language and region
     All Settings: All settings
+    Profile Selector Hint: You can also right-click the profile icon to switch profiles
   Sort Settings Sections (A-Z): Sort Settings Sections (A-Z)
   Highlight Changed Settings: Highlight settings changed from defaults
   Reset Setting to Default: Reset this setting to its default
@@ -1163,10 +1164,10 @@ Tutorial:
     Description: Open several pages at once and switch between them without losing your place.
   Quick Settings:
     Title: Make it yours
-    Description: Select your profile in the top-right to switch profiles, change common preferences, or open all settings.
+    Description: Select your profile in the top-right to switch profiles, change common preferences, or open all settings. Right-click it to go straight to profile selection.
   Settings Moved:
     Title: Settings have moved
-    Description: Select your profile in the top-right for quick controls. The cog in that menu opens all settings.
+    Description: Select your profile in the top-right for quick controls. Right-click it to go straight to profile selection. The cog in that menu opens all settings.
 About:
   #On About page
   About: About


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Make sure to follow the contributing guidelines. -->
<!-- Important note, we may remove your pull request if you do not use this provided PR template correctly. -->
<!-- Agent instructions: Preserve every heading, comment, and marker in this template. Never remove or rewrite the release-note-category:start/end, release-note:start/end, or release-note-image:start/end marker pairs. Never remove or rewrite the Release note images section; leave its contents for a human. -->

## Pull Request Type
<!-- Please select what type of pull request this is: [x] -->
- [ ] Bugfix
- [x] Feature Implementation
- [ ] Documentation
- [ ] Other

## Related issue
<!-- Please link the issue your pull request is referring to. -->
<!-- If this pull request fully resolves the relevant issue, put "closes" before the issue number. -->
<!-- Example: "closes #123456". -->

None.

## Description
<!-- Please write a clear and concise description of what the pull request does. -->

Switching profiles currently requires opening quick settings and then selecting the profile summary. This adds a direct shortcut: right-clicking the profile icon opens the profile selector immediately.

The quick settings menu now shows a small hint below the active profile name, and the tutorials for new and existing users explain the shortcut. Normal left-click behavior remains unchanged.

## Release note category
<!-- Select exactly one category. Every pull request must select one. -->
<!-- Select "Not noteworthy" when the pull request fixes a bug in or improves functionality that has not yet appeared in a stable release. -->
<!-- release-note-category:start -->
- [x] Not noteworthy
- [ ] Highlights
- [ ] More improvements
- [ ] Fixed bugs
<!-- release-note-category:end -->

## Release note
<!-- Required unless "Not noteworthy" is selected. -->
<!-- Write one concise, user-facing entry without a leading bullet. -->
<!-- release-note:start -->

Right-click the profile icon to open the profile selector directly.

<!-- release-note:end -->

## Release note images
<!-- Human-only: Agents must preserve this entire section and leave it empty. -->
<!-- Optional. Paste one or more Markdown images or HTML image tags here. -->
<!-- The release notes will use an HTML image tag and limit images taller than 300 pixels. -->
<!-- release-note-image:start -->

<!-- release-note-image:end -->

## Testing
<!-- How can reviewers verify that the PR produces correct results? -->
<!-- Please provide instructions so that others can ensure that your pull request would produce correct results. For examples see, https://github.com/FreeTubeApp/FreeTube/pull/5743, https://github.com/FreeTubeApp/FreeTube/pull/7349, https://github.com/FreeTubeApp/FreeTube/pull/5125, https://github.com/FreeTubeApp/FreeTube/pull/7338 -->
<!-- Agent instructions: Only write human-facing steps that explain how to verify the change while running this branch in dev mode. Include expected results and, when applicable, helpful console snippets for interactive verification. Do not include automated checks, commands, results, pass counts, or CI status. -->

1. Left-click the profile icon and confirm quick settings opens normally.
2. Confirm the text below the active profile name says that the profile icon can also be right-clicked to switch profiles.
3. Close the menu, right-click the profile icon, and confirm the profile selector opens directly without showing the context menu.
4. Trigger the tutorial once as a new user and once as an existing user, and confirm both variants mention the right-click shortcut.

## Additional context
<!-- Add any other context about the pull request here. -->

The direct shortcut also handles reopening during the quick settings close animation.
