### PR TITLE
fix(settings): highlight all general toggles

### DIFF
--- a/e2e/tests/offline/settings.spec.mjs
+++ b/e2e/tests/offline/settings.spec.mjs
@@ -1226,6 +1226,31 @@ test.describe('settings', () => {
     await expect(resetButton).toHaveCount(0)
   })
 
+  test('highlights changed backend fallback and deep-link settings', async ({ page }) => {
+    await goTo(page, 'settings')
+
+    const backendFallbackToggle = page.getByRole('checkbox', {
+      name: /non-preferred backend/i
+    })
+    const openDeepLinksToggle = page.getByRole('checkbox', {
+      name: /Open URLs Passed to OpenTubeX in a New Window/i
+    })
+
+    const backendFallbackSetting = page.locator('.switch-ctn').filter({ has: backendFallbackToggle })
+    const openDeepLinksSetting = page.locator('.switch-ctn').filter({ has: openDeepLinksToggle })
+
+    await backendFallbackSetting.locator('label.switch-label').click()
+    await openDeepLinksSetting.locator('label.switch-label').click()
+    await page.getByRole('button', { name: 'Highlight settings changed from defaults' }).click()
+
+    for (const setting of [backendFallbackSetting, openDeepLinksSetting]) {
+      await expect(setting.getByRole('button', {
+        name: 'Reset this setting to its default'
+      })).toBeVisible()
+      await expect(setting).toHaveCSS('border-left-width', '3px')
+    }
+  })
+
   test('highlights and resets caption appearance settings individually', async ({ page }) => {
     await goTo(page, 'settings')
 

--- a/src/renderer/components/GeneralSettings/GeneralSettings.vue
+++ b/src/renderer/components/GeneralSettings/GeneralSettings.vue
@@ -7,6 +7,7 @@
         <FtToggleSwitch
           :label="t('Settings.General Settings.Check for Updates')"
           :default-value="checkForUpdates"
+          setting-key="checkForUpdates"
           :compact="true"
           @change="updateCheckForUpdates"
         />
@@ -14,6 +15,7 @@
           v-if="SUPPORTS_LOCAL_API"
           :label="t('Settings.General Settings.Fallback to Non-Preferred Backend on Failure')"
           :default-value="backendFallback"
+          setting-key="backendFallback"
           :compact="true"
           :tooltip="t('Tooltips.General Settings.Fallback to Non-Preferred Backend on Failure')"
           @change="updateBackendFallback"
@@ -41,6 +43,7 @@
           v-if="!IS_MAC && !isLinuxWayland && USING_ELECTRON"
           :label="t('Settings.General Settings.Minimize to system tray')"
           :default-value="hideToTrayOnMinimize"
+          setting-key="hideToTrayOnMinimize"
           :compact="true"
           @change="updateHideToTrayOnMinimize"
         />
@@ -57,6 +60,7 @@
           v-if="USING_ELECTRON"
           :label="t('Settings.General Settings.Open Deep Links In New Window')"
           :default-value="openDeepLinksInNewWindow"
+          setting-key="openDeepLinksInNewWindow"
           :compact="true"
           :tooltip="t('Tooltips.General Settings.Open Deep Links In New Window')"
           @change="updateOpenDeepLinksInNewWindow"


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Make sure to follow the contributing guidelines. -->
<!-- Important note, we may remove your pull request if you do not use this provided PR template correctly. -->
<!-- Agent instructions: Preserve every heading, comment, and marker in this template. Never remove or rewrite the release-note-category:start/end, release-note:start/end, or release-note-image:start/end marker pairs. Never remove or rewrite the Release note images section; leave its contents for a human. -->

## Pull Request Type
<!-- Please select what type of pull request this is: [x] -->
- [x] Bugfix
- [ ] Feature Implementation
- [ ] Documentation
- [ ] Other

## Related issue
<!-- Please link the issue your pull request is referring to. -->
<!-- If this pull request fully resolves the relevant issue, put "closes" before the issue number. -->
<!-- Example: "closes #123456". -->

## Description
<!-- Please write a clear and concise description of what the pull request does. -->

Some General toggles were not highlighted after changing them from their defaults, and offered no reset action. Their shared toggle components were missing setting keys, so the changed-setting indicator could not compare the current and default values.

Pass the corresponding setting key to every previously unkeyed General toggle. This fixes highlighting and resetting for backend fallback and opening passed URLs in a new window, while also covering Check for Updates and Minimize to Tray. A regression test covers the reported settings.

## Release note category
<!-- Select exactly one category. Every pull request must select one. -->
<!-- Select "Not noteworthy" when the pull request fixes a bug in or improves functionality that has not yet appeared in a stable release. -->
<!-- release-note-category:start -->
- [ ] Not noteworthy
- [ ] Highlights
- [ ] More improvements
- [x] Fixed bugs
<!-- release-note-category:end -->

## Release note
<!-- Required unless "Not noteworthy" is selected. -->
<!-- Write one concise, user-facing entry without a leading bullet. -->
<!-- release-note:start -->
Fixed changed General settings not being highlighted or offering reset actions.
<!-- release-note:end -->

## Release note images
<!-- Human-only: Agents must preserve this entire section and leave it empty. -->
<!-- Optional. Paste one or more Markdown images or HTML image tags here. -->
<!-- The release notes will use an HTML image tag and limit images taller than 300 pixels. -->
<!-- release-note-image:start -->

<!-- release-note-image:end -->

## Testing
<!-- How can reviewers verify that the PR produces correct results? -->
<!-- Please provide instructions so that others can ensure that your pull request would produce correct results. For examples see, https://github.com/FreeTubeApp/FreeTube/pull/5743, https://github.com/FreeTubeApp/FreeTube/pull/7349, https://github.com/FreeTubeApp/FreeTube/pull/5125, https://github.com/FreeTubeApp/FreeTube/pull/7338 -->
<!-- Agent instructions: Only write human-facing steps that explain how to verify the change while running this branch in dev mode. Include expected results and, when applicable, helpful console snippets for interactive verification. Do not include automated checks, commands, results, pass counts, or CI status. -->

1. Open General settings and enable “Revert to non-preferred backend on failure” and “Open URLs Passed to OpenTubeX in a New Window.”
2. Enable “Highlight settings changed from defaults.”
3. Confirm both changed controls receive the highlight and show a reset button.
4. Use each reset button and confirm its toggle returns to off and its highlight disappears.
5. Repeat with “Check for updates” and, on supported desktop environments, “Minimise to system tray.”

## Additional context
<!-- Add any other context about the pull request here. -->

The changed-setting UI depends on `setting-key`; non-syncable settings can still use it because sync visibility is checked separately.