### PR TITLE
feat(player): cache and reliably load voice-over translations

### DIFF
--- a/PRIVACY.md
+++ b/PRIVACY.md
@@ -28,7 +28,7 @@ Rows for optional services apply only when the feature is enabled. An IP address
 | Legacy sync | Configured sync operator | IP address, account identifier, authentication data, selected synced data, and timing |
 | `yt-dlp` playback and downloads | YouTube and the configured proxy, if any | IP address, requested page and media resources, video identifier, formats, and timing. OpenTubeX's proxy setting is passed to `yt-dlp`. |
 
-Voice-over translation is disabled by default. When it is enabled, no translation-service request is made until you request a translation. The separate background-preparation option is also disabled by default; enabling it requests a translation whenever a supported non-live video loads. These requests omit browser credentials and cookies.
+Voice-over translation is disabled by default. When it is enabled, no translation-service request is made until you request a translation. The separate background-preparation option is also disabled by default; enabling it requests a translation whenever a supported non-live video loads. Prepared translation URLs are cached locally for 24 hours by default and this cache can be disabled in the player settings. These requests omit browser credentials and cookies.
 
 HTTPS encrypts request paths and payloads in transit, but DNS providers and network operators may still learn destination hostnames and traffic patterns. A VPN or Tor changes which parties see your direct IP address; it does not prevent the destination service from seeing the request itself.
 

--- a/e2e/tests/offline/settings.spec.mjs
+++ b/e2e/tests/offline/settings.spec.mjs
@@ -993,6 +993,9 @@ test.describe('settings', () => {
     })
     await expect(backgroundToggle).toBeVisible()
     await expect(backgroundToggle).not.toBeChecked()
+    await expect(page.getByRole('checkbox', {
+      name: 'Cache voice-over translations for one day'
+    })).toBeChecked()
     await expect(page.getByText('Supported source languages: Russian, English, Chinese, Korean,'))
       .toBeVisible()
   })

--- a/src/main/VoiceOverTranslationCache.js
+++ b/src/main/VoiceOverTranslationCache.js
@@ -1,5 +1,6 @@
 import asyncFs from 'fs/promises'
 import path from 'path'
+import { randomUUID } from 'crypto'
 
 export const VOICE_OVER_TRANSLATION_CACHE_DURATION_MS = 24 * 60 * 60 * 1000
 
@@ -8,13 +9,24 @@ export class VoiceOverTranslationCache {
     this.directory = directory
     this.validateUrl = validateUrl
     this.now = now
+    this.pendingOperation = Promise.resolve()
   }
 
   pathFor(videoId, responseLanguage) {
     return path.join(this.directory, `${videoId}_${responseLanguage}.json`)
   }
 
-  async get(videoId, responseLanguage) {
+  runExclusive(operation) {
+    const result = this.pendingOperation.then(operation, operation)
+    this.pendingOperation = result.catch(() => {})
+    return result
+  }
+
+  get(videoId, responseLanguage) {
+    return this.runExclusive(() => this.getEntry(videoId, responseLanguage))
+  }
+
+  async getEntry(videoId, responseLanguage) {
     const filePath = this.pathFor(videoId, responseLanguage)
 
     try {
@@ -35,15 +47,29 @@ export class VoiceOverTranslationCache {
     }
   }
 
-  async set(videoId, responseLanguage, result) {
-    await asyncFs.mkdir(this.directory, { recursive: true })
-    await asyncFs.writeFile(this.pathFor(videoId, responseLanguage), JSON.stringify({
-      expiresAt: this.now() + VOICE_OVER_TRANSLATION_CACHE_DURATION_MS,
-      result
-    }))
+  set(videoId, responseLanguage, result) {
+    return this.runExclusive(async () => {
+      await asyncFs.mkdir(this.directory, { recursive: true })
+
+      const filePath = this.pathFor(videoId, responseLanguage)
+      const temporaryPath = `${filePath}.${randomUUID()}.tmp`
+      try {
+        await asyncFs.writeFile(temporaryPath, JSON.stringify({
+          expiresAt: this.now() + VOICE_OVER_TRANSLATION_CACHE_DURATION_MS,
+          result
+        }))
+        await asyncFs.rename(temporaryPath, filePath)
+      } finally {
+        await asyncFs.rm(temporaryPath, { force: true })
+      }
+    })
   }
 
-  async pruneExpired() {
+  pruneExpired() {
+    return this.runExclusive(() => this.pruneExpiredEntries())
+  }
+
+  async pruneExpiredEntries() {
     let entries
 
     try {
@@ -56,9 +82,15 @@ export class VoiceOverTranslationCache {
     }
 
     await Promise.all(entries
-      .filter(entry => entry.isFile() && entry.name.endsWith('.json'))
+      .filter(entry => entry.isFile() &&
+        (entry.name.endsWith('.json') || entry.name.endsWith('.tmp')))
       .map(async entry => {
         const filePath = path.join(this.directory, entry.name)
+        if (entry.name.endsWith('.tmp')) {
+          await asyncFs.rm(filePath, { force: true })
+          return
+        }
+
         try {
           const cached = JSON.parse(await asyncFs.readFile(filePath, 'utf8'))
           if (!Number.isFinite(cached.expiresAt) || cached.expiresAt <= this.now()) {

--- a/src/main/VoiceOverTranslationCache.js
+++ b/src/main/VoiceOverTranslationCache.js
@@ -1,0 +1,72 @@
+import asyncFs from 'fs/promises'
+import path from 'path'
+
+export const VOICE_OVER_TRANSLATION_CACHE_DURATION_MS = 24 * 60 * 60 * 1000
+
+export class VoiceOverTranslationCache {
+  constructor(directory, validateUrl, now = Date.now) {
+    this.directory = directory
+    this.validateUrl = validateUrl
+    this.now = now
+  }
+
+  pathFor(videoId, responseLanguage) {
+    return path.join(this.directory, `${videoId}_${responseLanguage}.json`)
+  }
+
+  async get(videoId, responseLanguage) {
+    const filePath = this.pathFor(videoId, responseLanguage)
+
+    try {
+      const cached = JSON.parse(await asyncFs.readFile(filePath, 'utf8'))
+      if (!Number.isFinite(cached.expiresAt) || cached.expiresAt <= this.now() ||
+          typeof cached.result?.url !== 'string') {
+        await asyncFs.rm(filePath, { force: true })
+        return undefined
+      }
+
+      const translationUrl = await this.validateUrl(cached.result.url)
+      return { ...cached.result, url: translationUrl.href }
+    } catch (error) {
+      if (error.code !== 'ENOENT') {
+        await asyncFs.rm(filePath, { force: true }).catch(() => {})
+      }
+      return undefined
+    }
+  }
+
+  async set(videoId, responseLanguage, result) {
+    await asyncFs.mkdir(this.directory, { recursive: true })
+    await asyncFs.writeFile(this.pathFor(videoId, responseLanguage), JSON.stringify({
+      expiresAt: this.now() + VOICE_OVER_TRANSLATION_CACHE_DURATION_MS,
+      result
+    }))
+  }
+
+  async pruneExpired() {
+    let entries
+
+    try {
+      entries = await asyncFs.readdir(this.directory, { withFileTypes: true })
+    } catch (error) {
+      if (error.code === 'ENOENT') {
+        return
+      }
+      throw error
+    }
+
+    await Promise.all(entries
+      .filter(entry => entry.isFile() && entry.name.endsWith('.json'))
+      .map(async entry => {
+        const filePath = path.join(this.directory, entry.name)
+        try {
+          const cached = JSON.parse(await asyncFs.readFile(filePath, 'utf8'))
+          if (!Number.isFinite(cached.expiresAt) || cached.expiresAt <= this.now()) {
+            await asyncFs.rm(filePath, { force: true })
+          }
+        } catch {
+          await asyncFs.rm(filePath, { force: true })
+        }
+      }))
+  }
+}

--- a/src/main/index.js
+++ b/src/main/index.js
@@ -45,7 +45,10 @@ import {
 } from '../searchEngines'
 import { fetchFaviconDataUrl, resolveFaviconUrl } from './favicon'
 import { LiveReminderManager } from './LiveReminderManager'
-import { requestVoiceOverTranslation } from './voiceOverTranslation'
+import {
+  configureVoiceOverTranslationCache,
+  requestVoiceOverTranslation
+} from './voiceOverTranslation'
 
 const brotliDecompressAsync = promisify(brotliDecompress)
 
@@ -1326,6 +1329,7 @@ function runApp() {
   const isTrayOnMinimizeSupported = process.platform !== 'darwin' && (process.platform !== 'linux' || app.commandLine.getSwitchValue('ozone-platform') !== 'wayland')
 
   const userDataPath = app.getPath('userData')
+  configureVoiceOverTranslationCache(path.join(userDataPath, 'voice_over_translation_cache'))
 
   function broadcastLiveReminderUpdate(videoId, scheduled) {
     for (const window of BrowserWindow.getAllWindows()) {

--- a/src/main/voiceOverTranslation.js
+++ b/src/main/voiceOverTranslation.js
@@ -1,7 +1,9 @@
 import { net } from 'electron'
+import { VoiceOverTranslationCache } from './VoiceOverTranslationCache'
 
 const MAX_VIDEO_DURATION_SECONDS = 4 * 60 * 60
 const MAX_AUDIO_REDIRECTS = 5
+const PARTIAL_CONTENT_STATUS = 5
 const RESPONSE_LANGUAGES = new Set(['ru', 'en', 'kk'])
 const YOUTUBE_VIDEO_ID_PATTERN = /^[\w-]{11}$/
 const TRANSLATION_AUDIO_HOST_PATTERNS = [
@@ -11,6 +13,14 @@ const TRANSLATION_AUDIO_HOST_PATTERNS = [
 ]
 
 let clientPromise
+let translationCache
+
+export function configureVoiceOverTranslationCache(directory) {
+  translationCache = new VoiceOverTranslationCache(directory, validateTranslationAudioUrl)
+  translationCache.pruneExpired().catch(error => {
+    console.error('Failed to prune the voice-over translation cache:', error)
+  })
+}
 
 function getClient() {
   clientPromise ??= import('@vot.js/core').then(({ default: VOTClient }) => {
@@ -45,6 +55,11 @@ async function validateTranslationAudioUrl(rawUrl) {
 
     if (response.status < 300 || response.status >= 400) {
       await response.body?.cancel()
+
+      if (!response.ok) {
+        throw new Error(`Voice-over audio URL returned status ${response.status}`)
+      }
+
       return audioUrl
     }
 
@@ -71,7 +86,7 @@ export async function requestVoiceOverTranslation(payload) {
     throw new TypeError('Invalid voice-over translation request')
   }
 
-  const { videoId, duration, responseLanguage } = payload
+  const { videoId, duration, responseLanguage, cache = true } = payload
 
   if (typeof videoId !== 'string' || !YOUTUBE_VIDEO_ID_PATTERN.test(videoId)) {
     throw new TypeError('Invalid YouTube video ID')
@@ -83,6 +98,17 @@ export async function requestVoiceOverTranslation(payload) {
 
   if (!RESPONSE_LANGUAGES.has(responseLanguage)) {
     throw new RangeError('Unsupported voice-over translation language')
+  }
+
+  if (typeof cache !== 'boolean') {
+    throw new TypeError('Invalid voice-over translation cache setting')
+  }
+
+  if (cache) {
+    const cachedResult = await translationCache?.get(videoId, responseLanguage)
+    if (cachedResult) {
+      return cachedResult
+    }
   }
 
   const client = await getClient()
@@ -100,12 +126,22 @@ export async function requestVoiceOverTranslation(payload) {
   if (result.translated) {
     const translationUrl = await validateTranslationAudioUrl(result.url)
 
-    return {
+    const response = {
       translated: true,
       url: translationUrl.href,
       remainingTime: result.remainingTime,
       status: result.status
     }
+
+    if (cache && result.status !== PARTIAL_CONTENT_STATUS) {
+      try {
+        await translationCache?.set(videoId, responseLanguage, response)
+      } catch (error) {
+        console.error('Failed to cache voice-over translation:', error)
+      }
+    }
+
+    return response
   }
 
   return {

--- a/src/main/voiceOverTranslation.js
+++ b/src/main/voiceOverTranslation.js
@@ -1,17 +1,12 @@
 import { net } from 'electron'
 import { VoiceOverTranslationCache } from './VoiceOverTranslationCache'
+import { isAllowedTranslationAudioUrl } from './voiceOverTranslationUrls'
 
 const MAX_VIDEO_DURATION_SECONDS = 4 * 60 * 60
 const MAX_AUDIO_REDIRECTS = 5
 const PARTIAL_CONTENT_STATUS = 5
 const RESPONSE_LANGUAGES = new Set(['ru', 'en', 'kk'])
 const YOUTUBE_VIDEO_ID_PATTERN = /^[\w-]{11}$/
-const TRANSLATION_AUDIO_HOST_PATTERNS = [
-  /(^|\.)strm\.yandex\.net$/,
-  /^strm\.yandex\.ru$/,
-  /^storage\.yandexcloud\.net$/,
-]
-
 let clientPromise
 let translationCache
 
@@ -34,17 +29,12 @@ function getClient() {
   return clientPromise
 }
 
-function isAllowedTranslationAudioUrl(url) {
-  return url.protocol === 'https:' &&
-    TRANSLATION_AUDIO_HOST_PATTERNS.some(pattern => pattern.test(url.hostname))
-}
-
 async function validateTranslationAudioUrl(rawUrl) {
   let audioUrl = new URL(rawUrl)
 
   for (let redirectCount = 0; redirectCount <= MAX_AUDIO_REDIRECTS; redirectCount++) {
     if (!isAllowedTranslationAudioUrl(audioUrl)) {
-      throw new Error('Voice-over service returned an untrusted audio URL')
+      throw new Error(`Voice-over service returned an untrusted audio URL: ${audioUrl.hostname}`)
     }
 
     const response = await net.fetch(audioUrl.href, {

--- a/src/main/voiceOverTranslationUrls.js
+++ b/src/main/voiceOverTranslationUrls.js
@@ -1,0 +1,10 @@
+const TRANSLATION_AUDIO_HOST_PATTERNS = [
+  /(^|\.)strm\.yandex\.net$/,
+  /(^|\.)strm\.yandex\.ru$/,
+  /^storage\.yandexcloud\.net$/,
+]
+
+export function isAllowedTranslationAudioUrl(url) {
+  return url.protocol === 'https:' &&
+    TRANSLATION_AUDIO_HOST_PATTERNS.some(pattern => pattern.test(url.hostname))
+}

--- a/src/main/voiceOverTranslationUrls.js
+++ b/src/main/voiceOverTranslationUrls.js
@@ -1,6 +1,7 @@
 const TRANSLATION_AUDIO_HOST_PATTERNS = [
   /(^|\.)strm\.yandex\.net$/,
   /(^|\.)strm\.yandex\.ru$/,
+  /^vtrans\.s3-private\.mds\.yandex\.net$/,
   /^storage\.yandexcloud\.net$/,
 ]
 

--- a/src/preload/interface.js
+++ b/src/preload/interface.js
@@ -155,7 +155,7 @@ export default {
   },
 
   /**
-   * @param {{ videoId: string, duration: number, responseLanguage: 'ru' | 'en' | 'kk' }} payload
+   * @param {{ videoId: string, duration: number, responseLanguage: 'ru' | 'en' | 'kk', cache?: boolean }} payload
    * @returns {Promise<{ translated: boolean, url?: string, remainingTime: number, status: number }>}
    */
   requestVoiceOverTranslation: (payload) => {

--- a/src/renderer/components/PlayerSettings/PlayerSettings.vue
+++ b/src/renderer/components/PlayerSettings/PlayerSettings.vue
@@ -144,6 +144,16 @@
           @change="updateVoiceOverTranslationPrepareInBackground"
         />
         <FtToggleSwitch
+          v-if="USING_ELECTRON"
+          :label="t('Settings.Player Settings.Voice-over Translation.Cache')"
+          :compact="true"
+          :disabled="!useVoiceOverTranslation"
+          :default-value="voiceOverTranslationCache"
+          setting-key="voiceOverTranslationCache"
+          :tooltip="t('Settings.Player Settings.Voice-over Translation.Cache Tooltip')"
+          @change="updateVoiceOverTranslationCache"
+        />
+        <FtToggleSwitch
           :label="t('Settings.Player Settings.Automatically Open Chapters')"
           :compact="true"
           :default-value="autoOpenChapters"
@@ -679,6 +689,16 @@ const voiceOverTranslationPrepareInBackground = computed(() => {
  */
 function updateVoiceOverTranslationPrepareInBackground(value) {
   store.dispatch('updateVoiceOverTranslationPrepareInBackground', value)
+}
+
+/** @type {import('vue').ComputedRef<boolean>} */
+const voiceOverTranslationCache = computed(() => store.getters.getVoiceOverTranslationCache)
+
+/**
+ * @param {boolean} value
+ */
+function updateVoiceOverTranslationCache(value) {
+  store.dispatch('updateVoiceOverTranslationCache', value)
 }
 
 const VOICE_OVER_TRANSLATION_LANGUAGE_VALUES = ['en', 'ru', 'kk']

--- a/src/renderer/components/ft-shaka-video-player/ft-shaka-video-player.js
+++ b/src/renderer/components/ft-shaka-video-player/ft-shaka-video-player.js
@@ -951,11 +951,15 @@ export default defineComponent({
       return voiceOverTranslationAvailable.value &&
         store.getters.getVoiceOverTranslationPrepareInBackground
     })
+    const voiceOverTranslationCache = computed(() => {
+      return store.getters.getVoiceOverTranslationCache
+    })
     const voiceOverTranslation = useVoiceOverTranslation({
       video,
       videoId: computed(() => props.videoId),
       responseLanguage: voiceOverTranslationLanguage,
       autoPrepare: voiceOverTranslationAutoPrepare,
+      cache: voiceOverTranslationCache,
       voiceVolume: voiceOverTranslationVolume,
       onError: error => {
         const message = error instanceof RangeError

--- a/src/renderer/components/ft-shaka-video-player/opentubex/useVoiceOverTranslation.js
+++ b/src/renderer/components/ft-shaka-video-player/opentubex/useVoiceOverTranslation.js
@@ -15,11 +15,20 @@ const MAX_AUDIO_DRIFT_SECONDS = 0.4
  *   videoId: import('vue').ComputedRef<string>,
  *   responseLanguage: import('vue').ComputedRef<'ru' | 'en' | 'kk'>,
  *   autoPrepare: import('vue').ComputedRef<boolean>,
+ *   cache: import('vue').ComputedRef<boolean>,
  *   voiceVolume: import('vue').ComputedRef<number>,
  *   onError: (error: unknown) => void
  * }} options
  */
-export function useVoiceOverTranslation({ video, videoId, responseLanguage, autoPrepare, voiceVolume, onError }) {
+export function useVoiceOverTranslation({
+  video,
+  videoId,
+  responseLanguage,
+  autoPrepare,
+  cache,
+  voiceVolume,
+  onError
+}) {
   const state = ref('idle')
   const enabled = ref(false)
   const preparationRequested = ref(false)
@@ -163,7 +172,8 @@ export function useVoiceOverTranslation({ video, videoId, responseLanguage, auto
       const result = await window.ftElectron.requestVoiceOverTranslation({
         videoId: videoId.value,
         duration,
-        responseLanguage: responseLanguage.value
+        responseLanguage: responseLanguage.value,
+        cache: cache.value
       })
 
       if (generation !== requestGeneration) {

--- a/src/renderer/store/modules/settings.js
+++ b/src/renderer/store/modules/settings.js
@@ -416,6 +416,7 @@ const state = {
   showSkipSilenceButton: false,
   useVoiceOverTranslation: false,
   voiceOverTranslationPrepareInBackground: false,
+  voiceOverTranslationCache: true,
   voiceOverTranslationLanguage: 'en',
   voiceOverTranslationVolume: 100,
   voiceOverTranslationOriginalVolume: 10,

--- a/static/locales/en-US.yaml
+++ b/static/locales/en-US.yaml
@@ -710,6 +710,8 @@ Settings:
       Enable: Enable voice-over translation
       Prepare in Background: Start preparing voice-over translations in the background
       Background Preparation Tooltip: Sends the current video's ID, duration, and selected language to the translation service as soon as a supported video loads.
+      Cache: Cache voice-over translations for one day
+      Cache Tooltip: Reuses prepared voice-over translations for 24 hours, including after restarting the app.
       Language: Voice-over translation language
       Supported Source Languages: "Supported source languages: Russian, English, Chinese, Korean, Lithuanian, Latvian, Arabic, French, Italian, Spanish, German, and Japanese."
       Voice Volume: Translated voice volume

--- a/tests/unit/voice-over-translation-cache.test.mjs
+++ b/tests/unit/voice-over-translation-cache.test.mjs
@@ -60,3 +60,23 @@ test('removes translations after one day', async () => {
     assert.equal(await cache.get(VIDEO_ID, 'en'), undefined)
   })
 })
+
+test('does not prune a replacement written concurrently', async () => {
+  await withCacheDirectory(async directory => {
+    let now = 1000
+    const cache = new VoiceOverTranslationCache(
+      directory,
+      async url => new URL(url),
+      () => now
+    )
+    await cache.set(VIDEO_ID, 'en', RESULT)
+
+    now += VOICE_OVER_TRANSLATION_CACHE_DURATION_MS
+    await Promise.all([
+      cache.pruneExpired(),
+      cache.set(VIDEO_ID, 'en', { ...RESULT, status: 2 })
+    ])
+
+    assert.equal((await cache.get(VIDEO_ID, 'en')).status, 2)
+  })
+})

--- a/tests/unit/voice-over-translation-cache.test.mjs
+++ b/tests/unit/voice-over-translation-cache.test.mjs
@@ -1,0 +1,62 @@
+import assert from 'node:assert/strict'
+import { mkdtemp, readdir, rm } from 'node:fs/promises'
+import os from 'node:os'
+import path from 'node:path'
+import test from 'node:test'
+
+import {
+  VoiceOverTranslationCache,
+  VOICE_OVER_TRANSLATION_CACHE_DURATION_MS
+} from '../../src/main/VoiceOverTranslationCache.js'
+
+const VIDEO_ID = 'abcdefghijk'
+const RESULT = {
+  translated: true,
+  url: 'https://strm.yandex.net/voice-over.mp3',
+  remainingTime: 0,
+  status: 1
+}
+
+async function withCacheDirectory (run) {
+  const directory = await mkdtemp(path.join(os.tmpdir(), 'opentubex-voice-over-cache-'))
+  try {
+    await run(directory)
+  } finally {
+    await rm(directory, { recursive: true, force: true })
+  }
+}
+
+test('persists a voice-over translation across cache instances', async () => {
+  await withCacheDirectory(async directory => {
+    const firstInstance = new VoiceOverTranslationCache(
+      directory,
+      async url => new URL(url),
+      () => 1000
+    )
+    await firstInstance.set(VIDEO_ID, 'en', RESULT)
+
+    const restartedInstance = new VoiceOverTranslationCache(
+      directory,
+      async url => new URL(url),
+      () => 2000
+    )
+    assert.deepEqual(await restartedInstance.get(VIDEO_ID, 'en'), RESULT)
+  })
+})
+
+test('removes translations after one day', async () => {
+  await withCacheDirectory(async directory => {
+    const cache = new VoiceOverTranslationCache(
+      directory,
+      async url => new URL(url),
+      () => 1000
+    )
+    await cache.set(VIDEO_ID, 'en', RESULT)
+
+    cache.now = () => 1000 + VOICE_OVER_TRANSLATION_CACHE_DURATION_MS
+    await cache.pruneExpired()
+
+    assert.deepEqual(await readdir(directory), [])
+    assert.equal(await cache.get(VIDEO_ID, 'en'), undefined)
+  })
+})

--- a/tests/unit/voice-over-translation-urls.test.mjs
+++ b/tests/unit/voice-over-translation-urls.test.mjs
@@ -1,0 +1,31 @@
+import assert from 'node:assert/strict'
+import test from 'node:test'
+
+import { isAllowedTranslationAudioUrl } from '../../src/main/voiceOverTranslationUrls.js'
+
+test('allows trusted Yandex voice-over delivery hosts', () => {
+  const trustedHosts = [
+    'strm.yandex.net',
+    'voice-over.strm.yandex.net',
+    'strm.yandex.ru',
+    'voice-over.strm.yandex.ru',
+    'storage.yandexcloud.net'
+  ]
+
+  for (const host of trustedHosts) {
+    assert.equal(isAllowedTranslationAudioUrl(new URL(`https://${host}/audio`)), true)
+  }
+})
+
+test('rejects insecure and look-alike voice-over delivery hosts', () => {
+  const untrustedUrls = [
+    'http://voice-over.strm.yandex.ru/audio',
+    'https://strm.yandex.ru.example.com/audio',
+    'https://voice-over-strm.yandex.ru/audio',
+    'https://storage.yandexcloud.net.example.com/audio'
+  ]
+
+  for (const url of untrustedUrls) {
+    assert.equal(isAllowedTranslationAudioUrl(new URL(url)), false)
+  }
+})

--- a/tests/unit/voice-over-translation-urls.test.mjs
+++ b/tests/unit/voice-over-translation-urls.test.mjs
@@ -9,6 +9,7 @@ test('allows trusted Yandex voice-over delivery hosts', () => {
     'voice-over.strm.yandex.net',
     'strm.yandex.ru',
     'voice-over.strm.yandex.ru',
+    'vtrans.s3-private.mds.yandex.net',
     'storage.yandexcloud.net'
   ]
 
@@ -22,6 +23,8 @@ test('rejects insecure and look-alike voice-over delivery hosts', () => {
     'http://voice-over.strm.yandex.ru/audio',
     'https://strm.yandex.ru.example.com/audio',
     'https://voice-over-strm.yandex.ru/audio',
+    'https://vtrans.s3-private.mds.yandex.net.example.com/audio',
+    'https://other.s3-private.mds.yandex.net/audio',
     'https://storage.yandexcloud.net.example.com/audio'
   ]
 


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Make sure to follow the contributing guidelines. -->
<!-- Important note, we may remove your pull request if you do not use this provided PR template correctly. -->
<!-- Agent instructions: Preserve every heading, comment, and marker in this template. Never remove or rewrite the release-note-category:start/end, release-note:start/end, or release-note-image:start/end marker pairs. Never remove or rewrite the Release note images section; leave its contents for a human. -->

## Pull Request Type
<!-- Please select what type of pull request this is: [x] -->
- [x] Bugfix
- [x] Feature Implementation
- [ ] Documentation
- [ ] Other

## Related issue
<!-- Please link the issue your pull request is referring to. -->
<!-- If this pull request fully resolves the relevant issue, put "closes" before the issue number. -->
<!-- Example: "closes #123456". -->

## Description
<!-- Please write a clear and concise description of what the pull request does. -->
Voice-over translation had two reliability gaps: prepared translations were forgotten when OpenTubeX restarted, and valid audio URLs from Yandex's current delivery hosts were rejected as untrusted.

This adds a default-on player setting that stores validated translation results in the app's user-data directory for 24 hours. Cached URLs are revalidated before reuse, unavailable entries fall back to the translation service, partial translations are never cached, and expired entries are removed. Cache reads, writes, and pruning are serialized, with atomic file replacement preventing incomplete entries.

The audio URL allowlist now accepts Yandex's trusted `*.strm.yandex.ru` delivery hosts and the VOT-specific `vtrans.s3-private.mds.yandex.net` storage host. Look-alike domains, unrelated Yandex storage hosts, and insecure URLs remain rejected.

## Release note category
<!-- Select exactly one category. Every pull request must select one. -->
<!-- Select "Not noteworthy" when the pull request fixes a bug in or improves functionality that has not yet appeared in a stable release. -->
<!-- release-note-category:start -->
- [x] Not noteworthy
- [ ] Highlights
- [ ] More improvements
- [ ] Fixed bugs
<!-- release-note-category:end -->

## Release note
<!-- Required unless "Not noteworthy" is selected. -->
<!-- Write one concise, user-facing entry without a leading bullet. -->
<!-- release-note:start -->
Voice-over translations now support current audio delivery URLs and can be cached for one day across app restarts.
<!-- release-note:end -->

## Release note images
<!-- Human-only: Agents must preserve this entire section and leave it empty. -->
<!-- Optional. Paste one or more Markdown images or HTML image tags here. -->
<!-- The release notes will use an HTML image tag and limit images taller than 300 pixels. -->
<!-- release-note-image:start -->

<!-- release-note-image:end -->

## Testing
<!-- How can reviewers verify that the PR produces correct results? -->
<!-- Please provide instructions so that others can ensure that your pull request would produce correct results. For examples see, https://github.com/FreeTubeApp/FreeTube/pull/5743, https://github.com/FreeTubeApp/FreeTube/pull/7349, https://github.com/FreeTubeApp/FreeTube/pull/5125, https://github.com/FreeTubeApp/FreeTube/pull/7338 -->
<!-- Agent instructions: Only write human-facing steps that explain how to verify the change while running this branch in dev mode. Include expected results and, when applicable, helpful console snippets for interactive verification. Do not include automated checks, commands, results, pass counts, or CI status. -->
1. Open Player Settings, enable voice-over translation, and confirm that **Cache voice-over translations for one day** is enabled by default.
2. Translate a supported non-live video and wait until its translated audio is ready. Playback should start without an untrusted audio URL error.
3. Fully quit and reopen OpenTubeX, return to the same video with the same output language, and click Translate. The prepared translation should be available immediately.
4. Disable the cache setting and translate a different video. Confirm that no cache entry is created for it in the `voice_over_translation_cache` directory inside Electron's user-data directory.

## Additional context
<!-- Add any other context about the pull request here. -->
The cache stores the provider's validated translation URL and expiry metadata, not a local copy of the audio stream, which avoids potentially large disk usage for long videos.
