### PR TITLE
fix(player): restore yt-dlp audio track selection

### DIFF
--- a/e2e/tests/offline/video-actions.spec.mjs
+++ b/e2e/tests/offline/video-actions.spec.mjs
@@ -103,13 +103,13 @@ test.describe('video downloads', () => {
     await expect(page.locator('.downloadProgressBarTrack')).toHaveCount(0)
   })
 
-  test('requests Android VR streams for yt-dlp playback', async ({ app, page }) => {
+  test('requests compatible streams and alternate audio for yt-dlp playback', async ({ app, page }) => {
     const executable = path.join(app.userDataDir, 'capture-yt-dlp-playback-args.sh')
     const capturedArgs = path.join(app.userDataDir, 'captured-yt-dlp-playback-args.txt')
     await writeFile(executable, [
       '#!/bin/sh',
       `printf '%s\\n' "$@" > "${capturedArgs}"`,
-      'printf \'%s\\n\' \'{"formats":[]}\''
+      'printf \'%s\\n\' \'{"formats":[{"format_id":"140","available_at":123}]}\''
     ].join('\n'))
     await chmod(executable, 0o755)
     await page.evaluate(async (ytDlpPath) => {
@@ -118,11 +118,12 @@ test.describe('video downloads', () => {
     }, executable)
 
     await page.bringToFront()
-    await page.evaluate(() => window.ftElectron.ytDlpGetPlaybackInfo('eeeeeeeeeee'))
+    const info = await page.evaluate(() => window.ftElectron.ytDlpGetPlaybackInfo('eeeeeeeeeee'))
 
     const passedArguments = (await readFile(capturedArgs, 'utf8')).trim().split('\n')
     const extractorArgsIndex = passedArguments.indexOf('--extractor-args')
-    expect(passedArguments[extractorArgsIndex + 1]).toBe('youtube:player_client=android_vr,default')
+    expect(passedArguments[extractorArgsIndex + 1]).toBe('youtube:player_client=android_vr,web_embedded,default')
+    expect(info.formats[0].availableAt).toBe(123)
   })
 
   test('disables media download actions and rejects direct requests', async ({ page }) => {

--- a/src/main/ytDlp.js
+++ b/src/main/ytDlp.js
@@ -1005,6 +1005,7 @@ export async function handleYtDlpDownloadBinary(event, binary) {
  * @property {string | null} language
  * @property {string | null} formatNote
  * @property {string | null} dynamicRange
+ * @property {number | null} availableAt Unix timestamp after which the format can be requested
  */
 
 /**
@@ -1064,7 +1065,8 @@ function mapPlaybackFormat(format) {
     audioChannels: toFiniteNumber(format.audio_channels),
     language: toNonEmptyString(format.language),
     formatNote: toNonEmptyString(format.format_note),
-    dynamicRange: toNonEmptyString(format.dynamic_range)
+    dynamicRange: toNonEmptyString(format.dynamic_range),
+    availableAt: toFiniteNumber(format.available_at)
   }
 }
 
@@ -1101,11 +1103,11 @@ export async function handleYtDlpGetPlaybackInfo(event, videoId) {
     '--no-progress',
     '--socket-timeout',
     '15',
-    // Some yt-dlp versions otherwise select an iOS live HLS manifest, whose
-    // segments can stop working when YouTube enforces a PO token. Android VR
-    // live HLS does not require that token; retain the defaults as fallbacks.
+    // Android VR avoids live HLS streams that require a PO token, while the
+    // embedded client exposes alternate audio languages. Keep yt-dlp's default
+    // clients as fallbacks for videos unsupported by either client.
     '--extractor-args',
-    'youtube:player_client=android_vr,default'
+    'youtube:player_client=android_vr,web_embedded,default'
   ]
 
   await pushProxyArgument(args)

--- a/src/renderer/components/ft-shaka-video-player/ft-shaka-video-player.js
+++ b/src/renderer/components/ft-shaka-video-player/ft-shaka-video-player.js
@@ -6526,7 +6526,10 @@ export default defineComponent({
     }
 
     function registerLegacyQualitySelection() {
+      let selectionGeneration = 0
+
       events.addEventListener('setLegacyFormat', async (/** @type {CustomEvent} */ event) => {
+        const currentSelectionGeneration = ++selectionGeneration
         const {
           format,
           playbackPosition,
@@ -6553,7 +6556,13 @@ export default defineComponent({
         }
 
         try {
-          if (!await waitForYtDlpFormatAvailability(format)) {
+          const isAvailable = await waitForYtDlpFormatAvailability(format)
+
+          if (currentSelectionGeneration !== selectionGeneration) {
+            return
+          }
+
+          if (!isAvailable) {
             throw new Error('yt-dlp format availability delay is too long')
           }
 

--- a/src/renderer/components/ft-shaka-video-player/ft-shaka-video-player.js
+++ b/src/renderer/components/ft-shaka-video-player/ft-shaka-video-player.js
@@ -70,6 +70,7 @@ import { setupSabrScheme } from '../../helpers/player/SabrSchemePlugin'
 import { getRememberedPlayerVolume, setRememberedPlayerVolume } from '../../helpers/player/volume-storage'
 import { parseChannelPreferences } from '../../helpers/channel-preferences'
 import { findLegacyFormatForQuality } from '../../helpers/player/legacyFormats'
+import { waitForYtDlpFormatAvailability } from '../../helpers/player/ytDlpFormatAvailability'
 import { getDashQualityFromDimensions } from '../../helpers/player/videoQuality'
 import {
   DEFAULT_VIDEO_ZOOM,
@@ -6552,6 +6553,10 @@ export default defineComponent({
         }
 
         try {
+          if (!await waitForYtDlpFormatAvailability(format)) {
+            throw new Error('yt-dlp format availability delay is too long')
+          }
+
           await player.load(format.url, playbackPosition, format.mimeType)
         } catch (error) {
           handleError(error, 'setLegacyFormat', event.detail)

--- a/src/renderer/helpers/player/ytDlpFormatAvailability.js
+++ b/src/renderer/helpers/player/ytDlpFormatAvailability.js
@@ -1,0 +1,29 @@
+export const MAX_YT_DLP_FORMAT_AVAILABILITY_WAIT_MS = 15_000
+
+/**
+ * Matches yt-dlp's whole-second comparison when calculating its download delay.
+ * @param {number | null | undefined} availableAt Unix timestamp in seconds
+ * @param {number} now Unix timestamp in milliseconds
+ */
+export function getYtDlpFormatAvailabilityWaitMs(availableAt, now = Date.now()) {
+  return (availableAt ?? 0) * 1000 - Math.floor(now / 1000) * 1000
+}
+
+/**
+ * Waits for a shortly delayed format, while rejecting stale or unexpectedly
+ * distant timestamps so they cannot hold up every usable playback format.
+ * @param {{ availableAt?: number | null }} format
+ */
+export async function waitForYtDlpFormatAvailability(format) {
+  const waitMs = getYtDlpFormatAvailabilityWaitMs(format.availableAt)
+
+  if (waitMs > MAX_YT_DLP_FORMAT_AVAILABILITY_WAIT_MS) {
+    return false
+  }
+
+  if (waitMs > 0) {
+    await new Promise(resolve => setTimeout(resolve, waitMs))
+  }
+
+  return true
+}

--- a/src/renderer/helpers/player/ytDlpPlayback.js
+++ b/src/renderer/helpers/player/ytDlpPlayback.js
@@ -3,6 +3,7 @@ import { FormatUtils, Misc } from 'youtubei.js'
 import { MANIFEST_TYPE_DASH, MANIFEST_TYPE_HLS } from './utils'
 import { probeStreamByteRanges } from './streamByteRanges'
 import { generateAudioTrackField } from '../api/local'
+import { waitForYtDlpFormatAvailability } from './ytDlpFormatAvailability'
 
 /** @typedef {import('../../../main/ytDlp').YtDlpPlaybackFormat} YtDlpPlaybackFormat */
 
@@ -173,7 +174,8 @@ function mapYtDlpLegacyFormat(format) {
     mimeType: buildMimeType(format),
     height: format.height,
     width: format.width,
-    url: format.url
+    url: format.url,
+    availableAt: format.availableAt
   }
 }
 
@@ -202,12 +204,8 @@ function getExpiryDate(formats) {
 async function convertAdaptiveFormats(formats, duration) {
   const results = await Promise.all(formats.map(async (format) => {
     try {
-      // Match yt-dlp's own download delay. It compares the timestamp to the
-      // current whole second, so keep that rounding to avoid probing just
-      // before YouTube makes the URL usable.
-      const waitMs = (format.availableAt ?? 0) * 1000 - Math.floor(Date.now() / 1000) * 1000
-      if (waitMs > 0) {
-        await new Promise(resolve => setTimeout(resolve, waitMs))
+      if (!await waitForYtDlpFormatAvailability(format)) {
+        return null
       }
 
       const byteRanges = await probeStreamByteRanges(format.url, format.ext === 'webm')

--- a/src/renderer/helpers/player/ytDlpPlayback.js
+++ b/src/renderer/helpers/player/ytDlpPlayback.js
@@ -202,6 +202,14 @@ function getExpiryDate(formats) {
 async function convertAdaptiveFormats(formats, duration) {
   const results = await Promise.all(formats.map(async (format) => {
     try {
+      // Match yt-dlp's own download delay. It compares the timestamp to the
+      // current whole second, so keep that rounding to avoid probing just
+      // before YouTube makes the URL usable.
+      const waitMs = (format.availableAt ?? 0) * 1000 - Math.floor(Date.now() / 1000) * 1000
+      if (waitMs > 0) {
+        await new Promise(resolve => setTimeout(resolve, waitMs))
+      }
+
       const byteRanges = await probeStreamByteRanges(format.url, format.ext === 'webm')
 
       return byteRanges === null ? null : convertYtDlpToLocalFormat(format, byteRanges, duration)

--- a/tests/unit/yt-dlp-format-availability.test.mjs
+++ b/tests/unit/yt-dlp-format-availability.test.mjs
@@ -1,0 +1,19 @@
+import assert from 'node:assert/strict'
+import { test } from 'node:test'
+
+import {
+  getYtDlpFormatAvailabilityWaitMs,
+  MAX_YT_DLP_FORMAT_AVAILABILITY_WAIT_MS,
+  waitForYtDlpFormatAvailability,
+} from '../../src/renderer/helpers/player/ytDlpFormatAvailability.js'
+
+test('yt-dlp format availability uses the current whole second', () => {
+  assert.equal(getYtDlpFormatAvailabilityWaitMs(104, 100999), 4000)
+  assert.equal(getYtDlpFormatAvailabilityWaitMs(null, 100999), -100000)
+})
+
+test('yt-dlp format availability rejects an unexpectedly long delay', async () => {
+  const availableAt = Math.ceil(Date.now() / 1000) + (MAX_YT_DLP_FORMAT_AVAILABILITY_WAIT_MS / 1000) + 1
+
+  assert.equal(await waitForYtDlpFormatAvailability({ availableAt }), false)
+})


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Make sure to follow the contributing guidelines. -->
<!-- Important note, we may remove your pull request if you do not use this provided PR template correctly. -->
<!-- Agent instructions: Preserve every heading, comment, and marker in this template. Never remove or rewrite the release-note-category:start/end, release-note:start/end, or release-note-image:start/end marker pairs. Never remove or rewrite the Release note images section; leave its contents for a human. -->

## Pull Request Type
<!-- Please select what type of pull request this is: [x] -->
- [x] Bugfix
- [ ] Feature Implementation
- [ ] Documentation
- [ ] Other

## Related issue
<!-- Please link the issue your pull request is referring to. -->
<!-- If this pull request fully resolves the relevant issue, put "closes" before the issue number. -->
<!-- Example: "closes #123456". -->

Closes #655.

## Description
<!-- Please write a clear and concise description of what the pull request does. -->

The default logged-out YouTube client used by yt-dlp can expose only one audio language, so videos with multiple audio tracks had no track selector when using the yt-dlp playback backend.

This adds yt-dlp's embedded client as an extraction source while retaining its default clients as fallbacks. Embedded-client streams can have a short server-enforced availability delay, so the returned timestamp is preserved and range probing waits until the stream is usable instead of failing with HTTP 403.

## Release note category
<!-- Select exactly one category. Every pull request must select one. -->
<!-- Select "Not noteworthy" when the pull request fixes a bug in or improves functionality that has not yet appeared in a stable release. -->
<!-- release-note-category:start -->
- [ ] Not noteworthy
- [ ] Highlights
- [ ] More improvements
- [x] Fixed bugs
<!-- release-note-category:end -->

## Release note
<!-- Required unless "Not noteworthy" is selected. -->
<!-- Write one concise, user-facing entry without a leading bullet. -->
<!-- release-note:start -->
Restored audio track selection for videos played through yt-dlp.
<!-- release-note:end -->

## Release note images
<!-- Human-only: Agents must preserve this entire section and leave it empty. -->
<!-- Optional. Paste one or more Markdown images or HTML image tags here. -->
<!-- The release notes will use an HTML image tag and limit images taller than 300 pixels. -->
<!-- release-note-image:start -->

<!-- release-note-image:end -->

## Testing
<!-- How can reviewers verify that the PR produces correct results? -->
<!-- Please provide instructions so that others can ensure that your pull request would produce correct results. For examples see, https://github.com/FreeTubeApp/FreeTube/pull/5743, https://github.com/FreeTubeApp/FreeTube/pull/7349, https://github.com/FreeTubeApp/FreeTube/pull/5125, https://github.com/FreeTubeApp/FreeTube/pull/7338 -->
<!-- Agent instructions: Only write human-facing steps that explain how to verify the change while running this branch in dev mode. Include expected results and, when applicable, helpful console snippets for interactive verification. Do not include automated checks, commands, results, pass counts, or CI status. -->

1. Configure yt-dlp as the playback engine and open `https://youtu.be/9Gr2QjvSQ-I`.
2. Wait for playback to begin, then open the audio track menu.
3. Confirm that English, Portuguese, and Spanish tracks are listed and that selecting each one changes the audio without falling back to the built-in engine.

## Additional context
<!-- Add any other context about the pull request here. -->

yt-dlp itself observes the per-format availability timestamp before downloading embedded-client streams. OpenTubeX now applies the same delay before its byte-range probes.
