### PR TITLE
fix(player): recover live streams without manifests

### DIFF
--- a/e2e/tests/offline/video-actions.spec.mjs
+++ b/e2e/tests/offline/video-actions.spec.mjs
@@ -103,6 +103,28 @@ test.describe('video downloads', () => {
     await expect(page.locator('.downloadProgressBarTrack')).toHaveCount(0)
   })
 
+  test('requests Android VR streams for yt-dlp playback', async ({ app, page }) => {
+    const executable = path.join(app.userDataDir, 'capture-yt-dlp-playback-args.sh')
+    const capturedArgs = path.join(app.userDataDir, 'captured-yt-dlp-playback-args.txt')
+    await writeFile(executable, [
+      '#!/bin/sh',
+      `printf '%s\\n' "$@" > "${capturedArgs}"`,
+      'printf \'%s\\n\' \'{"formats":[]}\''
+    ].join('\n'))
+    await chmod(executable, 0o755)
+    await page.evaluate(async (ytDlpPath) => {
+      const store = document.querySelector('#app').__vue_app__.config.globalProperties.$store
+      await store.dispatch('updateYtDlpPath', ytDlpPath)
+    }, executable)
+
+    await page.bringToFront()
+    await page.evaluate(() => window.ftElectron.ytDlpGetPlaybackInfo('eeeeeeeeeee'))
+
+    const passedArguments = (await readFile(capturedArgs, 'utf8')).trim().split('\n')
+    const extractorArgsIndex = passedArguments.indexOf('--extractor-args')
+    expect(passedArguments[extractorArgsIndex + 1]).toBe('youtube:player_client=android_vr,default')
+  })
+
   test('disables media download actions and rejects direct requests', async ({ page }) => {
     await page.evaluate(async () => {
       const store = document.querySelector('#app').__vue_app__.config.globalProperties.$store

--- a/e2e/tests/offline/watch-page.spec.mjs
+++ b/e2e/tests/offline/watch-page.spec.mjs
@@ -127,6 +127,7 @@ test.describe('watch page', () => {
       view.isLive = true
       view.manifestSrc = null
       view.legacyFormats = []
+      view.activeFormat = 'legacy'
       view.activePlaybackEngine = 'built-in'
       await view.applyYtDlpPlaybackSource(view.videoLoadGeneration, view.videoId)
       await view.$nextTick()
@@ -135,12 +136,14 @@ test.describe('watch page', () => {
     await expect(page.locator(`${activeTab} .videoTitle`)).toHaveText('Active live stream')
     expect(await watchView.evaluate((view) => ({
       manifestSrc: view.manifestSrc,
+      activeFormat: view.activeFormat,
       activePlaybackEngine: view.activePlaybackEngine,
       activePlaybackEngineVersion: view.activePlaybackEngineVersion,
       playerReady: view.playerReady,
       ytDlpStreamsPending: view.ytDlpStreamsPending
     }))).toEqual({
       manifestSrc: 'https://example.invalid/live.m3u8',
+      activeFormat: 'dash',
       activePlaybackEngine: 'yt-dlp',
       activePlaybackEngineVersion: 'test',
       playerReady: true,

--- a/e2e/tests/offline/watch-page.spec.mjs
+++ b/e2e/tests/offline/watch-page.spec.mjs
@@ -100,6 +100,54 @@ async function mockTranslatedEndscreen(app, page) {
 }
 
 test.describe('watch page', () => {
+  test('falls back to yt-dlp when the built-in live source has no manifest', async ({ app, page }) => {
+    await mockPlayableWatchPage(app, page)
+    await page.locator(sel.searchInput).fill('https://www.youtube.com/watch?v=jNQXAC9IVRw')
+    await page.locator(sel.searchInput).press('Enter')
+    await expect(page).toHaveURL(/#\/watch\/jNQXAC9IVRw/)
+    await expect(page.locator(`${activeTab} .videoLayout`)).toBeVisible()
+
+    await app.electronApp.evaluate(({ ipcMain }) => {
+      ipcMain.removeHandler('yt-dlp-get-playback-info')
+      ipcMain.handle('yt-dlp-get-playback-info', () => ({
+        isLive: true,
+        liveStatus: 'is_live',
+        hlsManifestUrl: 'https://example.invalid/live.m3u8',
+        formats: [],
+        duration: null,
+        version: 'test'
+      }))
+    })
+
+    const watchView = await watchViewHandle(page)
+    await watchView.evaluate(async (view) => {
+      view.isLoading = false
+      view.errorMessage = null
+      view.videoTitle = 'Active live stream'
+      view.isLive = true
+      view.manifestSrc = null
+      view.legacyFormats = []
+      view.activePlaybackEngine = 'built-in'
+      await view.applyYtDlpPlaybackSource(view.videoLoadGeneration, view.videoId)
+      await view.$nextTick()
+    })
+
+    await expect(page.locator(`${activeTab} .videoTitle`)).toHaveText('Active live stream')
+    expect(await watchView.evaluate((view) => ({
+      manifestSrc: view.manifestSrc,
+      activePlaybackEngine: view.activePlaybackEngine,
+      activePlaybackEngineVersion: view.activePlaybackEngineVersion,
+      playerReady: view.playerReady,
+      ytDlpStreamsPending: view.ytDlpStreamsPending
+    }))).toEqual({
+      manifestSrc: 'https://example.invalid/live.m3u8',
+      activePlaybackEngine: 'yt-dlp',
+      activePlaybackEngineVersion: 'test',
+      playerReady: true,
+      ytDlpStreamsPending: false
+    })
+  })
+
   test('keeps live chat and replay visibility independent and restores a closed chat', async ({ app, page }) => {
     await mockPlayableWatchPage(app, page)
     await openMockedVideo(page)

--- a/src/main/ytDlp.js
+++ b/src/main/ytDlp.js
@@ -1094,7 +1094,19 @@ export async function handleYtDlpGetPlaybackInfo(event, videoId) {
     }
   }
 
-  const args = ['--dump-single-json', '--no-playlist', '--no-warnings', '--no-progress', '--socket-timeout', '15']
+  const args = [
+    '--dump-single-json',
+    '--no-playlist',
+    '--no-warnings',
+    '--no-progress',
+    '--socket-timeout',
+    '15',
+    // Some yt-dlp versions otherwise select an iOS live HLS manifest, whose
+    // segments can stop working when YouTube enforces a PO token. Android VR
+    // live HLS does not require that token; retain the defaults as fallbacks.
+    '--extractor-args',
+    'youtube:player_client=android_vr,default'
+  ]
 
   await pushProxyArgument(args)
 

--- a/src/renderer/views/Watch/Watch.js
+++ b/src/renderer/views/Watch/Watch.js
@@ -2529,6 +2529,8 @@ export default defineComponent({
         }
 
         if (!this.isUpcoming) {
+          this.alignActiveFormatWithAvailableSources()
+
           // Deliberately not awaited, so that the metadata (title, description,
           // comments, recommendations, ...) is shown while yt-dlp is still extracting.
           this.applyYtDlpPlaybackSource(loadGeneration, videoId)
@@ -2765,6 +2767,8 @@ export default defineComponent({
           }
 
           if (!this.isUpcoming) {
+            this.alignActiveFormatWithAvailableSources()
+
             // Deliberately not awaited, so that the metadata (title, description,
             // comments, recommendations, ...) is shown while yt-dlp is still extracting.
             this.applyYtDlpPlaybackSource(loadGeneration, videoId)

--- a/src/renderer/views/Watch/Watch.js
+++ b/src/renderer/views/Watch/Watch.js
@@ -895,7 +895,13 @@ export default defineComponent({
      * only be created once the streams it is supposed to play are known.
      */
     playerReady() {
-      return !this.isLoading && !this.ytDlpStreamsPending
+      if (this.isLoading || this.ytDlpStreamsPending) {
+        return false
+      }
+
+      return this.activeFormat === 'legacy'
+        ? this.legacyFormats.length > 0
+        : this.manifestSrc !== null
     },
 
     canSaveWatchProgress() {
@@ -2312,16 +2318,20 @@ export default defineComponent({
           }
 
           if (useRemoteManifest) {
-            if (result.streaming_data.dash_manifest_url) {
+            if (result.streaming_data?.dash_manifest_url) {
               this.manifestSrc = result.streaming_data.dash_manifest_url
               this.manifestMimeType = MANIFEST_TYPE_DASH
             } else {
-              this.manifestSrc = result.streaming_data.hls_manifest_url
+              // A blocked live player response can contain all watch-page metadata
+              // without either manifest URL. Keep the missing source as `null`, as
+              // expected by the player availability checks, while yt-dlp extracts
+              // its independent HLS manifest.
+              this.manifestSrc = result.streaming_data?.hls_manifest_url ?? null
               this.manifestMimeType = MANIFEST_TYPE_HLS
             }
           }
 
-          this.streamingDataExpiryDate = result.streaming_data.expires
+          this.streamingDataExpiryDate = result.streaming_data?.expires ?? null
 
           if (this.activeFormat === 'legacy') {
             this.activeFormat = 'dash'
@@ -4010,10 +4020,20 @@ export default defineComponent({
      * @param {string} videoId
      */
     applyYtDlpPlaybackSource: async function (loadGeneration, videoId) {
+      const builtInLiveSourceMissing =
+        this.videoPlaybackEngine === 'built-in' &&
+        this.isLive &&
+        this.manifestSrc === null &&
+        this.legacyFormats.length === 0
+
       if (
         !process.env.IS_ELECTRON ||
         this.playbackEngineFallbackTarget === 'built-in' ||
-        (this.videoPlaybackEngine !== 'yt-dlp' && this.playbackEngineFallbackTarget !== 'yt-dlp')
+        (
+          this.videoPlaybackEngine !== 'yt-dlp' &&
+          this.playbackEngineFallbackTarget !== 'yt-dlp' &&
+          !builtInLiveSourceMissing
+        )
       ) {
         return
       }
@@ -4028,10 +4048,26 @@ export default defineComponent({
       this.ytDlpStreamsPending = true
 
       try {
-        await this.extractYtDlpPlaybackSource(loadGeneration, videoId)
+        const sourceApplied = await this.extractYtDlpPlaybackSource(loadGeneration, videoId)
+
+        if (
+          !sourceApplied &&
+          this.isCurrentVideoLoad(loadGeneration, videoId) &&
+          this.manifestSrc === null &&
+          this.legacyFormats.length === 0
+        ) {
+          this.errorMessage = this.t('This video is unavailable because of missing formats. This can happen due to country unavailability.')
+        }
       } catch (error) {
         // The callers don't await this, so nothing else can handle it.
         console.error('Applying the yt-dlp playback source failed', error)
+        if (
+          this.isCurrentVideoLoad(loadGeneration, videoId) &&
+          this.manifestSrc === null &&
+          this.legacyFormats.length === 0
+        ) {
+          this.errorMessage = this.t('This video is unavailable because of missing formats. This can happen due to country unavailability.')
+        }
       } finally {
         // A stale load has already had its state reset (and may have started its own
         // extraction), so it must not clear the flag of the load that replaced it.


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Make sure to follow the contributing guidelines. -->
<!-- Important note, we may remove your pull request if you do not use this provided PR template correctly. -->
<!-- Agent instructions: Preserve every heading, comment, and marker in this template. Never remove or rewrite the release-note-category:start/end, release-note:start/end, or release-note-image:start/end marker pairs. Never remove or rewrite the Release note images section; leave its contents for a human. -->

## Pull Request Type
<!-- Please select what type of pull request this is: [x] -->
- [x] Bugfix
- [ ] Feature Implementation
- [ ] Documentation
- [ ] Other

## Related issue
<!-- Please link the issue your pull request is referring to. -->
<!-- If this pull request fully resolves the relevant issue, put "closes" before the issue number. -->
<!-- Example: "closes #123456". -->

Closes #656.

## Description
<!-- Please write a clear and concise description of what the pull request does. -->

Live videos could render a blank page when YouTube returned complete watch metadata without a DASH or HLS manifest. The player was still mounted with a null source, while the built-in engine could not reach its normal error-driven yt-dlp fallback because no player existed to emit an error.

Keep the player unmounted until a real source is available, and automatically ask yt-dlp for an Android VR HLS source when the built-in live response contains no playable formats. If extraction also fails, show the existing missing-formats error instead of leaving an empty watch page.

## Release note category
<!-- Select exactly one category. Every pull request must select one. -->
<!-- Select "Not noteworthy" when the pull request fixes a bug in or improves functionality that has not yet appeared in a stable release. -->
<!-- release-note-category:start -->
- [ ] Not noteworthy
- [ ] Highlights
- [ ] More improvements
- [x] Fixed bugs
<!-- release-note-category:end -->

## Release note
<!-- Required unless "Not noteworthy" is selected. -->
<!-- Write one concise, user-facing entry without a leading bullet. -->
<!-- release-note:start -->
Fixed live videos intermittently showing a blank screen when YouTube omits playback formats.
<!-- release-note:end -->

## Release note images
<!-- Human-only: Agents must preserve this entire section and leave it empty. -->
<!-- Optional. Paste one or more Markdown images or HTML image tags here. -->
<!-- The release notes will use an HTML image tag and limit images taller than 300 pixels. -->
<!-- release-note-image:start -->

<!-- release-note-image:end -->

## Testing
<!-- How can reviewers verify that the PR produces correct results? -->
<!-- Please provide instructions so that others can ensure that your pull request produces correct results. For examples see, https://github.com/FreeTubeApp/FreeTube/pull/5743, https://github.com/FreeTubeApp/FreeTube/pull/7349, https://github.com/FreeTubeApp/FreeTube/pull/5125, https://github.com/FreeTubeApp/FreeTube/pull/7338 -->
<!-- Agent instructions: Only write human-facing steps that explain how to verify the change while running this branch in dev mode. Include expected results and, when applicable, helpful console snippets for interactive verification. Do not include automated checks, commands, results, pass counts, or CI status. -->

1. Run the app in dev mode with the Local API and Built-in playback engine selected.
2. Open an active YouTube live stream whose built-in response has no manifest.
3. Confirm that the watch metadata remains visible while streams are fetched, then the player appears and playback starts through yt-dlp.
4. Temporarily make yt-dlp unavailable and reload the stream. Confirm that a missing-formats message appears instead of a blank page or broken player.

## Additional context
<!-- Add any other context about the pull request here. -->

The originally reported stream and configuration were also verified interactively by the reporter.
