### PR TITLE
feat(player): make the settings menu easier to scan

### DIFF
--- a/e2e/tests/offline/player.spec.mjs
+++ b/e2e/tests/offline/player.spec.mjs
@@ -1,5 +1,10 @@
 import { setWindowSize, test, expect } from '../../helpers/app.mjs'
-import { activeTab, expectDockedToBottomRight, openMockedVideo } from '../../helpers/player.mjs'
+import {
+  activeTab,
+  expectDockedToBottomRight,
+  findWatchComponent,
+  openMockedVideo,
+} from '../../helpers/player.mjs'
 import { mockPlayableWatchPage } from '../../helpers/watch.mjs'
 
 // These used to live in the network suite, where they only ran when YouTube
@@ -187,6 +192,37 @@ test('the overflow menu can turn the zoom off again', async ({ app, page, attach
 
   await zoomMenu.getByRole('button', { name: 'Off' }).click()
   await expect(video).toHaveCSS('transform', 'none')
+})
+
+test('video zoom can be disabled', async ({ app, page }) => {
+  const video = await openDemoVideo({ app, page })
+
+  await page.locator('body').press('z')
+  await expect(video).toHaveCSS('transform', 'matrix(1.25, 0, 0, 1.25, 0, 0)')
+
+  const watchComponent = await page.evaluateHandle(findWatchComponent)
+  await watchComponent.evaluate(async (component) => {
+    await component.proxy.$store.dispatch('updateEnableVideoZoom', false)
+    await component.proxy.$nextTick()
+  })
+  await expect(video).toHaveCSS('transform', 'none')
+
+  const player = page.locator(`${activeTab} .ftVideoPlayer`)
+  await player.hover()
+  await player.getByRole('button', { name: 'More settings' }).click()
+  await expect(player.locator('.shaka-overflow-menu').getByRole('button', { name: 'Zoom' }))
+    .toHaveCount(0)
+
+  await page.keyboard.press('Escape')
+  await page.locator('body').press('z')
+  await expect(video).toHaveCSS('transform', 'none')
+
+  await watchComponent.evaluate(async (component) => {
+    await component.proxy.$store.dispatch('updateEnableVideoZoom', true)
+    await component.proxy.$nextTick()
+  })
+  await expect(video).toHaveCSS('transform', 'matrix(1.25, 0, 0, 1.25, 0, 0)')
+  await watchComponent.dispose()
 })
 
 test('keeps the context menu open when the pointer leaves a playing video', async ({ app, page, attachScreenshot }) => {

--- a/e2e/tests/offline/player.spec.mjs
+++ b/e2e/tests/offline/player.spec.mjs
@@ -192,6 +192,24 @@ test('the overflow menu can turn the zoom off again', async ({ app, page, attach
 
   await zoomMenu.getByRole('button', { name: 'Off' }).click()
   await expect(video).toHaveCSS('transform', 'none')
+
+  // A narrow player folds Autoplay into the overflow menu.
+  await player.evaluate(element => { element.style.width = '600px' })
+  const autoplaySwitch = overflowMenu.locator('.autoplay-toggle > .ft-autoplay-switch')
+  await moreOptions.click()
+  await expect(autoplaySwitch).toBeVisible()
+  await expect(autoplaySwitch).toHaveCSS('margin-right', '0px')
+
+  const watchComponent = await page.evaluateHandle(findWatchComponent)
+  await watchComponent.evaluate(async (component) => {
+    await component.proxy.$store.dispatch('updateUsePlayerMenuGrid', false)
+    await component.proxy.$nextTick()
+  })
+  await player.hover()
+  await moreOptions.click()
+  await expect(overflowMenu).not.toHaveClass(/ft-menu-grid/)
+  await expect(autoplaySwitch).toHaveCSS('margin-right', '14px')
+  await watchComponent.dispose()
 })
 
 test('video zoom can be disabled', async ({ app, page }) => {

--- a/e2e/tests/offline/player.spec.mjs
+++ b/e2e/tests/offline/player.spec.mjs
@@ -145,10 +145,47 @@ test('the overflow menu can turn the zoom off again', async ({ app, page, attach
   await moreOptions.click()
 
   const overflowMenu = player.locator('.shaka-overflow-menu')
+  await expect(overflowMenu).toHaveClass(/ft-menu-grid/)
+  await expect(overflowMenu).toHaveCSS('display', 'grid')
+  expect(await overflowMenu.locator(':scope > button').evaluateAll((buttons) => {
+    return buttons.every((button) => getComputedStyle(button).flexDirection === 'column')
+  })).toBe(true)
+  const overflowMenuHeight = (await overflowMenu.boundingBox()).height
+
   await overflowMenu.getByRole('button', { name: 'Zoom' }).click()
+  const zoomMenu = player.locator('.video-zoom-menu')
+  await expect(zoomMenu).toHaveClass(/ft-menu-grid/)
+  await expect(zoomMenu).toHaveCSS('flex-wrap', 'wrap')
+  expect((await overflowMenu.boundingBox()).height).toBe(overflowMenuHeight)
+  const zoomHeader = zoomMenu.locator('.shaka-back-to-overflow-button')
+  const zoomHeaderTitle = zoomHeader.getByText('Zoom')
+  const [headerBox, titleBox] = await Promise.all([
+    zoomHeader.boundingBox(),
+    zoomHeaderTitle.boundingBox(),
+  ])
+  expect(Math.abs(
+    (headerBox.x + headerBox.width / 2) - (titleBox.x + titleBox.width / 2)
+  )).toBeLessThanOrEqual(1)
+  expect(await zoomMenu.evaluate((menu) => {
+    // Caption tracks are not part of the local media fixture. Recreate its
+    // Options action in another submenu to verify the shared grid geometry.
+    const options = document.createElement('button')
+    options.className = 'ft-caption-options-button'
+    options.textContent = 'Options'
+    menu.append(options)
+
+    const header = menu.querySelector('.shaka-back-to-overflow-button')
+    const headerBox = header.getBoundingClientRect()
+    const optionsBox = options.getBoundingClientRect()
+    options.remove()
+
+    return Math.abs(
+      (headerBox.top + headerBox.height / 2) - (optionsBox.top + optionsBox.height / 2)
+    )
+  })).toBeLessThanOrEqual(1)
   await attachScreenshot('zoom menu')
 
-  await player.locator('.video-zoom-menu').getByRole('button', { name: 'Off' }).click()
+  await zoomMenu.getByRole('button', { name: 'Off' }).click()
   await expect(video).toHaveCSS('transform', 'none')
 })
 

--- a/src/renderer/components/PlayerSettings/PlayerSettings.vue
+++ b/src/renderer/components/PlayerSettings/PlayerSettings.vue
@@ -43,6 +43,14 @@
           @change="updateShowSkipSilenceButton"
         />
         <FtToggleSwitch
+          :label="t('Settings.Player Settings.Enable Video Zoom')"
+          :compact="true"
+          :default-value="enableVideoZoom"
+          setting-key="enableVideoZoom"
+          :tooltip="t('Tooltips.Player Settings.Enable Video Zoom')"
+          @change="updateEnableVideoZoom"
+        />
+        <FtToggleSwitch
           v-if="USING_ELECTRON"
           :label="t('Settings.Player Settings.Voice-over Translation.Enable')"
           :compact="true"
@@ -667,6 +675,16 @@ function updateShowSkipSilenceButton(value) {
   if (!value) {
     store.dispatch('updateSkipSilence', false)
   }
+}
+
+/** @type {import('vue').ComputedRef<boolean>} */
+const enableVideoZoom = computed(() => store.getters.getEnableVideoZoom)
+
+/**
+ * @param {boolean} value
+ */
+function updateEnableVideoZoom(value) {
+  store.dispatch('updateEnableVideoZoom', value)
 }
 
 /** @type {import('vue').ComputedRef<boolean>} */

--- a/src/renderer/components/ThemeSettings.vue
+++ b/src/renderer/components/ThemeSettings.vue
@@ -41,6 +41,14 @@
           @change="updateShowToastTimeoutIndicator"
         />
         <FtToggleSwitch
+          :label="$t('Settings.Theme Settings.Use Grid Player Menu')"
+          :tooltip="$t('Tooltips.Theme Settings.Use Grid Player Menu')"
+          compact
+          :default-value="usePlayerMenuGrid"
+          setting-key="usePlayerMenuGrid"
+          @change="updateUsePlayerMenuGrid"
+        />
+        <FtToggleSwitch
           v-if="usingElectron"
           :label="$t('Settings.Theme Settings.Use Fixed Tab Width')"
           :tooltip="$t('Tooltips.Theme Settings.Use Fixed Tab Width')"
@@ -463,6 +471,16 @@ const showToastTimeoutIndicator = computed(() => store.getters.getShowToastTimeo
  */
 function updateShowToastTimeoutIndicator(value) {
   store.dispatch('updateShowToastTimeoutIndicator', value)
+}
+
+/** @type {import('vue').ComputedRef<boolean>} */
+const usePlayerMenuGrid = computed(() => store.getters.getUsePlayerMenuGrid)
+
+/**
+ * @param {boolean} value
+ */
+function updateUsePlayerMenuGrid(value) {
+  store.dispatch('updateUsePlayerMenuGrid', value)
 }
 
 /** @type {import('vue').ComputedRef<boolean>} */

--- a/src/renderer/components/ft-shaka-video-player/ft-shaka-video-player.css
+++ b/src/renderer/components/ft-shaka-video-player/ft-shaka-video-player.css
@@ -1041,7 +1041,6 @@
 :deep(.shaka-sub-menu.ft-menu-grid > .ft-caption-options-button) {
   align-items: center;
   block-size: var(--ft-submenu-header-size);
-  min-block-size: 0 !important;
   padding-block: 0 !important;
 }
 
@@ -1049,7 +1048,10 @@
   The option and its quality mark (`HD`, `4K`) are siblings, so the tile wraps
   them in a row instead of stacking them.
 */
-:deep(.shaka-sub-menu.ft-menu-grid > button:not(.shaka-back-to-overflow-button)) {
+:deep(.shaka-sub-menu.ft-menu-grid > button:not(
+  .shaka-back-to-overflow-button,
+  .ft-caption-options-button
+)) {
   flex-wrap: wrap;
   place-content: center;
   gap: 0 2px;

--- a/src/renderer/components/ft-shaka-video-player/ft-shaka-video-player.css
+++ b/src/renderer/components/ft-shaka-video-player/ft-shaka-video-player.css
@@ -1327,6 +1327,10 @@
 }
 
 :deep(.shaka-overflow-menu .autoplay-toggle > .ft-autoplay-switch) {
+  margin-inline-end: 14px;
+}
+
+:deep(.shaka-overflow-menu.ft-menu-grid .autoplay-toggle > .ft-autoplay-switch) {
   margin-inline-end: 0;
 }
 

--- a/src/renderer/components/ft-shaka-video-player/ft-shaka-video-player.css
+++ b/src/renderer/components/ft-shaka-video-player/ft-shaka-video-player.css
@@ -877,6 +877,223 @@
   display: none;
 }
 
+/*
+  The overflow menu grew a row for every new option, so it ended up taller than
+  most players. Every entry is a tile instead: icon on top, name below it and the
+  current value underneath. The column count follows the menu width, so narrow
+  players (where the whole control bar folds into this menu) get fewer columns.
+*/
+:deep(.shaka-overflow-menu.ft-menu-grid) {
+  /* Height of a submenu's header, which is pinned above its options. */
+  --ft-submenu-header-size: 36px;
+
+  box-sizing: border-box;
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(90px, 1fr));
+
+  /*
+    `1fr` alone squeezes the rows against the menu's max height once there are
+    enough entries, which pushes the labels out of their tiles.
+  */
+  grid-auto-rows: minmax(min-content, 1fr);
+  align-content: start;
+  gap: 4px;
+  inline-size: min(400px, calc(100% - 24px));
+  max-block-size: min(50vh, 340px);
+  padding: 6px;
+}
+
+/* The submenus are rendered inside the menu, so they have to span every column. */
+:deep(.shaka-overflow-menu.ft-menu-grid > *) {
+  grid-column: 1 / -1;
+}
+
+/*
+  The menu is always dark, so its overlay scrollbar can't take the app's
+  scrollbar colour, which is dark itself in most themes.
+*/
+:deep(.shaka-overflow-menu.ft-menu-grid > .os-scrollbar) {
+  --os-handle-bg: rgb(255 255 255 / 40%);
+  --os-handle-bg-hover: rgb(255 255 255 / 55%);
+  --os-handle-bg-active: rgb(255 255 255 / 70%);
+}
+
+:deep(.shaka-overflow-menu.ft-menu-grid > button) {
+  grid-column: auto;
+  flex-direction: column;
+  justify-content: center;
+  gap: 3px;
+  min-block-size: 0;
+  padding: 6px 4px;
+  border-radius: calc(10px * var(--ui-roundness));
+  background: rgb(255 255 255 / 7%);
+  white-space: normal;
+}
+
+:deep(.shaka-overflow-menu.ft-menu-grid > button:hover),
+:deep(.shaka-overflow-menu.ft-menu-grid > button:focus-visible) {
+  background: rgb(255 255 255 / 20%);
+}
+
+/*
+  An active entry is readable at a glance, without going over its value. Toggles
+  say so through `aria-pressed`, entries that are active without being a toggle
+  (the sleep timer) mark themselves with `ft-active`.
+*/
+:deep(.shaka-overflow-menu.ft-menu-grid > button[aria-pressed='true']),
+:deep(.shaka-overflow-menu.ft-menu-grid > button.ft-active) {
+  background: color-mix(in srgb, var(--primary-color) 32%, transparent);
+}
+
+:deep(.shaka-overflow-menu.ft-menu-grid > button[aria-pressed='true']:hover),
+:deep(.shaka-overflow-menu.ft-menu-grid > button.ft-active:hover) {
+  background: color-mix(in srgb, var(--primary-color) 48%, transparent);
+}
+
+/* The icon sits above the label instead of next to it. */
+:deep(.shaka-overflow-menu.ft-menu-grid > button > .shaka-ui-icon) {
+  padding-inline-end: 0;
+  font-size: 20px;
+}
+
+:deep(.shaka-overflow-menu.ft-menu-grid > button > .shaka-overflow-button-label) {
+  flex-direction: column;
+  align-items: center;
+  gap: 2px;
+  inline-size: 100%;
+  min-inline-size: 0;
+  padding-inline-end: 0;
+  font-size: 11px;
+  line-height: 1.25;
+  text-align: center;
+
+  /* The chevron of the submenu entries doesn't fit into a tile. */
+  background-image: none;
+}
+
+/* Names that don't fit into a tile (`Fast-Forward Through Silence`) get cut off. */
+:deep(.shaka-overflow-menu.ft-menu-grid .shaka-overflow-button-label > span:not(.shaka-current-selection-span)) {
+  display: -webkit-box;
+  overflow: hidden;
+  max-inline-size: 100%;
+  text-align: center;
+  -webkit-box-orient: vertical;
+  line-clamp: 2;
+  -webkit-line-clamp: 2;
+}
+
+/* The current value (`On`, `2x`, the chapter title, …) stays on a single line. */
+:deep(.shaka-overflow-menu.ft-menu-grid .shaka-overflow-button-label > .shaka-current-selection-span) {
+  max-inline-size: 100%;
+  padding-inline-start: 0;
+  overflow: hidden;
+  font-size: 10px;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  opacity: 0.75;
+}
+
+/* The playback rate reserves room for its widest value, which offsets the tile. */
+:deep(.shaka-overflow-menu.ft-menu-grid .shaka-playbackrate-button .shaka-current-selection-span) {
+  inline-size: auto;
+  text-align: center;
+}
+
+/*
+  The submenus are laid out as tiles too, so that switching between the menu and
+  a submenu doesn't change the shape of the popup. Wrapping flex rather than a
+  grid: the options are all one size, and a row that isn't full stays centred
+  instead of being pushed to one side.
+*/
+:deep(.shaka-sub-menu.ft-menu-grid) {
+  position: relative;
+  flex-flow: row wrap;
+
+  /*
+    The menu keeps its height while a submenu is open, so the options are
+    centred in whatever is left below the header rather than stretched over it.
+  */
+  place-content: center;
+  gap: 4px;
+  padding-block-start: calc(var(--ft-submenu-header-size) + 4px);
+}
+
+/* Taken out of the flow, so that it stays put while the options are centred. */
+:deep(.shaka-sub-menu.ft-menu-grid > .shaka-back-to-overflow-button) {
+  position: absolute;
+  inset-block-start: 0;
+  inset-inline: 0;
+  box-sizing: border-box;
+  justify-content: center;
+  block-size: var(--ft-submenu-header-size);
+  padding-block: 0;
+  margin-block-end: 0;
+}
+
+/* Keep the title centred in the header instead of after the back icon. */
+:deep(.shaka-sub-menu.ft-menu-grid > .shaka-back-to-overflow-button > .shaka-ui-icon) {
+  position: absolute;
+  inset-inline-start: 10px;
+  padding-inline-end: 0;
+}
+
+/* Align the caption Options action with the submenu header beside it. */
+:deep(.shaka-sub-menu.ft-menu-grid > .ft-caption-options-button) {
+  align-items: center;
+  block-size: var(--ft-submenu-header-size);
+  min-block-size: 0 !important;
+  padding-block: 0 !important;
+}
+
+/*
+  The option and its quality mark (`HD`, `4K`) are siblings, so the tile wraps
+  them in a row instead of stacking them.
+*/
+:deep(.shaka-sub-menu.ft-menu-grid > button:not(.shaka-back-to-overflow-button)) {
+  flex-wrap: wrap;
+  place-content: center;
+  gap: 0 2px;
+
+  /* Room for a name that wraps onto a second line, so every option is one size. */
+  inline-size: 90px;
+  min-block-size: 40px;
+  padding: 6px 4px;
+  border-radius: calc(10px * var(--ui-roundness));
+  font-size: 11px;
+  line-height: 1.25;
+  text-align: center;
+  background: rgb(255 255 255 / 7%);
+  white-space: normal;
+}
+
+:deep(.shaka-sub-menu.ft-menu-grid > button:hover),
+:deep(.shaka-sub-menu.ft-menu-grid > button:focus-visible) {
+  background: rgb(255 255 255 / 20%);
+}
+
+/*
+  The checkmark would make the selected tile taller than the others, so the
+  selection is shown as a highlighted tile instead.
+*/
+:deep(.shaka-sub-menu.ft-menu-grid .shaka-ui-icon.shaka-chosen-item) {
+  display: none;
+}
+
+:deep(.shaka-sub-menu.ft-menu-grid > button:has(.shaka-chosen-item)) {
+  background: color-mix(in srgb, var(--primary-color) 32%, transparent);
+}
+
+:deep(.shaka-sub-menu.ft-menu-grid > button > span) {
+  display: -webkit-box;
+  overflow: hidden;
+  max-inline-size: 100%;
+  margin-inline-start: 0;
+  text-align: center;
+  -webkit-box-orient: vertical;
+  line-clamp: 2;
+  -webkit-line-clamp: 2;
+}
+
 :deep(.shaka-bottom-controls) {
   /*
     Force left to right, so that the UI doesn't break.
@@ -1108,7 +1325,7 @@
 }
 
 :deep(.shaka-overflow-menu .autoplay-toggle > .ft-autoplay-switch) {
-  margin-inline-end: 14px;
+  margin-inline-end: 0;
 }
 
 :deep(.shaka-overflow-menu .autoplay-toggle .ft-autoplay-switch-thumb) {

--- a/src/renderer/components/ft-shaka-video-player/ft-shaka-video-player.js
+++ b/src/renderer/components/ft-shaka-video-player/ft-shaka-video-player.js
@@ -60,6 +60,7 @@ import {
   FULLSCREEN_DOCK_OUTER_INSET,
   toggleFullscreenDockCollapsed,
 } from '../../helpers/fullscreenDocks'
+import { addOverlayScrollbars, removeOverlayScrollbars } from '../../helpers/overlayScrollbars'
 import { isReducedMotionEnabled } from '../../helpers/reducedMotion'
 import { appendTimestamp, getInvidiousVideoUrl, getYoutubeVideoShareUrl } from '../../helpers/share'
 import { MANIFEST_TYPE_SABR } from '../../helpers/player/SabrManifestParser'
@@ -1472,6 +1473,10 @@ export default defineComponent({
     /** @type {import('vue').ComputedRef<boolean>} */
     const enableScreenshot = computed(() => {
       return store.getters.getEnableScreenshot
+    })
+
+    const usePlayerMenuGrid = computed(() => {
+      return store.getters.getUsePlayerMenuGrid
     })
 
     /** @type {import('vue').ComputedRef<string>} */
@@ -3418,17 +3423,19 @@ export default defineComponent({
       // when full-window mode makes the player wide enough for the desktop
       // control layout.
       if (onlyUseOverFlowMenu.value || props.shortsPlayer) {
+        // Keep related settings together before the one-click actions so the
+        // grid's reading and tab order remain predictable.
         uiConfig.overflowMenuButtons = [
-          ...(props.shortsPlayer ? ['ft_shorts_video_info'] : []),
-          ...(!props.shortsPlayer ? ['ft_autoplay_toggle'] : []),
           props.format === 'legacy' ? 'ft_legacy_quality' : 'quality',
           'playback_rate',
-          'ft_skip_silence',
-          'ft_sleep_timer',
-          'ft_voice_over_translation',
           'captions',
           'ft_audio_tracks',
+          'ft_sleep_timer',
+          ...(props.shortsPlayer ? ['ft_shorts_video_info'] : []),
+          ...(!props.shortsPlayer ? ['ft_autoplay_toggle'] : []),
           ...(props.chapters.length > 0 ? ['ft_chapters'] : []),
+          'ft_skip_silence',
+          'ft_voice_over_translation',
           'ft_ambient_mode',
           'ft_video_zoom',
           'ft_loop',
@@ -3460,14 +3467,15 @@ export default defineComponent({
           'fullscreen'
         )
 
+        // Keep related settings together before the one-click actions.
         uiConfig.overflowMenuButtons.push(
           'ft_audio_tracks',
           'captions',
           'playback_rate',
-          'ft_skip_silence',
-          'ft_sleep_timer',
-          'ft_voice_over_translation',
           props.format === 'legacy' ? 'ft_legacy_quality' : 'quality',
+          'ft_sleep_timer',
+          'ft_skip_silence',
+          'ft_voice_over_translation',
           'ft_ambient_mode',
           'ft_video_zoom',
           'ft_loop',
@@ -3636,6 +3644,7 @@ export default defineComponent({
 
       syncPlayPauseControlIcons()
       syncMuteControlIcons(video.value.muted || video.value.volume === 0)
+      syncPipToggleState(document.pictureInPictureElement === video.value)
     }
 
     function closeChaptersOverlay() {
@@ -4139,11 +4148,91 @@ export default defineComponent({
 
       updateSponsorBlockSubmissionState()
       setupAdaptiveControlPanelLayout()
+      setupOverflowMenuLayout(controlsContainer)
+    }
+
+    /**
+     * The overflow menu and its submenus are rebuilt from scratch whenever the
+     * UI is configured, so they need their scrollbars and their height tracking
+     * back every time.
+     *
+     * @param {HTMLElement} controlsContainer
+     */
+    function setupOverflowMenuLayout(controlsContainer) {
+      overflowMenuResizeObserver?.disconnect()
+      overflowMenuResizeObserver = null
+      overflowMenuIdleHeight = 0
+
+      if (overflowMenuElement) {
+        removeOverlayScrollbars(overflowMenuElement)
+      }
+
+      const menu = controlsContainer.querySelector('.shaka-overflow-menu')
+      overflowMenuElement = menu instanceof HTMLElement ? menu : null
+      if (!overflowMenuElement) {
+        return
+      }
+
+      menu.classList.toggle('ft-menu-grid', usePlayerMenuGrid.value)
+
+      // The caption appearance submenu has controls rather than options, so it
+      // keeps its own layout.
+      const submenus = menu.querySelectorAll(':scope > .shaka-sub-menu:not(.ft-caption-appearance-menu)')
+      for (const submenu of submenus) {
+        submenu.classList.toggle('ft-menu-grid', usePlayerMenuGrid.value)
+      }
+
+      if (!usePlayerMenuGrid.value) {
+        menu.style.minBlockSize = ''
+        return
+      }
+
+      addOverlayScrollbars(menu)
+
+      // Opening a submenu replaces the tiles, which would otherwise resize the
+      // popup around them. Remember how tall the menu is while its own tiles are
+      // shown, so that a shorter submenu only leaves empty space below itself.
+      overflowMenuResizeObserver = new ResizeObserver(() => {
+        if (menu.querySelector(':scope > .shaka-sub-menu:not(.shaka-hidden)')) {
+          return
+        }
+
+        overflowMenuIdleHeight = menu.getBoundingClientRect().height
+      })
+      overflowMenuResizeObserver.observe(menu)
+
+      const controls = ui.getControls()
+      controls.removeEventListener('submenuopen', keepOverflowMenuHeight)
+      controls.removeEventListener('submenuclose', releaseOverflowMenuHeight)
+      controls.addEventListener('submenuopen', keepOverflowMenuHeight)
+      controls.addEventListener('submenuclose', releaseOverflowMenuHeight)
+    }
+
+    function keepOverflowMenuHeight() {
+      const menu = container.value?.querySelector('.shaka-overflow-menu')
+      if (menu instanceof HTMLElement && overflowMenuIdleHeight > 0) {
+        menu.style.minBlockSize = `${overflowMenuIdleHeight}px`
+      }
+    }
+
+    function releaseOverflowMenuHeight() {
+      const menu = container.value?.querySelector('.shaka-overflow-menu')
+      if (menu instanceof HTMLElement) {
+        menu.style.minBlockSize = ''
+      }
     }
 
     watch(uiConfig, (newValue, oldValue) => {
       if (newValue !== oldValue && ui) {
         configureUI()
+      }
+    })
+
+    // The menu is only rebuilt when the UI configuration changes, so switching
+    // the layout has to reach the existing one.
+    watch(usePlayerMenuGrid, () => {
+      if (ui) {
+        setupOverflowMenuLayout(ui.getControls().getControlsContainer())
       }
     })
 
@@ -4283,6 +4372,15 @@ export default defineComponent({
 
     /** @type {ResizeObserver|null} */
     let containerResizeObserver = null
+
+    /** @type {ResizeObserver|null} */
+    let overflowMenuResizeObserver = null
+
+    /** How tall the overflow menu is while its own tiles are shown. */
+    let overflowMenuIdleHeight = 0
+
+    /** @type {HTMLElement|null} */
+    let overflowMenuElement = null
 
     /** @type {ResizeObserver|null} */
     let controlPanelResizeObserver = null
@@ -4615,6 +4713,20 @@ export default defineComponent({
           }
 
           button.setAttribute('data-ft-muted', String(muted))
+        })
+      })
+    }
+
+    /**
+     * shaka-player's picture in picture button only tells its state through its
+     * label, so the overflow menu can't highlight it while it is active.
+     *
+     * @param {boolean} active
+     */
+    function syncPipToggleState(active) {
+      window.requestAnimationFrame(() => {
+        container.value?.querySelectorAll('.shaka-pip-button').forEach((button) => {
+          button.ariaPressed = active ? 'true' : 'false'
         })
       })
     }
@@ -5022,6 +5134,7 @@ export default defineComponent({
       }
 
       notifyPictureInPictureState(true)
+      syncPipToggleState(true)
     }
 
     function handleLeavePictureInPicture() {
@@ -5036,6 +5149,7 @@ export default defineComponent({
       pipWindowHeight.value = null
 
       notifyPictureInPictureState(false)
+      syncPipToggleState(false)
 
       updateScrollMiniPlayer()
     }
@@ -8914,6 +9028,16 @@ export default defineComponent({
       if (containerResizeObserver) {
         containerResizeObserver.disconnect()
         containerResizeObserver = null
+      }
+
+      if (overflowMenuResizeObserver) {
+        overflowMenuResizeObserver.disconnect()
+        overflowMenuResizeObserver = null
+      }
+
+      if (overflowMenuElement) {
+        removeOverlayScrollbars(overflowMenuElement)
+        overflowMenuElement = null
       }
 
       if (controlPanelResizeObserver) {

--- a/src/renderer/components/ft-shaka-video-player/ft-shaka-video-player.js
+++ b/src/renderer/components/ft-shaka-video-player/ft-shaka-video-player.js
@@ -3126,11 +3126,13 @@ export default defineComponent({
       return props.format === 'dash' && props.vrProjection === 'EQUIRECTANGULAR'
     })
 
+    const enableVideoZoom = computed(() => store.getters.getEnableVideoZoom)
+
     const videoZoomPossible = computed(() => {
       // Audio only playback has no video surface to crop and the shorts player
       // deliberately lets its content overflow the container, which is what
       // keeps a scaled video from spilling over the page for the other layouts.
-      return props.format !== 'audio' && !props.shortsPlayer && !useVrMode.value
+      return enableVideoZoom.value && props.format !== 'audio' && !props.shortsPlayer && !useVrMode.value
     })
 
     /** @type {import('vue').ComputedRef<number>} */

--- a/src/renderer/components/ft-shaka-video-player/player-components/AmbientModeButton.js
+++ b/src/renderer/components/ft-shaka-video-player/player-components/AmbientModeButton.js
@@ -98,6 +98,7 @@ export class AmbientModeButton extends shaka.ui.Element {
     this.currentStateValue_.textContent = this.ambientMode_.value ? enabledLabel : disabledLabel
     this.currentStateSizer_.textContent = this.ambientMode_.value ? disabledLabel : enabledLabel
     this.button_.ariaLabel = label
+    this.button_.ariaPressed = this.ambientMode_.value ? 'true' : 'false'
   }
 
   /** @private */

--- a/src/renderer/components/ft-shaka-video-player/player-components/FullWindowButton.js
+++ b/src/renderer/components/ft-shaka-video-player/player-components/FullWindowButton.js
@@ -88,6 +88,7 @@ export class FullWindowButton extends shaka.ui.Element {
       KeyboardShortcuts.VIDEO_PLAYER.GENERAL.FULLWINDOW
     )
     this.nameSpan_.textContent = this.button_.ariaLabel = newLabel
+    this.button_.ariaPressed = this.fullWindowEnabled_ ? 'true' : 'false'
   }
 
   /** @private */

--- a/src/renderer/components/ft-shaka-video-player/player-components/LoopButton.js
+++ b/src/renderer/components/ft-shaka-video-player/player-components/LoopButton.js
@@ -98,6 +98,7 @@ export class LoopButton extends shaka.ui.Element {
       ? shaka.ui.Enums.MaterialDesignSVGIcons.UNLOOP
       : shaka.ui.Enums.MaterialDesignSVGIcons.LOOP)
     this.button_.ariaLabel = this.localization.resolve(this.video.loop ? 'EXIT_LOOP_MODE' : 'ENTER_LOOP_MODE')
+    this.button_.ariaPressed = this.video.loop ? 'true' : 'false'
   }
 
   /** @private */

--- a/src/renderer/components/ft-shaka-video-player/player-components/SkipSilenceButton.js
+++ b/src/renderer/components/ft-shaka-video-player/player-components/SkipSilenceButton.js
@@ -106,6 +106,7 @@ export class SkipSilenceButton extends shaka.ui.Element {
     this.currentStateValue_.textContent = this.skipSilence_.value ? enabledLabel : disabledLabel
     this.currentStateSizer_.textContent = this.skipSilence_.value ? disabledLabel : enabledLabel
     this.button_.ariaLabel = label
+    this.button_.ariaPressed = this.skipSilence_.value ? 'true' : 'false'
   }
 
   /** @private */

--- a/src/renderer/components/ft-shaka-video-player/player-components/SleepTimer.js
+++ b/src/renderer/components/ft-shaka-video-player/player-components/SleepTimer.js
@@ -148,6 +148,9 @@ export class SleepTimer extends shaka.ui.SettingsMenu {
     }
 
     this.cancelButton_.classList.toggle('shaka-hidden', mode.value === null)
+    // A running timer highlights the entry in the overflow menu. This isn't a
+    // toggle button, so it can't use `aria-pressed` for it.
+    this.button.classList.toggle('ft-active', mode.value !== null)
     this.currentSelection.textContent = status
     this.button.setAttribute('shaka-status', status)
   }

--- a/src/renderer/helpers/overlayScrollbars.js
+++ b/src/renderer/helpers/overlayScrollbars.js
@@ -255,6 +255,27 @@ function toggleOverlayScrollbars(element, enabled) {
 }
 
 /**
+ * Adds the overlay scrollbars to an element that isn't rendered by Vue, so it
+ * can't use the directive below. Safe to call again for the same element.
+ *
+ * @param {HTMLElement} element
+ */
+export function addOverlayScrollbars(element) {
+  toggleOverlayScrollbars(element, true)
+}
+
+/**
+ * Counterpart of `addOverlayScrollbars`. Elements that are replaced rather than
+ * unmounted have to give up their instance themselves, otherwise it outlives
+ * them in `instances`.
+ *
+ * @param {HTMLElement} element
+ */
+export function removeOverlayScrollbars(element) {
+  toggleOverlayScrollbars(element, false)
+}
+
+/**
  * Forces any pending layout update before restoring a consumer-managed scroll
  * position. This is needed when a scroll container moves between layouts,
  * because OverlayScrollbars otherwise restores its previous offset afterwards.

--- a/src/renderer/store/modules/settings.js
+++ b/src/renderer/store/modules/settings.js
@@ -414,6 +414,7 @@ const state = {
   videoSkipMouseScroll: false,
   videoPlaybackRateInterval: 0.25,
   rememberVolume: true,
+  enableVideoZoom: true,
   // Last zoom level picked in the player, reused for subsequent videos
   videoZoom: DEFAULT_VIDEO_ZOOM,
   skipSilence: false,

--- a/src/renderer/store/modules/settings.js
+++ b/src/renderer/store/modules/settings.js
@@ -381,6 +381,7 @@ const state = {
   uiRoundness: 100,
   animationSpeed: 100,
   showToastTimeoutIndicator: true,
+  usePlayerMenuGrid: true,
   toastPosition: 'bottom-left',
   extraThumbnailAction: '',
   blurThumbnails: false,

--- a/static/locales/en-US.yaml
+++ b/static/locales/en-US.yaml
@@ -707,6 +707,7 @@ Settings:
     Remember Volume: Remember Volume
     Fast-Forward Through Silence: Fast-Forward Through Silence
     Show Fast-Forward Through Silence Toggle: Show Fast-Forward Through Silence Toggle
+    Enable Video Zoom: Enable Video Zoom
     Voice-over Translation:
       Enable: Enable voice-over translation
       Prepare in Background: Start preparing voice-over translations in the background
@@ -1883,6 +1884,7 @@ Tooltips:
     Use YouTube-style Shorts: Displays Shorts in a portrait grid on subscription and channel pages and uses the YouTube-style Shorts player.
     Loop Shorts: When enabled, Shorts restart automatically. When disabled, Shorts stop at the end and show a replay button.
     Show Fast-Forward Through Silence Toggle: Shows an on/off toggle for fast-forwarding through silence in the player's settings menu.
+    Enable Video Zoom: Shows the Zoom control in the player's settings menu and enables its keyboard shortcuts and panning controls.
     Voice-over Translation: Sends the video ID, duration, and selected language to the unofficial Yandex voice-over translation service when you request a translation. Disabled by default.
     Hold to Double Playback Speed: Hold the Spacebar or left mouse button over the player to temporarily double the current playback speed.
     Ambient Mode: Blends the video's colors into the area around the player.

--- a/static/locales/en-US.yaml
+++ b/static/locales/en-US.yaml
@@ -513,6 +513,7 @@ Settings:
     Use Fixed Tab Width: Use Fixed Tab Width in Horizontal Mode
     Tab Width: Tab Width
     Show Toast Timeout Indicator: Show toast timeout indicator
+    Use Grid Player Menu: Use Grid Player Menu
     Show Progress as Notification: Show progress as notification
     Operation in Progress: Operation in progress
     Toast Position:
@@ -1938,6 +1939,7 @@ Tooltips:
     Show Progress as Notification: Shows a persistent notification with live progress for background operations, such as subscription refreshes and managed tool downloads, instead of using the global progress bar.
     Always Show Scrollbars: Keeps the scrollbars visible at all times. When disabled, they fade out shortly after you stop moving the mouse and reappear as soon as you move it again.
     Use Fixed Tab Width: Gives every tab in the horizontal tab bar the same width instead of sizing them to their title.
+    Use Grid Player Menu: Arranges the video player's settings menu as a grid of tiles instead of a list of rows.
   Experimental Settings:
     Replace HTTP Cache: Disables Electron's disk based HTTP cache and enables a custom in-memory image cache. Will lead to increased RAM usage.
   SponsorBlock Settings:


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Make sure to follow the contributing guidelines. -->
<!-- Important note, we may remove your pull request if you do not use this provided PR template correctly. -->
<!-- Agent instructions: Preserve every heading, comment, and marker in this template. Never remove or rewrite the release-note-category:start/end, release-note:start/end, or release-note-image:start/end marker pairs. Never remove or rewrite the Release note images section; leave its contents for a human. -->

## Pull Request Type
<!-- Please select what type of pull request this is: [x] -->
- [ ] Bugfix
- [x] Feature Implementation
- [ ] Documentation
- [ ] Other

## Related issue
<!-- Please link the issue your pull request is referring to. -->
<!-- If this pull request fully resolves the relevant issue, put "closes" before the issue number. -->
<!-- Example: "closes #123456". -->

## Description
<!-- Please write a clear and concise description of what the pull request does. -->
The player settings menu has accumulated enough controls that its single-column layout wastes space and can extend beyond the player.

This redesign arranges every main-menu entry and submenu option in a responsive grid of compact tiles. It preserves a stable menu height while switching panels, gives active controls a visible state, adds an overlay scrollbar when needed, and keeps caption submenu headers and actions aligned. The grid is enabled by default and can be disabled in Theme Settings.

Video Zoom can now also be disabled independently from the left column of Player Settings. Disabling it immediately returns the video to its unzoomed presentation, removes the Zoom menu entry, and disables its keyboard and panning controls while preserving the selected zoom level for later.

## Release note category
<!-- Select exactly one category. Every pull request must select one. -->
<!-- Select "Not noteworthy" when the pull request fixes a bug in or improves functionality that has not yet appeared in a stable release. -->
<!-- release-note-category:start -->
- [ ] Not noteworthy
- [ ] Highlights
- [x] More improvements
- [ ] Fixed bugs
<!-- release-note-category:end -->

## Release note
<!-- Required unless "Not noteworthy" is selected. -->
<!-- Write one concise, user-facing entry without a leading bullet. -->
<!-- release-note:start -->
The player settings menu now uses a compact, responsive grid that makes its controls easier to scan. (You can go back to the old style via theme settings)
<!-- release-note:end -->

## Release note images
<!-- Human-only: Agents must preserve this entire section and leave it empty. -->
<!-- Optional. Paste one or more Markdown images or HTML image tags here. -->
<!-- The release notes will use an HTML image tag and limit images taller than 300 pixels. -->
<!-- release-note-image:start -->
<img width="468" height="310" alt="image" src="https://github.com/user-attachments/assets/c5c82592-c974-43a4-b625-90559be26a79" />
<img width="256" height="48" alt="image" src="https://github.com/user-attachments/assets/0b1c62ef-7b73-40df-bf0d-96d9a26c4778" />

<!-- release-note-image:end -->

## Testing
<!-- How can reviewers verify that the PR produces correct results? -->
<!-- Please provide instructions so that others can ensure that your pull request produces correct results. For examples see, https://github.com/FreeTubeApp/FreeTube/pull/5743, https://github.com/FreeTubeApp/FreeTube/pull/7349, https://github.com/FreeTubeApp/FreeTube/pull/5125, https://github.com/FreeTubeApp/FreeTube/pull/7338 -->
<!-- Agent instructions: Only write human-facing steps that explain how to verify the change while running this branch in dev mode. Include expected results and, when applicable, helpful console snippets for interactive verification. Do not include automated checks, commands, results, pass counts, or CI status. -->
1. Open a video and select **More settings** in the player controls. Confirm every available action appears as a compact tile and the menu stays within the player.
2. Resize the window to narrow the player. Confirm the grid reduces its column count without clipping labels or controls.
3. Open the Resolution, Playback speed, Zoom, and Captions submenus. Confirm their options use tiles, the popup keeps a stable height, submenu titles are centered, and the Captions **Options** action stays aligned in its header.
4. Toggle Ambient Mode, Loop, and another available stateful control. Confirm active tiles are highlighted and the menu remains usable with keyboard navigation.
5. Disable **Use Grid Player Menu** in Theme Settings. Confirm the player returns to the original list layout.
6. Disable **Enable Video Zoom** in the left Player Settings column while a video is zoomed. Confirm the video immediately appears unzoomed, the Zoom menu entry disappears, and its keyboard shortcuts no longer change the video. Re-enable it and confirm the saved zoom level returns.

## Additional context
<!-- Add any other context about the pull request here. -->
The layout uses responsive CSS grid sizing, so narrow players do not need separate media or container-query breakpoints.
