### PR TITLE
fix(player): isolate video zoom per tab

### DIFF
--- a/e2e/tests/offline/player.spec.mjs
+++ b/e2e/tests/offline/player.spec.mjs
@@ -77,7 +77,7 @@ test('keyboard shortcuts change the playback rate', async ({ app, page, attachSc
   await attachScreenshot('playback rate lowered')
 })
 
-test('zooms the video and keeps the level for the next video', async ({ app, page, attachScreenshot }) => {
+test('keeps each tab\'s video zoom independent', async ({ app, page, attachScreenshot }) => {
   const video = await openDemoVideo({ app, page })
 
   await page.locator('body').press('z')
@@ -87,14 +87,22 @@ test('zooms the video and keeps the level for the next video', async ({ app, pag
   await page.locator('body').press('z')
   await expect(video).toHaveCSS('transform', 'matrix(1.5, 0, 0, 1.5, 0, 0)')
 
-  // The zoom level carries over to the next video (#651)
+  // A new tab starts at the default zoom instead of inheriting another
+  // player's level.
   await page.locator('.tabBar .newTabButton').click()
   await expect(page.locator('.tabBar .tab')).toHaveCount(2)
   const nextVideo = await openMockedVideo(page)
-  await expect(nextVideo).toHaveCSS('transform', 'matrix(1.5, 0, 0, 1.5, 0, 0)')
+  await expect(nextVideo).toHaveCSS('transform', 'none')
 
-  await page.locator('body').press('Shift+Z')
+  await page.locator('body').press('z')
   await expect(nextVideo).toHaveCSS('transform', 'matrix(1.25, 0, 0, 1.25, 0, 0)')
+
+  const tabs = page.locator('.tabBar .tab')
+  await tabs.first().click()
+  await expect(page.locator(`${activeTab} video`)).toHaveCSS('transform', 'matrix(1.5, 0, 0, 1.5, 0, 0)')
+
+  await tabs.last().click()
+  await expect(page.locator(`${activeTab} video`)).toHaveCSS('transform', 'matrix(1.25, 0, 0, 1.25, 0, 0)')
 })
 
 test('shift-dragging moves the visible part of a zoomed video', async ({ app, page, attachScreenshot }) => {

--- a/e2e/tests/offline/player.spec.mjs
+++ b/e2e/tests/offline/player.spec.mjs
@@ -77,7 +77,7 @@ test('keyboard shortcuts change the playback rate', async ({ app, page, attachSc
   await attachScreenshot('playback rate lowered')
 })
 
-test('keeps each tab\'s video zoom independent', async ({ app, page, attachScreenshot }) => {
+test('keeps video zoom within its tab', async ({ app, page, attachScreenshot }) => {
   const video = await openDemoVideo({ app, page })
 
   await page.locator('body').press('z')
@@ -86,6 +86,11 @@ test('keeps each tab\'s video zoom independent', async ({ app, page, attachScree
 
   await page.locator('body').press('z')
   await expect(video).toHaveCSS('transform', 'matrix(1.5, 0, 0, 1.5, 0, 0)')
+
+  // Recreating the player for another video in the same tab keeps that tab's
+  // zoom level.
+  const nextVideoInTab = await openMockedVideo(page, 'aqz-KE-bpKQ')
+  await expect(nextVideoInTab).toHaveCSS('transform', 'matrix(1.5, 0, 0, 1.5, 0, 0)')
 
   // A new tab starts at the default zoom instead of inheriting another
   // player's level.

--- a/src/renderer/components/ft-shaka-video-player/ft-shaka-video-player.js
+++ b/src/renderer/components/ft-shaka-video-player/ft-shaka-video-player.js
@@ -3128,6 +3128,7 @@ export default defineComponent({
     })
 
     const enableVideoZoom = computed(() => store.getters.getEnableVideoZoom)
+    const selectedVideoZoom = ref(DEFAULT_VIDEO_ZOOM)
 
     const videoZoomPossible = computed(() => {
       // Audio only playback has no video surface to crop and the shorts player
@@ -3142,7 +3143,7 @@ export default defineComponent({
         return DEFAULT_VIDEO_ZOOM
       }
 
-      return sanitizeVideoZoom(store.getters.getVideoZoom)
+      return selectedVideoZoom.value
     })
 
     /**
@@ -3183,9 +3184,9 @@ export default defineComponent({
       }
     })
 
-    // The zoom level is a preference that carries over, but the framing was
-    // chosen for one specific video, so a player that is reused for the next
-    // one starts centered again.
+    // The zoom level belongs to this player (and therefore this tab), while the
+    // framing belongs to one specific video. A player reused for the next video
+    // keeps its zoom level but starts centered again.
     watch(() => props.videoId, () => {
       recenterVideoZoom()
     })
@@ -3197,7 +3198,7 @@ export default defineComponent({
 
     /** @param {number} value */
     function updateVideoZoom(value) {
-      store.dispatch('updateVideoZoom', sanitizeVideoZoom(value))
+      selectedVideoZoom.value = sanitizeVideoZoom(value)
     }
 
     /** @param {number} direction `1` to zoom in, `-1` to zoom out */

--- a/src/renderer/components/ft-shaka-video-player/ft-shaka-video-player.js
+++ b/src/renderer/components/ft-shaka-video-player/ft-shaka-video-player.js
@@ -3128,7 +3128,9 @@ export default defineComponent({
     })
 
     const enableVideoZoom = computed(() => store.getters.getEnableVideoZoom)
-    const selectedVideoZoom = ref(DEFAULT_VIDEO_ZOOM)
+    const selectedVideoZoom = computed(() => {
+      return sanitizeVideoZoom(store.getters.getTabVideoZoom(mediaTabId))
+    })
 
     const videoZoomPossible = computed(() => {
       // Audio only playback has no video surface to crop and the shorts player
@@ -3198,7 +3200,10 @@ export default defineComponent({
 
     /** @param {number} value */
     function updateVideoZoom(value) {
-      selectedVideoZoom.value = sanitizeVideoZoom(value)
+      store.commit('setTabVideoZoom', {
+        tabId: mediaTabId,
+        value: sanitizeVideoZoom(value)
+      })
     }
 
     /** @param {number} direction `1` to zoom in, `-1` to zoom out */

--- a/src/renderer/store/modules/settings.js
+++ b/src/renderer/store/modules/settings.js
@@ -19,7 +19,6 @@ import { setReducedMotionPreference } from '../../helpers/reducedMotion'
 import { setAnimationSpeed } from '../../helpers/animationSpeed'
 import { DEFAULT_SEARCH_ENGINES_SETTING } from '../../../searchEngines'
 import { DEFAULT_SEGMENT_PREFETCH_LIMIT } from '../../helpers/player/segmentPrefetch'
-import { DEFAULT_VIDEO_ZOOM } from '../../helpers/player/videoZoom'
 
 const YT_DLP_PLAYBACK_ENGINE_MIGRATION_SETTING = 'ytDlpPlaybackEngineDefaultMigration'
 
@@ -415,8 +414,6 @@ const state = {
   videoPlaybackRateInterval: 0.25,
   rememberVolume: true,
   enableVideoZoom: true,
-  // Last zoom level picked in the player, reused for subsequent videos
-  videoZoom: DEFAULT_VIDEO_ZOOM,
   skipSilence: false,
   showSkipSilenceButton: false,
   useVoiceOverTranslation: false,

--- a/src/renderer/store/modules/tabs.js
+++ b/src/renderer/store/modules/tabs.js
@@ -1,6 +1,7 @@
 import packageDetails from '../../../../package.json'
 import { getTabNavigationService } from '../../tabs/TabNavigationService'
 import { getTabPageIcon } from '../../tabs/tabPageIcon'
+import { DEFAULT_VIDEO_ZOOM } from '../../helpers/player/videoZoom'
 
 const MAX_LOGICAL_HISTORY_ENTRIES = 100
 const NAV_HISTORY_DISPLAY_LIMIT = 15
@@ -17,7 +18,8 @@ const state = {
   transitionTargetTabId: null,
   containerIds: [],
   tabBarScrollPosition: 0,
-  currentWatchTimestamps: {}
+  currentWatchTimestamps: {},
+  videoZoomByTabId: {}
 }
 
 const getters = {
@@ -33,6 +35,7 @@ const getters = {
   getTabBarScrollPosition: (state) => state.tabBarScrollPosition,
   getCurrentWatchTimestamp: (state) => state.currentWatchTimestamps[state.activeTabId] ?? null,
   getWatchTimestamp: (state) => (tabId) => state.currentWatchTimestamps[tabId] ?? null,
+  getTabVideoZoom: (state) => (tabId) => state.videoZoomByTabId[tabId] ?? DEFAULT_VIDEO_ZOOM,
   getTabHistoryState: (state) => (tabId) => {
     const tab = state.tabs.find(candidate => candidate.id === tabId)
     if (!tab) {
@@ -96,6 +99,11 @@ const mutations = {
     for (const tabId of Object.keys(state.currentWatchTimestamps)) {
       if (!incomingIds.has(tabId)) {
         delete state.currentWatchTimestamps[tabId]
+      }
+    }
+    for (const tabId of Object.keys(state.videoZoomByTabId)) {
+      if (tabId !== 'web' && !incomingIds.has(tabId)) {
+        delete state.videoZoomByTabId[tabId]
       }
     }
   },
@@ -196,6 +204,10 @@ const mutations = {
     } else {
       delete state.currentWatchTimestamps[tabId]
     }
+  },
+
+  setTabVideoZoom(state, { tabId, value }) {
+    state.videoZoomByTabId[tabId] = value
   }
 }
 


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Make sure to follow the contributing guidelines. -->
<!-- Important note, we may remove your pull request if you do not use this provided PR template correctly. -->
<!-- Agent instructions: Preserve every heading, comment, and marker in this template. Never remove or rewrite the release-note-category:start/end, release-note:start/end, or release-note-image:start/end marker pairs. Never remove or rewrite the Release note images section; leave its contents for a human. -->

## Pull Request Type
<!-- Please select what type of pull request this is: [x] -->
- [x] Bugfix
- [ ] Feature Implementation
- [ ] Documentation
- [ ] Other

## Related issue
<!-- Please link the issue your pull request is referring to. -->
<!-- If this pull request fully resolves the relevant issue, put "closes" before the issue number. -->
<!-- Example: "closes #123456". -->

N/A

## Description
<!-- Please write a clear and concise description of what the pull request does. -->

Changing video zoom in one tab also changed every other tab because the selected level was stored as a global player setting.

Keep the selected zoom level in each player instance instead. New tabs now start at the default zoom, while an existing tab retains its own level as it changes videos. The global setting that enables or disables video zoom remains unchanged.

## Release note category
<!-- Select exactly one category. Every pull request must select one. -->
<!-- Select "Not noteworthy" when the pull request fixes a bug in or improves functionality that has not yet appeared in a stable release. -->
<!-- release-note-category:start -->
- [x] Not noteworthy
- [ ] Highlights
- [ ] More improvements
- [ ] Fixed bugs
<!-- release-note-category:end -->

## Release note
<!-- Required unless "Not noteworthy" is selected. -->
<!-- Write one concise, user-facing entry without a leading bullet. -->
<!-- release-note:start -->

<!-- release-note:end -->

## Release note images
<!-- Human-only: Agents must preserve this entire section and leave it empty. -->
<!-- Optional. Paste one or more Markdown images or HTML image tags here. -->
<!-- The release notes will use an HTML image tag and limit images taller than 300 pixels. -->
<!-- release-note-image:start -->

<!-- release-note-image:end -->

## Testing
<!-- How can reviewers verify that the PR produces correct results? -->
<!-- Please provide instructions so that others can ensure that your pull request would produce correct results. For examples see, https://github.com/FreeTubeApp/FreeTube/pull/5743, https://github.com/FreeTubeApp/FreeTube/pull/7349, https://github.com/FreeTubeApp/FreeTube/pull/5125, https://github.com/FreeTubeApp/FreeTube/pull/7338 -->
<!-- Agent instructions: Only write human-facing steps that explain how to verify the change while running this branch in dev mode. Include expected results and, when applicable, helpful console snippets for interactive verification. Do not include automated checks, commands, results, pass counts, or CI status. -->

1. Open a video and increase its video zoom level.
2. Open another video in a new tab and confirm it starts at 100% zoom.
3. Set a different zoom level in the second tab.
4. Switch between both tabs and confirm each video retains its own zoom level.

## Additional context
<!-- Add any other context about the pull request here. -->

None.
