### PR TITLE
fix(invidious): restore real subscription publish dates

### DIFF
--- a/src/renderer/helpers/api/invidious-channel-videos.js
+++ b/src/renderer/helpers/api/invidious-channel-videos.js
@@ -1,0 +1,51 @@
+import { mapConcurrently } from '../concurrent-map.js'
+
+const FALLBACK_PUBLICATION_DATE_MAX_AGE_MS = 5 * 60 * 1000
+const PUBLICATION_DATE_ENRICHMENT_CONCURRENCY = 3
+
+/**
+ * YouTube sometimes omits publication and view metadata from channel cards.
+ * Invidious represents those missing values as the current time and zero views.
+ * @param {object} video
+ * @param {number} fetchedAt
+ */
+export function usesFallbackInvidiousPublicationDate(video, fetchedAt) {
+  return video.liveNow !== true &&
+    video.isUpcoming !== true &&
+    video.viewCount === 0 &&
+    Number.isFinite(video.published) &&
+    Math.abs(fetchedAt - video.published) <= FALLBACK_PUBLICATION_DATE_MAX_AGE_MS
+}
+
+/**
+ * Fetches exact video metadata only for channel entries using Invidious' fallback.
+ * @param {object[]} videos
+ * @param {(videoId: string) => Promise<object>} fetchVideoDetails
+ * @param {number} [fetchedAt]
+ */
+export async function enrichFallbackInvidiousPublicationDates(
+  videos,
+  fetchVideoDetails,
+  fetchedAt = Date.now()
+) {
+  return await mapConcurrently(videos, PUBLICATION_DATE_ENRICHMENT_CONCURRENCY, async video => {
+    if (!usesFallbackInvidiousPublicationDate(video, fetchedAt)) return video
+
+    try {
+      const details = await fetchVideoDetails(video.videoId)
+
+      if (typeof details.published !== 'number') return video
+
+      return {
+        ...video,
+        published: details.published * 1000,
+        publishedText: details.publishedText,
+        viewCount: details.viewCount,
+        viewCountText: details.viewCountText,
+        isInvidiousPublicationDateEnriched: true
+      }
+    } catch {
+      return video
+    }
+  })
+}

--- a/src/renderer/helpers/api/invidious-channel-videos.js
+++ b/src/renderer/helpers/api/invidious-channel-videos.js
@@ -1,7 +1,27 @@
-import { mapConcurrently } from '../concurrent-map.js'
-
 const FALLBACK_PUBLICATION_DATE_MAX_AGE_MS = 5 * 60 * 1000
 const PUBLICATION_DATE_ENRICHMENT_CONCURRENCY = 3
+const publicationDateEnrichmentQueue = []
+let activePublicationDateEnrichments = 0
+
+async function withPublicationDateEnrichmentLimit(task) {
+  if (activePublicationDateEnrichments >= PUBLICATION_DATE_ENRICHMENT_CONCURRENCY) {
+    await new Promise(resolve => publicationDateEnrichmentQueue.push(resolve))
+  } else {
+    activePublicationDateEnrichments++
+  }
+
+  try {
+    return await task()
+  } finally {
+    const next = publicationDateEnrichmentQueue.shift()
+
+    if (next) {
+      next()
+    } else {
+      activePublicationDateEnrichments--
+    }
+  }
+}
 
 /**
  * YouTube sometimes omits publication and view metadata from channel cards.
@@ -28,13 +48,20 @@ export async function enrichFallbackInvidiousPublicationDates(
   fetchVideoDetails,
   fetchedAt = Date.now()
 ) {
-  return await mapConcurrently(videos, PUBLICATION_DATE_ENRICHMENT_CONCURRENCY, async video => {
+  return await Promise.all(videos.map(async video => {
     if (!usesFallbackInvidiousPublicationDate(video, fetchedAt)) return video
 
-    try {
-      const details = await fetchVideoDetails(video.videoId)
+    const fallbackVideo = {
+      ...video,
+      isInvidiousPublicationDateFallback: true
+    }
 
-      if (typeof details.published !== 'number') return video
+    try {
+      const details = await withPublicationDateEnrichmentLimit(
+        async () => await fetchVideoDetails(video.videoId)
+      )
+
+      if (typeof details.published !== 'number') return fallbackVideo
 
       return {
         ...video,
@@ -45,7 +72,7 @@ export async function enrichFallbackInvidiousPublicationDates(
         isInvidiousPublicationDateEnriched: true
       }
     } catch {
-      return video
+      return fallbackVideo
     }
-  })
+  }))
 }

--- a/src/renderer/helpers/api/invidious.js
+++ b/src/renderer/helpers/api/invidious.js
@@ -1,6 +1,7 @@
 import store from '../../store/index'
 import { calculatePublishedDate, getRelativeTimeFromDate } from '../utils'
 import { isNullOrEmpty } from '../strings'
+import { enrichFallbackInvidiousPublicationDates } from './invidious-channel-videos'
 import { filterUnavailableInvidiousPlaylistVideos } from './invidious-playlists'
 import autolinker from 'autolinker'
 import { FormatUtils, Misc, Player } from 'youtubei.js'
@@ -180,6 +181,10 @@ export async function getInvidiousChannelVideos(channelId, sortBy, continuation)
 
   normalizeManyInvidiousVideosAttributes(response.videos, channelId)
   setMultiplePublishedTimestamps(response.videos)
+  response.videos = await enrichFallbackInvidiousPublicationDates(
+    response.videos,
+    invidiousGetVideoInformation
+  )
 
   return response
 }

--- a/src/renderer/helpers/subscription-entries.js
+++ b/src/renderer/helpers/subscription-entries.js
@@ -158,6 +158,17 @@ export function reconcileFetchedSubscriptionEntries(
       reconciledEntry[publicationDateKey] = previousEntry[publicationDateKey]
     }
 
+    if (
+      entry.isInvidiousPublicationDateFallback === true &&
+      previousEntry?.isInvidiousPublicationDateEnriched === true
+    ) {
+      reconciledEntry.publishedText = previousEntry.publishedText
+      reconciledEntry.viewCount = previousEntry.viewCount
+      reconciledEntry.viewCountText = previousEntry.viewCountText
+      reconciledEntry.isInvidiousPublicationDateEnriched = true
+      delete reconciledEntry.isInvidiousPublicationDateFallback
+    }
+
     return reconciledEntry
   })
 }

--- a/src/renderer/helpers/subscription-entries.js
+++ b/src/renderer/helpers/subscription-entries.js
@@ -96,6 +96,9 @@ function keepPreviousPublicationDate(entry, previousEntry, key) {
     Number.isFinite(Number(entry[key])) &&
     !hasVolatilePublicationDate(entry) &&
     !hasVolatilePublicationDate(previousEntry) &&
+    // Exact video metadata must replace Invidious' cached current-time fallback.
+    !(entry.isInvidiousPublicationDateEnriched === true &&
+      previousEntry.isInvidiousPublicationDateEnriched !== true) &&
     // RSS feeds report exact dates, so they may replace a scraped estimate
     !(entry.isRSS === true && previousEntry.isRSS !== true)
 }

--- a/tests/unit/invidious-channel-videos.test.mjs
+++ b/tests/unit/invidious-channel-videos.test.mjs
@@ -71,5 +71,37 @@ test('keeps channel metadata when video details cannot be fetched', async () => 
     now
   )
 
-  assert.equal(result[0], fallback)
+  assert.deepEqual(result[0], {
+    ...fallback,
+    isInvidiousPublicationDateFallback: true
+  })
+})
+
+test('shares the enrichment request limit across channel fetches', async () => {
+  let activeRequests = 0
+  let maximumActiveRequests = 0
+  const releaseRequests = []
+  const fetchVideoDetails = async () => {
+    activeRequests++
+    maximumActiveRequests = Math.max(maximumActiveRequests, activeRequests)
+    await new Promise(resolve => releaseRequests.push(resolve))
+    activeRequests--
+    return { published: now / 1000 }
+  }
+  const channelVideos = Array.from({ length: 4 }, (_, index) => video({ videoId: `video-${index}` }))
+  const enrichments = [
+    enrichFallbackInvidiousPublicationDates(channelVideos, fetchVideoDetails, now),
+    enrichFallbackInvidiousPublicationDates(channelVideos, fetchVideoDetails, now)
+  ]
+
+  await new Promise(resolve => setTimeout(resolve, 0))
+  assert.equal(maximumActiveRequests, 3)
+
+  while (releaseRequests.length > 0) {
+    releaseRequests.shift()()
+    await new Promise(resolve => setTimeout(resolve, 0))
+  }
+  await Promise.all(enrichments)
+
+  assert.equal(maximumActiveRequests, 3)
 })

--- a/tests/unit/invidious-channel-videos.test.mjs
+++ b/tests/unit/invidious-channel-videos.test.mjs
@@ -1,0 +1,75 @@
+import assert from 'node:assert/strict'
+import test from 'node:test'
+
+import {
+  enrichFallbackInvidiousPublicationDates,
+  usesFallbackInvidiousPublicationDate
+} from '../../src/renderer/helpers/api/invidious-channel-videos.js'
+
+const now = Date.parse('2026-08-12T16:00:00Z')
+
+function video(extra = {}) {
+  return {
+    videoId: 'xLPCqKawpZc',
+    published: now - 2 * 60_000,
+    viewCount: 0,
+    liveNow: false,
+    isUpcoming: false,
+    ...extra
+  }
+}
+
+test('detects Invidious current-time publication fallbacks', () => {
+  assert.equal(usesFallbackInvidiousPublicationDate(video(), now), true)
+  assert.equal(usesFallbackInvidiousPublicationDate(video({ viewCount: 1 }), now), false)
+  assert.equal(usesFallbackInvidiousPublicationDate(video({ published: now - 6 * 60_000 }), now), false)
+  assert.equal(usesFallbackInvidiousPublicationDate(video({ liveNow: true }), now), false)
+  assert.equal(usesFallbackInvidiousPublicationDate(video({ isUpcoming: true }), now), false)
+})
+
+test('replaces fallback publication and view metadata with video details', async () => {
+  const exactPublishedSeconds = Date.parse('2025-12-30T21:00:06Z') / 1000
+  const result = await enrichFallbackInvidiousPublicationDates(
+    [video()],
+    async videoId => {
+      assert.equal(videoId, 'xLPCqKawpZc')
+      return {
+        published: exactPublishedSeconds,
+        publishedText: '7 months ago',
+        viewCount: 620_420,
+        viewCountText: '620K views'
+      }
+    },
+    now
+  )
+
+  assert.deepEqual(result[0], video({
+    published: exactPublishedSeconds * 1000,
+    publishedText: '7 months ago',
+    viewCount: 620_420,
+    viewCountText: '620K views',
+    isInvidiousPublicationDateEnriched: true
+  }))
+})
+
+test('does not request details for entries with valid channel metadata', async () => {
+  const valid = video({ published: now - 7 * 30 * 24 * 60 * 60_000, viewCount: 620_420 })
+  const result = await enrichFallbackInvidiousPublicationDates(
+    [valid],
+    async () => assert.fail('details should not be requested'),
+    now
+  )
+
+  assert.equal(result[0], valid)
+})
+
+test('keeps channel metadata when video details cannot be fetched', async () => {
+  const fallback = video()
+  const result = await enrichFallbackInvidiousPublicationDates(
+    [fallback],
+    async () => { throw new Error('unavailable') },
+    now
+  )
+
+  assert.equal(result[0], fallback)
+})

--- a/tests/unit/subscription-entries.test.mjs
+++ b/tests/unit/subscription-entries.test.mjs
@@ -161,6 +161,34 @@ test('prefers enriched Invidious metadata over a cached fallback date', () => {
   assert.equal(reconciled[0].published, exactPublished)
 })
 
+test('keeps enriched Invidious metadata after a later detail request fails', () => {
+  const exactPublished = Date.parse('2025-12-30T21:00:06Z')
+  const reconciled = reconcileFetchedSubscriptionEntries(
+    [video('a', now, {
+      publishedText: '0 seconds ago',
+      viewCount: 0,
+      viewCountText: '0 views',
+      isInvidiousPublicationDateFallback: true
+    })],
+    [video('a', exactPublished, {
+      publishedText: '7 months ago',
+      viewCount: 620_420,
+      viewCountText: '620K views',
+      isInvidiousPublicationDateEnriched: true
+    })],
+    'videoId',
+    now - HOUR
+  )
+
+  assert.deepEqual(reconciled[0], video('a', exactPublished, {
+    publishedText: '7 months ago',
+    viewCount: 620_420,
+    viewCountText: '620K views',
+    isInvidiousPublicationDateEnriched: true,
+    isNewInSubscriptionFeed: false
+  }))
+})
+
 test('keeps the cached publication time of posts', () => {
   const reconciled = reconcileFetchedSubscriptionEntries(
     [{ postId: 'p1', publishedTime: now - 24 * HOUR }],

--- a/tests/unit/subscription-entries.test.mjs
+++ b/tests/unit/subscription-entries.test.mjs
@@ -149,6 +149,18 @@ test('prefers the exact date of an RSS entry over a cached estimate', () => {
   assert.equal(reconciled[0].published, now - 24 * HOUR)
 })
 
+test('prefers enriched Invidious metadata over a cached fallback date', () => {
+  const exactPublished = Date.parse('2025-12-30T21:00:06Z')
+  const reconciled = reconcileFetchedSubscriptionEntries(
+    [video('a', exactPublished, { isInvidiousPublicationDateEnriched: true })],
+    [video('a', now - 2 * 60_000)],
+    'videoId',
+    now - HOUR
+  )
+
+  assert.equal(reconciled[0].published, exactPublished)
+})
+
 test('keeps the cached publication time of posts', () => {
   const reconciled = reconcileFetchedSubscriptionEntries(
     [{ postId: 'p1', publishedTime: now - 24 * HOUR }],


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Make sure to follow the contributing guidelines. -->
<!-- Important note, we may remove your pull request if you do not use this provided PR template correctly. -->
<!-- Agent instructions: Preserve every heading, comment, and marker in this template. Never remove or rewrite the release-note-category:start/end, release-note:start/end, or release-note-image:start/end marker pairs. Never remove or rewrite the Release note images section; leave its contents for a human. -->

## Pull Request Type
<!-- Please select what type of pull request this is: [x] -->
- [x] Bugfix
- [ ] Feature Implementation
- [ ] Documentation
- [ ] Other

## Related issue
<!-- Please link the issue your pull request is referring to. -->
<!-- If this pull request fully resolves the relevant issue, put "closes" before the issue number. -->
<!-- Example: "closes #123456". -->
Follow-up to #647.

## Description
<!-- Please write a clear and concise description of what the pull request does. -->
The first fix for #647 stopped regular Invidious videos from displaying the Unix epoch, but some subscription entries still appeared as newly uploaded with zero views. YouTube can omit publication and view metadata from channel cards, causing Invidious to substitute its current time and zero views.

This change detects that fallback combination and requests exact metadata from the individual Invidious video endpoint only for affected entries. Enriched dates also replace incorrect fallback timestamps already stored in the subscription cache.

## Release note category
<!-- Select exactly one category. Every pull request must select one. -->
<!-- Select "Not noteworthy" when the pull request fixes a bug in or improves functionality that has not yet appeared in a stable release. -->
<!-- release-note-category:start -->
- [x] Not noteworthy
- [ ] Highlights
- [ ] More improvements
- [ ] Fixed bugs
<!-- release-note-category:end -->

## Release note
<!-- Required unless "Not noteworthy" is selected. -->
<!-- Write one concise, user-facing entry without a leading bullet. -->
<!-- release-note:start -->

<!-- release-note:end -->

## Release note images
<!-- Human-only: Agents must preserve this entire section and leave it empty. -->
<!-- Optional. Paste one or more Markdown images or HTML image tags here. -->
<!-- The release notes will use an HTML image tag and limit images taller than 300 pixels. -->
<!-- release-note-image:start -->

<!-- release-note-image:end -->

## Testing
<!-- How can reviewers verify that the PR produces correct results? -->
<!-- Please provide instructions so that others can ensure that your pull request would produce correct results. For examples see, https://github.com/FreeTubeApp/FreeTube/pull/5743, https://github.com/FreeTubeApp/FreeTube/pull/7349, https://github.com/FreeTubeApp/FreeTube/pull/5125, https://github.com/FreeTubeApp/FreeTube/pull/7338 -->
<!-- Agent instructions: Only write human-facing steps that explain how to verify the change while running this branch in dev mode. Include expected results and, when applicable, helpful console snippets for interactive verification. Do not include automated checks, commands, results, pass counts, or CI status. -->
1. Select a self-hosted Invidious instance and disable RSS feeds for subscriptions.
2. Refresh the subscriptions video feed containing `xLPCqKawpZc` or another older channel video for which the channel endpoint returns zero views and a near-current publication date.
3. Confirm the card shows the real relative upload date and view count instead of `0 views` and the feed refresh time.
4. Refresh the feed again and confirm the corrected date remains in the cached feed.

## Additional context
<!-- Add any other context about the pull request here. -->
Invidious falls back to its local current time when YouTube omits `publishedTimeText` from a channel card. The individual `/api/v1/videos/{id}` response still contains the correct publication timestamp and view count for the reported video.
