### PR TITLE
fix(player): prevent duplicate SponsorBlock notifications

### DIFF
--- a/e2e/tests/offline/watch-page.spec.mjs
+++ b/e2e/tests/offline/watch-page.spec.mjs
@@ -763,6 +763,48 @@ test.describe('watch page', () => {
     await expect(sponsorBlock.locator('.os-scrollbar-vertical')).toHaveCount(1)
   })
 
+  test('does not restore a SponsorBlock prompt when a skip remains inside the segment', async ({ app, page }) => {
+    await mockPlayableWatchPage(app, page)
+    await page.route('**/api/skipSegments/**', route => route.fulfill({
+      body: JSON.stringify([{
+        videoID: 'jNQXAC9IVRw',
+        segments: [{
+          UUID: 'terminal-outro',
+          actionType: 'skip',
+          category: 'outro',
+          description: '',
+          locked: 0,
+          segment: [15, 30],
+          videoDuration: 30,
+          votes: 1
+        }]
+      }]),
+      contentType: 'application/json'
+    }))
+    await page.evaluate(() => {
+      const store = document.querySelector('#app').__vue_app__.config.globalProperties.$store
+      store.commit('setUseSponsorBlock', true)
+    })
+    await openMockedVideo(page)
+
+    const video = page.locator('.ftVideoPlayer video')
+    await video.evaluate(element => {
+      element.pause()
+      element.currentTime = 16
+      element.dispatchEvent(new Event('timeupdate'))
+    })
+
+    const prompt = page.locator('.skippedSegment').filter({ hasText: 'Skip Endcards/Credits?' })
+    await expect(prompt).toBeVisible()
+    await prompt.getByRole('button', { name: /Skip/ }).click()
+    await page.evaluate(() => new Promise(resolve => {
+      requestAnimationFrame(() => requestAnimationFrame(resolve))
+    }))
+
+    await expect(page.locator('.skippedSegment').filter({ hasText: 'Endcards/Credits Skipped' })).toBeVisible()
+    await expect(prompt).toHaveCount(0)
+  })
+
   test('displays and submits full-video SponsorBlock labels', async ({ app, page }) => {
     await mockPlayableWatchPage(app, page)
     const fullVideoSegment = {

--- a/e2e/tests/offline/watch-page.spec.mjs
+++ b/e2e/tests/offline/watch-page.spec.mjs
@@ -774,8 +774,8 @@ test.describe('watch page', () => {
           category: 'outro',
           description: '',
           locked: 0,
-          segment: [15, 30],
-          videoDuration: 30,
+          segment: [15, 40],
+          videoDuration: 40,
           votes: 1
         }]
       }]),
@@ -797,6 +797,7 @@ test.describe('watch page', () => {
     const prompt = page.locator('.skippedSegment').filter({ hasText: 'Skip Endcards/Credits?' })
     await expect(prompt).toBeVisible()
     await prompt.getByRole('button', { name: /Skip/ }).click()
+    await expect.poll(() => video.evaluate(element => element.currentTime)).toBeLessThan(40)
     await page.evaluate(() => new Promise(resolve => {
       requestAnimationFrame(() => requestAnimationFrame(resolve))
     }))

--- a/src/renderer/components/ft-shaka-video-player/ft-shaka-video-player.js
+++ b/src/renderer/components/ft-shaka-video-player/ft-shaka-video-player.js
@@ -2370,7 +2370,7 @@ export default defineComponent({
         return false
       }
 
-      sponsorBlockDismissedPromptSegments.delete(uuid)
+      sponsorBlockDismissedPromptSegments.add(uuid)
       removePromptSponsorBlockToast(uuid)
 
       if (segment.actionType === 'mute') {
@@ -2679,7 +2679,7 @@ export default defineComponent({
       if (sponsorBlockShowSkippedToast.value) {
         skippedSegments.forEach(({ uuid, category }) => {
           removePromptSponsorBlockToast(uuid)
-          sponsorBlockDismissedPromptSegments.delete(uuid)
+          sponsorBlockDismissedPromptSegments.add(uuid)
           upsertSkippedSponsorBlockToast({
             uuid,
             translatedCategory: translateSponsorBlockCategory(category),
@@ -2804,7 +2804,7 @@ export default defineComponent({
       }
 
       sponsorBlockDoNotSkipSegments.add(uuid)
-      sponsorBlockDismissedPromptSegments.delete(uuid)
+      sponsorBlockDismissedPromptSegments.add(uuid)
       removePromptSponsorBlockToast(uuid)
 
       if (canSeek()) {
@@ -2853,7 +2853,7 @@ export default defineComponent({
       }
 
       sponsorBlockDoNotSkipSegments.delete(uuid)
-      sponsorBlockDismissedPromptSegments.delete(uuid)
+      sponsorBlockDismissedPromptSegments.add(uuid)
       removePromptSponsorBlockToast(uuid)
 
       if (canSeek()) {


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Make sure to follow the contributing guidelines. -->
<!-- Important note, we may remove your pull request if you do not use this provided PR template correctly. -->
<!-- Agent instructions: Preserve every heading, comment, and marker in this template. Never remove or rewrite the release-note-category:start/end, release-note:start/end, or release-note-image:start/end marker pairs. Never remove or rewrite the Release note images section; leave its contents for a human. -->

## Pull Request Type
<!-- Please select what type of pull request this is: [x] -->
- [x] Bugfix
- [ ] Feature Implementation
- [ ] Documentation
- [ ] Other

## Related issue
<!-- Please link the issue your pull request is referring to. -->
<!-- If this pull request fully resolves the relevant issue, put "closes" before the issue number. -->
<!-- Example: "closes #123456". -->

## Description
<!-- Please write a clear and concise description of what the pull request does. -->
Skipping a prompted SponsorBlock segment near the end of a video could show both the original prompt and the skipped notification for the same segment. The seek target can remain slightly inside SponsorBlock's reported segment when the player's seek range ends first, causing the next time update to recreate the prompt.

Keep prompts dismissed after every skip-state transition until playback actually leaves the segment. This prevents duplicate notifications while preserving the existing behavior when the segment is entered again later.

## Release note category
<!-- Select exactly one category. Every pull request must select one. -->
<!-- Select "Not noteworthy" when the pull request fixes a bug in or improves functionality that has not yet appeared in a stable release. -->
<!-- release-note-category:start -->
- [ ] Not noteworthy
- [ ] Highlights
- [ ] More improvements
- [x] Fixed bugs
<!-- release-note-category:end -->

## Release note
<!-- Required unless "Not noteworthy" is selected. -->
<!-- Write one concise, user-facing entry without a leading bullet. -->
<!-- release-note:start -->
Fixed duplicate SponsorBlock notifications when skipping a segment near the end of a video.
<!-- release-note:end -->

## Release note images
<!-- Human-only: Agents must preserve this entire section and leave it empty. -->
<!-- Optional. Paste one or more Markdown images or HTML image tags here. -->
<!-- The release notes will use an HTML image tag and limit images taller than 300 pixels. -->
<!-- release-note-image:start -->

<!-- release-note-image:end -->

## Testing
<!-- How can reviewers verify that the PR produces correct results? -->
<!-- Please provide instructions so that others can ensure that your pull request would produce correct results. For examples see, https://github.com/FreeTubeApp/FreeTube/pull/5743, https://github.com/FreeTubeApp/FreeTube/pull/7349, https://github.com/FreeTubeApp/FreeTube/pull/5125, https://github.com/FreeTubeApp/FreeTube/pull/7338 -->
<!-- Agent instructions: Only write human-facing steps that explain how to verify the change while running this branch in dev mode. Include expected results and, when applicable, helpful console snippets for interactive verification. Do not include automated checks, commands, results, pass counts, or CI status. -->
1. Configure the SponsorBlock endcards/credits category to prompt before skipping.
2. Play a video whose endcards/credits segment extends to or slightly beyond the player's seekable end.
3. Use the prompt to skip the segment.
4. Confirm that only the skipped notification remains and the skip prompt does not reappear beside it.

## Additional context
<!-- Add any other context about the pull request here. -->
The regression coverage uses a terminal segment whose end exceeds the mocked player's seek range.
