### PR TITLE
fix(player): restore overflow menu behavior

### DIFF
--- a/e2e/tests/offline/player.spec.mjs
+++ b/e2e/tests/offline/player.spec.mjs
@@ -165,6 +165,8 @@ test('the overflow menu can turn the zoom off again', async ({ app, page, attach
   const overflowMenu = player.locator('.shaka-overflow-menu')
   await expect(overflowMenu).toHaveClass(/ft-menu-grid/)
   await expect(overflowMenu).toHaveCSS('display', 'grid')
+  await expect(overflowMenu).toHaveCSS('overscroll-behavior', 'contain')
+  await expect(overflowMenu.locator(':scope > .os-scrollbar-vertical')).toHaveCount(1)
   expect(await overflowMenu.locator(':scope > button').evaluateAll((buttons) => {
     return buttons.every((button) => getComputedStyle(button).flexDirection === 'column')
   })).toBe(true)
@@ -221,6 +223,7 @@ test('the overflow menu can turn the zoom off again', async ({ app, page, attach
   await player.hover()
   await moreOptions.click()
   await expect(overflowMenu).not.toHaveClass(/ft-menu-grid/)
+  await expect(overflowMenu.locator(':scope > .os-scrollbar-vertical')).toHaveCount(1)
   await expect(autoplaySwitch).toHaveCSS('margin-right', '14px')
   await watchComponent.dispose()
 })

--- a/e2e/tests/offline/watch-page.spec.mjs
+++ b/e2e/tests/offline/watch-page.spec.mjs
@@ -501,6 +501,8 @@ test.describe('watch page', () => {
     const auxPanel = page.locator('.shortsAuxPanel')
 
     await moreOptions.click()
+    await expect(overflowMenu.locator(':scope > button').first())
+      .toHaveAccessibleName('Video information')
     await overflowMenu.getByRole('button', { name: 'Video information' }).click()
     await expect(auxPanel).toHaveClass(/shortsAuxPanelOpen/)
 

--- a/src/renderer/components/ft-shaka-video-player/ft-shaka-video-player.css
+++ b/src/renderer/components/ft-shaka-video-player/ft-shaka-video-player.css
@@ -877,6 +877,10 @@
   display: none;
 }
 
+:deep(.shaka-overflow-menu) {
+  overscroll-behavior: contain;
+}
+
 /*
   The overflow menu grew a row for every new option, so it ended up taller than
   most players. Every entry is a tile instead: icon on top, name below it and the
@@ -912,7 +916,7 @@
   The menu is always dark, so its overlay scrollbar can't take the app's
   scrollbar colour, which is dark itself in most themes.
 */
-:deep(.shaka-overflow-menu.ft-menu-grid > .os-scrollbar) {
+:deep(.shaka-overflow-menu > .os-scrollbar) {
   --os-handle-bg: rgb(255 255 255 / 40%);
   --os-handle-bg-hover: rgb(255 255 255 / 55%);
   --os-handle-bg-active: rgb(255 255 255 / 70%);

--- a/src/renderer/components/ft-shaka-video-player/ft-shaka-video-player.js
+++ b/src/renderer/components/ft-shaka-video-player/ft-shaka-video-player.js
@@ -3435,12 +3435,12 @@ export default defineComponent({
         // Keep related settings together before the one-click actions so the
         // grid's reading and tab order remain predictable.
         uiConfig.overflowMenuButtons = [
+          ...(props.shortsPlayer ? ['ft_shorts_video_info'] : []),
           props.format === 'legacy' ? 'ft_legacy_quality' : 'quality',
           'playback_rate',
           'captions',
           'ft_audio_tracks',
           'ft_sleep_timer',
-          ...(props.shortsPlayer ? ['ft_shorts_video_info'] : []),
           ...(!props.shortsPlayer ? ['ft_autoplay_toggle'] : []),
           ...(props.chapters.length > 0 ? ['ft_chapters'] : []),
           'ft_skip_silence',
@@ -4191,12 +4191,12 @@ export default defineComponent({
         submenu.classList.toggle('ft-menu-grid', usePlayerMenuGrid.value)
       }
 
+      addOverlayScrollbars(menu)
+
       if (!usePlayerMenuGrid.value) {
         menu.style.minBlockSize = ''
         return
       }
-
-      addOverlayScrollbars(menu)
 
       // Opening a submenu replaces the tiles, which would otherwise resize the
       // popup around them. Remember how tall the menu is while its own tiles are


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Make sure to follow the contributing guidelines. -->
<!-- Important note, we may remove your pull request if you do not use this provided PR template correctly. -->
<!-- Agent instructions: Preserve every heading, comment, and marker in this template. Never remove or rewrite the release-note-category:start/end, release-note:start/end, or release-note-image:start/end marker pairs. Never remove or rewrite the Release note images section; leave its contents for a human. -->

## Pull Request Type
<!-- Please select what type of pull request this is: [x] -->
- [x] Bugfix
- [ ] Feature Implementation
- [ ] Documentation
- [ ] Other

## Related issue
<!-- Please link the issue your pull request is referring to. -->
<!-- If this pull request fully resolves the relevant issue, put "closes" before the issue number. -->
<!-- Example: "closes #123456". -->

## Description
<!-- Please write a clear and concise description of what the pull request does. -->
The grid-style player menu accidentally moved Video information away from the first position in Shorts and limited custom overlay scrollbars to the grid layout.

This restores Video information as the first Shorts menu action, initializes overlay scrollbars for both player menu layouts, and contains menu overscroll so wheel and touch scrolling do not propagate to content behind the menu.

## Release note category
<!-- Select exactly one category. Every pull request must select one. -->
<!-- Select "Not noteworthy" when the pull request fixes a bug in or improves functionality that has not yet appeared in a stable release. -->
<!-- release-note-category:start -->
- [x] Not noteworthy
- [ ] Highlights
- [ ] More improvements
- [ ] Fixed bugs
<!-- release-note-category:end -->

## Release note
<!-- Required unless "Not noteworthy" is selected. -->
<!-- Write one concise, user-facing entry without a leading bullet. -->
<!-- release-note:start -->

<!-- release-note:end -->

## Release note images
<!-- Human-only: Agents must preserve this entire section and leave it empty. -->
<!-- Optional. Paste one or more Markdown images or HTML image tags here. -->
<!-- The release notes will use an HTML image tag and limit images taller than 300 pixels. -->
<!-- release-note-image:start -->

<!-- release-note-image:end -->

## Testing
<!-- How can reviewers verify that the PR produces correct results? -->
<!-- Please provide instructions so that others can ensure that your pull request produces correct results. For examples see, https://github.com/FreeTubeApp/FreeTube/pull/5743, https://github.com/FreeTubeApp/FreeTube/pull/7349, https://github.com/FreeTubeApp/FreeTube/pull/5125, https://github.com/FreeTubeApp/FreeTube/pull/7338 -->
<!-- Agent instructions: Only write human-facing steps that explain how to verify the change while running this branch in dev mode. Include expected results and, when applicable, helpful console snippets for interactive verification. Do not include automated checks, commands, results, pass counts, or CI status. -->
1. Open a Short and open its More Options menu. Confirm Video information is the first item.
2. Disable the grid-style player menu and open the regular menu. Confirm it uses the themed overlay scrollbar instead of a native scrollbar.
3. Scroll to either end of the menu while keeping the pointer over it. Confirm the page and other content behind the menu do not scroll.

## Additional context
<!-- Add any other context about the pull request here. -->
Regression coverage verifies the Shorts ordering, both menu layouts' overlay scrollbar, and scroll containment.
