### PR TITLE
fix(tabs): load icons for collaboration videos

### DIFF
--- a/src/renderer/helpers/api/local.js
+++ b/src/renderer/helpers/api/local.js
@@ -825,52 +825,7 @@ export async function getLocalShortLinkedVideo(id) {
   return parseLocalShortLinkedVideo(response)
 }
 
-/**
- * @typedef {object} LocalVideoCollaborator
- * @property {string} id
- * @property {string} name
- * @property {string} thumbnail
- * @property {string} subtitle
- */
-
-/**
- * @param {import('youtubei.js').YT.VideoInfo} videoInfo
- * @returns {LocalVideoCollaborator[]}
- */
-export function parseLocalVideoCollaborators(videoInfo) {
-  const listItems = videoInfo.secondary_info?.owner?.author?.endpoint?.payload
-    ?.panelLoadingStrategy?.inlineContent?.dialogViewModel?.customContent
-    ?.listViewModel?.listItems
-
-  if (!Array.isArray(listItems)) {
-    return []
-  }
-
-  const collaborators = []
-  const seenChannelIds = new Set()
-
-  for (const item of listItems) {
-    const viewModel = item.listItemViewModel
-    const avatar = viewModel?.leadingAccessory?.avatarViewModel
-    const channelId = viewModel?.title?.commandRuns?.[0]?.onTap?.innertubeCommand?.browseEndpoint?.browseId ??
-      avatar?.endpoint?.innertubeCommand?.browseEndpoint?.browseId
-    const name = viewModel?.title?.content
-
-    if (!channelId || !name || seenChannelIds.has(channelId)) {
-      continue
-    }
-
-    seenChannelIds.add(channelId)
-    collaborators.push({
-      id: channelId,
-      name,
-      thumbnail: avatar?.image?.sources?.at(-1)?.url ?? '',
-      subtitle: viewModel?.subtitle?.content?.replaceAll(/[\u200e\u2068\u2069]/g, '') ?? ''
-    })
-  }
-
-  return collaborators
-}
+export { parseLocalVideoCollaborators } from '../video-collaborators'
 
 /**
  * @param {string} id

--- a/src/renderer/helpers/loadTabAvatars.js
+++ b/src/renderer/helpers/loadTabAvatars.js
@@ -12,6 +12,7 @@ import {
   invidiousGetVideoInformation,
   youtubeImageUrlToInvidious
 } from './api/invidious'
+import { getLocalVideoAvatarUrl } from './video-collaborators'
 
 const TAB_AVATAR_LOAD_CONCURRENCY = 4
 
@@ -29,7 +30,7 @@ async function resolveLocalAvatarUrl(path) {
   const videoId = path.match(/^\/watch\/([^/]+)/)?.[1]
   if (videoId) {
     const video = await getLocalVideoInfo(videoId)
-    return normalizeAvatarUrl(video.info?.secondary_info?.owner?.author?.best_thumbnail?.url)
+    return normalizeAvatarUrl(getLocalVideoAvatarUrl(video.info))
   }
 
   return null

--- a/src/renderer/helpers/video-collaborators.js
+++ b/src/renderer/helpers/video-collaborators.js
@@ -1,0 +1,58 @@
+/**
+ * @typedef {object} LocalVideoCollaborator
+ * @property {string} id
+ * @property {string} name
+ * @property {string} thumbnail
+ * @property {string} subtitle
+ */
+
+/**
+ * @param {import('youtubei.js').YT.VideoInfo} videoInfo
+ * @returns {LocalVideoCollaborator[]}
+ */
+export function parseLocalVideoCollaborators(videoInfo) {
+  const listItems = videoInfo.secondary_info?.owner?.author?.endpoint?.payload
+    ?.panelLoadingStrategy?.inlineContent?.dialogViewModel?.customContent
+    ?.listViewModel?.listItems
+
+  if (!Array.isArray(listItems)) {
+    return []
+  }
+
+  const collaborators = []
+  const seenChannelIds = new Set()
+
+  for (const item of listItems) {
+    const viewModel = item.listItemViewModel
+    const avatar = viewModel?.leadingAccessory?.avatarViewModel
+    const channelId = viewModel?.title?.commandRuns?.[0]?.onTap?.innertubeCommand?.browseEndpoint?.browseId ??
+      avatar?.endpoint?.innertubeCommand?.browseEndpoint?.browseId
+    const name = viewModel?.title?.content
+
+    if (!channelId || !name || seenChannelIds.has(channelId)) {
+      continue
+    }
+
+    seenChannelIds.add(channelId)
+    collaborators.push({
+      id: channelId,
+      name,
+      thumbnail: avatar?.image?.sources?.at(-1)?.url ?? '',
+      subtitle: viewModel?.subtitle?.content?.replaceAll(/[\u200e\u2068\u2069]/g, '') ?? ''
+    })
+  }
+
+  return collaborators
+}
+
+/**
+ * Resolve the channel avatar represented by local video information.
+ * Collaboration videos store their primary channel in an attachment instead
+ * of the regular owner thumbnail.
+ * @param {import('youtubei.js').YT.VideoInfo} videoInfo
+ * @returns {string | undefined}
+ */
+export function getLocalVideoAvatarUrl(videoInfo) {
+  const primaryCollaborator = parseLocalVideoCollaborators(videoInfo)[0]
+  return primaryCollaborator?.thumbnail ?? videoInfo.secondary_info?.owner?.author?.best_thumbnail?.url
+}

--- a/src/renderer/helpers/video-collaborators.js
+++ b/src/renderer/helpers/video-collaborators.js
@@ -54,5 +54,5 @@ export function parseLocalVideoCollaborators(videoInfo) {
  */
 export function getLocalVideoAvatarUrl(videoInfo) {
   const primaryCollaborator = parseLocalVideoCollaborators(videoInfo)[0]
-  return primaryCollaborator?.thumbnail ?? videoInfo.secondary_info?.owner?.author?.best_thumbnail?.url
+  return primaryCollaborator?.thumbnail || videoInfo.secondary_info?.owner?.author?.best_thumbnail?.url
 }

--- a/tests/unit/video-collaborators.test.mjs
+++ b/tests/unit/video-collaborators.test.mjs
@@ -61,3 +61,43 @@ test('uses the regular owner avatar for non-collaboration videos', () => {
     }
   }), 'https://images.test/owner-avatar.jpg')
 })
+
+test('uses the regular owner avatar when the primary collaborator has no avatar', () => {
+  assert.equal(getLocalVideoAvatarUrl({
+    secondary_info: {
+      owner: {
+        author: {
+          endpoint: {
+            payload: {
+              panelLoadingStrategy: {
+                inlineContent: {
+                  dialogViewModel: {
+                    customContent: {
+                      listViewModel: {
+                        listItems: [{
+                          listItemViewModel: {
+                            title: {
+                              content: 'Primary collaborator',
+                              commandRuns: [{
+                                onTap: {
+                                  innertubeCommand: {
+                                    browseEndpoint: { browseId: 'UCprimary' }
+                                  }
+                                }
+                              }]
+                            }
+                          }
+                        }]
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          },
+          best_thumbnail: { url: 'https://images.test/owner-avatar.jpg' }
+        }
+      }
+    }
+  }), 'https://images.test/owner-avatar.jpg')
+})

--- a/tests/unit/video-collaborators.test.mjs
+++ b/tests/unit/video-collaborators.test.mjs
@@ -1,0 +1,63 @@
+import assert from 'node:assert/strict'
+import test from 'node:test'
+
+import { getLocalVideoAvatarUrl } from '../../src/renderer/helpers/video-collaborators.js'
+
+test('uses the primary collaborator avatar without reading the attachment-backed owner thumbnail', () => {
+  const author = {
+    endpoint: {
+      payload: {
+        panelLoadingStrategy: {
+          inlineContent: {
+            dialogViewModel: {
+              customContent: {
+                listViewModel: {
+                  listItems: [{
+                    listItemViewModel: {
+                      title: {
+                        content: 'Primary collaborator',
+                        commandRuns: [{
+                          onTap: {
+                            innertubeCommand: {
+                              browseEndpoint: { browseId: 'UCprimary' }
+                            }
+                          }
+                        }]
+                      },
+                      leadingAccessory: {
+                        avatarViewModel: {
+                          image: {
+                            sources: [{ url: 'https://images.test/primary-avatar.jpg' }]
+                          }
+                        }
+                      }
+                    }
+                  }]
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    get best_thumbnail () {
+      throw new Error('regular owner thumbnail should not be read')
+    }
+  }
+
+  assert.equal(getLocalVideoAvatarUrl({
+    secondary_info: { owner: { author } }
+  }), 'https://images.test/primary-avatar.jpg')
+})
+
+test('uses the regular owner avatar for non-collaboration videos', () => {
+  assert.equal(getLocalVideoAvatarUrl({
+    secondary_info: {
+      owner: {
+        author: {
+          best_thumbnail: { url: 'https://images.test/owner-avatar.jpg' }
+        }
+      }
+    }
+  }), 'https://images.test/owner-avatar.jpg')
+})


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Make sure to follow the contributing guidelines. -->
<!-- Important note, we may remove your pull request if you do not use this provided PR template correctly. -->
<!-- Agent instructions: Preserve every heading, comment, and marker in this template. Never remove or rewrite the release-note-category:start/end, release-note:start/end, or release-note-image:start/end marker pairs. Never remove or rewrite the Release note images section; leave its contents for a human. -->

## Pull Request Type
<!-- Please select what type of pull request this is: [x] -->
- [x] Bugfix
- [ ] Feature Implementation
- [ ] Documentation
- [ ] Other

## Related issue
<!-- Please link the issue your pull request is referring to. -->
<!-- If this pull request fully resolves the relevant issue, put "closes" before the issue number. -->
<!-- Example: "closes #123456". -->

## Description
<!-- Please write a clear and concise description of what the pull request does. -->
Restored or unloaded tabs for collaboration videos could not load their channel icon because the local API exposes the primary channel through the collaborators attachment instead of the ordinary owner thumbnail.

This reuses the existing collaborator parser when resolving video tab avatars, while preserving the ordinary owner-avatar fallback for non-collaboration videos. The parser now lives in a small standalone helper so the attachment behavior has direct regression coverage.

## Release note category
<!-- Select exactly one category. Every pull request must select one. -->
<!-- Select "Not noteworthy" when the pull request fixes a bug in or improves functionality that has not yet appeared in a stable release. -->
<!-- release-note-category:start -->
- [x] Not noteworthy
- [ ] Highlights
- [ ] More improvements
- [ ] Fixed bugs
<!-- release-note-category:end -->

## Release note
<!-- Required unless "Not noteworthy" is selected. -->
<!-- Write one concise, user-facing entry without a leading bullet. -->
<!-- release-note:start -->
Fixed missing tab icons for collaboration videos after restoring a session or loading missing icons.
<!-- release-note:end -->

## Release note images
<!-- Human-only: Agents must preserve this entire section and leave it empty. -->
<!-- Optional. Paste one or more Markdown images or HTML image tags here. -->
<!-- The release notes will use an HTML image tag and limit images taller than 300 pixels. -->
<!-- release-note-image:start -->

<!-- release-note-image:end -->

## Testing
<!-- How can reviewers verify that the PR produces correct results? -->
<!-- Please provide instructions so that others can ensure that your pull request would produce correct results. For examples see, https://github.com/FreeTubeApp/FreeTube/pull/5743, https://github.com/FreeTubeApp/FreeTube/pull/7349, https://github.com/FreeTubeApp/FreeTube/pull/5125, https://github.com/FreeTubeApp/FreeTube/pull/7338 -->
<!-- Agent instructions: Only write human-facing steps that explain how to verify the change while running this branch in dev mode. Include expected results and, when applicable, helpful console snippets for interactive verification. Do not include automated checks, commands, results, pass counts, or CI status. -->
1. Open a collaboration video and leave its tab open.
2. Restart the app with session restoration enabled, or clear the tab icon and use **Settings → Theme → Load Missing Tab Icons**.
3. Confirm the tab receives the primary collaborator's channel avatar without activating the unloaded tab.
4. Repeat with a regular video and confirm its ordinary channel avatar still loads.

## Additional context
<!-- Add any other context about the pull request here. -->
The previous lookup reached YouTube.js's attachment-backed author text as if it were a regular author, producing `[YOUTUBEJS][Text]: Unable to find matching run for attachment run` warnings and no usable avatar URL.