### PR TITLE
fix(settings): polish search, highlights, and modal closing

### DIFF
--- a/e2e/tests/offline/quick-settings.spec.mjs
+++ b/e2e/tests/offline/quick-settings.spec.mjs
@@ -109,6 +109,19 @@ test.describe('quick settings menu', () => {
     await expect(settingsWindow).toBeVisible()
     await expect(settingsWindow.locator('.settingsMenu')).toBeVisible()
   })
+
+  test('keeps About visible while its close animation plays', async ({ page }) => {
+    await page.locator('.profileTrigger').click()
+    await page.getByRole('dialog', { name: 'Quick settings' }).getByRole('button', { name: 'About' }).click()
+
+    const aboutWindow = page.getByRole('dialog', { name: 'About' })
+    await aboutWindow.locator('.settingsCloseButton').click()
+
+    await expect(aboutWindow).toHaveClass(/settings-window-leave-active/)
+    await expect(aboutWindow.locator('.settingsBreadcrumb')).toContainText('About')
+    await expect(aboutWindow.locator('.settingsMenu')).toHaveCount(0)
+    await expect(aboutWindow).toBeHidden()
+  })
 })
 
 test.describe('quick distraction settings', () => {

--- a/e2e/tests/offline/settings.spec.mjs
+++ b/e2e/tests/offline/settings.spec.mjs
@@ -191,7 +191,16 @@ test.describe('settings', () => {
 
     await search.fill('Check for Updates')
     await page.getByRole('button', { name: /Check for updates/i, exact: true }).click()
-    await expect(page.locator('.switch-ctn.settingsSearchTarget')).toContainText(/Check for updates/i)
+    const switchHighlight = page.locator('.switch-ctn.settingsSearchTarget')
+    await expect(switchHighlight).toContainText(/Check for updates/i)
+    const { borderRadius, uiRoundness } = await switchHighlight.evaluate(element => {
+      const style = getComputedStyle(element)
+      return {
+        borderRadius: Number.parseFloat(style.borderRadius),
+        uiRoundness: Number.parseFloat(style.getPropertyValue('--ui-roundness'))
+      }
+    })
+    expect(borderRadius).toBeCloseTo(4 * uiRoundness)
     await expect(page.locator('.section.settingsSearchTarget')).toHaveCount(0)
 
     await search.fill('UI Scale')
@@ -237,6 +246,9 @@ test.describe('settings', () => {
     await expect(page.locator('.settingsSearchResultMatch')).toHaveCount(0)
 
     await search.fill('How do I import my subscriptions?')
+    await expect(page.locator('.settingsSearchResultMatch')).toHaveCount(0)
+
+    await search.fill('successfully imported')
     await expect(page.locator('.settingsSearchResultMatch')).toHaveCount(0)
 
     await search.fill('checking')

--- a/e2e/tests/offline/settings.spec.mjs
+++ b/e2e/tests/offline/settings.spec.mjs
@@ -2535,6 +2535,42 @@ test.describe('synced setting indicators', () => {
     expect(neighbourAfter.x).toBeCloseTo(neighbourBefore.x, 0)
   })
 
+  test('aligns non-resettable controls while changed settings are highlighted', async ({ page }) => {
+    await goTo(page, 'settings')
+    await page.getByRole('button', { name: 'Highlight settings changed from defaults' }).click()
+
+    const playerSection = await goToSettingsSection(page, 'player')
+    const proxyToggle = playerSection.locator('.switch-ctn')
+      .filter({ hasText: 'Proxy Videos Through Invidious' })
+    const subtitlesToggle = playerSection.locator('.switch-ctn')
+      .filter({ hasText: 'Enable Subtitles by Default' })
+    await expect(proxyToggle).toHaveCSS('border-left-width', '3px')
+
+    const [proxyBox, subtitlesBox] = await Promise.all([
+      proxyToggle.boundingBox(),
+      subtitlesToggle.boundingBox()
+    ])
+    expect(proxyBox).not.toBeNull()
+    expect(subtitlesBox).not.toBeNull()
+    expect(proxyBox.x).toBeCloseTo(subtitlesBox.x, 0)
+
+    const themeSection = await goToSettingsSection(page, 'theme')
+    const smoothScrollingToggle = themeSection.locator('.switch-ctn')
+      .filter({ hasText: 'Disable Smooth Scrolling' })
+    await expect(smoothScrollingToggle).toHaveCSS('border-left-width', '3px')
+
+    const playerSectionAgain = await goToSettingsSection(page, 'player')
+    const viewingModeSelect = playerSectionAgain.locator('.select')
+      .filter({ hasText: 'Default Viewing Mode' })
+    const [selectBox, selectLabelBox] = await Promise.all([
+      viewingModeSelect.locator('.select-text').boundingBox(),
+      viewingModeSelect.locator('.select-label').boundingBox()
+    ])
+    expect(selectBox).not.toBeNull()
+    expect(selectLabelBox).not.toBeNull()
+    expect(selectLabelBox.x).toBeCloseTo(selectBox.x, 0)
+  })
+
   test('keeps a wrapped slider label beside its icons and above its track', async ({ page }) => {
     await goTo(page, 'settings')
     await page.getByRole('button', { name: 'Highlight settings changed from defaults' }).click()

--- a/e2e/tests/offline/watch-page.spec.mjs
+++ b/e2e/tests/offline/watch-page.spec.mjs
@@ -246,6 +246,8 @@ test.describe('watch page', () => {
 
     await expect(ytDlp).toHaveAttribute('aria-pressed', 'true')
     await expect(builtIn).toHaveAttribute('aria-pressed', 'false')
+    await expect(ytDlp.locator('.engineOptionCheck')).toBeVisible()
+    await expect(builtIn.locator('.engineOptionCheck')).toHaveCount(0)
     await expect(prompt.locator('.engineBadge')).toHaveText('yt-dlp')
     await expect(prompt.getByTitle('Streaming protocol')).toHaveCount(0)
 

--- a/src/renderer/App.vue
+++ b/src/renderer/App.vue
@@ -69,7 +69,10 @@
         </Transition>
       </RouterView>
     </FtFlexBox>
-    <Transition name="settings-window">
+    <Transition
+      name="settings-window"
+      @after-leave="resetClosedSettingsWindowView"
+    >
       <KeepAlive>
         <SettingsWindow v-if="settingsWindowOpen" />
       </KeepAlive>
@@ -463,6 +466,12 @@ const showSearchFilters = computed(() => store.getters.getShowSearchFilters)
 /** @type {import('vue').ComputedRef<boolean>} */
 const isKeyboardShortcutPromptShown = computed(() => store.getters.getIsKeyboardShortcutPromptShown)
 const settingsWindowOpen = computed(() => store.getters.getSettingsWindowOpen)
+
+function resetClosedSettingsWindowView() {
+  if (!settingsWindowOpen.value) {
+    store.dispatch('showSettingsWindowRoot')
+  }
+}
 
 /** @type {import('vue').ComputedRef<boolean>} */
 const showAddToPlaylistPrompt = computed(() => store.getters.getShowAddToPlaylistPrompt)

--- a/src/renderer/components/FtQuickSettingsMenu/FtQuickSettingsMenu.vue
+++ b/src/renderer/components/FtQuickSettingsMenu/FtQuickSettingsMenu.vue
@@ -585,7 +585,7 @@ function handleHideRecommendedVideos(value) {
 
 function openSettings() {
   menuOpen.value = false
-  store.dispatch('showSettingsWindow')
+  store.dispatch('toggleSettingsWindow')
 }
 
 function openKeyboardShortcuts() {

--- a/src/renderer/components/FtToggleSwitch/FtToggleSwitch.vue
+++ b/src/renderer/components/FtToggleSwitch/FtToggleSwitch.vue
@@ -32,10 +32,7 @@
         :tooltip="tooltip"
         :allow-newlines="tooltipAllowNewlines"
       />
-      <FtSyncedSettingIndicator
-        :setting-key="settingKey"
-        :is-changed="reserveChangedIndicatorSpace ? false : null"
-      />
+      <FtSyncedSettingIndicator :setting-key="settingKey" />
     </label>
   </div>
 </template>
@@ -79,10 +76,6 @@ const props = defineProps({
   settingKey: {
     type: String,
     default: ''
-  },
-  reserveChangedIndicatorSpace: {
-    type: Boolean,
-    default: false
   },
 })
 

--- a/src/renderer/components/ThemeSettings.vue
+++ b/src/renderer/components/ThemeSettings.vue
@@ -23,7 +23,6 @@
           :label="$t('Settings.Theme Settings.Disable Smooth Scrolling')"
           compact
           :default-value="disableSmoothScrollingToggleValue"
-          reserve-changed-indicator-space
           @change="handleRestartPrompt"
         />
         <FtToggleSwitch

--- a/src/renderer/components/WatchVideoFormatPrompt/WatchVideoFormatPrompt.vue
+++ b/src/renderer/components/WatchVideoFormatPrompt/WatchVideoFormatPrompt.vue
@@ -45,8 +45,9 @@
             @click="selectPlaybackEngine(engine.value)"
           >
             {{ engine.label }}
-            <FontAwesomeIcon
+            <FtIcon
               v-if="engine.value === playbackEngineSelection"
+              class="engineOptionCheck"
               :icon="['fas', 'check']"
             />
           </button>

--- a/src/renderer/helpers/settings-search-config.js
+++ b/src/renderer/helpers/settings-search-config.js
@@ -47,6 +47,27 @@ export const SETTINGS_SEARCH_SELECT_GROUP_LABELS = {
     'Default Quality': ['Default Quality'],
     'Screenshot.Modes': []
   },
+  data: {
+    '': [
+      'Data Settings',
+      'Import Subscriptions',
+      'Export Subscriptions',
+      'Import History',
+      'Export History',
+      'Import Playlists',
+      'Export Playlists',
+      'Search history',
+      'Import search history',
+      'Export search history',
+      'Import Settings',
+      'Export Settings',
+      'Import subscriptions formats',
+      'Import history formats',
+      'Import playlists formats',
+      'Import search history formats',
+      'Manage Subscriptions'
+    ]
+  },
   'caption-appearance': {
     Anchor: ['Anchor'],
     'Edge Style': ['Edge Style']

--- a/src/renderer/store/modules/utils.js
+++ b/src/renderer/store/modules/utils.js
@@ -375,7 +375,9 @@ const actions = {
   },
 
   toggleSettingsWindow ({ state, commit }) {
-    const open = !state.settingsWindowOpen
+    const open = !state.settingsWindowOpen ||
+      state.settingsWindowView !== null ||
+      state.isKeyboardShortcutPromptShown
     commit('setIsKeyboardShortcutPromptShown', false)
     commit('setSettingsWindowView', null)
     commit('setSettingsWindowOpen', open)

--- a/src/renderer/store/modules/utils.js
+++ b/src/renderer/store/modules/utils.js
@@ -384,7 +384,6 @@ const actions = {
   hideSettingsWindow ({ commit }) {
     commit('setIsKeyboardShortcutPromptShown', false)
     commit('setSettingsWindowOpen', false)
-    commit('setSettingsWindowView', null)
   },
 
   showSettingsWindowRoot ({ commit }) {

--- a/src/renderer/views/Settings/Settings.css
+++ b/src/renderer/views/Settings/Settings.css
@@ -335,6 +335,7 @@
 .settingsContent :deep(.settingsSearchTarget) {
   outline: 2px solid transparent;
   outline-offset: 4px;
+  border-radius: calc(4px * var(--ui-roundness));
   animation: settings-search-highlight 2.2s ease-in-out;
 }
 

--- a/src/renderer/views/Settings/Settings.css
+++ b/src/renderer/views/Settings/Settings.css
@@ -359,20 +359,27 @@
   display: none;
 }
 
-/* A setting still at its default reserves the marker's space (the placeholder
-   is only rendered while highlighting is on), so changing it colors the border
-   in rather than shifting the control sideways — which can otherwise re-wrap
-   its label mid-drag. Kept as specific as the rule below, which follows it and
-   therefore wins once the setting really has changed. */
-:deep(.switch-ctn:has(.changedSettingIndicatorPlaceholder)),
-:deep(.select:has(.changedSettingIndicatorPlaceholder)),
-:deep(.ft-input-component:has(.changedSettingIndicatorPlaceholder)),
-:deep(.pure-material-slider:has(.changedSettingIndicatorPlaceholder)),
-:deep(.pure-checkbox:has(.changedSettingIndicatorPlaceholder)),
-:deep(.inputTags:has(.changedSettingIndicatorPlaceholder)),
-:deep(.sponsorBlockCategory:has(.changedSettingIndicatorPlaceholder)) {
+/* Every control reserves the marker gutter while highlighting is on, including
+   controls that cannot be reset. Otherwise those controls sit further towards
+   the edge than their resettable neighbours. The low-specificity :where keeps
+   the colored marker rule below in control when a setting has changed. */
+.settingsContent.highlightChangedSettings :deep(:where(
+  .switch-ctn,
+  .select,
+  .ft-input-component,
+  .pure-material-slider,
+  .pure-checkbox,
+  .inputTags,
+  .sponsorBlockCategory
+)) {
   border-inline-start: 3px solid transparent;
   padding-inline-start: 9px;
+}
+
+/* Select labels are absolutely positioned, so the wrapper padding above does
+   not move them with the field unless their inset reserves the same gutter. */
+.settingsContent.highlightChangedSettings :deep(.select-label) {
+  inset-inline-start: 9px;
 }
 
 :deep(.switch-ctn:has(.changedSettingIndicator)),

--- a/src/renderer/views/Settings/Settings.vue
+++ b/src/renderer/views/Settings/Settings.vue
@@ -245,7 +245,10 @@
             ref="settingsContentRef"
             v-overlay-scrollbars
             class="settingsContent"
-            :class="settingsContentTransitionClass"
+            :class="[
+              settingsContentTransitionClass,
+              { highlightChangedSettings }
+            ]"
             tabindex="-1"
             @scroll.passive="clampSettingsContentScroll"
           >

--- a/tests/unit/icon-packs.test.mjs
+++ b/tests/unit/icon-packs.test.mjs
@@ -86,6 +86,19 @@ test('every semantic icon the renderer asks for has a mapping', async () => {
   )
 })
 
+test('renderer icons use the icon-pack-aware component', async () => {
+  const legacyUsages = []
+
+  for (const file of await readRendererSources()) {
+    const source = await readFile(file, 'utf8')
+    if (/<(?:font-awesome-icon|FontAwesomeIcon)\b/.test(source)) {
+      legacyUsages.push(path.relative(repoRoot, file))
+    }
+  }
+
+  assert.deepEqual(legacyUsages, [])
+})
+
 async function readRendererSources() {
   const files = []
   const walk = async (directory) => {

--- a/tests/unit/settings-search-config.test.mjs
+++ b/tests/unit/settings-search-config.test.mjs
@@ -24,12 +24,13 @@ test('settings search paths match the canonical locale structure', () => {
     for (const [groupPath, retainedKeys] of Object.entries(
       SETTINGS_SEARCH_SELECT_GROUP_LABELS[section] ?? {}
     )) {
-      const group = getAtPath(messages, groupPath)
-      assert.equal(typeof group, 'object', `${localePath}.${groupPath} must resolve to an object`)
+      const group = groupPath === '' ? messages : getAtPath(messages, groupPath)
+      const fullGroupPath = [localePath, groupPath].filter(Boolean).join('.')
+      assert.equal(typeof group, 'object', `${fullGroupPath} must resolve to an object`)
       for (const retainedKey of retainedKeys) {
         assert.ok(
           Object.hasOwn(group, retainedKey),
-          `${localePath}.${groupPath}.${retainedKey} must exist`
+          `${fullGroupPath}.${retainedKey} must exist`
         )
       }
     }


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Make sure to follow the contributing guidelines. -->
<!-- Important note, we may remove your pull request if you do not use this provided PR template correctly. -->
<!-- Agent instructions: Preserve every heading, comment, and marker in this template. Never remove or rewrite the release-note-category:start/end, release-note:start/end, or release-note-image:start/end marker pairs. Never remove or rewrite the Release note images section; leave its contents for a human. -->

## Pull Request Type
<!-- Please select what type of pull request this is: [x] -->
- [x] Bugfix
- [ ] Feature Implementation
- [ ] Documentation
- [ ] Other

## Related issue
<!-- Please link the issue your pull request is referring to. -->
<!-- If this pull request fully resolves the relevant issue, put "closes" before the issue number. -->
<!-- Example: "closes #123456". -->

Closes #673
Closes #674

## Description
<!-- Please write a clear and concise description of what the pull request does. -->

Settings search could expose operational import/export messages that are not settings, and its temporary target outline ignored the configured UI roundness. Changed-setting markers also offset controls that cannot be reset, while closing About replaced its content with Settings during the leave animation. The format prompt also retained a legacy Font Awesome checkmark that no longer rendered after the icon-pack migration.

Limit Data settings search to visible settings text, scale search highlights with UI roundness, and reserve one consistent marker gutter across supported controls. Keep the active Settings view mounted until the modal finishes closing so About remains visible throughout its animation. Route the format-selection checkmark through the icon-pack-aware component and reject future legacy component usage.

## Release note category
<!-- Select exactly one category. Every pull request must select one. -->
<!-- Select "Not noteworthy" when the pull request fixes a bug in or improves functionality that has not yet appeared in a stable release. -->
<!-- release-note-category:start -->
- [x] Not noteworthy
- [ ] Highlights
- [ ] More improvements
- [ ] Fixed bugs
<!-- release-note-category:end -->

## Release note
<!-- Required unless "Not noteworthy" is selected. -->
<!-- Write one concise, user-facing entry without a leading bullet. -->
<!-- release-note:start -->

<!-- release-note:end -->

## Release note images
<!-- Human-only: Agents must preserve this entire section and leave it empty. -->
<!-- Optional. Paste one or more Markdown images or HTML image tags here. -->
<!-- The release notes will use an HTML image tag and limit images taller than 300 pixels. -->
<!-- release-note-image:start -->

<!-- release-note-image:end -->

## Testing
<!-- How can reviewers verify that the PR produces correct results? -->
<!-- Please provide instructions so that others can ensure that your pull request works properly. For examples see, https://github.com/FreeTubeApp/FreeTube/pull/5743, https://github.com/FreeTubeApp/FreeTube/pull/7349, https://github.com/FreeTubeApp/FreeTube/pull/5125, https://github.com/FreeTubeApp/FreeTube/pull/7338 -->
<!-- Agent instructions: Only write human-facing steps that explain how to verify the change while running this branch in dev mode. Include expected results and, when applicable, helpful console snippets for interactive verification. Do not include automated checks, commands, results, pass counts, or CI status. -->

1. Open Settings, search for “Check for Updates,” and select the matching result.
2. Change UI Roundness and repeat the search. Confirm the temporary outline follows the selected roundness.
3. Search for “successfully imported.” Confirm no operational import status messages appear as results.
4. Enable changed-setting highlighting and open Player settings. Confirm “Proxy Videos Through Invidious,” neighboring toggles, and select titles stay aligned.
5. Open About from Quick Settings and close it. Confirm About remains visible for the entire close animation.
6. Open Change Media Formats on a video and confirm the selected extraction method shows a checkmark.

## Additional context
<!-- Add any other context about the pull request here. -->

The Data settings locale group contains both visible controls and runtime status/error messages, so it now uses an explicit allowlist of visible search labels. The changed-setting gutter is reserved at the Settings content level so non-resettable control variants cannot drift from resettable neighbors. A renderer-wide audit found no other legacy Font Awesome component usages.

