### PR TITLE
feat(captions): translate into any language

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -4,6 +4,7 @@
 - Always run Electron/Playwright E2E tests under a private X server using `xvfb-run -a -s "-screen 0 1920x1080x24"`.
 - Before running modified Electron/Playwright E2E tests, run `pnpm run test:e2e:pack` so `dist-e2e` includes the current CSS and rendering or measurement tests do not run against an unstyled app.
 - Custom Shaka overflow-menu controls must hide while any submenu is open; follow the existing `submenuopen` / `submenuclose` visibility pattern using `isSubMenuOpened` and `shaka-hidden`.
+- Headers in scrollable menus and panels must stay outside the content's scroll viewport so neither content nor its scrollbar can pass behind the header; prefer a fixed header plus a separate inner scroller over covering content with a sticky header. When switching between menu views, explicitly restore the actual scroll viewport to the intended position; use `restoreOverlayScrollTop` for OverlayScrollbars-managed elements instead of relying on focus or DOM replacement to reset it.
 - If the request somehow involves other repos (e.g. Website, APT, RPM, Flatpak, AUR, ...) you can find them in the parent folder.
 - Before considering work done here, you need to reproduce it with the test suite (for bugfixes), and verify that your fix/feature works (unless otherwise told to do so or when it makes no sense to do a test for the change).
 - After creating a PR babysit it. Wait for reviews of CodeRabbit/Greptile. When they come in resolve the reviews.

--- a/e2e/helpers/watch.mjs
+++ b/e2e/helpers/watch.mjs
@@ -77,15 +77,19 @@ export async function mockWatchPage(app, page, { playable = false, captionTransl
 
   if (captionTranslations) {
     await page.route('https://www.youtube.com/api/timedtext**', (route) => {
-      const format = new URL(route.request().url()).searchParams.get('fmt')
+      const searchParams = new URL(route.request().url()).searchParams
+      const format = searchParams.get('fmt')
       const body = format === 'srt'
         ? '1\n00:00:00,000 --> 00:00:05,000\nTranslated caption\n'
         : 'WEBVTT\n\n00:00:00.000 --> 00:00:05.000\nOriginal caption\n'
-      return route.fulfill({
+      const fulfill = () => route.fulfill({
         status: 200,
         contentType: format === 'srt' ? 'application/x-subrip' : 'text/vtt',
         body
       })
+      return format === 'srt' && searchParams.get('tlang') === 'fr'
+        ? new Promise(resolve => setTimeout(resolve, 250)).then(fulfill)
+        : fulfill()
     })
   }
 

--- a/e2e/helpers/watch.mjs
+++ b/e2e/helpers/watch.mjs
@@ -60,8 +60,9 @@ async function fixture(dir, name) {
  * @param {import('@playwright/test').Page} page
  * @param {object} [options]
  * @param {boolean} [options.playable] serve the demo video instead of an error
+ * @param {boolean} [options.captionTranslations] include a translatable caption and target languages
  */
-export async function mockWatchPage(app, page, { playable = false } = {}) {
+export async function mockWatchPage(app, page, { playable = false, captionTranslations = false } = {}) {
   const counters = new Map()
 
   await stubPoToken(app.electronApp)
@@ -72,6 +73,20 @@ export async function mockWatchPage(app, page, { playable = false } = {}) {
 
   if (playable) {
     await routeDemoMedia(page)
+  }
+
+  if (captionTranslations) {
+    await page.route('https://www.youtube.com/api/timedtext**', (route) => {
+      const format = new URL(route.request().url()).searchParams.get('fmt')
+      const body = format === 'srt'
+        ? '1\n00:00:00,000 --> 00:00:05,000\nTranslated caption\n'
+        : 'WEBVTT\n\n00:00:00.000 --> 00:00:05.000\nOriginal caption\n'
+      return route.fulfill({
+        status: 200,
+        contentType: format === 'srt' ? 'application/x-subrip' : 'text/vtt',
+        body
+      })
+    })
   }
 
   await page.route(/^https?:\/\//, async (route, request) => {
@@ -99,6 +114,32 @@ export async function mockWatchPage(app, page, { playable = false } = {}) {
     if (url.includes('/youtubei/v1/player')) {
       const videoId = JSON.parse(request.postData() ?? '{}').videoId ?? 'jNQXAC9IVRw'
       const json = demoPlayerResponse(videoId)
+
+      if (captionTranslations) {
+        const displayNames = new Intl.DisplayNames(['en'], { type: 'language' })
+        const languageCodes = [
+          'af', 'sq', 'am', 'ar', 'hy', 'as', 'ay', 'az', 'eu', 'be',
+          'bn', 'bs', 'bg', 'my', 'ca', 'ceb', 'zh', 'co', 'hr', 'cs',
+          'da', 'nl', 'dz', 'en', 'eo', 'et', 'ee', 'fo', 'fj', 'fil',
+          'fi', 'fr', 'de'
+        ]
+        json.captions = {
+          playerCaptionsTracklistRenderer: {
+            captionTracks: [{
+              baseUrl: `https://www.youtube.com/api/timedtext?v=${videoId}&caps=asr&kind=asr&lang=en`,
+              name: { simpleText: 'English (auto-generated)' },
+              vssId: 'a.en',
+              languageCode: 'en',
+              kind: 'asr',
+              isTranslatable: true
+            }],
+            translationLanguages: languageCodes.map(languageCode => ({
+              languageCode,
+              languageName: { simpleText: displayNames.of(languageCode) ?? languageCode }
+            }))
+          }
+        }
+      }
 
       if (!playable) {
         json.playabilityStatus = { status: 'UNPLAYABLE', reason: 'Video unavailable' }
@@ -150,8 +191,8 @@ export function mockUnplayableWatchPage(app, page) {
 }
 
 /** @see mockWatchPage */
-export function mockPlayableWatchPage(app, page) {
-  return mockWatchPage(app, page, { playable: true })
+export function mockPlayableWatchPage(app, page, options = {}) {
+  return mockWatchPage(app, page, { ...options, playable: true })
 }
 
 /**

--- a/e2e/tests/offline/player.spec.mjs
+++ b/e2e/tests/offline/player.spec.mjs
@@ -262,9 +262,16 @@ test('auto-translates captions into an arbitrary language', async ({ app, page, 
   await expect.poll(() => translations.evaluate(element => element.scrollTop)).toBeGreaterThan(0)
   await attachScreenshot('auto-translate language grid')
 
+  const frenchResponse = page.waitForResponse(response => {
+    const url = new URL(response.url())
+    return url.pathname === '/api/timedtext' && url.searchParams.get('tlang') === 'fr'
+  })
+  await translations.getByRole('button', { name: 'French' }).click()
   await translations.getByRole('button', { name: 'German' }).click()
   await expect(player.locator('.shaka-text-languages')).toBeVisible()
   expect(await overflowMenu.evaluate(element => element.scrollTop)).toBe(0)
+  await expect(player.locator('.shaka-text-languages')).toContainText('German')
+  await frenchResponse
   await expect(player.locator('.shaka-text-languages')).toContainText('German')
 
   const watchComponent = await page.evaluateHandle(findWatchComponent)
@@ -285,6 +292,21 @@ test('auto-translates captions into an arbitrary language', async ({ app, page, 
   ])
   expect(Math.abs(languageBounds.x - listBounds.x)).toBeLessThanOrEqual(1)
   expect(Math.abs(languageBounds.width - listBounds.width)).toBeLessThanOrEqual(1)
+
+  const nextVideoId = 'aqz-KE-bpKQ'
+  await openMockedVideo(page, nextVideoId)
+  await player.hover()
+  await moreOptions.click()
+  await overflowMenu.getByRole('button', { name: 'Captions' }).click()
+  await player.locator('.shaka-text-languages').getByRole('button', { name: 'Auto-translate' }).click()
+  const nextVideoTranslationRequest = page.waitForRequest(request => {
+    const url = new URL(request.url())
+    return url.pathname === '/api/timedtext' &&
+      url.searchParams.get('v') === nextVideoId &&
+      url.searchParams.get('tlang') === 'de'
+  })
+  await translations.getByRole('button', { name: 'German' }).click()
+  await nextVideoTranslationRequest
   await watchComponent.dispose()
 })
 

--- a/e2e/tests/offline/player.spec.mjs
+++ b/e2e/tests/offline/player.spec.mjs
@@ -296,6 +296,21 @@ test('auto-translates captions into an arbitrary language', async ({ app, page, 
   expect(Math.abs(languageBounds.x - listBounds.x)).toBeLessThanOrEqual(1)
   expect(Math.abs(languageBounds.width - listBounds.width)).toBeLessThanOrEqual(1)
 
+  await header.click()
+  const captionsMenu = player.locator('.shaka-text-languages')
+  await captionsMenu.getByRole('button', { name: 'Off' }).click()
+  await overflowMenu.getByRole('button', { name: 'Captions' }).click()
+  await captionsMenu.getByRole('button', { name: 'Auto-translate' }).click()
+  await expect(selectedTranslation).toHaveAttribute('aria-selected', 'false')
+  await expect(selectedTranslation.locator('.shaka-chosen-item')).toHaveCount(0)
+
+  await header.click()
+  await captionsMenu.getByRole('button', { name: 'English (auto-generated)', exact: true }).click()
+  await overflowMenu.getByRole('button', { name: 'Captions' }).click()
+  await captionsMenu.getByRole('button', { name: 'Auto-translate' }).click()
+  await expect(selectedTranslation).toHaveAttribute('aria-selected', 'false')
+  await expect(selectedTranslation.locator('.shaka-chosen-item')).toHaveCount(0)
+
   const nextVideoId = 'aqz-KE-bpKQ'
   await openMockedVideo(page, nextVideoId)
   await player.hover()

--- a/e2e/tests/offline/player.spec.mjs
+++ b/e2e/tests/offline/player.spec.mjs
@@ -228,6 +228,66 @@ test('the overflow menu can turn the zoom off again', async ({ app, page, attach
   await watchComponent.dispose()
 })
 
+test('auto-translates captions into an arbitrary language', async ({ app, page, attachScreenshot }) => {
+  await mockPlayableWatchPage(app, page, { captionTranslations: true })
+  await openMockedVideo(page)
+
+  const player = page.locator(`${activeTab} .ftVideoPlayer`)
+  await player.hover()
+  const moreOptions = player.getByRole('button', { name: 'More settings' })
+  await moreOptions.click()
+
+  const overflowMenu = player.locator('.shaka-overflow-menu')
+  await overflowMenu.getByRole('button', { name: 'Captions' }).click()
+  await player.locator('.shaka-text-languages').getByRole('button', { name: 'Auto-translate' }).click()
+
+  const translationMenu = player.locator('.ft-caption-translation-menu')
+  const header = translationMenu.locator(':scope > .shaka-back-to-overflow-button')
+  const translations = translationMenu.locator('.ft-caption-translation-options')
+  await expect(translationMenu).toBeVisible()
+  await expect(translations).toHaveClass(/ft-menu-grid/)
+  await expect(translations.locator(':scope > .os-scrollbar-vertical')).toHaveCount(1)
+  await expect(overflowMenu.locator(':scope > .os-scrollbar-vertical')).toHaveCSS('display', 'none')
+  expect(await translations.evaluate(element => element.scrollHeight > element.clientHeight)).toBe(true)
+
+  const [headerBounds, translationsBounds, scrollbarBounds] = await Promise.all([
+    header.boundingBox(),
+    translations.boundingBox(),
+    translations.locator(':scope > .os-scrollbar-vertical').boundingBox(),
+  ])
+  expect(translationsBounds.y).toBeGreaterThanOrEqual(headerBounds.y + headerBounds.height - 1)
+  expect(scrollbarBounds.y).toBeGreaterThanOrEqual(translationsBounds.y - 1)
+
+  await translations.evaluate(element => { element.scrollTop = element.scrollHeight })
+  await expect.poll(() => translations.evaluate(element => element.scrollTop)).toBeGreaterThan(0)
+  await attachScreenshot('auto-translate language grid')
+
+  await translations.getByRole('button', { name: 'German' }).click()
+  await expect(player.locator('.shaka-text-languages')).toBeVisible()
+  expect(await overflowMenu.evaluate(element => element.scrollTop)).toBe(0)
+  await expect(player.locator('.shaka-text-languages')).toContainText('German')
+
+  const watchComponent = await page.evaluateHandle(findWatchComponent)
+  await watchComponent.evaluate(async (component) => {
+    await component.proxy.$store.dispatch('updateUsePlayerMenuGrid', false)
+    await component.proxy.$nextTick()
+  })
+  await page.keyboard.press('Escape')
+  await player.hover()
+  await moreOptions.click()
+  await overflowMenu.getByRole('button', { name: 'Captions' }).click()
+  await player.locator('.shaka-text-languages').getByRole('button', { name: 'Auto-translate' }).click()
+  await expect(translations).not.toHaveClass(/ft-menu-grid/)
+
+  const [listBounds, languageBounds] = await Promise.all([
+    translations.boundingBox(),
+    translations.getByRole('button', { name: 'Afrikaans' }).boundingBox(),
+  ])
+  expect(Math.abs(languageBounds.x - listBounds.x)).toBeLessThanOrEqual(1)
+  expect(Math.abs(languageBounds.width - listBounds.width)).toBeLessThanOrEqual(1)
+  await watchComponent.dispose()
+})
+
 test('video zoom can be disabled', async ({ app, page }) => {
   const video = await openDemoVideo({ app, page })
 

--- a/e2e/tests/offline/player.spec.mjs
+++ b/e2e/tests/offline/player.spec.mjs
@@ -285,6 +285,9 @@ test('auto-translates captions into an arbitrary language', async ({ app, page, 
   await overflowMenu.getByRole('button', { name: 'Captions' }).click()
   await player.locator('.shaka-text-languages').getByRole('button', { name: 'Auto-translate' }).click()
   await expect(translations).not.toHaveClass(/ft-menu-grid/)
+  const selectedTranslation = translations.getByRole('button', { name: 'German' })
+  await expect(selectedTranslation).toHaveAttribute('aria-selected', 'true')
+  await expect(selectedTranslation.locator('.shaka-chosen-item')).toHaveCount(2)
 
   const [listBounds, languageBounds] = await Promise.all([
     translations.boundingBox(),

--- a/src/renderer/components/ft-shaka-video-player/ft-shaka-video-player.css
+++ b/src/renderer/components/ft-shaka-video-player/ft-shaka-video-player.css
@@ -1100,6 +1100,84 @@
   -webkit-line-clamp: 2;
 }
 
+/* Keep the translation header and scrollbar outside each other's regions. */
+:deep(.shaka-overflow-menu:has(> .ft-caption-translation-menu:not(.shaka-hidden))) {
+  block-size: min(50vh, 340px);
+  overflow: hidden;
+}
+
+:deep(.shaka-overflow-menu:has(> .ft-caption-translation-menu:not(.shaka-hidden)) > .os-scrollbar) {
+  display: none;
+}
+
+:deep(.ft-caption-translation-menu) {
+  display: flex;
+  flex-direction: column;
+  block-size: 100%;
+  overflow: hidden;
+}
+
+:deep(.ft-caption-translation-menu > .shaka-back-to-overflow-button) {
+  flex: 0 0 auto;
+}
+
+:deep(.ft-caption-translation-options) {
+  flex: 1 1 0;
+  block-size: 0;
+  min-block-size: 0;
+  overflow-y: auto;
+  overscroll-behavior: contain;
+}
+
+:deep(.ft-caption-translation-options > button) {
+  box-sizing: border-box;
+  inline-size: 100%;
+}
+
+:deep(.ft-caption-translation-options > .os-scrollbar) {
+  --os-handle-bg: rgb(255 255 255 / 40%);
+  --os-handle-bg-hover: rgb(255 255 255 / 55%);
+  --os-handle-bg-active: rgb(255 255 255 / 70%);
+}
+
+:deep(.ft-caption-translation-options.ft-menu-grid) {
+  display: flex;
+  flex-flow: row wrap;
+  place-content: flex-start center;
+  gap: 4px;
+  padding: 4px;
+}
+
+:deep(.ft-caption-translation-options.ft-menu-grid > button) {
+  flex-wrap: wrap;
+  place-content: center;
+  inline-size: 90px;
+  min-block-size: 40px;
+  padding: 6px 4px;
+  border-radius: calc(10px * var(--ui-roundness));
+  font-size: 11px;
+  line-height: 1.25;
+  text-align: center;
+  background: rgb(255 255 255 / 7%);
+  white-space: normal;
+}
+
+:deep(.ft-caption-translation-options.ft-menu-grid > button:hover),
+:deep(.ft-caption-translation-options.ft-menu-grid > button:focus-visible) {
+  background: rgb(255 255 255 / 20%);
+}
+
+:deep(.ft-caption-translation-options.ft-menu-grid > button > span) {
+  display: -webkit-box;
+  overflow: hidden;
+  max-inline-size: 100%;
+  margin-inline-start: 0;
+  text-align: center;
+  -webkit-box-orient: vertical;
+  line-clamp: 2;
+  -webkit-line-clamp: 2;
+}
+
 :deep(.shaka-bottom-controls) {
   /*
     Force left to right, so that the UI doesn't break.

--- a/src/renderer/components/ft-shaka-video-player/ft-shaka-video-player.css
+++ b/src/renderer/components/ft-shaka-video-player/ft-shaka-video-player.css
@@ -1081,11 +1081,13 @@
   The checkmark would make the selected tile taller than the others, so the
   selection is shown as a highlighted tile instead.
 */
-:deep(.shaka-sub-menu.ft-menu-grid .shaka-ui-icon.shaka-chosen-item) {
+:deep(.shaka-sub-menu.ft-menu-grid .shaka-ui-icon.shaka-chosen-item),
+:deep(.ft-caption-translation-options.ft-menu-grid .shaka-ui-icon.shaka-chosen-item) {
   display: none;
 }
 
-:deep(.shaka-sub-menu.ft-menu-grid > button:has(.shaka-chosen-item)) {
+:deep(.shaka-sub-menu.ft-menu-grid > button:has(.shaka-chosen-item)),
+:deep(.ft-caption-translation-options.ft-menu-grid > button:has(.shaka-chosen-item)) {
   background: color-mix(in srgb, var(--primary-color) 32%, transparent);
 }
 

--- a/src/renderer/components/ft-shaka-video-player/ft-shaka-video-player.js
+++ b/src/renderer/components/ft-shaka-video-player/ft-shaka-video-player.js
@@ -5898,11 +5898,14 @@ export default defineComponent({
       registerOwnElement(shakaOverflowMenu, 'captions', new CaptionSelectionFactory())
     }
 
+    let captionTranslationSelectionGeneration = 0
+
     /**
      * @param {{ url: string, label: string, language: string, mimeType: string }} caption
      * @returns {Promise<boolean>}
      */
     async function selectCaptionTranslation(caption) {
+      const selectionGeneration = ++captionTranslationSelectionGeneration
       let track = findMatchingTextTrack(player.getTextTracks(), caption)
 
       if (!track) {
@@ -5919,6 +5922,10 @@ export default defineComponent({
           handleError(error, 'addTextTrackAsync', caption)
           return false
         }
+      }
+
+      if (selectionGeneration !== captionTranslationSelectionGeneration) {
+        return false
       }
 
       player.selectTextTrack(track)

--- a/src/renderer/components/ft-shaka-video-player/ft-shaka-video-player.js
+++ b/src/renderer/components/ft-shaka-video-player/ft-shaka-video-player.js
@@ -5887,6 +5887,7 @@ export default defineComponent({
             updateCaptionAppearance,
             resetCaptionAppearance,
             () => props.captionTranslations,
+            caption => Boolean(findMatchingTextTrack(player.getTextTracks(), caption)?.active),
             selectCaptionTranslation,
             rootElement,
             controls

--- a/src/renderer/components/ft-shaka-video-player/ft-shaka-video-player.js
+++ b/src/renderer/components/ft-shaka-video-player/ft-shaka-video-player.js
@@ -234,6 +234,10 @@ export default defineComponent({
       type: Array,
       default: () => ([])
     },
+    captionTranslations: {
+      type: Array,
+      default: () => ([])
+    },
     chapters: {
       type: Array,
       default: () => ([])
@@ -4188,7 +4192,10 @@ export default defineComponent({
       // keeps its own layout.
       const submenus = menu.querySelectorAll(':scope > .shaka-sub-menu:not(.ft-caption-appearance-menu)')
       for (const submenu of submenus) {
-        submenu.classList.toggle('ft-menu-grid', usePlayerMenuGrid.value)
+        const isTranslationMenu = submenu.classList.contains('ft-caption-translation-menu')
+        submenu.classList.toggle('ft-menu-grid', usePlayerMenuGrid.value && !isTranslationMenu)
+        submenu.querySelector('.ft-caption-translation-options')
+          ?.classList.toggle('ft-menu-grid', usePlayerMenuGrid.value)
       }
 
       addOverlayScrollbars(menu)
@@ -5879,6 +5886,8 @@ export default defineComponent({
             () => captionSettings.value,
             updateCaptionAppearance,
             resetCaptionAppearance,
+            () => props.captionTranslations,
+            selectCaptionTranslation,
             rootElement,
             controls
           )
@@ -5887,6 +5896,33 @@ export default defineComponent({
 
       registerOwnElement(shakaControls, 'captions', new CaptionSelectionFactory())
       registerOwnElement(shakaOverflowMenu, 'captions', new CaptionSelectionFactory())
+    }
+
+    /**
+     * @param {{ url: string, label: string, language: string, mimeType: string }} caption
+     * @returns {Promise<boolean>}
+     */
+    async function selectCaptionTranslation(caption) {
+      let track = findMatchingTextTrack(player.getTextTracks(), caption)
+
+      if (!track) {
+        try {
+          track = await player.addTextTrackAsync(
+            caption.url,
+            caption.language,
+            'captions',
+            caption.mimeType,
+            undefined,
+            caption.label
+          )
+        } catch (error) {
+          handleError(error, 'addTextTrackAsync', caption)
+          return false
+        }
+      }
+
+      player.selectTextTrack(track)
+      return true
     }
 
     function toggleCaptions() {

--- a/src/renderer/components/ft-shaka-video-player/player-components/CaptionSelection.js
+++ b/src/renderer/components/ft-shaka-video-player/player-components/CaptionSelection.js
@@ -29,19 +29,22 @@ export class CaptionSelection extends shaka.ui.TextSelection {
    * @param {(setting: string, value: string | number) => void} updateSetting
    * @param {() => void} resetSettings
    * @param {() => {id: string, url: string, label: string, translationName: string, language: string, mimeType: string}[]} getTranslations
+   * @param {(caption: {id: string, url: string, label: string, language: string, mimeType: string}) => boolean} isTranslationSelected
    * @param {(caption: {url: string, label: string, language: string, mimeType: string}) => Promise<boolean>} selectTranslation
    * @param {!HTMLElement} parent
    * @param {!shaka.ui.Controls} controls
    */
-  constructor(events, getSettings, updateSetting, resetSettings, getTranslations, selectTranslation, parent, controls) {
+  constructor(events, getSettings, updateSetting, resetSettings, getTranslations, isTranslationSelected, selectTranslation, parent, controls) {
     super(parent, controls)
 
     this.getSettings_ = getSettings
     this.updateSetting_ = updateSetting
     this.resetSettings_ = resetSettings
     this.getTranslations_ = getTranslations
+    this.isTranslationSelected_ = isTranslationSelected
     this.selectTranslation_ = selectTranslation
     this.openColorControl_ = null
+    this.translationOverlayFrame_ = 0
 
     this.optionsButton_ = document.createElement('button')
     this.optionsButton_.type = 'button'
@@ -76,6 +79,7 @@ export class CaptionSelection extends shaka.ui.TextSelection {
     this.translationOptions_ = document.createElement('div')
     this.translationOptions_.classList.add('ft-caption-translation-options')
     this.translationMenu_.appendChild(this.translationOptions_)
+    this.translationButtons_ = []
     this.translationSignature_ = ''
 
     this.appearanceMenu_ = document.createElement('div')
@@ -131,7 +135,9 @@ export class CaptionSelection extends shaka.ui.TextSelection {
       this.setMenuDisplay_(this.menu, false)
       this.setMenuDisplay_(this.translationMenu_, true)
       this.translationBackButton_.focus({ preventScroll: true })
-      requestAnimationFrame(() => {
+      cancelAnimationFrame(this.translationOverlayFrame_)
+      this.translationOverlayFrame_ = requestAnimationFrame(() => {
+        this.translationOverlayFrame_ = 0
         addOverlayScrollbars(this.translationOptions_)
         restoreOverlayScrollTop(this.translationOptions_, 0)
       })
@@ -178,6 +184,8 @@ export class CaptionSelection extends shaka.ui.TextSelection {
   }
 
   release() {
+    cancelAnimationFrame(this.translationOverlayFrame_)
+    this.translationOverlayFrame_ = 0
     removeOverlayScrollbars(this.translationOptions_)
     this.translationMenu_.remove()
     this.appearanceMenu_.remove()
@@ -520,9 +528,10 @@ export class CaptionSelection extends shaka.ui.TextSelection {
     }
 
     this.translationSignature_ = signature
-    for (const button of this.translationOptions_.querySelectorAll(':scope > button')) {
+    for (const button of this.translationButtons_) {
       button.remove()
     }
+    this.translationButtons_ = []
 
     for (const translation of translations) {
       const button = document.createElement('button')
@@ -531,6 +540,7 @@ export class CaptionSelection extends shaka.ui.TextSelection {
       label.textContent = translation.translationName
       button.appendChild(label)
       this.translationOptions_.appendChild(button)
+      this.translationButtons_.push(button)
 
       this.eventManager.listen(button, 'click', async () => {
         button.disabled = true
@@ -538,12 +548,37 @@ export class CaptionSelection extends shaka.ui.TextSelection {
         button.disabled = false
 
         if (selected) {
+          this.updateTranslationSelection_()
           this.setMenuDisplay_(this.translationMenu_, false)
           this.setMenuDisplay_(this.menu, true)
           this.menu.querySelector('.shaka-back-to-overflow-button')?.focus({ preventScroll: true })
           this.resetMenuScroll_(this.menu.parentElement)
         }
       })
+    }
+
+    this.updateTranslationSelection_()
+  }
+
+  /** @private */
+  updateTranslationSelection_() {
+    const translations = this.getTranslations_()
+    for (const [index, translation] of translations.entries()) {
+      const button = this.translationButtons_[index]
+      const label = button.querySelector(':scope > span')
+      const isSelected = this.isTranslationSelected_(translation)
+      label.classList.toggle('shaka-chosen-item', isSelected)
+      button.ariaSelected = isSelected ? 'true' : 'false'
+      button.querySelector(':scope > .shaka-ui-icon.shaka-chosen-item')?.remove()
+      if (isSelected) {
+        const checkmark = new shaka.ui.Icon(
+          null,
+          shaka.ui.Enums.MaterialDesignSVGIcons.CHECKMARK
+        ).getSvgElement()
+        checkmark.classList.add('shaka-chosen-item')
+        checkmark.ariaHidden = 'true'
+        button.prepend(checkmark)
+      }
     }
   }
 

--- a/src/renderer/components/ft-shaka-video-player/player-components/CaptionSelection.js
+++ b/src/renderer/components/ft-shaka-video-player/player-components/CaptionSelection.js
@@ -514,7 +514,7 @@ export class CaptionSelection extends shaka.ui.TextSelection {
   /** @private */
   updateTranslationOptions_() {
     const translations = this.getTranslations_()
-    const signature = translations.map(translation => translation.id).join('\n')
+    const signature = translations.map(translation => `${translation.id}\0${translation.url}`).join('\n')
     if (signature === this.translationSignature_) {
       return
     }

--- a/src/renderer/components/ft-shaka-video-player/player-components/CaptionSelection.js
+++ b/src/renderer/components/ft-shaka-video-player/player-components/CaptionSelection.js
@@ -2,6 +2,11 @@ import shaka from 'shaka-player'
 
 import i18n from '../../../i18n/index'
 import {
+  addOverlayScrollbars,
+  removeOverlayScrollbars,
+  restoreOverlayScrollTop,
+} from '../../../helpers/overlayScrollbars'
+import {
   CAPTION_ANCHORS,
   CAPTION_EDGE_STYLES,
   DEFAULT_CAPTION_SETTINGS,
@@ -23,20 +28,55 @@ export class CaptionSelection extends shaka.ui.TextSelection {
    * @param {() => ReturnType<import('../../../helpers/player/caption-settings').parseCaptionSettings>} getSettings
    * @param {(setting: string, value: string | number) => void} updateSetting
    * @param {() => void} resetSettings
+   * @param {() => {id: string, url: string, label: string, translationName: string, language: string, mimeType: string}[]} getTranslations
+   * @param {(caption: {url: string, label: string, language: string, mimeType: string}) => Promise<boolean>} selectTranslation
    * @param {!HTMLElement} parent
    * @param {!shaka.ui.Controls} controls
    */
-  constructor(events, getSettings, updateSetting, resetSettings, parent, controls) {
+  constructor(events, getSettings, updateSetting, resetSettings, getTranslations, selectTranslation, parent, controls) {
     super(parent, controls)
 
     this.getSettings_ = getSettings
     this.updateSetting_ = updateSetting
     this.resetSettings_ = resetSettings
+    this.getTranslations_ = getTranslations
+    this.selectTranslation_ = selectTranslation
     this.openColorControl_ = null
 
     this.optionsButton_ = document.createElement('button')
     this.optionsButton_.type = 'button'
     this.optionsButton_.classList.add('ft-caption-options-button')
+
+    this.autoTranslateButton_ = document.createElement('button')
+    this.autoTranslateButton_.type = 'button'
+    this.autoTranslateButton_.classList.add('ft-caption-auto-translate-button')
+    this.autoTranslateLabel_ = document.createElement('span')
+    this.autoTranslateButton_.appendChild(this.autoTranslateLabel_)
+
+    this.translationMenu_ = document.createElement('div')
+    this.translationMenu_.classList.add(
+      'shaka-no-propagation',
+      'shaka-show-controls-on-mouse-over',
+      'shaka-hidden',
+      'ft-caption-translation-menu',
+      this.isSubMenu ? 'shaka-sub-menu' : 'shaka-settings-menu'
+    )
+    const translationMenuParent = this.isSubMenu ? parent : controls.getControlsContainer()
+    translationMenuParent.appendChild(this.translationMenu_)
+
+    this.translationBackButton_ = document.createElement('button')
+    this.translationBackButton_.classList.add('shaka-back-to-overflow-button')
+    this.translationMenu_.appendChild(this.translationBackButton_)
+    this.translationBackIcon_ = new shaka.ui.Icon(
+      this.translationBackButton_,
+      shaka.ui.Enums.MaterialDesignSVGIcons.BACK
+    )
+    this.translationBackLabel_ = document.createElement('span')
+    this.translationBackButton_.appendChild(this.translationBackLabel_)
+    this.translationOptions_ = document.createElement('div')
+    this.translationOptions_.classList.add('ft-caption-translation-options')
+    this.translationMenu_.appendChild(this.translationOptions_)
+    this.translationSignature_ = ''
 
     this.appearanceMenu_ = document.createElement('div')
     this.appearanceMenu_.classList.add(
@@ -86,6 +126,24 @@ export class CaptionSelection extends shaka.ui.TextSelection {
       this.appearanceBackButton_.focus()
     })
 
+    this.eventManager.listen(this.autoTranslateButton_, 'click', (event) => {
+      event.stopPropagation()
+      this.setMenuDisplay_(this.menu, false)
+      this.setMenuDisplay_(this.translationMenu_, true)
+      this.translationBackButton_.focus({ preventScroll: true })
+      requestAnimationFrame(() => {
+        addOverlayScrollbars(this.translationOptions_)
+        restoreOverlayScrollTop(this.translationOptions_, 0)
+      })
+    })
+
+    this.eventManager.listen(this.translationBackButton_, 'click', () => {
+      this.setMenuDisplay_(this.translationMenu_, false)
+      this.setMenuDisplay_(this.menu, true)
+      this.autoTranslateButton_.focus({ preventScroll: true })
+      this.resetMenuScroll_(this.menu.parentElement)
+    })
+
     this.eventManager.listen(this.appearanceBackButton_, 'click', () => {
       this.closeColorPopover_()
       this.setMenuDisplay_(this.appearanceMenu_, false)
@@ -105,20 +163,23 @@ export class CaptionSelection extends shaka.ui.TextSelection {
 
     // Shaka rebuilds the language menu whenever tracks or caption state change.
     this.eventManager.listen(this.controls, 'captionselectionupdated', () => {
-      this.addOptionsButton_()
+      this.addCaptionActions_()
     })
 
     this.eventManager.listen(this.controls, 'submenuclose', () => {
       this.closeColorPopover_()
       this.setMenuDisplay_(this.appearanceMenu_, false)
+      this.setMenuDisplay_(this.translationMenu_, false)
     })
 
     this.updateLocalisedStrings_()
     this.updateAppearanceControls_(this.getSettings_())
-    this.addOptionsButton_()
+    this.addCaptionActions_()
   }
 
   release() {
+    removeOverlayScrollbars(this.translationOptions_)
+    this.translationMenu_.remove()
     this.appearanceMenu_.remove()
     super.release()
   }
@@ -308,6 +369,11 @@ export class CaptionSelection extends shaka.ui.TextSelection {
 
     this.optionsButton_.textContent = optionsLabel
     this.optionsButton_.ariaLabel = optionsLabel
+    const autoTranslateLabel = i18n.global.t('Video.Player.Auto-translate')
+    this.autoTranslateLabel_.textContent = autoTranslateLabel
+    this.autoTranslateButton_.ariaLabel = autoTranslateLabel
+    this.translationBackButton_.ariaLabel = this.localization.resolve('BACK')
+    this.translationBackLabel_.textContent = autoTranslateLabel
     this.appearanceBackButton_.ariaLabel = this.localization.resolve('BACK')
     this.appearanceBackLabel_.textContent = title
     this.textColor_.label.textContent = i18n.global.t('Settings.Player Settings.Caption Appearance.Text Color')
@@ -429,9 +495,64 @@ export class CaptionSelection extends shaka.ui.TextSelection {
   }
 
   /** @private */
-  addOptionsButton_() {
+  addCaptionActions_() {
+    this.updateTranslationOptions_()
+
     if (!this.menu.contains(this.optionsButton_)) {
       this.menu.querySelector('.shaka-back-to-overflow-button')?.after(this.optionsButton_)
     }
+
+    if (this.getTranslations_().length > 0) {
+      if (!this.menu.contains(this.autoTranslateButton_)) {
+        this.menu.appendChild(this.autoTranslateButton_)
+      }
+    } else {
+      this.autoTranslateButton_.remove()
+    }
+  }
+
+  /** @private */
+  updateTranslationOptions_() {
+    const translations = this.getTranslations_()
+    const signature = translations.map(translation => translation.id).join('\n')
+    if (signature === this.translationSignature_) {
+      return
+    }
+
+    this.translationSignature_ = signature
+    for (const button of this.translationOptions_.querySelectorAll(':scope > button')) {
+      button.remove()
+    }
+
+    for (const translation of translations) {
+      const button = document.createElement('button')
+      button.type = 'button'
+      const label = document.createElement('span')
+      label.textContent = translation.translationName
+      button.appendChild(label)
+      this.translationOptions_.appendChild(button)
+
+      this.eventManager.listen(button, 'click', async () => {
+        button.disabled = true
+        const selected = await this.selectTranslation_(translation)
+        button.disabled = false
+
+        if (selected) {
+          this.setMenuDisplay_(this.translationMenu_, false)
+          this.setMenuDisplay_(this.menu, true)
+          this.menu.querySelector('.shaka-back-to-overflow-button')?.focus({ preventScroll: true })
+          this.resetMenuScroll_(this.menu.parentElement)
+        }
+      })
+    }
+  }
+
+  /** @private */
+  resetMenuScroll_(scrollViewport) {
+    requestAnimationFrame(() => {
+      if (scrollViewport instanceof HTMLElement) {
+        restoreOverlayScrollTop(scrollViewport, 0)
+      }
+    })
   }
 }

--- a/src/renderer/components/ft-shaka-video-player/player-components/CaptionSelection.js
+++ b/src/renderer/components/ft-shaka-video-player/player-components/CaptionSelection.js
@@ -524,6 +524,7 @@ export class CaptionSelection extends shaka.ui.TextSelection {
     const translations = this.getTranslations_()
     const signature = translations.map(translation => `${translation.id}\0${translation.url}`).join('\n')
     if (signature === this.translationSignature_) {
+      this.updateTranslationSelection_()
       return
     }
 

--- a/src/renderer/views/Watch/Watch.js
+++ b/src/renderer/views/Watch/Watch.js
@@ -300,6 +300,7 @@ export default defineComponent({
       ytDlpStreamsPending: false,
       legacyFormats: [],
       captions: [],
+      captionTranslations: [],
       currentTime: 0,
       showTranscript: false,
       showSidebarChapters: false,
@@ -1623,6 +1624,7 @@ export default defineComponent({
       this.ytDlpStreamsPending = false
       this.legacyFormats = []
       this.captions = []
+      this.captionTranslations = []
       this.currentTime = 0
       if (!preserveShortsPanels) {
         this.showTranscript = false
@@ -2424,6 +2426,10 @@ export default defineComponent({
                   mimeType: 'text/vtt'
                 }
               }) ?? []
+
+              this.captionTranslations = (result.captions.translation_languages ?? []).map(language =>
+                this.getTranslatedCaption(result.captions, language)
+              ).filter(Boolean)
 
               if (captionTracks.length > 0) {
                 const languagesSet = new Set([this.preferredCaptionLocale, this.preferredCaptionLocale.split('-')[0]])
@@ -4310,19 +4316,32 @@ export default defineComponent({
      */
     getTranslatedLocaleCaption: function (captions, userLanguages) {
       // check if we can translate to the users language
-      const translationLanguage = captions.translation_languages.find(language => userLanguages.has(language.language_code))
+      let translationLanguage = captions.translation_languages.find(language => userLanguages.has(language.language_code))
 
-      let translationName, translationCode
       // Otherwise use the preferred caption locale and hope that YouTube can handle it.
       if (!translationLanguage) {
-        translationCode = userLanguages.values().next().value
-        translationName = this.$store.getters.getPreferredCaptionLocale
-          ? new Intl.DisplayNames([this.currentLocale, 'en'], { type: 'language' }).of(translationCode) ?? translationCode
-          : this.t('Locale Name')
-      } else {
-        translationName = translationLanguage.language_name.text
-        translationCode = translationLanguage.language_code
+        const languageCode = userLanguages.values().next().value
+        translationLanguage = {
+          language_code: languageCode,
+          language_name: {
+            text: this.$store.getters.getPreferredCaptionLocale
+              ? new Intl.DisplayNames([this.currentLocale, 'en'], { type: 'language' }).of(languageCode) ?? languageCode
+              : this.t('Locale Name')
+          }
+        }
       }
+
+      return this.getTranslatedCaption(captions, translationLanguage)
+    },
+
+    /**
+     * @param {import('youtubei.js').YTNodes.PlayerCaptionsTracklist} captions
+     * @param {{ language_code: string, language_name: { text: string } }} translationLanguage
+     * @returns {null|{ url: string, label: string, language: string, mimeType: string, isAutotranslated: boolean }}
+     */
+    getTranslatedCaption: function (captions, translationLanguage) {
+      const translationName = translationLanguage.language_name.text
+      const translationCode = translationLanguage.language_code
 
       let trackToTranslate
 
@@ -4336,6 +4355,10 @@ export default defineComponent({
       } else {
         // if there is no auto-generated track choose the first translatable track
         trackToTranslate = captions.caption_tracks.find(track => track.is_translatable) ?? captions.caption_tracks[0]
+      }
+
+      if (!trackToTranslate) {
+        return null
       }
 
       const url = new URL(trackToTranslate.base_url)
@@ -4352,6 +4375,7 @@ export default defineComponent({
         id: `${trackToTranslate.vss_id}.${translationCode}`,
         url: url.toString(),
         label,
+        translationName,
         language: translationCode,
         mimeType: 'text/srt',
         isAutotranslated: true

--- a/src/renderer/views/Watch/Watch.vue
+++ b/src/renderer/views/Watch/Watch.vue
@@ -95,6 +95,7 @@
           :legacy-formats="legacyFormats"
           :start-time="startTimeSeconds"
           :captions="captions"
+          :caption-translations="captionTranslations"
           :storyboard-src="videoStoryboardSrc"
           :annotations="videoAnnotations"
           :hide-annotations="hideEndScreenAnnotations"

--- a/static/locales/en-US.yaml
+++ b/static/locales/en-US.yaml
@@ -1513,6 +1513,7 @@ Video:
       Options: Options
       Title: Caption Appearance
       Sample: Captions look like this
+    Auto-translate: Auto-translate
     Sleep Timer:
       Sleep Timer: Sleep timer
       Off: 'Off'


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Make sure to follow the contributing guidelines. -->
<!-- Important note, we may remove your pull request if you do not use this provided PR template correctly. -->
<!-- Agent instructions: Preserve every heading, comment, and marker in this template. Never remove or rewrite the release-note-category:start/end, release-note:start/end, or release-note-image:start/end marker pairs. Never remove or rewrite the Release note images section; leave its contents for a human. -->

## Pull Request Type
<!-- Please select what type of pull request this is: [x] -->
- [ ] Bugfix
- [x] Feature Implementation
- [ ] Documentation
- [ ] Other

## Related issue
<!-- Please link the issue your pull request is referring to. -->
<!-- If this pull request fully resolves the relevant issue, put "closes" before the issue number. -->
<!-- Example: "closes #123456". -->

Closes #661.

## Description
<!-- Please write a clear and concise description of what the pull request does. -->

OpenTubeX only prepared an automatic caption translation for the preferred caption language, so viewers could not choose any of YouTube's other translation targets.

This adds an Auto-translate submenu containing every language advertised by YouTube. A translated caption track is created only when selected, keeping the initial player load lightweight. The language list supports both player menu layouts and uses a separate scroll viewport below its fixed header.

## Release note category
<!-- Select exactly one category. Every pull request must select one. -->
<!-- Select "Not noteworthy" when the pull request fixes a bug in or improves functionality that has not yet appeared in a stable release. -->
<!-- release-note-category:start -->
- [ ] Not noteworthy
- [ ] Highlights
- [x] More improvements
- [ ] Fixed bugs
<!-- release-note-category:end -->

## Release note
<!-- Required unless "Not noteworthy" is selected. -->
<!-- Write one concise, user-facing entry without a leading bullet. -->
<!-- release-note:start -->

Automatically translate captions into any language offered by YouTube.

<!-- release-note:end -->

## Release note images
<!-- Human-only: Agents must preserve this entire section and leave it empty. -->
<!-- Optional. Paste one or more Markdown images or HTML image tags here. -->
<!-- The release notes will use an HTML image tag and limit images taller than 300 pixels. -->
<!-- release-note-image:start -->
<img width="110" height="62" alt="image" src="https://github.com/user-attachments/assets/217b8fb0-1377-41b3-ae7c-4b64cb1f3028" />
<img width="372" height="315" alt="image" src="https://github.com/user-attachments/assets/a706d1fa-a6b9-41a2-8ceb-9b42db1ca678" />
<!-- release-note-image:end -->

## Testing
<!-- How can reviewers verify that the PR produces correct results? -->
<!-- Please provide instructions so that others can ensure that your pull request would produce correct results. For examples see, https://github.com/FreeTubeApp/FreeTube/pull/5743, https://github.com/FreeTubeApp/FreeTube/pull/7349, https://github.com/FreeTubeApp/FreeTube/pull/5125, https://github.com/FreeTubeApp/FreeTube/pull/7338 -->
<!-- Agent instructions: Only write human-facing steps that explain how to verify the change while running this branch in dev mode. Include expected results and, when applicable, helpful console snippets for interactive verification. Do not include automated checks, commands, results, pass counts, or CI status. -->

1. Open a video with translatable captions and open Captions > Auto-translate.
2. Confirm the complete language list scrolls below a fixed header in both grid and list menu layouts.
3. Select a language other than the preferred caption language and confirm translated captions appear.
4. Reopen the captions menu and confirm it starts at the top and identifies the selected translated track.

## Additional context
<!-- Add any other context about the pull request here. -->
