### PR TITLE
feat(player): morph recommended thumbnails into player

### DIFF
--- a/e2e/tests/offline/watch-page.spec.mjs
+++ b/e2e/tests/offline/watch-page.spec.mjs
@@ -18,6 +18,87 @@ const WATCH_PAGE_SEED = {
 
 test.use({ seed: { settings: WATCH_PAGE_SEED } })
 
+for (const { defaultViewingMode, currentTheatreMode } of [
+  { defaultViewingMode: 'theatre', currentTheatreMode: false },
+  { defaultViewingMode: 'default', currentTheatreMode: true }
+]) {
+  test.describe(`recommended video morph with ${defaultViewingMode} as the default`, () => {
+    test.use({
+      seed: {
+        settings: {
+          ...WATCH_PAGE_SEED,
+          defaultViewingMode
+        }
+      }
+    })
+
+    test(`uses the current ${currentTheatreMode ? 'theatre' : 'default'} layout`, async ({ app, page }) => {
+      await mockPlayableWatchPage(app, page)
+
+      let releaseRecommendedPlayer
+      await page.route(/\/youtubei\/v1\/player/, async (route, request) => {
+        const videoId = JSON.parse(request.postData() ?? '{}').videoId
+        if (videoId === 'recommended-video') {
+          await new Promise(resolve => { releaseRecommendedPlayer = resolve })
+        }
+        return route.fallback()
+      })
+
+      await openMockedVideo(page)
+      const watchView = await watchViewHandle(page)
+      await watchView.evaluate(async (view, theatreMode) => {
+        view.useTheatreMode = theatreMode
+        view.recommendedVideos = [{
+          videoId: 'recommended-video',
+          title: 'Recommended video',
+          author: 'Recommended channel',
+          authorId: 'UC-recommended-channel',
+          lengthSeconds: 60,
+          published: Date.now(),
+          type: 'video'
+        }]
+        await view.$nextTick()
+      }, currentTheatreMode)
+      const lazyRecommendation = page.locator('.watchVideoRecommendations > div').nth(1)
+      await lazyRecommendation.evaluate(element => { element.style.minHeight = '1px' })
+      await lazyRecommendation.scrollIntoViewIfNeeded()
+      const recommendation = page.locator('.watchVideoRecommendations .title', {
+        hasText: 'Recommended video'
+      })
+      await expect(recommendation).toBeVisible()
+
+      await page.evaluate((activeTabSelector) => {
+        const startViewTransition = document.startViewTransition.bind(document)
+        document.startViewTransition = (update) => {
+          window.__recommendedMorph = {
+            sourceName: document.querySelector('.watchVideoRecommendations .thumbnailImage')
+              ?.style.viewTransitionName
+          }
+          return startViewTransition(async () => {
+            await update()
+            const player = document.querySelector(`${activeTabSelector} .videoPlayer`)
+            const layout = document.querySelector(`${activeTabSelector} .videoLayout`)
+            window.__recommendedMorph.destinationName = getComputedStyle(player).viewTransitionName
+            window.__recommendedMorph.usesTheatreLayout = layout.classList.contains('useTheatreMode')
+          })
+        }
+      }, activeTab)
+
+      await recommendation.click()
+      await expect(page).toHaveURL(/#\/watch\/recommended-video/)
+      await expect.poll(() => page.evaluate(() => window.__recommendedMorph)).toEqual({
+        sourceName: 'video-morph',
+        destinationName: 'video-morph',
+        usesTheatreLayout: currentTheatreMode
+      })
+      expect(await watchView.evaluate(view => view.loadingTheatreMode)).toBe(currentTheatreMode)
+
+      await expect.poll(() => typeof releaseRecommendedPlayer).toBe('function')
+      releaseRecommendedPlayer()
+    })
+  })
+}
+
 const FULLSCREEN_PLAYLIST_ID = 'fullscreen-preview'
 const FULLSCREEN_PLAYLIST = {
   _id: FULLSCREEN_PLAYLIST_ID,

--- a/src/renderer/components/FtListVideo/FtListVideo.vue
+++ b/src/renderer/components/FtListVideo/FtListVideo.vue
@@ -1374,7 +1374,8 @@ async function handleWatchPageLinkClick(event) {
   if (opensActiveTab) {
     event.preventDefault()
     requestWatchPageViewTransition(event.currentTarget, {
-      isShort: props.data.isShort === true && store.getters.getUseCustomShortsPlayer
+      isShort: props.data.isShort === true && store.getters.getUseCustomShortsPlayer,
+      allowVisiblePlayer: props.appearance === 'recommendation'
     })
     openInternalPath({
       path: `/watch/${id.value}`,
@@ -1412,7 +1413,8 @@ async function handleWatchPageLinkClick(event) {
   // Plain left click navigates in this tab: morph the thumbnail into the player
   if (event?.button === 0 && !event.ctrlKey && !event.metaKey && !event.shiftKey && !event.altKey) {
     requestWatchPageViewTransition(event.currentTarget, {
-      isShort: props.data.isShort === true && store.getters.getUseCustomShortsPlayer
+      isShort: props.data.isShort === true && store.getters.getUseCustomShortsPlayer,
+      allowVisiblePlayer: props.appearance === 'recommendation'
     })
   }
 }

--- a/src/renderer/helpers/viewTransitions.js
+++ b/src/renderer/helpers/viewTransitions.js
@@ -18,8 +18,9 @@ let shortMorphRequested = false
  * @param {EventTarget | null} linkElement the clicked watch page link
  * @param {object} [options]
  * @param {boolean} [options.isShort] whether the destination uses the Shorts layout
+ * @param {boolean} [options.allowVisiblePlayer] whether the source can be beside the current player
  */
-export function requestWatchPageViewTransition(linkElement, { isShort } = {}) {
+export function requestWatchPageViewTransition(linkElement, { isShort, allowVisiblePlayer = false } = {}) {
   if (typeof document.startViewTransition !== 'function' || isReducedMotionEnabled()) {
     return
   }
@@ -39,14 +40,13 @@ export function requestWatchPageViewTransition(linkElement, { isShort } = {}) {
 
   const thumbnail = findThumbnail(linkElement)
 
-  // Only name the thumbnail when nothing else on the page carries the name
-  // (e.g. the current watch page's player), as duplicate view-transition-names
-  // would abort the transition. Players in hidden background tabs don't count
-  // because display: none elements aren't captured.
+  // Players in hidden background tabs don't count because display: none
+  // elements aren't captured. Recommendations explicitly allow a visible
+  // player: its name is assigned only after the old thumbnail snapshot.
   const hasVisiblePlayer = Array.from(document.querySelectorAll('.videoPlayer'))
     .some((el) => el.offsetParent !== null)
 
-  if (thumbnail instanceof HTMLElement && !hasVisiblePlayer) {
+  if (thumbnail instanceof HTMLElement && (!hasVisiblePlayer || allowVisiblePlayer)) {
     morphSourceElement = thumbnail
     thumbnail.style.viewTransitionName = VIDEO_MORPH_NAME
   }
@@ -131,13 +131,16 @@ export function installViewTransitions(router) {
     shortMorphRequested = false
 
     return new Promise((resolve) => {
-      // Names the watch page's player for the duration of the transition
-      // (a permanent name would force a stacking context on the player,
-      // breaking its full-window mode)
-      document.documentElement.classList.add('viewTransitionMorphActive')
-      document.documentElement.classList.toggle('viewTransitionShortMorphActive', shortMorph)
-
       const transition = document.startViewTransition(() => {
+        // The old snapshot has been captured, so the thumbnail can give its
+        // name to the destination player. This matters for watch-to-watch
+        // navigation where both elements remain mounted during the update.
+        if (source) {
+          source.style.viewTransitionName = ''
+        }
+        document.documentElement.classList.add('viewTransitionMorphActive')
+        document.documentElement.classList.toggle('viewTransitionShortMorphActive', shortMorph)
+
         return new Promise((_resolve) => {
           // Let the navigation proceed, then wait for the new view to render
           const stop = router.afterEach(() => {
@@ -205,8 +208,6 @@ export function takePendingViewTransition(maxAge = 1000) {
   let started = false
   const runTransition = async (update) => {
     started = true
-    document.documentElement.classList.add('viewTransitionMorphActive')
-    document.documentElement.classList.toggle('viewTransitionShortMorphActive', shortMorph)
 
     const cleanup = () => {
       document.documentElement.classList.remove(
@@ -221,6 +222,14 @@ export function takePendingViewTransition(maxAge = 1000) {
     let transition
     try {
       transition = document.startViewTransition(async () => {
+        // The source must lose the shared name before the new snapshot. On a
+        // watch page the recommendations stay mounted while the player updates.
+        if (source) {
+          source.style.viewTransitionName = ''
+        }
+        document.documentElement.classList.add('viewTransitionMorphActive')
+        document.documentElement.classList.toggle('viewTransitionShortMorphActive', shortMorph)
+
         await update()
         await nextTick()
       })

--- a/src/renderer/views/Watch/Watch.js
+++ b/src/renderer/views/Watch/Watch.js
@@ -197,6 +197,9 @@ export default defineComponent({
       // because the instance is reused across same-tab navigation.
       hasBeenPresented: false,
       useTheatreMode: false,
+      // Same-tab navigation keeps the current layout while its skeleton loads.
+      // A newly mounted watch tab falls back to the configured default instead.
+      loadingTheatreMode: null,
       applyDefaultTheatreModeAfterLoad: false,
       theatreLayoutAvailable: window.innerWidth > RESPONSIVE_THEATRE_MODE_MAX_WIDTH,
       videoPlayerLoaded: false,
@@ -932,6 +935,7 @@ export default defineComponent({
   watch: {
     isLoading(loading) {
       if (!loading) {
+        this.loadingTheatreMode = null
         this.shortsTransitionPreview = ''
         this.shortsTransitionDirection = 0
 
@@ -1474,6 +1478,7 @@ export default defineComponent({
     async reloadView({ preserveTitle = false } = {}) {
       const loadGeneration = ++this.videoLoadGeneration
       const requestedVideoId = this.tabRoute.params.id
+      this.loadingTheatreMode = this.useTheatreMode
       preserveTitle ||= this.preserveTitleOnNextReload
       this.preserveTitleOnNextReload = false
 

--- a/src/renderer/views/Watch/Watch.vue
+++ b/src/renderer/views/Watch/Watch.vue
@@ -6,7 +6,9 @@
       ambientModeActive,
       isLoading,
       shortsPlayerActive: customShortsPlayerActive,
-      useTheatreMode: (useTheatreMode && !isLoading) || (isLoading && defaultViewingMode === 'theatre'),
+      useTheatreMode: isLoading
+        ? (loadingTheatreMode ?? (defaultViewingMode === 'theatre'))
+        : useTheatreMode,
       noSidebar: !theatrePossible && !sidebarPanelLeaving
     }"
   >


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Make sure to follow the contributing guidelines. -->
<!-- Important note, we may remove your pull request if you do not use this provided PR template correctly. -->
<!-- Agent instructions: Preserve every heading, comment, and marker in this template. Never remove or rewrite the release-note-category:start/end, release-note:start/end, or release-note-image:start/end marker pairs. Never remove or rewrite the Release note images section; leave its contents for a human. -->

## Pull Request Type
<!-- Please select what type of pull request this is: [x] -->
- [ ] Bugfix
- [x] Feature Implementation
- [ ] Documentation
- [ ] Other

## Related issue
<!-- Please link the issue your pull request is referring to. -->
<!-- If this pull request fully resolves the relevant issue, put "closes" before the issue number. -->
<!-- Example: "closes #123456". -->
Closes #670

## Description
<!-- Please write a clear and concise description of what the pull request does. -->
Recommended videos previously cross-faded into the watch page because the visible player prevented their thumbnails from participating in the existing view transition. The loading skeleton also used the configured default viewing mode instead of the current video's layout, which could make the morph land at the wrong size.

This lets recommendation thumbnails provide the outgoing morph snapshot, transfers the shared transition name to the player after that snapshot is captured, and preserves the current theater-mode choice during same-tab loading. Newly opened watch tabs continue to use the configured default viewing mode.

## Release note category
<!-- Select exactly one category. Every pull request must select one. -->
<!-- Select "Not noteworthy" when the pull request fixes a bug in or improves functionality that has not yet appeared in a stable release. -->
<!-- release-note-category:start -->
- [ ] Not noteworthy
- [ ] Highlights
- [x] More improvements
- [ ] Fixed bugs
<!-- release-note-category:end -->

## Release note
<!-- Required unless "Not noteworthy" is selected. -->
<!-- Write one concise, user-facing entry without a leading bullet. -->
<!-- release-note:start -->
Recommended video thumbnails now morph smoothly into the player.
<!-- release-note:end -->

## Release note images
<!-- Human-only: Agents must preserve this entire section and leave it empty. -->
<!-- Optional. Paste one or more Markdown images or HTML image tags here. -->
<!-- The release notes will use an HTML image tag and limit images taller than 300 pixels. -->
<!-- release-note-image:start -->
<img width="1710" height="884" alt="Screencast_20260813_102646" src="https://github.com/user-attachments/assets/668f9401-8bf1-473b-b53c-5cc2237b6634" />
<!-- release-note-image:end -->

## Testing
<!-- How can reviewers verify that the PR produces correct results? -->
<!-- Please provide instructions so that others can ensure that your pull request would produce correct results. For examples see, https://github.com/FreeTubeApp/FreeTube/pull/5743, https://github.com/FreeTubeApp/FreeTube/pull/7349, https://github.com/FreeTubeApp/FreeTube/pull/5125, https://github.com/FreeTubeApp/FreeTube/pull/7338 -->
<!-- Agent instructions: Only write human-facing steps that explain how to verify the change while running this branch in dev mode. Include expected results and, when applicable, helpful console snippets for interactive verification. Do not include automated checks, commands, results, pass counts, or CI status. -->
1. Open a video with recommendations visible and click a recommended video's thumbnail or title. The thumbnail should morph into the destination player.
2. Set theater mode as the default, exit theater mode on the current video, then open a recommendation. The morph should land on the standard-size player skeleton.
3. Set standard mode as the default, enter theater mode on the current video, then open a recommendation. The morph should land on the theater-size player skeleton.
4. Enable reduced motion and repeat the navigation. The morph animation should remain disabled.

## Additional context
<!-- Add any other context about the pull request here. -->
The player receives its view-transition name only while a morph is active so full-window stacking behavior remains unchanged.
