### PR TITLE
fix(player): prefer SABR over legacy fallback

### DIFF
--- a/e2e/tests/offline/sabr-error-recovery.spec.mjs
+++ b/e2e/tests/offline/sabr-error-recovery.spec.mjs
@@ -221,6 +221,120 @@ test('terminal yt-dlp playback failure restores the built-in source once', async
   })
 })
 
+test('yt-dlp playback refreshes once then prefers built-in SABR over legacy', async ({ app, page }) => {
+  await mockUnplayableWatchPage(app, page)
+  await goTo(page, 'history')
+  await page.getByText('SABR test video').click()
+  await expect(page).toHaveURL(/#\/watch\/jNQXAC9IVRw/)
+  await expect(page.locator('.errorMessage')).toBeVisible({ timeout: 30_000 })
+
+  const result = await page.evaluate(async () => {
+    const app = document.querySelector('#app')?.__vue_app__
+
+    const findWatchView = (vnode) => {
+      if (vnode?.component?.type?.name === 'Watch') return vnode.component.proxy
+      if (vnode?.component?.subTree) {
+        const match = findWatchView(vnode.component.subTree)
+        if (match) return match
+      }
+      if (Array.isArray(vnode?.children)) {
+        for (const child of vnode.children) {
+          const match = findWatchView(child)
+          if (match) return match
+        }
+      }
+      return null
+    }
+
+    const watchView = findWatchView(app?._container?._vnode)
+    if (!watchView) throw new Error('Unable to access the watch view')
+
+    watchView.errorMessage = ''
+    watchView.isLoading = false
+    watchView.isLive = false
+    watchView.isPostLiveDvr = false
+    watchView.activeFormat = 'dash'
+    watchView.activePlaybackEngine = 'yt-dlp'
+    watchView.activePlaybackEngineVersion = 'test'
+    watchView.streamErrorReloadAttemptedForCurrentVideo = false
+    watchView.playbackEngineFallbackAttemptedForCurrentVideo = false
+    watchView.playbackEngineFallbackTarget = null
+    watchView.manifestSrc = 'data:application/dash+xml,yt-dlp'
+    watchView.manifestMimeType = 'application/dash+xml'
+    watchView.legacyFormats = [{ itag: 18 }]
+    watchView.builtInPlaybackSource = {
+      manifestSrc: 'data:application/sabr+json,built-in',
+      manifestMimeType: 'application/sabr+json',
+      sabrData: { scheme: 'sabr-test' },
+      legacyFormats: [],
+      streamingDataExpiryDate: new Date(Date.now() + 60_000)
+    }
+
+    let refreshes = 0
+    watchView.reloadView = async () => {
+      refreshes++
+    }
+    let progressSaves = 0
+    watchView.handleWatchProgressAutoSaveWhenProgressEnabled = () => {
+      progressSaves++
+    }
+
+    const error = { code: 1002, data: ['https://example.invalid/video', 500] }
+    await watchView.handlePlayerError(error)
+    const engineAfterRefresh = watchView.activePlaybackEngine
+    const formatAfterRefresh = watchView.activeFormat
+    await watchView.handlePlayerError(error)
+    const fallbackPlaybackEngine = watchView.activePlaybackEngine
+    const fallbackFormat = watchView.activeFormat
+    const fallbackManifestMimeType = watchView.manifestMimeType
+    const fallbackSabrScheme = watchView.sabrData?.scheme
+
+    watchView.activeFormat = 'dash'
+    watchView.activePlaybackEngine = 'yt-dlp'
+    watchView.playbackEngineFallbackAttemptedForCurrentVideo = false
+    watchView.playbackEngineFallbackTarget = null
+    watchView.manifestSrc = 'data:application/dash+xml,yt-dlp'
+    watchView.manifestMimeType = 'application/dash+xml'
+    watchView.legacyFormats = [{ itag: 18 }]
+    watchView.builtInPlaybackSource = {
+      manifestSrc: null,
+      manifestMimeType: 'application/dash+xml',
+      sabrData: null,
+      legacyFormats: [],
+      streamingDataExpiryDate: null
+    }
+    const emptyBuiltInFallbackApplied = await watchView.tryPlaybackEngineFallback(error)
+
+    return {
+      refreshes,
+      progressSaves,
+      engineAfterRefresh,
+      formatAfterRefresh,
+      fallbackPlaybackEngine,
+      fallbackFormat,
+      fallbackManifestMimeType,
+      fallbackSabrScheme,
+      emptyBuiltInFallbackApplied,
+      engineAfterEmptyBuiltInFallback: watchView.activePlaybackEngine,
+      legacyFormatCount: watchView.legacyFormats.length
+    }
+  })
+
+  expect(result).toEqual({
+    refreshes: 1,
+    progressSaves: 1,
+    engineAfterRefresh: 'yt-dlp',
+    formatAfterRefresh: 'dash',
+    fallbackPlaybackEngine: 'built-in',
+    fallbackFormat: 'dash',
+    fallbackManifestMimeType: 'application/sabr+json',
+    fallbackSabrScheme: 'sabr-test',
+    emptyBuiltInFallbackApplied: false,
+    engineAfterEmptyBuiltInFallback: 'yt-dlp',
+    legacyFormatCount: 1
+  })
+})
+
 test('expired built-in playback source is refreshed before yt-dlp falls back', async ({ app, page }) => {
   await mockUnplayableWatchPage(app, page)
   await goTo(page, 'history')

--- a/src/renderer/views/Watch/Watch.js
+++ b/src/renderer/views/Watch/Watch.js
@@ -3740,6 +3740,7 @@ export default defineComponent({
       }
 
       this.streamErrorReloadAttemptedForCurrentVideo = true
+      this.handleWatchProgressAutoSaveWhenProgressEnabled()
       this.showTabToast({
         message: `${this.t('Video.Reloading video after streaming URL error')}: ${specificError}`,
         icon: ['fas', 'sync'],
@@ -3769,7 +3770,19 @@ export default defineComponent({
           // shaka-player will keep trying until the internet connection returns and resume playback automatically when it does
           return
         }
-      } else if (error.code === Code.BAD_HTTP_STATUS) {
+      }
+
+      // A terminal player error can still come from a transiently bad yt-dlp
+      // URL or extraction. Refresh those streams once before changing format or
+      // restoring the cached built-in source (which may use SABR).
+      if (this.activePlaybackEngine === 'yt-dlp') {
+        const status = error.code === Code.BAD_HTTP_STATUS ? error.data[1] : error.code
+        if (await this.reloadAfterStreamErrorOnce(`[PLAYER_ERROR: ${status}]`)) {
+          return
+        }
+      }
+
+      if (error.code === Code.BAD_HTTP_STATUS) {
         switch (error.data[1]) {
           case 429:
             this.handleWatchProgressAutoSaveWhenProgressEnabled()
@@ -3845,6 +3858,17 @@ export default defineComponent({
           'Refreshing SABR stream after playback error'
         )
       ) { return }
+
+      // yt-dlp legacy formats come from the same extraction as its DASH
+      // formats. Prefer the independent built-in source after the one-shot
+      // yt-dlp refresh above, and keep legacy as the last resort when no
+      // built-in source is available.
+      if (
+        this.activePlaybackEngine === 'yt-dlp' &&
+        await this.tryPlaybackEngineFallback(error)
+      ) {
+        return
+      }
 
       const stopPlaybackRecovery = async () => {
         if (await this.tryPlaybackEngineFallback(error)) {
@@ -3925,7 +3949,11 @@ export default defineComponent({
       const videoId = this.videoId
 
       if (this.activePlaybackEngine === 'yt-dlp') {
-        if (this.builtInPlaybackSource === null) {
+        const source = this.builtInPlaybackSource
+        if (
+          source === null ||
+          (source.manifestSrc === null && source.legacyFormats.length === 0)
+        ) {
           return false
         }
 
@@ -3937,7 +3965,6 @@ export default defineComponent({
           return true
         }
 
-        const source = this.builtInPlaybackSource
         if (
           source.streamingDataExpiryDate !== null &&
           new Date() > source.streamingDataExpiryDate


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Make sure to follow the contributing guidelines. -->
<!-- Important note, we may remove your pull request if you do not use this provided PR template correctly. -->
<!-- Agent instructions: Preserve every heading, comment, and marker in this template. Never remove or rewrite the release-note-category:start/end, release-note:start/end, or release-note-image:start/end marker pairs. Never remove or rewrite the Release note images section; leave its contents for a human. -->

## Pull Request Type
<!-- Please select what type of pull request this is: [x] -->
- [x] Bugfix
- [ ] Feature Implementation
- [ ] Documentation
- [ ] Other

## Related issue
<!-- Please link the issue your pull request is referring to. -->
<!-- If this pull request fully resolves the relevant issue, put "closes" before the issue number. -->
<!-- Example: "closes #123456". -->

## Description
<!-- Please write a clear and concise description of what the pull request does. -->
Transient yt-dlp playback failures could immediately switch DASH playback to legacy formats and then restore the cached built-in source. This meant a recoverable failure could unexpectedly degrade the selected format or end up on SABR only after an unnecessary legacy attempt.

Refresh yt-dlp streams once before falling back. If the refreshed stream also fails, prefer the independent built-in playback source—including SABR—over yt-dlp legacy formats. Legacy remains the last resort when no built-in source is available.

## Release note category
<!-- Select exactly one category. Every pull request must select one. -->
<!-- Select "Not noteworthy" when the pull request fixes a bug in or improves functionality that has not yet appeared in a stable release. -->
<!-- release-note-category:start -->
- [ ] Not noteworthy
- [ ] Highlights
- [ ] More improvements
- [x] Fixed bugs
<!-- release-note-category:end -->

## Release note
<!-- Required unless "Not noteworthy" is selected. -->
<!-- Write one concise, user-facing entry without a leading bullet. -->
<!-- release-note:start -->
Fixed yt-dlp playback falling back to legacy formats before retrying or switching to built-in streaming.
<!-- release-note:end -->

## Release note images
<!-- Human-only: Agents must preserve this entire section and leave it empty. -->
<!-- Optional. Paste one or more Markdown images or HTML image tags here. -->
<!-- The release notes will use an HTML image tag and limit images taller than 300 pixels. -->
<!-- release-note-image:start -->

<!-- release-note-image:end -->

## Testing
<!-- How can reviewers verify that the PR produces correct results? -->
<!-- Please provide instructions so that others can ensure that your pull request would produce correct results. For examples see, https://github.com/FreeTubeApp/FreeTube/pull/5743, https://github.com/FreeTubeApp/FreeTube/pull/7349, https://github.com/FreeTubeApp/FreeTube/pull/5125, https://github.com/FreeTubeApp/FreeTube/pull/7338 -->
<!-- Agent instructions: Only write human-facing steps that explain how to verify the change while running this branch in dev mode. Include expected results and, when applicable, helpful console snippets for interactive verification. Do not include automated checks, commands, results, pass counts, or CI status. -->
1. Configure yt-dlp as the stream extraction method and play a video with DASH and legacy formats available.
2. Interrupt a yt-dlp DASH stream long enough to produce a terminal player error, then restore connectivity. The video should refresh yt-dlp once and remain on DASH.
3. Make the refreshed yt-dlp stream fail again. The media formats menu should report the built-in engine and SABR rather than legacy playback.

## Additional context
<!-- Add any other context about the pull request here. -->
The fallback remains bounded to one refresh and one engine switch per video.
