### PR TITLE
fix(player): align resolution status styling

### DIFF
--- a/e2e/tests/offline/player.spec.mjs
+++ b/e2e/tests/offline/player.spec.mjs
@@ -170,6 +170,30 @@ test('the overflow menu can turn the zoom off again', async ({ app, page, attach
   expect(await overflowMenu.locator(':scope > button').evaluateAll((buttons) => {
     return buttons.every((button) => getComputedStyle(button).flexDirection === 'column')
   })).toBe(true)
+  const statusTypography = await overflowMenu.evaluate((menu) => {
+    // The local fixture uses a legacy format, so reproduce Shaka's additional
+    // wrapper around the standard resolution status in the live menu.
+    const button = document.createElement('button')
+    button.innerHTML = `
+      <label class="shaka-overflow-button-label">
+        <span><span class="shaka-current-selection-span">1080p60</span></span>
+      </label>`
+    menu.append(button)
+
+    const resolutionStatus = button.querySelector('.shaka-current-selection-span')
+    const playbackRateStatus = menu.querySelector(
+      '.shaka-playbackrate-button .shaka-current-selection-span'
+    )
+    const typography = (element) => {
+      const { color, fontSize, opacity } = getComputedStyle(element)
+      return { color, fontSize, opacity }
+    }
+    const result = [typography(resolutionStatus), typography(playbackRateStatus)]
+    button.remove()
+    return result
+  })
+  expect(statusTypography[0]).toEqual(statusTypography[1])
+  expect(statusTypography[0]).toMatchObject({ fontSize: '10px', opacity: '0.75' })
   const overflowMenuHeight = (await overflowMenu.boundingBox()).height
 
   await overflowMenu.getByRole('button', { name: 'Zoom' }).click()

--- a/src/renderer/components/ft-shaka-video-player/ft-shaka-video-player.css
+++ b/src/renderer/components/ft-shaka-video-player/ft-shaka-video-player.css
@@ -987,7 +987,7 @@
 }
 
 /* The current value (`On`, `2x`, the chapter title, …) stays on a single line. */
-:deep(.shaka-overflow-menu.ft-menu-grid .shaka-overflow-button-label > .shaka-current-selection-span) {
+:deep(.shaka-overflow-menu.ft-menu-grid .shaka-overflow-button-label .shaka-current-selection-span) {
   max-inline-size: 100%;
   padding-inline-start: 0;
   overflow: hidden;


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Make sure to follow the contributing guidelines. -->
<!-- Important note, we may remove your pull request if you do not use this provided PR template correctly. -->
<!-- Agent instructions: Preserve every heading, comment, and marker in this template. Never remove or rewrite the release-note-category:start/end, release-note:start/end, or release-note-image:start/end marker pairs. Never remove or rewrite the Release note images section; leave its contents for a human. -->

## Pull Request Type
<!-- Please select what type of pull request this is: [x] -->
- [x] Bugfix
- [ ] Feature Implementation
- [ ] Documentation
- [ ] Other

## Related issue
<!-- Please link the issue your pull request is referring to. -->
<!-- If this pull request fully resolves the relevant issue, put "closes" before the issue number. -->
<!-- Example: "closes #123456". -->

## Description
<!-- Please write a clear and concise description of what the pull request does. -->
The resolution value in the player overflow menu used a larger, brighter style than other current-state indicators. Shaka wraps this particular value in an additional element, so the grid-menu selector did not reach it.

This broadens the selector to cover nested current-state indicators and adds regression coverage for the computed typography.

## Release note category
<!-- Select exactly one category. Every pull request must select one. -->
<!-- Select "Not noteworthy" when the pull request fixes a bug in or improves functionality that has not yet appeared in a stable release. -->
<!-- release-note-category:start -->
- [ ] Not noteworthy
- [ ] Highlights
- [ ] More improvements
- [x] Fixed bugs
<!-- release-note-category:end -->

## Release note
<!-- Required unless "Not noteworthy" is selected. -->
<!-- Write one concise, user-facing entry without a leading bullet. -->
<!-- release-note:start -->
Made the resolution value consistent with other status text in the player menu.
<!-- release-note:end -->

## Release note images
<!-- Human-only: Agents must preserve this entire section and leave it empty. -->
<!-- Optional. Paste one or more Markdown images or HTML image tags here. -->
<!-- The release notes will use an HTML image tag and limit images taller than 300 pixels. -->
<!-- release-note-image:start -->

<!-- release-note-image:end -->

## Testing
<!-- How can reviewers verify that the PR produces correct results? -->
<!-- Please provide instructions so that others can ensure that your pull request would produce correct results. For examples see, https://github.com/FreeTubeApp/FreeTube/pull/5743, https://github.com/FreeTubeApp/FreeTube/pull/7349, https://github.com/FreeTubeApp/FreeTube/pull/5125, https://github.com/FreeTubeApp/FreeTube/pull/7338 -->
<!-- Agent instructions: Only write human-facing steps that explain how to verify the change while running this branch in dev mode. Include expected results and, when applicable, helpful console snippets for interactive verification. Do not include automated checks, commands, results, pass counts, or CI status. -->
1. Play a video with a standard resolution such as 1080p60.
2. Set the playback speed to a value such as 2x.
3. Open the player's overflow menu.
4. Confirm the resolution and playback-speed values use the same font size, color, and opacity.

## Additional context
<!-- Add any other context about the pull request here. -->
