### PR TITLE
fix(player): recover from watch page IP blocks

### DIFF
--- a/e2e/tests/offline/watch-page.spec.mjs
+++ b/e2e/tests/offline/watch-page.spec.mjs
@@ -210,8 +210,21 @@ test.describe('watch page', () => {
     }))).toEqual({
       ipBlockDetected: true,
       fallbackAttempted: true,
-      fallbackTarget: 'yt-dlp'
+      fallbackTarget: null
     })
+
+    expect(await watchView.evaluate(async (view) => {
+      let recoveryCalls = 0
+      view.ipBlockDetectedInCurrentChain = true
+      view.playbackEngineFallbackTarget = 'yt-dlp'
+      view.extractYtDlpPlaybackSource = async () => false
+      view.runIpBlockRecoveryScriptAndReload = async () => {
+        recoveryCalls++
+        return true
+      }
+      await view.applyYtDlpPlaybackSource(view.videoLoadGeneration, view.videoId)
+      return recoveryCalls
+    })).toBe(1)
   })
 
   test('falls back to yt-dlp when the built-in live source has no manifest', async ({ app, page }) => {

--- a/e2e/tests/offline/watch-page.spec.mjs
+++ b/e2e/tests/offline/watch-page.spec.mjs
@@ -181,6 +181,39 @@ async function mockTranslatedEndscreen(app, page) {
 }
 
 test.describe('watch page', () => {
+  test('an IP-blocked HTML watch page makes the built-in engine try yt-dlp', async ({ app, page }) => {
+    await mockPlayableWatchPage(app, page)
+    await page.route(/^https:\/\/www\.youtube\.com\/watch\?/, (route) => route.fulfill({
+      status: 429,
+      contentType: 'text/html',
+      body: '<title>Sorry...</title>'
+    }))
+    await app.electronApp.evaluate(({ ipcMain }) => {
+      globalThis.__ytDlpIpBlockFallbackCalls = 0
+      ipcMain.removeHandler('yt-dlp-get-playback-info')
+      ipcMain.handle('yt-dlp-get-playback-info', () => {
+        globalThis.__ytDlpIpBlockFallbackCalls++
+        return { error: 'ENOENT' }
+      })
+    })
+
+    await page.locator(sel.searchInput).fill('https://www.youtube.com/watch?v=jNQXAC9IVRw')
+    await page.locator(sel.searchInput).press('Enter')
+    await expect(page).toHaveURL(/#\/watch\/jNQXAC9IVRw/)
+
+    await expect.poll(() => app.electronApp.evaluate(() => globalThis.__ytDlpIpBlockFallbackCalls)).toBe(1)
+    const watchView = await watchViewHandle(page)
+    expect(await watchView.evaluate((view) => ({
+      ipBlockDetected: view.ipBlockDetectedInCurrentChain,
+      fallbackAttempted: view.playbackEngineFallbackAttemptedForCurrentVideo,
+      fallbackTarget: view.playbackEngineFallbackTarget
+    }))).toEqual({
+      ipBlockDetected: true,
+      fallbackAttempted: true,
+      fallbackTarget: 'yt-dlp'
+    })
+  })
+
   test('falls back to yt-dlp when the built-in live source has no manifest', async ({ app, page }) => {
     await mockPlayableWatchPage(app, page)
     await page.locator(sel.searchInput).fill('https://www.youtube.com/watch?v=jNQXAC9IVRw')

--- a/src/renderer/helpers/api/local.js
+++ b/src/renderer/helpers/api/local.js
@@ -406,7 +406,7 @@ export async function getLocalSearchContinuation(continuationData) {
  */
 async function getWatchHTMLWatchPage(videoId, fetchFunc) {
   // This returns session/tracking cookies but they get removed in onHeadersReceived in the main process before they are saved by Electron
-  const htmlResponse = await fetch(`https://www.youtube.com/watch?v=${videoId}&bpctr=9999999999&has_verified=1`,
+  const htmlResponse = await fetchFunc(`https://www.youtube.com/watch?v=${videoId}&bpctr=9999999999&has_verified=1`,
     {
       headers: {
         // We need to be able to parse the localised strings in the /next response data (e.g. view counts and published dates)
@@ -415,12 +415,22 @@ async function getWatchHTMLWatchPage(videoId, fetchFunc) {
     }
   )
 
+  const isIpBlockResponse = htmlResponse.status === 429 || htmlResponse.url.startsWith('https://www.google.com/sorry/')
+
+  if (!htmlResponse.ok) {
+    const error = new Error(`YouTube returned HTTP ${htmlResponse.status} for the HTML watch page`)
+    error.isIpBlock = isIpBlockResponse
+    throw error
+  }
+
   const htmlPage = await htmlResponse.text()
 
   const ytConfigStr = htmlPage.match(/ytcfg\.set\(({.+?})\);/s)?.[1]
   if (!ytConfigStr) {
     // required for botguard
-    throw new Error('Could not find ytcfg in the HTML page')
+    const error = new Error('Could not find ytcfg in the HTML page')
+    error.isIpBlock = isIpBlockResponse
+    throw error
   }
 
   const ytConfig = JSON.parse(ytConfigStr)
@@ -542,13 +552,15 @@ function buildSessionFromYtConfig(ytConfig, fetchFunc) {
  *   },
  *   adEndTimeUnixMs: number,
  *   paidPromotionDurationMs: number | null,
- *   isPremiere: boolean | undefined
+ *   isPremiere: boolean | undefined,
+ *   watchPageIpBlocked: boolean
  * }>}
  */
 export async function getLocalVideoInfo(id) {
   let responseTime
   let paidPromotionDurationMs = null
   let isPremiere
+  let watchPageIpBlocked = false
 
   const fetchFunc = async (input, init) => {
     if (!(input.url?.startsWith('https://www.youtube.com/youtubei/v1/player'))) {
@@ -573,15 +585,40 @@ export async function getLocalVideoInfo(id) {
     })
   }
 
-  const htmlExtracts = await getWatchHTMLWatchPage(id, fetchFunc)
-  responseTime = Date.now()
+  let htmlExtracts
+  let player
+
+  try {
+    htmlExtracts = await getWatchHTMLWatchPage(id, fetchFunc)
+    responseTime = Date.now()
+  } catch (error) {
+    if (!error.isIpBlock) {
+      throw error
+    }
+
+    watchPageIpBlocked = true
+
+    try {
+      const innertube = await createInnertube({
+        withPlayer: true,
+        generateSessionLocally: false,
+        fetchFunc,
+      })
+
+      htmlExtracts = { session: innertube.session }
+      player = innertube.session.player
+    } catch (fallbackError) {
+      fallbackError.isIpBlock = true
+      throw fallbackError
+    }
+  }
 
   if (htmlExtracts.playerResponse) {
     paidPromotionDurationMs ??= getPaidPromotionDurationMs(htmlExtracts.playerResponse)
     isPremiere ??= getLocalPremiereState(htmlExtracts.playerResponse.videoDetails)
   }
 
-  const player = await Player.create(
+  player ??= await Player.create(
     process.env.IS_ELECTRON ? new PlayerCache() : new UniversalCache(false),
     (input, init) => fetch(input, init),
     undefined,
@@ -592,7 +629,7 @@ export async function getLocalVideoInfo(id) {
   // based on the videoId
   let contentPoToken
 
-  if (process.env.IS_ELECTRON) {
+  if (process.env.IS_ELECTRON && !watchPageIpBlocked) {
     try {
       contentPoToken = await window.ftElectron.generatePoToken(
         id,
@@ -710,7 +747,7 @@ export async function getLocalVideoInfo(id) {
 
   if ((info.playability_status.status === 'UNPLAYABLE' && (!hasTrailer || trailerIsAgeRestricted)) ||
     info.playability_status.status === 'LOGIN_REQUIRED') {
-    return { info, poToken: undefined, clientInfo, paidPromotionDurationMs, isPremiere }
+    return { info, poToken: undefined, clientInfo, paidPromotionDurationMs, isPremiere, watchPageIpBlocked }
   }
 
   if (hasTrailer && info.playability_status.status !== 'OK') {
@@ -777,6 +814,7 @@ export async function getLocalVideoInfo(id) {
     adEndTimeUnixMs,
     paidPromotionDurationMs,
     isPremiere,
+    watchPageIpBlocked,
   }
 }
 

--- a/src/renderer/views/Watch/Watch.js
+++ b/src/renderer/views/Watch/Watch.js
@@ -4117,6 +4117,21 @@ export default defineComponent({
         if (
           !sourceApplied &&
           this.isCurrentVideoLoad(loadGeneration, videoId) &&
+          this.playbackEngineFallbackTarget === 'yt-dlp' &&
+          this.ipBlockDetectedInCurrentChain
+        ) {
+          this.playbackEngineFallbackTarget = null
+          const didReload = await this.runIpBlockRecoveryScriptAndReload()
+          if (!this.isCurrentVideoLoad(loadGeneration, videoId) || didReload) {
+            return
+          }
+          this.errorMessage = this.t('Video.IP block')
+          return
+        }
+
+        if (
+          !sourceApplied &&
+          this.isCurrentVideoLoad(loadGeneration, videoId) &&
           this.manifestSrc === null &&
           this.legacyFormats.length === 0
         ) {

--- a/src/renderer/views/Watch/Watch.js
+++ b/src/renderer/views/Watch/Watch.js
@@ -2004,7 +2004,20 @@ export default defineComponent({
         const videoInfo = await getLocalVideoInfo(videoId)
         if (!this.isCurrentVideoLoad(loadGeneration, videoId)) { return }
 
-        const { info: result, poToken, clientInfo, adEndTimeUnixMs, paidPromotionDurationMs, isPremiere } = videoInfo
+        const { info: result, poToken, clientInfo, adEndTimeUnixMs, paidPromotionDurationMs, isPremiere, watchPageIpBlocked } = videoInfo
+
+        if (watchPageIpBlocked) {
+          this.ipBlockDetectedInCurrentChain = true
+
+          if (process.env.IS_ELECTRON && this.videoPlaybackEngine === 'built-in') {
+            this.playbackEngineFallbackAttemptedForCurrentVideo = true
+            this.playbackEngineFallbackTarget = 'yt-dlp'
+            this.showTabToast({
+              message: this.t('Change Format.Built-in Fallback Template', { error: this.t('Video.IP block') }),
+              icon: ['fas', 'exchange-alt'],
+            })
+          }
+        }
 
         const playabilityStatus = result.playability_status
         this.playabilityStatus = playabilityStatus.status
@@ -2274,7 +2287,13 @@ export default defineComponent({
             }
           }
 
-          if (this.backendFallback) {
+          const tryingYtDlpForIpBlock =
+            this.playbackEngineFallbackTarget === 'yt-dlp' &&
+            this.ipBlockDetectedInCurrentChain
+
+          if (tryingYtDlpForIpBlock) {
+            console.warn('Built-in metadata is IP blocked; continuing so yt-dlp can provide the playback source')
+          } else if (this.backendFallback) {
             throw new Error(errorText)
           } else {
             const didReload = await this.runIpBlockRecoveryScriptAndReload()
@@ -2457,7 +2476,7 @@ export default defineComponent({
 
               this.captions = sortCaptions(captionTracks, this.preferredCaptionLocale)
             }
-          } else {
+          } else if (this.playbackEngineFallbackTarget !== 'yt-dlp') {
             // video might be region locked or something else. This leads to no formats being available
             this.showTabToast({
               message: this.t('This video is unavailable because of missing formats. This can happen due to country unavailability.'),
@@ -2466,6 +2485,8 @@ export default defineComponent({
             })
             this.handleVideoEnded()
             return
+          } else {
+            console.warn('Built-in metadata has no streams; continuing so yt-dlp can provide the playback source')
           }
 
           let storyboard
@@ -2491,6 +2512,7 @@ export default defineComponent({
               ?.projection_type ?? null
 
             if (
+              poToken &&
               videoInfo.info.streaming_data?.server_abr_streaming_url &&
               videoInfo.info.player_config.media_common_config.media_ustreamer_request_config
             ) {
@@ -2561,10 +2583,16 @@ export default defineComponent({
       } catch (err) {
         if (!this.isCurrentVideoLoad(loadGeneration, videoId)) { return }
 
-        console.error(err)
-        if (this.backendPreference === 'local' && this.backendFallback && !err.toString().includes('private') && !err.toString().includes('unavailable')) {
+        let handledError = err
+        if (err.isIpBlock) {
+          this.ipBlockDetectedInCurrentChain = true
+          handledError = new Error(this.t('Video.IP block'), { cause: err })
+        }
+
+        console.error(handledError)
+        if (this.backendPreference === 'local' && this.backendFallback && !handledError.toString().includes('private') && !handledError.toString().includes('unavailable')) {
           const errorMessage = this.t('Local API Error (Click to copy)')
-          showApiErrorToast(errorMessage, err, this.showTabToast)
+          showApiErrorToast(errorMessage, handledError, this.showTabToast)
           this.showTabToast({ message: this.t('Falling back to Invidious API'), icon: ['fas', 'exchange-alt'] })
           this.getVideoInformationInvidious(loadGeneration)
         } else {
@@ -2578,7 +2606,7 @@ export default defineComponent({
           if (!this.thumbnail) {
             this.thumbnail = this.getUnavailableVideoThumbnail()
           }
-          this.errorMessage = err.message || err.toString()
+          this.errorMessage = handledError.message || handledError.toString()
         }
       }
     },


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Make sure to follow the contributing guidelines. -->
<!-- Important note, we may remove your pull request if you do not use this provided PR template correctly. -->
<!-- Agent instructions: Preserve every heading, comment, and marker in this template. Never remove or rewrite the release-note-category:start/end, release-note:start/end, or release-note-image:start/end marker pairs. Never remove or rewrite the Release note images section; leave its contents for a human. -->

## Pull Request Type
<!-- Please select what type of pull request this is: [x] -->
- [x] Bugfix
- [ ] Feature Implementation
- [ ] Documentation
- [ ] Other

## Related issue
<!-- Please link the issue your pull request is referring to. -->
<!-- If this pull request fully resolves the relevant issue, put "closes" before the issue number. -->
<!-- Example: "closes #123456". -->

## Description
<!-- Please write a clear and concise description of what the pull request does. -->
YouTube can rate-limit the HTML watch page and redirect it to a captcha response. Since local video loading now requires configuration from that page, this surfaced as a missing `ytcfg` error before any playback engine could run.

This detects that response as an IP block, retrieves metadata through the Innertube fallback, and lets built-in playback try yt-dlp before the existing IP-block recovery flow continues. SABR is also skipped when the blocked response cannot provide a PoToken.

## Release note category
<!-- Select exactly one category. Every pull request must select one. -->
<!-- Select "Not noteworthy" when the pull request fixes a bug in or improves functionality that has not yet appeared in a stable release. -->
<!-- release-note-category:start -->
- [ ] Not noteworthy
- [ ] Highlights
- [ ] More improvements
- [x] Fixed bugs
<!-- release-note-category:end -->

## Release note
<!-- Required unless "Not noteworthy" is selected. -->
<!-- Write one concise, user-facing entry without a leading bullet. -->
<!-- release-note:start -->
Treat blocked YouTube watch pages as IP blocks and try yt-dlp playback instead of leaving videos stuck loading.
<!-- release-note:end -->

## Release note images
<!-- Human-only: Agents must preserve this entire section and leave it empty. -->
<!-- Optional. Paste one or more Markdown images or HTML image tags here. -->
<!-- The release notes will use an HTML image tag and limit images taller than 300 pixels. -->
<!-- release-note-image:start -->

<!-- release-note-image:end -->

## Testing
<!-- How can reviewers verify that the PR produces correct results? -->
<!-- Please provide instructions so that others can ensure that your pull request produces correct results. For examples see, https://github.com/FreeTubeApp/FreeTube/pull/5743, https://github.com/FreeTubeApp/FreeTube/pull/7349, https://github.com/FreeTubeApp/FreeTube/pull/5125, https://github.com/FreeTubeApp/FreeTube/pull/7338 -->
<!-- Agent instructions: Only write human-facing steps that explain how to verify the change while running this branch in dev mode. Include expected results and, when applicable, helpful console snippets for interactive verification. Do not include automated checks, commands, results, pass counts, or CI status. -->
1. Run the app in dev mode from an IP for which the YouTube HTML watch page returns HTTP 429 or redirects to `google.com/sorry`.
2. Select the built-in stream extraction method and open a video.
3. Confirm the error is treated as an IP block and yt-dlp is attempted instead of the page remaining on its loading skeletons.
4. If an IP-block recovery script is configured, make yt-dlp fail and confirm the existing recovery flow still runs.

## Additional context
<!-- Add any other context about the pull request here. -->
The HTML watch page is more likely to trigger YouTube captchas than Innertube requests, while its BotGuard configuration remains necessary whenever the page is available.
