### PR TITLE
fix(tabs): keep background watch loading state accurate

### DIFF
--- a/e2e/tests/network/watch.spec.mjs
+++ b/e2e/tests/network/watch.spec.mjs
@@ -196,7 +196,7 @@ test.describe('background watch tab', () => {
     await expect(page.locator('.commentsTitle')).toBeVisible()
   })
 
-  test('does not show a stale loading indicator after leaving a loaded video tab', async ({ page }) => {
+  test('keeps reporting genuine loading after leaving a video tab', async ({ page }) => {
     await openVideo(page)
 
     const videoTab = page.locator(sel.tabs).first()
@@ -229,8 +229,8 @@ test.describe('background watch tab', () => {
 
     expect(await page.evaluate(
       () => window.__videoTabShowedLoadingAfterDeactivation
-    )).toBe(false)
-    await expect(videoTab).not.toHaveClass(/loading/)
+    )).toBe(true)
+    await expect(videoTab).toHaveClass(/loading/)
 
     await videoTab.click()
     await expect(videoTab).toHaveClass(/loading/)
@@ -239,7 +239,7 @@ test.describe('background watch tab', () => {
     ).toHaveCount(1)
   })
 
-  test('restores loading updates when tab activation is rejected', async ({ page }) => {
+  test('keeps loading updates when tab activation is rejected', async ({ page }) => {
     await openVideo(page)
 
     const videoTab = page.locator(sel.tabs).first()

--- a/e2e/tests/offline/watch-page.spec.mjs
+++ b/e2e/tests/offline/watch-page.spec.mjs
@@ -18,6 +18,53 @@ const WATCH_PAGE_SEED = {
 
 test.use({ seed: { settings: WATCH_PAGE_SEED } })
 
+test('a background watch tab stays loading until its cached avatar is ready', async ({ app, page }) => {
+  await mockPlayableWatchPage(app, page)
+
+  await page.evaluate(() => {
+    const store = document.querySelector('#app').__vue_app__.config.globalProperties.$store
+    store.commit('setVideoAvatar', {
+      videoId: 'jNQXAC9IVRw',
+      avatar: 'data:image/png;base64,iVBORw0KGgo='
+    })
+
+    window.__backgroundWatchIconStates = []
+    const record = () => {
+      for (const tab of document.querySelectorAll('.tab')) {
+        window.__backgroundWatchIconStates.push({
+          id: tab.dataset.tabId,
+          loading: tab.querySelector('.loadingDot') != null,
+          avatar: tab.querySelector('.tabAvatar') != null,
+          pageIcon: tab.querySelector('.tabPageIcon') != null
+        })
+      }
+    }
+    new MutationObserver(record).observe(
+      document.querySelector('.tabsContainer'),
+      { childList: true, subtree: true }
+    )
+  })
+
+  const watchTab = await page.evaluate(() => window.ftElectron.tabs.create({
+    route: '/watch/jNQXAC9IVRw',
+    title: 'Cached video',
+    makeActive: false,
+    preloadInBackground: true
+  }))
+  const tab = page.locator(`.tab[data-tab-id="${watchTab.id}"]`)
+
+  await expect(tab.locator('.loadingDot')).toBeVisible()
+  await expect(tab.locator('.loadingDot')).toHaveCount(0)
+  await expect(tab.locator('.tabAvatar')).toBeVisible()
+
+  const states = await page.evaluate(
+    tabId => window.__backgroundWatchIconStates.filter(state => state.id === tabId),
+    watchTab.id
+  )
+  expect(states.some(state => state.loading)).toBe(true)
+  expect(states.some(state => state.pageIcon)).toBe(false)
+})
+
 for (const { defaultViewingMode, currentTheatreMode } of [
   { defaultViewingMode: 'theatre', currentTheatreMode: false },
   { defaultViewingMode: 'default', currentTheatreMode: true }

--- a/src/main/tabs/TabManager.js
+++ b/src/main/tabs/TabManager.js
@@ -1071,7 +1071,7 @@ export class TabManager {
       this._deferredCloseTabIds.has(tabId) ||
       this._deferredUnloadTabIds.has(tabId)
     ) {
-      return false
+      return
     }
 
     const previousActiveId = this.activeTabId
@@ -1080,7 +1080,7 @@ export class TabManager {
       tab.pendingActivation !== true &&
       tab.loadState !== 'unloaded'
     ) {
-      return true
+      return
     }
 
     const outgoingTabId = this.presentedTabId ?? previousActiveId
@@ -1103,7 +1103,6 @@ export class TabManager {
     this.bridge.send(IpcChannels.TABS_ACTIVE_CHANGED, tabId, this.selectionRevision)
     this._broadcastStateUpdate()
     this._saveSession()
-    return true
   }
 
   /**
@@ -3007,12 +3006,11 @@ export async function setupTabsIPC(options = {}) {
     }
   })
 
-  ipcMain.handle(IpcChannels.TABS_ACTIVATE, (event, tabId) => {
+  ipcMain.on(IpcChannels.TABS_ACTIVATE, (event, tabId) => {
     const manager = getManager(event)
     if (manager && typeof tabId === 'string') {
-      return manager.activateTab(tabId)
+      manager.activateTab(tabId)
     }
-    return false
   })
 
   ipcMain.on(IpcChannels.TABS_SET_SELECTED, (event, tabIds) => {

--- a/src/preload/interface.js
+++ b/src/preload/interface.js
@@ -814,10 +814,9 @@ export default {
     /**
      * Activate a tab
      * @param {string} tabId
-     * @returns {Promise<boolean>}
      */
     activate: (tabId) => {
-      return ipcRenderer.invoke(IpcChannels.TABS_ACTIVATE, tabId)
+      ipcRenderer.send(IpcChannels.TABS_ACTIVATE, tabId)
     },
 
     /**

--- a/src/renderer/store/modules/tabs.js
+++ b/src/renderer/store/modules/tabs.js
@@ -1,5 +1,4 @@
 import packageDetails from '../../../../package.json'
-import { getTabNavigationService } from '../../tabs/TabNavigationService'
 import { getTabPageIcon } from '../../tabs/tabPageIcon'
 import { DEFAULT_VIDEO_ZOOM } from '../../helpers/player/videoZoom'
 
@@ -211,39 +210,16 @@ const mutations = {
   }
 }
 
-function prepareTabActivationLoading(state, payload) {
-  const outgoingTabId = state.activeTabId
-  const incomingTabId = payload.activeTabId ?? null
-  if (!outgoingTabId || !incomingTabId || outgoingTabId === incomingTabId) {
-    return payload
-  }
-
-  const navigation = getTabNavigationService()
-  navigation.setLoadingSuppressed(incomingTabId, false)
-  const outgoingTab = state.tabs.find(tab => tab.id === outgoingTabId)
-  if (!outgoingTab?.route?.path?.startsWith('/watch/')) {
-    return payload
-  }
-
-  navigation.setLoadingSuppressed(outgoingTabId, true)
-  return {
-    ...payload,
-    tabs: payload.tabs?.map(tab => tab.id === outgoingTabId
-      ? { ...tab, isLoading: false }
-      : tab)
-  }
-}
-
 const actions = {
-  async initializeTabs({ commit, state }) {
+  async initializeTabs({ commit }) {
     if (!process.env.IS_ELECTRON) return () => {}
 
     const removeStateListener = window.ftElectron.tabs.onStateUpdated((newState) => {
-      commit('setTabsState', prepareTabActivationLoading(state, newState))
+      commit('setTabsState', newState)
     })
     const tabState = await window.ftElectron.tabs.getState()
     if (tabState) {
-      commit('setTabsState', prepareTabActivationLoading(state, tabState))
+      commit('setTabsState', tabState)
     }
 
     return () => {
@@ -261,27 +237,9 @@ const actions = {
     return await window.ftElectron.tabs.create(tabOptions)
   },
 
-  async activateTab({ rootGetters }, tabId) {
+  activateTab(_context, tabId) {
     if (!process.env.IS_ELECTRON) return
-
-    const activeTabId = rootGetters.getActiveTabId
-    const activeTab = rootGetters.getTabById(activeTabId)
-    const navigation = getTabNavigationService()
-    navigation.setLoadingSuppressed(tabId, false)
-    if (
-      activeTabId !== tabId &&
-      activeTab?.route?.path?.startsWith('/watch/')
-    ) {
-      // Send this before activation so the main process cannot publish the
-      // outgoing Watch tab as both inactive and transiently loading. The
-      // hidden Watch view stops contributing its loader during deactivation.
-      navigation.setLoadingSuppressed(activeTabId, true)
-    }
-
-    const activated = await window.ftElectron.tabs.activate(tabId)
-    if (!activated && rootGetters.getActiveTabId === activeTabId) {
-      navigation.setLoadingSuppressed(activeTabId, false)
-    }
+    window.ftElectron.tabs.activate(tabId)
   },
 
   setTabSelection({ commit }, tabIds) {

--- a/src/renderer/tabs/TabNavigationService.js
+++ b/src/renderer/tabs/TabNavigationService.js
@@ -42,7 +42,6 @@ export class TabNavigationService {
     this.pendingPresentation = null
     this.staleTransitionResolvers = new Map()
     this.loadingSourcesByTabId = new Map()
-    this.loadingSuppressedTabIds = new Set()
     this.navigationQueuesByTabId = new Map()
     this.routeLoadingStateByTabId = new Map()
     this.beforeEachHooksByTabId = new Map()
@@ -644,20 +643,7 @@ export class TabNavigationService {
     if (sources.size === 0) {
       this.loadingSourcesByTabId.delete(tabId)
     }
-    if (!this.loadingSuppressedTabIds.has(tabId)) {
-      window.ftElectron?.tabs?.setLoading?.(sources.size > 0, tabId)
-    }
-  }
-
-  setLoadingSuppressed(tabId, suppressed) {
-    if (suppressed) {
-      this.loadingSuppressedTabIds.add(tabId)
-      window.ftElectron?.tabs?.setLoading?.(false, tabId)
-    } else {
-      this.loadingSuppressedTabIds.delete(tabId)
-      const sources = this.loadingSourcesByTabId.get(tabId)
-      window.ftElectron?.tabs?.setLoading?.((sources?.size ?? 0) > 0, tabId)
-    }
+    window.ftElectron?.tabs?.setLoading?.(sources.size > 0, tabId)
   }
 
   startRouteLoading(tabId) {
@@ -694,7 +680,6 @@ export class TabNavigationService {
 
   disposeTab(tabId) {
     this.loadingSourcesByTabId.delete(tabId)
-    this.loadingSuppressedTabIds.delete(tabId)
     this.navigationQueuesByTabId.delete(tabId)
     const routeLoadingState = this.routeLoadingStateByTabId.get(tabId)
     if (routeLoadingState?.timeoutId != null) {

--- a/src/renderer/views/Watch/Watch.vue
+++ b/src/renderer/views/Watch/Watch.vue
@@ -30,7 +30,7 @@
         <div
           v-if="isLoading && customShortsPlayerActive"
           class="videoPlayer videoPlayerPlaceholder shortsPlayerPlaceholder"
-          :data-tab-loading-indicator="isTabPresented ? '' : null"
+          data-tab-loading-indicator
         >
           <img
             v-if="shortsTransitionPreview"
@@ -64,13 +64,13 @@
         <div
           v-else-if="isLoading"
           class="videoPlayer videoPlayerPlaceholder ft-shimmer"
-          :data-tab-loading-indicator="isTabPresented ? '' : null"
+          data-tab-loading-indicator
         />
         <div
           v-else-if="ytDlpStreamsPending && (!isUpcoming || playabilityStatus === 'OK') && !errorMessage"
           class="videoPlayer videoPlayerPlaceholder streamPlaceholder"
           :class="{ shortsPlayerPlaceholder: customShortsPlayerActive }"
-          :data-tab-loading-indicator="isTabPresented ? '' : null"
+          data-tab-loading-indicator
         >
           <img
             v-if="thumbnail"


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Make sure to follow the contributing guidelines. -->
<!-- Important note, we may remove your pull request if you do not use this provided PR template correctly. -->
<!-- Agent instructions: Preserve every heading, comment, and marker in this template. Never remove or rewrite the release-note-category:start/end, release-note:start/end, or release-note-image:start/end marker pairs. Never remove or rewrite the Release note images section; leave its contents for a human. -->

## Pull Request Type
<!-- Please select what type of pull request this is: [x] -->
- [x] Bugfix
- [ ] Feature Implementation
- [ ] Documentation
- [ ] Other

## Related issue
<!-- Please link the issue your pull request is referring to. -->
<!-- If this pull request fully resolves the relevant issue, put "closes" before the issue number. -->
<!-- Example: "closes #123456". -->

## Description
<!-- Please write a clear and concise description of what the pull request does. -->
The Watch-tab loading workaround hid all renderer loading updates after switching away from a tab. Besides masking legitimate background work, that broke the handoff from the main-process mount loader to the renderer loader and briefly exposed the generic Watch icon before a cached avatar became available.

This removes the presentation-specific suppression and lets every Watch view report its real loading state. It also removes the activation IPC response that existed only to roll suppression back after a rejected activation.

## Release note category
<!-- Select exactly one category. Every pull request must select one. -->
<!-- Select "Not noteworthy" when this pull request fixes a bug in or improves functionality that has not yet appeared in a stable release. -->
<!-- release-note-category:start -->
- [x] Not noteworthy
- [ ] Highlights
- [ ] More improvements
- [ ] Fixed bugs
<!-- release-note-category:end -->

## Release note
<!-- Required unless "Not noteworthy" is selected. -->
<!-- Write one concise, user-facing entry without a leading bullet. -->
<!-- release-note:start -->

<!-- release-note:end -->

## Release note images
<!-- Human-only: Agents must preserve this entire section and leave it empty. -->
<!-- Optional. Paste one or more Markdown images or HTML image tags here. -->
<!-- The release notes will use an HTML image tag and limit images taller than 300 pixels. -->
<!-- release-note-image:start -->

<!-- release-note-image:end -->

## Testing
<!-- How can reviewers verify that the PR produces correct results? -->
<!-- Please provide instructions so that others can ensure that this pull request would produce correct results. For examples see, https://github.com/FreeTubeApp/FreeTube/pull/5743, https://github.com/FreeTubeApp/FreeTube/pull/7349, https://github.com/FreeTubeApp/FreeTube/pull/5125, https://github.com/FreeTubeApp/FreeTube/pull/7338 -->
<!-- Agent instructions: Only write human-facing steps that explain how to verify the change while running this branch in dev mode. Include expected results and, when applicable, helpful console snippets for interactive verification. Do not include automated checks, commands, results, pass counts, or CI status. -->
1. Open a video in a background tab and wait for its metadata to load.
2. Confirm that the tab shows its loading indicator continuously until its channel avatar appears, without briefly showing the generic Watch icon.
3. Start loading a video, switch to another tab, and confirm that the background tab continues to reflect genuine pending work.

## Additional context
<!-- Add any other context about the pull request here. -->
The previous regression test manually changed the hidden Watch component to `isLoading = true` and treated the resulting real loader as stale. The replacement coverage verifies the actual background mount-to-renderer loading handoff instead.
