### PR TITLE
fix(player): avoid stale and rejected yt-dlp streams and cache manifest

### DIFF
--- a/e2e/tests/offline/video-actions.spec.mjs
+++ b/e2e/tests/offline/video-actions.spec.mjs
@@ -122,7 +122,7 @@ test.describe('video downloads', () => {
 
     const passedArguments = (await readFile(capturedArgs, 'utf8')).trim().split('\n')
     const extractorArgsIndex = passedArguments.indexOf('--extractor-args')
-    expect(passedArguments[extractorArgsIndex + 1]).toBe('youtube:player_client=android_vr,web_embedded,default')
+    expect(passedArguments[extractorArgsIndex + 1]).toBe('youtube:player_client=web_embedded,default,-android_vr')
     expect(info.formats[0].availableAt).toBe(123)
   })
 

--- a/src/constants.js
+++ b/src/constants.js
@@ -132,7 +132,8 @@ const IpcChannels = {
   YT_DLP_GET_INFO: 'yt-dlp-get-info',
   YT_DLP_GET_PLAYBACK_INFO: 'yt-dlp-get-playback-info',
   YT_DLP_DOWNLOAD_BINARY: 'yt-dlp-download-binary',
-  YT_DLP_BINARY_DOWNLOAD_PROGRESS: 'yt-dlp-binary-download-progress'
+  YT_DLP_BINARY_DOWNLOAD_PROGRESS: 'yt-dlp-binary-download-progress',
+  YT_DLP_BINARY_UPDATED: 'yt-dlp-binary-updated'
 }
 
 const DBActions = {

--- a/src/main/ytDlp.js
+++ b/src/main/ytDlp.js
@@ -714,6 +714,7 @@ async function downloadManagedYtDlp(onProgress, onDownloadStart) {
     } catch (error) {
       console.warn('Could not save yt-dlp download metadata', error)
     }
+    broadcastToRenderers(IpcChannels.YT_DLP_BINARY_UPDATED)
   }
 
   return { version, updated: download.data !== null }
@@ -984,9 +985,6 @@ export async function handleYtDlpDownloadBinary(event, binary) {
   } finally {
     const updated = result != null && 'version' in result && result.updated
     sendProgress(updated ? 100 : null, false)
-    if (binary === 'yt-dlp' && updated) {
-      broadcastToRenderers(IpcChannels.YT_DLP_BINARY_UPDATED)
-    }
   }
 }
 

--- a/src/main/ytDlp.js
+++ b/src/main/ytDlp.js
@@ -982,7 +982,11 @@ export async function handleYtDlpDownloadBinary(event, binary) {
       : await downloadManagedFfmpeg(onProgress, () => sendProgress(0, true))
     return result
   } finally {
-    sendProgress(result != null && 'version' in result && result.updated ? 100 : null, false)
+    const updated = result != null && 'version' in result && result.updated
+    sendProgress(updated ? 100 : null, false)
+    if (binary === 'yt-dlp' && updated) {
+      broadcastToRenderers(IpcChannels.YT_DLP_BINARY_UPDATED)
+    }
   }
 }
 

--- a/src/main/ytDlp.js
+++ b/src/main/ytDlp.js
@@ -1103,11 +1103,13 @@ export async function handleYtDlpGetPlaybackInfo(event, videoId) {
     '--no-progress',
     '--socket-timeout',
     '15',
-    // Android VR avoids live HLS streams that require a PO token, while the
-    // embedded client exposes alternate audio languages. Keep yt-dlp's default
-    // clients as fallbacks for videos unsupported by either client.
+    // The embedded client exposes alternate audio languages without requiring
+    // a PO token. Android VR used to provide the same token-free fallback, but
+    // YouTube now selectively enforces GVS tokens for its non-HLS formats and
+    // returns 403 for the extracted URLs. Keep the remaining default clients as
+    // fallbacks for videos the embedded client cannot access.
     '--extractor-args',
-    'youtube:player_client=android_vr,web_embedded,default'
+    'youtube:player_client=web_embedded,default,-android_vr'
   ]
 
   await pushProxyArgument(args)

--- a/src/preload/interface.js
+++ b/src/preload/interface.js
@@ -12,10 +12,17 @@ ipcRenderer.on(IpcChannels.NATIVE_THEME_UPDATE, (_, shouldUseDarkColors) => {
 let currentUpdateSearchInputTextListener
 let currentYtDlpBinaryDownloadProgressListener
 const ytDlpBinaryDownloadProgressListeners = new Set()
+const ytDlpBinaryUpdatedListeners = new Set()
 
 ipcRenderer.on(IpcChannels.YT_DLP_BINARY_DOWNLOAD_PROGRESS, (_, progress) => {
   for (const listener of ytDlpBinaryDownloadProgressListeners) {
     listener(progress)
+  }
+})
+
+ipcRenderer.on(IpcChannels.YT_DLP_BINARY_UPDATED, () => {
+  for (const listener of ytDlpBinaryUpdatedListeners) {
+    listener()
   }
 })
 
@@ -383,6 +390,15 @@ export default {
   addYtDlpBinaryDownloadProgressListener: (handler) => {
     ytDlpBinaryDownloadProgressListeners.add(handler)
     return () => ytDlpBinaryDownloadProgressListeners.delete(handler)
+  },
+
+  /**
+   * @param {() => void} handler
+   * @returns {() => void}
+   */
+  addYtDlpBinaryUpdatedListener: (handler) => {
+    ytDlpBinaryUpdatedListeners.add(handler)
+    return () => ytDlpBinaryUpdatedListeners.delete(handler)
   },
 
   /**

--- a/src/renderer/App.vue
+++ b/src/renderer/App.vue
@@ -563,6 +563,7 @@ let removeTabsStateListener = null
 let removeReloadRequestListener = null
 let removeConfirmMultipleTabsActionListener = null
 let removeOpenUrlListener = null
+let removeYtDlpBinaryUpdatedListener = null
 const pendingSubscriptionAutoRefreshes = []
 const pendingSubscriptionAutoRefreshKeys = new Set()
 const cancelledSubscriptionAutoRefreshKeys = new Set()
@@ -697,10 +698,6 @@ async function initializeManagedExternalSoftware() {
       .filter(({ result }) => result !== null && 'version' in result && result.updated)
       .map(({ binary }) => binary)
 
-    if (updatedBinaries.includes('yt-dlp')) {
-      invalidateAllYtDlpPlaybackSources()
-    }
-
     if (failures.length === 0 && updatedBinaries.length > 0) {
       toolProgressPercentage = 100
       store.commit('setProgressBarPercentage', toolProgressPercentage)
@@ -776,6 +773,9 @@ onMounted(async () => {
   preloadUtilityRoutes()
 
   if (isElectron) {
+    removeYtDlpBinaryUpdatedListener = window.ftElectron.addYtDlpBinaryUpdatedListener(
+      invalidateAllYtDlpPlaybackSources
+    )
     removeTabsStateListener = await store.dispatch('initializeTabs')
     window.ftElectron.tabs.rendererReady()
   }
@@ -927,6 +927,7 @@ onBeforeUnmount(() => {
   removeReloadRequestListener?.()
   removeConfirmMultipleTabsActionListener?.()
   removeOpenUrlListener?.()
+  removeYtDlpBinaryUpdatedListener?.()
 })
 
 watch([activeTabId, selectionRevision], ([tabId, revision]) => {

--- a/src/renderer/App.vue
+++ b/src/renderer/App.vue
@@ -348,6 +348,7 @@ import { normalizeScrollbarThumbWidth } from './constants/scrollbar'
 import { getTabAccentColor } from './constants/tabColors'
 import { getThumbnailListStyles } from './constants/thumbnailSize'
 import { getLastUsedVersion, setLastUsedVersion } from './helpers/lastUsedVersion'
+import { invalidateAllYtDlpPlaybackSources } from './helpers/player/ytDlpPlayback'
 import { getTabNavigationService } from './tabs/TabNavigationService'
 import { tabRuntimeRegistry } from './tabs/TabRuntimeRegistry'
 import { getTabAvatarUrl, getTabPageIcon, getTabPreviewFallbackUrl } from './tabs/tabPreview'
@@ -695,6 +696,10 @@ async function initializeManagedExternalSoftware() {
     const updatedBinaries = results
       .filter(({ result }) => result !== null && 'version' in result && result.updated)
       .map(({ binary }) => binary)
+
+    if (updatedBinaries.includes('yt-dlp')) {
+      invalidateAllYtDlpPlaybackSources()
+    }
 
     if (failures.length === 0 && updatedBinaries.length > 0) {
       toolProgressPercentage = 100

--- a/src/renderer/components/ExternalSoftwareSettings.vue
+++ b/src/renderer/components/ExternalSoftwareSettings.vue
@@ -193,6 +193,7 @@ import FtFlexBox from './ft-flex-box/ft-flex-box.vue'
 import store from '../store/index'
 
 import { showToast } from '../helpers/utils'
+import { invalidateAllYtDlpPlaybackSources } from '../helpers/player/ytDlpPlayback'
 
 const { t } = useI18n()
 
@@ -477,6 +478,9 @@ async function downloadBinary(binary) {
       binariesInfoCache.value[key].managed = { source: 'managed', available: true, version: result.version }
 
       if (result.updated) {
+        if (binary === 'yt-dlp') {
+          invalidateAllYtDlpPlaybackSources()
+        }
         showToast({
           message: binary === 'yt-dlp'
             ? t('Settings.External Software Settings.yt-dlp Downloaded Template', { version: result.version })

--- a/src/renderer/components/ExternalSoftwareSettings.vue
+++ b/src/renderer/components/ExternalSoftwareSettings.vue
@@ -193,7 +193,6 @@ import FtFlexBox from './ft-flex-box/ft-flex-box.vue'
 import store from '../store/index'
 
 import { showToast } from '../helpers/utils'
-import { invalidateAllYtDlpPlaybackSources } from '../helpers/player/ytDlpPlayback'
 
 const { t } = useI18n()
 
@@ -478,9 +477,6 @@ async function downloadBinary(binary) {
       binariesInfoCache.value[key].managed = { source: 'managed', available: true, version: result.version }
 
       if (result.updated) {
-        if (binary === 'yt-dlp') {
-          invalidateAllYtDlpPlaybackSources()
-        }
         showToast({
           message: binary === 'yt-dlp'
             ? t('Settings.External Software Settings.yt-dlp Downloaded Template', { version: result.version })

--- a/src/renderer/helpers/player/ytDlpPlayback.js
+++ b/src/renderer/helpers/player/ytDlpPlayback.js
@@ -4,11 +4,12 @@ import { MANIFEST_TYPE_DASH, MANIFEST_TYPE_HLS } from './utils'
 import { probeStreamByteRanges } from './streamByteRanges'
 import { generateAudioTrackField } from '../api/local'
 import { waitForYtDlpFormatAvailability } from './ytDlpFormatAvailability'
+import { getEarliestYtDlpFormatExpiry, YtDlpPlaybackSourceCache } from './ytDlpPlaybackCache'
 
 /** @typedef {import('../../../main/ytDlp').YtDlpPlaybackFormat} YtDlpPlaybackFormat */
 
 /**
- * @typedef YtDlpPlaybackSource
+ * @typedef {object} YtDlpPlaybackSource
  * @property {string} manifestSrc
  * @property {MANIFEST_TYPE_DASH | MANIFEST_TYPE_HLS} manifestMimeType
  * @property {any[]} legacyFormats
@@ -19,6 +20,15 @@ import { waitForYtDlpFormatAvailability } from './ytDlpFormatAvailability'
 
 // yt-dlp appends the audio track or a suffix like "-drc" to the itag for some formats
 const ITAG_REGEX = /^\d+/
+const dashPlaybackSourceCache = new YtDlpPlaybackSourceCache()
+
+/**
+ * Ensures playback-error recovery extracts fresh signed stream URLs.
+ * @param {string} videoId
+ */
+export function invalidateYtDlpPlaybackSource(videoId) {
+  dashPlaybackSourceCache.delete(videoId)
+}
 
 /**
  * @param {YtDlpPlaybackFormat} format
@@ -180,22 +190,6 @@ function mapYtDlpLegacyFormat(format) {
 }
 
 /**
- * @param {YtDlpPlaybackFormat[]} formats
- * @returns {Date | null}
- */
-function getExpiryDate(formats) {
-  for (const format of formats) {
-    const expire = parseInt(new URL(format.url).searchParams.get('expire'))
-
-    if (Number.isFinite(expire)) {
-      return new Date(expire * 1000)
-    }
-  }
-
-  return null
-}
-
-/**
  * Reads the byte ranges of every adaptive format in parallel and drops the ones
  * that the byte ranges couldn't be determined for.
  * @param {YtDlpPlaybackFormat[]} formats
@@ -241,6 +235,11 @@ async function convertAdaptiveFormats(formats, duration) {
  * @returns {Promise<YtDlpPlaybackSource>}
  */
 export async function getYtDlpPlaybackSource(videoId) {
+  const cachedSource = dashPlaybackSourceCache.get(videoId)
+  if (cachedSource !== null) {
+    return cachedSource
+  }
+
   const info = await window.ftElectron.ytDlpGetPlaybackInfo(videoId)
 
   if (info === null) {
@@ -266,14 +265,17 @@ export async function getYtDlpPlaybackSource(videoId) {
     if (localFormats.some(format => format.has_video) && localFormats.some(format => format.has_audio)) {
       const manifest = await FormatUtils.toDash({ adaptive_formats: localFormats })
 
-      return {
+      const source = {
         manifestSrc: `data:${MANIFEST_TYPE_DASH};charset=UTF-8,${encodeURIComponent(manifest)}`,
         manifestMimeType: MANIFEST_TYPE_DASH,
         legacyFormats,
-        expiryDate: getExpiryDate(adaptiveFormats),
+        expiryDate: getEarliestYtDlpFormatExpiry(adaptiveFormats),
         isLive: false,
         version: info.version
       }
+
+      dashPlaybackSourceCache.set(videoId, source)
+      return source
     }
   }
 

--- a/src/renderer/helpers/player/ytDlpPlayback.js
+++ b/src/renderer/helpers/player/ytDlpPlayback.js
@@ -232,10 +232,11 @@ async function convertAdaptiveFormats(formats, duration) {
  * SABR streaming protocol. Live streams use YouTube's HLS manifests, which keep the
  * DVR window available, so that they can be rewound.
  * @param {string} videoId
+ * @param {string} cacheKey identifies the yt-dlp executable and proxy configuration
  * @returns {Promise<YtDlpPlaybackSource>}
  */
-export async function getYtDlpPlaybackSource(videoId) {
-  const cachedSource = dashPlaybackSourceCache.get(videoId)
+export async function getYtDlpPlaybackSource(videoId, cacheKey = '') {
+  const cachedSource = dashPlaybackSourceCache.get(videoId, cacheKey)
   if (cachedSource !== null) {
     return cachedSource
   }
@@ -274,7 +275,7 @@ export async function getYtDlpPlaybackSource(videoId) {
         version: info.version
       }
 
-      dashPlaybackSourceCache.set(videoId, source)
+      dashPlaybackSourceCache.set(videoId, cacheKey, source)
       return source
     }
   }

--- a/src/renderer/helpers/player/ytDlpPlayback.js
+++ b/src/renderer/helpers/player/ytDlpPlayback.js
@@ -30,6 +30,10 @@ export function invalidateYtDlpPlaybackSource(videoId) {
   dashPlaybackSourceCache.delete(videoId)
 }
 
+export function invalidateAllYtDlpPlaybackSources() {
+  dashPlaybackSourceCache.clear()
+}
+
 /**
  * @param {YtDlpPlaybackFormat} format
  */

--- a/src/renderer/helpers/player/ytDlpPlaybackCache.js
+++ b/src/renderer/helpers/player/ytDlpPlaybackCache.js
@@ -1,0 +1,85 @@
+const DEFAULT_EXPIRY_MARGIN_MS = 2 * 60 * 1000
+const DEFAULT_MAX_ENTRIES = 50
+
+/**
+ * @param {{ url: string }[]} formats
+ * @returns {Date | null}
+ */
+export function getEarliestYtDlpFormatExpiry(formats) {
+  let earliestExpiry = Infinity
+
+  for (const format of formats) {
+    const expire = parseInt(new URL(format.url).searchParams.get('expire'))
+
+    if (Number.isFinite(expire)) {
+      earliestExpiry = Math.min(earliestExpiry, expire)
+    }
+  }
+
+  return Number.isFinite(earliestExpiry) ? new Date(earliestExpiry * 1000) : null
+}
+
+export class YtDlpPlaybackSourceCache {
+  /**
+   * @param {{ expiryMarginMs?: number, maxEntries?: number, now?: () => number }} [options]
+   */
+  constructor({
+    expiryMarginMs = DEFAULT_EXPIRY_MARGIN_MS,
+    maxEntries = DEFAULT_MAX_ENTRIES,
+    now = Date.now
+  } = {}) {
+    this.expiryMarginMs = expiryMarginMs
+    this.maxEntries = maxEntries
+    this.now = now
+    /** @type {Map<string, import('./ytDlpPlayback').YtDlpPlaybackSource>} */
+    this.sources = new Map()
+  }
+
+  /**
+   * @param {string} videoId
+   * @returns {import('./ytDlpPlayback').YtDlpPlaybackSource | null}
+   */
+  get(videoId) {
+    const source = this.sources.get(videoId)
+
+    if (
+      source === undefined ||
+      source.expiryDate === null ||
+      this.now() >= source.expiryDate.getTime() - this.expiryMarginMs
+    ) {
+      this.sources.delete(videoId)
+      return null
+    }
+
+    // Refresh insertion order so the size limit evicts the least recently used source.
+    this.sources.delete(videoId)
+    this.sources.set(videoId, source)
+    return source
+  }
+
+  /**
+   * @param {string} videoId
+   * @param {import('./ytDlpPlayback').YtDlpPlaybackSource} source
+   */
+  set(videoId, source) {
+    if (
+      source.expiryDate === null ||
+      this.now() >= source.expiryDate.getTime() - this.expiryMarginMs
+    ) {
+      return
+    }
+
+    this.sources.delete(videoId)
+    while (this.sources.size >= this.maxEntries) {
+      this.sources.delete(this.sources.keys().next().value)
+    }
+    this.sources.set(videoId, source)
+  }
+
+  /**
+   * @param {string} videoId
+   */
+  delete(videoId) {
+    this.sources.delete(videoId)
+  }
+}

--- a/src/renderer/helpers/player/ytDlpPlaybackCache.js
+++ b/src/renderer/helpers/player/ytDlpPlaybackCache.js
@@ -31,21 +31,23 @@ export class YtDlpPlaybackSourceCache {
     this.expiryMarginMs = expiryMarginMs
     this.maxEntries = maxEntries
     this.now = now
-    /** @type {Map<string, import('./ytDlpPlayback').YtDlpPlaybackSource>} */
+    /** @type {Map<string, { cacheKey: string, source: import('./ytDlpPlayback').YtDlpPlaybackSource }>} */
     this.sources = new Map()
   }
 
   /**
    * @param {string} videoId
+   * @param {string} cacheKey
    * @returns {import('./ytDlpPlayback').YtDlpPlaybackSource | null}
    */
-  get(videoId) {
-    const source = this.sources.get(videoId)
+  get(videoId, cacheKey) {
+    const entry = this.sources.get(videoId)
 
     if (
-      source === undefined ||
-      source.expiryDate === null ||
-      this.now() >= source.expiryDate.getTime() - this.expiryMarginMs
+      entry === undefined ||
+      entry.cacheKey !== cacheKey ||
+      entry.source.expiryDate === null ||
+      this.now() >= entry.source.expiryDate.getTime() - this.expiryMarginMs
     ) {
       this.sources.delete(videoId)
       return null
@@ -53,15 +55,16 @@ export class YtDlpPlaybackSourceCache {
 
     // Refresh insertion order so the size limit evicts the least recently used source.
     this.sources.delete(videoId)
-    this.sources.set(videoId, source)
-    return source
+    this.sources.set(videoId, entry)
+    return entry.source
   }
 
   /**
    * @param {string} videoId
+   * @param {string} cacheKey
    * @param {import('./ytDlpPlayback').YtDlpPlaybackSource} source
    */
-  set(videoId, source) {
+  set(videoId, cacheKey, source) {
     if (
       source.expiryDate === null ||
       this.now() >= source.expiryDate.getTime() - this.expiryMarginMs
@@ -73,7 +76,7 @@ export class YtDlpPlaybackSourceCache {
     while (this.sources.size >= this.maxEntries) {
       this.sources.delete(this.sources.keys().next().value)
     }
-    this.sources.set(videoId, source)
+    this.sources.set(videoId, { cacheKey, source })
   }
 
   /**

--- a/src/renderer/helpers/player/ytDlpPlaybackCache.js
+++ b/src/renderer/helpers/player/ytDlpPlaybackCache.js
@@ -85,4 +85,8 @@ export class YtDlpPlaybackSourceCache {
   delete(videoId) {
     this.sources.delete(videoId)
   }
+
+  clear() {
+    this.sources.clear()
+  }
 }

--- a/src/renderer/views/Watch/Watch.js
+++ b/src/renderer/views/Watch/Watch.js
@@ -519,6 +519,26 @@ export default defineComponent({
     proxyVideos: function () {
       return this.$store.getters.getProxyVideos
     },
+    ytDlpPlaybackCacheKey: function () {
+      const getters = this.$store.getters
+      const proxyConfiguration = getters.getUseProxy
+        ? [
+            getters.getProxyProtocol,
+            getters.getProxyHostname,
+            getters.getProxyPort,
+            getters.getProxyUsername,
+            getters.getProxyPassword
+          ]
+        : []
+
+      return JSON.stringify([
+        getters.getYtDlpSource,
+        getters.getYtDlpChannel,
+        getters.getYtDlpPath,
+        getters.getUseProxy,
+        ...proxyConfiguration
+      ])
+    },
     defaultAutoplayInterruptionIntervalHours: function () {
       return this.$store.getters.getDefaultAutoplayInterruptionIntervalHours
     },
@@ -4164,7 +4184,7 @@ export default defineComponent({
     extractYtDlpPlaybackSource: async function (loadGeneration, videoId) {
       let source
       try {
-        source = await getYtDlpPlaybackSource(videoId)
+        source = await getYtDlpPlaybackSource(videoId, this.ytDlpPlaybackCacheKey)
       } catch (error) {
         if (!this.isCurrentVideoLoad(loadGeneration, videoId)) { return false }
 

--- a/src/renderer/views/Watch/Watch.js
+++ b/src/renderer/views/Watch/Watch.js
@@ -72,7 +72,7 @@ import {
   MANIFEST_TYPE_DASH,
   MANIFEST_TYPE_HLS
 } from '../../helpers/player/utils'
-import { getYtDlpPlaybackSource } from '../../helpers/player/ytDlpPlayback'
+import { getYtDlpPlaybackSource, invalidateYtDlpPlaybackSource } from '../../helpers/player/ytDlpPlayback'
 import { selectSponsorBlockFullVideoLabel } from '../../helpers/player/sponsorBlockFullVideo'
 import {
   buildSubscriptionShortsFeed,
@@ -3804,6 +3804,7 @@ export default defineComponent({
       // URL or extraction. Refresh those streams once before changing format or
       // restoring the cached built-in source (which may use SABR).
       if (this.activePlaybackEngine === 'yt-dlp') {
+        invalidateYtDlpPlaybackSource(this.videoId)
         const status = error.code === Code.BAD_HTTP_STATUS ? error.data[1] : error.code
         if (await this.reloadAfterStreamErrorOnce(`[PLAYER_ERROR: ${status}]`)) {
           return

--- a/tests/unit/yt-dlp-playback-cache.test.mjs
+++ b/tests/unit/yt-dlp-playback-cache.test.mjs
@@ -78,3 +78,14 @@ test('invalidates a source after a playback error', () => {
 
   assert.equal(cache.get('video', 'settings'), null)
 })
+
+test('clears every source after the managed binary is updated', () => {
+  const cache = new YtDlpPlaybackSourceCache({ now: () => 0 })
+  cache.set('first', 'settings', source(new Date(1000000)))
+  cache.set('second', 'settings', source(new Date(1000000)))
+
+  cache.clear()
+
+  assert.equal(cache.get('first', 'settings'), null)
+  assert.equal(cache.get('second', 'settings'), null)
+})

--- a/tests/unit/yt-dlp-playback-cache.test.mjs
+++ b/tests/unit/yt-dlp-playback-cache.test.mjs
@@ -1,0 +1,73 @@
+import assert from 'node:assert/strict'
+import test from 'node:test'
+
+import {
+  getEarliestYtDlpFormatExpiry,
+  YtDlpPlaybackSourceCache
+} from '../../src/renderer/helpers/player/ytDlpPlaybackCache.js'
+
+function source (expiryDate) {
+  return { expiryDate }
+}
+
+test('uses the earliest expiry from the yt-dlp formats', () => {
+  assert.deepEqual(getEarliestYtDlpFormatExpiry([
+    { url: 'https://example.com/videoplayback?expire=2000' },
+    { url: 'https://example.com/videoplayback?expire=1000' },
+    { url: 'https://example.com/videoplayback' }
+  ]), new Date(1000 * 1000))
+})
+
+test('reuses DASH sources until the early expiry margin', () => {
+  let now = 1000000
+  const cache = new YtDlpPlaybackSourceCache({
+    expiryMarginMs: 120000,
+    now: () => now
+  })
+  const cachedSource = source(new Date(now + 300000))
+
+  cache.set('video', cachedSource)
+  assert.equal(cache.get('video'), cachedSource)
+
+  now += 180000
+  assert.equal(cache.get('video'), null)
+})
+
+test('does not cache sources without a safely usable expiry', () => {
+  const now = 1000000
+  const cache = new YtDlpPlaybackSourceCache({
+    expiryMarginMs: 120000,
+    now: () => now
+  })
+
+  cache.set('missing-expiry', source(null))
+  cache.set('near-expiry', source(new Date(now + 60000)))
+
+  assert.equal(cache.get('missing-expiry'), null)
+  assert.equal(cache.get('near-expiry'), null)
+})
+
+test('evicts the least recently used source at the size limit', () => {
+  const cache = new YtDlpPlaybackSourceCache({ maxEntries: 2, now: () => 0 })
+  const first = source(new Date(1000000))
+  const second = source(new Date(1000000))
+  const third = source(new Date(1000000))
+
+  cache.set('first', first)
+  cache.set('second', second)
+  cache.get('first')
+  cache.set('third', third)
+
+  assert.equal(cache.get('first'), first)
+  assert.equal(cache.get('second'), null)
+  assert.equal(cache.get('third'), third)
+})
+
+test('invalidates a source after a playback error', () => {
+  const cache = new YtDlpPlaybackSourceCache({ now: () => 0 })
+  cache.set('video', source(new Date(1000000)))
+
+  cache.delete('video')
+
+  assert.equal(cache.get('video'), null)
+})

--- a/tests/unit/yt-dlp-playback-cache.test.mjs
+++ b/tests/unit/yt-dlp-playback-cache.test.mjs
@@ -26,11 +26,11 @@ test('reuses DASH sources until the early expiry margin', () => {
   })
   const cachedSource = source(new Date(now + 300000))
 
-  cache.set('video', cachedSource)
-  assert.equal(cache.get('video'), cachedSource)
+  cache.set('video', 'settings', cachedSource)
+  assert.equal(cache.get('video', 'settings'), cachedSource)
 
   now += 180000
-  assert.equal(cache.get('video'), null)
+  assert.equal(cache.get('video', 'settings'), null)
 })
 
 test('does not cache sources without a safely usable expiry', () => {
@@ -40,11 +40,11 @@ test('does not cache sources without a safely usable expiry', () => {
     now: () => now
   })
 
-  cache.set('missing-expiry', source(null))
-  cache.set('near-expiry', source(new Date(now + 60000)))
+  cache.set('missing-expiry', 'settings', source(null))
+  cache.set('near-expiry', 'settings', source(new Date(now + 60000)))
 
-  assert.equal(cache.get('missing-expiry'), null)
-  assert.equal(cache.get('near-expiry'), null)
+  assert.equal(cache.get('missing-expiry', 'settings'), null)
+  assert.equal(cache.get('near-expiry', 'settings'), null)
 })
 
 test('evicts the least recently used source at the size limit', () => {
@@ -53,21 +53,28 @@ test('evicts the least recently used source at the size limit', () => {
   const second = source(new Date(1000000))
   const third = source(new Date(1000000))
 
-  cache.set('first', first)
-  cache.set('second', second)
-  cache.get('first')
-  cache.set('third', third)
+  cache.set('first', 'settings', first)
+  cache.set('second', 'settings', second)
+  cache.get('first', 'settings')
+  cache.set('third', 'settings', third)
 
-  assert.equal(cache.get('first'), first)
-  assert.equal(cache.get('second'), null)
-  assert.equal(cache.get('third'), third)
+  assert.equal(cache.get('first', 'settings'), first)
+  assert.equal(cache.get('second', 'settings'), null)
+  assert.equal(cache.get('third', 'settings'), third)
+})
+
+test('does not reuse sources extracted with different settings', () => {
+  const cache = new YtDlpPlaybackSourceCache({ now: () => 0 })
+  cache.set('video', 'old-settings', source(new Date(1000000)))
+
+  assert.equal(cache.get('video', 'new-settings'), null)
 })
 
 test('invalidates a source after a playback error', () => {
   const cache = new YtDlpPlaybackSourceCache({ now: () => 0 })
-  cache.set('video', source(new Date(1000000)))
+  cache.set('video', 'settings', source(new Date(1000000)))
 
   cache.delete('video')
 
-  assert.equal(cache.get('video'), null)
+  assert.equal(cache.get('video', 'settings'), null)
 })


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Make sure to follow the contributing guidelines. -->
<!-- Important note, we may remove your pull request if you do not use this provided PR template correctly. -->
<!-- Agent instructions: Preserve every heading, comment, and marker in this template. Never remove or rewrite the release-note-category:start/end, release-note:start/end, or release-note-image:start/end marker pairs. Never remove or rewrite the Release note images section; leave its contents for a human. -->

## Pull Request Type
<!-- Please select what type of pull request this is: [x] -->
- [x] Bugfix
- [ ] Feature Implementation
- [ ] Documentation
- [ ] Other

## Related issue
<!-- Please link the issue your pull request is referring to. -->
<!-- If this pull request fully resolves the relevant issue, put "closes" before the issue number. -->
<!-- Example: "closes #123456". -->

## Description
<!-- Please write a clear and concise description of what the pull request does. -->
yt-dlp playback recently began returning intermittent 403 responses because OpenTubeX explicitly selected the Android VR client, whose non-HLS Googlevideo URLs are now subject to selective PO-token enforcement.

This excludes Android VR while preserving the embedded client for alternate audio and the remaining yt-dlp defaults as fallbacks. It also caches generated non-live DASH playback sources until two minutes before the earliest signed stream URL expires, avoids caching live HLS manifests, and invalidates the cache when playback fails so recovery still extracts fresh URLs.

## Release note category
<!-- Select exactly one category. Every pull request must select one. -->
<!-- Select "Not noteworthy" when the pull request fixes a bug in or improves functionality that has not yet appeared in a stable release. -->
<!-- release-note-category:start -->
- [ ] Not noteworthy
- [ ] Highlights
- [ ] More improvements
- [x] Fixed bugs
<!-- release-note-category:end -->

## Release note
<!-- Required unless "Not noteworthy" is selected. -->
<!-- Write one concise, user-facing entry without a leading bullet. -->
<!-- release-note:start -->
Fixed yt-dlp video playback failing with HTTP 403 errors and sped up reopening videos by safely reusing unexpired streams.
<!-- release-note:end -->

## Release note images
<!-- Human-only: Agents must preserve this entire section and leave it empty. -->
<!-- Optional. Paste one or more Markdown images or HTML image tags here. -->
<!-- The release notes will use an HTML image tag and limit images taller than 300 pixels. -->
<!-- release-note-image:start -->

<!-- release-note-image:end -->

## Testing
<!-- How can reviewers verify that the PR produces correct results? -->
<!-- Please provide instructions so that others can ensure that your pull request produces correct results. For examples see, https://github.com/FreeTubeApp/FreeTube/pull/5743, https://github.com/FreeTubeApp/FreeTube/pull/7349, https://github.com/FreeTubeApp/FreeTube/pull/5125, https://github.com/FreeTubeApp/FreeTube/pull/7338 -->
<!-- Agent instructions: Only write human-facing steps that explain how to verify the change while running this branch in dev mode. Include expected results and, when applicable, helpful console snippets for interactive verification. Do not include automated checks, commands, results, pass counts, or CI status. -->
1. Select yt-dlp as the stream extraction method and open a regular video. Confirm adaptive video and audio play without a 403 reload loop.
2. Navigate away and reopen the same video before its signed URLs expire. Confirm playback starts without another yt-dlp extraction message.
3. Open a live stream and confirm its HLS playback still initializes normally rather than reusing a static cached manifest.
4. Cause an active yt-dlp stream request to fail, then restore connectivity. Confirm recovery extracts a fresh source instead of repeatedly using the failed cached URL.

## Additional context
<!-- Add any other context about the pull request here. -->
The DASH cache is renderer-session scoped, capped at 50 least-recently-used entries, and uses the earliest `expire` parameter across the adaptive formats as its validity boundary.
