### PR TITLE
feat(watch): add live chat loading skeleton

### DIFF
--- a/e2e/tests/offline/watch-page.spec.mjs
+++ b/e2e/tests/offline/watch-page.spec.mjs
@@ -278,6 +278,28 @@ test.describe('watch page', () => {
     })
   })
 
+  test('shows a live chat skeleton while chat availability loads', async ({ app, page }) => {
+    await mockPlayableWatchPage(app, page)
+
+    let releaseMetadata
+    await page.route(/\/youtubei\/v1\/next/, async (route) => {
+      await new Promise(resolve => { releaseMetadata = resolve })
+      await route.fallback()
+    })
+
+    await page.locator(sel.searchInput).fill('https://www.youtube.com/watch?v=jNQXAC9IVRw')
+    await page.locator(sel.searchInput).press('Enter')
+    await expect(page).toHaveURL(/#\/watch\/jNQXAC9IVRw/)
+    const sidebarSkeletons = page.locator(`${activeTab} .sidebarArea > :is(.liveChatSkeleton, .recommendationsSkeleton)`)
+    await expect(sidebarSkeletons).toHaveCount(2)
+    await expect(sidebarSkeletons.nth(0)).toHaveClass(/liveChatSkeleton/)
+    await expect(sidebarSkeletons.nth(1)).toHaveClass(/recommendationsSkeleton/)
+
+    await expect.poll(() => typeof releaseMetadata).toBe('function')
+    releaseMetadata()
+    await expect(page.locator(`${activeTab} .ftVideoPlayer`)).toBeVisible()
+  })
+
   test('keeps live chat and replay visibility independent and restores a closed chat', async ({ app, page }) => {
     await mockPlayableWatchPage(app, page)
     await openMockedVideo(page)
@@ -314,6 +336,7 @@ test.describe('watch page', () => {
 
     const replay = page.locator(`${activeTab} .watchVideoPlaylist`).filter({ hasText: 'Live Chat Replay' })
     await expect(replay).toBeVisible()
+    await expect(replay.locator('.liveChatSkeleton')).toBeVisible()
     await replay.getByRole('button', { name: 'Close Live Chat Replay' }).click()
     await expect(replay).toHaveCount(0)
 

--- a/src/renderer/components/WatchVideoLiveChat/WatchVideoLiveChat.css
+++ b/src/renderer/components/WatchVideoLiveChat/WatchVideoLiveChat.css
@@ -7,6 +7,57 @@
   overscroll-behavior: contain;
 }
 
+.liveChatSkeleton {
+  display: flex;
+  flex: 1 1 auto;
+  flex-direction: column;
+  box-sizing: border-box;
+  min-block-size: 0;
+  padding-block: 8px;
+  gap: 14px;
+}
+
+.liveChatSkeletonMessage {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+}
+
+.liveChatSkeletonAvatar {
+  flex: 0 0 25px;
+  block-size: 25px;
+  border-radius: 50%;
+}
+
+.liveChatSkeletonContent {
+  display: flex;
+  flex: 1 1 auto;
+  flex-direction: column;
+  gap: 6px;
+}
+
+.liveChatSkeletonAuthor,
+.liveChatSkeletonText {
+  block-size: 10px;
+  border-radius: calc(4px * var(--ui-roundness));
+}
+
+.liveChatSkeletonAuthor {
+  inline-size: 28%;
+}
+
+.liveChatSkeletonText {
+  inline-size: 65%;
+}
+
+.liveChatSkeletonMessage:nth-child(3n + 1) .liveChatSkeletonText {
+  inline-size: 82%;
+}
+
+.liveChatSkeletonMessage:nth-child(3n + 2) .liveChatSkeletonText {
+  inline-size: 48%;
+}
+
 .relative {
   position: relative;
 }

--- a/src/renderer/components/WatchVideoLiveChat/WatchVideoLiveChat.vue
+++ b/src/renderer/components/WatchVideoLiveChat/WatchVideoLiveChat.vue
@@ -141,9 +141,24 @@
         </div>
       </div>
     </div>
-    <FtLoader
+    <div
       v-if="isLoading"
-    />
+      class="liveChatSkeleton"
+      data-tab-loading-indicator
+      aria-hidden="true"
+    >
+      <div
+        v-for="index in 8"
+        :key="index"
+        class="liveChatSkeletonMessage"
+      >
+        <div class="liveChatSkeletonAvatar ft-shimmer" />
+        <div class="liveChatSkeletonContent">
+          <div class="liveChatSkeletonAuthor ft-shimmer" />
+          <div class="liveChatSkeletonText ft-shimmer" />
+        </div>
+      </div>
+    </div>
     <div
       v-else-if="hasError"
       class="messageContainer"
@@ -403,7 +418,6 @@ import { computed, nextTick, onBeforeUnmount, onMounted, ref, shallowReactive, u
 import { useI18n } from 'vue-i18n'
 import { YTNodes } from 'youtubei.js'
 
-import FtLoader from '../FtLoader/FtLoader.vue'
 import FtCard from '../ft-card/ft-card.vue'
 import FtButton from '../FtButton/FtButton.vue'
 import FtToggleSwitch from '../FtToggleSwitch/FtToggleSwitch.vue'
@@ -458,9 +472,16 @@ let stayAtBottom = true
 let isScrollingToBottom = false
 /** @type {ReturnType<typeof setTimeout> | null} */
 let scrollToLiveHoldTimer = null
+/** @type {number | null} */
+let startLiveChatFrame = null
+/** @type {ReturnType<typeof setTimeout> | null} */
+let finishLoadingTimer = null
+let skeletonShownAt = 0
 
 /** Hold auto-follow through the message enter animation (~180ms). */
 const SCROLL_TO_LIVE_HOLD_MS = 220
+/** Avoid replacing a fast-loading skeleton before it can be perceived. */
+const MINIMUM_SKELETON_DURATION_MS = 1000
 
 /**
  * Replay messages that were fetched but that the player hasn't reached yet.
@@ -547,6 +568,14 @@ onBeforeUnmount(() => {
     clearTimeout(scrollToLiveHoldTimer)
     scrollToLiveHoldTimer = null
   }
+  if (startLiveChatFrame !== null) {
+    cancelAnimationFrame(startLiveChatFrame)
+    startLiveChatFrame = null
+  }
+  if (finishLoadingTimer !== null) {
+    clearTimeout(finishLoadingTimer)
+    finishLoadingTimer = null
+  }
   handleEnd()
 })
 
@@ -554,13 +583,25 @@ onMounted(() => {
   // Fullscreen docks stop pointer events from bubbling into the player. Capture
   // the event first so clicking another dock can still dismiss this menu.
   document.addEventListener('pointerdown', handleChatSettingsClickOutside, true)
+
+  // Setup can finish after a cached continuation has already returned. Starting
+  // on the next frame guarantees the loading skeleton is painted before chat
+  // polling begins, so it covers the real request instead of flashing afterward.
+  skeletonShownAt = performance.now()
+  startLiveChatFrame = requestAnimationFrame(() => {
+    startLiveChatFrame = null
+    initializeLiveChat()
+  })
 })
 
-if (!process.env.SUPPORTS_LOCAL_API) {
-  hasError.value = true
-  errorMessage.value = t('Video["Live Chat is currently not supported in this build."]')
-  isLoading.value = false
-} else {
+function initializeLiveChat() {
+  if (!process.env.SUPPORTS_LOCAL_API) {
+    hasError.value = true
+    errorMessage.value = t('Video["Live Chat is currently not supported in this build."]')
+    isLoading.value = false
+    return
+  }
+
   switch (backendPreference.value) {
     case 'local':
       if (props.liveChat) {
@@ -587,6 +628,7 @@ function enableLiveChat() {
   hasError.value = false
   showEnableChat.value = false
   isLoading.value = true
+  skeletonShownAt = performance.now()
   getLiveChatLocal()
 }
 
@@ -701,14 +743,33 @@ function handleStart(initialData) {
     handleChatAction(action)
   }
 
-  isLoading.value = false
+  finishLoading()
 
   if (isReplay.value) {
     releaseReplayComments()
     requestMoreReplayComments()
   }
+}
 
-  scrollToLiveAfterLayout()
+function finishLoading() {
+  const remainingDuration = MINIMUM_SKELETON_DURATION_MS - (performance.now() - skeletonShownAt)
+
+  if (finishLoadingTimer !== null) {
+    clearTimeout(finishLoadingTimer)
+    finishLoadingTimer = null
+  }
+
+  if (remainingDuration <= 0) {
+    isLoading.value = false
+    scrollToLiveAfterLayout()
+    return
+  }
+
+  finishLoadingTimer = setTimeout(() => {
+    finishLoadingTimer = null
+    isLoading.value = false
+    scrollToLiveAfterLayout()
+  }, remainingDuration)
 }
 
 /**

--- a/src/renderer/views/Watch/Watch.vue
+++ b/src/renderer/views/Watch/Watch.vue
@@ -790,6 +790,21 @@
         </div>
       </div>
       <div
+        v-if="isLoading && (!hideLiveChat || !hideLiveChatReplay)"
+        class="liveChatSkeleton watchVideoSideBar watchVideoPlaylist"
+        aria-hidden="true"
+      >
+        <div class="skeletonLine skeletonLiveChatTitle ft-shimmer" />
+        <div
+          v-for="index in 8"
+          :key="index"
+          class="skeletonLiveChatMessage"
+        >
+          <div class="skeletonLiveChatAvatar ft-shimmer" />
+          <div class="skeletonLine skeletonLiveChatLine ft-shimmer" />
+        </div>
+      </div>
+      <div
         v-if="isLoading && !hideRecommendedVideos"
         class="recommendationsSkeleton"
         aria-hidden="true"
@@ -893,21 +908,6 @@
           />
         </transition>
       </Teleport>
-      <div
-        v-if="isLoading && showLiveChat"
-        class="liveChatSkeleton watchVideoSideBar watchVideoPlaylist"
-        aria-hidden="true"
-      >
-        <div class="skeletonLine skeletonLiveChatTitle ft-shimmer" />
-        <div
-          v-for="index in 8"
-          :key="index"
-          class="skeletonLiveChatMessage"
-        >
-          <div class="skeletonLiveChatAvatar ft-shimmer" />
-          <div class="skeletonLine skeletonLiveChatLine ft-shimmer" />
-        </div>
-      </div>
       <Teleport
         :to="fullscreenLiveChatTarget || 'body'"
         :disabled="!fullscreenLiveChatOpen"


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Make sure to follow the contributing guidelines. -->
<!-- Important note, we may remove your pull request if you do not use this provided PR template correctly. -->
<!-- Agent instructions: Preserve every heading, comment, and marker in this template. Never remove or rewrite the release-note-category:start/end, release-note:start/end, or release-note-image:start/end marker pairs. Never remove or rewrite the Release note images section; leave its contents for a human. -->

## Pull Request Type
<!-- Please select what type of pull request this is: [x] -->
- [ ] Bugfix
- [x] Feature Implementation
- [ ] Documentation
- [ ] Other

## Related issue
<!-- Please link the issue your pull request is referring to. -->
<!-- If this pull request fully resolves the relevant issue, put "closes" before the issue number. -->
<!-- Example: "closes #123456". -->

## Description
<!-- Please write a clear and concise description of what the pull request does. -->
Live chat previously used a spinner only after its panel mounted, while the initial watch-page loading state had no visible chat-shaped placeholder. Fast chat responses could also replace that spinner before it painted.

This adds message-shaped skeletons for both the initial sidebar loading state and the mounted live chat panel. Chat polling begins after the first painted frame, and fast successful responses keep the placeholder visible long enough to avoid a flash. The recommendations skeleton remains below the chat skeleton while the page loads.

## Release note category
<!-- Select exactly one category. Every pull request must select one. -->
<!-- Select "Not noteworthy" when the pull request fixes a bug in or improves functionality that has not yet appeared in a stable release. -->
<!-- release-note-category:start -->
- [ ] Not noteworthy
- [ ] Highlights
- [x] More improvements
- [ ] Fixed bugs
<!-- release-note-category:end -->

## Release note
<!-- Required unless "Not noteworthy" is selected. -->
<!-- Write one concise, user-facing entry without a leading bullet. -->
<!-- release-note:start -->
Live chat and chat replays now show message-shaped placeholders while loading.
<!-- release-note:end -->

## Release note images
<!-- Human-only: Agents must preserve this entire section and leave it empty. -->
<!-- Optional. Paste one or more Markdown images or HTML image tags here. -->
<!-- The release notes will use an HTML image tag and limit images taller than 300 pixels. -->
<!-- release-note-image:start -->

<!-- release-note-image:end -->

## Testing
<!-- How can reviewers verify that the PR produces correct results? -->
<!-- Please provide instructions so that others can ensure that your pull request would produce correct results. For examples see, https://github.com/FreeTubeApp/FreeTube/pull/5743, https://github.com/FreeTubeApp/FreeTube/pull/7349, https://github.com/FreeTubeApp/FreeTube/pull/5125, https://github.com/FreeTubeApp/FreeTube/pull/7338 -->
<!-- Agent instructions: Only write human-facing steps that explain how to verify the change while running this branch in dev mode. Include expected results and, when applicable, helpful console snippets for interactive verification. Do not include automated checks, commands, results, pass counts, or CI status. -->
1. Open a video with an active live chat. Confirm a chat-shaped skeleton appears immediately in the sidebar, with the recommendations skeleton below it, then changes into the live chat.
2. Open a finished stream with chat replay available. Confirm the skeleton appears before replay messages.
3. Disable both live chat and live chat replay in Distraction Free Settings. Open another video and confirm the chat skeleton is omitted.

## Additional context
<!-- Add any other context about the pull request here. -->