### PR TITLE
feat(player): retain yt-dlp stream cache across restarts

### DIFF
--- a/e2e/tests/offline/video-actions.spec.mjs
+++ b/e2e/tests/offline/video-actions.spec.mjs
@@ -75,6 +75,25 @@ test('persists the yt-dlp playback cache across app restarts', async ({ app, pag
   })).toBeNull()
 })
 
+test('limits persisted yt-dlp playback entries by UTF-8 byte size', async ({ page }) => {
+  const source = {
+    manifestSrc: `data:application/dash+xml;charset=UTF-8,${'€'.repeat(700_000)}`,
+    manifestMimeType: 'application/dash+xml',
+    legacyFormats: [],
+    isLive: false,
+    version: '2026.08.13'
+  }
+
+  expect(await page.evaluate(source => {
+    return window.ftElectron.ytDlpPlaybackCacheSet(
+      'eeeeeeeeeee',
+      'settings',
+      Date.now() + 60 * 60 * 1000,
+      source
+    )
+  }, source)).toBe(false)
+})
+
 async function readPlaylist(app, id) {
   const contents = await readFile(path.join(app.userDataDir, 'playlists.db'), 'utf8')
   const records = contents.trim().split('\n').map((line) => JSON.parse(line))

--- a/e2e/tests/offline/video-actions.spec.mjs
+++ b/e2e/tests/offline/video-actions.spec.mjs
@@ -51,6 +51,30 @@ const SEED = {
 
 test.use({ seed: SEED })
 
+test('persists the yt-dlp playback cache across app restarts', async ({ app, page }) => {
+  const expiryTime = Date.now() + 60 * 60 * 1000
+  const source = {
+    manifestSrc: 'data:application/dash+xml;charset=UTF-8,manifest',
+    manifestMimeType: 'application/dash+xml',
+    legacyFormats: [],
+    isLive: false,
+    version: '2026.08.13'
+  }
+
+  expect(await page.evaluate(({ expiryTime, source }) => {
+    return window.ftElectron.ytDlpPlaybackCacheSet('eeeeeeeeeee', 'settings', expiryTime, source)
+  }, { expiryTime, source })).toBe(true)
+
+  ;({ page } = await app.relaunch())
+
+  expect(await page.evaluate(() => {
+    return window.ftElectron.ytDlpPlaybackCacheGet('eeeeeeeeeee', 'settings')
+  })).toEqual({ expiryTime, source })
+  expect(await page.evaluate(() => {
+    return window.ftElectron.ytDlpPlaybackCacheGet('eeeeeeeeeee', 'other-settings')
+  })).toBeNull()
+})
+
 async function readPlaylist(app, id) {
   const contents = await readFile(path.join(app.userDataDir, 'playlists.db'), 'utf8')
   const records = contents.trim().split('\n').map((line) => JSON.parse(line))

--- a/src/constants.js
+++ b/src/constants.js
@@ -131,6 +131,10 @@ const IpcChannels = {
   YT_DLP_CHOOSE_EXECUTABLE: 'yt-dlp-choose-executable',
   YT_DLP_GET_INFO: 'yt-dlp-get-info',
   YT_DLP_GET_PLAYBACK_INFO: 'yt-dlp-get-playback-info',
+  YT_DLP_PLAYBACK_CACHE_GET: 'yt-dlp-playback-cache-get',
+  YT_DLP_PLAYBACK_CACHE_SET: 'yt-dlp-playback-cache-set',
+  YT_DLP_PLAYBACK_CACHE_DELETE: 'yt-dlp-playback-cache-delete',
+  YT_DLP_PLAYBACK_CACHE_CLEAR: 'yt-dlp-playback-cache-clear',
   YT_DLP_DOWNLOAD_BINARY: 'yt-dlp-download-binary',
   YT_DLP_BINARY_DOWNLOAD_PROGRESS: 'yt-dlp-binary-download-progress',
   YT_DLP_BINARY_UPDATED: 'yt-dlp-binary-updated'

--- a/src/main/index.js
+++ b/src/main/index.js
@@ -32,6 +32,7 @@ import { brotliDecompress } from 'zlib'
 import packageDetails from '../../package.json'
 import { handleOpenInExternalPlayer } from './externalPlayer'
 import { handleYtDlpCancelDownload, handleYtDlpClearDownloads, handleYtDlpDownload, handleYtDlpDownloadBinary, handleYtDlpGetInfo, handleYtDlpGetPlaybackInfo, handleYtDlpListDownloads, handleYtDlpOpenDownload, handleYtDlpRemoveDownload, shutdownYtDlpDownloads } from './ytDlp'
+import { handleYtDlpPlaybackCacheClear, handleYtDlpPlaybackCacheDelete, handleYtDlpPlaybackCacheGet, handleYtDlpPlaybackCacheSet } from './ytDlpPlaybackCache'
 import { generatePoToken } from './poTokenGenerator'
 import { buildProxyUrl, DEFAULT_PROXY_SETTINGS, isOpenTubeXUrl } from './utils'
 import { TabManager, setupTabsIPC } from './tabs/TabManager'
@@ -3517,6 +3518,10 @@ function runApp() {
   ipcMain.handle(IpcChannels.YT_DLP_GET_INFO, handleYtDlpGetInfo)
 
   ipcMain.handle(IpcChannels.YT_DLP_GET_PLAYBACK_INFO, handleYtDlpGetPlaybackInfo)
+  ipcMain.handle(IpcChannels.YT_DLP_PLAYBACK_CACHE_GET, handleYtDlpPlaybackCacheGet)
+  ipcMain.handle(IpcChannels.YT_DLP_PLAYBACK_CACHE_SET, handleYtDlpPlaybackCacheSet)
+  ipcMain.handle(IpcChannels.YT_DLP_PLAYBACK_CACHE_DELETE, handleYtDlpPlaybackCacheDelete)
+  ipcMain.handle(IpcChannels.YT_DLP_PLAYBACK_CACHE_CLEAR, handleYtDlpPlaybackCacheClear)
 
   ipcMain.handle(IpcChannels.YT_DLP_DOWNLOAD_BINARY, handleYtDlpDownloadBinary)
 

--- a/src/main/ytDlpPlaybackCache.js
+++ b/src/main/ytDlpPlaybackCache.js
@@ -1,4 +1,5 @@
 import { app } from 'electron'
+import { Buffer } from 'node:buffer'
 import { createHash } from 'node:crypto'
 import { readFile, rename, writeFile } from 'node:fs/promises'
 import { join } from 'node:path'
@@ -41,14 +42,14 @@ function isValidCacheKey(cacheKey) {
 function isValidEntry(entry) {
   if (entry === null || typeof entry !== 'object') return false
 
-  let serializedLength
+  let serializedEntry
   try {
-    serializedLength = JSON.stringify(entry).length
+    serializedEntry = JSON.stringify(entry)
   } catch {
     return false
   }
 
-  return serializedLength <= MAX_ENTRY_LENGTH &&
+  return Buffer.byteLength(serializedEntry, 'utf8') <= MAX_ENTRY_LENGTH &&
     VIDEO_ID_REGEX.test(entry.videoId) &&
     CACHE_KEY_HASH_REGEX.test(entry.cacheKeyHash) &&
     Number.isFinite(entry.expiryTime) &&

--- a/src/main/ytDlpPlaybackCache.js
+++ b/src/main/ytDlpPlaybackCache.js
@@ -1,0 +1,171 @@
+import { app } from 'electron'
+import { createHash } from 'node:crypto'
+import { readFile, rename, writeFile } from 'node:fs/promises'
+import { join } from 'node:path'
+
+import { isOpenTubeXUrl } from './utils'
+
+const CACHE_FILENAME = 'yt-dlp-playback-cache.json'
+const MAX_ENTRIES = 50
+const EXPIRY_MARGIN_MS = 2 * 60 * 1000
+const MAX_ENTRY_LENGTH = 2_000_000
+const MAX_CACHE_KEY_LENGTH = 20_000
+const VIDEO_ID_REGEX = /^[\w-]{11}$/
+const CACHE_KEY_HASH_REGEX = /^[a-f\d]{64}$/
+
+/** @type {Map<string, YtDlpPlaybackCacheEntry>} */
+const entries = new Map()
+let loadPromise = null
+let writeQueue = Promise.resolve()
+
+/**
+ * @typedef {object} YtDlpPlaybackCacheEntry
+ * @property {string} videoId
+ * @property {string} cacheKeyHash
+ * @property {number} expiryTime
+ * @property {object} source
+ */
+
+function cachePath() {
+  return join(app.getPath('userData'), CACHE_FILENAME)
+}
+
+function hashCacheKey(cacheKey) {
+  return createHash('sha256').update(cacheKey).digest('hex')
+}
+
+function isValidCacheKey(cacheKey) {
+  return typeof cacheKey === 'string' && cacheKey.length <= MAX_CACHE_KEY_LENGTH
+}
+
+function isValidEntry(entry) {
+  if (entry === null || typeof entry !== 'object') return false
+
+  let serializedLength
+  try {
+    serializedLength = JSON.stringify(entry).length
+  } catch {
+    return false
+  }
+
+  return serializedLength <= MAX_ENTRY_LENGTH &&
+    VIDEO_ID_REGEX.test(entry.videoId) &&
+    CACHE_KEY_HASH_REGEX.test(entry.cacheKeyHash) &&
+    Number.isFinite(entry.expiryTime) &&
+    entry.source !== null &&
+    typeof entry.source === 'object' &&
+    entry.source.isLive === false &&
+    entry.source.manifestMimeType === 'application/dash+xml' &&
+    typeof entry.source.manifestSrc === 'string' &&
+    entry.source.manifestSrc.startsWith('data:application/dash+xml;') &&
+    Array.isArray(entry.source.legacyFormats)
+}
+
+async function loadEntries() {
+  if (loadPromise === null) {
+    loadPromise = (async () => {
+      try {
+        const storedEntries = JSON.parse(await readFile(cachePath(), 'utf8'))
+        if (!Array.isArray(storedEntries)) return
+
+        for (const entry of storedEntries.slice(-MAX_ENTRIES)) {
+          if (isValidEntry(entry) && Date.now() < entry.expiryTime - EXPIRY_MARGIN_MS) {
+            entries.set(entry.videoId, entry)
+          }
+        }
+      } catch (error) {
+        if (error.code !== 'ENOENT') {
+          console.warn('Could not load the yt-dlp playback cache', error)
+        }
+      }
+    })()
+  }
+  await loadPromise
+}
+
+function saveEntries() {
+  writeQueue = writeQueue
+    .catch(() => {})
+    .then(async () => {
+      const path = cachePath()
+      const temporaryPath = `${path}.tmp`
+      await writeFile(temporaryPath, JSON.stringify([...entries.values()]), 'utf8')
+      await rename(temporaryPath, path)
+    })
+  return writeQueue
+}
+
+export async function handleYtDlpPlaybackCacheGet(event, videoId, cacheKey) {
+  if (
+    !isOpenTubeXUrl(event.senderFrame.url) ||
+    !VIDEO_ID_REGEX.test(videoId) ||
+    !isValidCacheKey(cacheKey)
+  ) return null
+
+  await loadEntries()
+  const entry = entries.get(videoId)
+  if (entry === undefined) return null
+
+  if (
+    entry.cacheKeyHash !== hashCacheKey(cacheKey) ||
+    Date.now() >= entry.expiryTime - EXPIRY_MARGIN_MS
+  ) {
+    entries.delete(videoId)
+    await saveEntries()
+    return null
+  }
+
+  return { expiryTime: entry.expiryTime, source: entry.source }
+}
+
+export async function handleYtDlpPlaybackCacheSet(event, videoId, cacheKey, expiryTime, source) {
+  if (
+    !isOpenTubeXUrl(event.senderFrame.url) ||
+    !VIDEO_ID_REGEX.test(videoId) ||
+    !isValidCacheKey(cacheKey)
+  ) return false
+
+  const entry = {
+    videoId,
+    cacheKeyHash: hashCacheKey(cacheKey),
+    expiryTime,
+    source: source === null || typeof source !== 'object'
+      ? source
+      : {
+          manifestSrc: source.manifestSrc,
+          manifestMimeType: source.manifestMimeType,
+          legacyFormats: source.legacyFormats,
+          isLive: source.isLive,
+          version: source.version
+        }
+  }
+
+  if (!isValidEntry(entry)) return false
+  if (Date.now() >= entry.expiryTime - EXPIRY_MARGIN_MS) return false
+
+  await loadEntries()
+  entries.delete(entry.videoId)
+  while (entries.size >= MAX_ENTRIES) {
+    entries.delete(entries.keys().next().value)
+  }
+  entries.set(entry.videoId, entry)
+  await saveEntries()
+  return true
+}
+
+export async function handleYtDlpPlaybackCacheDelete(event, videoId) {
+  if (!isOpenTubeXUrl(event.senderFrame.url) || !VIDEO_ID_REGEX.test(videoId)) return false
+
+  await loadEntries()
+  if (entries.delete(videoId)) await saveEntries()
+  return true
+}
+
+export async function handleYtDlpPlaybackCacheClear(event) {
+  if (!isOpenTubeXUrl(event.senderFrame.url)) return false
+
+  await loadEntries()
+  entries.clear()
+  await saveEntries()
+  return true
+}

--- a/src/preload/interface.js
+++ b/src/preload/interface.js
@@ -358,6 +358,22 @@ export default {
     return ipcRenderer.invoke(IpcChannels.YT_DLP_GET_PLAYBACK_INFO, videoId)
   },
 
+  ytDlpPlaybackCacheGet: (videoId, cacheKey) => {
+    return ipcRenderer.invoke(IpcChannels.YT_DLP_PLAYBACK_CACHE_GET, videoId, cacheKey)
+  },
+
+  ytDlpPlaybackCacheSet: (videoId, cacheKey, expiryTime, source) => {
+    return ipcRenderer.invoke(IpcChannels.YT_DLP_PLAYBACK_CACHE_SET, videoId, cacheKey, expiryTime, source)
+  },
+
+  ytDlpPlaybackCacheDelete: (videoId) => {
+    return ipcRenderer.invoke(IpcChannels.YT_DLP_PLAYBACK_CACHE_DELETE, videoId)
+  },
+
+  ytDlpPlaybackCacheClear: () => {
+    return ipcRenderer.invoke(IpcChannels.YT_DLP_PLAYBACK_CACHE_CLEAR)
+  },
+
   /**
    * @param {'yt-dlp' | 'ffmpeg'} binary
    * @returns {Promise<{ version: string, updated: boolean } | { error: string } | null>}

--- a/src/renderer/helpers/player/ytDlpPlayback.js
+++ b/src/renderer/helpers/player/ytDlpPlayback.js
@@ -28,10 +28,16 @@ const dashPlaybackSourceCache = new YtDlpPlaybackSourceCache()
  */
 export function invalidateYtDlpPlaybackSource(videoId) {
   dashPlaybackSourceCache.delete(videoId)
+  window.ftElectron.ytDlpPlaybackCacheDelete(videoId).catch(error => {
+    console.warn('Could not remove an entry from the persistent yt-dlp playback cache', error)
+  })
 }
 
 export function invalidateAllYtDlpPlaybackSources() {
   dashPlaybackSourceCache.clear()
+  window.ftElectron.ytDlpPlaybackCacheClear().catch(error => {
+    console.warn('Could not clear the persistent yt-dlp playback cache', error)
+  })
 }
 
 /**
@@ -240,7 +246,25 @@ async function convertAdaptiveFormats(formats, duration) {
  * @returns {Promise<YtDlpPlaybackSource>}
  */
 export async function getYtDlpPlaybackSource(videoId, cacheKey = '') {
-  const cachedSource = dashPlaybackSourceCache.get(videoId, cacheKey)
+  let cachedSource = dashPlaybackSourceCache.get(videoId, cacheKey)
+
+  if (cachedSource === null) {
+    try {
+      const entry = await window.ftElectron.ytDlpPlaybackCacheGet(videoId, cacheKey)
+      if (entry !== null) {
+        const source = { ...entry.source, expiryDate: new Date(entry.expiryTime) }
+        dashPlaybackSourceCache.set(videoId, cacheKey, source)
+        cachedSource = dashPlaybackSourceCache.get(videoId, cacheKey)
+
+        if (cachedSource === null) {
+          await window.ftElectron.ytDlpPlaybackCacheDelete(videoId)
+        }
+      }
+    } catch (error) {
+      console.warn('Could not read the persistent yt-dlp playback cache', error)
+    }
+  }
+
   if (cachedSource !== null) {
     return cachedSource
   }
@@ -280,6 +304,16 @@ export async function getYtDlpPlaybackSource(videoId, cacheKey = '') {
       }
 
       dashPlaybackSourceCache.set(videoId, cacheKey, source)
+      try {
+        await window.ftElectron.ytDlpPlaybackCacheSet(
+          videoId,
+          cacheKey,
+          source.expiryDate?.getTime() ?? NaN,
+          source
+        )
+      } catch (error) {
+        console.warn('Could not save the persistent yt-dlp playback cache', error)
+      }
       return source
     }
   }

--- a/src/renderer/helpers/player/ytDlpPlaybackCache.js
+++ b/src/renderer/helpers/player/ytDlpPlaybackCache.js
@@ -42,12 +42,15 @@ export class YtDlpPlaybackSourceCache {
    */
   get(videoId, cacheKey) {
     const entry = this.sources.get(videoId)
+    const expiryTime = entry?.source.expiryDate instanceof Date
+      ? entry.source.expiryDate.getTime()
+      : NaN
 
     if (
       entry === undefined ||
       entry.cacheKey !== cacheKey ||
-      entry.source.expiryDate === null ||
-      this.now() >= entry.source.expiryDate.getTime() - this.expiryMarginMs
+      !Number.isFinite(expiryTime) ||
+      this.now() >= expiryTime - this.expiryMarginMs
     ) {
       this.sources.delete(videoId)
       return null
@@ -65,9 +68,10 @@ export class YtDlpPlaybackSourceCache {
    * @param {import('./ytDlpPlayback').YtDlpPlaybackSource} source
    */
   set(videoId, cacheKey, source) {
+    const expiryTime = source.expiryDate instanceof Date ? source.expiryDate.getTime() : NaN
     if (
-      source.expiryDate === null ||
-      this.now() >= source.expiryDate.getTime() - this.expiryMarginMs
+      !Number.isFinite(expiryTime) ||
+      this.now() >= expiryTime - this.expiryMarginMs
     ) {
       return
     }


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Make sure to follow the contributing guidelines. -->
<!-- Important note, we may remove your pull request if you do not use this provided PR template correctly. -->
<!-- Agent instructions: Preserve every heading, comment, and marker in this template. Never remove or rewrite the release-note-category:start/end, release-note:start/end, or release-note-image:start/end marker pairs. Never remove or rewrite the Release note images section; leave its contents for a human. -->

## Pull Request Type
<!-- Please select what type of pull request this is: [x] -->
- [x] Bugfix
- [ ] Feature Implementation
- [ ] Documentation
- [ ] Other

## Related issue
<!-- Please link the issue your pull request is referring to. -->
<!-- If this pull request fully resolves the relevant issue, put "closes" before the issue number. -->
<!-- Example: "closes #123456". -->
Follow-up to #691.

## Description
<!-- Please write a clear and concise description of what the pull request does. -->
The DASH cache introduced in #691 only lived in renderer memory, so restarting the app caused another yt-dlp extraction even while the signed stream URLs were still valid.

This stores non-live yt-dlp DASH sources in the app data directory and restores them until two minutes before the earliest signed stream URL expires. The cache is bounded, written atomically, and keyed by a SHA-256 fingerprint of the yt-dlp and proxy configuration so credentials are not written to disk. Playback recovery and managed yt-dlp updates invalidate both the memory and disk cache.

## Release note category
<!-- Select exactly one category. Every pull request must select one. -->
<!-- Select "Not noteworthy" when the pull request fixes a bug in or improves functionality that has not yet appeared in a stable release. -->
<!-- release-note-category:start -->
- [x] Not noteworthy
- [ ] Highlights
- [ ] More improvements
- [ ] Fixed bugs
<!-- release-note-category:end -->

## Release note
<!-- Required unless "Not noteworthy" is selected. -->
<!-- Write one concise, user-facing entry without a leading bullet. -->
<!-- release-note:start -->
Retained valid yt-dlp stream URLs across app restarts.
<!-- release-note:end -->

## Release note images
<!-- Human-only: Agents must preserve this entire section and leave it empty. -->
<!-- Optional. Paste one or more Markdown images or HTML image tags here. -->
<!-- The release notes will use an HTML image tag and limit images taller than 300 pixels. -->
<!-- release-note-image:start -->

<!-- release-note-image:end -->

## Testing
<!-- How can reviewers verify that the PR produces correct results? -->
<!-- Please provide instructions so that others can ensure that your pull request would produce correct results. For examples see, https://github.com/FreeTubeApp/FreeTube/pull/5743, https://github.com/FreeTubeApp/FreeTube/pull/7349, https://github.com/FreeTubeApp/FreeTube/pull/5125, https://github.com/FreeTubeApp/FreeTube/pull/7338 -->
<!-- Agent instructions: Only write human-facing steps that explain how to verify the change while running this branch in dev mode. Include expected results and, when applicable, helpful console snippets for interactive verification. Do not include automated checks, commands, results, pass counts, or CI status. -->
1. Select yt-dlp playback and open a regular video until playback starts.
2. Quit and reopen the app before the stream URLs expire, then open the same video again. It should begin playback without showing the yt-dlp stream-fetching message.
3. Change the yt-dlp path or proxy configuration and reopen the video. It should perform a fresh extraction.
4. Trigger a terminal playback error or update the managed yt-dlp binary. Reopening the video should use newly extracted URLs.

## Additional context
<!-- Add any other context about the pull request here. -->
The cache stores at most 50 entries with a 2 MB limit per entry. Live/HLS playback remains uncached because those manifests refresh dynamically.

Implemented with GPT-5 in Codex.