### PR TITLE
fix(settings): open settings from the About quick menu

### DIFF
--- a/e2e/tests/offline/quick-settings.spec.mjs
+++ b/e2e/tests/offline/quick-settings.spec.mjs
@@ -93,7 +93,7 @@ test.describe('quick settings menu', () => {
     await expect(menu).toBeHidden()
   })
 
-  test('opens About in the settings-style window', async ({ page }) => {
+  test('opens About and switches to Settings from the quick menu', async ({ page }) => {
     await page.locator('.profileTrigger').click()
     await page.getByRole('dialog', { name: 'Quick settings' }).getByRole('button', { name: 'About' }).click()
 
@@ -101,6 +101,13 @@ test.describe('quick settings menu', () => {
     await expect(aboutWindow).toBeVisible()
     await expect(aboutWindow.locator('.settingsBreadcrumb')).toContainText('About')
     await expect(aboutWindow.locator('.settingsMenu')).toHaveCount(0)
+
+    await page.locator('.profileTrigger').click()
+    await page.getByRole('dialog', { name: 'Quick settings' }).getByRole('button', { name: 'All Settings' }).click()
+
+    const settingsWindow = page.getByRole('dialog', { name: 'Settings', exact: true })
+    await expect(settingsWindow).toBeVisible()
+    await expect(settingsWindow.locator('.settingsMenu')).toBeVisible()
   })
 })
 

--- a/src/renderer/components/FtQuickSettingsMenu/FtQuickSettingsMenu.vue
+++ b/src/renderer/components/FtQuickSettingsMenu/FtQuickSettingsMenu.vue
@@ -560,7 +560,7 @@ function handleHideRecommendedVideos(value) {
 
 function openSettings() {
   menuOpen.value = false
-  store.dispatch('toggleSettingsWindow')
+  store.dispatch('showSettingsWindow')
 }
 
 function openKeyboardShortcuts() {


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Make sure to follow the contributing guidelines. -->
<!-- Important note, we may remove your pull request if you do not use this provided PR template correctly. -->
<!-- Agent instructions: Preserve every heading, comment, and marker in this template. Never remove or rewrite the release-note-category:start/end, release-note:start/end, or release-note-image:start/end marker pairs. Never remove or rewrite the Release note images section; leave its contents for a human. -->

## Pull Request Type
<!-- Please select what type of pull request this is: [x] -->
- [x] Bugfix
- [ ] Feature Implementation
- [ ] Documentation
- [ ] Other

## Related issue
<!-- Please link the issue your pull request is referring to. -->
<!-- If this pull request fully resolves the relevant issue, put "closes" before the issue number. -->
<!-- Example: "closes #123456". -->

## Description
<!-- Please write a clear and concise description of what the pull request does. -->
Opening About puts the app's settings-style window into its About view. The quick-settings cog previously toggled that window, so clicking it while About was open closed the window instead of opening Settings.

The cog now explicitly opens the root Settings view. The quick-settings E2E coverage also exercises the About-to-Settings transition to prevent regressions.

## Release note category
<!-- Select exactly one category. Every pull request must select one. -->
<!-- Select "Not noteworthy" when the pull request fixes a bug in or improves functionality that has not yet appeared in a stable release. -->
<!-- release-note-category:start -->
- [ ] Not noteworthy
- [ ] Highlights
- [ ] More improvements
- [x] Fixed bugs
<!-- release-note-category:end -->

## Release note
<!-- Required unless "Not noteworthy" is selected. -->
<!-- Write one concise, user-facing entry without a leading bullet. -->
<!-- release-note:start -->
Opening Settings from the quick-settings menu now works while About is open.
<!-- release-note:end -->

## Release note images
<!-- Human-only: Agents must preserve this entire section and leave it empty. -->
<!-- Optional. Paste one or more Markdown images or HTML image tags here. -->
<!-- The release notes will use an HTML image tag and limit images taller than 300 pixels. -->
<!-- release-note-image:start -->

<!-- release-note-image:end -->

## Testing
<!-- How can reviewers verify that the PR produces correct results? -->
<!-- Please provide instructions so that others can ensure that the pull request produces correct results. For examples see, https://github.com/FreeTubeApp/FreeTube/pull/5743, https://github.com/FreeTubeApp/FreeTube/pull/7349, https://github.com/FreeTubeApp/FreeTube/pull/5125, https://github.com/FreeTubeApp/FreeTube/pull/7338 -->
<!-- Agent instructions: Only write human-facing steps that explain how to verify the change while running this branch in dev mode. Include expected results and, when applicable, helpful console snippets for interactive verification. Do not include automated checks, commands, results, pass counts, or CI status. -->
1. Open the quick-settings menu and select About.
2. Reopen the quick-settings menu while About remains visible.
3. Click the cog button.
4. Confirm the Settings window stays open and shows the full settings menu.

## Additional context
<!-- Add any other context about the pull request here. -->
