### PR TITLE
fix(player): keep Shorts controls synchronized

### DIFF
--- a/e2e/tests/network/watch.spec.mjs
+++ b/e2e/tests/network/watch.spec.mjs
@@ -1443,6 +1443,26 @@ test.describe('custom Shorts player', () => {
     await expect(topControls).toHaveCSS('opacity', '0')
     await expect(topControls).toHaveCSS('transition-duration', '0.6s, 0s')
 
+    const hiddenSeekBarState = await player.evaluate(element => {
+      const videoElement = element.querySelector('video')
+      const seekInput = element.querySelector('.shaka-seek-bar')
+      const seekRange = element.ui.getControls().getPlayer().seekRange()
+      const currentTime = seekRange.start + (seekRange.end - seekRange.start) / 2
+      seekInput.value = seekRange.start
+      videoElement.currentTime = currentTime
+      window.dispatchEvent(new Event('blur'))
+      videoElement.dispatchEvent(new Event('timeupdate'))
+      return { currentTime, seekValue: Number(seekInput.value) }
+    })
+    expect(hiddenSeekBarState.seekValue).toBeCloseTo(hiddenSeekBarState.currentTime, 3)
+
+    const volumeSlider = player.locator('.shortsVolumeSlider')
+    await video.evaluate(element => {
+      element.muted = false
+      element.volume = 0.37
+    })
+    await expect(volumeSlider).toHaveValue('37')
+
     await expect(seekBar).toHaveCSS('opacity', '1')
     await expect(seekBar).toHaveCSS('height', '3px')
     await expect(seekBar).toHaveCSS('bottom', '-2px')
@@ -1503,6 +1523,7 @@ test.describe('custom Shorts player', () => {
     const topControls = player.locator('.shortsTopControls')
     const actionDock = player.locator('.fullscreenActions')
     const videoSpace = player.locator('.shortsFullscreenVideoSpace')
+    const seekBar = player.locator('.shaka-seek-bar-container')
     const [playerBounds, videoBounds] = await Promise.all([
       player.boundingBox(),
       videoSpace.boundingBox(),
@@ -1517,12 +1538,17 @@ test.describe('custom Shorts player', () => {
     await expect(controls).toHaveAttribute('shown', 'true')
     await expect(topControls).toHaveCSS('opacity', '1')
 
+    await player.evaluate(element => element.classList.add('no-cursor'))
     await page.mouse.move(playerBounds.x + 8, playerBounds.y + playerBounds.height / 2)
+    await expect(player).not.toHaveClass(/no-cursor/)
     await expect(controls).not.toHaveAttribute('shown', 'true')
     await expect(topControls).toHaveCSS('transition-duration', '0.6s, 0s, 0.25s, 0.25s')
     await expect(topControls).toHaveCSS('opacity', '0')
     await expect(actionDock).toHaveCSS('opacity', '1')
     await expect(actionDock).toHaveCSS('pointer-events', 'auto')
+    const seekBarBounds = await seekBar.boundingBox()
+    expect(Math.abs(seekBarBounds.x - videoBounds.x)).toBeLessThan(2)
+    expect(Math.abs(seekBarBounds.width - videoBounds.width)).toBeLessThan(2)
 
     await page.mouse.move(
       videoBounds.x + videoBounds.width / 2,

--- a/e2e/tests/network/watch.spec.mjs
+++ b/e2e/tests/network/watch.spec.mjs
@@ -1498,7 +1498,7 @@ test.describe('custom Shorts player', () => {
     expect((await replayIcon.locator('path').getAttribute('d')).length).toBeGreaterThan(20)
   })
 
-  test('fullscreen Shorts controls follow the video hover area', async ({ page, innertube }) => {
+  test('fullscreen Shorts controls follow the video hover area', async ({ app, page, innertube }) => {
     test.skip(innertube.replay, 'no recorded fixtures for this Short')
     await page.locator(sel.searchInput).fill('https://www.youtube.com/shorts/w1WKmSqwM8I')
     await page.locator(sel.searchInput).press('Enter')
@@ -1556,6 +1556,17 @@ test.describe('custom Shorts player', () => {
     )
     await expect(controls).toHaveAttribute('shown', 'true')
     await expect(topControls).toHaveCSS('opacity', '1')
+
+    await setPlayerFullscreen(page, false)
+    await setWindowWidth(app, 600)
+    await player.evaluate(element => element.classList.add('fullWindow'))
+    await expect(player).toHaveCSS('width', '600px')
+    const [narrowVideoBounds, narrowSeekBarBounds] = await Promise.all([
+      videoSpace.boundingBox(),
+      seekBar.boundingBox(),
+    ])
+    expect(Math.abs(narrowSeekBarBounds.x - narrowVideoBounds.x)).toBeLessThan(2)
+    expect(Math.abs(narrowSeekBarBounds.width - narrowVideoBounds.width)).toBeLessThan(2)
   })
 
   test('preserves the tall aspect ratio of an explicit Shorts link', async ({ page, innertube }) => {

--- a/src/renderer/components/ft-shaka-video-player/ft-shaka-video-player.css
+++ b/src/renderer/components/ft-shaka-video-player/ft-shaka-video-player.css
@@ -245,14 +245,28 @@
   transition: none;
 }
 
+.ftVideoPlayer.shortsPlayer:is(:fullscreen, .fullWindow) {
+  --shorts-metadata-min-width: min(
+    220px,
+    calc((100vw - var(--shorts-dock-width, 0px)) / 3)
+  );
+  --shorts-video-width: min(
+    calc(100dvh * var(--shorts-aspect-ratio)),
+    calc(
+      100vw - var(--shorts-dock-width, 0px) -
+      var(--shorts-metadata-min-width)
+    )
+  );
+}
+
 .ftVideoPlayer.shortsPlayer:is(:fullscreen, .fullWindow) :deep(.shaka-seek-bar-container) {
   inset-inline: auto;
-  inset-inline-start: 50%;
-  inline-size: min(
-    calc(100dvh * var(--shorts-aspect-ratio)),
-    100%
+  inset-inline-start: max(
+    calc((100% - var(--shorts-video-width)) / 2),
+    var(--shorts-metadata-min-width)
   );
-  transform: translateX(-50%);
+  inline-size: var(--shorts-video-width);
+  transform: none;
 }
 
 .ftVideoPlayer.shortsPlayer :deep(.shaka-seek-bar-container .shaka-range-element::-webkit-slider-thumb) {
@@ -331,11 +345,6 @@
 
 .ftVideoPlayer.shortsPlayer:fullscreen .shortsFullscreenMetadata,
 .ftVideoPlayer.shortsPlayer.fullWindow .shortsFullscreenMetadata {
-  --shorts-metadata-min-width: min(
-    220px,
-    calc((100vw - var(--shorts-dock-width, 0px)) / 3)
-  );
-
   position: absolute;
   z-index: 5;
   inset-block: 0;
@@ -364,13 +373,7 @@
 .shortsFullscreenVideoSpace {
   grid-column: 2;
   block-size: 100%;
-  inline-size: min(
-    calc(100dvh * var(--shorts-aspect-ratio)),
-    calc(
-      100vw - var(--shorts-dock-width, 0px) -
-      var(--shorts-metadata-min-width)
-    )
-  );
+  inline-size: var(--shorts-video-width);
   aspect-ratio: var(--shorts-aspect-ratio);
 }
 

--- a/src/renderer/components/ft-shaka-video-player/ft-shaka-video-player.css
+++ b/src/renderer/components/ft-shaka-video-player/ft-shaka-video-player.css
@@ -245,6 +245,16 @@
   transition: none;
 }
 
+.ftVideoPlayer.shortsPlayer:is(:fullscreen, .fullWindow) :deep(.shaka-seek-bar-container) {
+  inset-inline: auto;
+  inset-inline-start: 50%;
+  inline-size: min(
+    calc(100dvh * var(--shorts-aspect-ratio)),
+    100%
+  );
+  transform: translateX(-50%);
+}
+
 .ftVideoPlayer.shortsPlayer :deep(.shaka-seek-bar-container .shaka-range-element::-webkit-slider-thumb) {
   opacity: 0;
   transform: scale(0);

--- a/src/renderer/components/ft-shaka-video-player/ft-shaka-video-player.js
+++ b/src/renderer/components/ft-shaka-video-player/ft-shaka-video-player.js
@@ -4901,6 +4901,7 @@ export default defineComponent({
       const video_ = video.value
       const muted = video_.muted || video_.volume === 0
       shortsMuted.value = muted
+      scrollMiniVolume.value = muted ? 0 : video_.volume
 
       syncMuteControlIcons(muted)
 
@@ -4972,6 +4973,7 @@ export default defineComponent({
         const currentTime = video.value.currentTime
         sponsorBlockCurrentTime.value = currentTime
         annotationCurrentTime.value = currentTime
+        updateHiddenShortsSeekBar(currentTime)
 
         emit('timeupdate', currentTime)
         emitTerminalSponsorBlockOutroStarted(currentTime)
@@ -4996,6 +4998,58 @@ export default defineComponent({
 
         updateScrollMiniDragHandleContrast()
       }
+    }
+
+    /**
+     * Shaka stops refreshing its seek bar while its controls are hidden, but
+     * Shorts keep the seek bar visible. Keep that visible progress in sync
+     * without interfering while Shaka is showing or operating the controls.
+     * @param {number} currentTime
+     */
+    function updateHiddenShortsSeekBar(currentTime) {
+      const controls = ui?.getControls()
+      if (!props.shortsPlayer || !hasLoaded.value || !player || !controls ||
+          controls.getControlsContainer().hasAttribute('shown') || controls.isSeeking()) {
+        return
+      }
+
+      const seekBarContainer = container.value?.querySelector('.shaka-seek-bar-container')
+      const seekBar = seekBarContainer?.querySelector('.shaka-seek-bar')
+      if (!(seekBarContainer instanceof HTMLElement) || !(seekBar instanceof HTMLInputElement)) {
+        return
+      }
+
+      const seekRange = player.seekRange()
+      const seekRangeSize = seekRange.end - seekRange.start
+      if (seekRangeSize <= 0) {
+        return
+      }
+
+      const clampedCurrentTime = Math.min(Math.max(currentTime, seekRange.start), seekRange.end)
+      const buffered = video.value.buffered
+      const bufferedEnd = buffered.length > 0
+        ? Math.min(buffered.end(buffered.length - 1), seekRange.end)
+        : clampedCurrentTime
+      const playedPercent = (clampedCurrentTime - seekRange.start) / seekRangeSize * 100
+      const bufferedPercent = Math.max(
+        playedPercent,
+        (bufferedEnd - seekRange.start) / seekRangeSize * 100
+      )
+      const colors = ui.getConfiguration().seekBarColors
+      const gradient = [
+        'to right',
+        `${colors.played} 0%`,
+        `${colors.played} ${playedPercent}%`,
+        `${colors.buffered} ${playedPercent}%`,
+        `${colors.buffered} ${bufferedPercent}%`,
+        `${colors.base} ${bufferedPercent}%`,
+        `${colors.base} 100%`,
+      ]
+
+      seekBar.min = seekRange.start.toString()
+      seekBar.max = seekRange.end.toString()
+      seekBar.value = clampedCurrentTime.toString()
+      seekBarContainer.style.background = `linear-gradient(${gradient.join(', ')})`
     }
 
     /**
@@ -6047,6 +6101,7 @@ export default defineComponent({
       const bounds = videoSpace.getBoundingClientRect()
       if (event.clientX < bounds.left || event.clientX > bounds.right ||
           event.clientY < bounds.top || event.clientY > bounds.bottom) {
+        container.value.classList.remove('no-cursor')
         event.stopPropagation()
         ui?.getControls().getControlsContainer().removeAttribute('shown')
       }


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Make sure to follow the contributing guidelines. -->
<!-- Important note, we may remove your pull request if you do not use this provided PR template correctly. -->
<!-- Agent instructions: Preserve every heading, comment, and marker in this template. Never remove or rewrite the release-note-category:start/end, release-note:start/end, or release-note-image:start/end marker pairs. Never remove or rewrite the Release note images section; leave its contents for a human. -->

## Pull Request Type
<!-- Please select what type of pull request this is: [x] -->
- [x] Bugfix
- [ ] Feature Implementation
- [ ] Documentation
- [ ] Other

## Related issue
<!-- Please link the issue your pull request is referring to. -->
<!-- If this pull request fully resolves the relevant issue, put "closes" before the issue number. -->
<!-- Example: "closes #123456". -->

## Description
<!-- Please write a clear and concise description of what the pull request does. -->
The Shorts player could display stale control state: its volume slider started at 100% instead of the restored media volume, its always-visible seek bar stopped refreshing while Shaka's controls were hidden, and fullscreen gutter movement could leave the cursor hidden. The fullscreen seek bar also spanned the viewport rather than the vertical video.

This keeps the custom volume and seek state synchronized with the media element, restores the cursor on movement outside the fullscreen video without revealing playback controls, and sizes the fullscreen seek bar to the unrounded video region.

## Release note category
<!-- Select exactly one category. Every pull request must select one. -->
<!-- Select "Not noteworthy" when the pull request fixes a bug in or improves functionality that has not yet appeared in a stable release. -->
<!-- release-note-category:start -->
- [ ] Not noteworthy
- [ ] Highlights
- [ ] More improvements
- [x] Fixed bugs
<!-- release-note-category:end -->

## Release note
<!-- Required unless "Not noteworthy" is selected. -->
<!-- Write one concise, user-facing entry without a leading bullet. -->
<!-- release-note:start -->
Improved volume, seek bar, and fullscreen cursor behavior in the Shorts player.
<!-- release-note:end -->

## Release note images
<!-- Human-only: Agents must preserve this entire section and leave it empty. -->
<!-- Optional. Paste one or more Markdown images or HTML image tags here. -->
<!-- The release notes will use an HTML image tag and limit images taller than 300 pixels. -->
<!-- release-note-image:start -->

<!-- release-note-image:end -->

## Testing
<!-- How can reviewers verify that the PR produces correct results? -->
<!-- Please provide instructions so that others can ensure that your pull request would produce correct results. For examples see, https://github.com/FreeTubeApp/FreeTube/pull/5743, https://github.com/FreeTubeApp/FreeTube/pull/7349, https://github.com/FreeTubeApp/FreeTube/pull/5125, https://github.com/FreeTubeApp/FreeTube/pull/7338 -->
<!-- Agent instructions: Only write human-facing steps that explain how to verify the change while running this branch in dev mode. Include expected results and, when applicable, helpful console snippets for interactive verification. Do not include automated checks, commands, results, pass counts, or CI status. -->
1. Set playback volume below 100%, open a Short in a background tab, then switch to it. The Shorts volume slider should show the restored volume.
2. Play a Short and move focus to another window. The seek bar should continue following playback.
3. Enter fullscreen, let the cursor hide, then move it in a gutter beside the vertical video. The cursor should return without revealing the video controls.
4. In fullscreen, verify that the seek bar spans the complete video width without extending into either gutter.

## Additional context
<!-- Add any other context about the pull request here. -->
Shaka normally stops refreshing its seek UI while the controls are hidden. The Shorts layout deliberately keeps the seek bar visible, so it needs a media-driven refresh for that hidden-controls state.
