### PR TITLE
fix(sponsorblock): preserve precise segment timing

### DIFF
--- a/e2e/tests/offline/watch-page.spec.mjs
+++ b/e2e/tests/offline/watch-page.spec.mjs
@@ -1039,6 +1039,59 @@ test.describe('watch page', () => {
     }])
   })
 
+  test('skips SponsorBlock segments at their boundary without timeupdate events', async ({ app, page }) => {
+    await mockPlayableWatchPage(app, page)
+    await page.route('**/api/skipSegments/**', route => route.fulfill({
+      body: JSON.stringify([{
+        videoID: 'jNQXAC9IVRw',
+        segments: [{
+          UUID: 'precise-skip-segment',
+          actionType: 'skip',
+          category: 'sponsor',
+          description: '',
+          locked: 0,
+          segment: [15, 20],
+          videoDuration: 30,
+          votes: 1
+        }]
+      }]),
+      contentType: 'application/json'
+    }))
+    await page.evaluate(() => {
+      const store = document.querySelector('#app').__vue_app__.config.globalProperties.$store
+      store.commit('setUseSponsorBlock', true)
+    })
+
+    await openMockedVideo(page)
+    await expect(page.locator('.sponsorBlockMarker')).toHaveCount(1)
+
+    const video = page.locator('.ftVideoPlayer video')
+    await video.evaluate(element => {
+      element.pause()
+      element.currentTime = 14.57
+      element.dispatchEvent(new Event('timeupdate'))
+
+      const currentTime = Object.getOwnPropertyDescriptor(HTMLMediaElement.prototype, 'currentTime')
+      Object.defineProperty(element, 'currentTime', {
+        configurable: true,
+        get: currentTime.get,
+        set(value) {
+          if (value === 20) {
+            window.__sponsorBlockSkipStartedAt = currentTime.get.call(this)
+          }
+          currentTime.set.call(this, value)
+        }
+      })
+      element.addEventListener('timeupdate', event => event.stopImmediatePropagation(), { capture: true })
+      return element.play()
+    })
+
+    await expect.poll(() => page.evaluate(() => window.__sponsorBlockSkipStartedAt ?? null)).not.toBeNull()
+    const skipStartedAt = await page.evaluate(() => window.__sponsorBlockSkipStartedAt)
+    expect(skipStartedAt).toBeGreaterThanOrEqual(15)
+    expect(skipStartedAt).toBeLessThan(15.05)
+  })
+
   test('displays and submits full-video SponsorBlock labels', async ({ app, page }) => {
     await mockPlayableWatchPage(app, page)
     const fullVideoSegment = {

--- a/e2e/tests/offline/watch-page.spec.mjs
+++ b/e2e/tests/offline/watch-page.spec.mjs
@@ -982,6 +982,63 @@ test.describe('watch page', () => {
     await expect(prompt).toHaveCount(0)
   })
 
+  test('previews and submits edited SponsorBlock timestamps', async ({ app, page }) => {
+    await mockPlayableWatchPage(app, page)
+    let submittedBody = null
+
+    await page.route('**/api/skipSegments/**', route => route.fulfill({
+      body: JSON.stringify([]),
+      contentType: 'application/json'
+    }))
+    await page.route('**/api/skipSegments', async route => {
+      submittedBody = route.request().postDataJSON()
+      await route.fulfill({
+        body: JSON.stringify([{
+          UUID: 'submitted-edited-segment',
+          category: 'sponsor',
+          segment: [11.722, 12]
+        }]),
+        contentType: 'application/json'
+      })
+    })
+    await page.evaluate(async () => {
+      const store = document.querySelector('#app').__vue_app__.config.globalProperties.$store
+      store.commit('setUseSponsorBlock', true)
+      await store.dispatch('updateSponsorBlockEnableSubmission', true)
+    })
+
+    await openMockedVideo(page)
+
+    const video = page.locator('.ftVideoPlayer video')
+    await video.evaluate(element => {
+      element.pause()
+      element.currentTime = 11
+    })
+    await page.locator('.sponsorblock-start-button').click({ force: true })
+    await video.evaluate(element => { element.currentTime = 12 })
+    await page.locator('.sponsorblock-end-button').click({ force: true })
+
+    const submissionMenu = page.locator('.sponsorBlockSubmissionMenu')
+    await submissionMenu.locator('.sponsorBlockDraftTimeInput').first().fill('0:11.722')
+    await submissionMenu.getByRole('button', { name: 'Inspect' }).click()
+    await expect.poll(() => video.evaluate(element => element.currentTime)).toBeCloseTo(11.722, 3)
+
+    await submissionMenu.getByRole('button', { name: 'Preview' }).click()
+    await video.evaluate(element => {
+      element.currentTime = 11.8
+      element.dispatchEvent(new Event('timeupdate'))
+    })
+    await submissionMenu.locator('.sponsorBlockSubmissionButton').click()
+
+    await expect.poll(() => submittedBody).not.toBeNull()
+    expect(submittedBody.segments).toEqual([{
+      actionType: 'skip',
+      category: 'sponsor',
+      description: '',
+      segment: [11.722, 12]
+    }])
+  })
+
   test('displays and submits full-video SponsorBlock labels', async ({ app, page }) => {
     await mockPlayableWatchPage(app, page)
     const fullVideoSegment = {

--- a/e2e/tests/offline/watch-page.spec.mjs
+++ b/e2e/tests/offline/watch-page.spec.mjs
@@ -1023,7 +1023,20 @@ test.describe('watch page', () => {
     await submissionMenu.getByRole('button', { name: 'Inspect' }).click()
     await expect.poll(() => video.evaluate(element => element.currentTime)).toBeCloseTo(11.722, 3)
 
+    await video.evaluate(element => {
+      const currentTime = Object.getOwnPropertyDescriptor(HTMLMediaElement.prototype, 'currentTime')
+      Object.defineProperty(element, 'currentTime', {
+        configurable: true,
+        get: currentTime.get,
+        set(value) {
+          window.__sponsorBlockPreviewSeekTime ??= value
+          currentTime.set.call(this, value)
+        }
+      })
+    })
     await submissionMenu.getByRole('button', { name: 'Preview' }).click()
+    await expect.poll(() => page.evaluate(() => window.__sponsorBlockPreviewSeekTime ?? null))
+      .toBeCloseTo(9.722, 3)
     await video.evaluate(element => {
       element.currentTime = 11.8
       element.dispatchEvent(new Event('timeupdate'))

--- a/src/renderer/components/ft-shaka-video-player/ft-shaka-video-player.js
+++ b/src/renderer/components/ft-shaka-video-player/ft-shaka-video-player.js
@@ -108,6 +108,8 @@ import thumbnailPlaceholder from '../../assets/img/thumbnail_placeholder.svg'
 
 const SPONSORBLOCK_HIGHLIGHT_LABEL_PLAYBACK_MS = 5000
 const SPONSORBLOCK_SEGMENT_START_TOLERANCE_SECONDS = 0.1
+const SPONSORBLOCK_SKIP_SCHEDULE_LEAD_MS = 150
+const SPONSORBLOCK_SKIP_POLL_INTERVAL_MS = 4
 const SPONSORBLOCK_TERMINAL_OUTRO_TOLERANCE_SECONDS = 1
 const SPONSORBLOCK_NOT_FOUND_REFETCH_RECENT_VIDEO_AGE_MS = 24 * 60 * 60 * 1000
 const SPONSORBLOCK_NOT_FOUND_REFETCH_MIN_DELAY_MS = 10000
@@ -1731,6 +1733,7 @@ export default defineComponent({
         sponsorBlockInfoSegments.value = sponsorBlockInfoSegments.value
           .concat(submittedSegments.map(segment => ({ ...segment, locked: 0, votes: 0 })))
           .sort((a, b) => a.startTime - b.startTime)
+        scheduleSponsorBlockSkip()
         emitSponsorBlockInfoState()
         refreshSponsorBlockMarkers()
       },
@@ -1755,6 +1758,15 @@ export default defineComponent({
      */
     let sponsorBlockDismissedPromptSegments = new Set()
     let sponsorBlockNotFoundRefetchTimeout = null
+    let sponsorBlockSkipScheduleTimeout = null
+    let sponsorBlockSkipScheduleInterval = null
+
+    function cancelSponsorBlockSkipSchedule() {
+      clearTimeout(sponsorBlockSkipScheduleTimeout)
+      clearInterval(sponsorBlockSkipScheduleInterval)
+      sponsorBlockSkipScheduleTimeout = null
+      sponsorBlockSkipScheduleInterval = null
+    }
 
     function clearSponsorBlockNotFoundRefetchTimeout() {
       if (sponsorBlockNotFoundRefetchTimeout !== null) {
@@ -1830,6 +1842,7 @@ export default defineComponent({
           syncPromptSponsorBlockSegments(currentTime)
           updateSponsorBlockHighlightState(currentTime)
           syncSponsorBlockMuteSegments(currentTime, !props.sponsorBlockAutoSkipDisabled)
+          scheduleSponsorBlockSkip()
         }
       } else {
         scheduleSponsorBlockNotFoundRefetch()
@@ -1843,6 +1856,7 @@ export default defineComponent({
       let refetchWhenNotFound = false
 
       clearSponsorBlockNotFoundRefetchTimeout()
+      cancelSponsorBlockSkipSchedule()
 
       // Reset the do-not-skip set for the new video
       sponsorBlockDoNotSkipSegments = new Set()
@@ -1900,6 +1914,7 @@ export default defineComponent({
         syncPromptSponsorBlockSegments(currentTime)
         updateSponsorBlockHighlightState(currentTime)
         syncSponsorBlockMuteSegments(currentTime, !props.sponsorBlockAutoSkipDisabled)
+        scheduleSponsorBlockSkip()
       }
     }
 
@@ -2687,6 +2702,77 @@ export default defineComponent({
           })
         })
       }
+    }
+
+    function getNextSponsorBlockAutoSkipSegment(currentTime) {
+      const { autoSkip } = sponsorSkips.value
+
+      return sponsorBlockSegments.find(segment =>
+        segment.actionType === 'skip' &&
+        !isSponsorBlockPointSegment(segment) &&
+        !sponsorBlockDoNotSkipSegments.has(segment.uuid) &&
+        autoSkip.has(segment.category) &&
+        segment.startTime > currentTime &&
+        segment.endTime > segment.startTime
+      ) ?? null
+    }
+
+    function startSponsorBlockSkipPolling(segment) {
+      sponsorBlockSkipScheduleInterval = setInterval(() => {
+        const videoElement = video.value
+        if (!videoElement || videoElement.paused || videoElement.ended) {
+          cancelSponsorBlockSkipSchedule()
+          return
+        }
+
+        const currentTime = videoElement.currentTime
+        if (currentTime < segment.startTime) {
+          const remainingMs = (segment.startTime - currentTime) * 1000 / videoElement.playbackRate
+          if (remainingMs > SPONSORBLOCK_SKIP_SCHEDULE_LEAD_MS) {
+            scheduleSponsorBlockSkip()
+          }
+          return
+        }
+
+        cancelSponsorBlockSkipSchedule()
+        skipSponsorBlockSegments(currentTime)
+        scheduleSponsorBlockSkip()
+      }, SPONSORBLOCK_SKIP_POLL_INTERVAL_MS)
+    }
+
+    function scheduleSponsorBlockSkip() {
+      cancelSponsorBlockSkipSchedule()
+
+      const videoElement = video.value
+      if (
+        !useSponsorBlock.value ||
+        props.sponsorBlockAutoSkipDisabled ||
+        !videoElement ||
+        videoElement.paused ||
+        videoElement.ended ||
+        !Number.isFinite(videoElement.playbackRate) ||
+        videoElement.playbackRate <= 0 ||
+        sponsorBlockSegments.length === 0 ||
+        !canSeek()
+      ) {
+        return
+      }
+
+      const segment = getNextSponsorBlockAutoSkipSegment(videoElement.currentTime)
+      if (!segment) {
+        return
+      }
+
+      const delayMs = (segment.startTime - videoElement.currentTime) * 1000 / videoElement.playbackRate
+      if (delayMs <= SPONSORBLOCK_SKIP_SCHEDULE_LEAD_MS) {
+        startSponsorBlockSkipPolling(segment)
+        return
+      }
+
+      sponsorBlockSkipScheduleTimeout = setTimeout(() => {
+        sponsorBlockSkipScheduleTimeout = null
+        startSponsorBlockSkipPolling(segment)
+      }, delayMs - SPONSORBLOCK_SKIP_SCHEDULE_LEAD_MS)
     }
 
     function syncSponsorBlockMuteSegments(currentTime, autoMuteEnabled = true) {
@@ -4310,12 +4396,18 @@ export default defineComponent({
         closeSponsorBlockInfo()
         sponsorBlockMuteController.reset()
         clearSponsorBlockMuteSegments()
+        cancelSponsorBlockSkipSchedule()
+      } else {
+        scheduleSponsorBlockSkip()
       }
     })
 
     watch(() => props.sponsorBlockAutoSkipDisabled, disabled => {
       syncSponsorBlockMuteSegments(video.value?.currentTime ?? 0, !disabled)
+      scheduleSponsorBlockSkip()
     })
+
+    watch(sponsorSkips, scheduleSponsorBlockSkip)
 
     watch(sponsorBlockEnableSubmission, () => emitSponsorBlockInfoState())
 
@@ -4758,6 +4850,7 @@ export default defineComponent({
 
       sleepTimer.resumeCountdown()
       startSponsorBlockHighlightLabelCountdown()
+      scheduleSponsorBlockSkip()
 
       tabMediaCoordinator.setPlaybackState(mediaTabId, 'playing')
 
@@ -4794,6 +4887,7 @@ export default defineComponent({
 
       sleepTimer.pauseCountdown()
       pauseSponsorBlockHighlightLabelCountdown()
+      cancelSponsorBlockSkipSchedule()
 
       tabMediaCoordinator.setPlaybackState(mediaTabId, 'paused')
 
@@ -4820,6 +4914,7 @@ export default defineComponent({
       const sleepTimerEnded = sleepTimer.consumeEndOfVideo()
 
       pauseSponsorBlockHighlightLabelCountdown()
+      cancelSponsorBlockSkipSchedule()
 
       tabMediaCoordinator.setPlaybackState(mediaTabId, 'none')
 
@@ -4838,6 +4933,7 @@ export default defineComponent({
 
     function handleSeeking() {
       shortsEnded.value = false
+      cancelSponsorBlockSkipSchedule()
       syncPlayPauseControlIcons()
       emit('seeking')
     }
@@ -4989,6 +5085,7 @@ export default defineComponent({
 
           if (!props.sponsorBlockAutoSkipDisabled) {
             skipSponsorBlockSegments(currentTime)
+            scheduleSponsorBlockSkip()
           }
         } else {
           sponsorBlockMuteController.setSourceActive('segments', false)
@@ -8663,12 +8760,14 @@ export default defineComponent({
         if (!temporaryPlaybackRateActive && !silenceSkipping.handlePlaybackRateChange(playbackRate)) {
           emit('playback-rate-updated', playbackRate)
         }
+        scheduleSponsorBlockSkip()
       })
     })
     onUnmounted(() => {
       clearSabrBackoffTimer()
       clearPreRollTimer()
       clearTimeout(sponsorBlockHighlightLabelTimeout)
+      cancelSponsorBlockSkipSchedule()
     })
 
     async function performFirstLoad() {
@@ -9198,6 +9297,7 @@ export default defineComponent({
     async function destroyPlayer() {
       ignoreErrors = true
       cancelPendingVolumeUserSet()
+      cancelSponsorBlockSkipSchedule()
       // The media element can emit one final timeupdate while Shaka is being
       // destroyed, after its internal manifest has already been cleared.
       hasLoaded.value = false

--- a/src/renderer/components/ft-shaka-video-player/opentubex/useSponsorBlockSubmission.js
+++ b/src/renderer/components/ft-shaka-video-player/opentubex/useSponsorBlockSubmission.js
@@ -586,12 +586,16 @@ export function useSponsorBlockSubmission({
   }
 
   async function previewSponsorBlockDraft(segmentId, mode = 'preview') {
-    const draft = sponsorBlockDraftSegments.value.find(segment => segment.id === segmentId)
-    if (!draft || !canSeek()) {
+    if (!sponsorBlockDraftSegments.value.some(segment => segment.id === segmentId) || !canSeek()) {
       return
     }
 
     if (!await saveSponsorBlockDraft(segmentId)) {
+      return
+    }
+
+    const draft = sponsorBlockDraftSegments.value.find(segment => segment.id === segmentId)
+    if (!draft) {
       return
     }
 


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Make sure to follow the contributing guidelines. -->
<!-- Important note, we may remove your pull request if you do not use this provided PR template correctly. -->
<!-- Agent instructions: Preserve every heading, comment, and marker in this template. Never remove or rewrite the release-note-category:start/end, release-note:start/end, or release-note-image:start/end marker pairs. Never remove or rewrite the Release note images section; leave its contents for a human. -->

## Pull Request Type
<!-- Please select what type of pull request this is: [x] -->
- [x] Bugfix
- [ ] Feature Implementation
- [ ] Documentation
- [ ] Other

## Related issue
<!-- Please link the issue your pull request is referring to. -->
<!-- If this pull request fully resolves the relevant issue, put "closes" before the issue number. -->
<!-- Example: "closes #123456". -->

None.

## Description
<!-- Please write a clear and concise description of what the pull request does. -->

SponsorBlock timing differed from the browser extension in two places. Editing a boundary saved the new timestamp, but Preview and Inspect continued using the stale segment object captured before the save. Existing segments were also skipped only when Chromium emitted a `timeupdate` event, which can be roughly 250 ms after the exact boundary.

Re-read the saved draft before previewing it so millisecond edits are reviewed and submitted consistently. For playback, schedule the next eligible automatic skip until 150 ms before its boundary, then poll the media clock closely like the official extension does. The schedule is reset when playback, seeking, playback rate, settings, or segment data changes, while `timeupdate` remains a fallback.

Deterministic regressions cover editing, inspecting, previewing, and submitting an `11.722` second boundary, plus skipping an existing segment at its exact boundary with subsequent `timeupdate` events suppressed.

## Release note category
<!-- Select exactly one category. Every pull request must select one. -->
<!-- Select "Not noteworthy" when the pull request fixes a bug in or improves functionality that has not yet appeared in a stable release. -->
<!-- release-note-category:start -->
- [ ] Not noteworthy
- [ ] Highlights
- [ ] More improvements
- [x] Fixed bugs
<!-- release-note-category:end -->

## Release note
<!-- Required unless "Not noteworthy" is selected. -->
<!-- Write one concise, user-facing entry without a leading bullet. -->
<!-- release-note:start -->
SponsorBlock now previews edited millisecond timestamps and skips existing segments at their precise boundaries.
<!-- release-note:end -->

## Release note images
<!-- Human-only: Agents must preserve this entire section and leave it empty. -->
<!-- Optional. Paste one or more Markdown images or HTML image tags here. -->
<!-- The release notes will use an HTML image tag and limit images taller than 300 pixels. -->
<!-- release-note-image:start -->

<!-- release-note-image:end -->

## Testing
<!-- How can reviewers verify that the PR produces correct results? -->
<!-- Please provide instructions so that others can ensure that this pull request produces correct results. -->
<!-- Agent instructions: Only write human-facing steps that explain how to verify the change while running this branch in dev mode. Include expected results and, when applicable, helpful console snippets for interactive verification. Do not include automated checks, commands, results, pass counts, or CI status. -->

1. Enable SponsorBlock and SponsorBlock submission, then open a video with an existing automatic-skip segment.
2. Watch its start boundary and compare it with the same video in a browser using the official extension. Both should skip at the same moment rather than OpenTubeX showing a fraction of a second more content.
3. Create a new segment and change one boundary to include milliseconds, for example `0:11.722`.
4. Click Inspect and confirm playback seeks to the edited boundary rather than the value captured before editing.
5. Preview and submit the segment, then confirm the submitted boundary behaves at the same frame in the browser extension.

## Additional context
<!-- Add any other context about the pull request here. -->

The official extension implementation in `src/content.ts` was used as the scheduling reference. It similarly sleeps until shortly before a boundary and switches to close media-clock polling for the final interval.