### PR TITLE
feat(sync): sync custom themes between devices

### DIFF
--- a/e2e/tests/network/sync-server.spec.mjs
+++ b/e2e/tests/network/sync-server.spec.mjs
@@ -1,4 +1,5 @@
 import { readFile } from 'node:fs/promises'
+import { randomUUID } from 'node:crypto'
 import path from 'node:path'
 
 import { test, expect, goToSettingsSection, latestSettings } from '../../helpers/app.mjs'
@@ -314,7 +315,7 @@ test.describe('OpenTubeX sync server', () => {
     const enhancedPrivacy = (await getSyncCapabilities()).encrypted_sync === 1
     test.skip(!enhancedPrivacy, 'Enhanced privacy server required')
 
-    const username = `opentubex-themes-${Date.now()}-${Math.random().toString(16).slice(2)}`
+    const username = `opentubex-themes-${randomUUID()}`
     const theme = {
       ...structuredClone(DEFAULT_CUSTOM_THEME),
       id: 'synced-theme',

--- a/e2e/tests/network/sync-server.spec.mjs
+++ b/e2e/tests/network/sync-server.spec.mjs
@@ -375,6 +375,7 @@ test.describe('OpenTubeX sync server', () => {
 
     await page.evaluate(async () => {
       const store = document.querySelector('#app').__vue_app__.config.globalProperties.$store
+      await store.dispatch('updateBaseTheme', 'custom:synced-theme')
       const themes = await window.ftElectron.replaceCustomThemes([])
       await store.dispatch('updateCustomThemes', themes)
     })
@@ -391,6 +392,9 @@ test.describe('OpenTubeX sync server', () => {
       () => true,
       error => error.code !== 'ENOENT'
     )).toBe(false)
+    await expect.poll(async () => (
+      latestSettings(await readFile(settingsPath, 'utf8')).baseTheme
+    )).toBe(theme.basedOn)
   })
 
   test('migrates existing plaintext data before locking the account', async ({ app, page }, testInfo) => {

--- a/e2e/tests/network/sync-server.spec.mjs
+++ b/e2e/tests/network/sync-server.spec.mjs
@@ -2,6 +2,7 @@ import { readFile } from 'node:fs/promises'
 import path from 'node:path'
 
 import { test, expect, goToSettingsSection, latestSettings } from '../../helpers/app.mjs'
+import { DEFAULT_CUSTOM_THEME } from '../../../src/customTheme.js'
 
 const syncServerUrl = process.env.OPENTUBEX_SYNC_SERVER_URL
 const channelId = 'UCuAXFkgsw1L7xaCfnd5JJOw'
@@ -307,6 +308,88 @@ test.describe('OpenTubeX sync server', () => {
     expect(await readFile(path.join(app.userDataDir, 'profiles.db'), 'utf8')).toContain(channelId)
     expect(await readFile(path.join(app.userDataDir, 'playlists.db'), 'utf8')).toContain('sync-playlist')
     expect(await readFile(path.join(app.userDataDir, 'history.db'), 'utf8')).toContain('dQw4w9WgXcQ')
+  })
+
+  test('syncs custom themes and their deletion', async ({ app, page }) => {
+    const enhancedPrivacy = (await getSyncCapabilities()).encrypted_sync === 1
+    test.skip(!enhancedPrivacy, 'Enhanced privacy server required')
+
+    const username = `opentubex-themes-${Date.now()}-${Math.random().toString(16).slice(2)}`
+    const theme = {
+      ...structuredClone(DEFAULT_CUSTOM_THEME),
+      id: 'synced-theme',
+      name: 'Synced Theme',
+      colors: {
+        ...DEFAULT_CUSTOM_THEME.colors,
+        background: '#123456',
+      },
+    }
+    const themePath = path.join(app.userDataDir, 'themes', `${theme.id}.json`)
+    const settingsPath = path.join(app.userDataDir, 'settings.db')
+
+    await page.evaluate(async customTheme => {
+      const store = document.querySelector('#app').__vue_app__.config.globalProperties.$store
+      const themes = await window.ftElectron.saveCustomTheme(customTheme)
+      store.commit('setCustomThemes', themes)
+    }, theme)
+
+    const syncSection = await goToSettingsSection(page, 'sync')
+    await syncSection.getByLabel('Server URL').fill(syncServerUrl)
+    await syncSection.getByLabel('Username').fill(username)
+    await syncSection.getByLabel('Password').fill('local-test-password')
+    await syncSection.getByLabel(/Privacy passphrase/).fill('local-test-privacy-passphrase')
+    await syncSection.getByRole('button', { name: 'Register' }).click()
+    await expect(syncSection.getByText(`Connected as ${username}`)).toBeVisible()
+    await expect(syncSection.getByText(/Last synced:/)).toBeVisible()
+    await expect.poll(async () => {
+      const settings = latestSettings(await readFile(settingsPath, 'utf8'))
+      return JSON.parse(settings.syncServerSnapshot).settings.customThemes.value
+    }).toEqual([theme])
+
+    async function syncNow() {
+      const previousSyncAt = latestSettings(await readFile(settingsPath, 'utf8')).syncServerLastSyncAt
+      await syncSection.getByRole('button', { name: 'Sync now' }).click()
+      await expect.poll(async () => (
+        latestSettings(await readFile(settingsPath, 'utf8')).syncServerLastSyncAt
+      )).not.toBe(previousSyncAt)
+    }
+
+    await page.evaluate(async () => {
+      const store = document.querySelector('#app').__vue_app__.config.globalProperties.$store
+      await store.dispatch('setSyncServerAutoSync', false)
+      const themes = await window.ftElectron.replaceCustomThemes([])
+      store.commit('setCustomThemes', themes)
+      await store.dispatch('updateSyncServerSnapshot', '')
+    })
+    await syncNow()
+    await expect.poll(async () => {
+      const settings = latestSettings(await readFile(settingsPath, 'utf8'))
+      return JSON.parse(settings.syncServerSnapshot).settings.customThemes.value
+    }).toEqual([theme])
+    await expect.poll(async () => JSON.parse(await readFile(themePath, 'utf8'))).toMatchObject({
+      id: theme.id,
+      name: theme.name,
+      colors: { background: '#123456' },
+    })
+
+    await page.evaluate(async () => {
+      const store = document.querySelector('#app').__vue_app__.config.globalProperties.$store
+      const themes = await window.ftElectron.replaceCustomThemes([])
+      await store.dispatch('updateCustomThemes', themes)
+    })
+    await syncNow()
+
+    await page.evaluate(async customTheme => {
+      const store = document.querySelector('#app').__vue_app__.config.globalProperties.$store
+      const themes = await window.ftElectron.replaceCustomThemes([customTheme])
+      store.commit('setCustomThemes', themes)
+      await store.dispatch('updateSyncServerSnapshot', '')
+    }, theme)
+    await syncNow()
+    await expect.poll(async () => readFile(themePath, 'utf8').then(
+      () => true,
+      error => error.code !== 'ENOENT'
+    )).toBe(false)
   })
 
   test('migrates existing plaintext data before locking the account', async ({ app, page }, testInfo) => {

--- a/src/constants.js
+++ b/src/constants.js
@@ -15,6 +15,7 @@ const IpcChannels = {
   CUSTOM_THEME_LOAD: 'custom-theme-load',
   CUSTOM_THEME_SAVE: 'custom-theme-save',
   CUSTOM_THEME_DELETE: 'custom-theme-delete',
+  CUSTOM_THEME_REPLACE: 'custom-theme-replace',
   CUSTOM_THEME_UPDATED: 'custom-theme-updated',
 
   SEARCH_INPUT_HANDLING_READY: 'search-input-handling-ready',

--- a/src/customTheme.js
+++ b/src/customTheme.js
@@ -1,4 +1,5 @@
 export const CUSTOM_THEMES_DIRECTORY = 'themes'
+export const CUSTOM_THEMES_SYNC_KEY = 'customThemes'
 export const CUSTOM_THEME_VALUE_PREFIX = 'custom:'
 
 export const CUSTOM_THEME_COLORS = Object.freeze([

--- a/src/main/index.js
+++ b/src/main/index.js
@@ -28,6 +28,7 @@ import {
   customThemeValue,
   isCustomThemeValue,
   normalizeCustomTheme,
+  normalizeCustomThemes,
 } from '../customTheme'
 import * as baseHandlers from '../datastores/handlers/base'
 import { liveReminders } from '../datastores'
@@ -156,6 +157,42 @@ function runApp() {
   async function deleteCustomTheme(id) {
     await asyncFs.unlink(getCustomThemePath(id))
     return await loadCustomThemes()
+  }
+
+  async function replaceCustomThemes(themes) {
+    const normalizedThemes = normalizeCustomThemes(themes)
+    const themeIds = new Set()
+    for (const theme of normalizedThemes) {
+      if (themeIds.has(theme.id)) throw new TypeError(`Duplicate custom theme ID: ${theme.id}`)
+      themeIds.add(theme.id)
+    }
+
+    await asyncFs.mkdir(CUSTOM_THEMES_PATH, { recursive: true })
+    await Promise.all(normalizedThemes.map(writeCustomThemeFile))
+
+    const entries = await asyncFs.readdir(CUSTOM_THEMES_PATH, { withFileTypes: true })
+    await Promise.all(entries.map(async entry => {
+      if (!entry.isFile() || path.extname(entry.name) !== '.json') return
+      const id = path.basename(entry.name, '.json')
+      if (!themeIds.has(id)) await asyncFs.unlink(path.join(CUSTOM_THEMES_PATH, entry.name))
+    }))
+
+    return await loadCustomThemes()
+  }
+
+  async function publishCustomThemes(themes) {
+    const selectedTheme = (await baseHandlers.settings._findOne('baseTheme'))?.value
+    const selectedCustomTheme = isCustomThemeValue(selectedTheme)
+      ? themes.find(({ id }) => id === customThemeIdFromValue(selectedTheme)) ?? themes[0]
+      : null
+    if (selectedCustomTheme) {
+      nativeTheme.themeSource = selectedCustomTheme.isDark ? 'dark' : 'light'
+    }
+    BrowserWindow.getAllWindows().forEach((window) => {
+      if (isOpenTubeXUrl(window.webContents.getURL())) {
+        window.webContents.send(IpcChannels.CUSTOM_THEME_UPDATED, themes)
+      }
+    })
   }
 
   async function getSelectedCustomTheme(value) {
@@ -3762,19 +3799,16 @@ function runApp() {
     if (!isOpenTubeXUrl(event.senderFrame.url)) return
 
     const themes = await saveCustomTheme(theme)
-    const selectedTheme = (await baseHandlers.settings._findOne('baseTheme'))?.value
-    const selectedCustomTheme = isCustomThemeValue(selectedTheme)
-      ? themes.find(({ id }) => id === customThemeIdFromValue(selectedTheme)) ?? themes[0]
-      : null
-    if (selectedCustomTheme) {
-      nativeTheme.themeSource = selectedCustomTheme.isDark ? 'dark' : 'light'
-    }
-    BrowserWindow.getAllWindows().forEach((window) => {
-      if (isOpenTubeXUrl(window.webContents.getURL())) {
-        window.webContents.send(IpcChannels.CUSTOM_THEME_UPDATED, themes)
-      }
-    })
+    await publishCustomThemes(themes)
     return themes
+  })
+
+  ipcMain.handle(IpcChannels.CUSTOM_THEME_REPLACE, async (event, themes) => {
+    if (!isOpenTubeXUrl(event.senderFrame.url)) return
+
+    const normalizedThemes = await replaceCustomThemes(themes)
+    await publishCustomThemes(normalizedThemes)
+    return normalizedThemes
   })
 
   ipcMain.handle(IpcChannels.CUSTOM_THEME_DELETE, async (event, themeId) => {
@@ -3802,11 +3836,7 @@ function runApp() {
         updateThemeSource(deletedTheme.basedOn)
       }
     }
-    BrowserWindow.getAllWindows().forEach((window) => {
-      if (isOpenTubeXUrl(window.webContents.getURL())) {
-        window.webContents.send(IpcChannels.CUSTOM_THEME_UPDATED, themes)
-      }
-    })
+    await publishCustomThemes(themes)
     return themes
   })
 

--- a/src/preload/interface.js
+++ b/src/preload/interface.js
@@ -73,6 +73,10 @@ export default {
     return ipcRenderer.invoke(IpcChannels.CUSTOM_THEME_DELETE, themeId)
   },
 
+  replaceCustomThemes: (themes) => {
+    return ipcRenderer.invoke(IpcChannels.CUSTOM_THEME_REPLACE, themes)
+  },
+
   handleCustomThemeUpdated: (handler) => {
     const listener = (_, theme) => handler(theme)
     ipcRenderer.on(IpcChannels.CUSTOM_THEME_UPDATED, listener)

--- a/src/renderer/components/CustomThemeEditor/CustomThemeEditor.vue
+++ b/src/renderer/components/CustomThemeEditor/CustomThemeEditor.vue
@@ -404,7 +404,7 @@ async function saveAndApply() {
   try {
     flushColorPreviews()
     const themes = await saveCustomTheme(draft)
-    store.commit('setCustomThemes', themes)
+    await store.dispatch('updateCustomThemes', themes)
     const savedTheme = themes.find(({ id }) => id === draft.id)
     setDraft(savedTheme)
     if (!keepSystemThemeOnSave) {
@@ -426,7 +426,7 @@ async function handleDeletePrompt(value) {
 
   try {
     const themes = await deleteCustomTheme(draft.id)
-    store.commit('setCustomThemes', themes)
+    await store.dispatch('updateCustomThemes', themes)
     showToast({
       message: t('Settings.Theme Settings.Custom Theme.Theme Deleted'),
       icon: ['fas', 'trash']

--- a/src/renderer/helpers/customTheme.js
+++ b/src/renderer/helpers/customTheme.js
@@ -68,6 +68,16 @@ export async function deleteCustomTheme(id) {
   return themes
 }
 
+export async function replaceCustomThemes(themes) {
+  const normalizedThemes = normalizeCustomThemes(themes)
+  if (process.env.IS_ELECTRON) {
+    return normalizeCustomThemes(await window.ftElectron.replaceCustomThemes(normalizedThemes))
+  }
+
+  localStorage.setItem(STORAGE_KEY, JSON.stringify(normalizedThemes, null, 2))
+  return normalizedThemes
+}
+
 export function handleCustomThemeUpdated(handler) {
   if (!process.env.IS_ELECTRON) return () => {}
   return window.ftElectron.handleCustomThemeUpdated(themes => handler(normalizeCustomThemes(themes)))

--- a/src/renderer/helpers/sync-server-scheduling.js
+++ b/src/renderer/helpers/sync-server-scheduling.js
@@ -22,12 +22,14 @@ export const SYNC_ACTION_REASONS = new Map([
   ['removeVideos', 'playlists'],
   ['updateHistory', 'history'],
   ['updateChannelPlaybackSpeeds', 'playbackSpeeds'],
+  ['updateCustomThemes', 'settings'],
   ['updatePlaylist', 'playlists'],
   ['updateProfile', 'profilesOrSubscriptions'],
   ['updateWatchProgress', 'history'],
 ])
 
 export const SYNC_MUTATION_REASONS = new Map([
+  ['setCustomThemes', 'settings'],
   ['addProfileToList', 'profiles'],
   ['addChannelToProfiles', 'profilesOrSubscriptions'],
   ['removeChannelFromProfiles', 'profilesOrSubscriptions'],

--- a/src/renderer/helpers/sync-server.js
+++ b/src/renderer/helpers/sync-server.js
@@ -1,5 +1,9 @@
 import { MAIN_PROFILE_ID } from '../../constants'
-import { CUSTOM_THEMES_SYNC_KEY, normalizeCustomThemes } from '../../customTheme'
+import {
+  CUSTOM_THEMES_SYNC_KEY,
+  customThemeIdFromValue,
+  normalizeCustomThemes,
+} from '../../customTheme'
 import {
   SyncServerDataLossError,
   SyncServerCancelledError,
@@ -976,6 +980,28 @@ function settingUpdater(key) {
   return `update${key.charAt(0).toUpperCase()}${key.slice(1)}`
 }
 
+async function repairDeletedCustomThemeReferences(store, previousThemes, themes) {
+  const themeIds = new Set(themes.map(theme => theme.id))
+  const previousById = new Map(previousThemes.map(theme => [theme.id, theme]))
+  const fallbacks = {
+    baseTheme: 'system',
+    systemLightTheme: 'light',
+    systemDarkTheme: 'dark',
+  }
+
+  for (const [key, defaultTheme] of Object.entries(fallbacks)) {
+    const id = customThemeIdFromValue(store.state.settings[key])
+    if (id === null || themeIds.has(id)) continue
+
+    const deletedTheme = previousById.get(id)
+    if (key === 'baseTheme' && deletedTheme) {
+      await store.dispatch('updateMainColor', deletedTheme.mainColor)
+      await store.dispatch('updateSecColor', deletedTheme.secondaryColor)
+    }
+    await store.dispatch(settingUpdater(key), deletedTheme?.basedOn ?? defaultTheme)
+  }
+}
+
 function latestSessionUpdate(sessions) {
   return sessions.reduce((latest, session) => (
     Number.isFinite(session.updatedAt) ? Math.max(latest, session.updatedAt) : latest
@@ -1044,8 +1070,10 @@ export async function syncSettings(client, store, previous = {}) {
     merged[key] = entry
     if (!metadataEquals(value, entry.value)) {
       if (key === CUSTOM_THEMES_SYNC_KEY) {
+        const previousThemes = store.state.utils.customThemes
         const themes = await replaceCustomThemes(entry.value)
         store.commit('setCustomThemes', themes)
+        await repairDeletedCustomThemeReferences(store, previousThemes, themes)
       } else {
         await store.dispatch(settingUpdater(key), deepCopy(entry.value))
       }

--- a/src/renderer/helpers/sync-server.js
+++ b/src/renderer/helpers/sync-server.js
@@ -1,4 +1,5 @@
 import { MAIN_PROFILE_ID } from '../../constants'
+import { CUSTOM_THEMES_SYNC_KEY, normalizeCustomThemes } from '../../customTheme'
 import {
   SyncServerDataLossError,
   SyncServerCancelledError,
@@ -9,6 +10,7 @@ import {
 } from './sync-server-errors'
 import { getSyncableSettingKeys } from '../store/modules/settings'
 import { deepCopy } from './utils'
+import { replaceCustomThemes } from './customTheme'
 import { generateRandomUniqueId } from './playlists'
 import {
   getMergedProfileBackground,
@@ -1018,9 +1020,12 @@ export async function syncSettings(client, store, previous = {}) {
   const remote = Object.fromEntries(remoteEntries.map(entry => [entry.key, entry]))
   const merged = {}
   const now = Date.now()
+  const local = Object.fromEntries(getSyncableSettingKeys(store.state.settings).map(key => (
+    [key, deepCopy(store.state.settings[key])]
+  )))
+  local[CUSTOM_THEMES_SYNC_KEY] = normalizeCustomThemes(store.state.utils.customThemes)
 
-  for (const key of getSyncableSettingKeys(store.state.settings)) {
-    const value = deepCopy(store.state.settings[key])
+  for (const [key, value] of Object.entries(local)) {
     const old = previous[key]
     const remoteEntry = remote[key]
     const localChanged = old !== undefined && !metadataEquals(value, old.value)
@@ -1038,8 +1043,17 @@ export async function syncSettings(client, store, previous = {}) {
 
     merged[key] = entry
     if (!metadataEquals(value, entry.value)) {
-      await store.dispatch(settingUpdater(key), deepCopy(entry.value))
+      if (key === CUSTOM_THEMES_SYNC_KEY) {
+        const themes = await replaceCustomThemes(entry.value)
+        store.commit('setCustomThemes', themes)
+      } else {
+        await store.dispatch(settingUpdater(key), deepCopy(entry.value))
+      }
     }
+  }
+
+  for (const [key, entry] of Object.entries(remote)) {
+    if (!Object.prototype.hasOwnProperty.call(local, key)) merged[key] = entry
   }
 
   await client.putSettings(Object.values(merged))

--- a/src/renderer/store/modules/sync-server.js
+++ b/src/renderer/store/modules/sync-server.js
@@ -111,7 +111,7 @@ async function runSync(context, { allowDataLoss = false } = {}) {
   const previous = parseSnapshot(settings.syncServerSnapshot)
   const next = { ...previous }
   const result = {}
-  const store = { state: rootState, dispatch }
+  const store = { state: rootState, commit, dispatch }
   const stages = [
     ...(settings.syncServerPrivacyMode === 'enhanced' ? ['download'] : []),
     ...(settings.syncServerSyncSubscriptions ? ['subscriptions'] : []),

--- a/src/renderer/store/modules/utils.js
+++ b/src/renderer/store/modules/utils.js
@@ -246,6 +246,10 @@ const getters = {
 }
 
 const actions = {
+  updateCustomThemes({ commit }, themes) {
+    commit('setCustomThemes', themes)
+  },
+
   showOutlines({ commit }) {
     commit('setOutlinesHidden', false)
   },

--- a/tests/unit/sync-server-scheduling.test.mjs
+++ b/tests/unit/sync-server-scheduling.test.mjs
@@ -26,6 +26,7 @@ test('maps local actions to their affected sync collection', () => {
   assert.equal(SYNC_ACTION_REASONS.get('updateWatchProgress'), 'history')
   assert.equal(SYNC_ACTION_REASONS.get('addVideo'), 'playlists')
   assert.equal(SYNC_ACTION_REASONS.get('updateChannelPlaybackSpeeds'), 'playbackSpeeds')
+  assert.equal(SYNC_ACTION_REASONS.get('updateCustomThemes'), 'settings')
   assert.equal(SYNC_ACTION_REASONS.get('createProfile'), 'profiles')
   assert.equal(SYNC_ACTION_REASONS.get('addChannelToProfiles'), 'profilesOrSubscriptions')
 })


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Make sure to follow the contributing guidelines. -->
<!-- Important note, we may remove your pull request if you do not use this provided PR template correctly. -->
<!-- Agent instructions: Preserve every heading, comment, and marker in this template. Never remove or rewrite the release-note-category:start/end, release-note:start/end, or release-note-image:start/end marker pairs. Never remove or rewrite the Release note images section; leave its contents for a human. -->

## Pull Request Type
<!-- Please select what type of pull request this is: [x] -->
- [ ] Bugfix
- [x] Feature Implementation
- [ ] Documentation
- [ ] Other

## Related issue
<!-- Please link the issue your pull request is referring to. -->
<!-- If this pull request fully resolves the relevant issue, put "closes" before the issue number. -->
<!-- Example: "closes #123456". -->

None.

## Description
<!-- Please write a clear and concise description of what the pull request does. -->

Custom theme selections were already part of settings sync, but their color definitions remained local files. This could leave another device pointing at a theme it did not have.

This adds custom theme definitions to the existing encrypted settings collection, restores remote definitions into local theme storage, propagates changes across open windows, and schedules sync after theme edits or deletions. Unknown remote setting entries are now retained so newer setting types are not discarded by this client.

No sync-server changes are required.

## Release note category
<!-- Select exactly one category. Every pull request must select one. -->
<!-- Select "Not noteworthy" when the pull request fixes a bug in or improves functionality that has not yet appeared in a stable release. -->
<!-- release-note-category:start -->
- [x] Not noteworthy
- [ ] Highlights
- [ ] More improvements
- [ ] Fixed bugs
<!-- release-note-category:end -->

## Release note
<!-- Required unless "Not noteworthy" is selected. -->
<!-- Write one concise, user-facing entry without a leading bullet. -->
<!-- release-note:start -->
Custom themes now sync between devices when encrypted settings sync is enabled.
<!-- release-note:end -->

## Release note images
<!-- Human-only: Agents must preserve this entire section and leave it empty. -->
<!-- Optional. Paste one or more Markdown images or HTML image tags here. -->
<!-- The release notes will use an HTML image tag and limit images taller than 300 pixels. -->
<!-- release-note-image:start -->

<!-- release-note-image:end -->

## Testing
<!-- How can reviewers verify that the PR produces correct results? -->
<!-- Please provide instructions so that others can ensure that your pull request would produce correct results. For examples see, https://github.com/FreeTubeApp/FreeTube/pull/5743, https://github.com/FreeTubeApp/FreeTube/pull/7349, https://github.com/FreeTubeApp/FreeTube/pull/5125, https://github.com/FreeTubeApp/FreeTube/pull/7338 -->
<!-- Agent instructions: Only write human-facing steps that explain how to verify the change while running this branch in dev mode. Include expected results and, when applicable, helpful console snippets for interactive verification. Do not include automated checks, commands, results, pass counts, or CI status. -->

1. Connect two development clients to the same enhanced-privacy sync account with settings sync enabled.
2. Create and apply a custom theme on the first client, then sync both clients. The theme and its colors should appear and apply on the second client.
3. Edit the theme on one client and sync both clients. The updated colors should appear on the other client.
4. Delete the theme and sync both clients. The theme should be removed from both clients without affecting built-in themes.

## Additional context
<!-- Add any other context about the pull request here. -->

Custom themes share the existing encrypted settings quota and use the same last-write-wins conflict behavior as individual settings.