### PR TITLE
perf(videos): load collaborators without player setup

### DIFF
--- a/src/renderer/components/FtListVideo/FtListVideo.vue
+++ b/src/renderer/components/FtListVideo/FtListVideo.vue
@@ -1552,9 +1552,9 @@ async function openCollaboratorsPrompt() {
 
   isFetchingCollaborators.value = true
   setCollaboratorsLoading(true)
+  const videoId = id.value
 
   try {
-    const videoId = id.value
     const collaborators = await getLocalVideoCollaborators(videoId)
 
     if (id.value !== videoId) {
@@ -1567,8 +1567,10 @@ async function openCollaboratorsPrompt() {
       showCollaboratorsPrompt.value = true
     }
   } catch (error) {
-    console.error(`Failed to fetch collaborators for ${id.value}`, error)
-    showToast({ message: t('Video.Failed to load collaborators'), icon: ['fas', 'circle-exclamation'] })
+    if (id.value === videoId) {
+      console.error(`Failed to fetch collaborators for ${videoId}`, error)
+      showToast({ message: t('Video.Failed to load collaborators'), icon: ['fas', 'circle-exclamation'] })
+    }
   } finally {
     isFetchingCollaborators.value = false
     setCollaboratorsLoading(false)

--- a/src/renderer/components/FtListVideo/FtListVideo.vue
+++ b/src/renderer/components/FtListVideo/FtListVideo.vue
@@ -378,7 +378,7 @@ import {
   deepCopy,
   debounce
 } from '../../helpers/utils.js'
-import { getLocalVideoInfo, parseLocalVideoCollaborators } from '../../helpers/api/local.js'
+import { getLocalVideoCollaborators } from '../../helpers/api/local.js'
 import { isHistoryEntryWatched } from '../../helpers/history.js'
 import { getUpcomingPremiereTimestamp } from '../../helpers/subscription-entries.js'
 import { deArrowData, deArrowThumbnail, getSponsorBlockVideoLabel } from '../../helpers/sponsorblock.js'
@@ -1554,8 +1554,14 @@ async function openCollaboratorsPrompt() {
   setCollaboratorsLoading(true)
 
   try {
-    const videoInfo = await getLocalVideoInfo(id.value)
-    channelCollaborators.value = parseLocalVideoCollaborators(videoInfo.info)
+    const videoId = id.value
+    const collaborators = await getLocalVideoCollaborators(videoId)
+
+    if (id.value !== videoId) {
+      return
+    }
+
+    channelCollaborators.value = collaborators
 
     if (channelCollaborators.value.length > 1) {
       showCollaboratorsPrompt.value = true

--- a/src/renderer/helpers/api/local.js
+++ b/src/renderer/helpers/api/local.js
@@ -865,6 +865,7 @@ export async function getLocalShortLinkedVideo(id) {
 }
 
 const LOCAL_VIDEO_COLLABORATORS_CACHE_SIZE = 100
+const LOCAL_VIDEO_COLLABORATORS_TIMEOUT_MS = 15_000
 const localVideoCollaboratorsCache = new Map()
 
 /**
@@ -881,19 +882,30 @@ export function getLocalVideoCollaborators(id) {
   }
 
   const request = (async () => {
-    const innertube = await createInnertube()
-    const response = await innertube.actions.execute('/next', {
-      videoId: id,
-      racyCheckOk: true,
-      contentCheckOk: true,
-      parse: true,
-    })
-    const secondaryInfo = response.contents_memo
-      ?.getType(YTNodes.VideoSecondaryInfo)[0]
+    const abortController = new AbortController()
+    const timeout = setTimeout(() => abortController.abort(), LOCAL_VIDEO_COLLABORATORS_TIMEOUT_MS)
 
-    return parseLocalVideoCollaborators({ secondary_info: secondaryInfo })
+    try {
+      const innertube = await createInnertube({
+        fetchFunc: (input, init) => fetch(input, { ...init, signal: abortController.signal })
+      })
+      const response = await innertube.actions.execute('/next', {
+        videoId: id,
+        racyCheckOk: true,
+        contentCheckOk: true,
+        parse: true,
+      })
+      const secondaryInfo = response.contents_memo
+        ?.getType(YTNodes.VideoSecondaryInfo)[0]
+
+      return parseLocalVideoCollaborators({ secondary_info: secondaryInfo })
+    } finally {
+      clearTimeout(timeout)
+    }
   })().catch((error) => {
-    localVideoCollaboratorsCache.delete(id)
+    if (localVideoCollaboratorsCache.get(id) === request) {
+      localVideoCollaboratorsCache.delete(id)
+    }
     throw error
   })
 

--- a/src/renderer/helpers/api/local.js
+++ b/src/renderer/helpers/api/local.js
@@ -8,6 +8,7 @@ import { loadSearchContinuation } from '../search-continuation'
 import { parseLocalShortLinkedVideo } from '../player/shorts'
 import { getPaidPromotionDurationMs } from '../player/paidPromotion'
 import { getLocalPremiereState } from '../premiere'
+import { parseLocalVideoCollaborators } from '../video-collaborators'
 import {
   CHANNEL_HANDLE_REGEX,
   calculatePublishedDate,
@@ -861,6 +862,46 @@ export async function getLocalShortLinkedVideo(id) {
   })
 
   return parseLocalShortLinkedVideo(response)
+}
+
+const LOCAL_VIDEO_COLLABORATORS_CACHE_SIZE = 100
+const localVideoCollaboratorsCache = new Map()
+
+/**
+ * Loads only the watch-next metadata needed by the collaborators prompt.
+ * Unlike getLocalVideoInfo, this avoids player setup, proof-token generation,
+ * playback requests, and paid-promotion metadata.
+ * @param {string} id
+ * @returns {Promise<ReturnType<typeof parseLocalVideoCollaborators>>}
+ */
+export function getLocalVideoCollaborators(id) {
+  const cachedRequest = localVideoCollaboratorsCache.get(id)
+  if (cachedRequest) {
+    return cachedRequest
+  }
+
+  const request = (async () => {
+    const innertube = await createInnertube()
+    const response = await innertube.actions.execute('/next', {
+      videoId: id,
+      racyCheckOk: true,
+      contentCheckOk: true,
+      parse: true,
+    })
+    const secondaryInfo = response.contents_memo
+      ?.getType(YTNodes.VideoSecondaryInfo)[0]
+
+    return parseLocalVideoCollaborators({ secondary_info: secondaryInfo })
+  })().catch((error) => {
+    localVideoCollaboratorsCache.delete(id)
+    throw error
+  })
+
+  localVideoCollaboratorsCache.set(id, request)
+  if (localVideoCollaboratorsCache.size > LOCAL_VIDEO_COLLABORATORS_CACHE_SIZE) {
+    localVideoCollaboratorsCache.delete(localVideoCollaboratorsCache.keys().next().value)
+  }
+  return request
 }
 
 export { parseLocalVideoCollaborators } from '../video-collaborators'


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Make sure to follow the contributing guidelines. -->
<!-- Important note, we may remove your pull request if you do not use this provided PR template correctly. -->
<!-- Agent instructions: Preserve every heading, comment, and marker in this template. Never remove or rewrite the release-note-category:start/end, release-note:start/end, or release-note-image:start/end marker pairs. Never remove or rewrite the Release note images section; leave its contents for a human. -->

## Pull Request Type
<!-- Please select what type of pull request this is: [x] -->
- [ ] Bugfix
- [ ] Feature Implementation
- [ ] Documentation
- [x] Other

## Related issue
<!-- Please link the issue your pull request is referring to. -->
<!-- If this pull request fully resolves the relevant issue, put "closes" before the issue number. -->
<!-- Example: "closes #123456". -->

## Description
<!-- Please write a clear and concise description of what the pull request does. -->
Opening the collaborators prompt from a subscription-feed video was slow because it loaded the video's complete playback information. That initialized the player, generated a proof token, and requested unrelated playback and promotion data before the prompt could open.

This adds a lightweight collaborator lookup that requests only watch-next metadata. Requests and results are shared through a bounded cache, failed requests remain retryable, and a response is ignored if its reused feed card has since changed videos.

## Release note category
<!-- Select exactly one category. Every pull request must select one. -->
<!-- Select "Not noteworthy" when the pull request fixes a bug in or improves functionality that has not yet appeared in a stable release. -->
<!-- release-note-category:start -->
- [ ] Not noteworthy
- [ ] Highlights
- [x] More improvements
- [ ] Fixed bugs
<!-- release-note-category:end -->

## Release note
<!-- Required unless "Not noteworthy" is selected. -->
<!-- Write one concise, user-facing entry without a leading bullet. -->
<!-- release-note:start -->
The collaborator lists from the subscription feed now opens faster.
<!-- release-note:end -->

## Release note images
<!-- Human-only: Agents must preserve this entire section and leave it empty. -->
<!-- Optional. Paste one or more Markdown images or HTML image tags here. -->
<!-- The release notes will use an HTML image tag and limit images taller than 300 pixels. -->
<!-- release-note-image:start -->

<!-- release-note-image:end -->

## Testing
<!-- How can reviewers verify that the PR produces correct results? -->
<!-- Please provide instructions so that others can ensure that your pull request would produce correct results. For examples see, https://github.com/FreeTubeApp/FreeTube/pull/5743, https://github.com/FreeTubeApp/FreeTube/pull/7349, https://github.com/FreeTubeApp/FreeTube/pull/5125, https://github.com/FreeTubeApp/FreeTube/pull/7338 -->
<!-- Agent instructions: Only write human-facing steps that explain how to verify the change while running this branch in dev mode. Include expected results and, when applicable, helpful console snippets for interactive verification. Do not include automated checks, commands, results, pass counts, or CI status. -->
1. Open the subscription feed using the Local API.
2. Find a collaboration video and click its channel/collaborator label.
3. Confirm the collaborators prompt opens noticeably faster and lists each collaborator.
4. Close and reopen the prompt; confirm it opens immediately.
5. Switch to the Invidious API and confirm ordinary subscription channel links continue to navigate normally.

## Additional context
<!-- Add any other context about the pull request here. -->
Invidious responses do not expose collaborator metadata, so the optimized lookup remains limited to Local API entries that identify themselves as collaborations.
