### PR TITLE
fix(playlists): load videos after members-only pages

### DIFF
--- a/e2e/tests/network/playlist.spec.mjs
+++ b/e2e/tests/network/playlist.spec.mjs
@@ -7,6 +7,11 @@ const MEMBERS_ONLY_PLAYLIST = {
   url: 'https://www.youtube.com/playlist?list=PLIwiAebpd5CK-T-TP6lnpLI5heKC9zDlc'
 }
 
+const MEMBERS_ONLY_FIRST_PAGES_PLAYLIST = {
+  id: 'PLxOs22nkVmnJ_dgTuecVIaIYW2iXOOiML',
+  url: 'https://www.youtube.com/playlist?list=PLxOs22nkVmnJ_dgTuecVIaIYW2iXOOiML'
+}
+
 test('loads playlists containing members-only videos', async ({ page, innertube }) => {
   test.skip(innertube.replay, 'playlist hydration needs the real API')
 
@@ -23,4 +28,17 @@ test('loads playlists containing members-only videos', async ({ page, innertube 
     () => page.locator('.playlistItemsCard .autoGrid > .grid').count(),
     { timeout: 30_000 }
   ).toBeGreaterThan(20)
+})
+
+test('loads playable videos after full pages of members-only videos', async ({ page, innertube }) => {
+  test.skip(innertube.replay, 'playlist hydration needs the real API')
+
+  await page.locator(sel.searchInput).fill(MEMBERS_ONLY_FIRST_PAGES_PLAYLIST.url)
+  await page.locator(sel.searchInput).press('Enter')
+
+  await expect(page).toHaveURL(new RegExp(`#\\/playlist\\/${MEMBERS_ONLY_FIRST_PAGES_PLAYLIST.id}`))
+  await expect.poll(
+    () => page.locator('.playlistItemsCard .autoGrid > .grid').count(),
+    { timeout: 30_000 }
+  ).toBeGreaterThan(0)
 })

--- a/src/renderer/views/Playlist/Playlist.vue
+++ b/src/renderer/views/Playlist/Playlist.vue
@@ -251,6 +251,7 @@ const isLoadingMore = ref(false)
 const playlistInEditMode = ref(false)
 const forceListView = ref(false)
 let alreadyShownNotice = false
+let fetchedLocalPlaylistItemCount = 0
 const videoSearchQuery = ref('')
 const promptOpen = ref(false)
 /** @type {import('vue').Ref<string[]>} */
@@ -483,6 +484,7 @@ function resetState() {
   infoSource.value = 'local'
   playlistItems.value = []
   continuationData.value = null
+  fetchedLocalPlaylistItemCount = 0
 }
 
 async function getPlaylistLocal() {
@@ -504,6 +506,7 @@ async function getPlaylistLocal() {
     }
 
     const playlistItems_ = parseLocalPlaylistVideos(result.items)
+    fetchedLocalPlaylistItemCount = result.items.length
 
     playlistTitle.value = result.info.title
     playlistDescription.value = result.info.description ?? ''
@@ -528,10 +531,10 @@ async function getPlaylistLocal() {
     let shouldGetNextPage = false
     if (result.has_continuation) {
       continuationData.value = result
-      shouldGetNextPage = result.items.length < 100 && playlistItems.value.length < 100
+      shouldGetNextPage = playlistItems.value.length < 100 && fetchedLocalPlaylistItemCount < videoCount.value
     }
-    // To workaround the effect of useless continuation data
-    // auto load next page again when no. of parsed items < page size
+    // Fill the first page when unplayable entries were filtered out. The raw
+    // item count bounds automatic continuation loading to the playlist size.
     if (shouldGetNextPage) {
       getNextPageLocal()
     }
@@ -730,14 +733,15 @@ async function getNextPageLocal() {
 
   if (result) {
     const parsedVideos = parseLocalPlaylistVideos(result.items)
+    fetchedLocalPlaylistItemCount += result.items.length
     playlistItems.value = playlistItems.value.concat(parsedVideos)
 
     if (result.has_continuation) {
       continuationData.value = result
 
-      // To workaround the effect of useless continuation data
-      // auto load next page again when no. of parsed items < page size
-      shouldGetNextPage = result.items.length < 100 && parsedVideos.length < 100
+      // Keep crossing pages that contain filtered entries until this page is
+      // full or every advertised playlist item has been fetched.
+      shouldGetNextPage = parsedVideos.length < 100 && fetchedLocalPlaylistItemCount < videoCount.value
     } else {
       continuationData.value = null
     }


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Make sure to follow the contributing guidelines. -->
<!-- Important note, we may remove your pull request if you do not use this provided PR template correctly. -->
<!-- Agent instructions: Preserve every heading, comment, and marker in this template. Never remove or rewrite the release-note-category:start/end, release-note:start/end, or release-note-image:start/end marker pairs. Never remove or rewrite the Release note images section; leave its contents for a human. -->

## Pull Request Type
<!-- Please select what type of pull request this is: [x] -->
- [x] Bugfix
- [ ] Feature Implementation
- [ ] Documentation
- [ ] Other

## Related issue
<!-- Please link the issue your pull request is referring to. -->
<!-- If this pull request fully resolves the relevant issue, put "closes" before the issue number. -->
<!-- Example: "closes #123456". -->
Closes https://gitlab.com/opentubex/OpenTubeX/-/work_items/520

## Description
<!-- Please write a clear and concise description of what the pull request does. -->
Playlists could stop loading when their first full pages contained only members-only videos, even when playable videos existed later. The continuation safeguard treated a full raw page as a reason not to continue after those entries were filtered out.

Track how many raw playlist entries have been fetched and continue across filtered pages until playable entries are found or the playlist's advertised item count is exhausted. This keeps continuation loading bounded while allowing regular videos beyond multiple members-only pages to appear.

## Release note category
<!-- Select exactly one category. Every pull request must select one. -->
<!-- Select "Not noteworthy" when the pull request fixes a bug in or improves functionality that has not yet appeared in a stable release. -->
<!-- release-note-category:start -->
- [ ] Not noteworthy
- [ ] Highlights
- [ ] More improvements
- [x] Fixed bugs
<!-- release-note-category:end -->

## Release note
<!-- Required unless "Not noteworthy" is selected. -->
<!-- Write one concise, user-facing entry without a leading bullet. -->
<!-- release-note:start -->
Playlists now load playable videos that appear after full pages of members-only entries.
<!-- release-note:end -->

## Release note images
<!-- Human-only: Agents must preserve this entire section and leave it empty. -->
<!-- Optional. Paste one or more Markdown images or HTML image tags here. -->
<!-- The release notes will use an HTML image tag and limit images taller than 300 pixels. -->
<!-- release-note-image:start -->

<!-- release-note-image:end -->

## Testing
<!-- How can reviewers verify that the PR produces correct results? -->
<!-- Please provide instructions so that others can ensure that your pull request would produce correct results. For examples see, https://github.com/FreeTubeApp/FreeTube/pull/5743, https://github.com/FreeTubeApp/FreeTube/pull/7349, https://github.com/FreeTubeApp/FreeTube/pull/5125, https://github.com/FreeTubeApp/FreeTube/pull/7338 -->
<!-- Agent instructions: Only write human-facing steps that explain how to verify the change while running this branch in dev mode. Include expected results and, when applicable, helpful console snippets for interactive verification. Do not include automated checks, commands, results, pass counts, or CI status. -->
1. Select the Local API and open https://www.youtube.com/playlist?list=PLxOs22nkVmnJ_dgTuecVIaIYW2iXOOiML in the app.
2. Wait for the playlist page to finish loading.
3. Confirm that playable regular videos appear even though the first pages contain only members-only entries.
4. Scroll through the loaded videos and confirm normal playlist pagination remains available.

## Additional context
<!-- Add any other context about the pull request here. -->
The regression fixture is the playlist reported in the linked issue.