### PR TITLE
feat(subscriptions): make scheduled feed priority optional

### DIFF
--- a/src/renderer/components/SubscriptionSettings/SubscriptionSettings.vue
+++ b/src/renderer/components/SubscriptionSettings/SubscriptionSettings.vue
@@ -90,6 +90,14 @@
           @change="updateShowNewSubscriptionFeed"
         />
         <FtToggleSwitch
+          :label="$t('Settings.Subscription Settings.Show Scheduled Live Streams / Premieres First')"
+          :default-value="showScheduledLiveStreamsFirst"
+          setting-key="showScheduledLiveStreamsFirst"
+          :tooltip="$t('Tooltips.Subscription Settings.Show Scheduled Live Streams / Premieres First')"
+          compact
+          @change="updateShowScheduledLiveStreamsFirst"
+        />
+        <FtToggleSwitch
           :label="$t('Settings.Subscription Settings.Show New Content Indicators')"
           :default-value="showNewSubscriptionFeedIndicators"
           setting-key="showNewSubscriptionFeedIndicators"
@@ -208,11 +216,21 @@ const showNewSubscriptionFeedIndicators = computed(() => store.getters.getShowNe
 /** @type {import('vue').ComputedRef<boolean>} */
 const showNewSubscriptionFeed = computed(() => store.getters.getShowNewSubscriptionFeed)
 
+/** @type {import('vue').ComputedRef<boolean>} */
+const showScheduledLiveStreamsFirst = computed(() => store.getters.getShowScheduledLiveStreamsFirst)
+
 /**
  * @param {boolean} value
  */
 function updateShowNewSubscriptionFeed(value) {
   store.dispatch('updateShowNewSubscriptionFeed', value)
+}
+
+/**
+ * @param {boolean} value
+ */
+function updateShowScheduledLiveStreamsFirst(value) {
+  store.dispatch('updateShowScheduledLiveStreamsFirst', value)
 }
 
 /**

--- a/src/renderer/components/SubscriptionsVideos.vue
+++ b/src/renderer/components/SubscriptionsVideos.vue
@@ -20,7 +20,10 @@ import store from '../store/index'
 
 import { useRelativeTimeClock } from '../composables/useRelativeTimeClock'
 import { useSubscriptionChannelUpdates } from '../composables/useSubscriptionChannelUpdates'
-import { getUpcomingPremiereTimestamp } from '../helpers/subscription-entries'
+import {
+  ensureUpcomingSubscriptionFeedPublished,
+  getUpcomingPremiereTimestamp
+} from '../helpers/subscription-entries'
 import { getCachedRelativeTimeFormat, getCachedShortDateTimeFormat, getRelativeTimeFromDate } from '../helpers/utils'
 import {
   refreshSubscriptionVideosFromRemote,
@@ -49,6 +52,8 @@ const subscriptionCacheReady = computed(() => store.getters.getSubscriptionCache
 
 /** @type {import('vue').ComputedRef<boolean>} */
 const fetchSubscriptionsAutomatically = computed(() => store.getters.getFetchSubscriptionsAutomatically)
+
+const showScheduledLiveStreamsFirst = computed(() => store.getters.getShowScheduledLiveStreamsFirst)
 
 const activeSubscriptionList = computed(() => store.getters.getActiveProfile.subscriptions)
 
@@ -88,6 +93,12 @@ const nextUpcomingPremiereTimestamp = computed(() => {
 })
 
 watch(nextUpcomingPremiereTimestamp, scheduleNextPremiereUpdate, { immediate: true })
+
+watch(showScheduledLiveStreamsFirst, () => {
+  if (subscriptionCacheReady.value) {
+    loadVideosFromCacheForAllActiveProfileChannels()
+  }
+})
 
 function scheduleNextPremiereUpdate(timestamp) {
   if (premiereUpdateTimer !== null) {
@@ -266,7 +277,15 @@ function loadVideosFromCacheSometimes() {
 
 function loadVideosFromCacheForAllActiveProfileChannels() {
   const videoList_ = cacheEntriesForAllActiveProfileChannels.value.flatMap((cacheEntry) => {
-    return cacheEntry.videos ?? []
+    const cacheTimestamp = new Date(cacheEntry.timestamp).getTime()
+
+    return (cacheEntry.videos ?? []).map(video => {
+      return ensureUpcomingSubscriptionFeedPublished(
+        video,
+        cacheTimestamp,
+        premiereUpdateNow.value
+      )
+    })
   })
 
   videoList.value = updateVideoListAfterProcessing(videoList_, premiereUpdateNow.value)

--- a/src/renderer/helpers/api/invidious.js
+++ b/src/renderer/helpers/api/invidious.js
@@ -1010,6 +1010,9 @@ function setPublishedTimestamp(video) {
   if (video.liveNow) {
     video.published = Date.now()
   } else if (video.isUpcoming) {
+    if (typeof video.published === 'number') {
+      video.subscriptionFeedPublished = video.published * 1000
+    }
     video.published = video.premiereTimestamp * 1000
   } else if (typeof video.published === 'number') {
     video.published *= 1000

--- a/src/renderer/helpers/subscription-entries.js
+++ b/src/renderer/helpers/subscription-entries.js
@@ -52,6 +52,74 @@ export function updateUpcomingPremiereState(video, now) {
 }
 
 /**
+ * @param {object} video
+ * @param {boolean} showScheduledLiveStreamsFirst
+ * @param {number} now
+ */
+export function getSubscriptionVideoSortTimestamp(video, showScheduledLiveStreamsFirst, now) {
+  const scheduledTimestamp = getUpcomingPremiereTimestamp(video)
+  const isUpcoming = scheduledTimestamp != null
+    ? scheduledTimestamp > now
+    : video.isUpcoming === true || video.premiere === true
+
+  if (
+    !showScheduledLiveStreamsFirst &&
+    isUpcoming &&
+    video.subscriptionFeedPublished != null &&
+    Number.isFinite(Number(video.subscriptionFeedPublished))
+  ) {
+    return Number(video.subscriptionFeedPublished)
+  }
+
+  return video.published
+}
+
+/**
+ * Gives pre-setting cache entries a stable announcement position before they
+ * are fetched and reconciled again.
+ * @param {object} video
+ * @param {number} fallbackTimestamp
+ * @param {number} now
+ */
+export function ensureUpcomingSubscriptionFeedPublished(video, fallbackTimestamp, now) {
+  const existingTimestamp = Number(video.subscriptionFeedPublished)
+  if (video.subscriptionFeedPublished != null && Number.isFinite(existingTimestamp)) {
+    return video
+  }
+
+  const scheduledTimestamp = getUpcomingPremiereTimestamp(video)
+  const isUpcoming = scheduledTimestamp != null
+    ? scheduledTimestamp > now
+    : video.isUpcoming === true || video.premiere === true
+  const timestamp = Number(fallbackTimestamp)
+
+  if (!isUpcoming || !Number.isFinite(timestamp)) {
+    return video
+  }
+
+  return {
+    ...video,
+    subscriptionFeedPublished: timestamp
+  }
+}
+
+/**
+ * Returns the announcement position used for an upcoming subscription entry.
+ * Exact publication dates are preferred; scraper entries fall back to the time
+ * they first entered OpenTubeX's subscription cache.
+ * @param {object} video
+ * @param {number} fallbackTimestamp
+ */
+function getSubscriptionFeedPublishedTimestamp(video, fallbackTimestamp) {
+  if (video.subscriptionFeedPublished == null) {
+    return fallbackTimestamp
+  }
+
+  const timestamp = Number(video.subscriptionFeedPublished)
+  return Number.isFinite(timestamp) ? timestamp : fallbackTimestamp
+}
+
+/**
  * Adds YouTube's selected portrait thumbnails to dated Shorts entries without
  * replacing the exact publication and view metadata supplied by RSS.
  * @param {object[]} entries
@@ -154,6 +222,18 @@ export function reconcileFetchedSubscriptionEntries(
       isNewInSubscriptionFeed: !isWatched && (wasPreviouslyNew || isNewlyFetched)
     }
 
+    if (entry.isUpcoming === true || entry.premiere === true) {
+      const scheduledTimestamp = getUpcomingPremiereTimestamp(entry)
+      const previousFeedTimestamp = getSubscriptionFeedPublishedTimestamp(previousEntry ?? {}, null)
+      const fetchedFeedTimestamp = getSubscriptionFeedPublishedTimestamp(entry, null)
+
+      // Some backends expose the scheduled start as both publication fields.
+      // That is not an announcement date, so use first-seen time instead.
+      reconciledEntry.subscriptionFeedPublished = [previousFeedTimestamp, fetchedFeedTimestamp]
+        .find(timestamp => timestamp != null && timestamp !== scheduledTimestamp) ??
+          (Number.isFinite(previousFetchTime) ? previousFetchTime : Date.now())
+    }
+
     if (previousEntry != null && keepPreviousPublicationDate(entry, previousEntry, publicationDateKey)) {
       reconciledEntry[publicationDateKey] = previousEntry[publicationDateKey]
     }
@@ -254,7 +334,8 @@ export function applyRssPremiereVerdict(video, upcomingInfo) {
 
   const enrichedVideo = {
     ...video,
-    isUpcoming: true
+    isUpcoming: true,
+    subscriptionFeedPublished: getSubscriptionFeedPublishedTimestamp(video, video.published)
   }
 
   if (upcomingInfo.premiereDate) {

--- a/src/renderer/helpers/subscriptions.js
+++ b/src/renderer/helpers/subscriptions.js
@@ -23,6 +23,7 @@ import { getValidSubscriptionChannels } from './subscription-channels'
 import {
   applyRssPremiereVerdict,
   collectResolvedNonPremiereVideoIds,
+  getSubscriptionVideoSortTimestamp,
   getUpcomingPremiereTimestamp,
   mergeSubscriptionShortThumbnails,
   reconcileFetchedSubscriptionEntries,
@@ -500,8 +501,11 @@ export function updateVideoListAfterProcessing(videos, now = Date.now()) {
     videoList = videoList.filter(item => !isUpcomingPremiere(item, now))
   }
 
+  const showScheduledLiveStreamsFirst = store.getters.getShowScheduledLiveStreamsFirst
+
   videoList.sort((a, b) => {
-    return b.published - a.published
+    return getSubscriptionVideoSortTimestamp(b, showScheduledLiveStreamsFirst, now) -
+      getSubscriptionVideoSortTimestamp(a, showScheduledLiveStreamsFirst, now)
   })
 
   return videoList

--- a/src/renderer/store/modules/settings.js
+++ b/src/renderer/store/modules/settings.js
@@ -451,6 +451,7 @@ const state = {
   highlightChangedSettings: false,
   showPerformanceImpactIndicators: false,
   fetchSubscriptionsAutomatically: true,
+  showScheduledLiveStreamsFirst: true,
   showNewSubscriptionFeed: true,
   showNewSubscriptionFeedIndicators: false,
   subscriptionFeedAutoRefreshInterval: '0',

--- a/static/locales/de-DE.yaml
+++ b/static/locales/de-DE.yaml
@@ -558,6 +558,7 @@ Settings:
     Fetch Feed on Startup: Feed beim Start abrufen
     Show New Content Feed: Feed mit neuen Inhalten anzeigen
     Show New Content Indicators: Markierungen für neue Inhalte anzeigen
+    Show Scheduled Live Streams / Premieres First: Geplante Livestreams / Premieren zuerst anzeigen
     Confirm Before Unsubscribing: Unbeabsichtigtes Deabonnieren verhindern
 
     'Limit the number of videos displayed for each channel': Anzahl der für jeden Kanal angezeigten Videos begrenzen
@@ -1343,6 +1344,7 @@ Tooltips:
     Fetch Feed on Startup: Wenn aktiviert, ruft OpenTubeX deine Abos automatisch beim Start und beim Öffnen eines neuen Fensters ab.
     Show New Content Feed: Zeigt eine Registerkarte „Neu“ mit Abo-Feed-Einträgen an, die beim vorherigen Abruf noch nicht vorhanden waren.
     Show New Content Indicators: Zeigt einen kleinen Punkt neben Abo-Feed-Einträgen an, die beim vorherigen Abruf noch nicht vorhanden waren.
+    Show Scheduled Live Streams / Premieres First: Zeigt bevorstehende Livestreams und Premieren oben im Abo-Feed an. Wenn deaktiviert, bleiben sie bis zum Start an der Position ihrer Ankündigung.
     Auto Refresh Interval: Wie oft OpenTubeX automatisch deine Abos aktualisiert während die Anwendung geöffnet ist.
   Player Settings:
     Enable Caption Translations: Wenn aktiviert, bevorzugen die Untertitel-Schaltfläche und das Tastenkürzel C eine automatisch übersetzte Spur in der bevorzugten Untertitelsprache, wenn das Video keine passende Originalspur bereitstellt.

--- a/static/locales/en-US.yaml
+++ b/static/locales/en-US.yaml
@@ -973,6 +973,7 @@ Settings:
     Fetch Feed on Startup: Fetch Feed on Startup
     Show New Content Feed: Show New Content Feed
     Show New Content Indicators: Show New Content Indicators
+    Show Scheduled Live Streams / Premieres First: Show Scheduled Live Streams / Premieres First
     Auto Refresh Interval: Auto Refresh Interval
     Videos Auto Refresh Interval: Videos Auto Refresh Interval
     Shorts Auto Refresh Interval: Shorts Auto Refresh Interval
@@ -2016,6 +2017,7 @@ Tooltips:
       your subscription feed on startup and when a new window is opened.
     Show New Content Feed: Shows a New tab containing subscription feed items that were not present during the previous fetch.
     Show New Content Indicators: Shows a small dot beside subscription feed items that were not present during the previous fetch.
+    Show Scheduled Live Streams / Premieres First: Keeps upcoming live streams and premieres at the top of the subscription feed. When disabled, they remain at their announcement position until they start.
     Auto Refresh Interval: How often OpenTubeX automatically refreshes your subscription feed while the app is open.
   Theme Settings:
     Show Progress as Notification: Shows a persistent notification with live progress for background operations, such as subscription refreshes and managed tool downloads, instead of using the global progress bar.

--- a/tests/unit/subscription-entries.test.mjs
+++ b/tests/unit/subscription-entries.test.mjs
@@ -4,7 +4,9 @@ import test from 'node:test'
 import {
   applyRssPremiereVerdict,
   collectResolvedNonPremiereVideoIds,
+  ensureUpcomingSubscriptionFeedPublished,
   ensureSubscriptionFeedEntryState,
+  getSubscriptionVideoSortTimestamp,
   getUpcomingPremiereTimestamp,
   mergeSubscriptionShortThumbnails,
   reconcileFetchedSubscriptionEntries,
@@ -61,6 +63,51 @@ test('marks an upcoming premiere as live when its scheduled time arrives', () =>
     liveNow: false
   }
   assert.equal(updateUpcomingPremiereState(completed, scheduledTime), completed)
+})
+
+test('sorts scheduled entries by announcement time until they start', () => {
+  const scheduledTime = now + HOUR
+  const announcementTime = now - HOUR
+  const upcoming = video('premiere', scheduledTime, {
+    isUpcoming: true,
+    premiereDate: new Date(scheduledTime),
+    subscriptionFeedPublished: announcementTime
+  })
+
+  assert.equal(getSubscriptionVideoSortTimestamp(upcoming, true, now), scheduledTime)
+  assert.equal(getSubscriptionVideoSortTimestamp(upcoming, false, now), announcementTime)
+  assert.equal(getSubscriptionVideoSortTimestamp(upcoming, false, scheduledTime), scheduledTime)
+})
+
+test('backfills and keeps the first-seen feed position for scraper and legacy entries', () => {
+  const scheduledTime = now + HOUR
+  const firstSeenTime = now - HOUR
+  const entry = video('premiere', scheduledTime, {
+    isUpcoming: true,
+    premiereDate: new Date(scheduledTime)
+  })
+
+  const backfilled = ensureUpcomingSubscriptionFeedPublished(entry, firstSeenTime, now)
+  assert.equal(backfilled.subscriptionFeedPublished, firstSeenTime)
+  assert.equal(getSubscriptionVideoSortTimestamp(backfilled, false, now), firstSeenTime)
+
+  const reconciled = reconcileFetchedSubscriptionEntries(
+    [{ ...entry, subscriptionFeedPublished: scheduledTime }],
+    [backfilled],
+    'videoId',
+    now - HOUR
+  )
+
+  assert.equal(reconciled[0].subscriptionFeedPublished, firstSeenTime)
+
+  const refreshedLegacyEntry = reconcileFetchedSubscriptionEntries(
+    [{ ...entry, subscriptionFeedPublished: scheduledTime }],
+    [entry],
+    'videoId',
+    firstSeenTime
+  )
+
+  assert.equal(refreshedLegacyEntry[0].subscriptionFeedPublished, firstSeenTime)
 })
 
 test('adds selected Shorts thumbnails without replacing RSS metadata', () => {
@@ -314,10 +361,14 @@ test('a settled lookup records the verdict both ways', () => {
   assert.deepEqual([...collectResolvedNonPremiereVideoIds([{ ch: { videos: [notPremiere] } }])], ['a'])
 
   const premiereDate = new Date('2026-01-02T03:04:05Z')
-  const premiere = applyRssPremiereVerdict({ videoId: 'b' }, { isUpcoming: true, premiereDate })
+  const premiere = applyRssPremiereVerdict(
+    { videoId: 'b', published: 1234 },
+    { isUpcoming: true, premiereDate }
+  )
   assert.equal(premiere.isUpcoming, true)
   assert.equal(premiere.premiereDate, premiereDate)
   assert.equal(premiere.published, premiereDate.getTime())
+  assert.equal(premiere.subscriptionFeedPublished, 1234)
   // An upcoming premiere goes live eventually, so it is never a durable negative.
   assert.equal(collectResolvedNonPremiereVideoIds([{ ch: { videos: [premiere] } }]).size, 0)
 })


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Make sure to follow the contributing guidelines. -->
<!-- Important note, we may remove your pull request if you do not use this provided PR template correctly. -->
<!-- Agent instructions: Preserve every heading, comment, and marker in this template. Never remove or rewrite the release-note-category:start/end, release-note:start/end, or release-note-image:start/end marker pairs. Never remove or rewrite the Release note images section; leave its contents for a human. -->

## Pull Request Type
<!-- Please select what type of pull request this is: [x] -->
- [ ] Bugfix
- [x] Feature Implementation
- [ ] Documentation
- [ ] Other

## Related issue
<!-- Please link the issue your pull request is referring to. -->
<!-- If this pull request fully resolves the relevant issue, put "closes" before the issue number. -->
<!-- Example: "closes #123456". -->

Closes #703.

## Description
<!-- Please write a clear and concise description of what the pull request does. -->

Scheduled live streams and premieres currently use their future start time as their subscription-feed publication date, which keeps them above newly published content.

This adds an enabled-by-default subscription setting that preserves the existing priority. When disabled, upcoming entries use their announcement time—or the time OpenTubeX first saw them when the backend has no announcement date—until they begin airing. At their scheduled start, the existing feed timer automatically promotes them to the current position.

## Release note category
<!-- Select exactly one category. Every pull request must select one. -->
<!-- Select "Not noteworthy" when the pull request fixes a bug in or improves functionality that has not yet appeared in a stable release. -->
<!-- release-note-category:start -->
- [ ] Not noteworthy
- [ ] Highlights
- [x] More improvements
- [ ] Fixed bugs
<!-- release-note-category:end -->

## Release note
<!-- Required unless "Not noteworthy" is selected. -->
<!-- Write one concise, user-facing entry without a leading bullet. -->
<!-- release-note:start -->
Added an option to keep upcoming live streams and premieres at their announcement position in the subscription feed until they start.
<!-- release-note:end -->

## Release note images
<!-- Human-only: Agents must preserve this entire section and leave it empty. -->
<!-- Optional. Paste one or more Markdown images or HTML image tags here. -->
<!-- The release notes will use an HTML image tag and limit images taller than 300 pixels. -->
<!-- release-note-image:start -->
<img width="390" height="36" alt="image" src="https://github.com/user-attachments/assets/862391b5-e7cb-4b5a-b2ff-01193baa1a57" />
<!-- release-note-image:end -->

## Testing
<!-- How can reviewers verify that the PR produces correct results? -->
<!-- Please provide instructions so that others can ensure that your pull request produces correct results. For examples see, https://github.com/FreeTubeApp/FreeTube/pull/5743, https://github.com/FreeTubeApp/FreeTube/pull/7349, https://github.com/FreeTubeApp/FreeTube/pull/5125, https://github.com/FreeTubeApp/FreeTube/pull/7338 -->
<!-- Agent instructions: Only write human-facing steps that explain how to verify the change while running this branch in dev mode. Include expected results and, when applicable, helpful console snippets for interactive verification. Do not include automated checks, commands, results, pass counts, or CI status. -->

1. Open Subscription settings and confirm **Show Scheduled Live Streams / Premieres First** is enabled by default.
2. Open a subscription feed containing a future scheduled stream or premiere and confirm it remains above ordinary new uploads while the setting is enabled.
3. Disable the setting and refresh the feed. Confirm the scheduled entry moves to its original announcement position while its displayed scheduled date remains unchanged.
4. Leave the feed open as a scheduled entry reaches its start time. Confirm it automatically moves to the newest position without manually refreshing.
5. Re-enable the setting and confirm future scheduled entries return to the top.

## Additional context
<!-- Add any other context about the pull request here. -->

RSS and compatible Invidious responses provide an announcement timestamp. Local scraper responses that omit it use the stable first-seen cache timestamp instead.