### PR TITLE
fix(subscriptions): sort local upcoming entries by announcement

### DIFF
--- a/src/renderer/helpers/subscription-entries.js
+++ b/src/renderer/helpers/subscription-entries.js
@@ -104,6 +104,35 @@ export function ensureUpcomingSubscriptionFeedPublished(video, fallbackTimestamp
 }
 
 /**
+ * Adds exact announcement dates supplied by RSS to scraped upcoming entries.
+ * @param {object[]} videos
+ * @param {object[]} rssVideos
+ */
+export function mergeUpcomingSubscriptionFeedPublished(videos, rssVideos) {
+  const publishedByVideoId = new Map(
+    rssVideos
+      .filter(video => video.videoId != null && Number.isFinite(Number(video.published)))
+      .map(video => [video.videoId, Number(video.published)])
+  )
+
+  return videos.map(video => {
+    if (video.isUpcoming !== true && video.premiere !== true) {
+      return video
+    }
+
+    const published = publishedByVideoId.get(video.videoId)
+    if (published == null) {
+      return video
+    }
+
+    return {
+      ...video,
+      subscriptionFeedPublished: published
+    }
+  })
+}
+
+/**
  * Returns the announcement position used for an upcoming subscription entry.
  * Exact publication dates are preferred; scraper entries fall back to the time
  * they first entered OpenTubeX's subscription cache.

--- a/src/renderer/helpers/subscription-entries.js
+++ b/src/renderer/helpers/subscription-entries.js
@@ -258,7 +258,7 @@ export function reconcileFetchedSubscriptionEntries(
 
       // Some backends expose the scheduled start as both publication fields.
       // That is not an announcement date, so use first-seen time instead.
-      reconciledEntry.subscriptionFeedPublished = [previousFeedTimestamp, fetchedFeedTimestamp]
+      reconciledEntry.subscriptionFeedPublished = [fetchedFeedTimestamp, previousFeedTimestamp]
         .find(timestamp => timestamp != null && timestamp !== scheduledTimestamp) ??
           (Number.isFinite(previousFetchTime) ? previousFetchTime : Date.now())
     }

--- a/src/renderer/helpers/subscriptions.js
+++ b/src/renderer/helpers/subscriptions.js
@@ -26,6 +26,7 @@ import {
   getSubscriptionVideoSortTimestamp,
   getUpcomingPremiereTimestamp,
   mergeSubscriptionShortThumbnails,
+  mergeUpcomingSubscriptionFeedPublished,
   reconcileFetchedSubscriptionEntries,
   updateUpcomingPremiereState
 } from './subscription-entries'
@@ -544,6 +545,51 @@ export async function parseYouTubeRSSFeed(rssString, channelId) {
 }
 
 /**
+ * Parses only the exact publication metadata needed to position scraped
+ * upcoming entries. Unlike the full RSS parser, this performs no watch-page
+ * enrichment.
+ * @param {string} rssString
+ */
+function parseYouTubeRSSPublicationDates(rssString) {
+  try {
+    const xmlDom = new DOMParser().parseFromString(rssString, 'application/xml')
+
+    return Array.from(xmlDom.querySelectorAll('entry'), entry => ({
+      videoId: entry.getElementsByTagName('yt:videoId')[0]?.textContent,
+      published: Date.parse(entry.querySelector('published')?.textContent)
+    }))
+  } catch {
+    return []
+  }
+}
+
+/**
+ * @param {string} channelId
+ * @param {object[]} videos
+ */
+async function enrichScrapedUpcomingPublicationDates(channelId, videos) {
+  if (!videos.some(video => video.isUpcoming === true || video.premiere === true)) {
+    return videos
+  }
+
+  try {
+    const response = await fetchWithTimeout(
+      RSS_ENRICHMENT_TIMEOUT_MS,
+      `https://www.youtube.com/feeds/videos.xml?channel_id=${channelId}`
+    )
+
+    if (!response.ok) {
+      return videos
+    }
+
+    const rssVideos = parseYouTubeRSSPublicationDates(await response.text())
+    return mergeUpcomingSubscriptionFeedPublished(videos, rssVideos)
+  } catch {
+    return videos
+  }
+}
+
+/**
  * @param {{
  *  t: (key: string, named?: Record<string, unknown>) => string,
  *  showStartToast?: boolean,
@@ -1000,7 +1046,12 @@ async function getChannelVideosLocalScraper(channel, t, errorChannels, failedAtt
       return { videos: null }
     }
 
-    return result
+    return {
+      ...result,
+      videos: store.getters.getShowScheduledLiveStreamsFirst
+        ? result.videos
+        : await enrichScrapedUpcomingPublicationDates(channel.id, result.videos)
+    }
   } catch (err) {
     showSubscriptionFetchError(channel, err, t('Local API Error (Click to copy)'))
 

--- a/tests/unit/subscription-entries.test.mjs
+++ b/tests/unit/subscription-entries.test.mjs
@@ -9,6 +9,7 @@ import {
   getSubscriptionVideoSortTimestamp,
   getUpcomingPremiereTimestamp,
   mergeSubscriptionShortThumbnails,
+  mergeUpcomingSubscriptionFeedPublished,
   reconcileFetchedSubscriptionEntries,
   updateUpcomingPremiereState
 } from '../../src/renderer/helpers/subscription-entries.js'
@@ -130,6 +131,30 @@ test('adds selected Shorts thumbnails without replacing RSS metadata', () => {
     }),
     entries[1]
   ])
+})
+
+test('adds RSS announcement dates only to scraped upcoming entries', () => {
+  const scheduledTime = now + HOUR
+  const announcementTime = now - 4 * HOUR
+  const upcoming = video('upcoming', scheduledTime, {
+    isUpcoming: true,
+    premiereDate: new Date(scheduledTime)
+  })
+  const ordinary = video('ordinary', now - HOUR)
+
+  const merged = mergeUpcomingSubscriptionFeedPublished(
+    [upcoming, ordinary],
+    [
+      video('upcoming', announcementTime, { isRSS: true }),
+      video('ordinary', now, { isRSS: true })
+    ]
+  )
+
+  assert.deepEqual(merged, [
+    { ...upcoming, subscriptionFeedPublished: announcementTime },
+    ordinary
+  ])
+  assert.equal(getSubscriptionVideoSortTimestamp(merged[0], false, now), announcementTime)
 })
 
 test('keeps the cached publication date of entries that were already fetched', () => {

--- a/tests/unit/subscription-entries.test.mjs
+++ b/tests/unit/subscription-entries.test.mjs
@@ -157,6 +157,29 @@ test('adds RSS announcement dates only to scraped upcoming entries', () => {
   assert.equal(getSubscriptionVideoSortTimestamp(merged[0], false, now), announcementTime)
 })
 
+test('replaces a cached first-seen fallback with an exact RSS announcement date', () => {
+  const scheduledTime = now + HOUR
+  const announcementTime = now - 4 * HOUR
+  const firstSeenTime = now - HOUR
+  const upcoming = video('upcoming', scheduledTime, {
+    isUpcoming: true,
+    premiereDate: new Date(scheduledTime)
+  })
+  const [enriched] = mergeUpcomingSubscriptionFeedPublished(
+    [upcoming],
+    [video('upcoming', announcementTime, { isRSS: true })]
+  )
+
+  const [reconciled] = reconcileFetchedSubscriptionEntries(
+    [enriched],
+    [{ ...upcoming, subscriptionFeedPublished: firstSeenTime }],
+    'videoId',
+    firstSeenTime
+  )
+
+  assert.equal(reconciled.subscriptionFeedPublished, announcementTime)
+})
+
 test('keeps the cached publication date of entries that were already fetched', () => {
   const previousEntries = [
     video('a', now - 25 * HOUR),


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Make sure to follow the contributing guidelines. -->
<!-- Important note, we may remove your pull request if you do not use this provided PR template correctly. -->
<!-- Agent instructions: Preserve every heading, comment, and marker in this template. Never remove or rewrite the release-note-category:start/end, release-note:start/end, or release-note-image:start/end marker pairs. Never remove or rewrite the Release note images section; leave its contents for a human. -->

## Pull Request Type
<!-- Please select what type of pull request this is: [x] -->
- [x] Bugfix
- [ ] Feature Implementation
- [ ] Documentation
- [ ] Other

## Related issue
<!-- Please link the issue your pull request is referring to. -->
<!-- If this pull request fully resolves the relevant issue, put "closes" before the issue number. -->
<!-- Example: "closes #123456". -->

Follow-up to #703 and #708.

## Description
<!-- Please write a clear and concise description of what the pull request does. -->

Disabling scheduled feed priority still left Local API premieres and scheduled live streams at the top. Local API results only contain the future start time, so the first-seen fallback treated every scheduled entry as newly published after a feed refresh.

When scheduled priority is disabled, channels with upcoming Local API entries now make a lightweight RSS metadata request and merge the exact announcement dates by video ID. Local API remains the content source, ordinary videos are untouched, and an unavailable RSS feed falls back to the existing behavior without failing the subscription refresh.

## Release note category
<!-- Select exactly one category. Every pull request must select one. -->
<!-- Select "Not noteworthy" when the pull request fixes a bug in or improves functionality that has not yet appeared in a stable release. -->
<!-- release-note-category:start -->
- [x] Not noteworthy
- [ ] Highlights
- [ ] More improvements
- [ ] Fixed bugs
<!-- release-note-category:end -->

## Release note
<!-- Required unless "Not noteworthy" is selected. -->
<!-- Write one concise, user-facing entry without a leading bullet. -->
<!-- release-note:start -->

<!-- release-note:end -->

## Release note images
<!-- Human-only: Agents must preserve this entire section and leave it empty. -->
<!-- Optional. Paste one or more Markdown images or HTML image tags here. -->
<!-- The release notes will use an HTML image tag and limit images taller than 300 pixels. -->
<!-- release-note-image:start -->

<!-- release-note-image:end -->

## Testing
<!-- How can reviewers verify that the PR produces correct results? -->
<!-- Please provide instructions so that others can ensure that your pull request would produce correct results. For examples see, https://github.com/FreeTubeApp/FreeTube/pull/5743, https://github.com/FreeTubeApp/FreeTube/pull/7349, https://github.com/FreeTubeApp/FreeTube/pull/5125, https://github.com/FreeTubeApp/FreeTube/pull/7338 -->
<!-- Agent instructions: Only write human-facing steps that explain how to verify the change while running this branch in dev mode. Include expected results and, when applicable, helpful console snippets for interactive verification. Do not include automated checks, commands, results, pass counts, or CI status. -->

1. Use the Local API for subscription fetching and disable **Show Scheduled Live Streams / Premieres First**.
2. Refresh a subscription feed containing a future scheduled stream or premiere.
3. Confirm the upcoming entry sorts at its original announcement position instead of the refresh time, while still displaying its scheduled start date.
4. Re-enable the setting, refresh again, and confirm upcoming entries return to the top.
5. Temporarily make the channel RSS request fail and confirm the Local API subscription refresh still completes.

## Additional context
<!-- Add any other context about the pull request here. -->

The RSS request is only made for Local API channels that contain upcoming entries while scheduled priority is disabled. It parses publication metadata only and does not perform the full RSS watch-page enrichment path.
