### PR TITLE
fix(captions): honor configured alignment

### DIFF
--- a/e2e/helpers/watch.mjs
+++ b/e2e/helpers/watch.mjs
@@ -61,9 +61,15 @@ async function fixture(dir, name) {
  * @param {object} [options]
  * @param {boolean} [options.playable] serve the demo video instead of an error
  * @param {boolean} [options.captionTranslations] include a translatable caption and target languages
+ * @param {string} [options.captionCueSettings] append WebVTT settings to the test caption cue
  */
-export async function mockWatchPage(app, page, { playable = false, captionTranslations = false } = {}) {
+export async function mockWatchPage(app, page, {
+  playable = false,
+  captionTranslations = false,
+  captionCueSettings = ''
+} = {}) {
   const counters = new Map()
+  const includeCaptions = captionTranslations || captionCueSettings !== ''
 
   await stubPoToken(app.electronApp)
 
@@ -75,13 +81,13 @@ export async function mockWatchPage(app, page, { playable = false, captionTransl
     await routeDemoMedia(page)
   }
 
-  if (captionTranslations) {
+  if (includeCaptions) {
     await page.route('https://www.youtube.com/api/timedtext**', (route) => {
       const searchParams = new URL(route.request().url()).searchParams
       const format = searchParams.get('fmt')
       const body = format === 'srt'
         ? '1\n00:00:00,000 --> 00:00:05,000\nTranslated caption\n'
-        : 'WEBVTT\n\n00:00:00.000 --> 00:00:05.000\nOriginal caption\n'
+        : `WEBVTT\n\n00:00:00.000 --> 00:01:00.000 ${captionCueSettings}\nOriginal caption\n`
       const fulfill = () => route.fulfill({
         status: 200,
         contentType: format === 'srt' ? 'application/x-subrip' : 'text/vtt',
@@ -119,7 +125,7 @@ export async function mockWatchPage(app, page, { playable = false, captionTransl
       const videoId = JSON.parse(request.postData() ?? '{}').videoId ?? 'jNQXAC9IVRw'
       const json = demoPlayerResponse(videoId)
 
-      if (captionTranslations) {
+      if (includeCaptions) {
         const displayNames = new Intl.DisplayNames(['en'], { type: 'language' })
         const languageCodes = [
           'af', 'sq', 'am', 'ar', 'hy', 'as', 'ay', 'az', 'eu', 'be',
@@ -130,17 +136,19 @@ export async function mockWatchPage(app, page, { playable = false, captionTransl
         json.captions = {
           playerCaptionsTracklistRenderer: {
             captionTracks: [{
-              baseUrl: `https://www.youtube.com/api/timedtext?v=${videoId}&caps=asr&kind=asr&lang=en`,
-              name: { simpleText: 'English (auto-generated)' },
-              vssId: 'a.en',
+              baseUrl: `https://www.youtube.com/api/timedtext?v=${videoId}&lang=en`,
+              name: { simpleText: captionTranslations ? 'English (auto-generated)' : 'English' },
+              vssId: captionTranslations ? 'a.en' : '.en',
               languageCode: 'en',
-              kind: 'asr',
+              ...(captionTranslations ? { kind: 'asr' } : {}),
               isTranslatable: true
             }],
-            translationLanguages: languageCodes.map(languageCode => ({
-              languageCode,
-              languageName: { simpleText: displayNames.of(languageCode) ?? languageCode }
-            }))
+            translationLanguages: captionTranslations
+              ? languageCodes.map(languageCode => ({
+                  languageCode,
+                  languageName: { simpleText: displayNames.of(languageCode) ?? languageCode }
+                }))
+              : []
           }
         }
       }

--- a/e2e/tests/offline/watch-page.spec.mjs
+++ b/e2e/tests/offline/watch-page.spec.mjs
@@ -1336,6 +1336,7 @@ test.describe('fullscreen playlist dock', () => {
     seed: {
       settings: {
         ...WATCH_PAGE_SEED,
+        enableSubtitlesByDefault: true,
         uiRoundness: 200,
       },
       playlists: [FULLSCREEN_PLAYLIST],
@@ -1380,6 +1381,44 @@ test.describe('fullscreen playlist dock', () => {
     await item.locator('.videoThumbnail').hover()
     await expect(item.locator('.trashIcon')).toHaveCount(1)
     await expect(item.locator('.quickBookmarkVideoIcon')).toHaveCount(0)
+  })
+
+  test('keeps positioned captions centered across playlist videos', async ({ app, page }) => {
+    test.setTimeout(120_000)
+    await mockPlayableWatchPage(app, page, { captionCueSettings: 'position:63% align:start' })
+    await openMockedVideo(page)
+    await openFullscreenPlaylistVideo(page)
+
+    const player = page.locator('.ftVideoPlayer')
+    const caption = player.locator('.shaka-text-container [translate="no"]')
+    const expectCaptionCentered = async () => {
+      await expect(caption).toBeVisible()
+      await expect.poll(async () => {
+        const [playerBounds, captionBounds] = await Promise.all([
+          player.boundingBox(),
+          caption.boundingBox(),
+        ])
+        if (!playerBounds || !captionBounds) return Number.POSITIVE_INFINITY
+
+        return Math.abs(
+          (playerBounds.x + playerBounds.width / 2) -
+          (captionBounds.x + captionBounds.width / 2)
+        )
+      }).toBeLessThanOrEqual(1)
+    }
+
+    // The source cue must not override the configured anchor in the inline player either.
+    await expectCaptionCentered()
+    await setPlayerFullscreen(page, true)
+    await expectCaptionCentered()
+
+    for (let index = 1; index <= 9; index++) {
+      await player.locator('.skip-next-button').click({ force: true })
+      await expect(page).toHaveURL(new RegExp(
+        `#\\/watch\\/playlist${String(index).padStart(3, '0')}\\?.*playlistId=${FULLSCREEN_PLAYLIST_ID}`
+      ))
+      await expectCaptionCentered()
+    }
   })
 
   test('clamps the watch playlist after removing most entries', async ({ app, page }) => {

--- a/src/renderer/components/ft-shaka-video-player/ft-shaka-video-player.js
+++ b/src/renderer/components/ft-shaka-video-player/ft-shaka-video-player.js
@@ -163,7 +163,17 @@ let liveCustomControlPlayers = 0
 const RequestType = shaka.net.NetworkingEngine.RequestType
 const AdvancedRequestType = shaka.net.NetworkingEngine.AdvancedRequestType
 const TrackLabelFormat = shaka.ui.Overlay.TrackLabelFormat
+const CaptionPositionArea = shaka.config.PositionArea
 const { Severity: ErrorSeverity, Category: ErrorCategory, Code: ErrorCode } = shaka.util.Error
+
+const CAPTION_POSITION_AREAS = Object.freeze({
+  'top-left': CaptionPositionArea.TOP_LEFT,
+  'top-center': CaptionPositionArea.TOP_CENTER,
+  'top-right': CaptionPositionArea.TOP_RIGHT,
+  'bottom-left': CaptionPositionArea.BOTTOM_LEFT,
+  'bottom-center': CaptionPositionArea.BOTTOM_CENTER,
+  'bottom-right': CaptionPositionArea.BOTTOM_RIGHT,
+})
 
 const NORMAL_PLAYBACK_RATE = 1
 
@@ -1199,6 +1209,7 @@ export default defineComponent({
 
     const captionSettings = computed(() => parseCaptionSettings(store.getters.getDefaultCaptionSettings))
     const captionCssVariables = computed(() => getCaptionCssVariables(captionSettings.value))
+    const captionPositionArea = computed(() => CAPTION_POSITION_AREAS[captionSettings.value.anchor])
     const showCaptionAppearanceSample = ref(false)
     const captionAppearanceSampleBottom = ref('var(--caption-hidden-bottom-gap)')
     let captionAppearanceSampleTimeout = null
@@ -1241,6 +1252,10 @@ export default defineComponent({
       store.dispatch('updateDefaultCaptionSettings', JSON.stringify(DEFAULT_CAPTION_SETTINGS))
       previewCaptionAppearance()
     }
+
+    watch(captionPositionArea, positionArea => {
+      player?.configure('textDisplayer.positionArea', positionArea)
+    })
 
     onUnmounted(() => {
       clearTimeout(captionAppearanceSampleTimeout)
@@ -3054,6 +3069,12 @@ export default defineComponent({
               format: '',
               forced: false,
             }],
+
+        // Caption appearance is user-controlled, so discard source WebVTT positioning (for
+        // example YouTube's occasional position:63% cues) before Shaka creates the cue DOM.
+        textDisplayer: {
+          positionArea: captionPositionArea.value,
+        },
 
         // Electron doesn't like YouTube's vp9 VR video streams and throws:
         // "CHUNK_DEMUXER_ERROR_APPEND_FAILED: Projection element is incomplete; ProjectionPoseYaw required."


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Make sure to follow the contributing guidelines. -->
<!-- Important note, we may remove your pull request if you do not use this provided PR template correctly. -->
<!-- Agent instructions: Preserve every heading, comment, and marker in this template. Never remove or rewrite the release-note-category:start/end, release-note:start/end, or release-note-image:start/end marker pairs. Never remove or rewrite the Release note images section; leave its contents for a human. -->

## Pull Request Type
<!-- Please select what type of pull request this is: [x] -->
- [x] Bugfix
- [ ] Feature Implementation
- [ ] Documentation
- [ ] Other

## Related issue
<!-- Please link the issue your pull request is referring to. -->
<!-- If this pull request fully resolves the relevant issue, put "closes" before the issue number. -->
<!-- Example: "closes #123456". -->

Resolves https://gitlab.com/opentubex/OpenTubeX/-/work_items/517

## Description
<!-- Please write a clear and concise description of what the pull request does. -->

Some YouTube caption cues include their own WebVTT position, which could override the user's caption alignment and move subtitles toward the right. This was especially noticeable while advancing through a playlist, but also occurred in the inline player and after restoring the app.

Configure Shaka's text displayer with the selected caption anchor so it resets source cue geometry before rendering. Caption anchor changes are also applied immediately. The regression coverage uses a positioned cue and verifies centering inline, in fullscreen, and across nine Next-button transitions.

## Release note category
<!-- Select exactly one category. Every pull request must select one. -->
<!-- Select "Not noteworthy" when the pull request fixes a bug in or improves functionality that has not yet appeared in a stable release. -->
<!-- release-note-category:start -->
- [ ] Not noteworthy
- [ ] Highlights
- [ ] More improvements
- [x] Fixed bugs
<!-- release-note-category:end -->

## Release note
<!-- Required unless "Not noteworthy" is selected. -->
<!-- Write one concise, user-facing entry without a leading bullet. -->
<!-- release-note:start -->
Keep subtitles aligned with the configured caption position when videos provide their own cue placement.
<!-- release-note:end -->

## Release note images
<!-- Human-only: Agents must preserve this entire section and leave it empty. -->
<!-- Optional. Paste one or more Markdown images or HTML image tags here. -->
<!-- The release notes will use an HTML image tag and limit images taller than 300 pixels. -->
<!-- release-note-image:start -->

<!-- release-note-image:end -->

## Testing
<!-- How can reviewers verify that the PR produces correct results? -->
<!-- Please provide instructions so that others can ensure that your pull request does produce correct results. For examples see, https://github.com/FreeTubeApp/FreeTube/pull/5743, https://github.com/FreeTubeApp/FreeTube/pull/7349, https://github.com/FreeTubeApp/FreeTube/pull/5125, https://github.com/FreeTubeApp/FreeTube/pull/7338 -->
<!-- Agent instructions: Only write human-facing steps that explain how to verify the change while running this branch in dev mode. Include expected results and, when applicable, helpful console snippets for interactive verification. Do not include automated checks, commands, results, pass counts, or CI status. -->

1. Play a captioned video whose WebVTT cues specify a horizontal position, such as the playlist reported in the linked issue.
2. Enable captions and confirm they follow the configured caption anchor in the regular player.
3. Enter fullscreen and advance through at least nine playlist videos with the Next button.
4. Confirm captions remain aligned after each transition and after restarting the app.

## Additional context
<!-- Add any other context about the pull request here. -->

This uses Shaka's built-in `textDisplayer.positionArea` handling, which resets cue positioning while retaining the user's appearance settings.
