### PR TITLE
fix(profiles): center custom profile images

### DIFF
--- a/e2e/tests/offline/profiles.spec.mjs
+++ b/e2e/tests/offline/profiles.spec.mjs
@@ -63,6 +63,30 @@ test.describe('profile selector', () => {
   })
 })
 
+test.describe('profile selector with a custom image', () => {
+  test.use({
+    seed: {
+      profiles: [{
+        ...mainProfile,
+        icon: {
+          type: 'image',
+          value: 'data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mNk+M/wHwAF/gL+Xw4AAAAASUVORK5CYII='
+        }
+      }]
+    }
+  })
+
+  test('keeps the profile button centered in the top navigation', async ({ page }) => {
+    await expect(profileIconInitial(page).locator('img')).toBeVisible()
+
+    const navigationBox = await page.locator('.topNav').boundingBox()
+    const profileButtonBox = await profileIcon(page).boundingBox()
+
+    expect(profileButtonBox.y + profileButtonBox.height / 2)
+      .toBeCloseTo(navigationBox.y + navigationBox.height / 2, 0)
+  })
+})
+
 test.describe('default profile setting', () => {
   test.use({
     seed: {

--- a/src/renderer/components/FtQuickSettingsMenu/FtQuickSettingsMenu.css
+++ b/src/renderer/components/FtQuickSettingsMenu/FtQuickSettingsMenu.css
@@ -1,4 +1,5 @@
 .quickSettings {
+  display: flex;
   position: relative;
 }
 


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Make sure to follow the contributing guidelines. -->
<!-- Important note, we may remove your pull request if you do not use this provided PR template correctly. -->
<!-- Agent instructions: Preserve every heading, comment, and marker in this template. Never remove or rewrite the release-note-category:start/end, release-note:start/end, or release-note-image:start/end marker pairs. Never remove or rewrite the Release note images section; leave its contents for a human. -->

## Pull Request Type
<!-- Please select what type of pull request this is: [x] -->
- [x] Bugfix
- [ ] Feature Implementation
- [ ] Documentation
- [ ] Other

## Related issue
<!-- Please link the issue your pull request is referring to. -->
<!-- If this pull request fully resolves the relevant issue, put "closes" before the issue number. -->
<!-- Example: "closes #123456". -->

## Description
<!-- Please write a clear and concise description of what the pull request does. -->
Custom profile images changed the inline-flex trigger's baseline, which pulled the profile selector toward the top of the navigation bar. This makes the quick-settings wrapper a flex container so the trigger is positioned independently of its contents, and adds a regression test that checks the image-backed trigger remains centered.

## Release note category
<!-- Select exactly one category. Every pull request must select one. -->
<!-- Select "Not noteworthy" when the pull request fixes a bug in or improves functionality that has not yet appeared in a stable release. -->
<!-- release-note-category:start -->
- [ ] Not noteworthy
- [ ] Highlights
- [ ] More improvements
- [x] Fixed bugs
<!-- release-note-category:end -->

## Release note
<!-- Required unless "Not noteworthy" is selected. -->
<!-- Write one concise, user-facing entry without a leading bullet. -->
<!-- release-note:start -->
Fixed custom profile images appearing above the center of the profile selector.
<!-- release-note:end -->

## Release note images
<!-- Human-only: Agents must preserve this entire section and leave it empty. -->
<!-- Optional. Paste one or more Markdown images or HTML image tags here. -->
<!-- The release notes will use an HTML image tag and limit images taller than 300 pixels. -->
<!-- release-note-image:start -->

<!-- release-note-image:end -->

## Testing
<!-- How can reviewers verify that the PR produces correct results? -->
<!-- Please provide instructions so that others can ensure that this pull request would produce correct results. For examples see, https://github.com/FreeTubeApp/FreeTube/pull/5743, https://github.com/FreeTubeApp/FreeTube/pull/7349, https://github.com/FreeTubeApp/FreeTube/pull/5125, https://github.com/FreeTubeApp/FreeTube/pull/7338 -->
<!-- Agent instructions: Only write human-facing steps that explain how to verify the change while running this branch in dev mode. Include expected results and, when applicable, helpful console snippets for interactive verification. Do not include automated checks, commands, results, pass counts, or CI status. -->
1. Open Profile Manager and set a custom image as the active profile icon.
2. Return to the main view.
3. Confirm the profile selector image is vertically centered in the top navigation bar.

## Additional context
<!-- Add any other context about the pull request here. -->
