### PR TITLE
fix(player): retry yt-dlp with default clients

### DIFF
--- a/e2e/tests/offline/video-actions.spec.mjs
+++ b/e2e/tests/offline/video-actions.spec.mjs
@@ -146,7 +146,7 @@ test.describe('video downloads', () => {
     await expect(page.locator('.downloadProgressBarTrack')).toHaveCount(0)
   })
 
-  test('requests compatible streams and alternate audio for yt-dlp playback', async ({ app, page }) => {
+  test('can retry playback extraction with yt-dlp default clients', async ({ app, page }) => {
     const executable = path.join(app.userDataDir, 'capture-yt-dlp-playback-args.sh')
     const capturedArgs = path.join(app.userDataDir, 'captured-yt-dlp-playback-args.txt')
     await writeFile(executable, [
@@ -161,11 +161,16 @@ test.describe('video downloads', () => {
     }, executable)
 
     await page.bringToFront()
-    const info = await page.evaluate(() => window.ftElectron.ytDlpGetPlaybackInfo('eeeeeeeeeee'))
+    await page.evaluate(() => window.ftElectron.ytDlpGetPlaybackInfo('eeeeeeeeeee'))
 
-    const passedArguments = (await readFile(capturedArgs, 'utf8')).trim().split('\n')
+    let passedArguments = (await readFile(capturedArgs, 'utf8')).trim().split('\n')
     const extractorArgsIndex = passedArguments.indexOf('--extractor-args')
     expect(passedArguments[extractorArgsIndex + 1]).toBe('youtube:player_client=web_embedded,default,-android_vr')
+
+    const info = await page.evaluate(() => window.ftElectron.ytDlpGetPlaybackInfo('eeeeeeeeeee', true))
+
+    passedArguments = (await readFile(capturedArgs, 'utf8')).trim().split('\n')
+    expect(passedArguments).not.toContain('--extractor-args')
     expect(info.formats[0].availableAt).toBe(123)
   })
 

--- a/e2e/tests/offline/watch-page.spec.mjs
+++ b/e2e/tests/offline/watch-page.spec.mjs
@@ -264,6 +264,10 @@ test.describe('watch page', () => {
 
   test('ignores a superseded yt-dlp extraction after rapid engine switches', async ({ app, page }) => {
     await mockPlayableWatchPage(app, page)
+    await page.route('https://example.invalid/*.m3u8', route => route.fulfill({
+      contentType: 'application/x-mpegURL',
+      body: '#EXTM3U\n'
+    }))
     await openMockedVideo(page)
 
     await app.electronApp.evaluate(({ ipcMain }) => {
@@ -340,13 +344,23 @@ test.describe('watch page', () => {
       contentType: 'text/html',
       body: '<title>Sorry...</title>'
     }))
+    await page.route('https://example.invalid/rejected.m3u8', route => route.fulfill({ status: 403 }))
     await app.electronApp.evaluate(({ ipcMain }) => {
       globalThis.__ytDlpIpBlockFallbackCalls = 0
+      globalThis.__ytDlpIpBlockFallbackDefaultClients = []
       ipcMain.removeHandler('yt-dlp-get-playback-info')
-      ipcMain.handle('yt-dlp-get-playback-info', () => {
+      ipcMain.handle('yt-dlp-get-playback-info', (_event, _videoId, useDefaultClients) => {
         globalThis.__ytDlpIpBlockFallbackCalls++
+        globalThis.__ytDlpIpBlockFallbackDefaultClients.push(useDefaultClients)
         return globalThis.__ytDlpIpBlockFallbackCalls === 1
-          ? { error: 'preferred clients failed' }
+          ? {
+              isLive: true,
+              liveStatus: 'is_live',
+              hlsManifestUrl: 'https://example.invalid/rejected.m3u8',
+              formats: [],
+              duration: null,
+              version: 'test'
+            }
           : { error: 'ENOENT' }
       })
     })
@@ -356,6 +370,7 @@ test.describe('watch page', () => {
     await expect(page).toHaveURL(/#\/watch\/jNQXAC9IVRw/)
 
     await expect.poll(() => app.electronApp.evaluate(() => globalThis.__ytDlpIpBlockFallbackCalls)).toBe(2)
+    expect(await app.electronApp.evaluate(() => globalThis.__ytDlpIpBlockFallbackDefaultClients)).toEqual([false, true])
     const watchView = await watchViewHandle(page)
     expect(await watchView.evaluate((view) => ({
       ipBlockDetected: view.ipBlockDetectedInCurrentChain,
@@ -383,6 +398,11 @@ test.describe('watch page', () => {
 
   test('falls back to yt-dlp when the built-in live source has no manifest', async ({ app, page }) => {
     await mockPlayableWatchPage(app, page)
+    await page.route('https://example.invalid/live.m3u8', route => route.fulfill({
+      contentType: 'application/x-mpegURL',
+      body: '#EXTM3U\n'
+    }))
+    await page.route('https://example.invalid/rejected.mp4', route => route.fulfill({ status: 403 }))
     await page.locator(sel.searchInput).fill('https://www.youtube.com/watch?v=jNQXAC9IVRw')
     await page.locator(sel.searchInput).press('Enter')
     await expect(page).toHaveURL(/#\/watch\/jNQXAC9IVRw/)
@@ -394,7 +414,24 @@ test.describe('watch page', () => {
         isLive: true,
         liveStatus: 'is_live',
         hlsManifestUrl: 'https://example.invalid/live.m3u8',
-        formats: [],
+        formats: [{
+          formatId: '18',
+          url: 'https://example.invalid/rejected.mp4',
+          protocol: 'https',
+          ext: 'mp4',
+          vcodec: 'avc1',
+          acodec: 'mp4a',
+          width: 640,
+          height: 360,
+          fps: 30,
+          bitrate: 500_000,
+          audioSampleRate: 44_100,
+          audioChannels: 2,
+          language: null,
+          formatNote: null,
+          dynamicRange: 'SDR',
+          availableAt: null
+        }],
         duration: null,
         version: 'test'
       }))
@@ -420,6 +457,7 @@ test.describe('watch page', () => {
       activeFormat: view.activeFormat,
       activePlaybackEngine: view.activePlaybackEngine,
       activePlaybackEngineVersion: view.activePlaybackEngineVersion,
+      legacyFormats: view.legacyFormats,
       playerReady: view.playerReady,
       ytDlpStreamsPending: view.ytDlpStreamsPending
     }))).toEqual({
@@ -427,6 +465,7 @@ test.describe('watch page', () => {
       activeFormat: 'dash',
       activePlaybackEngine: 'yt-dlp',
       activePlaybackEngineVersion: 'test',
+      legacyFormats: [],
       playerReady: true,
       ytDlpStreamsPending: false
     })

--- a/e2e/tests/offline/watch-page.spec.mjs
+++ b/e2e/tests/offline/watch-page.spec.mjs
@@ -333,7 +333,7 @@ test.describe('watch page', () => {
     })
   })
 
-  test('an IP-blocked HTML watch page makes the built-in engine try yt-dlp', async ({ app, page }) => {
+  test('an IP-blocked HTML watch page retries yt-dlp with its default clients', async ({ app, page }) => {
     await mockPlayableWatchPage(app, page)
     await page.route(/^https:\/\/www\.youtube\.com\/watch\?/, (route) => route.fulfill({
       status: 429,
@@ -345,7 +345,9 @@ test.describe('watch page', () => {
       ipcMain.removeHandler('yt-dlp-get-playback-info')
       ipcMain.handle('yt-dlp-get-playback-info', () => {
         globalThis.__ytDlpIpBlockFallbackCalls++
-        return { error: 'ENOENT' }
+        return globalThis.__ytDlpIpBlockFallbackCalls === 1
+          ? { error: 'preferred clients failed' }
+          : { error: 'ENOENT' }
       })
     })
 
@@ -353,7 +355,7 @@ test.describe('watch page', () => {
     await page.locator(sel.searchInput).press('Enter')
     await expect(page).toHaveURL(/#\/watch\/jNQXAC9IVRw/)
 
-    await expect.poll(() => app.electronApp.evaluate(() => globalThis.__ytDlpIpBlockFallbackCalls)).toBe(1)
+    await expect.poll(() => app.electronApp.evaluate(() => globalThis.__ytDlpIpBlockFallbackCalls)).toBe(2)
     const watchView = await watchViewHandle(page)
     expect(await watchView.evaluate((view) => ({
       ipBlockDetected: view.ipBlockDetectedInCurrentChain,

--- a/e2e/tests/offline/watch-page.spec.mjs
+++ b/e2e/tests/offline/watch-page.spec.mjs
@@ -344,7 +344,10 @@ test.describe('watch page', () => {
       contentType: 'text/html',
       body: '<title>Sorry...</title>'
     }))
-    await page.route('https://example.invalid/rejected.m3u8', route => route.fulfill({ status: 403 }))
+    await page.route('https://example.invalid/rejected.m3u8', route => route.fulfill({
+      contentType: 'text/html',
+      body: '<html>expired</html>'
+    }))
     await app.electronApp.evaluate(({ ipcMain }) => {
       globalThis.__ytDlpIpBlockFallbackCalls = 0
       globalThis.__ytDlpIpBlockFallbackDefaultClients = []

--- a/src/main/ytDlp.js
+++ b/src/main/ytDlp.js
@@ -1077,9 +1077,10 @@ function mapPlaybackFormat(format) {
  * without relying on the SABR streaming protocol.
  * @param {import('electron').IpcMainInvokeEvent} event
  * @param {string} videoId
+ * @param {boolean} useDefaultClients
  * @returns {Promise<YtDlpPlaybackInfo | { error: string } | null>}
  */
-export async function handleYtDlpGetPlaybackInfo(event, videoId) {
+export async function handleYtDlpGetPlaybackInfo(event, videoId, useDefaultClients = false) {
   if (!isOpenTubeXUrl(event.senderFrame.url)) {
     return null
   }
@@ -1104,15 +1105,18 @@ export async function handleYtDlpGetPlaybackInfo(event, videoId) {
     '--no-warnings',
     '--no-progress',
     '--socket-timeout',
-    '15',
-    // The embedded client exposes alternate audio languages without requiring
-    // a PO token. Android VR used to provide the same token-free fallback, but
-    // YouTube now selectively enforces GVS tokens for its non-HLS formats and
-    // returns 403 for the extracted URLs. Keep the remaining default clients as
-    // fallbacks for videos the embedded client cannot access.
-    '--extractor-args',
-    'youtube:player_client=web_embedded,default,-android_vr'
+    '15'
   ]
+
+  if (useDefaultClients !== true) {
+    // Prefer clients whose URLs are not currently subject to selective PO-token
+    // enforcement. The renderer retries with yt-dlp's defaults if none of these
+    // formats are playable for the current video.
+    args.push(
+      '--extractor-args',
+      'youtube:player_client=web_embedded,default,-android_vr'
+    )
+  }
 
   await pushProxyArgument(args)
 

--- a/src/preload/interface.js
+++ b/src/preload/interface.js
@@ -374,10 +374,11 @@ export default {
 
   /**
    * @param {string} videoId
+   * @param {boolean} [useDefaultClients]
    * @returns {Promise<import('../main/ytDlp').YtDlpPlaybackInfo | { error: string } | null>}
    */
-  ytDlpGetPlaybackInfo: (videoId) => {
-    return ipcRenderer.invoke(IpcChannels.YT_DLP_GET_PLAYBACK_INFO, videoId)
+  ytDlpGetPlaybackInfo: (videoId, useDefaultClients = false) => {
+    return ipcRenderer.invoke(IpcChannels.YT_DLP_GET_PLAYBACK_INFO, videoId, useDefaultClients)
   },
 
   ytDlpPlaybackCacheGet: (videoId, cacheKey) => {

--- a/src/renderer/helpers/player/ytDlpPlayback.js
+++ b/src/renderer/helpers/player/ytDlpPlayback.js
@@ -215,6 +215,18 @@ async function probeYtDlpUrl(url) {
 }
 
 /**
+ * @param {string} url
+ */
+async function probeYtDlpHlsManifest(url) {
+  try {
+    const response = await fetch(url, { signal: AbortSignal.timeout(URL_PROBE_TIMEOUT) })
+    return response.ok && (await response.text()).trimStart().startsWith('#EXTM3U')
+  } catch {
+    return false
+  }
+}
+
+/**
  * @param {YtDlpPlaybackFormat[]} formats
  */
 async function convertLegacyFormats(formats) {
@@ -361,7 +373,7 @@ export async function getYtDlpPlaybackSource(videoId, cacheKey = '') {
 
     if (
       info.hlsManifestUrl !== null &&
-      await probeYtDlpUrl(info.hlsManifestUrl)
+      await probeYtDlpHlsManifest(info.hlsManifestUrl)
     ) {
       return {
         manifestSrc: info.hlsManifestUrl,

--- a/src/renderer/helpers/player/ytDlpPlayback.js
+++ b/src/renderer/helpers/player/ytDlpPlayback.js
@@ -269,65 +269,75 @@ export async function getYtDlpPlaybackSource(videoId, cacheKey = '') {
     return cachedSource
   }
 
-  const info = await window.ftElectron.ytDlpGetPlaybackInfo(videoId)
+  let extractionError = null
 
-  if (info === null) {
-    throw new Error('yt-dlp is not available')
-  }
+  for (const useDefaultClients of [false, true]) {
+    const info = await window.ftElectron.ytDlpGetPlaybackInfo(videoId, useDefaultClients)
 
-  if ('error' in info) {
-    throw new Error(info.error === 'ENOENT' ? 'yt-dlp could not be found' : info.error)
-  }
+    if (info === null) {
+      throw new Error('yt-dlp is not available')
+    }
 
-  const httpFormats = info.formats.filter(format => format.protocol === 'https' && format.url !== null)
+    if ('error' in info) {
+      if (info.error === 'ENOENT') {
+        throw new Error('yt-dlp could not be found')
+      }
 
-  const legacyFormats = httpFormats
-    .filter(format => isVideoFormat(format) && isAudioFormat(format))
-    .map(mapYtDlpLegacyFormat)
+      extractionError = new Error(info.error)
+      continue
+    }
 
-  // live streams are only available as HLS, which is what makes rewinding within
-  // the DVR window possible
-  if (!info.isLive && info.liveStatus !== 'is_live') {
-    const adaptiveFormats = httpFormats.filter(format => !(isVideoFormat(format) && isAudioFormat(format)))
-    const localFormats = await convertAdaptiveFormats(adaptiveFormats, info.duration)
+    const httpFormats = info.formats.filter(format => format.protocol === 'https' && format.url !== null)
+    const legacyFormats = httpFormats
+      .filter(format => isVideoFormat(format) && isAudioFormat(format))
+      .map(mapYtDlpLegacyFormat)
 
-    if (localFormats.some(format => format.has_video) && localFormats.some(format => format.has_audio)) {
-      const manifest = await FormatUtils.toDash({ adaptive_formats: localFormats })
+    // live streams are only available as HLS, which is what makes rewinding within
+    // the DVR window possible
+    if (!info.isLive && info.liveStatus !== 'is_live') {
+      const adaptiveFormats = httpFormats.filter(format => !(isVideoFormat(format) && isAudioFormat(format)))
+      const localFormats = await convertAdaptiveFormats(adaptiveFormats, info.duration)
 
-      const source = {
-        manifestSrc: `data:${MANIFEST_TYPE_DASH};charset=UTF-8,${encodeURIComponent(manifest)}`,
-        manifestMimeType: MANIFEST_TYPE_DASH,
+      if (localFormats.some(format => format.has_video) && localFormats.some(format => format.has_audio)) {
+        const manifest = await FormatUtils.toDash({ adaptive_formats: localFormats })
+
+        const source = {
+          manifestSrc: `data:${MANIFEST_TYPE_DASH};charset=UTF-8,${encodeURIComponent(manifest)}`,
+          manifestMimeType: MANIFEST_TYPE_DASH,
+          legacyFormats,
+          expiryDate: getEarliestYtDlpFormatExpiry(adaptiveFormats),
+          isLive: false,
+          version: info.version
+        }
+
+        dashPlaybackSourceCache.set(videoId, cacheKey, source)
+        try {
+          await window.ftElectron.ytDlpPlaybackCacheSet(
+            videoId,
+            cacheKey,
+            source.expiryDate?.getTime() ?? NaN,
+            source
+          )
+        } catch (error) {
+          console.warn('Could not save the persistent yt-dlp playback cache', error)
+        }
+        return source
+      }
+    }
+
+    if (info.hlsManifestUrl !== null) {
+      return {
+        manifestSrc: info.hlsManifestUrl,
+        manifestMimeType: MANIFEST_TYPE_HLS,
         legacyFormats,
-        expiryDate: getEarliestYtDlpFormatExpiry(adaptiveFormats),
-        isLive: false,
+        expiryDate: null,
+        isLive: info.isLive,
         version: info.version
       }
-
-      dashPlaybackSourceCache.set(videoId, cacheKey, source)
-      try {
-        await window.ftElectron.ytDlpPlaybackCacheSet(
-          videoId,
-          cacheKey,
-          source.expiryDate?.getTime() ?? NaN,
-          source
-        )
-      } catch (error) {
-        console.warn('Could not save the persistent yt-dlp playback cache', error)
-      }
-      return source
     }
+
+    extractionError = new Error('yt-dlp did not return any playable formats')
   }
 
-  if (info.hlsManifestUrl !== null) {
-    return {
-      manifestSrc: info.hlsManifestUrl,
-      manifestMimeType: MANIFEST_TYPE_HLS,
-      legacyFormats,
-      expiryDate: null,
-      isLive: info.isLive,
-      version: info.version
-    }
-  }
-
-  throw new Error('yt-dlp did not return any playable formats')
+  throw extractionError ?? new Error('yt-dlp did not return any playable formats')
 }

--- a/src/renderer/helpers/player/ytDlpPlayback.js
+++ b/src/renderer/helpers/player/ytDlpPlayback.js
@@ -20,6 +20,7 @@ import { getEarliestYtDlpFormatExpiry, YtDlpPlaybackSourceCache } from './ytDlpP
 
 // yt-dlp appends the audio track or a suffix like "-drc" to the itag for some formats
 const ITAG_REGEX = /^\d+/
+const URL_PROBE_TIMEOUT = 10_000
 const dashPlaybackSourceCache = new YtDlpPlaybackSourceCache()
 
 /**
@@ -200,6 +201,38 @@ function mapYtDlpLegacyFormat(format) {
 }
 
 /**
+ * Checks that a stream or manifest URL is accepted before exposing it to the player.
+ * @param {string} url
+ */
+async function probeYtDlpUrl(url) {
+  try {
+    const response = await fetch(url, { signal: AbortSignal.timeout(URL_PROBE_TIMEOUT) })
+    await response.body?.cancel()
+    return response.ok
+  } catch {
+    return false
+  }
+}
+
+/**
+ * @param {YtDlpPlaybackFormat[]} formats
+ */
+async function convertLegacyFormats(formats) {
+  const results = await Promise.all(formats.map(async format => {
+    if (
+      !await waitForYtDlpFormatAvailability(format) ||
+      !await probeYtDlpUrl(format.url)
+    ) {
+      return null
+    }
+
+    return mapYtDlpLegacyFormat(format)
+  }))
+
+  return results.filter(format => format !== null)
+}
+
+/**
  * Reads the byte ranges of every adaptive format in parallel and drops the ones
  * that the byte ranges couldn't be determined for.
  * @param {YtDlpPlaybackFormat[]} formats
@@ -288,9 +321,9 @@ export async function getYtDlpPlaybackSource(videoId, cacheKey = '') {
     }
 
     const httpFormats = info.formats.filter(format => format.protocol === 'https' && format.url !== null)
-    const legacyFormats = httpFormats
-      .filter(format => isVideoFormat(format) && isAudioFormat(format))
-      .map(mapYtDlpLegacyFormat)
+    const legacyFormatsPromise = convertLegacyFormats(
+      httpFormats.filter(format => isVideoFormat(format) && isAudioFormat(format))
+    )
 
     // live streams are only available as HLS, which is what makes rewinding within
     // the DVR window possible
@@ -300,6 +333,7 @@ export async function getYtDlpPlaybackSource(videoId, cacheKey = '') {
 
       if (localFormats.some(format => format.has_video) && localFormats.some(format => format.has_audio)) {
         const manifest = await FormatUtils.toDash({ adaptive_formats: localFormats })
+        const legacyFormats = await legacyFormatsPromise
 
         const source = {
           manifestSrc: `data:${MANIFEST_TYPE_DASH};charset=UTF-8,${encodeURIComponent(manifest)}`,
@@ -325,11 +359,14 @@ export async function getYtDlpPlaybackSource(videoId, cacheKey = '') {
       }
     }
 
-    if (info.hlsManifestUrl !== null) {
+    if (
+      info.hlsManifestUrl !== null &&
+      await probeYtDlpUrl(info.hlsManifestUrl)
+    ) {
       return {
         manifestSrc: info.hlsManifestUrl,
         manifestMimeType: MANIFEST_TYPE_HLS,
-        legacyFormats,
+        legacyFormats: await legacyFormatsPromise,
         expiryDate: null,
         isLive: info.isLive,
         version: info.version


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Make sure to follow the contributing guidelines. -->
<!-- Important note, we may remove your pull request if you do not use this provided PR template correctly. -->
<!-- Agent instructions: Preserve every heading, comment, and marker in this template. Never remove or rewrite the release-note-category:start/end, release-note:start/end, or release-note-image:start/end marker pairs. Never remove or rewrite the Release note images section; leave its contents for a human. -->

## Pull Request Type
<!-- Please select what type of pull request this is: [x] -->
- [x] Bugfix
- [ ] Feature Implementation
- [ ] Documentation
- [ ] Other

## Related issue
<!-- Please link the issue your pull request is referring to. -->
<!-- If this pull request fully resolves the relevant issue, put "closes" before the issue number. -->
<!-- Example: "closes #123456". -->

Closes #714.

## Description
<!-- Please write a clear and concise description of what the pull request does. -->

The IP-block recovery added in #687 can reach yt-dlp, yet still fail for videos that yt-dlp handles successfully with its normal client selection. OpenTubeX currently forces a safer client set to avoid the rejected Android VR streams addressed by #691.

Keep that safer extraction as the first attempt. If it fails or all of its returned formats are rejected as unplayable, retry once with yt-dlp's maintained default clients and subject those formats to the same availability checks before playback.

## Release note category
<!-- Select exactly one category. Every pull request must select one. -->
<!-- Select "Not noteworthy" when the pull request fixes a bug in or improves functionality that has not yet appeared in a stable release. -->
<!-- release-note-category:start -->
- [ ] Not noteworthy
- [ ] Highlights
- [ ] More improvements
- [x] Fixed bugs
<!-- release-note-category:end -->

## Release note
<!-- Required unless "Not noteworthy" is selected. -->
<!-- Write one concise, user-facing entry without a leading bullet. -->
<!-- release-note:start -->
Fixed yt-dlp playback fallback failing for some videos after an IP block is detected.
<!-- release-note:end -->

## Release note images
<!-- Human-only: Agents must preserve this entire section and leave it empty. -->
<!-- Optional. Paste one or more Markdown images or HTML image tags here. -->
<!-- The release notes will use an HTML image tag and limit images taller than 300 pixels. -->
<!-- release-note-image:start -->

<!-- release-note-image:end -->

## Testing
<!-- How can reviewers verify that the PR produces correct results? -->
<!-- Please provide instructions so that others can ensure that your pull request would produce correct results. For examples see, https://github.com/FreeTubeApp/FreeTube/pull/5743, https://github.com/FreeTubeApp/FreeTube/pull/7349, https://github.com/FreeTubeApp/FreeTube/pull/5125, https://github.com/FreeTubeApp/FreeTube/pull/7338 -->
<!-- Agent instructions: Only write human-facing steps that explain how to verify the change while running this branch in dev mode. Include expected results and, when applicable, helpful console snippets for interactive verification. Do not include automated checks, commands, results, pass counts, or CI status. -->

1. Configure the built-in playback engine and use a connection for which the YouTube watch page is IP-blocked.
2. Open a video that fails with OpenTubeX's preferred yt-dlp client set but succeeds when running yt-dlp with its defaults.
3. Confirm playback begins through yt-dlp instead of stopping at the IP-block message.
4. Open an ordinary video and confirm the initial yt-dlp extraction still excludes Android VR and plays without rejected stream URLs.

## Additional context
<!-- Add any other context about the pull request here. -->

This is a follow-up to #687 and preserves the safer primary client selection introduced by #691.
