### PR TITLE
fix(invidious): handle comments without avatars

### DIFF
--- a/src/renderer/helpers/api/invidious-comments.js
+++ b/src/renderer/helpers/api/invidious-comments.js
@@ -1,0 +1,7 @@
+/**
+ * @param {{authorThumbnails?: {url?: string}[]}} comment
+ * @returns {string | null}
+ */
+export function getInvidiousCommentAuthorThumbnail(comment) {
+  return comment.authorThumbnails?.at(-1)?.url ?? null
+}

--- a/src/renderer/helpers/api/invidious.js
+++ b/src/renderer/helpers/api/invidious.js
@@ -439,7 +439,7 @@ export async function invidiousGetVideoInformation(videoId) {
  * @typedef {object} InvidiousComment
  * @property {string} id
  * @property {string} authorLink
- * @property {string} authorThumb
+ * @property {string | null} authorThumb
  * @property {string} author
  * @property {number} likes
  * @property {string} text

--- a/src/renderer/helpers/api/invidious.js
+++ b/src/renderer/helpers/api/invidious.js
@@ -2,6 +2,7 @@ import store from '../../store/index'
 import { calculatePublishedDate, getRelativeTimeFromDate } from '../utils'
 import { isNullOrEmpty } from '../strings'
 import { enrichFallbackInvidiousPublicationDates } from './invidious-channel-videos'
+import { getInvidiousCommentAuthorThumbnail } from './invidious-comments'
 import { filterUnavailableInvidiousPlaylistVideos } from './invidious-playlists'
 import autolinker from 'autolinker'
 import { FormatUtils, Misc, Player } from 'youtubei.js'
@@ -625,7 +626,7 @@ function parseInvidiousCommentData(response) {
     return {
       id: comment.commentId,
       authorLink: comment.authorId,
-      authorThumb: youtubeImageUrlToInvidious(comment.authorThumbnails.at(-1).url),
+      authorThumb: youtubeImageUrlToInvidious(getInvidiousCommentAuthorThumbnail(comment)),
       author: comment.author,
       likes: comment.likeCount,
       text: autolinker.link(invidiousImageUrlToInvidious(comment.contentHtml, getCurrentInstanceUrl())),

--- a/tests/unit/invidious-comments.test.mjs
+++ b/tests/unit/invidious-comments.test.mjs
@@ -1,0 +1,18 @@
+import assert from 'node:assert/strict'
+import test from 'node:test'
+
+import { getInvidiousCommentAuthorThumbnail } from '../../src/renderer/helpers/api/invidious-comments.js'
+
+test('returns the largest Invidious comment author thumbnail', () => {
+  assert.equal(getInvidiousCommentAuthorThumbnail({
+    authorThumbnails: [
+      { url: 'small.jpg' },
+      { url: 'large.jpg' }
+    ]
+  }), 'large.jpg')
+})
+
+test('handles Invidious comments without author thumbnails', () => {
+  assert.equal(getInvidiousCommentAuthorThumbnail({}), null)
+  assert.equal(getInvidiousCommentAuthorThumbnail({ authorThumbnails: [] }), null)
+})


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Make sure to follow the contributing guidelines. -->
<!-- Important note, we may remove your pull request if you do not use this provided PR template correctly. -->
<!-- Agent instructions: Preserve every heading, comment, and marker in this template. Never remove or rewrite the release-note-category:start/end, release-note:start/end, or release-note-image:start/end marker pairs. Never remove or rewrite the Release note images section; leave its contents for a human. -->

## Pull Request Type
<!-- Please select what type of pull request this is: [x] -->
- [x] Bugfix
- [ ] Feature Implementation
- [ ] Documentation
- [ ] Other

## Related issue
<!-- Please link the issue your pull request is referring to. -->
<!-- If this pull request fully resolves the relevant issue, put "closes" before the issue number. -->
<!-- Example: "closes #123456". -->

closes #713

## Description
<!-- Please write a clear and concise description of what the pull request does. -->

Invidious comment responses can omit an author's thumbnail list. Comment parsing previously called `.at(-1)` on the missing list, which rejected the entire comment response and displayed repeated API error toasts during playback.

Treat missing or empty author thumbnail lists as comments without an avatar. The existing comment UI then displays its normal fallback avatar while the remaining comment data loads normally.

## Release note category
<!-- Select exactly one category. Every pull request must select one. -->
<!-- Select "Not noteworthy" when the pull request fixes a bug in or improves functionality that has not yet appeared in a stable release. -->
<!-- release-note-category:start -->
- [ ] Not noteworthy
- [ ] Highlights
- [ ] More improvements
- [x] Fixed bugs
<!-- release-note-category:end -->

## Release note
<!-- Required unless "Not noteworthy" is selected. -->
<!-- Write one concise, user-facing entry without a leading bullet. -->
<!-- release-note:start -->
Fixed repeated Invidious API errors when loading comments whose authors have no avatar.
<!-- release-note:end -->

## Release note images
<!-- Human-only: Agents must preserve this entire section and leave it empty. -->
<!-- Optional. Paste one or more Markdown images or HTML image tags here. -->
<!-- The release notes will use an HTML image tag and limit images taller than 300 pixels. -->
<!-- release-note-image:start -->

<!-- release-note-image:end -->

## Testing
<!-- How can reviewers verify that the PR produces correct results? -->
<!-- Please provide instructions so that others can ensure that your pull request would produce correct results. For examples see, https://github.com/FreeTubeApp/FreeTube/pull/5743, https://github.com/FreeTubeApp/FreeTube/pull/7349, https://github.com/FreeTubeApp/FreeTube/pull/5125, https://github.com/FreeTubeApp/FreeTube/pull/7338 -->
<!-- Agent instructions: Only write human-facing steps that explain how to verify the change while running this branch in dev mode. Include expected results and, when applicable, helpful console snippets for interactive verification. Do not include automated checks, commands, results, pass counts, or CI status. -->

1. Configure an Invidious instance that returns at least one comment without `authorThumbnails`.
2. Open a video with that comment and load its comments.
3. Confirm the affected comment uses the fallback avatar, all comments still load, and no `Cannot read properties of undefined (reading 'at')` toast or console error appears.

## Additional context
<!-- Add any other context about the pull request here. -->

The nearby Shaka network timeout and YouTube.js parser warning shown in the issue screenshots are separate from this exception.