### PR TITLE
fix(i18n): support translated plurals for bulk tab closing

### DIFF
--- a/src/renderer/App.vue
+++ b/src/renderer/App.vue
@@ -2491,17 +2491,22 @@ const multipleTabsActionPromptTitle = computed(() => {
   return t('Close Multiple Tabs Confirmation.Title')
 })
 const multipleTabsActionPromptMessage = computed(() => {
-  const parameters = { count: multipleTabsActionPromptCount.value }
+  const count = multipleTabsActionPromptCount.value
+  const parameters = { count }
   if (multipleTabsActionPrompt.value === 'load') return t('Load Multiple Tabs Confirmation.Message', parameters)
   if (multipleTabsActionPrompt.value === 'unload') return t('Unload Multiple Tabs Confirmation.Message', parameters)
-  return t('Close Multiple Tabs Confirmation.Message', parameters)
+  return t('Close Multiple Tabs Confirmation.Message', parameters, count)
 })
 const multipleTabsActionPromptNames = computed(() => [
   multipleTabsActionPrompt.value === 'load'
     ? t('Load Multiple Tabs Confirmation.Load Tabs', { count: multipleTabsActionPromptCount.value })
     : multipleTabsActionPrompt.value === 'unload'
       ? t('Unload Multiple Tabs Confirmation.Unload Tabs', { count: multipleTabsActionPromptCount.value })
-      : t('Close Multiple Tabs Confirmation.Close Tabs', { count: multipleTabsActionPromptCount.value }),
+      : t(
+          'Close Multiple Tabs Confirmation.Close Tabs',
+          { count: multipleTabsActionPromptCount.value },
+          multipleTabsActionPromptCount.value
+        ),
   t('Cancel'),
   t('Confirmations.Never Ask Again')
 ])

--- a/tests/unit/locale-plurals.test.mjs
+++ b/tests/unit/locale-plurals.test.mjs
@@ -99,6 +99,13 @@ function splitCallArguments(source, openingParenthesisIndex) {
 }
 
 const pluralPaths = collectPluralPaths(locale)
+// These messages only describe bulk actions, so English never needs a singular
+// form. Translated locales can still provide plural forms for categories such
+// as Polish "few" and "many".
+const translatedLocalePluralPaths = [
+  'Close Multiple Tabs Confirmation.Message',
+  'Close Multiple Tabs Confirmation.Close Tabs'
+]
 const sourceFiles = await collectSourceFiles(sourceDirUrl)
 
 test('plural messages declare a singular and a plural form', () => {
@@ -117,7 +124,7 @@ test('plural messages declare a singular and a plural form', () => {
 })
 
 test('plural messages are translated with a plural choice', async () => {
-  const pluralPathSet = new Set(pluralPaths)
+  const pluralPathSet = new Set([...pluralPaths, ...translatedLocalePluralPaths])
   const callPattern = /\$?t\(\s*(['"])(.+?)\1/gs
 
   for (const file of sourceFiles) {


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Make sure to follow the contributing guidelines. -->
<!-- Important note, we may remove your pull request if you do not use this provided PR template correctly. -->
<!-- Agent instructions: Preserve every heading, comment, and marker in this template. Never remove or rewrite the release-note-category:start/end, release-note:start/end, or release-note-image:start/end marker pairs. Never remove or rewrite the Release note images section; leave its contents for a human. -->

## Pull Request Type
<!-- Please select what type of pull request this is: [x] -->
- [x] Bugfix
- [ ] Feature Implementation
- [ ] Documentation
- [ ] Other

## Related issue
<!-- Please link the issue your pull request is referring to. -->
<!-- If this pull request fully resolves the relevant issue, put "closes" before the issue number. -->
<!-- Example: "closes #123456". -->

Raised in https://github.com/OpenTubeX/OpenTubeX/pull/589#issuecomment-5288005380

## Description
<!-- Please write a clear and concise description of what the pull request does. -->

The multiple-tab close confirmation interpolated its count without passing it as vue-i18n's plural choice. English is unaffected because this dialog always covers multiple tabs, but translated locales such as Polish still distinguish plural categories like `few` and `many`.

Pass the tab count as the plural choice for both the confirmation message and its close button. Keep the English source naturally plural while explicitly covering these translation-only plural paths in the locale regression test.

## Release note category
<!-- Select exactly one category. Every pull request must select one. -->
<!-- Select "Not noteworthy" when the pull request fixes a bug in or improves functionality that has not yet appeared in a stable release. -->
<!-- release-note-category:start -->
- [x] Not noteworthy
- [ ] Highlights
- [ ] More improvements
- [ ] Fixed bugs
<!-- release-note-category:end -->

## Release note
<!-- Required unless "Not noteworthy" is selected. -->
<!-- Write one concise, user-facing entry without a leading bullet. -->
<!-- release-note:start -->

<!-- release-note:end -->

## Release note images
<!-- Human-only: Agents must preserve this entire section and leave it empty. -->
<!-- Optional. Paste one or more Markdown images or HTML image tags here. -->
<!-- The release notes will use an HTML image tag and limit images taller than 300 pixels. -->
<!-- release-note-image:start -->

<!-- release-note-image:end -->

## Testing
<!-- How can reviewers verify that the PR produces correct results? -->
<!-- Please provide instructions so that others can ensure that your pull request would produce correct results. For examples see, https://github.com/FreeTubeApp/FreeTube/pull/5743, https://github.com/FreeTubeApp/FreeTube/pull/7349, https://github.com/FreeTubeApp/FreeTube/pull/5125, https://github.com/FreeTubeApp/FreeTube/pull/7338 -->
<!-- Agent instructions: Only write human-facing steps that explain how to verify the change while running this branch in dev mode. Include expected results and, when applicable, helpful console snippets for interactive verification. Do not include automated checks, commands, results, pass counts, or CI status. -->

1. Give `Close Multiple Tabs Confirmation.Message` and `Close Multiple Tabs Confirmation.Close Tabs` three Polish forms in the order `one | few | many`.
2. In dev mode, select and close two tabs. The confirmation message and button should use the Polish `few` forms.
3. Repeat with five tabs. Both should use the Polish `many` forms.
4. Switch to English and repeat. The existing naturally plural English wording should remain unchanged.

## Additional context
<!-- Add any other context about the pull request here. -->

The English strings intentionally do not declare a singular form because this confirmation cannot be shown for one tab.

Changes prepared by GPT-5.6 Codex.