### PR TITLE
fix(watch): avoid chat skeleton on regular videos

### DIFF
--- a/e2e/tests/offline/watch-page.spec.mjs
+++ b/e2e/tests/offline/watch-page.spec.mjs
@@ -1578,6 +1578,32 @@ test.describe('fullscreen playlist dock', () => {
   })
 })
 
+test('treats an empty comments response as no comments', async ({ app, page }) => {
+  await mockPlayableWatchPage(app, page)
+
+  let commentRequestCount = 0
+  await page.route(/\/youtubei\/v1\/next/, (route, request) => {
+    const body = JSON.parse(request.postData() ?? '{}')
+    if (!body.continuation) {
+      return route.fallback()
+    }
+
+    commentRequestCount++
+    return route.fulfill({
+      status: 200,
+      contentType: 'application/json',
+      body: '{}'
+    })
+  })
+
+  await openMockedVideo(page)
+  await page.locator('.commentAutoLoadSentinel').scrollIntoViewIfNeeded()
+
+  await expect(page.locator('.noCommentMsg')).toHaveText('There are no comments available for this video')
+  await expect(page.locator('.toast', { hasText: 'Local API Error' })).toHaveCount(0)
+  expect(commentRequestCount).toBe(1)
+})
+
 test.describe('manual comment loading', () => {
   // These drive the click-to-load path and the reply pagination on top of a
   // single loaded page, so they turn off the automatic pagination that would

--- a/e2e/tests/offline/watch-page.spec.mjs
+++ b/e2e/tests/offline/watch-page.spec.mjs
@@ -430,7 +430,7 @@ test.describe('watch page', () => {
     })
   })
 
-  test('shows a live chat skeleton while chat availability loads', async ({ app, page }) => {
+  test('does not speculate about live chat while availability loads', async ({ app, page }) => {
     await mockPlayableWatchPage(app, page)
 
     let releaseMetadata
@@ -442,10 +442,8 @@ test.describe('watch page', () => {
     await page.locator(sel.searchInput).fill('https://www.youtube.com/watch?v=jNQXAC9IVRw')
     await page.locator(sel.searchInput).press('Enter')
     await expect(page).toHaveURL(/#\/watch\/jNQXAC9IVRw/)
-    const sidebarSkeletons = page.locator(`${activeTab} .sidebarArea > :is(.liveChatSkeleton, .recommendationsSkeleton)`)
-    await expect(sidebarSkeletons).toHaveCount(2)
-    await expect(sidebarSkeletons.nth(0)).toHaveClass(/liveChatSkeleton/)
-    await expect(sidebarSkeletons.nth(1)).toHaveClass(/recommendationsSkeleton/)
+    await expect(page.locator(`${activeTab} .sidebarArea > .liveChatSkeleton`)).toHaveCount(0)
+    await expect(page.locator(`${activeTab} .sidebarArea > .recommendationsSkeleton`)).toBeVisible()
 
     await expect.poll(() => typeof releaseMetadata).toBe('function')
     releaseMetadata()

--- a/src/renderer/components/CommentSection/CommentSection.vue
+++ b/src/renderer/components/CommentSection/CommentSection.vue
@@ -1221,7 +1221,7 @@ async function getCommentDataLocal(more = false, preserveSort = false) {
 
     // region No comment detection
     // No comment related info when video info requested earlier in parent component
-    if (err.message.includes('Comments page did not have any content')) {
+    if (/comments page did not have any content/i.test(err?.message)) {
       // For videos without any comment (comment disabled?)
       // e.g. https://youtu.be/8NBSwDEf8a8
       commentData.value = []

--- a/src/renderer/views/Watch/Watch.scss
+++ b/src/renderer/views/Watch/Watch.scss
@@ -1407,41 +1407,6 @@
   }
 }
 
-.liveChatSkeleton {
-  box-sizing: border-box;
-  block-size: 510px;
-  padding-block: 26px 16px;
-  padding-inline: 16px;
-  background: var(--card-bg-color);
-  border-radius: calc(10px * var(--ui-roundness));
-}
-
-.skeletonLiveChatTitle {
-  inline-size: 42%;
-  margin-block-end: 30px;
-}
-
-.skeletonLiveChatMessage {
-  display: flex;
-  align-items: center;
-  gap: 10px;
-  margin-block: 14px;
-}
-
-.skeletonLiveChatLine {
-  inline-size: calc(55% + var(--skeleton-offset, 0%));
-}
-
-.skeletonLiveChatMessage:nth-child(3n) .skeletonLiveChatLine {
-  inline-size: 75%;
-}
-
-.skeletonLiveChatAvatar {
-  flex: 0 0 25px;
-  block-size: 25px;
-  border-radius: 50%;
-}
-
 .recommendationsSkeleton {
   display: flex;
   flex-direction: column;

--- a/src/renderer/views/Watch/Watch.vue
+++ b/src/renderer/views/Watch/Watch.vue
@@ -797,21 +797,6 @@
         </div>
       </div>
       <div
-        v-if="isLoading && (!hideLiveChat || !hideLiveChatReplay)"
-        class="liveChatSkeleton watchVideoSideBar watchVideoPlaylist"
-        aria-hidden="true"
-      >
-        <div class="skeletonLine skeletonLiveChatTitle ft-shimmer" />
-        <div
-          v-for="index in 8"
-          :key="index"
-          class="skeletonLiveChatMessage"
-        >
-          <div class="skeletonLiveChatAvatar ft-shimmer" />
-          <div class="skeletonLine skeletonLiveChatLine ft-shimmer" />
-        </div>
-      </div>
-      <div
         v-if="isLoading && !hideRecommendedVideos"
         class="recommendationsSkeleton"
         aria-hidden="true"


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Make sure to follow the contributing guidelines. -->
<!-- Important note, we may remove your pull request if you do not use this provided PR template correctly. -->
<!-- Agent instructions: Preserve every heading, comment, and marker in this template. Never remove or rewrite the release-note-category:start/end, release-note:start/end, or release-note-image:start/end marker pairs. Never remove or rewrite the Release note images section; leave its contents for a human. -->

## Pull Request Type
<!-- Please select what type of pull request this is: [x] -->
- [x] Bugfix
- [ ] Feature Implementation
- [ ] Documentation
- [ ] Other

## Related issue
<!-- Please link the issue your pull request is referring to. -->
<!-- If this pull request fully resolves the relevant issue, put "closes" before the issue number. -->
<!-- Example: "closes #123456". -->

Follow-up to #693.

## Description
<!-- Please write a clear and concise description of what the pull request does. -->

Regular videos briefly showed a live-chat skeleton before watch metadata established whether chat was available. Videos with no comments could also repeatedly show Local API error toasts instead of their empty state.

Remove the speculative page-level chat placeholder while retaining the confirmed live-chat skeleton. Also recognize the current empty-comments response from the local API so it renders the zero-comments state without retrying or showing an error.

## Release note category
<!-- Select exactly one category. Every pull request must select one. -->
<!-- Select "Not noteworthy" when the pull request fixes a bug in or improves functionality that has not yet appeared in a stable release. -->
<!-- release-note-category:start -->
- [ ] Not noteworthy
- [ ] Highlights
- [ ] More improvements
- [x] Fixed bugs
<!-- release-note-category:end -->

## Release note
<!-- Required unless "Not noteworthy" is selected. -->
<!-- Write one concise, user-facing entry without a leading bullet. -->
<!-- release-note:start -->
Fixed live-chat placeholders appearing on videos without chat and repeated errors on videos with no comments.
<!-- release-note:end -->

## Release note images
<!-- Human-only: Agents must preserve this entire section and leave it empty. -->
<!-- Optional. Paste one or more Markdown images or HTML image tags here. -->
<!-- The release notes will use an HTML image tag and limit images taller than 300 pixels. -->
<!-- release-note-image:start -->

<!-- release-note-image:end -->

## Testing
<!-- How can reviewers verify that the PR produces correct results? -->
<!-- Please provide instructions so that others can ensure that your pull request would produce correct results. For examples see, https://github.com/FreeTubeApp/FreeTube/pull/5743, https://github.com/FreeTubeApp/FreeTube/pull/7349, https://github.com/FreeTubeApp/FreeTube/pull/5125, https://github.com/FreeTubeApp/FreeTube/pull/7338 -->
<!-- Agent instructions: Only write human-facing steps that explain how to verify the change while running this branch in dev mode. Include expected results and, when applicable, helpful console snippets for interactive verification. Do not include automated checks, commands, results, pass counts, or CI status. -->

1. Open a regular video without live chat and reload it. The recommendations skeleton should appear while metadata loads, but no live-chat skeleton should appear.
2. Open a livestream or a video with chat replay. Once chat availability is confirmed, the chat panel should show message-shaped skeleton rows while chat content initializes.
3. Open a video that has no comments and scroll to the comments section. It should show “There are no comments available for this video” once, with no Local API error toasts or repeated requests.
4. Disable recommended videos and repeat the regular-video check. No sidebar skeleton should appear.

## Additional context
<!-- Add any other context about the pull request here. -->

The initial page loader cannot know chat availability until metadata resolves, so showing a chat placeholder at that stage creates false positives. The local comments dependency now prefixes and lowercases its empty-page exception, which bypassed the existing case-sensitive empty-state detection.
