### PR TITLE
feat(sync): sync saved channel settings together

### DIFF
--- a/PRIVACY.md
+++ b/PRIVACY.md
@@ -6,7 +6,7 @@ This document describes the data exposed by OpenTubeX itself. It assumes that yo
 
 ## Data stored by OpenTubeX
 
-By default, subscriptions, playlists, settings, history, profiles, open tabs and channel playback speeds remain on your device. Enabling synchronization sends copies of the selected categories to the configured sync server:
+By default, subscriptions, playlists, settings (including saved channel settings), history, profiles and open tabs remain on your device. Enabling synchronization sends copies of the selected categories to the configured sync server:
 
 - Enhanced-privacy sync encrypts the selected data on your device before upload. The server still receives account and traffic metadata.
 - A legacy sync server does not support this encryption. Synced data is visible to that server's operator.

--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ experience. Some of its major areas of focus are:
 - **A browser-style desktop workflow** with tabs, configurable session restoration, multiple windows, a scroll mini-player and a watch queue.
 - **Deeper SponsorBlock integration** with a segment side panel, richer skip controls, channel whitelisting, submissions and full-video labels.
 - **More ways to manage and understand your library** through watch-time statistics, configurable history retention, enhanced subscription refreshes and advanced search history.
-- **Optional end-to-end encrypted sync** for subscriptions, playlists, history, profiles, tabs, settings and channel playback speeds.
+- **Optional end-to-end encrypted sync** for subscriptions, playlists, history, profiles, tabs and settings, including saved channel settings.
 
 > [!NOTE] 
 > OpenTubeX is currently in Beta. While it should work well for most users, there are still bugs and missing features that need to be addressed.
@@ -220,7 +220,7 @@ experience. Some of its major areas of focus are:
 
 - Open a chatter's channel by clicking their handle in live chat
 
-- Support for end-to-end encrypted synchronization of subscriptions, playlists, history, channel playback speeds, profiles, tabs and settings. LibreTube Sync Servers are also supported.
+- Support for end-to-end encrypted synchronization of subscriptions, playlists, history, profiles, tabs and settings, including saved channel settings. LibreTube Sync Servers are also supported.
 <img height="300" alt="image" src="https://github.com/user-attachments/assets/15144ab2-0111-4e38-b011-c7a57417fcd0" />
 
 - Simple watch queue. Videos can be queued from the three-dots menu and managed in a side panel on the watch page, including drag-and-drop reordering.

--- a/e2e/tests/network/sync-server.spec.mjs
+++ b/e2e/tests/network/sync-server.spec.mjs
@@ -161,17 +161,18 @@ test.describe('OpenTubeX sync server', () => {
       expect(versionedSubscriptionsResponse.status).toBe(409)
       const encryptedResponse = await fetch(`${syncServerUrl}/v1/encrypted_sync`, { headers })
       const encryptedManifest = await encryptedResponse.json()
-      expect(encryptedManifest.collections.map(entry => entry.collection)).toEqual(
+      const encryptedCollectionNames = encryptedManifest.collections.map(entry => entry.collection)
+      expect(encryptedCollectionNames).toEqual(
         expect.arrayContaining([
           'subscriptions',
           'playlists',
           'history',
-          'playbackSpeeds',
           'profiles',
           'sessions',
           'settings'
         ])
       )
+      expect(encryptedCollectionNames).not.toContain('playbackSpeeds')
       for (const { collection, revision } of encryptedManifest.collections) {
         expect(revision).toBeGreaterThan(0)
         const collectionResponse = await fetch(
@@ -215,15 +216,6 @@ test.describe('OpenTubeX sync server', () => {
         })
       ]))
 
-      const playbackSpeedsResponse = await fetch(
-        `${syncServerUrl}${apiPrefix}/channel_playback_speeds/`,
-        { headers }
-      )
-      expect(playbackSpeedsResponse.ok).toBe(true)
-      expect(await playbackSpeedsResponse.json()).toEqual(expect.arrayContaining([
-        { channel_id: channelId, playback_speed: 1.5 }
-      ]))
-
       const profilesResponse = await fetch(
         `${syncServerUrl}${apiPrefix}/subscriptions/groups/`,
         { headers }
@@ -239,16 +231,6 @@ test.describe('OpenTubeX sync server', () => {
           channels: expect.arrayContaining([expect.objectContaining({ id: secondChannelId })])
         })
       ]))
-
-      const putPlaybackSpeedResponse = await fetch(
-        `${syncServerUrl}${apiPrefix}/channel_playback_speeds/`,
-        {
-          method: 'PUT',
-          headers,
-          body: JSON.stringify({ channel_id: remoteChannelId, playback_speed: 2 })
-        }
-      )
-      expect(putPlaybackSpeedResponse.ok).toBe(true)
 
       const addRemoteResponse = await fetch(`${syncServerUrl}${apiPrefix}/subscriptions/`, {
         method: 'PUT',
@@ -281,8 +263,7 @@ test.describe('OpenTubeX sync server', () => {
         const syncedSettings = latestSettings(await readFile(settingsPath, 'utf8'))
         return JSON.parse(syncedSettings.channelPlaybackSpeeds || '{}')
       }).toEqual({
-        [channelId]: 1.5,
-        [remoteChannelId]: 2
+        [channelId]: 1.5
       })
     }
 

--- a/e2e/tests/offline/channel-settings.spec.mjs
+++ b/e2e/tests/offline/channel-settings.spec.mjs
@@ -8,7 +8,12 @@ test.use({
     settings: {
       channelPlaybackSpeeds: JSON.stringify({
         [CHANNEL_ID]: 1.5
-      })
+      }),
+      syncServerAutoSync: false,
+      syncServerEnabled: true,
+      syncServerPrivacyMode: 'enhanced',
+      syncServerSyncSettings: true,
+      syncServerToken: 'e2e-sync-token'
     },
     profiles: [
       {
@@ -25,6 +30,47 @@ test.use({
 })
 
 test.describe('channel settings', () => {
+  test('configures saved channel setting sync beside the manager and in its breadcrumb', async ({ page }) => {
+    await goToSettingsSection(page, 'channel')
+
+    const manageButton = page.getByRole('button', { name: 'Manage Saved Channels (1)' })
+    const manageControls = manageButton.locator('..')
+    const disableSync = manageControls.getByRole('button', {
+      name: 'Stop syncing saved channel settings'
+    })
+    await expect(disableSync).toBeVisible()
+    await expect(manageButton.getByRole('button')).toHaveCount(0)
+
+    await manageButton.click()
+
+    const breadcrumb = page.locator('.settingsWindow .settingsBreadcrumb')
+    const breadcrumbSync = breadcrumb.getByRole('button', {
+      name: 'Stop syncing saved channel settings'
+    })
+    await expect(breadcrumbSync).toBeVisible()
+    await breadcrumbSync.click()
+
+    const channelSettingKeys = [
+      'channelPlaybackSpeeds',
+      'channelVideoQualities',
+      'channelSubtitlesStates',
+      'channelVolumes'
+    ]
+    await expect.poll(() => page.evaluate(() => {
+      const store = document.querySelector('#app').__vue_app__.config.globalProperties.$store
+      return store.state.settings.syncServerSettingsExcluded
+    })).toEqual(expect.arrayContaining(channelSettingKeys))
+
+    const enableSync = breadcrumb.getByRole('button', {
+      name: 'Sync saved channel settings'
+    })
+    await enableSync.click()
+    await expect.poll(() => page.evaluate(() => {
+      const store = document.querySelector('#app').__vue_app__.config.globalProperties.$store
+      return store.state.settings.syncServerSettingsExcluded
+    })).not.toEqual(expect.arrayContaining(channelSettingKeys))
+  })
+
   test('saved channels in the manager open their channel page', async ({ page }) => {
     await goToSettingsSection(page, 'channel')
 

--- a/e2e/tests/offline/channel-settings.spec.mjs
+++ b/e2e/tests/offline/channel-settings.spec.mjs
@@ -9,6 +9,7 @@ test.use({
       channelPlaybackSpeeds: JSON.stringify({
         [CHANNEL_ID]: 1.5
       }),
+      syncServerSettingsExcluded: ['channelPlaybackSpeeds'],
       syncServerAutoSync: false,
       syncServerEnabled: true,
       syncServerPrivacyMode: 'enhanced',
@@ -65,10 +66,12 @@ test.describe('channel settings', () => {
       name: 'Sync saved channel settings'
     })
     await enableSync.click()
-    await expect.poll(() => page.evaluate(() => {
+    await expect.poll(() => page.evaluate(channelSettingKeys => {
       const store = document.querySelector('#app').__vue_app__.config.globalProperties.$store
-      return store.state.settings.syncServerSettingsExcluded
-    })).not.toEqual(expect.arrayContaining(channelSettingKeys))
+      return store.state.settings.syncServerSettingsExcluded.filter(
+        settingKey => channelSettingKeys.includes(settingKey)
+      )
+    }, channelSettingKeys)).toEqual([])
   })
 
   test('saved channels in the manager open their channel page', async ({ page }) => {

--- a/src/renderer/components/ChannelSettings/ChannelSettings.css
+++ b/src/renderer/components/ChannelSettings/ChannelSettings.css
@@ -16,6 +16,17 @@
   margin-inline-start: 1em;
 }
 
+.manageButton {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.5em;
+}
+
+.manageButton :deep(.syncedSettingIndicator) {
+  font-size: 0.8em;
+  margin-inline-start: 0;
+}
+
 .channelSearch {
   margin-block-end: 1em;
 }

--- a/src/renderer/components/ChannelSettings/ChannelSettings.vue
+++ b/src/renderer/components/ChannelSettings/ChannelSettings.vue
@@ -30,11 +30,18 @@
       </div>
     </div>
     <FtFlexBox>
-      <FtButton
-        :label="manageButtonLabel"
-        :icon="['fas', 'sliders-h']"
-        @click="showManager = true"
-      />
+      <div class="manageButton">
+        <FtButton
+          :label="manageButtonLabel"
+          :icon="['fas', 'sliders-h']"
+          @click="showManager = true"
+        />
+        <FtSyncedSettingIndicator
+          :setting-keys="channelPreferenceSettingKeys"
+          :enable-label="savedChannelSyncEnableLabel"
+          :disable-label="savedChannelSyncDisableLabel"
+        />
+      </div>
     </FtFlexBox>
     <FtSettingsSubpage
       :open="showManager"
@@ -42,6 +49,13 @@
       :icon="['fas', 'users']"
       @close="showManager = false"
     >
+      <template #breadcrumb-action>
+        <FtSyncedSettingIndicator
+          :setting-keys="channelPreferenceSettingKeys"
+          :enable-label="savedChannelSyncEnableLabel"
+          :disable-label="savedChannelSyncDisableLabel"
+        />
+      </template>
       <FtInput
         v-if="channelEntries.length > SEARCH_THRESHOLD"
         class="channelSearch"
@@ -190,6 +204,7 @@ import FtSettingsSubpage from '../FtSettingsSubpage/FtSettingsSubpage.vue'
 import FtSelect from '../FtSelect/FtSelect.vue'
 import FtSettingsSection from '../FtSettingsSection/FtSettingsSection.vue'
 import FtSlider from '../FtSlider/FtSlider.vue'
+import FtSyncedSettingIndicator from '../FtSyncedSettingIndicator/FtSyncedSettingIndicator.vue'
 import FtToggleSwitch from '../FtToggleSwitch/FtToggleSwitch.vue'
 
 import store from '../../store/index'
@@ -204,6 +219,7 @@ import { AUTO_QUALITY_FALLBACK, playbackEngineSupportsAutoQuality } from '../../
 const { locale, t } = useI18n()
 
 const PREFERENCES = CHANNEL_PREFERENCE_TYPES
+const channelPreferenceSettingKeys = PREFERENCES.map(preference => preference.valuesKey)
 const disableChannelLinks = computed(() => store.getters.getDisableChannelLinks)
 
 /** Only offer the search field once scanning the list by eye gets tedious */
@@ -273,6 +289,12 @@ const preferences = computed(() => PREFERENCES.map(preference => ({
 })))
 
 const settings = computed(() => store.state.settings)
+const savedChannelSyncEnableLabel = computed(() => (
+  t('Settings.Channel Settings.Enable Saved Channel Settings Sync')
+))
+const savedChannelSyncDisableLabel = computed(() => (
+  t('Settings.Channel Settings.Disable Saved Channel Settings Sync')
+))
 
 /** @type {import('vue').ComputedRef<string>} */
 const defaultQuality = computed(() => {

--- a/src/renderer/components/FtSettingsSubpage/FtSettingsSubpage.vue
+++ b/src/renderer/components/FtSettingsSubpage/FtSettingsSubpage.vue
@@ -1,6 +1,12 @@
 <template>
   <Teleport
     v-if="open"
+    :to="`#${settingsWindow.breadcrumbTargetId}`"
+  >
+    <slot name="breadcrumb-action" />
+  </Teleport>
+  <Teleport
+    v-if="open"
     :to="`#${settingsWindow.targetId}`"
   >
     <div

--- a/src/renderer/components/FtSyncedSettingIndicator/FtSyncedSettingIndicator.vue
+++ b/src/renderer/components/FtSyncedSettingIndicator/FtSyncedSettingIndicator.vue
@@ -53,6 +53,18 @@ const props = defineProps({
     type: String,
     default: ''
   },
+  settingKeys: {
+    type: Array,
+    default: () => []
+  },
+  enableLabel: {
+    type: String,
+    default: ''
+  },
+  disableLabel: {
+    type: String,
+    default: ''
+  },
   isChanged: {
     type: Boolean,
     default: null
@@ -67,16 +79,23 @@ const emit = defineEmits(['reset'])
 
 const { t } = useI18n()
 
+const syncableSettingKeys = computed(() => {
+  const keys = props.settingKeys.length > 0 ? props.settingKeys : [props.settingKey]
+  return keys.filter(isSettingSyncable)
+})
+
 const canConfigureSync = computed(() => {
   const settings = store.state.settings
   return settings.syncServerEnabled &&
     settings.syncServerToken !== '' &&
     settings.syncServerSyncSettings &&
-    isSettingSyncable(props.settingKey)
+    syncableSettingKeys.value.length > 0
 })
 
 const isSynced = computed(() => {
-  return isSettingSyncEnabled(store.state.settings, props.settingKey)
+  return syncableSettingKeys.value.every(settingKey => (
+    isSettingSyncEnabled(store.state.settings, settingKey)
+  ))
 })
 
 const canShowReset = computed(() => {
@@ -94,8 +113,8 @@ const showReset = computed(() => {
 })
 
 const label = computed(() => isSynced.value
-  ? t('Settings.Sync Settings.Disable Setting Sync')
-  : t('Settings.Sync Settings.Enable Setting Sync'))
+  ? props.disableLabel || t('Settings.Sync Settings.Disable Setting Sync')
+  : props.enableLabel || t('Settings.Sync Settings.Enable Setting Sync'))
 
 const resetLabel = computed(() => t('Settings.Reset Setting to Default'))
 
@@ -128,11 +147,13 @@ async function toggleSync() {
   const excluded = Array.isArray(store.state.settings.syncServerSettingsExcluded)
     ? store.state.settings.syncServerSettingsExcluded
     : []
-  const next = isSynced.value
-    ? [...excluded, props.settingKey]
-    : excluded.filter(settingKey => settingKey !== props.settingKey)
+  const settingKeys = new Set(syncableSettingKeys.value)
+  const enableSync = !isSynced.value
+  const next = !enableSync
+    ? Array.from(new Set([...excluded, ...settingKeys]))
+    : excluded.filter(settingKey => !settingKeys.has(settingKey))
   await store.dispatch('updateSyncServerSettingsExcluded', next)
-  if (!next.includes(props.settingKey)) {
+  if (enableSync) {
     store.dispatch('scheduleSyncServer', 'settings')
   }
 }

--- a/src/renderer/components/FtSyncedSettingIndicator/FtSyncedSettingIndicator.vue
+++ b/src/renderer/components/FtSyncedSettingIndicator/FtSyncedSettingIndicator.vue
@@ -93,7 +93,7 @@ const canConfigureSync = computed(() => {
 })
 
 const isSynced = computed(() => {
-  return syncableSettingKeys.value.every(settingKey => (
+  return syncableSettingKeys.value.some(settingKey => (
     isSettingSyncEnabled(store.state.settings, settingKey)
   ))
 })

--- a/src/renderer/components/SyncSettings/SyncSettings.vue
+++ b/src/renderer/components/SyncSettings/SyncSettings.vue
@@ -165,13 +165,6 @@
             @change="store.dispatch('updateSyncServerSyncHistory', $event)"
           />
           <FtToggleSwitch
-            :label="t('Settings.Sync Settings.Channel Playback Speeds')"
-            :default-value="syncPlaybackSpeedsEnabled"
-            :disabled="busy || playbackSpeedsSupported === false"
-            compact
-            @change="store.dispatch('updateSyncServerSyncPlaybackSpeeds', $event)"
-          />
-          <FtToggleSwitch
             :label="t('Settings.Sync Settings.Profiles')"
             :default-value="syncProfilesEnabled"
             :disabled="busy"
@@ -207,19 +200,7 @@
           {{ t('Settings.Sync Settings.History not supported') }}
         </p>
         <p
-          v-if="playbackSpeedsSupported === false && settingsSupported"
-          class="compatibilityWarning"
-        >
-          {{ t('Settings.Sync Settings.Playback speeds not supported') }}
-        </p>
-        <p
-          v-else-if="playbackSpeedsSupported === false"
-          class="compatibilityWarning"
-        >
-          {{ t('Settings.Sync Settings.Playback speeds and settings not supported') }}
-        </p>
-        <p
-          v-else-if="settingsSupported === false"
+          v-if="settingsSupported === false"
           class="compatibilityWarning"
         >
           {{ t('Settings.Sync Settings.Settings not supported') }}
@@ -405,7 +386,6 @@ const syncProgressLabel = computed(() => {
     subscriptions: t('Settings.Sync Settings.Syncing subscriptions'),
     playlists: t('Settings.Sync Settings.Syncing playlists'),
     history: t('Settings.Sync Settings.Syncing history'),
-    playbackSpeeds: t('Settings.Sync Settings.Syncing playback speeds'),
     profiles: t('Settings.Sync Settings.Syncing profiles'),
     sessions: t('Settings.Sync Settings.Syncing open tabs'),
     settings: t('Settings.Sync Settings.Syncing settings'),
@@ -421,14 +401,10 @@ const autoSync = computed(() => store.getters.getSyncServerAutoSync)
 const syncSubscriptionsEnabled = computed(() => store.getters.getSyncServerSyncSubscriptions)
 const syncPlaylistsEnabled = computed(() => store.getters.getSyncServerSyncPlaylists)
 const syncHistoryEnabled = computed(() => store.getters.getSyncServerSyncHistory)
-const syncPlaybackSpeedsEnabled = computed(() => store.getters.getSyncServerSyncPlaybackSpeeds)
 const syncProfilesEnabled = computed(() => store.getters.getSyncServerSyncProfiles)
 const syncSessionsEnabled = computed(() => store.getters.getSyncServerSyncSessions)
 const syncSettingsEnabled = computed(() => store.getters.getSyncServerSyncSettings)
 const historySupported = computed(() => store.getters.getSyncServerHistorySupported)
-const playbackSpeedsSupported = computed(
-  () => store.getters.getSyncServerPlaybackSpeedsSupported
-)
 const privacyMode = computed(() => store.getters.getSyncServerPrivacyMode)
 const settingsSupported = computed(() => privacyMode.value === 'enhanced')
 const sessionsSupported = computed(() => (

--- a/src/renderer/helpers/sync-server-privacy.js
+++ b/src/renderer/helpers/sync-server-privacy.js
@@ -219,6 +219,29 @@ export function createEmptySyncDocument() {
   }
 }
 
+export function migrateLegacyPlaybackSpeedsToSettings(document, localValue, updatedAt = Date.now()) {
+  if (document.settings.some(entry => entry.key === 'channelPlaybackSpeeds')) return false
+
+  const legacy = Object.fromEntries(document.playbackSpeeds
+    .filter(entry => entry.channel_id && Number.isFinite(entry.playback_speed) &&
+      entry.playback_speed > 0.07)
+    .map(entry => [entry.channel_id, entry.playback_speed]))
+  if (Object.keys(legacy).length === 0) return false
+
+  let local = {}
+  try {
+    const parsed = JSON.parse(localValue)
+    if (parsed && typeof parsed === 'object' && !Array.isArray(parsed)) local = parsed
+  } catch {}
+
+  document.settings.push({
+    key: 'channelPlaybackSpeeds',
+    value: JSON.stringify({ ...legacy, ...local }),
+    updatedAt,
+  })
+  return true
+}
+
 export async function loadLegacySyncDocument(client) {
   const [subscriptions, playlistHeaders, history, playbackSpeeds, subscriptionGroups, playlistBookmarks] =
     await Promise.all([

--- a/src/renderer/helpers/sync-server-scheduling.js
+++ b/src/renderer/helpers/sync-server-scheduling.js
@@ -21,7 +21,6 @@ export const SYNC_ACTION_REASONS = new Map([
   ['removeVideo', 'playlists'],
   ['removeVideos', 'playlists'],
   ['updateHistory', 'history'],
-  ['updateChannelPlaybackSpeeds', 'playbackSpeeds'],
   ['updateCustomThemes', 'settings'],
   ['updatePlaylist', 'playlists'],
   ['updateProfile', 'profilesOrSubscriptions'],
@@ -52,7 +51,6 @@ export const SYNC_MUTATION_REASONS = new Map([
   ['removeFromHistoryCacheById', 'history'],
   ['removeMultipleFromHistoryCache', 'history'],
   ['updateRecordWatchProgressInHistoryCache', 'history'],
-  ['setChannelPlaybackSpeeds', 'playbackSpeeds'],
 ])
 
 export function isSyncReasonEnabled(settings, reason) {
@@ -63,8 +61,6 @@ export function isSyncReasonEnabled(settings, reason) {
       return settings.syncServerSyncPlaylists
     case 'history':
       return settings.syncServerSyncHistory
-    case 'playbackSpeeds':
-      return settings.syncServerSyncPlaybackSpeeds
     case 'profiles':
       return settings.syncServerSyncProfiles
     case 'profilesOrSubscriptions':
@@ -80,7 +76,6 @@ export function isSyncReasonEnabled(settings, reason) {
       return settings.syncServerSyncSubscriptions ||
         settings.syncServerSyncPlaylists ||
         settings.syncServerSyncHistory ||
-        settings.syncServerSyncPlaybackSpeeds ||
         settings.syncServerSyncProfiles ||
         (settings.syncServerPrivacyMode === 'enhanced' && (
           settings.syncServerSyncSessions || settings.syncServerSyncSettings

--- a/src/renderer/helpers/sync-server.js
+++ b/src/renderer/helpers/sync-server.js
@@ -592,63 +592,6 @@ export async function syncSubscriptions(client, store, previousIds = [], options
   return Array.from(mergedIds)
 }
 
-function parseChannelPlaybackSpeeds(value) {
-  try {
-    const speeds = JSON.parse(value)
-    return Object.fromEntries(Object.entries(speeds).filter(([, speed]) => {
-      return Number.isFinite(speed) && speed > 0.07
-    }))
-  } catch {
-    return {}
-  }
-}
-
-export async function syncChannelPlaybackSpeeds(client, store, previous = {}, options = {}) {
-  const local = parseChannelPlaybackSpeeds(store.state.settings.channelPlaybackSpeeds)
-  const remoteEntries = await client.getChannelPlaybackSpeeds()
-  if (remoteEntries === null) return null
-
-  const remote = Object.fromEntries(remoteEntries.map(entry => {
-    return [entry.channel_id, entry.playback_speed]
-  }))
-  const mergedIds = mergeIds(Object.keys(local), Object.keys(remote), Object.keys(previous), {
-    ...options,
-    collection: 'channel playback speeds',
-  })
-  const merged = {}
-
-  for (const channelId of Object.keys(remote)) {
-    if (!mergedIds.has(channelId)) {
-      await client.deleteChannelPlaybackSpeed(channelId)
-    }
-  }
-
-  for (const channelId of mergedIds) {
-    const localSpeed = local[channelId]
-    const remoteSpeed = remote[channelId]
-    const previousSpeed = previous[channelId]
-    const localChanged = localSpeed !== previousSpeed
-    const remoteChanged = remoteSpeed !== previousSpeed
-    const speed = remoteSpeed !== undefined && remoteChanged && !localChanged
-      ? remoteSpeed
-      : localSpeed ?? remoteSpeed
-
-    merged[channelId] = speed
-    if (remoteSpeed !== speed) {
-      await client.putChannelPlaybackSpeed({
-        channel_id: channelId,
-        playback_speed: speed,
-      })
-    }
-  }
-
-  if (!metadataEquals(local, merged)) {
-    await store.dispatch('updateChannelPlaybackSpeeds', JSON.stringify(merged))
-  }
-
-  return merged
-}
-
 export async function syncPlaylists(client, store, previous = {}, options = {}) {
   const localPlaylists = store.state.playlists.playlists
   const localById = mapBy(localPlaylists, playlist => playlist._id)

--- a/src/renderer/store/modules/settings.js
+++ b/src/renderer/store/modules/settings.js
@@ -24,6 +24,7 @@ import { resolveBaseTheme } from '../../../appearanceSettings.js'
 import { resolveColor } from '../../helpers/colors.js'
 
 const YT_DLP_PLAYBACK_ENGINE_MIGRATION_SETTING = 'ytDlpPlaybackEngineDefaultMigration'
+const CHANNEL_SETTINGS_SYNC_MIGRATION_SETTING = 'channelSettingsSyncMigration'
 
 /*
  * Due to the complexity of the settings module in FreeTube, a more
@@ -401,7 +402,6 @@ const state = {
   syncServerSyncSubscriptions: true,
   syncServerSyncPlaylists: true,
   syncServerSyncHistory: true,
-  syncServerSyncPlaybackSpeeds: true,
   syncServerSyncProfiles: true,
   syncServerSyncSessions: true,
   syncServerSyncSettings: true,
@@ -658,7 +658,6 @@ export const NON_TRANSFERABLE_SETTINGS = new Set([
   'syncServerSyncSubscriptions',
   'syncServerSyncPlaylists',
   'syncServerSyncHistory',
-  'syncServerSyncPlaybackSpeeds',
   'syncServerSyncProfiles',
   'syncServerSyncSessions',
   'syncServerSyncSettings',
@@ -680,8 +679,6 @@ export const NON_SYNCABLE_SETTINGS = new Set([
   'scrollMiniPlayerSavedRect',
   'uiScale',
   'verticalTabBarWidth',
-  // Synced through its dedicated collection when enabled.
-  'channelPlaybackSpeeds',
 ])
 
 export function isSettingSyncable(settingKey) {
@@ -861,6 +858,29 @@ const customActions = {
       const hasProgressToastSetting = userSettings.some(entry => entry._id === 'showProgressBarToast')
       const legacyHideLiveChatEntry = userSettings.find(entry => entry._id === 'hideLiveChat')
       const hasHideLiveChatReplaySetting = userSettings.some(entry => entry._id === 'hideLiveChatReplay')
+      const legacyPlaybackSpeedSyncEntry = userSettings.find(
+        entry => entry._id === 'syncServerSyncPlaybackSpeeds'
+      )
+      const hasMigratedChannelSettingsSync = userSettings.some(
+        entry => entry._id === CHANNEL_SETTINGS_SYNC_MIGRATION_SETTING
+      )
+
+      if (!hasMigratedChannelSettingsSync) {
+        try {
+          if (legacyPlaybackSpeedSyncEntry?.value === false) {
+            const excluded = Array.isArray(state.syncServerSettingsExcluded)
+              ? state.syncServerSettingsExcluded
+              : []
+            await dispatch('updateSyncServerSettingsExcluded', Array.from(new Set([
+              ...excluded,
+              'channelPlaybackSpeeds',
+            ])))
+          }
+          await DBSettingHandlers.upsert(CHANNEL_SETTINGS_SYNC_MIGRATION_SETTING, true)
+        } catch (error) {
+          console.error('Failed to migrate saved channel settings sync', error)
+        }
+      }
 
       // Switch every existing installation to the new default once, while allowing
       // users to select the built-in engine again afterwards.

--- a/src/renderer/store/modules/sync-server.js
+++ b/src/renderer/store/modules/sync-server.js
@@ -6,7 +6,6 @@ import {
   isExpiredSessionReauthentication,
   isSessionExpiredError,
   normalizeSyncServerUrl,
-  syncChannelPlaybackSpeeds,
   syncHistory,
   syncPlaylists,
   syncProfiles,
@@ -71,7 +70,6 @@ const state = {
   syncServerError: '',
   syncServerLastResult: null,
   syncServerHistorySupported: null,
-  syncServerPlaybackSpeedsSupported: null,
   syncServerSessionExpired: false,
 }
 
@@ -81,7 +79,6 @@ const getters = {
   getSyncServerError: state => state.syncServerError,
   getSyncServerLastResult: state => state.syncServerLastResult,
   getSyncServerHistorySupported: state => state.syncServerHistorySupported,
-  getSyncServerPlaybackSpeedsSupported: state => state.syncServerPlaybackSpeedsSupported,
 }
 
 function parseSnapshot(value) {
@@ -117,7 +114,6 @@ async function runSync(context, { allowDataLoss = false } = {}) {
     ...(settings.syncServerSyncSubscriptions ? ['subscriptions'] : []),
     ...(settings.syncServerSyncPlaylists ? ['playlists'] : []),
     ...(settings.syncServerSyncHistory ? ['history'] : []),
-    ...(settings.syncServerSyncPlaybackSpeeds ? ['playbackSpeeds'] : []),
     ...(settings.syncServerSyncProfiles ? ['profiles'] : []),
     ...(process.env.IS_ELECTRON &&
       settings.syncServerPrivacyMode === 'enhanced' &&
@@ -189,22 +185,6 @@ async function runSync(context, { allowDataLoss = false } = {}) {
           result.history = history.length
         } else {
           commit('setSyncServerHistorySupported', false)
-        }
-        break
-      }
-      case 'playbackSpeeds': {
-        const speeds = await syncChannelPlaybackSpeeds(
-          targetClient,
-          store,
-          previous.playbackSpeeds,
-          { allowDataLoss }
-        )
-        if (speeds !== null) {
-          commit('setSyncServerPlaybackSpeedsSupported', true)
-          next.playbackSpeeds = speeds
-          result.playbackSpeeds = Object.keys(speeds).length
-        } else {
-          commit('setSyncServerPlaybackSpeedsSupported', false)
         }
         break
       }
@@ -512,7 +492,6 @@ const actions = {
     commit('setSyncServerError', '')
     commit('setSyncServerLastResult', null)
     commit('setSyncServerHistorySupported', null)
-    commit('setSyncServerPlaybackSpeedsSupported', null)
     commit('setSyncServerProgress', null)
     commit('setSyncServerStatus', 'idle')
     commit('setSyncServerSessionExpired', false)
@@ -725,9 +704,6 @@ const mutations = {
   },
   setSyncServerHistorySupported(state, supported) {
     state.syncServerHistorySupported = supported
-  },
-  setSyncServerPlaybackSpeedsSupported(state, supported) {
-    state.syncServerPlaybackSpeedsSupported = supported
   },
   setSyncServerSessionExpired(state, expired) {
     state.syncServerSessionExpired = expired

--- a/src/renderer/store/modules/sync-server.js
+++ b/src/renderer/store/modules/sync-server.js
@@ -20,6 +20,7 @@ import {
   decryptSyncDocument,
   encryptSyncDocument,
   loadLegacySyncDocument,
+  migrateLegacyPlaybackSpeedsToSettings,
   preparePrivacyKey,
 } from '../../helpers/sync-server-privacy'
 import {
@@ -27,6 +28,7 @@ import {
   isRecentSync,
   isSyncReasonEnabled,
 } from '../../helpers/sync-server-scheduling'
+import { isSettingSyncEnabled } from './settings'
 
 const EVENT_SYNC_DEBOUNCE_MS = 1500
 const ENCRYPTED_SYNC_RETRIES = 3
@@ -251,9 +253,15 @@ async function runSync(context, { allowDataLoss = false } = {}) {
         const uploadCollections = manifest.legacy_data || legacyEncrypted?.payload
           ? Array.from(new Set([...enabledCollections, ...LEGACY_ENCRYPTED_COLLECTIONS]))
           : enabledCollections
+        const hasLegacyPlaybackSpeeds = manifest.collections.some(
+          entry => entry.collection === 'playbackSpeeds'
+        )
+        const downloadCollections = hasLegacyPlaybackSpeeds
+          ? Array.from(new Set([...uploadCollections, 'playbackSpeeds']))
+          : uploadCollections
         const document = createEmptySyncDocument()
         const original = {}
-        const entries = await Promise.all(uploadCollections.map(async collection => {
+        const entries = await Promise.all(downloadCollections.map(async collection => {
           const response = await networkClient.getEncryptedSyncCollection(collection)
           const data = response.payload
             ? await decryptSyncDocument(response.payload, settings.syncServerPrivacyKey)
@@ -262,6 +270,13 @@ async function runSync(context, { allowDataLoss = false } = {}) {
           original[collection] = structuredClone(document[collection])
           return [collection, response]
         }))
+        if (settings.syncServerSyncSettings &&
+            isSettingSyncEnabled(settings, 'channelPlaybackSpeeds')) {
+          migrateLegacyPlaybackSpeedsToSettings(
+            document,
+            settings.channelPlaybackSpeeds
+          )
+        }
         return { document, original, remote: Object.fromEntries(entries), uploadCollections }
       })
       client = new EncryptedSyncAdapter(document)

--- a/src/renderer/views/Settings/Settings.css
+++ b/src/renderer/views/Settings/Settings.css
@@ -135,6 +135,13 @@
   text-overflow: ellipsis;
 }
 
+.settingsBreadcrumbAction {
+  display: inline-flex;
+  align-items: center;
+  flex: 0 0 auto;
+  font-size: 16px;
+}
+
 .settingsBreadcrumbRoot,
 .settingsBreadcrumbParent {
   appearance: none;

--- a/src/renderer/views/Settings/Settings.vue
+++ b/src/renderer/views/Settings/Settings.vue
@@ -110,6 +110,10 @@
             <span class="settingsBreadcrumbText">{{ subpageTitle }}</span>
           </span>
         </template>
+        <span
+          :id="subpageBreadcrumbTargetId"
+          class="settingsBreadcrumbAction"
+        />
       </div>
       <label
         v-if="unlocked && !isProfileManagerOpen && !isKeyboardShortcutPromptOpen && !isAboutOpen && !subpageTitle"
@@ -399,6 +403,7 @@ const settingsSearchInputRef = useTemplateRef('settingsSearchInputRef')
 const settingsCloseButtonRef = useTemplateRef('settingsCloseButtonRef')
 const menuRef = useTemplateRef('menuRef')
 const subpageTargetId = `settings-subpage-${useId().replaceAll(':', '')}`
+const subpageBreadcrumbTargetId = `settings-subpage-breadcrumb-${useId().replaceAll(':', '')}`
 const subpageTitle = ref('')
 const subpageIcon = ref(null)
 let closeSubpage = null
@@ -659,6 +664,7 @@ const unlocked = ref(store.getters.getSettingsPassword === '')
 
 provide(settingsSubpageKey, {
   targetId: subpageTargetId,
+  breadcrumbTargetId: subpageBreadcrumbTargetId,
   open(title, close, persistOnDeactivate = false, icon = null) {
     subpageTitle.value = title
     subpageIcon.value = icon

--- a/static/locales/en-US.yaml
+++ b/static/locales/en-US.yaml
@@ -860,6 +860,8 @@ Settings:
     Auto Update Volume: Automatically update whenever you change the volume
     Manage Saved Channels: 'Manage Saved Channels ({channelCount})'
     Saved Channels: Saved Channel Settings
+    Enable Saved Channel Settings Sync: Sync saved channel settings
+    Disable Saved Channel Settings Sync: Stop syncing saved channel settings
     Search Channels: Search channels
     No Saved Channels: No channel specific settings have been saved yet
     No Matching Channels: No channels match your search
@@ -1124,7 +1126,6 @@ Settings:
     Account Deleted: Sync account deleted
     Connected as: 'Connected as {username}'
     Automatic Sync: Sync automatically after changes and every five minutes
-    Channel Playback Speeds: Channel playback speeds
     Profiles: Profiles
     Open Tabs: Open tabs and session
     Settings: Settings
@@ -1135,7 +1136,6 @@ Settings:
     Syncing subscriptions: Syncing subscriptions…
     Syncing playlists: Syncing playlists…
     Syncing history: Syncing watch history…
-    Syncing playback speeds: Syncing channel playback speeds…
     Syncing profiles: Syncing profiles…
     Syncing open tabs: Syncing open tabs and session…
     Syncing settings: Syncing settings…
@@ -1144,8 +1144,6 @@ Settings:
     Sync progress percentage: '{percentage}%'
     Last synced: 'Last synced: {date}'
     History not supported: This server version does not support watch history syncing.
-    Playback speeds not supported: This server version does not support channel playback speed syncing.
-    Playback speeds and settings not supported: This server version does not support channel playback speed or settings syncing.
     Settings not supported: This server version does not support settings syncing.
     Sync completed: Sync completed
     Data Loss Confirmation: Confirm destructive sync?

--- a/tests/unit/sync-server-privacy.test.mjs
+++ b/tests/unit/sync-server-privacy.test.mjs
@@ -4,6 +4,7 @@ import test from 'node:test'
 import {
   decryptLegacySyncDocument,
   decryptSyncDocument,
+  migrateLegacyPlaybackSpeedsToSettings,
   preparePrivacyKey,
 } from '../../src/renderer/helpers/sync-server-privacy.js'
 
@@ -67,4 +68,40 @@ test('decrypts the original single-document encrypted sync format', async () => 
     () => decryptSyncDocument(payload, privacy.key),
     /corrupted sync data/
   )
+})
+
+test('moves legacy playback speeds into settings while preserving local values', () => {
+  const document = {
+    settings: [],
+    playbackSpeeds: [
+      { channel_id: 'remote', playback_speed: 1.25 },
+      { channel_id: 'shared', playback_speed: 1.5 },
+    ],
+  }
+
+  assert.equal(migrateLegacyPlaybackSpeedsToSettings(
+    document,
+    JSON.stringify({ local: 0.75, shared: 2 }),
+    123
+  ), true)
+  assert.deepEqual(document.settings, [{
+    key: 'channelPlaybackSpeeds',
+    value: JSON.stringify({ remote: 1.25, shared: 2, local: 0.75 }),
+    updatedAt: 123,
+  }])
+})
+
+test('keeps the current settings collection instead of legacy playback speeds', () => {
+  const current = {
+    key: 'channelPlaybackSpeeds',
+    value: JSON.stringify({ current: 1.75 }),
+    updatedAt: 456,
+  }
+  const document = {
+    settings: [current],
+    playbackSpeeds: [{ channel_id: 'legacy', playback_speed: 1.25 }],
+  }
+
+  assert.equal(migrateLegacyPlaybackSpeedsToSettings(document, '{}', 789), false)
+  assert.deepEqual(document.settings, [current])
 })

--- a/tests/unit/sync-server-scheduling.test.mjs
+++ b/tests/unit/sync-server-scheduling.test.mjs
@@ -14,7 +14,6 @@ function settings (overrides = {}) {
     syncServerSyncSubscriptions: false,
     syncServerSyncPlaylists: false,
     syncServerSyncHistory: false,
-    syncServerSyncPlaybackSpeeds: false,
     syncServerSyncProfiles: false,
     syncServerSyncSessions: false,
     syncServerSyncSettings: false,
@@ -25,7 +24,7 @@ function settings (overrides = {}) {
 test('maps local actions to their affected sync collection', () => {
   assert.equal(SYNC_ACTION_REASONS.get('updateWatchProgress'), 'history')
   assert.equal(SYNC_ACTION_REASONS.get('addVideo'), 'playlists')
-  assert.equal(SYNC_ACTION_REASONS.get('updateChannelPlaybackSpeeds'), 'playbackSpeeds')
+  assert.equal(SYNC_ACTION_REASONS.has('updateChannelPlaybackSpeeds'), false)
   assert.equal(SYNC_ACTION_REASONS.get('updateCustomThemes'), 'settings')
   assert.equal(SYNC_ACTION_REASONS.get('createProfile'), 'profiles')
   assert.equal(SYNC_ACTION_REASONS.get('addChannelToProfiles'), 'profilesOrSubscriptions')


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Make sure to follow the contributing guidelines. -->
<!-- Important note, we may remove your pull request if you do not use this provided PR template correctly. -->
<!-- Agent instructions: Preserve every heading, comment, and marker in this template. Never remove or rewrite the release-note-category:start/end, release-note:start/end, or release-note-image:start/end marker pairs. Never remove or rewrite the Release note images section; leave its contents for a human. -->

## Pull Request Type
<!-- Please select what type of pull request this is: [x] -->
- [ ] Bugfix
- [x] Feature Implementation
- [ ] Documentation
- [ ] Other

## Related issue
<!-- Please link the issue your pull request is referring to. -->
<!-- If this pull request fully resolves the relevant issue, put "closes" before the issue number. -->
<!-- Example: "closes #123456". -->

## Description
<!-- Please write a clear and concise description of what the pull request does. -->
Channel playback speeds were synchronized through a dedicated collection even though the newer per-channel quality, subtitle, and volume preferences already use Settings sync. This made saved channel settings behave inconsistently and exposed a separate top-level sync category.

This moves saved playback speeds into Settings sync, removes the dedicated category, and adds one grouped sync control for all saved channel values beside the manager button and in the saved-channel breadcrumb. Existing users who disabled playback-speed sync keep that preference through a one-time exclusion migration.

## Release note category
<!-- Select exactly one category. Every pull request must select one. -->
<!-- Select "Not noteworthy" when the pull request fixes a bug in or improves functionality that has not yet appeared in a stable release. -->
<!-- release-note-category:start -->
- [ ] Not noteworthy
- [ ] Highlights
- [x] More improvements
- [ ] Fixed bugs
<!-- release-note-category:end -->

## Release note
<!-- Required unless "Not noteworthy" is selected. -->
<!-- Write one concise, user-facing entry without a leading bullet. -->
<!-- release-note:start -->
Saved channel playback speed, quality, subtitle, and volume preferences can now be synchronized together through Settings sync.
<!-- release-note:end -->

## Release note images
<!-- Human-only: Agents must preserve this entire section and leave it empty. -->
<!-- Optional. Paste one or more Markdown images or HTML image tags here. -->
<!-- The release notes will use an HTML image tag and limit images taller than 300 pixels. -->
<!-- release-note-image:start -->
<img width="572" height="110" alt="image" src="https://github.com/user-attachments/assets/e20cf7d3-b7cc-4414-b9c6-ebdef3c71f8d" />
<!-- release-note-image:end -->

## Testing
<!-- How can reviewers verify that the PR produces correct results? -->
<!-- Please provide instructions so that others can ensure that your pull request would produce correct results. For examples see, https://github.com/FreeTubeApp/FreeTube/pull/5743, https://github.com/FreeTubeApp/FreeTube/pull/7349, https://github.com/FreeTubeApp/FreeTube/pull/5125, https://github.com/FreeTubeApp/FreeTube/pull/7338 -->
<!-- Agent instructions: Only write human-facing steps that explain how to verify the change while running this branch in dev mode. Include expected results and, when applicable, helpful console snippets for interactive verification. Do not include automated checks, commands, results, pass counts, or CI status. -->
1. Connect to an enhanced-privacy sync server and enable Settings sync.
2. Open Channel Settings and confirm the sync icon is next to, rather than inside, **Manage Saved Channels**.
3. Open the saved-channel manager and confirm the same control appears after **Saved Channel Settings** in the breadcrumb.
4. Toggle either control and confirm both locations update together and all saved channel values stop or resume syncing.
5. Confirm the Sync section no longer shows a separate channel playback-speed category.

## Additional context
<!-- Add any other context about the pull request here. -->
Legacy sync servers do not support Settings sync, so saved channel preferences remain local when connected to one. The dedicated server API is being deprecated separately while remaining available to older clients during rollout.
