### PR TITLE
fix: use default avatar for deleted channels

### DIFF
--- a/e2e/tests/offline/subscribed-channels.spec.mjs
+++ b/e2e/tests/offline/subscribed-channels.spec.mjs
@@ -43,6 +43,23 @@ test.describe('subscribed channels', () => {
     await expect(page.locator('.channel', { hasText: 'Alpha Channel' })).toBeHidden()
   })
 
+  test('uses the default avatar when a channel thumbnail fails to load', async ({ page }) => {
+    await goTo(page, 'subscribedchannels')
+
+    const alpha = page.locator('.channel', { hasText: 'Alpha Channel' })
+    await page.evaluate(() => {
+      const store = document.querySelector('#app').__vue_app__.config.globalProperties.$store
+      store.dispatch('updateSubscriptionDetails', {
+        channelId: 'UCaaaaaaaaaaaaaaaaaaaaaa',
+        channelName: 'Alpha Channel',
+        channelThumbnailUrl: 'data:image/png;base64,invalid'
+      })
+    })
+
+    await expect(alpha.locator('img.channelThumbnail')).toHaveCount(0)
+    await expect(alpha.locator('.channelThumbnail:not(img)')).toBeVisible()
+  })
+
   test('profile dropdown uses an overlay scrollbar', async ({ page }) => {
     await goTo(page, 'subscribedchannels')
 

--- a/src/renderer/views/SubscribedChannels/SubscribedChannels.vue
+++ b/src/renderer/views/SubscribedChannels/SubscribedChannels.vue
@@ -45,11 +45,11 @@
               :to="`/channel/${channel.id}`"
             >
               <img
-                v-if="channel.thumbnail != null"
+                v-if="hasUsableThumbnail(channel.thumbnail)"
                 class="channelThumbnail"
                 :src="thumbnailURL(channel.thumbnail)"
                 alt=""
-                @error.once="updateThumbnail(channel)"
+                @error.once="handleThumbnailError(channel)"
               >
               <ft-icon
                 v-else
@@ -131,6 +131,7 @@ const query = ref('')
 const channelLimit = ref(channelsPerPage)
 const subscribedChannels = ref([])
 const filteredChannels = ref([])
+const failedThumbnailUrls = ref(new Set())
 
 const searchBarChannels = useTemplateRef('searchBarChannels')
 
@@ -229,6 +230,20 @@ function thumbnailURL(originalURL) {
   }
 
   return newURL.replace(re.url, `$1${thumbnailSize}$2`)
+}
+
+function hasUsableThumbnail(originalURL) {
+  const url = thumbnailURL(originalURL)
+  return url !== null && !failedThumbnailUrls.value.has(url)
+}
+
+function handleThumbnailError(channel) {
+  const url = thumbnailURL(channel.thumbnail)
+  if (url !== null) {
+    failedThumbnailUrls.value = new Set(failedThumbnailUrls.value).add(url)
+  }
+
+  updateThumbnail(channel)
 }
 
 function updateThumbnail(channel) {


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Make sure to follow the contributing guidelines. -->
<!-- Important note, we may remove your pull request if you do not use this provided PR template correctly. -->
<!-- Agent instructions: Preserve every heading, comment, and marker in this template. Never remove or rewrite the release-note-category:start/end, release-note:start/end, or release-note-image:start/end marker pairs. Never remove or rewrite the Release note images section; leave its contents for a human. -->

## Pull Request Type
<!-- Please select what type of pull request this is: [x] -->
- [x] Bugfix
- [ ] Feature Implementation
- [ ] Documentation
- [ ] Other

## Related issue
<!-- Please link the issue your pull request is referring to. -->
<!-- If this pull request fully resolves the relevant issue, put "closes" before the issue number. -->
<!-- Example: "closes #123456". -->

## Description
<!-- Please write a clear and concise description of what the pull request does. -->
Deleted channels can leave subscriptions pointing at thumbnails that no longer load. The subscribed-channels grid kept the failed image mounted while trying to refresh its metadata, which exposed Chromium's broken-image placeholder.

Track failed resolved thumbnail URLs and render the existing default channel avatar for them. A newly resolved URL can still be displayed after subscription metadata changes.

## Release note category
<!-- Select exactly one category. Every pull request must select one. -->
<!-- Select "Not noteworthy" when the pull request fixes a bug in or improves functionality that has not yet appeared in a stable release. -->
<!-- release-note-category:start -->
- [ ] Not noteworthy
- [ ] Highlights
- [ ] More improvements
- [x] Fixed bugs
<!-- release-note-category:end -->

## Release note
<!-- Required unless "Not noteworthy" is selected. -->
<!-- Write one concise, user-facing entry without a leading bullet. -->
<!-- release-note:start -->
Show the default channel avatar when a subscribed channel's thumbnail no longer loads.
<!-- release-note:end -->

## Release note images
<!-- Human-only: Agents must preserve this entire section and leave it empty. -->
<!-- Optional. Paste one or more Markdown images or HTML image tags here. -->
<!-- The release notes will use an HTML image tag and limit images taller than 300 pixels. -->
<!-- release-note-image:start -->

<!-- release-note-image:end -->

## Testing
<!-- How can reviewers verify that the PR produces correct results? -->
<!-- Please provide instructions so that others can ensure that your pull request produces correct results. For examples see, https://github.com/FreeTubeApp/FreeTube/pull/5743, https://github.com/FreeTubeApp/FreeTube/pull/7349, https://github.com/FreeTubeApp/FreeTube/pull/5125, https://github.com/FreeTubeApp/FreeTube/pull/7338 -->
<!-- Agent instructions: Only write human-facing steps that explain how to verify the change while running this branch in dev mode. Include expected results and, when applicable, helpful console snippets for interactive verification. Do not include automated checks, commands, results, pass counts, or CI status. -->
1. Subscribe to a channel whose saved thumbnail URL no longer loads, such as a deleted channel.
2. Open the Channels page.
3. Confirm the channel uses the default user avatar instead of Chromium's broken-image placeholder.
4. Confirm other subscribed channels continue to show their thumbnails normally.

## Additional context
<!-- Add any other context about the pull request here. -->
A focused regression test covers the image-error fallback.
