### PR TITLE
fix: use default avatars in channel bubbles

### DIFF
--- a/e2e/tests/offline/profiles.spec.mjs
+++ b/e2e/tests/offline/profiles.spec.mjs
@@ -100,6 +100,32 @@ test.describe('default profile setting', () => {
   })
 })
 
+test.describe('profile channel thumbnails', () => {
+  test.use({
+    seed: {
+      settings: { hideUnsubscribeButton: true },
+      profiles: [{
+        ...mainProfile,
+        subscriptions: [{
+          id: 'UCaaaaaaaaaaaaaaaaaaaaaa',
+          name: 'Deleted Channel',
+          thumbnail: 'data:image/png;base64,invalid'
+        }]
+      }]
+    }
+  })
+
+  test('uses the default avatar when a channel thumbnail fails to load', async ({ page }) => {
+    await openProfileList(page)
+    await page.locator('.profilePanelHeader button').last().click()
+    await page.locator('.card .profileList').getByText('All Channels').click()
+
+    const channel = page.locator('#subscriptionsPanel').getByRole('link', { name: 'Deleted Channel' })
+    await expect(channel.locator('img.bubble')).toHaveCount(0)
+    await expect(channel.locator('.bubble:not(img)')).toBeVisible()
+  })
+})
+
 test.describe('profile manager', () => {
   test.describe('scroll position', () => {
     test.use({

--- a/src/renderer/components/FtChannelBubble/FtChannelBubble.vue
+++ b/src/renderer/components/FtChannelBubble/FtChannelBubble.vue
@@ -6,10 +6,11 @@
     :to="`/channel/${channelId}`"
   >
     <img
-      v-if="channelThumbnail != null"
+      v-if="channelThumbnail != null && !thumbnailLoadFailed"
       class="bubble"
       :src="channelThumbnail"
       alt=""
+      @error="handleThumbnailError"
     >
     <FtIcon
       v-else
@@ -35,10 +36,17 @@
     @keydown.space.enter.prevent="handleClick"
   >
     <img
+      v-if="channelThumbnail != null && !thumbnailLoadFailed"
       class="bubble"
       :src="channelThumbnail"
       alt=""
+      @error="handleThumbnailError"
     >
+    <FtIcon
+      v-else
+      :icon="['fas', 'circle-user']"
+      class="bubble"
+    />
     <div
       v-if="selected"
       class="bubble selected"
@@ -60,7 +68,7 @@
 
 <script setup>
 import { FtIcon } from '@opentubex/icons'
-import { useId } from 'vue'
+import { ref, useId, watch } from 'vue'
 
 const props = defineProps({
   channelId: {
@@ -86,11 +94,20 @@ const props = defineProps({
 })
 
 const id = useId()
+const thumbnailLoadFailed = ref(false)
+
+watch(() => props.channelThumbnail, () => {
+  thumbnailLoadFailed.value = false
+})
 
 const emit = defineEmits(['change'])
 
 function handleClick() {
   emit('change', !props.selected)
+}
+
+function handleThumbnailError() {
+  thumbnailLoadFailed.value = true
 }
 </script>
 


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Make sure to follow the contributing guidelines. -->
<!-- Important note, we may remove your pull request if you do not use this provided PR template correctly. -->
<!-- Agent instructions: Preserve every heading, comment, and marker in this template. Never remove or rewrite the release-note-category:start/end, release-note:start/end, or release-note-image:start/end marker pairs. Never remove or rewrite the Release note images section; leave its contents for a human. -->

## Pull Request Type
<!-- Please select what type of pull request this is: [x] -->
- [x] Bugfix
- [ ] Feature Implementation
- [ ] Documentation
- [ ] Other

## Related issue
<!-- Please link the issue your pull request is referring to. -->
<!-- If this pull request fully resolves the relevant issue, put "closes" before the issue number. -->
<!-- Example: "closes #123456". -->

Follow-up to #721.

## Description
<!-- Please write a clear and concise description of what the pull request does. -->
#721 added the broken-thumbnail fallback to the subscribed-channels grid, but subscription error channels use the separate `FtChannelBubble` component and could still expose Chromium's broken-image placeholder.

Track thumbnail load failures inside each channel bubble and render the existing default channel avatar instead. Reset the failure state when the component receives a different thumbnail URL, and apply the same behavior to linked and selectable bubbles.

## Release note category
<!-- Select exactly one category. Every pull request must select one. -->
<!-- Select "Not noteworthy" when the pull request fixes a bug in or improves functionality that has not yet appeared in a stable release. -->
<!-- release-note-category:start -->
- [x] Not noteworthy
- [ ] Highlights
- [ ] More improvements
- [ ] Fixed bugs
<!-- release-note-category:end -->

## Release note
<!-- Required unless "Not noteworthy" is selected. -->
<!-- Write one concise, user-facing entry without a leading bullet. -->
<!-- release-note:start -->

<!-- release-note:end -->

## Release note images
<!-- Human-only: Agents must preserve this entire section and leave it empty. -->
<!-- Optional. Paste one or more Markdown images or HTML image tags here. -->
<!-- The release notes will use an HTML image tag and limit images taller than 300 pixels. -->
<!-- release-note-image:start -->

<!-- release-note-image:end -->

## Testing
<!-- How can reviewers verify that the PR produces correct results? -->
<!-- Please provide instructions so that others can ensure that your pull request produces correct results. For examples see, https://github.com/FreeTubeApp/FreeTube/pull/5743, https://github.com/FreeTubeApp/FreeTube/pull/7349, https://github.com/FreeTubeApp/FreeTube/pull/5125, https://github.com/FreeTubeApp/FreeTube/pull/7338 -->
<!-- Agent instructions: Only write human-facing steps that explain how to verify the change while running this branch in dev mode. Include expected results and, when applicable, helpful console snippets for interactive verification. Do not include automated checks, commands, results, pass counts, or CI status. -->
1. Open Subscriptions with a channel whose feed refresh and saved thumbnail both fail.
2. Find the channel under Channels with Errors.
3. Confirm it shows the default user avatar instead of Chromium's broken-image placeholder.
4. Open a profile's channel list and confirm failed thumbnails use the same fallback there.

## Additional context
<!-- Add any other context about the pull request here. -->
A focused regression test covers the linked channel-bubble path that remained after #721.
