### PR TITLE
fix: match fallback channel avatar size

### DIFF
--- a/e2e/tests/offline/profiles.spec.mjs
+++ b/e2e/tests/offline/profiles.spec.mjs
@@ -122,7 +122,9 @@ test.describe('profile channel thumbnails', () => {
 
     const channel = page.locator('#subscriptionsPanel').getByRole('link', { name: 'Deleted Channel' })
     await expect(channel.locator('img.bubble')).toHaveCount(0)
-    await expect(channel.locator('.bubble:not(img)')).toBeVisible()
+    const fallbackAvatar = channel.locator('.bubble:not(img)')
+    await expect(fallbackAvatar).toBeVisible()
+    await expect(fallbackAvatar).toHaveCSS('font-size', '50px')
   })
 })
 

--- a/src/renderer/components/FtChannelBubble/FtChannelBubble.css
+++ b/src/renderer/components/FtChannelBubble/FtChannelBubble.css
@@ -27,6 +27,10 @@
   object-fit: cover;
 }
 
+.ft-icon.bubble {
+  font-size: 50px;
+}
+
 .selected {
   position: absolute;
   inset-block-start: 10px;


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Make sure to follow the contributing guidelines. -->
<!-- Important note, we may remove your pull request if you do not use this provided PR template correctly. -->
<!-- Agent instructions: Preserve every heading, comment, and marker in this template. Never remove or rewrite the release-note-category:start/end, release-note:start/end, or release-note-image:start/end marker pairs. Never remove or rewrite the Release note images section; leave its contents for a human. -->

## Pull Request Type
<!-- Please select what type of pull request this is: [x] -->
- [x] Bugfix
- [ ] Feature Implementation
- [ ] Documentation
- [ ] Other

## Related issue
<!-- Please link the issue your pull request is referring to. -->
<!-- If this pull request fully resolves the relevant issue, put "closes" before the issue number. -->
<!-- Example: "closes #123456". -->

Follow-up to #723.

## Description
<!-- Please write a clear and concise description of what the pull request does. -->
#723 replaced failed channel-bubble images with the default avatar, but the icon glyph retained its small inherited font size inside the normal 50px avatar box.

Size the fallback icon glyph to 50px so it visually matches regular channel avatars. Strengthen the existing regression test to verify the computed glyph size.

## Release note category
<!-- Select exactly one category. Every pull request must select one. -->
<!-- Select "Not noteworthy" when the pull request fixes a bug in or improves functionality that has not yet appeared in a stable release. -->
<!-- release-note-category:start -->
- [x] Not noteworthy
- [ ] Highlights
- [ ] More improvements
- [ ] Fixed bugs
<!-- release-note-category:end -->

## Release note
<!-- Required unless "Not noteworthy" is selected. -->
<!-- Write one concise, user-facing entry without a leading bullet. -->
<!-- release-note:start -->

<!-- release-note:end -->

## Release note images
<!-- Human-only: Agents must preserve this entire section and leave it empty. -->
<!-- Optional. Paste one or more Markdown images or HTML image tags here. -->
<!-- The release notes will use an HTML image tag and limit images taller than 300 pixels. -->
<!-- release-note-image:start -->

<!-- release-note-image:end -->

## Testing
<!-- How can reviewers verify that the PR produces correct results? -->
<!-- Please provide instructions so that others can ensure that your pull request produces correct results. For examples see, https://github.com/FreeTubeApp/FreeTube/pull/5743, https://github.com/FreeTubeApp/FreeTube/pull/7349, https://github.com/FreeTubeApp/FreeTube/pull/5125, https://github.com/FreeTubeApp/FreeTube/pull/7338 -->
<!-- Agent instructions: Only write human-facing steps that explain how to verify the change while running this branch in dev mode. Include expected results and, when applicable, helpful console snippets for interactive verification. Do not include automated checks, commands, results, pass counts, or CI status. -->
1. Open Subscriptions with a channel whose feed refresh and saved thumbnail both fail.
2. Find the channel under Channels with Errors.
3. Confirm the default avatar fills the same 50px area as regular channel avatars instead of appearing as a small glyph.

## Additional context
<!-- Add any other context about the pull request here. -->
The fallback behavior itself was introduced in #723.
