### PR TITLE
fix(channel): show fallbacks for unavailable metadata

### DIFF
--- a/e2e/tests/offline/channel-errors.spec.mjs
+++ b/e2e/tests/offline/channel-errors.spec.mjs
@@ -1,0 +1,53 @@
+import { test, expect, sel } from '../../helpers/app.mjs'
+
+const CACHED_CHANNEL_ID = 'UCaaaaaaaaaaaaaaaaaaaaaa'
+const UNKNOWN_CHANNEL_ID = 'UCbbbbbbbbbbbbbbbbbbbbbb'
+
+test.use({
+  seed: {
+    settings: {
+      backendPreference: 'invidious',
+      defaultInvidiousInstance: 'https://invidious.test'
+    },
+    profiles: [{
+      _id: 'allChannels',
+      name: 'All Channels',
+      bgColor: '#000000',
+      textColor: '#FFFFFF',
+      subscriptions: [{
+        id: CACHED_CHANNEL_ID,
+        name: 'Deleted Channel',
+        thumbnail: 'data:image/png;base64,invalid'
+      }]
+    }]
+  }
+})
+
+async function openChannelTab(page, channelId) {
+  const tab = await page.evaluate((id) => window.ftElectron.tabs.create({
+    route: `/channel/${id}`,
+    makeActive: false
+  }), channelId)
+  await page.locator(`.tab[data-tab-id="${tab.id}"]`).click()
+}
+
+test('shows fallback metadata for unavailable channels', async ({ page }) => {
+  await page.route('https://invidious.test/api/v1/channels/**', route => route.fulfill({
+    json: { error: 'This channel is unavailable' }
+  }))
+
+  await openChannelTab(page, CACHED_CHANNEL_ID)
+
+  const cachedChannel = page.locator('.channelDetails:visible')
+  await expect(cachedChannel.locator('.name')).toHaveText('Deleted Channel')
+  await expect(cachedChannel.locator('img.thumbnail')).toHaveCount(0)
+  const fallbackAvatar = cachedChannel.locator('.thumbnail:not(img)')
+  await expect(fallbackAvatar).toBeVisible()
+  await expect(fallbackAvatar).toHaveCSS('font-size', '100px')
+
+  await openChannelTab(page, UNKNOWN_CHANNEL_ID)
+
+  const unknownChannel = page.locator('.channelDetails:visible')
+  await expect(unknownChannel.locator('.name')).toHaveText('Channel name unavailable')
+  await expect(page.locator(sel.activeTab)).toContainText('Channel name unavailable')
+})

--- a/e2e/tests/offline/channel-errors.spec.mjs
+++ b/e2e/tests/offline/channel-errors.spec.mjs
@@ -50,4 +50,16 @@ test('shows fallback metadata for unavailable channels', async ({ page }) => {
   const unknownChannel = page.locator('.channelDetails:visible')
   await expect(unknownChannel.locator('.name')).toHaveText('Channel name unavailable')
   await expect(page.locator(sel.activeTab)).toContainText('Channel name unavailable')
+
+  await page.evaluate(() => {
+    const app = document.querySelector('#app').__vue_app__
+    const i18n = app._context.provides[app.__VUE_I18N_SYMBOL__].global
+    i18n.setLocaleMessage('e2e', {
+      Channel: { 'Channel Name Unavailable': 'Localized unavailable name' }
+    })
+    i18n.locale.value = 'e2e'
+  })
+
+  await expect(unknownChannel.locator('.name')).toHaveText('Localized unavailable name')
+  await expect(page.locator(sel.activeTab)).toContainText('Localized unavailable name')
 })

--- a/src/renderer/components/ChannelDetails/ChannelDetails.css
+++ b/src/renderer/components/ChannelDetails/ChannelDetails.css
@@ -41,6 +41,10 @@
   object-fit: cover;
 }
 
+.ft-icon.thumbnail {
+  font-size: 100px;
+}
+
 .name {
   font-weight: bold;
   inline-size: 100%;

--- a/src/renderer/components/ChannelDetails/ChannelDetails.vue
+++ b/src/renderer/components/ChannelDetails/ChannelDetails.vue
@@ -19,10 +19,11 @@
           class="thumbnailContainer"
         >
           <img
-            v-if="thumbnailUrl"
+            v-if="thumbnailUrl && !thumbnailLoadFailed"
             class="thumbnail"
             :src="thumbnailUrl"
             alt=""
+            @error="handleThumbnailError"
           >
           <FtIcon
             v-else
@@ -36,7 +37,7 @@
               class="name"
               dir="auto"
             >
-              {{ name }}
+              {{ name || $t('Channel.Channel Name Unavailable') }}
             </h1>
 
             <p
@@ -254,7 +255,7 @@
 </template>
 
 <script setup>
-import { computed, onBeforeUnmount, onMounted, useTemplateRef } from 'vue'
+import { computed, onBeforeUnmount, onMounted, ref, useTemplateRef, watch } from 'vue'
 
 import { FtIcon } from '@opentubex/icons'
 import FtCard from '../ft-card/ft-card.vue'
@@ -319,6 +320,16 @@ const props = defineProps({
 })
 
 const emit = defineEmits(['change-tab', 'search', 'subscribed'])
+
+const thumbnailLoadFailed = ref(false)
+
+watch(() => props.thumbnailUrl, () => {
+  thumbnailLoadFailed.value = false
+})
+
+function handleThumbnailError() {
+  thumbnailLoadFailed.value = true
+}
 
 /** @type {import('vue').ComputedRef<boolean>} */
 const hideChannelSubscriptions = computed(() => {

--- a/src/renderer/views/Channel/Channel.vue
+++ b/src/renderer/views/Channel/Channel.vue
@@ -359,7 +359,7 @@ import {
   getLocalChannelSearchResultType,
 } from './channel-search'
 
-const { t } = useI18n()
+const { locale, t } = useI18n()
 const route = useRoute()
 const router = useRouter()
 const setTabTitle = useTabTitle()
@@ -400,7 +400,7 @@ const isFamilyFriendly = ref(false)
 
 // Publish the resolved name or its fallback only after channel loading finishes.
 // This keeps a late tab-mount or route projection from restoring the route placeholder.
-watch([channelName, isLoading], ([name, loading]) => {
+watch([channelName, isLoading, locale], ([name, loading]) => {
   if (!loading) {
     setTabTitle(name || t('Channel.Channel Name Unavailable'))
   }

--- a/src/renderer/views/Channel/Channel.vue
+++ b/src/renderer/views/Channel/Channel.vue
@@ -398,12 +398,11 @@ const relatedChannels = shallowRef([])
 const isArtistTopicChannel = ref(false)
 const isFamilyFriendly = ref(false)
 
-// Publish the resolved name only after channel loading finishes. This keeps a
-// late tab-mount or route projection from restoring the route placeholder and
-// also covers error responses that fall back to cached subscription details.
+// Publish the resolved name or its fallback only after channel loading finishes.
+// This keeps a late tab-mount or route projection from restoring the route placeholder.
 watch([channelName, isLoading], ([name, loading]) => {
-  if (!loading && typeof name === 'string' && name.length > 0) {
-    setTabTitle(name)
+  if (!loading) {
+    setTabTitle(name || t('Channel.Channel Name Unavailable'))
   }
 })
 

--- a/static/locales/en-US.yaml
+++ b/static/locales/en-US.yaml
@@ -1342,6 +1342,7 @@ Profile:
 Channel:
   Subscribe: Subscribe
   Unsubscribe: Unsubscribe
+  Channel Name Unavailable: Channel name unavailable
   Channel has been removed from your subscriptions: Channel has been removed from
     your subscriptions
   Removed subscription from {count} other channel(s): Removed subscription from 1 other channel | Removed subscription from {count} other channels


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Make sure to follow the contributing guidelines. -->
<!-- Important note, we may remove your pull request if you do not use this provided PR template correctly. -->
<!-- Agent instructions: Preserve every heading, comment, and marker in this template. Never remove or rewrite the release-note-category:start/end, release-note:start/end, or release-note-image:start/end marker pairs. Never remove or rewrite the Release note images section; leave its contents for a human. -->

## Pull Request Type
<!-- Please select what type of pull request this is: [x] -->
- [x] Bugfix
- [ ] Feature Implementation
- [ ] Documentation
- [ ] Other

## Related issue
<!-- Please link the issue your pull request is referring to. -->
<!-- If this pull request fully resolves the relevant issue, put "closes" before the issue number. -->
<!-- Example: "closes #123456". -->

## Description
<!-- Please write a clear and concise description of what the pull request does. -->
Unavailable or deleted channels can retain an unusable thumbnail URL, causing Chromium's broken-image placeholder to appear on the channel page. Channels without cached subscription metadata also leave the channel name and tab title blank.

Fall back to the correctly sized default channel avatar when the header thumbnail fails, and show a localized unavailable-name placeholder in both the channel header and tab title. An offline regression test covers cached broken thumbnails and channels with no cached metadata.

## Release note category
<!-- Select exactly one category. Every pull request must select one. -->
<!-- Select "Not noteworthy" when the pull request fixes a bug in or improves functionality that has not yet appeared in a stable release. -->
<!-- release-note-category:start -->
- [ ] Not noteworthy
- [ ] Highlights
- [ ] More improvements
- [x] Fixed bugs
<!-- release-note-category:end -->

## Release note
<!-- Required unless "Not noteworthy" is selected. -->
<!-- Write one concise, user-facing entry without a leading bullet. -->
<!-- release-note:start -->
Unavailable channels now show a default avatar and name instead of broken or blank metadata.
<!-- release-note:end -->

## Release note images
<!-- Human-only: Agents must preserve this entire section and leave it empty. -->
<!-- Optional. Paste one or more Markdown images or HTML image tags here. -->
<!-- The release notes will use an HTML image tag and limit images taller than 300 pixels. -->
<!-- release-note-image:start -->

<!-- release-note-image:end -->

## Testing
<!-- How can reviewers verify that the PR produces correct results? -->
<!-- Please provide instructions so that others can ensure that your pull request produces the expected behavior. -->
<!-- Agent instructions: Only write human-facing steps that explain how to verify the change while running this branch in dev mode. Include expected results and, when applicable, helpful console snippets for interactive verification. Do not include automated checks, commands, results, pass counts, or CI status. -->
1. Open a deleted or unavailable channel whose cached thumbnail no longer loads. Confirm that the channel header shows the default avatar at the same size as a normal channel avatar.
2. Open an unavailable channel that is not present in the active profile's subscriptions. Confirm that both the channel header and active tab display “Channel name unavailable”.

## Additional context
<!-- Add any other context about the pull request here. -->
This follows the deleted-channel avatar fallbacks added to the subscriptions and profile channel lists.
