### PR TITLE
feat: preserve background tab opening order

### DIFF
--- a/e2e/tests/offline/tabs.spec.mjs
+++ b/e2e/tests/offline/tabs.spec.mjs
@@ -55,6 +55,51 @@ test.describe('tab bar', () => {
     await expect(page.locator(sel.tabs).nth(1).locator('[data-icon="rss"]')).toBeVisible()
   })
 
+  test('opens background tabs beside their opener in creation order', async ({ page }) => {
+    const openerTabId = await page.locator(sel.tabs).getAttribute('data-tab-id')
+    const existingTab = await page.evaluate(() => window.ftElectron.tabs.create({
+      route: '/history',
+      title: 'Existing tab',
+      makeActive: false,
+      lazyLoad: true,
+      openerTabId: 'unrelated-tab'
+    }))
+    const firstVideo = await page.evaluate(openerTabId => window.ftElectron.tabs.create({
+      route: '/watch/first',
+      title: 'First video',
+      makeActive: false,
+      lazyLoad: true,
+      openerTabId
+    }), openerTabId)
+    const secondVideo = await page.evaluate(openerTabId => window.ftElectron.tabs.create({
+      route: '/watch/second',
+      title: 'Second video',
+      makeActive: false,
+      lazyLoad: true,
+      openerTabId
+    }), openerTabId)
+
+    await expect(page.locator(sel.tabs)).toHaveCount(4)
+    await expect.poll(async () => page.locator(sel.tabs).evaluateAll(
+      tabs => tabs.map(tab => tab.dataset.tabId)
+    )).toEqual([openerTabId, firstVideo.id, secondVideo.id, existingTab.id])
+
+    await page.evaluate(({ tabId }) => window.ftElectron.tabs.move(tabId, 3), {
+      tabId: secondVideo.id
+    })
+    const thirdVideo = await page.evaluate(openerTabId => window.ftElectron.tabs.create({
+      route: '/watch/third',
+      title: 'Third video',
+      makeActive: false,
+      lazyLoad: true,
+      openerTabId
+    }), openerTabId)
+
+    await expect.poll(async () => page.locator(sel.tabs).evaluateAll(
+      tabs => tabs.map(tab => tab.dataset.tabId)
+    )).toEqual([openerTabId, firstVideo.id, thirdVideo.id, existingTab.id, secondVideo.id])
+  })
+
   test('fixed internal routes use their page title before mounting', async ({ page }) => {
     const fixedRoutes = [
       ['/subscriptions', 'Subscriptions'],

--- a/src/main/tabs/TabManager.js
+++ b/src/main/tabs/TabManager.js
@@ -11,7 +11,11 @@ import {
   saveTabSession
 } from './TabSessionStore.js'
 import { TabRendererBridge } from './TabRendererBridge.js'
-import { buildReorderedTabMap, getGroupedTabInsertIndex } from './tabOrder.js'
+import {
+  buildReorderedTabMap,
+  getGroupedTabInsertIndex,
+  restoreTabPlacementOpeners
+} from './tabOrder.js'
 import {
   createTabAvatarFileName,
   createTabPreviewFileName,
@@ -2813,6 +2817,8 @@ export class TabManager {
           preloadInBackground: loadInBackground && !makeActive
         })
       }
+
+      restoreTabPlacementOpeners(this.tabs, sessionData.tabs)
 
       if (!this.activeTabId) {
         const firstTabId = this.tabs.keys().next().value

--- a/src/main/tabs/TabManager.js
+++ b/src/main/tabs/TabManager.js
@@ -11,7 +11,7 @@ import {
   saveTabSession
 } from './TabSessionStore.js'
 import { TabRendererBridge } from './TabRendererBridge.js'
-import { buildReorderedTabMap } from './tabOrder.js'
+import { buildReorderedTabMap, getGroupedTabInsertIndex } from './tabOrder.js'
 import {
   createTabAvatarFileName,
   createTabPreviewFileName,
@@ -33,8 +33,8 @@ import { isOpenTubeXUrl } from '../utils.js'
 /** @type {Map<number, TabManager>} windowId -> TabManager */
 const tabManagers = new Map()
 
-const DEFAULT_NEW_TAB_POSITION = 'afterCurrent'
-const VALID_NEW_TAB_POSITIONS = new Set(['end', 'afterCurrent'])
+const DEFAULT_NEW_TAB_POSITION = 'afterCurrentInOrder'
+const VALID_NEW_TAB_POSITIONS = new Set(['end', 'afterCurrent', 'afterCurrentInOrder'])
 const DEFAULT_TAB_CLOSE_FOCUS = 'previousTab'
 const VALID_TAB_CLOSE_FOCUS = new Set(['previousTab', 'nextTab'])
 // Closing a tab has to pick the replacement synchronously, so the preference is
@@ -83,6 +83,7 @@ const TAB_AVATAR_SIZE = 64
  * @property {boolean} pendingActivation
  * @property {number} mountRevision
  * @property {number} refreshKey
+ * @property {string | null} placementOpenerTabId
  * @property {NavigationHistoryEntry[] | null} navigationHistory
  * @property {number} navigationHistoryIndex
  * @property {boolean} persistNavigationHistory
@@ -99,7 +100,7 @@ const TAB_AVATAR_SIZE = 64
 export class TabManager {
   /**
    * @param {unknown} value
-   * @returns {'end' | 'afterCurrent'}
+   * @returns {'end' | 'afterCurrent' | 'afterCurrentInOrder'}
    */
   static normalizeNewTabPosition(value) {
     return VALID_NEW_TAB_POSITIONS.has(value)
@@ -189,7 +190,7 @@ export class TabManager {
   }
 
   /**
-   * @returns {Promise<'end' | 'afterCurrent'>}
+   * @returns {Promise<'end' | 'afterCurrent' | 'afterCurrentInOrder'>}
    */
   static async getStoredNewTabPosition() {
     try {
@@ -882,6 +883,7 @@ export class TabManager {
       history = null,
       historyIndex = null,
       persistHistory = history != null,
+      openerTabId = this.activeTabId,
       _deferUpdates = false
     } = options
 
@@ -930,17 +932,25 @@ export class TabManager {
       pendingActivation: false,
       mountRevision: shouldMount ? 1 : 0,
       refreshKey: 0,
+      placementOpenerTabId: this.tabs.has(openerTabId) ? openerTabId : null,
       navigationHistory: restoredNavigationHistory?.history ?? null,
       navigationHistoryIndex: restoredNavigationHistory?.historyIndex ?? 0,
       persistNavigationHistory: Boolean(persistHistory) && restoredNavigationHistory != null
     }
 
     let preferredIndex = this.tabs.size
-    if (TabManager.normalizeNewTabPosition(openPosition) === 'afterCurrent' && this.activeTabId != null) {
+    const normalizedOpenPosition = TabManager.normalizeNewTabPosition(openPosition)
+    if (normalizedOpenPosition === 'afterCurrent' && this.activeTabId != null) {
       const activeTabIndex = Array.from(this.tabs.keys()).indexOf(this.activeTabId)
       if (activeTabIndex !== -1) {
         preferredIndex = activeTabIndex + 1
       }
+    } else if (normalizedOpenPosition === 'afterCurrentInOrder' && tabInfo.placementOpenerTabId != null) {
+      preferredIndex = getGroupedTabInsertIndex(
+        this.tabs,
+        tabInfo.placementOpenerTabId,
+        tabInfo.isPinned
+      ) ?? preferredIndex
     }
 
     this._insertTabEntry(id, tabInfo, preferredIndex)
@@ -1042,7 +1052,7 @@ export class TabManager {
    * @returns {Promise<TabInfo>}
    */
   async createTabWithPreferenceFromOpener(options = {}, openerTabId = this.activeTabId) {
-    return this.createTabWithPreference(this._withOpenerTabColor(options, openerTabId))
+    return this.createTabWithPreference(this._withOpenerTab(options, openerTabId))
   }
 
   /**
@@ -1050,13 +1060,17 @@ export class TabManager {
    * @param {string | undefined | null} openerTabId
    * @returns {object}
    */
-  _withOpenerTabColor(options, openerTabId) {
+  _withOpenerTab(options, openerTabId) {
     if (Object.hasOwn(options, 'color')) {
-      return options
+      return { ...options, openerTabId }
     }
 
     const openerColor = TabManager.normalizeTabColor(this.tabs.get(openerTabId)?.color)
-    return openerColor == null ? options : { ...options, color: openerColor }
+    return {
+      ...options,
+      openerTabId,
+      ...(openerColor != null && { color: openerColor })
+    }
   }
 
   /**
@@ -2374,6 +2388,7 @@ export class TabManager {
       pendingActivation: false,
       mountRevision: 1,
       refreshKey: 0,
+      placementOpenerTabId: null,
       isTransferStaged: true
     }
 
@@ -2606,7 +2621,10 @@ export class TabManager {
           title: tab.title,
           isPinned: tab.isPinned,
           color: TabManager.normalizeTabColor(tab.color),
-          isUnloaded: tab.loadState === 'unloaded' || this._deferredUnloadTabIds.has(tab.id)
+          isUnloaded: tab.loadState === 'unloaded' || this._deferredUnloadTabIds.has(tab.id),
+          ...(tab.placementOpenerTabId != null && {
+            placementOpenerTabId: tab.placementOpenerTabId
+          })
         }
 
         const previewFileName = normalizeTabPreviewFileName(tab.previewFileName)
@@ -2654,6 +2672,9 @@ export class TabManager {
         isPinned: tab.isPinned,
         color: tab.color,
         isUnloaded: tab.isUnloaded || this._deferredUnloadTabIds.has(tab.id),
+        ...(this.tabs.get(tab.id)?.placementOpenerTabId != null && {
+          placementOpenerTabId: this.tabs.get(tab.id).placementOpenerTabId
+        }),
         ...(this.tabs.get(tab.id)?.persistNavigationHistory && tab.history != null && {
           history: tab.history,
           historyIndex: tab.historyIndex
@@ -2732,7 +2753,7 @@ export class TabManager {
   }
 
   /**
-   * @param {{ tabs?: Array<{id?: string, url: string, title?: string, avatarFileName?: string | null, isPinned?: boolean, color?: string | null, isUnloaded?: boolean, previewFileName?: string | null, previewCapturedAt?: number, history?: object[], historyIndex?: number}>, activeTabId?: string }} sessionData
+   * @param {{ tabs?: Array<{id?: string, url: string, title?: string, avatarFileName?: string | null, isPinned?: boolean, color?: string | null, isUnloaded?: boolean, previewFileName?: string | null, previewCapturedAt?: number, placementOpenerTabId?: string | null, history?: object[], historyIndex?: number}>, activeTabId?: string }} sessionData
    * @param {{ loadInactiveTabs?: boolean, restoreTabLoadState?: boolean }} [options]
    * @returns {Promise<boolean>}
    */
@@ -2785,6 +2806,9 @@ export class TabManager {
           persistHistory: restoreNavigationHistory,
           makeActive,
           openPosition: 'end',
+          openerTabId: typeof tabData.placementOpenerTabId === 'string'
+            ? tabData.placementOpenerTabId
+            : null,
           lazyLoad: restoreAsUnloaded,
           preloadInBackground: loadInBackground && !makeActive
         })
@@ -2988,12 +3012,12 @@ export async function setupTabsIPC(options = {}) {
       ...tabOptions
     } = options != null && typeof options === 'object' ? options : {}
 
+    const resolvedOpenerTabId = typeof openerTabId === 'string'
+      ? openerTabId
+      : manager.presentedTabId ?? manager.activeTabId
     const tab = inheritColorFromOpener === true
-      ? await manager.createTabWithPreferenceFromOpener(
-          tabOptions,
-          typeof openerTabId === 'string' ? openerTabId : manager.presentedTabId ?? manager.activeTabId
-        )
-      : await manager.createTabWithPreference(tabOptions)
+      ? await manager.createTabWithPreferenceFromOpener(tabOptions, resolvedOpenerTabId)
+      : await manager.createTabWithPreference({ ...tabOptions, openerTabId: resolvedOpenerTabId })
 
     return {
       id: tab.id,

--- a/src/main/tabs/tabOrder.js
+++ b/src/main/tabs/tabOrder.js
@@ -60,3 +60,24 @@ export function getGroupedTabInsertIndex(tabs, openerTabId, isPinned) {
 
   return insertIndex
 }
+
+/**
+ * Restore opener relationships after every saved tab exists, including links
+ * to openers that appeared later in the saved order.
+ * @param {Map<string, {placementOpenerTabId?: string | null}>} tabs
+ * @param {Array<{id?: string, placementOpenerTabId?: string | null}>} savedTabs
+ */
+export function restoreTabPlacementOpeners(tabs, savedTabs) {
+  const savedTabsById = new Map(savedTabs.map(tab => [tab.id, tab]))
+
+  for (const [tabId, tab] of tabs) {
+    const openerTabId = savedTabsById.get(tabId)?.placementOpenerTabId
+    tab.placementOpenerTabId = (
+      typeof openerTabId === 'string' &&
+      openerTabId !== tabId &&
+      tabs.has(openerTabId)
+    )
+      ? openerTabId
+      : null
+  }
+}

--- a/src/main/tabs/tabOrder.js
+++ b/src/main/tabs/tabOrder.js
@@ -30,3 +30,33 @@ export function buildReorderedTabMap(tabs, tabIds) {
 
   return new Map(normalizedTabIds.map(tabId => [tabId, tabs.get(tabId)]))
 }
+
+/**
+ * Find the end of the contiguous group created from an opener. Tabs moved out
+ * of that group do not become its new insertion point.
+ * @param {Map<string, {isPinned?: boolean, placementOpenerTabId?: string | null}>} tabs
+ * @param {string} openerTabId
+ * @param {boolean} isPinned
+ * @returns {number | null}
+ */
+export function getGroupedTabInsertIndex(tabs, openerTabId, isPinned) {
+  const entries = Array.from(tabs.entries())
+  const openerIndex = entries.findIndex(([tabId]) => tabId === openerTabId)
+  if (openerIndex === -1) return null
+
+  const pinnedCount = entries.filter(([, tab]) => tab.isPinned).length
+  const openerIsPinned = entries[openerIndex][1].isPinned
+  const groupStartIndex = openerIsPinned && !isPinned
+    ? pinnedCount
+    : openerIndex + 1
+  let insertIndex = groupStartIndex
+
+  while (
+    insertIndex < entries.length &&
+    entries[insertIndex][1].placementOpenerTabId === openerTabId
+  ) {
+    insertIndex += 1
+  }
+
+  return insertIndex
+}

--- a/src/preload/interface.js
+++ b/src/preload/interface.js
@@ -843,6 +843,7 @@ export default {
      * @param {object} [options.query] - Query params for the route
      * @param {boolean} [options.makeActive=true] - Whether to activate the tab
      * @param {boolean} [options.inheritColorFromOpener=false] - Whether to inherit the opener tab color
+     * @param {string} [options.openerTabId] - Tab whose ordered placement group this tab belongs to
      * @param {boolean} [options.preloadInBackground=false] - Whether to attach an inactive tab while it loads
      * @returns {Promise<{id: string, url: string, title: string}|null>}
      */

--- a/src/renderer/components/GeneralSettings/GeneralSettings.vue
+++ b/src/renderer/components/GeneralSettings/GeneralSettings.vue
@@ -535,18 +535,19 @@ function updateLandingPage(value) {
   store.dispatch('updateLandingPage', value)
 }
 
-const NEW_TAB_POSITION_VALUES = ['end', 'afterCurrent']
+const NEW_TAB_POSITION_VALUES = ['end', 'afterCurrent', 'afterCurrentInOrder']
 
 const newTabPositionNames = computed(() => [
   t('Settings.General Settings.New Tab Position.At the end'),
-  t('Settings.General Settings.New Tab Position.After current tab')
+  t('Settings.General Settings.New Tab Position.After current tab'),
+  t('Settings.General Settings.New Tab Position.After current tab in opened order')
 ])
 
-/** @type {import('vue').ComputedRef<'end' | 'afterCurrent'>} */
+/** @type {import('vue').ComputedRef<'end' | 'afterCurrent' | 'afterCurrentInOrder'>} */
 const newTabPosition = computed(() => store.getters.getNewTabPosition)
 
 /**
- * @param {'end' | 'afterCurrent'} value
+ * @param {'end' | 'afterCurrent' | 'afterCurrentInOrder'} value
  */
 function updateNewTabPosition(value) {
   store.dispatch('updateNewTabPosition', value)

--- a/src/renderer/store/modules/settings.js
+++ b/src/renderer/store/modules/settings.js
@@ -299,7 +299,7 @@ const state = {
   showLiveChatTimestamps: false,
   liveChatFilter: 'TOP_CHAT',
   landingPage: 'subscriptions',
-  newTabPosition: 'afterCurrent',
+  newTabPosition: 'afterCurrentInOrder',
   tabCloseFocus: 'previousTab',
   startupBehavior: 'loadLastActiveTab',
   showTabIcons: true,

--- a/static/locales/de-DE.yaml
+++ b/static/locales/de-DE.yaml
@@ -296,6 +296,7 @@ Settings:
       New Tab Position: Neuer Tab Position
       At the end: Am Ende
       After current tab: Nach dem aktuellen Tab
+      After current tab in opened order: Nach dem aktuellen Tab, in geöffneter Reihenfolge
     Avoid translation:
       Avoid translation: Originaltext beibehalten
       Disabled: Deaktiviert

--- a/static/locales/en-US.yaml
+++ b/static/locales/en-US.yaml
@@ -427,6 +427,7 @@ Settings:
       New Tab Position: New Tab Position
       At the end: At the end
       After current tab: After current tab
+      After current tab in opened order: After current tab, in opened order
     Tab Close Focus:
       Tab Close Focus: After Closing a Tab
       Previous tab: Select the previous tab

--- a/tests/unit/tab-order.test.mjs
+++ b/tests/unit/tab-order.test.mjs
@@ -1,7 +1,10 @@
 import assert from 'node:assert/strict'
 import test from 'node:test'
 
-import { buildReorderedTabMap } from '../../src/main/tabs/tabOrder.js'
+import {
+  buildReorderedTabMap,
+  getGroupedTabInsertIndex
+} from '../../src/main/tabs/tabOrder.js'
 
 function createTabs() {
   return new Map([
@@ -40,4 +43,36 @@ test('builds a valid changed order without changing tab objects', () => {
   assert.deepEqual(Array.from(reorderedTabs.keys()), ['pinned', 'second', 'first'])
   assert.equal(reorderedTabs.get('first'), tabs.get('first'))
   assert.equal(reorderedTabs.get('second'), tabs.get('second'))
+})
+
+test('appends new tabs to the contiguous group created from their opener', () => {
+  const tabs = new Map([
+    ['subscriptions', { isPinned: false }],
+    ['first-video', { isPinned: false, placementOpenerTabId: 'subscriptions' }],
+    ['second-video', { isPinned: false, placementOpenerTabId: 'subscriptions' }],
+    ['existing', { isPinned: false }]
+  ])
+
+  assert.equal(getGroupedTabInsertIndex(tabs, 'subscriptions', false), 3)
+})
+
+test('does not follow a grouped tab that was moved elsewhere', () => {
+  const tabs = new Map([
+    ['subscriptions', { isPinned: false }],
+    ['first-video', { isPinned: false, placementOpenerTabId: 'subscriptions' }],
+    ['existing', { isPinned: false }],
+    ['moved-video', { isPinned: false, placementOpenerTabId: 'subscriptions' }]
+  ])
+
+  assert.equal(getGroupedTabInsertIndex(tabs, 'subscriptions', false), 2)
+})
+
+test('starts an unpinned group after all pinned tabs', () => {
+  const tabs = new Map([
+    ['subscriptions', { isPinned: true }],
+    ['other-pinned', { isPinned: true }],
+    ['existing', { isPinned: false }]
+  ])
+
+  assert.equal(getGroupedTabInsertIndex(tabs, 'subscriptions', false), 2)
 })

--- a/tests/unit/tab-order.test.mjs
+++ b/tests/unit/tab-order.test.mjs
@@ -3,10 +3,11 @@ import test from 'node:test'
 
 import {
   buildReorderedTabMap,
-  getGroupedTabInsertIndex
+  getGroupedTabInsertIndex,
+  restoreTabPlacementOpeners
 } from '../../src/main/tabs/tabOrder.js'
 
-function createTabs() {
+function createTabs () {
   return new Map([
     ['pinned', { isPinned: true }],
     ['first', { isPinned: false }],
@@ -75,4 +76,25 @@ test('starts an unpinned group after all pinned tabs', () => {
   ])
 
   assert.equal(getGroupedTabInsertIndex(tabs, 'subscriptions', false), 2)
+})
+
+test('restores forward opener links after every saved tab exists', () => {
+  const tabs = new Map([
+    ['moved-video', { placementOpenerTabId: null }],
+    ['subscriptions', { placementOpenerTabId: null }],
+    ['invalid', { placementOpenerTabId: null }],
+    ['self-linked', { placementOpenerTabId: null }]
+  ])
+  const savedTabs = [
+    { id: 'moved-video', placementOpenerTabId: 'subscriptions' },
+    { id: 'subscriptions' },
+    { id: 'invalid', placementOpenerTabId: 'missing' },
+    { id: 'self-linked', placementOpenerTabId: 'self-linked' }
+  ]
+
+  restoreTabPlacementOpeners(tabs, savedTabs)
+
+  assert.equal(tabs.get('moved-video').placementOpenerTabId, 'subscriptions')
+  assert.equal(tabs.get('invalid').placementOpenerTabId, null)
+  assert.equal(tabs.get('self-linked').placementOpenerTabId, null)
 })


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Make sure to follow the contributing guidelines. -->
<!-- Important note, we may remove your pull request if you do not use this provided PR template correctly. -->
<!-- Agent instructions: Preserve every heading, comment, and marker in this template. Never remove or rewrite the release-note-category:start/end, release-note:start/end, or release-note-image:start/end marker pairs. Never remove or rewrite the Release note images section; leave its contents for a human. -->

## Pull Request Type
<!-- Please select what type of pull request this is: [x] -->
- [ ] Bugfix
- [x] Feature Implementation
- [ ] Documentation
- [ ] Other

## Related issue
<!-- Please link the issue your pull request is referring to. -->
<!-- If this pull request fully resolves the relevant issue, put "closes" before the issue number. -->
<!-- Example: "closes #123456". -->

## Description
<!-- Please write a clear and concise description of what the pull request does. -->
Opening several videos from a feed in background tabs currently places the last-clicked video closest to the feed, reversing the order someone intended to watch them.

This adds an "After current tab, in opened order" position and makes it the default. Tabs opened from the same source form a contiguous group in creation order, while tabs manually moved elsewhere do not pull the insertion point with them. The opener relationship is retained across restored and synced sessions.

## Release note category
<!-- Select exactly one category. Every pull request must select one. -->
<!-- Select "Not noteworthy" when the pull request fixes a bug in or improves functionality that has not yet appeared in a stable release. -->
<!-- release-note-category:start -->
- [ ] Not noteworthy
- [ ] Highlights
- [x] More improvements
- [ ] Fixed bugs
<!-- release-note-category:end -->

## Release note
<!-- Required unless "Not noteworthy" is selected. -->
<!-- Write one concise, user-facing entry without a leading bullet. -->
<!-- release-note:start -->
New option to keep background tabs in the order they were opened.
<!-- release-note:end -->

## Release note images
<!-- Human-only: Agents must preserve this entire section and leave it empty. -->
<!-- Optional. Paste one or more Markdown images or HTML image tags here. -->
<!-- The release notes will use an HTML image tag and limit images taller than 300 pixels. -->
<!-- release-note-image:start -->
<img width="335" height="74" alt="image" src="https://github.com/user-attachments/assets/33013650-f70b-4a21-bf21-314d4f090bf6" />
<!-- release-note-image:end -->

## Testing
<!-- How can reviewers verify that the PR produces correct results? -->
<!-- Please provide instructions so that others can ensure that your pull request would produce correct results? For examples see, https://github.com/FreeTubeApp/FreeTube/pull/5743, https://github.com/FreeTubeApp/FreeTube/pull/7349, https://github.com/FreeTubeApp/FreeTube/pull/5125, https://github.com/FreeTubeApp/FreeTube/pull/7338 -->
<!-- Agent instructions: Only write human-facing steps that explain how to verify the change while running this branch in dev mode. Include expected results and, when applicable, helpful console snippets for interactive verification. Do not include automated checks, commands, results, pass counts, or CI status. -->
1. Open General settings and select "After current tab, in opened order" under New Tab Position. It should already be selected on a fresh profile.
2. Leave another tab to the right of Subscriptions, then middle-click three videos in the subscription feed from first to last.
3. Confirm the videos appear directly after Subscriptions in first, second, third order, before the existing tab.
4. Drag the third video tab elsewhere and middle-click another feed video. Confirm the new tab continues the original group instead of following the moved tab.

## Additional context
<!-- Add any other context about the pull request here. -->
Tab groups are scoped to their opener, avoiding a global insertion cursor that could place tabs beside an unrelated source after switching tabs.
