### PR TITLE
fix(invidious): show comment author photos

### DIFF
--- a/src/renderer/helpers/api/invidious-comments.js
+++ b/src/renderer/helpers/api/invidious-comments.js
@@ -1,7 +1,7 @@
 /**
- * @param {{authorThumbnails?: {url?: string}[]}} comment
+ * @param {{authorThumbnail?: string, authorThumbnails?: {url?: string}[]}} comment
  * @returns {string | null}
  */
 export function getInvidiousCommentAuthorThumbnail(comment) {
-  return comment.authorThumbnails?.at(-1)?.url ?? null
+  return comment.authorThumbnail || comment.authorThumbnails?.at(-1)?.url || null
 }

--- a/tests/unit/invidious-comments.test.mjs
+++ b/tests/unit/invidious-comments.test.mjs
@@ -3,6 +3,12 @@ import test from 'node:test'
 
 import { getInvidiousCommentAuthorThumbnail } from '../../src/renderer/helpers/api/invidious-comments.js'
 
+test('returns the Invidious comment author thumbnail', () => {
+  assert.equal(getInvidiousCommentAuthorThumbnail({
+    authorThumbnail: 'author.jpg'
+  }), 'author.jpg')
+})
+
 test('returns the largest Invidious comment author thumbnail', () => {
   assert.equal(getInvidiousCommentAuthorThumbnail({
     authorThumbnails: [


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Make sure to follow the contributing guidelines. -->
<!-- Important note, we may remove your pull request if you do not use this provided PR template correctly. -->
<!-- Agent instructions: Preserve every heading, comment, and marker in this template. Never remove or rewrite the release-note-category:start/end, release-note:start/end, or release-note-image:start/end marker pairs. Never remove or rewrite the Release note images section; leave its contents for a human. -->

## Pull Request Type
<!-- Please select what type of pull request this is: [x] -->
- [x] Bugfix
- [ ] Feature Implementation
- [ ] Documentation
- [ ] Other

## Related issue
<!-- Please link the issue your pull request is referring to. -->
<!-- If this pull request fully resolves the relevant issue, put "closes" before the issue number. -->
<!-- Example: "closes #123456". -->

Closes #727.

## Description
<!-- Please write a clear and concise description of what the pull request does. -->

Invidious comments always displayed the fallback initials avatar when the API returned the author's photo through the singular `authorThumbnail` field. The thumbnail normalizer now accepts that current response shape while retaining support for the plural `authorThumbnails` array and the missing-avatar fallback.

## Release note category
<!-- Select exactly one category. Every pull request must select one. -->
<!-- Select "Not noteworthy" when the pull request fixes a bug in or improves functionality that has not yet appeared in a stable release. -->
<!-- release-note-category:start -->
- [ ] Not noteworthy
- [ ] Highlights
- [ ] More improvements
- [x] Fixed bugs
<!-- release-note-category:end -->

## Release note
<!-- Required unless "Not noteworthy" is selected. -->
<!-- Write one concise, user-facing entry without a leading bullet. -->
<!-- release-note:start -->
Show comment author photos returned by Invidious instead of fallback initials.
<!-- release-note:end -->

## Release note images
<!-- Human-only: Agents must preserve this entire section and leave it empty. -->
<!-- Optional. Paste one or more Markdown images or HTML image tags here. -->
<!-- The release notes will use an HTML image tag and limit images taller than 300 pixels. -->
<!-- release-note-image:start -->

<!-- release-note-image:end -->

## Testing
<!-- How can reviewers verify that the PR produces correct results? -->
<!-- Please provide instructions so that others can ensure that your pull request would produce correct results. For examples see, https://github.com/FreeTubeApp/FreeTube/pull/5743, https://github.com/FreeTubeApp/FreeTube/pull/7349, https://github.com/FreeTubeApp/FreeTube/pull/5125, https://github.com/FreeTubeApp/FreeTube/pull/7338 -->
<!-- Agent instructions: Only write human-facing steps that explain how to verify the change while running this branch in dev mode. Include expected results and, when applicable, helpful console snippets for interactive verification. Do not include automated checks, commands, results, pass counts, or CI status. -->

1. Select an Invidious instance and open a video with comments whose response contains `authorThumbnail` URLs.
2. Expand the comments section.
3. Confirm that the authors' photos are shown.
4. Open comments without an available thumbnail and confirm that their fallback initials still appear.

## Additional context
<!-- Add any other context about the pull request here. -->

The earlier missing-avatar fix only read `authorThumbnails`, but some Invidious/Companion responses use `authorThumbnail` as a string.
