### PR TITLE
fix(i18n): support localized plurals across tab counts

### DIFF
--- a/src/main/index.js
+++ b/src/main/index.js
@@ -43,6 +43,7 @@ import { handleOpenInExternalPlayer } from './externalPlayer'
 import { handleYtDlpCancelDownload, handleYtDlpClearDownloads, handleYtDlpDownload, handleYtDlpDownloadBinary, handleYtDlpGetInfo, handleYtDlpGetPlaybackInfo, handleYtDlpListDownloads, handleYtDlpOpenDownload, handleYtDlpRemoveDownload, shutdownYtDlpDownloads } from './ytDlp'
 import { handleYtDlpPlaybackCacheClear, handleYtDlpPlaybackCacheDelete, handleYtDlpPlaybackCacheGet, handleYtDlpPlaybackCacheSet } from './ytDlpPlaybackCache'
 import { generatePoToken } from './poTokenGenerator'
+import { expandMultipleOnlyPluralMessages, selectPluralForm } from '../renderer/i18n/plurals'
 import { buildProxyUrl, DEFAULT_PROXY_SETTINGS, isOpenTubeXUrl } from './utils'
 import { TabManager, setupTabsIPC } from './tabs/TabManager'
 import { clearAllTabSessions, loadAllTabSessions } from './tabs/TabSessionStore'
@@ -378,7 +379,7 @@ function runApp() {
   }
 
   /**
-   * @returns {Promise<(key: string) => string>}
+   * @returns {Promise<(key: string, parameters?: Record<string, string | number>, pluralChoice?: number) => string>}
    */
   async function createMainTranslator() {
     const fallbackLocale = 'en-US'
@@ -396,7 +397,7 @@ function runApp() {
       try {
         messagesByLocale.push({
           locale,
-          messages: await loadLocaleMessages(locale)
+          messages: expandMultipleOnlyPluralMessages(locale, await loadLocaleMessages(locale))
         })
       } catch (error) {
         if (locale === fallbackLocale) {
@@ -405,11 +406,20 @@ function runApp() {
       }
     }
 
-    return (key) => {
-      for (const { messages } of messagesByLocale) {
+    return (key, parameters = {}, pluralChoice) => {
+      for (const { locale, messages } of messagesByLocale) {
         const message = getLocaleMessage(key, messages)
         if (message) {
-          return message
+          const selectedMessage = pluralChoice == null
+            ? message
+            : selectPluralForm(locale, message, pluralChoice)
+
+          if (selectedMessage == null) continue
+
+          return Object.entries(parameters).reduce(
+            (text, [name, value]) => text.replaceAll(`{${name}}`, String(value)),
+            selectedMessage
+          )
         }
       }
 
@@ -488,7 +498,7 @@ function runApp() {
       const { response } = await dialog.showMessageBox(browserWindow, {
         type: 'question',
         title: t('Close Window Confirmation.Title'),
-        message: t('Close Window Confirmation.Message').replaceAll('{count}', String(count)),
+        message: t('Close Window Confirmation.Message', { count }, count),
         detail: t('Confirmations.Settings Hint'),
         buttons: [
           t('Close Window Confirmation.Close Window'),

--- a/src/renderer/App.vue
+++ b/src/renderer/App.vue
@@ -2493,15 +2493,23 @@ const multipleTabsActionPromptTitle = computed(() => {
 const multipleTabsActionPromptMessage = computed(() => {
   const count = multipleTabsActionPromptCount.value
   const parameters = { count }
-  if (multipleTabsActionPrompt.value === 'load') return t('Load Multiple Tabs Confirmation.Message', parameters)
-  if (multipleTabsActionPrompt.value === 'unload') return t('Unload Multiple Tabs Confirmation.Message', parameters)
+  if (multipleTabsActionPrompt.value === 'load') return t('Load Multiple Tabs Confirmation.Message', parameters, count)
+  if (multipleTabsActionPrompt.value === 'unload') return t('Unload Multiple Tabs Confirmation.Message', parameters, count)
   return t('Close Multiple Tabs Confirmation.Message', parameters, count)
 })
 const multipleTabsActionPromptNames = computed(() => [
   multipleTabsActionPrompt.value === 'load'
-    ? t('Load Multiple Tabs Confirmation.Load Tabs', { count: multipleTabsActionPromptCount.value })
+    ? t(
+        'Load Multiple Tabs Confirmation.Load Tabs',
+        { count: multipleTabsActionPromptCount.value },
+        multipleTabsActionPromptCount.value
+      )
     : multipleTabsActionPrompt.value === 'unload'
-      ? t('Unload Multiple Tabs Confirmation.Unload Tabs', { count: multipleTabsActionPromptCount.value })
+      ? t(
+          'Unload Multiple Tabs Confirmation.Unload Tabs',
+          { count: multipleTabsActionPromptCount.value },
+          multipleTabsActionPromptCount.value
+        )
       : t(
           'Close Multiple Tabs Confirmation.Close Tabs',
           { count: multipleTabsActionPromptCount.value },

--- a/src/renderer/components/ContextMenuSearchSettings/ContextMenuSearchSettings.vue
+++ b/src/renderer/components/ContextMenuSearchSettings/ContextMenuSearchSettings.vue
@@ -166,10 +166,12 @@ function showInvalidEngineToast() {
 }
 
 function showEngineLimitToast() {
+  const count = MAX_CUSTOM_SEARCH_ENGINES
+
   showToast({
     message: t('Settings.Context Menu Search Settings.Engine Limit', {
-      count: MAX_CUSTOM_SEARCH_ENGINES
-    }),
+      count
+    }, count),
     icon: ['fas', 'circle-exclamation']
   })
 }

--- a/src/renderer/components/FtContextMenu/FtContextMenu.vue
+++ b/src/renderer/components/FtContextMenu/FtContextMenu.vue
@@ -431,8 +431,15 @@ async function execute(item) {
 function localizedLabel(item) {
   if (!item.labelKey) return item.label
 
+  const parameters = item.labelParameters ?? {}
+
+  if (typeof parameters.count === 'number') {
+    // eslint-disable-next-line @intlify/vue-i18n/no-dynamic-keys
+    return t(item.labelKey, parameters, parameters.count)
+  }
+
   // eslint-disable-next-line @intlify/vue-i18n/no-dynamic-keys
-  return t(item.labelKey, item.labelParameters ?? {})
+  return t(item.labelKey, parameters)
 }
 
 function handleKeydown(event) {

--- a/src/renderer/components/ThemeSettings.vue
+++ b/src/renderer/components/ThemeSettings.vue
@@ -610,7 +610,7 @@ async function loadTabIcons() {
     } else if (failed > 0) {
       showToast(t('Settings.Theme Settings.Loaded Tab Icons With Failures', { loaded, failed }))
     } else {
-      showToast(t('Settings.Theme Settings.Loaded Tab Icons', { count: loaded }))
+      showToast(t('Settings.Theme Settings.Loaded Tab Icons', { count: loaded }, loaded))
     }
   } finally {
     loadingTabIcons.value = false

--- a/src/renderer/i18n/index.js
+++ b/src/renderer/i18n/index.js
@@ -1,7 +1,7 @@
 import { createI18n } from 'vue-i18n'
 import { ref } from 'vue'
 import { createWebURL } from '../helpers/utils'
-import { createPluralRules } from './plurals'
+import { createPluralRules, expandMultipleOnlyPluralMessages } from './plurals'
 // List of locales approved for use
 import activeLocales from '../../../static/locales/activeLocales.json'
 
@@ -51,7 +51,7 @@ export async function loadLocale(locale) {
 
   const response = await fetch(url)
   const data = await response.json()
-  i18n.global.setLocaleMessage(locale, data)
+  i18n.global.setLocaleMessage(locale, expandMultipleOnlyPluralMessages(locale, data))
 }
 
 // Set by _scripts/ProcessLocalesPlugin.js
@@ -70,7 +70,7 @@ if (process.env.HOT_RELOAD_LOCALES) {
           Object.keys(i18n.global.messages.value[locale]).length > 0) {
           const localeData = JSON.parse(data)
 
-          i18n.global.setLocaleMessage(locale, localeData)
+          i18n.global.setLocaleMessage(locale, expandMultipleOnlyPluralMessages(locale, localeData))
         }
       }
     }

--- a/src/renderer/i18n/plurals.js
+++ b/src/renderer/i18n/plurals.js
@@ -11,6 +11,21 @@
 // The order translations are written in, as used by CLDR and Weblate.
 const PLURAL_CATEGORY_ORDER = ['zero', 'one', 'two', 'few', 'many', 'other']
 
+// These messages are only shown for counts of at least two. Translations may
+// therefore omit plural categories that cannot occur in that range, e.g. a
+// Polish translation can provide "few | many" instead of "one | few | many".
+export const MULTIPLE_ONLY_PLURAL_PATHS = [
+  'Close Window Confirmation.Message',
+  'Close Multiple Tabs Confirmation.Message',
+  'Close Multiple Tabs Confirmation.Close Tabs',
+  'Load Multiple Tabs Confirmation.Message',
+  'Load Multiple Tabs Confirmation.Load Tabs',
+  'Unload Multiple Tabs Confirmation.Message',
+  'Unload Multiple Tabs Confirmation.Unload Tabs',
+  'Context Menu.Close Multiple Tabs',
+  'Context Menu.Duplicate Multiple Tabs'
+]
+
 // Categories are collected by sampling instead of using
 // `resolvedOptions().pluralCategories`, because that also reports categories
 // that only apply to fractions, which never occur in our counts.
@@ -37,13 +52,72 @@ const PLURAL_CATEGORY_SAMPLES = (() => {
 /**
  * The plural categories a locale uses for the counts we display, in the order translations write them.
  * @param {string} locale
+ * @param {number} [minimum]
  * @returns {string[]}
  */
-function getPluralCategories(locale) {
+function getPluralCategories(locale, minimum = 0) {
   const pluralRules = new Intl.PluralRules(locale)
-  const categories = new Set(PLURAL_CATEGORY_SAMPLES.map(count => pluralRules.select(count)))
+  const categories = new Set(PLURAL_CATEGORY_SAMPLES
+    .filter(count => count >= minimum)
+    .map(count => pluralRules.select(count)))
 
   return PLURAL_CATEGORY_ORDER.filter(category => categories.has(category))
+}
+
+/**
+ * Expand abbreviated multiple-only messages to the locale's complete plural layout.
+ * @param {string} locale
+ * @param {Record<string, unknown>} messages
+ * @returns {Record<string, unknown>}
+ */
+export function expandMultipleOnlyPluralMessages(locale, messages) {
+  const categories = getPluralCategories(locale)
+  const multipleCategories = getPluralCategories(locale, 2)
+
+  if (categories.length === multipleCategories.length) return messages
+
+  for (const path of MULTIPLE_ONLY_PLURAL_PATHS) {
+    const keys = path.split('.')
+    const messageKey = keys.pop()
+    let parent = messages
+
+    for (const key of keys) {
+      if (parent[key] == null || typeof parent[key] !== 'object') {
+        parent = null
+        break
+      }
+      parent = parent[key]
+    }
+
+    if (parent == null || typeof parent[messageKey] !== 'string') continue
+
+    const forms = parent[messageKey].split(' | ')
+    if (forms.length !== multipleCategories.length) continue
+
+    const formsByCategory = new Map(multipleCategories.map((category, index) => [category, forms[index]]))
+    parent[messageKey] = categories
+      .map(category => formsByCategory.get(category) ?? forms[0])
+      .join(' | ')
+  }
+
+  return messages
+}
+
+/**
+ * Select a plural form without vue-i18n, for translations used in the main process.
+ * @param {string} locale
+ * @param {string} message
+ * @param {number} choice
+ * @returns {string | null}
+ */
+export function selectPluralForm(locale, message, choice) {
+  const forms = message.split(' | ')
+  if (forms.length === 1) return message
+
+  const categories = getPluralCategories(locale)
+  if (forms.length !== categories.length) return null
+
+  return forms[categories.indexOf(new Intl.PluralRules(locale).select(Math.abs(choice)))] ?? null
 }
 
 /**

--- a/static/locales/en-US.yaml
+++ b/static/locales/en-US.yaml
@@ -512,7 +512,7 @@ Settings:
     Load Missing Tab Icons: Load Missing Tab Icons
     Loading Missing Tab Icons: Loading Missing Tab Icons…
     No Missing Tab Icons: All supported tab icons are already loaded
-    Loaded Tab Icons: 'Missing tab icons loaded: {count}'
+    Loaded Tab Icons: 'Missing tab icon loaded: {count} | Missing tab icons loaded: {count}'
     Loaded Tab Icons With Failures: Loaded {loaded} tab icons; {failed} could not be loaded
     Show Tab Previews: Show Tab Previews
     Use Fixed Tab Width: Use Fixed Tab Width in Horizontal Mode

--- a/tests/unit/locale-plurals.test.mjs
+++ b/tests/unit/locale-plurals.test.mjs
@@ -4,7 +4,12 @@ import test from 'node:test'
 
 import { load as loadYaml } from 'js-yaml'
 
-import { createPluralRules } from '../../src/renderer/i18n/plurals.js'
+import {
+  createPluralRules,
+  expandMultipleOnlyPluralMessages,
+  MULTIPLE_ONLY_PLURAL_PATHS,
+  selectPluralForm
+} from '../../src/renderer/i18n/plurals.js'
 
 const localeUrl = new URL('../../static/locales/en-US.yaml', import.meta.url)
 const sourceDirUrl = new URL('../../src/', import.meta.url)
@@ -99,13 +104,6 @@ function splitCallArguments(source, openingParenthesisIndex) {
 }
 
 const pluralPaths = collectPluralPaths(locale)
-// These messages only describe bulk actions, so English never needs a singular
-// form. Translated locales can still provide plural forms for categories such
-// as Polish "few" and "many".
-const translatedLocalePluralPaths = [
-  'Close Multiple Tabs Confirmation.Message',
-  'Close Multiple Tabs Confirmation.Close Tabs'
-]
 const sourceFiles = await collectSourceFiles(sourceDirUrl)
 
 test('plural messages declare a singular and a plural form', () => {
@@ -124,7 +122,7 @@ test('plural messages declare a singular and a plural form', () => {
 })
 
 test('plural messages are translated with a plural choice', async () => {
-  const pluralPathSet = new Set([...pluralPaths, ...translatedLocalePluralPaths])
+  const pluralPathSet = new Set([...pluralPaths, ...MULTIPLE_ONLY_PLURAL_PATHS])
   const callPattern = /\$?t\(\s*(['"])(.+?)\1/gs
 
   for (const file of sourceFiles) {
@@ -143,6 +141,46 @@ test('plural messages are translated with a plural choice', async () => {
       )
     }
   }
+})
+
+test('multiple-only messages can omit unreachable plural categories', () => {
+  const messages = {
+    'Close Multiple Tabs Confirmation': {
+      Message: 'few | many'
+    },
+    Global: {
+      Counts: {
+        'Comment Count': 'one | other'
+      }
+    }
+  }
+
+  expandMultipleOnlyPluralMessages('pl', messages)
+
+  assert.equal(messages['Close Multiple Tabs Confirmation'].Message, 'few | few | many')
+  assert.equal(messages.Global.Counts['Comment Count'], 'one | other')
+  assert.equal(selectPluralForm('pl', messages['Close Multiple Tabs Confirmation'].Message, 2), 'few')
+  assert.equal(selectPluralForm('pl', messages['Close Multiple Tabs Confirmation'].Message, 5), 'many')
+})
+
+test('multiple-only expansion respects categories reachable above one', () => {
+  const englishMessages = {
+    'Close Multiple Tabs Confirmation': {
+      Message: 'multiple'
+    }
+  }
+  const russianMessages = {
+    'Close Multiple Tabs Confirmation': {
+      Message: 'one | few | many'
+    }
+  }
+
+  expandMultipleOnlyPluralMessages('en-US', englishMessages)
+  expandMultipleOnlyPluralMessages('ru', russianMessages)
+
+  assert.equal(englishMessages['Close Multiple Tabs Confirmation'].Message, 'multiple | multiple')
+  assert.equal(russianMessages['Close Multiple Tabs Confirmation'].Message, 'one | few | many')
+  assert.equal(selectPluralForm('ru', russianMessages['Close Multiple Tabs Confirmation'].Message, 21), 'one')
 })
 
 /** vue-i18n's built-in rule, which our rules fall back to. */


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Make sure to follow the contributing guidelines. -->
<!-- Important note, we may remove your pull request if you do not use this provided PR template correctly. -->
<!-- Agent instructions: Preserve every heading, comment, and marker in this template. Never remove or rewrite the release-note-category:start/end, release-note:start/end, or release-note-image:start/end marker pairs. Never remove or rewrite the Release note images section; leave its contents for a human. -->

## Pull Request Type
<!-- Please select what type of pull request this is: [x] -->
- [x] Bugfix
- [ ] Feature Implementation
- [ ] Documentation
- [ ] Other

## Related issue
<!-- Please link the issue your pull request is referring to. -->
<!-- If this pull request fully resolves the relevant issue, put "closes" before the issue number. -->
<!-- Example: "closes #123456". -->

Follow-up to #718 and https://github.com/OpenTubeX/OpenTubeX/pull/589#issuecomment-5288005380

## Description
<!-- Please write a clear and concise description of what the pull request does. -->

Bulk-count English strings such as “Load {count} Tabs” are naturally always plural, but other languages still distinguish plural categories within counts above one. The existing translation API required complete forms such as Polish `one | few | many`, even though the singular form could never be displayed, and several counter-bearing call sites did not request plural selection at all.

Register the translations that are guaranteed to receive counts of at least two and expand their locale-specific reachable forms into vue-i18n’s complete internal layout when locales load. Polish translators can now write `few | many` for those strings without changing the meaning of existing ordinary two-form `one | other` translations.

This also wires plural choices through load/unload confirmations, the native multi-tab window confirmation, translated context-menu counters, and fixed search-engine limits. The missing-tab-icon success message now has ordinary singular and plural English forms because its count may be one.

## Release note category
<!-- Select exactly one category. Every pull request must select one. -->
<!-- Select "Not noteworthy" when the pull request fixes a bug in or improves functionality that has not yet appeared in a stable release. -->
<!-- release-note-category:start -->
- [x] Not noteworthy
- [ ] Highlights
- [ ] More improvements
- [ ] Fixed bugs
<!-- release-note-category:end -->

## Release note
<!-- Required unless "Not noteworthy" is selected. -->
<!-- Write one concise, user-facing entry without a leading bullet. -->
<!-- release-note:start -->

<!-- release-note:end -->

## Release note images
<!-- Human-only: Agents must preserve this entire section and leave it empty. -->
<!-- Optional. Paste one or more Markdown images or HTML image tags here. -->
<!-- The release notes will use an HTML image tag and limit images taller than 300 pixels. -->
<!-- release-note-image:start -->

<!-- release-note-image:end -->

## Testing
<!-- How can reviewers verify that the PR produces correct results? -->
<!-- Please provide instructions so that others can ensure that your pull request would produce correct results. For examples see, https://github.com/FreeTubeApp/FreeTube/pull/5743, https://github.com/FreeTubeApp/FreeTube/pull/7349, https://github.com/FreeTubeApp/FreeTube/pull/5125, https://github.com/FreeTubeApp/FreeTube/pull/7338 -->
<!-- Agent instructions: Only write human-facing steps that explain how to verify the change while running this branch in dev mode. Include expected results and, when applicable, helpful console snippets for interactive verification. Do not include automated checks, commands, results, pass counts, or CI status. -->

1. Give one of the registered Polish bulk-tab messages two forms in the order `few | many`, for example `Załaduj {count} karty | Załaduj {count} kart`.
2. In dev mode, trigger that action for two tabs and then five tabs. The first prompt should use `karty`; the second should use `kart`.
3. Verify the same behavior in the close, load, unload, native close-window, and tab context-menu flows.
4. Switch back to English. All bulk-tab messages should retain their existing naturally plural wording.
5. Load exactly one missing tab icon and then multiple missing tab icons. The success toast should use “icon” for one and “icons” for multiple.

## Additional context
<!-- Add any other context about the pull request here. -->

Plural categories that remain reachable above one are not omitted. For example, Russian still requires its `one` form because counts such as 21 use that category.

Prepared with Codex.