### PR TITLE
fix(subscriptions): refresh reused video cards

### DIFF
--- a/e2e/tests/offline/subscriptions-feed.spec.mjs
+++ b/e2e/tests/offline/subscriptions-feed.spec.mjs
@@ -56,6 +56,7 @@ const seed = {
         }),
         feedVideo('aaaaaaaaaa2', 'Video A older', CHANNEL_A, now - 3 * HOUR),
         feedVideo('aaaaaaaaaa3', 'Upcoming premiere video', CHANNEL_A, now + 30 * 24 * HOUR, {
+          isUpcoming: true,
           premiereDate: new Date(now + 30 * 24 * HOUR).toISOString()
         })
       ],
@@ -294,6 +295,51 @@ test.describe('subscriptions feed with upcoming premieres shown', () => {
     await reminderButton.click()
     await expect(upcomingPremiere.getByRole('button', { name: 'Notification on' }))
       .toHaveAttribute('aria-pressed', 'true')
+  })
+
+  test('updates a reused upcoming card when refreshed premiere state changes', async ({ page }) => {
+    await goTo(page, 'subscriptions')
+
+    const upcomingPremiere = page.locator('.ft-list-video').filter({ hasText: 'Upcoming premiere video' })
+    await expect(upcomingPremiere.locator('.videoDuration')).toHaveText('Upcoming')
+    await expect(upcomingPremiere.getByRole('button', { name: 'Notify me' })).toBeVisible()
+
+    const updateCachedPremiere = async (updates) => {
+      await page.evaluate(async ({ channelId, updates }) => {
+        const app = document.querySelector('#app').__vue_app__
+        const store = app.config.globalProperties.$store
+        const videos = store.getters.getVideoCache[channelId].videos.map(video => {
+          if (video.videoId !== 'aaaaaaaaaa3') return video
+
+          const updatedVideo = { ...video, ...updates }
+          delete updatedVideo.premiereDate
+          return updatedVideo
+        })
+
+        await store.dispatch('updateSubscriptionVideosCacheByChannel', { channelId, videos })
+        window.dispatchEvent(new CustomEvent('opentubex-subscription-refresh-channel', {
+          detail: { tab: 'videos' }
+        }))
+      }, { channelId: CHANNEL_A, updates })
+    }
+
+    await updateCachedPremiere({
+      isUpcoming: false,
+      isPremiere: true,
+      liveNow: true,
+      lengthSeconds: ''
+    })
+
+    await expect(upcomingPremiere.locator('.videoDuration')).toHaveText('Premiere')
+    await expect(upcomingPremiere.getByRole('button', { name: /Notify me|Notification on/ })).toHaveCount(0)
+
+    await updateCachedPremiere({
+      isPremiere: false,
+      liveNow: false,
+      lengthSeconds: 702
+    })
+
+    await expect(upcomingPremiere.locator('.videoDuration')).toHaveText('11:42')
   })
 
   test('cleans up repeated live-reminder subscriptions independently', async ({ app, page }) => {

--- a/e2e/tests/offline/subscriptions-feed.spec.mjs
+++ b/e2e/tests/offline/subscriptions-feed.spec.mjs
@@ -303,6 +303,8 @@ test.describe('subscriptions feed with upcoming premieres shown', () => {
     const upcomingPremiere = page.locator('.ft-list-video').filter({ hasText: 'Upcoming premiere video' })
     await expect(upcomingPremiere.locator('.videoDuration')).toHaveText('Upcoming')
     await expect(upcomingPremiere.getByRole('button', { name: 'Notify me' })).toBeVisible()
+    await upcomingPremiere.evaluate(element => { element.dataset.reuseMarker = 'upcoming-premiere' })
+    const reusedCard = page.locator('[data-reuse-marker="upcoming-premiere"]')
 
     const updateCachedPremiere = async (updates) => {
       await page.evaluate(async ({ channelId, updates }) => {
@@ -330,6 +332,7 @@ test.describe('subscriptions feed with upcoming premieres shown', () => {
       lengthSeconds: ''
     })
 
+    await expect(reusedCard).toBeVisible()
     await expect(upcomingPremiere.locator('.videoDuration')).toHaveText('Premiere')
     await expect(upcomingPremiere.getByRole('button', { name: /Notify me|Notification on/ })).toHaveCount(0)
 
@@ -339,6 +342,7 @@ test.describe('subscriptions feed with upcoming premieres shown', () => {
       lengthSeconds: 702
     })
 
+    await expect(reusedCard).toBeVisible()
     await expect(upcomingPremiere.locator('.videoDuration')).toHaveText('11:42')
   })
 

--- a/src/renderer/components/FtListVideo/FtListVideo.vue
+++ b/src/renderer/components/FtListVideo/FtListVideo.vue
@@ -1582,7 +1582,9 @@ function handleExtraThumbnailAction() {
 }
 
 function parseVideoData() {
+  uploadedTime.value = ''
   uploadedTimeIsRelative.value = false
+  published.value = undefined
   id.value = props.data.videoId
   title.value = props.data.title
 

--- a/src/renderer/components/FtListVideo/FtListVideo.vue
+++ b/src/renderer/components/FtListVideo/FtListVideo.vue
@@ -1843,7 +1843,7 @@ function onDragStart(event) {
   }
 }
 
-parseVideoData()
+watch(() => props.data, parseVideoData, { immediate: true })
 
 showDeArrowTitle.value = useDeArrowTitles.value
 showDeArrowThumbnail.value = useDeArrowThumbnails.value


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Make sure to follow the contributing guidelines. -->
<!-- Important note, we may remove your pull request if you do not use this provided PR template correctly. -->
<!-- Agent instructions: Preserve every heading, comment, and marker in this template. Never remove or rewrite the release-note-category:start/end, release-note:start/end, or release-note-image:start/end marker pairs. Never remove or rewrite the Release note images section; leave its contents for a human. -->

## Pull Request Type
<!-- Please select what type of pull request this is: [x] -->
- [x] Bugfix
- [ ] Feature Implementation
- [ ] Documentation
- [ ] Other

## Related issue
<!-- Please link the issue your pull request is referring to. -->
<!-- If this pull request fully resolves the relevant issue, put "closes" before the issue number. -->
<!-- Example: "closes #123456". -->

Reported directly.

## Description
<!-- Please write a clear and concise description of what the pull request does. -->

Subscription refreshes reuse video-card components for stable feed entries. Those cards parsed their input only when first created, so an upcoming video could keep displaying "Upcoming" after the cache had already changed it to a running premiere or finished video. This also made the correctly expired notification action look inconsistent with the stale label.

Re-parse a card whenever its data object changes, while retaining the existing immediate initialization. Add an offline regression covering the complete Upcoming → Premiere → finished transition on the same card.

## Release note category
<!-- Select exactly one category. Every pull request must select one. -->
<!-- Select "Not noteworthy" when the pull request fixes a bug in or improves functionality that has not yet appeared in a stable release. -->
<!-- release-note-category:start -->
- [ ] Not noteworthy
- [ ] Highlights
- [ ] More improvements
- [x] Fixed bugs
<!-- release-note-category:end -->

## Release note
<!-- Required unless "Not noteworthy" is selected. -->
<!-- Write one concise, user-facing entry without a leading bullet. -->
<!-- release-note:start -->
Subscription video cards now update their upcoming, premiere, and finished states after refreshes.
<!-- release-note:end -->

## Release note images
<!-- Human-only: Agents must preserve this entire section and leave it empty. -->
<!-- Optional. Paste one or more Markdown images or HTML image tags here. -->
<!-- The release notes will use an HTML image tag and limit images taller than 300 pixels. -->
<!-- release-note-image:start -->

<!-- release-note-image:end -->

## Testing
<!-- How can reviewers verify that the PR produces correct results? -->
<!-- Please provide instructions so that others can ensure that your pull request would produce correct results. For examples see, https://github.com/FreeTubeApp/FreeTube/pull/5743, https://github.com/FreeTubeApp/FreeTube/pull/7349, https://github.com/FreeTubeApp/FreeTube/pull/5125, https://github.com/FreeTubeApp/FreeTube/pull/7338 -->
<!-- Agent instructions: Only write human-facing steps that explain how to verify the change while running this branch in dev mode. Include expected results and, when applicable, helpful console snippets for interactive verification. Do not include automated checks, commands, results, pass counts, or CI status. -->

1. Open Subscriptions while a future scheduled premiere is visible and confirm its card says "Upcoming" and offers the notification action.
2. Keep the subscription task open and refresh after the premiere starts. Confirm the same card says "Premiere" and no longer offers the expired notification action.
3. Refresh again after the premiere finishes. Confirm the card displays the video's duration instead of "Upcoming" or "Premiere."

## Additional context
<!-- Add any other context about the pull request here. -->

The reporter's persisted profile showed the same video cached successively as upcoming, running premiere, and finished while the mounted card continued showing its initial upcoming state.