### PR TITLE
fix(player): keep Shorts loading during rapid navigation

### DIFF
--- a/e2e/tests/offline/watch-page.spec.mjs
+++ b/e2e/tests/offline/watch-page.spec.mjs
@@ -113,6 +113,43 @@ test.describe('Shorts transcript navigation', () => {
     await expect(transcriptPanel).toHaveCount(0)
     await expect(transcriptButton).toHaveCount(0)
   })
+
+  test('keeps loading Shorts when another player keeps the shared caption factory alive', async ({ app, page }) => {
+    await mockPlayableWatchPage(app, page, { captionTranslations: true })
+
+    const backgroundTab = await page.evaluate(() => window.ftElectron.tabs.create({
+      route: '/watch/background-captioned-video',
+      title: 'Background captioned video',
+      makeActive: false,
+      preloadInBackground: true
+    }))
+    const backgroundContent = page.locator(`.tabContent[data-tab-id="${backgroundTab.id}"]`)
+    const backgroundPlayer = backgroundContent.locator('.ftVideoPlayer')
+    await expect(backgroundPlayer).toHaveCount(1, { timeout: 30_000 })
+    await expect.poll(() => backgroundPlayer.evaluate(element => {
+      return element.ui?.getControls().getPlayer().getAssetUri() ?? ''
+    })).not.toBe('')
+
+    await page.locator(sel.searchInput)
+      .fill(`https://www.youtube.com/shorts/${CAPTIONED_SHORT_IDS[0]}`)
+    await page.locator(sel.searchInput).press('Enter')
+    await expect(page).toHaveURL(new RegExp(`#\\/watch\\/${CAPTIONED_SHORT_IDS[0]}\\?short=true`))
+    await waitForPlayback(page)
+
+    const rendererErrors = []
+    page.on('pageerror', error => rendererErrors.push(error.message))
+    page.on('console', message => {
+      if (message.type() === 'error') rendererErrors.push(message.text())
+    })
+
+    await page.locator('.shortsNavigationButton').last().click()
+    await expect(page).toHaveURL(new RegExp(`#\\/watch\\/${CAPTIONED_SHORT_IDS[1]}\\?short=true`))
+    await waitForPlayback(page)
+
+    expect(rendererErrors.filter(error => (
+      error.includes('getTextTracks') || error.includes('failed to render')
+    ))).toEqual([])
+  })
 })
 
 test('a background watch tab stays loading until its cached avatar is ready', async ({ app, page }) => {

--- a/src/renderer/components/ft-shaka-video-player/ft-shaka-video-player.js
+++ b/src/renderer/components/ft-shaka-video-player/ft-shaka-video-player.js
@@ -6057,14 +6057,18 @@ export default defineComponent({
       /** @implements {shaka.extern.IUIElement.Factory} */
       class CaptionSelectionFactory {
         create(rootElement, controls) {
+          // Shaka's factory registry is process-global, so this factory can be
+          // invoked briefly while another player instance is being created.
+          // Always use the player belonging to these controls instead of the
+          // component's player, which may already have been destroyed.
           return new CaptionSelection(
             events,
             () => captionSettings.value,
             updateCaptionAppearance,
             resetCaptionAppearance,
             () => props.captionTranslations,
-            caption => Boolean(findMatchingTextTrack(player.getTextTracks(), caption)?.active),
-            selectCaptionTranslation,
+            caption => Boolean(findMatchingTextTrack(controls.getPlayer().getTextTracks(), caption)?.active),
+            caption => selectCaptionTranslation(caption, controls.getPlayer()),
             rootElement,
             controls
           )
@@ -6079,15 +6083,16 @@ export default defineComponent({
 
     /**
      * @param {{ url: string, label: string, language: string, mimeType: string }} caption
+     * @param {shaka.Player} captionPlayer
      * @returns {Promise<boolean>}
      */
-    async function selectCaptionTranslation(caption) {
+    async function selectCaptionTranslation(caption, captionPlayer) {
       const selectionGeneration = ++captionTranslationSelectionGeneration
-      let track = findMatchingTextTrack(player.getTextTracks(), caption)
+      let track = findMatchingTextTrack(captionPlayer.getTextTracks(), caption)
 
       if (!track) {
         try {
-          track = await player.addTextTrackAsync(
+          track = await captionPlayer.addTextTrackAsync(
             caption.url,
             caption.language,
             'captions',
@@ -6101,11 +6106,14 @@ export default defineComponent({
         }
       }
 
-      if (selectionGeneration !== captionTranslationSelectionGeneration) {
+      if (
+        selectionGeneration !== captionTranslationSelectionGeneration ||
+        captionPlayer !== player
+      ) {
         return false
       }
 
-      player.selectTextTrack(track)
+      captionPlayer.selectTextTrack(track)
       return true
     }
 


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Make sure to follow the contributing guidelines. -->
<!-- Important note, we may remove your pull request if you do not use this provided PR template correctly. -->
<!-- Agent instructions: Preserve every heading, comment, and marker in this template. Never remove or rewrite the release-note-category:start/end, release-note:start/end, or release-note-image:start/end marker pairs. Never remove or rewrite the Release note images section; leave its contents for a human. -->

## Pull Request Type
<!-- Please select what type of pull request this is: [x] -->
- [x] Bugfix
- [ ] Feature Implementation
- [ ] Documentation
- [ ] Other

## Related issue
<!-- Please link the issue your pull request is referring to. -->
<!-- If this pull request fully resolves the relevant issue, put "closes" before the issue number. -->
<!-- Example: "closes #123456". -->

## Description
<!-- Please write a clear and concise description of what the pull request does. -->

Switching between Shorts quickly could make the active tab fail to render and leave later videos buffering indefinitely. Shaka's process-global caption factory could briefly outlive the player instance that registered it, then read text tracks from that destroyed player while the next player was being created.

Caption controls now use the player attached to the Shaka controls that invoked the factory. Asynchronous translation selection is also discarded if navigation replaces that player. An offline regression test keeps a captioned player alive in a background tab while navigating between captioned Shorts, reproducing the shared-factory lifecycle.

## Release note category
<!-- Select exactly one category. Every pull request must select one. -->
<!-- Select "Not noteworthy" when the pull request fixes a bug in or improves functionality that has not yet appeared in a stable release. -->
<!-- release-note-category:start -->
- [ ] Not noteworthy
- [ ] Highlights
- [ ] More improvements
- [x] Fixed bugs
<!-- release-note-category:end -->

## Release note
<!-- Required unless "Not noteworthy" is selected. -->
<!-- Write one concise, user-facing entry without a leading bullet. -->
<!-- release-note:start -->
Fixed videos buffering indefinitely after switching between Shorts quickly.
<!-- release-note:end -->

## Release note images
<!-- Human-only: Agents must preserve this entire section and leave it empty. -->
<!-- Optional. Paste one or more Markdown images or HTML image tags here. -->
<!-- The release notes will use an HTML image tag and limit images taller than 300 pixels. -->
<!-- release-note-image:start -->

<!-- release-note-image:end -->

## Testing
<!-- How can reviewers verify that the PR produces correct results? -->
<!-- Please provide instructions so that others can ensure that your pull request would produce correct results. For examples see, https://github.com/FreeTubeApp/FreeTube/pull/5743, https://github.com/FreeTubeApp/FreeTube/pull/7349, https://github.com/FreeTubeApp/FreeTube/pull/5125, https://github.com/FreeTubeApp/FreeTube/pull/7338 -->
<!-- Agent instructions: Only write human-facing steps that explain how to verify the change while running this branch in dev mode. Include expected results and, when applicable, helpful console snippets for interactive verification. Do not include automated checks, commands, results, pass counts, or CI status. -->

1. Open a captioned video in one tab and leave it open in the background.
2. In the active tab, open the custom Shorts feed and switch between captioned Shorts quickly.
3. Confirm each Short loads and plays, later videos do not buffer indefinitely, and the console does not report `getTextTracks` errors or a logical tab render failure.

## Additional context
<!-- Add any other context about the pull request here. -->

The unrelated Invidious instance fallback and YouTube.js parser warnings in the original console log are not part of this failure. The fatal error was the stale caption factory dereferencing a null player.