### PR TITLE
fix(channel): keep relative video dates current

### DIFF
--- a/e2e/tests/offline/subscriptions-feed.spec.mjs
+++ b/e2e/tests/offline/subscriptions-feed.spec.mjs
@@ -250,6 +250,34 @@ test.describe('relative timestamp updates disabled', () => {
     await goTo(page, 'subscriptions')
     await expect(newestVideo.locator('.uploadedTime')).toHaveText('• 1 hour ago')
   })
+
+  test('uses the current time when a reused card receives new data', async ({ page }) => {
+    await goTo(page, 'trending')
+    await page.clock.install({ time: now })
+    await goTo(page, 'subscriptions')
+
+    const newestVideo = page.locator('.ft-list-video').filter({ hasText: 'Video B newest' })
+    await expect(newestVideo).toBeVisible()
+    await newestVideo.evaluate(element => { element.dataset.reuseMarker = 'relative-time' })
+
+    await page.clock.fastForward(2 * HOUR)
+    await page.evaluate(async ({ channelId, published }) => {
+      const app = document.querySelector('#app').__vue_app__
+      const store = app.config.globalProperties.$store
+      const videos = store.getters.getVideoCache[channelId].videos.map(video => ({
+        ...video,
+        published
+      }))
+
+      await store.dispatch('updateSubscriptionVideosCacheByChannel', { channelId, videos })
+      window.dispatchEvent(new CustomEvent('opentubex-subscription-refresh-channel', {
+        detail: { tab: 'videos' }
+      }))
+    }, { channelId: CHANNEL_B, published: now + 1.5 * HOUR })
+
+    await expect(page.locator('[data-reuse-marker="relative-time"]')).toBeVisible()
+    await expect(newestVideo.locator('.uploadedTime')).toHaveText('• 30 minutes ago')
+  })
 })
 
 test.describe('subscriptions feed with upcoming premieres shown', () => {

--- a/src/renderer/components/FtListVideo/FtListVideo.vue
+++ b/src/renderer/components/FtListVideo/FtListVideo.vue
@@ -494,13 +494,19 @@ const viewCount = ref(0)
 const uploadedTime = ref('')
 const uploadedTimeIsRelative = ref(false)
 const relativeTimeNow = useRelativeTimeClock()
+const relativeTimeDataLoadedAt = ref(Date.now())
 const lengthSeconds = ref(0)
 const duration = ref('')
 const description = ref('')
 const published = ref(undefined)
 const displayedUploadedTime = computed(() => {
   if (uploadedTimeIsRelative.value && published.value) {
-    return getRelativeTimeFromDate(published.value, false, true, relativeTimeNow.value)
+    return getRelativeTimeFromDate(
+      published.value,
+      false,
+      true,
+      Math.max(relativeTimeNow.value, relativeTimeDataLoadedAt.value)
+    )
   }
 
   return uploadedTime.value
@@ -1590,6 +1596,7 @@ function handleExtraThumbnailAction() {
 }
 
 function parseVideoData() {
+  relativeTimeDataLoadedAt.value = Date.now()
   uploadedTime.value = ''
   uploadedTimeIsRelative.value = false
   published.value = undefined

--- a/src/renderer/components/FtListVideo/FtListVideo.vue
+++ b/src/renderer/components/FtListVideo/FtListVideo.vue
@@ -495,18 +495,22 @@ const uploadedTime = ref('')
 const uploadedTimeIsRelative = ref(false)
 const relativeTimeNow = useRelativeTimeClock()
 const relativeTimeDataLoadedAt = ref(Date.now())
+const relativeTimeClockAtLoad = ref(relativeTimeNow.value)
 const lengthSeconds = ref(0)
 const duration = ref('')
 const description = ref('')
 const published = ref(undefined)
 const displayedUploadedTime = computed(() => {
   if (uploadedTimeIsRelative.value && published.value) {
-    return getRelativeTimeFromDate(
-      published.value,
-      false,
-      true,
-      Math.max(relativeTimeNow.value, relativeTimeDataLoadedAt.value)
-    )
+    const clockNow = relativeTimeNow.value
+    // Use the load-time clock while the shared tick is unchanged so reused cards
+    // aren't formatted against a stale value. Follow later ticks, including
+    // backward clock corrections.
+    const now = clockNow === relativeTimeClockAtLoad.value
+      ? relativeTimeDataLoadedAt.value
+      : clockNow
+
+    return getRelativeTimeFromDate(published.value, false, true, now)
   }
 
   return uploadedTime.value
@@ -1597,6 +1601,7 @@ function handleExtraThumbnailAction() {
 
 function parseVideoData() {
   relativeTimeDataLoadedAt.value = Date.now()
+  relativeTimeClockAtLoad.value = relativeTimeNow.value
   uploadedTime.value = ''
   uploadedTimeIsRelative.value = false
   published.value = undefined


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Make sure to follow the contributing guidelines. -->
<!-- Important note, we may remove your pull request if you do not use this provided PR template correctly. -->
<!-- Agent instructions: Preserve every heading, comment, and marker in this template. Never remove or rewrite the release-note-category:start/end, release-note:start/end, or release-note-image:start/end marker pairs. Never remove or rewrite the Release note images section; leave its contents for a human. -->

## Pull Request Type
<!-- Please select what type of pull request this is: [x] -->
- [x] Bugfix
- [ ] Feature Implementation
- [ ] Documentation
- [ ] Other

## Related issue
<!-- Please link the issue your pull request is referring to. -->
<!-- If this pull request fully resolves the relevant issue, put "closes" before the issue number. -->
<!-- Example: "closes #123456". -->

## Description
<!-- Please write a clear and concise description of what the pull request does. -->
Channel video cards could initially show stale relative upload dates and then jump to the correct values when the shared clock refreshed. Reused cards now use the time their current data was loaded as a lower bound, so newly received video data is formatted against the current time immediately.

## Release note category
<!-- Select exactly one category. Every pull request must select one. -->
<!-- Select "Not noteworthy" when the pull request fixes a bug in or improves functionality that has not yet appeared in a stable release. -->
<!-- release-note-category:start -->
- [x] Not noteworthy
- [ ] Highlights
- [ ] More improvements
- [ ] Fixed bugs
<!-- release-note-category:end -->

## Release note
<!-- Required unless "Not noteworthy" is selected. -->
<!-- Write one concise, user-facing entry without a leading bullet. -->
<!-- release-note:start -->

<!-- release-note:end -->

## Release note images
<!-- Human-only: Agents must preserve this entire section and leave it empty. -->
<!-- Optional. Paste one or more Markdown images or HTML image tags here. -->
<!-- The release notes will use an HTML image tag and limit images taller than 300 pixels. -->
<!-- release-note-image:start -->

<!-- release-note-image:end -->

## Testing
<!-- How can reviewers verify that the PR produces correct results? -->
<!-- Please provide instructions so that others can ensure that your pull request would produce correct results. For examples see, https://github.com/FreeTubeApp/FreeTube/pull/5743, https://github.com/FreeTubeApp/FreeTube/pull/7349, https://github.com/FreeTubeApp/FreeTube/pull/5125, https://github.com/FreeTubeApp/FreeTube/pull/7338 -->
<!-- Agent instructions: Only write human-facing steps that explain how to verify the change while running this branch in dev mode. Include expected results and, when applicable, helpful console snippets for interactive verification. Do not include automated checks, commands, results, pass counts, or CI status. -->

## Additional context
<!-- Add any other context about the pull request here. -->
The stale value came from the relative-time clock belonging to a card instance that Vue reused for newly loaded video data.
