### PR TITLE
fix(live-chat): stabilize scrolling during reflows

### DIFF
--- a/src/renderer/components/WatchVideoLiveChat/WatchVideoLiveChat.vue
+++ b/src/renderer/components/WatchVideoLiveChat/WatchVideoLiveChat.vue
@@ -1122,9 +1122,42 @@ function stopScrollingToBottom() {
  */
 function handleLiveChatPointerDown(event) {
   const clickedScrollbar = event.target instanceof Element && event.target.closest('.os-scrollbar-vertical') !== null
-  if (event.pointerType === 'touch' || event.button === 1 || clickedScrollbar) {
+  if (event.button === 1 || clickedScrollbar) {
     stopScrollingToBottom()
+    return
   }
+
+  if (event.pointerType !== 'touch') {
+    return
+  }
+
+  const element = event.currentTarget
+  const pointerId = event.pointerId
+  const startX = event.clientX
+  const startY = event.clientY
+
+  const finish = (finishEvent) => {
+    if (finishEvent.pointerId !== pointerId) {
+      return
+    }
+
+    element.removeEventListener('pointermove', handlePointerMove)
+    element.removeEventListener('pointerup', finish)
+    element.removeEventListener('pointercancel', finish)
+  }
+
+  const handlePointerMove = (moveEvent) => {
+    if (moveEvent.pointerId !== pointerId || Math.hypot(moveEvent.clientX - startX, moveEvent.clientY - startY) < 6) {
+      return
+    }
+
+    stopScrollingToBottom()
+    finish(moveEvent)
+  }
+
+  element.addEventListener('pointermove', handlePointerMove, { passive: true })
+  element.addEventListener('pointerup', finish, { passive: true })
+  element.addEventListener('pointercancel', finish, { passive: true })
 }
 
 /**

--- a/src/renderer/components/WatchVideoLiveChat/WatchVideoLiveChat.vue
+++ b/src/renderer/components/WatchVideoLiveChat/WatchVideoLiveChat.vue
@@ -285,7 +285,7 @@
           class="liveChatComments"
           :style="{ blockSize: chatHeight }"
           tabindex="0"
-          @pointerdown="stopScrollingToBottom"
+          @pointerdown="handleLiveChatPointerDown"
           @scroll.passive="onScroll"
           @scrollend="onScrollEnd"
           @keydown="handleLiveChatScrollKeydown"
@@ -429,7 +429,7 @@ import store from '../../store/index'
 import { formatNumber } from '../../helpers/utils'
 import { getRandomColorClass } from '../../helpers/colors'
 import { getLocalVideoInfo, parseLocalTextRuns } from '../../helpers/api/local'
-import { restoreOverlayScrollTop } from '../../helpers/overlayScrollbars'
+import { clampOverlayScrollTop, restoreOverlayScrollTop } from '../../helpers/overlayScrollbars'
 import {
   createCoalescingPoller,
   isReplaySeek,
@@ -698,7 +698,10 @@ watch(commentsRef, (element, _previous, onCleanup) => {
     return
   }
 
+  const contentElement = element.querySelector('.liveChatCommentList')
   const resizeObserver = new ResizeObserver(() => {
+    clampOverlayScrollTop(element, contentElement)
+
     if (!stayAtBottom) {
       return
     }
@@ -707,6 +710,9 @@ watch(commentsRef, (element, _previous, onCleanup) => {
   })
 
   resizeObserver.observe(element)
+  if (contentElement !== null) {
+    resizeObserver.observe(contentElement)
+  }
   onCleanup(() => {
     resizeObserver.disconnect()
   })
@@ -1065,6 +1071,10 @@ function updateLiveChatFilter(value) {
 
 function onScroll() {
   const liveChatComments = commentsRef.value
+  if (liveChatComments === null) {
+    return
+  }
+
   const isAtBottom = liveChatComments.scrollHeight - liveChatComments.scrollTop - liveChatComments.clientHeight <= 1
 
   if (isAtBottom) {
@@ -1102,6 +1112,19 @@ function stopScrollingToBottom() {
 
   isScrollingToBottom = false
   stayAtBottom = false
+}
+
+/**
+ * Clicking links or selecting text in chat must not disable auto-follow. Pointer
+ * input only expresses scroll intent when it pans the viewport or uses its
+ * scrollbar; wheel and keyboard scrolling have their own handlers.
+ * @param {PointerEvent} event
+ */
+function handleLiveChatPointerDown(event) {
+  const clickedScrollbar = event.target instanceof Element && event.target.closest('.os-scrollbar-vertical') !== null
+  if (event.pointerType === 'touch' || event.button === 1 || clickedScrollbar) {
+    stopScrollingToBottom()
+  }
 }
 
 /**
@@ -1149,11 +1172,13 @@ function scrollToBottom(behavior = scrollingBehaviour.value) {
   }
 
   const top = liveChatComments.scrollHeight
+  const contentElement = liveChatComments.querySelector('.liveChatCommentList')
 
   if (behavior === 'instant' || behavior === 'auto') {
     // Force OverlayScrollbars to accept the new end offset; a plain scrollTo can
     // lose to its restored pre-teleport / pre-trim position.
     restoreOverlayScrollTop(liveChatComments, top)
+    clampOverlayScrollTop(liveChatComments, contentElement)
     scrollToLiveHoldTimer = setTimeout(() => {
       scrollToLiveHoldTimer = null
       if (commentsRef.value !== liveChatComments) {
@@ -1162,6 +1187,7 @@ function scrollToBottom(behavior = scrollingBehaviour.value) {
 
       if (stayAtBottom) {
         restoreOverlayScrollTop(liveChatComments, liveChatComments.scrollHeight)
+        clampOverlayScrollTop(liveChatComments, contentElement)
       }
 
       isScrollingToBottom = false


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Make sure to follow the contributing guidelines. -->
<!-- Important note, we may remove your pull request if you do not use this provided PR template correctly. -->
<!-- Agent instructions: Preserve every heading, comment, and marker in this template. Never remove or rewrite the release-note-category:start/end, release-note:start/end, or release-note-image:start/end marker pairs. Never remove or rewrite the Release note images section; leave its contents for a human. -->

## Pull Request Type
<!-- Please select what type of pull request this is: [x] -->
- [x] Bugfix
- [ ] Feature Implementation
- [ ] Documentation
- [ ] Other

## Related issue
<!-- Please link the issue your pull request is referring to. -->
<!-- If this pull request fully resolves the relevant issue, put "closes" before the issue number. -->
<!-- Example: "closes #123456". -->

## Description
<!-- Please write a clear and concise description of what the pull request does. -->
The live chat observed only its viewport size, so message-list reflows and window resizing could leave it behind the live edge or parked over empty space. Observe both the viewport and rendered message list, clamp against the real content end, and preserve auto-follow through reflows. This also prevents ordinary chat clicks from disabling follow and guards late scroll events during teardown.

## Release note category
<!-- Select exactly one category. Every pull request must select one. -->
<!-- Select "Not noteworthy" when the pull request fixes a bug in or improves functionality that has not yet appeared in a stable release. -->
<!-- release-note-category:start -->
- [ ] Not noteworthy
- [ ] Highlights
- [ ] More improvements
- [x] Fixed bugs
<!-- release-note-category:end -->

## Release note
<!-- Required unless "Not noteworthy" is selected. -->
<!-- Write one concise, user-facing entry without a leading bullet. -->
<!-- release-note:start -->
Fixed that live chat scrolled to live status was not respected. New chat messages are now shown immediately.
<!-- release-note:end -->

## Release note images
<!-- Human-only: Agents must preserve this entire section and leave it empty. -->
<!-- Optional. Paste one or more Markdown images or HTML image tags here. -->
<!-- The release notes will use an HTML image tag and limit images taller than 300 pixels. -->
<!-- release-note-image:start -->

<!-- release-note-image:end -->

## Testing
<!-- How can reviewers verify that the PR produces correct results? -->
<!-- Please provide instructions so that others can ensure that your pull request would produce correct results. For examples see, https://github.com/FreeTubeApp/FreeTube/pull/5743, https://github.com/FreeTubeApp/FreeTube/pull/7349, https://github.com/FreeTubeApp/FreeTube/pull/5125, https://github.com/FreeTubeApp/FreeTube/pull/7338 -->
<!-- Agent instructions: Only write human-facing steps that explain how to verify the change while running this branch in dev mode. Include expected results and, when applicable, helpful console snippets for interactive verification. Do not include automated checks, commands, results, pass counts, or CI status. -->
Open a video with active chat or chat replay and leave the chat at its live edge. Let new messages arrive and repeatedly resize the window narrower and wider. The chat should remain at the latest message without empty space below it. Scroll upward manually and confirm auto-follow stops and the scroll-to-bottom button appears.

## Additional context
<!-- Add any other context about the pull request here. -->
Follow-up to #734 after tracing the rendered viewport and message-list dimensions during reproduction.
