### PR TITLE
fix(playlist): correct watched styling and initial scrolling

### DIFF
--- a/src/renderer/components/WatchVideoPlaylist/WatchVideoPlaylist.css
+++ b/src/renderer/components/WatchVideoPlaylist/WatchVideoPlaylist.css
@@ -290,8 +290,7 @@
   display: grid;
   grid-template-columns: 30px 1fr;
   align-items: center;
-  content-visibility: auto;
-  contain-intrinsic-block-size: auto 72px;
+  border-radius: calc(8px * var(--ui-roundness));
   transition: background 0.2s ease-out;
 }
 

--- a/src/renderer/scss-partials/_ft-list-item.scss
+++ b/src/renderer/scss-partials/_ft-list-item.scss
@@ -58,6 +58,10 @@ $watched-transition-duration: 0.5s;
   &.watched {
     background-color: var(--bg-color);
 
+    @include is-watch-playlist-item {
+      background-color: transparent;
+    }
+
     @include low-contrast-when-watched(var(--primary-text-color));
 
     .thumbnailImage {


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Make sure to follow the contributing guidelines. -->
<!-- Important note, we may remove your pull request if you do not use this provided PR template correctly. -->
<!-- Agent instructions: Preserve every heading, comment, and marker in this template. Never remove or rewrite the release-note-category:start/end, release-note:start/end, or release-note-image:start/end marker pairs. Never remove or rewrite the Release note images section; leave its contents for a human. -->

## Pull Request Type
<!-- Please select what type of pull request this is: [x] -->
- [x] Bugfix
- [ ] Feature Implementation
- [ ] Documentation
- [ ] Other

## Related issue
<!-- Please link the issue your pull request is referring to. -->
<!-- If this pull request fully resolves the relevant issue, put "closes" before the issue number. -->
<!-- Example: "closes #123456". -->

## Description
<!-- Please write a clear and concise description of what the pull request does. -->
Watched videos in the playlist side panel and fullscreen dock were given a background across the entire row, and long playlists could initially scroll to the wrong position near their end because offscreen rows used estimated heights.

This keeps the watched treatment on the thumbnail, rounds playlist hover highlights according to the configured UI roundness, and uses the rows' real layout heights so the current video is positioned reliably.

## Release note category
<!-- Select exactly one category. Every pull request must select one. -->
<!-- Select "Not noteworthy" when the pull request fixes a bug in or improves functionality that has not yet appeared in a stable release. -->
<!-- release-note-category:start -->
- [ ] Not noteworthy
- [ ] Highlights
- [ ] More improvements
- [x] Fixed bugs
<!-- release-note-category:end -->

## Release note
<!-- Required unless "Not noteworthy" is selected. -->
<!-- Write one concise, user-facing entry without a leading bullet. -->
<!-- release-note:start -->
Fixed watched styling, hover rounding, and initial scrolling in playlist panels.
<!-- release-note:end -->

## Release note images
<!-- Human-only: Agents must preserve this entire section and leave it empty. -->
<!-- Optional. Paste one or more Markdown images or HTML image tags here. -->
<!-- The release notes will use an HTML image tag and limit images taller than 300 pixels. -->
<!-- release-note-image:start -->

<!-- release-note-image:end -->

## Testing
<!-- How can reviewers verify that the PR produces correct results? -->
<!-- Please provide instructions so that others can ensure that your pull request would produce correct results. For examples see, https://github.com/FreeTubeApp/FreeTube/pull/5743, https://github.com/FreeTubeApp/FreeTube/pull/7349, https://github.com/FreeTubeApp/FreeTube/pull/5125, https://github.com/FreeTubeApp/FreeTube/pull/7338 -->
<!-- Agent instructions: Only write human-facing steps that explain how to verify the change while running this branch in dev mode. Include expected results and, when applicable, helpful console snippets for interactive verification. Do not include automated checks, commands, results, pass counts, or CI status. -->
1. Open a playlist containing watched videos in the watch-page side panel and verify that watched dimming is limited to each thumbnail rather than covering the full row.
2. Hover a playlist row at different UI roundness settings and verify that the highlight corners follow the configured roundness.
3. Open the playlist in the fullscreen dock and repeat the watched and hover checks.
4. Open video 98 of a 99-video playlist and verify that the current item is visible at the correct initial scroll position in both layouts.

## Additional context
<!-- Add any other context about the pull request here. -->
