### PR TITLE
test(e2e): shard CI across isolated runners

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -22,9 +22,14 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
-  e2e:
+  e2e-shard:
+    name: e2e (${{ matrix.shard }}/4)
     if: ${{ github.event_name != 'pull_request' || github.head_ref != 'weblate-translations' }}
     runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        shard: [ 1, 2, 3, 4 ]
     env:
       OPENTUBEX_SYNC_SERVER_URL: http://127.0.0.1:8080
 
@@ -91,7 +96,7 @@ jobs:
     # attempt and automatically falls back to recorded fixtures on retry.
     - name: Run E2E tests
       run: |
-        test_args=()
+        test_args=("--shard=${{ matrix.shard }}/4")
         if [ "${{ github.event_name }}" = "pull_request" ]; then
           test_args+=("--only-changed=origin/${GITHUB_BASE_REF}" "--pass-with-no-tests")
         fi
@@ -114,8 +119,19 @@ jobs:
       if: ${{ !cancelled() }}
       uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
       with:
-        name: playwright-report
+        name: playwright-report-${{ matrix.shard }}
         path: |
           e2e/report/
           e2e/results/
         retention-days: 14
+
+  # Keep a stable required-check name while the test suite runs as a matrix.
+  e2e:
+    if: ${{ always() && (github.event_name != 'pull_request' || github.head_ref != 'weblate-translations') }}
+    needs: e2e-shard
+    runs-on: ubuntu-latest
+    steps:
+    - name: Check E2E shards
+      env:
+        SHARD_RESULT: ${{ needs.e2e-shard.result }}
+      run: test "$SHARD_RESULT" = success

--- a/e2e/README.md
+++ b/e2e/README.md
@@ -105,6 +105,10 @@ E2E_USE_FIXTURES=1 pnpm run test:e2e:network
 - **Nightly** → full offline and network suites.
 - **Manual dispatch** → all suites by default, or an individual suite.
 
+The selected tests are split across four CI jobs. Each job still uses one
+Playwright worker and its own X server, avoiding interference between Electron
+windows while substantially reducing the suite's wall-clock time.
+
 Pull requests without changed or affected E2E tests pass without running tests.
 Network tests use the fixture fallback on retry.
 


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Make sure to follow the contributing guidelines. -->
<!-- Important note, we may remove your pull request if you do not use this provided PR template correctly. -->
<!-- Agent instructions: Preserve every heading, comment, and marker in this template. Never remove or rewrite the release-note-category:start/end, release-note:start/end, or release-note-image:start/end marker pairs. Never remove or rewrite the Release note images section; leave its contents for a human. -->

## Pull Request Type
<!-- Please select what type of pull request this is: [x] -->
- [ ] Bugfix
- [ ] Feature Implementation
- [ ] Documentation
- [x] Other

## Related issue
<!-- Please link the issue your pull request is referring to. -->
<!-- If this pull request fully resolves the relevant issue, put "closes" before the issue number. -->
<!-- Example: "closes #123456". -->

## Description
<!-- Please write a clear and concise description of what the pull request does. -->

Large E2E selections currently run every Electron test sequentially in one job. Recent full selections took over 20 minutes in the Playwright step alone, while setup and packaging took under one minute.

Split the selected Playwright tests across four GitHub Actions jobs. Each shard retains one worker and receives its own runner and X server, preserving the pointer-input isolation that motivated serial CI execution while reducing wall-clock time. A final aggregation job keeps the existing `e2e` check name stable for branch protection, and each shard uploads its own report.

## Release note category
<!-- Select exactly one category. Every pull request must select one. -->
<!-- Select "Not noteworthy" when the pull request fixes a bug in or improves functionality that has not yet appeared in a stable release. -->
<!-- release-note-category:start -->
- [x] Not noteworthy
- [ ] Highlights
- [ ] More improvements
- [ ] Fixed bugs
<!-- release-note-category:end -->

## Release note
<!-- Required unless "Not noteworthy" is selected. -->
<!-- Write one concise, user-facing entry without a leading bullet. -->
<!-- release-note:start -->

<!-- release-note:end -->

## Release note images
<!-- Human-only: Agents must preserve this entire section and leave it empty. -->
<!-- Optional. Paste one or more Markdown images or HTML image tags here. -->
<!-- The release notes will use an HTML image tag and limit images taller than 300 pixels. -->
<!-- release-note-image:start -->

<!-- release-note-image:end -->

## Testing
<!-- How can reviewers verify that the PR produces correct results? -->
<!-- Please provide instructions so that others can ensure that your pull request would produce correct results. For examples see, https://github.com/FreeTubeApp/FreeTube/pull/5743, https://github.com/FreeTubeApp/FreeTube/pull/7349, https://github.com/FreeTubeApp/FreeTube/pull/5125, https://github.com/FreeTubeApp/FreeTube/pull/7338 -->
<!-- Agent instructions: Only write human-facing steps that explain how to verify the change while running this branch in dev mode. Include expected results and, when applicable, helpful console snippets for interactive verification. Do not include automated checks, commands, results, pass counts, or CI status. -->

No dev-mode verification is applicable because this changes only GitHub Actions orchestration.

## Additional context
<!-- Add any other context to help reviewers understand the change. -->

The modified workflow passes its scoped YAML lint. Playwright's list mode assigns 141 of the current 564 tests to each shard. The repository-wide YAML lint still reports a pre-existing empty mapping in `e2e/sync-server/compose.yml` and two Arabic locale warnings.