### PR TITLE
fix(search): keep history open after middle-click

### DIFF
--- a/e2e/tests/offline/search-history.spec.mjs
+++ b/e2e/tests/offline/search-history.spec.mjs
@@ -79,6 +79,9 @@ test.describe('search history suggestions', () => {
     await expect(page.locator(sel.tabs)).toHaveCount(2)
     await expect(page.locator(sel.tabs).first()).toHaveClass(/active/)
     await expect(page).not.toHaveURL(/#\/search\/android%20tutorial/)
+    await expect(page.locator(sel.searchInput)).toBeFocused()
+    await expect(page.locator(sel.searchInput)).toHaveValue('')
+    await expect(suggestions(page)).toHaveCount(2)
 
     await page.locator(sel.tabs).nth(1).click()
     await expect(page).toHaveURL(/#\/search\/android%20tutorial/)

--- a/src/renderer/components/FtInput/FtInput.vue
+++ b/src/renderer/components/FtInput/FtInput.vue
@@ -426,7 +426,11 @@ function handleOptionAuxClick(index, event) {
   }
 
   event.preventDefault()
-  handleOptionClick(index, event)
+  inputRef.value.focus()
+  emit('click', visibleDataList.value[index], {
+    event,
+    dataListIndex: getDataListIndex(index)
+  })
 }
 
 function resetSelectedOption() {

--- a/src/renderer/components/TopNav/TopNav.vue
+++ b/src/renderer/components/TopNav/TopNav.vue
@@ -666,11 +666,13 @@ async function goToSearch(queryText, { event, dataListIndex }) {
   const doCreateNewTab = (ctrlOrCmdPressed || isMiddleClick) && !doCreateNewWindow
   const makeActive = !isMiddleClick
 
-  if (window.innerWidth <= MOBILE_WIDTH_THRESHOLD) {
-    searchContainer.value.blur()
-    showSearchContainer.value = false
-  } else {
-    searchInput.value.blur()
+  if (!isMiddleClick) {
+    if (window.innerWidth <= MOBILE_WIDTH_THRESHOLD) {
+      searchContainer.value.blur()
+      showSearchContainer.value = false
+    } else {
+      searchInput.value.blur()
+    }
   }
 
   clearLocalSearchSuggestionsSession()


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Make sure to follow the contributing guidelines. -->
<!-- Important note, we may remove your pull request if you do not use this provided PR template correctly. -->
<!-- Agent instructions: Preserve every heading, comment, and marker in this template. Never remove or rewrite the release-note-category:start/end, release-note:start/end, or release-note-image:start/end marker pairs. Never remove or rewrite the Release note images section; leave its contents for a human. -->

## Pull Request Type
<!-- Please select what type of pull request this is: [x] -->
- [x] Bugfix
- [ ] Feature Implementation
- [ ] Documentation
- [ ] Other

## Related issue
<!-- Please link the issue your pull request is referring to. -->
<!-- If this pull request fully resolves the relevant issue, put "closes" before the issue number. -->
<!-- Example: "closes #123456". -->

Closes #739.

## Description
<!-- Please write a clear and concise description of what the pull request does. -->

Middle-clicking a search history entry reused the normal selection handler, which copied the entry into the search field and closed the suggestions panel before opening the background tab.

This gives Electron middle-clicks a separate navigation path that preserves the current input and dropdown state. The search field also keeps focus while the selected result opens in a background tab.

## Release note category
<!-- Select exactly one category. Every pull request must select one. -->
<!-- Select "Not noteworthy" when the pull request fixes a bug in or improves functionality that has not yet appeared in a stable release. -->
<!-- release-note-category:start -->
- [ ] Not noteworthy
- [ ] Highlights
- [ ] More improvements
- [x] Fixed bugs
<!-- release-note-category:end -->

## Release note
<!-- Required unless "Not noteworthy" is selected. -->
<!-- Write one concise, user-facing entry without a leading bullet. -->
<!-- release-note:start -->
Keep the Search History panel open and its input unchanged when middle-clicking an entry.
<!-- release-note:end -->

## Release note images
<!-- Human-only: Agents must preserve this entire section and leave it empty. -->
<!-- Optional. Paste one or more Markdown images or HTML image tags here. -->
<!-- The release notes will use an HTML image tag and limit images taller than 300 pixels. -->
<!-- release-note-image:start -->

<!-- release-note-image:end -->

## Testing
<!-- How can reviewers verify that the PR produces correct results? -->
<!-- Please provide instructions so that others can ensure that your pull request would produce correct results. For examples see, https://github.com/FreeTubeApp/FreeTube/pull/5743, https://github.com/FreeTubeApp/FreeTube/pull/7349, https://github.com/FreeTubeApp/FreeTube/pull/5125, https://github.com/FreeTubeApp/FreeTube/pull/7338 -->
<!-- Agent instructions: Only write human-facing steps that explain how to verify the change while running this branch in dev mode. Include expected results and, when applicable, helpful console snippets for interactive verification. Do not include automated checks, commands, results, pass counts, or CI status. -->

1. Focus the empty search field so recent search history entries appear.
2. Middle-click an entry.
3. Confirm the result opens in a new background tab while the Search History panel remains open, the search field stays focused, and its value remains unchanged.
4. Middle-click another entry and confirm it can be opened without reopening the panel.

## Additional context
<!-- Add any other context about the pull request here. -->
