### PR TITLE
fix: preserve playback cache entries for open tabs

### DIFF
--- a/e2e/tests/offline/video-actions.spec.mjs
+++ b/e2e/tests/offline/video-actions.spec.mjs
@@ -95,6 +95,45 @@ test('limits persisted yt-dlp playback entries by UTF-8 byte size', async ({ pag
   }, source)).toBe(false)
 })
 
+test('prefers evicting yt-dlp playback entries without open tabs', async ({ page }) => {
+  const result = await page.evaluate(async () => {
+    const openVideoId = 'aaaaaaaaaaa'
+    const unusedVideoId = 'bbbbbbbbbbb'
+    const source = {
+      manifestSrc: 'data:application/dash+xml;charset=UTF-8,manifest',
+      manifestMimeType: 'application/dash+xml',
+      legacyFormats: [],
+      isLive: false,
+      version: '2026.08.13'
+    }
+    const expiryTime = Date.now() + 60 * 60 * 1000
+    const videoIds = [
+      openVideoId,
+      unusedVideoId,
+      ...Array.from({ length: 48 }, (_, index) => `cache${String(index).padStart(6, '0')}`)
+    ]
+
+    await window.ftElectron.ytDlpPlaybackCacheClear()
+    await window.ftElectron.tabs.create({
+      route: `/watch/${openVideoId}`,
+      makeActive: false,
+      lazyLoad: true
+    })
+    for (const videoId of videoIds) {
+      await window.ftElectron.ytDlpPlaybackCacheSet(videoId, 'settings', expiryTime, source)
+    }
+    await window.ftElectron.ytDlpPlaybackCacheSet('zzzzzzzzzzz', 'settings', expiryTime, source)
+
+    return {
+      openEntry: await window.ftElectron.ytDlpPlaybackCacheGet(openVideoId, 'settings'),
+      unusedEntry: await window.ftElectron.ytDlpPlaybackCacheGet(unusedVideoId, 'settings')
+    }
+  })
+
+  expect(result.openEntry).not.toBeNull()
+  expect(result.unusedEntry).toBeNull()
+})
+
 async function readPlaylist(app, id) {
   const contents = await readFile(path.join(app.userDataDir, 'playlists.db'), 'utf8')
   const records = contents.trim().split('\n').map((line) => JSON.parse(line))

--- a/src/main/tabs/TabManager.js
+++ b/src/main/tabs/TabManager.js
@@ -459,6 +459,22 @@ export class TabManager {
   }
 
   /**
+   * @returns {Set<string>} video IDs referenced by tabs in any window
+   */
+  static getOpenVideoIds() {
+    const videoIds = new Set()
+    for (const manager of tabManagers.values()) {
+      for (const tab of manager.tabs.values()) {
+        const videoId = TabManager.getVideoIdFromUrl(tab.url)
+        if (videoId !== null) {
+          videoIds.add(videoId)
+        }
+      }
+    }
+    return videoIds
+  }
+
+  /**
    * @param {number} excludeWindowId
    * @returns {Array<{ windowId: number, label: string }>}
    */

--- a/src/main/ytDlpPlaybackCache.js
+++ b/src/main/ytDlpPlaybackCache.js
@@ -4,6 +4,7 @@ import { createHash } from 'node:crypto'
 import { readFile, rename, writeFile } from 'node:fs/promises'
 import { join } from 'node:path'
 
+import { TabManager } from './tabs/TabManager'
 import { isOpenTubeXUrl } from './utils'
 
 const CACHE_FILENAME = 'yt-dlp-playback-cache.json'
@@ -146,8 +147,10 @@ export async function handleYtDlpPlaybackCacheSet(event, videoId, cacheKey, expi
 
   await loadEntries()
   entries.delete(entry.videoId)
+  const openVideoIds = TabManager.getOpenVideoIds()
   while (entries.size >= MAX_ENTRIES) {
-    entries.delete(entries.keys().next().value)
+    const videoId = Array.from(entries.keys()).find(videoId => !openVideoIds.has(videoId)) ?? entries.keys().next().value
+    entries.delete(videoId)
   }
   entries.set(entry.videoId, entry)
   await saveEntries()


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Make sure to follow the contributing guidelines. -->
<!-- Important note, we may remove your pull request if you do not use this provided PR template correctly. -->
<!-- Agent instructions: Preserve every heading, comment, and marker in this template. Never remove or rewrite the release-note-category:start/end, release-note:start/end, or release-note-image:start/end marker pairs. Never remove or rewrite the Release note images section; leave its contents for a human. -->

## Pull Request Type
<!-- Please select what type of pull request this is: [x] -->
- [x] Bugfix
- [ ] Feature Implementation
- [ ] Documentation
- [ ] Other

## Related issue
<!-- Please link the issue your pull request is referring to. -->
<!-- If this pull request fully resolves the relevant issue, put "closes" before the issue number. -->
<!-- Example: "closes #123456". -->

## Description
<!-- Please write a clear and concise description of what the pull request does. -->
When the persisted yt-dlp playback cache reached its entry limit, it always removed the oldest entry, even when that video's tab was still open. This could discard streams that an open background or unloaded tab was likely to reuse.

Collect the video IDs referenced by tabs across all windows and prefer the oldest cache entry without an open tab during eviction. If every cached video is open, retain the existing oldest-first fallback.

## Release note category
<!-- Select exactly one category. Every pull request must select one. -->
<!-- Select "Not noteworthy" when the pull request fixes a bug in or improves functionality that has not yet appeared in a stable release. -->
<!-- release-note-category:start -->
- [ ] Not noteworthy
- [ ] Highlights
- [ ] More improvements
- [x] Fixed bugs
<!-- release-note-category:end -->

## Release note
<!-- Required unless "Not noteworthy" is selected. -->
<!-- Write one concise, user-facing entry without a leading bullet. -->
<!-- release-note:start -->
Kept cached yt-dlp streams for open tabs when pruning the playback cache.
<!-- release-note:end -->

## Release note images
<!-- Human-only: Agents must preserve this entire section and leave it empty. -->
<!-- Optional. Paste one or more Markdown images or HTML image tags here. -->
<!-- The release notes will use an HTML image tag and limit images taller than 300 pixels. -->
<!-- release-note-image:start -->

<!-- release-note-image:end -->

## Testing
<!-- How can reviewers verify that the PR produces correct results? -->
<!-- Please provide instructions so that others can ensure that your pull request would produce correct results. For examples see, https://github.com/FreeTubeApp/FreeTube/pull/5743, https://github.com/FreeTubeApp/FreeTube/pull/7349, https://github.com/FreeTubeApp/FreeTube/pull/5125, https://github.com/FreeTubeApp/FreeTube/pull/7338 -->
<!-- Agent instructions: Only write human-facing steps that explain how to verify the change while running this branch in dev mode. Include expected results and, when applicable, helpful console snippets for interactive verification. Do not include automated checks, commands, results, pass counts, or CI status. -->
1. Open a video and leave its tab open in the background or unload the tab.
2. Fill the yt-dlp playback cache to its entry limit with other videos, then add one more entry.
3. Confirm the open tab's entry remains cached and the oldest entry without an open tab is removed.

## Additional context
<!-- Add any other context about the pull request here. -->
When every cached video has an open tab, eviction still removes the oldest entry so the cache remains bounded.
