### PR TITLE
fix(live-chat): align loading skeleton with messages

### DIFF
--- a/e2e/tests/offline/watch-page.spec.mjs
+++ b/e2e/tests/offline/watch-page.spec.mjs
@@ -670,7 +670,33 @@ test.describe('watch page', () => {
 
     const replay = page.locator(`${activeTab} .watchVideoPlaylist`).filter({ hasText: 'Live Chat Replay' })
     await expect(replay).toBeVisible()
-    await expect(replay.locator('.liveChatSkeleton')).toBeVisible()
+    const skeleton = replay.locator('.liveChatSkeleton')
+    await expect(skeleton).toBeVisible()
+    expect(await skeleton.evaluate((element) => {
+      const firstMessage = element.querySelector('.liveChatSkeletonMessage')
+      const avatar = firstMessage.querySelector('.liveChatSkeletonAvatar')
+      const author = firstMessage.querySelector('.liveChatSkeletonAuthor')
+      const text = firstMessage.querySelector('.liveChatSkeletonText')
+      const skeletonRect = element.getBoundingClientRect()
+
+      return {
+        avatarInset: avatar.getBoundingClientRect().top - skeletonRect.top,
+        fillsViewport: element.scrollHeight >= element.clientHeight,
+        linesAligned: Math.abs(author.getBoundingClientRect().top - text.getBoundingClientRect().top) <= 1
+      }
+    })).toEqual({
+      avatarInset: 5,
+      fillsViewport: true,
+      linesAligned: true
+    })
+    const skeletonLines = skeleton.locator('.liveChatSkeletonContent').first().locator('div')
+    await expect(skeletonLines.nth(0)).toHaveCSS('block-size', '10px')
+    await expect(skeletonLines.nth(1)).toHaveCSS('block-size', '10px')
+    await watchView.evaluate((view) => {
+      view.liveChat.dispatchEvent(new ErrorEvent('error', { message: 'Unavailable' }))
+    })
+    await expect(replay.locator('.messageContainer.hasError')).toBeVisible()
+    await expect(replay.locator('.titleContainer')).toHaveCSS('margin-block-start', '0px')
     await replay.getByRole('button', { name: 'Close Live Chat Replay' }).click()
     await expect(replay).toHaveCount(0)
 

--- a/e2e/tests/offline/watch-page.spec.mjs
+++ b/e2e/tests/offline/watch-page.spec.mjs
@@ -672,6 +672,7 @@ test.describe('watch page', () => {
     await expect(replay).toBeVisible()
     const skeleton = replay.locator('.liveChatSkeleton')
     await expect(skeleton).toBeVisible()
+    await expect(skeleton.locator('.liveChatSkeletonMessage')).toHaveCount(24)
     expect(await skeleton.evaluate((element) => {
       const firstMessage = element.querySelector('.liveChatSkeletonMessage')
       const avatar = firstMessage.querySelector('.liveChatSkeletonAvatar')
@@ -681,12 +682,13 @@ test.describe('watch page', () => {
 
       return {
         avatarInset: avatar.getBoundingClientRect().top - skeletonRect.top,
-        fillsViewport: element.scrollHeight >= element.clientHeight,
+        clipsOverflow: element.scrollHeight > element.clientHeight &&
+          getComputedStyle(element).overflowY === 'hidden',
         linesAligned: Math.abs(author.getBoundingClientRect().top - text.getBoundingClientRect().top) <= 1
       }
     })).toEqual({
       avatarInset: 5,
-      fillsViewport: true,
+      clipsOverflow: true,
       linesAligned: true
     })
     const skeletonLines = skeleton.locator('.liveChatSkeletonContent').first().locator('div')

--- a/src/renderer/components/WatchVideoLiveChat/WatchVideoLiveChat.css
+++ b/src/renderer/components/WatchVideoLiveChat/WatchVideoLiveChat.css
@@ -13,14 +13,14 @@
   flex-direction: column;
   box-sizing: border-box;
   min-block-size: 0;
-  padding-block: 8px;
-  gap: 14px;
+  overflow: hidden;
 }
 
 .liveChatSkeletonMessage {
   display: flex;
   align-items: center;
-  gap: 10px;
+  padding-block: 5px 7px;
+  gap: 5px;
 }
 
 .liveChatSkeletonAvatar {
@@ -32,7 +32,7 @@
 .liveChatSkeletonContent {
   display: flex;
   flex: 1 1 auto;
-  flex-direction: column;
+  align-items: center;
   gap: 6px;
 }
 
@@ -43,19 +43,19 @@
 }
 
 .liveChatSkeletonAuthor {
-  inline-size: 28%;
+  inline-size: 24%;
 }
 
 .liveChatSkeletonText {
-  inline-size: 65%;
+  inline-size: 55%;
 }
 
 .liveChatSkeletonMessage:nth-child(3n + 1) .liveChatSkeletonText {
-  inline-size: 82%;
+  inline-size: 70%;
 }
 
 .liveChatSkeletonMessage:nth-child(3n + 2) .liveChatSkeletonText {
-  inline-size: 48%;
+  inline-size: 40%;
 }
 
 .relative {
@@ -617,4 +617,8 @@
   display: flex;
   justify-content: space-between;
   margin-block: 1em;
+}
+
+.card.hasError .titleContainer {
+  margin-block-start: 0;
 }

--- a/src/renderer/components/WatchVideoLiveChat/WatchVideoLiveChat.vue
+++ b/src/renderer/components/WatchVideoLiveChat/WatchVideoLiveChat.vue
@@ -144,11 +144,12 @@
     <div
       v-if="isLoading"
       class="liveChatSkeleton"
+      :style="{ blockSize: chatHeight }"
       data-tab-loading-indicator
       aria-hidden="true"
     >
       <div
-        v-for="index in 8"
+        v-for="index in 24"
         :key="index"
         class="liveChatSkeletonMessage"
       >


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Make sure to follow the contributing guidelines. -->
<!-- Important note, we may remove your pull request if you do not use this provided PR template correctly. -->
<!-- Agent instructions: Preserve every heading, comment, and marker in this template. Never remove or rewrite the release-note-category:start/end, release-note:start/end, or release-note-image:start/end marker pairs. Never remove or rewrite the Release note images section; leave its contents for a human. -->

## Pull Request Type
<!-- Please select what type of pull request this is: [x] -->
- [x] Bugfix
- [ ] Feature Implementation
- [ ] Documentation
- [ ] Other

## Related issue
<!-- Please link the issue your pull request is referring to. -->
<!-- If this pull request fully resolves the relevant issue, put "closes" before the issue number. -->
<!-- Example: "closes #123456". -->

## Description
<!-- Please write a clear and concise description of what the pull request does. -->
The live chat loading skeleton did not occupy the same area or use the same row layout as loaded messages, leaving a large empty region at one edge of the panel. The unavailable state also combined its card padding with the regular title margin, making its top spacing larger than its bottom spacing.

This aligns skeleton rows with real chat message spacing, fills and clips them to the chat viewport, and removes the unavailable state's extra header margin. An offline Electron regression test covers the skeleton geometry and unavailable-state spacing.

## Release note category
<!-- Select exactly one category. Every pull request must select one. -->
<!-- Select "Not noteworthy" when the pull request fixes a bug in or improves functionality that has not yet appeared in a stable release. -->
<!-- release-note-category:start -->
- [ ] Not noteworthy
- [ ] Highlights
- [ ] More improvements
- [x] Fixed bugs
<!-- release-note-category:end -->

## Release note
<!-- Required unless "Not noteworthy" is selected. -->
<!-- Write one concise, user-facing entry without a leading bullet. -->
<!-- release-note:start -->
Aligned the live chat loading placeholders and unavailable message within the chat panel.
<!-- release-note:end -->

## Release note images
<!-- Human-only: Agents must preserve this entire section and leave it empty. -->
<!-- Optional. Paste one or more Markdown images or HTML image tags here. -->
<!-- The release notes will use an HTML image tag and limit images taller than 300 pixels. -->
<!-- release-note-image:start -->

<!-- release-note-image:end -->

## Testing
<!-- How can reviewers verify that the PR produces correct results? -->
<!-- Please provide instructions so that others can ensure that your pull request produces correct results. For examples see, https://github.com/FreeTubeApp/FreeTube/pull/5743, https://github.com/FreeTubeApp/FreeTube/pull/7349, https://github.com/FreeTubeApp/FreeTube/pull/5125, https://github.com/FreeTubeApp/FreeTube/pull/7338 -->
<!-- Agent instructions: Only write human-facing steps that explain how to verify the change while running this branch in dev mode. Include expected results and, when applicable, helpful console snippets for interactive verification. Do not include automated checks, commands, results, pass counts, or CI status. -->
1. In dev mode, open a video with live chat replay and observe the panel while chat data loads.
2. Confirm the skeleton begins where real message rows appear, fills the chat viewport without an empty region, and changes to loaded messages without a layout jump.
3. Open a stream whose live chat is unavailable or disabled and confirm the space above the header matches the card's bottom spacing.

## Additional context
<!-- Add any other context about the pull request here. -->
