### PR TITLE
fix(channels): fall back from broken avatars across tabs and channel lists

### DIFF
--- a/e2e/tests/offline/channel-errors.spec.mjs
+++ b/e2e/tests/offline/channel-errors.spec.mjs
@@ -45,6 +45,41 @@ test('shows fallback metadata for unavailable channels', async ({ page }) => {
   await expect(fallbackAvatar).toBeVisible()
   await expect(fallbackAvatar).toHaveCSS('font-size', '100px')
 
+  const cachedChannelTab = page.locator(sel.activeTab)
+  await expect(cachedChannelTab.locator('.tabAvatar')).toHaveCount(0)
+  await expect(cachedChannelTab.locator('.tabPageIcon'))
+    .toHaveAttribute('data-icon', 'circle-user')
+
+  await page.evaluate(() => window.ftElectron.tabs.setPreviewCapturePaused(true))
+  try {
+    await cachedChannel.hover()
+    await cachedChannelTab.hover()
+    const tooltipPreview = page.locator('.tabTooltipPreview')
+    await expect(tooltipPreview).toBeVisible()
+    await expect(tooltipPreview.locator('.tabTooltipPreviewAvatar')).toHaveCount(0)
+    await expect(tooltipPreview.locator('.tabTooltipFallbackIcon'))
+      .toHaveAttribute('data-icon', 'circle-user')
+
+    await page.keyboard.down('Control')
+    try {
+      await page.keyboard.press('Tab')
+      const switcherItem = page.locator('.tabSwitcherItem', { hasText: 'Deleted Channel' })
+      await expect(switcherItem).toBeVisible()
+      const switcherTitleAvatar = switcherItem.locator('.tabSwitcherTitleAvatar')
+      const switcherTitleIcon = switcherItem.locator('.tabSwitcherTitleIcon')
+      await expect(switcherTitleAvatar.or(switcherTitleIcon)).toHaveCount(1)
+      if (await switcherTitleAvatar.count() > 0) {
+        await switcherTitleAvatar.dispatchEvent('error')
+      }
+      await expect(switcherItem.locator('.tabSwitcherTitleIcon'))
+        .toHaveAttribute('data-icon', 'circle-user')
+    } finally {
+      await page.keyboard.up('Control')
+    }
+  } finally {
+    await page.evaluate(() => window.ftElectron.tabs.setPreviewCapturePaused(false))
+  }
+
   await openChannelTab(page, UNKNOWN_CHANNEL_ID)
 
   const unknownChannel = page.locator('.channelDetails:visible')

--- a/e2e/tests/offline/subscribed-channels.spec.mjs
+++ b/e2e/tests/offline/subscribed-channels.spec.mjs
@@ -57,7 +57,11 @@ test.describe('subscribed channels', () => {
     })
 
     await expect(alpha.locator('img.channelThumbnail')).toHaveCount(0)
-    await expect(alpha.locator('.channelThumbnail:not(img)')).toBeVisible()
+    const fallbackAvatar = alpha.locator('.channelThumbnail:not(img)')
+    await expect(fallbackAvatar).toBeVisible()
+    await expect(fallbackAvatar).toHaveCSS('inline-size', '120px')
+    await expect(fallbackAvatar).toHaveCSS('block-size', '120px')
+    await expect(fallbackAvatar).toHaveCSS('font-size', '120px')
   })
 
   test('profile dropdown uses an overlay scrollbar', async ({ page }) => {

--- a/src/renderer/App.vue
+++ b/src/renderer/App.vue
@@ -256,17 +256,19 @@
             class="tabSwitcherPreview"
           >
             <img
-              v-if="tabSwitcherPreviewUrls[tab.id]"
+              v-if="getUsableTabSwitcherPreviewUrl(tab)"
               :src="tabSwitcherPreviewUrls[tab.id]"
               :alt="`${formatTabSwitcherTitle(tab.title)} preview`"
               draggable="false"
+              @error="handleTabSwitcherPreviewError(tab)"
             >
             <img
-              v-else-if="!tabSwitcherPreviewPending[tab.id] && getTabPreviewFallbackUrl(tab)"
-              :src="getTabPreviewFallbackUrl(tab)"
+              v-else-if="!tabSwitcherPreviewPending[tab.id] && getUsableTabSwitcherAvatarUrl(tab)"
+              :src="getUsableTabSwitcherAvatarUrl(tab)"
               :alt="`${formatTabSwitcherTitle(tab.title)} preview`"
               class="tabSwitcherPreviewAvatar"
               draggable="false"
+              @error="handleTabSwitcherAvatarError(tab)"
             >
             <span
               v-else-if="!tabSwitcherPreviewPending[tab.id]"
@@ -274,18 +276,19 @@
               aria-hidden="true"
             >
               <FtIcon
-                :icon="['fas', 'display']"
+                :icon="getTabPageIcon(tab) || ['fas', 'display']"
                 class="tabSwitcherFallbackIcon"
               />
             </span>
           </span>
           <span class="tabSwitcherTitle">
             <img
-              v-if="showTabIcons && getTabAvatarUrl(tab)"
-              :src="getTabAvatarUrl(tab)"
+              v-if="showTabIcons && getUsableTabSwitcherAvatarUrl(tab)"
+              :src="getUsableTabSwitcherAvatarUrl(tab)"
               class="tabSwitcherTitleAvatar"
               alt=""
               draggable="false"
+              @error="handleTabSwitcherAvatarError(tab)"
             >
             <FtIcon
               v-else-if="showTabIcons && getTabPageIcon(tab)"
@@ -560,6 +563,8 @@ const tabSwitcherVisible = ref(false)
 const tabSwitcherSelectedIndex = ref(-1)
 const tabSwitcherPreviewUrls = ref({})
 const tabSwitcherPreviewPending = ref({})
+const tabSwitcherFailedAvatarUrls = ref({})
+const tabSwitcherFailedPreviewUrls = ref({})
 const tabSwitcherPointerActive = ref(false)
 const tabSwitcherRef = useTemplateRef('tabSwitcherRef')
 const subscriptionAutoRefreshTimers = {
@@ -2345,6 +2350,30 @@ function loadTabSwitcherPreviews() {
   })
 }
 
+function getUsableTabSwitcherAvatarUrl(tab) {
+  const avatarUrl = getTabAvatarUrl(tab) || getTabPreviewFallbackUrl(tab)
+  return avatarUrl !== tabSwitcherFailedAvatarUrls.value[tab.id] ? avatarUrl : null
+}
+
+function getUsableTabSwitcherPreviewUrl(tab) {
+  const previewUrl = tabSwitcherPreviewUrls.value[tab.id]
+  return previewUrl !== tabSwitcherFailedPreviewUrls.value[tab.id] ? previewUrl : null
+}
+
+function handleTabSwitcherAvatarError(tab) {
+  tabSwitcherFailedAvatarUrls.value = {
+    ...tabSwitcherFailedAvatarUrls.value,
+    [tab.id]: getUsableTabSwitcherAvatarUrl(tab)
+  }
+}
+
+function handleTabSwitcherPreviewError(tab) {
+  tabSwitcherFailedPreviewUrls.value = {
+    ...tabSwitcherFailedPreviewUrls.value,
+    [tab.id]: getUsableTabSwitcherPreviewUrl(tab)
+  }
+}
+
 /**
  * @param {number} index
  */
@@ -2426,6 +2455,8 @@ function cancelTabSwitcher() {
   tabSwitcherSelectedIndex.value = -1
   tabSwitcherPreviewUrls.value = {}
   tabSwitcherPreviewPending.value = {}
+  tabSwitcherFailedAvatarUrls.value = {}
+  tabSwitcherFailedPreviewUrls.value = {}
   tabSwitcherPointerActive.value = false
   tabSwitcherPreviewRequestId++
   window.ftElectron.tabs.setPreviewCapturePaused(false)

--- a/src/renderer/components/TabBar/SortableTab.vue
+++ b/src/renderer/components/TabBar/SortableTab.vue
@@ -39,11 +39,12 @@
         aria-hidden="true"
       />
       <img
-        v-else-if="showIcon && tabAvatarUrl"
+        v-else-if="showIcon && usableTabAvatarUrl"
         :src="tabAvatarUrl"
         class="tabAvatar"
         alt=""
         draggable="false"
+        @error="handleAvatarError"
       >
       <FtIcon
         v-else-if="showIcon && tabPageIcon"
@@ -90,13 +91,15 @@
             :src="tooltipPreviewUrl"
             :alt="tooltipPreviewAlt"
             draggable="false"
+            @error="handleTooltipPreviewError"
           >
           <img
-            v-else-if="channelThumbnailUrl"
-            :src="channelThumbnailUrl"
+            v-else-if="usableTabAvatarUrl"
+            :src="usableTabAvatarUrl"
             :alt="tooltipPreviewAlt"
             class="tabTooltipPreviewAvatar"
             draggable="false"
+            @error="handleAvatarError"
           >
           <div
             v-else
@@ -104,7 +107,7 @@
             aria-hidden="true"
           >
             <FtIcon
-              :icon="['fas', 'display']"
+              :icon="tabPageIcon || ['fas', 'display']"
               class="tabTooltipFallbackIcon"
             />
           </div>
@@ -189,6 +192,7 @@ const tabRef = useTemplateRef('tabRef')
 const tooltipRef = useTemplateRef('tooltipRef')
 const isTooltipVisible = ref(false)
 const tooltipPreviewUrl = ref(null)
+const failedAvatarUrl = ref(null)
 const tooltipStyle = ref({})
 const tooltipRequestId = ref(0)
 let showTooltipTimeoutId = null
@@ -240,9 +244,21 @@ const tooltipEstimatedHeight = computed(() => props.showPreview
 
 // When a tab points at a channel page and no screenshot has been captured yet,
 // fall back to the channel's profile picture (cached by the Channel view).
-const channelThumbnailUrl = computed(() => getTabPreviewFallbackUrl(props.tab))
 const tabAvatarUrl = computed(() => getTabAvatarUrl(props.tab))
+const previewFallbackUrl = computed(() => getTabPreviewFallbackUrl(props.tab))
+const usableTabAvatarUrl = computed(() => {
+  const avatarUrl = tabAvatarUrl.value || previewFallbackUrl.value
+  return avatarUrl !== failedAvatarUrl.value ? avatarUrl : null
+})
 const tabPageIcon = computed(() => getTabPageIcon(props.tab))
+
+function handleAvatarError() {
+  failedAvatarUrl.value = usableTabAvatarUrl.value
+}
+
+function handleTooltipPreviewError() {
+  tooltipPreviewUrl.value = null
+}
 
 function handleClick(event) {
   emit('activate', event, props.tab.id)
@@ -448,6 +464,12 @@ watch(() => props.showPreview, (showPreview) => {
     if (showPreview) {
       loadTooltipPreview()
     }
+  }
+})
+
+watch(tabAvatarUrl, (avatarUrl) => {
+  if (avatarUrl !== failedAvatarUrl.value) {
+    failedAvatarUrl.value = null
   }
 })
 </script>

--- a/src/renderer/views/SubscribedChannels/SubscribedChannels.css
+++ b/src/renderer/views/SubscribedChannels/SubscribedChannels.css
@@ -44,8 +44,10 @@
 }
 
 .channelThumbnail {
+  inline-size: 120px;
   block-size: 120px;
   border-radius: 50%;
+  font-size: 120px;
 }
 
 .channelName {
@@ -90,6 +92,8 @@
   }
 
   .channelThumbnail {
+    inline-size: 80px;
     block-size: 80px;
+    font-size: 80px;
   }
 }


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Make sure to follow the contributing guidelines. -->
<!-- Important note, we may remove your pull request if you do not use this provided PR template correctly. -->
<!-- Agent instructions: Preserve every heading, comment, and marker in this template. Never remove or rewrite the release-note-category:start/end, release-note:start/end, or release-note-image:start/end marker pairs. Never remove or rewrite the Release note images section; leave its contents for a human. -->

## Pull Request Type
<!-- Please select what type of pull request this is: [x] -->
- [x] Bugfix
- [ ] Feature Implementation
- [ ] Documentation
- [ ] Other

## Related issue
<!-- Please link the issue your pull request is referring to. -->
<!-- If this pull request fully resolves the relevant issue, put "closes" before the issue number. -->
<!-- Example: "closes #123456". -->

## Description
<!-- Please write a clear and concise description of what the pull request does. -->
Unavailable channels can retain an avatar URL that exists in application state but cannot be decoded. Tabs and preview fallbacks therefore rendered broken images instead of their channel icon, while the subscribed-channels placeholder kept the icon glyph at its default size.

Track avatar and preview load failures in both tab surfaces and fall back to the route-specific page icon. Size the subscribed-channels placeholder to the same dimensions as a regular channel avatar.

## Release note category
<!-- Select exactly one category. Every pull request must select one. -->
<!-- Select "Not noteworthy" when the pull request fixes a bug in or improves functionality that has not yet appeared in a stable release. -->
<!-- release-note-category:start -->
- [x] Not noteworthy
- [ ] Highlights
- [ ] More improvements
- [ ] Fixed bugs
<!-- release-note-category:end -->

## Release note
<!-- Required unless "Not noteworthy" is selected. -->
<!-- Write one concise, user-facing entry without a leading bullet. -->
<!-- release-note:start -->

<!-- release-note:end -->

## Release note images
<!-- Human-only: Agents must preserve this entire section and leave it empty. -->
<!-- Optional. Paste one or more Markdown images or HTML image tags here. -->
<!-- The release notes will use an HTML image tag and limit images taller than 300 pixels. -->
<!-- release-note-image:start -->

<!-- release-note-image:end -->

## Testing
<!-- How can reviewers verify that the PR produces correct results? -->
<!-- Please provide instructions so that others can ensure that your pull request would produce correct results. For examples see, https://github.com/FreeTubeApp/FreeTube/pull/5743, https://github.com/FreeTubeApp/FreeTube/pull/7349, https://github.com/FreeTubeApp/FreeTube/pull/5125, https://github.com/FreeTubeApp/FreeTube/pull/7338 -->
<!-- Agent instructions: Only write human-facing steps that explain how to verify the change while running this branch in dev mode. Include expected results and, when applicable, helpful console snippets for interactive verification. Do not include automated checks, commands, results, pass counts, or CI status. -->
1. Open an unavailable subscribed channel whose cached avatar no longer loads.
2. Confirm its tab uses the channel page icon instead of leaving an empty or broken avatar.
3. Hover the tab and confirm its fallback preview shows the channel icon without broken-image text.
4. Open the Ctrl+Tab switcher and confirm the channel title uses the same fallback icon.
5. Open the subscribed-channels page and confirm the unavailable channel placeholder fills the same circular area as regular avatars at both wide and narrow window sizes.

## Additional context
<!-- Add any other context about the pull request here. -->
