### PR TITLE
perf(tabs): prioritize active watch tab on startup

### DIFF
--- a/e2e/tests/offline/session-restore.spec.mjs
+++ b/e2e/tests/offline/session-restore.spec.mjs
@@ -205,6 +205,9 @@ test.describe('restored watch tab startup priority', () => {
     await expect(page.locator(sel.activeTab)).toHaveAttribute('data-tab-id', ACTIVE_WATCH_TAB_ID)
     await expect(backgroundWatchTab).toHaveClass(/unloaded/)
     await expect(subscriptionsTab).not.toHaveClass(/unloaded/)
+    await page.evaluate(activeTabId => {
+      window.ftElectron.tabs.setLoading(true, activeTabId)
+    }, ACTIVE_WATCH_TAB_ID)
     await expect.poll(async () => {
       const state = await page.evaluate(() => window.ftElectron.tabs.getState())
       return state.tabs.find(tab => tab.id === ACTIVE_WATCH_TAB_ID)?.isLoading
@@ -237,6 +240,22 @@ test.describe('restored watch tab startup priority', () => {
     await subscriptionsTab.click()
 
     await expect(page.locator(sel.activeTab)).toHaveAttribute('data-tab-id', SUBSCRIPTIONS_TAB_ID)
+    await expect(backgroundWatchTab).not.toHaveClass(/unloaded/)
+  })
+
+  test('releases background watch tabs when the priority mount fails', async ({ page }) => {
+    const backgroundWatchTab = page.locator(`.tab[data-tab-id="${BACKGROUND_WATCH_TAB_ID}"]`)
+
+    await expect(backgroundWatchTab).toHaveClass(/unloaded/)
+    const mountRevision = await page.evaluate(async activeTabId => {
+      const state = await window.ftElectron.tabs.getState()
+      return state.tabs.find(tab => tab.id === activeTabId)?.mountRevision
+    }, ACTIVE_WATCH_TAB_ID)
+
+    await page.evaluate(({ activeTabId, mountRevision }) => {
+      window.ftElectron.tabs.mountFailed(activeTabId, mountRevision)
+    }, { activeTabId: ACTIVE_WATCH_TAB_ID, mountRevision })
+
     await expect(backgroundWatchTab).not.toHaveClass(/unloaded/)
   })
 })

--- a/e2e/tests/offline/session-restore.spec.mjs
+++ b/e2e/tests/offline/session-restore.spec.mjs
@@ -223,4 +223,20 @@ test.describe('restored watch tab startup priority', () => {
       return state.tabs.find(tab => tab.id === BACKGROUND_WATCH_TAB_ID)?.loadState
     }).not.toBe('unloaded')
   })
+
+  test('releases background watch tabs when a loaded tab becomes active', async ({ page }) => {
+    const backgroundWatchTab = page.locator(`.tab[data-tab-id="${BACKGROUND_WATCH_TAB_ID}"]`)
+    const subscriptionsTab = page.locator(`.tab[data-tab-id="${SUBSCRIPTIONS_TAB_ID}"]`)
+
+    await expect(backgroundWatchTab).toHaveClass(/unloaded/)
+    await expect.poll(async () => {
+      const state = await page.evaluate(() => window.ftElectron.tabs.getState())
+      return state.tabs.find(tab => tab.id === SUBSCRIPTIONS_TAB_ID)?.loadState
+    }).toBe('loaded')
+
+    await subscriptionsTab.click()
+
+    await expect(page.locator(sel.activeTab)).toHaveAttribute('data-tab-id', SUBSCRIPTIONS_TAB_ID)
+    await expect(backgroundWatchTab).not.toHaveClass(/unloaded/)
+  })
 })

--- a/e2e/tests/offline/session-restore.spec.mjs
+++ b/e2e/tests/offline/session-restore.spec.mjs
@@ -142,3 +142,85 @@ test.describe('active watch tab restore', () => {
     )).toBeVisible()
   })
 })
+
+test.describe('restored watch tab startup priority', () => {
+  const ACTIVE_WATCH_TAB_ID = 'e2e-active-watch-tab'
+  const BACKGROUND_WATCH_TAB_ID = 'e2e-background-watch-tab'
+  const SUBSCRIPTIONS_TAB_ID = 'e2e-background-subscriptions-tab'
+  const priorityRestoreSeed = {
+    settings: {
+      backendPreference: 'invidious',
+      defaultInvidiousInstance: '',
+      startupBehavior: 'loadAllTabs'
+    },
+    tabSessions: [
+      {
+        _id: 'e2e-window-session',
+        value: {
+          tabs: [
+            {
+              id: BACKGROUND_WATCH_TAB_ID,
+              url: 'app://bundle/index.html#/watch/background-video',
+              title: 'Background video',
+              isUnloaded: false
+            },
+            {
+              id: ACTIVE_WATCH_TAB_ID,
+              url: 'app://bundle/index.html#/watch/active-video',
+              title: 'Active video',
+              isUnloaded: false
+            },
+            {
+              id: SUBSCRIPTIONS_TAB_ID,
+              url: 'app://bundle/index.html#/subscriptions',
+              title: 'Subscriptions',
+              isUnloaded: false
+            }
+          ],
+          activeTabId: ACTIVE_WATCH_TAB_ID,
+          bounds: { x: 0, y: 0, width: 1600, height: 900, maximized: false }
+        }
+      }
+    ]
+  }
+  const invidiousServer = createServer()
+
+  test.use({ seed: priorityRestoreSeed })
+
+  test.beforeAll(async () => {
+    await new Promise(resolve => invidiousServer.listen(0, '127.0.0.1', resolve))
+    const address = invidiousServer.address()
+    priorityRestoreSeed.settings.defaultInvidiousInstance = `http://127.0.0.1:${address.port}`
+  })
+
+  test.afterAll(async () => {
+    invidiousServer.closeAllConnections()
+    await new Promise(resolve => invidiousServer.close(resolve))
+  })
+
+  test('defers background watch tabs until the active watch load finishes', async ({ page }) => {
+    const backgroundWatchTab = page.locator(`.tab[data-tab-id="${BACKGROUND_WATCH_TAB_ID}"]`)
+    const subscriptionsTab = page.locator(`.tab[data-tab-id="${SUBSCRIPTIONS_TAB_ID}"]`)
+
+    await expect(page.locator(sel.activeTab)).toHaveAttribute('data-tab-id', ACTIVE_WATCH_TAB_ID)
+    await expect(backgroundWatchTab).toHaveClass(/unloaded/)
+    await expect(subscriptionsTab).not.toHaveClass(/unloaded/)
+    await expect.poll(async () => {
+      const state = await page.evaluate(() => window.ftElectron.tabs.getState())
+      return state.tabs.find(tab => tab.id === ACTIVE_WATCH_TAB_ID)?.isLoading
+    }).toBe(true)
+
+    await page.evaluate(activeTabId => {
+      window.ftElectron.tabs.setLoading(false, activeTabId)
+    }, ACTIVE_WATCH_TAB_ID)
+
+    await expect(backgroundWatchTab).not.toHaveClass(/unloaded/)
+    await expect(page.locator(
+      `.tabContent[data-tab-id="${BACKGROUND_WATCH_TAB_ID}"] [data-tab-loading-indicator]`
+    )).toHaveCount(1)
+    await expect.poll(async () => {
+      const state = await page.evaluate(() => window.ftElectron.tabs.getState())
+      return state.tabs.find(tab => tab.id === BACKGROUND_WATCH_TAB_ID)?.loadState
+    }).not.toBe('unloaded')
+  })
+})

--- a/src/main/tabs/TabManager.js
+++ b/src/main/tabs/TabManager.js
@@ -597,6 +597,12 @@ export class TabManager {
     this._pendingTabMountWaiters = new Map()
     this._deferredCloseTabIds = new Set()
     this._deferredUnloadTabIds = new Set()
+    // Loading every restored watch page at once makes them compete with the
+    // selected video's metadata and stream requests. Keep those background
+    // mounts queued until the selected watch page has finished its initial load.
+    this._deferredStartupWatchTabIds = new Set()
+    this._startupPriorityTabId = null
+    this._startupPriorityLoadingObserved = false
     // While a batch runs, state broadcasts and session writes are collapsed into
     // a single one that is emitted once the batch finishes (see runBatched).
     this._batchDepth = 0
@@ -1106,9 +1112,15 @@ export class TabManager {
     }
 
     if (tab.loadState === 'unloaded') {
+      this._deferredStartupWatchTabIds.delete(tabId)
       tab.loadState = 'mounting'
       tab.mountRevision += 1
       this._setTabLoadingSource(tab, TAB_LOADING_SOURCE_MOUNT, true)
+    }
+
+    if (this._deferredStartupWatchTabIds.size > 0 && previousActiveId !== tabId) {
+      this._startupPriorityTabId = tabId
+      this._startupPriorityLoadingObserved = false
     }
 
     tab.pendingActivation = false
@@ -2477,7 +2489,31 @@ export class TabManager {
     const tab = this.tabs.get(tabId)
     if (tab) {
       this._setTabLoadingSource(tab, TAB_LOADING_SOURCE_RENDERER, isLoading)
+      if (tabId === this._startupPriorityTabId) {
+        if (isLoading) {
+          this._startupPriorityLoadingObserved = true
+        } else if (this._startupPriorityLoadingObserved) {
+          this._resumeDeferredStartupWatchTabs()
+        }
+      }
     }
+  }
+
+  _resumeDeferredStartupWatchTabs() {
+    const tabIds = Array.from(this._deferredStartupWatchTabIds)
+    this._deferredStartupWatchTabIds.clear()
+    this._startupPriorityTabId = null
+    this._startupPriorityLoadingObserved = false
+
+    // Resuming can touch dozens of tabs, so publish one renderer snapshot and
+    // one session write rather than waking the shared renderer for every tab.
+    this.runBatched(() => {
+      for (const tabId of tabIds) {
+        this.loadTab(tabId)
+      }
+    }).catch(error => {
+      console.error('Failed to resume deferred startup watch tabs:', error)
+    })
   }
 
   /**
@@ -2714,6 +2750,9 @@ export class TabManager {
       this.closedTabs = []
       this._deferredCloseTabIds.clear()
       this._deferredUnloadTabIds.clear()
+      this._deferredStartupWatchTabIds.clear()
+      this._startupPriorityTabId = null
+      this._startupPriorityLoadingObserved = false
       this.selectionRevision += 1
       this._broadcastStateUpdate()
       this.sessionId = sessionData.sessionId
@@ -2776,6 +2815,10 @@ export class TabManager {
 
     try {
       const restoreNavigationHistory = await TabManager.getStoredRememberTabNavigationHistory()
+      const activeTabData = sessionData.tabs.find(tab => tab.id === sessionData.activeTabId)
+      const prioritizeActiveWatchTab = activeTabData != null &&
+        TabManager.getRouteFromUrl(activeTabData.url).path.startsWith('/watch/')
+      const deferredStartupWatchTabIds = new Set()
 
       for (const tabData of sessionData.tabs) {
         const makeActive = tabData.id === sessionData.activeTabId
@@ -2784,12 +2827,16 @@ export class TabManager {
         const avatarFileName = normalizeTabPreviewFileName(tabData.avatarFileName)
         const avatarDataUrl = await this._loadTabPreviewDataUrl(avatarFileName)
         const loadInBackground = loadInactiveTabs || (restoreTabLoadState && tabData.isUnloaded === false)
-        const restoreAsUnloaded = !loadInactiveTabs && !makeActive && (
+        const deferForActiveWatchTab = prioritizeActiveWatchTab &&
+          !makeActive &&
+          loadInBackground &&
+          TabManager.getRouteFromUrl(tabData.url).path.startsWith('/watch/')
+        const restoreAsUnloaded = deferForActiveWatchTab || (!loadInactiveTabs && !makeActive && (
           (restoreTabLoadState && tabData.isUnloaded === true) ||
           (!loadInBackground && hasSavedTitle)
-        )
+        ))
 
-        this.createTab({
+        const tab = this.createTab({
           id: typeof tabData.id === 'string' ? tabData.id : undefined,
           // Strip here as well to heal sessions persisted before the strip on save existed
           url: TabManager.stripOneTimeTimestampFromUrl(tabData.url),
@@ -2814,8 +2861,17 @@ export class TabManager {
             ? tabData.placementOpenerTabId
             : null,
           lazyLoad: restoreAsUnloaded,
-          preloadInBackground: loadInBackground && !makeActive
+          preloadInBackground: loadInBackground && !makeActive && !deferForActiveWatchTab
         })
+        if (deferForActiveWatchTab) {
+          deferredStartupWatchTabIds.add(tab.id)
+        }
+      }
+
+      if (deferredStartupWatchTabIds.size > 0) {
+        this._deferredStartupWatchTabIds = deferredStartupWatchTabIds
+        this._startupPriorityTabId = this.activeTabId
+        this._startupPriorityLoadingObserved = false
       }
 
       restoreTabPlacementOpeners(this.tabs, sessionData.tabs)

--- a/src/main/tabs/TabManager.js
+++ b/src/main/tabs/TabManager.js
@@ -1240,6 +1240,9 @@ export class TabManager {
     tab.pendingActivation = false
     this._setTabLoadingSource(tab, TAB_LOADING_SOURCE_MOUNT, false)
     this._resolveTabMountWaiters(tabId, mountRevision, false)
+    if (tabId === this._startupPriorityTabId) {
+      this._resumeDeferredStartupWatchTabs()
+    }
 
     // The failed tab was activated as the replacement for one or more tabs whose
     // close/unload was deferred until it presented. Since it will never present,

--- a/src/main/tabs/TabManager.js
+++ b/src/main/tabs/TabManager.js
@@ -1118,7 +1118,15 @@ export class TabManager {
       this._setTabLoadingSource(tab, TAB_LOADING_SOURCE_MOUNT, true)
     }
 
-    if (this._deferredStartupWatchTabIds.size > 0 && previousActiveId !== tabId) {
+    const shouldResumeDeferredStartupWatchTabs =
+      this._deferredStartupWatchTabIds.size > 0 &&
+      previousActiveId !== tabId &&
+      tab.loadState === 'loaded'
+    if (
+      this._deferredStartupWatchTabIds.size > 0 &&
+      previousActiveId !== tabId &&
+      !shouldResumeDeferredStartupWatchTabs
+    ) {
       this._startupPriorityTabId = tabId
       this._startupPriorityLoadingObserved = false
     }
@@ -1130,6 +1138,9 @@ export class TabManager {
     this.selectionRevision += 1
     this.browserWindow.setTitle(tab.title)
     this.bridge.send(IpcChannels.TABS_ACTIVE_CHANGED, tabId, this.selectionRevision)
+    if (shouldResumeDeferredStartupWatchTabs) {
+      this._resumeDeferredStartupWatchTabs()
+    }
     this._broadcastStateUpdate()
     this._saveSession()
   }


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Make sure to follow the contributing guidelines. -->
<!-- Important note, we may remove your pull request if you do not use this provided PR template correctly. -->
<!-- Agent instructions: Preserve every heading, comment, and marker in this template. Never remove or rewrite the release-note-category:start/end, release-note:start/end, or release-note-image:start/end marker pairs. Never remove or rewrite the Release note images section; leave its contents for a human. -->

## Pull Request Type
<!-- Please select what type of pull request this is: [x] -->
- [x] Bugfix
- [ ] Feature Implementation
- [ ] Documentation
- [ ] Other

## Related issue
<!-- Please link the issue your pull request is referring to. -->
<!-- If this pull request fully resolves the relevant issue, put "closes" before the issue number. -->
<!-- Example: "closes #123456". -->

## Description
<!-- Please write a clear and concise description of what the pull request does. -->
Restoring a session with many loaded watch tabs starts every video's metadata and stream work at once, delaying playback in the selected tab.

This change keeps inactive restored watch tabs queued while the active watch page performs its initial load. Once the active page's real loading indicator clears, the queued watch tabs resume in one batched update. Other restored page types continue loading normally, and selecting a queued tab during startup prioritizes that tab.

## Release note category
<!-- Select exactly one category. Every pull request must select one. -->
<!-- Select "Not noteworthy" when the pull request fixes a bug in or improves functionality that has not yet appeared in a stable release. -->
<!-- release-note-category:start -->
- [ ] Not noteworthy
- [ ] Highlights
- [ ] More improvements
- [x] Fixed bugs
<!-- release-note-category:end -->

## Release note
<!-- Required unless "Not noteworthy" is selected. -->
<!-- Write one concise, user-facing entry without a leading bullet. -->
<!-- release-note:start -->
Restored sessions now load the active video before background watch tabs.
<!-- release-note:end -->

## Release note images
<!-- Human-only: Agents must preserve this entire section and leave it empty. -->
<!-- Optional. Paste one or more Markdown images or HTML image tags here. -->
<!-- The release notes will use an HTML image tag and limit images taller than 300 pixels. -->
<!-- release-note-image:start -->

<!-- release-note-image:end -->

## Testing
<!-- How can reviewers verify that the PR produces correct results? -->
<!-- Please provide instructions so that others can ensure that your pull request would produce correct results. For examples see, https://github.com/FreeTubeApp/FreeTube/pull/5743, https://github.com/FreeTubeApp/FreeTube/pull/7349, https://github.com/FreeTubeApp/FreeTube/pull/5125, https://github.com/FreeTubeApp/FreeTube/pull/7338 -->
<!-- Agent instructions: Only write human-facing steps that explain how to verify the change while running this branch in dev mode. Include expected results and, when applicable, helpful console snippets for interactive verification. Do not include automated checks, commands, results, pass counts, or CI status. -->
1. Set startup behavior to load all tabs.
2. Open several watch tabs, leave one of them selected, and restart the app.
3. Confirm the selected video's player becomes ready before the inactive watch tabs begin loading.
4. Confirm non-watch tabs restore normally and inactive watch tabs begin loading after the selected watch page finishes its initial load.

## Additional context
<!-- Add any other context about the pull request here. -->
The behavior was also confirmed manually with a large restored tab session.