### PR TITLE
fix: keep refresh feed progress in one location

### DIFF
--- a/e2e/tests/offline/subscriptions-refresh.spec.mjs
+++ b/e2e/tests/offline/subscriptions-refresh.spec.mjs
@@ -140,7 +140,8 @@ test.describe('incremental subscription feed refresh', () => {
     await expect(page.getByText('Fresh video 0', { exact: true })).toBeVisible({ timeout: 3_000 })
     await expect(page.getByText('Fresh video 1', { exact: true })).toHaveCount(0)
     await expect(page.getByText('Cached video 1', { exact: true })).toBeVisible()
-    await expect(page.locator('.tabsProgressBar')).toBeVisible()
+    await expect(page.getByTestId('subscription-refresh-toast')).toBeVisible()
+    await expect(page.locator('.tabsProgressBar')).toHaveCount(0)
 
     await expect(page.getByText('Fresh video 1', { exact: true })).toBeVisible({ timeout: 30_000 })
     await expect(page.locator('.tab.active .loadingDot')).toHaveCount(0)
@@ -174,20 +175,47 @@ test.describe('incremental subscription feed refresh', () => {
     await expect(page.getByText('Fresh video 0', { exact: true })).toBeVisible({ timeout: 3_000 })
   })
 
-  test('keeps a manual refresh in the progress toast after navigation', async ({ page }) => {
+  test('keeps a manual refresh in the progress toast across navigation', async ({ page }) => {
     await routeFeeds(page, () => 8_000)
     await goTo(page, 'subscriptions')
 
     await page.getByRole('button', { name: /Refresh Videos/ }).click()
-    await expect(page.getByTestId('subscription-refresh-toast')).toHaveCount(0)
-    await goTo(page, 'history')
-
     const refreshToast = page.getByTestId('subscription-refresh-toast')
     await expect(refreshToast).toContainText('Refreshing subscription videos')
     await expect(page.locator('.app > .progressBar')).toHaveCount(0)
 
     await expect(refreshToast).toBeVisible()
+    await goTo(page, 'history')
+    await expect(refreshToast).toBeVisible()
     await expect(refreshToast).toHaveCount(0, { timeout: 30_000 })
+  })
+})
+
+test.describe('subscription refresh bottom progress', () => {
+  test.use({
+    seed: {
+      settings: {
+        ...commonSettings,
+        showProgressBarToast: false
+      },
+      profiles: [profileWith(2)],
+      subscriptionCache: [cachedChannel(0), cachedChannel(1)]
+    }
+  })
+
+  test('keeps the global progress bar visible across navigation', async ({ page }) => {
+    await routeFeeds(page, () => 8_000)
+    await goTo(page, 'subscriptions')
+
+    await page.getByRole('button', { name: /Refresh Videos/ }).click()
+    const progressBar = page.locator('.app > .progressBar')
+    await expect(progressBar).toBeVisible()
+    await expect(page.locator('.tab.active .loadingDot')).toBeVisible()
+    await expect(page.locator('.tabsProgressBar')).toHaveCount(0)
+
+    await goTo(page, 'history')
+    await expect(progressBar).toBeVisible()
+    await expect(progressBar).toHaveCount(0, { timeout: 30_000 })
   })
 })
 

--- a/src/renderer/App.vue
+++ b/src/renderer/App.vue
@@ -144,9 +144,7 @@
       v-if="showCreatePlaylistPrompt"
     />
     <FtContextMenu v-if="isElectron" />
-    <FtToast
-      :show-subscription-refresh="presentedRoutePath !== '/subscriptions'"
-    />
+    <FtToast />
     <FtProgressBar
       v-if="showProgressBar"
       :progress="displayedProgressBarPercentage"
@@ -496,19 +494,9 @@ const progressUsesToast = computed(() => {
   return store.getters.getShowProgressBarToast
 })
 
-const presentedRoutePath = computed(() => {
-  if (isElectron) {
-    return store.getters.getTabById(presentedTabId.value)?.route.path ?? ''
-  }
-  return route.path
-})
-
 const showProgressBar = computed(() => {
-  // The Subscriptions view shows its own progress bar below the tab bar
   return (localProgressBarVisible.value && !progressUsesToast.value) ||
-    (subscriptionRefreshInProgress.value &&
-      !progressUsesToast.value &&
-      presentedRoutePath.value !== '/subscriptions')
+    (subscriptionRefreshInProgress.value && !progressUsesToast.value)
 })
 const displayedProgressBarPercentage = computed(() => {
   return localProgressBarVisible.value

--- a/src/renderer/components/FtToast/FtToast.vue
+++ b/src/renderer/components/FtToast/FtToast.vue
@@ -70,13 +70,6 @@ import FtToastItem from './FtToastItem.vue'
 let removeShowToastListener = null
 const { t } = useI18n()
 
-const props = defineProps({
-  showSubscriptionRefresh: {
-    type: Boolean,
-    default: false
-  }
-})
-
 /**
  * @typedef ToastState the live state handed to {@link FtToastItem}
  * @property {string} message
@@ -228,7 +221,7 @@ const showProgressToast = computed(() => {
   return fullscreenTarget.value === null &&
     store.getters.getShowProgressBarToast &&
     (store.getters.getShowProgressBar ||
-      (props.showSubscriptionRefresh && store.getters.getSubscriptionFeedRefreshInProgress))
+      store.getters.getSubscriptionFeedRefreshInProgress)
 })
 const progressToastPercentage = computed(() => {
   return store.getters.getShowProgressBar

--- a/src/renderer/views/Subscriptions/Subscriptions.css
+++ b/src/renderer/views/Subscriptions/Subscriptions.css
@@ -170,14 +170,6 @@
   font-weight: bold;
 }
 
-.tabsProgressBar {
-  position: absolute;
-  inset-block-end: 0;
-  inset-inline-start: 0;
-  block-size: 3px;
-  background-color: var(--primary-color);
-}
-
 .subscriptionIcon {
   color: var(--primary-color);
 }

--- a/src/renderer/views/Subscriptions/Subscriptions.vue
+++ b/src/renderer/views/Subscriptions/Subscriptions.vue
@@ -185,12 +185,6 @@
             @cancel="cancelRefresh"
           />
         </div>
-        <div
-          v-if="currentTabRefreshing"
-          class="tabsProgressBar"
-          data-tab-loading-indicator
-          :style="{ inlineSize: refreshProgressPercentage + '%' }"
-        />
       </div>
       <SubscriptionsVideos
         v-if="currentTab === 'videos'"
@@ -344,11 +338,6 @@ const currentTabRefreshing = computed(() => {
 
   const currentFeedTab = currentTab.value === 'community' ? 'posts' : currentTab.value
   return refreshingFeedTab.value !== null && refreshingFeedTab.value === currentFeedTab
-})
-
-/** @type {import('vue').ComputedRef<number>} */
-const refreshProgressPercentage = computed(() => {
-  return store.getters.getSubscriptionFeedRefreshProgress
 })
 
 /** @type {import('vue').Ref<'videos' | 'shorts' | 'live' | 'community' | 'new' | null>} */


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Make sure to follow the contributing guidelines. -->
<!-- Important note, we may remove your pull request if you do not use this provided PR template correctly. -->
<!-- Agent instructions: Preserve every heading, comment, and marker in this template. Never remove or rewrite the release-note-category:start/end, release-note:start/end, or release-note-image:start/end marker pairs. Never remove or rewrite the Release note images section; leave its contents for a human. -->

## Pull Request Type
<!-- Please select what type of pull request this is: [x] -->
- [ ] Bugfix
- [x] Feature Implementation
- [ ] Documentation
- [ ] Other

## Related issue
<!-- Please link the issue your pull request is referring to. -->
<!-- If this pull request fully resolves the relevant issue, put "closes" before the issue number. -->
<!-- Example: "closes #123456". -->

Closes #741

## Description
<!-- Please write a clear and concise description of what the pull request does. -->

Subscription feed refresh progress previously moved between an embedded bar on the Subscriptions page and the global progress presentation elsewhere. It could also disappear when viewing a different subscription feed.

This consolidates refresh progress into the existing app-level presentation: the persistent notification when that setting is enabled, or the bottom progress bar otherwise. The feed tab's pulsing activity indicator remains in place.

## Release note category
<!-- Select exactly one category. Every pull request must select one. -->
<!-- Select "Not noteworthy" when the pull request fixes a bug in or improves functionality that has not yet appeared in a stable release. -->
<!-- release-note-category:start -->
- [ ] Not noteworthy
- [ ] Highlights
- [x] More improvements
- [ ] Fixed bugs
<!-- release-note-category:end -->

## Release note
<!-- Required unless "Not noteworthy" is selected. -->
<!-- Write one concise, user-facing entry without a leading bullet. -->
<!-- release-note:start -->
Subscription feed refresh progress now stays in one consistent location throughout the app.
<!-- release-note:end -->

## Release note images
<!-- Human-only: Agents must preserve this entire section and leave it empty. -->
<!-- Optional. Paste one or more Markdown images or HTML image tags here. -->
<!-- The release notes will use an HTML image tag and limit images taller than 300 pixels. -->
<!-- release-note-image:start -->

<!-- release-note-image:end -->

## Testing
<!-- How can reviewers verify that the PR produces correct results? -->
<!-- Please provide instructions so that others can ensure that your pull request would produce correct results. For examples see, https://github.com/FreeTubeApp/FreeTube/pull/5743, https://github.com/FreeTubeApp/FreeTube/pull/7349, https://github.com/FreeTubeApp/FreeTube/pull/5125, https://github.com/FreeTubeApp/FreeTube/pull/7338 -->
<!-- Agent instructions: Only write human-facing steps that explain how to verify the change while running this branch in dev mode. Include expected results and, when applicable, helpful console snippets for interactive verification. Do not include automated checks, commands, results, pass counts, or CI status. -->

1. Enable **Show progress as notification**, open Subscriptions, and refresh a feed. Confirm the persistent progress notification is visible on Subscriptions and remains visible after switching feeds or navigating elsewhere.
2. Confirm the refreshed feed tab still shows its pulsing activity indicator while the refresh runs.
3. Disable **Show progress as notification** and repeat the refresh. Confirm progress stays in the global bar at the bottom of the window on Subscriptions, after switching feeds, and after navigating elsewhere.
4. Confirm the former progress bar beneath the Subscriptions header is no longer shown.

## Additional context
<!-- Add any other context about the pull request here. -->

The progress presentation now follows the same setting regardless of the active page or subscription feed.
