### PR TITLE
feat(theme): add transparent colors, blur, and distinct interaction states

### DIFF
--- a/e2e/tests/offline/appearance.spec.mjs
+++ b/e2e/tests/offline/appearance.spec.mjs
@@ -207,6 +207,28 @@ test.describe('default appearance', () => {
 test.describe('custom theme editor', () => {
   test.use({ seed: { settings: { baseTheme: 'dark' } } })
 
+  test('clamps the color-source list after a responsive reflow', async ({ app, page }) => {
+    await setWindowWidth(app, 420)
+    await goToSettingsSection(page, 'theme')
+    await page.getByRole('button', { name: 'Create custom theme' }).click()
+    await page.getByRole('button', { name: 'Page background', exact: true }).click()
+    const picker = page.getByRole('dialog', { name: 'Page background' })
+    await picker.getByRole('button', { name: 'Copy from another color' }).click()
+
+    const list = page.locator('.colorSourceList')
+    await expect(list).toHaveAttribute('data-overlayscrollbars-viewport')
+    await list.evaluate(element => { element.scrollTop = element.scrollHeight })
+    await expect.poll(() => list.evaluate(element => element.scrollTop)).toBeGreaterThan(0)
+
+    await setWindowWidth(app, 1200)
+    await expect.poll(() => list.evaluate((element) => {
+      const content = element.querySelector('.colorSourceContent')
+      const contentEnd = content.offsetTop + content.offsetHeight +
+        Number.parseFloat(getComputedStyle(element).paddingBottom)
+      return element.scrollTop <= Math.max(0, contentEnd - element.clientHeight) + 1
+    })).toBe(true)
+  })
+
   test('applies a new theme created from System Default', async ({ page }) => {
     await goToSettingsSection(page, 'theme')
     const baseTheme = page.getByRole('combobox', { name: 'Base Theme' })

--- a/e2e/tests/offline/appearance.spec.mjs
+++ b/e2e/tests/offline/appearance.spec.mjs
@@ -246,6 +246,12 @@ test.describe('custom theme editor', () => {
 
     await page.keyboard.press('Escape')
     await expect(picker).toHaveCount(0)
+    await expect(trigger).toBeFocused()
+
+    await page.keyboard.press('Enter')
+    await picker.getByRole('button', { name: 'Apply' }).click()
+    await expect(picker).toHaveCount(0)
+    await expect(trigger).toBeFocused()
   })
 
   test('applies a new theme created from System Default', async ({ page }) => {

--- a/e2e/tests/offline/appearance.spec.mjs
+++ b/e2e/tests/offline/appearance.spec.mjs
@@ -274,32 +274,31 @@ test.describe('custom theme editor', () => {
     const basedOn = page.getByRole('combobox', { name: 'Based on' })
 
     const setEditorColor = async (label, value) => {
-      const field = editor.locator('.colorField').filter({ has: page.getByText(label, { exact: true }) })
-      await field.locator('input[type="color"]').evaluate((input, color) => {
-        input.value = color
-        input.dispatchEvent(new Event('input', { bubbles: true }))
-        input.dispatchEvent(new Event('change', { bubbles: true }))
-      }, value)
+      await editor.getByRole('button', { name: label, exact: true }).click()
+      const picker = page.getByRole('dialog', { name: label })
+      await picker.getByRole('textbox', { name: 'Hex color' }).fill(value)
+      await picker.getByRole('textbox', { name: 'Hex color' }).press('Enter')
+      await picker.getByRole('button', { name: 'Apply' }).click()
     }
 
     await setEditorColor('Logo icon', '#123456')
     await expect(resetColorsButton).toBeEnabled()
     await setEditorColor('Logo text', '#654321')
-    await setEditorColor('Background', '#101112')
+    await setEditorColor('Page background', '#101112')
     await sourceMainColor.click()
     await page.locator(`#${await sourceMainColor.getAttribute('aria-controls')}`)
       .getByRole('option', { name: 'Orange', exact: true }).click()
     await expect(page.locator('body')).toHaveCSS('--primary-color', '#ff9800')
     await expect(page.locator('body')).toHaveCSS('--bg-color', '#101112')
-    await expect(editor.locator('.colorField').filter({ hasText: 'Logo icon' }).locator('input'))
-      .toHaveValue('#123456')
+    await expect(editor.locator('.ftColorPicker').filter({ hasText: 'Logo icon' }).locator('code'))
+      .toHaveText('#123456')
     await sourceSecondaryColor.click()
     await page.locator(`#${await sourceSecondaryColor.getAttribute('aria-controls')}`)
       .getByRole('option', { name: 'Teal', exact: true }).click()
     await expect(page.locator('body')).toHaveCSS('--accent-color', '#009688')
     await expect(page.locator('body')).toHaveCSS('--bg-color', '#101112')
-    await expect(editor.locator('.colorField').filter({ hasText: 'Logo text' }).locator('input'))
-      .toHaveValue('#654321')
+    await expect(editor.locator('.ftColorPicker').filter({ hasText: 'Logo text' }).locator('code'))
+      .toHaveText('#654321')
     await page.evaluate(() => {
       const store = document.querySelector('#app').__vue_app__.config.globalProperties.$store
       store.commit('setBarColor', true)
@@ -315,10 +314,10 @@ test.describe('custom theme editor', () => {
     await expect(page.locator('.topNav .logoIcon')).toHaveCSS('background-color', 'rgb(171, 205, 239)')
     await expect(page.locator('.topNav .logoText')).toHaveCSS('background-color', 'rgb(171, 205, 239)')
 
-    await setEditorColor('Scrollbar hover', '#345678')
+    await setEditorColor('Scrollbar thumb hover', '#345678')
     await expect(page.locator('.os-scrollbar').first()).toHaveCSS('--os-handle-bg-hover', '#345678')
 
-    await setEditorColor('Dropdown hover text', '#fedcba')
+    await setEditorColor('Dropdown item hover text', '#fedcba')
     await basedOn.click()
     await expect(page.getByRole('option', { name: 'System Default' })).toHaveCount(0)
     await page.getByRole('option', { name: 'Dark', exact: true }).hover()
@@ -329,37 +328,30 @@ test.describe('custom theme editor', () => {
     await page.locator(`#${await basedOn.getAttribute('aria-controls')}`)
       .getByRole('option', { name: 'Dark', exact: true }).click()
 
-    const backgroundField = page.locator('.colorField')
-      .filter({ has: page.getByText('Background', { exact: true }) })
-    const backgroundInput = backgroundField.locator('input[type="color"]')
-    await expect(backgroundInput).toHaveValue('#0f0f0f')
+    const backgroundField = editor.locator('.ftColorPicker')
+      .filter({ has: page.getByText('Page background', { exact: true }) })
+    const backgroundValue = backgroundField.locator('code')
+    await expect(backgroundValue).toHaveText('#0f0f0f')
     await expect(page.locator('body')).toHaveCSS('--bg-color', '#0f0f0f')
     await expect(resetColorsButton).toBeDisabled()
 
-    const dragState = await backgroundInput.evaluate((input) => {
-      const code = input.parentElement.querySelector('code')
-      const before = {
-        preview: document.body.style.getPropertyValue('--bg-color'),
-        label: code.textContent
-      }
-      input.value = '#334455'
-      input.dispatchEvent(new Event('input', { bubbles: true }))
-      input.value = '#445566'
-      input.dispatchEvent(new Event('input', { bubbles: true }))
-      return {
-        before,
-        immediatePreview: document.body.style.getPropertyValue('--bg-color'),
-        immediateLabel: code.textContent
-      }
-    })
-    // Native drag events only queue the latest preview. They must not trigger a
-    // Vue render or a whole-app style update for every pointer movement.
-    expect(dragState.immediatePreview).toBe(dragState.before.preview)
-    expect(dragState.immediateLabel).toBe(dragState.before.label)
-    await expect(page.locator('body')).toHaveCSS('--bg-color', '#445566')
+    await backgroundField.getByRole('button', { name: 'Page background' }).click()
+    let backgroundPicker = page.getByRole('dialog', { name: 'Page background' })
+    await expect(backgroundPicker.getByRole('button', { name: 'Reset' })).toBeDisabled()
+    await backgroundPicker.getByRole('textbox', { name: 'Hex color' }).fill('#33445580')
+    await backgroundPicker.getByRole('textbox', { name: 'Hex color' }).press('Enter')
+    await expect(page.locator('body')).toHaveCSS('--bg-color', '#33445580')
+    await expect(backgroundPicker.getByRole('button', { name: 'Reset' })).toBeEnabled()
+    await page.locator('.customThemeEditor .themeNameField input').click()
+    await expect(page.getByRole('dialog', { name: 'Page background' })).toHaveCount(0)
+    await expect(page.locator('body')).toHaveCSS('--bg-color', '#0f0f0f')
 
-    await backgroundInput.evaluate(input => input.dispatchEvent(new Event('change', { bubbles: true })))
-    await expect(backgroundField.locator('code')).toHaveText('#445566')
+    await backgroundField.getByRole('button', { name: 'Page background' }).click()
+    backgroundPicker = page.getByRole('dialog', { name: 'Page background' })
+    await backgroundPicker.getByRole('textbox', { name: 'Hex color' }).fill('#445566')
+    await backgroundPicker.getByRole('textbox', { name: 'Hex color' }).press('Enter')
+    await backgroundPicker.getByRole('button', { name: 'Apply' }).click()
+    await expect(backgroundValue).toHaveText('#445566')
     await expect(resetColorsButton).toBeEnabled()
 
     const darkTheme = page.getByRole('checkbox', { name: 'Dark theme' })
@@ -367,14 +359,14 @@ test.describe('custom theme editor', () => {
     await page.locator('label.switch-label').filter({ hasText: 'Dark theme' }).click()
     await expect(page.locator('body')).toHaveAttribute('data-custom-theme', 'light')
 
-    await setEditorColor('Primary hover', '#123456')
-    await setEditorColor('Primary active', '#234567')
-    await setEditorColor('Accent hover', '#345678')
-    await setEditorColor('Accent active', '#456789')
+    await setEditorColor('Primary control hover and focus', '#123456')
+    await setEditorColor('Primary control pressed', '#234567')
+    await setEditorColor('Secondary control hover and focus', '#345678')
+    await setEditorColor('Secondary control pressed', '#456789')
     await setEditorColor('Destructive action', '#123abc')
-    await setEditorColor('Destructive hover', '#456def')
-    await setEditorColor('Destructive active', '#789abc')
-    await setEditorColor('Text on destructive action', '#fedcba')
+    await setEditorColor('Destructive hover and focus', '#456def')
+    await setEditorColor('Destructive pressed', '#789abc')
+    await setEditorColor('Text and icons on destructive actions', '#fedcba')
 
     const saveAndApplyButton = page.getByRole('button', { name: 'Save and apply' })
     await page.keyboard.press('Tab')
@@ -437,23 +429,23 @@ test.describe('custom theme editor', () => {
     await page.locator('.topNav .profileTrigger').click()
     await goTo(page, 'settings')
     await expect(page.getByText('Custom theme creator', { exact: true })).toBeVisible()
-    await expect(backgroundInput).toHaveValue('#445566')
+    await expect(backgroundValue).toHaveText('#445566')
 
     const discardChangesButton = page.getByRole('button', { name: 'Discard changes' })
     await expect(saveAndApplyButton).toBeDisabled()
     await expect(discardChangesButton).toBeDisabled()
 
-    await setEditorColor('Background', '#112233')
+    await setEditorColor('Page background', '#112233')
     await expect(page.locator('body')).toHaveCSS('--bg-color', '#112233')
     await expect(saveAndApplyButton).toBeEnabled()
     await expect(discardChangesButton).toBeEnabled()
     await discardChangesButton.click()
-    await expect(backgroundInput).toHaveValue('#445566')
+    await expect(backgroundValue).toHaveText('#445566')
     await expect(page.locator('body')).toHaveCSS('--bg-color', '#445566')
     await expect(saveAndApplyButton).toBeDisabled()
     await expect(discardChangesButton).toBeDisabled()
 
-    await setEditorColor('Background', '#112233')
+    await setEditorColor('Page background', '#112233')
     await expect(page.locator('body')).toHaveCSS('--bg-color', '#112233')
     await page.getByRole('button', { name: 'Show Keyboard Shortcuts' }).click()
     await expect(page.getByText('Custom theme creator', { exact: true })).toHaveCount(0)
@@ -465,7 +457,7 @@ test.describe('custom theme editor', () => {
     await expect(page.getByRole('combobox', { name: /Secondary colou?r theme/i })).toBeDisabled()
 
     await page.getByRole('button', { name: 'Create custom theme' }).click()
-    await expect(backgroundInput).toHaveValue('#445566')
+    await expect(backgroundValue).toHaveText('#445566')
     await expect(page.getByRole('combobox', { name: 'Based on' })).toHaveText('Dark')
     await expect(editor.getByRole('combobox', { name: /Main colou?r theme/i })).toHaveText('Orange')
     await expect(editor.getByRole('combobox', { name: /Secondary colou?r theme/i })).toHaveText('Teal')
@@ -516,13 +508,13 @@ test.describe('custom theme editor', () => {
       .getByRole('option', { name: 'Paper', exact: true }).click()
     await expect(page.getByRole('button', { name: 'Edit custom theme' })).toBeVisible()
     await page.getByRole('button', { name: 'Edit custom theme' }).click()
-    await setEditorColor('Background', '#abcdef')
+    await setEditorColor('Page background', '#abcdef')
     await expect(page.locator('body')).toHaveCSS('--bg-color', '#abcdef')
     await page.locator('.settingsBackButton').click()
     await expect(page.locator('body')).toHaveCSS('--bg-color', '#f1f1f1')
     await expect(page.locator('body')).toHaveClass(/custom/)
     await page.getByRole('button', { name: 'Edit custom theme' }).click()
-    await setEditorColor('Background', '#abcdef')
+    await setEditorColor('Page background', '#abcdef')
     await page.emulateMedia({ colorScheme: 'dark' })
     await page.getByRole('button', { name: 'Save and apply' }).click()
     await expect(page.locator('.settingsWindow:visible')
@@ -539,7 +531,7 @@ test.describe('custom theme editor', () => {
     await expect(page.locator('body')).toHaveCSS('--bg-color', '#445566')
     await page.getByRole('button', { name: 'Edit custom theme' }).click()
     await expect(page.getByRole('combobox', { name: 'Based on' })).toHaveText('Dark')
-    await expect(backgroundInput).toHaveValue('#445566')
+    await expect(backgroundValue).toHaveText('#445566')
 
     ;({ page } = await app.relaunch())
     await expect(page.locator('body')).toHaveClass(/custom/)

--- a/e2e/tests/offline/appearance.spec.mjs
+++ b/e2e/tests/offline/appearance.spec.mjs
@@ -229,6 +229,25 @@ test.describe('custom theme editor', () => {
     })).toBe(true)
   })
 
+  test('moves keyboard focus into the color picker', async ({ page }) => {
+    await goToSettingsSection(page, 'theme')
+    await page.getByRole('button', { name: 'Create custom theme' }).click()
+
+    const trigger = page.getByRole('button', { name: 'Page background', exact: true })
+    await trigger.focus()
+    await page.keyboard.press('Enter')
+
+    const picker = page.getByRole('dialog', { name: 'Page background' })
+    const saturationSlider = picker.getByRole('slider', { name: 'Saturation and brightness' })
+    await expect(saturationSlider).toBeFocused()
+    const valueBefore = await saturationSlider.getAttribute('aria-valuetext')
+    await page.keyboard.press('ArrowRight')
+    await expect(saturationSlider).not.toHaveAttribute('aria-valuetext', valueBefore)
+
+    await page.keyboard.press('Escape')
+    await expect(picker).toHaveCount(0)
+  })
+
   test('applies a new theme created from System Default', async ({ page }) => {
     await goToSettingsSection(page, 'theme')
     const baseTheme = page.getByRole('combobox', { name: 'Base Theme' })

--- a/e2e/tests/offline/profiles.spec.mjs
+++ b/e2e/tests/offline/profiles.spec.mjs
@@ -371,9 +371,13 @@ test.describe('profile manager', () => {
     await expect(customEmoji).toHaveValue('')
     await expect(preview.locator('img')).toBeVisible()
 
+    await page.locator('.profileColorPicker .colorFieldTrigger').click()
+    await colorPicker.locator('input[type="text"]').fill('#123456')
+    await colorPicker.locator('input[type="text"]').press('Enter')
     await customEmoji.fill('❤')
     await expect(customEmoji).toHaveValue('❤')
     await expect(preview).toContainText('❤')
+    await expect(preview).not.toHaveCSS('background-color', 'rgba(0, 0, 0, 0)')
 
     await customEmoji.fill('🌍')
     await expect(preview.locator('img')).toHaveCount(0)

--- a/e2e/tests/offline/profiles.spec.mjs
+++ b/e2e/tests/offline/profiles.spec.mjs
@@ -198,6 +198,28 @@ test.describe('profile manager', () => {
   test.describe('theme color profiles', () => {
     test.use({ seed: { settings: { mainColor: 'Green' } } })
 
+    test('keeps a keyboard-selected swatch when the custom picker was open', async ({ app, page }) => {
+      await openProfileList(page)
+      await page.locator('.profilePanelHeader button').last().click()
+      await page.locator('.card .profileList').getByText('All Channels').click()
+      await page.locator('.themeColorOption').click()
+      await page.locator('.profileColorPicker .colorFieldTrigger').click()
+
+      const redSwatch = page.locator('.colorOptions .colorOption').nth(1)
+      await redSwatch.focus()
+      await redSwatch.press('Enter')
+      await expect(page.locator('.colorPickerPopover')).toHaveCount(0)
+      await expect(page.locator('.profilePreviewIcon')).toHaveCSS('background-color', 'rgb(213, 0, 0)')
+
+      await page.getByRole('button', { name: 'Update Profile' }).click()
+      await expect.poll(async () => {
+        const contents = await readFile(path.join(app.userDataDir, 'profiles.db'), 'utf8')
+        const records = contents.trim().split('\n').map(line => JSON.parse(line))
+        const profile = records.findLast(record => record._id === 'allChannels' && !record.$$deleted)
+        return profile?.bgColor
+      }).toBe('#d50000')
+    })
+
     test('follows the theme color when the theme color option is picked', async ({ app, page }) => {
       await openProfileList(page)
       await page.locator('.profilePanelHeader button').last().click()

--- a/e2e/tests/offline/profiles.spec.mjs
+++ b/e2e/tests/offline/profiles.spec.mjs
@@ -302,6 +302,33 @@ test.describe('profile manager', () => {
     })
   })
 
+  test('applies opaque black to an image profile that was transparent', async ({ app, page }) => {
+    await openProfileList(page)
+    await page.locator('.profilePanelHeader button').last().click()
+    await page.locator('.card .profileList').getByText('All Channels').click()
+
+    await page.locator('.imageInput').setInputFiles({
+      name: 'globe.svg',
+      mimeType: 'image/svg+xml',
+      buffer: Buffer.from('<svg xmlns="http://www.w3.org/2000/svg" width="24" height="24"><circle cx="12" cy="12" r="10"/></svg>')
+    })
+    await page.getByRole('button', { name: 'Apply Crop' }).click()
+
+    await page.locator('.profileColorPicker .colorFieldTrigger').click()
+    const colorPicker = page.locator('.colorPickerPopover')
+    await colorPicker.locator('input[type="text"]').fill('#000000')
+    await colorPicker.locator('input[type="text"]').press('Enter')
+    await colorPicker.getByRole('button', { name: 'Apply' }).click()
+    await expect(page.locator('.profilePreviewIcon')).toHaveCSS('background-color', 'rgb(0, 0, 0)')
+
+    await page.getByRole('button', { name: 'Update Profile' }).click()
+    await expect.poll(async () => {
+      const contents = await readFile(path.join(app.userDataDir, 'profiles.db'), 'utf8')
+      const records = contents.trim().split('\n').map(line => JSON.parse(line))
+      return records.findLast(record => record._id === 'allChannels' && !record.$$deleted)?.bgColor
+    }).toBe('#000000')
+  })
+
   test('customizes a profile icon with a cropped SVG or emoji', async ({ app, page }) => {
     await openProfileList(page)
     await page.locator('.profilePanelHeader button').last().click()

--- a/e2e/tests/offline/profiles.spec.mjs
+++ b/e2e/tests/offline/profiles.spec.mjs
@@ -216,6 +216,15 @@ test.describe('profile manager', () => {
       await page.getByRole('heading', { name: 'Profile Preview' }).click()
       await expect(preview).toHaveCSS('background-color', 'rgb(76, 175, 80)')
 
+      await page.locator('.profileColorPicker .colorFieldTrigger').click()
+      await page.evaluate(() => {
+        const store = document.querySelector('#app').__vue_app__.config.globalProperties.$store
+        return store.dispatch('updateMainColor', 'Orange')
+      })
+      await expect(preview).toHaveCSS('background-color', 'rgb(255, 152, 0)')
+      await page.getByRole('heading', { name: 'Profile Preview' }).click()
+      await expect(preview).toHaveCSS('background-color', 'rgb(255, 152, 0)')
+
       await page.getByRole('button', { name: 'Update Profile' }).click()
 
       await expect.poll(async () => {
@@ -227,7 +236,7 @@ test.describe('profile manager', () => {
 
       ;({ page } = await app.relaunch())
       // the profile keeps the resolved theme color after restart
-      await expect(profileIconInitial(page)).toHaveCSS('background-color', 'rgb(76, 175, 80)')
+      await expect(profileIconInitial(page)).toHaveCSS('background-color', 'rgb(255, 152, 0)')
       // switching the theme color has to repaint the profile, without touching the profile itself
       await goToSettingsSection(page, 'theme')
 

--- a/e2e/tests/offline/profiles.spec.mjs
+++ b/e2e/tests/offline/profiles.spec.mjs
@@ -243,6 +243,34 @@ test.describe('profile manager', () => {
     })
   })
 
+  test.describe('shorthand theme color profiles', () => {
+    test.use({ seed: { settings: { baseTheme: 'hotPink' } } })
+
+    test('preserves the theme color when cancelling picker changes', async ({ app, page }) => {
+      await openProfileList(page)
+      await page.locator('.profilePanelHeader button').last().click()
+      await page.locator('.card .profileList').getByText('All Channels').click()
+      await page.locator('.themeColorOption').click()
+
+      const preview = page.locator('.profilePreviewIcon')
+      await expect(preview).toHaveCSS('background-color', 'rgb(0, 0, 0)')
+
+      await page.locator('.profileColorPicker .colorFieldTrigger').click()
+      const colorPicker = page.locator('.colorPickerPopover')
+      await colorPicker.locator('input[type="text"]').fill('#123456')
+      await colorPicker.locator('input[type="text"]').press('Enter')
+      await page.getByRole('heading', { name: 'Profile Preview' }).click()
+      await page.getByRole('button', { name: 'Update Profile' }).click()
+
+      await expect.poll(async () => {
+        const contents = await readFile(path.join(app.userDataDir, 'profiles.db'), 'utf8')
+        const records = contents.trim().split('\n').map(line => JSON.parse(line))
+        const profile = records.findLast(record => record._id === 'allChannels' && !record.$$deleted)
+        return profile?.bgColor
+      }).toBe('var(--primary-color)')
+    })
+  })
+
   test('customizes a profile icon with a cropped SVG or emoji', async ({ app, page }) => {
     await openProfileList(page)
     await page.locator('.profilePanelHeader button').last().click()

--- a/e2e/tests/offline/profiles.spec.mjs
+++ b/e2e/tests/offline/profiles.spec.mjs
@@ -208,6 +208,14 @@ test.describe('profile manager', () => {
       // 'Green' is the seeded main color theme
       const preview = page.locator('.profilePreviewIcon')
       await expect(preview).toHaveCSS('background-color', 'rgb(76, 175, 80)')
+
+      await page.locator('.profileColorPicker .colorFieldTrigger').click()
+      const colorPicker = page.locator('.colorPickerPopover')
+      await colorPicker.locator('input[type="text"]').fill('#123456')
+      await colorPicker.locator('input[type="text"]').press('Enter')
+      await page.getByRole('heading', { name: 'Profile Preview' }).click()
+      await expect(preview).toHaveCSS('background-color', 'rgb(76, 175, 80)')
+
       await page.getByRole('button', { name: 'Update Profile' }).click()
 
       await expect.poll(async () => {
@@ -255,6 +263,14 @@ test.describe('profile manager', () => {
     const preview = page.locator('.profilePreviewIcon')
     await expect(preview.locator('img')).toBeVisible()
     await expect(preview).toHaveCSS('background-color', 'rgba(0, 0, 0, 0)')
+
+    await page.locator('.profileColorPicker .colorFieldTrigger').click()
+    const colorPicker = page.locator('.colorPickerPopover')
+    await colorPicker.locator('input[type="text"]').fill('#123456')
+    await colorPicker.locator('input[type="text"]').press('Enter')
+    await page.getByRole('heading', { name: 'Profile Preview' }).click()
+    await expect(preview).toHaveCSS('background-color', 'rgba(0, 0, 0, 0)')
+
     await page.getByRole('button', { name: 'Update Profile' }).click()
 
     await expect.poll(async () => {

--- a/e2e/tests/offline/settings.spec.mjs
+++ b/e2e/tests/offline/settings.spec.mjs
@@ -903,20 +903,19 @@ test.describe('settings', () => {
     await edgeStyle.click()
     await page.getByRole('option', { name: 'Drop Shadow' }).click()
 
-    const edgeStyleLabel = edgeStyle.locator('..').locator('.select-label')
+    const edgeStyleControl = edgeStyle.locator('..').locator('..')
     const edgeColorControl = page.locator('.captionColorControl').filter({ hasText: 'Edge Color' })
-    const edgeColorLabel = edgeColorControl.locator(':scope > span')
-    const edgeColorInput = edgeColorControl.locator('input[type="color"]')
-    const [styleLabelBounds, colorLabelBounds, styleInputBounds, colorInputBounds] = await Promise.all([
-      edgeStyleLabel.boundingBox(),
-      edgeColorLabel.boundingBox(),
-      edgeStyle.boundingBox(),
-      edgeColorInput.boundingBox()
+    const edgeColorTrigger = edgeColorControl.getByRole('button', { name: 'Edge Color' })
+    const [styleControlBounds, colorControlBounds, colorTriggerBounds] = await Promise.all([
+      edgeStyleControl.boundingBox(),
+      edgeColorControl.boundingBox(),
+      edgeColorTrigger.boundingBox()
     ])
 
-    expect(colorLabelBounds.y).toBeCloseTo(styleLabelBounds.y, 0)
-    expect(colorInputBounds.y).toBeCloseTo(styleInputBounds.y, 0)
-    expect(colorInputBounds.height).toBeCloseTo(styleInputBounds.height, 0)
+    expect(colorControlBounds.y).toBeCloseTo(styleControlBounds.y, 0)
+    expect(colorControlBounds.height).toBeCloseTo(styleControlBounds.height, 0)
+    expect(colorTriggerBounds.y).toBeCloseTo(colorControlBounds.y + 1, 0)
+    expect(colorTriggerBounds.height).toBeCloseTo(colorControlBounds.height - 2, 0)
   })
 
   test('stacks caption controls at narrow settings widths', async ({ page, attachScreenshot }) => {

--- a/e2e/tests/offline/settings.spec.mjs
+++ b/e2e/tests/offline/settings.spec.mjs
@@ -1372,12 +1372,13 @@ test.describe('settings', () => {
     await page.locator('.settingsMenu [data-section="theme"]').click()
 
     const selectRows = page.locator('.themeSelectRow')
-    await expect(selectRows).toHaveCount(3)
-    await expect(selectRows.nth(0).locator('.select')).toHaveCount(3)
-    await expect(selectRows.nth(1).locator('.select')).toHaveCount(2)
+    await expect(selectRows).toHaveCount(4)
+    await expect(selectRows.nth(0).locator('.select')).toHaveCount(1)
+    await expect(selectRows.nth(1).locator('.select')).toHaveCount(3)
     await expect(selectRows.nth(2).locator('.select')).toHaveCount(2)
+    await expect(selectRows.nth(3).locator('.select')).toHaveCount(2)
 
-    const baseThemeLabel = selectRows.nth(0).locator('.select').first().locator('.select-label')
+    const baseThemeLabel = selectRows.nth(1).locator('.select').first().locator('.select-label')
     const alignedLabelParts = await baseThemeLabel
       .locator('.select-icon, .select-placeholder, .syncedSettingIndicator, .changedSettingIndicatorPlaceholder')
       .evaluateAll(elements => elements.map(element => {

--- a/src/customTheme.js
+++ b/src/customTheme.js
@@ -3,70 +3,102 @@ export const CUSTOM_THEMES_SYNC_KEY = 'customThemes'
 export const CUSTOM_THEME_VALUE_PREFIX = 'custom:'
 
 export const CUSTOM_THEME_COLORS = Object.freeze([
-  ['primaryText', '--primary-text-color', 'Primary text'],
+  ['primaryText', '--primary-text-color', 'Main text'],
   ['secondaryText', '--secondary-text-color', 'Secondary text'],
-  ['tertiaryText', '--tertiary-text-color', 'Tertiary text'],
-  ['title', '--title-color', 'Titles'],
+  ['tertiaryText', '--tertiary-text-color', 'Subtle text'],
+  ['border', '--border-color', 'Borders and dividers'],
+  ['subtleSurface', '--subtle-surface-color', 'Subtle surfaces and indicators'],
+  ['title', '--title-color', 'Title text'],
   ['logoPrimary', '--logo-primary-color', 'Logo icon'],
   ['logoSecondary', '--logo-secondary-color', 'Logo text'],
   ['logoTertiary', '--logo-tertiary-color', 'Logo hover'],
-  ['background', '--bg-color', 'Background'],
-  ['cardBackground', '--card-bg-color', 'Cards'],
-  ['secondaryCardBackground', '--secondary-card-bg-color', 'Secondary cards'],
+  ['logoPressed', '--logo-pressed-color', 'Logo pressed'],
+  ['background', '--bg-color', 'Page background'],
+  ['cardBackground', '--card-bg-color', 'Card background'],
+  ['secondaryCardBackground', '--secondary-card-bg-color', 'Secondary card background'],
   ['favoriteIcon', '--favorite-icon-color', 'Favorite icon'],
-  ['error', '--red-500', 'Errors'],
-  ['scrollbar', '--scrollbar-color', 'Scrollbar'],
-  ['scrollbarHover', '--scrollbar-color-hover', 'Scrollbar hover'],
-  ['scrollbarTextHover', '--scrollbar-text-color-hover', 'Dropdown hover text'],
-  ['sideNav', '--side-nav-color', 'Side navigation'],
-  ['sideNavHover', '--side-nav-hover-color', 'Side navigation hover'],
-  ['sideNavHoverText', '--side-nav-hover-text-color', 'Side navigation hover text'],
-  ['sideNavActive', '--side-nav-active-color', 'Side navigation active'],
-  ['sideNavActiveText', '--side-nav-active-text-color', 'Side navigation active text'],
-  ['searchBar', '--search-bar-color', 'Search bar'],
-  ['settingsSearchBar', '--settings-search-bar-color', 'Settings search bar'],
+  ['error', '--red-500', 'Error color'],
+  ['scrollbar', '--scrollbar-color', 'Scrollbar thumb'],
+  ['scrollbarHover', '--scrollbar-color-hover', 'Scrollbar thumb hover'],
+  ['scrollbarActive', '--scrollbar-color-active', 'Scrollbar thumb pressed'],
+  ['scrollbarTextHover', '--scrollbar-text-color-hover', 'Dropdown item hover text'],
+  ['dropdownHover', '--dropdown-item-hover-color', 'Dropdown item hover background'],
+  ['dropdownHoverText', '--dropdown-item-hover-text-color', 'Dropdown item hover text'],
+  ['sideNav', '--side-nav-color', 'Navigation and panel background'],
+  ['sideNavHover', '--side-nav-hover-color', 'Neutral item hover and focus background'],
+  ['sideNavHoverText', '--side-nav-hover-text-color', 'Neutral item hover and focus text and icons'],
+  ['sideNavActive', '--side-nav-active-color', 'Neutral item pressed background'],
+  ['sideNavActiveText', '--side-nav-active-text-color', 'Neutral item pressed text and icons'],
+  ['headerHover', '--header-button-hover-color', 'Header button hover and focus background'],
+  ['headerHoverText', '--header-button-hover-text-color', 'Header button hover and focus text and icons'],
+  ['headerPressed', '--header-button-pressed-color', 'Header button pressed background'],
+  ['headerPressedText', '--header-button-pressed-text-color', 'Header button pressed text and icons'],
+  ['coloredHeaderHover', '--colored-header-button-hover-color', 'Colored header button hover and focus background'],
+  ['coloredHeaderHoverText', '--colored-header-button-hover-text-color', 'Colored header button hover and focus text and icons'],
+  ['coloredHeaderPressed', '--colored-header-button-pressed-color', 'Colored header button pressed background'],
+  ['coloredHeaderPressedText', '--colored-header-button-pressed-text-color', 'Colored header button pressed text and icons'],
+  ['searchBar', '--search-bar-color', 'Search and dropdown background'],
+  ['settingsSearchBar', '--settings-search-bar-color', 'Settings search background'],
   ['instanceMenu', '--instance-menu-color', 'Instance menu'],
   ['primaryInput', '--primary-input-color', 'Input background'],
-  ['primaryShadow', '--primary-shadow-color', 'Shadows'],
-  ['primary', '--primary-color', 'Primary color'],
-  ['primaryHover', '--primary-color-hover', 'Primary hover'],
-  ['primaryActive', '--primary-color-active', 'Primary active'],
-  ['textWithPrimary', '--text-with-main-color', 'Text on primary'],
-  ['accent', '--accent-color', 'Accent color'],
-  ['accentHover', '--accent-color-hover', 'Accent hover'],
-  ['accentActive', '--accent-color-active', 'Accent active'],
-  ['accentLight', '--accent-color-light', 'Light accent'],
+  ['primaryShadow', '--primary-shadow-color', 'Shadow color'],
+  ['primary', '--primary-color', 'Primary controls and highlights'],
+  ['primaryHover', '--primary-color-hover', 'Primary control hover and focus'],
+  ['primaryActive', '--primary-color-active', 'Primary control pressed'],
+  ['textWithPrimary', '--text-with-main-color', 'Text and icons on primary controls'],
+  ['accent', '--accent-color', 'Secondary controls and highlights'],
+  ['accentHover', '--accent-color-hover', 'Secondary control hover and focus'],
+  ['accentActive', '--accent-color-active', 'Secondary control pressed'],
+  ['accentLight', '--accent-color-light', 'Light secondary color'],
   ['accentVisited', '--accent-color-visited', 'Visited accent'],
-  ['textWithAccent', '--text-with-accent-color', 'Text on accent'],
+  ['textWithAccent', '--text-with-accent-color', 'Text and icons on secondary controls'],
   ['link', '--link-color', 'Links'],
   ['linkVisited', '--link-visited-color', 'Visited links'],
   ['destructive', '--destructive-color', 'Destructive action'],
-  ['destructiveHover', '--destructive-hover-color', 'Destructive hover'],
-  ['destructiveActive', '--destructive-active-color', 'Destructive active'],
-  ['destructiveText', '--destructive-text-color', 'Text on destructive action'],
+  ['destructiveHover', '--destructive-hover-color', 'Destructive hover and focus'],
+  ['destructiveActive', '--destructive-active-color', 'Destructive pressed'],
+  ['destructiveText', '--destructive-text-color', 'Text and icons on destructive actions'],
 ])
 
-const LEGACY_UNUSED_CUSTOM_THEME_COLOR_KEYS = new Set(['instanceMenu', 'accentVisited'])
+const LEGACY_UNUSED_CUSTOM_THEME_COLOR_KEYS = new Set([
+  'instanceMenu', 'accentVisited', 'scrollbarTextHover'
+])
 export const CUSTOM_THEME_EDITABLE_COLORS = Object.freeze(
   CUSTOM_THEME_COLORS.filter(([key]) => !LEGACY_UNUSED_CUSTOM_THEME_COLOR_KEYS.has(key))
 )
 
+export const CUSTOM_THEME_BLURS = Object.freeze([
+  ['cardBackground', '--card-bg-blur'],
+  ['secondaryCardBackground', '--secondary-card-bg-blur'],
+  ['searchBar', '--search-bar-blur'],
+  ['settingsSearchBar', '--settings-search-bar-blur'],
+  ['primaryInput', '--primary-input-blur'],
+])
+
+const DEFAULT_CUSTOM_THEME_BLURS = Object.freeze(
+  Object.fromEntries(CUSTOM_THEME_BLURS.map(([key]) => [key, 0]))
+)
+
 export const DEFAULT_CUSTOM_THEME = Object.freeze({
-  version: 1,
+  version: 2,
   id: '',
   name: 'Custom Theme',
   basedOn: 'dark',
   mainColor: 'Red',
   secondaryColor: 'Blue',
   isDark: true,
+  blurs: DEFAULT_CUSTOM_THEME_BLURS,
   colors: Object.freeze({
     primaryText: '#eeeeee',
     secondaryText: '#dddddd',
     tertiaryText: '#999999',
+    border: '#999999',
+    subtleSurface: '#999999',
     title: '#eeeeee',
     logoPrimary: '#eeeeee',
     logoSecondary: '#eeeeee',
     logoTertiary: '#eeeeee',
+    logoPressed: '#eeeeee',
     background: '#121212',
     cardBackground: '#242424',
     secondaryCardBackground: '#181818',
@@ -74,12 +106,23 @@ export const DEFAULT_CUSTOM_THEME = Object.freeze({
     error: '#f44336',
     scrollbar: '#515151',
     scrollbarHover: '#757575',
+    scrollbarActive: '#919191',
     scrollbarTextHover: '#eeeeee',
+    dropdownHover: '#757575',
+    dropdownHoverText: '#eeeeee',
     sideNav: '#181818',
     sideNavHover: '#242424',
     sideNavHoverText: '#eeeeee',
     sideNavActive: '#303030',
     sideNavActiveText: '#eeeeee',
+    headerHover: '#242424',
+    headerHoverText: '#eeeeee',
+    headerPressed: '#999999',
+    headerPressedText: '#eeeeee',
+    coloredHeaderHover: '#e53935',
+    coloredHeaderHoverText: '#ffffff',
+    coloredHeaderPressed: '#c62828',
+    coloredHeaderPressedText: '#ffffff',
     searchBar: '#262626',
     settingsSearchBar: '#242424',
     instanceMenu: '#262626',
@@ -104,7 +147,23 @@ export const DEFAULT_CUSTOM_THEME = Object.freeze({
   })
 })
 
-const HEX_COLOR_PATTERN = /^#[\da-f]{6}$/i
+const HEX_COLOR_PATTERN = /^#[\da-f]{6}(?:[\da-f]{2})?$/i
+
+const LEGACY_CUSTOM_THEME_COLOR_FALLBACKS = Object.freeze({
+  logoPressed: 'logoTertiary',
+  border: 'tertiaryText',
+  subtleSurface: 'tertiaryText',
+  dropdownHover: 'scrollbarHover',
+  dropdownHoverText: 'scrollbarTextHover',
+  headerHover: 'sideNavHover',
+  headerHoverText: 'sideNavHoverText',
+  headerPressed: 'tertiaryText',
+  headerPressedText: 'sideNavActiveText',
+  coloredHeaderHover: 'primaryHover',
+  coloredHeaderHoverText: 'textWithPrimary',
+  coloredHeaderPressed: 'primaryActive',
+  coloredHeaderPressedText: 'textWithPrimary',
+})
 
 export function normalizeCustomTheme(value) {
   if (value === null || typeof value !== 'object' || Array.isArray(value)) {
@@ -113,15 +172,24 @@ export function normalizeCustomTheme(value) {
 
   const colors = {}
   for (const [key] of CUSTOM_THEME_COLORS) {
-    const color = value.colors?.[key]
+    const color = value.colors?.[key] ??
+      (key === 'scrollbarActive' ? deriveScrollbarActiveColor(value.colors?.scrollbarHover) : undefined) ??
+      value.colors?.[LEGACY_CUSTOM_THEME_COLOR_FALLBACKS[key]]
     if (typeof color !== 'string' || !HEX_COLOR_PATTERN.test(color)) {
       throw new TypeError(`Invalid or missing custom theme color: ${key}`)
     }
     colors[key] = color.toLowerCase()
   }
 
+  const blurs = Object.fromEntries(CUSTOM_THEME_BLURS.map(([key]) => {
+    const blur = value.blurs?.[key]
+    return [key, typeof blur === 'number' && Number.isFinite(blur)
+      ? Math.round(Math.min(40, Math.max(0, blur)))
+      : 0]
+  }))
+
   return {
-    version: 1,
+    version: 2,
     id: typeof value.id === 'string' && /^[\w-]{1,80}$/.test(value.id)
       ? value.id
       : 'custom-theme',
@@ -138,13 +206,42 @@ export function normalizeCustomTheme(value) {
       ? value.secondaryColor
       : DEFAULT_CUSTOM_THEME.secondaryColor,
     isDark: value.isDark !== false,
+    blurs,
     colors
   }
+}
+
+function deriveScrollbarActiveColor(hoverColor) {
+  if (typeof hoverColor !== 'string' || !HEX_COLOR_PATTERN.test(hoverColor)) return undefined
+
+  const components = hoverColor.match(/[\da-f]{2}/gi).map(component => Number.parseInt(component, 16))
+  const hoverAlpha = (components[3] ?? 255) / 255
+  const mixedAlpha = hoverAlpha * 0.8 + 0.2
+  const rgb = components.slice(0, 3).map(component =>
+    Math.round((component * hoverAlpha * 0.8 + 255 * 0.2) / mixedAlpha))
+  const alpha = Math.round(mixedAlpha * 255)
+  return formatHexColor(rgb, alpha)
+}
+
+function formatHexColor(rgb, alpha) {
+  const color = rgb.map(component => component.toString(16).padStart(2, '0')).join('')
+  const transparency = alpha < 255 ? alpha.toString(16).padStart(2, '0') : ''
+  return `#${color}${transparency}`
 }
 
 export function normalizeCustomThemes(value) {
   if (!Array.isArray(value)) throw new TypeError('Custom themes must be a JSON array')
   return value.map(normalizeCustomTheme)
+}
+
+export function hexColorToRgbComponents(color) {
+  const components = color.match(/[\da-f]{2}/gi)
+  return components.slice(0, 3).map(value => Number.parseInt(value, 16)).join(' ')
+}
+
+export function customThemeBackdropBlur(color, strength) {
+  const alpha = color.length === 9 ? Number.parseInt(color.slice(7, 9), 16) : 255
+  return alpha < 255 && strength > 0 ? `blur(${strength}px)` : 'none'
 }
 
 export function customThemeValue(id) {
@@ -164,6 +261,7 @@ export function customThemeIdFromValue(value) {
 export function cloneDefaultCustomTheme() {
   return {
     ...DEFAULT_CUSTOM_THEME,
+    blurs: { ...DEFAULT_CUSTOM_THEME.blurs },
     colors: { ...DEFAULT_CUSTOM_THEME.colors }
   }
 }

--- a/src/renderer/App.css
+++ b/src/renderer/App.css
@@ -118,7 +118,7 @@
   padding-block: 0.75em;
   padding-inline: 1em;
   background-color: color-mix(in srgb, var(--card-bg-color) 88%, var(--primary-text-color));
-  border: 1px solid var(--tertiary-text-color);
+  border: 1px solid var(--border-color);
   border-radius: calc(6px * var(--ui-roundness));
 }
 
@@ -176,7 +176,7 @@
   padding: 8px;
   color: var(--primary-text-color);
   background-color: color-mix(in srgb, var(--bg-color) 94%, #000);
-  border: 1px solid var(--tertiary-text-color);
+  border: 1px solid var(--border-color);
   border-radius: calc(8px * var(--ui-roundness));
   box-shadow: 0 12px 32px rgb(0 0 0 / 32%);
 }
@@ -195,7 +195,8 @@
   padding-inline: 8px;
   color: var(--primary-text-color);
   background-color: var(--card-bg-color);
-  border: 1px solid var(--tertiary-text-color);
+  backdrop-filter: var(--card-bg-blur, none);
+  border: 1px solid var(--border-color);
   border-radius: calc(6px * var(--ui-roundness));
   outline: none;
 }
@@ -274,7 +275,7 @@
   overflow: auto;
   padding: 12px;
   background-color: color-mix(in srgb, var(--bg-color) 92%, #000);
-  border: 1px solid var(--tertiary-text-color);
+  border: 1px solid var(--border-color);
   border-radius: calc(8px * var(--ui-roundness));
   box-shadow: 0 16px 40px rgb(0 0 0 / 38%);
 }
@@ -287,6 +288,7 @@
   padding: 8px;
   color: var(--primary-text-color);
   background-color: var(--card-bg-color);
+  backdrop-filter: var(--card-bg-blur, none);
   border: 2px solid transparent;
   border-radius: calc(8px * var(--ui-roundness));
   cursor: pointer;

--- a/src/renderer/components/CaptionSettings/CaptionSettings.css
+++ b/src/renderer/components/CaptionSettings/CaptionSettings.css
@@ -68,6 +68,7 @@
   border: 1px solid var(--border-color);
   border-radius: calc(5px * var(--ui-roundness));
   background-color: var(--card-bg-color);
+  backdrop-filter: var(--card-bg-blur, none);
 }
 
 .captionControl :deep(.pure-material-slider) {
@@ -82,30 +83,15 @@
 }
 
 .captionColorControl {
-  flex-direction: column;
-  align-items: stretch;
-  justify-content: center;
-  gap: 0;
+  padding: 0;
   color: color-mix(in srgb, var(--primary-text-color) 87%, transparent);
-  cursor: pointer;
 }
 
-.captionColorControl > span {
-  min-block-size: 20px;
-  display: flex;
-  align-items: center;
-  gap: 4px;
-}
-
-.captionColorControl input {
+.captionColorControl :deep(.colorFieldTrigger) {
   inline-size: 100%;
-  block-size: 45px;
-  box-sizing: border-box;
-  padding: 2px;
-  border: 1px solid var(--border-color);
-  border-radius: calc(4px * var(--ui-roundness));
-  background: transparent;
-  cursor: pointer;
+  block-size: 100%;
+  min-block-size: 76px;
+  border-radius: inherit;
 }
 
 .captionActions {

--- a/src/renderer/components/CaptionSettings/CaptionSettings.vue
+++ b/src/renderer/components/CaptionSettings/CaptionSettings.vue
@@ -32,36 +32,38 @@
             @change="updateEnableCaptionTranslations"
           />
         </div>
-        <label class="captionControl captionColorControl">
-          <span>
+        <FtColorPicker
+          class="captionControl captionColorControl"
+          :label="t('Settings.Player Settings.Caption Appearance.Text Color')"
+          :model-value="captionSettings.textColor"
+          :allow-alpha="false"
+          @update:model-value="updateCaptionSetting('textColor', $event)"
+        >
+          <template #label>
             {{ t('Settings.Player Settings.Caption Appearance.Text Color') }}
             <FtSyncedSettingIndicator
               setting-key="defaultCaptionSettings"
               :is-changed="isCaptionSettingChanged('textColor')"
               @reset="resetCaptionSetting('textColor')"
             />
-          </span>
-          <input
-            type="color"
-            :value="captionSettings.textColor"
-            @input="updateCaptionSetting('textColor', $event.target.value)"
-          >
-        </label>
-        <label class="captionControl captionColorControl">
-          <span>
+          </template>
+        </FtColorPicker>
+        <FtColorPicker
+          class="captionControl captionColorControl"
+          :label="t('Settings.Player Settings.Caption Appearance.Background Color')"
+          :model-value="captionSettings.backgroundColor"
+          :allow-alpha="false"
+          @update:model-value="updateCaptionSetting('backgroundColor', $event)"
+        >
+          <template #label>
             {{ t('Settings.Player Settings.Caption Appearance.Background Color') }}
             <FtSyncedSettingIndicator
               setting-key="defaultCaptionSettings"
               :is-changed="isCaptionSettingChanged('backgroundColor')"
               @reset="resetCaptionSetting('backgroundColor')"
             />
-          </span>
-          <input
-            type="color"
-            :value="captionSettings.backgroundColor"
-            @input="updateCaptionSetting('backgroundColor', $event.target.value)"
-          >
-        </label>
+          </template>
+        </FtColorPicker>
         <div class="captionControl">
           <FtSlider
             :label="t('Settings.Player Settings.Caption Appearance.Background Opacity')"
@@ -130,24 +132,23 @@
             @reset="resetCaptionSetting('edgeStyle')"
           />
         </div>
-        <label
+        <FtColorPicker
           v-if="captionSettings.edgeStyle !== 'none'"
           class="captionControl captionColorControl"
+          :label="t('Settings.Player Settings.Caption Appearance.Edge Color')"
+          :model-value="captionSettings.edgeColor"
+          :allow-alpha="false"
+          @update:model-value="updateCaptionSetting('edgeColor', $event)"
         >
-          <span>
+          <template #label>
             {{ t('Settings.Player Settings.Caption Appearance.Edge Color') }}
             <FtSyncedSettingIndicator
               setting-key="defaultCaptionSettings"
               :is-changed="isCaptionSettingChanged('edgeColor')"
               @reset="resetCaptionSetting('edgeColor')"
             />
-          </span>
-          <input
-            type="color"
-            :value="captionSettings.edgeColor"
-            @input="updateCaptionSetting('edgeColor', $event.target.value)"
-          >
-        </label>
+          </template>
+        </FtColorPicker>
       </div>
       <div class="captionActions">
         <FtButton
@@ -165,6 +166,7 @@ import { computed } from 'vue'
 import { useI18n } from 'vue-i18n'
 
 import FtButton from '../FtButton/FtButton.vue'
+import FtColorPicker from '../FtColorPicker/FtColorPicker.vue'
 import FtSelect from '../FtSelect/FtSelect.vue'
 import FtSettingsSection from '../FtSettingsSection/FtSettingsSection.vue'
 import FtSlider from '../FtSlider/FtSlider.vue'

--- a/src/renderer/components/ChannelAbout/ChannelAbout.css
+++ b/src/renderer/components/ChannelAbout/ChannelAbout.css
@@ -1,5 +1,6 @@
 .about {
   background-color: var(--card-bg-color);
+  backdrop-filter: var(--card-bg-blur, none);
   margin-block-start: 0;
   padding: 10px;
   position: relative;
@@ -27,6 +28,7 @@
 
 .aboutTagLink {
   background-color: var(--secondary-card-bg-color);
+  backdrop-filter: var(--secondary-card-bg-blur, none);
   color: var(--primary-text-color);
   border-radius: calc(7px * var(--ui-roundness));
   padding: 7px;

--- a/src/renderer/components/ChannelDetails/ChannelDetails.css
+++ b/src/renderer/components/ChannelDetails/ChannelDetails.css
@@ -17,6 +17,7 @@
 .infoContainer {
   position: relative;
   background-color: var(--card-bg-color);
+  backdrop-filter: var(--card-bg-blur, none);
   border-radius: 0 0 calc(8px * var(--ui-roundness)) calc(8px * var(--ui-roundness));
   margin-block-start: 10px;
   padding-block: 0;
@@ -107,7 +108,7 @@
 .tab:hover,
 .tab:focus {
   font-weight: bold;
-  border-block-end: 3px solid var(--tertiary-text-color);
+  border-block-end: 3px solid var(--border-color);
 }
 
 .selectedTab {

--- a/src/renderer/components/CommentSection/CommentSection.css
+++ b/src/renderer/components/CommentSection/CommentSection.css
@@ -22,6 +22,7 @@
   overflow: hidden;
   color: #fff;
   background-color: transparent;
+  backdrop-filter: none;
   box-shadow: none;
 }
 
@@ -254,7 +255,7 @@
 .commentThread {
   position: relative;
 
-  --comment-thread-line-color: color-mix(in srgb, var(--tertiary-text-color) 55%, var(--card-bg-color));
+  --comment-thread-line-color: color-mix(in srgb, var(--border-color) 55%, var(--card-bg-color));
   --highlighted-comment-offset: 13px;
 }
 
@@ -313,6 +314,7 @@
 
 .commentOwner {
   background-color: var(--secondary-card-bg-color);
+  backdrop-filter: var(--secondary-card-bg-blur, none);
   border-radius: calc(10px * var(--ui-roundness));
   padding-inline: 10px;
 }

--- a/src/renderer/components/CustomThemeEditor/CustomThemeEditor.vue
+++ b/src/renderer/components/CustomThemeEditor/CustomThemeEditor.vue
@@ -68,20 +68,17 @@
       </div>
 
       <div class="colorGrid">
-        <label
+        <FtColorPicker
           v-for="([key, property, label]) in CUSTOM_THEME_EDITABLE_COLORS"
           :key="key"
-          class="colorField"
-        >
-          <input
-            :value="draft.colors[key]"
-            type="color"
-            @input="updateColor(key, property, $event.target.value)"
-            @change="commitColorChanges"
-          >
-          <span>{{ colorNames[label] ?? label }}</span>
-          <code>{{ draft.colors[key] }}</code>
-        </label>
+          :model-value="draft.colors[key]"
+          :blur-value="getBlurValue(key)"
+          :label="colorNames[label] ?? label"
+          :other-colors="getOtherColors(key)"
+          @update:model-value="updateColor(key, property, $event)"
+          @update:blur-value="updateBlur(key, $event)"
+          @change="commitThemeChanges"
+        />
       </div>
 
       <div class="editorFooter">
@@ -136,15 +133,19 @@ import FtPrompt from '../FtPrompt/FtPrompt.vue'
 import FtSettingsSubpage from '../FtSettingsSubpage/FtSettingsSubpage.vue'
 import FtSelect from '../FtSelect/FtSelect.vue'
 import FtToggleSwitch from '../FtToggleSwitch/FtToggleSwitch.vue'
+import FtColorPicker from '../FtColorPicker/FtColorPicker.vue'
 
 import store from '../../store/index'
 import { useColorTranslations } from '../../composables/colors'
 import {
   cloneDefaultCustomTheme,
+  CUSTOM_THEME_BLURS,
   CUSTOM_THEME_COLORS,
   CUSTOM_THEME_EDITABLE_COLORS,
+  customThemeBackdropBlur,
   customThemeIdFromValue,
   customThemeValue,
+  hexColorToRgbComponents,
   normalizeCustomTheme,
 } from '../../../customTheme'
 import {
@@ -193,11 +194,16 @@ const BASE_THEME_TRANSLATION_KEYS = [
   'Everforest Light Hard', 'Everforest Light Medium', 'Everforest Light Low',
   'Gruvbox Dark', 'Gruvbox Light', 'Solarized Dark', 'Solarized Light'
 ]
-const MAIN_COLOR_KEYS = ['primary', 'primaryHover', 'primaryActive', 'textWithPrimary']
+const MAIN_COLOR_KEYS = [
+  'primary', 'primaryHover', 'primaryActive', 'textWithPrimary',
+  'coloredHeaderHover', 'coloredHeaderHoverText',
+  'coloredHeaderPressed', 'coloredHeaderPressedText'
+]
 const SECONDARY_COLOR_KEYS = [
   'accent', 'accentHover', 'accentActive', 'accentLight', 'accentVisited',
   'textWithAccent', 'link', 'linkVisited'
 ]
+const blurProperties = new Map(CUSTOM_THEME_BLURS.map(([key, property]) => [key, property]))
 const baseThemeNames = computed(() => {
   const translations = tm('Settings.Theme Settings.Base Theme')
   return BASE_THEME_TRANSLATION_KEYS.map(key => translations[key] ?? key)
@@ -208,7 +214,22 @@ const colorNames = computed(() => tm('Settings.Theme Settings.Custom Theme.Color
 const isSavedTheme = computed(() => store.getters.getCustomThemes.some(({ id }) => id === draft.id))
 const hasChanges = computed(() => savedTheme.value === null || !themesMatch(draft, savedTheme.value))
 const isUsingThemeSourceColors = computed(() => themeSourceColors.value !== null &&
-  CUSTOM_THEME_EDITABLE_COLORS.every(([key]) => draft.colors[key] === themeSourceColors.value[key]))
+  CUSTOM_THEME_EDITABLE_COLORS.every(([key]) => draft.colors[key] === themeSourceColors.value[key]) &&
+  CUSTOM_THEME_BLURS.every(([key]) => draft.blurs[key] === 0))
+
+function getBlurValue(key) {
+  return blurProperties.has(key) ? draft.blurs[key] : null
+}
+
+function getOtherColors(currentKey) {
+  return CUSTOM_THEME_EDITABLE_COLORS
+    .filter(([key]) => key !== currentKey)
+    .map(([key, , label]) => ({
+      key,
+      label: colorNames.value[label] ?? label,
+      value: draft.colors[key]
+    }))
+}
 
 watch(() => props.open, async (open) => {
   const loadId = ++editorLoadId
@@ -276,6 +297,7 @@ function setDraft(theme) {
   draft.mainColor = theme.mainColor
   draft.secondaryColor = theme.secondaryColor
   draft.isDark = theme.isDark
+  draft.blurs = { ...theme.blurs }
   draft.colors = { ...theme.colors }
 }
 
@@ -287,7 +309,12 @@ function themesMatch(first, second) {
     first.mainColor === second.mainColor &&
     first.secondaryColor === second.secondaryColor &&
     first.isDark === second.isDark &&
+    blursMatch(first.blurs, second.blurs) &&
     colorsMatch(first.colors, second.colors)
+}
+
+function blursMatch(first, second) {
+  return CUSTOM_THEME_BLURS.every(([key]) => first[key] === second[key])
 }
 
 function colorsMatch(first, second) {
@@ -338,12 +365,25 @@ function updateColor(key, property, value) {
   }
 }
 
-function commitColorChanges() {
+function updateBlur(key, value) {
+  const property = blurProperties.get(key)
+  if (property === undefined) return
+  draft.blurs[key] = value
+  if (previewing) {
+    document.body.style.setProperty(
+      property,
+      customThemeBackdropBlur(draft.colors[key], value)
+    )
+  }
+}
+
+function commitThemeChanges() {
   flushColorPreviews()
   // Keep drag-time changes outside Vue's render cycle. Replacing the object
   // once the native picker commits updates the displayed hex value without
   // writing back into an open color picker on every pointer movement.
   draft.colors = { ...draft.colors }
+  draft.blurs = { ...draft.blurs }
 }
 
 function flushColorPreviews() {
@@ -353,10 +393,17 @@ function flushColorPreviews() {
   }
   for (const [key, { property, value }] of pendingColorPreviews) {
     document.body.style.setProperty(property, value)
+    const blurProperty = blurProperties.get(key)
+    if (blurProperty !== undefined) {
+      document.body.style.setProperty(
+        blurProperty,
+        customThemeBackdropBlur(value, draft.blurs[key])
+      )
+    }
     if (key === 'accent') {
       document.body.style.setProperty(
         '--accent-color-rgb',
-        value.match(/[\da-f]{2}/gi).map(component => Number.parseInt(component, 16)).join(' ')
+        hexColorToRgbComponents(value)
       )
     }
   }
@@ -400,6 +447,7 @@ function copyThemeSources() {
   const sourceColors = readThemeSourceColors()
   themeSourceColors.value = sourceColors
   draft.colors = { ...sourceColors }
+  draft.blurs = Object.fromEntries(CUSTOM_THEME_BLURS.map(([key]) => [key, 0]))
   draft.isDark = !['light', 'pastelPink', 'catppuccinLatte', 'everforestLightHard',
     'everforestLightMedium', 'everforestLightLow', 'gruvboxLight', 'solarizedLight']
     .includes(draft.basedOn)
@@ -426,25 +474,23 @@ function readThemeSourceColors() {
   const probe = document.createElement('span')
   probe.hidden = true
   document.body.append(probe)
-  const backgroundHex = readColor(probe, '--bg-color', [255, 255, 255])
-  const background = backgroundHex.match(/[\da-f]{2}/gi).map(value => Number.parseInt(value, 16))
   const colors = Object.fromEntries(CUSTOM_THEME_COLORS.map(([key, property]) =>
-    [key, readColor(probe, property, background)]))
+    [key, readColor(probe, property)]))
   probe.remove()
   return colors
 }
 
-function readColor(probe, property, background) {
+function readColor(probe, property) {
   probe.style.color = `var(${property})`
   const color = getComputedStyle(probe).color
   const match = color.match(/rgba?\(\s*(\d+)[, ]+\s*(\d+)[, ]+\s*(\d+)(?:\s*[,/]\s*([\d.]+))?\s*\)/)
   if (!match) return '#000000'
 
-  const alpha = match[4] === undefined ? 1 : Number.parseFloat(match[4])
-  return '#' + match.slice(1, 4).map((value, index) => {
-    const composited = Math.round(Number.parseInt(value, 10) * alpha + background[index] * (1 - alpha))
-    return composited.toString(16).padStart(2, '0')
-  }).join('')
+  const rgb = match.slice(1, 4)
+    .map(value => Number.parseInt(value, 10).toString(16).padStart(2, '0'))
+    .join('')
+  const alpha = match[4] === undefined ? 255 : Math.round(Number.parseFloat(match[4]) * 255)
+  return `#${rgb}${alpha < 255 ? alpha.toString(16).padStart(2, '0') : ''}`
 }
 
 async function saveAndApply() {
@@ -610,38 +656,13 @@ onBeforeUnmount(() => {
   padding-inline: 12px;
   color: var(--primary-text-color);
   background: var(--search-bar-color);
+  backdrop-filter: var(--search-bar-blur, none);
 }
 
 .colorGrid {
   display: grid;
   grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
   gap: 10px;
-}
-
-.colorField {
-  display: grid;
-  grid-template-columns: 38px minmax(0, 1fr) auto;
-  align-items: center;
-  gap: 10px;
-  min-block-size: 46px;
-  border-radius: calc(8px * var(--ui-roundness));
-  padding: 6px 10px;
-  color: var(--primary-text-color);
-  background: var(--card-bg-color);
-}
-
-.colorField input {
-  inline-size: 38px;
-  block-size: 32px;
-  border: 0;
-  padding: 0;
-  background: transparent;
-  cursor: pointer;
-}
-
-.colorField code {
-  color: var(--tertiary-text-color);
-  font-size: 0.78rem;
 }
 
 @container (width < 560px) {

--- a/src/renderer/components/FtAddToPlaylistDropdown/FtAddToPlaylistDropdown.scss
+++ b/src/renderer/components/FtAddToPlaylistDropdown/FtAddToPlaylistDropdown.scss
@@ -5,7 +5,7 @@
 }
 
 .dropdownHeader {
-  border-block-end: 1px solid var(--tertiary-text-color);
+  border-block-end: 1px solid var(--border-color);
   font-size: 13px;
   font-weight: bold;
   margin: 0;
@@ -80,7 +80,7 @@
 .createRow {
   background: none;
   border: 0;
-  border-block-start: 1px solid var(--tertiary-text-color);
+  border-block-start: 1px solid var(--border-color);
   color: inherit;
   font: inherit;
   gap: 8px;

--- a/src/renderer/components/FtAgeRestricted/FtAgeRestricted.css
+++ b/src/renderer/components/FtAgeRestricted/FtAgeRestricted.css
@@ -12,6 +12,7 @@
 .frown {
   color: var(--primary-text-color);
   background-color: var(--card-bg-color);
+  backdrop-filter: var(--card-bg-blur, none);
   padding-inline: 0;
   text-align: center;
   inline-size: 100%;

--- a/src/renderer/components/FtColorPicker/FtColorPicker.vue
+++ b/src/renderer/components/FtColorPicker/FtColorPicker.vue
@@ -1,0 +1,963 @@
+<template>
+  <div class="ftColorPicker">
+    <button
+      ref="triggerRef"
+      type="button"
+      class="colorFieldTrigger"
+      :aria-label="label"
+      :aria-expanded="open"
+      @click="togglePicker"
+    >
+      <span
+        class="swatch checkerboard"
+        aria-hidden="true"
+      >
+        <span
+          class="swatchColor"
+          :style="{ backgroundColor: modelValue }"
+        />
+      </span>
+      <span class="colorFieldLabel">
+        <slot name="label">{{ label }}</slot>
+      </span>
+      <code>{{ modelValue }}</code>
+    </button>
+
+    <Teleport to="body">
+      <div
+        v-if="open"
+        ref="popoverRef"
+        class="colorPickerPopover"
+        :style="popoverStyle"
+        role="dialog"
+        :aria-label="label"
+        @keydown.esc.stop="closePicker()"
+      >
+        <div class="pickerHeader">
+          <strong class="pickerTitle">{{ label }}</strong>
+          <div class="pickerHeaderActions">
+            <button
+              type="button"
+              class="pickerHeaderAction"
+              :title="t('Color Picker.Reset Color')"
+              :aria-label="t('Color Picker.Reset Color')"
+              :disabled="resetDisabled"
+              @click="resetColor"
+            >
+              <FtIcon :icon="['fas', 'undo']" />
+            </button>
+            <button
+              type="button"
+              class="pickerHeaderAction"
+              :title="t('Color Picker.Apply Color')"
+              :aria-label="t('Color Picker.Apply Color')"
+              @click="closePicker(true)"
+            >
+              <FtIcon :icon="['fas', 'check']" />
+            </button>
+          </div>
+        </div>
+        <div
+          class="saturationValue"
+          role="slider"
+          tabindex="0"
+          :aria-label="t('Color Picker.Saturation and Brightness')"
+          :aria-valuemin="0"
+          :aria-valuemax="100"
+          :aria-valuenow="Math.round(value)"
+          :aria-valuetext="`${Math.round(saturation)}%, ${Math.round(value)}%`"
+          :style="{ backgroundColor: `hsl(${hue} 100% 50%)` }"
+          @pointerdown="startSaturationValue"
+          @keydown="adjustSaturationValue"
+        >
+          <span
+            class="saturationValueThumb"
+            :style="{ insetInlineStart: `${saturation}%`, insetBlockStart: `${100 - value}%` }"
+          />
+        </div>
+
+        <label class="sliderField">
+          <span>{{ t('Color Picker.Hue') }}</span>
+          <input
+            v-model.number="hue"
+            class="hueSlider"
+            type="range"
+            min="0"
+            max="359"
+            @input="emitCurrentColor"
+            @change="emit('change')"
+          >
+        </label>
+        <label
+          v-if="allowAlpha"
+          class="sliderField"
+        >
+          <span>{{ t('Color Picker.Opacity') }}</span>
+          <span>{{ opacityLabel }}</span>
+          <span
+            class="alphaSliderBackground checkerboard"
+            :style="{ '--opaque-color': opaqueHex }"
+          >
+            <input
+              v-model.number="alpha"
+              class="alphaSlider"
+              type="range"
+              min="0"
+              max="255"
+              @input="emitCurrentColor"
+              @change="emit('change')"
+            >
+          </span>
+        </label>
+        <label
+          v-if="supportsBlur"
+          class="sliderField"
+          :class="{ disabled: !isTransparent }"
+        >
+          <span>{{ t('Color Picker.Backdrop Blur') }}</span>
+          <span>{{ blurLabel }}</span>
+          <input
+            v-model.number="blurStrength"
+            class="blurSlider"
+            type="range"
+            min="0"
+            max="40"
+            :disabled="!isTransparent"
+            @input="emitCurrentBlur"
+            @change="emit('change')"
+          >
+        </label>
+
+        <div class="valueRow">
+          <label class="hexField">
+            <span>{{ t('Color Picker.Hex Color') }}</span>
+            <span class="hexInputControl">
+              <input
+                v-model="hexInput"
+                type="text"
+                :maxlength="allowAlpha ? 9 : 7"
+                spellcheck="false"
+                @focus="$event.target.select()"
+                @blur="commitHexInput"
+                @keydown.enter.prevent="commitHexInput"
+              >
+              <button
+                type="button"
+                class="copyColorButton"
+                :title="copyButtonLabel"
+                :aria-label="copyButtonLabel"
+                @click="copyColor"
+              >
+                <FtIcon :icon="['fas', copied ? 'check' : 'copy']" />
+              </button>
+            </span>
+          </label>
+        </div>
+        <div
+          v-if="otherColors.length > 0"
+          class="copyFromControl"
+        >
+          <button
+            ref="copyFromButtonRef"
+            type="button"
+            class="copyFromButton"
+            :aria-expanded="showColorSources"
+            @click="toggleColorSources"
+          >
+            {{ t('Color Picker.Copy From Another Color') }}
+          </button>
+          <div
+            v-if="showColorSources"
+            v-overlay-scrollbars
+            class="colorSourceList"
+            :class="{ above: colorSourcesAbove }"
+            :aria-label="t('Color Picker.Copy From Another Color')"
+          >
+            <button
+              v-for="color in otherColors"
+              :key="color.key"
+              type="button"
+              @click="copyFromColor(color.value)"
+            >
+              <span class="sourceSwatch checkerboard">
+                <span :style="{ backgroundColor: color.value }" />
+              </span>
+              <span>{{ color.label }}</span>
+              <code>{{ color.value }}</code>
+            </button>
+          </div>
+        </div>
+        <small
+          v-if="status"
+          class="pickerStatus"
+          role="status"
+        >{{ status }}</small>
+      </div>
+    </Teleport>
+  </div>
+</template>
+
+<script setup>
+import { computed, nextTick, onBeforeUnmount, ref, useTemplateRef, watch } from 'vue'
+import { useI18n } from 'vue-i18n'
+
+const props = defineProps({
+  modelValue: {
+    type: String,
+    required: true
+  },
+  label: {
+    type: String,
+    required: true
+  },
+  otherColors: {
+    type: Array,
+    default: () => []
+  },
+  allowAlpha: {
+    type: Boolean,
+    default: true
+  },
+  blurValue: {
+    type: Number,
+    default: null
+  }
+})
+const emit = defineEmits(['update:modelValue', 'update:blurValue', 'change'])
+const { t } = useI18n()
+const triggerRef = useTemplateRef('triggerRef')
+const popoverRef = useTemplateRef('popoverRef')
+const copyFromButtonRef = useTemplateRef('copyFromButtonRef')
+const open = ref(false)
+const hue = ref(0)
+const saturation = ref(0)
+const value = ref(0)
+const alpha = ref(255)
+const blurStrength = ref(props.blurValue ?? 0)
+const hexInput = ref(props.modelValue)
+const copied = ref(false)
+const status = ref('')
+const showColorSources = ref(false)
+const colorSourcesAbove = ref(false)
+const popoverStyle = ref({})
+const colorWhenOpened = ref(props.modelValue)
+const blurWhenOpened = ref(props.blurValue ?? 0)
+let draggingSaturationValue = false
+let statusTimeout = null
+let copiedTimeout = null
+let lastEmittedColor = null
+
+const opaqueHex = computed(() => formatHex(hsvToRgb(hue.value, saturation.value, value.value), 255))
+const supportsBlur = computed(() => props.blurValue !== null)
+const isTransparent = computed(() => alpha.value < 255)
+const opacityLabel = computed(() => `${Math.round(alpha.value / 255 * 100)}%`)
+const blurLabel = computed(() => `${blurStrength.value} px`)
+const copyColorLabel = computed(() => t('Color Picker.Copy Color'))
+const colorCopiedLabel = computed(() => t('Color Picker.Color Copied'))
+const copyButtonLabel = computed(() => copied.value ? colorCopiedLabel.value : copyColorLabel.value)
+const resetDisabled = computed(() =>
+  normalizedColor(props.modelValue) === normalizedColor(colorWhenOpened.value) &&
+  (!supportsBlur.value || blurStrength.value === blurWhenOpened.value))
+
+watch(() => props.modelValue, syncFromModel, { immediate: true })
+watch(() => props.blurValue, blur => {
+  if (blur !== null) blurStrength.value = blur
+})
+watch(open, async value => {
+  if (!value) {
+    showColorSources.value = false
+    removeOpenListeners()
+    return
+  }
+  colorWhenOpened.value = props.modelValue
+  blurWhenOpened.value = props.blurValue ?? 0
+  document.addEventListener('pointerdown', closeFromOutside)
+  window.addEventListener('resize', positionPopover)
+  window.addEventListener('scroll', positionPopover, true)
+  await nextTick()
+  positionPopover()
+})
+function syncFromModel(color, force = false) {
+  if (!force && color === lastEmittedColor) {
+    lastEmittedColor = null
+    return
+  }
+  const parsed = parseHex(color)
+  if (parsed === null) return
+  const hsv = rgbToHsv(parsed)
+  hue.value = hsv.h
+  saturation.value = hsv.s
+  value.value = hsv.v
+  alpha.value = props.allowAlpha ? parsed.a : 255
+  hexInput.value = formatHex(parsed, alpha.value)
+}
+
+function togglePicker() {
+  if (open.value) closePicker()
+  else open.value = true
+}
+
+function closePicker(apply = false) {
+  if (!apply && !resetDisabled.value) resetColor()
+  open.value = false
+}
+
+function emitCurrentColor() {
+  const color = formatHex(
+    hsvToRgb(hue.value, saturation.value, value.value),
+    props.allowAlpha ? alpha.value : 255
+  )
+  hexInput.value = color
+  lastEmittedColor = color
+  emit('update:modelValue', color)
+}
+
+function emitCurrentBlur() {
+  emit('update:blurValue', blurStrength.value)
+}
+
+function startSaturationValue(event) {
+  if (event.button !== 0) return
+  draggingSaturationValue = true
+  updateSaturationValue(event)
+  window.addEventListener('pointermove', updateSaturationValue)
+  window.addEventListener('pointerup', stopSaturationValue, { once: true })
+  event.preventDefault()
+}
+
+function updateSaturationValue(event) {
+  if (!draggingSaturationValue) return
+  const bounds = event.currentTarget?.classList?.contains('saturationValue')
+    ? event.currentTarget.getBoundingClientRect()
+    : popoverRef.value?.querySelector('.saturationValue')?.getBoundingClientRect()
+  if (bounds === undefined) return
+  saturation.value = clamp((event.clientX - bounds.left) / bounds.width * 100, 0, 100)
+  value.value = 100 - clamp((event.clientY - bounds.top) / bounds.height * 100, 0, 100)
+  emitCurrentColor()
+}
+
+function stopSaturationValue() {
+  draggingSaturationValue = false
+  window.removeEventListener('pointermove', updateSaturationValue)
+  emit('change')
+}
+
+function adjustSaturationValue(event) {
+  const step = event.shiftKey ? 10 : 1
+  if (event.key === 'ArrowLeft') saturation.value = clamp(saturation.value - step, 0, 100)
+  else if (event.key === 'ArrowRight') saturation.value = clamp(saturation.value + step, 0, 100)
+  else if (event.key === 'ArrowUp') value.value = clamp(value.value + step, 0, 100)
+  else if (event.key === 'ArrowDown') value.value = clamp(value.value - step, 0, 100)
+  else return
+  event.preventDefault()
+  emitCurrentColor()
+  emit('change')
+}
+
+function commitHexInput() {
+  const parsed = parseHex(hexInput.value)
+  if (parsed === null) {
+    hexInput.value = props.modelValue
+    showStatus(t('Color Picker.Invalid Color'))
+    return
+  }
+  if (!props.allowAlpha) parsed.a = 255
+  const color = formatHex(parsed, parsed.a)
+  lastEmittedColor = color
+  emit('update:modelValue', color)
+  emit('change')
+  syncFromModel(color, true)
+}
+
+async function copyColor() {
+  try {
+    await navigator.clipboard.writeText(hexInput.value)
+    copied.value = true
+    if (copiedTimeout !== null) clearTimeout(copiedTimeout)
+    copiedTimeout = setTimeout(() => {
+      copied.value = false
+      copiedTimeout = null
+    }, 2000)
+  } catch (error) {
+    console.error('Unable to copy custom theme color:', error)
+    showStatus(t('Color Picker.Clipboard Unavailable'))
+  }
+}
+
+function resetColor() {
+  const parsed = parseHex(colorWhenOpened.value)
+  if (parsed === null) return
+  if (!props.allowAlpha) parsed.a = 255
+  const color = formatHex(parsed, parsed.a)
+  lastEmittedColor = color
+  emit('update:modelValue', color)
+  syncFromModel(color, true)
+  if (supportsBlur.value) {
+    blurStrength.value = blurWhenOpened.value
+    emit('update:blurValue', blurStrength.value)
+  }
+  emit('change')
+}
+
+function normalizedColor(color) {
+  const parsed = parseHex(color)
+  if (parsed === null) return color
+  return formatHex(parsed, props.allowAlpha ? parsed.a : 255)
+}
+
+function copyFromColor(color) {
+  const parsed = parseHex(color)
+  if (parsed === null) return
+  if (!props.allowAlpha) parsed.a = 255
+  const normalized = formatHex(parsed, parsed.a)
+  lastEmittedColor = normalized
+  emit('update:modelValue', normalized)
+  emit('change')
+  syncFromModel(normalized, true)
+  showColorSources.value = false
+}
+
+async function toggleColorSources() {
+  showColorSources.value = !showColorSources.value
+  if (!showColorSources.value) return
+  await nextTick()
+  const bounds = copyFromButtonRef.value?.getBoundingClientRect()
+  if (bounds === undefined) return
+  colorSourcesAbove.value = window.innerHeight - bounds.bottom < 230 && bounds.top > 230
+}
+
+function showStatus(message) {
+  status.value = message
+  if (statusTimeout !== null) clearTimeout(statusTimeout)
+  statusTimeout = setTimeout(() => {
+    status.value = ''
+    statusTimeout = null
+  }, 2000)
+}
+
+function positionPopover() {
+  const trigger = triggerRef.value
+  const popover = popoverRef.value
+  if (trigger === null || popover === null) return
+  const triggerBounds = trigger.getBoundingClientRect()
+  const margin = 12
+  const left = clamp(triggerBounds.left, margin, window.innerWidth - popover.offsetWidth - margin)
+  const below = triggerBounds.bottom + 8
+  const top = below + popover.offsetHeight <= window.innerHeight - margin
+    ? below
+    : Math.max(margin, triggerBounds.top - popover.offsetHeight - 8)
+  popoverStyle.value = { left: `${left}px`, top: `${top}px` }
+}
+
+function closeFromOutside(event) {
+  if (triggerRef.value?.contains(event.target) || popoverRef.value?.contains(event.target)) return
+  closePicker()
+}
+
+function removeOpenListeners() {
+  document.removeEventListener('pointerdown', closeFromOutside)
+  window.removeEventListener('resize', positionPopover)
+  window.removeEventListener('scroll', positionPopover, true)
+}
+
+function parseHex(input) {
+  let hex = input.trim().toLowerCase()
+  if (!hex.startsWith('#')) hex = `#${hex}`
+  if (/^#[\da-f]{3,4}$/.test(hex)) {
+    hex = '#' + [...hex.slice(1)].map(character => character.repeat(2)).join('')
+  }
+  if (!/^#[\da-f]{6}(?:[\da-f]{2})?$/.test(hex)) return null
+  return {
+    r: Number.parseInt(hex.slice(1, 3), 16),
+    g: Number.parseInt(hex.slice(3, 5), 16),
+    b: Number.parseInt(hex.slice(5, 7), 16),
+    a: hex.length === 9 ? Number.parseInt(hex.slice(7, 9), 16) : 255
+  }
+}
+
+function formatHex({ r, g, b }, alphaValue) {
+  const rgb = [r, g, b].map(component => Math.round(component).toString(16).padStart(2, '0')).join('')
+  const alphaHex = Math.round(alphaValue).toString(16).padStart(2, '0')
+  return `#${rgb}${alphaValue < 255 ? alphaHex : ''}`
+}
+
+function rgbToHsv({ r, g, b }) {
+  const red = r / 255
+  const green = g / 255
+  const blue = b / 255
+  const max = Math.max(red, green, blue)
+  const min = Math.min(red, green, blue)
+  const delta = max - min
+  let calculatedHue = 0
+  if (delta !== 0) {
+    if (max === red) calculatedHue = 60 * (((green - blue) / delta) % 6)
+    else if (max === green) calculatedHue = 60 * ((blue - red) / delta + 2)
+    else calculatedHue = 60 * ((red - green) / delta + 4)
+  }
+  return {
+    h: Math.round((calculatedHue + 360) % 360),
+    s: max === 0 ? 0 : delta / max * 100,
+    v: max * 100
+  }
+}
+
+function hsvToRgb(h, s, v) {
+  const saturationValue = s / 100
+  const brightness = v / 100
+  const chroma = brightness * saturationValue
+  const section = h / 60
+  const x = chroma * (1 - Math.abs(section % 2 - 1))
+  const match = brightness - chroma
+  let rgb
+  if (section < 1) rgb = [chroma, x, 0]
+  else if (section < 2) rgb = [x, chroma, 0]
+  else if (section < 3) rgb = [0, chroma, x]
+  else if (section < 4) rgb = [0, x, chroma]
+  else if (section < 5) rgb = [x, 0, chroma]
+  else rgb = [chroma, 0, x]
+  return {
+    r: (rgb[0] + match) * 255,
+    g: (rgb[1] + match) * 255,
+    b: (rgb[2] + match) * 255
+  }
+}
+
+function clamp(number, minimum, maximum) {
+  return Math.min(maximum, Math.max(minimum, number))
+}
+
+onBeforeUnmount(() => {
+  removeOpenListeners()
+  window.removeEventListener('pointermove', updateSaturationValue)
+  if (statusTimeout !== null) clearTimeout(statusTimeout)
+  if (copiedTimeout !== null) clearTimeout(copiedTimeout)
+})
+</script>
+
+<style scoped>
+.ftColorPicker {
+  min-inline-size: 0;
+}
+
+.checkerboard {
+  background-color: #fff;
+  background-image:
+    linear-gradient(45deg, #bbb 25%, transparent 25%),
+    linear-gradient(-45deg, #bbb 25%, transparent 25%),
+    linear-gradient(45deg, transparent 75%, #bbb 75%),
+    linear-gradient(-45deg, transparent 75%, #bbb 75%);
+  background-position: 0 0, 0 6px, 6px -6px, -6px 0;
+  background-size: 12px 12px;
+}
+
+.colorFieldTrigger {
+  inline-size: 100%;
+  display: grid;
+  grid-template-columns: 38px minmax(0, 1fr) auto;
+  align-items: center;
+  gap: 10px;
+  min-block-size: 46px;
+  border: 0;
+  border-radius: calc(8px * var(--ui-roundness));
+  padding: 6px 10px;
+  color: var(--primary-text-color);
+  background: var(--card-bg-color);
+  backdrop-filter: var(--card-bg-blur, none);
+  font: inherit;
+  text-align: start;
+  cursor: pointer;
+}
+
+.colorFieldTrigger code {
+  color: var(--tertiary-text-color);
+  font-size: 0.78rem;
+}
+
+.colorFieldLabel {
+  min-inline-size: 0;
+  display: flex;
+  align-items: center;
+  gap: 4px;
+}
+
+.colorFieldTrigger:focus-visible {
+  outline: 2px solid var(--primary-color);
+  outline-offset: 2px;
+}
+
+.swatch {
+  position: relative;
+  display: block;
+  inline-size: 38px;
+  block-size: 32px;
+  overflow: hidden;
+  border: 0;
+  border-radius: calc(4px * var(--ui-roundness));
+}
+
+.swatchColor {
+  position: absolute;
+  inset: 0;
+  border-radius: inherit;
+}
+
+.swatch::after,
+.sourceSwatch::after {
+  content: '';
+  position: absolute;
+  z-index: 1;
+  inset: 0;
+  box-sizing: border-box;
+  border: 1px solid var(--border-color);
+  border-radius: inherit;
+  pointer-events: none;
+}
+
+.colorPickerPopover {
+  position: fixed;
+  z-index: 1001;
+  box-sizing: border-box;
+  inline-size: min(300px, calc(100vw - 24px));
+  display: grid;
+  grid-template-columns: minmax(0, 1fr);
+  gap: 12px;
+  border: 1px solid var(--border-color);
+  border-radius: calc(10px * var(--ui-roundness));
+  padding: 14px;
+  color: var(--primary-text-color);
+  background: var(--card-bg-color);
+  backdrop-filter: var(--card-bg-blur, none);
+  box-shadow: 0 12px 36px rgb(0 0 0 / 45%);
+  font-family: Roboto, sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol', 'Noto Color Emoji';
+}
+
+.colorPickerPopover button,
+.colorPickerPopover input {
+  font: inherit;
+}
+
+.pickerTitle {
+  min-inline-size: 0;
+  flex: 1;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.pickerHeader {
+  min-inline-size: 0;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 8px;
+}
+
+.pickerHeaderActions {
+  flex: none;
+  display: flex;
+  gap: 2px;
+}
+
+.pickerHeaderAction {
+  flex: none;
+  inline-size: 32px;
+  block-size: 32px;
+  border: 0;
+  border-radius: calc(5px * var(--ui-roundness));
+  padding: 0;
+  color: var(--primary-text-color);
+  background: transparent;
+  cursor: pointer;
+}
+
+.pickerHeaderAction:not(:disabled):hover,
+.pickerHeaderAction:not(:disabled):focus-visible {
+  background: var(--side-nav-hover-color);
+}
+
+.pickerHeaderAction:disabled {
+  opacity: 0.5;
+  cursor: default;
+}
+
+.saturationValue {
+  position: relative;
+  block-size: 150px;
+  border-radius: calc(6px * var(--ui-roundness));
+  cursor: crosshair;
+  touch-action: none;
+  background-image:
+    linear-gradient(to top, #000, transparent),
+    linear-gradient(to right, #fff, transparent);
+}
+
+.saturationValue:focus-visible {
+  outline: 2px solid var(--primary-color);
+  outline-offset: 2px;
+}
+
+.saturationValueThumb {
+  position: absolute;
+  inline-size: 14px;
+  block-size: 14px;
+  border: 2px solid #fff;
+  border-radius: 50%;
+  box-shadow: 0 0 0 1px #000;
+  transform: translate(-50%, -50%);
+  pointer-events: none;
+}
+
+.sliderField {
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) auto;
+  align-items: center;
+  gap: 6px 8px;
+  font-size: 0.82rem;
+}
+
+.sliderField input[type='range'] {
+  inline-size: 100%;
+  margin: 0;
+  cursor: pointer;
+}
+
+.sliderField.disabled {
+  opacity: 0.5;
+}
+
+.sliderField input[type='range']:disabled {
+  cursor: default;
+}
+
+.hueSlider {
+  grid-column: 1 / -1;
+  block-size: 16px;
+  appearance: none;
+  background: transparent;
+  accent-color: var(--primary-color);
+}
+
+.hueSlider::-webkit-slider-runnable-track {
+  block-size: 10px;
+  border-radius: 999px;
+  background: linear-gradient(to right, #f00, #ff0, #0f0, #0ff, #00f, #f0f, #f00);
+}
+
+.blurSlider {
+  grid-column: 1 / -1;
+  block-size: 16px;
+  appearance: none;
+  background: transparent;
+}
+
+.blurSlider::-webkit-slider-runnable-track {
+  block-size: 10px;
+  border-radius: 999px;
+  background: var(--subtle-surface-color);
+}
+
+.alphaSliderBackground {
+  grid-column: 1 / -1;
+  position: relative;
+  block-size: 10px;
+  border-radius: 999px;
+}
+
+.alphaSliderBackground::after {
+  content: '';
+  position: absolute;
+  inset: 0;
+  border-radius: inherit;
+  background: linear-gradient(to right, transparent, var(--opaque-color));
+  pointer-events: none;
+}
+
+.alphaSlider {
+  position: absolute;
+  z-index: 1;
+  inset: 50% 0 auto;
+  transform: translateY(-50%);
+  appearance: none;
+  background: transparent;
+}
+
+.hueSlider::-webkit-slider-thumb,
+.alphaSlider::-webkit-slider-thumb,
+.blurSlider::-webkit-slider-thumb {
+  appearance: none;
+  inline-size: 16px;
+  block-size: 16px;
+  border: 2px solid #fff;
+  border-radius: 50%;
+  background: #222;
+  box-shadow: 0 0 0 1px #000;
+}
+
+.hueSlider::-webkit-slider-thumb {
+  margin-block-start: -3px;
+  background: transparent;
+}
+
+.blurSlider::-webkit-slider-thumb {
+  margin-block-start: -3px;
+}
+
+.valueRow {
+  display: grid;
+  grid-template-columns: minmax(0, 1fr);
+  align-items: end;
+  gap: 6px;
+}
+
+.hexField {
+  grid-column: 1 / -1;
+  display: grid;
+  gap: 4px;
+  min-inline-size: 0;
+  font-size: 0.78rem;
+}
+
+.hexField input,
+.valueRow button {
+  box-sizing: border-box;
+  min-block-size: 34px;
+  border: 1px solid var(--border-color);
+  border-radius: calc(5px * var(--ui-roundness));
+  color: var(--primary-text-color);
+  background: var(--search-bar-color);
+  backdrop-filter: var(--search-bar-blur, none);
+}
+
+.hexField input {
+  min-inline-size: 0;
+  inline-size: 100%;
+  padding-inline: 8px;
+  font-family: monospace;
+}
+
+.hexInputControl {
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) 34px;
+}
+
+.hexInputControl input {
+  border-start-end-radius: 0;
+  border-end-end-radius: 0;
+}
+
+.hexInputControl .copyColorButton {
+  border-inline-start: 0;
+  border-start-start-radius: 0;
+  border-end-start-radius: 0;
+  padding: 0;
+}
+
+.valueRow button {
+  padding-inline: 9px;
+  cursor: pointer;
+}
+
+.valueRow button:disabled {
+  opacity: 0.5;
+  cursor: default;
+}
+
+.valueRow button:not(:disabled):hover,
+.valueRow button:not(:disabled):focus-visible {
+  background: var(--side-nav-hover-color);
+}
+
+.copyFromControl {
+  position: relative;
+}
+
+.copyFromButton {
+  inline-size: 100%;
+  min-block-size: 36px;
+  border: 1px solid var(--border-color);
+  border-radius: calc(5px * var(--ui-roundness));
+  color: var(--primary-text-color);
+  background: var(--search-bar-color);
+  backdrop-filter: var(--search-bar-blur, none);
+  cursor: pointer;
+}
+
+.copyFromButton:hover,
+.copyFromButton:focus-visible {
+  background: var(--side-nav-hover-color);
+}
+
+.colorSourceList {
+  position: absolute;
+  z-index: 1;
+  inset-block-start: calc(100% + 4px);
+  inset-inline: 0;
+  box-sizing: border-box;
+  block-size: min(220px, calc(100vh - 24px));
+  max-block-size: 220px;
+  overflow-y: auto;
+  display: grid;
+  gap: 2px;
+  border: 1px solid var(--border-color);
+  border-radius: calc(6px * var(--ui-roundness));
+  padding: 4px;
+  background: var(--side-nav-color);
+  box-shadow: 0 8px 24px rgb(0 0 0 / 40%);
+}
+
+.colorSourceList.above {
+  inset-block-start: auto;
+  inset-block-end: calc(100% + 4px);
+}
+
+.colorSourceList button {
+  min-inline-size: 0;
+  display: grid;
+  grid-template-columns: 24px minmax(0, 1fr) auto;
+  align-items: center;
+  gap: 8px;
+  border: 0;
+  border-radius: calc(4px * var(--ui-roundness));
+  padding: 6px;
+  color: var(--primary-text-color);
+  background: transparent;
+  text-align: start;
+  cursor: pointer;
+}
+
+.colorSourceList button:hover,
+.colorSourceList button:focus-visible {
+  background: var(--side-nav-hover-color);
+}
+
+.colorSourceList button > span:nth-child(2) {
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.colorSourceList code {
+  color: var(--tertiary-text-color);
+  font-size: 0.72rem;
+}
+
+.sourceSwatch {
+  position: relative;
+  display: block;
+  inline-size: 22px;
+  block-size: 22px;
+  overflow: hidden;
+  border: 0;
+  border-radius: calc(4px * var(--ui-roundness));
+}
+
+.sourceSwatch > span {
+  position: absolute;
+  inset: 0;
+  border-radius: inherit;
+}
+
+.pickerStatus {
+  color: var(--secondary-text-color);
+}
+</style>

--- a/src/renderer/components/FtColorPicker/FtColorPicker.vue
+++ b/src/renderer/components/FtColorPicker/FtColorPicker.vue
@@ -322,6 +322,7 @@ function togglePicker() {
 }
 
 function closePicker(apply = false) {
+  if (!open.value) return
   if (!apply && !resetDisabled.value) resetColor()
   if (apply) emit('apply')
   else emit('cancel')
@@ -567,6 +568,8 @@ function hsvToRgb(h, s, v) {
 function clamp(number, minimum, maximum) {
   return Math.min(maximum, Math.max(minimum, number))
 }
+
+defineExpose({ close: closePicker })
 
 onBeforeUnmount(() => {
   removeOpenListeners()

--- a/src/renderer/components/FtColorPicker/FtColorPicker.vue
+++ b/src/renderer/components/FtColorPicker/FtColorPicker.vue
@@ -269,8 +269,6 @@ watch(open, async value => {
     removeOpenListeners()
     return
   }
-  colorWhenOpened.value = props.modelValue
-  blurWhenOpened.value = props.blurValue ?? 0
   document.addEventListener('pointerdown', closeFromOutside)
   window.addEventListener('resize', positionPopover)
   window.addEventListener('scroll', positionPopover, true)
@@ -294,7 +292,11 @@ function syncFromModel(color, force = false) {
 
 function togglePicker() {
   if (open.value) closePicker()
-  else open.value = true
+  else {
+    colorWhenOpened.value = props.modelValue
+    blurWhenOpened.value = props.blurValue ?? 0
+    open.value = true
+  }
 }
 
 function closePicker(apply = false) {

--- a/src/renderer/components/FtColorPicker/FtColorPicker.vue
+++ b/src/renderer/components/FtColorPicker/FtColorPicker.vue
@@ -324,12 +324,13 @@ function togglePicker() {
   }
 }
 
-function closePicker(apply = false) {
+function closePicker(apply = false, restoreFocus = true) {
   if (!open.value) return
   if (!apply && !resetDisabled.value) resetColor()
   if (apply) emit('apply')
   else emit('cancel')
   open.value = false
+  if (restoreFocus) nextTick(() => triggerRef.value?.focus())
 }
 
 function emitCurrentColor() {
@@ -497,7 +498,7 @@ function positionPopover() {
 
 function closeFromOutside(event) {
   if (triggerRef.value?.contains(event.target) || popoverRef.value?.contains(event.target)) return
-  closePicker()
+  closePicker(false, false)
 }
 
 function removeOpenListeners() {

--- a/src/renderer/components/FtColorPicker/FtColorPicker.vue
+++ b/src/renderer/components/FtColorPicker/FtColorPicker.vue
@@ -168,23 +168,29 @@
           </button>
           <div
             v-if="showColorSources"
+            ref="colorSourceListRef"
             v-overlay-scrollbars
             class="colorSourceList"
             :class="{ above: colorSourcesAbove }"
             :aria-label="t('Color Picker.Copy From Another Color')"
           >
-            <button
-              v-for="color in otherColors"
-              :key="color.key"
-              type="button"
-              @click="copyFromColor(color.value)"
+            <div
+              ref="colorSourceContentRef"
+              class="colorSourceContent"
             >
-              <span class="sourceSwatch checkerboard">
-                <span :style="{ backgroundColor: color.value }" />
-              </span>
-              <span>{{ color.label }}</span>
-              <code>{{ color.value }}</code>
-            </button>
+              <button
+                v-for="color in otherColors"
+                :key="color.key"
+                type="button"
+                @click="copyFromColor(color.value)"
+              >
+                <span class="sourceSwatch checkerboard">
+                  <span :style="{ backgroundColor: color.value }" />
+                </span>
+                <span>{{ color.label }}</span>
+                <code>{{ color.value }}</code>
+              </button>
+            </div>
           </div>
         </div>
         <small
@@ -200,6 +206,8 @@
 <script setup>
 import { computed, nextTick, onBeforeUnmount, ref, useTemplateRef, watch } from 'vue'
 import { useI18n } from 'vue-i18n'
+
+import { clampOverlayScrollTop } from '../../helpers/overlayScrollbars'
 
 const props = defineProps({
   modelValue: {
@@ -223,11 +231,13 @@ const props = defineProps({
     default: null
   }
 })
-const emit = defineEmits(['update:modelValue', 'update:blurValue', 'change'])
+const emit = defineEmits(['update:modelValue', 'update:blurValue', 'change', 'apply', 'cancel', 'reset'])
 const { t } = useI18n()
 const triggerRef = useTemplateRef('triggerRef')
 const popoverRef = useTemplateRef('popoverRef')
 const copyFromButtonRef = useTemplateRef('copyFromButtonRef')
+const colorSourceListRef = useTemplateRef('colorSourceListRef')
+const colorSourceContentRef = useTemplateRef('colorSourceContentRef')
 const open = ref(false)
 const hue = ref(0)
 const saturation = ref(0)
@@ -246,6 +256,7 @@ let draggingSaturationValue = false
 let statusTimeout = null
 let copiedTimeout = null
 let lastEmittedColor = null
+let colorSourcesResizeObserver = null
 
 const opaqueHex = computed(() => formatHex(hsvToRgb(hue.value, saturation.value, value.value), 255))
 const supportsBlur = computed(() => props.blurValue !== null)
@@ -275,6 +286,17 @@ watch(open, async value => {
   await nextTick()
   positionPopover()
 })
+watch(showColorSources, async value => {
+  stopObservingColorSources()
+  if (!value) return
+
+  await nextTick()
+  const bounds = copyFromButtonRef.value?.getBoundingClientRect()
+  if (bounds !== undefined) {
+    colorSourcesAbove.value = window.innerHeight - bounds.bottom < 230 && bounds.top > 230
+  }
+  observeColorSources()
+})
 function syncFromModel(color, force = false) {
   if (!force && color === lastEmittedColor) {
     lastEmittedColor = null
@@ -301,6 +323,8 @@ function togglePicker() {
 
 function closePicker(apply = false) {
   if (!apply && !resetDisabled.value) resetColor()
+  if (apply) emit('apply')
+  else emit('cancel')
   open.value = false
 }
 
@@ -399,6 +423,7 @@ function resetColor() {
     emit('update:blurValue', blurStrength.value)
   }
   emit('change')
+  emit('reset')
 }
 
 function normalizedColor(color) {
@@ -419,13 +444,28 @@ function copyFromColor(color) {
   showColorSources.value = false
 }
 
-async function toggleColorSources() {
+function toggleColorSources() {
   showColorSources.value = !showColorSources.value
-  if (!showColorSources.value) return
-  await nextTick()
-  const bounds = copyFromButtonRef.value?.getBoundingClientRect()
-  if (bounds === undefined) return
-  colorSourcesAbove.value = window.innerHeight - bounds.bottom < 230 && bounds.top > 230
+}
+
+function clampColorSourcesScroll() {
+  if (colorSourceListRef.value !== null && colorSourceContentRef.value !== null) {
+    clampOverlayScrollTop(colorSourceListRef.value, colorSourceContentRef.value)
+  }
+}
+
+function observeColorSources() {
+  if (colorSourceListRef.value === null || colorSourceContentRef.value === null) return
+
+  colorSourcesResizeObserver = new ResizeObserver(clampColorSourcesScroll)
+  colorSourcesResizeObserver.observe(colorSourceListRef.value)
+  colorSourcesResizeObserver.observe(colorSourceContentRef.value)
+  clampColorSourcesScroll()
+}
+
+function stopObservingColorSources() {
+  colorSourcesResizeObserver?.disconnect()
+  colorSourcesResizeObserver = null
 }
 
 function showStatus(message) {
@@ -530,6 +570,7 @@ function clamp(number, minimum, maximum) {
 
 onBeforeUnmount(() => {
   removeOpenListeners()
+  stopObservingColorSources()
   window.removeEventListener('pointermove', updateSaturationValue)
   if (statusTimeout !== null) clearTimeout(statusTimeout)
   if (copiedTimeout !== null) clearTimeout(copiedTimeout)
@@ -898,13 +939,16 @@ onBeforeUnmount(() => {
   block-size: min(220px, calc(100vh - 24px));
   max-block-size: 220px;
   overflow-y: auto;
-  display: grid;
-  gap: 2px;
   border: 1px solid var(--border-color);
   border-radius: calc(6px * var(--ui-roundness));
   padding: 4px;
   background: var(--side-nav-color);
   box-shadow: 0 8px 24px rgb(0 0 0 / 40%);
+}
+
+.colorSourceContent {
+  display: grid;
+  gap: 2px;
 }
 
 .colorSourceList.above {

--- a/src/renderer/components/FtColorPicker/FtColorPicker.vue
+++ b/src/renderer/components/FtColorPicker/FtColorPicker.vue
@@ -58,6 +58,7 @@
           </div>
         </div>
         <div
+          ref="saturationValueRef"
           class="saturationValue"
           role="slider"
           tabindex="0"
@@ -235,6 +236,7 @@ const emit = defineEmits(['update:modelValue', 'update:blurValue', 'change', 'ap
 const { t } = useI18n()
 const triggerRef = useTemplateRef('triggerRef')
 const popoverRef = useTemplateRef('popoverRef')
+const saturationValueRef = useTemplateRef('saturationValueRef')
 const copyFromButtonRef = useTemplateRef('copyFromButtonRef')
 const colorSourceListRef = useTemplateRef('colorSourceListRef')
 const colorSourceContentRef = useTemplateRef('colorSourceContentRef')
@@ -285,6 +287,7 @@ watch(open, async value => {
   window.addEventListener('scroll', positionPopover, true)
   await nextTick()
   positionPopover()
+  saturationValueRef.value?.focus()
 })
 watch(showColorSources, async value => {
   stopObservingColorSources()

--- a/src/renderer/components/FtContextMenu/FtContextMenu.css
+++ b/src/renderer/components/FtContextMenu/FtContextMenu.css
@@ -6,7 +6,7 @@
   padding: 5px;
   color: var(--primary-text-color);
   background-color: color-mix(in srgb, var(--card-bg-color) 96%, var(--bg-color));
-  border: 1px solid color-mix(in srgb, var(--tertiary-text-color) 55%, transparent);
+  border: 1px solid color-mix(in srgb, var(--border-color) 55%, transparent);
   border-radius: calc(8px * var(--ui-roundness));
   box-shadow: 0 12px 32px rgb(0 0 0 / 34%);
 }
@@ -89,6 +89,7 @@
   padding: 1px;
   color: var(--primary-color);
   background-color: var(--card-bg-color);
+  backdrop-filter: var(--card-bg-blur, none);
   border-radius: 50%;
   font-size: 8px;
 }
@@ -121,7 +122,7 @@
   block-size: 1px;
   margin-block: 4px;
   margin-inline: 7px;
-  background-color: color-mix(in srgb, var(--tertiary-text-color) 45%, transparent);
+  background-color: color-mix(in srgb, var(--border-color) 45%, transparent);
 }
 
 .submenuScroll {

--- a/src/renderer/components/FtIconButton/FtIconButton.scss
+++ b/src/renderer/components/FtIconButton/FtIconButton.scss
@@ -28,6 +28,7 @@
 
   &.base {
     background-color: var(--card-bg-color);
+    backdrop-filter: var(--card-bg-blur, none);
     color: var(--primary-text-color);
 
     &:not(.disabled) {
@@ -246,7 +247,7 @@
   }
 
   .listItemDivider {
-    border-block-start: 1px solid var(--tertiary-text-color);
+    border-block-start: 1px solid var(--border-color);
     margin-block: 1px;
     margin-inline: auto;
     // Too "visible" with current color

--- a/src/renderer/components/FtInput/FtInput.css
+++ b/src/renderer/components/FtInput/FtInput.css
@@ -89,7 +89,7 @@ body[dir='rtl'] .ft-input-component.search.showClearTextButton:focus-within .inp
 }
 
 .clearInputTextButton.visible:active {
-  background-color: var(--tertiary-text-color);
+  background-color: var(--subtle-surface-color);
   color: var(--side-nav-active-text-color);
   transition: background 0.2s ease-in;
 }
@@ -119,6 +119,7 @@ body[dir='rtl'] .ft-input-component.search.showClearTextButton:focus-within .inp
   color: var(--secondary-text-color);
   border-radius: calc(5px * var(--ui-roundness));
   background-color: var(--search-bar-color);
+  backdrop-filter: var(--search-bar-blur, none);
 }
 
 .ftcomponent ::placeholder {
@@ -129,6 +130,7 @@ body[dir='rtl'] .ft-input-component.search.showClearTextButton:focus-within .inp
 .forceTextColor .ft-input {
   color: #eee;
   background-color: var(--primary-input-color);
+  backdrop-filter: var(--primary-input-blur, none);
 }
 
 .forceTextColor .ft-input:focus {
@@ -219,7 +221,7 @@ body[dir='rtl'] .ft-input-component.search.showClearTextButton:focus-within .inp
 }
 
 .inputAction.enabled:active {
-  background-color: var(--tertiary-text-color);
+  background-color: var(--subtle-surface-color);
   color: var(--side-nav-active-text-color);
   transition: background 0.2s ease-in;
 }
@@ -239,12 +241,13 @@ body[dir='rtl'] .ft-input-component.search.showClearTextButton:focus-within .inp
   z-index: 10;
   border-radius: 0 0 calc(5px * var(--ui-roundness)) calc(5px * var(--ui-roundness));
   overflow-wrap: break-word;
-  box-shadow: 0 0 10px var(--scrollbar-color-hover);
+  box-shadow: 0 0 10px var(--dropdown-item-hover-color);
   background-color: var(--search-bar-color);
+  backdrop-filter: var(--search-bar-blur, none);
 
   /* The handle crosses hovered rows because this is an overlay scrollbar.
      Match the row highlight instead of drawing a darker stripe through it. */
-  --scrollbar-color: var(--scrollbar-color-hover);
+  --scrollbar-color: var(--dropdown-item-hover-color);
 }
 
 .search .list {
@@ -303,6 +306,6 @@ body[dir='rtl'] .ft-input-component.search.showClearTextButton:focus-within .inp
 }
 
 .hover {
-  background-color: var(--scrollbar-color-hover);
-  color: var(--scrollbar-text-color-hover);
+  background-color: var(--dropdown-item-hover-color);
+  color: var(--dropdown-item-hover-text-color);
 }

--- a/src/renderer/components/FtInputTags/FtInputTags.css
+++ b/src/renderer/components/FtInputTags/FtInputTags.css
@@ -22,6 +22,7 @@
 .ft-tag-box li {
   list-style: none;
   background-color: var(--card-bg-color);
+  backdrop-filter: var(--card-bg-blur, none);
   margin: 5px;
   border-radius: calc(5px * var(--ui-roundness));
   display: flex;

--- a/src/renderer/components/FtKeyboardShortcutPrompt/FtKeyboardShortcutPrompt.css
+++ b/src/renderer/components/FtKeyboardShortcutPrompt/FtKeyboardShortcutPrompt.css
@@ -138,6 +138,7 @@ h3 {
   border-radius: calc(4px * var(--ui-roundness));
   color: var(--primary-text-color);
   background: var(--card-bg-color);
+  backdrop-filter: var(--card-bg-blur, none);
   font: inherit;
   text-transform: capitalize;
   cursor: pointer;

--- a/src/renderer/components/FtListVideo/FtListVideo.scss
+++ b/src/renderer/components/FtListVideo/FtListVideo.scss
@@ -19,6 +19,12 @@
   opacity: 0.3;
 }
 
+.ft-list-item.premiereVideo .info .title,
+.ft-list-item.premiereVideo .info .infoLine,
+.ft-list-item.premiereVideo .info .infoLine .channelName {
+  color: var(--tertiary-text-color);
+}
+
 .draggable:not(.draggable:only-child):focus .grabBar,
 .draggable:not(.draggable:only-child):hover .grabBar {
   display: revert;
@@ -155,6 +161,7 @@
   padding: 3px;
   margin-inline: 2px;
   background-color: var(--secondary-card-bg-color);
+  backdrop-filter: var(--secondary-card-bg-blur, none);
   font-size: 10px;
   border-radius: calc(2px * var(--ui-roundness));
   display: inline-block;

--- a/src/renderer/components/FtListVideo/FtListVideo.vue
+++ b/src/renderer/components/FtListVideo/FtListVideo.vue
@@ -5,7 +5,8 @@
       list: effectiveListTypeIsList,
       grid: !effectiveListTypeIsList,
       [appearance]: true,
-      watched: addWatchedStyle
+      watched: addWatchedStyle,
+      premiereVideo: isPremiere || isUpcoming
     }"
   >
     <div

--- a/src/renderer/components/FtProfileEdit/FtProfileEdit.css
+++ b/src/renderer/components/FtProfileEdit/FtProfileEdit.css
@@ -38,6 +38,7 @@ h3 {
 
 .emojiOption {
   background: var(--card-bg-color);
+  backdrop-filter: var(--card-bg-blur, none);
   border: 2px solid transparent;
   border-radius: 8px;
   cursor: pointer;
@@ -60,6 +61,7 @@ h3 {
 
 .customEmojiInput {
   background: var(--search-bar-color);
+  backdrop-filter: var(--search-bar-blur, none);
   border: 1px solid var(--divider-color);
   border-radius: calc(4px * var(--ui-roundness));
   color: var(--primary-text-color);
@@ -144,11 +146,9 @@ h3 {
   min-inline-size: 250px;
 }
 
-.customColorSection {
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  gap: 5px;
+.profileColorPicker {
+  inline-size: min(350px, 100%);
+  margin-inline: auto;
   margin-block-start: 5px;
 }
 

--- a/src/renderer/components/FtProfileEdit/FtProfileEdit.vue
+++ b/src/renderer/components/FtProfileEdit/FtProfileEdit.vue
@@ -374,12 +374,19 @@ function updateProfileBgColorFromPicker(color) {
     const resolvedSemanticColor = semanticProfileBgColor.value === THEME_BG_COLOR
       ? themeColor.value
       : '#000000'
-    if (color.toLowerCase() === resolvedSemanticColor.toLowerCase()) {
+    if (normalizeHexColor(color) === normalizeHexColor(resolvedSemanticColor)) {
       profileBgColor.value = semanticProfileBgColor.value
       return
     }
   }
   profileBgColor.value = color
+}
+
+function normalizeHexColor(color) {
+  const normalized = color.toLowerCase()
+  if (!/^#[\da-f]{3,4}$/.test(normalized)) return normalized
+
+  return '#' + [...normalized.slice(1)].map(character => character.repeat(2)).join('')
 }
 
 const translatedProfileName = computed(() => {

--- a/src/renderer/components/FtProfileEdit/FtProfileEdit.vue
+++ b/src/renderer/components/FtProfileEdit/FtProfileEdit.vue
@@ -15,8 +15,8 @@
               :title="$t('Profile.Theme Color')"
               tabindex="0"
               role="button"
-              @click="profileBgColor = THEME_BG_COLOR"
-              @keydown.enter.space.prevent="profileBgColor = THEME_BG_COLOR"
+              @click="selectProfileBgColor(THEME_BG_COLOR)"
+              @keydown.enter.space.prevent="selectProfileBgColor(THEME_BG_COLOR)"
             />
             <div
               v-for="color in COLOR_VALUES"
@@ -28,8 +28,8 @@
               :style="{ background: color }"
               tabindex="0"
               role="button"
-              @click="profileBgColor = color"
-              @keydown.enter.space.prevent="profileBgColor = color"
+              @click="selectProfileBgColor(color)"
+              @keydown.enter.space.prevent="selectProfileBgColor(color)"
             />
             <div
               v-if="profileIcon?.type === 'image'"
@@ -39,8 +39,8 @@
               :title="$t('Profile.Transparent')"
               tabindex="0"
               role="button"
-              @click="profileBgColor = 'transparent'"
-              @keydown.enter.space.prevent="profileBgColor = 'transparent'"
+              @click="selectProfileBgColor('transparent')"
+              @keydown.enter.space.prevent="selectProfileBgColor('transparent')"
             />
           </FtFlexBox>
           <FtColorPicker
@@ -48,7 +48,7 @@
             :label="$t('Profile.Custom Color')"
             :model-value="customColorPickerValue"
             :allow-alpha="false"
-            @update:model-value="profileBgColor = $event"
+            @update:model-value="updateProfileBgColorFromPicker"
           />
           <FtInput
             class="colorSelection"
@@ -293,6 +293,9 @@ const profileName = ref(props.profile.name)
 
 /** @type {import('vue').Ref<string>} */
 const profileBgColor = ref(props.profile.bgColor)
+const semanticProfileBgColor = ref(isSemanticProfileBgColor(profileBgColor.value)
+  ? profileBgColor.value
+  : null)
 const lastOpaqueProfileBgColor = ref(
   props.profile.bgColor === 'transparent' ? THEME_BG_COLOR : props.profile.bgColor
 )
@@ -350,6 +353,34 @@ const customColorPickerValue = computed(() => {
 const profileBgColorLabel = computed(() => {
   return profileBgColor.value === THEME_BG_COLOR ? t('Profile.Theme Color') : profileBgColor.value
 })
+
+function isSemanticProfileBgColor(color) {
+  return color === THEME_BG_COLOR || color === 'transparent'
+}
+
+function selectProfileBgColor(color) {
+  profileBgColor.value = color
+  rememberSemanticProfileBgColor()
+}
+
+function rememberSemanticProfileBgColor() {
+  semanticProfileBgColor.value = isSemanticProfileBgColor(profileBgColor.value)
+    ? profileBgColor.value
+    : null
+}
+
+function updateProfileBgColorFromPicker(color) {
+  if (semanticProfileBgColor.value !== null) {
+    const resolvedSemanticColor = semanticProfileBgColor.value === THEME_BG_COLOR
+      ? themeColor.value
+      : '#000000'
+    if (color.toLowerCase() === resolvedSemanticColor.toLowerCase()) {
+      profileBgColor.value = semanticProfileBgColor.value
+      return
+    }
+  }
+  profileBgColor.value = color
+}
 
 const translatedProfileName = computed(() => {
   return props.isMainProfile ? t('Profile.All Channels') : profileName.value
@@ -576,7 +607,7 @@ function applyCrop() {
     type: 'image',
     value: canvas.toDataURL('image/webp', 0.9)
   }
-  profileBgColor.value = 'transparent'
+  selectProfileBgColor('transparent')
   closeCropEditor()
 }
 
@@ -598,7 +629,7 @@ function clearProfileIcon() {
 
 function restoreOpaqueProfileColor() {
   if (profileBgColor.value === 'transparent') {
-    profileBgColor.value = lastOpaqueProfileBgColor.value
+    selectProfileBgColor(lastOpaqueProfileBgColor.value)
   }
 }
 

--- a/src/renderer/components/FtProfileEdit/FtProfileEdit.vue
+++ b/src/renderer/components/FtProfileEdit/FtProfileEdit.vue
@@ -43,15 +43,13 @@
               @keydown.enter.space.prevent="profileBgColor = 'transparent'"
             />
           </FtFlexBox>
-          <div class="customColorSection">
-            <label for="colorPicker">{{ $t("Profile.Custom Color") }}</label>
-            <input
-              id="colorPicker"
-              type="color"
-              :value="customColorPickerValue"
-              @input="profileBgColor = $event.target.value"
-            >
-          </div>
+          <FtColorPicker
+            class="profileColorPicker"
+            :label="$t('Profile.Custom Color')"
+            :model-value="customColorPickerValue"
+            :allow-alpha="false"
+            @update:model-value="profileBgColor = $event"
+          />
           <FtInput
             class="colorSelection"
             placeholder=""
@@ -239,6 +237,7 @@ import FtPrompt from '../FtPrompt/FtPrompt.vue'
 import FtFlexBox from '../ft-flex-box/ft-flex-box.vue'
 import FtInput from '../FtInput/FtInput.vue'
 import FtButton from '../FtButton/FtButton.vue'
+import FtColorPicker from '../FtColorPicker/FtColorPicker.vue'
 import FtProfileIcon from '../FtProfileIcon/FtProfileIcon.vue'
 import FtSlider from '../FtSlider/FtSlider.vue'
 

--- a/src/renderer/components/FtProfileEdit/FtProfileEdit.vue
+++ b/src/renderer/components/FtProfileEdit/FtProfileEdit.vue
@@ -44,6 +44,7 @@
             />
           </FtFlexBox>
           <FtColorPicker
+            ref="profileColorPickerRef"
             class="profileColorPicker"
             :label="$t('Profile.Custom Color')"
             :model-value="customColorPickerValue"
@@ -310,6 +311,7 @@ const profileIcon = ref(deepCopy(props.profile.icon ?? null))
 
 const imageInput = useTemplateRef('imageInput')
 const cropCanvas = useTemplateRef('cropCanvas')
+const profileColorPickerRef = useTemplateRef('profileColorPickerRef')
 const cropDialogOpen = ref(false)
 const cropZoom = ref(1)
 const cropOffset = { x: 0, y: 0 }
@@ -362,6 +364,7 @@ function isSemanticProfileBgColor(color) {
 }
 
 function selectProfileBgColor(color) {
+  profileColorPickerRef.value?.close(true)
   profileBgColor.value = color
   rememberSemanticProfileBgColor()
 }

--- a/src/renderer/components/FtProfileEdit/FtProfileEdit.vue
+++ b/src/renderer/components/FtProfileEdit/FtProfileEdit.vue
@@ -364,7 +364,7 @@ function isSemanticProfileBgColor(color) {
 }
 
 function selectProfileBgColor(color) {
-  profileColorPickerRef.value?.close(true)
+  profileColorPickerRef.value?.close(true, false)
   profileBgColor.value = color
   rememberSemanticProfileBgColor()
 }

--- a/src/renderer/components/FtProfileEdit/FtProfileEdit.vue
+++ b/src/renderer/components/FtProfileEdit/FtProfileEdit.vue
@@ -49,6 +49,9 @@
             :model-value="customColorPickerValue"
             :allow-alpha="false"
             @update:model-value="updateProfileBgColorFromPicker"
+            @apply="rememberSemanticProfileBgColor"
+            @cancel="restoreSemanticProfileBgColor"
+            @reset="restoreSemanticProfileBgColor"
           />
           <FtInput
             class="colorSelection"
@@ -367,6 +370,12 @@ function rememberSemanticProfileBgColor() {
   semanticProfileBgColor.value = isSemanticProfileBgColor(profileBgColor.value)
     ? profileBgColor.value
     : null
+}
+
+function restoreSemanticProfileBgColor() {
+  if (semanticProfileBgColor.value !== null) {
+    profileBgColor.value = semanticProfileBgColor.value
+  }
 }
 
 function updateProfileBgColorFromPicker(color) {

--- a/src/renderer/components/FtProfileEdit/FtProfileEdit.vue
+++ b/src/renderer/components/FtProfileEdit/FtProfileEdit.vue
@@ -380,7 +380,7 @@ async function restoreSemanticProfileBgColor() {
   if (semanticColor === null) return
 
   await nextTick()
-  profileBgColor.value = semanticColor
+  if (semanticProfileBgColor.value === semanticColor) profileBgColor.value = semanticColor
 }
 
 function updateProfileBgColorFromPicker(color) {
@@ -633,7 +633,7 @@ function clearProfileIcon() {
 }
 
 function restoreOpaqueProfileColor() {
-  if (profileBgColor.value === 'transparent') {
+  if (profileBgColor.value === 'transparent' || semanticProfileBgColor.value === 'transparent') {
     selectProfileBgColor(lastOpaqueProfileBgColor.value)
   }
 }

--- a/src/renderer/components/FtProfileEdit/FtProfileEdit.vue
+++ b/src/renderer/components/FtProfileEdit/FtProfileEdit.vue
@@ -375,30 +375,16 @@ function rememberSemanticProfileBgColor() {
     : null
 }
 
-function restoreSemanticProfileBgColor() {
-  if (semanticProfileBgColor.value !== null) {
-    profileBgColor.value = semanticProfileBgColor.value
-  }
+async function restoreSemanticProfileBgColor() {
+  const semanticColor = semanticProfileBgColor.value
+  if (semanticColor === null) return
+
+  await nextTick()
+  profileBgColor.value = semanticColor
 }
 
 function updateProfileBgColorFromPicker(color) {
-  if (semanticProfileBgColor.value !== null) {
-    const resolvedSemanticColor = semanticProfileBgColor.value === THEME_BG_COLOR
-      ? themeColor.value
-      : '#000000'
-    if (normalizeHexColor(color) === normalizeHexColor(resolvedSemanticColor)) {
-      profileBgColor.value = semanticProfileBgColor.value
-      return
-    }
-  }
   profileBgColor.value = color
-}
-
-function normalizeHexColor(color) {
-  const normalized = color.toLowerCase()
-  if (!/^#[\da-f]{3,4}$/.test(normalized)) return normalized
-
-  return '#' + [...normalized.slice(1)].map(character => character.repeat(2)).join('')
 }
 
 const translatedProfileName = computed(() => {

--- a/src/renderer/components/FtQuickBookmarkIconPicker/FtQuickBookmarkIconPicker.vue
+++ b/src/renderer/components/FtQuickBookmarkIconPicker/FtQuickBookmarkIconPicker.vue
@@ -395,6 +395,7 @@ function closeCropEditor() {
 .iconOption {
   align-items: center;
   background: var(--card-bg-color);
+  backdrop-filter: var(--card-bg-blur, none);
   border: 2px solid transparent;
   border-radius: calc(6px * var(--ui-roundness));
   color: var(--primary-text-color);
@@ -427,6 +428,7 @@ function closeCropEditor() {
 
 .customEmojiInput {
   background: var(--search-bar-color);
+  backdrop-filter: var(--search-bar-blur, none);
   border: 1px solid var(--scrollbar-color);
   border-radius: calc(4px * var(--ui-roundness));
   color: var(--primary-text-color);

--- a/src/renderer/components/FtQuickSettingsMenu/FtQuickSettingsMenu.css
+++ b/src/renderer/components/FtQuickSettingsMenu/FtQuickSettingsMenu.css
@@ -38,6 +38,7 @@
 
 .profileHeaderRow {
   background-color: var(--card-bg-color);
+  backdrop-filter: var(--card-bg-blur, none);
   display: grid;
   grid-template-columns: minmax(0, 1fr) 44px;
   padding-inline-end: 8px;
@@ -161,6 +162,7 @@
 
 .quickSettingsMenu {
   background-color: var(--card-bg-color);
+  backdrop-filter: var(--card-bg-blur, none);
   box-shadow: 0 16px 40px rgb(0 0 0 / 55%), 0 3px 10px rgb(0 0 0 / 45%);
   display: flex;
   flex-direction: column;

--- a/src/renderer/components/FtRefreshWidget/FtRefreshWidget.scss
+++ b/src/renderer/components/FtRefreshWidget/FtRefreshWidget.scss
@@ -6,6 +6,7 @@
   padding-inline: 10px;
   box-shadow: 0 2px 1px 0 var(--primary-shadow-color);
   background-color: var(--card-bg-color);
+  backdrop-filter: var(--card-bg-blur, none);
   border-inline-start: 2px solid var(--primary-shadow-color);
   display: flex;
   align-items: center;
@@ -113,6 +114,7 @@
   border: 0;
   box-shadow: none;
   background-color: transparent;
+  backdrop-filter: none;
   gap: 12px;
   justify-content: flex-end;
   z-index: auto;

--- a/src/renderer/components/FtSearchFilters/FtSearchFilters.css
+++ b/src/renderer/components/FtSearchFilters/FtSearchFilters.css
@@ -44,7 +44,7 @@
   }
 
   &:active {
-    background-color: var(--tertiary-text-color);
+    background-color: var(--subtle-surface-color);
     color: var(--side-nav-active-text-color);
     transition: background 0.2s ease-in;
   }

--- a/src/renderer/components/FtSelect/FtSelect.css
+++ b/src/renderer/components/FtSelect/FtSelect.css
@@ -35,6 +35,7 @@
   position: relative;
   font-family: inherit;
   background-color: var(--search-bar-color);
+  backdrop-filter: var(--search-bar-blur, none);
   color: var(--primary-text-color);
   inline-size: 100%;
   block-size: 45px;
@@ -88,7 +89,8 @@
   font-size: 16px;
   color: var(--secondary-text-color);
   background-color: var(--card-bg-color);
-  border: 1px solid var(--tertiary-text-color);
+  backdrop-filter: var(--card-bg-blur, none);
+  border: 1px solid var(--border-color);
   border-radius: calc(5px * var(--ui-roundness));
   box-shadow: 0 2px 8px rgb(0 0 0 / 35%);
 }
@@ -130,11 +132,11 @@
 }
 
 .selectOption.active {
-  color: var(--scrollbar-text-color-hover);
+  color: var(--dropdown-item-hover-text-color);
 }
 
 .selectOption.active::before {
-  background-color: var(--scrollbar-color-hover);
+  background-color: var(--dropdown-item-hover-color);
 }
 
 .selectOption.selected {

--- a/src/renderer/components/FtSettingsSection/FtSettingsSection.scss
+++ b/src/renderer/components/FtSettingsSection/FtSettingsSection.scss
@@ -14,6 +14,7 @@
 
 .sectionBody {
   background-color: var(--card-bg-color);
+  backdrop-filter: var(--card-bg-blur, none);
   border-radius: calc(8px * var(--ui-roundness));
   padding-block: 10px;
 

--- a/src/renderer/components/FtShareButton/FtShareButton.css
+++ b/src/renderer/components/FtShareButton/FtShareButton.css
@@ -29,7 +29,7 @@
 }
 
 .divider {
-  background: var(--tertiary-text-color);
+  background: var(--border-color);
   grid-row: span 3;
   margin-block: 0;
   margin-inline: 12px;

--- a/src/renderer/components/FtSponsorBlockCategory/FtSponsorBlockCategory.vue
+++ b/src/renderer/components/FtSponsorBlockCategory/FtSponsorBlockCategory.vue
@@ -16,7 +16,7 @@
       :select-values="COLOR_VALUES"
       :icon="['fas', 'palette']"
       :class="'sec' + sponsorBlockValues.color"
-      icon-color="rgb(var(--accent-color-rgb))"
+      icon-color="var(--accent-color)"
       @change="updateColor"
       @reset="resetValue('color')"
     />

--- a/src/renderer/components/FtTutorialOverlay/FtTutorialOverlay.css
+++ b/src/renderer/components/FtTutorialOverlay/FtTutorialOverlay.css
@@ -52,7 +52,7 @@
   inline-size: 7px;
   block-size: 7px;
   border-radius: 50%;
-  background-color: var(--tertiary-text-color);
+  background-color: var(--subtle-surface-color);
   transition: inline-size 180ms ease-out, background-color 180ms ease-out;
 }
 

--- a/src/renderer/components/PlayerSettings/PlayerSettings.css
+++ b/src/renderer/components/PlayerSettings/PlayerSettings.css
@@ -118,6 +118,7 @@
   padding-block: calc(20px + 0.5rem) 0.5rem;
   padding-inline: 20px;
   background-color: var(--card-bg-color);
+  backdrop-filter: var(--card-bg-blur, none);
 }
 
 .quickPlaybackSpeedList {
@@ -136,6 +137,7 @@
   border: 1px solid var(--border-color);
   border-radius: calc(4px * var(--ui-roundness));
   background-color: var(--card-bg-color);
+  backdrop-filter: var(--card-bg-blur, none);
   transition: transform 0.18s ease, opacity 0.18s ease;
   will-change: transform;
 }
@@ -190,6 +192,7 @@
   border: 0;
   border-radius: calc(5px * var(--ui-roundness));
   background-color: var(--search-bar-color);
+  backdrop-filter: var(--search-bar-blur, none);
   color: var(--secondary-text-color);
   font-size: 16px;
 }

--- a/src/renderer/components/TabBar/SortableTab.vue
+++ b/src/renderer/components/TabBar/SortableTab.vue
@@ -562,7 +562,7 @@ watch(tabAvatarUrl, (avatarUrl) => {
 }
 
 .tab.vertical.active {
-  border-color: var(--tab-border-color, var(--tertiary-text-color));
+  border-color: var(--tab-border-color, var(--border-color));
 }
 
 .tab.vertical.colored {
@@ -581,7 +581,7 @@ watch(tabAvatarUrl, (avatarUrl) => {
 
 .tab.active {
   background-color: var(--tab-active-color, var(--card-bg-color));
-  border-color: var(--tab-border-color, var(--tertiary-text-color));
+  border-color: var(--tab-border-color, var(--border-color));
 }
 
 .tab.selected {
@@ -598,7 +598,7 @@ watch(tabAvatarUrl, (avatarUrl) => {
   --tab-surface-color: color-mix(in srgb, var(--tab-accent-color) var(--tab-accent-mix), var(--bg-color));
   --tab-hover-color: color-mix(in srgb, var(--tab-accent-color) 22%, var(--card-bg-color));
   --tab-active-color: color-mix(in srgb, var(--tab-accent-color) 26%, var(--card-bg-color));
-  --tab-border-color: color-mix(in srgb, var(--tab-accent-color) var(--tab-accent-border-mix), var(--tertiary-text-color));
+  --tab-border-color: color-mix(in srgb, var(--tab-accent-color) var(--tab-accent-border-mix), var(--border-color));
 
   box-shadow: inset 0 2px 0 var(--tab-accent-color);
 }
@@ -785,9 +785,10 @@ watch(tabAvatarUrl, (avatarUrl) => {
   inline-size: max-content;
   max-inline-size: min(340px, calc(100vw - 16px));
   padding: 8px;
-  border: 1px solid var(--tertiary-text-color);
+  border: 1px solid var(--border-color);
   border-radius: calc(8px * var(--ui-roundness));
   background-color: var(--card-bg-color);
+  backdrop-filter: var(--card-bg-blur, none);
   box-shadow: 0 8px 26px rgb(0 0 0 / 32%);
   color: var(--primary-text-color);
   font-family: Roboto, sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol', 'Noto Color Emoji';
@@ -821,6 +822,7 @@ watch(tabAvatarUrl, (avatarUrl) => {
   overflow: hidden;
   border-radius: calc(5px * var(--ui-roundness));
   background-color: var(--secondary-card-bg-color);
+  backdrop-filter: var(--secondary-card-bg-blur, none);
 }
 
 .tabTooltipPreview img {

--- a/src/renderer/components/TopNav/TopNav.scss
+++ b/src/renderer/components/TopNav/TopNav.scss
@@ -130,14 +130,14 @@
 .navButton,
 :deep(.ftIconButton:not(.arrowDisabled) .iconButton) {
   &:hover {
-    background-color: var(--side-nav-hover-color);
-    color: var(--side-nav-hover-text-color);
+    background-color: var(--header-button-hover-color);
+    color: var(--header-button-hover-text-color);
     transition: background 0.2s ease-in;
   }
 
   &:active {
-    background-color: var(--tertiary-text-color);
-    color: var(--side-nav-active-text-color);
+    background-color: var(--header-button-pressed-color);
+    color: var(--header-button-pressed-text-color);
     transition: background 0.2s ease-in;
   }
 }
@@ -166,11 +166,13 @@
   color: var(--text-with-main-color);
 
   &:hover {
-    background-color: var(--primary-color-hover);
+    background-color: var(--colored-header-button-hover-color);
+    color: var(--colored-header-button-hover-text-color);
   }
 
   &:active {
-    background-color: var(--primary-color-active);
+    background-color: var(--colored-header-button-pressed-color);
+    color: var(--colored-header-button-pressed-text-color);
   }
 }
 
@@ -233,21 +235,21 @@
     padding-inline: 10px 25px;
 
     &:hover {
-      background-color: var(--side-nav-hover-color);
-      color: var(--side-nav-hover-text-color);
+      background-color: var(--header-button-hover-color);
+      color: var(--header-button-hover-text-color);
       transition: background 0.2s ease-in;
 
       @include top-nav-is-colored {
-        background-color: var(--primary-color-hover);
+        background-color: var(--colored-header-button-hover-color);
       }
     }
 
     &:active {
-      background-color: var(--tertiary-text-color);
+      background-color: var(--header-button-pressed-color);
       transition: background 0.2s ease-in;
 
       @include top-nav-is-colored {
-        background-color: var(--primary-color-active);
+        background-color: var(--colored-header-button-pressed-color);
       }
     }
 

--- a/src/renderer/components/WatchVideoDescription/WatchVideoDescription.css
+++ b/src/renderer/components/WatchVideoDescription/WatchVideoDescription.css
@@ -78,6 +78,7 @@
   padding-block: 2px;
   inset-inline-end: 16px;
   background-color: var(--card-bg-color);
+  backdrop-filter: var(--card-bg-blur, none);
   text-decoration: none;
 }
 
@@ -101,6 +102,7 @@
   inset-block-end: 0;
   margin-block-start: 1.5em;
   background-color: var(--card-bg-color);
+  backdrop-filter: var(--card-bg-blur, none);
 }
 
 .videoDescription:not(.short) .descriptionStatus::before {
@@ -150,6 +152,7 @@
 
 .videoTagLink {
   background-color: var(--secondary-card-bg-color);
+  backdrop-filter: var(--secondary-card-bg-blur, none);
   color: var(--primary-text-color);
   border-radius: calc(7px * var(--ui-roundness));
   padding: 7px;

--- a/src/renderer/components/WatchVideoDownloadPrompt/WatchVideoDownloadPrompt.css
+++ b/src/renderer/components/WatchVideoDownloadPrompt/WatchVideoDownloadPrompt.css
@@ -142,6 +142,7 @@
 
 .downloadFooter {
   background: var(--card-bg-color);
+  backdrop-filter: var(--card-bg-blur, none);
   border-block-start: 1px solid var(--side-nav-color);
   flex: none;
   padding-block: 8px 10px;

--- a/src/renderer/components/WatchVideoFormatPrompt/WatchVideoFormatPrompt.vue
+++ b/src/renderer/components/WatchVideoFormatPrompt/WatchVideoFormatPrompt.vue
@@ -324,6 +324,7 @@ function selectPlaybackEngine(value) {
 .badge {
   align-items: center;
   background-color: var(--card-bg-color);
+  backdrop-filter: var(--card-bg-blur, none);
   border-radius: calc(20px * var(--ui-roundness));
   color: var(--secondary-text-color);
   display: inline-flex;

--- a/src/renderer/components/WatchVideoInfo/WatchVideoInfo.css
+++ b/src/renderer/components/WatchVideoInfo/WatchVideoInfo.css
@@ -32,6 +32,7 @@
 .videoBadge {
   align-items: center;
   background-color: var(--secondary-card-bg-color);
+  backdrop-filter: var(--secondary-card-bg-blur, none);
   border-radius: calc(5px * var(--ui-roundness));
   display: inline-flex;
   gap: 3px;

--- a/src/renderer/components/WatchVideoLiveChat/WatchVideoLiveChat.css
+++ b/src/renderer/components/WatchVideoLiveChat/WatchVideoLiveChat.css
@@ -79,6 +79,7 @@
   box-shadow: none;
   color: var(--primary-text-color);
   background: transparent;
+  backdrop-filter: none;
 }
 
 .fullscreenChat > .relative {
@@ -573,7 +574,7 @@
 }
 
 .liveChatActionButton:active {
-  background-color: var(--tertiary-text-color);
+  background-color: var(--subtle-surface-color);
   color: var(--side-nav-active-text-color);
   transition: background 0.2s ease-in;
 }

--- a/src/renderer/components/WatchVideoPlaylist/WatchVideoPlaylist.css
+++ b/src/renderer/components/WatchVideoPlaylist/WatchVideoPlaylist.css
@@ -68,6 +68,7 @@
   inline-size: max-content;
   max-inline-size: 100%;
   background-color: var(--card-bg-color);
+  backdrop-filter: var(--card-bg-blur, none);
   border: 1px solid var(--primary-border-color);
   border-radius: calc(8px * var(--ui-roundness));
   padding-block: 8px;

--- a/src/renderer/components/WatchVideoSponsorBlock/WatchVideoSponsorBlock.vue
+++ b/src/renderer/components/WatchVideoSponsorBlock/WatchVideoSponsorBlock.vue
@@ -267,6 +267,7 @@ function isSegmentPassed(segment) {
   overflow: hidden;
   color: var(--primary-text-color);
   background-color: var(--card-bg-color);
+  backdrop-filter: var(--card-bg-blur, none);
   border-radius: calc(8px * var(--ui-roundness));
   box-shadow: 0 1px 2px rgb(0 0 0 / 10%);
 }
@@ -444,6 +445,7 @@ function isSegmentPassed(segment) {
   padding-inline: 0;
   color: inherit;
   background-color: var(--secondary-card-bg-color);
+  backdrop-filter: var(--secondary-card-bg-blur, none);
   border: 0;
   border-radius: calc(6px * var(--ui-roundness));
   cursor: pointer;
@@ -546,6 +548,7 @@ function isSegmentPassed(segment) {
   padding-inline: 10px 12px;
   color: var(--primary-text-color);
   background-color: var(--secondary-card-bg-color);
+  backdrop-filter: var(--secondary-card-bg-blur, none);
   border: 1px solid transparent;
   border-radius: calc(10px * var(--ui-roundness));
   cursor: pointer;
@@ -583,6 +586,7 @@ function isSegmentPassed(segment) {
   block-size: 30px;
   color: var(--secondary-text-color);
   background-color: var(--card-bg-color);
+  backdrop-filter: var(--card-bg-blur, none);
   border-radius: calc(8px * var(--ui-roundness));
   font-size: 13px;
   transition: background-color 160ms ease, color 160ms ease;
@@ -618,6 +622,7 @@ function isSegmentPassed(segment) {
   inline-size: 44px;
   block-size: 24px;
   background-color: var(--secondary-card-bg-color);
+  backdrop-filter: var(--secondary-card-bg-blur, none);
   border: 1px solid var(--side-nav-hover-color);
   border-radius: calc(999px * var(--ui-roundness));
   transition: background-color 160ms ease, border-color 160ms ease;

--- a/src/renderer/components/ft-card/ft-card.css
+++ b/src/renderer/components/ft-card/ft-card.css
@@ -1,5 +1,6 @@
 .ft-card {
   background-color: var(--card-bg-color);
+  backdrop-filter: var(--card-bg-blur, none);
   border-radius: calc(8px * var(--ui-roundness));
   margin: 8px;
   padding-block: 3px 16px;

--- a/src/renderer/helpers/customTheme.js
+++ b/src/renderer/helpers/customTheme.js
@@ -1,5 +1,8 @@
 import {
+  CUSTOM_THEME_BLURS,
   CUSTOM_THEME_COLORS,
+  customThemeBackdropBlur,
+  hexColorToRgbComponents,
   isCustomThemeValue,
   normalizeCustomTheme,
   normalizeCustomThemes,
@@ -22,15 +25,24 @@ export function applyThemeToDocument(baseTheme, mainColor, secColor, customTheme
   for (const [, property] of CUSTOM_THEME_COLORS) {
     document.body.style.removeProperty(property)
   }
+  for (const [, property] of CUSTOM_THEME_BLURS) {
+    document.body.style.removeProperty(property)
+  }
   document.body.style.removeProperty('--accent-color-rgb')
 
   if (isCustomThemeValue(baseTheme) && customTheme) {
     for (const [key, property] of CUSTOM_THEME_COLORS) {
       document.body.style.setProperty(property, customTheme.colors[key])
     }
+    for (const [key, property] of CUSTOM_THEME_BLURS) {
+      document.body.style.setProperty(
+        property,
+        customThemeBackdropBlur(customTheme.colors[key], customTheme.blurs[key])
+      )
+    }
     document.body.style.setProperty(
       '--accent-color-rgb',
-      customTheme.colors.accent.match(/[\da-f]{2}/gi).map(value => Number.parseInt(value, 16)).join(' ')
+      hexColorToRgbComponents(customTheme.colors.accent)
     )
   }
 }

--- a/src/renderer/scss-partials/_ft-list-item.scss
+++ b/src/renderer/scss-partials/_ft-list-item.scss
@@ -137,6 +137,7 @@ $watched-transition-duration: 0.5s;
     .videoDuration {
       place-self: flex-end end;
       background-color: var(--card-bg-color);
+      backdrop-filter: var(--card-bg-blur, none);
       border-radius: calc(5px * var(--ui-roundness));
       color: var(--primary-text-color);
       font-size: 15px;

--- a/src/renderer/themes.css
+++ b/src/renderer/themes.css
@@ -6,7 +6,11 @@ body {
 
   --ui-roundness: 1;
   --scrollbar-thumb-width: 6px;
-  --divider-color: color-mix(in srgb, var(--tertiary-text-color) 45%, transparent);
+  --border-color: var(--tertiary-text-color);
+  --divider-color: color-mix(in srgb, var(--border-color) 45%, transparent);
+  --subtle-surface-color: var(--tertiary-text-color);
+  --dropdown-item-hover-color: var(--scrollbar-color-hover);
+  --dropdown-item-hover-text-color: var(--scrollbar-text-color-hover);
 
   /*
     This works because CSS variables are just a find and replace and
@@ -45,6 +49,18 @@ body {
   --logo-primary-color: var(--primary-text-color);
   --logo-secondary-color: var(--primary-text-color);
   --logo-tertiary-color: var(--primary-text-color);
+  --logo-pressed-color: var(--logo-tertiary-color);
+
+  /* Header interaction colors default to the legacy palette mappings so
+     built-in and version 1 custom themes retain their existing appearance. */
+  --header-button-hover-color: var(--side-nav-hover-color);
+  --header-button-hover-text-color: var(--side-nav-hover-text-color);
+  --header-button-pressed-color: var(--subtle-surface-color);
+  --header-button-pressed-text-color: var(--side-nav-active-text-color);
+  --colored-header-button-hover-color: var(--primary-color-hover);
+  --colored-header-button-hover-text-color: var(--text-with-main-color);
+  --colored-header-button-pressed-color: var(--primary-color-active);
+  --colored-header-button-pressed-text-color: var(--text-with-main-color);
 }
 
 /*************** RULE TWEAKS ***************/
@@ -259,6 +275,10 @@ it can be safely elided. This looks quite pleasant on this theme. */
 
 .custom .logo:hover :is(.logoIcon, .logoText) {
   background-color: var(--logo-tertiary-color);
+}
+
+.custom .logo:active :is(.logoIcon, .logoText) {
+  background-color: var(--logo-pressed-color);
 }
 
 .nordic {
@@ -2243,7 +2263,10 @@ body .os-scrollbar {
   --os-handle-border-radius: calc(var(--scrollbar-thumb-width) * var(--ui-roundness));
   --os-handle-bg: var(--scrollbar-color);
   --os-handle-bg-hover: var(--scrollbar-color-hover);
-  --os-handle-bg-active: color-mix(in srgb, var(--scrollbar-color-hover) 80%, #fff);
+  --os-handle-bg-active: var(
+    --scrollbar-color-active,
+    color-mix(in srgb, var(--scrollbar-color-hover) 80%, #fff)
+  );
 }
 
 /* shared shimmer for skeleton loading placeholders */

--- a/src/renderer/views/Channel/Channel.css
+++ b/src/renderer/views/Channel/Channel.css
@@ -30,7 +30,8 @@
 .channelSearchFilter {
   color: var(--primary-text-color);
   background-color: var(--search-bar-color);
-  border: 1px solid var(--tertiary-text-color);
+  backdrop-filter: var(--search-bar-blur, none);
+  border: 1px solid var(--border-color);
   border-radius: 999px;
   padding-block: 7px;
   padding-inline: 14px;
@@ -58,6 +59,7 @@
 
 .getNextPage {
   background-color: var(--search-bar-color);
+  backdrop-filter: var(--search-bar-blur, none);
   inline-size: 100%;
   block-size: 45px;
   line-height: 45px;

--- a/src/renderer/views/Hashtag/Hashtag.css
+++ b/src/renderer/views/Hashtag/Hashtag.css
@@ -1,5 +1,6 @@
 .getNextPage {
   background-color: var(--search-bar-color);
+  backdrop-filter: var(--search-bar-blur, none);
   inline-size: 100%;
   block-size: 45px;
   line-height: 45px;

--- a/src/renderer/views/Playlist/Playlist.scss
+++ b/src/renderer/views/Playlist/Playlist.scss
@@ -49,6 +49,7 @@
       inline-size: 100%;
       max-inline-size: 92vw;
       background-color: var(--card-bg-color);
+      backdrop-filter: var(--card-bg-blur, none);
       box-shadow: 0 2px 1px 0 var(--primary-shadow-color);
 
       /* video progress bar has z-index 2 and this must be above it */
@@ -74,6 +75,7 @@
 
     .playlistInfoContainer {
       background-color: var(--card-bg-color);
+      backdrop-filter: var(--card-bg-blur, none);
       block-size: calc(100vh - 132px);
       inline-size: 30%;
       inset-block-start: 96px;

--- a/src/renderer/views/Popular/Popular.css
+++ b/src/renderer/views/Popular/Popular.css
@@ -24,6 +24,7 @@
   border-start-start-radius: calc(8px * var(--ui-roundness));
   border-start-end-radius: calc(8px * var(--ui-roundness));
   background-color: var(--card-bg-color);
+  backdrop-filter: var(--card-bg-blur, none);
   box-shadow: 0 1px 0 var(--primary-shadow-color);
 }
 

--- a/src/renderer/views/ProfileSettings/ProfileSettings.css
+++ b/src/renderer/views/ProfileSettings/ProfileSettings.css
@@ -20,7 +20,7 @@ h2 {
 
 .openedProfile:hover,
 .openedProfile:focus-visible {
-  background-color: var(--tertiary-text-color);
+  background-color: var(--subtle-surface-color);
   transition: background 0.2s ease-in;
 }
 

--- a/src/renderer/views/SearchPage/SearchPage.css
+++ b/src/renderer/views/SearchPage/SearchPage.css
@@ -1,5 +1,6 @@
 .getNextPage {
   background-color: var(--search-bar-color);
+  backdrop-filter: var(--search-bar-blur, none);
   inline-size: 100%;
   block-size: 45px;
   line-height: 45px;

--- a/src/renderer/views/Settings/Settings.css
+++ b/src/renderer/views/Settings/Settings.css
@@ -14,7 +14,8 @@
   flex-direction: column;
   color: var(--primary-text-color);
   background: var(--card-bg-color);
-  border: 1px solid var(--tertiary-text-color);
+  backdrop-filter: var(--card-bg-blur, none);
+  border: 1px solid var(--border-color);
   border-radius: calc(10px * var(--ui-roundness));
   box-shadow: 0 12px 40px rgb(0 0 0 / 38%);
   container-name: settings-window;
@@ -166,6 +167,7 @@
   border-radius: calc(6px * var(--ui-roundness));
   color: var(--tertiary-text-color);
   background: var(--settings-search-bar-color);
+  backdrop-filter: var(--settings-search-bar-blur, none);
   cursor: text;
 }
 
@@ -295,6 +297,7 @@
   border: 1px solid var(--border-color);
   border-radius: calc(6px * var(--ui-roundness));
   background: var(--card-bg-color);
+  backdrop-filter: var(--card-bg-blur, none);
 }
 
 .settingsSearchResultHeading {

--- a/src/renderer/views/Stats/Stats.css
+++ b/src/renderer/views/Stats/Stats.css
@@ -28,9 +28,10 @@
 
 .summaryCard,
 .chartCard {
-  border: 1px solid color-mix(in srgb, var(--tertiary-text-color) 18%, transparent);
+  border: 1px solid color-mix(in srgb, var(--border-color) 18%, transparent);
   border-radius: calc(18px * var(--ui-roundness));
   background-color: var(--card-bg-color);
+  backdrop-filter: var(--card-bg-blur, none);
   box-shadow: 0 8px 30px rgb(0 0 0 / 7%);
 }
 
@@ -151,6 +152,7 @@
   border: 3px solid var(--primary-color);
   border-radius: 50%;
   background-color: var(--card-bg-color);
+  backdrop-filter: var(--card-bg-blur, none);
   cursor: pointer;
   transform: translate(-50%, -50%);
 }
@@ -264,7 +266,7 @@
   align-items: flex-end;
   overflow: hidden;
   border-radius: calc(8px * var(--ui-roundness));
-  background-color: color-mix(in srgb, var(--tertiary-text-color) 8%, transparent);
+  background-color: color-mix(in srgb, var(--subtle-surface-color) 8%, transparent);
 }
 
 .bar {

--- a/src/renderer/views/Subscriptions/Subscriptions.css
+++ b/src/renderer/views/Subscriptions/Subscriptions.css
@@ -24,6 +24,7 @@
   border-start-start-radius: calc(8px * var(--ui-roundness));
   border-start-end-radius: calc(8px * var(--ui-roundness));
   background-color: var(--card-bg-color);
+  backdrop-filter: var(--card-bg-blur, none);
   box-shadow: 0 1px 0 var(--primary-shadow-color);
 }
 

--- a/src/renderer/views/Trending/Trending.css
+++ b/src/renderer/views/Trending/Trending.css
@@ -24,6 +24,7 @@
   border-start-start-radius: calc(8px * var(--ui-roundness));
   border-start-end-radius: calc(8px * var(--ui-roundness));
   background-color: var(--card-bg-color);
+  backdrop-filter: var(--card-bg-blur, none);
   box-shadow: 0 1px 0 var(--primary-shadow-color);
 }
 

--- a/src/renderer/views/Watch/Watch.scss
+++ b/src/renderer/views/Watch/Watch.scss
@@ -784,6 +784,7 @@
       overflow: hidden;
       border-radius: calc(12px * var(--ui-roundness));
       background-color: var(--card-bg-color);
+      backdrop-filter: var(--card-bg-blur, none);
       box-shadow: 0 8px 32px rgb(0 0 0 / 35%);
       opacity: 0;
       visibility: hidden;
@@ -1086,6 +1087,7 @@
     min-block-size: 0;
     overflow: hidden;
     background-color: var(--card-bg-color);
+    backdrop-filter: var(--card-bg-blur, none);
     border-radius: calc(8px * var(--ui-roundness));
     color: var(--primary-text-color);
     box-shadow: 0 1px 2px rgb(0 0 0 / 10%);
@@ -1127,6 +1129,7 @@
 
     :deep(.chapterThumbnail) {
       background-color: var(--secondary-card-bg-color);
+      backdrop-filter: var(--secondary-card-bg-blur, none);
     }
 
   }
@@ -1295,6 +1298,7 @@
   padding: 16px;
   border-radius: calc(5px * var(--ui-roundness));
   background-color: var(--card-bg-color);
+  backdrop-filter: var(--card-bg-blur, none);
   box-sizing: border-box;
 
   .skeletonTitle {
@@ -1328,6 +1332,7 @@
   padding-inline: 16px;
   border-radius: calc(5px * var(--ui-roundness));
   background-color: var(--card-bg-color);
+  backdrop-filter: var(--card-bg-blur, none);
 
   .skeletonPlaylistTitle {
     inline-size: 45%;
@@ -1416,6 +1421,7 @@
   padding-block: 16px;
   padding-inline: 16px;
   background-color: var(--card-bg-color);
+  backdrop-filter: var(--card-bg-blur, none);
   box-shadow: 0 1px 2px rgb(0 0 0 / 10%);
 
   .skeletonRecommendation {

--- a/static/locales/en-US.yaml
+++ b/static/locales/en-US.yaml
@@ -1,6 +1,20 @@
 # Put the name of your locale in the same language
 Locale Name: English (US)
 
+Color Picker:
+  Hue: Hue
+  Opacity: Opacity
+  Backdrop Blur: Backdrop blur
+  Hex Color: Hex color
+  Apply Color: Apply
+  Reset Color: Reset
+  Copy Color: Copy
+  Copy From Another Color: Copy from another color
+  Color Copied: Color copied
+  Invalid Color: Enter a valid hex color
+  Clipboard Unavailable: Clipboard unavailable
+  Saturation and Brightness: Saturation and brightness
+
 # Webkit Menu Bar
 File: File
 New Window: New Window
@@ -582,7 +596,7 @@ Settings:
       Delete Theme Confirmation: Delete “{name}”? This cannot be undone.
       Save and Apply: Save and apply
       Discard Changes: Discard changes
-      Reset Colors: Reset colors
+      Reset Colors: Reset colors and effects
       Theme File: OpenTubeX theme file
       Theme Saved: Custom theme saved and applied
       Theme Imported: Theme imported into the editor
@@ -594,47 +608,60 @@ Settings:
       Unable to Delete: Unable to delete the custom theme
       Invalid Theme File: Invalid custom theme file
       Colors:
-        Primary text: Primary text
+        Main text: Main text
         Secondary text: Secondary text
-        Tertiary text: Tertiary text
-        Titles: Titles
+        Subtle text: Subtle text
+        Borders and dividers: Borders and dividers
+        Subtle surfaces and indicators: Subtle surfaces and indicators
+        Title text: Title text
         Logo icon: Logo icon
         Logo text: Logo text
         Logo hover: Logo hover
-        Background: Background
-        Cards: Cards
-        Secondary cards: Secondary cards
+        Logo pressed: Logo pressed
+        Page background: Page background
+        Card background: Card background
+        Secondary card background: Secondary card background
         Favorite icon: Favorite icon
-        Errors: Errors
-        Scrollbar: Scrollbar
-        Scrollbar hover: Scrollbar hover
-        Dropdown hover text: Dropdown hover text
-        Side navigation: Side navigation
-        Side navigation hover: Side navigation hover
-        Side navigation hover text: Side navigation hover text
-        Side navigation active: Side navigation active
-        Side navigation active text: Side navigation active text
-        Search bar: Search bar
-        Settings search bar: Settings search bar
+        Error color: Error color
+        Scrollbar thumb: Scrollbar thumb
+        Scrollbar thumb hover: Scrollbar thumb hover
+        Scrollbar thumb pressed: Scrollbar thumb pressed
+        Dropdown item hover text: Dropdown item hover text
+        Dropdown item hover background: Dropdown item hover background
+        Navigation and panel background: Navigation and panel background
+        Neutral item hover and focus background: Neutral item hover and focus background
+        Neutral item hover and focus text and icons: Neutral item hover and focus text and icons
+        Neutral item pressed background: Neutral item pressed background
+        Neutral item pressed text and icons: Neutral item pressed text and icons
+        Header button hover and focus background: Header button hover and focus background
+        Header button hover and focus text and icons: Header button hover and focus text and icons
+        Header button pressed background: Header button pressed background
+        Header button pressed text and icons: Header button pressed text and icons
+        Colored header button hover and focus background: Colored header button hover and focus background
+        Colored header button hover and focus text and icons: Colored header button hover and focus text and icons
+        Colored header button pressed background: Colored header button pressed background
+        Colored header button pressed text and icons: Colored header button pressed text and icons
+        Search and dropdown background: Search and dropdown background
+        Settings search background: Settings search background
         Instance menu: Instance menu
         Input background: Input background
-        Shadows: Shadows
-        Primary color: Primary color
-        Primary hover: Primary hover
-        Primary active: Primary active
-        Text on primary: Text on primary
-        Accent color: Accent color
-        Accent hover: Accent hover
-        Accent active: Accent active
-        Light accent: Light accent
+        Shadow color: Shadow color
+        Primary controls and highlights: Primary controls and highlights
+        Primary control hover and focus: Primary control hover and focus
+        Primary control pressed: Primary control pressed
+        Text and icons on primary controls: Text and icons on primary controls
+        Secondary controls and highlights: Secondary controls and highlights
+        Secondary control hover and focus: Secondary control hover and focus
+        Secondary control pressed: Secondary control pressed
+        Light secondary color: Light secondary color
         Visited accent: Visited accent
-        Text on accent: Text on accent
+        Text and icons on secondary controls: Text and icons on secondary controls
         Links: Links
         Visited links: Visited links
         Destructive action: Destructive action
-        Destructive hover: Destructive hover
-        Destructive active: Destructive active
-        Text on destructive action: Text on destructive action
+        Destructive hover and focus: Destructive hover and focus
+        Destructive pressed: Destructive pressed
+        Text and icons on destructive actions: Text and icons on destructive actions
     Main Color Theme:
       Main Color Theme: Main Color Theme
       Red: Red

--- a/tests/unit/custom-theme.test.mjs
+++ b/tests/unit/custom-theme.test.mjs
@@ -1,0 +1,67 @@
+import assert from 'node:assert/strict'
+import { test } from 'node:test'
+
+import {
+  customThemeBackdropBlur,
+  DEFAULT_CUSTOM_THEME,
+  normalizeCustomTheme,
+} from '../../src/customTheme.js'
+
+function legacyTheme() {
+  const theme = JSON.parse(JSON.stringify(DEFAULT_CUSTOM_THEME))
+  delete theme.version
+  delete theme.blurs
+  for (const key of [
+    'border',
+    'subtleSurface',
+    'logoPressed',
+    'scrollbarActive',
+    'dropdownHover',
+    'dropdownHoverText',
+    'headerHover',
+    'headerHoverText',
+    'headerPressed',
+    'headerPressedText',
+    'coloredHeaderHover',
+    'coloredHeaderHoverText',
+    'coloredHeaderPressed',
+    'coloredHeaderPressedText',
+  ]) delete theme.colors[key]
+  return theme
+}
+
+test('migrates legacy custom themes without changing their existing appearance', () => {
+  const theme = legacyTheme()
+  theme.colors.scrollbarHover = '#75757580'
+  const migrated = normalizeCustomTheme(theme)
+
+  assert.equal(migrated.version, 2)
+  assert.equal(migrated.colors.border, theme.colors.tertiaryText)
+  assert.equal(migrated.colors.logoPressed, theme.colors.logoTertiary)
+  assert.equal(migrated.colors.headerHover, theme.colors.sideNavHover)
+  assert.equal(migrated.colors.headerPressed, theme.colors.tertiaryText)
+  assert.equal(migrated.colors.coloredHeaderPressed, theme.colors.primaryActive)
+  assert.equal(migrated.colors.scrollbarActive, '#a3a3a399')
+  assert.deepEqual(migrated.blurs, {
+    cardBackground: 0,
+    secondaryCardBackground: 0,
+    searchBar: 0,
+    settingsSearchBar: 0,
+    primaryInput: 0,
+  })
+})
+
+test('normalizes transparent colors and bounded backdrop blur strengths', () => {
+  const theme = JSON.parse(JSON.stringify(DEFAULT_CUSTOM_THEME))
+  theme.colors.cardBackground = '#12345680'
+  theme.blurs.cardBackground = 100
+  theme.blurs.searchBar = -4
+
+  const normalized = normalizeCustomTheme(theme)
+  assert.equal(normalized.colors.cardBackground, '#12345680')
+  assert.equal(normalized.blurs.cardBackground, 40)
+  assert.equal(normalized.blurs.searchBar, 0)
+  assert.equal(customThemeBackdropBlur(normalized.colors.cardBackground, 12), 'blur(12px)')
+  assert.equal(customThemeBackdropBlur('#123456', 12), 'none')
+  assert.equal(customThemeBackdropBlur('#12345680', 0), 'none')
+})


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Make sure to follow the contributing guidelines. -->
<!-- Important note, we may remove your pull request if you do not use this provided PR template correctly. -->
<!-- Agent instructions: Preserve every heading, comment, and marker in this template. Never remove or rewrite the release-note-category:start/end, release-note:start/end, or release-note-image:start/end marker pairs. Never remove or rewrite the Release note images section; leave its contents for a human. -->

## Pull Request Type
<!-- Please select what type of pull request this is: [x] -->
- [x] Bugfix
- [x] Feature Implementation
- [ ] Documentation
- [ ] Other

## Related issue
<!-- Please link the issue your pull request is referring to. -->
<!-- If this pull request fully resolves the relevant issue, put "closes" before the issue number. -->
<!-- Example: "closes #123456". -->
Closes #738
Closes #740

## Description
<!-- Please write a clear and concise description of what the pull request does. -->
Custom themes previously conflated unrelated pressed and navigation colors, depended on native color inputs, and could not express transparent or blurred surfaces. The editor labels also made several color roles difficult to understand.

This adds a reusable custom color picker used by themes, captions, and profile customization; supports alpha colors, copying from another theme color, reset/apply/cancel behavior, and context-aware backdrop blur; and splits header, dropdown, logo, scrollbar, border, and neutral-item states into clear tokens. Custom themes are normalized to schema version 2, with legacy fallbacks chosen to preserve existing themes' appearance. It also fixes premiere metadata contrast and gives pressed scrollbars their own configurable color.

## Release note category
<!-- Select exactly one category. Every pull request must select one. -->
<!-- Select "Not noteworthy" when the pull request fixes a bug in or improves functionality that has not yet appeared in a stable release. -->
<!-- release-note-category:start -->
- [ ] Not noteworthy
- [ ] Highlights
- [x] More improvements
- [ ] Fixed bugs
<!-- release-note-category:end -->

## Release note
<!-- Required unless "Not noteworthy" is selected. -->
<!-- Write one concise, user-facing entry without a leading bullet. -->
<!-- release-note:start -->
Custom themes now offer transparent colors, backdrop blur, clearer interaction-state colors, and a reusable in-app color picker.
<!-- release-note:end -->

## Release note images
<!-- Human-only: Agents must preserve this entire section and leave it empty. -->
<!-- Optional. Paste one or more Markdown images or HTML image tags here. -->
<!-- The release notes will use an HTML image tag and limit images taller than 300 pixels. -->
<!-- release-note-image:start -->

<!-- release-note-image:end -->

## Testing
<!-- How can reviewers verify that the PR produces correct results? -->
<!-- Please provide instructions so that others can ensure that your pull request would produce correct results. For examples see, https://github.com/FreeTubeApp/FreeTube/pull/5743, https://github.com/FreeTubeApp/FreeTube/pull/7349, https://github.com/FreeTubeApp/FreeTube/pull/5125, https://github.com/FreeTubeApp/FreeTube/pull/7338 -->
<!-- Agent instructions: Only write human-facing steps that explain how to verify the change while running this branch in dev mode. Include expected results and, when applicable, helpful console snippets for interactive verification. Do not include automated checks, commands, results, pass counts, or CI status. -->
1. Open Theme settings, create a custom theme, and click a color label, swatch, or value. Confirm the in-app picker opens and that reset, apply, click-away cancel, alpha, copy, and “Copy from another color” behave as described.
2. Make Card background partly transparent, add backdrop blur, and open card-based surfaces such as Quick Settings. Confirm content behind the surface blurs, while fully opaque backgrounds do not apply blur.
3. Set distinct neutral-item, header-button, and colored-header hover/pressed colors. Confirm each component uses its dedicated values without changing side-navigation text colors.
4. Open caption appearance and profile customization. Confirm their color controls use the same picker and remain aligned with neighboring controls.
5. Load an existing schema-v1 custom theme. Confirm it opens as version 2 without a visible appearance change and can be saved normally.

## Additional context
<!-- Add any other context about the pull request here. -->
The navigation/panel background intentionally does not expose backdrop blur because the current opaque layout beneath it prevents that control from having a visible effect.
