### PR TITLE
feat(search): clear filters on right-click

### DIFF
--- a/e2e/tests/offline/search-filters.spec.mjs
+++ b/e2e/tests/offline/search-filters.spec.mjs
@@ -1,0 +1,30 @@
+import { test, expect, sel } from '../../helpers/app.mjs'
+
+test('right-clicking the search filter button clears active filters', async ({ page }) => {
+  const searchInput = page.locator(sel.searchInput)
+  const filterButton = page.locator('.navFilterButton')
+
+  await searchInput.fill('keep this query')
+  await filterButton.click()
+  await page.locator('.searchRadio', { hasText: 'Prioritize' }).getByText('Popularity', { exact: true }).click()
+  await page.locator('.searchRadio', { hasText: 'Time' }).getByText('Today', { exact: true }).click()
+  await page.locator('.searchRadio', { hasText: 'Type' }).getByText('Videos', { exact: true }).click()
+  await page.locator('.searchRadio', { hasText: 'Duration' }).getByText('3 - 20 minutes', { exact: true }).click()
+  await page.locator('.searchRadio', { hasText: 'Features' }).getByText('HD', { exact: true }).click()
+  await page.getByRole('button', { name: 'Close', exact: true }).click()
+  await expect(filterButton).toHaveClass(/filterChanged/)
+
+  await filterButton.click({ button: 'right' })
+
+  await expect(filterButton).not.toHaveClass(/filterChanged/)
+  await expect(searchInput).toHaveValue('keep this query')
+  await expect(page.getByRole('heading', { name: 'Search Filters' })).toBeHidden()
+  await expect(page.getByRole('menu', { name: 'Context Menu' })).toBeHidden()
+
+  await filterButton.click()
+  await expect(page.locator('input[type="radio"][value="relevance"]')).toBeChecked()
+  await expect(page.locator('.searchRadio', { hasText: 'Time' }).locator('input[value=""]')).toBeChecked()
+  await expect(page.locator('input[type="radio"][value="all"]')).toBeChecked()
+  await expect(page.locator('.searchRadio', { hasText: 'Duration' }).locator('input[value=""]')).toBeChecked()
+  await expect(page.getByRole('checkbox', { name: 'HD', exact: true })).not.toBeChecked()
+})

--- a/e2e/tests/offline/search-filters.spec.mjs
+++ b/e2e/tests/offline/search-filters.spec.mjs
@@ -14,9 +14,15 @@ test('right-clicking the search filter button clears active filters', async ({ p
   await page.getByRole('button', { name: 'Close', exact: true }).click()
   await expect(filterButton).toHaveClass(/filterChanged/)
 
+  await filterButton.evaluate(element => {
+    element.addEventListener('contextmenu', event => {
+      element.dataset.contextMenuDefaultPrevented = String(event.defaultPrevented)
+    }, { once: true })
+  })
   await filterButton.click({ button: 'right' })
 
   await expect(filterButton).not.toHaveClass(/filterChanged/)
+  await expect(filterButton).toHaveAttribute('data-context-menu-default-prevented', 'true')
   await expect(searchInput).toHaveValue('keep this query')
   await expect(page.getByRole('heading', { name: 'Search Filters' })).toBeHidden()
   await expect(page.getByRole('menu', { name: 'Context Menu' })).toBeHidden()
@@ -27,4 +33,33 @@ test('right-clicking the search filter button clears active filters', async ({ p
   await expect(page.locator('input[type="radio"][value="all"]')).toBeChecked()
   await expect(page.locator('.searchRadio', { hasText: 'Duration' }).locator('input[value=""]')).toBeChecked()
   await expect(page.getByRole('checkbox', { name: 'HD', exact: true })).not.toBeChecked()
+})
+
+test('right-clicking the search filter button clears only the active tab', async ({ page }) => {
+  const searchInput = page.locator(sel.searchInput)
+  const filterButton = page.locator('.navFilterButton')
+
+  await searchInput.fill('first tab query')
+  await filterButton.click()
+  await page.locator('.searchRadio', { hasText: 'Time' }).getByText('Today', { exact: true }).click()
+  await page.getByRole('button', { name: 'Close', exact: true }).click()
+
+  await page.locator(sel.newTabButton).click()
+  await searchInput.fill('second tab query')
+  await filterButton.click()
+  await page.locator('.searchRadio', { hasText: 'Prioritize' }).getByText('Popularity', { exact: true }).click()
+  await page.getByRole('button', { name: 'Close', exact: true }).click()
+
+  await page.locator(sel.tabs).first().click()
+  await expect(searchInput).toHaveValue('first tab query')
+  await expect(filterButton).toHaveClass(/filterChanged/)
+  await filterButton.click({ button: 'right' })
+  await expect(filterButton).not.toHaveClass(/filterChanged/)
+
+  await page.locator(sel.tabs).nth(1).click()
+  await expect(searchInput).toHaveValue('second tab query')
+  await expect(filterButton).toHaveClass(/filterChanged/)
+  await filterButton.click()
+  await expect(page.locator('input[type="radio"][value="popularity"]')).toBeChecked()
+  await expect(page.locator('input[type="radio"][value="today"]')).not.toBeChecked()
 })

--- a/src/renderer/components/TopNav/TopNav.vue
+++ b/src/renderer/components/TopNav/TopNav.vue
@@ -111,6 +111,7 @@
                 :aria-label="t('Search Filters.Search Filters')"
                 :title="t('Search Filters.Search Filters')"
                 @click="showSearchFilters"
+                @contextmenu.stop.prevent="clearSearchFilters"
               >
                 <FtIcon
                   class="navIcon"
@@ -441,6 +442,16 @@ const searchFilterValueChanged = computed(() => {
 
 function showSearchFilters() {
   store.dispatch('showSearchFilters')
+}
+
+function clearSearchFilters() {
+  const tabId = searchFilterTabId.value
+  store.commit('setSearchPrioritize', { tabId, value: 'relevance' })
+  store.commit('setSearchTime', { tabId, value: '' })
+  store.commit('setSearchType', { tabId, value: 'all' })
+  store.commit('setSearchDuration', { tabId, value: '' })
+  store.commit('setSearchFeatures', { tabId, value: [] })
+  store.commit('setSearchFilterValueChanged', { tabId, value: false })
 }
 
 const searchContainer = useTemplateRef('searchContainer')


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Make sure to follow the contributing guidelines. -->
<!-- Important note, we may remove your pull request if you do not use this provided PR template correctly. -->
<!-- Agent instructions: Preserve every heading, comment, and marker in this template. Never remove or rewrite the release-note-category:start/end, release-note:start/end, or release-note-image:start/end marker pairs. Never remove or rewrite the Release note images section; leave its contents for a human. -->

## Pull Request Type
<!-- Please select what type of pull request this is: [x] -->
- [ ] Bugfix
- [x] Feature Implementation
- [ ] Documentation
- [ ] Other

## Related issue
<!-- Please link the issue your pull request is referring to. -->
<!-- If this pull request fully resolves the relevant issue, put "closes" before the issue number. -->
<!-- Example: "closes #123456". -->

Closes #585

## Description
<!-- Please write a clear and concise description of what the pull request does. -->

Clearing active search filters currently requires opening the filter dialog and using its clear action. This adds a quick reset to the search bar: right-clicking the filter button restores every filter to its default while preserving the search text and the filters of other tabs.

The context-menu event is handled directly by the filter button, so neither the browser nor the app context menu opens. A focused Electron regression test covers all filter categories, the preserved query, and the resulting default state.

## Release note category
<!-- Select exactly one category. Every pull request must select one. -->
<!-- Select "Not noteworthy" when the pull request fixes a bug in or improves functionality that has not yet appeared in a stable release. -->
<!-- release-note-category:start -->
- [ ] Not noteworthy
- [ ] Highlights
- [x] More improvements
- [ ] Fixed bugs
<!-- release-note-category:end -->

## Release note
<!-- Required unless "Not noteworthy" is selected. -->
<!-- Write one concise, user-facing entry without a leading bullet. -->
<!-- release-note:start -->

Right-click the search filter button to clear all active filters instantly.

<!-- release-note:end -->

## Release note images
<!-- Human-only: Agents must preserve this entire section and leave it empty. -->
<!-- Optional. Paste one or more Markdown images or HTML image tags here. -->
<!-- The release notes will use an HTML image tag and limit images taller than 300 pixels. -->
<!-- release-note-image:start -->

<!-- release-note-image:end -->

## Testing
<!-- How can reviewers verify that the PR produces correct results? -->
<!-- Please provide instructions so that others can ensure that your pull request would produce correct results. For examples see, https://github.com/FreeTubeApp/FreeTube/pull/5743, https://github.com/FreeTubeApp/FreeTube/pull/7349, https://github.com/FreeTubeApp/FreeTube/pull/5125, https://github.com/FreeTubeApp/FreeTube/pull/7338 -->
<!-- Agent instructions: Only write human-facing steps that explain how to verify the change while running this branch in dev mode. Include expected results and, when applicable, helpful console snippets for interactive verification. Do not include automated checks, commands, results, pass counts, or CI status. -->

1. Enter text in the search bar and open the search filter dialog.
2. Change filters in several categories, then close the dialog. The filter button should indicate that filters are active.
3. Right-click the filter button. The active indicator should disappear, the search text should remain, and no context menu should open.
4. Open the search filter dialog normally. Every filter should be restored to its default value.

## Additional context
<!-- Add any other context about the pull request here. -->
