### PR TITLE
feat(downloads): add automatic downloads and template management

### DIFF
--- a/e2e/tests/offline/download-settings.spec.mjs
+++ b/e2e/tests/offline/download-settings.spec.mjs
@@ -124,13 +124,34 @@ test.describe('download settings', () => {
       videoId: 'ccccccccccc',
       title: 'Automatic video',
       mode: 'video',
+      template: 'video:best',
       automatic: true,
+      channelId: BETA_CHANNEL_ID,
+      automaticMediaType: 'video',
       minDurationSeconds: 60,
       maxDurationSeconds: 180,
       minFileSizeMb: 5,
       maxFileSizeMb: 25,
-      maxAgeDays: 7
+      maxAgeDays: 7,
+      customArgs: '--write-description'
     }
+    expect(await page.evaluate((download) => window.ftElectron.ytDlpDownload(download), payload)).toBeNull()
+    await page.evaluate(async ({ channelId, rule }) => {
+      const store = document.querySelector('#app').__vue_app__.config.globalProperties.$store
+      await store.dispatch('updateYtDlpAutomaticDownloadRules', JSON.stringify({ [channelId]: rule }))
+    }, {
+      channelId: BETA_CHANNEL_ID,
+      rule: {
+        template: 'video:best',
+        includeVideos: true,
+        minDurationSeconds: 60,
+        maxDurationSeconds: 180,
+        minFileSizeMb: 5,
+        maxFileSizeMb: 25,
+        maxAgeDays: 7
+      }
+    })
+
     const result = await page.evaluate((download) => window.ftElectron.ytDlpDownload(download), payload)
     expect(result).toEqual({ id: expect.any(Number) })
     await expect.poll(() => page.evaluate(async (id) => {
@@ -140,7 +161,7 @@ test.describe('download settings', () => {
     const args = (await readFile(argumentsFile, 'utf8')).trim().split('\n')
     expect(args).toEqual(expect.arrayContaining([
       '--match-filter',
-      'duration >= 60 & duration <= 180',
+      `channel_id = ${BETA_CHANNEL_ID} & duration >= 60 & duration <= 180`,
       '--min-filesize',
       '5M',
       '--max-filesize',
@@ -149,6 +170,7 @@ test.describe('download settings', () => {
       'now-7days',
       '--no-overwrites'
     ]))
+    expect(args).not.toContain('--write-description')
 
     const duplicate = await page.evaluate((download) => window.ftElectron.ytDlpDownload(download), payload)
     expect(duplicate).toEqual({ skipped: 'already-downloaded' })

--- a/e2e/tests/offline/download-settings.spec.mjs
+++ b/e2e/tests/offline/download-settings.spec.mjs
@@ -215,7 +215,12 @@ test.describe('automatic download authorization', () => {
       videoId: 'ddddddddddd'
     })).toBeNull()
 
-    const result = await page.evaluate((download) => window.ftElectron.ytDlpDownload(download), authorizedPayload)
+    const concurrentResults = await page.evaluate((download) => Promise.all([
+      window.ftElectron.ytDlpDownload(download),
+      window.ftElectron.ytDlpDownload(download)
+    ]), authorizedPayload)
+    const result = concurrentResults.find(download => 'id' in download)
+    expect(concurrentResults).toContainEqual({ skipped: 'already-downloaded' })
     expect(result).toEqual({ id: expect.any(Number) })
     await expect.poll(() => page.evaluate(async (id) => {
       return (await window.ftElectron.ytDlpListDownloads()).find(download => download.id === id)?.status

--- a/e2e/tests/offline/download-settings.spec.mjs
+++ b/e2e/tests/offline/download-settings.spec.mjs
@@ -5,21 +5,31 @@ import { test, expect, goToSettingsSection } from '../../helpers/app.mjs'
 
 const ALPHA_CHANNEL_ID = 'UCaaaaaaaaaaaaaaaaaaaaaa'
 const BETA_CHANNEL_ID = 'UCbbbbbbbbbbbbbbbbbbbbbb'
+const PROFILES = [
+  {
+    _id: 'allChannels',
+    name: 'All Channels',
+    bgColor: '#000000',
+    textColor: '#FFFFFF',
+    subscriptions: [
+      { id: ALPHA_CHANNEL_ID, name: 'Alpha Channel', thumbnail: '' },
+      { id: BETA_CHANNEL_ID, name: 'Beta Channel', thumbnail: '' }
+    ]
+  }
+]
+const AUTOMATIC_RULE = {
+  template: 'video:best',
+  includeVideos: true,
+  minDurationSeconds: 60,
+  maxDurationSeconds: 180,
+  minFileSizeMb: 5,
+  maxFileSizeMb: 25,
+  maxAgeDays: 7
+}
 
 test.use({
   seed: {
-    profiles: [
-      {
-        _id: 'allChannels',
-        name: 'All Channels',
-        bgColor: '#000000',
-        textColor: '#FFFFFF',
-        subscriptions: [
-          { id: ALPHA_CHANNEL_ID, name: 'Alpha Channel', thumbnail: '' },
-          { id: BETA_CHANNEL_ID, name: 'Beta Channel', thumbnail: '' }
-        ]
-      }
-    ]
+    profiles: PROFILES
   }
 })
 
@@ -67,7 +77,7 @@ test.describe('download settings', () => {
     })).toEqual(['Podcast', 'Podcast Copy'])
   })
 
-  test('searches channels and keeps the template and media switches aligned', async ({ page }) => {
+  test('searches channels and keeps the template and media switches aligned', async ({ app, page }) => {
     await goToSettingsSection(page, 'download')
     await page.getByRole('button', { name: 'Manage Automatic Downloads (0)' }).click()
 
@@ -104,6 +114,21 @@ test.describe('download settings', () => {
       expect(center).toBeCloseTo(geometry.centers[0], 0)
     }
     expect(geometry.widths[0]).toBeGreaterThan(geometry.widths[1])
+
+    const { page: relaunchedPage } = await app.relaunch()
+    await goToSettingsSection(relaunchedPage, 'download')
+    await expect(relaunchedPage.getByRole('button', { name: 'Manage Automatic Downloads (1)' })).toBeVisible()
+  })
+})
+
+test.describe('automatic download authorization', () => {
+  test.use({
+    seed: {
+      settings: {
+        ytDlpAutomaticDownloadRules: JSON.stringify({ [BETA_CHANNEL_ID]: AUTOMATIC_RULE })
+      },
+      profiles: PROFILES
+    }
   })
 
   test('starts filtered automatic downloads without user activation and deduplicates them', async ({ app, page }) => {
@@ -135,22 +160,10 @@ test.describe('download settings', () => {
       maxAgeDays: 7,
       customArgs: '--write-description'
     }
-    expect(await page.evaluate((download) => window.ftElectron.ytDlpDownload(download), payload)).toBeNull()
-    await page.evaluate(async ({ channelId, rule }) => {
-      const store = document.querySelector('#app').__vue_app__.config.globalProperties.$store
-      await store.dispatch('updateYtDlpAutomaticDownloadRules', JSON.stringify({ [channelId]: rule }))
-    }, {
-      channelId: BETA_CHANNEL_ID,
-      rule: {
-        template: 'video:best',
-        includeVideos: true,
-        minDurationSeconds: 60,
-        maxDurationSeconds: 180,
-        minFileSizeMb: 5,
-        maxFileSizeMb: 25,
-        maxAgeDays: 7
-      }
-    })
+    expect(await page.evaluate((download) => window.ftElectron.ytDlpDownload(download), {
+      ...payload,
+      channelId: ALPHA_CHANNEL_ID
+    })).toBeNull()
 
     const result = await page.evaluate((download) => window.ftElectron.ytDlpDownload(download), payload)
     expect(result).toEqual({ id: expect.any(Number) })

--- a/e2e/tests/offline/download-settings.spec.mjs
+++ b/e2e/tests/offline/download-settings.spec.mjs
@@ -75,6 +75,14 @@ test.describe('download settings', () => {
       const store = document.querySelector('#app').__vue_app__.config.globalProperties.$store
       return JSON.parse(store.getters.getYtDlpDownloadTemplates).map(template => template.name)
     })).toEqual(['Podcast', 'Podcast Copy'])
+
+    await name.fill('Podcast')
+    await page.getByRole('button', { name: 'Save Template' }).click()
+    await expect(page.getByText('A download template named "Podcast" already exists.')).toBeVisible()
+    await expect.poll(() => page.evaluate(() => {
+      const store = document.querySelector('#app').__vue_app__.config.globalProperties.$store
+      return JSON.parse(store.getters.getYtDlpDownloadTemplates).map(template => template.name)
+    })).toEqual(['Podcast', 'Podcast Copy'])
   })
 
   test('searches channels and keeps the template and media switches aligned', async ({ app, page }) => {
@@ -134,6 +142,13 @@ test.describe('automatic download authorization', () => {
   test('starts filtered automatic downloads only for the active subscription refresh', async ({ app, page }) => {
     const executable = path.join(app.userDataDir, 'fake-automatic-yt-dlp.sh')
     const argumentsFile = path.join(app.userDataDir, 'automatic-yt-dlp-arguments.txt')
+    await writeFile(path.join(app.userDataDir, 'automatic-download-discovery.xml'), [
+      '<feed xmlns:yt="http://www.youtube.com/xml/schemas/2015">',
+      '<entry>',
+      `<yt:videoId>ccccccccccc</yt:videoId><yt:channelId>${BETA_CHANNEL_ID}</yt:channelId>`,
+      '</entry>',
+      '</feed>'
+    ].join(''))
     await writeFile(executable, [
       '#!/bin/sh',
       `printf '%s\\n' "$@" > ${argumentsFile}`,
@@ -168,13 +183,18 @@ test.describe('automatic download authorization', () => {
       return await window.ftElectron.subscriptionAutoRefresh.acquire(tabId, 'videos') ? tabId : null
     })
     expect(refreshOwnerTabId).not.toBeNull()
+    const authorizedPayload = { ...payload, refreshOwnerTabId }
 
     expect(await page.evaluate((download) => window.ftElectron.ytDlpDownload(download), {
-      ...payload,
+      ...authorizedPayload,
       channelId: ALPHA_CHANNEL_ID
     })).toBeNull()
+    expect(await page.evaluate((download) => window.ftElectron.ytDlpDownload(download), {
+      ...authorizedPayload,
+      videoId: 'ddddddddddd'
+    })).toBeNull()
 
-    const result = await page.evaluate((download) => window.ftElectron.ytDlpDownload(download), payload)
+    const result = await page.evaluate((download) => window.ftElectron.ytDlpDownload(download), authorizedPayload)
     expect(result).toEqual({ id: expect.any(Number) })
     await expect.poll(() => page.evaluate(async (id) => {
       return (await window.ftElectron.ytDlpListDownloads()).find(download => download.id === id)?.status
@@ -194,7 +214,7 @@ test.describe('automatic download authorization', () => {
     ]))
     expect(args).not.toContain('--write-description')
 
-    const duplicate = await page.evaluate((download) => window.ftElectron.ytDlpDownload(download), payload)
+    const duplicate = await page.evaluate((download) => window.ftElectron.ytDlpDownload(download), authorizedPayload)
     expect(duplicate).toEqual({ skipped: 'already-downloaded' })
     await page.evaluate((tabId) => window.ftElectron.subscriptionAutoRefresh.release(tabId), refreshOwnerTabId)
   })

--- a/e2e/tests/offline/download-settings.spec.mjs
+++ b/e2e/tests/offline/download-settings.spec.mjs
@@ -19,12 +19,15 @@ const PROFILES = [
 ]
 const AUTOMATIC_RULE = {
   template: 'video:best',
+  enabledAt: Date.parse('2026-08-14T00:00:00Z'),
   includeVideos: true,
   minDurationSeconds: 60,
   maxDurationSeconds: 180,
   minFileSizeMb: 5,
   maxFileSizeMb: 25,
-  maxAgeDays: 7
+  maxAgeDays: 7,
+  titleIncludes: 'Automatic',
+  titleExcludes: 'Trailer'
 }
 
 test.use({
@@ -146,6 +149,11 @@ test.describe('automatic download authorization', () => {
       '<feed xmlns:yt="http://www.youtube.com/xml/schemas/2015">',
       '<entry>',
       `<yt:videoId>ccccccccccc</yt:videoId><yt:channelId>${BETA_CHANNEL_ID}</yt:channelId>`,
+      '<published>2026-08-14T01:00:00Z</published>',
+      '</entry>',
+      '<entry>',
+      `<yt:videoId>ddddddddddd</yt:videoId><yt:channelId>${BETA_CHANNEL_ID}</yt:channelId>`,
+      '<published>2026-08-13T23:59:59Z</published>',
       '</entry>',
       '</feed>'
     ].join(''))
@@ -173,9 +181,19 @@ test.describe('automatic download authorization', () => {
       minFileSizeMb: 5,
       maxFileSizeMb: 25,
       maxAgeDays: 7,
+      enabledAt: 1,
+      titleIncludes: 'Injected',
+      titleExcludes: '',
       customArgs: '--write-description'
     }
     expect(await page.evaluate((download) => window.ftElectron.ytDlpDownload(download), payload)).toBeNull()
+
+    if ((await page.evaluate(() => window.ftElectron.subscriptionAutoRefresh.isInProgress())).inProgress) {
+      await page.evaluate(() => window.ftElectron.subscriptionAutoRefresh.cancel())
+      await expect.poll(() => page.evaluate(async () => (
+        await window.ftElectron.subscriptionAutoRefresh.isInProgress()
+      ).inProgress)).toBe(false)
+    }
 
     const refreshOwnerTabId = await page.evaluate(async () => {
       const store = document.querySelector('#app').__vue_app__.config.globalProperties.$store
@@ -210,6 +228,8 @@ test.describe('automatic download authorization', () => {
       '25M',
       '--dateafter',
       'now-7days',
+      '--match-title',
+      '(?i)^(?=.*(?:Automatic))(?!.*(?:Trailer)).*$',
       '--no-overwrites'
     ]))
     expect(args).not.toContain('--write-description')

--- a/e2e/tests/offline/download-settings.spec.mjs
+++ b/e2e/tests/offline/download-settings.spec.mjs
@@ -131,7 +131,7 @@ test.describe('automatic download authorization', () => {
     }
   })
 
-  test('starts filtered automatic downloads without user activation and deduplicates them', async ({ app, page }) => {
+  test('starts filtered automatic downloads only for the active subscription refresh', async ({ app, page }) => {
     const executable = path.join(app.userDataDir, 'fake-automatic-yt-dlp.sh')
     const argumentsFile = path.join(app.userDataDir, 'automatic-yt-dlp-arguments.txt')
     await writeFile(executable, [
@@ -160,6 +160,15 @@ test.describe('automatic download authorization', () => {
       maxAgeDays: 7,
       customArgs: '--write-description'
     }
+    expect(await page.evaluate((download) => window.ftElectron.ytDlpDownload(download), payload)).toBeNull()
+
+    const refreshOwnerTabId = await page.evaluate(async () => {
+      const store = document.querySelector('#app').__vue_app__.config.globalProperties.$store
+      const tabId = store.getters.getActiveTabId
+      return await window.ftElectron.subscriptionAutoRefresh.acquire(tabId, 'videos') ? tabId : null
+    })
+    expect(refreshOwnerTabId).not.toBeNull()
+
     expect(await page.evaluate((download) => window.ftElectron.ytDlpDownload(download), {
       ...payload,
       channelId: ALPHA_CHANNEL_ID
@@ -187,5 +196,6 @@ test.describe('automatic download authorization', () => {
 
     const duplicate = await page.evaluate((download) => window.ftElectron.ytDlpDownload(download), payload)
     expect(duplicate).toEqual({ skipped: 'already-downloaded' })
+    await page.evaluate((tabId) => window.ftElectron.subscriptionAutoRefresh.release(tabId), refreshOwnerTabId)
   })
 })

--- a/e2e/tests/offline/download-settings.spec.mjs
+++ b/e2e/tests/offline/download-settings.spec.mjs
@@ -1,0 +1,156 @@
+import { chmod, readFile, writeFile } from 'node:fs/promises'
+import path from 'node:path'
+
+import { test, expect, goToSettingsSection } from '../../helpers/app.mjs'
+
+const ALPHA_CHANNEL_ID = 'UCaaaaaaaaaaaaaaaaaaaaaa'
+const BETA_CHANNEL_ID = 'UCbbbbbbbbbbbbbbbbbbbbbb'
+
+test.use({
+  seed: {
+    profiles: [
+      {
+        _id: 'allChannels',
+        name: 'All Channels',
+        bgColor: '#000000',
+        textColor: '#FFFFFF',
+        subscriptions: [
+          { id: ALPHA_CHANNEL_ID, name: 'Alpha Channel', thumbnail: '' },
+          { id: BETA_CHANNEL_ID, name: 'Beta Channel', thumbnail: '' }
+        ]
+      }
+    ]
+  }
+})
+
+test.describe('download settings', () => {
+  test('creates templates from built-in and custom templates', async ({ page }) => {
+    await goToSettingsSection(page, 'download')
+
+    await expect(page.getByText(
+      'yt-dlp, FFmpeg, and FFprobe are configured in the External Software settings.',
+      { exact: true }
+    )).toHaveCount(0)
+    await page.getByRole('button', { name: 'Manage Download Templates (0)' }).click()
+
+    const header = page.locator('.templateManagerHeader')
+    const source = header.getByRole('combobox', { name: 'Template to Edit or Use as a Base' })
+    const name = header.getByRole('textbox', { name: 'Template Name' })
+    const [sourceBox, nameBox] = await Promise.all([source.boundingBox(), name.boundingBox()])
+    expect(sourceBox.y).toBeCloseTo(nameBox.y, 0)
+    expect(sourceBox.height).toBeCloseTo(nameBox.height, 0)
+
+    await source.click()
+    await page.locator(`#${await source.getAttribute('aria-controls')}`)
+      .getByRole('option', { name: 'Audio - MP3 (Built-in)', exact: true }).click()
+    await expect(page.getByRole('combobox', { name: 'Media Type' })).toHaveText('Audio')
+    await name.fill('Podcast')
+    await page.getByRole('button', { name: 'Save Template' }).click()
+
+    await expect.poll(() => page.evaluate(() => {
+      const store = document.querySelector('#app').__vue_app__.config.globalProperties.$store
+      return JSON.parse(store.getters.getYtDlpDownloadTemplates)
+    })).toEqual([
+      expect.objectContaining({
+        name: 'Podcast',
+        options: expect.objectContaining({ mode: 'audio', audioFormat: 'mp3' })
+      })
+    ])
+
+    await page.getByRole('button', { name: 'Create Copy' }).click()
+    await expect(name).toHaveValue('Podcast Copy')
+    await page.getByRole('button', { name: 'Save Template' }).click()
+
+    await expect.poll(() => page.evaluate(() => {
+      const store = document.querySelector('#app').__vue_app__.config.globalProperties.$store
+      return JSON.parse(store.getters.getYtDlpDownloadTemplates).map(template => template.name)
+    })).toEqual(['Podcast', 'Podcast Copy'])
+  })
+
+  test('searches channels and keeps the template and media switches aligned', async ({ page }) => {
+    await goToSettingsSection(page, 'download')
+    await page.getByRole('button', { name: 'Manage Automatic Downloads (0)' }).click()
+
+    const manager = page.locator('.settingsSubpageContent')
+    const search = manager.getByRole('textbox', { name: 'Search channels' })
+    await search.fill('beta')
+    await expect(manager.getByText('Beta Channel', { exact: true })).toBeVisible()
+    await expect(manager.getByText('Alpha Channel', { exact: true })).toHaveCount(0)
+
+    await manager.getByText('Beta Channel', { exact: true }).click()
+    await expect.poll(() => page.evaluate((channelId) => {
+      const store = document.querySelector('#app').__vue_app__.config.globalProperties.$store
+      return JSON.parse(store.getters.getYtDlpAutomaticDownloadRules)[channelId]
+    }, BETA_CHANNEL_ID)).toEqual(expect.objectContaining({
+      template: 'video:best',
+      includeVideos: true,
+      includeShorts: false,
+      includeLivestreams: false,
+      enabledAt: expect.any(Number)
+    }))
+
+    const options = manager.locator('.templateAndTypes')
+    const geometry = await options.evaluate((row) => {
+      const controls = [
+        row.querySelector('.select-text'),
+        ...row.querySelectorAll('.switch-label')
+      ].map(element => element.getBoundingClientRect())
+      return {
+        centers: controls.map(box => box.y + box.height / 2),
+        widths: controls.map(box => box.width)
+      }
+    })
+    for (const center of geometry.centers.slice(1)) {
+      expect(center).toBeCloseTo(geometry.centers[0], 0)
+    }
+    expect(geometry.widths[0]).toBeGreaterThan(geometry.widths[1])
+  })
+
+  test('starts filtered automatic downloads without user activation and deduplicates them', async ({ app, page }) => {
+    const executable = path.join(app.userDataDir, 'fake-automatic-yt-dlp.sh')
+    const argumentsFile = path.join(app.userDataDir, 'automatic-yt-dlp-arguments.txt')
+    await writeFile(executable, [
+      '#!/bin/sh',
+      `printf '%s\\n' "$@" > ${argumentsFile}`,
+      "printf '__OPENTUBEX_FILE__:ccccccccccc\\t120\\t1920\\t1080\\t/tmp/automatic.webm\\n'"
+    ].join('\n'))
+    await chmod(executable, 0o755)
+    await page.evaluate(async (ytDlpPath) => {
+      const store = document.querySelector('#app').__vue_app__.config.globalProperties.$store
+      await store.dispatch('updateYtDlpPath', ytDlpPath)
+    }, executable)
+
+    const payload = {
+      videoId: 'ccccccccccc',
+      title: 'Automatic video',
+      mode: 'video',
+      automatic: true,
+      minDurationSeconds: 60,
+      maxDurationSeconds: 180,
+      minFileSizeMb: 5,
+      maxFileSizeMb: 25,
+      maxAgeDays: 7
+    }
+    const result = await page.evaluate((download) => window.ftElectron.ytDlpDownload(download), payload)
+    expect(result).toEqual({ id: expect.any(Number) })
+    await expect.poll(() => page.evaluate(async (id) => {
+      return (await window.ftElectron.ytDlpListDownloads()).find(download => download.id === id)?.status
+    }, result.id)).toBe('completed')
+
+    const args = (await readFile(argumentsFile, 'utf8')).trim().split('\n')
+    expect(args).toEqual(expect.arrayContaining([
+      '--match-filter',
+      'duration >= 60 & duration <= 180',
+      '--min-filesize',
+      '5M',
+      '--max-filesize',
+      '25M',
+      '--dateafter',
+      'now-7days',
+      '--no-overwrites'
+    ]))
+
+    const duplicate = await page.evaluate((download) => window.ftElectron.ytDlpDownload(download), payload)
+    expect(duplicate).toEqual({ skipped: 'already-downloaded' })
+  })
+})

--- a/e2e/tests/offline/download-settings.spec.mjs
+++ b/e2e/tests/offline/download-settings.spec.mjs
@@ -184,7 +184,10 @@ test.describe('automatic download authorization', () => {
       enabledAt: 1,
       titleIncludes: 'Injected',
       titleExcludes: '',
-      customArgs: '--write-description'
+      customArgs: '--write-description',
+      videoIds: ['eeeeeeeeeee'],
+      isPlaylist: true,
+      playlistId: 'PL1234567890'
     }
     expect(await page.evaluate((download) => window.ftElectron.ytDlpDownload(download), payload)).toBeNull()
 
@@ -233,6 +236,9 @@ test.describe('automatic download authorization', () => {
       '--no-overwrites'
     ]))
     expect(args).not.toContain('--write-description')
+    expect(args).toContain('https://www.youtube.com/watch?v=ccccccccccc')
+    expect(args).not.toContain('https://www.youtube.com/watch?v=eeeeeeeeeee')
+    expect(args).not.toContain('https://www.youtube.com/playlist?list=PL1234567890')
 
     const duplicate = await page.evaluate((download) => window.ftElectron.ytDlpDownload(download), authorizedPayload)
     expect(duplicate).toEqual({ skipped: 'already-downloaded' })

--- a/src/main/index.js
+++ b/src/main/index.js
@@ -3699,7 +3699,10 @@ function runApp() {
 
   ipcMain.on(IpcChannels.OPEN_IN_EXTERNAL_PLAYER, handleOpenInExternalPlayer)
 
-  ipcMain.handle(IpcChannels.YT_DLP_DOWNLOAD, handleYtDlpDownload)
+  ipcMain.handle(IpcChannels.YT_DLP_DOWNLOAD, (event, payload, retryDownloadId) => {
+    const automaticDownloadAuthorized = subscriptionAutoRefreshOwner?.webContents.id === event.sender.id
+    return handleYtDlpDownload(event, payload, retryDownloadId, automaticDownloadAuthorized)
+  })
 
   ipcMain.on(IpcChannels.YT_DLP_CANCEL_DOWNLOAD, handleYtDlpCancelDownload)
   ipcMain.handle(IpcChannels.YT_DLP_LIST_DOWNLOADS, handleYtDlpListDownloads)

--- a/src/main/index.js
+++ b/src/main/index.js
@@ -3700,7 +3700,8 @@ function runApp() {
   ipcMain.on(IpcChannels.OPEN_IN_EXTERNAL_PLAYER, handleOpenInExternalPlayer)
 
   ipcMain.handle(IpcChannels.YT_DLP_DOWNLOAD, (event, payload, retryDownloadId) => {
-    const automaticDownloadAuthorized = subscriptionAutoRefreshOwner?.webContents.id === event.sender.id
+    const automaticDownloadAuthorized = subscriptionAutoRefreshOwner?.webContents.id === event.sender.id &&
+      payload?.refreshOwnerTabId === subscriptionAutoRefreshOwner.tabId
     return handleYtDlpDownload(event, payload, retryDownloadId, automaticDownloadAuthorized)
   })
 

--- a/src/main/ytDlp.js
+++ b/src/main/ytDlp.js
@@ -232,6 +232,12 @@ function loadDownloadRecords() {
   return downloadRecordsLoadPromise
 }
 
+function hasAutomaticDownloadRecord(videoId) {
+  return [...downloadRecords.values()].some(record => (
+    record.videoId === videoId && ['downloading', 'processing', 'completed', 'skipped'].includes(record.status)
+  ))
+}
+
 function saveDownloadRecords() {
   downloadRecordsSaveQueue = downloadRecordsSaveQueue
     .catch(() => {})
@@ -1516,9 +1522,7 @@ async function startYtDlpDownload(
 
   await loadDownloadRecords()
 
-  if (payload.automatic === true && isSingleVideo && [...downloadRecords.values()].some(record => (
-    record.videoId === payload.videoId && ['downloading', 'processing', 'completed', 'skipped'].includes(record.status)
-  ))) {
+  if (payload.automatic === true && isSingleVideo && hasAutomaticDownloadRecord(payload.videoId)) {
     return { skipped: 'already-downloaded' }
   }
 
@@ -1712,6 +1716,13 @@ async function startYtDlpDownload(
   // existing video file when both variants have the same source extension.
   const temporaryDownloadFolder = await mkdtemp(join(app.getPath('temp'), 'opentubex-download-'))
   args.push('--paths', `temp:${temporaryDownloadFolder}`)
+
+  // Authorization and executable setup contain awaits, so another refresh can
+  // start the same video after the initial fast-path check above.
+  if (payload.automatic === true && isSingleVideo && hasAutomaticDownloadRecord(payload.videoId)) {
+    await rm(temporaryDownloadFolder, { recursive: true, force: true })
+    return { skipped: 'already-downloaded' }
+  }
 
   const id = ++downloadCounter
   const child = spawn(executable, args, { windowsHide: true })

--- a/src/main/ytDlp.js
+++ b/src/main/ytDlp.js
@@ -109,32 +109,6 @@ const AUTOMATIC_NUMBER_LIMITS = Object.freeze({
   maxFileSizeMb: 1_000_000,
   maxAgeDays: 36_500
 })
-const AUTOMATIC_TEMPLATE_OPTION_KEYS = new Set([
-  'mode',
-  'quality',
-  'videoFormat',
-  'videoCodec',
-  'audioFormat',
-  'filenameTemplate',
-  'startTime',
-  'endTime',
-  'splitChapters',
-  'removeSponsorblock',
-  'sponsorBlockCategories',
-  'includeSubtitles',
-  'embedSubtitles',
-  'subtitleLanguages',
-  'subtitleFormat',
-  'embedThumbnail',
-  'embedMetadata',
-  'customArgs'
-])
-const AUTOMATIC_RULE_OPTION_KEYS = new Set([
-  ...Object.keys(AUTOMATIC_NUMBER_LIMITS),
-  'enabledAt',
-  'titleIncludes',
-  'titleExcludes'
-])
 const BUILT_IN_AUTOMATIC_TEMPLATE_OPTIONS = new Map([
   ['video:best', { mode: 'video' }],
   ['video:best:mp4', { mode: 'video', videoFormat: 'mp4' }],
@@ -1456,9 +1430,13 @@ async function authorizeAutomaticDownload(payload, discoveryPreviouslyAuthorized
     }
   }
 
-  const sanitizedPayload = Object.fromEntries(Object.entries(payload).filter(([key]) => (
-    !AUTOMATIC_TEMPLATE_OPTION_KEYS.has(key) && !AUTOMATIC_RULE_OPTION_KEYS.has(key)
-  )))
+  const sanitizedPayload = {
+    videoId: payload.videoId,
+    channelId: payload.channelId,
+    title: payload.title,
+    thumbnail: payload.thumbnail,
+    notification: payload.notification
+  }
   for (const [key, maximum] of Object.entries(AUTOMATIC_NUMBER_LIMITS)) {
     sanitizedPayload[key] = automaticNumber(rule[key], maximum)
   }

--- a/src/main/ytDlp.js
+++ b/src/main/ytDlp.js
@@ -60,6 +60,7 @@ function takeGetInfoAbortSignal(key) {
  * @property {boolean} [automatic] whether a subscription refresh started the download
  * @property {string} [channelId] channel whose persisted rule authorized the automatic download
  * @property {'video' | 'short' | 'livestream'} [automaticMediaType]
+ * @property {string} [refreshOwnerTabId] logical tab that owns the subscription refresh
  * @property {number} [minDurationSeconds]
  * @property {number} [maxDurationSeconds]
  * @property {number} [minFileSizeMb]
@@ -96,6 +97,9 @@ function takeGetInfoAbortSignal(key) {
 
 const ID_REGEX = /^[\w-]{11}$/
 const CHANNEL_ID_REGEX = /^UC[\w-]{22}$/
+const AUTOMATIC_DISCOVERY_CACHE_TTL_MS = 60_000
+const AUTOMATIC_DISCOVERY_TIMEOUT_MS = 15_000
+const AUTOMATIC_DISCOVERY_E2E_FIXTURE = 'automatic-download-discovery.xml'
 const AUTOMATIC_NUMBER_LIMITS = Object.freeze({
   minDurationSeconds: 31_536_000,
   maxDurationSeconds: 31_536_000,
@@ -178,6 +182,7 @@ let downloadRecordsSaveQueue = Promise.resolve()
 let binaryInstallCounter = 0
 let managedBinaryInstallQueue = Promise.resolve()
 const retryingDownloadIds = new Set()
+const automaticDiscoveryCache = new Map()
 const activeAutomaticDownloadNotifications = new Set()
 
 /** @type {Map<number, { child: import('node:child_process').ChildProcess, cancelled: boolean }>} */
@@ -1272,6 +1277,61 @@ function automaticNumber(value, maximum) {
     : null
 }
 
+/**
+ * Loads recent video IDs for a channel from a main-process-owned source. This
+ * prevents a renderer from turning a persisted channel rule into permission to
+ * download an arbitrary video that was not present in the subscription feed.
+ * @param {string} channelId
+ * @returns {Promise<Set<string> | null>}
+ */
+async function getAutomaticDiscoveryVideoIds(channelId) {
+  const cached = automaticDiscoveryCache.get(channelId)
+  if (cached?.expiresAt > Date.now()) {
+    return cached.videoIds
+  }
+
+  let feed
+  if (process.env.OPENTUBEX_E2E_USER_DATA_DIR) {
+    try {
+      feed = await readFile(join(app.getPath('userData'), AUTOMATIC_DISCOVERY_E2E_FIXTURE), 'utf8')
+    } catch {
+      return null
+    }
+  } else {
+    const controller = new AbortController()
+    const timeout = setTimeout(() => controller.abort(), AUTOMATIC_DISCOVERY_TIMEOUT_MS)
+    try {
+      const response = await net.fetch(
+        `https://www.youtube.com/feeds/videos.xml?channel_id=${channelId}`,
+        { signal: controller.signal }
+      )
+      if (!response.ok) {
+        return null
+      }
+      feed = await response.text()
+    } catch {
+      return null
+    } finally {
+      clearTimeout(timeout)
+    }
+  }
+
+  const videoIds = new Set()
+  for (const entry of feed.matchAll(/<entry\b[\s\S]*?<\/entry>/g)) {
+    const entryChannelId = entry[0].match(/<yt:channelId>([^<]+)<\/yt:channelId>/)?.[1]
+    const videoId = entry[0].match(/<yt:videoId>([^<]+)<\/yt:videoId>/)?.[1]
+    if (entryChannelId === channelId && ID_REGEX.test(videoId)) {
+      videoIds.add(videoId)
+    }
+  }
+
+  automaticDiscoveryCache.set(channelId, {
+    expiresAt: Date.now() + AUTOMATIC_DISCOVERY_CACHE_TTL_MS,
+    videoIds
+  })
+  return videoIds
+}
+
 async function getAutomaticTemplateOptions(template) {
   const builtInOptions = BUILT_IN_AUTOMATIC_TEMPLATE_OPTIONS.get(template)
   if (builtInOptions) {
@@ -1309,10 +1369,12 @@ async function getAutomaticTemplateOptions(template) {
  * A renderer-provided `automatic` flag alone must never waive the activation
  * boundary or select arbitrary yt-dlp arguments.
  * @param {YtDlpDownloadPayload} payload
+ * @param {boolean} [discoveryPreviouslyAuthorized]
  * @returns {Promise<YtDlpDownloadPayload | null>}
  */
-async function authorizeAutomaticDownload(payload) {
-  if (typeof payload.channelId !== 'string' || !CHANNEL_ID_REGEX.test(payload.channelId)) {
+async function authorizeAutomaticDownload(payload, discoveryPreviouslyAuthorized = false) {
+  if (typeof payload.channelId !== 'string' || !CHANNEL_ID_REGEX.test(payload.channelId) ||
+    typeof payload.videoId !== 'string' || !ID_REGEX.test(payload.videoId)) {
     return null
   }
 
@@ -1350,6 +1412,13 @@ async function authorizeAutomaticDownload(payload) {
     return null
   }
 
+  if (!discoveryPreviouslyAuthorized) {
+    const discoveredVideoIds = await getAutomaticDiscoveryVideoIds(payload.channelId)
+    if (!discoveredVideoIds?.has(payload.videoId)) {
+      return null
+    }
+  }
+
   const sanitizedPayload = Object.fromEntries(Object.entries(payload).filter(([key]) => (
     !AUTOMATIC_TEMPLATE_OPTION_KEYS.has(key) && !Object.hasOwn(AUTOMATIC_NUMBER_LIMITS, key)
   )))
@@ -1369,15 +1438,21 @@ async function authorizeAutomaticDownload(payload) {
  * @param {import('electron').IpcMainInvokeEvent} event
  * @param {YtDlpDownloadPayload} incomingPayload
  * @param {boolean} automaticDownloadAuthorized
+ * @param {boolean} [automaticDiscoveryPreviouslyAuthorized]
  * @returns {Promise<{ id: number } | { error: string } | { skipped: string } | null>}
  */
-async function startYtDlpDownload(event, incomingPayload, automaticDownloadAuthorized) {
+async function startYtDlpDownload(
+  event,
+  incomingPayload,
+  automaticDownloadAuthorized,
+  automaticDiscoveryPreviouslyAuthorized = false
+) {
   if (!isOpenTubeXUrl(event.senderFrame.url) || typeof incomingPayload !== 'object' || incomingPayload === null) {
     return null
   }
 
   const payload = incomingPayload.automatic === true && automaticDownloadAuthorized
-    ? await authorizeAutomaticDownload(incomingPayload)
+    ? await authorizeAutomaticDownload(incomingPayload, automaticDiscoveryPreviouslyAuthorized)
     : incomingPayload.automatic === true ? null : incomingPayload
   if (payload === null || (payload.automatic !== true && !event.sender.isFocused())) {
     return null
@@ -1852,7 +1927,7 @@ export async function handleYtDlpDownload(event, payload, retryDownloadId, autom
     }
 
     const retryPayload = retryRecord.automatic === true ? retryRecord.retryPayload : payload
-    const result = await startYtDlpDownload(event, retryPayload, true)
+    const result = await startYtDlpDownload(event, retryPayload, true, retryRecord.automatic === true)
     if (result && 'id' in result) {
       downloadRecords.delete(retryDownloadId)
       broadcastToRenderers(IpcChannels.YT_DLP_DOWNLOADS_REMOVED, [retryDownloadId])

--- a/src/main/ytDlp.js
+++ b/src/main/ytDlp.js
@@ -58,6 +58,8 @@ function takeGetInfoAbortSignal(key) {
  * @property {string} [customArgs] additional yt-dlp command line arguments
  * @property {string} [template] the template the options came from, only used for display purposes
  * @property {boolean} [automatic] whether a subscription refresh started the download
+ * @property {string} [channelId] channel whose persisted rule authorized the automatic download
+ * @property {'video' | 'short' | 'livestream'} [automaticMediaType]
  * @property {number} [minDurationSeconds]
  * @property {number} [maxDurationSeconds]
  * @property {number} [minFileSizeMb]
@@ -93,6 +95,48 @@ function takeGetInfoAbortSignal(key) {
  */
 
 const ID_REGEX = /^[\w-]{11}$/
+const CHANNEL_ID_REGEX = /^UC[\w-]{22}$/
+const AUTOMATIC_NUMBER_LIMITS = Object.freeze({
+  minDurationSeconds: 31_536_000,
+  maxDurationSeconds: 31_536_000,
+  minFileSizeMb: 1_000_000,
+  maxFileSizeMb: 1_000_000,
+  maxAgeDays: 36_500
+})
+const AUTOMATIC_TEMPLATE_OPTION_KEYS = new Set([
+  'mode',
+  'quality',
+  'videoFormat',
+  'videoCodec',
+  'audioFormat',
+  'filenameTemplate',
+  'startTime',
+  'endTime',
+  'splitChapters',
+  'removeSponsorblock',
+  'sponsorBlockCategories',
+  'includeSubtitles',
+  'embedSubtitles',
+  'subtitleLanguages',
+  'subtitleFormat',
+  'embedThumbnail',
+  'embedMetadata',
+  'customArgs'
+])
+const BUILT_IN_AUTOMATIC_TEMPLATE_OPTIONS = new Map([
+  ['video:best', { mode: 'video' }],
+  ['video:best:mp4', { mode: 'video', videoFormat: 'mp4' }],
+  ['video:1080', { mode: 'video', quality: '1080' }],
+  ['video:1080:mp4', { mode: 'video', quality: '1080', videoFormat: 'mp4' }],
+  ['video:720', { mode: 'video', quality: '720' }],
+  ['video:720:mp4', { mode: 'video', quality: '720', videoFormat: 'mp4' }],
+  ['video:480', { mode: 'video', quality: '480' }],
+  ['video:480:mp4', { mode: 'video', quality: '480', videoFormat: 'mp4' }],
+  ['audio:best', { mode: 'audio', embedThumbnail: true, embedMetadata: true }],
+  ['audio:mp3', { mode: 'audio', audioFormat: 'mp3', embedThumbnail: true, embedMetadata: true }],
+  ['subtitles:srt', { mode: 'subtitles', subtitleFormat: 'srt' }],
+  ['subtitles:vtt', { mode: 'subtitles', subtitleFormat: 'vtt' }]
+])
 const PLAYLIST_ID_REGEX = /^[\w-]{10,128}$/
 const QUALITY_REGEX = /^\d{3,4}$/
 const VIDEO_FORMATS = ['mp4', 'mkv', 'webm']
@@ -1222,23 +1266,124 @@ function splitArguments(argsString) {
   return args
 }
 
+function automaticNumber(value, maximum) {
+  return Number.isFinite(Number(value)) && Number(value) > 0 && Number(value) <= maximum
+    ? Number(value)
+    : null
+}
+
+async function getAutomaticTemplateOptions(template) {
+  const builtInOptions = BUILT_IN_AUTOMATIC_TEMPLATE_OPTIONS.get(template)
+  if (builtInOptions) {
+    return builtInOptions
+  }
+  if (!template.startsWith('template:')) {
+    return null
+  }
+
+  let templates
+  try {
+    templates = JSON.parse((await settings._findOne('ytDlpDownloadTemplates'))?.value || '[]')
+  } catch {
+    return null
+  }
+  if (!Array.isArray(templates)) {
+    return null
+  }
+
+  const customTemplate = templates.find(candidate => (
+    candidate?.name === template.slice('template:'.length)
+  ))
+  if (customTemplate?.options !== null && typeof customTemplate?.options === 'object' &&
+    !Array.isArray(customTemplate.options)) {
+    return { mode: 'video', ...customTemplate.options }
+  }
+  if (typeof customTemplate?.args === 'string') {
+    return { mode: 'video', customArgs: customTemplate.args }
+  }
+  return null
+}
+
+/**
+ * Rebuilds automatic-only options from settings owned by the main process.
+ * A renderer-provided `automatic` flag alone must never waive the activation
+ * boundary or select arbitrary yt-dlp arguments.
+ * @param {YtDlpDownloadPayload} payload
+ * @returns {Promise<YtDlpDownloadPayload | null>}
+ */
+async function authorizeAutomaticDownload(payload) {
+  if (typeof payload.channelId !== 'string' || !CHANNEL_ID_REGEX.test(payload.channelId)) {
+    return null
+  }
+
+  let rules
+  try {
+    rules = JSON.parse((await settings._findOne('ytDlpAutomaticDownloadRules'))?.value || '{}')
+  } catch {
+    return null
+  }
+  if (rules === null || typeof rules !== 'object' || Array.isArray(rules) ||
+    !Object.hasOwn(rules, payload.channelId)) {
+    return null
+  }
+
+  const rule = rules[payload.channelId]
+  if (rule === null || typeof rule !== 'object' || Array.isArray(rule)) {
+    return null
+  }
+  const template = typeof rule.template === 'string' && rule.template !== '' ? rule.template : 'video:best'
+  if (payload.template !== template) {
+    return null
+  }
+
+  const mediaTypeAllowed = payload.automaticMediaType === 'short'
+    ? rule.includeShorts === true
+    : payload.automaticMediaType === 'livestream'
+      ? rule.includeLivestreams === true
+      : payload.automaticMediaType === 'video' && rule.includeVideos !== false
+  if (!mediaTypeAllowed) {
+    return null
+  }
+
+  const templateOptions = await getAutomaticTemplateOptions(template)
+  if (templateOptions === null) {
+    return null
+  }
+
+  const sanitizedPayload = Object.fromEntries(Object.entries(payload).filter(([key]) => (
+    !AUTOMATIC_TEMPLATE_OPTION_KEYS.has(key) && !Object.hasOwn(AUTOMATIC_NUMBER_LIMITS, key)
+  )))
+  for (const [key, maximum] of Object.entries(AUTOMATIC_NUMBER_LIMITS)) {
+    sanitizedPayload[key] = automaticNumber(rule[key], maximum)
+  }
+
+  return {
+    ...sanitizedPayload,
+    ...structuredClone(templateOptions),
+    template,
+    automatic: true
+  }
+}
+
 /**
  * @param {import('electron').IpcMainInvokeEvent} event
- * @param {YtDlpDownloadPayload} payload
+ * @param {YtDlpDownloadPayload} incomingPayload
  * @returns {Promise<{ id: number } | { error: string } | { skipped: string } | null>}
  */
-async function startYtDlpDownload(event, payload) {
-  if (!isOpenTubeXUrl(event.senderFrame.url) ||
-    (payload?.automatic !== true && !event.sender.isFocused())) {
+async function startYtDlpDownload(event, incomingPayload) {
+  if (!isOpenTubeXUrl(event.senderFrame.url) || typeof incomingPayload !== 'object' || incomingPayload === null) {
+    return null
+  }
+
+  const payload = incomingPayload.automatic === true
+    ? await authorizeAutomaticDownload(incomingPayload)
+    : incomingPayload
+  if (payload === null || (payload.automatic !== true && !event.sender.isFocused())) {
     return null
   }
 
   if ((await settings._findOne('enableDownloads'))?.value === false) {
     return { error: 'downloads-disabled' }
-  }
-
-  if (typeof payload !== 'object' || payload === null) {
-    return null
   }
 
   if (!['video', 'audio', 'subtitles', 'custom'].includes(payload.mode)) {
@@ -1419,16 +1564,14 @@ async function startYtDlpDownload(event, payload) {
   if (!subtitlesOnly && payload.embedMetadata === true) {
     args.push('--embed-metadata', '--embed-chapters')
   }
-  const automaticNumber = (value, maximum) => Number.isFinite(Number(value)) && Number(value) > 0 && Number(value) <= maximum
-    ? Number(value)
-    : null
   if (payload.automatic === true) {
-    const minDurationSeconds = automaticNumber(payload.minDurationSeconds, 31_536_000)
-    const maxDurationSeconds = automaticNumber(payload.maxDurationSeconds, 31_536_000)
-    const minFileSizeMb = automaticNumber(payload.minFileSizeMb, 1_000_000)
-    const maxFileSizeMb = automaticNumber(payload.maxFileSizeMb, 1_000_000)
-    const maxAgeDays = automaticNumber(payload.maxAgeDays, 36_500)
+    const minDurationSeconds = automaticNumber(payload.minDurationSeconds, AUTOMATIC_NUMBER_LIMITS.minDurationSeconds)
+    const maxDurationSeconds = automaticNumber(payload.maxDurationSeconds, AUTOMATIC_NUMBER_LIMITS.maxDurationSeconds)
+    const minFileSizeMb = automaticNumber(payload.minFileSizeMb, AUTOMATIC_NUMBER_LIMITS.minFileSizeMb)
+    const maxFileSizeMb = automaticNumber(payload.maxFileSizeMb, AUTOMATIC_NUMBER_LIMITS.maxFileSizeMb)
+    const maxAgeDays = automaticNumber(payload.maxAgeDays, AUTOMATIC_NUMBER_LIMITS.maxAgeDays)
     const durationFilters = [
+      `channel_id = ${payload.channelId}`,
       minDurationSeconds === null ? null : `duration >= ${minDurationSeconds}`,
       maxDurationSeconds === null ? null : `duration <= ${maxDurationSeconds}`
     ].filter(Boolean)

--- a/src/main/ytDlp.js
+++ b/src/main/ytDlp.js
@@ -100,6 +100,8 @@ const CHANNEL_ID_REGEX = /^UC[\w-]{22}$/
 const AUTOMATIC_DISCOVERY_CACHE_TTL_MS = 60_000
 const AUTOMATIC_DISCOVERY_TIMEOUT_MS = 15_000
 const AUTOMATIC_DISCOVERY_E2E_FIXTURE = 'automatic-download-discovery.xml'
+const AUTOMATIC_TITLE_TERM_LIMIT = 20
+const AUTOMATIC_TITLE_TERM_LENGTH_LIMIT = 100
 const AUTOMATIC_NUMBER_LIMITS = Object.freeze({
   minDurationSeconds: 31_536_000,
   maxDurationSeconds: 31_536_000,
@@ -126,6 +128,12 @@ const AUTOMATIC_TEMPLATE_OPTION_KEYS = new Set([
   'embedThumbnail',
   'embedMetadata',
   'customArgs'
+])
+const AUTOMATIC_RULE_OPTION_KEYS = new Set([
+  ...Object.keys(AUTOMATIC_NUMBER_LIMITS),
+  'enabledAt',
+  'titleIncludes',
+  'titleExcludes'
 ])
 const BUILT_IN_AUTOMATIC_TEMPLATE_OPTIONS = new Map([
   ['video:best', { mode: 'video' }],
@@ -1282,12 +1290,12 @@ function automaticNumber(value, maximum) {
  * prevents a renderer from turning a persisted channel rule into permission to
  * download an arbitrary video that was not present in the subscription feed.
  * @param {string} channelId
- * @returns {Promise<Set<string> | null>}
+ * @returns {Promise<Map<string, number> | null>}
  */
 async function getAutomaticDiscoveryVideoIds(channelId) {
   const cached = automaticDiscoveryCache.get(channelId)
   if (cached?.expiresAt > Date.now()) {
-    return cached.videoIds
+    return cached.videos
   }
 
   let feed
@@ -1316,20 +1324,48 @@ async function getAutomaticDiscoveryVideoIds(channelId) {
     }
   }
 
-  const videoIds = new Set()
+  const videos = new Map()
   for (const entry of feed.matchAll(/<entry\b[\s\S]*?<\/entry>/g)) {
     const entryChannelId = entry[0].match(/<yt:channelId>([^<]+)<\/yt:channelId>/)?.[1]
     const videoId = entry[0].match(/<yt:videoId>([^<]+)<\/yt:videoId>/)?.[1]
-    if (entryChannelId === channelId && ID_REGEX.test(videoId)) {
-      videoIds.add(videoId)
+    const published = Date.parse(entry[0].match(/<published>([^<]+)<\/published>/)?.[1])
+    if (entryChannelId === channelId && ID_REGEX.test(videoId) && Number.isFinite(published)) {
+      videos.set(videoId, published)
     }
   }
 
   automaticDiscoveryCache.set(channelId, {
     expiresAt: Date.now() + AUTOMATIC_DISCOVERY_CACHE_TTL_MS,
-    videoIds
+    videos
   })
-  return videoIds
+  return videos
+}
+
+function automaticTitleTerms(value) {
+  return typeof value === 'string'
+    ? value.split(',')
+        .map(term => term.trim().slice(0, AUTOMATIC_TITLE_TERM_LENGTH_LIMIT))
+        .filter(Boolean)
+        .slice(0, AUTOMATIC_TITLE_TERM_LIMIT)
+    : []
+}
+
+function escapeRegularExpression(value) {
+  return value.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')
+}
+
+function automaticTitleRegex(includedTerms, excludedTerms) {
+  if (includedTerms.length === 0 && excludedTerms.length === 0) {
+    return null
+  }
+
+  const include = includedTerms.length === 0
+    ? ''
+    : `(?=.*(?:${includedTerms.map(escapeRegularExpression).join('|')}))`
+  const exclude = excludedTerms.length === 0
+    ? ''
+    : `(?!.*(?:${excludedTerms.map(escapeRegularExpression).join('|')}))`
+  return `(?i)^${include}${exclude}.*$`
 }
 
 async function getAutomaticTemplateOptions(template) {
@@ -1413,18 +1449,21 @@ async function authorizeAutomaticDownload(payload, discoveryPreviouslyAuthorized
   }
 
   if (!discoveryPreviouslyAuthorized) {
-    const discoveredVideoIds = await getAutomaticDiscoveryVideoIds(payload.channelId)
-    if (!discoveredVideoIds?.has(payload.videoId)) {
+    const discoveredVideos = await getAutomaticDiscoveryVideoIds(payload.channelId)
+    const enabledAt = automaticNumber(rule.enabledAt, Number.MAX_SAFE_INTEGER)
+    if (enabledAt === null || (discoveredVideos?.get(payload.videoId) ?? -Infinity) < enabledAt) {
       return null
     }
   }
 
   const sanitizedPayload = Object.fromEntries(Object.entries(payload).filter(([key]) => (
-    !AUTOMATIC_TEMPLATE_OPTION_KEYS.has(key) && !Object.hasOwn(AUTOMATIC_NUMBER_LIMITS, key)
+    !AUTOMATIC_TEMPLATE_OPTION_KEYS.has(key) && !AUTOMATIC_RULE_OPTION_KEYS.has(key)
   )))
   for (const [key, maximum] of Object.entries(AUTOMATIC_NUMBER_LIMITS)) {
     sanitizedPayload[key] = automaticNumber(rule[key], maximum)
   }
+  sanitizedPayload.titleIncludes = automaticTitleTerms(rule.titleIncludes)
+  sanitizedPayload.titleExcludes = automaticTitleTerms(rule.titleExcludes)
 
   return {
     ...sanitizedPayload,
@@ -1646,6 +1685,10 @@ async function startYtDlpDownload(
     const minFileSizeMb = automaticNumber(payload.minFileSizeMb, AUTOMATIC_NUMBER_LIMITS.minFileSizeMb)
     const maxFileSizeMb = automaticNumber(payload.maxFileSizeMb, AUTOMATIC_NUMBER_LIMITS.maxFileSizeMb)
     const maxAgeDays = automaticNumber(payload.maxAgeDays, AUTOMATIC_NUMBER_LIMITS.maxAgeDays)
+    const titleRegex = automaticTitleRegex(
+      Array.isArray(payload.titleIncludes) ? payload.titleIncludes : [],
+      Array.isArray(payload.titleExcludes) ? payload.titleExcludes : []
+    )
     const durationFilters = [
       `channel_id = ${payload.channelId}`,
       minDurationSeconds === null ? null : `duration >= ${minDurationSeconds}`,
@@ -1656,6 +1699,7 @@ async function startYtDlpDownload(
     if (minFileSizeMb !== null) args.push('--min-filesize', `${minFileSizeMb}M`)
     if (maxFileSizeMb !== null) args.push('--max-filesize', `${maxFileSizeMb}M`)
     if (maxAgeDays !== null) args.push('--dateafter', `now-${Math.ceil(maxAgeDays)}days`)
+    if (titleRegex !== null) args.push('--match-title', titleRegex)
     args.push('--no-overwrites')
   }
   const startTime = !subtitlesOnly && typeof payload.startTime === 'string' && TIME_REGEX.test(payload.startTime) ? payload.startTime : ''

--- a/src/main/ytDlp.js
+++ b/src/main/ytDlp.js
@@ -1368,16 +1368,17 @@ async function authorizeAutomaticDownload(payload) {
 /**
  * @param {import('electron').IpcMainInvokeEvent} event
  * @param {YtDlpDownloadPayload} incomingPayload
+ * @param {boolean} automaticDownloadAuthorized
  * @returns {Promise<{ id: number } | { error: string } | { skipped: string } | null>}
  */
-async function startYtDlpDownload(event, incomingPayload) {
+async function startYtDlpDownload(event, incomingPayload, automaticDownloadAuthorized) {
   if (!isOpenTubeXUrl(event.senderFrame.url) || typeof incomingPayload !== 'object' || incomingPayload === null) {
     return null
   }
 
-  const payload = incomingPayload.automatic === true
+  const payload = incomingPayload.automatic === true && automaticDownloadAuthorized
     ? await authorizeAutomaticDownload(incomingPayload)
-    : incomingPayload
+    : incomingPayload.automatic === true ? null : incomingPayload
   if (payload === null || (payload.automatic !== true && !event.sender.isFocused())) {
     return null
   }
@@ -1826,11 +1827,12 @@ async function startYtDlpDownload(event, incomingPayload) {
  * @param {import('electron').IpcMainInvokeEvent} event
  * @param {YtDlpDownloadPayload} payload
  * @param {number} [retryDownloadId]
+ * @param {boolean} [automaticDownloadAuthorized]
  * @returns {Promise<{ id: number } | { error: string } | { skipped: string } | null>}
  */
-export async function handleYtDlpDownload(event, payload, retryDownloadId) {
+export async function handleYtDlpDownload(event, payload, retryDownloadId, automaticDownloadAuthorized = false) {
   if (retryDownloadId === undefined) {
-    return startYtDlpDownload(event, payload)
+    return startYtDlpDownload(event, payload, automaticDownloadAuthorized)
   }
 
   if (!isOpenTubeXUrl(event.senderFrame.url) || !event.sender.isFocused() ||
@@ -1849,7 +1851,8 @@ export async function handleYtDlpDownload(event, payload, retryDownloadId) {
       return { error: 'download-not-retryable' }
     }
 
-    const result = await startYtDlpDownload(event, payload)
+    const retryPayload = retryRecord.automatic === true ? retryRecord.retryPayload : payload
+    const result = await startYtDlpDownload(event, retryPayload, true)
     if (result && 'id' in result) {
       downloadRecords.delete(retryDownloadId)
       broadcastToRenderers(IpcChannels.YT_DLP_DOWNLOADS_REMOVED, [retryDownloadId])

--- a/src/main/ytDlp.js
+++ b/src/main/ytDlp.js
@@ -4,7 +4,7 @@ import { chmod, mkdir, mkdtemp, readFile, rename, rm, stat, writeFile } from 'no
 import { dirname, join } from 'node:path'
 import { promisify } from 'node:util'
 import { inflateRawSync } from 'node:zlib'
-import { app, BrowserWindow, net, shell } from 'electron'
+import { app, BrowserWindow, net, Notification, shell } from 'electron'
 import { settings } from '../datastores/handlers/base'
 import { buildProxyUrl, isOpenTubeXUrl } from './utils'
 import { IpcChannels } from '../constants'
@@ -57,6 +57,13 @@ function takeGetInfoAbortSignal(key) {
  * @property {boolean} [embedMetadata]
  * @property {string} [customArgs] additional yt-dlp command line arguments
  * @property {string} [template] the template the options came from, only used for display purposes
+ * @property {boolean} [automatic] whether a subscription refresh started the download
+ * @property {number} [minDurationSeconds]
+ * @property {number} [maxDurationSeconds]
+ * @property {number} [minFileSizeMb]
+ * @property {number} [maxFileSizeMb]
+ * @property {number} [maxAgeDays]
+ * @property {{ startedTitle?: string, startedBody?: string, completedTitle?: string, completedBody?: string, failedTitle?: string, failedBody?: string }} [notification]
  */
 
 /**
@@ -69,8 +76,9 @@ function takeGetInfoAbortSignal(key) {
  * @property {string} thumbnail
  * @property {'video' | 'audio' | 'subtitles' | 'custom'} mode
  * @property {string} template
+ * @property {boolean} [automatic]
  * @property {YtDlpDownloadPayload} [retryPayload]
- * @property {'downloading' | 'processing' | 'completed' | 'failed' | 'cancelled'} status
+ * @property {'downloading' | 'processing' | 'completed' | 'failed' | 'cancelled' | 'skipped'} status
  * @property {number} percent
  * @property {string | null} speed
  * @property {string | null} eta
@@ -126,6 +134,7 @@ let downloadRecordsSaveQueue = Promise.resolve()
 let binaryInstallCounter = 0
 let managedBinaryInstallQueue = Promise.resolve()
 const retryingDownloadIds = new Set()
+const activeAutomaticDownloadNotifications = new Set()
 
 /** @type {Map<number, { child: import('node:child_process').ChildProcess, cancelled: boolean }>} */
 const activeDownloads = new Map()
@@ -142,6 +151,33 @@ function broadcastToRenderers(channel, payload) {
   }
 }
 
+function showAutomaticDownloadNotification(payload, phase) {
+  if (payload.automatic !== true || !Notification.isSupported()) {
+    return
+  }
+
+  const title = payload.notification?.[`${phase}Title`]
+  const body = payload.notification?.[`${phase}Body`]
+  if (typeof title !== 'string' || title.length === 0 || title.length > 200 ||
+    typeof body !== 'string' || body.length === 0 || body.length > 500) {
+    return
+  }
+
+  const notification = new Notification({ title, body })
+  activeAutomaticDownloadNotifications.add(notification)
+  notification.once('close', () => activeAutomaticDownloadNotifications.delete(notification))
+  notification.once('click', () => {
+    activeAutomaticDownloadNotifications.delete(notification)
+    const browserWindow = BrowserWindow.getAllWindows().find(window => !window.isDestroyed())
+    if (browserWindow) {
+      if (browserWindow.isMinimized()) browserWindow.restore()
+      browserWindow.show()
+      browserWindow.focus()
+    }
+  })
+  notification.show()
+}
+
 function getDownloadRecordsPath() {
   return join(app.getPath('userData'), 'downloads.json')
 }
@@ -153,7 +189,7 @@ function loadDownloadRecords() {
       if (!Array.isArray(records)) return
       for (const record of records) {
         if (Number.isInteger(record?.id) && typeof record.title === 'string' &&
-          ['completed', 'failed', 'cancelled'].includes(record.status)) {
+          ['completed', 'failed', 'cancelled', 'skipped'].includes(record.status)) {
           if (!downloadRecords.has(record.id)) downloadRecords.set(record.id, record)
           downloadCounter = Math.max(downloadCounter, record.id)
         }
@@ -1189,10 +1225,11 @@ function splitArguments(argsString) {
 /**
  * @param {import('electron').IpcMainInvokeEvent} event
  * @param {YtDlpDownloadPayload} payload
- * @returns {Promise<{ id: number } | { error: string } | null>}
+ * @returns {Promise<{ id: number } | { error: string } | { skipped: string } | null>}
  */
 async function startYtDlpDownload(event, payload) {
-  if (!isOpenTubeXUrl(event.senderFrame.url) || !event.sender.isFocused()) {
+  if (!isOpenTubeXUrl(event.senderFrame.url) ||
+    (payload?.automatic !== true && !event.sender.isFocused())) {
     return null
   }
 
@@ -1240,6 +1277,12 @@ async function startYtDlpDownload(event, payload) {
   }
 
   await loadDownloadRecords()
+
+  if (payload.automatic === true && isSingleVideo && [...downloadRecords.values()].some(record => (
+    record.videoId === payload.videoId && ['downloading', 'processing', 'completed', 'skipped'].includes(record.status)
+  ))) {
+    return { skipped: 'already-downloaded' }
+  }
 
   const args = [
     '--newline',
@@ -1376,6 +1419,26 @@ async function startYtDlpDownload(event, payload) {
   if (!subtitlesOnly && payload.embedMetadata === true) {
     args.push('--embed-metadata', '--embed-chapters')
   }
+  const automaticNumber = (value, maximum) => Number.isFinite(Number(value)) && Number(value) > 0 && Number(value) <= maximum
+    ? Number(value)
+    : null
+  if (payload.automatic === true) {
+    const minDurationSeconds = automaticNumber(payload.minDurationSeconds, 31_536_000)
+    const maxDurationSeconds = automaticNumber(payload.maxDurationSeconds, 31_536_000)
+    const minFileSizeMb = automaticNumber(payload.minFileSizeMb, 1_000_000)
+    const maxFileSizeMb = automaticNumber(payload.maxFileSizeMb, 1_000_000)
+    const maxAgeDays = automaticNumber(payload.maxAgeDays, 36_500)
+    const durationFilters = [
+      minDurationSeconds === null ? null : `duration >= ${minDurationSeconds}`,
+      maxDurationSeconds === null ? null : `duration <= ${maxDurationSeconds}`
+    ].filter(Boolean)
+
+    if (durationFilters.length > 0) args.push('--match-filter', durationFilters.join(' & '))
+    if (minFileSizeMb !== null) args.push('--min-filesize', `${minFileSizeMb}M`)
+    if (maxFileSizeMb !== null) args.push('--max-filesize', `${maxFileSizeMb}M`)
+    if (maxAgeDays !== null) args.push('--dateafter', `now-${Math.ceil(maxAgeDays)}days`)
+    args.push('--no-overwrites')
+  }
   const startTime = !subtitlesOnly && typeof payload.startTime === 'string' && TIME_REGEX.test(payload.startTime) ? payload.startTime : ''
   const endTime = !subtitlesOnly && typeof payload.endTime === 'string' && TIME_REGEX.test(payload.endTime) ? payload.endTime : ''
   if (startTime !== '' || endTime !== '') {
@@ -1426,6 +1489,7 @@ async function startYtDlpDownload(event, payload) {
     thumbnail: typeof payload.thumbnail === 'string' ? payload.thumbnail.slice(0, 2048) : '',
     mode: payload.mode,
     template: typeof payload.template === 'string' ? payload.template.slice(0, 255) : '',
+    automatic: payload.automatic === true,
     retryPayload: structuredClone(payload),
     status: 'downloading',
     percent: 0,
@@ -1437,6 +1501,7 @@ async function startYtDlpDownload(event, payload) {
     errorMessage: null
   }
   downloadRecords.set(id, status)
+  showAutomaticDownloadNotification(payload, 'started')
 
   let lastSent = 0
   let finished = false
@@ -1565,6 +1630,7 @@ async function startYtDlpDownload(event, payload) {
     removeTemporaryDownloadFolder()
     status.status = 'failed'
     status.errorMessage = error.code === 'ENOENT' ? 'ENOENT' : error.message
+    showAutomaticDownloadNotification(payload, 'failed')
     sendStatus(true)
     saveDownloadRecords().catch(error => console.warn('Could not save download history', error))
   })
@@ -1591,11 +1657,19 @@ async function startYtDlpDownload(event, payload) {
         ))
         status.destination = convertedSubtitleDestinations.get(status.destination) ?? status.destination
       }
-      status.status = 'completed'
-      status.percent = 100
+      status.status = payload.automatic === true && status.destinations.length === 0
+        ? 'skipped'
+        : 'completed'
+      if (status.status === 'completed') status.percent = 100
     } else {
       status.status = 'failed'
       status.errorMessage = stderrLines.join('\n')
+    }
+
+    if (status.status === 'completed') {
+      showAutomaticDownloadNotification(payload, 'completed')
+    } else if (status.status === 'failed') {
+      showAutomaticDownloadNotification(payload, 'failed')
     }
 
     sendStatus(true)
@@ -1609,7 +1683,7 @@ async function startYtDlpDownload(event, payload) {
  * @param {import('electron').IpcMainInvokeEvent} event
  * @param {YtDlpDownloadPayload} payload
  * @param {number} [retryDownloadId]
- * @returns {Promise<{ id: number } | { error: string } | null>}
+ * @returns {Promise<{ id: number } | { error: string } | { skipped: string } | null>}
  */
 export async function handleYtDlpDownload(event, payload, retryDownloadId) {
   if (retryDownloadId === undefined) {

--- a/src/preload/interface.js
+++ b/src/preload/interface.js
@@ -1,5 +1,5 @@
 import { ipcRenderer, webFrame } from 'electron/renderer'
-import { IpcChannels } from '../constants.js'
+import { DBActions, IpcChannels } from '../constants.js'
 
 /**
  * Linux fix for dynamically updating theme preference, this works on
@@ -470,6 +470,10 @@ export default {
    * @param {any} [data]
    */
   dbSettings: (action, data) => {
+    if (action === DBActions.GENERAL.UPSERT && data?._id === 'ytDlpAutomaticDownloadRules' &&
+      !navigator.userActivation.isActive) {
+      return Promise.resolve(null)
+    }
     return ipcRenderer.invoke(IpcChannels.DB_SETTINGS, data ? { action, data } : { action })
   },
 

--- a/src/preload/interface.js
+++ b/src/preload/interface.js
@@ -279,11 +279,11 @@ export default {
   /**
    * @param {import('../main/ytDlp').YtDlpDownloadPayload} payload
    * @param {number} [retryDownloadId]
-   * @returns {Promise<{ id: number } | { error: string } | null>}
+   * @returns {Promise<{ id: number } | { error: string } | { skipped: string } | null>}
    */
   ytDlpDownload: (payload, retryDownloadId) => {
     // require the user to have interacted with the page recently
-    if (navigator.userActivation.isActive) {
+    if (payload?.automatic === true || navigator.userActivation.isActive) {
       return ipcRenderer.invoke(IpcChannels.YT_DLP_DOWNLOAD, payload, retryDownloadId)
     }
 

--- a/src/renderer/components/AutomaticDownloadSettings/AutomaticDownloadSettings.vue
+++ b/src/renderer/components/AutomaticDownloadSettings/AutomaticDownloadSettings.vue
@@ -1,0 +1,394 @@
+<template>
+  <FtFlexBox>
+    <FtButton
+      :label="t('Settings.Download Settings.Manage Automatic Downloads', { channelCount: enabledRuleCount })"
+      :icon="['fas', 'download']"
+      @click="showManager = true"
+    />
+  </FtFlexBox>
+  <FtSettingsSubpage
+    :open="showManager"
+    :title="t('Settings.Download Settings.Automatic Downloads')"
+    :icon="['fas', 'download']"
+    @close="showManager = false"
+  >
+    <div class="automaticDownloadsHeader">
+      <p>{{ t('Settings.Download Settings.Automatic Downloads Description') }}</p>
+      <p class="automaticDownloadsHint">
+        {{ t('Settings.Download Settings.Automatic Downloads New Only') }}
+      </p>
+      <FtInput
+        :placeholder="t('Settings.Download Settings.Search Automatic Download Channels')"
+        :show-action-button="false"
+        :show-clear-text-button="true"
+        :value="searchQuery"
+        @input="searchQuery = $event"
+        @clear="searchQuery = ''"
+      />
+    </div>
+    <div
+      v-overlay-scrollbars
+      class="automaticDownloadsScroller"
+    >
+      <p
+        v-if="channels.length === 0"
+        class="emptyState"
+      >
+        {{ t('Settings.Download Settings.Automatic Downloads No Channels') }}
+      </p>
+      <p
+        v-else-if="visibleChannels.length === 0"
+        class="emptyState"
+      >
+        {{ t('Settings.Download Settings.No Matching Automatic Download Channels') }}
+      </p>
+      <ul
+        v-else
+        class="channelRules"
+      >
+        <li
+          v-for="channel in visibleChannels"
+          :key="channel.id"
+          class="channelRule"
+        >
+          <div class="channelRuleHeader">
+            <img
+              v-if="channel.thumbnail"
+              class="channelThumbnail"
+              :src="channel.thumbnail"
+              alt=""
+            >
+            <span
+              v-else
+              class="channelThumbnail channelThumbnailPlaceholder"
+            >
+              <FtIcon :icon="['fas', 'circle-user']" />
+            </span>
+            <FtToggleSwitch
+              class="channelToggle"
+              :label="channel.name || channel.id"
+              :compact="true"
+              :default-value="rules[channel.id] !== undefined"
+              @change="enabled => setChannelEnabled(channel.id, enabled)"
+            />
+          </div>
+          <div
+            v-if="rules[channel.id] !== undefined"
+            class="channelRuleOptions"
+          >
+            <div class="templateAndTypes">
+              <FtSelect
+                class="templateSelect"
+                :placeholder="t('Downloads.Template')"
+                :value="ruleFor(channel.id).template"
+                :select-names="templateNames"
+                :select-values="templateValues"
+                :show-icon="false"
+                @change="value => updateRule(channel.id, 'template', value)"
+              />
+              <FtToggleSwitch
+                :label="t('Settings.Download Settings.Automatic Downloads Videos')"
+                :compact="true"
+                :default-value="ruleFor(channel.id).includeVideos"
+                @change="value => updateRule(channel.id, 'includeVideos', value)"
+              />
+              <FtToggleSwitch
+                :label="t('Global.Shorts')"
+                :compact="true"
+                :default-value="ruleFor(channel.id).includeShorts"
+                @change="value => updateRule(channel.id, 'includeShorts', value)"
+              />
+              <FtToggleSwitch
+                :label="t('Settings.Download Settings.Automatic Downloads Livestreams')"
+                :compact="true"
+                :default-value="ruleFor(channel.id).includeLivestreams"
+                @change="value => updateRule(channel.id, 'includeLivestreams', value)"
+              />
+            </div>
+            <div class="filterGrid">
+              <FtInput
+                input-type="number"
+                :placeholder="t('Settings.Download Settings.Minimum Duration Seconds')"
+                :show-label="true"
+                :show-action-button="false"
+                :maxlength="9"
+                :value="displayNumber(ruleFor(channel.id).minDurationSeconds)"
+                @input="value => updateNumber(channel.id, 'minDurationSeconds', value)"
+              />
+              <FtInput
+                input-type="number"
+                :placeholder="t('Settings.Download Settings.Maximum Duration Seconds')"
+                :show-label="true"
+                :show-action-button="false"
+                :maxlength="9"
+                :value="displayNumber(ruleFor(channel.id).maxDurationSeconds)"
+                @input="value => updateNumber(channel.id, 'maxDurationSeconds', value)"
+              />
+              <FtInput
+                input-type="number"
+                :placeholder="t('Settings.Download Settings.Minimum File Size MB')"
+                :show-label="true"
+                :show-action-button="false"
+                :maxlength="9"
+                :value="displayNumber(ruleFor(channel.id).minFileSizeMb)"
+                @input="value => updateNumber(channel.id, 'minFileSizeMb', value)"
+              />
+              <FtInput
+                input-type="number"
+                :placeholder="t('Settings.Download Settings.Maximum File Size MB')"
+                :show-label="true"
+                :show-action-button="false"
+                :maxlength="9"
+                :value="displayNumber(ruleFor(channel.id).maxFileSizeMb)"
+                @input="value => updateNumber(channel.id, 'maxFileSizeMb', value)"
+              />
+              <FtInput
+                input-type="number"
+                :placeholder="t('Settings.Download Settings.Maximum Age Days')"
+                :show-label="true"
+                :show-action-button="false"
+                :maxlength="6"
+                :value="displayNumber(ruleFor(channel.id).maxAgeDays)"
+                @input="value => updateNumber(channel.id, 'maxAgeDays', value)"
+              />
+            </div>
+            <div class="titleFilters">
+              <FtInput
+                :placeholder="t('Settings.Download Settings.Title Includes')"
+                :show-label="true"
+                :show-action-button="false"
+                :maxlength="200"
+                :value="ruleFor(channel.id).titleIncludes"
+                @input="value => updateRule(channel.id, 'titleIncludes', value)"
+              />
+              <FtInput
+                :placeholder="t('Settings.Download Settings.Title Excludes')"
+                :show-label="true"
+                :show-action-button="false"
+                :maxlength="200"
+                :value="ruleFor(channel.id).titleExcludes"
+                @input="value => updateRule(channel.id, 'titleExcludes', value)"
+              />
+            </div>
+            <p class="filterHint">
+              {{ t('Settings.Download Settings.Title Filter Hint') }}
+            </p>
+          </div>
+        </li>
+      </ul>
+    </div>
+  </FtSettingsSubpage>
+</template>
+
+<script setup>
+import { FtIcon } from '@opentubex/icons'
+import { computed, ref } from 'vue'
+import { useI18n } from 'vue-i18n'
+
+import FtButton from '../FtButton/FtButton.vue'
+import FtFlexBox from '../ft-flex-box/ft-flex-box.vue'
+import FtInput from '../FtInput/FtInput.vue'
+import FtSelect from '../FtSelect/FtSelect.vue'
+import FtSettingsSubpage from '../FtSettingsSubpage/FtSettingsSubpage.vue'
+import FtToggleSwitch from '../FtToggleSwitch/FtToggleSwitch.vue'
+
+import store from '../../store/index'
+import {
+  DEFAULT_AUTOMATIC_DOWNLOAD_RULE,
+  normalizeAutomaticDownloadRule,
+  parseAutomaticDownloadRules
+} from '../../helpers/automaticDownloadRules'
+import { DEFAULT_DOWNLOAD_TEMPLATES } from '../../helpers/downloadTemplates'
+
+const { locale, t } = useI18n()
+const showManager = ref(false)
+const searchQuery = ref('')
+
+const rules = computed(() => parseAutomaticDownloadRules(store.getters.getYtDlpAutomaticDownloadRules))
+const channels = computed(() => {
+  const allChannelsProfile = store.getters.getProfileList[0]
+  const collator = new Intl.Collator([locale.value, 'en'], { sensitivity: 'base' })
+  return [...(allChannelsProfile?.subscriptions ?? [])]
+    .sort((a, b) => collator.compare(a.name || a.id, b.name || b.id))
+})
+const enabledRuleCount = computed(() => channels.value.filter(channel => rules.value[channel.id] !== undefined).length)
+const visibleChannels = computed(() => {
+  const query = searchQuery.value.trim().toLocaleLowerCase()
+  if (query === '') return channels.value
+  return channels.value.filter(channel => (
+    (channel.name || '').toLocaleLowerCase().includes(query) || channel.id.toLocaleLowerCase().includes(query)
+  ))
+})
+
+const customTemplates = computed(() => {
+  try {
+    const parsed = JSON.parse(store.getters.getYtDlpDownloadTemplates || '[]')
+    return Array.isArray(parsed) ? parsed : []
+  } catch {
+    return []
+  }
+})
+const templateNames = computed(() => [
+  ...DEFAULT_DOWNLOAD_TEMPLATES.map(template => template.label(t)),
+  ...customTemplates.value.map(template => template.name)
+])
+const templateValues = computed(() => [
+  ...DEFAULT_DOWNLOAD_TEMPLATES.map(template => template.value),
+  ...customTemplates.value.map(template => `template:${template.name}`)
+])
+
+function ruleFor(channelId) {
+  return normalizeAutomaticDownloadRule(rules.value[channelId])
+}
+
+function saveRules(nextRules) {
+  store.dispatch('updateYtDlpAutomaticDownloadRules', JSON.stringify(nextRules))
+}
+
+function setChannelEnabled(channelId, enabled) {
+  const nextRules = { ...rules.value }
+  if (enabled) {
+    nextRules[channelId] = { ...DEFAULT_AUTOMATIC_DOWNLOAD_RULE, enabledAt: Date.now() }
+  } else {
+    delete nextRules[channelId]
+  }
+  saveRules(nextRules)
+}
+
+function updateRule(channelId, key, value) {
+  saveRules({
+    ...rules.value,
+    [channelId]: {
+      ...ruleFor(channelId),
+      [key]: value
+    }
+  })
+}
+
+function updateNumber(channelId, key, value) {
+  const number = Number(value)
+  updateRule(channelId, key, value === '' || !Number.isFinite(number) || number <= 0 ? null : number)
+}
+
+function displayNumber(value) {
+  return value === null ? '' : String(value)
+}
+</script>
+
+<style scoped>
+.automaticDownloadsHeader {
+  flex: none;
+  padding: 16px 20px 8px;
+}
+
+.automaticDownloadsHeader p {
+  margin-block: 0 8px;
+}
+
+.automaticDownloadsHint,
+.filterHint,
+.emptyState {
+  color: var(--tertiary-text-color);
+}
+
+.automaticDownloadsScroller {
+  min-block-size: 0;
+  flex: 1;
+  padding-inline: 20px;
+}
+
+.channelRules {
+  display: grid;
+  gap: 16px;
+  padding: 0 0 24px;
+  margin: 0;
+  list-style: none;
+}
+
+.channelRule {
+  padding: 16px;
+  border: 1px solid var(--tertiary-text-color);
+  border-radius: 10px;
+}
+
+.channelRuleHeader {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+}
+
+.channelThumbnail {
+  inline-size: 44px;
+  block-size: 44px;
+  flex: none;
+  border-radius: 50%;
+  object-fit: cover;
+  font-size: 44px;
+}
+
+.channelThumbnailPlaceholder {
+  display: flex;
+}
+
+.channelToggle {
+  min-inline-size: 0;
+  flex: 1;
+}
+
+.channelRuleOptions {
+  display: grid;
+  gap: 18px;
+  padding-block-start: 18px;
+}
+
+.templateAndTypes,
+.filterGrid,
+.titleFilters {
+  display: grid;
+  gap: 16px;
+}
+
+.templateAndTypes {
+  align-items: end;
+  grid-template-columns: minmax(260px, 2fr) repeat(3, minmax(max-content, 1fr));
+}
+
+.templateSelect {
+  inline-size: 100%;
+}
+
+.templateAndTypes :deep(.switch-label) {
+  align-items: center;
+  box-sizing: border-box;
+  block-size: 45px;
+  display: inline-flex;
+}
+
+.filterGrid,
+.titleFilters {
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+}
+
+.filterHint {
+  margin: -8px 0 0;
+  font-size: 0.9rem;
+}
+
+@container (width <= 760px) {
+  .templateAndTypes {
+    grid-template-columns: repeat(3, minmax(0, 1fr));
+  }
+
+  .templateSelect {
+    grid-column: 1 / -1;
+  }
+}
+
+@container (width <= 600px) {
+  .templateAndTypes,
+  .filterGrid,
+  .titleFilters {
+    grid-template-columns: 1fr;
+  }
+}
+</style>

--- a/src/renderer/components/DownloadSettings.vue
+++ b/src/renderer/components/DownloadSettings.vue
@@ -27,6 +27,8 @@
         @click="openDownloads"
       />
     </FtFlexBox>
+    <DownloadTemplateSettings v-if="enableDownloads" />
+    <AutomaticDownloadSettings v-if="enableDownloads" />
     <FtFlexBox
       v-if="enableDownloads"
       class="downloadPathInputs settingsFlexStart460px"
@@ -43,16 +45,6 @@
         @click="chooseDownloadFolder"
       />
     </FtFlexBox>
-    <FtFlexBox v-if="enableDownloads">
-      <p class="templatesHint">
-        {{ t('Settings.Download Settings.Templates Hint') }}
-      </p>
-    </FtFlexBox>
-    <FtFlexBox v-if="enableDownloads">
-      <p class="templatesHint">
-        {{ t('Settings.Download Settings.External Software Hint') }}
-      </p>
-    </FtFlexBox>
   </FtSettingsSection>
 </template>
 
@@ -65,6 +57,8 @@ import FtInput from './FtInput/FtInput.vue'
 import FtFlexBox from './ft-flex-box/ft-flex-box.vue'
 import FtToggleSwitch from './FtToggleSwitch/FtToggleSwitch.vue'
 import FtButton from './FtButton/FtButton.vue'
+import AutomaticDownloadSettings from './AutomaticDownloadSettings/AutomaticDownloadSettings.vue'
+import DownloadTemplateSettings from './DownloadTemplateSettings/DownloadTemplateSettings.vue'
 
 import store from '../store/index'
 
@@ -118,7 +112,4 @@ async function chooseDownloadFolder() {
   max-inline-size: 100%;
 }
 
-.templatesHint {
-  margin-block: 0;
-}
 </style>

--- a/src/renderer/components/DownloadTemplateSettings/DownloadTemplateSettings.vue
+++ b/src/renderer/components/DownloadTemplateSettings/DownloadTemplateSettings.vue
@@ -1,0 +1,551 @@
+<template>
+  <FtFlexBox>
+    <FtButton
+      :label="t('Settings.Download Settings.Manage Download Templates', { templateCount: customTemplates.length })"
+      :icon="['fas', 'save']"
+      @click="openManager"
+    />
+  </FtFlexBox>
+  <FtSettingsSubpage
+    :open="showManager"
+    :title="t('Settings.Download Settings.Download Templates')"
+    :icon="['fas', 'save']"
+    @close="showManager = false"
+  >
+    <div class="templateManagerHeader">
+      <FtSelect
+        :placeholder="t('Settings.Download Settings.Template Source')"
+        :value="selectedSourceValue"
+        :select-names="templateSelectionNames"
+        :select-values="templateSelectionValues"
+        :show-icon="false"
+        @change="loadTemplateSource"
+      />
+      <FtInput
+        :placeholder="t('Downloads.Template Name')"
+        :show-label="true"
+        :show-action-button="false"
+        :maxlength="100"
+        :value="draftName"
+        @input="draftName = $event"
+      />
+    </div>
+    <div
+      v-overlay-scrollbars
+      class="templateOptions"
+    >
+      <section class="optionSection optionGrid">
+        <FtSelect
+          :placeholder="t('Downloads.Media Type')"
+          :value="options.mode"
+          :select-names="[t('Downloads.Video'), t('Downloads.Audio'), t('Downloads.Subtitles')]"
+          :select-values="['video', 'audio', 'subtitles']"
+          @change="setOption('mode', $event)"
+        />
+        <FtSelect
+          :placeholder="t('Downloads.Maximum Resolution')"
+          :value="options.quality"
+          :disabled="options.mode !== 'video'"
+          :select-names="[t('Downloads.Best Available'), '2160p', '1440p', '1080p', '720p', '480p', '360p']"
+          :select-values="['', '2160', '1440', '1080', '720', '480', '360']"
+          @change="setOption('quality', $event)"
+        />
+        <FtSelect
+          :placeholder="t('Downloads.Container')"
+          :value="options.videoFormat"
+          :disabled="options.mode !== 'video'"
+          :select-names="[t('Downloads.Automatic'), 'MP4', 'MKV', 'WebM']"
+          :select-values="['', 'mp4', 'mkv', 'webm']"
+          @change="setOption('videoFormat', $event)"
+        />
+        <FtSelect
+          :placeholder="formatLabel"
+          :value="selectedCodec"
+          :select-names="codecNames"
+          :select-values="codecValues"
+          @change="setSelectedCodec"
+        />
+      </section>
+
+      <section class="optionSection">
+        <FtInput
+          :placeholder="t('Downloads.File Name Template')"
+          :tooltip="fileNameTemplateHelp"
+          :show-action-button="false"
+          :show-label="true"
+          :value="options.filenameTemplate"
+          @input="setOption('filenameTemplate', $event)"
+        />
+      </section>
+
+      <section class="optionSection">
+        <h3>{{ t('Downloads.Time Range and Chapters') }}</h3>
+        <div class="optionGrid">
+          <FtInput
+            :placeholder="t('Downloads.Start Time')"
+            :disabled="subtitlesOnly"
+            :show-action-button="false"
+            :show-label="true"
+            :value="options.startTime"
+            @input="setOption('startTime', $event)"
+          />
+          <FtInput
+            :placeholder="t('Downloads.End Time')"
+            :disabled="subtitlesOnly"
+            :show-action-button="false"
+            :show-label="true"
+            :value="options.endTime"
+            @input="setOption('endTime', $event)"
+          />
+        </div>
+        <div class="toggleGrid">
+          <FtToggleSwitch
+            compact
+            :label="t('Downloads.Split by Chapters')"
+            :default-value="!subtitlesOnly && options.splitChapters"
+            :disabled="subtitlesOnly"
+            @change="setOption('splitChapters', $event)"
+          />
+        </div>
+      </section>
+
+      <section class="optionSection">
+        <h3>{{ t('Downloads.SponsorBlock') }}</h3>
+        <div class="toggleGrid">
+          <FtToggleSwitch
+            compact
+            :label="t('Downloads.Remove Segments')"
+            :default-value="!subtitlesOnly && options.removeSponsorblock"
+            :disabled="subtitlesOnly"
+            @change="setOption('removeSponsorblock', $event)"
+          />
+        </div>
+        <div
+          :class="{ disabledOptions: !sponsorBlockCategoriesEnabled }"
+          :inert="!sponsorBlockCategoriesEnabled"
+          :aria-disabled="!sponsorBlockCategoriesEnabled"
+        >
+          <FtCheckboxList
+            v-model="sponsorBlockCategories"
+            class="sponsorCategories"
+            :labels="sponsorBlockCategoryLabels"
+            :values="SPONSORBLOCK_CATEGORIES"
+          />
+        </div>
+      </section>
+
+      <section class="optionSection">
+        <h3>{{ t('Downloads.Subtitles and Metadata') }}</h3>
+        <div class="toggleGrid">
+          <FtToggleSwitch
+            compact
+            :label="t('Downloads.Embed Cover Art')"
+            :default-value="!subtitlesOnly && options.embedThumbnail"
+            :disabled="subtitlesOnly"
+            @change="setOption('embedThumbnail', $event)"
+          />
+          <FtToggleSwitch
+            compact
+            :label="t('Downloads.Embed Metadata')"
+            :default-value="!subtitlesOnly && options.embedMetadata"
+            :disabled="subtitlesOnly"
+            @change="setOption('embedMetadata', $event)"
+          />
+          <FtToggleSwitch
+            compact
+            :label="t('Downloads.Include Subtitles')"
+            :default-value="subtitlesOnly || options.includeSubtitles"
+            :disabled="subtitlesOnly"
+            @change="setOption('includeSubtitles', $event)"
+          />
+          <FtToggleSwitch
+            compact
+            :label="t('Downloads.Embed Subtitles')"
+            :default-value="!subtitlesOnly && options.embedSubtitles"
+            :disabled="subtitlesOnly || !options.includeSubtitles"
+            @change="setOption('embedSubtitles', $event)"
+          />
+        </div>
+        <FtInput
+          class="subtitleLanguages"
+          :placeholder="t('Downloads.Subtitle Languages')"
+          :tooltip="t('Downloads.Subtitle Languages Help')"
+          :disabled="!subtitlesOnly && !options.includeSubtitles"
+          :show-action-button="false"
+          :show-label="true"
+          :value="options.subtitleLanguages"
+          @input="setOption('subtitleLanguages', $event)"
+        />
+      </section>
+
+      <section class="optionSection">
+        <FtInput
+          :placeholder="t('Downloads.Additional yt-dlp Arguments')"
+          :show-action-button="false"
+          :show-label="true"
+          :value="options.customArgs"
+          @input="setOption('customArgs', $event)"
+        />
+      </section>
+    </div>
+    <footer class="templateManagerFooter">
+      <FtFlexBox>
+        <FtButton
+          :label="t('Settings.Download Settings.New Template')"
+          :icon="['fas', 'plus']"
+          :text-color="null"
+          :background-color="null"
+          @click="loadTemplateSource('')"
+        />
+        <FtButton
+          v-if="selectedTemplateName !== ''"
+          :label="t('Settings.Download Settings.Create Template Copy')"
+          :icon="['fas', 'copy']"
+          :text-color="null"
+          :background-color="null"
+          @click="createCopy"
+        />
+        <FtButton
+          :label="t('Downloads.Save Template')"
+          :icon="['fas', 'save']"
+          :disabled="draftName.trim() === ''"
+          @click="saveTemplate"
+        />
+        <FtButton
+          v-if="selectedTemplateName !== ''"
+          :label="t('Downloads.Delete Template')"
+          :icon="['fas', 'trash']"
+          theme="destructive"
+          @click="deleteTemplate"
+        />
+      </FtFlexBox>
+    </footer>
+  </FtSettingsSubpage>
+</template>
+
+<script setup>
+import { computed, reactive, ref } from 'vue'
+import { useI18n } from 'vue-i18n'
+
+import FtButton from '../FtButton/FtButton.vue'
+import FtCheckboxList from '../FtCheckboxList/FtCheckboxList.vue'
+import FtFlexBox from '../ft-flex-box/ft-flex-box.vue'
+import FtInput from '../FtInput/FtInput.vue'
+import FtSelect from '../FtSelect/FtSelect.vue'
+import FtSettingsSubpage from '../FtSettingsSubpage/FtSettingsSubpage.vue'
+import FtToggleSwitch from '../FtToggleSwitch/FtToggleSwitch.vue'
+
+import store from '../../store/index'
+import {
+  DEFAULT_DOWNLOAD_TEMPLATES,
+  getDownloadTemplateOptions,
+  replaceAutomaticDownloadTemplateReferences
+} from '../../helpers/downloadTemplates'
+import { showToast } from '../../helpers/utils'
+
+const { locale, t } = useI18n()
+const showManager = ref(false)
+const selectedSourceValue = ref('')
+const selectedTemplateName = ref('')
+const draftName = ref('')
+
+const SPONSORBLOCK_CATEGORIES = ['sponsor', 'intro', 'outro', 'selfpromo', 'interaction', 'music_offtopic', 'preview', 'filler']
+
+function defaultSubtitleLanguages() {
+  return [...new Set([locale.value.split('-')[0], 'en'])]
+    .map(language => `${language}.*`)
+    .join(',')
+}
+
+function baseOptions() {
+  return {
+    mode: 'video',
+    quality: '',
+    videoFormat: '',
+    videoCodec: '',
+    audioFormat: '',
+    filenameTemplate: '{title} [{id}].{ext}',
+    startTime: '',
+    endTime: '',
+    splitChapters: false,
+    removeSponsorblock: false,
+    sponsorBlockCategories: [...SPONSORBLOCK_CATEGORIES],
+    includeSubtitles: false,
+    embedSubtitles: true,
+    subtitleLanguages: defaultSubtitleLanguages(),
+    subtitleFormat: '',
+    embedThumbnail: false,
+    embedMetadata: false,
+    customArgs: ''
+  }
+}
+
+const options = reactive(baseOptions())
+
+const customTemplates = computed(() => {
+  try {
+    const parsed = JSON.parse(store.getters.getYtDlpDownloadTemplates || '[]')
+    return Array.isArray(parsed) ? parsed : []
+  } catch {
+    return []
+  }
+})
+const templateSelectionNames = computed(() => [
+  t('Settings.Download Settings.New Template'),
+  ...DEFAULT_DOWNLOAD_TEMPLATES.map(template => t('Settings.Download Settings.Built-in Template', {
+    name: template.label(t)
+  })),
+  ...customTemplates.value.map(template => t('Settings.Download Settings.Custom Template Name', {
+    name: template.name
+  }))
+])
+const templateSelectionValues = computed(() => [
+  '',
+  ...DEFAULT_DOWNLOAD_TEMPLATES.map(template => `builtin:${template.value}`),
+  ...customTemplates.value.map(template => `custom:${template.name}`)
+])
+const subtitlesOnly = computed(() => options.mode === 'subtitles')
+const formatOptionKey = computed(() => {
+  if (subtitlesOnly.value) return 'subtitleFormat'
+  return options.mode === 'video' ? 'videoCodec' : 'audioFormat'
+})
+const formatLabel = computed(() => {
+  if (subtitlesOnly.value) return t('Downloads.Subtitle Format')
+  return options.mode === 'video' ? t('Downloads.Video Codec') : t('Downloads.Audio Codec')
+})
+const selectedCodec = computed(() => options[formatOptionKey.value])
+const codecNames = computed(() => {
+  if (subtitlesOnly.value) return [t('Downloads.Automatic'), 'SRT', 'VTT', 'ASS', 'LRC']
+  return options.mode === 'video'
+    ? [t('Downloads.Automatic'), 'H.264', 'H.265 / HEVC', 'VP9', 'AV1']
+    : [t('Downloads.Best Available'), 'MP3', 'M4A', 'Opus', 'FLAC']
+})
+const codecValues = computed(() => {
+  if (subtitlesOnly.value) return ['', 'srt', 'vtt', 'ass', 'lrc']
+  return options.mode === 'video'
+    ? ['', 'h264', 'h265', 'vp9', 'av1']
+    : ['', 'mp3', 'm4a', 'opus', 'flac']
+})
+const sponsorBlockCategoriesEnabled = computed(() => !subtitlesOnly.value && options.removeSponsorblock)
+const sponsorBlockCategories = computed({
+  get: () => options.sponsorBlockCategories,
+  set: value => setOption('sponsorBlockCategories', value)
+})
+const sponsorBlockCategoryLabels = computed(() => [
+  t('Video.Sponsor Block category.sponsor'),
+  t('Video.Sponsor Block category.intro'),
+  t('Video.Sponsor Block category.outro'),
+  t('Video.Sponsor Block category.self-promotion'),
+  t('Video.Sponsor Block category.interaction'),
+  t('Video.Sponsor Block category.music offtopic'),
+  t('Video.Sponsor Block category.recap'),
+  t('Video.Sponsor Block category.filler')
+])
+const fileNameTemplateHelp = computed(() => t('Downloads.File Name Template Help', {
+  title: '{title}',
+  author: '{author}',
+  upload_date: '{upload_date}',
+  id: '{id}',
+  playlist: '{playlist}',
+  playlist_index: '{playlist_index}',
+  ext: '{ext}'
+}))
+
+function normalizedOptions(source) {
+  const defaults = baseOptions()
+  return Object.fromEntries(Object.keys(defaults).map(key => {
+    const value = source?.[key] ?? defaults[key]
+    return [key, Array.isArray(value) ? [...value].sort() : value]
+  }))
+}
+
+function setOption(key, value) {
+  options[key] = value
+}
+
+function setSelectedCodec(value) {
+  setOption(formatOptionKey.value, value)
+}
+
+function openManager() {
+  showManager.value = true
+  loadTemplateSource(customTemplates.value[0] ? `custom:${customTemplates.value[0].name}` : '')
+}
+
+function loadTemplateSource(value) {
+  selectedSourceValue.value = value
+
+  if (value.startsWith('builtin:')) {
+    const templateValue = value.slice('builtin:'.length)
+    selectedTemplateName.value = ''
+    draftName.value = ''
+    Object.assign(options, normalizedOptions(
+      getDownloadTemplateOptions(templateValue, customTemplates.value) ?? {}
+    ))
+    return
+  }
+
+  if (value.startsWith('custom:')) {
+    const name = value.slice('custom:'.length)
+    const template = customTemplates.value.find(template => template.name === name)
+    if (template) {
+      selectedTemplateName.value = template.name
+      draftName.value = template.name
+      Object.assign(options, normalizedOptions(
+        template.options ?? (template.args ? { customArgs: template.args } : {})
+      ))
+      return
+    }
+  }
+
+  selectedSourceValue.value = ''
+  selectedTemplateName.value = ''
+  draftName.value = ''
+  Object.assign(options, normalizedOptions({}))
+}
+
+function createCopy() {
+  const sourceName = selectedTemplateName.value
+  if (sourceName === '') return
+  selectedSourceValue.value = ''
+  selectedTemplateName.value = ''
+  draftName.value = t('Settings.Download Settings.Template Copy Name', { name: sourceName })
+}
+
+function updateReferences(oldValue, replacementValue) {
+  if (store.getters.getYtDlpSelectedTemplate === oldValue) {
+    store.dispatch('updateYtDlpSelectedTemplate', replacementValue)
+  }
+  store.dispatch('updateYtDlpAutomaticDownloadRules', replaceAutomaticDownloadTemplateReferences(
+    store.getters.getYtDlpAutomaticDownloadRules,
+    oldValue,
+    replacementValue
+  ))
+}
+
+function saveTemplate() {
+  const name = draftName.value.trim()
+  if (name === '') return
+
+  const previousName = selectedTemplateName.value
+  const templates = customTemplates.value.filter(template => (
+    template.name !== previousName && template.name !== name
+  ))
+  templates.push({ name, options: normalizedOptions(options) })
+  store.dispatch('updateYtDlpDownloadTemplates', JSON.stringify(templates))
+
+  if (previousName !== '' && previousName !== name) {
+    updateReferences(`template:${previousName}`, `template:${name}`)
+  }
+
+  selectedTemplateName.value = name
+  selectedSourceValue.value = `custom:${name}`
+  draftName.value = name
+  showToast({ message: t('Downloads.Template Saved', { name }), icon: ['fas', 'save'] })
+}
+
+function deleteTemplate() {
+  const name = selectedTemplateName.value
+  if (name === '') return
+
+  store.dispatch('updateYtDlpDownloadTemplates', JSON.stringify(
+    customTemplates.value.filter(template => template.name !== name)
+  ))
+  updateReferences(`template:${name}`, 'video:best')
+  loadTemplateSource('')
+}
+</script>
+
+<style scoped>
+.templateManagerHeader {
+  flex: none;
+  display: grid;
+  align-items: start;
+  grid-template-columns: minmax(240px, 1fr) minmax(280px, 2fr);
+  gap: 16px;
+  padding: 16px 20px;
+}
+
+.templateOptions {
+  min-block-size: 0;
+  flex: 1;
+  padding-inline: 20px;
+}
+
+.optionSection {
+  border-block-start: 1px solid var(--side-nav-color);
+  padding-block: 16px;
+}
+
+.optionSection:first-child {
+  border-block-start: 0;
+}
+
+.optionSection h3 {
+  font-size: 1rem;
+  margin-block: 0 12px;
+}
+
+.optionGrid,
+.toggleGrid {
+  display: grid;
+  align-items: start;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: 12px 16px;
+}
+
+.optionGrid > :deep(.select),
+.templateManagerHeader > :deep(.select) {
+  inline-size: 100%;
+}
+
+.templateManagerHeader > :deep(.ft-input-component) {
+  margin-block-start: 30px;
+}
+
+.templateManagerHeader :deep(.selectLabel) {
+  position: absolute;
+  inset-block-start: -20px;
+  inset-inline-start: 0;
+  color: var(--accent-color);
+  font-size: 14px;
+  line-height: 1;
+}
+
+.templateManagerHeader :deep(.ft-input) {
+  margin-block-end: 0;
+}
+
+.toggleGrid {
+  margin-block-start: 10px;
+}
+
+.sponsorCategories {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: 2px 18px;
+}
+
+.disabledOptions {
+  opacity: 0.4;
+}
+
+.subtitleLanguages {
+  margin-block-start: 12px;
+}
+
+.templateManagerFooter {
+  flex: none;
+  border-block-start: 1px solid var(--side-nav-color);
+  padding: 10px 20px;
+}
+
+@container (width <= 600px) {
+  .templateManagerHeader,
+  .optionGrid,
+  .toggleGrid,
+  .sponsorCategories {
+    grid-template-columns: 1fr;
+  }
+}
+</style>

--- a/src/renderer/components/DownloadTemplateSettings/DownloadTemplateSettings.vue
+++ b/src/renderer/components/DownloadTemplateSettings/DownloadTemplateSettings.vue
@@ -428,6 +428,10 @@ function saveTemplate() {
   if (name === '') return
 
   const previousName = selectedTemplateName.value
+  if (customTemplates.value.some(template => template.name === name && template.name !== previousName)) {
+    showToast({ message: t('Downloads.Template Name Exists', { name }), icon: ['fas', 'circle-exclamation'] })
+    return
+  }
   const templates = customTemplates.value.filter(template => (
     template.name !== previousName && template.name !== name
   ))

--- a/src/renderer/components/WatchVideoDownloadPrompt/WatchVideoDownloadPrompt.vue
+++ b/src/renderer/components/WatchVideoDownloadPrompt/WatchVideoDownloadPrompt.vue
@@ -336,7 +336,7 @@ import FtPrompt from '../FtPrompt/FtPrompt.vue'
 import FtSelect from '../FtSelect/FtSelect.vue'
 import FtToggleSwitch from '../FtToggleSwitch/FtToggleSwitch.vue'
 import store from '../../store/index'
-import { DEFAULT_DOWNLOAD_TEMPLATES } from '../../helpers/downloadTemplates'
+import { DEFAULT_DOWNLOAD_TEMPLATES, replaceAutomaticDownloadTemplateReferences } from '../../helpers/downloadTemplates'
 import { showToast } from '../../helpers/utils'
 
 const props = defineProps({
@@ -541,9 +541,15 @@ function closeSaveTemplatePrompt() {
 }
 function deleteTemplate() {
   if (!selectedCustomTemplate.value) return
+  const deletedValue = `template:${selectedCustomTemplate.value.name}`
   const templates = customTemplates.value.filter(template => template.name !== selectedCustomTemplate.value.name)
   store.dispatch('updateYtDlpDownloadTemplates', JSON.stringify(templates))
   store.dispatch('updateYtDlpSelectedTemplate', 'video:best')
+  store.dispatch('updateYtDlpAutomaticDownloadRules', replaceAutomaticDownloadTemplateReferences(
+    store.getters.getYtDlpAutomaticDownloadRules,
+    deletedValue,
+    'video:best'
+  ))
   loadTemplate('video:best')
 }
 

--- a/src/renderer/helpers/automaticDownloadRules.js
+++ b/src/renderer/helpers/automaticDownloadRules.js
@@ -66,7 +66,8 @@ function getDurationSeconds(video) {
   }
 
   if (typeof video.lengthSeconds === 'string' && /^\d+(?::[0-5]?\d){1,2}$/.test(video.lengthSeconds)) {
-    return video.lengthSeconds.split(':').reduce((seconds, part) => seconds * 60 + Number(part), 0)
+    const seconds = video.lengthSeconds.split(':').reduce((total, part) => total * 60 + Number(part), 0)
+    return seconds > 0 ? seconds : null
   }
 
   return null
@@ -100,6 +101,8 @@ export function matchesAutomaticDownloadRule(video, source, rawRule, now = Date.
   }
 
   const duration = getDurationSeconds(video)
+  // RSS feeds do not provide a usable duration. Keep the candidate so yt-dlp
+  // can apply the same min/max constraints after it extracts real metadata.
   if (duration !== null && (
     (rule.minDurationSeconds !== null && duration < rule.minDurationSeconds) ||
     (rule.maxDurationSeconds !== null && duration > rule.maxDurationSeconds)

--- a/src/renderer/helpers/automaticDownloadRules.js
+++ b/src/renderer/helpers/automaticDownloadRules.js
@@ -1,0 +1,125 @@
+export const DEFAULT_AUTOMATIC_DOWNLOAD_RULE = Object.freeze({
+  template: 'video:best',
+  enabledAt: null,
+  includeVideos: true,
+  includeShorts: false,
+  includeLivestreams: false,
+  minDurationSeconds: null,
+  maxDurationSeconds: null,
+  minFileSizeMb: null,
+  maxFileSizeMb: null,
+  maxAgeDays: null,
+  titleIncludes: '',
+  titleExcludes: ''
+})
+
+/**
+ * @param {string} value
+ * @returns {Record<string, object>}
+ */
+export function parseAutomaticDownloadRules(value) {
+  try {
+    const parsed = JSON.parse(value || '{}')
+    return parsed !== null && typeof parsed === 'object' && !Array.isArray(parsed) ? parsed : {}
+  } catch (error) {
+    console.error('Failed to parse automatic download rules:', error)
+    return {}
+  }
+}
+
+/**
+ * @param {unknown} value
+ * @returns {number | null}
+ */
+function optionalPositiveNumber(value) {
+  const number = Number(value)
+  return Number.isFinite(number) && number > 0 ? number : null
+}
+
+/**
+ * @param {object} rule
+ */
+export function normalizeAutomaticDownloadRule(rule = {}) {
+  return {
+    ...DEFAULT_AUTOMATIC_DOWNLOAD_RULE,
+    ...rule,
+    template: typeof rule.template === 'string' && rule.template !== ''
+      ? rule.template
+      : DEFAULT_AUTOMATIC_DOWNLOAD_RULE.template,
+    enabledAt: optionalPositiveNumber(rule.enabledAt),
+    includeVideos: rule.includeVideos !== false,
+    includeShorts: rule.includeShorts === true,
+    includeLivestreams: rule.includeLivestreams === true,
+    minDurationSeconds: optionalPositiveNumber(rule.minDurationSeconds),
+    maxDurationSeconds: optionalPositiveNumber(rule.maxDurationSeconds),
+    minFileSizeMb: optionalPositiveNumber(rule.minFileSizeMb),
+    maxFileSizeMb: optionalPositiveNumber(rule.maxFileSizeMb),
+    maxAgeDays: optionalPositiveNumber(rule.maxAgeDays),
+    titleIncludes: typeof rule.titleIncludes === 'string' ? rule.titleIncludes : '',
+    titleExcludes: typeof rule.titleExcludes === 'string' ? rule.titleExcludes : ''
+  }
+}
+
+function getDurationSeconds(video) {
+  if (Number.isFinite(Number(video.lengthSeconds)) && Number(video.lengthSeconds) > 0) {
+    return Number(video.lengthSeconds)
+  }
+
+  if (typeof video.lengthSeconds === 'string' && /^\d+(?::[0-5]?\d){1,2}$/.test(video.lengthSeconds)) {
+    return video.lengthSeconds.split(':').reduce((seconds, part) => seconds * 60 + Number(part), 0)
+  }
+
+  return null
+}
+
+function getTerms(value) {
+  return value.split(',').map(term => term.trim().toLocaleLowerCase()).filter(Boolean)
+}
+
+/**
+ * @param {object} video
+ * @param {'videos' | 'shorts' | 'live'} source
+ * @param {object} rawRule
+ * @param {number} [now]
+ */
+export function matchesAutomaticDownloadRule(video, source, rawRule, now = Date.now()) {
+  if (video?.isNewInSubscriptionFeed !== true || typeof video.videoId !== 'string') {
+    return false
+  }
+
+  const rule = normalizeAutomaticDownloadRule(rawRule)
+  const isLivestream = source === 'live' || video.liveNow === true || video.isUpcoming === true || video.premiere === true
+
+  // An upcoming stream has no complete file yet. It can be picked up by a
+  // later live-feed refresh after it starts.
+  if (video.isUpcoming === true || video.premiere === true) {
+    return false
+  }
+  if (source === 'shorts' ? !rule.includeShorts : isLivestream ? !rule.includeLivestreams : !rule.includeVideos) {
+    return false
+  }
+
+  const duration = getDurationSeconds(video)
+  if (duration !== null && (
+    (rule.minDurationSeconds !== null && duration < rule.minDurationSeconds) ||
+    (rule.maxDurationSeconds !== null && duration > rule.maxDurationSeconds)
+  )) {
+    return false
+  }
+
+  const published = Number(video.subscriptionFeedPublished ?? video.published)
+  if (rule.enabledAt !== null && (!Number.isFinite(published) || published < rule.enabledAt)) {
+    return false
+  }
+  if (rule.maxAgeDays !== null && Number.isFinite(published) &&
+    published < now - rule.maxAgeDays * 24 * 60 * 60 * 1000) {
+    return false
+  }
+
+  const title = String(video.title ?? '').toLocaleLowerCase()
+  const includedTerms = getTerms(rule.titleIncludes)
+  const excludedTerms = getTerms(rule.titleExcludes)
+
+  return (includedTerms.length === 0 || includedTerms.some(term => title.includes(term))) &&
+    !excludedTerms.some(term => title.includes(term))
+}

--- a/src/renderer/helpers/automaticDownloads.js
+++ b/src/renderer/helpers/automaticDownloads.js
@@ -73,8 +73,9 @@ function getThumbnail(video) {
  * @param {object[]} videos
  * @param {'videos' | 'shorts' | 'live'} source
  * @param {(key: string, values?: object) => string} t
+ * @param {string | null} refreshOwnerTabId
  */
-export async function startAutomaticDownloadsForChannel(channel, videos, source, t) {
+export async function startAutomaticDownloadsForChannel(channel, videos, source, t, refreshOwnerTabId) {
   if (!process.env.IS_ELECTRON || !store.getters.getEnableDownloads || !Array.isArray(videos)) {
     return
   }
@@ -108,29 +109,35 @@ export async function startAutomaticDownloadsForChannel(channel, videos, source,
     const automaticMediaType = source === 'shorts'
       ? 'short'
       : source === 'live' || video.liveNow === true ? 'livestream' : 'video'
-    const result = await window.ftElectron.ytDlpDownload({
-      ...templateOptions,
-      videoId: video.videoId,
-      title,
-      thumbnail: getThumbnail(video),
-      template: rule.template,
-      automatic: true,
-      channelId: channel.id,
-      automaticMediaType,
-      minDurationSeconds: rule.minDurationSeconds,
-      maxDurationSeconds: rule.maxDurationSeconds,
-      minFileSizeMb: rule.minFileSizeMb,
-      maxFileSizeMb: rule.maxFileSizeMb,
-      maxAgeDays: rule.maxAgeDays,
-      notification: {
-        startedTitle: t('Downloads.Automatic Download Started'),
-        startedBody: t('Downloads.Automatic Download Started Body', { title, channel: channel.name || channel.id }),
-        completedTitle: t('Downloads.Automatic Download Complete'),
-        completedBody: t('Downloads.Download Complete Template', { title }),
-        failedTitle: t('Downloads.Automatic Download Failed'),
-        failedBody: t('Downloads.Download Failed Template', { title })
-      }
-    })
+    let result
+    try {
+      result = await window.ftElectron.ytDlpDownload({
+        ...templateOptions,
+        videoId: video.videoId,
+        title,
+        thumbnail: getThumbnail(video),
+        template: rule.template,
+        automatic: true,
+        channelId: channel.id,
+        automaticMediaType,
+        refreshOwnerTabId,
+        minDurationSeconds: rule.minDurationSeconds,
+        maxDurationSeconds: rule.maxDurationSeconds,
+        minFileSizeMb: rule.minFileSizeMb,
+        maxFileSizeMb: rule.maxFileSizeMb,
+        maxAgeDays: rule.maxAgeDays,
+        notification: {
+          startedTitle: t('Downloads.Automatic Download Started'),
+          startedBody: t('Downloads.Automatic Download Started Body', { title, channel: channel.name || channel.id }),
+          completedTitle: t('Downloads.Automatic Download Complete'),
+          completedBody: t('Downloads.Download Complete Template', { title }),
+          failedTitle: t('Downloads.Automatic Download Failed'),
+          failedBody: t('Downloads.Download Failed Template', { title })
+        }
+      })
+    } catch {
+      result = null
+    }
 
     if (result == null || 'error' in result) {
       scheduledVideoIds.delete(video.videoId)

--- a/src/renderer/helpers/automaticDownloads.js
+++ b/src/renderer/helpers/automaticDownloads.js
@@ -12,6 +12,17 @@ import { showToastOnAllTabs } from './utils'
 const scheduledVideoIds = new Set()
 
 /**
+ * Failed or canceled downloads may be retried by a later feed refresh. The
+ * main-process history remains the source of truth for terminal deduplication.
+ * @param {object} download
+ */
+export function releaseAutomaticDownloadSchedule(download) {
+  if (download?.automatic === true && ['failed', 'cancelled'].includes(download.status)) {
+    scheduledVideoIds.delete(download.videoId)
+  }
+}
+
+/**
  * Adds channels with automatic rules to the set fetched for a subscription
  * feed, even when the current profile filters those channels out.
  * @param {{ id: string }[]} activeSubscriptions
@@ -94,6 +105,9 @@ export async function startAutomaticDownloadsForChannel(channel, videos, source,
 
     scheduledVideoIds.add(video.videoId)
     const title = video.title || video.videoId
+    const automaticMediaType = source === 'shorts'
+      ? 'short'
+      : source === 'live' || video.liveNow === true ? 'livestream' : 'video'
     const result = await window.ftElectron.ytDlpDownload({
       ...templateOptions,
       videoId: video.videoId,
@@ -101,6 +115,8 @@ export async function startAutomaticDownloadsForChannel(channel, videos, source,
       thumbnail: getThumbnail(video),
       template: rule.template,
       automatic: true,
+      channelId: channel.id,
+      automaticMediaType,
       minDurationSeconds: rule.minDurationSeconds,
       maxDurationSeconds: rule.maxDurationSeconds,
       minFileSizeMb: rule.minFileSizeMb,

--- a/src/renderer/helpers/automaticDownloads.js
+++ b/src/renderer/helpers/automaticDownloads.js
@@ -1,0 +1,124 @@
+import store from '../store/index'
+import { getDownloadTemplateOptions } from './downloadTemplates'
+import {
+  matchesAutomaticDownloadRule,
+  normalizeAutomaticDownloadRule,
+  parseAutomaticDownloadRules
+} from './automaticDownloadRules'
+import { showToastOnAllTabs } from './utils'
+
+// Feed refreshes can overlap across profiles and views. Keep a session-level
+// guard in addition to the persistent download history in the main process.
+const scheduledVideoIds = new Set()
+
+/**
+ * Adds channels with automatic rules to the set fetched for a subscription
+ * feed, even when the current profile filters those channels out.
+ * @param {{ id: string }[]} activeSubscriptions
+ * @param {'videos' | 'shorts' | 'live'} source
+ */
+export function includeAutomaticDownloadChannels(activeSubscriptions, source) {
+  if (!process.env.IS_ELECTRON || !store.getters.getEnableDownloads) {
+    return activeSubscriptions
+  }
+
+  const rules = parseAutomaticDownloadRules(store.getters.getYtDlpAutomaticDownloadRules)
+  const automaticChannelIds = new Set(Object.entries(rules)
+    .filter(([, rawRule]) => {
+      const rule = normalizeAutomaticDownloadRule(rawRule)
+      if (source === 'shorts') return rule.includeShorts
+      if (source === 'live') return rule.includeLivestreams
+      return rule.includeVideos || rule.includeLivestreams
+    })
+    .map(([channelId]) => channelId))
+  if (automaticChannelIds.size === 0) {
+    return activeSubscriptions
+  }
+
+  const includedIds = new Set(activeSubscriptions.map(channel => channel.id))
+  const allSubscriptions = store.getters.getProfileList[0]?.subscriptions ?? []
+  return [
+    ...activeSubscriptions,
+    ...allSubscriptions.filter(channel => automaticChannelIds.has(channel.id) && !includedIds.has(channel.id))
+  ]
+}
+
+function parseCustomTemplates() {
+  try {
+    const templates = JSON.parse(store.getters.getYtDlpDownloadTemplates || '[]')
+    return Array.isArray(templates) ? templates : []
+  } catch {
+    return []
+  }
+}
+
+function getThumbnail(video) {
+  return video.thumbnailUrl ?? video.videoThumbnails?.at(-1)?.url ?? video.thumbnail ?? ''
+}
+
+/**
+ * Starts eligible automatic downloads discovered by a subscription refresh.
+ * @param {{ id: string, name?: string }} channel
+ * @param {object[]} videos
+ * @param {'videos' | 'shorts' | 'live'} source
+ * @param {(key: string, values?: object) => string} t
+ */
+export async function startAutomaticDownloadsForChannel(channel, videos, source, t) {
+  if (!process.env.IS_ELECTRON || !store.getters.getEnableDownloads || !Array.isArray(videos)) {
+    return
+  }
+
+  const rawRule = parseAutomaticDownloadRules(store.getters.getYtDlpAutomaticDownloadRules)[channel.id]
+  if (!rawRule) {
+    return
+  }
+
+  const rule = normalizeAutomaticDownloadRule(rawRule)
+  const customTemplates = parseCustomTemplates()
+  const templateOptions = getDownloadTemplateOptions(rule.template, customTemplates)
+  if (templateOptions === null) {
+    console.warn(`Automatic download template no longer exists for ${channel.id}: ${rule.template}`)
+    return
+  }
+
+  const existingDownloads = Object.values(store.getters.getYtDlpDownloads)
+  const knownVideoIds = new Set(existingDownloads
+    .filter(download => !['failed', 'cancelled'].includes(download.status))
+    .map(download => download.videoId))
+
+  for (const video of videos) {
+    if (!matchesAutomaticDownloadRule(video, source, rule) ||
+      scheduledVideoIds.has(video.videoId) || knownVideoIds.has(video.videoId)) {
+      continue
+    }
+
+    scheduledVideoIds.add(video.videoId)
+    const title = video.title || video.videoId
+    const result = await window.ftElectron.ytDlpDownload({
+      ...templateOptions,
+      videoId: video.videoId,
+      title,
+      thumbnail: getThumbnail(video),
+      template: rule.template,
+      automatic: true,
+      minDurationSeconds: rule.minDurationSeconds,
+      maxDurationSeconds: rule.maxDurationSeconds,
+      minFileSizeMb: rule.minFileSizeMb,
+      maxFileSizeMb: rule.maxFileSizeMb,
+      maxAgeDays: rule.maxAgeDays,
+      notification: {
+        startedTitle: t('Downloads.Automatic Download Started'),
+        startedBody: t('Downloads.Automatic Download Started Body', { title, channel: channel.name || channel.id }),
+        completedTitle: t('Downloads.Automatic Download Complete'),
+        completedBody: t('Downloads.Download Complete Template', { title }),
+        failedTitle: t('Downloads.Automatic Download Failed'),
+        failedBody: t('Downloads.Download Failed Template', { title })
+      }
+    })
+
+    if (result == null || 'error' in result) {
+      scheduledVideoIds.delete(video.videoId)
+      showToastOnAllTabs(t('Downloads.Automatic Download Could Not Start', { title }), 5000, ['fas', 'circle-exclamation'])
+    }
+  }
+}

--- a/src/renderer/helpers/downloadTemplates.js
+++ b/src/renderer/helpers/downloadTemplates.js
@@ -26,6 +26,61 @@ export const DEFAULT_DOWNLOAD_TEMPLATES = [
 ]
 
 /**
+ * Resolves the options stored by a built-in or custom template. Automatic
+ * downloads use the same templates as the download prompt, without needing to
+ * duplicate their interpretation.
+ * @param {string} value
+ * @param {{ name?: string, options?: object, args?: string }[]} customTemplates
+ * @returns {object | null}
+ */
+export function getDownloadTemplateOptions(value, customTemplates = []) {
+  const defaultTemplate = DEFAULT_DOWNLOAD_TEMPLATES.find(template => template.value === value)
+  if (defaultTemplate) {
+    return { mode: 'video', ...defaultTemplate.options }
+  }
+
+  const customTemplate = customTemplates.find(template => `template:${template.name}` === value)
+  if (customTemplate?.options && typeof customTemplate.options === 'object') {
+    return { mode: 'video', ...customTemplate.options }
+  }
+  if (typeof customTemplate?.args === 'string') {
+    return { mode: 'video', customArgs: customTemplate.args }
+  }
+
+  return null
+}
+
+/**
+ * Moves per-channel automatic download rules away from a renamed or deleted
+ * custom template.
+ * @param {string} rulesValue
+ * @param {string} oldTemplate
+ * @param {string} replacementTemplate
+ * @returns {string}
+ */
+export function replaceAutomaticDownloadTemplateReferences(rulesValue, oldTemplate, replacementTemplate) {
+  let rules
+  try {
+    rules = JSON.parse(rulesValue || '{}')
+  } catch {
+    return rulesValue
+  }
+  if (rules === null || typeof rules !== 'object' || Array.isArray(rules)) {
+    return rulesValue
+  }
+
+  let changed = false
+  for (const rule of Object.values(rules)) {
+    if (rule?.template === oldTemplate) {
+      rule.template = replacementTemplate
+      changed = true
+    }
+  }
+
+  return changed ? JSON.stringify(rules) : rulesValue
+}
+
+/**
  * @param {string} value
  * @param {(key: string, values?: object) => string} t
  * @returns {string} empty when the download wasn't started from a template

--- a/src/renderer/helpers/subscriptions.js
+++ b/src/renderer/helpers/subscriptions.js
@@ -31,6 +31,7 @@ import {
   updateUpcomingPremiereState
 } from './subscription-entries'
 import { mapConcurrently } from './concurrent-map'
+import { includeAutomaticDownloadChannels, startAutomaticDownloadsForChannel } from './automaticDownloads'
 
 const AUTO_REFRESH_TOAST_DURATION = 5000
 export const SUBSCRIPTION_REFRESH_CHANNEL_EVENT = 'opentubex-subscription-refresh-channel'
@@ -611,7 +612,9 @@ async function refreshSubscriptionVideosFromRemoteUnlocked({
   errorChannels = []
 }, activeProfile) {
   const activeSubscriptionList = getValidSubscriptionChannels(activeProfile.subscriptions)
-  if (activeSubscriptionList.length === 0) {
+  const activeSubscriptionIds = new Set(activeSubscriptionList.map(channel => channel.id))
+  const subscriptionList = includeAutomaticDownloadChannels(activeSubscriptionList, 'videos')
+  if (subscriptionList.length === 0) {
     completeSubscriptionRefresh('videos', activeProfile._id)
     return []
   }
@@ -646,7 +649,7 @@ async function refreshSubscriptionVideosFromRemoteUnlocked({
       }
 
       channelCount++
-      setSubscriptionRefreshProgress((channelCount / activeSubscriptionList.length) * 100)
+      setSubscriptionRefreshProgress((channelCount / subscriptionList.length) * 100)
 
       if (videos != null) {
         const previousCache = store.getters.getVideoCache[channel.id]
@@ -661,6 +664,7 @@ async function refreshSubscriptionVideosFromRemoteUnlocked({
           channelId: channel.id,
           videos
         })
+        await startAutomaticDownloadsForChannel(channel, videos, 'videos', t)
         notifySubscriptionChannelRefreshed('videos')
       }
 
@@ -672,12 +676,13 @@ async function refreshSubscriptionVideosFromRemoteUnlocked({
         })
       }
 
-      return videos ?? store.getters.getVideoCache[channel.id]?.videos ?? []
+      const channelVideos = videos ?? store.getters.getVideoCache[channel.id]?.videos ?? []
+      return activeSubscriptionIds.has(channel.id) ? channelVideos : []
     }
 
     const videoListFromRemote = useRss
-      ? await fetchSubscriptionsConcurrently(activeSubscriptionList, fetchChannel)
-      : await fetchSubscriptionsInBatches(activeSubscriptionList, fetchChannel)
+      ? await fetchSubscriptionsConcurrently(subscriptionList, fetchChannel)
+      : await fetchSubscriptionsInBatches(subscriptionList, fetchChannel)
 
     store.dispatch('batchUpdateSubscriptionDetails', subscriptionUpdates)
 
@@ -715,7 +720,9 @@ async function refreshSubscriptionShortsFromRemoteUnlocked({
   errorChannels = []
 }, activeProfile) {
   const activeSubscriptionList = getValidSubscriptionChannels(activeProfile.subscriptions)
-  if (activeSubscriptionList.length === 0) {
+  const activeSubscriptionIds = new Set(activeSubscriptionList.map(channel => channel.id))
+  const subscriptionList = includeAutomaticDownloadChannels(activeSubscriptionList, 'shorts')
+  if (subscriptionList.length === 0) {
     completeSubscriptionRefresh('shorts', activeProfile._id)
     return []
   }
@@ -731,7 +738,7 @@ async function refreshSubscriptionShortsFromRemoteUnlocked({
   let channelCount = 0
 
   try {
-    const videoListFromRemote = await fetchSubscriptionsConcurrently(activeSubscriptionList, async (channel) => {
+    const videoListFromRemote = await fetchSubscriptionsConcurrently(subscriptionList, async (channel) => {
       let videos, name
 
       if (!process.env.SUPPORTS_LOCAL_API || store.getters.getBackendPreference === 'invidious') {
@@ -741,7 +748,7 @@ async function refreshSubscriptionShortsFromRemoteUnlocked({
       }
 
       channelCount++
-      setSubscriptionRefreshProgress((channelCount / activeSubscriptionList.length) * 100)
+      setSubscriptionRefreshProgress((channelCount / subscriptionList.length) * 100)
 
       if (videos != null) {
         const previousCache = store.getters.getShortsCache[channel.id]
@@ -756,6 +763,7 @@ async function refreshSubscriptionShortsFromRemoteUnlocked({
           channelId: channel.id,
           videos
         })
+        await startAutomaticDownloadsForChannel(channel, videos, 'shorts', t)
         notifySubscriptionChannelRefreshed('shorts')
       }
 
@@ -766,7 +774,8 @@ async function refreshSubscriptionShortsFromRemoteUnlocked({
         })
       }
 
-      return videos ?? store.getters.getShortsCache[channel.id]?.videos ?? []
+      const channelVideos = videos ?? store.getters.getShortsCache[channel.id]?.videos ?? []
+      return activeSubscriptionIds.has(channel.id) ? channelVideos : []
     })
 
     store.dispatch('batchUpdateSubscriptionDetails', subscriptionUpdates)
@@ -805,7 +814,9 @@ async function refreshSubscriptionLiveFromRemoteUnlocked({
   errorChannels = []
 }, activeProfile) {
   const activeSubscriptionList = getValidSubscriptionChannels(activeProfile.subscriptions)
-  if (activeSubscriptionList.length === 0) {
+  const activeSubscriptionIds = new Set(activeSubscriptionList.map(channel => channel.id))
+  const subscriptionList = includeAutomaticDownloadChannels(activeSubscriptionList, 'live')
+  if (subscriptionList.length === 0) {
     completeSubscriptionRefresh('live', activeProfile._id)
     return []
   }
@@ -840,7 +851,7 @@ async function refreshSubscriptionLiveFromRemoteUnlocked({
       }
 
       channelCount++
-      setSubscriptionRefreshProgress((channelCount / activeSubscriptionList.length) * 100)
+      setSubscriptionRefreshProgress((channelCount / subscriptionList.length) * 100)
 
       if (videos != null) {
         const previousCache = store.getters.getLiveCache[channel.id]
@@ -855,6 +866,7 @@ async function refreshSubscriptionLiveFromRemoteUnlocked({
           channelId: channel.id,
           videos
         })
+        await startAutomaticDownloadsForChannel(channel, videos, 'live', t)
         notifySubscriptionChannelRefreshed('live')
       }
 
@@ -866,12 +878,13 @@ async function refreshSubscriptionLiveFromRemoteUnlocked({
         })
       }
 
-      return videos ?? store.getters.getLiveCache[channel.id]?.videos ?? []
+      const channelVideos = videos ?? store.getters.getLiveCache[channel.id]?.videos ?? []
+      return activeSubscriptionIds.has(channel.id) ? channelVideos : []
     }
 
     const videoListFromRemote = useRss
-      ? await fetchSubscriptionsConcurrently(activeSubscriptionList, fetchChannel)
-      : await fetchSubscriptionsInBatches(activeSubscriptionList, fetchChannel)
+      ? await fetchSubscriptionsConcurrently(subscriptionList, fetchChannel)
+      : await fetchSubscriptionsInBatches(subscriptionList, fetchChannel)
 
     store.dispatch('batchUpdateSubscriptionDetails', subscriptionUpdates)
 

--- a/src/renderer/helpers/subscriptions.js
+++ b/src/renderer/helpers/subscriptions.js
@@ -664,7 +664,7 @@ async function refreshSubscriptionVideosFromRemoteUnlocked({
           channelId: channel.id,
           videos
         })
-        await startAutomaticDownloadsForChannel(channel, videos, 'videos', t)
+        await startAutomaticDownloadsForChannel(channel, videos, 'videos', t, electronRefreshOwnerTabId)
         notifySubscriptionChannelRefreshed('videos')
       }
 
@@ -763,7 +763,7 @@ async function refreshSubscriptionShortsFromRemoteUnlocked({
           channelId: channel.id,
           videos
         })
-        await startAutomaticDownloadsForChannel(channel, videos, 'shorts', t)
+        await startAutomaticDownloadsForChannel(channel, videos, 'shorts', t, electronRefreshOwnerTabId)
         notifySubscriptionChannelRefreshed('shorts')
       }
 
@@ -866,7 +866,7 @@ async function refreshSubscriptionLiveFromRemoteUnlocked({
           channelId: channel.id,
           videos
         })
-        await startAutomaticDownloadsForChannel(channel, videos, 'live', t)
+        await startAutomaticDownloadsForChannel(channel, videos, 'live', t, electronRefreshOwnerTabId)
         notifySubscriptionChannelRefreshed('live')
       }
 

--- a/src/renderer/main.js
+++ b/src/renderer/main.js
@@ -90,12 +90,12 @@ if (process.env.IS_ELECTRON) {
   window.ftElectron.handleYtDlpDownloadStatus((download) => {
     store.commit('upsertYtDlpDownload', download)
 
-    if (download.status === 'completed') {
+    if (download.status === 'completed' && download.automatic !== true) {
       showToast({
         message: i18n.global.t('Downloads.Download Complete Template', { title: download.title }),
         icon: ['fas', 'download'],
       })
-    } else if (download.status === 'failed') {
+    } else if (download.status === 'failed' && download.automatic !== true) {
       showToast({
         message: download.errorMessage === 'ENOENT'
           ? i18n.global.t('Downloads.yt-dlp Not Found')

--- a/src/renderer/main.js
+++ b/src/renderer/main.js
@@ -7,6 +7,7 @@ import { initializeTabNavigationService } from './tabs/TabNavigationService'
 import { showExternalPlayerUnsupportedActionToast, showToast } from './helpers/utils'
 import { installViewTransitions } from './helpers/viewTransitions'
 import { initializeAppScrollbars, overlayScrollbarsDirective } from './helpers/overlayScrollbars'
+import { releaseAutomaticDownloadSchedule } from './helpers/automaticDownloads'
 // import the styles
 import 'overlayscrollbars/styles/overlayscrollbars.css'
 // Only the positioning and stacking rules are used, FtToast supplies the design
@@ -89,6 +90,7 @@ if (process.env.IS_ELECTRON) {
 
   window.ftElectron.handleYtDlpDownloadStatus((download) => {
     store.commit('upsertYtDlpDownload', download)
+    releaseAutomaticDownloadSchedule(download)
 
     if (download.status === 'completed' && download.automatic !== true) {
       showToast({

--- a/src/renderer/store/modules/profiles.js
+++ b/src/renderer/store/modules/profiles.js
@@ -244,10 +244,22 @@ const actions = {
     }
   },
 
-  async removeChannelFromProfiles({ commit }, { channelId, profileIds }) {
+  async removeChannelFromProfiles({ commit, dispatch, rootGetters }, { channelId, profileIds }) {
     try {
       await DBProfileHandlers.removeChannelFromProfiles(channelId, profileIds)
       commit('removeChannelFromProfiles', { channelId, profileIds })
+
+      if (profileIds.includes(MAIN_PROFILE_ID)) {
+        try {
+          const rules = JSON.parse(rootGetters.getYtDlpAutomaticDownloadRules || '{}')
+          if (rules !== null && typeof rules === 'object' && !Array.isArray(rules) && rules[channelId] !== undefined) {
+            delete rules[channelId]
+            await dispatch('updateYtDlpAutomaticDownloadRules', JSON.stringify(rules))
+          }
+        } catch (error) {
+          console.error('Failed to remove automatic download settings for the unsubscribed channel', error)
+        }
+      }
     } catch (errMessage) {
       console.error(errMessage)
     }

--- a/src/renderer/store/modules/settings.js
+++ b/src/renderer/store/modules/settings.js
@@ -250,6 +250,7 @@ const state = {
   ytDlpDownloadFolderPath: '',
   ytDlpDownloadTemplates: '[]',
   ytDlpSelectedTemplate: 'video:best',
+  ytDlpAutomaticDownloadRules: '{}',
   expandSideBar: false,
   hideActiveSubscriptions: false,
   hideChannelCommunity: false,

--- a/src/renderer/views/Downloads/DownloadRow.vue
+++ b/src/renderer/views/Downloads/DownloadRow.vue
@@ -212,6 +212,8 @@ const statusText = computed(() => {
         : t('Downloads.Download Complete')
     case 'cancelled':
       return t('Downloads.Download Cancelled')
+    case 'skipped':
+      return t('Downloads.Automatic Download Skipped')
     default:
       return t('Downloads.Download Failed')
   }

--- a/src/renderer/views/Downloads/Downloads.vue
+++ b/src/renderer/views/Downloads/Downloads.vue
@@ -9,7 +9,7 @@
       </p>
       <FtButton
         v-if="clearableDownloads.length > 0"
-        :label="t('Downloads.Clear Failed Canceled And Missing')"
+        :label="t('Downloads.Clear Failed Canceled Skipped And Missing')"
         :icon="['fas', 'trash']"
         :text-color="null"
         :background-color="null"

--- a/src/renderer/views/Downloads/Downloads.vue
+++ b/src/renderer/views/Downloads/Downloads.vue
@@ -88,7 +88,7 @@ const downloads = computed(() => Object.values(store.getters.getYtDlpDownloads).
 const activeDownloads = computed(() => downloads.value.filter(download => ['downloading', 'processing'].includes(download.status)))
 const finishedDownloads = computed(() => downloads.value.filter(download => !['downloading', 'processing'].includes(download.status)))
 const clearableDownloads = computed(() => finishedDownloads.value.filter(download => (
-  ['failed', 'cancelled'].includes(download.status) ||
+  ['failed', 'cancelled', 'skipped'].includes(download.status) ||
   (download.status === 'completed' && download.availability === 'missing')
 )))
 const totalSizeBytes = computed(() => downloads.value.reduce((total, download) => total + (download.sizeBytes ?? 0), 0))

--- a/static/locales/en-US.yaml
+++ b/static/locales/en-US.yaml
@@ -2216,7 +2216,7 @@ Downloads:
   Open Downloads: Open Downloads
   No Downloads: No downloads yet
   No Downloads Description: Downloads you start will appear here.
-  Clear Failed Canceled And Missing: Clear failed, canceled, and missing
+  Clear Failed Canceled Skipped And Missing: Clear failed, canceled, skipped, and missing
   Clear From List: Clear From List
   Show in Folder: Show in Folder
   Play Download: Play download
@@ -2268,6 +2268,7 @@ Downloads:
   Save Template: Save Template
   Delete Template: Delete Template
   Template Saved: 'Saved download template "{name}"'
+  Template Name Exists: 'A download template named "{name}" already exists.'
   Choose Folder: Change
   Select Folder: Choose Folder
   Folder Required: Choose a download folder to enable downloads.

--- a/static/locales/en-US.yaml
+++ b/static/locales/en-US.yaml
@@ -895,8 +895,32 @@ Settings:
     Managed Tools Download Error Template: 'Could not download the managed tools: {errors}'
     Download Folder: Download Folder
     Choose Download Folder: Choose Download Folder
-    Templates Hint: Custom download templates can be created and managed in the download prompt, which is located beneath the video player.
     External Software Hint: yt-dlp, FFmpeg, and FFprobe are configured in the External Software settings.
+    Download Templates: Download Templates
+    Manage Download Templates: 'Manage Download Templates ({templateCount})'
+    New Template: New Template
+    Template Source: Template to Edit or Use as a Base
+    Built-in Template: '{name} (Built-in)'
+    Custom Template Name: '{name} (Custom)'
+    Create Template Copy: Create Copy
+    Template Copy Name: '{name} Copy'
+    Automatic Downloads: Automatic Downloads
+    Manage Automatic Downloads: 'Manage Automatic Downloads ({channelCount})'
+    Automatic Downloads Description: Select a download template and filters for each subscribed channel. Matching videos download in the background when subscription feeds refresh.
+    Automatic Downloads New Only: Enabling a channel starts with its next new upload. Existing videos and the channel backlog are not downloaded.
+    Automatic Downloads No Channels: Subscribe to a channel before configuring automatic downloads.
+    Search Automatic Download Channels: Search channels
+    No Matching Automatic Download Channels: No channels match your search.
+    Automatic Downloads Videos: Videos
+    Automatic Downloads Livestreams: Livestreams
+    Minimum Duration Seconds: Minimum duration (seconds)
+    Maximum Duration Seconds: Maximum duration (seconds)
+    Minimum File Size MB: Minimum file size (MB)
+    Maximum File Size MB: Maximum file size (MB)
+    Maximum Age Days: Maximum age (days)
+    Title Includes: Title includes
+    Title Excludes: Title excludes
+    Title Filter Hint: Separate multiple title terms with commas. A video must match at least one included term and no excluded terms.
   External Software Settings:
     External Software Settings: External Software
     yt-dlp Source: yt-dlp Source
@@ -2252,6 +2276,12 @@ Downloads:
   Download Complete: Download complete
   Download Cancelled: Download canceled
   Download Failed: Download failed
+  Automatic Download Started: Automatic download started
+  Automatic Download Started Body: 'Downloading "{title}" from {channel} in the background.'
+  Automatic Download Complete: Automatic download complete
+  Automatic Download Failed: Automatic download failed
+  Automatic Download Could Not Start: 'Could not start the automatic download of "{title}".'
+  Automatic Download Skipped: Skipped by automatic download filters
   Cancel Download: Cancel Download
   yt-dlp Not Found: yt-dlp was not found. Install it or set its path in the Download Settings.
   Download Complete Template: 'Download of "{title}" has finished'

--- a/tests/unit/automatic-download-rules.test.mjs
+++ b/tests/unit/automatic-download-rules.test.mjs
@@ -1,0 +1,88 @@
+import assert from 'node:assert/strict'
+import test from 'node:test'
+
+import {
+  DEFAULT_AUTOMATIC_DOWNLOAD_RULE,
+  matchesAutomaticDownloadRule,
+  normalizeAutomaticDownloadRule,
+  parseAutomaticDownloadRules
+} from '../../src/renderer/helpers/automaticDownloadRules.js'
+
+const DAY = 24 * 60 * 60 * 1000
+const now = Date.parse('2026-08-14T12:00:00Z')
+
+function video(extra = {}) {
+  return {
+    videoId: 'abcdefghijk',
+    title: 'Weekly Open Source Roundup',
+    published: now - DAY,
+    lengthSeconds: 600,
+    isNewInSubscriptionFeed: true,
+    ...extra
+  }
+}
+
+test('parses and normalizes automatic download rules', () => {
+  assert.deepEqual(parseAutomaticDownloadRules(''), {})
+  assert.deepEqual(parseAutomaticDownloadRules('[]'), {})
+  assert.deepEqual(normalizeAutomaticDownloadRule({
+    includeVideos: false,
+    includeShorts: true,
+    minDurationSeconds: '30',
+    maxFileSizeMb: 0,
+    titleIncludes: null
+  }), {
+    ...DEFAULT_AUTOMATIC_DOWNLOAD_RULE,
+    includeVideos: false,
+    includeShorts: true,
+    minDurationSeconds: 30,
+    maxFileSizeMb: null,
+    titleIncludes: ''
+  })
+})
+
+test('only admits entries announced after the rule was enabled', () => {
+  const rule = { enabledAt: now - 2 * DAY }
+
+  assert.equal(matchesAutomaticDownloadRule(video(), 'videos', rule, now), true)
+  assert.equal(matchesAutomaticDownloadRule(video({ published: now - 3 * DAY }), 'videos', rule, now), false)
+  assert.equal(matchesAutomaticDownloadRule(video({ isNewInSubscriptionFeed: false }), 'videos', rule, now), false)
+  assert.equal(matchesAutomaticDownloadRule(video({ published: undefined }), 'videos', rule, now), false)
+})
+
+test('applies content-type, duration, age, and title filters', () => {
+  const rule = {
+    enabledAt: now - 10 * DAY,
+    includeVideos: true,
+    includeShorts: false,
+    includeLivestreams: false,
+    minDurationSeconds: 300,
+    maxDurationSeconds: 900,
+    maxAgeDays: 2,
+    titleIncludes: 'linux, open source',
+    titleExcludes: 'sponsored, trailer'
+  }
+
+  assert.equal(matchesAutomaticDownloadRule(video(), 'videos', rule, now), true)
+  assert.equal(matchesAutomaticDownloadRule(video({ lengthSeconds: '2:00' }), 'videos', rule, now), false)
+  assert.equal(matchesAutomaticDownloadRule(video({ lengthSeconds: 1200 }), 'videos', rule, now), false)
+  assert.equal(matchesAutomaticDownloadRule(video({ published: now - 3 * DAY }), 'videos', rule, now), false)
+  assert.equal(matchesAutomaticDownloadRule(video({ title: 'A sponsored open source roundup' }), 'videos', rule, now), false)
+  assert.equal(matchesAutomaticDownloadRule(video({ title: 'Unrelated update' }), 'videos', rule, now), false)
+  assert.equal(matchesAutomaticDownloadRule(video(), 'shorts', rule, now), false)
+  assert.equal(matchesAutomaticDownloadRule(video({ liveNow: true }), 'videos', rule, now), false)
+})
+
+test('allows opted-in Shorts and started livestreams but not upcoming streams', () => {
+  const rule = {
+    enabledAt: now - 2 * DAY,
+    includeVideos: false,
+    includeShorts: true,
+    includeLivestreams: true
+  }
+
+  assert.equal(matchesAutomaticDownloadRule(video(), 'shorts', rule, now), true)
+  assert.equal(matchesAutomaticDownloadRule(video({ liveNow: true }), 'live', rule, now), true)
+  assert.equal(matchesAutomaticDownloadRule(video({ isUpcoming: true }), 'live', rule, now), false)
+  assert.equal(matchesAutomaticDownloadRule(video({ premiere: true }), 'videos', rule, now), false)
+})

--- a/tests/unit/automatic-download-rules.test.mjs
+++ b/tests/unit/automatic-download-rules.test.mjs
@@ -11,7 +11,7 @@ import {
 const DAY = 24 * 60 * 60 * 1000
 const now = Date.parse('2026-08-14T12:00:00Z')
 
-function video(extra = {}) {
+function video (extra = {}) {
   return {
     videoId: 'abcdefghijk',
     title: 'Weekly Open Source Roundup',
@@ -66,6 +66,7 @@ test('applies content-type, duration, age, and title filters', () => {
   assert.equal(matchesAutomaticDownloadRule(video(), 'videos', rule, now), true)
   assert.equal(matchesAutomaticDownloadRule(video({ lengthSeconds: '2:00' }), 'videos', rule, now), false)
   assert.equal(matchesAutomaticDownloadRule(video({ lengthSeconds: 1200 }), 'videos', rule, now), false)
+  assert.equal(matchesAutomaticDownloadRule(video({ lengthSeconds: '0:00' }), 'videos', rule, now), true)
   assert.equal(matchesAutomaticDownloadRule(video({ published: now - 3 * DAY }), 'videos', rule, now), false)
   assert.equal(matchesAutomaticDownloadRule(video({ title: 'A sponsored open source roundup' }), 'videos', rule, now), false)
   assert.equal(matchesAutomaticDownloadRule(video({ title: 'Unrelated update' }), 'videos', rule, now), false)

--- a/tests/unit/download-templates.test.mjs
+++ b/tests/unit/download-templates.test.mjs
@@ -1,7 +1,12 @@
 import assert from 'node:assert/strict'
 import test from 'node:test'
 
-import { DEFAULT_DOWNLOAD_TEMPLATES, downloadTemplateName } from '../../src/renderer/helpers/downloadTemplates.js'
+import {
+  DEFAULT_DOWNLOAD_TEMPLATES,
+  downloadTemplateName,
+  getDownloadTemplateOptions,
+  replaceAutomaticDownloadTemplateReferences
+} from '../../src/renderer/helpers/downloadTemplates.js'
 
 /** the en-US strings the template labels are built from */
 const MESSAGES = {
@@ -34,6 +39,41 @@ test('has no name for downloads that did not use a template', () => {
   // options edited after loading a template are reported as template-less
   assert.equal(downloadTemplateName('unsaved', t), '')
   assert.equal(downloadTemplateName('video:9999', t), '')
+})
+
+test('resolves built-in, current custom, and legacy custom template options', () => {
+  assert.deepEqual(getDownloadTemplateOptions('audio:mp3'), {
+    mode: 'audio',
+    audioFormat: 'mp3',
+    embedThumbnail: true,
+    embedMetadata: true
+  })
+  assert.deepEqual(getDownloadTemplateOptions('template:Podcast', [{
+    name: 'Podcast',
+    options: { mode: 'audio', audioFormat: 'opus' }
+  }]), { mode: 'audio', audioFormat: 'opus' })
+  assert.deepEqual(getDownloadTemplateOptions('template:Legacy', [{
+    name: 'Legacy',
+    args: '--write-description'
+  }]), { mode: 'video', customArgs: '--write-description' })
+  assert.equal(getDownloadTemplateOptions('template:Missing', []), null)
+})
+
+test('moves automatic download rules away from renamed or deleted templates', () => {
+  const rules = JSON.stringify({
+    first: { template: 'template:Old', includeVideos: true },
+    second: { template: 'video:720', includeVideos: true }
+  })
+
+  assert.deepEqual(JSON.parse(replaceAutomaticDownloadTemplateReferences(
+    rules,
+    'template:Old',
+    'template:New'
+  )), {
+    first: { template: 'template:New', includeVideos: true },
+    second: { template: 'video:720', includeVideos: true }
+  })
+  assert.equal(replaceAutomaticDownloadTemplateReferences(rules, 'template:Missing', 'video:best'), rules)
 })
 
 test('every template has a unique value and a translatable label', () => {


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Make sure to follow the contributing guidelines. -->
<!-- Important note, we may remove your pull request if you do not use this provided PR template correctly. -->
<!-- Agent instructions: Preserve every heading, comment, and marker in this template. Never remove or rewrite the release-note-category:start/end, release-note:start/end, or release-note-image:start/end marker pairs. Never remove or rewrite the Release note images section; leave its contents for a human. -->

## Pull Request Type
<!-- Please select what type of pull request this is: [x] -->
- [ ] Bugfix
- [x] Feature Implementation
- [ ] Documentation
- [ ] Other

## Related issue
<!-- Please link the issue your pull request is referring to. -->
<!-- If this pull request fully resolves the relevant issue, put "closes" before the issue number. -->
<!-- Example: "closes #123456". -->

Closes #626

## Description
<!-- Please write a clear and concise description of what the pull request does. -->

New uploads from subscribed channels previously had to be downloaded manually, and custom download templates could only be managed from a video's download prompt.

This adds per-channel automatic download rules that run during subscription refreshes, start downloads in the background, show system notifications, and remember completed or filtered videos to prevent duplicate attempts. Each channel can select a built-in or custom template, choose videos, Shorts, and livestreams, and filter by duration, estimated file size, upload age, or title terms.

Download settings now also include a complete custom template manager. Templates can be created from scratch or from a built-in/custom template, copied, renamed, and deleted, with automatic-download references kept valid. The automatic-download manager includes channel search and a compact, aligned template/media-type row.

## Release note category
<!-- Select exactly one category. Every pull request must select one. -->
<!-- Select "Not noteworthy" when the pull request fixes a bug in or improves functionality that has not yet appeared in a stable release. -->
<!-- release-note-category:start -->
- [ ] Not noteworthy
- [ ] Highlights
- [x] More improvements
- [ ] Fixed bugs
<!-- release-note-category:end -->

## Release note
<!-- Required unless "Not noteworthy" is selected. -->
<!-- Write one concise, user-facing entry without a leading bullet. -->
<!-- release-note:start -->
Automatically download new uploads from selected channels using per-channel templates and filters.
<!-- release-note:end -->

## Release note images
<!-- Human-only: Agents must preserve this entire section and leave it empty. -->
<!-- Optional. Paste one or more Markdown images or HTML image tags here. -->
<!-- The release notes will use an HTML image tag and limit images taller than 300 pixels. -->
<!-- release-note-image:start -->
<img width="1340" height="762" alt="image" src="https://github.com/user-attachments/assets/39df3b81-e95e-456c-887d-b2e634b76276" />
<!-- release-note-image:end -->

## Testing
<!-- How can reviewers verify that the PR produces correct results? -->
<!-- Please provide instructions so that others can ensure that your pull request would produce correct results. For examples see, https://github.com/FreeTubeApp/FreeTube/pull/5743, https://github.com/FreeTubeApp/FreeTube/pull/7349, https://github.com/FreeTubeApp/FreeTube/pull/5125, https://github.com/FreeTubeApp/FreeTube/pull/7338 -->
<!-- Agent instructions: Only write human-facing steps that explain how to verify the change while running this branch in dev mode. Include expected results and, when applicable, helpful console snippets for interactive verification. Do not include automated checks, commands, results, pass counts, or CI status. -->

1. Open Settings → Downloads → Manage Download Templates. Create a template using a built-in template as the base, save it, create a copy, rename it, and delete it. The template list and any automatic-download references should update immediately.
2. Open Manage Automatic Downloads, search for a subscribed channel, enable it, and configure its template, media types, and filters. Close and reopen the manager; the rule should remain selected with the same values.
3. Refresh subscriptions after the configured channel publishes a new matching upload. The download should start without focusing a download prompt, a system notification should announce its progress, and the item should appear in Downloads. Repeated refreshes should not download the same video again.
4. Confirm that uploads which predate enabling the channel, or which do not satisfy the configured duration, size, age, media-type, or title filters, are not downloaded.

## Additional context
<!-- Add any other context about the pull request here. -->
