### PR TITLE
feat(dev): isolate worktree sessions

### DIFF
--- a/_scripts/dev-runner.js
+++ b/_scripts/dev-runner.js
@@ -6,7 +6,11 @@ const WebpackDevServer = require('webpack-dev-server')
 const kill = require('@magda/tree-kill')
 
 const path = require('path')
+const { createHash } = require('crypto')
 const { spawn } = require('child_process')
+const { mkdirSync, realpathSync } = require('fs')
+const { tmpdir } = require('os')
+const net = require('net')
 
 const ProcessLocalesPlugin = require('./ProcessLocalesPlugin')
 
@@ -20,6 +24,7 @@ const manualRestartResetMs = 2500
 
 const remoteDebugging = process.argv.indexOf('--remote-debug') !== -1
 const web = process.argv.indexOf('--web') !== -1
+const worktree = process.argv.indexOf('--worktree') !== -1
 
 let mainConfig
 let rendererConfig
@@ -27,18 +32,6 @@ let preloadConfig
 let botGuardScriptConfig
 let webConfig
 let SHAKA_LOCALES_TO_BE_BUNDLED
-
-if (!web) {
-  mainConfig = require('./webpack.main.config')
-  rendererConfig = require('./webpack.renderer.config')
-  preloadConfig = require('./webpack.preload.config.js')
-  botGuardScriptConfig = require('./webpack.botGuardScript.config')
-
-  SHAKA_LOCALES_TO_BE_BUNDLED = rendererConfig.SHAKA_LOCALES_TO_BE_BUNDLED
-  delete rendererConfig.SHAKA_LOCALES_TO_BE_BUNDLED
-} else {
-  webConfig = require('./webpack.web.config')
-}
 
 if (remoteDebugging) {
   // disable dvtools open in electron
@@ -49,7 +42,56 @@ if (remoteDebugging) {
 const relaunchExitCode = 69
 process.env.OPENTUBEX_RELAUNCH_EXIT_CODE = relaunchExitCode
 
-const port = 9080
+let port = 9080
+
+function findAvailablePort() {
+  return new Promise((resolve, reject) => {
+    const server = net.createServer()
+    server.unref()
+    server.on('error', reject)
+    server.listen(0, 'localhost', () => {
+      const address = server.address()
+      server.close(error => {
+        if (error) {
+          reject(error)
+        } else if (typeof address === 'object' && address !== null) {
+          resolve(address.port)
+        } else {
+          reject(new Error('Unable to allocate a development server port'))
+        }
+      })
+    })
+  })
+}
+
+async function configureWorktree() {
+  port = await findAvailablePort()
+
+  const projectPath = realpathSync(path.resolve(__dirname, '..'))
+  const profileId = createHash('sha256').update(projectPath).digest('hex').slice(0, 12)
+  const profilePath = path.join(tmpdir(), `opentubex-dev-${profileId}`)
+  mkdirSync(profilePath, { recursive: true, mode: 0o700 })
+
+  process.env.OPENTUBEX_DEV_SERVER_PORT = String(port)
+  process.env.OPENTUBEX_DEV_USER_DATA_DIR = profilePath
+
+  console.log(`Using development server port ${port}`)
+  console.log(`Using worktree profile ${profilePath}`)
+}
+
+function loadWebpackConfigs() {
+  if (!web) {
+    mainConfig = require('./webpack.main.config')
+    rendererConfig = require('./webpack.renderer.config')
+    preloadConfig = require('./webpack.preload.config.js')
+    botGuardScriptConfig = require('./webpack.botGuardScript.config')
+
+    SHAKA_LOCALES_TO_BE_BUNDLED = rendererConfig.SHAKA_LOCALES_TO_BE_BUNDLED
+    delete rendererConfig.SHAKA_LOCALES_TO_BE_BUNDLED
+  } else {
+    webConfig = require('./webpack.web.config')
+  }
+}
 
 async function killElectron(pid) {
   return new Promise((resolve, reject) => {
@@ -281,12 +323,22 @@ function startWeb () {
     console.log(`\nCompiled ${name} script!\n\nWatching file changes for ${name} script...`)
   })
 }
-if (!web) {
-  startRenderer(() => {
-    startBotGuardScript()
-    startPreload()
-    startMain()
-  })
-} else {
-  startWeb()
+async function start() {
+  if (worktree) await configureWorktree()
+  loadWebpackConfigs()
+
+  if (!web) {
+    startRenderer(() => {
+      startBotGuardScript()
+      startPreload()
+      startMain()
+    })
+  } else {
+    startWeb()
+  }
 }
+
+start().catch(error => {
+  console.error(error)
+  process.exitCode = 1
+})

--- a/_scripts/dev-runner.js
+++ b/_scripts/dev-runner.js
@@ -283,7 +283,7 @@ function startRenderer(callback) {
 
   let firstTime = true
 
-  compiler.watch({ aggregateTimeout: 250 }, (err, result) => {
+  const watching = compiler.watch({ aggregateTimeout: 250 }, (err, result) => {
     if (err) console.error(err)
 
     if (result) {
@@ -296,7 +296,9 @@ function startRenderer(callback) {
       firstTime = false
       getListeningPort(server).then(callback).catch(error => {
         console.error(error)
-        process.exitCode = 1
+        watching.close(() => {
+          process.exitCode = 1
+        })
       })
     }
   })

--- a/_scripts/dev-runner.js
+++ b/_scripts/dev-runner.js
@@ -10,7 +10,6 @@ const { createHash } = require('crypto')
 const { spawn } = require('child_process')
 const { mkdirSync, realpathSync } = require('fs')
 const { tmpdir } = require('os')
-const net = require('net')
 
 const ProcessLocalesPlugin = require('./ProcessLocalesPlugin')
 
@@ -44,39 +43,49 @@ process.env.OPENTUBEX_RELAUNCH_EXIT_CODE = relaunchExitCode
 
 let port = 9080
 
-function findAvailablePort() {
-  return new Promise((resolve, reject) => {
-    const server = net.createServer()
-    server.unref()
-    server.on('error', reject)
-    server.listen(0, 'localhost', () => {
-      const address = server.address()
-      server.close(error => {
-        if (error) {
-          reject(error)
-        } else if (typeof address === 'object' && address !== null) {
-          resolve(address.port)
-        } else {
-          reject(new Error('Unable to allocate a development server port'))
-        }
-      })
-    })
-  })
-}
-
-async function configureWorktree() {
-  port = await findAvailablePort()
-
+function configureWorktree() {
+  // Let the operating system atomically assign the port when the development
+  // server starts, instead of probing a port that another process could claim.
+  port = 0
   const projectPath = realpathSync(path.resolve(__dirname, '..'))
   const profileId = createHash('sha256').update(projectPath).digest('hex').slice(0, 12)
   const profilePath = path.join(tmpdir(), `opentubex-dev-${profileId}`)
   mkdirSync(profilePath, { recursive: true, mode: 0o700 })
 
-  process.env.OPENTUBEX_DEV_SERVER_PORT = String(port)
   process.env.OPENTUBEX_DEV_USER_DATA_DIR = profilePath
 
-  console.log(`Using development server port ${port}`)
   console.log(`Using worktree profile ${profilePath}`)
+}
+
+/** @param {WebpackDevServer} devServer */
+function getListeningPort(devServer) {
+  return new Promise((resolve, reject) => {
+    const server = devServer.server
+    if (!server) {
+      reject(new Error('Development server was not created'))
+      return
+    }
+
+    const onError = error => {
+      server.off('listening', onListening)
+      reject(error)
+    }
+    const onListening = () => {
+      server.off('error', onError)
+      const address = server.address()
+      if (typeof address === 'object' && address !== null) {
+        resolve(address.port)
+      } else {
+        reject(new Error('Unable to determine the development server port'))
+      }
+    }
+
+    if (server.listening) onListening()
+    else {
+      server.once('error', onError)
+      server.once('listening', onListening)
+    }
+  })
 }
 
 function loadWebpackConfigs() {
@@ -285,7 +294,10 @@ function startRenderer(callback) {
 
     if (firstTime) {
       firstTime = false
-      callback()
+      getListeningPort(server).then(callback).catch(error => {
+        console.error(error)
+        process.exitCode = 1
+      })
     }
   })
 }
@@ -324,11 +336,15 @@ function startWeb () {
   })
 }
 async function start() {
-  if (worktree) await configureWorktree()
+  if (worktree) configureWorktree()
   loadWebpackConfigs()
 
   if (!web) {
-    startRenderer(() => {
+    startRenderer(devServerPort => {
+      if (worktree) {
+        process.env.OPENTUBEX_DEV_SERVER_PORT = String(devServerPort)
+        console.log(`Using development server port ${devServerPort}`)
+      }
       startBotGuardScript()
       startPreload()
       startMain()

--- a/_scripts/webpack.renderer.config.js
+++ b/_scripts/webpack.renderer.config.js
@@ -158,6 +158,7 @@ const config = {
       'process.env.IS_ELECTRON': true,
       'process.env.IS_ELECTRON_MAIN': false,
       'process.env.SUPPORTS_LOCAL_API': true,
+      'process.env.OPENTUBEX_DEV_SERVER_PORT': JSON.stringify(process.env.OPENTUBEX_DEV_SERVER_PORT ?? '9080'),
       'process.env.BUILD_COMMIT': JSON.stringify(process.env.GITHUB_SHA ?? ''),
       __VUE_OPTIONS_API__: 'true',
       __VUE_PROD_DEVTOOLS__: 'false',

--- a/_scripts/webpack.renderer.config.js
+++ b/_scripts/webpack.renderer.config.js
@@ -158,7 +158,6 @@ const config = {
       'process.env.IS_ELECTRON': true,
       'process.env.IS_ELECTRON_MAIN': false,
       'process.env.SUPPORTS_LOCAL_API': true,
-      'process.env.OPENTUBEX_DEV_SERVER_PORT': JSON.stringify(process.env.OPENTUBEX_DEV_SERVER_PORT ?? '9080'),
       'process.env.BUILD_COMMIT': JSON.stringify(process.env.GITHUB_SHA ?? ''),
       __VUE_OPTIONS_API__: 'true',
       __VUE_PROD_DEVTOOLS__: 'false',

--- a/package.json
+++ b/package.json
@@ -29,6 +29,7 @@
     "clean": "node _scripts/clean.mjs",
     "debug": "node _scripts/dev-runner.js --remote-debug",
     "dev": "node _scripts/dev-runner.js",
+    "dev:worktree": "node _scripts/dev-runner.js --worktree",
     "dev:web": "node _scripts/dev-runner.js --web",
     "get-instances": "node _scripts/getInstances.js",
     "get-regions": "node _scripts/getRegions.mjs",

--- a/src/main/e2eUserDataOverride.js
+++ b/src/main/e2eUserDataOverride.js
@@ -1,9 +1,11 @@
 import { app } from 'electron'
 
-// Allows E2E tests to isolate their data from the user's real profile.
+// Allows E2E tests and worktree development servers to isolate their data from
+// the user's real profile.
 // This lives in its own module imported first by main/index.js, because it
 // must run before any module that resolves app.getPath('userData') at import
 // time (e.g. src/datastores/index.js).
-if (process.env.OPENTUBEX_E2E_USER_DATA_DIR) {
-  app.setPath('userData', process.env.OPENTUBEX_E2E_USER_DATA_DIR)
+const userDataPath = process.env.OPENTUBEX_E2E_USER_DATA_DIR ?? process.env.OPENTUBEX_DEV_USER_DATA_DIR
+if (userDataPath) {
+  app.setPath('userData', userDataPath)
 }

--- a/src/main/index.js
+++ b/src/main/index.js
@@ -127,7 +127,8 @@ function runApp() {
       : []),
   ])
 
-  const ROOT_APP_URL = process.env.NODE_ENV === 'development' ? 'http://localhost:9080' : 'app://bundle/index.html'
+  const devServerPort = process.env.OPENTUBEX_DEV_SERVER_PORT ?? '9080'
+  const ROOT_APP_URL = process.env.NODE_ENV === 'development' ? `http://localhost:${devServerPort}` : 'app://bundle/index.html'
   const CUSTOM_THEMES_PATH = path.join(app.getPath('userData'), CUSTOM_THEMES_DIRECTORY)
 
   function getCustomThemePath(id) {

--- a/src/main/utils.js
+++ b/src/main/utils.js
@@ -115,7 +115,8 @@ export function isOpenTubeXUrl(url) {
   }
 
   if (process.env.NODE_ENV === 'development') {
-    return url_ !== null && url_.protocol === 'http:' && url_.host === 'localhost:9080' && (url_.pathname === '/' || url_.pathname === '/index.html')
+    const devServerPort = process.env.OPENTUBEX_DEV_SERVER_PORT ?? '9080'
+    return url_ !== null && url_.protocol === 'http:' && url_.host === `localhost:${devServerPort}` && (url_.pathname === '/' || url_.pathname === '/index.html')
   } else {
     return url_ !== null && url_.protocol === 'app:' && url_.host === 'bundle' && (url_.pathname === '/' || url_.pathname === '/index.html')
   }

--- a/src/renderer/i18n/index.js
+++ b/src/renderer/i18n/index.js
@@ -56,7 +56,7 @@ export async function loadLocale(locale) {
 
 // Set by _scripts/ProcessLocalesPlugin.js
 if (process.env.HOT_RELOAD_LOCALES) {
-  const websocket = new WebSocket(`ws://localhost:${process.env.OPENTUBEX_DEV_SERVER_PORT}/ws`)
+  const websocket = new WebSocket(`ws://${window.location.host}/ws`)
 
   websocket.onmessage = (event) => {
     const message = JSON.parse(event.data)

--- a/src/renderer/i18n/index.js
+++ b/src/renderer/i18n/index.js
@@ -56,7 +56,7 @@ export async function loadLocale(locale) {
 
 // Set by _scripts/ProcessLocalesPlugin.js
 if (process.env.HOT_RELOAD_LOCALES) {
-  const websocket = new WebSocket('ws://localhost:9080/ws')
+  const websocket = new WebSocket(`ws://localhost:${process.env.OPENTUBEX_DEV_SERVER_PORT}/ws`)
 
   websocket.onmessage = (event) => {
     const message = JSON.parse(event.data)

--- a/tests/unit/proxy-url.test.mjs
+++ b/tests/unit/proxy-url.test.mjs
@@ -1,7 +1,7 @@
 import assert from 'node:assert/strict'
 import test from 'node:test'
 
-import { buildProxyUrl, isNonPublicNetworkAddress } from '../../src/main/utils.js'
+import { buildProxyUrl, isNonPublicNetworkAddress, isOpenTubeXUrl } from '../../src/main/utils.js'
 
 test('identifies network addresses which are unsafe for untrusted fetches', () => {
   for (const address of [
@@ -23,7 +23,6 @@ test('identifies network addresses which are unsafe for untrusted fetches', () =
     assert.equal(isNonPublicNetworkAddress(address), false, address)
   }
 })
-
 test('builds a proxy URL from the proxy settings', () => {
   assert.equal(buildProxyUrl({
     protocol: 'socks5',
@@ -94,4 +93,44 @@ test('falls back to the default proxy settings', () => {
   assert.equal(buildProxyUrl({ protocol: 'http', port: '8080' }), 'http://127.0.0.1:8080')
   assert.equal(buildProxyUrl({ protocol: '', hostname: '', port: '' }), 'socks5://127.0.0.1:9050')
   assert.equal(buildProxyUrl({ username: 'user', password: 'pass' }), 'socks5://user:pass@127.0.0.1:9050')
+})
+
+test('recognizes the configured development server origin', () => {
+  const previousNodeEnv = process.env.NODE_ENV
+  const previousPort = process.env.OPENTUBEX_DEV_SERVER_PORT
+
+  try {
+    process.env.NODE_ENV = 'development'
+    process.env.OPENTUBEX_DEV_SERVER_PORT = '12345'
+
+    assert.equal(isOpenTubeXUrl('http://localhost:12345/'), true)
+    assert.equal(isOpenTubeXUrl('http://localhost:12345/index.html'), true)
+    assert.equal(isOpenTubeXUrl('http://localhost:9080/'), false)
+    assert.equal(isOpenTubeXUrl('http://127.0.0.1:12345/'), false)
+  } finally {
+    if (previousNodeEnv === undefined) delete process.env.NODE_ENV
+    else process.env.NODE_ENV = previousNodeEnv
+
+    if (previousPort === undefined) delete process.env.OPENTUBEX_DEV_SERVER_PORT
+    else process.env.OPENTUBEX_DEV_SERVER_PORT = previousPort
+  }
+})
+
+test('uses the default development server origin without an override', () => {
+  const previousNodeEnv = process.env.NODE_ENV
+  const previousPort = process.env.OPENTUBEX_DEV_SERVER_PORT
+
+  try {
+    process.env.NODE_ENV = 'development'
+    delete process.env.OPENTUBEX_DEV_SERVER_PORT
+
+    assert.equal(isOpenTubeXUrl('http://localhost:9080/'), true)
+    assert.equal(isOpenTubeXUrl('http://localhost:12345/'), false)
+  } finally {
+    if (previousNodeEnv === undefined) delete process.env.NODE_ENV
+    else process.env.NODE_ENV = previousNodeEnv
+
+    if (previousPort === undefined) delete process.env.OPENTUBEX_DEV_SERVER_PORT
+    else process.env.OPENTUBEX_DEV_SERVER_PORT = previousPort
+  }
 })


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Make sure to follow the contributing guidelines. -->
<!-- Important note, we may remove your pull request if you do not use this provided PR template correctly. -->
<!-- Agent instructions: Preserve every heading, comment, and marker in this template. Never remove or rewrite the release-note-category:start/end, release-note:start/end, or release-note-image:start/end marker pairs. Never remove or rewrite the Release note images section; leave its contents for a human. -->

## Pull Request Type
<!-- Please select what type of pull request this is: [x] -->
- [ ] Bugfix
- [x] Feature Implementation
- [ ] Documentation
- [ ] Other

## Related issue
<!-- Please link the issue your pull request is referring to. -->
<!-- If this pull request fully resolves the relevant issue, put "closes" before the issue number. -->
<!-- Example: "closes #123456". -->

## Description
<!-- Please write a clear and concise description of what the pull request does. -->

Multiple worktrees could not run Electron development windows concurrently because every dev server used port 9080 and every window shared the regular Electron profile.

Add `pnpm dev:worktree`, which allocates a free renderer port and creates a persistent temporary profile keyed by the canonical worktree path. The selected port is shared with Electron URL loading, trusted-origin validation, and locale hot reload so each worktree remains internally consistent and isolated.

The existing `pnpm dev` behavior remains unchanged.

## Release note category
<!-- Select exactly one category. Every pull request must select one. -->
<!-- Select "Not noteworthy" when the pull request fixes a bug in or improves functionality that has not yet appeared in a stable release. -->
<!-- release-note-category:start -->
- [x] Not noteworthy
- [ ] Highlights
- [ ] More improvements
- [ ] Fixed bugs
<!-- release-note-category:end -->

## Release note
<!-- Required unless "Not noteworthy" is selected. -->
<!-- Write one concise, user-facing entry without a leading bullet. -->
<!-- release-note:start -->

<!-- release-note:end -->

## Release note images
<!-- Human-only: Agents must preserve this entire section and leave it empty. -->
<!-- Optional. Paste one or more Markdown images or HTML image tags here. -->
<!-- The release notes will use an HTML image tag and limit images taller than 300 pixels. -->
<!-- release-note-image:start -->

<!-- release-note-image:end -->

## Testing
<!-- How can reviewers verify that the PR produces correct results? -->
<!-- Please provide instructions so that others can ensure that your pull request produces correct results. For examples see, https://github.com/FreeTubeApp/FreeTube/pull/5743, https://github.com/FreeTubeApp/FreeTube/pull/7349, https://github.com/FreeTubeApp/FreeTube/pull/5125, https://github.com/FreeTubeApp/FreeTube/pull/7338 -->
<!-- Agent instructions: Only write human-facing steps that explain how to verify the change while running this branch in dev mode. Include expected results and, when applicable, helpful console snippets for interactive verification. Do not include automated checks, commands, results, pass counts, or CI status. -->

1. In two different worktrees, run `pnpm dev:worktree`.
2. Confirm each terminal prints a different development server port and profile directory.
3. Confirm both Electron windows open and remain usable at the same time.
4. Close and rerun one worktree's command. Confirm it prints the same profile directory and retains that worktree's settings.
5. Run `pnpm dev` by itself and confirm it still uses port 9080.

## Additional context
<!-- Add any other context about the pull request here. -->

The isolated profile lives under the operating system's temporary directory. It persists across command reruns but may be removed by normal operating-system temporary-file cleanup.
