### PR TITLE
feat(tabs): add configurable tab layouts

### DIFF
--- a/e2e/tests/network/watch.spec.mjs
+++ b/e2e/tests/network/watch.spec.mjs
@@ -632,7 +632,7 @@ test.describe('watch page', () => {
 
     await page.evaluate(() => {
       const store = document.querySelector('#app').__vue_app__.config.globalProperties.$store
-      store.commit('setUseVerticalTabBar', true)
+      store.commit('setTabBarPosition', 'left')
       store.commit('setVerticalTabBarWidth', 180)
     })
     await expect(page.locator('.app')).toHaveClass(/verticalTabs/)
@@ -676,7 +676,7 @@ test.describe('watch page', () => {
 
     await page.evaluate(() => {
       const store = document.querySelector('#app').__vue_app__.config.globalProperties.$store
-      store.commit('setUseVerticalTabBar', false)
+      store.commit('setTabBarPosition', 'top')
     })
     await expect(page.locator('.app')).not.toHaveClass(/verticalTabs/)
     await expect.poll(async () => {

--- a/e2e/tests/offline/appearance.spec.mjs
+++ b/e2e/tests/offline/appearance.spec.mjs
@@ -22,7 +22,7 @@ async function setWindowWidth (app, width) {
 async function enableVerticalTabBar (page, width) {
   await page.evaluate((tabBarWidth) => {
     const store = document.querySelector('#app').__vue_app__.config.globalProperties.$store
-    store.commit('setUseVerticalTabBar', true)
+    store.commit('setTabBarPosition', 'left')
     store.commit('setVerticalTabBarWidth', tabBarWidth)
   }, width)
   await expect(page.locator('.app')).toHaveClass(/verticalTabs/)
@@ -39,6 +39,36 @@ async function expectAdjacent (left, right) {
   expect(Math.abs(leftBox.y - rightBox.y)).toBeLessThan(1)
   expect(rightBox.x - leftBox.x - leftBox.width).toBeGreaterThanOrEqual(0)
   expect(rightBox.x - leftBox.x - leftBox.width).toBeLessThanOrEqual(12)
+}
+
+async function getTabEdgeBorderCoverage (page, tab, edge, inset = 0) {
+  const [screenshot, borderColor] = await Promise.all([
+    tab.screenshot(),
+    tab.evaluate((element, targetEdge) => {
+      const style = getComputedStyle(element)
+      return targetEdge === 'top' ? style.borderTopColor : style.borderBottomColor
+    }, edge)
+  ])
+
+  return page.evaluate(async ({ base64, borderColor, edge, inset }) => {
+    const bytes = Uint8Array.from(atob(base64), character => character.charCodeAt(0))
+    const bitmap = await createImageBitmap(new Blob([bytes], { type: 'image/png' }))
+    const canvas = new OffscreenCanvas(bitmap.width, bitmap.height)
+    const context = canvas.getContext('2d')
+    context.drawImage(bitmap, 0, 0)
+
+    const target = borderColor.match(/\d+/g).slice(0, 3).map(Number)
+    const row = edge === 'top' ? inset : bitmap.height - 1 - inset
+    const pixels = context.getImageData(0, row, bitmap.width, 1).data
+    let matchingPixels = 0
+    for (let offset = 0; offset < pixels.length; offset += 4) {
+      if (target.every((channel, index) => Math.abs(channel - pixels[offset + index]) <= 8)) {
+        matchingPixels++
+      }
+    }
+
+    return matchingPixels / bitmap.width
+  }, { base64: screenshot.toString('base64'), borderColor, edge, inset })
 }
 
 test.describe('distraction and appearance settings', () => {
@@ -80,6 +110,66 @@ test.describe('default appearance', () => {
     await expect(page.locator('.topNav .profileTrigger')).toBeVisible()
     await expect(page.locator('body')).toHaveClass(/(?:light|dark)/)
     await attachScreenshot('default appearance')
+  })
+
+  test('selects every tab layout from Theme settings instead of the header', async ({ page, attachScreenshot }) => {
+    await expect(page.locator('.navTabLayoutButton')).toHaveCount(0)
+    const themeSection = await goToSettingsSection(page, 'theme')
+    const layout = themeSection.getByRole('combobox', { name: 'Tab Layout' })
+    await expect(layout).toHaveText('Horizontal at top')
+    for (const [label, className] of [
+      ['Horizontal at bottom', 'position-bottom'],
+      ['Vertical on left', 'position-left'],
+      ['Vertical on right', 'position-right'],
+      ['Horizontal at top', 'position-top']
+    ]) {
+      await layout.click()
+      await page.locator(`#${await layout.getAttribute('aria-controls')}`)
+        .getByRole('option', { name: label, exact: true }).click()
+      const tabBar = page.locator(`.tabBar.${className}`)
+      await expect(tabBar).toBeVisible()
+      await expect(layout).toHaveText(label)
+
+      if (className === 'position-bottom' || className === 'position-top') {
+        const activeTab = tabBar.locator('.tab.active')
+        const insets = await tabBar.evaluate((element) => {
+          const barBounds = element.getBoundingClientRect()
+          const tab = element.querySelector('.tab.active')
+          const tabBounds = tab.getBoundingClientRect()
+          return {
+            bottom: barBounds.bottom - tabBounds.bottom,
+            bottomBorder: getComputedStyle(tab).borderBottomWidth,
+            top: tabBounds.top - barBounds.top,
+            topBorder: getComputedStyle(tab).borderTopWidth,
+          }
+        })
+
+        if (className === 'position-bottom') {
+          expect(insets).toEqual({
+            bottom: 4,
+            bottomBorder: '1px',
+            top: 0,
+            topBorder: '0px',
+          })
+          const clipClearance = await activeTab.evaluate((element) => {
+            return element.parentElement.getBoundingClientRect().bottom -
+              element.getBoundingClientRect().bottom
+          })
+          expect(clipClearance).toBeGreaterThanOrEqual(1)
+          expect(await getTabEdgeBorderCoverage(page, activeTab, 'bottom')).toBeGreaterThan(0.7)
+          await attachScreenshot('horizontal tabs at bottom with safe inset')
+        } else {
+          expect(insets).toEqual({
+            bottom: 0,
+            bottomBorder: '0px',
+            top: 2,
+            topBorder: '1px',
+          })
+          expect(await getTabEdgeBorderCoverage(page, activeTab, 'top')).toBeGreaterThan(0.7)
+          await attachScreenshot('horizontal tabs at top')
+        }
+      }
+    }
   })
 
   test('maps system light and dark modes to chosen themes', async ({ app, page }) => {
@@ -667,33 +757,26 @@ test.describe('top nav beside the vertical tab bar', () => {
   })
 })
 
-test.describe('tab orientation shortcut', () => {
-  test('F1 switches between horizontal and vertical tabs', async ({ page, attachScreenshot }) => {
+test.describe('tab layout shortcut', () => {
+  test('F1 cycles through every tab layout', async ({ page, attachScreenshot }) => {
     const app = page.locator('.app')
-    await expect(app).not.toHaveClass(/verticalTabs/)
-
-    await page.keyboard.press('F1')
-    await expect(app).toHaveClass(/verticalTabs/)
-    await expect.poll(async () => {
-      return page.locator('.tab.vertical.active').evaluate((tab) => {
-        const tabEnd = tab.getBoundingClientRect().right
-        const viewportEnd = tab.parentElement.getBoundingClientRect().right
-        return viewportEnd - tabEnd
-      })
-    }).toBeGreaterThanOrEqual(1)
-    await attachScreenshot('vertical tabs')
-
-    await page.keyboard.press('F1')
-    await expect(app).not.toHaveClass(/verticalTabs/)
-    await attachScreenshot('horizontal tabs')
+    for (const className of [
+      'tabBar-left',
+      'tabBar-bottom',
+      'tabBar-right',
+      'tabBar-top'
+    ]) {
+      await page.keyboard.press('F1')
+      await expect(app).toHaveClass(new RegExp(`(?:^|\\s)${className}(?:\\s|$)`))
+    }
+    await attachScreenshot('tab layouts cycled with F1')
   })
 
   test('presses in quick succession are not swallowed by the pending write', async ({ app: appHandle, page }) => {
     const app = page.locator('.app')
 
     // The setting is only committed once persisted, so two presses that beat
-    // the write have to queue up instead of both negating the same value —
-    // otherwise they collapse into a single toggle and the layout flips.
+    // the write have to queue up instead of both advancing from the same value.
     await page.evaluate(() => {
       for (let i = 0; i < 2; i++) {
         document.dispatchEvent(new KeyboardEvent('keydown', { key: 'F1', code: 'F1', bubbles: true }))
@@ -705,13 +788,13 @@ test.describe('tab orientation shortcut', () => {
       return Object.fromEntries(contents.trim().split('\n')
         .map(line => JSON.parse(line))
         .map(record => [record._id, record.value]))
-        .useVerticalTabBar
-    }).toBe(false)
-    await expect(app).not.toHaveClass(/verticalTabs/)
+        .tabBarPosition
+    }).toBe('bottom')
+    await expect(app).toHaveClass(/tabBar-bottom/)
   })
 })
 
-test.describe('tab orientation shortcut rebound to a printable key', () => {
+test.describe('tab layout shortcut rebound to a printable key', () => {
   test.use({
     seed: {
       settings: {
@@ -728,12 +811,12 @@ test.describe('tab orientation shortcut rebound to a printable key', () => {
     await searchInput.type('vv')
 
     await expect(searchInput).toHaveValue('vv')
-    await expect(app).not.toHaveClass(/verticalTabs/)
+    await expect(app).toHaveClass(/tabBar-top/)
 
     // Outside a text field the rebound key still works.
     await page.locator('.app').click()
     await page.keyboard.press('v')
-    await expect(app).toHaveClass(/verticalTabs/)
+    await expect(app).toHaveClass(/tabBar-left/)
   })
 })
 

--- a/e2e/tests/offline/scrollbar-overlay.spec.mjs
+++ b/e2e/tests/offline/scrollbar-overlay.spec.mjs
@@ -56,6 +56,7 @@ test.describe('overlay scrollbars', () => {
       store.commit('setTabBarPosition', 'left')
     })
 
+    await expect(page.locator('.tabBar.position-left')).toBeVisible()
     const scrollbarBox = await page.locator(PAGE_SCROLLBAR).boundingBox()
     const innerWidth = await page.evaluate(() => window.innerWidth)
 

--- a/e2e/tests/offline/scrollbar-overlay.spec.mjs
+++ b/e2e/tests/offline/scrollbar-overlay.spec.mjs
@@ -32,6 +32,36 @@ test.describe('overlay scrollbars', () => {
     expect(clientWidth).toBe(innerWidth)
   })
 
+  test('the page scrollbar stays on the content side of right vertical tabs', async ({ page }) => {
+    await addPageOverflow(page)
+    await page.evaluate(() => {
+      const store = document.querySelector('#app').__vue_app__.config.globalProperties.$store
+      store.commit('setVerticalTabBarWidth', 220)
+      store.commit('setTabBarPosition', 'right')
+    })
+
+    const [scrollbarBox, tabBarBox] = await Promise.all([
+      page.locator(PAGE_SCROLLBAR).boundingBox(),
+      page.locator('.tabBar.position-right').boundingBox()
+    ])
+
+    expect(Math.abs(scrollbarBox.x + scrollbarBox.width - tabBarBox.x)).toBeLessThanOrEqual(1)
+  })
+
+  test('the page scrollbar stays on the window edge with left vertical tabs', async ({ page }) => {
+    await addPageOverflow(page)
+    await page.evaluate(() => {
+      const store = document.querySelector('#app').__vue_app__.config.globalProperties.$store
+      store.commit('setVerticalTabBarWidth', 220)
+      store.commit('setTabBarPosition', 'left')
+    })
+
+    const scrollbarBox = await page.locator(PAGE_SCROLLBAR).boundingBox()
+    const innerWidth = await page.evaluate(() => window.innerWidth)
+
+    expect(Math.abs(scrollbarBox.x + scrollbarBox.width - innerWidth)).toBeLessThanOrEqual(1)
+  })
+
   test('the scrollbar hides once the pointer rests and follows it back', async ({ page }) => {
     await addPageOverflow(page)
     const scrollbar = page.locator(PAGE_SCROLLBAR)

--- a/e2e/tests/offline/search-history.spec.mjs
+++ b/e2e/tests/offline/search-history.spec.mjs
@@ -209,7 +209,7 @@ test.describe('search suggestion remove button layout', () => {
     // stays open.
     await page.evaluate(() => {
       const store = document.querySelector('#app').__vue_app__.config.globalProperties.$store
-      store.commit('setUseVerticalTabBar', true)
+      store.commit('setTabBarPosition', 'left')
       store.commit('setVerticalTabBarWidth', 300)
     })
     await expect(page.locator('.app')).toHaveClass(/verticalTabs/)

--- a/e2e/tests/offline/subscriptions-refresh.spec.mjs
+++ b/e2e/tests/offline/subscriptions-refresh.spec.mjs
@@ -443,6 +443,20 @@ test.describe('cancelling an automatic subscription feed refresh', () => {
     expect(minimizedBounds.y).toBeCloseTo(expandedBounds.y, 0)
     expect(minimizedBounds.y).toBeGreaterThanOrEqual(tabBarBounds.y + tabBarBounds.height)
 
+    await page.evaluate(() => {
+      const store = document.querySelector('#app').__vue_app__.config.globalProperties.$store
+      store.commit('setVerticalTabBarWidth', 220)
+      store.commit('setTabBarPosition', 'left')
+    })
+    const leftTabBar = page.locator('.tabBar.position-left')
+    await expect(leftTabBar).toBeVisible()
+    await expect(refreshToast).not.toHaveClass(/minimized/)
+    const [shiftedBounds, leftTabBarBounds] = await Promise.all([
+      refreshToast.boundingBox(),
+      leftTabBar.boundingBox()
+    ])
+    expect(shiftedBounds.x).toBeGreaterThanOrEqual(leftTabBarBounds.x + leftTabBarBounds.width)
+
     const viewport = await page.evaluate(() => ({ width: innerWidth, height: innerHeight }))
     await page.mouse.move(viewport.width / 2, viewport.height / 2)
     await expect(refreshToast).not.toHaveClass(/minimized/)

--- a/e2e/tests/offline/tab-preview.spec.mjs
+++ b/e2e/tests/offline/tab-preview.spec.mjs
@@ -74,6 +74,35 @@ test.describe('tab previews', () => {
     expect(width).toBeGreaterThanOrEqual(Math.round(displayed.width))
   })
 
+  test('keeps the tooltip clear of the page scrollbar beside right vertical tabs', async ({ page, attachScreenshot }) => {
+    await page.evaluate(() => {
+      const store = document.querySelector('#app').__vue_app__.config.globalProperties.$store
+      store.commit('setVerticalTabBarWidth', 220)
+      store.commit('setTabBarPosition', 'right')
+
+      const content = document.createElement('div')
+      content.dataset.tabPreviewOverflow = ''
+      content.style.height = '3000px'
+      document.body.append(content)
+    })
+    await expect.poll(() => page.evaluate(
+      () => document.documentElement.scrollHeight > window.innerHeight
+    )).toBe(true)
+    await hoverTabForPreview(page, 0)
+
+    const [tooltipBox, scrollbarBox, tabBarBox] = await Promise.all([
+      page.locator('.tabTooltip').boundingBox(),
+      page.locator('body > .os-scrollbar-vertical').boundingBox(),
+      page.locator('.tabBar.position-right').boundingBox()
+    ])
+    const gap = scrollbarBox.x - (tooltipBox.x + tooltipBox.width)
+    expect(gap).toBeGreaterThanOrEqual(5)
+    expect(gap).toBeLessThanOrEqual(7)
+    expect(tooltipBox.x + tooltipBox.width).toBeLessThan(scrollbarBox.x)
+    expect(scrollbarBox.x + scrollbarBox.width).toBeLessThanOrEqual(tabBarBox.x + 1)
+    await attachScreenshot('tab preview beside right tabs')
+  })
+
   test('repositions an open tooltip after previews are disabled', async ({ page }) => {
     await hoverTabForPreview(page, 0)
 

--- a/e2e/tests/offline/video-actions.spec.mjs
+++ b/e2e/tests/offline/video-actions.spec.mjs
@@ -50,6 +50,24 @@ const SEED = {
   history: [historyEntry('eeeeeeeeeee', 'Bookmarkable video')]
 }
 
+function silentWav(duration, sampleRate = 8_000) {
+  const samples = sampleRate * duration
+  const wav = Buffer.alloc(44 + samples * 2)
+  wav.write('RIFF', 0)
+  wav.writeUInt32LE(wav.length - 8, 4)
+  wav.write('WAVEfmt ', 8)
+  wav.writeUInt32LE(16, 16)
+  wav.writeUInt16LE(1, 20)
+  wav.writeUInt16LE(1, 22)
+  wav.writeUInt32LE(sampleRate, 24)
+  wav.writeUInt32LE(sampleRate * 2, 28)
+  wav.writeUInt16LE(2, 32)
+  wav.writeUInt16LE(16, 34)
+  wav.write('data', 36)
+  wav.writeUInt32LE(samples * 2, 40)
+  return wav
+}
+
 test.use({ seed: SEED })
 
 test('persists the yt-dlp playback cache across app restarts', async ({ app, page }) => {
@@ -328,14 +346,20 @@ test.describe('video downloads', () => {
 
   test('plays a downloaded video locally and reconciles it after external deletion', async ({ app, page }) => {
     const downloadedFile = path.join(app.userDataDir, 'downloaded-demo.webm')
+    const downloadedAudioFile = path.join(app.userDataDir, 'downloaded-audio-alternative.wav')
     const downloadThumbnail = 'data:image/svg+xml,%3Csvg xmlns="http://www.w3.org/2000/svg" width="640" height="360"%3E%3Cpath fill="%23b00020" d="M0 0h640v360H0z"/%3E%3C/svg%3E'
     const executable = path.join(app.userDataDir, 'fake-yt-dlp.sh')
     const argumentsFile = path.join(app.userDataDir, 'yt-dlp-arguments.txt')
     await copyFile(DEMO_MEDIA_PATH, downloadedFile)
+    await writeFile(downloadedAudioFile, silentWav(2))
     await writeFile(executable, [
       '#!/bin/sh',
       `printf '%s\\n' "$@" >> '${argumentsFile}'`,
-      `printf '__OPENTUBEX_FILE__:eeeeeeeeeee\\t30\\t640\\t360\\t${downloadedFile}\\n'`
+      'if printf \'%s\\n\' "$@" | grep -q -- \'--extract-audio\'; then',
+      `  printf '__OPENTUBEX_FILE__:eeeeeeeeeee\\t2\\tNA\\tNA\\t${downloadedAudioFile}\\n'`,
+      'else',
+      `  printf '__OPENTUBEX_FILE__:eeeeeeeeeee\\t30\\t640\\t360\\t${downloadedFile}\\n'`,
+      'fi'
     ].join('\n'))
     await chmod(executable, 0o755)
     await page.evaluate(async (ytDlpPath) => {
@@ -489,7 +513,10 @@ test.describe('video downloads', () => {
     await expect(page.locator('.videoPlayerPlaceholder.ft-shimmer')).toHaveCount(0)
     await expect(page.locator('.tab.active .tabTitleText')).toHaveText('Downloaded demo')
 
-    await unlink(downloadedFile)
+    await Promise.all([
+      unlink(downloadedFile),
+      unlink(downloadedAudioFile)
+    ])
     await page.locator('.topNav .downloadsButton').click()
     await expect(page.getByRole('dialog', { name: 'Downloads', exact: true })).toBeVisible()
     await expect(downloadRow).toContainText('Download unavailable')
@@ -497,7 +524,7 @@ test.describe('video downloads', () => {
     await expect(downloadRow.getByTitle('Play download')).toHaveCount(0)
     await expect(downloadRow.getByTitle('Show in Folder')).toHaveCount(0)
     await expect(downloadRow.getByTitle('Remove File')).toHaveCount(0)
-    await page.getByRole('button', { name: 'Clear failed, canceled, and missing' }).click()
+    await page.getByRole('button', { name: 'Clear failed, canceled, skipped, and missing' }).click()
     await expect(downloadRow).toHaveCount(0)
     await expect(page.locator('.downloadRow').filter({ hasText: 'Downloaded audio alternative' })).toHaveCount(0)
   })
@@ -505,23 +532,8 @@ test.describe('video downloads', () => {
   test('plays an audio download in the normal player', async ({ app, page }) => {
     const downloadedFile = path.join(app.userDataDir, 'downloaded-audio.wav')
     const executable = path.join(app.userDataDir, 'fake-audio-yt-dlp.sh')
-    const sampleRate = 8_000
     const duration = 2
-    const samples = sampleRate * duration
-    const wav = Buffer.alloc(44 + samples * 2)
-    wav.write('RIFF', 0)
-    wav.writeUInt32LE(wav.length - 8, 4)
-    wav.write('WAVEfmt ', 8)
-    wav.writeUInt32LE(16, 16)
-    wav.writeUInt16LE(1, 20)
-    wav.writeUInt16LE(1, 22)
-    wav.writeUInt32LE(sampleRate, 24)
-    wav.writeUInt32LE(sampleRate * 2, 28)
-    wav.writeUInt16LE(2, 32)
-    wav.writeUInt16LE(16, 34)
-    wav.write('data', 36)
-    wav.writeUInt32LE(samples * 2, 40)
-    await writeFile(downloadedFile, wav)
+    await writeFile(downloadedFile, silentWav(duration))
     await writeFile(executable, [
       '#!/bin/sh',
       `printf '__OPENTUBEX_FILE__:eeeeeeeeeee\\t${duration}\\tNA\\tNA\\t${downloadedFile}\\n'`
@@ -714,7 +726,7 @@ test.describe('video downloads', () => {
     await hydratedDownload.getByTitle('Cancel Download').click()
     await expect(otherDownload).toContainText('Download canceled')
 
-    await lateWindow.getByRole('button', { name: 'Clear failed, canceled, and missing' }).click()
+    await lateWindow.getByRole('button', { name: 'Clear failed, canceled, skipped, and missing' }).click()
     await expect(otherDownload).toHaveCount(0)
   })
 

--- a/e2e/tests/offline/video-actions.spec.mjs
+++ b/e2e/tests/offline/video-actions.spec.mjs
@@ -1146,7 +1146,7 @@ test.describe('list video actions', () => {
     await goTo(page, 'history')
     await page.evaluate(() => {
       const store = document.querySelector('#app').__vue_app__.config.globalProperties.$store
-      store.commit('setUseVerticalTabBar', true)
+      store.commit('setTabBarPosition', 'left')
     })
 
     const video = page.locator('.ft-list-video').first()

--- a/src/main/tabs/tabPreviewGeometry.js
+++ b/src/main/tabs/tabPreviewGeometry.js
@@ -3,6 +3,7 @@
  * @property {number} contentTop
  * @property {number} contentLeft
  * @property {number} contentRight
+ * @property {number} contentBottom
  * @property {number} viewportWidth
  * @property {number} viewportHeight
  * @property {number} devicePixelRatio
@@ -39,6 +40,7 @@ export function measureTabPreviewContentBounds(window, document) {
   let contentTop = 0
   let contentLeft = 0
   let contentRight = viewportWidth
+  let contentBottom = viewportHeight
 
   if (tabBar != null) {
     const rect = tabBar.getBoundingClientRect()
@@ -50,8 +52,10 @@ export function measureTabPreviewContentBounds(window, document) {
       } else {
         contentRight = clampX(rect.left)
       }
-    } else {
+    } else if (rect.top < viewportHeight - rect.bottom) {
       contentTop = clampY(rect.bottom)
+    } else {
+      contentBottom = clampY(rect.top)
     }
   }
 
@@ -67,6 +71,7 @@ export function measureTabPreviewContentBounds(window, document) {
     contentTop,
     contentLeft,
     contentRight,
+    contentBottom,
     viewportWidth,
     viewportHeight,
     // Display scaling times page zoom. NativeImage reports and exports sizes in
@@ -124,8 +129,14 @@ export function getTabPreviewTargetSize({ width, height }, contentBounds) {
 export function cropTabPreviewToContent(image, contentBounds) {
   const { contentTop = 0, contentLeft = 0, viewportWidth, viewportHeight } = contentBounds
   const contentRight = contentBounds.contentRight ?? viewportWidth
+  const contentBottom = contentBounds.contentBottom ?? viewportHeight
 
-  if (contentTop <= 0 && contentLeft <= 0 && contentRight >= viewportWidth) {
+  if (
+    contentTop <= 0 &&
+    contentLeft <= 0 &&
+    contentRight >= viewportWidth &&
+    contentBottom >= viewportHeight
+  ) {
     return image
   }
 
@@ -138,9 +149,10 @@ export function cropTabPreviewToContent(image, contentBounds) {
   const scaleY = height / viewportHeight
   const cropX = Math.min(width, Math.max(0, Math.ceil(contentLeft * scaleX)))
   const cropRight = Math.min(width, Math.max(0, Math.floor(contentRight * scaleX)))
+  const cropBottom = Math.min(height, Math.max(0, Math.floor(contentBottom * scaleY)))
   const cropY = Math.min(height, Math.max(0, Math.ceil(contentTop * scaleY)))
   const cropWidth = cropRight - cropX
-  const cropHeight = height - cropY
+  const cropHeight = cropBottom - cropY
   return cropWidth <= 0 || cropHeight <= 0
     ? null
     : image.crop({ x: cropX, y: cropY, width: cropWidth, height: cropHeight })

--- a/src/renderer/App.css
+++ b/src/renderer/App.css
@@ -444,20 +444,46 @@
   }
 }
 
-/* Adjust SideNav position when tab bar is present */
-.app:has(.tabBar) :deep(.sideNav) {
+/* The bottom strip includes a 2px compositor-safe inset. */
+.app.topTabs :deep(.sideNav) {
   block-size: calc(100vh - 92px);
   inset-block-start: 92px;
 }
 
-.app:has(.tabBar) .sideNavBackdrop {
+.app.bottomTabs :deep(.sideNav) {
+  block-size: calc(100vh - 94px);
+  inset-block-start: 60px;
+}
+
+.app.topTabs .sideNavBackdrop {
   inset-block-start: 92px;
 }
 
+.app.bottomTabs {
+  box-sizing: border-box;
+  padding-block-end: 34px;
+}
+
+.app.bottomTabs .sideNavBackdrop {
+  inset-block: 60px 34px;
+}
+
+.app.bottomTabs :deep(.progressBar) {
+  inset-block-end: 34px;
+}
+
 @media only screen and (width <= 680px) {
-  .app:has(.tabBar) :deep(.sideNav) {
+  .app:is(.topTabs, .bottomTabs) :deep(.sideNav) {
     block-size: 60px;
     inset-block-start: auto;
+  }
+
+  .app.bottomTabs :deep(.sideNav) {
+    inset-block-end: 34px;
+  }
+
+  .app.bottomTabs :deep(.moreOptionContainer) {
+    inset-block-end: 94px;
   }
 
   .sideNavBackdrop {
@@ -466,20 +492,31 @@
 
   /* The fixed top nav is taller when a tab bar is present, so restore the gap
      between it and the page content (the .flexBox rule above shrinks it). */
-  .app:has(.tabBar) .routerView {
+  .app.topTabs .routerView {
     margin-block-start: 68px;
   }
 }
 
-/* Vertical tab bar layout: the tab bar is a fixed column on the inline-start
-   side, so content shifts over and vertical offsets return to top-nav only. */
-.app.verticalTabs {
-  padding-inline-start: var(--vertical-tab-bar-width, 220px);
+/* These settings name physical window edges, independent of text direction. */
+/* stylelint-disable liberty/use-logical-spec */
+.app.verticalTabsLeft {
+  box-sizing: border-box;
+  padding-left: var(--vertical-tab-bar-width, 220px);
 }
 
-.app.verticalTabs :deep(.progressBar) {
-  inset-inline-start: var(--vertical-tab-bar-width, 220px);
+.app.verticalTabsRight {
+  box-sizing: border-box;
+  padding-right: var(--vertical-tab-bar-width, 220px);
 }
+
+.app.verticalTabsLeft :deep(.progressBar) {
+  left: var(--vertical-tab-bar-width, 220px);
+}
+
+.app.verticalTabsRight :deep(.progressBar) {
+  right: var(--vertical-tab-bar-width, 220px);
+}
+/* stylelint-enable liberty/use-logical-spec */
 
 .app.verticalTabs .sideNavBackdrop {
   inset-block-start: 60px;
@@ -491,15 +528,34 @@
     inset-block-start: 60px;
   }
 
-  .watchSideNavOverlay.verticalTabs :deep(.sideNav) {
-    inset-inline-start: var(--vertical-tab-bar-width, 220px);
+  /* The fixed overlay navigation only shifts when it shares the tab bar's
+     physical edge. */
+  /* stylelint-disable liberty/use-logical-spec */
+  .watchSideNavOverlay.verticalTabsLeft:not(.isLocaleRightToLeft) :deep(.sideNav) {
+    left: var(--vertical-tab-bar-width, 220px);
   }
+
+  .watchSideNavOverlay.verticalTabsRight.isLocaleRightToLeft :deep(.sideNav) {
+    right: var(--vertical-tab-bar-width, 220px);
+  }
+  /* stylelint-enable liberty/use-logical-spec */
 }
 
 /* The mobile bottom nav is fixed, so shift it past the vertical tab column */
 @media only screen and (width <= 680px) {
   .app.verticalTabs :deep(.sideNav) {
-    inset-inline-start: var(--vertical-tab-bar-width, 220px);
     inline-size: calc(100% - var(--vertical-tab-bar-width, 220px));
   }
+
+  /* stylelint-disable liberty/use-logical-spec */
+  .app.verticalTabsLeft :deep(.sideNav) {
+    left: var(--vertical-tab-bar-width, 220px);
+    right: 0;
+  }
+
+  .app.verticalTabsRight :deep(.sideNav) {
+    left: 0;
+    right: var(--vertical-tab-bar-width, 220px);
+  }
+  /* stylelint-enable liberty/use-logical-spec */
 }

--- a/src/renderer/App.vue
+++ b/src/renderer/App.vue
@@ -2,15 +2,19 @@
   <div
     v-if="dataReady"
     class="app"
-    :class="{
+    :class="[{
       hideOutlines: outlinesHidden,
       isLocaleRightToLeft: isLocaleRightToLeft,
       isSideNavOpen: isSideNavOpen,
       hideLabelsSideBar: hideLabelsSideBar && !isSideNavOpen,
       verticalTabs: useVerticalTabBar,
+      verticalTabsLeft: tabBarPosition === 'left',
+      verticalTabsRight: tabBarPosition === 'right',
+      bottomTabs: isElectron && tabBarPosition === 'bottom',
+      topTabs: isElectron && tabBarPosition === 'top',
       watchSideNavOverlay: useWatchSideNavOverlay,
       watchSideNavTransitionDisabled
-    }"
+    }, `tabBar-${tabBarPosition}`]"
     :style="appStyle"
   >
     <TabBar
@@ -361,6 +365,11 @@ import { initializePlatformInfo } from './helpers/platform'
 import { normalizeScrollbarThumbWidth } from './constants/scrollbar'
 import { getTabAccentColor } from './constants/tabColors'
 import { getThumbnailListStyles } from './constants/thumbnailSize'
+import {
+  getNextTabBarPosition,
+  isVerticalTabBarPosition,
+  normalizeTabBarPosition
+} from './constants/tabBarPosition'
 import { getLastUsedVersion, setLastUsedVersion } from './helpers/lastUsedVersion'
 import { invalidateAllYtDlpPlaybackSources } from './helpers/player/ytDlpPlayback'
 import { getTabNavigationService } from './tabs/TabNavigationService'
@@ -397,8 +406,10 @@ const isSideNavOpen = computed(() => store.getters.getIsSideNavOpen)
 /** @type {import('vue').ComputedRef<boolean>} */
 const hideLabelsSideBar = computed(() => store.getters.getHideLabelsSideBar)
 
-/** @type {import('vue').ComputedRef<boolean>} */
-const useVerticalTabBar = computed(() => isElectron && store.getters.getUseVerticalTabBar)
+const tabBarPosition = computed(() => isElectron
+  ? normalizeTabBarPosition(store.getters.getTabBarPosition)
+  : 'top')
+const useVerticalTabBar = computed(() => isElectron && isVerticalTabBarPosition(tabBarPosition.value))
 
 const appStyle = computed(() => {
   if (!useVerticalTabBar.value) {
@@ -1959,7 +1970,7 @@ function handleKeyboardShortcuts(event) {
     // F1: Toggle between horizontal and vertical tabs
     if (matchesKeyboardShortcut(event, shortcuts.TOGGLE_TAB_ORIENTATION) && !isTypingTarget(event.target)) {
       event.preventDefault()
-      toggleTabOrientation()
+      cycleTabLayout()
       return
     }
 
@@ -2019,14 +2030,14 @@ function handleKeyboardShortcuts(event) {
 
 /**
  * The setting is only committed to the store once it has been persisted, so
- * consecutive presses are queued to keep every one of them from negating the
- * same stale value.
+ * consecutive presses are queued to keep every one of them from advancing
+ * from the same stale value.
  */
-let pendingTabOrientationUpdate = Promise.resolve()
+let pendingTabLayoutUpdate = Promise.resolve()
 
-function toggleTabOrientation() {
-  pendingTabOrientationUpdate = pendingTabOrientationUpdate.then(() =>
-    store.dispatch('updateUseVerticalTabBar', !useVerticalTabBar.value)
+function cycleTabLayout() {
+  pendingTabLayoutUpdate = pendingTabLayoutUpdate.then(() =>
+    store.dispatch('updateTabBarPosition', getNextTabBarPosition(tabBarPosition.value))
   )
 }
 

--- a/src/renderer/components/FtIconButton/FtIconButton.vue
+++ b/src/renderer/components/FtIconButton/FtIconButton.vue
@@ -350,7 +350,7 @@ function getTopChromeBottom() {
 
   let bottom = 0
 
-  for (const selector of ['.topNav', '.tabBar:not(.vertical)']) {
+  for (const selector of ['.topNav', '.tabBar.position-top']) {
     const element = document.querySelector(selector)
 
     if (element != null) {

--- a/src/renderer/components/FtQuickSettingsMenu/FtQuickSettingsMenu.css
+++ b/src/renderer/components/FtQuickSettingsMenu/FtQuickSettingsMenu.css
@@ -3,8 +3,12 @@
   position: relative;
 }
 
-:global(.app:not(.verticalTabs):has(.tabBar)) .quickSettings {
+:global(.app.topTabs) .quickSettings {
   --quick-settings-viewport-offset: 32px;
+}
+
+:global(.app.bottomTabs) .quickSettings {
+  --quick-settings-viewport-offset: 34px;
 }
 
 .profileTrigger {

--- a/src/renderer/components/FtSelect/FtSelect.vue
+++ b/src/renderer/components/FtSelect/FtSelect.vue
@@ -336,7 +336,7 @@ function getTopChromeBottom() {
   }
 
   let bottom = 0
-  for (const selector of ['.topNav', '.tabBar:not(.vertical)']) {
+  for (const selector of ['.topNav', '.tabBar.position-top']) {
     const element = document.querySelector(selector)
     if (element !== null) {
       bottom = Math.max(bottom, element.getBoundingClientRect().bottom)

--- a/src/renderer/components/FtToast/FtToast.css
+++ b/src/renderer/components/FtToast/FtToast.css
@@ -220,7 +220,7 @@
 /* stylelint-disable liberty/use-logical-spec */
 .progress-toast-holder.position-bottom-left,
 .progress-toast-holder.position-top-left {
-  left: 24px;
+  left: calc(24px + var(--left-tab-bar-offset, 0px));
   justify-content: flex-start;
 }
 
@@ -233,16 +233,23 @@
 
 .progress-toast-holder.position-bottom-right,
 .progress-toast-holder.position-top-right {
-  right: 24px;
+  right: calc(24px + var(--right-tab-bar-offset, 0px));
   justify-content: flex-end;
 }
 /* stylelint-enable liberty/use-logical-spec */
 
 /* Keep top-positioned toasts below the horizontal tab bar. */
-.progress-toast-holder.horizontal-tabs.position-top-left,
-.progress-toast-holder.horizontal-tabs.position-top-center,
-.progress-toast-holder.horizontal-tabs.position-top-right {
+.progress-toast-holder.top-tabs.position-top-left,
+.progress-toast-holder.top-tabs.position-top-center,
+.progress-toast-holder.top-tabs.position-top-right {
   inset-block-start: 56px;
+}
+
+/* Keep bottom-positioned toasts above the bottom horizontal tab bar. */
+.progress-toast-holder.bottom-tabs.position-bottom-left,
+.progress-toast-holder.bottom-tabs.position-bottom-center,
+.progress-toast-holder.bottom-tabs.position-bottom-right {
+  inset-block-end: 58px;
 }
 
 :is(.toast-holder, .progress-toast-holder) .toast-slot {
@@ -317,15 +324,27 @@
   transform: translate(18px, -18px) scale(0.5);
 }
 
-.progress-toast-holder.horizontal-tabs.position-top-left .persistent-slot.minimized {
+.progress-toast-holder.top-tabs.position-top-left .persistent-slot.minimized {
   transform: translateX(-18px) scale(0.5);
 }
 
-.progress-toast-holder.horizontal-tabs.position-top-center .persistent-slot.minimized {
+.progress-toast-holder.top-tabs.position-top-center .persistent-slot.minimized {
   transform: scale(0.5);
 }
 
-.progress-toast-holder.horizontal-tabs.position-top-right .persistent-slot.minimized {
+.progress-toast-holder.top-tabs.position-top-right .persistent-slot.minimized {
+  transform: translateX(18px) scale(0.5);
+}
+
+.progress-toast-holder.bottom-tabs.position-bottom-left .persistent-slot.minimized {
+  transform: translateX(-18px) scale(0.5);
+}
+
+.progress-toast-holder.bottom-tabs.position-bottom-center .persistent-slot.minimized {
+  transform: scale(0.5);
+}
+
+.progress-toast-holder.bottom-tabs.position-bottom-right .persistent-slot.minimized {
   transform: translateX(18px) scale(0.5);
 }
 

--- a/src/renderer/components/FtToast/FtToast.vue
+++ b/src/renderer/components/FtToast/FtToast.vue
@@ -5,7 +5,7 @@
   >
     <Toaster
       class="toast-holder"
-      :class="[`position-${toastPosition}`, { 'horizontal-tabs': hasHorizontalTabBar }]"
+      :class="[`position-${toastPosition}`, tabBarToastClasses]"
       :position="SONNER_POSITION"
       :gap="TOAST_GAP"
       :visible-toasts="MAX_VISIBLE_TOASTS"
@@ -17,7 +17,8 @@
     <div
       v-if="showProgressToast"
       class="progress-toast-holder"
-      :class="[`position-${toastPosition}`, { 'horizontal-tabs': hasHorizontalTabBar }]"
+      :class="[`position-${toastPosition}`, tabBarToastClasses]"
+      :style="progressToastHolderStyle"
     >
       <div
         ref="progressToast"
@@ -105,6 +106,8 @@ const TOAST_GAP = 10
 const VIEWPORT_INSET = 29
 /** Larger top inset that keeps top-positioned toasts below the horizontal tab bar */
 const TAB_BAR_INSET = 61
+/** Bottom tabs reserve two extra pixels that stay clear of decorated window frames */
+const BOTTOM_TAB_BAR_INSET = TAB_BAR_INSET + 2
 /** Distance in px at which the persistent refresh toast gets out of the pointer's way */
 const PROGRESS_TOAST_PROXIMITY = 32
 /** Extra distance required before restoring the toast, to avoid flicker around the boundary */
@@ -183,9 +186,20 @@ let progressToastPointerY = 0
 const toastPosition = computed(() => {
   return normalizeToastPosition(store.getters.getToastPosition)
 })
-const hasHorizontalTabBar = computed(() => {
-  return process.env.IS_ELECTRON && !store.getters.getUseVerticalTabBar
-})
+const tabBarPosition = computed(() => process.env.IS_ELECTRON
+  ? store.getters.getTabBarPosition
+  : null)
+const hasHorizontalTabBar = computed(() => ['top', 'bottom'].includes(tabBarPosition.value))
+const tabBarToastClasses = computed(() => ({
+  'horizontal-tabs': hasHorizontalTabBar.value,
+  'top-tabs': tabBarPosition.value === 'top',
+  'bottom-tabs': tabBarPosition.value === 'bottom'
+}))
+const tabBarInlineOffset = computed(() => `${store.getters.getVerticalTabBarWidth}px`)
+const progressToastHolderStyle = computed(() => ({
+  '--left-tab-bar-offset': tabBarPosition.value === 'left' ? tabBarInlineOffset.value : '0px',
+  '--right-tab-bar-offset': tabBarPosition.value === 'right' ? tabBarInlineOffset.value : '0px'
+}))
 
 /**
  * Toasts are swiped away towards the screen edge they are anchored to, so they
@@ -207,10 +221,10 @@ const toasterOffset = computed(() => {
   const progressInset = showProgressToast.value ? progressToastHeight.value + TOAST_GAP : 0
 
   return {
-    left: VIEWPORT_INSET,
-    right: VIEWPORT_INSET,
-    bottom: VIEWPORT_INSET + progressInset,
-    top: (hasHorizontalTabBar.value ? TAB_BAR_INSET : VIEWPORT_INSET) + progressInset
+    left: VIEWPORT_INSET + (tabBarPosition.value === 'left' ? store.getters.getVerticalTabBarWidth : 0),
+    right: VIEWPORT_INSET + (tabBarPosition.value === 'right' ? store.getters.getVerticalTabBarWidth : 0),
+    bottom: (tabBarPosition.value === 'bottom' ? BOTTOM_TAB_BAR_INSET : VIEWPORT_INSET) + progressInset,
+    top: (tabBarPosition.value === 'top' ? TAB_BAR_INSET : VIEWPORT_INSET) + progressInset
   }
 })
 

--- a/src/renderer/components/FtToast/FtToast.vue
+++ b/src/renderer/components/FtToast/FtToast.vue
@@ -488,6 +488,14 @@ watch(progressToast, (element) => {
   progressToastResizeObserver.observe(element)
 })
 
+watch(
+  () => [tabBarPosition.value, store.getters.getVerticalTabBarWidth],
+  async () => {
+    await nextTick()
+    resetProgressToastProximity()
+  }
+)
+
 // The holder is recreated when the toasts are teleported into or out of a
 // fullscreen element, so the observers have to be pointed at the new one.
 watch(fullscreenTarget, () => nextTick(trackFrontToast))

--- a/src/renderer/components/TabBar/SortableTab.vue
+++ b/src/renderer/components/TabBar/SortableTab.vue
@@ -145,6 +145,11 @@ const props = defineProps({
     type: Boolean,
     default: false
   },
+  tabBarPosition: {
+    type: String,
+    default: 'top',
+    validator: value => ['top', 'bottom', 'left', 'right'].includes(value)
+  },
   isDragging: {
     type: Boolean,
     default: false
@@ -211,7 +216,8 @@ const tabClasses = computed(() => ({
   dragging: props.isDragging,
   settling: props.isSettling,
   noTransition: props.suppressTransition,
-  vertical: props.vertical
+  vertical: props.vertical,
+  bottom: props.tabBarPosition === 'bottom'
 }))
 
 const tabStyle = computed(() => {
@@ -376,10 +382,41 @@ function updateTooltipPosition() {
       TOOLTIP_MARGIN_PX,
       Math.min(window.innerHeight - tooltipEstimatedHeight.value, rect.top)
     )
+    const tabBarRect = element.closest('.tabBar')?.getBoundingClientRect()
+    let adjacentEdge = props.tabBarPosition === 'right'
+      ? (tabBarRect?.left ?? rect.left)
+      : (tabBarRect?.right ?? rect.right)
+    if (props.tabBarPosition === 'right') {
+      const pageScrollbar = document.querySelector(
+        'body > .os-scrollbar-vertical:not(.os-scrollbar-unusable)'
+      )
+      if (pageScrollbar instanceof HTMLElement) {
+        adjacentEdge = Math.min(adjacentEdge, pageScrollbar.getBoundingClientRect().left)
+      }
+    }
 
+    const availableWidth = props.tabBarPosition === 'right'
+      ? adjacentEdge - TOOLTIP_OFFSET_PX - TOOLTIP_MARGIN_PX
+      : window.innerWidth - adjacentEdge - TOOLTIP_OFFSET_PX - TOOLTIP_MARGIN_PX
+    const constrainedWidth = Math.min(tooltipWidth, Math.max(120, availableWidth))
+    const horizontalPosition = props.tabBarPosition === 'right'
+      ? {
+          left: 'auto',
+          // Anchor the outer tooltip edge directly to the rail. Calculating a
+          // left position from its width drifts when preview content changes
+          // the tooltip's final box size after the first render.
+          right: `${Math.round(window.innerWidth - adjacentEdge + TOOLTIP_OFFSET_PX)}px`,
+          transformOrigin: 'right top'
+        }
+      : {
+          left: `${Math.round(adjacentEdge + TOOLTIP_OFFSET_PX)}px`,
+          right: 'auto',
+          transformOrigin: 'left top'
+        }
     tooltipStyle.value = {
-      insetInlineStart: `${Math.round(rect.right + TOOLTIP_OFFSET_PX)}px`,
-      insetBlockStart: `${Math.round(top)}px`
+      ...horizontalPosition,
+      maxInlineSize: `${Math.round(constrainedWidth)}px`,
+      top: `${Math.round(top)}px`
     }
     return
   }
@@ -392,9 +429,12 @@ function updateTooltipPosition() {
     )
   )
 
+  const top = props.tabBarPosition === 'bottom'
+    ? rect.top - tooltipEstimatedHeight.value - TOOLTIP_OFFSET_PX
+    : rect.bottom + TOOLTIP_OFFSET_PX
   tooltipStyle.value = {
-    insetInlineStart: `${Math.round(left)}px`,
-    insetBlockStart: `${Math.round(rect.bottom + TOOLTIP_OFFSET_PX)}px`
+    left: `${Math.round(left)}px`,
+    top: `${Math.round(Math.max(TOOLTIP_MARGIN_PX, top))}px`
   }
 }
 
@@ -512,6 +552,12 @@ watch(tabAvatarUrl, (avatarUrl) => {
   min-inline-size: 0;
   max-inline-size: none;
   border-radius: calc(6px * var(--ui-roundness));
+  border-block-end: 1px solid transparent;
+}
+
+.tab.bottom {
+  border-radius: 0 0 calc(6px * var(--ui-roundness)) calc(6px * var(--ui-roundness));
+  border-block-start: 0;
   border-block-end: 1px solid transparent;
 }
 
@@ -733,6 +779,7 @@ watch(tabAvatarUrl, (avatarUrl) => {
 }
 
 .tabTooltip {
+  box-sizing: border-box;
   position: fixed;
   z-index: 10000;
   inline-size: max-content;

--- a/src/renderer/components/TabBar/TabBar.css
+++ b/src/renderer/components/TabBar/TabBar.css
@@ -2,7 +2,7 @@
   box-sizing: border-box;
   display: flex;
 
-  /* Sit tabs on the bottom edge so the top radii clear the window chrome and
+  /* Top tabs sit on the bottom edge so their radii clear the window chrome and
      the scrollport clip (overflow-y cannot stay visible while overflow-x scrolls). */
   align-items: flex-end;
   background-color: var(--side-nav-color);
@@ -113,7 +113,32 @@
   font-size: 12px;
 }
 
-/* ===== Vertical layout: fixed column on the inline-start side ===== */
+/* ===== Bottom layout: fixed row on the bottom edge ===== */
+
+.tabBar.position-bottom {
+  align-items: flex-start;
+  block-size: 34px;
+  min-block-size: 34px;
+  position: fixed;
+  inset-block: auto 0;
+
+  /* Some decorated Linux windows paint the last two client pixels underneath
+     the compositor frame. Keep the mirrored tab and its 2px edge gap above
+     that area instead of letting the rounded border disappear behind it. */
+  padding-block: 0 4px;
+}
+
+.tabBar.position-bottom .tabsScrollbar {
+  inset-block: 0 auto;
+}
+
+/* overflow-y is hidden on this scrollport. Leave a pixel inside its clip edge
+   so the selected tab's rounded bottom border is painted in full. */
+.tabBar.position-bottom .tabsContainer {
+  padding-block-end: 1px;
+}
+
+/* ===== Vertical layout: fixed column on either side ===== */
 
 .tabBar.vertical {
   flex-direction: column;
@@ -123,7 +148,6 @@
   overflow: visible;
   position: fixed;
   inset-block: 0;
-  inset-inline-start: 0;
   inline-size: var(--vertical-tab-bar-width, 220px);
   block-size: auto;
   min-block-size: 0;
@@ -133,6 +157,31 @@
   padding-block: 4px 0;
   border-block-end: 0;
 }
+
+/* These settings name physical window edges, independent of text direction. */
+/* stylelint-disable liberty/use-logical-spec */
+.tabBar.vertical.position-left {
+  left: 0;
+  right: auto;
+}
+
+.tabBar.vertical.position-right {
+  left: auto;
+  right: 0;
+}
+
+/* Keep the scrollbar against the window edge, leaving tab content and the
+   resize divider unobstructed on the content-facing side. */
+.tabBar.vertical.position-left .tabsContainer :deep(.os-scrollbar-vertical) {
+  left: 0;
+  right: auto;
+}
+
+.tabBar.vertical.position-right .tabsContainer :deep(.os-scrollbar-vertical) {
+  left: auto;
+  right: 0;
+}
+/* stylelint-enable liberty/use-logical-spec */
 
 .tabBar.vertical .newTabButton {
   align-self: stretch;
@@ -156,7 +205,8 @@
 .tabBarResizeHandle {
   position: absolute;
   inset-block: 0;
-  inset-inline-end: -2.5px;
+  /* stylelint-disable-next-line liberty/use-logical-spec */
+  right: -2.5px;
   inline-size: 5px;
   cursor: col-resize;
   z-index: 1;
@@ -178,3 +228,10 @@
     transparent 4px
   );
 }
+
+/* stylelint-disable liberty/use-logical-spec */
+.tabBar.position-right .tabBarResizeHandle {
+  left: -2.5px;
+  right: auto;
+}
+/* stylelint-enable liberty/use-logical-spec */

--- a/src/renderer/components/TabBar/TabBar.vue
+++ b/src/renderer/components/TabBar/TabBar.vue
@@ -4,7 +4,7 @@
     ref="tabBarRef"
     class="tabBar"
     data-tutorial="tabs"
-    :class="{ vertical }"
+    :class="[`position-${tabBarPosition}`, { vertical }]"
     :style="fixedTabWidthStyle"
   >
     <div
@@ -28,6 +28,7 @@
           :tab="tab"
           :index="index"
           :vertical="vertical"
+          :tab-bar-position="tabBarPosition"
           :offset="tabOffsets[tab.id] || 0"
           :is-dragging="draggingTabIds.has(tab.id)"
           :is-settling="isSettling && settlingTabIds.has(tab.id)"
@@ -89,6 +90,7 @@ import store from '../../store/index'
 import { getConfiguredKeyboardShortcuts } from '../../../constants'
 import { localizeAndAddKeyboardShortcutToActionTitle } from '../../helpers/utils'
 import { normalizeFixedTabWidth } from '../../constants/tabWidth'
+import { isVerticalTabBarPosition, normalizeTabBarPosition } from '../../constants/tabBarPosition'
 import { getTabAvatarUrl } from '../../tabs/tabPreview'
 import { removeLegacyTabAvatar } from '../../helpers/channelThumbnailStorage'
 import { fetchTabAvatarBytes } from '../../helpers/tabAvatar'
@@ -112,8 +114,8 @@ const isElectron = process.env.IS_ELECTRON
 /** @type {import('vue').ComputedRef<Array<{id: string, url: string, title: string, isActive: boolean, isPinned?: boolean, color?: string | null}>>} */
 const tabs = computed(() => store.getters.getTabs)
 
-/** @type {import('vue').ComputedRef<boolean>} */
-const vertical = computed(() => store.getters.getUseVerticalTabBar)
+const tabBarPosition = computed(() => normalizeTabBarPosition(store.getters.getTabBarPosition))
+const vertical = computed(() => isVerticalTabBarPosition(tabBarPosition.value))
 const showTabIcons = computed(() => store.getters.getShowTabIcons)
 const showTabPreviews = computed(() => store.getters.getShowTabPreviews)
 const migratingAvatarTabIds = new Set()
@@ -667,8 +669,9 @@ function handleResizePointerMove(event) {
   if (!bar) return
 
   const rect = bar.getBoundingClientRect()
-  const isRtl = getComputedStyle(bar).direction === 'rtl'
-  const width = isRtl ? rect.right - event.clientX : event.clientX - rect.left
+  const width = tabBarPosition.value === 'right'
+    ? rect.right - event.clientX
+    : event.clientX - rect.left
   const clampedWidth = Math.round(
     Math.max(MIN_VERTICAL_TAB_BAR_WIDTH, Math.min(MAX_VERTICAL_TAB_BAR_WIDTH, width))
   )

--- a/src/renderer/components/ThemeSettings.vue
+++ b/src/renderer/components/ThemeSettings.vue
@@ -107,6 +107,17 @@
       </div>
     </div>
     <template v-if="usingElectron">
+      <FtFlexBox class="themeSelectRow">
+        <FtSelect
+          :placeholder="t('Settings.Theme Settings.Tab Layout.Tab Layout')"
+          :value="tabBarPosition"
+          setting-key="tabBarPosition"
+          :select-names="tabBarPositionNames"
+          :select-values="TAB_BAR_POSITIONS"
+          :icon="['fac', 'horizontal-tabs']"
+          @change="updateTabBarPosition"
+        />
+      </FtFlexBox>
       <FtFlexBox>
         <div class="switchColumn">
           <FtSlider
@@ -326,6 +337,10 @@ import {
   MIN_FIXED_TAB_WIDTH
 } from '../constants/tabWidth'
 import {
+  normalizeTabBarPosition,
+  TAB_BAR_POSITIONS
+} from '../constants/tabBarPosition'
+import {
   MAX_SCROLLBAR_THUMB_WIDTH,
   MIN_SCROLLBAR_THUMB_WIDTH,
   normalizeScrollbarThumbWidth,
@@ -413,6 +428,22 @@ const iconPackNames = computed(() => [
   t('Settings.Theme Settings.Icon Pack.Material Symbols'),
   t('Settings.Theme Settings.Icon Pack.Remix Icon')
 ])
+
+const tabBarPositionNames = computed(() => [
+  t('Settings.Theme Settings.Tab Layout.Horizontal Top'),
+  t('Settings.Theme Settings.Tab Layout.Horizontal Bottom'),
+  t('Settings.Theme Settings.Tab Layout.Vertical Left'),
+  t('Settings.Theme Settings.Tab Layout.Vertical Right')
+])
+
+const tabBarPosition = computed(() => normalizeTabBarPosition(store.getters.getTabBarPosition))
+
+/**
+ * @param {'top' | 'bottom' | 'left' | 'right'} value
+ */
+function updateTabBarPosition(value) {
+  store.dispatch('updateTabBarPosition', value)
+}
 
 const COLOR_VALUES = colors.map(color => color.name)
 const colorNames = useColorTranslations()

--- a/src/renderer/components/TopNav/TopNav.scss
+++ b/src/renderer/components/TopNav/TopNav.scss
@@ -52,8 +52,8 @@
   }
 }
 
-/* Adjust top position when tab bar is present */
-.app:has(.tabBar) .topNav {
+/* Only the top tab bar sits above the navigation. */
+.app.topTabs .topNav {
   inset-block-start: 32px;
 
   @media only screen and (width <= 680px) {
@@ -66,10 +66,24 @@
   inset-block-start: 0;
 
   @media only screen and (width <= 680px) {
-    inset-inline-start: var(--vertical-tab-bar-width, 220px);
     inline-size: calc(100% - var(--vertical-tab-bar-width, 220px));
   }
 }
+
+/* These settings name physical window edges, independent of text direction. */
+/* stylelint-disable liberty/use-logical-spec */
+@media only screen and (width <= 680px) {
+  .app.verticalTabsLeft .topNav {
+    left: var(--vertical-tab-bar-width, 220px);
+    right: 0;
+  }
+
+  .app.verticalTabsRight .topNav {
+    left: 0;
+    right: var(--vertical-tab-bar-width, 220px);
+  }
+}
+/* stylelint-enable liberty/use-logical-spec */
 
 @media only screen and (width <= 680px) {
   /* Beat .navButton { display: inline-flex } from the icon-pack styles. */
@@ -205,8 +219,7 @@
     }
   }
 
-  .navNewWindowButton,
-  .navTabLayoutButton {
+  .navNewWindowButton {
     @media only screen and (width <= 680px) {
       display: none;
     }
@@ -303,7 +316,7 @@
 
 /* The fixed mobile search bar is positioned against the viewport, so it needs
    the same vertical/horizontal offsets as the top nav when a tab bar is present. */
-.app:has(.tabBar) .middle .searchContainer {
+.app.topTabs .middle .searchContainer {
   @media only screen and (width <= 680px) {
     inset-block-start: 92px;
   }
@@ -312,6 +325,19 @@
 .app.verticalTabs .middle .searchContainer {
   @media only screen and (width <= 680px) {
     inset-block-start: 60px;
-    inset-inline-start: var(--vertical-tab-bar-width, 220px);
   }
 }
+
+/* stylelint-disable liberty/use-logical-spec */
+@media only screen and (width <= 680px) {
+  .app.verticalTabsLeft .middle .searchContainer {
+    left: var(--vertical-tab-bar-width, 220px);
+    right: 0;
+  }
+
+  .app.verticalTabsRight .middle .searchContainer {
+    left: 0;
+    right: var(--vertical-tab-bar-width, 220px);
+  }
+}
+/* stylelint-enable liberty/use-logical-spec */

--- a/src/renderer/components/TopNav/TopNav.vue
+++ b/src/renderer/components/TopNav/TopNav.vue
@@ -66,18 +66,6 @@
             :icon="['fas', 'clone']"
           />
         </button>
-        <button
-          v-if="isElectron"
-          class="navTabLayoutButton navButton"
-          :aria-label="tabLayoutText"
-          :title="tabLayoutText"
-          @click="toggleVerticalTabBar"
-        >
-          <FtIcon
-            class="navIcon"
-            :icon="tabLayoutIcon"
-          />
-        </button>
         <RouterLink
           v-if="!hideHeaderLogo"
           class="logo"
@@ -342,22 +330,6 @@ function toggleDownloadsWindow() {
 
 function restoreSettingsWindow() {
   store.dispatch('restoreSettingsWindow')
-}
-
-/** @type {import('vue').ComputedRef<boolean>} */
-const useVerticalTabBar = computed(() => store.getters.getUseVerticalTabBar)
-
-const tabLayoutText = computed(() => {
-  return useVerticalTabBar.value ? t('Use Horizontal Tabs') : t('Use Vertical Tabs')
-})
-
-// Show the layout the button switches to
-const tabLayoutIcon = computed(() => {
-  return useVerticalTabBar.value ? ['fac', 'horizontal-tabs'] : ['fac', 'vertical-tabs']
-})
-
-function toggleVerticalTabBar() {
-  store.dispatch('updateUseVerticalTabBar', !useVerticalTabBar.value)
 }
 
 function createNewWindow() {

--- a/src/renderer/components/ft-shaka-video-player/opentubex/useScrollMiniPlayer.js
+++ b/src/renderer/components/ft-shaka-video-player/opentubex/useScrollMiniPlayer.js
@@ -963,7 +963,7 @@ export function useScrollMiniPlayer({ container, fullWindowEnabled, getUi, isAct
   // firing a window resize, so re-dock explicitly (after the DOM updates, so the
   // rail's new bounds are measurable).
   watch(
-    () => [store.getters.getUseVerticalTabBar, store.getters.getVerticalTabBarWidth],
+    () => [store.getters.getTabBarPosition, store.getters.getVerticalTabBarWidth],
     () => { nextTick(resnapScrollMiniPlayerToEdge) }
   )
 

--- a/src/renderer/constants/tabBarPosition.js
+++ b/src/renderer/constants/tabBarPosition.js
@@ -1,0 +1,15 @@
+export const TAB_BAR_POSITIONS = ['top', 'bottom', 'left', 'right']
+const TAB_BAR_CYCLE_POSITIONS = ['top', 'left', 'bottom', 'right']
+
+export function normalizeTabBarPosition(value) {
+  return TAB_BAR_POSITIONS.includes(value) ? value : 'top'
+}
+
+export function isVerticalTabBarPosition(value) {
+  return value === 'left' || value === 'right'
+}
+
+export function getNextTabBarPosition(value) {
+  const currentIndex = TAB_BAR_CYCLE_POSITIONS.indexOf(normalizeTabBarPosition(value))
+  return TAB_BAR_CYCLE_POSITIONS[(currentIndex + 1) % TAB_BAR_CYCLE_POSITIONS.length]
+}

--- a/src/renderer/helpers/overlayScrollbars.js
+++ b/src/renderer/helpers/overlayScrollbars.js
@@ -55,12 +55,42 @@ function create(initialization) {
   instance.on('destroyed', () => instances.delete(instance))
 
   if (initialization === document.body) {
+    updateBodyScrollbarPosition(instance)
     optimizeBodyScrollbarDrag(instance)
   } else if (initialization.elements?.viewport instanceof HTMLElement) {
     reconcileScrollbarOnResize(initialization.elements.viewport, instance)
   }
 
   return instance
+}
+
+/**
+ * Keeps the page scrollbar clear of a right-side vertical tab rail.
+ * OverlayScrollbars appends this element directly to the body, so app padding
+ * cannot move it out from underneath the fixed rail by itself. A left-side
+ * rail does not cover the scrollbar's normal window edge and needs no offset.
+ *
+ * @param {import('overlayscrollbars').OverlayScrollbars} instance
+ */
+function updateBodyScrollbarPosition(instance) {
+  const { scrollbar } = instance.elements().scrollbarVertical
+  const position = store.getters.getTabBarPosition
+  const width = `${store.getters.getVerticalTabBarWidth}px`
+
+  // OverlayScrollbars transitions physical edges by default. Moving between
+  // layouts should be atomic so the page scrollbar never sweeps across (or
+  // briefly remains behind) the fixed tab rail.
+  scrollbar.classList.add('os-scrollbar-transitionless')
+  scrollbar.style.removeProperty('left')
+  scrollbar.style.removeProperty('right')
+
+  if (position === 'right') {
+    scrollbar.style.right = width
+  }
+
+  requestAnimationFrame(() => {
+    scrollbar.classList.remove('os-scrollbar-transitionless')
+  })
 }
 
 /**
@@ -222,6 +252,17 @@ function optimizeBodyScrollbarDrag(instance) {
  */
 export function initializeAppScrollbars() {
   create(document.body)
+
+  watch(
+    () => [store.getters.getTabBarPosition, store.getters.getVerticalTabBarWidth],
+    () => {
+      for (const [instance, initialization] of instances) {
+        if (initialization === document.body) {
+          updateBodyScrollbarPosition(instance)
+        }
+      }
+    }
+  )
 
   // Rebuilt rather than reconfigured: switching `autoHide` on a live instance
   // leaves its already scheduled hide behind, so the scrollbars disappear again

--- a/src/renderer/helpers/scrollMiniPlayer.js
+++ b/src/renderer/helpers/scrollMiniPlayer.js
@@ -210,6 +210,7 @@ export function getViewportInsets() {
   let topInset = MARGIN
   let leftInset = MARGIN
   let rightInset = MARGIN
+  let bottomInset = MARGIN
 
   const topNav = document.querySelector('.topNav')
   const tabBar = document.querySelector('.tabBar')
@@ -220,12 +221,20 @@ export function getViewportInsets() {
     topInset = Math.max(topInset, rect.bottom + MARGIN)
   } else if (tabBar) {
     const rect = tabBar.getBoundingClientRect()
-    topInset = Math.max(topInset, rect.bottom + MARGIN)
+    if (rect.top < window.innerHeight - rect.bottom) {
+      topInset = Math.max(topInset, rect.bottom + MARGIN)
+    }
   }
 
-  // Keep clear of the fixed vertical tab bar column. It sits on the inline-start
-  // side, which is the right edge under RTL, so derive the physical side from
-  // its bounds rather than assuming the left.
+  if (tabBar && !verticalTabBar) {
+    const rect = tabBar.getBoundingClientRect()
+    if (rect.top >= window.innerHeight - rect.bottom) {
+      bottomInset = Math.max(bottomInset, window.innerHeight - rect.top + MARGIN)
+    }
+  }
+
+  // Keep clear of the fixed vertical tab bar column. Its setting names a
+  // physical edge, so derive that edge from the measured bounds.
   if (verticalTabBar) {
     const rect = verticalTabBar.getBoundingClientRect()
     const viewportWidth = getViewportWidth()
@@ -240,7 +249,7 @@ export function getViewportInsets() {
     top: topInset,
     left: leftInset,
     right: rightInset,
-    bottom: MARGIN,
+    bottom: bottomInset,
   }
 }
 

--- a/src/renderer/helpers/settings-migrations.js
+++ b/src/renderer/helpers/settings-migrations.js
@@ -21,5 +21,12 @@ export function migrateLegacySettings(settings) {
     migratedSettings.hideLiveChatReplay = migratedSettings.hideLiveChat === true
   }
 
+  if (Object.hasOwn(migratedSettings, 'useVerticalTabBar')) {
+    if (!Object.hasOwn(migratedSettings, 'tabBarPosition')) {
+      migratedSettings.tabBarPosition = migratedSettings.useVerticalTabBar === true ? 'left' : 'top'
+    }
+    delete migratedSettings.useVerticalTabBar
+  }
+
   return migratedSettings
 }

--- a/src/renderer/helpers/settings-search-config.js
+++ b/src/renderer/helpers/settings-search-config.js
@@ -35,6 +35,7 @@ export const SETTINGS_SEARCH_SELECT_GROUP_LABELS = {
     'External Link Handling': ['External Link Handling']
   },
   theme: {
+    'Tab Layout': ['Tab Layout'],
     'Toast Position': ['Toast Position'],
     'Base Theme': ['Base Theme'],
     'Main Color Theme': ['Main Color Theme']

--- a/src/renderer/scss-partials/_utils.scss
+++ b/src/renderer/scss-partials/_utils.scss
@@ -20,8 +20,8 @@
    content, so it doesn't add to the top chrome height. */
 @mixin has-tab-bar {
   @at-root {
-    .app:has(.tabBar):not(.verticalTabs) &,
-    .app:has(.tabBar):not(.verticalTabs)#{&} {
+    .app.topTabs &,
+    .app.topTabs#{&} {
       @content;
     }
   }

--- a/src/renderer/store/modules/settings.js
+++ b/src/renderer/store/modules/settings.js
@@ -14,6 +14,7 @@ import { getTabNavigationService } from '../../tabs/TabNavigationService'
 import { getSystemLocale, showToast } from '../../helpers/utils'
 import { DEFAULT_THUMBNAIL_SIZE } from '../../constants/thumbnailSize'
 import { DEFAULT_FIXED_TAB_WIDTH } from '../../constants/tabWidth'
+import { normalizeTabBarPosition } from '../../constants/tabBarPosition'
 import { DEFAULT_SCROLLBAR_THUMB_WIDTH } from '../../constants/scrollbar'
 import { setReducedMotionPreference } from '../../helpers/reducedMotion'
 import { setAnimationSpeed } from '../../helpers/animationSpeed'
@@ -308,7 +309,7 @@ const state = {
   showTabIcons: true,
   showTabPreviews: true,
   updateRelativeTimestamps: true,
-  useVerticalTabBar: false,
+  tabBarPosition: 'top',
   verticalTabBarWidth: 220,
   useFixedTabWidth: false,
   fixedTabWidth: DEFAULT_FIXED_TAB_WIDTH,
@@ -738,7 +739,11 @@ const customGetters = {
   }
 }
 
-const customMutations = {}
+const customMutations = {
+  setTabBarPosition: (state, value) => {
+    state.tabBarPosition = normalizeTabBarPosition(value)
+  }
+}
 
 async function updateValidatedSetting(commit, settingId, value) {
   try {
@@ -778,6 +783,12 @@ const customActions = {
     commit,
     'secColor',
     resolveColor(value, 'Blue')
+  ),
+
+  updateTabBarPosition: ({ commit }, value) => updateValidatedSetting(
+    commit,
+    'tabBarPosition',
+    normalizeTabBarPosition(value)
   ),
 
   updateIconPack: async ({ commit }, value) => {
@@ -839,6 +850,12 @@ const customActions = {
         if (mutationIds.includes(defaultMutationId(_id))) {
           commit(defaultMutationId(_id), value)
         }
+      }
+
+      const hasTabBarPosition = userSettings.some(entry => entry._id === 'tabBarPosition')
+      const legacyVerticalTabBar = userSettings.find(entry => entry._id === 'useVerticalTabBar')
+      if (!hasTabBarPosition && legacyVerticalTabBar?.value === true) {
+        await dispatch('updateTabBarPosition', 'left')
       }
 
       if (state.landingPage === 'settings') {

--- a/src/renderer/views/Popular/Popular.vue
+++ b/src/renderer/views/Popular/Popular.vue
@@ -58,7 +58,7 @@ const { t } = useI18n()
 const isElectron = process.env.IS_ELECTRON
 
 /** @type {import('vue').ComputedRef<boolean>} */
-const hasHorizontalTabBar = computed(() => isElectron && !store.getters.getUseVerticalTabBar)
+const hasHorizontalTabBar = computed(() => isElectron && store.getters.getTabBarPosition === 'top')
 
 const isLoading = ref(false)
 const relativeTimeNow = useRelativeTimeClock()

--- a/src/renderer/views/Subscriptions/Subscriptions.vue
+++ b/src/renderer/views/Subscriptions/Subscriptions.vue
@@ -272,7 +272,7 @@ import {
 const isElectron = process.env.IS_ELECTRON
 
 /** @type {import('vue').ComputedRef<boolean>} */
-const hasHorizontalTabBar = computed(() => isElectron && !store.getters.getUseVerticalTabBar)
+const hasHorizontalTabBar = computed(() => isElectron && store.getters.getTabBarPosition === 'top')
 
 const { tabId, isTabPresented } = useTabContext()
 const { t } = useI18n()

--- a/src/renderer/views/Trending/Trending.vue
+++ b/src/renderer/views/Trending/Trending.vue
@@ -136,7 +136,7 @@ const showTabToast = useTabToast()
 const isElectron = process.env.IS_ELECTRON
 
 /** @type {import('vue').ComputedRef<boolean>} */
-const hasHorizontalTabBar = computed(() => isElectron && !store.getters.getUseVerticalTabBar)
+const hasHorizontalTabBar = computed(() => isElectron && store.getters.getTabBarPosition === 'top')
 
 /** @type {import('vue').ComputedRef<'local' | 'invidious'>} */
 const backendPreference = computed(() => {

--- a/static/locales/en-US.yaml
+++ b/static/locales/en-US.yaml
@@ -518,6 +518,12 @@ Settings:
     Show Tab Previews: Show Tab Previews
     Use Fixed Tab Width: Use Fixed Tab Width in Horizontal Mode
     Tab Width: Tab Width
+    Tab Layout:
+      Tab Layout: Tab Layout
+      Horizontal Top: Horizontal at top
+      Horizontal Bottom: Horizontal at bottom
+      Vertical Left: Vertical on left
+      Vertical Right: Vertical on right
     Show Toast Timeout Indicator: Show toast timeout indicator
     Use Grid Player Menu: Use Grid Player Menu
     Show Progress as Notification: Show progress as notification
@@ -2173,7 +2179,7 @@ KeyboardShortcutPrompt:
   Next Tab: Switch to the next tab
   Previous Tab: Switch to the previous tab
   Switch to Tab: Switch to tab 1–9
-  Toggle Tab Orientation: Switch between horizontal and vertical tabs
+  Toggle Tab Orientation: Switch between tab layouts
   Navigate to Settings: Navigate to the Settings page
   Navigate to History: Navigate to the History page
   Refresh: Refresh feed with latest content

--- a/tests/unit/scroll-mini-player-insets.test.mjs
+++ b/tests/unit/scroll-mini-player-insets.test.mjs
@@ -17,16 +17,26 @@ import {
 /**
  * @param {object} options
  * @param {{ left: number, right: number } | null} [options.verticalTabBarRect]
+ * @param {{ top: number, bottom: number } | null} [options.tabBarRect]
  * @param {number} options.clientWidth usable width (excludes the scrollbar)
  * @param {number} [options.scrollbarWidth]
  * @param {number} [options.clientHeight]
  */
-function stubViewport ({ verticalTabBarRect = null, clientWidth, scrollbarWidth = 0, clientHeight = 800 }) {
+function stubViewport ({
+  verticalTabBarRect = null,
+  tabBarRect = null,
+  clientWidth,
+  scrollbarWidth = 0,
+  clientHeight = 800
+}) {
   global.window = { innerWidth: clientWidth + scrollbarWidth, innerHeight: clientHeight }
   global.document = {
     querySelector (selector) {
       if (selector === '.tabBar.vertical' && verticalTabBarRect) {
         return { getBoundingClientRect: () => verticalTabBarRect }
+      }
+      if (selector === '.tabBar' && tabBarRect) {
+        return { getBoundingClientRect: () => tabBarRect }
       }
       return null
     },
@@ -84,6 +94,19 @@ test('without a vertical tab bar both inline insets stay at the margin', () => {
 
   assert.equal(insets.left, MARGIN)
   assert.equal(insets.right, MARGIN)
+})
+
+test('a bottom tab bar pads the bottom inset', () => {
+  stubViewport({
+    tabBarRect: { top: 766, bottom: 800 },
+    clientWidth: 1000,
+    clientHeight: 800
+  })
+
+  const insets = getViewportInsets()
+
+  assert.equal(insets.top, MARGIN)
+  assert.equal(insets.bottom, 34 + MARGIN)
 })
 
 test('the left dock edge follows the tab rail width', () => {

--- a/tests/unit/settings-migrations.test.mjs
+++ b/tests/unit/settings-migrations.test.mjs
@@ -40,3 +40,18 @@ test('prefers an explicit live chat replay visibility choice', () => {
     hideLiveChatReplay: false,
   })
 })
+
+test('migrates the legacy vertical tab bar preference to the left layout', () => {
+  assert.deepEqual(migrateLegacySettings({ useVerticalTabBar: true }), {
+    tabBarPosition: 'left',
+  })
+})
+
+test('prefers an explicit tab bar position over the legacy preference', () => {
+  assert.deepEqual(migrateLegacySettings({
+    useVerticalTabBar: true,
+    tabBarPosition: 'right',
+  }), {
+    tabBarPosition: 'right',
+  })
+})

--- a/tests/unit/tab-bar-position.test.mjs
+++ b/tests/unit/tab-bar-position.test.mjs
@@ -1,0 +1,26 @@
+import assert from 'node:assert/strict'
+import test from 'node:test'
+
+import {
+  getNextTabBarPosition,
+  isVerticalTabBarPosition,
+  normalizeTabBarPosition,
+} from '../../src/renderer/constants/tabBarPosition.js'
+
+test('normalizes unsupported tab bar positions to the top layout', () => {
+  assert.equal(normalizeTabBarPosition('right'), 'right')
+  assert.equal(normalizeTabBarPosition('diagonal'), 'top')
+})
+
+test('recognizes both vertical positions', () => {
+  assert.equal(isVerticalTabBarPosition('left'), true)
+  assert.equal(isVerticalTabBarPosition('right'), true)
+  assert.equal(isVerticalTabBarPosition('top'), false)
+})
+
+test('cycles through every tab bar position', () => {
+  assert.equal(getNextTabBarPosition('top'), 'left')
+  assert.equal(getNextTabBarPosition('left'), 'bottom')
+  assert.equal(getNextTabBarPosition('bottom'), 'right')
+  assert.equal(getNextTabBarPosition('right'), 'top')
+})

--- a/tests/unit/tab-preview-geometry.test.mjs
+++ b/tests/unit/tab-preview-geometry.test.mjs
@@ -49,6 +49,7 @@ test('excludes both the horizontal tab bar and the header', () => {
     contentTop: 92,
     contentLeft: 0,
     contentRight: VIEWPORT_WIDTH,
+    contentBottom: VIEWPORT_HEIGHT,
     viewportWidth: VIEWPORT_WIDTH,
     viewportHeight: VIEWPORT_HEIGHT,
     devicePixelRatio: 1
@@ -65,6 +66,7 @@ test('excludes the vertical tab bar column and the header', () => {
     contentTop: 60,
     contentLeft: 220,
     contentRight: VIEWPORT_WIDTH,
+    contentBottom: VIEWPORT_HEIGHT,
     viewportWidth: VIEWPORT_WIDTH,
     viewportHeight: VIEWPORT_HEIGHT,
     devicePixelRatio: 1
@@ -86,6 +88,28 @@ test('crops the inline-end vertical tab bar for right-to-left layouts', () => {
   assert.equal(bounds.contentTop, 60)
 })
 
+test('excludes a horizontal tab bar on the bottom edge', () => {
+  const { window, document } = createEnvironment({
+    tabBar: createElement({
+      left: 0,
+      right: VIEWPORT_WIDTH,
+      top: VIEWPORT_HEIGHT - 32,
+      bottom: VIEWPORT_HEIGHT
+    }),
+    topNav: createElement({ left: 0, right: VIEWPORT_WIDTH, top: 0, bottom: 60 })
+  })
+
+  assert.deepEqual(measureTabPreviewContentBounds(window, document), {
+    contentTop: 60,
+    contentLeft: 0,
+    contentRight: VIEWPORT_WIDTH,
+    contentBottom: VIEWPORT_HEIGHT - 32,
+    viewportWidth: VIEWPORT_WIDTH,
+    viewportHeight: VIEWPORT_HEIGHT,
+    devicePixelRatio: 1
+  })
+})
+
 test('keeps the full viewport when the chrome is missing or collapsed', () => {
   const hidden = createEnvironment({
     topNav: createElement({ left: 0, right: 0, top: 0, bottom: 0 })
@@ -94,6 +118,7 @@ test('keeps the full viewport when the chrome is missing or collapsed', () => {
     contentTop: 0,
     contentLeft: 0,
     contentRight: VIEWPORT_WIDTH,
+    contentBottom: VIEWPORT_HEIGHT,
     viewportWidth: VIEWPORT_WIDTH,
     viewportHeight: VIEWPORT_HEIGHT,
     devicePixelRatio: 1


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Make sure to follow the contributing guidelines. -->
<!-- Important note, we may remove your pull request if you do not use this provided PR template correctly. -->
<!-- Agent instructions: Preserve every heading, comment, and marker in this template. Never remove or rewrite the release-note-category:start/end, release-note:start/end, or release-note-image:start/end marker pairs. Never remove or rewrite the Release note images section; leave its contents for a human. -->

## Pull Request Type
<!-- Please select what type of pull request this is: [x] -->
- [ ] Bugfix
- [x] Feature Implementation
- [ ] Documentation
- [ ] Other

## Related issue
<!-- Please link the issue your pull request is referring to. -->
<!-- If this pull request fully resolves the relevant issue, put "closes" before the issue number. -->
<!-- Example: "closes #123456". -->

Closes #677

## Description
<!-- Please write a clear and concise description of what the pull request does. -->

Tab placement was limited to the top or left and was switched from an icon in the app header. This adds top, bottom, left, and right tab layouts and moves the choice into a select dropdown in Theme settings.

The F1 shortcut now cycles through top, left, bottom, and right. Layout-aware positioning keeps navigation, scrollbars, tab previews, toasts, menus, progress UI, and the scroll mini player clear of every tab-bar edge. Existing vertical-tab preferences migrate to the corresponding new layout.

## Release note category
<!-- Select exactly one category. Every pull request must select one. -->
<!-- Select "Not noteworthy" when the pull request fixes a bug in or improves functionality that has not yet appeared in a stable release. -->
<!-- release-note-category:start -->
- [ ] Not noteworthy
- [ ] Highlights
- [x] More improvements
- [ ] Fixed bugs
<!-- release-note-category:end -->

## Release note
<!-- Required unless "Not noteworthy" is selected. -->
<!-- Write one concise, user-facing entry without a leading bullet. -->
<!-- release-note:start -->
Choose whether tabs appear at the top, bottom, left, or right of the window.
<!-- release-note:end -->

## Release note images
<!-- Human-only: Agents must preserve this entire section and leave it empty. -->
<!-- Optional. Paste one or more Markdown images or HTML image tags here. -->
<!-- The release notes will use an HTML image tag and limit images taller than 300 pixels. -->
<!-- release-note-image:start -->
<img width="239" height="225" alt="image" src="https://github.com/user-attachments/assets/358e09be-feb3-4dd2-809e-d868f93c7da5" />
<!-- release-note-image:end -->

## Testing
<!-- How can reviewers verify that the PR produces correct results? -->
<!-- Please provide instructions so that others can ensure that your pull request would produce correct results. For examples see, https://github.com/FreeTubeApp/FreeTube/pull/5743, https://github.com/FreeTubeApp/FreeTube/pull/7349, https://github.com/FreeTubeApp/FreeTube/pull/5125, https://github.com/FreeTubeApp/FreeTube/pull/7338 -->
<!-- Agent instructions: Only write human-facing steps that explain how to verify the change while running this branch in dev mode. Include expected results and, when applicable, helpful console snippets for interactive verification. Do not include automated checks, commands, results, pass counts, or CI status. -->

1. Run the branch in dev mode and open Settings → Theme.
2. Select each Tab Layout option. Tabs should move to the chosen edge without covering the page scrollbar, navigation, or page content.
3. With tabs on the right, hover a tab and confirm its preview stays aligned and clear of the relocated page scrollbar.
4. With tabs at the bottom, confirm the selected tab has a complete rounded bottom border and mirrors the top-tab appearance.
5. Press F1 repeatedly. The layouts should cycle top → left → bottom → right → top.
6. Confirm the old tab-layout button is absent from the app header and the shortcut description reads “Switch between tab layouts”.

## Additional context
<!-- Add any other context about the pull request here. -->

The legacy `useVerticalTabBar` setting is retained for compatibility and migrated to the new `tabBarPosition` setting.
