### PR TITLE
feat(player): add quick playback speed bar to Shorts

### DIFF
--- a/e2e/tests/offline/watch-page.spec.mjs
+++ b/e2e/tests/offline/watch-page.spec.mjs
@@ -131,18 +131,16 @@ test.describe('Shorts transcript navigation', () => {
     await expect.poll(opacity).toBe(1)
     await attachScreenshot('Shorts quick playback speed bar')
 
-    const seekBarBounds = await seekBar.boundingBox()
-    expect(seekBarBounds).not.toBeNull()
-    await seekBar.dispatchEvent('mousemove', {
-      clientX: seekBarBounds.x + seekBarBounds.width / 2,
-      clientY: seekBarBounds.y + seekBarBounds.height / 2
-    })
+    const playbackRateButton = playbackRateBar.getByRole('button', { name: '1.25x', exact: true })
+    await playbackRateButton.click()
+    await expect(playbackRateButton).toBeFocused()
+    await expect.poll(() => video.evaluate(element => element.playbackRate)).toBe(1.25)
+
+    await seekBar.hover()
     await expect.poll(opacity).toBe(0)
+    await expect(playbackRateButton).not.toBeFocused()
     expect(await seekBar.evaluate(element => getComputedStyle(element).zIndex)).toBe('3')
     expect(await controlPanel.evaluate(element => getComputedStyle(element).zIndex)).toBe('2')
-
-    await playbackRateBar.getByRole('button', { name: '1.25x', exact: true }).click()
-    await expect.poll(() => video.evaluate(element => element.playbackRate)).toBe(1.25)
   })
 
   test('preserves the panel until navigation reaches a captionless Short', async ({ app, page }) => {

--- a/e2e/tests/offline/watch-page.spec.mjs
+++ b/e2e/tests/offline/watch-page.spec.mjs
@@ -105,26 +105,38 @@ test.describe('Shorts transcript navigation', () => {
     expect(playerBounds).not.toBeNull()
     expect(rateBarBounds).not.toBeNull()
 
-    await page.mouse.move(playerBounds.x + playerBounds.width / 2, playerBounds.y + 80)
+    await player.dispatchEvent('mousemove', {
+      clientX: playerBounds.x + playerBounds.width / 2,
+      clientY: playerBounds.y + 80
+    })
     await expect.poll(opacity).toBe(0)
 
-    await page.mouse.move(rateBarBounds.x + rateBarBounds.width / 2, rateBarBounds.y - 24)
+    await player.dispatchEvent('mousemove', {
+      clientX: rateBarBounds.x + rateBarBounds.width / 2,
+      clientY: rateBarBounds.y - 24
+    })
     await expect.poll(opacity).toBeGreaterThan(0.2)
     expect(await opacity()).toBeLessThan(0.5)
 
-    await page.mouse.move(rateBarBounds.x + rateBarBounds.width / 2, rateBarBounds.y - 6)
+    await player.dispatchEvent('mousemove', {
+      clientX: rateBarBounds.x + rateBarBounds.width / 2,
+      clientY: rateBarBounds.y - 6
+    })
     await expect.poll(opacity).toBeGreaterThan(0.75)
 
-    await page.mouse.move(rateBarBounds.x + rateBarBounds.width / 2, rateBarBounds.y + rateBarBounds.height / 2)
+    await playbackRateBar.dispatchEvent('mousemove', {
+      clientX: rateBarBounds.x + rateBarBounds.width / 2,
+      clientY: rateBarBounds.y + rateBarBounds.height / 2
+    })
     await expect.poll(opacity).toBe(1)
     await attachScreenshot('Shorts quick playback speed bar')
 
     const seekBarBounds = await seekBar.boundingBox()
     expect(seekBarBounds).not.toBeNull()
-    await page.mouse.move(
-      seekBarBounds.x + seekBarBounds.width / 2,
-      seekBarBounds.y + seekBarBounds.height / 2
-    )
+    await seekBar.dispatchEvent('mousemove', {
+      clientX: seekBarBounds.x + seekBarBounds.width / 2,
+      clientY: seekBarBounds.y + seekBarBounds.height / 2
+    })
     await expect.poll(opacity).toBe(0)
     expect(await seekBar.evaluate(element => getComputedStyle(element).zIndex)).toBe('3')
     expect(await controlPanel.evaluate(element => getComputedStyle(element).zIndex)).toBe('2')
@@ -209,12 +221,6 @@ test('a background watch tab stays loading until its cached avatar is ready', as
   await mockPlayableWatchPage(app, page)
 
   await page.evaluate(() => {
-    const store = document.querySelector('#app').__vue_app__.config.globalProperties.$store
-    store.commit('setVideoAvatar', {
-      videoId: 'jNQXAC9IVRw',
-      avatar: 'data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mNk+M/wHwAF/gL+Xw4AAAAASUVORK5CYII='
-    })
-
     window.__backgroundWatchIconStates = []
     const record = () => {
       for (const tab of document.querySelectorAll('.tab')) {
@@ -241,6 +247,16 @@ test('a background watch tab stays loading until its cached avatar is ready', as
   const tab = page.locator(`.tab[data-tab-id="${watchTab.id}"]`)
 
   await expect(tab.locator('.loadingDot')).toBeVisible()
+  const avatarCached = await page.evaluate(async tabId => {
+    const avatarBase64 = 'iVBORw0KGgoAAAANSUhEUgAAAAEAAAABAQMAAAAl21bKAAAAA1BMVEUzZpk7I4HSAAAACklEQVQI12NgAAAAAgAB4iG8MwAAAABJRU5ErkJggg=='
+    const avatarBytes = Uint8Array.from(atob(avatarBase64), character => character.charCodeAt(0))
+    return await window.ftElectron.tabs.updateAvatar(
+      avatarBytes.buffer,
+      tabId,
+      '/watch/jNQXAC9IVRw'
+    )
+  }, watchTab.id)
+  expect(avatarCached).toBe(true)
   await expect(tab.locator('.loadingDot')).toHaveCount(0)
   await expect.poll(() => page.evaluate(tabId => (
     window.__backgroundWatchIconStates.some(state => state.id === tabId && !state.loading && state.avatar)

--- a/e2e/tests/offline/watch-page.spec.mjs
+++ b/e2e/tests/offline/watch-page.spec.mjs
@@ -98,12 +98,8 @@ test.describe('Shorts transcript navigation', () => {
     await expect(playbackRateBar).toHaveCount(1)
     await expect(playbackRateBar.getByRole('button')).toHaveCount(9)
 
-    const [playerBounds, rateBarBounds] = await Promise.all([
-      player.boundingBox(),
-      playbackRateBar.boundingBox(),
-    ])
+    const playerBounds = await player.boundingBox()
     expect(playerBounds).not.toBeNull()
-    expect(rateBarBounds).not.toBeNull()
 
     await player.dispatchEvent('mousemove', {
       clientX: playerBounds.x + playerBounds.width / 2,
@@ -111,6 +107,8 @@ test.describe('Shorts transcript navigation', () => {
     })
     await expect.poll(opacity).toBe(0)
 
+    let rateBarBounds = await playbackRateBar.boundingBox()
+    expect(rateBarBounds).not.toBeNull()
     await player.dispatchEvent('mousemove', {
       clientX: rateBarBounds.x + rateBarBounds.width / 2,
       clientY: rateBarBounds.y - 24
@@ -118,12 +116,16 @@ test.describe('Shorts transcript navigation', () => {
     await expect.poll(opacity).toBeGreaterThan(0.2)
     expect(await opacity()).toBeLessThan(0.5)
 
+    rateBarBounds = await playbackRateBar.boundingBox()
+    expect(rateBarBounds).not.toBeNull()
     await player.dispatchEvent('mousemove', {
       clientX: rateBarBounds.x + rateBarBounds.width / 2,
       clientY: rateBarBounds.y - 6
     })
     await expect.poll(opacity).toBeGreaterThan(0.75)
 
+    rateBarBounds = await playbackRateBar.boundingBox()
+    expect(rateBarBounds).not.toBeNull()
     await playbackRateBar.dispatchEvent('mousemove', {
       clientX: rateBarBounds.x + rateBarBounds.width / 2,
       clientY: rateBarBounds.y + rateBarBounds.height / 2

--- a/e2e/tests/offline/watch-page.spec.mjs
+++ b/e2e/tests/offline/watch-page.spec.mjs
@@ -59,6 +59,7 @@ test.describe('Shorts transcript navigation', () => {
       settings: {
         ...WATCH_PAGE_SEED,
         useCustomShortsPlayer: true,
+        useQuickPlaybackSpeedBar: true,
         fetchSubscriptionsAutomatically: false
       },
       profiles: [{
@@ -78,6 +79,58 @@ test.describe('Shorts transcript navigation', () => {
         shortsTimestamp: new Date().toISOString()
       }]
     }
+  })
+
+  test('shows quick playback speeds near the pointer without covering the seek preview', async ({ app, page, attachScreenshot }) => {
+    await mockPlayableWatchPage(app, page)
+    await page.locator(sel.searchInput)
+      .fill(`https://www.youtube.com/shorts/${CAPTIONED_SHORT_IDS[0]}`)
+    await page.locator(sel.searchInput).press('Enter')
+    await expect(page).toHaveURL(new RegExp(`#\\/watch\\/${CAPTIONED_SHORT_IDS[0]}\\?short=true`))
+    const video = await waitForPlayback(page)
+
+    const player = page.locator('.ftVideoPlayer.shortsPlayer')
+    const controlPanel = player.locator('.shaka-controls-button-panel')
+    const playbackRateBar = controlPanel.locator('.ft-quick-playback-rate-bar')
+    const seekBar = player.locator('.shaka-seek-bar-container')
+    const opacity = () => controlPanel.evaluate(element => Number(getComputedStyle(element).opacity))
+
+    await expect(playbackRateBar).toHaveCount(1)
+    await expect(playbackRateBar.getByRole('button')).toHaveCount(9)
+
+    const [playerBounds, rateBarBounds] = await Promise.all([
+      player.boundingBox(),
+      playbackRateBar.boundingBox(),
+    ])
+    expect(playerBounds).not.toBeNull()
+    expect(rateBarBounds).not.toBeNull()
+
+    await page.mouse.move(playerBounds.x + playerBounds.width / 2, playerBounds.y + 80)
+    await expect.poll(opacity).toBe(0)
+
+    await page.mouse.move(rateBarBounds.x + rateBarBounds.width / 2, rateBarBounds.y - 24)
+    await expect.poll(opacity).toBeGreaterThan(0.2)
+    expect(await opacity()).toBeLessThan(0.5)
+
+    await page.mouse.move(rateBarBounds.x + rateBarBounds.width / 2, rateBarBounds.y - 6)
+    await expect.poll(opacity).toBeGreaterThan(0.75)
+
+    await page.mouse.move(rateBarBounds.x + rateBarBounds.width / 2, rateBarBounds.y + rateBarBounds.height / 2)
+    await expect.poll(opacity).toBe(1)
+    await attachScreenshot('Shorts quick playback speed bar')
+
+    const seekBarBounds = await seekBar.boundingBox()
+    expect(seekBarBounds).not.toBeNull()
+    await page.mouse.move(
+      seekBarBounds.x + seekBarBounds.width / 2,
+      seekBarBounds.y + seekBarBounds.height / 2
+    )
+    await expect.poll(opacity).toBe(0)
+    expect(await seekBar.evaluate(element => getComputedStyle(element).zIndex)).toBe('3')
+    expect(await controlPanel.evaluate(element => getComputedStyle(element).zIndex)).toBe('2')
+
+    await playbackRateBar.getByRole('button', { name: '1.25x', exact: true }).click()
+    await expect.poll(() => video.evaluate(element => element.playbackRate)).toBe(1.25)
   })
 
   test('preserves the panel until navigation reaches a captionless Short', async ({ app, page }) => {

--- a/src/renderer/components/ft-shaka-video-player/ft-shaka-video-player.css
+++ b/src/renderer/components/ft-shaka-video-player/ft-shaka-video-player.css
@@ -228,6 +228,65 @@
   display: none;
 }
 
+/*
+  Keep the quick speed presets in their familiar lower-player position without
+  bringing back the standard Shorts control panel. The row scrolls when custom
+  labels or presets outgrow the narrow portrait player.
+*/
+.ftVideoPlayer.shortsPlayer :deep(
+  .shaka-controls-button-panel:has(> .ft-quick-playback-rate-bar)
+) {
+  position: absolute;
+  inset-block-end: 14px;
+  inset-inline: 16px;
+  z-index: 2;
+  display: flex;
+  justify-content: center;
+  box-sizing: border-box;
+  inline-size: auto;
+  block-size: auto;
+  padding: 0;
+  opacity: var(--shorts-quick-playback-rate-bar-opacity, 0);
+  pointer-events: none;
+  transition: opacity 50ms linear;
+}
+
+.ftVideoPlayer.shortsPlayer :deep(
+  .shaka-controls-button-panel:has(> .ft-quick-playback-rate-bar:is(:hover, :focus-within))
+) {
+  opacity: 1;
+}
+
+.ftVideoPlayer.shortsPlayer :deep(
+  .shaka-controls-button-panel > :not(.ft-quick-playback-rate-bar)
+) {
+  display: none !important;
+}
+
+.ftVideoPlayer.shortsPlayer :deep(
+  .shaka-controls-button-panel > .ft-quick-playback-rate-bar
+) {
+  max-inline-size: 100%;
+  margin: 0;
+  padding-block: 2px;
+  padding-inline: 6px;
+  border-radius: calc(999px * var(--ui-roundness));
+  background-color: rgb(0 0 0 / 32%);
+  backdrop-filter: blur(8px) saturate(120%);
+  pointer-events: auto;
+}
+
+.ftVideoPlayer.shortsPlayer:is(:fullscreen, .fullWindow) :deep(
+  .shaka-controls-button-panel:has(> .ft-quick-playback-rate-bar)
+) {
+  inset-inline: auto;
+  inset-inline-start: max(
+    calc((100% - var(--shorts-video-width)) / 2),
+    var(--shorts-metadata-min-width)
+  );
+  inline-size: var(--shorts-video-width);
+}
+
 .ftVideoPlayer.shortsPlayer :deep(.shaka-bottom-controls) {
   position: absolute;
   inset-block-end: 0;
@@ -257,6 +316,12 @@
   z-index: 1;
   opacity: 1;
   transition: none;
+}
+
+.ftVideoPlayer.shortsPlayer:has(:deep(.ft-quick-playback-rate-bar)) :deep(
+  .shaka-seek-bar-container
+) {
+  z-index: 3;
 }
 
 .ftVideoPlayer.shortsPlayer:is(:fullscreen, .fullWindow) {

--- a/src/renderer/components/ft-shaka-video-player/ft-shaka-video-player.js
+++ b/src/renderer/components/ft-shaka-video-player/ft-shaka-video-player.js
@@ -6284,7 +6284,17 @@ export default defineComponent({
 
       const target = event.target instanceof Element ? event.target : null
       const playbackRateBar = playerContainer.querySelector('.ft-quick-playback-rate-bar')
-      if (!playbackRateBar || target?.closest('.shaka-seek-bar-container')) {
+      const seekBarTarget = target?.closest('.shaka-seek-bar-container')
+      const focusedElement = document.activeElement
+      if (
+        seekBarTarget &&
+        focusedElement instanceof HTMLElement &&
+        playbackRateBar?.contains(focusedElement)
+      ) {
+        focusedElement.blur()
+      }
+
+      if (!playbackRateBar || seekBarTarget) {
         playerContainer.style.setProperty('--shorts-quick-playback-rate-bar-opacity', '0')
         return
       }

--- a/src/renderer/components/ft-shaka-video-player/ft-shaka-video-player.js
+++ b/src/renderer/components/ft-shaka-video-player/ft-shaka-video-player.js
@@ -3608,7 +3608,14 @@ export default defineComponent({
 
         elementList = uiConfig.overflowMenuButtons
 
-        uiConfig.controlPanelElements.push('ft_caption_toggle', 'overflow_menu', 'fullscreen')
+        uiConfig.controlPanelElements.push(
+          ...(props.shortsPlayer && useQuickPlaybackSpeedBar.value && !isLive.value
+            ? ['ft_quick_playback_rate_bar']
+            : []),
+          'ft_caption_toggle',
+          'overflow_menu',
+          'fullscreen'
+        )
       } else {
         uiConfig.controlPanelElements.push(
           ...(useQuickPlaybackSpeedBar.value && !isLive.value ? ['ft_quick_playback_rate_bar'] : []),
@@ -6252,10 +6259,47 @@ export default defineComponent({
 
     function handlePlayerMouseLeave(event) {
       handleScrollMiniPlayerLeave(event)
+      container.value?.style.removeProperty('--shorts-quick-playback-rate-bar-opacity')
 
       if (props.shortsPlayer && !video.value.paused) {
         ui?.getControls().getControlsContainer().removeAttribute('shown')
       }
+    }
+
+    /**
+     * Fade the Shorts quick playback controls in as the pointer approaches
+     * without adding an invisible element that intercepts clicks.
+     * @param {MouseEvent} event
+     */
+    function updateShortsQuickPlaybackRateBarProximity(event) {
+      const playerContainer = container.value
+      if (!playerContainer) {
+        return
+      }
+
+      if (!props.shortsPlayer) {
+        playerContainer.style.removeProperty('--shorts-quick-playback-rate-bar-opacity')
+        return
+      }
+
+      const target = event.target instanceof Element ? event.target : null
+      const playbackRateBar = playerContainer.querySelector('.ft-quick-playback-rate-bar')
+      if (!playbackRateBar || target?.closest('.shaka-seek-bar-container')) {
+        playerContainer.style.setProperty('--shorts-quick-playback-rate-bar-opacity', '0')
+        return
+      }
+
+      const proximity = 36
+      const bounds = playbackRateBar.getBoundingClientRect()
+      const distanceX = Math.max(bounds.left - event.clientX, 0, event.clientX - bounds.right)
+      const distanceY = Math.max(bounds.top - event.clientY, 0, event.clientY - bounds.bottom)
+      const distance = Math.hypot(distanceX, distanceY)
+      const opacity = Math.max(0, 1 - (distance / proximity))
+
+      playerContainer.style.setProperty(
+        '--shorts-quick-playback-rate-bar-opacity',
+        opacity.toFixed(3)
+      )
     }
 
     /**
@@ -6266,6 +6310,8 @@ export default defineComponent({
      * @param {MouseEvent} event
      */
     function handlePlayerMouseMove(event) {
+      updateShortsQuickPlaybackRateBarProximity(event)
+
       const videoElement = video.value
       revealPausedInterface()
 


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Make sure to follow the contributing guidelines. -->
<!-- Important note, we may remove your pull request if you do not use this provided PR template correctly. -->
<!-- Agent instructions: Preserve every heading, comment, and marker in this template. Never remove or rewrite the release-note-category:start/end, release-note:start/end, or release-note-image:start/end marker pairs. Never remove or rewrite the Release note images section; leave its contents for a human. -->

## Pull Request Type
<!-- Please select what type of pull request this is: [x] -->
- [ ] Bugfix
- [x] Feature Implementation
- [ ] Documentation
- [ ] Other

## Related issue
<!-- Please link the issue your pull request is referring to. -->
<!-- If this pull request fully resolves the relevant issue, put "closes" before the issue number. -->
<!-- Example: "closes #123456". -->
Closes #742.

## Description
<!-- Please write a clear and concise description of what the pull request does. -->
The YouTube-style Shorts player did not expose the optional Quick Playback Speed Bar, forcing users through the playback-rate menu.

This adds the configured quick-speed presets above the Shorts seek bar. The bar fades according to pointer distance, stays accessible by keyboard, clears the seek preview while scrubbing, works in full-window and fullscreen layouts, and reuses the existing playback-rate and per-channel-default behavior.

## Release note category
<!-- Select exactly one category. Every pull request must select one. -->
<!-- Select "Not noteworthy" when the pull request fixes a bug in or improves functionality that has not yet appeared in a stable release. -->
<!-- release-note-category:start -->
- [ ] Not noteworthy
- [ ] Highlights
- [x] More improvements
- [ ] Fixed bugs
<!-- release-note-category:end -->

## Release note
<!-- Required unless "Not noteworthy" is selected. -->
<!-- Write one concise, user-facing entry without a leading bullet. -->
<!-- release-note:start -->
Quick playback speed controls are now available in the YouTube-style Shorts player.
<!-- release-note:end -->

## Release note images
<!-- Human-only: Agents must preserve this entire section and leave it empty. -->
<!-- Optional. Paste one or more Markdown images or HTML image tags here. -->
<!-- The release notes will use an HTML image tag and limit images taller than 300 pixels. -->
<!-- release-note-image:start -->
<img width="1249" height="406" alt="Image" src="https://github.com/user-attachments/assets/84ec5eb9-2d69-4fcf-a6fd-d71b42308487" />
<!-- release-note-image:end -->

## Testing
<!-- How can reviewers verify that the PR produces correct results? -->
<!-- Please provide instructions so that others can ensure that your pull request produces correct results. For examples see, https://github.com/FreeTubeApp/FreeTube/pull/5743, https://github.com/FreeTubeApp/FreeTube/pull/7349, https://github.com/FreeTubeApp/FreeTube/pull/5125, https://github.com/FreeTubeApp/FreeTube/pull/7338 -->
<!-- Agent instructions: Only write human-facing steps that explain how to verify the change while running this branch in dev mode. Include expected results and, when applicable, helpful console snippets for interactive verification. Do not include automated checks, commands, results, pass counts, or CI status. -->
1. Enable both the YouTube-style Shorts player and Quick Playback Speed Bar in Player Settings.
2. Open a Short and move the pointer toward the bottom of the video. The configured speed presets should fade in progressively before the pointer reaches them.
3. Move away from the presets. They should fade out regardless of whether playback is running, paused, or ended.
4. Hover the seek bar. The speed presets should clear so the seek thumbnail remains on top.
5. Select a speed preset and confirm playback changes immediately.
6. Repeat in full-window and fullscreen modes; the bar should stay aligned with the portrait video.

## Additional context
<!-- Add any other context about the pull request here. -->