### PR TITLE
fix(player): close auto PiP when native focus returns

### DIFF
--- a/e2e/tests/network/auto-picture-in-picture.spec.mjs
+++ b/e2e/tests/network/auto-picture-in-picture.spec.mjs
@@ -7,9 +7,9 @@ const VIDEO = { id: 'jNQXAC9IVRw', title: 'Me at the zoo', url: 'https://www.you
 test.use({ seed: { settings: { autoPictureInPictureTriggers: ['tab', 'minimize', 'blur'] } } })
 
 /**
- * The renderer derives the focus part of the auto PiP triggers from
+ * The renderer initializes the focus part of the auto PiP triggers from
  * `document.hasFocus()`, which is not controllable from the test (and is
- * unreliable without a window manager), so it is driven explicitly here.
+ * unreliable without a window manager), so the initial value is stubbed here.
  */
 async function stubFocus(page) {
   await page.evaluate(() => {
@@ -18,11 +18,17 @@ async function stubFocus(page) {
   })
 }
 
-async function setFocused(page, focused) {
+async function emitFocusedState(app, focused) {
+  await app.electronApp.evaluate(({ BrowserWindow }, event) => {
+    BrowserWindow.getAllWindows()[0].emit(event)
+  }, focused ? 'focus' : 'blur')
+}
+
+async function setFocused(app, page, focused) {
   await page.evaluate((value) => {
     window.__e2eFocused = value
-    window.dispatchEvent(new Event(value ? 'focus' : 'blur'))
   }, focused)
+  await emitFocusedState(app, focused)
 }
 
 /**
@@ -45,7 +51,7 @@ function openVideo(page) {
 }
 
 test.describe('automatic Picture-in-Picture', () => {
-  test.beforeEach(async ({ page, innertube }) => {
+  test.beforeEach(async ({ app, page, innertube }) => {
     // Auto PiP only applies to a playing video, and recorded fixtures cannot
     // hydrate a watch page or serve media streams.
     test.skip(innertube.replay, 'no recorded fixtures for this video')
@@ -55,7 +61,7 @@ test.describe('automatic Picture-in-Picture', () => {
     await waitForPlaybackOrSkip(test, page)
     // The blur trigger would fire on its own if the harness window never
     // gained focus, so start from a known focused state.
-    await setFocused(page, true)
+    await setFocused(app, page, true)
     await expect.poll(() => pictureInPictureActive(page)).toBe(false)
   })
 
@@ -78,7 +84,7 @@ test.describe('automatic Picture-in-Picture', () => {
     await setMinimized(app, false)
     await expect.poll(() => pictureInPictureActive(page)).toBe(false)
 
-    await setFocused(page, false)
+    await setFocused(app, page, false)
     // Longer than the delay after which the blur trigger is re-checked, so a
     // reopen would have happened by now.
     await page.waitForTimeout(2000)
@@ -91,11 +97,23 @@ test.describe('automatic Picture-in-Picture', () => {
     await setMinimized(app, false)
     await expect.poll(() => pictureInPictureActive(page)).toBe(false)
 
-    await setFocused(page, true)
-    await setFocused(page, false)
+    await setFocused(app, page, true)
+    await setFocused(app, page, false)
     await expect.poll(() => pictureInPictureActive(page)).toBe(true)
 
-    await setFocused(page, true)
+    await setFocused(app, page, true)
+    await expect.poll(() => pictureInPictureActive(page)).toBe(false)
+  })
+
+  // Regression (#773): Windows can restore native BrowserWindow focus after
+  // the covering window is closed without dispatching a renderer focus event.
+  test('native focus closes PiP when renderer focus remains stale', async ({ app, page }) => {
+    await setFocused(app, page, false)
+    await expect.poll(() => pictureInPictureActive(page)).toBe(true)
+
+    // Deliberately keep document.hasFocus() false and only emit the native
+    // event that Electron receives when the covering application closes.
+    await emitFocusedState(app, true)
     await expect.poll(() => pictureInPictureActive(page)).toBe(false)
   })
 
@@ -105,7 +123,7 @@ test.describe('automatic Picture-in-Picture', () => {
   test('blur and minimize together open PiP exactly once', async ({ app, page }) => {
     // Deliberately not awaiting the PiP state in between, so the second
     // trigger lands while the PiP request is still in flight.
-    await setFocused(page, false)
+    await setFocused(app, page, false)
     await setMinimized(app, true)
 
     await expect.poll(() => pictureInPictureActive(page)).toBe(true)
@@ -125,8 +143,8 @@ test.describe('automatic Picture-in-Picture', () => {
 
     // Re-evaluating the triggers while the window is still minimized must not
     // undo the manual dismissal.
-    await setFocused(page, false)
-    await setFocused(page, true)
+    await setFocused(app, page, false)
+    await setFocused(app, page, true)
     await page.waitForTimeout(2000)
     expect(await pictureInPictureActive(page)).toBe(false)
   })

--- a/e2e/tests/offline/video-metadata-history.spec.mjs
+++ b/e2e/tests/offline/video-metadata-history.spec.mjs
@@ -123,6 +123,11 @@ test('stores and presents every previous metadata version', async ({ app, page }
 
     const dialog = page.getByRole('dialog', { name: 'Metadata history' })
     await expect(dialog).toBeVisible()
+    // Geometry captured during the prompt's scale/translate entrance animation
+    // can differ by fractional pixels even though the fixed header never moves.
+    await dialog.evaluate(element => Promise.all(
+      element.getAnimations({ subtree: false }).map(animation => animation.finished)
+    ))
     await expect(dialog.getByRole('heading', { name: 'Title history' })).toBeVisible()
     await expect(dialog.getByRole('heading', { name: 'Thumbnail history' })).toBeVisible()
     await expect(dialog.getByRole('heading', { name: 'Description history' })).toBeVisible()

--- a/src/constants.js
+++ b/src/constants.js
@@ -81,6 +81,7 @@ const IpcChannels = {
   TABS_SET_PLAYBACK_STATE: 'tabs-set-playback-state',
   TABS_REQUEST_PICTURE_IN_PICTURE: 'tabs-request-picture-in-picture',
   WINDOW_MINIMIZED_STATE: 'window-minimized-state',
+  WINDOW_FOCUSED_STATE: 'window-focused-state',
   TABS_REQUEST_FULLSCREEN: 'tabs-request-fullscreen',
   TABS_SET_TAB_BAR_SCROLL: 'tabs-set-tab-bar-scroll',
   TABS_SET_CONTEXT_MENU_TAB: 'tabs-set-context-menu-tab',

--- a/src/main/index.js
+++ b/src/main/index.js
@@ -2453,6 +2453,17 @@ function runApp() {
     newWindow.on('hide', () => sendMinimizedState(true))
     newWindow.on('show', () => sendMinimizedState(false))
 
+    // Renderer focus events can be skipped on Windows when focus returns after
+    // another application's window is closed. Forward the native state so
+    // blur-triggered auto PiP can still re-embed the video.
+    const sendFocusedState = (focused) => {
+      if (!newWindow.isDestroyed() && !newWindow.webContents.isDestroyed()) {
+        newWindow.webContents.send(IpcChannels.WINDOW_FOCUSED_STATE, focused)
+      }
+    }
+    newWindow.on('focus', () => sendFocusedState(true))
+    newWindow.on('blur', () => sendFocusedState(false))
+
     if (isTrayOnMinimizeSupported) {
       function manageTray(window, removeWindow = false) {
         if (tray) {

--- a/src/preload/interface.js
+++ b/src/preload/interface.js
@@ -175,6 +175,18 @@ export default {
   },
 
   /**
+   * Listen for native window focus changes, which are more reliable than DOM
+   * focus events when another application closes its covering window.
+   * @param {(focused: boolean) => void} handler
+   * @returns {() => void} unsubscribe
+   */
+  handleWindowFocusedState: (handler) => {
+    const listener = (_, focused) => handler(focused)
+    ipcRenderer.on(IpcChannels.WINDOW_FOCUSED_STATE, listener)
+    return () => ipcRenderer.removeListener(IpcChannels.WINDOW_FOCUSED_STATE, listener)
+  },
+
+  /**
    * @param {string} key
    * @returns {Promise<ArrayBuffer>}
    */

--- a/src/renderer/components/ft-shaka-video-player/opentubex/useAutoPictureInPicture.js
+++ b/src/renderer/components/ft-shaka-video-player/opentubex/useAutoPictureInPicture.js
@@ -44,6 +44,7 @@ export function useAutoPictureInPicture({ getUi, props, video, tabId = null, isT
   })
   let stopActiveTabWatch = null
   let removeMinimizedListener = null
+  let removeFocusedListener = null
   let blurTriggerRecheckTimeout = null
 
   function canAutoPipNow() {
@@ -133,6 +134,11 @@ export function useAutoPictureInPicture({ getUi, props, video, tabId = null, isT
     updateAutoPip()
   }
 
+  function handleFocusedState(focused) {
+    applyFocusState(state, focused)
+    updateAutoPip()
+  }
+
   function clearBlurTriggerRecheck() {
     if (blurTriggerRecheckTimeout != null) {
       clearTimeout(blurTriggerRecheckTimeout)
@@ -151,11 +157,12 @@ export function useAutoPictureInPicture({ getUi, props, video, tabId = null, isT
   function setupAutoPictureInPicture() {
     if (process.env.IS_ELECTRON) {
       removeMinimizedListener = window.ftElectron?.handleWindowMinimizedState?.(handleMinimizedState) ?? null
+      removeFocusedListener = window.ftElectron?.handleWindowFocusedState?.(handleFocusedState) ?? null
     } else {
       document.addEventListener('visibilitychange', refreshVisibilityState)
+      window.addEventListener('focus', refreshFocusState)
+      window.addEventListener('blur', refreshFocusState)
     }
-    window.addEventListener('focus', refreshFocusState)
-    window.addEventListener('blur', refreshFocusState)
     stopActiveTabWatch = watch(isActiveTab, updateAutoPip)
   }
 
@@ -174,11 +181,13 @@ export function useAutoPictureInPicture({ getUi, props, video, tabId = null, isT
     if (process.env.IS_ELECTRON) {
       removeMinimizedListener?.()
       removeMinimizedListener = null
+      removeFocusedListener?.()
+      removeFocusedListener = null
     } else {
       document.removeEventListener('visibilitychange', refreshVisibilityState)
+      window.removeEventListener('focus', refreshFocusState)
+      window.removeEventListener('blur', refreshFocusState)
     }
-    window.removeEventListener('focus', refreshFocusState)
-    window.removeEventListener('blur', refreshFocusState)
     clearBlurTriggerRecheck()
     stopActiveTabWatch?.()
     stopActiveTabWatch = null


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Make sure to follow the contributing guidelines. -->
<!-- Important note, we may remove your pull request if you do not use this provided PR template correctly. -->
<!-- Agent instructions: Preserve every heading, comment, and marker in this template. Never remove or rewrite the release-note-category:start/end, release-note:start/end, or release-note-image:start/end marker pairs. Never remove or rewrite the Release note images section; leave its contents for a human. -->

## Pull Request Type
<!-- Please select what type of pull request this is: [x] -->
- [x] Bugfix
- [ ] Feature Implementation
- [ ] Documentation
- [ ] Other

## Related issue
<!-- Please link the issue your pull request is referring to. -->
<!-- If this pull request fully resolves the relevant issue, put "closes" before the issue number. -->
<!-- Example: "closes #123456". -->

Closes #773.

## Description
<!-- Please write a clear and concise description of what the pull request does. -->

On Windows, closing another application that covered OpenTubeX could leave an automatically opened Picture-in-Picture window active even after OpenTubeX regained focus. Electron's native `BrowserWindow` focus event was delivered, but the corresponding renderer DOM focus event could be skipped.

Forward native window focus changes through the preload bridge and use them as the authoritative focus source for Electron auto-PiP. Browser builds continue to use DOM focus events.

## Release note category
<!-- Select exactly one category. Every pull request must select one. -->
<!-- Select "Not noteworthy" when the pull request fixes a bug in or improves functionality that has not yet appeared in a stable release. -->
<!-- release-note-category:start -->
- [ ] Not noteworthy
- [ ] Highlights
- [ ] More improvements
- [x] Fixed bugs
<!-- release-note-category:end -->

## Release note
<!-- Required unless "Not noteworthy" is selected. -->
<!-- Write one concise, user-facing entry without a leading bullet. -->
<!-- release-note:start -->
Closing a window that covers OpenTubeX now correctly returns an automatically detached video from Picture-in-Picture.
<!-- release-note:end -->

## Release note images
<!-- Human-only: Agents must preserve this entire section and leave it empty. -->
<!-- Optional. Paste one or more Markdown images or HTML image tags here. -->
<!-- The release notes will use an HTML image tag and limit images taller than 300 pixels. -->
<!-- release-note-image:start -->

<!-- release-note-image:end -->

## Testing
<!-- How can reviewers verify that the PR produces correct results? -->
<!-- Please provide instructions so that others can ensure that your pull request produces correct results. For examples see, https://github.com/FreeTubeApp/FreeTube/pull/5743, https://github.com/FreeTubeApp/FreeTube/pull/7349, https://github.com/FreeTubeApp/FreeTube/pull/5125, https://github.com/FreeTubeApp/FreeTube/pull/7338 -->
<!-- Agent instructions: Only write human-facing steps that explain how to verify the change while running this branch in dev mode. Include expected results and, when applicable, helpful console snippets for interactive verification. Do not include automated checks, commands, results, pass counts, or CI status. -->

1. On Windows, enable automatic Picture-in-Picture for "When the window loses focus or is switched away."
2. Play a video, then cover OpenTubeX with another application.
3. Confirm that the video enters Picture-in-Picture.
4. Close the covering application.
5. Confirm that Picture-in-Picture closes and the video returns to the main player.
6. Repeat by minimizing the covering application and confirm that behavior remains unchanged.

## Additional context
<!-- Add any other context about the pull request here. -->

The regression test keeps `document.hasFocus()` stale while delivering native focus, matching the event sequence from the issue.