### PR TITLE
fix(player): retry yt-dlp default extraction

### DIFF
--- a/e2e/tests/offline/watch-page.spec.mjs
+++ b/e2e/tests/offline/watch-page.spec.mjs
@@ -489,7 +489,7 @@ test.describe('watch page', () => {
       ipcMain.handle('yt-dlp-get-playback-info', (_event, _videoId, useDefaultClients) => {
         globalThis.__ytDlpIpBlockFallbackCalls++
         globalThis.__ytDlpIpBlockFallbackDefaultClients.push(useDefaultClients)
-        return globalThis.__ytDlpIpBlockFallbackCalls === 1
+        return globalThis.__ytDlpIpBlockFallbackCalls <= 2
           ? {
               isLive: true,
               liveStatus: 'is_live',
@@ -506,8 +506,11 @@ test.describe('watch page', () => {
     await page.locator(sel.searchInput).press('Enter')
     await expect(page).toHaveURL(/#\/watch\/jNQXAC9IVRw/)
 
-    await expect.poll(() => app.electronApp.evaluate(() => globalThis.__ytDlpIpBlockFallbackCalls)).toBe(2)
-    expect(await app.electronApp.evaluate(() => globalThis.__ytDlpIpBlockFallbackDefaultClients)).toEqual([false, true])
+    await expect.poll(() => app.electronApp.evaluate(() => globalThis.__ytDlpIpBlockFallbackCalls)).toBe(3)
+    expect(await app.electronApp.evaluate(() => globalThis.__ytDlpIpBlockFallbackDefaultClients)).toEqual([false, true, true])
+    await expect(page.locator('.toast', {
+      hasText: 'The preferred yt-dlp clients could not provide playable streams'
+    })).toHaveCount(1)
     const watchView = await watchViewHandle(page)
     expect(await watchView.evaluate((view) => ({
       ipBlockDetected: view.ipBlockDetectedInCurrentChain,

--- a/src/renderer/helpers/player/ytDlpPlayback.js
+++ b/src/renderer/helpers/player/ytDlpPlayback.js
@@ -288,9 +288,10 @@ async function convertAdaptiveFormats(formats, duration) {
  * DVR window available, so that they can be rewound.
  * @param {string} videoId
  * @param {string} cacheKey identifies the yt-dlp executable and proxy configuration
+ * @param {() => void} [onDefaultClientsFallback] called before retrying with yt-dlp's default clients
  * @returns {Promise<YtDlpPlaybackSource>}
  */
-export async function getYtDlpPlaybackSource(videoId, cacheKey = '') {
+export async function getYtDlpPlaybackSource(videoId, cacheKey = '', onDefaultClientsFallback) {
   let cachedSource = dashPlaybackSourceCache.get(videoId, cacheKey)
 
   if (cachedSource === null) {
@@ -316,7 +317,16 @@ export async function getYtDlpPlaybackSource(videoId, cacheKey = '') {
 
   let extractionError = null
 
-  for (const useDefaultClients of [false, true]) {
+  // A fresh extraction with the same default clients can return working URLs after
+  // an immediately preceding extraction returned URLs that respond with 403. Give
+  // yt-dlp's defaults one bounded retry before falling back to the built-in source.
+  let defaultClientsFallbackAnnounced = false
+  for (const useDefaultClients of [false, true, true]) {
+    if (useDefaultClients && !defaultClientsFallbackAnnounced) {
+      defaultClientsFallbackAnnounced = true
+      onDefaultClientsFallback?.()
+    }
+
     const info = await window.ftElectron.ytDlpGetPlaybackInfo(videoId, useDefaultClients)
 
     if (info === null) {

--- a/src/renderer/views/Watch/Watch.js
+++ b/src/renderer/views/Watch/Watch.js
@@ -4640,7 +4640,17 @@ export default defineComponent({
     ) {
       let source
       try {
-        source = await getYtDlpPlaybackSource(videoId, this.ytDlpPlaybackCacheKey)
+        source = await getYtDlpPlaybackSource(videoId, this.ytDlpPlaybackCacheKey, () => {
+          if (
+            this.isCurrentVideoLoad(loadGeneration, videoId) &&
+            playbackEngineSwitchGeneration === this.playbackEngineSwitchGeneration
+          ) {
+            this.showTabToast({
+              message: this.t('Change Format.yt-dlp Default Clients Fallback'),
+              icon: ['fas', 'exchange-alt'],
+            })
+          }
+        })
       } catch (error) {
         if (
           !this.isCurrentVideoLoad(loadGeneration, videoId) ||

--- a/static/locales/en-US.yaml
+++ b/static/locales/en-US.yaml
@@ -1815,6 +1815,8 @@ Change Format:
     Audio: Audio only, useful for saving bandwidth or listening in the background
   yt-dlp Fallback Template: 'yt-dlp could not provide the streams, using the built-in
     engine instead: {error}'
+  yt-dlp Default Clients Fallback: The preferred yt-dlp clients could not provide playable
+    streams, trying yt-dlp's default clients instead
   Built-in Fallback Template: 'The built-in engine could not play the stream, trying
     yt-dlp instead: {error}'
 Share:


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Make sure to follow the contributing guidelines. -->
<!-- Important note, we may remove your pull request if you do not use this provided PR template correctly. -->
<!-- Agent instructions: Preserve every heading, comment, and marker in this template. Never remove or rewrite the release-note-category:start/end, release-note:start/end, or release-note-image:start/end marker pairs. Never remove or rewrite the Release note images section; leave its contents for a human. -->

## Pull Request Type
<!-- Please select what type of pull request this is: [x] -->
- [x] Bugfix
- [ ] Feature Implementation
- [ ] Documentation
- [ ] Other

## Related issue
<!-- Please link the issue your pull request is referring to. -->
<!-- If this pull request fully resolves the relevant issue, put "closes" before the issue number. -->
<!-- Example: "closes #123456". -->

Closes #735.

## Description
<!-- Please write a clear and concise description of what the pull request does. -->

A transient 403 can make yt-dlp's first extraction with its default clients unusable. OpenTubeX treated that single failure as exhaustion of the default fallback and switched to the built-in SABR source, even though repeating the same default extraction can return working URLs.

Retry the default-client extraction once before falling back to the built-in engine. Show a toast when the preferred client arguments fail and OpenTubeX starts using yt-dlp's defaults, while keeping the retry bounded.

## Release note category
<!-- Select exactly one category. Every pull request must select one. -->
<!-- Select "Not noteworthy" when the pull request fixes a bug in or improves functionality that has not yet appeared in a stable release. -->
<!-- release-note-category:start -->
- [ ] Not noteworthy
- [ ] Highlights
- [ ] More improvements
- [x] Fixed bugs
<!-- release-note-category:end -->

## Release note
<!-- Required unless "Not noteworthy" is selected. -->
<!-- Write one concise, user-facing entry without a leading bullet. -->
<!-- release-note:start -->
Retry yt-dlp's default extraction when a transient 403 prevents playback.
<!-- release-note:end -->

## Release note images
<!-- Human-only: Agents must preserve this entire section and leave it empty. -->
<!-- Optional. Paste one or more Markdown images or HTML image tags here. -->
<!-- The release notes will use an HTML image tag and limit images taller than 300 pixels. -->
<!-- release-note-image:start -->

<!-- release-note-image:end -->

## Testing
<!-- How can reviewers verify that the PR produces correct results? -->
<!-- Please provide instructions so that others can ensure that your pull request produces correct results. For examples see, https://github.com/FreeTubeApp/FreeTube/pull/5743, https://github.com/FreeTubeApp/FreeTube/pull/7349, https://github.com/FreeTubeApp/FreeTube/pull/5125, https://github.com/FreeTubeApp/FreeTube/pull/7338 -->
<!-- Agent instructions: Only write human-facing steps that explain how to verify the change while running this branch in dev mode. Include expected results and, when applicable, helpful console snippets for interactive verification. Do not include automated checks, commands, results, pass counts, or CI status. -->

1. Start the app in dev mode with yt-dlp selected as the stream extraction method.
2. Open the example video from #735 in a network environment where the preferred clients fail or return unusable URLs.
3. Confirm that a toast says OpenTubeX is trying yt-dlp's default clients.
4. Confirm that OpenTubeX retries the default extraction once if its first URLs are rejected, and only switches to the built-in source if that retry also fails.

## Additional context
<!-- Add any other context about the pull request here. -->

The issue recording runs the same default yt-dlp command twice: the first receives HTTP 403 for format 18, while the second succeeds.