### PR TITLE
fix(player): keep silence skipping within its tab

### DIFF
--- a/e2e/tests/offline/player.spec.mjs
+++ b/e2e/tests/offline/player.spec.mjs
@@ -618,7 +618,7 @@ test.describe('fast-forward through silence shortcut', () => {
     const popup = page.locator(`${activeTab} .valueChangePopup`)
     const skipSilence = () => page.evaluate(() => {
       const store = document.querySelector('#app').__vue_app__.config.globalProperties.$store
-      return store.getters.getSkipSilence
+      return store.getters.getTabSkipSilence(store.getters.getActiveTabId)
     })
 
     await page.locator('body').press('h')
@@ -632,5 +632,46 @@ test.describe('fast-forward through silence shortcut', () => {
     await expect(popup).toHaveText(/Off/)
     await expect.poll(skipSilence).toBe(false)
     await attachScreenshot('skip silence disabled')
+  })
+
+  test('keeps the setting within its tab', async ({ app, page }) => {
+    await openDemoVideo({ app, page })
+
+    const readSkipSilenceState = () => page.evaluate(() => {
+      const store = document.querySelector('#app').__vue_app__.config.globalProperties.$store
+      return {
+        activeTabId: store.getters.getActiveTabId,
+        values: { ...store.state.tabs.skipSilenceByTabId }
+      }
+    })
+
+    await page.locator('body').press('h')
+    const firstTabId = (await readSkipSilenceState()).activeTabId
+    await expect.poll(readSkipSilenceState).toMatchObject({
+      values: { [firstTabId]: true }
+    })
+
+    await page.locator('.tabBar .newTabButton').click()
+    await expect(page.locator('.tabBar .tab')).toHaveCount(2)
+    await openMockedVideo(page)
+
+    const secondTabId = (await readSkipSilenceState()).activeTabId
+    expect(secondTabId).not.toBe(firstTabId)
+    await expect.poll(readSkipSilenceState).toMatchObject({
+      values: { [firstTabId]: true }
+    })
+    expect(await page.evaluate((tabId) => {
+      const store = document.querySelector('#app').__vue_app__.config.globalProperties.$store
+      return store.getters.getTabSkipSilence(tabId)
+    }, secondTabId)).toBe(false)
+
+    await page.locator('body').press('h')
+    await page.locator('body').press('h')
+    await expect.poll(readSkipSilenceState).toMatchObject({
+      values: {
+        [firstTabId]: true,
+        [secondTabId]: false
+      }
+    })
   })
 })

--- a/e2e/tests/offline/player.spec.mjs
+++ b/e2e/tests/offline/player.spec.mjs
@@ -674,4 +674,26 @@ test.describe('fast-forward through silence shortcut', () => {
       }
     })
   })
+
+  test('disables the setting for an unmounted player when the control is hidden', async ({ app, page }) => {
+    await openDemoVideo({ app, page })
+
+    await page.evaluate(async () => {
+      const store = document.querySelector('#app').__vue_app__.config.globalProperties.$store
+      await store.dispatch('updateShowSkipSilenceButton', true)
+    })
+    await page.locator('body').press('h')
+
+    await page.locator('.sideNav a[href="#/history"]').first().evaluate(link => link.click())
+    await expect(page.locator(`${activeTab} .ftVideoPlayer`)).toHaveCount(0)
+    await page.evaluate(async () => {
+      const store = document.querySelector('#app').__vue_app__.config.globalProperties.$store
+      await store.dispatch('updateShowSkipSilenceButton', false)
+    })
+
+    await expect.poll(() => page.evaluate(() => {
+      const store = document.querySelector('#app').__vue_app__.config.globalProperties.$store
+      return store.getters.getTabSkipSilence(store.getters.getActiveTabId)
+    })).toBe(false)
+  })
 })

--- a/src/constants.js
+++ b/src/constants.js
@@ -79,6 +79,7 @@ const IpcChannels = {
   TABS_IS_ACTIVE: 'tabs-is-active',
   TABS_GO_HISTORY: 'tabs-go-history',
   TABS_SET_PLAYBACK_STATE: 'tabs-set-playback-state',
+  TABS_SET_SKIP_SILENCE: 'tabs-set-skip-silence',
   TABS_REQUEST_PICTURE_IN_PICTURE: 'tabs-request-picture-in-picture',
   WINDOW_MINIMIZED_STATE: 'window-minimized-state',
   WINDOW_FOCUSED_STATE: 'window-focused-state',

--- a/src/main/tabs/TabManager.js
+++ b/src/main/tabs/TabManager.js
@@ -548,6 +548,7 @@ export class TabManager {
       stagedTab.previewDataUrl = detached.previewDataUrl
       stagedTab.previewCapturedAt = detached.previewCapturedAt
       stagedTab.previewFileName = detached.previewFileName
+      stagedTab.skipSilence = detached.skipSilence === true
 
       stagedTab.isTransferStaged = false
       target.activateTab(tabId)

--- a/src/main/tabs/TabManager.js
+++ b/src/main/tabs/TabManager.js
@@ -82,6 +82,7 @@ const TAB_AVATAR_SIZE = 64
  * @property {string | null} previewFileName
  * @property {ReturnType<typeof setTimeout> | null} previewCaptureTimeoutId
  * @property {Promise<string | null> | null} previewCapturePromise
+ * @property {boolean} skipSilence
  * @property {TabLoadState} loadState
  * @property {boolean} preloadInBackground
  * @property {boolean} pendingActivation
@@ -937,6 +938,7 @@ export class TabManager {
       previewFileName: restoredPreviewFileName,
       previewCaptureTimeoutId: null,
       previewCapturePromise: null,
+      skipSilence: false,
       loadState: startsUnloaded ? 'unloaded' : 'mounting',
       preloadInBackground: Boolean(preloadInBackground),
       pendingActivation: false,
@@ -2337,7 +2339,8 @@ export class TabManager {
       color: tab.color,
       previewDataUrl: tab.previewDataUrl,
       previewCapturedAt: tab.previewCapturedAt,
-      previewFileName: tab.previewFileName
+      previewFileName: tab.previewFileName,
+      skipSilence: tab.skipSilence === true
     }
   }
 
@@ -2413,6 +2416,7 @@ export class TabManager {
       previewFileName: normalizeTabPreviewFileName(snapshot.previewFileName),
       previewCaptureTimeoutId: null,
       previewCapturePromise: null,
+      skipSilence: snapshot.skipSilence === true,
       loadState: 'mounting',
       preloadInBackground: true,
       pendingActivation: false,
@@ -2560,6 +2564,7 @@ export class TabManager {
         isUnloaded: tab.loadState === 'unloaded',
         isLoading: this._getTabLoadingState(tab),
         isPlaying: tab.isPlaying || false,
+        skipSilence: tab.skipSilence === true,
         isPinned: tab.isPinned || false,
         color: TabManager.normalizeTabColor(tab.color),
         loadState: tab.loadState,
@@ -3361,6 +3366,14 @@ export async function setupTabsIPC(options = {}) {
     if (manager && tab && typeof playbackState === 'string') {
       tab.isPlaying = playbackState === 'playing'
       manager._broadcastStateUpdate()
+    }
+  })
+
+  ipcMain.on(IpcChannels.TABS_SET_SKIP_SILENCE, (event, enabled, tabId) => {
+    const manager = getManager(event)
+    const tab = typeof tabId === 'string' ? manager?.tabs.get(tabId) : null
+    if (tab) {
+      tab.skipSilence = enabled === true
     }
   })
 

--- a/src/main/tabs/TabManager.js
+++ b/src/main/tabs/TabManager.js
@@ -3373,8 +3373,10 @@ export async function setupTabsIPC(options = {}) {
   ipcMain.on(IpcChannels.TABS_SET_SKIP_SILENCE, (event, enabled, tabId) => {
     const manager = getManager(event)
     const tab = typeof tabId === 'string' ? manager?.tabs.get(tabId) : null
-    if (tab) {
-      tab.skipSilence = enabled === true
+    const skipSilence = enabled === true
+    if (tab && tab.skipSilence !== skipSilence) {
+      tab.skipSilence = skipSilence
+      manager._broadcastStateUpdate()
     }
   })
 

--- a/src/preload/interface.js
+++ b/src/preload/interface.js
@@ -1085,6 +1085,15 @@ export default {
     },
 
     /**
+     * Set silence skipping for a logical tab.
+     * @param {boolean} enabled
+     * @param {string} tabId
+     */
+    setSkipSilence: (enabled, tabId) => {
+      ipcRenderer.send(IpcChannels.TABS_SET_SKIP_SILENCE, enabled === true, tabId)
+    },
+
+    /**
      * Publish a logical tab title.
      * @param {string} title
      * @param {string} tabId

--- a/src/renderer/components/PlayerSettings/PlayerSettings.vue
+++ b/src/renderer/components/PlayerSettings/PlayerSettings.vue
@@ -675,10 +675,6 @@ const showSkipSilenceButton = computed(() => store.getters.getShowSkipSilenceBut
  */
 function updateShowSkipSilenceButton(value) {
   store.dispatch('updateShowSkipSilenceButton', value)
-
-  if (!value) {
-    store.dispatch('updateSkipSilence', false)
-  }
 }
 
 /** @type {import('vue').ComputedRef<boolean>} */

--- a/src/renderer/components/ft-shaka-video-player/ft-shaka-video-player.js
+++ b/src/renderer/components/ft-shaka-video-player/ft-shaka-video-player.js
@@ -1179,7 +1179,7 @@ export default defineComponent({
     })
 
     const skipSilence = computed(() => {
-      return store.getters.getSkipSilence
+      return store.getters.getTabSkipSilence(mediaTabId)
     })
 
     const showSkipSilenceButton = computed(() => {
@@ -1272,8 +1272,17 @@ export default defineComponent({
 
     /** @param {boolean} value */
     function updateSkipSilence(value) {
-      return store.dispatch('updateSkipSilence', value)
+      store.commit('setTabSkipSilence', {
+        tabId: mediaTabId,
+        value
+      })
     }
+
+    watch(showSkipSilenceButton, (visible) => {
+      if (!visible) {
+        updateSkipSilence(false)
+      }
+    })
 
     watch(displayVideoPlayButton, (newValue) => {
       ui.configure({
@@ -8109,14 +8118,9 @@ export default defineComponent({
         case matches(KeyboardShortcuts.VIDEO_PLAYER.PLAYBACK.TOGGLE_SKIP_SILENCE): {
           event.preventDefault()
           const enabled = !skipSilence.value
-          try {
-            await updateSkipSilence(enabled)
-          } catch (error) {
-            console.error('Failed to update skip-silence setting:', error)
-            break
-          }
+          updateSkipSilence(enabled)
 
-          // Only confirm the state that was actually persisted.
+          // Only confirm the state that was actually applied to this tab.
           if (skipSilence.value !== enabled) {
             break
           }

--- a/src/renderer/components/ft-shaka-video-player/ft-shaka-video-player.js
+++ b/src/renderer/components/ft-shaka-video-player/ft-shaka-video-player.js
@@ -1272,17 +1272,11 @@ export default defineComponent({
 
     /** @param {boolean} value */
     function updateSkipSilence(value) {
-      store.commit('setTabSkipSilence', {
+      return store.dispatch('updateTabSkipSilence', {
         tabId: mediaTabId,
         value
       })
     }
-
-    watch(showSkipSilenceButton, (visible) => {
-      if (!visible) {
-        updateSkipSilence(false)
-      }
-    })
 
     watch(displayVideoPlayButton, (newValue) => {
       ui.configure({

--- a/src/renderer/store/modules/settings.js
+++ b/src/renderer/store/modules/settings.js
@@ -608,6 +608,12 @@ const sideEffectHandlers = {
     }
   },
 
+  showSkipSilenceButton: ({ dispatch }, value) => {
+    if (!value) {
+      dispatch('clearTabSkipSilence')
+    }
+  },
+
   rememberTabNavigationHistory: (_, value) => {
     // Sync (or clear) the histories of already-open tabs right away,
     // so toggling doesn't require a navigation in every tab first.

--- a/src/renderer/store/modules/settings.js
+++ b/src/renderer/store/modules/settings.js
@@ -424,7 +424,6 @@ const state = {
   videoPlaybackRateInterval: 0.25,
   rememberVolume: true,
   enableVideoZoom: true,
-  skipSilence: false,
   showSkipSilenceButton: false,
   useVoiceOverTranslation: false,
   voiceOverTranslationPrepareInBackground: false,

--- a/src/renderer/store/modules/tabs.js
+++ b/src/renderer/store/modules/tabs.js
@@ -87,9 +87,7 @@ const mutations = {
 
     state.tabs = incomingTabs.map(tab => reconcileTab(previousTabsById.get(tab.id), tab))
     for (const tab of incomingTabs) {
-      if (!Object.prototype.hasOwnProperty.call(state.skipSilenceByTabId, tab.id)) {
-        state.skipSilenceByTabId[tab.id] = tab.skipSilence === true
-      }
+      state.skipSilenceByTabId[tab.id] = tab.skipSilence === true
     }
     state.selectedTabIds = state.selectedTabIds.filter(tabId => incomingIds.has(tabId))
     state.activeTabId = payload.activeTabId ?? null

--- a/src/renderer/store/modules/tabs.js
+++ b/src/renderer/store/modules/tabs.js
@@ -18,7 +18,8 @@ const state = {
   containerIds: [],
   tabBarScrollPosition: 0,
   currentWatchTimestamps: {},
-  videoZoomByTabId: {}
+  videoZoomByTabId: {},
+  skipSilenceByTabId: {}
 }
 
 const getters = {
@@ -35,6 +36,7 @@ const getters = {
   getCurrentWatchTimestamp: (state) => state.currentWatchTimestamps[state.activeTabId] ?? null,
   getWatchTimestamp: (state) => (tabId) => state.currentWatchTimestamps[tabId] ?? null,
   getTabVideoZoom: (state) => (tabId) => state.videoZoomByTabId[tabId] ?? DEFAULT_VIDEO_ZOOM,
+  getTabSkipSilence: (state) => (tabId) => state.skipSilenceByTabId[tabId] ?? false,
   getTabHistoryState: (state) => (tabId) => {
     const tab = state.tabs.find(candidate => candidate.id === tabId)
     if (!tab) {
@@ -103,6 +105,11 @@ const mutations = {
     for (const tabId of Object.keys(state.videoZoomByTabId)) {
       if (tabId !== 'web' && !incomingIds.has(tabId)) {
         delete state.videoZoomByTabId[tabId]
+      }
+    }
+    for (const tabId of Object.keys(state.skipSilenceByTabId)) {
+      if (tabId !== 'web' && !incomingIds.has(tabId)) {
+        delete state.skipSilenceByTabId[tabId]
       }
     }
   },
@@ -207,6 +214,10 @@ const mutations = {
 
   setTabVideoZoom(state, { tabId, value }) {
     state.videoZoomByTabId[tabId] = value
+  },
+
+  setTabSkipSilence(state, { tabId, value }) {
+    state.skipSilenceByTabId[tabId] = value === true
   }
 }
 

--- a/src/renderer/store/modules/tabs.js
+++ b/src/renderer/store/modules/tabs.js
@@ -86,6 +86,11 @@ const mutations = {
     }
 
     state.tabs = incomingTabs.map(tab => reconcileTab(previousTabsById.get(tab.id), tab))
+    for (const tab of incomingTabs) {
+      if (!Object.prototype.hasOwnProperty.call(state.skipSilenceByTabId, tab.id)) {
+        state.skipSilenceByTabId[tab.id] = tab.skipSilence === true
+      }
+    }
     state.selectedTabIds = state.selectedTabIds.filter(tabId => incomingIds.has(tabId))
     state.activeTabId = payload.activeTabId ?? null
     state.mainPresentedTabId = payload.presentedTabId ?? null
@@ -218,6 +223,12 @@ const mutations = {
 
   setTabSkipSilence(state, { tabId, value }) {
     state.skipSilenceByTabId[tabId] = value === true
+  },
+
+  clearTabSkipSilence(state) {
+    for (const tabId of Object.keys(state.skipSilenceByTabId)) {
+      state.skipSilenceByTabId[tabId] = false
+    }
   }
 }
 
@@ -235,6 +246,18 @@ const actions = {
 
     return () => {
       removeStateListener()
+    }
+  },
+
+  updateTabSkipSilence({ commit }, { tabId, value }) {
+    commit('setTabSkipSilence', { tabId, value })
+    window.ftElectron?.tabs?.setSkipSilence?.(value, tabId)
+  },
+
+  clearTabSkipSilence({ commit, state }) {
+    commit('clearTabSkipSilence')
+    for (const tab of state.tabs) {
+      window.ftElectron?.tabs?.setSkipSilence?.(false, tab.id)
     }
   },
 


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Make sure to follow the contributing guidelines. -->
<!-- Important note, we may remove your pull request if you do not use this provided PR template correctly. -->
<!-- Agent instructions: Preserve every heading, comment, and marker in this template. Never remove or rewrite the release-note-category:start/end, release-note:start/end, or release-note-image:start/end marker pairs. Never remove or rewrite the Release note images section; leave its contents for a human. -->

## Pull Request Type
<!-- Please select what type of pull request this is: [x] -->
- [x] Bugfix
- [ ] Feature Implementation
- [ ] Documentation
- [ ] Other

## Related issue
<!-- Please link the issue your pull request is referring to. -->
<!-- If this pull request fully resolves the relevant issue, put "closes" before the issue number. -->
<!-- Example: "closes #123456". -->

Closes #772.

## Description
<!-- Please write a clear and concise description of what the pull request does. -->

Fast-Forward Through Silence was stored as a persisted application setting, so toggling it caused every mounted video player to react. This moves the toggle into logical-tab state: each new tab starts with it disabled, each existing tab retains its own choice across video navigation, and closing a tab removes its state.

## Release note category
<!-- Select exactly one category. Every pull request must select one. -->
<!-- Select "Not noteworthy" when the pull request fixes a bug in or improves functionality that has not yet appeared in a stable release. -->
<!-- release-note-category:start -->
- [ ] Not noteworthy
- [ ] Highlights
- [ ] More improvements
- [x] Fixed bugs
<!-- release-note-category:end -->

## Release note
<!-- Required unless "Not noteworthy" is selected. -->
<!-- Write one concise, user-facing entry without a leading bullet. -->
<!-- release-note:start -->
Fast-Forward Through Silence no longer affects videos playing in other tabs.
<!-- release-note:end -->

## Release note images
<!-- Human-only: Agents must preserve this entire section and leave it empty. -->
<!-- Optional. Paste one or more Markdown images or HTML image tags here. -->
<!-- The release notes will use an HTML image tag and limit images taller than 300 pixels. -->
<!-- release-note-image:start -->

<!-- release-note-image:end -->

## Testing
<!-- How can reviewers verify that the PR produces correct results? -->
<!-- Please provide instructions so that others can ensure that your pull request would produce correct results. For examples see, https://github.com/FreeTubeApp/FreeTube/pull/5743, https://github.com/FreeTubeApp/FreeTube/pull/7349, https://github.com/FreeTubeApp/FreeTube/pull/5125, https://github.com/FreeTubeApp/FreeTube/pull/7338 -->
<!-- Agent instructions: Only write human-facing steps that explain how to verify the change while running this branch in dev mode. Include expected results and, when applicable, helpful console snippets for interactive verification. Do not include automated checks, commands, results, pass counts, or CI status. -->

1. Open a video and enable Fast-Forward Through Silence from the player menu or its configured shortcut.
2. Open another video in a new tab and confirm Fast-Forward Through Silence starts disabled there.
3. Toggle the feature in the second tab, switch between both tabs, and confirm each tab retains its own state.
4. Navigate to another video within either tab and confirm that tab's state is retained.

## Additional context
<!-- Add any other context about the pull request here. -->

The obsolete persisted global setting is ignored so an existing profile cannot enable silence skipping across all open players.
