### PR TITLE
fix(captions): lower captions with hidden paused controls

### DIFF
--- a/e2e/tests/offline/watch-page.spec.mjs
+++ b/e2e/tests/offline/watch-page.spec.mjs
@@ -1530,6 +1530,47 @@ test.describe('fullscreen captions', () => {
   })
 })
 
+test.describe('bottom captions', () => {
+  test.use({
+    seed: {
+      settings: {
+        ...WATCH_PAGE_SEED,
+        enableSubtitlesByDefault: true,
+        showPlayerControlsWhenPaused: false,
+        pausedInterfaceHideDelay: 0.5,
+      }
+    }
+  })
+
+  test('lowers captions with the hidden paused controls', async ({ app, page }) => {
+    await mockPlayableWatchPage(app, page, { captionCueSettings: 'align:center' })
+    const video = await openMockedVideo(page)
+
+    const player = page.locator('.ftVideoPlayer')
+    const captions = player.locator('.shaka-text-container')
+    await expect(captions.locator('[translate="no"]')).toBeVisible()
+    await page.locator('body').press('s')
+    await expect(player).toHaveClass(/fullWindow/)
+    await video.evaluate(element => element.pause())
+    await expect(player).toHaveClass(/playerPaused/)
+
+    const playerBounds = await player.boundingBox()
+    await page.mouse.move(
+      playerBounds.x + playerBounds.width / 2,
+      playerBounds.y + playerBounds.height / 2
+    )
+    await expect(player).toHaveClass(/pausedInterfaceRevealed/)
+    const raisedBottom = await captions.evaluate(element => {
+      return Number.parseFloat(getComputedStyle(element).bottom)
+    })
+
+    await expect(player).not.toHaveClass(/pausedInterfaceRevealed/, { timeout: 1500 })
+    await expect.poll(() => captions.evaluate(element => {
+      return Number.parseFloat(getComputedStyle(element).bottom)
+    })).toBeLessThan(raisedBottom)
+  })
+})
+
 test.describe('fullscreen playlist dock', () => {
   test.use({
     seed: {

--- a/src/renderer/components/ft-shaka-video-player/ft-shaka-video-player.css
+++ b/src/renderer/components/ft-shaka-video-player/ft-shaka-video-player.css
@@ -3037,6 +3037,11 @@
   bottom: var(--caption-hidden-bottom-gap) !important;
 }
 
+.ftVideoPlayer:is(:fullscreen, .fullWindow).playerPaused:not(.pausedInterfaceRevealed).hidePlayerControlsWhenPaused
+:is(:deep(.shaka-text-container), :deep(.shaka-speech-to-text-container)) {
+  bottom: var(--caption-hidden-bottom-gap) !important;
+}
+
 .ftVideoPlayer.shortsPlayer :deep(.shaka-text-container),
 .ftVideoPlayer.shortsPlayer :deep(.shaka-speech-to-text-container) {
   /*


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Make sure to follow the contributing guidelines. -->
<!-- Important note, we may remove your pull request if you do not use this provided PR template correctly. -->
<!-- Agent instructions: Preserve every heading, comment, and marker in this template. Never remove or rewrite the release-note-category:start/end, release-note:start/end, or release-note-image:start/end marker pairs. Never remove or rewrite the Release note images section; leave its contents for a human. -->

## Pull Request Type
<!-- Please select what type of pull request this is: [x] -->
- [x] Bugfix
- [ ] Feature Implementation
- [ ] Documentation
- [ ] Other

## Related issue
<!-- Please link the issue your pull request is referring to. -->
<!-- If this pull request fully resolves the relevant issue, put "closes" before the issue number. -->
<!-- Example: "closes #123456". -->

Follow-up to #754.

## Description
<!-- Please write a clear and concise description of what the pull request does. -->

The paused-interface controls introduced in #754 disappear visually without clearing Shaka's controls-visible state. Bottom-anchored captions therefore remain raised for controls that are no longer on screen.

Apply the caption bottom gap while the configured paused controls are hidden, and cover the full-window pause/reveal/hide transition with an E2E regression test.

## Release note category
<!-- Select exactly one category. Every pull request must select one. -->
<!-- Select "Not noteworthy" when the pull request fixes a bug in or improves functionality that has not yet appeared in a stable release. -->
<!-- release-note-category:start -->
- [x] Not noteworthy
- [ ] Highlights
- [ ] More improvements
- [ ] Fixed bugs
<!-- release-note-category:end -->

## Release note
<!-- Required unless "Not noteworthy" is selected. -->
<!-- Write one concise, user-facing entry without a leading bullet. -->
<!-- release-note:start -->

<!-- release-note:end -->

## Release note images
<!-- Human-only: Agents must preserve this entire section and leave it empty. -->
<!-- Optional. Paste one or more Markdown images or HTML image tags here. -->
<!-- The release notes will use an HTML image tag and limit images taller than 300 pixels. -->
<!-- release-note-image:start -->

<!-- release-note-image:end -->

## Testing
<!-- How can reviewers verify that the PR produces correct results? -->
<!-- Please provide instructions so that others can ensure that your pull request would produce correct results. For examples see, https://github.com/FreeTubeApp/FreeTube/pull/5743, https://github.com/FreeTubeApp/FreeTube/pull/7349, https://github.com/FreeTubeApp/FreeTube/pull/5125, https://github.com/FreeTubeApp/FreeTube/pull/7338 -->
<!-- Agent instructions: Only write human-facing steps that explain how to verify the change while running this branch in dev mode. Include expected results and, when applicable, helpful console snippets for interactive verification. Do not include automated checks, commands, results, pass counts, or CI status. -->

1. Enable subtitles and keep their anchor at Bottom Center.
2. Disable “Show player controls while paused” and set a short paused-interface hide delay.
3. Open a captioned video in full-window or fullscreen mode and pause it.
4. Move the pointer over the player: captions should rise above the visible controls.
5. Wait for the paused controls to hide: captions should move back down to the configured bottom gap.

## Additional context
<!-- Add any other context about the pull request here. -->

This is stacked on `paused-interface-visibility` so the regression fix can be reviewed independently while #754 remains open.