### PR TITLE
fix(subscriptions): preserve premiere and refresh labels

### DIFF
--- a/e2e/tests/offline/subscriptions-feed.spec.mjs
+++ b/e2e/tests/offline/subscriptions-feed.spec.mjs
@@ -57,6 +57,7 @@ const seed = {
         feedVideo('aaaaaaaaaa2', 'Video A older', CHANNEL_A, now - 3 * HOUR),
         feedVideo('aaaaaaaaaa3', 'Upcoming premiere video', CHANNEL_A, now + 30 * 24 * HOUR, {
           isUpcoming: true,
+          isPremiere: true,
           premiereDate: new Date(now + 30 * 24 * HOUR).toISOString()
         })
       ],
@@ -345,7 +346,7 @@ test.describe('subscriptions feed with upcoming premieres shown', () => {
     await goTo(page, 'subscriptions')
 
     const upcomingPremiere = page.locator('.ft-list-video').filter({ hasText: 'Upcoming premiere video' })
-    await expect(upcomingPremiere.locator('.videoDuration')).toHaveText('Upcoming')
+    await expect(upcomingPremiere.locator('.videoDuration')).toHaveText('Premiere')
     await expect(upcomingPremiere.getByRole('button', { name: 'Notify me' })).toBeVisible()
     await upcomingPremiere.evaluate(element => { element.dataset.reuseMarker = 'upcoming-premiere' })
     const reusedCard = page.locator('[data-reuse-marker="upcoming-premiere"]')

--- a/e2e/tests/offline/subscriptions-feed.spec.mjs
+++ b/e2e/tests/offline/subscriptions-feed.spec.mjs
@@ -60,14 +60,26 @@ const seed = {
           premiereDate: new Date(now + 30 * 24 * HOUR).toISOString()
         })
       ],
-      videosTimestamp: new Date(now - 2 * HOUR).toISOString()
+      videosTimestamp: new Date(now - 2 * HOUR).toISOString(),
+      shorts: [],
+      shortsTimestamp: new Date(now - 2 * HOUR).toISOString(),
+      liveStreams: [],
+      liveStreamsTimestamp: new Date(now - 2 * HOUR).toISOString(),
+      communityPosts: [],
+      communityPostsTimestamp: new Date(now - 2 * HOUR).toISOString()
     },
     {
       _id: CHANNEL_B,
       videos: [
         feedVideo('bbbbbbbbbb1', 'Video B newest', CHANNEL_B, now - 0.5 * HOUR)
       ],
-      videosTimestamp: new Date(now - 1 * HOUR).toISOString()
+      videosTimestamp: new Date(now - 1 * HOUR).toISOString(),
+      shorts: [],
+      shortsTimestamp: new Date(now - 1 * HOUR).toISOString(),
+      liveStreams: [],
+      liveStreamsTimestamp: new Date(now - 1 * HOUR).toISOString(),
+      communityPosts: [],
+      communityPostsTimestamp: new Date(now - 1 * HOUR).toISOString()
     }
   ]
 }
@@ -124,7 +136,7 @@ test.describe('subscriptions feed from cache', () => {
     await expect(page.getByText('Upcoming premiere video')).toHaveCount(0)
   })
 
-  test('shows a hidden upcoming premiere when its scheduled time arrives', async ({ page }) => {
+  test('shows a hidden upcoming premiere as a premiere when its scheduled time arrives', async ({ page }) => {
     // The app opens on Subscriptions, so leave it before installing the clock;
     // timers created before installation cannot be advanced by Playwright.
     await goTo(page, 'trending')
@@ -138,7 +150,7 @@ test.describe('subscriptions feed from cache', () => {
 
     const premiere = page.locator('.ft-list-video').filter({ hasText: 'Upcoming premiere video' })
     await expect(premiere).toBeVisible()
-    await expect(premiere.locator('.videoDuration')).toHaveText('Live')
+    await expect(premiere.locator('.videoDuration')).toHaveText('Premiere')
   })
 
   test('an open video menu does not lift feed content over the sticky header', async ({ page }) => {
@@ -181,15 +193,19 @@ test.describe('subscriptions feed from cache', () => {
     await expect(page.getByRole('option', { name: 'Add to Queue' })).toBeVisible()
   })
 
-  test('shows when the cache was last refreshed, from the oldest channel timestamp', async ({ page }) => {
+  test('shows when the feed was last updated without being held back by a stale channel', async ({ page }) => {
     await goTo(page, 'subscriptions')
     await expect(page.getByText('Video B newest')).toBeVisible()
 
     // Cache timestamps must survive the IPC round trip as dates (7ad96d185).
-    // The displayed value is the oldest per-channel timestamp (2 hours ago).
-    const lastRefresh = page.locator('.lastRefreshTimestamp').first()
-    await expect(lastRefresh).toBeVisible()
-    await expect(lastRefresh).toContainText('2 hours ago')
+    // The displayed value is the latest per-channel timestamp (1 hour ago).
+    for (const tab of ['videos', 'shorts', 'live', 'posts']) {
+      await page.locator(`[data-subscription-feed-tab="${tab}"]`).click()
+
+      const lastRefresh = page.locator('.headerRefreshWidget .lastRefreshTimestamp')
+      await expect(lastRefresh).toBeVisible()
+      await expect(lastRefresh).toContainText('1 hour ago')
+    }
   })
 
   test('updates relative timestamps without reloading the page', async ({ page }) => {

--- a/src/renderer/components/SubscriptionsLive.vue
+++ b/src/renderer/components/SubscriptionsLive.vue
@@ -89,14 +89,14 @@ const lastLiveRefreshTimestamp = computed(() => {
     return ''
   }
 
-  let minTimestamp = null
+  let latestTimestamp = null
   cacheEntriesForAllActiveProfileChannels.value.forEach((cacheEntry) => {
-    if (!minTimestamp || cacheEntry.timestamp.getTime() < minTimestamp.getTime()) {
-      minTimestamp = cacheEntry.timestamp
+    if (!latestTimestamp || cacheEntry.timestamp.getTime() > latestTimestamp.getTime()) {
+      latestTimestamp = cacheEntry.timestamp
     }
   })
 
-  return getRelativeTimeFromDate(minTimestamp.getTime(), true, true, now.value)
+  return getRelativeTimeFromDate(latestTimestamp.getTime(), true, true, now.value)
 })
 
 const refreshTitle = computed(() => {

--- a/src/renderer/components/SubscriptionsPosts.vue
+++ b/src/renderer/components/SubscriptionsPosts.vue
@@ -88,14 +88,14 @@ const lastPostsRefreshTimestamp = computed(() => {
     return ''
   }
 
-  let minTimestamp = null
+  let latestTimestamp = null
   cacheEntriesForAllActiveProfileChannels.value.forEach((cacheEntry) => {
-    if (!minTimestamp || cacheEntry.timestamp.getTime() < minTimestamp.getTime()) {
-      minTimestamp = cacheEntry.timestamp
+    if (!latestTimestamp || cacheEntry.timestamp.getTime() > latestTimestamp.getTime()) {
+      latestTimestamp = cacheEntry.timestamp
     }
   })
 
-  return getRelativeTimeFromDate(minTimestamp.getTime(), true, true, now.value)
+  return getRelativeTimeFromDate(latestTimestamp.getTime(), true, true, now.value)
 })
 
 const refreshTitle = computed(() => {

--- a/src/renderer/components/SubscriptionsShorts.vue
+++ b/src/renderer/components/SubscriptionsShorts.vue
@@ -92,13 +92,13 @@ const lastShortRefreshTimestamp = computed(() => {
     return ''
   }
 
-  let minTimestamp = null
+  let latestTimestamp = null
   cacheEntriesForAllActiveProfileChannels.value.forEach((cacheEntry) => {
-    if (!minTimestamp || cacheEntry.timestamp.getTime() < minTimestamp.getTime()) {
-      minTimestamp = cacheEntry.timestamp
+    if (!latestTimestamp || cacheEntry.timestamp.getTime() > latestTimestamp.getTime()) {
+      latestTimestamp = cacheEntry.timestamp
     }
   })
-  return getRelativeTimeFromDate(minTimestamp.getTime(), true, true, now.value)
+  return getRelativeTimeFromDate(latestTimestamp.getTime(), true, true, now.value)
 })
 
 const refreshTitle = computed(() => {

--- a/src/renderer/components/SubscriptionsVideos.vue
+++ b/src/renderer/components/SubscriptionsVideos.vue
@@ -150,13 +150,13 @@ const lastVideoRefreshTimestamp = computed(() => {
     return ''
   }
 
-  let minTimestamp = null
+  let latestTimestamp = null
   cacheEntriesForAllActiveProfileChannels.value.forEach((cacheEntry) => {
-    if (!minTimestamp || cacheEntry.timestamp.getTime() < minTimestamp.getTime()) {
-      minTimestamp = cacheEntry.timestamp
+    if (!latestTimestamp || cacheEntry.timestamp.getTime() > latestTimestamp.getTime()) {
+      latestTimestamp = cacheEntry.timestamp
     }
   })
-  return getRelativeTimeFromDate(minTimestamp.getTime(), true, true, now.value)
+  return getRelativeTimeFromDate(latestTimestamp.getTime(), true, true, now.value)
 })
 
 const nextVideoAutoRefreshTimestamp = computed(() => {

--- a/src/renderer/helpers/api/local.js
+++ b/src/renderer/helpers/api/local.js
@@ -1921,7 +1921,8 @@ export function parseLocalListVideo(item, channelId, channelName) {
 
 const VIEWS_OR_WATCHING_REGEX = /views?|watching|waiting/i
 const VIEWS_IN_NUMBER_ONLY = /^\d+(\.\d)?[bkm]?$/i
-const PREMIERES_TIME_REGEX = /^(premieres|scheduled for) /i
+const PREMIERE_TIME_REGEX = /^premieres? /i
+const UPCOMING_TIME_REGEX = /^(premieres?|scheduled for) /i
 // Sometimes got `Streamed N (unit) ago`
 const PUBLISH_TIME_REGEX = /^(streamed )?\d+ ?\w+? ago/i
 const COLLABORATIVE_AUTHOR_TEXT_REGEX = /\s+and\s+/i
@@ -1941,7 +1942,7 @@ function isViewCountText(text) {
 function isPremieresTimeText(text) {
   if (typeof text !== 'string') { return false }
 
-  return PREMIERES_TIME_REGEX.test(text)
+  return UPCOMING_TIME_REGEX.test(text)
 }
 
 /**
@@ -2035,6 +2036,7 @@ function parseLockupView(lockupView, channelId = undefined, channelName = undefi
           isPremiere = /premiere/i.test(liveBadge.text ?? '')
         } else if (thumbnailBottomOverlayView.badges.some(badge => badge.text?.toLowerCase() === 'upcoming')) {
           isUpcoming = true
+          isPremiere = metadataParts.some(part => PREMIERE_TIME_REGEX.test(part.text?.text ?? ''))
 
           // The premiere date can be in any non-views, non-relative-time part, often with a
           // "Premieres "/"Scheduled for " prefix that breaks Date.parse. Try every candidate

--- a/src/renderer/helpers/assigned-json.js
+++ b/src/renderer/helpers/assigned-json.js
@@ -1,0 +1,60 @@
+/**
+ * Extracts the JSON object assigned to a named JavaScript variable.
+ *
+ * @param {string} source
+ * @param {string} variableName
+ * @returns {string | undefined}
+ */
+export function extractAssignedJsonObject(source, variableName) {
+  let assignmentStart = source.indexOf(variableName)
+  let objectStart = -1
+
+  while (assignmentStart !== -1) {
+    let cursor = assignmentStart + variableName.length
+    while (/\s/.test(source[cursor])) cursor++
+
+    if (source[cursor] === '=') {
+      cursor++
+      while (/\s/.test(source[cursor])) cursor++
+
+      if (source[cursor] === '{') {
+        objectStart = cursor
+        break
+      }
+    }
+
+    assignmentStart = source.indexOf(variableName, assignmentStart + variableName.length)
+  }
+
+  if (objectStart === -1) return undefined
+
+  let depth = 0
+  let escaped = false
+  let inString = false
+
+  for (let index = objectStart; index < source.length; index++) {
+    const character = source[index]
+
+    if (inString) {
+      if (escaped) {
+        escaped = false
+      } else if (character === '\\') {
+        escaped = true
+      } else if (character === '"') {
+        inString = false
+      }
+      continue
+    }
+
+    if (character === '"') {
+      inString = true
+    } else if (character === '{') {
+      depth++
+    } else if (character === '}') {
+      depth--
+      if (depth === 0) return source.slice(objectStart, index + 1)
+    }
+  }
+
+  return undefined
+}

--- a/src/renderer/helpers/subscription-entries.js
+++ b/src/renderer/helpers/subscription-entries.js
@@ -43,7 +43,6 @@ export function updateUpcomingPremiereState(video, now) {
     return {
       ...video,
       isUpcoming: false,
-      isPremiere: true,
       premiere: false,
       liveNow: true
     }
@@ -348,7 +347,7 @@ export function collectResolvedNonPremiereVideoIds(caches) {
  * for a resolved "not a premiere" and the next refresh looks it up again.
  *
  * @param {object} video
- * @param {{ isUpcoming: boolean, failed?: boolean, premiereDate?: Date }} upcomingInfo
+ * @param {{ isUpcoming: boolean, failed?: boolean, isPremiere?: boolean, premiereDate?: Date }} upcomingInfo
  */
 export function applyRssPremiereVerdict(video, upcomingInfo) {
   if (upcomingInfo.failed) {
@@ -366,6 +365,10 @@ export function applyRssPremiereVerdict(video, upcomingInfo) {
     ...video,
     isUpcoming: true,
     subscriptionFeedPublished: getSubscriptionFeedPublishedTimestamp(video, video.published)
+  }
+
+  if (typeof upcomingInfo.isPremiere === 'boolean') {
+    enrichedVideo.isPremiere = upcomingInfo.isPremiere
   }
 
   if (upcomingInfo.premiereDate) {

--- a/src/renderer/helpers/subscription-entries.js
+++ b/src/renderer/helpers/subscription-entries.js
@@ -43,6 +43,7 @@ export function updateUpcomingPremiereState(video, now) {
     return {
       ...video,
       isUpcoming: false,
+      isPremiere: true,
       premiere: false,
       liveNow: true
     }

--- a/src/renderer/helpers/subscriptions.js
+++ b/src/renderer/helpers/subscriptions.js
@@ -32,6 +32,7 @@ import {
 } from './subscription-entries'
 import { mapConcurrently } from './concurrent-map'
 import { includeAutomaticDownloadChannels, startAutomaticDownloadsForChannel } from './automaticDownloads'
+import { getLocalPremiereState } from './premiere'
 
 const AUTO_REFRESH_TOAST_DURATION = 5000
 export const SUBSCRIPTION_REFRESH_CHANNEL_EVENT = 'opentubex-subscription-refresh-channel'
@@ -58,6 +59,7 @@ let activeRefresh = null
 let cancelCount = 0
 
 const IS_UPCOMING_REGEX = /"isUpcoming"\s*:\s*true/
+const PLAYER_RESPONSE_REGEX = /ytInitialPlayerResponse\s*=\s*(\{.+?\});/
 const SCHEDULED_START_REGEX = /"scheduledStartTime"\s*:\s*"(\d+)"/
 const SUBSCRIPTION_FETCH_BATCH_SIZE = 80
 const SUBSCRIPTION_FETCH_BATCH_DELAY_MS = 2000
@@ -375,7 +377,7 @@ export function isVideoHiddenByPreferences(video, {
  * @type {Set<string>}
  */
 const rssNonPremiereVideoIds = new Set()
-/** @type {Map<string, Promise<{ isUpcoming: boolean, premiereDate?: Date }>>} */
+/** @type {Map<string, Promise<{ isUpcoming: boolean, failed?: boolean, isPremiere?: boolean, premiereDate?: Date }>>} */
 const rssUpcomingInfoRequests = new Map()
 
 let rssNonPremiereVideoIdsSeeded = false
@@ -465,9 +467,20 @@ async function fetchRssVideoUpcomingInfoUncached(videoId) {
     const premiereDate = scheduledStartMatch
       ? new Date(parseInt(scheduledStartMatch[1], 10) * 1000)
       : undefined
+    const playerResponseText = html.match(PLAYER_RESPONSE_REGEX)?.[1]
+    let isPremiere
+
+    if (playerResponseText) {
+      try {
+        isPremiere = getLocalPremiereState(JSON.parse(playerResponseText).videoDetails)
+      } catch {
+        // The upcoming state is still useful when YouTube's embedded response is malformed.
+      }
+    }
 
     return {
       isUpcoming: true,
+      isPremiere,
       premiereDate
     }
   } catch {

--- a/src/renderer/helpers/subscriptions.js
+++ b/src/renderer/helpers/subscriptions.js
@@ -32,6 +32,7 @@ import {
 } from './subscription-entries'
 import { mapConcurrently } from './concurrent-map'
 import { includeAutomaticDownloadChannels, startAutomaticDownloadsForChannel } from './automaticDownloads'
+import { extractAssignedJsonObject } from './assigned-json'
 import { getLocalPremiereState } from './premiere'
 
 const AUTO_REFRESH_TOAST_DURATION = 5000
@@ -59,7 +60,6 @@ let activeRefresh = null
 let cancelCount = 0
 
 const IS_UPCOMING_REGEX = /"isUpcoming"\s*:\s*true/
-const PLAYER_RESPONSE_REGEX = /ytInitialPlayerResponse\s*=\s*(\{.+?\});/
 const SCHEDULED_START_REGEX = /"scheduledStartTime"\s*:\s*"(\d+)"/
 const SUBSCRIPTION_FETCH_BATCH_SIZE = 80
 const SUBSCRIPTION_FETCH_BATCH_DELAY_MS = 2000
@@ -467,7 +467,7 @@ async function fetchRssVideoUpcomingInfoUncached(videoId) {
     const premiereDate = scheduledStartMatch
       ? new Date(parseInt(scheduledStartMatch[1], 10) * 1000)
       : undefined
-    const playerResponseText = html.match(PLAYER_RESPONSE_REGEX)?.[1]
+    const playerResponseText = extractAssignedJsonObject(html, 'ytInitialPlayerResponse')
     let isPremiere
 
     if (playerResponseText) {

--- a/tests/unit/assigned-json.test.mjs
+++ b/tests/unit/assigned-json.test.mjs
@@ -1,0 +1,43 @@
+import assert from 'node:assert/strict'
+import test from 'node:test'
+
+import { extractAssignedJsonObject } from '../../src/renderer/helpers/assigned-json.js'
+
+test('extracts a multiline assigned JSON object', () => {
+  const json = `{
+    "videoDetails": {
+      "isLive": true,
+      "isLiveContent": false
+    }
+  }`
+
+  assert.equal(
+    extractAssignedJsonObject(`ytInitialPlayerResponse = ${json};`, 'ytInitialPlayerResponse'),
+    json
+  )
+})
+
+test('ignores braces and assignment terminators inside JSON strings', () => {
+  const json = JSON.stringify({
+    message: 'contains }; and { braces',
+    escaped: 'a quote: " and a slash: \\',
+    nested: { isLive: true }
+  })
+
+  assert.equal(
+    extractAssignedJsonObject(`ytInitialPlayerResponse = ${json}; nextCall();`, 'ytInitialPlayerResponse'),
+    json
+  )
+})
+
+test('returns no object for missing or incomplete assignments', () => {
+  assert.equal(extractAssignedJsonObject('const other = {};', 'ytInitialPlayerResponse'), undefined)
+  assert.equal(extractAssignedJsonObject('ytInitialPlayerResponse = {"open": true', 'ytInitialPlayerResponse'), undefined)
+})
+
+test('skips non-assignment occurrences before the player response', () => {
+  const json = '{"videoDetails":{"isLive":true}}'
+  const source = `"ytInitialPlayerResponse is documented here"; ytInitialPlayerResponse = ${json};`
+
+  assert.equal(extractAssignedJsonObject(source, 'ytInitialPlayerResponse'), json)
+})

--- a/tests/unit/subscription-entries.test.mjs
+++ b/tests/unit/subscription-entries.test.mjs
@@ -34,7 +34,7 @@ test('marks an upcoming premiere as running when its scheduled time arrives', ()
   const scheduledTime = now + HOUR
   const upcoming = video('premiere', scheduledTime, {
     isUpcoming: true,
-    isPremiere: false,
+    isPremiere: true,
     premiere: true,
     premiereDate: new Date(scheduledTime)
   })
@@ -43,7 +43,6 @@ test('marks an upcoming premiere as running when its scheduled time arrives', ()
   assert.deepEqual(updateUpcomingPremiereState(upcoming, scheduledTime), {
     ...upcoming,
     isUpcoming: false,
-    isPremiere: true,
     premiere: false,
     liveNow: true
   })
@@ -55,7 +54,18 @@ test('marks an upcoming premiere as running when its scheduled time arrives', ()
   }, scheduledTime), {
     ...upcoming,
     isUpcoming: false,
-    isPremiere: true,
+    premiere: false,
+    liveNow: true
+  })
+
+  const scheduledStream = {
+    ...upcoming,
+    videoId: 'scheduled-stream',
+    isPremiere: false
+  }
+  assert.deepEqual(updateUpcomingPremiereState(scheduledStream, scheduledTime), {
+    ...scheduledStream,
+    isUpcoming: false,
     premiere: false,
     liveNow: true
   })
@@ -414,14 +424,21 @@ test('a settled lookup records the verdict both ways', () => {
   const premiereDate = new Date('2026-01-02T03:04:05Z')
   const premiere = applyRssPremiereVerdict(
     { videoId: 'b', published: 1234 },
-    { isUpcoming: true, premiereDate }
+    { isUpcoming: true, isPremiere: true, premiereDate }
   )
   assert.equal(premiere.isUpcoming, true)
+  assert.equal(premiere.isPremiere, true)
   assert.equal(premiere.premiereDate, premiereDate)
   assert.equal(premiere.published, premiereDate.getTime())
   assert.equal(premiere.subscriptionFeedPublished, 1234)
   // An upcoming premiere goes live eventually, so it is never a durable negative.
   assert.equal(collectResolvedNonPremiereVideoIds([{ ch: { videos: [premiere] } }]).size, 0)
+
+  const scheduledStream = applyRssPremiereVerdict(
+    { videoId: 'c', published: 1234 },
+    { isUpcoming: true, isPremiere: false, premiereDate }
+  )
+  assert.equal(scheduledStream.isPremiere, false)
 })
 
 test('an upcoming premiere without a scheduled time keeps its original date', () => {

--- a/tests/unit/subscription-entries.test.mjs
+++ b/tests/unit/subscription-entries.test.mjs
@@ -30,10 +30,11 @@ test('reads premiere times from Local API dates and Invidious timestamps', () =>
   assert.equal(getUpcomingPremiereTimestamp({ premiereDate: 'invalid' }), null)
 })
 
-test('marks an upcoming premiere as live when its scheduled time arrives', () => {
+test('marks an upcoming premiere as running when its scheduled time arrives', () => {
   const scheduledTime = now + HOUR
   const upcoming = video('premiere', scheduledTime, {
     isUpcoming: true,
+    isPremiere: false,
     premiere: true,
     premiereDate: new Date(scheduledTime)
   })
@@ -42,6 +43,7 @@ test('marks an upcoming premiere as live when its scheduled time arrives', () =>
   assert.deepEqual(updateUpcomingPremiereState(upcoming, scheduledTime), {
     ...upcoming,
     isUpcoming: false,
+    isPremiere: true,
     premiere: false,
     liveNow: true
   })
@@ -53,6 +55,7 @@ test('marks an upcoming premiere as live when its scheduled time arrives', () =>
   }, scheduledTime), {
     ...upcoming,
     isUpcoming: false,
+    isPremiere: true,
     premiere: false,
     liveNow: true
   })


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Make sure to follow the contributing guidelines. -->
<!-- Important note, we may remove your pull request if you do not use this provided PR template correctly. -->
<!-- Agent instructions: Preserve every heading, comment, and marker in this template. Never remove or rewrite the release-note-category:start/end, release-note:start/end, or release-note-image:start/end marker pairs. Never remove or rewrite the Release note images section; leave its contents for a human. -->

## Pull Request Type
<!-- Please select what type of pull request this is: [x] -->
- [x] Bugfix
- [ ] Feature Implementation
- [ ] Documentation
- [ ] Other

## Related issue
<!-- Please link the issue your pull request is referring to. -->
<!-- If this pull request fully resolves the relevant issue, put "closes" before the issue number. -->
<!-- Example: "closes #123456". -->

## Description
<!-- Please write a clear and concise description of what the pull request does. -->
Started premieres in the subscriptions feed were shown as ordinary live streams, and a single stale channel cache could make every feed report an outdated refresh time.

The premiere transition introduced in #621 set the active-stream flag but did not preserve the premiere content type, so the card fell back to its **Live** label. Preserve `isPremiere` when the scheduled start arrives while keeping `liveNow` for watching-count behavior.

Feed headers also used the oldest channel cache timestamp. Report the latest successful cache update instead, so a channel that repeatedly fails to refresh does not pin Videos, Shorts, Live, or Posts to an old date.

## Release note category
<!-- Select exactly one category. Every pull request must select one. -->
<!-- Select "Not noteworthy" when the pull request fixes a bug in or improves functionality that has not yet appeared in a stable release. -->
<!-- release-note-category:start -->
- [ ] Not noteworthy
- [ ] Highlights
- [ ] More improvements
- [x] Fixed bugs
<!-- release-note-category:end -->

## Release note
<!-- Required unless "Not noteworthy" is selected. -->
<!-- Write one concise, user-facing entry without a leading bullet. -->
<!-- release-note:start -->
Running premieres keep their Premiere label, and stale channels no longer make subscription feeds appear outdated.
<!-- release-note:end -->

## Release note images
<!-- Human-only: Agents must preserve this entire section and leave it empty. -->
<!-- Optional. Paste one or more Markdown images or HTML image tags here. -->
<!-- The release notes will use an HTML image tag and limit images taller than 300 pixels. -->
<!-- release-note-image:start -->

<!-- release-note-image:end -->

## Testing
<!-- How can reviewers verify that the PR produces correct results? -->
<!-- Please provide instructions so that others can ensure that your pull request would produce correct results. For examples see, https://github.com/FreeTubeApp/FreeTube/pull/5743, https://github.com/FreeTubeApp/FreeTube/pull/7349, https://github.com/FreeTubeApp/FreeTube/pull/5125, https://github.com/FreeTubeApp/FreeTube/pull/7338 -->
<!-- Agent instructions: Only write human-facing steps that explain how to verify the change while running this branch in dev mode. Include expected results and, when applicable, helpful console snippets for interactive verification. Do not include automated checks, commands, results, pass counts, or CI status. -->
1. Open Subscriptions with an upcoming premiere and leave the feed open until its scheduled start.
2. Confirm it becomes visible with a **Premiere** badge and a watching count.
3. Use a profile where most channels refreshed recently but at least one channel still has an older cache entry.
4. Switch between Videos, Shorts, Live, and Posts and confirm each last-updated label reflects the recent successful cache update.

## Additional context
<!-- Please write any additional context that might be helpful to the reviewer. -->