### PR TITLE
fix(captions): restore bottom controls offset

### DIFF
--- a/e2e/tests/offline/caption-position.spec.mjs
+++ b/e2e/tests/offline/caption-position.spec.mjs
@@ -1,0 +1,57 @@
+import { setPlayerFullscreen, test, expect } from '../../helpers/app.mjs'
+import { openMockedVideo } from '../../helpers/player.mjs'
+import { mockPlayableWatchPage } from '../../helpers/watch.mjs'
+
+test.use({
+  seed: {
+    settings: {
+      videoPlaybackEngine: 'built-in',
+      ytDlpPlaybackEngineDefaultMigration: true,
+      enableSubtitlesByDefault: true,
+    }
+  }
+})
+
+test('lowers bottom captions after the player controls fade', async ({ app, page }) => {
+  await mockPlayableWatchPage(app, page, { captionCueSettings: 'align:start position:0%' })
+  await openMockedVideo(page)
+
+  const player = page.locator('.ftVideoPlayer')
+  const controls = player.locator('.shaka-controls-container')
+  const captions = player.locator('.shaka-text-container')
+  const caption = captions.locator('[translate="no"]')
+  await expect(caption).toBeVisible()
+  await setPlayerFullscreen(page, true)
+
+  await player.hover()
+  await expect(controls).toHaveAttribute('shown', 'true')
+  const raisedBottom = await captions.evaluate(element => {
+    return Number.parseFloat(getComputedStyle(element).bottom)
+  })
+  expect(raisedBottom).toBeGreaterThan(0)
+  const raisedCaptionBounds = await caption.boundingBox()
+
+  await page.mouse.move(0, 0)
+  await expect(controls).not.toHaveAttribute('shown', 'true')
+  const expectedHiddenBottom = await player.evaluate(element => {
+    return Math.max(12, element.getBoundingClientRect().height * 0.04)
+  })
+  await expect.poll(() => captions.evaluate(element => {
+    return Number.parseFloat(getComputedStyle(element).bottom)
+  })).toBeCloseTo(expectedHiddenBottom, 1)
+  await expect.poll(async () => {
+    const bounds = await caption.boundingBox()
+    return bounds?.y + bounds?.height
+  }).toBeGreaterThan(raisedCaptionBounds.y + raisedCaptionBounds.height)
+  await expect.poll(async () => {
+    const [playerBounds, captionBounds] = await Promise.all([
+      player.boundingBox(),
+      caption.boundingBox(),
+    ])
+    if (!playerBounds || !captionBounds) return Number.POSITIVE_INFINITY
+
+    const visualBottomGap = playerBounds.y + playerBounds.height -
+      (captionBounds.y + captionBounds.height)
+    return Math.abs(visualBottomGap - expectedHiddenBottom)
+  }).toBeLessThanOrEqual(1)
+})

--- a/e2e/tests/offline/watch-page.spec.mjs
+++ b/e2e/tests/offline/watch-page.spec.mjs
@@ -1530,61 +1530,6 @@ test.describe('fullscreen captions', () => {
   })
 })
 
-test.describe('bottom captions', () => {
-  test.use({
-    seed: {
-      settings: {
-        ...WATCH_PAGE_SEED,
-        enableSubtitlesByDefault: true,
-      }
-    }
-  })
-
-  test('lowers captions after the player controls fade', async ({ app, page }) => {
-    await mockPlayableWatchPage(app, page, { captionCueSettings: 'align:start position:0%' })
-    await openMockedVideo(page)
-
-    const player = page.locator('.ftVideoPlayer')
-    const controls = player.locator('.shaka-controls-container')
-    const captions = player.locator('.shaka-text-container')
-    const caption = captions.locator('[translate="no"]')
-    await expect(caption).toBeVisible()
-    await setPlayerFullscreen(page, true)
-
-    await player.hover()
-    await expect(controls).toHaveAttribute('shown', 'true')
-    const raisedBottom = await captions.evaluate(element => {
-      return Number.parseFloat(getComputedStyle(element).bottom)
-    })
-    expect(raisedBottom).toBeGreaterThan(0)
-    const raisedCaptionBounds = await caption.boundingBox()
-
-    await page.mouse.move(0, 0)
-    await expect(controls).not.toHaveAttribute('shown', 'true')
-    const expectedHiddenBottom = await player.evaluate(element => {
-      return Math.max(12, element.getBoundingClientRect().height * 0.04)
-    })
-    await expect.poll(() => captions.evaluate(element => {
-      return Number.parseFloat(getComputedStyle(element).bottom)
-    })).toBeCloseTo(expectedHiddenBottom, 1)
-    await expect.poll(async () => {
-      const bounds = await caption.boundingBox()
-      return bounds?.y + bounds?.height
-    }).toBeGreaterThan(raisedCaptionBounds.y + raisedCaptionBounds.height)
-    await expect.poll(async () => {
-      const [playerBounds, captionBounds] = await Promise.all([
-        player.boundingBox(),
-        caption.boundingBox(),
-      ])
-      if (!playerBounds || !captionBounds) return Number.POSITIVE_INFINITY
-
-      const visualBottomGap = playerBounds.y + playerBounds.height -
-        (captionBounds.y + captionBounds.height)
-      return Math.abs(visualBottomGap - expectedHiddenBottom)
-    }).toBeLessThanOrEqual(1)
-  })
-})
-
 test.describe('fullscreen playlist dock', () => {
   test.use({
     seed: {

--- a/e2e/tests/offline/watch-page.spec.mjs
+++ b/e2e/tests/offline/watch-page.spec.mjs
@@ -1530,6 +1530,61 @@ test.describe('fullscreen captions', () => {
   })
 })
 
+test.describe('bottom captions', () => {
+  test.use({
+    seed: {
+      settings: {
+        ...WATCH_PAGE_SEED,
+        enableSubtitlesByDefault: true,
+      }
+    }
+  })
+
+  test('lowers captions after the player controls fade', async ({ app, page }) => {
+    await mockPlayableWatchPage(app, page, { captionCueSettings: 'align:start position:0%' })
+    await openMockedVideo(page)
+
+    const player = page.locator('.ftVideoPlayer')
+    const controls = player.locator('.shaka-controls-container')
+    const captions = player.locator('.shaka-text-container')
+    const caption = captions.locator('[translate="no"]')
+    await expect(caption).toBeVisible()
+    await setPlayerFullscreen(page, true)
+
+    await player.hover()
+    await expect(controls).toHaveAttribute('shown', 'true')
+    const raisedBottom = await captions.evaluate(element => {
+      return Number.parseFloat(getComputedStyle(element).bottom)
+    })
+    expect(raisedBottom).toBeGreaterThan(0)
+    const raisedCaptionBounds = await caption.boundingBox()
+
+    await page.mouse.move(0, 0)
+    await expect(controls).not.toHaveAttribute('shown', 'true')
+    const expectedHiddenBottom = await player.evaluate(element => {
+      return Math.max(12, element.getBoundingClientRect().height * 0.04)
+    })
+    await expect.poll(() => captions.evaluate(element => {
+      return Number.parseFloat(getComputedStyle(element).bottom)
+    })).toBeCloseTo(expectedHiddenBottom, 1)
+    await expect.poll(async () => {
+      const bounds = await caption.boundingBox()
+      return bounds?.y + bounds?.height
+    }).toBeGreaterThan(raisedCaptionBounds.y + raisedCaptionBounds.height)
+    await expect.poll(async () => {
+      const [playerBounds, captionBounds] = await Promise.all([
+        player.boundingBox(),
+        caption.boundingBox(),
+      ])
+      if (!playerBounds || !captionBounds) return Number.POSITIVE_INFINITY
+
+      const visualBottomGap = playerBounds.y + playerBounds.height -
+        (captionBounds.y + captionBounds.height)
+      return Math.abs(visualBottomGap - expectedHiddenBottom)
+    }).toBeLessThanOrEqual(1)
+  })
+})
+
 test.describe('fullscreen playlist dock', () => {
   test.use({
     seed: {

--- a/src/renderer/components/ft-shaka-video-player/ft-shaka-video-player.css
+++ b/src/renderer/components/ft-shaka-video-player/ft-shaka-video-player.css
@@ -2990,6 +2990,13 @@
   transition: inset-inline-end 250ms ease, bottom cubic-bezier(0.4, 0, 0.6, 1) 0.1s;
 }
 
+:deep(.shaka-text-region) {
+  /* The app already provides the configured edge gap, so don't stack Shaka's 5% safe area on it. */
+  inset: 0 !important;
+  block-size: 100% !important;
+  inline-size: 100% !important;
+}
+
 :deep(.shaka-controls-container:not([shown='true'], [casting='true']) ~ .shaka-text-container) {
   bottom: var(--caption-hidden-bottom-gap) !important;
 }


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Make sure to follow the contributing guidelines. -->
<!-- Important note, we may remove your pull request if you do not use this provided PR template correctly. -->
<!-- Agent instructions: Preserve every heading, comment, and marker in this template. Never remove or rewrite the release-note-category:start/end, release-note:start/end, or release-note-image:start/end marker pairs. Never remove or rewrite the Release note images section; leave its contents for a human. -->

## Pull Request Type
<!-- Please select what type of pull request this is: [x] -->
- [x] Bugfix
- [ ] Feature Implementation
- [ ] Documentation
- [ ] Other

## Related issue
<!-- Please link the issue your pull request is referring to. -->
<!-- If this pull request fully resolves the relevant issue, put "closes" before the issue number. -->
<!-- Example: "closes #123456". -->

## Description
<!-- Please write a clear and concise description of what the pull request does. -->
Bottom-anchored captions remained too high after the player controls faded. The WebVTT positioning fix made Shaka render configured caption positions inside its own 90% safe region, while the app continued applying its existing edge gap around that region.

Expand Shaka's custom region to the full caption container so the app's configured edge gap remains the single source of spacing. This preserves the WebVTT alignment fix while restoring the previous bottom-caption movement.

The regression test uses a positioned WebVTT cue and verifies the visible cue's final gap from the player edge, rather than only checking its container.

## Release note category
<!-- Select exactly one category. Every pull request must select one. -->
<!-- Select "Not noteworthy" when the pull request fixes a bug in or improves functionality that has not yet appeared in a stable release. -->
<!-- release-note-category:start -->
- [x] Not noteworthy
- [ ] Highlights
- [ ] More improvements
- [ ] Fixed bugs
<!-- release-note-category:end -->

## Release note
<!-- Required unless "Not noteworthy" is selected. -->
<!-- Write one concise, user-facing entry without a leading bullet. -->
<!-- release-note:start -->

<!-- release-note:end -->

## Release note images
<!-- Human-only: Agents must preserve this entire section and leave it empty. -->
<!-- Optional. Paste one or more Markdown images or HTML image tags here. -->
<!-- The release notes will use an HTML image tag and limit images taller than 300 pixels. -->
<!-- release-note-image:start -->

<!-- release-note-image:end -->

## Testing
<!-- How can reviewers verify that the PR produces correct results? -->
<!-- Please provide instructions so that others can ensure that this pull request would produce correct results. For examples see, https://github.com/FreeTubeApp/FreeTube/pull/5743, https://github.com/FreeTubeApp/FreeTube/pull/7349, https://github.com/FreeTubeApp/FreeTube/pull/5125, https://github.com/FreeTubeApp/FreeTube/pull/7338 -->
<!-- Agent instructions: Only write human-facing steps that explain how to verify the change while running this branch in dev mode. Include expected results and, when applicable, helpful console snippets for interactive verification. Do not include automated checks, commands, results, pass counts, or CI status. -->
1. Open a regular video with WebVTT captions and enable captions at the bottom-center position.
2. Enter fullscreen, move the pointer over the player to show the controls, then move it away and wait for the controls to fade. The captions should lower with the controls and stop at one normal edge gap instead of remaining unusually high.
3. Repeat with a source cue that carries its own horizontal position. The configured left, center, or right caption alignment should still win.
4. Check a Shorts video with captions. Its captions should remain fixed when hover controls appear.

## Additional context
<!-- Add any other context the pull request here. -->
The triggering regression was #711: Shaka's forced `BOTTOM_CENTER` region adds a 5% inset internally. Combined with the app's existing 4% edge gap, the packaged AUR build showed a doubled bottom margin. Switching the same running player back to Shaka's pre-#711 `DEFAULT` positioning removed the extra inset, confirming the boundary.