### PR TITLE
fix(downloads): refresh completed video titles and thumbnails

### DIFF
--- a/e2e/tests/offline/video-actions.spec.mjs
+++ b/e2e/tests/offline/video-actions.spec.mjs
@@ -421,6 +421,36 @@ test.describe('video downloads', () => {
     await expect(downloadRow.locator('.downloadThumbnail')).toHaveAttribute('src', currentThumbnail)
   })
 
+  test('clears a stale feed thumbnail when yt-dlp finds none', async ({ app, page }) => {
+    const downloadedFile = path.join(app.userDataDir, 'no-thumbnail-demo.webm')
+    const executable = path.join(app.userDataDir, 'no-thumbnail-yt-dlp.sh')
+    await writeFile(downloadedFile, '')
+    await writeFile(executable, [
+      '#!/bin/sh',
+      'printf \'__OPENTUBEX_METADATA__:"eeeeeeeeeee"\\t"Current video title"\\tnull\\n\'',
+      `printf '__OPENTUBEX_FILE__:eeeeeeeeeee\\t1\\t640\\t360\\t${downloadedFile}\\n'`
+    ].join('\n'))
+    await chmod(executable, 0o755)
+    await page.evaluate(async (ytDlpPath) => {
+      const store = document.querySelector('#app').__vue_app__.config.globalProperties.$store
+      await store.dispatch('updateYtDlpPath', ytDlpPath)
+    }, executable)
+
+    const result = await page.evaluate(() => window.ftElectron.ytDlpDownload({
+      videoId: 'eeeeeeeeeee',
+      title: 'Translated feed title',
+      thumbnail: 'https://images.example/stale-feed-thumbnail.jpg',
+      mode: 'video'
+    }))
+    await expect.poll(() => page.evaluate(async (id) => {
+      return (await window.ftElectron.ytDlpListDownloads()).find(download => download.id === id)
+    }, result.id)).toMatchObject({
+      title: 'Current video title',
+      thumbnail: '',
+      status: 'completed'
+    })
+  })
+
   test('plays a downloaded video locally and reconciles it after external deletion', async ({ app, page }) => {
     const downloadedFile = path.join(app.userDataDir, 'downloaded-demo.webm')
     const downloadedAudioFile = path.join(app.userDataDir, 'downloaded-audio-alternative.wav')

--- a/e2e/tests/offline/video-actions.spec.mjs
+++ b/e2e/tests/offline/video-actions.spec.mjs
@@ -383,6 +383,44 @@ test.describe('video downloads', () => {
     }, result.id)).toMatchObject({ title: '', status: 'completed' })
   })
 
+  test('uses yt-dlp metadata for a completed single-video download', async ({ app, page }) => {
+    const downloadedFile = path.join(app.userDataDir, 'metadata-demo.webm')
+    const executable = path.join(app.userDataDir, 'metadata-yt-dlp.sh')
+    const currentTitle = 'Current video title'
+    const currentThumbnail = 'data:image/svg+xml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciLz4='
+    const metadataLine = `__OPENTUBEX_METADATA__:${JSON.stringify('eeeeeeeeeee')}\t${JSON.stringify(currentTitle)}\t${JSON.stringify(currentThumbnail)}`
+    await writeFile(downloadedFile, '')
+    await writeFile(executable, [
+      '#!/bin/sh',
+      `printf '%s\\n' '${metadataLine}'`,
+      `printf '__OPENTUBEX_FILE__:eeeeeeeeeee\\t1\\t640\\t360\\t${downloadedFile}\\n'`
+    ].join('\n'))
+    await chmod(executable, 0o755)
+    await page.evaluate(async (ytDlpPath) => {
+      const store = document.querySelector('#app').__vue_app__.config.globalProperties.$store
+      await store.dispatch('updateYtDlpPath', ytDlpPath)
+    }, executable)
+
+    const result = await page.evaluate(() => window.ftElectron.ytDlpDownload({
+      videoId: 'eeeeeeeeeee',
+      title: 'Translated feed title',
+      thumbnail: '',
+      mode: 'video'
+    }))
+    await expect.poll(() => page.evaluate(async (id) => {
+      return (await window.ftElectron.ytDlpListDownloads()).find(download => download.id === id)
+    }, result.id)).toMatchObject({
+      title: currentTitle,
+      thumbnail: currentThumbnail,
+      status: 'completed'
+    })
+
+    await goTo(page, 'downloads')
+    const downloadRow = page.locator('.downloadRow').filter({ hasText: currentTitle })
+    await expect(downloadRow).toBeVisible()
+    await expect(downloadRow.locator('.downloadThumbnail')).toHaveAttribute('src', currentThumbnail)
+  })
+
   test('plays a downloaded video locally and reconciles it after external deletion', async ({ app, page }) => {
     const downloadedFile = path.join(app.userDataDir, 'downloaded-demo.webm')
     const downloadedAudioFile = path.join(app.userDataDir, 'downloaded-audio-alternative.wav')

--- a/e2e/tests/offline/video-actions.spec.mjs
+++ b/e2e/tests/offline/video-actions.spec.mjs
@@ -401,6 +401,8 @@ test.describe('video downloads', () => {
       await store.dispatch('updateYtDlpPath', ytDlpPath)
     }, executable)
 
+    await page.bringToFront()
+    await page.locator('body').click({ position: { x: 1, y: 1 } })
     const result = await page.evaluate(() => window.ftElectron.ytDlpDownload({
       videoId: 'eeeeeeeeeee',
       title: 'Translated feed title',
@@ -436,6 +438,8 @@ test.describe('video downloads', () => {
       await store.dispatch('updateYtDlpPath', ytDlpPath)
     }, executable)
 
+    await page.bringToFront()
+    await page.locator('body').click({ position: { x: 1, y: 1 } })
     const result = await page.evaluate(() => window.ftElectron.ytDlpDownload({
       videoId: 'eeeeeeeeeee',
       title: 'Translated feed title',

--- a/src/main/ytDlp.js
+++ b/src/main/ytDlp.js
@@ -158,6 +158,7 @@ const MERGER_REGEX = /^\[Merger\] Merging formats into "(.+)"$/
 // yt-dlp doesn't include subtitle files in its `after_move:%(filepath)s` output
 const SUBTITLE_DESTINATION_REGEX = /^\[info\] Writing video subtitles to: (.+)$/
 const FINAL_PATH_PREFIX = '__OPENTUBEX_FILE__:'
+const FINAL_METADATA_PREFIX = '__OPENTUBEX_METADATA__:'
 
 let downloadCounter = 0
 let downloadRecordsSaveQueue = Promise.resolve()
@@ -1532,6 +1533,12 @@ async function startYtDlpDownload(
     '--print',
     `after_move:${FINAL_PATH_PREFIX}%(id)s\t%(duration)s\t%(width)s\t%(height)s\t%(filepath)s`
   ]
+  if (isSingleVideo) {
+    args.push(
+      '--print',
+      `after_move:${FINAL_METADATA_PREFIX}%(id)j\t%(title)j\t%(thumbnail)j`
+    )
+  }
 
   if (!isRemotePlaylist) {
     args.push('--no-playlist')
@@ -1782,6 +1789,23 @@ async function startYtDlpDownload(
    * @param {string} line
    */
   function handleStdoutLine(line) {
+    if (line.startsWith(FINAL_METADATA_PREFIX)) {
+      const [rawVideoId, rawTitle, rawThumbnail] = line.slice(FINAL_METADATA_PREFIX.length).split('\t')
+      try {
+        const videoId = JSON.parse(rawVideoId)
+        const title = JSON.parse(rawTitle)
+        const thumbnail = JSON.parse(rawThumbnail)
+        if (videoId === status.videoId) {
+          if (typeof title === 'string' && title !== '') status.title = title.slice(0, 255)
+          if (typeof thumbnail === 'string') status.thumbnail = thumbnail.slice(0, 2048)
+          sendStatus(true)
+        }
+      } catch {
+        // A malformed metadata line must not interfere with the download itself.
+      }
+      return
+    }
+
     if (line.startsWith(FINAL_PATH_PREFIX)) {
       const parts = line.slice(FINAL_PATH_PREFIX.length).split('\t')
       const hasMediaMetadata = parts.length >= 5

--- a/src/main/ytDlp.js
+++ b/src/main/ytDlp.js
@@ -1798,6 +1798,7 @@ async function startYtDlpDownload(
         if (videoId === status.videoId) {
           if (typeof title === 'string' && title !== '') status.title = title.slice(0, 255)
           if (typeof thumbnail === 'string') status.thumbnail = thumbnail.slice(0, 2048)
+          else if (thumbnail === null) status.thumbnail = ''
           sendStatus(true)
         }
       } catch {


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Make sure to follow the contributing guidelines. -->
<!-- Important note, we may remove your pull request if you do not use this provided PR template correctly. -->
<!-- Agent instructions: Preserve every heading, comment, and marker in this template. Never remove or rewrite the release-note-category:start/end, release-note:start/end, or release-note-image:start/end marker pairs. Never remove or rewrite the Release note images section; leave its contents for a human. -->

## Pull Request Type
<!-- Please select what type of pull request this is: [x] -->
- [x] Bugfix
- [ ] Feature Implementation
- [ ] Documentation
- [ ] Other

## Related issue
<!-- Please link the issue your pull request is referring to. -->
<!-- If this pull request fully resolves the relevant issue, put "closes" before the issue number. -->
<!-- Example: "closes #123456". -->

## Description
<!-- Please write a clear and concise description of what the pull request does. -->
Automatic downloads retain titles and thumbnails from the subscription feed, which can leave the download manager showing a translated title, a scheduled timestamp, or no thumbnail after the download completes.

For completed single-video downloads, this change asks yt-dlp to print its final extracted title and thumbnail and updates the persisted download record with that authoritative metadata. Playlist display metadata remains unchanged. An offline Electron regression covers both the persisted record and the download-manager UI.

## Release note category
<!-- Select exactly one category. Every pull request must select one. -->
<!-- Select "Not noteworthy" when the pull request fixes a bug in or improves functionality that has not yet appeared in a stable release. -->
<!-- release-note-category:start -->
- [ ] Not noteworthy
- [ ] Highlights
- [ ] More improvements
- [x] Fixed bugs
<!-- release-note-category:end -->

## Release note
<!-- Required unless "Not noteworthy" is selected. -->
<!-- Write one concise, user-facing entry without a leading bullet. -->
<!-- release-note:start -->
Completed downloads now show the current video title and thumbnail in the download manager.
<!-- release-note:end -->

## Release note images
<!-- Human-only: Agents must preserve this entire section and leave it empty. -->
<!-- Optional. Paste one or more Markdown images or HTML image tags here. -->
<!-- The release notes will use an HTML image tag and limit images taller than 300 pixels. -->
<!-- release-note-image:start -->

<!-- release-note-image:end -->

## Testing
<!-- How can reviewers verify that the PR produces correct results? -->
<!-- Please provide instructions so that others can ensure that your pull request would produce correct results. For examples see, https://github.com/FreeTubeApp/FreeTube/pull/5743, https://github.com/FreeTubeApp/FreeTube/pull/7349, https://github.com/FreeTubeApp/FreeTube/pull/5125, https://github.com/FreeTubeApp/FreeTube/pull/7338 -->
<!-- Agent instructions: Only write human-facing steps that explain how to verify the change while running this branch in dev mode. Include expected results and, when applicable, helpful console snippets for interactive verification. Do not include automated checks, commands, results, pass counts, or CI status. -->
1. Enable automatic downloads for a subscribed channel and refresh subscriptions so a new video is downloaded.
2. Open Downloads while the job is active and wait for it to complete.
3. Confirm the completed row uses the video's current title and thumbnail rather than translated or placeholder feed metadata.
4. Restart the app and confirm the corrected title and thumbnail remain in download history.

## Additional context
<!-- Add any other context about the pull request here. -->
The final metadata line uses JSON-escaped yt-dlp output fields so titles containing tabs or other control characters cannot break parsing.
