### PR TITLE
feat(subscriptions): sort new feed oldest first

### DIFF
--- a/e2e/tests/offline/subscriptions-header-layout.spec.mjs
+++ b/e2e/tests/offline/subscriptions-header-layout.spec.mjs
@@ -82,6 +82,37 @@ function headerBoxes (page) {
 }
 
 test.describe('subscriptions header layout', () => {
+  test('keeps the New feed sort control compact beside refresh', async ({ app, page, attachScreenshot }) => {
+    await goTo(page, 'subscriptions')
+    await page.locator('[data-subscription-feed-tab="all"]').click()
+    await setWindowWidth(app, page, 340)
+
+    const layout = await page.evaluate(() => {
+      const toBox = element => {
+        const rect = element.getBoundingClientRect()
+        return { start: rect.left, end: rect.right, top: rect.top, bottom: rect.bottom }
+      }
+      const select = document.querySelector('.headerSortSelect .select-text')
+
+      return {
+        select: toBox(select),
+        label: toBox(document.querySelector('.headerSortSelect .select-label')),
+        refresh: toBox(document.querySelector('.headerRefreshWidget .refreshButton')),
+        selectedText: select.textContent.trim()
+      }
+    })
+
+    expect(layout.selectedText).toBe('Newest first')
+    expect(layout.select.end).toBeLessThanOrEqual(layout.refresh.start)
+    expect(Math.abs(
+      (layout.select.top + layout.select.bottom) / 2 -
+      (layout.refresh.top + layout.refresh.bottom) / 2
+    )).toBeLessThanOrEqual(1)
+    expect(layout.label.top).toBeGreaterThanOrEqual(layout.select.top)
+    expect(layout.label.bottom).toBeLessThanOrEqual(layout.select.bottom)
+    await attachScreenshot('compact New feed header actions')
+  })
+
   test('puts the tabs beside the title when they fit', async ({ page, attachScreenshot }) => {
     await goTo(page, 'subscriptions')
 

--- a/e2e/tests/offline/subscriptions-new-feed.spec.mjs
+++ b/e2e/tests/offline/subscriptions-new-feed.spec.mjs
@@ -239,6 +239,13 @@ test.describe('new subscriptions feed sorting', () => {
 
     const sortSelect = page.locator('.headerSortSelect').getByRole('combobox')
     await expect(sortSelect).toHaveText('Newest first')
+    await page.evaluate(() => {
+      const store = document.querySelector('#app').__vue_app__.config.globalProperties.$store
+      store.commit('setNewSubscriptionFeedSortBy', 'unsupported')
+    })
+    await expect(sortSelect).toHaveText('Newest first')
+    await expect.poll(() => videoTitles(page)).toEqual(['Newest video', 'Oldest video'])
+
     await sortSelect.click()
     await page.getByRole('option', { name: 'Oldest first' }).click()
 

--- a/e2e/tests/offline/subscriptions-new-feed.spec.mjs
+++ b/e2e/tests/offline/subscriptions-new-feed.spec.mjs
@@ -195,6 +195,70 @@ test.describe('new subscriptions feed', () => {
   })
 })
 
+test.describe('new subscriptions feed sorting', () => {
+  const newestVideo = video('sort-newest-video', 'Newest video', now - HOUR, {
+    isNewInSubscriptionFeed: true
+  })
+  const oldestVideo = video('sort-oldest-video', 'Oldest video', now - 3 * HOUR, {
+    isNewInSubscriptionFeed: true
+  })
+  const newestPost = post('sort-newest-post', 'Newest post', now - 2 * HOUR)
+  const oldestPost = post('sort-oldest-post', 'Oldest post', now - 4 * HOUR)
+
+  test.use({
+    seed: {
+      settings: commonSettings,
+      profiles: [profile()],
+      subscriptionCache: [{
+        _id: CHANNEL_ID,
+        videos: [oldestVideo, newestVideo],
+        videosTimestamp: new Date(now).toISOString(),
+        shorts: [],
+        shortsTimestamp: new Date(now).toISOString(),
+        liveStreams: [],
+        liveStreamsTimestamp: new Date(now).toISOString(),
+        communityPosts: [oldestPost, newestPost],
+        communityPostsTimestamp: new Date(now).toISOString()
+      }]
+    }
+  })
+
+  test('sorts every section oldest first and persists the preference', async ({ app, page }) => {
+    const videoTitles = page => page.locator('.newFeed > .autoGrid .ft-list-video').evaluateAll(cards => {
+      return cards.map(card => card.querySelector('.title').textContent.trim())
+    })
+    const postTexts = page => page.locator('.newFeed .postsSection .ft-list-post').evaluateAll(posts => {
+      return posts.map(post => post.querySelector('.postText').textContent.trim())
+    })
+
+    await goTo(page, 'subscriptions')
+    await page.locator('[data-subscription-feed-tab="all"]').click()
+
+    await expect.poll(() => videoTitles(page)).toEqual(['Newest video', 'Oldest video'])
+    await expect.poll(() => postTexts(page)).toEqual(['Newest post', 'Oldest post'])
+
+    const sortSelect = page.locator('.headerSortSelect').getByRole('combobox')
+    await expect(sortSelect).toHaveText('Newest first')
+    await sortSelect.click()
+    await page.getByRole('option', { name: 'Oldest first' }).click()
+
+    await expect(sortSelect).toHaveText('Oldest first')
+    await expect.poll(() => videoTitles(page)).toEqual(['Oldest video', 'Newest video'])
+    await expect.poll(() => postTexts(page)).toEqual(['Oldest post', 'Newest post'])
+    await expect.poll(() => page.evaluate(() => {
+      return document.querySelector('#app').__vue_app__.config.globalProperties.$store.getters.getNewSubscriptionFeedSortBy
+    })).toBe('oldest')
+
+    const relaunched = await app.relaunch()
+    await goTo(relaunched.page, 'subscriptions')
+    await relaunched.page.locator('[data-subscription-feed-tab="all"]').click()
+
+    await expect(relaunched.page.locator('.headerSortSelect').getByRole('combobox')).toHaveText('Oldest first')
+    await expect.poll(() => videoTitles(relaunched.page)).toEqual(['Oldest video', 'Newest video'])
+    await expect.poll(() => postTexts(relaunched.page)).toEqual(['Oldest post', 'Newest post'])
+  })
+})
+
 test.describe('new feed settings and seen state', () => {
   const videoPost = {
     ...post('new-post-2', 'New video post', now - 40 * 60000),

--- a/src/renderer/components/SubscriptionsNew.vue
+++ b/src/renderer/components/SubscriptionsNew.vue
@@ -146,7 +146,9 @@ const newContentByCategory = computed(() => {
 })
 
 const forbiddenTitles = computed(() => store.getters.getForbiddenTitlesParsed)
-const sortBy = computed(() => store.getters.getNewSubscriptionFeedSortBy)
+const sortBy = computed(() => {
+  return store.getters.getNewSubscriptionFeedSortBy === 'oldest' ? 'oldest' : 'newest'
+})
 
 function applySortPreference(entries) {
   return sortBy.value === 'oldest' ? entries.toReversed() : entries

--- a/src/renderer/components/SubscriptionsNew.vue
+++ b/src/renderer/components/SubscriptionsNew.vue
@@ -146,6 +146,12 @@ const newContentByCategory = computed(() => {
 })
 
 const forbiddenTitles = computed(() => store.getters.getForbiddenTitlesParsed)
+const sortBy = computed(() => store.getters.getNewSubscriptionFeedSortBy)
+
+function applySortPreference(entries) {
+  return sortBy.value === 'oldest' ? entries.toReversed() : entries
+}
+
 const newMediaByCategory = computed(() => {
   let mediaEntries = ['videos', 'shorts', 'live'].flatMap(category => {
     return newContentByCategory.value[category].map(entry => ({ category, entry }))
@@ -181,7 +187,7 @@ const newMediaByCategory = computed(() => {
     })
   }
 
-  return mediaEntries.reduce((entries, { category, entry }) => {
+  const entriesByCategory = mediaEntries.reduce((entries, { category, entry }) => {
     entries[category].push(entry)
     return entries
   }, {
@@ -189,17 +195,25 @@ const newMediaByCategory = computed(() => {
     shorts: [],
     live: []
   })
+
+  Object.keys(entriesByCategory).forEach(category => {
+    entriesByCategory[category] = applySortPreference(entriesByCategory[category])
+  })
+
+  return entriesByCategory
 })
 
 const newVideos = computed(() => newMediaByCategory.value.videos)
 const newShorts = computed(() => newMediaByCategory.value.shorts)
 const newLive = computed(() => newMediaByCategory.value.live)
-const newPosts = computed(() => newContentByCategory.value.posts.filter(entry => {
-  const lowerCaseAuthor = entry.author?.toLowerCase()
+const newPosts = computed(() => applySortPreference(
+  newContentByCategory.value.posts.filter(entry => {
+    const lowerCaseAuthor = entry.author?.toLowerCase()
 
-  return entry.postId != null &&
-    !forbiddenTitles.value.some(text => lowerCaseAuthor?.includes(text))
-}))
+    return entry.postId != null &&
+      !forbiddenTitles.value.some(text => lowerCaseAuthor?.includes(text))
+  })
+))
 const useCustomShortsPlayer = computed(() => store.getters.getUseCustomShortsPlayer)
 
 const hasAdditionalContent = computed(() => {

--- a/src/renderer/store/modules/settings.js
+++ b/src/renderer/store/modules/settings.js
@@ -465,6 +465,7 @@ const state = {
   showScheduledLiveStreamsFirst: true,
   showNewSubscriptionFeed: true,
   showNewSubscriptionFeedIndicators: false,
+  newSubscriptionFeedSortBy: 'newest',
   subscriptionFeedAutoRefreshInterval: '0',
   subscriptionShortsAutoRefreshInterval: '0',
   subscriptionLiveAutoRefreshInterval: '0',

--- a/src/renderer/views/Subscriptions/Subscriptions.css
+++ b/src/renderer/views/Subscriptions/Subscriptions.css
@@ -69,11 +69,54 @@
   opacity: 0.5;
 }
 
-.headerRefreshWidget {
+.headerActions {
+  align-items: center;
+  display: flex;
+  gap: 12px;
+
   /* Size to its content so the header row positions the whole widget: tucked to
      the inline-end while it fits beside the title, and flush to the inline-start
      once it wraps onto its own line. */
   max-inline-size: 100%;
+}
+
+.headerActions .headerSortSelect {
+  flex-shrink: 0;
+  inline-size: 220px;
+  margin-block-start: 0;
+}
+
+.headerSortSelect :deep(.select-text) {
+  block-size: 36px;
+  padding-inline-start: 86px;
+  font-size: 0.9rem;
+}
+
+.headerSortSelect :deep(.nativeSelect) {
+  block-size: 36px;
+}
+
+.headerSortSelect :deep(.select-label),
+.headerSortSelect :deep(.select-text ~ .select-label) {
+  inset-block-start: 50%;
+  inset-inline-start: 12px;
+  z-index: 1;
+  max-inline-size: 68px;
+  overflow: hidden;
+  color: var(--tertiary-text-color);
+  font-size: 0.8rem;
+  pointer-events: none;
+  text-overflow: ellipsis;
+  transform: translateY(-50%);
+}
+
+.headerSortSelect :deep(.select-label-text) {
+  overflow: hidden;
+}
+
+.headerSortSelect :deep(.select-placeholder) {
+  overflow: hidden;
+  text-overflow: ellipsis;
 }
 
 .message {
@@ -123,7 +166,7 @@
   margin-block-start: 0;
 }
 
-.subscriptionsHeader.singleRow .headerRefreshWidget {
+.subscriptionsHeader.singleRow .headerActions {
   margin-inline-start: auto;
 }
 

--- a/src/renderer/views/Subscriptions/Subscriptions.vue
+++ b/src/renderer/views/Subscriptions/Subscriptions.vue
@@ -169,21 +169,35 @@
               {{ $t('Subscriptions.Mark All as Seen') }}
             </button>
           </div>
-          <FtRefreshWidget
+          <div
             v-if="currentTabPanel !== null"
-            embedded
-            class="headerRefreshWidget"
-            :disable-refresh="subscriptionFeedRefreshInProgress || currentTabPanel.isLoading || activeSubscriptionList.length === 0"
-            :last-refresh-timestamp="currentTabPanel.lastRefreshTimestamp"
-            :next-auto-refresh-timestamp="currentTabPanel.nextAutoRefreshTimestamp"
-            :next-auto-refresh-tooltip="currentTabPanel.nextAutoRefreshTooltip"
-            :next-auto-refresh-at="currentAutoRefresh.timestamp"
-            :auto-refresh-interval="currentAutoRefresh.interval"
-            :title="currentTabPanel.refreshTitle"
-            :refresh-in-progress="subscriptionFeedRefreshInProgress"
-            @click="refreshCurrentTab"
-            @cancel="cancelRefresh"
-          />
+            class="headerActions"
+          >
+            <FtSelect
+              v-if="currentTab === 'new'"
+              class="headerSortSelect"
+              :placeholder="$t('Global.Sort By')"
+              :value="newFeedSortBy"
+              :select-names="newFeedSortByNames"
+              :select-values="NEW_FEED_SORT_BY_VALUES"
+              :icon="newFeedSortByIcon"
+              @change="updateNewFeedSortBy"
+            />
+            <FtRefreshWidget
+              embedded
+              class="headerRefreshWidget"
+              :disable-refresh="subscriptionFeedRefreshInProgress || currentTabPanel.isLoading || activeSubscriptionList.length === 0"
+              :last-refresh-timestamp="currentTabPanel.lastRefreshTimestamp"
+              :next-auto-refresh-timestamp="currentTabPanel.nextAutoRefreshTimestamp"
+              :next-auto-refresh-tooltip="currentTabPanel.nextAutoRefreshTooltip"
+              :next-auto-refresh-at="currentAutoRefresh.timestamp"
+              :auto-refresh-interval="currentAutoRefresh.interval"
+              :title="currentTabPanel.refreshTitle"
+              :refresh-in-progress="subscriptionFeedRefreshInProgress"
+              @click="refreshCurrentTab"
+              @cancel="cancelRefresh"
+            />
+          </div>
         </div>
       </div>
       <SubscriptionsVideos
@@ -250,6 +264,7 @@ import FtLoader from '../../components/FtLoader/FtLoader.vue'
 import FtFlexBox from '../../components/ft-flex-box/ft-flex-box.vue'
 import FtPrompt from '../../components/FtPrompt/FtPrompt.vue'
 import FtRefreshWidget from '../../components/FtRefreshWidget/FtRefreshWidget.vue'
+import FtSelect from '../../components/FtSelect/FtSelect.vue'
 import SubscriptionsNew from '../../components/SubscriptionsNew.vue'
 import SubscriptionsVideos from '../../components/SubscriptionsVideos.vue'
 import SubscriptionsLive from '../../components/SubscriptionsLive.vue'
@@ -257,6 +272,7 @@ import SubscriptionsShorts from '../../components/SubscriptionsShorts.vue'
 import SubscriptionsPosts from '../../components/SubscriptionsPosts.vue'
 
 import { getAnimationSpeedMultiplier } from '../../helpers/animationSpeed'
+import { getIconForSortPreference } from '../../helpers/utils'
 import store from '../../store/index'
 import { useTabContext } from '../../tabs/TabContext'
 import { getTabNavigationService } from '../../tabs/TabNavigationService'
@@ -283,6 +299,7 @@ const {
   showRefreshWarning: showAllFeedsRefreshWarning
 } = useRefreshAllSubscriptionFeeds()
 const currentTabStorageKey = 'Subscriptions/currentTab'
+const NEW_FEED_SORT_BY_VALUES = ['newest', 'oldest']
 
 /** @type {import('vue').ComputedRef<boolean>} */
 const hideSubscriptionsVideos = computed(() => {
@@ -311,6 +328,19 @@ const showNewSubscriptionFeedIndicators = computed(() => {
 const showNewSubscriptionFeed = computed(() => {
   return store.getters.getShowNewSubscriptionFeed
 })
+
+const newFeedSortBy = computed(() => store.getters.getNewSubscriptionFeedSortBy)
+const newFeedSortByNames = computed(() => [
+  t('Subscriptions.Newest First'),
+  t('Subscriptions.Oldest First')
+])
+const newFeedSortByIcon = computed(() => getIconForSortPreference(newFeedSortBy.value))
+
+function updateNewFeedSortBy(value) {
+  if (NEW_FEED_SORT_BY_VALUES.includes(value)) {
+    store.dispatch('updateNewSubscriptionFeedSortBy', value)
+  }
+}
 
 const activeSubscriptionList = computed(() => {
   return store.getters.getActiveProfile.subscriptions

--- a/src/renderer/views/Subscriptions/Subscriptions.vue
+++ b/src/renderer/views/Subscriptions/Subscriptions.vue
@@ -329,7 +329,10 @@ const showNewSubscriptionFeed = computed(() => {
   return store.getters.getShowNewSubscriptionFeed
 })
 
-const newFeedSortBy = computed(() => store.getters.getNewSubscriptionFeedSortBy)
+const newFeedSortBy = computed(() => {
+  const value = store.getters.getNewSubscriptionFeedSortBy
+  return NEW_FEED_SORT_BY_VALUES.includes(value) ? value : 'newest'
+})
 const newFeedSortByNames = computed(() => [
   t('Subscriptions.Newest First'),
   t('Subscriptions.Oldest First')

--- a/static/locales/en-US.yaml
+++ b/static/locales/en-US.yaml
@@ -230,6 +230,8 @@ Subscriptions:
   Mark as Seen: Mark as seen
   Mark All as Seen: Mark all as seen
   No New Content: There is no new content.
+  Newest First: Newest first
+  Oldest First: Oldest first
 More: More
 Channels:
   Channels: Channels


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Make sure to follow the contributing guidelines. -->
<!-- Important note, we may remove your pull request if you do not use this provided PR template correctly. -->
<!-- Agent instructions: Preserve every heading, comment, and marker in this template. Never remove or rewrite the release-note-category:start/end, release-note:start/end, or release-note-image:start/end marker pairs. Never remove or rewrite the Release note images section; leave its contents for a human. -->

## Pull Request Type
<!-- Please select what type of pull request this is: [x] -->
- [ ] Bugfix
- [x] Feature Implementation
- [ ] Documentation
- [ ] Other

## Related issue
<!-- Please link the issue your pull request is referring to. -->
<!-- If this pull request fully resolves the relevant issue, put "closes" before the issue number. -->
<!-- Example: "closes #123456". -->

## Description
<!-- Please write a clear and concise description of what the pull request does. -->

The New subscriptions feed was fixed to newest-first, which made it awkward to work through unseen content chronologically.

This adds a persistent newest/oldest sort control to the New feed header beside refresh. Videos, Shorts, live streams, and posts follow the selected order, while the existing latest-per-channel limit continues to select the genuinely latest entries before presentation order is applied. The compact header treatment keeps the control aligned at the minimum supported window width.

## Release note category
<!-- Select exactly one category. Every pull request must select one. -->
<!-- Select "Not noteworthy" when the pull request fixes a bug in or improves functionality that has not yet appeared in a stable release. -->
<!-- release-note-category:start -->
- [ ] Not noteworthy
- [ ] Highlights
- [x] More improvements
- [ ] Fixed bugs
<!-- release-note-category:end -->

## Release note
<!-- Required unless "Not noteworthy" is selected. -->
<!-- Write one concise, user-facing entry without a leading bullet. -->
<!-- release-note:start -->
The New subscriptions feed can now be sorted with the oldest content first.
<!-- release-note:end -->

## Release note images
<!-- Human-only: Agents must preserve this entire section and leave it empty. -->
<!-- Optional. Paste one or more Markdown images or HTML image tags here. -->
<!-- The release notes will use an HTML image tag and limit images taller than 300 pixels. -->
<!-- release-note-image:start -->
<img width="293" height="143" alt="image" src="https://github.com/user-attachments/assets/c2c107bb-4330-462a-a92a-0e256f1ed55d" />
<!-- release-note-image:end -->

## Testing
<!-- How can reviewers verify that the PR produces correct results? -->
<!-- Please provide instructions so that others can ensure that your pull request would produce correct results. For examples see, https://github.com/FreeTubeApp/FreeTube/pull/5743, https://github.com/FreeTubeApp/FreeTube/pull/7349, https://github.com/FreeTubeApp/FreeTube/pull/5125, https://github.com/FreeTubeApp/FreeTube/pull/7338 -->
<!-- Agent instructions: Only write human-facing steps that explain how to verify the change while running this branch in dev mode. Include expected results and, when applicable, helpful console snippets for interactive verification. Do not include automated checks, commands, results, pass counts, or CI status. -->

1. Refresh subscriptions so the New tab contains at least two entries with different publication times.
2. Open the New tab and confirm the compact **Sort by** control appears immediately left of refresh.
3. Select **Oldest first** and confirm each visible content section changes to chronological order.
4. Switch tabs or restart the app, return to New, and confirm **Oldest first** remains selected.
5. Enable the per-channel latest-content limit and confirm it still keeps the latest entries, while displaying those retained entries oldest-first.
6. Resize the window to its minimum width and confirm the sort control remains aligned beside refresh without a detached floating label.

## Additional context
<!-- Add any other context about the pull request here. -->
