### PR TITLE
fix(posts): enable attached video channel links

### DIFF
--- a/src/renderer/components/FtListVideo/FtListVideo.scss
+++ b/src/renderer/components/FtListVideo/FtListVideo.scss
@@ -142,7 +142,7 @@
   grid-column: 1 / -1;
 }
 
-.channelName.collaboratorChannelButton {
+.channelName.channelResolverButton {
   background: none;
   border: 0;
   color: inherit;
@@ -153,7 +153,7 @@
   text-decoration: underline;
 }
 
-.channelName.collaboratorChannelButton:disabled {
+.channelName.channelResolverButton:disabled {
   cursor: wait;
 }
 

--- a/src/renderer/components/FtListVideo/FtListVideo.vue
+++ b/src/renderer/components/FtListVideo/FtListVideo.vue
@@ -1369,7 +1369,7 @@ const deArrowCache = computed(() => store.getters.getDeArrowCache[id.value])
 
 const disableChannelLinks = computed(() => store.getters.getDisableChannelLinks)
 
-const shouldShowChannelResolverButton = computed(() => channelName.value !== null && (
+const shouldShowChannelResolverButton = computed(() => !disableChannelLinks.value && channelName.value !== null && (
   !!props.data.hasCollaborators || channelId.value === null
 ))
 
@@ -1562,7 +1562,7 @@ function openInExternalPlayer() {
 }
 
 async function openChannelByline() {
-  if (isFetchingCollaborators.value) {
+  if (disableChannelLinks.value || isFetchingCollaborators.value) {
     return
   }
 
@@ -1578,7 +1578,7 @@ async function openChannelByline() {
   try {
     const collaborators = await getLocalVideoChannels(videoId)
 
-    if (id.value !== videoId) {
+    if (id.value !== videoId || disableChannelLinks.value) {
       return
     }
 

--- a/src/renderer/components/FtListVideo/FtListVideo.vue
+++ b/src/renderer/components/FtListVideo/FtListVideo.vue
@@ -383,6 +383,7 @@ import { getLocalVideoCollaborators } from '../../helpers/api/local.js'
 import { isHistoryEntryWatched } from '../../helpers/history.js'
 import { getUpcomingPremiereTimestamp } from '../../helpers/subscription-entries.js'
 import { deArrowData, deArrowThumbnail, getSponsorBlockVideoLabel } from '../../helpers/sponsorblock.js'
+import { isCollaborativeVideoAuthor } from '../../helpers/video-collaborators.js'
 import {
   morphThumbnailIntoNewTab,
   requestWatchPageViewTransition
@@ -1369,7 +1370,10 @@ const deArrowCache = computed(() => store.getters.getDeArrowCache[id.value])
 
 const disableChannelLinks = computed(() => store.getters.getDisableChannelLinks)
 
-const shouldShowCollaboratorsButton = computed(() => !!props.data.hasCollaborators && channelName.value !== null)
+const shouldShowCollaboratorsButton = computed(() => channelName.value !== null && (
+  !!props.data.hasCollaborators ||
+  (channelId.value === null && isCollaborativeVideoAuthor(channelName.value))
+))
 
 async function handleWatchPageLinkClick(event) {
   // `auxclick` also fires for the right mouse button after `contextmenu`.

--- a/src/renderer/components/FtListVideo/FtListVideo.vue
+++ b/src/renderer/components/FtListVideo/FtListVideo.vue
@@ -379,7 +379,7 @@ import {
   deepCopy,
   debounce
 } from '../../helpers/utils.js'
-import { getLocalVideoCollaborators } from '../../helpers/api/local.js'
+import { getLocalVideoChannels } from '../../helpers/api/local.js'
 import { isHistoryEntryWatched } from '../../helpers/history.js'
 import { getUpcomingPremiereTimestamp } from '../../helpers/subscription-entries.js'
 import { deArrowData, deArrowThumbnail, getSponsorBlockVideoLabel } from '../../helpers/sponsorblock.js'
@@ -1578,7 +1578,7 @@ async function openCollaboratorsPrompt() {
   const videoId = id.value
 
   try {
-    const collaborators = await getLocalVideoCollaborators(videoId)
+    const collaborators = await getLocalVideoChannels(videoId)
 
     if (id.value !== videoId) {
       return
@@ -1588,6 +1588,8 @@ async function openCollaboratorsPrompt() {
 
     if (channelCollaborators.value.length > 1) {
       showCollaboratorsPrompt.value = true
+    } else if (channelCollaborators.value.length === 1) {
+      openInternalPath({ path: `/channel/${channelCollaborators.value[0].id}` })
     }
   } catch (error) {
     if (id.value === videoId) {

--- a/src/renderer/components/FtListVideo/FtListVideo.vue
+++ b/src/renderer/components/FtListVideo/FtListVideo.vue
@@ -192,12 +192,12 @@
       </RouterLink>
       <div class="infoLine">
         <button
-          v-if="shouldShowCollaboratorsButton"
+          v-if="shouldShowChannelResolverButton"
           type="button"
-          class="channelName collaboratorChannelButton"
+          class="channelName channelResolverButton"
           dir="auto"
           :disabled="isFetchingCollaborators"
-          @click.stop.prevent="openCollaboratorsPrompt"
+          @click.stop.prevent="openChannelByline"
         >
           {{ channelName }}
         </button>
@@ -383,7 +383,6 @@ import { getLocalVideoChannels } from '../../helpers/api/local.js'
 import { isHistoryEntryWatched } from '../../helpers/history.js'
 import { getUpcomingPremiereTimestamp } from '../../helpers/subscription-entries.js'
 import { deArrowData, deArrowThumbnail, getSponsorBlockVideoLabel } from '../../helpers/sponsorblock.js'
-import { isCollaborativeVideoAuthor } from '../../helpers/video-collaborators.js'
 import {
   morphThumbnailIntoNewTab,
   requestWatchPageViewTransition
@@ -1370,9 +1369,8 @@ const deArrowCache = computed(() => store.getters.getDeArrowCache[id.value])
 
 const disableChannelLinks = computed(() => store.getters.getDisableChannelLinks)
 
-const shouldShowCollaboratorsButton = computed(() => channelName.value !== null && (
-  !!props.data.hasCollaborators ||
-  (channelId.value === null && isCollaborativeVideoAuthor(channelName.value))
+const shouldShowChannelResolverButton = computed(() => channelName.value !== null && (
+  !!props.data.hasCollaborators || channelId.value === null
 ))
 
 async function handleWatchPageLinkClick(event) {
@@ -1563,7 +1561,7 @@ function openInExternalPlayer() {
   }
 }
 
-async function openCollaboratorsPrompt() {
+async function openChannelByline() {
   if (isFetchingCollaborators.value) {
     return
   }

--- a/src/renderer/helpers/api/local.js
+++ b/src/renderer/helpers/api/local.js
@@ -8,7 +8,7 @@ import { loadSearchContinuation } from '../search-continuation'
 import { parseLocalShortLinkedVideo } from '../player/shorts'
 import { getPaidPromotionDurationMs } from '../player/paidPromotion'
 import { getLocalPremiereState } from '../premiere'
-import { isCollaborativeVideoAuthor, parseLocalVideoCollaborators } from '../video-collaborators'
+import { isCollaborativeVideoAuthor, parseLocalVideoChannels } from '../video-collaborators'
 import {
   CHANNEL_HANDLE_REGEX,
   calculatePublishedDate,
@@ -864,26 +864,26 @@ export async function getLocalShortLinkedVideo(id) {
   return parseLocalShortLinkedVideo(response)
 }
 
-const LOCAL_VIDEO_COLLABORATORS_CACHE_SIZE = 100
-const LOCAL_VIDEO_COLLABORATORS_TIMEOUT_MS = 15_000
-const localVideoCollaboratorsCache = new Map()
+const LOCAL_VIDEO_CHANNELS_CACHE_SIZE = 100
+const LOCAL_VIDEO_CHANNELS_TIMEOUT_MS = 15_000
+const localVideoChannelsCache = new Map()
 
 /**
- * Loads only the watch-next metadata needed by the collaborators prompt.
+ * Loads only the watch-next metadata needed to resolve a video's channels.
  * Unlike getLocalVideoInfo, this avoids player setup, proof-token generation,
  * playback requests, and paid-promotion metadata.
  * @param {string} id
- * @returns {Promise<ReturnType<typeof parseLocalVideoCollaborators>>}
+ * @returns {Promise<ReturnType<typeof parseLocalVideoChannels>>}
  */
-export function getLocalVideoCollaborators(id) {
-  const cachedRequest = localVideoCollaboratorsCache.get(id)
+export function getLocalVideoChannels(id) {
+  const cachedRequest = localVideoChannelsCache.get(id)
   if (cachedRequest) {
     return cachedRequest
   }
 
   const request = (async () => {
     const abortController = new AbortController()
-    const timeout = setTimeout(() => abortController.abort(), LOCAL_VIDEO_COLLABORATORS_TIMEOUT_MS)
+    const timeout = setTimeout(() => abortController.abort(), LOCAL_VIDEO_CHANNELS_TIMEOUT_MS)
 
     try {
       const innertube = await createInnertube({
@@ -898,20 +898,20 @@ export function getLocalVideoCollaborators(id) {
       const secondaryInfo = response.contents_memo
         ?.getType(YTNodes.VideoSecondaryInfo)[0]
 
-      return parseLocalVideoCollaborators({ secondary_info: secondaryInfo })
+      return parseLocalVideoChannels({ secondary_info: secondaryInfo })
     } finally {
       clearTimeout(timeout)
     }
   })().catch((error) => {
-    if (localVideoCollaboratorsCache.get(id) === request) {
-      localVideoCollaboratorsCache.delete(id)
+    if (localVideoChannelsCache.get(id) === request) {
+      localVideoChannelsCache.delete(id)
     }
     throw error
   })
 
-  localVideoCollaboratorsCache.set(id, request)
-  if (localVideoCollaboratorsCache.size > LOCAL_VIDEO_COLLABORATORS_CACHE_SIZE) {
-    localVideoCollaboratorsCache.delete(localVideoCollaboratorsCache.keys().next().value)
+  localVideoChannelsCache.set(id, request)
+  if (localVideoChannelsCache.size > LOCAL_VIDEO_CHANNELS_CACHE_SIZE) {
+    localVideoChannelsCache.delete(localVideoChannelsCache.keys().next().value)
   }
   return request
 }

--- a/src/renderer/helpers/api/local.js
+++ b/src/renderer/helpers/api/local.js
@@ -8,7 +8,7 @@ import { loadSearchContinuation } from '../search-continuation'
 import { parseLocalShortLinkedVideo } from '../player/shorts'
 import { getPaidPromotionDurationMs } from '../player/paidPromotion'
 import { getLocalPremiereState } from '../premiere'
-import { parseLocalVideoCollaborators } from '../video-collaborators'
+import { isCollaborativeVideoAuthor, parseLocalVideoCollaborators } from '../video-collaborators'
 import {
   CHANNEL_HANDLE_REGEX,
   calculatePublishedDate,
@@ -1899,7 +1899,7 @@ export function parseLocalListVideo(item, channelId, channelName) {
       title: video.title.text?.trim(),
       author: video.author.name !== 'N/A' ? video.author.name : channelName,
       authorId: video.author.id !== 'N/A' ? video.author.id : channelId,
-      hasCollaborators: video.author.id === 'N/A' && COLLABORATIVE_AUTHOR_TEXT_REGEX.test(video.author.name),
+      hasCollaborators: video.author.id === 'N/A' && isCollaborativeVideoAuthor(video.author.name),
       description: video.description,
       viewCount,
       published,
@@ -1925,8 +1925,6 @@ const PREMIERE_TIME_REGEX = /^premieres? /i
 const UPCOMING_TIME_REGEX = /^(premieres?|scheduled for) /i
 // Sometimes got `Streamed N (unit) ago`
 const PUBLISH_TIME_REGEX = /^(streamed )?\d+ ?\w+? ago/i
-const COLLABORATIVE_AUTHOR_TEXT_REGEX = /\s+and\s+/i
-
 /**
  * @param {string | undefined} text
  */
@@ -2102,7 +2100,7 @@ function parseLockupView(lockupView, channelId = undefined, channelName = undefi
       const imageAuthorId = lockupView.metadata.image?.renderer_context?.command_context?.on_tap?.payload?.browseId
       const author = authorPart?.text ?? channelName
       const authorId = authorPart?.endpoint?.payload?.browseId ?? imageAuthorId ?? channelId
-      const hasCollaborators = authorPart?.endpoint == null && COLLABORATIVE_AUTHOR_TEXT_REGEX.test(author ?? '')
+      const hasCollaborators = authorPart?.endpoint == null && isCollaborativeVideoAuthor(author)
 
       return {
         type: 'video',

--- a/src/renderer/helpers/video-collaborators.js
+++ b/src/renderer/helpers/video-collaborators.js
@@ -6,6 +6,18 @@
  * @property {string} subtitle
  */
 
+const COLLABORATIVE_AUTHOR_TEXT_REGEX = /\s+and\s+/i
+
+/**
+ * YouTube replaces the regular channel link with a collaboration dialog for
+ * videos with multiple authors.
+ * @param {string | undefined} author
+ * @returns {boolean}
+ */
+export function isCollaborativeVideoAuthor(author) {
+  return typeof author === 'string' && COLLABORATIVE_AUTHOR_TEXT_REGEX.test(author)
+}
+
 /**
  * @param {import('youtubei.js').YT.VideoInfo} videoInfo
  * @returns {LocalVideoCollaborator[]}

--- a/src/renderer/helpers/video-collaborators.js
+++ b/src/renderer/helpers/video-collaborators.js
@@ -47,6 +47,35 @@ export function parseLocalVideoCollaborators(videoInfo) {
 }
 
 /**
+ * Resolve every channel represented by local video information. Regular
+ * videos expose one owner while collaboration videos expose multiple entries.
+ * @param {import('youtubei.js').YT.VideoInfo} videoInfo
+ * @returns {LocalVideoCollaborator[]}
+ */
+export function parseLocalVideoChannels(videoInfo) {
+  const collaborators = parseLocalVideoCollaborators(videoInfo)
+  if (collaborators.length > 0) {
+    return collaborators
+  }
+
+  const owner = videoInfo.secondary_info?.owner
+  const author = owner?.author
+  const channelId = (author?.id !== 'N/A' ? author?.id : undefined) ??
+    author?.endpoint?.payload?.browseId ??
+    owner?.endpoint?.payload?.browseId
+  const name = author?.name
+
+  return channelId && name
+    ? [{
+        id: channelId,
+        name,
+        thumbnail: author.best_thumbnail?.url ?? '',
+        subtitle: owner.subscriber_count?.text ?? ''
+      }]
+    : []
+}
+
+/**
  * Resolve the channel avatar represented by local video information.
  * Collaboration videos store their primary channel in an attachment instead
  * of the regular owner thumbnail.

--- a/tests/unit/video-collaborators.test.mjs
+++ b/tests/unit/video-collaborators.test.mjs
@@ -1,7 +1,17 @@
 import assert from 'node:assert/strict'
 import test from 'node:test'
 
-import { getLocalVideoAvatarUrl, parseLocalVideoCollaborators } from '../../src/renderer/helpers/video-collaborators.js'
+import {
+  getLocalVideoAvatarUrl,
+  isCollaborativeVideoAuthor,
+  parseLocalVideoCollaborators
+} from '../../src/renderer/helpers/video-collaborators.js'
+
+test('recognizes a collaboration byline without treating ordinary channel names as collaborations', () => {
+  assert.equal(isCollaborativeVideoAuthor('Creator One and Creator Two'), true)
+  assert.equal(isCollaborativeVideoAuthor('Creator One & Creator Two'), false)
+  assert.equal(isCollaborativeVideoAuthor(undefined), false)
+})
 
 test('uses the primary collaborator avatar without reading the attachment-backed owner thumbnail', () => {
   const author = {

--- a/tests/unit/video-collaborators.test.mjs
+++ b/tests/unit/video-collaborators.test.mjs
@@ -4,6 +4,7 @@ import test from 'node:test'
 import {
   getLocalVideoAvatarUrl,
   isCollaborativeVideoAuthor,
+  parseLocalVideoChannels,
   parseLocalVideoCollaborators
 } from '../../src/renderer/helpers/video-collaborators.js'
 
@@ -11,6 +12,26 @@ test('recognizes a collaboration byline without treating ordinary channel names 
   assert.equal(isCollaborativeVideoAuthor('Creator One and Creator Two'), true)
   assert.equal(isCollaborativeVideoAuthor('Creator One & Creator Two'), false)
   assert.equal(isCollaborativeVideoAuthor(undefined), false)
+})
+
+test('resolves a regular video owner when no collaborators are present', () => {
+  assert.deepEqual(parseLocalVideoChannels({
+    secondary_info: {
+      owner: {
+        author: {
+          id: 'UCowner',
+          name: 'Bread and Butter',
+          best_thumbnail: { url: 'https://images.test/owner-avatar.jpg' }
+        },
+        subscriber_count: { text: '10 subscribers' }
+      }
+    }
+  }), [{
+    id: 'UCowner',
+    name: 'Bread and Butter',
+    thumbnail: 'https://images.test/owner-avatar.jpg',
+    subtitle: '10 subscribers'
+  }])
 })
 
 test('uses the primary collaborator avatar without reading the attachment-backed owner thumbnail', () => {


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Make sure to follow the contributing guidelines. -->
<!-- Important note, we may remove your pull request if you do not use this provided PR template correctly. -->
<!-- Agent instructions: Preserve every heading, comment, and marker in this template. Never remove or rewrite the release-note-category:start/end, release-note:start/end, or release-note-image:start/end marker pairs. Never remove or rewrite the Release note images section; leave its contents for a human. -->

## Pull Request Type
<!-- Please select what type of pull request this is: [x] -->
- [x] Bugfix
- [ ] Feature Implementation
- [ ] Documentation
- [ ] Other

## Related issue
<!-- Please link the issue your pull request is referring to. -->
<!-- If this pull request fully resolves the relevant issue, put "closes" before the issue number. -->
<!-- Example: "closes #123456". -->

## Description
<!-- Please write a clear and concise description of what the pull request does. -->
Attached collaboration videos in community posts could show their channel byline as plain text when cached or backend-provided attachment data lacked the collaboration marker and channel ID.

This centralizes collaboration-byline detection and applies it while rendering video cards, allowing existing cached posts to open the collaborators prompt without requiring their attachment data to be reparsed.

## Release note category
<!-- Select exactly one category. Every pull request must select one. -->
<!-- Select "Not noteworthy" when the pull request fixes a bug in or improves functionality that has not yet appeared in a stable release. -->
<!-- release-note-category:start -->
- [ ] Not noteworthy
- [ ] Highlights
- [ ] More improvements
- [x] Fixed bugs
<!-- release-note-category:end -->

## Release note
<!-- Required unless "Not noteworthy" is selected. -->
<!-- Write one concise, user-facing entry without a leading bullet. -->
<!-- release-note:start -->
Fixed channel bylines not being clickable for attached collaboration videos in community posts.
<!-- release-note:end -->

## Release note images
<!-- Human-only: Agents must preserve this entire section and leave it empty. -->
<!-- Optional. Paste one or more Markdown images or HTML image tags here. -->
<!-- The release notes will use an HTML image tag and limit images taller than 300 pixels. -->
<!-- release-note-image:start -->

<!-- release-note-image:end -->

## Testing
<!-- How can reviewers verify that the PR produces correct results? -->
<!-- Please provide instructions so that others can ensure that your pull request would produce correct results. For examples see, https://github.com/FreeTubeApp/FreeTube/pull/5743, https://github.com/FreeTubeApp/FreeTube/pull/7349, https://github.com/FreeTubeApp/FreeTube/pull/5125, https://github.com/FreeTubeApp/FreeTube/pull/7338 -->
<!-- Agent instructions: Only write human-facing steps that explain how to verify the change while running this branch in dev mode. Include expected results and, when applicable, helpful console snippets for interactive verification. Do not include automated checks, commands, results, pass counts, or CI status. -->
1. Open a community post containing an attached collaboration video.
2. Select the attached video's channel byline.
3. Confirm that the collaborators prompt opens and offers the linked channels.
4. Return to a previously cached copy of the post and confirm the byline remains interactive without refreshing the cached post data.

## Additional context
<!-- Add any other context about the pull request here. -->
The rendering fallback intentionally requires a missing channel ID so ordinary channel links keep their existing behavior.
