### PR TITLE
fix(subscriptions): prevent tab width changes on hover

### DIFF
--- a/e2e/tests/offline/subscriptions-tab-indicator.spec.mjs
+++ b/e2e/tests/offline/subscriptions-tab-indicator.spec.mjs
@@ -55,6 +55,21 @@ test.use({
 })
 
 test.describe('subscriptions feed tab indicator', () => {
+  test('keeps tab widths stable when hovering with fonts whose bold glyphs are wider', async ({ page }) => {
+    await goTo(page, 'subscriptions')
+
+    await page.locator('body').evaluate(element => {
+      element.style.fontFamily = 'Arial, sans-serif'
+    })
+
+    const tab = page.locator('[data-subscription-feed-tab="shorts"]')
+    const widthBeforeHover = (await tab.boundingBox()).width
+
+    await tab.hover()
+
+    expect((await tab.boundingBox()).width).toBe(widthBeforeHover)
+  })
+
   test('only animates the transform, so it runs on the compositor', async ({ page }) => {
     await goTo(page, 'subscriptions')
 

--- a/src/renderer/views/Subscriptions/Subscriptions.css
+++ b/src/renderer/views/Subscriptions/Subscriptions.css
@@ -214,6 +214,21 @@
   font-weight: bold;
 }
 
+.tabLabel {
+  display: inline-grid;
+}
+
+.tabLabel::after {
+  content: attr(data-label);
+  grid-area: 1 / 1;
+  font-weight: bold;
+  visibility: hidden;
+}
+
+.tabLabel > span {
+  grid-area: 1 / 1;
+}
+
 .subscriptionIcon {
   color: var(--primary-color);
 }

--- a/src/renderer/views/Subscriptions/Subscriptions.vue
+++ b/src/renderer/views/Subscriptions/Subscriptions.vue
@@ -55,7 +55,10 @@
                   :icon="['fa', 'video']"
                   class="subscriptionIcon"
                 />
-                {{ $t("Global.Videos") }}
+                <span
+                  class="tabLabel"
+                  :data-label="$t('Global.Videos')"
+                ><span>{{ $t("Global.Videos") }}</span></span>
                 <FtLoader
                   v-if="refreshingFeedTab === 'videos'"
                   class="tabLoadingIndicator"
@@ -80,7 +83,10 @@
                   :icon="['fa', 'clapperboard']"
                   class="subscriptionIcon"
                 />
-                {{ $t("Global.Shorts") }}
+                <span
+                  class="tabLabel"
+                  :data-label="$t('Global.Shorts')"
+                ><span>{{ $t("Global.Shorts") }}</span></span>
                 <FtLoader
                   v-if="refreshingFeedTab === 'shorts'"
                   class="tabLoadingIndicator"
@@ -105,7 +111,10 @@
                   :icon="['fa', 'tower-broadcast']"
                   class="subscriptionIcon"
                 />
-                {{ $t("Global.Live") }}
+                <span
+                  class="tabLabel"
+                  :data-label="$t('Global.Live')"
+                ><span>{{ $t("Global.Live") }}</span></span>
                 <FtLoader
                   v-if="refreshingFeedTab === 'live'"
                   class="tabLoadingIndicator"
@@ -130,7 +139,10 @@
                   :icon="['fa', 'message']"
                   class="subscriptionIcon"
                 />
-                {{ $t("Global.Posts") }}
+                <span
+                  class="tabLabel"
+                  :data-label="$t('Global.Posts')"
+                ><span>{{ $t("Global.Posts") }}</span></span>
                 <FtLoader
                   v-if="refreshingFeedTab === 'posts'"
                   class="tabLoadingIndicator"
@@ -155,7 +167,10 @@
                   :icon="['fa', 'fire']"
                   class="subscriptionIcon"
                 />
-                {{ $t("Global.New") }}
+                <span
+                  class="tabLabel"
+                  :data-label="$t('Global.New')"
+                ><span>{{ $t("Global.New") }}</span></span>
               </div>
             </FtFlexBox>
             <button


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Make sure to follow the contributing guidelines. -->
<!-- Important note, we may remove your pull request if you do not use this provided PR template correctly. -->
<!-- Agent instructions: Preserve every heading, comment, and marker in this template. Never remove or rewrite the release-note-category:start/end, release-note:start/end, or release-note-image:start/end marker pairs. Never remove or rewrite the Release note images section; leave its contents for a human. -->

## Pull Request Type
<!-- Please select what type of pull request this is: [x] -->
- [x] Bugfix
- [ ] Feature Implementation
- [ ] Documentation
- [ ] Other

## Related issue
<!-- Please link the issue your pull request is referring to. -->
<!-- If this pull request fully resolves the relevant issue, put "closes" before the issue number. -->
<!-- Example: "closes #123456". -->

## Description
<!-- Please write a clear and concise description of what the pull request does. -->
Subscription feed tabs changed width on hover with fonts whose bold glyphs are wider than their regular glyphs, causing the surrounding tabs to shift.

Reserve each translated label's bold width with an invisible grid layer so the visible label can change weight without changing the tab geometry. A regression test covers the behavior with Arial.

## Release note category
<!-- Select exactly one category. Every pull request must select one. -->
<!-- Select "Not noteworthy" when the pull request fixes a bug in or improves functionality that has not yet appeared in a stable release. -->
<!-- release-note-category:start -->
- [ ] Not noteworthy
- [ ] Highlights
- [ ] More improvements
- [x] Fixed bugs
<!-- release-note-category:end -->

## Release note
<!-- Required unless "Not noteworthy" is selected. -->
<!-- Write one concise, user-facing entry without a leading bullet. -->
<!-- release-note:start -->
Fixed subscription feed tabs shifting when hovered while using certain custom fonts.
<!-- release-note:end -->

## Release note images
<!-- Human-only: Agents must preserve this entire section and leave it empty. -->
<!-- Optional. Paste one or more Markdown images or HTML image tags here. -->
<!-- The release notes will use an HTML image tag and limit images taller than 300 pixels. -->
<!-- release-note-image:start -->

<!-- release-note-image:end -->

## Testing
<!-- How can reviewers verify that the PR produces correct results? -->
<!-- Please provide instructions so that others can ensure that your pull request would produce correct results. For examples see, https://github.com/FreeTubeApp/FreeTube/pull/5743, https://github.com/FreeTubeApp/FreeTube/pull/7349, https://github.com/FreeTubeApp/FreeTube/pull/5125, https://github.com/FreeTubeApp/FreeTube/pull/7338 -->
<!-- Agent instructions: Only write human-facing steps that explain how to verify the change while running this branch in dev mode. Include expected results and, when applicable, helpful console snippets for interactive verification. Do not include automated checks, commands, results, pass counts, or CI status. -->
1. Set the application font to Arial, SF Pro Display, or another font with different regular and bold glyph widths.
2. Open the Subscriptions page and hover each feed tab.
3. Confirm that the hovered label becomes bold without changing the tab's width or moving adjacent tabs.

## Additional context
<!-- Add any other context about the pull request here. -->