### PR TITLE
feat(onboarding): add first-run customization and data import

### DIFF
--- a/e2e/tests/offline/tutorial.spec.mjs
+++ b/e2e/tests/offline/tutorial.spec.mjs
@@ -117,28 +117,70 @@ test('walks new users through the essential controls', async ({ page }) => {
 
   const tutorial = page.locator('.tutorialCard')
   await expect(tutorial).toHaveAccessibleName('Welcome to OpenTubeX')
-  await expect(tutorial.locator('.tutorialProgress span')).toHaveCount(5)
+  await expect(tutorial.locator('.tutorialProgress span')).toHaveCount(6)
+  await expect(tutorial.getByRole('button', { name: 'Skip' })).toBeVisible()
 
   await tutorial.getByRole('button', { name: 'Next' }).click()
   await expect(tutorial).toHaveAccessibleName('Your library is always nearby')
   await expect(tutorial.getByRole('heading', { name: 'Your library is always nearby' })).toBeFocused()
+  await expect(tutorial.getByRole('button', { name: 'Skip' })).toHaveCount(0)
   await expectHighlightCenteredOn(page, '[data-tutorial="navigation"]')
 
   await tutorial.getByRole('button', { name: 'Next' }).click()
   await expect(tutorial).toHaveAccessibleName('Search or paste a link')
-  await expectHighlightCenteredOn(page, '[data-tutorial="search"]')
+  await expectHighlightCenteredOn(page, '.searchContainer[data-tutorial="search"] .ft-input')
+  const highlightStyles = await page.locator('.tutorialHighlight').evaluate(element => {
+    const styles = getComputedStyle(element)
+    return { borderRadius: Number.parseFloat(styles.borderRadius), boxShadow: styles.boxShadow }
+  })
+  expect(highlightStyles.borderRadius).toBeGreaterThan(0)
+  expect(highlightStyles.boxShadow).toContain('inset')
 
   await tutorial.getByRole('button', { name: 'Next' }).click()
   await expect(tutorial).toHaveAccessibleName('Keep pages open in tabs')
-  await expectHighlightCenteredOn(page, '[data-tutorial="tabs"]')
+  const layout = tutorial.getByRole('combobox', { name: 'Tab Layout' })
+  for (const [label, className] of [
+    ['Horizontal at bottom', 'position-bottom'],
+    ['Vertical on left', 'position-left'],
+    ['Vertical on right', 'position-right'],
+    ['Horizontal at top', 'position-top']
+  ]) {
+    await layout.click()
+    await page.locator(`#${await layout.getAttribute('aria-controls')}`)
+      .getByRole('option', { name: label, exact: true }).click()
+    await expect(page.locator(`.tabBar.${className}`)).toBeVisible()
+    await expectHighlightCenteredOn(page, '[data-tutorial="tabs"]')
+    await expect.poll(async () => {
+      const [card, tabs] = await Promise.all([
+        tutorial.evaluate(element => element.getBoundingClientRect().toJSON()),
+        page.locator('[data-tutorial="tabs"]').evaluate(element => element.getBoundingClientRect().toJSON())
+      ])
+      return card.left < tabs.right && card.right > tabs.left && card.top < tabs.bottom && card.bottom > tabs.top
+    }).toBe(false)
+  }
 
   await tutorial.getByRole('button', { name: 'Next' }).click()
   await expect(tutorial).toHaveAccessibleName('Make it yours')
-  await expect(tutorial).toContainText('Right-click it to go straight to profile selection.')
+  await expect(tutorial).toContainText('right-click it to switch profiles.')
   await expectHighlightCenteredOn(page, '[data-tutorial="quick-settings"]')
+  const baseTheme = tutorial.getByRole('combobox', { name: 'Base Theme' })
+  await baseTheme.click()
+  await page.locator(`#${await baseTheme.getAttribute('aria-controls')}`)
+    .getByRole('option', { name: 'Light', exact: true }).click()
+  await expect(page.locator('body')).toHaveClass(/light/)
+  const quality = tutorial.getByRole('combobox', { name: 'Default Quality' })
+  await quality.click()
+  await page.locator(`#${await quality.getAttribute('aria-controls')}`)
+    .getByRole('option', { name: '480p', exact: true }).click()
+  await expect(quality).toHaveText('480p')
 
-  await tutorial.getByRole('button', { name: 'Finish' }).click()
+  await tutorial.getByRole('button', { name: 'Next' }).click()
+  await expect(tutorial).toHaveAccessibleName('Bring your data with you')
+  await expect(tutorial.getByRole('button', { name: 'Not now' })).toBeVisible()
+  await tutorial.getByRole('button', { name: 'Import data' }).click()
   await expect(tutorial).toBeHidden()
+  await expect(page.locator('.settingsContent [data-section="data"]')
+    .getByRole('button', { name: 'Import subscriptions', exact: true })).toBeVisible()
 
   await page.reload()
   await expect(page.locator('.tutorialOverlay')).toHaveCount(0)

--- a/e2e/tests/offline/tutorial.spec.mjs
+++ b/e2e/tests/offline/tutorial.spec.mjs
@@ -102,6 +102,34 @@ test('keeps the tutorial actions reachable in a short window', async ({ app, pag
   })).toBe(true)
 })
 
+test('resets the managed content viewport after a shorter step replaces it', async ({ app, page }) => {
+  await app.electronApp.evaluate(({ BrowserWindow }) => {
+    BrowserWindow.getAllWindows()[0].setSize(800, 420)
+  })
+  await page.evaluate(() => localStorage.setItem('opentubex.tutorial.audience', 'new'))
+  await page.reload()
+
+  const tutorial = page.locator('.tutorialCard')
+  for (let step = 0; step < 4; step++) {
+    await tutorial.getByRole('button', { name: 'Next' }).click()
+  }
+  await expect(tutorial).toHaveAccessibleName('Make it yours')
+
+  const scrollViewport = tutorial.locator('.tutorialScroll')
+  const scrollbar = scrollViewport.locator(':scope > .os-scrollbar-vertical')
+  await expect(scrollbar).not.toHaveClass(/os-scrollbar-unusable/)
+  await scrollViewport.evaluate(element => { element.scrollTop = element.scrollHeight })
+  await expect.poll(() => scrollViewport.evaluate(element => element.scrollTop)).toBeGreaterThan(0)
+
+  await tutorial.getByRole('button', { name: 'Next' }).click()
+  await expect(tutorial).toHaveAccessibleName('Bring your data with you')
+  await expect.poll(() => scrollViewport.evaluate(element => ({
+    scrollTop: element.scrollTop,
+    scrollRange: element.scrollHeight - element.clientHeight
+  }))).toEqual({ scrollTop: 0, scrollRange: 0 })
+  await expect(scrollbar).toHaveClass(/os-scrollbar-unusable/)
+})
+
 test.describe('right-to-left layout', () => {
   test.use({ seed: { settings: { currentLocale: 'ar' } } })
 

--- a/e2e/tests/offline/tutorial.spec.mjs
+++ b/e2e/tests/offline/tutorial.spec.mjs
@@ -30,7 +30,7 @@ test('shows returning users only where settings moved', async ({ app, page }) =>
   const lastUsedVersion = await page.evaluate(() => localStorage.getItem('opentubex.lastUsedVersion'))
   expect(lastUsedVersion).toMatch(/^\d+\.\d+\.\d+(?:-|$)/)
   await expect(tutorial).toContainText('Right-click it to go straight to profile selection.')
-  await expect(tutorial).toContainText('The cog in that menu opens all settings.')
+  await expect(tutorial).toContainText('The cog in that menu opens all settings, and About and Downloads have moved to this menu too.')
   await expect(tutorial.locator('.tutorialProgress')).toHaveCount(0)
   await expectHighlightCenteredOn(page, '[data-tutorial="quick-settings"]')
 

--- a/e2e/tests/offline/tutorial.spec.mjs
+++ b/e2e/tests/offline/tutorial.spec.mjs
@@ -139,8 +139,17 @@ test('walks new users through the essential controls', async ({ page }) => {
   await tutorial.getByRole('button', { name: 'Next' }).click()
   await expect(tutorial).toHaveAccessibleName('Keep pages open in tabs')
   const layout = tutorial.getByRole('combobox', { name: 'Tab Layout' })
+  await layout.focus()
+  await page.keyboard.press('Enter')
+  await expect(layout).toHaveAttribute('aria-expanded', 'true')
+  await page.keyboard.press('Escape')
+  await expect(layout).toHaveAttribute('aria-expanded', 'false')
+  await page.keyboard.press('Enter')
+  await page.keyboard.press('ArrowDown')
+  await page.keyboard.press('Enter')
+  await expect(layout).toHaveText('Horizontal at bottom')
+  await expect(page.locator('.tabBar.position-bottom')).toBeVisible()
   for (const [label, className] of [
-    ['Horizontal at bottom', 'position-bottom'],
     ['Vertical on left', 'position-left'],
     ['Vertical on right', 'position-right'],
     ['Horizontal at top', 'position-top']

--- a/src/renderer/components/FtSelect/FtSelect.vue
+++ b/src/renderer/components/FtSelect/FtSelect.vue
@@ -267,7 +267,7 @@ function openDropdown() {
 
   emit('open')
   activeIndex.value = Math.max(0, selectedIndex.value)
-  dropdownTarget.value = selectRoot.value?.closest('.prompt') ?? document.fullscreenElement ?? document.body
+  dropdownTarget.value = selectRoot.value?.closest('.prompt, .tutorialCard') ?? document.fullscreenElement ?? document.body
   dropdownShown.value = true
 
   nextTick(async () => {

--- a/src/renderer/components/FtTutorialOverlay/FtTutorialOverlay.css
+++ b/src/renderer/components/FtTutorialOverlay/FtTutorialOverlay.css
@@ -14,7 +14,7 @@
   position: fixed;
   border-radius: calc(10px * var(--ui-roundness));
   box-shadow:
-    0 0 0 2px var(--primary-color),
+    inset 0 0 0 2px var(--primary-color),
     0 0 0 9999px rgb(0 0 0 / 72%);
   box-sizing: border-box;
   pointer-events: none;
@@ -83,6 +83,20 @@
   margin-block: 0 20px;
   color: var(--secondary-text-color);
   line-height: 1.5;
+}
+
+.tutorialTabLayoutSelect {
+  margin-block-end: 20px;
+  margin-inline: auto;
+  text-align: start;
+}
+
+.tutorialSelects {
+  display: grid;
+  gap: 16px;
+  justify-items: center;
+  margin-block-end: 20px;
+  text-align: start;
 }
 
 .tutorialActions {

--- a/src/renderer/components/FtTutorialOverlay/FtTutorialOverlay.css
+++ b/src/renderer/components/FtTutorialOverlay/FtTutorialOverlay.css
@@ -26,10 +26,12 @@
 
 .tutorialCard {
   position: fixed;
+  display: flex;
+  flex-direction: column;
   box-sizing: border-box;
   inline-size: min(380px, calc(100vw - 24px));
   max-block-size: calc(100dvh - 24px);
-  overflow: auto;
+  overflow: hidden;
   margin: 0;
   padding: 24px;
   color: var(--primary-text-color);
@@ -74,6 +76,12 @@
   font-size: 22px;
 }
 
+.tutorialProgress,
+.tutorialIcon,
+.tutorialCard h2 {
+  flex-shrink: 0;
+}
+
 .tutorialCard h2 {
   margin-block: 16px 8px;
   font-size: 1.35rem;
@@ -83,6 +91,11 @@
   margin-block: 0 20px;
   color: var(--secondary-text-color);
   line-height: 1.5;
+}
+
+.tutorialScroll {
+  min-block-size: 0;
+  overflow-y: auto;
 }
 
 .tutorialTabLayoutSelect {

--- a/src/renderer/components/FtTutorialOverlay/FtTutorialOverlay.vue
+++ b/src/renderer/components/FtTutorialOverlay/FtTutorialOverlay.vue
@@ -4,7 +4,7 @@
       class="tutorialOverlay"
       :class="{ centered: targetRect === null }"
       role="presentation"
-      @keydown.capture="handleKeydown"
+      @keydown="handleKeydown"
     >
       <div
         v-if="targetRect"
@@ -275,8 +275,7 @@ const highlightStyle = computed(() => {
     insetBlockStart: `${targetRect.value.top}px`,
     left: `${targetRect.value.left}px`,
     inlineSize: `${targetRect.value.width}px`,
-    blockSize: `${targetRect.value.height}px`,
-    borderRadius: targetRect.value.borderRadius
+    blockSize: `${targetRect.value.height}px`
   }
 })
 
@@ -390,6 +389,8 @@ async function updatePosition() {
 
 function handleDocumentKeydown(event) {
   if (event.key === 'Escape') {
+    if (event.target.closest?.('.tutorialCard .select.open')) return
+
     event.preventDefault()
     event.stopPropagation()
   }

--- a/src/renderer/components/FtTutorialOverlay/FtTutorialOverlay.vue
+++ b/src/renderer/components/FtTutorialOverlay/FtTutorialOverlay.vue
@@ -48,15 +48,63 @@
         <p :id="descriptionId">
           {{ step.description }}
         </p>
+        <FtSelect
+          v-if="step.showTabLayoutSelect"
+          class="tutorialTabLayoutSelect"
+          :placeholder="t('Settings.Theme Settings.Tab Layout.Tab Layout')"
+          :value="tabBarPosition"
+          setting-key="tabBarPosition"
+          :select-names="tabBarPositionNames"
+          :select-values="TAB_BAR_POSITIONS"
+          :icon="['fac', 'horizontal-tabs']"
+          @change="updateTabBarPosition"
+        />
+        <div
+          v-if="step.showAppearanceSelects"
+          class="tutorialSelects"
+        >
+          <FtSelect
+            :placeholder="t('Settings.Theme Settings.Base Theme.Base Theme')"
+            :value="baseTheme"
+            setting-key="baseTheme"
+            :select-names="baseThemeNames"
+            :select-values="BASE_THEME_VALUES"
+            :icon="['fas', 'palette']"
+            @change="updateBaseTheme"
+          />
+          <FtSelect
+            :placeholder="t('Settings.Player Settings.Default Quality.Default Quality')"
+            :value="defaultQuality"
+            setting-key="defaultQuality"
+            :select-names="qualityNames"
+            :select-values="qualityValues"
+            :icon="['fas', 'photo-film']"
+            @change="updateDefaultQuality"
+          />
+        </div>
         <div class="tutorialActions">
           <FtButton
-            v-if="steps.length > 1"
+            v-if="steps.length > 1 && stepIndex === 0"
             :label="t('Tutorial.Skip')"
             :text-color="null"
             :background-color="null"
             @click="finishTutorial"
           />
           <FtButton
+            v-if="step.showImportAction"
+            :label="t('Tutorial.Import Data.Not Now')"
+            :text-color="null"
+            :background-color="null"
+            @click="finishTutorial"
+          />
+          <FtButton
+            v-if="step.showImportAction"
+            :label="t('Tutorial.Import Data.Action')"
+            :icon="['fas', 'database']"
+            @click="openDataImport"
+          />
+          <FtButton
+            v-else
             ref="primaryButtonRef"
             :label="primaryButtonLabel"
             :icon="isLastStep ? ['fas', 'check'] : ['fas', 'arrow-right']"
@@ -74,9 +122,12 @@ import { computed, nextTick, onBeforeUnmount, onMounted, ref, useId, useTemplate
 import { useI18n } from 'vue-i18n'
 
 import store from '../../store/index'
+import { normalizeTabBarPosition, TAB_BAR_POSITIONS } from '../../constants/tabBarPosition'
+import { AUTO_QUALITY_FALLBACK, playbackEngineSupportsAutoQuality } from '../../helpers/player/autoQuality'
 
 import FtButton from '../FtButton/FtButton.vue'
 import FtCard from '../ft-card/ft-card.vue'
+import FtSelect from '../FtSelect/FtSelect.vue'
 import { lockBodyScroll, unlockBodyScroll } from '../FtPrompt/scrollLock'
 
 const props = defineProps({
@@ -101,6 +152,15 @@ const cardStyle = ref({})
 let updateFrame = null
 let lastActiveElement = null
 
+const BASE_THEME_VALUES = [
+  'system', 'light', 'dark', 'black', 'nordic', 'hotPink', 'pastelPink',
+  'catppuccinFrappe', 'catppuccinLatte', 'catppuccinMocha', 'dracula',
+  'everforestDarkHard', 'everforestDarkMedium', 'everforestDarkLow',
+  'everforestLightHard', 'everforestLightMedium', 'everforestLightLow',
+  'gruvboxDark', 'gruvboxLight', 'solarizedDark', 'solarizedLight'
+]
+const RESOLUTION_VALUES = ['2160', '1440', '1080', '720', '480', '360', '240', '144']
+
 const newUserSteps = computed(() => [
   {
     icon: ['fas', 'play'],
@@ -118,21 +178,30 @@ const newUserSteps = computed(() => [
     icon: ['fas', 'search'],
     title: t('Tutorial.Search.Title'),
     description: t('Tutorial.Search.Description'),
-    target: '[data-tutorial="search"]'
+    target: '.searchContainer[data-tutorial="search"] .ft-input, .navSearchButton[data-tutorial="search"]'
   },
   ...(process.env.IS_ELECTRON
     ? [{
         icon: ['fas', 'clone'],
         title: t('Tutorial.Tabs.Title'),
         description: t('Tutorial.Tabs.Description'),
-        target: '[data-tutorial="tabs"]'
+        target: '[data-tutorial="tabs"]',
+        showTabLayoutSelect: true
       }]
     : []),
   {
     icon: ['fas', 'sliders-h'],
     title: t('Tutorial.Quick Settings.Title'),
     description: t('Tutorial.Quick Settings.Description'),
-    target: '[data-tutorial="quick-settings"]'
+    target: '[data-tutorial="quick-settings"]',
+    showAppearanceSelects: true
+  },
+  {
+    icon: ['fas', 'database'],
+    title: t('Tutorial.Import Data.Title'),
+    description: t('Tutorial.Import Data.Description'),
+    target: null,
+    showImportAction: true
   }
 ])
 
@@ -149,6 +218,54 @@ const isLastStep = computed(() => stepIndex.value === steps.value.length - 1)
 const primaryButtonLabel = computed(() => {
   if (!props.newInstallation) return t('Tutorial.Got It')
   return isLastStep.value ? t('Tutorial.Finish') : t('Tutorial.Next')
+})
+const tabBarPositionNames = computed(() => [
+  t('Settings.Theme Settings.Tab Layout.Horizontal Top'),
+  t('Settings.Theme Settings.Tab Layout.Horizontal Bottom'),
+  t('Settings.Theme Settings.Tab Layout.Vertical Left'),
+  t('Settings.Theme Settings.Tab Layout.Vertical Right')
+])
+const tabBarPosition = computed(() => normalizeTabBarPosition(store.getters.getTabBarPosition))
+const baseThemeNames = computed(() => [
+  t('Settings.Theme Settings.Base Theme.System Default'),
+  t('Settings.Theme Settings.Base Theme.Light'),
+  t('Settings.Theme Settings.Base Theme.Dark'),
+  t('Settings.Theme Settings.Base Theme.Black'),
+  t('Settings.Theme Settings.Base Theme.Nordic'),
+  t('Settings.Theme Settings.Base Theme.Hot Pink'),
+  t('Settings.Theme Settings.Base Theme.Pastel Pink'),
+  t('Settings.Theme Settings.Base Theme.Catppuccin Frappe'),
+  t('Settings.Theme Settings.Base Theme.Catppuccin Latte'),
+  t('Settings.Theme Settings.Base Theme.Catppuccin Mocha'),
+  t('Settings.Theme Settings.Base Theme.Dracula'),
+  t('Settings.Theme Settings.Base Theme.Everforest Dark Hard'),
+  t('Settings.Theme Settings.Base Theme.Everforest Dark Medium'),
+  t('Settings.Theme Settings.Base Theme.Everforest Dark Low'),
+  t('Settings.Theme Settings.Base Theme.Everforest Light Hard'),
+  t('Settings.Theme Settings.Base Theme.Everforest Light Medium'),
+  t('Settings.Theme Settings.Base Theme.Everforest Light Low'),
+  t('Settings.Theme Settings.Base Theme.Gruvbox Dark'),
+  t('Settings.Theme Settings.Base Theme.Gruvbox Light'),
+  t('Settings.Theme Settings.Base Theme.Solarized Dark'),
+  t('Settings.Theme Settings.Base Theme.Solarized Light')
+])
+const baseTheme = computed(() => store.getters.getBaseTheme)
+const autoQualityAvailable = computed(() => playbackEngineSupportsAutoQuality(store.getters.getVideoPlaybackEngine))
+const qualityValues = computed(() => autoQualityAvailable.value ? [...RESOLUTION_VALUES, 'auto'] : RESOLUTION_VALUES)
+const qualityNames = computed(() => [
+  t('Settings.Player Settings.Default Quality.4k'),
+  t('Settings.Player Settings.Default Quality.1440p'),
+  t('Settings.Player Settings.Default Quality.1080p'),
+  t('Settings.Player Settings.Default Quality.720p'),
+  t('Settings.Player Settings.Default Quality.480p'),
+  t('Settings.Player Settings.Default Quality.360p'),
+  t('Settings.Player Settings.Default Quality.240p'),
+  t('Settings.Player Settings.Default Quality.144p'),
+  ...(autoQualityAvailable.value ? [t('Settings.Player Settings.Default Quality.Auto')] : [])
+])
+const defaultQuality = computed(() => {
+  const value = store.getters.getDefaultQuality
+  return value === 'auto' && !autoQualityAvailable.value ? AUTO_QUALITY_FALLBACK : value
 })
 
 const highlightStyle = computed(() => {
@@ -205,8 +322,7 @@ async function updatePosition() {
         top: rect.top,
         left: rect.left,
         width: rect.width,
-        height: rect.height,
-        borderRadius: getComputedStyle(target).borderRadius
+        height: rect.height
       }
     : null
 
@@ -221,6 +337,41 @@ async function updatePosition() {
   const cardRect = card.getBoundingClientRect()
   const gap = 14
   const cardViewportPadding = 12
+  const availableOnRight = window.innerWidth - targetRect.value.left - targetRect.value.width
+  const availableOnLeft = targetRect.value.left
+  const minimumSideCardWidth = 240
+  const placeBesideTarget = targetRect.value.height > window.innerHeight / 2 &&
+    Math.max(availableOnLeft, availableOnRight) - gap - cardViewportPadding >= minimumSideCardWidth
+
+  if (placeBesideTarget) {
+    const placeOnRight = availableOnRight >= availableOnLeft
+    const availableWidth = (placeOnRight ? availableOnRight : availableOnLeft) - gap - cardViewportPadding
+    const width = Math.min(cardRect.width, availableWidth)
+    const left = placeOnRight
+      ? targetRect.value.left + targetRect.value.width + gap
+      : targetRect.value.left - gap - width
+
+    cardStyle.value = {
+      inlineSize: `${width}px`,
+      left: `${left}px`
+    }
+    await nextTick()
+
+    const resizedCardRect = card.getBoundingClientRect()
+    const top = Math.min(
+      window.innerHeight - resizedCardRect.height - cardViewportPadding,
+      Math.max(
+        cardViewportPadding,
+        targetRect.value.top + targetRect.value.height / 2 - resizedCardRect.height / 2
+      )
+    )
+    cardStyle.value = {
+      ...cardStyle.value,
+      insetBlockStart: `${top}px`
+    }
+    return
+  }
+
   const availableBelow = window.innerHeight - targetRect.value.top - targetRect.value.height
   const top = availableBelow >= cardRect.height + gap
     ? targetRect.value.top + targetRect.value.height + gap
@@ -249,7 +400,7 @@ function handleKeydown(event) {
 
   if (event.key !== 'Tab') return
 
-  const buttons = Array.from(cardRef.value?.$el.querySelectorAll('.btn') ?? [])
+  const buttons = Array.from(cardRef.value?.$el.querySelectorAll('button:not(:disabled)') ?? [])
   if (buttons.length === 0) return
 
   const currentIndex = buttons.indexOf(document.activeElement)
@@ -260,6 +411,26 @@ function handleKeydown(event) {
   event.preventDefault()
   buttons[nextIndex].focus()
   store.dispatch('showOutlines')
+}
+
+async function updateTabBarPosition(value) {
+  await store.dispatch('updateTabBarPosition', value)
+  schedulePositionUpdate()
+}
+
+function updateBaseTheme(value) {
+  store.dispatch('updateBaseTheme', value)
+}
+
+function updateDefaultQuality(value) {
+  store.dispatch('updateDefaultQuality', value)
+}
+
+async function openDataImport() {
+  finishTutorial()
+  await nextTick()
+  store.commit('setSettingsWindowSection', 'data')
+  store.dispatch('showSettingsWindow')
 }
 
 function advanceTutorial() {

--- a/src/renderer/components/FtTutorialOverlay/FtTutorialOverlay.vue
+++ b/src/renderer/components/FtTutorialOverlay/FtTutorialOverlay.vue
@@ -45,71 +45,82 @@
         >
           {{ step.title }}
         </h2>
-        <p :id="descriptionId">
-          {{ step.description }}
-        </p>
-        <FtSelect
-          v-if="step.showTabLayoutSelect"
-          class="tutorialTabLayoutSelect"
-          :placeholder="t('Settings.Theme Settings.Tab Layout.Tab Layout')"
-          :value="tabBarPosition"
-          setting-key="tabBarPosition"
-          :select-names="tabBarPositionNames"
-          :select-values="TAB_BAR_POSITIONS"
-          :icon="['fac', 'horizontal-tabs']"
-          @change="updateTabBarPosition"
-        />
         <div
-          v-if="step.showAppearanceSelects"
-          class="tutorialSelects"
+          ref="scrollRef"
+          v-overlay-scrollbars
+          class="tutorialScroll"
         >
-          <FtSelect
-            :placeholder="t('Settings.Theme Settings.Base Theme.Base Theme')"
-            :value="baseTheme"
-            setting-key="baseTheme"
-            :select-names="baseThemeNames"
-            :select-values="BASE_THEME_VALUES"
-            :icon="['fas', 'palette']"
-            @change="updateBaseTheme"
-          />
-          <FtSelect
-            :placeholder="t('Settings.Player Settings.Default Quality.Default Quality')"
-            :value="defaultQuality"
-            setting-key="defaultQuality"
-            :select-names="qualityNames"
-            :select-values="qualityValues"
-            :icon="['fas', 'photo-film']"
-            @change="updateDefaultQuality"
-          />
-        </div>
-        <div class="tutorialActions">
-          <FtButton
-            v-if="steps.length > 1 && stepIndex === 0"
-            :label="t('Tutorial.Skip')"
-            :text-color="null"
-            :background-color="null"
-            @click="finishTutorial"
-          />
-          <FtButton
-            v-if="step.showImportAction"
-            :label="t('Tutorial.Import Data.Not Now')"
-            :text-color="null"
-            :background-color="null"
-            @click="finishTutorial"
-          />
-          <FtButton
-            v-if="step.showImportAction"
-            :label="t('Tutorial.Import Data.Action')"
-            :icon="['fas', 'database']"
-            @click="openDataImport"
-          />
-          <FtButton
-            v-else
-            ref="primaryButtonRef"
-            :label="primaryButtonLabel"
-            :icon="isLastStep ? ['fas', 'check'] : ['fas', 'arrow-right']"
-            @click="advanceTutorial"
-          />
+          <div
+            ref="contentRef"
+            class="tutorialContent"
+          >
+            <p :id="descriptionId">
+              {{ step.description }}
+            </p>
+            <FtSelect
+              v-if="step.showTabLayoutSelect"
+              class="tutorialTabLayoutSelect"
+              :placeholder="t('Settings.Theme Settings.Tab Layout.Tab Layout')"
+              :value="tabBarPosition"
+              setting-key="tabBarPosition"
+              :select-names="tabBarPositionNames"
+              :select-values="TAB_BAR_POSITIONS"
+              :icon="['fac', 'horizontal-tabs']"
+              @change="updateTabBarPosition"
+            />
+            <div
+              v-if="step.showAppearanceSelects"
+              class="tutorialSelects"
+            >
+              <FtSelect
+                :placeholder="t('Settings.Theme Settings.Base Theme.Base Theme')"
+                :value="baseTheme"
+                setting-key="baseTheme"
+                :select-names="baseThemeNames"
+                :select-values="BASE_THEME_VALUES"
+                :icon="['fas', 'palette']"
+                @change="updateBaseTheme"
+              />
+              <FtSelect
+                :placeholder="t('Settings.Player Settings.Default Quality.Default Quality')"
+                :value="defaultQuality"
+                setting-key="defaultQuality"
+                :select-names="qualityNames"
+                :select-values="qualityValues"
+                :icon="['fas', 'photo-film']"
+                @change="updateDefaultQuality"
+              />
+            </div>
+            <div class="tutorialActions">
+              <FtButton
+                v-if="steps.length > 1 && stepIndex === 0"
+                :label="t('Tutorial.Skip')"
+                :text-color="null"
+                :background-color="null"
+                @click="finishTutorial"
+              />
+              <FtButton
+                v-if="step.showImportAction"
+                :label="t('Tutorial.Import Data.Not Now')"
+                :text-color="null"
+                :background-color="null"
+                @click="finishTutorial"
+              />
+              <FtButton
+                v-if="step.showImportAction"
+                :label="t('Tutorial.Import Data.Action')"
+                :icon="['fas', 'database']"
+                @click="openDataImport"
+              />
+              <FtButton
+                v-else
+                ref="primaryButtonRef"
+                :label="primaryButtonLabel"
+                :icon="isLastStep ? ['fas', 'check'] : ['fas', 'arrow-right']"
+                @click="advanceTutorial"
+              />
+            </div>
+          </div>
         </div>
       </FtCard>
     </div>
@@ -124,6 +135,7 @@ import { useI18n } from 'vue-i18n'
 import store from '../../store/index'
 import { normalizeTabBarPosition, TAB_BAR_POSITIONS } from '../../constants/tabBarPosition'
 import { AUTO_QUALITY_FALLBACK, playbackEngineSupportsAutoQuality } from '../../helpers/player/autoQuality'
+import { clampOverlayScrollTop, restoreOverlayScrollTop } from '../../helpers/overlayScrollbars'
 
 import FtButton from '../FtButton/FtButton.vue'
 import FtCard from '../ft-card/ft-card.vue'
@@ -146,11 +158,14 @@ const promptId = useId()
 const cardRef = useTemplateRef('cardRef')
 const primaryButtonRef = useTemplateRef('primaryButtonRef')
 const titleRef = useTemplateRef('titleRef')
+const scrollRef = useTemplateRef('scrollRef')
+const contentRef = useTemplateRef('contentRef')
 const stepIndex = ref(0)
 const targetRect = ref(null)
 const cardStyle = ref({})
 let updateFrame = null
 let lastActiveElement = null
+let contentResizeObserver = null
 
 const BASE_THEME_VALUES = [
   'system', 'light', 'dark', 'black', 'nordic', 'hotPink', 'pastelPink',
@@ -287,7 +302,10 @@ onMounted(() => {
   window.addEventListener('scroll', schedulePositionUpdate, true)
   document.addEventListener('keydown', handleDocumentKeydown, true)
   updatePosition()
-  nextTick(() => primaryButtonRef.value?.$el.focus())
+  nextTick(() => {
+    primaryButtonRef.value?.$el.focus()
+    observeTutorialContent()
+  })
 })
 
 onBeforeUnmount(() => {
@@ -295,6 +313,7 @@ onBeforeUnmount(() => {
   window.removeEventListener('resize', schedulePositionUpdate)
   window.removeEventListener('scroll', schedulePositionUpdate, true)
   document.removeEventListener('keydown', handleDocumentKeydown, true)
+  contentResizeObserver?.disconnect()
   store.commit('removeOpenPrompt', promptId)
   unlockBodyScroll()
   nextTick(() => lastActiveElement?.focus())
@@ -306,6 +325,21 @@ function schedulePositionUpdate() {
     updateFrame = null
     updatePosition()
   })
+}
+
+function clampTutorialScroll() {
+  if (scrollRef.value && contentRef.value) {
+    clampOverlayScrollTop(scrollRef.value, contentRef.value)
+  }
+}
+
+function observeTutorialContent() {
+  contentResizeObserver?.disconnect()
+  if (!contentRef.value) return
+
+  contentResizeObserver = new ResizeObserver(clampTutorialScroll)
+  contentResizeObserver.observe(contentRef.value)
+  clampTutorialScroll()
 }
 
 async function updatePosition() {
@@ -434,15 +468,18 @@ async function openDataImport() {
   store.dispatch('showSettingsWindow')
 }
 
-function advanceTutorial() {
+async function advanceTutorial() {
   if (isLastStep.value) {
     finishTutorial()
     return
   }
 
   stepIndex.value++
-  updatePosition()
-  nextTick(() => titleRef.value?.focus())
+  await nextTick()
+  if (scrollRef.value) restoreOverlayScrollTop(scrollRef.value, 0)
+  clampTutorialScroll()
+  await updatePosition()
+  titleRef.value?.focus()
 }
 
 function finishTutorial() {

--- a/static/locales/en-US.yaml
+++ b/static/locales/en-US.yaml
@@ -1329,10 +1329,15 @@ Tutorial:
     Description: Find videos and channels, or paste a supported video URL directly into the search field.
   Tabs:
     Title: Keep pages open in tabs
-    Description: Open several pages at once and switch between them without losing your place.
+    Description: Open several pages at once without losing your place. Choose where tabs fit best in your layout.
   Quick Settings:
     Title: Make it yours
-    Description: Select your profile in the top-right to switch profiles, change common preferences, or open all settings. Right-click it to go straight to profile selection.
+    Description: Choose a theme and default video quality. Change these and other preferences from your profile menu at any time, or right-click it to switch profiles.
+  Import Data:
+    Title: Bring your data with you
+    Description: Optionally import subscriptions, history, playlists, search history, or settings from another supported app or backup.
+    Action: Import data
+    Not Now: Not now
   Settings Moved:
     Title: Settings have moved
     Description: Select your profile in the top-right for quick controls. Right-click it to go straight to profile selection. The cog in that menu opens all settings, and About and Downloads have moved to this menu too.


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Make sure to follow the contributing guidelines. -->
<!-- Important note, we may remove your pull request if you do not use this provided PR template correctly. -->
<!-- Agent instructions: Preserve every heading, comment, and marker in this template. Never remove or rewrite the release-note-category:start/end, release-note:start/end, or release-note-image:start/end marker pairs. Never remove or rewrite the Release note images section; leave its contents for a human. -->

## Pull Request Type
<!-- Please select what type of pull request this is: [x] -->
- [ ] Bugfix
- [x] Feature Implementation
- [ ] Documentation
- [ ] Other

## Related issue
<!-- Please link the issue your pull request is referring to. -->
<!-- If this pull request fully resolves the relevant issue, put "closes" before the issue number. -->
<!-- Example: "closes #123456". -->

## Description
<!-- Please write a clear and concise description of what the pull request does. -->

New users could see where tabs and quick settings live during onboarding, but they could not configure the core choices that shape their first experience. The tutorial spotlight also measured the search wrapper instead of the visible field and could cover full-height vertical tabs.

This adds persisted tab-layout, base-theme, and default-quality controls to the tutorial, followed by an optional handoff to the existing Data settings import tools. Skip is available only from the welcome page, while the import step retains a dedicated Not now action. Spotlight geometry now follows the visible search field, preserves UI roundness at viewport edges, and places the card beside vertical tab bars.

## Release note category
<!-- Select exactly one category. Every pull request must select one. -->
<!-- Select "Not noteworthy" when the pull request fixes a bug in or improves functionality that has not yet appeared in a stable release. -->
<!-- release-note-category:start -->
- [ ] Not noteworthy
- [ ] Highlights
- [x] More improvements
- [ ] Fixed bugs
<!-- release-note-category:end -->

## Release note
<!-- Required unless "Not noteworthy" is selected. -->
<!-- Write one concise, user-facing entry without a leading bullet. -->
<!-- release-note:start -->
New users can choose their tab layout, theme, and default video quality during onboarding, with an optional shortcut to import existing data.
<!-- release-note:end -->

## Release note images
<!-- Human-only: Agents must preserve this entire section and leave it empty. -->
<!-- Optional. Paste one or more Markdown images or HTML image tags here. -->
<!-- The release notes will use an HTML image tag and limit images taller than 300 pixels. -->
<!-- release-note-image:start -->

<!-- release-note-image:end -->

## Testing
<!-- How can reviewers verify that the PR produces correct results? -->
<!-- Please provide instructions so that others can ensure that your pull request would produce correct results. For examples see, https://github.com/FreeTubeApp/FreeTube/pull/5743, https://github.com/FreeTubeApp/FreeTube/pull/7349, https://github.com/FreeTubeApp/FreeTube/pull/5125, https://github.com/FreeTubeApp/FreeTube/pull/7338 -->
<!-- Agent instructions: Only write human-facing steps that explain how to verify the change while running this branch in dev mode. Include expected results and, when applicable, helpful console snippets for interactive verification. Do not include automated checks, commands, results, pass counts, or CI status. -->

1. Open DevTools while running the branch and evaluate:
   ```js
   localStorage.setItem('opentubex.tutorial.audience', 'new')
   location.reload()
   ```
2. Advance through onboarding. Confirm Skip appears only on the welcome page.
3. On the search step, confirm the spotlight follows the visible search input and its corners follow UI roundness.
4. On the tabs step, try all four layouts. Confirm the selector is centered, the spotlight border is visible on every viewport edge, and the tutorial card never covers vertical tabs.
5. Choose a base theme and default quality. Confirm both selectors are centered and the choices apply immediately.
6. Continue to the import step. Confirm Not now closes onboarding and Import data opens the Data settings section.

## Additional context
<!-- Add any other context about the pull request here. -->
