### PR TITLE
fix(tabs): keep pinned title font size consistent

### DIFF
--- a/e2e/tests/offline/tabs.spec.mjs
+++ b/e2e/tests/offline/tabs.spec.mjs
@@ -739,6 +739,23 @@ test.describe('tab bar', () => {
     expect(pinnedCloseBox.x).toBe(unpinnedCloseBox.x)
   })
 
+  test('uses the same title font size for pinned and unpinned tabs', async ({ page }) => {
+    await page.keyboard.press('Control+t')
+
+    const tabs = page.locator(sel.tabs)
+    const pinnedTab = tabs.first()
+    const pinnedTabId = await pinnedTab.getAttribute('data-tab-id')
+
+    await page.evaluate(tabId => window.ftElectron.tabs.setPinned(tabId, true), pinnedTabId)
+    await expect(pinnedTab).toHaveClass(/pinned/)
+
+    const titleFontSizes = await tabs.locator('.tabTitle').evaluateAll(titles => {
+      return titles.map(title => getComputedStyle(title).fontSize)
+    })
+
+    expect(titleFontSizes[0]).toBe(titleFontSizes[1])
+  })
+
   // Regression: search bar text used to leak between tabs (65f4e2e13)
   test('search bar text is independent per tab', async ({ page }) => {
     const searchInput = page.locator(sel.searchInput)

--- a/src/renderer/components/TabBar/SortableTab.vue
+++ b/src/renderer/components/TabBar/SortableTab.vue
@@ -675,7 +675,6 @@ watch(tabAvatarUrl, (avatarUrl) => {
 
 .tab.pinned .tabTitle {
   padding-inline-start: 9px;
-  font-size: 11px;
 }
 
 .pinBadge {


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Make sure to follow the contributing guidelines. -->
<!-- Important note, we may remove your pull request if you do not use this provided PR template correctly. -->
<!-- Agent instructions: Preserve every heading, comment, and marker in this template. Never remove or rewrite the release-note-category:start/end, release-note:start/end, or release-note-image:start/end marker pairs. Never remove or rewrite the Release note images section; leave its contents for a human. -->

## Pull Request Type
<!-- Please select what type of pull request this is: [x] -->
- [x] Bugfix
- [ ] Feature Implementation
- [ ] Documentation
- [ ] Other

## Related issue
<!-- Please link the issue your pull request is referring to. -->
<!-- If this pull request fully resolves the relevant issue, put "closes" before the issue number. -->
<!-- Example: "closes #123456". -->

## Description
<!-- Please write a clear and concise description of what the pull request does. -->
Pinned tab titles were rendered one pixel smaller than regular tab titles. The difference was particularly noticeable with custom fonts that have a smaller x-height.

This removes the pinned-only font-size override so all tab titles use the same size, while preserving the pinned tab's compact layout. A regression test compares the computed title sizes for pinned and unpinned tabs.

## Release note category
<!-- Select exactly one category. Every pull request must select one. -->
<!-- Select "Not noteworthy" when the pull request fixes a bug in or improves functionality that has not yet appeared in a stable release. -->
<!-- release-note-category:start -->
- [x] Not noteworthy
- [ ] Highlights
- [ ] More improvements
- [ ] Fixed bugs
<!-- release-note-category:end -->

## Release note
<!-- Required unless "Not noteworthy" is selected. -->
<!-- Write one concise, user-facing entry without a leading bullet. -->
<!-- release-note:start -->

<!-- release-note:end -->

## Release note images
<!-- Human-only: Agents must preserve this entire section and leave it empty. -->
<!-- Optional. Paste one or more Markdown images or HTML image tags here. -->
<!-- The release notes will use an HTML image tag and limit images taller than 300 pixels. -->
<!-- release-note-image:start -->

<!-- release-note-image:end -->

## Testing
<!-- How can reviewers verify that the PR produces correct results? -->
<!-- Please provide instructions so that others can ensure that your pull request would produce correct results. For examples see, https://github.com/FreeTubeApp/FreeTube/pull/5743, https://github.com/FreeTubeApp/FreeTube/pull/7349, https://github.com/FreeTubeApp/FreeTube/pull/5125, https://github.com/FreeTubeApp/FreeTube/pull/7338 -->
<!-- Agent instructions: Only write human-facing steps that explain how to verify the change while running this branch in dev mode. Include expected results and, when applicable, helpful console snippets for interactive verification. Do not include automated checks, commands, results, pass counts, or CI status. -->

1. Configure a custom application font, preferably one with a relatively small x-height.
2. Open at least two tabs and pin one of them.
3. Confirm that the pinned and unpinned tab titles render at the same font size.

## Additional context
<!-- Add any other context about the pull request here. -->
The pinned title rule explicitly set `font-size: 11px`, while the shared tab title rule uses `12px`. Custom font metrics made that intentional size difference appear more pronounced.