### PR TITLE
fix(player): preserve tab title during SABR reload

### DIFF
--- a/e2e/tests/offline/sabr-error-recovery.spec.mjs
+++ b/e2e/tests/offline/sabr-error-recovery.spec.mjs
@@ -470,6 +470,64 @@ test('a SABR reload preserves the active video quality', async ({ app, page }) =
   expect(quality).toBe('720')
 })
 
+test('a SABR reload preserves the tab title while adding its resume timestamp', async ({ app, page }) => {
+  await mockUnplayableWatchPage(app, page)
+  await goTo(page, 'history')
+  await page.getByText('SABR test video').click()
+  await expect(page).toHaveURL(/#\/watch\/jNQXAC9IVRw/)
+  await expect(page.locator('.errorMessage')).toBeVisible({ timeout: 30_000 })
+
+  const titles = await page.evaluate(async () => {
+    const app = document.querySelector('#app')?.__vue_app__
+
+    const findWatchView = (vnode) => {
+      if (vnode?.component?.type?.name === 'Watch') {
+        return vnode.component.proxy
+      }
+      if (vnode?.component?.subTree) {
+        const match = findWatchView(vnode.component.subTree)
+        if (match) return match
+      }
+      if (Array.isArray(vnode?.children)) {
+        for (const child of vnode.children) {
+          const match = findWatchView(child)
+          if (match) return match
+        }
+      }
+      return null
+    }
+
+    const watchView = findWatchView(app?._container?._vnode)
+    if (!watchView) {
+      throw new Error('Unable to access the watch view')
+    }
+
+    watchView.getTimestamp = () => 42
+    watchView.reloadView = async () => {}
+    watchView.showTabToast = () => {}
+
+    const titleBeforeReload = watchView.$store.getters.getTabById(watchView.tabId).contentTitle
+    const publishedTitles = []
+    const unsubscribe = watchView.$store.subscribe((mutation) => {
+      if (mutation.type === 'setTabContentTitle' && mutation.payload.tabId === watchView.tabId) {
+        publishedTitles.push(mutation.payload.title)
+      }
+    })
+
+    try {
+      await watchView.performSabrReload({}, 'Synthetic SABR reload')
+    } finally {
+      unsubscribe()
+    }
+
+    return { titleBeforeReload, publishedTitles }
+  })
+
+  expect(titles.publishedTitles).toEqual([titles.titleBeforeReload])
+  await expect(page).toHaveURL(/oneTimeTimestamp=42/)
+  await expect(page).toHaveTitle(`${titles.titleBeforeReload} - OpenTubeX`)
+})
+
 test('a second SABR failure after successful playback refetches instead of dropping to legacy', async ({ app, page }) => {
   await mockUnplayableWatchPage(app, page)
   await goTo(page, 'history')

--- a/src/renderer/views/Watch/Watch.js
+++ b/src/renderer/views/Watch/Watch.js
@@ -5313,6 +5313,13 @@ export default defineComponent({
         const reloadLocation = {
           path: this.tabRoute.path,
           query: { ...this.tabRoute.query, oneTimeTimestamp: timestamp },
+          // This only carries the resume position for the same video. Keep the
+          // resolved title throughout navigation instead of briefly replacing
+          // it with the updated watch URL while the metadata reloads.
+          state: {
+            skipTabRouteLoading: true,
+            tabTitle: this.videoTitle,
+          },
         }
 
         if (this.tabRouter.resolve(reloadLocation).fullPath !== this.tabRoute.fullPath) {


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Make sure to follow the contributing guidelines. -->
<!-- Important note, we may remove your pull request if you do not use this provided PR template correctly. -->
<!-- Agent instructions: Preserve every heading, comment, and marker in this template. Never remove or rewrite the release-note-category:start/end, release-note:start/end, or release-note-image:start/end marker pairs. Never remove or rewrite the Release note images section; leave its contents for a human. -->

## Pull Request Type
<!-- Please select what type of pull request this is: [x] -->
- [x] Bugfix
- [ ] Feature Implementation
- [ ] Documentation
- [ ] Other

## Related issue
<!-- Please link the issue your pull request is referring to. -->
<!-- If this pull request fully resolves the relevant issue, put "closes" before the issue number. -->
<!-- Example: "closes #123456". -->

## Description
<!-- Please write a clear and concise description of what the pull request does. -->

A SABR-requested player reload adds a one-time resume timestamp to the current watch route. That internal route replacement was treated as a new tab navigation, so the resolved video title was briefly replaced by the watch URL while metadata reloaded.

Preserve the current tab title and skip route-loading title replacement for this same-video navigation. The watch view continues to preserve its resolved metadata title while the player is rebuilt.

## Release note category
<!-- Select exactly one category. Every pull request must select one. -->
<!-- Select "Not noteworthy" when the pull request fixes a bug in or improves functionality that has not yet appeared in a stable release. -->
<!-- release-note-category:start -->
- [ ] Not noteworthy
- [ ] Highlights
- [ ] More improvements
- [x] Fixed bugs
<!-- release-note-category:end -->

## Release note
<!-- Required unless "Not noteworthy" is selected. -->
<!-- Write one concise, user-facing entry without a leading bullet. -->
<!-- release-note:start -->
SABR-requested player reloads no longer briefly replace the tab title with the video URL.
<!-- release-note:end -->

## Release note images
<!-- Human-only: Agents must preserve this entire section and leave it empty. -->
<!-- Optional. Paste one or more Markdown images or HTML image tags here. -->
<!-- The release notes will use an HTML image tag and limit images taller than 300 pixels. -->
<!-- release-note-image:start -->

<!-- release-note-image:end -->

## Testing
<!-- How can reviewers verify that the PR produces correct results? -->
<!-- Please provide instructions so that others can ensure that your pull request would produce correct results. For examples see, https://github.com/FreeTubeApp/FreeTube/pull/5743, https://github.com/FreeTubeApp/FreeTube/pull/7349, https://github.com/FreeTubeApp/FreeTube/pull/5125, https://github.com/FreeTubeApp/FreeTube/pull/7338 -->
<!-- Agent instructions: Only write human-facing steps that explain how to verify the change while running this branch in dev mode. Include expected results and, when applicable, helpful console snippets for interactive verification. Do not include automated checks, commands, results, pass counts, or CI status. -->

1. Start the app in dev mode and play a video using the built-in SABR stream.
2. Keep the tab bar visible and let playback continue until SABR requests a player reload.
3. Watch the tab title while the player reloads and confirm it keeps the resolved video title throughout.
4. Confirm playback resumes from the previous position after the reload.

## Additional context
<!-- Add any other context about the pull request here. -->

The regression occurred only when playback had advanced far enough for the reload to add a one-time resume timestamp to the route.