### PR TITLE
fix(player): reposition paid promotion badge after title fades

### DIFF
--- a/e2e/tests/offline/ui-bugfixes.spec.mjs
+++ b/e2e/tests/offline/ui-bugfixes.spec.mjs
@@ -153,13 +153,28 @@ test('paid promotion badge follows the full-window title visibility', async ({ p
 
   await controls.evaluate(element => element.setAttribute('shown', 'false'))
   await expect(badge).toHaveCSS('transition-delay', '0s, 0.45s')
-  await page.waitForTimeout(300)
+  const badgePositionTransition = await badge.evaluateHandle((element) => {
+    const transition = element.getAnimations().find(animation =>
+      animation instanceof CSSTransition &&
+      ['inset-block-start', 'top'].includes(animation.transitionProperty)
+    )
+    if (!transition) {
+      throw new Error('Paid promotion badge position transition not found')
+    }
+    transition.pause()
+    return transition
+  })
+  await badgePositionTransition.evaluate((transition) => {
+    transition.currentTime = 300
+  })
   const fadingTitleBadgeBounds = await badge.boundingBox()
   expect(fadingTitleBadgeBounds.y).toBeCloseTo(visibleTitleBadgeBounds.y, 0)
-  await expect.poll(async () => {
-    const bounds = await badge.boundingBox()
-    return bounds ? bounds.y - playerBounds.y : null
-  }).toBeCloseTo(12, 0)
+  await badgePositionTransition.evaluate((transition) => {
+    transition.currentTime = 600
+  })
+  const hiddenTitleBadgeBounds = await badge.boundingBox()
+  expect(hiddenTitleBadgeBounds.y - playerBounds.y).toBeCloseTo(12, 0)
+  await badgePositionTransition.dispose()
 
   await player.evaluate((element) => {
     element.classList.remove('fullWindow')

--- a/e2e/tests/offline/ui-bugfixes.spec.mjs
+++ b/e2e/tests/offline/ui-bugfixes.spec.mjs
@@ -143,10 +143,23 @@ test('paid promotion badge follows the full-window title visibility', async ({ p
   const controls = player.locator('.shaka-controls-container')
   await expect(badge).toHaveCSS('top', '65px')
   await expect(badge).toHaveCSS('transition-delay', '0s, 0s')
+  const [playerBounds, visibleTitleBadgeBounds] = await Promise.all([
+    player.boundingBox(),
+    badge.boundingBox(),
+  ])
+  expect(playerBounds).not.toBeNull()
+  expect(visibleTitleBadgeBounds).not.toBeNull()
+  expect(visibleTitleBadgeBounds.y - playerBounds.y).toBeCloseTo(65, 0)
 
   await controls.evaluate(element => element.setAttribute('shown', 'false'))
   await expect(badge).toHaveCSS('transition-delay', '0s, 0.45s')
-  await expect(badge).toHaveCSS('top', '12px')
+  await page.waitForTimeout(300)
+  const fadingTitleBadgeBounds = await badge.boundingBox()
+  expect(fadingTitleBadgeBounds.y).toBeCloseTo(visibleTitleBadgeBounds.y, 0)
+  await expect.poll(async () => {
+    const bounds = await badge.boundingBox()
+    return bounds ? bounds.y - playerBounds.y : null
+  }).toBeCloseTo(12, 0)
 
   await player.evaluate((element) => {
     element.classList.remove('fullWindow')

--- a/e2e/tests/offline/ui-bugfixes.spec.mjs
+++ b/e2e/tests/offline/ui-bugfixes.spec.mjs
@@ -115,6 +115,49 @@ test('full-window player shows the title overlay', async ({ page }) => {
   await expect(title).toHaveCSS('display', 'block')
 })
 
+test('paid promotion badge follows the full-window title visibility', async ({ page }) => {
+  const playerStyles = await readFile(
+    path.join(
+      repoRoot,
+      'src/renderer/components/ft-shaka-video-player/ft-shaka-video-player.css'
+    ),
+    'utf8'
+  )
+  await page.addStyleTag({
+    content: playerStyles.replaceAll(/:deep\(((?:[^()]|\([^()]*\))*)\)/g, '$1')
+  })
+  await page.evaluate(() => {
+    const player = document.createElement('div')
+    const badge = document.createElement('button')
+    const controls = document.createElement('div')
+    player.className = 'ftVideoPlayer fullWindow'
+    badge.className = 'paidPromotionOverlay'
+    controls.className = 'shaka-controls-container'
+    controls.setAttribute('shown', 'true')
+    player.append(badge, controls)
+    document.body.append(player)
+  })
+
+  const player = page.locator('.ftVideoPlayer')
+  const badge = player.locator('.paidPromotionOverlay')
+  const controls = player.locator('.shaka-controls-container')
+  await expect(badge).toHaveCSS('top', '65px')
+  await expect(badge).toHaveCSS('transition-delay', '0s, 0s')
+
+  await controls.evaluate(element => element.setAttribute('shown', 'false'))
+  await expect(badge).toHaveCSS('transition-delay', '0s, 0.45s')
+  await expect(badge).toHaveCSS('top', '12px')
+
+  await player.evaluate((element) => {
+    element.classList.remove('fullWindow')
+    element.classList.add('presentationModeChanging')
+  })
+  await controls.evaluate(element => element.setAttribute('shown', 'true'))
+  await player.evaluate(element => element.classList.add('fullWindow'))
+  await expect(badge).toHaveCSS('top', '65px')
+  await expect(badge).toHaveCSS('transition-property', 'opacity')
+})
+
 test('Shorts top controls stay visible over white video content', async ({ page }) => {
   await goTo(page, 'history')
   const playerStyles = await readFile(

--- a/src/renderer/components/ft-shaka-video-player/ft-shaka-video-player.css
+++ b/src/renderer/components/ft-shaka-video-player/ft-shaka-video-player.css
@@ -70,7 +70,8 @@
   inset-block-start: 12px;
   inset-inline-start: 8px;
   opacity: 0.82;
-  transition: opacity 150ms ease;
+  transition: opacity 150ms ease,
+    inset-block-start 150ms ease 450ms;
 }
 
 .paidPromotionOverlay:hover,
@@ -78,9 +79,16 @@
   opacity: 1;
 }
 
-.ftVideoPlayer:is(:fullscreen, .fullWindow) > .paidPromotionOverlay {
+.ftVideoPlayer.presentationModeChanging > .paidPromotionOverlay {
+  transition: opacity 150ms ease;
+}
+
+.ftVideoPlayer:is(:fullscreen, .fullWindow):has(
+  :deep(.shaka-controls-container[shown='true'])
+):not(.playerPaused.hideVideoTitleWhenPaused:not(.pausedInterfaceRevealed)) > .paidPromotionOverlay {
   /* Keep the badge clear of the single-line fullscreen title overlay. */
   inset-block-start: 65px;
+  transition-delay: 0s, 0s;
 }
 
 .ftVideoPlayer.shortsPlayer {


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Make sure to follow the contributing guidelines. -->
<!-- Important note, we may remove your pull request if you do not use this provided PR template correctly. -->
<!-- Agent instructions: Preserve every heading, comment, and marker in this template. Never remove or rewrite the release-note-category:start/end, release-note:start/end, or release-note-image:start/end marker pairs. Never remove or rewrite the Release note images section; leave its contents for a human. -->

## Pull Request Type
<!-- Please select what type of pull request this is: [x] -->
- [x] Bugfix
- [ ] Feature Implementation
- [ ] Documentation
- [ ] Other

## Related issue
<!-- Please link the issue your pull request is referring to. -->
<!-- If this pull request fully resolves the relevant issue, put "closes" before the issue number. -->
<!-- Example: "closes #123456". -->

## Description
<!-- Please write a clear and concise description of what the pull request does. -->

The paid promotion badge stayed below the fullscreen title after that title faded away, leaving unnecessary empty space above the badge.

Position the badge from the Shaka controls' title visibility state. It waits until the title is almost fully faded before moving up, moves down immediately when the title returns, and does not animate during fullscreen or full-window mode changes. The paused-title preference follows the same behavior.

## Release note category
<!-- Select exactly one category. Every pull request must select one. -->
<!-- Select "Not noteworthy" when the pull request fixes a bug in or improves functionality that has not yet appeared in a stable release. -->
<!-- release-note-category:start -->
- [ ] Not noteworthy
- [ ] Highlights
- [ ] More improvements
- [x] Fixed bugs
<!-- release-note-category:end -->

## Release note
<!-- Required unless "Not noteworthy" is selected. -->
<!-- Write one concise, user-facing entry without a leading bullet. -->
<!-- release-note:start -->
Paid promotion badges now move up after fullscreen video titles fade out.
<!-- release-note:end -->

## Release note images
<!-- Human-only: Agents must preserve this entire section and leave it empty. -->
<!-- Optional. Paste one or more Markdown images or HTML image tags here. -->
<!-- The release notes will use an HTML image tag and limit images taller than 300 pixels. -->
<!-- release-note-image:start -->

<!-- release-note-image:end -->

## Testing
<!-- How can reviewers verify that the PR produces correct results? -->
<!-- Please provide instructions so that others can ensure that your pull request would produce correct results. For examples see, https://github.com/FreeTubeApp/FreeTube/pull/5743, https://github.com/FreeTubeApp/FreeTube/pull/7349, https://github.com/FreeTubeApp/FreeTube/pull/5125, https://github.com/FreeTubeApp/FreeTube/pull/7338 -->
<!-- Agent instructions: Only write human-facing steps that explain how to verify the change while running this branch in dev mode. Include expected results and, when applicable, helpful console snippets for interactive verification. Do not include automated checks, commands, results, pass counts, or CI status. -->

1. Open a video that displays the paid promotion badge.
2. Enter full-window or fullscreen mode and leave the pointer idle.
3. Confirm the badge stays below the title while it fades, then quickly moves to the top after the title is almost gone.
4. Move the pointer and confirm the badge immediately moves below the returning title.
5. Enter and exit full-window and fullscreen modes and confirm the badge does not animate between its regular and presentation-mode positions.

## Additional context
<!-- Add any other context about the pull request here. -->