### PR TITLE
style(captions): simplify caption appearance settings

### DIFF
--- a/e2e/tests/offline/settings.spec.mjs
+++ b/e2e/tests/offline/settings.spec.mjs
@@ -938,8 +938,8 @@ test.describe('settings', () => {
 
     expect(colorControlBounds.y).toBeCloseTo(styleControlBounds.y, 0)
     expect(colorControlBounds.height).toBeCloseTo(styleControlBounds.height, 0)
-    expect(colorTriggerBounds.y).toBeCloseTo(colorControlBounds.y + 1, 0)
-    expect(colorTriggerBounds.height).toBeCloseTo(colorControlBounds.height - 2, 0)
+    expect(colorTriggerBounds.y).toBeCloseTo(colorControlBounds.y, 0)
+    expect(colorTriggerBounds.height).toBeCloseTo(colorControlBounds.height, 0)
   })
 
   test('stacks caption controls at narrow settings widths', async ({ page, attachScreenshot }) => {
@@ -1521,7 +1521,9 @@ test.describe('settings', () => {
     await page.locator('.settingsMenu [data-section="caption-appearance"]').click()
 
     await expect(page.locator('.captionSettings')).toHaveCSS('user-select', 'none')
-    await expect(page.locator('.captionControl').first()).toHaveCSS('border-width', '0px')
+    for (const captionControl of await page.locator('.captionControl').all()) {
+      await expect(captionControl).toHaveCSS('border-width', '0px')
+    }
     await expect(page.locator('.captionActions')).toHaveCSS('border-top-width', '0px')
 
     const backgroundOpacity = page.getByRole('slider', { name: /Background Opacity/ })

--- a/e2e/tests/offline/settings.spec.mjs
+++ b/e2e/tests/offline/settings.spec.mjs
@@ -1520,6 +1520,10 @@ test.describe('settings', () => {
     await page.getByRole('button', { name: 'Highlight settings changed from defaults' }).click()
     await page.locator('.settingsMenu [data-section="caption-appearance"]').click()
 
+    await expect(page.locator('.captionSettings')).toHaveCSS('user-select', 'none')
+    await expect(page.locator('.captionControl').first()).toHaveCSS('border-width', '0px')
+    await expect(page.locator('.captionActions')).toHaveCSS('border-top-width', '0px')
+
     const backgroundOpacity = page.getByRole('slider', { name: /Background Opacity/ })
     await backgroundOpacity.fill('50')
 

--- a/src/renderer/components/CaptionSettings/CaptionSettings.css
+++ b/src/renderer/components/CaptionSettings/CaptionSettings.css
@@ -1,3 +1,7 @@
+.captionSettings {
+  user-select: none;
+}
+
 .captionPreview {
   position: relative;
   box-sizing: border-box;
@@ -65,7 +69,6 @@
   min-inline-size: 0;
   min-block-size: 76px;
   padding: 0.75rem;
-  border: 1px solid var(--border-color);
   border-radius: calc(5px * var(--ui-roundness));
   background-color: var(--card-bg-color);
   backdrop-filter: var(--card-bg-blur, none);
@@ -98,7 +101,6 @@
   display: flex;
   justify-content: flex-start;
   padding-block-start: 0.25rem;
-  border-block-start: 1px solid var(--border-color);
 }
 
 @container settings-content (width <= 1100px) {


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Make sure to follow the contributing guidelines. -->
<!-- Important note, we may remove your pull request if you do not use this provided PR template correctly. -->
<!-- Agent instructions: Preserve every heading, comment, and marker in this template. Never remove or rewrite the release-note-category:start/end, release-note:start/end, or release-note-image:start/end marker pairs. Never remove or rewrite the Release note images section; leave its contents for a human. -->

## Pull Request Type
<!-- Please select what type of pull request this is: [x] -->
- [ ] Bugfix
- [ ] Feature Implementation
- [ ] Documentation
- [x] Other

## Related issue
<!-- Please link the issue your pull request is referring to. -->
<!-- If this pull request fully resolves the relevant issue, put "closes" before the issue number. -->
<!-- Example: "closes #123456". -->

## Description
<!-- Please write a clear and concise description of what the pull request does. -->
Caption appearance settings used bordered cards and a separator above the reset action, which made the section visually busier than necessary. This removes those borders and makes the section text non-selectable to behave like the rest of the settings interface.

The existing caption appearance E2E coverage now also checks these presentation rules.

## Release note category
<!-- Select exactly one category. Every pull request must select one. -->
<!-- Select "Not noteworthy" when the pull request fixes a bug in or improves functionality that has not yet appeared in a stable release. -->
<!-- release-note-category:start -->
- [x] Not noteworthy
- [ ] Highlights
- [ ] More improvements
- [ ] Fixed bugs
<!-- release-note-category:end -->

## Release note
<!-- Required unless "Not noteworthy" is selected. -->
<!-- Write one concise, user-facing entry without a leading bullet. -->
<!-- release-note:start -->
Simplified caption appearance settings by removing card borders and preventing accidental text selection.
<!-- release-note:end -->

## Release note images
<!-- Human-only: Agents must preserve this entire section and leave it empty. -->
<!-- Optional. Paste one or more Markdown images or HTML image tags here. -->
<!-- The release notes will use an HTML image tag and limit images taller than 300 pixels. -->
<!-- release-note-image:start -->

<!-- release-note-image:end -->

## Testing
<!-- How can reviewers verify that the PR produces correct results? -->
<!-- Please provide instructions so that others can ensure that your pull request would produce correct results. For examples see, https://github.com/FreeTubeApp/FreeTube/pull/5743, https://github.com/FreeTubeApp/FreeTube/pull/7349, https://github.com/FreeTubeApp/FreeTube/pull/5125, https://github.com/FreeTubeApp/FreeTube/pull/7338 -->
<!-- Agent instructions: Only write human-facing steps that explain how to verify the change while running this branch in dev mode. Include expected results and, when applicable, helpful console snippets for interactive verification. Do not include automated checks, commands, results, pass counts, or CI status. -->
1. Open Settings and navigate to Caption Appearance.
2. Confirm the individual caption controls no longer have outlines.
3. Confirm there is no separator above Reset Caption Appearance.
4. Try to select text in the caption appearance section and confirm it remains unselected while the controls remain interactive.

## Additional context
<!-- Add any other context about the pull request here. -->
