### PR TITLE
feat: control managed yt-dlp and FFmpeg updates

### DIFF
--- a/e2e/tests/offline/settings.spec.mjs
+++ b/e2e/tests/offline/settings.spec.mjs
@@ -197,7 +197,7 @@ test.describe('settings', () => {
     await search.fill('update')
     await expect(page.locator('.settingsMenu .title.active')).toHaveCount(0)
     await expect(page.locator('.settingsContent > .section')).toHaveCount(0)
-    await expect(page.locator('.settingsSearchResult')).toHaveCount(3)
+    await expect(page.locator('.settingsSearchResult')).toHaveCount(4)
     expect((await page.locator('.settingsMenu .title').first().boundingBox()).height)
       .toBeLessThanOrEqual(50)
 
@@ -1909,6 +1909,83 @@ test.describe('settings', () => {
     await expect.poll(readable).toBe(2)
   })
 
+  test('does not rewrap an indefinite toast while transient toasts leave the stack', async ({ page }) => {
+    await page.mouse.move(800, 300)
+    await page.evaluate(() => {
+      window.dispatchEvent(new CustomEvent('opentubex:preview-managed-tools-update', {
+        detail: ['yt-dlp', 'ffmpeg']
+      }))
+    })
+
+    const updateToast = page.locator('.toast', { hasText: 'An update is available for yt-dlp and ffmpeg.' })
+    const updateMessage = updateToast.locator('.message')
+    await expect(updateToast).toBeVisible()
+    const initialSize = await updateMessage.evaluate(element => ({
+      width: element.offsetWidth,
+      height: element.offsetHeight
+    }))
+
+    await page.evaluate(() => {
+      window.ftElectron.showToastOnAllTabs('First short-lived toast', 800)
+      window.ftElectron.showToastOnAllTabs('Second short-lived toast', 1000)
+      window.ftElectron.showToastOnAllTabs('Third short-lived toast', 1200)
+      window.ftElectron.showToastOnAllTabs('Fourth short-lived toast', 1400)
+    })
+    await expect(page.locator('.toast', { hasText: 'Fourth short-lived toast' })).toBeVisible()
+
+    const sizes = await updateMessage.evaluate((element) => {
+      const samples = []
+      const start = performance.now()
+      return new Promise((resolve) => {
+        function sample () {
+          samples.push({ width: element.offsetWidth, height: element.offsetHeight })
+          if (performance.now() - start < 2200) {
+            requestAnimationFrame(sample)
+          } else {
+            resolve(samples)
+          }
+        }
+        requestAnimationFrame(sample)
+      })
+    })
+
+    expect(new Set(sizes.map(({ width }) => width))).toEqual(new Set([initialSize.width]))
+    expect(new Set(sizes.map(({ height }) => height))).toEqual(new Set([initialSize.height]))
+    await expect(updateToast).toBeVisible()
+  })
+
+  test('keeps indefinite toast actions after the transient toast limit is exceeded', async ({ page }) => {
+    await page.mouse.move(800, 300)
+    await page.evaluate(() => {
+      window.dispatchEvent(new CustomEvent('opentubex:preview-managed-tools-update', {
+        detail: ['yt-dlp', 'ffmpeg']
+      }))
+      for (let index = 0; index < 8; index++) {
+        window.ftElectron.showToastOnAllTabs(`Transient toast ${index}`, 600)
+      }
+    })
+
+    const updateToast = page.locator('.toast', { hasText: 'An update is available for yt-dlp and ffmpeg.' })
+    await expect(updateToast).toBeVisible()
+    await expect(updateToast.locator('.timeout-indicator-track')).toHaveCount(0)
+    await expect(updateToast).toHaveCSS('background-color', 'rgb(28, 28, 28)')
+
+    await page.waitForTimeout(1200)
+    await expect(updateToast).toBeVisible()
+    await updateToast.getByRole('button', { name: 'Cancel' }).click()
+    await expect(updateToast).toHaveCount(0)
+
+    await page.evaluate(() => {
+      window.dispatchEvent(new CustomEvent('opentubex:preview-managed-tools-update', {
+        detail: ['yt-dlp']
+      }))
+    })
+    const singleToolToast = page.locator('.toast', { hasText: 'An update is available for yt-dlp.' })
+    await expect(singleToolToast).toBeVisible()
+    await singleToolToast.getByRole('button', { name: 'Update' }).click()
+    await expect(singleToolToast).toHaveCount(0)
+  })
+
   test('keeps the stack fanned out while the pointer moves between toasts', async ({ page }) => {
     await page.mouse.move(800, 300)
     await page.evaluate(() => {
@@ -2117,6 +2194,41 @@ test.describe('settings', () => {
       await page.mouse.move(from.x + (to.x - from.x) * step / 16, from.y + (to.y - from.y) * step / 16)
       await expect(rows.first()).toHaveAttribute('data-expanded', 'true')
     }
+  })
+})
+
+test.describe('managed external software update controls', () => {
+  test.use({
+    seed: {
+      settings: {
+        ytDlpSource: 'managed',
+        externalSoftwareUpdateMode: 'ask'
+      }
+    }
+  })
+
+  test('offers automatic, ask, and manual update modes', async ({ app, page }) => {
+    const section = await goToSettingsSection(page, 'external-software')
+    const updateMode = section.locator('.select')
+      .filter({ hasText: 'Managed Tool Updates' })
+      .locator('select')
+
+    await expect(updateMode).toHaveValue('ask')
+    await expect(updateMode.locator('option')).toHaveText([
+      'Update automatically',
+      'Ask before updating',
+      'Only update manually'
+    ])
+    await expect(section.locator('.select').filter({ hasText: 'Managed Tool Updates' }))
+      .toContainText('Managed Tool Updates')
+
+    await updateMode.selectOption('manual')
+    await expect(updateMode).toHaveValue('manual')
+    await expect.poll(async () => {
+      return latestSettings(
+        await readFile(path.join(app.userDataDir, 'settings.db'), 'utf8')
+      ).externalSoftwareUpdateMode
+    }).toBe('manual')
   })
 })
 

--- a/src/constants.js
+++ b/src/constants.js
@@ -147,6 +147,7 @@ const IpcChannels = {
   YT_DLP_PLAYBACK_CACHE_SET: 'yt-dlp-playback-cache-set',
   YT_DLP_PLAYBACK_CACHE_DELETE: 'yt-dlp-playback-cache-delete',
   YT_DLP_PLAYBACK_CACHE_CLEAR: 'yt-dlp-playback-cache-clear',
+  YT_DLP_CHECK_BINARY_UPDATE: 'yt-dlp-check-binary-update',
   YT_DLP_DOWNLOAD_BINARY: 'yt-dlp-download-binary',
   YT_DLP_BINARY_DOWNLOAD_PROGRESS: 'yt-dlp-binary-download-progress',
   YT_DLP_BINARY_UPDATED: 'yt-dlp-binary-updated'

--- a/src/main/index.js
+++ b/src/main/index.js
@@ -44,7 +44,7 @@ import { brotliDecompress } from 'zlib'
 
 import packageDetails from '../../package.json'
 import { handleOpenInExternalPlayer } from './externalPlayer'
-import { getYtDlpDownloadFile, handleYtDlpCancelDownload, handleYtDlpClearDownloads, handleYtDlpDownload, handleYtDlpDownloadBinary, handleYtDlpGetInfo, handleYtDlpGetPlaybackInfo, handleYtDlpListDownloads, handleYtDlpOpenDownload, handleYtDlpRemoveDownload, shutdownYtDlpDownloads } from './ytDlp'
+import { getYtDlpDownloadFile, handleYtDlpCancelDownload, handleYtDlpCheckBinaryUpdate, handleYtDlpClearDownloads, handleYtDlpDownload, handleYtDlpDownloadBinary, handleYtDlpGetInfo, handleYtDlpGetPlaybackInfo, handleYtDlpListDownloads, handleYtDlpOpenDownload, handleYtDlpRemoveDownload, shutdownYtDlpDownloads } from './ytDlp'
 import { handleYtDlpPlaybackCacheClear, handleYtDlpPlaybackCacheDelete, handleYtDlpPlaybackCacheGet, handleYtDlpPlaybackCacheSet } from './ytDlpPlaybackCache'
 import { generatePoToken } from './poTokenGenerator'
 import { expandMultipleOnlyPluralMessages, selectPluralForm } from '../renderer/i18n/plurals'
@@ -3887,6 +3887,7 @@ function runApp() {
   ipcMain.handle(IpcChannels.YT_DLP_PLAYBACK_CACHE_DELETE, handleYtDlpPlaybackCacheDelete)
   ipcMain.handle(IpcChannels.YT_DLP_PLAYBACK_CACHE_CLEAR, handleYtDlpPlaybackCacheClear)
 
+  ipcMain.handle(IpcChannels.YT_DLP_CHECK_BINARY_UPDATE, handleYtDlpCheckBinaryUpdate)
   ipcMain.handle(IpcChannels.YT_DLP_DOWNLOAD_BINARY, handleYtDlpDownloadBinary)
 
   ipcMain.handle(IpcChannels.YT_DLP_CHOOSE_EXECUTABLE, async (event, currentPath) => {

--- a/src/main/ytDlp.js
+++ b/src/main/ytDlp.js
@@ -536,6 +536,37 @@ async function downloadFile(url, onProgress, onDownloadStart, validators) {
 }
 
 /**
+ * Checks a managed download without transferring its payload.
+ * A missing validator means there is no trustworthy installed-release baseline.
+ * @param {string} url
+ * @param {BinaryDownloadValidators | null} validators
+ * @returns {Promise<boolean>}
+ */
+async function isFileUpdateAvailable(url, validators) {
+  if (validators === null) {
+    return false
+  }
+
+  const headers = {}
+  if (validators.etag) {
+    headers['If-None-Match'] = validators.etag
+  }
+  if (validators.lastModified) {
+    headers['If-Modified-Since'] = validators.lastModified
+  }
+
+  const response = await net.fetch(url, { method: 'HEAD', headers })
+  if (response.status === 304) {
+    return false
+  }
+  if (!response.ok) {
+    throw new Error(`${response.status} ${response.statusText}`)
+  }
+
+  return true
+}
+
+/**
  * @param {string} binaryPath
  * @param {string} source
  * @param {'stable' | 'nightly' | 'master'} [channel]
@@ -905,6 +936,40 @@ async function downloadManagedFfmpeg(onProgress, onDownloadStart) {
 }
 
 /**
+ * Checks whether the selected managed binary has a newer remote asset.
+ * @param {'yt-dlp' | 'ffmpeg'} binary
+ * @returns {Promise<boolean>}
+ */
+async function isManagedBinaryUpdateAvailable(binary) {
+  if (binary === 'yt-dlp') {
+    const configuredChannel = (await settings._findOne('ytDlpChannel'))?.value
+    const channel = Object.hasOwn(YT_DLP_RELEASE_REPOSITORIES, configuredChannel) ? configuredChannel : 'stable'
+    const assetName = getYtDlpAssetName(process.platform, process.arch)
+    const source = `https://github.com/${YT_DLP_RELEASE_REPOSITORIES[channel]}/releases/latest/download/${assetName}`
+    const managedPath = getManagedBinaryPath('yt-dlp')
+    return isFileUpdateAvailable(source, await readDownloadValidators(managedPath, source, channel))
+  }
+
+  const ffmpegPath = getManagedBinaryPath('ffmpeg')
+  if (process.platform === 'win32') {
+    const url = 'https://github.com/yt-dlp/FFmpeg-Builds/releases/latest/download/ffmpeg-master-latest-win64-gpl.zip'
+    return isFileUpdateAvailable(url, await readDownloadValidators(ffmpegPath, url))
+  }
+
+  const platform = process.platform === 'darwin' ? 'macos' : 'linux'
+  const arch = process.arch === 'arm64' ? 'arm64' : 'amd64'
+  for (const binaryName of ['ffmpeg', 'ffprobe']) {
+    const url = `https://ffmpeg.martin-riedl.de/redirect/latest/${platform}/${arch}/release/${binaryName}.zip`
+    const binaryPath = getManagedBinaryPath(binaryName)
+    if (await isFileUpdateAvailable(url, await readDownloadValidators(binaryPath, url))) {
+      return true
+    }
+  }
+
+  return false
+}
+
+/**
  * @typedef YtDlpBinaryInfo
  * @property {'system' | 'managed'} source
  * @property {boolean} available
@@ -1015,6 +1080,23 @@ export async function handleYtDlpGetInfo(event, options) {
     if (getInfoAbortControllers.get(probeKey)?.signal === signal) {
       getInfoAbortControllers.delete(probeKey)
     }
+  }
+}
+
+/**
+ * @param {import('electron').IpcMainInvokeEvent} event
+ * @param {'yt-dlp' | 'ffmpeg'} binary
+ * @returns {Promise<{ available: boolean } | { error: string } | null>}
+ */
+export async function handleYtDlpCheckBinaryUpdate(event, binary) {
+  if (!isOpenTubeXUrl(event.senderFrame.url) || (binary !== 'yt-dlp' && binary !== 'ffmpeg')) {
+    return null
+  }
+
+  try {
+    return { available: await isManagedBinaryUpdateAvailable(binary) }
+  } catch (error) {
+    return { error: error.message }
   }
 }
 

--- a/src/main/ytDlp.js
+++ b/src/main/ytDlp.js
@@ -100,6 +100,7 @@ const CHANNEL_ID_REGEX = /^UC[\w-]{22}$/
 const AUTOMATIC_DISCOVERY_CACHE_TTL_MS = 60_000
 const AUTOMATIC_DISCOVERY_TIMEOUT_MS = 15_000
 const AUTOMATIC_DISCOVERY_E2E_FIXTURE = 'automatic-download-discovery.xml'
+const MANAGED_BINARY_UPDATE_CHECK_TIMEOUT_MS = 15_000
 const AUTOMATIC_TITLE_TERM_LIMIT = 20
 const AUTOMATIC_TITLE_TERM_LENGTH_LIMIT = 100
 const AUTOMATIC_NUMBER_LIMITS = Object.freeze({
@@ -543,7 +544,7 @@ async function downloadFile(url, onProgress, onDownloadStart, validators) {
  * @returns {Promise<boolean>}
  */
 async function isFileUpdateAvailable(url, validators) {
-  if (validators === null) {
+  if (!validators?.etag && !validators?.lastModified) {
     return false
   }
 
@@ -555,7 +556,11 @@ async function isFileUpdateAvailable(url, validators) {
     headers['If-Modified-Since'] = validators.lastModified
   }
 
-  const response = await net.fetch(url, { method: 'HEAD', headers })
+  const response = await net.fetch(url, {
+    method: 'HEAD',
+    headers,
+    signal: AbortSignal.timeout(MANAGED_BINARY_UPDATE_CHECK_TIMEOUT_MS)
+  })
   if (response.status === 304) {
     return false
   }

--- a/src/preload/interface.js
+++ b/src/preload/interface.js
@@ -426,6 +426,14 @@ export default {
 
   /**
    * @param {'yt-dlp' | 'ffmpeg'} binary
+   * @returns {Promise<{ available: boolean } | { error: string } | null>}
+   */
+  ytDlpCheckBinaryUpdate: (binary) => {
+    return ipcRenderer.invoke(IpcChannels.YT_DLP_CHECK_BINARY_UPDATE, binary)
+  },
+
+  /**
+   * @param {'yt-dlp' | 'ffmpeg'} binary
    * @returns {Promise<{ version: string, updated: boolean } | { error: string } | null>}
    */
   ytDlpDownloadBinary: (binary) => {

--- a/src/renderer/App.vue
+++ b/src/renderer/App.vue
@@ -619,9 +619,11 @@ const tabSwitcherSelectedTabId = computed(() => {
 
 /**
  * Falls back to OpenTubeX-managed external software when the configured system
- * executables are unavailable and updates every selected managed executable.
+ * executables are unavailable. Selected managed executables are updated when
+ * automatic updates are enabled or the user accepts an available update.
+ * @param {('yt-dlp' | 'ffmpeg')[] | null} requestedUpdates
  */
-async function initializeManagedExternalSoftware() {
+async function initializeManagedExternalSoftware(requestedUpdates = null) {
   if (!isElectron) {
     return
   }
@@ -646,15 +648,35 @@ async function initializeManagedExternalSoftware() {
     missingBinaries.push('ffprobe')
   }
 
-  if (store.getters.getYtDlpSource === 'managed' || missingBinaries.includes('yt-dlp')) {
+  const updateMode = store.getters.getExternalSoftwareUpdateMode
+  const automaticUpdates = updateMode === 'automatic'
+  let missingManagedBinaries = missingBinaries
+  if (!automaticUpdates && missingBinaries.length > 0) {
+    const managedInfo = await window.ftElectron.ytDlpGetInfo({
+      ytDlpSource: 'managed',
+      ytDlpPath: '',
+      ffmpegSource: 'managed',
+      ffmpegPath: ''
+    })
+    if (managedInfo !== null) {
+      missingManagedBinaries = missingBinaries.filter(binary => {
+        if (binary === 'yt-dlp') {
+          return !managedInfo.ytDlp.available
+        }
+        return binary === 'ffmpeg' ? !managedInfo.ffmpeg.available : !managedInfo.ffprobe.available
+      })
+    }
+  }
+
+  if (missingManagedBinaries.includes('yt-dlp') ||
+    (store.getters.getYtDlpSource === 'managed' &&
+      (automaticUpdates || requestedUpdates?.includes('yt-dlp')))) {
     binariesToUpdate.push('yt-dlp')
   }
-  if (store.getters.getYtDlpFfmpegSource === 'managed' ||
-    missingBinaries.includes('ffmpeg') || missingBinaries.includes('ffprobe')) {
+  if (missingManagedBinaries.includes('ffmpeg') || missingManagedBinaries.includes('ffprobe') ||
+    (store.getters.getYtDlpFfmpegSource === 'managed' &&
+      (automaticUpdates || requestedUpdates?.includes('ffmpeg')))) {
     binariesToUpdate.push('ffmpeg')
-  }
-  if (binariesToUpdate.length === 0) {
-    return
   }
 
   const settingUpdates = []
@@ -667,7 +689,14 @@ async function initializeManagedExternalSoftware() {
   }
   await Promise.all(settingUpdates)
 
-  let downloadStarted = missingBinaries.length > 0
+  if (binariesToUpdate.length === 0) {
+    if (updateMode === 'ask' && requestedUpdates === null) {
+      await notifyAboutManagedExternalSoftwareUpdates([])
+    }
+    return
+  }
+
+  let downloadStarted = missingManagedBinaries.length > 0
   let toolProgressPercentage = 0
 
   function showToolProgress(message) {
@@ -729,7 +758,7 @@ async function initializeManagedExternalSoftware() {
       store.commit('setProgressBarPercentage', toolProgressPercentage)
       const updatedTools = updatedBinaries.join(' and ')
       showToast({
-        message: missingBinaries.length > 0
+        message: missingManagedBinaries.length > 0
           ? t('Settings.Download Settings.Managed Tools Download Finished Template', { tools: updatedTools })
           : t('Settings.Download Settings.Managed Tools Update Finished Template', { tools: updatedTools }),
         icon: ['fas', 'check'],
@@ -752,6 +781,77 @@ async function initializeManagedExternalSoftware() {
       store.commit('setProgressBarIcon', ['fas', 'sync'])
     }
   }
+
+  if (updateMode === 'ask' && requestedUpdates === null) {
+    await notifyAboutManagedExternalSoftwareUpdates(missingManagedBinaries)
+  }
+}
+
+/**
+ * Checks installed managed tools and offers an explicit update action.
+ * @param {('yt-dlp' | 'ffmpeg' | 'ffprobe')[]} binariesInstalledThisRun
+ */
+async function notifyAboutManagedExternalSoftwareUpdates(binariesInstalledThisRun) {
+  const candidates = []
+  if (store.getters.getYtDlpSource === 'managed' && !binariesInstalledThisRun.includes('yt-dlp')) {
+    candidates.push('yt-dlp')
+  }
+  if (store.getters.getYtDlpFfmpegSource === 'managed' &&
+    !binariesInstalledThisRun.includes('ffmpeg') && !binariesInstalledThisRun.includes('ffprobe')) {
+    candidates.push('ffmpeg')
+  }
+
+  const checks = await Promise.all(candidates.map(async binary => {
+    const result = await window.ftElectron.ytDlpCheckBinaryUpdate(binary)
+    if (result !== null && 'error' in result) {
+      console.warn(`Checking for a managed ${binary} update failed`, result.error)
+    }
+    return result?.available === true ? binary : null
+  }))
+  const availableUpdates = checks.filter(binary => binary !== null)
+  if (availableUpdates.length === 0) {
+    return
+  }
+
+  showManagedExternalSoftwareUpdatePrompt(availableUpdates)
+}
+
+/**
+ * @param {('yt-dlp' | 'ffmpeg')[]} availableUpdates
+ */
+function showManagedExternalSoftwareUpdatePrompt(availableUpdates) {
+  showToast({
+    message: t('Settings.Download Settings.Managed Tools Update Available Template', {
+      tools: availableUpdates.join(' and ')
+    }),
+    time: Infinity,
+    icon: ['fas', 'download'],
+    buttons: [
+      { label: t('Cancel') },
+      {
+        label: t('Settings.Download Settings.Update Managed Tools'),
+        primary: true,
+        action: () => {
+          initializeManagedExternalSoftware(availableUpdates)
+            .catch(error => console.error('Failed to update managed external software', error))
+        }
+      }
+    ]
+  })
+}
+
+const MANAGED_TOOLS_UPDATE_PREVIEW_EVENT = 'opentubex:preview-managed-tools-update'
+
+/**
+ * Allows the real actionable update prompt to be previewed from DevTools.
+ * @param {Event} event
+ */
+function previewManagedExternalSoftwareUpdatePrompt(event) {
+  const detail = event instanceof CustomEvent ? event.detail : null
+  const availableUpdates = Array.isArray(detail)
+    ? detail.filter(binary => binary === 'yt-dlp' || binary === 'ffmpeg')
+    : []
+  showManagedExternalSoftwareUpdatePrompt(availableUpdates.length > 0 ? [...new Set(availableUpdates)] : ['yt-dlp'])
 }
 
 const TUTORIAL_AUDIENCE_STORAGE_KEY = 'opentubex.tutorial.audience'
@@ -799,6 +899,7 @@ onMounted(async () => {
   preloadUtilityRoutes()
 
   if (isElectron) {
+    window.addEventListener(MANAGED_TOOLS_UPDATE_PREVIEW_EVENT, previewManagedExternalSoftwareUpdatePrompt)
     removeYtDlpBinaryUpdatedListener = window.ftElectron.addYtDlpBinaryUpdatedListener(
       invalidateAllYtDlpPlaybackSources
     )
@@ -956,6 +1057,7 @@ onBeforeUnmount(() => {
   window.removeEventListener('blur', cancelTabSwitcher)
   window.removeEventListener('online', refreshOverdueSubscriptionFeeds)
   window.removeEventListener('storage', handleSubscriptionAutoRefreshStorage)
+  window.removeEventListener(MANAGED_TOOLS_UPDATE_PREVIEW_EVENT, previewManagedExternalSoftwareUpdatePrompt)
   window.removeEventListener(SUBSCRIPTION_REFRESH_CANCELLED_EVENT, handleSubscriptionRefreshCancelled)
   window.removeEventListener(SUBSCRIPTION_REFRESH_COMPLETED_EVENT, handleSubscriptionRefreshCompleted)
   window.removeEventListener(SUBSCRIPTION_REFRESH_FINISHED_EVENT, handleSubscriptionRefreshFinished)

--- a/src/renderer/components/ExternalSoftwareSettings.vue
+++ b/src/renderer/components/ExternalSoftwareSettings.vue
@@ -35,6 +35,18 @@
         @change="updateYtDlpFfmpegSource"
       />
     </FtFlexBox>
+    <FtFlexBox v-if="ytDlpSource === 'managed' || ytDlpFfmpegSource === 'managed'">
+      <FtSelect
+        class="sourceSelect"
+        :placeholder="t('Settings.External Software Settings.Managed Tool Updates')"
+        :value="externalSoftwareUpdateMode"
+        :select-names="updateModeNames"
+        :select-values="UPDATE_MODE_VALUES"
+        :tooltip="t('Tooltips.External Software Settings.Managed Tool Updates')"
+        :icon="['fas', 'sync']"
+        @change="updateExternalSoftwareUpdateMode"
+      />
+    </FtFlexBox>
     <FtFlexBox class="binaryStatusStart">
       <p
         v-if="ytDlpInfo === null"
@@ -199,10 +211,17 @@ const { t } = useI18n()
 const SOURCE_VALUES = ['system', 'managed']
 const CHANNEL_NAMES = ['Stable', 'Nightly', 'Master']
 const CHANNEL_VALUES = ['stable', 'nightly', 'master']
+const UPDATE_MODE_VALUES = ['automatic', 'ask', 'manual']
 
 const sourceNames = computed(() => [
   t('Settings.External Software Settings.Sources.System'),
   t('Settings.External Software Settings.Sources.Managed')
+])
+
+const updateModeNames = computed(() => [
+  t('Settings.External Software Settings.Update Modes.Automatic'),
+  t('Settings.External Software Settings.Update Modes.Ask'),
+  t('Settings.External Software Settings.Update Modes.Manual')
 ])
 
 /** @type {import('vue').ComputedRef<'system' | 'managed'>} */
@@ -219,6 +238,9 @@ const ytDlpFfmpegSource = computed(() => store.getters.getYtDlpFfmpegSource)
 
 /** @type {import('vue').ComputedRef<string>} */
 const ytDlpFfmpegPath = computed(() => store.getters.getYtDlpFfmpegPath)
+
+/** @type {import('vue').ComputedRef<'automatic' | 'ask' | 'manual'>} */
+const externalSoftwareUpdateMode = computed(() => store.getters.getExternalSoftwareUpdateMode)
 
 /** @typedef {import('../../main/ytDlp').YtDlpBinaryInfo} BinaryInfo */
 
@@ -447,6 +469,13 @@ function updateYtDlpFfmpegSource(value) {
  */
 function updateYtDlpFfmpegPath(value) {
   store.dispatch('updateYtDlpFfmpegPath', value)
+}
+
+/**
+ * @param {'automatic' | 'ask' | 'manual'} value
+ */
+function updateExternalSoftwareUpdateMode(value) {
+  store.dispatch('updateExternalSoftwareUpdateMode', value)
 }
 
 /**

--- a/src/renderer/components/FtToast/FtToast.css
+++ b/src/renderer/components/FtToast/FtToast.css
@@ -254,7 +254,19 @@
 
 :is(.toast-holder, .progress-toast-holder) .toast-slot {
   position: relative;
+  display: flex;
   pointer-events: none;
+}
+
+.toast-holder.position-bottom-center .toast-slot,
+.toast-holder.position-top-center .toast-slot {
+  justify-content: center;
+}
+
+/* stylelint-disable-next-line liberty/use-logical-spec -- names a physical edge */
+.toast-holder.position-bottom-right .toast-slot,
+.toast-holder.position-top-right .toast-slot {
+  justify-content: flex-end;
 }
 
 /* The scale half of the enter and leave animations, kept off the row itself so
@@ -354,16 +366,19 @@
   position: relative;
   display: flex;
   align-items: center;
+  flex-shrink: 0;
   gap: 12px;
 
   /* Stay within the viewport on narrow windows, accounting for the holder's
      inline inset and this element's own margins */
   max-inline-size: min(400px, calc(100vw - 60px));
+  inline-size: max-content;
   padding-block: 12px;
   padding-inline: 18px;
   text-align: start;
   overflow-y: auto;
   background-color: rgb(28 28 28 / 92%);
+  backdrop-filter: blur(12px);
   color: #fff;
   border-radius: calc(12px * var(--ui-roundness));
   box-shadow: 0 4px 16px rgb(0 0 0 / 35%);
@@ -377,6 +392,24 @@
 
 :is(.toast-holder, .progress-toast-holder) .toast.actionable {
   cursor: pointer;
+}
+
+:is(.toast-holder, .progress-toast-holder) .toast.indefinite {
+  background-color: rgb(28 28 28);
+  backdrop-filter: none;
+}
+
+:is(.toast-holder, .progress-toast-holder) .toastActions {
+  display: flex;
+  flex-shrink: 0;
+  gap: 8px;
+  margin-inline-start: auto;
+}
+
+:is(.toast-holder, .progress-toast-holder) .toastActions .btn {
+  min-inline-size: auto;
+  padding-block: 6px;
+  padding-inline: 10px;
 }
 
 :is(.toast-holder, .progress-toast-holder) .timeout-indicator-track {
@@ -575,10 +608,18 @@
    behind them are trimmed to the size of the second, which is what they are
    stacked behind, so the pile tucks under it as one run of equally sized cards
    rather than a ragged edge. */
-.toast-holder[data-sonner-toaster] [data-sonner-toast][data-expanded='false']:not([data-index='0'], [data-index='1']) .toast-slot,
-.toast-holder[data-sonner-toaster] [data-sonner-toast][data-expanded='false']:not([data-index='0'], [data-index='1']) .toast {
+.toast-holder[data-sonner-toaster] [data-sonner-toast][data-expanded='false']:not([data-index='0'], [data-index='1']) .toast-slot {
   box-sizing: border-box;
   inline-size: var(--stacked-toast-width, var(--front-toast-width));
+  block-size: 100%;
+  overflow: hidden;
+}
+
+/* Keep the toast's own layout width stable while its collapsed slot clips the
+   card to the stack width. Changing the card width here reflows its text during
+   fan-out and dismissal animations. */
+.toast-holder[data-sonner-toaster] [data-sonner-toast][data-expanded='false']:not([data-index='0'], [data-index='1']) .toast {
+  flex-shrink: 0;
   block-size: 100%;
 }
 

--- a/src/renderer/components/FtToast/FtToast.vue
+++ b/src/renderer/components/FtToast/FtToast.vue
@@ -75,6 +75,7 @@ const { t } = useI18n()
  * @typedef ToastState the live state handed to {@link FtToastItem}
  * @property {string} message
  * @property {Function | null} action
+ * @property {{ label: string, action?: Function, primary?: boolean }[]} buttons
  * @property {string | null} image
  * @property {[string, string] | null} icon
  * @property {number} duration lifetime of the toast in milliseconds
@@ -125,6 +126,8 @@ const messageIntervals = new Map()
  * @type {(number | string)[]}
  */
 const liveToasts = []
+/** Toast ids which must remain until explicitly dismissed. */
+const indefiniteToastIds = new Set()
 /**
  * Removes the abort listener of each toast raised with an abort signal, by toast
  * id.
@@ -390,15 +393,16 @@ function resetProgressToastProximity() {
 }
 
 /**
- * @param {CustomEvent<{ message: string | (({elapsedMs: number, remainingMs: number}) => string), time: number | null, action: Function | null, abortSignal: AbortSignal | null, image: string | null, icon: [string, string] | null }>} event
+ * @param {CustomEvent<{ message: string | (({elapsedMs: number, remainingMs: number}) => string), time: number | null, action: Function | null, abortSignal: AbortSignal | null, image: string | null, icon: [string, string] | null, buttons: { label: string, action?: Function, primary?: boolean }[] }>} event
  */
-function open({ detail: { message, time, action, abortSignal, image, icon } }) {
+function open({ detail: { message, time, action, abortSignal, image, icon, buttons } }) {
   time ||= 3000
 
   /** @type {ToastState} */
   const state = reactive({
     message: typeof message === 'function' ? message({ elapsedMs: 0, remainingMs: time }) : message,
     action: action ?? null,
+    buttons: buttons ?? [],
     image: image ?? null,
     icon: icon ?? null,
     duration: time
@@ -441,8 +445,15 @@ function open({ detail: { message, time, action, abortSignal, image, icon } }) {
   }
 
   liveToasts.push(id)
+  if (!Number.isFinite(time)) {
+    indefiniteToastIds.add(id)
+  }
   while (liveToasts.length > MAX_VISIBLE_TOASTS) {
-    sonner.dismiss(liveToasts.shift())
+    const transientIndex = liveToasts.findIndex(toastId => !indefiniteToastIds.has(toastId))
+    if (transientIndex === -1) {
+      break
+    }
+    sonner.dismiss(liveToasts.splice(transientIndex, 1)[0])
   }
 }
 
@@ -451,6 +462,7 @@ function open({ detail: { message, time, action, abortSignal, image, icon } }) {
  */
 function forgetToast(toast) {
   clearMessageInterval(toast.id)
+  indefiniteToastIds.delete(toast.id)
   abortListeners.get(toast.id)?.()
   abortListeners.delete(toast.id)
 

--- a/src/renderer/components/FtToast/FtToastItem.vue
+++ b/src/renderer/components/FtToast/FtToastItem.vue
@@ -4,9 +4,14 @@
     class="toast-slot"
   >
     <div
+      ref="toastElement"
       v-overlay-scrollbars
       class="toast"
-      :class="{ hasImage: toast.image, actionable: toast.action }"
+      :class="{
+        hasImage: toast.image,
+        actionable: toast.action,
+        indefinite: !Number.isFinite(toast.duration)
+      }"
       :tabindex="toast.action ? 0 : null"
       role="status"
       @click="onClick"
@@ -31,6 +36,19 @@
       <p class="message">
         {{ toast.message }}
       </p>
+      <div
+        v-if="toast.buttons.length > 0"
+        class="toastActions"
+      >
+        <FtButton
+          v-for="button in toast.buttons"
+          :key="button.label"
+          :label="button.label"
+          :text-color="button.primary ? undefined : null"
+          :background-color="button.primary ? undefined : null"
+          @click="performButtonAction(button)"
+        />
+      </div>
     </div>
     <div
       v-if="showTimeoutIndicator"
@@ -55,6 +73,7 @@ import { FtIcon } from '@opentubex/icons'
 import { computed, onBeforeUnmount, onMounted, useTemplateRef } from 'vue'
 import store from '../../store'
 import FtEmbeddedProgress from '../FtEmbeddedProgress/FtEmbeddedProgress.vue'
+import FtButton from '../FtButton/FtButton.vue'
 
 /** Distance in px the pointer may travel before a click counts as the tail end of a swipe */
 const CLICK_SLOP = 5
@@ -89,8 +108,11 @@ let pointerMoved = false
 let row = null
 
 const slot = useTemplateRef('slot')
+const toastElement = useTemplateRef('toastElement')
 
-const showTimeoutIndicator = computed(() => store.getters.getShowToastTimeoutIndicator)
+const showTimeoutIndicator = computed(() => {
+  return store.getters.getShowToastTimeoutIndicator && Number.isFinite(props.toast.duration)
+})
 const toastProgressRadius = computed(() => 12 * store.getters.getUiRoundness / 100)
 const toastProgressLineWidth = computed(() => Math.min(4, Math.max(2, 2 * store.getters.getUiRoundness / 100)))
 
@@ -114,6 +136,10 @@ function onRowKeydown(event) {
 }
 
 onMounted(() => {
+  // The collapsed stack clips the slot around this card. Pinning the card's
+  // measured width keeps that constraint from shrinking its flex contents and
+  // rewrapping the message while toasts enter or leave the stack.
+  toastElement.value.style.inlineSize = `${toastElement.value.offsetWidth}px`
   row = slot.value?.parentElement ?? null
   row?.addEventListener('keydown', onRowKeydown)
 })
@@ -126,6 +152,14 @@ function performAction() {
   if (!props.toast.action) { return }
 
   props.toast.action()
+  close()
+}
+
+/**
+ * @param {{ action?: Function }} button
+ */
+function performButtonAction(button) {
+  button.action?.()
   close()
 }
 

--- a/src/renderer/components/FtToast/FtToastItem.vue
+++ b/src/renderer/components/FtToast/FtToastItem.vue
@@ -15,8 +15,8 @@
       :tabindex="toast.action ? 0 : null"
       role="status"
       @click="onClick"
-      @keydown.enter.prevent="performAction"
-      @keydown.space.prevent="performAction"
+      @keydown.enter.self.prevent="performAction"
+      @keydown.space.self.prevent="performAction"
       @pointerdown="onPointerDown"
       @pointerup="onPointerUp"
     >
@@ -39,6 +39,7 @@
       <div
         v-if="toast.buttons.length > 0"
         class="toastActions"
+        @click.stop
       >
         <FtButton
           v-for="button in toast.buttons"

--- a/src/renderer/helpers/utils.js
+++ b/src/renderer/helpers/utils.js
@@ -262,6 +262,7 @@ const ERROR_TOAST_ICON = ['fas', 'circle-exclamation']
  * @property {string | (({elapsedMs: number, remainingMs: number}) => string)} message
  * @property {number} [time]
  * @property {Function} [action]
+ * @property {{ label: string, action?: Function, primary?: boolean }[]} [buttons]
  * @property {AbortSignal} [abortSignal]
  * @property {string} [image] optional image URL (e.g. a video thumbnail) shown alongside the message
  * @property {[string, string]} [icon] optional semantic icon (e.g. `['fas', 'trash']`) shown
@@ -278,11 +279,12 @@ const ERROR_TOAST_ICON = ['fas', 'circle-exclamation']
 export function showToast(message, time = null, action = null, abortSignal = null) {
   let image = null
   let icon = null
+  let buttons = []
 
   // Allow calling with a single options object while staying backwards compatible
   // with the positional (message, time, action, abortSignal) signature
   if (message !== null && typeof message === 'object') {
-    ({ message, time = null, action = null, abortSignal = null, image = null, icon = null } = message)
+    ({ message, time = null, action = null, abortSignal = null, image = null, icon = null, buttons = [] } = message)
   }
 
   // Sometimes caller just pass user setting based value in and it can be zero
@@ -299,6 +301,7 @@ export function showToast(message, time = null, action = null, abortSignal = nul
       abortSignal,
       image,
       icon,
+      buttons,
     }
   }))
 }

--- a/src/renderer/store/modules/settings.js
+++ b/src/renderer/store/modules/settings.js
@@ -249,6 +249,7 @@ const state = {
   ytDlpPath: '',
   ytDlpFfmpegSource: 'system',
   ytDlpFfmpegPath: '',
+  externalSoftwareUpdateMode: 'automatic',
   enableDownloads: true,
   moveDownloadsToAppHeader: false,
   moveSettingsToAppHeader: false,
@@ -658,6 +659,7 @@ export const NON_TRANSFERABLE_SETTINGS = new Set([
   'ytDlpPath',
   'ytDlpFfmpegSource',
   'ytDlpFfmpegPath',
+  'externalSoftwareUpdateMode',
   // DownloadSettings
   'ytDlpDownloadFolderPath',
   // Others

--- a/static/locales/en-US.yaml
+++ b/static/locales/en-US.yaml
@@ -934,6 +934,8 @@ Settings:
     Managed Tools Download Finished Template: 'Finished downloading {tools}'
     Managed Tools Update Started Template: 'An update was found for {tools}. Downloading…'
     Managed Tools Update Finished Template: 'Finished updating {tools}'
+    Managed Tools Update Available Template: 'An update is available for {tools}.'
+    Update Managed Tools: Update
     Managed Tools Download Error Template: 'Could not download the managed tools: {errors}'
     Download Folder: Download Folder
     Choose Download Folder: Choose Download Folder
@@ -999,6 +1001,11 @@ Settings:
     FFmpeg and FFprobe Downloaded Template: FFmpeg and FFprobe {version} have been downloaded
     FFmpeg and FFprobe Download Error Template: 'Downloading FFmpeg and FFprobe failed: {error}'
     Managed Tool Already Current Template: '{tool} {version} is already up to date'
+    Managed Tool Updates: Managed Tool Updates
+    Update Modes:
+      Automatic: Update automatically
+      Ask: Ask before updating
+      Manual: Only update manually
     yt-dlp Executable Path: yt-dlp Executable Path
     FFmpeg Executable Path: FFmpeg Executable Path
   Privacy Settings:
@@ -2090,6 +2097,7 @@ Tooltips:
       Stable is recommended for most users.
     FFmpeg Source: OpenTubeX can either use FFmpeg and FFprobe installed on your system or
       download and manage its own static builds, which are stored in the user data directory.
+    Managed Tool Updates: Choose whether managed tools update automatically, ask before updating, or only update through the manual buttons. Missing tools are still downloaded when required.
     yt-dlp Executable Path: By default, OpenTubeX will assume that yt-dlp can be found via
       the PATH environment variable. If needed, a custom path can be set here.
     FFmpeg Executable Path: FFmpeg is required for merging separate video and audio streams


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Make sure to follow the contributing guidelines. -->
<!-- Important note, we may remove your pull request if you do not use this provided PR template correctly. -->
<!-- Agent instructions: Preserve every heading, comment, and marker in this template. Never remove or rewrite the release-note-category:start/end, release-note:start/end, or release-note-image:start/end marker pairs. Never remove or rewrite the Release note images section; leave its contents for a human. -->

## Pull Request Type
<!-- Please select what type of pull request this is: [x] -->
- [ ] Bugfix
- [x] Feature Implementation
- [ ] Documentation
- [ ] Other

## Related issue
<!-- Please link the issue your pull request is referring to. -->
<!-- If this pull request fully resolves the relevant issue, put "closes" before the issue number. -->
<!-- Example: "closes #123456". -->

Closes #791.

## Description
<!-- Please write a clear and concise description of what the pull request does. -->

Managed yt-dlp and FFmpeg installations previously checked for and installed updates automatically, which could overwrite a version the user intentionally kept. This adds a Managed Tool Updates select with automatic, ask-before-updating, and manual-only modes.

Ask mode checks the existing download validators without downloading the asset and presents an indefinite toast with Cancel and Update actions. The toast stack now supports buttons, keeps indefinite notifications when transient notifications exceed the visible limit, and preserves card dimensions while the stack animates so text does not rewrap.

## Release note category
<!-- Select exactly one category. Every pull request must select one. -->
<!-- Select "Not noteworthy" when the pull request fixes a bug in or improves functionality that has not yet appeared in a stable release. -->
<!-- release-note-category:start -->
- [ ] Not noteworthy
- [ ] Highlights
- [x] More improvements
- [ ] Fixed bugs
<!-- release-note-category:end -->

## Release note
<!-- Required unless "Not noteworthy" is selected. -->
<!-- Write one concise, user-facing entry without a leading bullet. -->
<!-- release-note:start -->
Choose whether managed yt-dlp and FFmpeg tools update automatically, ask before updating, or update only when requested manually.
<!-- release-note:end -->

## Release note images
<!-- Human-only: Agents must preserve this entire section and leave it empty. -->
<!-- Optional. Paste one or more Markdown images or HTML image tags here. -->
<!-- The release notes will use an HTML image tag and limit images taller than 300 pixels. -->
<!-- release-note-image:start -->
<img width="237" height="178" alt="image" src="https://github.com/user-attachments/assets/9f9e0236-373c-4eb6-8bcc-486875b1e62d" />
<!-- release-note-image:end -->

## Testing
<!-- How can reviewers verify that the PR produces correct results? -->
<!-- Please provide instructions so that others can ensure that your pull request would produce correct results. For examples see, https://github.com/FreeTubeApp/FreeTube/pull/5743, https://github.com/FreeTubeApp/FreeTube/pull/7349, https://github.com/FreeTubeApp/FreeTube/pull/5125, https://github.com/FreeTubeApp/FreeTube/pull/7338 -->
<!-- Agent instructions: Only write human-facing steps that explain how to verify the change while running this branch in dev mode. Include expected results and, when applicable, helpful console snippets for interactive verification. Do not include automated checks, commands, results, pass counts, or CI status. -->

1. Open External Software settings and select a managed source. Verify Managed Tool Updates offers Update automatically, Ask before updating, and Only update manually, and that the choice persists after restarting.
2. In DevTools, run:
   ```js
   window.dispatchEvent(new CustomEvent(
     'opentubex:preview-managed-tools-update',
     { detail: ['yt-dlp', 'ffmpeg'] }
   ))
   ```
   Verify an opaque, indefinite update toast appears with working Cancel and Update buttons and no timeout indicator.
3. While that toast is visible, run:
   ```js
   for (let index = 0; index < 8; index++) {
     window.ftElectron.showToastOnAllTabs(`Transient toast ${index}`, 800)
   }
   ```
   Verify the update toast remains available and its message does not rewrap while the transient toasts fan out and animate away.

## Additional context
<!-- Add any other context about the pull request here. -->

Missing managed tools are still downloaded when required, regardless of the selected update mode.
