### PR TITLE
fix(settings): restore built-in extraction default and clarify yt-dlp delay

### DIFF
--- a/e2e/tests/offline/settings.spec.mjs
+++ b/e2e/tests/offline/settings.spec.mjs
@@ -2139,43 +2139,27 @@ test.describe('dark theme settings', () => {
   })
 })
 
-test.describe('playback engine migration', () => {
-  test.use({ seed: { settings: { videoPlaybackEngine: 'built-in' } } })
-
-  test('switches existing users to yt-dlp only once', async ({ app }) => {
-    await expect.poll(async () => {
-      const settings = latestSettings(
-        await readFile(path.join(app.userDataDir, 'settings.db'), 'utf8')
-      )
-      return {
-        engine: settings.videoPlaybackEngine,
-        migrated: settings.ytDlpPlaybackEngineDefaultMigration
-      }
-    }).toEqual({ engine: 'yt-dlp', migrated: true })
-
+test.describe('playback engine default', () => {
+  test('uses the built-in engine for new users', async ({ app }) => {
     await goTo(app.page, 'settings')
-    const generalSection = app.page.locator('[data-section="general"]')
-    const playbackEngine = generalSection.locator('.select').filter({ hasText: 'Stream extraction method' })
-    await expect(playbackEngine.locator('select')).toHaveValue('yt-dlp')
     await expect(
-      app.page.locator('[data-section="experimental"] .select').filter({ hasText: 'Stream extraction method' })
-    ).toHaveCount(0)
-
-    await playbackEngine.locator('select').selectOption('built-in')
-    await expect.poll(async () => {
-      const settings = latestSettings(
-        await readFile(path.join(app.userDataDir, 'settings.db'), 'utf8')
-      )
-      return settings.videoPlaybackEngine
-    }).toBe('built-in')
-
-    const { page } = await app.relaunch()
-    await goTo(page, 'settings')
-    await expect(
-      page.locator('[data-section="general"] .select')
+      app.page.locator('[data-section="general"] .select')
         .filter({ hasText: 'Stream extraction method' })
         .locator('select')
     ).toHaveValue('built-in')
+  })
+})
+
+test.describe('saved playback engine', () => {
+  test.use({ seed: { settings: { videoPlaybackEngine: 'yt-dlp' } } })
+
+  test('preserves the existing user choice', async ({ app }) => {
+    await goTo(app.page, 'settings')
+    await expect(
+      app.page.locator('[data-section="general"] .select')
+        .filter({ hasText: 'Stream extraction method' })
+        .locator('select')
+    ).toHaveValue('yt-dlp')
   })
 })
 
@@ -2213,30 +2197,6 @@ test.describe('Downloads placement migration', () => {
     })
 
     await expect(app.page.locator('.topNav .downloadsButton')).toBeVisible()
-  })
-})
-
-test.describe('playback engine proxy migration', () => {
-  test.use({
-    seed: {
-      settings: {
-        proxyVideos: true,
-        useProxy: false,
-        videoPlaybackEngine: 'built-in'
-      }
-    }
-  })
-
-  test('preserves Invidious media proxying for existing users', async ({ app }) => {
-    await expect.poll(async () => {
-      const settings = latestSettings(
-        await readFile(path.join(app.userDataDir, 'settings.db'), 'utf8')
-      )
-      return {
-        engine: settings.videoPlaybackEngine,
-        migrated: settings.ytDlpPlaybackEngineDefaultMigration
-      }
-    }).toEqual({ engine: 'built-in', migrated: true })
   })
 })
 

--- a/src/renderer/store/modules/settings.js
+++ b/src/renderer/store/modules/settings.js
@@ -25,7 +25,6 @@ import { resolveBaseTheme } from '../../../appearanceSettings.js'
 import { resolveColor } from '../../helpers/colors.js'
 import { DEFAULT_APP_FONT, normalizeAppFont } from '../../helpers/appFont.js'
 
-const YT_DLP_PLAYBACK_ENGINE_MIGRATION_SETTING = 'ytDlpPlaybackEngineDefaultMigration'
 const CHANNEL_SETTINGS_SYNC_MIGRATION_SETTING = 'channelSettingsSyncMigration'
 
 /*
@@ -243,7 +242,7 @@ const state = {
   externalPlayerIgnoreDefaultArgs: false,
   externalPlayerCustomArgs: '[]',
   showAddedExternalPlayerCustomArgs: true,
-  videoPlaybackEngine: 'yt-dlp',
+  videoPlaybackEngine: 'built-in',
   ytDlpSource: 'system',
   ytDlpChannel: 'stable',
   ytDlpPath: '',
@@ -943,28 +942,6 @@ const customActions = {
           await DBSettingHandlers.upsert(CHANNEL_SETTINGS_SYNC_MIGRATION_SETTING, true)
         } catch (error) {
           console.error('Failed to migrate saved channel settings sync', error)
-        }
-      }
-
-      // Switch every existing installation to the new default once, while allowing
-      // users to select the built-in engine again afterwards.
-      const hasMigratedPlaybackEngine = userSettings.some(
-        entry => entry._id === YT_DLP_PLAYBACK_ENGINE_MIGRATION_SETTING
-      )
-      if (!hasMigratedPlaybackEngine) {
-        try {
-          // Invidious media proxying cannot be passed to yt-dlp. Keep the built-in
-          // engine when it is the user's only protection against direct requests.
-          if (!state.proxyVideos || state.useProxy) {
-            await DBSettingHandlers.upsert('videoPlaybackEngine', 'yt-dlp')
-            commit('setVideoPlaybackEngine', 'yt-dlp')
-          }
-
-          // Persist this only after the engine update above succeeds, so a failed
-          // write is retried on the next launch.
-          await DBSettingHandlers.upsert(YT_DLP_PLAYBACK_ENGINE_MIGRATION_SETTING, true)
-        } catch (error) {
-          console.error('Failed to migrate the playback engine to yt-dlp', error)
         }
       }
 

--- a/static/locales/en-US.yaml
+++ b/static/locales/en-US.yaml
@@ -2008,6 +2008,7 @@ Tooltips:
     Update Relative Timestamps: Updates relative timestamps throughout the app while a page remains open. When disabled, they update only after reloading or revisiting the page.
     Stream Extraction Method: |
       Choose how OpenTubeX obtains video streams. yt-dlp must be available when selected.
+      Videos may take longer to start when using yt-dlp.
       Built-in does not support seeking for livestreams and premieres.
     Avoid translation: |
       Disable YouTube's autotranslation of title, description and chapters of a video.


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Make sure to follow the contributing guidelines. -->
<!-- Important note, we may remove your pull request if you do not use this provided PR template correctly. -->
<!-- Agent instructions: Preserve every heading, comment, and marker in this template. Never remove or rewrite the release-note-category:start/end, release-note:start/end, or release-note-image:start/end marker pairs. Never remove or rewrite the Release note images section; leave its contents for a human. -->

## Pull Request Type
<!-- Please select what type of pull request this is: [x] -->
- [x] Bugfix
- [ ] Feature Implementation
- [ ] Documentation
- [ ] Other

## Related issue
<!-- Please link the issue your pull request is referring to. -->
<!-- If this pull request fully resolves the relevant issue, put "closes" before the issue number. -->
<!-- Example: "closes #123456". -->

## Description
<!-- Please write a clear and concise description of what the pull request does. -->
New installations currently select yt-dlp as their stream extraction method, although the built-in extractor should be the default again.

This restores the built-in default and removes the earlier one-time migration to yt-dlp. Existing users keep whichever extraction method they already have saved. The stream extraction help tooltip also notes that yt-dlp may take longer to start videos. The E2E coverage now verifies both a fresh profile and a saved yt-dlp preference.

## Release note category
<!-- Select exactly one category. Every pull request must select one. -->
<!-- Select "Not noteworthy" when the pull request fixes a bug in or improves functionality that has not yet appeared in a stable release. -->
<!-- release-note-category:start -->
- [ ] Not noteworthy
- [ ] Highlights
- [x] More improvements
- [ ] Fixed bugs
<!-- release-note-category:end -->

## Release note
<!-- Required unless "Not noteworthy" is selected. -->
<!-- Write one concise, user-facing entry without a leading bullet. -->
<!-- release-note:start -->
New installations use the built-in stream extraction method by default again, with clearer guidance about yt-dlp startup time.
<!-- release-note:end -->

## Release note images
<!-- Human-only: Agents must preserve this entire section and leave it empty. -->
<!-- Optional. Paste one or more Markdown images or HTML image tags here. -->
<!-- The release notes will use an HTML image tag and limit images taller than 300 pixels. -->
<!-- release-note-image:start -->

<!-- release-note-image:end -->

## Testing
<!-- How can reviewers verify that the PR produces correct results? -->
<!-- Please provide instructions so that others can ensure that your pull request produces correct results. For examples see, https://github.com/FreeTubeApp/FreeTube/pull/5743, https://github.com/FreeTubeApp/FreeTube/pull/7349, https://github.com/FreeTubeApp/FreeTube/pull/5125, https://github.com/FreeTubeApp/FreeTube/pull/7338 -->
<!-- Agent instructions: Only write human-facing steps that explain how to verify the change while running this branch in dev mode. Include expected results and, when applicable, helpful console snippets for interactive verification. Do not include automated checks, commands, results, pass counts, or CI status. -->
1. Start the app with a fresh user-data directory and open General Settings. Confirm that Stream extraction method is set to Built-in.
2. Select yt-dlp, restart the app with the same user-data directory, and confirm that yt-dlp remains selected.
3. Start the app with an existing profile that already has either method saved and confirm that its selection is unchanged.
4. Open the help tooltip next to Stream extraction method and confirm that it notes videos may take longer to start with yt-dlp.

## Additional context
<!-- Add any other context about the pull request here. -->
No reverse migration is included because the default change should only affect new users.
