### PR TITLE
fix(ui): keep search selection highlights compact

### DIFF
--- a/e2e/tests/offline/appearance.spec.mjs
+++ b/e2e/tests/offline/appearance.spec.mjs
@@ -418,6 +418,7 @@ test.describe('custom theme editor', () => {
       const selectionStyle = getComputedStyle(document.body, '::selection')
       return [selectionStyle.backgroundColor, selectionStyle.color]
     })).toEqual(['rgb(52, 86, 120)', 'rgb(254, 220, 186)'])
+    await expect(page.locator('.topNav .searchInput .ft-input')).toHaveCSS('line-height', '20px')
     await setEditorColor('Page background', '#101112')
     await sourceMainColor.click()
     await page.locator(`#${await sourceMainColor.getAttribute('aria-controls')}`)

--- a/src/renderer/components/FtInput/FtInput.css
+++ b/src/renderer/components/FtInput/FtInput.css
@@ -153,9 +153,14 @@ body[dir='rtl'] .ft-input-component.search.showClearTextButton:focus-within .inp
 
 .search .ft-input {
   display: block;
-  padding-block: 0 var(--search-input-padding-block-end, 0);
+
+  /* Keep themed text selection close to the glyphs while the padding centers
+     the line and compensates for taller fallback fonts. */
+  padding-block:
+    var(--search-input-padding-block-start, 12.5px)
+    var(--search-input-padding-block-end, 12.5px);
   font-family: inherit;
-  line-height: var(--search-input-line-height, 45px);
+  line-height: 20px;
   margin-block-end: 0;
 }
 

--- a/src/renderer/components/FtInput/FtInput.vue
+++ b/src/renderer/components/FtInput/FtInput.vue
@@ -266,11 +266,11 @@ const inputTextStyle = computed(() => {
   if (!props.isSearch) return null
 
   const offset = getInputTextAscentOffset(inputDataDisplayed.value)
-  const paddingBlockEnd = offset * 2
+  const centeredPadding = (45 - 20) / 2
 
   return {
-    '--search-input-padding-block-end': `${paddingBlockEnd}px`,
-    '--search-input-line-height': `${45 - paddingBlockEnd}px`
+    '--search-input-padding-block-start': `${centeredPadding - offset}px`,
+    '--search-input-padding-block-end': `${centeredPadding + offset}px`
   }
 })
 


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Make sure to follow the contributing guidelines. -->
<!-- Important note, we may remove your pull request if you do not use this provided PR template correctly. -->
<!-- Agent instructions: Preserve every heading, comment, and marker in this template. Never remove or rewrite the release-note-category:start/end, release-note:start/end, or release-note-image:start/end marker pairs. Never remove or rewrite the Release note images section; leave its contents for a human. -->

## Pull Request Type
<!-- Please select what type of pull request this is: [x] -->
- [x] Bugfix
- [ ] Feature Implementation
- [ ] Documentation
- [ ] Other

## Related issue
<!-- Please link the issue your pull request is referring to. -->
<!-- If this pull request fully resolves the relevant issue, put "closes" before the issue number. -->
<!-- Example: "closes #123456". -->

Follow-up to #792.

## Description
<!-- Please write a clear and concise description of what the pull request does. -->

The themed `::selection` background added in #792 exposed that search inputs use their full 45px line box to center text. Chromium consequently painted selected text across the full height of the search field.

This keeps a compact 20px text line box and centers it with block padding instead. The existing measured offset for taller fallback-font glyphs is preserved through asymmetric padding, so only the selection highlight height changes.

## Release note category
<!-- Select exactly one category. Every pull request must select one. -->
<!-- Select "Not noteworthy" when the pull request fixes a bug in or improves functionality that has not yet appeared in a stable release. -->
<!-- release-note-category:start -->
- [x] Not noteworthy
- [ ] Highlights
- [ ] More improvements
- [ ] Fixed bugs
<!-- release-note-category:end -->

## Release note
<!-- Required unless "Not noteworthy" is selected. -->
<!-- Write one concise, user-facing entry without a leading bullet. -->
<!-- release-note:start -->

<!-- release-note:end -->

## Release note images
<!-- Human-only: Agents must preserve this entire section and leave it empty. -->
<!-- Optional. Paste one or more Markdown images or HTML image tags here. -->
<!-- The release notes will use an HTML image tag and limit images taller than 300 pixels. -->
<!-- release-note-image:start -->

<!-- release-note-image:end -->

## Testing
<!-- How can reviewers verify that the PR produces correct results? -->
<!-- Please provide instructions so that others can ensure that the pull request produces correct results. For examples see, https://github.com/FreeTubeApp/FreeTube/pull/5743, https://github.com/FreeTubeApp/FreeTube/pull/7349, https://github.com/FreeTubeApp/FreeTube/pull/5125, https://github.com/FreeTubeApp/FreeTube/pull/7338 -->
<!-- Agent instructions: Only write human-facing steps that explain how to verify the change while running this branch in dev mode. Include expected results and, when applicable, helpful console snippets for interactive verification. Do not include automated checks, commands, results, pass counts, or CI status. -->

1. Apply a custom theme with a conspicuous “Selected text background” color.
2. Enter text in the header search bar and select it.
3. Confirm the highlight closely follows the text height instead of filling the 45px search field.
4. Enter text containing emoji or glyphs from a taller fallback font and confirm it remains vertically aligned in the search field.

## Additional context
<!-- Add any other context about the pull request here. -->

The compact line box and its two padding values still total the existing 45px control height.
