### PR TITLE
feat(downloads): support global yt-dlp arguments

### DIFF
--- a/e2e/tests/offline/download-settings.spec.mjs
+++ b/e2e/tests/offline/download-settings.spec.mjs
@@ -58,6 +58,43 @@ test.use({
 })
 
 test.describe('download settings', () => {
+  test('stores global yt-dlp arguments and centers wrapped download actions', async ({ app, page }) => {
+    await goToSettingsSection(page, 'download')
+
+    const globalArguments = page.getByRole('textbox', { name: 'Global Additional yt-dlp Arguments' })
+    await globalArguments.fill('--cookies-from-browser firefox')
+    await expect.poll(() => page.evaluate(() => {
+      const store = document.querySelector('#app').__vue_app__.config.globalProperties.$store
+      return store.getters.getYtDlpDownloadCustomArgs
+    })).toBe('--cookies-from-browser firefox')
+
+    await page.getByRole('button', { name: 'Maximize' }).click()
+    await setWindowSize(app, page, { width: 1501, height: 751 })
+    const actions = page.locator('.downloadActions')
+    await expect.poll(() => actions.locator('.btn').evaluateAll(buttons => (
+      new Set(buttons.map(button => button.offsetTop)).size
+    ))).toBe(1)
+
+    await setWindowSize(app, page, { width: 701, height: 801 })
+    const wrappedGeometry = await actions.evaluate(element => {
+      const container = element.getBoundingClientRect()
+      const buttons = [...element.querySelectorAll('.btn')].map(button => button.getBoundingClientRect())
+      return {
+        containerCenter: container.x + container.width / 2,
+        centers: buttons.map(button => button.x + button.width / 2),
+        tops: buttons.map(button => button.y),
+        actionsBottom: container.bottom
+      }
+    })
+    expect(wrappedGeometry.tops[0]).toBeCloseTo(wrappedGeometry.tops[1], 0)
+    expect(wrappedGeometry.tops[2]).toBeGreaterThan(wrappedGeometry.tops[0])
+    expect(wrappedGeometry.centers[2]).toBeCloseTo(wrappedGeometry.containerCenter, 0)
+
+    const inputsTop = await page.getByRole('textbox', { name: 'Download Folder' })
+      .evaluate(element => element.getBoundingClientRect().top)
+    expect(inputsTop - wrappedGeometry.actionsBottom).toBeGreaterThanOrEqual(20)
+  })
+
   test('creates templates from built-in and custom templates', async ({ page }) => {
     await goToSettingsSection(page, 'download')
 

--- a/e2e/tests/offline/video-actions.spec.mjs
+++ b/e2e/tests/offline/video-actions.spec.mjs
@@ -202,6 +202,11 @@ test.describe('video downloads', () => {
 
     await expect(page.getByText('Download failed', { exact: true })).toBeVisible()
     await expect(page.locator('.downloadProgressBarTrack')).toHaveCount(0)
+    const separatorSpacing = await page.locator('.downloadPromptContent').evaluate(prompt => ({
+      above: Number.parseFloat(getComputedStyle(prompt.querySelector('.downloadProgress')).paddingBottom),
+      below: Number.parseFloat(getComputedStyle(prompt.querySelector('.downloadFooter')).paddingTop)
+    }))
+    expect(separatorSpacing.below).toBe(separatorSpacing.above)
   })
 
   test('can retry playback extraction with yt-dlp default clients', async ({ app, page }) => {
@@ -296,6 +301,48 @@ test.describe('video downloads', () => {
       customArgs
     }))), customArguments)
     expect(results).toEqual(customArguments.map(() => ({ error: 'unsupported-custom-argument' })))
+  })
+
+  test('applies global custom arguments before per-download arguments', async ({ app, page }) => {
+    const executable = path.join(app.userDataDir, 'capture-global-yt-dlp-args.sh')
+    const capturedArgs = path.join(app.userDataDir, 'captured-global-yt-dlp-args.txt')
+    await writeFile(executable, `#!/bin/sh\nprintf '%s\\n' "$@" > "${capturedArgs}"\n`)
+    await chmod(executable, 0o755)
+    await page.evaluate(async ({ ytDlpPath, globalArgs }) => {
+      const store = document.querySelector('#app').__vue_app__.config.globalProperties.$store
+      await store.dispatch('updateYtDlpPath', ytDlpPath)
+      await store.dispatch('updateYtDlpDownloadCustomArgs', globalArgs)
+    }, {
+      ytDlpPath: executable,
+      globalArgs: '--cookies-from-browser "firefox:default-release" --format webm'
+    })
+
+    await page.bringToFront()
+    await page.evaluate(() => window.ftElectron.ytDlpDownload({
+      videoId: 'eeeeeeeeeee',
+      mode: 'video',
+      customArgs: '--format mp4'
+    }))
+
+    await expect.poll(async () => readFile(capturedArgs, 'utf8').catch(() => '')).toContain('--cookies-from-browser')
+    const passedArguments = (await readFile(capturedArgs, 'utf8')).trim().split('\n')
+    const formatIndexes = passedArguments
+      .map((argument, index) => argument === '--format' ? index : -1)
+      .filter(index => index >= 0)
+    expect(passedArguments[passedArguments.indexOf('--cookies-from-browser') + 1]).toBe('firefox:default-release')
+    expect(passedArguments[formatIndexes[0] + 1]).toBe('webm')
+    expect(passedArguments[formatIndexes[1] + 1]).toBe('mp4')
+    expect(formatIndexes[1]).toBeGreaterThan(formatIndexes[0])
+
+    await page.evaluate(async () => {
+      const store = document.querySelector('#app').__vue_app__.config.globalProperties.$store
+      await store.dispatch('updateYtDlpDownloadCustomArgs', '--exec "echo unsafe"')
+    })
+    await page.bringToFront()
+    expect(await page.evaluate(() => window.ftElectron.ytDlpDownload({
+      videoId: 'eeeeeeeeeee',
+      mode: 'video'
+    }))).toEqual({ error: 'unsupported-custom-argument' })
   })
 
   test('escapes percent signs in local playlist folder names', async ({ app, page }) => {

--- a/e2e/tests/offline/video-actions.spec.mjs
+++ b/e2e/tests/offline/video-actions.spec.mjs
@@ -303,7 +303,7 @@ test.describe('video downloads', () => {
     expect(results).toEqual(customArguments.map(() => ({ error: 'unsupported-custom-argument' })))
   })
 
-  test('applies global custom arguments before per-download arguments', async ({ app, page }) => {
+  test('applies global custom arguments before download-specific arguments', async ({ app, page }) => {
     const executable = path.join(app.userDataDir, 'capture-global-yt-dlp-args.sh')
     const capturedArgs = path.join(app.userDataDir, 'captured-global-yt-dlp-args.txt')
     await writeFile(executable, `#!/bin/sh\nprintf '%s\\n' "$@" > "${capturedArgs}"\n`)
@@ -314,13 +314,14 @@ test.describe('video downloads', () => {
       await store.dispatch('updateYtDlpDownloadCustomArgs', globalArgs)
     }, {
       ytDlpPath: executable,
-      globalArgs: '--cookies-from-browser "firefox:default-release" --format webm'
+      globalArgs: '--cookies-from-browser "firefox:default-release" --merge-output-format webm --format webm'
     })
 
     await page.bringToFront()
     await page.evaluate(() => window.ftElectron.ytDlpDownload({
       videoId: 'eeeeeeeeeee',
       mode: 'video',
+      videoFormat: 'mp4',
       customArgs: '--format mp4'
     }))
 
@@ -330,6 +331,12 @@ test.describe('video downloads', () => {
       .map((argument, index) => argument === '--format' ? index : -1)
       .filter(index => index >= 0)
     expect(passedArguments[passedArguments.indexOf('--cookies-from-browser') + 1]).toBe('firefox:default-release')
+    const mergeFormatIndexes = passedArguments
+      .map((argument, index) => argument === '--merge-output-format' ? index : -1)
+      .filter(index => index >= 0)
+    expect(passedArguments[mergeFormatIndexes[0] + 1]).toBe('webm')
+    expect(passedArguments[mergeFormatIndexes[1] + 1]).toBe('mp4')
+    expect(mergeFormatIndexes[1]).toBeGreaterThan(mergeFormatIndexes[0])
     expect(passedArguments[formatIndexes[0] + 1]).toBe('webm')
     expect(passedArguments[formatIndexes[1] + 1]).toBe('mp4')
     expect(formatIndexes[1]).toBeGreaterThan(formatIndexes[0])

--- a/src/main/ytDlp.js
+++ b/src/main/ytDlp.js
@@ -1495,10 +1495,14 @@ async function startYtDlpDownload(
     ? payload.subtitleFormat
     : ''
 
+  const globalCustomArgsSetting = (await settings._findOne('ytDlpDownloadCustomArgs'))?.value
+  const globalCustomArgs = typeof globalCustomArgsSetting === 'string' && globalCustomArgsSetting.trim() !== ''
+    ? splitArguments(globalCustomArgsSetting)
+    : []
   const customArgs = typeof payload.customArgs === 'string' && payload.customArgs.trim() !== ''
     ? splitArguments(payload.customArgs)
     : []
-  if (customArgs.some(argument => DENIED_CUSTOM_ARGS.includes(argument.split('=')[0]))) {
+  if ([...globalCustomArgs, ...customArgs].some(argument => DENIED_CUSTOM_ARGS.includes(argument.split('=')[0]))) {
     return { error: 'unsupported-custom-argument' }
   }
 
@@ -1696,9 +1700,7 @@ async function startYtDlpDownload(
   if (startTime !== '' || endTime !== '') {
     args.push('--download-sections', `*${startTime || '0'}-${endTime || 'inf'}`, '--force-keyframes-at-cuts')
   }
-  if (customArgs.length > 0) {
-    args.push(...customArgs)
-  }
+  args.push(...globalCustomArgs, ...customArgs)
 
   if (isRemotePlaylist) {
     args.push(`https://www.youtube.com/playlist?list=${payload.playlistId}`)

--- a/src/main/ytDlp.js
+++ b/src/main/ytDlp.js
@@ -1549,6 +1549,7 @@ async function startYtDlpDownload(
   }
 
   await pushProxyArgument(args)
+  args.push(...globalCustomArgs)
 
   const ffmpeg = await resolveExecutable('ytDlpFfmpegSource', 'ytDlpFfmpegPath', 'ffmpeg')
 
@@ -1700,7 +1701,7 @@ async function startYtDlpDownload(
   if (startTime !== '' || endTime !== '') {
     args.push('--download-sections', `*${startTime || '0'}-${endTime || 'inf'}`, '--force-keyframes-at-cuts')
   }
-  args.push(...globalCustomArgs, ...customArgs)
+  args.push(...customArgs)
 
   if (isRemotePlaylist) {
     args.push(`https://www.youtube.com/playlist?list=${payload.playlistId}`)

--- a/src/renderer/components/AutomaticDownloadSettings/AutomaticDownloadSettings.vue
+++ b/src/renderer/components/AutomaticDownloadSettings/AutomaticDownloadSettings.vue
@@ -1,11 +1,9 @@
 <template>
-  <FtFlexBox>
-    <FtButton
-      :label="t('Settings.Download Settings.Manage Automatic Downloads', { channelCount: enabledRuleCount })"
-      :icon="['fas', 'download']"
-      @click="showManager = true"
-    />
-  </FtFlexBox>
+  <FtButton
+    :label="t('Settings.Download Settings.Manage Automatic Downloads', { channelCount: enabledRuleCount })"
+    :icon="['fas', 'download']"
+    @click="showManager = true"
+  />
   <FtSettingsSubpage
     :open="showManager"
     :title="t('Settings.Download Settings.Automatic Downloads')"
@@ -189,7 +187,6 @@ import { computed, nextTick, onBeforeUnmount, ref, useTemplateRef, watch } from 
 import { useI18n } from 'vue-i18n'
 
 import FtButton from '../FtButton/FtButton.vue'
-import FtFlexBox from '../ft-flex-box/ft-flex-box.vue'
 import FtInput from '../FtInput/FtInput.vue'
 import FtSelect from '../FtSelect/FtSelect.vue'
 import FtSettingsSubpage from '../FtSettingsSubpage/FtSettingsSubpage.vue'

--- a/src/renderer/components/DownloadSettings.vue
+++ b/src/renderer/components/DownloadSettings.vue
@@ -11,15 +11,18 @@
         @change="updateEnableDownloads"
       />
     </FtFlexBox>
-    <FtFlexBox v-if="enableDownloads">
+    <FtFlexBox
+      v-if="enableDownloads"
+      class="downloadActions"
+    >
       <FtButton
         :label="t('Downloads.Open Downloads')"
         :icon="['fas', 'download']"
         @click="openDownloads"
       />
+      <DownloadTemplateSettings />
+      <AutomaticDownloadSettings />
     </FtFlexBox>
-    <DownloadTemplateSettings v-if="enableDownloads" />
-    <AutomaticDownloadSettings v-if="enableDownloads" />
     <FtFlexBox
       v-if="enableDownloads"
       class="downloadPathInputs settingsFlexStart460px"
@@ -34,6 +37,14 @@
         :tooltip="t('Tooltips.Download Settings.Download Folder')"
         @input="updateYtDlpDownloadFolderPath"
         @click="chooseDownloadFolder"
+      />
+      <FtInput
+        :placeholder="t('Settings.Download Settings.Global Additional yt-dlp Arguments')"
+        :show-action-button="false"
+        :show-label="true"
+        :value="ytDlpDownloadCustomArgs"
+        :tooltip="t('Tooltips.Download Settings.Global Additional yt-dlp Arguments')"
+        @input="updateYtDlpDownloadCustomArgs"
       />
     </FtFlexBox>
   </FtSettingsSection>
@@ -61,6 +72,9 @@ const enableDownloads = computed(() => store.getters.getEnableDownloads)
 /** @type {import('vue').ComputedRef<string>} */
 const ytDlpDownloadFolderPath = computed(() => store.getters.getYtDlpDownloadFolderPath)
 
+/** @type {import('vue').ComputedRef<string>} */
+const ytDlpDownloadCustomArgs = computed(() => store.getters.getYtDlpDownloadCustomArgs)
+
 /**
  * @param {boolean} value
  */
@@ -79,6 +93,13 @@ function updateYtDlpDownloadFolderPath(value) {
   store.dispatch('updateYtDlpDownloadFolderPath', value)
 }
 
+/**
+ * @param {string} value
+ */
+function updateYtDlpDownloadCustomArgs(value) {
+  store.dispatch('updateYtDlpDownloadCustomArgs', value)
+}
+
 async function chooseDownloadFolder() {
   const path = await window.ftElectron.ytDlpChooseDownloadFolder(ytDlpDownloadFolderPath.value)
 
@@ -89,6 +110,22 @@ async function chooseDownloadFolder() {
 </script>
 
 <style scoped>
+.downloadActions {
+  align-items: stretch;
+  gap: 10px;
+  justify-content: center;
+  margin-block-end: 20px;
+}
+
+.downloadActions :deep(.btn) {
+  flex: 1 1 230px;
+  inline-size: 100%;
+  max-inline-size: 340px;
+  block-size: auto;
+  margin: 0;
+  white-space: normal;
+}
+
 .downloadPathInputs {
   column-gap: 12px;
 }

--- a/src/renderer/components/DownloadTemplateSettings/DownloadTemplateSettings.vue
+++ b/src/renderer/components/DownloadTemplateSettings/DownloadTemplateSettings.vue
@@ -1,11 +1,9 @@
 <template>
-  <FtFlexBox>
-    <FtButton
-      :label="t('Settings.Download Settings.Manage Download Templates', { templateCount: customTemplates.length })"
-      :icon="['fas', 'save']"
-      @click="openManager"
-    />
-  </FtFlexBox>
+  <FtButton
+    :label="t('Settings.Download Settings.Manage Download Templates', { templateCount: customTemplates.length })"
+    :icon="['fas', 'save']"
+    @click="openManager"
+  />
   <FtSettingsSubpage
     :open="showManager"
     :title="t('Settings.Download Settings.Download Templates')"

--- a/src/renderer/components/WatchVideoDownloadPrompt/WatchVideoDownloadPrompt.css
+++ b/src/renderer/components/WatchVideoDownloadPrompt/WatchVideoDownloadPrompt.css
@@ -149,6 +149,10 @@
   padding-inline: 12px;
 }
 
+.activeDownloadFooter {
+  padding-block-start: 30px;
+}
+
 .downloadFolderRow {
   align-items: center;
   display: flex;

--- a/src/renderer/components/WatchVideoDownloadPrompt/WatchVideoDownloadPrompt.vue
+++ b/src/renderer/components/WatchVideoDownloadPrompt/WatchVideoDownloadPrompt.vue
@@ -241,7 +241,10 @@
         </p>
       </div>
 
-      <footer class="downloadFooter">
+      <footer
+        class="downloadFooter"
+        :class="{ activeDownloadFooter: activeDownload !== null }"
+      >
         <p class="downloadFolderRow">
           <FtIcon :icon="['fas', 'folder-open']" />
           <span>{{ downloadFolderDisplay }}</span>

--- a/src/renderer/store/modules/settings.js
+++ b/src/renderer/store/modules/settings.js
@@ -253,6 +253,7 @@ const state = {
   moveDownloadsToAppHeader: false,
   moveSettingsToAppHeader: false,
   ytDlpDownloadFolderPath: '',
+  ytDlpDownloadCustomArgs: '',
   ytDlpDownloadTemplates: '[]',
   ytDlpSelectedTemplate: 'video:best',
   ytDlpAutomaticDownloadRules: '{}',
@@ -660,6 +661,7 @@ export const NON_TRANSFERABLE_SETTINGS = new Set([
   'ytDlpFfmpegPath',
   // DownloadSettings
   'ytDlpDownloadFolderPath',
+  'ytDlpDownloadCustomArgs',
   // Others
   'disableSmoothScrolling',
   'hideToTrayOnMinimize',

--- a/static/locales/en-US.yaml
+++ b/static/locales/en-US.yaml
@@ -936,6 +936,7 @@ Settings:
     Managed Tools Update Finished Template: 'Finished updating {tools}'
     Managed Tools Download Error Template: 'Could not download the managed tools: {errors}'
     Download Folder: Download Folder
+    Global Additional yt-dlp Arguments: Global Additional yt-dlp Arguments
     Choose Download Folder: Choose Download Folder
     External Software Hint: yt-dlp, FFmpeg, and FFprobe are configured in the External Software settings.
     Download Templates: Download Templates
@@ -2083,6 +2084,7 @@ Tooltips:
     DefaultCustomArgumentsTemplate: "(Default: '{defaultCustomArguments}')"
   Download Settings:
     Download Folder: Videos are saved to this folder. Leave blank to use your system's Downloads folder.
+    Global Additional yt-dlp Arguments: Additional command line arguments passed to yt-dlp for every download, for example --cookies-from-browser firefox.
   External Software Settings:
     yt-dlp Source: OpenTubeX can either use the yt-dlp installed on your system or download
       and manage its own copy of yt-dlp, which is stored in the user data directory.


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Make sure to follow the contributing guidelines. -->
<!-- Important note, we may remove your pull request if you do not use this provided PR template correctly. -->
<!-- Agent instructions: Preserve every heading, comment, and marker in this template. Never remove or rewrite the release-note-category:start/end, release-note:start/end, or release-note-image:start/end marker pairs. Never remove or rewrite the Release note images section; leave its contents for a human. -->

## Pull Request Type
<!-- Please select what type of pull request this is: [x] -->
- [ ] Bugfix
- [x] Feature Implementation
- [ ] Documentation
- [ ] Other

## Related issue
<!-- Please link the issue your pull request is referring to. -->
<!-- If this pull request fully resolves the relevant issue, put "closes" before the issue number. -->
<!-- Example: "closes #123456". -->

## Description
<!-- Please write a clear and concise description of what the pull request does. -->
Downloads could only add reusable yt-dlp arguments through individual templates, which made device-wide options such as browser cookies repetitive to configure.

This adds a device-specific global yt-dlp arguments field to Download Settings. Global arguments are validated with the existing custom-argument safety restrictions and are applied before template or per-download arguments so individual downloads can still override them. The download action buttons now share a responsive, centered row, and the active download modal uses balanced spacing around its footer separator.

## Release note category
<!-- Select exactly one category. Every pull request must select one. -->
<!-- Select "Not noteworthy" when the pull request fixes a bug in or improves functionality that has not yet appeared in a stable release. -->
<!-- release-note-category:start -->
- [ ] Not noteworthy
- [ ] Highlights
- [x] More improvements
- [ ] Fixed bugs
<!-- release-note-category:end -->

## Release note
<!-- Required unless "Not noteworthy" is selected. -->
<!-- Write one concise, user-facing entry without a leading bullet. -->
<!-- release-note:start -->
Added a Download setting for yt-dlp arguments that should apply to every download.
<!-- release-note:end -->

## Release note images
<!-- Human-only: Agents must preserve this entire section and leave it empty. -->
<!-- Optional. Paste one or more Markdown images or HTML image tags here. -->
<!-- The release notes will use an HTML image tag and limit images taller than 300 pixels. -->
<!-- release-note-image:start -->
<img width="391" height="101" alt="image" src="https://github.com/user-attachments/assets/3f1c3e0b-fbf0-44b0-a250-109201ae2277" />
<!-- release-note-image:end -->

## Testing
<!-- How can reviewers verify that the PR produces correct results? -->
<!-- Please provide instructions so that others can ensure that your pull request would produce correct results. For examples see, https://github.com/FreeTubeApp/FreeTube/pull/5743, https://github.com/FreeTubeApp/FreeTube/pull/7349, https://github.com/FreeTubeApp/FreeTube/pull/5125, https://github.com/FreeTubeApp/FreeTube/pull/7338 -->
<!-- Agent instructions: Only write human-facing steps that explain how to verify the change while running this branch in dev mode. Include expected results and, when applicable, helpful console snippets for interactive verification. Do not include automated checks, commands, results, pass counts, or CI status. -->
1. Open Settings > Downloads and enter `--cookies-from-browser firefox` in Global Additional yt-dlp Arguments.
2. Start a download and confirm yt-dlp receives the configured browser-cookie arguments.
3. Add a conflicting option to a download template and confirm the template option is passed after the global option.
4. Resize the Downloads settings page and confirm the three action buttons use one row when space permits and center the final row when they wrap.
5. Start a download and confirm the footer separator has equal spacing above and below it.

## Additional context
<!-- Add any other context about the pull request here. -->
The new setting is not exported or synced because browser profiles and cookie paths are device-specific.
