### PR TITLE
feat(player): skip silent sections instead of fast-forwarding

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ endorsed by, maintained by, or supported by the FreeTube project.
 OpenTubeX is aimed at users who want extensive control over their viewing
 experience. Some of its major areas of focus are:
 
-- **More playback control**, including per-channel speed and quality preferences, customizable shortcuts, a quick speed bar and fast-forwarding through silence.
+- **More playback control**, including per-channel speed and quality preferences, customizable shortcuts, a quick speed bar and silence skipping.
 - **A browser-style desktop workflow** with tabs, configurable session restoration, multiple windows, a scroll mini-player and a watch queue.
 - **Deeper SponsorBlock integration** with a segment side panel, richer skip controls, channel whitelisting, submissions and full-video labels.
 - **More ways to manage and understand your library** through watch-time statistics, configurable history retention, enhanced subscription refreshes and advanced search history.
@@ -162,7 +162,7 @@ experience. Some of its major areas of focus are:
 - Transcript panel
 <img height="200" alt="image" src="https://github.com/user-attachments/assets/f69a2074-746d-4afe-bee5-9828040f048e" />
 
-- Fast-forward through silence (needs to be enabled via Player settings)
+- Skip silence (needs to be enabled via Player settings)
 <img width="264" height="59" alt="image" src="https://github.com/user-attachments/assets/7886468c-0f08-4ebb-9cfd-2ce07a4230f5" />
 
 - Support for YouTube end-screen annotations

--- a/e2e/tests/network/skip-silence.spec.mjs
+++ b/e2e/tests/network/skip-silence.spec.mjs
@@ -1,0 +1,63 @@
+import { test, expect } from '../../helpers/innertube.mjs'
+import { activeTab, openVideoOrSkip, waitForPlaybackOrSkip } from '../../helpers/player.mjs'
+
+const VIDEO = {
+  id: 'erWLQ0uHQkg',
+  title: 'silence fast forward test v2',
+  url: 'https://www.youtube.com/watch?v=erWLQ0uHQkg'
+}
+
+test.use({
+  seed: {
+    settings: {
+      showSkipSilenceButton: true,
+      keyboardShortcuts: JSON.stringify({
+        VIDEO_PLAYER: {
+          PLAYBACK: {
+            TOGGLE_SKIP_SILENCE: 'h'
+          }
+        }
+      })
+    }
+  }
+})
+
+test('jumps to the end of silence without changing playback rate', async ({ page, innertube }) => {
+  test.skip(innertube.replay, 'needs the adaptive audio segments of the real API')
+
+  await openVideoOrSkip(test, page, VIDEO)
+  const video = await waitForPlaybackOrSkip(test, page)
+  await video.evaluate(element => {
+    window.__skipSilenceJumps = []
+    window.__skipSilenceRates = [element.playbackRate]
+    let lastTime = element.currentTime
+    element.addEventListener('timeupdate', () => {
+      lastTime = element.currentTime
+    })
+    element.addEventListener('seeking', () => {
+      window.__skipSilenceJumps.push(element.currentTime - lastTime)
+    })
+    element.addEventListener('ratechange', () => {
+      window.__skipSilenceRates.push(element.playbackRate)
+    })
+  })
+
+  await page.locator(`${activeTab} .ftVideoPlayer`).press('h')
+  await expect.poll(() => page.evaluate(() => {
+    const store = document.querySelector('#app').__vue_app__.config.globalProperties.$store
+    return store.getters.getTabSkipSilence(store.getters.getActiveTabId)
+  })).toBe(true)
+
+  await expect.poll(() => page.evaluate(() => Math.max(0, ...window.__skipSilenceJumps)), {
+    timeout: 30_000,
+    intervals: [500]
+  }).toBeGreaterThan(2)
+  await expect.poll(() => video.evaluate(element => element.playbackRate)).toBe(1)
+
+  const { jumps, rates } = await page.evaluate(() => ({
+    jumps: window.__skipSilenceJumps,
+    rates: window.__skipSilenceRates
+  }))
+  expect(jumps.filter(jump => jump > 0.1)).toHaveLength(1)
+  expect(rates.every(rate => rate === 1)).toBe(true)
+})

--- a/e2e/tests/offline/player.spec.mjs
+++ b/e2e/tests/offline/player.spec.mjs
@@ -124,6 +124,20 @@ test('keyboard shortcuts change the playback rate', async ({ app, page, attachSc
   await attachScreenshot('playback rate lowered')
 })
 
+test('playback rate shortcuts use the normal rate while hold-to-double is active', async ({ app, page }) => {
+  const video = await openDemoVideo({ app, page })
+
+  await expect.poll(() => video.evaluate(element => element.playbackRate)).toBe(1)
+  await page.keyboard.down('Space')
+  try {
+    await expect.poll(() => video.evaluate(element => element.playbackRate)).toBe(2)
+    await page.locator('body').press('p')
+    await expect.poll(() => video.evaluate(element => element.playbackRate)).toBe(1.25)
+  } finally {
+    await page.keyboard.up('Space')
+  }
+})
+
 test('keeps video zoom within its tab', async ({ app, page, attachScreenshot }) => {
   const video = await openDemoVideo({ app, page })
 

--- a/e2e/tests/offline/player.spec.mjs
+++ b/e2e/tests/offline/player.spec.mjs
@@ -643,7 +643,7 @@ test.describe('scroll mini player', () => {
   })
 })
 
-test.describe('fast-forward through silence shortcut', () => {
+test.describe('skip silence shortcut', () => {
   test.use({
     seed: {
       settings: {

--- a/e2e/tests/offline/settings.spec.mjs
+++ b/e2e/tests/offline/settings.spec.mjs
@@ -14,6 +14,22 @@ import {
   waitForAppReady
 } from '../../helpers/app.mjs'
 
+test.describe('skip silence settings search', () => {
+  test.use({ seed: { settings: { currentLocale: 'en-US' } } })
+
+  test('opens and highlights the visibility toggle', async ({ page }) => {
+    await goTo(page, 'settings')
+    const search = page.getByRole('searchbox', { name: 'Search settings' })
+
+    await search.fill('Skip Silence')
+    await page.getByRole('button', { name: 'Show Skip Silence Toggle', exact: true }).click()
+
+    await expect(page.locator('.switch-ctn.settingsSearchTarget'))
+      .toContainText('Show Skip Silence Toggle')
+    await expect(page.locator('.section.settingsSearchTarget')).toHaveCount(0)
+  })
+})
+
 test.describe('settings', () => {
   test('groups confirmation preferences together', async ({ page }) => {
     await goTo(page, 'settings')

--- a/src/renderer/components/FtKeyboardShortcutPrompt/FtKeyboardShortcutPrompt.vue
+++ b/src/renderer/components/FtKeyboardShortcutPrompt/FtKeyboardShortcutPrompt.vue
@@ -379,7 +379,7 @@ const localizedShortcutNameToShortcutsMappings = computed(() => {
     [t('KeyboardShortcutPrompt.Decrease Video Speed'), ['DECREASE_VIDEO_SPEED', 'DECREASE_VIDEO_SPEED_ALT']],
     [t('KeyboardShortcutPrompt.Increase Video Speed'), ['INCREASE_VIDEO_SPEED', 'INCREASE_VIDEO_SPEED_ALT']],
     [t('KeyboardShortcutPrompt.Toggle Normal Playback Speed'), ['TOGGLE_NORMAL_PLAYBACK_SPEED']],
-    [t('KeyboardShortcutPrompt.Toggle Fast-Forward Through Silence'), ['TOGGLE_SKIP_SILENCE']],
+    [t('KeyboardShortcutPrompt.Toggle Skip Silence'), ['TOGGLE_SKIP_SILENCE']],
     [t('KeyboardShortcutPrompt.Home'), ['HOME']],
     [t('KeyboardShortcutPrompt.End'), ['END']],
     [t('KeyboardShortcutPrompt.Skip by Tenths'), ['SKIP_N_TENTHS']],

--- a/src/renderer/components/PlayerSettings/PlayerSettings.vue
+++ b/src/renderer/components/PlayerSettings/PlayerSettings.vue
@@ -36,11 +36,11 @@
           @change="updateRememberVolume"
         />
         <FtToggleSwitch
-          :label="t('Settings.Player Settings.Show Fast-Forward Through Silence Toggle')"
+          :label="t('Settings.Player Settings.Show Skip Silence Toggle')"
           :compact="true"
           :default-value="showSkipSilenceButton"
           setting-key="showSkipSilenceButton"
-          :tooltip="t('Tooltips.Player Settings.Show Fast-Forward Through Silence Toggle')"
+          :tooltip="t('Tooltips.Player Settings.Show Skip Silence Toggle')"
           @change="updateShowSkipSilenceButton"
         />
         <FtToggleSwitch

--- a/src/renderer/components/ft-shaka-video-player/ft-shaka-video-player.css
+++ b/src/renderer/components/ft-shaka-video-player/ft-shaka-video-player.css
@@ -1067,7 +1067,7 @@
   background-image: none;
 }
 
-/* Names that don't fit into a tile (`Fast-Forward Through Silence`) get cut off. */
+/* Names that don't fit into a tile get cut off. */
 :deep(.shaka-overflow-menu.ft-menu-grid .shaka-overflow-button-label > span:not(.shaka-current-selection-span)) {
   display: -webkit-box;
   overflow: hidden;

--- a/src/renderer/components/ft-shaka-video-player/ft-shaka-video-player.js
+++ b/src/renderer/components/ft-shaka-video-player/ft-shaka-video-player.js
@@ -7820,7 +7820,7 @@ export default defineComponent({
      * @param {number} step
      */
     function changePlayBackRate(step) {
-      applyPlaybackRate(player.getPlaybackRate() + step)
+      applyPlaybackRate(getCurrentPlaybackRate() + step)
     }
 
     /**
@@ -7831,7 +7831,7 @@ export default defineComponent({
     }
 
     function toggleNormalPlaybackRate() {
-      const currentRate = player.getPlaybackRate()
+      const currentRate = getCurrentPlaybackRate()
 
       if (!isNormalPlaybackRate(currentRate)) {
         togglePlaybackRate = currentRate
@@ -7931,7 +7931,7 @@ export default defineComponent({
      * @param {WheelEvent} event
      */
     function mouseScrollSkip(event) {
-      const seekMultiplier = seekIntervalMultiplyByPlaybackRate.value ? player.getPlaybackRate() : 1
+      const seekMultiplier = seekIntervalMultiplyByPlaybackRate.value ? getCurrentPlaybackRate() : 1
       if ((event.deltaY < 0 || event.deltaX > 0)) {
         seekBySeconds(defaultSkipInterval.value * seekMultiplier, true)
       } else if ((event.deltaY > 0 || event.deltaX < 0)) {
@@ -8260,14 +8260,14 @@ export default defineComponent({
         case matches(KeyboardShortcuts.VIDEO_PLAYER.PLAYBACK.LARGE_REWIND): {
           // Rewind by 2x the time-skip interval (in seconds)
           event.preventDefault()
-          const largeRewindMultiplier = seekIntervalMultiplyByPlaybackRate.value ? player.getPlaybackRate() : 1
+          const largeRewindMultiplier = seekIntervalMultiplyByPlaybackRate.value ? getCurrentPlaybackRate() : 1
           seekBySeconds(-defaultSkipInterval.value * largeRewindMultiplier * 2, false, true)
           break
         }
         case matches(KeyboardShortcuts.VIDEO_PLAYER.PLAYBACK.LARGE_FAST_FORWARD): {
           // Fast-Forward by 2x the time-skip interval (in seconds)
           event.preventDefault()
-          const largeFastForwardMultiplier = seekIntervalMultiplyByPlaybackRate.value ? player.getPlaybackRate() : 1
+          const largeFastForwardMultiplier = seekIntervalMultiplyByPlaybackRate.value ? getCurrentPlaybackRate() : 1
           seekBySeconds(defaultSkipInterval.value * largeFastForwardMultiplier * 2, false, true)
           break
         }
@@ -8322,14 +8322,14 @@ export default defineComponent({
         case matches(KeyboardShortcuts.VIDEO_PLAYER.PLAYBACK.SMALL_REWIND): {
           event.preventDefault()
           // Rewind by the time-skip interval (in seconds)
-          const smallRewindMultiplier = seekIntervalMultiplyByPlaybackRate.value ? player.getPlaybackRate() : 1
+          const smallRewindMultiplier = seekIntervalMultiplyByPlaybackRate.value ? getCurrentPlaybackRate() : 1
           seekBySeconds(-defaultSkipInterval.value * smallRewindMultiplier, false, true)
           break
         }
         case matches(KeyboardShortcuts.VIDEO_PLAYER.PLAYBACK.SMALL_FAST_FORWARD): {
           event.preventDefault()
           // Fast-Forward by the time-skip interval (in seconds)
-          const smallFastForwardMultiplier = seekIntervalMultiplyByPlaybackRate.value ? player.getPlaybackRate() : 1
+          const smallFastForwardMultiplier = seekIntervalMultiplyByPlaybackRate.value ? getCurrentPlaybackRate() : 1
           seekBySeconds(defaultSkipInterval.value * smallFastForwardMultiplier, false, true)
           break
         }

--- a/src/renderer/components/ft-shaka-video-player/ft-shaka-video-player.js
+++ b/src/renderer/components/ft-shaka-video-player/ft-shaka-video-player.js
@@ -1007,6 +1007,10 @@ export default defineComponent({
       const volume = Number(store.getters.getVoiceOverTranslationVolume) / 100
       return Number.isFinite(volume) ? Math.min(1, Math.max(0, volume)) : 1
     })
+    const voiceOverTranslationOriginalVolume = computed(() => {
+      const volume = Number(store.getters.getVoiceOverTranslationOriginalVolume) / 100
+      return Number.isFinite(volume) ? Math.min(1, Math.max(0, volume)) : 0.1
+    })
     const voiceOverTranslationAvailable = computed(() => {
       return process.env.IS_ELECTRON &&
         useVoiceOverTranslationSetting.value &&
@@ -1022,6 +1026,7 @@ export default defineComponent({
       videoId: computed(() => props.videoId),
       responseLanguage: voiceOverTranslationLanguage,
       autoPrepare: voiceOverTranslationAutoPrepare,
+      originalVolume: voiceOverTranslationOriginalVolume,
       voiceVolume: voiceOverTranslationVolume,
       onError: error => {
         const message = error instanceof RangeError
@@ -1223,30 +1228,26 @@ export default defineComponent({
       return store.getters.getShowSkipSilenceButton
     })
 
-    const silenceSkippingEnabled = computed(() => {
-      return skipSilence.value
-    })
-
-    const originalAudioGain = computed(() => {
-      if (!voiceOverTranslation.enabled.value) {
-        return 1
-      }
-
-      const volume = Number(store.getters.getVoiceOverTranslationOriginalVolume) / 100
-      return Number.isFinite(volume) ? Math.min(1, Math.max(0, volume)) : 0.1
-    })
-
     const silenceSkipping = useSilenceSkipping({
-      enabled: silenceSkippingEnabled,
+      available: showSkipSilenceButton,
+      enabled: skipSilence,
       isLive,
       video,
-      outputGain: originalAudioGain,
     })
 
-    const silenceSkippingIndicatorMessage = computed(() => {
-      const rate = silenceSkipping.accelerationRate.value
-      return rate === null ? '' : `${Number.parseFloat(rate.toFixed(2))}x`
-    })
+    /** @type {shaka.extern.RequestFilter} */
+    function silenceSkippingRequestFilter(type, _request, context) {
+      if (type === RequestType.SEGMENT) {
+        silenceSkipping.handleSegmentRequest(context)
+      }
+    }
+
+    /** @type {shaka.extern.ResponseFilter} */
+    function silenceSkippingResponseFilter(type, response, context) {
+      if (type === RequestType.SEGMENT) {
+        silenceSkipping.handleSegmentResponse(response, context)
+      }
+    }
 
     const captionSettings = computed(() => parseCaptionSettings(store.getters.getDefaultCaptionSettings))
     const captionCssVariables = computed(() => getCaptionCssVariables(captionSettings.value))
@@ -7589,12 +7590,12 @@ export default defineComponent({
 
       const playerRate = normalizePlaybackRate(player?.getPlaybackRate())
       if (playerRate !== null) {
-        return silenceSkipping.getNormalPlaybackRate(playerRate)
+        return playerRate
       }
 
       const videoRate = normalizePlaybackRate(video.value?.playbackRate)
       if (videoRate !== null) {
-        return silenceSkipping.getNormalPlaybackRate(videoRate)
+        return videoRate
       }
 
       return normalizePlaybackRate(props.currentPlaybackRate)
@@ -7642,11 +7643,9 @@ export default defineComponent({
         return
       }
 
-      silenceSkipping.suspend()
       const playbackRate = getCurrentPlaybackRate()
       if (playbackRate === null) {
         temporaryPlaybackRateSources.delete(source)
-        silenceSkipping.resume()
         return
       }
 
@@ -7669,7 +7668,6 @@ export default defineComponent({
         wasPausedBeforeTemporaryPlayback = false
         temporaryPlaybackRateActive = false
         showTemporaryPlaybackRateIndicator.value = false
-        silenceSkipping.resume()
         console.error('Failed to apply temporary playback rate:', error)
       }
     }
@@ -7723,7 +7721,6 @@ export default defineComponent({
         wasPausedBeforeTemporaryPlayback = false
         temporaryPlaybackRateActive = false
         showTemporaryPlaybackRateIndicator.value = false
-        silenceSkipping.resume()
       }
     }
 
@@ -7823,7 +7820,7 @@ export default defineComponent({
      * @param {number} step
      */
     function changePlayBackRate(step) {
-      applyPlaybackRate(getCurrentPlaybackRate() + step)
+      applyPlaybackRate(player.getPlaybackRate() + step)
     }
 
     /**
@@ -7834,7 +7831,7 @@ export default defineComponent({
     }
 
     function toggleNormalPlaybackRate() {
-      const currentRate = getCurrentPlaybackRate()
+      const currentRate = player.getPlaybackRate()
 
       if (!isNormalPlaybackRate(currentRate)) {
         togglePlaybackRate = currentRate
@@ -7934,7 +7931,7 @@ export default defineComponent({
      * @param {WheelEvent} event
      */
     function mouseScrollSkip(event) {
-      const seekMultiplier = seekIntervalMultiplyByPlaybackRate.value ? getCurrentPlaybackRate() : 1
+      const seekMultiplier = seekIntervalMultiplyByPlaybackRate.value ? player.getPlaybackRate() : 1
       if ((event.deltaY < 0 || event.deltaX > 0)) {
         seekBySeconds(defaultSkipInterval.value * seekMultiplier, true)
       } else if ((event.deltaY > 0 || event.deltaX < 0)) {
@@ -8225,7 +8222,7 @@ export default defineComponent({
 
           const localization = ui.getControls().getLocalization()
           const message = localization.resolve(enabled ? 'ON' : 'OFF')
-          showValueChange(message, 'forward-fast', true)
+          showValueChange(message, 'volume-xmark', true)
           blurTooltipButtons()
           break
         }
@@ -8263,14 +8260,14 @@ export default defineComponent({
         case matches(KeyboardShortcuts.VIDEO_PLAYER.PLAYBACK.LARGE_REWIND): {
           // Rewind by 2x the time-skip interval (in seconds)
           event.preventDefault()
-          const largeRewindMultiplier = seekIntervalMultiplyByPlaybackRate.value ? getCurrentPlaybackRate() : 1
+          const largeRewindMultiplier = seekIntervalMultiplyByPlaybackRate.value ? player.getPlaybackRate() : 1
           seekBySeconds(-defaultSkipInterval.value * largeRewindMultiplier * 2, false, true)
           break
         }
         case matches(KeyboardShortcuts.VIDEO_PLAYER.PLAYBACK.LARGE_FAST_FORWARD): {
           // Fast-Forward by 2x the time-skip interval (in seconds)
           event.preventDefault()
-          const largeFastForwardMultiplier = seekIntervalMultiplyByPlaybackRate.value ? getCurrentPlaybackRate() : 1
+          const largeFastForwardMultiplier = seekIntervalMultiplyByPlaybackRate.value ? player.getPlaybackRate() : 1
           seekBySeconds(defaultSkipInterval.value * largeFastForwardMultiplier * 2, false, true)
           break
         }
@@ -8325,14 +8322,14 @@ export default defineComponent({
         case matches(KeyboardShortcuts.VIDEO_PLAYER.PLAYBACK.SMALL_REWIND): {
           event.preventDefault()
           // Rewind by the time-skip interval (in seconds)
-          const smallRewindMultiplier = seekIntervalMultiplyByPlaybackRate.value ? getCurrentPlaybackRate() : 1
+          const smallRewindMultiplier = seekIntervalMultiplyByPlaybackRate.value ? player.getPlaybackRate() : 1
           seekBySeconds(-defaultSkipInterval.value * smallRewindMultiplier, false, true)
           break
         }
         case matches(KeyboardShortcuts.VIDEO_PLAYER.PLAYBACK.SMALL_FAST_FORWARD): {
           event.preventDefault()
           // Fast-Forward by the time-skip interval (in seconds)
-          const smallFastForwardMultiplier = seekIntervalMultiplyByPlaybackRate.value ? getCurrentPlaybackRate() : 1
+          const smallFastForwardMultiplier = seekIntervalMultiplyByPlaybackRate.value ? player.getPlaybackRate() : 1
           seekBySeconds(defaultSkipInterval.value * smallFastForwardMultiplier, false, true)
           break
         }
@@ -8707,7 +8704,7 @@ export default defineComponent({
               return
             }
 
-            emit('playback-rate-user-set', getCurrentPlaybackRate())
+            emit('playback-rate-user-set', player.getPlaybackRate())
           }, 10)
         }
       }
@@ -8803,6 +8800,8 @@ export default defineComponent({
         player.getNetworkingEngine().registerRequestFilter(requestFilter)
         player.getNetworkingEngine().registerResponseFilter(responseFilter)
       }
+      player.getNetworkingEngine().registerRequestFilter(silenceSkippingRequestFilter)
+      player.getNetworkingEngine().registerResponseFilter(silenceSkippingResponseFilter)
 
       await setLocale(locale.value)
 
@@ -8911,6 +8910,7 @@ export default defineComponent({
       window.addEventListener('blur', handleTemporaryPlaybackRateFocusLoss)
 
       player.addEventListener('loading', () => {
+        silenceSkipping.reset()
         hasLoaded.value = false
         annotationVideoAspectRatio.value = null
         if (props.shortsPlayer) {
@@ -8965,7 +8965,7 @@ export default defineComponent({
 
       player?.addEventListener('ratechange', () => {
         const playbackRate = player.getPlaybackRate()
-        if (!temporaryPlaybackRateActive && !silenceSkipping.handlePlaybackRateChange(playbackRate)) {
+        if (!temporaryPlaybackRateActive) {
           emit('playback-rate-updated', playbackRate)
         }
         scheduleSponsorBlockSkip()
@@ -9856,8 +9856,6 @@ export default defineComponent({
       invertValueChangeContentOrder,
       showTemporaryPlaybackRateIndicator,
       temporaryPlaybackRateIndicatorMessage,
-      silenceSkippingActive: silenceSkipping.isAccelerating,
-      silenceSkippingIndicatorMessage,
 
       scrollMiniPlayerActive,
       scrollMiniPlayerAnimating,

--- a/src/renderer/components/ft-shaka-video-player/ft-shaka-video-player.vue
+++ b/src/renderer/components/ft-shaka-video-player/ft-shaka-video-player.vue
@@ -775,31 +775,26 @@
       </div>
       <Transition name="fade">
         <div
-          v-if="showTemporaryPlaybackRateIndicator || showValueChangePopup || silenceSkippingActive"
+          v-if="showTemporaryPlaybackRateIndicator || showValueChangePopup"
           class="valueChangePopup"
           :class="{
             'invert-content-order':
-              showTemporaryPlaybackRateIndicator ||
-              (showValueChangePopup ? invertValueChangeContentOrder : silenceSkippingActive)
+              showTemporaryPlaybackRateIndicator || invertValueChangeContentOrder
           }"
         >
           <ft-icon
-            v-if="showTemporaryPlaybackRateIndicator || (showValueChangePopup ? valueChangeIcon : silenceSkippingActive)"
+            v-if="showTemporaryPlaybackRateIndicator || valueChangeIcon"
             :icon="[
               'fas',
               showTemporaryPlaybackRateIndicator
                 ? 'forward'
-                : showValueChangePopup
-                  ? valueChangeIcon
-                  : 'forward-fast'
+                : valueChangeIcon
             ]"
           />
           <span>{{
             showTemporaryPlaybackRateIndicator
               ? temporaryPlaybackRateIndicatorMessage
-              : showValueChangePopup
-                ? valueChangeMessage
-                : silenceSkippingIndicatorMessage
+              : valueChangeMessage
           }}</span>
         </div>
       </Transition>

--- a/src/renderer/components/ft-shaka-video-player/opentubex/useSilenceSkipping.js
+++ b/src/renderer/components/ft-shaka-video-player/opentubex/useSilenceSkipping.js
@@ -1,118 +1,204 @@
-import { onBeforeUnmount, onMounted, ref, watch } from 'vue'
+import { onBeforeUnmount, onMounted, watch } from 'vue'
 
-const ANALYSER_FFT_SIZE = 1024
+const ANALYSIS_GAP_SECONDS = 1
+const ANALYSIS_PLAYBACK_RATE = 4
+const ANALYSER_FFT_SIZE = 4096
 const AUDIBLE_PEAK_THRESHOLD_DB = -25
+const BUFFER_RETENTION_SECONDS = 30
 const FALLBACK_THRESHOLD_DB = -40
 const HYSTERESIS_DB = 3
-const LOOKAHEAD_SECONDS = 0.06
+const MAX_CAPTURED_SEGMENT_BYTES = 4 * 1024 * 1024
 const MAX_HISTORY_SAMPLES = 600
 const MIN_HISTORY_SAMPLES = 60
-const SILENCE_HOLD_MS = 700
+const MIN_SILENCE_SECONDS = 0.7
+const MIN_SKIP_SECONDS = 0.25
+const RANGE_MERGE_GAP_SECONDS = 0.05
+const SILENCE_END_PADDING_SECONDS = 0.15
 const SPEECH_PEAK_THRESHOLD_DB = -35
-const SPEED_RAMP_MS = 200
+
+export function createRequestPresentationTracker() {
+  let presentation = 0
+  const requestPresentations = new WeakMap()
+
+  return {
+    /**
+     * @param {shaka.extern.RequestContext | undefined} context
+     */
+    beginRequest(context) {
+      if (context && !requestPresentations.has(context)) {
+        requestPresentations.set(context, presentation)
+      }
+    },
+    /**
+     * @param {shaka.extern.RequestContext | undefined} context
+     * @returns {boolean}
+     */
+    isCurrent(context) {
+      return Boolean(context && requestPresentations.get(context) === presentation)
+    },
+    reset() {
+      presentation++
+    },
+  }
+}
 
 /**
- * Detects sustained silence and temporarily accelerates playback without
- * changing the speed selected by the user.
+ * Releases deduplication entries once their media is removed, allowing Shaka
+ * to provide those segments again after a backward seek.
+ *
+ * @param {Map<string, CapturedSegment>} analysisSegments
+ * @param {CapturedSegment[]} appendQueue
+ * @param {number} endTime
+ */
+export function releaseAnalysisSegmentsBefore(analysisSegments, appendQueue, endTime) {
+  for (const [key, segment] of analysisSegments) {
+    if (Number.isFinite(segment.end) && segment.end <= endTime) {
+      analysisSegments.delete(key)
+    }
+  }
+
+  for (let index = appendQueue.length - 1; index >= 0; index--) {
+    const segment = appendQueue[index]
+    if (Number.isFinite(segment.end) && segment.end <= endTime) {
+      appendQueue.splice(index, 1)
+    }
+  }
+}
+
+/**
+ * @typedef {object} CapturedSegment
+ * @property {ArrayBuffer} data
+ * @property {number} end
+ * @property {string} key
+ * @property {number} start
+ */
+
+/**
+ * @typedef {object} CapturedStream
+ * @property {string} contentType
+ * @property {ArrayBuffer | null} initData
+ * @property {Map<string, CapturedSegment>} segments
+ */
+
+/**
+ * Detects silence in a second, accelerated media pipeline that is fed the
+ * audio segments already downloaded by Shaka. This lets the visible player
+ * seek directly to a known silence endpoint without changing playback rate.
  *
  * @param {object} options
+ * @param {import('vue').ComputedRef<boolean>} options.available
  * @param {import('vue').ComputedRef<boolean>} options.enabled
  * @param {import('vue').Ref<boolean>} options.isLive
  * @param {import('vue').Ref<HTMLVideoElement | null>} options.video
- * @param {import('vue').ComputedRef<number>} options.outputGain
  */
-export function useSilenceSkipping({ enabled, isLive, video, outputGain }) {
+export function useSilenceSkipping({ available, enabled, isLive, video }) {
   /** @type {AudioContext | null} */
-  let audioContext = null
-  /** @type {AnalyserNode[]} */
-  const analysers = []
-  /** @type {DelayNode | null} */
-  let delay = null
+  let analysisAudioContext = null
+  /** @type {HTMLAudioElement | null} */
+  let analysisAudio = null
+  /** @type {MediaSource | null} */
+  let analysisMediaSource = null
+  /** @type {SourceBuffer | null} */
+  let analysisSourceBuffer = null
+  /** @type {MediaElementAudioSourceNode | null} */
+  let analysisSourceNode = null
   /** @type {GainNode | null} */
-  let gain = null
+  let analysisSink = null
+  /** @type {AnalyserNode[]} */
+  let analysers = []
   /** @type {Float32Array[]} */
-  const sampleBuffers = []
+  let sampleBuffers = []
   /** @type {number | null} */
-  let animationFrame = null
+  let analysisFrame = null
   /** @type {number | null} */
-  let controlledPlaybackRate = null
-  /** @type {number | null} */
-  let controlledPlaybackRateTimeout = null
-  /** @type {number | null} */
-  let normalPlaybackRate = null
-  let graphSetupPromise = null
+  let skipFrame = null
+  /** @type {string | null} */
+  let analysisObjectUrl = null
+  /** @type {number | string | null} */
+  let analysisStreamId = null
+  /** @type {CapturedSegment[]} */
+  let appendQueue = []
+  /** @type {Map<string, CapturedSegment>} */
+  const analysisSegments = new Map()
+  let analysisGeneration = 0
+  let analysisHasStarted = false
+  let analysisPlayPending = false
+  let lastRemovedTime = 0
+
   let destroyed = false
-  let suspended = false
-  let isSilent = false
-  const isAccelerating = ref(false)
-  /** @type {import('vue').Ref<number | null>} */
-  const accelerationRate = ref(null)
-  let lastSampleTime = 0
-  let silenceDuration = 0
+  let analysisIsSilent = false
+  /** @type {number | null} */
+  let analysisSilenceStart = null
+  /** @type {number | null} */
+  let lastAnalysisTime = null
   let dynamicThresholdDb = FALLBACK_THRESHOLD_DB
   let samplesUntilThresholdUpdate = 0
   const volumeHistory = []
+  /** @type {Array<{start: number, end: number}>} */
+  let silenceRanges = []
 
-  function shouldRun() {
+  /** @type {Map<number | string, CapturedStream>} */
+  const capturedStreams = new Map()
+  /** @type {number | string | null} */
+  let latestStreamId = null
+  const requestPresentationTracker = createRequestPresentationTracker()
+
+  function shouldSkip() {
     const videoElement = video.value
-    return !destroyed && !suspended && enabled.value && !isLive.value && videoElement &&
+    return !destroyed && enabled.value && !isLive.value && videoElement &&
       !videoElement.paused && !videoElement.ended && !videoElement.muted && videoElement.volume > 0 &&
-      !videoElement.seeking && videoElement.readyState >= HTMLMediaElement.HAVE_FUTURE_DATA
+      !videoElement.seeking
   }
 
-  function setControlledPlaybackRate(rate) {
-    const videoElement = video.value
-    if (!videoElement || Math.abs(videoElement.playbackRate - rate) < 0.01) {
+  /**
+   * @param {ArrayBuffer | ArrayBufferView} data
+   * @returns {ArrayBuffer}
+   */
+  function copyBuffer(data) {
+    if (data instanceof ArrayBuffer) {
+      return data.slice(0)
+    }
+
+    return data.buffer.slice(data.byteOffset, data.byteOffset + data.byteLength)
+  }
+
+  /**
+   * @param {{start: number, end: number}} range
+   */
+  function addSilenceRange(range) {
+    if (range.end - range.start < MIN_SILENCE_SECONDS) {
       return
     }
 
-    controlledPlaybackRate = rate
-    if (controlledPlaybackRateTimeout !== null) {
-      clearTimeout(controlledPlaybackRateTimeout)
+    silenceRanges.push(range)
+    silenceRanges.sort((a, b) => a.start - b.start)
+
+    /** @type {Array<{start: number, end: number}>} */
+    const merged = []
+    for (const current of silenceRanges) {
+      const previous = merged.at(-1)
+      if (previous && current.start <= previous.end + RANGE_MERGE_GAP_SECONDS) {
+        previous.end = Math.max(previous.end, current.end)
+      } else {
+        merged.push({ ...current })
+      }
     }
-    controlledPlaybackRateTimeout = window.setTimeout(() => {
-      controlledPlaybackRate = null
-      controlledPlaybackRateTimeout = null
-    }, 100)
-    videoElement.playbackRate = rate
+    silenceRanges = merged
   }
 
-  function restoreGain() {
-    if (!gain) {
-      return
-    }
-
-    const now = gain.context.currentTime
-    gain.gain.cancelScheduledValues(now)
-    gain.gain.setValueAtTime(gain.gain.value, now)
-    gain.gain.linearRampToValueAtTime(outputGain.value, now + 0.04)
+  function resetAnalysisDetection() {
+    analysisIsSilent = false
+    analysisSilenceStart = null
+    lastAnalysisTime = null
   }
 
-  function resetDetection() {
-    lastSampleTime = 0
-    silenceDuration = 0
-    isSilent = false
-
-    if (isAccelerating.value && normalPlaybackRate !== null) {
-      setControlledPlaybackRate(normalPlaybackRate)
+  function flushPendingSilence() {
+    if (analysisIsSilent && analysisSilenceStart !== null && lastAnalysisTime !== null) {
+      addSilenceRange({ start: analysisSilenceStart, end: lastAnalysisTime })
     }
 
-    isAccelerating.value = false
-    accelerationRate.value = null
-    restoreGain()
-  }
-
-  function stop() {
-    if (animationFrame !== null) {
-      cancelAnimationFrame(animationFrame)
-      animationFrame = null
-    }
-
-    if (delay) {
-      delay.delayTime.value = 0
-    }
-
-    resetDetection()
+    analysisIsSilent = false
+    analysisSilenceStart = null
   }
 
   function updateDynamicThreshold(volumeDb) {
@@ -131,8 +217,6 @@ export function useSilenceSkipping({ enabled, isLive, video, outputGain }) {
     samplesUntilThresholdUpdate = 30
     const sortedHistory = [...volumeHistory].sort((a, b) => a - b)
     const noiseFloor = sortedHistory[Math.floor(sortedHistory.length * 0.15)]
-    // Cap at -30 dB: in loud videos the 15th percentile is quiet-but-audible
-    // content (e.g. a musical breakdown), not an actual noise floor.
     dynamicThresholdDb = Math.min(-30, Math.max(-60, noiseFloor + 3))
   }
 
@@ -156,126 +240,194 @@ export function useSilenceSkipping({ enabled, isLive, video, outputGain }) {
       )
     }
 
-    // MediaElementAudioSourceNode applies the element's volume before analysis.
-    // Normalize levels so silence detection behaves the same at every user volume.
-    const volumeAdjustmentDb = -20 * Math.log10(video.value?.volume ?? 1)
     return {
-      peakDb: peak === 0 ? -100 : 20 * Math.log10(peak) + volumeAdjustmentDb,
-      volumeDb: rootMeanSquare === 0
-        ? -100
-        : 20 * Math.log10(rootMeanSquare) + volumeAdjustmentDb,
+      peakDb: peak === 0 ? -100 : 20 * Math.log10(peak),
+      volumeDb: rootMeanSquare === 0 ? -100 : 20 * Math.log10(rootMeanSquare),
     }
   }
 
-  function getSilencePlaybackRate() {
-    const baseRate = normalPlaybackRate ?? video.value?.playbackRate ?? 1
-    return Math.min(16, Math.max(3, baseRate * 2))
-  }
+  function analyseAhead() {
+    analysisFrame = null
 
-  function enterSilence() {
-    isAccelerating.value = true
-    accelerationRate.value = getSilencePlaybackRate()
-
-    if (gain) {
-      const now = gain.context.currentTime
-      gain.gain.cancelScheduledValues(now)
-      gain.gain.setTargetAtTime(0, now, 0.015)
-    }
-  }
-
-  function exitSilence() {
-    if (normalPlaybackRate !== null) {
-      setControlledPlaybackRate(normalPlaybackRate)
-    }
-
-    isAccelerating.value = false
-    accelerationRate.value = null
-    silenceDuration = 0
-    restoreGain()
-  }
-
-  function analyse() {
-    animationFrame = null
-
-    if (!shouldRun() || analysers.length === 0) {
-      stop()
+    if (!analysisAudio || analysisAudio.paused || analysisAudio.ended || analysisAudio.seeking || analysers.length === 0) {
+      flushPendingSilence()
       return
     }
 
-    const now = performance.now()
-    const elapsed = lastSampleTime === 0 ? 0 : Math.min(now - lastSampleTime, 100)
-    lastSampleTime = now
+    const currentTime = analysisAudio.currentTime
+    if (lastAnalysisTime !== null && currentTime <= lastAnalysisTime) {
+      analysisFrame = requestAnimationFrame(analyseAhead)
+      return
+    }
+
+    if (lastAnalysisTime === null || currentTime - lastAnalysisTime > ANALYSIS_GAP_SECONDS) {
+      flushPendingSilence()
+      resetAnalysisDetection()
+      lastAnalysisTime = currentTime
+      analysisFrame = requestAnimationFrame(analyseAhead)
+      return
+    }
 
     const { peakDb, volumeDb } = getAudioLevels()
     updateDynamicThreshold(volumeDb)
 
-    // Room tone can sit above the adaptive RMS threshold while quiet speech
-    // has recurring peaks. Treat either low measure as a silence candidate,
-    // but require both to recover before leaving silence. A strong peak means
-    // clearly audible content (e.g. quiet music with percussive transients
-    // whose RMS dips below the threshold), so it always blocks silence.
     const containsAudiblePeak = peakDb >= AUDIBLE_PEAK_THRESHOLD_DB
     const containsSpeechPeak = peakDb >= SPEECH_PEAK_THRESHOLD_DB
-    if (isSilent) {
+    if (analysisIsSilent) {
       if (containsAudiblePeak || (containsSpeechPeak && volumeDb > dynamicThresholdDb + HYSTERESIS_DB)) {
-        isSilent = false
+        if (analysisSilenceStart !== null) {
+          addSilenceRange({ start: analysisSilenceStart, end: currentTime })
+        }
+        analysisIsSilent = false
+        analysisSilenceStart = null
       }
     } else if (!containsAudiblePeak && (!containsSpeechPeak || volumeDb < dynamicThresholdDb)) {
-      isSilent = true
+      analysisIsSilent = true
+      analysisSilenceStart = lastAnalysisTime
     }
 
-    if (isSilent) {
-      silenceDuration += elapsed
-
-      if (silenceDuration >= SILENCE_HOLD_MS) {
-        if (!isAccelerating.value) {
-          enterSilence()
-        }
-
-        const progress = Math.min((silenceDuration - SILENCE_HOLD_MS) / SPEED_RAMP_MS, 1)
-        const baseRate = normalPlaybackRate ?? video.value.playbackRate
-        const silenceRate = getSilencePlaybackRate()
-        setControlledPlaybackRate(baseRate + (silenceRate - baseRate) * progress)
-      }
-    } else if (isAccelerating.value) {
-      exitSilence()
-    } else {
-      silenceDuration = 0
-    }
-
-    animationFrame = requestAnimationFrame(analyse)
+    lastAnalysisTime = currentTime
+    analysisFrame = requestAnimationFrame(analyseAhead)
   }
 
-  async function setupGraph() {
-    if (analysers.length > 0) {
+  function scheduleAnalysis() {
+    if (analysisFrame === null && analysisAudio && !analysisAudio.paused && !analysisAudio.seeking) {
+      analysisFrame = requestAnimationFrame(analyseAhead)
+    }
+  }
+
+  function findBufferedAnalysisTime(target) {
+    if (!analysisAudio) {
+      return null
+    }
+
+    for (let index = 0; index < analysisAudio.buffered.length; index++) {
+      const start = analysisAudio.buffered.start(index)
+      const end = analysisAudio.buffered.end(index)
+      if (target < end - 0.01) {
+        return Math.max(target, start + 0.01)
+      }
+    }
+
+    return null
+  }
+
+  async function ensureAnalysisPlayback() {
+    if (!analysisAudio || !analysisAudioContext || analysisPlayPending || !enabled.value || isLive.value) {
       return
     }
 
     const videoElement = video.value
-    if (!videoElement) {
+    const playbackTime = videoElement?.currentTime ?? 0
+    if (!analysisHasStarted || analysisAudio.currentTime + 0.5 < playbackTime) {
+      const target = findBufferedAnalysisTime(playbackTime) ?? (
+        !analysisMediaSource && analysisAudio.readyState >= HTMLMediaElement.HAVE_METADATA
+          ? playbackTime
+          : null
+      )
+      if (target === null) {
+        return
+      }
+
+      flushPendingSilence()
+      resetAnalysisDetection()
+      analysisAudio.currentTime = target
+      analysisHasStarted = true
+    }
+
+    if (!analysisAudio.paused) {
+      analysisAudio.playbackRate = ANALYSIS_PLAYBACK_RATE
+      scheduleAnalysis()
       return
     }
 
-    audioContext ??= new AudioContext()
-    await audioContext.resume()
-    if (audioContext.state !== 'running' || destroyed || video.value !== videoElement) {
+    analysisPlayPending = true
+    try {
+      await analysisAudioContext.resume()
+      analysisAudio.defaultPlaybackRate = ANALYSIS_PLAYBACK_RATE
+      analysisAudio.playbackRate = ANALYSIS_PLAYBACK_RATE
+      await analysisAudio.play()
+      scheduleAnalysis()
+    } catch (error) {
+      if (error?.name !== 'AbortError' && error?.name !== 'NotAllowedError') {
+        console.warn('Unable to start look-ahead audio analysis for silence skipping', error)
+      }
+    } finally {
+      analysisPlayPending = false
+    }
+  }
+
+  function processAppendQueue() {
+    if (!analysisSourceBuffer || analysisSourceBuffer.updating || analysisMediaSource?.readyState !== 'open') {
       return
     }
 
-    const source = audioContext.createMediaElementSource(videoElement)
-    const splitter = audioContext.createChannelSplitter(2)
-    const analysisSink = audioContext.createGain()
+    const videoElement = video.value
+    const cleanupTime = Math.min(
+      analysisAudio?.currentTime ?? 0,
+      videoElement?.currentTime ?? 0
+    ) - BUFFER_RETENTION_SECONDS
+    if (cleanupTime > lastRemovedTime + BUFFER_RETENTION_SECONDS && analysisSourceBuffer.buffered.length > 0) {
+      lastRemovedTime = cleanupTime
+      releaseAnalysisSegmentsBefore(analysisSegments, appendQueue, cleanupTime)
+      analysisSourceBuffer.remove(0, cleanupTime)
+      return
+    }
+
+    const segment = appendQueue.shift()
+    if (!segment) {
+      ensureAnalysisPlayback()
+      return
+    }
+
+    try {
+      analysisSourceBuffer.appendBuffer(segment.data)
+    } catch (error) {
+      if (error?.name === 'QuotaExceededError' && cleanupTime > 0) {
+        appendQueue.unshift(segment)
+        lastRemovedTime = cleanupTime
+        releaseAnalysisSegmentsBefore(analysisSegments, appendQueue, cleanupTime)
+        analysisSourceBuffer.remove(0, cleanupTime)
+      } else {
+        console.warn('Unable to buffer audio for silence skipping', error)
+        queueMicrotask(processAppendQueue)
+      }
+    }
+  }
+
+  /**
+   * @param {CapturedSegment} segment
+   */
+  function queueSegmentForAnalysis(segment) {
+    if (analysisSegments.has(segment.key)) {
+      return
+    }
+
+    analysisSegments.set(segment.key, segment)
+    appendQueue.push(segment)
+    appendQueue.sort((a, b) => a.start - b.start)
+    processAppendQueue()
+  }
+
+  async function setupAnalysisGraph(generation) {
+    if (!analysisAudio || generation !== analysisGeneration) {
+      return
+    }
+
+    analysisAudioContext = new AudioContext()
+    await analysisAudioContext.resume()
+    if (!analysisAudio || generation !== analysisGeneration) {
+      return
+    }
+
+    analysisSourceNode = analysisAudioContext.createMediaElementSource(analysisAudio)
+    const splitter = analysisAudioContext.createChannelSplitter(2)
+    analysisSink = analysisAudioContext.createGain()
     analysisSink.gain.value = 0
-    delay = audioContext.createDelay(1)
-    gain = audioContext.createGain()
 
-    source.connect(delay)
-    delay.connect(gain)
-    gain.connect(audioContext.destination)
-
-    source.connect(splitter)
+    analysisSourceNode.connect(splitter)
     for (let channel = 0; channel < splitter.numberOfOutputs; channel++) {
-      const analyser = audioContext.createAnalyser()
+      const analyser = analysisAudioContext.createAnalyser()
       analyser.fftSize = ANALYSER_FFT_SIZE
       analyser.smoothingTimeConstant = 0
       splitter.connect(analyser, channel)
@@ -283,168 +435,349 @@ export function useSilenceSkipping({ enabled, isLive, video, outputGain }) {
       analysers.push(analyser)
       sampleBuffers.push(new Float32Array(analyser.fftSize))
     }
-    analysisSink.connect(audioContext.destination)
+    analysisSink.connect(analysisAudioContext.destination)
   }
 
-  async function start() {
-    if (!shouldRun() || animationFrame !== null) {
+  function destroyAnalysisPipeline() {
+    analysisGeneration++
+
+    if (analysisFrame !== null) {
+      cancelAnimationFrame(analysisFrame)
+      analysisFrame = null
+    }
+
+    analysisAudio?.pause()
+    analysisSourceNode?.disconnect()
+    analysisSink?.disconnect()
+    analysisAudioContext?.close().catch(() => {})
+    if (analysisAudio) {
+      analysisAudio.removeAttribute('src')
+      analysisAudio.load()
+    }
+    if (analysisObjectUrl) {
+      URL.revokeObjectURL(analysisObjectUrl)
+    }
+
+    analysisAudioContext = null
+    analysisAudio = null
+    analysisMediaSource = null
+    analysisSourceBuffer = null
+    analysisSourceNode = null
+    analysisSink = null
+    analysisObjectUrl = null
+    analysisStreamId = null
+    analysers = []
+    sampleBuffers = []
+    appendQueue = []
+    analysisSegments.clear()
+    analysisHasStarted = false
+    analysisPlayPending = false
+    lastRemovedTime = 0
+    dynamicThresholdDb = FALLBACK_THRESHOLD_DB
+    samplesUntilThresholdUpdate = 0
+    volumeHistory.length = 0
+    resetAnalysisDetection()
+  }
+
+  /**
+   * @param {number | string} streamId
+   * @param {CapturedStream} stream
+   */
+  function setupSegmentAnalysis(streamId, stream) {
+    if (!stream.initData || !MediaSource.isTypeSupported(stream.contentType)) {
+      destroyAnalysisPipeline()
       return
     }
 
-    normalPlaybackRate ??= video.value.playbackRate
+    destroyAnalysisPipeline()
+    const generation = analysisGeneration
+    analysisStreamId = streamId
+    analysisAudio = document.createElement('audio')
+    analysisAudio.preload = 'auto'
+    analysisAudio.defaultPlaybackRate = ANALYSIS_PLAYBACK_RATE
+    analysisAudio.playbackRate = ANALYSIS_PLAYBACK_RATE
+    analysisAudio.preservesPitch = false
+    analysisAudio.addEventListener('playing', scheduleAnalysis)
+    analysisAudio.addEventListener('seeking', resetAnalysisDetection)
+    analysisAudio.addEventListener('seeked', ensureAnalysisPlayback)
 
-    try {
-      graphSetupPromise ??= setupGraph()
-      await graphSetupPromise
-      if (analysers.length === 0) {
-        graphSetupPromise = null
+    analysisMediaSource = new MediaSource()
+    analysisObjectUrl = URL.createObjectURL(analysisMediaSource)
+    analysisAudio.src = analysisObjectUrl
+
+    const initSegment = {
+      data: stream.initData,
+      end: Number.NEGATIVE_INFINITY,
+      key: `init:${streamId}`,
+      start: Number.NEGATIVE_INFINITY,
+    }
+    queueSegmentForAnalysis(initSegment)
+    for (const segment of stream.segments.values()) {
+      queueSegmentForAnalysis(segment)
+    }
+
+    analysisMediaSource.addEventListener('sourceopen', async () => {
+      if (!analysisMediaSource || !analysisAudio || generation !== analysisGeneration) {
         return
       }
-      await audioContext?.resume()
-    } catch (error) {
-      if (analysers.length === 0 && audioContext?.state !== 'running') {
-        graphSetupPromise = null
+
+      try {
+        analysisSourceBuffer = analysisMediaSource.addSourceBuffer(stream.contentType)
+        analysisSourceBuffer.addEventListener('updateend', processAppendQueue)
+        await setupAnalysisGraph(generation)
+        processAppendQueue()
+      } catch (error) {
+        console.warn('Unable to create look-ahead audio analysis for silence skipping', error)
+        destroyAnalysisPipeline()
       }
-      console.warn('Unable to analyse audio for silence skipping', error)
+    }, { once: true })
+  }
+
+  async function setupLocalFileAnalysis() {
+    const videoElement = video.value
+    const source = videoElement?.currentSrc
+    if (!source || !source.startsWith('downloadmedia:')) {
       return
     }
 
-    if (!shouldRun() || analysers.length === 0 || animationFrame !== null) {
+    destroyAnalysisPipeline()
+    const generation = analysisGeneration
+    analysisAudio = document.createElement('audio')
+    analysisAudio.preload = 'auto'
+    analysisAudio.defaultPlaybackRate = ANALYSIS_PLAYBACK_RATE
+    analysisAudio.playbackRate = ANALYSIS_PLAYBACK_RATE
+    analysisAudio.preservesPitch = false
+    analysisAudio.src = source
+    analysisAudio.addEventListener('playing', scheduleAnalysis)
+    analysisAudio.addEventListener('canplay', ensureAnalysisPlayback)
+    analysisAudio.addEventListener('progress', ensureAnalysisPlayback)
+    analysisAudio.addEventListener('seeking', resetAnalysisDetection)
+    analysisAudio.addEventListener('seeked', ensureAnalysisPlayback)
+
+    try {
+      await setupAnalysisGraph(generation)
+      await ensureAnalysisPlayback()
+    } catch (error) {
+      console.warn('Unable to analyse downloaded audio for silence skipping', error)
+      destroyAnalysisPipeline()
+    }
+  }
+
+  function startAnalysisPipeline() {
+    if (!enabled.value || isLive.value || destroyed) {
       return
     }
 
-    delay.delayTime.value = LOOKAHEAD_SECONDS
-    lastSampleTime = 0
-    animationFrame = requestAnimationFrame(analyse)
+    if (latestStreamId !== null) {
+      const stream = capturedStreams.get(latestStreamId)
+      if (stream?.initData) {
+        if (analysisStreamId !== latestStreamId) {
+          setupSegmentAnalysis(latestStreamId, stream)
+        } else {
+          ensureAnalysisPlayback()
+        }
+        return
+      }
+    }
+
+    if (!analysisAudio) {
+      setupLocalFileAnalysis()
+    }
+  }
+
+  function skipKnownSilence() {
+    skipFrame = null
+    if (!shouldSkip()) {
+      return
+    }
+
+    const videoElement = video.value
+    const currentTime = videoElement.currentTime
+    const range = silenceRanges.find(({ start, end }) => start <= currentTime && end > currentTime)
+    if (range) {
+      const target = range.end - SILENCE_END_PADDING_SECONDS
+      if (target - currentTime >= MIN_SKIP_SECONDS) {
+        videoElement.currentTime = target
+        return
+      }
+    }
+
+    skipFrame = requestAnimationFrame(skipKnownSilence)
+  }
+
+  function updateSkipState() {
+    if (shouldSkip()) {
+      if (skipFrame === null) {
+        skipFrame = requestAnimationFrame(skipKnownSilence)
+      }
+      startAnalysisPipeline()
+      ensureAnalysisPlayback()
+    } else if (skipFrame !== null) {
+      cancelAnimationFrame(skipFrame)
+      skipFrame = null
+    }
+  }
+
+  function syncAnalysisAfterSeek() {
+    flushPendingSilence()
+    analysisAudio?.pause()
+    analysisHasStarted = false
+    resetAnalysisDetection()
+    updateSkipState()
+  }
+
+  function pruneCapturedSegments(stream) {
+    const currentTime = video.value?.currentTime ?? 0
+    for (const [key, segment] of stream.segments) {
+      if (segment.end < currentTime - BUFFER_RETENTION_SECONDS) {
+        stream.segments.delete(key)
+      }
+    }
+
+    let capturedBytes = [...stream.segments.values()]
+      .reduce((total, segment) => total + segment.data.byteLength, 0)
+    if (capturedBytes <= MAX_CAPTURED_SEGMENT_BYTES) {
+      return
+    }
+
+    const oldestSegments = [...stream.segments.values()].sort((a, b) => a.end - b.end)
+    for (const segment of oldestSegments) {
+      stream.segments.delete(segment.key)
+      capturedBytes -= segment.data.byteLength
+      if (capturedBytes <= MAX_CAPTURED_SEGMENT_BYTES) {
+        break
+      }
+    }
   }
 
   /**
-   * Tracks user-selected rates and identifies rate changes made by this helper.
-   * @param {number} rate
-   * @returns {boolean} whether the event was caused by silence skipping
+   * Marks a request with the presentation that started it. The same request
+   * context is passed to Shaka's response filters, including across retries.
+   *
+   * @param {shaka.extern.RequestContext | undefined} context
    */
-  function handlePlaybackRateChange(rate) {
-    if (controlledPlaybackRate !== null && Math.abs(rate - controlledPlaybackRate) < 0.01) {
-      return true
-    }
-
-    controlledPlaybackRate = null
-    if (controlledPlaybackRateTimeout !== null) {
-      clearTimeout(controlledPlaybackRateTimeout)
-      controlledPlaybackRateTimeout = null
-    }
-    normalPlaybackRate = rate
-
-    if (isAccelerating.value) {
-      isAccelerating.value = false
-      accelerationRate.value = null
-      silenceDuration = 0
-      restoreGain()
-    }
-
-    return false
+  function handleSegmentRequest(context) {
+    requestPresentationTracker.beginRequest(context)
   }
 
   /**
-   * @param {number | null} fallbackRate
-   * @returns {number | null}
+   * Records Shaka's audio responses so they can also be decoded by the
+   * look-ahead media pipeline.
+   *
+   * @param {shaka.extern.Response} response
+   * @param {shaka.extern.RequestContext | undefined} context
    */
-  function getNormalPlaybackRate(fallbackRate) {
-    return normalPlaybackRate ?? fallbackRate
-  }
+  function handleSegmentResponse(response, context) {
+    if (!requestPresentationTracker.isCurrent(context)) {
+      return
+    }
 
-  function handlePlay() {
-    start()
-  }
+    const shakaStream = context?.stream
+    if (!shakaStream || shakaStream.type !== 'audio' || shakaStream.encrypted || !response.data) {
+      return
+    }
 
-  function handlePause() {
-    stop()
-  }
+    const streamId = shakaStream.id
+    if (streamId === undefined || streamId === null) {
+      return
+    }
 
-  function handleVolumeChange() {
-    updateEnabledState()
-  }
+    const contentType = shakaStream.codecs
+      ? `${shakaStream.mimeType}; codecs="${shakaStream.codecs}"`
+      : shakaStream.mimeType
+    let stream = capturedStreams.get(streamId)
+    if (!stream) {
+      stream = { contentType, initData: null, segments: new Map() }
+      capturedStreams.set(streamId, stream)
+    } else {
+      stream.contentType = contentType
+    }
 
-  function handlePlaybackStateChange() {
-    updateEnabledState()
+    if (!context.segment) {
+      stream.initData = copyBuffer(response.data)
+      if (enabled.value && latestStreamId === streamId && analysisStreamId !== streamId) {
+        setupSegmentAnalysis(streamId, stream)
+      }
+      return
+    }
+
+    if (!available.value && !enabled.value) {
+      return
+    }
+
+    const { startTime: start, endTime: end } = context.segment
+    if (!Number.isFinite(start) || !Number.isFinite(end) || end <= start) {
+      return
+    }
+
+    const key = `${streamId}:${start}:${end}`
+    let segment = stream.segments.get(key)
+    if (!segment) {
+      segment = { data: copyBuffer(response.data), end, key, start }
+      stream.segments.set(key, segment)
+      pruneCapturedSegments(stream)
+    }
+
+    if (enabled.value && analysisStreamId === streamId) {
+      queueSegmentForAnalysis(segment)
+    }
+
+    latestStreamId = streamId
+    for (const [otherStreamId, otherStream] of capturedStreams) {
+      if (otherStreamId !== streamId) {
+        otherStream.segments.clear()
+      }
+    }
+
+    if (enabled.value && analysisStreamId !== streamId && stream.initData) {
+      silenceRanges = []
+      setupSegmentAnalysis(streamId, stream)
+    }
   }
 
   function updateEnabledState() {
-    if (shouldRun()) {
-      start()
+    if (!enabled.value || isLive.value) {
+      destroyAnalysisPipeline()
+      silenceRanges = []
     } else {
-      stop()
+      startAnalysisPipeline()
     }
+    updateSkipState()
   }
 
-  async function updateOutputGain() {
-    if (!gain && outputGain.value !== 1) {
-      try {
-        graphSetupPromise ??= setupGraph()
-        await graphSetupPromise
-        if (!gain) {
-          graphSetupPromise = null
-        }
-      } catch (error) {
-        if (!gain) {
-          graphSetupPromise = null
-        }
-        console.warn('Unable to adjust original audio volume', error)
-        return
-      }
-    }
-
-    if (!isAccelerating.value) {
-      restoreGain()
-    }
-  }
-
-  function suspend() {
-    suspended = true
-    stop()
-  }
-
-  function resume() {
-    suspended = false
-    updateEnabledState()
+  function reset() {
+    requestPresentationTracker.reset()
+    destroyAnalysisPipeline()
+    capturedStreams.clear()
+    latestStreamId = null
+    silenceRanges = []
   }
 
   watch([enabled, isLive], updateEnabledState)
-  watch(outputGain, updateOutputGain)
 
   onMounted(() => {
-    video.value?.addEventListener('play', handlePlay)
-    video.value?.addEventListener('pause', handlePause)
-    video.value?.addEventListener('volumechange', handleVolumeChange)
-    video.value?.addEventListener('playing', handlePlaybackStateChange)
-    video.value?.addEventListener('waiting', handlePlaybackStateChange)
-    video.value?.addEventListener('seeking', handlePlaybackStateChange)
-    video.value?.addEventListener('seeked', handlePlaybackStateChange)
+    video.value?.addEventListener('play', updateSkipState)
+    video.value?.addEventListener('pause', updateSkipState)
+    video.value?.addEventListener('volumechange', updateSkipState)
+    video.value?.addEventListener('seeking', updateSkipState)
+    video.value?.addEventListener('seeked', syncAnalysisAfterSeek)
+    video.value?.addEventListener('loadedmetadata', startAnalysisPipeline)
     updateEnabledState()
   })
 
   onBeforeUnmount(() => {
     destroyed = true
-    video.value?.removeEventListener('play', handlePlay)
-    video.value?.removeEventListener('pause', handlePause)
-    video.value?.removeEventListener('volumechange', handleVolumeChange)
-    video.value?.removeEventListener('playing', handlePlaybackStateChange)
-    video.value?.removeEventListener('waiting', handlePlaybackStateChange)
-    video.value?.removeEventListener('seeking', handlePlaybackStateChange)
-    video.value?.removeEventListener('seeked', handlePlaybackStateChange)
-    stop()
-    if (controlledPlaybackRateTimeout !== null) {
-      clearTimeout(controlledPlaybackRateTimeout)
+    video.value?.removeEventListener('play', updateSkipState)
+    video.value?.removeEventListener('pause', updateSkipState)
+    video.value?.removeEventListener('volumechange', updateSkipState)
+    video.value?.removeEventListener('seeking', updateSkipState)
+    video.value?.removeEventListener('seeked', syncAnalysisAfterSeek)
+    video.value?.removeEventListener('loadedmetadata', startAnalysisPipeline)
+    if (skipFrame !== null) {
+      cancelAnimationFrame(skipFrame)
     }
-    audioContext?.close()
+    reset()
   })
 
-  return {
-    accelerationRate,
-    getNormalPlaybackRate,
-    handlePlaybackRateChange,
-    isAccelerating,
-    resume,
-    suspend,
-  }
+  return { handleSegmentRequest, handleSegmentResponse, reset }
 }

--- a/src/renderer/components/ft-shaka-video-player/opentubex/useSilenceSkipping.js
+++ b/src/renderer/components/ft-shaka-video-player/opentubex/useSilenceSkipping.js
@@ -446,7 +446,15 @@ export function useSilenceSkipping({ available, enabled, isLive, video }) {
       analysisFrame = null
     }
 
-    analysisAudio?.pause()
+    if (analysisAudio) {
+      analysisAudio.removeEventListener('playing', scheduleAnalysis)
+      analysisAudio.removeEventListener('canplay', ensureAnalysisPlayback)
+      analysisAudio.removeEventListener('progress', ensureAnalysisPlayback)
+      analysisAudio.removeEventListener('seeking', resetAnalysisDetection)
+      analysisAudio.removeEventListener('seeked', ensureAnalysisPlayback)
+      analysisAudio.pause()
+    }
+    analysisSourceBuffer?.removeEventListener('updateend', processAppendQueue)
     analysisSourceNode?.disconnect()
     analysisSink?.disconnect()
     analysisAudioContext?.close().catch(() => {})

--- a/src/renderer/components/ft-shaka-video-player/opentubex/useSilenceSkipping.js
+++ b/src/renderer/components/ft-shaka-video-player/opentubex/useSilenceSkipping.js
@@ -528,7 +528,9 @@ export function useSilenceSkipping({ available, enabled, isLive, video }) {
         processAppendQueue()
       } catch (error) {
         console.warn('Unable to create look-ahead audio analysis for silence skipping', error)
-        destroyAnalysisPipeline()
+        if (generation === analysisGeneration) {
+          destroyAnalysisPipeline()
+        }
       }
     }, { once: true })
   }
@@ -559,7 +561,9 @@ export function useSilenceSkipping({ available, enabled, isLive, video }) {
       await ensureAnalysisPlayback()
     } catch (error) {
       console.warn('Unable to analyse downloaded audio for silence skipping', error)
-      destroyAnalysisPipeline()
+      if (generation === analysisGeneration) {
+        destroyAnalysisPipeline()
+      }
     }
   }
 

--- a/src/renderer/components/ft-shaka-video-player/opentubex/useVoiceOverTranslation.js
+++ b/src/renderer/components/ft-shaka-video-player/opentubex/useVoiceOverTranslation.js
@@ -43,6 +43,7 @@ export function getVoiceOverPlaybackRate(playbackRate, drift) {
  *   videoId: import('vue').ComputedRef<string>,
  *   responseLanguage: import('vue').ComputedRef<'ru' | 'en' | 'kk'>,
  *   autoPrepare: import('vue').ComputedRef<boolean>,
+ *   originalVolume: import('vue').ComputedRef<number>,
  *   voiceVolume: import('vue').ComputedRef<number>,
  *   onError: (error: unknown) => void
  * }} options
@@ -52,6 +53,7 @@ export function useVoiceOverTranslation({
   videoId,
   responseLanguage,
   autoPrepare,
+  originalVolume,
   voiceVolume,
   onError
 }) {
@@ -69,6 +71,66 @@ export function useVoiceOverTranslation({
   let requestGeneration = 0
   let pollAttempts = 0
   let enableOnReady = false
+  let destroyed = false
+
+  /** @type {AudioContext | null} */
+  let outputAudioContext = null
+  /** @type {GainNode | null} */
+  let outputGainNode = null
+  let outputGraphSetupPromise = null
+
+  async function setupOutputGraph() {
+    if (outputGainNode) {
+      return
+    }
+
+    const videoElement = video.value
+    if (!videoElement) {
+      return
+    }
+
+    outputAudioContext ??= new AudioContext()
+    await outputAudioContext.resume()
+    if (destroyed || video.value !== videoElement) {
+      return
+    }
+
+    // A media element can only have one MediaElementAudioSourceNode. Future
+    // output processing for the player must reuse this graph.
+    const source = outputAudioContext.createMediaElementSource(videoElement)
+    outputGainNode = outputAudioContext.createGain()
+    outputGainNode.gain.value = enabled.value ? originalVolume.value : 1
+    source.connect(outputGainNode)
+    outputGainNode.connect(outputAudioContext.destination)
+  }
+
+  async function updateOriginalVolume() {
+    const initialGain = enabled.value ? originalVolume.value : 1
+    if (!outputGainNode && initialGain !== 1) {
+      try {
+        outputGraphSetupPromise ??= setupOutputGraph()
+        await outputGraphSetupPromise
+        if (!outputGainNode) {
+          outputGraphSetupPromise = null
+        }
+      } catch (error) {
+        if (!outputGainNode) {
+          outputGraphSetupPromise = null
+        }
+        console.warn('Unable to adjust original audio volume', error)
+        return
+      }
+    }
+
+    if (!outputGainNode) {
+      return
+    }
+
+    const gain = enabled.value ? originalVolume.value : 1
+    const now = outputGainNode.context.currentTime
+    outputGainNode.gain.cancelScheduledValues(now)
+    outputGainNode.gain.setTargetAtTime(gain, now, 0.015)
+  }
 
   function clearPollTimeout() {
     if (pollTimeout !== null) {
@@ -367,12 +429,18 @@ export function useVoiceOverTranslation({
   }
 
   onBeforeUnmount(() => {
+    destroyed = true
     reset()
     if (video.value) {
       detach(video.value)
     }
+    outputAudioContext?.close().catch(() => {})
+    outputAudioContext = null
+    outputGainNode = null
+    outputGraphSetupPromise = null
   })
 
+  watch([enabled, originalVolume], updateOriginalVolume)
   watch(voiceVolume, syncAudioPlayback)
 
   return {

--- a/src/renderer/components/ft-shaka-video-player/player-components/SkipSilenceButton.js
+++ b/src/renderer/components/ft-shaka-video-player/player-components/SkipSilenceButton.js
@@ -1,7 +1,7 @@
 import shaka from 'shaka-player'
 import { watch } from 'vue'
 
-import { KeyboardShortcuts } from '../../../../constants'
+import { KeyboardShortcuts, PlayerIcons } from '../../../../constants'
 import i18n from '../../../i18n/index'
 import { addKeyboardShortcutToActionTitle } from '../../../helpers/utils'
 
@@ -29,7 +29,7 @@ export class SkipSilenceButton extends shaka.ui.Element {
     /** @private */
     this.icon_ = new shaka.ui.Icon(
       this.button_,
-      shaka.ui.Enums.MaterialDesignSVGIcons.FAST_FORWARD
+      PlayerIcons.SKIP_NEXT_FILLED
     )
 
     const label = document.createElement('label')
@@ -94,7 +94,7 @@ export class SkipSilenceButton extends shaka.ui.Element {
 
   /** @private */
   updateLocalisedStrings_() {
-    const baseLabel = i18n.global.t('Settings.Player Settings.Fast-Forward Through Silence')
+    const baseLabel = i18n.global.t('Settings.Player Settings.Skip Silence')
     const shortcut = KeyboardShortcuts.VIDEO_PLAYER.PLAYBACK.TOGGLE_SKIP_SILENCE
     const label = shortcut
       ? addKeyboardShortcutToActionTitle(baseLabel, shortcut)

--- a/src/renderer/helpers/settings-search-config.js
+++ b/src/renderer/helpers/settings-search-config.js
@@ -82,5 +82,6 @@ export const SETTINGS_SEARCH_SELECT_GROUP_LABELS = {
 
 export const SETTINGS_SEARCH_EXCLUDED_MESSAGE_PATHS = {
   general: new Set(['System Default']),
+  player: new Set(['Skip Silence']),
   'caption-appearance': new Set(['Application Language'])
 }

--- a/static/locales/de-DE.yaml
+++ b/static/locales/de-DE.yaml
@@ -502,8 +502,8 @@ Settings:
     Scroll Playback Rate Over Video Player: Abspielgeschwindigkeit durch Scrollen ändern
     Video Playback Rate Interval: Intervall für Geschwindigkeitseinstellung
     Max Video Playback Rate: Maximale Wiedergabegeschwindigkeit
-    Fast-Forward Through Silence: Stille vorspulen
-    Show Fast-Forward Through Silence Toggle: Schalter „Stille vorspulen“ anzeigen
+    Skip Silence: Stille überspringen
+    Show Skip Silence Toggle: Schalter „Stille überspringen“ anzeigen
     Hold to Double Playback Speed: Für doppelte Wiedergabegeschwindigkeit gedrückt halten
     Screenshot:
       Enable: Screenshots aktivieren
@@ -1356,7 +1356,7 @@ Tooltips:
     Skip by Scrolling Over Video Player: Verwende das Scrollrad, um durch das Video zu springen, MPV-Stil.
     Multiply Seek Interval by Playback Rate: Wenn aktiviert, werden Sprungintervalle (Pfeiltasten und J/L) mit der aktuellen Wiedergabegeschwindigkeit multipliziert. Wenn deaktiviert, bleiben die Sprungintervalle unabhängig von der Wiedergabegeschwindigkeit konstant.
     Show Playback Rate Adjusted Timestamp: Wenn aktiviert und die Wiedergabegeschwindigkeit nicht 1x ist, zeigt der Player nach der normalen Zeitanzeige zusätzliche angepasste Zeitstempel in Klammern an.
-    Show Fast-Forward Through Silence Toggle: Zeigt im Einstellungsmenü des Players einen Ein-/Aus-Schalter zum Vorspulen von Stille an.
+    Show Skip Silence Toggle: Zeigt im Einstellungsmenü des Players einen Ein-/Aus-Schalter zum Überspringen von Stille an.
     Hold to Double Playback Speed: Halte die Leertaste oder die linke Maustaste über dem Player gedrückt, um die aktuelle Wiedergabegeschwindigkeit vorübergehend zu verdoppeln.
     Ambient Mode: Lässt die Farben des Videos in den Bereich um den Player ausstrahlen.
     Default Volume: Deaktiviert, wenn Lautstärke beibehalten aktiviert ist. Schalte Lautstärke beibehalten aus, um eine feste Lautstärke beim Start jedes Videos zu setzen.
@@ -1530,7 +1530,7 @@ KeyboardShortcutPrompt:
   Skip by Tenths: Prozentuales Überspringen des Videos (3 Sprünge bis 30% der Dauer)
   Next Frame: Nächstes Bild (bei pausierter Wiedergabe)
   Small Rewind: X Sekunden zurückspulen, basierend auf dem Rückspulintervall und der aktuellen Wiedergabegeschwindigkeit
-  Toggle Fast-Forward Through Silence: Vorspulen von Stille umschalten
+  Toggle Skip Silence: Überspringen von Stille umschalten
   End: Zum Ende des Videos springen
   Home: Zum Anfang des Videos springen
   Skip to Next Video: Zum nächsten Video in der Playlist bzw. nächsten empfohlenen Video springen

--- a/static/locales/en-US.yaml
+++ b/static/locales/en-US.yaml
@@ -828,8 +828,8 @@ Settings:
     Fast-Forward / Rewind Interval: Fast-Forward / Rewind Interval
     Default Volume: Default Volume
     Remember Volume: Remember Volume
-    Fast-Forward Through Silence: Fast-Forward Through Silence
-    Show Fast-Forward Through Silence Toggle: Show Fast-Forward Through Silence Toggle
+    Skip Silence: Skip Silence
+    Show Skip Silence Toggle: Show Skip Silence Toggle
     Enable Video Zoom: Enable Video Zoom
     Voice-over Translation:
       Title: Voice-over translation
@@ -2066,7 +2066,7 @@ Tooltips:
     Show Playback Rate Adjusted Timestamp: When enabled and playback speed differs from 1x, the player shows playback-rate-adjusted timestamps in parentheses after the normal timestamp display.
     Use YouTube-style Shorts: Displays Shorts in a portrait grid on subscription and channel pages and uses the YouTube-style Shorts player.
     Loop Shorts: When enabled, Shorts restart automatically. When disabled, Shorts stop at the end and show a replay button.
-    Show Fast-Forward Through Silence Toggle: Shows an on/off toggle for fast-forwarding through silence in the player's settings menu.
+    Show Skip Silence Toggle: Shows an on/off toggle for skipping silence in the player's settings menu.
     Enable Video Zoom: Shows the Zoom control in the player's settings menu and enables its keyboard shortcuts and panning controls.
     Voice-over Translation: Sends the video ID, duration, and selected language to the unofficial Yandex voice-over translation service when you request a translation. Disabled by default.
     Hold to Double Playback Speed: Hold the Spacebar or left mouse button over the player to temporarily double the current playback speed.
@@ -2251,7 +2251,7 @@ KeyboardShortcutPrompt:
   Decrease Video Speed: 'Decrease video speed based on Video Playback Rate Interval'
   Increase Video Speed: 'Increase video speed based on Video Playback Rate Interval'
   Toggle Normal Playback Speed: Toggle between 1x speed and the previous playback speed
-  Toggle Fast-Forward Through Silence: Toggle fast-forward through silence
+  Toggle Skip Silence: Toggle skip silence
   Full Window: Toggle full window
   Theatre Mode: Toggle theater mode
   Take Screenshot: Take screenshot

--- a/static/locales/pl.yaml
+++ b/static/locales/pl.yaml
@@ -569,8 +569,8 @@ Settings:
       On Window Minimize: Podczas minimalizowania okna
       On Window Hide: Gdy okno traci skupienie lub jest przełączane
       Wayland Minimize Unsupported: Wayland nie zgłasza aplikacjom minimalizacji okna, więc ten wyzwalacz jest niedostępny. Zamiast tego użyj opcji „Gdy okno traci skupienie lub jest przełączane”, która obejmuje również minimalizowanie.
-    Fast-Forward Through Silence: Szybkie przewijanie poprzez ciszę
-    Show Fast-Forward Through Silence Toggle: Pokaż przełącznik szybkiego przewijania poprzez ciszę
+    Skip Silence: Pomijanie ciszy
+    Show Skip Silence Toggle: Pokaż przełącznik pomijania ciszy
     Hold to Double Playback Speed: Przytrzymaj, aby podwoić prędkość odtwarzania
     Automatically Open Chapters: Automatycznie otwieraj rozdziały
     Use YouTube-style Shorts: Użyj stylu Filmów Short z YouTube
@@ -1444,7 +1444,7 @@ Tooltips:
     Show Playback Rate Adjusted Timestamp: Jeśli włączone, a prędkość odtwarzania jest inna niż 1x, odtwarzacz wyświetla w nawiasach po normalnym wyświetlaniu znaczników czasu znaczniki czasu dostosowane do prędkości odtwarzania.
     Default Volume: Wyłączone, gdy opcja zapamiętywania głośności na kanale jest włączona. Wyłącz zapamiętywanie głośności na kanale, aby ustawić stałą głośność początkową dla każdego filmu.
     Enable Caption Translations: Po włączeniu, przycisk napisów i skrót C będą preferować automatycznie przetłumaczoną ścieżkę w preferowanym języku napisów, jeśli film nie zawiera pasującej oryginalnej ścieżki.
-    Show Fast-Forward Through Silence Toggle: Pokazuje przełącznik szybkiego przewijania przez ciszę w menu ustawień odtwarzacza.
+    Show Skip Silence Toggle: Pokazuje przełącznik pomijania ciszy w menu ustawień odtwarzacza.
     Hold to Double Playback Speed: Przytrzymaj klawisz spacji lub lewy przycisk myszy nad odtwarzaczem, aby tymczasowo podwoić aktualną prędkość odtwarzania.
     Ambient Mode: Rzutuje kolory odtwarzanego wideo na obszar wokół odtwarzacza.
   External Player Settings:
@@ -1638,7 +1638,7 @@ KeyboardShortcutPrompt:
   Reserved Shortcut Conflict: '{shortcut} jest zarezerwowany dla {actions} i nie można go ponownie przypisać.'
   Reassign: Przypisz ponownie
   Undo: Cofnij
-  Toggle Fast-Forward Through Silence: Przełączanie szybkiego przewijania przez ciszę
+  Toggle Skip Silence: Przełącz pomijanie ciszy
   Toggle Tab Orientation: Przełączanie między kartami poziomymi i pionowymi
 shortcutLabelSeparator: ｜
 Compact side navigation: Skompresuj boczną nawigację

--- a/tests/unit/silence-skipping.test.mjs
+++ b/tests/unit/silence-skipping.test.mjs
@@ -1,0 +1,48 @@
+import assert from 'node:assert/strict'
+import test from 'node:test'
+
+import {
+  createRequestPresentationTracker,
+  releaseAnalysisSegmentsBefore
+} from '../../src/renderer/components/ft-shaka-video-player/opentubex/useSilenceSkipping.js'
+
+test('rejects late responses from an earlier presentation', () => {
+  const tracker = createRequestPresentationTracker()
+  const previousRequest = {}
+  const currentRequest = {}
+
+  tracker.beginRequest(previousRequest)
+  tracker.reset()
+  tracker.beginRequest(currentRequest)
+
+  assert.equal(tracker.isCurrent(previousRequest), false)
+  assert.equal(tracker.isCurrent(currentRequest), true)
+})
+
+test('does not relabel a retried request after the presentation changes', () => {
+  const tracker = createRequestPresentationTracker()
+  const retriedRequest = {}
+
+  tracker.beginRequest(retriedRequest)
+  tracker.reset()
+  tracker.beginRequest(retriedRequest)
+
+  assert.equal(tracker.isCurrent(retriedRequest), false)
+})
+
+test('allows evicted analysis segments to be queued again after a backward seek', () => {
+  const initSegment = { end: Number.NEGATIVE_INFINITY, key: 'init' }
+  const evictedSegment = { end: 20, key: 'old' }
+  const retainedSegment = { end: 50, key: 'current' }
+  const analysisSegments = new Map([
+    [initSegment.key, initSegment],
+    [evictedSegment.key, evictedSegment],
+    [retainedSegment.key, retainedSegment]
+  ])
+  const appendQueue = [evictedSegment, retainedSegment]
+
+  releaseAnalysisSegmentsBefore(analysisSegments, appendQueue, 30)
+
+  assert.deepEqual([...analysisSegments.keys()], ['init', 'current'])
+  assert.deepEqual(appendQueue, [retainedSegment])
+})


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Make sure to follow the contributing guidelines. -->
<!-- Important note, we may remove your pull request if you do not use this provided PR template correctly. -->
<!-- Agent instructions: Preserve every heading, comment, and marker in this template. Never remove or rewrite the release-note-category:start/end, release-note:start/end, or release-note-image:start/end marker pairs. Never remove or rewrite the Release note images section; leave its contents for a human. -->

## Pull Request Type
<!-- Please select what type of pull request this is: [x] -->
- [ ] Bugfix
- [x] Feature Implementation
- [ ] Documentation
- [ ] Other

## Related issue
<!-- Please link the issue your pull request is referring to. -->
<!-- If this pull request fully resolves the relevant issue, put "closes" before the issue number. -->
<!-- Example: "closes #123456". -->

Closes #563.

## Description
<!-- Please write a clear and concise description of what the pull request does. -->

Fast-Forward Through Silence only increased playback speed, so silent sections were still played and the feature did not match its new Skip Silence name.

This replaces acceleration with a muted look-ahead audio pipeline fed by the adaptive audio segments Shaka already downloaded. Detected silent ranges are recorded ahead of visible playback, allowing the player to seek directly to the end of each range while leaving the user's playback rate unchanged. It also updates the labels, icon, settings search target, shortcut feedback, translations, and documentation to consistently use Skip Silence.

## Release note category
<!-- Select exactly one category. Every pull request must select one. -->
<!-- Select "Not noteworthy" when the pull request fixes a bug in or improves functionality that has not yet appeared in a stable release. -->
<!-- release-note-category:start -->
- [ ] Not noteworthy
- [ ] Highlights
- [x] More improvements
- [ ] Fixed bugs
<!-- release-note-category:end -->

## Release note
<!-- Required unless "Not noteworthy" is selected. -->
<!-- Write one concise, user-facing entry without a leading bullet. -->
<!-- release-note:start -->
Skip Silence now jumps over detected silent sections instead of speeding through them.
<!-- release-note:end -->

## Release note images
<!-- Human-only: Agents must preserve this entire section and leave it empty. -->
<!-- Optional. Paste one or more Markdown images or HTML image tags here. -->
<!-- The release notes will use an HTML image tag and limit images taller than 300 pixels. -->
<!-- release-note-image:start -->

<!-- release-note-image:end -->

## Testing
<!-- How can reviewers verify that the PR produces correct results? -->
<!-- Please provide instructions so that others can ensure that your pull request would produce correct results. For examples see, https://github.com/FreeTubeApp/FreeTube/pull/5743, https://github.com/FreeTubeApp/FreeTube/pull/7349, https://github.com/FreeTubeApp/FreeTube/pull/5125, https://github.com/FreeTubeApp/FreeTube/pull/7338 -->
<!-- Agent instructions: Only write human-facing steps that explain how to verify the change while running this branch in dev mode. Include expected results and, when applicable, helpful console snippets for interactive verification. Do not include automated checks, commands, results, pass counts, or CI status. -->

1. In Player settings, enable **Show Skip Silence Toggle**.
2. Play a video and enable **Skip Silence** in the player's settings menu.
3. Confirm the silent section is skipped in one jump and the displayed playback rate remains unchanged.
4. Search settings for **Skip Silence**, select **Show Skip Silence Toggle**, and confirm that toggle is opened and highlighted.

## Additional context
<!-- Add any other context about the pull request here. -->

The look-ahead pipeline reuses audio responses already fetched for playback and retains only a bounded set of recent segments.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Rewrites core Shaka player playback and networking behavior (segment capture, seeks, audio pipelines) in a user-facing feature, though e2e and unit tests mitigate regression risk.
> 
> **Overview**
> **Skip Silence** no longer speeds up playback during quiet parts. It **seeks** over detected silence while the user’s chosen playback rate stays unchanged.
> 
> The player wires Shaka segment request/response filters into a rewritten `useSilenceSkipping`: a muted, faster **look-ahead** pipeline reuses downloaded adaptive audio, builds silence ranges, and the main video jumps to each range’s end. The old acceleration overlay, playback-rate hijacking, and suspend/resume around temporary speed boosts are removed; shortcut feedback uses a volume-xmark icon instead of fast-forward.
> 
> **Voice-over translation** now applies **original audio volume** through its own `MediaElementAudioSourceNode` graph (freeing the main video element from silence-skipping gain routing). UI copy, the skip-silence control icon, settings search, README, and locale strings are aligned on **Skip Silence**. Coverage adds a network e2e that asserts a forward jump with playback rate still at 1x, settings-search e2e, and unit tests for segment presentation tracking and buffer eviction after seeks.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9d308babb9fa1bd3d2ba31c5534f0d3e0dab32c1. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->