### PR TITLE
fix(channel): prevent tab width changes on hover

### DIFF
--- a/e2e/tests/network/channel.spec.mjs
+++ b/e2e/tests/network/channel.spec.mjs
@@ -24,6 +24,16 @@ test.describe('channel page', () => {
     await expect(page.locator('.channelDetails .infoContainer')).toHaveCSS('border-bottom-left-radius', '16px')
     await expect(page.locator('.channelDetails .infoContainer')).toHaveCSS('border-bottom-right-radius', '16px')
 
+    await page.locator('body').evaluate(element => {
+      element.style.fontFamily = 'Arial, sans-serif'
+    })
+
+    const aboutTab = page.getByRole('tab', { name: 'About' })
+    await expect(aboutTab).toHaveAttribute('aria-selected', 'false')
+    const widthBeforeHover = (await aboutTab.boundingBox()).width
+    await aboutTab.hover()
+    expect((await aboutTab.boundingBox()).width).toBe(widthBeforeHover)
+
     // Channel tab changes must update the route and title without creating a
     // new history entry for every tab selection (796650405, 912e5ea6e).
     await expect(page.locator(sel.activeTab)).toContainText('Blender')

--- a/src/renderer/components/ChannelDetails/ChannelDetails.css
+++ b/src/renderer/components/ChannelDetails/ChannelDetails.css
@@ -111,6 +111,21 @@
   border-block-end: 3px solid var(--border-color);
 }
 
+.tabLabel {
+  display: inline-grid;
+}
+
+.tabLabel::after {
+  content: attr(data-label);
+  grid-area: 1 / 1;
+  font-weight: bold;
+  visibility: hidden;
+}
+
+.tabLabel > span {
+  grid-area: 1 / 1;
+}
+
 .selectedTab {
   color: var(--primary-text-color);
   border-block-end: 3px solid var(--primary-color);

--- a/src/renderer/components/ChannelDetails/ChannelDetails.vue
+++ b/src/renderer/components/ChannelDetails/ChannelDetails.vue
@@ -90,7 +90,10 @@
             @keydown.left.right="focusTab('home', $event)"
             @keydown.enter.space.prevent="changeTab('home')"
           >
-            {{ $t("Channel.Home.Home") }}
+            <span
+              class="tabLabel"
+              :data-label="$t('Channel.Home.Home')"
+            ><span>{{ $t("Channel.Home.Home") }}</span></span>
           </div>
           <!-- eslint-disable-next-line vuejs-accessibility/interactive-supports-focus -->
           <div
@@ -106,7 +109,10 @@
             @keydown.left.right="focusTab('videos', $event)"
             @keydown.enter.space.prevent="changeTab('videos')"
           >
-            {{ $t("Channel.Videos.Videos") }}
+            <span
+              class="tabLabel"
+              :data-label="$t('Channel.Videos.Videos')"
+            ><span>{{ $t("Channel.Videos.Videos") }}</span></span>
           </div>
           <!-- eslint-disable-next-line vuejs-accessibility/interactive-supports-focus -->
           <div
@@ -122,7 +128,10 @@
             @keydown.left.right="focusTab('shorts', $event)"
             @keydown.enter.space.prevent="changeTab('shorts')"
           >
-            {{ $t("Global.Shorts") }}
+            <span
+              class="tabLabel"
+              :data-label="$t('Global.Shorts')"
+            ><span>{{ $t("Global.Shorts") }}</span></span>
           </div>
           <!-- eslint-disable-next-line vuejs-accessibility/interactive-supports-focus -->
           <div
@@ -138,7 +147,10 @@
             @keydown.left.right="focusTab('live', $event)"
             @keydown.enter.space.prevent="changeTab('live')"
           >
-            {{ $t("Channel.Live.Live") }}
+            <span
+              class="tabLabel"
+              :data-label="$t('Channel.Live.Live')"
+            ><span>{{ $t("Channel.Live.Live") }}</span></span>
           </div>
           <!-- eslint-disable-next-line vuejs-accessibility/interactive-supports-focus -->
           <div
@@ -154,7 +166,10 @@
             @keydown.left.right="focusTab('releases', $event)"
             @keydown.enter.space.prevent="changeTab('releases')"
           >
-            {{ $t("Channel.Releases.Releases") }}
+            <span
+              class="tabLabel"
+              :data-label="$t('Channel.Releases.Releases')"
+            ><span>{{ $t("Channel.Releases.Releases") }}</span></span>
           </div>
           <!-- eslint-disable-next-line vuejs-accessibility/interactive-supports-focus -->
           <div
@@ -170,7 +185,10 @@
             @keydown.left.right="focusTab('podcasts', $event)"
             @keydown.enter.space.prevent="changeTab('podcasts')"
           >
-            {{ $t("Channel.Podcasts.Podcasts") }}
+            <span
+              class="tabLabel"
+              :data-label="$t('Channel.Podcasts.Podcasts')"
+            ><span>{{ $t("Channel.Podcasts.Podcasts") }}</span></span>
           </div>
           <!-- eslint-disable-next-line vuejs-accessibility/interactive-supports-focus -->
           <div
@@ -186,7 +204,10 @@
             @keydown.left.right="focusTab('courses', $event)"
             @keydown.enter.space.prevent="changeTab('courses')"
           >
-            {{ $t("Channel.Courses.Courses") }}
+            <span
+              class="tabLabel"
+              :data-label="$t('Channel.Courses.Courses')"
+            ><span>{{ $t("Channel.Courses.Courses") }}</span></span>
           </div>
           <!-- eslint-disable-next-line vuejs-accessibility/interactive-supports-focus -->
           <div
@@ -202,7 +223,10 @@
             @keydown.left.right="focusTab('playlists', $event)"
             @keydown.enter.space.prevent="changeTab('playlists')"
           >
-            {{ $t("Channel.Playlists.Playlists") }}
+            <span
+              class="tabLabel"
+              :data-label="$t('Channel.Playlists.Playlists')"
+            ><span>{{ $t("Channel.Playlists.Playlists") }}</span></span>
           </div>
           <!-- eslint-disable-next-line vuejs-accessibility/interactive-supports-focus -->
           <div
@@ -218,7 +242,10 @@
             @keydown.left.right="focusTab('community', $event)"
             @keydown.enter.space.prevent="changeTab('community')"
           >
-            {{ $t("Global.Posts") }}
+            <span
+              class="tabLabel"
+              :data-label="$t('Global.Posts')"
+            ><span>{{ $t("Global.Posts") }}</span></span>
           </div>
           <!-- eslint-disable-next-line vuejs-accessibility/interactive-supports-focus -->
           <div
@@ -233,7 +260,10 @@
             @keydown.left.right="focusTab('about', $event)"
             @keydown.enter.space.prevent="changeTab('about')"
           >
-            {{ $t("Channel.About.About") }}
+            <span
+              class="tabLabel"
+              :data-label="$t('Channel.About.About')"
+            ><span>{{ $t("Channel.About.About") }}</span></span>
           </div>
         </div>
 

--- a/src/renderer/views/Subscriptions/Subscriptions.vue
+++ b/src/renderer/views/Subscriptions/Subscriptions.vue
@@ -968,8 +968,7 @@ watch([selectedTab, visibleTabs, refreshingFeedTab], () => nextTick(updateTabsIn
 
 onMounted(() => {
   if (typeof ResizeObserver === 'function') {
-    // Tab widths shift on hover (bold text) and when the per-tab loader
-    // appears, which also resizes the container
+    // Per-tab loaders resize the container while a refresh is running
     tabsResizeObserver = new ResizeObserver(() => updateTabsIndicator())
 
     if (tabsContainerRef.value?.$el instanceof HTMLElement) {


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Make sure to follow the contributing guidelines. -->
<!-- Important note, we may remove your pull request if you do not use this provided PR template correctly. -->
<!-- Agent instructions: Preserve every heading, comment, and marker in this template. Never remove or rewrite the release-note-category:start/end, release-note:start/end, or release-note-image:start/end marker pairs. Never remove or rewrite the Release note images section; leave its contents for a human. -->

## Pull Request Type
<!-- Please select what type of pull request this is: [x] -->
- [x] Bugfix
- [ ] Feature Implementation
- [ ] Documentation
- [ ] Other

## Related issue
<!-- Please link the issue your pull request is referring to. -->
<!-- If this pull request fully resolves the relevant issue, put "closes" before the issue number. -->
<!-- Example: "closes #123456". -->
Follow-up to #793.

## Description
<!-- Please write a clear and concise description of what the pull request does. -->
Channel-page tabs still changed width on hover with fonts whose bold glyphs are wider than their regular glyphs, moving adjacent tabs even after the subscription feed tabs were fixed.

Apply the same bold-width reservation to every channel tab so hover, focus, and selection can change the visible weight without changing tab geometry. Extend the channel-page regression coverage with Arial and update the subscription observer comment now that hover no longer resizes those tabs.

## Release note category
<!-- Select exactly one category. Every pull request must select one. -->
<!-- Select "Not noteworthy" when the pull request fixes a bug in or improves functionality that has not yet appeared in a stable release. -->
<!-- release-note-category:start -->
- [ ] Not noteworthy
- [ ] Highlights
- [ ] More improvements
- [x] Fixed bugs
<!-- release-note-category:end -->

## Release note
<!-- Required unless "Not noteworthy" is selected. -->
<!-- Write one concise, user-facing entry without a leading bullet. -->
<!-- release-note:start -->
Fixed channel tabs shifting when hovered while using certain custom fonts.
<!-- release-note:end -->

## Release note images
<!-- Human-only: Agents must preserve this entire section and leave it empty. -->
<!-- Optional. Paste one or more Markdown images or HTML image tags here. -->
<!-- The release notes will use an HTML image tag and limit images taller than 300 pixels. -->
<!-- release-note-image:start -->

<!-- release-note-image:end -->

## Testing
<!-- How can reviewers verify that the PR produces correct results? -->
<!-- Please provide instructions so that others can ensure that your pull request would produce correct results. For examples see, https://github.com/FreeTubeApp/FreeTube/pull/5743, https://github.com/FreeTubeApp/FreeTube/pull/7349, https://github.com/FreeTubeApp/FreeTube/pull/5125, https://github.com/FreeTubeApp/FreeTube/pull/7338 -->
<!-- Agent instructions: Only write human-facing steps that explain how to verify the change while running this branch in dev mode. Include expected results and, when applicable, helpful console snippets for interactive verification. Do not include automated checks, commands, results, pass counts, or CI status. -->
1. Set the application font to Arial, SF Pro Display, or another font with different regular and bold glyph widths.
2. Open a channel page that exposes several channel tabs.
3. Hover and keyboard-focus the tabs, then switch between them.
4. Confirm the text weight and underline change without resizing tabs or moving adjacent tabs.

## Additional context
<!-- Add any other context about the pull request here. -->