### PR TITLE
feat: add media controls to the macOS Dock menu

### DIFF
--- a/src/constants.js
+++ b/src/constants.js
@@ -80,6 +80,8 @@ const IpcChannels = {
   TABS_IS_ACTIVE: 'tabs-is-active',
   TABS_GO_HISTORY: 'tabs-go-history',
   TABS_SET_PLAYBACK_STATE: 'tabs-set-playback-state',
+  TABS_SET_MEDIA_SESSION_STATE: 'tabs-set-media-session-state',
+  TABS_REQUEST_MEDIA_SESSION_ACTION: 'tabs-request-media-session-action',
   TABS_SET_SKIP_SILENCE: 'tabs-set-skip-silence',
   TABS_REQUEST_PICTURE_IN_PICTURE: 'tabs-request-picture-in-picture',
   WINDOW_MINIMIZED_STATE: 'window-minimized-state',

--- a/src/main/dockMediaSession.js
+++ b/src/main/dockMediaSession.js
@@ -1,13 +1,10 @@
 /**
- * Decide whether a renderer update represents newly owned playback rather than
- * another publication of the current Media Session state.
- * @param {{playbackState: string, ownerId: string | null} | undefined} previous
+ * Decide whether a renderer update represents newly started or resumed
+ * playback rather than another publication of the current Media Session state.
  * @param {string} playbackState
- * @param {string | null} ownerId
+ * @param {boolean} playbackStarted
  * @returns {boolean}
  */
-export function shouldAdvanceDockMediaSequence(previous, playbackState, ownerId) {
-  return playbackState === 'playing' && (
-    previous?.playbackState !== 'playing' || previous.ownerId !== ownerId
-  )
+export function shouldAdvanceDockMediaSequence(playbackState, playbackStarted) {
+  return playbackState === 'playing' && playbackStarted === true
 }

--- a/src/main/dockMediaSession.js
+++ b/src/main/dockMediaSession.js
@@ -1,0 +1,13 @@
+/**
+ * Decide whether a renderer update represents newly owned playback rather than
+ * another publication of the current Media Session state.
+ * @param {{playbackState: string, ownerId: string | null} | undefined} previous
+ * @param {string} playbackState
+ * @param {string | null} ownerId
+ * @returns {boolean}
+ */
+export function shouldAdvanceDockMediaSequence(previous, playbackState, ownerId) {
+  return playbackState === 'playing' && (
+    previous?.playbackState !== 'playing' || previous.ownerId !== ownerId
+  )
+}

--- a/src/main/index.js
+++ b/src/main/index.js
@@ -62,6 +62,7 @@ import { fetchFaviconDataUrl, resolveFaviconUrl } from './favicon'
 import { LiveReminderManager } from './LiveReminderManager'
 import { requestVoiceOverTranslation } from './voiceOverTranslation'
 import { clearVideoMetadataCache, getVideoMetadataCacheSize, updateVideoMetadataCache } from './videoMetadataCache'
+import { shouldAdvanceDockMediaSequence } from './dockMediaSession'
 
 const brotliDecompressAsync = promisify(brotliDecompress)
 if (process.argv.includes('--version')) {
@@ -220,12 +221,19 @@ function runApp() {
     const playbackState = ['playing', 'paused', 'none'].includes(state.playbackState)
       ? state.playbackState
       : 'none'
+    const ownerId = typeof state.ownerId === 'string' ? state.ownerId : null
+    const shouldAdvanceSequence = shouldAdvanceDockMediaSequence(
+      previous,
+      playbackState,
+      ownerId
+    )
     dockMediaSessions.set(windowId, {
       manager,
       playbackState,
+      ownerId,
       hasMetadata: state.hasMetadata === true,
       actions: new Set(Array.isArray(state.actions) ? state.actions : []),
-      lastPlayedAt: playbackState === 'playing'
+      lastPlayedAt: shouldAdvanceSequence
         ? ++dockMediaPlaySequence
         : previous?.lastPlayedAt ?? 0,
       updatedAt: Date.now()

--- a/src/main/index.js
+++ b/src/main/index.js
@@ -221,16 +221,13 @@ function runApp() {
     const playbackState = ['playing', 'paused', 'none'].includes(state.playbackState)
       ? state.playbackState
       : 'none'
-    const ownerId = typeof state.ownerId === 'string' ? state.ownerId : null
     const shouldAdvanceSequence = shouldAdvanceDockMediaSequence(
-      previous,
       playbackState,
-      ownerId
+      state.playbackStarted
     )
     dockMediaSessions.set(windowId, {
       manager,
       playbackState,
-      ownerId,
       hasMetadata: state.hasMetadata === true,
       actions: new Set(Array.isArray(state.actions) ? state.actions : []),
       lastPlayedAt: shouldAdvanceSequence

--- a/src/main/index.js
+++ b/src/main/index.js
@@ -132,6 +132,108 @@ function runApp() {
   const ROOT_APP_URL = process.env.NODE_ENV === 'development' ? `http://localhost:${devServerPort}` : 'app://bundle/index.html'
   const CUSTOM_THEMES_PATH = path.join(app.getPath('userData'), CUSTOM_THEMES_DIRECTORY)
 
+  const dockMediaSessions = new Map()
+  const dockMediaTrackedWindowIds = new Set()
+  let dockMediaPlaySequence = 0
+
+  function getDockMediaSession() {
+    const sessions = Array.from(dockMediaSessions.values())
+      .filter(({ manager }) => !manager.browserWindow.isDestroyed())
+    const playingSessions = sessions.filter(({ playbackState }) => playbackState === 'playing')
+
+    if (playingSessions.length > 0) {
+      return playingSessions.reduce((latest, session) => (
+        session.lastPlayedAt > latest.lastPlayedAt ? session : latest
+      ))
+    }
+
+    const focusedSession = sessions.find(({ manager, hasMetadata }) => (
+      hasMetadata && manager.browserWindow.isFocused()
+    ))
+    if (focusedSession) {
+      return focusedSession
+    }
+
+    return sessions
+      .filter(({ hasMetadata }) => hasMetadata)
+      .sort((left, right) => right.updatedAt - left.updatedAt)[0] ?? null
+  }
+
+  function requestDockMediaAction(action) {
+    const session = getDockMediaSession()
+    if (!session || !session.actions.has(action)) {
+      return
+    }
+    session.manager.bridge.send(IpcChannels.TABS_REQUEST_MEDIA_SESSION_ACTION, action)
+  }
+
+  function updateDockMenu() {
+    if (process.platform !== 'darwin' || !app.dock) {
+      return
+    }
+
+    const session = getDockMediaSession()
+    const actions = session?.actions ?? new Set()
+    const toggleAction = session?.playbackState === 'playing' ? 'pause' : 'play'
+    const dockMenu = Menu.buildFromTemplate([
+      {
+        label: 'Previous',
+        enabled: actions.has('previoustrack'),
+        click: () => requestDockMediaAction('previoustrack')
+      },
+      {
+        label: 'Play/Pause',
+        enabled: actions.has(toggleAction),
+        click: () => requestDockMediaAction(toggleAction)
+      },
+      {
+        label: 'Next',
+        enabled: actions.has('nexttrack'),
+        click: () => requestDockMediaAction('nexttrack')
+      },
+      { type: 'separator' },
+      {
+        label: 'New Window',
+        click: () => {
+          createWindow({
+            replaceMainWindow: false,
+            showWindowNow: true
+          })
+        }
+      }
+    ])
+    app.dock.setMenu(dockMenu)
+  }
+
+  function updateDockMediaSession(manager, state) {
+    const windowId = manager.browserWindow.id
+    const previous = dockMediaSessions.get(windowId)
+    const playbackState = ['playing', 'paused', 'none'].includes(state.playbackState)
+      ? state.playbackState
+      : 'none'
+    dockMediaSessions.set(windowId, {
+      manager,
+      playbackState,
+      hasMetadata: state.hasMetadata === true,
+      actions: new Set(Array.isArray(state.actions) ? state.actions : []),
+      lastPlayedAt: playbackState === 'playing'
+        ? ++dockMediaPlaySequence
+        : previous?.lastPlayedAt ?? 0,
+      updatedAt: Date.now()
+    })
+
+    if (!dockMediaTrackedWindowIds.has(windowId)) {
+      dockMediaTrackedWindowIds.add(windowId)
+      manager.browserWindow.on('focus', updateDockMenu)
+      manager.browserWindow.once('closed', () => {
+        dockMediaSessions.delete(windowId)
+        dockMediaTrackedWindowIds.delete(windowId)
+        updateDockMenu()
+      })
+    }
+    updateDockMenu()
+  }
+
   function getCustomThemePath(id) {
     if (!/^[\w-]{1,80}$/.test(id)) throw new TypeError('Invalid custom theme ID')
     return path.join(CUSTOM_THEMES_PATH, `${id}.json`)
@@ -1602,18 +1704,7 @@ function runApp() {
 
   app.on('ready', async (_, __) => {
     if (process.platform === 'darwin') {
-      const dockMenu = Menu.buildFromTemplate([
-        {
-          label: 'New Window',
-          click: () => {
-            createWindow({
-              replaceMainWindow: false,
-              showWindowNow: true
-            })
-          }
-        }
-      ])
-      app.dock.setMenu(dockMenu)
+      updateDockMenu()
     }
 
     if (process.env.NODE_ENV === 'production') {
@@ -2072,7 +2163,8 @@ function runApp() {
         if (BrowserWindow.getAllWindows().length === 1) {
           closeConfirmedWindowIds.add(browserWindow.id)
         }
-      }
+      },
+      mediaSessionStateChanged: updateDockMediaSession
     })
 
     // Restore every window that was open last time the app quit. Each window

--- a/src/main/index.js
+++ b/src/main/index.js
@@ -135,6 +135,13 @@ function runApp() {
   const dockMediaSessions = new Map()
   const dockMediaTrackedWindowIds = new Set()
   let dockMediaPlaySequence = 0
+  let dockMediaLabels = {
+    previous: 'Previous',
+    play: 'Play',
+    pause: 'Pause',
+    next: 'Next',
+    newWindow: 'New Window'
+  }
 
   function getDockMediaSession() {
     const sessions = Array.from(dockMediaSessions.values())
@@ -177,23 +184,25 @@ function runApp() {
     const toggleAction = session?.playbackState === 'playing' ? 'pause' : 'play'
     const dockMenu = Menu.buildFromTemplate([
       {
-        label: 'Previous',
+        label: dockMediaLabels.previous,
         enabled: actions.has('previoustrack'),
         click: () => requestDockMediaAction('previoustrack')
       },
       {
-        label: 'Play/Pause',
+        label: session?.playbackState === 'playing'
+          ? dockMediaLabels.pause
+          : dockMediaLabels.play,
         enabled: actions.has(toggleAction),
         click: () => requestDockMediaAction(toggleAction)
       },
       {
-        label: 'Next',
+        label: dockMediaLabels.next,
         enabled: actions.has('nexttrack'),
         click: () => requestDockMediaAction('nexttrack')
       },
       { type: 'separator' },
       {
-        label: 'New Window',
+        label: dockMediaLabels.newWindow,
         click: () => {
           createWindow({
             replaceMainWindow: false,
@@ -1704,6 +1713,14 @@ function runApp() {
 
   app.on('ready', async (_, __) => {
     if (process.platform === 'darwin') {
+      const t = await createMainTranslator()
+      dockMediaLabels = {
+        previous: t('Video.Previous'),
+        play: t('Video.Player.Scroll Mini Player.Play'),
+        pause: t('Video.Player.Scroll Mini Player.Pause'),
+        next: t('Video.Next'),
+        newWindow: t('New Window')
+      }
       updateDockMenu()
     }
 

--- a/src/main/tabs/TabManager.js
+++ b/src/main/tabs/TabManager.js
@@ -3027,11 +3027,13 @@ function cloneRoute(route) {
  * @param {object} [options]
  * @param {(browserWindow: import('electron').BrowserWindow) => boolean | Promise<boolean>} [options.confirmCloseWindow]
  * @param {(browserWindow: import('electron').BrowserWindow) => void} [options.markWindowCloseConfirmed]
+ * @param {(manager: TabManager, state: object) => void} [options.mediaSessionStateChanged]
  */
 export async function setupTabsIPC(options = {}) {
   const {
     confirmCloseWindow = () => true,
-    markWindowCloseConfirmed = () => {}
+    markWindowCloseConfirmed = () => {},
+    mediaSessionStateChanged = () => {}
   } = options
 
   // Loaded before the first window exists, so a tab can never be closed while
@@ -3383,6 +3385,13 @@ export async function setupTabsIPC(options = {}) {
     if (manager && tab && typeof playbackState === 'string') {
       tab.isPlaying = playbackState === 'playing'
       manager._broadcastStateUpdate()
+    }
+  })
+
+  ipcMain.on(IpcChannels.TABS_SET_MEDIA_SESSION_STATE, (event, state) => {
+    const manager = getManager(event)
+    if (manager && state && typeof state === 'object') {
+      mediaSessionStateChanged(manager, state)
     }
   })
 

--- a/src/preload/interface.js
+++ b/src/preload/interface.js
@@ -1092,6 +1092,25 @@ export default {
     },
 
     /**
+     * Keep native media menus in sync with the renderer-owned Media Session.
+     * @param {{playbackState: 'playing' | 'paused' | 'none', hasMetadata: boolean, actions: string[]}} state
+     */
+    setMediaSessionState: (state) => {
+      ipcRenderer.send(IpcChannels.TABS_SET_MEDIA_SESSION_STATE, state)
+    },
+
+    /**
+     * Listen for media actions requested by native application menus.
+     * @param {(action: string) => void} handler
+     * @returns {() => void}
+     */
+    onMediaSessionAction: (handler) => {
+      const listener = (_event, action) => handler(action)
+      ipcRenderer.on(IpcChannels.TABS_REQUEST_MEDIA_SESSION_ACTION, listener)
+      return () => ipcRenderer.removeListener(IpcChannels.TABS_REQUEST_MEDIA_SESSION_ACTION, listener)
+    },
+
+    /**
      * Set silence skipping for a logical tab.
      * @param {boolean} enabled
      * @param {string} tabId

--- a/src/preload/interface.js
+++ b/src/preload/interface.js
@@ -1093,7 +1093,7 @@ export default {
 
     /**
      * Keep native media menus in sync with the renderer-owned Media Session.
-     * @param {{ownerId: string | null, playbackState: 'playing' | 'paused' | 'none', hasMetadata: boolean, actions: string[]}} state
+     * @param {{playbackState: 'playing' | 'paused' | 'none', playbackStarted: boolean, hasMetadata: boolean, actions: string[]}} state
      */
     setMediaSessionState: (state) => {
       ipcRenderer.send(IpcChannels.TABS_SET_MEDIA_SESSION_STATE, state)

--- a/src/preload/interface.js
+++ b/src/preload/interface.js
@@ -1093,7 +1093,7 @@ export default {
 
     /**
      * Keep native media menus in sync with the renderer-owned Media Session.
-     * @param {{playbackState: 'playing' | 'paused' | 'none', hasMetadata: boolean, actions: string[]}} state
+     * @param {{ownerId: string | null, playbackState: 'playing' | 'paused' | 'none', hasMetadata: boolean, actions: string[]}} state
      */
     setMediaSessionState: (state) => {
       ipcRenderer.send(IpcChannels.TABS_SET_MEDIA_SESSION_STATE, state)

--- a/src/renderer/tabs/TabMediaCoordinator.js
+++ b/src/renderer/tabs/TabMediaCoordinator.js
@@ -92,6 +92,13 @@ function applyOwner() {
       // The action is not supported on this platform.
     }
   }
+
+  globalThis.window?.ftElectron?.tabs?.setMediaSessionState?.({
+    playbackState: owner?.playbackState ?? 'none',
+    hasMetadata: owner?.metadata != null,
+    actions: Object.keys(actionHandlers)
+      .filter(action => typeof actionHandlers[action] === 'function')
+  })
 }
 
 function applyPowerSaveState() {
@@ -114,6 +121,17 @@ function applyPowerSaveState() {
 }
 
 export const tabMediaCoordinator = {
+  dispatchAction(action) {
+    if (!MEDIA_SESSION_ACTIONS.includes(action)) {
+      return
+    }
+
+    const handler = getActionHandlers(mediaByTabId.get(ownerTabId))[action]
+    if (typeof handler === 'function') {
+      handler()
+    }
+  },
+
   setPresented(tabId) {
     presentedTabId = tabId
     applyOwner()
@@ -196,5 +214,9 @@ export const tabMediaCoordinator = {
     applyPowerSaveState()
   }
 }
+
+globalThis.window?.ftElectron?.tabs?.onMediaSessionAction?.((action) => {
+  tabMediaCoordinator.dispatchAction(action)
+})
 
 export default tabMediaCoordinator

--- a/src/renderer/tabs/TabMediaCoordinator.js
+++ b/src/renderer/tabs/TabMediaCoordinator.js
@@ -73,7 +73,7 @@ function getActionHandlers(entry) {
   return handlers
 }
 
-function applyOwner() {
+function applyOwner(playbackStartedTabId = null) {
   if (!('mediaSession' in navigator)) {
     return
   }
@@ -94,8 +94,8 @@ function applyOwner() {
   }
 
   globalThis.window?.ftElectron?.tabs?.setMediaSessionState?.({
-    ownerId: ownerTabId,
     playbackState: owner?.playbackState ?? 'none',
+    playbackStarted: ownerTabId === playbackStartedTabId && owner?.playbackState === 'playing',
     hasMetadata: owner?.metadata != null,
     actions: Object.keys(actionHandlers)
       .filter(action => typeof actionHandlers[action] === 'function')
@@ -160,7 +160,7 @@ export const tabMediaCoordinator = {
     if (playbackState === 'playing') {
       entry.lastPlayedAt = ++playSequence
     }
-    applyOwner()
+    applyOwner(playbackState === 'playing' ? tabId : null)
     applyPowerSaveState()
   },
 

--- a/src/renderer/tabs/TabMediaCoordinator.js
+++ b/src/renderer/tabs/TabMediaCoordinator.js
@@ -94,6 +94,7 @@ function applyOwner() {
   }
 
   globalThis.window?.ftElectron?.tabs?.setMediaSessionState?.({
+    ownerId: ownerTabId,
     playbackState: owner?.playbackState ?? 'none',
     hasMetadata: owner?.metadata != null,
     actions: Object.keys(actionHandlers)

--- a/tests/unit/dock-media-session.test.mjs
+++ b/tests/unit/dock-media-session.test.mjs
@@ -4,17 +4,7 @@ import test from 'node:test'
 import { shouldAdvanceDockMediaSequence } from '../../src/main/dockMediaSession.js'
 
 test('advances Dock media ownership only for newly owned playback', () => {
-  assert.equal(shouldAdvanceDockMediaSequence(undefined, 'playing', 'first-tab'), true)
-  assert.equal(shouldAdvanceDockMediaSequence({
-    playbackState: 'playing',
-    ownerId: 'first-tab'
-  }, 'playing', 'first-tab'), false)
-  assert.equal(shouldAdvanceDockMediaSequence({
-    playbackState: 'playing',
-    ownerId: 'first-tab'
-  }, 'playing', 'second-tab'), true)
-  assert.equal(shouldAdvanceDockMediaSequence({
-    playbackState: 'paused',
-    ownerId: 'second-tab'
-  }, 'playing', 'second-tab'), true)
+  assert.equal(shouldAdvanceDockMediaSequence('playing', true), true)
+  assert.equal(shouldAdvanceDockMediaSequence('playing', false), false)
+  assert.equal(shouldAdvanceDockMediaSequence('paused', true), false)
 })

--- a/tests/unit/dock-media-session.test.mjs
+++ b/tests/unit/dock-media-session.test.mjs
@@ -1,0 +1,20 @@
+import assert from 'node:assert/strict'
+import test from 'node:test'
+
+import { shouldAdvanceDockMediaSequence } from '../../src/main/dockMediaSession.js'
+
+test('advances Dock media ownership only for newly owned playback', () => {
+  assert.equal(shouldAdvanceDockMediaSequence(undefined, 'playing', 'first-tab'), true)
+  assert.equal(shouldAdvanceDockMediaSequence({
+    playbackState: 'playing',
+    ownerId: 'first-tab'
+  }, 'playing', 'first-tab'), false)
+  assert.equal(shouldAdvanceDockMediaSequence({
+    playbackState: 'playing',
+    ownerId: 'first-tab'
+  }, 'playing', 'second-tab'), true)
+  assert.equal(shouldAdvanceDockMediaSequence({
+    playbackState: 'paused',
+    ownerId: 'second-tab'
+  }, 'playing', 'second-tab'), true)
+})

--- a/tests/unit/tab-media-coordinator.test.mjs
+++ b/tests/unit/tab-media-coordinator.test.mjs
@@ -152,3 +152,54 @@ test('dispatches native menu actions to the media session owner', (t) => {
 
   assert.deepEqual(dispatched, ['play', 'pause', 'previous', 'next'])
 })
+
+test('reports playback starts without treating owner reselection as a new start', (t) => {
+  const states = []
+  const navigatorDescriptor = Object.getOwnPropertyDescriptor(globalThis, 'navigator')
+  const windowDescriptor = Object.getOwnPropertyDescriptor(globalThis, 'window')
+
+  Object.defineProperty(globalThis, 'navigator', {
+    configurable: true,
+    value: {
+      mediaSession: {
+        metadata: null,
+        playbackState: 'none',
+        setActionHandler () {}
+      }
+    }
+  })
+  Object.defineProperty(globalThis, 'window', {
+    configurable: true,
+    value: {
+      ftElectron: {
+        tabs: {
+          setMediaSessionState: state => states.push(state)
+        }
+      }
+    }
+  })
+  t.after(() => {
+    tabMediaCoordinator.unregister('first-playing-tab')
+    tabMediaCoordinator.unregister('second-playing-tab')
+    for (const [property, descriptor] of [
+      ['navigator', navigatorDescriptor],
+      ['window', windowDescriptor]
+    ]) {
+      if (descriptor) {
+        Object.defineProperty(globalThis, property, descriptor)
+      } else {
+        delete globalThis[property]
+      }
+    }
+  })
+
+  tabMediaCoordinator.setPresented('first-playing-tab')
+  tabMediaCoordinator.setPlaybackState('first-playing-tab', 'playing')
+  assert.equal(states.at(-1).playbackStarted, true)
+
+  tabMediaCoordinator.setPlaybackState('second-playing-tab', 'playing')
+  assert.equal(states.at(-1).playbackStarted, false)
+
+  tabMediaCoordinator.setPresented('second-playing-tab')
+  assert.equal(states.at(-1).playbackStarted, false)
+})

--- a/tests/unit/tab-media-coordinator.test.mjs
+++ b/tests/unit/tab-media-coordinator.test.mjs
@@ -109,3 +109,46 @@ test('clears the skip actions a source no longer offers', (t) => {
 
   assert.equal(handlers.get('nexttrack'), null)
 })
+
+test('dispatches native menu actions to the media session owner', (t) => {
+  const dispatched = []
+  const navigatorDescriptor = Object.getOwnPropertyDescriptor(globalThis, 'navigator')
+
+  Object.defineProperty(globalThis, 'navigator', {
+    configurable: true,
+    value: {
+      mediaSession: {
+        metadata: null,
+        playbackState: 'none',
+        setActionHandler () {}
+      }
+    }
+  })
+  t.after(() => {
+    tabMediaCoordinator.unregister('dock-tab')
+    if (navigatorDescriptor) {
+      Object.defineProperty(globalThis, 'navigator', navigatorDescriptor)
+    } else {
+      delete globalThis.navigator
+    }
+  })
+
+  tabMediaCoordinator.setPresented('dock-tab')
+  tabMediaCoordinator.setActionHandlers('dock-tab', 'player', {
+    play: () => dispatched.push('play'),
+    pause: () => dispatched.push('pause')
+  })
+  tabMediaCoordinator.setActionHandlers('dock-tab', 'playlist', {
+    previoustrack: () => dispatched.push('previous'),
+    nexttrack: () => dispatched.push('next')
+  })
+  tabMediaCoordinator.setPlaybackState('dock-tab', 'playing')
+
+  tabMediaCoordinator.dispatchAction('play')
+  tabMediaCoordinator.dispatchAction('pause')
+  tabMediaCoordinator.dispatchAction('previoustrack')
+  tabMediaCoordinator.dispatchAction('nexttrack')
+  tabMediaCoordinator.dispatchAction('unsupported')
+
+  assert.deepEqual(dispatched, ['play', 'pause', 'previous', 'next'])
+})


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Make sure to follow the contributing guidelines. -->
<!-- Important note, we may remove your pull request if you do not use this provided PR template correctly. -->
<!-- Agent instructions: Preserve every heading, comment, and marker in this template. Never remove or rewrite the release-note-category:start/end, release-note:start/end, or release-note-image:start/end marker pairs. Never remove or rewrite the Release note images section; leave its contents for a human. -->

## Pull Request Type
<!-- Please select what type of pull request this is: [x] -->
- [ ] Bugfix
- [x] Feature Implementation
- [ ] Documentation
- [ ] Other

## Related issue
<!-- Please link the issue your pull request is referring to. -->
<!-- If this pull request fully resolves the relevant issue, put "closes" before the issue number. -->
<!-- Example: "closes #123456". -->

Closes #810.

## Description
<!-- Please write a clear and concise description of what the pull request does. -->

macOS users could only open a new window from the Dock menu, with no way to control active media.

This adds Previous, Play/Pause, and Next items backed by the existing Media Session coordinator. The menu follows the current media owner across tabs and windows, disables unavailable actions, and preserves the existing New Window item.

## Release note category
<!-- Select exactly one category. Every pull request must select one. -->
<!-- Select "Not noteworthy" when the pull request fixes a bug in or improves functionality that has not yet appeared in a stable release. -->
<!-- release-note-category:start -->
- [ ] Not noteworthy
- [ ] Highlights
- [x] More improvements
- [ ] Fixed bugs
<!-- release-note-category:end -->

## Release note
<!-- Required unless "Not noteworthy" is selected. -->
<!-- Write one concise, user-facing entry without a leading bullet. -->
<!-- release-note:start -->
Added media playback controls to the macOS Dock menu.
<!-- release-note:end -->

## Release note images
<!-- Human-only: Agents must preserve this entire section and leave it empty. -->
<!-- Optional. Paste one or more Markdown images or HTML image tags here. -->
<!-- The release notes will use an HTML image tag and limit images taller than 300 pixels. -->
<!-- release-note-image:start -->
<img width="442" height="352" alt="image" src="https://github.com/user-attachments/assets/0e8e7633-44fb-4ede-b558-945f578a2cb7" />
<!-- release-note-image:end -->

## Testing
<!-- How can reviewers verify that the PR produces correct results? -->
<!-- Please provide instructions so that others can ensure that your pull request would produce correct results. For examples see, https://github.com/FreeTubeApp/FreeTube/pull/5743, https://github.com/FreeTubeApp/FreeTube/pull/7349, https://github.com/FreeTubeApp/FreeTube/pull/5125, https://github.com/FreeTubeApp/FreeTube/pull/7338 -->
<!-- Agent instructions: Only write human-facing steps that explain how to verify the change while running this branch in dev mode. Include expected results and, when applicable, helpful console snippets for interactive verification. Do not include automated checks, commands, results, pass counts, or CI status. -->

1. Run the app on macOS and start a video from a playlist.
2. Open the app's Dock menu and confirm Previous, Play/Pause, Next, and New Window are shown.
3. Use Play/Pause and confirm playback toggles without focusing the app.
4. Use Previous and Next and confirm the playlist navigates when those actions are available.
5. Open a second app window, play media there, and confirm the Dock controls follow the currently playing media.

## Additional context
<!-- Add any other context about the pull request here. -->

The Dock controls share the same handlers as macOS media keys and system media controls, so playback behavior remains centralized in the Media Session coordinator.
