### PR TITLE
fix(invidious): handle backend edge cases

### DIFF
--- a/e2e/tests/offline/popular.spec.mjs
+++ b/e2e/tests/offline/popular.spec.mjs
@@ -16,6 +16,15 @@ test('shows an explicit status for an empty Popular feed', async ({ page }) => {
 
   await expect(page.locator('.emptyMessage')).toHaveText("This Invidious instance's Most Popular feed is empty.")
   await expect(page.locator('.toast', { hasText: 'Invidious API Error' })).toHaveCount(0)
+
+  await page.unrouteAll()
+  await page.route('https://invidious.test/api/v1/popular/**', route => route.fulfill({
+    json: { error: 'Popular feed unavailable' }
+  }))
+  await page.locator('.headerRefreshWidget .refreshButton').click()
+
+  await expect(page.locator('.toast', { hasText: 'Invidious API Error' })).toBeVisible()
+  await expect(page.locator('.emptyMessage')).toHaveCount(0)
 })
 
 test('does not present a failed Popular request as an empty feed', async ({ page }) => {

--- a/e2e/tests/offline/popular.spec.mjs
+++ b/e2e/tests/offline/popular.spec.mjs
@@ -1,0 +1,30 @@
+import { test, expect, goTo } from '../../helpers/app.mjs'
+
+test.use({
+  seed: {
+    settings: {
+      backendPreference: 'invidious',
+      defaultInvidiousInstance: 'https://invidious.test'
+    }
+  }
+})
+
+test('shows an explicit status for an empty Popular feed', async ({ page }) => {
+  await page.route('https://invidious.test/api/v1/popular/**', route => route.fulfill({ json: [] }))
+
+  await goTo(page, 'popular')
+
+  await expect(page.locator('.emptyMessage')).toHaveText("This Invidious instance's Most Popular feed is empty.")
+  await expect(page.locator('.toast', { hasText: 'Invidious API Error' })).toHaveCount(0)
+})
+
+test('does not present a failed Popular request as an empty feed', async ({ page }) => {
+  await page.route('https://invidious.test/api/v1/popular/**', route => route.fulfill({
+    json: { error: 'Popular feed unavailable' }
+  }))
+
+  await goTo(page, 'popular')
+
+  await expect(page.locator('.toast', { hasText: 'Invidious API Error' })).toBeVisible()
+  await expect(page.locator('.emptyMessage')).toHaveCount(0)
+})

--- a/src/renderer/components/CommentSection/CommentSection.vue
+++ b/src/renderer/components/CommentSection/CommentSection.vue
@@ -713,6 +713,8 @@ const canPerformInitialCommentLoading = computed(() => {
   return !props.commentsDisabled && commentData.value.length === 0 && !isLoading.value && !showComments.value
 })
 
+const sortNewest = ref(false)
+
 watch(() => props.highlightedCommentId, (commentId, previousCommentId) => {
   const targetChanged = previousCommentId !== undefined && previousCommentId !== commentId
   if (targetChanged) {
@@ -796,7 +798,6 @@ const sortValues = [
   'newest'
 ]
 
-const sortNewest = ref(false)
 const sortMenuOpen = ref(false)
 
 const currentSortValue = computed(() => sortNewest.value ? 'newest' : 'top')

--- a/src/renderer/views/Popular/Popular.css
+++ b/src/renderer/views/Popular/Popular.css
@@ -51,6 +51,11 @@
   color: var(--primary-color);
 }
 
+.emptyMessage {
+  margin-block: 48px;
+  text-align: center;
+}
+
 @media only screen and (width <= 680px) {
   .card {
     inline-size: 100%;

--- a/src/renderer/views/Popular/Popular.vue
+++ b/src/renderer/views/Popular/Popular.vue
@@ -33,7 +33,7 @@
         :data="shownResults"
       />
       <p
-        v-else
+        v-else-if="hasLoaded"
         class="emptyMessage"
         role="status"
       >
@@ -80,6 +80,7 @@ const popularCache = computed(() => {
 })
 
 const shownResults = shallowRef(popularCache.value || [])
+const hasLoaded = ref(popularCache.value !== null)
 
 onMounted(() => {
   document.addEventListener('keydown', keyboardShortcutHandler)
@@ -101,6 +102,7 @@ async function fetchPopularInfo() {
 
     store.commit('setLastPopularRefreshTimestamp', new Date())
     shownResults.value = items
+    hasLoaded.value = true
     isLoading.value = false
     store.commit('setPopularCache', items)
   } catch (err) {

--- a/src/renderer/views/Popular/Popular.vue
+++ b/src/renderer/views/Popular/Popular.vue
@@ -29,9 +29,16 @@
         v-if="isLoading"
       />
       <ft-element-list
-        v-else
+        v-else-if="shownResults.length > 0"
         :data="shownResults"
       />
+      <p
+        v-else
+        class="emptyMessage"
+        role="status"
+      >
+        {{ $t("Most Popular Feed Empty") }}
+      </p>
     </ft-card>
   </div>
 </template>

--- a/src/renderer/views/Popular/Popular.vue
+++ b/src/renderer/views/Popular/Popular.vue
@@ -96,6 +96,7 @@ onBeforeUnmount(() => {
 
 async function fetchPopularInfo() {
   isLoading.value = true
+  hasLoaded.value = false
 
   try {
     const items = await getInvidiousPopularFeed()

--- a/src/renderer/views/Watch/Watch.js
+++ b/src/renderer/views/Watch/Watch.js
@@ -3034,7 +3034,7 @@ export default defineComponent({
               this.thumbnail = `${this.currentInvidiousInstanceUrl}/vi/${this.videoId}/maxres3.jpg`
               break
             default:
-              this.thumbnail = result.videoThumbnails[0].url
+              this.thumbnail = new URL(result.videoThumbnails[0].url, this.currentInvidiousInstanceUrl).toString()
               break
           }
 

--- a/static/locales/en-US.yaml
+++ b/static/locales/en-US.yaml
@@ -246,6 +246,7 @@ Trending:
   Sports: Sports
   Trending Tabs: Trending Tabs
 Most Popular: Most Popular
+Most Popular Feed Empty: This Invidious instance's Most Popular feed is empty.
 Feed:
   Cancel Refresh: Cancel refresh
   Feed Last Updated: '{feedName} feed last updated: {date}'


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Make sure to follow the contributing guidelines. -->
<!-- Important note, we may remove your pull request if you do not use this provided PR template correctly. -->
<!-- Agent instructions: Preserve every heading, comment, and marker in this template. Never remove or rewrite the release-note-category:start/end, release-note:start/end, or release-note-image:start/end marker pairs. Never remove or rewrite the Release note images section; leave its contents for a human. -->

## Pull Request Type
<!-- Please select what type of pull request this is: [x] -->
- [x] Bugfix
- [ ] Feature Implementation
- [ ] Documentation
- [ ] Other

## Related issue
<!-- Please link the issue your pull request is referring to. -->
<!-- If this pull request fully resolves the relevant issue, put "closes" before the issue number. -->
<!-- Example: "closes #123456". -->

## Description
<!-- Please write a clear and concise description of what the pull request does. -->
Some valid Invidious responses exposed three frontend edge cases: relative video thumbnail paths were resolved against the app instead of the instance, an empty Most Popular response rendered a blank page, and immediate comment loading could access its sort state before initialization.

This resolves relative thumbnails against the selected instance, gives empty Popular feeds an explicit status message, and initializes the comments sort state before any immediate watcher can start loading comments. Existing absolute thumbnail URLs, non-empty Popular feeds, and comment sorting behavior remain unchanged.

## Release note category
<!-- Select exactly one category. Every pull request must select one. -->
<!-- Select "Not noteworthy" when the pull request fixes a bug in or improves functionality that has not yet appeared in a stable release. -->
<!-- release-note-category:start -->
- [ ] Not noteworthy
- [ ] Highlights
- [ ] More improvements
- [x] Fixed bugs
<!-- release-note-category:end -->

## Release note
<!-- Required unless "Not noteworthy" is selected. -->
<!-- Write one concise, user-facing entry without a leading bullet. -->
<!-- release-note:start -->
Fixed missing Invidious video thumbnails, blank empty Popular feeds, and an error during automatic comment loading.
<!-- release-note:end -->

## Release note images
<!-- Human-only: Agents must preserve this entire section and leave it empty. -->
<!-- Optional. Paste one or more Markdown images or HTML image tags here. -->
<!-- The release notes will use an HTML image tag and limit images taller than 300 pixels. -->
<!-- release-note-image:start -->

<!-- release-note-image:end -->

## Testing
<!-- How can reviewers verify that the PR produces correct results? -->
<!-- Please provide instructions so that others can ensure that your pull request would produce correct results. For examples see, https://github.com/FreeTubeApp/FreeTube/pull/5743, https://github.com/FreeTubeApp/FreeTube/pull/7349, https://github.com/FreeTubeApp/FreeTube/pull/5125, https://github.com/FreeTubeApp/FreeTube/pull/7338 -->
<!-- Agent instructions: Only write human-facing steps that explain how to verify the change while running this branch in dev mode. Include expected results and, when applicable, helpful console snippets for interactive verification. Do not include automated checks, commands, results, pass counts, or CI status. -->
1. Select an Invidious instance whose video API returns relative thumbnail paths such as `/vi/<id>/maxres.jpg`, then open a video. Confirm its player poster loads from the selected instance without a broken-image icon.
2. Open Most Popular against a fresh/private Invidious instance that returns an empty array from `/api/v1/popular`. Confirm the page displays an explicit empty-feed message instead of a blank result area.
3. Use Invidious comments with automatic paginated-item loading enabled and open a video in a background tab or with a highlighted comment. Confirm comments load without `Cannot access 'sortNewest' before initialization` in the console, then switch between Top comments and Newest first to confirm sorting is unchanged.

## Additional context
<!-- Add any other context about the pull request here. -->
The empty Popular response is valid for a fresh private Invidious instance because its Popular feed is derived from subscriptions held by users registered on that instance.
