### PR TITLE
fix(comments): refresh reply counts after loading

### DIFF
--- a/src/renderer/components/CommentSection/CommentSection.vue
+++ b/src/renderer/components/CommentSection/CommentSection.vue
@@ -462,6 +462,7 @@ import { useTabContext } from '../../tabs/TabContext'
 import { copyToClipboard, formatNumber, getRelativeTimeFromDate, showApiErrorToast, showToast } from '../../helpers/utils'
 import { useRelativeTimeClock } from '../../composables/useRelativeTimeClock'
 import {
+  getCommentReplyCount,
   getReplyContinuationToken,
   getReplyLoadState,
   isEmptyReplyContinuation,
@@ -975,11 +976,13 @@ function getMoreComments() {
  * @param {Comment} comment
  */
 function toggleCommentRepliesLinkText(comment) {
+  const replyCount = getCommentReplyCount(comment)
+
   if (comment.showReplies) {
-    return t('Comments.Hide {replyCount} replies', { replyCount: comment.numReplies }, comment.numReplies)
+    return t('Comments.Hide {replyCount} replies', { replyCount }, replyCount)
   }
 
-  return t('Comments.Reply Count', { replyCount: comment.numReplies }, comment.numReplies)
+  return t('Comments.Reply Count', { replyCount }, replyCount)
 }
 
 /**

--- a/src/renderer/helpers/comment-replies.js
+++ b/src/renderer/helpers/comment-replies.js
@@ -1,4 +1,20 @@
 /**
+ * @param {{ replies: object[] }} comment
+ * @returns {number}
+ */
+function countLoadedReplies(comment) {
+  return comment.replies.reduce((count, reply) => count + 1 + countLoadedReplies(reply), 0)
+}
+
+/**
+ * @param {{ numReplies: number, replies: object[] }} comment
+ * @returns {number}
+ */
+export function getCommentReplyCount(comment) {
+  return Math.max(comment.numReplies, countLoadedReplies(comment))
+}
+
+/**
  * @param {number} loadedReplyCount
  * @param {number} expectedReplyCount
  * @param {boolean} hasNextContinuation

--- a/tests/unit/comment-replies.test.mjs
+++ b/tests/unit/comment-replies.test.mjs
@@ -2,12 +2,52 @@ import assert from 'node:assert/strict'
 import test from 'node:test'
 
 import {
+  getCommentReplyCount,
   getReplyContinuationToken,
   getReplyLoadState,
   isEmptyReplyContinuation,
   isMissingReplyResponseError,
   shouldLoadInitialReplies
 } from '../../src/renderer/helpers/comment-replies.js'
+
+test('refreshes a stale advertised count after newer replies load', () => {
+  const comment = {
+    numReplies: 1,
+    replies: [
+      { replies: [] },
+      { replies: [] },
+      { replies: [] }
+    ]
+  }
+
+  assert.equal(getCommentReplyCount(comment), 3)
+})
+
+test('includes nested descendants in the loaded reply count', () => {
+  const comment = {
+    numReplies: 1,
+    replies: [
+      { replies: [] },
+      {
+        replies: [
+          { replies: [] },
+          { replies: [{ replies: [] }] }
+        ]
+      }
+    ]
+  }
+
+  assert.equal(getCommentReplyCount(comment), 5)
+})
+
+test('keeps an advertised reply count above the number loaded so far', () => {
+  const comment = {
+    numReplies: 5,
+    replies: [{ replies: [] }]
+  }
+
+  assert.equal(getCommentReplyCount(comment), 5)
+})
 
 test('exhausts a stale advertised reply without opening the reply panel', () => {
   assert.deepEqual(getReplyLoadState(0, 1, false), {


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Make sure to follow the contributing guidelines. -->
<!-- Important note, we may remove your pull request if you do not use this provided PR template correctly. -->
<!-- Agent instructions: Preserve every heading, comment, and marker in this template. Never remove or rewrite the release-note-category:start/end, release-note:start/end, or release-note-image:start/end marker pairs. Never remove or rewrite the Release note images section; leave its contents for a human. -->

## Pull Request Type
<!-- Please select what type of pull request this is: [x] -->
- [x] Bugfix
- [ ] Feature Implementation
- [ ] Documentation
- [ ] Other

## Related issue
<!-- Please link the issue your pull request is referring to. -->
<!-- If this pull request fully resolves the relevant issue, put "closes" before the issue number. -->
<!-- Example: "closes #123456". -->

## Description
<!-- Please write a clear and concise description of what the pull request does. -->
Comment reply toggles kept the count from the initial comments response. When more replies were posted before the thread was expanded, loading the current replies displayed them but the toggle continued to show the stale count. Loaded local-API replies can also form a nested tree, while the label only considered the root's advertised count.

Count every loaded descendant and use the greater of that current total and the advertised count. This refreshes stale counts after loading, includes nested replies as YouTube does, and preserves a larger server-provided total while a thread is only partially loaded.

## Release note category
<!-- Select exactly one category. Every pull request must select one. -->
<!-- Select "Not noteworthy" when the pull request fixes a bug in or improves functionality that has not yet appeared in a stable release. -->
<!-- release-note-category:start -->
- [ ] Not noteworthy
- [ ] Highlights
- [ ] More improvements
- [x] Fixed bugs
<!-- release-note-category:end -->

## Release note
<!-- Required unless "Not noteworthy" is selected. -->
<!-- Write one concise, user-facing entry without a leading bullet. -->
<!-- release-note:start -->
Reply counts now update when newer or nested replies are loaded
<!-- release-note:end -->

## Release note images
<!-- Human-only: Agents must preserve this entire section and leave it empty. -->
<!-- Optional. Paste one or more Markdown images or HTML image tags here. -->
<!-- The release notes will use an HTML image tag and limit images taller than 300 pixels. -->
<!-- release-note-image:start -->

<!-- release-note-image:end -->

## Testing
<!-- How can reviewers verify that the PR produces correct results? -->
<!-- Please provide instructions so that others can ensure that your pull request produces correct results. For examples see, https://github.com/FreeTubeApp/FreeTube/pull/5743, https://github.com/FreeTubeApp/FreeTube/pull/7349, https://github.com/FreeTubeApp/FreeTube/pull/5125, https://github.com/FreeTubeApp/FreeTube/pull/7338 -->
<!-- Agent instructions: Only write human-facing steps that explain how to verify the change while running this branch in dev mode. Include expected results and, when applicable, helpful console snippets for interactive verification. Do not include automated checks, commands, results, pass counts, or CI status. -->
1. Load comments for a thread, then add more replies from another client before expanding it.
2. Expand the thread and confirm the “Hide replies” label updates to include every newly loaded reply.
3. Check a thread with replies to replies and confirm nested descendants are included in the count.
4. Collapse the thread and confirm the corrected count remains on the “replies” label.

## Additional context
<!-- Add any other context about the pull request here. -->
