### PR TITLE
fix: open collaborator channels in background tabs

### DIFF
--- a/e2e/tests/offline/collaborators-modal-animation.spec.mjs
+++ b/e2e/tests/offline/collaborators-modal-animation.spec.mjs
@@ -1,4 +1,4 @@
-import { test, expect, goTo } from '../../helpers/app.mjs'
+import { test, expect, goTo, sel, waitForAppReady } from '../../helpers/app.mjs'
 
 const now = Date.now()
 const HOUR = 3600000
@@ -162,6 +162,43 @@ function defineCase () {
     expect(shifted, `items shifted: ${JSON.stringify(shifted.slice(0, 3))}`).toEqual([])
   })
 }
+
+test('middle-clicking a collaborator opens its channel in a background tab', async ({ page }) => {
+  await goTo(page, 'subscriptions')
+
+  await page.locator('.channelResolverButton').click()
+  const prompt = page.locator('.prompt')
+  await expect(prompt).toBeVisible()
+
+  await prompt.getByRole('link', { name: 'Channel C' }).click({ button: 'middle' })
+
+  await expect(page.locator(sel.tabs)).toHaveCount(2)
+  await expect(page.locator(sel.tabs).first()).toHaveClass(/active/)
+  await expect(prompt).toBeVisible()
+  await expect(page).toHaveURL(/#\/subscriptions$/)
+  await expect.poll(() => page.evaluate(async () => {
+    const state = await window.ftElectron.tabs.getState()
+    return state.tabs.find(tab => tab.id !== state.activeTabId)?.route.fullPath
+  })).toBe('/channel/UCcccccccccccccccccccccc')
+})
+
+test('shift-middle-clicking a collaborator opens its channel in a new window', async ({ app, page }) => {
+  await goTo(page, 'subscriptions')
+
+  await page.locator('.channelResolverButton').click()
+  const prompt = page.locator('.prompt')
+  await expect(prompt).toBeVisible()
+
+  const [newWindow] = await Promise.all([
+    app.electronApp.waitForEvent('window'),
+    prompt.getByRole('link', { name: 'Channel C' }).click({ button: 'middle', modifiers: ['Shift'] })
+  ])
+  await waitForAppReady(newWindow)
+
+  await expect(newWindow).toHaveURL(/#\/channel\/UCcccccccccccccccccccccc$/)
+  await expect(page).toHaveURL(/#\/subscriptions$/)
+  await expect(prompt).toBeVisible()
+})
 
 test.describe('at 100% display scale', () => {
   defineCase()

--- a/src/renderer/components/FtCollaboratorsPrompt/FtCollaboratorsPrompt.vue
+++ b/src/renderer/components/FtCollaboratorsPrompt/FtCollaboratorsPrompt.vue
@@ -25,6 +25,7 @@
           class="collaboratorLink"
           :class="{ initialCursor: !enableChannelLinks }"
           @click="emit('close')"
+          @auxclick="handleChannelLinkAuxClick($event, collaborator)"
         >
           <img
             :src="collaborator.thumbnail"
@@ -66,6 +67,7 @@ import { useI18n } from 'vue-i18n'
 import FtPrompt from '../FtPrompt/FtPrompt.vue'
 import FtSubscribeButton from '../FtSubscribeButton/FtSubscribeButton.vue'
 
+import { openInternalPath } from '../../helpers/utils'
 import store from '../../store'
 import { useTabContext } from '../../tabs/TabContext'
 
@@ -84,6 +86,21 @@ const { isTabPresented } = useTabContext()
 const enableChannelLinks = computed(() => !store.getters.getDisableChannelLinks)
 
 const hideUnsubscribeButton = computed(() => store.getters.getHideUnsubscribeButton)
+
+function handleChannelLinkAuxClick(event, collaborator) {
+  if (!process.env.IS_ELECTRON || !enableChannelLinks.value || event.button !== 1) {
+    return
+  }
+
+  event.preventDefault()
+  openInternalPath({
+    path: `/channel/${collaborator.id}`,
+    title: collaborator.name,
+    doCreateNewWindow: event.shiftKey,
+    doCreateNewTab: !event.shiftKey,
+    makeActive: false
+  })
+}
 </script>
 
 <style scoped src="./FtCollaboratorsPrompt.css" />


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Make sure to follow the contributing guidelines. -->
<!-- Important note, we may remove your pull request if you do not use this provided PR template correctly. -->
<!-- Agent instructions: Preserve every heading, comment, and marker in this template. Never remove or rewrite the release-note-category:start/end, release-note:start/end, or release-note-image:start/end marker pairs. Never remove or rewrite the Release note images section; leave its contents for a human. -->

## Pull Request Type
<!-- Please select what type of pull request this is: [x] -->
- [ ] Bugfix
- [x] Feature Implementation
- [ ] Documentation
- [ ] Other

## Related issue
<!-- Please link the issue your pull request is referring to. -->
<!-- If this pull request fully resolves the relevant issue, put "closes" before the issue number. -->
<!-- Example: "closes #123456". -->

Closes #814.

## Description
<!-- Please write a clear and concise description of what the pull request does. -->

Middle-clicking a channel in the collaborators prompt previously fell through to Electron's generic window-open handler, which always activated the resulting tab. This routes collaborator middle-clicks through the app's tab service so the channel opens in the background and the prompt remains available for opening more collaborators.

Shift+middle-click continues to open a new window, and the web build keeps its native browser behavior.

## Release note category
<!-- Select exactly one category. Every pull request must select one. -->
<!-- Select "Not noteworthy" when the pull request fixes a bug in or improves functionality that has not yet appeared in a stable release. -->
<!-- release-note-category:start -->
- [ ] Not noteworthy
- [ ] Highlights
- [x] More improvements
- [ ] Fixed bugs
<!-- release-note-category:end -->

## Release note
<!-- Required unless "Not noteworthy" is selected. -->
<!-- Write one concise, user-facing entry without a leading bullet. -->
<!-- release-note:start -->
Middle-clicking collaborator channels now opens them in background tabs.
<!-- release-note:end -->

## Release note images
<!-- Human-only: Agents must preserve this entire section and leave it empty. -->
<!-- Optional. Paste one or more Markdown images or HTML image tags here. -->
<!-- The release notes will use an HTML image tag and limit images taller than 300 pixels. -->
<!-- release-note-image:start -->

<!-- release-note-image:end -->

## Testing
<!-- How can reviewers verify that the PR produces correct results? -->
<!-- Please provide instructions so that others can ensure that your pull request would produce correct results. For examples see, https://github.com/FreeTubeApp/FreeTube/pull/5743, https://github.com/FreeTubeApp/FreeTube/pull/7349, https://github.com/FreeTubeApp/FreeTube/pull/5125, https://github.com/FreeTubeApp/FreeTube/pull/7338 -->
<!-- Agent instructions: Only write human-facing steps that explain how to verify the change while running this branch in dev mode. Include expected results and, when applicable, helpful console snippets for interactive verification. Do not include automated checks, commands, results, pass counts, or CI status. -->

1. Open a video with multiple collaborator channels.
2. Open the collaborators prompt and middle-click one or more channel rows.
3. Confirm each channel appears in a new background tab while the current video tab stays active and the prompt remains open.
4. Switch to the created tabs and confirm each one shows the selected collaborator channel.
5. Shift+middle-click a collaborator and confirm it still opens in a new window.

## Additional context
<!-- Add any other context about the pull request here. -->

The behavior now matches middle-clicking regular channel links elsewhere on the watch page.