### PR TITLE
fix(downloads): use destination storage for temporary files

### DIFF
--- a/e2e/tests/offline/video-actions.spec.mjs
+++ b/e2e/tests/offline/video-actions.spec.mjs
@@ -702,8 +702,14 @@ test.describe('video downloads', () => {
 
   test('tracks a download when its configured folder is unavailable', async ({ app, page }) => {
     const executable = path.join(app.userDataDir, 'failing-yt-dlp.sh')
+    const argumentsFile = path.join(app.userDataDir, 'failing-yt-dlp-arguments.txt')
     const unavailableDownloadFolder = path.join(app.userDataDir, 'missing', 'downloads')
-    await writeFile(executable, '#!/bin/sh\nexit 1')
+    const fallbackDownloadFolder = await app.electronApp.evaluate(({ app }) => app.getPath('temp'))
+    await writeFile(executable, [
+      '#!/bin/sh',
+      `printf '%s\\n' "$@" > '${argumentsFile}'`,
+      'exit 1'
+    ].join('\n'))
     await chmod(executable, 0o755)
     await page.evaluate(async ({ unavailableDownloadFolder, ytDlpPath }) => {
       const store = document.querySelector('#app').__vue_app__.config.globalProperties.$store
@@ -721,6 +727,12 @@ test.describe('video downloads', () => {
     await expect.poll(() => page.evaluate(async (id) => {
       return (await window.ftElectron.ytDlpListDownloads()).find(download => download.id === id)?.status
     }, result.id)).toBe('failed')
+    const temporaryPath = (await readFile(argumentsFile, 'utf8'))
+      .split('\n')
+      .find(argument => argument.startsWith('temp:'))
+    expect(temporaryPath).toBeDefined()
+    expect(path.dirname(temporaryPath.slice('temp:'.length))).toBe(fallbackDownloadFolder)
+    expect(temporaryPath.startsWith(`temp:${unavailableDownloadFolder}`)).toBe(false)
   })
 
   test('plays an audio download in the normal player', async ({ app, page }) => {

--- a/e2e/tests/offline/video-actions.spec.mjs
+++ b/e2e/tests/offline/video-actions.spec.mjs
@@ -510,11 +510,13 @@ test.describe('video downloads', () => {
   })
 
   test('plays a downloaded video locally and reconciles it after external deletion', async ({ app, page }) => {
+    const downloadFolder = path.join(app.userDataDir, 'downloads')
     const downloadedFile = path.join(app.userDataDir, 'downloaded-demo.webm')
     const downloadedAudioFile = path.join(app.userDataDir, 'downloaded-audio-alternative.wav')
     const downloadThumbnail = 'data:image/svg+xml,%3Csvg xmlns="http://www.w3.org/2000/svg" width="640" height="360"%3E%3Cpath fill="%23b00020" d="M0 0h640v360H0z"/%3E%3C/svg%3E'
     const executable = path.join(app.userDataDir, 'fake-yt-dlp.sh')
     const argumentsFile = path.join(app.userDataDir, 'yt-dlp-arguments.txt')
+    await mkdir(downloadFolder)
     await copyFile(DEMO_MEDIA_PATH, downloadedFile)
     await writeFile(downloadedAudioFile, silentWav(2))
     await writeFile(executable, [
@@ -527,10 +529,11 @@ test.describe('video downloads', () => {
       'fi'
     ].join('\n'))
     await chmod(executable, 0o755)
-    await page.evaluate(async (ytDlpPath) => {
+    await page.evaluate(async ({ downloadFolder, ytDlpPath }) => {
       const store = document.querySelector('#app').__vue_app__.config.globalProperties.$store
       await store.dispatch('updateYtDlpPath', ytDlpPath)
-    }, executable)
+      await store.dispatch('updateYtDlpDownloadFolderPath', downloadFolder)
+    }, { downloadFolder, ytDlpPath: executable })
 
     const result = await page.evaluate((thumbnail) => window.ftElectron.ytDlpDownload({
       videoId: 'eeeeeeeeeee',
@@ -582,6 +585,9 @@ test.describe('video downloads', () => {
       .filter(argument => argument.startsWith('temp:'))
     expect(temporaryPaths).toHaveLength(2)
     expect(new Set(temporaryPaths).size).toBe(2)
+    expect(temporaryPaths.every(temporaryPath => (
+      path.dirname(temporaryPath.slice('temp:'.length)) === downloadFolder
+    ))).toBe(true)
     const downloadRow = page.locator('.downloadRow').filter({ hasText: 'Downloaded demo' })
     await expect(downloadRow.locator('.downloadSummary')).toContainText('140 KiB')
     await expect(page.locator('.settingsBackButton')).toHaveCount(0)

--- a/e2e/tests/offline/video-actions.spec.mjs
+++ b/e2e/tests/offline/video-actions.spec.mjs
@@ -700,6 +700,29 @@ test.describe('video downloads', () => {
     await expect(page.locator('.downloadRow').filter({ hasText: 'Downloaded audio alternative' })).toHaveCount(0)
   })
 
+  test('tracks a download when its configured folder is unavailable', async ({ app, page }) => {
+    const executable = path.join(app.userDataDir, 'failing-yt-dlp.sh')
+    const unavailableDownloadFolder = path.join(app.userDataDir, 'missing', 'downloads')
+    await writeFile(executable, '#!/bin/sh\nexit 1')
+    await chmod(executable, 0o755)
+    await page.evaluate(async ({ unavailableDownloadFolder, ytDlpPath }) => {
+      const store = document.querySelector('#app').__vue_app__.config.globalProperties.$store
+      await store.dispatch('updateYtDlpPath', ytDlpPath)
+      await store.dispatch('updateYtDlpDownloadFolderPath', unavailableDownloadFolder)
+    }, { unavailableDownloadFolder, ytDlpPath: executable })
+
+    const result = await page.evaluate(() => window.ftElectron.ytDlpDownload({
+      videoId: 'eeeeeeeeeee',
+      title: 'Unavailable download folder',
+      thumbnail: '',
+      mode: 'video'
+    }))
+    expect(result.id).toBeGreaterThan(0)
+    await expect.poll(() => page.evaluate(async (id) => {
+      return (await window.ftElectron.ytDlpListDownloads()).find(download => download.id === id)?.status
+    }, result.id)).toBe('failed')
+  })
+
   test('plays an audio download in the normal player', async ({ app, page }) => {
     const downloadedFile = path.join(app.userDataDir, 'downloaded-audio.wav')
     const executable = path.join(app.userDataDir, 'fake-audio-yt-dlp.sh')

--- a/src/main/ytDlp.js
+++ b/src/main/ytDlp.js
@@ -1813,7 +1813,13 @@ async function startYtDlpDownload(
   // sandbox's capacity-limited runtime directory does not hold the media data.
   // Audio extraction otherwise reuses and then deletes an existing video file
   // when both variants have the same source extension.
-  const temporaryDownloadFolder = await mkdtemp(join(downloadFolder, '.opentubex-download-'))
+  let temporaryDownloadFolder
+  try {
+    temporaryDownloadFolder = await mkdtemp(join(downloadFolder, '.opentubex-download-'))
+  } catch {
+    // Let yt-dlp report an unavailable destination through the tracked job.
+    temporaryDownloadFolder = await mkdtemp(join(app.getPath('temp'), 'opentubex-download-'))
+  }
   args.push('--paths', `temp:${temporaryDownloadFolder}`)
 
   // Authorization and executable setup contain awaits, so another refresh can

--- a/src/main/ytDlp.js
+++ b/src/main/ytDlp.js
@@ -1808,10 +1808,12 @@ async function startYtDlpDownload(
     }
   }
 
-  // Keep post-processing inputs away from completed files with the same
-  // title and video ID. Audio extraction otherwise reuses and then deletes an
-  // existing video file when both variants have the same source extension.
-  const temporaryDownloadFolder = await mkdtemp(join(app.getPath('temp'), 'opentubex-download-'))
+  // Keep post-processing inputs away from completed files with the same title
+  // and video ID. Put the isolated directory beside the completed files so a
+  // sandbox's capacity-limited runtime directory does not hold the media data.
+  // Audio extraction otherwise reuses and then deletes an existing video file
+  // when both variants have the same source extension.
+  const temporaryDownloadFolder = await mkdtemp(join(downloadFolder, '.opentubex-download-'))
   args.push('--paths', `temp:${temporaryDownloadFolder}`)
 
   // Authorization and executable setup contain awaits, so another refresh can


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Make sure to follow the contributing guidelines. -->
<!-- Important note, we may remove your pull request if you do not use this provided PR template correctly. -->
<!-- Agent instructions: Preserve every heading, comment, and marker in this template. Never remove or rewrite the release-note-category:start/end, release-note:start/end, or release-note-image:start/end marker pairs. Never remove or rewrite the Release note images section; leave its contents for a human. -->

## Pull Request Type
<!-- Please select what type of pull request this is: [x] -->
- [x] Bugfix
- [ ] Feature Implementation
- [ ] Documentation
- [ ] Other

## Related issue
<!-- Please link the issue your pull request is referring to. -->
<!-- If this pull request fully resolves the relevant issue, put "closes" before the issue number. -->
<!-- Example: "closes #123456". -->

## Description
<!-- Please write a clear and concise description of what the pull request does. -->
The per-download isolation added to prevent video and audio downloads from reusing the same post-processing input stored full temporary media files in Electron's temporary directory. Flatpak maps that directory to its capacity-limited runtime filesystem, so large downloads could fail with `No space left on device` even when the configured download drive had ample free space.

This creates each isolated yt-dlp temporary directory beside the final files in the configured download folder. Downloads therefore use the destination filesystem's capacity while retaining unique working directories for collision protection and the existing cleanup behavior.

## Release note category
<!-- Select exactly one category. Every pull request must select one. -->
<!-- Select "Not noteworthy" when the pull request fixes a bug in or improves functionality that has not yet appeared in a stable release. -->
<!-- release-note-category:start -->
- [ ] Not noteworthy
- [ ] Highlights
- [ ] More improvements
- [x] Fixed bugs
<!-- release-note-category:end -->

## Release note
<!-- Required unless "Not noteworthy" is selected. -->
<!-- Write one concise, user-facing entry without a leading bullet. -->
<!-- release-note:start -->
Downloads no longer exhaust Flatpak's limited temporary storage when the configured download drive has sufficient space.
<!-- release-note:end -->

## Release note images
<!-- Human-only: Agents must preserve this entire section and leave it empty. -->
<!-- Optional. Paste one or more Markdown images or HTML image tags here. -->
<!-- The release notes will use an HTML image tag and limit images taller than 300 pixels. -->
<!-- release-note-image:start -->

<!-- release-note-image:end -->

## Testing
<!-- How can reviewers verify that the PR produces correct results? -->
<!-- Please provide instructions so that others can ensure that your pull request would produce correct results. For examples see, https://github.com/FreeTubeApp/FreeTube/pull/5743, https://github.com/FreeTubeApp/FreeTube/pull/7349, https://github.com/FreeTubeApp/FreeTube/pull/5125, https://github.com/FreeTubeApp/FreeTube/pull/7338 -->
<!-- Agent instructions: Only write human-facing steps that explain how to verify the change while running this branch in dev mode. Include expected results and, when applicable, helpful console snippets for interactive verification. Do not include automated checks, commands, results, pass counts, or CI status. -->
1. Configure a download folder on a filesystem with enough free space.
2. Download a sufficiently large video through the Flatpak build while its runtime temporary filesystem has less free space than the media requires.
3. Verify the download completes in the configured folder without a `No space left on device` error.
4. Download the same item as both video and audio and verify both files remain available.

## Additional context
<!-- Add any other context about the pull request here. -->
The temporary directories remain unique per download and are removed through the existing completion, cancellation, and failure cleanup paths.
