### PR TITLE
fix(player): restore reliable live stream playback

### DIFF
--- a/e2e/tests/offline/watch-page.spec.mjs
+++ b/e2e/tests/offline/watch-page.spec.mjs
@@ -434,13 +434,16 @@ async function mockTranslatedEndscreen(app, page) {
 }
 
 test.describe('watch page', () => {
-  test('shows the selected extraction method while yt-dlp streams are pending', async ({ app, page }) => {
+  test('shows the automatic yt-dlp live fallback while streams are pending', async ({ app, page }) => {
     await mockPlayableWatchPage(app, page)
     await openMockedVideo(page)
 
     const watchView = await watchViewHandle(page)
     await watchView.evaluate(async (view) => {
-      view.playbackEngineFallbackTarget = 'yt-dlp'
+      view.isLive = true
+      view.manifestSrc = null
+      view.legacyFormats = []
+      view.playbackEngineFallbackTarget = null
       view.ytDlpStreamsPending = true
       await view.$nextTick()
     })
@@ -543,13 +546,8 @@ test.describe('watch page', () => {
     })
   })
 
-  test('an IP-blocked HTML watch page retries yt-dlp with its default clients', async ({ app, page }) => {
+  test('an IP-blocked playback fallback retries yt-dlp with its default clients', async ({ app, page }) => {
     await mockPlayableWatchPage(app, page)
-    await page.route(/^https:\/\/www\.youtube\.com\/watch\?/, (route) => route.fulfill({
-      status: 429,
-      contentType: 'text/html',
-      body: '<title>Sorry...</title>'
-    }))
     await page.route('https://example.invalid/rejected.m3u8', route => route.fulfill({
       contentType: 'text/html',
       body: '<html>expired</html>'
@@ -574,16 +572,21 @@ test.describe('watch page', () => {
       })
     })
 
-    await page.locator(sel.searchInput).fill('https://www.youtube.com/watch?v=jNQXAC9IVRw')
-    await page.locator(sel.searchInput).press('Enter')
-    await expect(page).toHaveURL(/#\/watch\/jNQXAC9IVRw/)
+    await openMockedVideo(page)
+    const watchView = await watchViewHandle(page)
+    await watchView.evaluate(async (view) => {
+      view.ipBlockDetectedInCurrentChain = true
+      view.playbackEngineFallbackAttemptedForCurrentVideo = true
+      view.playbackEngineFallbackTarget = 'yt-dlp'
+      view.runIpBlockRecoveryScriptAndReload = async () => false
+      await view.applyYtDlpPlaybackSource(view.videoLoadGeneration, view.videoId)
+    })
 
     await expect.poll(() => app.electronApp.evaluate(() => globalThis.__ytDlpIpBlockFallbackCalls)).toBe(3)
     expect(await app.electronApp.evaluate(() => globalThis.__ytDlpIpBlockFallbackDefaultClients)).toEqual([false, true, true])
     await expect(page.locator('.toast', {
       hasText: 'The preferred yt-dlp clients could not provide playable streams'
     })).toHaveCount(1)
-    const watchView = await watchViewHandle(page)
     expect(await watchView.evaluate((view) => ({
       ipBlockDetected: view.ipBlockDetectedInCurrentChain,
       fallbackAttempted: view.playbackEngineFallbackAttemptedForCurrentVideo,
@@ -606,6 +609,61 @@ test.describe('watch page', () => {
       await view.applyYtDlpPlaybackSource(view.videoLoadGeneration, view.videoId)
       return recoveryCalls
     })).toBe(1)
+  })
+
+  test('retries yt-dlp with its default clients for a limited live DVR manifest', async ({ app, page }) => {
+    await mockPlayableWatchPage(app, page)
+    await page.route(/^https:\/\/example\.invalid\/.*\.m3u8$/, route => route.fulfill({
+      contentType: 'application/x-mpegURL',
+      body: '#EXTM3U\n'
+    }))
+    await openMockedVideo(page)
+
+    await app.electronApp.evaluate(({ ipcMain }) => {
+      globalThis.__ytDlpLiveDvrFallbackDefaultClients = []
+      ipcMain.removeHandler('yt-dlp-get-playback-info')
+      ipcMain.handle('yt-dlp-get-playback-info', (_event, _videoId, useDefaultClients) => {
+        globalThis.__ytDlpLiveDvrFallbackDefaultClients.push(useDefaultClients)
+        return {
+          isLive: true,
+          liveStatus: 'is_live',
+          hlsManifestUrl: useDefaultClients
+            ? 'https://example.invalid/playlist_type/DVR/full.m3u8'
+            : 'https://example.invalid/manifest_duration/30/limited.m3u8',
+          formats: [],
+          duration: null,
+          version: 'test'
+        }
+      })
+    })
+
+    const watchView = await watchViewHandle(page)
+    await watchView.evaluate((view) => view.handlePlaybackEngineChange('yt-dlp'))
+
+    expect(await app.electronApp.evaluate(
+      () => globalThis.__ytDlpLiveDvrFallbackDefaultClients
+    )).toEqual([false, true])
+    expect(await watchView.evaluate((view) => ({
+      activeEngine: view.activePlaybackEngine,
+      manifest: view.manifestSrc
+    }))).toEqual({
+      activeEngine: 'yt-dlp',
+      manifest: 'https://example.invalid/playlist_type/DVR/full.m3u8'
+    })
+
+    // A stream error can cause a fresh extraction for the same video. The retry
+    // still uses the default clients, but should not repeat the same notification.
+    await watchView.evaluate((view) => view.extractYtDlpPlaybackSource(
+      view.videoLoadGeneration,
+      view.videoId,
+      view.playbackEngineSwitchGeneration
+    ))
+    expect(await app.electronApp.evaluate(
+      () => globalThis.__ytDlpLiveDvrFallbackDefaultClients
+    )).toEqual([false, true, false, true])
+    await expect(page.locator('.toast', {
+      hasText: 'The preferred yt-dlp clients could not provide playable streams'
+    })).toHaveCount(1)
   })
 
   test('falls back to yt-dlp when the built-in live source has no manifest', async ({ app, page }) => {
@@ -652,7 +710,7 @@ test.describe('watch page', () => {
     const watchView = await watchViewHandle(page)
     await watchView.evaluate(async (view) => {
       view.isLoading = false
-      view.errorMessage = null
+      view.errorMessage = 'Previous playback source failed'
       view.videoTitle = 'Active live stream'
       view.isLive = true
       view.manifestSrc = null
@@ -669,6 +727,7 @@ test.describe('watch page', () => {
       activeFormat: view.activeFormat,
       activePlaybackEngine: view.activePlaybackEngine,
       activePlaybackEngineVersion: view.activePlaybackEngineVersion,
+      errorMessage: view.errorMessage,
       legacyFormats: view.legacyFormats,
       playerReady: view.playerReady,
       ytDlpStreamsPending: view.ytDlpStreamsPending
@@ -677,9 +736,43 @@ test.describe('watch page', () => {
       activeFormat: 'dash',
       activePlaybackEngine: 'yt-dlp',
       activePlaybackEngineVersion: 'test',
+      errorMessage: null,
       legacyFormats: [],
       playerReady: true,
       ytDlpStreamsPending: false
+    })
+  })
+
+  test('does not override a manual built-in selection when its live source is unavailable', async ({ app, page }) => {
+    await mockPlayableWatchPage(app, page)
+    await openMockedVideo(page)
+
+    const watchView = await watchViewHandle(page)
+    const result = await watchView.evaluate(async (view) => {
+      view.isLive = true
+      view.isPostLiveDvr = false
+      view.manifestSrc = null
+      view.legacyFormats = []
+      view.activePlaybackEngine = 'built-in'
+      view.playbackEngineFallbackTarget = 'built-in'
+      view.ytDlpStreamsPending = true
+      view.errorMessage = null
+
+      await view.applyYtDlpPlaybackSource(view.videoLoadGeneration, view.videoId)
+
+      return {
+        activeEngine: view.activePlaybackEngine,
+        fallbackTarget: view.playbackEngineFallbackTarget,
+        pending: view.ytDlpStreamsPending,
+        errorMessage: view.errorMessage
+      }
+    })
+
+    expect(result).toEqual({
+      activeEngine: 'built-in',
+      fallbackTarget: 'built-in',
+      pending: false,
+      errorMessage: 'This video is unavailable because of missing formats. This can happen due to country unavailability.'
     })
   })
 

--- a/src/main/ytDlp.js
+++ b/src/main/ytDlp.js
@@ -1279,7 +1279,7 @@ export async function handleYtDlpGetPlaybackInfo(event, videoId, useDefaultClien
   if (useDefaultClients !== true) {
     // Prefer clients whose URLs are not currently subject to selective PO-token
     // enforcement. The renderer retries with yt-dlp's defaults if none of these
-    // formats are playable for the current video.
+    // formats are playable or they expose only a minimal live DVR window.
     args.push(
       '--extractor-args',
       'youtube:player_client=web_embedded,default,-android_vr'

--- a/src/renderer/components/ft-shaka-video-player/ft-shaka-video-player.js
+++ b/src/renderer/components/ft-shaka-video-player/ft-shaka-video-player.js
@@ -8434,6 +8434,13 @@ export default defineComponent({
      * @param {object?} details
      */
     function handleError(error, context, details) {
+      // A previous critical error is already being handled, or the player is
+      // unloading/destroying. Shaka can still dispatch errors from its queued
+      // segment requests during that window; neither log nor emit them again.
+      if (ignoreErrors) {
+        return
+      }
+
       // These two errors are just wrappers around another error, so use the original error instead
       // As they can be nested (e.g. multiple googlevideo redirects because the Invidious server was far away from the user) we should pick the inner most one
       while (error.code === ErrorCode.REQUEST_FILTER_ERROR || error.code === ErrorCode.RESPONSE_FILTER_ERROR) {

--- a/src/renderer/helpers/player/ytDlpPlayback.js
+++ b/src/renderer/helpers/player/ytDlpPlayback.js
@@ -21,7 +21,16 @@ import { getEarliestYtDlpFormatExpiry, YtDlpPlaybackSourceCache } from './ytDlpP
 // yt-dlp appends the audio track or a suffix like "-drc" to the itag for some formats
 const ITAG_REGEX = /^\d+/
 const URL_PROBE_TIMEOUT = 10_000
+const MINIMUM_LIVE_DVR_WINDOW_SECONDS = 30
 const dashPlaybackSourceCache = new YtDlpPlaybackSourceCache()
+
+/**
+ * @param {string} url
+ */
+function hasLimitedLiveDvrWindow(url) {
+  const match = url.match(/\/(?:manifest|playlist)_duration\/(\d+)\//)
+  return match !== null && parseInt(match[1], 10) <= MINIMUM_LIVE_DVR_WINDOW_SECONDS
+}
 
 /**
  * Ensures playback-error recovery extracts fresh signed stream URLs.
@@ -316,6 +325,7 @@ export async function getYtDlpPlaybackSource(videoId, cacheKey = '', onDefaultCl
   }
 
   let extractionError = null
+  let limitedLiveSource = null
 
   // A fresh extraction with the same default clients can return working URLs after
   // an immediately preceding extraction returned URLs that respond with 403. Give
@@ -385,7 +395,7 @@ export async function getYtDlpPlaybackSource(videoId, cacheKey = '', onDefaultCl
       info.hlsManifestUrl !== null &&
       await probeYtDlpHlsManifest(info.hlsManifestUrl)
     ) {
-      return {
+      const source = {
         manifestSrc: info.hlsManifestUrl,
         manifestMimeType: MANIFEST_TYPE_HLS,
         legacyFormats: await legacyFormatsPromise,
@@ -393,9 +403,28 @@ export async function getYtDlpPlaybackSource(videoId, cacheKey = '', onDefaultCl
         isLive: info.isLive,
         version: info.version
       }
+
+      // The preferred web clients sometimes expose only the last 30 seconds of an
+      // otherwise rewindable live stream. Let the existing default-client fallback
+      // try to obtain its full DVR manifest, while retaining this playable source in
+      // case those clients fail.
+      if (
+        !useDefaultClients &&
+        (info.isLive || info.liveStatus === 'is_live') &&
+        hasLimitedLiveDvrWindow(info.hlsManifestUrl)
+      ) {
+        limitedLiveSource = source
+        continue
+      }
+
+      return source
     }
 
     extractionError = new Error('yt-dlp did not return any playable formats')
+  }
+
+  if (limitedLiveSource !== null) {
+    return limitedLiveSource
   }
 
   throw extractionError ?? new Error('yt-dlp did not return any playable formats')

--- a/src/renderer/views/Watch/Watch.js
+++ b/src/renderer/views/Watch/Watch.js
@@ -322,6 +322,7 @@ export default defineComponent({
       // metadata is already there at that point, so the rest of the page is shown
       // immediately and only the player waits behind a thumbnail placeholder.
       ytDlpStreamsPending: false,
+      ytDlpDefaultClientsFallbackToastShown: false,
       legacyFormats: [],
       captions: [],
       captionTranslations: [],
@@ -778,7 +779,22 @@ export default defineComponent({
     },
     playbackEngineSelection: function () {
       if (this.ytDlpStreamsPending) {
-        return this.playbackEngineFallbackTarget ?? this.videoPlaybackEngine
+        if (this.playbackEngineFallbackTarget !== null) {
+          return this.playbackEngineFallbackTarget
+        }
+
+        // A live stream without built-in formats automatically falls back to
+        // yt-dlp even when the configured default remains the built-in engine.
+        if (
+          this.videoPlaybackEngine === 'built-in' &&
+          this.isLive &&
+          this.manifestSrc === null &&
+          this.legacyFormats.length === 0
+        ) {
+          return 'yt-dlp'
+        }
+
+        return this.videoPlaybackEngine
       }
 
       return this.activePlaybackEngine
@@ -1645,6 +1661,7 @@ export default defineComponent({
         this.streamErrorReloadAttemptedForCurrentVideo = false
         this.playbackEngineFallbackAttemptedForCurrentVideo = false
         this.playbackEngineFallbackTarget = null
+        this.ytDlpDefaultClientsFallbackToastShown = false
         this.sabrErrorRecoveryAttempts = 0
         this.sabrErrorRecoveriesForCurrentVideo = 0
         this.sabrErrorRecoveryLastSeconds = null
@@ -3895,9 +3912,29 @@ export default defineComponent({
 
       this.playbackEngineFallbackAttemptedForCurrentVideo = false
       this.playbackEngineFallbackTarget = playbackEngine
+      this.errorMessage = null
 
-      if (playbackEngine === this.activePlaybackEngine) {
+      const activePlaybackSourceAvailable = this.activeFormat === 'legacy'
+        ? this.legacyFormats.length > 0
+        : this.manifestSrc !== null
+
+      if (playbackEngine === this.activePlaybackEngine && activePlaybackSourceAvailable) {
         this.ytDlpStreamsPending = false
+        return
+      }
+
+      // `ytDlpStreamsPending` removes the current player from the DOM. Destroy
+      // Shaka first so its live manifest refreshes and segment retries cannot
+      // survive the engine switch as an orphaned player.
+      if (this.$refs.player) {
+        await this.destroyPlayer()
+      }
+
+      if (
+        !this.isCurrentVideoLoad(loadGeneration, videoId) ||
+        playbackEngineSwitchGeneration !== this.playbackEngineSwitchGeneration ||
+        this.playbackEngineFallbackTarget !== playbackEngine
+      ) {
         return
       }
 
@@ -3914,7 +3951,20 @@ export default defineComponent({
 
       if (playbackEngine === 'yt-dlp') {
         try {
-          await this.extractYtDlpPlaybackSource(loadGeneration, videoId, playbackEngineSwitchGeneration)
+          const sourceApplied = await this.extractYtDlpPlaybackSource(
+            loadGeneration,
+            videoId,
+            playbackEngineSwitchGeneration
+          )
+          if (
+            !sourceApplied &&
+            this.isCurrentVideoLoad(loadGeneration, videoId) &&
+            playbackEngineSwitchGeneration === this.playbackEngineSwitchGeneration &&
+            this.manifestSrc === null &&
+            this.legacyFormats.length === 0
+          ) {
+            this.errorMessage = this.t('This video is unavailable because of missing formats. This can happen due to country unavailability.')
+          }
         } finally {
           if (
             this.isCurrentVideoLoad(loadGeneration, videoId) &&
@@ -3946,6 +3996,7 @@ export default defineComponent({
       this.streamingDataExpiryDate = source.streamingDataExpiryDate
       this.activePlaybackEngine = 'built-in'
       this.activePlaybackEngineVersion = null
+      this.errorMessage = null
       this.alignActiveFormatWithAvailableSources()
       this.ytDlpStreamsPending = false
     },
@@ -4426,6 +4477,18 @@ export default defineComponent({
 
         this.playbackEngineFallbackAttemptedForCurrentVideo = true
         this.playbackEngineFallbackTarget = 'built-in'
+
+        if (this.$refs.player) {
+          await this.destroyPlayer()
+        }
+
+        if (
+          !this.isCurrentVideoLoad(loadGeneration, videoId) ||
+          playbackEngineSwitchGeneration !== this.playbackEngineSwitchGeneration
+        ) {
+          return true
+        }
+
         this.ytDlpStreamsPending = true
         await this.$nextTick()
         if (
@@ -4474,6 +4537,18 @@ export default defineComponent({
 
       this.playbackEngineFallbackAttemptedForCurrentVideo = true
       this.playbackEngineFallbackTarget = 'yt-dlp'
+
+      if (this.$refs.player) {
+        await this.destroyPlayer()
+      }
+
+      if (
+        !this.isCurrentVideoLoad(loadGeneration, videoId) ||
+        playbackEngineSwitchGeneration !== this.playbackEngineSwitchGeneration
+      ) {
+        return true
+      }
+
       this.ytDlpStreamsPending = true
       this.showTabToast({
         message: this.t('Change Format.Built-in Fallback Template', { error: reason }),
@@ -4543,11 +4618,22 @@ export default defineComponent({
      */
     applyYtDlpPlaybackSource: async function (loadGeneration, videoId) {
       const playbackEngineSwitchGeneration = this.playbackEngineSwitchGeneration
-      const builtInLiveSourceMissing =
-        this.videoPlaybackEngine === 'built-in' &&
+      const liveSourceMissing =
         this.isLive &&
         this.manifestSrc === null &&
         this.legacyFormats.length === 0
+      const builtInLiveSourceMissing =
+        this.videoPlaybackEngine === 'built-in' &&
+        liveSourceMissing
+
+      // A manual Built-in selection is authoritative. If its metadata reload
+      // still has no live source, report that result instead of silently
+      // switching back to yt-dlp or leaving an unexplained empty player area.
+      if (liveSourceMissing && this.playbackEngineFallbackTarget === 'built-in') {
+        this.ytDlpStreamsPending = false
+        this.errorMessage = this.t('This video is unavailable because of missing formats. This can happen due to country unavailability.')
+        return
+      }
 
       if (
         !process.env.IS_ELECTRON ||
@@ -4643,8 +4729,10 @@ export default defineComponent({
         source = await getYtDlpPlaybackSource(videoId, this.ytDlpPlaybackCacheKey, () => {
           if (
             this.isCurrentVideoLoad(loadGeneration, videoId) &&
-            playbackEngineSwitchGeneration === this.playbackEngineSwitchGeneration
+            playbackEngineSwitchGeneration === this.playbackEngineSwitchGeneration &&
+            !this.ytDlpDefaultClientsFallbackToastShown
           ) {
+            this.ytDlpDefaultClientsFallbackToastShown = true
             this.showTabToast({
               message: this.t('Change Format.yt-dlp Default Clients Fallback'),
               icon: ['fas', 'exchange-alt'],
@@ -4694,6 +4782,7 @@ export default defineComponent({
       this.sabrData = null
       this.activePlaybackEngine = 'yt-dlp'
       this.activePlaybackEngineVersion = source.version
+      this.errorMessage = null
 
       this.alignActiveFormatWithAvailableSources()
 


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Make sure to follow the contributing guidelines. -->
<!-- Important note, we may remove your pull request if you do not use this provided PR template correctly. -->
<!-- Agent instructions: Preserve every heading, comment, and marker in this template. Never remove or rewrite the release-note-category:start/end, release-note:start/end, or release-note-image:start/end marker pairs. Never remove or rewrite the Release note images section; leave its contents for a human. -->

## Pull Request Type
<!-- Please select what type of pull request this is: [x] -->
- [x] Bugfix
- [ ] Feature Implementation
- [ ] Documentation
- [ ] Other

## Related issue
<!-- Please link the issue your pull request is referring to. -->
<!-- If this pull request fully resolves the relevant issue, put "closes" before the issue number. -->
<!-- Example: "closes #123456". -->

## Description
<!-- Please write a clear and concise description of what the pull request does. -->
Some active YouTube livestreams expose only a 30-second HLS window through the preferred yt-dlp clients, even though the default clients expose the full rewindable DVR window. Engine switches could also leave the old Shaka player retrying requests after it disappeared, while stale errors, misleading format selections, and duplicate fallback notifications remained visible.

This retries yt-dlp with its default clients when the preferred manifest has a minimal live window, destroys the current player before changing sources, and makes manual and automatic engine state authoritative in the media-format UI. Successful source changes now clear stale errors, while unavailable manual choices report a stable error instead of silently switching back.

Built-in remains the configured default, but an active livestream can still use yt-dlp automatically when the built-in extractor returns no playable manifest or legacy formats. The media-format dialog now shows that automatic fallback while extraction is pending.

## Release note category
<!-- Select exactly one category. Every pull request must select one. -->
<!-- Select "Not noteworthy" when the pull request fixes a bug in or improves functionality that has not yet appeared in a stable release. -->
<!-- release-note-category:start -->
- [ ] Not noteworthy
- [ ] Highlights
- [ ] More improvements
- [x] Fixed bugs
<!-- release-note-category:end -->

## Release note
<!-- Required unless "Not noteworthy" is selected. -->
<!-- Write one concise, user-facing entry without a leading bullet. -->
<!-- release-note:start -->
Livestreams played through yt-dlp retain their rewindable DVR window and switch playback engines reliably.
<!-- release-note:end -->

## Release note images
<!-- Human-only: Agents must preserve this entire section and leave it empty. -->
<!-- Optional. Paste one or more Markdown images or HTML image tags here. -->
<!-- The release notes will use an HTML image tag and limit images taller than 300 pixels. -->
<!-- release-note-image:start -->

<!-- release-note-image:end -->

## Testing
<!-- How can reviewers verify that the PR produces correct results? -->
<!-- Please provide instructions so that others can ensure that your pull request would produce correct results. For examples see, https://github.com/FreeTubeApp/FreeTube/pull/5743, https://github.com/FreeTubeApp/FreeTube/pull/7349, https://github.com/FreeTubeApp/FreeTube/pull/5125, https://github.com/FreeTubeApp/FreeTube/pull/7338 -->
<!-- Agent instructions: Only write human-facing steps that explain how to verify the change while running this branch in dev mode. Include expected results and, when applicable, helpful console snippets for interactive verification. Do not include automated checks, commands, results, pass counts, or CI status. -->
1. Set the default playback engine to Built-in, then open `https://youtu.be/AO5I5nNbbnE` (or another active YouTube DVR livestream).
2. Open Change Media Formats while extraction is pending. yt-dlp should be selected when the built-in extractor did not return a playable live source.
3. Let playback start and seek backward by more than 30 seconds. The player should retain the available DVR history.
4. Switch to Built-in and back to yt-dlp, including once while yt-dlp is still fetching. The player should reappear for a successful source, retain the manual selection when unavailable, and clear any stale source error after recovery.
5. Repeat a yt-dlp recovery and close the video. The default-client fallback notification should appear only once for that video, and DevTools should not keep logging repeated Shaka segment errors after the player is gone.

## Additional context
<!-- Add any other context about the pull request here. -->
The original stream's preferred-client URL advertised `manifest_duration/30`, while yt-dlp's default clients returned the longer DVR manifest.