### PR TITLE
fix(live-chat): smooth fullscreen dock transitions

### DIFF
--- a/e2e/tests/offline/watch-page.spec.mjs
+++ b/e2e/tests/offline/watch-page.spec.mjs
@@ -817,6 +817,13 @@ test.describe('watch page', () => {
         liveChat.removeEventListener(listeners.get(listener), listener)
         listeners.delete(listener)
       }
+      liveChat.emit = (event, value) => {
+        for (const [listener, listenerEvent] of listeners) {
+          if (listenerEvent === event) {
+            listener(value)
+          }
+        }
+      }
       liveChat.start = () => {}
       liveChat.stop = () => {}
 
@@ -874,9 +881,65 @@ test.describe('watch page', () => {
       }
     })
     expect(fullscreenSkeletonGeometry.firstMessageInlineInset).toBe(16)
+    expect(fullscreenSkeletonGeometry.lastMessageBlockInset).toBeGreaterThanOrEqual(0)
     expect(fullscreenSkeletonGeometry.lastMessageBlockInset).toBeLessThan(30)
 
+    await watchView.evaluate((view) => {
+      const actions = Array.from({ length: 60 }, (_, index) => {
+        let actionTypeChecks = 0
+        return {
+          is: () => ++actionTypeChecks === 2,
+          item: {
+            is: () => true,
+            id: `mock-live-chat-message-${index}`,
+            timestamp: Date.now(),
+            message: { runs: [{ text: `Mock live chat message ${index}` }] },
+            author: {
+              badges: [],
+              id: `mock-live-chat-author-${index}`,
+              name: `Chat author ${index}`,
+              thumbnails: [{ url: '' }],
+              is_moderator: false
+            }
+          }
+        }
+      })
+      view.liveChat.emit('start', { actions })
+    })
+
+    const liveChatComments = fullscreenChat.locator('.liveChatComments')
+    await expect(liveChatComments).toBeVisible()
+    await expect(liveChatComments).toHaveClass(/atLiveEdge/)
+    await expect.poll(() => liveChatComments.evaluate(
+      element => element.scrollHeight > element.clientHeight
+    )).toBe(true)
+    await liveChatComments.evaluate((element) => { element.scrollTop = element.scrollHeight })
+    await expect.poll(() => liveChatComments.evaluate(
+      element => element.scrollTop
+    )).toBeGreaterThan(0)
+
+    await page.locator('.fullscreenCommentsToggle').click({ force: true })
+    await expect(page.locator('.fullscreenCommentsOverlay.open')).toBeVisible()
+    await expect.poll(() => liveChatComments.evaluate(element =>
+      Math.abs(element.scrollHeight - element.clientHeight - element.scrollTop)
+    )).toBeLessThanOrEqual(1)
+    await page.locator('.fullscreenCommentsToggle').click({ force: true })
+    await expect(page.locator('.fullscreenCommentsOverlay.open')).toHaveCount(0)
+
+    await liveChatComments.locator('.comment').evaluateAll((comments) => {
+      for (const comment of comments.slice(3)) {
+        comment.style.display = 'none'
+      }
+    })
+    await expect.poll(() => liveChatComments.evaluate(element => ({
+      fits: element.scrollHeight <= element.clientHeight,
+      scrollTop: element.scrollTop
+    }))).toEqual({ fits: true, scrollTop: 0 })
+    await expect(liveChatComments.locator(':scope > .os-scrollbar-vertical'))
+      .toHaveClass(/os-scrollbar-unusable/)
+
     await fullscreenLiveChatToggle.click({ force: true })
+    await expect(fullscreenChat).toHaveCount(0)
     await setPlayerFullscreen(page, false)
     await watchView.evaluate((view) => {
       view.liveChat.dispatchEvent(new ErrorEvent('error', { message: 'Unavailable' }))

--- a/e2e/tests/offline/watch-page.spec.mjs
+++ b/e2e/tests/offline/watch-page.spec.mjs
@@ -856,6 +856,28 @@ test.describe('watch page', () => {
     const skeletonLines = skeleton.locator('.liveChatSkeletonContent').first().locator('div')
     await expect(skeletonLines.nth(0)).toHaveCSS('block-size', '10px')
     await expect(skeletonLines.nth(1)).toHaveCSS('block-size', '10px')
+
+    await setPlayerFullscreen(page, true)
+    const fullscreenLiveChatToggle = page.locator('.fullscreenLiveChatToggle')
+    await fullscreenLiveChatToggle.click({ force: true })
+    const fullscreenChat = page.locator('.fullscreenLiveChatOverlay.open')
+    const fullscreenSkeleton = fullscreenChat.locator('.liveChatSkeleton')
+    await expect(fullscreenSkeleton).toBeVisible()
+    const fullscreenSkeletonGeometry = await fullscreenSkeleton.evaluate((element) => {
+      const bounds = element.getBoundingClientRect()
+      const firstMessageBounds = element.firstElementChild.getBoundingClientRect()
+      const lastMessageBounds = element.lastElementChild.getBoundingClientRect()
+
+      return {
+        firstMessageInlineInset: Math.round(firstMessageBounds.left - bounds.left),
+        lastMessageBlockInset: Math.round(bounds.bottom - lastMessageBounds.bottom)
+      }
+    })
+    expect(fullscreenSkeletonGeometry.firstMessageInlineInset).toBe(16)
+    expect(fullscreenSkeletonGeometry.lastMessageBlockInset).toBeLessThan(30)
+
+    await fullscreenLiveChatToggle.click({ force: true })
+    await setPlayerFullscreen(page, false)
     await watchView.evaluate((view) => {
       view.liveChat.dispatchEvent(new ErrorEvent('error', { message: 'Unavailable' }))
     })

--- a/src/renderer/components/WatchVideoLiveChat/WatchVideoLiveChat.css
+++ b/src/renderer/components/WatchVideoLiveChat/WatchVideoLiveChat.css
@@ -90,6 +90,13 @@
   overflow: hidden;
 }
 
+.fullscreenChat .liveChatSkeleton {
+  block-size: auto !important;
+  justify-content: space-evenly;
+  padding-block: 6px 12px;
+  padding-inline: 16px;
+}
+
 .liveChatDockHeader {
   display: flex;
   flex: 0 0 52px;
@@ -452,6 +459,17 @@
 
 .liveChatComments:dir(rtl) {
   mask-position: 100% 0, 0 0;
+}
+
+.liveChatComments.atLiveEdge {
+  mask-image:
+    linear-gradient(
+      to bottom,
+      transparent,
+      #000 var(--live-chat-fade-size),
+      #000 100%
+    ),
+    linear-gradient(#000 0 0);
 }
 
 .liveChatCommentList {

--- a/src/renderer/components/WatchVideoLiveChat/WatchVideoLiveChat.css
+++ b/src/renderer/components/WatchVideoLiveChat/WatchVideoLiveChat.css
@@ -92,9 +92,14 @@
 
 .fullscreenChat .liveChatSkeleton {
   block-size: auto !important;
-  justify-content: space-evenly;
   padding-block: 6px 12px;
   padding-inline: 16px;
+}
+
+.fullscreenChat .liveChatSkeletonMessage {
+  flex: 1 1 25px;
+  min-block-size: 25px;
+  padding-block: 0;
 }
 
 .liveChatDockHeader {

--- a/src/renderer/components/WatchVideoLiveChat/WatchVideoLiveChat.vue
+++ b/src/renderer/components/WatchVideoLiveChat/WatchVideoLiveChat.vue
@@ -284,6 +284,7 @@
           ref="commentsRef"
           v-overlay-scrollbars
           class="liveChatComments"
+          :class="{ atLiveEdge: !showScrollToBottom }"
           :style="{ blockSize: chatHeight }"
           tabindex="0"
           @pointerdown="handleLiveChatPointerDown"
@@ -483,6 +484,8 @@ let skeletonShownAt = 0
 const SCROLL_TO_LIVE_HOLD_MS = 220
 /** Avoid replacing a fast-loading skeleton before it can be perceived. */
 const MINIMUM_SKELETON_DURATION_MS = 1000
+/** Coalesce the repeated viewport resizes produced by stacked dock transitions. */
+const VIEWPORT_RESIZE_SETTLE_MS = 50
 
 /**
  * Replay messages that were fetched but that the player hasn't reached yet.
@@ -691,6 +694,8 @@ watch(() => props.fullscreenOverlay, () => {
 
 /**
  * Keep the live edge glued across dock open/close animations and height shares.
+ * Content changes are synchronized immediately, while viewport changes settle
+ * first so a dock transition does not force scrollbar layout on every frame.
  * OverlayScrollbars otherwise restores a stale scrollTop past the content end —
  * empty view until the user scrolls up (same failure mode as the comments dock).
  */
@@ -700,7 +705,8 @@ watch(commentsRef, (element, _previous, onCleanup) => {
   }
 
   const contentElement = element.querySelector('.liveChatCommentList')
-  const resizeObserver = new ResizeObserver(() => {
+  let viewportResizeTimer = null
+  const syncScrollPosition = () => {
     clampOverlayScrollTop(element, contentElement)
 
     if (!stayAtBottom) {
@@ -708,14 +714,28 @@ watch(commentsRef, (element, _previous, onCleanup) => {
     }
 
     scrollToBottom('instant')
+  }
+  const viewportResizeObserver = new ResizeObserver(() => {
+    if (viewportResizeTimer !== null) {
+      clearTimeout(viewportResizeTimer)
+    }
+    viewportResizeTimer = setTimeout(() => {
+      viewportResizeTimer = null
+      syncScrollPosition()
+    }, VIEWPORT_RESIZE_SETTLE_MS)
   })
+  const contentResizeObserver = new ResizeObserver(syncScrollPosition)
 
-  resizeObserver.observe(element)
+  viewportResizeObserver.observe(element)
   if (contentElement !== null) {
-    resizeObserver.observe(contentElement)
+    contentResizeObserver.observe(contentElement)
   }
   onCleanup(() => {
-    resizeObserver.disconnect()
+    viewportResizeObserver.disconnect()
+    contentResizeObserver.disconnect()
+    if (viewportResizeTimer !== null) {
+      clearTimeout(viewportResizeTimer)
+    }
   })
 }, { flush: 'post' })
 


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Make sure to follow the contributing guidelines. -->
<!-- Important note, we may remove your pull request if you do not use this provided PR template correctly. -->
<!-- Agent instructions: Preserve every heading, comment, and marker in this template. Never remove or rewrite the release-note-category:start/end, release-note:start/end, or release-note-image:start/end marker pairs. Never remove or rewrite the Release note images section; leave its contents for a human. -->

## Pull Request Type
<!-- Please select what type of pull request this is: [x] -->
- [x] Bugfix
- [ ] Feature Implementation
- [ ] Documentation
- [ ] Other

## Related issue
<!-- Please link the issue your pull request is referring to. -->
<!-- If this pull request fully resolves the relevant issue, put "closes" before the issue number. -->
<!-- Example: "closes #123456". -->

## Description
<!-- Please write a clear and concise description of what the pull request does. -->
Opening or closing another fullscreen dock caused the populated live chat to recalculate and restore its scrollbar on every frame of the stacked-dock resize animation, making the animation visibly choppy.

This separates live-chat content resizing from viewport resizing. New messages still synchronize immediately, while repeated viewport changes are coalesced until the dock animation settles. It also aligns and fills the fullscreen loading skeleton and removes the lower message fade while the chat is at the live edge.

## Release note category
<!-- Select exactly one category. Every pull request must select one. -->
<!-- Select "Not noteworthy" when the pull request fixes a bug in or improves functionality that has not yet appeared in a stable release. -->
<!-- release-note-category:start -->
- [ ] Not noteworthy
- [ ] Highlights
- [ ] More improvements
- [x] Fixed bugs
<!-- release-note-category:end -->

## Release note
<!-- Required unless "Not noteworthy" is selected. -->
<!-- Write one concise, user-facing entry without a leading bullet. -->
<!-- release-note:start -->
Fullscreen live chat no longer makes other dock animations stutter, and its loading placeholders now fill the dock correctly.
<!-- release-note:end -->

## Release note images
<!-- Human-only: Agents must preserve this entire section and leave it empty. -->
<!-- Optional. Paste one or more Markdown images or HTML image tags here. -->
<!-- The release notes will use an HTML image tag and limit images taller than 300 pixels. -->
<!-- release-note-image:start -->

<!-- release-note-image:end -->

## Testing
<!-- How can reviewers verify that the PR produces correct results? -->
<!-- Please provide instructions so that others can ensure that your pull request would produce correct results. For examples see, https://github.com/FreeTubeApp/FreeTube/pull/5743, https://github.com/FreeTubeApp/FreeTube/pull/7349, https://github.com/FreeTubeApp/FreeTube/pull/5125, https://github.com/FreeTubeApp/FreeTube/pull/7338 -->
<!-- Agent instructions: Only write human-facing steps that explain how to verify the change while running this branch in dev mode. Include expected results and, when applicable, helpful console snippets for interactive verification. Do not include automated checks, commands, results, pass counts, or CI status. -->
1. Open a video with a populated live chat or live chat replay, enter fullscreen, and open the live-chat dock.
2. Open and close another fullscreen dock. Both docks should animate smoothly while the chat remains pinned to the live edge.
3. Reload while the fullscreen live-chat dock is open. Its loading placeholders should have consistent horizontal padding and extend to the bottom of the dock.
4. Let the chat follow the live edge, then scroll upward and back down. The lower fade should appear while browsing older messages and disappear at the live edge.

## Additional context
<!-- Add any other context about the pull request here. -->
The live-chat content observer remains immediate so incoming messages and shortened content still clamp against the rendered content end. Only rapid viewport resize notifications are coalesced.
