### PR TITLE
fix(downloads): handle delayed automatic-download RSS entries

### DIFF
--- a/e2e/tests/offline/download-settings.spec.mjs
+++ b/e2e/tests/offline/download-settings.spec.mjs
@@ -234,10 +234,6 @@ test.describe('automatic download authorization', () => {
     await writeFile(path.join(app.userDataDir, 'automatic-download-discovery.xml'), [
       '<feed xmlns:yt="http://www.youtube.com/xml/schemas/2015">',
       '<entry>',
-      `<yt:videoId>ccccccccccc</yt:videoId><yt:channelId>${BETA_CHANNEL_ID}</yt:channelId>`,
-      '<published>2026-08-14T01:00:00Z</published>',
-      '</entry>',
-      '<entry>',
       `<yt:videoId>ddddddddddd</yt:videoId><yt:channelId>${BETA_CHANNEL_ID}</yt:channelId>`,
       '<published>2026-08-13T23:59:59Z</published>',
       '</entry>',
@@ -245,6 +241,12 @@ test.describe('automatic download authorization', () => {
     ].join(''))
     await writeFile(executable, [
       '#!/bin/sh',
+      'for argument in "$@"; do',
+      '  if [ "$argument" = "--dump-single-json" ]; then',
+      `    printf '%s\\n' '{"id":"ccccccccccc","channel_id":"${BETA_CHANNEL_ID}","timestamp":1786669200}'`,
+      '    exit 0',
+      '  fi',
+      'done',
       `printf '%s\\n' "$@" > ${argumentsFile}`,
       "printf '__OPENTUBEX_FILE__:ccccccccccc\\t120\\t1920\\t1080\\t/tmp/automatic.webm\\n'"
     ].join('\n'))

--- a/e2e/tests/offline/download-settings.spec.mjs
+++ b/e2e/tests/offline/download-settings.spec.mjs
@@ -25,7 +25,7 @@ const PROFILES = [
 ]
 const AUTOMATIC_RULE = {
   template: 'video:best',
-  enabledAt: Date.parse('2026-08-14T00:00:00Z'),
+  enabledAt: Date.parse('2026-08-14T01:00:00.500Z'),
   includeVideos: true,
   minDurationSeconds: 60,
   maxDurationSeconds: 180,

--- a/e2e/tests/offline/download-settings.spec.mjs
+++ b/e2e/tests/offline/download-settings.spec.mjs
@@ -231,19 +231,17 @@ test.describe('automatic download authorization', () => {
   test('starts filtered automatic downloads only for the active subscription refresh', async ({ app, page }) => {
     const executable = path.join(app.userDataDir, 'fake-automatic-yt-dlp.sh')
     const argumentsFile = path.join(app.userDataDir, 'automatic-yt-dlp-arguments.txt')
-    await writeFile(path.join(app.userDataDir, 'automatic-download-discovery.xml'), [
-      '<feed xmlns:yt="http://www.youtube.com/xml/schemas/2015">',
-      '<entry>',
-      `<yt:videoId>ddddddddddd</yt:videoId><yt:channelId>${BETA_CHANNEL_ID}</yt:channelId>`,
-      '<published>2026-08-13T23:59:59Z</published>',
-      '</entry>',
-      '</feed>'
-    ].join(''))
+    const metadataLookupsFile = path.join(app.userDataDir, 'automatic-yt-dlp-metadata-lookups.txt')
     await writeFile(executable, [
       '#!/bin/sh',
       'for argument in "$@"; do',
       '  if [ "$argument" = "--dump-single-json" ]; then',
-      `    printf '%s\\n' '{"id":"ccccccccccc","channel_id":"${BETA_CHANNEL_ID}","timestamp":1786669200}'`,
+      `    printf '%s\\n' metadata >> ${metadataLookupsFile}`,
+      '    case "$*" in',
+      `      *ccccccccccc*) printf '%s\\n' '{"id":"ccccccccccc","channel_id":"${BETA_CHANNEL_ID}","timestamp":1786669200}' ;;`,
+      `      *ddddddddddd*) printf '%s\\n' '{"id":"ddddddddddd","channel_id":"${BETA_CHANNEL_ID}","timestamp":1786665599}' ;;`,
+      "      *eeeeeeeeeee*) printf '%s\\n' 'null' ;;",
+      '    esac',
       '    exit 0',
       '  fi',
       'done',
@@ -302,6 +300,10 @@ test.describe('automatic download authorization', () => {
       ...authorizedPayload,
       videoId: 'ddddddddddd'
     })).toBeNull()
+    expect(await page.evaluate((download) => window.ftElectron.ytDlpDownload(download), {
+      ...authorizedPayload,
+      videoId: 'eeeeeeeeeee'
+    })).toBeNull()
 
     const concurrentResults = await page.evaluate((download) => Promise.all([
       window.ftElectron.ytDlpDownload(download),
@@ -333,8 +335,10 @@ test.describe('automatic download authorization', () => {
     expect(args).not.toContain('https://www.youtube.com/watch?v=eeeeeeeeeee')
     expect(args).not.toContain('https://www.youtube.com/playlist?list=PL1234567890')
 
+    const metadataLookupsBeforeDuplicate = await readFile(metadataLookupsFile, 'utf8')
     const duplicate = await page.evaluate((download) => window.ftElectron.ytDlpDownload(download), authorizedPayload)
     expect(duplicate).toEqual({ skipped: 'already-downloaded' })
+    expect(await readFile(metadataLookupsFile, 'utf8')).toBe(metadataLookupsBeforeDuplicate)
     await page.evaluate((tabId) => window.ftElectron.subscriptionAutoRefresh.release(tabId), refreshOwnerTabId)
   })
 })

--- a/src/main/ytDlp.js
+++ b/src/main/ytDlp.js
@@ -1572,7 +1572,8 @@ async function authorizeAutomaticDownload(payload, discoveryPreviouslyAuthorized
       publishedAt = await getAutomaticVideoPublishedAt(payload.videoId, payload.channelId)
       if (publishedAt !== null) discoveredVideos?.set(payload.videoId, publishedAt)
     }
-    if (enabledAt === null || publishedAt === null || publishedAt < enabledAt) {
+    if (enabledAt === null || publishedAt === null ||
+      Math.floor(publishedAt / 1000) < Math.floor(enabledAt / 1000)) {
       return null
     }
   }

--- a/src/main/ytDlp.js
+++ b/src/main/ytDlp.js
@@ -99,6 +99,8 @@ const ID_REGEX = /^[\w-]{11}$/
 const CHANNEL_ID_REGEX = /^UC[\w-]{22}$/
 const AUTOMATIC_DISCOVERY_CACHE_TTL_MS = 60_000
 const AUTOMATIC_DISCOVERY_TIMEOUT_MS = 15_000
+const AUTOMATIC_METADATA_TIMEOUT_MS = 30_000
+const AUTOMATIC_METADATA_MAX_BUFFER = 1024 * 1024
 const AUTOMATIC_DISCOVERY_E2E_FIXTURE = 'automatic-download-discovery.xml'
 const MANAGED_BINARY_UPDATE_CHECK_TIMEOUT_MS = 15_000
 const AUTOMATIC_TITLE_TERM_LIMIT = 20
@@ -1409,6 +1411,52 @@ async function getAutomaticDiscoveryVideoIds(channelId) {
   return videos
 }
 
+/**
+ * Verifies a candidate directly when YouTube's RSS feed has not indexed it
+ * yet. Keep this check in the main process so a renderer cannot authorize an
+ * arbitrary video by supplying its own channel or publication metadata.
+ * @param {string} videoId
+ * @param {string} channelId
+ * @returns {Promise<number | null>} publication time in milliseconds
+ */
+async function getAutomaticVideoPublishedAt(videoId, channelId) {
+  const { source, executable } = await resolveExecutable('ytDlpSource', 'ytDlpPath', 'yt-dlp')
+
+  if (source === 'managed' && !existsSync(executable)) {
+    const result = await downloadManagedYtDlp()
+    if ('error' in result) return null
+  }
+
+  const args = [
+    '--flat-playlist',
+    '--dump-single-json',
+    '--no-playlist',
+    '--no-warnings',
+    '--no-progress',
+    '--socket-timeout',
+    '15'
+  ]
+  await pushProxyArgument(args)
+  args.push(`https://www.youtube.com/watch?v=${videoId}`)
+
+  let info
+  try {
+    const { stdout } = await execFileAsync(executable, args, {
+      timeout: AUTOMATIC_METADATA_TIMEOUT_MS,
+      maxBuffer: AUTOMATIC_METADATA_MAX_BUFFER,
+      windowsHide: true
+    })
+    info = JSON.parse(stdout)
+  } catch {
+    return null
+  }
+
+  const publishedAt = toFiniteNumber(info.timestamp)
+  return info.id === videoId && info.channel_id === channelId && publishedAt !== null
+    ? publishedAt * 1000
+    : null
+}
+
 function automaticTitleTerms(value) {
   return typeof value === 'string'
     ? value.split(',')
@@ -1519,7 +1567,12 @@ async function authorizeAutomaticDownload(payload, discoveryPreviouslyAuthorized
   if (!discoveryPreviouslyAuthorized) {
     const discoveredVideos = await getAutomaticDiscoveryVideoIds(payload.channelId)
     const enabledAt = automaticNumber(rule.enabledAt, Number.MAX_SAFE_INTEGER)
-    if (enabledAt === null || (discoveredVideos?.get(payload.videoId) ?? -Infinity) < enabledAt) {
+    let publishedAt = discoveredVideos?.get(payload.videoId) ?? null
+    if (enabledAt !== null && publishedAt === null) {
+      publishedAt = await getAutomaticVideoPublishedAt(payload.videoId, payload.channelId)
+      if (publishedAt !== null) discoveredVideos?.set(payload.videoId, publishedAt)
+    }
+    if (enabledAt === null || publishedAt === null || publishedAt < enabledAt) {
       return null
     }
   }

--- a/src/main/ytDlp.js
+++ b/src/main/ytDlp.js
@@ -1451,6 +1451,10 @@ async function getAutomaticVideoPublishedAt(videoId, channelId) {
     return null
   }
 
+  if (info === null || typeof info !== 'object' || Array.isArray(info)) {
+    return null
+  }
+
   const publishedAt = toFiniteNumber(info.timestamp)
   return info.id === videoId && info.channel_id === channelId && publishedAt !== null
     ? publishedAt * 1000
@@ -1565,12 +1569,21 @@ async function authorizeAutomaticDownload(payload, discoveryPreviouslyAuthorized
   }
 
   if (!discoveryPreviouslyAuthorized) {
-    const discoveredVideos = await getAutomaticDiscoveryVideoIds(payload.channelId)
+    let discoveredVideos = await getAutomaticDiscoveryVideoIds(payload.channelId)
     const enabledAt = automaticNumber(rule.enabledAt, Number.MAX_SAFE_INTEGER)
     let publishedAt = discoveredVideos?.get(payload.videoId) ?? null
     if (enabledAt !== null && publishedAt === null) {
       publishedAt = await getAutomaticVideoPublishedAt(payload.videoId, payload.channelId)
-      if (publishedAt !== null) discoveredVideos?.set(payload.videoId, publishedAt)
+      if (publishedAt !== null) {
+        if (discoveredVideos === null) {
+          discoveredVideos = new Map()
+          automaticDiscoveryCache.set(payload.channelId, {
+            expiresAt: Date.now() + AUTOMATIC_DISCOVERY_CACHE_TTL_MS,
+            videos: discoveredVideos
+          })
+        }
+        discoveredVideos.set(payload.videoId, publishedAt)
+      }
     }
     if (enabledAt === null || publishedAt === null ||
       Math.floor(publishedAt / 1000) < Math.floor(enabledAt / 1000)) {

--- a/src/renderer/helpers/automaticDownloadRules.js
+++ b/src/renderer/helpers/automaticDownloadRules.js
@@ -111,7 +111,8 @@ export function matchesAutomaticDownloadRule(video, source, rawRule, now = Date.
   }
 
   const published = Number(video.subscriptionFeedPublished ?? video.published)
-  if (rule.enabledAt !== null && (!Number.isFinite(published) || published < rule.enabledAt)) {
+  if (rule.enabledAt !== null && (!Number.isFinite(published) ||
+    Math.floor(published / 1000) < Math.floor(rule.enabledAt / 1000))) {
     return false
   }
   if (rule.maxAgeDays !== null && Number.isFinite(published) &&

--- a/tests/unit/automatic-download-rules.test.mjs
+++ b/tests/unit/automatic-download-rules.test.mjs
@@ -50,6 +50,14 @@ test('only admits entries announced after the rule was enabled', () => {
   assert.equal(matchesAutomaticDownloadRule(video({ published: undefined }), 'videos', rule, now), false)
 })
 
+test('compares publication and activation times at feed timestamp precision', () => {
+  const enabledAt = now - 2 * DAY + 500
+  const rule = { enabledAt }
+
+  assert.equal(matchesAutomaticDownloadRule(video({ published: enabledAt - 500 }), 'videos', rule, now), true)
+  assert.equal(matchesAutomaticDownloadRule(video({ published: enabledAt - 1000 }), 'videos', rule, now), false)
+})
+
 test('applies content-type, duration, age, and title filters', () => {
   const rule = {
     enabledAt: now - 10 * DAY,


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Make sure to follow the contributing guidelines. -->
<!-- Important note, we may remove your pull request if you do not use this provided PR template correctly. -->
<!-- Agent instructions: Preserve every heading, comment, and marker in this template. Never remove or rewrite the release-note-category:start/end, release-note:start/end, or release-note-image:start/end marker pairs. Never remove or rewrite the Release note images section; leave its contents for a human. -->

## Pull Request Type
<!-- Please select what type of pull request this is: [x] -->
- [x] Bugfix
- [ ] Feature Implementation
- [ ] Documentation
- [ ] Other

## Related issue
<!-- Please link the issue your pull request is referring to. -->
<!-- If this pull request fully resolves the relevant issue, put "closes" before the issue number. -->
<!-- Example: "closes #123456". -->

## Description
<!-- Please write a clear and concise description of what the pull request does. -->
Automatic downloads could be rejected immediately after publication because the subscription scraper discovered a video before YouTube's RSS feed indexed it. The main-process authorization returned no download, leaving only a generic failure toast and no Downloads entry.

When RSS does not contain the candidate yet, the main process now performs a lightweight yt-dlp metadata lookup. It only authorizes the download when the returned video ID, channel ID, and publication time match the persisted automatic-download rule, preserving the existing renderer security boundary.

## Release note category
<!-- Select exactly one category. Every pull request must select one. -->
<!-- Select "Not noteworthy" when the pull request fixes a bug in or improves functionality that has not yet appeared in a stable release. -->
<!-- release-note-category:start -->
- [x] Not noteworthy
- [ ] Highlights
- [ ] More improvements
- [ ] Fixed bugs
<!-- release-note-category:end -->

## Release note
<!-- Required unless "Not noteworthy" is selected. -->
<!-- Write one concise, user-facing entry without a leading bullet. -->
<!-- release-note:start -->

<!-- release-note:end -->

## Release note images
<!-- Human-only: Agents must preserve this entire section and leave it empty. -->
<!-- Optional. Paste one or more Markdown images or HTML image tags here. -->
<!-- The release notes will use an HTML image tag and limit images taller than 300 pixels. -->
<!-- release-note-image:start -->

<!-- release-note-image:end -->

## Testing
<!-- How can reviewers verify that the PR produces correct results? -->
<!-- Please provide instructions so that others can ensure that your pull request would produce correct results. For examples see, https://github.com/FreeTubeApp/FreeTube/pull/5743, https://github.com/FreeTubeApp/FreeTube/pull/7349, https://github.com/FreeTubeApp/FreeTube/pull/5125, https://github.com/FreeTubeApp/FreeTube/pull/7338 -->
<!-- Agent instructions: Only write human-facing steps that explain how to verify the change while running this branch in dev mode. Include expected results and, when applicable, helpful console snippets for interactive verification. Do not include automated checks, commands, results, pass counts, or CI status. -->
1. In dev mode, enable automatic downloads for a subscribed channel.
2. Refresh subscriptions immediately after that channel publishes a public video, while YouTube's channel RSS feed still omits it.
3. Confirm the download starts and appears in Downloads instead of showing the "Could not start" toast.
4. Confirm a video from another channel or one published before the rule was enabled is still rejected.

## Additional context
<!-- Add any other context about the pull request here. -->
The fallback uses yt-dlp's flat metadata mode and does not trust renderer-provided channel or publication metadata.
