### PR TITLE
fix(history): restore binary behavior at 0% threshold

### DIFF
--- a/e2e/tests/offline/history.spec.mjs
+++ b/e2e/tests/offline/history.spec.mjs
@@ -245,6 +245,7 @@ test.describe('watch history with an immediate watched threshold', () => {
     await page.locator('[data-subscription-feed-tab="videos"]').click()
 
     const video = page.locator('.ft-list-video').filter({ hasText: 'Immediately watched video' })
+    await expect(video.locator('.watchedProgressBar')).toHaveCount(1)
     await video.hover()
     await video.locator('.optionsButton').click()
     await page.getByRole('option', { name: 'Unmark As Watched' }).click()

--- a/e2e/tests/offline/history.spec.mjs
+++ b/e2e/tests/offline/history.spec.mjs
@@ -190,12 +190,36 @@ test.describe('watch history', () => {
 })
 
 test.describe('watch history with an immediate watched threshold', () => {
+  const immediateHistoryEntry = historyEntry(
+    'ddddddddddd',
+    'Immediately watched video',
+    Date.now(),
+    true
+  )
+
   test.use({
     seed: {
-      settings: { watchedPercentageThreshold: 0 },
-      history: [
-        historyEntry('ddddddddddd', 'Immediately watched video', Date.now(), true)
-      ]
+      settings: {
+        fetchSubscriptionsAutomatically: false,
+        watchedPercentageThreshold: 0,
+      },
+      profiles: [{
+        _id: 'allChannels',
+        name: 'All Channels',
+        bgColor: '#000000',
+        textColor: '#FFFFFF',
+        subscriptions: [{
+          id: immediateHistoryEntry.authorId,
+          name: immediateHistoryEntry.author,
+          thumbnail: '',
+        }]
+      }],
+      history: [immediateHistoryEntry],
+      subscriptionCache: [{
+        _id: immediateHistoryEntry.authorId,
+        videos: [immediateHistoryEntry],
+        videosTimestamp: new Date().toISOString(),
+      }]
     }
   })
 
@@ -214,6 +238,34 @@ test.describe('watch history with an immediate watched threshold', () => {
       const records = contents.trim().split('\n').filter(Boolean).map(line => JSON.parse(line))
       return records.filter(record => record._id === 'ddddddddddd').at(-1)?.$$deleted
     }).toBe(true)
+  })
+
+  test('removes and cleanly re-adds a history entry from the subscriptions feed', async ({ app, page }) => {
+    await goTo(page, 'subscriptions')
+    await page.locator('[data-subscription-feed-tab="videos"]').click()
+
+    const video = page.locator('.ft-list-video').filter({ hasText: 'Immediately watched video' })
+    await video.hover()
+    await video.locator('.optionsButton').click()
+    await page.getByRole('option', { name: 'Unmark As Watched' }).click()
+
+    await expect(video).toBeVisible()
+    await expect(video.locator('.watchedProgressBar')).toHaveCount(0)
+    await expect.poll(() => page.evaluate(() => {
+      const store = document.querySelector('#app').__vue_app__.config.globalProperties.$store
+      return store.getters.getHistoryCacheById.ddddddddddd
+    })).toBeUndefined()
+
+    await video.hover()
+    await video.locator('.optionsButton').click()
+    await page.getByRole('option', { name: 'Mark As Watched' }).click()
+
+    await expect.poll(async () => {
+      const contents = await readFile(path.join(app.userDataDir, 'history.db'), 'utf8')
+      const records = contents.trim().split('\n').filter(Boolean).map(line => JSON.parse(line))
+      return records.filter(record => record.videoId === 'ddddddddddd').at(-1)?.watchProgress
+    }).toBe(0)
+    await expect(video.locator('.watchedProgressBar')).toHaveCount(0)
   })
 })
 

--- a/src/renderer/components/FtListVideo/FtListVideo.vue
+++ b/src/renderer/components/FtListVideo/FtListVideo.vue
@@ -39,7 +39,7 @@
           alt=""
         >
         <FtEmbeddedProgress
-          v-if="historyEntryExists"
+          v-if="historyEntryExists && progressPercentage > 0"
           class="watchedProgressBar"
           :progress="progressPercentage"
           :corner-radius="thumbnailProgressRadius"
@@ -1727,7 +1727,7 @@ function markAsWatched() {
 }
 
 async function unmarkAsWatched() {
-  if (inHistory.value && watchedPercentageThreshold.value === 0) {
+  if (watchedPercentageThreshold.value === 0) {
     await store.dispatch('removeFromHistory', id.value)
   } else {
     await store.dispatch('updateHistory', {


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Make sure to follow the contributing guidelines. -->
<!-- Important note, we may remove your pull request if you do not use this provided PR template correctly. -->
<!-- Agent instructions: Preserve every heading, comment, and marker in this template. Never remove or rewrite the release-note-category:start/end, release-note:start/end, or release-note-image:start/end marker pairs. Never remove or rewrite the Release note images section; leave its contents for a human. -->

## Pull Request Type
<!-- Please select what type of pull request this is: [x] -->
- [x] Bugfix
- [ ] Feature Implementation
- [ ] Documentation
- [ ] Other

## Related issue
<!-- Please link the issue your pull request is referring to. -->
<!-- If this pull request fully resolves the relevant issue, put "closes" before the issue number. -->
<!-- Example: "closes #123456". -->

Closes #770.

## Description
<!-- Please write a clear and concise description of what the pull request does. -->

With a 0% watched threshold, unmarking a video only removed it from history when the action was performed on the History page. The same action from Subscriptions or another feed instead kept an unwatched history record because the removal branch depended on the current route.

This makes the 0% behavior route-independent: unmarking a watched video now removes its history record from every view. It also avoids rendering the zero-length rounded progress stroke, so manually marked videos with no playback progress do not show a misleading red dot.

## Release note category
<!-- Select exactly one category. Every pull request must select one. -->
<!-- Select "Not noteworthy" when the pull request fixes a bug in or improves functionality that has not yet appeared in a stable release. -->
<!-- release-note-category:start -->
- [ ] Not noteworthy
- [ ] Highlights
- [ ] More improvements
- [x] Fixed bugs
<!-- release-note-category:end -->

## Release note
<!-- Required unless "Not noteworthy" is selected. -->
<!-- Write one concise, user-facing entry without a leading bullet. -->
<!-- release-note:start -->
Setting the watched threshold to 0% now removes videos from history immediately when they are marked as unwatched from any view.
<!-- release-note:end -->

## Release note images
<!-- Human-only: Agents must preserve this entire section and leave it empty. -->
<!-- Optional. Paste one or more Markdown images or HTML image tags here. -->
<!-- The release notes will use an HTML image tag and limit images taller than 300 pixels. -->
<!-- release-note-image:start -->

<!-- release-note-image:end -->

## Testing
<!-- How can reviewers verify that the PR produces correct results? -->
<!-- Please provide instructions so that others can ensure that your pull request would produce correct results. For examples see, https://github.com/FreeTubeApp/FreeTube/pull/5743, https://github.com/FreeTubeApp/FreeTube/pull/7349, https://github.com/FreeTubeApp/FreeTube/pull/5125, https://github.com/FreeTubeApp/FreeTube/pull/7338 -->
<!-- Agent instructions: Only write human-facing steps that explain how to verify the change while running this branch in dev mode. Include expected results and, when applicable, helpful console snippets for interactive verification. Do not include automated checks, commands, results, pass counts, or CI status. -->

1. Set the Watch Percentage Threshold to 0%.
2. Mark a video as watched from the Subscriptions feed and confirm it appears in History without a red playback-progress dot.
3. From the Subscriptions feed, mark the same video as unwatched.
4. Open History and confirm the video was removed immediately.
5. Repeat the watched/unwatched toggle from the History page and confirm its existing immediate-removal behavior is unchanged.

## Additional context
<!-- Add any other context about the pull request here. -->

The fix keeps non-zero thresholds unchanged.