### PR TITLE
fix(downloads): add yt-dlp failure guidance

### DIFF
--- a/e2e/tests/offline/video-actions.spec.mjs
+++ b/e2e/tests/offline/video-actions.spec.mjs
@@ -201,6 +201,12 @@ test.describe('video downloads', () => {
     await page.getByRole('button', { name: 'Download', exact: true }).click()
 
     await expect(page.getByText('Download failed', { exact: true })).toBeVisible()
+    const failureHintLink = page.getByRole('link', { name: 'recent yt-dlp issues for YouTube' })
+    await expect(failureHintLink).toHaveAttribute(
+      'href',
+      'https://github.com/yt-dlp/yt-dlp/issues?q=is%3Aissue%20sort%3Acreated-desc%20YouTube'
+    )
+    await expect(page.getByText(/then try switching the yt-dlp channel to Nightly or Master/)).toBeVisible()
     await expect(page.locator('.downloadProgressBarTrack')).toHaveCount(0)
     const separatorSpacing = await page.locator('.downloadPromptContent').evaluate(prompt => ({
       above: Number.parseFloat(getComputedStyle(prompt.querySelector('.downloadProgress')).paddingBottom),
@@ -1050,6 +1056,8 @@ test.describe('video downloads', () => {
     const downloadRow = page.locator('.downloadRow').filter({ hasText: 'Bookmarkable video' })
     await expect(downloadRow.locator('.destination')).toHaveText('/tmp/subtitles.en.vtt')
     await expect(downloadRow.locator('.downloadError')).toContainText('Subtitle conversion failed')
+    await expect(downloadRow.getByRole('link', { name: 'recent yt-dlp issues for YouTube' })).toBeVisible()
+    await expect(downloadRow).toContainText('then try switching the yt-dlp channel to Nightly or Master')
     await downloadRow.getByTitle('Retry download').click()
     await expect.poll(() => page.evaluate(async () => {
       return (await window.ftElectron.ytDlpListDownloads())

--- a/src/renderer/components/DownloadFailureHint/DownloadFailureHint.vue
+++ b/src/renderer/components/DownloadFailureHint/DownloadFailureHint.vue
@@ -1,0 +1,29 @@
+<template>
+  <Translation
+    keypath="Downloads.Download Failure Hint"
+    tag="p"
+    class="downloadFailureHint"
+  >
+    <template #issuesLink>
+      <a :href="YT_DLP_YOUTUBE_ISSUES_URL">
+        {{ t('Downloads.yt-dlp YouTube Issues') }}
+      </a>
+    </template>
+  </Translation>
+</template>
+
+<script setup>
+import { Translation, useI18n } from 'vue-i18n'
+
+const YT_DLP_YOUTUBE_ISSUES_URL = 'https://github.com/yt-dlp/yt-dlp/issues?q=is%3Aissue%20sort%3Acreated-desc%20YouTube'
+const { t } = useI18n()
+</script>
+
+<style scoped>
+.downloadFailureHint {
+  color: var(--secondary-text-color);
+  font-size: 0.9rem;
+  margin-block: 4px;
+  overflow-wrap: anywhere;
+}
+</style>

--- a/src/renderer/components/WatchVideoDownloadPrompt/WatchVideoDownloadPrompt.vue
+++ b/src/renderer/components/WatchVideoDownloadPrompt/WatchVideoDownloadPrompt.vue
@@ -239,6 +239,7 @@
         >
           {{ activeDownload.errorMessage }}
         </p>
+        <DownloadFailureHint v-if="activeDownload.status === 'failed'" />
       </div>
 
       <footer
@@ -330,6 +331,7 @@ import { FtIcon } from '@opentubex/icons'
 import { computed, nextTick, reactive, ref, useTemplateRef } from 'vue'
 import { useI18n } from 'vue-i18n'
 
+import DownloadFailureHint from '../DownloadFailureHint/DownloadFailureHint.vue'
 import FtButton from '../FtButton/FtButton.vue'
 import FtCheckboxList from '../FtCheckboxList/FtCheckboxList.vue'
 import FtFlexBox from '../ft-flex-box/ft-flex-box.vue'

--- a/src/renderer/views/Downloads/DownloadRow.vue
+++ b/src/renderer/views/Downloads/DownloadRow.vue
@@ -44,6 +44,7 @@
         >
           {{ errorText }}
         </p>
+        <DownloadFailureHint v-if="download.status === 'failed'" />
         <ul
           v-if="destinations.length > 0"
           class="destinationList"
@@ -118,6 +119,7 @@
 <script setup>
 import { computed } from 'vue'
 import { useI18n } from 'vue-i18n'
+import DownloadFailureHint from '../../components/DownloadFailureHint/DownloadFailureHint.vue'
 import FtIconButton from '../../components/FtIconButton/FtIconButton.vue'
 import thumbnailPlaceholder from '../../assets/img/thumbnail_placeholder.svg'
 import { downloadTemplateName } from '../../helpers/downloadTemplates'

--- a/static/locales/en-US.yaml
+++ b/static/locales/en-US.yaml
@@ -2351,6 +2351,8 @@ Downloads:
   Download Complete: Download complete
   Download Cancelled: Download canceled
   Download Failed: Download failed
+  Download Failure Hint: Check {issuesLink}, then try switching the yt-dlp channel to Nightly or Master in External Software settings.
+  yt-dlp YouTube Issues: recent yt-dlp issues for YouTube
   Automatic Download Started: Automatic download started
   Automatic Download Started Body: 'Downloading "{title}" from {channel} in the background.'
   Automatic Download Complete: Automatic download complete


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Make sure to follow the contributing guidelines. -->
<!-- Important note, we may remove your pull request if you do not use this provided PR template correctly. -->
<!-- Agent instructions: Preserve every heading, comment, and marker in this template. Never remove or rewrite the release-note-category:start/end, release-note:start/end, or release-note-image:start/end marker pairs. Never remove or rewrite the Release note images section; leave its contents for a human. -->

## Pull Request Type
<!-- Please select what type of pull request this is: [x] -->
- [ ] Bugfix
- [x] Feature Implementation
- [ ] Documentation
- [ ] Other

## Related issue
<!-- Please link the issue your pull request is referring to. -->
<!-- If this pull request fully resolves the relevant issue, put "closes" before the issue number. -->
<!-- Example: "closes #123456". -->

## Description
<!-- Please write a clear and concise description of what the pull request does. -->
When a yt-dlp download fails, users currently see the error without guidance about upstream YouTube breakages or alternative release channels.

This adds a reusable failure hint to both the active download prompt and saved download rows. The hint links to recent YouTube-related yt-dlp issues and suggests trying the Nightly or Master channel in External Software settings.

## Release note category
<!-- Select exactly one category. Every pull request must select one. -->
<!-- Select "Not noteworthy" when the pull request fixes a bug in or improves functionality that has not yet appeared in a stable release. -->
<!-- release-note-category:start -->
- [ ] Not noteworthy
- [ ] Highlights
- [x] More improvements
- [ ] Fixed bugs
<!-- release-note-category:end -->

## Release note
<!-- Required unless "Not noteworthy" is selected. -->
<!-- Write one concise, user-facing entry without a leading bullet. -->
<!-- release-note:start -->
Failed downloads now link to recent yt-dlp YouTube issues and suggest trying the Nightly or Master channel.
<!-- release-note:end -->

## Release note images
<!-- Human-only: Agents must preserve this entire section and leave it empty. -->
<!-- Optional. Paste one or more Markdown images or HTML image tags here. -->
<!-- The release notes will use an HTML image tag and limit images taller than 300 pixels. -->
<!-- release-note-image:start -->

<!-- release-note-image:end -->

## Testing
<!-- How can reviewers verify that the PR produces correct results? -->
<!-- Please provide instructions so that others can ensure that your pull request produces correct results. For examples see, https://github.com/FreeTubeApp/FreeTube/pull/5743, https://github.com/FreeTubeApp/FreeTube/pull/7349, https://github.com/FreeTubeApp/FreeTube/pull/5125, https://github.com/FreeTubeApp/FreeTube/pull/7338 -->
<!-- Agent instructions: Only write human-facing steps that explain how to verify the change while running this branch in dev mode. Include expected results and, when applicable, helpful console snippets for interactive verification. Do not include automated checks, commands, results, pass counts, or CI status. -->
1. Configure yt-dlp to use `/bin/false` as a custom system executable in External Software settings.
2. Start a video download and confirm the failed-download prompt shows the linked hint beneath the error.
3. Open Downloads and confirm the failed row shows the same hint.
4. Click the link and confirm it opens the recent YouTube-related yt-dlp issues search externally.

## Additional context
<!-- Add any other context about the pull request here. -->
Focused Electron coverage verifies the prompt and saved-row variants, including the exact upstream URL.
