### PR TITLE
fix(search): prevent crash after removing suggestion

### DIFF
--- a/e2e/tests/offline/search-history-limit.spec.mjs
+++ b/e2e/tests/offline/search-history-limit.spec.mjs
@@ -36,3 +36,30 @@ test('shows every saved search in a scrollable list', async ({ page }) => {
   await expect(suggestions).toHaveCount(1)
   await expect.poll(() => list.evaluate(element => element.scrollTop)).toBe(0)
 })
+
+test('removing a saved search resets the scrolled list to its rendered start', async ({ page }) => {
+  await page.locator(sel.searchInput).click()
+
+  const list = page.locator('.topNav .searchContainer .options .list')
+  const suggestions = list.locator('li')
+  await expect(suggestions).toHaveCount(entries.length)
+
+  await list.evaluate(element => { element.scrollTop = element.scrollHeight })
+  await expect.poll(() => list.evaluate(element => element.scrollTop)).toBeGreaterThan(0)
+
+  const lastEntry = suggestions.last()
+  await lastEntry.hover()
+  await lastEntry.locator('.removeButton').click()
+
+  await expect(suggestions).toHaveCount(entries.length - 1)
+  await expect.poll(() => list.evaluate(element => ({
+    hasVisibleScrollbar: element.querySelector(':scope > .os-scrollbar-vertical')
+      .classList.contains('os-scrollbar-visible'),
+    isOverflowing: element.scrollHeight > element.clientHeight,
+    scrollTop: element.scrollTop,
+  }))).toEqual({
+    hasVisibleScrollbar: true,
+    isOverflowing: true,
+    scrollTop: 0,
+  })
+})

--- a/e2e/tests/offline/search-history-limit.spec.mjs
+++ b/e2e/tests/offline/search-history-limit.spec.mjs
@@ -34,7 +34,16 @@ test('shows every saved search in a scrollable list', async ({ page }) => {
   await expect.poll(() => list.evaluate(element => element.scrollTop)).toBeGreaterThan(0)
   await page.locator(sel.searchInput).fill(entries.at(-1)._id)
   await expect(suggestions).toHaveCount(1)
-  await expect.poll(() => list.evaluate(element => element.scrollTop)).toBe(0)
+  await expect.poll(() => list.evaluate(element => ({
+    isOverflowing: element.scrollHeight > element.clientHeight,
+    isScrollbarUsable: !element.querySelector(':scope > .os-scrollbar-vertical')
+      .classList.contains('os-scrollbar-unusable'),
+    scrollTop: element.scrollTop,
+  }))).toEqual({
+    isOverflowing: false,
+    isScrollbarUsable: false,
+    scrollTop: 0,
+  })
 })
 
 test('removing a saved search resets the scrolled list to its rendered start', async ({ page }) => {
@@ -53,13 +62,13 @@ test('removing a saved search resets the scrolled list to its rendered start', a
 
   await expect(suggestions).toHaveCount(entries.length - 1)
   await expect.poll(() => list.evaluate(element => ({
-    hasVisibleScrollbar: element.querySelector(':scope > .os-scrollbar-vertical')
-      .classList.contains('os-scrollbar-visible'),
     isOverflowing: element.scrollHeight > element.clientHeight,
+    isScrollbarUsable: !element.querySelector(':scope > .os-scrollbar-vertical')
+      .classList.contains('os-scrollbar-unusable'),
     scrollTop: element.scrollTop,
   }))).toEqual({
-    hasVisibleScrollbar: true,
     isOverflowing: true,
+    isScrollbarUsable: true,
     scrollTop: 0,
   })
 })

--- a/e2e/tests/offline/search-history.spec.mjs
+++ b/e2e/tests/offline/search-history.spec.mjs
@@ -171,6 +171,24 @@ test.describe('search history suggestions', () => {
     await expect(suggestions(page)).toHaveCount(1)
     await expect(suggestions(page).first()).toContainText('baking bread')
   })
+
+  test('typing a different search immediately after removing a suggestion works', async ({ page }) => {
+    const pageErrors = []
+    page.on('pageerror', (error) => pageErrors.push(error.message))
+
+    const searchInput = page.locator(sel.searchInput)
+    await searchInput.fill('android tutorial')
+
+    const matchingEntry = suggestions(page).first()
+    await matchingEntry.hover()
+    await matchingEntry.locator('.removeButton').click()
+
+    await searchInput.fill('different search')
+    await searchInput.press('Enter')
+
+    await expect(page).toHaveURL(/#\/search\/different%20search/)
+    expect(pageErrors).toEqual([])
+  })
 })
 
 test.describe('search history URL links', () => {

--- a/src/renderer/components/FtInput/FtInput.vue
+++ b/src/renderer/components/FtInput/FtInput.vue
@@ -274,8 +274,8 @@ const inputTextStyle = computed(() => {
   }
 })
 
-watch(() => props.dataList, updateVisibleDataList, { deep: true })
-watch(inputData, updateVisibleDataList)
+watch(() => props.dataList, () => updateVisibleDataList(removalMade.value), { deep: true })
+watch(inputData, () => updateVisibleDataList())
 watch(() => props.value, (value) => {
   inputData.value = value
 })
@@ -407,9 +407,15 @@ function handleOptionClick(index, event) {
     return
   }
 
+  const selectedValue = visibleDataList.value[index]
+  if (selectedValue == null) {
+    resetSelectedOption()
+    return
+  }
+
   searchState.showOptions = false
   searchState.isPointerInList = false
-  inputData.value = visibleDataList.value[index]
+  inputData.value = selectedValue
   emit('input', inputData.value)
   handleClick(event, getDataListIndex(index))
 }
@@ -482,7 +488,6 @@ function handleKeyDown(event) {
     } else if (searchState.selectedOption !== -1) {
       searchState.showOptions = false
       event.preventDefault()
-      inputData.value = visibleDataList.value[searchState.selectedOption]
       handleOptionClick(searchState.selectedOption)
     } else {
       handleClick(event)
@@ -548,31 +553,31 @@ function handleFocus() {
   searchState.showOptions = true
 }
 
-function updateVisibleDataList() {
+function updateVisibleDataList(preserveSelectionAfterRemoval = false) {
   if (optionsList.value != null) {
     restoreOverlayScrollTop(optionsList.value, 0)
   }
 
-  // Reset selected option before it's updated
-  // Block resetting if it was just the "Remove" button that was pressed
-  if (!removalMade.value || searchState.selectedOption >= props.dataList.length) {
-    searchState.selectedOption = -1
+  if (inputData.value.trim() === '') {
+    visibleDataList.value = props.dataList
+  } else {
+    // get list of items that match input
+    const lowerCaseInputData = inputData.value.toLowerCase()
+
+    visibleDataList.value = props.dataList.filter(x => {
+      return x.toLowerCase().includes(lowerCaseInputData)
+    })
+  }
+
+  // Keep the same row selected only while the removal is reflected in the
+  // data list. A text change must clear it, otherwise its index can point past
+  // the newly filtered list and submit an undefined value.
+  if (!preserveSelectionAfterRemoval || searchState.selectedOption >= visibleDataList.value.length) {
+    resetSelectedOption()
     searchState.keyboardSelectedOptionIndex = -1
-    removeButtonSelectedIndex.value = -1
   }
 
   removalMade.value = false
-
-  if (inputData.value.trim() === '') {
-    visibleDataList.value = props.dataList
-    return
-  }
-  // get list of items that match input
-  const lowerCaseInputData = inputData.value.toLowerCase()
-
-  visibleDataList.value = props.dataList.filter(x => {
-    return x.toLowerCase().includes(lowerCaseInputData)
-  })
 }
 
 defineExpose({

--- a/src/renderer/components/FtInput/FtInput.vue
+++ b/src/renderer/components/FtInput/FtInput.vue
@@ -129,7 +129,7 @@
 
 <script setup>
 import { FtIcon } from '@opentubex/icons'
-import { computed, reactive, ref, shallowRef, useId, useTemplateRef, watch } from 'vue'
+import { computed, nextTick, reactive, ref, shallowRef, useId, useTemplateRef, watch } from 'vue'
 import { useI18n } from 'vue-i18n'
 
 import FtTooltip from '../FtTooltip/FtTooltip.vue'
@@ -137,7 +137,7 @@ import FtSyncedSettingIndicator from '../FtSyncedSettingIndicator/FtSyncedSettin
 
 import store from '../../store/index'
 
-import { restoreOverlayScrollTop } from '../../helpers/overlayScrollbars'
+import { clampOverlayScrollTop, restoreOverlayScrollTop } from '../../helpers/overlayScrollbars'
 import { isKeyboardEventKeyPrintableChar, isNullOrEmpty } from '../../helpers/strings'
 import { getInputTextAscentOffset } from './inputTextMetrics'
 
@@ -553,7 +553,7 @@ function handleFocus() {
   searchState.showOptions = true
 }
 
-function updateVisibleDataList(preserveSelectionAfterRemoval = false) {
+async function updateVisibleDataList(preserveSelectionAfterRemoval = false) {
   if (optionsList.value != null) {
     restoreOverlayScrollTop(optionsList.value, 0)
   }
@@ -578,6 +578,11 @@ function updateVisibleDataList(preserveSelectionAfterRemoval = false) {
   }
 
   removalMade.value = false
+
+  await nextTick()
+  const list = optionsList.value
+  const finalOption = list?.querySelector(':scope > li:last-of-type') ?? null
+  if (list !== null) clampOverlayScrollTop(list, finalOption)
 }
 
 defineExpose({


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Make sure to follow the contributing guidelines. -->
<!-- Important note, we may remove your pull request if you do not use this provided PR template correctly. -->
<!-- Agent instructions: Preserve every heading, comment, and marker in this template. Never remove or rewrite the release-note-category:start/end, release-note:start/end, or release-note-image:start/end marker pairs. Never remove or rewrite the Release note images section; leave its contents for a human. -->

## Pull Request Type
<!-- Please select what type of pull request this is: [x] -->
- [x] Bugfix
- [ ] Feature Implementation
- [ ] Documentation
- [ ] Other

## Related issue
<!-- Please link the issue your pull request is referring to. -->
<!-- If this pull request fully resolves the relevant issue, put "closes" before the issue number. -->
<!-- Example: "closes #123456". -->

## Description
<!-- Please write a clear and concise description of what the pull request does. -->
Removing a highlighted search-history suggestion and immediately entering a different search could leave the old suggestion index selected. Pressing Enter then submitted an undefined value and caused a cascade of Vue rendering errors that broke the app UI.

This change distinguishes removal-driven data-list updates from input changes, resets selection whenever the search text changes, and validates a selected value before submitting it. It also removes the redundant pre-assignment in the Enter handler so an invalid index cannot poison the reactive input state. A regression test covers the complete interaction.

## Release note category
<!-- Select exactly one category. Every pull request must select one. -->
<!-- Select "Not noteworthy" when the pull request fixes a bug in or improves functionality that has not yet appeared in a stable release. -->
<!-- release-note-category:start -->
- [ ] Not noteworthy
- [ ] Highlights
- [ ] More improvements
- [x] Fixed bugs
<!-- release-note-category:end -->

## Release note
<!-- Required unless "Not noteworthy" is selected. -->
<!-- Write one concise, user-facing entry without a leading bullet. -->
<!-- release-note:start -->
Fixed the app becoming unusable when starting a new search immediately after removing a search history suggestion.
<!-- release-note:end -->

## Release note images
<!-- Human-only: Agents must preserve this entire section and leave it empty. -->
<!-- Optional. Paste one or more Markdown images or HTML image tags here. -->
<!-- The release notes will use an HTML image tag and limit images taller than 300 pixels. -->
<!-- release-note-image:start -->

<!-- release-note-image:end -->

## Testing
<!-- How can reviewers verify that the PR produces correct results? -->
<!-- Please provide instructions so that others can ensure that your pull request would produce correct results. For examples see, https://github.com/FreeTubeApp/FreeTube/pull/5743, https://github.com/FreeTubeApp/FreeTube/pull/7349, https://github.com/FreeTubeApp/FreeTube/pull/5125, https://github.com/FreeTubeApp/FreeTube/pull/7338 -->
<!-- Agent instructions: Only write human-facing steps that explain how to verify the change while running this branch in dev mode. Include expected results and, when applicable, helpful console snippets for interactive verification. Do not include automated checks, commands, results, pass counts, or CI status. -->
1. Search for a query so it appears in search history.
2. Focus the search input, hover that history suggestion, and click its X button.
3. Immediately enter a different query and press Enter.
4. Confirm the new query opens normally and the app remains responsive without Vue errors in the developer console.

## Additional context
<!-- Add any other context about the pull request here. -->
