### PR TITLE
fix(downloads): make automatic notification actions work

### DIFF
--- a/e2e/tests/offline/download-settings.spec.mjs
+++ b/e2e/tests/offline/download-settings.spec.mjs
@@ -232,6 +232,14 @@ test.describe('automatic download authorization', () => {
     const executable = path.join(app.userDataDir, 'fake-automatic-yt-dlp.sh')
     const argumentsFile = path.join(app.userDataDir, 'automatic-yt-dlp-arguments.txt')
     const metadataLookupsFile = path.join(app.userDataDir, 'automatic-yt-dlp-metadata-lookups.txt')
+    const releaseDownloadFile = path.join(app.userDataDir, 'release-automatic-download')
+    await app.electronApp.evaluate(({ Notification }) => {
+      Notification.isSupported = () => true
+      globalThis.automaticDownloadNotifications = []
+      Notification.prototype.show = function () {
+        globalThis.automaticDownloadNotifications.push(this)
+      }
+    })
     await writeFile(executable, [
       '#!/bin/sh',
       'for argument in "$@"; do',
@@ -246,6 +254,7 @@ test.describe('automatic download authorization', () => {
       '  fi',
       'done',
       `printf '%s\\n' "$@" > ${argumentsFile}`,
+      `while [ ! -f "${releaseDownloadFile}" ]; do sleep 0.05; done`,
       "printf '__OPENTUBEX_FILE__:ccccccccccc\\t120\\t1920\\t1080\\t/tmp/automatic.webm\\n'"
     ].join('\n'))
     await chmod(executable, 0o755)
@@ -273,7 +282,13 @@ test.describe('automatic download authorization', () => {
       customArgs: '--write-description',
       videoIds: ['eeeeeeeeeee'],
       isPlaylist: true,
-      playlistId: 'PL1234567890'
+      playlistId: 'PL1234567890',
+      notification: {
+        startedTitle: 'Automatic download started',
+        startedBody: 'Automatic video is downloading',
+        completedTitle: 'Automatic download finished',
+        completedBody: 'Automatic video was downloaded'
+      }
     }
     expect(await page.evaluate((download) => window.ftElectron.ytDlpDownload(download), payload)).toBeNull()
 
@@ -312,9 +327,46 @@ test.describe('automatic download authorization', () => {
     const result = concurrentResults.find(download => 'id' in download)
     expect(concurrentResults).toContainEqual({ skipped: 'already-downloaded' })
     expect(result).toEqual({ id: expect.any(Number) })
+
+    await expect.poll(() => app.electronApp.evaluate(() => (
+      globalThis.automaticDownloadNotifications.map(notification => notification.title)
+    ))).toContain('Automatic download started')
+    await app.electronApp.evaluate(() => {
+      globalThis.automaticDownloadNotifications
+        .find(notification => notification.title === 'Automatic download started')
+        .emit('click')
+    })
+    await expect.poll(() => page.evaluate(() => {
+      const store = document.querySelector('#app').__vue_app__.config.globalProperties.$store
+      return store.getters.getSettingsWindowView
+    })).toBe('downloads')
+
+    const tabCount = await page.evaluate(() => {
+      const store = document.querySelector('#app').__vue_app__.config.globalProperties.$store
+      return store.getters.getTabCount
+    })
+    await writeFile(releaseDownloadFile, '')
     await expect.poll(() => page.evaluate(async (id) => {
       return (await window.ftElectron.ytDlpListDownloads()).find(download => download.id === id)?.status
     }, result.id)).toBe('completed')
+    await expect.poll(() => app.electronApp.evaluate(() => (
+      globalThis.automaticDownloadNotifications.map(notification => notification.title)
+    ))).toContain('Automatic download finished')
+    await app.electronApp.evaluate(() => {
+      globalThis.automaticDownloadNotifications
+        .find(notification => notification.title === 'Automatic download finished')
+        .emit('click')
+    })
+    await expect.poll(() => page.evaluate(() => {
+      const store = document.querySelector('#app').__vue_app__.config.globalProperties.$store
+      return {
+        tabCount: store.getters.getTabCount,
+        route: store.getters.getActiveTab?.route.fullPath
+      }
+    })).toEqual({
+      tabCount: tabCount + 1,
+      route: '/watch?v=ccccccccccc'
+    })
 
     const args = (await readFile(argumentsFile, 'utf8')).trim().split('\n')
     expect(args).toEqual(expect.arrayContaining([

--- a/src/main/ytDlp.js
+++ b/src/main/ytDlp.js
@@ -7,6 +7,7 @@ import { inflateRawSync } from 'node:zlib'
 import { app, BrowserWindow, net, Notification, shell } from 'electron'
 import { settings } from '../datastores/handlers/base'
 import { buildProxyUrl, isOpenTubeXUrl } from './utils'
+import { TabManager } from './tabs/TabManager'
 import { IpcChannels } from '../constants'
 import { getMatchingDownloadValidators, getYtDlpAssetName } from './ytDlpAsset'
 import { shouldUseGioTrash } from './trashPlatform'
@@ -203,11 +204,26 @@ function showAutomaticDownloadNotification(payload, phase) {
   notification.once('close', () => activeAutomaticDownloadNotifications.delete(notification))
   notification.once('click', () => {
     activeAutomaticDownloadNotifications.delete(notification)
-    const browserWindow = BrowserWindow.getAllWindows().find(window => !window.isDestroyed())
+    const browserWindow = BrowserWindow.getAllWindows().find(window => (
+      !window.isDestroyed() && TabManager.getForWindow(window.id)
+    )) ?? BrowserWindow.getAllWindows().find(window => !window.isDestroyed())
     if (browserWindow) {
       if (browserWindow.isMinimized()) browserWindow.restore()
       browserWindow.show()
       browserWindow.focus()
+
+      const tabManager = TabManager.getForWindow(browserWindow.id)
+      if (phase === 'started') {
+        browserWindow.webContents.send(IpcChannels.CHANGE_VIEW, '/downloads')
+      } else if (phase === 'completed' && tabManager && ID_REGEX.test(payload.videoId)) {
+        tabManager.createTabWithPreference({
+          route: '/watch',
+          query: { v: payload.videoId },
+          makeActive: true
+        }).catch(error => {
+          console.error('Failed to open automatically downloaded video', error)
+        })
+      }
     }
   })
   notification.show()


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Make sure to follow the contributing guidelines. -->
<!-- Important note, we may remove your pull request if you do not use this provided PR template correctly. -->
<!-- Agent instructions: Preserve every heading, comment, and marker in this template. Never remove or rewrite the release-note-category:start/end, release-note:start/end, or release-note-image:start/end marker pairs. Never remove or rewrite the Release note images section; leave its contents for a human. -->

## Pull Request Type
<!-- Please select what type of pull request this is: [x] -->
- [x] Bugfix
- [ ] Feature Implementation
- [ ] Documentation
- [ ] Other

## Related issue
<!-- Please link the issue your pull request is referring to. -->
<!-- If this pull request fully resolves the relevant issue, put "closes" before the issue number. -->
<!-- Example: "closes #123456". -->

No linked issue.

## Description
<!-- Please write a clear and concise description of what the pull request does. -->

Clicking an automatic-download notification only restored and focused the app because every notification phase shared the same focus-only handler. The started notification now opens the Downloads dialog, while the completed notification creates and activates a new watch tab for the downloaded video. Failed notifications keep their existing focus behavior.

The existing automatic-download E2E coverage now captures native notifications and verifies both click actions against an in-progress and completed download.

## Release note category
<!-- Select exactly one category. Every pull request must select one. -->
<!-- Select "Not noteworthy" when the pull request fixes a bug in or improves functionality that has not yet appeared in a stable release. -->
<!-- release-note-category:start -->
- [x] Not noteworthy
- [ ] Highlights
- [ ] More improvements
- [ ] Fixed bugs
<!-- release-note-category:end -->

## Release note
<!-- Required unless "Not noteworthy" is selected. -->
<!-- Write one concise, user-facing entry without a leading bullet. -->
<!-- release-note:start -->
Automatic-download notifications now open Downloads while running and the video in a new tab when finished.
<!-- release-note:end -->

## Release note images
<!-- Human-only: Agents must preserve this entire section and leave it empty. -->
<!-- Optional. Paste one or more Markdown images or HTML image tags here. -->
<!-- The release notes will use an HTML image tag and limit images taller than 300 pixels. -->
<!-- release-note-image:start -->

<!-- release-note-image:end -->

## Testing
<!-- How can reviewers verify that the PR produces correct results? -->
<!-- Please provide instructions so that others can ensure that your pull request produces correct results. For examples see, https://github.com/FreeTubeApp/FreeTube/pull/5743, https://github.com/FreeTubeApp/FreeTube/pull/7349, https://github.com/FreeTubeApp/FreeTube/pull/5125, https://github.com/FreeTubeApp/FreeTube/pull/7338 -->
<!-- Agent instructions: Only write human-facing steps that explain how to verify the change while running this branch in dev mode. Include expected results and, when applicable, helpful console snippets for interactive verification. Do not include automated checks, commands, results, pass counts, or CI status. -->

1. Configure an automatic download for a subscribed channel and refresh subscriptions so a matching video starts downloading.
2. Select View on the started notification and verify that the Downloads dialog opens with the active download.
3. After the download completes, select View on the finished notification and verify that the video opens in a new active tab.

## Additional context
<!-- Add any other context about the pull request here. -->

Scheduled livestream reminder notifications already open their video in a new tab and are unchanged.