### PR TITLE
fix(profiles): ignore stale cross-window updates

### DIFF
--- a/e2e/tests/offline/profiles.spec.mjs
+++ b/e2e/tests/offline/profiles.spec.mjs
@@ -33,6 +33,39 @@ async function openProfileList(page) {
 test.describe('profile selector', () => {
   test.use({ seed: { profiles: [mainProfile, secondProfile] } })
 
+  test('ignores stale profile deletion events from another window', async ({ page }) => {
+    await openProfileList(page)
+    await expect(page.locator('.profileList .profileOption')).toHaveCount(2)
+
+    await page.evaluate(() => {
+      const store = document.querySelector('#app').__vue_app__.config.globalProperties.$store
+      store.commit('removeProfileFromList', 'missing-profile')
+    })
+
+    await expect(page.locator('.profileList .profileOption')).toHaveCount(2)
+    await expect(page.locator('.profileList .profileOption').filter({ hasText: 'Second profile' })).toBeVisible()
+  })
+
+  test('ignores channel updates for profiles removed in another window', async ({ page }) => {
+    const profileIds = await page.evaluate(() => {
+      const store = document.querySelector('#app').__vue_app__.config.globalProperties.$store
+      const payload = {
+        channel: { id: 'channel', name: 'Channel', thumbnail: '' },
+        profileIds: ['missing-profile']
+      }
+
+      store.commit('addChannelToProfiles', payload)
+      store.commit('removeChannelFromProfiles', {
+        channelId: payload.channel.id,
+        profileIds: payload.profileIds
+      })
+
+      return store.getters.getProfileList.map(profile => profile._id)
+    })
+
+    expect(profileIds).toEqual(['allChannels', 'e2eprofile'])
+  })
+
   test('opens directly from the profile button context menu', async ({ page }) => {
     await profileIcon(page).click()
     await expect(page.locator('.profileSummaryText')).toContainText('You can also right-click the profile icon to switch profiles')

--- a/src/renderer/store/modules/profiles.js
+++ b/src/renderer/store/modules/profiles.js
@@ -310,6 +310,7 @@ const mutations = {
   addChannelToProfiles(state, { channel, profileIds }) {
     for (const id of profileIds) {
       const profile = state.profileList.find(profile => profile._id === id)
+      if (!profile) { continue }
 
       if (!profile.subscriptions.some(subscription => subscription.id === channel.id)) {
         profile.subscriptions.push(channel)
@@ -320,6 +321,7 @@ const mutations = {
   removeChannelFromProfiles(state, { channelId, profileIds }) {
     for (const id of profileIds) {
       const profile = state.profileList.find(profile => profile._id === id)
+      if (!profile) { continue }
 
       // use filter instead of splice in case the subscription appears multiple times
       // https://github.com/FreeTubeApp/FreeTube/pull/3468#discussion_r1179290877
@@ -332,7 +334,9 @@ const mutations = {
       return profile._id === profileId
     })
 
-    state.profileList.splice(i, 1)
+    if (i !== -1) {
+      state.profileList.splice(i, 1)
+    }
   }
 }
 


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Make sure to follow the contributing guidelines. -->
<!-- Important note, we may remove your pull request if you do not use this provided PR template correctly. -->
<!-- Agent instructions: Preserve every heading, comment, and marker in this template. Never remove or rewrite the release-note-category:start/end, release-note:start/end, or release-note-image:start/end marker pairs. Never remove or rewrite the Release note images section; leave its contents for a human. -->

## Pull Request Type
<!-- Please select what type of pull request this is: [x] -->
- [x] Bugfix
- [ ] Feature Implementation
- [ ] Documentation
- [ ] Other

## Related issue
<!-- Please link the issue your pull request is referring to. -->
<!-- If this pull request fully resolves the relevant issue, put "closes" before the issue number. -->
<!-- Example: "closes #123456". -->

## Description
<!-- Please write a clear and concise description of what the pull request does. -->
When a renderer received a stale cross-window profile update, a deletion for an unknown profile could remove the last valid profile and channel updates could throw after dereferencing a profile that no longer existed.

This guards all three profile mutations against missing IDs and adds regressions for stale deletion and channel-update events. Valid profiles and subscriptions remain unchanged when an outdated event arrives.

## Release note category
<!-- Select exactly one category. Every pull request must select one. -->
<!-- Select "Not noteworthy" when the pull request fixes a bug in or improves functionality that has not yet appeared in a stable release. -->
<!-- release-note-category:start -->
- [ ] Not noteworthy
- [ ] Highlights
- [ ] More improvements
- [x] Fixed bugs
<!-- release-note-category:end -->

## Release note
<!-- Required unless "Not noteworthy" is selected. -->
<!-- Write one concise, user-facing entry without a leading bullet. -->
<!-- release-note:start -->
Stale profile updates from another window no longer remove unrelated profiles or cause errors.
<!-- release-note:end -->

## Release note images
<!-- Human-only: Agents must preserve this entire section and leave it empty. -->
<!-- Optional. Paste one or more Markdown images or HTML image tags here. -->
<!-- The release notes will use an HTML image tag and limit images taller than 300 pixels. -->
<!-- release-note-image:start -->

<!-- release-note-image:end -->

## Testing
<!-- How can reviewers verify that the PR produces correct results? -->
<!-- Please provide instructions so that others can ensure that your pull request produces correct results. For examples see, https://github.com/FreeTubeApp/FreeTube/pull/5743, https://github.com/FreeTubeApp/FreeTube/pull/7349, https://github.com/FreeTubeApp/FreeTube/pull/5125, https://github.com/FreeTubeApp/FreeTube/pull/7338 -->
<!-- Agent instructions: Only write human-facing steps that explain how to verify the change while running this branch in dev mode. Include expected results and, when applicable, helpful console snippets for interactive verification. Do not include automated checks, commands, results, pass counts, or CI status. -->
1. Start the app with at least two profiles and open the profile selector.
2. In the renderer DevTools console, get the store with `const store = document.querySelector('#app').__vue_app__.config.globalProperties.$store`.
3. Run `store.commit('removeProfileFromList', 'missing-profile')`. The existing profiles should remain visible.
4. Run `store.commit('addChannelToProfiles', { channel: { id: 'channel', name: 'Channel', thumbnail: '' }, profileIds: ['missing-profile'] })`, then run `store.commit('removeChannelFromProfiles', { channelId: 'channel', profileIds: ['missing-profile'] })`. Neither command should throw, and existing profiles should remain unchanged.

## Additional context
<!-- Add any other context about the pull request here. -->
The profile sync listener commits these mutations when another window changes profile data, so the guards also make duplicate and out-of-order events harmless.
