### PR TITLE
fix(player): prevent playback sessions from stalling

### DIFF
--- a/src/main/poTokenGenerator.js
+++ b/src/main/poTokenGenerator.js
@@ -2,6 +2,8 @@ import { session, WebContentsView } from 'electron'
 import { readFile } from 'fs/promises'
 import { join } from 'path'
 
+import { withTimeout } from './promiseTimeout'
+
 // #region queue
 
 /**
@@ -145,6 +147,9 @@ async function sharedInit() {
   cachedScript = scriptContent.replace(scriptExportMatch[0], `;${scriptExportMatch[1]}(FT_PARAMS)`)
 }
 
+// bgutils-js 4 can leave its callback-backed snapshot pending forever.
+const GENERATE_TIMEOUT_MS = 30 * 1000
+
 /**
  * @param {string} videoId
  * @param {string} context
@@ -209,7 +214,11 @@ async function internalGeneratePotoken(videoId, context, initialAttestationData,
 
     const script = cachedScript.replace('FT_PARAMS', `"${videoId}",${context},${initialAttestationData},${ytConfig}`)
 
-    return await webContentsView.webContents.executeJavaScript(script)
+    return await withTimeout(
+      webContentsView.webContents.executeJavaScript(script),
+      GENERATE_TIMEOUT_MS,
+      `PO token generation timed out after ${GENERATE_TIMEOUT_MS}ms`
+    )
   } finally {
     if (webContentsView) {
       webContentsView.webContents.close({ waitForBeforeUnload: false })

--- a/src/main/promiseTimeout.js
+++ b/src/main/promiseTimeout.js
@@ -1,0 +1,17 @@
+/**
+ * @template T
+ * @param {Promise<T>} promise
+ * @param {number} timeoutMs
+ * @param {string} message
+ * @returns {Promise<T>}
+ */
+export function withTimeout(promise, timeoutMs, message) {
+  let timeoutId
+
+  return Promise.race([
+    promise,
+    new Promise((_resolve, reject) => {
+      timeoutId = setTimeout(() => reject(new Error(message)), timeoutMs)
+    })
+  ]).finally(() => clearTimeout(timeoutId))
+}

--- a/src/renderer/components/ft-shaka-video-player/ft-shaka-video-player.js
+++ b/src/renderer/components/ft-shaka-video-player/ft-shaka-video-player.js
@@ -9004,13 +9004,13 @@ export default defineComponent({
         startPreRollTimer(initialLoadDelayMs)
         await new Promise((resolve) => setTimeout(resolve, initialLoadDelayMs))
         clearPreRollTimer()
-        if (!isCurrentLoad()) return
+        if (!ui || !player || !isCurrentLoad()) return
       }
 
       if (props.format === 'dash' || props.format === 'audio') {
         try {
           await player.load(props.manifestSrc, props.startTime, props.manifestMimeType)
-          if (!isCurrentLoad()) return
+          if (!ui || !player || !isCurrentLoad()) return
 
           if (props.format === 'dash') {
             // Let shaka-player's ABR pick the variant when auto quality is preferred
@@ -9037,7 +9037,7 @@ export default defineComponent({
             }
           }
         } catch (error) {
-          if (isCurrentLoad()) {
+          if (ui && player && isCurrentLoad()) {
             handleError(error, 'loading dash/audio manifest and setting default quality in mounted')
           }
         }

--- a/src/renderer/helpers/player/SabrSchemePlugin.js
+++ b/src/renderer/helpers/player/SabrSchemePlugin.js
@@ -11,12 +11,16 @@ import {
   SabrContextUpdate,
   SabrContextWritePolicy,
   NextRequestPolicy,
-  PlaybackCookie,
   ReloadPlaybackContext,
 } from 'googlevideo/protos'
 import shaka from 'shaka-player'
 
 import { deepCopy } from '../utils'
+import {
+  createAbandonedSabrResponse,
+  extractRawProtobufField,
+  parseSabrFormatId
+} from './sabrProtocol'
 
 const AbortableOperation = shaka.util.AbortableOperation
 const ShakaError = shaka.util.Error
@@ -63,6 +67,7 @@ const ShakaError = shaka.util.Error
  * @property {Set<number>} activeSabrContextTypes
  * @property {Map<number, SabrContextUpdate>} sabrContexts
  * @property {?NextRequestPolicy} nextRequestPolicy
+ * @property {Uint8Array | undefined} playbackCookieBytes
  * @property {boolean} playerReloadRequested
  * @property {number} requestNumber
  */
@@ -80,18 +85,8 @@ const ShakaError = shaka.util.Error
  * @property {() => void | undefined} cleanup
  */
 
-/**
- * @param {string} str
- */
-function formatIdFromString(str) {
-  const videoFormatIdParts = str.split('-')
-
-  return {
-    itag: parseInt(videoFormatIdParts[0]),
-    lastModified: videoFormatIdParts[1],
-    xtags: videoFormatIdParts[2]
-  }
-}
+/** NextRequestPolicy.playbackCookie, field 7. */
+const PLAYBACK_COOKIE_FIELD_NUMBER = 7
 
 /**
  * @param {import('googlevideo/protos').FormatId} formatId
@@ -161,7 +156,7 @@ function fillBufferedRanges(player, manifest, audioFormatsActive, streamIsVideo,
       })
     }
 
-    const audioFormatId = formatIdFromString(activeVariant.originalAudioId)
+    const audioFormatId = parseSabrFormatId(activeVariant.originalAudioId)
     const audioSegmentIndex = activeManifestVariant.audio.segmentIndex
 
     if (streamIsVideo) {
@@ -177,12 +172,12 @@ function fillBufferedRanges(player, manifest, audioFormatsActive, streamIsVideo,
     let videoSegmentIndex
 
     if (streamIsAudio && bufferedInfo.video.length > 0) {
-      videoFormatId = formatIdFromString(activeVariant.originalVideoId)
+      videoFormatId = parseSabrFormatId(activeVariant.originalVideoId)
       bufferedRanges.push(createFullBufferRange(videoFormatId))
     } else {
       for (const buffered of bufferedInfo.video) {
         if (!videoFormatId) {
-          videoFormatId = formatIdFromString(activeVariant.originalVideoId)
+          videoFormatId = parseSabrFormatId(activeVariant.originalVideoId)
         }
 
         if (!videoSegmentIndex) {
@@ -347,7 +342,7 @@ async function doRequest(
 
     operationInputs.headersReceived({})
 
-    const { itag, lastModified, xtags } = formatIdFromString(operationInputs.formatIdString)
+    const { itag, lastModified, xtags } = parseSabrFormatId(operationInputs.formatIdString)
     let mediaHeaderId
 
     const reader = response.body.getReader()
@@ -425,7 +420,16 @@ async function doRequest(
             shouldRetryDueToNextRequestPolicy = true
 
             currentState.sabrStreamState.nextRequestPolicy = nextRequestPolicy
-            currentState.abrRequest.streamerContext.playbackCookie = nextRequestPolicy?.playbackCookie ? PlaybackCookie.encode(nextRequestPolicy.playbackCookie).finish() : undefined
+
+            const rawPolicy = part.data.chunks.length === 1
+              ? part.data.chunks[0]
+              : concatenateChunks(part.data.chunks)
+            currentState.sabrStreamState.playbackCookieBytes = extractRawProtobufField(
+              rawPolicy,
+              PLAYBACK_COOKIE_FIELD_NUMBER
+            )
+            currentState.abrRequest.streamerContext.playbackCookie =
+              currentState.sabrStreamState.playbackCookieBytes
 
             currentState.abrRequest.streamerContext.backoffTimeMs = nextRequestPolicy?.backoffTimeMs
             break
@@ -649,6 +653,7 @@ export function setupSabrScheme(sabrData, getPlayer, getManifest, playerWidth, p
     activeSabrContextTypes: new Set(),
     sabrContexts: new Map(),
     nextRequestPolicy: undefined,
+    playbackCookieBytes: undefined,
     playerReloadRequested: false,
     requestNumber: 0,
   }
@@ -659,9 +664,17 @@ export function setupSabrScheme(sabrData, getPlayer, getManifest, playerWidth, p
     const player = getPlayer()
     if (player == null) {
       // This is true during reload, returning a promise to suppress error
-      return new AbortableOperation(Promise.resolve())
+      return new AbortableOperation(Promise.resolve(createAbandonedSabrResponse(uri, request)))
     }
-    const isAudioOnly = player.isAudioOnly()
+
+    let isAudioOnly
+    try {
+      isAudioOnly = player.isAudioOnly()
+    } catch {
+      // Shaka keeps the cast proxy reachable after destroying its sender. A
+      // request queued before teardown can therefore throw on property access.
+      return new AbortableOperation(Promise.resolve(createAbandonedSabrResponse(uri, request)))
+    }
 
     const url = new URL(request.uris[0])
 
@@ -682,21 +695,21 @@ export function setupSabrScheme(sabrData, getPlayer, getManifest, playerWidth, p
     let videoFormatId
 
     if (streamIsAudio) {
-      audioFormatId = formatIdFromString(formatIdString)
+      audioFormatId = parseSabrFormatId(formatIdString)
 
       if (isAudioOnly) {
         // We need to specify a video format even for audio only otherwise we get an error response
-        videoFormatId = formatIdFromString(url.searchParams.get('videoFormatId'))
+        videoFormatId = parseSabrFormatId(url.searchParams.get('videoFormatId'))
       } else {
-        videoFormatId = formatIdFromString((activeVariant ?? variantTracks[0]).originalVideoId)
+        videoFormatId = parseSabrFormatId((activeVariant ?? variantTracks[0]).originalVideoId)
       }
     } else if (streamIsVideo) {
-      videoFormatId = formatIdFromString(formatIdString)
+      videoFormatId = parseSabrFormatId(formatIdString)
 
       // for the first fetching of the initial data there won't be an active variant
       // (shaka-player only sets it to active after it has fetched the init/segment data)
       if (activeVariant) {
-        audioFormatId = formatIdFromString(activeVariant.originalAudioId)
+        audioFormatId = parseSabrFormatId(activeVariant.originalAudioId)
       } else {
         const candidates = variantTracks.filter((track) => track.audioRoles.includes('main'))
 
@@ -704,7 +717,7 @@ export function setupSabrScheme(sabrData, getPlayer, getManifest, playerWidth, p
           return current.audioBandwidth >= previous.audioBandwidth ? current : previous
         }, candidates[0])
 
-        audioFormatId = formatIdFromString(probableAudioFormat.originalAudioId)
+        audioFormatId = parseSabrFormatId(probableAudioFormat.originalAudioId)
       }
     }
 
@@ -754,7 +767,7 @@ export function setupSabrScheme(sabrData, getPlayer, getManifest, playerWidth, p
         clientInfo,
         sabrContexts,
         unsentSabrContexts,
-        playbackCookie: sabrStreamState.nextRequestPolicy?.playbackCookie ? PlaybackCookie.encode(sabrStreamState.nextRequestPolicy.playbackCookie).finish() : undefined,
+        playbackCookie: sabrStreamState.playbackCookieBytes,
       },
       field1000: [],
       videoPlaybackUstreamerConfig,

--- a/src/renderer/helpers/player/sabrProtocol.js
+++ b/src/renderer/helpers/player/sabrProtocol.js
@@ -1,0 +1,85 @@
+/**
+ * Extract a length-delimited protobuf field without decoding it.
+ *
+ * @param {Uint8Array} bytes
+ * @param {number} fieldNumber
+ * @returns {Uint8Array | undefined}
+ */
+export function extractRawProtobufField(bytes, fieldNumber) {
+  let offset = 0
+
+  function readVarint() {
+    let result = 0
+    let shift = 0
+
+    while (offset < bytes.length) {
+      const byte = bytes[offset++]
+      result += (byte & 0x7f) * 2 ** shift
+      if ((byte & 0x80) === 0) {
+        return result
+      }
+      shift += 7
+    }
+
+    return undefined
+  }
+
+  while (offset < bytes.length) {
+    const key = readVarint()
+    if (key === undefined) return undefined
+
+    const wireType = key % 8
+    const field = Math.floor(key / 8)
+
+    if (wireType === 2) {
+      const length = readVarint()
+      if (length === undefined || offset + length > bytes.length) return undefined
+      if (field === fieldNumber) {
+        return bytes.subarray(offset, offset + length)
+      }
+      offset += length
+    } else if (wireType === 0) {
+      if (readVarint() === undefined) return undefined
+    } else if (wireType === 5) {
+      offset += 4
+    } else if (wireType === 1) {
+      offset += 8
+    } else {
+      return undefined
+    }
+  }
+
+  return undefined
+}
+
+/**
+ * @param {string} formatId
+ */
+export function parseSabrFormatId(formatId) {
+  // xtags can contain hyphens, so only the first two separators are structural.
+  const firstSeparator = formatId.indexOf('-')
+  const secondSeparator = formatId.indexOf('-', firstSeparator + 1)
+
+  return {
+    itag: parseInt(formatId.slice(0, firstSeparator)),
+    lastModified: formatId.slice(firstSeparator + 1, secondSeparator),
+    xtags: formatId.slice(secondSeparator + 1)
+  }
+}
+
+/**
+ * @param {string} uri
+ * @param {object} request
+ */
+export function createAbandonedSabrResponse(uri, request) {
+  return {
+    uri,
+    originalUri: uri,
+    data: new ArrayBuffer(0),
+    headers: {},
+    status: 200,
+    fromCache: false,
+    originalRequest: request,
+    timeMs: 0,
+  }
+}

--- a/src/renderer/helpers/player/utils.js
+++ b/src/renderer/helpers/player/utils.js
@@ -9,13 +9,33 @@ export const MANIFEST_TYPE_DASH = 'application/dash+xml'
 export const MANIFEST_TYPE_HLS = 'application/x-mpegurl'
 
 /**
- * @param {shaka.util.Error} error
+ * @param {shaka.util.Error | Error} error
  * @param {string} context
  * @param {string} videoId
  * @param {object?} details
  */
 export function logShakaError(error, context, videoId, details) {
   const { Severity, Category, Code } = shaka.util.Error
+
+  if (error?.category === undefined && error?.code === undefined) {
+    /** @type {*[]} */
+    const args = [
+      'Player exception. This is a JavaScript error, not a shaka-player error.\n' +
+      `Video ID: "${videoId}"\n` +
+      `OpenTubeX player context: "${context}"\n`,
+      error
+    ]
+
+    if (details) {
+      args.push(
+        '\n\nOpenTubeX data:',
+        typeof details === 'object' ? deepCopy(details) : details
+      )
+    }
+
+    console.error(...args)
+    return
+  }
 
   // shaka's error type also has a message property but that is apparently only available in uncompiled mode
 
@@ -29,9 +49,9 @@ export function logShakaError(error, context, videoId, details) {
   const codeText = Object.keys(Code).find((/** @type {keyof Code} */ key) => Code[key] === error.code)
 
   const message =
-    'Player Error (category and code explainations here: https://shaka-player-demo.appspot.com/docs/api/shaka.util.Error.html)\n' +
+    'Player Error (category and code explanations here: https://shaka-player-demo.appspot.com/docs/api/shaka.util.Error.html)\n' +
     `Video ID: "${videoId}"\n` +
-    `FreeTube player context: "${context}"\n\n` +
+    `OpenTubeX player context: "${context}"\n\n` +
     `Severity: ${severityText} (${error.severity})\n` +
     `Category: ${categoryText} (${error.category})\n` +
     `Code: ${codeText} (${error.code})\n` +
@@ -49,7 +69,7 @@ export function logShakaError(error, context, videoId, details) {
 
   if (details) {
     args.push(
-      '\n\nFreeTube data:',
+      '\n\nOpenTubeX data:',
       // use deepCopy to get rid of Vue's proxying,
       // as that requires you click the 3 dots for every property in the logged object to see their values
       // doing it like this, results in a "clean" object where everything is immediately visible

--- a/src/renderer/views/Watch/Watch.js
+++ b/src/renderer/views/Watch/Watch.js
@@ -4811,7 +4811,6 @@ export default defineComponent({
      */
     createLocalSabrManifest: function (videoInfo, poToken, clientInfo, storyboards) {
       const url = new URL(videoInfo.streaming_data.server_abr_streaming_url)
-      url.searchParams.set('alr', 'yes')
       url.searchParams.set('cpn', videoInfo.cpn)
       // Shaka's scheme registry is renderer-global. Each retained tab therefore
       // needs its own scheme so one SABR player cannot replace or unregister

--- a/tests/unit/promise-timeout.test.mjs
+++ b/tests/unit/promise-timeout.test.mjs
@@ -1,0 +1,17 @@
+import assert from 'node:assert/strict'
+import test from 'node:test'
+
+import { withTimeout } from '../../src/main/promiseTimeout.js'
+
+test('returns a result that settles before the timeout', async () => {
+  await assert.doesNotReject(async () => {
+    assert.equal(await withTimeout(Promise.resolve('token'), 100, 'timed out'), 'token')
+  })
+})
+
+test('rejects work that does not settle before the timeout', async () => {
+  await assert.rejects(
+    withTimeout(new Promise(() => {}), 10, 'PO token generation timed out'),
+    /PO token generation timed out/
+  )
+})

--- a/tests/unit/sabr-protocol.test.mjs
+++ b/tests/unit/sabr-protocol.test.mjs
@@ -1,0 +1,45 @@
+import assert from 'node:assert/strict'
+import test from 'node:test'
+
+import {
+  createAbandonedSabrResponse,
+  extractRawProtobufField,
+  parseSabrFormatId
+} from '../../src/renderer/helpers/player/sabrProtocol.js'
+
+test('preserves hyphens inside SABR format xtags', () => {
+  assert.deepEqual(
+    parseSabrFormatId('251-1720000000000-acont=dubbed-auto:lang=ar'),
+    {
+      itag: 251,
+      lastModified: '1720000000000',
+      xtags: 'acont=dubbed-auto:lang=ar'
+    }
+  )
+})
+
+test('extracts the playback cookie without dropping explicit defaults', () => {
+  const cookie = Uint8Array.from([0x08, 0x01, 0x10, 0x00])
+  const nextRequestPolicy = Uint8Array.from([
+    0x08, 0x01,
+    0x3a, cookie.length, ...cookie,
+    0x40, 0x02
+  ])
+
+  assert.deepEqual(
+    extractRawProtobufField(nextRequestPolicy, 7),
+    cookie
+  )
+})
+
+test('returns the response shape Shaka expects for an abandoned request', () => {
+  const request = { uris: ['sabr1:video'] }
+  const response = createAbandonedSabrResponse('sabr1:video', request)
+
+  assert.equal(response.uri, 'sabr1:video')
+  assert.equal(response.originalUri, 'sabr1:video')
+  assert.equal(response.originalRequest, request)
+  assert.equal(response.data.byteLength, 0)
+  assert.equal(response.status, 200)
+  assert.equal(response.timeMs, 0)
+})


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Make sure to follow the contributing guidelines. -->
<!-- Important note, we may remove your pull request if you do not use this provided PR template correctly. -->
<!-- Agent instructions: Preserve every heading, comment, and marker in this template. Never remove or rewrite the release-note-category:start/end, release-note:start/end, or release-note-image:start/end marker pairs. Never remove or rewrite the Release note images section; leave its contents for a human. -->

## Pull Request Type
<!-- Please select what type of pull request this is: [x] -->
- [x] Bugfix
- [ ] Feature Implementation
- [ ] Documentation
- [ ] Other

## Related issue
<!-- Please link the issue your pull request is referring to. -->
<!-- If this pull request fully resolves the relevant issue, put "closes" before the issue number. -->
<!-- Example: "closes #123456". -->

## Description
<!-- Please write a clear and concise description of what the pull request does. -->

Long-running SABR playback could lose its server session because the opaque playback cookie was decoded and re-encoded. Alternate-audio format tags containing hyphens could also be truncated, while an abandoned request during player teardown resolved without the response shape Shaka expects. Separately, a stalled BotGuard callback could block every later PO token request.

This preserves SABR cookies byte-for-byte, parses complete format tags, returns a valid empty response during teardown, and stops requesting a redirect format the SABR handler cannot consume. PO token execution now has a 30-second upper bound, first-load work stops after player teardown, and ordinary JavaScript exceptions retain their message and stack in player logs.

Focused unit coverage protects the protocol parsing, opaque cookie bytes, abandoned response, and timeout behavior.

## Release note category
<!-- Select exactly one category. Every pull request must select one. -->
<!-- Select "Not noteworthy" when the pull request fixes a bug in or improves functionality that has not yet appeared in a stable release. -->
<!-- release-note-category:start -->
- [ ] Not noteworthy
- [ ] Highlights
- [ ] More improvements
- [x] Fixed bugs
<!-- release-note-category:end -->

## Release note
<!-- Required unless "Not noteworthy" is selected. -->
<!-- Write one concise, user-facing entry without a leading bullet. -->
<!-- release-note:start -->
Prevent long-running and alternate-audio playback sessions from stalling or losing their stream state.
<!-- release-note:end -->

## Release note images
<!-- Human-only: Agents must preserve this entire section and leave it empty. -->
<!-- Optional. Paste one or more Markdown images or HTML image tags here. -->
<!-- The release notes will use an HTML image tag and limit images taller than 300 pixels. -->
<!-- release-note-image:start -->

<!-- release-note-image:end -->

## Testing
<!-- How can reviewers verify that the PR produces correct results? -->
<!-- Please provide instructions so that others can ensure that your pull request would produce correct results. For examples see, https://github.com/FreeTubeApp/FreeTube/pull/5743, https://github.com/FreeTubeApp/FreeTube/pull/7349, https://github.com/FreeTubeApp/FreeTube/pull/5125, https://github.com/FreeTubeApp/FreeTube/pull/7338 -->
<!-- Agent instructions: Only write human-facing steps that explain how to verify the change while running this branch in dev mode. Include expected results and, when applicable, helpful console snippets for interactive verification. Do not include automated checks, commands, results, pass counts, or CI status. -->

1. Start the app in development mode and play a long video with the built-in playback engine. Seek repeatedly and switch audio tracks when the video offers them. Playback should continue without entering a repeated SABR reload loop.
2. Open a video in a background tab, then close or navigate away from that tab while its player is loading. The visible tab should remain responsive and the console should not report an uncategorized Shaka error from the destroyed player.
3. Play another built-in video after the teardown scenario. PO token generation and playback should still start normally.

## Additional context
<!-- Add any other context about the pull request here. -->
