### PR TITLE
fix(subscriptions): balance empty feed spacing

### DIFF
--- a/e2e/tests/offline/subscriptions-new-feed.spec.mjs
+++ b/e2e/tests/offline/subscriptions-new-feed.spec.mjs
@@ -70,6 +70,18 @@ const populatedCache = [{
   communityPostsTimestamp: new Date(now - HOUR).toISOString()
 }]
 
+const cacheWithoutNewContent = [{
+  _id: CHANNEL_ID,
+  videos: [oldVideo],
+  videosTimestamp: new Date(now - HOUR).toISOString(),
+  shorts: [],
+  shortsTimestamp: new Date(now - HOUR).toISOString(),
+  liveStreams: [],
+  liveStreamsTimestamp: new Date(now - HOUR).toISOString(),
+  communityPosts: [],
+  communityPostsTimestamp: new Date(now - HOUR).toISOString()
+}]
+
 const watchedHistory = [{
   _id: watchedVideo.videoId,
   ...watchedVideo,
@@ -194,6 +206,45 @@ test.describe('new subscriptions feed', () => {
     await expect(page.getByRole('option', { name: 'Mark as seen' })).toHaveCount(0)
   })
 })
+
+for (const uiScale of [100, 125]) {
+  test.describe(`new subscriptions feed empty state at ${uiScale}% UI scale`, () => {
+    test.use({
+      seed: {
+        settings: {
+          ...commonSettings,
+          uiScale
+        },
+        profiles: [profile()],
+        subscriptionCache: cacheWithoutNewContent
+      }
+    })
+
+    test('uses matching space above and below the message', async ({ page, attachScreenshot }) => {
+      await goTo(page, 'subscriptions')
+      await page.locator('[data-subscription-feed-tab="all"]').click()
+
+      const message = page.getByText('There is no new content.', { exact: true })
+      await expect(message).toBeVisible()
+
+      const spacing = await message.evaluate(element => {
+        const card = element.closest('.card').getBoundingClientRect()
+        const header = element.closest('.card').querySelector('.subscriptionsHeader').getBoundingClientRect()
+        const message = element.getBoundingClientRect()
+
+        return {
+          top: message.top - header.bottom,
+          bottom: card.bottom - message.bottom
+        }
+      })
+
+      expect(spacing.top).toBeGreaterThanOrEqual(15)
+      expect(spacing.top).toBeLessThanOrEqual(17)
+      expect(Math.abs(spacing.top - spacing.bottom)).toBeLessThanOrEqual(1)
+      await attachScreenshot(`empty New feed at ${uiScale}% UI scale`)
+    })
+  })
+}
 
 test.describe('new subscriptions feed sorting', () => {
   const newestVideo = video('sort-newest-video', 'Newest video', now - HOUR, {

--- a/src/renderer/components/SubscriptionsTabUi/SubscriptionsTabUi.css
+++ b/src/renderer/components/SubscriptionsTabUi/SubscriptionsTabUi.css
@@ -1,3 +1,4 @@
 .message {
+  margin-block: 16px 0;
   color: var(--tertiary-text-color);
 }


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Make sure to follow the contributing guidelines. -->
<!-- Important note, we may remove your pull request if you do not use this provided PR template correctly. -->
<!-- Agent instructions: Preserve every heading, comment, and marker in this template. Never remove or rewrite the release-note-category:start/end, release-note:start/end, or release-note-image:start/end marker pairs. Never remove or rewrite the Release note images section; leave its contents for a human. -->

## Pull Request Type
<!-- Please select what type of pull request this is: [x] -->
- [x] Bugfix
- [ ] Feature Implementation
- [ ] Documentation
- [ ] Other

## Related issue
<!-- Please link the issue your pull request is referring to. -->
<!-- If this pull request fully resolves the relevant issue, put "closes" before the issue number. -->
<!-- Example: "closes #123456". -->

## Description
<!-- Please write a clear and concise description of what the pull request does. -->
When the New subscriptions feed had no unseen content, the message's default bottom margin stacked with the card padding and left twice as much space below the text as above it.

This gives the empty-state message explicit block margins so the card has matching 16 px gaps above and below it. The regression coverage checks the rendered spacing at both 100% and 125% UI scale.

## Release note category
<!-- Select exactly one category. Every pull request must select one. -->
<!-- Select "Not noteworthy" when the pull request fixes a bug in or improves functionality that has not yet appeared in a stable release. -->
<!-- release-note-category:start -->
- [ ] Not noteworthy
- [ ] Highlights
- [ ] More improvements
- [x] Fixed bugs
<!-- release-note-category:end -->

## Release note
<!-- Required unless "Not noteworthy" is selected. -->
<!-- Write one concise, user-facing entry without a leading bullet. -->
<!-- release-note:start -->
Fixed uneven vertical spacing around empty subscription feed messages.
<!-- release-note:end -->

## Release note images
<!-- Human-only: Agents must preserve this entire section and leave it empty. -->
<!-- Optional. Paste one or more Markdown images or HTML image tags here. -->
<!-- The release notes will use an HTML image tag and limit images taller than 300 pixels. -->
<!-- release-note-image:start -->

<!-- release-note-image:end -->

## Testing
<!-- How can reviewers verify that the PR produces correct results? -->
<!-- Please provide instructions so that others can ensure that your pull request would produce correct results. For examples see, https://github.com/FreeTubeApp/FreeTube/pull/5743, https://github.com/FreeTubeApp/FreeTube/pull/7349, https://github.com/FreeTubeApp/FreeTube/pull/5125, https://github.com/FreeTubeApp/FreeTube/pull/7338 -->
<!-- Agent instructions: Only write human-facing steps that explain how to verify the change while running this branch in dev mode. Include expected results and, when applicable, helpful console snippets for interactive verification. Do not include automated checks, commands, results, pass counts, or CI status. -->
1. Start the app in dev mode with a profile that has subscriptions but no unseen feed entries.
2. Open Subscriptions and select the New tab.
3. Confirm that "There is no new content." has equal vertical space above and below it.
4. Set UI Scale to 125% and confirm that the spacing remains equal.

## Additional context
<!-- Add any other context about the pull request here. -->
The card already supplies 16 px of bottom padding, so the empty-state paragraph no longer needs its default bottom margin.
