### PR TITLE
perf(subscriptions): switch feed tabs immediately

### DIFF
--- a/e2e/tests/offline/subscriptions-tab-indicator.spec.mjs
+++ b/e2e/tests/offline/subscriptions-tab-indicator.spec.mjs
@@ -31,7 +31,8 @@ test.use({
     settings: {
       fetchSubscriptionsAutomatically: false,
       hideSubscriptionsVideos: false,
-      hideSubscriptionsShorts: false
+      hideSubscriptionsShorts: false,
+      reducedMotion: 'off'
     },
     profiles: [
       {
@@ -207,6 +208,31 @@ test.describe('subscriptions feed tab indicator', () => {
     })
 
     expect(Math.abs(indicator - tab)).toBeLessThan(1)
+  })
+
+  test('keeps feed scroll positions across microtask-separated switches', async ({ page }) => {
+    await goTo(page, 'subscriptions')
+
+    await expect(page.getByText('video video 000')).toBeVisible()
+    await page.evaluate(() => window.scrollTo(0, document.documentElement.scrollHeight))
+    await expect.poll(() => page.evaluate(() => window.scrollY)).toBeGreaterThan(0)
+    const videosScrollTop = await page.evaluate(() => window.scrollY)
+
+    await page.evaluate(() => {
+      document.querySelector('[data-subscription-feed-tab="shorts"]').click()
+      queueMicrotask(() => {
+        document.querySelector('[data-subscription-feed-tab="videos"]').click()
+      })
+    })
+
+    await expect(page.locator('[data-subscription-feed-tab="videos"]'))
+      .toHaveAttribute('aria-selected', 'true')
+    await expect.poll(() => page.evaluate(() => window.scrollY)).toBe(videosScrollTop)
+
+    await page.locator('[data-subscription-feed-tab="shorts"]').click()
+    await expect(page.locator('[data-subscription-feed-tab="shorts"]'))
+      .toHaveAttribute('aria-selected', 'true')
+    await expect.poll(() => page.evaluate(() => window.scrollY)).toBe(0)
   })
 
   test('keeps the panel hidden after every tab is hidden', async ({ page }) => {

--- a/e2e/tests/offline/subscriptions-tab-indicator.spec.mjs
+++ b/e2e/tests/offline/subscriptions-tab-indicator.spec.mjs
@@ -56,6 +56,22 @@ test.use({
 })
 
 test.describe('subscriptions feed tab indicator', () => {
+  test('falls back when the persisted tab is hidden on startup', async ({ page }) => {
+    await page.evaluate(async () => {
+      localStorage.setItem('Subscriptions/currentTab', 'videos')
+
+      const store = document.querySelector('#app').__vue_app__.config.globalProperties.$store
+      await store.dispatch('updateHideSubscriptionsVideos', true)
+    })
+
+    await goTo(page, 'subscriptions')
+
+    await expect(page.locator('[data-subscription-feed-tab="videos"]')).toHaveCount(0)
+    await expect(page.locator('[data-subscription-feed-tab="shorts"]'))
+      .toHaveAttribute('aria-selected', 'true')
+    await expect(page.getByText('short video 000')).toBeVisible()
+  })
+
   test('keeps tab widths stable when hovering with fonts whose bold glyphs are wider', async ({ page }) => {
     await goTo(page, 'subscriptions')
 

--- a/e2e/tests/offline/subscriptions-tab-indicator.spec.mjs
+++ b/e2e/tests/offline/subscriptions-tab-indicator.spec.mjs
@@ -81,50 +81,77 @@ test.describe('subscriptions feed tab indicator', () => {
     await expect(page.locator('.tabsIndicator')).toHaveCSS('transition-property', 'transform')
   })
 
-  test('starts moving before the new feed is rendered', async ({ page }) => {
+  test('renders the selected feed by the next frame', async ({ page }) => {
     await goTo(page, 'subscriptions')
 
     await expect(page.getByText('video video 000')).toBeVisible()
     await expect(page.locator('.tabsIndicator')).toBeVisible()
 
-    // Record whether the indicator is repositioned before or after the panel
-    // with the new feed is put into the DOM
-    await page.evaluate(() => {
-      window.__mutations = []
+    const state = await page.evaluate(() => {
+      document.querySelector('[data-subscription-feed-tab="shorts"]').click()
 
-      const observer = new MutationObserver((mutations) => {
-        for (const mutation of mutations) {
-          if (mutation.type === 'attributes') {
-            if (mutation.target.classList.contains('tabsIndicator')) {
-              window.__mutations.push('indicator')
-            }
-          } else if ([...mutation.addedNodes, ...mutation.removedNodes].some((node) => {
-            return node.nodeType === Node.ELEMENT_NODE &&
-              (node.id === 'subscriptionsPanel' || node.classList.contains('ft-list-video'))
-          })) {
-            window.__mutations.push('panel')
-          }
-        }
-      })
-
-      observer.observe(document.querySelector('.subscriptionsPage'), {
-        subtree: true,
-        childList: true,
-        attributes: true,
-        attributeFilter: ['style']
+      return new Promise(resolve => {
+        requestAnimationFrame(() => {
+          resolve({
+            selectedTab: document.querySelector('[role="tab"][aria-selected="true"]')
+              ?.dataset.subscriptionFeedTab,
+            panelText: document.querySelector('#subscriptionsPanel')?.textContent
+          })
+        })
       })
     })
 
-    await page.locator('[data-subscription-feed-tab="shorts"]').click()
-    await expect(page.getByText('short video 000')).toBeVisible()
+    expect(state.selectedTab).toBe('shorts')
+    expect(state.panelText).toContain('short video 000')
+    expect(state.panelText).not.toContain('video video 000')
+  })
 
-    const mutations = await page.evaluate(() => window.__mutations)
+  test('animates through an intermediate position after rendering a large feed', async ({ page }) => {
+    await goTo(page, 'subscriptions')
 
-    expect(mutations.indexOf('indicator')).toBeGreaterThanOrEqual(0)
-    expect(
-      mutations.indexOf('indicator'),
-      `mutation order: ${mutations.slice(0, 5).join(', ')}`
-    ).toBeLessThan(mutations.indexOf('panel'))
+    await expect(page.getByText('video video 000')).toBeVisible()
+    await expect(page.locator('.tabsIndicator')).toBeVisible()
+
+    const animation = await page.evaluate(() => {
+      const indicator = document.querySelector('.tabsIndicator')
+      const targetTab = document.querySelector('[data-subscription-feed-tab="shorts"]')
+      const startX = indicator.getBoundingClientRect().x
+      const endX = targetTab.getBoundingClientRect().x
+
+      return new Promise(resolve => {
+        let sawIntermediatePosition = false
+        let animationFrame = 0
+
+        const samplePosition = () => {
+          const currentX = indicator.getBoundingClientRect().x
+          const progress = (currentX - startX) / (endX - startX)
+
+          if (progress > 0.05 && progress < 0.95) {
+            sawIntermediatePosition = true
+          }
+
+          animationFrame = requestAnimationFrame(samplePosition)
+        }
+
+        indicator.addEventListener('transitionend', event => {
+          if (event.propertyName !== 'transform') {
+            return
+          }
+
+          cancelAnimationFrame(animationFrame)
+          resolve({
+            elapsedTime: event.elapsedTime,
+            sawIntermediatePosition
+          })
+        }, { once: true })
+
+        animationFrame = requestAnimationFrame(samplePosition)
+        targetTab.click()
+      })
+    })
+
+    expect(animation.sawIntermediatePosition).toBe(true)
+    expect(animation.elapsedTime).toBeCloseTo(0.2, 2)
   })
 
   test('ends up aligned with the selected tab', async ({ page, attachScreenshot }) => {
@@ -159,8 +186,7 @@ test.describe('subscriptions feed tab indicator', () => {
 
     await expect(page.getByText('video video 000')).toBeVisible()
 
-    // Both clicks happen in the same task, so the second one lands while the
-    // first tab change is still deferred
+    // Both clicks happen in the same task, so the last activation must win.
     await page.evaluate(() => {
       document.querySelector('[data-subscription-feed-tab="shorts"]').click()
       document.querySelector('[data-subscription-feed-tab="videos"]').click()
@@ -183,23 +209,7 @@ test.describe('subscriptions feed tab indicator', () => {
     expect(Math.abs(indicator - tab)).toBeLessThan(1)
   })
 
-  test('completes a pending switch when the selected tab is clicked again', async ({ page }) => {
-    await goTo(page, 'subscriptions')
-
-    await expect(page.getByText('video video 000')).toBeVisible()
-    await page.locator('[data-subscription-feed-tab="shorts"]').click()
-
-    // Let the deferred swap reach its first animation frame, then activate the
-    // visually selected tab again before the second frame replaces the panel.
-    await page.evaluate(() => new Promise(resolve => requestAnimationFrame(resolve)))
-    await page.locator('[data-subscription-feed-tab="shorts"]').click()
-
-    await expect(page.locator('.tab.selectedTab')).toHaveText(/Shorts/)
-    await expect(page.getByText('short video 000')).toBeVisible()
-    await expect(page.getByText('video video 000')).toHaveCount(0)
-  })
-
-  test('does not restore a pending feed after every tab is hidden', async ({ page }) => {
+  test('keeps the panel hidden after every tab is hidden', async ({ page }) => {
     await goTo(page, 'subscriptions')
 
     await expect(page.getByText('video video 000')).toBeVisible()
@@ -214,10 +224,6 @@ test.describe('subscriptions feed tab indicator', () => {
         store.dispatch('updateHideSubscriptionsCommunity', true)
       ])
     })
-
-    // Wait long enough that the stale second animation frame would have put
-    // the shorts panel back after the all-tabs-hidden state was selected.
-    await page.waitForTimeout(100)
 
     await expect(page.locator('.tabs [role="tab"]')).toHaveCount(0)
     await expect(page.locator('#subscriptionsPanel')).toHaveCount(0)

--- a/e2e/tests/offline/subscriptions-tab-indicator.spec.mjs
+++ b/e2e/tests/offline/subscriptions-tab-indicator.spec.mjs
@@ -1,4 +1,4 @@
-import { test, expect, goTo } from '../../helpers/app.mjs'
+import { test, expect, goTo, sel } from '../../helpers/app.mjs'
 
 const now = Date.now()
 const CHANNEL_ID = 'UCaaaaaaaaaaaaaaaaaaaaaa'
@@ -248,6 +248,29 @@ test.describe('subscriptions feed tab indicator', () => {
     await page.locator('[data-subscription-feed-tab="shorts"]').click()
     await expect(page.locator('[data-subscription-feed-tab="shorts"]'))
       .toHaveAttribute('aria-selected', 'true')
+    await expect.poll(() => page.evaluate(() => window.scrollY)).toBe(0)
+  })
+
+  test('restores the fallback feed scroll after a background visibility change', async ({ page }) => {
+    await goTo(page, 'subscriptions')
+
+    await expect(page.getByText('video video 000')).toBeVisible()
+    await page.evaluate(() => window.scrollTo(0, document.documentElement.scrollHeight))
+    await expect.poll(() => page.evaluate(() => window.scrollY)).toBeGreaterThan(0)
+
+    await page.locator(sel.newTabButton).click()
+    await goTo(page, 'settings')
+    await page.evaluate(async () => {
+      const store = document.querySelector('#app').__vue_app__.config.globalProperties.$store
+      await store.dispatch('updateHideSubscriptionsVideos', true)
+    })
+
+    await page.locator(sel.tabs).first().click()
+    const subscriptionsView = page.locator('.tabContent[aria-hidden="false"]')
+
+    await expect(subscriptionsView.locator('[data-subscription-feed-tab="shorts"]'))
+      .toHaveAttribute('aria-selected', 'true')
+    await expect(subscriptionsView.getByText('short video 000')).toBeVisible()
     await expect.poll(() => page.evaluate(() => window.scrollY)).toBe(0)
   })
 

--- a/src/renderer/views/Subscriptions/Subscriptions.vue
+++ b/src/renderer/views/Subscriptions/Subscriptions.vue
@@ -289,7 +289,7 @@ import SubscriptionsPosts from '../../components/SubscriptionsPosts.vue'
 import { getAnimationSpeedMultiplier } from '../../helpers/animationSpeed'
 import { getIconForSortPreference } from '../../helpers/utils'
 import store from '../../store/index'
-import { useTabContext } from '../../tabs/TabContext'
+import { useTabContext, useTabLifecycle } from '../../tabs/TabContext'
 import { getTabNavigationService } from '../../tabs/TabNavigationService'
 import { useRefreshAllSubscriptionFeeds } from '../../composables/useRefreshAllSubscriptionFeeds'
 import {
@@ -400,6 +400,20 @@ const tabScrollPositions = {
 }
 /** @type {'videos' | 'shorts' | 'live' | 'community' | 'new' | null} */
 let scrollPositionOwnerTab = currentTab.value
+let restoreScrollOnActivate = false
+
+useTabLifecycle({
+  activate: () => {
+    if (!restoreScrollOnActivate) {
+      return
+    }
+
+    restoreScrollOnActivate = false
+    const value = currentTab.value
+    window.scrollTo(0, value === null ? 0 : tabScrollPositions[value])
+    scrollPositionOwnerTab = value
+  }
+})
 
 const subscriptionRefreshTimestamps = computed(() => [
   store.getters.getSubscriptionFeedLastRefreshTimestamp,
@@ -481,8 +495,16 @@ watch(currentTab, async (value) => {
     localStorage.removeItem(currentTabStorageKey)
   }
 
-  if (!isMounted || (isElectron && isTabPresented?.value !== true)) {
+  if (!isMounted) {
     scrollPositionOwnerTab = value
+    return
+  }
+
+  if (isElectron && isTabPresented?.value !== true) {
+    // The shared window scroll still belongs to the presented logical tab.
+    // Restore this feed only after tab activation restores its page-level scroll.
+    scrollPositionOwnerTab = null
+    restoreScrollOnActivate = true
     return
   }
 

--- a/src/renderer/views/Subscriptions/Subscriptions.vue
+++ b/src/renderer/views/Subscriptions/Subscriptions.vue
@@ -557,14 +557,14 @@ if (visibleTabs.value.length === 0) {
  * @param {'videos' | 'shorts' | 'live' | 'community' | 'new'} tab
  */
 function changeTab(tab) {
-  if (tab === currentTab.value) {
-    return
-  }
-
   // First visible tab or no tab as fallback
   const target = visibleTabs.value.includes(tab)
     ? tab
     : (visibleTabs.value.length > 0 ? visibleTabs.value[0] : null)
+
+  if (target === currentTab.value) {
+    return
+  }
 
   // The feed is the primary response to activating a tab. Keep the indicator
   // animation decorative so it never delays the panel change.

--- a/src/renderer/views/Subscriptions/Subscriptions.vue
+++ b/src/renderer/views/Subscriptions/Subscriptions.vue
@@ -398,6 +398,8 @@ const tabScrollPositions = {
   community: 0,
   new: 0
 }
+/** @type {'videos' | 'shorts' | 'live' | 'community' | 'new' | null} */
+let scrollPositionOwnerTab = currentTab.value
 
 const subscriptionRefreshTimestamps = computed(() => [
   store.getters.getSubscriptionFeedLastRefreshTimestamp,
@@ -471,7 +473,7 @@ onBeforeUnmount(() => {
   removeFeedReloadRequestListener?.()
 })
 
-watch(currentTab, async (value, previousValue) => {
+watch(currentTab, async (value) => {
   if (value !== null) {
     // Use the last selected feed when opening another subscription view
     localStorage.setItem(currentTabStorageKey, value)
@@ -480,15 +482,27 @@ watch(currentTab, async (value, previousValue) => {
   }
 
   if (!isMounted || (isElectron && isTabPresented?.value !== true)) {
+    scrollPositionOwnerTab = value
     return
   }
 
-  if (previousValue !== null) {
-    tabScrollPositions[previousValue] = window.scrollY
+  if (scrollPositionOwnerTab !== null) {
+    tabScrollPositions[scrollPositionOwnerTab] = window.scrollY
   }
+  scrollPositionOwnerTab = null
 
   await nextTick()
+
+  if (
+    value !== currentTab.value ||
+    !isMounted ||
+    (isElectron && isTabPresented?.value !== true)
+  ) {
+    return
+  }
+
   window.scrollTo(0, value === null ? 0 : tabScrollPositions[value])
+  scrollPositionOwnerTab = value
 })
 
 const visibleTabs = computed(() => {

--- a/src/renderer/views/Subscriptions/Subscriptions.vue
+++ b/src/renderer/views/Subscriptions/Subscriptions.vue
@@ -46,7 +46,7 @@
                 aria-controls="subscriptionsPanel"
                 data-subscription-feed-tab="videos"
                 :tabindex="currentTab === 'videos' ? 0 : -1"
-                :class="{ selectedTab: selectedTab === 'videos' }"
+                :class="{ selectedTab: currentTab === 'videos' }"
                 @click="changeTabFromPointer($event, 'videos')"
                 @keydown.space.enter.prevent="changeTab('videos')"
                 @keydown.left.right="switchTab($event, 'videos')"
@@ -74,7 +74,7 @@
                 aria-controls="subscriptionsPanel"
                 data-subscription-feed-tab="shorts"
                 :tabindex="currentTab === 'shorts' ? 0 : -1"
-                :class="{ selectedTab: selectedTab === 'shorts' }"
+                :class="{ selectedTab: currentTab === 'shorts' }"
                 @click="changeTabFromPointer($event, 'shorts')"
                 @keydown.space.enter.prevent="changeTab('shorts')"
                 @keydown.left.right="switchTab($event, 'shorts')"
@@ -102,7 +102,7 @@
                 aria-controls="subscriptionsPanel"
                 data-subscription-feed-tab="live"
                 :tabindex="currentTab === 'live' ? 0 : -1"
-                :class="{ selectedTab: selectedTab === 'live' }"
+                :class="{ selectedTab: currentTab === 'live' }"
                 @click="changeTabFromPointer($event, 'live')"
                 @keydown.space.enter.prevent="changeTab('live')"
                 @keydown.left.right="switchTab($event, 'live')"
@@ -130,7 +130,7 @@
                 aria-controls="subscriptionsPanel"
                 data-subscription-feed-tab="posts"
                 :tabindex="currentTab === 'community' ? 0 : -1"
-                :class="{ selectedTab: selectedTab === 'community' }"
+                :class="{ selectedTab: currentTab === 'community' }"
                 @click="changeTabFromPointer($event, 'community')"
                 @keydown.space.enter.prevent="changeTab('community')"
                 @keydown.left.right="switchTab($event, 'community')"
@@ -158,7 +158,7 @@
                 aria-controls="subscriptionsPanel"
                 data-subscription-feed-tab="all"
                 :tabindex="currentTab === 'new' ? 0 : -1"
-                :class="{ selectedTab: selectedTab === 'new' }"
+                :class="{ selectedTab: currentTab === 'new' }"
                 @click="changeTabFromPointer($event, 'new')"
                 @keydown.space.enter.prevent="changeTab('new')"
                 @keydown.left.right="switchTab($event, 'new')"
@@ -390,7 +390,6 @@ const currentTabRefreshing = computed(() => {
 
 /** @type {import('vue').Ref<'videos' | 'shorts' | 'live' | 'community' | 'new' | null>} */
 const currentTab = ref('videos')
-const selectedTab = ref('videos')
 
 const tabScrollPositions = {
   videos: 0,
@@ -456,9 +455,6 @@ function nextAnimationFrame() {
 
 let isMounted = false
 let removeFeedReloadRequestListener = null
-/** @type {number | null} */
-let pendingTabChangeFrame = null
-let tabChangeSequence = 0
 
 onMounted(() => {
   isMounted = true
@@ -471,14 +467,8 @@ onMounted(() => {
 
 onBeforeUnmount(() => {
   isMounted = false
-  tabChangeSequence++
   document.removeEventListener('keydown', handlePanelTabNavigation)
   removeFeedReloadRequestListener?.()
-
-  if (pendingTabChangeFrame !== null) {
-    window.cancelAnimationFrame(pendingTabChangeFrame)
-    pendingTabChangeFrame = null
-  }
 })
 
 watch(currentTab, async (value, previousValue) => {
@@ -531,23 +521,13 @@ const visibleTabs = computed(() => {
 
 watch(visibleTabs, (value) => {
   if (value.length === 0) {
-    // Invalidate both scheduled nextTick work and an already queued frame so a
-    // deferred switch cannot restore a feed after its final tab is hidden.
-    tabChangeSequence++
-    if (pendingTabChangeFrame !== null) {
-      window.cancelAnimationFrame(pendingTabChangeFrame)
-      pendingTabChangeFrame = null
-    }
-
-    selectedTab.value = null
     currentTab.value = null
-  } else if (!value.includes(selectedTab.value)) {
+  } else if (!value.includes(currentTab.value)) {
     changeTab(value[0])
   }
 })
 
 if (visibleTabs.value.length === 0) {
-  selectedTab.value = null
   currentTab.value = null
 } else {
   // Restore currentTab
@@ -555,7 +535,6 @@ if (visibleTabs.value.length === 0) {
   if (lastCurrentTabId !== null) {
     changeTab(lastCurrentTabId)
   } else if (!visibleTabs.value.includes(currentTab.value)) {
-    selectedTab.value = visibleTabs.value[0]
     currentTab.value = visibleTabs.value[0]
   }
 }
@@ -564,23 +543,7 @@ if (visibleTabs.value.length === 0) {
  * @param {'videos' | 'shorts' | 'live' | 'community' | 'new'} tab
  */
 function changeTab(tab) {
-  // A pending change from a previous click is always dropped, its indicator
-  // placement included, so the last clicked tab wins
-  const hadPendingChange = pendingTabChangeFrame !== null
-
-  if (hadPendingChange) {
-    window.cancelAnimationFrame(pendingTabChangeFrame)
-    pendingTabChangeFrame = null
-  }
-
-  if (tab === selectedTab.value) {
-    if (hadPendingChange) {
-      // Complete the cancelled panel swap so the highlighted tab and its
-      // content cannot get separated by a repeated activation.
-      currentTab.value = tab
-      updateTabsIndicator()
-    }
-
+  if (tab === currentTab.value) {
     return
   }
 
@@ -589,30 +552,9 @@ function changeTab(tab) {
     ? tab
     : (visibleTabs.value.length > 0 ? visibleTabs.value[0] : null)
 
-  selectedTab.value = target
-  const sequence = ++tabChangeSequence
-
-  if (!isMounted || target === null) {
-    currentTab.value = target
-    return
-  }
-
-  // Let the selected label reach its final bold width before measuring the
-  // indicator. The content is swapped two frames later, after the compositor
-  // has started moving the indicator toward that stable target.
-  nextTick(() => {
-    if (sequence !== tabChangeSequence) { return }
-
-    moveTabsIndicatorTo(target)
-    pendingTabChangeFrame = window.requestAnimationFrame(() => {
-      pendingTabChangeFrame = window.requestAnimationFrame(() => {
-        if (sequence !== tabChangeSequence) { return }
-
-        pendingTabChangeFrame = null
-        currentTab.value = target
-      })
-    })
-  })
+  // The feed is the primary response to activating a tab. Keep the indicator
+  // animation decorative so it never delays the panel change.
+  currentTab.value = target
 }
 
 /**
@@ -813,7 +755,7 @@ function handlePanelTabNavigation(event) {
     return
   }
 
-  switchTab(event, selectedTab.value, false)
+  switchTab(event, currentTab.value, false)
 }
 
 function refreshCurrentTab() {
@@ -947,14 +889,6 @@ let tabsResizeObserver = null
 // otherwise it visibly flies in from the stale position.
 let tabsIndicatorWasHidden = true
 
-const tabElementRefs = {
-  videos: videosTab,
-  shorts: shortsTab,
-  live: liveTab,
-  community: communityTab,
-  new: newTab
-}
-
 /**
  * @param {HTMLElement} tabElement
  * @returns {boolean} whether the indicator was positioned on the tab
@@ -984,13 +918,6 @@ function placeTabsIndicator(tabElement) {
 }
 
 function updateTabsIndicator() {
-  // While a tab change is pending the indicator already sits on the tab that is
-  // about to be selected, so re-measuring the still selected one (e.g. from the
-  // ResizeObserver when a refresh loader appears) would move it back
-  if (pendingTabChangeFrame !== null) {
-    return
-  }
-
   const container = tabsContainerRef.value?.$el
   const selected = container?.querySelector('.tab.selectedTab')
 
@@ -1003,23 +930,7 @@ function updateTabsIndicator() {
   placeTabsIndicator(selected)
 }
 
-/**
- * Moves the indicator onto a tab before it becomes the selected one, so the
- * animation can start before the new panel is rendered.
- * @param {'videos' | 'shorts' | 'live' | 'community' | 'new'} tab
- * @returns {boolean} whether the indicator was moved
- */
-function moveTabsIndicatorTo(tab) {
-  if (!isMounted || tabsIndicatorStyle.value === null || tabsIndicatorWasHidden) {
-    return false
-  }
-
-  const tabElement = tabElementRefs[tab]?.value
-
-  return tabElement instanceof HTMLElement && placeTabsIndicator(tabElement)
-}
-
-watch([selectedTab, visibleTabs, refreshingFeedTab], () => nextTick(updateTabsIndicator))
+watch([currentTab, visibleTabs, refreshingFeedTab], () => nextTick(updateTabsIndicator))
 
 onMounted(() => {
   if (typeof ResizeObserver === 'function') {


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Make sure to follow the contributing guidelines. -->
<!-- Important note, we may remove your pull request if you do not use this provided PR template correctly. -->
<!-- Agent instructions: Preserve every heading, comment, and marker in this template. Never remove or rewrite the release-note-category:start/end, release-note:start/end, or release-note-image:start/end marker pairs. Never remove or rewrite the Release note images section; leave its contents for a human. -->

## Pull Request Type
<!-- Please select what type of pull request this is: [x] -->
- [x] Bugfix
- [ ] Feature Implementation
- [ ] Documentation
- [ ] Other

## Related issue
<!-- Please link the issue your pull request is referring to. -->
<!-- If this pull request fully resolves the relevant issue, put "closes" before the issue number. -->
<!-- Example: "closes #123456". -->

## Description
<!-- Please write a clear and concise description of what the pull request does. -->

Switching subscription feed tabs waited for two animation frames before replacing the panel. This made the feed feel tied to the indicator animation, especially when a large feed took time to render.

The feed now becomes active immediately. The indicator remains a compositor-only transform and starts after Vue renders the panel, so a large render cannot stall an animation already in progress. Regression coverage checks both next-frame panel rendering and intermediate indicator movement with a 150-entry feed.

## Release note category
<!-- Select exactly one category. Every pull request must select one. -->
<!-- Select "Not noteworthy" when the pull request fixes a bug in or improves functionality that has not yet appeared in a stable release. -->
<!-- release-note-category:start -->
- [ ] Not noteworthy
- [ ] Highlights
- [ ] More improvements
- [x] Fixed bugs
<!-- release-note-category:end -->

## Release note
<!-- Required unless "Not noteworthy" is selected. -->
<!-- Write one concise, user-facing entry without a leading bullet. -->
<!-- release-note:start -->
Subscription feed tabs now show their content immediately instead of waiting for the tab indicator animation.
<!-- release-note:end -->

## Release note images
<!-- Human-only: Agents must preserve this entire section and leave it empty. -->
<!-- Optional. Paste one or more Markdown images or HTML image tags here. -->
<!-- The release notes will use an HTML image tag and limit images taller than 300 pixels. -->
<!-- release-note-image:start -->

<!-- release-note-image:end -->

## Testing
<!-- How can reviewers verify that the PR produces correct results? -->
<!-- Please provide instructions so that others can ensure that your pull request would produce correct results. For examples see, https://github.com/FreeTubeApp/FreeTube/pull/5743, https://github.com/FreeTubeApp/FreeTube/pull/7349, https://github.com/FreeTubeApp/FreeTube/pull/5125, https://github.com/FreeTubeApp/FreeTube/pull/7338 -->
<!-- Agent instructions: Only write human-facing steps that explain how to verify the change while running this branch in dev mode. Include expected results and, when applicable, helpful console snippets for interactive verification. Do not include automated checks, commands, results, pass counts, or CI status. -->

1. Open Subscriptions with cached entries in at least two feed tabs.
2. Switch repeatedly between Videos, Shorts, Live, Posts, and New.
3. Confirm the selected feed appears without waiting for the indicator line to reach the tab.
4. Confirm the indicator still moves smoothly and finishes aligned below the selected tab, including with a large feed.

## Additional context
<!-- Add any other context about the pull request here. -->

The removed two-frame delay was originally added to let the indicator start before mounting a large feed. Updating the indicator after the panel render keeps the transition smooth without making content wait.