### PR TITLE
fix(sidebar): center collapsed navigation tiles

### DIFF
--- a/e2e/tests/offline/navigation.spec.mjs
+++ b/e2e/tests/offline/navigation.spec.mjs
@@ -41,6 +41,92 @@ test.describe('side nav navigation', () => {
   })
 })
 
+for (const uiScale of [90, 100, 125]) {
+  test.describe(`side nav without labels at ${uiScale}% UI scale`, () => {
+    test.use({
+      seed: {
+        settings: { hideLabelsSideBar: true, uiScale },
+        profiles: [{
+          _id: 'allChannels',
+          name: 'All Channels',
+          bgColor: '#000000',
+          textColor: '#FFFFFF',
+          subscriptions: [{
+            id: 'UCaaaaaaaaaaaaaaaaaaaaaa',
+            name: 'Alpha Channel',
+            thumbnail: 'data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mNk+M/wHwAF/gL+Xw4AAAAASUVORK5CYII='
+          }]
+        }]
+      }
+    })
+
+    test('uses square tiles with centered icons and avatars in the collapsed side bar', async ({ page }) => {
+      await goTo(page, 'channel/UCaaaaaaaaaaaaaaaaaaaaaa')
+      const sideNav = page.locator('.sideNav.hiddenLabels')
+      const activeIndicator = sideNav.locator('.activeIndicator')
+      const [avatarBounds, channelTileBounds, channelIndicatorBounds] = await Promise.all([
+        sideNav.locator('.navChannel.router-link-active .channelThumbnail').boundingBox(),
+        sideNav.locator('.navChannel.router-link-active').boundingBox(),
+        activeIndicator.boundingBox()
+      ])
+      const avatarClearance = avatarBounds.x -
+        (channelIndicatorBounds.x + channelIndicatorBounds.width)
+      const avatarInlineCenter = avatarBounds.x + avatarBounds.width / 2
+      const avatarCenter = avatarBounds.y + avatarBounds.height / 2
+      const channelInlineCenter = channelTileBounds.x + channelTileBounds.width / 2
+      const channelCenter = channelTileBounds.y + channelTileBounds.height / 2
+      expect(Math.abs(channelTileBounds.width - 50)).toBeLessThanOrEqual(1)
+      expect(Math.abs(channelTileBounds.height - 50)).toBeLessThanOrEqual(1)
+      expect(Math.abs(avatarInlineCenter - channelInlineCenter)).toBeLessThanOrEqual(1)
+      expect(Math.abs(avatarCenter - channelCenter)).toBeLessThanOrEqual(1)
+      expect(avatarClearance).toBeGreaterThanOrEqual(4)
+
+      await goTo(page, 'history')
+      const sideNavBounds = await sideNav.boundingBox()
+      expect(Math.abs(sideNavBounds.width - 50)).toBeLessThanOrEqual(1)
+      const tileMetrics = await sideNav.locator('.inner > .navOption:visible .navIcon').evaluateAll(
+        icons => icons.map(icon => {
+          const bounds = icon.getBoundingClientRect()
+          const optionBounds = icon.closest('.navOption').getBoundingClientRect()
+          const iconInlineCenter = bounds.left + bounds.width / 2
+          const iconCenter = bounds.top + bounds.height / 2
+          const optionInlineCenter = optionBounds.left + optionBounds.width / 2
+          const optionCenter = optionBounds.top + optionBounds.height / 2
+          return {
+            centerOffset: Math.abs(iconCenter - optionCenter),
+            height: optionBounds.height,
+            inlineCenterOffset: icon.matches(
+              "[data-icon='user-check'][data-icon-pack='material']"
+            )
+              ? null
+              : Math.abs(iconInlineCenter - optionInlineCenter),
+            left: optionBounds.left,
+            width: optionBounds.width
+          }
+        })
+      )
+      expect(tileMetrics.length).toBeGreaterThan(0)
+
+      for (const tile of tileMetrics) {
+        expect(Math.abs(tile.width - 50)).toBeLessThanOrEqual(1)
+        expect(Math.abs(tile.height - 50)).toBeLessThanOrEqual(1)
+        expect(Math.abs(tile.left - sideNavBounds.x)).toBeLessThanOrEqual(1)
+        expect(tile.centerOffset).toBeLessThanOrEqual(1)
+        if (tile.inlineCenterOffset !== null) {
+          expect(tile.inlineCenterOffset).toBeLessThanOrEqual(1)
+        }
+      }
+
+      const activeTile = sideNav.locator('.inner > .navOption.router-link-active:visible')
+      const [activeTileBounds, indicatorBounds] = await Promise.all([
+        activeTile.boundingBox(),
+        activeIndicator.boundingBox()
+      ])
+      expect(Math.abs(activeTileBounds.x - indicatorBounds.x)).toBeLessThanOrEqual(1)
+    })
+  })
+}
+
 test.describe('navigation history titles', () => {
   test.use({
     seed: {

--- a/src/renderer/components/SideNav/SideNav.css
+++ b/src/renderer/components/SideNav/SideNav.css
@@ -170,7 +170,7 @@
 }
 
 .hiddenLabels {
-  inline-size: 60px;
+  inline-size: 50px;
 }
 
 .hiddenLabels .navLabel {
@@ -186,6 +186,17 @@
 }
 
 @media only screen and (width > 680px) {
+  .hiddenLabels .navOption,
+  .hiddenLabels .navChannel {
+    align-items: center;
+    block-size: 50px;
+    box-sizing: border-box;
+    display: flex;
+    inline-size: 50px;
+    justify-content: center;
+    margin-inline: 0 auto;
+  }
+
   .expanded {
     inline-size: 200px;
   }


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Make sure to follow the contributing guidelines. -->
<!-- Important note, we may remove your pull request if you do not use this provided PR template correctly. -->
<!-- Agent instructions: Preserve every heading, comment, and marker in this template. Never remove or rewrite the release-note-category:start/end, release-note:start/end, or release-note-image:start/end marker pairs. Never remove or rewrite the Release note images section; leave its contents for a human. -->

## Pull Request Type
<!-- Please select what type of pull request this is: [x] -->
- [x] Bugfix
- [ ] Feature Implementation
- [ ] Documentation
- [ ] Other

## Related issue
<!-- Please link the issue your pull request is referring to. -->
<!-- If this pull request fully resolves the relevant issue, put "closes" before the issue number. -->
<!-- Example: "closes #123456". -->

None.

## Description
<!-- Please write a clear and concise description of what the pull request does. -->

Hiding side bar labels left navigation icons and subscribed-channel avatars off-center inside rectangular or partially filled hover backgrounds. The active indicator could also sit too close to channel avatars.

The collapsed desktop side bar now uses 50 by 50 pixel square entries and matches the rail width to those entries. Flex centering keeps icons and avatars centered while the active indicator remains flush with the outer edge. Regression coverage checks square geometry, centering, indicator alignment, and avatar clearance at several UI scales.

The root cause was that label-free entries kept their content-flow height and inherited rail width instead of sharing one explicit square size.

## Release note category
<!-- Select exactly one category. Every pull request must select one. -->
<!-- Select "Not noteworthy" when the pull request fixes a bug in or improves functionality that has not yet appeared in a stable release. -->
<!-- release-note-category:start -->
- [ ] Not noteworthy
- [ ] Highlights
- [ ] More improvements
- [x] Fixed bugs
<!-- release-note-category:end -->

## Release note
<!-- Required unless "Not noteworthy" is selected. -->
<!-- Write one concise, user-facing entry without a leading bullet. -->
<!-- release-note:start -->
Center icons and channel avatars inside square side bar tiles when labels are hidden.
<!-- release-note:end -->

## Release note images
<!-- Human-only: Agents must preserve this entire section and leave it empty. -->
<!-- Optional. Paste one or more Markdown images or HTML image tags here. -->
<!-- The release notes will use an HTML image tag and limit images taller than 300 pixels. -->
<!-- release-note-image:start -->

<!-- release-note-image:end -->

## Testing
<!-- How can reviewers verify that the PR produces correct results? -->
<!-- Please provide instructions so that others can ensure that your pull request would produce correct results. For examples see, https://github.com/FreeTubeApp/FreeTube/pull/5743, https://github.com/FreeTubeApp/FreeTube/pull/7349, https://github.com/FreeTubeApp/FreeTube/pull/5125, https://github.com/FreeTubeApp/FreeTube/pull/7338 -->
<!-- Agent instructions: Only write human-facing steps that explain how to verify the change while running this branch in dev mode. Include expected results and, when applicable, helpful console snippets for interactive verification. Do not include automated checks, commands, results, pass counts, or CI status. -->

1. Run the app in dev mode on a desktop-sized window and enable "Hide Labels Side Bar".
2. Hover and select several side bar destinations. Each background should be a 50 by 50 pixel square, with its icon centered and the active indicator flush against the outer edge.
3. Open a subscribed channel from the side bar. Its avatar should be centered in the square with visible clearance from the active indicator.
4. Repeat at 90%, 100%, and 125% UI scale. The alignment should remain unchanged.

## Additional context
<!-- Add any other context about the pull request here. -->

The active indicator stays in its original position. The collapsed rail grows only enough to give 35 pixel channel avatars balanced spacing.
