### PR TITLE
fix(downloads): play auto downloads from notifications

### DIFF
--- a/e2e/tests/offline/download-settings.spec.mjs
+++ b/e2e/tests/offline/download-settings.spec.mjs
@@ -258,7 +258,7 @@ test.describe('automatic download authorization', () => {
       'done',
       `printf '%s\\n' "$@" > ${argumentsFile}`,
       `while [ ! -f "${releaseDownloadFile}" ]; do sleep 0.05; done`,
-      `printf '__OPENTUBEX_FILE__:ccccccccccc\\t120\\t1920\\t1080\\t%s\\n' '${downloadedFile}'`
+      `printf '__OPENTUBEX_FILE__:ccccccccccc\\t120\\t640\\t360\\t%s\\n' '${downloadedFile}'`
     ].join('\n'))
     await chmod(executable, 0o755)
     await page.evaluate(async (ytDlpPath) => {

--- a/e2e/tests/offline/download-settings.spec.mjs
+++ b/e2e/tests/offline/download-settings.spec.mjs
@@ -1,7 +1,8 @@
-import { chmod, readFile, writeFile } from 'node:fs/promises'
+import { chmod, copyFile, readFile, writeFile } from 'node:fs/promises'
 import path from 'node:path'
 
 import { test, expect, goToSettingsSection, setWindowSize } from '../../helpers/app.mjs'
+import { DEMO_MEDIA_PATH } from '../../helpers/media.mjs'
 
 const ALPHA_CHANNEL_ID = 'UCaaaaaaaaaaaaaaaaaaaaaa'
 const BETA_CHANNEL_ID = 'UCbbbbbbbbbbbbbbbbbbbbbb'
@@ -230,6 +231,7 @@ test.describe('automatic download authorization', () => {
 
   test('starts filtered automatic downloads only for the active subscription refresh', async ({ app, page }) => {
     const executable = path.join(app.userDataDir, 'fake-automatic-yt-dlp.sh')
+    const downloadedFile = path.join(app.userDataDir, 'automatic.webm')
     const argumentsFile = path.join(app.userDataDir, 'automatic-yt-dlp-arguments.txt')
     const metadataLookupsFile = path.join(app.userDataDir, 'automatic-yt-dlp-metadata-lookups.txt')
     const releaseDownloadFile = path.join(app.userDataDir, 'release-automatic-download')
@@ -240,6 +242,7 @@ test.describe('automatic download authorization', () => {
         globalThis.automaticDownloadNotifications.push(this)
       }
     })
+    await copyFile(DEMO_MEDIA_PATH, downloadedFile)
     await writeFile(executable, [
       '#!/bin/sh',
       'for argument in "$@"; do',
@@ -255,7 +258,7 @@ test.describe('automatic download authorization', () => {
       'done',
       `printf '%s\\n' "$@" > ${argumentsFile}`,
       `while [ ! -f "${releaseDownloadFile}" ]; do sleep 0.05; done`,
-      "printf '__OPENTUBEX_FILE__:ccccccccccc\\t120\\t1920\\t1080\\t/tmp/automatic.webm\\n'"
+      `printf '__OPENTUBEX_FILE__:ccccccccccc\\t120\\t1920\\t1080\\t%s\\n' '${downloadedFile}'`
     ].join('\n'))
     await chmod(executable, 0o755)
     await page.evaluate(async (ytDlpPath) => {
@@ -365,8 +368,10 @@ test.describe('automatic download authorization', () => {
       }
     })).toEqual({
       tabCount: tabCount + 1,
-      route: '/watch?v=ccccccccccc'
+      route: `/watch/ccccccccccc?downloadId=${result.id}`
     })
+    await expect(page.locator('.videoPlayerPlaceholder.ft-shimmer')).toHaveCount(0)
+    await expect(page.locator('.legacy-quality-button')).toHaveAttribute('shaka-status', '640×360 • Local file')
 
     const args = (await readFile(argumentsFile, 'utf8')).trim().split('\n')
     expect(args).toEqual(expect.arrayContaining([

--- a/src/main/ytDlp.js
+++ b/src/main/ytDlp.js
@@ -187,7 +187,7 @@ function broadcastToRenderers(channel, payload) {
   }
 }
 
-function showAutomaticDownloadNotification(payload, phase) {
+function showAutomaticDownloadNotification(payload, phase, downloadId = null) {
   if (payload.automatic !== true || !Notification.isSupported()) {
     return
   }
@@ -215,10 +215,10 @@ function showAutomaticDownloadNotification(payload, phase) {
       const tabManager = TabManager.getForWindow(browserWindow.id)
       if (phase === 'started') {
         browserWindow.webContents.send(IpcChannels.CHANGE_VIEW, '/downloads')
-      } else if (phase === 'completed' && tabManager && ID_REGEX.test(payload.videoId)) {
+      } else if (phase === 'completed' && tabManager && ID_REGEX.test(payload.videoId) && Number.isInteger(downloadId)) {
         tabManager.createTabWithPreference({
-          route: '/watch',
-          query: { v: payload.videoId },
+          route: `/watch/${payload.videoId}`,
+          query: { downloadId },
           makeActive: true
         }).catch(error => {
           console.error('Failed to open automatically downloaded video', error)
@@ -2125,7 +2125,7 @@ async function startYtDlpDownload(
     }
 
     if (status.status === 'completed') {
-      showAutomaticDownloadNotification(payload, 'completed')
+      showAutomaticDownloadNotification(payload, 'completed', id)
     } else if (status.status === 'failed') {
       showAutomaticDownloadNotification(payload, 'failed')
     }


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Make sure to follow the contributing guidelines. -->
<!-- Important note, we may remove your pull request if you do not use this provided PR template correctly. -->
<!-- Agent instructions: Preserve every heading, comment, and marker in this template. Never remove or rewrite the release-note-category:start/end, release-note:start/end, or release-note-image:start/end marker pairs. Never remove or rewrite the Release note images section; leave its contents for a human. -->

## Pull Request Type
<!-- Please select what type of pull request this is: [x] -->
- [x] Bugfix
- [ ] Feature Implementation
- [ ] Documentation
- [ ] Other

## Related issue
<!-- Please link the issue your pull request is referring to. -->
<!-- If this pull request fully resolves the relevant issue, put "closes" before the issue number. -->
<!-- Example: "closes #123456". -->

No linked issue.

## Description
<!-- Please write a clear and concise description of what the pull request does. -->

The completed automatic-download notification opened `/watch?v=<videoId>`, but the current watch route requires the video ID in the path. It also needs the download record ID to select local playback. The invalid route left the new tab on its loading placeholder.

The notification now opens `/watch/<videoId>?downloadId=<recordId>`, matching the Downloads dialog's Play action. The automatic-download E2E coverage now uses a real local media fixture and verifies that the completed notification opens the local player without the placeholder.

## Release note category
<!-- Select exactly one category. Every pull request must select one. -->
<!-- Select "Not noteworthy" when the pull request fixes a bug in or improves functionality that has not yet appeared in a stable release. -->
<!-- release-note-category:start -->
- [ ] Not noteworthy
- [ ] Highlights
- [ ] More improvements
- [x] Fixed bugs
<!-- release-note-category:end -->

## Release note
<!-- Required unless "Not noteworthy" is selected. -->
<!-- Write one concise, user-facing entry without a leading bullet. -->
<!-- release-note:start -->
Completed automatic-download notifications now play the local file instead of opening an empty watch tab.
<!-- release-note:end -->

## Release note images
<!-- Human-only: Agents must preserve this entire section and leave it empty. -->
<!-- Optional. Paste one or more Markdown images or HTML image tags here. -->
<!-- The release notes will use an HTML image tag and limit images taller than 300 pixels. -->
<!-- release-note-image:start -->

<!-- release-note-image:end -->

## Testing
<!-- How can reviewers verify that the PR produces correct results? -->
<!-- Please provide instructions so that others can ensure that your pull request produces correct results. For examples see, https://github.com/FreeTubeApp/FreeTube/pull/5743, https://github.com/FreeTubeApp/FreeTube/pull/7349, https://github.com/FreeTubeApp/FreeTube/pull/5125, https://github.com/FreeTubeApp/FreeTube/pull/7338 -->
<!-- Agent instructions: Only write human-facing steps that explain how to verify the change while running this branch in dev mode. Include expected results and, when applicable, helpful console snippets for interactive verification. Do not include automated checks, commands, results, pass counts, or CI status. -->

1. Configure an automatic download for a subscribed channel and refresh subscriptions so a matching video downloads.
2. Wait for the completed notification, then select View.
3. Verify that a new active tab opens the downloaded video, playback uses the local file, and the loading placeholder is gone.

## Additional context
<!-- Add any other context about the pull request here. -->

This fixes the completed notification action introduced in #829.