### PR TITLE
perf(subscriptions): reuse loaded feed tabs

### DIFF
--- a/e2e/tests/offline/subscriptions-new-feed.spec.mjs
+++ b/e2e/tests/offline/subscriptions-new-feed.spec.mjs
@@ -191,7 +191,9 @@ test.describe('new subscriptions feed', () => {
     const video = page.locator('.ft-list-video').filter({
       has: page.getByText('New video', { exact: true })
     })
+    const markAllAsSeen = page.getByRole('button', { name: 'Mark all as seen' })
     await expect(video.locator('.newContentDot')).toBeVisible()
+    await expect(markAllAsSeen).toBeVisible()
 
     await video.hover()
     await video.locator('.optionsButton').click()
@@ -200,6 +202,7 @@ test.describe('new subscriptions feed', () => {
     await expect(video).toBeVisible()
     await expect(video.locator('.newContentDot')).toHaveCount(0)
     await expect(video).not.toHaveClass(/watched/)
+    await expect(markAllAsSeen).toHaveCount(0)
 
     await video.hover()
     await video.locator('.optionsButton').click()

--- a/e2e/tests/offline/subscriptions-tab-indicator.spec.mjs
+++ b/e2e/tests/offline/subscriptions-tab-indicator.spec.mjs
@@ -32,7 +32,10 @@ test.use({
       fetchSubscriptionsAutomatically: false,
       hideSubscriptionsVideos: false,
       hideSubscriptionsShorts: false,
-      reducedMotion: 'off'
+      showNewSubscriptionFeed: true,
+      generalAutoLoadMorePaginatedItemsEnabled: false,
+      reducedMotion: 'off',
+      uiScale: 95
     },
     profiles: [
       {
@@ -98,32 +101,35 @@ test.describe('subscriptions feed tab indicator', () => {
     await expect(page.locator('.tabsIndicator')).toHaveCSS('transition-property', 'transform')
   })
 
-  test('renders the selected feed by the next frame', async ({ page }) => {
+  test('paints selection feedback before mounting the selected feed', async ({ page }) => {
     await goTo(page, 'subscriptions')
 
     await expect(page.getByText('video video 000')).toBeVisible()
     await expect(page.locator('.tabsIndicator')).toBeVisible()
+    await page.locator('[data-subscription-feed-tab="all"]').click()
+    await expect(page.locator('#subscriptionsPanel.newFeed')).toBeVisible()
 
     const state = await page.evaluate(() => {
-      document.querySelector('[data-subscription-feed-tab="shorts"]').click()
-
       return new Promise(resolve => {
         requestAnimationFrame(() => {
-          resolve({
-            selectedTab: document.querySelector('[role="tab"][aria-selected="true"]')
+          document.querySelector('[data-subscription-feed-tab="videos"]').click()
+
+          requestAnimationFrame(() => resolve({
+            visuallySelectedTab: document.querySelector('.tab.selectedTab')
               ?.dataset.subscriptionFeedTab,
-            panelText: document.querySelector('#subscriptionsPanel')?.textContent
-          })
+            panelIsStillNew: document.querySelector('#subscriptionsPanel')
+              ?.classList.contains('newFeed')
+          }))
         })
       })
     })
 
-    expect(state.selectedTab).toBe('shorts')
-    expect(state.panelText).toContain('short video 000')
-    expect(state.panelText).not.toContain('video video 000')
+    expect(state.visuallySelectedTab).toBe('videos')
+    expect(state.panelIsStillNew).toBe(true)
+    await expect(page.getByText('video video 000')).toBeVisible()
   })
 
-  test('animates through an intermediate position after rendering a large feed', async ({ page }) => {
+  test('runs the indicator transition while rendering a large feed', async ({ page }) => {
     await goTo(page, 'subscriptions')
 
     await expect(page.getByText('video video 000')).toBeVisible()
@@ -132,43 +138,21 @@ test.describe('subscriptions feed tab indicator', () => {
     const animation = await page.evaluate(() => {
       const indicator = document.querySelector('.tabsIndicator')
       const targetTab = document.querySelector('[data-subscription-feed-tab="shorts"]')
-      const startX = indicator.getBoundingClientRect().x
-      const endX = targetTab.getBoundingClientRect().x
 
       return new Promise(resolve => {
-        let sawIntermediatePosition = false
-        let animationFrame = 0
-
-        const samplePosition = () => {
-          const currentX = indicator.getBoundingClientRect().x
-          const progress = (currentX - startX) / (endX - startX)
-
-          if (progress > 0.05 && progress < 0.95) {
-            sawIntermediatePosition = true
-          }
-
-          animationFrame = requestAnimationFrame(samplePosition)
-        }
-
         indicator.addEventListener('transitionend', event => {
           if (event.propertyName !== 'transform') {
             return
           }
 
-          cancelAnimationFrame(animationFrame)
-          resolve({
-            elapsedTime: event.elapsedTime,
-            sawIntermediatePosition
-          })
+          resolve(event.elapsedTime)
         }, { once: true })
 
-        animationFrame = requestAnimationFrame(samplePosition)
         targetTab.click()
       })
     })
 
-    expect(animation.sawIntermediatePosition).toBe(true)
-    expect(animation.elapsedTime).toBeCloseTo(0.2, 2)
+    expect(animation).toBeCloseTo(0.2, 2)
   })
 
   test('ends up aligned with the selected tab', async ({ page, attachScreenshot }) => {
@@ -192,9 +176,11 @@ test.describe('subscriptions feed tab indicator', () => {
       }
     })
 
-    expect(Math.abs(indicator.x - tab.x)).toBeLessThan(1)
-    expect(Math.abs(indicator.width - tab.width)).toBeLessThan(1)
-    expect(Math.abs(indicator.top - tab.bottom)).toBeLessThan(1)
+    // Electron's 95% zoom produces fractional CSS-pixel geometry while the
+    // offset measurements used by the indicator are integer layout values.
+    expect(Math.abs(indicator.x - tab.x)).toBeLessThan(2)
+    expect(Math.abs(indicator.width - tab.width)).toBeLessThan(2)
+    expect(Math.abs(indicator.top - tab.bottom)).toBeLessThan(2)
     await attachScreenshot('indicator under the Shorts tab')
   })
 
@@ -249,6 +235,21 @@ test.describe('subscriptions feed tab indicator', () => {
     await expect(page.locator('[data-subscription-feed-tab="shorts"]'))
       .toHaveAttribute('aria-selected', 'true')
     await expect.poll(() => page.evaluate(() => window.scrollY)).toBe(0)
+  })
+
+  test('keeps pagination limits separate between feed tabs', async ({ page }) => {
+    await goTo(page, 'subscriptions')
+
+    const panelItems = page.locator('#subscriptionsPanel .autoGrid').first().locator(':scope > div')
+    await expect(panelItems).toHaveCount(100)
+    await page.getByRole('button', { name: 'Load More Videos' }).click()
+    await expect(panelItems).toHaveCount(150)
+
+    await page.locator('[data-subscription-feed-tab="shorts"]').click()
+    await expect(page.locator('[data-subscription-feed-tab="shorts"]'))
+      .toHaveAttribute('aria-selected', 'true')
+    await expect(panelItems).toHaveCount(100)
+    await expect(page.getByRole('button', { name: 'Load More Videos' })).toBeVisible()
   })
 
   test('restores the fallback feed scroll after a background visibility change', async ({ page }) => {

--- a/e2e/tests/offline/subscriptions-tab-indicator.spec.mjs
+++ b/e2e/tests/offline/subscriptions-tab-indicator.spec.mjs
@@ -155,6 +155,38 @@ test.describe('subscriptions feed tab indicator', () => {
     expect(animation).toBeCloseTo(0.2, 2)
   })
 
+  test('animates a cached feed when switching back to it', async ({ page }) => {
+    await goTo(page, 'subscriptions')
+
+    await expect(page.getByText('video video 000')).toBeVisible()
+    await page.locator('[data-subscription-feed-tab="all"]').click()
+    await expect(page.locator('#subscriptionsPanel.newFeed')).toBeVisible()
+
+    const hasEntryAnimation = await page.evaluate(() => new Promise(resolve => {
+      const target = document.querySelector('[data-subscription-feed-tab="videos"]')
+
+      function inspectFrame() {
+        if (target.getAttribute('aria-selected') !== 'true') {
+          requestAnimationFrame(inspectFrame)
+          return
+        }
+
+        requestAnimationFrame(() => {
+          const panel = document.querySelector('#subscriptionsPanel')
+          resolve(panel.getAnimations({ subtree: true }).some(animation => {
+            return animation.playState === 'running' &&
+              animation.effect.getComputedTiming().duration > 0
+          }))
+        })
+      }
+
+      target.click()
+      requestAnimationFrame(inspectFrame)
+    }))
+
+    expect(hasEntryAnimation).toBe(true)
+  })
+
   test('ends up aligned with the selected tab', async ({ page, attachScreenshot }) => {
     await goTo(page, 'subscriptions')
 

--- a/e2e/tests/offline/subscriptions-tab-indicator.spec.mjs
+++ b/e2e/tests/offline/subscriptions-tab-indicator.spec.mjs
@@ -155,14 +155,14 @@ test.describe('subscriptions feed tab indicator', () => {
     expect(animation).toBeCloseTo(0.2, 2)
   })
 
-  test('animates a cached feed when switching back to it', async ({ page }) => {
+  test('animates cached feed content when switching back to it', async ({ page }) => {
     await goTo(page, 'subscriptions')
 
     await expect(page.getByText('video video 000')).toBeVisible()
     await page.locator('[data-subscription-feed-tab="all"]').click()
     await expect(page.locator('#subscriptionsPanel.newFeed')).toBeVisible()
 
-    const hasEntryAnimation = await page.evaluate(() => new Promise(resolve => {
+    const animationTargetClass = await page.evaluate(() => new Promise(resolve => {
       const target = document.querySelector('[data-subscription-feed-tab="videos"]')
 
       function inspectFrame() {
@@ -173,9 +173,43 @@ test.describe('subscriptions feed tab indicator', () => {
 
         requestAnimationFrame(() => {
           const panel = document.querySelector('#subscriptionsPanel')
-          resolve(panel.getAnimations({ subtree: true }).some(animation => {
+          const animation = panel.getAnimations({ subtree: true }).find(animation => {
             return animation.playState === 'running' &&
               animation.effect.getComputedTiming().duration > 0
+          })
+          resolve(animation?.effect.target.className ?? null)
+        })
+      }
+
+      target.click()
+      requestAnimationFrame(inspectFrame)
+    }))
+
+    expect(animationTargetClass).toContain('autoGrid')
+  })
+
+  test('does not animate a cached empty-state message', async ({ page }) => {
+    await goTo(page, 'subscriptions')
+
+    await page.locator('[data-subscription-feed-tab="all"]').click()
+    await expect(page.getByText('There is no new content.')).toBeVisible()
+    await page.locator('[data-subscription-feed-tab="videos"]').click()
+    await expect(page.getByText('video video 000')).toBeVisible()
+
+    const messageIsAnimated = await page.evaluate(() => new Promise(resolve => {
+      const target = document.querySelector('[data-subscription-feed-tab="all"]')
+
+      function inspectFrame() {
+        if (target.getAttribute('aria-selected') !== 'true') {
+          requestAnimationFrame(inspectFrame)
+          return
+        }
+
+        requestAnimationFrame(() => {
+          const panel = document.querySelector('#subscriptionsPanel')
+          const message = panel.querySelector('.message')
+          resolve(panel.getAnimations({ subtree: true }).some(animation => {
+            return animation.effect.target === message || animation.effect.target.contains(message)
           }))
         })
       }
@@ -184,7 +218,40 @@ test.describe('subscriptions feed tab indicator', () => {
       requestAnimationFrame(inspectFrame)
     }))
 
-    expect(hasEntryAnimation).toBe(true)
+    expect(messageIsAnimated).toBe(false)
+  })
+
+  test('defers hidden feed cache updates until it is activated', async ({ page }) => {
+    await goTo(page, 'subscriptions')
+
+    await expect(page.getByText('video video 000')).toBeVisible()
+    const retainedPanel = await page.locator('#subscriptionsPanel').elementHandle()
+
+    await page.locator('[data-subscription-feed-tab="all"]').click()
+    await expect(page.locator('#subscriptionsPanel.newFeed')).toBeVisible()
+    await page.evaluate(channelId => {
+      const store = document.querySelector('#app').__vue_app__.config.globalProperties.$store
+      const replacement = {
+        ...store.getters.getVideoCache[channelId].videos[0],
+        videoId: 'background-update',
+        title: 'Background update'
+      }
+
+      store.commit('updateVideoCacheByChannel', {
+        channelId,
+        entries: [replacement],
+        timestamp: new Date()
+      })
+      window.dispatchEvent(new CustomEvent('opentubex-subscription-refresh-channel', {
+        detail: { tab: 'videos' }
+      }))
+    }, CHANNEL_ID)
+
+    await page.waitForTimeout(600)
+    expect(await retainedPanel.textContent()).not.toContain('Background update')
+
+    await page.locator('[data-subscription-feed-tab="videos"]').click()
+    await expect(page.getByText('Background update')).toBeVisible()
   })
 
   test('ends up aligned with the selected tab', async ({ page, attachScreenshot }) => {

--- a/e2e/tests/offline/subscriptions-tab-performance.spec.mjs
+++ b/e2e/tests/offline/subscriptions-tab-performance.spec.mjs
@@ -1,0 +1,104 @@
+import { test, expect, goTo } from '../../helpers/app.mjs'
+
+const now = Date.now()
+const channelCount = 600
+const videosPerChannel = 36
+
+const profiles = [{
+  _id: 'allChannels',
+  name: 'All Channels',
+  bgColor: '#000000',
+  textColor: '#FFFFFF',
+  subscriptions: Array.from({ length: channelCount }, (_, channelIndex) => ({
+    id: `UC${String(channelIndex).padStart(22, '0')}`,
+    name: `Channel ${channelIndex}`,
+    thumbnail: ''
+  }))
+}]
+
+const subscriptionCache = profiles[0].subscriptions.map((channel, channelIndex) => ({
+  _id: channel.id,
+  videos: Array.from({ length: videosPerChannel }, (_, videoIndex) => ({
+    videoId: `video-${channelIndex}-${videoIndex}`,
+    title: `Video ${channelIndex}-${videoIndex}`,
+    author: channel.name,
+    authorId: channel.id,
+    published: now - (videoIndex * channelCount + channelIndex) * 3600000,
+    viewCount: 1000,
+    lengthSeconds: 120,
+    liveNow: false,
+    isUpcoming: false,
+    isNewInSubscriptionFeed: true,
+    type: 'video'
+  })),
+  videosTimestamp: new Date(now).toISOString(),
+  shorts: [],
+  shortsTimestamp: new Date(now).toISOString()
+}))
+
+test.use({
+  seed: {
+    settings: {
+      fetchSubscriptionsAutomatically: false,
+      hideSubscriptionsVideos: false,
+      hideSubscriptionsShorts: true,
+      hideSubscriptionsLive: true,
+      hideSubscriptionsCommunity: true,
+      showNewSubscriptionFeed: true,
+      reducedMotion: 'off',
+      uiScale: 95
+    },
+    profiles,
+    subscriptionCache
+  }
+})
+
+async function measureVideosSwitch(page) {
+  return page.evaluate(() => new Promise(resolve => {
+    const target = document.querySelector('[data-subscription-feed-tab="videos"]')
+    const startedAt = performance.now()
+    let previousFrame = startedAt
+    let longestFrame = 0
+
+    function sampleFrame(timestamp) {
+      longestFrame = Math.max(longestFrame, timestamp - previousFrame)
+      previousFrame = timestamp
+
+      if (target.getAttribute('aria-selected') === 'true') {
+        requestAnimationFrame(finishedAt => resolve({
+          elapsed: finishedAt - startedAt,
+          longestFrame
+        }))
+        return
+      }
+
+      requestAnimationFrame(sampleFrame)
+    }
+
+    target.click()
+    requestAnimationFrame(sampleFrame)
+  }))
+}
+
+test('switches a production-sized cached feed without repeating expensive work', async ({ page }) => {
+  await goTo(page, 'trending')
+  await page.evaluate(() => localStorage.setItem('Subscriptions/currentTab', 'new'))
+  await goTo(page, 'subscriptions')
+
+  await expect(page.locator('#subscriptionsPanel.newFeed')).toBeVisible()
+
+  const firstSwitch = await measureVideosSwitch(page)
+
+  expect(firstSwitch.longestFrame).toBeLessThan(200)
+  expect(firstSwitch.elapsed).toBeLessThan(250)
+  await expect(page.getByText('Video 0-0')).toBeVisible()
+
+  await page.locator('[data-subscription-feed-tab="all"]').click()
+  await expect(page.locator('#subscriptionsPanel.newFeed')).toBeVisible()
+
+  const repeatedSwitch = await measureVideosSwitch(page)
+
+  expect(repeatedSwitch.longestFrame).toBeLessThan(100)
+  expect(repeatedSwitch.elapsed).toBeLessThan(150)
+  await expect(page.getByText('Video 0-0')).toBeVisible()
+})

--- a/e2e/tests/offline/subscriptions-tab-performance.spec.mjs
+++ b/e2e/tests/offline/subscriptions-tab-performance.spec.mjs
@@ -64,7 +64,11 @@ async function measureVideosSwitch(page) {
       longestFrame = Math.max(longestFrame, timestamp - previousFrame)
       previousFrame = timestamp
 
-      if (target.getAttribute('aria-selected') === 'true') {
+      const panel = document.querySelector('#subscriptionsPanel:not(.newFeed)')
+      const feedIsRendered = target.getAttribute('aria-selected') === 'true' &&
+        panel?.querySelector('.ft-list-video') !== null
+
+      if (feedIsRendered) {
         requestAnimationFrame(finishedAt => resolve({
           elapsed: finishedAt - startedAt,
           longestFrame

--- a/src/renderer/components/SubscriptionsLive.vue
+++ b/src/renderer/components/SubscriptionsLive.vue
@@ -18,6 +18,7 @@ import SubscriptionsTabUi from './SubscriptionsTabUi/SubscriptionsTabUi.vue'
 
 import store from '../store/index'
 
+import { useKeepAliveEffectScope } from '../composables/useKeepAliveEffectScope'
 import { useRelativeTimeClock } from '../composables/useRelativeTimeClock'
 import { useSubscriptionChannelUpdates } from '../composables/useSubscriptionChannelUpdates'
 import { getCachedRelativeTimeFormat, getCachedShortDateTimeFormat, getRelativeTimeFromDate } from '../helpers/utils'
@@ -28,6 +29,7 @@ import {
 
 const { locale, t } = useI18n()
 const tabUi = useTemplateRef('tabUi')
+useKeepAliveEffectScope()
 
 const isLoading = ref(true)
 const videoList = shallowRef([])

--- a/src/renderer/components/SubscriptionsNew.vue
+++ b/src/renderer/components/SubscriptionsNew.vue
@@ -80,12 +80,14 @@ import SubscriptionsTabUi from './SubscriptionsTabUi/SubscriptionsTabUi.vue'
 
 import store from '../store/index'
 
+import { useKeepAliveEffectScope } from '../composables/useKeepAliveEffectScope'
 import { useRefreshAllSubscriptionFeeds } from '../composables/useRefreshAllSubscriptionFeeds'
 import { isHistoryEntryWatched } from '../helpers/history'
 import { isVideoHiddenByPreferences } from '../helpers/subscriptions'
 
 const { t } = useI18n()
 const tabUi = useTemplateRef('tabUi')
+useKeepAliveEffectScope()
 const {
   activeSubscriptionIds,
   attemptedFetch,

--- a/src/renderer/components/SubscriptionsPosts.vue
+++ b/src/renderer/components/SubscriptionsPosts.vue
@@ -20,6 +20,7 @@ import SubscriptionsTabUi from './SubscriptionsTabUi/SubscriptionsTabUi.vue'
 
 import store from '../store/index'
 
+import { useKeepAliveEffectScope } from '../composables/useKeepAliveEffectScope'
 import { useRelativeTimeClock } from '../composables/useRelativeTimeClock'
 import { useSubscriptionChannelUpdates } from '../composables/useSubscriptionChannelUpdates'
 import { getCachedRelativeTimeFormat, getCachedShortDateTimeFormat, getRelativeTimeFromDate } from '../helpers/utils'
@@ -27,6 +28,7 @@ import { refreshSubscriptionPostsFromRemote } from '../helpers/subscriptions'
 
 const { locale, t } = useI18n()
 const tabUi = useTemplateRef('tabUi')
+useKeepAliveEffectScope()
 
 const isLoading = ref(true)
 const postList = shallowRef([])

--- a/src/renderer/components/SubscriptionsShorts.vue
+++ b/src/renderer/components/SubscriptionsShorts.vue
@@ -19,6 +19,7 @@ import SubscriptionsTabUi from './SubscriptionsTabUi/SubscriptionsTabUi.vue'
 
 import store from '../store/index'
 
+import { useKeepAliveEffectScope } from '../composables/useKeepAliveEffectScope'
 import { useRelativeTimeClock } from '../composables/useRelativeTimeClock'
 import { useSubscriptionChannelUpdates } from '../composables/useSubscriptionChannelUpdates'
 import {
@@ -29,6 +30,7 @@ import { getCachedRelativeTimeFormat, getCachedShortDateTimeFormat, getRelativeT
 
 const { locale, t } = useI18n()
 const tabUi = useTemplateRef('tabUi')
+useKeepAliveEffectScope()
 
 const isLoading = ref(true)
 const videoList = shallowRef([])

--- a/src/renderer/components/SubscriptionsTabUi/SubscriptionsTabUi.vue
+++ b/src/renderer/components/SubscriptionsTabUi/SubscriptionsTabUi.vue
@@ -1,5 +1,5 @@
 <template>
-  <div>
+  <div ref="root">
     <FtLoader
       v-if="displayIsLoading && activeVideoList.length === 0 && isCommunity"
     />
@@ -78,7 +78,16 @@
 </template>
 
 <script setup>
-import { computed, onActivated, onBeforeUnmount, onDeactivated, onMounted, reactive, ref } from 'vue'
+import {
+  computed,
+  onActivated,
+  onBeforeUnmount,
+  onDeactivated,
+  onMounted,
+  reactive,
+  ref,
+  useTemplateRef
+} from 'vue'
 
 import FtAutoLoadNextPageWrapper from '../FtAutoLoadNextPageWrapper.vue'
 import FtButton from '../FtButton/FtButton.vue'
@@ -91,12 +100,15 @@ import FtSkeletonGrid from '../FtSkeletonGrid/FtSkeletonGrid.vue'
 import store from '../../store/index'
 
 import { KeyboardShortcuts } from '../../../constants'
+import { applyAnimationSpeed } from '../../helpers/animationSpeed'
 import { isHistoryEntryWatched } from '../../helpers/history'
 import { matchesKeyboardShortcut } from '../../helpers/keyboardShortcuts'
+import { isReducedMotionEnabled } from '../../helpers/reducedMotion'
 import { isVideoHiddenByPreferences } from '../../helpers/subscriptions'
 import { useTabContext } from '../../tabs/TabContext'
 
 const { tabId, isTabPresented } = useTabContext()
+const root = useTemplateRef('root')
 
 const props = defineProps({
   isLoading: {
@@ -334,11 +346,42 @@ function removeKeyboardShortcutListener() {
   document.removeEventListener('keydown', keyboardShortcutHandler)
 }
 
-onMounted(addKeyboardShortcutListener)
-onActivated(addKeyboardShortcutListener)
-onDeactivated(removeKeyboardShortcutListener)
+let hasActivated = false
+/** @type {Animation | null} */
+let activationAnimation = null
 
-onBeforeUnmount(removeKeyboardShortcutListener)
+onMounted(addKeyboardShortcutListener)
+onActivated(() => {
+  addKeyboardShortcutListener()
+
+  if (!hasActivated) {
+    hasActivated = true
+    return
+  }
+
+  if (isReducedMotionEnabled()) {
+    return
+  }
+
+  activationAnimation?.cancel()
+  activationAnimation = applyAnimationSpeed(root.value.animate([
+    { opacity: 0, transform: 'translateY(10px)' },
+    { opacity: 1, transform: 'translateY(0)' }
+  ], {
+    duration: 300,
+    easing: 'ease'
+  }))
+})
+onDeactivated(() => {
+  removeKeyboardShortcutListener()
+  activationAnimation?.cancel()
+  activationAnimation = null
+})
+
+onBeforeUnmount(() => {
+  removeKeyboardShortcutListener()
+  activationAnimation?.cancel()
+})
 onBeforeUnmount(unsubscribeFromStore)
 
 function refresh() {

--- a/src/renderer/components/SubscriptionsTabUi/SubscriptionsTabUi.vue
+++ b/src/renderer/components/SubscriptionsTabUi/SubscriptionsTabUi.vue
@@ -99,6 +99,7 @@ import FtSkeletonGrid from '../FtSkeletonGrid/FtSkeletonGrid.vue'
 
 import store from '../../store/index'
 
+import { useKeepAliveEffectScope } from '../../composables/useKeepAliveEffectScope'
 import { KeyboardShortcuts } from '../../../constants'
 import { applyAnimationSpeed } from '../../helpers/animationSpeed'
 import { isHistoryEntryWatched } from '../../helpers/history'
@@ -109,6 +110,7 @@ import { useTabContext } from '../../tabs/TabContext'
 
 const { tabId, isTabPresented } = useTabContext()
 const root = useTemplateRef('root')
+useKeepAliveEffectScope()
 
 const props = defineProps({
   isLoading: {
@@ -171,9 +173,15 @@ const subscriptionLimit = sessionStorage.getItem(subscriptionLimitStorageKey)
 
 const dataLimit = ref(subscriptionLimit !== null ? parseInt(subscriptionLimit) : props.initialDataLimit)
 const subscriptionEntryVersion = ref(0)
+let subscriptionEntryUpdatePending = false
+let isActive = true
 const unsubscribeFromStore = store.subscribe((mutation) => {
   if (mutation.type === 'markSubscriptionEntriesAsSeenInCache') {
-    subscriptionEntryVersion.value++
+    if (isActive) {
+      subscriptionEntryVersion.value++
+    } else {
+      subscriptionEntryUpdatePending = true
+    }
   }
 })
 
@@ -347,12 +355,23 @@ function removeKeyboardShortcutListener() {
 }
 
 let hasActivated = false
-/** @type {Animation | null} */
-let activationAnimation = null
+/** @type {Animation[]} */
+let activationAnimations = []
+
+function cancelActivationAnimations() {
+  activationAnimations.forEach(animation => animation.cancel())
+  activationAnimations = []
+}
 
 onMounted(addKeyboardShortcutListener)
 onActivated(() => {
+  isActive = true
   addKeyboardShortcutListener()
+
+  if (subscriptionEntryUpdatePending) {
+    subscriptionEntryUpdatePending = false
+    subscriptionEntryVersion.value++
+  }
 
   if (!hasActivated) {
     hasActivated = true
@@ -363,24 +382,26 @@ onActivated(() => {
     return
   }
 
-  activationAnimation?.cancel()
-  activationAnimation = applyAnimationSpeed(root.value.animate([
-    { opacity: 0, transform: 'translateY(10px)' },
-    { opacity: 1, transform: 'translateY(0)' }
-  ], {
-    duration: 300,
-    easing: 'ease'
-  }))
+  cancelActivationAnimations()
+  activationAnimations = Array.from(root.value.querySelectorAll('.autoGrid'))
+    .filter(grid => grid.childElementCount > 0)
+    .map(grid => applyAnimationSpeed(grid.animate([
+      { opacity: 0, transform: 'translateY(10px)' },
+      { opacity: 1, transform: 'translateY(0)' }
+    ], {
+      duration: 300,
+      easing: 'ease'
+    })))
 })
 onDeactivated(() => {
+  isActive = false
   removeKeyboardShortcutListener()
-  activationAnimation?.cancel()
-  activationAnimation = null
+  cancelActivationAnimations()
 })
 
 onBeforeUnmount(() => {
   removeKeyboardShortcutListener()
-  activationAnimation?.cancel()
+  cancelActivationAnimations()
 })
 onBeforeUnmount(unsubscribeFromStore)
 

--- a/src/renderer/components/SubscriptionsTabUi/SubscriptionsTabUi.vue
+++ b/src/renderer/components/SubscriptionsTabUi/SubscriptionsTabUi.vue
@@ -78,7 +78,7 @@
 </template>
 
 <script setup>
-import { computed, onBeforeUnmount, onMounted, ref } from 'vue'
+import { computed, onActivated, onBeforeUnmount, onDeactivated, onMounted, reactive, ref } from 'vue'
 
 import FtAutoLoadNextPageWrapper from '../FtAutoLoadNextPageWrapper.vue'
 import FtButton from '../FtButton/FtButton.vue'
@@ -97,7 +97,6 @@ import { isVideoHiddenByPreferences } from '../../helpers/subscriptions'
 import { useTabContext } from '../../tabs/TabContext'
 
 const { tabId, isTabPresented } = useTabContext()
-const subscriptionLimitStorageKey = tabId ? `Subscriptions/${tabId}/dataLimit` : 'subscriptionLimit'
 
 const props = defineProps({
   isLoading: {
@@ -152,16 +151,31 @@ const props = defineProps({
 
 const emit = defineEmits(['refresh'])
 
+const paginationKey = props.refreshTab ?? (props.onlyShowNew ? 'new' : 'subscriptions')
+const subscriptionLimitStorageKey = tabId
+  ? `Subscriptions/${tabId}/${paginationKey}/dataLimit`
+  : `subscriptionLimit/${paginationKey}`
 const subscriptionLimit = sessionStorage.getItem(subscriptionLimitStorageKey)
 
 const dataLimit = ref(subscriptionLimit !== null ? parseInt(subscriptionLimit) : props.initialDataLimit)
+const subscriptionEntryVersion = ref(0)
+const unsubscribeFromStore = store.subscribe((mutation) => {
+  if (mutation.type === 'markSubscriptionEntriesAsSeenInCache') {
+    subscriptionEntryVersion.value++
+  }
+})
 
 const activeVideoList = computed(() => {
+  let activeEntries
   if (filteredVideoList.value.length < dataLimit.value) {
-    return filteredVideoList.value
+    activeEntries = filteredVideoList.value
   } else {
-    return filteredVideoList.value.slice(0, dataLimit.value)
+    activeEntries = filteredVideoList.value.slice(0, dataLimit.value)
   }
+
+  // Only the rendered page needs field-level reactivity. Tracking every field
+  // in a large cached feed makes mounting the tab scale with the full cache.
+  return activeEntries.map(entry => reactive(entry))
 })
 
 const activeProfileHasSubscriptions = computed(() => {
@@ -211,7 +225,11 @@ const hideUpcomingPremieres = computed(() => store.getters.getHideUpcomingPremie
 const forbiddenTitles = computed(() => store.getters.getForbiddenTitlesParsed)
 
 const filteredVideoList = computed(() => {
-  let videoList = props.videoList
+  // Copy after in-place cache mutations so the rendered page receives fresh
+  // props even though the full cached array stays non-reactive.
+  let videoList = subscriptionEntryVersion.value === 0
+    ? props.videoList
+    : props.videoList.slice()
 
   // Subscription feeds intentionally ignore the general hidden-channel list.
   videoList = videoList.filter(video => !isVideoHiddenByPreferences(video, {
@@ -308,13 +326,20 @@ function keyboardShortcutHandler(event) {
   }
 }
 
-onMounted(() => {
+function addKeyboardShortcutListener() {
   document.addEventListener('keydown', keyboardShortcutHandler)
-})
+}
 
-onBeforeUnmount(() => {
+function removeKeyboardShortcutListener() {
   document.removeEventListener('keydown', keyboardShortcutHandler)
-})
+}
+
+onMounted(addKeyboardShortcutListener)
+onActivated(addKeyboardShortcutListener)
+onDeactivated(removeKeyboardShortcutListener)
+
+onBeforeUnmount(removeKeyboardShortcutListener)
+onBeforeUnmount(unsubscribeFromStore)
 
 function refresh() {
   emit('refresh')

--- a/src/renderer/components/SubscriptionsTabUi/SubscriptionsTabUi.vue
+++ b/src/renderer/components/SubscriptionsTabUi/SubscriptionsTabUi.vue
@@ -100,6 +100,7 @@ import FtSkeletonGrid from '../FtSkeletonGrid/FtSkeletonGrid.vue'
 import store from '../../store/index'
 
 import { useKeepAliveEffectScope } from '../../composables/useKeepAliveEffectScope'
+import { useSubscriptionEntryVersion } from '../../composables/useSubscriptionEntryVersion'
 import { KeyboardShortcuts } from '../../../constants'
 import { applyAnimationSpeed } from '../../helpers/animationSpeed'
 import { isHistoryEntryWatched } from '../../helpers/history'
@@ -172,18 +173,7 @@ const subscriptionLimitStorageKey = tabId
 const subscriptionLimit = sessionStorage.getItem(subscriptionLimitStorageKey)
 
 const dataLimit = ref(subscriptionLimit !== null ? parseInt(subscriptionLimit) : props.initialDataLimit)
-const subscriptionEntryVersion = ref(0)
-let subscriptionEntryUpdatePending = false
-let isActive = true
-const unsubscribeFromStore = store.subscribe((mutation) => {
-  if (mutation.type === 'markSubscriptionEntriesAsSeenInCache') {
-    if (isActive) {
-      subscriptionEntryVersion.value++
-    } else {
-      subscriptionEntryUpdatePending = true
-    }
-  }
-})
+const subscriptionEntryVersion = useSubscriptionEntryVersion()
 
 const activeVideoList = computed(() => {
   let activeEntries
@@ -365,13 +355,7 @@ function cancelActivationAnimations() {
 
 onMounted(addKeyboardShortcutListener)
 onActivated(() => {
-  isActive = true
   addKeyboardShortcutListener()
-
-  if (subscriptionEntryUpdatePending) {
-    subscriptionEntryUpdatePending = false
-    subscriptionEntryVersion.value++
-  }
 
   if (!hasActivated) {
     hasActivated = true
@@ -394,7 +378,6 @@ onActivated(() => {
     })))
 })
 onDeactivated(() => {
-  isActive = false
   removeKeyboardShortcutListener()
   cancelActivationAnimations()
 })
@@ -403,7 +386,6 @@ onBeforeUnmount(() => {
   removeKeyboardShortcutListener()
   cancelActivationAnimations()
 })
-onBeforeUnmount(unsubscribeFromStore)
 
 function refresh() {
   emit('refresh')

--- a/src/renderer/components/SubscriptionsVideos.vue
+++ b/src/renderer/components/SubscriptionsVideos.vue
@@ -11,7 +11,7 @@
 </template>
 
 <script setup>
-import { computed, onBeforeUnmount, onMounted, ref, shallowRef, useTemplateRef, watch } from 'vue'
+import { computed, onBeforeUnmount, onMounted, ref, shallowRef, toRaw, useTemplateRef, watch } from 'vue'
 import { useI18n } from 'vue-i18n'
 
 import SubscriptionsTabUi from './SubscriptionsTabUi/SubscriptionsTabUi.vue'
@@ -73,10 +73,18 @@ const cacheEntriesForAllActiveProfileChannels = computed(() => {
 })
 
 const nextUpcomingPremiereTimestamp = computed(() => {
+  // Cache refreshes can introduce a new upcoming premiere while this component
+  // remains mounted. Read the timestamp so this scan reruns after each refresh.
+  const refreshTimestamp = store.getters.getSubscriptionFeedLastRefreshTimestamp
+  const cacheEntries = cacheEntriesForAllActiveProfileChannels.value
+  if (!refreshTimestamp && cacheEntries.length === 0) {
+    return null
+  }
+
   let nextTimestamp = null
 
-  for (const cacheEntry of cacheEntriesForAllActiveProfileChannels.value) {
-    for (const video of cacheEntry.videos ?? []) {
+  for (const cacheEntry of cacheEntries) {
+    for (const video of toRaw(cacheEntry).videos ?? []) {
       const timestamp = getUpcomingPremiereTimestamp(video)
 
       if (
@@ -277,9 +285,10 @@ function loadVideosFromCacheSometimes() {
 
 function loadVideosFromCacheForAllActiveProfileChannels() {
   const videoList_ = cacheEntriesForAllActiveProfileChannels.value.flatMap((cacheEntry) => {
-    const cacheTimestamp = new Date(cacheEntry.timestamp).getTime()
+    const rawCacheEntry = toRaw(cacheEntry)
+    const cacheTimestamp = new Date(rawCacheEntry.timestamp).getTime()
 
-    return (cacheEntry.videos ?? []).map(video => {
+    return (rawCacheEntry.videos ?? []).map(video => {
       return ensureUpcomingSubscriptionFeedPublished(
         video,
         cacheTimestamp,

--- a/src/renderer/components/SubscriptionsVideos.vue
+++ b/src/renderer/components/SubscriptionsVideos.vue
@@ -11,13 +11,25 @@
 </template>
 
 <script setup>
-import { computed, onBeforeUnmount, onMounted, ref, shallowRef, toRaw, useTemplateRef, watch } from 'vue'
+import {
+  computed,
+  onActivated,
+  onBeforeUnmount,
+  onDeactivated,
+  onMounted,
+  ref,
+  shallowRef,
+  toRaw,
+  useTemplateRef,
+  watch
+} from 'vue'
 import { useI18n } from 'vue-i18n'
 
 import SubscriptionsTabUi from './SubscriptionsTabUi/SubscriptionsTabUi.vue'
 
 import store from '../store/index'
 
+import { useKeepAliveEffectScope } from '../composables/useKeepAliveEffectScope'
 import { useRelativeTimeClock } from '../composables/useRelativeTimeClock'
 import { useSubscriptionChannelUpdates } from '../composables/useSubscriptionChannelUpdates'
 import {
@@ -32,6 +44,7 @@ import {
 
 const { locale, t } = useI18n()
 const tabUi = useTemplateRef('tabUi')
+useKeepAliveEffectScope()
 
 const isLoading = ref(true)
 const videoList = shallowRef([])
@@ -126,11 +139,16 @@ function scheduleNextPremiereUpdate(timestamp) {
   }, Math.min(Math.max(timestamp - Date.now(), 0), MAX_TIMEOUT_MS))
 }
 
-onBeforeUnmount(() => {
+function clearPremiereUpdateTimer() {
   if (premiereUpdateTimer !== null) {
     clearTimeout(premiereUpdateTimer)
+    premiereUpdateTimer = null
   }
-})
+}
+
+onActivated(() => scheduleNextPremiereUpdate(nextUpcomingPremiereTimestamp.value))
+onDeactivated(clearPremiereUpdateTimer)
+onBeforeUnmount(clearPremiereUpdateTimer)
 
 const videoCacheForAllActiveProfileChannelsPresent = computed(() => {
   if (

--- a/src/renderer/composables/useKeepAliveEffectScope.js
+++ b/src/renderer/composables/useKeepAliveEffectScope.js
@@ -1,0 +1,13 @@
+import { getCurrentScope, onActivated, onDeactivated } from 'vue'
+
+/**
+ * KeepAlive preserves component state, but Vue continues running the retained
+ * component's reactive effects while its DOM is detached. Pause those effects
+ * until the component is visible again.
+ */
+export function useKeepAliveEffectScope() {
+  const scope = getCurrentScope()
+
+  onActivated(() => scope?.resume())
+  onDeactivated(() => scope?.pause())
+}

--- a/src/renderer/composables/useRelativeTimeClock.js
+++ b/src/renderer/composables/useRelativeTimeClock.js
@@ -1,4 +1,4 @@
-import { computed, onBeforeUnmount, onMounted, ref, watch } from 'vue'
+import { computed, onActivated, onBeforeUnmount, onDeactivated, onMounted, ref, watch } from 'vue'
 
 import store from '../store/index'
 
@@ -39,6 +39,23 @@ function stopClock() {
 export function useRelativeTimeClock() {
   const frozenNow = ref(Date.now())
   const updatesEnabled = computed(() => store.getters.getUpdateRelativeTimestamps)
+  let active = false
+
+  function activate() {
+    if (active) return
+
+    active = true
+    subscriberCount += 1
+    if (updatesEnabled.value) startClock()
+  }
+
+  function deactivate() {
+    if (!active) return
+
+    active = false
+    subscriberCount -= 1
+    if (subscriberCount === 0) stopClock()
+  }
 
   watch(updatesEnabled, (enabled) => {
     if (enabled && subscriberCount > 0) {
@@ -49,15 +66,10 @@ export function useRelativeTimeClock() {
     }
   })
 
-  onMounted(() => {
-    subscriberCount += 1
-    if (updatesEnabled.value) startClock()
-  })
-
-  onBeforeUnmount(() => {
-    subscriberCount -= 1
-    if (subscriberCount === 0) stopClock()
-  })
+  onMounted(activate)
+  onActivated(activate)
+  onDeactivated(deactivate)
+  onBeforeUnmount(deactivate)
 
   return computed(() => updatesEnabled.value ? now.value : frozenNow.value)
 }

--- a/src/renderer/composables/useSubscriptionChannelUpdates.js
+++ b/src/renderer/composables/useSubscriptionChannelUpdates.js
@@ -1,4 +1,4 @@
-import { onActivated, onBeforeUnmount, onDeactivated, onMounted, watch } from 'vue'
+import { onActivated, onBeforeUnmount, onDeactivated, reactive, watch } from 'vue'
 
 import { SUBSCRIPTION_REFRESH_CHANNEL_EVENT } from '../helpers/subscriptions'
 import { useTabContext } from '../tabs/TabContext'
@@ -6,6 +6,18 @@ import { useTabContext } from '../tabs/TabContext'
 // Rebuilding and sorting the whole feed for every channel would be wasteful
 // with hundreds of subscriptions, so updates are coalesced.
 const FEED_UPDATE_INTERVAL_MS = 500
+const updateVersions = reactive({
+  videos: 0,
+  shorts: 0,
+  live: 0,
+  posts: 0
+})
+
+window.addEventListener(SUBSCRIPTION_REFRESH_CHANNEL_EVENT, (event) => {
+  if (event.detail.tab in updateVersions) {
+    updateVersions[event.detail.tab]++
+  }
+})
 
 /**
  * Runs the callback while a refresh of the given feed is in progress, whenever
@@ -45,17 +57,10 @@ export function useSubscriptionChannelUpdates(tab, onChannelsRefreshed) {
     timeout = setTimeout(run, Math.max(remaining, 0))
   }
 
-  /**
-   * @param {CustomEvent<{tab: string}>} event
-   */
-  function handleChannelRefreshed(event) {
-    if (event.detail.tab !== tab) {
-      return
-    }
-
+  watch(() => updateVersions[tab], () => {
     updatePending = true
     schedule()
-  }
+  })
 
   if (isTabPresented !== null) {
     watch(isTabPresented, (presented) => {
@@ -72,14 +77,6 @@ export function useSubscriptionChannelUpdates(tab, onChannelsRefreshed) {
       }
     })
   }
-
-  onMounted(() => {
-    window.addEventListener(SUBSCRIPTION_REFRESH_CHANNEL_EVENT, handleChannelRefreshed)
-
-    if (updatePending) {
-      schedule()
-    }
-  })
 
   onActivated(() => {
     isActive = true
@@ -99,7 +96,6 @@ export function useSubscriptionChannelUpdates(tab, onChannelsRefreshed) {
   })
 
   onBeforeUnmount(() => {
-    window.removeEventListener(SUBSCRIPTION_REFRESH_CHANNEL_EVENT, handleChannelRefreshed)
     clearTimeout(timeout)
   })
 }

--- a/src/renderer/composables/useSubscriptionChannelUpdates.js
+++ b/src/renderer/composables/useSubscriptionChannelUpdates.js
@@ -1,4 +1,4 @@
-import { onBeforeUnmount, onMounted, watch } from 'vue'
+import { onActivated, onBeforeUnmount, onDeactivated, onMounted, watch } from 'vue'
 
 import { SUBSCRIPTION_REFRESH_CHANNEL_EVENT } from '../helpers/subscriptions'
 import { useTabContext } from '../tabs/TabContext'
@@ -18,6 +18,7 @@ export function useSubscriptionChannelUpdates(tab, onChannelsRefreshed) {
   let timeout = null
   let lastRun = 0
   let updatePending = false
+  let isActive = true
 
   function isPresented() {
     return isTabPresented?.value !== false
@@ -26,7 +27,7 @@ export function useSubscriptionChannelUpdates(tab, onChannelsRefreshed) {
   function run() {
     timeout = null
 
-    if (!isPresented()) {
+    if (!isActive || !isPresented()) {
       return
     }
 
@@ -36,7 +37,7 @@ export function useSubscriptionChannelUpdates(tab, onChannelsRefreshed) {
   }
 
   function schedule() {
-    if (!isPresented() || timeout !== null) {
+    if (!isActive || !isPresented() || timeout !== null) {
       return
     }
 
@@ -77,6 +78,23 @@ export function useSubscriptionChannelUpdates(tab, onChannelsRefreshed) {
 
     if (updatePending) {
       schedule()
+    }
+  })
+
+  onActivated(() => {
+    isActive = true
+
+    if (updatePending) {
+      schedule()
+    }
+  })
+
+  onDeactivated(() => {
+    isActive = false
+
+    if (timeout !== null) {
+      clearTimeout(timeout)
+      timeout = null
     }
   })
 

--- a/src/renderer/composables/useSubscriptionEntryVersion.js
+++ b/src/renderer/composables/useSubscriptionEntryVersion.js
@@ -3,9 +3,14 @@ import { readonly, ref } from 'vue'
 import store from '../store/index'
 
 const version = ref(0)
+const seenMutationTypes = new Set([
+  'markSubscriptionEntriesAsSeenInCache',
+  'markSubscriptionPostAsSeenByChannel',
+  'markSubscriptionVideoAsSeenByChannel'
+])
 
 store.subscribe((mutation) => {
-  if (mutation.type === 'markSubscriptionEntriesAsSeenInCache') {
+  if (seenMutationTypes.has(mutation.type)) {
     version.value++
   }
 })

--- a/src/renderer/composables/useSubscriptionEntryVersion.js
+++ b/src/renderer/composables/useSubscriptionEntryVersion.js
@@ -1,0 +1,19 @@
+import { readonly, ref } from 'vue'
+
+import store from '../store/index'
+
+const version = ref(0)
+
+store.subscribe((mutation) => {
+  if (mutation.type === 'markSubscriptionEntriesAsSeenInCache') {
+    version.value++
+  }
+})
+
+/**
+ * Returns one shared cache-mutation signal for every subscription panel.
+ * Paused KeepAlive scopes consume the latest version when reactivated.
+ */
+export function useSubscriptionEntryVersion() {
+  return readonly(version)
+}

--- a/src/renderer/views/Subscriptions/Subscriptions.vue
+++ b/src/renderer/views/Subscriptions/Subscriptions.vue
@@ -46,7 +46,7 @@
                 aria-controls="subscriptionsPanel"
                 data-subscription-feed-tab="videos"
                 :tabindex="currentTab === 'videos' ? 0 : -1"
-                :class="{ selectedTab: currentTab === 'videos' }"
+                :class="{ selectedTab: selectedTab === 'videos' }"
                 @click="changeTabFromPointer($event, 'videos')"
                 @keydown.space.enter.prevent="changeTab('videos')"
                 @keydown.left.right="switchTab($event, 'videos')"
@@ -74,7 +74,7 @@
                 aria-controls="subscriptionsPanel"
                 data-subscription-feed-tab="shorts"
                 :tabindex="currentTab === 'shorts' ? 0 : -1"
-                :class="{ selectedTab: currentTab === 'shorts' }"
+                :class="{ selectedTab: selectedTab === 'shorts' }"
                 @click="changeTabFromPointer($event, 'shorts')"
                 @keydown.space.enter.prevent="changeTab('shorts')"
                 @keydown.left.right="switchTab($event, 'shorts')"
@@ -102,7 +102,7 @@
                 aria-controls="subscriptionsPanel"
                 data-subscription-feed-tab="live"
                 :tabindex="currentTab === 'live' ? 0 : -1"
-                :class="{ selectedTab: currentTab === 'live' }"
+                :class="{ selectedTab: selectedTab === 'live' }"
                 @click="changeTabFromPointer($event, 'live')"
                 @keydown.space.enter.prevent="changeTab('live')"
                 @keydown.left.right="switchTab($event, 'live')"
@@ -130,7 +130,7 @@
                 aria-controls="subscriptionsPanel"
                 data-subscription-feed-tab="posts"
                 :tabindex="currentTab === 'community' ? 0 : -1"
-                :class="{ selectedTab: currentTab === 'community' }"
+                :class="{ selectedTab: selectedTab === 'community' }"
                 @click="changeTabFromPointer($event, 'community')"
                 @keydown.space.enter.prevent="changeTab('community')"
                 @keydown.left.right="switchTab($event, 'community')"
@@ -158,7 +158,7 @@
                 aria-controls="subscriptionsPanel"
                 data-subscription-feed-tab="all"
                 :tabindex="currentTab === 'new' ? 0 : -1"
-                :class="{ selectedTab: currentTab === 'new' }"
+                :class="{ selectedTab: selectedTab === 'new' }"
                 @click="changeTabFromPointer($event, 'new')"
                 @keydown.space.enter.prevent="changeTab('new')"
                 @keydown.left.right="switchTab($event, 'new')"
@@ -215,42 +215,44 @@
           </div>
         </div>
       </div>
-      <SubscriptionsVideos
-        v-if="currentTab === 'videos'"
-        id="subscriptionsPanel"
-        key="subscriptions-videos"
-        ref="videosPanel"
-        role="tabpanel"
-      />
-      <SubscriptionsShorts
-        v-else-if="currentTab === 'shorts'"
-        id="subscriptionsPanel"
-        key="subscriptions-shorts"
-        ref="shortsPanel"
-        role="tabpanel"
-      />
-      <SubscriptionsLive
-        v-else-if="currentTab === 'live'"
-        id="subscriptionsPanel"
-        key="subscriptions-live"
-        ref="livePanel"
-        role="tabpanel"
-      />
-      <SubscriptionsPosts
-        v-else-if="currentTab === 'community'"
-        id="subscriptionsPanel"
-        key="subscriptions-community"
-        ref="communityPanel"
-        role="tabpanel"
-      />
-      <SubscriptionsNew
-        v-else-if="currentTab === 'new'"
-        id="subscriptionsPanel"
-        key="subscriptions-new"
-        ref="newPanel"
-        role="tabpanel"
-      />
-      <p v-else>
+      <KeepAlive>
+        <SubscriptionsVideos
+          v-if="currentTab === 'videos'"
+          id="subscriptionsPanel"
+          key="subscriptions-videos"
+          ref="videosPanel"
+          role="tabpanel"
+        />
+        <SubscriptionsShorts
+          v-else-if="currentTab === 'shorts'"
+          id="subscriptionsPanel"
+          key="subscriptions-shorts"
+          ref="shortsPanel"
+          role="tabpanel"
+        />
+        <SubscriptionsLive
+          v-else-if="currentTab === 'live'"
+          id="subscriptionsPanel"
+          key="subscriptions-live"
+          ref="livePanel"
+          role="tabpanel"
+        />
+        <SubscriptionsPosts
+          v-else-if="currentTab === 'community'"
+          id="subscriptionsPanel"
+          key="subscriptions-community"
+          ref="communityPanel"
+          role="tabpanel"
+        />
+        <SubscriptionsNew
+          v-else-if="currentTab === 'new'"
+          id="subscriptionsPanel"
+          key="subscriptions-new"
+          ref="newPanel"
+          role="tabpanel"
+        />
+      </KeepAlive>
+      <p v-if="currentTab === null">
         {{ $t("Subscriptions.All Subscription Tabs Hidden", {
           subsection: $t('Settings.Distraction Free Settings.Sections.Subscriptions Page'),
           settingsSection: $t('Settings.Distraction Free Settings.Distraction Free Settings')
@@ -390,6 +392,8 @@ const currentTabRefreshing = computed(() => {
 
 /** @type {import('vue').Ref<'videos' | 'shorts' | 'live' | 'community' | 'new' | null>} */
 const currentTab = ref('videos')
+const selectedTab = ref('videos')
+let tabChangeSequence = 0
 
 const tabScrollPositions = {
   videos: 0,
@@ -483,6 +487,7 @@ onMounted(() => {
 
 onBeforeUnmount(() => {
   isMounted = false
+  tabChangeSequence++
   document.removeEventListener('keydown', handlePanelTabNavigation)
   removeFeedReloadRequestListener?.()
 })
@@ -557,13 +562,16 @@ const visibleTabs = computed(() => {
 
 watch(visibleTabs, (value) => {
   if (value.length === 0) {
+    tabChangeSequence++
+    selectedTab.value = null
     currentTab.value = null
-  } else if (!value.includes(currentTab.value)) {
+  } else if (!value.includes(selectedTab.value)) {
     changeTab(value[0])
   }
 })
 
 if (visibleTabs.value.length === 0) {
+  selectedTab.value = null
   currentTab.value = null
 } else {
   // Restore currentTab
@@ -571,6 +579,7 @@ if (visibleTabs.value.length === 0) {
   if (lastCurrentTabId !== null) {
     changeTab(lastCurrentTabId)
   } else if (!visibleTabs.value.includes(currentTab.value)) {
+    selectedTab.value = visibleTabs.value[0]
     currentTab.value = visibleTabs.value[0]
   }
 }
@@ -584,13 +593,39 @@ function changeTab(tab) {
     ? tab
     : (visibleTabs.value.length > 0 ? visibleTabs.value[0] : null)
 
+  if (target === selectedTab.value) {
+    return
+  }
+
+  selectedTab.value = target
+  const sequence = ++tabChangeSequence
+
+  if (
+    !isMounted ||
+    target === null ||
+    (isElectron && isTabPresented?.value !== true)
+  ) {
+    currentTab.value = target
+    return
+  }
+
   if (target === currentTab.value) {
     return
   }
 
-  // The feed is the primary response to activating a tab. Keep the indicator
-  // animation decorative so it never delays the panel change.
-  currentTab.value = target
+  // Give the selected label and indicator one paint before mounting the feed.
+  // The panel follows on the next painted frame instead of waiting for the
+  // indicator's 200ms transition.
+  nextTick(async () => {
+    await nextAnimationFrame()
+    await nextAnimationFrame()
+
+    if (sequence !== tabChangeSequence || !isMounted) {
+      return
+    }
+
+    currentTab.value = target
+  })
 }
 
 /**
@@ -791,7 +826,7 @@ function handlePanelTabNavigation(event) {
     return
   }
 
-  switchTab(event, currentTab.value, false)
+  switchTab(event, selectedTab.value, false)
 }
 
 function refreshCurrentTab() {
@@ -966,7 +1001,7 @@ function updateTabsIndicator() {
   placeTabsIndicator(selected)
 }
 
-watch([currentTab, visibleTabs, refreshingFeedTab], () => nextTick(updateTabsIndicator))
+watch([selectedTab, visibleTabs, refreshingFeedTab], () => nextTick(updateTabsIndicator))
 
 onMounted(() => {
   if (typeof ResizeObserver === 'function') {


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Make sure to follow the contributing guidelines. -->
<!-- Important note, we may remove your pull request if you do not use this provided PR template correctly. -->
<!-- Agent instructions: Preserve every heading, comment, and marker in this template. Never remove or rewrite the release-note-category:start/end, release-note:start/end, or release-note-image:start/end marker pairs. Never remove or rewrite the Release note images section; leave its contents for a human. -->

## Pull Request Type
<!-- Please select what type of pull request this is: [x] -->
- [x] Bugfix
- [ ] Feature Implementation
- [ ] Documentation
- [ ] Other

## Related issue
<!-- Please link the issue your pull request is referring to. -->
<!-- If this pull request fully resolves the relevant issue, put "closes" before the issue number. -->
<!-- Example: "closes #123456". -->

Follow-up to #835.

## Description
<!-- Please write a clear and concise description of what the pull request does. -->

Switching from the New subscriptions feed to Videos could still leave the interface unresponsive while a large cached feed mounted. The pagination limit only capped rendered cards. Videos still traversed and sorted the full cache, and Vue tracked fields on every cached entry.

This keeps field-level reactivity limited to the rendered page and reads the full cache without deep dependency tracking. Feed panels are cached after their first visit, so returning to a feed does not rebuild it. Unvisited feeds remain unmounted. Pagination state is now separate for each feed, preventing a larger limit from one feed from making another feed mount extra cards.

The selected tab and indicator still paint before the panel change introduced in #835.

## Release note category
<!-- Select exactly one category. Every pull request must select one. -->
<!-- Select "Not noteworthy" when the pull request fixes a bug in or improves functionality that has not yet appeared in a stable release. -->
<!-- release-note-category:start -->
- [x] Not noteworthy
- [ ] Highlights
- [ ] More improvements
- [ ] Fixed bugs
<!-- release-note-category:end -->

## Release note
<!-- Required unless "Not noteworthy" is selected. -->
<!-- Write one concise, user-facing entry without a leading bullet. -->
<!-- release-note:start -->

<!-- release-note:end -->

## Release note images
<!-- Human-only: Agents must preserve this entire section and leave it empty. -->
<!-- Optional. Paste one or more Markdown images or HTML image tags here. -->
<!-- The release notes will use an HTML image tag and limit images taller than 300 pixels. -->
<!-- release-note-image:start -->

<!-- release-note-image:end -->

## Testing
<!-- How can reviewers verify that the PR produces correct results? -->
<!-- Please provide instructions so that others can ensure that your pull request would produce correct results. For examples see, https://github.com/FreeTubeApp/FreeTube/pull/5743, https://github.com/FreeTubeApp/FreeTube/pull/7349, https://github.com/FreeTubeApp/FreeTube/pull/5125, https://github.com/FreeTubeApp/FreeTube/pull/7338 -->
<!-- Agent instructions: Only write human-facing steps that explain how to verify the change while running this branch in dev mode. Include expected results and, when applicable, helpful console snippets for interactive verification. Do not include automated checks, commands, results, pass counts, or CI status. -->

1. Run this branch in dev mode with a profile that has a large subscription cache.
2. Open Subscriptions, select New, then switch to Videos. The tab label and indicator should respond immediately, followed by the Videos panel without the previous long pause.
3. Switch between New and Videos several times. Returning to either visited feed should be faster than its first visit.
4. Load more items in Videos, then visit Shorts for the first time. Shorts should start at its own initial page size instead of inheriting the Videos limit.

## Additional context
<!-- Add any other context about the pull request here. -->

The production-sized regression fixture contains 21,600 cached videos and runs at 95% UI scale.
