### PR TITLE
fix(color-picker): preserve hue when dragging outside color area

### DIFF
--- a/e2e/tests/offline/appearance.spec.mjs
+++ b/e2e/tests/offline/appearance.spec.mjs
@@ -335,6 +335,30 @@ test.describe('custom theme editor', () => {
     await expect(trigger).toBeFocused()
   })
 
+  test('keeps the hue when dragging outside the saturation and brightness area', async ({ page }) => {
+    await goToSettingsSection(page, 'theme')
+    await page.getByRole('button', { name: 'Create custom theme' }).click()
+    await page.getByRole('button', { name: 'Page background', exact: true }).click()
+
+    const picker = page.getByRole('dialog', { name: 'Page background' })
+    const hexInput = picker.getByRole('textbox', { name: 'Hex color' })
+    const hueSlider = picker.locator('.hueSlider')
+    await hexInput.fill('#00ff00')
+    await hexInput.press('Enter')
+    await expect(hueSlider).toHaveValue('120')
+
+    const saturationSlider = picker.getByRole('slider', { name: 'Saturation and brightness' })
+    const bounds = await saturationSlider.boundingBox()
+    expect(bounds).not.toBeNull()
+    await page.mouse.move(bounds.x + bounds.width / 2, bounds.y + bounds.height / 2)
+    await page.mouse.down()
+    await page.mouse.move(bounds.x + bounds.width / 2, bounds.y + bounds.height + 50)
+    await expect(hueSlider).toHaveValue('120')
+    await page.mouse.up()
+
+    await expect(hueSlider).toHaveValue('120')
+  })
+
   test('applies a new theme created from System Default', async ({ page }) => {
     await goToSettingsSection(page, 'theme')
     const baseTheme = page.getByRole('combobox', { name: 'Base Theme' })

--- a/src/renderer/components/FtColorPicker/FtColorPicker.vue
+++ b/src/renderer/components/FtColorPicker/FtColorPicker.vue
@@ -308,7 +308,8 @@ function syncFromModel(color, force = false) {
   const parsed = parseHex(color)
   if (parsed === null) return
   const hsv = rgbToHsv(parsed)
-  hue.value = hsv.h
+  // Achromatic RGB colors do not encode a hue, so keep the current selection.
+  if (hsv.s > 0) hue.value = hsv.h
   saturation.value = hsv.s
   value.value = hsv.v
   alpha.value = props.allowAlpha ? parsed.a : 255


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Make sure to follow the contributing guidelines. -->
<!-- Important note, we may remove your pull request if you do not use this provided PR template correctly. -->
<!-- Agent instructions: Preserve every heading, comment, and marker in this template. Never remove or rewrite the release-note-category:start/end, release-note:start/end, or release-note-image:start/end marker pairs. Never remove or rewrite the Release note images section; leave its contents for a human. -->

## Pull Request Type
<!-- Please select what type of pull request this is: [x] -->
- [x] Bugfix
- [ ] Feature Implementation
- [ ] Documentation
- [ ] Other

## Related issue
<!-- Please link the issue your pull request is referring to. -->
<!-- If this pull request fully resolves the relevant issue, put "closes" before the issue number. -->
<!-- Example: "closes #123456". -->

## Description
<!-- Please write a clear and concise description of what the pull request does. -->

Holding the pointer in the saturation and brightness area and dragging below it could turn the selected color black. When the picker committed that value, converting black back to HSV replaced the selected hue with red because black carries no hue information.

Keep the last meaningful hue when the picker synchronizes from black, white, or gray. A browser regression test covers the hue both while the pointer remains held outside the area and after release.

## Release note category
<!-- Select exactly one category. Every pull request must select one. -->
<!-- Select "Not noteworthy" when the pull request fixes a bug in or improves functionality that has not yet appeared in a stable release. -->
<!-- release-note-category:start -->
- [ ] Not noteworthy
- [ ] Highlights
- [ ] More improvements
- [x] Fixed bugs
<!-- release-note-category:end -->

## Release note
<!-- Required unless "Not noteworthy" is selected. -->
<!-- Write one concise, user-facing entry without a leading bullet. -->
<!-- release-note:start -->
Keep the custom color picker's hue when dragging outside the saturation and brightness area.
<!-- release-note:end -->

## Release note images
<!-- Human-only: Agents must preserve this entire section and leave it empty. -->
<!-- Optional. Paste one or more Markdown images or HTML image tags here. -->
<!-- The release notes will use an HTML image tag and limit images taller than 300 pixels. -->
<!-- release-note-image:start -->

<!-- release-note-image:end -->

## Testing
<!-- How can reviewers verify that the PR produces correct results? -->
<!-- Please provide instructions so that others can ensure that your pull request would produce correct results. For examples see, https://github.com/FreeTubeApp/FreeTube/pull/5743, https://github.com/FreeTubeApp/FreeTube/pull/7349, https://github.com/FreeTubeApp/FreeTube/pull/5125, https://github.com/FreeTubeApp/FreeTube/pull/7338 -->
<!-- Agent instructions: Only write human-facing steps that explain how to verify the change while running this branch in dev mode. Include expected results and, when applicable, helpful console snippets for interactive verification. Do not include automated checks, commands, results, pass counts, or CI status. -->

1. Open Settings, then Theme, and create or edit a custom theme.
2. Open a color picker and select a non-red hue such as green.
3. Hold the pointer in the saturation and brightness area, drag below that area, and release.
4. Drag back into the area. The picker should retain the selected hue instead of switching to red.

## Additional context
<!-- Add any other context about the pull request here. -->

Black, white, and gray do not encode a hue in RGB, so the picker keeps its existing hue when synchronizing those colors.