### PR TITLE
fix: show skip symbol in skip silence OSD

### DIFF
--- a/e2e/tests/offline/player.spec.mjs
+++ b/e2e/tests/offline/player.spec.mjs
@@ -685,6 +685,9 @@ test.describe('skip silence shortcut', () => {
     await page.locator('body').press('h')
     await expect(popup).toBeVisible()
     await expect(popup).toHaveText(/On/)
+    await expect(popup.locator('.valueChangeIcons .ft-icon')).toHaveCount(2)
+    await expect(popup.locator('.valueChangeIcons .ft-icon').nth(0)).toHaveAttribute('data-icon', 'forward-step')
+    await expect(popup.locator('.valueChangeIcons .ft-icon').nth(1)).toHaveAttribute('data-icon', 'volume-xmark')
     await expect.poll(skipSilence).toBe(true)
     await attachScreenshot('skip silence enabled')
 

--- a/src/renderer/components/ft-shaka-video-player/ft-shaka-video-player.css
+++ b/src/renderer/components/ft-shaka-video-player/ft-shaka-video-player.css
@@ -1599,6 +1599,12 @@
   flex-direction: row-reverse;
 }
 
+.valueChangeIcons {
+  display: inline-flex;
+  align-items: center;
+  gap: 2px;
+}
+
 .fade-enter-active,
 .fade-leave-active {
   transition: opacity 0.5s ease;

--- a/src/renderer/components/ft-shaka-video-player/ft-shaka-video-player.js
+++ b/src/renderer/components/ft-shaka-video-player/ft-shaka-video-player.js
@@ -8222,7 +8222,7 @@ export default defineComponent({
 
           const localization = ui.getControls().getLocalization()
           const message = localization.resolve(enabled ? 'ON' : 'OFF')
-          showValueChange(message, 'volume-xmark', true)
+          showValueChange(message, ['step-forward', 'volume-xmark'], true)
           blurTooltipButtons()
           break
         }
@@ -9671,7 +9671,7 @@ export default defineComponent({
 
     const showValueChangePopup = ref(false)
     const valueChangeMessage = ref('')
-    const valueChangeIcon = ref(null)
+    const valueChangeIcons = ref([])
     const invertValueChangeContentOrder = ref(false)
     const showTemporaryPlaybackRateIndicator = ref(false)
     const temporaryPlaybackRateIndicatorMessage = ref('')
@@ -9684,12 +9684,12 @@ export default defineComponent({
     /**
      * Shows a popup with a message and an icon on top of the video player.
      * @param {string} message - The message to display.
-     * @param {string} icon - The icon to display.
+     * @param {string | string[]} icons - The icons to display.
      * @param {boolean} invertContentOrder - Whether to invert the order of the icon and message.
      */
-    function showValueChange(message, icon = null, invertContentOrder = false) {
+    function showValueChange(message, icons = [], invertContentOrder = false) {
       valueChangeMessage.value = message
-      valueChangeIcon.value = icon
+      valueChangeIcons.value = Array.isArray(icons) ? icons : [icons]
       showValueChangePopup.value = true
       invertValueChangeContentOrder.value = invertContentOrder
 
@@ -9894,7 +9894,7 @@ export default defineComponent({
       handleVideoZoomPointerCancel,
 
       valueChangeMessage,
-      valueChangeIcon,
+      valueChangeIcons,
       showValueChangePopup,
       invertValueChangeContentOrder,
       showTemporaryPlaybackRateIndicator,

--- a/src/renderer/components/ft-shaka-video-player/ft-shaka-video-player.vue
+++ b/src/renderer/components/ft-shaka-video-player/ft-shaka-video-player.vue
@@ -782,15 +782,16 @@
               showTemporaryPlaybackRateIndicator || invertValueChangeContentOrder
           }"
         >
-          <ft-icon
-            v-if="showTemporaryPlaybackRateIndicator || valueChangeIcon"
-            :icon="[
-              'fas',
-              showTemporaryPlaybackRateIndicator
-                ? 'forward'
-                : valueChangeIcon
-            ]"
-          />
+          <span
+            v-if="showTemporaryPlaybackRateIndicator || valueChangeIcons.length > 0"
+            class="valueChangeIcons"
+          >
+            <ft-icon
+              v-for="icon in showTemporaryPlaybackRateIndicator ? ['forward'] : valueChangeIcons"
+              :key="icon"
+              :icon="['fas', icon]"
+            />
+          </span>
           <span>{{
             showTemporaryPlaybackRateIndicator
               ? temporaryPlaybackRateIndicatorMessage


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Make sure to follow the contributing guidelines. -->
<!-- Important note, we may remove your pull request if you do not use this provided PR template correctly. -->
<!-- Agent instructions: Preserve every heading, comment, and marker in this template. Never remove or rewrite the release-note-category:start/end, release-note:start/end, or release-note-image:start/end marker pairs. Never remove or rewrite the Release note images section; leave its contents for a human. -->

## Pull Request Type
<!-- Please select what type of pull request this is: [x] -->
- [x] Bugfix
- [ ] Feature Implementation
- [ ] Documentation
- [ ] Other

## Related issue
<!-- Please link the issue your pull request is referring to. -->
<!-- If this pull request fully resolves the relevant issue, put "closes" before the issue number. -->
<!-- Example: "closes #123456". -->

## Description
<!-- Please write a clear and concise description of what the pull request does. -->

The Skip Silence hotkey OSD only showed a mute symbol, which did not communicate the skipping behavior clearly.

This adds the existing skip-next symbol before the mute symbol. The OSD can now render grouped icons without changing its other indicators, and the shortcut regression test checks both icon order and state changes.

## Release note category
<!-- Select exactly one category. Every pull request must select one. -->
<!-- Select "Not noteworthy" when the pull request fixes a bug in or improves functionality that has not yet appeared in a stable release. -->
<!-- release-note-category:start -->
- [ ] Not noteworthy
- [ ] Highlights
- [ ] More improvements
- [x] Fixed bugs
<!-- release-note-category:end -->

## Release note
<!-- Required unless "Not noteworthy" is selected. -->
<!-- Write one concise, user-facing entry without a leading bullet. -->
<!-- release-note:start -->
The Skip Silence keyboard shortcut indicator now shows both skip and mute symbols.
<!-- release-note:end -->

## Release note images
<!-- Human-only: Agents must preserve this entire section and leave it empty. -->
<!-- Optional. Paste one or more Markdown images or HTML image tags here. -->
<!-- The release notes will use an HTML image tag and limit images taller than 300 pixels. -->
<!-- release-note-image:start -->

<!-- release-note-image:end -->

## Testing
<!-- How can reviewers verify that the PR produces correct results? -->
<!-- Please provide instructions so that others can ensure that your pull request would produce correct results. For examples see, https://github.com/FreeTubeApp/FreeTube/pull/5743, https://github.com/FreeTubeApp/FreeTube/pull/7349, https://github.com/FreeTubeApp/FreeTube/pull/5125, https://github.com/FreeTubeApp/FreeTube/pull/7338 -->
<!-- Agent instructions: Only write human-facing steps that explain how to verify the change while running this branch in dev mode. Include expected results and, when applicable, helpful console snippets for interactive verification. Do not include automated checks, commands, results, pass counts, or CI status. -->

1. Assign a hotkey to "Toggle Skip Silence" in the keyboard shortcut settings.
2. Open a video and press the shortcut.
3. Confirm the OSD shows "On" or "Off", followed by a skip symbol and a mute symbol in that order.

## Additional context
<!-- Add any other context about the pull request here. -->
