### PR TITLE
test(settings): align E2E coverage with category navigation

### DIFF
--- a/e2e/helpers/app.mjs
+++ b/e2e/helpers/app.mjs
@@ -350,13 +350,31 @@ export async function goTo(page, route) {
   await expect(page).toHaveURL(new RegExp(`#/${route}`))
 }
 
+const SETTINGS_CATEGORY_BY_LEGACY_SECTION = {
+  theme: 'appearance',
+  player: 'playback',
+  'caption-appearance': 'playback',
+  channel: 'playback',
+  subscription: 'subscriptions',
+  distraction: 'focus',
+  'parental-control': 'focus',
+  'sponsor-block': 'add-ons',
+  'return-youtube-dislike': 'add-ons',
+  'external-player': 'advanced',
+  'external-software': 'advanced',
+  proxy: 'advanced',
+  'context-menu-search': 'general',
+  experimental: 'advanced'
+}
+
 /** Opens Settings and selects one category in the two-column modal layout. */
 export async function goToSettingsSection(page, section) {
   if (!await page.locator('.settingsWindow').isVisible()) {
     await goTo(page, 'settings')
   }
-  await page.locator(`.settingsMenu [data-section="${section}"]`).click()
-  const content = page.locator(`.settingsContent > [data-section="${section}"]`)
+  const category = SETTINGS_CATEGORY_BY_LEGACY_SECTION[section] ?? section
+  await page.locator(`.settingsMenu [data-section="${category}"]`).click()
+  const content = page.locator(`.settingsContent > [data-section="${category}"]`)
   await expect(content).toBeVisible()
   return content
 }

--- a/e2e/tests/offline/appearance.spec.mjs
+++ b/e2e/tests/offline/appearance.spec.mjs
@@ -28,7 +28,7 @@ async function enableVerticalTabBar (page, width) {
   await expect(page.locator('.app')).toHaveClass(/verticalTabs/)
 }
 
-async function expectAdjacent (left, right) {
+async function expectHorizontalGap (left, right, expectedGap) {
   const [leftBox, rightBox] = await Promise.all([
     left.boundingBox(),
     right.boundingBox()
@@ -37,8 +37,18 @@ async function expectAdjacent (left, right) {
   expect(leftBox).not.toBeNull()
   expect(rightBox).not.toBeNull()
   expect(Math.abs(leftBox.y - rightBox.y)).toBeLessThan(1)
-  expect(rightBox.x - leftBox.x - leftBox.width).toBeGreaterThanOrEqual(0)
-  expect(rightBox.x - leftBox.x - leftBox.width).toBeLessThanOrEqual(12)
+  expect(Math.abs(rightBox.x - leftBox.x - leftBox.width - expectedGap)).toBeLessThanOrEqual(1)
+}
+
+async function expectChangeMarkerClearOfPreviousSelect (left, right) {
+  const [leftBox, rightSelectBox] = await Promise.all([
+    left.boundingBox(),
+    right.locator('..').boundingBox()
+  ])
+
+  expect(leftBox).not.toBeNull()
+  expect(rightSelectBox).not.toBeNull()
+  expect(rightSelectBox.x - leftBox.x - leftBox.width).toBeGreaterThanOrEqual(11)
 }
 
 async function getTabEdgeBorderCoverage (page, tab, edge, inset = 0) {
@@ -182,8 +192,11 @@ test.describe('default appearance', () => {
     const secondaryColorTheme = page.getByRole('combobox', { name: /Secondary colou?r theme/i })
     await expect(lightTheme).toHaveText('Light')
     await expect(darkTheme).toHaveText('Dark')
-    await expectAdjacent(lightTheme, darkTheme)
-    await expectAdjacent(mainColorTheme, secondaryColorTheme)
+    await expectHorizontalGap(lightTheme, darkTheme, 24)
+    await expectHorizontalGap(mainColorTheme, secondaryColorTheme, 24)
+    await page.getByRole('button', { name: 'Highlight settings changed from defaults' }).click()
+    await expectHorizontalGap(lightTheme, darkTheme, 12)
+    await expectHorizontalGap(mainColorTheme, secondaryColorTheme, 12)
     await expect(page.locator('.select').filter({ has: lightTheme }).locator('.select-icon')).toBeVisible()
     await expect(page.locator('.select').filter({ has: darkTheme }).locator('.select-icon')).toBeVisible()
 
@@ -203,6 +216,34 @@ test.describe('default appearance', () => {
     await expect(page.locator('body')).toHaveClass(/catppuccinMocha/)
   })
 
+  test('keeps a changed theme marker clear of the previous select', async ({ page }) => {
+    await goToSettingsSection(page, 'theme')
+
+    const lightTheme = page.getByRole('combobox', { name: 'Light theme' })
+    const darkTheme = page.getByRole('combobox', { name: 'Dark theme' })
+    await darkTheme.click()
+    await page.locator(`#${await darkTheme.getAttribute('aria-controls')}`)
+      .getByRole('option', { name: 'Catppuccin Mocha', exact: true }).click()
+
+    const darkThemeSelect = page.locator('.select').filter({ has: darkTheme })
+    await expect(darkThemeSelect.locator('.changedSettingIndicator')).toBeVisible()
+    await expectChangeMarkerClearOfPreviousSelect(lightTheme, darkTheme)
+  })
+
+  test.describe('at 95% UI scale', () => {
+    test.use({ seed: { settings: { uiScale: 95 } } })
+
+    test('keeps predictable spacing between paired theme selects', async ({ page }) => {
+      await goToSettingsSection(page, 'theme')
+
+      const lightTheme = page.getByRole('combobox', { name: 'Light theme' })
+      const darkTheme = page.getByRole('combobox', { name: 'Dark theme' })
+      await expectHorizontalGap(lightTheme, darkTheme, 24)
+      await page.getByRole('button', { name: 'Highlight settings changed from defaults' }).click()
+      await expectHorizontalGap(lightTheme, darkTheme, 12)
+    })
+  })
+
   test('lists installed fonts and persists the selected app font', async ({ app, page }) => {
     await goToSettingsSection(page, 'theme')
 
@@ -216,11 +257,11 @@ test.describe('default appearance', () => {
     await expect.poll(() => fontOptions.count()).toBeGreaterThan(3)
     await expect(fontOptions.nth(0)).toHaveText('Roboto')
     await expect(fontOptions.nth(1)).toHaveText('System default')
-    await expect(fontDropdown).toHaveClass(/above/)
+    await expect(fontDropdown).toHaveClass(/below/)
     expect(await page.evaluate(([buttonId, dropdownId]) => {
       const button = document.getElementById(buttonId).getBoundingClientRect()
       const dropdown = document.getElementById(dropdownId).getBoundingClientRect()
-      return Math.abs(button.top - dropdown.bottom - 4)
+      return Math.abs(dropdown.top - button.bottom - 4)
     }, [await appFont.getAttribute('id'), await fontDropdown.getAttribute('id')])).toBeLessThanOrEqual(2)
 
     await page.setViewportSize({ width: 600, height: 320 })
@@ -469,9 +510,13 @@ test.describe('custom theme editor', () => {
     await expect(page.locator('.topNav .logoIcon')).toHaveCSS('background-color', 'rgb(18, 52, 86)')
     await expect(page.locator('.topNav .logoText')).toHaveCSS('background-color', 'rgb(101, 67, 33)')
     await setEditorColor('Logo hover', '#abcdef')
+    await page.locator('.settingsCloseButton').click()
+    await expect(page.locator('.settingsWindow')).toBeHidden()
     await page.locator('.topNav .logo').hover()
     await expect(page.locator('.topNav .logoIcon')).toHaveCSS('background-color', 'rgb(171, 205, 239)')
     await expect(page.locator('.topNav .logoText')).toHaveCSS('background-color', 'rgb(171, 205, 239)')
+    await goTo(page, 'settings')
+    await expect(editor).toBeVisible()
 
     await setEditorColor('Scrollbar thumb hover', '#345678')
     await expect(page.locator('.os-scrollbar').first()).toHaveCSS('--os-handle-bg-hover', '#345678')
@@ -501,7 +546,7 @@ test.describe('custom theme editor', () => {
     await backgroundPicker.getByRole('textbox', { name: 'Hex color' }).press('Enter')
     await expect(page.locator('body')).toHaveCSS('--bg-color', '#33445580')
     await expect(backgroundPicker.getByRole('button', { name: 'Reset' })).toBeEnabled()
-    await page.locator('.customThemeEditor .themeNameField input').click()
+    await page.keyboard.press('Escape')
     await expect(page.getByRole('dialog', { name: 'Page background' })).toHaveCount(0)
     await expect(page.locator('body')).toHaveCSS('--bg-color', '#0f0f0f')
 
@@ -584,7 +629,6 @@ test.describe('custom theme editor', () => {
     const quickAppearance = page.locator('.quickSettingsMenu .menuSection').filter({ hasText: 'Appearance' })
     await expect(quickAppearance.getByRole('combobox', { name: 'Base Theme' })).toBeDisabled()
     await expect(quickAppearance.getByRole('combobox', { name: /Main colou?r theme/i })).toHaveCount(0)
-    await expect(quickAppearance.getByRole('button', { name: 'Reset this setting to its default' })).toBeDisabled()
     await page.locator('.topNav .profileTrigger').click()
     await goTo(page, 'settings')
     await expect(page.getByText('Custom theme creator', { exact: true })).toBeVisible()
@@ -659,7 +703,7 @@ test.describe('custom theme editor', () => {
     await page.keyboard.press('Escape')
     await expect(page.locator('.quickSettingsMenu')).toBeHidden()
     await goTo(page, 'settings')
-    await expect(page.locator('.settingsContent > [data-section="theme"]')).toBeVisible()
+    await expect(page.locator('.settingsContent > [data-section="appearance"]')).toBeVisible()
 
     const lightSystemTheme = page.getByRole('combobox', { name: 'Light theme' })
     await lightSystemTheme.click()

--- a/e2e/tests/offline/search-context-menu.spec.mjs
+++ b/e2e/tests/offline/search-context-menu.spec.mjs
@@ -1,4 +1,4 @@
-import { test, expect, goTo, sel } from '../../helpers/app.mjs'
+import { test, expect, goTo, goToSettingsSection, sel } from '../../helpers/app.mjs'
 import { DEFAULT_SEARCH_ENGINES } from '../../../src/searchEngines.js'
 
 const allExternalSearchEnginesEnabled = JSON.stringify(
@@ -286,16 +286,10 @@ test('keeps the newest overlapping context menu session executable', async ({ pa
 })
 
 test('adds a custom search engine from settings', async ({ page }) => {
-  await goTo(page, 'settings')
-  const sectionOrder = await page.locator('.settingsMenu [data-section]').evaluateAll(items => {
-    return items.map(item => item.dataset.section)
+  const general = await goToSettingsSection(page, 'general')
+  const section = general.locator('.settingsSection').filter({
+    has: page.getByRole('heading', { name: 'Context Menu Search', exact: true })
   })
-  expect(sectionOrder.indexOf('context-menu-search'))
-    .toBe(sectionOrder.indexOf('return-youtube-dislike') + 1)
-
-  await page.locator('.settingsMenu [data-section="context-menu-search"]').click()
-
-  const section = page.locator('.settingsContent > [data-section="context-menu-search"]')
   await section.getByLabel('Engine name').fill('Example Search')
   await section.getByLabel('Search URL').fill('https://example.com/search?q=%s')
   const addButton = section.getByRole('button', { name: 'Add engine' })
@@ -407,10 +401,10 @@ test.describe('with the maximum custom search engines configured', () => {
   })
 
   test('rejects another engine without clearing its inputs', async ({ page }) => {
-    await goTo(page, 'settings')
-    await page.locator('.settingsMenu [data-section="context-menu-search"]').click()
-
-    const addRow = page.locator('.settingsContent > [data-section="context-menu-search"] .addEngine')
+    const general = await goToSettingsSection(page, 'general')
+    const addRow = general.locator('.settingsSection').filter({
+      has: page.getByRole('heading', { name: 'Context Menu Search', exact: true })
+    }).locator('.addEngine')
     const nameInput = addRow.getByLabel('Engine name')
     const urlInput = addRow.getByLabel('Search URL')
     await nameInput.fill('One Too Many')

--- a/e2e/tests/offline/segment-prefetch-slider.spec.mjs
+++ b/e2e/tests/offline/segment-prefetch-slider.spec.mjs
@@ -1,12 +1,10 @@
 import { readFile } from 'node:fs/promises'
 import path from 'node:path'
 
-import { test, expect, goTo, latestSettings } from '../../helpers/app.mjs'
+import { test, expect, goToSettingsSection, latestSettings } from '../../helpers/app.mjs'
 
 async function openPlayerSettings(page) {
-  await goTo(page, 'settings')
-  await page.locator('.settingsMenu [data-section="player"]').click()
-  await expect(page.locator('.settingsContent > [data-section="player"]')).toBeVisible()
+  await goToSettingsSection(page, 'playback')
 
   return page.getByRole('slider', { name: /Parallel Segment Loading/ })
 }

--- a/e2e/tests/offline/tabs.spec.mjs
+++ b/e2e/tests/offline/tabs.spec.mjs
@@ -1,4 +1,4 @@
-import { test, expect, sel, goTo } from '../../helpers/app.mjs'
+import { test, expect, sel, goTo, goToSettingsSection } from '../../helpers/app.mjs'
 
 /**
  * Returns the box of an element that has stopped moving. Menus and submenus
@@ -1026,11 +1026,11 @@ test.describe('closed tabs', () => {
       await page.locator(sel.tabs).first().click()
       await page.keyboard.press('Control+w')
 
-      await goTo(page, 'settings')
+      const privacy = await goToSettingsSection(page, 'privacy')
       await expect(page.locator('.settingsWindow')).not.toHaveClass(/settings-window-enter-active/)
-      const rememberHistory = page.getByRole('checkbox', { name: 'Remember Tab Navigation History' })
+      const rememberHistory = privacy.getByRole('checkbox', { name: 'Remember Tab Navigation History' })
       await expect(rememberHistory).toBeChecked()
-      await page.locator('label.switch-label').filter({ hasText: 'Remember Tab Navigation History' }).click()
+      await privacy.locator('label.switch-label').filter({ hasText: 'Remember Tab Navigation History' }).click()
       await expect(rememberHistory).not.toBeChecked()
 
       await page.keyboard.press('Control+Shift+t')


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Make sure to follow the contributing guidelines. -->
<!-- Important note, we may remove your pull request if you do not use this provided PR template correctly. -->
<!-- Agent instructions: Preserve every heading, comment, and marker in this template. Never remove or rewrite the release-note-category:start/end, release-note:start/end, or release-note-image:start/end marker pairs. Never remove or rewrite the Release note images section; leave its contents for a human. -->

## Pull Request Type
<!-- Please select what type of pull request this is: [x] -->
- [ ] Bugfix
- [ ] Feature Implementation
- [ ] Documentation
- [x] Other

## Related issue
<!-- Please link the issue your pull request is referring to. -->
<!-- If this pull request fully resolves the relevant issue, put "closes" before the issue number. -->
<!-- Example: "closes #123456". -->

Follow-up to #841.

## Description
<!-- Please write a clear and concise description of what the pull request does. -->

The settings navigation redesign replaced several standalone section IDs with broader categories, but some E2E helpers and specs still targeted the removed IDs. This updates the shared helper to resolve legacy section names to their current categories and moves affected assertions to the correct sections.

The appearance coverage now matches the intended settings layout. It verifies the reserved change-marker gutter at normal and fractional UI scales and checks that a changed marker cannot touch the select to its left. It also updates modal, font-menu, custom search engine, and segment prefetch interactions for the redesigned settings window.

## Release note category
<!-- Select exactly one category. Every pull request must select one. -->
<!-- Select "Not noteworthy" when the pull request fixes a bug in or improves functionality that has not yet appeared in a stable release. -->
<!-- release-note-category:start -->
- [x] Not noteworthy
- [ ] Highlights
- [ ] More improvements
- [ ] Fixed bugs
<!-- release-note-category:end -->

## Release note
<!-- Required unless "Not noteworthy" is selected. -->
<!-- Write one concise, user-facing entry without a leading bullet. -->
<!-- release-note:start -->

<!-- release-note:end -->

## Release note images
<!-- Human-only: Agents must preserve this entire section and leave it empty. -->
<!-- Optional. Paste one or more Markdown images or HTML image tags here. -->
<!-- The release notes will use an HTML image tag and limit images taller than 300 pixels. -->
<!-- release-note-image:start -->

<!-- release-note-image:end -->

## Testing
<!-- How can reviewers verify that the PR produces correct results? -->
<!-- Please provide instructions so that others can ensure that your pull request would produce correct results. For examples see, https://github.com/FreeTubeApp/FreeTube/pull/5743, https://github.com/FreeTubeApp/FreeTube/pull/7349, https://github.com/FreeTubeApp/FreeTube/pull/5125, https://github.com/FreeTubeApp/FreeTube/pull/7338 -->
<!-- Agent instructions: Only write human-facing steps that explain how to verify the change while running this branch in dev mode. Include expected results and, when applicable, helpful console snippets for interactive verification. Do not include automated checks, commands, results, pass counts, or CI status. -->

1. Open Settings and visit Appearance, General, and Playback. Each category should open normally and show its expected controls.
2. In Appearance, change the Dark theme. Its reset marker should remain separated from the Light theme select on its left.
3. Toggle "Highlight settings changed from defaults". The theme controls should keep consistent rows without markers touching neighboring selects.
4. In General, add a custom context-menu search engine. The engine should appear and retain its values.
5. In Playback, change Parallel Segment Loading. The selected value should persist.

## Additional context
<!-- Add any other context about the pull request here. -->

This is test-only maintenance. It does not change the application layout or settings behavior.