### PR TITLE
perf(subscriptions): keep large refreshes responsive

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,6 +1,17 @@
 - Always run Electron/Playwright E2E tests under a private X server using `xvfb-run -a -s "-screen 0 1920x1080x24"`.
 - For filtered Electron/Playwright E2E runs, invoke Playwright directly, for example `pnpm exec playwright test -c e2e/playwright.config.mjs e2e/tests/network/channel.spec.mjs --project=network --grep "test name"`. Never use `pnpm run test:e2e -- ...`; the extra `--` stops Playwright from parsing the following path and options and can launch the full suite.
 - Before running modified Electron/Playwright E2E tests, run `pnpm run test:e2e:pack` so `dist-e2e` includes the current CSS and rendering or measurement tests do not run against an unstyled app.
+- If production webpack packing crashes natively under Node with signals such as `SIGSEGV`, `SIGBUS`, or `SIGTRAP`, limit the minimizers to one worker with a two-CPU systemd user scope instead of retrying at the default worker count:
+  ```sh
+  systemd-run --user --scope --collect --quiet \
+    --working-directory="$PWD" \
+    -p CPUQuota=200% \
+    -p MemoryHigh=2G \
+    -p MemoryMax=3G \
+    env NODE_OPTIONS='--max-old-space-size=1536 --v8-pool-size=1' \
+    pnpm run test:e2e:pack
+  ```
+  Use the CPU quota for packaging only. It distorts renderer frame-timing tests; run those with one Playwright worker and the memory limits, but without `CPUQuota`.
 - The in-app UI Scale setting changes Electron's zoom factor and can produce legitimate fractional CSS-pixel geometry. Changes involving scrolling, measurements, positioning, reflow, or animation boundaries must also work at non-100% UI scales; do not treat a subpixel difference from integer layout properties as stale or invalid state.
 - Custom Shaka overflow-menu controls must hide while any submenu is open; follow the existing `submenuopen` / `submenuclose` visibility pattern using `isSubMenuOpened` and `shaka-hidden`.
 - Headers in scrollable menus and panels must stay outside the content's scroll viewport so neither content nor its scrollbar can pass behind the header; prefer a fixed header plus a separate inner scroller over covering content with a sticky header. When switching between menu views, explicitly restore the actual scroll viewport to the intended position; use `restoreOverlayScrollTop` for OverlayScrollbars-managed elements instead of relying on focus or DOM replacement to reset it. Any reflow or dynamic update that can shorten scrollable content—including resize, responsive layout changes, searching, filtering, collapsing, removing, or replacing content—must clamp the scroll position against the real rendered content end after the DOM update; observe a stable content wrapper when practical and use `clampOverlayScrollTop` with that content element instead of trusting a possibly stale `scrollHeight`. Cover every relevant shortening trigger with a regression test that first scrolls to the bottom, triggers the shorter state, and verifies that no obsolete offset or empty space remains and that the rendered scrollbar thumb/overflow state matches the new scroll range.

--- a/e2e/tests/offline/subscriptions-refresh.spec.mjs
+++ b/e2e/tests/offline/subscriptions-refresh.spec.mjs
@@ -191,6 +191,138 @@ test.describe('incremental subscription feed refresh', () => {
   })
 })
 
+test.describe('subscription refresh performance with many tabs', () => {
+  const channelCount = 933
+  const tabCount = 46
+  const loadedTabCount = 17
+  const subscriptionTabId = 'perf-subscriptions'
+
+  test.use({
+    seed: {
+      settings: {
+        ...commonSettings,
+        startupBehavior: 'restoreTabLoadState',
+        reducedMotion: 'off'
+      },
+      profiles: [profileWith(channelCount)],
+      subscriptionCache: Array.from({ length: channelCount }, (_, index) => cachedChannel(index)),
+      tabSessions: [{
+        _id: 'perf-window-session',
+        value: {
+          tabs: Array.from({ length: tabCount }, (_, index) => ({
+            id: index === 0 ? subscriptionTabId : `perf-tab-${index}`,
+            url: index === 0
+              ? 'app://bundle/index.html#/subscriptions'
+              : 'app://bundle/index.html#/history',
+            title: index === 0 ? 'Subscriptions' : `Background tab ${index}`,
+            isUnloaded: index >= loadedTabCount
+          })),
+          activeTabId: subscriptionTabId,
+          bounds: { x: 0, y: 0, width: 1600, height: 900, maximized: false }
+        }
+      }]
+    }
+  })
+
+  test('keeps the renderer responsive while refreshing a large profile', async ({ app, page }, testInfo) => {
+    test.setTimeout(120_000)
+    let fulfilledFeedCount = 0
+    await routeFeeds(page, () => 0, (index) => {
+      fulfilledFeedCount++
+      return rssFeed(index)
+    })
+    await expect(page.locator(sel.tabs)).toHaveCount(tabCount)
+    await expect(page.locator(`${sel.tabs}:not(.unloaded)`)).toHaveCount(loadedTabCount)
+    await expect(page.getByText('Cached video 0', { exact: true })).toBeVisible({ timeout: 30_000 })
+
+    const profileUpdate = await page.evaluate(async () => {
+      const store = document.querySelector('#app').__vue_app__.config.globalProperties.$store
+      const channels = store.getters.getActiveProfile.subscriptions.map(channel => ({
+        channelId: channel.id,
+        channelName: channel.name
+      }))
+      const startedAt = performance.now()
+      await store.dispatch('batchUpdateSubscriptionDetails', channels)
+      return performance.now() - startedAt
+    })
+
+    const rendererWorkingSet = async () => app.electronApp.evaluate(({ app }) => {
+      return app.getAppMetrics()
+        .filter(metric => metric.type === 'Tab')
+        .reduce((total, metric) => total + metric.memory.workingSetSize, 0)
+    })
+    const memoryBefore = await rendererWorkingSet()
+
+    await page.getByRole('button', { name: /Refresh Videos/ }).evaluate(button => {
+      const startedAt = performance.now()
+      let previousFrame = startedAt
+      let longestFrame = 0
+      let refreshedChannels = 0
+      let completedAt = null
+      const longFrames = []
+      let animationFrame
+
+      const sampleFrame = (timestamp) => {
+        const duration = timestamp - previousFrame
+        longestFrame = Math.max(longestFrame, duration)
+        if (duration >= 50) {
+          longFrames.push({
+            at: timestamp - startedAt,
+            duration,
+            refreshedChannels,
+            completedAt
+          })
+        }
+        previousFrame = timestamp
+        animationFrame = requestAnimationFrame(sampleFrame)
+      }
+      const channelRefreshed = () => refreshedChannels++
+      const refreshCompleted = () => { completedAt = performance.now() - startedAt }
+
+      window.addEventListener('opentubex-subscription-refresh-channel', channelRefreshed)
+      window.addEventListener('opentubex-subscription-refresh-completed', refreshCompleted)
+      animationFrame = requestAnimationFrame(sampleFrame)
+      window.__subscriptionRefreshPerformance = {
+        stop: () => {
+          cancelAnimationFrame(animationFrame)
+          window.removeEventListener('opentubex-subscription-refresh-channel', channelRefreshed)
+          window.removeEventListener('opentubex-subscription-refresh-completed', refreshCompleted)
+          return {
+            elapsed: performance.now() - startedAt,
+            longestFrame,
+            longFrames
+          }
+        }
+      }
+      button.click()
+    })
+
+    const cancelRefresh = page.getByRole('button', { name: 'Cancel refresh' })
+    await expect(cancelRefresh).toBeVisible()
+    await expect(cancelRefresh).toHaveCount(0, { timeout: 90_000 })
+    expect(fulfilledFeedCount).toBe(channelCount)
+    await expect(page.getByText('Fresh video 0', { exact: true })).toBeVisible()
+    await page.evaluate(() => new Promise(resolve => requestAnimationFrame(resolve)))
+
+    const timing = await page.evaluate(() => window.__subscriptionRefreshPerformance.stop())
+    const memoryAfter = await rendererWorkingSet()
+    const metrics = {
+      ...timing,
+      profileUpdate,
+      rendererWorkingSetBeforeKiB: memoryBefore,
+      rendererWorkingSetAfterKiB: memoryAfter
+    }
+    await testInfo.attach('performance metrics', {
+      body: JSON.stringify(metrics, null, 2),
+      contentType: 'application/json'
+    })
+
+    expect(profileUpdate, JSON.stringify(metrics)).toBeLessThan(50)
+    expect(timing.longestFrame, JSON.stringify(metrics)).toBeLessThan(60)
+    expect(timing.elapsed).toBeLessThan(10_000)
+  })
+})
+
 test.describe('subscription refresh bottom progress', () => {
   test.use({
     seed: {

--- a/e2e/tests/offline/subscriptions-tab-performance.spec.mjs
+++ b/e2e/tests/offline/subscriptions-tab-performance.spec.mjs
@@ -1,7 +1,7 @@
 import { test, expect, goTo } from '../../helpers/app.mjs'
 
 const now = Date.now()
-const channelCount = 600
+const channelCount = 933
 const videosPerChannel = 36
 
 const profiles = [{
@@ -84,7 +84,7 @@ async function measureVideosSwitch(page) {
   }))
 }
 
-test('switches a production-sized cached feed without repeating expensive work', async ({ page }) => {
+test('switches a production-profile-sized cached feed without repeating expensive work', async ({ page }) => {
   await goTo(page, 'trending')
   await page.evaluate(() => localStorage.setItem('Subscriptions/currentTab', 'new'))
   await goTo(page, 'subscriptions')

--- a/src/renderer/components/FtAutoGrid/FtAutoGrid.vue
+++ b/src/renderer/components/FtAutoGrid/FtAutoGrid.vue
@@ -114,6 +114,13 @@ function applyThumbnailSizeStyles() {
 watch(() => store.getters.getThumbnailSize, applyThumbnailSizeStyles)
 
 function captureLeavingItemLayout(element) {
+  // Only the New feed takes leaving items out of flow and consumes these
+  // geometry variables. Measuring every removed card in other feeds forces
+  // repeated layouts during a large subscription refresh.
+  if (!(element instanceof Element) || element.closest('.newFeed') === null) {
+    return
+  }
+
   const itemRect = element.getBoundingClientRect()
   const gridRect = gridElement.value.$el.getBoundingClientRect()
 

--- a/src/renderer/composables/useSubscriptionChannelUpdates.js
+++ b/src/renderer/composables/useSubscriptionChannelUpdates.js
@@ -5,7 +5,7 @@ import { useTabContext } from '../tabs/TabContext'
 
 // Rebuilding and sorting the whole feed for every channel would be wasteful
 // with hundreds of subscriptions, so updates are coalesced.
-const FEED_UPDATE_INTERVAL_MS = 500
+const FEED_UPDATE_INTERVAL_MS = 100
 const updateVersions = reactive({
   videos: 0,
   shorts: 0,

--- a/src/renderer/helpers/subscription-profile-details.js
+++ b/src/renderer/helpers/subscription-profile-details.js
@@ -1,0 +1,55 @@
+/**
+ * Applies refreshed channel names and thumbnails to one profile without
+ * repeatedly scanning its subscription list.
+ *
+ * @param {object} profile
+ * @param {{ channelId: string, channelName?: string, channelThumbnailUrl?: string }[]} channels
+ * @returns {object | null} a copied profile when details changed
+ */
+export function getProfileWithUpdatedSubscriptionDetails(profile, channels) {
+  const updatesByChannelId = new Map()
+
+  for (const update of channels) {
+    const updates = updatesByChannelId.get(update.channelId)
+    if (updates === undefined) {
+      updatesByChannelId.set(update.channelId, [update])
+    } else {
+      updates.push(update)
+    }
+  }
+
+  let updatedProfile = null
+
+  for (let index = 0; index < profile.subscriptions.length; index++) {
+    const updates = updatesByChannelId.get(profile.subscriptions[index].id)
+    if (updates === undefined) {
+      continue
+    }
+
+    for (const { channelName, channelThumbnailUrl } of updates) {
+      const channel = (updatedProfile ?? profile).subscriptions[index]
+      const thumbnail = channelThumbnailUrl
+        ?.replace(/=s\d*/, '=s176')
+        .replace(/^https?:\/\/[^/]+\/ggpht/, 'https://yt3.googleusercontent.com')
+      const nameChanged = channelName != null && channel.name !== channelName
+      const thumbnailChanged = Boolean(channelThumbnailUrl) && channel.thumbnail !== thumbnail
+
+      if (!nameChanged && !thumbnailChanged) {
+        continue
+      }
+
+      if (updatedProfile === null) {
+        updatedProfile = JSON.parse(JSON.stringify(profile))
+      }
+
+      if (nameChanged) {
+        updatedProfile.subscriptions[index].name = channelName
+      }
+      if (thumbnailChanged) {
+        updatedProfile.subscriptions[index].thumbnail = thumbnail
+      }
+    }
+  }
+
+  return updatedProfile
+}

--- a/src/renderer/helpers/subscriptions.js
+++ b/src/renderer/helpers/subscriptions.js
@@ -210,35 +210,29 @@ function notifySubscriptionChannelRefreshed(tab) {
 }
 
 async function fetchSubscriptionsConcurrently(channels, fetchChannel) {
-  const results = await mapConcurrently(
+  await mapConcurrently(
     channels,
     SUBSCRIPTION_FETCH_CONCURRENCY,
     async channel => {
       // Channels that haven't started yet are skipped, the ones in flight
       // still finish and are cached.
       if (isRefreshCancelled()) {
-        return []
+        return
       }
 
       if (process.env.IS_ELECTRON) {
         await window.ftElectron.waitForIpBlockRecoveryScript()
       }
 
-      const result = await fetchChannel(channel)
+      await fetchChannel(channel)
 
       // Let input and navigation tasks run between parsing/cache updates.
       await new Promise(resolve => setTimeout(resolve, 0))
-
-      return result
     }
   )
-
-  return results.flat()
 }
 
 async function fetchSubscriptionsInBatches(channels, fetchChannel) {
-  const results = []
-
   for (let index = 0; index < channels.length; index += SUBSCRIPTION_FETCH_BATCH_SIZE) {
     if (isRefreshCancelled()) {
       break
@@ -249,10 +243,8 @@ async function fetchSubscriptionsInBatches(channels, fetchChannel) {
     }
 
     const batch = channels.slice(index, index + SUBSCRIPTION_FETCH_BATCH_SIZE)
-    results.push(...await fetchSubscriptionsConcurrently(batch, fetchChannel))
+    await fetchSubscriptionsConcurrently(batch, fetchChannel)
   }
-
-  return results
 }
 
 /**
@@ -625,7 +617,6 @@ async function refreshSubscriptionVideosFromRemoteUnlocked({
   errorChannels = []
 }, activeProfile) {
   const activeSubscriptionList = getValidSubscriptionChannels(activeProfile.subscriptions)
-  const activeSubscriptionIds = new Set(activeSubscriptionList.map(channel => channel.id))
   const subscriptionList = includeAutomaticDownloadChannels(activeSubscriptionList, 'videos')
   if (subscriptionList.length === 0) {
     completeSubscriptionRefresh('videos', activeProfile._id)
@@ -688,14 +679,13 @@ async function refreshSubscriptionVideosFromRemoteUnlocked({
           channelThumbnailUrl: thumbnailUrl
         })
       }
-
-      const channelVideos = videos ?? store.getters.getVideoCache[channel.id]?.videos ?? []
-      return activeSubscriptionIds.has(channel.id) ? channelVideos : []
     }
 
-    const videoListFromRemote = useRss
-      ? await fetchSubscriptionsConcurrently(subscriptionList, fetchChannel)
-      : await fetchSubscriptionsInBatches(subscriptionList, fetchChannel)
+    if (useRss) {
+      await fetchSubscriptionsConcurrently(subscriptionList, fetchChannel)
+    } else {
+      await fetchSubscriptionsInBatches(subscriptionList, fetchChannel)
+    }
 
     store.dispatch('batchUpdateSubscriptionDetails', subscriptionUpdates)
 
@@ -705,7 +695,7 @@ async function refreshSubscriptionVideosFromRemoteUnlocked({
 
     completeSubscriptionRefresh('videos', activeProfile._id)
 
-    return updateVideoListAfterProcessing(videoListFromRemote)
+    return []
   } finally {
     store.commit('setSubscriptionFeedRefreshInProgress', false)
   }
@@ -733,7 +723,6 @@ async function refreshSubscriptionShortsFromRemoteUnlocked({
   errorChannels = []
 }, activeProfile) {
   const activeSubscriptionList = getValidSubscriptionChannels(activeProfile.subscriptions)
-  const activeSubscriptionIds = new Set(activeSubscriptionList.map(channel => channel.id))
   const subscriptionList = includeAutomaticDownloadChannels(activeSubscriptionList, 'shorts')
   if (subscriptionList.length === 0) {
     completeSubscriptionRefresh('shorts', activeProfile._id)
@@ -751,7 +740,7 @@ async function refreshSubscriptionShortsFromRemoteUnlocked({
   let channelCount = 0
 
   try {
-    const videoListFromRemote = await fetchSubscriptionsConcurrently(subscriptionList, async (channel) => {
+    await fetchSubscriptionsConcurrently(subscriptionList, async (channel) => {
       let videos, name
 
       if (!process.env.SUPPORTS_LOCAL_API || store.getters.getBackendPreference === 'invidious') {
@@ -786,9 +775,6 @@ async function refreshSubscriptionShortsFromRemoteUnlocked({
           channelName: name
         })
       }
-
-      const channelVideos = videos ?? store.getters.getShortsCache[channel.id]?.videos ?? []
-      return activeSubscriptionIds.has(channel.id) ? channelVideos : []
     })
 
     store.dispatch('batchUpdateSubscriptionDetails', subscriptionUpdates)
@@ -799,7 +785,7 @@ async function refreshSubscriptionShortsFromRemoteUnlocked({
 
     completeSubscriptionRefresh('shorts', activeProfile._id)
 
-    return updateVideoListAfterProcessing(videoListFromRemote)
+    return []
   } finally {
     store.commit('setSubscriptionFeedRefreshInProgress', false)
   }
@@ -827,7 +813,6 @@ async function refreshSubscriptionLiveFromRemoteUnlocked({
   errorChannels = []
 }, activeProfile) {
   const activeSubscriptionList = getValidSubscriptionChannels(activeProfile.subscriptions)
-  const activeSubscriptionIds = new Set(activeSubscriptionList.map(channel => channel.id))
   const subscriptionList = includeAutomaticDownloadChannels(activeSubscriptionList, 'live')
   if (subscriptionList.length === 0) {
     completeSubscriptionRefresh('live', activeProfile._id)
@@ -890,14 +875,13 @@ async function refreshSubscriptionLiveFromRemoteUnlocked({
           channelThumbnailUrl: thumbnailUrl
         })
       }
-
-      const channelVideos = videos ?? store.getters.getLiveCache[channel.id]?.videos ?? []
-      return activeSubscriptionIds.has(channel.id) ? channelVideos : []
     }
 
-    const videoListFromRemote = useRss
-      ? await fetchSubscriptionsConcurrently(subscriptionList, fetchChannel)
-      : await fetchSubscriptionsInBatches(subscriptionList, fetchChannel)
+    if (useRss) {
+      await fetchSubscriptionsConcurrently(subscriptionList, fetchChannel)
+    } else {
+      await fetchSubscriptionsInBatches(subscriptionList, fetchChannel)
+    }
 
     store.dispatch('batchUpdateSubscriptionDetails', subscriptionUpdates)
 
@@ -907,7 +891,7 @@ async function refreshSubscriptionLiveFromRemoteUnlocked({
 
     completeSubscriptionRefresh('live', activeProfile._id)
 
-    return updateVideoListAfterProcessing(videoListFromRemote)
+    return []
   } finally {
     store.commit('setSubscriptionFeedRefreshInProgress', false)
   }
@@ -948,7 +932,6 @@ async function refreshSubscriptionPostsFromRemoteUnlocked({
   }
 
   const subscriptionUpdates = []
-  const postListFromRemote = []
   let channelCount = 0
 
   try {
@@ -993,18 +976,9 @@ async function refreshSubscriptionPostsFromRemoteUnlocked({
           })
         }
       }
-
-      return posts
     }
 
-    postListFromRemote.push(...await fetchSubscriptionsInBatches(activeSubscriptionList, processChannel))
-
-    postListFromRemote.sort((a, b) => b.publishedTime - a.publishedTime)
-
-    const forbiddenTitles = store.getters.getForbiddenTitlesParsed
-    const filteredPosts = postListFromRemote.filter(post => {
-      return !forbiddenTitles.some(text => post.author.toLowerCase().includes(text))
-    })
+    await fetchSubscriptionsInBatches(activeSubscriptionList, processChannel)
 
     store.dispatch('batchUpdateSubscriptionDetails', subscriptionUpdates)
 
@@ -1014,7 +988,7 @@ async function refreshSubscriptionPostsFromRemoteUnlocked({
 
     completeSubscriptionRefresh('posts', activeProfile._id)
 
-    return filteredPosts
+    return []
   } finally {
     store.commit('setSubscriptionFeedRefreshInProgress', false)
   }

--- a/src/renderer/store/modules/profiles.js
+++ b/src/renderer/store/modules/profiles.js
@@ -1,6 +1,7 @@
 import { MAIN_PROFILE_ID, THEME_BG_COLOR, THEME_TEXT_COLOR } from '../../../constants'
 import { DBProfileHandlers } from '../../../datastores/handlers/index'
 import { deepCopy } from '../../helpers/utils'
+import { getProfileWithUpdatedSubscriptionDetails } from '../../helpers/subscription-profile-details'
 
 const state = {
   profileList: [{
@@ -119,52 +120,10 @@ const actions = {
     const profileList = state.profileList
 
     for (const profile of profileList) {
-      // Only copied if something has actually changed, in which case this variable will be replaced with the copy.
-      let currentProfile = profile
-      let profileUpdated = false
+      const updatedProfile = getProfileWithUpdatedSubscriptionDetails(profile, channels)
 
-      for (const { channelThumbnailUrl, channelName, channelId } of channels) {
-        let channel = currentProfile.subscriptions.find((channel) => {
-          return channel.id === channelId
-        }) ?? null
-
-        if (channel === null) { continue }
-
-        if (channel.name !== channelName && channelName != null) {
-          if (!profileUpdated) {
-            const index = currentProfile.subscriptions.indexOf(channel)
-
-            currentProfile = deepCopy(currentProfile)
-            channel = currentProfile.subscriptions[index]
-            profileUpdated = true
-          }
-
-          channel.name = channelName
-        }
-
-        if (channelThumbnailUrl) {
-          const thumbnail = channelThumbnailUrl
-            // change thumbnail size if different
-            .replace(/=s\d*/, '=s176')
-            // If this is an Invidious URL, convert it to a YouTube one
-            .replace(/^https?:\/\/[^/]+\/ggpht/, 'https://yt3.googleusercontent.com')
-
-          if (channel.thumbnail !== thumbnail) {
-            if (!profileUpdated) {
-              const index = currentProfile.subscriptions.indexOf(channel)
-
-              currentProfile = deepCopy(currentProfile)
-              channel = currentProfile.subscriptions[index]
-              profileUpdated = true
-            }
-
-            channel.thumbnail = thumbnail
-          }
-        }
-      }
-
-      if (profileUpdated) {
-        await dispatch('updateProfile', currentProfile)
+      if (updatedProfile !== null) {
+        await dispatch('updateProfile', updatedProfile)
       }
     }
   },

--- a/tests/unit/subscription-profile-details.test.mjs
+++ b/tests/unit/subscription-profile-details.test.mjs
@@ -1,0 +1,74 @@
+import assert from 'node:assert/strict'
+import test from 'node:test'
+
+import { getProfileWithUpdatedSubscriptionDetails } from '../../src/renderer/helpers/subscription-profile-details.js'
+
+test('updates channel details without changing the source profile', () => {
+  const profile = {
+    _id: 'allChannels',
+    subscriptions: [
+      { id: 'first', name: 'Old name', thumbnail: 'old-thumbnail' },
+      { id: 'second', name: 'Unchanged', thumbnail: '' }
+    ]
+  }
+  const updated = getProfileWithUpdatedSubscriptionDetails(profile, [
+    {
+      channelId: 'first',
+      channelName: 'New name',
+      channelThumbnailUrl: 'https://invidious.example/ggpht/avatar=s88'
+    }
+  ])
+
+  assert.deepEqual(updated, {
+    _id: 'allChannels',
+    subscriptions: [
+      {
+        id: 'first',
+        name: 'New name',
+        thumbnail: 'https://yt3.googleusercontent.com/avatar=s176'
+      },
+      { id: 'second', name: 'Unchanged', thumbnail: '' }
+    ]
+  })
+  assert.equal(profile.subscriptions[0].name, 'Old name')
+  assert.equal(profile.subscriptions[0].thumbnail, 'old-thumbnail')
+})
+
+test('preserves ordered duplicate updates and skips an unchanged profile', () => {
+  const profile = {
+    _id: 'allChannels',
+    subscriptions: [{ id: 'channel', name: 'Original', thumbnail: '' }]
+  }
+
+  const updated = getProfileWithUpdatedSubscriptionDetails(profile, [
+    { channelId: 'channel', channelName: 'First' },
+    { channelId: 'channel', channelName: null, channelThumbnailUrl: '' },
+    { channelId: 'channel', channelName: 'Final' }
+  ])
+
+  assert.equal(updated.subscriptions[0].name, 'Final')
+  assert.equal(updated.subscriptions[0].thumbnail, '')
+  assert.equal(getProfileWithUpdatedSubscriptionDetails(updated, [
+    { channelId: 'channel', channelName: 'Final' }
+  ]), null)
+})
+
+test('checks each profile subscription once for a large no-op refresh', () => {
+  const channelCount = 933
+  let idReads = 0
+  const subscriptions = Array.from({ length: channelCount }, (_, index) => ({
+    get id () {
+      idReads++
+      return `channel-${index}`
+    },
+    name: `Channel ${index}`,
+    thumbnail: ''
+  }))
+  const channels = Array.from({ length: channelCount }, (_, index) => ({
+    channelId: `channel-${index}`,
+    channelName: `Channel ${index}`
+  }))
+
+  assert.equal(getProfileWithUpdatedSubscriptionDetails({ subscriptions }, channels), null)
+  assert.equal(idReads, channelCount)
+})


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Make sure to follow the contributing guidelines. -->
<!-- Important note, we may remove your pull request if you do not use this provided PR template correctly. -->
<!-- Agent instructions: Preserve every heading, comment, and marker in this template. Never remove or rewrite the release-note-category:start/end, release-note:start/end, or release-note-image:start/end marker pairs. Never remove or rewrite the Release note images section; leave its contents for a human. -->

## Pull Request Type
<!-- Please select what type of pull request this is: [x] -->
- [x] Bugfix
- [ ] Feature Implementation
- [ ] Documentation
- [ ] Other

## Related issue
<!-- Please link the issue your pull request is referring to. -->
<!-- If this pull request fully resolves the relevant issue, put "closes" before the issue number. -->
<!-- Example: "closes #123456". -->

## Description
<!-- Please write a clear and concise description of what the pull request does. -->
Large subscription refreshes accumulated enough UI and profile-update work to stall the renderer, especially when many tabs were loaded. This keeps the interface responsive by spreading feed updates into smaller batches, skipping unused aggregate result arrays, avoiding forced card-layout measurements outside the New feed, and indexing refreshed channel metadata by ID.

The regression coverage uses a production-sized workload with 933 subscriptions, 46 tabs, 17 loaded tabs, and 33,588 cached feed entries.

## Release note category
<!-- Select exactly one category. Every pull request must select one. -->
<!-- Select "Not noteworthy" when the pull request fixes a bug in or improves functionality that has not yet appeared in a stable release. -->
<!-- release-note-category:start -->
- [ ] Not noteworthy
- [ ] Highlights
- [ ] More improvements
- [x] Fixed bugs
<!-- release-note-category:end -->

## Release note
<!-- Required unless "Not noteworthy" is selected. -->
<!-- Write one concise, user-facing entry without a leading bullet. -->
<!-- release-note:start -->
Subscription feeds stay responsive while refreshing large subscription lists with many tabs open.
<!-- release-note:end -->

## Release note images
<!-- Human-only: Agents must preserve this entire section and leave it empty. -->
<!-- Optional. Paste one or more Markdown images or HTML image tags here. -->
<!-- The release notes will use an HTML image tag and limit images taller than 300 pixels. -->
<!-- release-note-image:start -->

<!-- release-note-image:end -->

## Testing
<!-- How can reviewers verify that the PR produces correct results? -->
<!-- Please provide instructions so that others can ensure that your pull request would produce correct results. For examples see, https://github.com/FreeTubeApp/FreeTube/pull/5743, https://github.com/FreeTubeApp/FreeTube/pull/7349, https://github.com/FreeTubeApp/FreeTube/pull/5125, https://github.com/FreeTubeApp/FreeTube/pull/7338 -->
<!-- Agent instructions: Only write human-facing steps that explain how to verify the change while running this branch in dev mode. Include expected results and, when applicable, helpful console snippets for interactive verification. Do not include automated checks, commands, results, pass counts, or CI status. -->
1. Run this branch in dev mode with a profile containing several hundred subscriptions and multiple loaded tabs.
2. Open the Videos subscription feed and start a refresh.
3. Scroll the feed, switch between app tabs, and open menus while fetched channels appear.
4. Confirm the feed updates progressively and the renderer remains responsive throughout the refresh.
5. Open the New feed, mark individual items as seen, and confirm its leaving-card animation still behaves normally.

## Additional context
<!-- Add any other context about the pull request here. -->
In the production-profile-sized scenario, the worst renderer frame improved from about 117 ms to 50 ms. The profile metadata pass dropped from 435,711 subscription ID reads to 933.
