### PR TITLE
fix: group external tools and prefer yt-dlp defaults

### DIFF
--- a/e2e/tests/offline/settings.spec.mjs
+++ b/e2e/tests/offline/settings.spec.mjs
@@ -69,6 +69,21 @@ async function expectMinimizeToPreserveSettingsScroll(page) {
   )).toBeLessThanOrEqual(1)
 }
 
+async function expectExternalSoftwarePathAlignment(tool, sourceName, pathPlaceholder) {
+  const source = tool.locator('.select').filter({ hasText: sourceName })
+  const [sourceBox, helpBox, pathBox] = await Promise.all([
+    source.locator('.select-text').boundingBox(),
+    source.locator('.selectIndicators button').boundingBox(),
+    tool.getByPlaceholder(pathPlaceholder).boundingBox()
+  ])
+
+  expect(sourceBox).not.toBeNull()
+  expect(helpBox).not.toBeNull()
+  expect(pathBox).not.toBeNull()
+  expect(pathBox.x).toBeCloseTo(sourceBox.x, 0)
+  expect(pathBox.x + pathBox.width).toBeCloseTo(helpBox.x + helpBox.width, 0)
+}
+
 test.describe('skip silence settings search', () => {
   test.use({ seed: { settings: { currentLocale: 'en-US' } } })
 
@@ -143,6 +158,121 @@ test.describe('settings', () => {
     expect(recoveryScriptBox.y).toBeGreaterThan(testProxyBox.y)
     expect(recoveryScriptBox.y - (testProxyBox.y + testProxyBox.height))
       .toBeGreaterThanOrEqual(16)
+  })
+
+  test('keeps each external tool grouped when its source changes', async ({ app, page }) => {
+    await app.electronApp.evaluate(({ ipcMain }) => {
+      ipcMain.removeHandler('yt-dlp-get-info')
+      ipcMain.handle('yt-dlp-get-info', (_event, options) => ({
+        ytDlp: {
+          source: options.ytDlpSource,
+          available: true,
+          version: '2026.08.19',
+          supportedBrowsers: []
+        },
+        ffmpeg: { source: options.ffmpegSource, available: true, version: '8.0' },
+        ffprobe: { source: options.ffmpegSource, available: true, version: '8.0' }
+      }))
+    })
+
+    const advanced = await goToSettingsSection(page, 'advanced')
+    const externalSoftware = advanced.locator('.settingsSection').filter({
+      has: page.getByRole('heading', { name: 'External Software', exact: true })
+    })
+    const tools = externalSoftware.locator('.externalSoftwareTool')
+    const ytDlpTool = tools.nth(0)
+    const ffmpegTool = tools.nth(1)
+
+    await expect(tools.locator('.externalSoftwareToolTitle')).toHaveText([
+      'yt-dlp',
+      'FFmpeg / FFprobe'
+    ])
+    await expect(ytDlpTool.getByRole('combobox', { name: 'yt-dlp Source' })).toBeVisible()
+    await expect(ytDlpTool.getByPlaceholder('yt-dlp Executable Path')).toBeVisible()
+    await expect(ffmpegTool.getByRole('combobox', { name: 'FFmpeg Source' })).toBeVisible()
+    await expect(ffmpegTool.getByPlaceholder('FFmpeg Executable Path')).toBeVisible()
+
+    const ytDlpSource = ytDlpTool.locator('.select').filter({ hasText: 'yt-dlp Source' })
+    const ffmpegSource = ffmpegTool.locator('.select').filter({ hasText: 'FFmpeg Source' })
+    await expect(ytDlpSource.locator('.select-icon')).toHaveCount(0)
+    await expect(ffmpegSource.locator('.select-icon')).toHaveCount(0)
+    await expectExternalSoftwarePathAlignment(
+      ytDlpTool,
+      'yt-dlp Source',
+      'yt-dlp Executable Path'
+    )
+    await expectExternalSoftwarePathAlignment(
+      ffmpegTool,
+      'FFmpeg Source',
+      'FFmpeg Executable Path'
+    )
+    const positionWithinTool = source => source.evaluate(element => {
+      const sourceBounds = element.getBoundingClientRect()
+      const toolBounds = element.closest('.externalSoftwareTool').getBoundingClientRect()
+      return {
+        x: sourceBounds.x - toolBounds.x,
+        y: sourceBounds.y - toolBounds.y
+      }
+    })
+    const positionsBefore = await Promise.all([
+      positionWithinTool(ytDlpSource),
+      positionWithinTool(ffmpegSource)
+    ])
+
+    await ytDlpSource.locator('select').selectOption('managed')
+    await expect(ytDlpTool.getByRole('combobox', { name: 'yt-dlp Channel' })).toBeVisible()
+    await expect(ytDlpTool.getByPlaceholder('yt-dlp Executable Path')).toHaveCount(0)
+    await expect(ytDlpTool.getByRole('button', { name: 'Update yt-dlp' })).toBeVisible()
+    await expect(ffmpegTool.getByPlaceholder('FFmpeg Executable Path')).toBeVisible()
+
+    const positionsAfter = await Promise.all([
+      positionWithinTool(ytDlpSource),
+      positionWithinTool(ffmpegSource)
+    ])
+    for (const index of [0, 1]) {
+      expect(positionsAfter[index].x).toBeCloseTo(positionsBefore[index].x, 0)
+      expect(positionsAfter[index].y).toBeCloseTo(positionsBefore[index].y, 0)
+    }
+
+    await ffmpegSource.locator('select').selectOption('managed')
+    await expect(ffmpegTool.getByPlaceholder('FFmpeg Executable Path')).toHaveCount(0)
+    await expect(ffmpegTool.getByRole('button', { name: 'Update FFmpeg and FFprobe' })).toBeVisible()
+    await expect(externalSoftware.getByRole('combobox', { name: 'Managed Tool Updates' })).toBeVisible()
+  })
+
+  test.describe('external software at 95% UI scale', () => {
+    test.use({
+      seed: {
+        settings: {
+          uiScale: 95,
+          ytDlpSource: 'system',
+          ytDlpFfmpegSource: 'system'
+        }
+      }
+    })
+
+    test('aligns path inputs with source controls when the cards stack', async ({ page }) => {
+      await page.setViewportSize({ width: 1000, height: 800 })
+      const advanced = await goToSettingsSection(page, 'advanced')
+      const tools = advanced.locator('.externalSoftwareTool')
+      const [ytDlpBox, ffmpegBox] = await Promise.all([
+        tools.nth(0).boundingBox(),
+        tools.nth(1).boundingBox()
+      ])
+
+      expect(ffmpegBox.y).toBeGreaterThan(ytDlpBox.y + ytDlpBox.height)
+
+      await expectExternalSoftwarePathAlignment(
+        tools.nth(0),
+        'yt-dlp Source',
+        'yt-dlp Executable Path'
+      )
+      await expectExternalSoftwarePathAlignment(
+        tools.nth(1),
+        'FFmpeg Source',
+        'FFmpeg Executable Path'
+      )
+    })
   })
 
   test('shows yt-dlp browsers dynamically and centers the optional profile field', async ({ app, page }) => {

--- a/e2e/tests/offline/video-actions.spec.mjs
+++ b/e2e/tests/offline/video-actions.spec.mjs
@@ -234,7 +234,7 @@ test.describe('video downloads', () => {
 
     let passedArguments = (await readFile(capturedArgs, 'utf8')).trim().split('\n')
     const extractorArgsIndex = passedArguments.indexOf('--extractor-args')
-    expect(passedArguments[extractorArgsIndex + 1]).toBe('youtube:player_client=web_embedded,default,-android_vr')
+    expect(passedArguments[extractorArgsIndex + 1]).toBe('youtube:player_client=default,web_embedded,-android_vr')
 
     const info = await page.evaluate(() => window.ftElectron.ytDlpGetPlaybackInfo('eeeeeeeeeee', true))
 

--- a/src/main/ytDlp.js
+++ b/src/main/ytDlp.js
@@ -1421,12 +1421,14 @@ export async function handleYtDlpGetPlaybackInfo(
   ]
 
   if (useDefaultClients !== true) {
-    // Prefer clients whose URLs are not currently subject to selective PO-token
-    // enforcement. The renderer retries with yt-dlp's defaults if none of these
-    // formats are playable or they expose only a minimal live DVR window.
+    // Prefer yt-dlp's maintained client order, while retaining web_embedded for
+    // alternate audio and excluding older Android VR defaults whose URLs can be
+    // subject to selective PO-token enforcement. The renderer retries with
+    // yt-dlp's defaults if none of these formats are playable or they expose only
+    // a minimal live DVR window.
     args.push(
       '--extractor-args',
-      'youtube:player_client=web_embedded,default,-android_vr'
+      'youtube:player_client=default,web_embedded,-android_vr'
     )
   }
 

--- a/src/renderer/components/ExternalSoftwareSettings.vue
+++ b/src/renderer/components/ExternalSoftwareSettings.vue
@@ -2,42 +2,198 @@
   <FtSettingsSection
     :title="t('Settings.External Software Settings.External Software Settings')"
   >
-    <FtFlexBox>
+    <div class="externalSoftwareTools">
+      <section
+        class="externalSoftwareTool"
+        aria-labelledby="yt-dlp-settings-heading"
+      >
+        <h4
+          id="yt-dlp-settings-heading"
+          class="externalSoftwareToolTitle"
+        >
+          <FtIcon :icon="['fas', 'download']" />
+          {{ YT_DLP_NAME }}
+        </h4>
+        <div class="externalSoftwareToolControls">
+          <FtSelect
+            class="externalSoftwareSelect"
+            :placeholder="t('Settings.External Software Settings.yt-dlp Source')"
+            :value="ytDlpSource"
+            :select-names="sourceNames"
+            :select-values="SOURCE_VALUES"
+            :tooltip="t('Tooltips.External Software Settings.yt-dlp Source')"
+            @change="updateYtDlpSource"
+          />
+          <FtSelect
+            v-if="ytDlpSource === 'managed'"
+            class="externalSoftwareSelect"
+            :placeholder="t('Settings.External Software Settings.yt-dlp Channel')"
+            :value="ytDlpChannel"
+            :select-names="CHANNEL_NAMES"
+            :select-values="CHANNEL_VALUES"
+            :tooltip="t('Tooltips.External Software Settings.yt-dlp Channel')"
+            :icon="['fas', 'download']"
+            @change="updateYtDlpChannel"
+          />
+          <FtInput
+            v-else
+            class="externalSoftwarePath"
+            :placeholder="t('Settings.External Software Settings.yt-dlp Executable Path')"
+            :show-action-button="true"
+            :allow-action-button-when-empty="true"
+            :force-action-button-icon-name="['fas', 'folder-open']"
+            :show-label="true"
+            :value="ytDlpPath"
+            :tooltip="t('Tooltips.External Software Settings.yt-dlp Executable Path')"
+            @input="updateYtDlpPath"
+            @click="chooseExecutablePath('yt-dlp')"
+          />
+        </div>
+        <div class="externalSoftwareToolStatus">
+          <p
+            v-if="ytDlpInfo === null"
+            class="ytDlpStatus"
+          >
+            {{ t('Settings.External Software Settings.Checking yt-dlp') }}
+          </p>
+          <p
+            v-else-if="!ytDlpInfo.available"
+            class="ytDlpStatus ytDlpWarning"
+          >
+            <FtIcon :icon="['fas', 'circle-exclamation']" />
+            {{ ytDlpSource === 'managed'
+              ? t('Settings.External Software Settings.Managed Not Downloaded')
+              : t('Settings.External Software Settings.System yt-dlp Missing Warning') }}
+          </p>
+          <p
+            v-else
+            class="ytDlpStatus"
+          >
+            {{ t('Settings.External Software Settings.Detected Version Template', { version: ytDlpInfo.version }) }}
+          </p>
+        </div>
+        <FtButton
+          v-if="ytDlpSource === 'managed'"
+          class="externalSoftwareToolAction"
+          :label="ytDlpBinaryDownloadInProgress
+            ? t('Settings.External Software Settings.Downloading yt-dlp')
+            : (ytDlpInfo === null
+              ? t('Settings.External Software Settings.Checking yt-dlp')
+              : ytDlpInfo.available
+                ? t('Settings.External Software Settings.Update yt-dlp')
+                : t('Settings.External Software Settings.Download yt-dlp'))"
+          :icon="['fas', 'download']"
+          :disabled="ytDlpBinaryDownloadInProgress || ytDlpInfo === null"
+          :text-color="null"
+          :background-color="null"
+          @click="downloadBinary('yt-dlp')"
+        />
+      </section>
+
+      <section
+        class="externalSoftwareTool"
+        aria-labelledby="ffmpeg-settings-heading"
+      >
+        <h4
+          id="ffmpeg-settings-heading"
+          class="externalSoftwareToolTitle"
+        >
+          <FtIcon :icon="['fas', 'file-video']" />
+          {{ FFMPEG_TOOL_NAME }}
+        </h4>
+        <div class="externalSoftwareToolControls">
+          <FtSelect
+            class="externalSoftwareSelect"
+            :placeholder="t('Settings.External Software Settings.FFmpeg Source')"
+            :value="ytDlpFfmpegSource"
+            :select-names="sourceNames"
+            :select-values="SOURCE_VALUES"
+            :tooltip="t('Tooltips.External Software Settings.FFmpeg Source')"
+            @change="updateYtDlpFfmpegSource"
+          />
+          <FtInput
+            v-if="ytDlpFfmpegSource === 'system'"
+            class="externalSoftwarePath"
+            :placeholder="t('Settings.External Software Settings.FFmpeg Executable Path')"
+            :show-action-button="true"
+            :allow-action-button-when-empty="true"
+            :force-action-button-icon-name="['fas', 'folder-open']"
+            :show-label="true"
+            :value="ytDlpFfmpegPath"
+            :tooltip="t('Tooltips.External Software Settings.FFmpeg Executable Path')"
+            @input="updateYtDlpFfmpegPath"
+            @click="chooseExecutablePath('ffmpeg')"
+          />
+        </div>
+        <div class="externalSoftwareToolStatus">
+          <p
+            v-if="ffmpegInfo === null"
+            class="ytDlpStatus"
+          >
+            {{ t('Settings.External Software Settings.Checking FFmpeg') }}
+          </p>
+          <p
+            v-else-if="!ffmpegInfo.available"
+            class="ytDlpStatus ytDlpWarning"
+          >
+            <FtIcon :icon="['fas', 'circle-exclamation']" />
+            {{ ytDlpFfmpegSource === 'managed'
+              ? t('Settings.External Software Settings.FFmpeg Managed Not Downloaded')
+              : t('Settings.External Software Settings.System FFmpeg Missing Warning') }}
+          </p>
+          <p
+            v-else
+            class="ytDlpStatus"
+          >
+            {{ t('Settings.External Software Settings.Detected FFmpeg Version Template', { version: ffmpegInfo.version }) }}
+          </p>
+          <p
+            v-if="ffprobeInfo === null"
+            class="ytDlpStatus"
+          >
+            {{ t('Settings.External Software Settings.Checking FFprobe') }}
+          </p>
+          <p
+            v-else-if="!ffprobeInfo.available"
+            class="ytDlpStatus ytDlpWarning"
+          >
+            <FtIcon :icon="['fas', 'circle-exclamation']" />
+            {{ ytDlpFfmpegSource === 'managed'
+              ? t('Settings.External Software Settings.FFprobe Managed Not Downloaded')
+              : t('Settings.External Software Settings.System FFprobe Missing Warning') }}
+          </p>
+          <p
+            v-else
+            class="ytDlpStatus"
+          >
+            {{ t('Settings.External Software Settings.Detected FFprobe Version Template', { version: ffprobeInfo.version }) }}
+          </p>
+        </div>
+        <FtButton
+          v-if="ytDlpFfmpegSource === 'managed'"
+          class="externalSoftwareToolAction"
+          :label="ffmpegBinaryDownloadInProgress
+            ? t('Settings.External Software Settings.Downloading FFmpeg and FFprobe')
+            : (ffmpegInfo === null
+              ? t('Settings.External Software Settings.Checking FFmpeg')
+              : ffmpegToolsAvailable
+                ? t('Settings.External Software Settings.Update FFmpeg and FFprobe')
+                : t('Settings.External Software Settings.Download FFmpeg and FFprobe'))"
+          :icon="['fas', 'download']"
+          :disabled="ffmpegBinaryDownloadInProgress || ffmpegInfo === null"
+          :text-color="null"
+          :background-color="null"
+          @click="downloadBinary('ffmpeg')"
+        />
+      </section>
+    </div>
+
+    <div
+      v-if="ytDlpSource === 'managed' || ytDlpFfmpegSource === 'managed'"
+      class="managedSoftwareControls"
+    >
       <FtSelect
-        v-if="ytDlpSource === 'managed'"
-        class="sourceSelect"
-        :placeholder="t('Settings.External Software Settings.yt-dlp Channel')"
-        :value="ytDlpChannel"
-        :select-names="CHANNEL_NAMES"
-        :select-values="CHANNEL_VALUES"
-        :tooltip="t('Tooltips.External Software Settings.yt-dlp Channel')"
-        :icon="['fas', 'download']"
-        @change="updateYtDlpChannel"
-      />
-      <FtSelect
-        class="sourceSelect"
-        :placeholder="t('Settings.External Software Settings.yt-dlp Source')"
-        :value="ytDlpSource"
-        :select-names="sourceNames"
-        :select-values="SOURCE_VALUES"
-        :tooltip="t('Tooltips.External Software Settings.yt-dlp Source')"
-        :icon="['fas', 'download']"
-        @change="updateYtDlpSource"
-      />
-      <FtSelect
-        class="sourceSelect"
-        :placeholder="t('Settings.External Software Settings.FFmpeg Source')"
-        :value="ytDlpFfmpegSource"
-        :select-names="sourceNames"
-        :select-values="SOURCE_VALUES"
-        :tooltip="t('Tooltips.External Software Settings.FFmpeg Source')"
-        :icon="['fas', 'file-video']"
-        @change="updateYtDlpFfmpegSource"
-      />
-    </FtFlexBox>
-    <FtFlexBox v-if="ytDlpSource === 'managed' || ytDlpFfmpegSource === 'managed'">
-      <FtSelect
-        class="sourceSelect"
+        class="externalSoftwareSelect"
         :placeholder="t('Settings.External Software Settings.Managed Tool Updates')"
         :value="externalSoftwareUpdateMode"
         :select-names="updateModeNames"
@@ -46,108 +202,7 @@
         :icon="['fas', 'sync']"
         @change="updateExternalSoftwareUpdateMode"
       />
-    </FtFlexBox>
-    <FtFlexBox class="binaryStatusStart">
-      <p
-        v-if="ytDlpInfo === null"
-        class="ytDlpStatus"
-      >
-        {{ t('Settings.External Software Settings.Checking yt-dlp') }}
-      </p>
-      <p
-        v-else-if="!ytDlpInfo.available"
-        class="ytDlpStatus ytDlpWarning"
-      >
-        <FtIcon :icon="['fas', 'circle-exclamation']" />
-        {{ ytDlpSource === 'managed'
-          ? t('Settings.External Software Settings.Managed Not Downloaded')
-          : t('Settings.External Software Settings.System yt-dlp Missing Warning') }}
-      </p>
-      <p
-        v-else
-        class="ytDlpStatus"
-      >
-        {{ t('Settings.External Software Settings.Detected Version Template', { version: ytDlpInfo.version }) }}
-      </p>
-    </FtFlexBox>
-    <FtFlexBox>
-      <p
-        v-if="ffmpegInfo === null"
-        class="ytDlpStatus"
-      >
-        {{ t('Settings.External Software Settings.Checking FFmpeg') }}
-      </p>
-      <p
-        v-else-if="!ffmpegInfo.available"
-        class="ytDlpStatus ytDlpWarning"
-      >
-        <FtIcon :icon="['fas', 'circle-exclamation']" />
-        {{ ytDlpFfmpegSource === 'managed'
-          ? t('Settings.External Software Settings.FFmpeg Managed Not Downloaded')
-          : t('Settings.External Software Settings.System FFmpeg Missing Warning') }}
-      </p>
-      <p
-        v-else
-        class="ytDlpStatus"
-      >
-        {{ t('Settings.External Software Settings.Detected FFmpeg Version Template', { version: ffmpegInfo.version }) }}
-      </p>
-    </FtFlexBox>
-    <FtFlexBox class="binaryStatusEnd">
-      <p
-        v-if="ffprobeInfo === null"
-        class="ytDlpStatus"
-      >
-        {{ t('Settings.External Software Settings.Checking FFprobe') }}
-      </p>
-      <p
-        v-else-if="!ffprobeInfo.available"
-        class="ytDlpStatus ytDlpWarning"
-      >
-        <FtIcon :icon="['fas', 'circle-exclamation']" />
-        {{ ytDlpFfmpegSource === 'managed'
-          ? t('Settings.External Software Settings.FFprobe Managed Not Downloaded')
-          : t('Settings.External Software Settings.System FFprobe Missing Warning') }}
-      </p>
-      <p
-        v-else
-        class="ytDlpStatus"
-      >
-        {{ t('Settings.External Software Settings.Detected FFprobe Version Template', { version: ffprobeInfo.version }) }}
-      </p>
-    </FtFlexBox>
-    <FtFlexBox v-if="ytDlpSource === 'managed' || ytDlpFfmpegSource === 'managed'">
-      <FtButton
-        v-if="ytDlpSource === 'managed'"
-        :label="ytDlpBinaryDownloadInProgress
-          ? t('Settings.External Software Settings.Downloading yt-dlp')
-          : (ytDlpInfo === null
-            ? t('Settings.External Software Settings.Checking yt-dlp')
-            : ytDlpInfo.available
-              ? t('Settings.External Software Settings.Update yt-dlp')
-              : t('Settings.External Software Settings.Download yt-dlp'))"
-        :icon="['fas', 'download']"
-        :disabled="ytDlpBinaryDownloadInProgress || ytDlpInfo === null"
-        :text-color="null"
-        :background-color="null"
-        @click="downloadBinary('yt-dlp')"
-      />
-      <FtButton
-        v-if="ytDlpFfmpegSource === 'managed'"
-        :label="ffmpegBinaryDownloadInProgress
-          ? t('Settings.External Software Settings.Downloading FFmpeg and FFprobe')
-          : (ffmpegInfo === null
-            ? t('Settings.External Software Settings.Checking FFmpeg')
-            : ffmpegToolsAvailable
-              ? t('Settings.External Software Settings.Update FFmpeg and FFprobe')
-              : t('Settings.External Software Settings.Download FFmpeg and FFprobe'))"
-        :icon="['fas', 'download']"
-        :disabled="ffmpegBinaryDownloadInProgress || ffmpegInfo === null"
-        :text-color="null"
-        :background-color="null"
-        @click="downloadBinary('ffmpeg')"
-      />
-    </FtFlexBox>
+    </div>
     <!-- extra wrapper, as the section adds inline padding to direct div children,
       which would offset the fill inside the track -->
     <div v-if="binaryDownloadProgress !== null">
@@ -159,35 +214,6 @@
         />
       </div>
     </div>
-    <FtFlexBox
-      v-if="ytDlpSource === 'system' || ytDlpFfmpegSource === 'system'"
-      class="executablePathInputs settingsFlexStart460px"
-    >
-      <FtInput
-        v-if="ytDlpSource === 'system'"
-        :placeholder="t('Settings.External Software Settings.yt-dlp Executable Path')"
-        :show-action-button="true"
-        :allow-action-button-when-empty="true"
-        :force-action-button-icon-name="['fas', 'folder-open']"
-        :show-label="true"
-        :value="ytDlpPath"
-        :tooltip="t('Tooltips.External Software Settings.yt-dlp Executable Path')"
-        @input="updateYtDlpPath"
-        @click="chooseExecutablePath('yt-dlp')"
-      />
-      <FtInput
-        v-if="ytDlpFfmpegSource === 'system'"
-        :placeholder="t('Settings.External Software Settings.FFmpeg Executable Path')"
-        :show-action-button="true"
-        :allow-action-button-when-empty="true"
-        :force-action-button-icon-name="['fas', 'folder-open']"
-        :show-label="true"
-        :value="ytDlpFfmpegPath"
-        :tooltip="t('Tooltips.External Software Settings.FFmpeg Executable Path')"
-        @input="updateYtDlpFfmpegPath"
-        @click="chooseExecutablePath('ffmpeg')"
-      />
-    </FtFlexBox>
   </FtSettingsSection>
   <FtSettingsSection
     :title="t('Settings.External Software Settings.Restricted Playback Authentication')"
@@ -279,6 +305,8 @@ import { showToast } from '../helpers/utils'
 
 const { t } = useI18n()
 
+const YT_DLP_NAME = 'yt-dlp'
+const FFMPEG_TOOL_NAME = 'FFmpeg / FFprobe'
 const SOURCE_VALUES = ['system', 'managed']
 const CHANNEL_NAMES = ['Stable', 'Nightly', 'Master']
 const CHANNEL_VALUES = ['stable', 'nightly', 'master']
@@ -718,17 +746,83 @@ async function chooseBrowserProfilePath() {
 </script>
 
 <style scoped>
-.sourceSelect {
+.externalSoftwareTools {
+  --external-software-select-gutter: 70px;
+  --external-software-help-width: 28px;
+
+  align-items: stretch;
+  display: grid;
+  gap: 18px;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  margin-block: 8px 18px;
+  margin-inline: auto;
+  max-inline-size: 860px;
+}
+
+.externalSoftwareTool {
+  border-radius: calc(6px * var(--ui-roundness));
+  box-sizing: border-box;
+  display: flex;
+  flex-direction: column;
+  min-inline-size: 0;
+  padding-block: 14px 18px;
+  padding-inline: 18px;
+}
+
+.externalSoftwareToolTitle {
+  align-items: center;
+  display: flex;
+  font-size: 18px;
+  gap: 8px;
+  margin-block: 0 6px;
+  margin-inline: 0;
+}
+
+.externalSoftwareToolTitle :deep(.ft-icon) {
+  color: var(--accent-color);
+}
+
+.externalSoftwareToolControls {
+  display: flex;
+  flex-direction: column;
+  min-inline-size: 0;
+}
+
+.externalSoftwareSelect {
+  inline-size: calc(100% - var(--external-software-select-gutter));
+  max-inline-size: 340px;
+}
+
+.externalSoftwarePath {
+  inline-size: calc(
+    100% - var(--external-software-select-gutter) + var(--external-software-help-width)
+  );
+  margin-block-start: 24px;
+  max-inline-size: calc(340px + var(--external-software-help-width));
+}
+
+.externalSoftwareToolStatus {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+  margin-block: 20px 14px;
+  text-align: center;
+}
+
+.externalSoftwareToolAction {
+  align-self: center;
+  margin-block: auto 5px;
+}
+
+.managedSoftwareControls {
+  display: flex;
+  justify-content: center;
+  margin-block-end: 12px;
+}
+
+.managedSoftwareControls .externalSoftwareSelect {
   inline-size: 250px;
-}
-
-.executablePathInputs {
-  column-gap: 12px;
-}
-
-.executablePathInputs :deep(.ft-input-component) {
-  inline-size: 340px;
-  max-inline-size: 100%;
+  margin-inline-start: 70px;
 }
 
 .restrictedPlaybackAuthControls {
@@ -788,14 +882,6 @@ async function chooseBrowserProfilePath() {
   text-align: center;
 }
 
-.binaryStatusStart {
-  margin-block-start: 8px;
-}
-
-.binaryStatusEnd {
-  margin-block-end: 8px;
-}
-
 .ytDlpStatus {
   margin-block: 0;
 }
@@ -843,8 +929,32 @@ async function chooseBrowserProfilePath() {
   }
 }
 
-@media only screen and (width <= 800px) {
-  .sourceSelect {
+@container settings-content (width <= 800px) {
+  .externalSoftwareTools {
+    grid-template-columns: minmax(0, 1fr);
+    max-inline-size: 520px;
+  }
+}
+
+@container settings-content (width <= 460px) {
+  .externalSoftwareTools {
+    --external-software-select-gutter: 28px;
+  }
+
+  .externalSoftwareTool {
+    padding-inline: 14px;
+  }
+
+  .externalSoftwareSelect,
+  .managedSoftwareControls .externalSoftwareSelect {
+    margin-inline: 0 28px;
+  }
+
+  .externalSoftwareSelect {
+    inline-size: calc(100% - var(--external-software-select-gutter));
+  }
+
+  .managedSoftwareControls .externalSoftwareSelect {
     inline-size: calc(100% - 28px);
   }
 }


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Make sure to follow the contributing guidelines. -->
<!-- Important note, we may remove your pull request if you do not use this provided PR template correctly. -->
<!-- Agent instructions: Preserve every heading, comment, and marker in this template. Never remove or rewrite the release-note-category:start/end, release-note:start/end, or release-note-image:start/end marker pairs. Never remove or rewrite the Release note images section; leave its contents for a human. -->

## Pull Request Type
<!-- Please select what type of pull request this is: [x] -->
- [x] Bugfix
- [ ] Feature Implementation
- [ ] Documentation
- [ ] Other

## Related issue
<!-- Please link the issue your pull request is referring to. -->
<!-- If this pull request fully resolves the relevant issue, put "closes" before the issue number. -->
<!-- Example: "closes #123456". -->

## Description
<!-- Please write a clear and concise description of what the pull request does. -->
Changing an external tool's source could move its related controls, versions, and actions around the section. This made it easy to lose track of which setting belonged to yt-dlp and which belonged to FFmpeg or FFprobe.

This keeps each tool in a stable, responsive column with its source, path or channel, detected versions, and managed action. It also follows yt-dlp's maintained default YouTube client order before trying `web_embedded`, which remains available for alternate audio formats.

## Release note category
<!-- Select exactly one category. Every pull request must select one. -->
<!-- Select "Not noteworthy" when the pull request fixes a bug in or improves functionality that has not yet appeared in a stable release. -->
<!-- release-note-category:start -->
- [ ] Not noteworthy
- [ ] Highlights
- [x] More improvements
- [ ] Fixed bugs
<!-- release-note-category:end -->

## Release note
<!-- Required unless "Not noteworthy" is selected. -->
<!-- Write one concise, user-facing entry without a leading bullet. -->
<!-- release-note:start -->
External software settings now keep yt-dlp and FFmpeg controls grouped, while YouTube playback follows yt-dlp's maintained client order before using the embedded fallback.
<!-- release-note:end -->

## Release note images
<!-- Human-only: Agents must preserve this entire section and leave it empty. -->
<!-- Optional. Paste one or more Markdown images or HTML image tags here. -->
<!-- The release notes will use an HTML image tag and limit images taller than 300 pixels. -->
<!-- release-note-image:start -->

<!-- release-note-image:end -->

## Testing
<!-- How can reviewers verify that the PR produces correct results? -->
<!-- Please provide instructions so that others can ensure that your pull request would produce correct results. For examples see, https://github.com/FreeTubeApp/FreeTube/pull/5743, https://github.com/FreeTubeApp/FreeTube/pull/7349, https://github.com/FreeTubeApp/FreeTube/pull/5125, https://github.com/FreeTubeApp/FreeTube/pull/7338 -->
<!-- Agent instructions: Only write human-facing steps that explain how to verify the change while running this branch in dev mode. Include expected results and, when applicable, helpful console snippets for interactive verification. Do not include automated checks, commands, results, pass counts, or CI status. -->
1. Open Settings, go to Advanced, and find External Software.
2. Change the yt-dlp and FFmpeg sources between system and managed. Each tool's controls, detected versions, and update action should stay under its own heading without moving the other tool.
3. Resize the settings window until the tool columns stack. Both groups should remain readable, and each executable path should end at the same edge as its source selector and help icon.
4. Play a YouTube video with alternate audio tracks and switch tracks. Playback should continue with the selected audio.

## Additional context
<!-- Add any other context about the pull request here. -->
The explicit `web_embedded` fallback remains in place. The Android VR client stays excluded because its URLs can require a PO token.
