### PR TITLE
feat(settings): improve data controls, selects, and SponsorBlock colors

### DIFF
--- a/e2e/tests/offline/data-settings.spec.mjs
+++ b/e2e/tests/offline/data-settings.spec.mjs
@@ -1,0 +1,83 @@
+import { expect, goToSettingsSection, test } from '../../helpers/app.mjs'
+
+test('shows icons on data actions and vertically centers export choices', async ({ page }) => {
+  const dataSection = await goToSettingsSection(page, 'data')
+  const actionButtons = dataSection.locator('.ft-flex-box.box > .btn')
+
+  await expect(actionButtons).toHaveCount(12)
+  await expect.poll(() => actionButtons.locator(':scope > .ft-icon').count()).toBe(12)
+
+  await dataSection.getByRole('button', { name: /Export Subscriptions/i }).click()
+  const exportChoices = page.locator('.settingsSubpageContent .exportTypeButtons')
+  await expect(exportChoices).toHaveCSS('align-content', 'center')
+  await expect(exportChoices).toHaveCSS('align-items', 'center')
+  await expect(exportChoices).toHaveCSS('justify-content', 'space-evenly')
+  await expect.poll(() => exportChoices.evaluate(container => {
+    const subpage = container.closest('.settingsSubpageContent')
+    const buttons = [...container.querySelectorAll('button')]
+    if (!subpage || buttons.length === 0) return Number.POSITIVE_INFINITY
+
+    const subpageRect = subpage.getBoundingClientRect()
+    const buttonRects = buttons.map(button => button.getBoundingClientRect())
+    const buttonsTop = Math.min(...buttonRects.map(rect => rect.top))
+    const buttonsBottom = Math.max(...buttonRects.map(rect => rect.bottom))
+    const subpageCenter = (subpageRect.top + subpageRect.bottom) / 2
+    const buttonsCenter = (buttonsTop + buttonsBottom) / 2
+    return Math.abs(subpageCenter - buttonsCenter)
+  })).toBeLessThanOrEqual(1)
+  await expect.poll(() => exportChoices.getByRole('button').evaluateAll(buttons => (
+    buttons.length > 0 && buttons.every(button => button.querySelector('.ft-icon'))
+  ))).toBe(true)
+})
+
+test('opens the profile directory in the file manager', async ({ app }) => {
+  const { electronApp, page, userDataDir } = app
+  await electronApp.evaluate(({ shell }) => {
+    globalThis.openedProfileDirectory = null
+    shell.openPath = async (directory) => {
+      globalThis.openedProfileDirectory = directory
+      return ''
+    }
+  })
+
+  const dataSection = await goToSettingsSection(page, 'data')
+  await expect(dataSection.locator('.groupTitle').last()).toHaveText(/Profile directory/i)
+  await dataSection.getByRole('button', { name: /Open Profile Directory/i }).click()
+
+  await expect.poll(() => electronApp.evaluate(() => globalThis.openedProfileDirectory))
+    .toBe(userDataDir)
+})
+
+test('does not show a delayed IPC error after opening the profile directory', async ({ app }) => {
+  const { electronApp, page, userDataDir } = app
+  await electronApp.evaluate(({ shell }) => {
+    globalThis.openedProfileDirectory = null
+    globalThis.profileDirectoryOpenSettled = false
+    shell.openPath = async (directory) => {
+      globalThis.openedProfileDirectory = directory
+      await new Promise(resolve => setTimeout(resolve, 50))
+      globalThis.profileDirectoryOpenSettled = true
+      throw new Error('reply was never sent')
+    }
+  })
+
+  const dataSection = await goToSettingsSection(page, 'data')
+  await page.evaluate(() => {
+    globalThis.profileDirectoryErrorToastShown = false
+    const observer = new MutationObserver(() => {
+      if (document.body.textContent.includes('Unable to open profile directory')) {
+        globalThis.profileDirectoryErrorToastShown = true
+        observer.disconnect()
+      }
+    })
+    observer.observe(document.body, { childList: true, subtree: true })
+  })
+  await dataSection.getByRole('button', { name: /Open Profile Directory/i }).click()
+
+  await expect.poll(() => electronApp.evaluate(() => globalThis.openedProfileDirectory))
+    .toBe(userDataDir)
+  await expect.poll(() => electronApp.evaluate(() => globalThis.profileDirectoryOpenSettled))
+    .toBe(true)
+  await page.waitForTimeout(2500)
+  expect(await page.evaluate(() => globalThis.profileDirectoryErrorToastShown)).toBe(false)
+})

--- a/e2e/tests/offline/settings.spec.mjs
+++ b/e2e/tests/offline/settings.spec.mjs
@@ -319,6 +319,43 @@ test.describe('settings', () => {
     expect(paletteColors).toEqual(['rgb(76, 175, 80)', 'rgb(255, 235, 59)'])
   })
 
+  test('offers a custom SponsorBlock category color initialized from its default', async ({ app, page }) => {
+    const addOns = await goToSettingsSection(page, 'add-ons')
+    await addOns.locator('label.switch-label').filter({ hasText: 'Enable SponsorBlock' }).click()
+
+    const sponsorCategory = addOns.locator('.sponsorBlockCategory')
+      .filter({ has: page.locator('.sponsorTitle', { hasText: /^Sponsor$/ }) })
+    const colorSelect = sponsorCategory.locator('.select-text').first()
+    await colorSelect.click()
+
+    const colorOptions = page.locator('.selectDropdown .selectOption')
+    await expect(colorOptions.first()).toHaveText('Custom color')
+    await colorOptions.first().click()
+
+    const picker = sponsorCategory.locator('.ftColorPicker')
+    await expect(picker.getByRole('button', { name: 'Custom color' })).toBeVisible()
+    await expect(picker.locator('code')).toHaveText('#4caf50')
+    await expect(sponsorCategory.locator('.select-icon').first())
+      .toHaveCSS('color', 'rgb(76, 175, 80)')
+
+    await picker.getByRole('button', { name: 'Custom color' }).click()
+    const pickerDialog = page.getByRole('dialog', { name: 'Custom color' })
+    const hexColor = pickerDialog.getByLabel('Hex color')
+    await hexColor.fill('#123456')
+    await hexColor.press('Enter')
+    await pickerDialog.getByRole('button', { name: 'Apply' }).click()
+
+    await expect(picker.locator('code')).toHaveText('#123456')
+    await expect(sponsorCategory.locator('.select-icon').first())
+      .toHaveCSS('color', 'rgb(18, 52, 86)')
+    await expect.poll(async () => {
+      const settings = latestSettings(
+        await readFile(path.join(app.userDataDir, 'settings.db'), 'utf8')
+      )
+      return settings.sponsorBlockSponsor
+    }).toEqual({ color: '#123456', skip: 'autoSkip' })
+  })
+
   test('keeps General selects compact with tooltip indicators inside their width', async ({ page, attachScreenshot }) => {
     await goTo(page, 'settings')
 
@@ -1683,6 +1720,39 @@ test.describe('settings', () => {
     await page.getByRole('combobox', { name: 'Preferred API backend' }).click()
     await expect(dropdown).toBeVisible()
     expect(await dropdown.evaluate(menu => menu.scrollHeight <= menu.clientHeight)).toBe(true)
+  })
+
+  test('contains wheel scrolling at the ends of select dropdowns', async ({ page }) => {
+    await goTo(page, 'settings')
+
+    await page.evaluate(() => {
+      document.body.style.minBlockSize = '4000px'
+      document.scrollingElement.scrollTop = 1000
+    })
+    await expect.poll(() => page.evaluate(() => document.scrollingElement.scrollTop))
+      .toBe(1000)
+
+    await page.getByRole('combobox', { name: /Language preference|Locale Preference/ }).click()
+    const dropdown = page.locator('.selectDropdown')
+    await expect(dropdown).toBeVisible()
+    await dropdown.hover()
+
+    for (const { dropdownEnd, wheelDelta } of [
+      { dropdownEnd: 'bottom', wheelDelta: 1000 },
+      { dropdownEnd: 'top', wheelDelta: -1000 }
+    ]) {
+      await dropdown.evaluate((element, end) => {
+        element.scrollTop = end === 'bottom' ? element.scrollHeight : 0
+      }, dropdownEnd)
+      const pageScrollTop = await page.evaluate(() => document.scrollingElement.scrollTop)
+
+      for (let index = 0; index < 5; index++) {
+        await page.mouse.wheel(0, wheelDelta)
+      }
+
+      await expect.poll(() => page.evaluate(() => document.scrollingElement.scrollTop))
+        .toBe(pageScrollTop)
+    }
   })
 
   test('closes without replacing the underlying page', async ({ page }) => {
@@ -3598,7 +3668,7 @@ test.describe('synced setting indicators', () => {
     await expect(tooltipText).toBeVisible()
 
     const neighboringIndicators = page.locator('.select')
-      .filter({ hasText: 'Keep original text' })
+      .filter({ hasText: 'Prefer untranslated video text' })
       .locator('.selectIndicators')
     const [tooltipBox, indicatorsBox] = await Promise.all([
       tooltipText.boundingBox(),

--- a/e2e/tests/offline/watch-page.spec.mjs
+++ b/e2e/tests/offline/watch-page.spec.mjs
@@ -1671,6 +1671,47 @@ test.describe('watch page', () => {
     await expect(sponsorBlock.locator('.os-scrollbar-vertical')).toHaveCount(1)
   })
 
+  test('uses a custom SponsorBlock category color for markers and prompts', async ({ app, page }) => {
+    await mockPlayableWatchPage(app, page)
+    await page.route('**/api/skipSegments/**', route => route.fulfill({
+      body: JSON.stringify([{
+        videoID: 'jNQXAC9IVRw',
+        segments: [{
+          UUID: 'custom-color-sponsor',
+          actionType: 'skip',
+          category: 'sponsor',
+          description: '',
+          locked: 0,
+          segment: [15, 20],
+          videoDuration: 30,
+          votes: 1
+        }]
+      }]),
+      contentType: 'application/json'
+    }))
+    await page.evaluate(() => {
+      const store = document.querySelector('#app').__vue_app__.config.globalProperties.$store
+      store.commit('setUseSponsorBlock', true)
+      store.commit('setSponsorBlockSponsor', { color: '#123456', skip: 'promptToSkip' })
+    })
+
+    await openMockedVideo(page)
+
+    const marker = page.locator('.sponsorBlockMarker')
+    await expect(marker).toHaveCount(1)
+    await expect(marker).toHaveCSS('background-color', 'rgb(18, 52, 86)')
+
+    const video = page.locator('.ftVideoPlayer video')
+    await video.evaluate(element => {
+      element.pause()
+      element.currentTime = 16
+      element.dispatchEvent(new Event('timeupdate'))
+    })
+    const prompt = page.locator('.skippedSegment').filter({ hasText: 'Skip Sponsor?' })
+    await expect(prompt).toBeVisible()
+    await expect(prompt.locator('.skippedSegmentShield')).toHaveCSS('color', 'rgb(18, 52, 86)')
+  })
+
   test('does not restore a SponsorBlock prompt when a skip remains inside the segment', async ({ app, page }) => {
     await mockPlayableWatchPage(app, page)
     await page.route('**/api/skipSegments/**', route => route.fulfill({

--- a/src/constants.js
+++ b/src/constants.js
@@ -123,6 +123,7 @@ const IpcChannels = {
 
   GENERATE_PO_TOKEN: 'generate-po-token',
 
+  OPEN_PROFILE_DIRECTORY: 'open-profile-directory',
   CHOOSE_DEFAULT_FOLDER: 'choose-default-folder',
   CHOOSE_IP_BLOCK_RECOVERY_SCRIPT: 'choose-ip-block-recovery-script',
   WRITE_TO_DEFAULT_FOLDER: 'write-to-default-folder',

--- a/src/main/index.js
+++ b/src/main/index.js
@@ -3599,6 +3599,20 @@ function runApp() {
     }
   })
 
+  ipcMain.on(IpcChannels.OPEN_PROFILE_DIRECTORY, (event) => {
+    if (!isOpenTubeXUrl(event.senderFrame.url)) {
+      return
+    }
+
+    shell.openPath(app.getPath('userData')).then((error) => {
+      if (error) {
+        console.error(`Unable to open profile directory: ${error}`)
+      }
+    }).catch((error) => {
+      console.error('Unable to open profile directory', error)
+    })
+  })
+
   /**
    * @param {import('electron').WebContents} webContents
    * @param {string | undefined} [currentPath]

--- a/src/preload/interface.js
+++ b/src/preload/interface.js
@@ -228,6 +228,10 @@ export default {
     return ipcRenderer.invoke(IpcChannels.GENERATE_PO_TOKEN, videoId, context, initialAttestationData, ytConfig)
   },
 
+  openProfileDirectory: () => {
+    ipcRenderer.send(IpcChannels.OPEN_PROFILE_DIRECTORY)
+  },
+
   chooseDefaultFolder: () => {
     ipcRenderer.send(IpcChannels.CHOOSE_DEFAULT_FOLDER)
   },

--- a/src/renderer/components/DataSettings/DataSettings.css
+++ b/src/renderer/components/DataSettings/DataSettings.css
@@ -2,6 +2,12 @@
   justify-content: center;
 }
 
+.exportTypeButtons {
+  align-content: center;
+  align-items: center;
+  flex: 1;
+}
+
 .importFormatsHint {
   color: var(--secondary-text-color);
   font-size: 0.9em;

--- a/src/renderer/components/DataSettings/DataSettings.vue
+++ b/src/renderer/components/DataSettings/DataSettings.vue
@@ -8,14 +8,17 @@
     <FtFlexBox class="box">
       <FtButton
         :label="$t('Settings.Data Settings.Import Subscriptions')"
+        :icon="['fas', 'folder-open']"
         @click="importSubscriptions"
       />
       <FtButton
         :label="$t('Settings.Data Settings.Manage Subscriptions')"
+        :icon="['fas', 'users']"
         @click="openProfileSettings"
       />
       <FtButton
         :label="$t('Settings.Data Settings.Export Subscriptions')"
+        :icon="['fas', 'file-download']"
         @click="showExportSubscriptionsPrompt = true"
       />
     </FtFlexBox>
@@ -35,10 +38,12 @@
     <FtFlexBox class="box">
       <FtButton
         :label="$t('Settings.Data Settings.Import History')"
+        :icon="['fas', 'folder-open']"
         @click="importWatchHistory"
       />
       <FtButton
         :label="$t('Settings.Data Settings.Export History')"
+        :icon="['fas', 'file-download']"
         @click="showExportWatchHistoryPrompt = true"
       />
     </FtFlexBox>
@@ -51,10 +56,12 @@
     <FtFlexBox class="box">
       <FtButton
         :label="$t('Settings.Data Settings.Import Playlists')"
+        :icon="['fas', 'folder-open']"
         @click="importPlaylists"
       />
       <FtButton
         :label="$t('Settings.Data Settings.Export Playlists')"
+        :icon="['fas', 'file-download']"
         @click="exportPlaylists"
       />
     </FtFlexBox>
@@ -67,10 +74,12 @@
     <FtFlexBox class="box">
       <FtButton
         :label="t('Settings.Data Settings.Import search history')"
+        :icon="['fas', 'folder-open']"
         @click="importSearchHistory"
       />
       <FtButton
         :label="t('Settings.Data Settings.Export search history')"
+        :icon="['fas', 'file-download']"
         @click="showExportSearchHistoryPrompt = true"
       />
     </FtFlexBox>
@@ -88,24 +97,39 @@
     <FtFlexBox class="box">
       <FtButton
         :label="t('Settings.Data Settings.Import Settings')"
+        :icon="['fas', 'folder-open']"
         @click="importSettings"
       />
       <FtButton
         :label="t('Settings.Data Settings.Export Settings')"
+        :icon="['fas', 'file-download']"
         @click="exportSettings"
       />
     </FtFlexBox>
+    <template v-if="isElectron">
+      <h4 class="groupTitle">
+        {{ t('Settings.Data Settings.Profile Directory') }}
+      </h4>
+      <FtFlexBox class="box">
+        <FtButton
+          :label="t('Settings.Data Settings.Open Profile Directory')"
+          :icon="['fas', 'folder-open']"
+          @click="openProfileDirectory"
+        />
+      </FtFlexBox>
+    </template>
     <FtSettingsSubpage
       :open="showExportSubscriptionsPrompt"
       :title="t('Settings.Data Settings.Select Export Type')"
       :icon="['fas', 'file-download']"
       @close="showExportSubscriptionsPrompt = false"
     >
-      <FtFlexBox>
+      <FtFlexBox class="exportTypeButtons">
         <FtButton
           v-for="(name, index) in exportSubscriptionsPromptNames.slice(0, SUBSCRIPTIONS_PROMPT_VALUES.length - 1)"
           :key="SUBSCRIPTIONS_PROMPT_VALUES[index]"
           :label="name"
+          :icon="['fas', 'file-download']"
           @click="exportSubscriptions(SUBSCRIPTIONS_PROMPT_VALUES[index])"
         />
       </FtFlexBox>
@@ -116,11 +140,12 @@
       :icon="['fas', 'file-download']"
       @close="showExportWatchHistoryPrompt = false"
     >
-      <FtFlexBox>
+      <FtFlexBox class="exportTypeButtons">
         <FtButton
           v-for="(name, index) in exportWatchSearchHistoryPromptNames.slice(0, WATCH_SEARCH_HISTORY_PROMPT_VALUES.length)"
           :key="WATCH_SEARCH_HISTORY_PROMPT_VALUES[index]"
           :label="name"
+          :icon="['fas', 'file-download']"
           @click="exportWatchHistory(WATCH_SEARCH_HISTORY_PROMPT_VALUES[index])"
         />
       </FtFlexBox>
@@ -131,11 +156,12 @@
       :icon="['fas', 'file-download']"
       @close="showExportSearchHistoryPrompt = false"
     >
-      <FtFlexBox>
+      <FtFlexBox class="exportTypeButtons">
         <FtButton
           v-for="(name, index) in exportWatchSearchHistoryPromptNames.slice(0, WATCH_SEARCH_HISTORY_PROMPT_VALUES.length)"
           :key="WATCH_SEARCH_HISTORY_PROMPT_VALUES[index]"
           :label="name"
+          :icon="['fas', 'file-download']"
           @click="exportSearchHistory(WATCH_SEARCH_HISTORY_PROMPT_VALUES[index])"
         />
       </FtFlexBox>
@@ -179,8 +205,14 @@ import {
 
 const IMPORT_DIRECTORY_ID = 'data-settings-import'
 const START_IN_DIRECTORY = 'downloads'
+const isElectron = process.env.IS_ELECTRON
 
 const { t } = useI18n()
+
+function openProfileDirectory() {
+  window.ftElectron.openProfileDirectory()
+}
+
 function openProfileSettings() {
   store.dispatch('showSettingsWindow', 'profile')
 }

--- a/src/renderer/components/FtSelect/FtSelect.css
+++ b/src/renderer/components/FtSelect/FtSelect.css
@@ -81,6 +81,7 @@
   z-index: 12;
   box-sizing: border-box;
   overflow-y: auto;
+  overscroll-behavior: contain;
   padding-block: 4px;
   padding-inline: 0;
   margin: 0;

--- a/src/renderer/components/FtSponsorBlockCategory/FtSponsorBlockCategory.css
+++ b/src/renderer/components/FtSponsorBlockCategory/FtSponsorBlockCategory.css
@@ -16,6 +16,10 @@
   inline-size: 100%;
 }
 
+.sponsorBlockColorPicker {
+  margin-block-start: 12px;
+}
+
 @media only screen and (width <= 680px) {
   .sponsorBlockCategory {
     inline-size: 100%;

--- a/src/renderer/components/FtSponsorBlockCategory/FtSponsorBlockCategory.vue
+++ b/src/renderer/components/FtSponsorBlockCategory/FtSponsorBlockCategory.vue
@@ -9,16 +9,24 @@
     <FtSelect
       :describe-by-id="id"
       :placeholder="$t('Settings.SponsorBlock Settings.Category Color')"
-      :value="sponsorBlockValues.color"
+      :value="colorSelectValue"
       :setting-key="settingKey"
       :is-changed="isValueChanged('color')"
       :select-names="colorNames"
-      :select-values="COLOR_VALUES"
+      :select-values="COLOR_SELECT_VALUES"
       :icon="['fas', 'palette']"
-      :class="'sec' + sponsorBlockValues.color"
-      icon-color="rgb(var(--accent-color-rgb))"
+      :class="colorSelectClass"
+      :icon-color="colorIconColor"
       @change="updateColor"
       @reset="resetValue('color')"
+    />
+    <FtColorPicker
+      v-if="customColorSelected"
+      class="sponsorBlockColorPicker"
+      :label="t('Settings.SponsorBlock Settings.Custom Color')"
+      :model-value="sponsorBlockValues.color"
+      :allow-alpha="false"
+      @update:model-value="updateColor"
     />
     <FtSelect
       :describe-by-id="id"
@@ -39,12 +47,13 @@
 import { computed, useId } from 'vue'
 import { useI18n } from 'vue-i18n'
 
+import FtColorPicker from '../FtColorPicker/FtColorPicker.vue'
 import FtSelect from '../FtSelect/FtSelect.vue'
 
 import store from '../../store/index'
 import { DEFAULT_SETTINGS } from '../../store/modules/settings'
 
-import { colors } from '../../helpers/colors'
+import { colors, isHexColor } from '../../helpers/colors'
 import { useColorTranslations } from '../../composables/colors'
 
 const props = defineProps({
@@ -82,8 +91,15 @@ const selectableSkipValues = computed(() => {
 
 const skipNames = computed(() => selectableSkipValues.value.map(value => skipOptionNamesByValue.value[value]))
 
+const CUSTOM_COLOR_VALUE = 'custom'
 const COLOR_VALUES = colors.map(color => color.name)
-const colorNames = useColorTranslations()
+const COLOR_VALUE_SET = new Set(COLOR_VALUES)
+const COLOR_SELECT_VALUES = [CUSTOM_COLOR_VALUE, ...COLOR_VALUES]
+const presetColorNames = useColorTranslations()
+const colorNames = computed(() => [
+  t('Settings.SponsorBlock Settings.Custom Color'),
+  ...presetColorNames.value
+])
 
 const id = useId()
 
@@ -122,6 +138,21 @@ const sponsorBlockValues = computed(() => ({
     ? 'promptToSkip'
     : storedSponsorBlockValues.value.skip
 }))
+
+const customColorSelected = computed(() => isHexColor(sponsorBlockValues.value.color))
+const colorSelectValue = computed(() => {
+  if (customColorSelected.value) return CUSTOM_COLOR_VALUE
+  if (COLOR_VALUE_SET.has(sponsorBlockValues.value.color)) return sponsorBlockValues.value.color
+  return DEFAULT_SETTINGS[settingKey.value].color
+})
+const colorSelectClass = computed(() => (
+  customColorSelected.value ? null : `sec${colorSelectValue.value}`
+))
+const colorIconColor = computed(() => (
+  customColorSelected.value
+    ? sponsorBlockValues.value.color
+    : 'rgb(var(--accent-color-rgb))'
+))
 
 const translatedCategoryName = computed(() => {
   switch (props.categoryName) {
@@ -193,8 +224,21 @@ function resetValue(property) {
 function updateColor(color) {
   updateSponsorCategory({
     ...storedSponsorBlockValues.value,
-    color,
+    color: color === CUSTOM_COLOR_VALUE ? resolveDefaultCustomColor() : color,
   })
+}
+
+function resolveDefaultCustomColor() {
+  const defaultColorName = DEFAULT_SETTINGS[settingKey.value].color
+  const probe = document.createElement('span')
+  probe.className = `main${defaultColorName}`
+  probe.hidden = true
+  document.body.append(probe)
+  const color = getComputedStyle(probe).getPropertyValue('--primary-color').trim()
+  probe.remove()
+
+  if (isHexColor(color)) return color.toLowerCase()
+  return colors.find(({ name }) => name === defaultColorName)?.value.toLowerCase() ?? '#000000'
 }
 
 /**

--- a/src/renderer/components/ft-shaka-video-player/ft-shaka-video-player.js
+++ b/src/renderer/components/ft-shaka-video-player/ft-shaka-video-player.js
@@ -53,7 +53,7 @@ import {
   removeFromArrayIfExists,
   copyToClipboard,
 } from '../../helpers/utils'
-import { colors } from '../../helpers/colors'
+import { isHexColor, resolveColorValue } from '../../helpers/colors'
 import { applyAnimationSpeed, getAnimationSpeedMultiplier } from '../../helpers/animationSpeed'
 import {
   FULLSCREEN_DOCK_GAP,
@@ -2159,7 +2159,7 @@ export default defineComponent({
      */
     function getSponsorBlockToastColor(category) {
       const colorName = sponsorSkips.value.categoryData[category]?.color
-      return colors.find(color => color.name === colorName)?.value ?? '#39be70'
+      return resolveColorValue(colorName, '#39be70')
     }
 
     /**
@@ -8513,11 +8513,22 @@ export default defineComponent({
       return sponsorBlockAverageVideoDuration || getSponsorBlockSubmissionVideoDuration() || 0
     }
 
-    function createSponsorBlockMarker(duration, startTime, endTime, title, className, isPointMarker = false) {
+    function createSponsorBlockMarker(
+      duration,
+      startTime,
+      endTime,
+      title,
+      className,
+      isPointMarker = false,
+      customColor = null
+    ) {
       const markerDiv = document.createElement('div')
 
       markerDiv.title = title
       markerDiv.className = className
+      if (customColor !== null) {
+        markerDiv.style.setProperty('--primary-color', customColor)
+      }
       if (isPointMarker) {
         markerDiv.style.left = `calc(${(startTime / duration) * 100}% - 1px)`
       } else {
@@ -8539,14 +8550,16 @@ export default defineComponent({
       const markers = sponsorBlockSegments.map((segment) => {
         const isPointMarker = isSponsorBlockPointSegment(segment)
         const color = sponsorSkips.value.categoryData[segment.category]?.color ?? 'Green'
+        const customColor = isHexColor(color) ? color : null
 
         return createSponsorBlockMarker(
           duration,
           segment.startTime,
           segment.endTime,
           translateSponsorBlockCategory(segment.category),
-          `sponsorBlockMarker${isPointMarker ? ' sponsorBlockPointMarker' : ''} main${color}`,
-          isPointMarker
+          `sponsorBlockMarker${isPointMarker ? ' sponsorBlockPointMarker' : ''}${customColor === null ? ` main${color}` : ''}`,
+          isPointMarker,
+          customColor
         )
       })
 

--- a/src/renderer/helpers/colors.js
+++ b/src/renderer/helpers/colors.js
@@ -91,6 +91,16 @@ export const colors = [
 ]
 
 const COLOR_VALUES = new Set(colors.map(({ name }) => name))
+const OPAQUE_HEX_COLOR_PATTERN = /^#[\da-f]{6}$/i
+
+export function isHexColor(value) {
+  return typeof value === 'string' && OPAQUE_HEX_COLOR_PATTERN.test(value)
+}
+
+export function resolveColorValue(value, fallback) {
+  if (isHexColor(value)) return value
+  return colors.find(color => color.name === value)?.value ?? fallback
+}
 
 export function resolveColor(value, fallback) {
   return COLOR_VALUES.has(value) ? value : fallback

--- a/static/locales/en-US.yaml
+++ b/static/locales/en-US.yaml
@@ -483,7 +483,7 @@ Settings:
       Force Off: Force off
     System Default: System Default
     Avoid translation:
-      Avoid translation: Keep original text
+      Avoid translation: Prefer untranslated video text
       Disabled: Disabled
       Watch Only: Video UI Only
       Entire App: Entire App
@@ -1160,6 +1160,8 @@ Settings:
     Paused Interface Hide Delay: Paused Interface Hide Delay
   Data Settings:
     Data Settings: Data
+    Profile Directory: Profile directory
+    Open Profile Directory: Open profile directory
     Select Export Type: Select Export Type
     Import Subscriptions: Import Subscriptions
     Subscription File: Subscription File
@@ -1318,6 +1320,7 @@ Settings:
       Prompt To Skip: Prompt To Skip
       Do Nothing: Do Nothing
     Category Color: Category Color
+    Custom Color: Custom color
   Return YouTube Dislike Settings:
     Return YouTube Dislike Settings: Return YouTube Dislike
     Enable Return YouTube Dislike: Enable Return YouTube Dislike


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Make sure to follow the contributing guidelines. -->
<!-- Important note, we may remove your pull request if you do not use this provided PR template correctly. -->
<!-- Agent instructions: Preserve every heading, comment, and marker in this template. Never remove or rewrite the release-note-category:start/end, release-note:start/end, or release-note-image:start/end marker pairs. Never remove or rewrite the Release note images section; leave its contents for a human. -->

## Pull Request Type
<!-- Please select what type of pull request this is: [x] -->
- [ ] Bugfix
- [x] Feature Implementation
- [ ] Documentation
- [ ] Other

## Related issue
<!-- Please link the issue your pull request is referring to. -->
<!-- If this pull request fully resolves the relevant issue, put "closes" before the issue number. -->
<!-- Example: "closes #123456". -->

N/A

## Description
<!-- Please write a clear and concise description of what the pull request does. -->

Several Settings interactions were inconsistent or easy to misread. Data actions lacked a shared visual treatment, opening the profile directory could report a stale IPC error after a renderer refresh, select menus passed wheel scrolling through to the page, and SponsorBlock categories only supported preset colors.

This adds a desktop profile-directory action and icons to the Data page, centers the export choices vertically, clarifies the untranslated-text preference, contains select-menu scrolling, and adds the existing spectrum picker as the first color option for every SponsorBlock category. Custom SponsorBlock colors persist in the existing setting and appear on category icons, seek markers, prompts, notices, and segment information.

## Release note category
<!-- Select exactly one category. Every pull request must select one. -->
<!-- Select "Not noteworthy" when the pull request fixes a bug in or improves functionality that has not yet appeared in a stable release. -->
<!-- release-note-category:start -->
- [ ] Not noteworthy
- [ ] Highlights
- [x] More improvements
- [ ] Fixed bugs
<!-- release-note-category:end -->

## Release note
<!-- Required unless "Not noteworthy" is selected. -->
<!-- Write one concise, user-facing entry without a leading bullet. -->
<!-- release-note:start -->
Settings now include custom SponsorBlock colors, a profile-directory shortcut, clearer Data controls, and contained select-menu scrolling.
<!-- release-note:end -->

## Release note images
<!-- Human-only: Agents must preserve this entire section and leave it empty. -->
<!-- Optional. Paste one or more Markdown images or HTML image tags here. -->
<!-- The release notes will use an HTML image tag and limit images taller than 300 pixels. -->
<!-- release-note-image:start -->

<!-- release-note-image:end -->

## Testing
<!-- How can reviewers verify that the PR produces correct results? -->
<!-- Please provide instructions so that others can ensure that your pull request would produce correct results. For examples see, https://github.com/FreeTubeApp/FreeTube/pull/5743, https://github.com/FreeTubeApp/FreeTube/pull/7349, https://github.com/FreeTubeApp/FreeTube/pull/5125, https://github.com/FreeTubeApp/FreeTube/pull/7338 -->
<!-- Agent instructions: Only write human-facing steps that explain how to verify the change while running this branch in dev mode. Include expected results and, when applicable, helpful console snippets for interactive verification. Do not include automated checks, commands, results, pass counts, or CI status. -->

1. Open Settings > Data. Confirm every action has an icon, the export-format choices are vertically centered, and "Open profile directory" appears at the bottom on desktop. Click it and confirm the active profile directory opens without a delayed error notice.
2. Open a long select menu in Settings. Scroll to its top and bottom, then keep scrolling while the pointer remains over the options. The page behind the menu should stay still.
3. Open Settings > Add-ons and enable SponsorBlock. Open any category color menu and choose "Custom color" at the top. Confirm the picker initially matches that category's default color and that changing it updates the palette icon.
4. Play a video with SponsorBlock segments. Confirm a category's custom color appears on its seek marker and any prompt or skipped-segment notice.
5. Open Settings > General and confirm the translation preference is labeled "Prefer untranslated video text".

## Additional context
<!-- Add any other context about the pull request here. -->

The profile-directory action uses one-way IPC because the operating-system action completes independently of the renderer. This prevents a renderer refresh from producing a late "reply was never sent" notice after the directory has already opened.
