### PR TITLE
feat(thumbnails): add opt-out hover previews

### DIFF
--- a/e2e/tests/network/search.spec.mjs
+++ b/e2e/tests/network/search.spec.mjs
@@ -2,7 +2,16 @@ import { sel } from '../../helpers/app.mjs'
 import { test, expect } from '../../helpers/innertube.mjs'
 
 test.describe('search', () => {
-  test('search returns video results', async ({ page, innertube }) => {
+  test('search returns video results', async ({ page }) => {
+    let releasePreviewRequest
+    await page.route(/\/an_webp\//, async route => {
+      await new Promise(resolve => { releasePreviewRequest = resolve })
+      await route.fulfill({
+        contentType: 'image/svg+xml',
+        body: '<svg xmlns="http://www.w3.org/2000/svg" width="320" height="180"/>'
+      })
+    })
+
     await page.locator(sel.searchInput).fill('big buck bunny')
     await page.locator(sel.searchInput).press('Enter')
 
@@ -19,11 +28,25 @@ test.describe('search', () => {
       await store.dispatch('updateUiScale', 95)
     })
 
+    const href = await thumbnail.getAttribute('href')
+    const videoId = /\/watch\/([^?]+)/.exec(href)?.[1]
+    expect(videoId).toBeTruthy()
+    await page.evaluate((videoId) => {
+      const store = document.querySelector('#app').__vue_app__.config.globalProperties.$store
+      store.commit('upsertToHistoryCache', { videoId, isWatched: true })
+    }, videoId)
+    await expect(video).toHaveClass(/watched/)
+
     await thumbnail.hover()
     await expect(preview).toHaveAttribute('src', /\/an_webp\//)
-    if (!innertube.replay) {
-      await expect(preview).toHaveClass(/loaded/)
-    }
+    await expect.poll(() => typeof releasePreviewRequest).toBe('function')
+    await expect(preview).not.toHaveClass(/loaded/)
+    await expect(preview).toHaveCSS('opacity', '0')
+
+    releasePreviewRequest()
+    await expect(preview).toHaveClass(/loaded/)
+    await expect(preview).toHaveCSS('opacity', '1')
+
     const [thumbnailBox, previewBox] = await Promise.all([
       video.locator('.thumbnailImage').first().boundingBox(),
       preview.boundingBox()

--- a/e2e/tests/network/search.spec.mjs
+++ b/e2e/tests/network/search.spec.mjs
@@ -2,13 +2,48 @@ import { sel } from '../../helpers/app.mjs'
 import { test, expect } from '../../helpers/innertube.mjs'
 
 test.describe('search', () => {
-  test('search returns video results', async ({ page }) => {
+  test('search returns video results', async ({ page, innertube }) => {
     await page.locator(sel.searchInput).fill('big buck bunny')
     await page.locator(sel.searchInput).press('Enter')
 
     await expect(page).toHaveURL(/#\/search\//)
     await expect(page.locator('.ft-list-video').first()).toBeVisible({ timeout: 30_000 })
     expect(await page.locator('.ft-list-video').count()).toBeGreaterThan(3)
+
+    const video = page.locator('.ft-list-video').first()
+    const thumbnail = video.locator('.thumbnailLink')
+    const preview = video.locator('.thumbnailPreview')
+
+    await page.evaluate(async () => {
+      const store = document.querySelector('#app').__vue_app__.config.globalProperties.$store
+      await store.dispatch('updateUiScale', 95)
+    })
+
+    await thumbnail.hover()
+    await expect(preview).toHaveAttribute('src', /\/an_webp\//)
+    if (!innertube.replay) {
+      await expect(preview).toHaveClass(/loaded/)
+    }
+    const [thumbnailBox, previewBox] = await Promise.all([
+      video.locator('.thumbnailImage').first().boundingBox(),
+      preview.boundingBox()
+    ])
+    expect(previewBox.x).toBeCloseTo(thumbnailBox.x, 1)
+    expect(previewBox.y).toBeCloseTo(thumbnailBox.y, 1)
+    expect(previewBox.width).toBeCloseTo(thumbnailBox.width, 1)
+    expect(previewBox.height).toBeCloseTo(thumbnailBox.height, 1)
+
+    await page.mouse.move(0, 0)
+    await expect(preview).toHaveCount(0)
+
+    await page.evaluate(() => {
+      const store = document.querySelector('#app').__vue_app__.config.globalProperties.$store
+      store.commit('setShowThumbnailPreviews', false)
+    })
+
+    await thumbnail.hover()
+    await page.waitForTimeout(600)
+    await expect(preview).toHaveCount(0)
   })
 
   test('opening a search result loads the watch page', async ({ page, innertube }) => {

--- a/e2e/tests/offline/settings.spec.mjs
+++ b/e2e/tests/offline/settings.spec.mjs
@@ -2208,6 +2208,21 @@ test.describe('settings', () => {
     await expect(resetButton).toHaveCount(0)
   })
 
+  test('turns thumbnail hover previews off from appearance settings', async ({ page }) => {
+    const appearance = await goToSettingsSection(page, 'appearance')
+    const toggle = appearance.getByRole('checkbox', { name: 'Show thumbnail previews' })
+
+    await expect(toggle).toBeChecked()
+    await appearance.locator('label.switch-label')
+      .filter({ hasText: 'Show thumbnail previews' })
+      .click()
+    await expect(toggle).not.toBeChecked()
+    await expect.poll(() => page.evaluate(() => {
+      const store = document.querySelector('#app').__vue_app__.config.globalProperties.$store
+      return store.getters.getShowThumbnailPreviews
+    })).toBe(false)
+  })
+
   test('highlights changed backend fallback and deep-link settings', async ({ page }) => {
     await goTo(page, 'settings')
 

--- a/src/renderer/components/FtListVideo/FtListVideo.scss
+++ b/src/renderer/components/FtListVideo/FtListVideo.scss
@@ -54,6 +54,10 @@
   opacity: 1;
 }
 
+.ft-list-item.watched .thumbnailPreview:not(.loaded) {
+  opacity: 0;
+}
+
 .youtubeShort.grid {
   .videoThumbnail .thumbnailImage {
     aspect-ratio: 2 / 3;

--- a/src/renderer/components/FtListVideo/FtListVideo.scss
+++ b/src/renderer/components/FtListVideo/FtListVideo.scss
@@ -42,6 +42,18 @@
   aspect-ratio: 16/9 auto;
 }
 
+.thumbnailPreview {
+  block-size: 100%;
+  inset: 0;
+  object-fit: cover;
+  opacity: 0;
+  position: absolute;
+}
+
+.thumbnailPreview.loaded {
+  opacity: 1;
+}
+
 .youtubeShort.grid {
   .videoThumbnail .thumbnailImage {
     aspect-ratio: 2 / 3;

--- a/src/renderer/components/FtListVideo/FtListVideo.vue
+++ b/src/renderer/components/FtListVideo/FtListVideo.vue
@@ -31,12 +31,27 @@
         :to="watchVideoRouterLink"
         @click="handleWatchPageLinkClick"
         @auxclick="handleWatchPageLinkClick"
+        @pointerenter="startThumbnailPreview"
+        @pointerleave="stopThumbnailPreview"
       >
         <img
           :src="thumbnail"
           class="thumbnailImage"
           :class="{ blur: blurThumbnails }"
           alt=""
+        >
+        <img
+          v-if="thumbnailPreviewActive"
+          :src="thumbnailPreviewUrl"
+          class="thumbnailImage thumbnailPreview"
+          :class="{
+            blur: blurThumbnails,
+            loaded: thumbnailPreviewLoaded
+          }"
+          alt=""
+          aria-hidden="true"
+          @load="thumbnailPreviewLoaded = true"
+          @error="thumbnailPreviewLoaded = false"
         >
         <FtEmbeddedProgress
           v-if="historyEntryExists && progressPercentage > 0"
@@ -534,6 +549,10 @@ watch(enableDownloads, (enabled) => {
 })
 const isPremium = ref(false)
 const hideViews = ref(false)
+const thumbnailPreviewActive = ref(false)
+const thumbnailPreviewLoaded = ref(false)
+const THUMBNAIL_PREVIEW_DELAY = 500
+let thumbnailPreviewTimer = null
 const deArrowTogglePinned = ref(false)
 const showDeArrowTitle = ref(false)
 const showDeArrowThumbnail = ref(false)
@@ -620,6 +639,52 @@ const thumbnailPreference = computed(() => store.getters.getThumbnailPreference)
 
 /** @type {import('vue').ComputedRef<boolean>} */
 const blurThumbnails = computed(() => store.getters.getBlurThumbnails)
+
+const thumbnailPreviewUrl = computed(() => {
+  if (
+    !store.getters.getShowThumbnailPreviews ||
+    thumbnailPreference.value === 'hidden' ||
+    props.appearance === 'youtubeShort'
+  ) {
+    return null
+  }
+
+  return typeof props.data.thumbnailPreviewUrl === 'string'
+    ? props.data.thumbnailPreviewUrl
+    : null
+})
+
+function clearThumbnailPreviewTimer() {
+  if (thumbnailPreviewTimer !== null) {
+    clearTimeout(thumbnailPreviewTimer)
+    thumbnailPreviewTimer = null
+  }
+}
+
+function startThumbnailPreview() {
+  clearThumbnailPreviewTimer()
+
+  const previewUrl = thumbnailPreviewUrl.value
+  if (!previewUrl) {
+    return
+  }
+
+  thumbnailPreviewLoaded.value = false
+  thumbnailPreviewTimer = setTimeout(() => {
+    thumbnailPreviewTimer = null
+    if (thumbnailPreviewUrl.value === previewUrl) {
+      thumbnailPreviewActive.value = true
+    }
+  }, THUMBNAIL_PREVIEW_DELAY)
+}
+
+function stopThumbnailPreview() {
+  clearThumbnailPreviewTimer()
+  thumbnailPreviewActive.value = false
+  thumbnailPreviewLoaded.value = false
+}
+
+watch(thumbnailPreviewUrl, stopThumbnailPreview)
 
 /** @type {import('vue').ComputedRef<'local' | 'invidious'>} */
 const backendPreference = computed(() => store.getters.getBackendPreference)
@@ -1895,6 +1960,7 @@ onMounted(() => {
 })
 
 onBeforeUnmount(() => {
+  clearThumbnailPreviewTimer()
   clearPremiereStartTimer()
   removeLiveReminderUpdatedListener?.()
 })

--- a/src/renderer/components/GeneralSettings/GeneralSettings.vue
+++ b/src/renderer/components/GeneralSettings/GeneralSettings.vue
@@ -5,6 +5,15 @@
     <div class="switchColumnGrid">
       <div class="switchColumn">
         <FtToggleSwitch
+          v-if="mode === 'appearance'"
+          :label="t('Settings.General Settings.Show Thumbnail Previews')"
+          :default-value="showThumbnailPreviews"
+          setting-key="showThumbnailPreviews"
+          :compact="true"
+          :tooltip="t('Tooltips.General Settings.Show Thumbnail Previews')"
+          @change="updateShowThumbnailPreviews"
+        />
+        <FtToggleSwitch
           v-if="mode === 'general'"
           :label="t('Settings.General Settings.Check for Updates')"
           :default-value="checkForUpdates"
@@ -610,6 +619,16 @@ const listType = computed(() => store.getters.getListType)
  */
 function updateListType(value) {
   store.dispatch('updateListType', value)
+}
+
+/** @type {import('vue').ComputedRef<boolean>} */
+const showThumbnailPreviews = computed(() => store.getters.getShowThumbnailPreviews)
+
+/**
+ * @param {boolean} value
+ */
+function updateShowThumbnailPreviews(value) {
+  store.dispatch('updateShowThumbnailPreviews', value)
 }
 
 const THUMBNAIL_TYPE_VALUES = ['', 'start', 'middle', 'end', 'hidden', 'blur']

--- a/src/renderer/helpers/api/local.js
+++ b/src/renderer/helpers/api/local.js
@@ -8,6 +8,7 @@ import { loadSearchContinuation } from '../search-continuation'
 import { parseLocalShortLinkedVideo } from '../player/shorts'
 import { getPaidPromotionDurationMs } from '../player/paidPromotion'
 import { getLocalPremiereState } from '../premiere'
+import { getThumbnailPreviewUrl } from '../thumbnailPreview'
 import { isCollaborativeVideoAuthor, parseLocalVideoChannels } from '../video-collaborators'
 import {
   CHANNEL_HANDLE_REGEX,
@@ -1840,6 +1841,7 @@ export function parseLocalListVideo(item, channelId, channelName) {
     return {
       type: 'video',
       videoId: movie.id,
+      thumbnailPreviewUrl: getThumbnailPreviewUrl(movie),
       title: movie.title.text?.trim(),
       author: movie.author.name !== 'N/A' ? movie.author.name : channelName,
       authorId: movie.author.id !== 'N/A' ? movie.author.id : channelId,
@@ -1870,6 +1872,7 @@ export function parseLocalListVideo(item, channelId, channelName) {
     return {
       type: 'video',
       videoId: video.video_id,
+      thumbnailPreviewUrl: getThumbnailPreviewUrl(video),
       title: video.title.text?.trim(),
       author: video.author?.name ?? channelName,
       authorId: (video.author?.id != null && video.author.id !== 'N/A') ? video.author.id : channelId,
@@ -1887,6 +1890,7 @@ export function parseLocalListVideo(item, channelId, channelName) {
     return {
       type: 'video',
       videoId: movie.id,
+      thumbnailPreviewUrl: getThumbnailPreviewUrl(movie),
       title: movie.title.text,
       author: movie.author.name !== 'N/A' ? movie.author.name : channelName,
       authorId: movie.author.id !== 'N/A' ? movie.author.id : channelId,
@@ -1929,6 +1933,7 @@ export function parseLocalListVideo(item, channelId, channelName) {
     return {
       type: 'video',
       videoId: video.video_id,
+      thumbnailPreviewUrl: getThumbnailPreviewUrl(video),
       title: video.title.text?.trim(),
       author: video.author.name !== 'N/A' ? video.author.name : channelName,
       authorId: video.author.id !== 'N/A' ? video.author.id : channelId,
@@ -2138,6 +2143,7 @@ function parseLockupView(lockupView, channelId = undefined, channelName = undefi
       return {
         type: 'video',
         videoId: lockupView.content_id,
+        thumbnailPreviewUrl: getThumbnailPreviewUrl(lockupView),
         title: lockupView.metadata.title.text?.trim(),
         author,
         authorId,
@@ -2280,6 +2286,7 @@ export function parseLocalWatchNextVideo(video) {
     return {
       type: 'video',
       videoId: video.id,
+      thumbnailPreviewUrl: getThumbnailPreviewUrl(video),
       title: video.title.text?.trim(),
       author: video.author.name,
       authorId: video.author.id,
@@ -2299,6 +2306,7 @@ export function parseLocalWatchNextVideo(video) {
     return {
       type: 'video',
       videoId: video.video_id,
+      thumbnailPreviewUrl: getThumbnailPreviewUrl(video),
       title: video.title.text?.trim(),
       author: video.author.name,
       authorId: video.author.id,

--- a/src/renderer/helpers/settings-search-config.js
+++ b/src/renderer/helpers/settings-search-config.js
@@ -20,6 +20,7 @@ const GENERAL_EVERYDAY_KEYS = new Set([
 ])
 
 const GENERAL_APPEARANCE_KEYS = new Set([
+  'Show Thumbnail Previews',
   'Thumbnail Preference',
   'Video View Type'
 ])

--- a/src/renderer/helpers/thumbnailPreview.js
+++ b/src/renderer/helpers/thumbnailPreview.js
@@ -1,0 +1,24 @@
+/**
+ * Read the animated thumbnail URL from youtubei.js' old and new video card
+ * shapes.
+ *
+ * @param {object | null | undefined} video
+ * @returns {string | null}
+ */
+export function getThumbnailPreviewUrl(video) {
+  const richThumbnailUrl = video?.rich_thumbnail?.find?.(
+    thumbnail => typeof thumbnail?.url === 'string'
+  )?.url
+
+  if (richThumbnailUrl) {
+    return richThumbnailUrl
+  }
+
+  const animatedOverlay = video?.content_image?.overlays?.find?.(
+    overlay => overlay?.type === 'AnimatedThumbnailOverlayView'
+  )
+
+  return animatedOverlay?.thumbnail?.find?.(
+    thumbnail => typeof thumbnail?.url === 'string'
+  )?.url ?? null
+}

--- a/src/renderer/store/modules/settings.js
+++ b/src/renderer/store/modules/settings.js
@@ -408,6 +408,7 @@ const state = {
     skip: 'promptToSkip'
   },
   thumbnailPreference: '',
+  showThumbnailPreviews: true,
   thumbnailSize: DEFAULT_THUMBNAIL_SIZE,
   uiRoundness: 100,
   animationSpeed: 100,

--- a/static/locales/en-US.yaml
+++ b/static/locales/en-US.yaml
@@ -503,6 +503,7 @@ Settings:
       End: End
       Hidden: Hidden
       Blur: Blur
+    Show Thumbnail Previews: Show thumbnail previews
     Extra Thumbnail Action Button:
       Extra Thumbnail Action Button: Extra Thumbnail Action Button
       None: None
@@ -2073,6 +2074,7 @@ Tooltips:
       method when enabled.
     Thumbnail Preference: All thumbnails throughout OpenTubeX will be replaced with
       a frame of the video, blurred or hidden instead of the default thumbnail.
+    Show Thumbnail Previews: Show animated previews when hovering over video thumbnails.
     Startup Behavior: |
       Choose what OpenTubeX does when it starts.
       Load all tabs restores every saved tab immediately, but background tabs will not autoplay videos.

--- a/tests/unit/thumbnail-preview.test.mjs
+++ b/tests/unit/thumbnail-preview.test.mjs
@@ -1,0 +1,42 @@
+import assert from 'node:assert/strict'
+import test from 'node:test'
+
+import { getThumbnailPreviewUrl } from '../../src/renderer/helpers/thumbnailPreview.js'
+
+test('reads moving thumbnails from regular YouTube video results', () => {
+  assert.equal(getThumbnailPreviewUrl({
+    rich_thumbnail: [{
+      url: 'https://i.ytimg.com/an_webp/video/mqdefault_6s.webp',
+      width: 320,
+      height: 180
+    }]
+  }), 'https://i.ytimg.com/an_webp/video/mqdefault_6s.webp')
+})
+
+test('reads moving thumbnails from YouTube lockup results', () => {
+  assert.equal(getThumbnailPreviewUrl({
+    content_image: {
+      overlays: [{
+        type: 'ThumbnailBottomOverlayView'
+      }, {
+        type: 'AnimatedThumbnailOverlayView',
+        thumbnail: [{
+          url: 'https://i.ytimg.com/an_webp/lockup/mqdefault_6s.webp'
+        }]
+      }]
+    }
+  }), 'https://i.ytimg.com/an_webp/lockup/mqdefault_6s.webp')
+})
+
+test('ignores video results without a usable moving thumbnail', () => {
+  assert.equal(getThumbnailPreviewUrl(null), null)
+  assert.equal(getThumbnailPreviewUrl({ rich_thumbnail: [] }), null)
+  assert.equal(getThumbnailPreviewUrl({
+    content_image: {
+      overlays: [{
+        type: 'AnimatedThumbnailOverlayView',
+        thumbnail: [{}]
+      }]
+    }
+  }), null)
+})


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Make sure to follow the contributing guidelines. -->
<!-- Important note, we may remove your pull request if you do not use this provided PR template correctly. -->
<!-- Agent instructions: Preserve every heading, comment, and marker in this template. Never remove or rewrite the release-note-category:start/end, release-note:start/end, or release-note-image:start/end marker pairs. Never remove or rewrite the Release note images section; leave its contents for a human. -->

## Pull Request Type
<!-- Please select what type of pull request this is: [x] -->
- [ ] Bugfix
- [x] Feature Implementation
- [ ] Documentation
- [ ] Other

## Related issue
<!-- Please link the issue your pull request is referring to. -->
<!-- If this pull request fully resolves the relevant issue, put "closes" before the issue number. -->
<!-- Example: "closes #123456". -->

No related issue.

## Description
<!-- Please write a clear and concise description of what the pull request does. -->

Some YouTube video results include animated hover-preview thumbnails, but OpenTubeX discarded that metadata and offered no control for people who prefer static thumbnails.

This preserves YouTube's moving-thumbnail URL in Local API results and shows it after a brief, intentional hover. The animated image is requested only after the hover delay, disappears on pointer leave, follows the existing thumbnail visibility and blur preferences, and is excluded from Shorts. A new Appearance setting, enabled by default, lets users turn the previews off entirely.

## Release note category
<!-- Select exactly one category. Every pull request must select one. -->
<!-- Select "Not noteworthy" when the pull request fixes a bug in or improves functionality that has not yet appeared in a stable release. -->
<!-- release-note-category:start -->
- [ ] Not noteworthy
- [ ] Highlights
- [x] More improvements
- [ ] Fixed bugs
<!-- release-note-category:end -->

## Release note
<!-- Required unless "Not noteworthy" is selected. -->
<!-- Write one concise, user-facing entry without a leading bullet. -->
<!-- release-note:start -->

Video thumbnails can now show YouTube's animated hover previews, with an Appearance setting to turn them off.

<!-- release-note:end -->

## Release note images
<!-- Human-only: Agents must preserve this entire section and leave it empty. -->
<!-- Optional. Paste one or more Markdown images or HTML image tags here. -->
<!-- The release notes will use an HTML image tag and limit images taller than 300 pixels. -->
<!-- release-note-image:start -->
<img width="822" height="300" alt="Screencast_20260820_115341" src="https://github.com/user-attachments/assets/90d4871b-0add-446e-b4a0-d1461b6d9ca9" />
<!-- release-note-image:end -->

## Testing
<!-- How can reviewers verify that the PR produces correct results? -->
<!-- Please provide instructions so that others can ensure that your pull request would produce correct results. For examples see, https://github.com/FreeTubeApp/FreeTube/pull/5743, https://github.com/FreeTubeApp/FreeTube/pull/7349, https://github.com/FreeTubeApp/FreeTube/pull/5125, https://github.com/FreeTubeApp/FreeTube/pull/7338 -->
<!-- Agent instructions: Only write human-facing steps that explain how to verify the change while running this branch in dev mode. Include expected results and, when applicable, helpful console snippets for interactive verification. Do not include automated checks, commands, results, pass counts, or CI status. -->

1. Run this branch in dev mode with the Local API backend and search for a common video topic.
2. Hover an ordinary video thumbnail that has preview metadata. After a short delay, an animated preview should replace the static image; leaving the thumbnail should immediately restore the static image.
3. Open Settings → Appearance, turn off **Show thumbnail previews**, return to the results, and hover the same thumbnail. It should remain static and should not request the animated image.
4. Set the UI scale to 95% and repeat the hover. The preview should cover the static thumbnail exactly without spilling outside its rounded edges.

## Additional context
<!-- Add any other context about the pull request here. -->

Invidious does not currently provide moving-thumbnail metadata, so previews appear only when the Local API response contains a usable YouTube moving thumbnail.
