### PR TITLE
fix(settings): align search results and highlights with visible controls

### DIFF
--- a/e2e/tests/offline/settings.spec.mjs
+++ b/e2e/tests/offline/settings.spec.mjs
@@ -84,6 +84,31 @@ async function expectExternalSoftwarePathAlignment(tool, sourceName, pathPlaceho
   expect(pathBox.x + pathBox.width).toBeCloseTo(helpBox.x + helpBox.width, 0)
 }
 
+async function expectSubscriptionRefreshIntervalSelectHighlight(page) {
+  await goTo(page, 'settings')
+  const search = page.getByRole('searchbox', { name: 'Search settings' })
+
+  await search.fill('Auto Refresh Interval')
+  await expect(page.locator('.settingsSearchResultMatch')).toHaveText([
+    'Live Auto Refresh Interval',
+    'Posts Auto Refresh Interval',
+    'Videos Auto Refresh Interval',
+    'Shorts Auto Refresh Interval'
+  ])
+  await page.getByRole('button', { name: 'Videos Auto Refresh Interval', exact: true }).click()
+
+  const selectHighlight = page.locator('.select.settingsSearchTarget')
+  const highlightFrame = selectHighlight.locator('.selectSearchHighlightFrame')
+  await expect(selectHighlight).toContainText('Videos Auto Refresh Interval')
+  await expect(highlightFrame).toHaveCSS('animation-name', /settings-search-highlight/)
+  const highlightBounds = await highlightFrame.boundingBox()
+  const labelBounds = await selectHighlight.locator('.select-label').boundingBox()
+  const tooltipBounds = await selectHighlight.locator('.selectTooltip').boundingBox()
+  expect(highlightBounds.y).toBeLessThanOrEqual(labelBounds.y)
+  expect(highlightBounds.x + highlightBounds.width)
+    .toBeGreaterThanOrEqual(tooltipBounds.x + tooltipBounds.width)
+}
+
 test.describe('skip silence settings search', () => {
   test.use({ seed: { settings: { currentLocale: 'en-US' } } })
 
@@ -97,6 +122,116 @@ test.describe('skip silence settings search', () => {
     await expect(page.locator('.switch-ctn.settingsSearchTarget'))
       .toContainText('Show Skip Silence Toggle')
     await expect(page.locator('.section.settingsSearchTarget')).toHaveCount(0)
+  })
+})
+
+test.describe('settings search highlights', () => {
+  test.use({ seed: { settings: { currentLocale: 'en-US' } } })
+
+  test('finds and highlights specific subscription refresh interval selects', async ({ page }) => {
+    await expectSubscriptionRefreshIntervalSelectHighlight(page)
+  })
+
+  test.describe('at 95% UI scale', () => {
+    test.use({ seed: { settings: { currentLocale: 'en-US', uiScale: 95 } } })
+
+    test('keeps the select highlight around its label and help icon', async ({ page }) => {
+      await expectSubscriptionRefreshIntervalSelectHighlight(page)
+    })
+  })
+
+  test('highlights a category opened through its description', async ({ page }) => {
+    await goTo(page, 'settings')
+    const search = page.getByRole('searchbox', { name: 'Search settings' })
+
+    await search.fill('Feed refresh and display options')
+    await page.getByRole('button', { name: 'Feed refresh and display options', exact: true }).click()
+
+    const sectionHighlight = page.locator('.section.settingsSearchTarget')
+    await expect(sectionHighlight).toHaveAttribute('data-section', 'subscriptions')
+    await expect(sectionHighlight).toHaveCSS('animation-name', /settings-search-highlight/)
+  })
+
+  test('highlights a whole settings subsection opened through its heading', async ({ page }) => {
+    await goTo(page, 'settings')
+    const search = page.getByRole('searchbox', { name: 'Search settings' })
+
+    await search.fill('Context Menu Search')
+    await page.getByRole('button', { name: 'Context Menu Search', exact: true }).click()
+
+    const contextMenuSearchSection = page.locator('.settingsSection').filter({
+      has: page.getByRole('heading', { name: 'Context Menu Search', exact: true })
+    })
+    await expect(contextMenuSearchSection).toHaveClass(/settingsSearchTarget/)
+    await expect(contextMenuSearchSection)
+      .toHaveCSS('animation-name', /settings-search-highlight/)
+  })
+
+  for (const { searchTerm, sectionType, settingLabel } of [{
+    searchTerm: 'Subscription',
+    sectionType: 'subscriptions',
+    settingLabel: 'Fetch Feed on Startup'
+  }, {
+    searchTerm: 'Caption Appearance',
+    sectionType: 'playback',
+    settingLabel: 'Preferred Caption Language'
+  }]) {
+    test(`highlights the subsection represented by the hidden ${searchTerm} title`, async ({ page }) => {
+      await goTo(page, 'settings')
+      const search = page.getByRole('searchbox', { name: 'Search settings' })
+
+      await search.fill(searchTerm)
+      await page.getByRole('button', { name: searchTerm, exact: true }).click()
+
+      const subsectionHighlight = page.locator(
+        `.section[data-section="${sectionType}"] .settingsSection.settingsSearchTarget`
+      )
+      await expect(subsectionHighlight).toContainText(settingLabel)
+      await expect(subsectionHighlight).toHaveCSS('animation-name', /settings-search-highlight/)
+    })
+  }
+
+  test('does not search input placeholders or feedback messages', async ({ page }) => {
+    await goTo(page, 'settings')
+    const search = page.getByRole('searchbox', { name: 'Search settings' })
+
+    for (const searchTerm of [
+      'Engine name',
+      'Search URL',
+      'Search history and cache have been cleared'
+    ]) {
+      await search.fill(searchTerm)
+      await expect(page.locator('.settingsSearchResultMatch')).toHaveCount(0)
+    }
+  })
+
+  test('only searches controls while their settings are visible', async ({ page }) => {
+    await goTo(page, 'settings')
+    const search = page.getByRole('searchbox', { name: 'Search settings' })
+
+    for (const searchTerm of [
+      'Screenshot Mode',
+      'Edge Color',
+      'Server URL',
+      'Custom External Player Executable',
+      'SponsorBlock API Url (Default is https://sponsor.ajay.app)',
+      'Return YouTube Dislike API URL (Default is https://ryd-proxy.kavin.rocks)',
+      'Proxy Host'
+    ]) {
+      await search.fill(searchTerm)
+      await expect(page.locator('.settingsSearchResultMatch')).toHaveCount(0, { timeout: 1_000 })
+    }
+
+    await search.fill('')
+    const playback = await goToSettingsSection(page, 'playback')
+    await playback.locator('label.switch-label').filter({ hasText: 'Enable Screenshot' }).click()
+    await playback.getByRole('combobox', { name: 'Edge Style' }).click()
+    await page.getByRole('option', { name: 'Outline', exact: true }).click()
+
+    for (const searchTerm of ['Screenshot Mode', 'Edge Color']) {
+      await search.fill(searchTerm)
+      await expect(page.getByRole('button', { name: searchTerm, exact: true })).toBeVisible()
+    }
   })
 })
 
@@ -788,7 +923,7 @@ test.describe('settings', () => {
     await search.fill('update')
     await expect(page.locator('.settingsMenu .title.active')).toHaveCount(0)
     await expect(page.locator('.settingsContent > .section')).toHaveCount(0)
-    await expect(page.locator('.settingsSearchResult')).toHaveCount(4)
+    await expect(page.locator('.settingsSearchResult')).toHaveCount(1)
     expect(await page.locator('.settingsMenu .title').evaluateAll(elements => (
       elements.every(element => element.scrollHeight <= element.clientHeight + 1)
     ))).toBe(true)
@@ -862,15 +997,13 @@ test.describe('settings', () => {
       .toContainText('Proxy Videos Through Invidious')
 
     await search.fill('test')
-    await expect(page.getByRole('button', { name: 'Test Proxy', exact: true })).toBeVisible()
-    await expect(page.locator('.settingsSearchResultMatch')).not.toContainText('Clicking on Test Proxy')
+    await expect(page.getByRole('button', { name: 'Test Proxy', exact: true })).toHaveCount(0)
+    await expect(page.locator('.settingsSearchResultMatch')).toHaveCount(0)
 
     const proxyInfo = 'Clicking on Test Proxy will send a request to ' +
       'https://ipwho.is/?output=json&fields=ip,country,city,region&lang=en'
     await search.fill(proxyInfo)
-    await expect(page.locator('.settingsMenu [data-section="advanced"]')).toBeVisible()
-    await page.getByRole('button', { name: proxyInfo, exact: true }).click()
-    await expect(page.locator('.section.settingsSearchTarget')).toHaveCount(0)
+    await expect(page.locator('.settingsSearchResultMatch')).toHaveCount(0)
 
     await search.fill('Manage Saved Channels')
     await expect(page.locator('.settingsSearchResultMatch')).toHaveCount(0)

--- a/e2e/tests/offline/settings.spec.mjs
+++ b/e2e/tests/offline/settings.spec.mjs
@@ -99,11 +99,19 @@ async function expectSubscriptionRefreshIntervalSelectHighlight(page) {
 
   const selectHighlight = page.locator('.select.settingsSearchTarget')
   const highlightFrame = selectHighlight.locator('.selectSearchHighlightFrame')
+  const selectLabel = selectHighlight.locator('.select-label')
+  const selectTooltip = selectHighlight.locator('.selectTooltip')
   await expect(selectHighlight).toContainText('Videos Auto Refresh Interval')
+  await expect(highlightFrame).toBeVisible()
+  await expect(selectLabel).toBeVisible()
+  await expect(selectTooltip).toBeVisible()
   await expect(highlightFrame).toHaveCSS('animation-name', /settings-search-highlight/)
   const highlightBounds = await highlightFrame.boundingBox()
-  const labelBounds = await selectHighlight.locator('.select-label').boundingBox()
-  const tooltipBounds = await selectHighlight.locator('.selectTooltip').boundingBox()
+  const labelBounds = await selectLabel.boundingBox()
+  const tooltipBounds = await selectTooltip.boundingBox()
+  expect(highlightBounds).not.toBeNull()
+  expect(labelBounds).not.toBeNull()
+  expect(tooltipBounds).not.toBeNull()
   expect(highlightBounds.y).toBeLessThanOrEqual(labelBounds.y)
   expect(highlightBounds.x + highlightBounds.width)
     .toBeGreaterThanOrEqual(tooltipBounds.x + tooltipBounds.width)
@@ -198,9 +206,11 @@ test.describe('settings search highlights', () => {
     for (const searchTerm of [
       'Engine name',
       'Search URL',
-      'Search history and cache have been cleared'
+      'Search history and cache have been cleared',
+      'Generated SponsorBlock user ID copied to clipboard'
     ]) {
       await search.fill(searchTerm)
+      await expect(page.locator('.settingsNoResults')).toBeVisible()
       await expect(page.locator('.settingsSearchResultMatch')).toHaveCount(0)
     }
   })
@@ -216,9 +226,14 @@ test.describe('settings search highlights', () => {
       'Custom External Player Executable',
       'SponsorBlock API Url (Default is https://sponsor.ajay.app)',
       'Return YouTube Dislike API URL (Default is https://ryd-proxy.kavin.rocks)',
-      'Proxy Host'
+      'Proxy Host',
+      'Edit custom theme',
+      'Remove Password',
+      'Generated SponsorBlock User ID',
+      'Export Generated User ID'
     ]) {
       await search.fill(searchTerm)
+      await expect(page.locator('.settingsNoResults')).toBeVisible()
       await expect(page.locator('.settingsSearchResultMatch')).toHaveCount(0, { timeout: 1_000 })
     }
 
@@ -930,11 +945,17 @@ test.describe('settings', () => {
 
     await search.fill('a')
     const searchContent = page.locator('.settingsContent')
+    const searchScrollbar = searchContent.locator(':scope > .os-scrollbar-vertical')
     await searchContent.evaluate(element => { element.scrollTop = element.scrollHeight })
     await expect.poll(() => searchContent.evaluate(element => element.scrollTop)).toBeGreaterThan(0)
+    await expect(searchScrollbar).not.toHaveClass(/os-scrollbar-unusable/)
 
     await search.fill('FFmpeg Source')
     await expect.poll(() => searchContent.evaluate(element => element.scrollTop)).toBe(0)
+    await expect.poll(() => searchContent.evaluate(
+      element => element.scrollHeight <= element.clientHeight + 1
+    )).toBe(true)
+    await expect(searchScrollbar).toHaveClass(/os-scrollbar-unusable/)
     await expect(page.locator('.settingsMenu .title')).toHaveCount(1)
     await expect(page.locator('.settingsMenu [data-section="advanced"]')).toBeVisible()
     await expect(page.locator('.settingsSearchResult')).toContainText('FFmpeg Source')

--- a/src/renderer/components/FtSelect/FtSelect.css
+++ b/src/renderer/components/FtSelect/FtSelect.css
@@ -31,6 +31,18 @@
   margin-inline-end: 70px;
 }
 
+.selectSearchHighlightFrame {
+  display: block;
+  position: absolute;
+  inset-block: -24px 0;
+  inset-inline: 0;
+  pointer-events: none;
+}
+
+.select.containsTooltip > .selectSearchHighlightFrame {
+  inset-inline-end: -30px;
+}
+
 .select-text {
   position: relative;
   font-family: inherit;

--- a/src/renderer/components/FtSelect/FtSelect.vue
+++ b/src/renderer/components/FtSelect/FtSelect.vue
@@ -94,6 +94,10 @@
         @reset="emit('reset')"
       />
     </span>
+    <span
+      class="selectSearchHighlightFrame"
+      aria-hidden="true"
+    />
     <Teleport :to="dropdownTarget">
       <Transition name="select-dropdown">
         <ul

--- a/src/renderer/helpers/settings-search-config.js
+++ b/src/renderer/helpers/settings-search-config.js
@@ -172,6 +172,26 @@ export const SETTINGS_SEARCH_SELECT_GROUP_LABELS = {
     'Default Quality': ['Default Quality'],
     'Screenshot.Modes': []
   },
+  channel: {
+    '': [
+      'Channel Settings',
+      'Enable Playback Speed',
+      'Enable Video Quality',
+      'Enable Subtitles State',
+      'Enable Volume',
+      'Auto Update',
+      'Auto Update Subtitles',
+      'Auto Update Volume'
+    ]
+  },
+  download: {
+    '': [
+      'Download Settings',
+      'Enable Downloads',
+      'Download Folder',
+      'Global Additional yt-dlp Arguments'
+    ]
+  },
   data: {
     '': [
       'Data Settings',
@@ -198,13 +218,31 @@ export const SETTINGS_SEARCH_SELECT_GROUP_LABELS = {
     'Edge Style': ['Edge Style']
   },
   'external-player': { Players: [] },
-  'external-software': { Sources: [] },
+  'external-software': {
+    Sources: [],
+    'Update Modes': [],
+    'Cookie Sources': []
+  },
   privacy: { 'Watched Progress Saving Mode.Modes': [] },
   'sponsor-block': { 'Skip Options': ['Skip Option'] }
 }
 
 export const SETTINGS_SEARCH_EXCLUDED_MESSAGE_PATHS = {
   general: new Set(['System Default']),
+  'context-menu-search': new Set(['Engine Name', 'Search URL']),
   player: new Set(['Skip Silence']),
-  'caption-appearance': new Set(['Application Language'])
+  subscription: new Set(['Auto Refresh Interval']),
+  'caption-appearance': new Set(['Application Language']),
+  'external-software': new Set([
+    'Download yt-dlp',
+    'Update yt-dlp',
+    'Downloading yt-dlp',
+    'Download FFmpeg',
+    'Update FFmpeg',
+    'Downloading FFmpeg',
+    'Download FFmpeg and FFprobe',
+    'Update FFmpeg and FFprobe',
+    'Downloading FFmpeg and FFprobe',
+    'Select Browser'
+  ])
 }

--- a/src/renderer/helpers/settings-search-config.js
+++ b/src/renderer/helpers/settings-search-config.js
@@ -161,13 +161,15 @@ export const SETTINGS_SEARCH_SELECT_GROUP_LABELS = {
     'Tab Layout': ['Tab Layout'],
     'Toast Position': ['Toast Position'],
     'Base Theme': ['Base Theme'],
+    'Icon Pack': ['Icon Pack'],
     Font: ['App Font'],
-    'Main Color Theme': ['Main Color Theme']
+    'Main Color Theme': ['Main Color Theme'],
+    'Custom Theme': ['Create Custom Theme', 'Edit Custom Theme']
   },
   player: {
     'Caption Appearance': [],
     'Default Viewing Mode': ['Default Viewing Mode', 'Tooltip'],
-    'Auto Picture in Picture': ['Auto Picture in Picture', 'Wayland Minimize Unsupported'],
+    'Auto Picture in Picture': ['Auto Picture in Picture'],
     'Default Video Format': ['Default Video Format'],
     'Default Quality': ['Default Quality'],
     'Screenshot.Modes': []
@@ -231,6 +233,8 @@ export const SETTINGS_SEARCH_EXCLUDED_MESSAGE_PATHS = {
   general: new Set(['System Default']),
   'context-menu-search': new Set(['Engine Name', 'Search URL']),
   player: new Set(['Skip Silence']),
+  password: new Set(['Password']),
+  'sponsor-block': new Set(['Generated SponsorBlock User ID Copy Button']),
   subscription: new Set(['Auto Refresh Interval']),
   'caption-appearance': new Set(['Application Language']),
   'external-software': new Set([

--- a/src/renderer/views/Settings/Settings.css
+++ b/src/renderer/views/Settings/Settings.css
@@ -354,6 +354,18 @@
   animation: settings-search-highlight 2.2s ease-in-out;
 }
 
+.settingsContent :deep(.select.settingsSearchTarget) {
+  outline: none;
+  animation: none;
+}
+
+.settingsContent :deep(.select.settingsSearchTarget > .selectSearchHighlightFrame) {
+  outline: 2px solid transparent;
+  outline-offset: 4px;
+  border-radius: calc(4px * var(--ui-roundness));
+  animation: settings-search-highlight 2.2s ease-in-out;
+}
+
 @keyframes settings-search-highlight {
   0%,
   40%,

--- a/src/renderer/views/Settings/Settings.css
+++ b/src/renderer/views/Settings/Settings.css
@@ -280,6 +280,7 @@
 }
 
 .settingsNoResults {
+  grid-column: 1 / -1;
   margin: auto;
   color: var(--tertiary-text-color);
   text-align: center;
@@ -290,6 +291,10 @@
   grid-template-columns: repeat(auto-fit, minmax(min(280px, 100%), 1fr));
   align-content: start;
   gap: 12px;
+}
+
+.settingsSearchResultsEmpty {
+  block-size: 100%;
 }
 
 .settingsSearchResult {
@@ -347,7 +352,8 @@
   background: var(--side-nav-hover-color);
 }
 
-.settingsContent :deep(.settingsSearchTarget) {
+.settingsContent :deep(.settingsSearchTarget),
+.settingsContent :deep(.select.settingsSearchTarget > .selectSearchHighlightFrame) {
   outline: 2px solid transparent;
   outline-offset: 4px;
   border-radius: calc(4px * var(--ui-roundness));
@@ -357,13 +363,6 @@
 .settingsContent :deep(.select.settingsSearchTarget) {
   outline: none;
   animation: none;
-}
-
-.settingsContent :deep(.select.settingsSearchTarget > .selectSearchHighlightFrame) {
-  outline: 2px solid transparent;
-  outline-offset: 4px;
-  border-radius: calc(4px * var(--ui-roundness));
-  animation: settings-search-highlight 2.2s ease-in-out;
 }
 
 @keyframes settings-search-highlight {

--- a/src/renderer/views/Settings/Settings.vue
+++ b/src/renderer/views/Settings/Settings.vue
@@ -275,39 +275,42 @@
               :data-section="activeSettingsSection.type"
             />
             <div
-              v-else-if="settingsSearchResults.length > 0"
-              class="settingsSearchResults"
-            >
-              <section
-                v-for="result in settingsSearchResults"
-                :key="result.section.type"
-                class="settingsSearchResult"
-              >
-                <button
-                  type="button"
-                  class="settingsSearchResultHeading"
-                  @click="navigateToSection(result.section.type)"
-                >
-                  <FtIcon :icon="result.section.icon" />
-                  {{ result.section.title }}
-                </button>
-                <button
-                  v-for="match in result.matches"
-                  :key="match"
-                  type="button"
-                  class="settingsSearchResultMatch"
-                  @click="openSearchResult(result.section.type, match)"
-                >
-                  {{ match }}
-                </button>
-              </section>
-            </div>
-            <p
               v-else-if="settingsSearchQuery !== ''"
-              class="settingsNoResults"
+              class="settingsSearchResults"
+              :class="{ settingsSearchResultsEmpty: settingsSearchResults.length === 0 }"
             >
-              {{ t('Settings.No Settings Found') }}
-            </p>
+              <template v-if="settingsSearchResults.length > 0">
+                <section
+                  v-for="result in settingsSearchResults"
+                  :key="result.section.type"
+                  class="settingsSearchResult"
+                >
+                  <button
+                    type="button"
+                    class="settingsSearchResultHeading"
+                    @click="navigateToSection(result.section.type)"
+                  >
+                    <FtIcon :icon="result.section.icon" />
+                    {{ result.section.title }}
+                  </button>
+                  <button
+                    v-for="match in result.matches"
+                    :key="match"
+                    type="button"
+                    class="settingsSearchResultMatch"
+                    @click="openSearchResult(result.section.type, match)"
+                  >
+                    {{ match }}
+                  </button>
+                </section>
+              </template>
+              <p
+                v-else
+                class="settingsNoResults"
+              >
+                {{ t('Settings.No Settings Found') }}
+              </p>
+            </div>
           </div>
           <div
             v-show="subpageTitle"
@@ -373,6 +376,7 @@ import ProfileSettings from '../ProfileSettings/ProfileSettings.vue'
 import About from '../About/About.vue'
 import Downloads from '../Downloads/Downloads.vue'
 
+import { customThemeIdFromValue } from '../../../customTheme'
 import store from '../../store/index'
 import { settingsSubpageKey } from '../../components/FtSettingsSubpage/settingsSubpage'
 import {
@@ -380,6 +384,7 @@ import {
   isOverlayScrollTopOutOfBounds,
   restoreOverlayScrollTop
 } from '../../helpers/overlayScrollbars'
+import { initializePlatformInfo, isLinuxWayland } from '../../helpers/platform'
 import {
   SETTINGS_SEARCH_EXCLUDED_MESSAGE_PATHS,
   SETTINGS_SEARCH_SOURCES,
@@ -387,6 +392,8 @@ import {
 } from '../../helpers/settings-search-config'
 
 const USING_ELECTRON = !!process.env.IS_ELECTRON
+const SUPPORTS_LOCAL_API = !!process.env.SUPPORTS_LOCAL_API
+const IS_MAC = process.platform === 'darwin'
 const SETTINGS_DESKTOP_WIDTH_THRESHOLD = 760
 const SETTINGS_BOUNDS_STORAGE_KEY = 'opentubex-settings-window-bounds'
 const WINDOW_MARGIN = 12
@@ -413,9 +420,15 @@ const LEGACY_SETTINGS_SECTION_MAP = {
   experimental: 'advanced'
 }
 
-const NON_SETTING_MESSAGE_KEY_PATTERN = /(?:^Are you sure\b|^Failed to\b|^Invalid\b|^No\b|^How\b|^Checking\b|^Downloading\b|^Current .+\b(?:has|is|will)\b|\b(?:has|have) been (?:cleared|removed|saved|updated)\b|^Operation in Progress$|(?:Description|Hint|Tooltip|Placeholder|Template|Warning|Error|Status|Message|Not Downloaded|Unavailable|Connected|Connecting|Success|Failed|Failure|Invalid|Saved|Already Exists)$)/i
+const NON_SETTING_MESSAGE_KEY_PATTERN = /(?:^Are you sure\b|^Failed to\b|^Invalid\b|^No\b|^How\b|^Checking\b|^Downloading\b|^Loading\b|^Loaded\b|^Current .+\b(?:has|is|will)\b|\b(?:has|have) been (?:cleared|removed|saved|updated)\b|^Operation in Progress$|(?:Description|Hint|Tooltip|Placeholder|Template|Warning|Error|Status|Message|Not Downloaded|Unavailable|Connected|Connecting|Success|Failed|Failure|Invalid|Saved|Copied|Already Exists)$)/i
 
 const { locale, t, tm } = useI18n()
+initializePlatformInfo()
+const systemColorScheme = window.matchMedia('(prefers-color-scheme: dark)')
+const systemUsesDarkTheme = ref(systemColorScheme.matches)
+const updateSystemColorScheme = (event) => {
+  systemUsesDarkTheme.value = event.matches
+}
 const settingsSearchSubsectionTargets = computed(() => ({
   subscriptions: [{
     search: t('Settings.Subscription Settings.Subscription Settings'),
@@ -591,9 +604,6 @@ const settingsSectionComponents = computed(() => [{
   icon: ['fas', 'border-all'],
   component: GeneralCategorySettings
 }, ...settingsComponentsData.value])
-const settingsSearchExtraValues = computed(() => ({
-  privacy: flattenMessageValues(tm('Settings.Password Settings'))
-}))
 const getCaptionEdgeStyle = () => {
   const value = store.getters.getDefaultCaptionSettings
   if (value !== null && typeof value === 'object') return value.edgeStyle ?? 'none'
@@ -631,6 +641,31 @@ const isSettingsSearchMessageVisible = (sectionType, path) => {
   ].includes(group)) {
     return store.getters.getBackendPreference === 'invidious' ||
       store.getters.getBackendFallback
+  }
+
+  if (sectionType === 'general') {
+    if (group === 'Minimize to system tray') {
+      return USING_ELECTRON && !IS_MAC && !isLinuxWayland.value
+    }
+    if ([
+      'Open Deep Links In New Window',
+      'New Tab Position',
+      'Tab Close Focus',
+      'Startup Behavior',
+      'Confirm Before',
+      'Confirmation Options',
+      'Stream Extraction Method'
+    ].includes(group)) {
+      return USING_ELECTRON
+    }
+    if (group === 'Fallback to Non-Preferred Backend on Failure') {
+      return SUPPORTS_LOCAL_API
+    }
+    if (group === 'Avoid translation') {
+      return SUPPORTS_LOCAL_API && (
+        store.getters.getBackendPreference === 'local' || store.getters.getBackendFallback
+      )
+    }
   }
 
   if (sectionType === 'sync') {
@@ -679,12 +714,13 @@ const isSettingsSearchMessageVisible = (sectionType, path) => {
     ].includes(group)) {
       return useSponsorBlock
     }
-    if ([
-      'SponsorBlock Private User ID (optional)',
-      'Generated SponsorBlock User ID',
-      'Export Generated User ID'
-    ].includes(group)) {
+    if (group === 'SponsorBlock Private User ID (optional)') {
       return useSponsorBlock && store.getters.getSponsorBlockEnableSubmission
+    }
+    if (group === 'Generated SponsorBlock User ID') return false
+    if (group === 'Export Generated User ID') {
+      return useSponsorBlock && store.getters.getSponsorBlockEnableSubmission &&
+        store.getters.getSponsorBlockGeneratedUserId !== ''
     }
     if (group === 'DeArrow Thumbnail Generator API Url (Default is https://dearrow-thumb.ajay.app)') {
       return useDeArrowThumbnails
@@ -736,14 +772,14 @@ const isSettingsSearchMessageVisible = (sectionType, path) => {
 
   if (sectionType === 'channel') {
     if (group === 'Auto Update') {
-      return store.state.settings.rememberPlaybackSpeedPerChannel ||
-        store.state.settings.rememberVideoQualityPerChannel
+      return store.getters.getRememberPlaybackSpeedPerChannel ||
+        store.getters.getRememberVideoQualityPerChannel
     }
     if (group === 'Auto Update Subtitles') {
-      return store.state.settings.rememberSubtitlesStatePerChannel
+      return store.getters.getRememberSubtitlesStatePerChannel
     }
     if (group === 'Auto Update Volume') {
-      return store.state.settings.rememberVolumePerChannel
+      return store.getters.getRememberVolumePerChannel
     }
     return [
       'Channel Settings',
@@ -754,21 +790,51 @@ const isSettingsSearchMessageVisible = (sectionType, path) => {
     ].includes(group)
   }
 
-  if (sectionType === 'distraction' && group === 'Show Added Items') {
-    let forbiddenTitles = []
-    try {
-      forbiddenTitles = JSON.parse(store.getters.getForbiddenTitles)
-    } catch {
-      // A malformed persisted value is normalized elsewhere and has no visible tags here.
+  if (sectionType === 'distraction') {
+    if (group === 'Show Added Items') {
+      return store.getters.getChannelsHiddenParsed.length > 0 ||
+        store.getters.getForbiddenTitlesParsed.length > 0
     }
-    return store.getters.getChannelsHiddenParsed.length > 0 || forbiddenTitles.length > 0
+    if (group === 'Hide Trending Videos') return SUPPORTS_LOCAL_API
   }
 
   if (sectionType === 'theme') {
+    if (group === 'Custom Theme' && item === 'Edit Custom Theme') {
+      const baseTheme = store.getters.getBaseTheme
+      const selectedTheme = baseTheme === 'system'
+        ? (systemUsesDarkTheme.value
+            ? store.getters.getSystemDarkTheme
+            : store.getters.getSystemLightTheme)
+        : baseTheme
+      return customThemeIdFromValue(selectedTheme) !== null
+    }
     if (group === 'Light Theme' || group === 'Dark Theme') {
       return store.getters.getBaseTheme === 'system'
     }
-    if (group === 'Load Missing Tab Icons') return store.getters.getShowTabIcons
+    if ([
+      'Move Downloads to App Header',
+      'Disable Smooth Scrolling',
+      'Use Fixed Tab Width',
+      'Move Settings to App Header',
+      'Show Tab Icons',
+      'Show Tab Previews',
+      'Tab Layout',
+      'Tab Width',
+      'Load Missing Tab Icons',
+      'UI Scale'
+    ].includes(group)) {
+      return USING_ELECTRON && (
+        group !== 'Load Missing Tab Icons' || store.getters.getShowTabIcons
+      )
+    }
+  }
+
+  if (sectionType === 'password') {
+    const hasStoredPassword = store.getters.getSettingsPassword !== ''
+    if (group === 'Remove Password') return hasStoredPassword
+    if (['Set Password To Prevent Access', 'Set Password'].includes(group)) {
+      return !hasStoredPassword
+    }
   }
 
   return true
@@ -781,6 +847,14 @@ const isSearchableSettingsMessage = (sectionType, path, value) => {
     !NON_SETTING_MESSAGE_KEY_PATTERN.test(messageKey) &&
     isSettingsSearchMessageVisible(sectionType, path)
 }
+const settingsSearchExtraValues = computed(() => ({
+  privacy: flattenMessageValues(
+    tm('Settings.Password Settings'),
+    {},
+    [],
+    (path, value) => isSearchableSettingsMessage('password', path, value)
+  )
+}))
 const removeRedundantSearchMatches = (values) => {
   const keptMatches = []
   const normalizedMatches = []
@@ -880,7 +954,10 @@ provide(settingsSubpageKey, {
   }
 })
 
-onMounted(handleMounted)
+onMounted(() => {
+  handleMounted()
+  systemColorScheme.addEventListener('change', updateSystemColorScheme)
+})
 onActivated(() => {
   handleMounted()
   nextTick(restoreMinimizedScrollPositions)
@@ -894,6 +971,7 @@ onDeactivated(() => {
   stopResizing()
 })
 onBeforeUnmount(() => {
+  systemColorScheme.removeEventListener('change', updateSystemColorScheme)
   stopObserving()
   stopDragging()
   stopResizing()
@@ -966,7 +1044,7 @@ function handleMounted() {
         if (settingsContentRef.value) {
           clampOverlayScrollTop(
             settingsContentRef.value,
-            getActiveSettingsSectionEnd(settingsContentRef.value)
+            getSettingsContentEnd(settingsContentRef.value)
           )
         }
         scheduleStandaloneScrollClamp()
@@ -1036,23 +1114,23 @@ function observeActiveSettingsSection() {
   settingsSectionResizeObserver?.disconnect()
   settingsSectionResizeObserver = null
   const content = settingsContentRef.value
-  const section = getActiveSettingsSectionEnd(content)
-  if (!content || !section) return
+  const contentEnd = getSettingsContentEnd(content)
+  if (!content || !contentEnd) return
   settingsSectionResizeObserver = new ResizeObserver(() => {
-    clampOverlayScrollTop(content, section)
+    clampOverlayScrollTop(content, contentEnd)
   })
-  content.querySelectorAll(':scope > .section').forEach(element => {
+  content.querySelectorAll(':scope > .section, :scope > .settingsSearchResults').forEach(element => {
     settingsSectionResizeObserver.observe(element)
   })
-  clampOverlayScrollTop(content, section)
+  clampOverlayScrollTop(content, contentEnd)
 }
 
 function clampSettingsContentScroll(event) {
   const content = event.currentTarget
-  const section = getActiveSettingsSectionEnd(content)
-  if (!section) return
-  if (isOverlayScrollTopOutOfBounds(content, section)) {
-    clampOverlayScrollTop(content, section)
+  const contentEnd = getSettingsContentEnd(content)
+  if (!contentEnd) return
+  if (isOverlayScrollTopOutOfBounds(content, contentEnd)) {
+    clampOverlayScrollTop(content, contentEnd)
   }
 }
 
@@ -1074,8 +1152,10 @@ function cancelStandaloneScrollClamp() {
   }
 }
 
-function getActiveSettingsSectionEnd(content) {
-  const sections = content?.querySelectorAll(':scope > .section')
+function getSettingsContentEnd(content) {
+  const sections = content?.querySelectorAll(
+    ':scope > .section, :scope > .settingsSearchResults'
+  )
   return sections?.[sections.length - 1] ?? null
 }
 

--- a/src/renderer/views/Settings/Settings.vue
+++ b/src/renderer/views/Settings/Settings.vue
@@ -380,7 +380,6 @@ import {
   isOverlayScrollTopOutOfBounds,
   restoreOverlayScrollTop
 } from '../../helpers/overlayScrollbars'
-import { getProxyTestUrl } from '../../helpers/proxy-test'
 import {
   SETTINGS_SEARCH_EXCLUDED_MESSAGE_PATHS,
   SETTINGS_SEARCH_SOURCES,
@@ -414,9 +413,19 @@ const LEGACY_SETTINGS_SECTION_MAP = {
   experimental: 'advanced'
 }
 
-const NON_SETTING_MESSAGE_KEY_PATTERN = /(?:^No\b|^How\b|^Checking\b|^Current .+\b(?:has|is|will)\b|^Operation in Progress$|(?:Description|Hint|Tooltip|Template|Warning|Error|Status|Message|Not Downloaded|Unavailable|Connected|Connecting|Success|Failed|Failure)$)/i
+const NON_SETTING_MESSAGE_KEY_PATTERN = /(?:^Are you sure\b|^Failed to\b|^Invalid\b|^No\b|^How\b|^Checking\b|^Downloading\b|^Current .+\b(?:has|is|will)\b|\b(?:has|have) been (?:cleared|removed|saved|updated)\b|^Operation in Progress$|(?:Description|Hint|Tooltip|Placeholder|Template|Warning|Error|Status|Message|Not Downloaded|Unavailable|Connected|Connecting|Success|Failed|Failure|Invalid|Saved|Already Exists)$)/i
 
 const { locale, t, tm } = useI18n()
+const settingsSearchSubsectionTargets = computed(() => ({
+  subscriptions: [{
+    search: t('Settings.Subscription Settings.Subscription Settings'),
+    target: t('Settings.Subscription Settings.Subscription Settings')
+  }],
+  playback: [{
+    search: t('Settings.Player Settings.Caption Appearance.Caption Appearance'),
+    target: t('Settings.Player Settings.Caption Appearance.Captions')
+  }]
+}))
 const isInDesktopView = ref(true)
 const isMaximized = ref(false)
 const activeSection = ref(
@@ -583,20 +592,194 @@ const settingsSectionComponents = computed(() => [{
   component: GeneralCategorySettings
 }, ...settingsComponentsData.value])
 const settingsSearchExtraValues = computed(() => ({
-  privacy: flattenMessageValues(tm('Settings.Password Settings')),
-  advanced: USING_ELECTRON
-    ? [
-        `${t('Settings.Proxy Settings.Clicking on Test Proxy will send a request to')} ` +
-        getProxyTestUrl(locale.value)
-      ]
-    : []
+  privacy: flattenMessageValues(tm('Settings.Password Settings'))
 }))
+const getCaptionEdgeStyle = () => {
+  const value = store.getters.getDefaultCaptionSettings
+  if (value !== null && typeof value === 'object') return value.edgeStyle ?? 'none'
+  try {
+    return JSON.parse(value).edgeStyle ?? 'none'
+  } catch {
+    return 'none'
+  }
+}
+const isSettingsSearchMessageVisible = (sectionType, path) => {
+  const [group, item] = path
+
+  if (sectionType === 'player' && group === 'Screenshot') {
+    if (item === 'Enable') return true
+    if (!store.getters.getEnableScreenshot) return false
+    if (item === 'Mode') return true
+    if (['Format Label', 'Quality Label', 'File Name Label'].includes(item)) {
+      return store.getters.getScreenshotMode !== 'clipboard'
+    }
+    if (['Folder Label', 'Folder Button'].includes(item)) {
+      return USING_ELECTRON && store.getters.getScreenshotMode === 'default_folder'
+    }
+    return false
+  }
+
+  if (sectionType === 'caption-appearance' && group === 'Edge Color') {
+    return getCaptionEdgeStyle() !== 'none'
+  }
+
+  if (sectionType === 'general' && [
+    'Current Invidious Instance',
+    'View all Invidious instance information',
+    'Set Current Instance as Default',
+    'Clear Default Instance'
+  ].includes(group)) {
+    return store.getters.getBackendPreference === 'invidious' ||
+      store.getters.getBackendFallback
+  }
+
+  if (sectionType === 'sync') {
+    if (['Sync Settings', 'Enable Sync'].includes(group)) return true
+    if (!store.getters.getSyncServerEnabled) return false
+    const connected = store.getters.getSyncServerToken !== ''
+    if (['Password', 'Privacy Passphrase', 'Log In', 'Register'].includes(group)) {
+      return !connected
+    }
+    if ([
+      'Automatic Sync',
+      'Profiles',
+      'Settings',
+      'Sync Now',
+      'Disconnect',
+      'Delete Account'
+    ].includes(group)) {
+      return connected
+    }
+    if (group === 'Open Tabs') {
+      return connected && USING_ELECTRON && store.getters.getSyncServerPrivacyMode === 'enhanced'
+    }
+    return true
+  }
+
+  if (sectionType === 'external-player' && [
+    'Custom External Player Executable',
+    'Custom External Player Arguments'
+  ].includes(group)) {
+    return store.getters.getExternalPlayer !== ''
+  }
+
+  if (sectionType === 'sponsor-block') {
+    const useSponsorBlock = store.getters.getUseSponsorBlock
+    const useDeArrowTitles = store.getters.getUseDeArrowTitles
+    const useDeArrowThumbnails = store.getters.getUseDeArrowThumbnails
+    if (group === 'SponsorBlock API Url (Default is https://sponsor.ajay.app)') {
+      return useSponsorBlock || useDeArrowTitles || useDeArrowThumbnails
+    }
+    if ([
+      'Enable SponsorBlock Submission',
+      'Notify when sponsor segment is skipped',
+      'Skip notification timeout',
+      'Skip Options',
+      'Category Color'
+    ].includes(group)) {
+      return useSponsorBlock
+    }
+    if ([
+      'SponsorBlock Private User ID (optional)',
+      'Generated SponsorBlock User ID',
+      'Export Generated User ID'
+    ].includes(group)) {
+      return useSponsorBlock && store.getters.getSponsorBlockEnableSubmission
+    }
+    if (group === 'DeArrow Thumbnail Generator API Url (Default is https://dearrow-thumb.ajay.app)') {
+      return useDeArrowThumbnails
+    }
+  }
+
+  if (sectionType === 'return-youtube-dislike' && group === 'Return YouTube Dislike Url') {
+    return store.getters.getUseReturnYouTubeDislikes
+  }
+
+  if (sectionType === 'proxy') {
+    if ([
+      'Proxy Settings',
+      'Enable Tor / Proxy',
+      'IP Block Recovery Script Path'
+    ].includes(group)) {
+      return true
+    }
+    if (['Proxy Username', 'Proxy Password'].includes(group)) {
+      return store.getters.getUseProxy &&
+        ['http', 'https'].includes(store.getters.getProxyProtocol)
+    }
+    return store.getters.getUseProxy && [
+      'Proxy Protocol',
+      'Proxy Host',
+      'Proxy Port Number',
+      'Test Proxy'
+    ].includes(group)
+  }
+
+  if (sectionType === 'download') {
+    return ['Download Settings', 'Enable Downloads'].includes(group) ||
+      store.getters.getEnableDownloads
+  }
+
+  if (sectionType === 'external-software') {
+    if (group === 'yt-dlp Channel') return store.getters.getYtDlpSource === 'managed'
+    if (group === 'Managed Tool Updates') {
+      return store.getters.getYtDlpSource === 'managed' ||
+        store.getters.getYtDlpFfmpegSource === 'managed'
+    }
+    if (group === 'yt-dlp Executable Path') return store.getters.getYtDlpSource === 'system'
+    if (group === 'FFmpeg Executable Path') return store.getters.getYtDlpFfmpegSource === 'system'
+    if (group === 'Cookie File') return store.getters.getYtDlpPlaybackAuthMode === 'file'
+    if (group === 'Browser for Cookies' || group === 'Browser Profile') {
+      return store.getters.getYtDlpPlaybackAuthMode === 'browser'
+    }
+  }
+
+  if (sectionType === 'channel') {
+    if (group === 'Auto Update') {
+      return store.state.settings.rememberPlaybackSpeedPerChannel ||
+        store.state.settings.rememberVideoQualityPerChannel
+    }
+    if (group === 'Auto Update Subtitles') {
+      return store.state.settings.rememberSubtitlesStatePerChannel
+    }
+    if (group === 'Auto Update Volume') {
+      return store.state.settings.rememberVolumePerChannel
+    }
+    return [
+      'Channel Settings',
+      'Enable Playback Speed',
+      'Enable Video Quality',
+      'Enable Subtitles State',
+      'Enable Volume'
+    ].includes(group)
+  }
+
+  if (sectionType === 'distraction' && group === 'Show Added Items') {
+    let forbiddenTitles = []
+    try {
+      forbiddenTitles = JSON.parse(store.getters.getForbiddenTitles)
+    } catch {
+      // A malformed persisted value is normalized elsewhere and has no visible tags here.
+    }
+    return store.getters.getChannelsHiddenParsed.length > 0 || forbiddenTitles.length > 0
+  }
+
+  if (sectionType === 'theme') {
+    if (group === 'Light Theme' || group === 'Dark Theme') {
+      return store.getters.getBaseTheme === 'system'
+    }
+    if (group === 'Load Missing Tab Icons') return store.getters.getShowTabIcons
+  }
+
+  return true
+}
 const isSearchableSettingsMessage = (sectionType, path, value) => {
   if (/\{[^{}]+\}/.test(value)) return false
   const messagePath = path.join('.')
   const messageKey = path.at(-1) ?? ''
   return !SETTINGS_SEARCH_EXCLUDED_MESSAGE_PATHS[sectionType]?.has(messagePath) &&
-    !NON_SETTING_MESSAGE_KEY_PATTERN.test(messageKey)
+    !NON_SETTING_MESSAGE_KEY_PATTERN.test(messageKey) &&
+    isSettingsSearchMessageVisible(sectionType, path)
 }
 const removeRedundantSearchMatches = (values) => {
   const keptMatches = []
@@ -991,22 +1174,44 @@ async function openSearchResult(sectionType, label) {
   const content = settingsContentRef.value
   if (!content) return
   const normalizedLabel = normalizeSearchText(label.trim())
-  const visibleTextElements = [...content.querySelectorAll(
-    'label, button, p, h1, h2, h3, h4, span, legend, div'
-  )]
-    .filter(element => element.getClientRects().length > 0)
-  const labelElement = visibleTextElements
-    .filter(element => getSearchTargetText(element) === normalizedLabel)
-    .at(-1) ?? visibleTextElements
-    .filter(element => getSearchTargetText(element).startsWith(`${normalizedLabel}:`))
-    .at(-1)
-  const control = labelElement?.closest(
-    '.switch-ctn, .select, .ft-input-component, .pure-material-slider, ' +
-    '.pure-checkbox, .captionControl, .preferenceToggle'
-  ) ?? labelElement
-  const target = control?.classList.contains('ft-input-component')
-    ? control.querySelector('.ft-input')
-    : control
+  const section = settingsSectionComponents.value.find(({ type }) => type === sectionType)
+  const isSectionMatch = [section?.title, section?.description]
+    .some(value => normalizeSearchText(value ?? '') === normalizedLabel)
+  let target = isSectionMatch
+    ? content.querySelector(`.section[data-section="${sectionType}"]`)
+    : null
+  if (target === null) {
+    const subsectionTarget = settingsSearchSubsectionTargets.value[sectionType]?.find(
+      ({ search }) => normalizeSearchText(search) === normalizedLabel
+    )
+    if (subsectionTarget) {
+      const targetHeading = normalizeSearchText(subsectionTarget.target)
+      const headingElement = [...content.querySelectorAll('h1, h2, h3, h4')]
+        .find(element => getSearchTargetText(element) === targetHeading)
+      target = headingElement?.closest('.settingsSection') ?? null
+    }
+  }
+  if (target === null) {
+    const visibleTextElements = [...content.querySelectorAll(
+      'label, button, p, h1, h2, h3, h4, span, legend, div'
+    )]
+      .filter(element => element.getClientRects().length > 0)
+    const labelElement = visibleTextElements
+      .filter(element => getSearchTargetText(element) === normalizedLabel)
+      .at(-1) ?? visibleTextElements
+      .filter(element => getSearchTargetText(element).startsWith(`${normalizedLabel}:`))
+      .at(-1)
+    const settingsSection = labelElement?.matches('h1, h2, h3, h4')
+      ? labelElement.closest('.settingsSection')
+      : null
+    const control = settingsSection ?? labelElement?.closest(
+      '.switch-ctn, .select, .ft-input-component, .pure-material-slider, ' +
+      '.pure-checkbox, .captionControl, .preferenceToggle'
+    ) ?? labelElement
+    target = control?.classList.contains('ft-input-component')
+      ? control.querySelector('.ft-input')
+      : control
+  }
   if (!target) return
 
   target.scrollIntoView({ block: 'center', behavior: 'smooth' })

--- a/tests/unit/settings-search-config.test.mjs
+++ b/tests/unit/settings-search-config.test.mjs
@@ -61,3 +61,24 @@ test('playback search retains caption controls without caption option values', (
     SETTINGS_SEARCH_EXCLUDED_MESSAGE_PATHS['caption-appearance'].has('Application Language')
   )
 })
+
+test('settings search excludes values that only exist in hidden controls', () => {
+  assert.deepEqual(
+    SETTINGS_SEARCH_SELECT_GROUP_LABELS.theme['Icon Pack'],
+    ['Icon Pack']
+  )
+  assert.deepEqual(
+    SETTINGS_SEARCH_SELECT_GROUP_LABELS.theme['Custom Theme'],
+    ['Create Custom Theme', 'Edit Custom Theme']
+  )
+  assert.deepEqual(
+    SETTINGS_SEARCH_SELECT_GROUP_LABELS.player['Auto Picture in Picture'],
+    ['Auto Picture in Picture']
+  )
+  assert.ok(SETTINGS_SEARCH_EXCLUDED_MESSAGE_PATHS.password.has('Password'))
+  assert.equal(typeof getAtPath(locale, 'Settings.Password Settings.Password'), 'string')
+  assert.ok(
+    SETTINGS_SEARCH_EXCLUDED_MESSAGE_PATHS['sponsor-block']
+      .has('Generated SponsorBlock User ID Copy Button')
+  )
+})


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Make sure to follow the contributing guidelines. -->
<!-- Important note, we may remove your pull request if you do not use this provided PR template correctly. -->
<!-- Agent instructions: Preserve every heading, comment, and marker in this template. Never remove or rewrite the release-note-category:start/end, release-note:start/end, or release-note-image:start/end marker pairs. Never remove or rewrite the Release note images section; leave its contents for a human. -->

## Pull Request Type
<!-- Please select what type of pull request this is: [x] -->
- [x] Bugfix
- [ ] Feature Implementation
- [ ] Documentation
- [ ] Other

## Related issue
<!-- Please link the issue your pull request is referring to. -->
<!-- If this pull request fully resolves the relevant issue, put "closes" before the issue number. -->
<!-- Example: "closes #123456". -->

## Description
<!-- Please write a clear and concise description of what the pull request does. -->
Settings search could highlight only a select control or heading instead of the complete setting or section. It also indexed placeholders and feedback text, and kept results for controls that were currently hidden.

This makes search targets match the rendered setting or section, keeps hidden subsection aliases discoverable, excludes non-setting text, and filters controls using their current visibility conditions.

## Release note category
<!-- Select exactly one category. Every pull request must select one. -->
<!-- Select "Not noteworthy" when the pull request fixes a bug in or improves functionality that has not yet appeared in a stable release. -->
<!-- release-note-category:start -->
- [ ] Not noteworthy
- [ ] Highlights
- [ ] More improvements
- [x] Fixed bugs
<!-- release-note-category:end -->

## Release note
<!-- Required unless "Not noteworthy" is selected. -->
<!-- Write one concise, user-facing entry without a leading bullet. -->
<!-- release-note:start -->
Settings search now highlights complete settings and sections, excludes non-setting text, and hides unavailable controls from results.
<!-- release-note:end -->

## Release note images
<!-- Human-only: Agents must preserve this entire section and leave it empty. -->
<!-- Optional. Paste one or more Markdown images or HTML image tags here. -->
<!-- The release notes will use an HTML image tag and limit images taller than 300 pixels. -->
<!-- release-note-image:start -->

<!-- release-note-image:end -->

## Testing
<!-- How can reviewers verify that the PR produces correct results? -->
<!-- Please provide instructions so that others can ensure that your pull request would produce correct results. For examples see, https://github.com/FreeTubeApp/FreeTube/pull/5743, https://github.com/FreeTubeApp/FreeTube/pull/7349, https://github.com/FreeTubeApp/FreeTube/pull/5125, https://github.com/FreeTubeApp/FreeTube/pull/7338 -->
<!-- Agent instructions: Only write human-facing steps that explain how to verify the change while running this branch in dev mode. Include expected results and, when applicable, helpful console snippets for interactive verification. Do not include automated checks, commands, results, pass counts, or CI status. -->
1. Open Settings, search for Auto Refresh Interval, and select one of the results. The highlight should surround the label, help icon, and select control.
2. Search for Context Menu, Subscription, and Caption Appearance, then open each result. The highlight should surround the complete corresponding section.
3. Search for Engine name, Search URL, and Search history and cache have been cleared. None of these placeholder or feedback strings should produce results.
4. Disable a feature that owns conditional settings, such as the proxy, and search for one of its hidden controls, such as Test Proxy. The result should be absent while the control is hidden and return after the feature is enabled.

## Additional context
<!-- Add any other context about the pull request here. -->
The search remains able to find hidden subsection titles when they represent a visible section.
