### PR TITLE
fix(player): keep active Shorts at their current size

### DIFF
--- a/e2e/tests/offline/watch-page.spec.mjs
+++ b/e2e/tests/offline/watch-page.spec.mjs
@@ -1,4 +1,4 @@
-import { sel, setPlayerFullscreen, test, expect } from '../../helpers/app.mjs'
+import { goTo, sel, setPlayerFullscreen, test, expect } from '../../helpers/app.mjs'
 import { activeTab, findWatchComponent, openMockedVideo, waitForPlayback } from '../../helpers/player.mjs'
 import { mockPlayableWatchPage, watchViewHandle } from '../../helpers/watch.mjs'
 import { demoPlayerResponse } from '../../helpers/media.mjs'
@@ -151,6 +151,43 @@ test.describe('Shorts transcript navigation', () => {
         shortsTimestamp: new Date().toISOString()
       }]
     }
+  })
+
+  test('keeps the current Short from expanding when YouTube-style Shorts are disabled', async ({ app, page }) => {
+    await mockPlayableWatchPage(app, page)
+    await page.evaluate(async () => {
+      const store = document.querySelector('#app').__vue_app__.config.globalProperties.$store
+      await store.dispatch('updateUiScale', 95)
+    })
+    await page.locator(sel.searchInput)
+      .fill(`https://www.youtube.com/shorts/${CAPTIONED_SHORT_IDS[0]}`)
+    await page.locator(sel.searchInput).press('Enter')
+    await expect(page).toHaveURL(new RegExp(`#\\/watch\\/${CAPTIONED_SHORT_IDS[0]}\\?short=true`))
+    await waitForPlayback(page)
+
+    const player = page.locator('.ftVideoPlayer')
+    await expect(player).toHaveClass(/shortsPlayer/)
+    const shortsBounds = await player.boundingBox()
+    expect(shortsBounds).not.toBeNull()
+
+    await goTo(page, 'settings')
+    await page.locator('.settingsMenu [data-section="playback"]').click()
+    const toggle = page.getByRole('checkbox', { name: 'Use YouTube-style Shorts' })
+    await expect(toggle).toBeChecked()
+    await page.locator('label.switch-label')
+      .filter({ hasText: 'Use YouTube-style Shorts' })
+      .click()
+    await expect(toggle).not.toBeChecked()
+    await expect(player).toHaveClass(/shortsPlayer/)
+
+    const bounds = await player.boundingBox()
+    expect(bounds).not.toBeNull()
+    expect(bounds.width).toBeLessThanOrEqual(shortsBounds.width + 1)
+
+    await page.locator('.settingsWindow').getByRole('button', { name: 'Close' }).click()
+    await page.locator('.shortsNavigationButton').last().click()
+    await expect(page).toHaveURL(new RegExp(`#\\/watch\\/${CAPTIONED_SHORT_IDS[1]}\\?short=true`))
+    await expect(player).not.toHaveClass(/shortsPlayer/)
   })
 
   test('shows quick playback speeds near the pointer without covering the seek preview', async ({ app, page, attachScreenshot }) => {

--- a/e2e/tests/offline/watch-page.spec.mjs
+++ b/e2e/tests/offline/watch-page.spec.mjs
@@ -187,6 +187,7 @@ test.describe('Shorts transcript navigation', () => {
     await page.locator('.settingsWindow').getByRole('button', { name: 'Close' }).click()
     await page.locator('.shortsNavigationButton').last().click()
     await expect(page).toHaveURL(new RegExp(`#\\/watch\\/${CAPTIONED_SHORT_IDS[1]}\\?short=true`))
+    await waitForPlayback(page)
     await expect(player).not.toHaveClass(/shortsPlayer/)
   })
 

--- a/src/renderer/views/Watch/Watch.js
+++ b/src/renderer/views/Watch/Watch.js
@@ -220,6 +220,7 @@ export default defineComponent({
       isPostLiveDvr: false,
       isUnlisted: false,
       isShort: false,
+      useCustomShortsPlayerForCurrentVideo: false,
       videoAspectRatio: null,
       shortsLinkedVideo: null,
       shortsTouchStartY: null,
@@ -646,7 +647,7 @@ export default defineComponent({
         this.vrProjection !== 'EQUIRECTANGULAR'
     },
     customShortsPlayerActive: function () {
-      return this.$store.getters.getUseCustomShortsPlayer &&
+      return this.useCustomShortsPlayerForCurrentVideo &&
         this.isShort &&
         this.activeFormat !== 'audio'
     },
@@ -1136,6 +1137,7 @@ export default defineComponent({
     this.theatreModeAnimations = []
     this.videoId = this.tabRoute.params.id
     this.isShort = this.tabRoute.query.short === 'true'
+    this.useCustomShortsPlayerForCurrentVideo = this.$store.getters.getUseCustomShortsPlayer
     this.videoAspectRatio = this.isShort ? 9 / 16 : null
     this.activeFormat = this.defaultVideoFormat
     // So that the value for this session remains unchanged even if setting changed
@@ -1694,6 +1696,7 @@ export default defineComponent({
         this.videoId = this.tabRoute.params.id
         const videoIdChanged = this.videoId !== previousVideoId
         if (videoIdChanged) {
+          this.useCustomShortsPlayerForCurrentVideo = this.$store.getters.getUseCustomShortsPlayer
           this.ipBlockRecoveryAttemptedForCurrentVideo = false
           this.streamErrorReloadAttemptedForCurrentVideo = false
           this.playbackEngineFallbackAttemptedForCurrentVideo = false


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Make sure to follow the contributing guidelines. -->
<!-- Important note, we may remove your pull request if you do not use this provided PR template correctly. -->
<!-- Agent instructions: Preserve every heading, comment, and marker in this template. Never remove or rewrite the release-note-category:start/end, release-note:start/end, or release-note-image:start/end marker pairs. Never remove or rewrite the Release note images section; leave its contents for a human. -->

## Pull Request Type
<!-- Please select what type of pull request this is: [x] -->
- [x] Bugfix
- [ ] Feature Implementation
- [ ] Documentation
- [ ] Other

## Related issue
<!-- Please link the issue your pull request is referring to. -->
<!-- If this pull request fully resolves the relevant issue, put "closes" before the issue number. -->
<!-- Example: "closes #123456". -->

None.

## Description
<!-- Please write a clear and concise description of what the pull request does. -->

Turning off YouTube-style Shorts while a Short was playing immediately replaced its narrow player layout with the regular wide layout. This made the player jump from about 419 px to 1053 px in a desktop window.

The watch view now snapshots this preference for the current video. A playing Short keeps its layout, while the updated setting applies when the user opens the next video.

## Release note category
<!-- Select exactly one category. Every pull request must select one. -->
<!-- Select "Not noteworthy" when the pull request fixes a bug in or improves functionality that has not yet appeared in a stable release. -->
<!-- release-note-category:start -->
- [ ] Not noteworthy
- [ ] Highlights
- [ ] More improvements
- [x] Fixed bugs
<!-- release-note-category:end -->

## Release note
<!-- Required unless "Not noteworthy" is selected. -->
<!-- Write one concise, user-facing entry without a leading bullet. -->
<!-- release-note:start -->
Changing the YouTube-style Shorts setting no longer resizes a Short that is already playing.
<!-- release-note:end -->

## Release note images
<!-- Human-only: Agents must preserve this entire section and leave it empty. -->
<!-- Optional. Paste one or more Markdown images or HTML image tags here. -->
<!-- The release notes will use an HTML image tag and limit images taller than 300 pixels. -->
<!-- release-note-image:start -->

<!-- release-note-image:end -->

## Testing
<!-- How can reviewers verify that the PR produces correct results? -->
<!-- Please provide instructions so that others can ensure that your pull request would produce correct results. For examples see, https://github.com/FreeTubeApp/FreeTube/pull/5743, https://github.com/FreeTubeApp/FreeTube/pull/7349, https://github.com/FreeTubeApp/FreeTube/pull/5125, https://github.com/FreeTubeApp/FreeTube/pull/7338 -->
<!-- Agent instructions: Only write human-facing steps that explain how to verify the change while running this branch in dev mode. Include expected results and, when applicable, helpful console snippets for interactive verification. Do not include automated checks, commands, results, pass counts, or CI status. -->

1. Enable Use YouTube-style Shorts and open a Short.
2. While it is playing, open Settings, select Playback, and turn Use YouTube-style Shorts off.
3. Confirm the current player stays at the same narrow size.
4. Open another Short and confirm it uses the regular player layout.

## Additional context
<!-- Add any other context about the pull request here. -->

The regression coverage also runs at 95% UI scale to exercise fractional CSS-pixel geometry.