### PR TITLE
fix(posts): center author metadata on avatars

### DIFF
--- a/e2e/tests/offline/subscriptions-new-feed.spec.mjs
+++ b/e2e/tests/offline/subscriptions-new-feed.spec.mjs
@@ -3,6 +3,7 @@ import { test, expect, goTo } from '../../helpers/app.mjs'
 const now = Date.now()
 const HOUR = 3600000
 const CHANNEL_ID = 'UCaaaaaaaaaaaaaaaaaaaaaa'
+const AUTHOR_THUMBNAIL = 'data:image/svg+xml,<svg xmlns="http://www.w3.org/2000/svg" width="55" height="55"/>'
 
 function video (videoId, title, published, extra = {}) {
   return {
@@ -26,7 +27,7 @@ function post (postId, text, publishedTime) {
     postText: text,
     author: 'Channel A',
     authorId: CHANNEL_ID,
-    authorThumbnails: [],
+    authorThumbnails: [{ url: AUTHOR_THUMBNAIL, width: 55, height: 55 }],
     publishedTime,
     voteCount: 1,
     commentCount: 0,
@@ -211,6 +212,43 @@ test.describe('new subscriptions feed', () => {
 })
 
 for (const uiScale of [100, 125]) {
+  test.describe(`community post author at ${uiScale}% UI scale`, () => {
+    test.use({
+      seed: {
+        settings: {
+          ...commonSettings,
+          uiScale
+        },
+        profiles: [profile()],
+        subscriptionCache: populatedCache
+      }
+    })
+
+    test('centers the channel name and relative time on the avatar', async ({ page }) => {
+      await goTo(page, 'subscriptions')
+      await page.locator('[data-subscription-feed-tab="posts"]').click()
+
+      const post = page.locator('.ft-list-post').filter({ hasText: 'New community post' })
+      await expect(post).toBeVisible()
+
+      const centers = await post.evaluate(element => {
+        const verticalCenter = selector => {
+          const rect = element.querySelector(selector).getBoundingClientRect()
+          return (rect.top + rect.bottom) / 2
+        }
+
+        return {
+          avatar: verticalCenter('.communityThumbnail'),
+          author: verticalCenter('.authorName'),
+          published: verticalCenter('.publishedText')
+        }
+      })
+
+      expect(Math.abs(centers.author - centers.avatar)).toBeLessThanOrEqual(1)
+      expect(Math.abs(centers.published - centers.avatar)).toBeLessThanOrEqual(1)
+    })
+  })
+
   test.describe(`new subscriptions feed empty state at ${uiScale}% UI scale`, () => {
     test.use({
       seed: {

--- a/src/renderer/components/FtCommunityPost/FtCommunityPost.scss
+++ b/src/renderer/components/FtCommunityPost/FtCommunityPost.scss
@@ -35,12 +35,17 @@
 }
 
 .author-div {
+  align-items: center;
   display: flex;
+
+  .authorThumbnailLink {
+    display: flex;
+  }
 
   .authorName {
     font-size: 15px;
     font-weight: bold;
-    margin-block: 5px 0;
+    margin-block: 0;
     margin-inline: 5px 6px;
 
     .authorNameLink {
@@ -51,7 +56,7 @@
 
   .publishedText {
     font-size: 15px;
-    margin-block: 5px 0;
+    margin-block: 0;
     margin-inline: 5px 6px;
   }
 }

--- a/src/renderer/components/FtCommunityPost/FtCommunityPost.vue
+++ b/src/renderer/components/FtCommunityPost/FtCommunityPost.vue
@@ -14,6 +14,7 @@
           :is="enableChannelLinks ? 'router-link' : 'div'"
           v-if="authorId"
           :to="`/channel/${authorId}`"
+          class="authorThumbnailLink"
           tabindex="-1"
           aria-hidden="true"
         >


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Make sure to follow the contributing guidelines. -->
<!-- Important note, we may remove your pull request if you do not use this provided PR template correctly. -->
<!-- Agent instructions: Preserve every heading, comment, and marker in this template. Never remove or rewrite the release-note-category:start/end, release-note:start/end, or release-note-image:start/end marker pairs. Never remove or rewrite the Release note images section; leave its contents for a human. -->

## Pull Request Type
<!-- Please select what type of pull request this is: [x] -->
- [x] Bugfix
- [ ] Feature Implementation
- [ ] Documentation
- [ ] Other

## Related issue
<!-- Please link the issue your pull request is referring to. -->
<!-- If this pull request fully resolves the relevant issue, put "closes" before the issue number. -->
<!-- Example: "closes #123456". -->

None.

## Description
<!-- Please write a clear and concise description of what the pull request does. -->

Post channel names and relative timestamps sat near the top of their channel avatars. This centers the author row on the avatar and removes the asymmetric text margins that skewed the alignment.

The avatar link now uses a flex box so its inline baseline does not offset the image. The regression test checks the rendered centers at 100% and 125% UI scale.

## Release note category
<!-- Select exactly one category. Every pull request must select one. -->
<!-- Select "Not noteworthy" when the pull request fixes a bug in or improves functionality that has not yet appeared in a stable release. -->
<!-- release-note-category:start -->
- [ ] Not noteworthy
- [ ] Highlights
- [ ] More improvements
- [x] Fixed bugs
<!-- release-note-category:end -->

## Release note
<!-- Required unless "Not noteworthy" is selected. -->
<!-- Write one concise, user-facing entry without a leading bullet. -->
<!-- release-note:start -->
Channel names and relative timestamps in posts are now vertically centered beside channel avatars.
<!-- release-note:end -->

## Release note images
<!-- Human-only: Agents must preserve this entire section and leave it empty. -->
<!-- Optional. Paste one or more Markdown images or HTML image tags here. -->
<!-- The release notes will use an HTML image tag and limit images taller than 300 pixels. -->
<!-- release-note-image:start -->

<!-- release-note-image:end -->

## Testing
<!-- How can reviewers verify that the PR produces correct results? -->
<!-- Please provide instructions so that others can ensure that your pull request would produce correct results. For examples see, https://github.com/FreeTubeApp/FreeTube/pull/5743, https://github.com/FreeTubeApp/FreeTube/pull/7349, https://github.com/FreeTubeApp/FreeTube/pull/5125, https://github.com/FreeTubeApp/FreeTube/pull/7338 -->
<!-- Agent instructions: Only write human-facing steps that explain how to verify the change while running this branch in dev mode. Include expected results and, when applicable, helpful console snippets for interactive verification. Do not include automated checks, commands, results, pass counts, or CI status. -->

1. Open the Subscriptions page and select the Posts tab.
2. Find a post with a channel avatar. Confirm the channel name and relative timestamp share the avatar's vertical center.
3. Change UI Scale to 125%, return to the Posts tab, and confirm the alignment remains centered.

## Additional context
<!-- Add any other context about the pull request here. -->

None.
