### PR TITLE
fix(community): recover gallery loading and navigation

### DIFF
--- a/e2e/tests/offline/community-post-images.spec.mjs
+++ b/e2e/tests/offline/community-post-images.spec.mjs
@@ -1,3 +1,4 @@
+import { createServer } from 'node:http'
 import { deflateSync } from 'node:zlib'
 
 import { test, expect, goTo } from '../../helpers/app.mjs'
@@ -94,6 +95,25 @@ function singleImagePost() {
     postContent: {
       type: 'image',
       content: thumbnails('wide', 800, 450)
+    },
+    type: 'community',
+    isNewInSubscriptionFeed: true
+  }
+}
+
+function interruptedImagePost(imageUrls) {
+  return {
+    postId: 'interrupted-image-post',
+    postText: 'Generic gallery post',
+    author: 'Example Channel',
+    authorId: CHANNEL_ID,
+    authorThumbnails: [],
+    publishedTime: now - 10 * 60000,
+    voteCount: 2,
+    commentCount: 0,
+    postContent: {
+      type: 'multiImage',
+      content: imageUrls.map((url) => [{ width: 640, height: 640, url }])
     },
     type: 'community',
     isNewInSubscriptionFeed: true
@@ -205,4 +225,111 @@ test.describe('community post images', () => {
       expect(carouselLayout.paginationBottom).toBeLessThanOrEqual(carouselLayout.containerBottom + 1)
     }
   })
+
+  test('restores carousel navigation after returning to the Posts tab', async ({ page }) => {
+    await stubPostImages(page)
+
+    await goTo(page, 'subscriptions')
+    await page.locator('[data-subscription-feed-tab="posts"]').click()
+
+    const post = page.locator('.ft-list-post').filter({ hasText: 'Multi image community post' })
+    const carousel = post.locator('swiper-container')
+    await expect(post).toBeVisible()
+    await expect.poll(async () => carousel.evaluate((element) => element.swiper?.activeIndex)).toBe(0)
+
+    await page.locator('[data-subscription-feed-tab="videos"]').click()
+    await expect(post).toHaveCount(0)
+    await page.locator('[data-subscription-feed-tab="posts"]').click()
+    await expect(post).toBeVisible()
+
+    await expect.poll(async () => carousel.evaluate((element) => element.swiper?.activeIndex)).toBe(0)
+    await carousel.locator('.swiper-button-next').click()
+    await expect.poll(async () => carousel.evaluate((element) => element.swiper?.activeIndex)).toBe(1)
+  })
+})
+
+const interruptedImageTest = test.extend({
+  interruptedImageUrls: [async ({ browserName: _browserName }, use) => {
+    const image = solidPng(640, 640)
+    const server = createServer((request, response) => {
+      response.setHeader('Access-Control-Allow-Origin', '*')
+      response.setHeader('Content-Type', 'image/png')
+      response.setHeader('Connection', 'close')
+
+      if (request.url === '/interrupted.png') {
+        // Send valid image bytes, then end one byte short of the declared
+        // length so Chromium emits an error after lazy loading has started.
+        response.setHeader('Content-Length', image.length + 1)
+        response.write(image)
+        setTimeout(() => response.end(), 750)
+        return
+      }
+
+      response.setHeader('Content-Length', image.length)
+      response.end(image)
+    })
+
+    await new Promise((resolve, reject) => {
+      const onError = (error) => reject(error)
+      server.once('error', onError)
+      server.listen(0, '127.0.0.1', () => {
+        server.off('error', onError)
+        resolve()
+      })
+    })
+
+    const address = server.address()
+    if (address == null || typeof address === 'string') {
+      throw new Error('Failed to start the gallery image server')
+    }
+
+    try {
+      const baseUrl = `http://127.0.0.1:${address.port}`
+      await use([`${baseUrl}/interrupted.png`, `${baseUrl}/complete.png`])
+    } finally {
+      await new Promise((resolve) => server.close(resolve))
+    }
+  }, { scope: 'worker' }],
+
+  seed: async ({ interruptedImageUrls }, use) => {
+    await use({
+      settings: {
+        fetchSubscriptionsAutomatically: false,
+        hideSubscriptionsCommunity: false,
+        showNewSubscriptionFeed: true,
+        useRssFeeds: false,
+        listType: 'list'
+      },
+      profiles: [{
+        _id: 'allChannels',
+        name: 'All Channels',
+        bgColor: '#000000',
+        textColor: '#FFFFFF',
+        subscriptions: [{ id: CHANNEL_ID, name: 'Example Channel', thumbnail: '' }]
+      }],
+      subscriptionCache: [{
+        _id: CHANNEL_ID,
+        communityPosts: [interruptedImagePost(interruptedImageUrls)],
+        communityPostsTimestamp: new Date(now - 3600000).toISOString()
+      }]
+    })
+  }
+})
+
+interruptedImageTest.use({
+  launchArgs: ['--disable-web-security', '--allow-running-insecure-content']
+})
+
+interruptedImageTest('clears the loader when a gallery image request is interrupted', async ({ page }) => {
+  await goTo(page, 'subscriptions')
+  await page.locator('[data-subscription-feed-tab="posts"]').click()
+
+  const post = page.locator('.ft-list-post').filter({ hasText: 'Generic gallery post' })
+  await expect(post).toBeVisible()
+
+  const firstSlide = post.locator('swiper-slide').first()
+  const image = firstSlide.locator('img.communityImage')
+  await expect.poll(async () => image.evaluate((element) => element.complete)).toBe(true)
+
+  await expect(firstSlide.locator('.swiper-lazy-preloader')).toHaveCount(0)
 })

--- a/src/renderer/components/FtCommunityPost/FtCommunityPost.vue
+++ b/src/renderer/components/FtCommunityPost/FtCommunityPost.vue
@@ -76,6 +76,7 @@
           class="communityImage"
           alt=""
           loading="lazy"
+          @error="removeImagePreloader"
         >
       </swiper-slide>
     </swiper-container>
@@ -165,7 +166,7 @@
 <script setup>
 import { FtIcon } from '@opentubex/icons'
 import autolinker from 'autolinker'
-import { computed, onMounted, useTemplateRef } from 'vue'
+import { computed, onActivated, onMounted, useTemplateRef } from 'vue'
 
 import FtListVideo from '../FtListVideo/FtListVideo.vue'
 import FtListPlaylist from '../FtListPlaylist/FtListPlaylist.vue'
@@ -321,42 +322,73 @@ function getBestQualityImage(imageArray, options = {}) {
   return url.replace(/-c-fcrop64=[^-]+/i, '')
 }
 
+/**
+ * Swiper only removes its lazy preloader after an image load event. Failed
+ * requests can therefore leave it visible indefinitely.
+ *
+ * @param {Event} event
+ */
+function removeImagePreloader(event) {
+  const image = event.currentTarget
+  if (!(image instanceof HTMLElement)) {
+    return
+  }
+
+  const slide = image.closest('swiper-slide')
+  const preloader = slide?.querySelector('.swiper-lazy-preloader') ??
+    slide?.shadowRoot?.querySelector('.swiper-lazy-preloader')
+  preloader?.remove()
+}
+
 const swiperContainerRef = useTemplateRef('swiperContainerRef')
+let swiperInitializationPromise = null
+
+async function initializeSwiper() {
+  const existingSwiper = swiperContainerRef.value?.swiper
+  if (swiperInitializationPromise || (existingSwiper && !existingSwiper.destroyed)) {
+    return
+  }
+
+  swiperInitializationPromise = loadSwiperModules()
+
+  try {
+    const { A11y, Navigation, Pagination } = await swiperInitializationPromise
+    /** @type {import('swiper/element').SwiperContainer|null} */
+    const swiperContainer = swiperContainerRef.value
+    if (!swiperContainer?.isConnected || (swiperContainer.swiper && !swiperContainer.swiper.destroyed)) {
+      return
+    }
+
+    const swiperOptions = {
+      modules: [A11y, Navigation, Pagination],
+
+      injectStylesUrls: [
+        // This file is created with the copy webpack plugin in the web and renderer webpack configs.
+        // If you add more modules, please remember to add their CSS files to the list in webpack config files.
+        createWebURL(`/swiper-${process.env.SWIPER_VERSION}.css`)
+      ],
+
+      a11y: true,
+      navigation: true,
+      pagination: {
+        enabled: true,
+        clickable: true
+      },
+      slidesPerView: 1
+    }
+
+    Object.assign(swiperContainer, swiperOptions)
+    swiperContainer.initialize()
+  } catch (error) {
+    console.error('Failed to initialize community post carousel', error)
+  } finally {
+    swiperInitializationPromise = null
+  }
+}
 
 if (postType === 'multiImage' && postContent.content.length > 0) {
-  onMounted(async () => {
-    try {
-      const { A11y, Navigation, Pagination } = await loadSwiperModules()
-      /** @type {import('swiper/element').SwiperContainer|null} */
-      const swiperContainer = swiperContainerRef.value
-      if (!swiperContainer) {
-        return
-      }
-
-      const swiperOptions = {
-        modules: [A11y, Navigation, Pagination],
-
-        injectStylesUrls: [
-          // This file is created with the copy webpack plugin in the web and renderer webpack configs.
-          // If you add more modules, please remember to add their CSS files to the list in webpack config files.
-          createWebURL(`/swiper-${process.env.SWIPER_VERSION}.css`)
-        ],
-
-        a11y: true,
-        navigation: true,
-        pagination: {
-          enabled: true,
-          clickable: true
-        },
-        slidesPerView: 1
-      }
-
-      Object.assign(swiperContainer, swiperOptions)
-      swiperContainer.initialize()
-    } catch (error) {
-      console.error('Failed to initialize community post carousel', error)
-    }
-  })
+  onMounted(initializeSwiper)
+  onActivated(initializeSwiper)
 }
 
 const enableChannelLinks = computed(() => !store.getters.getDisableChannelLinks)


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Make sure to follow the contributing guidelines. -->
<!-- Important note, we may remove your pull request if you do not use this provided PR template correctly. -->
<!-- Agent instructions: Preserve every heading, comment, and marker in this template. Never remove or rewrite the release-note-category:start/end, release-note:start/end, or release-note-image:start/end marker pairs. Never remove or rewrite the Release note images section; leave its contents for a human. -->

## Pull Request Type
<!-- Please select what type of pull request this is: [x] -->
- [x] Bugfix
- [ ] Feature Implementation
- [ ] Documentation
- [ ] Other

## Related issue
<!-- Please link the issue your pull request is referring to. -->
<!-- If this pull request fully resolves the relevant issue, put "closes" before the issue number. -->
<!-- Example: "closes #123456". -->

## Description
<!-- Please write a clear and concise description of what the pull request does. -->
Community post galleries could enter two stale states in the subscription feed. An image request error left Swiper's lazy-loading indicator visible because Swiper only registered a load listener. Separately, switching away from the Posts tab destroyed the cached carousel instance, while the element's disabled automatic initialization left its arrow controls inert after returning.

This removes the affected slide preloader on the image error path and reinitializes destroyed carousels when a cached Posts panel becomes active again. Generic regression coverage exercises both failure modes with placeholder post metadata and generated image data.

## Release note category
<!-- Select exactly one category. Every pull request must select one. -->
<!-- Select "Not noteworthy" when the pull request fixes a bug in or improves functionality that has not yet appeared in a stable release. -->
<!-- release-note-category:start -->
- [ ] Not noteworthy
- [ ] Highlights
- [ ] More improvements
- [x] Fixed bugs
<!-- release-note-category:end -->

## Release note
<!-- Required unless "Not noteworthy" is selected. -->
<!-- Write one concise, user-facing entry without a leading bullet. -->
<!-- release-note:start -->
Community post image galleries now recover after failed image requests and remain navigable after switching subscription feed tabs.
<!-- release-note:end -->

## Release note images
<!-- Human-only: Agents must preserve this entire section and leave it empty. -->
<!-- Optional. Paste one or more Markdown images or HTML image tags here. -->
<!-- The release notes will use an HTML image tag and limit images taller than 300 pixels. -->
<!-- release-note-image:start -->

<!-- release-note-image:end -->

## Testing
<!-- How can reviewers verify that the PR produces correct results? -->
<!-- Please provide instructions so that others can ensure that your pull request would produce correct results. For examples see, https://github.com/FreeTubeApp/FreeTube/pull/5743, https://github.com/FreeTubeApp/FreeTube/pull/7349, https://github.com/FreeTubeApp/FreeTube/pull/5125, https://github.com/FreeTubeApp/FreeTube/pull/7338 -->
<!-- Agent instructions: Only write human-facing steps that explain how to verify the change while running this branch in dev mode. Include expected results and, when applicable, helpful console snippets for interactive verification. Do not include automated checks, commands, results, pass counts, or CI status. -->
1. In dev mode, open Subscriptions → Posts with a multi-image community post and confirm its next arrow changes slides.
2. Switch to another subscription feed tab, return to Posts, and confirm the carousel arrows still change slides.
3. Use DevTools request blocking to make the first gallery image request fail, then reload the feed.
4. Confirm the loader disappears after the request fails instead of spinning indefinitely and that the other slides remain navigable.

## Additional context
<!-- Add any other context about the pull request here. -->

