### PR TITLE
fix: correct playlist metadata, search ordering, and UI feedback

### DIFF
--- a/e2e/tests/network/watch.spec.mjs
+++ b/e2e/tests/network/watch.spec.mjs
@@ -717,7 +717,7 @@ test.describe('watch page', () => {
       const store = document.querySelector('#app').__vue_app__.config.globalProperties.$store
       store.commit('setGeneralAutoLoadMorePaginatedItemsEnabled', true)
     })
-    await expect(page.getByLabel('Load More Comments')).toHaveCount(0)
+    await expect(page.getByRole('status', { name: 'Load More Comments' })).toHaveCount(0)
 
     // Exercise reply loading and its continuation path, not only the initial
     // top-level comment batch (8bcf0b58d).

--- a/e2e/tests/network/watch.spec.mjs
+++ b/e2e/tests/network/watch.spec.mjs
@@ -717,7 +717,7 @@ test.describe('watch page', () => {
       const store = document.querySelector('#app').__vue_app__.config.globalProperties.$store
       store.commit('setGeneralAutoLoadMorePaginatedItemsEnabled', true)
     })
-    await expect(page.getByLabel('Loading more comments')).toHaveCount(0)
+    await expect(page.getByLabel('Load More Comments')).toHaveCount(0)
 
     // Exercise reply loading and its continuation path, not only the initial
     // top-level comment batch (8bcf0b58d).

--- a/src/renderer/components/CommentSection/CommentSection.vue
+++ b/src/renderer/components/CommentSection/CommentSection.vue
@@ -413,7 +413,7 @@
       </div>
       <FtSpinner
         v-if="shouldShowAutoLoadMoreCommentsSpinner"
-        label="Loading more comments"
+        :label="$t('Comments.Load More Comments')"
       />
       <h4
         v-else-if="canPerformMoreCommentLoading"

--- a/src/renderer/components/FtAutoLoadNextPageWrapper.vue
+++ b/src/renderer/components/FtAutoLoadNextPageWrapper.vue
@@ -11,7 +11,7 @@
     </div>
     <FtSpinner
       v-if="loading || generalAutoLoadMorePaginatedItemsEnabled"
-      label="Loading more"
+      :label="$t('Global.Loading More')"
     />
     <slot v-else />
   </div>

--- a/src/renderer/components/FtToast/FtToast.css
+++ b/src/renderer/components/FtToast/FtToast.css
@@ -505,8 +505,10 @@
 /* Fade a toast out as it is pushed towards the edge it is anchored to */
 [data-sonner-toast][data-swiping='true'] .toast,
 [data-sonner-toast][data-swiping='true'] .timeout-indicator-track {
+  /* Keeping the division inside abs() stops postcss-calc from misreading the
+     pixel divisor as a scalar. The browser still resolves px / px to a number. */
   /* stylelint-disable-next-line scss/no-global-function-names -- CSS abs(), not the Sass one */
-  opacity: max(0, calc(1 - abs(var(--swipe-amount-x, 0px)) / 200px));
+  opacity: max(0, calc(1 - abs(var(--swipe-amount-x, 0px) / 200px)));
 }
 
 [data-sonner-toast][data-swiping='true'] .toast {

--- a/src/renderer/helpers/playlists.js
+++ b/src/renderer/helpers/playlists.js
@@ -77,6 +77,32 @@ export function videoDurationWithFallback(video) {
   return 0
 }
 
+/**
+ * Fills playlist durations from matching history entries when possible.
+ * @param {object[]} playlistItems
+ * @param {Record<string, object>} historyCacheById
+ * @returns {boolean} whether any playlist item still lacks a duration
+ */
+export function fillMissingPlaylistVideoDurations(playlistItems, historyCacheById) {
+  let anyVideoMissingDuration = false
+
+  for (const video of playlistItems) {
+    if (videoDurationPresent(video)) { continue }
+
+    const videoHistory = historyCacheById[video.videoId]
+    const fetchedLengthSeconds = videoHistory == null
+      ? 0
+      : videoDurationWithFallback(videoHistory)
+
+    video.lengthSeconds = fetchedLengthSeconds
+    if (fetchedLengthSeconds === 0) {
+      anyVideoMissingDuration = true
+    }
+  }
+
+  return anyVideoMissingDuration
+}
+
 function publishedWithFallback(video) {
   const published = video.published
   return typeof published === 'number' && !isNaN(published) && published !== 0 ? published : 0

--- a/src/renderer/helpers/search-history.js
+++ b/src/renderer/helpers/search-history.js
@@ -1,0 +1,8 @@
+/**
+ * Sorts search history in place from the most recent entry to the oldest.
+ * @param {{ lastUpdatedAt: number }[]} historyItems
+ * @returns {{ lastUpdatedAt: number }[]}
+ */
+export function sortSearchHistoryByLastUpdatedAt(historyItems) {
+  return historyItems.sort((a, b) => b.lastUpdatedAt - a.lastUpdatedAt)
+}

--- a/src/renderer/store/modules/search-history.js
+++ b/src/renderer/store/modules/search-history.js
@@ -1,5 +1,6 @@
 import { MIXED_SEARCH_HISTORY_ENTRIES_DISPLAY_LIMIT } from '../../../constants'
 import { DBSearchHistoryHandlers } from '../../../datastores/handlers/index'
+import { sortSearchHistoryByLastUpdatedAt } from '../../helpers/search-history'
 
 const state = {
   searchHistoryEntries: []
@@ -65,7 +66,7 @@ const actions = {
     try {
       // sort before sending saving to the database and passing to other windows
       // so that the other windows can use it as is, without having to sort the array themselves
-      historyItems.sort((a, b) => b.timeWatched - a.timeWatched)
+      sortSearchHistoryByLastUpdatedAt(historyItems)
 
       await DBSearchHistoryHandlers.overwrite(historyItems)
       commit('setSearchHistoryEntries', historyItems)

--- a/src/renderer/views/Playlist/Playlist.vue
+++ b/src/renderer/views/Playlist/Playlist.vue
@@ -210,7 +210,7 @@ import {
   throttle,
 } from '../../helpers/utils'
 import { invidiousGetPlaylistInfo, youtubeImageUrlToInvidious } from '../../helpers/api/invidious'
-import { getSortedPlaylistItems, videoDurationPresent, videoDurationWithFallback, SORT_BY_VALUES } from '../../helpers/playlists'
+import { fillMissingPlaylistVideoDurations, getSortedPlaylistItems, SORT_BY_VALUES } from '../../helpers/playlists'
 import { MOBILE_WIDTH_THRESHOLD, PLAYLIST_HEIGHT_FORCE_LIST_THRESHOLD } from '../../../constants'
 import { useTabContext, useTabLifecycle, useTabTitle } from '../../tabs/TabContext'
 import { useTabToast } from '../../composables/useTabToast'
@@ -667,28 +667,10 @@ const historyCacheById = computed(() => store.getters.getHistoryCacheById)
 
 function getPlaylistItemsWithDuration() {
   const modifiedPlaylistItems = deepCopy(shownPlaylistItems.value)
-  let anyVideoMissingDuration = false
-
-  modifiedPlaylistItems.forEach(video => {
-    if (videoDurationPresent(video)) { return }
-
-    const videoHistory = historyCacheById[video.videoId]
-
-    if (typeof videoHistory !== 'undefined') {
-      const fetchedLengthSeconds = videoDurationWithFallback(videoHistory)
-      video.lengthSeconds = fetchedLengthSeconds
-
-      // if the video duration is 0, it will be the fallback value, so mark it as missing a duration
-      if (fetchedLengthSeconds === 0) {
-        anyVideoMissingDuration = true
-      }
-    } else {
-      // Mark at least one video have no duration, show notice later
-      // Also assign fallback duration here
-      anyVideoMissingDuration = true
-      video.lengthSeconds = 0
-    }
-  })
+  const anyVideoMissingDuration = fillMissingPlaylistVideoDurations(
+    modifiedPlaylistItems,
+    historyCacheById.value
+  )
 
   // Show notice if not already shown before returning playlist items
   if (anyVideoMissingDuration && !alreadyShownNotice) {

--- a/src/renderer/views/UserPlaylists/UserPlaylists.vue
+++ b/src/renderer/views/UserPlaylists/UserPlaylists.vue
@@ -83,7 +83,7 @@
       >
         <FtFlexBox>
           <FtButton
-            label="Load More"
+            :label="$t('User Playlists.Load More Playlists')"
             background-color="var(--primary-color)"
             text-color="var(--text-with-main-color)"
             @click="increaseLimit"

--- a/static/locales/en-US.yaml
+++ b/static/locales/en-US.yaml
@@ -91,6 +91,7 @@ Are you sure you want to open this link?: Are you sure you want to open this lin
 # Anything shared among components / views should be put here
 Global:
   Ambient Mode: Ambient Mode
+  Loading More: Loading more
   Videos: Videos
   Shorts: Shorts
   Live: Live
@@ -255,6 +256,7 @@ Feed:
 Playlists: Playlists
 User Playlists:
   Your Playlists: Your Playlists
+  Load More Playlists: Load More Playlists
   You have no playlists. Click on the create new playlist button to create a new one.: You have no playlists. Click on the create new playlist button to create a new one.
   Empty Search Message: There are no videos in this playlist that match your search
   Search bar placeholder: Search for Playlists

--- a/tests/unit/pagination-accessibility-labels.test.mjs
+++ b/tests/unit/pagination-accessibility-labels.test.mjs
@@ -1,0 +1,43 @@
+import assert from 'node:assert/strict'
+import { readFile } from 'node:fs/promises'
+import path from 'node:path'
+import test from 'node:test'
+
+import { load as loadYaml } from 'js-yaml'
+import { createI18n } from 'vue-i18n'
+
+const files = {
+  autoLoad: path.join(process.cwd(), 'src/renderer/components/FtAutoLoadNextPageWrapper.vue'),
+  comments: path.join(process.cwd(), 'src/renderer/components/CommentSection/CommentSection.vue'),
+  spinner: path.join(process.cwd(), 'src/renderer/components/FtSpinner/FtSpinner.vue'),
+  userPlaylists: path.join(process.cwd(), 'src/renderer/views/UserPlaylists/UserPlaylists.vue'),
+}
+
+test('pagination controls pass translated labels to buttons and status indicators', async () => {
+  const [autoLoad, comments, spinner, userPlaylists] = await Promise.all(
+    Object.values(files).map(file => readFile(file, 'utf8'))
+  )
+
+  assert.match(autoLoad, /:label="\$t\('Global\.Loading More'\)"/)
+  assert.match(comments, /:label="\$t\('Comments\.Load More Comments'\)"/)
+  assert.match(userPlaylists, /:label="\$t\('User Playlists\.Load More Playlists'\)"/)
+  assert.match(spinner, /:aria-label="label"/)
+})
+
+test('the comment loading status has a German accessibility name', async () => {
+  const [english, german] = await Promise.all([
+    readFile(path.join(process.cwd(), 'static/locales/en-US.yaml'), 'utf8'),
+    readFile(path.join(process.cwd(), 'static/locales/de-DE.yaml'), 'utf8'),
+  ])
+  const i18n = createI18n({
+    legacy: false,
+    locale: 'de-DE',
+    fallbackLocale: 'en-US',
+    messages: {
+      'de-DE': loadYaml(german),
+      'en-US': loadYaml(english),
+    },
+  })
+
+  assert.equal(i18n.global.t('Comments.Load More Comments'), 'Weitere Kommentare laden')
+})

--- a/tests/unit/playlist-duration-fallback.test.mjs
+++ b/tests/unit/playlist-duration-fallback.test.mjs
@@ -1,0 +1,33 @@
+import assert from 'node:assert/strict'
+import test from 'node:test'
+
+import { fillMissingPlaylistVideoDurations } from '../../src/renderer/helpers/playlists.js'
+
+test('fills a missing playlist duration from the matching history entry', () => {
+  const playlistItems = [
+    { videoId: 'missing-duration', title: 'Missing duration' },
+    { videoId: 'known-duration', title: 'Known duration', lengthSeconds: 90 },
+  ]
+  const historyCacheById = {
+    'missing-duration': { videoId: 'missing-duration', lengthSeconds: 125 },
+    'known-duration': { videoId: 'known-duration', lengthSeconds: 200 },
+  }
+
+  const anyVideoMissingDuration = fillMissingPlaylistVideoDurations(
+    playlistItems,
+    historyCacheById
+  )
+
+  assert.equal(anyVideoMissingDuration, false)
+  assert.equal(playlistItems[0].lengthSeconds, 125)
+  assert.equal(playlistItems[1].lengthSeconds, 90)
+})
+
+test('uses zero and reports a missing duration when history has no fallback', () => {
+  const playlistItems = [{ videoId: 'unknown', title: 'Unknown duration' }]
+
+  const anyVideoMissingDuration = fillMissingPlaylistVideoDurations(playlistItems, {})
+
+  assert.equal(anyVideoMissingDuration, true)
+  assert.equal(playlistItems[0].lengthSeconds, 0)
+})

--- a/tests/unit/search-history-sort.test.mjs
+++ b/tests/unit/search-history-sort.test.mjs
@@ -1,0 +1,15 @@
+import assert from 'node:assert/strict'
+import test from 'node:test'
+
+import { sortSearchHistoryByLastUpdatedAt } from '../../src/renderer/helpers/search-history.js'
+
+test('sorts overwritten search history by newest update first', () => {
+  const older = { _id: 'older search', lastUpdatedAt: 100 }
+  const newer = { _id: 'newer search', lastUpdatedAt: 200 }
+  const historyItems = [older, newer]
+
+  const sorted = sortSearchHistoryByLastUpdatedAt(historyItems)
+
+  assert.equal(sorted, historyItems)
+  assert.deepEqual(sorted, [newer, older])
+})


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Make sure to follow the contributing guidelines. -->
<!-- Important note, we may remove your pull request if you do not use this provided PR template correctly. -->
<!-- Agent instructions: Preserve every heading, comment, and marker in this template. Never remove or rewrite the release-note-category:start/end, release-note:start/end, or release-note-image:start/end marker pairs. Never remove or rewrite the Release note images section; leave its contents for a human. -->

## Pull Request Type
<!-- Please select what type of pull request this is: [x] -->
- [x] Bugfix
- [ ] Feature Implementation
- [ ] Documentation
- [ ] Other

## Related issue
<!-- Please link the issue your pull request is referring to. -->
<!-- If this pull request fully resolves the relevant issue, put "closes" before the issue number. -->
<!-- Example: "closes #123456". -->

Direct follow-up to the application audit; these small fixes did not need separate tracking issues.

## Description
<!-- Please write a clear and concise description of what the pull request does. -->

Playlist duration sorting read the computed history cache incorrectly, imported search history used a video-history timestamp, several pagination states had hard-coded English labels, and the toast swipe expression confused the production CSS optimizer.

This corrects the two metadata paths, routes the UI labels through localization, and rewrites the equivalent toast opacity calculation in a form the optimizer accepts.

## Release note category
<!-- Select exactly one category. Every pull request must select one. -->
<!-- Select "Not noteworthy" when the pull request fixes a bug in or improves functionality that has not yet appeared in a stable release. -->
<!-- release-note-category:start -->
- [ ] Not noteworthy
- [ ] Highlights
- [ ] More improvements
- [x] Fixed bugs
<!-- release-note-category:end -->

## Release note
<!-- Required unless "Not noteworthy" is selected. -->
<!-- Write one concise, user-facing entry without a leading bullet. -->
<!-- release-note:start -->

Playlist duration sorting now uses watch-history metadata, imported search history stays newest-first, and pagination feedback supports localization.

<!-- release-note:end -->

## Release note images
<!-- Human-only: Agents must preserve this entire section and leave it empty. -->
<!-- Optional. Paste one or more Markdown images or HTML image tags here. -->
<!-- The release notes will use an HTML image tag and limit images taller than 300 pixels. -->
<!-- release-note-image:start -->

<!-- release-note-image:end -->

## Testing
<!-- How can reviewers verify that the PR produces correct results? -->
<!-- Please provide instructions so that others can ensure that your pull request would produce correct results. For examples see, https://github.com/FreeTubeApp/FreeTube/pull/5743, https://github.com/FreeTubeApp/FreeTube/pull/7349, https://github.com/FreeTubeApp/FreeTube/pull/5125, https://github.com/FreeTubeApp/FreeTube/pull/7338 -->
<!-- Agent instructions: Only write human-facing steps that explain how to verify the change while running this branch in dev mode. Include expected results and, when applicable, helpful console snippets for interactive verification. Do not include automated checks, commands, results, pass counts, or CI status. -->

1. Import or overwrite search history with records whose input order differs from their `lastUpdatedAt` order. The newest record should appear first.
2. Open a playlist containing a video without a duration but with a matching watch-history entry, then sort by duration. The recovered duration should be used, and the missing-duration notice should remain hidden when every duration is recoverable.
3. Switch to German, enable automatic comment pagination, and load more comments. The loading status should be announced as “Weitere Kommentare laden” instead of the previous hard-coded English text.
4. Show several toasts, swipe one toward the configured screen edge, and watch its opacity. It should fade progressively and dismiss without disturbing the other toasts.

## Additional context
<!-- Add any other context about the pull request here. -->

Implementation was prepared with gpt-5.6-sol subagents in Codex and integrated and verified in Codex.
