### PR TITLE
fix(toast): size fullscreen notifications to their content

### DIFF
--- a/e2e/tests/offline/sabr-error-recovery.spec.mjs
+++ b/e2e/tests/offline/sabr-error-recovery.spec.mjs
@@ -1,5 +1,11 @@
-import { goTo, sel, test, expect } from '../../helpers/app.mjs'
-import { mockUnplayableWatchPage, watchHistoryEntry, watchViewHandle } from '../../helpers/watch.mjs'
+import { goTo, sel, setPlayerFullscreen, test, expect } from '../../helpers/app.mjs'
+import { openMockedVideo } from '../../helpers/player.mjs'
+import {
+  mockPlayableWatchPage,
+  mockUnplayableWatchPage,
+  watchHistoryEntry,
+  watchViewHandle
+} from '../../helpers/watch.mjs'
 
 // Mirror the module-level Watch constants, which cannot be imported here.
 const MAX_SABR_ERROR_RECOVERIES = 3
@@ -468,6 +474,50 @@ test('a SABR reload preserves the active video quality', async ({ app, page }) =
   })
 
   expect(quality).toBe('720')
+})
+
+test('sizes the fullscreen playback-error reload toast to its content', async ({ app, page }) => {
+  await page.evaluate(() => window.ftElectron.setZoomFactor(1.25))
+  await mockPlayableWatchPage(app, page)
+  await openMockedVideo(page)
+  await setPlayerFullscreen(page, true)
+
+  const watchView = await watchViewHandle(page)
+  await watchView.evaluate(async (view) => {
+    view.getTimestamp = () => 0
+    view.reloadView = async () => {}
+    view.tryPlaybackEngineFallback = async () => false
+    view.errorMessage = ''
+    view.isLoading = false
+    view.isLive = false
+    view.isPostLiveDvr = false
+    view.activeFormat = 'dash'
+    view.manifestMimeType = 'application/sabr+json'
+
+    await view.handlePlayerError({
+      severity: 2,
+      category: 1,
+      code: 1002,
+      data: ['https://example.invalid/sabr', 500]
+    })
+  })
+
+  const toast = page.locator('.toast', { hasText: 'Refreshing SABR stream after playback error' })
+  await expect(toast).toBeVisible()
+  await expect(toast).toHaveCount(1)
+  await expect(toast.locator('..')).toHaveCSS('transform', 'none')
+
+  const { trailingSpace, paddingEnd } = await toast.evaluate((element) => {
+    const toastBounds = element.getBoundingClientRect()
+    const messageBounds = element.querySelector('.message').getBoundingClientRect()
+
+    return {
+      trailingSpace: toastBounds.right - messageBounds.right,
+      paddingEnd: Number.parseFloat(getComputedStyle(element).paddingInlineEnd)
+    }
+  })
+
+  expect(Math.abs(trailingSpace - paddingEnd)).toBeLessThanOrEqual(1)
 })
 
 test('a SABR reload preserves the tab title while adding its resume timestamp', async ({ app, page }) => {

--- a/e2e/tests/offline/toast-fullscreen.spec.mjs
+++ b/e2e/tests/offline/toast-fullscreen.spec.mjs
@@ -19,7 +19,7 @@ test('keeps toast wrapping stable without scrollbars in player fullscreen', asyn
   await page.evaluate(() => {
     window.ftElectron.showToastOnAllTabs(
       'IP block recovery script finished',
-      1000,
+      30000,
       ['fas', 'check']
     )
   })
@@ -47,6 +47,8 @@ test('keeps toast wrapping stable without scrollbars in player fullscreen', asyn
   })
 
   const windowed = await measure()
+  await toast.locator('..').locator('..').focus()
+  await page.keyboard.press('Escape')
   await expect(toast).toHaveCount(0)
 
   await setPlayerFullscreen(page, true)

--- a/e2e/tests/offline/toast-fullscreen.spec.mjs
+++ b/e2e/tests/offline/toast-fullscreen.spec.mjs
@@ -1,0 +1,73 @@
+import { setPlayerFullscreen, test, expect } from '../../helpers/app.mjs'
+import { openMockedVideo } from '../../helpers/player.mjs'
+import { mockPlayableWatchPage } from '../../helpers/watch.mjs'
+
+test.use({
+  seed: {
+    settings: {
+      uiScale: 95,
+      videoPlaybackEngine: 'built-in',
+      ytDlpPlaybackEngineDefaultMigration: true
+    }
+  }
+})
+
+test('keeps toast wrapping stable without scrollbars in player fullscreen', async ({ app, page }) => {
+  await mockPlayableWatchPage(app, page)
+  await openMockedVideo(page)
+
+  await page.evaluate(() => {
+    window.ftElectron.showToastOnAllTabs(
+      'IP block recovery script finished',
+      1000,
+      ['fas', 'check']
+    )
+  })
+
+  const toast = page.locator('.toast', { hasText: 'IP block recovery script finished' })
+  await expect(toast).toBeVisible()
+  await expect(toast.locator('..')).toHaveCSS('transform', 'none')
+
+  const measure = () => toast.evaluate((element) => {
+    const message = element.querySelector('.message')
+    const toastBounds = element.getBoundingClientRect()
+    const messageBounds = message.getBoundingClientRect()
+
+    return {
+      toastWidth: toastBounds.width,
+      toastHeight: toastBounds.height,
+      messageWidth: messageBounds.width,
+      messageHeight: messageBounds.height,
+      messageScrollWidth: message.scrollWidth,
+      messageScrollHeight: message.scrollHeight,
+      messageClientWidth: message.clientWidth,
+      messageClientHeight: message.clientHeight,
+      overflowY: getComputedStyle(element).overflowY
+    }
+  })
+
+  const windowed = await measure()
+  await expect(toast).toHaveCount(0)
+
+  await setPlayerFullscreen(page, true)
+  await page.evaluate(() => {
+    window.ftElectron.showToastOnAllTabs(
+      'IP block recovery script finished',
+      30000,
+      ['fas', 'check']
+    )
+  })
+  await expect(toast).toBeVisible()
+  await expect(toast.locator('..')).toHaveCSS('transform', 'none')
+
+  const fullscreen = await measure()
+
+  expect(fullscreen.overflowY).toBe('visible')
+  await expect(toast.locator('.os-scrollbar')).toHaveCount(0)
+  expect(fullscreen.messageScrollWidth).toBeLessThanOrEqual(fullscreen.messageClientWidth)
+  expect(fullscreen.messageScrollHeight).toBeLessThanOrEqual(fullscreen.messageClientHeight)
+  expect(fullscreen.toastWidth).toBeCloseTo(windowed.toastWidth, 0)
+  expect(fullscreen.toastHeight).toBeCloseTo(windowed.toastHeight, 0)
+  expect(fullscreen.messageWidth).toBeCloseTo(windowed.messageWidth, 0)
+  expect(fullscreen.messageHeight).toBeCloseTo(windowed.messageHeight, 0)
+})

--- a/src/renderer/components/FtToast/FtToast.css
+++ b/src/renderer/components/FtToast/FtToast.css
@@ -376,7 +376,6 @@
   padding-block: 12px;
   padding-inline: 18px;
   text-align: start;
-  overflow-y: auto;
   background-color: rgb(28 28 28 / 92%);
   backdrop-filter: blur(12px);
   color: #fff;

--- a/src/renderer/components/FtToast/FtToastItem.vue
+++ b/src/renderer/components/FtToast/FtToastItem.vue
@@ -5,7 +5,6 @@
   >
     <div
       ref="toastElement"
-      v-overlay-scrollbars
       class="toast"
       :class="{
         hasImage: toast.image,


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Make sure to follow the contributing guidelines. -->
<!-- Important note, we may remove your pull request if you do not use this provided PR template correctly. -->
<!-- Agent instructions: Preserve every heading, comment, and marker in this template. Never remove or rewrite the release-note-category:start/end, release-note:start/end, or release-note-image:start/end marker pairs. Never remove or rewrite the Release note images section; leave its contents for a human. -->

## Pull Request Type
<!-- Please select what type of pull request this is: [x] -->
- [x] Bugfix
- [ ] Feature Implementation
- [ ] Documentation
- [ ] Other

## Related issue
<!-- Please link the issue your pull request is referring to. -->
<!-- If this pull request fully resolves the relevant issue, put "closes" before the issue number. -->
<!-- Example: "closes #123456". -->

No linked issue.

## Description
<!-- Please write a clear and concise description of what the pull request does. -->

Toasts were still vertical scroll containers from the old notification implementation. The themed scrollbar wrapper could reflow a toast when it moved into the fullscreen player, changing the message wrapping and sometimes exposing a scrollbar. It also participated in intrinsic sizing, leaving the SABR playback-error notification wider than its content.

This removes the unused scroll behavior and its scrollbar directive. Toasts now grow with their content and keep their intended content width in both the normal window and player fullscreen. Regression coverage compares notification geometry across both modes at a fractional UI scale and exercises the real SABR playback-error recovery path to verify that no excess trailing space returns.

## Release note category
<!-- Select exactly one category. Every pull request must select one. -->
<!-- Select "Not noteworthy" when the pull request fixes a bug in or improves functionality that has not yet appeared in a stable release. -->
<!-- release-note-category:start -->
- [ ] Not noteworthy
- [ ] Highlights
- [ ] More improvements
- [x] Fixed bugs
<!-- release-note-category:end -->

## Release note
<!-- Required unless "Not noteworthy" is selected. -->
<!-- Write one concise, user-facing entry without a leading bullet. -->
<!-- release-note:start -->
Notifications no longer have excess space, wrap differently, or show scrollbars in fullscreen
<!-- release-note:end -->

## Release note images
<!-- Human-only: Agents must preserve this entire section and leave it empty. -->
<!-- Optional. Paste one or more Markdown images or HTML image tags here. -->
<!-- The release notes will use an HTML image tag and limit images taller than 300 pixels. -->
<!-- release-note-image:start -->

<!-- release-note-image:end -->

## Testing
<!-- How can reviewers verify that the PR produces correct results? -->
<!-- Please provide instructions so that others can ensure that your pull request would produce correct results. For examples see, https://github.com/FreeTubeApp/FreeTube/pull/5743, https://github.com/FreeTubeApp/FreeTube/pull/7349, https://github.com/FreeTubeApp/FreeTube/pull/5125, https://github.com/FreeTubeApp/FreeTube/pull/7338 -->
<!-- Agent instructions: Only write human-facing steps that explain how to verify the change while running this branch in dev mode. Include expected results and, when applicable, helpful console snippets for interactive verification. Do not include automated checks, commands, results, pass counts, or CI status. -->

1. Open a video, enter player fullscreen, and raise the reported notifications from the renderer devtools console:

   ```js
   window.ftElectron.showToastOnAllTabs('IP block recovery script finished', 30000, ['fas', 'check'])
   window.ftElectron.showToastOnAllTabs('Refreshing SABR stream after playback error', 30000, ['fas', 'sync'])
   ```

2. Confirm that both messages are fully visible, neither notification has a scrollbar, and the SABR notification has only its normal padding after the text.
3. Exit fullscreen and raise the same notifications again. Their width, height, and message wrapping should match the fullscreen notifications.
4. Repeat at a non-100% UI Scale. The notifications should still fit their content without extra space or scrollbars.

## Additional context
<!-- Add any other context about the pull request here. -->

The removed overflow rule predated the current toast implementation. Toasts have no fixed or maximum block size, so they do not need an internal scroll viewport.
