### PR TITLE
fix(tabs): show status icons after loading tab icons

### DIFF
--- a/e2e/tests/offline/tab-avatar-cache.spec.mjs
+++ b/e2e/tests/offline/tab-avatar-cache.spec.mjs
@@ -86,7 +86,8 @@ test.describe('loading missing tab icons', () => {
     seed: {
       settings: {
         backendPreference: 'invidious',
-        defaultInvidiousInstance: 'https://invidious.test'
+        defaultInvidiousInstance: 'https://invidious.test',
+        backendFallback: false
       }
     }
   })
@@ -117,7 +118,9 @@ test.describe('loading missing tab icons', () => {
     const themeSection = await goToSettingsSection(page, 'theme')
     const loadButton = themeSection.getByRole('button', { name: 'Load Missing Tab Icons' })
     await loadButton.click()
-    await expect(page.locator('.toast')).toContainText('Missing tab icon loaded: 1')
+    const toast = page.locator('.toast', { hasText: 'Missing tab icon loaded: 1' })
+    await expect(toast).toBeVisible()
+    await expect(toast.locator('.icon[data-prefix="fas"][data-icon="check"]')).toBeVisible()
     await expect(loadButton).toBeDisabled()
 
     await expect.poll(() => page.evaluate(tabId => {
@@ -134,6 +137,26 @@ test.describe('loading missing tab icons', () => {
       avatarLoaded: true,
       isUnloaded: true
     })
+  })
+
+  test('shows an error icon when an icon cannot be loaded', async ({ page }) => {
+    await page.route('https://invidious.test/api/v1/channels/UCmissing?*', route => route.fulfill({
+      contentType: 'application/json',
+      body: JSON.stringify({ authorThumbnails: [], tabs: [] })
+    }))
+
+    await page.evaluate(() => window.ftElectron.tabs.create({
+      route: '/channel/UCmissing',
+      makeActive: false,
+      lazyLoad: true
+    }))
+
+    const themeSection = await goToSettingsSection(page, 'theme')
+    await themeSection.getByRole('button', { name: 'Load Missing Tab Icons' }).click()
+
+    const toast = page.locator('.toast', { hasText: 'Loaded 0 tab icons; 1 could not be loaded' })
+    await expect(toast).toBeVisible()
+    await expect(toast.locator('.icon[data-prefix="fas"][data-icon="circle-exclamation"]')).toBeVisible()
   })
 })
 

--- a/src/renderer/components/ThemeSettings.vue
+++ b/src/renderer/components/ThemeSettings.vue
@@ -722,11 +722,20 @@ async function loadTabIcons() {
   try {
     const { loaded, failed } = await loadMissingTabAvatars(store.getters.getTabs)
     if (loaded === 0 && failed === 0) {
-      showToast(t('Settings.Theme Settings.No Missing Tab Icons'))
+      showToast({
+        message: t('Settings.Theme Settings.No Missing Tab Icons'),
+        icon: ['fas', 'circle-info'],
+      })
     } else if (failed > 0) {
-      showToast(t('Settings.Theme Settings.Loaded Tab Icons With Failures', { loaded, failed }))
+      showToast({
+        message: t('Settings.Theme Settings.Loaded Tab Icons With Failures', { loaded, failed }),
+        icon: ['fas', 'circle-exclamation'],
+      })
     } else {
-      showToast(t('Settings.Theme Settings.Loaded Tab Icons', { count: loaded }, loaded))
+      showToast({
+        message: t('Settings.Theme Settings.Loaded Tab Icons', { count: loaded }, loaded),
+        icon: ['fas', 'check'],
+      })
     }
   } finally {
     loadingTabIcons.value = false


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Make sure to follow the contributing guidelines. -->
<!-- Important note, we may remove your pull request if you do not use this provided PR template correctly. -->
<!-- Agent instructions: Preserve every heading, comment, and marker in this template. Never remove or rewrite the release-note-category:start/end, release-note:start/end, or release-note-image:start/end marker pairs. Never remove or rewrite the Release note images section; leave its contents for a human. -->

## Pull Request Type
<!-- Please select what type of pull request this is: [x] -->
- [x] Bugfix
- [ ] Feature Implementation
- [ ] Documentation
- [ ] Other

## Related issue
<!-- Please link the issue your pull request is referring to. -->
<!-- If this pull request fully resolves the relevant issue, put "closes" before the issue number. -->
<!-- Example: "closes #123456". -->

## Description
<!-- Please write a clear and concise description of what the pull request does. -->
The notification shown after loading missing tab icons relied on text alone, including when some icons failed to load. This adds a check icon for success, an error icon for failures, and an info icon when no work remains. The focused Electron coverage now checks the success and failure icons.

## Release note category
<!-- Select exactly one category. Every pull request must select one. -->
<!-- Select "Not noteworthy" when the pull request fixes a bug in or improves functionality that has not yet appeared in a stable release. -->
<!-- release-note-category:start -->
- [x] Not noteworthy
- [ ] Highlights
- [ ] More improvements
- [ ] Fixed bugs
<!-- release-note-category:end -->

## Release note
<!-- Required unless "Not noteworthy" is selected. -->
<!-- Write one concise, user-facing entry without a leading bullet. -->
<!-- release-note:start -->

<!-- release-note:end -->

## Release note images
<!-- Human-only: Agents must preserve this entire section and leave it empty. -->
<!-- Optional. Paste one or more Markdown images or HTML image tags here. -->
<!-- The release notes will use an HTML image tag and limit images taller than 300 pixels. -->
<!-- release-note-image:start -->

<!-- release-note-image:end -->

## Testing
<!-- How can reviewers verify that the PR produces correct results? -->
<!-- Please provide instructions so that others can ensure that the pull request produces correct results. For examples see, https://github.com/FreeTubeApp/FreeTube/pull/5743, https://github.com/FreeTubeApp/FreeTube/pull/7349, https://github.com/FreeTubeApp/FreeTube/pull/5125, https://github.com/FreeTubeApp/FreeTube/pull/7338 -->
<!-- Agent instructions: Only write human-facing steps that explain how to verify the change while running this branch in dev mode. Include expected results and, when applicable, helpful console snippets for interactive verification. Do not include automated checks, commands, results, pass counts, or CI status. -->
1. Enable tab icons, open an unloaded channel or watch tab with no cached icon, then open Theme Settings.
2. Click Load Missing Tab Icons and confirm the completed notification shows a check icon.
3. Repeat while blocking the channel or avatar request and confirm the failure notification shows an error icon.

## Additional context
<!-- Add any other context about the pull request here. -->
None.