### PR TITLE
fix(datastore): surface failed playlist and stats writes

### DIFF
--- a/e2e/helpers/datastore-failure.mjs
+++ b/e2e/helpers/datastore-failure.mjs
@@ -1,0 +1,15 @@
+/**
+ * Permanently replaces a datastore handler for this isolated E2E app process.
+ * Install it after startup has finished loading the datastore.
+ *
+ * @param {import('@playwright/test').ElectronApplication} electronApp
+ * @param {string} channel
+ */
+export function rejectDatastoreRequests(electronApp, channel) {
+  return electronApp.evaluate(({ ipcMain }, channel_) => {
+    ipcMain.removeHandler(channel_)
+    ipcMain.handle(channel_, () => {
+      throw new Error('Synthetic datastore failure')
+    })
+  }, channel)
+}

--- a/e2e/helpers/datastore-failure.mjs
+++ b/e2e/helpers/datastore-failure.mjs
@@ -4,12 +4,16 @@
  *
  * @param {import('@playwright/test').ElectronApplication} electronApp
  * @param {string} channel
+ * @param {number} [delayMs]
  */
-export function rejectDatastoreRequests(electronApp, channel) {
-  return electronApp.evaluate(({ ipcMain }, channel_) => {
-    ipcMain.removeHandler(channel_)
-    ipcMain.handle(channel_, () => {
+export function rejectDatastoreRequests(electronApp, channel, delayMs = 0) {
+  return electronApp.evaluate(({ ipcMain }, options) => {
+    ipcMain.removeHandler(options.channel)
+    ipcMain.handle(options.channel, async () => {
+      if (options.delayMs > 0) {
+        await new Promise(resolve => setTimeout(resolve, options.delayMs))
+      }
       throw new Error('Synthetic datastore failure')
     })
-  }, channel)
+  }, { channel, delayMs })
 }

--- a/e2e/tests/offline/playlist-skip-buttons.spec.mjs
+++ b/e2e/tests/offline/playlist-skip-buttons.spec.mjs
@@ -1,4 +1,6 @@
 import { goTo, test, expect } from '../../helpers/app.mjs'
+import { rejectDatastoreRequests } from '../../helpers/datastore-failure.mjs'
+import { IpcChannels } from '../../../src/constants.js'
 
 const VIDEO_TITLES = ['Skip test video one', 'Skip test video two', 'Skip test video three']
 
@@ -129,6 +131,27 @@ test('only offers skipping to playlist videos that exist', async ({ page, attach
     canPlayNext: true,
     canPlayPrevious: true
   })
+})
+
+test('restores the watch playlist order when persistence fails', async ({ app, page }) => {
+  await page.route(/^https?:\/\//, (route) => route.abort())
+
+  await goTo(page, 'userplaylists')
+  await page.getByText('Skip button playlist').click()
+  await page.getByText(VIDEO_TITLES[0]).first().click()
+
+  const playlistItems = page.locator('.watchVideoPlaylist .playlistItem')
+  await expect(playlistItems).toHaveCount(VIDEO_TITLES.length)
+  await rejectDatastoreRequests(app.electronApp, IpcChannels.DB_PLAYLISTS)
+  await playlistItems.nth(1).getByTitle('Move Video Up').click()
+
+  await expect(page.locator('.toast', { hasText: 'There was an issue with updating this playlist.' })).toBeVisible()
+  await expect(playlistItems.first()).toContainText(VIDEO_TITLES[0])
+  await expect.poll(() => page.evaluate(() => {
+    const store = document.querySelector('#app').__vue_app__.config.globalProperties.$store
+    return store.getters.getPlaylist('e2eskipplaylist').videos.slice(0, 2)
+      .map(video => video.playlistItemId)
+  })).toEqual(['e2e-skip-item-0', 'e2e-skip-item-1'])
 })
 
 test('offers skipping to a queued video without a playlist', async ({ page }) => {

--- a/e2e/tests/offline/playlists.spec.mjs
+++ b/e2e/tests/offline/playlists.spec.mjs
@@ -2,8 +2,12 @@ import { readFile } from 'node:fs/promises'
 import path from 'node:path'
 
 import { test, expect, sel, goTo } from '../../helpers/app.mjs'
+import { rejectDatastoreRequests } from '../../helpers/datastore-failure.mjs'
+import { IpcChannels } from '../../../src/constants.js'
 
 test.describe('playlist creation', () => {
+  test.use({ seed: { settings: { currentLocale: 'en-US' } } })
+
   test('a playlist can be created through the UI', async ({ page }) => {
     await goTo(page, 'userplaylists')
 
@@ -15,6 +19,70 @@ test.describe('playlist creation', () => {
     await createDialog.getByRole('button', { name: 'Create', exact: true }).click()
 
     await expect(page.getByRole('link', { name: 'Created via UI' })).toBeVisible()
+  })
+
+  test('playlist actions reject when persistence fails', async ({ app, page }) => {
+    await goTo(page, 'userplaylists')
+    await expect(page.getByRole('link', { name: 'Favorites' })).toBeVisible()
+    await expect(page.getByRole('link', { name: 'Watch Later' })).toBeVisible()
+    await rejectDatastoreRequests(app.electronApp, IpcChannels.DB_PLAYLISTS)
+
+    const result = await page.evaluate(async () => {
+      const store = document.querySelector('#app').__vue_app__.config.globalProperties.$store
+      const existingPlaylists = store.state.playlists.playlists.map(({ _id, playlistName }) => ({
+        _id,
+        playlistName,
+      }))
+      const favorites = store.state.playlists.playlists.find(playlist => playlist._id === 'favorites')
+      const [create, createMany, update] = await Promise.allSettled([
+        store.dispatch('addPlaylist', {
+          playlistName: 'Rejected playlist',
+          protected: false,
+          description: '',
+          videos: [],
+        }),
+        store.dispatch('addPlaylists', [{
+          playlistName: 'Another rejected playlist',
+          protected: false,
+          description: '',
+          videos: [],
+        }]),
+        store.dispatch('updatePlaylist', {
+          ...favorites,
+          playlistName: 'Rejected update',
+          videos: favorites.videos.slice(),
+        }),
+      ])
+
+      return {
+        statuses: [create.status, createMany.status, update.status],
+        playlists: store.state.playlists.playlists.map(({ _id, playlistName }) => ({
+          _id,
+          playlistName,
+        })),
+        existingPlaylists,
+      }
+    })
+
+    expect(result.statuses).toEqual(['rejected', 'rejected', 'rejected'])
+    expect(result.playlists).toEqual(result.existingPlaylists)
+  })
+
+  test('keeps the create dialog and its input when persistence fails', async ({ app, page }) => {
+    await goTo(page, 'userplaylists')
+
+    await page.getByTitle('Create New Playlist').click()
+    const createDialog = page.getByRole('dialog')
+    const nameInput = createDialog.locator('.playlistNameInput input')
+    await nameInput.fill('Unsaved playlist')
+    await rejectDatastoreRequests(app.electronApp, IpcChannels.DB_PLAYLISTS)
+    await createDialog.getByRole('button', { name: 'Create', exact: true }).click()
+
+    await expect(createDialog).toBeVisible()
+    await expect(nameInput).toHaveValue('Unsaved playlist')
+    await expect(createDialog.getByText('There was an issue with creating the playlist.')).toBeVisible()
+    await expect(page.locator('.toast', { hasText: 'has been successfully created' })).toHaveCount(0)
+    await expect(page.getByRole('link', { name: 'Unsaved playlist' })).toHaveCount(0)
   })
 })
 
@@ -146,6 +214,30 @@ test.describe('seeded playlists', () => {
     }).toBe(true)
   })
 
+  test('keeps playlist edits open when persistence fails', async ({ app, page }) => {
+    await goTo(page, 'userplaylists')
+    await page.getByText('My seeded playlist').click()
+
+    await page.getByTitle('Edit Playlist Info').click()
+    const titleInput = page.locator('.playlistStats input')
+    const descriptionInput = page.locator('.descriptionInput input')
+    await titleInput.fill('Unsaved playlist title')
+    await descriptionInput.fill('Unsaved playlist description')
+    await rejectDatastoreRequests(app.electronApp, IpcChannels.DB_PLAYLISTS)
+    await page.getByTitle('Save Changes').click()
+
+    await expect(titleInput).toBeVisible()
+    await expect(titleInput).toHaveValue('Unsaved playlist title')
+    await expect(descriptionInput).toHaveValue('Unsaved playlist description')
+    await expect(page.locator('.toast', { hasText: 'There was an issue with updating this playlist.' })).toBeVisible()
+    await expect(page.locator('.toast', { hasText: 'Playlist has been updated.' })).toHaveCount(0)
+    await expect.poll(() => page.evaluate(() => {
+      const store = document.querySelector('#app').__vue_app__.config.globalProperties.$store
+      const playlist = store.getters.getPlaylist('e2eseeded')
+      return [playlist.playlistName, playlist.description]
+    })).toEqual(['My seeded playlist', 'Playlist created by the E2E seed'])
+  })
+
   test('a custom quick bookmark emoji persists across restarts', async ({ app, page }) => {
     await goTo(page, 'userplaylists')
     await page.getByText('Favorites').click()
@@ -260,5 +352,24 @@ test.describe('custom playlist order', () => {
     await page.getByRole('option', { name: 'Move Video to the Top' }).click()
 
     await expect(page.locator('.playlistItemsCard .h3Title').first()).toHaveText('Custom playlist video 3')
+  })
+
+  test('keeps the playlist order when persistence fails', async ({ app, page }) => {
+    await goTo(page, 'userplaylists')
+    await page.getByText('Large custom playlist').click()
+
+    const secondVideo = page.locator('.ft-list-video').filter({
+      has: page.getByText('Custom playlist video 2', { exact: true })
+    })
+    await rejectDatastoreRequests(app.electronApp, IpcChannels.DB_PLAYLISTS)
+    await secondVideo.getByTitle('Move Video Up').click()
+
+    await expect(page.locator('.toast', { hasText: 'There was an issue with updating this playlist.' })).toBeVisible()
+    await expect(page.locator('.playlistItemsCard .h3Title').first()).toHaveText('Custom playlist video 1')
+    await expect.poll(() => page.evaluate(() => {
+      const store = document.querySelector('#app').__vue_app__.config.globalProperties.$store
+      return store.getters.getPlaylist('large-custom-playlist').videos.slice(0, 2)
+        .map(video => video.playlistItemId)
+    })).toEqual(['custom-playlist-item-0', 'custom-playlist-item-1'])
   })
 })

--- a/e2e/tests/offline/playlists.spec.mjs
+++ b/e2e/tests/offline/playlists.spec.mjs
@@ -3,7 +3,7 @@ import path from 'node:path'
 
 import { test, expect, sel, goTo } from '../../helpers/app.mjs'
 import { rejectDatastoreRequests } from '../../helpers/datastore-failure.mjs'
-import { IpcChannels } from '../../../src/constants.js'
+import { DBActions, IpcChannels } from '../../../src/constants.js'
 
 test.describe('playlist creation', () => {
   test.use({ seed: { settings: { currentLocale: 'en-US' } } })
@@ -66,6 +66,37 @@ test.describe('playlist creation', () => {
 
     expect(result.statuses).toEqual(['rejected', 'rejected', 'rejected'])
     expect(result.playlists).toEqual(result.existingPlaylists)
+  })
+
+  test('marks playlists ready when creating defaults fails', async ({ app, page }) => {
+    await app.electronApp.evaluate(({ ipcMain }, options) => {
+      ipcMain.removeHandler(options.channel)
+      ipcMain.handle(options.channel, (_event, request) => {
+        if (request.action === options.findAction) {
+          return []
+        }
+        throw new Error('Synthetic default playlist failure')
+      })
+    }, {
+      channel: IpcChannels.DB_PLAYLISTS,
+      findAction: DBActions.GENERAL.FIND,
+    })
+
+    const result = await page.evaluate(async () => {
+      const store = document.querySelector('#app').__vue_app__.config.globalProperties.$store
+      store.commit('removeAllPlaylists')
+      store.commit('setPlaylistsReady', false)
+      await store.dispatch('grabAllPlaylists')
+      return {
+        playlistsReady: store.getters.getPlaylistsReady,
+        playlistCount: store.getters.getAllPlaylists.length,
+      }
+    })
+
+    expect(result).toEqual({
+      playlistsReady: true,
+      playlistCount: 0,
+    })
   })
 
   test('keeps the create dialog and its input when persistence fails', async ({ app, page }) => {

--- a/e2e/tests/offline/playlists.spec.mjs
+++ b/e2e/tests/offline/playlists.spec.mjs
@@ -354,22 +354,50 @@ test.describe('custom playlist order', () => {
     await expect(page.locator('.playlistItemsCard .h3Title').first()).toHaveText('Custom playlist video 3')
   })
 
-  test('keeps the playlist order when persistence fails', async ({ app, page }) => {
+  test('keeps newer playlist state when an earlier reorder fails', async ({ app, page }) => {
     await goTo(page, 'userplaylists')
     await page.getByText('Large custom playlist').click()
 
     const secondVideo = page.locator('.ft-list-video').filter({
       has: page.getByText('Custom playlist video 2', { exact: true })
     })
-    await rejectDatastoreRequests(app.electronApp, IpcChannels.DB_PLAYLISTS)
+    await rejectDatastoreRequests(app.electronApp, IpcChannels.DB_PLAYLISTS, 500)
     await secondVideo.getByTitle('Move Video Up').click()
+    await expect(page.locator('.playlistItemsCard .h3Title').first()).toHaveText('Custom playlist video 2')
+
+    await page.evaluate(() => {
+      const store = document.querySelector('#app').__vue_app__.config.globalProperties.$store
+      const playlist = store.getters.getPlaylist('large-custom-playlist')
+      store.commit('upsertPlaylistToList', {
+        ...playlist,
+        lastUpdatedAt: Date.now(),
+        videos: playlist.videos.toSpliced(2, 0, {
+          videoId: 'concurrent1',
+          title: 'Concurrent playlist video',
+          author: 'Test Channel',
+          authorId: 'UC-test-channel-id',
+          lengthSeconds: 120,
+          published: Date.now() - 86_400_000,
+          timeAdded: Date.now(),
+          playlistItemId: 'concurrent-playlist-item',
+          type: 'video'
+        })
+      })
+    })
 
     await expect(page.locator('.toast', { hasText: 'There was an issue with updating this playlist.' })).toBeVisible()
     await expect(page.locator('.playlistItemsCard .h3Title').first()).toHaveText('Custom playlist video 1')
+    await expect(page.getByText('Concurrent playlist video', { exact: true })).toBeVisible()
     await expect.poll(() => page.evaluate(() => {
       const store = document.querySelector('#app').__vue_app__.config.globalProperties.$store
-      return store.getters.getPlaylist('large-custom-playlist').videos.slice(0, 2)
-        .map(video => video.playlistItemId)
-    })).toEqual(['custom-playlist-item-0', 'custom-playlist-item-1'])
+      const videos = store.getters.getPlaylist('large-custom-playlist').videos
+      return {
+        firstIds: videos.slice(0, 2).map(video => video.playlistItemId),
+        thirdId: videos[2].playlistItemId,
+      }
+    })).toEqual({
+      firstIds: ['custom-playlist-item-0', 'custom-playlist-item-1'],
+      thirdId: 'concurrent-playlist-item',
+    })
   })
 })

--- a/e2e/tests/offline/stats.spec.mjs
+++ b/e2e/tests/offline/stats.spec.mjs
@@ -1,4 +1,6 @@
 import { test, expect, goTo } from '../../helpers/app.mjs'
+import { rejectDatastoreRequests } from '../../helpers/datastore-failure.mjs'
+import { IpcChannels } from '../../../src/constants.js'
 
 /**
  * @param {Date} date
@@ -55,6 +57,27 @@ test.describe('watch stats', () => {
     await page.getByRole('button', { name: 'Reset', exact: true }).click()
 
     await expect(page.locator('.summaryCard').filter({ hasText: 'Total watch time' })).toContainText('0 min')
+  })
+
+  test('keeps statistics when resetting persistence fails', async ({ app, page }) => {
+    await goTo(page, 'stats')
+    const totalWatchTime = page.locator('.summaryCard').filter({ hasText: 'Total watch time' })
+    await expect(totalWatchTime).toContainText('1 hr 30 min')
+
+    await rejectDatastoreRequests(app.electronApp, IpcChannels.DB_WATCH_STATS)
+    await page.locator('.resetStatsButton').click()
+    await page.getByRole('button', { name: 'Reset', exact: true }).click()
+
+    await expect(totalWatchTime).toContainText('1 hr 30 min')
+    await expect(page.locator('.toast', { hasText: 'Failed to reset watch statistics' })).toBeVisible()
+    await expect(page.locator('.toast', { hasText: 'Watch statistics have been reset' })).toHaveCount(0)
+    await expect.poll(() => page.evaluate(() => {
+      const store = document.querySelector('#app').__vue_app__.config.globalProperties.$store
+      return store.getters.getWatchSecondsByDate
+    })).toEqual({
+      [today]: 3600,
+      [yesterday]: 1800,
+    })
   })
 })
 

--- a/src/renderer/components/DataSettings/DataSettings.vue
+++ b/src/renderer/components/DataSettings/DataSettings.vue
@@ -1350,6 +1350,7 @@ async function importPlaylists() {
   ]
 
   const newPlaylists = []
+  const playlistWrites = []
 
   playlists.forEach((playlistData) => {
     // We would technically already be done by the time the data is parsed,
@@ -1461,17 +1462,28 @@ async function importPlaylists() {
       }
     })
     // Update playlist's `lastUpdatedAt` & other attributes
-    store.dispatch('updatePlaylist', {
+    playlistWrites.push(store.dispatch('updatePlaylist', {
       _id: existingPlaylist._id,
       // Only these attributes would be updated (besides videos)
       playlistName: playlistObject.playlistName,
       description: playlistObject.description,
       videos: playlistVideos
-    })
+    }))
   })
 
   if (newPlaylists.length > 0) {
-    store.dispatch('addPlaylists', newPlaylists)
+    playlistWrites.push(store.dispatch('addPlaylists', newPlaylists))
+  }
+
+  try {
+    await Promise.all(playlistWrites)
+  } catch (error) {
+    showToast({
+      message: t('Settings.Data Settings.Unable to import all playlists'),
+      icon: ['fas', 'circle-exclamation'],
+    })
+    console.error(error)
+    return
   }
 
   showToast({

--- a/src/renderer/components/FtCreatePlaylistPrompt/FtCreatePlaylistPrompt.vue
+++ b/src/renderer/components/FtCreatePlaylistPrompt/FtCreatePlaylistPrompt.vue
@@ -27,6 +27,11 @@
         {{ $t('User Playlists.CreatePlaylistPrompt.Toast["There is already a playlist with this name. Please pick a different name."]') }}
       </p>
     </FtFlexBox>
+    <FtFlexBox v-if="playlistPersistenceFailed">
+      <p>
+        {{ $t('User Playlists.CreatePlaylistPrompt.Toast["There was an issue with creating the playlist."]') }}
+      </p>
+    </FtFlexBox>
     <FtFlexBox>
       <FtButton
         :label="$t('User Playlists.CreatePlaylistPrompt.Create')"
@@ -80,6 +85,8 @@ const playlistWithNameExists = computed(() => {
   return allPlaylists.value.some((playlist) => playlist.playlistName === playlistName_)
 })
 
+const playlistPersistenceFailed = ref(false)
+
 const playlistPersistenceDisabled = computed(() => {
   return playlistName.value === '' || playlistNameBlank.value || playlistWithNameExists.value
 })
@@ -117,6 +124,7 @@ async function createNewPlaylist() {
     videos: initialVideos,
   }
 
+  playlistPersistenceFailed.value = false
   try {
     await store.dispatch('addPlaylist', playlistObject)
     showToast({
@@ -125,14 +133,10 @@ async function createNewPlaylist() {
       }),
       icon: ['fac', 'playlist-check'],
     })
-  } catch (e) {
-    showToast({
-      message: t('User Playlists.CreatePlaylistPrompt.Toast["There was an issue with creating the playlist."]'),
-      icon: ['fas', 'circle-exclamation'],
-    })
-    console.error(e)
-  } finally {
     hideCreatePlaylistPrompt()
+  } catch (e) {
+    playlistPersistenceFailed.value = true
+    console.error(e)
   }
 }
 

--- a/src/renderer/components/PlaylistInfo/PlaylistInfo.vue
+++ b/src/renderer/components/PlaylistInfo/PlaylistInfo.vue
@@ -649,14 +649,13 @@ async function savePlaylistInfo() {
       message: t('User Playlists.SinglePlaylistView.Toast["Playlist has been updated."]'),
       icon: ['fas', 'check'],
     })
+    exitEditMode()
   } catch (e) {
     showToast({
       message: t('User Playlists.SinglePlaylistView.Toast["There was an issue with updating this playlist."]'),
       icon: ['fas', 'circle-exclamation'],
     })
     console.error(e)
-  } finally {
-    exitEditMode()
   }
 }
 

--- a/src/renderer/components/WatchVideoPlaylist/WatchVideoPlaylist.vue
+++ b/src/renderer/components/WatchVideoPlaylist/WatchVideoPlaylist.vue
@@ -438,8 +438,10 @@ const sortOrder = computed(() => isUserPlaylist.value ? userPlaylistSortOrder.va
 
 const isSortOrderCustom = computed(() => sortOrder.value === SORT_BY_VALUES.Custom)
 
+const playlistOrderUpdateInProgress = ref(false)
+
 const canMoveVideos = computed(() => {
-  return isUserPlaylist.value && isSortOrderCustom.value && playlistItems.value.length > 1
+  return isUserPlaylist.value && isSortOrderCustom.value && !playlistOrderUpdateInProgress.value && playlistItems.value.length > 1
 })
 
 const MAX_ENHANCED_PLAYLIST_ITEMS = 200
@@ -679,6 +681,8 @@ function applyReversePlaylistState(items) {
  * @param {any[]} items
  */
 async function persistPlaylistOrder(items) {
+  if (playlistOrderUpdateInProgress.value) { return }
+
   const selectedPlaylist = selectedUserPlaylist.value
   if (selectedPlaylist == null) { return }
 
@@ -690,14 +694,19 @@ async function persistPlaylistOrder(items) {
     _id: selectedPlaylist._id,
   }
 
+  playlistOrderUpdateInProgress.value = true
+
   try {
     await store.dispatch('updatePlaylist', playlist)
   } catch (error) {
+    parseUserPlaylist(selectedPlaylist)
     showToast({
       message: t('User Playlists.SinglePlaylistView.Toast["There was an issue with updating this playlist."]'),
       icon: ['fas', 'circle-exclamation'],
     })
     console.error(error)
+  } finally {
+    playlistOrderUpdateInProgress.value = false
   }
 }
 

--- a/src/renderer/store/modules/playlists.js
+++ b/src/renderer/store/modules/playlists.js
@@ -164,36 +164,28 @@ const actions = {
   async addPlaylist({ state, commit, rootState, dispatch }, payload) {
     processNewPlayist(payload)
 
-    try {
-      await DBPlaylistHandlers.create([payload])
+    await DBPlaylistHandlers.create([payload])
 
-      const noQuickBookmarkSet = !rootState.settings.quickBookmarkTargetPlaylistId || !state.playlists.some((playlist) => playlist._id === rootState.settings.quickBookmarkTargetPlaylistId)
-      if (noQuickBookmarkSet) {
-        dispatch('updateQuickBookmarkTargetPlaylistId', payload._id, { root: true })
-      }
-
-      commit('addPlaylist', payload)
-    } catch (errMessage) {
-      console.error(errMessage)
+    const noQuickBookmarkSet = !rootState.settings.quickBookmarkTargetPlaylistId || !state.playlists.some((playlist) => playlist._id === rootState.settings.quickBookmarkTargetPlaylistId)
+    if (noQuickBookmarkSet) {
+      dispatch('updateQuickBookmarkTargetPlaylistId', payload._id, { root: true })
     }
+
+    commit('addPlaylist', payload)
   },
 
   async addPlaylists({ state, commit, rootState, dispatch }, payload) {
     payload.forEach(processNewPlayist)
 
-    try {
-      await DBPlaylistHandlers.create(payload)
+    await DBPlaylistHandlers.create(payload)
 
-      const noQuickBookmarkSet = !rootState.settings.quickBookmarkTargetPlaylistId || !state.playlists.some((playlist) => playlist._id === rootState.settings.quickBookmarkTargetPlaylistId)
-      if (noQuickBookmarkSet) {
-        const chosenPlaylist = findEmptyOrLatestPlayedPlaylist(payload)
-        dispatch('updateQuickBookmarkTargetPlaylistId', chosenPlaylist._id, { root: true })
-      }
-
-      commit('addPlaylists', payload)
-    } catch (errMessage) {
-      console.error(errMessage)
+    const noQuickBookmarkSet = !rootState.settings.quickBookmarkTargetPlaylistId || !state.playlists.some((playlist) => playlist._id === rootState.settings.quickBookmarkTargetPlaylistId)
+    if (noQuickBookmarkSet) {
+      const chosenPlaylist = findEmptyOrLatestPlayedPlaylist(payload)
+      dispatch('updateQuickBookmarkTargetPlaylistId', chosenPlaylist._id, { root: true })
     }
+
+    commit('addPlaylists', payload)
   },
 
   async updatePlaylist({ commit }, playlist) {
@@ -208,12 +200,8 @@ const actions = {
     // Caller no need to assign last updated time
     playlist.lastUpdatedAt = Date.now()
 
-    try {
-      await DBPlaylistHandlers.upsert(playlist)
-      commit('upsertPlaylistToList', playlist)
-    } catch (errMessage) {
-      console.error(errMessage)
-    }
+    await DBPlaylistHandlers.upsert(playlist)
+    commit('upsertPlaylistToList', playlist)
   },
 
   async updatePlaylistLastPlayedAt({ commit }, playlist) {
@@ -311,10 +299,10 @@ const actions = {
       const payload = (await DBPlaylistHandlers.find()).filter((e) => e != null)
       if (payload.length === 0) {
         // Not using `addPlaylists` to ensure required attributes with dynamic values added
-        state.defaultPlaylists.forEach(playlist => {
+        await Promise.all(state.defaultPlaylists.map(playlist => {
           // Deep copy so `addPlaylist` doesn't mutate the defaults template in state
-          dispatch('addPlaylist', deepCopy(playlist))
-        })
+          return dispatch('addPlaylist', deepCopy(playlist))
+        }))
       } else {
         const dateNow = Date.now()
         const currentTime = Date.now()

--- a/src/renderer/store/modules/playlists.js
+++ b/src/renderer/store/modules/playlists.js
@@ -427,9 +427,10 @@ const actions = {
 
         commit('setAllPlaylists', payload)
       }
-      commit('setPlaylistsReady', true)
     } catch (errMessage) {
       console.error(errMessage)
+    } finally {
+      commit('setPlaylistsReady', true)
     }
   },
 

--- a/src/renderer/store/modules/watch-stats.js
+++ b/src/renderer/store/modules/watch-stats.js
@@ -55,12 +55,8 @@ const actions = {
   },
 
   async clearWatchStats({ commit }) {
-    try {
-      await DBWatchStatsHandlers.deleteAll()
-      commit('resetWatchStats')
-    } catch (errMessage) {
-      console.error(errMessage)
-    }
+    await DBWatchStatsHandlers.deleteAll()
+    commit('resetWatchStats')
   },
 
   async adjustHistoricalWatchTime({ commit }, { defaultSpeed, channelPlaybackSpeeds }) {

--- a/src/renderer/views/Playlist/Playlist.vue
+++ b/src/renderer/views/Playlist/Playlist.vue
@@ -756,20 +756,52 @@ async function getNextPageLocal() {
   }
 }
 
+const playlistOrderUpdateInProgress = ref(false)
+
 const canMoveVideos = computed(() => {
-  return isUserPlaylistRequested.value && !playlistInVideoSearchMode.value && isSortOrderCustom.value && !pendingDeletionRemovalInProgress.value
+  return isUserPlaylistRequested.value && !playlistInVideoSearchMode.value && isSortOrderCustom.value &&
+    !pendingDeletionRemovalInProgress.value && !playlistOrderUpdateInProgress.value
 })
 
 const videoDraggingPossible = computed(() => {
   return isUserPlaylistRequested.value && !playlistInVideoSearchMode.value && isSortOrderCustom.value &&
-    !pendingDeletionRemovalInProgress.value && shownPlaylistItems.value.length >= 2
+    !pendingDeletionRemovalInProgress.value && !playlistOrderUpdateInProgress.value && shownPlaylistItems.value.length >= 2
 })
+
+async function persistPlaylistOrder(orderedItems) {
+  if (playlistOrderUpdateInProgress.value) { return }
+
+  const previousItems = playlistItems.value
+  const playlist = {
+    playlistName: playlistTitle.value,
+    protected: selectedUserPlaylist.value.protected,
+    description: playlistDescription.value,
+    videos: deepCopy(orderedItems),
+    _id: playlistId.value
+  }
+
+  playlistItems.value = orderedItems
+  playlistOrderUpdateInProgress.value = true
+
+  try {
+    await store.dispatch('updatePlaylist', playlist)
+  } catch (error) {
+    playlistItems.value = previousItems
+    showToast({
+      message: t('User Playlists.SinglePlaylistView.Toast["There was an issue with updating this playlist."]'),
+      icon: ['fas', 'circle-exclamation'],
+    })
+    console.error(error)
+  } finally {
+    playlistOrderUpdateInProgress.value = false
+  }
+}
 
 /**
  * @param {string} videoId
  * @param {string} playlistItemId
  */
-function moveVideoUp(videoId, playlistItemId) {
+async function moveVideoUp(videoId, playlistItemId) {
   const playlistItems_ = playlistItems.value.slice()
   const shownIndex = shownPlaylistItems.value.findIndex((video) => {
     return video.videoId === videoId && video.playlistItemId === playlistItemId
@@ -795,31 +827,14 @@ function moveVideoUp(videoId, playlistItemId) {
   playlistItems_[index] = playlistItems_[previousIndex]
   playlistItems_[previousIndex] = video
 
-  const playlist = {
-    playlistName: playlistTitle.value,
-    protected: selectedUserPlaylist.value.protected,
-    description: playlistDescription.value,
-    videos: deepCopy(playlistItems_),
-    _id: playlistId.value
-  }
-
-  try {
-    store.dispatch('updatePlaylist', playlist)
-    playlistItems.value = playlistItems_
-  } catch (e) {
-    showToast({
-      message: t('User Playlists.SinglePlaylistView.Toast["There was an issue with updating this playlist."]'),
-      icon: ['fas', 'circle-exclamation'],
-    })
-    console.error(e)
-  }
+  await persistPlaylistOrder(playlistItems_)
 }
 
 /**
  * @param {string} videoId
  * @param {string} playlistItemId
  */
-function moveVideoDown(videoId, playlistItemId) {
+async function moveVideoDown(videoId, playlistItemId) {
   const playlistItems_ = playlistItems.value.slice()
   const shownIndex = shownPlaylistItems.value.findIndex((video) => {
     return video.videoId === videoId && video.playlistItemId === playlistItemId
@@ -845,31 +860,14 @@ function moveVideoDown(videoId, playlistItemId) {
   playlistItems_[index] = playlistItems_[nextIndex]
   playlistItems_[nextIndex] = video
 
-  const playlist = {
-    playlistName: playlistTitle.value,
-    protected: selectedUserPlaylist.value.protected,
-    description: playlistDescription.value,
-    videos: deepCopy(playlistItems_),
-    _id: playlistId.value
-  }
-
-  try {
-    store.dispatch('updatePlaylist', playlist)
-    playlistItems.value = playlistItems_
-  } catch (e) {
-    showToast({
-      message: t('User Playlists.SinglePlaylistView.Toast["There was an issue with updating this playlist."]'),
-      icon: ['fas', 'circle-exclamation'],
-    })
-    console.error(e)
-  }
+  await persistPlaylistOrder(playlistItems_)
 }
 
 /**
  * @param {string} videoId
  * @param {string} playlistItemId
  */
-function moveVideoToTheTop(videoId, playlistItemId) {
+async function moveVideoToTheTop(videoId, playlistItemId) {
   const playlistItems_ = playlistItems.value.slice()
 
   const index = playlistItems_.findIndex((video) => {
@@ -889,28 +887,14 @@ function moveVideoToTheTop(videoId, playlistItemId) {
   playlistItems_.splice(index, 1)
   playlistItems_.unshift(videoObject)
 
-  const playlist = {
-    playlistName: playlistTitle.value,
-    protected: selectedUserPlaylist.value.protected,
-    description: playlistDescription.value,
-    videos: deepCopy(playlistItems_),
-    _id: playlistId.value
-  }
-
-  try {
-    store.dispatch('updatePlaylist', playlist)
-    playlistItems.value = playlistItems_
-  } catch (e) {
-    showToast(t('User Playlists.SinglePlaylistView.Toast["There was an issue with updating this playlist."]'))
-    console.error(e)
-  }
+  await persistPlaylistOrder(playlistItems_)
 }
 
 /**
  * @param {string} videoId
  * @param {string} playlistItemId
  */
-function moveVideoToTheBottom(videoId, playlistItemId) {
+async function moveVideoToTheBottom(videoId, playlistItemId) {
   const playlistItems_ = playlistItems.value.slice()
 
   const index = playlistItems_.findIndex((video) => {
@@ -930,21 +914,7 @@ function moveVideoToTheBottom(videoId, playlistItemId) {
   playlistItems_.splice(index, 1)
   playlistItems_.push(videoObject)
 
-  const playlist = {
-    playlistName: playlistTitle.value,
-    protected: selectedUserPlaylist.value.protected,
-    description: playlistDescription.value,
-    videos: deepCopy(playlistItems_),
-    _id: playlistId.value
-  }
-
-  try {
-    store.dispatch('updatePlaylist', playlist)
-    playlistItems.value = playlistItems_
-  } catch (e) {
-    showToast(t('User Playlists.SinglePlaylistView.Toast["There was an issue with updating this playlist."]'))
-    console.error(e)
-  }
+  await persistPlaylistOrder(playlistItems_)
 }
 
 /**
@@ -957,25 +927,7 @@ function setDraggedVideo(video) {
 async function onDragVideoEnd() {
   if (tempShownPlaylistItems.value != null) {
     // Save on drag end ONLY
-    const playlist = {
-      playlistName: playlistTitle.value,
-      protected: selectedUserPlaylist.value.protected,
-      description: playlistDescription.value,
-      // Save whatever is shown
-      videos: deepCopy(tempShownPlaylistItems.value),
-      _id: playlistId.value
-    }
-
-    try {
-      await store.dispatch('updatePlaylist', playlist)
-      playlistItems.value = tempShownPlaylistItems.value
-    } catch (e) {
-      showToast({
-        message: t('User Playlists.SinglePlaylistView.Toast["There was an issue with updating this playlist."]'),
-        icon: ['fas', 'circle-exclamation'],
-      })
-      console.error(e)
-    }
+    await persistPlaylistOrder(tempShownPlaylistItems.value)
   }
 
   // Cleanup

--- a/src/renderer/views/Playlist/Playlist.vue
+++ b/src/renderer/views/Playlist/Playlist.vue
@@ -771,7 +771,6 @@ const videoDraggingPossible = computed(() => {
 async function persistPlaylistOrder(orderedItems) {
   if (playlistOrderUpdateInProgress.value) { return }
 
-  const previousItems = playlistItems.value
   const playlist = {
     playlistName: playlistTitle.value,
     protected: selectedUserPlaylist.value.protected,
@@ -786,7 +785,7 @@ async function persistPlaylistOrder(orderedItems) {
   try {
     await store.dispatch('updatePlaylist', playlist)
   } catch (error) {
-    playlistItems.value = previousItems
+    playlistItems.value = selectedUserPlaylist.value?.videos ?? []
     showToast({
       message: t('User Playlists.SinglePlaylistView.Toast["There was an issue with updating this playlist."]'),
       icon: ['fas', 'circle-exclamation'],

--- a/src/renderer/views/Stats/Stats.vue
+++ b/src/renderer/views/Stats/Stats.vue
@@ -366,8 +366,13 @@ async function handleResetStats(option) {
   showResetPrompt.value = false
   if (option !== 'reset') { return }
 
-  await store.dispatch('clearWatchStats')
-  showToast({ message: t('Stats.Reset success'), icon: ['fas', 'undo'] })
+  try {
+    await store.dispatch('clearWatchStats')
+    showToast({ message: t('Stats.Reset success'), icon: ['fas', 'undo'] })
+  } catch (error) {
+    showToast({ message: t('Stats.Reset failed'), icon: ['fas', 'circle-exclamation'] })
+    console.error(error)
+  }
 }
 
 function toDateKey(date) {

--- a/static/locales/en-US.yaml
+++ b/static/locales/en-US.yaml
@@ -200,6 +200,7 @@ Stats:
   Reset: Reset
   Reset confirmation: Are you sure you want to reset all watch statistics? This cannot be undone.
   Reset success: Watch statistics have been reset
+  Reset failed: Failed to reset watch statistics
   Less than a minute: < 1 min
   Minutes: '{minutes} min'
   Hours: '{hours} hr'
@@ -1212,6 +1213,7 @@ Settings:
     All settings have been successfully exported: All settings have been
       successfully exported
     Unable to read file: Unable to read file
+    Unable to import all playlists: Unable to import all playlists
     Unable to write file: Unable to write file
     Unknown data key: Unknown data key
     Setting object has insufficient data, skipping item: Setting object has insufficient data, skipping item


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Make sure to follow the contributing guidelines. -->
<!-- Important note, we may remove your pull request if you do not use this provided PR template correctly. -->
<!-- Agent instructions: Preserve every heading, comment, and marker in this template. Never remove or rewrite the release-note-category:start/end, release-note:start/end, or release-note-image:start/end marker pairs. Never remove or rewrite the Release note images section; leave its contents for a human. -->

## Pull Request Type
<!-- Please select what type of pull request this is: [x] -->
- [x] Bugfix
- [ ] Feature Implementation
- [ ] Documentation
- [ ] Other

## Related issue
<!-- Please link the issue your pull request is referring to. -->
<!-- If this pull request fully resolves the relevant issue, put "closes" before the issue number. -->
<!-- Example: "closes #123456". -->

Resolves #864

## Description
<!-- Please write a clear and concise description of what the pull request does. -->

Playlist and watch-stat datastore failures were being caught inside Vuex actions, so callers could not distinguish a failed write from a successful one. This made create and edit dialogs close, displayed success feedback, and left optimistic ordering out of sync with persisted data.

The affected shared actions now propagate their existing datastore rejections. Their callers await those writes before reporting success, retain modal input after failures, and roll back optimistic playlist ordering while preventing concurrent reorder writes. Bulk playlist imports and fresh-profile defaults follow the same rejection contract. Electron and web handlers already preserve the underlying rejection, so both builds use the same behavior without a new Vuex result wrapper.

## Release note category
<!-- Select exactly one category. Every pull request must select one. -->
<!-- Select "Not noteworthy" when the pull request fixes a bug in or improves functionality that has not yet appeared in a stable release. -->
<!-- release-note-category:start -->
- [x] Not noteworthy
- [ ] Highlights
- [ ] More improvements
- [ ] Fixed bugs
<!-- release-note-category:end -->

## Release note
<!-- Required unless "Not noteworthy" is selected. -->
<!-- Write one concise, user-facing entry without a leading bullet. -->
<!-- release-note:start -->

<!-- release-note:end -->

## Release note images
<!-- Human-only: Agents must preserve this entire section and leave it empty. -->
<!-- Optional. Paste one or more Markdown images or HTML image tags here. -->
<!-- The release notes will use an HTML image tag and limit images taller than 300 pixels. -->
<!-- release-note-image:start -->

<!-- release-note-image:end -->

## Testing
<!-- How can reviewers verify that the PR produces correct results? -->
<!-- Please provide instructions so that others can ensure that your pull request would produce correct results. For examples see, https://github.com/FreeTubeApp/FreeTube/pull/5743, https://github.com/FreeTubeApp/FreeTube/pull/7349, https://github.com/FreeTubeApp/FreeTube/pull/5125, https://github.com/FreeTubeApp/FreeTube/pull/7338 -->
<!-- Agent instructions: Only write human-facing steps that explain how to verify the change while running this branch in dev mode. Include expected results and, when applicable, helpful console snippets for interactive verification. Do not include automated checks, commands, results, pass counts, or CI status. -->

1. While running this branch in dev mode, temporarily make the playlist datastore create or upsert handler reject.
2. Try creating a playlist. Its dialog and entered name should remain visible, an error should appear, and no success toast or playlist row should be shown.
3. Try editing a playlist. Edit mode and the entered values should remain visible, and only the error toast should appear.
4. Try reordering a user playlist from both the playlist page and the watch-page playlist. The move should appear immediately, further moves should be unavailable while saving, and the original order should return with an error toast after rejection.
5. Temporarily make the watch-stat datastore delete-all handler reject, then reset watch statistics. The totals should remain unchanged and only the failure toast should appear.
6. Restore the handlers and repeat the operations. Successful changes should close their dialogs where applicable, show success feedback, and remain after restarting the app.

## Additional context
<!-- Add any other context about the pull request here. -->

The Electron IPC bridge and web datastore facade both return the underlying handler promises, so no platform-specific changes were needed.
