### PR TITLE
fix(imports): preserve line-delimited records and report row errors

### DIFF
--- a/e2e/tests/offline/line-delimited-imports.spec.mjs
+++ b/e2e/tests/offline/line-delimited-imports.spec.mjs
@@ -168,3 +168,45 @@ test('line-delimited search history keeps valid rows around a malformed row', as
   })).toEqual(['issue866-search-a', 'issue866-search-b'])
   expect(pageErrors).toEqual([])
 })
+
+test('malformed-only line-delimited imports do not report success', async ({ page }) => {
+  const pageErrors = []
+  page.on('pageerror', error => pageErrors.push(error.message))
+  const dataSection = await goToSettingsSection(page, 'data')
+  let expectedErrorCount = 0
+  const imports = [
+    {
+      filename: 'issue-866-subscriptions.db',
+      button: 'Import subscriptions',
+      success: 'All subscriptions and profiles have been successfully imported'
+    },
+    {
+      filename: 'issue-866-watch-history.db',
+      button: 'Import history',
+      success: 'All watched history has been successfully imported'
+    },
+    {
+      filename: 'issue-866-playlists.db',
+      button: 'Import playlists',
+      success: 'All playlists has been successfully imported'
+    },
+    {
+      filename: 'issue-866-search-history.db',
+      button: 'Import search history',
+      success: 'All search history has been successfully imported'
+    }
+  ]
+
+  for (const { filename, button, success } of imports) {
+    await mockImportFile(page, filename, ' \t \r\n{"broken":')
+    await dataSection.getByRole('button', { name: button, exact: true }).click()
+
+    expectedErrorCount++
+    await expect(page.locator('.toast', {
+      hasText: 'Invalid JSON at row 2, skipping item'
+    })).toHaveCount(expectedErrorCount)
+    await expect(page.locator('.toast', { hasText: success })).toHaveCount(0)
+  }
+
+  expect(pageErrors).toEqual([])
+})

--- a/e2e/tests/offline/line-delimited-imports.spec.mjs
+++ b/e2e/tests/offline/line-delimited-imports.spec.mjs
@@ -65,6 +65,15 @@ function playlistRecord(_id) {
   }
 }
 
+function playlistVideo(videoId) {
+  return {
+    lengthSeconds: 60,
+    timeAdded: 1,
+    title: videoId,
+    videoId
+  }
+}
+
 function searchRecord(_id, lastUpdatedAt) {
   return { _id, lastUpdatedAt }
 }
@@ -124,10 +133,23 @@ test('line-delimited playlists keep valid rows around a malformed row', async ({
   page.on('pageerror', error => pageErrors.push(error.message))
   const dataSection = await goToSettingsSection(page, 'data')
 
-  await mockImportFile(page, 'issue-866-playlists.db', lineDelimitedFixture(
-    playlistRecord('issue866-playlist-a'),
-    playlistRecord('issue866-playlist-b')
-  ))
+  const playlistWithInvalidVideo = playlistRecord('issue866-playlist-mixed-videos')
+  playlistWithInvalidVideo.videos = [null, playlistVideo('issue866-playlist-video')]
+  const content = [
+    JSON.stringify(playlistRecord('issue866-playlist-a')),
+    ' \t ',
+    '',
+    '{"broken":',
+    JSON.stringify(playlistWithInvalidVideo),
+    JSON.stringify({
+      _id: 'issue866-playlist-invalid-videos',
+      playlistName: 'issue866-playlist-invalid-videos',
+      videos: null
+    }),
+    JSON.stringify(playlistRecord('issue866-playlist-b'))
+  ].join('\r\n')
+
+  await mockImportFile(page, 'issue-866-playlists.db', content)
   await dataSection.getByRole('button', { name: 'Import playlists', exact: true }).click()
 
   await expectRowError(page)
@@ -136,11 +158,21 @@ test('line-delimited playlists keep valid rows around a malformed row', async ({
   })).toBeVisible()
   await expect.poll(() => page.evaluate(() => {
     const store = document.querySelector('#app').__vue_app__.config.globalProperties.$store
-    return store.getters.getAllPlaylists
-      .map(({ _id }) => _id)
-      .filter(id => id.startsWith('issue866-playlist-'))
-      .sort()
-  })).toEqual(['issue866-playlist-a', 'issue866-playlist-b'])
+    const playlists = store.getters.getAllPlaylists
+      .filter(({ _id }) => _id.startsWith('issue866-playlist-'))
+    const mixedPlaylist = playlists.find(({ _id }) => _id === 'issue866-playlist-mixed-videos')
+    return {
+      ids: playlists.map(({ _id }) => _id).sort(),
+      mixedVideoIds: mixedPlaylist?.videos.map(({ videoId }) => videoId)
+    }
+  })).toEqual({
+    ids: [
+      'issue866-playlist-a',
+      'issue866-playlist-b',
+      'issue866-playlist-mixed-videos'
+    ],
+    mixedVideoIds: ['issue866-playlist-video']
+  })
   expect(pageErrors).toEqual([])
 })
 

--- a/e2e/tests/offline/line-delimited-imports.spec.mjs
+++ b/e2e/tests/offline/line-delimited-imports.spec.mjs
@@ -1,0 +1,170 @@
+import { expect, goToSettingsSection, test } from '../../helpers/app.mjs'
+
+function lineDelimitedFixture(firstRecord, lastRecord) {
+  return [
+    JSON.stringify(firstRecord),
+    ' \t ',
+    '',
+    '{"broken":',
+    JSON.stringify(lastRecord)
+  ].join('\r\n')
+}
+
+async function mockImportFile(page, filename, content) {
+  await page.evaluate(({ filename, content }) => {
+    Object.defineProperty(window, 'showOpenFilePicker', {
+      configurable: true,
+      value: async () => [{
+        getFile: async () => new File(
+          [content],
+          filename,
+          { type: 'application/x-freetube-db' }
+        )
+      }]
+    })
+  }, { filename, content })
+}
+
+async function expectRowError(page) {
+  await expect(page.locator('.toast', {
+    hasText: 'Invalid JSON at row 4, skipping item'
+  })).toHaveCount(1)
+}
+
+function subscriptionProfile(_id, channelId) {
+  return {
+    _id,
+    name: _id,
+    bgColor: '#000000',
+    textColor: '#FFFFFF',
+    subscriptions: [{ id: channelId, name: channelId, thumbnail: null }]
+  }
+}
+
+function watchRecord(videoId, timeWatched) {
+  return {
+    _id: videoId,
+    author: 'Issue 866',
+    authorId: 'UCissue866',
+    isLive: false,
+    lengthSeconds: 60,
+    published: 0,
+    timeWatched,
+    title: videoId,
+    type: 'video',
+    videoId,
+    watchProgress: 0
+  }
+}
+
+function playlistRecord(_id) {
+  return {
+    _id,
+    playlistName: _id,
+    videos: []
+  }
+}
+
+function searchRecord(_id, lastUpdatedAt) {
+  return { _id, lastUpdatedAt }
+}
+
+test('line-delimited subscriptions keep valid rows around a malformed row', async ({ page }) => {
+  const pageErrors = []
+  page.on('pageerror', error => pageErrors.push(error.message))
+  const dataSection = await goToSettingsSection(page, 'data')
+
+  await mockImportFile(page, 'issue-866-subscriptions.db', lineDelimitedFixture(
+    subscriptionProfile('issue866-profile-a', 'UCissue866-a'),
+    subscriptionProfile('issue866-profile-b', 'UCissue866-b')
+  ))
+  await dataSection.getByRole('button', { name: 'Import subscriptions', exact: true }).click()
+
+  await expectRowError(page)
+  await expect(page.locator('.toast', {
+    hasText: 'All subscriptions and profiles have been successfully imported'
+  })).toBeVisible()
+  await expect.poll(() => page.evaluate(() => {
+    const store = document.querySelector('#app').__vue_app__.config.globalProperties.$store
+    const primaryProfile = store.getters.getProfileList[0]
+    return primaryProfile.subscriptions
+      .map(({ id }) => id)
+      .filter(id => id.startsWith('UCissue866-'))
+      .sort()
+  })).toEqual(['UCissue866-a', 'UCissue866-b'])
+  expect(pageErrors).toEqual([])
+})
+
+test('line-delimited watch history keeps valid rows around a malformed row', async ({ page }) => {
+  const pageErrors = []
+  page.on('pageerror', error => pageErrors.push(error.message))
+  const dataSection = await goToSettingsSection(page, 'data')
+
+  await mockImportFile(page, 'issue-866-watch-history.db', lineDelimitedFixture(
+    watchRecord('issue866a01', 1),
+    watchRecord('issue866b02', 2)
+  ))
+  await dataSection.getByRole('button', { name: 'Import history', exact: true }).click()
+
+  await expectRowError(page)
+  await expect(page.locator('.toast', {
+    hasText: 'All watched history has been successfully imported'
+  })).toBeVisible()
+  await expect.poll(() => page.evaluate(() => {
+    const store = document.querySelector('#app').__vue_app__.config.globalProperties.$store
+    return Object.keys(store.getters.getHistoryCacheById)
+      .filter(videoId => videoId.startsWith('issue866'))
+      .sort()
+  })).toEqual(['issue866a01', 'issue866b02'])
+  expect(pageErrors).toEqual([])
+})
+
+test('line-delimited playlists keep valid rows around a malformed row', async ({ page }) => {
+  const pageErrors = []
+  page.on('pageerror', error => pageErrors.push(error.message))
+  const dataSection = await goToSettingsSection(page, 'data')
+
+  await mockImportFile(page, 'issue-866-playlists.db', lineDelimitedFixture(
+    playlistRecord('issue866-playlist-a'),
+    playlistRecord('issue866-playlist-b')
+  ))
+  await dataSection.getByRole('button', { name: 'Import playlists', exact: true }).click()
+
+  await expectRowError(page)
+  await expect(page.locator('.toast', {
+    hasText: 'All playlists has been successfully imported'
+  })).toBeVisible()
+  await expect.poll(() => page.evaluate(() => {
+    const store = document.querySelector('#app').__vue_app__.config.globalProperties.$store
+    return store.getters.getAllPlaylists
+      .map(({ _id }) => _id)
+      .filter(id => id.startsWith('issue866-playlist-'))
+      .sort()
+  })).toEqual(['issue866-playlist-a', 'issue866-playlist-b'])
+  expect(pageErrors).toEqual([])
+})
+
+test('line-delimited search history keeps valid rows around a malformed row', async ({ page }) => {
+  const pageErrors = []
+  page.on('pageerror', error => pageErrors.push(error.message))
+  const dataSection = await goToSettingsSection(page, 'data')
+
+  await mockImportFile(page, 'issue-866-search-history.db', lineDelimitedFixture(
+    searchRecord('issue866-search-a', 1),
+    searchRecord('issue866-search-b', 2)
+  ))
+  await dataSection.getByRole('button', { name: 'Import search history', exact: true }).click()
+
+  await expectRowError(page)
+  await expect(page.locator('.toast', {
+    hasText: 'All search history has been successfully imported'
+  })).toBeVisible()
+  await expect.poll(() => page.evaluate(() => {
+    const store = document.querySelector('#app').__vue_app__.config.globalProperties.$store
+    return store.getters.getSearchHistoryEntries
+      .map(({ _id }) => _id)
+      .filter(id => id.startsWith('issue866-search-'))
+      .sort()
+  })).toEqual(['issue866-search-a', 'issue866-search-b'])
+  expect(pageErrors).toEqual([])
+})

--- a/e2e/tests/offline/line-delimited-imports.spec.mjs
+++ b/e2e/tests/offline/line-delimited-imports.spec.mjs
@@ -169,7 +169,7 @@ test('line-delimited search history keeps valid rows around a malformed row', as
   expect(pageErrors).toEqual([])
 })
 
-test('malformed-only line-delimited imports do not report success', async ({ page }) => {
+test('invalid-only line-delimited imports do not report success', async ({ page }) => {
   const pageErrors = []
   page.on('pageerror', error => pageErrors.push(error.message))
   const dataSection = await goToSettingsSection(page, 'data')
@@ -205,6 +205,10 @@ test('malformed-only line-delimited imports do not report success', async ({ pag
     await expect(page.locator('.toast', {
       hasText: 'Invalid JSON at row 2, skipping item'
     })).toHaveCount(expectedErrorCount)
+    await expect(page.locator('.toast', { hasText: success })).toHaveCount(0)
+
+    await mockImportFile(page, filename, '{}')
+    await dataSection.getByRole('button', { name: button, exact: true }).click()
     await expect(page.locator('.toast', { hasText: success })).toHaveCount(0)
   }
 

--- a/e2e/tests/offline/subscription-import.spec.mjs
+++ b/e2e/tests/offline/subscription-import.spec.mjs
@@ -76,7 +76,7 @@ test('imports current OpenTubeX subscriptions without rejecting profile icons', 
       exportedIdCollisionProfile
     ]
       .map(profile => JSON.stringify(profile))
-      .join('\n') + '\n'
+      .join('\n')
 
     Object.defineProperty(window, 'showOpenFilePicker', {
       configurable: true,

--- a/src/renderer/components/DataSettings/DataSettings.vue
+++ b/src/renderer/components/DataSettings/DataSettings.vue
@@ -547,9 +547,11 @@ function importFreeTubeSubscriptions(profileRecords) {
     }
   })
 
-  if (shouldUpdatePrimaryProfile) {
-    store.dispatch('updateProfile', updatedPrimaryProfile)
+  if (!shouldUpdatePrimaryProfile) {
+    return
   }
+
+  store.dispatch('updateProfile', updatedPrimaryProfile)
 
   showToast({
     message: t('Settings.Data Settings.All subscriptions and profiles have been successfully imported'),
@@ -1082,6 +1084,7 @@ async function importFreeTubeWatchHistory(historyRecords) {
 
   // deep copy so we don't get errors from Electron when we try to pass reactive objects through the IPC channels
   const historyItems = new Map(deepCopy(Object.entries(historyCacheById.value)))
+  let importedCount = 0
 
   historyRecords.forEach((historyData) => {
     // We would technically already be done by the time the data is parsed,
@@ -1121,8 +1124,13 @@ async function importFreeTubeWatchHistory(historyRecords) {
       historyObject.description = historyObject.description ?? ''
 
       historyItems.set(historyObject.videoId, historyObject)
+      importedCount++
     }
   })
+
+  if (importedCount === 0) {
+    return
+  }
 
   await store.dispatch('overwriteHistory', historyItems)
 
@@ -1431,6 +1439,7 @@ async function importPlaylists() {
   ]
 
   const newPlaylists = []
+  let importedCount = 0
 
   playlists.forEach((playlistData) => {
     // We would technically already be done by the time the data is parsed,
@@ -1483,6 +1492,8 @@ async function importPlaylists() {
       showToast({ message: message, icon: ['fas', 'circle-exclamation'] })
       return
     }
+
+    importedCount++
 
     const existingPlaylist = allPlaylists.value.find((playlist) => {
       if (playlistObject._id != null && playlist._id === playlistObject._id) {
@@ -1556,6 +1567,10 @@ async function importPlaylists() {
       videos: playlistVideos
     })
   })
+
+  if (importedCount === 0) {
+    return
+  }
 
   if (newPlaylists.length > 0) {
     store.dispatch('addPlaylists', newPlaylists)
@@ -1634,6 +1649,7 @@ async function importSearchHistory() {
 async function importFreeTubeSearchHistory(searchHistoryRecords) {
   // deep copy so we don't get errors from Electron when we try to pass reactive objects through the IPC channels
   const historyItems = new Map(deepCopy(searchHistoryEntries.value).map(entry => [entry._id, entry]))
+  let importedCount = 0
 
   searchHistoryRecords.forEach((entry) => {
     if (!isJsonObject(entry) || typeof entry._id !== 'string' || typeof entry.lastUpdatedAt !== 'number') {
@@ -1643,6 +1659,7 @@ async function importFreeTubeSearchHistory(searchHistoryRecords) {
       })
       console.error('Missing keys:', entry)
     } else {
+      importedCount++
       const existingEntry = historyItems.get(entry._id)
 
       if (existingEntry == null || entry.lastUpdatedAt > existingEntry.lastUpdatedAt) {
@@ -1658,6 +1675,10 @@ async function importFreeTubeSearchHistory(searchHistoryRecords) {
       }
     }
   })
+
+  if (importedCount === 0) {
+    return
+  }
 
   const newSearchHistoryEntries = Array.from(historyItems.values())
 

--- a/src/renderer/components/DataSettings/DataSettings.vue
+++ b/src/renderer/components/DataSettings/DataSettings.vue
@@ -270,7 +270,7 @@ function parseImportedJson(content, invalidMessage) {
 
 /**
  * @param {string} content
- * @returns {unknown[]}
+ * @returns {unknown[] | null}
  */
 function parseImportedLineDelimitedJson(content) {
   const { records, errors } = parseLineDelimitedJson(content)
@@ -283,7 +283,7 @@ function parseImportedLineDelimitedJson(content) {
     })
   })
 
-  return records
+  return records.length === 0 ? null : records
 }
 
 /**
@@ -352,7 +352,10 @@ async function importSubscriptions() {
   if (filename.endsWith('.csv')) {
     importCsvYouTubeSubscriptions(content)
   } else if (filename.endsWith('.db')) {
-    importFreeTubeSubscriptions(parseImportedLineDelimitedJson(content))
+    const records = parseImportedLineDelimitedJson(content)
+    if (records !== null) {
+      importFreeTubeSubscriptions(records)
+    }
   } else if (filename.endsWith('.opml') || filename.endsWith('.xml')) {
     importOpmlYouTubeSubscriptions(content)
   } else if (filename.endsWith('.json')) {
@@ -1024,7 +1027,10 @@ async function importWatchHistory() {
   const { filename, content } = response
 
   if (filename.endsWith('.db')) {
-    importFreeTubeWatchHistory(parseImportedLineDelimitedJson(content))
+    const records = parseImportedLineDelimitedJson(content)
+    if (records !== null) {
+      importFreeTubeWatchHistory(records)
+    }
   } else if (filename.endsWith('.json')) {
     const jsonContent = parseImportedJson(content, t('Settings.Data Settings.Invalid history file'))
     if (jsonContent === null) {
@@ -1377,6 +1383,9 @@ async function importPlaylists() {
     // otherwise assume this is the correct database format,
     // which is also what we export now (used in 0.20.0 and later versions)
     playlists = parseImportedLineDelimitedJson(data)
+    if (playlists === null) {
+      return
+    }
   }
 
   const requiredKeys = [
@@ -1610,7 +1619,10 @@ async function importSearchHistory() {
   const { filename, content } = response
 
   if (filename.endsWith('.db')) {
-    importFreeTubeSearchHistory(parseImportedLineDelimitedJson(content))
+    const records = parseImportedLineDelimitedJson(content)
+    if (records !== null) {
+      importFreeTubeSearchHistory(records)
+    }
   } else if (filename.endsWith('.json')) {
     importYouTubeSearchHistory(JSON.parse(content))
   }

--- a/src/renderer/components/DataSettings/DataSettings.vue
+++ b/src/renderer/components/DataSettings/DataSettings.vue
@@ -202,6 +202,7 @@ import {
   getLibreTubeSubscriptions,
   isLibreTubeWatchHistoryBackup,
 } from '../../helpers/libretube'
+import { parseLineDelimitedJson } from '../../helpers/line-delimited-json'
 
 const IMPORT_DIRECTORY_ID = 'data-settings-import'
 const START_IN_DIRECTORY = 'downloads'
@@ -267,6 +268,32 @@ function parseImportedJson(content, invalidMessage) {
   }
 }
 
+/**
+ * @param {string} content
+ * @returns {unknown[]}
+ */
+function parseImportedLineDelimitedJson(content) {
+  const { records, errors } = parseLineDelimitedJson(content)
+
+  errors.forEach((error) => {
+    console.error('Unable to parse imported JSON row', error)
+    showToast({
+      message: t('Settings.Data Settings.Invalid JSON row, skipping item', { row: error.rowNumber }),
+      icon: ['fas', 'circle-exclamation'],
+    })
+  })
+
+  return records
+}
+
+/**
+ * @param {unknown} value
+ * @returns {value is Record<string, unknown>}
+ */
+function isJsonObject(value) {
+  return value !== null && typeof value === 'object' && !Array.isArray(value)
+}
+
 const SUBSCRIPTIONS_PROMPT_VALUES = [
   'freetube',
   'youtubenew',
@@ -325,7 +352,7 @@ async function importSubscriptions() {
   if (filename.endsWith('.csv')) {
     importCsvYouTubeSubscriptions(content)
   } else if (filename.endsWith('.db')) {
-    importFreeTubeSubscriptions(content)
+    importFreeTubeSubscriptions(parseImportedLineDelimitedJson(content))
   } else if (filename.endsWith('.opml') || filename.endsWith('.xml')) {
     importOpmlYouTubeSubscriptions(content)
   } else if (filename.endsWith('.json')) {
@@ -411,17 +438,20 @@ function convertOldFreeTubeFormatToNew(oldData) {
 }
 
 /**
- * @param {string} textDecode
+ * @param {unknown[]} profileRecords
  */
-function importFreeTubeSubscriptions(textDecode) {
-  textDecode = textDecode.split('\n')
-  textDecode.pop()
-  textDecode = textDecode.map(data => JSON.parse(data))
-
-  const firstEntry = textDecode[0]
-  if (firstEntry.channelId && firstEntry.channelName && firstEntry.channelThumbnail && firstEntry._id && firstEntry.profile) {
+function importFreeTubeSubscriptions(profileRecords) {
+  const firstEntry = profileRecords[0]
+  if (
+    isJsonObject(firstEntry) &&
+    firstEntry.channelId &&
+    firstEntry.channelName &&
+    firstEntry.channelThumbnail &&
+    firstEntry._id &&
+    firstEntry.profile
+  ) {
     // Old FreeTube subscriptions format detected, so convert it to the new one:
-    textDecode = convertOldFreeTubeFormatToNew(textDecode)
+    profileRecords = convertOldFreeTubeFormatToNew(profileRecords)
   }
 
   const requiredKeys = [
@@ -438,10 +468,16 @@ function importFreeTubeSubscriptions(textDecode) {
   const updatedPrimaryProfile = primaryProfile.value
   let shouldUpdatePrimaryProfile = false
 
-  textDecode.forEach((profileData) => {
+  profileRecords.forEach((profileData) => {
     // We would technically already be done by the time the data is parsed,
     // however we want to limit the possibility of malicious data being sent
     // to the app, so we'll only grab the data we need here.
+
+    if (!isJsonObject(profileData)) {
+      const message = t('Settings.Data Settings.Profile object has insufficient data, skipping item')
+      showToast({ message: message, icon: ['fas', 'circle-exclamation'] })
+      return
+    }
 
     const profileObject = {}
     Object.keys(profileData).forEach((key) => {
@@ -796,7 +832,7 @@ function exportSubscriptions(option) {
 async function exportFreeTubeSubscriptions() {
   const subscriptionsDb = profileList.value.map((profile) => {
     return JSON.stringify(profile)
-  }).join('\n') + '\n'// a trailing line is expected
+  }).join('\n') + '\n'
   const dateStr = getTodayDateStrLocalTimezone()
   const exportFileName = 'opentubex-subscriptions-' + dateStr + '.db'
 
@@ -988,7 +1024,7 @@ async function importWatchHistory() {
   const { filename, content } = response
 
   if (filename.endsWith('.db')) {
-    importFreeTubeWatchHistory(content.split('\n'))
+    importFreeTubeWatchHistory(parseImportedLineDelimitedJson(content))
   } else if (filename.endsWith('.json')) {
     const jsonContent = parseImportedJson(content, t('Settings.Data Settings.Invalid history file'))
     if (jsonContent === null) {
@@ -1006,11 +1042,9 @@ async function importWatchHistory() {
 }
 
 /**
- * @param {string[]} textDecode
+ * @param {unknown[]} historyRecords
  */
-async function importFreeTubeWatchHistory(textDecode) {
-  textDecode.pop()
-
+async function importFreeTubeWatchHistory(historyRecords) {
   const requiredKeys = [
     'author',
     'authorId',
@@ -1043,11 +1077,19 @@ async function importFreeTubeWatchHistory(textDecode) {
   // deep copy so we don't get errors from Electron when we try to pass reactive objects through the IPC channels
   const historyItems = new Map(deepCopy(Object.entries(historyCacheById.value)))
 
-  textDecode.forEach((history) => {
-    const historyData = JSON.parse(history)
+  historyRecords.forEach((historyData) => {
     // We would technically already be done by the time the data is parsed,
     // however we want to limit the possibility of malicious data being sent
     // to the app, so we'll only grab the data we need here.
+
+    if (!isJsonObject(historyData)) {
+      showToast({
+        message: t('Settings.Data Settings.History object has insufficient data, skipping item'),
+        icon: ['fas', 'circle-exclamation'],
+      })
+      console.error('Invalid history record:', historyData)
+      return
+    }
 
     const historyObject = {}
 
@@ -1320,7 +1362,7 @@ async function importPlaylists() {
     return
   }
 
-  let data = response.content
+  const data = response.content
 
   let playlists
 
@@ -1334,10 +1376,7 @@ async function importPlaylists() {
   } else {
     // otherwise assume this is the correct database format,
     // which is also what we export now (used in 0.20.0 and later versions)
-    data = data.split('\n')
-    data.pop()
-
-    playlists = data.map(playlistJson => JSON.parse(playlistJson))
+    playlists = parseImportedLineDelimitedJson(data)
   }
 
   const requiredKeys = [
@@ -1388,6 +1427,12 @@ async function importPlaylists() {
     // We would technically already be done by the time the data is parsed,
     // however we want to limit the possibility of malicious data being sent
     // to the app, so we'll only grab the data we need here.
+
+    if (!isJsonObject(playlistData)) {
+      const message = t('Settings.Data Settings.Playlist insufficient data', { playlist: '' })
+      showToast({ message: message, icon: ['fas', 'circle-exclamation'] })
+      return
+    }
 
     const playlistObject = {}
     const videoIdToBeAddedSet = new Set()
@@ -1519,7 +1564,7 @@ async function exportPlaylists() {
 
   const playlistsDb = allPlaylists.value.map(playlist => {
     return JSON.stringify(playlist)
-  }).join('\n') + '\n'// a trailing line is expected
+  }).join('\n') + '\n'
 
   await promptAndWriteToFile(
     exportFileName,
@@ -1565,25 +1610,21 @@ async function importSearchHistory() {
   const { filename, content } = response
 
   if (filename.endsWith('.db')) {
-    importFreeTubeSearchHistory(content.split('\n'))
+    importFreeTubeSearchHistory(parseImportedLineDelimitedJson(content))
   } else if (filename.endsWith('.json')) {
     importYouTubeSearchHistory(JSON.parse(content))
   }
 }
 
 /**
- * @param {string[]} textDecode
+ * @param {unknown[]} searchHistoryRecords
  */
-async function importFreeTubeSearchHistory(textDecode) {
-  textDecode.pop()
-
+async function importFreeTubeSearchHistory(searchHistoryRecords) {
   // deep copy so we don't get errors from Electron when we try to pass reactive objects through the IPC channels
   const historyItems = new Map(deepCopy(searchHistoryEntries.value).map(entry => [entry._id, entry]))
 
-  textDecode.forEach((rawEntry) => {
-    const entry = JSON.parse(rawEntry)
-
-    if (typeof entry._id !== 'string' || typeof entry.lastUpdatedAt !== 'number') {
+  searchHistoryRecords.forEach((entry) => {
+    if (!isJsonObject(entry) || typeof entry._id !== 'string' || typeof entry.lastUpdatedAt !== 'number') {
       showToast({
         message: t('Settings.Data Settings.History object has insufficient data, skipping item'),
         icon: ['fas', 'circle-exclamation'],

--- a/src/renderer/components/DataSettings/DataSettings.vue
+++ b/src/renderer/components/DataSettings/DataSettings.vue
@@ -1446,7 +1446,7 @@ async function importPlaylists() {
     // however we want to limit the possibility of malicious data being sent
     // to the app, so we'll only grab the data we need here.
 
-    if (!isJsonObject(playlistData)) {
+    if (!isJsonObject(playlistData) || !Array.isArray(playlistData.videos)) {
       const message = t('Settings.Data Settings.Playlist insufficient data', { playlist: '' })
       showToast({ message: message, icon: ['fas', 'circle-exclamation'] })
       return
@@ -1463,6 +1463,10 @@ async function importPlaylists() {
       } else if (key === 'videos') {
         const videoArray = []
         playlistData.videos.forEach((video) => {
+          if (!isJsonObject(video)) {
+            return
+          }
+
           const videoPropertyKeys = Object.keys(video)
           const videoObjectHasAllRequiredKeys = requiredVideoKeys.every((k) => videoPropertyKeys.includes(k))
 

--- a/src/renderer/helpers/line-delimited-json.js
+++ b/src/renderer/helpers/line-delimited-json.js
@@ -1,0 +1,28 @@
+/**
+ * Parses line-delimited JSON without applying record validation or deduplication.
+ *
+ * @param {string} source
+ * @returns {{ records: unknown[], errors: { rowNumber: number, message: string }[] }}
+ */
+export function parseLineDelimitedJson(source) {
+  const records = []
+  const errors = []
+
+  source.split(/\r?\n/).forEach((row, index) => {
+    const trimmedRow = row.trim()
+    if (trimmedRow === '') {
+      return
+    }
+
+    try {
+      records.push(JSON.parse(trimmedRow))
+    } catch (error) {
+      errors.push({
+        rowNumber: index + 1,
+        message: error instanceof Error ? error.message : String(error)
+      })
+    }
+  })
+
+  return { records, errors }
+}

--- a/static/locales/en-GB.yaml
+++ b/static/locales/en-GB.yaml
@@ -504,6 +504,7 @@ Settings:
     All subscriptions have been successfully imported: 'All subscriptions have been successfully imported'
     Invalid subscriptions file: 'Invalid subscriptions file'
     Invalid history file: 'Invalid history file'
+    Invalid JSON row, skipping item: 'Invalid JSON at row {row}, skipping item'
     Subscriptions have been successfully exported: 'Subscriptions have been successfully exported'
     History object has insufficient data, skipping item: 'History object has insufficient data, skipping item'
     All watched history has been successfully imported: 'All watched history has been successfully imported'

--- a/static/locales/en-US.yaml
+++ b/static/locales/en-US.yaml
@@ -1200,6 +1200,7 @@ Settings:
       successfully imported
     Invalid subscriptions file: Invalid subscriptions file
     Invalid history file: Invalid history file
+    Invalid JSON row, skipping item: 'Invalid JSON at row {row}, skipping item'
     Subscriptions have been successfully exported: Subscriptions have been successfully
       exported
     History object has insufficient data, skipping item: History object has insufficient

--- a/tests/unit/line-delimited-json.test.mjs
+++ b/tests/unit/line-delimited-json.test.mjs
@@ -1,0 +1,58 @@
+import assert from 'node:assert/strict'
+import test from 'node:test'
+
+import { parseLineDelimitedJson } from '../../src/renderer/helpers/line-delimited-json.js'
+
+test('parses LF records with or without a terminal newline', () => {
+  const source = '{"id":1}\n{"id":2}'
+  const expected = {
+    records: [{ id: 1 }, { id: 2 }],
+    errors: []
+  }
+
+  assert.deepEqual(parseLineDelimitedJson(source), expected)
+  assert.deepEqual(parseLineDelimitedJson(`${source}\n`), expected)
+})
+
+test('parses CRLF records and ignores whitespace-only rows', () => {
+  const source = '{"id":1}\r\n \t \r\n\r\n{"id":2}\r\n'
+
+  assert.deepEqual(parseLineDelimitedJson(source), {
+    records: [{ id: 1 }, { id: 2 }],
+    errors: []
+  })
+})
+
+test('returns valid records and a structured one-based error for malformed rows', () => {
+  const source = '{"id":1}\r\n \t \r\n\r\n{"broken":\r\n{"id":2}'
+  const result = parseLineDelimitedJson(source)
+
+  assert.deepEqual(result.records, [{ id: 1 }, { id: 2 }])
+  assert.equal(result.errors.length, 1)
+  assert.deepEqual(Object.keys(result.errors[0]), ['rowNumber', 'message'])
+  assert.equal(result.errors[0].rowNumber, 4)
+  assert.equal(typeof result.errors[0].message, 'string')
+  assert.notEqual(result.errors[0].message, '')
+})
+
+test('returns no records or errors for empty and blank input', () => {
+  assert.deepEqual(parseLineDelimitedJson(''), { records: [], errors: [] })
+  assert.deepEqual(parseLineDelimitedJson(' \n\t\r\n'), { records: [], errors: [] })
+})
+
+test('does not validate record shapes or remove duplicates', () => {
+  const source = [
+    '{"id":"duplicate"}',
+    '{"id":"duplicate"}',
+    '{"wrongSchemaForImporters":true}'
+  ].join('\n')
+
+  assert.deepEqual(parseLineDelimitedJson(source), {
+    records: [
+      { id: 'duplicate' },
+      { id: 'duplicate' },
+      { wrongSchemaForImporters: true }
+    ],
+    errors: []
+  })
+})


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Make sure to follow the contributing guidelines. -->
<!-- Important note, we may remove your pull request if you do not use this provided PR template correctly. -->
<!-- Agent instructions: Preserve every heading, comment, and marker in this template. Never remove or rewrite the release-note-category:start/end, release-note:start/end, or release-note-image:start/end marker pairs. Never remove or rewrite the Release note images section; leave its contents for a human. -->

## Pull Request Type
<!-- Please select what type of pull request this is: [x] -->
- [x] Bugfix
- [ ] Feature Implementation
- [ ] Documentation
- [ ] Other

## Related issue
<!-- Please link the issue your pull request is referring to. -->
<!-- If this pull request fully resolves the relevant issue, put "closes" before the issue number. -->
<!-- Example: "closes #123456". -->

Resolves #866.

## Description
<!-- Please write a clear and concise description of what the pull request does. -->

The four line-delimited `.db` import paths assumed every file ended with an empty row. A file without a terminal newline lost its final record, while a blank or malformed row could abort the whole import.

This adds one pure row-aware JSON parser and sends its valid records through the existing subscription, watch-history, playlist, and search-history validation and deduplication. Blank rows are ignored, malformed rows are skipped with a one-based row error, and records after an error still import.

## Release note category
<!-- Select exactly one category. Every pull request must select one. -->
<!-- Select "Not noteworthy" when the pull request fixes a bug in or improves functionality that has not yet appeared in a stable release. -->
<!-- release-note-category:start -->
- [ ] Not noteworthy
- [ ] Highlights
- [ ] More improvements
- [x] Fixed bugs
<!-- release-note-category:end -->

## Release note
<!-- Required unless "Not noteworthy" is selected. -->
<!-- Write one concise, user-facing entry without a leading bullet. -->
<!-- release-note:start -->

Line-delimited data imports now keep the final record and skip malformed rows with a row-number error.

<!-- release-note:end -->

## Release note images
<!-- Human-only: Agents must preserve this entire section and leave it empty. -->
<!-- Optional. Paste one or more Markdown images or HTML image tags here. -->
<!-- The release notes will use an HTML image tag and limit images taller than 300 pixels. -->
<!-- release-note-image:start -->

<!-- release-note-image:end -->

## Testing
<!-- How can reviewers verify that the PR produces correct results? -->
<!-- Please provide instructions so that others can ensure that your pull request would produce correct results. For examples see, https://github.com/FreeTubeApp/FreeTube/pull/5743, https://github.com/FreeTubeApp/FreeTube/pull/7349, https://github.com/FreeTubeApp/FreeTube/pull/5125, https://github.com/FreeTubeApp/FreeTube/pull/7338 -->
<!-- Agent instructions: Only write human-facing steps that explain how to verify the change while running this branch in dev mode. Include expected results and, when applicable, helpful console snippets for interactive verification. Do not include automated checks, commands, results, pass counts, or CI status. -->

1. In the development app, open Settings > Data and import line-delimited subscription, watch-history, playlist, and search-history files containing CRLF rows, blank rows, one malformed row, and no terminal newline.
2. Confirm that the valid records before and after the malformed row import, one error toast identifies the malformed row number, and the existing validation and duplicate handling still apply.

## Additional context
<!-- Add any other context about the pull request here. -->

The legacy playlist JSON-array format stays on its existing parser path.
