### PR TITLE
fix(tabs): avoid false loading during player refresh

### DIFF
--- a/e2e/tests/offline/sabr-error-recovery.spec.mjs
+++ b/e2e/tests/offline/sabr-error-recovery.spec.mjs
@@ -1,5 +1,5 @@
-import { goTo, test, expect } from '../../helpers/app.mjs'
-import { mockUnplayableWatchPage, watchHistoryEntry } from '../../helpers/watch.mjs'
+import { goTo, sel, test, expect } from '../../helpers/app.mjs'
+import { mockUnplayableWatchPage, watchHistoryEntry, watchViewHandle } from '../../helpers/watch.mjs'
 
 // Mirror the module-level Watch constants, which cannot be imported here.
 const MAX_SABR_ERROR_RECOVERIES = 3
@@ -526,6 +526,110 @@ test('a SABR reload preserves the tab title while adding its resume timestamp', 
   expect(titles.publishedTitles).toEqual([titles.titleBeforeReload])
   await expect(page).toHaveURL(/oneTimeTimestamp=42/)
   await expect(page).toHaveTitle(`${titles.titleBeforeReload} - OpenTubeX`)
+})
+
+test('a background SABR refresh does not flash the tab loading indicator', async ({ app, page }) => {
+  await mockUnplayableWatchPage(app, page)
+  await goTo(page, 'history')
+  await page.getByText('SABR test video').click()
+  await expect(page).toHaveURL(/#\/watch\/jNQXAC9IVRw/)
+  await expect(page.locator('.errorMessage')).toBeVisible({ timeout: 30_000 })
+
+  const watchView = await watchViewHandle(page)
+  const watchTabId = await watchView.evaluate(view => view.tabId)
+  const watchTab = page.locator(`.tab[data-tab-id="${watchTabId}"]`)
+  const watchContent = page.locator(`.tabContent[data-tab-id="${watchTabId}"]`)
+  const historyTab = await page.evaluate(() => window.ftElectron.tabs.create({
+    route: '/history',
+    title: 'History',
+    makeActive: false,
+    preloadInBackground: true
+  }))
+  const historyTabElement = page.locator(`.tab[data-tab-id="${historyTab.id}"]`)
+  await expect(page.locator(sel.tabs)).toHaveCount(2)
+
+  await watchView.evaluate(view => {
+    view.activeFormat = 'dash'
+    view.manifestMimeType = 'application/sabr+json'
+    view.manifestSrc = 'sabr://test'
+    view.isLive = false
+    view.isPostLiveDvr = false
+    view.isLoading = false
+    view.getTimestamp = () => 42
+    view.showTabToast = () => {}
+    view.handleRouteChange = async () => {
+      window.__backgroundSabrRouteChangeStarted = true
+      await new Promise(resolve => { window.__finishBackgroundSabrRouteChange = resolve })
+    }
+    view.getVideoInformationLocal = async () => {
+      window.__backgroundSabrRefreshStarted = true
+      await new Promise(resolve => { window.__finishBackgroundSabrMetadata = resolve })
+      view.ytDlpStreamsPending = true
+      view.isLoading = false
+      window.__backgroundSabrStreamsStarted = true
+      await new Promise(resolve => { window.__finishBackgroundSabrStreams = resolve })
+      view.ytDlpStreamsPending = false
+    }
+
+    window.__backgroundSabrRouteChangeStarted = false
+    window.__backgroundSabrRefreshStarted = false
+    window.__backgroundSabrStreamsStarted = false
+    window.__backgroundSabrRefreshPromise = null
+    window.setTimeout(() => {
+      window.__backgroundSabrRefreshPromise = view.onPlayerReloadRequested({ wasPlaying: true })
+    }, 250)
+  })
+
+  try {
+    await historyTabElement.click()
+    await expect(historyTabElement).toHaveClass(/active/)
+    await expect.poll(() => page.evaluate(() => window.__backgroundSabrRouteChangeStarted)).toBe(true)
+    await watchView.evaluate(view => view.handleVideoLoaded({}))
+    await expect(watchContent.locator('.videoLayout')).toHaveAttribute('data-tab-loading-suppressed', '')
+
+    await page.evaluate(() => window.__finishBackgroundSabrRouteChange())
+    await expect.poll(() => page.evaluate(() => window.__backgroundSabrRefreshStarted)).toBe(true)
+    await expect(watchContent.locator('.videoPlayerPlaceholder')).toHaveCount(1)
+    await expect(watchContent.locator('.videoLayout')).toHaveAttribute('data-tab-loading-suppressed', '')
+    await expect(watchContent.locator('[data-tab-loading-indicator]')).not.toHaveCount(0)
+    await expect(watchTab).not.toHaveClass(/loading/)
+
+    await page.evaluate(() => window.__finishBackgroundSabrMetadata())
+    await expect.poll(() => page.evaluate(() => window.__backgroundSabrStreamsStarted)).toBe(true)
+    await expect(watchContent.locator('.streamPlaceholder')).toHaveCount(1)
+    await expect(watchContent.locator('.videoLayout')).toHaveAttribute('data-tab-loading-suppressed', '')
+    await expect(watchContent.locator('[data-tab-loading-indicator]')).not.toHaveCount(0)
+    await expect(watchTab).not.toHaveClass(/loading/)
+
+    await watchView.evaluate(view => { view.suppressTabLoadingIndicator = false })
+    await expect(watchContent.locator('.videoLayout')).not.toHaveAttribute('data-tab-loading-suppressed', '')
+    await page.waitForTimeout(250)
+    await expect(watchContent.locator('[data-tab-loading-indicator]')).not.toHaveCount(0)
+    await expect(watchTab).not.toHaveClass(/loading/)
+
+    await watchView.evaluate(view => { view.videoLoadGeneration++ })
+    await expect(watchTab).toHaveClass(/loading/)
+
+    await page.evaluate(async () => {
+      window.__finishBackgroundSabrStreams()
+      await window.__backgroundSabrRefreshPromise
+    })
+    await expect(watchContent.locator('[data-tab-loading-indicator]')).toHaveCount(0)
+
+    await watchView.evaluate(view => { view.isLoading = true })
+    await expect(watchTab).toHaveClass(/loading/)
+    await watchView.evaluate(view => { view.isLoading = false })
+    await expect(watchTab).not.toHaveClass(/loading/)
+  } finally {
+    await page.evaluate(async () => {
+      window.__finishBackgroundSabrRouteChange?.()
+      window.__finishBackgroundSabrMetadata?.()
+      await new Promise(resolve => window.setTimeout(resolve, 0))
+      window.__finishBackgroundSabrStreams?.()
+      await window.__backgroundSabrRefreshPromise
+    })
+    await watchView.dispose()
+  }
 })
 
 test('a second SABR failure after successful playback refetches instead of dropping to legacy', async ({ app, page }) => {

--- a/src/renderer/components/TabContent/TabContent.vue
+++ b/src/renderer/components/TabContent/TabContent.vue
@@ -44,6 +44,9 @@ import { tabRuntimeRegistry } from '../../tabs/TabRuntimeRegistry'
 import { tabIdKey, tabLifecycleKey, tabPresentedKey } from '../../tabs/TabContext'
 
 const TAB_LOADER_SELECTOR = '[data-tab-loading-indicator]'
+const TAB_LOADER_SUPPRESSION_SELECTOR = '[data-tab-loading-suppressed]'
+const TAB_LOADER_GENERATION_ATTRIBUTE = 'data-tab-loading-generation'
+const TAB_LOADER_GENERATION_SELECTOR = `[${TAB_LOADER_GENERATION_ATTRIBUTE}]`
 const TAB_LOADER_LOADING_SOURCE = 'loader'
 const TAB_LOADER_SETTLE_DELAY_MS = 100
 const CACHED_ROUTE_NAMES = new Set(['about'])
@@ -98,6 +101,9 @@ let removeRootRegistration = null
 let loaderObserver = null
 let loaderAnimationFrameId = null
 let loaderSettleTimeoutId = null
+// A suppression boundary can disappear before its loader does, while Vue can
+// reuse that element for a newer load. Remember both the element and its load.
+const suppressedLoaderGenerations = new WeakMap()
 let acknowledgedMountRevision = 0
 let previousRefreshKey = props.tab.refreshKey ?? 0
 // Guards against notifying `beforeDispose` twice for the same mounted instance:
@@ -191,7 +197,11 @@ onMounted(() => {
     loaderObserver = new MutationObserver(scheduleLoaderUpdate)
     loaderObserver.observe(tabContentRef.value, {
       attributes: true,
-      attributeFilter: ['data-tab-loading-indicator'],
+      attributeFilter: [
+        'data-tab-loading-indicator',
+        'data-tab-loading-suppressed',
+        TAB_LOADER_GENERATION_ATTRIBUTE
+      ],
       childList: true,
       subtree: true
     })
@@ -240,7 +250,7 @@ function scheduleLoaderUpdate() {
 }
 
 function updateLoaderState() {
-  if (tabContentRef.value?.querySelector(TAB_LOADER_SELECTOR) != null) {
+  if (hasUnsuppressedLoader()) {
     cancelLoaderSettle()
     navigation.setLoadingSource(props.tab.id, TAB_LOADER_LOADING_SOURCE, true)
     return
@@ -256,12 +266,33 @@ function updateLoaderState() {
 
 function settleLoaderState() {
   loaderSettleTimeoutId = null
-  if (tabContentRef.value?.querySelector(TAB_LOADER_SELECTOR) != null) {
+  if (hasUnsuppressedLoader()) {
     navigation.setLoadingSource(props.tab.id, TAB_LOADER_LOADING_SOURCE, true)
     return
   }
 
   navigation.setLoadingSource(props.tab.id, TAB_LOADER_LOADING_SOURCE, false)
+}
+
+function hasUnsuppressedLoader() {
+  const root = tabContentRef.value
+  if (!root) return false
+
+  for (const loader of root.querySelectorAll(TAB_LOADER_SELECTOR)) {
+    const generation = loader.closest(TAB_LOADER_GENERATION_SELECTOR)
+      ?.getAttribute(TAB_LOADER_GENERATION_ATTRIBUTE) ?? null
+
+    if (loader.closest(TAB_LOADER_SUPPRESSION_SELECTOR) !== null) {
+      suppressedLoaderGenerations.set(loader, generation)
+    } else if (
+      !suppressedLoaderGenerations.has(loader) ||
+      suppressedLoaderGenerations.get(loader) !== generation
+    ) {
+      return true
+    }
+  }
+
+  return false
 }
 
 function cancelLoaderSettle() {

--- a/src/renderer/views/Watch/Watch.js
+++ b/src/renderer/views/Watch/Watch.js
@@ -203,6 +203,8 @@ export default defineComponent({
       // Same-tab navigation keeps the current layout while its skeleton loads.
       // A newly mounted watch tab falls back to the configured default instead.
       loadingTheatreMode: null,
+      suppressTabLoadingIndicator: false,
+      suppressTabLoadingIndicatorOnNextReload: false,
       applyDefaultTheatreModeAfterLoad: false,
       theatreLayoutAvailable: window.innerWidth > RESPONSIVE_THEATRE_MODE_MAX_WIDTH,
       videoPlayerLoaded: false,
@@ -231,6 +233,7 @@ export default defineComponent({
       shortsCompletionBlockedBySeek: false,
       shortsPlaybackAfterSeekSeconds: 0,
       videoLoadGeneration: 0,
+      preparingVideoLoadGeneration: null,
       hasAiGeneratedContent: false,
       hasPaidPromotion: false,
       paidPromotionDurationMs: 10000,
@@ -1067,6 +1070,12 @@ export default defineComponent({
         }
       }
     },
+    errorMessage(message) {
+      if (message) {
+        this.suppressTabLoadingIndicator = false
+        this.suppressTabLoadingIndicatorOnNextReload = false
+      }
+    },
     isTabPresented: {
       immediate: true,
       handler() {
@@ -1662,44 +1671,53 @@ export default defineComponent({
     },
 
     async reloadView({ preserveTitle = false } = {}) {
+      this.suppressTabLoadingIndicator = this.suppressTabLoadingIndicatorOnNextReload
+      this.suppressTabLoadingIndicatorOnNextReload = false
       const loadGeneration = ++this.videoLoadGeneration
+      this.preparingVideoLoadGeneration = loadGeneration
       const requestedVideoId = this.tabRoute.params.id
       this.loadingTheatreMode = this.useTheatreMode
       preserveTitle ||= this.preserveTitleOnNextReload
       this.preserveTitleOnNextReload = false
 
-      await this.handleRouteChange()
-      if (!this.isCurrentVideoLoad(loadGeneration, requestedVideoId)) { return }
-
-      if (this.$refs.player) {
-        await this.destroyPlayer()
+      try {
+        await this.handleRouteChange()
         if (!this.isCurrentVideoLoad(loadGeneration, requestedVideoId)) { return }
-      }
 
-      // react to route changes...
-      const previousVideoId = this.videoId
-      this.videoId = this.tabRoute.params.id
-      const videoIdChanged = this.videoId !== previousVideoId
-      if (videoIdChanged) {
-        this.ipBlockRecoveryAttemptedForCurrentVideo = false
-        this.streamErrorReloadAttemptedForCurrentVideo = false
-        this.playbackEngineFallbackAttemptedForCurrentVideo = false
-        this.playbackEngineFallbackTarget = null
-        this.ytDlpDefaultClientsFallbackToastShown = false
-        this.sabrErrorRecoveryAttempts = 0
-        this.sabrErrorRecoveriesForCurrentVideo = 0
-        this.sabrErrorRecoveryLastSeconds = null
-        this.sabrErrorRecoveryPlayedSeconds = 0
+        if (this.$refs.player) {
+          await this.destroyPlayer()
+          if (!this.isCurrentVideoLoad(loadGeneration, requestedVideoId)) { return }
+        }
+
+        // react to route changes...
+        const previousVideoId = this.videoId
+        this.videoId = this.tabRoute.params.id
+        const videoIdChanged = this.videoId !== previousVideoId
+        if (videoIdChanged) {
+          this.ipBlockRecoveryAttemptedForCurrentVideo = false
+          this.streamErrorReloadAttemptedForCurrentVideo = false
+          this.playbackEngineFallbackAttemptedForCurrentVideo = false
+          this.playbackEngineFallbackTarget = null
+          this.ytDlpDefaultClientsFallbackToastShown = false
+          this.sabrErrorRecoveryAttempts = 0
+          this.sabrErrorRecoveriesForCurrentVideo = 0
+          this.sabrErrorRecoveryLastSeconds = null
+          this.sabrErrorRecoveryPlayedSeconds = 0
+        }
+        this.ipBlockDetectedInCurrentChain = false
+        const preserveShortsPanels = videoIdChanged &&
+          this.customShortsPlayerActive &&
+          this.tabRoute.query.short === 'true'
+        this.resetVideoState({
+          preserveTitle,
+          placeholderTitle: videoIdChanged ? this.getPendingVideoTitle() : '',
+          preserveShortsPanels,
+        })
+      } finally {
+        if (this.preparingVideoLoadGeneration === loadGeneration) {
+          this.preparingVideoLoadGeneration = null
+        }
       }
-      this.ipBlockDetectedInCurrentChain = false
-      const preserveShortsPanels = videoIdChanged &&
-        this.customShortsPlayerActive &&
-        this.tabRoute.query.short === 'true'
-      this.resetVideoState({
-        preserveTitle,
-        placeholderTitle: videoIdChanged ? this.getPendingVideoTitle() : '',
-        preserveShortsPanels,
-      })
 
       this.firstLoad = true
       this.videoPlayerLoaded = false
@@ -3894,6 +3912,10 @@ export default defineComponent({
     },
 
     handleVideoLoaded: function (mediaMetadata) {
+      if (this.isLoading || this.preparingVideoLoadGeneration !== null) { return }
+
+      this.suppressTabLoadingIndicator = false
+      this.suppressTabLoadingIndicatorOnNextReload = false
       // Only used one time = remove after use
       this.oneTimeTimestamp = null
       this.sabrReloadCaptionIndex = null
@@ -5515,6 +5537,8 @@ export default defineComponent({
       try {
         await this.performSabrReload(payload, toastMessage)
       } catch (error) {
+        this.suppressTabLoadingIndicator = false
+        this.suppressTabLoadingIndicatorOnNextReload = false
         console.error('SABR reload failed', error)
         return false
       }
@@ -5547,6 +5571,7 @@ export default defineComponent({
       this.sabrReloadVideoQuality = this.normalizeVideoQuality(payload?.videoQuality) ||
         this.normalizeVideoQuality(this.currentVideoQuality) || null
       this.preserveTitleOnNextReload = true
+      this.suppressTabLoadingIndicatorOnNextReload = true
       this.showTabToast({ message: toastMessage, icon: ['fas', 'sync'] })
 
       const timestamp = this.getTimestamp()

--- a/src/renderer/views/Watch/Watch.vue
+++ b/src/renderer/views/Watch/Watch.vue
@@ -2,6 +2,8 @@
   <div
     ref="videoLayout"
     class="videoLayout"
+    :data-tab-loading-generation="videoLoadGeneration"
+    :data-tab-loading-suppressed="suppressTabLoadingIndicator ? '' : undefined"
     :class="{
       ambientModeActive,
       isLoading,


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Make sure to follow the contributing guidelines. -->
<!-- Important note, we may remove your pull request if you do not use this provided PR template correctly. -->
<!-- Agent instructions: Preserve every heading, comment, and marker in this template. Never remove or rewrite the release-note-category:start/end, release-note:start/end, or release-note-image:start/end marker pairs. Never remove or rewrite the Release note images section; leave its contents for a human. -->

## Pull Request Type
<!-- Please select what type of pull request this is: [x] -->
- [x] Bugfix
- [ ] Feature Implementation
- [ ] Documentation
- [ ] Other

## Related issue
<!-- Please link the issue your pull request is referring to. -->
<!-- If this pull request fully resolves the relevant issue, put "closes" before the issue number. -->
<!-- Example: "closes #123456". -->

## Description
<!-- Please write a clear and concise description of what the pull request does. -->
Restored Watch tabs can run an internal SABR player refresh after startup. Their player and comments loaders briefly made the tab bar report the whole tab as loading when the user switched away.

This keeps loaders created by that internal refresh out of the tab bar. Suppression is tied to the exact Watch load generation, so a real navigation or newer video load still reports its loading state even when Vue reuses the same loader element.

## Release note category
<!-- Select exactly one category. Every pull request must select one. -->
<!-- Select "Not noteworthy" when the pull request fixes a bug in or improves functionality that has not yet appeared in a stable release. -->
<!-- release-note-category:start -->
- [ ] Not noteworthy
- [ ] Highlights
- [ ] More improvements
- [x] Fixed bugs
<!-- release-note-category:end -->

## Release note
<!-- Required unless "Not noteworthy" is selected. -->
<!-- Write one concise, user-facing entry without a leading bullet. -->
<!-- release-note:start -->
Switching away from a restored video tab no longer briefly shows it as loading.
<!-- release-note:end -->

## Release note images
<!-- Human-only: Agents must preserve this entire section and leave it empty. -->
<!-- Optional. Paste one or more Markdown images or HTML image tags here. -->
<!-- The release notes will use an HTML image tag and limit images taller than 300 pixels. -->
<!-- release-note-image:start -->

<!-- release-note-image:end -->

## Testing
<!-- How can reviewers verify that the PR produces correct results? -->
<!-- Please provide instructions so that others can ensure that your pull request would produce correct results. For examples see, https://github.com/FreeTubeApp/FreeTube/pull/5743, https://github.com/FreeTubeApp/FreeTube/pull/7349, https://github.com/FreeTubeApp/FreeTube/pull/5125, https://github.com/FreeTubeApp/FreeTube/pull/7338 -->
<!-- Agent instructions: Only write human-facing steps that explain how to verify the change while running this branch in dev mode. Include expected results and, when applicable, helpful console snippets for interactive verification. Do not include automated checks, commands, results, pass counts, or CI status. -->
1. Set startup behavior to restore saved tab load states, then leave a Watch tab and a non-Watch tab loaded.
2. Restart the app and wait for the restored tabs to finish loading.
3. Play the video for a few seconds and switch to the other tab several times.
4. Confirm the Watch tab does not briefly show a loading indicator when switching away.
5. Open another video in that tab and confirm its genuine loading indicator still appears.

## Additional context
<!-- Add any other context about the pull request here. -->
The tab loader tracker records both the loader element and the Watch load generation. This handles Vue reusing one DOM element across consecutive loads without letting an older suppression hide a newer load.
