### PR TITLE
fix(search): prevent stale search and hashtag results

### DIFF
--- a/e2e/tests/offline/route-request-generation.spec.mjs
+++ b/e2e/tests/offline/route-request-generation.spec.mjs
@@ -1,0 +1,515 @@
+import { test, expect, sel } from '../../helpers/app.mjs'
+
+test.use({
+  seed: {
+    settings: {
+      backendPreference: 'invidious',
+      backendFallback: true,
+      generalAutoLoadMorePaginatedItemsEnabled: false
+    }
+  }
+})
+
+function invidiousVideo(title, videoId) {
+  return {
+    type: 'video',
+    title,
+    videoId,
+    author: 'OpenTubeX',
+    authorId: 'UC-route-request-test',
+    authorUrl: '/channel/UC-route-request-test',
+    authorVerified: false,
+    videoThumbnails: [],
+    description: '',
+    descriptionHtml: '',
+    viewCount: 1,
+    viewCountText: '1 view',
+    lengthSeconds: 60,
+    published: 1_700_000_000,
+    publishedText: 'Today',
+    premiereTimestamp: 0,
+    liveNow: false,
+    premium: false,
+    isUpcoming: false,
+    hasCaptions: false
+  }
+}
+
+function localHashtagResponse(title, videoId) {
+  return {
+    contents: {
+      singleColumnBrowseResultsRenderer: {
+        tabs: [{
+          tabRenderer: {
+            selected: true,
+            content: {
+              richGridRenderer: {
+                contents: [{
+                  richItemRenderer: {
+                    content: {
+                      videoRenderer: {
+                        videoId,
+                        title: { simpleText: title },
+                        thumbnail: { thumbnails: [] },
+                        ownerText: {
+                          runs: [{
+                            text: 'OpenTubeX',
+                            navigationEndpoint: {
+                              browseEndpoint: { browseId: 'UC-local' }
+                            }
+                          }]
+                        },
+                        lengthText: { simpleText: '1:00' },
+                        viewCountText: { simpleText: '1 view' },
+                        publishedTimeText: { simpleText: '1 day ago' },
+                        thumbnailOverlays: []
+                      }
+                    }
+                  }
+                }]
+              }
+            }
+          }
+        }]
+      }
+    }
+  }
+}
+
+async function settleRenderer(page) {
+  await page.evaluate(() => new Promise(resolve => {
+    requestAnimationFrame(() => requestAnimationFrame(resolve))
+  }))
+}
+
+const defaultSearchSettings = {
+  prioritize: 'relevance',
+  time: '',
+  type: 'all',
+  duration: '',
+  features: []
+}
+
+async function cacheSearch(page, query, title) {
+  await page.evaluate(({ query, result, searchSettings }) => {
+    const store = document.querySelector('#app').__vue_app__.config.globalProperties.$store
+    store.commit('addToSessionSearchHistory', {
+      query,
+      data: [result],
+      searchSettings,
+      nextPageRef: null,
+      hasMoreResults: false,
+      apiUsed: 'local'
+    })
+  }, {
+    query,
+    result: invidiousVideo(title, `${query.replaceAll(' ', '-')}-video`),
+    searchSettings: defaultSearchSettings
+  })
+}
+
+test('clears old search state before rejecting an overlong query', async ({ page }) => {
+  await cacheSearch(page, 'cached search', 'cached search result')
+  await cacheSearch(page, 'recovery search', 'recovery search result')
+
+  await page.locator(sel.searchInput).fill('cached search')
+  await page.locator(sel.searchInput).press('Enter')
+  await expect(page.getByText('cached search result')).toBeVisible()
+
+  const rejectedQuery = 'x'.repeat(101)
+  await page.locator(sel.searchInput).fill(rejectedQuery)
+  await page.locator(sel.searchInput).press('Enter')
+
+  await expect(page.getByText('cached search result')).toHaveCount(0)
+  await expect(page.locator('[data-tab-loading-indicator]')).toHaveCount(0)
+  await expect(page.locator('.ft-auto-load-next-page-wrapper')).toHaveCount(0)
+  await expect(page.locator(sel.activeTab)).toContainText(rejectedQuery)
+
+  await page.locator(sel.searchInput).fill('recovery search')
+  await page.locator(sel.searchInput).press('Enter')
+  await expect(page.getByText('recovery search result')).toBeVisible()
+})
+
+test('settles the loader after an empty defensive search response', async ({ page }) => {
+  await page.route('**/api/v1/search/**', async (route, request) => {
+    const query = new URL(request.url()).searchParams.get('q')
+    await route.fulfill({
+      json: query === 'empty defensive response'
+        ? false
+        : [invidiousVideo(`${query} result`, `${query.replaceAll(' ', '-')}-video`)]
+    })
+  })
+
+  await page.locator(sel.searchInput).fill('empty defensive response')
+  await page.locator(sel.searchInput).press('Enter')
+  await expect(page.getByText('Your search results have returned 0 results')).toBeVisible()
+  await expect(page.locator('[data-tab-loading-indicator]')).toHaveCount(0)
+
+  await page.locator(sel.searchInput).fill('recovery search')
+  await page.locator(sel.searchInput).press('Enter')
+  await expect(page.getByText('recovery search result')).toBeVisible()
+})
+
+test('starts a Local API fallback at page one and replaces old results', async ({ page }) => {
+  const invidiousRequests = []
+  await page.route('**/api/v1/search/**', async (route, request) => {
+    const url = new URL(request.url())
+    const query = url.searchParams.get('q')
+    const requestedPage = Number(url.searchParams.get('page'))
+    invidiousRequests.push({ query, page: requestedPage })
+    await route.fulfill({
+      json: [invidiousVideo(`${query} page ${requestedPage}`, `${query}-${requestedPage}`)]
+    })
+  })
+  await page.route('**/youtubei/v1/search**', route => route.abort())
+
+  await page.locator(sel.searchInput).fill('old search')
+  await page.locator(sel.searchInput).press('Enter')
+  await expect(page.getByText('old search page 1')).toBeVisible()
+
+  await page.locator('.getNextPage').click()
+  await expect(page.getByText('old search page 2')).toBeVisible()
+
+  await page.evaluate(async () => {
+    const store = document.querySelector('#app').__vue_app__.config.globalProperties.$store
+    await store.dispatch('updateBackendPreference', 'local')
+  })
+  await page.locator(sel.searchInput).fill('fallback search')
+  await page.locator(sel.searchInput).press('Enter')
+
+  await expect(page.getByText('fallback search page 1')).toBeVisible()
+  await expect(page.getByText('old search page 1')).toHaveCount(0)
+  await expect(page.getByText('old search page 2')).toHaveCount(0)
+  expect(invidiousRequests.at(-1)).toEqual({ query: 'fallback search', page: 1 })
+})
+
+test('ignores a stale search response after the route changes', async ({ page }) => {
+  let releaseFirstRequest
+  let markFirstRequestStarted
+  const firstRequestStarted = new Promise(resolve => { markFirstRequestStarted = resolve })
+
+  await page.route('**/api/v1/search/**', async (route, request) => {
+    const query = new URL(request.url()).searchParams.get('q')
+    if (query === 'first search') {
+      markFirstRequestStarted()
+      await new Promise(resolve => { releaseFirstRequest = resolve })
+    }
+
+    await route.fulfill({
+      json: [invidiousVideo(`${query} result`, `${query.replaceAll(' ', '-')}-video`)]
+    })
+  })
+
+  await page.locator(sel.searchInput).fill('first search')
+  await page.locator(sel.searchInput).press('Enter')
+  await firstRequestStarted
+
+  await page.locator(sel.searchInput).fill('second search')
+  await page.locator(sel.searchInput).press('Enter')
+  await expect(page.getByText('second search result')).toBeVisible()
+
+  const firstResponseFinished = page.waitForResponse(response =>
+    new URL(response.url()).searchParams.get('q') === 'first search'
+  )
+  releaseFirstRequest()
+  await (await firstResponseFinished).finished()
+  await settleRenderer(page)
+
+  await expect(page.getByText('first search result')).toHaveCount(0)
+  await expect(page.getByText('second search result')).toBeVisible()
+  await expect(page.locator('[data-tab-loading-indicator]')).toHaveCount(0)
+  await expect(page.locator(sel.searchInput)).toHaveValue('second search')
+  expect(await page.evaluate(() => {
+    const store = document.querySelector('#app').__vue_app__.config.globalProperties.$store
+    return {
+      title: store.getters.getActiveTab.contentTitle,
+      cache: store.getters.getSessionSearchHistory.map(entry => ({
+        query: entry.query,
+        titles: entry.data.map(result => result.title),
+        searchPage: entry.searchPage,
+        apiUsed: entry.apiUsed
+      }))
+    }
+  })).toEqual({
+    title: 'second search',
+    cache: [{
+      query: 'second search',
+      titles: ['second search result'],
+      searchPage: 2,
+      apiUsed: 'invidious'
+    }]
+  })
+})
+
+test('keeps the newer search loader when a stale request fails', async ({ page }) => {
+  let releaseFirstRequest
+  let releaseSecondRequest
+  let markFirstRequestStarted
+  let markSecondRequestStarted
+  let localFallbackRequests = 0
+  const firstRequestStarted = new Promise(resolve => { markFirstRequestStarted = resolve })
+  const secondRequestStarted = new Promise(resolve => { markSecondRequestStarted = resolve })
+
+  await page.route('**/youtubei/v1/search**', route => {
+    localFallbackRequests++
+    return route.abort()
+  })
+  await page.route('**/api/v1/search/**', async (route, request) => {
+    const query = new URL(request.url()).searchParams.get('q')
+    if (query === 'stale failure') {
+      markFirstRequestStarted()
+      await new Promise(resolve => { releaseFirstRequest = resolve })
+      await route.fulfill({ status: 500, json: { error: 'stale test failure' } })
+      return
+    }
+    if (query === 'pending search') {
+      markSecondRequestStarted()
+      await new Promise(resolve => { releaseSecondRequest = resolve })
+    }
+    await route.fulfill({
+      json: [invidiousVideo(`${query} result`, `${query.replaceAll(' ', '-')}-video`)]
+    })
+  })
+
+  await page.locator(sel.searchInput).fill('stale failure')
+  await page.locator(sel.searchInput).press('Enter')
+  await firstRequestStarted
+
+  await page.locator(sel.searchInput).fill('pending search')
+  await page.locator(sel.searchInput).press('Enter')
+  await secondRequestStarted
+
+  const firstResponseFinished = page.waitForResponse(response =>
+    new URL(response.url()).searchParams.get('q') === 'stale failure'
+  )
+  try {
+    releaseFirstRequest()
+    await (await firstResponseFinished).finished()
+    await settleRenderer(page)
+
+    await expect(page.locator('.fullscreen[data-tab-loading-indicator]')).toBeVisible()
+    await expect(page.getByText('Falling back to Local API')).toHaveCount(0)
+    expect(localFallbackRequests).toBe(0)
+    expect(await page.evaluate(() => {
+      const store = document.querySelector('#app').__vue_app__.config.globalProperties.$store
+      return store.getters.getActiveTab.contentTitle
+    })).toBe('pending search')
+  } finally {
+    releaseSecondRequest?.()
+  }
+
+  await expect(page.getByText('pending search result')).toBeVisible()
+  await expect(page.locator('[data-tab-loading-indicator]')).toHaveCount(0)
+})
+
+test('keeps the newer search pagination loader when an old page settles', async ({ page }) => {
+  let releaseFirstPage
+  let releaseSecondPage
+  let markFirstPageStarted
+  let markSecondPageStarted
+  const firstPageStarted = new Promise(resolve => { markFirstPageStarted = resolve })
+  const secondPageStarted = new Promise(resolve => { markSecondPageStarted = resolve })
+
+  await page.route('**/api/v1/search/**', async (route, request) => {
+    const url = new URL(request.url())
+    const query = url.searchParams.get('q')
+    const requestedPage = Number(url.searchParams.get('page'))
+    if (query === 'first pages' && requestedPage === 2) {
+      markFirstPageStarted()
+      await new Promise(resolve => { releaseFirstPage = resolve })
+    } else if (query === 'second pages' && requestedPage === 2) {
+      markSecondPageStarted()
+      await new Promise(resolve => { releaseSecondPage = resolve })
+    }
+    await route.fulfill({
+      json: [invidiousVideo(`${query} page ${requestedPage}`, `${query}-${requestedPage}`)]
+    })
+  })
+
+  await page.locator(sel.searchInput).fill('first pages')
+  await page.locator(sel.searchInput).press('Enter')
+  await expect(page.getByText('first pages page 1')).toBeVisible()
+  await page.locator('.getNextPage').click()
+  await firstPageStarted
+
+  await page.locator(sel.searchInput).fill('second pages')
+  await page.locator(sel.searchInput).press('Enter')
+  await expect(page.getByText('second pages page 1')).toBeVisible()
+  await page.locator('.getNextPage').click()
+  await secondPageStarted
+  await expect(page.getByLabel('Loading more')).toBeVisible()
+
+  const firstResponseFinished = page.waitForResponse(response => {
+    const url = new URL(response.url())
+    return url.searchParams.get('q') === 'first pages' && url.searchParams.get('page') === '2'
+  })
+  try {
+    releaseFirstPage()
+    await (await firstResponseFinished).finished()
+    await settleRenderer(page)
+
+    await expect(page.getByLabel('Loading more')).toBeVisible()
+    await expect(page.getByText('first pages page 2')).toHaveCount(0)
+    await expect(page.getByText('second pages page 1')).toBeVisible()
+  } finally {
+    releaseSecondPage?.()
+  }
+
+  await expect(page.getByText('second pages page 2')).toBeVisible()
+  await expect(page.getByLabel('Loading more')).toHaveCount(0)
+})
+
+test('ignores a stale hashtag response after the route changes', async ({ page }) => {
+  let releaseFirstRequest
+  let markFirstRequestStarted
+  const firstRequestStarted = new Promise(resolve => { markFirstRequestStarted = resolve })
+
+  await page.route('**/api/v1/hashtag/**', async (route, request) => {
+    const hashtag = new URL(request.url()).pathname.split('/').filter(Boolean).at(-1)
+    if (hashtag === 'first-tag') {
+      markFirstRequestStarted()
+      await new Promise(resolve => { releaseFirstRequest = resolve })
+    }
+
+    await route.fulfill({
+      json: { results: [invidiousVideo(`${hashtag} result`, `${hashtag}-video`)] }
+    })
+  })
+
+  await page.locator(sel.searchInput).fill('https://www.youtube.com/hashtag/first-tag')
+  await page.locator(sel.searchInput).press('Enter')
+  await firstRequestStarted
+
+  await page.locator(sel.searchInput).fill('https://www.youtube.com/hashtag/second-tag')
+  await page.locator(sel.searchInput).press('Enter')
+  await expect(page.getByText('second-tag result')).toBeVisible()
+
+  const firstResponseFinished = page.waitForResponse(response =>
+    new URL(response.url()).pathname.endsWith('/first-tag')
+  )
+  releaseFirstRequest()
+  await (await firstResponseFinished).finished()
+  await settleRenderer(page)
+
+  await expect(page.getByText('first-tag result')).toHaveCount(0)
+  await expect(page.getByText('second-tag result')).toBeVisible()
+  await expect(page.locator('[data-tab-loading-indicator]')).toHaveCount(0)
+  expect(await page.evaluate(() => {
+    const store = document.querySelector('#app').__vue_app__.config.globalProperties.$store
+    return store.getters.getActiveTab.contentTitle
+  })).toBe('#second-tag')
+})
+
+test('ignores a stale Local API hashtag response after the route changes', async ({ page }) => {
+  let releaseFirstRequest
+  let markFirstRequestStarted
+  let hashtagRequestCount = 0
+  const firstRequestStarted = new Promise(resolve => { markFirstRequestStarted = resolve })
+
+  await page.route('**/youtubei/v1/browse**', async (route, request) => {
+    if (request.postDataJSON()?.browseId !== 'FEhashtag') {
+      await route.abort()
+      return
+    }
+
+    hashtagRequestCount++
+    const isFirstRequest = hashtagRequestCount === 1
+    if (isFirstRequest) {
+      markFirstRequestStarted()
+      await new Promise(resolve => { releaseFirstRequest = resolve })
+    }
+
+    await route.fulfill({
+      json: localHashtagResponse(
+        isFirstRequest ? 'first local result' : 'second local result',
+        isFirstRequest ? 'first-local-video' : 'second-local-video'
+      )
+    })
+  })
+  await page.evaluate(async () => {
+    const store = document.querySelector('#app').__vue_app__.config.globalProperties.$store
+    await store.dispatch('updateBackendPreference', 'local')
+  })
+
+  await page.locator(sel.searchInput).fill('https://www.youtube.com/hashtag/first-local')
+  await page.locator(sel.searchInput).press('Enter')
+  await firstRequestStarted
+
+  await page.locator(sel.searchInput).fill('https://www.youtube.com/hashtag/second-local')
+  await page.locator(sel.searchInput).press('Enter')
+  await expect(page.getByText('second local result')).toBeVisible()
+
+  const firstResponseFinished = page.waitForResponse(response =>
+    response.url().includes('/youtubei/v1/browse')
+  )
+  releaseFirstRequest()
+  await (await firstResponseFinished).finished()
+  await settleRenderer(page)
+
+  await expect(page.getByText('first local result')).toHaveCount(0)
+  await expect(page.getByText('second local result')).toBeVisible()
+  await expect(page.locator('[data-tab-loading-indicator]')).toHaveCount(0)
+  expect(await page.evaluate(() => {
+    const store = document.querySelector('#app').__vue_app__.config.globalProperties.$store
+    return store.getters.getActiveTab.contentTitle
+  })).toBe('#second-local')
+})
+
+test('keeps the newer hashtag pagination loader when an old page settles', async ({ page }) => {
+  let releaseFirstPage
+  let releaseSecondPage
+  let markFirstPageStarted
+  let markSecondPageStarted
+  const firstPageStarted = new Promise(resolve => { markFirstPageStarted = resolve })
+  const secondPageStarted = new Promise(resolve => { markSecondPageStarted = resolve })
+
+  await page.route('**/api/v1/hashtag/**', async (route, request) => {
+    const url = new URL(request.url())
+    const hashtag = url.pathname.split('/').filter(Boolean).at(-1)
+    const requestedPage = Number(url.searchParams.get('page'))
+    if (hashtag === 'first-pages' && requestedPage === 2) {
+      markFirstPageStarted()
+      await new Promise(resolve => { releaseFirstPage = resolve })
+    } else if (hashtag === 'second-pages' && requestedPage === 2) {
+      markSecondPageStarted()
+      await new Promise(resolve => { releaseSecondPage = resolve })
+    }
+    await route.fulfill({
+      json: {
+        results: [invidiousVideo(`${hashtag} page ${requestedPage}`, `${hashtag}-${requestedPage}`)]
+      }
+    })
+  })
+
+  await page.locator(sel.searchInput).fill('https://www.youtube.com/hashtag/first-pages')
+  await page.locator(sel.searchInput).press('Enter')
+  await expect(page.getByText('first-pages page 1')).toBeVisible()
+  await page.locator('.getNextPage').click()
+  await firstPageStarted
+
+  await page.locator(sel.searchInput).fill('https://www.youtube.com/hashtag/second-pages')
+  await page.locator(sel.searchInput).press('Enter')
+  await expect(page.getByText('second-pages page 1')).toBeVisible()
+  await page.locator('.getNextPage').click()
+  await secondPageStarted
+  await expect(page.getByLabel('Loading more')).toBeVisible()
+
+  const firstResponseFinished = page.waitForResponse(response => {
+    const url = new URL(response.url())
+    return url.pathname.endsWith('/first-pages') && url.searchParams.get('page') === '2'
+  })
+  try {
+    releaseFirstPage()
+    await (await firstResponseFinished).finished()
+    await settleRenderer(page)
+
+    await expect(page.getByLabel('Loading more')).toBeVisible()
+    await expect(page.getByText('first-pages page 2')).toHaveCount(0)
+    await expect(page.getByText('second-pages page 1')).toBeVisible()
+  } finally {
+    releaseSecondPage?.()
+  }
+
+  await expect(page.getByText('second-pages page 2')).toBeVisible()
+  await expect(page.getByLabel('Loading more')).toHaveCount(0)
+})

--- a/e2e/tests/offline/route-request-generation.spec.mjs
+++ b/e2e/tests/offline/route-request-generation.spec.mjs
@@ -359,6 +359,37 @@ test('keeps the newer search pagination loader when an old page settles', async 
   await expect(page.getByLabel('Loading more')).toHaveCount(0)
 })
 
+test('does not start an empty search while leaving the search route', async ({ page }) => {
+  let releaseSearch
+  let markSearchStarted
+  const searchStarted = new Promise(resolve => { markSearchStarted = resolve })
+  const requestedQueries = []
+
+  await page.route('**/api/v1/search/**', async (route, request) => {
+    const query = new URL(request.url()).searchParams.get('q')
+    requestedQueries.push(query)
+    if (query === 'leaving search') {
+      markSearchStarted()
+      await new Promise(resolve => { releaseSearch = resolve })
+    }
+    await route.fulfill({
+      json: [invidiousVideo(`${query} result`, `${query || 'empty'}-video`)]
+    })
+  })
+
+  await page.locator(sel.searchInput).fill('leaving search')
+  await page.locator(sel.searchInput).press('Enter')
+  await searchStarted
+
+  try {
+    await page.locator(`${sel.sideNavLink('history')}:visible`).first().click()
+    await expect(page).toHaveURL(/#\/history/)
+    expect(requestedQueries).toEqual(['leaving search'])
+  } finally {
+    releaseSearch?.()
+  }
+})
+
 test('ignores a stale hashtag response after the route changes', async ({ page }) => {
   let releaseFirstRequest
   let markFirstRequestStarted

--- a/src/renderer/views/Hashtag/Hashtag.vue
+++ b/src/renderer/views/Hashtag/Hashtag.vue
@@ -56,7 +56,7 @@
   </div>
 </template>
 <script setup>
-import { computed, onMounted, ref, shallowRef, watch } from 'vue'
+import { computed, onBeforeUnmount, onMounted, ref, shallowRef, watch } from 'vue'
 import { FtIcon } from '@opentubex/icons'
 import FtCard from '../../components/ft-card/ft-card.vue'
 import FtElementList from '../../components/FtElementList/FtElementList.vue'
@@ -84,6 +84,7 @@ const pageNumber = ref(1)
 const isLoading = ref(true)
 const isLoadingMore = ref(false)
 const hasMoreResults = ref(false)
+let requestGeneration = 0
 
 /** @type {import('vue').ComputedRef<'local' | 'invidious'>} */
 const backendPreference = computed(() => {
@@ -95,18 +96,17 @@ const backendFallback = computed(() => {
   return store.getters.getBackendFallback
 })
 
-onMounted(() => {
-  getHashtag()
-})
+onMounted(startHashtagRequest)
+watch(() => route.params.hashtag, startHashtagRequest)
+onBeforeUnmount(() => { requestGeneration++ })
 
-watch(() => route.params.hashtag, () => {
-  resetData()
-  getHashtag()
-})
+function isCurrentRequest(request) {
+  return request.generation === requestGeneration
+}
 
-function resetData() {
+function resetData(hashtagValue) {
   isLoading.value = true
-  hashtag.value = ''
+  hashtag.value = hashtagValue
   hashtagContinuationData.value = null
   videos.value = []
   apiUsed.value = 'local'
@@ -115,82 +115,128 @@ function resetData() {
   hasMoreResults.value = false
 }
 
-async function getHashtag() {
+function startHashtagRequest() {
   // Hashtag pages only exist in lowercase, querying them with the casing used in
   // a video description (e.g. `#ShiorinSketch`) returns no videos at all
-  hashtag.value = decodeURIComponent(route.params.hashtag).toLowerCase()
-  if (process.env.SUPPORTS_LOCAL_API && backendPreference.value === 'local') {
-    await getLocalHashtag()
-  } else {
-    await getInvidiousHashtag()
+  const request = {
+    generation: ++requestGeneration,
+    hashtag: decodeURIComponent(route.params.hashtag).toLowerCase()
   }
-  setTabTitle(`#${hashtag.value}`)
+  resetData(request.hashtag)
+  getHashtag(request)
+}
+
+async function getHashtag(request) {
+  if (process.env.SUPPORTS_LOCAL_API && backendPreference.value === 'local') {
+    await getLocalHashtag(request)
+  } else {
+    await getInvidiousHashtag(request)
+  }
+  if (isCurrentRequest(request)) {
+    setTabTitle(`#${request.hashtag}`)
+  }
 }
 
 /**
+ * @param {{generation: number, hashtag: string}} request
  * @param {number} page
  */
-async function getInvidiousHashtag(page = 1) {
+async function getInvidiousHashtag(request, page = 1) {
+  if (!isCurrentRequest(request)) {
+    return
+  }
+
   try {
-    const fetchedVideos = await getHashtagInvidious(hashtag.value, page)
-    isLoading.value = false
+    const fetchedVideos = await getHashtagInvidious(request.hashtag, page)
+    if (!isCurrentRequest(request)) {
+      return
+    }
     apiUsed.value = 'invidious'
     videos.value = videos.value.concat(fetchedVideos)
     hasMoreResults.value = fetchedVideos.length > 0
-    pageNumber.value += 1
+    pageNumber.value = page + 1
   } catch (error) {
+    if (!isCurrentRequest(request)) {
+      return
+    }
     console.error(error)
     const errorMessage = t('Invidious API Error (Click to copy)')
     showApiErrorToast(errorMessage, error)
     if (process.env.SUPPORTS_LOCAL_API && backendPreference.value === 'invidious' && backendFallback.value) {
       showToast({ message: t('Falling back to Local API'), icon: ['fas', 'exchange-alt'] })
-      resetData()
-      getLocalHashtag()
-    } else {
+      resetData(request.hashtag)
+      await getLocalHashtag(request)
+    }
+  } finally {
+    if (isCurrentRequest(request) && page === 1) {
       isLoading.value = false
     }
   }
 }
 
-async function getLocalHashtag() {
+async function getLocalHashtag(request) {
+  if (!isCurrentRequest(request)) {
+    return
+  }
+
   try {
-    const hashtagData = await getHashtagLocal(hashtag.value)
+    const hashtagData = await getHashtagLocal(request.hashtag)
+    if (!isCurrentRequest(request)) {
+      return
+    }
     videos.value = hashtagData.videos.map((video) => parseLocalListVideo(video)).filter(_ => _)
     apiUsed.value = 'local'
     hashtagContinuationData.value = hashtagData.has_continuation ? hashtagData : null
     hasMoreResults.value = hashtagContinuationData.value !== null
-    isLoading.value = false
   } catch (error) {
+    if (!isCurrentRequest(request)) {
+      return
+    }
     console.error(error)
     const errorMessage = t('Local API Error (Click to copy)')
     showApiErrorToast(errorMessage, error)
     if (backendPreference.value === 'local' && backendFallback.value) {
       showToast({ message: t('Falling back to Invidious API'), icon: ['fas', 'exchange-alt'] })
-      resetData()
-      getInvidiousHashtag()
-    } else {
+      resetData(request.hashtag)
+      await getInvidiousHashtag(request)
+    }
+  } finally {
+    if (isCurrentRequest(request)) {
       isLoading.value = false
     }
   }
 }
 
-async function getLocalHashtagMore() {
+async function getLocalHashtagMore(request) {
+  if (!isCurrentRequest(request)) {
+    return
+  }
+
+  const continuationData = hashtagContinuationData.value
+  if (continuationData === null) {
+    return
+  }
+
   try {
-    const continuation = await hashtagContinuationData.value.getContinuation()
+    const continuation = await continuationData.getContinuation()
+    if (!isCurrentRequest(request)) {
+      return
+    }
     const newVideos = continuation.videos.map((video) => parseLocalListVideo(video)).filter(_ => _)
     hashtagContinuationData.value = continuation.has_continuation ? continuation : null
     hasMoreResults.value = hashtagContinuationData.value !== null
     videos.value = videos.value.concat(newVideos)
   } catch (error) {
+    if (!isCurrentRequest(request)) {
+      return
+    }
     console.error(error)
     const errorMessage = t('Local API Error (Click to copy)')
     showApiErrorToast(errorMessage, error)
     if (backendPreference.value === 'local' && backendFallback.value) {
       showToast({ message: t('Falling back to Invidious API'), icon: ['fas', 'exchange-alt'] })
-      resetData()
-      getInvidiousHashtag()
-    } else {
-      isLoading.value = false
+      resetData(request.hashtag)
+      await getInvidiousHashtag(request)
     }
   }
 }
@@ -199,16 +245,25 @@ async function handleFetchMore() {
   if (isLoadingMore.value) {
     return
   }
+  const request = {
+    generation: requestGeneration,
+    hashtag: hashtag.value
+  }
+  if (!isCurrentRequest(request)) {
+    return
+  }
 
   isLoadingMore.value = true
   try {
     if (process.env.SUPPORTS_LOCAL_API && apiUsed.value === 'local') {
-      await getLocalHashtagMore()
+      await getLocalHashtagMore(request)
     } else if (apiUsed.value === 'invidious') {
-      await getInvidiousHashtag(pageNumber.value)
+      await getInvidiousHashtag(request, pageNumber.value)
     }
   } finally {
-    isLoadingMore.value = false
+    if (isCurrentRequest(request)) {
+      isLoadingMore.value = false
+    }
   }
 }
 </script>

--- a/src/renderer/views/SearchPage/SearchPage.vue
+++ b/src/renderer/views/SearchPage/SearchPage.vue
@@ -161,9 +161,14 @@ function resetSearchState(settings) {
 }
 
 function startSearch() {
+  if (typeof route.params.query !== 'string') {
+    requestGeneration++
+    return
+  }
+
   const routeSearchSettings = getRouteSearchSettings()
   const payload = {
-    query: String(route.params.query ?? '').trim(),
+    query: route.params.query.trim(),
     options: {},
     searchSettings: routeSearchSettings
   }

--- a/src/renderer/views/SearchPage/SearchPage.vue
+++ b/src/renderer/views/SearchPage/SearchPage.vue
@@ -46,7 +46,7 @@
 
 <script setup>
 import { FtIcon } from '@opentubex/icons'
-import { computed, onMounted, ref, shallowRef, watch } from 'vue'
+import { computed, onBeforeUnmount, onMounted, ref, shallowRef, watch } from 'vue'
 import { useI18n } from 'vue-i18n'
 import { useRoute } from 'vue-router'
 
@@ -86,6 +86,7 @@ const searchPage = ref(1)
 /** @type {import('vue').ShallowRef<import('youtubei.js').YT.Search | string | null>} */
 const nextPageRef = shallowRef(null)
 const shownResults = shallowRef([])
+let requestGeneration = 0
 
 const query = ref('')
 const processedQuery = computed(() => query.value.trim())
@@ -140,56 +141,70 @@ function getRouteSearchSettings() {
   }
 }
 
-watch(route, () => {
-  const query_ = route.params.query.trim()
-  const searchSettings = getRouteSearchSettings()
+watch(route, startSearch, { deep: true })
+onMounted(startSearch)
+onBeforeUnmount(() => { requestGeneration++ })
 
+function isCurrentRequest(generation) {
+  return generation === requestGeneration
+}
+
+function resetSearchState(settings) {
+  isLoading.value = false
+  isLoadingMore.value = false
+  hasMoreResults.value = false
+  apiUsed.value = backendPreference.value
+  searchSettings.value = settings
+  searchPage.value = 1
+  nextPageRef.value = null
+  shownResults.value = []
+}
+
+function startSearch() {
+  const routeSearchSettings = getRouteSearchSettings()
   const payload = {
-    query: query_,
+    query: String(route.params.query ?? '').trim(),
     options: {},
-    searchSettings: searchSettings
+    searchSettings: routeSearchSettings
+  }
+  const generation = ++requestGeneration
+
+  resetSearchState(routeSearchSettings)
+  query.value = payload.query
+  restoreActiveSearchFilters(routeSearchSettings)
+
+  if (!isCurrentRequest(generation)) {
+    return
+  }
+  setTabTitle(payload.query)
+  checkSearchCache(payload, generation)
+}
+
+function updateSearchHistoryEntry(payload, generation) {
+  if (!isCurrentRequest(generation)) {
+    return
   }
 
-  query.value = query_
-  restoreActiveSearchFilters(searchSettings)
-
-  setTabTitle(processedQuery.value)
-  checkSearchCache(payload)
-}, { deep: true })
-
-onMounted(() => {
-  query.value = route.params.query
-  setTabTitle(processedQuery.value)
-
-  searchSettings.value = getRouteSearchSettings()
-  restoreActiveSearchFilters(searchSettings.value)
-
-  const payload = {
-    query: processedQuery.value,
-    options: {},
-    searchSettings: searchSettings.value
-  }
-
-  checkSearchCache(payload)
-})
-
-function updateSearchHistoryEntry(searchSettings) {
   const persistentSearchHistoryPayload = {
-    _id: processedQuery.value,
+    _id: payload.query,
     lastUpdatedAt: Date.now(),
     searchSettings: {
-      prioritize: searchSettings.prioritize,
-      time: searchSettings.time,
-      type: searchSettings.type,
-      duration: searchSettings.duration,
-      features: [...searchSettings.features]
+      prioritize: payload.searchSettings.prioritize,
+      time: payload.searchSettings.time,
+      type: payload.searchSettings.type,
+      duration: payload.searchSettings.duration,
+      features: [...payload.searchSettings.features]
     }
   }
 
   store.dispatch('updateSearchHistoryEntry', persistentSearchHistoryPayload)
 }
 
-function checkSearchCache(payload) {
+function checkSearchCache(payload, generation) {
+  if (!isCurrentRequest(generation)) {
+    return
+  }
+
   if (payload.query.length > SEARCH_CHAR_LIMIT) {
     console.warn(`Search character limit is: ${SEARCH_CHAR_LIMIT}`)
     showToast({
@@ -205,7 +220,7 @@ function checkSearchCache(payload) {
 
   if (sameSearch.length > 0) {
     // No loading effect needed here, only rendered result update
-    replaceShownResults(sameSearch[0])
+    replaceShownResults(sameSearch[0], generation)
   } else {
     // Show loading effect coz there will be network request(s)
     isLoading.value = true
@@ -214,20 +229,23 @@ function checkSearchCache(payload) {
 
     switch (backendPreference.value) {
       case 'local':
-        performSearchLocal(payload)
+        performSearchLocal(payload, generation)
         break
       case 'invidious':
-        performSearchInvidious(payload, { resetSearchPage: true })
+        performSearchInvidious(payload, generation, { resetSearchPage: true })
         break
     }
   }
 
   if (rememberSearchHistory.value) {
-    updateSearchHistoryEntry(payload.searchSettings)
+    updateSearchHistoryEntry(payload, generation)
   }
 }
 
-async function performSearchLocal(payload) {
+async function performSearchLocal(payload, generation) {
+  if (!isCurrentRequest(generation)) {
+    return
+  }
   isLoading.value = true
 
   try {
@@ -236,6 +254,9 @@ async function performSearchLocal(payload) {
       payload.searchSettings,
       showFamilyFriendlyOnly.value
     )
+    if (!isCurrentRequest(generation)) {
+      return
+    }
 
     apiUsed.value = 'local'
 
@@ -243,12 +264,10 @@ async function performSearchLocal(payload) {
     nextPageRef.value = continuationData
     hasMoreResults.value = results.length > 0 && continuationData != null
 
-    isLoading.value = false
-
     const historyPayload = {
       query: payload.query,
       data: shownResults.value,
-      searchSettings: searchSettings.value,
+      searchSettings: payload.searchSettings,
       nextPageRef: nextPageRef.value ? extractLocalCacheableSearchContinuation(nextPageRef.value) : null,
       hasMoreResults: hasMoreResults.value,
       apiUsed: apiUsed.value
@@ -258,6 +277,9 @@ async function performSearchLocal(payload) {
 
     updateSubscriptionDetails(results)
   } catch (err) {
+    if (!isCurrentRequest(generation)) {
+      return
+    }
     console.error(err)
 
     const errorMessage = t('Local API Error (Click to copy)')
@@ -265,16 +287,22 @@ async function performSearchLocal(payload) {
 
     if (backendPreference.value === 'local' && backendFallback.value) {
       showToast({ message: t('Falling back to Invidious API'), icon: ['fas', 'exchange-alt'] })
-      await performSearchInvidious(payload)
-    } else {
+      resetSearchState(payload.searchSettings)
+      await performSearchInvidious(payload, generation, { resetSearchPage: true })
+    }
+  } finally {
+    if (isCurrentRequest(generation)) {
       isLoading.value = false
     }
   }
 }
 
-async function getNextpageLocal(payload) {
+async function getNextpageLocal(payload, generation) {
   try {
     const { results, continuationData } = await getLocalSearchContinuation(payload.options.nextPageRef)
+    if (!isCurrentRequest(generation)) {
+      return
+    }
 
     nextPageRef.value = continuationData
     hasMoreResults.value = results.length > 0 && continuationData != null
@@ -285,7 +313,7 @@ async function getNextpageLocal(payload) {
     const historyPayload = {
       query: payload.query,
       data: shownResults.value,
-      searchSettings: searchSettings.value,
+      searchSettings: payload.searchSettings,
       nextPageRef: nextPageRef.value ? extractLocalCacheableSearchContinuation(nextPageRef.value) : null,
       hasMoreResults: hasMoreResults.value,
       apiUsed: apiUsed.value
@@ -295,6 +323,9 @@ async function getNextpageLocal(payload) {
 
     updateSubscriptionDetails(results)
   } catch (err) {
+    if (!isCurrentRequest(generation)) {
+      return
+    }
     console.error(err)
 
     const errorMessage = t('Local API Error (Click to copy)')
@@ -302,25 +333,33 @@ async function getNextpageLocal(payload) {
 
     if (backendPreference.value === 'local' && backendFallback.value) {
       showToast({ message: t('Falling back to Invidious API'), icon: ['fas', 'exchange-alt'] })
-      await performSearchInvidious(payload)
-    } else {
-      isLoading.value = false
+      resetSearchState(payload.searchSettings)
+      await performSearchInvidious(payload, generation, { resetSearchPage: true })
     }
   }
 }
 
-async function performSearchInvidious(payload, options = { resetSearchPage: false }) {
-  if (options.resetSearchPage) {
-    searchPage.value = 1
+async function performSearchInvidious(payload, generation, { resetSearchPage = false } = {}) {
+  if (!isCurrentRequest(generation)) {
+    return
   }
 
-  if (searchPage.value === 1) {
+  const requestedPage = resetSearchPage ? 1 : searchPage.value
+  if (resetSearchPage) {
+    searchPage.value = requestedPage
+  }
+
+  if (requestedPage === 1) {
     isLoading.value = true
   }
 
   try {
-    const results = await getInvidiousSearchResults(payload.query, searchPage.value, payload.searchSettings)
+    const results = await getInvidiousSearchResults(payload.query, requestedPage, payload.searchSettings)
+    if (!isCurrentRequest(generation)) {
+      return
+    }
     if (!results) {
+      hasMoreResults.value = false
       return
     }
 
@@ -328,20 +367,18 @@ async function performSearchInvidious(payload, options = { resetSearchPage: fals
 
     apiUsed.value = 'invidious'
 
-    if (searchPage.value !== 1) {
+    if (requestedPage !== 1) {
       shownResults.value = shownResults.value.concat(results)
     } else {
       shownResults.value = results
     }
 
-    isLoading.value = false
-
-    searchPage.value++
+    searchPage.value = requestedPage + 1
 
     const historyPayload = {
       query: payload.query,
       data: shownResults.value,
-      searchSettings: searchSettings.value,
+      searchSettings: payload.searchSettings,
       searchPage: searchPage.value,
       hasMoreResults: hasMoreResults.value,
       apiUsed: apiUsed.value
@@ -351,6 +388,9 @@ async function performSearchInvidious(payload, options = { resetSearchPage: fals
 
     updateSubscriptionDetails(results)
   } catch (err) {
+    if (!isCurrentRequest(generation)) {
+      return
+    }
     console.error(err)
 
     const errorMessage = t('Invidious API Error (Click to copy)')
@@ -358,16 +398,22 @@ async function performSearchInvidious(payload, options = { resetSearchPage: fals
 
     if (process.env.SUPPORTS_LOCAL_API && backendPreference.value === 'invidious' && backendFallback.value) {
       showToast({ message: t('Falling back to Local API'), icon: ['fas', 'exchange-alt'] })
-      await performSearchLocal(payload)
-    } else {
+      resetSearchState(payload.searchSettings)
+      await performSearchLocal(payload, generation)
+    }
+  } finally {
+    if (isCurrentRequest(generation) && requestedPage === 1) {
       isLoading.value = false
-      // TODO: Show toast with error message
     }
   }
 }
 
 async function nextPage() {
   if (isLoadingMore.value) {
+    return
+  }
+  const generation = requestGeneration
+  if (!isCurrentRequest(generation)) {
     return
   }
 
@@ -383,9 +429,11 @@ async function nextPage() {
     if (nextPageRef.value !== null) {
       isLoadingMore.value = true
       try {
-        await getNextpageLocal(payload)
+        await getNextpageLocal(payload, generation)
       } finally {
-        isLoadingMore.value = false
+        if (isCurrentRequest(generation)) {
+          isLoadingMore.value = false
+        }
       }
     } else {
       showToast({ message: t('Search Filters.There are no more results for this search'), icon: ['fas', 'search'] })
@@ -393,14 +441,19 @@ async function nextPage() {
   } else {
     isLoadingMore.value = true
     try {
-      await performSearchInvidious(payload)
+      await performSearchInvidious(payload, generation)
     } finally {
-      isLoadingMore.value = false
+      if (isCurrentRequest(generation)) {
+        isLoadingMore.value = false
+      }
     }
   }
 }
 
-function replaceShownResults(history) {
+function replaceShownResults(history, generation) {
+  if (!isCurrentRequest(generation)) {
+    return
+  }
   query.value = history.query
   shownResults.value = history.data
   searchSettings.value = history.searchSettings
@@ -410,12 +463,10 @@ function replaceShownResults(history) {
     history.apiUsed === 'local' ? nextPageRef.value !== null : true
   )
 
-  if (typeof (history.searchPage) !== 'undefined') {
-    searchPage.value = history.searchPage
-  }
+  searchPage.value = history.searchPage ?? 1
 
-  // This is kept in case there is some race condition
   isLoading.value = false
+  isLoadingMore.value = false
 }
 
 /**


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Make sure to follow the contributing guidelines. -->
<!-- Important note, we may remove your pull request if you do not use this provided PR template correctly. -->
<!-- Agent instructions: Preserve every heading, comment, and marker in this template. Never remove or rewrite the release-note-category:start/end, release-note:start/end, or release-note-image:start/end marker pairs. Never remove or rewrite the Release note images section; leave its contents for a human. -->

## Pull Request Type
<!-- Please select what type of pull request this is: [x] -->
- [x] Bugfix
- [ ] Feature Implementation
- [ ] Documentation
- [ ] Other

## Related issue
<!-- Please link the issue your pull request is referring to. -->
<!-- If this pull request fully resolves the relevant issue, put "closes" before the issue number. -->
<!-- Example: "closes #123456". -->

Closes #868. Closes #870.

## Description
<!-- Please write a clear and concise description of what the pull request does. -->

Search and hashtag requests could finish after their route was superseded and overwrite the newer route's results, cache, title, pagination, or loading state. Search validation and backend fallback also retained state from earlier searches.

This tracks each routed load with a monotonic generation and ignores late success, failure, fallback, pagination, cache, title, and loader updates. Search state now resets before validation or cache lookup, and backend fallbacks restart at page one with the original route key.

## Release note category
<!-- Select exactly one category. Every pull request must select one. -->
<!-- Select "Not noteworthy" when the pull request fixes a bug in or improves functionality that has not yet appeared in a stable release. -->
<!-- release-note-category:start -->
- [x] Not noteworthy
- [ ] Highlights
- [ ] More improvements
- [ ] Fixed bugs
<!-- release-note-category:end -->

## Release note
<!-- Required unless "Not noteworthy" is selected. -->
<!-- Write one concise, user-facing entry without a leading bullet. -->
<!-- release-note:start -->

<!-- release-note:end -->

## Release note images
<!-- Human-only: Agents must preserve this entire section and leave it empty. -->
<!-- Optional. Paste one or more Markdown images or HTML image tags here. -->
<!-- The release notes will use an HTML image tag and limit images taller than 300 pixels. -->
<!-- release-note-image:start -->

<!-- release-note-image:end -->

## Testing
<!-- How can reviewers verify that the PR produces correct results? -->
<!-- Please provide instructions so that others can ensure that your pull request would produce correct results. For examples see, https://github.com/FreeTubeApp/FreeTube/pull/5743, https://github.com/FreeTubeApp/FreeTube/pull/7349, https://github.com/FreeTubeApp/FreeTube/pull/5125, https://github.com/FreeTubeApp/FreeTube/pull/7338 -->
<!-- Agent instructions: Only write human-facing steps that explain how to verify the change while running this branch in dev mode. Include expected results and, when applicable, helpful console snippets for interactive verification. Do not include automated checks, commands, results, pass counts, or CI status. -->

1. With Invidious selected, start a slow search and immediately route the same tab to a second query. Let the second query finish first. Its results, title, pagination, and loader state should remain unchanged when the first request completes.
2. Repeat the route race between two hashtag pages with Invidious and Local API. Only the second hashtag's videos and title should remain.
3. From a completed search, enter a query longer than 100 characters. The validation toast should appear, old results and pagination should clear, and a later valid search in the same tab should load normally.
4. Paginate an Invidious search, switch to Local API with fallback enabled, and make the next Local search fail. The Invidious fallback should request page one for the new query and replace the old results.

## Additional context
<!-- Add any other context about the pull request here. -->

Request generations keep this local to the two views. The API helpers do not consistently accept `AbortSignal`, so cancellation would require a wider change without improving the state ownership checks.
