### PR TITLE
fix(playlists): recover loading and pagination failures

### DIFF
--- a/e2e/tests/offline/playlist-loading.spec.mjs
+++ b/e2e/tests/offline/playlist-loading.spec.mjs
@@ -1,0 +1,119 @@
+import { test, expect } from '../../helpers/app.mjs'
+
+test.use({
+  seed: {
+    settings: {
+      backendPreference: 'invidious',
+      backendFallback: false,
+      defaultInvidiousInstance: 'https://invidious.test',
+      generalAutoLoadMorePaginatedItemsEnabled: true
+    }
+  }
+})
+
+function playlistVideo(index, videoId = `video-${String(index).padStart(5, '0')}`) {
+  return {
+    type: 'video',
+    title: `Playlist video ${index + 1}`,
+    videoId,
+    author: 'Playlist channel',
+    authorId: 'UCplaylistchannel',
+    authorUrl: '/channel/UCplaylistchannel',
+    videoThumbnails: [],
+    index,
+    lengthSeconds: 60,
+    liveNow: false
+  }
+}
+
+function playlistResponse(videos, videoCount = videos.length) {
+  return {
+    type: 'playlist',
+    title: 'Pagination test playlist',
+    playlistId: 'pagination-test',
+    author: 'Playlist channel',
+    authorId: 'UCplaylistchannel',
+    authorThumbnails: [
+      { url: 'https://yt3.ggpht.com/test=s32' },
+      { url: 'https://yt3.ggpht.com/test=s48' },
+      { url: 'https://yt3.ggpht.com/test=s76' }
+    ],
+    description: '',
+    descriptionHtml: '',
+    videoCount,
+    viewCount: 1,
+    updated: 1_700_000_000,
+    videos
+  }
+}
+
+async function openPlaylistTab(page, route) {
+  const tab = await page.evaluate((playlistRoute) => window.ftElectron.tabs.create({
+    route: playlistRoute,
+    makeActive: false
+  }), route)
+  await page.locator(`.tab[data-tab-id="${tab.id}"]`).click()
+  await expect(page).toHaveURL(/#\/playlist\//)
+}
+
+test('settles a missing user playlist into a persistent not-found state', async ({ page }) => {
+  await openPlaylistTab(page, '/playlist/missing-playlist?playlistType=user')
+
+  const playlistPage = page.locator('.playlistPage')
+  await expect(playlistPage.getByText('This playlist does not exist', { exact: true })).toBeVisible()
+  await expect(playlistPage.locator('[data-tab-loading-indicator]')).toHaveCount(0)
+})
+
+test('shows a persistent initial error and retries without navigation', async ({ page }) => {
+  let requestCount = 0
+  await page.route(/\/api\/v1\/playlists\/initial-retry\?/, async (route) => {
+    requestCount++
+    if (requestCount === 1) {
+      await route.fulfill({ status: 500, json: { error: 'Synthetic initial failure' } })
+    } else {
+      await route.fulfill({ json: playlistResponse([playlistVideo(0)]) })
+    }
+  })
+
+  await openPlaylistTab(page, '/playlist/initial-retry')
+
+  const playlistPage = page.locator('.playlistPage')
+  await expect(playlistPage.getByText('This playlist could not be loaded.', { exact: true })).toBeVisible()
+  await playlistPage.getByRole('button', { name: 'Retry', exact: true }).click()
+
+  await expect(playlistPage.getByText('Playlist video 1', { exact: true })).toBeVisible()
+  expect(requestCount).toBe(2)
+})
+
+test('retries the failed Invidious page and merges its overlapping videos once', async ({ page }) => {
+  const requestedPages = []
+  await page.route(/\/api\/v1\/playlists\/pagination-test\?/, async (route) => {
+    const pageNumber = new URL(route.request().url()).searchParams.get('page')
+    if (pageNumber === null) {
+      await route.fulfill({ json: playlistResponse([playlistVideo(0), playlistVideo(1)], 150) })
+      return
+    }
+
+    requestedPages.push(pageNumber)
+    if (requestedPages.length === 1) {
+      await route.fulfill({ status: 500, json: { error: 'Synthetic continuation failure' } })
+      return
+    }
+
+    await route.fulfill({
+      json: playlistResponse([playlistVideo(1), playlistVideo(2), playlistVideo(3)], 150)
+    })
+  })
+
+  await openPlaylistTab(page, '/playlist/pagination-test')
+  const playlistPage = page.locator('.playlistPage')
+  await expect(playlistPage.getByText('Playlist video 1', { exact: true })).toBeVisible()
+
+  await expect(playlistPage.getByText('More videos could not be loaded.', { exact: true })).toBeVisible()
+  await playlistPage.getByRole('button', { name: 'Retry', exact: true }).click()
+
+  await expect(playlistPage.getByText('Playlist video 4', { exact: true })).toBeVisible()
+  await expect(playlistPage.getByText('Playlist video 2', { exact: true })).toHaveCount(1)
+  await expect(playlistPage.locator('.ft-auto-load-next-page-wrapper')).toHaveCount(0)
+  expect(requestedPages).toEqual(['2', '2'])
+})

--- a/e2e/tests/offline/playlist-loading.spec.mjs
+++ b/e2e/tests/offline/playlist-loading.spec.mjs
@@ -1,4 +1,4 @@
-import { test, expect } from '../../helpers/app.mjs'
+import { test, expect, sel } from '../../helpers/app.mjs'
 
 test.use({
   seed: {
@@ -116,4 +116,69 @@ test('retries the failed Invidious page and merges its overlapping videos once',
   await expect(playlistPage.getByText('Playlist video 2', { exact: true })).toHaveCount(1)
   await expect(playlistPage.locator('.ft-auto-load-next-page-wrapper')).toHaveCount(0)
   expect(requestedPages).toEqual(['2', '2'])
+})
+
+test('uses the first playable video found on a later Invidious page', async ({ page }) => {
+  await page.route(/\/api\/v1\/playlists\/later-playable\?/, async (route) => {
+    const pageNumber = new URL(route.request().url()).searchParams.get('page')
+    if (pageNumber === null) {
+      await route.fulfill({
+        json: playlistResponse([{
+          ...playlistVideo(0),
+          title: '',
+          author: '',
+          authorId: null
+        }], 150)
+      })
+      return
+    }
+
+    await route.fulfill({ json: playlistResponse([playlistVideo(1)], 150) })
+  })
+
+  await openPlaylistTab(page, '/playlist/later-playable')
+  const playlistPage = page.locator('.playlistPage')
+  await expect(playlistPage.getByText('Playlist video 2', { exact: true })).toBeVisible()
+  await expect(playlistPage.locator('.playlistThumbnail a')).toHaveAttribute('href', /\/watch\/video-00001/)
+})
+
+test('ignores an Invidious continuation that finishes after playlist navigation', async ({ page }) => {
+  let markContinuationStarted
+  const continuationStarted = new Promise((resolve) => { markContinuationStarted = resolve })
+  let releaseContinuation
+  const continuationRelease = new Promise((resolve) => { releaseContinuation = resolve })
+  let markContinuationFinished
+  const continuationFinished = new Promise((resolve) => { markContinuationFinished = resolve })
+
+  await page.route(/\/api\/v1\/playlists\/(stale-source|fresh-target)\?/, async (route) => {
+    const requestUrl = new URL(route.request().url())
+    const pageNumber = requestUrl.searchParams.get('page')
+
+    if (requestUrl.pathname.endsWith('/stale-source') && pageNumber !== null) {
+      markContinuationStarted()
+      await continuationRelease
+      await route.fulfill({ json: playlistResponse([playlistVideo(99)], 150) })
+      markContinuationFinished()
+      return
+    }
+
+    const videos = requestUrl.pathname.endsWith('/stale-source')
+      ? [playlistVideo(0)]
+      : [playlistVideo(49)]
+    const count = requestUrl.pathname.endsWith('/stale-source') ? 150 : 1
+    await route.fulfill({ json: playlistResponse(videos, count) })
+  })
+
+  await openPlaylistTab(page, '/playlist/stale-source')
+  await continuationStarted
+
+  await page.locator(sel.searchInput).fill('https://www.youtube.com/playlist?list=fresh-target')
+  await page.locator(sel.searchInput).press('Enter')
+  await expect(page).toHaveURL(/#\/playlist\/fresh-target/)
+  await expect(page.locator('.playlistPage').getByText('Playlist video 50', { exact: true })).toBeVisible()
+
+  releaseContinuation()
+  await continuationFinished
+  await page.waitForTimeout(100)
+  await expect(page.locator('.playlistPage').getByText('Playlist video 100', { exact: true })).toHaveCount(0)
 })

--- a/src/renderer/helpers/api/invidious-playlists.js
+++ b/src/renderer/helpers/api/invidious-playlists.js
@@ -10,3 +10,49 @@ export function filterUnavailableInvidiousPlaylistVideos(videos) {
     video.authorId == null
   ))
 }
+
+function getInvidiousPlaylistVideoIdentity(video) {
+  if (Number.isInteger(video.index) && video.index >= 0) {
+    return `index:${video.index}:video:${video.videoId ?? ''}`
+  }
+
+  if (typeof video.videoId === 'string' && video.videoId !== '') {
+    return `video:${video.videoId}`
+  }
+
+  return null
+}
+
+/**
+ * Invidious playlist pages overlap, so append only entries that have not
+ * already appeared. Playlist position remains part of the identity because a
+ * playlist can intentionally contain the same video more than once.
+ * @param {object[]} currentVideos
+ * @param {object[]} nextVideos
+ */
+export function mergeInvidiousPlaylistVideos(currentVideos, nextVideos) {
+  const identities = new Set(currentVideos.map(getInvidiousPlaylistVideoIdentity).filter(Boolean))
+
+  return currentVideos.concat(nextVideos.filter((video) => {
+    const identity = getInvidiousPlaylistVideoIdentity(video)
+    if (identity == null) return true
+    if (identities.has(identity)) return false
+
+    identities.add(identity)
+    return true
+  }))
+}
+
+/**
+ * Invidious currently advances playlist pages by at least 100 positions even
+ * though responses may overlap and may contain up to 200 entries.
+ * @param {number} videoCount
+ * @param {number} loadedPage
+ * @param {number} loadedVideoCount
+ * @param {number} responseVideoCount count before unavailable entries are filtered
+ */
+export function hasMoreInvidiousPlaylistPages(videoCount, loadedPage, loadedVideoCount, responseVideoCount) {
+  return responseVideoCount > 0 &&
+    loadedVideoCount < videoCount &&
+    loadedPage * 100 < videoCount
+}

--- a/src/renderer/helpers/api/invidious.js
+++ b/src/renderer/helpers/api/invidious.js
@@ -292,6 +292,7 @@ export async function searchInvidiousChannel(channelId, query, page) {
 
 /**
  * @param {string} playlistId
+ * @param {number} [page]
  * @returns {Promise<{
  *  title: string,
  *  playlistId: string,
@@ -312,15 +313,18 @@ export async function searchInvidiousChannel(channelId, query, page) {
  *    videoThumbnails: InvidiousThumbnailObject[],
  *    index: number,
  *    lengthSeconds: number
- *  }[]
+ *  }[],
+ *  pageVideoCount: number
  * }>}
  */
-export async function invidiousGetPlaylistInfo(playlistId) {
+export async function invidiousGetPlaylistInfo(playlistId, page) {
   const playlist = await invidiousAPICall({
     resource: 'playlists',
     id: playlistId,
+    params: page == null ? {} : { page },
   })
 
+  playlist.pageVideoCount = playlist.videos.length
   playlist.videos = filterUnavailableInvidiousPlaylistVideos(playlist.videos)
   normalizeManyInvidiousVideosAttributes(playlist.videos)
   setMultiplePublishedTimestamps(playlist.videos)

--- a/src/renderer/helpers/playlist-pagination.js
+++ b/src/renderer/helpers/playlist-pagination.js
@@ -1,0 +1,23 @@
+/**
+ * Runs one retryable playlist request while keeping its loading and error
+ * states paired on every control-flow path.
+ * @template T
+ * @param {object} options
+ * @param {() => Promise<T>} options.request
+ * @param {(loading: boolean) => void} options.setLoading
+ * @param {(error: unknown | null) => void} options.setError
+ * @returns {Promise<{ ok: true, value: T } | { ok: false, error: unknown }>}
+ */
+export async function runRetryablePlaylistRequest({ request, setLoading, setError }) {
+  setLoading(true)
+  setError(null)
+
+  try {
+    return { ok: true, value: await request() }
+  } catch (error) {
+    setError(error)
+    return { ok: false, error }
+  } finally {
+    setLoading(false)
+  }
+}

--- a/src/renderer/views/Playlist/Playlist.scss
+++ b/src/renderer/views/Playlist/Playlist.scss
@@ -155,3 +155,16 @@
 .message {
   color: var(--tertiary-text-color);
 }
+
+.playlistErrorState {
+  margin: auto;
+}
+
+.errorStateContent {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 12px;
+  padding: 20px;
+  text-align: center;
+}

--- a/src/renderer/views/Playlist/Playlist.vue
+++ b/src/renderer/views/Playlist/Playlist.vue
@@ -12,8 +12,25 @@
       v-if="isLoading"
       :fullscreen="true"
     />
+    <FtFlexBox
+      v-else-if="playlistError"
+      class="playlistErrorState"
+    >
+      <div class="errorStateContent">
+        <p class="message">
+          {{ playlistError }}
+        </p>
+        <FtButton
+          v-if="playlistErrorRetryable"
+          :label="t('User Playlists.SinglePlaylistView.Retry')"
+          background-color="var(--primary-color)"
+          text-color="var(--text-with-main-color)"
+          @click="getPlaylistInfo"
+        />
+      </div>
+    </FtFlexBox>
     <div
-      v-if="!isLoading"
+      v-if="!isLoading && !playlistError"
       class="playlistInfoContainer"
       :class="{
         promptOpen,
@@ -52,11 +69,11 @@
     </div>
 
     <FtCard
-      v-if="!isLoading"
+      v-if="!isLoading && !playlistError"
       class="playlistItemsCard"
     >
       <template
-        v-if="shownPlaylistItems.length > 0"
+        v-if="shownPlaylistItems.length > 0 || moreVideoDataAvailable"
       >
         <FtSelect
           v-if="isUserPlaylistRequested && shownPlaylistItems.length > 1"
@@ -137,33 +154,49 @@
               @remove-from-playlist="removeVideoFromPlaylist"
             />
           </TransitionGroup>
-          <FtAutoLoadNextPageWrapper
-            v-if="moreVideoDataAvailable && !isLoadingMore"
-            @load-next-page="getNextPage"
-          >
-            <FtFlexBox>
-              <FtButton
-                :label="t('Subscriptions.Load More Videos')"
-                background-color="var(--primary-color)"
-                text-color="var(--text-with-main-color)"
-                @click="getNextPage"
-              />
-            </FtFlexBox>
-          </FtAutoLoadNextPageWrapper>
-          <div
-            v-if="isLoadingMore"
-            class="loadNextPageWrapper"
-          >
-            <FtLoader />
-          </div>
         </AutoScrollWrapper>
         <FtFlexBox
-          v-else
+          v-else-if="playlistInVideoSearchMode"
         >
           <p class="message">
             {{ t("User Playlists['Empty Search Message']") }}
           </p>
         </FtFlexBox>
+        <FtFlexBox
+          v-if="nextPageError && moreVideoDataAvailable && !isLoadingMore"
+          class="paginationErrorState"
+        >
+          <div class="errorStateContent">
+            <p class="message">
+              {{ nextPageError }}
+            </p>
+            <FtButton
+              :label="t('User Playlists.SinglePlaylistView.Retry')"
+              background-color="var(--primary-color)"
+              text-color="var(--text-with-main-color)"
+              @click="getNextPage"
+            />
+          </div>
+        </FtFlexBox>
+        <FtAutoLoadNextPageWrapper
+          v-else-if="moreVideoDataAvailable && !isLoadingMore"
+          @load-next-page="getNextPage"
+        >
+          <FtFlexBox>
+            <FtButton
+              :label="t('Subscriptions.Load More Videos')"
+              background-color="var(--primary-color)"
+              text-color="var(--text-with-main-color)"
+              @click="getNextPage"
+            />
+          </FtFlexBox>
+        </FtAutoLoadNextPageWrapper>
+        <div
+          v-if="isLoadingMore"
+          class="loadNextPageWrapper"
+        >
+          <FtLoader />
+        </div>
       </template>
       <FtFlexBox
         v-else
@@ -210,6 +243,8 @@ import {
   throttle,
 } from '../../helpers/utils'
 import { invidiousGetPlaylistInfo, youtubeImageUrlToInvidious } from '../../helpers/api/invidious'
+import { hasMoreInvidiousPlaylistPages, mergeInvidiousPlaylistVideos } from '../../helpers/api/invidious-playlists'
+import { runRetryablePlaylistRequest } from '../../helpers/playlist-pagination'
 import { fillMissingPlaylistVideoDurations, getSortedPlaylistItems, SORT_BY_VALUES } from '../../helpers/playlists'
 import { MOBILE_WIDTH_THRESHOLD, PLAYLIST_HEIGHT_FORCE_LIST_THRESHOLD } from '../../../constants'
 import { useTabContext, useTabLifecycle, useTabTitle } from '../../tabs/TabContext'
@@ -224,6 +259,8 @@ const setTabTitle = useTabTitle()
 const showTabToast = useTabToast()
 
 const isLoading = ref(true)
+const playlistError = ref('')
+const playlistErrorRetryable = ref(false)
 const playlistTitle = ref('')
 const playlistDescription = ref('')
 const firstVideoId = ref('')
@@ -247,7 +284,10 @@ const draggedVideo = ref({ videoId: null, playlistItemId: null })
 const userPlaylistVisibleLimit = ref(100)
 /** @type {import('vue').ShallowRef<import('youtubei.js').YT.Playlist | null>} */
 const continuationData = shallowRef(null)
+/** @type {import('vue').Ref<number | null>} */
+const nextInvidiousPlaylistPage = ref(null)
 const isLoadingMore = ref(false)
+const nextPageError = ref('')
 const playlistInEditMode = ref(false)
 const forceListView = ref(false)
 let alreadyShownNotice = false
@@ -308,9 +348,13 @@ const selectedUserPlaylistVideos = computed(() => selectedUserPlaylist.value?.vi
 const selectedUserPlaylistVideoCount = computed(() => selectedUserPlaylistVideos.value.length)
 
 const moreVideoDataAvailable = computed(() => {
-  return isUserPlaylistRequested.value
-    ? userPlaylistVisibleLimit.value < sometimesFilteredUserPlaylistItems.value.length
-    : continuationData.value !== null
+  if (isUserPlaylistRequested.value) {
+    return userPlaylistVisibleLimit.value < sometimesFilteredUserPlaylistItems.value.length
+  }
+  if (infoSource.value === 'invidious') {
+    return nextInvidiousPlaylistPage.value !== null
+  }
+  return continuationData.value !== null
 })
 
 const processedVideoSearchQuery = computed(() => videoSearchQuery.value.trim().toLowerCase())
@@ -446,6 +490,9 @@ const shownVideoCount = computed(() => isUserPlaylistRequested.value ? shownPlay
 
 function getPlaylistInfo() {
   isLoading.value = true
+  playlistError.value = ''
+  playlistErrorRetryable.value = false
+  nextPageError.value = ''
 
   if (isUserPlaylistRequested.value) {
     if (!userPlaylistsReady.value) { return }
@@ -453,6 +500,8 @@ function getPlaylistInfo() {
     if (selectedUserPlaylist.value != null) {
       parseUserPlaylist(selectedUserPlaylist.value)
     } else {
+      isLoading.value = false
+      playlistError.value = t('User Playlists.SinglePlaylistView.Toast.This playlist does not exist')
       showTabToast({
         message: t('User Playlists.SinglePlaylistView.Toast.This playlist does not exist'),
         icon: ['fas', 'circle-exclamation'],
@@ -460,9 +509,9 @@ function getPlaylistInfo() {
     }
   } else {
     if (!process.env.SUPPORTS_LOCAL_API || backendPreference.value === 'invidious') {
-      getPlaylistInvidious()
+      return getPlaylistInvidious()
     } else {
-      getPlaylistLocal()
+      return getPlaylistLocal()
     }
   }
 }
@@ -484,6 +533,11 @@ function resetState() {
   infoSource.value = 'local'
   playlistItems.value = []
   continuationData.value = null
+  nextInvidiousPlaylistPage.value = null
+  isLoadingMore.value = false
+  nextPageError.value = ''
+  playlistError.value = ''
+  playlistErrorRetryable.value = false
   fetchedLocalPlaylistItemCount = 0
 }
 
@@ -547,9 +601,11 @@ async function getPlaylistLocal() {
 
     if (backendPreference.value === 'local' && backendFallback.value) {
       console.warn('Falling back to Invidious API')
-      getPlaylistInvidious()
+      return getPlaylistInvidious()
     } else {
       isLoading.value = false
+      playlistError.value = t("User Playlists.SinglePlaylistView['This playlist could not be loaded.']")
+      playlistErrorRetryable.value = true
     }
   }
 }
@@ -578,6 +634,15 @@ async function getPlaylistInvidious() {
     lastUpdated.value = dateString.toLocaleDateString(locale.value, { year: 'numeric', month: 'short', day: 'numeric' })
 
     playlistItems.value = result.videos
+    const hasMorePages = hasMoreInvidiousPlaylistPages(
+      result.videoCount,
+      1,
+      result.videos.length,
+      result.pageVideoCount
+    )
+    nextInvidiousPlaylistPage.value = hasMorePages
+      ? 2
+      : null
 
     updatePageTitle()
 
@@ -587,10 +652,11 @@ async function getPlaylistInvidious() {
 
     if (process.env.SUPPORTS_LOCAL_API && backendPreference.value === 'invidious' && backendFallback.value) {
       console.warn('Error getting data with Invidious, falling back to local backend')
-      getPlaylistLocal()
+      return getPlaylistLocal()
     } else {
       isLoading.value = false
-      // TODO: Show toast with error message
+      playlistError.value = t("User Playlists.SinglePlaylistView['This playlist could not be loaded.']")
+      playlistErrorRetryable.value = true
     }
   }
 }
@@ -685,9 +751,11 @@ function getPlaylistItemsWithDuration() {
   return modifiedPlaylistItems
 }
 
-function getNextPage() {
+async function getNextPage() {
+  if (isLoadingMore.value) return
+
   if (process.env.SUPPORTS_LOCAL_API && infoSource.value === 'local') {
-    getNextPageLocal()
+    return await getNextPageLocal()
   } else if (infoSource.value === 'user') {
     // Stop users from spamming the load more button, by replacing it with a loading symbol until the newly added items are renderered
     isLoadingMore.value = true
@@ -702,40 +770,81 @@ function getNextPage() {
       isLoadingMore.value = false
     })
   } else if (infoSource.value === 'invidious') {
-    console.error('Playlist pagination is not currently supported when the Invidious backend is selected.')
+    return await getNextPageInvidious()
   }
 }
 
 async function getNextPageLocal() {
-  isLoadingMore.value = true
+  if (isLoadingMore.value || continuationData.value == null) return
 
-  const result = await getLocalPlaylistContinuation(continuationData.value)
+  await runRetryablePlaylistRequest({
+    request: async () => {
+      let shouldGetNextPage
+      do {
+        shouldGetNextPage = false
+        const result = await getLocalPlaylistContinuation(continuationData.value)
 
-  let shouldGetNextPage = false
+        if (result) {
+          const parsedVideos = parseLocalPlaylistVideos(result.items)
+          fetchedLocalPlaylistItemCount += result.items.length
+          playlistItems.value = playlistItems.value.concat(parsedVideos)
 
-  if (result) {
-    const parsedVideos = parseLocalPlaylistVideos(result.items)
-    fetchedLocalPlaylistItemCount += result.items.length
-    playlistItems.value = playlistItems.value.concat(parsedVideos)
+          if (result.has_continuation) {
+            continuationData.value = result
 
-    if (result.has_continuation) {
-      continuationData.value = result
+            // Keep crossing pages that contain filtered entries until this page is
+            // full or every advertised playlist item has been fetched.
+            shouldGetNextPage = parsedVideos.length < 100 && fetchedLocalPlaylistItemCount < videoCount.value
+          } else {
+            continuationData.value = null
+          }
+        } else {
+          continuationData.value = null
+        }
+      } while (shouldGetNextPage)
+    },
+    setLoading: loading => { isLoadingMore.value = loading },
+    setError: (error) => {
+      if (error == null) {
+        nextPageError.value = ''
+      } else {
+        console.error(error)
+        nextPageError.value = t("User Playlists.SinglePlaylistView['More videos could not be loaded.']")
+      }
+    },
+  })
+}
 
-      // Keep crossing pages that contain filtered entries until this page is
-      // full or every advertised playlist item has been fetched.
-      shouldGetNextPage = parsedVideos.length < 100 && fetchedLocalPlaylistItemCount < videoCount.value
-    } else {
-      continuationData.value = null
-    }
-  } else {
-    continuationData.value = null
-  }
+async function getNextPageInvidious() {
+  if (isLoadingMore.value || nextInvidiousPlaylistPage.value == null) return
 
-  isLoadingMore.value = false
+  const requestedPage = nextInvidiousPlaylistPage.value
 
-  if (shouldGetNextPage) {
-    getNextPageLocal()
-  }
+  await runRetryablePlaylistRequest({
+    request: async () => {
+      const result = await invidiousGetPlaylistInfo(playlistId.value, requestedPage)
+      const mergedVideos = mergeInvidiousPlaylistVideos(playlistItems.value, result.videos)
+      playlistItems.value = mergedVideos
+      const hasMorePages = hasMoreInvidiousPlaylistPages(
+        videoCount.value,
+        requestedPage,
+        mergedVideos.length,
+        result.pageVideoCount
+      )
+      nextInvidiousPlaylistPage.value = hasMorePages
+        ? requestedPage + 1
+        : null
+    },
+    setLoading: loading => { isLoadingMore.value = loading },
+    setError: (error) => {
+      if (error == null) {
+        nextPageError.value = ''
+      } else {
+        console.error(error)
+        nextPageError.value = t("User Playlists.SinglePlaylistView['More videos could not be loaded.']")
+      }
+    },
+  })
 }
 
 const canMoveVideos = computed(() => {

--- a/src/renderer/views/Playlist/Playlist.vue
+++ b/src/renderer/views/Playlist/Playlist.vue
@@ -292,6 +292,7 @@ const playlistInEditMode = ref(false)
 const forceListView = ref(false)
 let alreadyShownNotice = false
 let fetchedLocalPlaylistItemCount = 0
+let playlistRequestGeneration = 0
 const videoSearchQuery = ref('')
 const promptOpen = ref(false)
 /** @type {import('vue').Ref<string[]>} */
@@ -519,6 +520,7 @@ function getPlaylistInfo() {
 const getPlaylistInfoDebounce = debounce(getPlaylistInfo, 100)
 
 function resetState() {
+  playlistRequestGeneration++
   isLoading.value = true
   playlistTitle.value = ''
   playlistDescription.value = ''
@@ -777,12 +779,17 @@ async function getNextPage() {
 async function getNextPageLocal() {
   if (isLoadingMore.value || continuationData.value == null) return
 
+  const requestGeneration = playlistRequestGeneration
+  const requestedPlaylistId = playlistId.value
+  const requestIsCurrent = () => requestGeneration === playlistRequestGeneration && requestedPlaylistId === playlistId.value
+
   await runRetryablePlaylistRequest({
     request: async () => {
       let shouldGetNextPage
       do {
         shouldGetNextPage = false
         const result = await getLocalPlaylistContinuation(continuationData.value)
+        if (!requestIsCurrent()) return
 
         if (result) {
           const parsedVideos = parseLocalPlaylistVideos(result.items)
@@ -803,8 +810,14 @@ async function getNextPageLocal() {
         }
       } while (shouldGetNextPage)
     },
-    setLoading: loading => { isLoadingMore.value = loading },
+    setLoading: (loading) => {
+      if (requestIsCurrent()) {
+        isLoadingMore.value = loading
+      }
+    },
     setError: (error) => {
+      if (!requestIsCurrent()) return
+
       if (error == null) {
         nextPageError.value = ''
       } else {
@@ -818,13 +831,19 @@ async function getNextPageLocal() {
 async function getNextPageInvidious() {
   if (isLoadingMore.value || nextInvidiousPlaylistPage.value == null) return
 
+  const requestGeneration = playlistRequestGeneration
+  const requestedPlaylistId = playlistId.value
   const requestedPage = nextInvidiousPlaylistPage.value
+  const requestIsCurrent = () => requestGeneration === playlistRequestGeneration && requestedPlaylistId === playlistId.value
 
   await runRetryablePlaylistRequest({
     request: async () => {
-      const result = await invidiousGetPlaylistInfo(playlistId.value, requestedPage)
+      const result = await invidiousGetPlaylistInfo(requestedPlaylistId, requestedPage)
+      if (!requestIsCurrent()) return
+
       const mergedVideos = mergeInvidiousPlaylistVideos(playlistItems.value, result.videos)
       playlistItems.value = mergedVideos
+      firstVideoId.value ||= mergedVideos[0]?.videoId ?? ''
       const hasMorePages = hasMoreInvidiousPlaylistPages(
         videoCount.value,
         requestedPage,
@@ -835,8 +854,14 @@ async function getNextPageInvidious() {
         ? requestedPage + 1
         : null
     },
-    setLoading: loading => { isLoadingMore.value = loading },
+    setLoading: (loading) => {
+      if (requestIsCurrent()) {
+        isLoadingMore.value = loading
+      }
+    },
     setError: (error) => {
+      if (!requestIsCurrent()) return
+
       if (error == null) {
         nextPageError.value = ''
       } else {
@@ -1260,6 +1285,7 @@ onMounted(() => {
 })
 
 onBeforeUnmount(() => {
+  playlistRequestGeneration++
   window.removeEventListener('resize', handleResize)
 })
 

--- a/static/locales/en-US.yaml
+++ b/static/locales/en-US.yaml
@@ -317,6 +317,9 @@ User Playlists:
     EarliestPlayedFirst: 'Date Played (Oldest)'
   SinglePlaylistView:
     Search for Videos: Search for Videos
+    Retry: Retry
+    This playlist could not be loaded.: This playlist could not be loaded.
+    More videos could not be loaded.: More videos could not be loaded.
 
     Toast:
       This video cannot be moved up.: This video cannot be moved up.

--- a/tests/unit/invidious-playlists.test.mjs
+++ b/tests/unit/invidious-playlists.test.mjs
@@ -1,7 +1,11 @@
 import assert from 'node:assert/strict'
 import test from 'node:test'
 
-import { filterUnavailableInvidiousPlaylistVideos } from '../../src/renderer/helpers/api/invidious-playlists.js'
+import {
+  filterUnavailableInvidiousPlaylistVideos,
+  hasMoreInvidiousPlaylistPages,
+  mergeInvidiousPlaylistVideos,
+} from '../../src/renderer/helpers/api/invidious-playlists.js'
 
 test('filters unavailable Invidious playlist videos', () => {
   const available = {
@@ -31,4 +35,41 @@ test('keeps playlist videos when any identifying metadata is present', () => {
   ]
 
   assert.deepEqual(filterUnavailableInvidiousPlaylistVideos(videos), videos)
+})
+
+test('merges overlapping Invidious playlist pages by playlist position', () => {
+  const firstPage = [
+    { index: 0, videoId: 'same-video', title: 'First occurrence' },
+    { index: 1, videoId: 'other-video', title: 'Existing item' },
+  ]
+  const nextPage = [
+    { index: 1, videoId: 'other-video', title: 'Overlapping item' },
+    { index: 2, videoId: 'same-video', title: 'Second occurrence' },
+  ]
+
+  assert.deepEqual(mergeInvidiousPlaylistVideos(firstPage, nextPage), [
+    firstPage[0],
+    firstPage[1],
+    nextPage[1],
+  ])
+})
+
+test('falls back to video IDs when a playlist response omits positions', () => {
+  const firstPage = [{ videoId: 'first-video' }]
+
+  assert.deepEqual(mergeInvidiousPlaylistVideos(firstPage, [
+    { videoId: 'first-video' },
+    { videoId: 'second-video' },
+  ]), [
+    firstPage[0],
+    { videoId: 'second-video' },
+  ])
+})
+
+test('bounds later pages by the Invidious page stride', () => {
+  assert.equal(hasMoreInvidiousPlaylistPages(250, 1, 200, 200), true)
+  assert.equal(hasMoreInvidiousPlaylistPages(250, 2, 250, 200), false)
+  assert.equal(hasMoreInvidiousPlaylistPages(250, 3, 200, 200), false)
+  assert.equal(hasMoreInvidiousPlaylistPages(300, 1, 0, 100), true)
+  assert.equal(hasMoreInvidiousPlaylistPages(300, 1, 100, 0), false)
 })

--- a/tests/unit/playlist-pagination.test.mjs
+++ b/tests/unit/playlist-pagination.test.mjs
@@ -1,0 +1,35 @@
+import assert from 'node:assert/strict'
+import test from 'node:test'
+
+import { runRetryablePlaylistRequest } from '../../src/renderer/helpers/playlist-pagination.js'
+
+test('clears playlist pagination loading after failure and retries the same page', async () => {
+  const requestedPages = []
+  const loadingStates = []
+  const errors = []
+  let nextPage = 2
+
+  const runRequest = () => runRetryablePlaylistRequest({
+    request: async () => {
+      requestedPages.push(nextPage)
+      if (requestedPages.length === 1) throw new Error('Synthetic pagination failure')
+      nextPage++
+    },
+    setLoading: loading => loadingStates.push(loading),
+    setError: error => errors.push(error),
+  })
+
+  const failed = await runRequest()
+  assert.equal(failed.ok, false)
+  assert.equal(nextPage, 2)
+  assert.deepEqual(loadingStates, [true, false])
+  assert.equal(errors[0], null)
+  assert.match(errors[1].message, /Synthetic pagination failure/)
+
+  const retried = await runRequest()
+  assert.equal(retried.ok, true)
+  assert.equal(nextPage, 3)
+  assert.deepEqual(requestedPages, [2, 2])
+  assert.deepEqual(loadingStates, [true, false, true, false])
+  assert.equal(errors[2], null)
+})


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Make sure to follow the contributing guidelines. -->
<!-- Important note, we may remove your pull request if you do not use this provided PR template correctly. -->
<!-- Agent instructions: Preserve every heading, comment, and marker in this template. Never remove or rewrite the release-note-category:start/end, release-note:start/end, or release-note-image:start/end marker pairs. Never remove or rewrite the Release note images section; leave its contents for a human. -->

## Pull Request Type
<!-- Please select what type of pull request this is: [x] -->
- [x] Bugfix
- [ ] Feature Implementation
- [ ] Documentation
- [ ] Other

## Related issue
<!-- Please link the issue your pull request is referring to. -->
<!-- If this pull request fully resolves the relevant issue, put "closes" before the issue number. -->
<!-- Example: "closes #123456". -->

Closes #865
Closes #871

## Description
<!-- Please write a clear and concise description of what the pull request does. -->

Playlist loading failures could leave the page stuck or empty, and Invidious playlists stopped after the first response. This change gives initial and continuation failures persistent retry controls, keeps failed continuation state intact for exact retries, and loads later Invidious pages using the documented one-based `page` parameter. Overlapping responses are merged by playlist position and video ID so repeated playlist entries remain valid while pagination overlap is removed.

## Release note category
<!-- Select exactly one category. Every pull request must select one. -->
<!-- Select "Not noteworthy" when the pull request fixes a bug in or improves functionality that has not yet appeared in a stable release. -->
<!-- release-note-category:start -->
- [ ] Not noteworthy
- [ ] Highlights
- [ ] More improvements
- [x] Fixed bugs
<!-- release-note-category:end -->

## Release note
<!-- Required unless "Not noteworthy" is selected. -->
<!-- Write one concise, user-facing entry without a leading bullet. -->
<!-- release-note:start -->

Playlist loading failures can now be retried, and large Invidious playlists load later pages without duplicate videos.

<!-- release-note:end -->

## Release note images
<!-- Human-only: Agents must preserve this entire section and leave it empty. -->
<!-- Optional. Paste one or more Markdown images or HTML image tags here. -->
<!-- The release notes will use an HTML image tag and limit images taller than 300 pixels. -->
<!-- release-note-image:start -->

<!-- release-note-image:end -->

## Testing
<!-- How can reviewers verify that the PR produces correct results? -->
<!-- Please provide instructions so that others can ensure that your pull request would produce correct results. For examples see, https://github.com/FreeTubeApp/FreeTube/pull/5743, https://github.com/FreeTubeApp/FreeTube/pull/7349, https://github.com/FreeTubeApp/FreeTube/pull/5125, https://github.com/FreeTubeApp/FreeTube/pull/7338 -->
<!-- Agent instructions: Only write human-facing steps that explain how to verify the change while running this branch in dev mode. Include expected results and, when applicable, helpful console snippets for interactive verification. Do not include automated checks, commands, results, pass counts, or CI status. -->

1. Open a missing user playlist and confirm the page settles on a visible “This playlist does not exist” message instead of retaining the full-page loader.
2. With Invidious selected and fallback disabled, make an initial playlist request fail. Confirm the error remains visible, then restore the request and select Retry; the playlist should load without navigation.
3. Open an Invidious playlist with more than one page and make its next-page request fail. Confirm the inline error replaces automatic loading, then select Retry and verify the same numeric `page` is requested again.
4. Continue loading the playlist and confirm overlapping entries appear once while intentional occurrences of the same video at different playlist positions remain.
5. Repeat a failed continuation with the Local API and confirm the spinner clears and Retry resumes the failed continuation.

## Additional context
<!-- Add any other context about the pull request here. -->

The Invidious pagination contract and regression strategy were investigated with `gpt-5.6-sol` subagents at xhigh reasoning, then integrated and verified in Codex.
