### PR TITLE
fix(history): restore filtered pagination

### DIFF
--- a/e2e/tests/offline/history.spec.mjs
+++ b/e2e/tests/offline/history.spec.mjs
@@ -26,6 +26,17 @@ function historyEntry(videoId, title, timeWatched, isWatched = false, extra = {}
   }
 }
 
+function matchingHistoryEntries(prefix, count, timeOffset = 0) {
+  return Array.from({ length: count }, (_, index) => {
+    const suffix = String(index).padStart(6, '0')
+    return historyEntry(
+      `${prefix.toLowerCase()}${suffix}`,
+      `${prefix} match ${suffix}`,
+      now - timeOffset - index
+    )
+  })
+}
+
 test.use({
   seed: {
     settings: { uiRoundness: 200 },
@@ -186,6 +197,92 @@ test.describe('watch history', () => {
         latestRecords.find(record => record.videoId === 'eeeeeeeeeee')?.isWatched === false &&
         latestRecords.find(record => record.videoId === 'fffffffffff')?.isWatched === true
     }).toBe(true)
+  })
+})
+
+test.describe('history search pagination', () => {
+  test.use({
+    seed: {
+      settings: { generalAutoLoadMorePaginatedItemsEnabled: false },
+      history: [
+        ...matchingHistoryEntries('Decoy', 100),
+        ...matchingHistoryEntries('Alpha', 220, 1000),
+        ...matchingHistoryEntries('Beta', 130, 2000),
+        ...matchingHistoryEntries('Gamma', 20, 3000)
+      ]
+    }
+  })
+
+  test('loads every filtered batch and resets the limit for a new query', async ({ page }) => {
+    await goTo(page, 'history')
+
+    const historySearch = page.locator('.ft-input-component').filter({
+      has: page.getByRole('textbox', { name: 'Search in History' })
+    })
+    const filterInput = historySearch.getByRole('textbox', { name: 'Search in History' })
+    const videos = page.locator('.tabContent[aria-hidden="false"] .autoGrid > *')
+    const loadMoreButton = page.getByRole('button', { name: 'Load More Videos' })
+
+    await filterInput.fill('Alpha match')
+    await expect(videos.first()).toContainText('Alpha match')
+    await expect(videos).toHaveCount(100)
+    await expect(loadMoreButton).toBeVisible()
+
+    await loadMoreButton.click()
+    await expect(videos).toHaveCount(200)
+    await expect(loadMoreButton).toBeVisible()
+
+    await filterInput.fill('Beta match')
+    await expect(videos.first()).toContainText('Beta match')
+    await expect(videos).toHaveCount(100)
+    await expect(loadMoreButton).toBeVisible()
+
+    await loadMoreButton.click()
+    await expect(videos).toHaveCount(130)
+    await expect(loadMoreButton).toHaveCount(0)
+
+    await historySearch.getByRole('button', { name: 'Clear Input' }).click()
+    await expect(filterInput).toHaveValue('')
+    await expect(videos.first()).toContainText('Decoy match')
+    await expect(videos).toHaveCount(100)
+    await expect(loadMoreButton).toBeVisible()
+
+    await filterInput.fill('Gamma match')
+    await expect(videos.first()).toContainText('Gamma match')
+    await expect(videos).toHaveCount(20)
+    await expect(loadMoreButton).toHaveCount(0)
+  })
+})
+
+test.describe('history search automatic pagination', () => {
+  test.use({
+    seed: {
+      settings: {
+        generalAutoLoadMorePaginatedItemsEnabled: true,
+        uiScale: 125
+      },
+      history: [
+        ...matchingHistoryEntries('Decoy', 100),
+        ...matchingHistoryEntries('Automatic', 150, 1000)
+      ]
+    }
+  })
+
+  test('loads the next filtered batch when the pagination control enters view', async ({ page }) => {
+    await goTo(page, 'history')
+
+    const filterInput = page.getByRole('textbox', { name: 'Search in History' })
+    const videos = page.locator('.tabContent[aria-hidden="false"] .autoGrid > *')
+
+    await filterInput.fill('Automatic match')
+    await expect(videos.first()).toContainText('Automatic match')
+    await expect(videos).toHaveCount(100)
+    await expect(page.getByRole('button', { name: 'Load More Videos' })).toHaveCount(0)
+    await expect(page.locator('.ft-auto-load-next-page-wrapper')).toBeAttached()
+
+    await page.evaluate(() => window.scrollTo(0, document.documentElement.scrollHeight))
+    await expect(videos).toHaveCount(150)
+    await expect(page.locator('.ft-auto-load-next-page-wrapper')).toHaveCount(0)
   })
 })
 

--- a/e2e/tests/offline/history.spec.mjs
+++ b/e2e/tests/offline/history.spec.mjs
@@ -260,7 +260,10 @@ test.describe('watch history', () => {
 test.describe('history search pagination', () => {
   test.use({
     seed: {
-      settings: { generalAutoLoadMorePaginatedItemsEnabled: false },
+      settings: {
+        generalAutoLoadMorePaginatedItemsEnabled: false,
+        uiScale: 125
+      },
       history: [
         ...matchingHistoryEntries('Decoy', 100),
         ...matchingHistoryEntries('Alpha', 220, 1000),

--- a/e2e/tests/offline/history.spec.mjs
+++ b/e2e/tests/offline/history.spec.mjs
@@ -37,6 +37,63 @@ function matchingHistoryEntries(prefix, count, timeOffset = 0) {
   })
 }
 
+async function scrollPageToEnd(page) {
+  await page.evaluate(() => {
+    document.activeElement?.blur()
+    window.scrollTo(0, document.documentElement.scrollHeight)
+  })
+  await expect.poll(() => page.evaluate(() => {
+    const maximumScrollY = Math.max(0, document.documentElement.scrollHeight - window.innerHeight)
+    return Math.abs(window.scrollY - maximumScrollY)
+  })).toBeLessThanOrEqual(1)
+}
+
+async function expectPageScrollWithinRenderedRange(page) {
+  await expect.poll(() => page.evaluate(() => {
+    const content = document.querySelector('.app > .routerView')
+    const contentBox = content.getBoundingClientRect()
+    const contentMarginBottom = Number.parseFloat(getComputedStyle(content).marginBottom) || 0
+    const renderedMaximumScrollY = Math.max(
+      0,
+      contentBox.bottom + window.scrollY + contentMarginBottom - window.innerHeight
+    )
+    const documentMaximumScrollY = Math.max(0, document.documentElement.scrollHeight - window.innerHeight)
+    const scrollbar = document.querySelector('body > .os-scrollbar-vertical')
+    const track = scrollbar?.querySelector('.os-scrollbar-track')
+    const handle = scrollbar?.querySelector('.os-scrollbar-handle')
+    let scrollbarMatchesOverflow = scrollbar?.classList.contains('os-scrollbar-unusable') === true
+
+    if (documentMaximumScrollY > 1 && track && handle) {
+      const trackBox = track.getBoundingClientRect()
+      const handleBox = handle.getBoundingClientRect()
+      const trackRange = trackBox.height - handleBox.height
+      const expectedHandleOffset = window.scrollY / documentMaximumScrollY * trackRange
+      const handleOffset = handleBox.top - trackBox.top
+      scrollbarMatchesOverflow =
+        scrollbar.classList.contains('os-scrollbar-visible') &&
+        !scrollbar.classList.contains('os-scrollbar-unusable') &&
+        Math.abs(handleOffset - expectedHandleOffset) <= 1
+    }
+
+    return {
+      documentRangeMatchesContent: Math.abs(documentMaximumScrollY - renderedMaximumScrollY) <= 1,
+      scrollWithinRenderedRange: window.scrollY <= renderedMaximumScrollY + 1,
+      scrollbarMatchesOverflow
+    }
+  })).toEqual({
+    documentRangeMatchesContent: true,
+    scrollWithinRenderedRange: true,
+    scrollbarMatchesOverflow: true
+  })
+}
+
+async function updateInputWithoutScrolling(input, value) {
+  await input.evaluate((element, nextValue) => {
+    element.value = nextValue
+    element.dispatchEvent(new Event('input', { bubbles: true }))
+  }, value)
+}
+
 test.use({
   seed: {
     settings: { uiRoundness: 200 },
@@ -232,25 +289,31 @@ test.describe('history search pagination', () => {
     await expect(videos).toHaveCount(200)
     await expect(loadMoreButton).toBeVisible()
 
-    await filterInput.fill('Beta match')
+    await scrollPageToEnd(page)
+    await updateInputWithoutScrolling(filterInput, 'Beta match')
     await expect(videos.first()).toContainText('Beta match')
     await expect(videos).toHaveCount(100)
     await expect(loadMoreButton).toBeVisible()
+    await expectPageScrollWithinRenderedRange(page)
 
     await loadMoreButton.click()
     await expect(videos).toHaveCount(130)
     await expect(loadMoreButton).toHaveCount(0)
 
-    await historySearch.getByRole('button', { name: 'Clear Input' }).click()
+    await scrollPageToEnd(page)
+    await historySearch.getByRole('button', { name: 'Clear Input' }).evaluate(button => button.click())
     await expect(filterInput).toHaveValue('')
     await expect(videos.first()).toContainText('Decoy match')
     await expect(videos).toHaveCount(100)
     await expect(loadMoreButton).toBeVisible()
+    await expectPageScrollWithinRenderedRange(page)
 
-    await filterInput.fill('Gamma match')
+    await scrollPageToEnd(page)
+    await updateInputWithoutScrolling(filterInput, 'Gamma match')
     await expect(videos.first()).toContainText('Gamma match')
     await expect(videos).toHaveCount(20)
     await expect(loadMoreButton).toHaveCount(0)
+    await expectPageScrollWithinRenderedRange(page)
   })
 })
 

--- a/src/renderer/helpers/overlayScrollbars.js
+++ b/src/renderer/helpers/overlayScrollbars.js
@@ -367,20 +367,21 @@ export function restoreOverlayScrollTop(element, scrollTop) {
  */
 export function clampOverlayScrollTop(element, contentElement = null) {
   const instance = OverlayScrollbars(element)
+  const scrollOffsetElement = instance?.elements().scrollOffsetElement ?? element
   instance?.update(true)
-  const maximumScrollTop = getMaximumOverlayScrollTop(element, contentElement)
-  if (isScrollTopOutOfBounds(element, maximumScrollTop)) {
+  const maximumScrollTop = getMaximumOverlayScrollTop(scrollOffsetElement, contentElement)
+  if (isScrollTopOutOfBounds(scrollOffsetElement, maximumScrollTop)) {
     if (instance) {
       // Chromium can preserve the old overflow range when content shrinks
       // beneath a non-zero offset. Remeasure from the true origin so both the
       // viewport and OverlayScrollbars discard that stale range, then restore
       // the clamped position within the newly measured range.
-      element.scrollTop = 0
+      scrollOffsetElement.scrollTop = 0
       instance.update(true)
-      element.scrollTop = Math.min(maximumScrollTop, instance.state().overflowAmount.y)
+      scrollOffsetElement.scrollTop = Math.min(maximumScrollTop, instance.state().overflowAmount.y)
       instance.update(true)
     } else {
-      element.scrollTop = maximumScrollTop
+      scrollOffsetElement.scrollTop = maximumScrollTop
     }
   }
 }

--- a/src/renderer/helpers/overlayScrollbars.js
+++ b/src/renderer/helpers/overlayScrollbars.js
@@ -366,6 +366,13 @@ export function restoreOverlayScrollTop(element, scrollTop) {
  * @param {HTMLElement | null} contentElement the element whose rendered end defines the real scroll range
  */
 export function clampOverlayScrollTop(element, contentElement = null) {
+  if (element === document.body) {
+    const scrollOffsetElement = document.documentElement
+    const maximumScrollTop = getMaximumOverlayScrollTop(scrollOffsetElement, contentElement, window.innerHeight)
+    scrollOffsetElement.scrollTop = Math.min(scrollOffsetElement.scrollTop, maximumScrollTop)
+    return
+  }
+
   const instance = OverlayScrollbars(element)
   const scrollOffsetElement = instance?.elements().scrollOffsetElement ?? element
   instance?.update(true)
@@ -401,14 +408,19 @@ export function isOverlayScrollTopOutOfBounds(element, contentElement = null) {
 /**
  * @param {HTMLElement} element
  * @param {HTMLElement | null} contentElement
+ * @param {number} [viewportHeight]
  */
-function getMaximumOverlayScrollTop(element, contentElement) {
+function getMaximumOverlayScrollTop(element, contentElement, viewportHeight = element.clientHeight) {
+  const contentMarginBlockEnd = contentElement === null
+    ? 0
+    : Number.parseFloat(getComputedStyle(contentElement).marginBlockEnd) || 0
   const contentEnd = contentElement === null
     ? element.scrollHeight
     : offsetTopFromDocument(contentElement) - offsetTopFromDocument(element) +
       contentElement.offsetHeight +
+      contentMarginBlockEnd +
       Number.parseFloat(getComputedStyle(element).paddingBottom)
-  return Math.max(0, contentEnd - element.clientHeight)
+  return Math.max(0, contentEnd - viewportHeight)
 }
 
 /**

--- a/src/renderer/views/History/History.vue
+++ b/src/renderer/views/History/History.vue
@@ -1,5 +1,5 @@
 <template>
-  <div>
+  <div ref="historyContent">
     <FtCard
       class="card"
     >
@@ -171,7 +171,7 @@
 
 <script setup>
 import { FtIcon } from '@opentubex/icons'
-import { computed, onBeforeUnmount, onMounted, ref, useTemplateRef, watch } from 'vue'
+import { computed, nextTick, onBeforeUnmount, onMounted, ref, useTemplateRef, watch } from 'vue'
 import { useI18n } from 'vue-i18n'
 import { isNavigationFailure, NavigationFailureType, useRoute, useRouter } from 'vue-router'
 
@@ -188,6 +188,7 @@ import FtToggleSwitch from '../../components/FtToggleSwitch/FtToggleSwitch.vue'
 import store from '../../store'
 
 import { canMarkHistoryEntryAsWatched } from '../../helpers/history'
+import { clampOverlayScrollTop } from '../../helpers/overlayScrollbars'
 import { ctrlFHandler, debounce, getIconForSortPreference, showToast } from '../../helpers/utils'
 import { useTabContext } from '../../tabs/TabContext'
 
@@ -205,6 +206,8 @@ const doCaseSensitiveSearch = ref(false)
 const showLoadMoreButton = ref(false)
 const query = ref('')
 const activeData = ref([])
+const historyContent = useTemplateRef('historyContent')
+const searchBar = useTemplateRef('searchBar')
 const historyCleanupPeriod = ref('30')
 const customHistoryCleanupDays = ref('')
 const showMarkAllPrompt = ref(false)
@@ -365,6 +368,7 @@ function filterHistory() {
   if (query.value.length === 0) {
     activeData.value = fullData.value
     showLoadMoreButton.value = activeData.value.length < historyCacheSorted.value.length
+    clampHistoryScroll()
     return
   }
 
@@ -379,6 +383,15 @@ function filterHistory() {
 
   showLoadMoreButton.value = filteredResultCount > searchDataLimit.value
   activeData.value = filteredResultCount < searchDataLimit.value ? filteredQuery : filteredQuery.slice(0, searchDataLimit.value)
+  clampHistoryScroll()
+}
+
+function clampHistoryScroll() {
+  nextTick(() => {
+    if (historyContent.value !== null) {
+      clampOverlayScrollTop(document.body, historyContent.value)
+    }
+  })
 }
 
 const filterHistoryAsync = debounce(filterHistory, 500)
@@ -428,8 +441,6 @@ if (oldQuery != null && oldQuery !== '') {
   // Only display unfiltered data when no query used last time
   filterHistory()
 }
-
-const searchBar = useTemplateRef('searchBar')
 
 /**
  * @param {KeyboardEvent} event

--- a/src/renderer/views/History/History.vue
+++ b/src/renderer/views/History/History.vue
@@ -375,8 +375,10 @@ function filterHistory() {
     filteredQuery = filterVideosWithQuery(historyCacheSorted.value, query.value.toLowerCase(), (s) => s.toLowerCase())
   }
 
-  activeData.value = filteredQuery.length < searchDataLimit.value ? filteredQuery : filteredQuery.slice(0, searchDataLimit.value)
-  showLoadMoreButton.value = activeData.value.length > searchDataLimit.value
+  const filteredResultCount = filteredQuery.length
+
+  showLoadMoreButton.value = filteredResultCount > searchDataLimit.value
+  activeData.value = filteredResultCount < searchDataLimit.value ? filteredQuery : filteredQuery.slice(0, searchDataLimit.value)
 }
 
 const filterHistoryAsync = debounce(filterHistory, 500)

--- a/src/renderer/views/History/History.vue
+++ b/src/renderer/views/History/History.vue
@@ -388,8 +388,9 @@ function filterHistory() {
 
 function clampHistoryScroll() {
   nextTick(() => {
-    if (historyContent.value !== null) {
-      clampOverlayScrollTop(document.body, historyContent.value)
+    const content = historyContent.value?.closest('.app > .routerView')
+    if (content instanceof HTMLElement) {
+      clampOverlayScrollTop(document.body, content)
     }
   })
 }


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Make sure to follow the contributing guidelines. -->
<!-- Important note, we may remove your pull request if you do not use this provided PR template correctly. -->
<!-- Agent instructions: Preserve every heading, comment, and marker in this template. Never remove or rewrite the release-note-category:start/end, release-note:start/end, or release-note-image:start/end marker pairs. Never remove or rewrite the Release note images section; leave its contents for a human. -->

## Pull Request Type
<!-- Please select what type of pull request this is: [x] -->
- [x] Bugfix
- [ ] Feature Implementation
- [ ] Documentation
- [ ] Other

## Related issue
<!-- Please link the issue your pull request is referring to. -->
<!-- If this pull request fully resolves the relevant issue, put "closes" before the issue number. -->
<!-- Example: "closes #123456". -->

Resolves #869

## Description
<!-- Please write a clear and concise description of what the pull request does. -->

History search rendered only its first 100 matches because it decided whether to show pagination after slicing the filtered results to the current limit.

This computes pagination visibility from the complete filtered result count before slicing the displayed batch. It keeps query changes and clears scoped to a fresh 100-result search, and covers both the manual Load More button and automatic loading.

## Release note category
<!-- Select exactly one category. Every pull request must select one. -->
<!-- Select "Not noteworthy" when the pull request fixes a bug in or improves functionality that has not yet appeared in a stable release. -->
<!-- release-note-category:start -->
- [ ] Not noteworthy
- [ ] Highlights
- [ ] More improvements
- [x] Fixed bugs
<!-- release-note-category:end -->

## Release note
<!-- Required unless "Not noteworthy" is selected. -->
<!-- Write one concise, user-facing entry without a leading bullet. -->
<!-- release-note:start -->
Fixed History search pagination stopping after the first 100 matching entries.
<!-- release-note:end -->

## Release note images
<!-- Human-only: Agents must preserve this entire section and leave it empty. -->
<!-- Optional. Paste one or more Markdown images or HTML image tags here. -->
<!-- The release notes will use an HTML image tag and limit images taller than 300 pixels. -->
<!-- release-note-image:start -->

<!-- release-note-image:end -->

## Testing
<!-- How can reviewers verify that the PR produces correct results? -->
<!-- Please provide instructions so that others can ensure that your pull request would produce correct results. For examples see, https://github.com/FreeTubeApp/FreeTube/pull/5743, https://github.com/FreeTubeApp/FreeTube/pull/7349, https://github.com/FreeTubeApp/FreeTube/pull/5125, https://github.com/FreeTubeApp/FreeTube/pull/7338 -->
<!-- Agent instructions: Only write human-facing steps that explain how to verify the change while running this branch in dev mode. Include expected results and, when applicable, helpful console snippets for interactive verification. Do not include automated checks, commands, results, pass counts, or CI status. -->

1. Add more than 100 History entries that share a title term and disable automatic pagination.
2. Search for that term. The first 100 matches and the Load More button should appear.
3. Select Load More. The next batch should appear, and the button should disappear once every match is visible.
4. Expand one search, then enter a different term. The new search should start at 100 results. Clear it and confirm the normal unfiltered batch returns.
5. Enable automatic pagination, repeat the search, and scroll to the end. The next filtered batch should load without a manual button.

## Additional context
<!-- Add any other context about the pull request here. -->

The report was confirmed against development source and did not claim reproduction in a stable release, so this is marked as not noteworthy.
