### PR TITLE
fix(downloads): expose progress to assistive technology

### DIFF
--- a/e2e/tests/offline/video-actions.spec.mjs
+++ b/e2e/tests/offline/video-actions.spec.mjs
@@ -1184,6 +1184,63 @@ test.describe('video downloads', () => {
   })
 })
 
+test('exposes download progress to assistive technology', async ({ page }) => {
+  await goTo(page, 'downloads')
+
+  const upsertDownload = (status, percent) => page.evaluate(({ status, percent }) => {
+    const store = document.querySelector('#app').__vue_app__.config.globalProperties.$store
+    store.commit('upsertYtDlpDownload', {
+      id: 42,
+      title: 'Accessible download',
+      status,
+      percent,
+      speed: '1 MiB/s',
+      eta: '00:10',
+      mode: 'video'
+    })
+  }, { status, percent })
+
+  await upsertDownload('downloading', 42)
+  const row = page.locator('.downloadRow').filter({ hasText: 'Accessible download' })
+  const progress = row.getByRole('progressbar')
+  const fill = row.locator('.progressFill')
+  await expect(progress).toHaveAccessibleName('Accessible download')
+  await expect(progress).toHaveAttribute('aria-valuemin', '0')
+  await expect(progress).toHaveAttribute('aria-valuemax', '100')
+  await expect(progress).toHaveAttribute('aria-valuenow', '42')
+  await expect(progress).toHaveAttribute('aria-valuetext', '42.0% • 1 MiB/s • ETA 00:10')
+  await expect(fill).toHaveAttribute('aria-hidden', 'true')
+  await expect(row.locator('.downloadStatus')).toHaveAttribute('aria-hidden', 'true')
+
+  await upsertDownload('downloading', 142)
+  await expect(progress).toHaveAttribute('aria-valuenow', '100')
+  await expect(progress).toHaveAttribute('aria-valuetext', '100.0% • 1 MiB/s • ETA 00:10')
+  expect(await fill.evaluate(element => element.style.inlineSize)).toBe('100%')
+
+  await upsertDownload('downloading', -42)
+  await expect(progress).toHaveAttribute('aria-valuenow', '0')
+  await expect(progress).toHaveAttribute('aria-valuetext', '0.0% • 1 MiB/s • ETA 00:10')
+  expect(await fill.evaluate(element => element.style.inlineSize)).toBe('0%')
+
+  await upsertDownload('processing', 42)
+  await expect(progress).toHaveAccessibleName('Accessible download')
+  await expect(progress).toHaveAttribute('aria-valuetext', 'Processing…')
+  expect(await progress.getAttribute('aria-valuenow')).toBeNull()
+  await expect(row.locator('[role="status"], [aria-live]')).toHaveCount(0)
+
+  const session = await page.context().newCDPSession(page)
+  const { nodes } = await session.send('Accessibility.getFullAXTree')
+  await session.detach()
+  const tree = nodes.filter(node => !node.ignored)
+  const processingBar = tree.find(node => (
+    node.role?.value === 'progressbar' && node.name?.value === 'Accessible download'
+  ))
+  expect(processingBar).toBeDefined()
+  expect(typeof processingBar?.value?.value).not.toBe('number')
+  expect(tree.flatMap(node => [node.name?.value, node.value?.value])
+    .filter(value => value === 'Processing…').length).toBeLessThanOrEqual(1)
+})
+
 test('asks for confirmation before removing a downloaded file', async ({ page }) => {
   await goTo(page, 'downloads')
   await page.evaluate(() => {

--- a/src/renderer/views/Downloads/DownloadRow.vue
+++ b/src/renderer/views/Downloads/DownloadRow.vue
@@ -10,7 +10,10 @@
         <h3 dir="auto">
           {{ download.title }}
         </h3>
-        <p class="downloadStatus">
+        <p
+          class="downloadStatus"
+          :aria-hidden="inProgress ? 'true' : undefined"
+        >
           {{ statusText }}
         </p>
         <p
@@ -23,12 +26,18 @@
         <div
           v-if="inProgress"
           class="progressTrack"
-          :aria-label="statusText"
+          role="progressbar"
+          :aria-label="download.title || t('Downloads.Downloading')"
+          :aria-valuenow="download.status === 'downloading' ? progressPercentage : undefined"
+          :aria-valuetext="statusText"
+          aria-valuemin="0"
+          aria-valuemax="100"
         >
           <div
             class="progressFill"
             :class="{ indeterminate: download.status === 'processing' }"
-            :style="{ inlineSize: `${download.percent}%` }"
+            :style="{ inlineSize: `${progressPercentage}%` }"
+            aria-hidden="true"
           />
         </div>
         <p
@@ -135,6 +144,11 @@ const props = defineProps({
 const emit = defineEmits(['clear', 'open', 'play', 'remove', 'retry'])
 const { t } = useI18n()
 const inProgress = computed(() => ['downloading', 'processing'].includes(props.download.status))
+const progressPercentage = computed(() => (
+  Number.isFinite(props.download.percent)
+    ? Math.min(100, Math.max(0, props.download.percent))
+    : 0
+))
 const canRetry = computed(() => (
   ['failed', 'cancelled'].includes(props.download.status) &&
   (props.download.retryPayload || props.download.videoId || props.download.playlistId)
@@ -203,7 +217,7 @@ const errorText = computed(() => {
 })
 const statusText = computed(() => {
   if (props.download.status === 'downloading') {
-    return [`${props.download.percent.toFixed(1)}%`, props.download.speed, props.download.eta ? `ETA ${props.download.eta}` : null].filter(Boolean).join(' • ')
+    return [`${progressPercentage.value.toFixed(1)}%`, props.download.speed, props.download.eta ? `ETA ${props.download.eta}` : null].filter(Boolean).join(' • ')
   }
   switch (props.download.status) {
     case 'processing':


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Make sure to follow the contributing guidelines. -->
<!-- Important note, we may remove your pull request if you do not use this provided PR template correctly. -->
<!-- Agent instructions: Preserve every heading, comment, and marker in this template. Never remove or rewrite the release-note-category:start/end, release-note:start/end, or release-note-image:start/end marker pairs. Never remove or rewrite the Release note images section; leave its contents for a human. -->

## Pull Request Type
<!-- Please select what type of pull request this is: [x] -->
- [x] Bugfix
- [ ] Feature Implementation
- [ ] Documentation
- [ ] Other

## Related issue
<!-- Please link the issue your pull request is referring to. -->
<!-- If this pull request fully resolves the relevant issue, put "closes" before the issue number. -->
<!-- Example: "closes #123456". -->

Resolves #873

## Description
<!-- Please write a clear and concise description of what the pull request does. -->

Active downloads were rendered as generic labeled elements, so assistive technology could not identify their progress or current value. Processing also lacked an indeterminate progress state.

The download row now exposes a named progress bar with bounded range metadata. Determinate downloads report a clamped current value, while processing omits the numeric value and reports its localized status through `aria-valuetext`. The duplicate visible status and decorative fill stay out of the accessibility tree.

## Release note category
<!-- Select exactly one category. Every pull request must select one. -->
<!-- Select "Not noteworthy" when the pull request fixes a bug in or improves functionality that has not yet appeared in a stable release. -->
<!-- release-note-category:start -->
- [x] Not noteworthy
- [ ] Highlights
- [ ] More improvements
- [ ] Fixed bugs
<!-- release-note-category:end -->

## Release note
<!-- Required unless "Not noteworthy" is selected. -->
<!-- Write one concise, user-facing entry without a leading bullet. -->
<!-- release-note:start -->

<!-- release-note:end -->

## Release note images
<!-- Human-only: Agents must preserve this entire section and leave it empty. -->
<!-- Optional. Paste one or more Markdown images or HTML image tags here. -->
<!-- The release notes will use an HTML image tag and limit images taller than 300 pixels. -->
<!-- release-note-image:start -->

<!-- release-note-image:end -->

## Testing
<!-- How can reviewers verify that the PR produces correct results? -->
<!-- Please provide instructions so that others can ensure that your pull request would produce correct results. For examples see, https://github.com/FreeTubeApp/FreeTube/pull/5743, https://github.com/FreeTubeApp/FreeTube/pull/7349, https://github.com/FreeTubeApp/FreeTube/pull/5125, https://github.com/FreeTubeApp/FreeTube/pull/7338 -->
<!-- Agent instructions: Only write human-facing steps that explain how to verify the change while running this branch in dev mode. Include expected results and, when applicable, helpful console snippets for interactive verification. Do not include automated checks, commands, results, pass counts, or CI status. -->

1. Open Downloads with an active item at a known percentage, such as 42%.
2. Inspect the item with the browser accessibility tools. It should appear as a progress bar named after the download, with a minimum of 0, maximum of 100, current value of 42, and status text containing the visible speed and ETA.
3. Change the item to processing. The same progress bar should report "Processing…" without a current numeric value.
4. Confirm that the visible status text and animated fill do not appear as separate accessibility-tree entries.

## Additional context
<!-- Add any other context about the pull request here. -->

The regression covers determinate and processing states, both percentage clamp boundaries, and Chromium's accessibility tree.
