### PR TITLE
fix(trending): keep category results with their requests

### DIFF
--- a/e2e/tests/network/trending.spec.mjs
+++ b/e2e/tests/network/trending.spec.mjs
@@ -1,5 +1,92 @@
+import { readFileSync } from 'node:fs'
+import { gunzipSync } from 'node:zlib'
+
 import { goTo } from '../../helpers/app.mjs'
 import { test, expect } from '../../helpers/innertube.mjs'
+
+const fixture = JSON.parse(gunzipSync(readFileSync(new URL(
+  '../../fixtures/innertube/trending/shows-trending-videos-and-switches-categories/browse-2cd8b157f6ed.0.json.gz',
+  import.meta.url
+))))
+
+const categories = {
+  UCOpNcN46UbXVtpKMrmU4Abg: 'gaming',
+  'UCEgdi0XIXXZ-qJOFPf4JSKw': 'sports'
+}
+
+const videoIds = {
+  gaming: 'gaming00001',
+  sports: 'sports00001'
+}
+
+function responseFor(category) {
+  const response = structuredClone(fixture)
+  const items = response.contents.twoColumnBrowseResultsRenderer.tabs[0]
+    .tabRenderer.content.sectionListRenderer.contents[0]
+    .itemSectionRenderer.contents[0].shelfRenderer.content.gridRenderer.items
+  const renderer = items[0].gridVideoRenderer
+
+  items.splice(1)
+  renderer.videoId = videoIds[category]
+  renderer.title = { runs: [{ text: `${category} request result` }] }
+
+  return response
+}
+
+async function controlTrendingRequests(page) {
+  const requests = []
+
+  await page.route(/\/youtubei\/v1\/browse/, async route => {
+    const category = categories[route.request().postDataJSON()?.browseId]
+    if (!category) {
+      return route.fallback()
+    }
+
+    const result = await new Promise(resolve => {
+      requests.push({ category, resolve })
+    })
+    await route.fulfill(result)
+  })
+
+  return {
+    total() {
+      return requests.length
+    },
+    count(category) {
+      return requests.filter(request => request.category === category).length
+    },
+    fulfill(category) {
+      const request = requests.find(request => request.category === category && request.resolve)
+      expect(request, `pending ${category} request`).toBeTruthy()
+      request.resolve({ json: responseFor(category) })
+      request.resolve = null
+    },
+    reject(category) {
+      const request = requests.find(request => request.category === category && request.resolve)
+      expect(request, `pending ${category} request`).toBeTruthy()
+      request.resolve({ status: 500, json: { error: `${category} request failed` } })
+      request.resolve = null
+    }
+  }
+}
+
+async function trendingCache(page) {
+  return await page.evaluate(() => {
+    const store = document.querySelector('#app').__vue_app__.config.globalProperties.$store
+    return Object.fromEntries(Object.entries(store.getters.getTrendingCache).map(([category, videos]) => [
+      category,
+      videos?.map(video => video.videoId) ?? null
+    ]))
+  })
+}
+
+async function trendingTimestamps(page) {
+  return await page.evaluate(() => {
+    const store = document.querySelector('#app').__vue_app__.config.globalProperties.$store
+    return Object.fromEntries(Object.entries(store.getters.getLastTrendingRefreshTimestamp)
+      .map(([category, timestamp]) => [category, timestamp ? new Date(timestamp).getTime() : null]))
+  })
+}
 
 test.describe('trending page', () => {
   test('shows trending videos and switches categories', async ({ page }) => {
@@ -19,5 +106,138 @@ test.describe('trending page', () => {
 
     await expect(gamingTab).toHaveAttribute('aria-selected', 'true')
     await expect(page.locator('.ft-list-video').first()).toBeVisible({ timeout: 30_000 })
+  })
+
+  test('keeps concurrent out-of-order category results with their requests', async ({ page }) => {
+    const controlled = await controlTrendingRequests(page)
+    const panel = page.locator('#trendingPanel')
+
+    await goTo(page, 'trending')
+    await expect.poll(() => controlled.count('gaming')).toBe(1)
+
+    const sportsTab = page.getByRole('tab', { name: 'Sports' })
+    await sportsTab.click()
+    await expect.poll(() => controlled.count('sports')).toBe(1)
+    expect(controlled.count('gaming')).toBe(1)
+    expect(await trendingTimestamps(page)).toEqual({
+      gaming: null,
+      sports: null,
+      podcasts: null
+    })
+
+    controlled.fulfill('gaming')
+    await expect.poll(async () => {
+      const cache = await trendingCache(page)
+      return Object.values(cache).some(ids => ids?.includes(videoIds.gaming))
+    }).toBe(true)
+
+    expect(await trendingCache(page)).toEqual({
+      gaming: [videoIds.gaming],
+      sports: null,
+      podcasts: null
+    })
+    await expect.poll(async () => (await trendingTimestamps(page)).gaming).not.toBeNull()
+    expect(await trendingTimestamps(page)).toEqual({
+      gaming: expect.any(Number),
+      sports: null,
+      podcasts: null
+    })
+    await expect(sportsTab).toHaveAttribute('aria-selected', 'true')
+    await expect(panel.locator('[data-tab-loading-indicator]')).toBeVisible()
+    await expect(panel.locator('.ft-list-video')).toHaveCount(0)
+
+    controlled.fulfill('sports')
+    await expect.poll(async () => (await trendingCache(page)).sports).toEqual([videoIds.sports])
+    expect(await trendingCache(page)).toEqual({
+      gaming: [videoIds.gaming],
+      sports: [videoIds.sports],
+      podcasts: null
+    })
+    expect(await trendingTimestamps(page)).toEqual({
+      gaming: expect.any(Number),
+      sports: expect.any(Number),
+      podcasts: null
+    })
+    await expect(panel.locator('.ft-list-video')).toContainText('sports request result')
+
+    const gamingTab = page.getByRole('tab', { name: 'Gaming' })
+    await gamingTab.click()
+    await expect(panel.locator('.ft-list-video')).toContainText('gaming request result')
+    expect(controlled.count('gaming')).toBe(1)
+  })
+
+  test('a failed hidden category request does not finish the active category request', async ({ page }) => {
+    const controlled = await controlTrendingRequests(page)
+    const panel = page.locator('#trendingPanel')
+
+    await goTo(page, 'trending')
+    await expect.poll(() => controlled.count('gaming')).toBe(1)
+
+    const sportsTab = page.getByRole('tab', { name: 'Sports' })
+    await sportsTab.click()
+    await expect.poll(() => controlled.count('sports')).toBe(1)
+
+    const failedResponse = page.waitForResponse(response => (
+      response.url().includes('/youtubei/v1/browse') && response.status() === 500
+    ))
+    controlled.reject('gaming')
+    await (await failedResponse).finished()
+    await page.evaluate(() => new Promise(resolve => {
+      requestAnimationFrame(() => requestAnimationFrame(resolve))
+    }))
+
+    await expect(page.locator('.toast', { hasText: 'Local API Error' })).toHaveCount(0)
+    await expect(sportsTab).toHaveAttribute('aria-selected', 'true')
+    await expect(panel.locator('[data-tab-loading-indicator]')).toBeVisible()
+    expect(await trendingCache(page)).toEqual({
+      gaming: null,
+      sports: null,
+      podcasts: null
+    })
+
+    controlled.fulfill('sports')
+    await expect(panel.locator('.ft-list-video')).toContainText('sports request result')
+    expect(await trendingCache(page)).toEqual({
+      gaming: null,
+      sports: [videoIds.sports],
+      podcasts: null
+    })
+
+    const gamingTab = page.getByRole('tab', { name: 'Gaming' })
+    await gamingTab.click()
+    await expect(panel.getByRole('status')).toContainText('Trending could not be loaded')
+    expect(controlled.count('gaming')).toBe(1)
+  })
+
+  test.describe('without a supported backend', () => {
+    test.use({
+      seed: {
+        settings: {
+          backendPreference: 'invidious',
+          backendFallback: true
+        }
+      }
+    })
+
+    test('shows the unsupported state without recording a successful refresh', async ({ page }) => {
+      const controlled = await controlTrendingRequests(page)
+
+      await page.locator('a[href="#/trending"]').evaluate(link => {
+        const store = document.querySelector('#app').__vue_app__.config.globalProperties.$store
+        store.commit('setBackendFallback', false)
+        link.click()
+      })
+      await expect(page).toHaveURL(/#\/trending/)
+
+      expect(controlled.total()).toBe(0)
+      expect(await trendingTimestamps(page)).toEqual({
+        gaming: null,
+        sports: null,
+        podcasts: null
+      })
+      await expect(page.locator('#trendingPanel [role="status"]')).toContainText(
+        'Trending requires the Local API'
+      )
+    })
   })
 })

--- a/src/renderer/views/Trending/Trending.css
+++ b/src/renderer/views/Trending/Trending.css
@@ -85,6 +85,11 @@
   color: var(--primary-color);
 }
 
+.statusMessage {
+  margin-block: 48px;
+  text-align: center;
+}
+
 @media only screen and (width <= 680px) {
   .card {
     inline-size: 100%;

--- a/src/renderer/views/Trending/Trending.vue
+++ b/src/renderer/views/Trending/Trending.vue
@@ -98,6 +98,13 @@
         <FtLoader
           v-if="isLoading[currentTab]"
         />
+        <p
+          v-else-if="currentErrorMessage"
+          class="statusMessage"
+          role="status"
+        >
+          {{ currentErrorMessage }}
+        </p>
         <FtElementList
           v-else
           :key="currentTab"
@@ -111,7 +118,7 @@
 
 <script setup>
 import { FtIcon } from '@opentubex/icons'
-import { computed, nextTick, onBeforeUnmount, onMounted, ref, shallowRef, useTemplateRef } from 'vue'
+import { computed, nextTick, onBeforeUnmount, onMounted, ref, useTemplateRef } from 'vue'
 import { useI18n } from 'vue-i18n'
 
 import FtCard from '../../components/ft-card/ft-card.vue'
@@ -165,13 +172,29 @@ const trendingCache = computed(() => {
 })
 
 const isLoading = ref({ gaming: false, sports: false, podcasts: false })
-const shownResults = shallowRef([])
+const errorMessages = ref({ gaming: null, sports: null, podcasts: null })
 
 const { tabId } = useTabContext()
 const currentTabStorageKey = tabId ? `Trending/${tabId}/currentTab` : 'Trending/currentTab'
 
 /** @type {import('vue').Ref<'gaming' | 'sports' | 'podcasts'>} */
 const currentTab = ref('gaming')
+
+const isBackendSupported = computed(() => {
+  return process.env.SUPPORTS_LOCAL_API && (backendFallback.value || backendPreference.value === 'local')
+})
+
+const currentErrorMessage = computed(() => {
+  if (!isBackendSupported.value) {
+    return t('Trending.Unsupported Backend')
+  }
+
+  return errorMessages.value[currentTab.value]
+})
+
+const shownResults = computed(() => {
+  return trendingCache.value[currentTab.value] ?? []
+})
 
 // Restore last used tab so navigating into a video and back returns here
 const lastCurrentTabId = sessionStorage.getItem(currentTabStorageKey)
@@ -181,44 +204,60 @@ if (lastCurrentTabId !== null && Object.hasOwn(isLoading.value, lastCurrentTabId
 
 const cacheEntry = trendingCache.value[currentTab.value]
 
-if (cacheEntry && cacheEntry.length > 0) {
-  shownResults.value = cacheEntry
-} else {
+if (cacheEntry === null) {
   onMounted(() => {
     getTrendingInfo()
   })
 }
 
 function getTrendingInfo(refresh = false) {
+  const category = currentTab.value
+
+  if (isLoading.value[category]) {
+    return
+  }
+
+  if (!isBackendSupported.value) {
+    return
+  }
+
   if (refresh) {
-    store.commit('clearTrendingCache', currentTab.value)
+    store.commit('clearTrendingCache', category)
   }
 
-  if (process.env.SUPPORTS_LOCAL_API && (backendFallback.value || backendPreference.value === 'local')) {
-    getTrendingInfoLocal()
-  }
-
-  store.commit('setLastTrendingRefreshTimestamp', { page: currentTab.value, timestamp: new Date() })
+  getTrendingInfoLocal(category)
 }
 
-async function getTrendingInfoLocal() {
-  isLoading.value[currentTab.value] = true
+/**
+ * @param {'gaming' | 'sports' | 'podcasts'} category
+ */
+async function getTrendingInfoLocal(category) {
+  isLoading.value[category] = true
+  errorMessages.value[category] = null
 
   try {
-    const results = await getLocalTrending(region.value, currentTab.value)
+    const results = await getLocalTrending(region.value, category)
 
-    shownResults.value = results
-    isLoading.value[currentTab.value] = false
+    store.commit('setTrendingCache', { value: results, page: category })
+    store.commit('setLastTrendingRefreshTimestamp', { page: category, timestamp: new Date() })
 
-    store.commit('setTrendingCache', { value: results, page: currentTab.value })
-    nextTick(() => {
-      focusTab(currentTab.value)
-    })
+    if (currentTab.value === category) {
+      nextTick(() => {
+        if (currentTab.value === category) {
+          focusTab(category)
+        }
+      })
+    }
   } catch (error) {
     console.error(error)
-    const errorMessage = t('Local API Error (Click to copy)')
-    showApiErrorToast(errorMessage, error, showTabToast)
-    isLoading.value[currentTab.value] = false
+    errorMessages.value[category] = t('Trending.Load Error')
+
+    if (currentTab.value === category) {
+      const errorMessage = t('Local API Error (Click to copy)')
+      showApiErrorToast(errorMessage, error, showTabToast)
+    }
+  } finally {
+    isLoading.value[category] = false
   }
 }
 
@@ -264,11 +303,9 @@ function changeTab(tab) {
   // Save last used tab, restored when the view is mounted again
   sessionStorage.setItem(currentTabStorageKey, tab)
 
-  const cacheEntry = trendingCache.value[currentTab.value]
+  const cacheEntry = trendingCache.value[tab]
 
-  if (cacheEntry && cacheEntry.length > 0) {
-    shownResults.value = cacheEntry
-  } else {
+  if (cacheEntry === null && !isLoading.value[tab] && errorMessages.value[tab] === null) {
     getTrendingInfo()
   }
 }

--- a/static/locales/en-US.yaml
+++ b/static/locales/en-US.yaml
@@ -245,6 +245,8 @@ Trending:
   Gaming: Gaming
   Sports: Sports
   Trending Tabs: Trending Tabs
+  Load Error: Trending could not be loaded.
+  Unsupported Backend: Trending requires the Local API. Select the Local API or enable backend fallback.
 Most Popular: Most Popular
 Most Popular Feed Empty: This Invidious instance's Most Popular feed is empty.
 Feed:


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Make sure to follow the contributing guidelines. -->
<!-- Important note, we may remove your pull request if you do not use this provided PR template correctly. -->
<!-- Agent instructions: Preserve every heading, comment, and marker in this template. Never remove or rewrite the release-note-category:start/end, release-note:start/end, or release-note-image:start/end marker pairs. Never remove or rewrite the Release note images section; leave its contents for a human. -->

## Pull Request Type
<!-- Please select what type of pull request this is: [x] -->
- [x] Bugfix
- [ ] Feature Implementation
- [ ] Documentation
- [ ] Other

## Related issue
<!-- Please link the issue your pull request is referring to. -->
<!-- If this pull request fully resolves the relevant issue, put "closes" before the issue number. -->
<!-- Example: "closes #123456". -->

Closes #872.

## Description
<!-- Please write a clear and concise description of what the pull request does. -->

Trending request completions read the currently selected category after awaiting the response. Switching categories while requests were pending could therefore put results, loading state, errors, and refresh timestamps under the wrong category.

This captures the requested category for the full request lifetime. Each category now updates only its own state while requests for other categories continue concurrently. Visible results come from the active category's cache, timestamps are committed only after success, and unsupported backend settings show an inline status without recording a refresh.

## Release note category
<!-- Select exactly one category. Every pull request must select one. -->
<!-- Select "Not noteworthy" when the pull request fixes a bug in or improves functionality that has not yet appeared in a stable release. -->
<!-- release-note-category:start -->
- [ ] Not noteworthy
- [ ] Highlights
- [ ] More improvements
- [x] Fixed bugs
<!-- release-note-category:end -->

## Release note
<!-- Required unless "Not noteworthy" is selected. -->
<!-- Write one concise, user-facing entry without a leading bullet. -->
<!-- release-note:start -->
Fixed Trending category switches showing results or refresh state from a different pending request.
<!-- release-note:end -->

## Release note images
<!-- Human-only: Agents must preserve this entire section and leave it empty. -->
<!-- Optional. Paste one or more Markdown images or HTML image tags here. -->
<!-- The release notes will use an HTML image tag and limit images taller than 300 pixels. -->
<!-- release-note-image:start -->

<!-- release-note-image:end -->

## Testing
<!-- How can reviewers verify that the PR produces correct results? -->
<!-- Please provide instructions so that others can ensure that your pull request would produce correct results. For examples see, https://github.com/FreeTubeApp/FreeTube/pull/5743, https://github.com/FreeTubeApp/FreeTube/pull/7349, https://github.com/FreeTubeApp/FreeTube/pull/5125, https://github.com/FreeTubeApp/FreeTube/pull/7338 -->
<!-- Agent instructions: Only write human-facing steps that explain how to verify the change while running this branch in dev mode. Include expected results and, when applicable, helpful console snippets for interactive verification. Do not include automated checks, commands, results, pass counts, or CI status. -->

1. Open Trending on Gaming and delay its Local API response.
2. Switch to Sports before Gaming finishes, then let Gaming finish first.
3. Confirm Sports stays selected and loading, Gaming results do not appear under Sports, and returning to Gaming shows the completed Gaming results without another request.
4. Repeat with the Gaming request failing. Confirm Sports stays loading and its result can finish normally, then return to Gaming and confirm its error appears there.
5. Select Invidious, disable backend fallback, and open Trending directly. Confirm the page explains that Trending requires the Local API and does not show a new refresh time.

## Additional context
<!-- Add any other context about the pull request here. -->

Prepared in Codex with GPT-5.6-sol subagents for race reproduction, state review, and regression-test coverage.
