### PR TITLE
fix(queue): make reordering accessible

### DIFF
--- a/e2e/tests/offline/watch-queue.spec.mjs
+++ b/e2e/tests/offline/watch-queue.spec.mjs
@@ -78,10 +78,7 @@ test('manages a temporary queue from video menus and the watch sidebar', async (
 
   const draggedItem = reorderButton('Queue video three')
   await expect(draggedItem).toHaveAttribute('title', 'Drag Queue video three to reorder queue')
-  const dataTransfer = await page.evaluateHandle(() => new DataTransfer())
-  await draggedItem.dispatchEvent('dragstart', { dataTransfer })
-  await queueItem('Queue video two').dispatchEvent('drop', { dataTransfer })
-  await draggedItem.dispatchEvent('dragend', { dataTransfer })
+  await draggedItem.dragTo(queueItem('Queue video two'))
   await expect(queue.locator('.queueVideoTitle')).toHaveText([
     'Queue video one',
     'Queue video two',

--- a/e2e/tests/offline/watch-queue.spec.mjs
+++ b/e2e/tests/offline/watch-queue.spec.mjs
@@ -59,7 +59,25 @@ test('manages a temporary queue from video menus and the watch sidebar', async (
 
   const queueItems = queue.locator('.queueItem')
   const queueItem = title => queueItems.filter({ hasText: title })
-  const draggedItem = queueItem('Queue video three').locator('.queueDragHandle')
+  const reorderButton = title => queueItem(title).getByRole('button', { name: `Reorder ${title}` })
+  const moveStatus = queue.locator('[role="status"]')
+
+  await expect(moveStatus).toHaveCount(1)
+  await expect(moveStatus).toHaveAttribute('aria-live', 'polite')
+  await expect(moveStatus).toHaveAttribute('aria-atomic', 'true')
+  await expect(queueItems.locator('[role="status"]')).toHaveCount(0)
+
+  const middleReorderButton = reorderButton('Queue video one')
+  await expect(middleReorderButton).toHaveAccessibleName('Reorder Queue video one')
+  await expect(middleReorderButton).toHaveAccessibleDescription(
+    'Use the Up and Down Arrow keys to move this video in the queue.'
+  )
+  await expect(middleReorderButton).toHaveAttribute('aria-keyshortcuts', 'ArrowUp ArrowDown')
+  await expect(queueItem('Queue video one')).toHaveAttribute('aria-posinset', '2')
+  await expect(queueItem('Queue video one')).toHaveAttribute('aria-setsize', '3')
+
+  const draggedItem = reorderButton('Queue video three')
+  await expect(draggedItem).toHaveAttribute('title', 'Drag Queue video three to reorder queue')
   const dataTransfer = await page.evaluateHandle(() => new DataTransfer())
   await draggedItem.dispatchEvent('dragstart', { dataTransfer })
   await queueItem('Queue video two').dispatchEvent('drop', { dataTransfer })
@@ -70,19 +88,50 @@ test('manages a temporary queue from video menus and the watch sidebar', async (
     'Queue video three'
   ])
 
-  const thirdDragHandle = queueItem('Queue video three').locator('.queueDragHandle')
-  await thirdDragHandle.press('ArrowUp')
-  await expect(queue.locator('.queueVideoTitle')).toHaveText([
-    'Queue video one',
-    'Queue video three',
-    'Queue video two'
-  ])
-  await queueItem('Queue video three').locator('.queueDragHandle').press('ArrowDown')
+  const firstReorderButton = reorderButton('Queue video one')
+  await firstReorderButton.press('ArrowUp')
   await expect(queue.locator('.queueVideoTitle')).toHaveText([
     'Queue video one',
     'Queue video two',
     'Queue video three'
   ])
+  await expect(firstReorderButton).toBeFocused()
+  await expect(moveStatus).toHaveText(
+    'Cannot move Queue video one up. It is already at position 1 of 3.'
+  )
+
+  const thirdReorderButton = reorderButton('Queue video three')
+  await thirdReorderButton.press('ArrowDown')
+  await expect(queue.locator('.queueVideoTitle')).toHaveText([
+    'Queue video one',
+    'Queue video two',
+    'Queue video three'
+  ])
+  await expect(thirdReorderButton).toBeFocused()
+  await expect(moveStatus).toHaveText(
+    'Cannot move Queue video three down. It is already at position 3 of 3.'
+  )
+
+  await thirdReorderButton.press('ArrowUp')
+  await expect(queue.locator('.queueVideoTitle')).toHaveText([
+    'Queue video one',
+    'Queue video three',
+    'Queue video two'
+  ])
+  await expect(queueItem('Queue video three')).toHaveAttribute('aria-posinset', '2')
+  await expect(queueItem('Queue video three')).toHaveAttribute('aria-setsize', '3')
+  await expect(thirdReorderButton).toBeFocused()
+  await expect(moveStatus).toHaveText('Moved Queue video three to position 2 of 3.')
+
+  await page.keyboard.press('ArrowDown')
+  await expect(queue.locator('.queueVideoTitle')).toHaveText([
+    'Queue video one',
+    'Queue video two',
+    'Queue video three'
+  ])
+  await expect(queueItem('Queue video three')).toHaveAttribute('aria-posinset', '3')
+  await expect(thirdReorderButton).toBeFocused()
+  await expect(moveStatus).toHaveText('Moved Queue video three to position 3 of 3.')
 
   await queue.getByRole('button', { name: 'Remove Queue video three from queue' }).click()
   await expect(queue.locator('.queueVideoTitle')).toHaveText([

--- a/src/renderer/components/WatchVideoQueue/WatchVideoQueue.scss
+++ b/src/renderer/components/WatchVideoQueue/WatchVideoQueue.scss
@@ -21,6 +21,18 @@
   font-size: 13px;
 }
 
+.queueReorderInstructions,
+.queueReorderStatus {
+  position: absolute;
+  inline-size: 1px;
+  block-size: 1px;
+  padding: 0;
+  overflow: hidden;
+  border: 0;
+  clip-path: inset(50%);
+  white-space: nowrap;
+}
+
 .clearQueue {
   border: 0;
   background: transparent;
@@ -60,11 +72,16 @@
   place-items: center;
   inline-size: 30px;
   block-size: 30px;
+  padding: 0;
+  border: 0;
   border-radius: 50%;
+  background: transparent;
   color: var(--secondary-text-color);
   cursor: grab;
+  font: inherit;
 
-  &:hover {
+  &:hover,
+  &:focus-visible {
     background-color: var(--side-nav-hover-color);
     color: var(--primary-text-color);
   }

--- a/src/renderer/components/WatchVideoQueue/WatchVideoQueue.vue
+++ b/src/renderer/components/WatchVideoQueue/WatchVideoQueue.vue
@@ -19,6 +19,12 @@
         {{ t('Video.Clear Queue') }}
       </button>
     </header>
+    <p
+      :id="reorderInstructionsId"
+      class="queueReorderInstructions"
+    >
+      {{ t('Video.Reorder Queue Item Instructions') }}
+    </p>
     <TransitionGroup
       ref="queueItems"
       v-overlay-scrollbars
@@ -27,26 +33,31 @@
       class="queueItems"
     >
       <li
-        v-for="item in items"
+        v-for="(item, index) in items"
         :key="item.queueItemId"
         class="queueItem"
         :class="{ dragging: draggedQueueItemId === item.queueItemId }"
+        :aria-posinset="index + 1"
+        :aria-setsize="items.length"
         @dragover.prevent
         @drop.prevent="dropDraggedItem(item.queueItemId)"
       >
-        <span
+        <button
+          :ref="element => setQueueDragHandle(item.queueItemId, element)"
+          type="button"
           class="queueDragHandle"
           draggable="true"
-          tabindex="0"
-          :aria-label="t('Video.Drag to Reorder Queue', { title: item.title })"
+          :aria-label="t('Video.Reorder Queue Item', { title: item.title })"
+          :aria-describedby="reorderInstructionsId"
+          aria-keyshortcuts="ArrowUp ArrowDown"
           :title="t('Video.Drag to Reorder Queue', { title: item.title })"
           @dragstart="startDrag($event, item.queueItemId)"
           @dragend="endDrag"
-          @keydown.up.prevent="move(item.queueItemId, -1)"
-          @keydown.down.prevent="move(item.queueItemId, 1)"
+          @keydown.up.prevent="moveWithKeyboard(item.queueItemId, -1)"
+          @keydown.down.prevent="moveWithKeyboard(item.queueItemId, 1)"
         >
           <FtIcon :icon="['fas', 'bars']" />
-        </span>
+        </button>
         <RouterLink
           class="queueVideo"
           :to="`/watch/${item.videoId}`"
@@ -80,12 +91,20 @@
         </div>
       </li>
     </TransitionGroup>
+    <p
+      class="queueReorderStatus"
+      role="status"
+      aria-live="polite"
+      aria-atomic="true"
+    >
+      {{ queueReorderStatus }}
+    </p>
   </FtCard>
 </template>
 
 <script setup>
 import { FtIcon } from '@opentubex/icons'
-import { computed, onBeforeUnmount, onMounted, ref, useTemplateRef } from 'vue'
+import { computed, nextTick, onBeforeUnmount, onMounted, ref, useId, useTemplateRef } from 'vue'
 import { useI18n } from 'vue-i18n'
 
 import FtCard from '../ft-card/ft-card.vue'
@@ -100,8 +119,12 @@ const backendPreference = computed(() => store.getters.getBackendPreference)
 const invidiousUrl = computed(() => store.getters.getCurrentInvidiousInstanceUrl)
 const draggedQueueItemId = ref(null)
 const queueItems = useTemplateRef('queueItems')
+const reorderInstructionsId = useId()
+const queueReorderStatus = ref('')
+const queueDragHandles = new Map()
 let queueObserver = null
 let queueClampFrame = null
+let queueAnnouncementSequence = 0
 
 onMounted(() => {
   const container = queueItems.value?.$el ?? queueItems.value
@@ -141,6 +164,51 @@ function playQueuedVideo(queueItemId, event) {
 
 function move(queueItemId, offset) {
   store.commit('moveVideoInWatchQueue', { queueItemId, offset })
+}
+
+function setQueueDragHandle(queueItemId, element) {
+  if (element) {
+    queueDragHandles.set(queueItemId, element)
+  } else {
+    queueDragHandles.delete(queueItemId)
+  }
+}
+
+async function announceQueueReorder(message) {
+  const sequence = ++queueAnnouncementSequence
+  queueReorderStatus.value = ''
+  await nextTick()
+
+  if (sequence === queueAnnouncementSequence) {
+    queueReorderStatus.value = message
+  }
+}
+
+async function moveWithKeyboard(queueItemId, offset) {
+  const currentIndex = items.value.findIndex(item => item.queueItemId === queueItemId)
+  if (currentIndex === -1) {
+    return
+  }
+
+  const item = items.value[currentIndex]
+  const total = items.value.length
+  const targetIndex = currentIndex + offset
+  if (targetIndex < 0 || targetIndex >= total) {
+    const message = offset < 0
+      ? t('Video.Queue Item Cannot Move Up', { title: item.title, total })
+      : t('Video.Queue Item Cannot Move Down', { title: item.title, total })
+    await announceQueueReorder(message)
+    return
+  }
+
+  move(queueItemId, offset)
+  await nextTick()
+  queueDragHandles.get(queueItemId)?.focus({ preventScroll: true })
+  await announceQueueReorder(t('Video.Queue Item Moved', {
+    title: item.title,
+    position: targetIndex + 1,
+    total
+  }))
 }
 
 function startDrag(event, queueItemId) {

--- a/static/locales/en-US.yaml
+++ b/static/locales/en-US.yaml
@@ -1550,6 +1550,11 @@ Video:
   Queue Video Count: '{count} video | {count} videos'
   Remove from Queue: 'Remove {title} from queue'
   Drag to Reorder Queue: 'Drag {title} to reorder queue'
+  Reorder Queue Item: 'Reorder {title}'
+  Reorder Queue Item Instructions: Use the Up and Down Arrow keys to move this video in the queue.
+  Queue Item Moved: 'Moved {title} to position {position} of {total}.'
+  Queue Item Cannot Move Up: 'Cannot move {title} up. It is already at position 1 of {total}.'
+  Queue Item Cannot Move Down: 'Cannot move {title} down. It is already at position {total} of {total}.'
   Metadata: Video information
   Close Metadata: Close video information
   Metadata Cache:


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Make sure to follow the contributing guidelines. -->
<!-- Important note, we may remove your pull request if you do not use this provided PR template correctly. -->
<!-- Agent instructions: Preserve every heading, comment, and marker in this template. Never remove or rewrite the release-note-category:start/end, release-note:start/end, or release-note-image:start/end marker pairs. Never remove or rewrite the Release note images section; leave its contents for a human. -->

## Pull Request Type
<!-- Please select what type of pull request this is: [x] -->
- [x] Bugfix
- [ ] Feature Implementation
- [ ] Documentation
- [ ] Other

## Related issue
<!-- Please link the issue your pull request is referring to. -->
<!-- If this pull request fully resolves the relevant issue, put "closes" before the issue number. -->
<!-- Example: "closes #123456". -->

Resolves #874

## Description
<!-- Please write a clear and concise description of what the pull request does. -->

Watch-queue reorder handles did not expose control semantics, item positions, keyboard instructions, or move results to assistive technology. Focus after a Vue list move was also not explicitly tied to the queued video's identity.

This changes each handle to a native draggable button while keeping the existing ordered list, pointer dragging, and overlay scrollbar behavior. Keyboard moves restore focus by `queueItemId`, expose list position metadata, and report successful or blocked moves through one polite live region outside the repeated rows.

## Release note category
<!-- Select exactly one category. Every pull request must select one. -->
<!-- Select "Not noteworthy" when the pull request fixes a bug in or improves functionality that has not yet appeared in a stable release. -->
<!-- release-note-category:start -->
- [x] Not noteworthy
- [ ] Highlights
- [ ] More improvements
- [ ] Fixed bugs
<!-- release-note-category:end -->

## Release note
<!-- Required unless "Not noteworthy" is selected. -->
<!-- Write one concise, user-facing entry without a leading bullet. -->
<!-- release-note:start -->

<!-- release-note:end -->

## Release note images
<!-- Human-only: Agents must preserve this entire section and leave it empty. -->
<!-- Optional. Paste one or more Markdown images or HTML image tags here. -->
<!-- The release notes will use an HTML image tag and limit images taller than 300 pixels. -->
<!-- release-note-image:start -->

<!-- release-note-image:end -->

## Testing
<!-- How can reviewers verify that the PR produces correct results? -->
<!-- Please provide instructions so that others can ensure that your pull request would produce correct results. For examples see, https://github.com/FreeTubeApp/FreeTube/pull/5743, https://github.com/FreeTubeApp/FreeTube/pull/7349, https://github.com/FreeTubeApp/FreeTube/pull/5125, https://github.com/FreeTubeApp/FreeTube/pull/7338 -->
<!-- Agent instructions: Only write human-facing steps that explain how to verify the change while running this branch in dev mode. Include expected results and, when applicable, helpful console snippets for interactive verification. Do not include automated checks, commands, results, pass counts, or CI status. -->

1. Add three videos to the watch queue and focus a reorder handle. Confirm it is exposed as a button named for its video, with Up and Down Arrow instructions and the item's position in the list.
2. Move the middle item in both directions with the Arrow keys. Focus should remain on that video's reorder button, and a screen reader should announce its new position once per move.
3. Press Arrow Up on the first item and Arrow Down on the last item. The order and focus should remain unchanged, and a screen reader should announce that the item cannot move farther.
4. Drag a queue item with the pointer and confirm the existing drag behavior still works. Add enough items to overflow the queue and confirm it still uses the themed overlay scrollbar.

## Additional context
<!-- Add any other context about the pull request here. -->

Focus restoration uses a map keyed by `queueItemId`, so TransitionGroup moves never substitute an item that happens to occupy the same array index. The status node stays mounted outside the ordered list and is reused for every keyboard result.
