### PR TITLE
fix(tabs): keep cleared search bar empty after tab switches

### DIFF
--- a/e2e/tests/offline/tabs.spec.mjs
+++ b/e2e/tests/offline/tabs.spec.mjs
@@ -816,6 +816,20 @@ test.describe('tab bar', () => {
     await expect(searchInput).toHaveValue('second tab query')
   })
 
+  test('cleared search bar text stays empty after switching tabs', async ({ page }) => {
+    const searchInput = page.locator(sel.searchInput)
+    await page.locator(sel.newTabButton).click()
+
+    await searchInput.fill('https://www.youtube.com/watch?v=jNQXAC9IVRw')
+    await page.locator('.topNav .searchInput .clearInputTextButton').click()
+    await expect(searchInput).toHaveValue('')
+
+    await page.locator(sel.tabs).first().click()
+    await page.locator(sel.tabs).nth(1).click()
+
+    await expect(searchInput).toHaveValue('')
+  })
+
   test('search filters are independent per tab', async ({ page }) => {
     const filterButton = page.locator('.navFilterButton')
 

--- a/src/renderer/components/TopNav/TopNav.vue
+++ b/src/renderer/components/TopNav/TopNav.vue
@@ -100,7 +100,7 @@
             show-data-when-empty
             @input="getSearchSuggestionsDebounce"
             @click="goToSearch"
-            @clear="clearLastSuggestionQuery"
+            @clear="handleSearchInputClear"
             @remove="removeSearchHistoryEntryInDbAndCache"
           >
             <template #extraAction>
@@ -727,6 +727,11 @@ async function goToSearch(queryText, { event, dataListIndex }) {
 
 function clearLastSuggestionQuery() {
   lastSuggestionQuery.value = ''
+}
+
+function handleSearchInputClear() {
+  currentSearchText = ''
+  clearLastSuggestionQuery()
 }
 
 /**


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Make sure to follow the contributing guidelines. -->
<!-- Important note, we may remove your pull request if you do not use this provided PR template correctly. -->
<!-- Agent instructions: Preserve every heading, comment, and marker in this template. Never remove or rewrite the release-note-category:start/end, release-note:start/end, or release-note-image:start/end marker pairs. Never remove or rewrite the Release note images section; leave its contents for a human. -->

## Pull Request Type
<!-- Please select what type of pull request this is: [x] -->
- [x] Bugfix
- [ ] Feature Implementation
- [ ] Documentation
- [ ] Other

## Related issue
<!-- Please link the issue your pull request is referring to. -->
<!-- If this pull request fully resolves the relevant issue, put "closes" before the issue number. -->
<!-- Example: "closes #123456". -->

## Description
<!-- Please write a clear and concise description of what the pull request does. -->
Clearing a pasted YouTube URL only emptied the visible search input. Its per-tab draft still held the URL, so switching away and back restored it.

The clear handler now clears both the input state and the active tab's cached search draft.

## Release note category
<!-- Select exactly one category. Every pull request must select one. -->
<!-- Select "Not noteworthy" when the pull request fixes a bug in or improves functionality that has not yet appeared in a stable release. -->
<!-- release-note-category:start -->
- [ ] Not noteworthy
- [ ] Highlights
- [ ] More improvements
- [x] Fixed bugs
<!-- release-note-category:end -->

## Release note
<!-- Required unless "Not noteworthy" is selected. -->
<!-- Write one concise, user-facing entry without a leading bullet. -->
<!-- release-note:start -->
Clearing the search bar now stays cleared when switching between tabs.
<!-- release-note:end -->

## Release note images
<!-- Human-only: Agents must preserve this entire section and leave it empty. -->
<!-- Optional. Paste one or more Markdown images or HTML image tags here. -->
<!-- The release notes will use an HTML image tag and limit images taller than 300 pixels. -->
<!-- release-note-image:start -->

<!-- release-note-image:end -->

## Testing
<!-- How can reviewers verify that the PR produces correct results? -->
<!-- Please provide instructions so that others can ensure that your pull request would produce correct results. For examples see, https://github.com/FreeTubeApp/FreeTube/pull/5743, https://github.com/FreeTubeApp/FreeTube/pull/7349, https://github.com/FreeTubeApp/FreeTube/pull/5125, https://github.com/FreeTubeApp/FreeTube/pull/7338 -->
<!-- Agent instructions: Only write human-facing steps that explain how to verify the change while running this branch in dev mode. Include expected results and, when applicable, helpful console snippets for interactive verification. Do not include automated checks, commands, results, pass counts, or CI status. -->
1. Run the app in dev mode and open a new tab.
2. Paste a YouTube URL into the search bar without submitting it.
3. Clear the search bar, switch to another tab, then switch back.
4. Confirm that the search bar remains empty.

## Additional context
<!-- Add any other context about the pull request here. -->
