### PR TITLE
fix(tabs): resume videos from saved progress after restart

### DIFF
--- a/e2e/tests/offline/player.spec.mjs
+++ b/e2e/tests/offline/player.spec.mjs
@@ -1,9 +1,10 @@
-import { setWindowSize, test, expect } from '../../helpers/app.mjs'
+import { sel, setWindowSize, test, expect } from '../../helpers/app.mjs'
 import {
   activeTab,
   expectDockedToBottomRight,
   findWatchComponent,
   openMockedVideo,
+  waitForPlayback,
 } from '../../helpers/player.mjs'
 import { mockPlayableWatchPage } from '../../helpers/watch.mjs'
 
@@ -46,6 +47,21 @@ test('playback starts', async ({ app, page, attachScreenshot }) => {
     .toBeGreaterThan(1)
 
   await attachScreenshot('playing video')
+})
+
+test('does not restore a consumed link timestamp after an app restart', async ({ app, page }) => {
+  await mockPlayableWatchPage(app, page)
+  await page.locator(sel.searchInput).fill('https://www.youtube.com/watch?v=jNQXAC9IVRw&t=2')
+  const timestampNavigation = page.waitForURL(/#\/watch\/jNQXAC9IVRw\?timestamp=2/)
+  await page.locator(sel.searchInput).press('Enter')
+
+  await timestampNavigation
+  const video = await waitForPlayback(page)
+  await expect.poll(() => video.evaluate(element => element.currentTime)).toBeGreaterThan(2)
+  await expect(page).toHaveURL(/#\/watch\/jNQXAC9IVRw$/)
+
+  ;({ page } = await app.relaunch())
+  await expect(page).toHaveURL(/#\/watch\/jNQXAC9IVRw$/)
 })
 
 test('hides configured paused interface elements until pointer activity', async ({ app, page }) => {

--- a/e2e/tests/offline/session-restore.spec.mjs
+++ b/e2e/tests/offline/session-restore.spec.mjs
@@ -68,7 +68,7 @@ async function readSavedSession(userDataDir) {
   return records.at(-1)?.value
 }
 
-test('does not restore consumed watch timestamps after an app restart', async ({ app, page }) => {
+test('keeps an unconsumed link timestamp across an app restart', async ({ app, page }) => {
   await expect.poll(async () => {
     const session = await readSavedSession(app.userDataDir)
     const watchTab = session?.tabs.find((tab) => tab.id === WATCH_TAB_ID)
@@ -77,15 +77,15 @@ test('does not restore consumed watch timestamps after an app restart', async ({
       historyQuery: watchTab?.history?.[0]?.route?.query
     }
   }).toEqual({
-    url: 'app://bundle/index.html#/watch/jNQXAC9IVRw',
-    historyQuery: {}
+    url: 'app://bundle/index.html#/watch/jNQXAC9IVRw?timestamp=34',
+    historyQuery: { timestamp: '34' }
   })
 
   ;({ page } = await app.relaunch())
   await expect.poll(async () => {
     const state = await page.evaluate(() => window.ftElectron.tabs.getState())
     return state.tabs.find((tab) => tab.id === WATCH_TAB_ID)?.url
-  }).toBe('app://bundle/index.html#/watch/jNQXAC9IVRw')
+  }).toBe('app://bundle/index.html#/watch/jNQXAC9IVRw?timestamp=34')
 })
 
 test('restores tab order, titles, active route, and saved load state across restarts', async ({ app, page }) => {

--- a/e2e/tests/offline/session-restore.spec.mjs
+++ b/e2e/tests/offline/session-restore.spec.mjs
@@ -11,7 +11,11 @@ const STALE_WATCH_URL = 'app://bundle/index.html#/watch/jNQXAC9IVRw?oneTimeTimes
 
 test.use({
   seed: {
-    settings: { currentLocale: 'de-DE', startupBehavior: 'restoreTabLoadState' },
+    settings: {
+      currentLocale: 'de-DE',
+      rememberTabNavigationHistory: true,
+      startupBehavior: 'restoreTabLoadState'
+    },
     tabSessions: [
       {
         _id: 'e2e-window-session',
@@ -33,7 +37,16 @@ test.use({
               id: WATCH_TAB_ID,
               url: STALE_WATCH_URL,
               title: 'Saved video',
-              isUnloaded: true
+              isUnloaded: true,
+              history: [{
+                route: {
+                  path: '/watch/jNQXAC9IVRw',
+                  query: { oneTimeTimestamp: '12', timestamp: '34' }
+                },
+                title: 'Saved video',
+                scroll: { left: 0, top: 0 }
+              }],
+              historyIndex: 0
             }
           ],
           activeTabId: HISTORY_TAB_ID,
@@ -55,6 +68,26 @@ async function readSavedSession(userDataDir) {
   return records.at(-1)?.value
 }
 
+test('does not restore consumed watch timestamps after an app restart', async ({ app, page }) => {
+  await expect.poll(async () => {
+    const session = await readSavedSession(app.userDataDir)
+    const watchTab = session?.tabs.find((tab) => tab.id === WATCH_TAB_ID)
+    return {
+      url: watchTab?.url,
+      historyQuery: watchTab?.history?.[0]?.route?.query
+    }
+  }).toEqual({
+    url: 'app://bundle/index.html#/watch/jNQXAC9IVRw',
+    historyQuery: {}
+  })
+
+  ;({ page } = await app.relaunch())
+  await expect.poll(async () => {
+    const state = await page.evaluate(() => window.ftElectron.tabs.getState())
+    return state.tabs.find((tab) => tab.id === WATCH_TAB_ID)?.url
+  }).toBe('app://bundle/index.html#/watch/jNQXAC9IVRw')
+})
+
 test('restores tab order, titles, active route, and saved load state across restarts', async ({ app, page }) => {
   const tabs = page.locator(sel.tabs)
   await expect(tabs).toHaveCount(3)
@@ -65,13 +98,6 @@ test('restores tab order, titles, active route, and saved load state across rest
   await expect(tabs.nth(0)).not.toHaveClass(/unloaded/)
   await expect(tabs.nth(2)).toHaveClass(/unloaded/)
   await expect(page).toHaveURL(/#\/history/)
-
-  // oneTimeTimestamp is only valid for an in-process player reload. Persisting
-  // it used to override the newer watch progress when a session was restored.
-  await expect.poll(async () => {
-    const session = await readSavedSession(app.userDataDir)
-    return session?.tabs.find((tab) => tab.id === WATCH_TAB_ID)?.url
-  }).toBe('app://bundle/index.html#/watch/jNQXAC9IVRw?timestamp=34')
 
   await tabs.nth(0).click()
   await expect(page).toHaveURL(/#\/subscriptions/)

--- a/src/main/tabs/TabManager.js
+++ b/src/main/tabs/TabManager.js
@@ -267,9 +267,11 @@ export class TabManager {
       .filter(entry => typeof entry?.route?.path === 'string')
       .map(entry => {
         const route = normalizeRoute(entry.route)
-        // `oneTimeTimestamp` must not survive persistence (see stripOneTimeTimestampFromUrl)
-        if ('oneTimeTimestamp' in route.query) {
+        // Watch timestamps only apply to the navigation that opened the video.
+        // Replaying them after a restart would override newer watch progress.
+        if (route.path.startsWith('/watch/')) {
           delete route.query.oneTimeTimestamp
+          delete route.query.timestamp
         }
         return {
           route: normalizeRoute(route),
@@ -333,15 +335,18 @@ export class TabManager {
   }
 
   /**
-   * `oneTimeTimestamp` is only meant to be consumed once by the Watch view
-   * (e.g. after a SABR player reload). If it survives into a persisted tab
-   * session, restoring the tab jumps to the stale reload position instead of
-   * the newer watch progress saved in the history database.
+   * Watch timestamps are only meant to be consumed by the navigation that
+   * opened the video. If one survives into a persisted tab session, restoring
+   * the tab jumps to the stale position instead of the newer watch progress
+   * saved in the history database.
    * @param {string} url
    * @returns {string}
    */
-  static stripOneTimeTimestampFromUrl(url) {
-    if (typeof url !== 'string' || !url.includes('oneTimeTimestamp=')) {
+  static stripWatchTimestampsFromUrl(url) {
+    if (
+      typeof url !== 'string' ||
+      (!url.includes('oneTimeTimestamp=') && !url.includes('timestamp='))
+    ) {
       return url
     }
 
@@ -351,11 +356,12 @@ export class TabManager {
     }
 
     const route = TabManager.getRouteFromUrl(url)
-    if (!('oneTimeTimestamp' in route.query)) {
+    if (!route.path.startsWith('/watch/')) {
       return url
     }
 
     delete route.query.oneTimeTimestamp
+    delete route.query.timestamp
     return url.slice(0, hashIndex + 1) + normalizeRoute(route).fullPath
   }
 
@@ -2715,7 +2721,7 @@ export class TabManager {
       .map(tab => {
         const tabData = {
           id: tab.id,
-          url: TabManager.stripOneTimeTimestampFromUrl(tab.url),
+          url: TabManager.stripWatchTimestampsFromUrl(tab.url),
           title: tab.title,
           isPinned: tab.isPinned,
           color: TabManager.normalizeTabColor(tab.color),
@@ -2765,7 +2771,7 @@ export class TabManager {
       .filter(tab => !this._deferredCloseTabIds.has(tab.id))
       .map(tab => ({
         id: tab.id,
-        url: TabManager.stripOneTimeTimestampFromUrl(tab.url),
+        url: TabManager.stripWatchTimestampsFromUrl(tab.url),
         title: tab.title,
         isPinned: tab.isPinned,
         color: tab.color,
@@ -2897,7 +2903,7 @@ export class TabManager {
         const tab = this.createTab({
           id: typeof tabData.id === 'string' ? tabData.id : undefined,
           // Strip here as well to heal sessions persisted before the strip on save existed
-          url: TabManager.stripOneTimeTimestampFromUrl(tabData.url),
+          url: TabManager.stripWatchTimestampsFromUrl(tabData.url),
           title: hasSavedTitle ? tabData.title : undefined,
           avatarDataUrl,
           avatarFileName: avatarDataUrl == null ? null : avatarFileName,

--- a/src/main/tabs/TabManager.js
+++ b/src/main/tabs/TabManager.js
@@ -267,11 +267,9 @@ export class TabManager {
       .filter(entry => typeof entry?.route?.path === 'string')
       .map(entry => {
         const route = normalizeRoute(entry.route)
-        // Watch timestamps only apply to the navigation that opened the video.
-        // Replaying them after a restart would override newer watch progress.
-        if (route.path.startsWith('/watch/')) {
+        // `oneTimeTimestamp` must not survive persistence (see stripOneTimeTimestampFromUrl)
+        if ('oneTimeTimestamp' in route.query) {
           delete route.query.oneTimeTimestamp
-          delete route.query.timestamp
         }
         return {
           route: normalizeRoute(route),
@@ -335,18 +333,15 @@ export class TabManager {
   }
 
   /**
-   * Watch timestamps are only meant to be consumed by the navigation that
-   * opened the video. If one survives into a persisted tab session, restoring
-   * the tab jumps to the stale position instead of the newer watch progress
-   * saved in the history database.
+   * `oneTimeTimestamp` is only meant to be consumed once by the Watch view
+   * (e.g. after a SABR player reload). If it survives into a persisted tab
+   * session, restoring the tab jumps to the stale reload position instead of
+   * the newer watch progress saved in the history database.
    * @param {string} url
    * @returns {string}
    */
-  static stripWatchTimestampsFromUrl(url) {
-    if (
-      typeof url !== 'string' ||
-      (!url.includes('oneTimeTimestamp=') && !url.includes('timestamp='))
-    ) {
+  static stripOneTimeTimestampFromUrl(url) {
+    if (typeof url !== 'string' || !url.includes('oneTimeTimestamp=')) {
       return url
     }
 
@@ -356,12 +351,11 @@ export class TabManager {
     }
 
     const route = TabManager.getRouteFromUrl(url)
-    if (!route.path.startsWith('/watch/')) {
+    if (!('oneTimeTimestamp' in route.query)) {
       return url
     }
 
     delete route.query.oneTimeTimestamp
-    delete route.query.timestamp
     return url.slice(0, hashIndex + 1) + normalizeRoute(route).fullPath
   }
 
@@ -2721,7 +2715,7 @@ export class TabManager {
       .map(tab => {
         const tabData = {
           id: tab.id,
-          url: TabManager.stripWatchTimestampsFromUrl(tab.url),
+          url: TabManager.stripOneTimeTimestampFromUrl(tab.url),
           title: tab.title,
           isPinned: tab.isPinned,
           color: TabManager.normalizeTabColor(tab.color),
@@ -2771,7 +2765,7 @@ export class TabManager {
       .filter(tab => !this._deferredCloseTabIds.has(tab.id))
       .map(tab => ({
         id: tab.id,
-        url: TabManager.stripWatchTimestampsFromUrl(tab.url),
+        url: TabManager.stripOneTimeTimestampFromUrl(tab.url),
         title: tab.title,
         isPinned: tab.isPinned,
         color: tab.color,
@@ -2903,7 +2897,7 @@ export class TabManager {
         const tab = this.createTab({
           id: typeof tabData.id === 'string' ? tabData.id : undefined,
           // Strip here as well to heal sessions persisted before the strip on save existed
-          url: TabManager.stripWatchTimestampsFromUrl(tabData.url),
+          url: TabManager.stripOneTimeTimestampFromUrl(tabData.url),
           title: hasSavedTitle ? tabData.title : undefined,
           avatarDataUrl,
           avatarFileName: avatarDataUrl == null ? null : avatarFileName,

--- a/src/renderer/views/Watch/Watch.js
+++ b/src/renderer/views/Watch/Watch.js
@@ -1086,6 +1086,14 @@ export default defineComponent({
     },
     async 'tabRoute.fullPath'(fullPath, previousFullPath) {
       if (
+        !('timestamp' in this.tabRoute.query) &&
+        this.watchRouteWithoutTimestamp(fullPath) ===
+          this.watchRouteWithoutTimestamp(previousFullPath)
+      ) {
+        return
+      }
+
+      if (
         this.playbackSourceRouteBase(fullPath) ===
         this.playbackSourceRouteBase(previousFullPath)
       ) {
@@ -1983,6 +1991,12 @@ export default defineComponent({
     playbackSourceRouteBase: function (fullPath) {
       const url = new URL(fullPath, 'https://opentubex.invalid')
       url.searchParams.delete('downloadId')
+      return `${url.pathname}${url.search}${url.hash}`
+    },
+
+    watchRouteWithoutTimestamp: function (fullPath) {
+      const url = new URL(fullPath, 'https://opentubex.invalid')
+      url.searchParams.delete('timestamp')
       return `${url.pathname}${url.search}${url.hash}`
     },
 
@@ -3911,7 +3925,7 @@ export default defineComponent({
       return isHistoryEntryWatched(this.$store.getters.getHistoryCacheById[videoId])
     },
 
-    handleVideoLoaded: function (mediaMetadata) {
+    handleVideoLoaded: async function (mediaMetadata) {
       if (this.isLoading || this.preparingVideoLoadGeneration !== null) { return }
 
       this.suppressTabLoadingIndicator = false
@@ -3960,6 +3974,10 @@ export default defineComponent({
         }
 
         this.updateLocalPlaylistLastPlayedAtSometimes()
+
+        if (process.env.IS_ELECTRON && this.timestamp !== null) {
+          await this.consumeTimestamp()
+        }
       }
     },
 
@@ -4014,6 +4032,19 @@ export default defineComponent({
 
       const timestamp = parseInt(this.tabRoute.query.timestamp)
       this.timestamp = isNaN(timestamp) || timestamp < 0 ? null : timestamp
+    },
+
+    consumeTimestamp: async function () {
+      const query = { ...this.tabRoute.query }
+      if (!('timestamp' in query)) return
+
+      delete query.timestamp
+      await this.tabRouter.replace({
+        path: this.tabRoute.path,
+        query,
+        hash: this.tabRoute.hash
+      })
+      this.timestamp = null
     },
 
     handleFormatChange: function (format) {


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Make sure to follow the contributing guidelines. -->
<!-- Important note, we may remove your pull request if you do not use this provided PR template correctly. -->
<!-- Agent instructions: Preserve every heading, comment, and marker in this template. Never remove or rewrite the release-note-category:start/end, release-note:start/end, or release-note-image:start/end marker pairs. Never remove or rewrite the Release note images section; leave its contents for a human. -->

## Pull Request Type
<!-- Please select what type of pull request this is: [x] -->
- [x] Bugfix
- [ ] Feature Implementation
- [ ] Documentation
- [ ] Other

## Related issue
<!-- Please link the issue your pull request is referring to. -->
<!-- If this pull request fully resolves the relevant issue, put "closes" before the issue number. -->
<!-- Example: "closes #123456". -->

## Description
<!-- Please write a clear and concise description of what the pull request does. -->
Restarting the app replayed the original timestamp from a pasted video link, even after newer watch progress had been saved.

This removes consumed watch timestamps from persisted tab URLs and saved navigation history. The initial navigation still honors the link timestamp, while a restored session falls back to the latest watch progress.

## Release note category
<!-- Select exactly one category. Every pull request must select one. -->
<!-- Select "Not noteworthy" when the pull request fixes a bug in or improves functionality that has not yet appeared in a stable release. -->
<!-- release-note-category:start -->
- [ ] Not noteworthy
- [ ] Highlights
- [ ] More improvements
- [x] Fixed bugs
<!-- release-note-category:end -->

## Release note
<!-- Required unless "Not noteworthy" is selected. -->
<!-- Write one concise, user-facing entry without a leading bullet. -->
<!-- release-note:start -->
Videos opened from timestamped links now resume from saved progress after restarting the app.
<!-- release-note:end -->

## Release note images
<!-- Human-only: Agents must preserve this entire section and leave it empty. -->
<!-- Optional. Paste one or more Markdown images or HTML image tags here. -->
<!-- The release notes will use an HTML image tag and limit images taller than 300 pixels. -->
<!-- release-note-image:start -->

<!-- release-note-image:end -->

## Testing
<!-- How can reviewers verify that the PR produces correct results? -->
<!-- Please provide instructions so that others can ensure that your pull request would produce correct results. For examples see, https://github.com/FreeTubeApp/FreeTube/pull/5743, https://github.com/FreeTubeApp/FreeTube/pull/7349, https://github.com/FreeTubeApp/FreeTube/pull/5125, https://github.com/FreeTubeApp/FreeTube/pull/7338 -->
<!-- Agent instructions: Only write human-facing steps that explain how to verify the change while running this branch in dev mode. Include expected results and, when applicable, helpful console snippets for interactive verification. Do not include automated checks, commands, results, pass counts, or CI status. -->
1. Enable watch history and configure the app to restore tabs after startup.
2. Paste a video link with a timestamp into the search field and start playback.
3. Watch past the link timestamp, then close and reopen the app.
4. Confirm that the video resumes from the later saved position instead of the link timestamp.

## Additional context
<!-- Add any other context about the pull request here. -->
