### PR TITLE
fix: leave short numeric references unlinked

### DIFF
--- a/e2e/tests/offline/description-links.spec.mjs
+++ b/e2e/tests/offline/description-links.spec.mjs
@@ -10,7 +10,7 @@ import { demoPlayerResponse, routeWatchPageHtml } from '../../helpers/media.mjs'
 const fixtureDir = path.join(repoRoot, 'e2e', 'fixtures', 'innertube', 'watch', 'shows-video-metadata')
 const sharedDir = path.join(repoRoot, 'e2e', 'fixtures', 'innertube', 'shared')
 
-const VIDEO_TITLE = 'Sketching again #ShiorinSketch'
+const VIDEO_TITLE = 'Numbered video #9 #ShiorinSketch'
 const VIDEO_DESCRIPTION = 'Follow @SomeCreator for more #ShiorinSketch clips'
 
 async function fixture(dir, name) {
@@ -97,7 +97,7 @@ async function mockWatchPage(app, page) {
   })
 }
 
-test.describe('unlinked hashtags and handles', () => {
+test.describe('hashtag and handle linkification', () => {
   test.use({
     seed: {
       history: [{
@@ -119,7 +119,7 @@ test.describe('unlinked hashtags and handles', () => {
     }
   })
 
-  test('are clickable in the video title and description', async ({ app, page }) => {
+  test('links valid tags but leaves short numeric references plain', async ({ app, page }) => {
     await mockWatchPage(app, page)
 
     await goTo(page, 'history')
@@ -127,6 +127,7 @@ test.describe('unlinked hashtags and handles', () => {
     await expect(page).toHaveURL(/#\/watch\/jNQXAC9IVRw/)
 
     const titleLink = page.locator('.videoTitle a')
+    await expect(titleLink).toHaveCount(1)
     await expect(titleLink).toHaveText('#ShiorinSketch')
     await expect(titleLink).toHaveAttribute('href', 'https://youtube.com/hashtag/ShiorinSketch')
     await expect(page.locator('.videoTitle')).toHaveText(VIDEO_TITLE)

--- a/src/renderer/helpers/descriptionLinks.js
+++ b/src/renderer/helpers/descriptionLinks.js
@@ -3,7 +3,7 @@ import autolinker from 'autolinker'
 const SHORT_NUMERIC_HASHTAG_PATTERN = /^\p{Number}{1,2}$/u
 
 function linkYouTubeMatch(match) {
-  if (match.getType() === 'hashtag' && SHORT_NUMERIC_HASHTAG_PATTERN.test(match.getHashtag())) {
+  if (match.type === 'hashtag' && SHORT_NUMERIC_HASHTAG_PATTERN.test(match.getHashtag())) {
     return false
   }
 

--- a/src/renderer/helpers/descriptionLinks.js
+++ b/src/renderer/helpers/descriptionLinks.js
@@ -1,12 +1,25 @@
 import autolinker from 'autolinker'
 
+const SHORT_NUMERIC_HASHTAG_PATTERN = /^\p{Number}{1,2}$/u
+
+function linkYouTubeMatch(match) {
+  if (match.getType() === 'hashtag' && SHORT_NUMERIC_HASHTAG_PATTERN.test(match.getHashtag())) {
+    return false
+  }
+
+  return true
+}
+
 // YouTube only links the `#hashtags` and `@handles` that it recognised itself,
 // the rest stays plain text, so we link those ourselves.
 // Autolinker skips text inside existing links and HTML attributes,
 // so the ones that came linked from the backend are left untouched.
 const HASHTAG_AND_HANDLE_OPTIONS = {
   hashtag: 'youtube',
-  mention: 'youtube'
+  mention: 'youtube',
+  // YouTube treats one- and two-digit `#` sequences as numbering. Numeric
+  // hashtags become links once they contain at least three digits.
+  replaceFn: linkYouTubeMatch
 }
 
 /**

--- a/tests/unit/description-links.test.mjs
+++ b/tests/unit/description-links.test.mjs
@@ -39,6 +39,20 @@ test('does not link things that only look like hashtags or handles', () => {
   assert.doesNotMatch(html, /<a/)
 })
 
+test('does not link one- or two-digit hashtags', () => {
+  const html = linkifyHashtagsAndHandles('Parts #9, #10 and #99')
+
+  assert.strictEqual(html, 'Parts #9, #10 and #99')
+})
+
+test('links longer numeric and short textual hashtags', () => {
+  const html = linkifyHashtagsAndHandles('#100 #123 #ai #9a #猫')
+
+  for (const tag of ['100', '123', 'ai', '9a', '猫']) {
+    assert.match(html, new RegExp(`<a href="https://youtube\\.com/hashtag/${tag}"[^>]*>#${tag}</a>`))
+  }
+})
+
 test('keeps the escaped HTML of a title escaped', () => {
   // titles are plain text, so they get escaped before their hashtags and handles are linked
   const html = linkifyHashtagsAndHandles('&lt;b&gt;Bold&lt;/b&gt; #Tag')


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Make sure to follow the contributing guidelines. -->
<!-- Important note, we may remove your pull request if you do not use this provided PR template correctly. -->
<!-- Agent instructions: Preserve every heading, comment, and marker in this template. Never remove or rewrite the release-note-category:start/end, release-note:start/end, or release-note-image:start/end marker pairs. Never remove or rewrite the Release note images section; leave its contents for a human. -->

## Pull Request Type
<!-- Please select what type of pull request this is: [x] -->
- [x] Bugfix
- [ ] Feature Implementation
- [ ] Documentation
- [ ] Other

## Related issue
<!-- Please link the issue your pull request is referring to. -->
<!-- If this pull request fully resolves the relevant issue, put "closes" before the issue number. -->
<!-- Example: "closes #123456". -->

## Description
<!-- Please write a clear and concise description of what the pull request does. -->

Autolinker currently turns one- and two-digit numbering references into hashtag links, while YouTube leaves them as plain text. This filters those short numeric matches without affecting longer numeric, textual, mixed, or Unicode hashtags. Unit and watch-page regression coverage protect both sides of the boundary.

## Release note category
<!-- Select exactly one category. Every pull request must select one. -->
<!-- Select "Not noteworthy" when the pull request fixes a bug in or improves functionality that has not yet appeared in a stable release. -->
<!-- release-note-category:start -->
- [x] Not noteworthy
- [ ] Highlights
- [ ] More improvements
- [ ] Fixed bugs
<!-- release-note-category:end -->

## Release note
<!-- Required unless "Not noteworthy" is selected. -->
<!-- Write one concise, user-facing entry without a leading bullet. -->
<!-- release-note:start -->

<!-- release-note:end -->

## Release note images
<!-- Human-only: Agents must preserve this entire section and leave it empty. -->
<!-- Optional. Paste one or more Markdown images or HTML image tags here. -->
<!-- The release notes will use an HTML image tag and limit images taller than 300 pixels. -->
<!-- release-note-image:start -->

<!-- release-note-image:end -->

## Testing
<!-- How can reviewers verify that the PR produces correct results? -->
<!-- Please provide instructions so that others can ensure that your pull request would produce correct results. For examples see, https://github.com/FreeTubeApp/FreeTube/pull/5743, https://github.com/FreeTubeApp/FreeTube/pull/7349, https://github.com/FreeTubeApp/FreeTube/pull/5125, https://github.com/FreeTubeApp/FreeTube/pull/7338 -->
<!-- Agent instructions: Only write human-facing steps that explain how to verify the change while running this branch in dev mode. Include expected results and, when applicable, helpful console snippets for interactive verification. Do not include automated checks, commands, results, pass counts, or CI status. -->

1. Run the branch in dev mode and open a video whose title contains a one- or two-digit number prefixed with `#`.
2. Confirm the numeric reference remains plain text and cannot be clicked.
3. Open a video with a textual hashtag or a numeric hashtag containing at least three digits.
4. Confirm the valid hashtag remains clickable and opens its hashtag page.

## Additional context
<!-- Add any other context about the pull request here. -->
