### PR TITLE
fix(shorts): repair information panels and fullscreen motion

### DIFF
--- a/e2e/tests/offline/watch-page.spec.mjs
+++ b/e2e/tests/offline/watch-page.spec.mjs
@@ -291,7 +291,7 @@ test.describe('Shorts transcript navigation', () => {
 
   test('docks, scrolls, and clamps video information across Shorts navigation', async ({ app, page }) => {
     await mockPlayableWatchPage(app, page)
-    await setWindowSize(app, page, { width: 1325, height: 1012 })
+    await setWindowSize(app, page, { width: 1325, height: 760 })
     await page.locator(sel.searchInput)
       .fill(`https://www.youtube.com/shorts/${CAPTIONED_SHORT_IDS[0]}`)
     await page.locator(sel.searchInput).press('Enter')
@@ -355,6 +355,28 @@ test.describe('Shorts transcript navigation', () => {
         renderedEndVisible: descriptionBounds.bottom <= viewportBounds.bottom + 1
       }
     })).toEqual({ atScrollEnd: true, renderedEndVisible: true })
+
+    await setWindowSize(app, page, { width: 1326, height: 1012 })
+    await expect.poll(() => scroller.evaluate(element => {
+      const contentEnd = element.querySelector('.shortsAuxPanelContentEnd')
+      const scrollbar = element.querySelector(':scope > .os-scrollbar-vertical')
+      const viewportBounds = element.getBoundingClientRect()
+      const contentEndBounds = contentEnd.getBoundingClientRect()
+      const maximumScrollTop = Math.max(0, contentEnd.offsetTop - element.clientHeight)
+      const hasVerticalOverflow = maximumScrollTop > 1
+      return {
+        atRenderedEnd: maximumScrollTop === 0
+          ? element.scrollTop <= 1
+          : Math.abs(contentEndBounds.bottom - viewportBounds.bottom) <= 1,
+        scrollbarMatchesOverflow:
+          scrollbar?.classList.contains('os-scrollbar-visible') === hasVerticalOverflow,
+        withinRenderedRange: element.scrollTop <= maximumScrollTop + 1
+      }
+    })).toEqual({
+      atRenderedEnd: true,
+      scrollbarMatchesOverflow: true,
+      withinRenderedRange: true
+    })
     await page.mouse.wheel(0, 500)
     await page.waitForTimeout(100)
     await expect(page).toHaveURL(new RegExp(`#\\/watch\\/${CAPTIONED_SHORT_IDS[0]}\\?short=true`))
@@ -1522,6 +1544,45 @@ test.describe('watch page', () => {
     await expect(page.locator('.shortsAuxPanelTarget .watchVideoTranscript')).toBeVisible()
     await page.waitForTimeout(250)
     expect(await target.evaluate(element => element.scrollTop)).toBe(0)
+
+    const transcript = page.locator('.shortsAuxPanelTarget .watchVideoTranscript')
+    await transcript.evaluate(element => { element.style.blockSize = '200%' })
+    await target.evaluate(element => { element.scrollTop = element.scrollHeight })
+    await expect.poll(() => target.evaluate(element => element.scrollTop)).toBeGreaterThan(0)
+    await watchComponent.evaluate(async (component) => {
+      component.proxy.closeTranscript()
+      await component.proxy.$nextTick()
+    })
+    await expect(transcript).toHaveCount(0)
+    await expect.poll(() => target.evaluate(element => element.scrollTop)).toBe(0)
+
+    await watchComponent.evaluate(async (component) => {
+      component.proxy.handleSponsorBlockInfoChange({
+        open: true,
+        loading: false,
+        pendingUuid: null,
+        segments: [],
+        submissionEnabled: false
+      })
+      await component.proxy.$nextTick()
+    })
+    const sponsorBlock = page.locator('.shortsAuxPanelTarget .watchVideoSponsorBlock')
+    await expect(sponsorBlock).toBeVisible()
+    await sponsorBlock.evaluate(element => { element.style.blockSize = '200%' })
+    await target.evaluate(element => { element.scrollTop = element.scrollHeight })
+    await expect.poll(() => target.evaluate(element => element.scrollTop)).toBeGreaterThan(0)
+    await watchComponent.evaluate(async (component) => {
+      component.proxy.handleSponsorBlockInfoChange({
+        open: false,
+        loading: false,
+        pendingUuid: null,
+        segments: [],
+        submissionEnabled: false
+      })
+      await component.proxy.$nextTick()
+    })
+    await expect(sponsorBlock).toHaveCount(0)
+    await expect.poll(() => target.evaluate(element => element.scrollTop)).toBe(0)
 
     await watchComponent.dispose()
   })

--- a/e2e/tests/offline/watch-page.spec.mjs
+++ b/e2e/tests/offline/watch-page.spec.mjs
@@ -1,4 +1,4 @@
-import { goTo, sel, setPlayerFullscreen, test, expect } from '../../helpers/app.mjs'
+import { goTo, sel, setPlayerFullscreen, setWindowSize, test, expect } from '../../helpers/app.mjs'
 import { activeTab, findWatchComponent, openMockedVideo, waitForPlayback } from '../../helpers/player.mjs'
 import { mockPlayableWatchPage, watchViewHandle } from '../../helpers/watch.mjs'
 import { demoPlayerResponse } from '../../helpers/media.mjs'
@@ -289,8 +289,9 @@ test.describe('Shorts transcript navigation', () => {
     await expect(transcriptButton).toHaveCount(0)
   })
 
-  test('scrolls long video information independently of Shorts navigation', async ({ app, page }) => {
+  test('docks, scrolls, and clamps video information across Shorts navigation', async ({ app, page }) => {
     await mockPlayableWatchPage(app, page)
+    await setWindowSize(app, page, { width: 1325, height: 1012 })
     await page.locator(sel.searchInput)
       .fill(`https://www.youtube.com/shorts/${CAPTIONED_SHORT_IDS[0]}`)
     await page.locator(sel.searchInput).press('Enter')
@@ -309,18 +310,43 @@ test.describe('Shorts transcript navigation', () => {
 
     const panel = page.locator('.shortsAuxPanel')
     const scroller = panel.locator('.shortsAuxPanelTarget')
+    const player = page.locator('.ftVideoPlayer.shortsPlayer')
     await expect(panel).toHaveClass(/shortsAuxPanelOpen/)
+    await expect.poll(async () => {
+      const [panelBounds, playerBounds] = await Promise.all([
+        panel.boundingBox(),
+        player.boundingBox()
+      ])
+      const bottomDelta = Math.abs(
+        panelBounds.y + panelBounds.height - playerBounds.y - playerBounds.height
+      )
+      const topDelta = Math.abs(panelBounds.y - playerBounds.y)
+      return Math.max(bottomDelta, topDelta)
+    }).toBeLessThanOrEqual(1)
     await expect(scroller).toHaveAttribute('data-overlayscrollbars-viewport')
     await expect(panel.locator('.os-scrollbar-vertical')).toHaveCount(1)
     await expect.poll(() => scroller.evaluate(element => {
-      return element.scrollHeight > element.clientHeight
-    })).toBe(true)
+      return element.scrollHeight - element.clientHeight
+    })).toBeGreaterThan(100)
 
     const initialScrollTop = await scroller.evaluate(element => element.scrollTop)
-    await scroller.hover()
-    await page.mouse.wheel(0, 10_000)
+    const pointer = await scroller.evaluate(element => {
+      const bounds = element.getBoundingClientRect()
+      return {
+        x: bounds.left + bounds.width / 2,
+        y: Math.min(bounds.bottom - 1, window.innerHeight - 1)
+      }
+    })
+    await page.mouse.move(pointer.x, pointer.y)
+    await expect(page).toHaveURL(new RegExp(`#\\/watch\\/${CAPTIONED_SHORT_IDS[0]}\\?short=true`))
+    expect(await scroller.evaluate((element, point) => {
+      const hit = document.elementFromPoint(point.x, point.y)
+      return element.contains(hit)
+    }, pointer)).toBe(true)
+    await page.mouse.wheel(0, 500)
     await expect.poll(() => scroller.evaluate(element => element.scrollTop))
       .toBeGreaterThan(initialScrollTop)
+    await scroller.evaluate(element => { element.scrollTop = element.scrollHeight })
     await expect.poll(() => scroller.evaluate(element => {
       const viewportBounds = element.getBoundingClientRect()
       const descriptionBounds = element.querySelector('.description').getBoundingClientRect()
@@ -329,7 +355,41 @@ test.describe('Shorts transcript navigation', () => {
         renderedEndVisible: descriptionBounds.bottom <= viewportBounds.bottom + 1
       }
     })).toEqual({ atScrollEnd: true, renderedEndVisible: true })
+    await page.mouse.wheel(0, 500)
+    await page.waitForTimeout(100)
     await expect(page).toHaveURL(new RegExp(`#\\/watch\\/${CAPTIONED_SHORT_IDS[0]}\\?short=true`))
+
+    await page.locator('.shortsNavigationButton').last().click()
+    await expect(page).toHaveURL(new RegExp(`#\\/watch\\/${CAPTIONED_SHORT_IDS[1]}\\?short=true`))
+    await waitForPlayback(page)
+    await expect(panel).toHaveClass(/shortsAuxPanelOpen/)
+    await expect.poll(() => scroller.evaluate(element => {
+      const content = element.querySelector('.watchVideo')
+      const scrollbar = element.querySelector(':scope > .os-scrollbar-vertical')
+      const viewportBounds = element.getBoundingClientRect()
+      const contentBounds = content?.getBoundingClientRect()
+      const maximumScrollTop = Math.max(
+        0,
+        (content?.offsetTop ?? 0) + (content?.offsetHeight ?? 0) - element.clientHeight
+      )
+      const hasVerticalOverflow = element.scrollHeight > element.clientHeight + 1
+      return {
+        atRenderedEnd: contentBounds != null &&
+          (maximumScrollTop === 0
+            ? element.scrollTop <= 1
+            : Math.abs(contentBounds.bottom - viewportBounds.bottom) <= 1),
+        horizontalOverflowHidden: getComputedStyle(element).overflowX === 'hidden' &&
+          element.scrollWidth <= element.clientWidth + 1,
+        scrollbarMatchesOverflow:
+          scrollbar?.classList.contains('os-scrollbar-visible') === hasVerticalOverflow,
+        withinRenderedRange: element.scrollTop <= maximumScrollTop + 1
+      }
+    })).toEqual({
+      atRenderedEnd: true,
+      horizontalOverflowHidden: true,
+      scrollbarMatchesOverflow: true,
+      withinRenderedRange: true
+    })
   })
 
   test('keeps loading Shorts when another player keeps the shared caption factory alive', async ({ app, page }) => {

--- a/e2e/tests/offline/watch-page.spec.mjs
+++ b/e2e/tests/offline/watch-page.spec.mjs
@@ -1641,7 +1641,7 @@ test.describe('watch page', () => {
     await watchComponent.dispose()
   })
 
-  test('matches the Shorts information header to the comments header', async ({ app, page }) => {
+  test('toggles information from the Shorts title and matches the comments header', async ({ app, page }) => {
     await mockPlayableWatchPage(app, page)
     await page.locator(sel.searchInput).fill('https://www.youtube.com/shorts/jNQXAC9IVRw')
     await page.locator(sel.searchInput).press('Enter')
@@ -1649,10 +1649,11 @@ test.describe('watch page', () => {
     await waitForPlayback(page)
 
     const watchComponent = await page.evaluateHandle(findWatchComponent)
-    await watchComponent.evaluate(async (component) => {
-      component.proxy.toggleShortsMetadata()
-      await component.proxy.$nextTick()
-    })
+    const titleButton = page.locator('.shortsExternalTitleButton')
+    await expect(titleButton).toHaveAttribute('aria-expanded', 'false')
+    await titleButton.click()
+    await expect(page.locator('.shortsAuxPanel')).toHaveClass(/shortsAuxPanelOpen/)
+    await expect(titleButton).toHaveAttribute('aria-expanded', 'true')
 
     const headerStyles = async (headerSelector, closeSelector) => page.evaluate(
       ({ headerSelector, closeSelector }) => {
@@ -1690,6 +1691,10 @@ test.describe('watch page', () => {
       '.shortsAuxPanelHeader',
       '.shortsAuxPanelClose'
     )
+
+    await titleButton.click()
+    await expect(page.locator('.shortsAuxPanel')).not.toHaveClass(/shortsAuxPanelOpen/)
+    await expect(titleButton).toHaveAttribute('aria-expanded', 'false')
 
     await watchComponent.evaluate(async (component) => {
       component.proxy.toggleShortsComments()

--- a/e2e/tests/offline/watch-page.spec.mjs
+++ b/e2e/tests/offline/watch-page.spec.mjs
@@ -1570,6 +1570,38 @@ test.describe('watch page', () => {
     await setPlayerFullscreen(page, true)
     const fullscreenMetadata = player.locator('.fullscreenMetadataOverlay.open')
     await expect(fullscreenMetadata).toBeVisible()
+    await expect(player).not.toHaveClass(/presentationModeChanging/)
+
+    expect(await player.evaluate(element => {
+      const movingProperties = [
+        ['.player', 'inline-size'],
+        ['.shaka-controls-container', 'inset-inline-end'],
+        ['.shaka-seek-bar-container', 'inset-inline-start'],
+        ['.shaka-seek-bar-container', 'inline-size'],
+        ['.shortsTopControls', 'inset-inline-start'],
+        ['.shortsTopControls', 'max-inline-size'],
+        ['.fullscreenActions', 'inset-inline-end']
+      ]
+      return movingProperties.map(([selector, property]) => {
+        const style = getComputedStyle(element.querySelector(selector))
+        const properties = style.transitionProperty.split(', ')
+        const durations = style.transitionDuration.split(', ')
+        const index = properties.indexOf(property)
+        return index === -1 ? null : durations[index % durations.length]
+      })
+    })).toEqual(Array(7).fill('0.25s'))
+
+    expect(await player.evaluate(element => {
+      const wasChanging = element.classList.contains('presentationModeChanging')
+      element.classList.add('presentationModeChanging')
+      const transitionProperty = getComputedStyle(
+        element.querySelector('.shaka-seek-bar-container')
+      ).transitionProperty
+      if (!wasChanging) {
+        element.classList.remove('presentationModeChanging')
+      }
+      return transitionProperty
+    })).toBe('none')
 
     await moreOptions.click({ force: true })
     await expect(overflowMenu).toBeVisible()

--- a/e2e/tests/offline/watch-page.spec.mjs
+++ b/e2e/tests/offline/watch-page.spec.mjs
@@ -1575,9 +1575,7 @@ test.describe('watch page', () => {
     expect(await player.evaluate(element => {
       const movingProperties = [
         ['.player', 'inline-size'],
-        ['.shaka-controls-container', 'inset-inline-end'],
-        ['.shaka-seek-bar-container', 'inset-inline-start'],
-        ['.shaka-seek-bar-container', 'inline-size'],
+        ['.shaka-controls-container', 'inline-size'],
         ['.shortsTopControls', 'inset-inline-start'],
         ['.shortsTopControls', 'max-inline-size'],
         ['.fullscreenActions', 'inset-inline-end']
@@ -1589,19 +1587,63 @@ test.describe('watch page', () => {
         const index = properties.indexOf(property)
         return index === -1 ? null : durations[index % durations.length]
       })
-    })).toEqual(Array(7).fill('0.25s'))
+    })).toEqual(Array(5).fill('0.25s'))
 
     expect(await player.evaluate(element => {
-      const wasChanging = element.classList.contains('presentationModeChanging')
-      element.classList.add('presentationModeChanging')
-      const transitionProperty = getComputedStyle(
+      return getComputedStyle(
         element.querySelector('.shaka-seek-bar-container')
       ).transitionProperty
-      if (!wasChanging) {
-        element.classList.remove('presentationModeChanging')
-      }
-      return transitionProperty
     })).toBe('none')
+
+    const closingMotion = player.evaluate(element => new Promise(resolve => {
+      const controls = element.querySelector('.shaka-controls-container')
+      const seek = element.querySelector('.shaka-seek-bar-container')
+      const initial = {
+        controlsWidth: controls.getBoundingClientRect().width,
+        seekLeft: seek.getBoundingClientRect().left
+      }
+      const observer = new MutationObserver(() => {
+        if (!element.classList.contains('fullscreenDockLayoutOpen')) {
+          observer.disconnect()
+          requestAnimationFrame(() => requestAnimationFrame(() => resolve({
+            initial,
+            intermediate: {
+              controlsWidth: controls.getBoundingClientRect().width,
+              seekLeft: seek.getBoundingClientRect().left
+            }
+          })))
+        }
+      })
+      observer.observe(element, { attributes: true, attributeFilter: ['class'] })
+    }))
+    await watchComponent.evaluate(component => {
+      component.proxy.$refs.player.setFullscreenMetadata(false)
+    })
+    const { initial, intermediate } = await closingMotion
+    await expect(fullscreenMetadata).toHaveCount(0)
+    const fullscreenWidth = (await player.boundingBox()).width
+    expect(intermediate.controlsWidth).toBeGreaterThan(initial.controlsWidth)
+    expect(intermediate.controlsWidth).toBeLessThan(fullscreenWidth)
+    expect(intermediate.seekLeft).toBeGreaterThan(initial.seekLeft)
+    await expect.poll(async () => {
+      return player.locator('.shaka-controls-container').evaluate(element => {
+        return element.getBoundingClientRect().width
+      })
+    }).toBeCloseTo(fullscreenWidth, 0)
+    const closedSeekLeft = await player.locator('.shaka-seek-bar-container').evaluate(element => {
+      return element.getBoundingClientRect().left
+    })
+    expect(intermediate.seekLeft).toBeLessThan(closedSeekLeft)
+
+    await watchComponent.evaluate(component => {
+      component.proxy.$refs.player.setFullscreenMetadata(true)
+    })
+    await expect(fullscreenMetadata).toBeVisible()
+    await expect.poll(async () => {
+      return player.locator('.shaka-controls-container').evaluate(element => {
+        return element.getBoundingClientRect().width
+      })
+    }).toBeCloseTo(initial.controlsWidth, 0)
 
     await moreOptions.click({ force: true })
     await expect(overflowMenu).toBeVisible()

--- a/e2e/tests/offline/watch-page.spec.mjs
+++ b/e2e/tests/offline/watch-page.spec.mjs
@@ -364,7 +364,7 @@ test.describe('Shorts transcript navigation', () => {
     await waitForPlayback(page)
     await expect(panel).toHaveClass(/shortsAuxPanelOpen/)
     await expect.poll(() => scroller.evaluate(element => {
-      const content = element.querySelector('.watchVideo')
+      const content = element.querySelector('.videoDescription')
       const scrollbar = element.querySelector(':scope > .os-scrollbar-vertical')
       const viewportBounds = element.getBoundingClientRect()
       const contentBounds = content?.getBoundingClientRect()

--- a/e2e/tests/offline/watch-page.spec.mjs
+++ b/e2e/tests/offline/watch-page.spec.mjs
@@ -1532,6 +1532,7 @@ test.describe('watch page', () => {
     await page.locator(sel.searchInput).press('Enter')
     await expect(page).toHaveURL(/#\/watch\/jNQXAC9IVRw\?short=true/)
     await waitForPlayback(page)
+    await page.evaluate(() => window.ftElectron.setZoomFactor(1.25))
 
     const watchComponent = await page.evaluateHandle(findWatchComponent)
     await watchComponent.evaluate(async (component) => {
@@ -1570,6 +1571,21 @@ test.describe('watch page', () => {
     const fullscreenMetadata = player.locator('.fullscreenMetadataOverlay.open')
     await expect(fullscreenMetadata).toBeVisible()
 
+    await moreOptions.click({ force: true })
+    await expect(overflowMenu).toBeVisible()
+    await expect.poll(async () => {
+      const [buttonBounds, menuBounds] = await Promise.all([
+        moreOptions.boundingBox(),
+        overflowMenu.boundingBox()
+      ])
+      return Math.max(
+        Math.abs(buttonBounds.x + buttonBounds.width - menuBounds.x - menuBounds.width),
+        Math.abs(buttonBounds.y + buttonBounds.height + 8 - menuBounds.y)
+      )
+    }).toBeLessThanOrEqual(1)
+    await page.keyboard.press('Escape')
+    await expect(overflowMenu).toBeHidden()
+
     await watchComponent.evaluate(component => {
       component.proxy.$refs.player.setFullscreenTranscript(true)
     })
@@ -1602,9 +1618,90 @@ test.describe('watch page', () => {
     await moreOptions.click({ force: true })
     await overflowMenu.getByRole('button', { name: 'Video information' }).click()
     await expect(player.locator('.fullscreenMetadataOverlay.open')).toBeVisible()
+
+    await moreOptions.click({ force: true })
+    await expect(overflowMenu).toBeVisible()
     await setPlayerFullscreen(page, false)
+    await expect(overflowMenu).toBeHidden()
     await expect(auxPanel).toHaveClass(/shortsAuxPanelOpen/)
 
+    await moreOptions.click()
+    await expect(overflowMenu).toBeVisible()
+    await expect.poll(async () => {
+      const [buttonBounds, menuBounds] = await Promise.all([
+        moreOptions.boundingBox(),
+        overflowMenu.boundingBox()
+      ])
+      return Math.max(
+        Math.abs(buttonBounds.x + buttonBounds.width - menuBounds.x - menuBounds.width),
+        Math.abs(buttonBounds.y + buttonBounds.height + 8 - menuBounds.y)
+      )
+    }).toBeLessThanOrEqual(1)
+
+    await watchComponent.dispose()
+  })
+
+  test('matches the Shorts information header to the comments header', async ({ app, page }) => {
+    await mockPlayableWatchPage(app, page)
+    await page.locator(sel.searchInput).fill('https://www.youtube.com/shorts/jNQXAC9IVRw')
+    await page.locator(sel.searchInput).press('Enter')
+    await expect(page).toHaveURL(/#\/watch\/jNQXAC9IVRw\?short=true/)
+    await waitForPlayback(page)
+
+    const watchComponent = await page.evaluateHandle(findWatchComponent)
+    await watchComponent.evaluate(async (component) => {
+      component.proxy.toggleShortsMetadata()
+      await component.proxy.$nextTick()
+    })
+
+    const headerStyles = async (headerSelector, closeSelector) => page.evaluate(
+      ({ headerSelector, closeSelector }) => {
+        const header = document.querySelector(headerSelector)
+        const heading = header?.querySelector('h2, h3')
+        const close = document.querySelector(closeSelector)
+        const headerStyle = getComputedStyle(header)
+        const headingStyle = getComputedStyle(heading)
+        const closeStyle = getComputedStyle(close)
+        return {
+          header: {
+            height: headerStyle.height,
+            padding: headerStyle.padding,
+            backgroundColor: headerStyle.backgroundColor,
+            borderBottomColor: headerStyle.borderBottomColor
+          },
+          heading: {
+            margin: headingStyle.margin,
+            fontSize: headingStyle.fontSize
+          },
+          close: {
+            width: closeStyle.width,
+            height: closeStyle.height,
+            color: closeStyle.color,
+            backgroundColor: closeStyle.backgroundColor,
+            borderRadius: closeStyle.borderRadius,
+            fontSize: closeStyle.fontSize
+          }
+        }
+      },
+      { headerSelector, closeSelector }
+    )
+
+    const informationStyles = await headerStyles(
+      '.shortsAuxPanelHeader',
+      '.shortsAuxPanelClose'
+    )
+
+    await watchComponent.evaluate(async (component) => {
+      component.proxy.toggleShortsComments()
+      await component.proxy.$nextTick()
+    })
+    await expect(page.locator('.shortsCommentsPanel .fullscreenCommentHeader')).toBeVisible()
+    const commentsStyles = await headerStyles(
+      '.shortsCommentsPanel .fullscreenCommentHeader',
+      '.shortsCommentsPanel .fullscreenCommentAction:last-of-type'
+    )
+
+    expect(informationStyles).toEqual(commentsStyles)
     await watchComponent.dispose()
   })
 

--- a/e2e/tests/offline/watch-page.spec.mjs
+++ b/e2e/tests/offline/watch-page.spec.mjs
@@ -289,6 +289,49 @@ test.describe('Shorts transcript navigation', () => {
     await expect(transcriptButton).toHaveCount(0)
   })
 
+  test('scrolls long video information independently of Shorts navigation', async ({ app, page }) => {
+    await mockPlayableWatchPage(app, page)
+    await page.locator(sel.searchInput)
+      .fill(`https://www.youtube.com/shorts/${CAPTIONED_SHORT_IDS[0]}`)
+    await page.locator(sel.searchInput).press('Enter')
+    await expect(page).toHaveURL(new RegExp(`#\\/watch\\/${CAPTIONED_SHORT_IDS[0]}\\?short=true`))
+    await waitForPlayback(page)
+    await page.evaluate(() => window.ftElectron.setZoomFactor(1.25))
+
+    const watchView = await watchViewHandle(page)
+    await watchView.evaluate(async (view) => {
+      const lines = Array.from({ length: 80 }, (_, index) => `Description line ${index + 1}`)
+      view.videoDescription = lines.join('\n')
+      view.videoDescriptionHtml = lines.join('<br>')
+      view.toggleShortsMetadata()
+      await view.$nextTick()
+    })
+
+    const panel = page.locator('.shortsAuxPanel')
+    const scroller = panel.locator('.shortsAuxPanelTarget')
+    await expect(panel).toHaveClass(/shortsAuxPanelOpen/)
+    await expect(scroller).toHaveAttribute('data-overlayscrollbars-viewport')
+    await expect(panel.locator('.os-scrollbar-vertical')).toHaveCount(1)
+    await expect.poll(() => scroller.evaluate(element => {
+      return element.scrollHeight > element.clientHeight
+    })).toBe(true)
+
+    const initialScrollTop = await scroller.evaluate(element => element.scrollTop)
+    await scroller.hover()
+    await page.mouse.wheel(0, 10_000)
+    await expect.poll(() => scroller.evaluate(element => element.scrollTop))
+      .toBeGreaterThan(initialScrollTop)
+    await expect.poll(() => scroller.evaluate(element => {
+      const viewportBounds = element.getBoundingClientRect()
+      const descriptionBounds = element.querySelector('.description').getBoundingClientRect()
+      return {
+        atScrollEnd: element.scrollHeight - element.clientHeight - element.scrollTop <= 1,
+        renderedEndVisible: descriptionBounds.bottom <= viewportBounds.bottom + 1
+      }
+    })).toEqual({ atScrollEnd: true, renderedEndVisible: true })
+    await expect(page).toHaveURL(new RegExp(`#\\/watch\\/${CAPTIONED_SHORT_IDS[0]}\\?short=true`))
+  })
+
   test('keeps loading Shorts when another player keeps the shared caption factory alive', async ({ app, page }) => {
     await mockPlayableWatchPage(app, page, { captionTranslations: true })
 

--- a/src/renderer/components/ft-shaka-video-player/ft-shaka-video-player.css
+++ b/src/renderer/components/ft-shaka-video-player/ft-shaka-video-player.css
@@ -137,7 +137,10 @@
 .ftVideoPlayer.shortsPlayer:has(:deep(.shaka-controls-container[shown='true'])) > .shortsTopControls {
   visibility: visible;
   opacity: 1;
-  transition: opacity 150ms ease;
+  transition:
+    opacity 150ms ease,
+    inset-inline-start 250ms ease,
+    max-inline-size 250ms ease;
 }
 
 .shortsTopControlsGroup {
@@ -354,6 +357,7 @@
   );
   inline-size: var(--shorts-video-width);
   transform: none;
+  transition: inset-inline-start 250ms ease, inline-size 250ms ease;
 }
 
 .ftVideoPlayer.shortsPlayer :deep(.shaka-seek-bar-container .shaka-range-element::-webkit-slider-thumb) {
@@ -3866,6 +3870,7 @@
 */
 .ftVideoPlayer.presentationModeChanging .player,
 .ftVideoPlayer.presentationModeChanging :deep(.shaka-controls-container),
+.ftVideoPlayer.presentationModeChanging :deep(.shaka-seek-bar-container),
 .ftVideoPlayer.presentationModeChanging :deep(.shaka-spinner-container),
 .ftVideoPlayer.presentationModeChanging .countdownOverlay,
 .ftVideoPlayer.presentationModeChanging :deep(.videoAnnotations),

--- a/src/renderer/components/ft-shaka-video-player/ft-shaka-video-player.css
+++ b/src/renderer/components/ft-shaka-video-player/ft-shaka-video-player.css
@@ -357,7 +357,6 @@
   );
   inline-size: var(--shorts-video-width);
   transform: none;
-  transition: inset-inline-start 250ms ease, inline-size 250ms ease;
 }
 
 .ftVideoPlayer.shortsPlayer :deep(.shaka-seek-bar-container .shaka-range-element::-webkit-slider-thumb) {
@@ -474,6 +473,7 @@
 }
 
 .ftVideoPlayer.shortsPlayer:fullscreen:is(
+  .fullscreenDockLayoutOpen,
   .fullscreenMetadataOpen,
   .fullscreenTranscriptOpen,
   .fullscreenSponsorBlockOpen,
@@ -483,6 +483,7 @@
   .chaptersOverlayOpen
 ),
   .ftVideoPlayer.shortsPlayer.fullWindow:is(
+  .fullscreenDockLayoutOpen,
   .fullscreenMetadataOpen,
   .fullscreenTranscriptOpen,
   .fullscreenSponsorBlockOpen,
@@ -2715,12 +2716,17 @@
 
 .ftVideoPlayer.fullWindow .ambientFullscreenCanvas,
 .ftVideoPlayer.shortsPlayer:fullscreen .ambientFullscreenCanvas,
-.ftVideoPlayer:fullscreen:is(.fullscreenMetadataOpen, .fullscreenTranscriptOpen, .fullscreenSponsorBlockOpen, .fullscreenLiveChatOpen, .fullscreenCommentsOpen, .fullscreenPlaylistOpen, .chaptersOverlayOpen) .ambientFullscreenCanvas {
+.ftVideoPlayer:fullscreen:is(.fullscreenDockLayoutOpen, .fullscreenMetadataOpen, .fullscreenTranscriptOpen, .fullscreenSponsorBlockOpen, .fullscreenLiveChatOpen, .fullscreenCommentsOpen, .fullscreenPlaylistOpen, .chaptersOverlayOpen) .ambientFullscreenCanvas {
   opacity: 0.42;
 }
 
+.ftVideoPlayer:is(:fullscreen, .fullWindow) :deep(.shaka-controls-container) {
+  inline-size: 100%;
+  inset-inline: 0 auto;
+}
+
 :deep(.shaka-controls-container) {
-  transition: inset-inline-end 250ms ease;
+  transition: inline-size 250ms ease;
 }
 
 :deep(.shaka-spinner-container),
@@ -2831,16 +2837,16 @@
 }
 
 /* Keep the floating fullscreen actions next to the video instead of under the panel. */
-.ftVideoPlayer:fullscreen:is(.fullscreenMetadataOpen, .fullscreenTranscriptOpen, .fullscreenSponsorBlockOpen, .fullscreenLiveChatOpen, .fullscreenCommentsOpen, .fullscreenPlaylistOpen, .chaptersOverlayOpen) .fullscreenActions,
-.ftVideoPlayer.fullWindow:is(.fullscreenMetadataOpen, .fullscreenTranscriptOpen, .fullscreenSponsorBlockOpen, .fullscreenLiveChatOpen, .fullscreenCommentsOpen, .fullscreenPlaylistOpen, .chaptersOverlayOpen) .fullscreenActions {
+.ftVideoPlayer:fullscreen:is(.fullscreenDockLayoutOpen, .fullscreenMetadataOpen, .fullscreenTranscriptOpen, .fullscreenSponsorBlockOpen, .fullscreenLiveChatOpen, .fullscreenCommentsOpen, .fullscreenPlaylistOpen, .chaptersOverlayOpen) .fullscreenActions,
+.ftVideoPlayer.fullWindow:is(.fullscreenDockLayoutOpen, .fullscreenMetadataOpen, .fullscreenTranscriptOpen, .fullscreenSponsorBlockOpen, .fullscreenLiveChatOpen, .fullscreenCommentsOpen, .fullscreenPlaylistOpen, .chaptersOverlayOpen) .fullscreenActions {
   inset-inline-end: calc(var(--side-panel-width) + 24px);
 }
 
 /* Keep SponsorBlock notices inside the video area when a dock is open. */
-.ftVideoPlayer:fullscreen:is(.fullscreenMetadataOpen, .fullscreenTranscriptOpen, .fullscreenSponsorBlockOpen, .fullscreenLiveChatOpen, .fullscreenCommentsOpen, .fullscreenPlaylistOpen, .chaptersOverlayOpen) .skippedSegmentsWrapper,
-.ftVideoPlayer.fullWindow:is(.fullscreenMetadataOpen, .fullscreenTranscriptOpen, .fullscreenSponsorBlockOpen, .fullscreenLiveChatOpen, .fullscreenCommentsOpen, .fullscreenPlaylistOpen, .chaptersOverlayOpen) .skippedSegmentsWrapper,
-.ftVideoPlayer:fullscreen:is(.fullscreenMetadataOpen, .fullscreenTranscriptOpen, .fullscreenSponsorBlockOpen, .fullscreenLiveChatOpen, .fullscreenCommentsOpen, .fullscreenPlaylistOpen, .chaptersOverlayOpen) .sponsorBlockSubmissionWrapper,
-.ftVideoPlayer.fullWindow:is(.fullscreenMetadataOpen, .fullscreenTranscriptOpen, .fullscreenSponsorBlockOpen, .fullscreenLiveChatOpen, .fullscreenCommentsOpen, .fullscreenPlaylistOpen, .chaptersOverlayOpen) .sponsorBlockSubmissionWrapper {
+.ftVideoPlayer:fullscreen:is(.fullscreenDockLayoutOpen, .fullscreenMetadataOpen, .fullscreenTranscriptOpen, .fullscreenSponsorBlockOpen, .fullscreenLiveChatOpen, .fullscreenCommentsOpen, .fullscreenPlaylistOpen, .chaptersOverlayOpen) .skippedSegmentsWrapper,
+.ftVideoPlayer.fullWindow:is(.fullscreenDockLayoutOpen, .fullscreenMetadataOpen, .fullscreenTranscriptOpen, .fullscreenSponsorBlockOpen, .fullscreenLiveChatOpen, .fullscreenCommentsOpen, .fullscreenPlaylistOpen, .chaptersOverlayOpen) .skippedSegmentsWrapper,
+.ftVideoPlayer:fullscreen:is(.fullscreenDockLayoutOpen, .fullscreenMetadataOpen, .fullscreenTranscriptOpen, .fullscreenSponsorBlockOpen, .fullscreenLiveChatOpen, .fullscreenCommentsOpen, .fullscreenPlaylistOpen, .chaptersOverlayOpen) .sponsorBlockSubmissionWrapper,
+.ftVideoPlayer.fullWindow:is(.fullscreenDockLayoutOpen, .fullscreenMetadataOpen, .fullscreenTranscriptOpen, .fullscreenSponsorBlockOpen, .fullscreenLiveChatOpen, .fullscreenCommentsOpen, .fullscreenPlaylistOpen, .chaptersOverlayOpen) .sponsorBlockSubmissionWrapper {
   inset-inline-end: calc(var(--side-panel-width) + 2%);
 }
 
@@ -3870,7 +3876,6 @@
 */
 .ftVideoPlayer.presentationModeChanging .player,
 .ftVideoPlayer.presentationModeChanging :deep(.shaka-controls-container),
-.ftVideoPlayer.presentationModeChanging :deep(.shaka-seek-bar-container),
 .ftVideoPlayer.presentationModeChanging :deep(.shaka-spinner-container),
 .ftVideoPlayer.presentationModeChanging .countdownOverlay,
 .ftVideoPlayer.presentationModeChanging :deep(.videoAnnotations),
@@ -3885,21 +3890,24 @@
   aside instead of covering it. Kept at the end of the file so the
   higher-specificity .player rules follow the scroll mini player ones.
 */
-.ftVideoPlayer:fullscreen:is(.fullscreenMetadataOpen, .fullscreenTranscriptOpen, .fullscreenSponsorBlockOpen, .fullscreenLiveChatOpen, .fullscreenCommentsOpen, .fullscreenPlaylistOpen, .chaptersOverlayOpen) .player,
-.ftVideoPlayer.fullWindow:is(.fullscreenMetadataOpen, .fullscreenTranscriptOpen, .fullscreenSponsorBlockOpen, .fullscreenLiveChatOpen, .fullscreenCommentsOpen, .fullscreenPlaylistOpen, .chaptersOverlayOpen) .player {
+.ftVideoPlayer:fullscreen:is(.fullscreenDockLayoutOpen, .fullscreenMetadataOpen, .fullscreenTranscriptOpen, .fullscreenSponsorBlockOpen, .fullscreenLiveChatOpen, .fullscreenCommentsOpen, .fullscreenPlaylistOpen, .chaptersOverlayOpen) .player,
+.ftVideoPlayer.fullWindow:is(.fullscreenDockLayoutOpen, .fullscreenMetadataOpen, .fullscreenTranscriptOpen, .fullscreenSponsorBlockOpen, .fullscreenLiveChatOpen, .fullscreenCommentsOpen, .fullscreenPlaylistOpen, .chaptersOverlayOpen) .player {
   inline-size: calc(100% - var(--side-panel-width));
 }
 
-.ftVideoPlayer:fullscreen:is(.fullscreenMetadataOpen, .fullscreenTranscriptOpen, .fullscreenSponsorBlockOpen, .fullscreenLiveChatOpen, .fullscreenCommentsOpen, .fullscreenPlaylistOpen, .chaptersOverlayOpen) :is(
-  :deep(.shaka-controls-container),
+.ftVideoPlayer:fullscreen:is(.fullscreenDockLayoutOpen, .fullscreenMetadataOpen, .fullscreenTranscriptOpen, .fullscreenSponsorBlockOpen, .fullscreenLiveChatOpen, .fullscreenCommentsOpen, .fullscreenPlaylistOpen, .chaptersOverlayOpen) :deep(.shaka-controls-container),
+.ftVideoPlayer.fullWindow:is(.fullscreenDockLayoutOpen, .fullscreenMetadataOpen, .fullscreenTranscriptOpen, .fullscreenSponsorBlockOpen, .fullscreenLiveChatOpen, .fullscreenCommentsOpen, .fullscreenPlaylistOpen, .chaptersOverlayOpen) :deep(.shaka-controls-container) {
+  inline-size: calc(100% - var(--side-panel-width));
+}
+
+.ftVideoPlayer:fullscreen:is(.fullscreenDockLayoutOpen, .fullscreenMetadataOpen, .fullscreenTranscriptOpen, .fullscreenSponsorBlockOpen, .fullscreenLiveChatOpen, .fullscreenCommentsOpen, .fullscreenPlaylistOpen, .chaptersOverlayOpen) :is(
   :deep(.shaka-spinner-container),
   .countdownOverlay,
   :deep(.videoAnnotations),
   :deep(.shaka-text-container),
   :deep(.shaka-speech-to-text-container)
 ),
-  .ftVideoPlayer.fullWindow:is(.fullscreenMetadataOpen, .fullscreenTranscriptOpen, .fullscreenSponsorBlockOpen, .fullscreenLiveChatOpen, .fullscreenCommentsOpen, .fullscreenPlaylistOpen, .chaptersOverlayOpen) :is(
-  :deep(.shaka-controls-container),
+  .ftVideoPlayer.fullWindow:is(.fullscreenDockLayoutOpen, .fullscreenMetadataOpen, .fullscreenTranscriptOpen, .fullscreenSponsorBlockOpen, .fullscreenLiveChatOpen, .fullscreenCommentsOpen, .fullscreenPlaylistOpen, .chaptersOverlayOpen) :is(
   :deep(.shaka-spinner-container),
   .countdownOverlay,
   :deep(.videoAnnotations),

--- a/src/renderer/components/ft-shaka-video-player/ft-shaka-video-player.js
+++ b/src/renderer/components/ft-shaka-video-player/ft-shaka-video-player.js
@@ -6212,7 +6212,9 @@ export default defineComponent({
 
     function openShortsOverflowMenu(event) {
       const buttonRect = event.currentTarget.getBoundingClientRect()
-      const containerRect = container.value.getBoundingClientRect()
+      const controlsContainer = ui?.getControls().getControlsContainer()
+      const containerRect = controlsContainer?.getBoundingClientRect() ??
+        container.value.getBoundingClientRect()
       container.value.style.setProperty(
         '--shorts-menu-top',
         `${buttonRect.bottom - containerRect.top + 8}px`
@@ -6222,6 +6224,16 @@ export default defineComponent({
         `${containerRect.right - buttonRect.right}px`
       )
       container.value?.querySelector('.shaka-overflow-menu-button')?.click()
+    }
+
+    function resetShortsOverflowMenu() {
+      const controls = ui?.getControls()
+      controls?.dispatchEvent(new shaka.util.FakeEvent('submenuclose'))
+      controls?.getControlsContainer()
+        .querySelectorAll('.shaka-overflow-menu, .shaka-settings-menu')
+        .forEach(menu => menu.classList.add('shaka-hidden'))
+      container.value?.style.removeProperty('--shorts-menu-top')
+      container.value?.style.removeProperty('--shorts-menu-right')
     }
 
     function positionShortsContextMenu() {
@@ -6769,18 +6781,11 @@ export default defineComponent({
 
     function registerFullWindowButton() {
       events.addEventListener('setFullWindow', async (/** @type {CustomEvent} */ event) => {
-        const controls = ui?.getControls()
-
         // Moving the player while its overflow menu is open can leave both the
         // menu DOM and its submenu state stuck. Reset both synchronously; the
         // public hide method uses a timer and can otherwise lose a race with
         // the layout transition and the next overflow-button click.
-        controls?.dispatchEvent(new shaka.util.FakeEvent('submenuclose'))
-        controls?.getControlsContainer()
-          .querySelectorAll('.shaka-overflow-menu, .shaka-settings-menu')
-          .forEach(menu => menu.classList.add('shaka-hidden'))
-        container.value?.style.removeProperty('--shorts-menu-top')
-        container.value?.style.removeProperty('--shorts-menu-right')
+        resetShortsOverflowMenu()
 
         fullWindowAnimation?.cancel()
         fullWindowAnimation = null
@@ -8647,6 +8652,9 @@ export default defineComponent({
 
     function fullscreenChangeHandler() {
       isFullscreen.value = isNativeFullscreenActive()
+      if (props.shortsPlayer) {
+        resetShortsOverflowMenu()
+      }
       suppressPanelTransitions(100)
       syncChapterOverlayButton()
 

--- a/src/renderer/components/ft-shaka-video-player/ft-shaka-video-player.js
+++ b/src/renderer/components/ft-shaka-video-player/ft-shaka-video-player.js
@@ -721,6 +721,32 @@ export default defineComponent({
     /** @type {import('vue').Ref<HTMLElement | null>} */
     const fullscreenPlaylistTarget = ref(null)
     const showFullscreenPlaylist = ref(false)
+    const fullscreenDockOpen = computed(() => {
+      return showFullscreenMetadata.value || showFullscreenTranscript.value ||
+        showFullscreenSponsorBlock.value || showFullscreenComments.value ||
+        showFullscreenLiveChat.value || showFullscreenPlaylist.value ||
+        (showChaptersOverlay.value && props.chapters.length > 0)
+    })
+    const fullscreenDockLayoutOpen = ref(false)
+    let fullscreenDockLayoutFrame = null
+    watch(fullscreenDockOpen, (open) => {
+      if (fullscreenDockLayoutFrame !== null) {
+        cancelAnimationFrame(fullscreenDockLayoutFrame)
+        fullscreenDockLayoutFrame = null
+      }
+
+      if (open) {
+        fullscreenDockLayoutOpen.value = true
+      } else {
+        // Paint the layout once after teleported dock content settles, then start the reverse transition.
+        fullscreenDockLayoutFrame = requestAnimationFrame(() => {
+          fullscreenDockLayoutFrame = requestAnimationFrame(() => {
+            fullscreenDockLayoutFrame = null
+            fullscreenDockLayoutOpen.value = false
+          })
+        })
+      }
+    }, { flush: 'post' })
     const chapterThumbnails = ref([])
     const currentChapterTitle = computed(() => {
       return props.chapters[props.currentChapterIndex]?.title ?? t('Chapters.Chapters')
@@ -9450,6 +9476,9 @@ export default defineComponent({
 
     onBeforeUnmount(() => {
       clearTimeout(paidPromotionTimer)
+      if (fullscreenDockLayoutFrame !== null) {
+        cancelAnimationFrame(fullscreenDockLayoutFrame)
+      }
       cancelPendingVolumeUserSet()
       fullWindowAnimation?.cancel()
       hasLoaded.value = false
@@ -9812,6 +9841,7 @@ export default defineComponent({
       fullscreenPlaylistOverlay,
       fullscreenPlaylistTarget,
       showFullscreenPlaylist,
+      fullscreenDockLayoutOpen,
       closeFullscreenPlaylist,
       setFullscreenPlaylist,
       showFullscreenShareAction,

--- a/src/renderer/components/ft-shaka-video-player/ft-shaka-video-player.vue
+++ b/src/renderer/components/ft-shaka-video-player/ft-shaka-video-player.vue
@@ -56,6 +56,7 @@
         fullscreenLiveChatOpen: showFullscreenLiveChat,
         fullscreenPlaylistOpen: showFullscreenPlaylist,
         chaptersOverlayOpen: showChaptersOverlay && chapters.length > 0,
+        fullscreenDockLayoutOpen,
         fullscreenDockResizing,
         fullscreenDockReordering,
         presentationModeChanging,

--- a/src/renderer/views/Watch/Watch.js
+++ b/src/renderer/views/Watch/Watch.js
@@ -1335,6 +1335,9 @@ export default defineComponent({
     },
     updateShortsViewportHeight() {
       this.shortsViewportHeight = window.innerHeight
+      if (this.shortsAuxPanelOpen) {
+        this.clampShortsAuxPanelScroll()
+      }
     },
     handleFullscreenMetadataChange({ open, target, presentationActive = false }) {
       this.fullscreenMetadataTarget = target
@@ -1342,6 +1345,7 @@ export default defineComponent({
 
       if (this.customShortsPlayerActive && presentationActive) {
         this.shortsMetadataOpen = this.fullscreenMetadataOpen
+        this.clampShortsAuxPanelScroll()
       }
 
       if (this.fullscreenMetadataOpen) {
@@ -1481,6 +1485,10 @@ export default defineComponent({
       this.sponsorBlockInfoSegments = segments
       this.sponsorBlockInfoSubmissionEnabled = submissionEnabled
 
+      if (!open && this.customShortsPlayerActive) {
+        this.clampShortsAuxPanelScroll()
+      }
+
       if (open && this.fullscreenMetadataOpen && !this.fullscreenSponsorBlockOpen) {
         this.$nextTick(() => this.$refs.player?.setFullscreenSponsorBlock(true))
       } else if (!open && this.fullscreenSponsorBlockOpen) {
@@ -1522,6 +1530,7 @@ export default defineComponent({
         this.$nextTick(() => this.$refs.player?.setFullscreenTranscript(true))
       } else if (!this.showTranscript) {
         this.$refs.player?.dismissFullscreenTranscript()
+        this.clampShortsAuxPanelScroll()
       }
     },
     closeTranscript() {
@@ -1530,6 +1539,7 @@ export default defineComponent({
       }
       this.showTranscript = false
       this.$refs.player?.dismissFullscreenTranscript()
+      this.clampShortsAuxPanelScroll()
     },
     closeShortsComments() {
       this.shortsCommentsOpen = false
@@ -1540,6 +1550,10 @@ export default defineComponent({
         this.resetShortsAuxPanelScroll()
       }
       this.shortsMetadataOpen = shouldOpen
+
+      if (!shouldOpen) {
+        this.clampShortsAuxPanelScroll()
+      }
 
       if (shouldOpen) {
         if (this.showTranscript) {
@@ -1564,8 +1578,7 @@ export default defineComponent({
       this.$nextTick(() => {
         requestAnimationFrame(() => {
           const target = this.$refs.shortsAuxPanelTarget
-          const contentElements = target?.querySelectorAll(':scope > .watchVideo')
-          const content = contentElements?.[contentElements.length - 1]
+          const content = this.$refs.shortsAuxPanelContentEnd
           if (target != null && content != null) {
             clampOverlayScrollTop(target, content)
           }

--- a/src/renderer/views/Watch/Watch.js
+++ b/src/renderer/views/Watch/Watch.js
@@ -1564,7 +1564,8 @@ export default defineComponent({
       this.$nextTick(() => {
         requestAnimationFrame(() => {
           const target = this.$refs.shortsAuxPanelTarget
-          const content = target?.querySelector('.watchVideo')
+          const contentElements = target?.querySelectorAll(':scope > .watchVideo')
+          const content = contentElements?.[contentElements.length - 1]
           if (target != null && content != null) {
             clampOverlayScrollTop(target, content)
           }

--- a/src/renderer/views/Watch/Watch.js
+++ b/src/renderer/views/Watch/Watch.js
@@ -26,7 +26,7 @@ import FtButton from '../../components/FtButton/FtButton.vue'
 import { calculateColorLuminance } from '../../helpers/colors'
 import { applyAnimationSpeed } from '../../helpers/animationSpeed'
 import { isReducedMotionEnabled } from '../../helpers/reducedMotion'
-import { restoreOverlayScrollTop } from '../../helpers/overlayScrollbars'
+import { clampOverlayScrollTop, restoreOverlayScrollTop } from '../../helpers/overlayScrollbars'
 import { hasReachedWatchedThreshold, isHistoryEntryWatched } from '../../helpers/history'
 import { DOWNLOADED_MEDIA_MIME_TYPES } from '../../../constants'
 import { isVideoHiddenByPreferences } from '../../helpers/subscriptions'
@@ -1058,6 +1058,10 @@ export default defineComponent({
         this.shortsTransitionPreview = ''
         this.shortsTransitionDirection = 0
 
+        if (this.shortsMetadataOpen) {
+          this.clampShortsAuxPanelScroll()
+        }
+
         if (this.applyDefaultTheatreModeAfterLoad) {
           this.applyDefaultTheatreModeAfterLoad = false
           this.useTheatreMode = this.theatreTogglePossible
@@ -1555,6 +1559,17 @@ export default defineComponent({
           requestAnimationFrame(() => restoreOverlayScrollTop(target, 0))
         })
       }
+    },
+    clampShortsAuxPanelScroll() {
+      this.$nextTick(() => {
+        requestAnimationFrame(() => {
+          const target = this.$refs.shortsAuxPanelTarget
+          const content = target?.querySelector('.watchVideo')
+          if (target != null && content != null) {
+            clampOverlayScrollTop(target, content)
+          }
+        })
+      })
     },
     handleSidebarPanelBeforeLeave() {
       this.sidebarPanelLeaving = true

--- a/src/renderer/views/Watch/Watch.scss
+++ b/src/renderer/views/Watch/Watch.scss
@@ -856,7 +856,7 @@
     .shortsAuxPanelTarget {
       flex: 1 1 auto;
       min-block-size: 0;
-      overflow: hidden;
+      overflow: hidden auto;
       overflow-anchor: none;
       overscroll-behavior: contain;
     }

--- a/src/renderer/views/Watch/Watch.scss
+++ b/src/renderer/views/Watch/Watch.scss
@@ -558,10 +558,33 @@
 
     .shortsExternalTitle {
       margin-block: 12px 0;
-      margin-inline: 0;
+      margin-inline: -12px 0;
+    }
+
+    .shortsExternalTitleButton {
+      max-inline-size: 100%;
+      padding-block: 8px;
+      padding-inline: 12px;
+      border: 0;
+      border-radius: calc(12px * var(--ui-roundness));
+      color: inherit;
+      background: transparent;
+      cursor: pointer;
       overflow-wrap: anywhere;
+      font: inherit;
       font-size: 20px;
       line-height: 1.3;
+      text-align: start;
+    }
+
+    .shortsExternalTitleButton:hover,
+    .shortsExternalTitleButton:focus-visible {
+      background-color: var(--side-nav-hover-color);
+    }
+
+    .shortsExternalTitleButton:focus-visible {
+      outline: 2px solid var(--primary-color);
+      outline-offset: 2px;
     }
 
     .shortsMetadataSkeleton {
@@ -1056,9 +1079,8 @@
         opacity: 1;
       }
 
-      .shortsExternalTitle {
+      .shortsExternalTitleButton {
         display: -webkit-box;
-        max-block-size: 2.6em;
         overflow: hidden;
         -webkit-box-orient: vertical;
         -webkit-line-clamp: 2;

--- a/src/renderer/views/Watch/Watch.scss
+++ b/src/renderer/views/Watch/Watch.scss
@@ -321,6 +321,11 @@
       display: none;
     }
 
+    .videoArea {
+      position: relative;
+      overscroll-behavior: contain;
+    }
+
     .videoArea .videoAreaMargin {
       position: relative;
       display: grid;
@@ -793,10 +798,11 @@
 
     .shortsCommentsPanel,
     .shortsAuxPanel {
-      position: fixed;
+      position: absolute;
       z-index: 20;
-      inset-block: 80px 16px;
+      inset-block-start: 0;
       inset-inline-end: 88px;
+      block-size: var(--shorts-player-height);
       inline-size: min(420px, calc(100vw - 32px));
       overflow: hidden;
       border-radius: calc(12px * var(--ui-roundness));

--- a/src/renderer/views/Watch/Watch.scss
+++ b/src/renderer/views/Watch/Watch.scss
@@ -843,12 +843,17 @@
     }
 
     .shortsAuxPanelHeader {
+      position: relative;
+      z-index: 2;
       display: flex;
+      box-sizing: border-box;
       flex: 0 0 52px;
       align-items: center;
       justify-content: space-between;
-      padding-inline: 16px 8px;
-      border-block-end: 1px solid color-mix(in srgb, var(--primary-text-color) 10%, transparent);
+      padding-block: 0;
+      padding-inline: 14px 8px;
+      border-block-end: 1px solid rgb(255 255 255 / 10%);
+      background-color: rgb(20 20 20 / 52%);
     }
 
     .shortsAuxPanelHeader h2 {
@@ -986,16 +991,23 @@
     }
 
     .shortsAuxPanelClose {
-      display: grid;
-      place-items: center;
+      display: inline-flex;
+      align-items: center;
+      justify-content: center;
       inline-size: 36px;
       block-size: 36px;
       padding: 0;
       border: 0;
       border-radius: 50%;
-      color: var(--primary-text-color);
-      background-color: var(--side-nav-hover-color);
+      color: #fff;
+      background-color: transparent;
       cursor: pointer;
+      font-size: 18px;
+    }
+
+    .shortsAuxPanelClose:hover,
+    .shortsAuxPanelClose:focus-visible {
+      background-color: rgb(255 255 255 / 20%);
     }
 
     @media (height <= 850px) {

--- a/src/renderer/views/Watch/Watch.vue
+++ b/src/renderer/views/Watch/Watch.vue
@@ -382,9 +382,17 @@
           <h1
             v-if="!isLoading"
             class="shortsExternalTitle"
-            dir="auto"
           >
-            {{ videoTitle }}
+            <button
+              type="button"
+              class="shortsExternalTitleButton"
+              dir="auto"
+              :aria-label="`${$t('Video.Metadata')}: ${videoTitle}`"
+              :aria-expanded="shortsMetadataOpen"
+              @click="toggleShortsMetadata"
+            >
+              {{ videoTitle }}
+            </button>
           </h1>
           <RouterLink
             v-if="!isLoading && shortsLinkedVideo?.videoId"

--- a/src/renderer/views/Watch/Watch.vue
+++ b/src/renderer/views/Watch/Watch.vue
@@ -691,6 +691,11 @@
             @close="closeTranscript"
             @timestamp-event="playTranscriptSegment"
           />
+          <div
+            ref="shortsAuxPanelContentEnd"
+            class="shortsAuxPanelContentEnd"
+            aria-hidden="true"
+          />
         </div>
       </div>
     </div>


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Make sure to follow the contributing guidelines. -->
<!-- Important note, we may remove your pull request if you do not use this provided PR template correctly. -->
<!-- Agent instructions: Preserve every heading, comment, and marker in this template. Never remove or rewrite the release-note-category:start/end, release-note:start/end, or release-note-image:start/end marker pairs. Never remove or rewrite the Release note images section; leave its contents for a human. -->

## Pull Request Type
<!-- Please select what type of pull request this is: [x] -->
- [x] Bugfix
- [ ] Feature Implementation
- [ ] Documentation
- [ ] Other

## Related issue
<!-- Please link the issue your pull request is referring to. -->
<!-- If this pull request fully resolves the relevant issue, put "closes" before the issue number. -->
<!-- Example: "closes #123456". -->

## Description
<!-- Please write a clear and concise description of what the pull request does. -->
YouTube-style Shorts auxiliary panels could be clipped or remain pinned to the page instead of following the player. Their shared viewport now scrolls vertically, stays aligned with the player, and clamps stale scroll positions after navigating to shorter content.

Opening a fullscreen dock also shrank Shaka's controls container without changing how the three-dots menu offsets were measured. That displaced the menu by the dock width and left stale offsets after pressing F. Menu positioning now uses the actual controls container and resets when the presentation mode changes.

The inline information panel header now matches the Shorts comments header. The non-fullscreen Short title also uses the same accessible Video information toggle as the fullscreen title.

Fullscreen dock changes now move the video, seek bar, top controls, and floating actions together on the same timing. Presentation-mode changes suppress the seek bar's position transition so entering or leaving fullscreen does not make it slide across the player.

## Release note category
<!-- Select exactly one category. Every pull request must select one. -->
<!-- Select "Not noteworthy" when the pull request fixes a bug in or improves functionality that has not yet appeared in a stable release. -->
<!-- release-note-category:start -->
- [ ] Not noteworthy
- [ ] Highlights
- [ ] More improvements
- [x] Fixed bugs
<!-- release-note-category:end -->

## Release note
<!-- Required unless "Not noteworthy" is selected. -->
<!-- Write one concise, user-facing entry without a leading bullet. -->
<!-- release-note:start -->
Fixed Shorts information panels, fullscreen menu positioning and dock animations, and made inline Shorts titles toggle Video information.
<!-- release-note:end -->

## Release note images
<!-- Human-only: Agents must preserve this entire section and leave it empty. -->
<!-- Optional. Paste one or more Markdown images or HTML image tags here. -->
<!-- The release notes will use an HTML image tag and limit images taller than 300 pixels. -->
<!-- release-note-image:start -->

<!-- release-note-image:end -->

## Testing
<!-- How can reviewers verify that the PR produces correct results? -->
<!-- Please provide instructions so that others can ensure that your pull request would produce correct results. For examples see, https://github.com/FreeTubeApp/FreeTube/pull/5743, https://github.com/FreeTubeApp/FreeTube/pull/7349, https://github.com/FreeTubeApp/FreeTube/pull/5125, https://github.com/FreeTubeApp/FreeTube/pull/7338 -->
<!-- Agent instructions: Only write human-facing steps that explain how to verify the change while running this branch in dev mode. Include expected results and, when applicable, helpful console snippets for interactive verification. Do not include automated checks, commands, results, pass counts, or CI status. -->
1. Open a Short with a long description, then open Video information. The panel should align with the player and scroll to the rendered content end without switching Shorts.
2. Click the inline Short title. It should open and close Video information, including with keyboard activation, and its expanded state should follow the panel.
3. Compare the Video information and comments panels outside fullscreen. Their header height, background, typography, divider, and close button should match.
4. Enter fullscreen, open Video information, and reopen the three-dots menu. It should stay directly below and right-aligned with its button.
5. Press F while that menu is open. The menu should close; reopening it outside fullscreen should place it below the button again.
6. In fullscreen, toggle Video information or comments. The video, top buttons, seek bar, and floating actions should move together smoothly.
7. Enter and leave fullscreen with no dock open. The seek bar should appear directly in place rather than sliding across the player.
8. Repeat the checks at 125% UI Scale.

## Additional context
<!-- Add any additional context about the PR here. -->
The Shorts page scrollbar remains responsible for switching between Shorts. Auxiliary panels keep their own themed OverlayScrollbars viewport, and fullscreen menu cleanup is limited to the Shorts player.
