### PR TITLE
fix(player): keep normal square videos in the standard player

### DIFF
--- a/e2e/tests/offline/shorts-classification.spec.mjs
+++ b/e2e/tests/offline/shorts-classification.spec.mjs
@@ -1,0 +1,63 @@
+import { expect, sel, test } from '../../helpers/app.mjs'
+import { findWatchComponent, waitForPlayback } from '../../helpers/player.mjs'
+import { mockPlayableWatchPage } from '../../helpers/watch.mjs'
+
+const VIDEO = {
+  type: 'video',
+  videoId: 'squareVid01',
+  title: 'Square music upload',
+  author: 'Test Channel',
+  authorId: 'UC-square-video',
+  lengthSeconds: 120,
+  isShort: false,
+}
+
+const SEARCH_SETTINGS = {
+  prioritize: 'relevance',
+  time: '',
+  type: 'all',
+  duration: '',
+  features: [],
+}
+
+test.use({
+  seed: {
+    settings: {
+      useCustomShortsPlayer: true,
+      videoPlaybackEngine: 'built-in',
+      ytDlpPlaybackEngineDefaultMigration: true,
+    }
+  }
+})
+
+test('keeps a normal square search result in the standard player', async ({ app, page }) => {
+  await mockPlayableWatchPage(app, page)
+  await page.evaluate(({ video, searchSettings }) => {
+    const store = document.querySelector('#app').__vue_app__.config.globalProperties.$store
+    store.commit('addToSessionSearchHistory', {
+      query: 'square music upload',
+      data: [video],
+      searchSettings,
+      nextPageRef: null,
+      hasMoreResults: false,
+      apiUsed: 'local'
+    })
+  }, { video: VIDEO, searchSettings: SEARCH_SETTINGS })
+
+  await page.locator(sel.searchInput).fill('square music upload')
+  await page.locator(sel.searchInput).press('Enter')
+  await page.getByRole('link', { name: VIDEO.title, exact: true }).click()
+
+  await expect(page).toHaveURL(/#\/watch\/squareVid01\?short=false/)
+  await waitForPlayback(page)
+
+  const watchComponent = await page.evaluateHandle(findWatchComponent)
+  await watchComponent.evaluate(async (component) => {
+    component.proxy.updateShortsPlayerState(120, [{ width: 1080, height: 1080 }])
+    await component.proxy.$nextTick()
+  })
+
+  await expect(page.locator('.videoLayout')).not.toHaveClass(/shortsPlayerActive/)
+  await expect(page.locator('.ftVideoPlayer')).not.toHaveClass(/shortsPlayer/)
+  await watchComponent.dispose()
+})

--- a/src/renderer/components/FtListVideo/FtListVideo.vue
+++ b/src/renderer/components/FtListVideo/FtListVideo.vue
@@ -1417,8 +1417,11 @@ const watchPageLinkQuery = computed(() => {
     query.downloadId = props.downloadId
   }
 
+  if (typeof props.data.isShort === 'boolean') {
+    query.short = String(props.data.isShort)
+  }
+
   if (props.data.isShort === true) {
-    query.short = 'true'
     if (props.data.shortSource === 'channel' && props.data.shortChannelId) {
       query.shortSource = 'channel'
       query.shortChannelId = props.data.shortChannelId

--- a/src/renderer/helpers/api/local.js
+++ b/src/renderer/helpers/api/local.js
@@ -1623,7 +1623,13 @@ function handleSearchResponse(response) {
     .filter((item) => {
       return item.type === 'Video' || item.type === 'Channel' || item.type === 'Playlist' || item.type === 'HashtagTile' || item.type === 'Movie' || item.type === 'LockupView'
     })
-    .map((item) => parseListItem(item))
+    .map((item) => {
+      const parsedItem = parseListItem(item)
+
+      return parsedItem?.type === 'video' && typeof parsedItem.isShort !== 'boolean'
+        ? { ...parsedItem, isShort: false }
+        : parsedItem
+    })
     .filter((item) => item)
 
   return {
@@ -2154,7 +2160,8 @@ function parseLockupView(lockupView, channelId = undefined, channelName = undefi
         liveNow,
         isPremiere,
         isUpcoming,
-        premiereDate
+        premiereDate,
+        isShort: lockupView.content_type === 'SHORT'
       }
     }
     default:

--- a/src/renderer/helpers/player/shorts.js
+++ b/src/renderer/helpers/player/shorts.js
@@ -130,19 +130,20 @@ export function getVideoAspectRatio(formats) {
 }
 
 /**
- * YouTube classifies square or vertical uploads up to three minutes long as
- * Shorts. Explicit navigation metadata wins because stream dimensions may not
- * be available until after the player has started loading.
+ * Portrait media up to three minutes long is a useful fallback when no content
+ * classification exists. Square media is ambiguous, so only explicit
+ * navigation metadata classifies it as a Short. Explicit metadata also wins
+ * over the geometry fallback.
  *
  * @param {object} options
- * @param {boolean} [options.explicit]
+ * @param {boolean | null} [options.explicit]
  * @param {number} [options.duration]
  * @param {object[]} [options.formats]
  * @returns {boolean}
  */
-export function isYouTubeShort({ explicit = false, duration, formats = [] }) {
-  if (explicit) {
-    return true
+export function isYouTubeShort({ explicit = null, duration, formats = [] }) {
+  if (typeof explicit === 'boolean') {
+    return explicit
   }
 
   const aspectRatio = getVideoAspectRatio(formats)
@@ -150,7 +151,7 @@ export function isYouTubeShort({ explicit = false, duration, formats = [] }) {
   return Number(duration) > 0 &&
     Number(duration) <= MAX_SHORT_DURATION_SECONDS &&
     aspectRatio !== null &&
-    aspectRatio <= 1
+    aspectRatio < 1
 }
 
 /**

--- a/src/renderer/views/Watch/Watch.js
+++ b/src/renderer/views/Watch/Watch.js
@@ -2107,7 +2107,12 @@ export default defineComponent({
     },
 
     updateShortsPlayerState: function (duration, formats) {
-      const explicit = this.tabRoute.query.short === 'true'
+      const shortQuery = this.tabRoute.query.short
+      const explicit = shortQuery === 'true'
+        ? true
+        : shortQuery === 'false'
+          ? false
+          : null
       const sourceAspectRatio = getVideoAspectRatio(formats)
       this.isShort = isYouTubeShort({ explicit, duration, formats })
 

--- a/tests/unit/shorts-player.test.mjs
+++ b/tests/unit/shorts-player.test.mjs
@@ -76,14 +76,10 @@ test('reads aspect ratios from local and Invidious formats', () => {
   assert.equal(getVideoAspectRatio([{ audioQuality: 'AUDIO_QUALITY_MEDIUM' }]), null)
 })
 
-test('detects square and portrait Shorts up to three minutes long', () => {
+test('detects portrait Shorts up to three minutes long', () => {
   assert.equal(isYouTubeShort({
     duration: 180,
     formats: [{ width: 1080, height: 1920 }],
-  }), true)
-  assert.equal(isYouTubeShort({
-    duration: 60,
-    formats: [{ width: 1080, height: 1080 }],
   }), true)
 })
 
@@ -94,6 +90,21 @@ test('does not mistake landscape or long portrait videos for Shorts', () => {
   }), false)
   assert.equal(isYouTubeShort({
     duration: 181,
+    formats: [{ width: 1080, height: 1920 }],
+  }), false)
+})
+
+test('does not infer a Short from ambiguous square watch-page media', () => {
+  assert.equal(isYouTubeShort({
+    duration: 120,
+    formats: [{ width: 1080, height: 1080 }],
+  }), false)
+})
+
+test('trusts an explicit non-Short classification over portrait dimensions', () => {
+  assert.equal(isYouTubeShort({
+    explicit: false,
+    duration: 120,
     formats: [{ width: 1080, height: 1920 }],
   }), false)
 })


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Make sure to follow the contributing guidelines. -->
<!-- Important note, we may remove your pull request if you do not use this provided PR template correctly. -->
<!-- Agent instructions: Preserve every heading, comment, and marker in this template. Never remove or rewrite the release-note-category:start/end, release-note:start/end, or release-note-image:start/end marker pairs. Never remove or rewrite the Release note images section; leave its contents for a human. -->

## Pull Request Type
<!-- Please select what type of pull request this is: [x] -->
- [x] Bugfix
- [ ] Feature Implementation
- [ ] Documentation
- [ ] Other

## Related issue
<!-- Please link the issue your pull request is referring to. -->
<!-- If this pull request fully resolves the relevant issue, put "closes" before the issue number. -->
<!-- Example: "closes #123456". -->

## Description
<!-- Please write a clear and concise description of what the pull request does. -->
Normal square videos opened from search could switch to the Shorts layout after their stream dimensions loaded. Search already classified these results as normal videos, but that classification was not carried to the Watch route, so the duration and aspect-ratio fallback overrode it.

This preserves the search result classification through navigation and makes explicit normal-video metadata authoritative. Square media is now treated as ambiguous when no classification exists, while portrait media keeps the existing fallback and explicit square Shorts still use the Shorts player.

## Release note category
<!-- Select exactly one category. Every pull request must select one. -->
<!-- Select "Not noteworthy" when the pull request fixes a bug in or improves functionality that has not yet appeared in a stable release. -->
<!-- release-note-category:start -->
- [ ] Not noteworthy
- [ ] Highlights
- [ ] More improvements
- [x] Fixed bugs
<!-- release-note-category:end -->

## Release note
<!-- Required unless "Not noteworthy" is selected. -->
<!-- Write one concise, user-facing entry without a leading bullet. -->
<!-- release-note:start -->
Normal square videos no longer open in the Shorts player.
<!-- release-note:end -->

## Release note images
<!-- Human-only: Agents must preserve this entire section and leave it empty. -->
<!-- Optional. Paste one or more Markdown images or HTML image tags here. -->
<!-- The release notes will use an HTML image tag and limit images taller than 300 pixels. -->
<!-- release-note-image:start -->

<!-- release-note-image:end -->

## Testing
<!-- How can reviewers verify that the PR produces correct results? -->
<!-- Please provide instructions so that others can ensure that your pull request would produce correct results. For examples see, https://github.com/FreeTubeApp/FreeTube/pull/5743, https://github.com/FreeTubeApp/FreeTube/pull/7349, https://github.com/FreeTubeApp/FreeTube/pull/5125, https://github.com/FreeTubeApp/FreeTube/pull/7338 -->
<!-- Agent instructions: Only write human-facing steps that explain how to verify the change while running this branch in dev mode. Include expected results and, when applicable, helpful console snippets for interactive verification. Do not include automated checks, commands, results, pass counts, or CI status. -->
1. Enable the custom Shorts player.
2. Search for a normal square video shorter than three minutes and open it. The standard Watch player and layout should remain active after playback loads.
3. Open a square Short from a Shorts feed or `/shorts/` URL. The custom Shorts player should still appear.

## Additional context
<!-- Add any other context about the pull request here. -->
The normal-video override is represented as `short=false` on internal Watch routes. Unclassified portrait media still uses duration and aspect ratio as a fallback.
