### PR TITLE
feat(playback): show authenticated restricted videos

### DIFF
--- a/e2e/tests/offline/data-settings.spec.mjs
+++ b/e2e/tests/offline/data-settings.spec.mjs
@@ -81,3 +81,45 @@ test('does not show a delayed IPC error after opening the profile directory', as
   await page.waitForTimeout(2500)
   expect(await page.evaluate(() => globalThis.profileDirectoryErrorToastShown)).toBe(false)
 })
+
+test('imports the members-only flag from exported watch history', async ({ page }) => {
+  const dataSection = await goToSettingsSection(page, 'data')
+  await page.evaluate(() => {
+    const historyEntry = {
+      author: 'Members Channel',
+      authorId: 'UCmembersOnlyImport',
+      isLive: false,
+      isMembersOnly: true,
+      lengthSeconds: 120,
+      published: Date.now() - 86_400_000,
+      timeWatched: Date.now(),
+      title: 'Members-only import',
+      type: 'video',
+      videoId: 'member00001',
+      watchProgress: 30
+    }
+    const contents = `${JSON.stringify(historyEntry)}\n`
+
+    Object.defineProperty(window, 'showOpenFilePicker', {
+      configurable: true,
+      value: async () => [{
+        getFile: async () => new File(
+          [contents],
+          'opentubex-history.db',
+          { type: 'application/x-freetube-db' }
+        )
+      }]
+    })
+  })
+
+  await dataSection.getByRole('button', { name: 'Import history', exact: true }).click()
+
+  await expect(page.locator('.toast', {
+    hasText: 'All watched history has been successfully imported'
+  })).toBeVisible()
+  await expect(page.locator('.toast', { hasText: 'Unknown data key' })).toHaveCount(0)
+  await expect.poll(() => page.evaluate(() => {
+    const store = document.querySelector('#app').__vue_app__.config.globalProperties.$store
+    return store.getters.getHistoryCacheById.member00001?.isMembersOnly
+  })).toBe(true)
+})

--- a/e2e/tests/offline/subscriptions-feed.spec.mjs
+++ b/e2e/tests/offline/subscriptions-feed.spec.mjs
@@ -49,7 +49,7 @@ const seed = {
     {
       _id: CHANNEL_A,
       videos: [
-        feedVideo('aaaaaaaaaa1', 'Video A newer', CHANNEL_A, now - 1 * HOUR),
+        feedVideo('aaaaaaaaaa1', 'Video A newer', CHANNEL_A, now - 1 * HOUR, { isMembersOnly: true }),
         feedVideo('aaaaaaaaaa4', 'Running premiere video', CHANNEL_A, now - 2 * HOUR, {
           isPremiere: true,
           liveNow: true
@@ -135,6 +135,16 @@ test.describe('subscriptions feed from cache', () => {
 
     // The subscription feed honours the hide-upcoming-premieres setting.
     await expect(page.getByText('Upcoming premiere video')).toHaveCount(0)
+  })
+
+  test('labels members-only videos', async ({ page }) => {
+    await goTo(page, 'subscriptions')
+
+    const video = page.locator('.ft-list-video').filter({ hasText: 'Video A newer' })
+    const badge = video.locator('.membersOnlyTag')
+    await expect(badge).toHaveText('Members only')
+    await expect(badge.locator('[data-icon="users"]')).toBeVisible()
+    await expect(badge).toHaveCSS('white-space', 'nowrap')
   })
 
   test('shows a hidden upcoming premiere as a premiere when its scheduled time arrives', async ({ page }) => {

--- a/e2e/tests/offline/video-actions.spec.mjs
+++ b/e2e/tests/offline/video-actions.spec.mjs
@@ -1650,25 +1650,35 @@ test.describe('list video actions', () => {
     }).toEqual(['eeeeeeeeeee'])
   })
 
-  test('quick bookmark saves the video to the target playlist', async ({ app, page }) => {
-    await goTo(page, 'history')
+  test.describe('members-only quick bookmarks', () => {
+    test.use({
+      seed: {
+        ...SEED,
+        history: [{ ...historyEntry('eeeeeeeeeee', 'Bookmarkable video'), isMembersOnly: true }]
+      }
+    })
 
-    const video = page.locator('.ft-list-video').first()
-    await video.hover()
-    await expect(video.locator('.quickBookmarkVideoIcon [data-icon="clock"]')).toBeVisible()
-    await video.locator('.quickBookmarkVideoIcon').click()
+    test('quick bookmark saves the video to the target playlist', async ({ app, page }) => {
+      await goTo(page, 'history')
 
-    // Once saved, the button keeps the configured icon and indicates state with color.
-    await expect(video.locator('.quickBookmarkVideoIcon.bookmarked')).toBeVisible()
-    await expect(video.locator('.quickBookmarkVideoIcon [data-icon="clock"]')).toBeVisible()
-    await expect(video.locator('.quickBookmarkVideoIcon .overlayIcon')).toHaveCount(0)
-    await expect(video.locator('.quickBookmarkVideoIcon .iconButton')).toHaveCSS('color', 'rgb(110, 170, 115)')
-    await expect(page.locator('.toast .message', { hasText: 'Video has been saved to Favorites' })).toBeVisible()
+      const video = page.locator('.ft-list-video').first()
+      await video.hover()
+      await expect(video.locator('.quickBookmarkVideoIcon [data-icon="clock"]')).toBeVisible()
+      await video.locator('.quickBookmarkVideoIcon').click()
 
-    await expect.poll(async () => {
-      const favorites = await readPlaylist(app, 'favorites')
-      return favorites?.videos?.map((entry) => entry.videoId)
-    }).toEqual(['eeeeeeeeeee'])
+      // Once saved, the button keeps the configured icon and indicates state with color.
+      await expect(video.locator('.quickBookmarkVideoIcon.bookmarked')).toBeVisible()
+      await expect(video.locator('.quickBookmarkVideoIcon [data-icon="clock"]')).toBeVisible()
+      await expect(video.locator('.quickBookmarkVideoIcon .overlayIcon')).toHaveCount(0)
+      await expect(video.locator('.quickBookmarkVideoIcon .iconButton')).toHaveCSS('color', 'rgb(110, 170, 115)')
+      await expect(page.locator('.toast .message', { hasText: 'Video has been saved to Favorites' })).toBeVisible()
+
+      await expect.poll(async () => {
+        const favorites = await readPlaylist(app, 'favorites')
+        const entry = favorites?.videos?.[0]
+        return { videoId: entry?.videoId, isMembersOnly: entry?.isMembersOnly }
+      }).toEqual({ videoId: 'eeeeeeeeeee', isMembersOnly: true })
+    })
   })
 
   test('the options dropdown toggles watched status separately from removing history', async ({ app, page }) => {

--- a/src/renderer/components/DataSettings/DataSettings.vue
+++ b/src/renderer/components/DataSettings/DataSettings.vue
@@ -1030,6 +1030,7 @@ async function importFreeTubeWatchHistory(textDecode) {
     'lastViewedPlaylistId',
     'lastViewedPlaylistItemId',
     'lastViewedPlaylistType',
+    'isMembersOnly',
     'isWatched',
     'viewCount',
     'description',

--- a/src/renderer/components/FtListVideo/FtListVideo.scss
+++ b/src/renderer/components/FtListVideo/FtListVideo.scss
@@ -181,6 +181,14 @@
   white-space-collapse: collapse;
 }
 
+.membersOnlyTag {
+  align-items: center;
+  color: var(--members-only-color);
+  display: inline-flex;
+  gap: 3px;
+  white-space: nowrap;
+}
+
 .videoTagLine .videoTag:first-child {
   margin-inline-start: 0;
 }

--- a/src/renderer/components/FtListVideo/FtListVideo.vue
+++ b/src/renderer/components/FtListVideo/FtListVideo.vue
@@ -247,9 +247,19 @@
         @close="showCollaboratorsPrompt = false"
       />
       <div
-        v-if="is4k || hasCaptions || is8k || isNew || isVr180 || isVr360 || is3D"
+        v-if="isMembersOnly || is4k || hasCaptions || is8k || isNew || isVr180 || isVr360 || is3D"
         class="videoTagLine"
       >
+        <div
+          v-if="isMembersOnly"
+          class="videoTag membersOnlyTag"
+        >
+          <FtIcon
+            :icon="['fas', 'users']"
+            aria-hidden="true"
+          />
+          {{ t('Search Listing.Label.Members Only') }}
+        </div>
         <div
           v-if="isNew"
           class="videoTag"
@@ -536,6 +546,7 @@ const isVr180 = ref(false)
 const isVr360 = ref(false)
 const is3D = ref(false)
 const hasCaptions = ref(false)
+const isMembersOnly = ref(false)
 const isUpcoming = ref(false)
 const showDownloadPrompt = ref(false)
 const enableDownloads = computed(() => store.getters.getEnableDownloads)
@@ -1749,6 +1760,7 @@ function parseVideoData() {
   isVr360.value = props.data.isVr360
   is3D.value = props.data.is3d
   hasCaptions.value = props.data.hasCaptions
+  isMembersOnly.value = props.data.isMembersOnly === true
   isPremium.value = props.data.premium || false
   viewCount.value = props.data.viewCount
 
@@ -1813,6 +1825,7 @@ function markAsWatched() {
     timeWatched: historyEntry.value?.timeWatched ?? Date.now(),
     isLive: false,
     isUpcoming: false,
+    isMembersOnly: isMembersOnly.value,
     type: 'video'
   }
 
@@ -1863,6 +1876,7 @@ const addToPlaylistVideoData = computed(() => ({
   published: published.value,
   premiereDate: props.data.premiereDate,
   premiereTimestamp: props.data.premiereTimestamp,
+  isMembersOnly: isMembersOnly.value,
 }))
 
 /**

--- a/src/renderer/components/FtListVideo/FtListVideo.vue
+++ b/src/renderer/components/FtListVideo/FtListVideo.vue
@@ -1924,6 +1924,7 @@ async function addToQuickBookmarkPlaylist() {
     published: published.value,
     premiereDate: props.data.premiereDate,
     premiereTimestamp: props.data.premiereTimestamp,
+    isMembersOnly: isMembersOnly.value,
   }
 
   const playlistName = quickBookmarkPlaylist.value.playlistName

--- a/src/renderer/helpers/api/local.js
+++ b/src/renderer/helpers/api/local.js
@@ -3,11 +3,13 @@ import Autolinker from 'autolinker'
 import { parseLooseJSON } from 'bgutils-js/utils'
 
 import { SEARCH_CHAR_LIMIT } from '../../../constants'
+import store from '../../store/index'
 import { PlayerCache } from './PlayerCache'
 import { loadSearchContinuation } from '../search-continuation'
 import { parseLocalShortLinkedVideo } from '../player/shorts'
 import { getPaidPromotionDurationMs } from '../player/paidPromotion'
 import { getLocalPremiereState } from '../premiere'
+import { shouldHideMembersOnlyContent } from '../restricted-playback'
 import { getThumbnailPreviewUrl } from '../thumbnailPreview'
 import { isCollaborativeVideoAuthor, parseLocalVideoChannels } from '../video-collaborators'
 import {
@@ -1474,7 +1476,9 @@ export function parseLocalChannelVideos(videos, channelId, channelName) {
 
   for (const video of videos) {
     // `BADGE_STYLE_TYPE_MEMBERS_ONLY` used for both `members only` and `members first` videos
-    if (video.is(YTNodes.Video) && video.badges.some(badge => badge.style === 'BADGE_STYLE_TYPE_MEMBERS_ONLY')) {
+    const isMembersOnly = video.is(YTNodes.Video) &&
+      video.badges.some(badge => badge.style === 'BADGE_STYLE_TYPE_MEMBERS_ONLY')
+    if (shouldHideMembersOnlyContent(isMembersOnly, store.getters)) {
       continue
     }
     const parsedVideo = parseLocalListVideo(video, channelId, channelName)
@@ -1662,11 +1666,16 @@ export function parseChannelHomeTab(homeTab, channelId, channelName) {
 
         const playlistId = shelf.play_all_button?.endpoint.payload.playlistId
 
-        // filter out the members-only video section as none of the videos in that section are playable as they require a paid channel membership
-        if (!playlistId || !playlistId.startsWith('UUMO')) {
+        const isMembersOnly = playlistId?.startsWith('UUMO') ?? false
+        if (!shouldHideMembersOnlyContent(isMembersOnly, store.getters)) {
           shelves.push({
             title: shelf.title.text,
-            content: shelf.content.items.map((item) => parseListItem(item, channelId, channelName)).filter(_ => _),
+            content: shelf.content.items
+              .map((item) => parseListItem(item, channelId, channelName))
+              .filter(_ => _)
+              .map(item => isMembersOnly && item.type === 'video'
+                ? { ...item, isMembersOnly: true }
+                : item),
             playlistId,
             subtitle: shelf.subtitle?.text
           })
@@ -1819,7 +1828,7 @@ export function parseLocalPlaylistVideo(video) {
 }
 
 /**
- * Parses playlist entries and removes videos that cannot be played, such as members-only videos.
+ * Parses playlist entries and removes members-only videos unless authenticated playback is configured.
  * @param {(import('youtubei.js').YTNodes.PlaylistVideo|import('youtubei.js').YTNodes.ReelItem|import('youtubei.js').YTNodes.ShortsLockupView|import('youtubei.js').YTNodes.LockupView)[]} videos
  */
 export function parseLocalPlaylistVideos(videos) {
@@ -1909,6 +1918,7 @@ export function parseLocalListVideo(item, channelId, channelName) {
   } else {
     /** @type {import('youtubei.js').YTNodes.Video} */
     const video = item
+    const isMembersOnly = video.badges.some(badge => badge.style === 'BADGE_STYLE_TYPE_MEMBERS_ONLY')
 
     // When video is passed in via like community post attachment
     if (video.title?.text === 'This video isn\'t publicly available') {
@@ -1958,7 +1968,8 @@ export function parseLocalListVideo(item, channelId, channelName) {
       isVr180: video.badges.some(badge => badge.label === 'VR180'),
       isVr360: video.badges.some(badge => badge.label === '360°'),
       is3d: video.badges.some(badge => badge.label === '3D'),
-      hasCaptions: video.has_captions
+      hasCaptions: video.has_captions,
+      isMembersOnly
     }
   }
 }
@@ -2047,7 +2058,7 @@ function parseLockupView(lockupView, channelId = undefined, channelName = undefi
       const isMemberOnly = lockupView.metadata.metadata?.metadata_rows.some(row => {
         return row.badges.some(badge => badge.style === 'BADGE_MEMBERS_ONLY')
       })
-      if (isMemberOnly) {
+      if (shouldHideMembersOnlyContent(isMemberOnly, store.getters)) {
         return null
       }
 
@@ -2161,7 +2172,8 @@ function parseLockupView(lockupView, channelId = undefined, channelName = undefi
         isPremiere,
         isUpcoming,
         premiereDate,
-        isShort: lockupView.content_type === 'SHORT'
+        isShort: lockupView.content_type === 'SHORT',
+        isMembersOnly: Boolean(isMemberOnly)
       }
     }
     default:

--- a/src/renderer/helpers/restricted-playback.js
+++ b/src/renderer/helpers/restricted-playback.js
@@ -1,0 +1,26 @@
+/**
+ * @param {Record<string, unknown>} getters
+ * @param {boolean} [isElectron]
+ */
+export function hasConfiguredRestrictedPlaybackAuthentication(
+  getters,
+  isElectron = process.env.IS_ELECTRON
+) {
+  const cookiePath = getters.getYtDlpPlaybackCookiesPath
+  const browser = getters.getYtDlpPlaybackCookiesBrowser
+  const cookieFileConfigured = getters.getYtDlpPlaybackAuthMode === 'file' &&
+    typeof cookiePath === 'string' && cookiePath.trim() !== ''
+  const browserConfigured = getters.getYtDlpPlaybackAuthMode === 'browser' &&
+    typeof browser === 'string' && browser.trim() !== ''
+
+  return Boolean(isElectron && (cookieFileConfigured || browserConfigured))
+}
+
+/**
+ * @param {boolean} isMembersOnly
+ * @param {Record<string, unknown>} getters
+ * @param {boolean} [isElectron]
+ */
+export function shouldHideMembersOnlyContent(isMembersOnly, getters, isElectron = process.env.IS_ELECTRON) {
+  return Boolean(isMembersOnly && !hasConfiguredRestrictedPlaybackAuthentication(getters, isElectron))
+}

--- a/src/renderer/themes.css
+++ b/src/renderer/themes.css
@@ -38,6 +38,7 @@ body {
   --destructive-text-color: #000;
   --destructive-hover-color: #e53935;
   --destructive-active-color: #c62828;
+  --members-only-color: #1b7331;
   --favorite-icon-filter: grayscale(1) sepia(1) saturate(2.2) hue-rotate(68deg) brightness(0.9);
 
   /* For the 'About' page, show the logo with the primary text color by default */
@@ -126,6 +127,7 @@ it can be safely elided. This looks quite pleasant on this theme. */
 .everforestDarkMedium,
 .everforestDarkLow {
   --primary-shadow-color: rgb(0 0 0 / 75%);
+  --members-only-color: #55c86b;
 
   .invidiousLogo {
     background-image: url('./assets/img/invidious-logo-dark.svg');

--- a/src/renderer/views/Watch/Watch.js
+++ b/src/renderer/views/Watch/Watch.js
@@ -15,6 +15,7 @@ import WatchVideoPlaylist from '../../components/WatchVideoPlaylist/WatchVideoPl
 import WatchVideoQueue from '../../components/WatchVideoQueue/WatchVideoQueue.vue'
 import WatchVideoRecommendations from '../../components/WatchVideoRecommendations/WatchVideoRecommendations.vue'
 import FtAgeRestricted from '../../components/FtAgeRestricted/FtAgeRestricted.vue'
+import { hasConfiguredRestrictedPlaybackAuthentication } from '../../helpers/restricted-playback'
 import FtSubscribeButton from '../../components/FtSubscribeButton/FtSubscribeButton.vue'
 import FtShareButton from '../../components/FtShareButton/FtShareButton.vue'
 import FtIconButton from '../../components/FtIconButton/FtIconButton.vue'
@@ -599,15 +600,7 @@ export default defineComponent({
       ])
     },
     hasConfiguredRestrictedPlaybackAuthentication: function () {
-      const getters = this.$store.getters
-      const cookiePath = getters.getYtDlpPlaybackCookiesPath
-      const browser = getters.getYtDlpPlaybackCookiesBrowser
-      const cookieFileConfigured = getters.getYtDlpPlaybackAuthMode === 'file' &&
-        typeof cookiePath === 'string' && cookiePath.trim() !== ''
-      const browserConfigured = getters.getYtDlpPlaybackAuthMode === 'browser' &&
-        typeof browser === 'string' && browser.trim() !== ''
-
-      return process.env.IS_ELECTRON && (cookieFileConfigured || browserConfigured)
+      return hasConfiguredRestrictedPlaybackAuthentication(this.$store.getters)
     },
     canTryRestrictedPlaybackWithCookies: function () {
       return this.restrictedPlaybackError !== null &&

--- a/static/locales/en-US.yaml
+++ b/static/locales/en-US.yaml
@@ -121,6 +121,7 @@ Search Listing:
     360 Video: 360°
     Subtitles: Subtitles
     New: New
+    Members Only: Members only
     3D: 3D
     # Aria labels
     Closed Captions: Closed Captions

--- a/tests/unit/restricted-playback.test.mjs
+++ b/tests/unit/restricted-playback.test.mjs
@@ -1,0 +1,59 @@
+import assert from 'node:assert/strict'
+import test from 'node:test'
+
+import {
+  hasConfiguredRestrictedPlaybackAuthentication,
+  shouldHideMembersOnlyContent
+} from '../../src/renderer/helpers/restricted-playback.js'
+
+function restrictedPlaybackSettings (overrides = {}) {
+  return {
+    getYtDlpPlaybackAuthMode: 'none',
+    getYtDlpPlaybackCookiesPath: '',
+    getYtDlpPlaybackCookiesBrowser: '',
+    ...overrides
+  }
+}
+
+test('recognises configured restricted playback authentication', () => {
+  assert.equal(hasConfiguredRestrictedPlaybackAuthentication(
+    restrictedPlaybackSettings({
+      getYtDlpPlaybackAuthMode: 'file',
+      getYtDlpPlaybackCookiesPath: '/tmp/cookies.txt'
+    }),
+    true
+  ), true)
+
+  assert.equal(hasConfiguredRestrictedPlaybackAuthentication(
+    restrictedPlaybackSettings({
+      getYtDlpPlaybackAuthMode: 'browser',
+      getYtDlpPlaybackCookiesBrowser: 'firefox'
+    }),
+    true
+  ), true)
+})
+
+test('does not treat incomplete or web authentication settings as configured', () => {
+  assert.equal(hasConfiguredRestrictedPlaybackAuthentication(
+    restrictedPlaybackSettings({ getYtDlpPlaybackAuthMode: 'file' }),
+    true
+  ), false)
+  assert.equal(hasConfiguredRestrictedPlaybackAuthentication(
+    restrictedPlaybackSettings({
+      getYtDlpPlaybackAuthMode: 'browser',
+      getYtDlpPlaybackCookiesBrowser: 'firefox'
+    }),
+    false
+  ), false)
+})
+
+test('keeps members-only content when restricted playback authentication is configured', () => {
+  const configuredSettings = restrictedPlaybackSettings({
+    getYtDlpPlaybackAuthMode: 'browser',
+    getYtDlpPlaybackCookiesBrowser: 'firefox'
+  })
+
+  assert.equal(shouldHideMembersOnlyContent(true, configuredSettings, true), false)
+  assert.equal(shouldHideMembersOnlyContent(true, restrictedPlaybackSettings(), true), true)
+  assert.equal(shouldHideMembersOnlyContent(false, restrictedPlaybackSettings(), true), false)
+})


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Make sure to follow the contributing guidelines. -->
<!-- Important note, we may remove your pull request if you do not use this provided PR template correctly. -->
<!-- Agent instructions: Preserve every heading, comment, and marker in this template. Never remove or rewrite the release-note-category:start/end, release-note:start/end, or release-note-image:start/end marker pairs. Never remove or rewrite the Release note images section; leave its contents for a human. -->

## Pull Request Type
<!-- Please select what type of pull request this is: [x] -->
- [ ] Bugfix
- [x] Feature Implementation
- [ ] Documentation
- [ ] Other

## Related issue
<!-- Please link the issue your pull request is referring to. -->
<!-- If this pull request fully resolves the relevant issue, put "closes" before the issue number. -->
<!-- Example: "closes #123456". -->
Follow-up to #844.

## Description
<!-- Please write a clear and concise description of what the pull request does. -->
Members-only videos are currently removed from channel and playlist listings even when restricted-video cookies are configured, so authenticated viewers cannot discover or open them.

This keeps members-only listings when cookie-file or browser authentication is configured, while retaining the existing filtering when authentication is unavailable. Visible members-only videos receive a themed green badge so viewers can identify them before opening them.

## Release note category
<!-- Select exactly one category. Every pull request must select one. -->
<!-- Select "Not noteworthy" when the pull request fixes a bug in or improves functionality that has not yet appeared in a stable release. -->
<!-- release-note-category:start -->
- [x] Not noteworthy
- [ ] Highlights
- [ ] More improvements
- [ ] Fixed bugs
<!-- release-note-category:end -->

## Release note
<!-- Required unless "Not noteworthy" is selected. -->
<!-- Write one concise, user-facing entry without a leading bullet. -->
<!-- release-note:start -->

<!-- release-note:end -->

## Release note images
<!-- Human-only: Agents must preserve this entire section and leave it empty. -->
<!-- Optional. Paste one or more Markdown images or HTML image tags here. -->
<!-- The release notes will use an HTML image tag and limit images taller than 300 pixels. -->
<!-- release-note-image:start -->

<!-- release-note-image:end -->

## Testing
<!-- How can reviewers verify that the PR produces correct results? -->
<!-- Please provide instructions so that others can ensure that your pull request would produce correct results. For examples see, https://github.com/FreeTubeApp/FreeTube/pull/5743, https://github.com/FreeTubeApp/FreeTube/pull/7349, https://github.com/FreeTubeApp/FreeTube/pull/5125, https://github.com/FreeTubeApp/FreeTube/pull/7338 -->
<!-- Agent instructions: Only write human-facing steps that explain how to verify the change while running this branch in dev mode. Include expected results and, when applicable, helpful console snippets for interactive verification. Do not include automated checks, commands, results, pass counts, or CI status. -->
1. Leave restricted-video authentication unconfigured, then open a channel or playlist containing members-only videos. Those entries should remain hidden.
2. Configure either a cookie file or browser under Settings → Advanced → Restricted Video Authentication, then revisit the same channel or playlist. Members-only entries should now be visible.
3. Verify that each visible members-only entry has a green “Members only” badge with a people icon and that the badge stays on one line at narrow widths.
4. Open one of the entries and verify that the configured-cookie playback flow remains available.
5. Check the badge in both light and dark themes and with both Material and Remix icon packs.

## Additional context
<!-- Add any other context about the pull request here. -->
This reuses the authentication-readiness check from the watch page so listing visibility and restricted playback agree on when cookies are usable.
