### PR TITLE
fix(comments): show uploader avatars in reply controls

### DIFF
--- a/e2e/helpers/watch.mjs
+++ b/e2e/helpers/watch.mjs
@@ -46,6 +46,28 @@ async function fixture(dir, name) {
   }
 }
 
+function addOwnerReplyMarker(body) {
+  const response = JSON.parse(body)
+  const pending = [response]
+
+  while (pending.length > 0) {
+    const value = pending.pop()
+    if (!value || typeof value !== 'object') continue
+
+    const replies = value.commentThreadRenderer?.replies?.commentRepliesRenderer
+    if (replies) {
+      replies.viewRepliesCreatorThumbnail = {
+        thumbnails: [{ url: 'https://images.test/channel-owner.png' }]
+      }
+      return Buffer.from(JSON.stringify(response))
+    }
+
+    pending.push(...Object.values(value))
+  }
+
+  throw new Error('Unable to add an owner-reply marker to the comment fixture')
+}
+
 /**
  * Serves the watch page for `jNQXAC9IVRw` from the committed Innertube
  * fixtures, without any network access.
@@ -63,12 +85,14 @@ async function fixture(dir, name) {
  * @param {boolean} [options.captionTranslations] include a translatable caption and target languages
  * @param {string} [options.captionCueSettings] append WebVTT settings to the test caption cue
  * @param {string[]|null} [options.captionVideoIds] limit captions to these video IDs
+ * @param {boolean} [options.ownerReply] mark the first reply thread as containing a video-owner reply
  */
 export async function mockWatchPage(app, page, {
   playable = false,
   captionTranslations = false,
   captionCueSettings = '',
-  captionVideoIds = null
+  captionVideoIds = null,
+  ownerReply = false
 } = {}) {
   const counters = new Map()
   const includeCaptions = captionTranslations || captionCueSettings !== '' || captionVideoIds !== null
@@ -189,6 +213,9 @@ export async function mockWatchPage(app, page, {
       }
 
       if (body) {
+        if (ownerReply && body.includes('commentThreadRenderer')) {
+          body = addOwnerReplyMarker(body)
+        }
         return route.fulfill({ status: 200, contentType: 'application/json', body })
       }
       console.warn(`[e2e] Missing watch page fixture: ${key}`)

--- a/e2e/tests/offline/watch-page.spec.mjs
+++ b/e2e/tests/offline/watch-page.spec.mjs
@@ -2302,6 +2302,27 @@ test.describe('manual comment loading', () => {
     }
   })
 
+  test('identifies collapsed replies from the video uploader', async ({ app, page, attachScreenshot }) => {
+    await mockPlayableWatchPage(app, page, { ownerReply: true })
+    await openMockedVideo(page)
+
+    const loadComments = page.locator('.getCommentsTitle')
+    await loadComments.scrollIntoViewIfNeeded()
+    await loadComments.click()
+    await expect(page.locator('.commentsTitle')).toBeVisible({ timeout: 30_000 })
+
+    const ownerReplyToggle = page.getByRole('button', {
+      name: /replies from .+ and others/
+    })
+    await expect(ownerReplyToggle).toBeVisible()
+    await expect(ownerReplyToggle.locator('.commentReplyOwnerThumbnail')).toBeVisible()
+    await expect(ownerReplyToggle.locator('.commentReplyOwnerSeparator')).toHaveText('•')
+    await expect(ownerReplyToggle.locator('.commentReplyToggleText')).toHaveText(/\d+ replies/)
+    await expect(ownerReplyToggle).not.toContainText('from')
+    await ownerReplyToggle.scrollIntoViewIfNeeded()
+    await attachScreenshot('uploader reply indicator')
+  })
+
   test('stale reply controls disappear after an empty final reply page', async ({ app, page }) => {
     await mockPlayableWatchPage(app, page)
     await openMockedVideo(page)

--- a/src/renderer/components/CommentSection/CommentSection.css
+++ b/src/renderer/components/CommentSection/CommentSection.css
@@ -498,6 +498,22 @@
   background-color: transparent;
 }
 
+.commentReplyToggleLabel {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+}
+
+.commentReplyOwnerThumbnail {
+  inline-size: 24px;
+  block-size: 24px;
+  border-radius: 50%;
+}
+
+.commentReplyOwnerSeparator {
+  font-weight: normal;
+}
+
 .getMoreComments {
   padding-block-end: 1em;
   text-align: center;

--- a/src/renderer/components/CommentSection/CommentSection.vue
+++ b/src/renderer/components/CommentSection/CommentSection.vue
@@ -277,6 +277,7 @@
               type="button"
               class="commentReplyContinuationButton"
               aria-expanded="false"
+              :aria-label="commentReplyAccessibleLabel(comment)"
               :disabled="isReplyLoading(comment.id)"
               @click="toggleCommentReplies(index)"
             >
@@ -288,7 +289,20 @@
                 :label="$t('Comments.Getting comment replies, please wait')"
               />
               <template v-else>
-                <span>{{ toggleCommentRepliesLinkText(comment) }}</span>
+                <span class="commentReplyToggleLabel">
+                  <FtRetryImage
+                    v-if="comment.hasOwnerReplied && channelThumbnail"
+                    :src="channelThumbnail"
+                    class="commentReplyOwnerThumbnail"
+                    aria-hidden="true"
+                  />
+                  <span
+                    v-if="comment.hasOwnerReplied && channelThumbnail"
+                    class="commentReplyOwnerSeparator"
+                    aria-hidden="true"
+                  >•</span>
+                  <span class="commentReplyToggleText">{{ toggleCommentRepliesLinkText(comment) }}</span>
+                </span>
                 <FtIcon
                   :icon="['fas', 'angle-down']"
                   aria-hidden="true"
@@ -462,6 +476,7 @@ import { useTabContext } from '../../tabs/TabContext'
 import { copyToClipboard, formatNumber, getRelativeTimeFromDate, showApiErrorToast, showToast } from '../../helpers/utils'
 import { useRelativeTimeClock } from '../../composables/useRelativeTimeClock'
 import {
+  getCommentReplyAccessibleLabel,
   getCommentReplyCount,
   getReplyContinuationToken,
   getReplyLoadState,
@@ -984,6 +999,13 @@ function toggleCommentRepliesLinkText(comment) {
   }
 
   return t('Comments.Reply Count', { replyCount }, replyCount)
+}
+
+/**
+ * @param {Comment} comment
+ */
+function commentReplyAccessibleLabel(comment) {
+  return getCommentReplyAccessibleLabel(comment, t, props.channelName)
 }
 
 /**

--- a/src/renderer/helpers/comment-replies.js
+++ b/src/renderer/helpers/comment-replies.js
@@ -15,6 +15,33 @@ export function getCommentReplyCount(comment) {
 }
 
 /**
+ * @param {{ hasOwnerReplied?: boolean, numReplies: number, replies: object[], showReplies: boolean }} comment
+ * @param {(key: string, values: object, count: number) => string} translate
+ * @param {string} channelName
+ */
+export function getCommentReplyAccessibleLabel(comment, translate, channelName) {
+  const replyCount = getCommentReplyCount(comment)
+
+  if (comment.showReplies) {
+    return translate('Comments.Hide {replyCount} replies', { replyCount }, replyCount)
+  }
+
+  if (comment.hasOwnerReplied) {
+    if (replyCount > 1) {
+      return translate(
+        'Comments.View {replyCount} replies from {channelName} and others',
+        { replyCount, channelName },
+        replyCount
+      )
+    }
+
+    return translate('Comments.View 1 reply from {channelName}', { channelName }, 1)
+  }
+
+  return translate('Comments.Reply Count', { replyCount }, replyCount)
+}
+
+/**
  * @param {number} loadedReplyCount
  * @param {number} expectedReplyCount
  * @param {boolean} hasNextContinuation

--- a/tests/unit/comment-replies.test.mjs
+++ b/tests/unit/comment-replies.test.mjs
@@ -2,6 +2,7 @@ import assert from 'node:assert/strict'
 import test from 'node:test'
 
 import {
+  getCommentReplyAccessibleLabel,
   getCommentReplyCount,
   getReplyContinuationToken,
   getReplyLoadState,
@@ -9,6 +10,20 @@ import {
   isMissingReplyResponseError,
   shouldLoadInitialReplies
 } from '../../src/renderer/helpers/comment-replies.js'
+
+test('describes collapsed replies from the video uploader', () => {
+  const comment = {
+    hasOwnerReplied: true,
+    numReplies: 3,
+    replies: [],
+    showReplies: false
+  }
+
+  assert.equal(
+    getCommentReplyAccessibleLabel(comment, key => key, 'Uploader'),
+    'Comments.View {replyCount} replies from {channelName} and others'
+  )
+})
 
 test('refreshes a stale advertised count after newer replies load', () => {
   const comment = {


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Make sure to follow the contributing guidelines. -->
<!-- Important note, we may remove your pull request if you do not use this provided PR template correctly. -->
<!-- Agent instructions: Preserve every heading, comment, and marker in this template. Never remove or rewrite the release-note-category:start/end, release-note:start/end, or release-note-image:start/end marker pairs. Never remove or rewrite the Release note images section; leave its contents for a human. -->

## Pull Request Type
<!-- Please select what type of pull request this is: [x] -->
- [x] Bugfix
- [ ] Feature Implementation
- [ ] Documentation
- [ ] Other

## Related issue
<!-- Please link the issue your pull request is referring to. -->
<!-- If this pull request fully resolves the relevant issue, put "closes" before the issue number. -->
<!-- Example: "closes #123456". -->

## Description
<!-- Please write a clear and concise description of what the pull request does. -->
Collapsed comment threads stopped indicating when the video uploader had replied. This restores that signal with a compact uploader avatar and dot before the reply count, matching the surrounding comment layout without bringing back the long owner-aware sentence. The button keeps that fuller description as its accessible label.

## Release note category
<!-- Select exactly one category. Every pull request must select one. -->
<!-- Select "Not noteworthy" when the pull request fixes a bug in or improves functionality that has not yet appeared in a stable release. -->
<!-- release-note-category:start -->
- [ ] Not noteworthy
- [ ] Highlights
- [ ] More improvements
- [x] Fixed bugs
<!-- release-note-category:end -->

## Release note
<!-- Required unless "Not noteworthy" is selected. -->
<!-- Write one concise, user-facing entry without a leading bullet. -->
<!-- release-note:start -->
Uploader replies are identified by the channel avatar beside collapsed reply counts.
<!-- release-note:end -->

## Release note images
<!-- Human-only: Agents must preserve this entire section and leave it empty. -->
<!-- Optional. Paste one or more Markdown images or HTML image tags here. -->
<!-- The release notes will use an HTML image tag and limit images taller than 300 pixels. -->
<!-- release-note-image:start -->

<!-- release-note-image:end -->

## Testing
<!-- How can reviewers verify that the PR produces correct results? -->
<!-- Please provide instructions so that others can ensure that your pull request would produce correct results. For examples see, https://github.com/FreeTubeApp/FreeTube/pull/5743, https://github.com/FreeTubeApp/FreeTube/pull/7349, https://github.com/FreeTubeApp/FreeTube/pull/5125, https://github.com/FreeTubeApp/FreeTube/pull/7338 -->
<!-- Agent instructions: Only write human-facing steps that explain how to verify the change while running this branch in dev mode. Include expected results and, when applicable, helpful console snippets for interactive verification. Do not include automated checks, commands, results, pass counts, or CI status. -->
1. Open a video with a collapsed top-level comment thread that contains a reply from the video uploader.
2. Confirm the reply control shows the uploader avatar, a dot, the compact reply count, and the expand chevron.
3. Confirm a thread without an uploader reply still shows only its reply count and chevron.
4. Repeat at a non-default UI scale such as 125% and confirm the avatar, dot, text, and chevron remain aligned.

## Additional context
<!-- Add any other context about the pull request here. -->
The local comment parser already preserved YouTube's uploader-reply marker. The regression was limited to how the collapsed reply control presented that state.
