### PR TITLE
fix(thumbnails): ignore failed hover previews

### DIFF
--- a/e2e/tests/network/search.spec.mjs
+++ b/e2e/tests/network/search.spec.mjs
@@ -4,7 +4,9 @@ import { test, expect } from '../../helpers/innertube.mjs'
 test.describe('search', () => {
   test('search returns video results', async ({ page }) => {
     let blockPreviewRequest = true
+    let returnPreviewPlaceholder = false
     let releasePreviewRequest
+    let placeholderPreviewRequested = false
     let previewRequestFinished = false
     page.on('requestfinished', request => {
       if (/\/an_webp\//.test(request.url())) {
@@ -12,6 +14,16 @@ test.describe('search', () => {
       }
     })
     await page.route(/\/an_webp\//, async route => {
+      if (returnPreviewPlaceholder) {
+        placeholderPreviewRequested = true
+        await route.fulfill({
+          status: 404,
+          contentType: 'image/svg+xml',
+          body: '<svg xmlns="http://www.w3.org/2000/svg" width="120" height="90"/>'
+        })
+        return
+      }
+
       if (blockPreviewRequest) {
         await new Promise(resolve => {
           releasePreviewRequest = () => {
@@ -81,6 +93,14 @@ test.describe('search', () => {
 
     await page.mouse.move(0, 0)
     await expect(preview).toHaveCount(0)
+
+    returnPreviewPlaceholder = true
+    const secondVideo = page.locator('.ft-list-video').nth(1)
+    await secondVideo.locator('.thumbnailLink').hover()
+    await expect.poll(() => placeholderPreviewRequested).toBe(true)
+    await page.waitForTimeout(600)
+    await expect(secondVideo.locator('.thumbnailPreview')).toHaveCount(0)
+    await expect(secondVideo.locator('.thumbnailImage').first()).toBeVisible()
 
     await page.evaluate(() => {
       const store = document.querySelector('#app').__vue_app__.config.globalProperties.$store

--- a/e2e/tests/network/search.spec.mjs
+++ b/e2e/tests/network/search.spec.mjs
@@ -94,6 +94,17 @@ test.describe('search', () => {
     await page.mouse.move(0, 0)
     await expect(preview).toHaveCount(0)
 
+    await page.evaluate(() => {
+      const NativeImage = window.Image
+      window.__thumbnailPreviewLoaderCount = 0
+      window.Image = new Proxy(NativeImage, {
+        construct(target, args) {
+          window.__thumbnailPreviewLoaderCount++
+          return Reflect.construct(target, args)
+        }
+      })
+    })
+
     returnPreviewPlaceholder = true
     const secondVideo = page.locator('.ft-list-video').nth(1)
     await secondVideo.locator('.thumbnailLink').hover()
@@ -101,6 +112,13 @@ test.describe('search', () => {
     await page.waitForTimeout(600)
     await expect(secondVideo.locator('.thumbnailPreview')).toHaveCount(0)
     await expect(secondVideo.locator('.thumbnailImage').first()).toBeVisible()
+    const loaderCountAfterPlaceholder = await page.evaluate(() => window.__thumbnailPreviewLoaderCount)
+
+    await page.mouse.move(0, 0)
+    returnPreviewPlaceholder = false
+    await secondVideo.locator('.thumbnailLink').hover()
+    await expect.poll(() => page.evaluate(() => window.__thumbnailPreviewLoaderCount))
+      .toBeGreaterThan(loaderCountAfterPlaceholder)
 
     await page.evaluate(() => {
       const store = document.querySelector('#app').__vue_app__.config.globalProperties.$store

--- a/src/renderer/components/FtListVideo/FtListVideo.vue
+++ b/src/renderer/components/FtListVideo/FtListVideo.vue
@@ -690,7 +690,11 @@ function startThumbnailPreview() {
         thumbnailPreviewLoader === loader &&
         thumbnailPreviewUrl.value === previewUrl
       ) {
-        thumbnailPreviewLoaded.value = isThumbnailPreviewImageUsable(loader)
+        if (isThumbnailPreviewImageUsable(loader)) {
+          thumbnailPreviewLoaded.value = true
+        } else {
+          resetThumbnailPreview()
+        }
       }
     }
     loader.onerror = () => {

--- a/src/renderer/components/FtListVideo/FtListVideo.vue
+++ b/src/renderer/components/FtListVideo/FtListVideo.vue
@@ -403,6 +403,7 @@ import {
 import { getLocalVideoChannels } from '../../helpers/api/local.js'
 import { isHistoryEntryWatched } from '../../helpers/history.js'
 import { getUpcomingPremiereTimestamp } from '../../helpers/subscription-entries.js'
+import { isThumbnailPreviewImageUsable } from '../../helpers/thumbnailPreview.js'
 import { deArrowData, deArrowThumbnail, getSponsorBlockVideoLabel } from '../../helpers/sponsorblock.js'
 import {
   morphThumbnailIntoNewTab,
@@ -689,7 +690,7 @@ function startThumbnailPreview() {
         thumbnailPreviewLoader === loader &&
         thumbnailPreviewUrl.value === previewUrl
       ) {
-        thumbnailPreviewLoaded.value = true
+        thumbnailPreviewLoaded.value = isThumbnailPreviewImageUsable(loader)
       }
     }
     loader.onerror = () => {

--- a/src/renderer/helpers/thumbnailPreview.js
+++ b/src/renderer/helpers/thumbnailPreview.js
@@ -22,3 +22,16 @@ export function getThumbnailPreviewUrl(video) {
     thumbnail => typeof thumbnail?.url === 'string'
   )?.url ?? null
 }
+
+/**
+ * YouTube's failed moving-thumbnail requests return a decodable 120x90 error
+ * image. Image loaders report it as loaded even though the response is a 404.
+ *
+ * @param {{ naturalWidth: number, naturalHeight: number }} image
+ * @returns {boolean}
+ */
+export function isThumbnailPreviewImageUsable(image) {
+  return image.naturalWidth > 0 &&
+    image.naturalHeight > 0 &&
+    !(image.naturalWidth === 120 && image.naturalHeight === 90)
+}

--- a/tests/unit/thumbnail-preview.test.mjs
+++ b/tests/unit/thumbnail-preview.test.mjs
@@ -50,6 +50,14 @@ test('rejects YouTube\'s decodable moving-thumbnail error image', () => {
     naturalHeight: 90
   }), false)
   assert.equal(isThumbnailPreviewImageUsable({
+    naturalWidth: 0,
+    naturalHeight: 180
+  }), false)
+  assert.equal(isThumbnailPreviewImageUsable({
+    naturalWidth: 320,
+    naturalHeight: 0
+  }), false)
+  assert.equal(isThumbnailPreviewImageUsable({
     naturalWidth: 320,
     naturalHeight: 180
   }), true)

--- a/tests/unit/thumbnail-preview.test.mjs
+++ b/tests/unit/thumbnail-preview.test.mjs
@@ -1,7 +1,10 @@
 import assert from 'node:assert/strict'
 import test from 'node:test'
 
-import { getThumbnailPreviewUrl } from '../../src/renderer/helpers/thumbnailPreview.js'
+import {
+  getThumbnailPreviewUrl,
+  isThumbnailPreviewImageUsable
+} from '../../src/renderer/helpers/thumbnailPreview.js'
 
 test('reads moving thumbnails from regular YouTube video results', () => {
   assert.equal(getThumbnailPreviewUrl({
@@ -39,4 +42,15 @@ test('ignores video results without a usable moving thumbnail', () => {
       }]
     }
   }), null)
+})
+
+test('rejects YouTube\'s decodable moving-thumbnail error image', () => {
+  assert.equal(isThumbnailPreviewImageUsable({
+    naturalWidth: 120,
+    naturalHeight: 90
+  }), false)
+  assert.equal(isThumbnailPreviewImageUsable({
+    naturalWidth: 320,
+    naturalHeight: 180
+  }), true)
 })


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Make sure to follow the contributing guidelines. -->
<!-- Important note, we may remove your pull request if you do not use this provided PR template correctly. -->
<!-- Agent instructions: Preserve every heading, comment, and marker in this template. Never remove or rewrite the release-note-category:start/end, release-note:start/end, or release-note-image:start/end marker pairs. Never remove or rewrite the Release note images section; leave its contents for a human. -->

## Pull Request Type
<!-- Please select what type of pull request this is: [x] -->
- [x] Bugfix
- [ ] Feature Implementation
- [ ] Documentation
- [ ] Other

## Related issue
<!-- Please link the issue your pull request is referring to. -->
<!-- If this pull request fully resolves the relevant issue, put "closes" before the issue number. -->
<!-- Example: "closes #123456". -->

Follow-up to #851.

## Description
<!-- Please write a clear and concise description of what the pull request does. -->

Failed moving-thumbnail requests can return a decodable 120x90 error image. The browser reports that response as a loaded image, so the error asset replaces the video's real thumbnail.

This change rejects that known error image after decoding and keeps the static thumbnail visible. Normal moving thumbnails continue to load through the existing preview path.

## Release note category
<!-- Select exactly one category. Every pull request must select one. -->
<!-- Select "Not noteworthy" when the pull request fixes a bug in or improves functionality that has not yet appeared in a stable release. -->
<!-- release-note-category:start -->
- [x] Not noteworthy
- [ ] Highlights
- [ ] More improvements
- [ ] Fixed bugs
<!-- release-note-category:end -->

## Release note
<!-- Required unless "Not noteworthy" is selected. -->
<!-- Write one concise, user-facing entry without a leading bullet. -->
<!-- release-note:start -->

<!-- release-note:end -->

## Release note images
<!-- Human-only: Agents must preserve this entire section and leave it empty. -->
<!-- Optional. Paste one or more Markdown images or HTML image tags here. -->
<!-- The release notes will use an HTML image tag and limit images taller than 300 pixels. -->
<!-- release-note-image:start -->

<!-- release-note-image:end -->

## Testing
<!-- How can reviewers verify that the PR produces correct results? -->
<!-- Please provide instructions so that others can ensure that your pull request would produce correct results. For examples see, https://github.com/FreeTubeApp/FreeTube/pull/5743, https://github.com/FreeTubeApp/FreeTube/pull/7349, https://github.com/FreeTubeApp/FreeTube/pull/5125, https://github.com/FreeTubeApp/FreeTube/pull/7338 -->
<!-- Agent instructions: Only write human-facing steps that explain how to verify the change while running this branch in dev mode. Include expected results and, when applicable, helpful console snippets for interactive verification. Do not include automated checks, commands, results, pass counts, or CI status. -->

1. Open a search page with moving thumbnail previews.
2. Hover a thumbnail whose preview request returns the 120x90 error image. The static thumbnail should remain visible.
3. Hover a thumbnail with a valid moving preview. The animated thumbnail should still appear after the normal delay.

## Additional context
<!-- Add any other context here. -->

The failed response is a valid image body, so the image element's error event does not catch it. The regression coverage returns the same dimensions and HTTP status through the existing hover lifecycle.
