### PR TITLE
fix(tabs): keep background comment loading local

### DIFF
--- a/e2e/tests/offline/sabr-error-recovery.spec.mjs
+++ b/e2e/tests/offline/sabr-error-recovery.spec.mjs
@@ -1,4 +1,4 @@
-import { goTo, sel, setPlayerFullscreen, test, expect } from '../../helpers/app.mjs'
+import { goTo, setPlayerFullscreen, test, expect } from '../../helpers/app.mjs'
 import { openMockedVideo } from '../../helpers/player.mjs'
 import {
   mockPlayableWatchPage,
@@ -576,110 +576,6 @@ test('a SABR reload preserves the tab title while adding its resume timestamp', 
   expect(titles.publishedTitles).toEqual([titles.titleBeforeReload])
   await expect(page).toHaveURL(/oneTimeTimestamp=42/)
   await expect(page).toHaveTitle(`${titles.titleBeforeReload} - OpenTubeX`)
-})
-
-test('a background SABR refresh does not flash the tab loading indicator', async ({ app, page }) => {
-  await mockUnplayableWatchPage(app, page)
-  await goTo(page, 'history')
-  await page.getByText('SABR test video').click()
-  await expect(page).toHaveURL(/#\/watch\/jNQXAC9IVRw/)
-  await expect(page.locator('.errorMessage')).toBeVisible({ timeout: 30_000 })
-
-  const watchView = await watchViewHandle(page)
-  const watchTabId = await watchView.evaluate(view => view.tabId)
-  const watchTab = page.locator(`.tab[data-tab-id="${watchTabId}"]`)
-  const watchContent = page.locator(`.tabContent[data-tab-id="${watchTabId}"]`)
-  const historyTab = await page.evaluate(() => window.ftElectron.tabs.create({
-    route: '/history',
-    title: 'History',
-    makeActive: false,
-    preloadInBackground: true
-  }))
-  const historyTabElement = page.locator(`.tab[data-tab-id="${historyTab.id}"]`)
-  await expect(page.locator(sel.tabs)).toHaveCount(2)
-
-  await watchView.evaluate(view => {
-    view.activeFormat = 'dash'
-    view.manifestMimeType = 'application/sabr+json'
-    view.manifestSrc = 'sabr://test'
-    view.isLive = false
-    view.isPostLiveDvr = false
-    view.isLoading = false
-    view.getTimestamp = () => 42
-    view.showTabToast = () => {}
-    view.handleRouteChange = async () => {
-      window.__backgroundSabrRouteChangeStarted = true
-      await new Promise(resolve => { window.__finishBackgroundSabrRouteChange = resolve })
-    }
-    view.getVideoInformationLocal = async () => {
-      window.__backgroundSabrRefreshStarted = true
-      await new Promise(resolve => { window.__finishBackgroundSabrMetadata = resolve })
-      view.ytDlpStreamsPending = true
-      view.isLoading = false
-      window.__backgroundSabrStreamsStarted = true
-      await new Promise(resolve => { window.__finishBackgroundSabrStreams = resolve })
-      view.ytDlpStreamsPending = false
-    }
-
-    window.__backgroundSabrRouteChangeStarted = false
-    window.__backgroundSabrRefreshStarted = false
-    window.__backgroundSabrStreamsStarted = false
-    window.__backgroundSabrRefreshPromise = null
-    window.setTimeout(() => {
-      window.__backgroundSabrRefreshPromise = view.onPlayerReloadRequested({ wasPlaying: true })
-    }, 250)
-  })
-
-  try {
-    await historyTabElement.click()
-    await expect(historyTabElement).toHaveClass(/active/)
-    await expect.poll(() => page.evaluate(() => window.__backgroundSabrRouteChangeStarted)).toBe(true)
-    await watchView.evaluate(view => view.handleVideoLoaded({}))
-    await expect(watchContent.locator('.videoLayout')).toHaveAttribute('data-tab-loading-suppressed', '')
-
-    await page.evaluate(() => window.__finishBackgroundSabrRouteChange())
-    await expect.poll(() => page.evaluate(() => window.__backgroundSabrRefreshStarted)).toBe(true)
-    await expect(watchContent.locator('.videoPlayerPlaceholder')).toHaveCount(1)
-    await expect(watchContent.locator('.videoLayout')).toHaveAttribute('data-tab-loading-suppressed', '')
-    await expect(watchContent.locator('[data-tab-loading-indicator]')).not.toHaveCount(0)
-    await expect(watchTab).not.toHaveClass(/loading/)
-
-    await page.evaluate(() => window.__finishBackgroundSabrMetadata())
-    await expect.poll(() => page.evaluate(() => window.__backgroundSabrStreamsStarted)).toBe(true)
-    await expect(watchContent.locator('.streamPlaceholder')).toHaveCount(1)
-    await expect(watchContent.locator('.videoLayout')).toHaveAttribute('data-tab-loading-suppressed', '')
-    await expect(watchContent.locator('[data-tab-loading-indicator]')).not.toHaveCount(0)
-    await expect(watchTab).not.toHaveClass(/loading/)
-
-    await watchView.evaluate(view => { view.suppressTabLoadingIndicator = false })
-    await expect(watchContent.locator('.videoLayout')).not.toHaveAttribute('data-tab-loading-suppressed', '')
-    await page.waitForTimeout(250)
-    await expect(watchContent.locator('[data-tab-loading-indicator]')).not.toHaveCount(0)
-    await expect(watchTab).not.toHaveClass(/loading/)
-
-    await watchView.evaluate(view => { view.videoLoadGeneration++ })
-    await expect(watchTab).toHaveClass(/loading/)
-
-    await page.evaluate(async () => {
-      window.__finishBackgroundSabrStreams()
-      await window.__backgroundSabrRefreshPromise
-    })
-    await expect(watchContent.locator('[data-tab-loading-indicator]')).toHaveCount(0)
-
-    await watchView.evaluate(view => { view.isLoading = true })
-    await expect(watchTab).toHaveClass(/loading/)
-    await watchView.evaluate(view => { view.isLoading = false })
-    await expect(watchTab).not.toHaveClass(/loading/)
-  } finally {
-    await page.evaluate(async () => {
-      window.__finishBackgroundSabrRouteChange?.()
-      window.__finishBackgroundSabrMetadata?.()
-      await new Promise(resolve => window.setTimeout(resolve, 0))
-      window.__finishBackgroundSabrStreams?.()
-      await window.__backgroundSabrRefreshPromise
-    })
-    await watchView.dispose()
-  }
 })
 
 test('a second SABR failure after successful playback refetches instead of dropping to legacy', async ({ app, page }) => {

--- a/e2e/tests/offline/sabr-error-recovery.spec.mjs
+++ b/e2e/tests/offline/sabr-error-recovery.spec.mjs
@@ -717,6 +717,64 @@ test('an error from the outgoing player is ignored while the view reloads', asyn
   expect(result.errorMessage).toBe('')
 })
 
+test('a loaded event from the outgoing player is ignored while the view reloads', async ({ app, page }) => {
+  await mockUnplayableWatchPage(app, page)
+  await goTo(page, 'history')
+  await page.getByText('SABR test video').click()
+  await expect(page).toHaveURL(/#\/watch\/jNQXAC9IVRw/)
+  await expect(page.locator('.errorMessage')).toBeVisible({ timeout: 30_000 })
+
+  const watchView = await watchViewHandle(page)
+  const result = await watchView.evaluate(async (view) => {
+    let historyCalls = 0
+    let playlistCalls = 0
+    let localPlaylistCalls = 0
+    let timestampCalls = 0
+    let stateDuringPreparation = null
+
+    view.isLoading = false
+    view.videoPlayerLoaded = false
+    view.isUpcoming = false
+    view.rememberHistory = true
+    view.oneTimeTimestamp = 73
+    view.sabrReloadCaptionIndex = 2
+    view.sabrReloadPlaybackRate = 1.5
+    view.addToHistory = () => { historyCalls++ }
+    view.handlePlaylistPersisting = () => { playlistCalls++ }
+    view.updateLocalPlaylistLastPlayedAtSometimes = () => { localPlaylistCalls++ }
+    view.consumeTimestamp = async () => { timestampCalls++ }
+    view.getVideoInformationLocal = async () => {}
+    view.handleRouteChange = async () => {
+      await Promise.resolve()
+      await view.handleVideoLoaded({})
+      stateDuringPreparation = {
+        oneTimeTimestamp: view.oneTimeTimestamp,
+        sabrReloadCaptionIndex: view.sabrReloadCaptionIndex,
+        sabrReloadPlaybackRate: view.sabrReloadPlaybackRate,
+        videoPlayerLoaded: view.videoPlayerLoaded,
+        historyCalls,
+        playlistCalls,
+        localPlaylistCalls,
+        timestampCalls
+      }
+    }
+
+    await view.reloadView()
+    return stateDuringPreparation
+  })
+
+  expect(result).toEqual({
+    oneTimeTimestamp: 73,
+    sabrReloadCaptionIndex: 2,
+    sabrReloadPlaybackRate: 1.5,
+    videoPlayerLoaded: false,
+    historyCalls: 0,
+    playlistCalls: 0,
+    localPlaylistCalls: 0,
+    timestampCalls: 0
+  })
+})
+
 test('a SABR reload request from the outgoing player is ignored', async ({ app, page }) => {
   await mockUnplayableWatchPage(app, page)
   await goTo(page, 'history')

--- a/e2e/tests/offline/watch-page.spec.mjs
+++ b/e2e/tests/offline/watch-page.spec.mjs
@@ -506,6 +506,57 @@ test('a background watch tab stays loading until its cached avatar is ready', as
   expect(states.some(state => state.loading && state.pageIcon)).toBe(false)
 })
 
+test('keeps background comment loading local to the loaded watch page', async ({ app, page }) => {
+  await mockPlayableWatchPage(app, page)
+  await page.evaluate(() => {
+    const store = document.querySelector('#app').__vue_app__.config.globalProperties.$store
+    store.commit('setGeneralAutoLoadMorePaginatedItemsEnabled', false)
+  })
+  await openMockedVideo(page)
+
+  const watchTabId = await page.locator(sel.activeTab).getAttribute('data-tab-id')
+  const watchTab = page.locator(`.tab[data-tab-id="${watchTabId}"]`)
+  const watchContent = page.locator(`.tabContent[data-tab-id="${watchTabId}"]`)
+  await expect(watchContent.locator('.getCommentsTitle')).toHaveCount(1)
+  await expect(watchTab).not.toHaveClass(/loading/)
+
+  let commentRequestStarted = false
+  let releaseComments = () => {}
+  const commentsReleased = new Promise(resolve => { releaseComments = resolve })
+  await page.route(/\/youtubei\/v1\/next/, async (route, request) => {
+    const body = JSON.parse(request.postData() ?? '{}')
+    if (!body.continuation) return route.fallback()
+
+    commentRequestStarted = true
+    await commentsReleased
+    return route.fallback()
+  })
+
+  try {
+    await page.locator(sel.newTabButton).click()
+    await expect(watchContent).toHaveAttribute('aria-hidden', 'true')
+    await page.evaluate(() => {
+      const store = document.querySelector('#app').__vue_app__.config.globalProperties.$store
+      store.commit('setGeneralAutoLoadMorePaginatedItemsEnabled', true)
+    })
+    await expect.poll(() => commentRequestStarted).toBe(true)
+    await expect(watchContent.locator('.commentsArea .commentLoader')).toHaveCount(1)
+    await expect(watchContent.locator('.commentsArea [data-tab-loading-indicator]')).toHaveCount(0)
+    await expect(watchTab).not.toHaveClass(/loading/)
+  } finally {
+    releaseComments()
+  }
+
+  await expect(watchContent.locator('.commentsArea .commentLoader')).toHaveCount(0)
+
+  const watchView = await watchViewHandle(page)
+  await watchView.evaluate(view => { view.isLoading = true })
+  await expect(watchTab).toHaveClass(/loading/)
+  await watchView.evaluate(view => { view.isLoading = false })
+  await expect(watchTab).not.toHaveClass(/loading/)
+  await watchView.dispose()
+})
+
 for (const { defaultViewingMode, currentTheatreMode } of [
   { defaultViewingMode: 'theatre', currentTheatreMode: false },
   { defaultViewingMode: 'default', currentTheatreMode: true }

--- a/src/renderer/components/CommentSection/CommentSection.vue
+++ b/src/renderer/components/CommentSection/CommentSection.vue
@@ -442,6 +442,8 @@
       </h4>
       <FtLoader
         v-if="isLoading"
+        :tab-loading-indicator="false"
+        class="commentLoader"
       />
       <div
         v-if="!isLoading && !isLoadingMoreComments"

--- a/src/renderer/components/FtLoader/FtLoader.vue
+++ b/src/renderer/components/FtLoader/FtLoader.vue
@@ -2,7 +2,7 @@
   <div
     class="container"
     :class="{ fullscreen }"
-    data-tab-loading-indicator
+    :data-tab-loading-indicator="tabLoadingIndicator ? '' : undefined"
   >
     <div class="spinner">
       <div class="double-bounce1" />
@@ -16,6 +16,10 @@ defineProps({
   fullscreen: {
     type: Boolean,
     default: false
+  },
+  tabLoadingIndicator: {
+    type: Boolean,
+    default: true
   }
 })
 </script>

--- a/src/renderer/components/TabContent/TabContent.vue
+++ b/src/renderer/components/TabContent/TabContent.vue
@@ -44,9 +44,6 @@ import { tabRuntimeRegistry } from '../../tabs/TabRuntimeRegistry'
 import { tabIdKey, tabLifecycleKey, tabPresentedKey } from '../../tabs/TabContext'
 
 const TAB_LOADER_SELECTOR = '[data-tab-loading-indicator]'
-const TAB_LOADER_SUPPRESSION_SELECTOR = '[data-tab-loading-suppressed]'
-const TAB_LOADER_GENERATION_ATTRIBUTE = 'data-tab-loading-generation'
-const TAB_LOADER_GENERATION_SELECTOR = `[${TAB_LOADER_GENERATION_ATTRIBUTE}]`
 const TAB_LOADER_LOADING_SOURCE = 'loader'
 const TAB_LOADER_SETTLE_DELAY_MS = 100
 const CACHED_ROUTE_NAMES = new Set(['about'])
@@ -101,9 +98,6 @@ let removeRootRegistration = null
 let loaderObserver = null
 let loaderAnimationFrameId = null
 let loaderSettleTimeoutId = null
-// A suppression boundary can disappear before its loader does, while Vue can
-// reuse that element for a newer load. Remember both the element and its load.
-const suppressedLoaderGenerations = new WeakMap()
 let acknowledgedMountRevision = 0
 let previousRefreshKey = props.tab.refreshKey ?? 0
 // Guards against notifying `beforeDispose` twice for the same mounted instance:
@@ -197,11 +191,7 @@ onMounted(() => {
     loaderObserver = new MutationObserver(scheduleLoaderUpdate)
     loaderObserver.observe(tabContentRef.value, {
       attributes: true,
-      attributeFilter: [
-        'data-tab-loading-indicator',
-        'data-tab-loading-suppressed',
-        TAB_LOADER_GENERATION_ATTRIBUTE
-      ],
+      attributeFilter: ['data-tab-loading-indicator'],
       childList: true,
       subtree: true
     })
@@ -250,7 +240,7 @@ function scheduleLoaderUpdate() {
 }
 
 function updateLoaderState() {
-  if (hasUnsuppressedLoader()) {
+  if (tabContentRef.value?.querySelector(TAB_LOADER_SELECTOR) != null) {
     cancelLoaderSettle()
     navigation.setLoadingSource(props.tab.id, TAB_LOADER_LOADING_SOURCE, true)
     return
@@ -266,33 +256,12 @@ function updateLoaderState() {
 
 function settleLoaderState() {
   loaderSettleTimeoutId = null
-  if (hasUnsuppressedLoader()) {
+  if (tabContentRef.value?.querySelector(TAB_LOADER_SELECTOR) != null) {
     navigation.setLoadingSource(props.tab.id, TAB_LOADER_LOADING_SOURCE, true)
     return
   }
 
   navigation.setLoadingSource(props.tab.id, TAB_LOADER_LOADING_SOURCE, false)
-}
-
-function hasUnsuppressedLoader() {
-  const root = tabContentRef.value
-  if (!root) return false
-
-  for (const loader of root.querySelectorAll(TAB_LOADER_SELECTOR)) {
-    const generation = loader.closest(TAB_LOADER_GENERATION_SELECTOR)
-      ?.getAttribute(TAB_LOADER_GENERATION_ATTRIBUTE) ?? null
-
-    if (loader.closest(TAB_LOADER_SUPPRESSION_SELECTOR) !== null) {
-      suppressedLoaderGenerations.set(loader, generation)
-    } else if (
-      !suppressedLoaderGenerations.has(loader) ||
-      suppressedLoaderGenerations.get(loader) !== generation
-    ) {
-      return true
-    }
-  }
-
-  return false
 }
 
 function cancelLoaderSettle() {

--- a/src/renderer/views/Watch/Watch.js
+++ b/src/renderer/views/Watch/Watch.js
@@ -233,6 +233,7 @@ export default defineComponent({
       shortsCompletionBlockedBySeek: false,
       shortsPlaybackAfterSeekSeconds: 0,
       videoLoadGeneration: 0,
+      preparingVideoLoadGeneration: null,
       hasAiGeneratedContent: false,
       hasPaidPromotion: false,
       paidPromotionDurationMs: 10000,
@@ -1695,44 +1696,51 @@ export default defineComponent({
 
     async reloadView({ preserveTitle = false } = {}) {
       const loadGeneration = ++this.videoLoadGeneration
+      this.preparingVideoLoadGeneration = loadGeneration
       const requestedVideoId = this.tabRoute.params.id
       this.loadingTheatreMode = this.useTheatreMode
       preserveTitle ||= this.preserveTitleOnNextReload
       this.preserveTitleOnNextReload = false
 
-      await this.handleRouteChange()
-      if (!this.isCurrentVideoLoad(loadGeneration, requestedVideoId)) { return }
-
-      if (this.$refs.player) {
-        await this.destroyPlayer()
+      try {
+        await this.handleRouteChange()
         if (!this.isCurrentVideoLoad(loadGeneration, requestedVideoId)) { return }
-      }
 
-      // react to route changes...
-      const previousVideoId = this.videoId
-      this.videoId = this.tabRoute.params.id
-      const videoIdChanged = this.videoId !== previousVideoId
-      if (videoIdChanged) {
-        this.useCustomShortsPlayerForCurrentVideo = this.$store.getters.getUseCustomShortsPlayer
-        this.ipBlockRecoveryAttemptedForCurrentVideo = false
-        this.streamErrorReloadAttemptedForCurrentVideo = false
-        this.playbackEngineFallbackAttemptedForCurrentVideo = false
-        this.playbackEngineFallbackTarget = null
-        this.ytDlpDefaultClientsFallbackToastShown = false
-        this.sabrErrorRecoveryAttempts = 0
-        this.sabrErrorRecoveriesForCurrentVideo = 0
-        this.sabrErrorRecoveryLastSeconds = null
-        this.sabrErrorRecoveryPlayedSeconds = 0
+        if (this.$refs.player) {
+          await this.destroyPlayer()
+          if (!this.isCurrentVideoLoad(loadGeneration, requestedVideoId)) { return }
+        }
+
+        // react to route changes...
+        const previousVideoId = this.videoId
+        this.videoId = this.tabRoute.params.id
+        const videoIdChanged = this.videoId !== previousVideoId
+        if (videoIdChanged) {
+          this.useCustomShortsPlayerForCurrentVideo = this.$store.getters.getUseCustomShortsPlayer
+          this.ipBlockRecoveryAttemptedForCurrentVideo = false
+          this.streamErrorReloadAttemptedForCurrentVideo = false
+          this.playbackEngineFallbackAttemptedForCurrentVideo = false
+          this.playbackEngineFallbackTarget = null
+          this.ytDlpDefaultClientsFallbackToastShown = false
+          this.sabrErrorRecoveryAttempts = 0
+          this.sabrErrorRecoveriesForCurrentVideo = 0
+          this.sabrErrorRecoveryLastSeconds = null
+          this.sabrErrorRecoveryPlayedSeconds = 0
+        }
+        this.ipBlockDetectedInCurrentChain = false
+        const preserveShortsPanels = videoIdChanged &&
+          this.customShortsPlayerActive &&
+          this.tabRoute.query.short === 'true'
+        this.resetVideoState({
+          preserveTitle,
+          placeholderTitle: videoIdChanged ? this.getPendingVideoTitle() : '',
+          preserveShortsPanels,
+        })
+      } finally {
+        if (this.preparingVideoLoadGeneration === loadGeneration) {
+          this.preparingVideoLoadGeneration = null
+        }
       }
-      this.ipBlockDetectedInCurrentChain = false
-      const preserveShortsPanels = videoIdChanged &&
-        this.customShortsPlayerActive &&
-        this.tabRoute.query.short === 'true'
-      this.resetVideoState({
-        preserveTitle,
-        placeholderTitle: videoIdChanged ? this.getPendingVideoTitle() : '',
-        preserveShortsPanels,
-      })
 
       this.firstLoad = true
       this.videoPlayerLoaded = false
@@ -3938,6 +3946,8 @@ export default defineComponent({
     },
 
     handleVideoLoaded: async function (mediaMetadata) {
+      if (this.isLoading || this.preparingVideoLoadGeneration !== null) { return }
+
       // Only used one time = remove after use
       this.oneTimeTimestamp = null
       this.sabrReloadCaptionIndex = null

--- a/src/renderer/views/Watch/Watch.js
+++ b/src/renderer/views/Watch/Watch.js
@@ -204,8 +204,6 @@ export default defineComponent({
       // Same-tab navigation keeps the current layout while its skeleton loads.
       // A newly mounted watch tab falls back to the configured default instead.
       loadingTheatreMode: null,
-      suppressTabLoadingIndicator: false,
-      suppressTabLoadingIndicatorOnNextReload: false,
       applyDefaultTheatreModeAfterLoad: false,
       theatreLayoutAvailable: window.innerWidth > RESPONSIVE_THEATRE_MODE_MAX_WIDTH,
       videoPlayerLoaded: false,
@@ -235,7 +233,6 @@ export default defineComponent({
       shortsCompletionBlockedBySeek: false,
       shortsPlaybackAfterSeekSeconds: 0,
       videoLoadGeneration: 0,
-      preparingVideoLoadGeneration: null,
       hasAiGeneratedContent: false,
       hasPaidPromotion: false,
       paidPromotionDurationMs: 10000,
@@ -1068,12 +1065,6 @@ export default defineComponent({
         }
       }
     },
-    errorMessage(message) {
-      if (message) {
-        this.suppressTabLoadingIndicator = false
-        this.suppressTabLoadingIndicatorOnNextReload = false
-      }
-    },
     isTabPresented: {
       immediate: true,
       handler() {
@@ -1703,54 +1694,45 @@ export default defineComponent({
     },
 
     async reloadView({ preserveTitle = false } = {}) {
-      this.suppressTabLoadingIndicator = this.suppressTabLoadingIndicatorOnNextReload
-      this.suppressTabLoadingIndicatorOnNextReload = false
       const loadGeneration = ++this.videoLoadGeneration
-      this.preparingVideoLoadGeneration = loadGeneration
       const requestedVideoId = this.tabRoute.params.id
       this.loadingTheatreMode = this.useTheatreMode
       preserveTitle ||= this.preserveTitleOnNextReload
       this.preserveTitleOnNextReload = false
 
-      try {
-        await this.handleRouteChange()
+      await this.handleRouteChange()
+      if (!this.isCurrentVideoLoad(loadGeneration, requestedVideoId)) { return }
+
+      if (this.$refs.player) {
+        await this.destroyPlayer()
         if (!this.isCurrentVideoLoad(loadGeneration, requestedVideoId)) { return }
-
-        if (this.$refs.player) {
-          await this.destroyPlayer()
-          if (!this.isCurrentVideoLoad(loadGeneration, requestedVideoId)) { return }
-        }
-
-        // react to route changes...
-        const previousVideoId = this.videoId
-        this.videoId = this.tabRoute.params.id
-        const videoIdChanged = this.videoId !== previousVideoId
-        if (videoIdChanged) {
-          this.useCustomShortsPlayerForCurrentVideo = this.$store.getters.getUseCustomShortsPlayer
-          this.ipBlockRecoveryAttemptedForCurrentVideo = false
-          this.streamErrorReloadAttemptedForCurrentVideo = false
-          this.playbackEngineFallbackAttemptedForCurrentVideo = false
-          this.playbackEngineFallbackTarget = null
-          this.ytDlpDefaultClientsFallbackToastShown = false
-          this.sabrErrorRecoveryAttempts = 0
-          this.sabrErrorRecoveriesForCurrentVideo = 0
-          this.sabrErrorRecoveryLastSeconds = null
-          this.sabrErrorRecoveryPlayedSeconds = 0
-        }
-        this.ipBlockDetectedInCurrentChain = false
-        const preserveShortsPanels = videoIdChanged &&
-          this.customShortsPlayerActive &&
-          this.tabRoute.query.short === 'true'
-        this.resetVideoState({
-          preserveTitle,
-          placeholderTitle: videoIdChanged ? this.getPendingVideoTitle() : '',
-          preserveShortsPanels,
-        })
-      } finally {
-        if (this.preparingVideoLoadGeneration === loadGeneration) {
-          this.preparingVideoLoadGeneration = null
-        }
       }
+
+      // react to route changes...
+      const previousVideoId = this.videoId
+      this.videoId = this.tabRoute.params.id
+      const videoIdChanged = this.videoId !== previousVideoId
+      if (videoIdChanged) {
+        this.useCustomShortsPlayerForCurrentVideo = this.$store.getters.getUseCustomShortsPlayer
+        this.ipBlockRecoveryAttemptedForCurrentVideo = false
+        this.streamErrorReloadAttemptedForCurrentVideo = false
+        this.playbackEngineFallbackAttemptedForCurrentVideo = false
+        this.playbackEngineFallbackTarget = null
+        this.ytDlpDefaultClientsFallbackToastShown = false
+        this.sabrErrorRecoveryAttempts = 0
+        this.sabrErrorRecoveriesForCurrentVideo = 0
+        this.sabrErrorRecoveryLastSeconds = null
+        this.sabrErrorRecoveryPlayedSeconds = 0
+      }
+      this.ipBlockDetectedInCurrentChain = false
+      const preserveShortsPanels = videoIdChanged &&
+        this.customShortsPlayerActive &&
+        this.tabRoute.query.short === 'true'
+      this.resetVideoState({
+        preserveTitle,
+        placeholderTitle: videoIdChanged ? this.getPendingVideoTitle() : '',
+        preserveShortsPanels,
+      })
 
       this.firstLoad = true
       this.videoPlayerLoaded = false
@@ -3956,10 +3938,6 @@ export default defineComponent({
     },
 
     handleVideoLoaded: async function (mediaMetadata) {
-      if (this.isLoading || this.preparingVideoLoadGeneration !== null) { return }
-
-      this.suppressTabLoadingIndicator = false
-      this.suppressTabLoadingIndicatorOnNextReload = false
       // Only used one time = remove after use
       this.oneTimeTimestamp = null
       this.sabrReloadCaptionIndex = null
@@ -5598,8 +5576,6 @@ export default defineComponent({
       try {
         await this.performSabrReload(payload, toastMessage)
       } catch (error) {
-        this.suppressTabLoadingIndicator = false
-        this.suppressTabLoadingIndicatorOnNextReload = false
         console.error('SABR reload failed', error)
         return false
       }
@@ -5632,7 +5608,6 @@ export default defineComponent({
       this.sabrReloadVideoQuality = this.normalizeVideoQuality(payload?.videoQuality) ||
         this.normalizeVideoQuality(this.currentVideoQuality) || null
       this.preserveTitleOnNextReload = true
-      this.suppressTabLoadingIndicatorOnNextReload = true
       this.showTabToast({ message: toastMessage, icon: ['fas', 'sync'] })
 
       const timestamp = this.getTimestamp()

--- a/src/renderer/views/Watch/Watch.vue
+++ b/src/renderer/views/Watch/Watch.vue
@@ -2,8 +2,6 @@
   <div
     ref="videoLayout"
     class="videoLayout"
-    :data-tab-loading-generation="videoLoadGeneration"
-    :data-tab-loading-suppressed="suppressTabLoadingIndicator ? '' : undefined"
     :class="{
       ambientModeActive,
       isLoading,


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Make sure to follow the contributing guidelines. -->
<!-- Important note, we may remove your pull request if you do not use this provided PR template correctly. -->
<!-- Agent instructions: Preserve every heading, comment, and marker in this template. Never remove or rewrite the release-note-category:start/end, release-note:start/end, or release-note-image:start/end marker pairs. Never remove or rewrite the Release note images section; leave its contents for a human. -->

## Pull Request Type
<!-- Please select what type of pull request this is: [x] -->
- [x] Bugfix
- [ ] Feature Implementation
- [ ] Documentation
- [ ] Other

## Related issue
<!-- Please link the issue your pull request is referring to. -->
<!-- If this pull request fully resolves the relevant issue, put "closes" before the issue number. -->
<!-- Example: "closes #123456". -->

Follow-up to #880.

## Description
<!-- Please write a clear and concise description of what the pull request does. -->

A loaded Watch tab can start its initial comments request when it moves into the background. The comments spinner was treated as whole-tab loading, so the tab briefly showed a loading dot even though its video and page were already ready.

Give the shared loader a default-on tab-loading signal and disable that signal only for the initial comments loader. Background comments still load. Real Watch page and player loading still appears in the tab.

This also reverts the SABR-specific suppression and generation tracking from #880. That machinery targeted the wrong request and is no longer needed.

## Release note category
<!-- Select exactly one category. Every pull request must select one. -->
<!-- Select "Not noteworthy" when the pull request fixes a bug in or improves functionality that has not yet appeared in a stable release. -->
<!-- release-note-category:start -->
- [x] Not noteworthy
- [ ] Highlights
- [ ] More improvements
- [ ] Fixed bugs
<!-- release-note-category:end -->

## Release note
<!-- Required unless "Not noteworthy" is selected. -->
<!-- Write one concise, user-facing entry without a leading bullet. -->
<!-- release-note:start -->

<!-- release-note:end -->

## Release note images
<!-- Human-only: Agents must preserve this entire section and leave it empty. -->
<!-- Optional. Paste one or more Markdown images or HTML image tags here. -->
<!-- The release notes will use an HTML image tag and limit images taller than 300 pixels. -->
<!-- release-note-image:start -->

<!-- release-note-image:end -->

## Testing
<!-- How can reviewers verify that the PR produces correct results? -->
<!-- Please provide instructions so that others can ensure that your pull request would produce correct results. For examples see, https://github.com/FreeTubeApp/FreeTube/pull/5743, https://github.com/FreeTubeApp/FreeTube/pull/7349, https://github.com/FreeTubeApp/FreeTube/pull/5125, https://github.com/FreeTubeApp/FreeTube/pull/7338 -->
<!-- Agent instructions: Only write human-facing steps that explain how to verify the change while running this branch in dev mode. Include expected results and, when applicable, helpful console snippets for interactive verification. Do not include automated checks, commands, results, pass counts, or CI status. -->

1. Enable automatic loading of paginated items and the setting that keeps loaded tabs.
2. Open a video, wait for playback to start, and leave the comments section unloaded.
3. Switch to another tab. The comments should begin loading in the background, but the loaded Watch tab should not show a loading dot.
4. Navigate the Watch tab to another video or otherwise trigger a real Watch-page load. The tab should show its loading dot until that load finishes.
5. Restart with several loaded Watch tabs and repeat the tab switch after the restored video starts playing. The background comments request should not flash the loading dot.

## Additional context
<!-- Add any other context about the pull request here. -->

The regression holds the background comments request open so the transient state is deterministic. It also checks that a genuine Watch-page loader still marks the tab as loading.
