### PR TITLE
fix(settings): keep modal state stable across toggles

### DIFF
--- a/e2e/tests/offline/settings.spec.mjs
+++ b/e2e/tests/offline/settings.spec.mjs
@@ -946,6 +946,20 @@ test.describe('settings', () => {
     await expect(page.locator('.settingsContent > [data-section="playback"]')).toBeVisible()
   })
 
+  test('reopens Keyboard Shortcuts when its shortcut is pressed during closing', async ({ page }) => {
+    await goTo(page, 'settings')
+    await page.getByRole('button', { name: 'Show Keyboard Shortcuts' }).click()
+    await expect(page.locator('.shortcutColumns')).toBeVisible()
+
+    const settingsWindow = page.locator('.settingsWindow')
+    await page.locator('.settingsCloseButton').click()
+    await expect(settingsWindow).toHaveClass(/settings-window-leave-active/)
+    await page.keyboard.press('Shift+?')
+
+    await expect(settingsWindow).toBeVisible()
+    await expect(page.locator('.shortcutColumns')).toBeVisible()
+  })
+
   test('minimizes utility windows into the header and restores their view', async ({ page }) => {
     for (const view of [null, 'about', 'downloads']) {
       await page.evaluate((windowView) => {

--- a/e2e/tests/offline/settings.spec.mjs
+++ b/e2e/tests/offline/settings.spec.mjs
@@ -69,6 +69,18 @@ async function expectMinimizeToPreserveSettingsScroll(page) {
   )).toBeLessThanOrEqual(1)
 }
 
+async function pressSettingsShortcut(app) {
+  await app.electronApp.evaluate(({ BrowserWindow, Menu }) => {
+    const browserWindow = BrowserWindow.getAllWindows()[0]
+    const fileMenu = Menu.getApplicationMenu()?.items.find(item => item.label === 'File')
+    const preferencesItem = fileMenu?.submenu?.items.find(item => item.label === 'Preferences')
+    if (!browserWindow || !preferencesItem) {
+      throw new Error('Preferences application-menu item was not found')
+    }
+    preferencesItem.click(undefined, browserWindow, undefined)
+  })
+}
+
 async function expectExternalSoftwarePathAlignment(tool, sourceName, pathPlaceholder) {
   const source = tool.locator('.select').filter({ hasText: sourceName })
   const [sourceBox, helpBox, pathBox] = await Promise.all([
@@ -958,6 +970,52 @@ test.describe('settings', () => {
 
     await expect(settingsWindow).toBeVisible()
     await expect(page.locator('.shortcutColumns')).toBeVisible()
+  })
+
+  test('toggles Settings and Keyboard Shortcuts with their app shortcuts', async ({ app, page }) => {
+    const settingsWindow = page.locator('.settingsWindow')
+
+    await pressSettingsShortcut(app)
+    await expect(settingsWindow).toBeVisible()
+    await expect(page.locator('.shortcutColumns')).toHaveCount(0)
+
+    await pressSettingsShortcut(app)
+    await expect(settingsWindow).toHaveClass(/settings-window-leave-active/)
+    await expect(settingsWindow).toBeHidden()
+
+    await page.keyboard.press('Shift+?')
+    await expect(settingsWindow).toBeVisible()
+    await expect(page.locator('.shortcutColumns')).toBeVisible()
+
+    await page.keyboard.press('Shift+?')
+    await expect(settingsWindow).toHaveClass(/settings-window-leave-active/)
+    await expect(page.locator('.shortcutColumns')).toBeVisible()
+    await expect(settingsWindow).toBeHidden()
+  })
+
+  test('preserves category scroll when Settings is toggled but resets it when switching categories', async ({ app, page }) => {
+    await page.evaluate(() => {
+      const store = document.querySelector('#app').__vue_app__.config.globalProperties.$store
+      return store.dispatch('updateUiScale', 95)
+    })
+    await pressSettingsShortcut(app)
+
+    await page.locator('.settingsMenu [data-section="appearance"]').click()
+    const content = page.locator('.settingsContent')
+    await content.evaluate(element => { element.scrollTop = element.scrollHeight })
+    await expect.poll(() => content.evaluate(element => element.scrollTop)).toBeGreaterThan(0)
+    const scrollTop = await content.evaluate(element => element.scrollTop)
+
+    await pressSettingsShortcut(app)
+    await expect(page.locator('.settingsWindow')).toBeHidden()
+    await pressSettingsShortcut(app)
+    await expect(page.locator('.settingsWindow')).toBeVisible()
+    await expect.poll(async () => Math.abs(
+      await content.evaluate(element => element.scrollTop) - scrollTop
+    )).toBeLessThanOrEqual(1)
+
+    await page.locator('.settingsMenu [data-section="playback"]').click()
+    await expect.poll(() => content.evaluate(element => element.scrollTop)).toBe(0)
   })
 
   test('minimizes utility windows into the header and restores their view', async ({ page }) => {

--- a/e2e/tests/offline/settings.spec.mjs
+++ b/e2e/tests/offline/settings.spec.mjs
@@ -1049,6 +1049,24 @@ test.describe('settings', () => {
     await expectMinimizeToPreserveSettingsScroll(page)
   })
 
+  test('keeps the current settings subpage when minimized and restored', async ({ page }) => {
+    await goTo(page, 'settings')
+    await page.locator('.settingsMenu [data-section="playback"]').click()
+    await page.getByRole('button', { name: /Manage Saved Channels/ }).click()
+
+    const settingsWindow = page.getByRole('dialog', { name: 'Settings', exact: true })
+    const breadcrumb = page.locator('.settingsBreadcrumb')
+    await expect(breadcrumb).toContainText('Saved Channel Settings')
+
+    await settingsWindow.getByRole('button', { name: /Minimi[sz]e/ }).click()
+    await expect(settingsWindow).toBeHidden()
+    await page.getByRole('button', { name: 'Restore: Settings' }).click()
+
+    await expect(settingsWindow).toBeVisible()
+    await expect(page.locator('.channelListContainer')).toBeVisible()
+    await expect(breadcrumb).toContainText('Saved Channel Settings')
+  })
+
   test.describe('minimized at 95% UI scale', () => {
     test.use({ seed: { settings: { uiScale: 95 } } })
 

--- a/e2e/tests/offline/settings.spec.mjs
+++ b/e2e/tests/offline/settings.spec.mjs
@@ -904,6 +904,48 @@ test.describe('settings', () => {
     await expect(page.locator('.settingsWindow')).toBeHidden()
   })
 
+  test('keeps the current compact view throughout the close animation at 95% UI scale', async ({ page }) => {
+    await page.evaluate(() => {
+      const store = document.querySelector('#app').__vue_app__.config.globalProperties.$store
+      localStorage.setItem('opentubex-settings-window-bounds', JSON.stringify({
+        x: 40,
+        y: 40,
+        width: 500,
+        height: 450
+      }))
+      return store.dispatch('updateUiScale', 95)
+    })
+
+    const settingsWindow = page.locator('.settingsWindow')
+    const settingsMenu = page.locator('.settingsMenu')
+
+    await goTo(page, 'settings')
+    await page.locator('.settingsMenu [data-section="playback"]').click()
+    await page.getByRole('button', { name: /Manage Saved Channels/ }).click()
+    await expect(page.locator('.channelListContainer')).toBeVisible()
+
+    await page.locator('.settingsCloseButton').click()
+    await expect(settingsWindow).toHaveClass(/settings-window-leave-active/)
+    await expect(settingsMenu).toBeHidden()
+    await expect(page.locator('.channelListContainer')).toBeVisible()
+    await expect(settingsWindow).toBeHidden()
+
+    await goTo(page, 'settings')
+    await page.getByRole('button', { name: 'Show Keyboard Shortcuts' }).click()
+    await expect(settingsMenu).toBeHidden()
+    await expect(page.locator('.shortcutColumns')).toBeVisible()
+
+    await page.locator('.settingsCloseButton').click()
+    await expect(settingsWindow).toHaveClass(/settings-window-leave-active/)
+    await expect(settingsMenu).toBeHidden()
+    await expect(page.locator('.shortcutColumns')).toBeVisible()
+    await expect(settingsWindow).toBeHidden()
+
+    await goTo(page, 'settings')
+    await expect(page.locator('.shortcutColumns')).toHaveCount(0)
+    await expect(page.locator('.settingsContent > [data-section="playback"]')).toBeVisible()
+  })
+
   test('minimizes utility windows into the header and restores their view', async ({ page }) => {
     for (const view of [null, 'about', 'downloads']) {
       await page.evaluate((windowView) => {

--- a/src/main/index.js
+++ b/src/main/index.js
@@ -5144,7 +5144,7 @@ function runApp() {
   })
    */
 
-  function navigateTo(path, browserWindow) {
+  function navigateTo(path, browserWindow, toggle = false) {
     if (browserWindow == null) {
       return
     }
@@ -5153,10 +5153,11 @@ function runApp() {
     if (tabManager?.activeTabId && isOpenTubeXUrl(browserWindow.webContents.getURL())) {
       browserWindow.webContents.send(IpcChannels.CHANGE_VIEW, {
         tabId: tabManager.activeTabId,
-        route: path
+        route: path,
+        toggle
       })
     } else if (isOpenTubeXUrl(browserWindow.webContents.getURL())) {
-      browserWindow.webContents.send(IpcChannels.CHANGE_VIEW, path)
+      browserWindow.webContents.send(IpcChannels.CHANGE_VIEW, toggle ? { route: path, toggle } : path)
     }
   }
 
@@ -5208,7 +5209,7 @@ function runApp() {
             accelerator: getElectronAccelerator(keyboardShortcuts.APP.GENERAL.NAVIGATE_TO_SETTINGS),
             click: (_menuItem, browserWindow, _event) => {
               if (browserWindow && appShortcutBlockedWindows.has(browserWindow)) { return }
-              navigateTo('/settings', browserWindow)
+              navigateTo('/settings', browserWindow, true)
             },
             type: 'normal'
           },

--- a/src/preload/interface.js
+++ b/src/preload/interface.js
@@ -581,7 +581,7 @@ export default {
   },
 
   /**
-   * @param {(route: string, tabId?: string) => void} handler
+   * @param {(route: string, tabId?: string, toggle?: boolean) => void} handler
    * @returns {() => void}
    */
   handleChangeView: (handler) => {
@@ -589,7 +589,7 @@ export default {
       if (typeof payload === 'string') {
         handler(payload)
       } else {
-        handler(payload?.route, payload?.tabId)
+        handler(payload?.route, payload?.tabId, payload?.toggle)
       }
     }
     ipcRenderer.on(IpcChannels.CHANGE_VIEW, listener)

--- a/src/renderer/App.vue
+++ b/src/renderer/App.vue
@@ -2125,7 +2125,7 @@ function handleKeyboardShortcuts(event) {
   if (matchesKeyboardShortcut(event, shortcuts.SHOW_SHORTCUTS) && !isTypingTarget(event.target)) {
     event.preventDefault()
     store.dispatch(isKeyboardShortcutPromptShown.value && settingsWindowOpen.value
-      ? 'hideKeyboardShortcutPrompt'
+      ? 'hideSettingsWindow'
       : 'showKeyboardShortcutPrompt')
   }
 

--- a/src/renderer/App.vue
+++ b/src/renderer/App.vue
@@ -2124,7 +2124,7 @@ function handleKeyboardShortcuts(event) {
 
   if (matchesKeyboardShortcut(event, shortcuts.SHOW_SHORTCUTS) && !isTypingTarget(event.target)) {
     event.preventDefault()
-    store.dispatch(isKeyboardShortcutPromptShown.value
+    store.dispatch(isKeyboardShortcutPromptShown.value && settingsWindowOpen.value
       ? 'hideKeyboardShortcutPrompt'
       : 'showKeyboardShortcutPrompt')
   }

--- a/src/renderer/main.js
+++ b/src/renderer/main.js
@@ -42,12 +42,18 @@ router.isReady().then(() => {
 
 // to avoid accessing electron api from web app build
 if (process.env.IS_ELECTRON) {
-  window.ftElectron.handleChangeView((route, tabId) => {
+  window.ftElectron.handleChangeView((route, tabId, toggle) => {
     if (typeof route === 'string' && (route === '/downloads' || route === '/settings' || route.startsWith('/settings/profile'))) {
       const view = route === '/downloads'
         ? 'downloads'
         : route.startsWith('/settings/profile') ? 'profile' : null
-      store.dispatch('showSettingsWindow', view)
+      const settingsWindowOpen = store.getters.getSettingsWindowOpen &&
+        !['about', 'downloads'].includes(store.getters.getSettingsWindowView)
+      if (toggle && route === '/settings' && settingsWindowOpen) {
+        store.dispatch('hideSettingsWindow')
+      } else {
+        store.dispatch('showSettingsWindow', view)
+      }
       return
     }
     const targetTabId = tabId ?? store.getters.getActiveTabId

--- a/src/renderer/store/modules/utils.js
+++ b/src/renderer/store/modules/utils.js
@@ -434,7 +434,6 @@ const actions = {
   },
 
   hideSettingsWindow ({ commit }) {
-    commit('setIsKeyboardShortcutPromptShown', false)
     commit('setSettingsWindowMinimized', false)
     commit('setSettingsWindowOpen', false)
   },

--- a/src/renderer/views/Settings/Settings.vue
+++ b/src/renderer/views/Settings/Settings.vue
@@ -962,7 +962,15 @@ onMounted(() => {
 onActivated(() => {
   if (closeSubpageOnActivate) {
     closeSubpageOnActivate = false
-    closeSubpage?.()
+    const deferredCloseSubpage = closeSubpage
+    deferredCloseSubpage?.()
+    if (closeSubpage === deferredCloseSubpage) {
+      subpageTitle.value = ''
+      subpageIcon.value = null
+      subpageFlush.value = false
+      closeSubpage = null
+      subpagePersistsOnDeactivate = false
+    }
   }
   handleMounted()
   nextTick(restorePreservedScrollPositions)
@@ -970,9 +978,9 @@ onActivated(() => {
 onDeactivated(() => {
   if (!settingsWindowMorphing.value) {
     preserveScrollPositions()
-  }
-  if (!subpagePersistsOnDeactivate) {
-    closeSubpageOnActivate = true
+    if (!subpagePersistsOnDeactivate) {
+      closeSubpageOnActivate = true
+    }
   }
   stopObserving()
   stopDragging()

--- a/src/renderer/views/Settings/Settings.vue
+++ b/src/renderer/views/Settings/Settings.vue
@@ -463,6 +463,7 @@ const subpageIcon = ref(null)
 const subpageFlush = ref(false)
 let closeSubpage = null
 let subpagePersistsOnDeactivate = false
+let closeSubpageOnActivate = false
 let settingsResizeObserver = null
 let settingsSectionResizeObserver = null
 let profileManagerResizeObserver = null
@@ -959,12 +960,16 @@ onMounted(() => {
   systemColorScheme.addEventListener('change', updateSystemColorScheme)
 })
 onActivated(() => {
+  if (closeSubpageOnActivate) {
+    closeSubpageOnActivate = false
+    closeSubpage?.()
+  }
   handleMounted()
   nextTick(restoreMinimizedScrollPositions)
 })
 onDeactivated(() => {
   if (!subpagePersistsOnDeactivate) {
-    closeSubpage?.()
+    closeSubpageOnActivate = true
   }
   stopObserving()
   stopDragging()
@@ -1410,7 +1415,6 @@ function handleResize(width) {
 }
 
 function closeSettings() {
-  store.dispatch('hideKeyboardShortcutPrompt')
   store.dispatch('hideSettingsWindow')
 }
 

--- a/src/renderer/views/Settings/Settings.vue
+++ b/src/renderer/views/Settings/Settings.vue
@@ -480,7 +480,7 @@ let dragOffsetY = 0
 let maximizedDragSession = null
 let restoreBounds = null
 /** @type {Array<{ element: HTMLElement, scrollTop: number }>} */
-let minimizedScrollPositions = []
+let preservedScrollPositions = []
 
 const windowBounds = ref(getInitialBounds())
 const windowStyle = computed(() => isMaximized.value
@@ -965,9 +965,12 @@ onActivated(() => {
     closeSubpage?.()
   }
   handleMounted()
-  nextTick(restoreMinimizedScrollPositions)
+  nextTick(restorePreservedScrollPositions)
 })
 onDeactivated(() => {
+  if (!settingsWindowMorphing.value) {
+    preserveScrollPositions()
+  }
   if (!subpagePersistsOnDeactivate) {
     closeSubpageOnActivate = true
   }
@@ -1419,20 +1422,24 @@ function closeSettings() {
 }
 
 function minimizeSettings() {
+  preserveScrollPositions()
+  store.dispatch('minimizeSettingsWindow')
+}
+
+function preserveScrollPositions() {
   const settingsWindow = settingsWindowRef.value
-  minimizedScrollPositions = settingsWindow
+  preservedScrollPositions = settingsWindow
     ? [...settingsWindow.querySelectorAll('[data-overlayscrollbars-initialize]')]
         .filter(element => element.scrollTop > 0)
         .map(element => ({ element, scrollTop: element.scrollTop }))
     : []
-  store.dispatch('minimizeSettingsWindow')
 }
 
-function restoreMinimizedScrollPositions() {
-  for (const { element, scrollTop } of minimizedScrollPositions) {
+function restorePreservedScrollPositions() {
+  for (const { element, scrollTop } of preservedScrollPositions) {
     if (element.isConnected) restoreOverlayScrollTop(element, scrollTop)
   }
-  minimizedScrollPositions = []
+  preservedScrollPositions = []
 }
 
 async function toggleMaximized() {


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Make sure to follow the contributing guidelines. -->
<!-- Important note, we may remove your pull request if you do not use this provided PR template correctly. -->
<!-- Agent instructions: Preserve every heading, comment, and marker in this template. Never remove or rewrite the release-note-category:start/end, release-note:start/end, or release-note-image:start/end marker pairs. Never remove or rewrite the Release note images section; leave its contents for a human. -->

## Pull Request Type
<!-- Please select what type of pull request this is: [x] -->
- [x] Bugfix
- [ ] Feature Implementation
- [ ] Documentation
- [ ] Other

## Related issue
<!-- Please link the issue your pull request is referring to. -->
<!-- If this pull request fully resolves the relevant issue, put "closes" before the issue number. -->
<!-- Example: "closes #123456". -->

## Description
<!-- Please write a clear and concise description of what the pull request does. -->
Closing Settings from a nested settings page or Keyboard Shortcuts reset the visible content before the window's leave animation ended. The Settings and Keyboard Shortcuts app shortcuts also opened their views without toggling the utility window closed, and reopening Settings reset the active category's scroll position.

Keep the current nested view mounted for the full close animation. Ctrl+, now toggles Settings, Shift+? toggles the window with Keyboard Shortcuts selected, and reopening Settings restores the active category's scroll position. Switching categories still starts the new category at the top.

## Release note category
<!-- Select exactly one category. Every pull request must select one. -->
<!-- Select "Not noteworthy" when the pull request fixes a bug in or improves functionality that has not yet appeared in a stable release. -->
<!-- release-note-category:start -->
- [ ] Not noteworthy
- [ ] Highlights
- [ ] More improvements
- [x] Fixed bugs
<!-- release-note-category:end -->

## Release note
<!-- Required unless "Not noteworthy" is selected. -->
<!-- Write one concise, user-facing entry without a leading bullet. -->
<!-- release-note:start -->
Fixed Settings shortcuts not toggling the window, nested views flashing during close, and category scroll being lost when reopened.
<!-- release-note:end -->

## Release note images
<!-- Human-only: Agents must preserve this entire section and leave it empty. -->
<!-- Optional. Paste one or more Markdown images or HTML image tags here. -->
<!-- The release notes will use an HTML image tag and limit images taller than 300 pixels. -->
<!-- release-note-image:start -->

<!-- release-note-image:end -->

## Testing
<!-- How can reviewers verify that the PR produces correct results? -->
<!-- Please provide instructions so that others can ensure that your pull request would produce correct results. For examples see, https://github.com/FreeTubeApp/FreeTube/pull/5743, https://github.com/FreeTubeApp/FreeTube/pull/7349, https://github.com/FreeTubeApp/FreeTube/pull/5125, https://github.com/FreeTubeApp/FreeTube/pull/7338 -->
<!-- Agent instructions: Only write human-facing steps that explain how to verify the change while running this branch in dev mode. Include expected results and, when applicable, helpful console snippets for interactive verification. Do not include automated checks, commands, results, pass counts, or CI status. -->
1. Press Ctrl+Comma to open Settings, select Appearance, and scroll down within the category.
2. Press Ctrl+Comma to close and reopen Settings. Appearance should reopen at the same scroll position.
3. Switch to Playback. The new category should start at the top.
4. Press Shift+? to open Keyboard Shortcuts, then press it again. The whole Settings window should close with Keyboard Shortcuts visible throughout the animation.
5. Open Manage Saved Channels and close Settings. The saved-channel page should remain visible for the whole close animation.

## Additional context
<!-- Add any other context about the pull request here. -->
The regression test runs at 95% UI scale so the cleanup timing is also covered with fractional CSS-pixel geometry.
