### PR TITLE
feat(player): show ambient glow in fullscreen bars

### DIFF
--- a/e2e/tests/offline/watch-page.spec.mjs
+++ b/e2e/tests/offline/watch-page.spec.mjs
@@ -38,6 +38,84 @@ for (const { name, options, expectedCount } of [
   })
 }
 
+test('keeps fullscreen ambient mode centered on letterboxed video beside a dock', async ({ app, page }) => {
+  await mockPlayableWatchPage(app, page)
+  const video = await openMockedVideo(page)
+
+  await page.evaluate(async () => {
+    const store = document.querySelector('#app').__vue_app__.config.globalProperties.$store
+    await store.dispatch('updateAmbientMode', true)
+  })
+
+  await video.evaluate(async (element) => {
+    const source = document.createElement('canvas')
+    source.width = 190
+    source.height = 90
+    source.getContext('2d').fillStyle = '#ff0000'
+    source.getContext('2d').fillRect(0, 0, source.width, source.height)
+
+    const stream = source.captureStream(10)
+    element.srcObject = stream
+    await element.play()
+    window.__ambientModeTestMedia = { source, stream }
+  })
+  await expect.poll(() => video.evaluate(element => [element.videoWidth, element.videoHeight]))
+    .toEqual([190, 90])
+
+  await setPlayerFullscreen(page, true)
+  const player = page.locator('.ftVideoPlayer')
+  const ambient = player.locator('.ambientFullscreenCanvas')
+  await expect.poll(() => ambient.evaluate(element => Number(getComputedStyle(element).opacity)))
+    .toBeGreaterThan(0)
+  await expect.poll(() => ambient.evaluate((element) => {
+    const [red, green, blue, alpha] = element.getContext('2d').getImageData(40, 22, 1, 1).data
+    return red > 200 && green < 20 && blue < 20 && alpha === 255
+  })).toBe(true)
+
+  const watchComponent = await page.evaluateHandle(findWatchComponent)
+  await watchComponent.evaluate(component => {
+    component.proxy.$refs.player.setFullscreenMetadata(true)
+  })
+  await expect(page.locator('.fullscreenMetadataOverlay.open')).toBeVisible()
+  await expect.poll(async () => {
+    const [playerBounds, videoBounds] = await Promise.all([
+      player.boundingBox(),
+      video.boundingBox()
+    ])
+    return playerBounds.width - videoBounds.width
+  }).toBeGreaterThan(100)
+  await expect.poll(async () => {
+    const [ambientBounds, videoBounds] = await Promise.all([
+      ambient.boundingBox(),
+      video.boundingBox()
+    ])
+    const ambientCenter = ambientBounds.x + ambientBounds.width / 2
+    const videoCenter = videoBounds.x + videoBounds.width / 2
+    return Math.abs(ambientCenter - videoCenter)
+  }).toBeLessThanOrEqual(1)
+
+  await player.evaluate((element) => {
+    for (const overlay of element.querySelectorAll('.shaka-controls-container, .playerFullscreenTitleOverlay')) {
+      overlay.style.visibility = 'hidden'
+    }
+  })
+  const screenshot = await player.screenshot()
+  const letterboxPixel = await page.evaluate(async (base64) => {
+    const image = new Image()
+    image.src = `data:image/png;base64,${base64}`
+    await image.decode()
+
+    const canvas = new OffscreenCanvas(image.width, image.height)
+    const context = canvas.getContext('2d')
+    context.drawImage(image, 0, 0)
+    return [...context.getImageData(Math.floor(image.width / 2), 20, 1, 1).data]
+  }, screenshot.toString('base64'))
+
+  expect(letterboxPixel[0]).toBeGreaterThan(40)
+  expect(letterboxPixel[0]).toBeGreaterThan(letterboxPixel[1] * 2)
+  expect(letterboxPixel[0]).toBeGreaterThan(letterboxPixel[2] * 2)
+})
+
 test('shows the restricted playback setup hint until an authenticated retry is available', async ({ app, page }) => {
   await mockPlayableWatchPage(app, page)
   await page.route('https://example.invalid/restricted.m3u8', route => route.fulfill({

--- a/e2e/tests/offline/watch-page.spec.mjs
+++ b/e2e/tests/offline/watch-page.spec.mjs
@@ -38,82 +38,96 @@ for (const { name, options, expectedCount } of [
   })
 }
 
-test('keeps fullscreen ambient mode centered on letterboxed video beside a dock', async ({ app, page }) => {
-  await mockPlayableWatchPage(app, page)
-  const video = await openMockedVideo(page)
-
-  await page.evaluate(async () => {
-    const store = document.querySelector('#app').__vue_app__.config.globalProperties.$store
-    await store.dispatch('updateAmbientMode', true)
-  })
-
-  await video.evaluate(async (element) => {
-    const source = document.createElement('canvas')
-    source.width = 190
-    source.height = 90
-    source.getContext('2d').fillStyle = '#ff0000'
-    source.getContext('2d').fillRect(0, 0, source.width, source.height)
-
-    const stream = source.captureStream(10)
-    element.srcObject = stream
-    await element.play()
-    window.__ambientModeTestMedia = { source, stream }
-  })
-  await expect.poll(() => video.evaluate(element => [element.videoWidth, element.videoHeight]))
-    .toEqual([190, 90])
-
-  await setPlayerFullscreen(page, true)
-  const player = page.locator('.ftVideoPlayer')
-  const ambient = player.locator('.ambientFullscreenCanvas')
-  await expect.poll(() => ambient.evaluate(element => Number(getComputedStyle(element).opacity)))
-    .toBeGreaterThan(0)
-  await expect.poll(() => ambient.evaluate((element) => {
-    const [red, green, blue, alpha] = element.getContext('2d').getImageData(40, 22, 1, 1).data
-    return red > 200 && green < 20 && blue < 20 && alpha === 255
-  })).toBe(true)
-
-  const watchComponent = await page.evaluateHandle(findWatchComponent)
-  await watchComponent.evaluate(component => {
-    component.proxy.$refs.player.setFullscreenMetadata(true)
-  })
-  await expect(page.locator('.fullscreenMetadataOverlay.open')).toBeVisible()
-  await expect.poll(async () => {
-    const [playerBounds, videoBounds] = await Promise.all([
-      player.boundingBox(),
-      video.boundingBox()
-    ])
-    return playerBounds.width - videoBounds.width
-  }).toBeGreaterThan(100)
-  await expect.poll(async () => {
-    const [ambientBounds, videoBounds] = await Promise.all([
-      ambient.boundingBox(),
-      video.boundingBox()
-    ])
-    const ambientCenter = ambientBounds.x + ambientBounds.width / 2
-    const videoCenter = videoBounds.x + videoBounds.width / 2
-    return Math.abs(ambientCenter - videoCenter)
-  }).toBeLessThanOrEqual(1)
-
-  await player.evaluate((element) => {
-    for (const overlay of element.querySelectorAll('.shaka-controls-container, .playerFullscreenTitleOverlay')) {
-      overlay.style.visibility = 'hidden'
+test.describe('fullscreen ambient mode', () => {
+  test.use({
+    seed: {
+      settings: {
+        ...WATCH_PAGE_SEED,
+        uiScale: 95
+      }
     }
   })
-  const screenshot = await player.screenshot()
-  const letterboxPixel = await page.evaluate(async (base64) => {
-    const image = new Image()
-    image.src = `data:image/png;base64,${base64}`
-    await image.decode()
 
-    const canvas = new OffscreenCanvas(image.width, image.height)
-    const context = canvas.getContext('2d')
-    context.drawImage(image, 0, 0)
-    return [...context.getImageData(Math.floor(image.width / 2), 20, 1, 1).data]
-  }, screenshot.toString('base64'))
+  test('stays off without bars and centers letterbox glow beside a dock', async ({ app, page }) => {
+    await mockPlayableWatchPage(app, page)
+    const video = await openMockedVideo(page)
 
-  expect(letterboxPixel[0]).toBeGreaterThan(40)
-  expect(letterboxPixel[0]).toBeGreaterThan(letterboxPixel[1] * 2)
-  expect(letterboxPixel[0]).toBeGreaterThan(letterboxPixel[2] * 2)
+    await page.evaluate(async () => {
+      const store = document.querySelector('#app').__vue_app__.config.globalProperties.$store
+      await store.dispatch('updateAmbientMode', true)
+    })
+
+    await setPlayerFullscreen(page, true)
+    const player = page.locator('.ftVideoPlayer')
+    const ambient = player.locator('.ambientFullscreenCanvas')
+    await expect.poll(() => ambient.evaluate(element => Number(getComputedStyle(element).opacity)))
+      .toBe(0)
+
+    await video.evaluate(async (element) => {
+      const source = document.createElement('canvas')
+      source.width = 190
+      source.height = 90
+      source.getContext('2d').fillStyle = '#ff0000'
+      source.getContext('2d').fillRect(0, 0, source.width, source.height)
+
+      const stream = source.captureStream(10)
+      element.srcObject = stream
+      await element.play()
+      window.__ambientModeTestMedia = { source, stream }
+    })
+    await expect.poll(() => video.evaluate(element => [element.videoWidth, element.videoHeight]))
+      .toEqual([190, 90])
+
+    await expect.poll(() => ambient.evaluate(element => Number(getComputedStyle(element).opacity)))
+      .toBeGreaterThan(0)
+    await expect.poll(() => ambient.evaluate((element) => {
+      const [red, green, blue, alpha] = element.getContext('2d').getImageData(40, 22, 1, 1).data
+      return red > 200 && green < 20 && blue < 20 && alpha === 255
+    })).toBe(true)
+
+    const watchComponent = await page.evaluateHandle(findWatchComponent)
+    await watchComponent.evaluate(component => {
+      component.proxy.$refs.player.setFullscreenMetadata(true)
+    })
+    await expect(page.locator('.fullscreenMetadataOverlay.open')).toBeVisible()
+    await expect.poll(async () => {
+      const [playerBounds, videoBounds] = await Promise.all([
+        player.boundingBox(),
+        video.boundingBox()
+      ])
+      return playerBounds.width - videoBounds.width
+    }).toBeGreaterThan(100)
+    await expect.poll(async () => {
+      const [ambientBounds, videoBounds] = await Promise.all([
+        ambient.boundingBox(),
+        video.boundingBox()
+      ])
+      const ambientCenter = ambientBounds.x + ambientBounds.width / 2
+      const videoCenter = videoBounds.x + videoBounds.width / 2
+      return Math.abs(ambientCenter - videoCenter)
+    }).toBeLessThanOrEqual(1)
+
+    await player.evaluate((element) => {
+      for (const overlay of element.querySelectorAll('.shaka-controls-container, .playerFullscreenTitleOverlay')) {
+        overlay.style.visibility = 'hidden'
+      }
+    })
+    const screenshot = await player.screenshot()
+    const letterboxPixel = await page.evaluate(async (base64) => {
+      const image = new Image()
+      image.src = `data:image/png;base64,${base64}`
+      await image.decode()
+
+      const canvas = new OffscreenCanvas(image.width, image.height)
+      const context = canvas.getContext('2d')
+      context.drawImage(image, 0, 0)
+      return [...context.getImageData(Math.floor(image.width / 2), 20, 1, 1).data]
+    }, screenshot.toString('base64'))
+
+    expect(letterboxPixel[0]).toBeGreaterThan(40)
+    expect(letterboxPixel[0]).toBeGreaterThan(letterboxPixel[1] * 2)
+    expect(letterboxPixel[0]).toBeGreaterThan(letterboxPixel[2] * 2)
+  })
 })
 
 test('shows the restricted playback setup hint until an authenticated retry is available', async ({ app, page }) => {

--- a/src/renderer/components/ft-shaka-video-player/ft-shaka-video-player.css
+++ b/src/renderer/components/ft-shaka-video-player/ft-shaka-video-player.css
@@ -2693,8 +2693,8 @@
 /*
   Ambient glow surface used in fullscreen and full window mode, where the
   host-level canvases are not visible. It sits behind the video and shines
-  around it (and through the translucent side panels): always in full window
-  mode, in fullscreen only while a side panel is open.
+  around it and through the translucent side panels. Keeping it active in
+  fullscreen also replaces letterbox and pillarbox bars with the glow.
 */
 .ambientFullscreenCanvas {
   position: absolute;
@@ -2706,7 +2706,7 @@
   opacity: 0;
   filter: blur(clamp(24px, 4vw, 52px)) saturate(1.05);
   pointer-events: none;
-  transition: opacity 250ms ease;
+  transition: opacity 250ms ease, inline-size 250ms ease;
 }
 
 /* Suppressed during presentation mode switches; see the block near the end of the file. */
@@ -2715,8 +2715,7 @@
 }
 
 .ftVideoPlayer.fullWindow .ambientFullscreenCanvas,
-.ftVideoPlayer.shortsPlayer:fullscreen .ambientFullscreenCanvas,
-.ftVideoPlayer:fullscreen:is(.fullscreenDockLayoutOpen, .fullscreenMetadataOpen, .fullscreenTranscriptOpen, .fullscreenSponsorBlockOpen, .fullscreenLiveChatOpen, .fullscreenCommentsOpen, .fullscreenPlaylistOpen, .chaptersOverlayOpen) .ambientFullscreenCanvas {
+.ftVideoPlayer:fullscreen .ambientFullscreenCanvas {
   opacity: 0.42;
 }
 
@@ -3890,8 +3889,8 @@
   aside instead of covering it. Kept at the end of the file so the
   higher-specificity .player rules follow the scroll mini player ones.
 */
-.ftVideoPlayer:fullscreen:is(.fullscreenDockLayoutOpen, .fullscreenMetadataOpen, .fullscreenTranscriptOpen, .fullscreenSponsorBlockOpen, .fullscreenLiveChatOpen, .fullscreenCommentsOpen, .fullscreenPlaylistOpen, .chaptersOverlayOpen) .player,
-.ftVideoPlayer.fullWindow:is(.fullscreenDockLayoutOpen, .fullscreenMetadataOpen, .fullscreenTranscriptOpen, .fullscreenSponsorBlockOpen, .fullscreenLiveChatOpen, .fullscreenCommentsOpen, .fullscreenPlaylistOpen, .chaptersOverlayOpen) .player {
+.ftVideoPlayer:fullscreen:is(.fullscreenDockLayoutOpen, .fullscreenMetadataOpen, .fullscreenTranscriptOpen, .fullscreenSponsorBlockOpen, .fullscreenLiveChatOpen, .fullscreenCommentsOpen, .fullscreenPlaylistOpen, .chaptersOverlayOpen) :is(.player, .ambientFullscreenCanvas),
+.ftVideoPlayer.fullWindow:is(.fullscreenDockLayoutOpen, .fullscreenMetadataOpen, .fullscreenTranscriptOpen, .fullscreenSponsorBlockOpen, .fullscreenLiveChatOpen, .fullscreenCommentsOpen, .fullscreenPlaylistOpen, .chaptersOverlayOpen) :is(.player, .ambientFullscreenCanvas) {
   inline-size: calc(100% - var(--side-panel-width));
 }
 

--- a/src/renderer/components/ft-shaka-video-player/ft-shaka-video-player.css
+++ b/src/renderer/components/ft-shaka-video-player/ft-shaka-video-player.css
@@ -2715,7 +2715,7 @@
 }
 
 .ftVideoPlayer.fullWindow .ambientFullscreenCanvas,
-.ftVideoPlayer:fullscreen .ambientFullscreenCanvas {
+.ftVideoPlayer:fullscreen:is(.fullscreenAmbientBarsVisible, .fullscreenDockLayoutOpen, .fullscreenMetadataOpen, .fullscreenTranscriptOpen, .fullscreenSponsorBlockOpen, .fullscreenLiveChatOpen, .fullscreenCommentsOpen, .fullscreenPlaylistOpen, .chaptersOverlayOpen) .ambientFullscreenCanvas {
   opacity: 0.42;
 }
 

--- a/src/renderer/components/ft-shaka-video-player/ft-shaka-video-player.js
+++ b/src/renderer/components/ft-shaka-video-player/ft-shaka-video-player.js
@@ -5362,13 +5362,30 @@ export default defineComponent({
         !scrollMiniPlayerActive.value
     })
 
+    const fullscreenAmbientBarsVisible = computed(() => {
+      const contentAspectRatio = annotationVideoAspectRatio.value
+      const elementWidth = videoElementWidth.value
+      const elementHeight = videoElementHeight.value
+
+      if (!isFullscreen.value || contentAspectRatio === null ||
+        elementWidth === 0 || elementHeight === 0) {
+        return false
+      }
+
+      const fittedWidth = Math.min(elementWidth, elementHeight * contentAspectRatio)
+      const fittedHeight = Math.min(elementHeight, elementWidth / contentAspectRatio)
+      const minimumBarSize = Math.max(1, window.devicePixelRatio)
+
+      return elementWidth - fittedWidth > minimumBarSize ||
+        elementHeight - fittedHeight > minimumBarSize
+    })
+
     const { ambientCanvas, ambientFullscreenCanvas, ambientLayoutCanvas } = useAmbientMode({
       enabled: ambientModeVisible,
       video,
     })
 
-    /** @type {ResizeObserver} */
-    const videoResizeObserver = new ResizeObserver(() => {
+    function updateVideoElementGeometry() {
       if (video.value) {
         const devicePixelRatio = window.devicePixelRatio > 1 ? window.devicePixelRatio : 1
         const video_ = video.value
@@ -5379,7 +5396,10 @@ export default defineComponent({
         updateAnnotationVideoAspectRatio()
         updateScrollMiniVideoAspectRatio()
       }
-    })
+    }
+
+    /** @type {ResizeObserver} */
+    const videoResizeObserver = new ResizeObserver(updateVideoElementGeometry)
 
     /** @type {PictureInPictureWindow | null} */
     let pipWindow = null
@@ -9771,6 +9791,7 @@ export default defineComponent({
       toggleShortsCaptions,
       handlePlaying,
       handleWaiting,
+      updateVideoElementGeometry,
       openShortsOverflowMenu,
       positionShortsContextMenu,
       handlePlayerMouseMove,
@@ -9782,6 +9803,7 @@ export default defineComponent({
       ambientFullscreenCanvas,
       ambientLayoutCanvas,
       ambientModeVisible,
+      fullscreenAmbientBarsVisible,
       captionCssVariables,
       captionPlayerVariables,
       captionAppearanceSampleBottom,

--- a/src/renderer/components/ft-shaka-video-player/ft-shaka-video-player.js
+++ b/src/renderer/components/ft-shaka-video-player/ft-shaka-video-player.js
@@ -5374,7 +5374,7 @@ export default defineComponent({
 
       const fittedWidth = Math.min(elementWidth, elementHeight * contentAspectRatio)
       const fittedHeight = Math.min(elementHeight, elementWidth / contentAspectRatio)
-      const minimumBarSize = Math.max(1, window.devicePixelRatio)
+      const minimumBarSize = 1
 
       return elementWidth - fittedWidth > minimumBarSize ||
         elementHeight - fittedHeight > minimumBarSize

--- a/src/renderer/components/ft-shaka-video-player/ft-shaka-video-player.vue
+++ b/src/renderer/components/ft-shaka-video-player/ft-shaka-video-player.vue
@@ -57,6 +57,7 @@
         fullscreenPlaylistOpen: showFullscreenPlaylist,
         chaptersOverlayOpen: showChaptersOverlay && chapters.length > 0,
         fullscreenDockLayoutOpen,
+        fullscreenAmbientBarsVisible,
         fullscreenDockResizing,
         fullscreenDockReordering,
         presentationModeChanging,
@@ -116,6 +117,7 @@
         @canplay="handleCanPlay"
         @volumechange="updateVolume"
         @timeupdate="handleTimeupdate"
+        @loadedmetadata="updateVideoElementGeometry"
         @enterpictureinpicture="handleEnterPictureInPicture"
         @leavepictureinpicture="handleLeavePictureInPicture"
       />


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Make sure to follow the contributing guidelines. -->
<!-- Important note, we may remove your pull request if you do not use this provided PR template correctly. -->
<!-- Agent instructions: Preserve every heading, comment, and marker in this template. Never remove or rewrite the release-note-category:start/end, release-note:start/end, or release-note-image:start/end marker pairs. Never remove or rewrite the Release note images section; leave its contents for a human. -->

## Pull Request Type
<!-- Please select what type of pull request this is: [x] -->
- [ ] Bugfix
- [x] Feature Implementation
- [ ] Documentation
- [ ] Other

## Related issue
<!-- Please link the issue your pull request is referring to. -->
<!-- If this pull request fully resolves the relevant issue, put "closes" before the issue number. -->
<!-- Example: "closes #123456". -->

## Description
<!-- Please write a clear and concise description of what the pull request does. -->
Ambient mode currently leaves fullscreen letterbox and pillarbox space black. The in-player ambient canvas also remains centered on the full screen when an information dock narrows the video.

This detects whether the fitted video leaves fullscreen bars and enables the existing ambient canvas only when those bars or an information dock need it. The canvas uses the same width transition as the video when a dock opens or closes. A regression test uses a synthetic 19:9 video at 95% UI scale to verify the visible glow, matching-aspect fast path, and dock alignment.

## Release note category
<!-- Select exactly one category. Every pull request must select one. -->
<!-- Select "Not noteworthy" when the pull request fixes a bug in or improves functionality that has not yet appeared in a stable release. -->
<!-- release-note-category:start -->
- [ ] Not noteworthy
- [ ] Highlights
- [x] More improvements
- [ ] Fixed bugs
<!-- release-note-category:end -->

## Release note
<!-- Required unless "Not noteworthy" is selected. -->
<!-- Write one concise, user-facing entry without a leading bullet. -->
<!-- release-note:start -->
Ambient mode now fills fullscreen letterbox and pillarbox bars and stays centered beside open information docks.
<!-- release-note:end -->

## Release note images
<!-- Human-only: Agents must preserve this entire section and leave it empty. -->
<!-- Optional. Paste one or more Markdown images or HTML image tags here. -->
<!-- The release notes will use an HTML image tag and limit images taller than 300 pixels. -->
<!-- release-note-image:start -->

<!-- release-note-image:end -->

## Testing
<!-- How can reviewers verify that the PR produces correct results? -->
<!-- Please provide instructions so that others can ensure that your pull request produces correct results. For examples see, https://github.com/FreeTubeApp/FreeTube/pull/5743, https://github.com/FreeTubeApp/FreeTube/pull/7349, https://github.com/FreeTubeApp/FreeTube/pull/5125, https://github.com/FreeTubeApp/FreeTube/pull/7338 -->
<!-- Agent instructions: Only write human-facing steps that explain how to verify the change while running this branch in dev mode. Include expected results and, when applicable, helpful console snippets for interactive verification. Do not include automated checks, commands, results, pass counts, or CI status. -->
1. Enable Ambient Mode and open a video whose aspect ratio does not match the monitor.
2. Enter fullscreen and confirm the ambient glow fills the letterbox or pillarbox space without cropping or stretching the video.
3. Open an information dock and confirm the glow moves with the narrowed video and remains centered. Close the dock and confirm both expand together.
4. Open a video that exactly matches the monitor aspect ratio and confirm fullscreen has no visible ambient layer behind it.

## Additional context
<!-- Add any other context about the pull request here. -->
