### PR TITLE
fix(shorts): restore light panel contrast

### DIFF
--- a/e2e/tests/offline/watch-page.spec.mjs
+++ b/e2e/tests/offline/watch-page.spec.mjs
@@ -1828,6 +1828,11 @@ test.describe('watch page', () => {
   })
 
   test('toggles information from the Shorts title and matches the comments header', async ({ app, page }) => {
+    await page.evaluate(async () => {
+      const store = document.querySelector('#app').__vue_app__.config.globalProperties.$store
+      await store.dispatch('updateBaseTheme', 'light')
+    })
+    await expect(page.locator('body')).toHaveClass(/light/)
     await mockPlayableWatchPage(app, page)
     await page.locator(sel.searchInput).fill('https://www.youtube.com/shorts/jNQXAC9IVRw')
     await page.locator(sel.searchInput).press('Enter')
@@ -1858,7 +1863,8 @@ test.describe('watch page', () => {
           },
           heading: {
             margin: headingStyle.margin,
-            fontSize: headingStyle.fontSize
+            fontSize: headingStyle.fontSize,
+            color: headingStyle.color
           },
           close: {
             width: closeStyle.width,
@@ -1887,11 +1893,32 @@ test.describe('watch page', () => {
       await component.proxy.$nextTick()
     })
     await expect(page.locator('.shortsCommentsPanel .fullscreenCommentHeader')).toBeVisible()
+    const commentText = page.locator('.shortsCommentsPanel .commentText').first()
+    await expect(commentText).toBeVisible()
+    const commentContrast = await commentText.evaluate(element => {
+      const parseRgb = value => value.match(/[\d.]+/g).slice(0, 3).map(Number)
+      const luminance = value => {
+        const channels = parseRgb(value).map(channel => {
+          const normalized = channel / 255
+          return normalized <= 0.04045
+            ? normalized / 12.92
+            : ((normalized + 0.055) / 1.055) ** 2.4
+        })
+        return 0.2126 * channels[0] + 0.7152 * channels[1] + 0.0722 * channels[2]
+      }
+      const foreground = luminance(getComputedStyle(element).color)
+      const background = luminance(getComputedStyle(element.closest('.shortsCommentsPanel')).backgroundColor)
+      return (Math.max(foreground, background) + 0.05) /
+        (Math.min(foreground, background) + 0.05)
+    })
+    expect(commentContrast).toBeGreaterThanOrEqual(4.5)
     const commentsStyles = await headerStyles(
       '.shortsCommentsPanel .fullscreenCommentHeader',
       '.shortsCommentsPanel .fullscreenCommentAction:last-of-type'
     )
 
+    expect(informationStyles.header.backgroundColor).toBe('rgba(0, 0, 0, 0)')
+    expect(informationStyles.heading.color).toBe(informationStyles.close.color)
     expect(informationStyles).toEqual(commentsStyles)
     await watchComponent.dispose()
   })

--- a/src/renderer/views/Watch/Watch.scss
+++ b/src/renderer/views/Watch/Watch.scss
@@ -851,6 +851,29 @@
 
     .shortsCommentsPanel :deep(.fullscreenCommentCard) {
       block-size: 100%;
+      color: var(--primary-text-color);
+    }
+
+    .shortsCommentsPanel :deep(.commentsContentWrapper) {
+      // This panel sits on a themed card instead of over the video.
+      --scrollbar-color: inherit;
+      --scrollbar-color-hover: inherit;
+    }
+
+    .shortsCommentsPanel :deep(.fullscreenCommentHeader) {
+      color: var(--primary-text-color);
+      background-color: transparent;
+      border-block-end-color: var(--side-nav-hover-color);
+    }
+
+    .shortsCommentsPanel :deep(.fullscreenCommentAction) {
+      color: inherit;
+    }
+
+    .shortsCommentsPanel :deep(.fullscreenCommentAction:hover),
+    .shortsCommentsPanel :deep(.fullscreenCommentAction:focus-visible),
+    .shortsCommentsPanel :deep(.fullscreenCommentAction.active) {
+      background-color: var(--side-nav-hover-color);
     }
 
     .shortsAuxPanelOpen {
@@ -875,8 +898,9 @@
       justify-content: space-between;
       padding-block: 0;
       padding-inline: 14px 8px;
-      border-block-end: 1px solid rgb(255 255 255 / 10%);
-      background-color: rgb(20 20 20 / 52%);
+      border-block-end: 1px solid var(--side-nav-hover-color);
+      color: var(--primary-text-color);
+      background-color: transparent;
     }
 
     .shortsAuxPanelHeader h2 {
@@ -1022,7 +1046,7 @@
       padding: 0;
       border: 0;
       border-radius: 50%;
-      color: #fff;
+      color: inherit;
       background-color: transparent;
       cursor: pointer;
       font-size: 18px;
@@ -1030,7 +1054,7 @@
 
     .shortsAuxPanelClose:hover,
     .shortsAuxPanelClose:focus-visible {
-      background-color: rgb(255 255 255 / 20%);
+      background-color: var(--side-nav-hover-color);
     }
 
     @media (height <= 850px) {


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Make sure to follow the contributing guidelines. -->
<!-- Important note, we may remove your pull request if you do not use this provided PR template correctly. -->
<!-- Agent instructions: Preserve every heading, comment, and marker in this template. Never remove or rewrite the release-note-category:start/end, release-note:start/end, or release-note-image:start/end marker pairs. Never remove or rewrite the Release note images section; leave its contents for a human. -->

## Pull Request Type
<!-- Please select what type of pull request this is: [x] -->
- [x] Bugfix
- [ ] Feature Implementation
- [ ] Documentation
- [ ] Other

## Related issue
<!-- Please link the issue your pull request is referring to. -->
<!-- If this pull request fully resolves the relevant issue, put "closes" before the issue number. -->
<!-- Example: "closes #123456". -->

No linked issue.

## Description
<!-- Please write a clear and concise description of what the pull request does. -->

Docked Shorts panels reused colors meant for fullscreen overlays. In light mode, this made comment text white on a white card and left the comments and video information headers with mismatched overlay colors.

Use the active theme's text, divider, hover, and scrollbar colors in the non-fullscreen Shorts panels. Fullscreen overlays keep their existing colors. The watch-page regression now checks comment contrast and consistent header colors in light mode.

## Release note category
<!-- Select exactly one category. Every pull request must select one. -->
<!-- Select "Not noteworthy" when the pull request fixes a bug in or improves functionality that has not yet appeared in a stable release. -->
<!-- release-note-category:start -->
- [x] Not noteworthy
- [ ] Highlights
- [ ] More improvements
- [ ] Fixed bugs
<!-- release-note-category:end -->

## Release note
<!-- Required unless "Not noteworthy" is selected. -->
<!-- Write one concise, user-facing entry without a leading bullet. -->
<!-- release-note:start -->

Fixed unreadable comments and mismatched panel headers when watching Shorts in light mode.

<!-- release-note:end -->

## Release note images
<!-- Human-only: Agents must preserve this entire section and leave it empty. -->
<!-- Optional. Paste one or more Markdown images or HTML image tags here. -->
<!-- The release notes will use an HTML image tag and limit images taller than 300 pixels. -->
<!-- release-note-image:start -->

<!-- release-note-image:end -->

## Testing
<!-- How can reviewers verify that the PR produces correct results? -->
<!-- Please provide instructions so that others can ensure that your pull request would produce correct results. For examples see, https://github.com/FreeTubeApp/FreeTube/pull/5743, https://github.com/FreeTubeApp/FreeTube/pull/7349, https://github.com/FreeTubeApp/FreeTube/pull/5125, https://github.com/FreeTubeApp/FreeTube/pull/7338 -->
<!-- Agent instructions: Only write human-facing steps that explain how to verify the change while running this branch in dev mode. Include expected results and, when applicable, helpful console snippets for interactive verification. Do not include automated checks, commands, results, pass counts, or CI status. -->

1. Start the app in dev mode, select the Light theme, and open a Short without entering fullscreen.
2. Open Comments. Comment authors and text should be readable, and the header title and actions should use the same dark foreground color.
3. Open Video information. Its header should match the card and use consistent theme colors for the title, close button, divider, and hover state.
4. Enter fullscreen and reopen the panels. The fullscreen overlay colors should remain unchanged.

## Additional context
<!-- Add any other context about the pull request here. -->

The color overrides are scoped to the docked Shorts panels.
