### PR TITLE
fix(player): show full labels for clipped menu items

### DIFF
--- a/e2e/tests/offline/player.spec.mjs
+++ b/e2e/tests/offline/player.spec.mjs
@@ -329,6 +329,50 @@ test('the overflow menu can turn the zoom off again', async ({ app, page, attach
   await watchComponent.dispose()
 })
 
+/**
+ * @param {{ app: import('../../helpers/app.mjs').ElectronAppFixture, page: import('@playwright/test').Page }} fixtures
+ */
+async function expectEllipsizedPlayerMenuLabelTitles({ app, page }) {
+  await openDemoVideo({ app, page })
+
+  const player = page.locator(`${activeTab} .ftVideoPlayer`)
+  await player.hover()
+  await player.getByRole('button', { name: 'More settings' }).click()
+
+  const overflowMenu = player.locator('.shaka-overflow-menu')
+  const zoomButton = overflowMenu.getByRole('button', { name: 'Zoom' })
+  const expectFullTextOnHover = async (label, fullText) => {
+    await label.evaluate((element, text) => { element.textContent = text }, fullText)
+    expect(await label.evaluate((element) => {
+      return element.scrollHeight > element.clientHeight || element.scrollWidth > element.clientWidth
+    })).toBe(true)
+    await expect(label).toHaveAttribute('title', fullText, { timeout: 1000 })
+    await label.hover()
+  }
+
+  await expectFullTextOnHover(
+    zoomButton.locator('.shaka-overflow-button-label > span').first(),
+    'Zoom to a very long player menu option that cannot fit in its tile'
+  )
+
+  await zoomButton.click()
+  await expectFullTextOnHover(
+    player.locator('.video-zoom-menu > button:not(.shaka-back-to-overflow-button) > span').first(),
+    'An unusually long submenu option like the descriptive audio tracks'
+  )
+}
+
+test('ellipsized player menu labels expose their full text on hover', expectEllipsizedPlayerMenuLabelTitles)
+
+test.describe('at 125% display scale', () => {
+  test.use({ launchArgs: ['--force-device-scale-factor=1.25'] })
+
+  test(
+    'ellipsized player menu labels expose their full text on hover',
+    expectEllipsizedPlayerMenuLabelTitles
+  )
+})
+
 test('auto-translates captions into an arbitrary language', async ({ app, page, attachScreenshot }) => {
   await mockPlayableWatchPage(app, page, { captionTranslations: true })
   await openMockedVideo(page)

--- a/e2e/tests/offline/player.spec.mjs
+++ b/e2e/tests/offline/player.spec.mjs
@@ -342,12 +342,18 @@ async function expectEllipsizedPlayerMenuLabelTitles({ app, page }) {
   const overflowMenu = player.locator('.shaka-overflow-menu')
   const zoomButton = overflowMenu.getByRole('button', { name: 'Zoom' })
   const expectFullTextOnHover = async (label, fullText) => {
-    await label.evaluate((element, text) => { element.textContent = text }, fullText)
-    expect(await label.evaluate((element) => {
+    const isOverflowing = () => label.evaluate((element) => {
       return element.scrollHeight > element.clientHeight || element.scrollWidth > element.clientWidth
-    })).toBe(true)
+    })
+
+    await label.evaluate((element, text) => { element.textContent = text }, fullText)
+    expect(await isOverflowing()).toBe(true)
     await expect(label).toHaveAttribute('title', fullText, { timeout: 1000 })
     await label.hover()
+
+    await label.evaluate((element) => { element.textContent = 'Short label' })
+    expect(await isOverflowing()).toBe(false)
+    await expect(label).not.toHaveAttribute('title', { timeout: 1000 })
   }
 
   await expectFullTextOnHover(

--- a/src/renderer/components/ft-shaka-video-player/ft-shaka-video-player.js
+++ b/src/renderer/components/ft-shaka-video-player/ft-shaka-video-player.js
@@ -4355,6 +4355,12 @@ export default defineComponent({
     function setupOverflowMenuLayout(controlsContainer) {
       overflowMenuResizeObserver?.disconnect()
       overflowMenuResizeObserver = null
+      overflowMenuMutationObserver?.disconnect()
+      overflowMenuMutationObserver = null
+      if (overflowMenuTitleFrame !== null) {
+        cancelAnimationFrame(overflowMenuTitleFrame)
+        overflowMenuTitleFrame = null
+      }
       overflowMenuIdleHeight = 0
 
       if (overflowMenuElement) {
@@ -4368,6 +4374,11 @@ export default defineComponent({
       }
 
       menu.classList.toggle('ft-menu-grid', usePlayerMenuGrid.value)
+
+      for (const label of menu.querySelectorAll('[data-ft-overflow-title]')) {
+        label.removeAttribute('title')
+        delete label.dataset.ftOverflowTitle
+      }
 
       // The caption appearance submenu has controls rather than options, so it
       // keeps its own layout.
@@ -4386,10 +4397,23 @@ export default defineComponent({
         return
       }
 
+      overflowMenuMutationObserver = new MutationObserver(() => {
+        scheduleOverflowMenuLabelTitles(menu)
+      })
+      overflowMenuMutationObserver.observe(menu, {
+        attributeFilter: ['class'],
+        attributes: true,
+        characterData: true,
+        childList: true,
+        subtree: true,
+      })
+
       // Opening a submenu replaces the tiles, which would otherwise resize the
       // popup around them. Remember how tall the menu is while its own tiles are
       // shown, so that a shorter submenu only leaves empty space below itself.
       overflowMenuResizeObserver = new ResizeObserver(() => {
+        scheduleOverflowMenuLabelTitles(menu)
+
         if (menu.querySelector(':scope > .shaka-sub-menu:not(.shaka-hidden)')) {
           return
         }
@@ -4403,6 +4427,45 @@ export default defineComponent({
       controls.removeEventListener('submenuclose', releaseOverflowMenuHeight)
       controls.addEventListener('submenuopen', keepOverflowMenuHeight)
       controls.addEventListener('submenuclose', releaseOverflowMenuHeight)
+      scheduleOverflowMenuLabelTitles(menu)
+    }
+
+    /**
+     * Schedule title measurements after Shaka has finished updating the menu.
+     *
+     * @param {HTMLElement} menu
+     */
+    function scheduleOverflowMenuLabelTitles(menu) {
+      if (overflowMenuTitleFrame !== null) {
+        return
+      }
+
+      overflowMenuTitleFrame = requestAnimationFrame(() => {
+        overflowMenuTitleFrame = null
+        updateOverflowMenuLabelTitles(menu)
+      })
+    }
+
+    /**
+     * Add a native tooltip only when a visible player-menu label is clipped.
+     *
+     * @param {HTMLElement} menu
+     */
+    function updateOverflowMenuLabelTitles(menu) {
+      for (const label of menu.querySelectorAll('.ft-menu-grid button span')) {
+        const isVisible = label.clientWidth > 0 && label.clientHeight > 0
+        const isClipped = isVisible && (
+          label.scrollWidth > label.clientWidth || label.scrollHeight > label.clientHeight
+        )
+
+        if (isClipped && (!label.hasAttribute('title') || 'ftOverflowTitle' in label.dataset)) {
+          label.title = label.textContent.trim()
+          label.dataset.ftOverflowTitle = ''
+        } else if (!isClipped && 'ftOverflowTitle' in label.dataset) {
+          label.removeAttribute('title')
+          delete label.dataset.ftOverflowTitle
+        }
+      }
     }
 
     function keepOverflowMenuHeight() {
@@ -4410,12 +4473,16 @@ export default defineComponent({
       if (menu instanceof HTMLElement && overflowMenuIdleHeight > 0) {
         menu.style.minBlockSize = `${overflowMenuIdleHeight}px`
       }
+      if (menu instanceof HTMLElement) {
+        scheduleOverflowMenuLabelTitles(menu)
+      }
     }
 
     function releaseOverflowMenuHeight() {
       const menu = container.value?.querySelector('.shaka-overflow-menu')
       if (menu instanceof HTMLElement) {
         menu.style.minBlockSize = ''
+        scheduleOverflowMenuLabelTitles(menu)
       }
     }
 
@@ -4578,6 +4645,12 @@ export default defineComponent({
 
     /** @type {ResizeObserver|null} */
     let overflowMenuResizeObserver = null
+
+    /** @type {MutationObserver|null} */
+    let overflowMenuMutationObserver = null
+
+    /** @type {number|null} */
+    let overflowMenuTitleFrame = null
 
     /** How tall the overflow menu is while its own tiles are shown. */
     let overflowMenuIdleHeight = 0
@@ -9546,6 +9619,16 @@ export default defineComponent({
       if (overflowMenuResizeObserver) {
         overflowMenuResizeObserver.disconnect()
         overflowMenuResizeObserver = null
+      }
+
+      if (overflowMenuMutationObserver) {
+        overflowMenuMutationObserver.disconnect()
+        overflowMenuMutationObserver = null
+      }
+
+      if (overflowMenuTitleFrame !== null) {
+        cancelAnimationFrame(overflowMenuTitleFrame)
+        overflowMenuTitleFrame = null
       }
 
       if (overflowMenuElement) {


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Make sure to follow the contributing guidelines. -->
<!-- Important note, we may remove your pull request if you do not use this provided PR template correctly. -->
<!-- Agent instructions: Preserve every heading, comment, and marker in this template. Never remove or rewrite the release-note-category:start/end, release-note:start/end, or release-note-image:start/end marker pairs. Never remove or rewrite the Release note images section; leave its contents for a human. -->

## Pull Request Type
<!-- Please select what type of pull request this is: [x] -->
- [x] Bugfix
- [ ] Feature Implementation
- [ ] Documentation
- [ ] Other

## Related issue
<!-- Please link the issue your pull request is referring to. -->
<!-- If this pull request fully resolves the relevant issue, put "closes" before the issue number. -->
<!-- Example: "closes #123456". -->

No linked issue.

## Description
<!-- Please write a clear and concise description of what the pull request does. -->

Long labels in the player's grid menus can be cut off without any way to read the full value. This measures menu labels after Shaka updates or resizes them and adds a native title only when the rendered text is clipped. It covers top-level entries and submenus such as Audio Tracks, including fractional UI scales.

## Release note category
<!-- Select exactly one category. Every pull request must select one. -->
<!-- Select "Not noteworthy" when the pull request fixes a bug in or improves functionality that has not yet appeared in a stable release. -->
<!-- release-note-category:start -->
- [ ] Not noteworthy
- [ ] Highlights
- [ ] More improvements
- [x] Fixed bugs
<!-- release-note-category:end -->

## Release note
<!-- Required unless "Not noteworthy" is selected. -->
<!-- Write one concise, user-facing entry without a leading bullet. -->
<!-- release-note:start -->
Show full player menu labels in a tooltip when their text is cut off.
<!-- release-note:end -->

## Release note images
<!-- Human-only: Agents must preserve this entire section and leave it empty. -->
<!-- Optional. Paste one or more Markdown images or HTML image tags here. -->
<!-- The release notes will use an HTML image tag and limit images taller than 300 pixels. -->
<!-- release-note-image:start -->

<!-- release-note-image:end -->

## Testing
<!-- How can reviewers verify that the PR produces correct results? -->
<!-- Please provide instructions so that others can ensure that your pull request would produce correct results. For examples see, https://github.com/FreeTubeApp/FreeTube/pull/5743, https://github.com/FreeTubeApp/FreeTube/pull/7349, https://github.com/FreeTubeApp/FreeTube/pull/5125, https://github.com/FreeTubeApp/FreeTube/pull/7338 -->
<!-- Agent instructions: Only write human-facing steps that explain how to verify the change while running this branch in dev mode. Include expected results and, when applicable, helpful console snippets for interactive verification. Do not include automated checks, commands, results, pass counts, or CI status. -->

1. Play a video with multiple audio tracks and open Audio Tracks from the player menu.
2. Hover an audio-track label that ends in an ellipsis. A native tooltip should show the complete label.
3. Resize the player or change the UI scale. Tooltips should appear for clipped labels and remain absent from labels that fit.

## Additional context
<!-- Add any other context about the pull request here. -->

The label measurements run after menu mutations and resize updates so titles exist before the pointer reaches a newly rendered submenu.
