### PR TITLE
fix(sync): preserve tabs during session sync

### DIFF
--- a/e2e/tests/offline/tabs.spec.mjs
+++ b/e2e/tests/offline/tabs.spec.mjs
@@ -73,7 +73,15 @@ test.describe('tab bar', () => {
       const remoteSession = {
         ...session,
         tabs: [
-          ...session.tabs.filter(tab => tab.id !== remoteClosedTabId),
+          ...session.tabs
+            .filter(tab => tab.id !== remoteClosedTabId)
+            .map(tab => tab.id === retainedTabIds[0]
+              ? {
+                  ...tab,
+                  url: 'app://bundle/#/playlists',
+                  title: 'Playlists'
+                }
+              : tab),
           {
             id: 'remote-new-tab',
             url: 'app://bundle/#/settings',
@@ -104,6 +112,10 @@ test.describe('tab bar', () => {
     await expect(page.locator(`.tab[data-tab-id="${remoteClosedTab.id}"]`)).toHaveCount(0)
     await expect(page.locator('.tab[data-tab-id="remote-new-tab"]')).toHaveCount(1)
     await expect(page.locator(sel.activeTab)).toHaveAttribute('data-tab-id', secondRetainedTab.id)
+    await expect.poll(() => page.evaluate(tabId => {
+      const store = document.querySelector('#app').__vue_app__.config.globalProperties.$store
+      return store.getters.getTabById(tabId).route.fullPath
+    }, retainedTabId)).toBe('/playlists')
   })
 
   test('new tab button opens a tab and activates it', async ({ page }) => {

--- a/e2e/tests/offline/tabs.spec.mjs
+++ b/e2e/tests/offline/tabs.spec.mjs
@@ -46,6 +46,66 @@ async function openThreeTabsAndActivate(page, activeIndex) {
 }
 
 test.describe('tab bar', () => {
+  test('reconciles synced sessions without remounting retained tabs', async ({ page }) => {
+    const initialState = await page.evaluate(() => window.ftElectron.tabs.getState())
+    const retainedTabId = initialState.activeTabId
+    const remoteClosedTab = await page.evaluate(() => window.ftElectron.tabs.create({
+      route: '/about',
+      title: 'Closed remotely',
+      makeActive: false,
+      lazyLoad: true
+    }))
+    const secondRetainedTab = await page.evaluate(() => window.ftElectron.tabs.create({
+      route: '/history',
+      title: 'Retained history',
+      makeActive: true
+    }))
+
+    await expect(page.locator(`.tabContent[data-tab-id="${secondRetainedTab.id}"]`)).toBeVisible()
+    await page.locator(`.tab[data-tab-id="${retainedTabId}"]`).click()
+    await expect(page.locator(`.tabContent[data-tab-id="${retainedTabId}"]`)).toBeVisible()
+
+    const result = await page.evaluate(async ({ retainedTabIds, remoteClosedTabId }) => {
+      const retainedNodes = retainedTabIds.map(tabId => (
+        document.querySelector(`.tabContent[data-tab-id="${tabId}"]`)
+      ))
+      const [session] = await window.ftElectron.tabs.getSyncSessions()
+      const remoteSession = {
+        ...session,
+        tabs: [
+          ...session.tabs.filter(tab => tab.id !== remoteClosedTabId),
+          {
+            id: 'remote-new-tab',
+            url: 'app://bundle/#/settings',
+            title: 'Opened remotely',
+            isPinned: false,
+            color: null,
+            isUnloaded: true
+          }
+        ],
+        activeTabId: retainedTabIds[1],
+        updatedAt: session.updatedAt + 1
+      }
+
+      const applied = await window.ftElectron.tabs.applySyncSessions([remoteSession])
+      return {
+        applied,
+        retainedNodesConnected: retainedNodes.map(node => node?.isConnected === true)
+      }
+    }, {
+      retainedTabIds: [retainedTabId, secondRetainedTab.id],
+      remoteClosedTabId: remoteClosedTab.id
+    })
+
+    expect(result).toEqual({
+      applied: true,
+      retainedNodesConnected: [true, true]
+    })
+    await expect(page.locator(`.tab[data-tab-id="${remoteClosedTab.id}"]`)).toHaveCount(0)
+    await expect(page.locator('.tab[data-tab-id="remote-new-tab"]')).toHaveCount(1)
+    await expect(page.locator(sel.activeTab)).toHaveAttribute('data-tab-id', secondRetainedTab.id)
+  })
+
   test('new tab button opens a tab and activates it', async ({ page }) => {
     await page.locator(sel.newTabButton).click()
     await expect(page.locator(sel.tabs)).toHaveCount(2)

--- a/e2e/tests/offline/tabs.spec.mjs
+++ b/e2e/tests/offline/tabs.spec.mjs
@@ -64,11 +64,22 @@ test.describe('tab bar', () => {
     await expect(page.locator(`.tabContent[data-tab-id="${secondRetainedTab.id}"]`)).toBeVisible()
     await page.locator(`.tab[data-tab-id="${retainedTabId}"]`).click()
     await expect(page.locator(`.tabContent[data-tab-id="${retainedTabId}"]`)).toBeVisible()
+    await page.locator(`.tab[data-tab-id="${remoteClosedTab.id}"]`).click()
+    await expect(page.locator(`.tabContent[data-tab-id="${remoteClosedTab.id}"]`)).toBeVisible()
 
     const result = await page.evaluate(async ({ retainedTabIds, remoteClosedTabId }) => {
-      const retainedNodes = retainedTabIds.map(tabId => (
+      window.__syncRetainedTabNodes = retainedTabIds.map(tabId => (
         document.querySelector(`.tabContent[data-tab-id="${tabId}"]`)
       ))
+      const store = document.querySelector('#app').__vue_app__.config.globalProperties.$store
+      store.commit('prepareTabReloadRoute', {
+        tabId: retainedTabIds[0],
+        route: '/about'
+      })
+      store.commit('setTabContentTitle', {
+        tabId: retainedTabIds[0],
+        title: 'Stale local title'
+      })
       const [session] = await window.ftElectron.tabs.getSyncSessions()
       const remoteSession = {
         ...session,
@@ -96,9 +107,10 @@ test.describe('tab bar', () => {
       }
 
       const applied = await window.ftElectron.tabs.applySyncSessions([remoteSession])
+      const stateAfterApply = await window.ftElectron.tabs.getState()
       return {
         applied,
-        retainedNodesConnected: retainedNodes.map(node => node?.isConnected === true)
+        removedPresentedTabCleared: stateAfterApply.presentedTabId !== remoteClosedTabId
       }
     }, {
       retainedTabIds: [retainedTabId, secondRetainedTab.id],
@@ -107,7 +119,7 @@ test.describe('tab bar', () => {
 
     expect(result).toEqual({
       applied: true,
-      retainedNodesConnected: [true, true]
+      removedPresentedTabCleared: true
     })
     await expect(page.locator(`.tab[data-tab-id="${remoteClosedTab.id}"]`)).toHaveCount(0)
     await expect(page.locator('.tab[data-tab-id="remote-new-tab"]')).toHaveCount(1)
@@ -116,6 +128,19 @@ test.describe('tab bar', () => {
       const store = document.querySelector('#app').__vue_app__.config.globalProperties.$store
       return store.getters.getTabById(tabId).route.fullPath
     }, retainedTabId)).toBe('/playlists')
+    expect(await page.evaluate(tabId => {
+      const store = document.querySelector('#app').__vue_app__.config.globalProperties.$store
+      const tab = store.getters.getTabById(tabId)
+      return {
+        retainedNodesConnected: window.__syncRetainedTabNodes.map(node => node?.isConnected === true),
+        pendingReloadRoute: tab.pendingReloadRoute,
+        contentTitle: tab.contentTitle
+      }
+    }, retainedTabId)).toEqual({
+      retainedNodesConnected: [true, true],
+      pendingReloadRoute: null,
+      contentTitle: 'Playlists'
+    })
   })
 
   test('new tab button opens a tab and activates it', async ({ page }) => {

--- a/src/main/tabs/TabManager.js
+++ b/src/main/tabs/TabManager.js
@@ -2859,6 +2859,8 @@ export class TabManager {
           tab.color = TabManager.normalizeTabColor(tabData.color)
         } else {
           const hasSavedTitle = typeof tabData.title === 'string' && tabData.title.trim().length > 0
+          // createTab inserts into previousTabs through this.tabs. The synced
+          // map and restored placement openers below replace that temporary order.
           tab = this.createTab({
             id: syncedId,
             url: TabManager.stripOneTimeTimestampFromUrl(tabData.url),
@@ -2885,6 +2887,9 @@ export class TabManager {
       for (const tab of removedTabs) {
         this._clearTabPreviewRefresh(tab)
         this._resolveTabMountWaiters(tab.id, Number.MAX_SAFE_INTEGER, false)
+        if (this.presentedTabId === tab.id) {
+          this.presentedTabId = null
+        }
         this._deleteTabPreviewFile(tab.previewFileName).catch(error => {
           console.error('Failed to delete remotely closed tab preview:', error)
         })

--- a/src/main/tabs/TabManager.js
+++ b/src/main/tabs/TabManager.js
@@ -90,6 +90,7 @@ let tabPreviewCacheMaintenance = Promise.resolve()
  * @property {boolean} pendingActivation
  * @property {number} mountRevision
  * @property {number} refreshKey
+ * @property {number} syncedNavigationRevision
  * @property {string | null} placementOpenerTabId
  * @property {NavigationHistoryEntry[] | null} navigationHistory
  * @property {number} navigationHistoryIndex
@@ -979,6 +980,7 @@ export class TabManager {
       pendingActivation: false,
       mountRevision: shouldMount ? 1 : 0,
       refreshKey: 0,
+      syncedNavigationRevision: 0,
       placementOpenerTabId: this.tabs.has(openerTabId) ? openerTabId : null,
       navigationHistory: restoredNavigationHistory?.history ?? null,
       navigationHistoryIndex: restoredNavigationHistory?.historyIndex ?? 0,
@@ -2379,7 +2381,8 @@ export class TabManager {
       previewDataUrl: tab.previewDataUrl,
       previewCapturedAt: tab.previewCapturedAt,
       previewFileName: tab.previewFileName,
-      skipSilence: tab.skipSilence === true
+      skipSilence: tab.skipSilence === true,
+      syncedNavigationRevision: tab.syncedNavigationRevision
     }
   }
 
@@ -2461,6 +2464,9 @@ export class TabManager {
       pendingActivation: false,
       mountRevision: 1,
       refreshKey: 0,
+      syncedNavigationRevision: Number.isInteger(snapshot.syncedNavigationRevision)
+        ? snapshot.syncedNavigationRevision
+        : 0,
       placementOpenerTabId: null,
       isTransferStaged: true
     }
@@ -2610,7 +2616,8 @@ export class TabManager {
         preloadInBackground: tab.preloadInBackground,
         pendingActivation: tab.pendingActivation,
         mountRevision: tab.mountRevision,
-        refreshKey: tab.refreshKey
+        refreshKey: tab.refreshKey,
+        syncedNavigationRevision: tab.syncedNavigationRevision
       }
     })
 
@@ -2833,6 +2840,11 @@ export class TabManager {
               : null
             tab.navigationHistory = navigationHistory?.history ?? null
             tab.navigationHistoryIndex = navigationHistory?.historyIndex ?? 0
+            tab.persistNavigationHistory = restoreNavigationHistory && navigationHistory != null
+            // The renderer normally ignores main-process route echoes because
+            // it owns live navigation. Mark this remote route as authoritative.
+            tab.syncedNavigationRevision += 1
+            this._historyAnnouncedTabIds.delete(tab.id)
             this._deleteTabPreviewFile(previewFileName).catch(error => {
               console.error('Failed to delete stale synced tab preview:', error)
             })

--- a/src/main/tabs/TabManager.js
+++ b/src/main/tabs/TabManager.js
@@ -2791,33 +2791,128 @@ export class TabManager {
   }
 
   /**
-   * Replace this window's live tabs with a synced session.
+   * Reconcile this window's live tabs with a synced session.
+   * Existing tab objects stay alive so their mounted renderer state is not
+   * discarded when another device only adds, removes, or selects a tab.
    * @param {object} sessionData
    * @returns {Promise<boolean>}
    */
   async replaceFromSyncData(sessionData) {
+    if (!sessionData || !Array.isArray(sessionData.tabs) || sessionData.tabs.length === 0) {
+      return false
+    }
+
     this._sessionPersistenceDisabled = true
     try {
-      for (const tab of this.tabs.values()) {
+      const restoreNavigationHistory = await TabManager.getStoredRememberTabNavigationHistory()
+      const previousTabs = this.tabs
+      const syncedTabs = new Map()
+      const removedTabs = new Set(previousTabs.values())
+
+      for (const tabData of sessionData.tabs) {
+        const syncedId = typeof tabData.id === 'string' && tabData.id.length > 0
+          ? tabData.id
+          : undefined
+        let tab = syncedId == null ? null : previousTabs.get(syncedId)
+
+        if (tab) {
+          removedTabs.delete(tab)
+          const nextUrl = TabManager.stripOneTimeTimestampFromUrl(tabData.url)
+          if (tab.url !== nextUrl) {
+            const previewFileName = tab.previewFileName
+            const avatarFileName = tab.avatarFileName
+            tab.url = nextUrl
+            tab.route = TabManager.getRouteFromUrl(nextUrl)
+            tab.previewDataUrl = null
+            tab.previewCapturedAt = 0
+            tab.previewFileName = null
+            tab.avatarDataUrl = null
+            tab.avatarFileName = null
+            const navigationHistory = restoreNavigationHistory
+              ? TabManager.sanitizeNavigationHistory(tabData.history, tabData.historyIndex)
+              : null
+            tab.navigationHistory = navigationHistory?.history ?? null
+            tab.navigationHistoryIndex = navigationHistory?.historyIndex ?? 0
+            this._deleteTabPreviewFile(previewFileName).catch(error => {
+              console.error('Failed to delete stale synced tab preview:', error)
+            })
+            this._releaseTabAvatarFile(avatarFileName).catch(error => {
+              console.error('Failed to delete stale synced tab avatar:', error)
+            })
+          }
+          if (typeof tabData.title === 'string' && tabData.title.trim().length > 0) {
+            tab.title = tabData.title
+          }
+          tab.isPinned = tabData.isPinned === true
+          tab.color = TabManager.normalizeTabColor(tabData.color)
+        } else {
+          const hasSavedTitle = typeof tabData.title === 'string' && tabData.title.trim().length > 0
+          tab = this.createTab({
+            id: syncedId,
+            url: TabManager.stripOneTimeTimestampFromUrl(tabData.url),
+            title: hasSavedTitle ? tabData.title : undefined,
+            isPinned: tabData.isPinned === true,
+            color: tabData.color,
+            history: restoreNavigationHistory ? tabData.history : null,
+            historyIndex: restoreNavigationHistory ? tabData.historyIndex : null,
+            persistHistory: restoreNavigationHistory,
+            makeActive: false,
+            openPosition: 'end',
+            lazyLoad: tabData.isUnloaded === true,
+            preloadInBackground: tabData.isUnloaded === false,
+            _deferUpdates: true
+          })
+        }
+
+        syncedTabs.set(tab.id, tab)
+      }
+
+      this.tabs = syncedTabs
+      restoreTabPlacementOpeners(this.tabs, sessionData.tabs)
+
+      for (const tab of removedTabs) {
         this._clearTabPreviewRefresh(tab)
         this._resolveTabMountWaiters(tab.id, Number.MAX_SAFE_INTEGER, false)
+        this._deleteTabPreviewFile(tab.previewFileName).catch(error => {
+          console.error('Failed to delete remotely closed tab preview:', error)
+        })
+        this._releaseTabAvatarFile(tab.avatarFileName).catch(error => {
+          console.error('Failed to delete remotely closed tab avatar:', error)
+        })
       }
-      this.tabs.clear()
-      this.activeTabId = null
-      this.presentedTabId = null
-      this.closedTabs = []
+
+      const retainedTabIds = new Set(this.tabs.keys())
+      this.selectedTabIds = this.selectedTabIds.filter(tabId => retainedTabIds.has(tabId))
+      this.contextMenuSelectedTabIds = this.contextMenuSelectedTabIds.filter(tabId => retainedTabIds.has(tabId))
+      if (!retainedTabIds.has(this.contextMenuTabId)) {
+        this.contextMenuTabId = null
+      }
       this._deferredCloseTabIds.clear()
       this._deferredUnloadTabIds.clear()
-      this._deferredStartupWatchTabIds.clear()
-      this._startupPriorityTabId = null
-      this._startupPriorityLoadingObserved = false
-      this.selectionRevision += 1
-      this._broadcastStateUpdate()
+      this._deferredStartupWatchTabIds = new Set(
+        [...this._deferredStartupWatchTabIds].filter(tabId => retainedTabIds.has(tabId))
+      )
+      if (!retainedTabIds.has(this._startupPriorityTabId)) {
+        this._startupPriorityTabId = null
+        this._startupPriorityLoadingObserved = false
+      }
+
       this.sessionId = sessionData.sessionId
       this.sessionUpdatedAt = Number.isFinite(sessionData.updatedAt)
         ? sessionData.updatedAt
         : Date.now()
-      return await this.restoreFromData(sessionData, { restoreTabLoadState: true })
+
+      const nextActiveTabId = this.tabs.has(sessionData.activeTabId)
+        ? sessionData.activeTabId
+        : this.tabs.keys().next().value
+      if (nextActiveTabId !== this.activeTabId || this.tabs.get(nextActiveTabId)?.loadState === 'unloaded') {
+        this.activateTab(nextActiveTabId)
+      } else {
+        this.browserWindow.setTitle(this.tabs.get(nextActiveTabId).title)
+        this._broadcastStateUpdate()
+      }
+
+      return this.tabs.size > 0
     } finally {
       this._sessionPersistenceDisabled = false
     }

--- a/src/renderer/store/modules/tabs.js
+++ b/src/renderer/store/modules/tabs.js
@@ -370,7 +370,18 @@ function reconcileTab(previous, incoming) {
   let historyIndex = previous.historyIndex
   let route = previous.route
 
-  if (incoming.loadState === 'unloaded' && previous.loadState !== 'unloaded') {
+  // Ordinary incoming routes echo renderer-owned navigation and can be stale.
+  // A sync revision explicitly hands authority to the remote session instead.
+  if (
+    Number.isInteger(incoming.syncedNavigationRevision) &&
+    incoming.syncedNavigationRevision !== previous.syncedNavigationRevision
+  ) {
+    const title = stripDocumentTitle(incoming.title || incomingRoute.fullPath)
+    const restored = restoredHistoryState(incoming, incomingRoute, title)
+    history = restored.history
+    historyIndex = restored.historyIndex
+    route = incomingRoute
+  } else if (incoming.loadState === 'unloaded' && previous.loadState !== 'unloaded') {
     const currentEntry = normalizeHistoryEntry(history[historyIndex] ?? { route })
     history = [currentEntry]
     historyIndex = 0

--- a/src/renderer/store/modules/tabs.js
+++ b/src/renderer/store/modules/tabs.js
@@ -369,6 +369,8 @@ function reconcileTab(previous, incoming) {
   let history = previous.history
   let historyIndex = previous.historyIndex
   let route = previous.route
+  let pendingReloadRoute = previous.pendingReloadRoute
+  let contentTitle = previous.contentTitle
 
   // Ordinary incoming routes echo renderer-owned navigation and can be stale.
   // A sync revision explicitly hands authority to the remote session instead.
@@ -381,6 +383,8 @@ function reconcileTab(previous, incoming) {
     history = restored.history
     historyIndex = restored.historyIndex
     route = incomingRoute
+    pendingReloadRoute = null
+    contentTitle = title
   } else if (incoming.loadState === 'unloaded' && previous.loadState !== 'unloaded') {
     const currentEntry = normalizeHistoryEntry(history[historyIndex] ?? { route })
     history = [currentEntry]
@@ -394,7 +398,8 @@ function reconcileTab(previous, incoming) {
     route,
     history,
     historyIndex,
-    contentTitle: previous.contentTitle,
+    pendingReloadRoute,
+    contentTitle,
     refreshKey: incoming.refreshKey ?? previous.refreshKey ?? 0
   }
 }


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Make sure to follow the contributing guidelines. -->
<!-- Important note, we may remove your pull request if you do not use this provided PR template correctly. -->
<!-- Agent instructions: Preserve every heading, comment, and marker in this template. Never remove or rewrite the release-note-category:start/end, release-note:start/end, or release-note-image:start/end marker pairs. Never remove or rewrite the Release note images section; leave its contents for a human. -->

## Pull Request Type
<!-- Please select what type of pull request this is: [x] -->
- [x] Bugfix
- [ ] Feature Implementation
- [ ] Documentation
- [ ] Other

## Related issue
<!-- Please link the issue your pull request is referring to. -->
<!-- If this pull request fully resolves the relevant issue, put "closes" before the issue number. -->
<!-- Example: "closes #123456". -->

No linked issue.

## Description
<!-- Please write a clear and concise description of what the pull request does. -->

Applying a tab session received from sync cleared every live tab before restoring the remote snapshot. Even a remote active-tab change destroyed and recreated all retained tab content.

This changes session application to reconcile tabs by their stable IDs. Tabs that remain in the session keep their mounted content and local load state, remotely closed tabs are removed, and only new remote tabs are created. Portable metadata, tab order, and the active tab still follow the synced session.

## Release note category
<!-- Select exactly one category. Every pull request must select one. -->
<!-- Select "Not noteworthy" when the pull request fixes a bug in or improves functionality that has not yet appeared in a stable release. -->
<!-- release-note-category:start -->
- [ ] Not noteworthy
- [ ] Highlights
- [ ] More improvements
- [x] Fixed bugs
<!-- release-note-category:end -->

## Release note
<!-- Required unless "Not noteworthy" is selected. -->
<!-- Write one concise, user-facing entry without a leading bullet. -->
<!-- release-note:start -->

Syncing open tabs no longer reloads tabs that remain open on another device.

<!-- release-note:end -->

## Release note images
<!-- Human-only: Agents must preserve this entire section and leave it empty. -->
<!-- Optional. Paste one or more Markdown images or HTML image tags here. -->
<!-- The release notes will use an HTML image tag and limit images taller than 300 pixels. -->
<!-- release-note-image:start -->

<!-- release-note-image:end -->

## Testing
<!-- How can reviewers verify that the PR produces correct results? -->
<!-- Please provide instructions so that others can ensure that your pull request would produce correct results. For examples see, https://github.com/FreeTubeApp/FreeTube/pull/5743, https://github.com/FreeTubeApp/FreeTube/pull/7349, https://github.com/FreeTubeApp/FreeTube/pull/5125, https://github.com/FreeTubeApp/FreeTube/pull/7338 -->
<!-- Agent instructions: Only write human-facing steps that explain how to verify the change while running this branch in dev mode. Include expected results and, when applicable, helpful console snippets for interactive verification. Do not include automated checks, commands, results, pass counts, or CI status. -->

1. Connect two app instances to the same enhanced-privacy sync account and enable open-tab syncing.
2. Open several tabs on both instances and let them sync.
3. On the second instance, select a different existing tab, close one tab, and open a new tab.
4. Sync the first instance again. The selected tab, removed tab, and new tab should match the remote session, while retained loaded tabs should keep their current content without reloading.

## Additional context
<!-- Add any other context about the pull request here. -->

The regression test applies the remote snapshot through the real Electron IPC path and checks that retained tab DOM nodes remain connected.
