### PR TITLE
fix(subscriptions): pause auto-refresh while app is closed

### DIFF
--- a/e2e/tests/offline/subscriptions-refresh.spec.mjs
+++ b/e2e/tests/offline/subscriptions-refresh.spec.mjs
@@ -1,4 +1,4 @@
-import { test, expect, goTo, sel } from '../../helpers/app.mjs'
+import { test, expect, goTo, sel, waitForAppReady } from '../../helpers/app.mjs'
 
 const HOUR = 3_600_000
 const now = Date.now()
@@ -426,6 +426,66 @@ test.describe('subscription feed refresh controls', () => {
 
     await expect(page.locator('.newContentDot')).toHaveCount(0)
     await expect(markAllAsSeen).toHaveCount(0)
+  })
+})
+
+test.describe('subscription feed auto refresh after restart', () => {
+  test.use({
+    seed: {
+      settings: {
+        ...commonSettings,
+        subscriptionFeedAutoRefreshInterval: '60000'
+      },
+      profiles: [profileWith(12)],
+      subscriptionCache: Array.from({ length: 12 }, (_, index) => cachedChannel(index))
+    }
+  })
+
+  test('restarts an expired refresh interval instead of catching up on startup', async ({ app }) => {
+    await routeFeeds(app.page, () => 8_000)
+    await goTo(app.page, 'subscriptions')
+    await expect(app.page.getByText(/Next auto refresh:/i)).toBeVisible()
+    await expect(app.page.getByTestId('subscription-refresh-toast')).toHaveCount(0)
+
+    await app.page.evaluate(() => {
+      localStorage.setItem(
+        'opentubex.subscriptionAutoRefresh.completed.allChannels/videos',
+        String(Date.now() - 2 * 60 * 60 * 1000)
+      )
+      localStorage.setItem(
+        'opentubex.subscriptionAutoRefresh.deadline.allChannels/videos',
+        String(Date.now() - 60 * 1000)
+      )
+    })
+
+    const { page } = await app.relaunch()
+    await routeFeeds(page, () => 8_000)
+    await goTo(page, 'subscriptions')
+
+    await expect(page.getByTestId('subscription-refresh-toast')).toHaveCount(0)
+    await page.waitForTimeout(2_000)
+    await expect(page.getByTestId('subscription-refresh-toast')).toHaveCount(0)
+    await expect.poll(() => page.evaluate(() => Number(localStorage.getItem(
+      'opentubex.subscriptionAutoRefresh.deadline.allChannels/videos'
+    )))).toBeGreaterThan(Date.now() + 30_000)
+  })
+
+  test('keeps the current deadline when another window opens', async ({ app }) => {
+    const deadline = Date.now() + 10 * 60 * 1000
+    await app.page.evaluate((timestamp) => localStorage.setItem(
+      'opentubex.subscriptionAutoRefresh.deadline.allChannels/videos',
+      String(timestamp)
+    ), deadline)
+
+    const [newWindow] = await Promise.all([
+      app.electronApp.waitForEvent('window'),
+      app.page.locator('.topNav .navNewWindowButton').click()
+    ])
+    await waitForAppReady(newWindow)
+
+    await expect.poll(() => newWindow.evaluate(() => Number(localStorage.getItem(
+      'opentubex.subscriptionAutoRefresh.deadline.allChannels/videos'
+    )))).toBe(deadline)
   })
 })
 

--- a/src/constants.js
+++ b/src/constants.js
@@ -35,6 +35,7 @@ const IpcChannels = {
   VIDEO_METADATA_CACHE_CLEARED: 'video-metadata-cache-cleared',
   SUBSCRIPTION_AUTO_REFRESH_ACQUIRE: 'subscription-auto-refresh-acquire',
   SUBSCRIPTION_AUTO_REFRESH_CANCEL: 'subscription-auto-refresh-cancel',
+  SUBSCRIPTION_AUTO_REFRESH_GET_SESSION_ID: 'subscription-auto-refresh-get-session-id',
   SUBSCRIPTION_AUTO_REFRESH_GET_STATE: 'subscription-auto-refresh-get-state',
   SUBSCRIPTION_AUTO_REFRESH_RELEASE: 'subscription-auto-refresh-release',
   SUBSCRIPTION_AUTO_REFRESH_SET_PROGRESS: 'subscription-auto-refresh-set-progress',

--- a/src/main/index.js
+++ b/src/main/index.js
@@ -358,6 +358,7 @@ function runApp() {
   /** @type {{ webContents: import('electron').WebContents, tabId: string } | null} */
   let subscriptionAutoRefreshOwner = null
   let subscriptionAutoRefreshProgress = 0
+  let subscriptionAutoRefreshSessionId = randomUUID()
   /** @type {Promise<{ exitCode: number | null, signal: NodeJS.Signals | null, stdout: string, stderr: string }> | null} */
   let ipBlockRecoveryScriptPromise = null
   const faviconPromises = new Map()
@@ -3413,6 +3414,10 @@ function runApp() {
     }
   })
 
+  ipcMain.handle(IpcChannels.SUBSCRIPTION_AUTO_REFRESH_GET_SESSION_ID, (event) => {
+    return isOpenTubeXUrl(event.senderFrame.url) ? subscriptionAutoRefreshSessionId : null
+  })
+
   ipcMain.on(IpcChannels.SUBSCRIPTION_AUTO_REFRESH_SET_PROGRESS, (event, tabId, percentage) => {
     if (
       subscriptionAutoRefreshOwner?.webContents.id !== event.sender.id ||
@@ -4958,6 +4963,7 @@ function runApp() {
   }
 
   function handleQuit() {
+    subscriptionAutoRefreshSessionId = randomUUID()
     cleanUpResources().finally(() => {
       mainWindow = null
       if (process.platform !== 'darwin') {

--- a/src/preload/interface.js
+++ b/src/preload/interface.js
@@ -674,6 +674,14 @@ export default {
 
   subscriptionAutoRefresh: {
     /**
+     * Get the identifier for the current application-window session.
+     * @returns {Promise<string | null>}
+     */
+    getSessionId: () => {
+      return ipcRenderer.invoke(IpcChannels.SUBSCRIPTION_AUTO_REFRESH_GET_SESSION_ID)
+    },
+
+    /**
      * Atomically claim ownership of the subscription auto refresh.
      * @param {string} tabId
      * @param {'videos' | 'shorts' | 'live' | 'posts'} feedTab

--- a/src/renderer/App.vue
+++ b/src/renderer/App.vue
@@ -581,6 +581,7 @@ const LEGACY_SUBSCRIPTION_AUTO_REFRESH_STORAGE_KEY_PREFIX = 'opentubex.subscript
 const SUBSCRIPTION_AUTO_REFRESH_COMPLETION_STORAGE_KEY_PREFIX = 'opentubex.subscriptionAutoRefresh.completed.'
 const SUBSCRIPTION_AUTO_REFRESH_DEADLINE_STORAGE_KEY_PREFIX = 'opentubex.subscriptionAutoRefresh.deadline.'
 const SUBSCRIPTION_AUTO_REFRESH_PROGRESS_STORAGE_KEY = 'opentubex.subscriptionAutoRefresh.inProgress'
+const SUBSCRIPTION_AUTO_REFRESH_SESSION_STORAGE_KEY = 'opentubex.subscriptionAutoRefresh.sessionId'
 let historyCleanupTimer = null
 const subscriptionAutoRefreshTabs = ['videos', 'shorts', 'live', 'posts']
 let removeSubscriptionAutoRefreshActiveChangedListener = null
@@ -1190,13 +1191,42 @@ function scheduleHistoryCleanup(days) {
   }, HISTORY_CLEANUP_INTERVAL)
 }
 
-watch([dataReady, activeSubscriptionProfileId], ([ready, profileId]) => {
+watch([dataReady, activeSubscriptionProfileId], async ([ready, profileId]) => {
   clearSubscriptionFeedAutoRefreshTimer()
   if (ready && profileId) {
     migrateLegacySubscriptionAutoRefreshDeadlines()
-    synchronizeSubscriptionAutoRefreshProfile(profileId)
+    if (!await resetSubscriptionAutoRefreshForNewSession()) {
+      synchronizeSubscriptionAutoRefreshProfile(profileId)
+    }
   }
 })
+
+async function resetSubscriptionAutoRefreshForNewSession() {
+  if (!process.env.IS_ELECTRON) {
+    return false
+  }
+
+  try {
+    const sessionId = await window.ftElectron.subscriptionAutoRefresh.getSessionId()
+    if (sessionId === null) {
+      return false
+    }
+
+    if (localStorage.getItem(SUBSCRIPTION_AUTO_REFRESH_SESSION_STORAGE_KEY) === sessionId) {
+      return false
+    }
+
+    // Write the marker last so concurrently restored windows either observe a
+    // complete reset or harmlessly perform the same reset themselves.
+    for (const tab of subscriptionAutoRefreshTabs) {
+      resetSubscriptionTabAutoRefreshForAllProfiles(tab)
+    }
+    localStorage.setItem(SUBSCRIPTION_AUTO_REFRESH_SESSION_STORAGE_KEY, sessionId)
+    return true
+  } catch {
+    return false
+  }
+}
 
 watch([subscriptionFeedAutoRefreshInterval, hideSubscriptionsVideos], () => {
   resetSubscriptionTabAutoRefreshForAllProfiles('videos')


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Make sure to follow the contributing guidelines. -->
<!-- Important note, we may remove your pull request if you do not use this provided PR template correctly. -->
<!-- Agent instructions: Preserve every heading, comment, and marker in this template. Never remove or rewrite the release-note-category:start/end, release-note:start/end, or release-note-image:start/end marker pairs. Never remove or rewrite the Release note images section; leave its contents for a human. -->

## Pull Request Type
<!-- Please select what type of pull request this is: [x] -->
- [x] Bugfix
- [ ] Feature Implementation
- [ ] Documentation
- [ ] Other

## Related issue
<!-- Please link the issue your pull request is referring to. -->
<!-- If this pull request fully resolves the relevant issue, put "closes" before the issue number. -->
<!-- Example: "closes #123456". -->

## Description
<!-- Please write a clear and concise description of what the pull request does. -->
Subscription auto-refresh deadlines were stored as absolute timestamps, so time spent with OpenTubeX closed counted toward the interval. An overdue deadline then started a feed refresh on launch even when "Fetch Feed on Startup" was disabled.

Give each application run a session ID and restart the enabled feed intervals once for that session. Additional windows reuse the same session ID, so opening one does not postpone timers already running in another window.

## Release note category
<!-- Select exactly one category. Every pull request must select one. -->
<!-- Select "Not noteworthy" when the pull request fixes a bug in or improves functionality that has not yet appeared in a stable release. -->
<!-- release-note-category:start -->
- [ ] Not noteworthy
- [ ] Highlights
- [ ] More improvements
- [x] Fixed bugs
<!-- release-note-category:end -->

## Release note
<!-- Required unless "Not noteworthy" is selected. -->
<!-- Write one concise, user-facing entry without a leading bullet. -->
<!-- release-note:start -->
Subscription feeds no longer refresh immediately on startup when their auto-refresh interval elapsed while the app was closed.
<!-- release-note:end -->

## Release note images
<!-- Human-only: Agents must preserve this entire section and leave it empty. -->
<!-- Optional. Paste one or more Markdown images or HTML image tags here. -->
<!-- The release notes will use an HTML image tag and limit images taller than 300 pixels. -->
<!-- release-note-image:start -->

<!-- release-note-image:end -->

## Testing
<!-- How can reviewers verify that the PR produces correct results? -->
<!-- Please provide instructions so that others can ensure that your pull request would produce correct results. For examples see, https://github.com/FreeTubeApp/FreeTube/pull/5743, https://github.com/FreeTubeApp/FreeTube/pull/7349, https://github.com/FreeTubeApp/FreeTube/pull/5125, https://github.com/FreeTubeApp/FreeTube/pull/7338 -->
<!-- Agent instructions: Only write human-facing steps that explain how to verify the change while running this branch in dev mode. Include expected results and, when applicable, helpful console snippets for interactive verification. Do not include automated checks, commands, results, pass counts, or CI status. -->
1. Disable "Fetch Feed on Startup" and set the Videos Auto Refresh Interval to 30 minutes.
2. Open the subscriptions feed. In the renderer developer console, set its saved deadline to the past with `localStorage.setItem('opentubex.subscriptionAutoRefresh.deadline.allChannels/videos', String(Date.now() - 60000))`.
3. Close and restart the app. No subscription refresh should start, and the next auto-refresh time should be about 30 minutes after launch.
4. Open another window. Its displayed deadline should match the first window rather than restart the interval.

## Additional context
<!-- Add any other context about the pull request here. -->
The auto-refresh setting describes the interval as running while the app is open. The separate startup-fetch setting remains responsible for intentional launch refreshes.
