### PR TITLE
test(e2e): align assertions with current styles

### DIFF
--- a/e2e/tests/network/playlist-dock.spec.mjs
+++ b/e2e/tests/network/playlist-dock.spec.mjs
@@ -30,7 +30,6 @@ test('large fullscreen playlist dock remains responsive and preserves its state'
   ).toBeGreaterThan(1000)
   await expect(sidebar).toHaveAttribute('data-overlayscrollbars-viewport')
   await expect(sidebar.locator(':scope > .os-scrollbar-vertical')).toHaveCount(1)
-  await expect(sidebar.locator('.playlistItem').first()).toHaveCSS('content-visibility', 'auto')
   await expect.poll(async () => sidebar.evaluate((element) => element.scrollHeight)).toBeGreaterThan(1000)
 
   const sidebarCard = page.locator('.watchVideoPlaylist')

--- a/e2e/tests/offline/ui-bugfixes.spec.mjs
+++ b/e2e/tests/offline/ui-bugfixes.spec.mjs
@@ -268,7 +268,7 @@ test('Shorts top controls stay visible over white video content', async ({ page 
   await expect(topControls).toHaveCSS('opacity', '1')
   await expect(topControls).toHaveCSS('border-top-left-radius', '16px')
   await expect(topControls).toHaveCSS('border-top-right-radius', '16px')
-  await expect(topControls).toHaveCSS('transition-duration', '0.15s')
+  await expect(topControls).toHaveCSS('transition-duration', '0.15s, 0.25s, 0.25s')
   await expect(control).toHaveCSS('backdrop-filter', /blur\(8px\)/)
   await control.evaluate(element => element.classList.add('active'))
   await expect(control).toHaveCSS('background-color', 'rgba(0, 0, 0, 0.52)')


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Make sure to follow the contributing guidelines. -->
<!-- Important note, we may remove your pull request if you do not use this provided PR template correctly. -->
<!-- Agent instructions: Preserve every heading, comment, and marker in this template. Never remove or rewrite the release-note-category:start/end, release-note:start/end, or release-note-image:start/end marker pairs. Never remove or rewrite the Release note images section; leave its contents for a human. -->

## Pull Request Type
<!-- Please select what type of pull request this is: [x] -->
- [x] Bugfix
- [ ] Feature Implementation
- [ ] Documentation
- [ ] Other

## Related issue
<!-- Please link the issue your pull request is referring to. -->
<!-- If this pull request fully resolves the relevant issue, put "closes" before the issue number. -->
<!-- Example: "closes #123456". -->

Scheduled E2E failure: https://github.com/OpenTubeX/OpenTubeX/actions/runs/32689066739

## Description
<!-- Please write a clear and concise description of what the pull request does. -->

The scheduled E2E run failed because two assertions still described styles that had already changed. This updates the Shorts transition-duration expectation to include the fullscreen dock motion and removes the playlist content-visibility check after that optimization was removed.

## Release note category
<!-- Select exactly one category. Every pull request must select one. -->
<!-- Select "Not noteworthy" when the pull request fixes a bug in or improves functionality that has not yet appeared in a stable release. -->
<!-- release-note-category:start -->
- [x] Not noteworthy
- [ ] Highlights
- [ ] More improvements
- [ ] Fixed bugs
<!-- release-note-category:end -->

## Release note
<!-- Required unless "Not noteworthy" is selected. -->
<!-- Write one concise, user-facing entry without a leading bullet. -->
<!-- release-note:start -->

<!-- release-note:end -->

## Release note images
<!-- Human-only: Agents must preserve this entire section and leave it empty. -->
<!-- Optional. Paste one or more Markdown images or HTML image tags here. -->
<!-- The release notes will use an HTML image tag and limit images taller than 300 pixels. -->
<!-- release-note-image:start -->

<!-- release-note-image:end -->

## Testing
<!-- How can reviewers verify that the PR produces correct results? -->
<!-- Please provide instructions so that others can ensure that your pull request would produce correct results. For examples see, https://github.com/FreeTubeApp/FreeTube/pull/5743, https://github.com/FreeTubeApp/FreeTube/pull/7349, https://github.com/FreeTubeApp/FreeTube/pull/5125, https://github.com/FreeTubeApp/FreeTube/pull/7338 -->
<!-- Agent instructions: Only write human-facing steps that explain how to verify the change while running this branch in dev mode. Include expected results and, when applicable, helpful console snippets for interactive verification. Do not include automated checks, commands, results, pass counts, or CI status. -->

1. Open a Short, pause it, and open and close a fullscreen dock. The top controls should fade and move with the video without snapping.
2. Open a playlist with many items. Its sidebar and fullscreen dock should remain scrollable and preserve their positions when the dock closes and reopens.

## Additional context
<!-- Add any other context about the pull request here. -->

The runtime behavior is unchanged. The scheduled run exposed assertions left behind by #892 and #743.
