### PR TITLE
fix(player): recover IP-blocked videos with yt-dlp

### DIFF
--- a/e2e/tests/offline/video-actions.spec.mjs
+++ b/e2e/tests/offline/video-actions.spec.mjs
@@ -221,7 +221,7 @@ test.describe('video downloads', () => {
     await writeFile(executable, [
       '#!/bin/sh',
       `printf '%s\\n' "$@" > "${capturedArgs}"`,
-      'printf \'%s\\n\' \'{"formats":[{"format_id":"140","available_at":123}]}\''
+      'printf \'%s\\n\' \'{"title":"Playback title","formats":[{"format_id":"140","available_at":123}]}\''
     ].join('\n'))
     await chmod(executable, 0o755)
     await page.evaluate(async (ytDlpPath) => {
@@ -240,6 +240,7 @@ test.describe('video downloads', () => {
 
     passedArguments = (await readFile(capturedArgs, 'utf8')).trim().split('\n')
     expect(passedArguments).not.toContain('--extractor-args')
+    expect(info.title).toBe('Playback title')
     expect(info.formats[0].availableAt).toBe(123)
   })
 

--- a/e2e/tests/offline/video-actions.spec.mjs
+++ b/e2e/tests/offline/video-actions.spec.mjs
@@ -76,6 +76,7 @@ test('persists the yt-dlp playback cache across app restarts', async ({ app, pag
     manifestSrc: 'data:application/dash+xml;charset=UTF-8,manifest',
     manifestMimeType: 'application/dash+xml',
     legacyFormats: [],
+    title: 'Cached video title',
     isLive: false,
     version: '2026.08.13'
   }
@@ -99,6 +100,7 @@ test('limits persisted yt-dlp playback entries by UTF-8 byte size', async ({ pag
     manifestSrc: `data:application/dash+xml;charset=UTF-8,${'€'.repeat(700_000)}`,
     manifestMimeType: 'application/dash+xml',
     legacyFormats: [],
+    title: 'Cached video title',
     isLive: false,
     version: '2026.08.13'
   }
@@ -121,6 +123,7 @@ test('prefers evicting yt-dlp playback entries without open tabs', async ({ page
       manifestSrc: 'data:application/dash+xml;charset=UTF-8,manifest',
       manifestMimeType: 'application/dash+xml',
       legacyFormats: [],
+      title: 'Cached video title',
       isLive: false,
       version: '2026.08.13'
     }

--- a/e2e/tests/offline/watch-error-navigation.spec.mjs
+++ b/e2e/tests/offline/watch-error-navigation.spec.mjs
@@ -6,6 +6,7 @@ import { gunzipSync } from 'node:zlib'
 import { goTo, repoRoot, sel, test, expect } from '../../helpers/app.mjs'
 import { fixtureKey } from '../../helpers/innertube.mjs'
 import { demoPlayerResponse, routeWatchPageHtml } from '../../helpers/media.mjs'
+import { watchViewHandle } from '../../helpers/watch.mjs'
 
 const fixtureDir = path.join(repoRoot, 'e2e', 'fixtures', 'innertube', 'watch', 'shows-video-metadata')
 const sharedDir = path.join(repoRoot, 'e2e', 'fixtures', 'innertube', 'shared')
@@ -144,6 +145,57 @@ function expectNoRenderErrors(errors) {
   )
   expect(renderErrors, `Renderer errors:\n${errors.join('\n')}`).toEqual([])
 }
+
+test('an IP-blocked response still uses the configured yt-dlp extractor and title', async ({ app, page }) => {
+  await mockBlockedVideo({
+    app,
+    page,
+    omitVideoMetadata: true
+  })
+  await page.route('https://example.invalid/recovered.m3u8', route => route.fulfill({
+    contentType: 'application/x-mpegURL',
+    body: '#EXTM3U\n'
+  }))
+  await app.electronApp.evaluate(({ ipcMain }) => {
+    globalThis.__ipBlockedYtDlpCalls = 0
+    ipcMain.removeHandler('yt-dlp-get-playback-info')
+    ipcMain.handle('yt-dlp-get-playback-info', () => {
+      globalThis.__ipBlockedYtDlpCalls++
+      return {
+        title: 'Title recovered by yt-dlp',
+        isLive: false,
+        liveStatus: 'not_live',
+        hlsManifestUrl: 'https://example.invalid/recovered.m3u8',
+        formats: [],
+        duration: 60,
+        version: 'test'
+      }
+    })
+  })
+  await page.evaluate(async () => {
+    const store = document.querySelector('#app').__vue_app__.config.globalProperties.$store
+    await store.dispatch('updateVideoPlaybackEngine', 'yt-dlp')
+  })
+
+  await page.locator(sel.searchInput).fill('https://www.youtube.com/watch?v=jNQXAC9IVRw')
+  await page.locator(sel.searchInput).press('Enter')
+  await expect(page).toHaveURL(/#\/watch\/jNQXAC9IVRw/)
+
+  await expect.poll(() => app.electronApp.evaluate(
+    () => globalThis.__ipBlockedYtDlpCalls
+  )).toBeGreaterThan(0)
+  const watchView = await watchViewHandle(page)
+  await expect.poll(() => watchView.evaluate(view => ({
+    title: view.videoTitle,
+    titleResolved: view.hasResolvedVideoTitle
+  }))).toEqual({
+    title: 'Title recovered by yt-dlp',
+    titleResolved: true
+  })
+  expect(await watchView.evaluate(view => view.errorMessage ?? '')).not.toContain('blocked')
+  await expect(page.locator('.infoArea .videoTitle')).toHaveText('Title recovered by yt-dlp')
+  await expect(page.locator('.tabBar .tab.active')).toContainText('Title recovered by yt-dlp')
+})
 
 test('watch page IP-block error does not break later navigation', async ({ app, page }) => {
   const errors = captureRenderErrors(page)

--- a/src/main/ytDlp.js
+++ b/src/main/ytDlp.js
@@ -1270,6 +1270,7 @@ export async function handleYtDlpDownloadBinary(event, binary) {
 /**
  * @typedef YtDlpPlaybackInfo
  * @property {string | null} version the version of yt-dlp that extracted this
+ * @property {string | null} title
  * @property {boolean} isLive
  * @property {'is_live' | 'post_live' | 'was_live' | 'not_live' | 'is_upcoming' | null} liveStatus
  * @property {number | null} duration
@@ -1469,6 +1470,7 @@ export async function handleYtDlpGetPlaybackInfo(
 
   return {
     version: toNonEmptyString(info._version?.version),
+    title: toNonEmptyString(info.title),
     isLive: !!info.is_live,
     liveStatus: toNonEmptyString(info.live_status),
     duration: toFiniteNumber(info.duration),

--- a/src/main/ytDlpPlaybackCache.js
+++ b/src/main/ytDlpPlaybackCache.js
@@ -60,7 +60,8 @@ function isValidEntry(entry) {
     entry.source.manifestMimeType === 'application/dash+xml' &&
     typeof entry.source.manifestSrc === 'string' &&
     entry.source.manifestSrc.startsWith('data:application/dash+xml;') &&
-    Array.isArray(entry.source.legacyFormats)
+    Array.isArray(entry.source.legacyFormats) &&
+    (entry.source.title === null || typeof entry.source.title === 'string')
 }
 
 async function loadEntries() {
@@ -137,6 +138,7 @@ export async function handleYtDlpPlaybackCacheSet(event, videoId, cacheKey, expi
           manifestSrc: source.manifestSrc,
           manifestMimeType: source.manifestMimeType,
           legacyFormats: source.legacyFormats,
+          title: source.title,
           isLive: source.isLive,
           version: source.version
         }

--- a/src/renderer/helpers/player/ytDlpPlayback.js
+++ b/src/renderer/helpers/player/ytDlpPlayback.js
@@ -14,6 +14,7 @@ import { getEarliestYtDlpFormatExpiry, YtDlpPlaybackSourceCache } from './ytDlpP
  * @property {MANIFEST_TYPE_DASH | MANIFEST_TYPE_HLS} manifestMimeType
  * @property {any[]} legacyFormats
  * @property {Date | null} expiryDate
+ * @property {string | null} title
  * @property {boolean} isLive
  * @property {number | null} duration
  * @property {string | null} storyboardSrc
@@ -385,6 +386,7 @@ export async function getYtDlpPlaybackSource(
           manifestMimeType: MANIFEST_TYPE_DASH,
           legacyFormats,
           expiryDate: getEarliestYtDlpFormatExpiry(adaptiveFormats),
+          title: info.title,
           isLive: false,
           duration: info.duration,
           storyboardSrc: info.storyboardVtt === null
@@ -417,6 +419,7 @@ export async function getYtDlpPlaybackSource(
         manifestMimeType: MANIFEST_TYPE_HLS,
         legacyFormats: await legacyFormatsPromise,
         expiryDate: null,
+        title: info.title,
         isLive: info.isLive,
         duration: info.duration,
         storyboardSrc: info.storyboardVtt === null

--- a/src/renderer/views/Watch/Watch.js
+++ b/src/renderer/views/Watch/Watch.js
@@ -2394,6 +2394,15 @@ export default defineComponent({
         videoId === this.tabRoute.params.id
     },
 
+    isYtDlpPlaybackRequested: function () {
+      return process.env.IS_ELECTRON &&
+        this.playbackEngineFallbackTarget !== 'built-in' &&
+        (
+          this.videoPlaybackEngine === 'yt-dlp' ||
+          this.playbackEngineFallbackTarget === 'yt-dlp'
+        )
+    },
+
     setRestrictedPlaybackError: function (type) {
       this.restrictedPlaybackError = type
       this.errorMessage = type === 'members'
@@ -2790,7 +2799,7 @@ export default defineComponent({
             }
 
             const tryingYtDlpForIpBlock =
-              this.playbackEngineFallbackTarget === 'yt-dlp' &&
+              this.isYtDlpPlaybackRequested() &&
               this.ipBlockDetectedInCurrentChain
 
             if (tryingYtDlpForIpBlock) {
@@ -2987,7 +2996,7 @@ export default defineComponent({
             }
           } else if (
             this.restrictedPlaybackError === null &&
-            this.playbackEngineFallbackTarget !== 'yt-dlp'
+            !this.isYtDlpPlaybackRequested()
           ) {
             // video might be region locked or something else. This leads to no formats being available
             this.showTabToast({
@@ -5008,6 +5017,12 @@ export default defineComponent({
       this.activePlaybackEngine = 'yt-dlp'
       this.activePlaybackEngineVersion = source.version
       this.errorMessage = null
+
+      if (!this.hasResolvedVideoTitle && source.title) {
+        this.videoTitle = source.title
+        this.hasResolvedVideoTitle = true
+        this.updateTitle()
+      }
 
       this.alignActiveFormatWithAvailableSources()
 


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Make sure to follow the contributing guidelines. -->
<!-- Important note, we may remove your pull request if you do not use this provided PR template correctly. -->
<!-- Agent instructions: Preserve every heading, comment, and marker in this template. Never remove or rewrite the release-note-category:start/end, release-note:start/end, or release-note-image:start/end marker pairs. Never remove or rewrite the Release note images section; leave its contents for a human. -->

## Pull Request Type
<!-- Please select what type of pull request this is: [x] -->
- [x] Bugfix
- [ ] Feature Implementation
- [ ] Documentation
- [ ] Other

## Related issue
<!-- Please link the issue your pull request is referring to. -->
<!-- If this pull request fully resolves the relevant issue, put "closes" before the issue number. -->
<!-- Example: "closes #123456". -->

Closes #819.

## Description
<!-- Please write a clear and concise description of what the pull request does. -->

When YouTube's built-in metadata response reported an IP block, the watch page stopped before trying yt-dlp even when yt-dlp was the configured extractor. The same response could omit the title, leaving both the page heading and tab title blank.

This lets the configured yt-dlp path continue through the blocked metadata response while preserving manual Built-in overrides. It also carries yt-dlp's title through the playback source and uses it only when the metadata API did not resolve a title.

## Release note category
<!-- Select exactly one category. Every pull request must select one. -->
<!-- Select "Not noteworthy" when the pull request fixes a bug in or improves functionality that has not yet appeared in a stable release. -->
<!-- release-note-category:start -->
- [ ] Not noteworthy
- [ ] Highlights
- [ ] More improvements
- [x] Fixed bugs
<!-- release-note-category:end -->

## Release note
<!-- Required unless "Not noteworthy" is selected. -->
<!-- Write one concise, user-facing entry without a leading bullet. -->
<!-- release-note:start -->
Play videos with the configured yt-dlp extractor when the built-in metadata request is IP blocked.
<!-- release-note:end -->

## Release note images
<!-- Human-only: Agents must preserve this entire section and leave it empty. -->
<!-- Optional. Paste one or more Markdown images or HTML image tags here. -->
<!-- The release notes will use an HTML image tag and limit images taller than 300 pixels. -->
<!-- release-note-image:start -->

<!-- release-note-image:end -->

## Testing
<!-- How can reviewers verify that the PR produces correct results? -->
<!-- Please provide instructions so that others can ensure that your pull request would produce correct results. For examples see, https://github.com/FreeTubeApp/FreeTube/pull/5743, https://github.com/FreeTubeApp/FreeTube/pull/7349, https://github.com/FreeTubeApp/FreeTube/pull/5125, https://github.com/FreeTubeApp/FreeTube/pull/7338 -->
<!-- Agent instructions: Only write human-facing steps that explain how to verify the change while running this branch in dev mode. Include expected results and, when applicable, helpful console snippets for interactive verification. Do not include automated checks, commands, results, pass counts, or CI status. -->

1. Select yt-dlp as the stream extraction method and Local API as the primary API.
2. Open a video for which the Local API shows the IP-block response while yt-dlp can extract streams.
3. Confirm that yt-dlp starts fetching automatically, the video plays without manually changing formats, and the video title appears in both the page and tab.
4. Manually select Built-in and confirm that the explicit selection is still respected.

## Additional context
<!-- Add any other context about the pull request here. -->

The reporter's latest recording shows yt-dlp configured as the default, Built-in displayed as active after the blocked metadata response, and successful playback only after manually selecting yt-dlp.
