### PR TITLE
feat(playlists): add independent view setting

### DIFF
--- a/e2e/tests/offline/playlists.spec.mjs
+++ b/e2e/tests/offline/playlists.spec.mjs
@@ -1,7 +1,7 @@
 import { readFile } from 'node:fs/promises'
 import path from 'node:path'
 
-import { test, expect, sel, goTo } from '../../helpers/app.mjs'
+import { test, expect, sel, goTo, goToSettingsSection } from '../../helpers/app.mjs'
 
 test.describe('playlist creation', () => {
   test('a playlist can be created through the UI', async ({ page }) => {
@@ -161,6 +161,58 @@ test.describe('seeded playlists', () => {
     await goTo(page, 'userplaylists')
     await page.getByText('Favorites').click()
     await expect(page.getByTitle('Quick Bookmark Enabled').locator('.ft-custom-icon__emoji')).toHaveText('❤️‍🔥')
+  })
+})
+
+test.describe('playlist view type', () => {
+  test.use({
+    seed: {
+      settings: {
+        listType: 'list'
+      },
+      playlists: [{
+        _id: 'playlist-view-type',
+        playlistName: 'Playlist view type',
+        protected: false,
+        description: '',
+        videos: [{
+          videoId: 'eeeeeeeeeee',
+          title: 'Playlist view video',
+          author: 'Test Channel',
+          authorId: 'UC-test-channel-id',
+          lengthSeconds: 120,
+          published: Date.now() - 86_400_000,
+          timeAdded: Date.now(),
+          playlistItemId: 'playlist-view-item',
+          type: 'video'
+        }],
+        createdAt: Date.now() - 86_400_000,
+        lastUpdatedAt: Date.now()
+      }]
+    }
+  })
+
+  test('defaults to grid independently and persists list view', async ({ app, page }) => {
+    await goTo(page, 'userplaylists')
+    await page.getByText('Playlist view type').click()
+    await expect(page.locator('.playlistPage')).toHaveClass(/grid/)
+
+    const appearance = await goToSettingsSection(page, 'appearance')
+    const playlistViewSetting = appearance.locator('.select').filter({
+      has: page.getByRole('combobox', { name: 'Playlist View Type' })
+    })
+    const playlistViewSelect = playlistViewSetting.locator('select')
+    await expect(playlistViewSelect).toHaveValue('grid')
+    await playlistViewSelect.selectOption('list')
+    await page.locator('.settingsCloseButton').click()
+
+    await expect(page.locator('.playlistPage')).toHaveClass(/list/)
+    await expect(page.locator('.playlistItems')).toBeVisible()
+
+    ;({ page } = await app.relaunch())
+    await goTo(page, 'userplaylists')
+    await page.getByText('Playlist view type').click()
+    await expect(page.locator('.playlistPage')).toHaveClass(/list/)
   })
 })
 

--- a/src/renderer/components/GeneralSettings/GeneralSettings.vue
+++ b/src/renderer/components/GeneralSettings/GeneralSettings.vue
@@ -156,6 +156,16 @@
       />
       <FtSelect
         v-if="mode === 'appearance'"
+        :placeholder="t('Settings.General Settings.Playlist View Type.Playlist View Type')"
+        :value="playlistViewType"
+        setting-key="playlistViewType"
+        :select-names="viewTypeNames"
+        :select-values="VIEW_TYPE_VALUES"
+        :icon="playlistViewType === 'grid' ? ['fas', 'grip'] : ['fas', 'list']"
+        @change="updatePlaylistViewType"
+      />
+      <FtSelect
+        v-if="mode === 'appearance'"
         :placeholder="t('Settings.General Settings.Thumbnail Preference.Thumbnail Preference')"
         :value="thumbnailPreference"
         setting-key="thumbnailPreference"
@@ -619,6 +629,16 @@ const listType = computed(() => store.getters.getListType)
  */
 function updateListType(value) {
   store.dispatch('updateListType', value)
+}
+
+/** @type {import('vue').ComputedRef<'grid' | 'list'>} */
+const playlistViewType = computed(() => store.getters.getPlaylistViewType)
+
+/**
+ * @param {'grid' | 'list'} value
+ */
+function updatePlaylistViewType(value) {
+  store.dispatch('updatePlaylistViewType', value)
 }
 
 /** @type {import('vue').ComputedRef<boolean>} */

--- a/src/renderer/helpers/settings-search-config.js
+++ b/src/renderer/helpers/settings-search-config.js
@@ -20,6 +20,7 @@ const GENERAL_EVERYDAY_KEYS = new Set([
 ])
 
 const GENERAL_APPEARANCE_KEYS = new Set([
+  'Playlist View Type',
   'Show Thumbnail Previews',
   'Thumbnail Preference',
   'Video View Type'
@@ -152,6 +153,7 @@ export const SETTINGS_SEARCH_SELECT_GROUP_LABELS = {
     'Reduced Motion': ['Reduced Motion'],
     'Avoid translation': ['Avoid translation'],
     'Preferred API Backend': ['Preferred API Backend'],
+    'Playlist View Type': ['Playlist View Type'],
     'Video View Type': ['Video View Type'],
     'Thumbnail Preference': ['Thumbnail Preference'],
     'Extra Thumbnail Action Button': ['Extra Thumbnail Action Button'],

--- a/src/renderer/store/modules/settings.js
+++ b/src/renderer/store/modules/settings.js
@@ -335,6 +335,7 @@ const state = {
   useFixedTabWidth: false,
   fixedTabWidth: DEFAULT_FIXED_TAB_WIDTH,
   listType: 'grid',
+  playlistViewType: 'grid',
   maxVideoPlaybackRate: 3,
   onlyShowLatestFromChannel: false,
   onlyShowLatestFromChannelNumber: 1,

--- a/src/renderer/views/Playlist/Playlist.vue
+++ b/src/renderer/views/Playlist/Playlist.vue
@@ -280,7 +280,7 @@ const sortOrder = computed(() => isUserPlaylistRequested.value ? userPlaylistSor
 const playlistId = computed(() => route.params.id)
 
 /** @type {import('vue').ComputedRef<'grid' | 'list'>} */
-const listType = computed(() => !forceListView.value ? store.getters.getListType : 'list')
+const listType = computed(() => !forceListView.value ? store.getters.getPlaylistViewType : 'list')
 
 /** @type {import('vue').ComputedRef<boolean>} */
 const userPlaylistsReady = computed(() => store.getters.getPlaylistsReady)

--- a/static/locales/en-US.yaml
+++ b/static/locales/en-US.yaml
@@ -498,6 +498,10 @@ Settings:
       Video View Type: Video View Type
       Grid: Grid
       List: List
+    Playlist View Type:
+      Playlist View Type: Playlist View Type
+      Grid: Grid
+      List: List
     Thumbnail Preference:
       Thumbnail Preference: Thumbnail Preference
       Default: Default


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Make sure to follow the contributing guidelines. -->
<!-- Important note, we may remove your pull request if you do not use this provided PR template correctly. -->
<!-- Agent instructions: Preserve every heading, comment, and marker in this template. Never remove or rewrite the release-note-category:start/end, release-note:start/end, or release-note-image:start/end marker pairs. Never remove or rewrite the Release note images section; leave its contents for a human. -->

## Pull Request Type
<!-- Please select what type of pull request this is: [x] -->
- [ ] Bugfix
- [x] Feature Implementation
- [ ] Documentation
- [ ] Other

## Related issue
<!-- Please link the issue your pull request is referring to. -->
<!-- If this pull request fully resolves the relevant issue, put "closes" before the issue number. -->
<!-- Example: "closes #123456". -->

Closes #906

## Description
<!-- Please write a clear and concise description of what the pull request does. -->

Playlist pages currently reuse the global video view setting, so users cannot choose a playlist layout without changing other video feeds.

This adds a separate Playlist View Type selector under Appearance. It defaults to Grid, persists independently, and keeps the existing responsive List fallback for small windows.

## Release note category
<!-- Select exactly one category. Every pull request must select one. -->
<!-- Select "Not noteworthy" when the pull request fixes a bug in or improves functionality that has not yet appeared in a stable release. -->
<!-- release-note-category:start -->
- [ ] Not noteworthy
- [ ] Highlights
- [x] More improvements
- [ ] Fixed bugs
<!-- release-note-category:end -->

## Release note
<!-- Required unless "Not noteworthy" is selected. -->
<!-- Write one concise, user-facing entry without a leading bullet. -->
<!-- release-note:start -->
Playlist pages now have an independent Grid or List view setting.
<!-- release-note:end -->

## Release note images
<!-- Human-only: Agents must preserve this entire section and leave it empty. -->
<!-- Optional. Paste one or more Markdown images or HTML image tags here. -->
<!-- The release notes will use an HTML image tag and limit images taller than 300 pixels. -->
<!-- release-note-image:start -->

<!-- release-note-image:end -->

## Testing
<!-- How can reviewers verify that the PR produces correct results? -->
<!-- Please provide instructions so that others can ensure that your pull request would produce correct results. For examples see, https://github.com/FreeTubeApp/FreeTube/pull/5743, https://github.com/FreeTubeApp/FreeTube/pull/7349, https://github.com/FreeTubeApp/FreeTube/pull/5125, https://github.com/FreeTubeApp/FreeTube/pull/7338 -->
<!-- Agent instructions: Only write human-facing steps that explain how to verify the change while running this branch in dev mode. Include expected results and, when applicable, helpful console snippets for interactive verification. Do not include automated checks, commands, results, pass counts, or CI status. -->

1. Open Settings, select Appearance, and confirm Playlist View Type defaults to Grid.
2. Set Video View Type to List and open a playlist. The playlist should remain in Grid view.
3. Change Playlist View Type to List and reopen the playlist. It should use List view and retain that choice after restarting the app.
4. Set Playlist View Type to Grid and shrink the window below the existing responsive threshold. The playlist should temporarily use List view and return to Grid when the window is enlarged.

## Additional context
<!-- Add any other context about the pull request here. -->

