### PR TITLE
feat(player): let new tabs start with skip silence

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -10,3 +10,4 @@
 - New icons must be registered in the icon registry. Custom icons must also provide mappings for every currently supported icon pack: Material and Remix.
 - For icon-pack mapping work (#388): get human confirmation that remapped glyphs fit visually in Material and Remix before considering the mapping done.
 - Never use the "FreeTube" name for promotion of the project (see discussion #391 for details when in doubt).
+- When adding or changing translatable strings, update only the English (`en-US`) and German (`de-DE`) locales. Weblate handles all other translations.

--- a/e2e/tests/offline/player.spec.mjs
+++ b/e2e/tests/offline/player.spec.mjs
@@ -805,6 +805,54 @@ test.describe('skip silence shortcut', () => {
     })
   })
 
+  test('applies the default only to newly-created tabs', async ({ app, page }) => {
+    await openDemoVideo({ app, page })
+
+    const readSkipSilenceState = () => page.evaluate(() => {
+      const store = document.querySelector('#app').__vue_app__.config.globalProperties.$store
+      return {
+        activeTabId: store.getters.getActiveTabId,
+        values: { ...store.state.tabs.skipSilenceByTabId }
+      }
+    })
+
+    const firstTabId = (await readSkipSilenceState()).activeTabId
+    await page.evaluate(async () => {
+      const store = document.querySelector('#app').__vue_app__.config.globalProperties.$store
+      await store.dispatch('updateShowSkipSilenceButton', true)
+      await store.dispatch('updateEnableSkipSilenceByDefault', true)
+    })
+
+    await expect.poll(readSkipSilenceState).toMatchObject({
+      values: { [firstTabId]: false }
+    })
+    await page.locator('body').press('h')
+    await expect.poll(readSkipSilenceState).toMatchObject({
+      values: { [firstTabId]: true }
+    })
+
+    await page.locator('.tabBar .newTabButton').click()
+    await expect(page.locator('.tabBar .tab')).toHaveCount(2)
+    await openMockedVideo(page)
+
+    const secondTabId = (await readSkipSilenceState()).activeTabId
+    expect(secondTabId).not.toBe(firstTabId)
+    await expect.poll(readSkipSilenceState).toMatchObject({
+      values: {
+        [firstTabId]: true,
+        [secondTabId]: true
+      }
+    })
+
+    await page.locator('body').press('h')
+    await expect.poll(readSkipSilenceState).toMatchObject({
+      values: {
+        [firstTabId]: true,
+        [secondTabId]: false
+      }
+    })
+  })
+
   test('disables the setting for an unmounted player when the control is hidden', async ({ app, page }) => {
     await openDemoVideo({ app, page })
 
@@ -825,5 +873,26 @@ test.describe('skip silence shortcut', () => {
       const store = document.querySelector('#app').__vue_app__.config.globalProperties.$store
       return store.getters.getTabSkipSilence(store.getters.getActiveTabId)
     })).toBe(false)
+  })
+})
+
+test.describe('skip silence default', () => {
+  test.use({
+    seed: {
+      settings: {
+        ...PLAYER_SEED,
+        showSkipSilenceButton: true,
+        enableSkipSilenceByDefault: true
+      }
+    }
+  })
+
+  test('enables silence skipping in the initial tab', async ({ app, page }) => {
+    await openDemoVideo({ app, page })
+
+    await expect.poll(() => page.evaluate(() => {
+      const store = document.querySelector('#app').__vue_app__.config.globalProperties.$store
+      return store.getters.getTabSkipSilence(store.getters.getActiveTabId)
+    })).toBe(true)
   })
 })

--- a/e2e/tests/offline/session-restore.spec.mjs
+++ b/e2e/tests/offline/session-restore.spec.mjs
@@ -68,6 +68,72 @@ async function readSavedSession(userDataDir) {
   return records.at(-1)?.value
 }
 
+test.describe('skip silence session restore', () => {
+  const LEGACY_TAB_ID = 'e2e-legacy-skip-silence-tab'
+  const SAVED_TAB_ID = 'e2e-saved-skip-silence-tab'
+
+  test.use({
+    seed: {
+      settings: {
+        startupBehavior: 'restoreTabLoadState',
+        showSkipSilenceButton: true,
+        enableSkipSilenceByDefault: true
+      },
+      tabSessions: [
+        {
+          _id: 'e2e-window-session',
+          value: {
+            tabs: [
+              {
+                id: LEGACY_TAB_ID,
+                url: 'app://bundle/index.html#/history',
+                title: 'Legacy tab',
+                isUnloaded: true
+              },
+              {
+                id: SAVED_TAB_ID,
+                url: 'app://bundle/index.html#/subscriptions',
+                title: 'Saved tab',
+                skipSilence: true,
+                isUnloaded: false
+              }
+            ],
+            activeTabId: SAVED_TAB_ID,
+            bounds: { x: 0, y: 0, width: 1600, height: 900, maximized: false }
+          }
+        }
+      ]
+    }
+  })
+
+  const readSkipSilenceByTabId = (page) => page.evaluate(async () => {
+    const state = await window.ftElectron.tabs.getState()
+    return Object.fromEntries(state.tabs.map(tab => [tab.id, tab.skipSilence]))
+  })
+
+  test('preserves each tab value across restarts without applying the new-tab default', async ({ app, page }) => {
+    await expect.poll(() => readSkipSilenceByTabId(page)).toEqual({
+      [LEGACY_TAB_ID]: false,
+      [SAVED_TAB_ID]: true
+    })
+
+    await page.evaluate(async (tabId) => {
+      const store = document.querySelector('#app').__vue_app__.config.globalProperties.$store
+      await store.dispatch('updateTabSkipSilence', { tabId, value: false })
+    }, SAVED_TAB_ID)
+    await expect.poll(async () => {
+      const session = await readSavedSession(app.userDataDir)
+      return session?.tabs.find(tab => tab.id === SAVED_TAB_ID)?.skipSilence
+    }).toBe(false)
+
+    ;({ page } = await app.relaunch())
+    await expect.poll(() => readSkipSilenceByTabId(page)).toEqual({
+      [LEGACY_TAB_ID]: false,
+      [SAVED_TAB_ID]: false
+    })
+  })
+})
+
 test('keeps an unconsumed link timestamp across an app restart', async ({ app, page }) => {
   await expect.poll(async () => {
     const session = await readSavedSession(app.userDataDir)

--- a/e2e/tests/offline/settings.spec.mjs
+++ b/e2e/tests/offline/settings.spec.mjs
@@ -143,6 +143,24 @@ test.describe('skip silence settings search', () => {
       .toContainText('Show Skip Silence Toggle')
     await expect(page.locator('.section.settingsSearchTarget')).toHaveCount(0)
   })
+
+  test('opens the default toggle and reflects its dependency', async ({ page }) => {
+    await goTo(page, 'settings')
+    const search = page.getByRole('searchbox', { name: 'Search settings' })
+
+    await search.fill('Enable Skip Silence by Default')
+    await page.getByRole('button', { name: 'Enable Skip Silence by Default', exact: true }).click()
+
+    const defaultToggle = page.getByRole('checkbox', {
+      name: /^Enable Skip Silence by Default/
+    })
+    await expect(defaultToggle).toBeDisabled()
+
+    await page.locator('label.switch-label')
+      .filter({ hasText: 'Show Skip Silence Toggle' })
+      .click()
+    await expect(defaultToggle).toBeEnabled()
+  })
 })
 
 test.describe('settings search highlights', () => {

--- a/src/main/index.js
+++ b/src/main/index.js
@@ -4353,6 +4353,12 @@ function runApp() {
             case 'tabCloseFocus':
               TabManager.setTabCloseFocus(data.value)
               break
+            case 'showSkipSilenceButton':
+              TabManager.setShowSkipSilenceButton(data.value)
+              break
+            case 'enableSkipSilenceByDefault':
+              TabManager.setEnableSkipSilenceByDefault(data.value)
+              break
             case 'hideToTrayOnMinimize':
               if (isTrayOnMinimizeSupported) {
                 trayOnMinimize = data.value

--- a/src/main/tabs/TabManager.js
+++ b/src/main/tabs/TabManager.js
@@ -44,6 +44,10 @@ const VALID_TAB_CLOSE_FOCUS = new Set(['previousTab', 'nextTab'])
 // Closing a tab has to pick the replacement synchronously, so the preference is
 // cached here instead of being read from the settings store on every close.
 let tabCloseFocus = DEFAULT_TAB_CLOSE_FOCUS
+// Tab creation is also synchronous after its placement preferences have loaded.
+// Cache whether silence skipping should start enabled for newly-created tabs.
+let enableSkipSilenceByDefault = false
+let showSkipSilenceButton = false
 const VALID_TAB_COLORS = new Set(['red', 'orange', 'yellow', 'green', 'blue', 'purple'])
 const TAB_PREVIEW_REFRESH_DELAY_MS = 700
 const TAB_PREVIEW_CAPTURE_STYLE_ID = 'opentubex-tab-preview-capture-style'
@@ -141,6 +145,36 @@ export class TabManager {
       TabManager.setTabCloseFocus((await baseHandlers.settings._findOne('tabCloseFocus'))?.value)
     } catch (error) {
       console.error('Failed to load tab close focus preference:', error)
+    }
+  }
+
+  /**
+   * @param {unknown} value
+   */
+  static setEnableSkipSilenceByDefault(value) {
+    enableSkipSilenceByDefault = value === true
+  }
+
+  /**
+   * @param {unknown} value
+   */
+  static setShowSkipSilenceButton(value) {
+    showSkipSilenceButton = value === true
+  }
+
+  /**
+   * @returns {Promise<void>}
+   */
+  static async refreshStoredSkipSilenceSettings() {
+    try {
+      const [showButtonSetting, defaultSetting] = await Promise.all([
+        baseHandlers.settings._findOne('showSkipSilenceButton'),
+        baseHandlers.settings._findOne('enableSkipSilenceByDefault')
+      ])
+      TabManager.setShowSkipSilenceButton(showButtonSetting?.value)
+      TabManager.setEnableSkipSilenceByDefault(defaultSetting?.value)
+    } catch (error) {
+      console.error('Failed to load skip silence preferences:', error)
     }
   }
 
@@ -930,6 +964,7 @@ export class TabManager {
       history = null,
       historyIndex = null,
       persistHistory = history != null,
+      skipSilence = showSkipSilenceButton && enableSkipSilenceByDefault,
       openerTabId = this.activeTabId,
       _deferUpdates = false
     } = options
@@ -974,7 +1009,7 @@ export class TabManager {
       previewFileName: restoredPreviewFileName,
       previewCaptureTimeoutId: null,
       previewCapturePromise: null,
-      skipSilence: false,
+      skipSilence: skipSilence === true,
       loadState: startsUnloaded ? 'unloaded' : 'mounting',
       preloadInBackground: Boolean(preloadInBackground),
       pendingActivation: false,
@@ -3170,9 +3205,11 @@ export async function setupTabsIPC(options = {}) {
     mediaSessionStateChanged = () => {}
   } = options
 
-  // Loaded before the first window exists, so a tab can never be closed while
-  // the preference still holds its default.
-  await TabManager.refreshStoredTabCloseFocus()
+  // Load synchronous tab-lifecycle preferences before the first window exists.
+  await Promise.all([
+    TabManager.refreshStoredTabCloseFocus(),
+    TabManager.refreshStoredSkipSilenceSettings()
+  ])
 
   const getManager = event => TabManager.getFromWebContents(event.sender)
 
@@ -3243,6 +3280,8 @@ export async function setupTabsIPC(options = {}) {
       openerTabId,
       // Never let a renderer choose the internal tab id; it is always generated.
       id,
+      // Silence skipping starts from the main-owned default, not renderer input.
+      skipSilence,
       ...tabOptions
     } = options != null && typeof options === 'object' ? options : {}
 

--- a/src/main/tabs/TabManager.js
+++ b/src/main/tabs/TabManager.js
@@ -2761,6 +2761,7 @@ export class TabManager {
           title: tab.title,
           isPinned: tab.isPinned,
           color: TabManager.normalizeTabColor(tab.color),
+          skipSilence: tab.skipSilence === true,
           isUnloaded: tab.loadState === 'unloaded' || this._deferredUnloadTabIds.has(tab.id),
           ...(tab.placementOpenerTabId != null && {
             placementOpenerTabId: tab.placementOpenerTabId
@@ -3001,7 +3002,7 @@ export class TabManager {
   }
 
   /**
-   * @param {{ tabs?: Array<{id?: string, url: string, title?: string, avatarFileName?: string | null, isPinned?: boolean, color?: string | null, isUnloaded?: boolean, previewFileName?: string | null, previewCapturedAt?: number, placementOpenerTabId?: string | null, history?: object[], historyIndex?: number}>, activeTabId?: string }} sessionData
+   * @param {{ tabs?: Array<{id?: string, url: string, title?: string, avatarFileName?: string | null, isPinned?: boolean, color?: string | null, skipSilence?: boolean, isUnloaded?: boolean, previewFileName?: string | null, previewCapturedAt?: number, placementOpenerTabId?: string | null, history?: object[], historyIndex?: number}>, activeTabId?: string }} sessionData
    * @param {{ loadInactiveTabs?: boolean, restoreTabLoadState?: boolean }} [options]
    * @returns {Promise<boolean>}
    */
@@ -3050,6 +3051,9 @@ export class TabManager {
           avatarFileName: avatarDataUrl == null ? null : avatarFileName,
           isPinned: tabData.isPinned === true,
           color: tabData.color,
+          // Legacy sessions did not persist this field and must retain the old
+          // disabled behavior instead of inheriting the new-tab default.
+          skipSilence: tabData.skipSilence === true,
           // Preview images are only needed when the switcher asks for them.
           // Keep the cache reference and let getTabPreview load it on demand
           // instead of serially reading every restored tab before first paint.
@@ -3575,6 +3579,7 @@ export async function setupTabsIPC(options = {}) {
     if (tab && tab.skipSilence !== skipSilence) {
       tab.skipSilence = skipSilence
       manager._broadcastStateUpdate()
+      manager._saveSession()
     }
   })
 

--- a/src/renderer/components/PlayerSettings/PlayerSettings.vue
+++ b/src/renderer/components/PlayerSettings/PlayerSettings.vue
@@ -36,6 +36,15 @@
           @change="updateShowSkipSilenceButton"
         />
         <FtToggleSwitch
+          :label="t('Settings.Player Settings.Enable Skip Silence by Default')"
+          :compact="true"
+          :disabled="!showSkipSilenceButton"
+          :default-value="enableSkipSilenceByDefault"
+          setting-key="enableSkipSilenceByDefault"
+          :tooltip="t('Tooltips.Player Settings.Enable Skip Silence by Default')"
+          @change="updateEnableSkipSilenceByDefault"
+        />
+        <FtToggleSwitch
           :label="t('Settings.Player Settings.Enable Video Zoom')"
           :compact="true"
           :default-value="enableVideoZoom"
@@ -588,6 +597,16 @@ const showSkipSilenceButton = computed(() => store.getters.getShowSkipSilenceBut
  */
 function updateShowSkipSilenceButton(value) {
   store.dispatch('updateShowSkipSilenceButton', value)
+}
+
+/** @type {import('vue').ComputedRef<boolean>} */
+const enableSkipSilenceByDefault = computed(() => store.getters.getEnableSkipSilenceByDefault)
+
+/**
+ * @param {boolean} value
+ */
+function updateEnableSkipSilenceByDefault(value) {
+  store.dispatch('updateEnableSkipSilenceByDefault', value)
 }
 
 /** @type {import('vue').ComputedRef<boolean>} */

--- a/src/renderer/store/modules/settings.js
+++ b/src/renderer/store/modules/settings.js
@@ -448,6 +448,7 @@ const state = {
   rememberVolume: true,
   enableVideoZoom: true,
   showSkipSilenceButton: false,
+  enableSkipSilenceByDefault: false,
   useVoiceOverTranslation: false,
   voiceOverTranslationPrepareInBackground: false,
   voiceOverTranslationLanguage: 'en',

--- a/static/locales/de-DE.yaml
+++ b/static/locales/de-DE.yaml
@@ -657,6 +657,7 @@ Settings:
     Max Video Playback Rate: Maximale Wiedergabegeschwindigkeit
     Skip Silence: Stille überspringen
     Show Skip Silence Toggle: Schalter „Stille überspringen“ anzeigen
+    Enable Skip Silence by Default: „Stille überspringen“ standardmäßig aktivieren
     Hold to Double Playback Speed: Für doppelte Wiedergabegeschwindigkeit gedrückt halten
     Screenshot:
       Enable: Screenshots aktivieren
@@ -1844,6 +1845,7 @@ Tooltips:
     Multiply Seek Interval by Playback Rate: Wenn aktiviert, werden Sprungintervalle (Pfeiltasten und J/L) mit der aktuellen Wiedergabegeschwindigkeit multipliziert. Wenn deaktiviert, bleiben die Sprungintervalle unabhängig von der Wiedergabegeschwindigkeit konstant.
     Show Playback Rate Adjusted Timestamp: Wenn aktiviert und die Wiedergabegeschwindigkeit nicht 1x ist, zeigt der Player nach der normalen Zeitanzeige zusätzliche angepasste Zeitstempel in Klammern an.
     Show Skip Silence Toggle: Zeigt im Einstellungsmenü des Players einen Ein-/Aus-Schalter zum Überspringen von Stille an.
+    Enable Skip Silence by Default: Aktiviert „Stille überspringen“ für neue Tabs. Änderungen in einem Tab wirken sich nicht auf andere Tabs aus.
     Hold to Double Playback Speed: Halte die Leertaste oder die linke Maustaste über dem Player gedrückt, um die aktuelle Wiedergabegeschwindigkeit vorübergehend zu verdoppeln.
     Ambient Mode: Lässt die Farben des Videos in den Bereich um den Player ausstrahlen.
     Default Volume: Deaktiviert, wenn Lautstärke beibehalten aktiviert ist. Schalte Lautstärke beibehalten aus, um eine feste Lautstärke beim Start jedes Videos zu setzen.

--- a/static/locales/en-US.yaml
+++ b/static/locales/en-US.yaml
@@ -858,6 +858,7 @@ Settings:
     Remember Volume: Remember Volume
     Skip Silence: Skip Silence
     Show Skip Silence Toggle: Show Skip Silence Toggle
+    Enable Skip Silence by Default: Enable Skip Silence by Default
     Enable Video Zoom: Enable Video Zoom
     Voice-over Translation:
       Title: Voice-over translation
@@ -2122,6 +2123,7 @@ Tooltips:
     Use YouTube-style Shorts: Displays Shorts in a portrait grid on subscription and channel pages and uses the YouTube-style Shorts player.
     Loop Shorts: When enabled, Shorts restart automatically. When disabled, Shorts stop at the end and show a replay button.
     Show Skip Silence Toggle: Shows an on/off toggle for skipping silence in the player's settings menu.
+    Enable Skip Silence by Default: Enables silence skipping for new tabs. Changing it in one tab does not affect other tabs.
     Enable Video Zoom: Shows the Zoom control in the player's settings menu and enables its keyboard shortcuts and panning controls.
     Voice-over Translation: Sends the video ID, duration, and selected language to the unofficial Yandex voice-over translation service when you request a translation. Disabled by default.
     Hold to Double Playback Speed: Hold the Spacebar or left mouse button over the player to temporarily double the current playback speed.


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Make sure to follow the contributing guidelines. -->
<!-- Important note, we may remove your pull request if you do not use this provided PR template correctly. -->
<!-- Agent instructions: Preserve every heading, comment, and marker in this template. Never remove or rewrite the release-note-category:start/end, release-note:start/end, or release-note-image:start/end marker pairs. Never remove or rewrite the Release note images section; leave its contents for a human. -->

## Pull Request Type
<!-- Please select what type of pull request this is: [x] -->
- [ ] Bugfix
- [x] Feature Implementation
- [ ] Documentation
- [ ] Other

## Related issue
<!-- Please link the issue your pull request is referring to. -->
<!-- If this pull request fully resolves the relevant issue, put "closes" before the issue number. -->
<!-- Example: "closes #123456". -->

Closes #893.

## Description
<!-- Please write a clear and concise description of what the pull request does. -->

Skip Silence currently starts disabled whenever a user opens a new tab, even if they enable it for most videos.

This adds an "Enable Skip Silence by Default" player setting. The main process applies it to every newly created tab, including the initial tab and tabs opened from menus, shortcuts, links, or new windows. Existing tabs keep their own Skip Silence state, so changing one tab does not affect another.

The default control stays disabled while the Skip Silence player-menu control is hidden. English and German translations are included; Weblate remains responsible for other locales.

## Release note category
<!-- Select exactly one category. Every pull request must select one. -->
<!-- Select "Not noteworthy" when the pull request fixes a bug in or improves functionality that has not yet appeared in a stable release. -->
<!-- release-note-category:start -->
- [ ] Not noteworthy
- [ ] Highlights
- [x] More improvements
- [ ] Fixed bugs
<!-- release-note-category:end -->

## Release note
<!-- Required unless "Not noteworthy" is selected. -->
<!-- Write one concise, user-facing entry without a leading bullet. -->
<!-- release-note:start -->
New tabs can now start with Skip Silence enabled while each tab keeps its own choice.
<!-- release-note:end -->

## Release note images
<!-- Human-only: Agents must preserve this entire section and leave it empty. -->
<!-- Optional. Paste one or more Markdown images or HTML image tags here. -->
<!-- The release notes will use an HTML image tag and limit images taller than 300 pixels. -->
<!-- release-note-image:start -->

<!-- release-note-image:end -->

## Testing
<!-- How can reviewers verify that the PR produces correct results? -->
<!-- Please provide instructions so that others can ensure that your pull request would produce correct results. For examples see, https://github.com/FreeTubeApp/FreeTube/pull/5743, https://github.com/FreeTubeApp/FreeTube/pull/7349, https://github.com/FreeTubeApp/FreeTube/pull/5125, https://github.com/FreeTubeApp/FreeTube/pull/7338 -->
<!-- Agent instructions: Only write human-facing steps that explain how to verify the change while running this branch in dev mode. Include expected results and, when applicable, helpful console snippets for interactive verification. Do not include automated checks, commands, results, pass counts, or CI status. -->

1. Open Settings > Playback and enable both "Show Skip Silence Toggle" and "Enable Skip Silence by Default".
2. Open a video in a new tab and confirm Skip Silence starts enabled.
3. Disable Skip Silence in that tab, switch to another tab, and confirm the other tab's state is unchanged.
4. Disable the global default, open another tab, and confirm the new tab starts with Skip Silence disabled while existing tabs retain their choices.

## Additional context
<!-- Add any other context about the pull request here. -->

The renderer cannot provide a Skip Silence value when creating a tab. The main process owns the saved default and updates its cached value when either related setting changes.
