### PR TITLE
feat: add a controllable download queue and Downloads shortcut

### DIFF
--- a/e2e/helpers/app.mjs
+++ b/e2e/helpers/app.mjs
@@ -52,6 +52,7 @@ export function latestSettings(contents) {
  * @param {object[]} [seed.subscriptionCache] subscription-cache.db documents
  * @param {object[]} [seed.tabSessions] tab-session.db documents
  * @param {object[]} [seed.watchStats] watch-stats.db documents
+ * @param {object[]} [seed.downloads] persisted downloads
  */
 export async function createUserDataDir(seed = {}) {
   const userDataDir = await mkdtemp(path.join(tmpdir(), 'opentubex-e2e-'))
@@ -75,6 +76,9 @@ export async function createUserDataDir(seed = {}) {
     if (docs?.length) {
       await writeFile(path.join(userDataDir, `${store}.db`), toNedbFile(docs))
     }
+  }
+  if (seed.downloads?.length) {
+    await writeFile(path.join(userDataDir, 'downloads.json'), JSON.stringify(seed.downloads))
   }
 
   return userDataDir

--- a/e2e/tests/offline/download-queue.spec.mjs
+++ b/e2e/tests/offline/download-queue.spec.mjs
@@ -1,4 +1,4 @@
-import { chmod, readFile, writeFile } from 'node:fs/promises'
+import { chmod, readFile, readdir, writeFile } from 'node:fs/promises'
 import path from 'node:path'
 
 import { test, expect, goTo } from '../../helpers/app.mjs'
@@ -87,6 +87,7 @@ test('controls queue order, running jobs, bandwidth, and retry-all', async ({ ap
   await chmod(executable, 0o755)
   await configureQueue(page, {
     ytDlpPath: executable,
+    ytDlpDownloadFolderPath: app.userDataDir,
     ytDlpMaxConcurrentDownloads: 1,
     ytDlpDownloadBandwidthLimit: '900',
   })
@@ -101,6 +102,9 @@ test('controls queue order, running jobs, bandwidth, and retry-all', async ({ ap
   const results = await submitDownloads(page, payloads)
   expect(results.every(result => Number.isInteger(result?.id))).toBe(true)
   await expect.poll(() => readFile(startsFile, 'utf8').catch(() => '')).toBe('aaaaaaaaaaa\n')
+  await expect.poll(async () => (
+    (await readdir(app.userDataDir)).filter(name => name.startsWith('.opentubex-download-')).length
+  )).toBe(1)
 
   await goTo(page, 'downloads')
   const first = page.locator('.downloadRow').filter({ hasText: 'First queued download' })
@@ -168,7 +172,7 @@ test('controls queue order, running jobs, bandwidth, and retry-all', async ({ ap
   await expect(completed).not.toContainText('Download complete')
 })
 
-test('keeps the unsupported active-pause fallback resumable after completion', async ({ app, page }) => {
+test('keeps the unsupported active-pause fallback resumable', async ({ app, page }) => {
   const executable = path.join(app.userDataDir, 'fallback-pause-yt-dlp.sh')
   const startsFile = path.join(app.userDataDir, 'fallback-pause-starts.txt')
   await writeFile(executable, [
@@ -181,30 +185,54 @@ test('keeps the unsupported active-pause fallback resumable after completion', a
   await chmod(executable, 0o755)
   await configureQueue(page, { ytDlpPath: executable, ytDlpMaxConcurrentDownloads: 1 })
 
+  const originalPlatform = await app.electronApp.evaluate(() => process.platform)
+  async function pauseWithoutProcessSupport(id) {
+    await app.electronApp.evaluate((_electron, platform) => {
+      Object.defineProperty(process, 'platform', { configurable: true, value: platform })
+    }, 'win32')
+    try {
+      await expect.poll(async () => {
+        await page.bringToFront()
+        return page.evaluate(downloadId => window.ftElectron.ytDlpControlDownload(downloadId, 'pause'), id)
+      }).toBe(true)
+    } finally {
+      await app.electronApp.evaluate((_electron, platform) => {
+        Object.defineProperty(process, 'platform', { configurable: true, value: platform })
+      }, originalPlatform)
+    }
+  }
+
   const [active] = await submitDownloads(page, [
     { videoId: 'kkkkkkkkkkk', title: 'Fallback active download', mode: 'video' },
   ])
   await expect.poll(() => readFile(startsFile, 'utf8').catch(() => '')).toBe('kkkkkkkkkkk\n')
 
-  const originalPlatform = await app.electronApp.evaluate(() => process.platform)
-  await app.electronApp.evaluate((_electron, platform) => {
-    Object.defineProperty(process, 'platform', { configurable: true, value: platform })
-  }, 'win32')
-  try {
-    await expect.poll(async () => {
-      await page.bringToFront()
-      return page.evaluate(id => window.ftElectron.ytDlpControlDownload(id, 'pause'), active.id)
-    }).toBe(true)
-  } finally {
-    await app.electronApp.evaluate((_electron, platform) => {
-      Object.defineProperty(process, 'platform', { configurable: true, value: platform })
-    }, originalPlatform)
-  }
-
-  await writeFile(path.join(app.userDataDir, 'release-kkkkkkkkkkk'), '')
+  await pauseWithoutProcessSupport(active.id)
+  await expect.poll(async () => {
+    await page.bringToFront()
+    return page.evaluate(id => window.ftElectron.ytDlpControlDownload(id, 'resume'), active.id)
+  }).toBe(true)
+  const resumedVideoId = 'nnnnnnnnnnn'
+  const [resumedPending] = await submitDownloads(page, [
+    { videoId: resumedVideoId, title: 'Pending after fallback resume', mode: 'video' },
+  ])
   await expect.poll(() => page.evaluate(async id => (
     (await window.ftElectron.ytDlpListDownloads()).find(download => download.id === id)?.status
-  ), active.id)).toBe('completed')
+  ), resumedPending.id)).toBe('queued')
+
+  await writeFile(path.join(app.userDataDir, 'release-kkkkkkkkkkk'), '')
+  await expect.poll(() => readFile(startsFile, 'utf8')).toContain(`${resumedVideoId}\n`)
+  await writeFile(path.join(app.userDataDir, `release-${resumedVideoId}`), '')
+
+  const [completedPause] = await submitDownloads(page, [
+    { videoId: 'ooooooooooo', title: 'Completed fallback pause', mode: 'video' },
+  ])
+  await expect.poll(() => readFile(startsFile, 'utf8')).toContain('ooooooooooo\n')
+  await pauseWithoutProcessSupport(completedPause.id)
+  await writeFile(path.join(app.userDataDir, 'release-ooooooooooo'), '')
+  await expect.poll(() => page.evaluate(async id => (
+    (await window.ftElectron.ytDlpListDownloads()).find(download => download.id === id)?.status
+  ), completedPause.id)).toBe('completed')
 
   await submitDownloads(page, [
     { videoId: 'lllllllllll', title: 'Fallback paused download', mode: 'video' },
@@ -213,7 +241,7 @@ test('keeps the unsupported active-pause fallback resumable after completion', a
   const paused = page.locator('.downloadRow').filter({ hasText: 'Fallback paused download' })
   await expect(paused).toContainText('Paused')
   await clickUntil(page, page.getByRole('button', { name: 'Resume all' }), async () => (
-    await readFile(startsFile, 'utf8').catch(() => '') === 'kkkkkkkkkkk\nlllllllllll\n'
+    (await readFile(startsFile, 'utf8').catch(() => '')).endsWith('lllllllllll\n')
   ))
   await writeFile(path.join(app.userDataDir, 'release-lllllllllll'), '')
 })

--- a/e2e/tests/offline/download-queue.spec.mjs
+++ b/e2e/tests/offline/download-queue.spec.mjs
@@ -224,6 +224,19 @@ test('keeps the unsupported active-pause fallback resumable', async ({ app, page
   await expect.poll(() => readFile(startsFile, 'utf8')).toContain(`${resumedVideoId}\n`)
   await writeFile(path.join(app.userDataDir, `release-${resumedVideoId}`), '')
 
+  const [resumeAllActive] = await submitDownloads(page, [
+    { videoId: 'ppppppppppp', title: 'Resume-all fallback download', mode: 'video' },
+  ])
+  await expect.poll(() => readFile(startsFile, 'utf8')).toContain('ppppppppppp\n')
+  await pauseWithoutProcessSupport(resumeAllActive.id)
+  await goTo(page, 'downloads')
+  await clickUntil(page, page.getByRole('button', { name: 'Resume all' }), async () => (
+    (await page.evaluate(async id => (
+      (await window.ftElectron.ytDlpListDownloads()).find(download => download.id === id)?.status
+    ), resumeAllActive.id)) === 'downloading'
+  ))
+  await writeFile(path.join(app.userDataDir, 'release-ppppppppppp'), '')
+
   const [completedPause] = await submitDownloads(page, [
     { videoId: 'ooooooooooo', title: 'Completed fallback pause', mode: 'video' },
   ])

--- a/e2e/tests/offline/download-queue.spec.mjs
+++ b/e2e/tests/offline/download-queue.spec.mjs
@@ -123,6 +123,21 @@ test('controls queue order, running jobs, bandwidth, and retry-all', async ({ ap
   ))
   await expect(first).toContainText('Paused')
   await expect(second).toContainText('Paused')
+  await clickUntil(page, moved.getByTitle('Resume Download'), async () => (
+    (await moved.textContent()).includes('Queued, position 1')
+  ))
+  const [submittedWhilePaused] = await submitDownloads(page, [
+    { videoId: 'mmmmmmmmmmm', title: 'Submitted while paused', mode: 'video' },
+  ])
+  await expect.poll(() => page.evaluate(async id => (
+    (await window.ftElectron.ytDlpListDownloads()).find(download => download.id === id)?.status
+  ), submittedWhilePaused.id)).toBe('paused')
+  const submittedWhilePausedRow = page.locator('.downloadRow').filter({ hasText: 'Submitted while paused' })
+  await clickUntil(page, submittedWhilePausedRow.getByTitle('Cancel Download'), async () => (
+    (await page.evaluate(async id => (
+      (await window.ftElectron.ytDlpListDownloads()).find(download => download.id === id)?.status
+    ), submittedWhilePaused.id)) === 'cancelled'
+  ))
   await clickUntil(page, page.getByRole('button', { name: 'Resume all' }), async () => (
     (await first.textContent()).includes('0.0%')
   ))

--- a/e2e/tests/offline/download-queue.spec.mjs
+++ b/e2e/tests/offline/download-queue.spec.mjs
@@ -1,0 +1,198 @@
+import { chmod, readFile, writeFile } from 'node:fs/promises'
+import path from 'node:path'
+
+import { test, expect, goTo } from '../../helpers/app.mjs'
+
+async function configureQueue(page, values) {
+  await page.evaluate(async (settings) => {
+    const store = document.querySelector('#app').__vue_app__.config.globalProperties.$store
+    for (const [key, value] of Object.entries(settings)) {
+      await store.dispatch(`update${key[0].toUpperCase()}${key.slice(1)}`, value)
+    }
+  }, values)
+  await page.bringToFront()
+  await page.locator('body').click({ position: { x: 1, y: 1 } })
+}
+
+async function submitDownloads(page, downloads) {
+  return page.evaluate((payloads) => Promise.all(payloads.map(payload => window.ftElectron.ytDlpDownload(payload))), downloads)
+}
+
+test('opens downloads with the default shortcut', async ({ page }) => {
+  await page.keyboard.press('Control+J')
+  await expect(page.getByRole('dialog', { name: 'Downloads', exact: true })).toBeVisible()
+})
+
+test('separates canceled downloads without offering retry-all', async ({ page }) => {
+  await page.evaluate(() => {
+    const store = document.querySelector('#app').__vue_app__.config.globalProperties.$store
+    store.commit('upsertYtDlpDownload', {
+      id: 999,
+      title: 'Canceled queue download',
+      mode: 'video',
+      status: 'cancelled',
+      retryPayload: { videoId: 'iiiiiiiiiii', title: 'Canceled queue download', mode: 'video' },
+      destinations: [],
+      files: [],
+    })
+  })
+
+  await goTo(page, 'downloads')
+  await expect(page.getByRole('button', { name: 'Retry all failed downloads' })).toHaveCount(0)
+  const canceledSection = page.locator('.downloadSection').filter({
+    has: page.getByRole('heading', { name: 'Canceled', exact: true })
+  })
+  await expect(canceledSection).toContainText('Canceled queue download')
+  await expect(canceledSection).not.toContainText('Download canceled')
+  await expect(page.getByRole('heading', { name: 'Downloaded', exact: true })).toHaveCount(0)
+})
+
+test('controls queue order, running jobs, bandwidth, and retry-all', async ({ app, page }) => {
+  const executable = path.join(app.userDataDir, 'queued-yt-dlp.sh')
+  const startsFile = path.join(app.userDataDir, 'queue-starts.txt')
+  const failureMarker = path.join(app.userDataDir, 'failed-once')
+  await writeFile(executable, [
+    '#!/bin/sh',
+    'for argument do case "$argument" in https://www.youtube.com/watch?v=*) url="$argument" ;; esac; done',
+    'id="$' + '{url##*=}"',
+    `printf '%s\\n' "$id" >> '${startsFile}'`,
+    `printf '%s\\n' "$@" > "${app.userDataDir}/args-$id.txt"`,
+    `if [ "$id" = 'ddddddddddd' ] && [ ! -f '${failureMarker}' ]; then`,
+    `  touch '${failureMarker}'`,
+    '  exit 1',
+    'fi',
+    `while [ ! -f "${app.userDataDir}/release-$id" ]; do sleep 0.05; done`,
+  ].join('\n'))
+  await chmod(executable, 0o755)
+  await configureQueue(page, {
+    ytDlpPath: executable,
+    ytDlpMaxConcurrentDownloads: 1,
+    ytDlpDownloadBandwidthLimit: '900',
+  })
+
+  const payloads = [
+    { videoId: 'aaaaaaaaaaa', title: 'First queued download', mode: 'video' },
+    { videoId: 'bbbbbbbbbbb', title: 'Second queued download', mode: 'video' },
+    { videoId: 'ccccccccccc', title: 'Moved queue download', mode: 'video' },
+    { videoId: 'ddddddddddd', title: 'Retry-all download', mode: 'video' },
+    { videoId: 'jjjjjjjjjjj', title: 'Canceled download', mode: 'video' },
+  ]
+  const results = await submitDownloads(page, payloads)
+  expect(results.every(result => Number.isInteger(result?.id))).toBe(true)
+  await expect.poll(() => readFile(startsFile, 'utf8').catch(() => '')).toBe('aaaaaaaaaaa\n')
+
+  await goTo(page, 'downloads')
+  const first = page.locator('.downloadRow').filter({ hasText: 'First queued download' })
+  const second = page.locator('.downloadRow').filter({ hasText: 'Second queued download' })
+  const moved = page.locator('.downloadRow').filter({ hasText: 'Moved queue download' })
+  const canceled = page.locator('.downloadRow').filter({ hasText: 'Canceled download' })
+  await expect(first).toContainText('0.0%')
+  await expect(second).toContainText(/Queued, position/)
+  await moved.getByTitle('Move earlier').click()
+  await expect(moved).toContainText('Queued, position 1')
+  await expect(second.getByTitle('Move later')).toBeVisible()
+  await canceled.getByTitle('Cancel Download').click()
+  await expect(canceled).not.toContainText('Download canceled')
+  await expect(page.getByRole('heading', { name: 'Canceled', exact: true })).toBeVisible()
+
+  await page.getByRole('button', { name: 'Pause all' }).click()
+  await expect(first).toContainText('Paused')
+  await expect(second).toContainText('Paused')
+  await page.getByRole('button', { name: 'Resume all' }).click()
+  await expect(first).toContainText('0.0%')
+
+  await writeFile(path.join(app.userDataDir, 'release-aaaaaaaaaaa'), '')
+  await expect.poll(() => readFile(startsFile, 'utf8')).toBe('aaaaaaaaaaa\nccccccccccc\n')
+  const movedDownloadArgs = (await readFile(path.join(app.userDataDir, 'args-ccccccccccc.txt'), 'utf8')).split('\n')
+  const rateIndex = movedDownloadArgs.indexOf('--limit-rate')
+  expect(movedDownloadArgs[rateIndex + 1]).toBe('900K')
+
+  await writeFile(path.join(app.userDataDir, 'release-ccccccccccc'), '')
+  await expect.poll(() => readFile(startsFile, 'utf8')).toContain('bbbbbbbbbbb')
+  await writeFile(path.join(app.userDataDir, 'release-bbbbbbbbbbb'), '')
+  await expect.poll(() => readFile(startsFile, 'utf8')).toContain('ddddddddddd')
+  await expect(page.locator('.downloadRow').filter({ hasText: 'Retry-all download' })).toContainText('Download failed')
+
+  await page.getByRole('button', { name: 'Retry all failed downloads' }).click()
+  await expect.poll(() => readFile(startsFile, 'utf8')).toMatch(/ddddddddddd\nddddddddddd\n$/)
+  await expect.poll(() => page.evaluate(async id => (
+    (await window.ftElectron.ytDlpListDownloads()).find(download => download.id === id)?.status
+  ), results[4].id)).toBe('cancelled')
+  await writeFile(path.join(app.userDataDir, 'release-ddddddddddd'), '')
+  await expect.poll(() => page.evaluate(async () => (
+    (await window.ftElectron.ytDlpListDownloads()).find(download => download.title === 'Retry-all download')?.status
+  ))).toBe('completed')
+  const completed = page.locator('.downloadRow').filter({ hasText: 'Retry-all download' })
+  await expect(completed).not.toContainText('Download complete')
+})
+
+test('keeps paused downloads queued across a restart', async ({ app, page }) => {
+  const executable = path.join(app.userDataDir, 'persisted-yt-dlp.sh')
+  const startsFile = path.join(app.userDataDir, 'persisted-starts.txt')
+  await writeFile(executable, [
+    '#!/bin/sh',
+    'for argument do case "$argument" in https://www.youtube.com/watch?v=*) url="$argument" ;; esac; done',
+    'id="$' + '{url##*=}"',
+    `printf '%s\\n' "$id" >> '${startsFile}'`,
+    `while [ ! -f "${app.userDataDir}/release-$id" ]; do sleep 0.05; done`,
+  ].join('\n'))
+  await chmod(executable, 0o755)
+
+  await configureQueue(page, {
+    ytDlpPath: executable,
+    ytDlpMaxConcurrentDownloads: 1,
+  })
+  const queued = await submitDownloads(page, [
+    { videoId: 'eeeeeeeeeee', title: 'Persisted queue one', mode: 'video' },
+    { videoId: 'fffffffffff', title: 'Persisted queue two', mode: 'video' },
+  ])
+  await expect.poll(() => readFile(startsFile, 'utf8').catch(() => '')).toBe('eeeeeeeeeee\n')
+  await page.evaluate(id => window.ftElectron.ytDlpControlDownload(id, 'pause'), queued[1].id)
+  await expect.poll(() => page.evaluate(async () => (
+    (await window.ftElectron.ytDlpListDownloads()).find(download => download.title === 'Persisted queue two')?.status
+  ))).toBe('paused')
+  await writeFile(path.join(app.userDataDir, 'release-eeeeeeeeeee'), '')
+  await expect.poll(() => page.evaluate(async () => (
+    (await window.ftElectron.ytDlpListDownloads()).find(download => download.title === 'Persisted queue one')?.status
+  ))).toBe('completed')
+
+  ;({ page } = await app.relaunch())
+  await expect.poll(() => readFile(startsFile, 'utf8').catch(() => '')).toBe('eeeeeeeeeee\n')
+  await goTo(page, 'downloads')
+  const paused = page.locator('.downloadRow').filter({ hasText: 'Persisted queue two' })
+  await expect(paused).toContainText('Paused')
+  await page.getByRole('button', { name: 'Resume all' }).click()
+  await expect.poll(() => readFile(startsFile, 'utf8').catch(() => '')).toBe('eeeeeeeeeee\nfffffffffff\n')
+  await writeFile(path.join(app.userDataDir, 'release-fffffffffff'), '')
+})
+
+test('checks destination space before starting a download', async ({ app, page }) => {
+  const executable = path.join(app.userDataDir, 'space-check-yt-dlp.sh')
+  const startsFile = path.join(app.userDataDir, 'space-check-starts.txt')
+  await writeFile(executable, [
+    '#!/bin/sh',
+    'for argument do case "$argument" in https://www.youtube.com/watch?v=*) url="$argument" ;; esac; done',
+    'id="$' + '{url##*=}"',
+    `printf '%s\\n' "$id" >> '${startsFile}'`,
+    `while [ ! -f "${app.userDataDir}/release-$id" ]; do sleep 0.05; done`,
+  ].join('\n'))
+  await chmod(executable, 0o755)
+  await configureQueue(page, { ytDlpPath: executable, ytDlpMaxConcurrentDownloads: 1 })
+
+  const [oversized] = await submitDownloads(page, [{
+    videoId: 'ggggggggggg',
+    title: 'Known oversized download',
+    mode: 'video',
+    estimatedSizeBytes: Number.MAX_SAFE_INTEGER,
+  }])
+  await expect.poll(() => page.evaluate(async id => (
+    (await window.ftElectron.ytDlpListDownloads()).find(download => download.id === id)?.errorMessage
+  ), oversized.id)).toBe('INSUFFICIENT_SPACE')
+  expect(await readFile(startsFile, 'utf8').catch(() => '')).toBe('')
+
+  await submitDownloads(page, [{ videoId: 'hhhhhhhhhhh', title: 'Unknown size download', mode: 'video' }])
+  await expect.poll(() => readFile(startsFile, 'utf8').catch(() => '')).toBe('hhhhhhhhhhh\n')
+  await goTo(page, 'downloads')
+  await expect(page.locator('.downloadRow').filter({ hasText: 'Unknown size download' })).toContainText('Download size is unknown')
+  await writeFile(path.join(app.userDataDir, 'release-hhhhhhhhhhh'), '')
+})

--- a/e2e/tests/offline/download-queue.spec.mjs
+++ b/e2e/tests/offline/download-queue.spec.mjs
@@ -303,6 +303,34 @@ test('keeps paused downloads queued across a restart', async ({ app, page }) => 
   await writeFile(path.join(app.userDataDir, 'release-fffffffffff'), '')
 })
 
+test.describe('persisted queue with downloads disabled', () => {
+  const persistedDownload = {
+    id: 1,
+    videoId: 'qqqqqqqqqqq',
+    title: 'Disabled persisted download',
+    mode: 'video',
+    template: '',
+    retryPayload: { videoId: 'qqqqqqqqqqq', title: 'Disabled persisted download', mode: 'video' },
+    status: 'queued',
+    queuePosition: 1,
+    percent: 0,
+    speed: null,
+    eta: null,
+    destination: null,
+    destinations: [],
+    files: [],
+    errorMessage: null,
+  }
+  test.use({ seed: { settings: { enableDownloads: false }, downloads: [persistedDownload] } })
+
+  test('keeps persisted downloads queued while downloads are disabled', async ({ page }) => {
+    await expect.poll(() => page.evaluate(async id => {
+      const downloads = await window.ftElectron.ytDlpListDownloads()
+      return downloads.find(download => download.id === id)
+    }, persistedDownload.id)).toMatchObject({ status: 'queued', errorMessage: null })
+  })
+})
+
 test('checks destination space before starting a download', async ({ app, page }) => {
   const executable = path.join(app.userDataDir, 'space-check-yt-dlp.sh')
   const startsFile = path.join(app.userDataDir, 'space-check-starts.txt')

--- a/e2e/tests/offline/download-queue.spec.mjs
+++ b/e2e/tests/offline/download-queue.spec.mjs
@@ -15,7 +15,28 @@ async function configureQueue(page, values) {
 }
 
 async function submitDownloads(page, downloads) {
-  return page.evaluate((payloads) => Promise.all(payloads.map(payload => window.ftElectron.ytDlpDownload(payload))), downloads)
+  const results = []
+  for (const download of downloads) {
+    let result = null
+    await expect.poll(async () => {
+      await page.bringToFront()
+      result = await page.evaluate(payload => window.ftElectron.ytDlpDownload(payload), download)
+      return result !== null
+    }).toBe(true)
+    results.push(result)
+  }
+  return results
+}
+
+async function clickUntil(page, button, isComplete) {
+  await expect.poll(async () => {
+    if (await isComplete()) return true
+    if (await button.isVisible()) {
+      await page.bringToFront()
+      await button.click()
+    }
+    return isComplete()
+  }).toBe(true)
 }
 
 test('opens downloads with the default shortcut', async ({ page }) => {
@@ -88,18 +109,23 @@ test('controls queue order, running jobs, bandwidth, and retry-all', async ({ ap
   const canceled = page.locator('.downloadRow').filter({ hasText: 'Canceled download' })
   await expect(first).toContainText('0.0%')
   await expect(second).toContainText(/Queued, position/)
-  await moved.getByTitle('Move earlier').click()
-  await expect(moved).toContainText('Queued, position 1')
+  await clickUntil(page, moved.getByTitle('Move earlier'), async () => (
+    (await moved.textContent()).includes('Queued, position 1')
+  ))
   await expect(second.getByTitle('Move later')).toBeVisible()
-  await canceled.getByTitle('Cancel Download').click()
+  await clickUntil(page, canceled.getByTitle('Cancel Download'), () => (
+    page.getByRole('heading', { name: 'Canceled', exact: true }).isVisible()
+  ))
   await expect(canceled).not.toContainText('Download canceled')
-  await expect(page.getByRole('heading', { name: 'Canceled', exact: true })).toBeVisible()
 
-  await page.getByRole('button', { name: 'Pause all' }).click()
+  await clickUntil(page, page.getByRole('button', { name: 'Pause all' }), async () => (
+    (await first.textContent()).includes('Paused') && (await second.textContent()).includes('Paused')
+  ))
   await expect(first).toContainText('Paused')
   await expect(second).toContainText('Paused')
-  await page.getByRole('button', { name: 'Resume all' }).click()
-  await expect(first).toContainText('0.0%')
+  await clickUntil(page, page.getByRole('button', { name: 'Resume all' }), async () => (
+    (await first.textContent()).includes('0.0%')
+  ))
 
   await writeFile(path.join(app.userDataDir, 'release-aaaaaaaaaaa'), '')
   await expect.poll(() => readFile(startsFile, 'utf8')).toBe('aaaaaaaaaaa\nccccccccccc\n')
@@ -113,8 +139,9 @@ test('controls queue order, running jobs, bandwidth, and retry-all', async ({ ap
   await expect.poll(() => readFile(startsFile, 'utf8')).toContain('ddddddddddd')
   await expect(page.locator('.downloadRow').filter({ hasText: 'Retry-all download' })).toContainText('Download failed')
 
-  await page.getByRole('button', { name: 'Retry all failed downloads' }).click()
-  await expect.poll(() => readFile(startsFile, 'utf8')).toMatch(/ddddddddddd\nddddddddddd\n$/)
+  await clickUntil(page, page.getByRole('button', { name: 'Retry all failed downloads' }), async () => (
+    /ddddddddddd\nddddddddddd\n$/.test(await readFile(startsFile, 'utf8'))
+  ))
   await expect.poll(() => page.evaluate(async id => (
     (await window.ftElectron.ytDlpListDownloads()).find(download => download.id === id)?.status
   ), results[4].id)).toBe('cancelled')
@@ -124,6 +151,56 @@ test('controls queue order, running jobs, bandwidth, and retry-all', async ({ ap
   ))).toBe('completed')
   const completed = page.locator('.downloadRow').filter({ hasText: 'Retry-all download' })
   await expect(completed).not.toContainText('Download complete')
+})
+
+test('keeps the unsupported active-pause fallback resumable after completion', async ({ app, page }) => {
+  const executable = path.join(app.userDataDir, 'fallback-pause-yt-dlp.sh')
+  const startsFile = path.join(app.userDataDir, 'fallback-pause-starts.txt')
+  await writeFile(executable, [
+    '#!/bin/sh',
+    'for argument do case "$argument" in https://www.youtube.com/watch?v=*) url="$argument" ;; esac; done',
+    'id="$' + '{url##*=}"',
+    `printf '%s\\n' "$id" >> '${startsFile}'`,
+    `while [ ! -f "${app.userDataDir}/release-$id" ]; do sleep 0.05; done`,
+  ].join('\n'))
+  await chmod(executable, 0o755)
+  await configureQueue(page, { ytDlpPath: executable, ytDlpMaxConcurrentDownloads: 1 })
+
+  const [active] = await submitDownloads(page, [
+    { videoId: 'kkkkkkkkkkk', title: 'Fallback active download', mode: 'video' },
+  ])
+  await expect.poll(() => readFile(startsFile, 'utf8').catch(() => '')).toBe('kkkkkkkkkkk\n')
+
+  const originalPlatform = await app.electronApp.evaluate(() => process.platform)
+  await app.electronApp.evaluate((_electron, platform) => {
+    Object.defineProperty(process, 'platform', { configurable: true, value: platform })
+  }, 'win32')
+  try {
+    await expect.poll(async () => {
+      await page.bringToFront()
+      return page.evaluate(id => window.ftElectron.ytDlpControlDownload(id, 'pause'), active.id)
+    }).toBe(true)
+  } finally {
+    await app.electronApp.evaluate((_electron, platform) => {
+      Object.defineProperty(process, 'platform', { configurable: true, value: platform })
+    }, originalPlatform)
+  }
+
+  await writeFile(path.join(app.userDataDir, 'release-kkkkkkkkkkk'), '')
+  await expect.poll(() => page.evaluate(async id => (
+    (await window.ftElectron.ytDlpListDownloads()).find(download => download.id === id)?.status
+  ), active.id)).toBe('completed')
+
+  await submitDownloads(page, [
+    { videoId: 'lllllllllll', title: 'Fallback paused download', mode: 'video' },
+  ])
+  await goTo(page, 'downloads')
+  const paused = page.locator('.downloadRow').filter({ hasText: 'Fallback paused download' })
+  await expect(paused).toContainText('Paused')
+  await clickUntil(page, page.getByRole('button', { name: 'Resume all' }), async () => (
+    await readFile(startsFile, 'utf8').catch(() => '') === 'kkkkkkkkkkk\nlllllllllll\n'
+  ))
+  await writeFile(path.join(app.userDataDir, 'release-lllllllllll'), '')
 })
 
 test('keeps paused downloads queued across a restart', async ({ app, page }) => {
@@ -147,7 +224,10 @@ test('keeps paused downloads queued across a restart', async ({ app, page }) => 
     { videoId: 'fffffffffff', title: 'Persisted queue two', mode: 'video' },
   ])
   await expect.poll(() => readFile(startsFile, 'utf8').catch(() => '')).toBe('eeeeeeeeeee\n')
-  await page.evaluate(id => window.ftElectron.ytDlpControlDownload(id, 'pause'), queued[1].id)
+  await expect.poll(async () => {
+    await page.bringToFront()
+    return page.evaluate(id => window.ftElectron.ytDlpControlDownload(id, 'pause'), queued[1].id)
+  }).toBe(true)
   await expect.poll(() => page.evaluate(async () => (
     (await window.ftElectron.ytDlpListDownloads()).find(download => download.title === 'Persisted queue two')?.status
   ))).toBe('paused')
@@ -161,8 +241,9 @@ test('keeps paused downloads queued across a restart', async ({ app, page }) => 
   await goTo(page, 'downloads')
   const paused = page.locator('.downloadRow').filter({ hasText: 'Persisted queue two' })
   await expect(paused).toContainText('Paused')
-  await page.getByRole('button', { name: 'Resume all' }).click()
-  await expect.poll(() => readFile(startsFile, 'utf8').catch(() => '')).toBe('eeeeeeeeeee\nfffffffffff\n')
+  await clickUntil(page, page.getByRole('button', { name: 'Resume all' }), async () => (
+    await readFile(startsFile, 'utf8').catch(() => '') === 'eeeeeeeeeee\nfffffffffff\n'
+  ))
   await writeFile(path.join(app.userDataDir, 'release-fffffffffff'), '')
 })
 

--- a/e2e/tests/offline/download-queue.spec.mjs
+++ b/e2e/tests/offline/download-queue.spec.mjs
@@ -40,7 +40,12 @@ async function clickUntil(page, button, isComplete) {
 }
 
 test('opens downloads with the default shortcut', async ({ page }) => {
-  await page.keyboard.press('Control+J')
+  await expect.poll(async () => {
+    if (/#\/downloads$/.test(page.url())) return true
+    await page.bringToFront()
+    await page.keyboard.press('Control+J')
+    return /#\/downloads$/.test(page.url())
+  }).toBe(true)
   await expect(page.getByRole('dialog', { name: 'Downloads', exact: true })).toBeVisible()
 })
 
@@ -170,6 +175,55 @@ test('controls queue order, running jobs, bandwidth, and retry-all', async ({ ap
   ))).toBe('completed')
   const completed = page.locator('.downloadRow').filter({ hasText: 'Retry-all download' })
   await expect(completed).not.toContainText('Download complete')
+})
+
+test('clears pause-all after every download is individually resumed', async ({ app, page }) => {
+  const executable = path.join(app.userDataDir, 'individual-resume-yt-dlp.sh')
+  const startsFile = path.join(app.userDataDir, 'individual-resume-starts.txt')
+  await writeFile(executable, [
+    '#!/bin/sh',
+    'for argument do case "$argument" in https://www.youtube.com/watch?v=*) url="$argument" ;; esac; done',
+    'id="$' + '{url##*=}"',
+    `printf '%s\\n' "$id" >> '${startsFile}'`,
+    `while [ ! -f "${app.userDataDir}/release-$id" ]; do sleep 0.05; done`,
+  ].join('\n'))
+  await chmod(executable, 0o755)
+  await configureQueue(page, { ytDlpPath: executable, ytDlpMaxConcurrentDownloads: 1 })
+
+  const [active, pending] = await submitDownloads(page, [
+    { videoId: 'rrrrrrrrrrr', title: 'Individually resumed active download', mode: 'video' },
+    { videoId: 'sssssssssss', title: 'Individually resumed pending download', mode: 'video' },
+  ])
+  await expect.poll(() => readFile(startsFile, 'utf8').catch(() => '')).toBe('rrrrrrrrrrr\n')
+
+  await expect.poll(async () => {
+    await page.bringToFront()
+    return page.evaluate(() => window.ftElectron.ytDlpQueueAction('pause-all'))
+  }).toBe(true)
+  await expect.poll(() => page.evaluate(async ids => (
+    (await window.ftElectron.ytDlpListDownloads())
+      .filter(download => ids.includes(download.id))
+      .map(download => download.status)
+  ), [active.id, pending.id])).toEqual(['paused', 'paused'])
+
+  for (const download of [active, pending]) {
+    await expect.poll(async () => {
+      await page.bringToFront()
+      return page.evaluate(id => window.ftElectron.ytDlpControlDownload(id, 'resume'), download.id)
+    }).toBe(true)
+  }
+
+  const [submittedAfterResume] = await submitDownloads(page, [
+    { videoId: 'ttttttttttt', title: 'Submitted after individual resumes', mode: 'video' },
+  ])
+  await expect.poll(() => page.evaluate(async id => (
+    (await window.ftElectron.ytDlpListDownloads()).find(download => download.id === id)?.status
+  ), submittedAfterResume.id)).toBe('queued')
+
+  for (const videoId of ['rrrrrrrrrrr', 'sssssssssss', 'ttttttttttt']) {
+    await writeFile(path.join(app.userDataDir, `release-${videoId}`), '')
+    await expect.poll(() => readFile(startsFile, 'utf8')).toContain(`${videoId}\n`)
+  }
 })
 
 test('keeps the unsupported active-pause fallback resumable', async ({ app, page }) => {

--- a/e2e/tests/offline/settings.spec.mjs
+++ b/e2e/tests/offline/settings.spec.mjs
@@ -36,6 +36,36 @@ async function expectCompactCustomThemeEditor(page) {
   expect(spacing.bottom).toBeLessThanOrEqual(12)
 }
 
+async function expectDownloadQueueSettingsAlignment(page) {
+  const downloads = await goToSettingsSection(page, 'download')
+  const enableDownloads = downloads.getByRole('checkbox', { name: 'Enable Downloads' })
+  if (!await enableDownloads.isChecked()) {
+    await downloads.locator('label.switch-label').filter({ hasText: 'Enable Downloads' }).click()
+  }
+
+  const bounds = await downloads.evaluate(element => {
+    const pathInputs = element.querySelectorAll('.downloadPathInputs .ft-input')
+    const queueSelect = element.querySelector('.downloadQueueInputs .select-text')
+    const queueSelectLabel = element.querySelector('.downloadQueueInputs .select-label')
+    const bandwidthInput = element.querySelector('.downloadQueueInputs .ft-input')
+    const bandwidthLabel = element.querySelector('.downloadQueueInputs .selectLabel')
+
+    return {
+      folder: pathInputs[0].getBoundingClientRect().toJSON(),
+      customArguments: pathInputs[1].getBoundingClientRect().toJSON(),
+      queueSelect: queueSelect.getBoundingClientRect().toJSON(),
+      queueSelectLabel: queueSelectLabel.getBoundingClientRect().toJSON(),
+      bandwidthInput: bandwidthInput.getBoundingClientRect().toJSON(),
+      bandwidthLabel: bandwidthLabel.getBoundingClientRect().toJSON()
+    }
+  })
+
+  expect(Math.abs(bounds.folder.x - bounds.queueSelect.x)).toBeLessThanOrEqual(1)
+  expect(Math.abs(bounds.customArguments.x - bounds.bandwidthInput.x)).toBeLessThanOrEqual(1)
+  expect(Math.abs(bounds.queueSelect.y - bounds.bandwidthInput.y)).toBeLessThanOrEqual(1)
+  expect(Math.abs(bounds.queueSelectLabel.y - bounds.bandwidthLabel.y)).toBeLessThanOrEqual(1)
+}
+
 async function expectAlwaysVisibleScrollbarsToPreserveSettingsScroll(page) {
   await goToSettingsSection(page, 'appearance')
   const content = page.locator('.settingsContent')
@@ -571,6 +601,10 @@ test.describe('settings', () => {
     test('keeps the custom theme editor compact', async ({ page }) => {
       await expectCompactCustomThemeEditor(page)
     })
+
+    test('aligns the download queue controls with the other fields', async ({ page }) => {
+      await expectDownloadQueueSettingsAlignment(page)
+    })
   })
 
   test('caps the width of the download action buttons', async ({ page }) => {
@@ -586,6 +620,10 @@ test.describe('settings', () => {
       elements.map(element => element.getBoundingClientRect().width)
     ))
     expect(Math.max(...widths)).toBeLessThanOrEqual(300)
+  })
+
+  test('aligns the download queue controls with the other fields', async ({ page }) => {
+    await expectDownloadQueueSettingsAlignment(page)
   })
 
   test('hides the redundant Privacy heading and keeps the original Distraction Free headings', async ({ page }) => {

--- a/e2e/tests/offline/video-actions.spec.mjs
+++ b/e2e/tests/offline/video-actions.spec.mjs
@@ -821,7 +821,7 @@ test.describe('video downloads', () => {
     ])
     await goTo(page, 'downloads')
     await expect(page.getByRole('dialog', { name: 'Downloads', exact: true })).toBeVisible()
-    await expect(downloadRow).toContainText('Download unavailable')
+    await expect(downloadRow).not.toContainText('Download unavailable')
     await expect(downloadRow).toContainText('The downloaded file is no longer available on the filesystem.')
     await expect(downloadRow.getByTitle('Play download')).toHaveCount(0)
     await expect(downloadRow.getByTitle('Show in Folder')).toHaveCount(0)
@@ -1049,13 +1049,15 @@ test.describe('video downloads', () => {
     await expect(hydratedDownload).toContainText('0.0%')
 
     await hydratedDownload.getByTitle('Cancel Download').click()
-    await expect(otherDownload).toContainText('Download canceled')
+    await expect(otherWindow.getByRole('heading', { name: 'Canceled', exact: true })).toBeVisible()
+    await expect(otherDownload.getByTitle('Retry download')).toBeVisible()
+    await expect(otherDownload).not.toContainText('Download canceled')
 
     await hydratedDownload.getByTitle('Retry download').click()
     await expect(otherDownload).toContainText('0.0%')
     await expect(hydratedDownload.getByTitle('Cancel Download')).toBeVisible()
     await hydratedDownload.getByTitle('Cancel Download').click()
-    await expect(otherDownload).toContainText('Download canceled')
+    await expect(otherDownload.getByTitle('Retry download')).toBeVisible()
 
     await lateWindow.getByRole('button', { name: 'Clear failed, canceled, skipped, and missing' }).click()
     await expect(otherDownload).toHaveCount(0)

--- a/src/constants.js
+++ b/src/constants.js
@@ -139,6 +139,8 @@ const IpcChannels = {
 
   YT_DLP_DOWNLOAD: 'yt-dlp-download',
   YT_DLP_CANCEL_DOWNLOAD: 'yt-dlp-cancel-download',
+  YT_DLP_CONTROL_DOWNLOAD: 'yt-dlp-control-download',
+  YT_DLP_QUEUE_ACTION: 'yt-dlp-queue-action',
   YT_DLP_DOWNLOAD_STATUS: 'yt-dlp-download-status',
   YT_DLP_DOWNLOADS_REMOVED: 'yt-dlp-downloads-removed',
   YT_DLP_LIST_DOWNLOADS: 'yt-dlp-list-downloads',
@@ -288,6 +290,7 @@ const DefaultKeyboardShortcuts = {
       HISTORY_FORWARD_ALT_MAC: 'cmd+]',
       FULLSCREEN: 'f11',
       NAVIGATE_TO_SETTINGS: 'ctrl+,',
+      NAVIGATE_TO_DOWNLOADS: 'ctrl+J',
       NAVIGATE_TO_HISTORY: 'ctrl+H',
       NAVIGATE_TO_HISTORY_MAC: 'cmd+Y',
       NEW_WINDOW: 'ctrl+N',

--- a/src/main/downloadQueue.js
+++ b/src/main/downloadQueue.js
@@ -12,3 +12,15 @@ export function compareQueuedDownloads(left, right) {
   return (left.queuePosition ?? left.id) - (right.queuePosition ?? right.id) ||
     left.id - right.id
 }
+
+export function updatePendingDownloadStatuses(records, pendingIds, status) {
+  const updated = []
+  for (const id of pendingIds) {
+    const record = records.get(id)
+    if (record && ['queued', 'paused'].includes(record.status) && record.status !== status) {
+      record.status = status
+      updated.push(record)
+    }
+  }
+  return updated
+}

--- a/src/main/downloadQueue.js
+++ b/src/main/downloadQueue.js
@@ -1,0 +1,14 @@
+export function normalizeDownloadConcurrency(value) {
+  const parsed = Number.parseInt(value, 10)
+  return Number.isInteger(parsed) ? Math.min(Math.max(parsed, 1), 10) : 2
+}
+
+export function normalizeDownloadBandwidth(value) {
+  const parsed = Number.parseInt(value, 10)
+  return Number.isInteger(parsed) ? Math.min(Math.max(parsed, 0), 10_000_000) : 0
+}
+
+export function compareQueuedDownloads(left, right) {
+  return (left.queuePosition ?? left.id) - (right.queuePosition ?? right.id) ||
+    left.id - right.id
+}

--- a/src/main/downloadQueue.js
+++ b/src/main/downloadQueue.js
@@ -24,3 +24,10 @@ export function updatePendingDownloadStatuses(records, pendingIds, status) {
   }
   return updated
 }
+
+export function resumePendingDownload(record, pendingIds, individuallyResumedIds, queuePaused) {
+  if (record?.status !== 'paused' || !pendingIds.has(record.id)) return false
+  record.status = 'queued'
+  if (queuePaused) individuallyResumedIds.add(record.id)
+  return true
+}

--- a/src/main/downloadQueue.js
+++ b/src/main/downloadQueue.js
@@ -25,8 +25,8 @@ export function updatePendingDownloadStatuses(records, pendingIds, status) {
   return updated
 }
 
-export function resumePendingDownload(record, pendingIds, individuallyResumedIds, queuePaused) {
-  if (record?.status !== 'paused' || !pendingIds.has(record.id)) return false
+export function resumePendingDownload(record, individuallyResumedIds, queuePaused) {
+  if (record?.status !== 'paused') return false
   record.status = 'queued'
   if (queuePaused) individuallyResumedIds.add(record.id)
   return true

--- a/src/main/index.js
+++ b/src/main/index.js
@@ -44,7 +44,7 @@ import { brotliDecompress } from 'zlib'
 
 import packageDetails from '../../package.json'
 import { handleOpenInExternalPlayer } from './externalPlayer'
-import { getYtDlpDownloadFile, handleYtDlpCancelDownload, handleYtDlpCheckBinaryUpdate, handleYtDlpClearDownloads, handleYtDlpDownload, handleYtDlpDownloadBinary, handleYtDlpGetInfo, handleYtDlpGetPlaybackInfo, handleYtDlpGetRecommendations, handleYtDlpListDownloads, handleYtDlpOpenDownload, handleYtDlpRemoveDownload, shutdownYtDlpDownloads } from './ytDlp'
+import { getYtDlpDownloadFile, handleYtDlpCancelDownload, handleYtDlpCheckBinaryUpdate, handleYtDlpClearDownloads, handleYtDlpControlDownload, handleYtDlpDownload, handleYtDlpDownloadBinary, handleYtDlpGetInfo, handleYtDlpGetPlaybackInfo, handleYtDlpGetRecommendations, handleYtDlpListDownloads, handleYtDlpOpenDownload, handleYtDlpQueueAction, handleYtDlpRemoveDownload, refreshYtDlpDownloadQueue, restoreYtDlpDownloadQueue, shutdownYtDlpDownloads } from './ytDlp'
 import { handleYtDlpPlaybackCacheClear, handleYtDlpPlaybackCacheDelete, handleYtDlpPlaybackCacheGet, handleYtDlpPlaybackCacheSet } from './ytDlpPlaybackCache'
 import { generatePoToken } from './poTokenGenerator'
 import { expandMultipleOnlyPluralMessages, selectPluralForm } from '../renderer/i18n/plurals'
@@ -1727,6 +1727,7 @@ function runApp() {
   let proxyUrl
 
   app.on('ready', async (_, __) => {
+    restoreYtDlpDownloadQueue().catch(error => console.warn('Could not restore the download queue', error))
     if (process.platform === 'darwin') {
       const t = await createMainTranslator()
       dockMediaLabels = {
@@ -4039,6 +4040,8 @@ function runApp() {
   })
 
   ipcMain.on(IpcChannels.YT_DLP_CANCEL_DOWNLOAD, handleYtDlpCancelDownload)
+  ipcMain.handle(IpcChannels.YT_DLP_CONTROL_DOWNLOAD, handleYtDlpControlDownload)
+  ipcMain.handle(IpcChannels.YT_DLP_QUEUE_ACTION, handleYtDlpQueueAction)
   ipcMain.handle(IpcChannels.YT_DLP_LIST_DOWNLOADS, handleYtDlpListDownloads)
   ipcMain.handle(IpcChannels.YT_DLP_CLEAR_DOWNLOADS, handleYtDlpClearDownloads)
   ipcMain.handle(IpcChannels.YT_DLP_OPEN_DOWNLOAD, handleYtDlpOpenDownload)
@@ -4396,6 +4399,10 @@ function runApp() {
               } else {
                 updateThemeSource(data.value)
               }
+              break
+            case 'ytDlpMaxConcurrentDownloads':
+            case 'ytDlpDownloadBandwidthLimit':
+              await refreshYtDlpDownloadQueue()
               break
 
             default:
@@ -5428,6 +5435,15 @@ function runApp() {
             label: 'Playlists',
             click: (_menuItem, browserWindow, _event) => {
               navigateTo('/userplaylists', browserWindow)
+            },
+            type: 'normal'
+          },
+          {
+            label: 'Downloads',
+            accelerator: getElectronAccelerator(keyboardShortcuts.APP.GENERAL.NAVIGATE_TO_DOWNLOADS),
+            click: (_menuItem, browserWindow, _event) => {
+              if (browserWindow && appShortcutBlockedWindows.has(browserWindow)) { return }
+              navigateTo('/downloads', browserWindow)
             },
             type: 'normal'
           },

--- a/src/main/index.js
+++ b/src/main/index.js
@@ -1727,7 +1727,11 @@ function runApp() {
   let proxyUrl
 
   app.on('ready', async (_, __) => {
-    restoreYtDlpDownloadQueue().catch(error => console.warn('Could not restore the download queue', error))
+    try {
+      await restoreYtDlpDownloadQueue()
+    } catch (error) {
+      console.warn('Could not restore the download queue', error)
+    }
     if (process.platform === 'darwin') {
       const t = await createMainTranslator()
       dockMediaLabels = {

--- a/src/main/ytDlp.js
+++ b/src/main/ytDlp.js
@@ -2841,6 +2841,9 @@ export async function handleYtDlpQueueAction(event, action) {
         entry.paused = false
         record.status = 'downloading'
         broadcastDownloadStatus(record)
+      } else if (entry && record.status === 'pausing') {
+        record.status = 'downloading'
+        broadcastDownloadStatus(record)
       } else if (record.status === 'paused') {
         persistedPaused.push(record)
       }

--- a/src/main/ytDlp.js
+++ b/src/main/ytDlp.js
@@ -2661,7 +2661,10 @@ async function restorePersistedDownloadQueue(event) {
         !queuedDownloadWaiters.has(record.id) && !activeDownloads.has(record.id))
       .sort(compareQueuedDownloads)
     for (const record of persisted) await restartPersistedDownload(event, record)
-  })()
+  })().catch(error => {
+    persistedDownloadQueueRestorePromise = null
+    throw error
+  })
   return persistedDownloadQueueRestorePromise
 }
 
@@ -2744,6 +2747,15 @@ export function handleYtDlpCancelDownload(event, id) {
   }
 }
 
+function clearQueuePauseAfterLastIndividualResume() {
+  if (!downloadQueuePauseAllRequested || [...downloadRecords.values()]
+    .some(download => ['paused', 'pausing'].includes(download.status))) return
+
+  downloadQueuePaused = false
+  downloadQueuePauseAllRequested = false
+  individuallyResumedDownloadIds.clear()
+}
+
 /**
  * @param {import('electron').IpcMainInvokeEvent} event
  * @param {number} id
@@ -2781,7 +2793,9 @@ export async function handleYtDlpControlDownload(event, id, action, value) {
     } else if (record.status === 'paused') {
       if (!queuedDownloadWaiters.has(id)) {
         const result = await restartPersistedDownload(event, record, true)
-        return Boolean(result && 'id' in result)
+        const resumed = Boolean(result && 'id' in result)
+        if (resumed) clearQueuePauseAfterLastIndividualResume()
+        return resumed
       }
       resumePendingDownload(record, individuallyResumedDownloadIds, downloadQueuePaused)
     } else if (record.status === 'pausing') {
@@ -2796,6 +2810,7 @@ export async function handleYtDlpControlDownload(event, id, action, value) {
     } else {
       return false
     }
+    clearQueuePauseAfterLastIndividualResume()
   } else if (action === 'move' && ['queued', 'paused'].includes(record.status) && !entry && (value === -1 || value === 1)) {
     const peers = [...downloadRecords.values()]
       .filter(download => ['queued', 'paused'].includes(download.status) && !activeDownloads.has(download.id))

--- a/src/main/ytDlp.js
+++ b/src/main/ytDlp.js
@@ -16,6 +16,7 @@ import {
   compareQueuedDownloads,
   normalizeDownloadBandwidth,
   normalizeDownloadConcurrency,
+  resumePendingDownload,
   updatePendingDownloadStatuses,
 } from './downloadQueue'
 
@@ -2580,13 +2581,23 @@ function queueYtDlpDownload(
   })
 }
 
-async function restartPersistedDownload(event, record) {
+async function restartPersistedDownload(event, record, resumeIndividually = false) {
   if (!record?.retryPayload) return { error: 'download-not-resumable' }
   downloadRecords.delete(record.id)
   const result = await queueYtDlpDownload(event, record.retryPayload, true, record.automatic === true, true)
   if (result && 'id' in result) {
+    const restartedRecord = downloadRecords.get(result.id)
+    if (resumeIndividually && resumePendingDownload(
+      restartedRecord,
+      queuedDownloadWaiters,
+      individuallyResumedDownloadIds,
+      downloadQueuePaused
+    )) {
+      broadcastDownloadStatus(restartedRecord)
+    }
     broadcastToRenderers(IpcChannels.YT_DLP_DOWNLOADS_REMOVED, [record.id])
     await saveDownloadRecords()
+    if (resumeIndividually) await requestDownloadQueueDrain()
     return result
   }
   record.status = 'failed'
@@ -2722,11 +2733,15 @@ export async function handleYtDlpControlDownload(event, id, action, value) {
       entry.child.kill('SIGCONT')
       entry.paused = false
       record.status = 'downloading'
-    } else if (record.status === 'paused' && queuedDownloadWaiters.has(id)) {
-      record.status = 'queued'
-      if (downloadQueuePaused) individuallyResumedDownloadIds.add(id)
     } else if (record.status === 'paused') {
-      return restartPersistedDownload(event, record)
+      if (!resumePendingDownload(
+        record,
+        queuedDownloadWaiters,
+        individuallyResumedDownloadIds,
+        downloadQueuePaused
+      )) {
+        return restartPersistedDownload(event, record, true)
+      }
     } else if (record.status === 'pausing') {
       record.status = 'downloading'
     } else {

--- a/src/main/ytDlp.js
+++ b/src/main/ytDlp.js
@@ -202,6 +202,7 @@ const activeDownloads = new Map()
 const downloadRecords = new Map()
 /** @type {Map<number, (permitted: boolean) => void>} */
 const queuedDownloadWaiters = new Map()
+const individuallyResumedDownloadIds = new Set()
 /** @type {Promise<void> | null} */
 let downloadRecordsLoadPromise = null
 
@@ -283,18 +284,21 @@ async function getDownloadQueueSettings() {
 }
 
 async function drainDownloadQueue() {
-  if (shuttingDownDownloads || downloadQueuePaused) return
+  if (shuttingDownDownloads) return
   const queueSettings = await getDownloadQueueSettings()
 
   while (runningDownloadCount < queueSettings.concurrency) {
     const next = [...queuedDownloadWaiters.keys()]
       .map(id => downloadRecords.get(id))
-      .filter(record => record?.status === 'queued')
+      .filter(record => record?.status === 'queued' && (
+        !downloadQueuePaused || individuallyResumedDownloadIds.has(record.id)
+      ))
       .sort(compareQueuedDownloads)[0]
     if (!next) return
 
     const resolve = queuedDownloadWaiters.get(next.id)
     queuedDownloadWaiters.delete(next.id)
+    individuallyResumedDownloadIds.delete(next.id)
     runningDownloadCount++
     resolve?.(true)
   }
@@ -328,6 +332,7 @@ function cancelQueuedDownload(id) {
   const resolve = queuedDownloadWaiters.get(id)
   if (!resolve) return false
   queuedDownloadWaiters.delete(id)
+  individuallyResumedDownloadIds.delete(id)
   resolve(false)
   return true
 }
@@ -2698,6 +2703,7 @@ export async function handleYtDlpControlDownload(event, id, action, value) {
   const entry = activeDownloads.get(id)
   if (action === 'pause') {
     if (record.status === 'queued') {
+      individuallyResumedDownloadIds.delete(id)
       record.status = 'paused'
     } else if (entry && ['downloading', 'processing'].includes(record.status)) {
       if (process.platform !== 'win32' && entry.child.kill('SIGSTOP')) {
@@ -2717,12 +2723,11 @@ export async function handleYtDlpControlDownload(event, id, action, value) {
       entry.paused = false
       record.status = 'downloading'
     } else if (record.status === 'paused' && queuedDownloadWaiters.has(id)) {
-      downloadQueuePaused = false
       record.status = 'queued'
+      if (downloadQueuePaused) individuallyResumedDownloadIds.add(id)
     } else if (record.status === 'paused') {
       return restartPersistedDownload(event, record)
     } else if (record.status === 'pausing') {
-      downloadQueuePaused = false
       record.status = 'downloading'
     } else {
       return false
@@ -2761,6 +2766,7 @@ export async function handleYtDlpQueueAction(event, action) {
   }
   if (action === 'pause-all') {
     downloadQueuePaused = true
+    individuallyResumedDownloadIds.clear()
     setPendingDownloadStatus('paused')
     for (const [id, entry] of activeDownloads) {
       const record = downloadRecords.get(id)
@@ -2775,6 +2781,7 @@ export async function handleYtDlpQueueAction(event, action) {
     }
   } else if (action === 'resume-all') {
     downloadQueuePaused = false
+    individuallyResumedDownloadIds.clear()
     setPendingDownloadStatus('queued')
     const persistedPaused = []
     for (const record of downloadRecords.values()) {

--- a/src/main/ytDlp.js
+++ b/src/main/ytDlp.js
@@ -196,6 +196,7 @@ let runningDownloadCount = 0
 let persistedDownloadQueueRestorePromise = null
 let shuttingDownDownloads = false
 let downloadQueuePaused = false
+let downloadQueuePauseAllRequested = false
 
 /** @type {Map<number, { child: import('node:child_process').ChildProcess, cancelled: boolean, paused: boolean, restarting: boolean, restartStatus: 'queued' | 'paused' }>} */
 const activeDownloads = new Map()
@@ -302,7 +303,6 @@ async function drainDownloadQueue() {
 
     const resolve = queuedDownloadWaiters.get(next.id)
     queuedDownloadWaiters.delete(next.id)
-    individuallyResumedDownloadIds.delete(next.id)
     runningDownloadCount++
     resolve?.(true)
   }
@@ -2242,24 +2242,9 @@ async function startYtDlpDownload(
     }
   }
 
-  // Keep post-processing inputs away from completed files with the same title
-  // and video ID. Put the isolated directory beside the completed files so a
-  // sandbox's capacity-limited runtime directory does not hold the media data.
-  // Audio extraction otherwise reuses and then deletes an existing video file
-  // when both variants have the same source extension.
-  let temporaryDownloadFolder
-  try {
-    temporaryDownloadFolder = await mkdtemp(join(downloadFolder, '.opentubex-download-'))
-  } catch {
-    // Let yt-dlp report an unavailable destination through the tracked job.
-    temporaryDownloadFolder = await mkdtemp(join(app.getPath('temp'), 'opentubex-download-'))
-  }
-  args.push('--paths', `temp:${temporaryDownloadFolder}`)
-
   // Authorization and executable setup contain awaits, so another refresh can
   // start the same video after the initial fast-path check above.
   if (payload.automatic === true && isSingleVideo && hasAutomaticDownloadRecord(payload.videoId)) {
-    await rm(temporaryDownloadFolder, { recursive: true, force: true })
     return { skipped: 'already-downloaded' }
   }
 
@@ -2318,9 +2303,31 @@ async function startYtDlpDownload(
   onQueued?.({ id })
 
   if (!await waitForDownloadSlot(id)) {
-    await rm(temporaryDownloadFolder, { recursive: true, force: true })
     return { id }
   }
+
+  // Keep post-processing inputs away from completed files with the same title
+  // and video ID. Put the isolated directory beside the completed files so a
+  // sandbox's capacity-limited runtime directory does not hold the media data.
+  // Audio extraction otherwise reuses and then deletes an existing video file
+  // when both variants have the same source extension.
+  let temporaryDownloadFolder
+  try {
+    temporaryDownloadFolder = await mkdtemp(join(downloadFolder, '.opentubex-download-'))
+  } catch {
+    try {
+      temporaryDownloadFolder = await mkdtemp(join(app.getPath('temp'), 'opentubex-download-'))
+    } catch (error) {
+      individuallyResumedDownloadIds.delete(id)
+      status.status = 'failed'
+      status.errorMessage = error.code === 'ENOENT' ? 'ENOENT' : error.message
+      sendStatus(true)
+      releaseDownloadSlot()
+      await saveDownloadRecords()
+      return { id }
+    }
+  }
+  args.push('--paths', `temp:${temporaryDownloadFolder}`)
 
   try {
     const fileSystem = await statfs(downloadFolder)
@@ -2328,6 +2335,7 @@ async function startYtDlpDownload(
     if (status.estimatedSizeBytes === undefined) {
       status.spaceWarning = 'unknown-estimate'
     } else if (status.availableSpaceBytes < status.estimatedSizeBytes) {
+      individuallyResumedDownloadIds.delete(id)
       status.status = 'failed'
       status.errorMessage = 'INSUFFICIENT_SPACE'
       sendStatus(true)
@@ -2341,13 +2349,22 @@ async function startYtDlpDownload(
   }
 
   async function abortQueuedPreparation() {
+    individuallyResumedDownloadIds.delete(id)
     releaseDownloadSlot()
     await rm(temporaryDownloadFolder, { recursive: true, force: true })
     await saveDownloadRecords()
     return { id }
   }
 
-  if (status.status !== 'queued') return abortQueuedPreparation()
+  function queuedPreparationWasInterrupted() {
+    if (status.status !== 'queued') return true
+    if (!downloadQueuePaused || individuallyResumedDownloadIds.has(id)) return false
+    status.status = 'paused'
+    sendStatus(true)
+    return true
+  }
+
+  if (queuedPreparationWasInterrupted()) return abortQueuedPreparation()
 
   const bandwidthLimit = normalizeDownloadBandwidth(
     (await settings._findOne('ytDlpDownloadBandwidthLimit'))?.value
@@ -2358,8 +2375,9 @@ async function startYtDlpDownload(
     ))
     args.push('--limit-rate', `${bandwidthShare}K`)
   }
-  if (status.status !== 'queued') return abortQueuedPreparation()
+  if (queuedPreparationWasInterrupted()) return abortQueuedPreparation()
 
+  individuallyResumedDownloadIds.delete(id)
   status.status = 'downloading'
   status.started = true
   const child = spawn(executable, args, { windowsHide: true })
@@ -2746,11 +2764,19 @@ export async function handleYtDlpControlDownload(event, id, action, value) {
       record.status = 'downloading'
     } else if (record.status === 'paused') {
       if (!queuedDownloadWaiters.has(id)) {
-        return restartPersistedDownload(event, record, true)
+        const result = await restartPersistedDownload(event, record, true)
+        return Boolean(result && 'id' in result)
       }
       resumePendingDownload(record, individuallyResumedDownloadIds, downloadQueuePaused)
     } else if (record.status === 'pausing') {
       record.status = 'downloading'
+      const anotherDownloadIsPausing = [...downloadRecords.values()]
+        .some(download => download.id !== id && download.status === 'pausing')
+      if (!downloadQueuePauseAllRequested && !anotherDownloadIsPausing) {
+        downloadQueuePaused = false
+        individuallyResumedDownloadIds.clear()
+        setPendingDownloadStatus('queued')
+      }
     } else {
       return false
     }
@@ -2788,6 +2814,7 @@ export async function handleYtDlpQueueAction(event, action) {
   }
   if (action === 'pause-all') {
     downloadQueuePaused = true
+    downloadQueuePauseAllRequested = true
     individuallyResumedDownloadIds.clear()
     setPendingDownloadStatus('paused')
     for (const [id, entry] of activeDownloads) {
@@ -2803,6 +2830,7 @@ export async function handleYtDlpQueueAction(event, action) {
     }
   } else if (action === 'resume-all') {
     downloadQueuePaused = false
+    downloadQueuePauseAllRequested = false
     individuallyResumedDownloadIds.clear()
     setPendingDownloadStatus('queued')
     const persistedPaused = []

--- a/src/main/ytDlp.js
+++ b/src/main/ytDlp.js
@@ -2348,8 +2348,14 @@ async function startYtDlpDownload(
     status.spaceWarning = 'space-check-unavailable'
   }
 
-  async function abortQueuedPreparation() {
+  async function abortQueuedPreparation(error) {
     individuallyResumedDownloadIds.delete(id)
+    if (error) {
+      console.error('Could not prepare queued download', error)
+      status.status = 'failed'
+      status.errorMessage = 'download-queue-failed'
+      sendStatus(true)
+    }
     releaseDownloadSlot()
     await rm(temporaryDownloadFolder, { recursive: true, force: true })
     await saveDownloadRecords()
@@ -2366,14 +2372,18 @@ async function startYtDlpDownload(
 
   if (queuedPreparationWasInterrupted()) return abortQueuedPreparation()
 
-  const bandwidthLimit = normalizeDownloadBandwidth(
-    (await settings._findOne('ytDlpDownloadBandwidthLimit'))?.value
-  )
-  if (bandwidthLimit > 0) {
-    const bandwidthShare = Math.max(1, Math.floor(
-      bandwidthLimit / (await getDownloadQueueSettings()).concurrency
-    ))
-    args.push('--limit-rate', `${bandwidthShare}K`)
+  try {
+    const bandwidthLimit = normalizeDownloadBandwidth(
+      (await settings._findOne('ytDlpDownloadBandwidthLimit'))?.value
+    )
+    if (bandwidthLimit > 0) {
+      const bandwidthShare = Math.max(1, Math.floor(
+        bandwidthLimit / (await getDownloadQueueSettings()).concurrency
+      ))
+      args.push('--limit-rate', `${bandwidthShare}K`)
+    }
+  } catch (error) {
+    return abortQueuedPreparation(error)
   }
   if (queuedPreparationWasInterrupted()) return abortQueuedPreparation()
 
@@ -2626,6 +2636,12 @@ async function restartPersistedDownload(event, record, resumeIndividually = fals
   )
   if (result && 'id' in result) {
     broadcastToRenderers(IpcChannels.YT_DLP_DOWNLOADS_REMOVED, [record.id])
+    await saveDownloadRecords()
+    return result
+  }
+  if (result?.error === 'downloads-disabled') {
+    downloadRecords.set(record.id, record)
+    broadcastDownloadStatus(record)
     await saveDownloadRecords()
     return result
   }

--- a/src/main/ytDlp.js
+++ b/src/main/ytDlp.js
@@ -1,6 +1,6 @@
 import { execFile, spawn } from 'node:child_process'
 import { existsSync } from 'node:fs'
-import { chmod, mkdir, mkdtemp, readFile, rename, rm, stat, writeFile } from 'node:fs/promises'
+import { chmod, mkdir, mkdtemp, readFile, rename, rm, stat, statfs, writeFile } from 'node:fs/promises'
 import { dirname, join } from 'node:path'
 import { promisify } from 'node:util'
 import { inflateRawSync } from 'node:zlib'
@@ -12,6 +12,11 @@ import { IpcChannels } from '../constants'
 import { getMatchingDownloadValidators, getYtDlpAssetName } from './ytDlpAsset'
 import { buildYtDlpStoryboardVtt } from './ytDlpStoryboard'
 import { shouldUseGioTrash } from './trashPlatform'
+import {
+  compareQueuedDownloads,
+  normalizeDownloadBandwidth,
+  normalizeDownloadConcurrency,
+} from './downloadQueue'
 
 const execFileAsync = promisify(execFile)
 
@@ -58,6 +63,7 @@ function takeGetInfoAbortSignal(key) {
  * @property {boolean} [embedThumbnail]
  * @property {boolean} [embedMetadata]
  * @property {string} [customArgs] additional yt-dlp command line arguments
+ * @property {number} [estimatedSizeBytes] estimated output size when the caller has format metadata
  * @property {string} [template] the template the options came from, only used for display purposes
  * @property {boolean} [automatic] whether a subscription refresh started the download
  * @property {string} [channelId] channel whose persisted rule authorized the automatic download
@@ -83,7 +89,9 @@ function takeGetInfoAbortSignal(key) {
  * @property {string} template
  * @property {boolean} [automatic]
  * @property {YtDlpDownloadPayload} [retryPayload]
- * @property {'downloading' | 'processing' | 'completed' | 'failed' | 'cancelled' | 'skipped'} status
+ * @property {'queued' | 'downloading' | 'processing' | 'pausing' | 'paused' | 'completed' | 'failed' | 'cancelled' | 'skipped'} status
+ * @property {number} queuePosition
+ * @property {boolean} [started]
  * @property {number} percent
  * @property {string | null} speed
  * @property {string | null} eta
@@ -95,6 +103,9 @@ function takeGetInfoAbortSignal(key) {
  * @property {number} [destinationCount]
  * @property {number} [sizeBytes]
  * @property {boolean} [titleTruncated]
+ * @property {number} [estimatedSizeBytes]
+ * @property {number} [availableSpaceBytes]
+ * @property {'unknown-estimate' | 'space-check-unavailable' | null} [spaceWarning]
  * @property {string | null} errorMessage
  */
 
@@ -170,17 +181,26 @@ const FINAL_METADATA_PREFIX = '__OPENTUBEX_METADATA__:'
 const DOWNLOAD_TITLE_FILENAME_BYTE_LIMIT = 200
 
 let downloadCounter = 0
+let downloadQueuePositionCounter = 0
 let downloadRecordsSaveQueue = Promise.resolve()
 let binaryInstallCounter = 0
 let managedBinaryInstallQueue = Promise.resolve()
 const retryingDownloadIds = new Set()
 const automaticDiscoveryCache = new Map()
 const activeAutomaticDownloadNotifications = new Set()
+let downloadQueueDrainRunning = false
+let downloadQueueDrainRequested = false
+let runningDownloadCount = 0
+let persistedDownloadQueueRestorePromise = null
+let shuttingDownDownloads = false
+let downloadQueuePaused = false
 
-/** @type {Map<number, { child: import('node:child_process').ChildProcess, cancelled: boolean }>} */
+/** @type {Map<number, { child: import('node:child_process').ChildProcess, cancelled: boolean, paused: boolean, restarting: boolean, restartStatus: 'queued' | 'paused' }>} */
 const activeDownloads = new Map()
 /** @type {Map<number, YtDlpDownloadStatus>} */
 const downloadRecords = new Map()
+/** @type {Map<number, (permitted: boolean) => void>} */
+const queuedDownloadWaiters = new Map()
 /** @type {Promise<void> | null} */
 let downloadRecordsLoadPromise = null
 
@@ -238,6 +258,69 @@ function getDownloadRecordsPath() {
   return join(app.getPath('userData'), 'downloads.json')
 }
 
+function broadcastDownloadStatus(record) {
+  broadcastToRenderers(IpcChannels.YT_DLP_DOWNLOAD_STATUS, { ...record })
+}
+
+async function getDownloadQueueSettings() {
+  const concurrency = await settings._findOne('ytDlpMaxConcurrentDownloads')
+  return {
+    concurrency: normalizeDownloadConcurrency(concurrency?.value),
+  }
+}
+
+async function drainDownloadQueue() {
+  if (shuttingDownDownloads || downloadQueuePaused) return
+  const queueSettings = await getDownloadQueueSettings()
+
+  while (runningDownloadCount < queueSettings.concurrency) {
+    const next = [...queuedDownloadWaiters.keys()]
+      .map(id => downloadRecords.get(id))
+      .filter(record => record?.status === 'queued')
+      .sort(compareQueuedDownloads)[0]
+    if (!next) return
+
+    const resolve = queuedDownloadWaiters.get(next.id)
+    queuedDownloadWaiters.delete(next.id)
+    runningDownloadCount++
+    resolve?.(true)
+  }
+}
+
+async function requestDownloadQueueDrain() {
+  downloadQueueDrainRequested = true
+  if (downloadQueueDrainRunning) return
+  downloadQueueDrainRunning = true
+  try {
+    while (downloadQueueDrainRequested) {
+      downloadQueueDrainRequested = false
+      await drainDownloadQueue()
+    }
+  } finally {
+    downloadQueueDrainRunning = false
+  }
+}
+
+function waitForDownloadSlot(id) {
+  return new Promise(resolve => {
+    queuedDownloadWaiters.set(id, resolve)
+    requestDownloadQueueDrain().catch(error => console.warn('Could not schedule downloads', error))
+  })
+}
+
+function cancelQueuedDownload(id) {
+  const resolve = queuedDownloadWaiters.get(id)
+  if (!resolve) return false
+  queuedDownloadWaiters.delete(id)
+  resolve(false)
+  return true
+}
+
+function releaseDownloadSlot() {
+  runningDownloadCount = Math.max(0, runningDownloadCount - 1)
+  requestDownloadQueueDrain().catch(error => console.warn('Could not schedule downloads', error))
+}
+
 function loadDownloadRecords() {
   downloadRecordsLoadPromise ??= (async () => {
     try {
@@ -245,9 +328,14 @@ function loadDownloadRecords() {
       if (!Array.isArray(records)) return
       for (const record of records) {
         if (Number.isInteger(record?.id) && typeof record.title === 'string' &&
-          ['completed', 'failed', 'cancelled', 'skipped'].includes(record.status)) {
-          if (!downloadRecords.has(record.id)) downloadRecords.set(record.id, record)
+          ['queued', 'paused', 'completed', 'failed', 'cancelled', 'skipped'].includes(record.status)) {
+          const normalizedRecord = {
+            ...record,
+            queuePosition: Number.isFinite(record.queuePosition) ? record.queuePosition : record.id,
+          }
+          if (!downloadRecords.has(record.id)) downloadRecords.set(record.id, normalizedRecord)
           downloadCounter = Math.max(downloadCounter, record.id)
+          downloadQueuePositionCounter = Math.max(downloadQueuePositionCounter, normalizedRecord.queuePosition)
         }
       }
     } catch (error) {
@@ -259,7 +347,7 @@ function loadDownloadRecords() {
 
 function hasAutomaticDownloadRecord(videoId) {
   return [...downloadRecords.values()].some(record => (
-    record.videoId === videoId && ['downloading', 'processing', 'completed', 'skipped'].includes(record.status)
+    record.videoId === videoId && ['queued', 'downloading', 'processing', 'pausing', 'paused', 'completed', 'skipped'].includes(record.status)
   ))
 }
 
@@ -268,7 +356,9 @@ function saveDownloadRecords() {
     .catch(() => {})
     .then(() => {
       const records = [...downloadRecords.values()]
-        .filter(record => !['downloading', 'processing'].includes(record.status))
+        .map(record => ['downloading', 'processing', 'pausing'].includes(record.status)
+          ? { ...record, status: record.status === 'pausing' ? 'paused' : 'queued', speed: null, eta: null }
+          : record)
         .slice(-200)
       return writeFile(getDownloadRecordsPath(), JSON.stringify(records), 'utf8')
     })
@@ -280,19 +370,23 @@ export function flushYtDlpDownloadRecords() {
 }
 
 export async function shutdownYtDlpDownloads() {
+  shuttingDownDownloads = true
   const downloads = [...activeDownloads.values()]
   const settled = downloads.map(({ child }) => new Promise((resolve) => {
     child.once('close', resolve)
     child.once('error', resolve)
   }))
 
-  for (const entry of downloads) {
-    entry.cancelled = true
+  for (const [id, entry] of activeDownloads) {
+    entry.restarting = true
+    const record = downloadRecords.get(id)
+    entry.restartStatus = record && ['paused', 'pausing'].includes(record.status) ? 'paused' : 'queued'
+    if (entry.paused) entry.child.kill('SIGCONT')
     entry.child.kill()
   }
 
   await Promise.allSettled(settled)
-  await flushYtDlpDownloadRecords()
+  await saveDownloadRecords()
 }
 const windowsShownOnce = new WeakSet()
 
@@ -1861,22 +1955,29 @@ async function authorizeAutomaticDownload(payload, discoveryPreviouslyAuthorized
  * @param {YtDlpDownloadPayload} incomingPayload
  * @param {boolean} automaticDownloadAuthorized
  * @param {boolean} [automaticDiscoveryPreviouslyAuthorized]
+ * @param {(result: { id: number }) => void} [onQueued]
+ * @param {boolean} [previouslyAccepted]
  * @returns {Promise<{ id: number } | { error: string } | { skipped: string } | null>}
  */
 async function startYtDlpDownload(
   event,
   incomingPayload,
   automaticDownloadAuthorized,
-  automaticDiscoveryPreviouslyAuthorized = false
+  automaticDiscoveryPreviouslyAuthorized = false,
+  onQueued,
+  previouslyAccepted = false
 ) {
-  if (!isOpenTubeXUrl(event.senderFrame.url) || typeof incomingPayload !== 'object' || incomingPayload === null) {
+  if ((!previouslyAccepted && !isOpenTubeXUrl(event?.senderFrame.url)) ||
+    typeof incomingPayload !== 'object' || incomingPayload === null) {
     return null
   }
 
-  const payload = incomingPayload.automatic === true && automaticDownloadAuthorized
-    ? await authorizeAutomaticDownload(incomingPayload, automaticDiscoveryPreviouslyAuthorized)
-    : incomingPayload.automatic === true ? null : incomingPayload
-  if (payload === null || (payload.automatic !== true && !event.sender.isFocused())) {
+  const payload = previouslyAccepted
+    ? incomingPayload
+    : incomingPayload.automatic === true && automaticDownloadAuthorized
+      ? await authorizeAutomaticDownload(incomingPayload, automaticDiscoveryPreviouslyAuthorized)
+      : incomingPayload.automatic === true ? null : incomingPayload
+  if (payload === null || (!previouslyAccepted && payload.automatic !== true && !event.sender.isFocused())) {
     return null
   }
 
@@ -2138,10 +2239,6 @@ async function startYtDlpDownload(
   }
 
   const id = ++downloadCounter
-  const child = spawn(executable, args, { windowsHide: true })
-  const entry = { child, cancelled: false }
-  activeDownloads.set(id, entry)
-
   /** @type {YtDlpDownloadStatus} */
   const status = {
     id,
@@ -2156,7 +2253,9 @@ async function startYtDlpDownload(
     template: typeof payload.template === 'string' ? payload.template.slice(0, 255) : '',
     automatic: payload.automatic === true,
     retryPayload: structuredClone(payload),
-    status: 'downloading',
+    status: 'queued',
+    started: false,
+    queuePosition: ++downloadQueuePositionCounter,
     percent: 0,
     speed: null,
     eta: null,
@@ -2164,10 +2263,14 @@ async function startYtDlpDownload(
     destinations: [],
     files: [],
     titleTruncated: false,
+    estimatedSizeBytes: Number.isSafeInteger(payload.estimatedSizeBytes) && payload.estimatedSizeBytes > 0
+      ? payload.estimatedSizeBytes
+      : undefined,
+    availableSpaceBytes: undefined,
+    spaceWarning: null,
     errorMessage: null
   }
   downloadRecords.set(id, status)
-  showAutomaticDownloadNotification(payload, 'started')
 
   let lastSent = 0
   let finished = false
@@ -2182,9 +2285,62 @@ async function startYtDlpDownload(
     }
     lastSent = now
 
-    broadcastToRenderers(IpcChannels.YT_DLP_DOWNLOAD_STATUS, { ...status })
+    broadcastDownloadStatus(status)
   }
 
+  sendStatus(true)
+  await saveDownloadRecords()
+  onQueued?.({ id })
+
+  if (!await waitForDownloadSlot(id)) {
+    await rm(temporaryDownloadFolder, { recursive: true, force: true })
+    return { id }
+  }
+
+  try {
+    const fileSystem = await statfs(downloadFolder)
+    status.availableSpaceBytes = fileSystem.bavail * fileSystem.bsize
+    if (status.estimatedSizeBytes === undefined) {
+      status.spaceWarning = 'unknown-estimate'
+    } else if (status.availableSpaceBytes < status.estimatedSizeBytes) {
+      status.status = 'failed'
+      status.errorMessage = 'INSUFFICIENT_SPACE'
+      sendStatus(true)
+      releaseDownloadSlot()
+      await rm(temporaryDownloadFolder, { recursive: true, force: true })
+      await saveDownloadRecords()
+      return { id }
+    }
+  } catch {
+    status.spaceWarning = 'space-check-unavailable'
+  }
+
+  async function abortQueuedPreparation() {
+    releaseDownloadSlot()
+    await rm(temporaryDownloadFolder, { recursive: true, force: true })
+    await saveDownloadRecords()
+    return { id }
+  }
+
+  if (status.status !== 'queued') return abortQueuedPreparation()
+
+  const bandwidthLimit = normalizeDownloadBandwidth(
+    (await settings._findOne('ytDlpDownloadBandwidthLimit'))?.value
+  )
+  if (bandwidthLimit > 0) {
+    const bandwidthShare = Math.max(1, Math.floor(
+      bandwidthLimit / (await getDownloadQueueSettings()).concurrency
+    ))
+    args.push('--limit-rate', `${bandwidthShare}K`)
+  }
+  if (status.status !== 'queued') return abortQueuedPreparation()
+
+  status.status = 'downloading'
+  status.started = true
+  const child = spawn(executable, args, { windowsHide: true })
+  const entry = { child, cancelled: false, paused: false, restarting: false, restartStatus: 'queued' }
+  activeDownloads.set(id, entry)
+  showAutomaticDownloadNotification(payload, 'started')
   sendStatus(true)
 
   /** @type {string[]} */
@@ -2317,10 +2473,11 @@ async function startYtDlpDownload(
     finished = true
 
     activeDownloads.delete(id)
+    releaseDownloadSlot()
     removeTemporaryDownloadFolder()
-    status.status = 'failed'
-    status.errorMessage = error.code === 'ENOENT' ? 'ENOENT' : error.message
-    showAutomaticDownloadNotification(payload, 'failed')
+    status.status = entry.restarting ? entry.restartStatus : 'failed'
+    status.errorMessage = entry.restarting ? null : error.code === 'ENOENT' ? 'ENOENT' : error.message
+    if (!entry.restarting) showAutomaticDownloadNotification(payload, 'failed')
     sendStatus(true)
     saveDownloadRecords().catch(error => console.warn('Could not save download history', error))
   })
@@ -2332,9 +2489,14 @@ async function startYtDlpDownload(
     finished = true
 
     activeDownloads.delete(id)
+    releaseDownloadSlot()
     removeTemporaryDownloadFolder()
 
-    if (entry.cancelled) {
+    if (entry.restarting) {
+      status.status = entry.restartStatus
+      status.speed = null
+      status.eta = null
+    } else if (entry.cancelled) {
       status.status = 'cancelled'
     } else if (code === 0) {
       if (subtitleFormat !== '') {
@@ -2369,6 +2531,71 @@ async function startYtDlpDownload(
   return { id }
 }
 
+function queueYtDlpDownload(
+  event,
+  payload,
+  automaticDownloadAuthorized,
+  automaticDiscoveryPreviouslyAuthorized = false,
+  previouslyAccepted = false
+) {
+  return new Promise(resolve => {
+    let resolved = false
+    const resolveOnce = result => {
+      if (resolved) return
+      resolved = true
+      resolve(result)
+    }
+    startYtDlpDownload(
+      event,
+      payload,
+      automaticDownloadAuthorized,
+      automaticDiscoveryPreviouslyAuthorized,
+      resolveOnce,
+      previouslyAccepted
+    ).then(resolveOnce).catch(error => {
+      console.error('Could not queue download', error)
+      resolveOnce({ error: 'download-queue-failed' })
+    })
+  })
+}
+
+async function restartPersistedDownload(event, record) {
+  if (!record?.retryPayload) return { error: 'download-not-resumable' }
+  downloadRecords.delete(record.id)
+  const result = await queueYtDlpDownload(event, record.retryPayload, true, record.automatic === true, true)
+  if (result && 'id' in result) {
+    broadcastToRenderers(IpcChannels.YT_DLP_DOWNLOADS_REMOVED, [record.id])
+    await saveDownloadRecords()
+    return result
+  }
+  record.status = 'failed'
+  record.errorMessage = result && 'error' in result ? result.error : 'download-queue-failed'
+  downloadRecords.set(record.id, record)
+  broadcastDownloadStatus(record)
+  await saveDownloadRecords()
+  return result
+}
+
+async function restorePersistedDownloadQueue(event) {
+  persistedDownloadQueueRestorePromise ??= (async () => {
+    await loadDownloadRecords()
+    const persisted = [...downloadRecords.values()]
+      .filter(record => record.status === 'queued' &&
+        !queuedDownloadWaiters.has(record.id) && !activeDownloads.has(record.id))
+      .sort(compareQueuedDownloads)
+    for (const record of persisted) await restartPersistedDownload(event, record)
+  })()
+  return persistedDownloadQueueRestorePromise
+}
+
+export function restoreYtDlpDownloadQueue() {
+  return restorePersistedDownloadQueue(null)
+}
+
+export function refreshYtDlpDownloadQueue() {
+  return requestDownloadQueueDrain()
+}
+
 /**
  * @param {import('electron').IpcMainInvokeEvent} event
  * @param {YtDlpDownloadPayload} payload
@@ -2378,7 +2605,7 @@ async function startYtDlpDownload(
  */
 export async function handleYtDlpDownload(event, payload, retryDownloadId, automaticDownloadAuthorized = false) {
   if (retryDownloadId === undefined) {
-    return startYtDlpDownload(event, payload, automaticDownloadAuthorized)
+    return queueYtDlpDownload(event, payload, automaticDownloadAuthorized)
   }
 
   if (!isOpenTubeXUrl(event.senderFrame.url) || !event.sender.isFocused() ||
@@ -2398,7 +2625,7 @@ export async function handleYtDlpDownload(event, payload, retryDownloadId, autom
     }
 
     const retryPayload = retryRecord.automatic === true ? retryRecord.retryPayload : payload
-    const result = await startYtDlpDownload(event, retryPayload, true, retryRecord.automatic === true)
+    const result = await queueYtDlpDownload(event, retryPayload, true, retryRecord.automatic === true)
     if (result && 'id' in result) {
       downloadRecords.delete(retryDownloadId)
       broadcastToRenderers(IpcChannels.YT_DLP_DOWNLOADS_REMOVED, [retryDownloadId])
@@ -2423,8 +2650,154 @@ export function handleYtDlpCancelDownload(event, id) {
   const entry = activeDownloads.get(id)
   if (entry) {
     entry.cancelled = true
+    if (entry.paused) entry.child.kill('SIGCONT')
     entry.child.kill()
+    return
   }
+
+  const record = downloadRecords.get(id)
+  if (record && ['queued', 'paused'].includes(record.status)) {
+    cancelQueuedDownload(id)
+    record.status = 'cancelled'
+    record.speed = null
+    record.eta = null
+    broadcastDownloadStatus(record)
+    saveDownloadRecords().catch(error => console.warn('Could not save download history', error))
+    requestDownloadQueueDrain().catch(error => console.warn('Could not schedule downloads', error))
+  }
+}
+
+/**
+ * @param {import('electron').IpcMainInvokeEvent} event
+ * @param {number} id
+ * @param {'pause' | 'resume' | 'move'} action
+ * @param {number} [value]
+ */
+export async function handleYtDlpControlDownload(event, id, action, value) {
+  if (!isOpenTubeXUrl(event.senderFrame.url) || !event.sender.isFocused() || !Number.isInteger(id)) return false
+  await loadDownloadRecords()
+  const record = downloadRecords.get(id)
+  if (!record) return false
+
+  const entry = activeDownloads.get(id)
+  if (action === 'pause') {
+    if (record.status === 'queued') {
+      record.status = 'paused'
+    } else if (entry && ['downloading', 'processing'].includes(record.status)) {
+      if (process.platform !== 'win32' && entry.child.kill('SIGSTOP')) {
+        entry.paused = true
+        record.status = 'paused'
+      } else {
+        downloadQueuePaused = true
+        record.status = 'pausing'
+      }
+    } else {
+      return false
+    }
+  } else if (action === 'resume') {
+    if (entry?.paused && record.status === 'paused') {
+      entry.child.kill('SIGCONT')
+      entry.paused = false
+      record.status = 'downloading'
+    } else if (record.status === 'paused' && queuedDownloadWaiters.has(id)) {
+      record.status = 'queued'
+    } else if (record.status === 'paused') {
+      return restartPersistedDownload(event, record)
+    } else if (record.status === 'pausing') {
+      downloadQueuePaused = false
+      record.status = 'downloading'
+    } else {
+      return false
+    }
+  } else if (action === 'move' && ['queued', 'paused'].includes(record.status) && !entry && (value === -1 || value === 1)) {
+    const peers = [...downloadRecords.values()]
+      .filter(download => ['queued', 'paused'].includes(download.status) && !activeDownloads.has(download.id))
+      .sort(compareQueuedDownloads)
+    const index = peers.findIndex(download => download.id === id)
+    const other = peers[index + value]
+    if (!other) return false
+    const position = record.queuePosition
+    record.queuePosition = other.queuePosition
+    other.queuePosition = position
+    broadcastDownloadStatus(other)
+  } else {
+    return false
+  }
+
+  broadcastDownloadStatus(record)
+  await saveDownloadRecords()
+  await requestDownloadQueueDrain()
+  return true
+}
+
+/**
+ * @param {import('electron').IpcMainInvokeEvent} event
+ * @param {'pause-all' | 'resume-all' | 'retry-all' | 'refresh'} action
+ */
+export async function handleYtDlpQueueAction(event, action) {
+  if (!isOpenTubeXUrl(event.senderFrame.url) || !event.sender.isFocused()) return false
+  await loadDownloadRecords()
+  if (action === 'refresh') {
+    await requestDownloadQueueDrain()
+    return true
+  }
+  if (action === 'pause-all') {
+    downloadQueuePaused = true
+    for (const record of downloadRecords.values()) {
+      if (record.status === 'queued') {
+        record.status = 'paused'
+        broadcastDownloadStatus(record)
+      }
+    }
+    for (const [id, entry] of activeDownloads) {
+      const record = downloadRecords.get(id)
+      if (!record || entry.paused) continue
+      if (process.platform !== 'win32' && entry.child.kill('SIGSTOP')) {
+        entry.paused = true
+        record.status = 'paused'
+      } else {
+        record.status = 'pausing'
+      }
+      broadcastDownloadStatus(record)
+    }
+  } else if (action === 'resume-all') {
+    downloadQueuePaused = false
+    const persistedPaused = []
+    for (const record of downloadRecords.values()) {
+      const entry = activeDownloads.get(record.id)
+      if (entry?.paused) {
+        entry.child.kill('SIGCONT')
+        entry.paused = false
+        record.status = 'downloading'
+        broadcastDownloadStatus(record)
+      } else if (record.status === 'paused' && queuedDownloadWaiters.has(record.id)) {
+        record.status = 'queued'
+        broadcastDownloadStatus(record)
+      } else if (record.status === 'paused') {
+        persistedPaused.push(record)
+      }
+    }
+    for (const record of persistedPaused) await restartPersistedDownload(event, record)
+  } else if (action === 'retry-all') {
+    const failed = [...downloadRecords.values()].filter(record => record.status === 'failed')
+    for (const record of failed) {
+      await handleYtDlpDownload(event, record.retryPayload ?? {
+        videoId: record.videoId,
+        playlistId: record.playlistId,
+        isPlaylist: Boolean(record.playlistId),
+        title: record.title,
+        thumbnail: record.thumbnail,
+        mode: record.mode,
+        template: record.template,
+      }, record.id, true)
+    }
+  } else {
+    return false
+  }
+
+  await saveDownloadRecords()
+  await requestDownloadQueueDrain()
+  return true
 }
 
 /**
@@ -2507,6 +2880,7 @@ export async function handleYtDlpRemoveDownload(event, id) {
 export async function handleYtDlpListDownloads(event) {
   if (!isOpenTubeXUrl(event.senderFrame.url)) return []
   await loadDownloadRecords()
+  await restorePersistedDownloadQueue(event)
   return Promise.all([...downloadRecords.values()].map(async record => {
     if (record.status !== 'completed') return record
 
@@ -2587,7 +2961,10 @@ export async function handleYtDlpClearDownloads(event, ids) {
   await loadDownloadRecords()
   const removedIds = []
   for (const id of ids) {
-    if (!activeDownloads.has(id) && downloadRecords.delete(id)) removedIds.push(id)
+    const record = downloadRecords.get(id)
+    if (!activeDownloads.has(id) && !queuedDownloadWaiters.has(id) &&
+      ['completed', 'failed', 'cancelled', 'skipped'].includes(record?.status) &&
+      downloadRecords.delete(id)) removedIds.push(id)
   }
   await saveDownloadRecords()
   if (removedIds.length > 0) broadcastToRenderers(IpcChannels.YT_DLP_DOWNLOADS_REMOVED, removedIds)

--- a/src/main/ytDlp.js
+++ b/src/main/ytDlp.js
@@ -16,6 +16,7 @@ import {
   compareQueuedDownloads,
   normalizeDownloadBandwidth,
   normalizeDownloadConcurrency,
+  updatePendingDownloadStatuses,
 } from './downloadQueue'
 
 const execFileAsync = promisify(execFile)
@@ -262,6 +263,18 @@ function broadcastDownloadStatus(record) {
   broadcastToRenderers(IpcChannels.YT_DLP_DOWNLOAD_STATUS, { ...record })
 }
 
+function setPendingDownloadStatus(status) {
+  const updated = updatePendingDownloadStatuses(
+    downloadRecords,
+    queuedDownloadWaiters.keys(),
+    status
+  )
+  for (const record of updated) {
+    broadcastDownloadStatus(record)
+  }
+  return updated
+}
+
 async function getDownloadQueueSettings() {
   const concurrency = await settings._findOne('ytDlpMaxConcurrentDownloads')
   return {
@@ -304,6 +317,9 @@ async function requestDownloadQueueDrain() {
 function waitForDownloadSlot(id) {
   return new Promise(resolve => {
     queuedDownloadWaiters.set(id, resolve)
+    if (downloadQueuePaused && setPendingDownloadStatus('paused').length > 0) {
+      saveDownloadRecords().catch(error => console.warn('Could not save download history', error))
+    }
     requestDownloadQueueDrain().catch(error => console.warn('Could not schedule downloads', error))
   })
 }
@@ -2253,7 +2269,7 @@ async function startYtDlpDownload(
     template: typeof payload.template === 'string' ? payload.template.slice(0, 255) : '',
     automatic: payload.automatic === true,
     retryPayload: structuredClone(payload),
-    status: 'queued',
+    status: downloadQueuePaused ? 'paused' : 'queued',
     started: false,
     queuePosition: ++downloadQueuePositionCounter,
     percent: 0,
@@ -2690,6 +2706,7 @@ export async function handleYtDlpControlDownload(event, id, action, value) {
       } else {
         downloadQueuePaused = true
         record.status = 'pausing'
+        setPendingDownloadStatus('paused')
       }
     } else {
       return false
@@ -2700,6 +2717,7 @@ export async function handleYtDlpControlDownload(event, id, action, value) {
       entry.paused = false
       record.status = 'downloading'
     } else if (record.status === 'paused' && queuedDownloadWaiters.has(id)) {
+      downloadQueuePaused = false
       record.status = 'queued'
     } else if (record.status === 'paused') {
       return restartPersistedDownload(event, record)
@@ -2743,12 +2761,7 @@ export async function handleYtDlpQueueAction(event, action) {
   }
   if (action === 'pause-all') {
     downloadQueuePaused = true
-    for (const record of downloadRecords.values()) {
-      if (record.status === 'queued') {
-        record.status = 'paused'
-        broadcastDownloadStatus(record)
-      }
-    }
+    setPendingDownloadStatus('paused')
     for (const [id, entry] of activeDownloads) {
       const record = downloadRecords.get(id)
       if (!record || entry.paused) continue
@@ -2762,6 +2775,7 @@ export async function handleYtDlpQueueAction(event, action) {
     }
   } else if (action === 'resume-all') {
     downloadQueuePaused = false
+    setPendingDownloadStatus('queued')
     const persistedPaused = []
     for (const record of downloadRecords.values()) {
       const entry = activeDownloads.get(record.id)
@@ -2769,9 +2783,6 @@ export async function handleYtDlpQueueAction(event, action) {
         entry.child.kill('SIGCONT')
         entry.paused = false
         record.status = 'downloading'
-        broadcastDownloadStatus(record)
-      } else if (record.status === 'paused' && queuedDownloadWaiters.has(record.id)) {
-        record.status = 'queued'
         broadcastDownloadStatus(record)
       } else if (record.status === 'paused') {
         persistedPaused.push(record)

--- a/src/main/ytDlp.js
+++ b/src/main/ytDlp.js
@@ -266,9 +266,12 @@ function broadcastDownloadStatus(record) {
 }
 
 function setPendingDownloadStatus(status) {
+  const pendingIds = status === 'paused'
+    ? [...queuedDownloadWaiters.keys()].filter(id => !individuallyResumedDownloadIds.has(id))
+    : queuedDownloadWaiters.keys()
   const updated = updatePendingDownloadStatuses(
     downloadRecords,
-    queuedDownloadWaiters.keys(),
+    pendingIds,
     status
   )
   for (const record of updated) {
@@ -2558,7 +2561,8 @@ function queueYtDlpDownload(
   payload,
   automaticDownloadAuthorized,
   automaticDiscoveryPreviouslyAuthorized = false,
-  previouslyAccepted = false
+  previouslyAccepted = false,
+  onQueued
 ) {
   return new Promise(resolve => {
     let resolved = false
@@ -2567,12 +2571,16 @@ function queueYtDlpDownload(
       resolved = true
       resolve(result)
     }
+    const resolveQueued = result => {
+      onQueued?.(result)
+      resolveOnce(result)
+    }
     startYtDlpDownload(
       event,
       payload,
       automaticDownloadAuthorized,
       automaticDiscoveryPreviouslyAuthorized,
-      resolveOnce,
+      resolveQueued,
       previouslyAccepted
     ).then(resolveOnce).catch(error => {
       console.error('Could not queue download', error)
@@ -2584,20 +2592,23 @@ function queueYtDlpDownload(
 async function restartPersistedDownload(event, record, resumeIndividually = false) {
   if (!record?.retryPayload) return { error: 'download-not-resumable' }
   downloadRecords.delete(record.id)
-  const result = await queueYtDlpDownload(event, record.retryPayload, true, record.automatic === true, true)
-  if (result && 'id' in result) {
-    const restartedRecord = downloadRecords.get(result.id)
-    if (resumeIndividually && resumePendingDownload(
-      restartedRecord,
-      queuedDownloadWaiters,
-      individuallyResumedDownloadIds,
-      downloadQueuePaused
-    )) {
-      broadcastDownloadStatus(restartedRecord)
+  const result = await queueYtDlpDownload(
+    event,
+    record.retryPayload,
+    true,
+    record.automatic === true,
+    true,
+    queuedResult => {
+      if (!resumeIndividually || !queuedResult || !('id' in queuedResult)) return
+      const restartedRecord = downloadRecords.get(queuedResult.id)
+      if (resumePendingDownload(restartedRecord, individuallyResumedDownloadIds, downloadQueuePaused)) {
+        broadcastDownloadStatus(restartedRecord)
+      }
     }
+  )
+  if (result && 'id' in result) {
     broadcastToRenderers(IpcChannels.YT_DLP_DOWNLOADS_REMOVED, [record.id])
     await saveDownloadRecords()
-    if (resumeIndividually) await requestDownloadQueueDrain()
     return result
   }
   record.status = 'failed'
@@ -2734,14 +2745,10 @@ export async function handleYtDlpControlDownload(event, id, action, value) {
       entry.paused = false
       record.status = 'downloading'
     } else if (record.status === 'paused') {
-      if (!resumePendingDownload(
-        record,
-        queuedDownloadWaiters,
-        individuallyResumedDownloadIds,
-        downloadQueuePaused
-      )) {
+      if (!queuedDownloadWaiters.has(id)) {
         return restartPersistedDownload(event, record, true)
       }
+      resumePendingDownload(record, individuallyResumedDownloadIds, downloadQueuePaused)
     } else if (record.status === 'pausing') {
       record.status = 'downloading'
     } else {

--- a/src/preload/interface.js
+++ b/src/preload/interface.js
@@ -329,6 +329,22 @@ export default {
 
   /**
    * @param {number} id
+   * @param {'pause' | 'resume' | 'move'} action
+   * @param {number} [value]
+   */
+  ytDlpControlDownload: (id, action, value) => {
+    return ipcRenderer.invoke(IpcChannels.YT_DLP_CONTROL_DOWNLOAD, id, action, value)
+  },
+
+  /**
+   * @param {'pause-all' | 'resume-all' | 'retry-all' | 'refresh'} action
+   */
+  ytDlpQueueAction: (action) => {
+    return ipcRenderer.invoke(IpcChannels.YT_DLP_QUEUE_ACTION, action)
+  },
+
+  /**
+   * @param {number} id
    */
   ytDlpOpenDownload: (id) => {
     return ipcRenderer.invoke(IpcChannels.YT_DLP_OPEN_DOWNLOAD, id)

--- a/src/renderer/App.vue
+++ b/src/renderer/App.vue
@@ -2241,7 +2241,7 @@ function handleKeyboardShortcuts(event) {
 
   if (matchesKeyboardShortcut(event, shortcuts.NAVIGATE_TO_DOWNLOADS)) {
     event.preventDefault()
-    store.dispatch('showSettingsWindow', 'downloads')
+    openInternalPath({ path: '/downloads' })
     return
   }
 

--- a/src/renderer/App.vue
+++ b/src/renderer/App.vue
@@ -2239,6 +2239,12 @@ function handleKeyboardShortcuts(event) {
     return
   }
 
+  if (matchesKeyboardShortcut(event, shortcuts.NAVIGATE_TO_DOWNLOADS)) {
+    event.preventDefault()
+    store.dispatch('showSettingsWindow', 'downloads')
+    return
+  }
+
   if (findbarVisible.value && handleFindbarNavigationShortcut(event)) {
     return
   }

--- a/src/renderer/components/DownloadSettings.vue
+++ b/src/renderer/components/DownloadSettings.vue
@@ -47,6 +47,29 @@
         @input="updateYtDlpDownloadCustomArgs"
       />
     </FtFlexBox>
+    <FtFlexBox
+      v-if="enableDownloads"
+      class="downloadQueueInputs settingsFlexStart460px"
+    >
+      <FtSelect
+        :placeholder="t('Settings.Download Settings.Concurrent Downloads')"
+        :value="ytDlpMaxConcurrentDownloads"
+        setting-key="ytDlpMaxConcurrentDownloads"
+        :select-names="['1', '2', '3', '4', '5', '6', '8', '10']"
+        :select-values="[1, 2, 3, 4, 5, 6, 8, 10]"
+        :tooltip="t('Tooltips.Download Settings.Concurrent Downloads')"
+        @change="updateYtDlpMaxConcurrentDownloads"
+      />
+      <FtInput
+        input-type="number"
+        :placeholder="t('Settings.Download Settings.Bandwidth Limit')"
+        :show-action-button="false"
+        :show-label="true"
+        :value="ytDlpDownloadBandwidthLimit"
+        :tooltip="t('Tooltips.Download Settings.Bandwidth Limit')"
+        @input="updateYtDlpDownloadBandwidthLimit"
+      />
+    </FtFlexBox>
   </FtSettingsSection>
 </template>
 
@@ -56,6 +79,7 @@ import { useI18n } from 'vue-i18n'
 
 import FtSettingsSection from './FtSettingsSection/FtSettingsSection.vue'
 import FtInput from './FtInput/FtInput.vue'
+import FtSelect from './FtSelect/FtSelect.vue'
 import FtFlexBox from './ft-flex-box/ft-flex-box.vue'
 import FtToggleSwitch from './FtToggleSwitch/FtToggleSwitch.vue'
 import FtButton from './FtButton/FtButton.vue'
@@ -74,6 +98,8 @@ const ytDlpDownloadFolderPath = computed(() => store.getters.getYtDlpDownloadFol
 
 /** @type {import('vue').ComputedRef<string>} */
 const ytDlpDownloadCustomArgs = computed(() => store.getters.getYtDlpDownloadCustomArgs)
+const ytDlpMaxConcurrentDownloads = computed(() => store.getters.getYtDlpMaxConcurrentDownloads)
+const ytDlpDownloadBandwidthLimit = computed(() => store.getters.getYtDlpDownloadBandwidthLimit)
 
 /**
  * @param {boolean} value
@@ -98,6 +124,18 @@ function updateYtDlpDownloadFolderPath(value) {
  */
 function updateYtDlpDownloadCustomArgs(value) {
   store.dispatch('updateYtDlpDownloadCustomArgs', value)
+}
+
+function updateQueueSetting(action, value) {
+  return store.dispatch(action, value)
+}
+
+function updateYtDlpMaxConcurrentDownloads(value) {
+  return updateQueueSetting('updateYtDlpMaxConcurrentDownloads', value)
+}
+
+function updateYtDlpDownloadBandwidthLimit(value) {
+  return updateQueueSetting('updateYtDlpDownloadBandwidthLimit', value)
 }
 
 async function chooseDownloadFolder() {
@@ -130,9 +168,24 @@ async function chooseDownloadFolder() {
   column-gap: 12px;
 }
 
-.downloadPathInputs :deep(.ft-input-component) {
+.downloadPathInputs :deep(.ft-input-component),
+.downloadQueueInputs > * {
   inline-size: 340px;
   max-inline-size: 100%;
+}
+
+.downloadQueueInputs {
+  align-items: flex-end;
+  column-gap: 12px;
+  margin-block-start: 16px;
+}
+
+.downloadQueueInputs :deep(.select.containsTooltip) {
+  margin-inline-end: 0;
+}
+
+.downloadQueueInputs :deep(.ft-input) {
+  margin-block-end: 0;
 }
 
 </style>

--- a/src/renderer/components/FtKeyboardShortcutPrompt/FtKeyboardShortcutPrompt.vue
+++ b/src/renderer/components/FtKeyboardShortcutPrompt/FtKeyboardShortcutPrompt.vue
@@ -218,6 +218,7 @@ const generalAppShortcuts = computed(() => getLocalizedShortcutNamesAndValues(
     'HISTORY_FORWARD',
     ...isMac ? ['HISTORY_BACKWARD_ALT_MAC', 'HISTORY_FORWARD_ALT_MAC'] : [],
     'NAVIGATE_TO_SETTINGS',
+    'NAVIGATE_TO_DOWNLOADS',
     isMac ? 'NAVIGATE_TO_HISTORY_MAC' : 'NAVIGATE_TO_HISTORY',
   ]
 ))
@@ -331,6 +332,7 @@ const localizedShortcutNameToShortcutsMappings = computed(() => {
       'HISTORY_FORWARD_ALT_MAC',
     ]],
     [t('KeyboardShortcutPrompt.Navigate to Settings'), ['NAVIGATE_TO_SETTINGS']],
+    [t('KeyboardShortcutPrompt.Navigate to Downloads'), ['NAVIGATE_TO_DOWNLOADS']],
     [t('KeyboardShortcutPrompt.Navigate to History'), ['NAVIGATE_TO_HISTORY', 'NAVIGATE_TO_HISTORY_MAC']],
     [t('KeyboardShortcutPrompt.New Window'), ['NEW_WINDOW']],
     [t('KeyboardShortcutPrompt.New Tab'), ['NEW_TAB']],

--- a/src/renderer/components/WatchVideoDownloadPrompt/WatchVideoDownloadPrompt.vue
+++ b/src/renderer/components/WatchVideoDownloadPrompt/WatchVideoDownloadPrompt.vue
@@ -575,7 +575,7 @@ function matchesDownload(download) {
 
 const runningDownload = Object.values(store.getters.getYtDlpDownloads).filter(download =>
   matchesDownload(download) &&
-  (download.status === 'downloading' || download.status === 'processing')
+  ['queued', 'downloading', 'processing', 'pausing', 'paused'].includes(download.status)
 ).at(-1)
 const downloadId = ref(runningDownload?.id ?? null)
 const downloadFolderPath = computed(() => store.getters.getYtDlpDownloadFolderPath)
@@ -609,10 +609,14 @@ const activeDownload = computed(() => downloadId.value === null
   : store.getters.getYtDlpDownloads[downloadId.value] ?? {
     id: downloadId.value, status: 'downloading', percent: 0, speed: null, eta: null, errorMessage: null
   })
-const downloadInProgress = computed(() => activeDownload.value !== null && ['downloading', 'processing'].includes(activeDownload.value.status))
+const downloadInProgress = computed(() => activeDownload.value !== null &&
+  ['queued', 'downloading', 'processing', 'pausing', 'paused'].includes(activeDownload.value.status))
 const statusLine = computed(() => {
   const download = activeDownload.value
   if (!download) return ''
+  if (download.status === 'queued') return t('Downloads.Queued')
+  if (download.status === 'paused') return t('Downloads.Paused')
+  if (download.status === 'pausing') return t('Downloads.Pausing')
   if (download.status === 'downloading') return [`${download.percent.toFixed(1)}%`, download.speed, download.eta ? `ETA ${download.eta}` : null].filter(Boolean).join(' • ')
   if (download.status === 'processing') return t('Downloads.Processing')
   if (download.status === 'completed') return t('Downloads.Download Complete')

--- a/src/renderer/store/modules/settings.js
+++ b/src/renderer/store/modules/settings.js
@@ -267,6 +267,8 @@ const state = {
   moveSettingsToAppHeader: false,
   ytDlpDownloadFolderPath: '',
   ytDlpDownloadCustomArgs: '',
+  ytDlpMaxConcurrentDownloads: 2,
+  ytDlpDownloadBandwidthLimit: '0',
   ytDlpDownloadTemplates: '[]',
   ytDlpSelectedTemplate: 'video:best',
   ytDlpAutomaticDownloadRules: '{}',

--- a/src/renderer/views/Downloads/DownloadRow.vue
+++ b/src/renderer/views/Downloads/DownloadRow.vue
@@ -11,6 +11,7 @@
           {{ download.title }}
         </h3>
         <p
+          v-if="statusText"
           class="downloadStatus"
           :aria-hidden="inProgress ? 'true' : undefined"
         >
@@ -45,6 +46,12 @@
           class="downloadSummary"
         >
           {{ summary }}
+        </p>
+        <p
+          v-if="spaceWarningText"
+          class="downloadSpaceWarning"
+        >
+          {{ spaceWarningText }}
         </p>
         <p
           v-if="errorText"
@@ -87,13 +94,44 @@
       </div>
     </div>
     <div class="downloadActions">
-      <FtIconButton
-        v-if="inProgress"
-        :title="t('Downloads.Cancel Download')"
-        :icon="['fas', 'times']"
-        theme="destructive"
-        @click="cancelDownload"
-      />
+      <template v-if="controllable">
+        <FtIconButton
+          v-if="queuePending"
+          :title="t('Downloads.Move Earlier')"
+          :icon="['fas', 'arrow-up']"
+          theme="secondary"
+          :disabled="!canMoveEarlier"
+          @click="emit('move', -1)"
+        />
+        <FtIconButton
+          v-if="queuePending"
+          :title="t('Downloads.Move Later')"
+          :icon="['fas', 'arrow-down']"
+          theme="secondary"
+          :disabled="!canMoveLater"
+          @click="emit('move', 1)"
+        />
+        <FtIconButton
+          v-if="download.status === 'paused' || download.status === 'pausing'"
+          :title="t('Downloads.Resume Download')"
+          :icon="['fas', 'play']"
+          theme="primary"
+          @click="emit('resume')"
+        />
+        <FtIconButton
+          v-else
+          :title="t('Downloads.Pause Download')"
+          :icon="['fas', 'pause']"
+          theme="secondary"
+          @click="emit('pause')"
+        />
+        <FtIconButton
+          :title="t('Downloads.Cancel Download')"
+          :icon="['fas', 'times']"
+          theme="destructive"
+          @click="cancelDownload"
+        />
+      </template>
       <template v-else>
         <FtIconButton
           v-if="canRetry"
@@ -150,15 +188,22 @@ const MAX_VISIBLE_DESTINATIONS = 3
 
 const props = defineProps({
   download: { type: Object, required: true },
-  retrying: { type: Boolean, default: false }
+  retrying: { type: Boolean, default: false },
+  queuePosition: { type: Number, default: 0 },
+  canMoveEarlier: { type: Boolean, default: false },
+  canMoveLater: { type: Boolean, default: false }
 })
-const emit = defineEmits(['clear', 'open', 'play', 'remove', 'retry'])
+const emit = defineEmits(['clear', 'move', 'open', 'pause', 'play', 'remove', 'resume', 'retry'])
 const { t } = useI18n()
 const inProgress = computed(() => ['downloading', 'processing'].includes(props.download.status))
 const progressPercentage = computed(() => (
   Number.isFinite(props.download.percent)
     ? Math.min(100, Math.max(0, props.download.percent))
     : 0
+))
+const controllable = computed(() => ['queued', 'downloading', 'processing', 'pausing', 'paused'].includes(props.download.status))
+const queuePending = computed(() => (
+  ['queued', 'paused'].includes(props.download.status) && props.download.started !== true
 ))
 const canRetry = computed(() => (
   ['failed', 'cancelled'].includes(props.download.status) &&
@@ -222,23 +267,45 @@ const availabilityText = computed(() => {
 })
 const errorText = computed(() => {
   if (props.download.status !== 'failed' || !props.download.errorMessage) return ''
+  if (props.download.errorMessage === 'INSUFFICIENT_SPACE') {
+    return t('Downloads.Insufficient Disk Space', {
+      required: formatBytes(props.download.estimatedSizeBytes),
+      available: formatBytes(props.download.availableSpaceBytes)
+    })
+  }
   return props.download.errorMessage === 'ENOENT'
     ? t('Downloads.yt-dlp Not Found')
     : props.download.errorMessage
+})
+const spaceWarningText = computed(() => {
+  if (!['queued', 'downloading', 'processing', 'pausing', 'paused'].includes(props.download.status)) return ''
+  if (props.download.spaceWarning === 'unknown-estimate' && Number.isFinite(props.download.availableSpaceBytes)) {
+    return t('Downloads.Unknown Download Size', { available: formatBytes(props.download.availableSpaceBytes) })
+  }
+  if (props.download.spaceWarning === 'space-check-unavailable') {
+    return t('Downloads.Disk Space Check Unavailable')
+  }
+  return ''
 })
 const statusText = computed(() => {
   if (props.download.status === 'downloading') {
     return [`${progressPercentage.value.toFixed(1)}%`, props.download.speed, props.download.eta ? `ETA ${props.download.eta}` : null].filter(Boolean).join(' • ')
   }
   switch (props.download.status) {
+    case 'queued':
+      return props.queuePosition > 0
+        ? t('Downloads.Queued Position', { position: props.queuePosition })
+        : t('Downloads.Queued')
+    case 'paused':
+      return t('Downloads.Paused')
+    case 'pausing':
+      return t('Downloads.Pausing')
     case 'processing':
       return t('Downloads.Processing')
     case 'completed':
-      return props.download.availability === 'missing'
-        ? t('Downloads.Download Missing')
-        : t('Downloads.Download Complete')
+      return ''
     case 'cancelled':
-      return t('Downloads.Download Cancelled')
+      return ''
     case 'skipped':
       return t('Downloads.Automatic Download Skipped')
     default:

--- a/src/renderer/views/Downloads/Downloads.css
+++ b/src/renderer/views/Downloads/Downloads.css
@@ -13,6 +13,7 @@
 }
 
 .downloadsHeader {
+  flex-wrap: wrap;
   gap: 20px;
   justify-content: space-between;
   min-block-size: 40px;
@@ -22,6 +23,14 @@
 .downloadsHeader p {
   color: var(--secondary-text-color);
   margin: 0;
+}
+
+.downloadHeaderActions {
+  align-items: center;
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px;
+  justify-content: flex-end;
 }
 
 .downloadRow h3,
@@ -73,6 +82,7 @@
 
 .downloadStatus,
 .downloadAvailability,
+.downloadSpaceWarning,
 .downloadSummary,
 .destination {
   color: var(--secondary-text-color);
@@ -85,6 +95,10 @@
 
 .downloadAvailability.missing {
   color: var(--destructive-color);
+}
+
+.downloadSpaceWarning {
+  color: var(--primary-color);
 }
 
 .downloadError {
@@ -157,6 +171,7 @@
   }
 
   .downloadActions {
+    flex-wrap: wrap;
     justify-content: flex-end;
   }
 

--- a/src/renderer/views/Downloads/Downloads.vue
+++ b/src/renderer/views/Downloads/Downloads.vue
@@ -7,14 +7,40 @@
       <p>
         {{ t('Downloads.Total Size', { size: formattedTotalSize }) }}
       </p>
-      <FtButton
-        v-if="clearableDownloads.length > 0"
-        :label="t('Downloads.Clear Failed Canceled Skipped And Missing')"
-        :icon="['fas', 'trash']"
-        :text-color="null"
-        :background-color="null"
-        @click="clearFailedAndMissing"
-      />
+      <div class="downloadHeaderActions">
+        <FtButton
+          v-if="pausableDownloads.length > 0"
+          :label="t('Downloads.Pause All')"
+          :icon="['fas', 'pause']"
+          :text-color="null"
+          :background-color="null"
+          @click="queueAction('pause-all')"
+        />
+        <FtButton
+          v-if="resumableDownloads.length > 0"
+          :label="t('Downloads.Resume All')"
+          :icon="['fas', 'play']"
+          :text-color="null"
+          :background-color="null"
+          @click="queueAction('resume-all')"
+        />
+        <FtButton
+          v-if="failedDownloads.length > 0"
+          :label="t('Downloads.Retry All')"
+          :icon="['fas', 'sync']"
+          :text-color="null"
+          :background-color="null"
+          @click="queueAction('retry-all')"
+        />
+        <FtButton
+          v-if="clearableDownloads.length > 0"
+          :label="t('Downloads.Clear Failed Canceled Skipped And Missing')"
+          :icon="['fas', 'trash']"
+          :text-color="null"
+          :background-color="null"
+          @click="clearFailedAndMissing"
+        />
+      </div>
     </div>
 
     <section
@@ -26,6 +52,26 @@
         v-for="download in activeDownloads"
         :key="download.id"
         :download="download"
+        @pause="controlDownload(download.id, 'pause')"
+        @resume="controlDownload(download.id, 'resume')"
+      />
+    </section>
+
+    <section
+      v-if="queuedDownloads.length > 0"
+      class="downloadSection"
+    >
+      <h2>{{ t('Downloads.Queue') }}</h2>
+      <DownloadRow
+        v-for="(download, index) in queuedDownloads"
+        :key="download.id"
+        :download="download"
+        :queue-position="index + 1"
+        :can-move-earlier="index > 0"
+        :can-move-later="index < queuedDownloads.length - 1"
+        @move="controlDownload(download.id, 'move', $event)"
+        @pause="controlDownload(download.id, 'pause')"
+        @resume="controlDownload(download.id, 'resume')"
       />
     </section>
 
@@ -43,6 +89,21 @@
         @open="openDownload(download.id)"
         @play="playDownload(download)"
         @remove="pendingRemoval = download"
+        @retry="retryDownload(download)"
+      />
+    </section>
+
+    <section
+      v-if="canceledDownloads.length > 0"
+      class="downloadSection"
+    >
+      <h2>{{ t('Downloads.Canceled') }}</h2>
+      <DownloadRow
+        v-for="download in canceledDownloads"
+        :key="download.id"
+        :download="download"
+        :retrying="retryingDownloadIds.includes(download.id)"
+        @clear="clearDownload(download.id)"
         @retry="retryDownload(download)"
       />
     </section>
@@ -85,9 +146,21 @@ const router = useRouter()
 const pendingRemoval = ref(null)
 const retryingDownloadIds = ref([])
 const downloads = computed(() => Object.values(store.getters.getYtDlpDownloads).sort((a, b) => b.id - a.id))
-const activeDownloads = computed(() => downloads.value.filter(download => ['downloading', 'processing'].includes(download.status)))
-const finishedDownloads = computed(() => downloads.value.filter(download => !['downloading', 'processing'].includes(download.status)))
-const clearableDownloads = computed(() => finishedDownloads.value.filter(download => (
+const activeDownloads = computed(() => downloads.value.filter(download => (
+  ['downloading', 'processing', 'pausing'].includes(download.status) ||
+  (download.status === 'paused' && download.started === true)
+)))
+const queuedDownloads = computed(() => downloads.value
+  .filter(download => download.status === 'queued' || (download.status === 'paused' && download.started !== true))
+  .sort((a, b) => (a.queuePosition ?? a.id) - (b.queuePosition ?? b.id)))
+const canceledDownloads = computed(() => downloads.value.filter(download => download.status === 'cancelled'))
+const finishedDownloads = computed(() => downloads.value.filter(download => (
+  !['queued', 'downloading', 'processing', 'pausing', 'paused', 'cancelled'].includes(download.status)
+)))
+const pausableDownloads = computed(() => downloads.value.filter(download => ['queued', 'downloading', 'processing'].includes(download.status)))
+const resumableDownloads = computed(() => downloads.value.filter(download => ['paused', 'pausing'].includes(download.status)))
+const failedDownloads = computed(() => finishedDownloads.value.filter(download => download.status === 'failed'))
+const clearableDownloads = computed(() => downloads.value.filter(download => (
   ['failed', 'cancelled', 'skipped'].includes(download.status) ||
   (download.status === 'completed' && download.availability === 'missing')
 )))
@@ -122,6 +195,13 @@ async function clearFailedAndMissing() {
   const ids = clearableDownloads.value.map(download => download.id)
   await window.ftElectron.ytDlpClearDownloads(ids)
   ids.forEach(id => store.commit('removeYtDlpDownload', id))
+}
+async function controlDownload(id, action, value) {
+  await window.ftElectron.ytDlpControlDownload(id, action, value)
+}
+async function queueAction(action) {
+  await window.ftElectron.ytDlpQueueAction(action)
+  await refreshDownloads()
 }
 async function openDownload(id) {
   if (!await window.ftElectron.ytDlpOpenDownload(id)) {

--- a/static/locales/de-DE.yaml
+++ b/static/locales/de-DE.yaml
@@ -1055,6 +1055,8 @@ Settings:
     Managed Tools Download Error Template: 'Die verwalteten Tools konnten nicht heruntergeladen werden: {errors}'
     Download Folder: Download-Ordner
     Global Additional yt-dlp Arguments: Globale zusätzliche yt-dlp-Argumente
+    Concurrent Downloads: Gleichzeitige Downloads
+    Bandwidth Limit: Bandbreitenlimit (KiB/s, 0 für unbegrenzt)
     Choose Download Folder: Download-Ordner auswählen
     Templates Hint: Benutzerdefinierte Download-Vorlagen können im Download-Dialog erstellt und verwaltet werden, der sich unterhalb des Video-Players befindet.
     External Software Hint: yt-dlp und FFmpeg werden in den Einstellungen für externe Software konfiguriert.
@@ -1964,6 +1966,8 @@ Tooltips:
   Download Settings:
     Download Folder: Videos werden in diesem Ordner gespeichert. Leer lassen, um den Downloads-Ordner deines Systems zu verwenden.
     Global Additional yt-dlp Arguments: Zusätzliche Befehlszeilenargumente, die bei jedem Download an yt-dlp übergeben werden, zum Beispiel --cookies-from-browser firefox.
+    Concurrent Downloads: Die maximale Anzahl von yt-dlp-Aufträgen, die gleichzeitig ausgeführt werden dürfen.
+    Bandwidth Limit: Begrenzt die gesamte Übertragungsrate der Warteschlange, indem das Limit auf gleichzeitige Aufträge verteilt wird. Gib 0 für kein Limit ein.
   External Software Settings:
     yt-dlp Source: OpenTubeX kann entweder das auf deinem System installierte yt-dlp verwenden oder eine eigene Kopie von yt-dlp herunterladen und verwalten, die im Benutzerdatenverzeichnis gespeichert wird.
     yt-dlp Channel: Wähle aus, welchen yt-dlp-Veröffentlichungskanal OpenTubeX herunterlädt und verwaltet. Für die meisten Benutzer wird „Stable“ empfohlen.
@@ -2108,6 +2112,7 @@ KeyboardShortcutPrompt:
   History Backward: Eine Seite zurückgehen
   New Window: Ein neues Fenster öffnen
   Navigate to Settings: Zur Einstellungsseite navigieren
+  Navigate to Downloads: Downloads öffnen
   Navigate to History: Zur Verlaufsseite navigieren
   Stats: Video-Statistiken anzeigen
   Fullscreen: Vollbildmodus umschalten
@@ -2287,10 +2292,17 @@ Downloads:
   Choose Folder: Ändern
   System Downloads Folder: Downloads-Ordner des Systems
   Processing: Verarbeitung läuft…
+  Queued: In Warteschlange
+  Queued Position: 'Position in Warteschlange: {position}'
+  Paused: Pausiert
+  Pausing: Der aktuelle Auftrag wird abgeschlossen, dann wird die Warteschlange pausiert
   Download Complete: Download abgeschlossen
   Download Cancelled: Download abgebrochen
   Download Failed: Download fehlgeschlagen
   File Name Shortened: Der Dateiname wurde gekürzt, weil der Videotitel zu lang war.
+  Insufficient Disk Space: Nicht genügend Speicherplatz. Ungefähr {required} werden benötigt und {available} sind verfügbar.
+  Unknown Download Size: Die Downloadgröße ist unbekannt. Auf dem Zieldateisystem sind {available} verfügbar.
+  Disk Space Check Unavailable: Der verfügbare Speicherplatz konnte vor Beginn dieses Downloads nicht geprüft werden.
   Cancel Download: Download abbrechen
   yt-dlp Not Found: yt-dlp wurde nicht gefunden. Installiere es oder lege den Pfad in den Download-Einstellungen fest.
   Download Complete Template: Download von „{title}“ ist abgeschlossen
@@ -2305,7 +2317,9 @@ Downloads:
   Downloads: Downloads
   Download Playlist: Wiedergabeliste herunterladen
   Downloading: Wird heruntergeladen
+  Queue: Warteschlange
   Downloaded: Heruntergeladen
+  Canceled: Abgebrochen
   Open Downloads: Downloads öffnen
   No Downloads: Noch keine Downloads
   No Downloads Description: Gestartete Downloads erscheinen hier.
@@ -2314,6 +2328,13 @@ Downloads:
   Show in Folder: Im Ordner anzeigen
   Play Download: Download wiedergeben
   Retry Download: Download erneut versuchen
+  Pause Download: Download pausieren
+  Resume Download: Download fortsetzen
+  Move Earlier: Nach vorne verschieben
+  Move Later: Nach hinten verschieben
+  Pause All: Alle pausieren
+  Resume All: Alle fortsetzen
+  Retry All: Alle fehlgeschlagenen Downloads erneut versuchen
   Total Size: 'Gesamtgröße: {size}'
   Local File: Lokale Datei
   Available Offline: Offline verfügbar

--- a/static/locales/de-DE.yaml
+++ b/static/locales/de-DE.yaml
@@ -1055,7 +1055,7 @@ Settings:
     Managed Tools Download Error Template: 'Die verwalteten Tools konnten nicht heruntergeladen werden: {errors}'
     Download Folder: Download-Ordner
     Global Additional yt-dlp Arguments: Globale zusätzliche yt-dlp-Argumente
-    Concurrent Downloads: Gleichzeitige Downloads
+    Concurrent Downloads: Parallele Downloads
     Bandwidth Limit: Bandbreitenlimit (KiB/s, 0 für unbegrenzt)
     Choose Download Folder: Download-Ordner auswählen
     Templates Hint: Benutzerdefinierte Download-Vorlagen können im Download-Dialog erstellt und verwaltet werden, der sich unterhalb des Video-Players befindet.
@@ -1966,8 +1966,8 @@ Tooltips:
   Download Settings:
     Download Folder: Videos werden in diesem Ordner gespeichert. Leer lassen, um den Downloads-Ordner deines Systems zu verwenden.
     Global Additional yt-dlp Arguments: Zusätzliche Befehlszeilenargumente, die bei jedem Download an yt-dlp übergeben werden, zum Beispiel --cookies-from-browser firefox.
-    Concurrent Downloads: Die maximale Anzahl von yt-dlp-Aufträgen, die gleichzeitig ausgeführt werden dürfen.
-    Bandwidth Limit: Begrenzt die gesamte Übertragungsrate der Warteschlange, indem das Limit auf gleichzeitige Aufträge verteilt wird. Gib 0 für kein Limit ein.
+    Concurrent Downloads: Die maximale Anzahl von yt-dlp-Downloads, die gleichzeitig ausgeführt werden dürfen.
+    Bandwidth Limit: Begrenzt die gesamte Übertragungsrate der Warteschlange, indem das Limit auf parallele Downloads verteilt wird. Gib 0 für kein Limit ein.
   External Software Settings:
     yt-dlp Source: OpenTubeX kann entweder das auf deinem System installierte yt-dlp verwenden oder eine eigene Kopie von yt-dlp herunterladen und verwalten, die im Benutzerdatenverzeichnis gespeichert wird.
     yt-dlp Channel: Wähle aus, welchen yt-dlp-Veröffentlichungskanal OpenTubeX herunterlädt und verwaltet. Für die meisten Benutzer wird „Stable“ empfohlen.
@@ -2295,7 +2295,7 @@ Downloads:
   Queued: In Warteschlange
   Queued Position: 'Position in Warteschlange: {position}'
   Paused: Pausiert
-  Pausing: Der aktuelle Auftrag wird abgeschlossen, dann wird die Warteschlange pausiert
+  Pausing: Der aktuelle Download wird abgeschlossen, dann wird die Warteschlange pausiert
   Download Complete: Download abgeschlossen
   Download Cancelled: Download abgebrochen
   Download Failed: Download fehlgeschlagen

--- a/static/locales/en-US.yaml
+++ b/static/locales/en-US.yaml
@@ -970,6 +970,8 @@ Settings:
     Managed Tools Download Error Template: 'Could not download the managed tools: {errors}'
     Download Folder: Download Folder
     Global Additional yt-dlp Arguments: Global Additional yt-dlp Arguments
+    Concurrent Downloads: Concurrent downloads
+    Bandwidth Limit: Bandwidth limit (KiB/s, 0 for unlimited)
     Choose Download Folder: Choose Download Folder
     Download Templates: Download Templates
     Manage Download Templates: 'Manage Download Templates ({templateCount})'
@@ -2238,6 +2240,8 @@ Tooltips:
   Download Settings:
     Download Folder: Videos are saved to this folder. Leave blank to use your system's Downloads folder.
     Global Additional yt-dlp Arguments: Additional command line arguments passed to yt-dlp for every download, for example --cookies-from-browser firefox.
+    Concurrent Downloads: The maximum number of yt-dlp jobs that may run at once.
+    Bandwidth Limit: Caps the queue's combined transfer rate by dividing this limit between concurrent jobs. Enter 0 for no limit.
   External Software Settings:
     yt-dlp Source: OpenTubeX can either use the yt-dlp installed on your system or download
       and manage its own copy of yt-dlp, which is stored in the user data directory.
@@ -2384,6 +2388,7 @@ KeyboardShortcutPrompt:
   Switch to Tab: Switch to tab 1–9
   Toggle Tab Orientation: Switch between tab layouts
   Navigate to Settings: Navigate to the Settings page
+  Navigate to Downloads: Open Downloads
   Navigate to History: Navigate to the History page
   Refresh: Refresh feed with latest content
   Find in Page: Find text on the current page
@@ -2472,7 +2477,9 @@ Downloads:
   Download Video: Download Video
   Download Playlist: Download Playlist
   Downloading: Downloading
+  Queue: Queue
   Downloaded: Downloaded
+  Canceled: Canceled
   Open Downloads: Open Downloads
   No Downloads: No downloads yet
   No Downloads Description: Downloads you start will appear here.
@@ -2481,6 +2488,13 @@ Downloads:
   Show in Folder: Show in Folder
   Play Download: Play download
   Retry Download: Retry download
+  Pause Download: Pause download
+  Resume Download: Resume download
+  Move Earlier: Move earlier
+  Move Later: Move later
+  Pause All: Pause all
+  Resume All: Resume all
+  Retry All: Retry all failed downloads
   Total Size: 'Total size: {size}'
   Local File: Local file
   Available Offline: Available offline
@@ -2534,10 +2548,17 @@ Downloads:
   Folder Required: Choose a download folder to enable downloads.
   System Downloads Folder: System Downloads Folder
   Processing: Processing…
+  Queued: Queued
+  Queued Position: 'Queued, position {position}'
+  Paused: Paused
+  Pausing: The current job will finish, then the queue will pause
   Download Complete: Download complete
   Download Cancelled: Download canceled
   Download Failed: Download failed
   File Name Shortened: The file name was shortened because the video title was too long.
+  Insufficient Disk Space: Not enough disk space. About {required} is needed and {available} is available.
+  Unknown Download Size: Download size is unknown. {available} is available on the destination filesystem.
+  Disk Space Check Unavailable: Available disk space could not be checked before starting this download.
   Download Failure Hint: Check {issuesLink}, then try switching the yt-dlp channel to Nightly or Master in Settings → Advanced → External Software.
   yt-dlp YouTube Issues: recent yt-dlp issues for YouTube
   Automatic Download Started: Automatic download started

--- a/tests/unit/download-queue.test.mjs
+++ b/tests/unit/download-queue.test.mjs
@@ -5,6 +5,7 @@ import {
   compareQueuedDownloads,
   normalizeDownloadBandwidth,
   normalizeDownloadConcurrency,
+  updatePendingDownloadStatuses,
 } from '../../src/main/downloadQueue.js'
 
 test('normalizes download queue limits', () => {
@@ -24,4 +25,22 @@ test('sorts queued downloads by position', () => {
     { id: 4, queuePosition: 1 },
   ]
   assert.deepEqual(downloads.sort(compareQueuedDownloads).map(download => download.id), [2, 4, 1, 3])
+})
+
+test('updates only pending download statuses when pausing and resuming the queue', () => {
+  const records = new Map([
+    [1, { id: 1, status: 'queued' }],
+    [2, { id: 2, status: 'paused' }],
+    [3, { id: 3, status: 'completed' }],
+  ])
+  const pendingIds = [1, 2, 3]
+
+  assert.deepEqual(updatePendingDownloadStatuses(records, pendingIds, 'paused'), [records.get(1)])
+  assert.equal(records.get(1).status, 'paused')
+  assert.equal(records.get(3).status, 'completed')
+
+  assert.deepEqual(updatePendingDownloadStatuses(records, pendingIds, 'queued'), [records.get(1), records.get(2)])
+  assert.equal(records.get(1).status, 'queued')
+  assert.equal(records.get(2).status, 'queued')
+  assert.equal(records.get(3).status, 'completed')
 })

--- a/tests/unit/download-queue.test.mjs
+++ b/tests/unit/download-queue.test.mjs
@@ -1,0 +1,27 @@
+import assert from 'node:assert/strict'
+import test from 'node:test'
+
+import {
+  compareQueuedDownloads,
+  normalizeDownloadBandwidth,
+  normalizeDownloadConcurrency,
+} from '../../src/main/downloadQueue.js'
+
+test('normalizes download queue limits', () => {
+  assert.equal(normalizeDownloadConcurrency('4'), 4)
+  assert.equal(normalizeDownloadConcurrency('0'), 1)
+  assert.equal(normalizeDownloadConcurrency('99'), 10)
+  assert.equal(normalizeDownloadConcurrency('invalid'), 2)
+  assert.equal(normalizeDownloadBandwidth('2048'), 2048)
+  assert.equal(normalizeDownloadBandwidth('-1'), 0)
+})
+
+test('sorts queued downloads by position', () => {
+  const downloads = [
+    { id: 1, queuePosition: 2 },
+    { id: 2, queuePosition: 1 },
+    { id: 3, queuePosition: 3 },
+    { id: 4, queuePosition: 1 },
+  ]
+  assert.deepEqual(downloads.sort(compareQueuedDownloads).map(download => download.id), [2, 4, 1, 3])
+})

--- a/tests/unit/download-queue.test.mjs
+++ b/tests/unit/download-queue.test.mjs
@@ -5,6 +5,7 @@ import {
   compareQueuedDownloads,
   normalizeDownloadBandwidth,
   normalizeDownloadConcurrency,
+  resumePendingDownload,
   updatePendingDownloadStatuses,
 } from '../../src/main/downloadQueue.js'
 
@@ -43,4 +44,14 @@ test('updates only pending download statuses when pausing and resuming the queue
   assert.equal(records.get(1).status, 'queued')
   assert.equal(records.get(2).status, 'queued')
   assert.equal(records.get(3).status, 'completed')
+})
+
+test('preserves an individual resume when a restarted download joins a paused queue', () => {
+  const record = { id: 5, status: 'paused' }
+  const pendingIds = new Map([[record.id, () => {}]])
+  const individuallyResumedIds = new Set()
+
+  assert.equal(resumePendingDownload(record, pendingIds, individuallyResumedIds, true), true)
+  assert.equal(record.status, 'queued')
+  assert.deepEqual([...individuallyResumedIds], [record.id])
 })

--- a/tests/unit/download-queue.test.mjs
+++ b/tests/unit/download-queue.test.mjs
@@ -48,10 +48,9 @@ test('updates only pending download statuses when pausing and resuming the queue
 
 test('preserves an individual resume when a restarted download joins a paused queue', () => {
   const record = { id: 5, status: 'paused' }
-  const pendingIds = new Map([[record.id, () => {}]])
   const individuallyResumedIds = new Set()
 
-  assert.equal(resumePendingDownload(record, pendingIds, individuallyResumedIds, true), true)
+  assert.equal(resumePendingDownload(record, individuallyResumedIds, true), true)
   assert.equal(record.status, 'queued')
   assert.deepEqual([...individuallyResumedIds], [record.id])
 })

--- a/tests/unit/keyboard-shortcuts.test.mjs
+++ b/tests/unit/keyboard-shortcuts.test.mjs
@@ -45,3 +45,7 @@ test('keeps contextual app shortcuts fixed', () => {
     sanitizedOverrides
   )
 })
+
+test('opens downloads with Ctrl or Command+J by default', () => {
+  assert.equal(getConfiguredKeyboardShortcuts().APP.GENERAL.NAVIGATE_TO_DOWNLOADS, 'ctrl+J')
+})


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Make sure to follow the contributing guidelines. -->
<!-- Important note, we may remove your pull request if you do not use this provided PR template correctly. -->
<!-- Agent instructions: Preserve every heading, comment, and marker in this template. Never remove or rewrite the release-note-category:start/end, release-note:start/end, or release-note-image:start/end marker pairs. Never remove or rewrite the Release note images section; leave its contents for a human. -->

## Pull Request Type
<!-- Please select what type of pull request this is: [x] -->
- [ ] Bugfix
- [x] Feature Implementation
- [ ] Documentation
- [ ] Other

## Related issue
<!-- Please link the issue your pull request is referring to. -->
<!-- If this pull request fully resolves the relevant issue, put "closes" before the issue number. -->
<!-- Example: "closes #123456". -->
Closes #856

## Description
<!-- Please write a clear and concise description of what the pull request does. -->
The Downloads page could start and cancel individual jobs, but it could not control pending work or limit the resources used by multiple downloads.

This adds one persistent queue for manual and automatic downloads. Users can reorder pending downloads, pause or resume individual jobs or the whole queue, retry failed jobs in bulk, and configure concurrency and a shared bandwidth limit. The queue survives app restarts and checks destination disk space before each job starts.

Canceled downloads have their own section and do not trigger or participate in retry-all. Completed and canceled rows no longer repeat their section heading as status text. Ctrl/Cmd+J now opens Downloads, and the new queue settings align with the existing download fields.

Priority tiers and scheduled start windows are intentionally excluded from the final scope.

## Release note category
<!-- Select exactly one category. Every pull request must select one. -->
<!-- Select "Not noteworthy" when the pull request fixes a bug in or improves functionality that has not yet appeared in a stable release. -->
<!-- release-note-category:start -->
- [ ] Not noteworthy
- [ ] Highlights
- [x] More improvements
- [ ] Fixed bugs
<!-- release-note-category:end -->

## Release note
<!-- Required unless "Not noteworthy" is selected. -->
<!-- Write one concise, user-facing entry without a leading bullet. -->
<!-- release-note:start -->
Downloads now use a persistent, controllable queue with concurrency and bandwidth limits, and Ctrl/Cmd+J opens the Downloads page.
<!-- release-note:end -->

## Release note images
<!-- Human-only: Agents must preserve this entire section and leave it empty. -->
<!-- Optional. Paste one or more Markdown images or HTML image tags here. -->
<!-- The release notes will use an HTML image tag and limit images taller than 300 pixels. -->
<!-- release-note-image:start -->

<!-- release-note-image:end -->

## Testing
<!-- How can reviewers verify that the PR produces correct results? -->
<!-- Please provide instructions so that others can ensure that your pull request would produce correct results. For examples see, https://github.com/FreeTubeApp/FreeTube/pull/5743, https://github.com/FreeTubeApp/FreeTube/pull/7349, https://github.com/FreeTubeApp/FreeTube/pull/5125, https://github.com/FreeTubeApp/FreeTube/pull/7338 -->
<!-- Agent instructions: Only write human-facing steps that explain how to verify the change while running this branch in dev mode. Include expected results and, when applicable, helpful console snippets for interactive verification. Do not include automated checks, commands, results, pass counts, or CI status. -->
1. Enable downloads, set concurrent downloads to 1, and start several manual and automatic downloads. Only one job should run while the rest appear in Queue.
2. Move queued jobs earlier and later. Pause and resume individual jobs, then use Pause all and Resume all. The displayed order and states should follow each action.
3. Set a bandwidth limit and verify yt-dlp respects the shared cap. Set it back to 0 and verify downloads are unlimited.
4. Restart the app with queued or paused jobs. Queued jobs should resume automatically, while paused jobs should stay paused.
5. Cancel a queued job. It should move to Canceled, stay out of Downloaded, and neither show nor participate in Retry all failed downloads.
6. Press Ctrl+J on Linux or Windows, or Cmd+J on macOS. The Downloads page should open.
7. Compare the two download setting rows at 100% and a non-100% UI scale. Their columns, labels, controls, and help icons should remain aligned.

## Additional context
<!-- Add any other context about the pull request here. -->
On platforms where suspending an active yt-dlp process is not reliable, pausing lets the current job finish and stops the queue before the next job starts.
