### PR TITLE
fix(search): stop filtered pagination when exhausted

### DIFF
--- a/src/renderer/helpers/search-continuation.js
+++ b/src/renderer/helpers/search-continuation.js
@@ -1,8 +1,11 @@
-const EMPTY_SEARCH_CONTINUATION_ERROR = 'No contents found in search response'
+const EXHAUSTED_SEARCH_CONTINUATION_ERRORS = [
+  'No contents found in search response',
+  'There are no continuations'
+]
 
 /**
- * YouTube returns a response without contents when a filtered search has
- * reached its end. youtubei.js represents that terminal state as an error.
+ * youtubei.js reports an exhausted filtered search as an error when the
+ * response has no contents or when the current feed has no continuation.
  *
  * @template T
  * @param {() => Promise<T>} loadContinuation
@@ -12,7 +15,10 @@ export async function loadSearchContinuation(loadContinuation) {
   try {
     return await loadContinuation()
   } catch (error) {
-    if (error instanceof Error && error.message === EMPTY_SEARCH_CONTINUATION_ERROR) {
+    const isExpectedContinuationError = error instanceof Error &&
+      EXHAUSTED_SEARCH_CONTINUATION_ERRORS.includes(error.message)
+
+    if (isExpectedContinuationError) {
       return null
     }
 

--- a/tests/unit/search-continuation.test.mjs
+++ b/tests/unit/search-continuation.test.mjs
@@ -11,6 +11,14 @@ test('treats a search continuation without contents as exhausted', async () => {
   assert.equal(result, null)
 })
 
+test('treats a search without a continuation as exhausted', async () => {
+  const result = await loadSearchContinuation(async () => {
+    throw new Error('There are no continuations')
+  })
+
+  assert.equal(result, null)
+})
+
 test('preserves unexpected search continuation errors', async () => {
   const error = new Error('Search request failed')
 


### PR DESCRIPTION
<!-- Thanks for taking the time to contribute to OpenTubeX! -->
<!-- Important: Please preserve every section and marker in this template. -->
<!-- Agent instructions: preserve this template's structure and comments. -->

## Pull Request Type

- [x] Bugfix
- [ ] Feature
- [ ] Refactor
- [ ] Documentation
- [ ] Other

## Related issue

Closes https://gitlab.com/opentubex/OpenTubeX/-/work_items/528

## Description

Filtered searches can reach the end of their result category while youtubei.js reports the terminal feed state as `There are no continuations`. OpenTubeX treated that normal end state as an API error, leaving automatic pagination available to retry.

Recognize both terminal search messages as exhaustion and return the existing null continuation result. Unexpected continuation failures still propagate.

## Release note category

<!-- release-note-category:start -->
- [ ] Not noteworthy
- [ ] Highlights
- [ ] More improvements
- [x] Fixed bugs
<!-- release-note-category:end -->

## Release note

<!-- release-note:start -->
Stopped filtered searches from repeatedly loading after reaching the end of their results
<!-- release-note:end -->

## Release note images

<!-- release-note-image:start -->

<!-- release-note-image:end -->

## Testing

1. Enable automatic loading of paginated items.
2. Search with a restrictive filter such as Channels or Playlists and use a query with few matching results.
3. Scroll to the end. The page should stop loading, show the exhausted-results status, and not retry.

## Additional context

youtubei.js exposes this terminal condition as an exception rather than a null response, so the helper keeps a narrow allowlist and rethrows other errors.
