### PR TITLE
fix(downloads): shorten long titles instead of failing

### DIFF
--- a/e2e/tests/offline/video-actions.spec.mjs
+++ b/e2e/tests/offline/video-actions.spec.mjs
@@ -225,6 +225,43 @@ test.describe('video downloads', () => {
     expect(separatorSpacing.below).toBe(separatorSpacing.above)
   })
 
+  test('shortens overly long generated file names and warns when it happens', async ({ app, page }) => {
+    const downloadedFile = path.join(app.userDataDir, 'shortened-title.webm')
+    const executable = path.join(app.userDataDir, 'long-title-yt-dlp.sh')
+    const capturedArgs = path.join(app.userDataDir, 'long-title-yt-dlp-args.txt')
+    const longTitle = '界'.repeat(80)
+    const metadataLine = `__OPENTUBEX_METADATA__:${JSON.stringify('eeeeeeeeeee')}\t${JSON.stringify(longTitle)}\tnull`
+    await writeFile(downloadedFile, '')
+    await writeFile(executable, [
+      '#!/bin/sh',
+      `printf '%s\\n' "$@" > '${capturedArgs}'`,
+      `printf '%s\\n' '${metadataLine}'`,
+      `printf '__OPENTUBEX_FILE__:eeeeeeeeeee\\t1\\t640\\t360\\t${downloadedFile}\\n'`
+    ].join('\n'))
+    await chmod(executable, 0o755)
+    await page.evaluate(async (ytDlpPath) => {
+      const store = document.querySelector('#app').__vue_app__.config.globalProperties.$store
+      await store.dispatch('updateYtDlpPath', ytDlpPath)
+    }, executable)
+
+    await goTo(page, 'history')
+    const video = page.locator('.ft-list-video').first()
+    await video.hover()
+    await video.locator('.optionsButton').click()
+    await page.getByRole('option', { name: 'Download Video' }).click()
+    await page.getByRole('button', { name: 'Download', exact: true }).click()
+
+    await expect(page.getByText('Download complete', { exact: true })).toBeVisible()
+    await expect(page.getByText('The file name was shortened because the video title was too long.')).toBeVisible()
+    const passedArguments = (await readFile(capturedArgs, 'utf8')).trim().split('\n')
+    expect(passedArguments[passedArguments.indexOf('--output') + 1]).toBe('%(title).200B [%(id)s].%(ext)s')
+
+    await page.getByRole('button', { name: 'Close', exact: true }).click()
+    await goTo(page, 'downloads')
+    const downloadRow = page.locator('.downloadRow').filter({ hasText: longTitle })
+    await expect(downloadRow.getByText('The file name was shortened because the video title was too long.')).toBeVisible()
+  })
+
   test('can retry playback extraction with yt-dlp default clients', async ({ app, page }) => {
     const executable = path.join(app.userDataDir, 'capture-yt-dlp-playback-args.sh')
     const capturedArgs = path.join(app.userDataDir, 'captured-yt-dlp-playback-args.txt')
@@ -532,6 +569,7 @@ test.describe('video downloads', () => {
     await goTo(page, 'downloads')
     const downloadRow = page.locator('.downloadRow').filter({ hasText: currentTitle })
     await expect(downloadRow).toBeVisible()
+    await expect(downloadRow.locator('.downloadWarning')).toHaveCount(0)
     await expect(downloadRow.locator('.downloadThumbnail')).toHaveAttribute('src', currentThumbnail)
   })
 

--- a/e2e/tests/offline/video-actions.spec.mjs
+++ b/e2e/tests/offline/video-actions.spec.mjs
@@ -262,6 +262,41 @@ test.describe('video downloads', () => {
     await expect(downloadRow.getByText('The file name was shortened because the video title was too long.')).toBeVisible()
   })
 
+  test('warns when a playlist contains a shortened video title', async ({ app, page }) => {
+    const downloadedFile = path.join(app.userDataDir, 'shortened-playlist-title.webm')
+    const executable = path.join(app.userDataDir, 'long-playlist-title-yt-dlp.sh')
+    const longTitle = '界'.repeat(80)
+    const metadataLine = `__OPENTUBEX_METADATA__:${JSON.stringify('eeeeeeeeeee')}\t${JSON.stringify(longTitle)}\tnull`
+    await writeFile(downloadedFile, '')
+    await writeFile(executable, [
+      '#!/bin/sh',
+      `printf '%s\\n' '${metadataLine}'`,
+      `printf '__OPENTUBEX_FILE__:eeeeeeeeeee\\t1\\t640\\t360\\t${downloadedFile}\\n'`
+    ].join('\n'))
+    await chmod(executable, 0o755)
+    await page.evaluate(async (ytDlpPath) => {
+      const store = document.querySelector('#app').__vue_app__.config.globalProperties.$store
+      await store.dispatch('updateYtDlpPath', ytDlpPath)
+    }, executable)
+
+    const result = await page.evaluate(() => window.ftElectron.ytDlpDownload({
+      videoIds: ['eeeeeeeeeee'],
+      isPlaylist: true,
+      title: 'Playlist with a long title',
+      mode: 'video'
+    }))
+    await expect.poll(() => page.evaluate(async (id) => {
+      return (await window.ftElectron.ytDlpListDownloads()).find(download => download.id === id)
+    }, result.id)).toMatchObject({
+      status: 'completed',
+      titleTruncated: true
+    })
+
+    await goTo(page, 'downloads')
+    const downloadRow = page.locator('.downloadRow').filter({ hasText: 'Playlist with a long title' })
+    await expect(downloadRow.getByText('The file name was shortened because the video title was too long.')).toBeVisible()
+  })
+
   test('can retry playback extraction with yt-dlp default clients', async ({ app, page }) => {
     const executable = path.join(app.userDataDir, 'capture-yt-dlp-playback-args.sh')
     const capturedArgs = path.join(app.userDataDir, 'captured-yt-dlp-playback-args.txt')

--- a/e2e/tests/offline/video-actions.spec.mjs
+++ b/e2e/tests/offline/video-actions.spec.mjs
@@ -1141,6 +1141,44 @@ test.describe('video downloads', () => {
     ])
   })
 
+  test('warns when a subtitle playlist contains a shortened video title', async ({ app, page }) => {
+    const executable = path.join(app.userDataDir, 'long-subtitle-playlist-title-yt-dlp.sh')
+    const argumentsFile = path.join(app.userDataDir, 'long-subtitle-playlist-title-arguments.txt')
+    const longTitle = '界'.repeat(80)
+    const metadataLine = `__OPENTUBEX_METADATA__:${JSON.stringify('eeeeeeeeeee')}\t${JSON.stringify(longTitle)}\tnull`
+    await writeFile(executable, [
+      '#!/bin/sh',
+      `printf '%s\\n' "$@" > ${argumentsFile}`,
+      `printf '%s\\n' '${metadataLine}'`,
+      'printf "[info] Writing video subtitles to: /tmp/subtitles.en.srt\\n"'
+    ].join('\n'))
+    await chmod(executable, 0o755)
+    await page.evaluate(async (ytDlpPath) => {
+      const store = document.querySelector('#app').__vue_app__.config.globalProperties.$store
+      await store.dispatch('updateYtDlpPath', ytDlpPath)
+    }, executable)
+
+    const result = await page.evaluate(() => window.ftElectron.ytDlpDownload({
+      videoIds: ['eeeeeeeeeee'],
+      isPlaylist: true,
+      title: 'Subtitle playlist with a long title',
+      mode: 'subtitles',
+      subtitleFormat: 'srt'
+    }))
+    await expect.poll(() => page.evaluate(async (id) => {
+      return (await window.ftElectron.ytDlpListDownloads()).find(download => download.id === id)
+    }, result.id)).toMatchObject({
+      status: 'completed',
+      titleTruncated: true
+    })
+    const passedArguments = (await readFile(argumentsFile, 'utf8')).split('\n')
+    expect(passedArguments).toContain('video:__OPENTUBEX_METADATA__:%(id)j\t%(title)j\t%(thumbnail)j')
+
+    await goTo(page, 'downloads')
+    const downloadRow = page.locator('.downloadRow').filter({ hasText: 'Subtitle playlist with a long title' })
+    await expect(downloadRow.getByText('The file name was shortened because the video title was too long.')).toBeVisible()
+  })
+
   test('keeps the source subtitle destination when conversion fails', async ({ app, page }) => {
     const executable = path.join(app.userDataDir, 'fake-yt-dlp.sh')
     const attemptMarker = path.join(app.userDataDir, 'subtitle-retry-attempted')

--- a/src/main/ytDlp.js
+++ b/src/main/ytDlp.js
@@ -1935,7 +1935,7 @@ async function startYtDlpDownload(
     '--print',
     `after_move:${FINAL_PATH_PREFIX}%(id)s\t%(duration)s\t%(width)s\t%(height)s\t%(filepath)s`,
     '--print',
-    `after_move:${FINAL_METADATA_PREFIX}%(id)j\t%(title)j\t%(thumbnail)j`
+    `${subtitlesOnly ? 'video' : 'after_move'}:${FINAL_METADATA_PREFIX}%(id)j\t%(title)j\t%(thumbnail)j`
   ]
 
   if (!isRemotePlaylist) {

--- a/src/main/ytDlp.js
+++ b/src/main/ytDlp.js
@@ -94,6 +94,7 @@ function takeGetInfoAbortSignal(key) {
  * @property {number} [availableDestinationCount]
  * @property {number} [destinationCount]
  * @property {number} [sizeBytes]
+ * @property {boolean} [titleTruncated]
  * @property {string | null} errorMessage
  */
 
@@ -164,6 +165,9 @@ const MERGER_REGEX = /^\[Merger\] Merging formats into "(.+)"$/
 const SUBTITLE_DESTINATION_REGEX = /^\[info\] Writing video subtitles to: (.+)$/
 const FINAL_PATH_PREFIX = '__OPENTUBEX_FILE__:'
 const FINAL_METADATA_PREFIX = '__OPENTUBEX_METADATA__:'
+// yt-dlp's B conversion limits UTF-8 bytes. Leave room for IDs, extensions,
+// format suffixes, and temporary-file suffixes within a 255-byte file name.
+const DOWNLOAD_TITLE_FILENAME_BYTE_LIMIT = 200
 
 let downloadCounter = 0
 let downloadRecordsSaveQueue = Promise.resolve()
@@ -1967,6 +1971,7 @@ async function startYtDlpDownload(
   let outputTemplate = typeof payload.filenameTemplate === 'string' && payload.filenameTemplate.trim() !== ''
     ? payload.filenameTemplate.trim()
     : '{title} [{id}].{ext}'
+  const truncatesLongTitles = outputTemplate.includes('{title}')
   let localPlaylistTitle = typeof payload.title === 'string'
     ? payload.title.replaceAll(/[<>:"/\\|?*]/g, '_')
       .split('').map(character => {
@@ -1980,7 +1985,7 @@ async function startYtDlpDownload(
   }
   localPlaylistTitle = localPlaylistTitle.replaceAll('%', '%%')
   const templateFields = {
-    title: '%(title)s',
+    title: `%(title).${DOWNLOAD_TITLE_FILENAME_BYTE_LIMIT}B`,
     author: '%(uploader)s',
     upload_date: '%(upload_date)s',
     id: '%(id)s',
@@ -2162,6 +2167,7 @@ async function startYtDlpDownload(
     destination: null,
     destinations: [],
     files: [],
+    titleTruncated: false,
     errorMessage: null
   }
   downloadRecords.set(id, status)
@@ -2201,7 +2207,11 @@ async function startYtDlpDownload(
         const title = JSON.parse(rawTitle)
         const thumbnail = JSON.parse(rawThumbnail)
         if (videoId === status.videoId) {
-          if (typeof title === 'string' && title !== '') status.title = title.slice(0, 255)
+          if (typeof title === 'string' && title !== '') {
+            status.title = title.slice(0, 255)
+            status.titleTruncated = truncatesLongTitles &&
+              Buffer.byteLength(title, 'utf8') > DOWNLOAD_TITLE_FILENAME_BYTE_LIMIT
+          }
           if (typeof thumbnail === 'string') status.thumbnail = thumbnail.slice(0, 2048)
           else if (thumbnail === null) status.thumbnail = ''
           sendStatus(true)

--- a/src/main/ytDlp.js
+++ b/src/main/ytDlp.js
@@ -1933,14 +1933,10 @@ async function startYtDlpDownload(
     '--newline',
     '--progress',
     '--print',
-    `after_move:${FINAL_PATH_PREFIX}%(id)s\t%(duration)s\t%(width)s\t%(height)s\t%(filepath)s`
+    `after_move:${FINAL_PATH_PREFIX}%(id)s\t%(duration)s\t%(width)s\t%(height)s\t%(filepath)s`,
+    '--print',
+    `after_move:${FINAL_METADATA_PREFIX}%(id)j\t%(title)j\t%(thumbnail)j`
   ]
-  if (isSingleVideo) {
-    args.push(
-      '--print',
-      `after_move:${FINAL_METADATA_PREFIX}%(id)j\t%(title)j\t%(thumbnail)j`
-    )
-  }
 
   if (!isRemotePlaylist) {
     args.push('--no-playlist')
@@ -2206,16 +2202,18 @@ async function startYtDlpDownload(
         const videoId = JSON.parse(rawVideoId)
         const title = JSON.parse(rawTitle)
         const thumbnail = JSON.parse(rawThumbnail)
+        if (typeof title === 'string' && title !== '') {
+          status.titleTruncated ||= truncatesLongTitles &&
+            Buffer.byteLength(title, 'utf8') > DOWNLOAD_TITLE_FILENAME_BYTE_LIMIT
+        }
         if (videoId === status.videoId) {
           if (typeof title === 'string' && title !== '') {
             status.title = title.slice(0, 255)
-            status.titleTruncated = truncatesLongTitles &&
-              Buffer.byteLength(title, 'utf8') > DOWNLOAD_TITLE_FILENAME_BYTE_LIMIT
           }
           if (typeof thumbnail === 'string') status.thumbnail = thumbnail.slice(0, 2048)
           else if (thumbnail === null) status.thumbnail = ''
-          sendStatus(true)
         }
+        sendStatus(true)
       } catch {
         // A malformed metadata line must not interfere with the download itself.
       }

--- a/src/renderer/components/WatchVideoDownloadPrompt/WatchVideoDownloadPrompt.css
+++ b/src/renderer/components/WatchVideoDownloadPrompt/WatchVideoDownloadPrompt.css
@@ -220,6 +220,13 @@
   white-space: pre-wrap;
 }
 
+.downloadWarning {
+  color: var(--primary-color);
+  font-size: 0.9rem;
+  margin-block-end: 0;
+  text-align: center;
+}
+
 @keyframes download-progress-indeterminate {
   50% {
     opacity: 0.4;

--- a/src/renderer/components/WatchVideoDownloadPrompt/WatchVideoDownloadPrompt.vue
+++ b/src/renderer/components/WatchVideoDownloadPrompt/WatchVideoDownloadPrompt.vue
@@ -239,6 +239,16 @@
         >
           {{ activeDownload.errorMessage }}
         </p>
+        <p
+          v-if="activeDownload.titleTruncated"
+          class="downloadWarning"
+        >
+          <FtIcon
+            :icon="['fas', 'triangle-exclamation']"
+            aria-hidden="true"
+          />
+          {{ t('Downloads.File Name Shortened') }}
+        </p>
         <DownloadFailureHint v-if="activeDownload.status === 'failed'" />
       </div>
 

--- a/src/renderer/views/Downloads/DownloadRow.vue
+++ b/src/renderer/views/Downloads/DownloadRow.vue
@@ -53,6 +53,16 @@
         >
           {{ errorText }}
         </p>
+        <p
+          v-if="download.titleTruncated"
+          class="downloadWarning"
+        >
+          <FtIcon
+            :icon="['fas', 'triangle-exclamation']"
+            aria-hidden="true"
+          />
+          {{ t('Downloads.File Name Shortened') }}
+        </p>
         <DownloadFailureHint v-if="download.status === 'failed'" />
         <ul
           v-if="destinations.length > 0"
@@ -126,6 +136,7 @@
 </template>
 
 <script setup>
+import { FtIcon } from '@opentubex/icons'
 import { computed } from 'vue'
 import { useI18n } from 'vue-i18n'
 import DownloadFailureHint from '../../components/DownloadFailureHint/DownloadFailureHint.vue'

--- a/src/renderer/views/Downloads/Downloads.css
+++ b/src/renderer/views/Downloads/Downloads.css
@@ -93,6 +93,11 @@
   white-space: pre-wrap;
 }
 
+.downloadWarning {
+  color: var(--primary-color);
+  font-size: 0.9rem;
+}
+
 .destinationList {
   list-style: none;
   margin-block: 4px;

--- a/static/locales/de-DE.yaml
+++ b/static/locales/de-DE.yaml
@@ -2205,6 +2205,7 @@ Downloads:
   Download Complete: Download abgeschlossen
   Download Cancelled: Download abgebrochen
   Download Failed: Download fehlgeschlagen
+  File Name Shortened: Der Dateiname wurde gekürzt, weil der Videotitel zu lang war.
   Cancel Download: Download abbrechen
   yt-dlp Not Found: yt-dlp wurde nicht gefunden. Installiere es oder lege den Pfad in den Download-Einstellungen fest.
   Download Complete Template: Download von „{title}“ ist abgeschlossen

--- a/static/locales/en-US.yaml
+++ b/static/locales/en-US.yaml
@@ -2456,6 +2456,7 @@ Downloads:
   Download Complete: Download complete
   Download Cancelled: Download canceled
   Download Failed: Download failed
+  File Name Shortened: The file name was shortened because the video title was too long.
   Download Failure Hint: Check {issuesLink}, then try switching the yt-dlp channel to Nightly or Master in Settings → Advanced → External Software.
   yt-dlp YouTube Issues: recent yt-dlp issues for YouTube
   Automatic Download Started: Automatic download started


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Make sure to follow the contributing guidelines. -->
<!-- Important note, we may remove your pull request if you do not use this provided PR template correctly. -->
<!-- Agent instructions: Preserve every heading, comment, and marker in this template. Never remove or rewrite the release-note-category:start/end, release-note:start/end, or release-note-image:start/end marker pairs. Never remove or rewrite the Release note images section; leave its contents for a human. -->

## Pull Request Type
<!-- Please select what type of pull request this is: [x] -->
- [x] Bugfix
- [ ] Feature Implementation
- [ ] Documentation
- [ ] Other

## Related issue
<!-- Please link the issue your pull request is referring to. -->
<!-- If this pull request fully resolves the relevant issue, put "closes" before the issue number. -->
<!-- Example: "closes #123456". -->
Closes https://gitlab.com/opentubex/OpenTubeX/-/work_items/527

## Description
<!-- Please write a clear and concise description of what the pull request does. -->
Downloads could fail when a video title made yt-dlp exceed the filesystem file-name limit.

Limit the `{title}` portion of generated download names to 200 UTF-8 bytes while preserving the video ID, extension, and yt-dlp suffixes. When yt-dlp shortens a title, show a warning in both the download prompt and Downloads page.

## Release note category
<!-- Select exactly one category. Every pull request must select one. -->
<!-- Select "Not noteworthy" when the pull request fixes a bug in or improves functionality that has not yet appeared in a stable release. -->
<!-- release-note-category:start -->
- [ ] Not noteworthy
- [ ] Highlights
- [ ] More improvements
- [x] Fixed bugs
<!-- release-note-category:end -->

## Release note
<!-- Required unless "Not noteworthy" is selected. -->
<!-- Write one concise, user-facing entry without a leading bullet. -->
<!-- release-note:start -->
Downloads with very long video titles are now shortened instead of failing.
<!-- release-note:end -->

## Release note images
<!-- Human-only: Agents must preserve this entire section and leave it empty. -->
<!-- Optional. Paste one or more Markdown images or HTML image tags here. -->
<!-- The release notes will use an HTML image tag and limit images taller than 300 pixels. -->
<!-- release-note-image:start -->

<!-- release-note-image:end -->

## Testing
<!-- How can reviewers verify that the PR produces correct results? -->
<!-- Please provide instructions so that others can ensure that your pull request produces correct results. For examples see, https://github.com/FreeTubeApp/FreeTube/pull/5743, https://github.com/FreeTubeApp/FreeTube/pull/7349, https://github.com/FreeTubeApp/FreeTube/pull/5125, https://github.com/FreeTubeApp/FreeTube/pull/7338 -->
<!-- Agent instructions: Only write human-facing steps that explain how to verify the change while running this branch in dev mode. Include expected results and, when applicable, helpful console snippets for interactive verification. Do not include automated checks, commands, results, pass counts, or CI status. -->
1. Open a video whose title is long enough to exceed the filesystem file-name limit, such as the video linked in the related issue.
2. Start a video download with the default file-name template.
3. Confirm that the download completes, the saved file keeps its video ID and extension, and the prompt shows a warning that the title was shortened.
4. Open the Downloads page and confirm that the completed download shows the same warning.

## Additional context
<!-- Add any other context about the pull request here. -->
The byte limit leaves room for output extensions, format identifiers, and temporary suffixes inside the common 255-byte file-name limit.
