### PR TITLE
ci(e2e): cache Electron across test shards

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -22,9 +22,83 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
+  prepare-e2e:
+    name: Prepare E2E tests
+    if: ${{ github.event_name != 'pull_request' || github.head_ref != 'weblate-translations' }}
+    runs-on: ubuntu-latest
+
+    permissions:
+      contents: read
+
+    steps:
+    - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+      with:
+        persist-credentials: false
+
+    - name: Use Node.js 24.x
+      uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
+      with:
+        node-version: 24.x
+        package-manager-cache: false
+
+    - name: Install pnpm
+      uses: pnpm/action-setup@0ebf47130e4866e96fce0953f49152a61190b271 # v6.0.9
+      with:
+        version: 11
+        cache: false
+
+    - name: Get pnpm cache directory
+      id: cache_dir
+      shell: bash
+      run: |
+        {
+          echo 'cache_dir<<EOF'
+          pnpm store path
+          echo EOF
+        } >> "$GITHUB_OUTPUT"
+
+    - name: Restore pnpm cache
+      uses: actions/cache/restore@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
+      with:
+        key: ${{ format('node-cache-{0}-{1}-pnpm-{2}', runner.os, runner.arch, hashFiles('pnpm-lock.yaml')) }}
+        path: ${{ steps.cache_dir.outputs.cache_dir }}
+
+    - run: pnpm run ci
+      shell: bash
+
+    - name: Get Electron version
+      id: electron
+      run: printf 'version=%s\n' "$(node -p "require('./node_modules/electron/package.json').version")" >> "$GITHUB_OUTPUT"
+      shell: bash
+
+    - name: Cache Electron binary
+      id: electron_cache
+      uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
+      with:
+        key: ${{ format('electron-{0}-{1}-{2}', runner.os, runner.arch, steps.electron.outputs.version) }}
+        path: |
+          node_modules/.pnpm/electron@*/node_modules/electron/dist
+          node_modules/.pnpm/electron@*/node_modules/electron/path.txt
+
+    - name: Install Electron binary
+      if: steps.electron_cache.outputs.cache-hit != 'true'
+      run: pnpm exec install-electron
+      shell: bash
+
+    - run: pnpm run test:e2e:pack
+      shell: bash
+
+    - name: Upload E2E build
+      uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+      with:
+        name: dist-e2e
+        path: dist-e2e/
+        retention-days: 1
+
   e2e-shard:
     name: e2e (${{ matrix.shard }}/4)
     if: ${{ github.event_name != 'pull_request' || github.head_ref != 'weblate-translations' }}
+    needs: prepare-e2e
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false
@@ -74,8 +148,24 @@ jobs:
     - run: pnpm run ci
       shell: bash
 
-    - run: pnpm run test:e2e:pack
+    - name: Get Electron version
+      id: electron
+      run: printf 'version=%s\n' "$(node -p "require('./node_modules/electron/package.json').version")" >> "$GITHUB_OUTPUT"
       shell: bash
+
+    - name: Restore Electron binary
+      uses: actions/cache/restore@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
+      with:
+        key: ${{ format('electron-{0}-{1}-{2}', runner.os, runner.arch, steps.electron.outputs.version) }}
+        path: |
+          node_modules/.pnpm/electron@*/node_modules/electron/dist
+          node_modules/.pnpm/electron@*/node_modules/electron/path.txt
+
+    - name: Download E2E build
+      uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+      with:
+        name: dist-e2e
+        path: dist-e2e
 
     - name: Determine test project
       id: project

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -57,8 +57,8 @@ jobs:
           echo EOF
         } >> "$GITHUB_OUTPUT"
 
-    - name: Restore pnpm cache
-      uses: actions/cache/restore@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
+    - name: Cache pnpm store
+      uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
       with:
         key: ${{ format('node-cache-{0}-{1}-pnpm-{2}', runner.os, runner.arch, hashFiles('pnpm-lock.yaml')) }}
         path: ${{ steps.cache_dir.outputs.cache_dir }}


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Make sure to follow the contributing guidelines. -->
<!-- Important note, we may remove your pull request if you do not use this provided PR template correctly. -->
<!-- Agent instructions: Preserve every heading, comment, and marker in this template. Never remove or rewrite the release-note-category:start/end, release-note:start/end, or release-note-image:start/end marker pairs. Never remove or rewrite the Release note images section; leave its contents for a human. -->

## Pull Request Type
<!-- Please select what type of pull request this is: [x] -->
- [ ] Bugfix
- [ ] Feature Implementation
- [ ] Documentation
- [x] Other

## Related issue
<!-- Please link the issue your pull request is referring to. -->
<!-- If this pull request fully resolves the relevant issue, put "closes" before the issue number. -->
<!-- Example: "closes #123456". -->

## Description
<!-- Please write a clear and concise description of what the pull request does. -->
Electron 43 downloads its binary on first use, outside the pnpm store cache. Every E2E shard therefore downloaded and extracted the same binary before its first test.

This adds a preparation job that installs and caches the exact Electron binary once. It also packs `dist-e2e` once and shares the resulting artifact with all four shards instead of running webpack four times.

## Release note category
<!-- Select exactly one category. Every pull request must select one. -->
<!-- Select "Not noteworthy" when the pull request fixes a bug in or improves functionality that has not yet appeared in a stable release. -->
<!-- release-note-category:start -->
- [x] Not noteworthy
- [ ] Highlights
- [ ] More improvements
- [ ] Fixed bugs
<!-- release-note-category:end -->

## Release note
<!-- Required unless "Not noteworthy" is selected. -->
<!-- Write one concise, user-facing entry without a leading bullet. -->
<!-- release-note:start -->

<!-- release-note:end -->

## Release note images
<!-- Human-only: Agents must preserve this entire section and leave it empty. -->
<!-- Optional. Paste one or more Markdown images or HTML image tags here. -->
<!-- The release notes will use an HTML image tag and limit images taller than 300 pixels. -->
<!-- release-note-image:start -->

<!-- release-note-image:end -->

## Testing
<!-- How can reviewers verify that the PR produces correct results? -->
<!-- Please provide instructions so that others can ensure that your pull request would produce correct results. For examples see, https://github.com/FreeTubeApp/FreeTube/pull/5743, https://github.com/FreeTubeApp/FreeTube/pull/7349, https://github.com/FreeTubeApp/FreeTube/pull/5125, https://github.com/FreeTubeApp/FreeTube/pull/7338 -->
<!-- Agent instructions: Only write human-facing steps that explain how to verify the change while running this branch in dev mode. Include expected results and, when applicable, helpful console snippets for interactive verification. Do not include automated checks, commands, results, pass counts, or CI status. -->
Not applicable. This only changes the GitHub Actions E2E setup and does not affect the app in dev mode.

## Additional context
<!-- Add any other context about the pull request here. -->
Three sampled PR runs each logged four lazy Electron downloads, one in every shard. Those runs also repeated the E2E webpack build four times.
