### PR TITLE
fix(tabs): restart opened order after manual reorder

### DIFF
--- a/e2e/tests/offline/tabs.spec.mjs
+++ b/e2e/tests/offline/tabs.spec.mjs
@@ -214,6 +214,64 @@ test.describe('tab bar', () => {
     ])
   })
 
+  test('single-tab moves reset creation order only when the order changes', async ({ page }) => {
+    const openerTabId = await page.locator(sel.tabs).getAttribute('data-tab-id')
+    const firstVideo = await page.evaluate(openerTabId => window.ftElectron.tabs.create({
+      route: '/watch/first',
+      title: 'First video',
+      makeActive: false,
+      lazyLoad: true,
+      openerTabId
+    }), openerTabId)
+    const secondVideo = await page.evaluate(openerTabId => window.ftElectron.tabs.create({
+      route: '/watch/second',
+      title: 'Second video',
+      makeActive: false,
+      lazyLoad: true,
+      openerTabId
+    }), openerTabId)
+
+    await page.evaluate(tabId => window.ftElectron.tabs.move(tabId, 2), secondVideo.id)
+    const thirdVideo = await page.evaluate(openerTabId => window.ftElectron.tabs.create({
+      route: '/watch/third',
+      title: 'Third video',
+      makeActive: false,
+      lazyLoad: true,
+      openerTabId
+    }), openerTabId)
+
+    await expect.poll(async () => page.locator(sel.tabs).evaluateAll(
+      tabs => tabs.map(tab => tab.dataset.tabId)
+    )).toEqual([openerTabId, firstVideo.id, secondVideo.id, thirdVideo.id])
+
+    await page.evaluate(tabId => window.ftElectron.tabs.move(tabId, 4), secondVideo.id)
+    const fourthVideo = await page.evaluate(openerTabId => window.ftElectron.tabs.create({
+      route: '/watch/fourth',
+      title: 'Fourth video',
+      makeActive: false,
+      lazyLoad: true,
+      openerTabId
+    }), openerTabId)
+    const fifthVideo = await page.evaluate(openerTabId => window.ftElectron.tabs.create({
+      route: '/watch/fifth',
+      title: 'Fifth video',
+      makeActive: false,
+      lazyLoad: true,
+      openerTabId
+    }), openerTabId)
+
+    await expect.poll(async () => page.locator(sel.tabs).evaluateAll(
+      tabs => tabs.map(tab => tab.dataset.tabId)
+    )).toEqual([
+      openerTabId,
+      fourthVideo.id,
+      fifthVideo.id,
+      firstVideo.id,
+      thirdVideo.id,
+      secondVideo.id
+    ])
+  })
+
   test('fixed internal routes use their page title before mounting', async ({ page }) => {
     const fixedRoutes = [
       ['/subscriptions', 'Subscriptions'],

--- a/e2e/tests/offline/tabs.spec.mjs
+++ b/e2e/tests/offline/tabs.spec.mjs
@@ -152,7 +152,7 @@ test.describe('tab bar', () => {
     await expect(page.locator(sel.tabs).nth(1).locator('[data-icon="rss"]')).toBeVisible()
   })
 
-  test('opens background tabs beside their opener in creation order', async ({ page }) => {
+  test('restarts background tab creation order after a manual move', async ({ page }) => {
     const openerTabId = await page.locator(sel.tabs).getAttribute('data-tab-id')
     const existingTab = await page.evaluate(() => window.ftElectron.tabs.create({
       route: '/history',
@@ -181,9 +181,12 @@ test.describe('tab bar', () => {
       tabs => tabs.map(tab => tab.dataset.tabId)
     )).toEqual([openerTabId, firstVideo.id, secondVideo.id, existingTab.id])
 
-    await page.evaluate(({ tabId }) => window.ftElectron.tabs.move(tabId, 3), {
-      tabId: secondVideo.id
-    })
+    await page.evaluate(tabIds => window.ftElectron.tabs.reorder(tabIds), [
+      openerTabId,
+      firstVideo.id,
+      existingTab.id,
+      secondVideo.id
+    ])
     const thirdVideo = await page.evaluate(openerTabId => window.ftElectron.tabs.create({
       route: '/watch/third',
       title: 'Third video',
@@ -191,10 +194,24 @@ test.describe('tab bar', () => {
       lazyLoad: true,
       openerTabId
     }), openerTabId)
+    const fourthVideo = await page.evaluate(openerTabId => window.ftElectron.tabs.create({
+      route: '/watch/fourth',
+      title: 'Fourth video',
+      makeActive: false,
+      lazyLoad: true,
+      openerTabId
+    }), openerTabId)
 
     await expect.poll(async () => page.locator(sel.tabs).evaluateAll(
       tabs => tabs.map(tab => tab.dataset.tabId)
-    )).toEqual([openerTabId, firstVideo.id, thirdVideo.id, existingTab.id, secondVideo.id])
+    )).toEqual([
+      openerTabId,
+      thirdVideo.id,
+      fourthVideo.id,
+      firstVideo.id,
+      existingTab.id,
+      secondVideo.id
+    ])
   })
 
   test('fixed internal routes use their page title before mounting', async ({ page }) => {

--- a/src/main/tabs/TabManager.js
+++ b/src/main/tabs/TabManager.js
@@ -14,6 +14,7 @@ import { TabRendererBridge } from './TabRendererBridge.js'
 import {
   buildReorderedTabMap,
   getGroupedTabInsertIndex,
+  resetTabPlacementOpeners,
   restoreTabPlacementOpeners
 } from './tabOrder.js'
 import {
@@ -2385,6 +2386,7 @@ export class TabManager {
    * @param {number} toIndex
    */
   moveTab(tabId, toIndex) {
+    const currentTabIds = Array.from(this.tabs.keys())
     const entries = Array.from(this.tabs.entries())
     const fromIndex = entries.findIndex(([id]) => id === tabId)
     if (fromIndex === -1) return
@@ -2402,6 +2404,9 @@ export class TabManager {
 
     entries.splice(targetIndex, 0, entry)
     this.tabs = new Map(entries)
+    if (entries.some(([id], index) => id !== currentTabIds[index])) {
+      resetTabPlacementOpeners(this.tabs)
+    }
     this._broadcastStateUpdate()
     this._saveSession()
   }
@@ -2415,6 +2420,7 @@ export class TabManager {
     if (reorderedTabs == null || reorderedTabs === this.tabs) return
 
     this.tabs = reorderedTabs
+    resetTabPlacementOpeners(this.tabs)
     this._broadcastStateUpdate()
     this._saveSession()
   }

--- a/src/main/tabs/tabOrder.js
+++ b/src/main/tabs/tabOrder.js
@@ -32,6 +32,16 @@ export function buildReorderedTabMap(tabs, tabIds) {
 }
 
 /**
+ * Start a new opened-order chain after the user manually rearranges tabs.
+ * @param {Map<string, {placementOpenerTabId?: string | null}>} tabs
+ */
+export function resetTabPlacementOpeners(tabs) {
+  for (const tab of tabs.values()) {
+    tab.placementOpenerTabId = null
+  }
+}
+
+/**
  * Find the end of the contiguous group created from an opener. Tabs moved out
  * of that group do not become its new insertion point.
  * @param {Map<string, {isPinned?: boolean, placementOpenerTabId?: string | null}>} tabs

--- a/tests/unit/tab-order.test.mjs
+++ b/tests/unit/tab-order.test.mjs
@@ -4,6 +4,7 @@ import test from 'node:test'
 import {
   buildReorderedTabMap,
   getGroupedTabInsertIndex,
+  resetTabPlacementOpeners,
   restoreTabPlacementOpeners
 } from '../../src/main/tabs/tabOrder.js'
 
@@ -44,6 +45,21 @@ test('builds a valid changed order without changing tab objects', () => {
   assert.deepEqual(Array.from(reorderedTabs.keys()), ['pinned', 'second', 'first'])
   assert.equal(reorderedTabs.get('first'), tabs.get('first'))
   assert.equal(reorderedTabs.get('second'), tabs.get('second'))
+})
+
+test('resets opened-order chains after a manual reorder', () => {
+  const tabs = new Map([
+    ['subscriptions', { placementOpenerTabId: null }],
+    ['first-video', { placementOpenerTabId: 'subscriptions' }],
+    ['second-video', { placementOpenerTabId: 'subscriptions' }]
+  ])
+
+  resetTabPlacementOpeners(tabs)
+
+  assert.deepEqual(
+    Array.from(tabs.values(), tab => tab.placementOpenerTabId),
+    [null, null, null]
+  )
 })
 
 test('appends new tabs to the contiguous group created from their opener', () => {


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Make sure to follow the contributing guidelines. -->
<!-- Important note, we may remove your pull request if you do not use this provided PR template correctly. -->
<!-- Agent instructions: Preserve every heading, comment, and marker in this template. Never remove or rewrite the release-note-category:start/end, release-note:start/end, or release-note-image:start/end marker pairs. Never remove or rewrite the Release note images section; leave its contents for a human. -->

## Pull Request Type
<!-- Please select what type of pull request this is: [x] -->
- [x] Bugfix
- [ ] Feature Implementation
- [ ] Documentation
- [ ] Other

## Related issue
<!-- Please link the issue your pull request is referring to. -->
<!-- If this pull request fully resolves the relevant issue, put "closes" before the issue number. -->
<!-- Example: "closes #123456". -->

## Description
<!-- Please write a clear and concise description of what the pull request does. -->
The "After current tab in opened order" setting kept its hidden opener chain after tabs were manually rearranged. New tabs could therefore appear according to an order the user had already changed.

Clear the old opener chain after a real manual reorder. The next tab starts a fresh chain beside its opener, while no-op moves leave the existing chain alone.

## Release note category
<!-- Select exactly one category. Every pull request must select one. -->
<!-- Select "Not noteworthy" when the pull request fixes a bug in or improves functionality that has not yet appeared in a stable release. -->
<!-- release-note-category:start -->
- [ ] Not noteworthy
- [ ] Highlights
- [ ] More improvements
- [x] Fixed bugs
<!-- release-note-category:end -->

## Release note
<!-- Required unless "Not noteworthy" is selected. -->
<!-- Write one concise, user-facing entry without a leading bullet. -->
<!-- release-note:start -->
Moving a tab now resets the "After current tab in opened order" sequence.
<!-- release-note:end -->

## Release note images
<!-- Human-only: Agents must preserve this entire section and leave it empty. -->
<!-- Optional. Paste one or more Markdown images or HTML image tags here. -->
<!-- The release notes will use an HTML image tag and limit images taller than 300 pixels. -->
<!-- release-note-image:start -->

<!-- release-note-image:end -->

## Testing
<!-- How can reviewers verify that the PR produces correct results? -->
<!-- Please provide instructions so that others can ensure that your pull request would produce correct results. For examples see, https://github.com/FreeTubeApp/FreeTube/pull/5743, https://github.com/FreeTubeApp/FreeTube/pull/7349, https://github.com/FreeTubeApp/FreeTube/pull/5125, https://github.com/FreeTubeApp/FreeTube/pull/7338 -->
<!-- Agent instructions: Only write human-facing steps that explain how to verify the change while running this branch in dev mode. Include expected results and, when applicable, helpful console snippets for interactive verification. Do not include automated checks, commands, results, pass counts, or CI status. -->
1. Set New Tab Position to "After current tab in opened order".
2. Open several background tabs from the same tab and confirm they appear beside it in the order they were opened.
3. Move any tab to a different position.
4. Open two more background tabs from the original tab. The first should appear directly after the original tab, and the second should appear after the first new tab.

## Additional context
<!-- Add any other context about the pull request here. -->
