### PR TITLE
fix: keep compact settings breadcrumb readable

### DIFF
--- a/e2e/tests/offline/settings.spec.mjs
+++ b/e2e/tests/offline/settings.spec.mjs
@@ -1874,8 +1874,10 @@ test.describe('settings', () => {
     })
     await expect.poll(() => channelList.evaluate(element => element.scrollTop)).toBeGreaterThan(0)
 
+    const settingsBackButton = page.locator('.settingsBackButton')
+    await settingsBackButton.click()
     await recordAnimations(page)
-    await page.locator('.settingsBreadcrumbRoot .settingsWindowIcon').click()
+    await settingsBackButton.click()
     await expect(page.locator('.settingsMenu')).toBeVisible()
     await expectAnimation(page, 'settings-compact-slide-backward')
 
@@ -1887,7 +1889,7 @@ test.describe('settings', () => {
     })
     await expect.poll(() => shortcuts.evaluate(element => element.scrollTop)).toBeGreaterThan(0)
 
-    await page.locator('.settingsBreadcrumbRoot .settingsWindowIcon').click()
+    await settingsBackButton.click()
     await expect(page.locator('.settingsMenu')).toBeVisible()
     await expect(page.locator('.settingsContent')).toBeHidden()
   })
@@ -4282,5 +4284,33 @@ test.describe('performance impact indicators on selects', () => {
       badge.boundingBox()
     ])
     expect(badgeBox.x + badgeBox.width).toBeLessThanOrEqual(selectBox.x + selectBox.width)
+  })
+})
+
+test.describe('localized compact settings breadcrumb', () => {
+  test.use({ seed: { settings: { currentLocale: 'de-DE' } } })
+
+  test('prioritizes the current category over the redundant root label', async ({ page }) => {
+    await page.evaluate(() => {
+      localStorage.setItem('opentubex-settings-window-bounds', JSON.stringify({
+        x: 40,
+        y: 40,
+        width: 650,
+        height: 520
+      }))
+    })
+    await goToSettingsSection(page, 'focus')
+
+    const breadcrumb = page.locator('.settingsBreadcrumb')
+    const root = breadcrumb.locator('.settingsBreadcrumbRoot')
+    const category = breadcrumb.locator('.settingsBreadcrumbLabel')
+
+    await expect(page.locator('.settingsPage')).toHaveClass(/compactSettings/)
+    await expect(root).toBeHidden()
+    await expect(breadcrumb.locator('.settingsBreadcrumbSeparator').first()).toBeHidden()
+    await expect(category.locator('.settingsBreadcrumbText')).toHaveText('Ablenkungsfreier Modus')
+    await expect.poll(() => category.locator('.settingsBreadcrumbText').evaluate(element => (
+      element.scrollWidth <= element.clientWidth + 1
+    ))).toBe(true)
   })
 })

--- a/src/renderer/views/Settings/Settings.css
+++ b/src/renderer/views/Settings/Settings.css
@@ -599,7 +599,7 @@
   user-select: none !important;
 }
 
-@container settings-window (width <= 560px) {
+@container settings-window (width < 760px) {
   .settingsWindowHeader {
     flex-wrap: wrap;
     padding-block: 5px;
@@ -612,7 +612,9 @@
     flex-basis: 100%;
     min-inline-size: 100%;
   }
+}
 
+@container settings-window (width <= 560px) {
   .settingsHeaderButton {
     inline-size: 34px;
     block-size: 34px;

--- a/src/renderer/views/Settings/Settings.vue
+++ b/src/renderer/views/Settings/Settings.vue
@@ -44,6 +44,7 @@
         </span>
         <button
           v-else-if="showBackButton"
+          v-show="isInDesktopView"
           type="button"
           class="settingsBreadcrumbRoot"
           @click="returnToSettingsMenu"
@@ -68,6 +69,7 @@
         </span>
         <template v-if="!isStandaloneViewOpen && currentSectionTitle">
           <FtIcon
+            v-show="isInDesktopView"
             class="settingsBreadcrumbSeparator"
             :icon="['fas', 'angle-right']"
           />


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Make sure to follow the contributing guidelines. -->
<!-- Important note, we may remove your pull request if you do not use this provided PR template correctly. -->
<!-- Agent instructions: Preserve every heading, comment, and marker in this template. Never remove or rewrite the release-note-category:start/end, release-note:start/end, or release-note-image:start/end marker pairs. Never remove or rewrite the Release note images section; leave its contents for a human. -->

## Pull Request Type
<!-- Please select what type of pull request this is: [x] -->
- [x] Bugfix
- [ ] Feature Implementation
- [ ] Documentation
- [ ] Other

## Related issue
<!-- Please link the issue your pull request is referring to. -->
<!-- If this pull request fully resolves the relevant issue, put "closes" before the issue number. -->
<!-- Example: "closes #123456". -->

None.

## Description
<!-- Please write a clear and concise description of what the pull request does. -->

Long translated category names were truncated in the compact settings breadcrumb because the root label, category label, search field, and header actions all competed for one row.

This hides the redundant root breadcrumb in compact mode and moves settings search to its own row at the existing 760 px compact-layout breakpoint. The current category remains readable, while the back button handles compact navigation one level at a time. The desktop breadcrumb is unchanged.

## Release note category
<!-- Select exactly one category. Every pull request must select one. -->
<!-- Select "Not noteworthy" when the pull request fixes a bug in or improves functionality that has not yet appeared in a stable release. -->
<!-- release-note-category:start -->
- [ ] Not noteworthy
- [ ] Highlights
- [ ] More improvements
- [x] Fixed bugs
<!-- release-note-category:end -->

## Release note
<!-- Required unless "Not noteworthy" is selected. -->
<!-- Write one concise, user-facing entry without a leading bullet. -->
<!-- release-note:start -->
Compact settings breadcrumbs now keep the current category name readable.
<!-- release-note:end -->

## Release note images
<!-- Human-only: Agents must preserve this entire section and leave it empty. -->
<!-- Optional. Paste one or more Markdown images or HTML image tags here. -->
<!-- The release notes will use an HTML image tag and limit images taller than 300 pixels. -->
<!-- release-note-image:start -->

<!-- release-note-image:end -->

## Testing
<!-- How can reviewers verify that the PR produces correct results? -->
<!-- Please provide instructions so that others can ensure that your pull request would produce correct results. For examples see, https://github.com/FreeTubeApp/FreeTube/pull/5743, https://github.com/FreeTubeApp/FreeTube/pull/7349, https://github.com/FreeTubeApp/FreeTube/pull/5125, https://github.com/FreeTubeApp/FreeTube/pull/7338 -->
<!-- Agent instructions: Only write human-facing steps that explain how to verify the change while running this branch in dev mode. Include expected results and, when applicable, helpful console snippets for interactive verification. Do not include automated checks, commands, results, pass counts, or CI status. -->

1. Run the app in German and resize the settings window below 760 px wide.
2. Open Settings and select "Ablenkungsfreier Modus".
3. Confirm the full category name appears beside its icon, the root cog is absent, and the search field occupies a separate row.
4. Open a nested settings page and use Back to return one level at a time, then return to the category menu.
5. Widen the settings window to at least 760 px and confirm the desktop breadcrumb still shows the full Settings root and category hierarchy.

## Additional context
<!-- Add any other context about the pull request here. -->

The compact layout keeps all existing header actions. Only the redundant breadcrumb root is removed.
