### PR TITLE
ci(performance): compare pull requests against base

### DIFF
--- a/.github/workflows/performance.yml
+++ b/.github/workflows/performance.yml
@@ -107,7 +107,7 @@ jobs:
     # variance before this becomes a required regression gate.
     - name: Compare performance
       run: |
-        xvfb-run --auto-servernum --server-args='-screen 0 1920x1080x24' \
+        xvfb-run -a -s "-screen 0 1920x1080x24" \
           node candidate/e2e/performance/compare.mjs \
           --base base \
           --candidate candidate \

--- a/.github/workflows/performance.yml
+++ b/.github/workflows/performance.yml
@@ -1,0 +1,134 @@
+name: Performance Comparison
+
+on:
+  pull_request:
+    branches: [ master, development, '**-RC' ]
+
+permissions: {}
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
+
+jobs:
+  performance:
+    name: Compare performance with base
+    if: ${{ github.head_ref != 'weblate-translations' }}
+    runs-on: ubuntu-24.04
+    timeout-minutes: 30
+
+    permissions:
+      contents: read
+
+    steps:
+    - name: Check out candidate
+      uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+      with:
+        path: candidate
+        persist-credentials: false
+
+    - name: Check out base
+      uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+      with:
+        ref: ${{ github.event.pull_request.base.sha }}
+        path: base
+        persist-credentials: false
+
+    - name: Use Node.js 24.x
+      uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
+      with:
+        node-version: 24.x
+        package-manager-cache: false
+
+    - name: Install pnpm
+      uses: pnpm/action-setup@0ebf47130e4866e96fce0953f49152a61190b271 # v6.0.9
+      with:
+        version: 11
+        cache: false
+
+    - name: Get pnpm cache directory
+      id: cache_dir
+      shell: bash
+      run: |
+        {
+          echo 'cache_dir<<EOF'
+          pnpm store path
+          echo EOF
+        } >> "$GITHUB_OUTPUT"
+
+    - name: Cache pnpm store
+      uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
+      with:
+        key: ${{ format('performance-{0}-{1}-pnpm-{2}', runner.os, runner.arch, hashFiles('base/pnpm-lock.yaml', 'candidate/pnpm-lock.yaml')) }}
+        path: ${{ steps.cache_dir.outputs.cache_dir }}
+
+    - name: Install candidate dependencies
+      run: pnpm --dir candidate run ci
+      shell: bash
+
+    - name: Install base dependencies
+      run: pnpm --dir base run ci
+      shell: bash
+
+    - name: Get Electron versions
+      id: electron
+      run: |
+        printf 'base=%s\n' "$(node -p "require('./base/node_modules/electron/package.json').version")" >> "$GITHUB_OUTPUT"
+        printf 'candidate=%s\n' "$(node -p "require('./candidate/node_modules/electron/package.json').version")" >> "$GITHUB_OUTPUT"
+      shell: bash
+
+    - name: Cache Electron binaries
+      id: electron_cache
+      uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
+      with:
+        key: ${{ format('performance-electron-{0}-{1}-{2}-{3}', runner.os, runner.arch, steps.electron.outputs.base, steps.electron.outputs.candidate) }}
+        path: |
+          base/node_modules/.pnpm/electron@*/node_modules/electron/dist
+          base/node_modules/.pnpm/electron@*/node_modules/electron/path.txt
+          candidate/node_modules/.pnpm/electron@*/node_modules/electron/dist
+          candidate/node_modules/.pnpm/electron@*/node_modules/electron/path.txt
+
+    - name: Install Electron binaries
+      if: steps.electron_cache.outputs.cache-hit != 'true'
+      run: |
+        pnpm --dir base exec install-electron
+        pnpm --dir candidate exec install-electron
+      shell: bash
+
+    - name: Build base app
+      run: pnpm --dir base run test:e2e:pack
+      shell: bash
+
+    - name: Build candidate app
+      run: pnpm --dir candidate run test:e2e:pack
+      shell: bash
+
+    # Start in report-only mode so ordinary PRs establish the runner's natural
+    # variance before this becomes a required regression gate.
+    - name: Compare performance
+      run: |
+        xvfb-run --auto-servernum --server-args='-screen 0 1920x1080x24' \
+          node candidate/e2e/performance/compare.mjs \
+          --base base \
+          --candidate candidate \
+          --output performance-results.json \
+          --summary performance-summary.md \
+          --report-only
+      shell: bash
+
+    - name: Publish performance summary
+      if: ${{ always() }}
+      run: |
+        if [ -f performance-summary.md ]; then
+          sed -n '1,$p' performance-summary.md >> "$GITHUB_STEP_SUMMARY"
+        fi
+      shell: bash
+
+    - name: Upload performance results
+      if: ${{ !cancelled() }}
+      uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+      with:
+        name: performance-results
+        path: performance-results.json
+        if-no-files-found: ignore
+        retention-days: 30

--- a/e2e/README.md
+++ b/e2e/README.md
@@ -131,7 +131,7 @@ longest-frame measurement.
 To compare two checkouts locally, build `dist-e2e` in both and run:
 
 ```bash
-xvfb-run --auto-servernum --server-args='-screen 0 1920x1080x24' \
+xvfb-run -a -s "-screen 0 1920x1080x24" \
   pnpm run test:performance -- \
   --base /path/to/base-checkout \
   --candidate /path/to/candidate-checkout

--- a/e2e/README.md
+++ b/e2e/README.md
@@ -113,3 +113,26 @@ Pull requests without changed or affected E2E tests pass without running tests.
 Network tests use the fixture fallback on retry.
 
 On failure the Playwright HTML report and traces are uploaded as artifacts.
+
+## Performance comparison
+
+The pull-request performance workflow builds the base and candidate commits,
+then runs the large cached-subscription benchmark against both builds on one
+runner. It alternates between builds, discards two warm-ups per build, and
+compares the median of seven samples. The Actions summary shows the comparison,
+and the raw samples are uploaded as `performance-results.json`.
+
+The workflow initially reports regressions without failing so its thresholds
+can be checked against normal runner variance. Without `--report-only`, the
+command exits with a failure when the candidate crosses an absolute limit or is
+both 15% and 20 ms slower for elapsed time, or both 20% and 16 ms slower for a
+longest-frame measurement.
+
+To compare two checkouts locally, build `dist-e2e` in both and run:
+
+```bash
+xvfb-run --auto-servernum --server-args='-screen 0 1920x1080x24' \
+  pnpm run test:performance -- \
+  --base /path/to/base-checkout \
+  --candidate /path/to/candidate-checkout
+```

--- a/e2e/helpers/app.mjs
+++ b/e2e/helpers/app.mjs
@@ -86,8 +86,15 @@ export async function createUserDataDir(seed = {}) {
 
 /**
  * Launches the packed app (dist/main.js) against the given userData directory.
+ *
+ * @param {string} userDataDir
+ * @param {string[]} [extraArgs]
+ * @param {object} [options]
+ * @param {string} [options.appRoot] repository root containing dist-e2e
+ * @param {string} [options.executablePath] Electron executable to launch
  */
-export async function launchApp(userDataDir, extraArgs = []) {
+export async function launchApp(userDataDir, extraArgs = [], options = {}) {
+  const appRoot = options.appRoot ?? repoRoot
   // Force X11 so the app renders on the xvfb display instead of escaping
   // to the user's real Wayland session.
   const env = {
@@ -104,13 +111,16 @@ export async function launchApp(userDataDir, extraArgs = []) {
   // (which rebuilds dist/ in development mode) can't clobber it.
   const launchOptions = {
     args: [
-      path.join(repoRoot, 'dist-e2e', 'main.js'),
+      path.join(appRoot, 'dist-e2e', 'main.js'),
       ...extraArgs,
       '--ozone-platform=x11',
       '--mute-audio'
     ],
-    cwd: repoRoot,
+    cwd: appRoot,
     env
+  }
+  if (options.executablePath) {
+    launchOptions.executablePath = options.executablePath
   }
 
   let electronApp
@@ -151,7 +161,7 @@ export async function launchApp(userDataDir, extraArgs = []) {
       const url = page.url()
       await electronApp.close().catch(() => {})
       throw new Error(
-        `Unexpected app URL ${url} — dist-e2e must contain a production build, run "pnpm run test:e2e:pack"`
+        `Unexpected app URL ${url}. ${path.join(appRoot, 'dist-e2e')} must contain a production build`
       )
     }
   }

--- a/e2e/performance/compare.mjs
+++ b/e2e/performance/compare.mjs
@@ -1,0 +1,302 @@
+import { execFileSync } from 'node:child_process'
+import { access, rm, writeFile } from 'node:fs/promises'
+import { createRequire } from 'node:module'
+import path from 'node:path'
+
+import {
+  createUserDataDir,
+  expect,
+  launchApp
+} from '../helpers/app.mjs'
+import {
+  largeSubscriptionsSeed,
+  runLargeSubscriptionsBenchmark
+} from './subscriptions.mjs'
+
+const METRICS = [
+  {
+    key: 'firstSwitchElapsedMs',
+    label: 'First switch elapsed',
+    absoluteLimit: 250,
+    relativeLimit: 1.15,
+    minimumDelta: 20
+  },
+  {
+    key: 'firstSwitchLongestFrameMs',
+    label: 'First switch longest frame',
+    absoluteLimit: 200,
+    relativeLimit: 1.2,
+    minimumDelta: 16
+  },
+  {
+    key: 'repeatedSwitchElapsedMs',
+    label: 'Repeated switch elapsed',
+    absoluteLimit: 150,
+    relativeLimit: 1.15,
+    minimumDelta: 20
+  },
+  {
+    key: 'repeatedSwitchLongestFrameMs',
+    label: 'Repeated switch longest frame',
+    absoluteLimit: 100,
+    relativeLimit: 1.2,
+    minimumDelta: 16
+  }
+]
+
+function parseArguments(argv) {
+  const options = {
+    samples: 7,
+    warmups: 2,
+    reportOnly: false
+  }
+
+  for (let index = 0; index < argv.length; index++) {
+    const argument = argv[index]
+    if (argument === '--') {
+      continue
+    }
+    if (argument === '--report-only') {
+      options.reportOnly = true
+      continue
+    }
+
+    const value = argv[++index]
+    if (!value) {
+      throw new Error(`Missing value for ${argument}`)
+    }
+
+    switch (argument) {
+      case '--base':
+        options.baseRoot = path.resolve(value)
+        break
+      case '--candidate':
+        options.candidateRoot = path.resolve(value)
+        break
+      case '--output':
+        options.output = path.resolve(value)
+        break
+      case '--summary':
+        options.summary = path.resolve(value)
+        break
+      case '--samples':
+        options.samples = parsePositiveInteger(argument, value)
+        break
+      case '--warmups':
+        options.warmups = parsePositiveInteger(argument, value)
+        break
+      default:
+        throw new Error(`Unknown argument ${argument}`)
+    }
+  }
+
+  if (!options.baseRoot || !options.candidateRoot) {
+    throw new Error('Usage: pnpm run test:performance -- --base <path> --candidate <path>')
+  }
+
+  return options
+}
+
+function parsePositiveInteger(argument, value) {
+  const parsed = Number.parseInt(value, 10)
+  if (!Number.isSafeInteger(parsed) || parsed < 1) {
+    throw new Error(`${argument} must be a positive integer`)
+  }
+  return parsed
+}
+
+function median(values) {
+  const sorted = [...values].sort((left, right) => left - right)
+  const midpoint = Math.floor(sorted.length / 2)
+  if (sorted.length % 2 === 1) {
+    return sorted[midpoint]
+  }
+  return (sorted[midpoint - 1] + sorted[midpoint]) / 2
+}
+
+function commitLabel(root) {
+  return execFileSync('git', ['-C', root, 'rev-parse', '--short=9', 'HEAD'], {
+    encoding: 'utf8'
+  }).trim()
+}
+
+async function targetFor(name, root) {
+  const mainPath = path.join(root, 'dist-e2e', 'main.js')
+  await access(mainPath)
+
+  const requireFromRoot = createRequire(path.join(root, 'package.json'))
+  const executablePath = requireFromRoot('electron')
+  await access(executablePath)
+
+  return {
+    name,
+    root,
+    commit: commitLabel(root),
+    executablePath
+  }
+}
+
+async function closeTutorial(page) {
+  const tutorial = page.locator('.tutorialOverlay')
+  await expect(tutorial).toBeVisible()
+  await tutorial.locator('.tutorialActions').getByRole('button').last().click()
+  await expect(tutorial).toBeHidden()
+}
+
+async function collectSample(target) {
+  const userDataDir = await createUserDataDir(largeSubscriptionsSeed)
+  let electronApp
+
+  try {
+    const launched = await launchApp(userDataDir, [], {
+      appRoot: target.root,
+      executablePath: target.executablePath
+    })
+    electronApp = launched.electronApp
+    await closeTutorial(launched.page)
+    return await runLargeSubscriptionsBenchmark(launched.page)
+  } finally {
+    await electronApp?.close().catch(() => {})
+    await rm(userDataDir, { recursive: true, force: true })
+  }
+}
+
+async function runSamples(base, candidate, options) {
+  const samples = { base: [], candidate: [] }
+  const warmupOrder = Array.from({ length: options.warmups }, (_, index) => (
+    index % 2 === 0 ? [base, candidate] : [candidate, base]
+  )).flat()
+
+  for (const target of warmupOrder) {
+    console.log(`Warm-up ${target.name}`)
+    await collectSample(target)
+  }
+
+  for (let index = 0; index < options.samples; index++) {
+    const order = index % 2 === 0 ? [base, candidate] : [candidate, base]
+    for (const target of order) {
+      console.log(`Sample ${index + 1}/${options.samples} ${target.name}`)
+      samples[target.name].push(await collectSample(target))
+    }
+  }
+
+  return samples
+}
+
+function compareSamples(samples) {
+  const failures = []
+  const metrics = METRICS.map(definition => {
+    const baseValues = samples.base.map(sample => sample[definition.key])
+    const candidateValues = samples.candidate.map(sample => sample[definition.key])
+    const baseMedian = median(baseValues)
+    const candidateMedian = median(candidateValues)
+    const delta = candidateMedian - baseMedian
+    const ratio = candidateMedian / baseMedian
+    const exceedsAbsoluteLimit = candidateMedian >= definition.absoluteLimit
+    const relativeRegression = ratio > definition.relativeLimit &&
+      delta > definition.minimumDelta
+
+    if (exceedsAbsoluteLimit) {
+      failures.push(
+        `${definition.label} is ${candidateMedian.toFixed(1)} ms, ` +
+        `above the ${definition.absoluteLimit} ms limit`
+      )
+    }
+    if (relativeRegression) {
+      failures.push(
+        `${definition.label} regressed by ${delta.toFixed(1)} ms ` +
+        `(${formatPercent(ratio - 1)})`
+      )
+    }
+
+    return {
+      ...definition,
+      baseValues,
+      candidateValues,
+      baseMedian,
+      candidateMedian,
+      delta,
+      ratio,
+      exceedsAbsoluteLimit,
+      relativeRegression,
+      passed: !exceedsAbsoluteLimit && !relativeRegression
+    }
+  })
+
+  return { metrics, failures }
+}
+
+function formatPercent(value) {
+  const sign = value > 0 ? '+' : ''
+  return `${sign}${(value * 100).toFixed(1)}%`
+}
+
+function renderSummary(base, candidate, comparison, reportOnly) {
+  const lines = [
+    '# Performance comparison',
+    '',
+    `Compared \`${base.commit}\` with \`${candidate.commit}\` on the same runner.`,
+    ''
+  ]
+
+  if (reportOnly) {
+    lines.push('This workflow reports regressions without failing while thresholds are calibrated.', '')
+  }
+
+  lines.push(
+    '| Metric | Base median | Candidate median | Change | Absolute limit | Result |',
+    '| --- | ---: | ---: | ---: | ---: | --- |'
+  )
+  for (const metric of comparison.metrics) {
+    lines.push(
+      `| ${metric.label} | ${metric.baseMedian.toFixed(1)} ms | ` +
+      `${metric.candidateMedian.toFixed(1)} ms | ${formatPercent(metric.ratio - 1)} | ` +
+      `${metric.absoluteLimit} ms | ${metric.passed ? 'Pass' : 'Regression'} |`
+    )
+  }
+
+  lines.push('')
+  if (comparison.failures.length === 0) {
+    lines.push('No regression crossed the configured thresholds.')
+  } else {
+    lines.push('Detected regressions:', '')
+    for (const failure of comparison.failures) {
+      lines.push(`- ${failure}`)
+    }
+  }
+
+  return `${lines.join('\n')}\n`
+}
+
+async function main() {
+  const options = parseArguments(process.argv.slice(2))
+  const base = await targetFor('base', options.baseRoot)
+  const candidate = await targetFor('candidate', options.candidateRoot)
+  const samples = await runSamples(base, candidate, options)
+  const comparison = compareSamples(samples)
+  const summary = renderSummary(base, candidate, comparison, options.reportOnly)
+  const result = {
+    base: { root: base.root, commit: base.commit },
+    candidate: { root: candidate.root, commit: candidate.commit },
+    sampleCount: options.samples,
+    warmupCount: options.warmups,
+    reportOnly: options.reportOnly,
+    samples,
+    metrics: comparison.metrics,
+    failures: comparison.failures
+  }
+
+  console.log(summary)
+  if (options.output) {
+    await writeFile(options.output, `${JSON.stringify(result, null, 2)}\n`)
+  }
+  if (options.summary) {
+    await writeFile(options.summary, summary)
+  }
+
+  if (!options.reportOnly && comparison.failures.length > 0) {
+    process.exitCode = 1
+  }
+}
+
+await main()

--- a/e2e/performance/compare.mjs
+++ b/e2e/performance/compare.mjs
@@ -268,34 +268,74 @@ function renderSummary(base, candidate, comparison, reportOnly) {
   return `${lines.join('\n')}\n`
 }
 
-async function main() {
-  const options = parseArguments(process.argv.slice(2))
-  const base = await targetFor('base', options.baseRoot)
-  const candidate = await targetFor('candidate', options.candidateRoot)
-  const samples = await runSamples(base, candidate, options)
-  const comparison = compareSamples(samples)
-  const summary = renderSummary(base, candidate, comparison, options.reportOnly)
-  const result = {
-    base: { root: base.root, commit: base.commit },
-    candidate: { root: candidate.root, commit: candidate.commit },
-    sampleCount: options.samples,
-    warmupCount: options.warmups,
-    reportOnly: options.reportOnly,
-    samples,
-    metrics: comparison.metrics,
-    failures: comparison.failures
-  }
+function renderFailureSummary(error) {
+  const message = error instanceof Error ? error.message : String(error)
+  return [
+    '# Performance comparison',
+    '',
+    'The benchmark failed before all samples completed.',
+    '',
+    `Error: ${message}`,
+    ''
+  ].join('\n')
+}
 
-  console.log(summary)
+async function writeReports(options, result, summary) {
   if (options.output) {
     await writeFile(options.output, `${JSON.stringify(result, null, 2)}\n`)
   }
   if (options.summary) {
     await writeFile(options.summary, summary)
   }
+}
 
-  if (!options.reportOnly && comparison.failures.length > 0) {
-    process.exitCode = 1
+async function main() {
+  const options = parseArguments(process.argv.slice(2))
+  let base
+  let candidate
+
+  try {
+    base = await targetFor('base', options.baseRoot)
+    candidate = await targetFor('candidate', options.candidateRoot)
+    const samples = await runSamples(base, candidate, options)
+    const comparison = compareSamples(samples)
+    const summary = renderSummary(base, candidate, comparison, options.reportOnly)
+    const result = {
+      base: { root: base.root, commit: base.commit },
+      candidate: { root: candidate.root, commit: candidate.commit },
+      sampleCount: options.samples,
+      warmupCount: options.warmups,
+      reportOnly: options.reportOnly,
+      samples,
+      metrics: comparison.metrics,
+      failures: comparison.failures
+    }
+
+    console.log(summary)
+    await writeReports(options, result, summary)
+
+    if (!options.reportOnly && comparison.failures.length > 0) {
+      process.exitCode = 1
+    }
+  } catch (error) {
+    const summary = renderFailureSummary(error)
+    const result = {
+      base: base ? { root: base.root, commit: base.commit } : { root: options.baseRoot },
+      candidate: candidate
+        ? { root: candidate.root, commit: candidate.commit }
+        : { root: options.candidateRoot },
+      sampleCount: options.samples,
+      warmupCount: options.warmups,
+      reportOnly: options.reportOnly,
+      failures: [error instanceof Error ? error.message : String(error)],
+      error: error instanceof Error
+        ? { name: error.name, message: error.message, stack: error.stack }
+        : { message: String(error) }
+    }
+
+    console.error(summary)
+    await writeReports(options, result, summary)
+    throw error
   }
 }
 

--- a/e2e/performance/subscriptions.mjs
+++ b/e2e/performance/subscriptions.mjs
@@ -3,6 +3,7 @@ import { expect, goTo } from '../helpers/app.mjs'
 const now = Date.now()
 const channelCount = 933
 const videosPerChannel = 36
+const switchTimeoutMs = 15_000
 
 const profiles = [{
   _id: 'allChannels',
@@ -52,34 +53,46 @@ export const largeSubscriptionsSeed = {
 }
 
 async function measureVideosSwitch(page) {
-  return page.evaluate(() => new Promise(resolve => {
-    const target = document.querySelector('[data-subscription-feed-tab="videos"]')
-    const startedAt = performance.now()
-    let previousFrame = startedAt
-    let longestFrame = 0
+  let timeout
+  try {
+    return await Promise.race([
+      page.evaluate(() => new Promise(resolve => {
+        const target = document.querySelector('[data-subscription-feed-tab="videos"]')
+        const startedAt = performance.now()
+        let previousFrame = startedAt
+        let longestFrame = 0
 
-    function sampleFrame(timestamp) {
-      longestFrame = Math.max(longestFrame, timestamp - previousFrame)
-      previousFrame = timestamp
+        function sampleFrame(timestamp) {
+          longestFrame = Math.max(longestFrame, timestamp - previousFrame)
+          previousFrame = timestamp
 
-      const panel = document.querySelector('#subscriptionsPanel:not(.newFeed)')
-      const feedIsRendered = target.getAttribute('aria-selected') === 'true' &&
-        panel?.querySelector('.ft-list-video') !== null
+          const panel = document.querySelector('#subscriptionsPanel:not(.newFeed)')
+          const feedIsRendered = target.getAttribute('aria-selected') === 'true' &&
+            panel?.querySelector('.ft-list-video') !== null
 
-      if (feedIsRendered) {
-        requestAnimationFrame(finishedAt => resolve({
-          elapsed: finishedAt - startedAt,
-          longestFrame
-        }))
-        return
-      }
+          if (feedIsRendered) {
+            requestAnimationFrame(finishedAt => resolve({
+              elapsed: finishedAt - startedAt,
+              longestFrame
+            }))
+            return
+          }
 
-      requestAnimationFrame(sampleFrame)
-    }
+          requestAnimationFrame(sampleFrame)
+        }
 
-    target.click()
-    requestAnimationFrame(sampleFrame)
-  }))
+        target.click()
+        requestAnimationFrame(sampleFrame)
+      })),
+      new Promise((resolve, reject) => {
+        timeout = setTimeout(() => reject(new Error(
+          `Subscription tab switch did not render within ${switchTimeoutMs} ms`
+        )), switchTimeoutMs)
+      })
+    ])
+  } finally {
+    clearTimeout(timeout)
+  }
 }
 
 export async function runLargeSubscriptionsBenchmark(page) {

--- a/e2e/performance/subscriptions.mjs
+++ b/e2e/performance/subscriptions.mjs
@@ -1,0 +1,105 @@
+import { expect, goTo } from '../helpers/app.mjs'
+
+const now = Date.now()
+const channelCount = 933
+const videosPerChannel = 36
+
+const profiles = [{
+  _id: 'allChannels',
+  name: 'All Channels',
+  bgColor: '#000000',
+  textColor: '#FFFFFF',
+  subscriptions: Array.from({ length: channelCount }, (_, channelIndex) => ({
+    id: `UC${String(channelIndex).padStart(22, '0')}`,
+    name: `Channel ${channelIndex}`,
+    thumbnail: ''
+  }))
+}]
+
+const subscriptionCache = profiles[0].subscriptions.map((channel, channelIndex) => ({
+  _id: channel.id,
+  videos: Array.from({ length: videosPerChannel }, (_, videoIndex) => ({
+    videoId: `video-${channelIndex}-${videoIndex}`,
+    title: `Video ${channelIndex}-${videoIndex}`,
+    author: channel.name,
+    authorId: channel.id,
+    published: now - (videoIndex * channelCount + channelIndex) * 3600000,
+    viewCount: 1000,
+    lengthSeconds: 120,
+    liveNow: false,
+    isUpcoming: false,
+    isNewInSubscriptionFeed: true,
+    type: 'video'
+  })),
+  videosTimestamp: new Date(now).toISOString(),
+  shorts: [],
+  shortsTimestamp: new Date(now).toISOString()
+}))
+
+export const largeSubscriptionsSeed = {
+  settings: {
+    fetchSubscriptionsAutomatically: false,
+    hideSubscriptionsVideos: false,
+    hideSubscriptionsShorts: true,
+    hideSubscriptionsLive: true,
+    hideSubscriptionsCommunity: true,
+    showNewSubscriptionFeed: true,
+    reducedMotion: 'off',
+    uiScale: 95
+  },
+  profiles,
+  subscriptionCache
+}
+
+async function measureVideosSwitch(page) {
+  return page.evaluate(() => new Promise(resolve => {
+    const target = document.querySelector('[data-subscription-feed-tab="videos"]')
+    const startedAt = performance.now()
+    let previousFrame = startedAt
+    let longestFrame = 0
+
+    function sampleFrame(timestamp) {
+      longestFrame = Math.max(longestFrame, timestamp - previousFrame)
+      previousFrame = timestamp
+
+      const panel = document.querySelector('#subscriptionsPanel:not(.newFeed)')
+      const feedIsRendered = target.getAttribute('aria-selected') === 'true' &&
+        panel?.querySelector('.ft-list-video') !== null
+
+      if (feedIsRendered) {
+        requestAnimationFrame(finishedAt => resolve({
+          elapsed: finishedAt - startedAt,
+          longestFrame
+        }))
+        return
+      }
+
+      requestAnimationFrame(sampleFrame)
+    }
+
+    target.click()
+    requestAnimationFrame(sampleFrame)
+  }))
+}
+
+export async function runLargeSubscriptionsBenchmark(page) {
+  await goTo(page, 'trending')
+  await page.evaluate(() => localStorage.setItem('Subscriptions/currentTab', 'new'))
+  await goTo(page, 'subscriptions')
+
+  await expect(page.locator('#subscriptionsPanel.newFeed')).toBeVisible()
+  const firstSwitch = await measureVideosSwitch(page)
+  await expect(page.getByText('Video 0-0')).toBeVisible()
+
+  await page.locator('[data-subscription-feed-tab="all"]').click()
+  await expect(page.locator('#subscriptionsPanel.newFeed')).toBeVisible()
+  const repeatedSwitch = await measureVideosSwitch(page)
+  await expect(page.getByText('Video 0-0')).toBeVisible()
+
+  return {
+    firstSwitchElapsedMs: firstSwitch.elapsed,
+    firstSwitchLongestFrameMs: firstSwitch.longestFrame,
+    repeatedSwitchElapsedMs: repeatedSwitch.elapsed,
+    repeatedSwitchLongestFrameMs: repeatedSwitch.longestFrame
+  }
+}

--- a/e2e/tests/offline/subscriptions-tab-performance.spec.mjs
+++ b/e2e/tests/offline/subscriptions-tab-performance.spec.mjs
@@ -1,108 +1,18 @@
-import { test, expect, goTo } from '../../helpers/app.mjs'
-
-const now = Date.now()
-const channelCount = 933
-const videosPerChannel = 36
-
-const profiles = [{
-  _id: 'allChannels',
-  name: 'All Channels',
-  bgColor: '#000000',
-  textColor: '#FFFFFF',
-  subscriptions: Array.from({ length: channelCount }, (_, channelIndex) => ({
-    id: `UC${String(channelIndex).padStart(22, '0')}`,
-    name: `Channel ${channelIndex}`,
-    thumbnail: ''
-  }))
-}]
-
-const subscriptionCache = profiles[0].subscriptions.map((channel, channelIndex) => ({
-  _id: channel.id,
-  videos: Array.from({ length: videosPerChannel }, (_, videoIndex) => ({
-    videoId: `video-${channelIndex}-${videoIndex}`,
-    title: `Video ${channelIndex}-${videoIndex}`,
-    author: channel.name,
-    authorId: channel.id,
-    published: now - (videoIndex * channelCount + channelIndex) * 3600000,
-    viewCount: 1000,
-    lengthSeconds: 120,
-    liveNow: false,
-    isUpcoming: false,
-    isNewInSubscriptionFeed: true,
-    type: 'video'
-  })),
-  videosTimestamp: new Date(now).toISOString(),
-  shorts: [],
-  shortsTimestamp: new Date(now).toISOString()
-}))
+import { test, expect } from '../../helpers/app.mjs'
+import {
+  largeSubscriptionsSeed,
+  runLargeSubscriptionsBenchmark
+} from '../../performance/subscriptions.mjs'
 
 test.use({
-  seed: {
-    settings: {
-      fetchSubscriptionsAutomatically: false,
-      hideSubscriptionsVideos: false,
-      hideSubscriptionsShorts: true,
-      hideSubscriptionsLive: true,
-      hideSubscriptionsCommunity: true,
-      showNewSubscriptionFeed: true,
-      reducedMotion: 'off',
-      uiScale: 95
-    },
-    profiles,
-    subscriptionCache
-  }
+  seed: largeSubscriptionsSeed
 })
 
-async function measureVideosSwitch(page) {
-  return page.evaluate(() => new Promise(resolve => {
-    const target = document.querySelector('[data-subscription-feed-tab="videos"]')
-    const startedAt = performance.now()
-    let previousFrame = startedAt
-    let longestFrame = 0
-
-    function sampleFrame(timestamp) {
-      longestFrame = Math.max(longestFrame, timestamp - previousFrame)
-      previousFrame = timestamp
-
-      const panel = document.querySelector('#subscriptionsPanel:not(.newFeed)')
-      const feedIsRendered = target.getAttribute('aria-selected') === 'true' &&
-        panel?.querySelector('.ft-list-video') !== null
-
-      if (feedIsRendered) {
-        requestAnimationFrame(finishedAt => resolve({
-          elapsed: finishedAt - startedAt,
-          longestFrame
-        }))
-        return
-      }
-
-      requestAnimationFrame(sampleFrame)
-    }
-
-    target.click()
-    requestAnimationFrame(sampleFrame)
-  }))
-}
-
 test('switches a production-profile-sized cached feed without repeating expensive work', async ({ page }) => {
-  await goTo(page, 'trending')
-  await page.evaluate(() => localStorage.setItem('Subscriptions/currentTab', 'new'))
-  await goTo(page, 'subscriptions')
+  const metrics = await runLargeSubscriptionsBenchmark(page)
 
-  await expect(page.locator('#subscriptionsPanel.newFeed')).toBeVisible()
-
-  const firstSwitch = await measureVideosSwitch(page)
-
-  expect(firstSwitch.longestFrame).toBeLessThan(200)
-  expect(firstSwitch.elapsed).toBeLessThan(250)
-  await expect(page.getByText('Video 0-0')).toBeVisible()
-
-  await page.locator('[data-subscription-feed-tab="all"]').click()
-  await expect(page.locator('#subscriptionsPanel.newFeed')).toBeVisible()
-
-  const repeatedSwitch = await measureVideosSwitch(page)
-
-  expect(repeatedSwitch.longestFrame).toBeLessThan(100)
-  expect(repeatedSwitch.elapsed).toBeLessThan(150)
-  await expect(page.getByText('Video 0-0')).toBeVisible()
+  expect(metrics.firstSwitchLongestFrameMs).toBeLessThan(200)
+  expect(metrics.firstSwitchElapsedMs).toBeLessThan(250)
+  expect(metrics.repeatedSwitchLongestFrameMs).toBeLessThan(100)
+  expect(metrics.repeatedSwitchElapsedMs).toBeLessThan(150)
 })

--- a/package.json
+++ b/package.json
@@ -58,6 +58,7 @@
     "test:e2e": "playwright test -c e2e/playwright.config.mjs",
     "test:e2e:offline": "playwright test -c e2e/playwright.config.mjs --project=offline",
     "test:e2e:network": "playwright test -c e2e/playwright.config.mjs --project=network",
+    "test:performance": "node e2e/performance/compare.mjs",
     "test:unit": "node --test tests/unit/*.test.mjs",
     "ci": "pnpm install --frozen-lockfile"
   },


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Make sure to follow the contributing guidelines. -->
<!-- Important note, we may remove your pull request if you do not use this provided PR template correctly. -->
<!-- Agent instructions: Preserve every heading, comment, and marker in this template. Never remove or rewrite the release-note-category:start/end, release-note:start/end, or release-note-image:start/end marker pairs. Never remove or rewrite the Release note images section; leave its contents for a human. -->

## Pull Request Type
<!-- Please select what type of pull request this is: [x] -->
- [ ] Bugfix
- [ ] Feature Implementation
- [ ] Documentation
- [x] Other

## Related issue
<!-- Please link the issue your pull request is referring to. -->
<!-- If this pull request fully resolves the relevant issue, put "closes" before the issue number. -->
<!-- Example: "closes #123456". -->

## Description
<!-- Please write a clear and concise description of what the pull request does. -->
Pull requests currently have fixed performance limits for a large subscriptions profile, but they do not compare the changed app with the base commit. Shared runner variance also makes one timing sample a weak regression signal.

This adds a dedicated performance workflow that builds both commits and benchmarks them on the same runner. It alternates between the builds, compares seven-sample medians, publishes the raw results and a job summary, and starts in report-only mode while normal CI variance is measured. The existing subscriptions performance test now uses the same benchmark scenario as the comparison runner.

## Release note category
<!-- Select exactly one category. Every pull request must select one. -->
<!-- Select "Not noteworthy" when the pull request fixes a bug in or improves functionality that has not yet appeared in a stable release. -->
<!-- release-note-category:start -->
- [x] Not noteworthy
- [ ] Highlights
- [ ] More improvements
- [ ] Fixed bugs
<!-- release-note-category:end -->

## Release note
<!-- Required unless "Not noteworthy" is selected. -->
<!-- Write one concise, user-facing entry without a leading bullet. -->
<!-- release-note:start -->

<!-- release-note:end -->

## Release note images
<!-- Human-only: Agents must preserve this entire section and leave it empty. -->
<!-- Optional. Paste one or more Markdown images or HTML image tags here. -->
<!-- The release notes will use an HTML image tag and limit images taller than 300 pixels. -->
<!-- release-note-image:start -->

<!-- release-note-image:end -->

## Testing
<!-- How can reviewers verify that the PR produces correct results? -->
<!-- Please provide instructions so that others can ensure that your pull request produces correct results. For examples see, https://github.com/FreeTubeApp/FreeTube/pull/5743, https://github.com/FreeTubeApp/FreeTube/pull/7349, https://github.com/FreeTubeApp/FreeTube/pull/5125, https://github.com/FreeTubeApp/FreeTube/pull/7338 -->
<!-- Agent instructions: Only write human-facing steps that explain how to verify the change while running this branch in dev mode. Include expected results and, when applicable, helpful console snippets for interactive verification. Do not include automated checks, commands, results, pass counts, or CI status. -->
No in-app verification is needed because this changes CI and test support code only.

## Additional context
<!-- Add any other context about the pull request here. -->
The workflow reports threshold crossings without failing at first. Once enough runs establish the normal variance, `--report-only` can be removed to make regressions blocking.
