### PR TITLE
fix(comments): load comments with the video automatically

### DIFF
--- a/e2e/tests/offline/watch-page.spec.mjs
+++ b/e2e/tests/offline/watch-page.spec.mjs
@@ -2900,19 +2900,9 @@ test('loads initial comments with the video when automatic pagination is enabled
   // Initial comments must not depend on the later-page sentinel being visible.
   await page.addStyleTag({ content: '.commentAutoLoadSentinel { display: none !important; }' })
 
-  let commentRequestCount = 0
-  await page.route(/\/youtubei\/v1\/next/, (route, request) => {
-    const body = JSON.parse(request.postData() ?? '{}')
-    if (body.continuation) {
-      commentRequestCount++
-    }
-    return route.fallback()
-  })
-
   await openMockedVideo(page)
 
   await expect(page.locator('.getCommentsTitle')).toHaveCount(0, { timeout: 5_000 })
-  await expect.poll(() => commentRequestCount).toBeGreaterThan(0)
   await expect(page.locator('.commentsTitle')).toBeVisible()
   await expect(page.locator('.getMoreComments')).toHaveCount(0)
   expect(await page.evaluate(() => window.scrollY)).toBe(0)

--- a/e2e/tests/offline/watch-page.spec.mjs
+++ b/e2e/tests/offline/watch-page.spec.mjs
@@ -2891,6 +2891,33 @@ test('treats an empty comments response as no comments', async ({ app, page }) =
   expect(commentRequestCount).toBe(1)
 })
 
+test('loads initial comments with the video when automatic pagination is enabled', async ({ app, page }) => {
+  await mockPlayableWatchPage(app, page)
+  await page.evaluate(() => {
+    const store = document.querySelector('#app').__vue_app__.config.globalProperties.$store
+    store.commit('setGeneralAutoLoadMorePaginatedItemsEnabled', true)
+  })
+  // Initial comments must not depend on the later-page sentinel being visible.
+  await page.addStyleTag({ content: '.commentAutoLoadSentinel { display: none !important; }' })
+
+  let commentRequestCount = 0
+  await page.route(/\/youtubei\/v1\/next/, (route, request) => {
+    const body = JSON.parse(request.postData() ?? '{}')
+    if (body.continuation) {
+      commentRequestCount++
+    }
+    return route.fallback()
+  })
+
+  await openMockedVideo(page)
+
+  await expect(page.locator('.getCommentsTitle')).toHaveCount(0, { timeout: 5_000 })
+  await expect.poll(() => commentRequestCount).toBeGreaterThan(0)
+  await expect(page.locator('.commentsTitle')).toBeVisible()
+  await expect(page.locator('.getMoreComments')).toHaveCount(0)
+  expect(await page.evaluate(() => window.scrollY)).toBe(0)
+})
+
 test.describe('manual comment loading', () => {
   // These drive the click-to-load path and the reply pagination on top of a
   // single loaded page, so they turn off the automatic pagination that would
@@ -2912,6 +2939,7 @@ test.describe('manual comment loading', () => {
     await loadComments.scrollIntoViewIfNeeded()
     await loadComments.click()
     await expect(page.locator('.commentsTitle')).toBeVisible({ timeout: 30_000 })
+    await expect(page.locator('.getMoreComments')).toHaveCount(1)
 
     const ownerReplyToggle = page.getByRole('button', {
       name: /replies from .+ and others/

--- a/src/renderer/components/CommentSection/CommentSection.vue
+++ b/src/renderer/components/CommentSection/CommentSection.vue
@@ -430,7 +430,7 @@
         :label="$t('Comments.Load More Comments')"
       />
       <h4
-        v-else-if="canPerformMoreCommentLoading"
+        v-else-if="!generalAutoLoadMorePaginatedItemsEnabled && canPerformMoreCommentLoading"
         class="getMoreComments"
         role="button"
         tabindex="0"
@@ -473,7 +473,6 @@ import FtSpinner from '../FtSpinner/FtSpinner.vue'
 import FtTimestampCatcher from '../FtTimestampCatcher.vue'
 
 import store from '../../store/index'
-import { useTabContext } from '../../tabs/TabContext'
 
 import { copyToClipboard, formatNumber, getRelativeTimeFromDate, showApiErrorToast, showToast } from '../../helpers/utils'
 import { useRelativeTimeClock } from '../../composables/useRelativeTimeClock'
@@ -502,7 +501,6 @@ import {
 } from '../../helpers/api/invidious'
 
 const { t } = useI18n()
-const { isTabPresented } = useTabContext()
 const relativeTimeNow = useRelativeTimeClock()
 
 function formatCommentTime(comment) {
@@ -753,17 +751,11 @@ watch(() => props.highlightedCommentId, (commentId, previousCommentId) => {
   }
 }, { immediate: true })
 
-watch(
-  [generalAutoLoadMorePaginatedItemsEnabled, () => isTabPresented?.value],
-  ([autoLoadEnabled, presented]) => {
-    // Background tabs have no layout, so their visibility observer cannot
-    // trigger the initial load.
-    if (autoLoadEnabled && presented === false && canPerformInitialCommentLoading.value) {
-      getCommentData()
-    }
-  },
-  { immediate: true }
-)
+watch(generalAutoLoadMorePaginatedItemsEnabled, (autoLoadEnabled) => {
+  if (autoLoadEnabled && canPerformInitialCommentLoading.value) {
+    getCommentData()
+  }
+}, { immediate: true })
 
 const canPerformMoreCommentLoading = computed(() => {
   return commentData.value.length > 0 && !isLoading.value && !isLoadingMoreComments.value && showComments.value && !!nextPageToken.value


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Make sure to follow the contributing guidelines. -->
<!-- Important note, we may remove your pull request if you do not use this provided PR template correctly. -->
<!-- Agent instructions: Preserve every heading, comment, and marker in this template. Never remove or rewrite the release-note-category:start/end, release-note:start/end, or release-note-image:start/end marker pairs. Never remove or rewrite the Release note images section; leave its contents for a human. -->

## Pull Request Type
<!-- Please select what type of pull request this is: [x] -->
- [x] Bugfix
- [ ] Feature Implementation
- [ ] Documentation
- [ ] Other

## Related issue
<!-- Please link the issue your pull request is referring to. -->
<!-- If this pull request fully resolves the relevant issue, put "closes" before the issue number. -->
<!-- Example: "closes #123456". -->

## Description
<!-- Please write a clear and concise description of what the pull request does. -->
When automatic pagination was enabled, initial comments still depended on the pagination sentinel entering the viewport. This could leave the "Click to View Comments" prompt visible instead of loading comments with the video.

The comments section now starts its initial request as soon as automatic pagination is enabled. The visibility observer remains responsible for later pages, and the manual "Load More Comments" control stays hidden while automatic pagination is active.

## Release note category
<!-- Select exactly one category. Every pull request must select one. -->
<!-- Select "Not noteworthy" when the pull request fixes a bug in or improves functionality that has not yet appeared in a stable release. -->
<!-- release-note-category:start -->
- [ ] Not noteworthy
- [ ] Highlights
- [ ] More improvements
- [x] Fixed bugs
<!-- release-note-category:end -->

## Release note
<!-- Required unless "Not noteworthy" is selected. -->
<!-- Write one concise, user-facing entry without a leading bullet. -->
<!-- release-note:start -->
Comments now load with the video when automatic pagination is enabled.
<!-- release-note:end -->

## Release note images
<!-- Human-only: Agents must preserve this entire section and leave it empty. -->
<!-- Optional. Paste one or more Markdown images or HTML image tags here. -->
<!-- The release notes will use an HTML image tag and limit images taller than 300 pixels. -->
<!-- release-note-image:start -->

<!-- release-note-image:end -->

## Testing
<!-- How can reviewers verify that the PR produces correct results? -->
<!-- Please provide instructions so that others can ensure that your pull request would produce correct results. For examples see, https://github.com/FreeTubeApp/FreeTube/pull/5743, https://github.com/FreeTubeApp/FreeTube/pull/7349, https://github.com/FreeTubeApp/FreeTube/pull/5125, https://github.com/FreeTubeApp/FreeTube/pull/7338 -->
<!-- Agent instructions: Only write human-facing steps that explain how to verify the change while running this branch in dev mode. Include expected results and, when applicable, helpful console snippets for interactive verification. Do not include automated checks, commands, results, pass counts, or CI status. -->
1. Enable "Auto Load Next Page" in General Settings.
2. Open a video without scrolling to the comments section. Comments should start loading with the video, and neither "Click to View Comments" nor "Load More Comments" should appear.
3. Disable "Auto Load Next Page", open another video, and load its comments manually. "Load More Comments" should appear when another page is available.

## Additional context
<!-- Add any other context about the pull request here. -->
