### PR TITLE
fix(tabs): prevent reorders from snapping back

### DIFF
--- a/e2e/tests/offline/tabs.spec.mjs
+++ b/e2e/tests/offline/tabs.spec.mjs
@@ -713,7 +713,8 @@ test.describe('tab bar', () => {
     ])
   })
 
-  test('keeps consecutive selected drags aligned while the first drop settles', async ({ page }) => {
+  test('keeps consecutive selected drags aligned while reorder updates are delayed', async ({ app, page }) => {
+    await page.evaluate(() => window.ftElectron.setZoomFactor(0.95))
     await page.locator(sel.newTabButton).click()
     await page.locator(sel.newTabButton).click()
     await page.locator(sel.newTabButton).click()
@@ -726,6 +727,15 @@ test.describe('tab bar', () => {
     await tabs.nth(2).click()
     await expect(tabs.nth(2)).toHaveClass(/active/)
     await tabs.nth(3).click({ modifiers: ['Control'] })
+
+    await app.electronApp.evaluate(({ ipcMain }) => {
+      const channel = 'tabs-reorder'
+      const [listener] = ipcMain.listeners(channel)
+      ipcMain.removeListener(channel, listener)
+      ipcMain.on(channel, (event, ...args) => {
+        setTimeout(() => listener(event, ...args), 1000)
+      })
+    })
 
     await page.evaluate(() => {
       const tabs = Array.from(document.querySelectorAll('.tabBar .tab'))
@@ -751,6 +761,24 @@ test.describe('tab bar', () => {
       drag(tabs[3], tabs[0])
       drag(tabs[2], tabs[4])
     })
+
+    await page.waitForTimeout(600)
+    const visualOrderWhileWaiting = await tabs.evaluateAll(elements => {
+      return elements
+        .map(element => ({
+          id: element.dataset.tabId,
+          start: element.getBoundingClientRect().left
+        }))
+        .sort((a, b) => a.start - b.start)
+        .map(({ id }) => id)
+    })
+    expect(visualOrderWhileWaiting).toEqual([
+      originalIds[0],
+      originalIds[1],
+      originalIds[4],
+      originalIds[2],
+      originalIds[3]
+    ])
 
     await expect.poll(() => {
       return tabs.evaluateAll(elements => {

--- a/e2e/tests/offline/tabs.spec.mjs
+++ b/e2e/tests/offline/tabs.spec.mjs
@@ -26,6 +26,23 @@ async function boundingBoxWhenSettled(locator) {
 }
 
 /**
+ * Delay reorder handling in the main process without delaying other tab
+ * operations, simulating a busy system around the renderer-to-main handoff.
+ * @param {{electronApp: import('@playwright/test').ElectronApplication}} app
+ * @param {number} [delayMs]
+ */
+async function delayTabReorders(app, delayMs = 1000) {
+  await app.electronApp.evaluate(({ ipcMain }, delay) => {
+    const channel = 'tabs-reorder'
+    const [listener] = ipcMain.listeners(channel)
+    ipcMain.removeListener(channel, listener)
+    ipcMain.on(channel, (event, ...args) => {
+      setTimeout(() => listener(event, ...args), delay)
+    })
+  }, delayMs)
+}
+
+/**
  * Leaves three tabs open with the requested one active and returns their ids in
  * tab bar order.
  * @param {import('@playwright/test').Page} page
@@ -728,14 +745,7 @@ test.describe('tab bar', () => {
     await expect(tabs.nth(2)).toHaveClass(/active/)
     await tabs.nth(3).click({ modifiers: ['Control'] })
 
-    await app.electronApp.evaluate(({ ipcMain }) => {
-      const channel = 'tabs-reorder'
-      const [listener] = ipcMain.listeners(channel)
-      ipcMain.removeListener(channel, listener)
-      ipcMain.on(channel, (event, ...args) => {
-        setTimeout(() => listener(event, ...args), 1000)
-      })
-    })
+    await delayTabReorders(app)
 
     await page.evaluate(() => {
       const tabs = Array.from(document.querySelectorAll('.tabBar .tab'))
@@ -791,6 +801,57 @@ test.describe('tab bar', () => {
       originalIds[2],
       originalIds[3]
     ])
+  })
+
+  test('restores the authoritative order when an intervening tab invalidates a reorder', async ({ app, page }) => {
+    await page.locator(sel.newTabButton).click()
+    await page.locator(sel.newTabButton).click()
+    await page.locator(sel.newTabButton).click()
+
+    const tabs = page.locator(sel.tabs)
+    const originalIds = await tabs.evaluateAll(elements => {
+      return elements.map(element => element.dataset.tabId)
+    })
+    await delayTabReorders(app)
+
+    await page.evaluate(() => {
+      const tabs = Array.from(document.querySelectorAll('.tabBar .tab'))
+      const sourceRect = tabs[3].getBoundingClientRect()
+      const targetRect = tabs[0].getBoundingClientRect()
+      tabs[3].dispatchEvent(new PointerEvent('pointerdown', {
+        bubbles: true,
+        button: 0,
+        clientX: sourceRect.left + sourceRect.width / 2,
+        clientY: sourceRect.top + sourceRect.height / 2
+      }))
+      window.dispatchEvent(new PointerEvent('pointermove', {
+        bubbles: true,
+        buttons: 1,
+        clientX: targetRect.left + targetRect.width / 2,
+        clientY: targetRect.top + targetRect.height / 2
+      }))
+      window.dispatchEvent(new PointerEvent('pointerup', { bubbles: true, button: 0 }))
+    })
+
+    await page.evaluate(openerTabId => window.ftElectron.tabs.create({
+      route: '/history',
+      title: 'Intervening tab',
+      makeActive: false,
+      lazyLoad: true,
+      openerTabId
+    }), originalIds[0])
+
+    const authoritativeOrder = await page.evaluate(async () => {
+      return (await window.ftElectron.tabs.getState()).tabs.map(tab => tab.id)
+    })
+    await expect(tabs).toHaveCount(5)
+    await expect.poll(() => tabs.evaluateAll(elements => {
+      return elements.map(element => element.dataset.tabId)
+    })).toEqual(authoritativeOrder)
+    await expect.poll(() => page.evaluate(() => {
+      const store = document.querySelector('#app').__vue_app__.config.globalProperties.$store
+      return store.state.tabs.pendingTabOrder
+    })).toBeNull()
   })
 
   test('keeps a submenu open while moving toward it diagonally', async ({ page }) => {

--- a/src/main/tabs/TabManager.js
+++ b/src/main/tabs/TabManager.js
@@ -688,6 +688,7 @@ export class TabManager {
     this.contextMenuSelectedTabIds = []
     /** @type {string[]} */
     this.selectedTabIds = []
+    this.lastReorderRequestId = null
     this.contextMenuSurface = 'content'
     this.contextMenuSubscriptionFeedTab = null
     this.contextMenuTabBarVertical = false
@@ -2409,10 +2410,15 @@ export class TabManager {
   /**
    * Apply a complete tab order in one state update.
    * @param {string[]} tabIds
+   * @param {string | null} requestId
    */
-  reorderTabs(tabIds) {
+  reorderTabs(tabIds, requestId) {
+    this.lastReorderRequestId = requestId
     const reorderedTabs = buildReorderedTabMap(this.tabs, tabIds)
-    if (reorderedTabs == null || reorderedTabs === this.tabs) return
+    if (reorderedTabs == null || reorderedTabs === this.tabs) {
+      this._broadcastStateUpdate()
+      return
+    }
 
     this.tabs = reorderedTabs
     this._broadcastStateUpdate()
@@ -2689,6 +2695,7 @@ export class TabManager {
       activeTabId: this.activeTabId,
       presentedTabId: this.presentedTabId,
       selectionRevision: this.selectionRevision,
+      reorderRequestId: this.lastReorderRequestId,
       tabBarScrollPosition: this.tabBarScrollPosition
     }
   }
@@ -3422,11 +3429,15 @@ export async function setupTabsIPC(options = {}) {
     }
   })
 
-  ipcMain.on(IpcChannels.TABS_REORDER, (event, tabIds) => {
+  ipcMain.on(IpcChannels.TABS_REORDER, (event, tabIds, requestId) => {
     const manager = getManager(event)
     const normalizedTabIds = Array.isArray(tabIds) ? Array.from(tabIds) : null
-    if (manager && normalizedTabIds?.every(tabId => typeof tabId === 'string')) {
-      manager.reorderTabs(normalizedTabIds)
+    if (
+      manager &&
+      normalizedTabIds?.every(tabId => typeof tabId === 'string') &&
+      (requestId === null || typeof requestId === 'string')
+    ) {
+      manager.reorderTabs(normalizedTabIds, requestId)
     }
   })
 

--- a/src/preload/interface.js
+++ b/src/preload/interface.js
@@ -1020,9 +1020,10 @@ export default {
     /**
      * Apply a complete tab order atomically.
      * @param {string[]} tabIds
+     * @param {string | null} [requestId]
      */
-    reorder: (tabIds) => {
-      ipcRenderer.send(IpcChannels.TABS_REORDER, tabIds)
+    reorder: (tabIds, requestId = null) => {
+      ipcRenderer.send(IpcChannels.TABS_REORDER, tabIds, requestId)
     },
 
     /**

--- a/src/renderer/store/modules/tabs.js
+++ b/src/renderer/store/modules/tabs.js
@@ -1,6 +1,7 @@
 import packageDetails from '../../../../package.json'
 import { getTabPageIcon } from '../../tabs/tabPageIcon'
 import { DEFAULT_VIDEO_ZOOM } from '../../helpers/player/videoZoom'
+import { reconcilePendingTabOrder } from '../../tabs/pendingTabOrder'
 
 const MAX_LOGICAL_HISTORY_ENTRIES = 100
 const NAV_HISTORY_DISPLAY_LIMIT = 15
@@ -8,6 +9,7 @@ const HALF_NAV_HISTORY_DISPLAY_LIMIT = Math.trunc(NAV_HISTORY_DISPLAY_LIMIT / 2)
 
 const state = {
   tabs: [],
+  pendingTabOrder: null,
   activeTabId: null,
   selectedTabIds: [],
   presentedTabId: null,
@@ -85,7 +87,10 @@ const mutations = {
       }
     }
 
-    state.tabs = incomingTabs.map(tab => reconcileTab(previousTabsById.get(tab.id), tab))
+    const reconciledTabs = incomingTabs.map(tab => reconcileTab(previousTabsById.get(tab.id), tab))
+    const reconciledOrder = reconcilePendingTabOrder(reconciledTabs, state.pendingTabOrder)
+    state.tabs = reconciledOrder.tabs
+    state.pendingTabOrder = reconciledOrder.pendingTabOrder
     for (const tab of incomingTabs) {
       state.skipSilenceByTabId[tab.id] = tab.skipSilence === true
     }
@@ -124,6 +129,20 @@ const mutations = {
   setSelectedTabIds(state, tabIds) {
     const existingIds = new Set(state.tabs.map(tab => tab.id))
     state.selectedTabIds = Array.from(new Set(tabIds.filter(tabId => existingIds.has(tabId))))
+  },
+
+  reorderTabsOptimistically(state, tabIds) {
+    const tabsById = new Map(state.tabs.map(tab => [tab.id, tab]))
+    if (
+      tabIds.length !== state.tabs.length ||
+      new Set(tabIds).size !== tabIds.length ||
+      !tabIds.every(tabId => tabsById.has(tabId))
+    ) {
+      return
+    }
+
+    state.pendingTabOrder = [...tabIds]
+    state.tabs = tabIds.map(tabId => tabsById.get(tabId))
   },
 
   setTabTransition(state, { revision, tabId }) {
@@ -312,8 +331,9 @@ const actions = {
     }
   },
 
-  reorderTabs(_context, tabIds) {
+  reorderTabs({ commit }, tabIds) {
     if (process.env.IS_ELECTRON) {
+      commit('reorderTabsOptimistically', tabIds)
       window.ftElectron.tabs.reorder(tabIds)
     }
   },

--- a/src/renderer/store/modules/tabs.js
+++ b/src/renderer/store/modules/tabs.js
@@ -10,6 +10,7 @@ const HALF_NAV_HISTORY_DISPLAY_LIMIT = Math.trunc(NAV_HISTORY_DISPLAY_LIMIT / 2)
 const state = {
   tabs: [],
   pendingTabOrder: null,
+  pendingTabOrderRequestId: null,
   activeTabId: null,
   selectedTabIds: [],
   presentedTabId: null,
@@ -88,9 +89,17 @@ const mutations = {
     }
 
     const reconciledTabs = incomingTabs.map(tab => reconcileTab(previousTabsById.get(tab.id), tab))
-    const reconciledOrder = reconcilePendingTabOrder(reconciledTabs, state.pendingTabOrder)
+    const pendingOrderAcknowledged = payload.reorderRequestId === state.pendingTabOrderRequestId
+    const reconciledOrder = reconcilePendingTabOrder(
+      reconciledTabs,
+      state.pendingTabOrder,
+      pendingOrderAcknowledged
+    )
     state.tabs = reconciledOrder.tabs
     state.pendingTabOrder = reconciledOrder.pendingTabOrder
+    if (reconciledOrder.pendingTabOrder == null) {
+      state.pendingTabOrderRequestId = null
+    }
     for (const tab of incomingTabs) {
       state.skipSilenceByTabId[tab.id] = tab.skipSilence === true
     }
@@ -131,7 +140,7 @@ const mutations = {
     state.selectedTabIds = Array.from(new Set(tabIds.filter(tabId => existingIds.has(tabId))))
   },
 
-  reorderTabsOptimistically(state, tabIds) {
+  reorderTabsOptimistically(state, { tabIds, requestId }) {
     const tabsById = new Map(state.tabs.map(tab => [tab.id, tab]))
     if (
       tabIds.length !== state.tabs.length ||
@@ -142,6 +151,7 @@ const mutations = {
     }
 
     state.pendingTabOrder = [...tabIds]
+    state.pendingTabOrderRequestId = requestId
     state.tabs = tabIds.map(tabId => tabsById.get(tabId))
   },
 
@@ -333,8 +343,9 @@ const actions = {
 
   reorderTabs({ commit }, tabIds) {
     if (process.env.IS_ELECTRON) {
-      commit('reorderTabsOptimistically', tabIds)
-      window.ftElectron.tabs.reorder(tabIds)
+      const requestId = window.crypto.randomUUID()
+      commit('reorderTabsOptimistically', { tabIds, requestId })
+      window.ftElectron.tabs.reorder(tabIds, requestId)
     }
   },
 

--- a/src/renderer/tabs/pendingTabOrder.js
+++ b/src/renderer/tabs/pendingTabOrder.js
@@ -12,10 +12,7 @@ export function reconcilePendingTabOrder(tabs, pendingTabOrder, acknowledged = f
   const tabIds = tabs.map(tab => tab.id)
   if (
     pendingTabOrder != null &&
-    (acknowledged || (
-      tabIds.length === pendingTabOrder.length &&
-      tabIds.every((tabId, index) => tabId === pendingTabOrder[index])
-    ))
+    acknowledged
   ) {
     return { tabs, pendingTabOrder: null }
   }

--- a/src/renderer/tabs/pendingTabOrder.js
+++ b/src/renderer/tabs/pendingTabOrder.js
@@ -5,14 +5,17 @@
  * @template {{id: string}} T
  * @param {T[]} tabs
  * @param {string[] | null} pendingTabOrder
+ * @param {boolean} acknowledged
  * @returns {{tabs: T[], pendingTabOrder: string[] | null}}
  */
-export function reconcilePendingTabOrder(tabs, pendingTabOrder) {
+export function reconcilePendingTabOrder(tabs, pendingTabOrder, acknowledged = false) {
   const tabIds = tabs.map(tab => tab.id)
   if (
     pendingTabOrder != null &&
-    tabIds.length === pendingTabOrder.length &&
-    tabIds.every((tabId, index) => tabId === pendingTabOrder[index])
+    (acknowledged || (
+      tabIds.length === pendingTabOrder.length &&
+      tabIds.every((tabId, index) => tabId === pendingTabOrder[index])
+    ))
   ) {
     return { tabs, pendingTabOrder: null }
   }

--- a/src/renderer/tabs/pendingTabOrder.js
+++ b/src/renderer/tabs/pendingTabOrder.js
@@ -1,0 +1,33 @@
+/**
+ * Keep the newest local reorder visible while older main-process snapshots
+ * arrive. New tabs are appended and closed tabs are removed from the pending
+ * order until the matching snapshot acknowledges it.
+ * @template {{id: string}} T
+ * @param {T[]} tabs
+ * @param {string[] | null} pendingTabOrder
+ * @returns {{tabs: T[], pendingTabOrder: string[] | null}}
+ */
+export function reconcilePendingTabOrder(tabs, pendingTabOrder) {
+  const tabIds = tabs.map(tab => tab.id)
+  if (
+    pendingTabOrder != null &&
+    tabIds.length === pendingTabOrder.length &&
+    tabIds.every((tabId, index) => tabId === pendingTabOrder[index])
+  ) {
+    return { tabs, pendingTabOrder: null }
+  }
+  if (pendingTabOrder == null) {
+    return { tabs, pendingTabOrder: null }
+  }
+
+  const tabsById = new Map(tabs.map(tab => [tab.id, tab]))
+  const pendingTabIds = new Set(pendingTabOrder)
+  const reconciledOrder = [
+    ...pendingTabOrder.filter(tabId => tabsById.has(tabId)),
+    ...tabIds.filter(tabId => !pendingTabIds.has(tabId))
+  ]
+  return {
+    tabs: reconciledOrder.map(tabId => tabsById.get(tabId)),
+    pendingTabOrder: reconciledOrder
+  }
+}

--- a/tests/unit/tab-reorder.test.mjs
+++ b/tests/unit/tab-reorder.test.mjs
@@ -123,3 +123,15 @@ test('reconciles opened and closed tabs into a pending local order', () => {
   assert.deepEqual(result.tabs.map(tab => tab.id), ['a', 'b', 'e', 'd', 'f'])
   assert.deepEqual(result.pendingTabOrder, ['a', 'b', 'e', 'd', 'f'])
 })
+
+test('accepts the authoritative order when a pending reorder is rejected', () => {
+  const authoritativeTabs = [tabs[0], tabs[1], { id: 'f' }, tabs[2], tabs[3], tabs[4]]
+  const result = reconcilePendingTabOrder(
+    authoritativeTabs,
+    ['a', 'c', 'b', 'e', 'd'],
+    true
+  )
+
+  assert.equal(result.tabs, authoritativeTabs)
+  assert.equal(result.pendingTabOrder, null)
+})

--- a/tests/unit/tab-reorder.test.mjs
+++ b/tests/unit/tab-reorder.test.mjs
@@ -8,6 +8,7 @@ import {
   getDraggedTabIds,
   getTabIndexShift
 } from '../../src/renderer/components/TabBar/tabReorder.js'
+import { reconcilePendingTabOrder } from '../../src/renderer/tabs/pendingTabOrder.js'
 
 const tabs = [
   { id: 'a', isPinned: true },
@@ -95,4 +96,30 @@ test('reconciles a pending drag with tabs opened or closed while settling', () =
     ),
     ['p', 'a', 'b', 'c', 'd', 'e']
   )
+})
+
+test('keeps the newest local order through stale reorder acknowledgments', () => {
+  const firstOrder = [tabs[2], tabs[3], tabs[0], tabs[1], tabs[4]]
+  const newestOrderIds = ['a', 'b', 'e', 'c', 'd']
+
+  const staleAcknowledgment = reconcilePendingTabOrder(firstOrder, newestOrderIds)
+  assert.deepEqual(staleAcknowledgment.tabs.map(tab => tab.id), newestOrderIds)
+  assert.deepEqual(staleAcknowledgment.pendingTabOrder, newestOrderIds)
+
+  const finalAcknowledgment = reconcilePendingTabOrder(
+    newestOrderIds.map(id => tabs.find(tab => tab.id === id)),
+    newestOrderIds
+  )
+  assert.deepEqual(finalAcknowledgment.tabs.map(tab => tab.id), newestOrderIds)
+  assert.equal(finalAcknowledgment.pendingTabOrder, null)
+})
+
+test('reconciles opened and closed tabs into a pending local order', () => {
+  const result = reconcilePendingTabOrder(
+    [...tabs.filter(tab => tab.id !== 'c'), { id: 'f' }],
+    ['a', 'c', 'b', 'e', 'd']
+  )
+
+  assert.deepEqual(result.tabs.map(tab => tab.id), ['a', 'b', 'e', 'd', 'f'])
+  assert.deepEqual(result.pendingTabOrder, ['a', 'b', 'e', 'd', 'f'])
 })

--- a/tests/unit/tab-reorder.test.mjs
+++ b/tests/unit/tab-reorder.test.mjs
@@ -108,10 +108,22 @@ test('keeps the newest local order through stale reorder acknowledgments', () =>
 
   const finalAcknowledgment = reconcilePendingTabOrder(
     newestOrderIds.map(id => tabs.find(tab => tab.id === id)),
-    newestOrderIds
+    newestOrderIds,
+    true
   )
   assert.deepEqual(finalAcknowledgment.tabs.map(tab => tab.id), newestOrderIds)
   assert.equal(finalAcknowledgment.pendingTabOrder, null)
+})
+
+test('keeps a pending order when a stale snapshot happens to match it', () => {
+  const newestOrderIds = ['a', 'b', 'e', 'c', 'd']
+  const result = reconcilePendingTabOrder(
+    newestOrderIds.map(id => tabs.find(tab => tab.id === id)),
+    newestOrderIds
+  )
+
+  assert.deepEqual(result.tabs.map(tab => tab.id), newestOrderIds)
+  assert.deepEqual(result.pendingTabOrder, newestOrderIds)
 })
 
 test('reconciles opened and closed tabs into a pending local order', () => {


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Make sure to follow the contributing guidelines. -->
<!-- Important note, we may remove your pull request if you do not use this provided PR template correctly. -->
<!-- Agent instructions: Preserve every heading, comment, and marker in this template. Never remove or rewrite the release-note-category:start/end, release-note:start/end, or release-note-image:start/end marker pairs. Never remove or rewrite the Release note images section; leave its contents for a human. -->

## Pull Request Type
<!-- Please select what type of pull request this is: [x] -->
- [x] Bugfix
- [ ] Feature Implementation
- [ ] Documentation
- [ ] Other

## Related issue
<!-- Please link the issue your pull request is referring to. -->
<!-- If this pull request fully resolves the relevant issue, put "closes" before the issue number. -->
<!-- Example: "closes #123456". -->

None.

## Description
<!-- Please write a clear and concise description of what the pull request does. -->

On slow systems, a reordered tab could briefly jump back to its old position while the renderer waited for the main process to confirm the new order. Rapidly moving several tabs made the jump especially noticeable.

Apply each reorder optimistically in the renderer and retain the newest local order until the matching main-process snapshot arrives. Older snapshots can still update tab metadata, but they no longer overwrite a newer visual order. The regression test delays reorder handling by one second and performs consecutive drags at a fractional UI scale.

## Release note category
<!-- Select exactly one category. Every pull request must select one. -->
<!-- Select "Not noteworthy" when the pull request fixes a bug in or improves functionality that has not yet appeared in a stable release. -->
<!-- release-note-category:start -->
- [ ] Not noteworthy
- [ ] Highlights
- [ ] More improvements
- [x] Fixed bugs
<!-- release-note-category:end -->

## Release note
<!-- Required unless "Not noteworthy" is selected. -->
<!-- Write one concise, user-facing entry without a leading bullet. -->
<!-- release-note:start -->
Tabs no longer jump back to their previous position while reordering them on slower systems.
<!-- release-note:end -->

## Release note images
<!-- Human-only: Agents must preserve this entire section and leave it empty. -->
<!-- Optional. Paste one or more Markdown images or HTML image tags here. -->
<!-- The release notes will use an HTML image tag and limit images taller than 300 pixels. -->
<!-- release-note-image:start -->

<!-- release-note-image:end -->

## Testing
<!-- How can reviewers verify that the PR produces correct results? -->
<!-- Please provide instructions so that others can ensure that your pull request would produce correct results. For examples see, https://github.com/FreeTubeApp/FreeTube/pull/5743, https://github.com/FreeTubeApp/FreeTube/pull/7349, https://github.com/FreeTubeApp/FreeTube/pull/5125, https://github.com/FreeTubeApp/FreeTube/pull/7338 -->
<!-- Agent instructions: Only write human-facing steps that explain how to verify the change while running this branch in dev mode. Include expected results and, when applicable, helpful console snippets for interactive verification. Do not include automated checks, commands, results, pass counts, or CI status. -->

1. Open at least five tabs, then drag one tab to a different position and immediately drag another tab elsewhere before the first settle animation would normally finish.
2. Confirm both tabs stay in their dropped positions without briefly returning to their previous positions.
3. Set UI Scale to 95% and repeat the consecutive drags. The tabs should remain aligned and settle into the requested order.

## Additional context
<!-- Add any other context about the pull request here. -->

The previous renderer handoff stopped preserving the visual order after a 300 ms wait. The main process still remains authoritative; this change only keeps the latest local reorder visible until its matching snapshot arrives.
