### PR TITLE
fix(player): show replay icon reliably after playback ends

### DIFF
--- a/e2e/tests/offline/player.spec.mjs
+++ b/e2e/tests/offline/player.spec.mjs
@@ -49,6 +49,28 @@ test('playback starts', async ({ app, page, attachScreenshot }) => {
   await attachScreenshot('playing video')
 })
 
+test('shows the replay icon when playback ends before Shaka updates its play icon', async ({ app, page }) => {
+  const video = await openDemoVideo({ app, page })
+  const watchComponent = await page.evaluateHandle(findWatchComponent)
+  const replayIconPath = await watchComponent.evaluate(component => component.refs.player.replayIcon)
+  const playButton = page.locator(`${activeTab} .shaka-play-button`).first()
+  const nativeIconPath = playButton.locator(
+    ':scope > .shaka-ui-icon:not(.ft-play-pause-morph-icon) > path'
+  )
+
+  await video.evaluate(element => element.pause())
+  await expect(playButton).toHaveAttribute('data-ft-play-pause-state', 'play')
+
+  await video.evaluate(element => {
+    Object.defineProperty(element, 'ended', { configurable: true, value: true })
+    element.dispatchEvent(new Event('ended'))
+  })
+
+  await expect(playButton).toHaveAttribute('data-ft-play-pause-state', 'replay')
+  await expect(nativeIconPath).toHaveAttribute('d', replayIconPath)
+  await watchComponent.dispose()
+})
+
 test('does not restore a consumed link timestamp after an app restart', async ({ app, page }) => {
   await mockPlayableWatchPage(app, page)
   await page.locator(sel.searchInput).fill('https://www.youtube.com/watch?v=jNQXAC9IVRw&t=2')

--- a/e2e/tests/offline/player.spec.mjs
+++ b/e2e/tests/offline/player.spec.mjs
@@ -56,31 +56,45 @@ test('shows the replay icon when playback ends before Shaka updates its play ico
     return component.refs.player.$.setupState.replayIcon
   })
   const playButtons = page.locator(`${activeTab} .shaka-play-button`)
-  const nativeIconPaths = playButtons.locator(
-    ':scope > .shaka-ui-icon:not(.ft-play-pause-morph-icon) > path'
-  )
+  const readPlayControls = () => playButtons.evaluateAll(buttons => buttons.map(button => ({
+    state: button.getAttribute('data-ft-play-pause-state'),
+    path: button.querySelector(
+      ':scope > .shaka-ui-icon:not(.ft-play-pause-morph-icon) > path'
+    )?.getAttribute('d')
+  })))
 
   await watchComponent.evaluate(async component => {
     await component.proxy.$store.dispatch('updateDisplayVideoPlayButton', true)
     await component.proxy.$nextTick()
   })
   await expect(playButtons).toHaveCount(2)
+  const initialControls = await readPlayControls()
+  const pauseIconPath = initialControls[0].path
+  expect(pauseIconPath).toBeTruthy()
+  expect(initialControls.map(control => control.path)).toEqual([pauseIconPath, pauseIconPath])
   await video.evaluate(element => element.pause())
-  await expect.poll(() => playButtons.evaluateAll(buttons => {
-    return buttons.map(button => button.getAttribute('data-ft-play-pause-state'))
-  })).toEqual(['play', 'play'])
+  await expect.poll(async () => (await readPlayControls()).map(control => control.state))
+    .toEqual(['play', 'play'])
 
   await video.evaluate(element => {
     Object.defineProperty(element, 'ended', { configurable: true, value: true })
     element.dispatchEvent(new Event('ended'))
   })
 
-  await expect.poll(() => playButtons.evaluateAll(buttons => {
-    return buttons.map(button => button.getAttribute('data-ft-play-pause-state'))
-  })).toEqual(['replay', 'replay'])
-  await expect.poll(() => nativeIconPaths.evaluateAll(paths => {
-    return paths.map(path => path.getAttribute('d'))
-  })).toEqual([replayIconPath, replayIconPath])
+  await expect.poll(readPlayControls).toEqual([
+    { state: 'replay', path: replayIconPath },
+    { state: 'replay', path: replayIconPath }
+  ])
+
+  await video.evaluate(async element => {
+    delete element.ended
+    element.currentTime = 0
+    await element.play()
+  })
+  await expect.poll(readPlayControls).toEqual([
+    { state: 'pause', path: pauseIconPath },
+    { state: 'pause', path: pauseIconPath }
+  ])
   await watchComponent.dispose()
 })
 

--- a/e2e/tests/offline/player.spec.mjs
+++ b/e2e/tests/offline/player.spec.mjs
@@ -52,22 +52,35 @@ test('playback starts', async ({ app, page, attachScreenshot }) => {
 test('shows the replay icon when playback ends before Shaka updates its play icon', async ({ app, page }) => {
   const video = await openDemoVideo({ app, page })
   const watchComponent = await page.evaluateHandle(findWatchComponent)
-  const replayIconPath = await watchComponent.evaluate(component => component.refs.player.replayIcon)
-  const playButton = page.locator(`${activeTab} .shaka-play-button`).first()
-  const nativeIconPath = playButton.locator(
+  const replayIconPath = await watchComponent.evaluate(component => {
+    return component.refs.player.$.setupState.replayIcon
+  })
+  const playButtons = page.locator(`${activeTab} .shaka-play-button`)
+  const nativeIconPaths = playButtons.locator(
     ':scope > .shaka-ui-icon:not(.ft-play-pause-morph-icon) > path'
   )
 
+  await watchComponent.evaluate(async component => {
+    await component.proxy.$store.dispatch('updateDisplayVideoPlayButton', true)
+    await component.proxy.$nextTick()
+  })
+  await expect(playButtons).toHaveCount(2)
   await video.evaluate(element => element.pause())
-  await expect(playButton).toHaveAttribute('data-ft-play-pause-state', 'play')
+  await expect.poll(() => playButtons.evaluateAll(buttons => {
+    return buttons.map(button => button.getAttribute('data-ft-play-pause-state'))
+  })).toEqual(['play', 'play'])
 
   await video.evaluate(element => {
     Object.defineProperty(element, 'ended', { configurable: true, value: true })
     element.dispatchEvent(new Event('ended'))
   })
 
-  await expect(playButton).toHaveAttribute('data-ft-play-pause-state', 'replay')
-  await expect(nativeIconPath).toHaveAttribute('d', replayIconPath)
+  await expect.poll(() => playButtons.evaluateAll(buttons => {
+    return buttons.map(button => button.getAttribute('data-ft-play-pause-state'))
+  })).toEqual(['replay', 'replay'])
+  await expect.poll(() => nativeIconPaths.evaluateAll(paths => {
+    return paths.map(path => path.getAttribute('d'))
+  })).toEqual([replayIconPath, replayIconPath])
   await watchComponent.dispose()
 })
 

--- a/src/renderer/components/ft-shaka-video-player/ft-shaka-video-player.js
+++ b/src/renderer/components/ft-shaka-video-player/ft-shaka-video-player.js
@@ -4965,6 +4965,12 @@ export default defineComponent({
             createPlayPauseMorphIcon(button, PLAY_MORPH_PATH)
           }
 
+          if (nextState === 'replay') {
+            button.querySelector(
+              ':scope > .shaka-ui-icon:not(.ft-play-pause-morph-icon) > path'
+            )?.setAttribute('d', shaka.ui.Enums.MaterialDesignSVGIcons.REPLAY)
+          }
+
           button.setAttribute('data-ft-play-pause-state', nextState)
         })
       })


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Make sure to follow the contributing guidelines. -->
<!-- Important note, we may remove your pull request if you do not use this provided PR template correctly. -->
<!-- Agent instructions: Preserve every heading, comment, and marker in this template. Never remove or rewrite the release-note-category:start/end, release-note:start/end, or release-note-image:start/end marker pairs. Never remove or rewrite the Release note images section; leave its contents for a human. -->

## Pull Request Type
<!-- Please select what type of pull request this is: [x] -->
- [x] Bugfix
- [ ] Feature Implementation
- [ ] Documentation
- [ ] Other

## Related issue
<!-- Please link the issue your pull request is referring to. -->
<!-- If this pull request fully resolves the relevant issue, put "closes" before the issue number. -->
<!-- Example: "closes #123456". -->

No linked issue.

## Description
<!-- Please write a clear and concise description of what the pull request does. -->

On slower systems, the player could enter its replay state while Shaka's native SVG still contained the play glyph. The tooltip said "Replay," but the button continued to show the play triangle.

Set the native replay SVG path when synchronizing the replay state instead of depending on Shaka's event timing. An end-to-end regression test reproduces the stale-icon order directly.

## Release note category
<!-- Select exactly one category. Every pull request must select one. -->
<!-- Select "Not noteworthy" when the pull request fixes a bug in or improves functionality that has not yet appeared in a stable release. -->
<!-- release-note-category:start -->
- [ ] Not noteworthy
- [ ] Highlights
- [ ] More improvements
- [x] Fixed bugs
<!-- release-note-category:end -->

## Release note
<!-- Required unless "Not noteworthy" is selected. -->
<!-- Write one concise, user-facing entry without a leading bullet. -->
<!-- release-note:start -->

The player now consistently shows the replay icon when a video ends.

<!-- release-note:end -->

## Release note images
<!-- Human-only: Agents must preserve this entire section and leave it empty. -->
<!-- Optional. Paste one or more Markdown images or HTML image tags here. -->
<!-- The release notes will use an HTML image tag and limit images taller than 300 pixels. -->
<!-- release-note-image:start -->

<!-- release-note-image:end -->

## Testing
<!-- How can reviewers verify that the PR produces correct results? -->
<!-- Please provide instructions so that others can ensure that your pull request would produce correct results. For examples see, https://github.com/FreeTubeApp/FreeTube/pull/5743, https://github.com/FreeTubeApp/FreeTube/pull/7349, https://github.com/FreeTubeApp/FreeTube/pull/5125, https://github.com/FreeTubeApp/FreeTube/pull/7338 -->
<!-- Agent instructions: Only write human-facing steps that explain how to verify the change while running this branch in dev mode. Include expected results and, when applicable, helpful console snippets for interactive verification. Do not include automated checks, commands, results, pass counts, or CI status. -->

1. Open a video and let it finish, or seek close enough to the end for playback to finish naturally.
2. Check both the large center control and the control-bar play button. Each should show the replay arrow and use the "Replay" tooltip.
3. Start playback again and confirm both controls return to their normal play and pause icons.

## Additional context
<!-- Add any other context about the pull request here. -->

Shaka listens for play, pause, and seeking state changes but not the ended event. Depending on event timing, its label could update while its SVG path remained stale.
