### PR TITLE
feat(player): retry errors with alternate extraction

### DIFF
--- a/e2e/tests/offline/watch-error-navigation.spec.mjs
+++ b/e2e/tests/offline/watch-error-navigation.spec.mjs
@@ -222,6 +222,9 @@ test('watch page IP-block error does not break later navigation', async ({ app, 
     await expect(page).toHaveURL(/#\/watch\/jNQXAC9IVRw/)
     await expect(page.locator('.errorMessage')).toBeVisible({ timeout: 30_000 })
     await expect(page.locator('.errorMessage')).toContainText('blocked')
+    await expect(page.locator('.errorActions').getByRole('button')).toHaveText(
+      /Retry with (?:built-in|yt-dlp) extraction/
+    )
 
     const tabs = page.locator('.tabBar .tab')
     await page.locator('.newTabButton').click()

--- a/e2e/tests/offline/watch-page.spec.mjs
+++ b/e2e/tests/offline/watch-page.spec.mjs
@@ -812,6 +812,74 @@ async function mockTranslatedEndscreen(app, page) {
 }
 
 test.describe('watch page', () => {
+  test('retries an error with the other extraction method without changing the default', async ({ app, page }) => {
+    await mockPlayableWatchPage(app, page)
+    await page.route('https://example.invalid/retry.m3u8', route => route.fulfill({
+      contentType: 'application/x-mpegURL',
+      body: '#EXTM3U\n'
+    }))
+    await app.electronApp.evaluate(({ ipcMain }) => {
+      ipcMain.removeHandler('yt-dlp-get-playback-info')
+      ipcMain.handle('yt-dlp-get-playback-info', () => ({
+        isLive: false,
+        liveStatus: 'not_live',
+        hlsManifestUrl: 'https://example.invalid/retry.m3u8',
+        formats: [],
+        duration: 600,
+        version: 'test'
+      }))
+    })
+    await openMockedVideo(page)
+
+    const watchView = await watchViewHandle(page)
+    const builtInManifest = await watchView.evaluate((view) => view.manifestSrc)
+    await page.evaluate(async () => {
+      const store = document.querySelector('#app').__vue_app__.config.globalProperties.$store
+      await store.dispatch('updateUiScale', 125)
+    })
+    await watchView.evaluate(async (view) => {
+      view.errorMessage = 'The built-in extraction failed'
+      await view.$nextTick()
+    })
+
+    const ytDlpRetry = page.getByRole('button', { name: 'Retry with yt-dlp extraction' })
+    const [buttonBounds, errorBounds] = await Promise.all([
+      ytDlpRetry.boundingBox(),
+      page.locator('.errorWrapper').boundingBox()
+    ])
+    expect(buttonBounds.x).toBeGreaterThanOrEqual(errorBounds.x)
+    expect(buttonBounds.x + buttonBounds.width).toBeLessThanOrEqual(errorBounds.x + errorBounds.width)
+    await ytDlpRetry.click()
+    await expect.poll(() => watchView.evaluate((view) => ({
+      activeEngine: view.activePlaybackEngine,
+      errorMessage: view.errorMessage,
+      manifest: view.manifestSrc
+    }))).toEqual({
+      activeEngine: 'yt-dlp',
+      errorMessage: null,
+      manifest: 'https://example.invalid/retry.m3u8'
+    })
+
+    await watchView.evaluate(async (view) => {
+      view.errorMessage = 'The yt-dlp extraction failed'
+      await view.$nextTick()
+    })
+    await page.getByRole('button', { name: 'Retry with built-in extraction' }).click()
+    await expect.poll(() => watchView.evaluate((view) => ({
+      activeEngine: view.activePlaybackEngine,
+      errorMessage: view.errorMessage,
+      manifest: view.manifestSrc
+    }))).toEqual({
+      activeEngine: 'built-in',
+      errorMessage: null,
+      manifest: builtInManifest
+    })
+    expect(await page.evaluate(() => {
+      const store = document.querySelector('#app').__vue_app__.config.globalProperties.$store
+      return store.getters.getVideoPlaybackEngine
+    })).toBe('built-in')
+  })
+
   test('shows the automatic yt-dlp live fallback while streams are pending', async ({ app, page }) => {
     await mockPlayableWatchPage(app, page)
     await openMockedVideo(page)

--- a/e2e/tests/offline/watch-page.spec.mjs
+++ b/e2e/tests/offline/watch-page.spec.mjs
@@ -812,6 +812,36 @@ async function mockTranslatedEndscreen(app, page) {
 }
 
 test.describe('watch page', () => {
+  test('keeps private and DRM errors ineligible for extraction retry after locale changes', async ({ app, page }) => {
+    await mockPlayableWatchPage(app, page)
+    await openMockedVideo(page)
+
+    const watchView = await watchViewHandle(page)
+    await watchView.evaluate(async (view) => {
+      view.setNonRetryablePlaybackError('private')
+      await view.$nextTick()
+    })
+    await page.evaluate(async () => {
+      const store = document.querySelector('#app').__vue_app__.config.globalProperties.$store
+      await store.dispatch('updateCurrentLocale', 'de-DE')
+    })
+    await expect.poll(() => watchView.evaluate(view => view.currentLocale)).toBe('de-DE')
+    expect(await watchView.evaluate(view => view.errorMessage === view.t('Video.Private'))).toBe(false)
+    await expect(page.locator('.errorActions')).toHaveCount(0)
+
+    await watchView.evaluate(async (view) => {
+      view.setNonRetryablePlaybackError('drm')
+      await view.$nextTick()
+    })
+    await page.evaluate(async () => {
+      const store = document.querySelector('#app').__vue_app__.config.globalProperties.$store
+      await store.dispatch('updateCurrentLocale', 'en-US')
+    })
+    await expect.poll(() => watchView.evaluate(view => view.currentLocale)).toBe('en-US')
+    expect(await watchView.evaluate(view => view.errorMessage === view.t('Video.DRMProtected'))).toBe(false)
+    await expect(page.locator('.errorActions')).toHaveCount(0)
+  })
+
   test('retries an error with the other extraction method without changing the default', async ({ app, page }) => {
     await mockPlayableWatchPage(app, page)
     await page.route('https://example.invalid/retry.m3u8', route => route.fulfill({

--- a/src/renderer/views/Watch/Watch.js
+++ b/src/renderer/views/Watch/Watch.js
@@ -398,6 +398,8 @@ export default defineComponent({
       customErrorIcon: null,
       /** @type {'age' | 'members' | null} */
       restrictedPlaybackError: null,
+      /** @type {'private' | 'drm' | null} */
+      nonRetryablePlaybackError: null,
       videoGenreIsMusic: false,
       /** @type {Date|null} */
       streamingDataExpiryDate: null,
@@ -833,8 +835,7 @@ export default defineComponent({
         !this.isUpcoming &&
         !this.isPostLiveDvr &&
         this.restrictedPlaybackError === null &&
-        this.errorMessage !== this.t('Video.Private') &&
-        this.errorMessage !== this.t('Video.DRMProtected')
+        this.nonRetryablePlaybackError === null
     },
     /** @returns {'sabr' | 'dash' | 'hls' | 'none'} */
     playbackStreamType: function () {
@@ -1890,6 +1891,7 @@ export default defineComponent({
       this.errorMessage = null
       this.customErrorIcon = null
       this.restrictedPlaybackError = null
+      this.nonRetryablePlaybackError = null
       this.videoGenreIsMusic = false
       this.streamingDataExpiryDate = null
       this.ipBlockDetectedInCurrentChain = false
@@ -2429,6 +2431,17 @@ export default defineComponent({
       this.customErrorIcon = type === 'members' ? ['fas', 'money-check-dollar'] : null
     },
 
+    /**
+     * Sets an error that switching stream extraction methods cannot resolve.
+     * @param {'private' | 'drm'} type
+     */
+    setNonRetryablePlaybackError: function (type) {
+      this.nonRetryablePlaybackError = type
+      this.errorMessage = type === 'private'
+        ? this.t('Video.Private')
+        : this.t('Video.DRMProtected')
+    },
+
     getRestrictedPlaybackErrorType: function (message) {
       if (typeof message !== 'string') {
         return null
@@ -2564,7 +2577,7 @@ export default defineComponent({
         if (playabilityStatus.status === 'LOGIN_REQUIRED' && playabilityStatus.error_screen?.reason?.text === 'Private video') {
           // Private videos cannot be played in FreeTube, as they require to be logged as the owner of the video
           // so there is no point continuing or trying any other backends as it will always fail
-          this.errorMessage = this.t('Video.Private')
+          this.setNonRetryablePlaybackError('private')
           this.thumbnail = this.getUnavailableVideoThumbnail()
           this.isLoading = false
           this.updateTitle()
@@ -2796,7 +2809,7 @@ export default defineComponent({
           } else if (isDrmProtected) {
             // DRM protected videos (e.g. movies) cannot be played in FreeTube,
             // as they require the proprietary and closed source Wideview CDM which is understandably not included in standard Electron builds
-            this.errorMessage = this.t('Video.DRMProtected')
+            this.setNonRetryablePlaybackError('drm')
             this.isLoading = false
             this.updateTitle()
             return

--- a/src/renderer/views/Watch/Watch.js
+++ b/src/renderer/views/Watch/Watch.js
@@ -818,6 +818,24 @@ export default defineComponent({
 
       return this.activePlaybackEngine
     },
+    otherPlaybackEngine: function () {
+      return this.playbackEngineSelection === 'yt-dlp' ? 'built-in' : 'yt-dlp'
+    },
+    retryWithOtherPlaybackEngineLabel: function () {
+      return this.otherPlaybackEngine === 'yt-dlp'
+        ? this.t('Video.Retry With yt-dlp Extraction')
+        : this.t('Video.Retry With Built-in Extraction')
+    },
+    canRetryWithOtherPlaybackEngine: function () {
+      return process.env.IS_ELECTRON &&
+        this.errorMessage !== null &&
+        !this.localFilePlayback &&
+        !this.isUpcoming &&
+        !this.isPostLiveDvr &&
+        this.restrictedPlaybackError === null &&
+        this.errorMessage !== this.t('Video.Private') &&
+        this.errorMessage !== this.t('Video.DRMProtected')
+    },
     /** @returns {'sabr' | 'dash' | 'hls' | 'none'} */
     playbackStreamType: function () {
       if (this.manifestSrc === null || this.activeFormat === 'legacy') {
@@ -4223,6 +4241,11 @@ export default defineComponent({
       this.errorMessage = null
       this.alignActiveFormatWithAvailableSources()
       this.ytDlpStreamsPending = false
+    },
+
+    retryWithOtherPlaybackEngine: function () {
+      this.customErrorIcon = null
+      return this.handlePlaybackEngineChange(this.otherPlaybackEngine)
     },
 
     enableDashFormat: function () {

--- a/src/renderer/views/Watch/Watch.scss
+++ b/src/renderer/views/Watch/Watch.scss
@@ -234,8 +234,17 @@
         font-size: 14px;
       }
 
-      .restrictedPlaybackButton {
+      .errorActions {
+        display: flex;
+        flex-wrap: wrap;
+        gap: 10px;
+      }
+
+      .errorActionButton {
         margin: 0;
+        min-block-size: 44px;
+        max-inline-size: 100%;
+        white-space: normal;
       }
 
       @media only screen and (width <= 680px) {

--- a/src/renderer/views/Watch/Watch.vue
+++ b/src/renderer/views/Watch/Watch.vue
@@ -318,14 +318,27 @@
                 >
                   {{ $t('Video.Configure Restricted Playback Cookies Hint') }}
                 </p>
-                <FtButton
-                  v-if="canTryRestrictedPlaybackWithCookies"
-                  class="restrictedPlaybackButton"
-                  :label="$t('Video.Try With Configured Cookies')"
-                  :text-color="null"
-                  :background-color="null"
-                  @click="tryRestrictedPlaybackWithCookies"
-                />
+                <div
+                  v-if="canTryRestrictedPlaybackWithCookies || canRetryWithOtherPlaybackEngine"
+                  class="errorActions"
+                >
+                  <FtButton
+                    v-if="canTryRestrictedPlaybackWithCookies"
+                    class="errorActionButton"
+                    :label="$t('Video.Try With Configured Cookies')"
+                    :text-color="null"
+                    :background-color="null"
+                    @click="tryRestrictedPlaybackWithCookies"
+                  />
+                  <FtButton
+                    v-if="canRetryWithOtherPlaybackEngine"
+                    class="errorActionButton"
+                    :label="retryWithOtherPlaybackEngineLabel"
+                    :text-color="null"
+                    :background-color="null"
+                    @click="retryWithOtherPlaybackEngine"
+                  />
+                </div>
               </div>
             </div>
           </div>

--- a/static/locales/de-DE.yaml
+++ b/static/locales/de-DE.yaml
@@ -1675,6 +1675,8 @@ Video:
       'Off': Aus
     Resize dock: Leiste in der Größe ändern
   IP block: YouTube hat deine IP-Adresse für die Videowiedergabe gesperrt. Bitte versuche, einen anderen VPN oder Proxy zu nutzen.
+  Retry With Built-in Extraction: Erneut mit der integrierten Extraktion versuchen
+  Retry With yt-dlp Extraction: Erneut mit der yt-dlp-Extraktion versuchen
   Unlisted: Nicht gelistet
   AI: KI
   AI-generated content: KI-generierte Inhalte

--- a/static/locales/en-US.yaml
+++ b/static/locales/en-US.yaml
@@ -1675,6 +1675,8 @@ Video:
     Empty: This transcript does not contain any text.
     No Results: No transcript segments match your search.
   IP block: 'YouTube has blocked your IP address from watching videos. Please try switching to a different VPN or proxy.'
+  Retry With Built-in Extraction: Retry with built-in extraction
+  Retry With yt-dlp Extraction: Retry with yt-dlp extraction
   Reloading video after streaming URL error: Reloading video after streaming URL error
   MembersOnly: This members-only video requires a Google account with an active membership to this channel.
   AgeRestricted: This age-restricted video requires an age-verified Google account.


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Make sure to follow the contributing guidelines. -->
<!-- Important note, we may remove your pull request if you do not use this provided PR template correctly. -->
<!-- Agent instructions: Preserve every heading, comment, and marker in this template. Never remove or rewrite the release-note-category:start/end, release-note:start/end, or release-note-image:start/end marker pairs. Never remove or rewrite the Release note images section; leave its contents for a human. -->

## Pull Request Type
<!-- Please select what type of pull request this is: [x] -->
- [ ] Bugfix
- [x] Feature Implementation
- [ ] Documentation
- [ ] Other

## Related issue
<!-- Please link the issue your pull request is referring to. -->
<!-- If this pull request fully resolves the relevant issue, put "closes" before the issue number. -->
<!-- Example: "closes #123456". -->

## Description
<!-- Please write a clear and concise description of what the pull request does. -->
The player error screen did not offer a direct way to try the other stream extraction method. Users had to open the format menu or change settings before retrying playback.

Add a localized retry button to eligible player errors. It switches only the current video between the built-in and yt-dlp extraction methods, preserves the configured default, and stays hidden where switching cannot help, such as private, DRM-protected, restricted-authentication, local-file, upcoming, and post-live DVR playback.

## Release note category
<!-- Select exactly one category. Every pull request must select one. -->
<!-- Select "Not noteworthy" when the pull request fixes a bug in or improves functionality that has not yet appeared in a stable release. -->
<!-- release-note-category:start -->
- [ ] Not noteworthy
- [ ] Highlights
- [x] More improvements
- [ ] Fixed bugs
<!-- release-note-category:end -->

## Release note
<!-- Required unless "Not noteworthy" is selected. -->
<!-- Write one concise, user-facing entry without a leading bullet. -->
<!-- release-note:start -->
Player errors now offer a one-click retry with the other stream extraction method.
<!-- release-note:end -->

## Release note images
<!-- Human-only: Agents must preserve this entire section and leave it empty. -->
<!-- Optional. Paste one or more Markdown images or HTML image tags here. -->
<!-- The release notes will use an HTML image tag and limit images taller than 300 pixels. -->
<!-- release-note-image:start -->

<!-- release-note-image:end -->

## Testing
<!-- How can reviewers verify that the PR produces correct results? -->
<!-- Please provide instructions so that others can ensure that your pull request would produce correct results. For examples see, https://github.com/FreeTubeApp/FreeTube/pull/5743, https://github.com/FreeTubeApp/FreeTube/pull/7349, https://github.com/FreeTubeApp/FreeTube/pull/5125, https://github.com/FreeTubeApp/FreeTube/pull/7338 -->
<!-- Agent instructions: Only write human-facing steps that explain how to verify the change while running this branch in dev mode. Include expected results and, when applicable, helpful console snippets for interactive verification. Do not include automated checks, commands, results, pass counts, or CI status. -->
1. Configure the built-in stream extraction method and open a video that reaches the player error screen, such as an IP-blocked video.
2. Confirm that the error shows a **Retry with yt-dlp extraction** button.
3. Activate the button and confirm that the video retries with yt-dlp while the configured default remains built-in.
4. Trigger an error while yt-dlp is active and confirm that the action changes to **Retry with built-in extraction** and restores the built-in source.
5. At 125% UI scale, confirm that the button remains inside the error overlay and its label does not overflow.

## Additional context
<!-- Add any other context about the pull request here. -->
Age-restricted and members-only errors retain their dedicated configured-cookie recovery action instead of showing this generic extraction retry.
