### PR TITLE
feat(settings): control yt-dlp URL caching

### DIFF
--- a/e2e/tests/offline/storage-settings.spec.mjs
+++ b/e2e/tests/offline/storage-settings.spec.mjs
@@ -134,6 +134,34 @@ test('moves storage controls into one searchable category', async ({ app, attach
   await expect(storage.getByRole('heading', { name: 'Stored histories' })).toBeVisible()
   await expect(storage.getByRole('heading', { name: 'Other user data' })).toBeVisible()
   await expect(storage.getByRole('checkbox', { name: 'Metadata history' })).toBeChecked()
+  const playbackCaches = storage.locator('.storageItem').filter({
+    has: page.getByRole('heading', { name: 'Playback caches', exact: true })
+  })
+  await expect(playbackCaches).toContainText(
+    'The URL cache applies only to streams fetched with yt-dlp.'
+  )
+  const playbackCacheSize = storage.getByRole('slider', {
+    name: /yt-dlp stream URL cache limit/
+  })
+  const playbackCacheTooltip = 'Sets the maximum size of each cached yt-dlp stream entry. Set it to 0 MB to disable persistent caching for yt-dlp streams.'
+  await playbackCaches.getByRole('button', { name: playbackCacheTooltip }).focus()
+  await expect(page.getByRole('tooltip')).toHaveText(playbackCacheTooltip)
+  await expect(playbackCacheSize).toHaveValue('5')
+  await playbackCacheSize.fill('4')
+  await expect.poll(() => page.evaluate(() => (
+    document.querySelector('#app').__vue_app__.config.globalProperties.$store
+      .getters.getYtDlpPlaybackCacheMaxEntrySize
+  ))).toBe(4)
+  await playbackCacheSize.fill('0')
+  await expect.poll(() => page.evaluate(() => (
+    document.querySelector('#app').__vue_app__.config.globalProperties.$store
+      .getters.getYtDlpPlaybackCacheMaxEntrySize
+  ))).toBe(0)
+  await playbackCacheSize.fill('5')
+  await expect.poll(() => page.evaluate(() => (
+    document.querySelector('#app').__vue_app__.config.globalProperties.$store
+      .getters.getYtDlpPlaybackCacheMaxEntrySize
+  ))).toBe(5)
   await expect(storage.getByLabel('Automatic History Retention (Days)')).toHaveValue('30')
   await expect(storage.getByRole('checkbox', { name: 'Replace HTTP Cache' })).toHaveCount(0)
   await expect(storage.locator('.storageKind')).toHaveCount(0)
@@ -166,6 +194,7 @@ test('moves storage controls into one searchable category', async ({ app, attach
   await attachScreenshot('storage settings overview')
 
   const cacheSegment = breakdown.locator('[data-chart-segment="browser-caches"]')
+  await breakdown.scrollIntoViewIfNeeded()
   const chartBox = await breakdown.locator('.storageDonutChart').boundingBox()
   await page.mouse.move(
     chartBox.x + chartBox.width * 0.8,

--- a/e2e/tests/offline/video-actions.spec.mjs
+++ b/e2e/tests/offline/video-actions.spec.mjs
@@ -124,7 +124,7 @@ test('persists an authenticated HLS playback source across app restarts', async 
   })).toEqual({ expiryTime, source })
 })
 
-test('limits persisted yt-dlp playback entries by UTF-8 byte size', async ({ page }) => {
+test('uses the configured UTF-8 byte limit for persisted yt-dlp playback entries', async ({ page }) => {
   const source = {
     manifestSrc: `data:application/dash+xml;charset=UTF-8,${'€'.repeat(700_000)}`,
     manifestMimeType: 'application/dash+xml',
@@ -134,6 +134,11 @@ test('limits persisted yt-dlp playback entries by UTF-8 byte size', async ({ pag
     version: '2026.08.13'
   }
 
+  await page.evaluate(() => {
+    const store = document.querySelector('#app').__vue_app__.config.globalProperties.$store
+    return store.dispatch('updateYtDlpPlaybackCacheMaxEntrySize', 2)
+  })
+
   expect(await page.evaluate(source => {
     return window.ftElectron.ytDlpPlaybackCacheSet(
       'eeeeeeeeeee',
@@ -142,6 +147,48 @@ test('limits persisted yt-dlp playback entries by UTF-8 byte size', async ({ pag
       source
     )
   }, source)).toBe(false)
+
+  await page.evaluate(() => {
+    const store = document.querySelector('#app').__vue_app__.config.globalProperties.$store
+    return store.dispatch('updateYtDlpPlaybackCacheMaxEntrySize', 4)
+  })
+
+  expect(await page.evaluate(source => {
+    return window.ftElectron.ytDlpPlaybackCacheSet(
+      'eeeeeeeeeee',
+      'settings',
+      Date.now() + 60 * 60 * 1000,
+      source
+    )
+  }, source)).toBe(true)
+})
+
+test('a zero size limit disables and clears the persistent yt-dlp playback cache', async ({ app, page }) => {
+  const source = {
+    manifestSrc: 'data:application/dash+xml;charset=UTF-8,manifest',
+    manifestMimeType: 'application/dash+xml',
+    legacyFormats: [],
+    title: 'Cached video title',
+    isLive: false,
+    version: '2026.08.13'
+  }
+  const expiryTime = Date.now() + 60 * 60 * 1000
+
+  expect(await page.evaluate(({ expiryTime, source }) => {
+    return window.ftElectron.ytDlpPlaybackCacheSet('eeeeeeeeeee', 'settings', expiryTime, source)
+  }, { expiryTime, source })).toBe(true)
+
+  await page.evaluate(() => {
+    const store = document.querySelector('#app').__vue_app__.config.globalProperties.$store
+    return store.dispatch('updateYtDlpPlaybackCacheMaxEntrySize', 0)
+  })
+
+  expect(await page.evaluate(({ expiryTime, source }) => Promise.all([
+    window.ftElectron.ytDlpPlaybackCacheGet('eeeeeeeeeee', 'settings'),
+    window.ftElectron.ytDlpPlaybackCacheSet('fffffffffff', 'settings', expiryTime, source)
+  ]), { expiryTime, source })).toEqual([null, false])
+  await expect(readFile(path.join(app.userDataDir, 'yt-dlp-playback-cache.json')))
+    .rejects.toMatchObject({ code: 'ENOENT' })
 })
 
 test('prefers evicting yt-dlp playback entries without open tabs', async ({ page }) => {

--- a/src/main/index.js
+++ b/src/main/index.js
@@ -45,7 +45,7 @@ import { brotliDecompress } from 'zlib'
 import packageDetails from '../../package.json'
 import { handleOpenInExternalPlayer } from './externalPlayer'
 import { getYtDlpDownloadFile, handleYtDlpCancelDownload, handleYtDlpCheckBinaryUpdate, handleYtDlpClearDownloads, handleYtDlpControlDownload, handleYtDlpDownload, handleYtDlpDownloadBinary, handleYtDlpGetInfo, handleYtDlpGetPlaybackInfo, handleYtDlpGetRecommendations, handleYtDlpListDownloads, handleYtDlpOpenDownload, handleYtDlpQueueAction, handleYtDlpRemoveDownload, refreshYtDlpDownloadQueue, restoreYtDlpDownloadQueue, shutdownYtDlpDownloads } from './ytDlp'
-import { handleYtDlpPlaybackCacheClear, handleYtDlpPlaybackCacheDelete, handleYtDlpPlaybackCacheGet, handleYtDlpPlaybackCacheSet } from './ytDlpPlaybackCache'
+import { applyYtDlpPlaybackCacheSettings, handleYtDlpPlaybackCacheClear, handleYtDlpPlaybackCacheDelete, handleYtDlpPlaybackCacheGet, handleYtDlpPlaybackCacheSet } from './ytDlpPlaybackCache'
 import { generatePoToken } from './poTokenGenerator'
 import { expandMultipleOnlyPluralMessages, selectPluralForm } from '../renderer/i18n/plurals'
 import { buildProxyUrl, DEFAULT_PROXY_SETTINGS, isNonPublicNetworkAddress, isOpenTubeXUrl } from './utils'
@@ -1728,6 +1728,11 @@ function runApp() {
   let proxyUrl
 
   app.on('ready', async (_, __) => {
+    try {
+      await applyYtDlpPlaybackCacheSettings()
+    } catch (error) {
+      console.warn('Could not apply the yt-dlp playback cache settings', error)
+    }
     try {
       await restoreYtDlpDownloadQueue()
     } catch (error) {
@@ -4408,6 +4413,13 @@ function runApp() {
             case 'ytDlpMaxConcurrentDownloads':
             case 'ytDlpDownloadBandwidthLimit':
               await refreshYtDlpDownloadQueue()
+              break
+            case 'ytDlpPlaybackCacheMaxEntrySize':
+              try {
+                await applyYtDlpPlaybackCacheSettings()
+              } catch (error) {
+                console.warn('Could not apply the yt-dlp playback cache settings', error)
+              }
               break
 
             default:

--- a/src/main/ytDlpPlaybackCache.js
+++ b/src/main/ytDlpPlaybackCache.js
@@ -179,7 +179,7 @@ export async function handleYtDlpPlaybackCacheSet(event, videoId, cacheKey, expi
   if (Date.now() >= entry.expiryTime - EXPIRY_MARGIN_MS) return false
 
   await loadEntries()
-  if (!cacheEnabled) return false
+  if (!cacheEnabled || !isValidEntry(entry)) return false
   entries.delete(entry.videoId)
   const openVideoIds = TabManager.getOpenVideoIds()
   while (entries.size >= MAX_ENTRIES) {

--- a/src/main/ytDlpPlaybackCache.js
+++ b/src/main/ytDlpPlaybackCache.js
@@ -4,13 +4,18 @@ import { createHash } from 'node:crypto'
 import { readFile, rename, rm, writeFile } from 'node:fs/promises'
 import { join } from 'node:path'
 
+import { settings } from '../datastores/handlers/base'
+import {
+  DEFAULT_YT_DLP_PLAYBACK_CACHE_MAX_ENTRY_SIZE_MB,
+  normalizeYtDlpPlaybackCacheMaxEntrySize
+} from '../ytDlpPlaybackCacheSettings'
 import { TabManager } from './tabs/TabManager'
 import { isOpenTubeXUrl } from './utils'
 
 const CACHE_FILENAME = 'yt-dlp-playback-cache.json'
 const MAX_ENTRIES = 50
 const EXPIRY_MARGIN_MS = 2 * 60 * 1000
-const MAX_ENTRY_LENGTH = 2_000_000
+const BYTES_PER_MEGABYTE = 1_000_000
 const MAX_CACHE_KEY_LENGTH = 20_000
 const VIDEO_ID_REGEX = /^[\w-]{11}$/
 const CACHE_KEY_HASH_REGEX = /^[a-f\d]{64}$/
@@ -19,6 +24,8 @@ const CACHE_KEY_HASH_REGEX = /^[a-f\d]{64}$/
 const entries = new Map()
 let loadPromise = null
 let writeQueue = Promise.resolve()
+let cacheEnabled = true
+let maxEntryLength = DEFAULT_YT_DLP_PLAYBACK_CACHE_MAX_ENTRY_SIZE_MB * BYTES_PER_MEGABYTE
 
 /**
  * @typedef {object} YtDlpPlaybackCacheEntry
@@ -73,7 +80,7 @@ function isValidEntry(entry) {
     legacyFormats.length > 0 &&
     legacyFormats.every(format => isHttpsUrl(format?.url))
 
-  return Buffer.byteLength(serializedEntry, 'utf8') <= MAX_ENTRY_LENGTH &&
+  return Buffer.byteLength(serializedEntry, 'utf8') <= maxEntryLength &&
     VIDEO_ID_REGEX.test(entry.videoId) &&
     CACHE_KEY_HASH_REGEX.test(entry.cacheKeyHash) &&
     Number.isFinite(entry.expiryTime) &&
@@ -125,8 +132,10 @@ export async function handleYtDlpPlaybackCacheGet(event, videoId, cacheKey) {
     !VIDEO_ID_REGEX.test(videoId) ||
     !isValidCacheKey(cacheKey)
   ) return null
+  if (!cacheEnabled) return null
 
   await loadEntries()
+  if (!cacheEnabled) return null
   const entry = entries.get(videoId)
   if (entry === undefined) return null
 
@@ -148,6 +157,7 @@ export async function handleYtDlpPlaybackCacheSet(event, videoId, cacheKey, expi
     !VIDEO_ID_REGEX.test(videoId) ||
     !isValidCacheKey(cacheKey)
   ) return false
+  if (!cacheEnabled) return false
 
   const entry = {
     videoId,
@@ -169,6 +179,7 @@ export async function handleYtDlpPlaybackCacheSet(event, videoId, cacheKey, expi
   if (Date.now() >= entry.expiryTime - EXPIRY_MARGIN_MS) return false
 
   await loadEntries()
+  if (!cacheEnabled) return false
   entries.delete(entry.videoId)
   const openVideoIds = TabManager.getOpenVideoIds()
   while (entries.size >= MAX_ENTRIES) {
@@ -205,4 +216,27 @@ export async function clearYtDlpPlaybackCache() {
       rm(`${cachePath()}.tmp`, { force: true })
     ]))
   await writeQueue
+}
+
+export async function applyYtDlpPlaybackCacheSettings() {
+  const maxEntrySizeSetting = await settings._findOne('ytDlpPlaybackCacheMaxEntrySize')
+  const maxEntrySize = normalizeYtDlpPlaybackCacheMaxEntrySize(maxEntrySizeSetting?.value)
+
+  cacheEnabled = maxEntrySize > 0
+  maxEntryLength = maxEntrySize * BYTES_PER_MEGABYTE
+
+  await loadEntries()
+  if (!cacheEnabled) {
+    await clearYtDlpPlaybackCache()
+    return
+  }
+
+  let changed = false
+  for (const [videoId, entry] of entries) {
+    if (!isValidEntry(entry)) {
+      entries.delete(videoId)
+      changed = true
+    }
+  }
+  if (changed) await saveEntries()
 }

--- a/src/renderer/components/StorageSettings/StorageItem.css
+++ b/src/renderer/components/StorageSettings/StorageItem.css
@@ -69,6 +69,17 @@
   inline-size: min(100%, 360px);
 }
 
+.storageActions :deep(.pure-material-slider) {
+  box-sizing: border-box;
+  inline-size: min(100%, 380px);
+  margin: 0;
+}
+
+.storageActions :deep(.pure-material-slider .selectTooltip) {
+  inset: auto;
+  position: relative;
+}
+
 @container settings-content (width <= 430px) {
   .storageItemHeader {
     flex-direction: column;

--- a/src/renderer/components/StorageSettings/StorageSettings.vue
+++ b/src/renderer/components/StorageSettings/StorageSettings.vue
@@ -186,6 +186,17 @@
           :description="t('Settings.Storage Settings.Playback Caches Description')"
           location="yt-dlp-playback-cache.json, player_cache/"
         >
+          <FtSlider
+            :label="t('Settings.Storage Settings.Playback URL Cache Entry Size')"
+            :tooltip="t('Settings.Storage Settings.Playback URL Cache Entry Size Tooltip')"
+            :default-value="ytDlpPlaybackCacheMaxEntrySize"
+            setting-key="ytDlpPlaybackCacheMaxEntrySize"
+            :min-value="MIN_YT_DLP_PLAYBACK_CACHE_MAX_ENTRY_SIZE_MB"
+            :max-value="MAX_YT_DLP_PLAYBACK_CACHE_MAX_ENTRY_SIZE_MB"
+            :step="1"
+            value-extension=" MB"
+            @change="updateYtDlpPlaybackCacheMaxEntrySize"
+          />
           <FtButton
             :label="t('Settings.Storage Settings.Clear Playback Caches')"
             theme="destructive"
@@ -332,11 +343,17 @@ import FtButton from '../FtButton/FtButton.vue'
 import FtInput from '../FtInput/FtInput.vue'
 import FtPrompt from '../FtPrompt/FtPrompt.vue'
 import FtSettingsSection from '../FtSettingsSection/FtSettingsSection.vue'
+import FtSlider from '../FtSlider/FtSlider.vue'
 import FtToggleSwitch from '../FtToggleSwitch/FtToggleSwitch.vue'
 import FtTooltip from '../FtTooltip/FtTooltip.vue'
 import StorageItem from './StorageItem.vue'
 
 import { MAIN_PROFILE_ID } from '../../../constants'
+import {
+  MAX_YT_DLP_PLAYBACK_CACHE_MAX_ENTRY_SIZE_MB,
+  MIN_YT_DLP_PLAYBACK_CACHE_MAX_ENTRY_SIZE_MB,
+  normalizeYtDlpPlaybackCacheMaxEntrySize
+} from '../../../ytDlpPlaybackCacheSettings'
 import { formatBytes } from '../../helpers/fileSize'
 import { invalidateAllYtDlpPlaybackSources } from '../../helpers/player/ytDlpPlayback'
 import { showToast } from '../../helpers/utils'
@@ -364,9 +381,16 @@ const downloadedMediaText = computed(() => hasLoadedUsage.value
   ? formatBytes(downloadedMediaBytes.value)
   : t('Settings.Storage Settings.Calculating'))
 const sessionSearchCount = computed(() => store.getters.getSessionSearchHistory.length)
+const ytDlpPlaybackCacheMaxEntrySize = computed(() => (
+  normalizeYtDlpPlaybackCacheMaxEntrySize(store.getters.getYtDlpPlaybackCacheMaxEntrySize)
+))
 const downloadFolderLocation = computed(() => (
   store.getters.getYtDlpDownloadFolderPath || t('Settings.Storage Settings.Selected Download Folders')
 ))
+
+function updateYtDlpPlaybackCacheMaxEntrySize(value) {
+  return store.dispatch('updateYtDlpPlaybackCacheMaxEntrySize', value)
+}
 
 function sumSizeText(...keys) {
   if (!hasLoadedUsage.value) return t('Settings.Storage Settings.Calculating')

--- a/src/renderer/helpers/settingsSearch.js
+++ b/src/renderer/helpers/settingsSearch.js
@@ -224,6 +224,10 @@ function isSettingsSearchMessageVisible(sectionType, path, options) {
       store.getters.getEnableDownloads
   }
 
+  if (sectionType === 'storage') {
+    if (group === 'Playback URL Cache Entry Size') return usingElectron
+  }
+
   if (sectionType === 'external-software') {
     if (group === 'yt-dlp Channel') return store.getters.getYtDlpSource === 'managed'
     if (group === 'Managed Tool Updates') {

--- a/src/renderer/store/modules/settings.js
+++ b/src/renderer/store/modules/settings.js
@@ -29,6 +29,7 @@ import {
   LAST_USED_VERSION_SETTING_ID,
   TUTORIAL_AUDIENCE_SETTING_ID,
 } from '../../helpers/tutorialState.js'
+import { DEFAULT_YT_DLP_PLAYBACK_CACHE_MAX_ENTRY_SIZE_MB } from '../../../ytDlpPlaybackCacheSettings.js'
 
 const CHANNEL_SETTINGS_SYNC_MIGRATION_SETTING = 'channelSettingsSyncMigration'
 const TUTORIAL_STATE_SETTING_IDS = new Set([
@@ -259,6 +260,7 @@ const state = {
   ytDlpPlaybackCookiesPath: '',
   ytDlpPlaybackCookiesBrowser: '',
   ytDlpPlaybackCookiesBrowserProfile: '',
+  ytDlpPlaybackCacheMaxEntrySize: DEFAULT_YT_DLP_PLAYBACK_CACHE_MAX_ENTRY_SIZE_MB,
   ytDlpFfmpegSource: 'system',
   ytDlpFfmpegPath: '',
   externalSoftwareUpdateMode: 'automatic',
@@ -686,6 +688,7 @@ export const NON_TRANSFERABLE_SETTINGS = new Set([
   'ytDlpPlaybackCookiesPath',
   'ytDlpPlaybackCookiesBrowser',
   'ytDlpPlaybackCookiesBrowserProfile',
+  'ytDlpPlaybackCacheMaxEntrySize',
   'ytDlpFfmpegSource',
   'ytDlpFfmpegPath',
   'externalSoftwareUpdateMode',

--- a/src/ytDlpPlaybackCacheSettings.js
+++ b/src/ytDlpPlaybackCacheSettings.js
@@ -1,0 +1,12 @@
+export const DEFAULT_YT_DLP_PLAYBACK_CACHE_MAX_ENTRY_SIZE_MB = 5
+export const MIN_YT_DLP_PLAYBACK_CACHE_MAX_ENTRY_SIZE_MB = 0
+export const MAX_YT_DLP_PLAYBACK_CACHE_MAX_ENTRY_SIZE_MB = 16
+
+export function normalizeYtDlpPlaybackCacheMaxEntrySize(value) {
+  const size = Number(value)
+  return Number.isInteger(size) &&
+    size >= MIN_YT_DLP_PLAYBACK_CACHE_MAX_ENTRY_SIZE_MB &&
+    size <= MAX_YT_DLP_PLAYBACK_CACHE_MAX_ENTRY_SIZE_MB
+    ? size
+    : DEFAULT_YT_DLP_PLAYBACK_CACHE_MAX_ENTRY_SIZE_MB
+}

--- a/static/locales/de-DE.yaml
+++ b/static/locales/de-DE.yaml
@@ -867,7 +867,9 @@ Settings:
     Clear Tab Image Cache Confirmation: Tab-Vorschaubilder und Kanalavatare löschen?
     Tab Image Cache Effect: Tab-Bilder können kurzzeitig verschwinden und werden bei der Nutzung ihrer Tabs neu erstellt.
     Playback Caches: Wiedergabe-Caches
-    Playback Caches Description: Speichert begrenzte yt-dlp-Streaminformationen und YouTube-Playerdateien. OpenTubeX ruft sie erneut ab, wenn sie für ein Video benötigt werden.
+    Playback Caches Description: Speichert yt-dlp-Stream-URLs sitzungsübergreifend sowie YouTube-Playerdateien. Der URL-Cache gilt nur für Streams, die mit yt-dlp abgerufen werden.
+    Playback URL Cache Entry Size: Cache-Limit für yt-dlp-Stream-URLs
+    Playback URL Cache Entry Size Tooltip: Legt die maximale Größe eines zwischengespeicherten yt-dlp-Stream-Eintrags fest. Setze den Wert auf 0 MB, um die dauerhafte Zwischenspeicherung von yt-dlp-Streams zu deaktivieren.
     Clear Playback Caches: Wiedergabe-Caches leeren
     Clear Playback Caches Confirmation: yt-dlp- und Player-Caches leeren?
     Playback Caches Effect: Die nächste lokale Wiedergabe kann länger dauern, während Stream- und Playerdaten erneut abgerufen werden.

--- a/static/locales/en-US.yaml
+++ b/static/locales/en-US.yaml
@@ -1145,7 +1145,9 @@ Settings:
     Clear Tab Image Cache Confirmation: Clear tab thumbnails and channel avatars?
     Tab Image Cache Effect: Tab images may disappear briefly and will be recreated as their tabs are used.
     Playback Caches: Playback caches
-    Playback Caches Description: Stores bounded yt-dlp stream information and YouTube player files. OpenTubeX refetches them when a video needs them.
+    Playback Caches Description: Stores yt-dlp stream URLs between app sessions, plus YouTube player files. The URL cache applies only to streams fetched with yt-dlp.
+    Playback URL Cache Entry Size: yt-dlp stream URL cache limit
+    Playback URL Cache Entry Size Tooltip: Sets the maximum size of each cached yt-dlp stream entry. Set it to 0 MB to disable persistent caching for yt-dlp streams.
     Clear Playback Caches: Clear playback caches
     Clear Playback Caches Confirmation: Clear the yt-dlp and player caches?
     Playback Caches Effect: The next local playback request may take longer while stream and player data is fetched again.

--- a/tests/unit/settings-search-config.test.mjs
+++ b/tests/unit/settings-search-config.test.mjs
@@ -159,3 +159,32 @@ test('settings search results retain their source tab', () => {
   const applicationCaches = values.find(({ label }) => label === 'Application caches')
   assert.equal(findSettingsSearchTab(applicationCaches), 'storage')
 })
+
+test('persistent playback cache search results follow desktop visibility', () => {
+  const sections = [{
+    type: 'data',
+    title: locale.Settings.Categories.Data,
+    description: locale.Settings.Categories['Data Description'],
+  }]
+  const options = {
+    sections,
+    tm: path => getAtPath(locale, path),
+    store: {
+      getters: new Proxy({}, {
+        get(target, key) {
+          return target[key] ?? false
+        }
+      })
+    },
+    supportsLocalApi: true,
+    isMac: false,
+    isLinuxWayland: false,
+    systemUsesDarkTheme: true,
+  }
+
+  const desktopValues = createSettingsSearchIndex({ ...options, usingElectron: true }).get('data')
+  const webValues = createSettingsSearchIndex({ ...options, usingElectron: false }).get('data')
+
+  assert.ok(desktopValues.some(({ label }) => label === 'yt-dlp stream URL cache limit'))
+  assert.ok(!webValues.some(({ label }) => label === 'yt-dlp stream URL cache limit'))
+})

--- a/tests/unit/yt-dlp-playback-cache.test.mjs
+++ b/tests/unit/yt-dlp-playback-cache.test.mjs
@@ -5,6 +5,10 @@ import {
   getEarliestYtDlpFormatExpiry,
   YtDlpPlaybackSourceCache
 } from '../../src/renderer/helpers/player/ytDlpPlaybackCache.js'
+import {
+  DEFAULT_YT_DLP_PLAYBACK_CACHE_MAX_ENTRY_SIZE_MB,
+  normalizeYtDlpPlaybackCacheMaxEntrySize
+} from '../../src/ytDlpPlaybackCacheSettings.js'
 
 function source (expiryDate) {
   return { expiryDate }
@@ -22,6 +26,24 @@ test('reads the expiry from a yt-dlp HLS manifest path', () => {
   assert.deepEqual(getEarliestYtDlpFormatExpiry([{
     url: 'https://example.com/api/manifest/hls_playlist/expire/2000/master.m3u8'
   }]), new Date(2000 * 1000))
+})
+
+test('normalizes the persistent playback cache entry size', () => {
+  assert.equal(normalizeYtDlpPlaybackCacheMaxEntrySize(4), 4)
+  assert.equal(normalizeYtDlpPlaybackCacheMaxEntrySize('8'), 8)
+  assert.equal(normalizeYtDlpPlaybackCacheMaxEntrySize(0), 0)
+  assert.equal(
+    normalizeYtDlpPlaybackCacheMaxEntrySize(-1),
+    DEFAULT_YT_DLP_PLAYBACK_CACHE_MAX_ENTRY_SIZE_MB
+  )
+  assert.equal(
+    normalizeYtDlpPlaybackCacheMaxEntrySize(17),
+    DEFAULT_YT_DLP_PLAYBACK_CACHE_MAX_ENTRY_SIZE_MB
+  )
+  assert.equal(
+    normalizeYtDlpPlaybackCacheMaxEntrySize(1.5),
+    DEFAULT_YT_DLP_PLAYBACK_CACHE_MAX_ENTRY_SIZE_MB
+  )
 })
 
 test('reuses DASH sources until the early expiry margin', () => {


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Make sure to follow the contributing guidelines. -->
<!-- Important note, we may remove your pull request if you do not use this provided PR template correctly. -->
<!-- Agent instructions: Preserve every heading, comment, and marker in this template. Never remove or rewrite the release-note-category:start/end, release-note:start/end, or release-note-image:start/end marker pairs. Never remove or rewrite the Release note images section; leave its contents for a human. -->

## Pull Request Type
<!-- Please select what type of pull request this is: [x] -->
- [ ] Bugfix
- [x] Feature Implementation
- [ ] Documentation
- [ ] Other

## Related issue
<!-- Please link the issue your pull request is referring to. -->
<!-- If this pull request fully resolves the relevant issue, put "closes" before the issue number. -->
<!-- Example: "closes #123456". -->

closes #919

## Description
<!-- Please write a clear and concise description of what the pull request does. -->

The persistent yt-dlp playback URL cache had a fixed per-entry limit and could not be disabled. This adds a 0 to 16 MB slider under Data & Storage, with a 5 MB default. Setting it to 0 disables persistent yt-dlp stream URL caching and removes the cache file. The setting does not affect the built-in playback engine or the YouTube player-file cache.

## Release note category
<!-- Select exactly one category. Every pull request must select one. -->
<!-- Select "Not noteworthy" when the pull request fixes a bug in or improves functionality that has not yet appeared in a stable release. -->
<!-- release-note-category:start -->
- [ ] Not noteworthy
- [ ] Highlights
- [x] More improvements
- [ ] Fixed bugs
<!-- release-note-category:end -->

## Release note
<!-- Required unless "Not noteworthy" is selected. -->
<!-- Write one concise, user-facing entry without a leading bullet. -->
<!-- release-note:start -->
Control persistent yt-dlp stream URL caching with a configurable per-entry limit in Data & Storage settings.
<!-- release-note:end -->

## Release note images
<!-- Human-only: Agents must preserve this entire section and leave it empty. -->
<!-- Optional. Paste one or more Markdown images or HTML image tags here. -->
<!-- The release notes will use an HTML image tag and limit images taller than 300 pixels. -->
<!-- release-note-image:start -->

<!-- release-note-image:end -->

## Testing
<!-- How can reviewers verify that the PR produces correct results? -->
<!-- Please provide instructions so that others can ensure that your pull request produces correct results. For examples see, https://github.com/FreeTubeApp/FreeTube/pull/5743, https://github.com/FreeTubeApp/FreeTube/pull/7349, https://github.com/FreeTubeApp/FreeTube/pull/5125, https://github.com/FreeTubeApp/FreeTube/pull/7338 -->
<!-- Agent instructions: Only write human-facing steps that explain how to verify the change while running this branch in dev mode. Include expected results and, when applicable, helpful console snippets for interactive verification. Do not include automated checks, commands, results, pass counts, or CI status. -->

1. Open Settings, then Data & Storage, then Storage in the desktop app.
2. Find Playback caches and confirm that the yt-dlp stream URL cache slider defaults to 5 MB.
3. Focus or hover the question-mark icon and confirm that its tooltip explains that 0 MB disables persistent caching.
4. Change the value, close and reopen Settings, and confirm that the selected value persists.
5. Set the slider to 0 MB and confirm that the persistent `yt-dlp-playback-cache.json` file is removed.
6. Set the slider above 0 MB, play a non-live video with the yt-dlp playback engine, and confirm that the cache file can be created again.

## Additional context
<!-- Add any other context about the pull request here. -->

The existing 50-entry cap remains unchanged. The slider controls only the maximum serialized size of each persistent yt-dlp stream entry.
