### PR TITLE
fix: improve authenticated restricted playback

### DIFF
--- a/e2e/tests/offline/video-actions.spec.mjs
+++ b/e2e/tests/offline/video-actions.spec.mjs
@@ -102,6 +102,28 @@ test('persists the yt-dlp playback cache across app restarts', async ({ app, pag
   })).toBeNull()
 })
 
+test('persists an authenticated HLS playback source across app restarts', async ({ app, page }) => {
+  const expiryTime = Date.now() + 60 * 60 * 1000
+  const source = {
+    manifestSrc: 'https://example.invalid/api/manifest/hls_playlist/expire/4102444800/master.m3u8',
+    manifestMimeType: 'application/x-mpegurl',
+    legacyFormats: [],
+    title: 'Cached restricted video',
+    isLive: false,
+    version: '2026.08.19'
+  }
+
+  expect(await page.evaluate(({ expiryTime, source }) => {
+    return window.ftElectron.ytDlpPlaybackCacheSet('rrrrrrrrrrr', 'authenticated-settings', expiryTime, source)
+  }, { expiryTime, source })).toBe(true)
+
+  ;({ page } = await app.relaunch())
+
+  expect(await page.evaluate(() => {
+    return window.ftElectron.ytDlpPlaybackCacheGet('rrrrrrrrrrr', 'authenticated-settings')
+  })).toEqual({ expiryTime, source })
+})
+
 test('limits persisted yt-dlp playback entries by UTF-8 byte size', async ({ page }) => {
   const source = {
     manifestSrc: `data:application/dash+xml;charset=UTF-8,${'€'.repeat(700_000)}`,
@@ -350,6 +372,10 @@ test.describe('video downloads', () => {
 
     await page.evaluate(() => window.ftElectron.ytDlpGetPlaybackInfo('eeeeeeeeeee', false, true))
     passedArguments = (await readFile(capturedArgs, 'utf8')).trim().split('\n')
+    const extractorArgsIndex = passedArguments.indexOf('--extractor-args')
+    expect(passedArguments[extractorArgsIndex + 1]).toBe(
+      'youtube:player_client=default,web_safari'
+    )
     let cookiesIndex = passedArguments.indexOf('--cookies-from-browser')
     expect(cookiesIndex).toBeGreaterThanOrEqual(0)
     expect(passedArguments[cookiesIndex + 1]).toBe('firefox:/tmp/restricted-profile')

--- a/e2e/tests/offline/watch-page.spec.mjs
+++ b/e2e/tests/offline/watch-page.spec.mjs
@@ -1096,6 +1096,49 @@ test.describe('watch page', () => {
     })).toHaveCount(1)
   })
 
+  test('treats yt-dlp live status as live and does not cache its HLS source', async ({ app, page }) => {
+    await mockPlayableWatchPage(app, page)
+    await page.route('https://example.invalid/live-status.m3u8', route => route.fulfill({
+      contentType: 'application/x-mpegURL',
+      body: '#EXTM3U\n'
+    }))
+    await openMockedVideo(page)
+
+    await app.electronApp.evaluate(({ ipcMain }) => {
+      globalThis.__ytDlpLiveStatusCalls = 0
+      ipcMain.removeHandler('yt-dlp-get-playback-info')
+      ipcMain.handle('yt-dlp-get-playback-info', () => {
+        globalThis.__ytDlpLiveStatusCalls++
+        return {
+          isLive: false,
+          liveStatus: 'is_live',
+          hlsManifestUrl: 'https://example.invalid/live-status.m3u8',
+          formats: [{
+            url: 'https://example.invalid/live-segment.mp4?expire=4102444800',
+            protocol: 'https',
+            vcodec: null,
+            acodec: null
+          }],
+          duration: null,
+          storyboardVtt: null,
+          title: 'Live video',
+          version: 'test'
+        }
+      })
+    })
+
+    const watchView = await watchViewHandle(page)
+    await watchView.evaluate((view) => view.handlePlaybackEngineChange('yt-dlp'))
+    expect(await watchView.evaluate((view) => view.isLive)).toBe(true)
+
+    await watchView.evaluate((view) => view.extractYtDlpPlaybackSource(
+      view.videoLoadGeneration,
+      view.videoId,
+      view.playbackEngineSwitchGeneration
+    ))
+    expect(await app.electronApp.evaluate(() => globalThis.__ytDlpLiveStatusCalls)).toBe(2)
+  })
+
   test('falls back to yt-dlp when the built-in live source has no manifest', async ({ app, page }) => {
     await mockPlayableWatchPage(app, page)
     await page.route('https://example.invalid/live.m3u8', route => route.fulfill({

--- a/e2e/tests/offline/watch-page.spec.mjs
+++ b/e2e/tests/offline/watch-page.spec.mjs
@@ -132,10 +132,7 @@ test.describe('fullscreen ambient mode', () => {
 
 test('shows the restricted playback setup hint until an authenticated retry is available', async ({ app, page }) => {
   await mockPlayableWatchPage(app, page)
-  await page.route('https://example.invalid/restricted.m3u8', route => route.fulfill({
-    contentType: 'application/x-mpegURL',
-    body: '#EXTM3U\n'
-  }))
+  await page.route('https://example.invalid/restricted.mp4?expire=4102444800', route => route.fulfill({ body: 'video' }))
   await openMockedVideo(page)
 
   const watchView = await watchViewHandle(page)
@@ -164,11 +161,32 @@ test('shows the restricted playback setup hint until an authenticated retry is a
       (_event, _videoId, useDefaultClients, useAuthentication) => {
         globalThis.__restrictedPlaybackCalls.push({ useDefaultClients, useAuthentication })
         return {
-          isLive: true,
-          liveStatus: 'is_live',
-          hlsManifestUrl: 'https://example.invalid/restricted.m3u8',
-          formats: [],
-          duration: null,
+          isLive: false,
+          liveStatus: 'not_live',
+          hlsManifestUrl: null,
+          formats: [{
+            formatId: '18',
+            url: 'https://example.invalid/restricted.mp4?expire=4102444800',
+            manifestUrl: null,
+            protocol: 'https',
+            ext: 'mp4',
+            container: 'mp4_dash',
+            vcodec: 'avc1.42001E',
+            acodec: 'mp4a.40.2',
+            width: 640,
+            height: 360,
+            fps: 30,
+            bitrate: 500000,
+            audioSampleRate: 44100,
+            audioChannels: 2,
+            language: null,
+            formatNote: '360p',
+            dynamicRange: 'SDR',
+            availableAt: null
+          }],
+          duration: 60,
+          storyboardVtt: null,
+          title: 'Restricted video',
           version: 'test'
         }
       }
@@ -180,7 +198,10 @@ test('shows the restricted playback setup hint until an authenticated retry is a
       const applied = await extractYtDlpPlaybackSource.apply(view, args)
       window.__restrictedPlaybackResult = {
         applied,
-        activeEngine: view.activePlaybackEngine
+        activeEngine: view.activePlaybackEngine,
+        activeFormat: view.activeFormat,
+        legacyFormats: view.legacyFormats.length,
+        manifest: view.manifestSrc
       }
       return applied
     }
@@ -198,8 +219,39 @@ test('shows the restricted playback setup hint until an authenticated retry is a
   )).toEqual([{ useDefaultClients: false, useAuthentication: true }])
   await expect.poll(() => page.evaluate(
     () => window.__restrictedPlaybackResult
-  )).toEqual({ applied: true, activeEngine: 'yt-dlp' })
+  )).toEqual({
+    applied: true,
+    activeEngine: 'yt-dlp',
+    activeFormat: 'legacy',
+    legacyFormats: 1,
+    manifest: null
+  })
   expect(await watchView.evaluate((view) => view.playbackEngineFallbackTarget)).toBeNull()
+
+  await watchView.evaluate(async (view) => {
+    window.__restrictedPlaybackResult = null
+    view.manifestSrc = null
+    view.legacyFormats = []
+    view.activeFormat = 'dash'
+    view.activePlaybackEngine = 'built-in'
+    view.playbackEngineFallbackTarget = 'built-in'
+    view.setRestrictedPlaybackError('age')
+    await view.$nextTick()
+  })
+
+  await expect.poll(() => page.evaluate(
+    () => window.__restrictedPlaybackResult
+  )).toEqual({
+    applied: true,
+    activeEngine: 'yt-dlp',
+    activeFormat: 'legacy',
+    legacyFormats: 1,
+    manifest: null
+  })
+  await expect.poll(() => app.electronApp.evaluate(
+    () => globalThis.__restrictedPlaybackCalls
+  )).toEqual([{ useDefaultClients: false, useAuthentication: true }])
+  await expect(page.getByRole('button', { name: 'Try with configured cookies' })).toHaveCount(0)
 })
 
 test.describe('Shorts transcript navigation', () => {

--- a/src/main/ytDlp.js
+++ b/src/main/ytDlp.js
@@ -1545,14 +1545,17 @@ export async function handleYtDlpGetPlaybackInfo(
   ]
 
   if (useDefaultClients !== true) {
-    // Prefer yt-dlp's maintained client order, while retaining web_embedded for
-    // alternate audio and excluding older Android VR defaults whose URLs can be
-    // subject to selective PO-token enforcement. The renderer retries with
-    // yt-dlp's defaults if none of these formats are playable or they expose only
-    // a minimal live DVR window.
+    // Keep yt-dlp's account-aware defaults first. For authenticated playback,
+    // upstream recommends appending web_safari to obtain its merged HLS formats:
+    // https://github.com/yt-dlp/yt-dlp/issues/17143
+    // Without authentication, retain web_embedded for alternate audio and exclude
+    // Android VR URLs that can face selective PO-token enforcement. The renderer
+    // retries with yt-dlp's defaults if these formats are not playable.
     args.push(
       '--extractor-args',
-      'youtube:player_client=default,web_embedded,-android_vr'
+      useAuthentication
+        ? 'youtube:player_client=default,web_safari'
+        : 'youtube:player_client=default,web_embedded,-android_vr'
     )
   }
 

--- a/src/main/ytDlpPlaybackCache.js
+++ b/src/main/ytDlpPlaybackCache.js
@@ -40,6 +40,16 @@ function isValidCacheKey(cacheKey) {
   return typeof cacheKey === 'string' && cacheKey.length <= MAX_CACHE_KEY_LENGTH
 }
 
+function isHttpsUrl(value) {
+  if (typeof value !== 'string') return false
+
+  try {
+    return new URL(value).protocol === 'https:'
+  } catch {
+    return false
+  }
+}
+
 function isValidEntry(entry) {
   if (entry === null || typeof entry !== 'object') return false
 
@@ -50,18 +60,29 @@ function isValidEntry(entry) {
     return false
   }
 
+  const source = entry.source
+  const legacyFormats = source?.legacyFormats
+  const hasDashManifest = source?.manifestMimeType === 'application/dash+xml' &&
+    typeof source.manifestSrc === 'string' &&
+    source.manifestSrc.startsWith('data:application/dash+xml;')
+  const hasHlsManifest = source?.manifestMimeType === 'application/x-mpegurl' &&
+    isHttpsUrl(source.manifestSrc)
+  const hasLegacyFormatsOnly = source?.manifestMimeType === 'application/dash+xml' &&
+    source.manifestSrc === null &&
+    Array.isArray(legacyFormats) &&
+    legacyFormats.length > 0 &&
+    legacyFormats.every(format => isHttpsUrl(format?.url))
+
   return Buffer.byteLength(serializedEntry, 'utf8') <= MAX_ENTRY_LENGTH &&
     VIDEO_ID_REGEX.test(entry.videoId) &&
     CACHE_KEY_HASH_REGEX.test(entry.cacheKeyHash) &&
     Number.isFinite(entry.expiryTime) &&
-    entry.source !== null &&
-    typeof entry.source === 'object' &&
-    entry.source.isLive === false &&
-    entry.source.manifestMimeType === 'application/dash+xml' &&
-    typeof entry.source.manifestSrc === 'string' &&
-    entry.source.manifestSrc.startsWith('data:application/dash+xml;') &&
-    Array.isArray(entry.source.legacyFormats) &&
-    (entry.source.title === null || typeof entry.source.title === 'string')
+    source !== null &&
+    typeof source === 'object' &&
+    source.isLive === false &&
+    (hasDashManifest || hasHlsManifest || hasLegacyFormatsOnly) &&
+    Array.isArray(legacyFormats) &&
+    (source.title === null || typeof source.title === 'string')
 }
 
 async function loadEntries() {

--- a/src/renderer/helpers/player/ytDlpPlayback.js
+++ b/src/renderer/helpers/player/ytDlpPlayback.js
@@ -10,7 +10,7 @@ import { getEarliestYtDlpFormatExpiry, YtDlpPlaybackSourceCache } from './ytDlpP
 
 /**
  * @typedef {object} YtDlpPlaybackSource
- * @property {string} manifestSrc
+ * @property {string | null} manifestSrc
  * @property {MANIFEST_TYPE_DASH | MANIFEST_TYPE_HLS} manifestMimeType
  * @property {any[]} legacyFormats
  * @property {Date | null} expiryDate
@@ -25,7 +25,23 @@ import { getEarliestYtDlpFormatExpiry, YtDlpPlaybackSourceCache } from './ytDlpP
 const ITAG_REGEX = /^\d+/
 const URL_PROBE_TIMEOUT = 10_000
 const MINIMUM_LIVE_DVR_WINDOW_SECONDS = 30
-const dashPlaybackSourceCache = new YtDlpPlaybackSourceCache()
+const playbackSourceCache = new YtDlpPlaybackSourceCache()
+
+async function cacheYtDlpPlaybackSource(videoId, cacheKey, source) {
+  playbackSourceCache.set(videoId, cacheKey, source)
+  if (source.expiryDate === null) return
+
+  try {
+    await window.ftElectron.ytDlpPlaybackCacheSet(
+      videoId,
+      cacheKey,
+      source.expiryDate.getTime(),
+      source
+    )
+  } catch (error) {
+    console.warn('Could not save the persistent yt-dlp playback cache', error)
+  }
+}
 
 /**
  * @param {string} url
@@ -40,14 +56,14 @@ function hasLimitedLiveDvrWindow(url) {
  * @param {string} videoId
  */
 export function invalidateYtDlpPlaybackSource(videoId) {
-  dashPlaybackSourceCache.delete(videoId)
+  playbackSourceCache.delete(videoId)
   window.ftElectron.ytDlpPlaybackCacheDelete(videoId).catch(error => {
     console.warn('Could not remove an entry from the persistent yt-dlp playback cache', error)
   })
 }
 
 export function invalidateAllYtDlpPlaybackSources() {
-  dashPlaybackSourceCache.clear()
+  playbackSourceCache.clear()
   return window.ftElectron.ytDlpPlaybackCacheClear().catch(error => {
     console.warn('Could not clear the persistent yt-dlp playback cache', error)
     return false
@@ -303,24 +319,26 @@ async function convertAdaptiveFormats(formats, duration) {
  * @param {string} cacheKey identifies the yt-dlp executable and proxy configuration
  * @param {() => void} [onDefaultClientsFallback] called before retrying with yt-dlp's default clients
  * @param {boolean} [useAuthentication] whether to use the explicitly configured cookie source
- * @returns {Promise<YtDlpPlaybackSource>}
+ * @param {boolean} [cachedOnly] prevents a cache miss from starting a new extraction
+ * @returns {Promise<YtDlpPlaybackSource | null>}
  */
 export async function getYtDlpPlaybackSource(
   videoId,
   cacheKey = '',
   onDefaultClientsFallback,
-  useAuthentication = false
+  useAuthentication = false,
+  cachedOnly = false
 ) {
   const effectiveCacheKey = JSON.stringify([cacheKey, useAuthentication])
-  let cachedSource = dashPlaybackSourceCache.get(videoId, effectiveCacheKey)
+  let cachedSource = playbackSourceCache.get(videoId, effectiveCacheKey)
 
   if (cachedSource === null) {
     try {
       const entry = await window.ftElectron.ytDlpPlaybackCacheGet(videoId, effectiveCacheKey)
       if (entry !== null) {
         const source = { ...entry.source, expiryDate: new Date(entry.expiryTime) }
-        dashPlaybackSourceCache.set(videoId, effectiveCacheKey, source)
-        cachedSource = dashPlaybackSourceCache.get(videoId, effectiveCacheKey)
+        playbackSourceCache.set(videoId, effectiveCacheKey, source)
+        cachedSource = playbackSourceCache.get(videoId, effectiveCacheKey)
 
         if (cachedSource === null) {
           await window.ftElectron.ytDlpPlaybackCacheDelete(videoId)
@@ -333,6 +351,10 @@ export async function getYtDlpPlaybackSource(
 
   if (cachedSource !== null) {
     return cachedSource
+  }
+
+  if (cachedOnly) {
+    return null
   }
 
   let extractionError = null
@@ -368,9 +390,8 @@ export async function getYtDlpPlaybackSource(
     }
 
     const httpFormats = info.formats.filter(format => format.protocol === 'https' && format.url !== null)
-    const legacyFormatsPromise = convertLegacyFormats(
-      httpFormats.filter(format => isVideoFormat(format) && isAudioFormat(format))
-    )
+    const legacyHttpFormats = httpFormats.filter(format => isVideoFormat(format) && isAudioFormat(format))
+    const legacyFormatsPromise = convertLegacyFormats(legacyHttpFormats)
 
     // live streams are only available as HLS, which is what makes rewinding within
     // the DVR window possible
@@ -396,17 +417,7 @@ export async function getYtDlpPlaybackSource(
           version: info.version
         }
 
-        dashPlaybackSourceCache.set(videoId, effectiveCacheKey, source)
-        try {
-          await window.ftElectron.ytDlpPlaybackCacheSet(
-            videoId,
-            effectiveCacheKey,
-            source.expiryDate?.getTime() ?? NaN,
-            source
-          )
-        } catch (error) {
-          console.warn('Could not save the persistent yt-dlp playback cache', error)
-        }
+        await cacheYtDlpPlaybackSource(videoId, effectiveCacheKey, source)
         return source
       }
     }
@@ -419,7 +430,9 @@ export async function getYtDlpPlaybackSource(
         manifestSrc: info.hlsManifestUrl,
         manifestMimeType: MANIFEST_TYPE_HLS,
         legacyFormats: await legacyFormatsPromise,
-        expiryDate: null,
+        expiryDate: getEarliestYtDlpFormatExpiry(
+          info.formats.filter(format => format.url !== null)
+        ),
         title: info.title,
         isLive: info.isLive,
         duration: info.duration,
@@ -442,7 +455,30 @@ export async function getYtDlpPlaybackSource(
         continue
       }
 
+      await cacheYtDlpPlaybackSource(videoId, effectiveCacheKey, source)
       return source
+    }
+
+    if (!info.isLive && info.liveStatus !== 'is_live') {
+      const legacyFormats = await legacyFormatsPromise
+      if (legacyFormats.length > 0) {
+        const source = {
+          manifestSrc: null,
+          manifestMimeType: MANIFEST_TYPE_DASH,
+          legacyFormats,
+          expiryDate: getEarliestYtDlpFormatExpiry(legacyHttpFormats),
+          title: info.title,
+          isLive: false,
+          duration: info.duration,
+          storyboardSrc: info.storyboardVtt === null
+            ? null
+            : `data:text/vtt;charset=utf-8,${encodeURIComponent(info.storyboardVtt)}`,
+          version: info.version
+        }
+
+        await cacheYtDlpPlaybackSource(videoId, effectiveCacheKey, source)
+        return source
+      }
     }
 
     extractionError = new Error('yt-dlp did not return any playable formats')

--- a/src/renderer/helpers/player/ytDlpPlayback.js
+++ b/src/renderer/helpers/player/ytDlpPlayback.js
@@ -28,6 +28,8 @@ const MINIMUM_LIVE_DVR_WINDOW_SECONDS = 30
 const playbackSourceCache = new YtDlpPlaybackSourceCache()
 
 async function cacheYtDlpPlaybackSource(videoId, cacheKey, source) {
+  if (source.isLive) return
+
   playbackSourceCache.set(videoId, cacheKey, source)
   if (source.expiryDate === null) return
 
@@ -389,13 +391,14 @@ export async function getYtDlpPlaybackSource(
       continue
     }
 
+    const isLive = info.isLive || info.liveStatus === 'is_live'
     const httpFormats = info.formats.filter(format => format.protocol === 'https' && format.url !== null)
     const legacyHttpFormats = httpFormats.filter(format => isVideoFormat(format) && isAudioFormat(format))
     const legacyFormatsPromise = convertLegacyFormats(legacyHttpFormats)
 
     // live streams are only available as HLS, which is what makes rewinding within
     // the DVR window possible
-    if (!info.isLive && info.liveStatus !== 'is_live') {
+    if (!isLive) {
       const adaptiveFormats = httpFormats.filter(format => !(isVideoFormat(format) && isAudioFormat(format)))
       const localFormats = await convertAdaptiveFormats(adaptiveFormats, info.duration)
 
@@ -434,7 +437,7 @@ export async function getYtDlpPlaybackSource(
           info.formats.filter(format => format.url !== null)
         ),
         title: info.title,
-        isLive: info.isLive,
+        isLive,
         duration: info.duration,
         storyboardSrc: info.storyboardVtt === null
           ? null
@@ -448,7 +451,7 @@ export async function getYtDlpPlaybackSource(
       // case those clients fail.
       if (
         !useDefaultClients &&
-        (info.isLive || info.liveStatus === 'is_live') &&
+        isLive &&
         hasLimitedLiveDvrWindow(info.hlsManifestUrl)
       ) {
         limitedLiveSource = source
@@ -459,7 +462,7 @@ export async function getYtDlpPlaybackSource(
       return source
     }
 
-    if (!info.isLive && info.liveStatus !== 'is_live') {
+    if (!isLive) {
       const legacyFormats = await legacyFormatsPromise
       if (legacyFormats.length > 0) {
         const source = {

--- a/src/renderer/helpers/player/ytDlpPlaybackCache.js
+++ b/src/renderer/helpers/player/ytDlpPlaybackCache.js
@@ -9,7 +9,10 @@ export function getEarliestYtDlpFormatExpiry(formats) {
   let earliestExpiry = Infinity
 
   for (const format of formats) {
-    const expire = parseInt(new URL(format.url).searchParams.get('expire'))
+    const url = new URL(format.url)
+    const queryExpiry = parseInt(url.searchParams.get('expire'))
+    const pathExpiry = parseInt(url.pathname.match(/\/expire\/(\d+)(?:\/|$)/)?.[1])
+    const expire = Number.isFinite(queryExpiry) ? queryExpiry : pathExpiry
 
     if (Number.isFinite(expire)) {
       earliestExpiry = Math.min(earliestExpiry, expire)

--- a/src/renderer/views/Watch/Watch.js
+++ b/src/renderer/views/Watch/Watch.js
@@ -2409,6 +2409,12 @@ export default defineComponent({
         ? this.t('Video.MembersOnly')
         : this.t('Video.AgeRestricted')
       this.customErrorIcon = type === 'members' ? ['fas', 'money-check-dollar'] : null
+
+      if (this.hasConfiguredRestrictedPlaybackAuthentication) {
+        this.tryCachedRestrictedPlayback(type).catch(error => {
+          console.warn('Could not restore cached authenticated playback', error)
+        })
+      }
     },
 
     getRestrictedPlaybackErrorType: function (message) {
@@ -2434,6 +2440,34 @@ export default defineComponent({
       }
 
       return null
+    },
+
+    tryCachedRestrictedPlayback: async function (restrictedPlaybackError) {
+      const loadGeneration = this.videoLoadGeneration
+      const videoId = this.videoId
+      const playbackEngineSwitchGeneration = this.playbackEngineSwitchGeneration
+      const previousFallbackTarget = this.playbackEngineFallbackTarget
+
+      const sourceApplied = await this.extractYtDlpPlaybackSource(
+        loadGeneration,
+        videoId,
+        playbackEngineSwitchGeneration,
+        true,
+        true
+      )
+
+      if (!this.isCurrentVideoLoad(loadGeneration, videoId) ||
+        playbackEngineSwitchGeneration !== this.playbackEngineSwitchGeneration ||
+        this.restrictedPlaybackError !== restrictedPlaybackError) {
+        return
+      }
+
+      if (sourceApplied) {
+        this.restrictedPlaybackError = null
+        this.playbackEngineFallbackTarget = null
+      } else {
+        this.playbackEngineFallbackTarget = previousFallbackTarget
+      }
     },
 
     tryRestrictedPlaybackWithCookies: async function () {
@@ -4942,12 +4976,15 @@ export default defineComponent({
      * @param {number} loadGeneration
      * @param {string} videoId
      * @param {number} playbackEngineSwitchGeneration
+     * @param {boolean} useAuthentication
+     * @param {boolean} cachedOnly
      */
     extractYtDlpPlaybackSource: async function (
       loadGeneration,
       videoId,
       playbackEngineSwitchGeneration = this.playbackEngineSwitchGeneration,
-      useAuthentication = false
+      useAuthentication = false,
+      cachedOnly = false
     ) {
       let source
       try {
@@ -4963,7 +5000,7 @@ export default defineComponent({
               icon: ['fas', 'exchange-alt'],
             })
           }
-        }, useAuthentication)
+        }, useAuthentication, cachedOnly)
       } catch (error) {
         if (
           !this.isCurrentVideoLoad(loadGeneration, videoId) ||
@@ -4981,12 +5018,14 @@ export default defineComponent({
         return false
       }
 
+      if (source === null) { return false }
+
       if (
         !this.isCurrentVideoLoad(loadGeneration, videoId) ||
         playbackEngineSwitchGeneration !== this.playbackEngineSwitchGeneration
       ) { return false }
 
-      if (this.playbackEngineFallbackTarget === 'built-in') { return false }
+      if (this.playbackEngineFallbackTarget === 'built-in' && !cachedOnly) { return false }
 
       this.builtInPlaybackSource = {
         manifestSrc: this.manifestSrc,

--- a/tests/unit/yt-dlp-playback-cache.test.mjs
+++ b/tests/unit/yt-dlp-playback-cache.test.mjs
@@ -18,6 +18,12 @@ test('uses the earliest expiry from the yt-dlp formats', () => {
   ]), new Date(1000 * 1000))
 })
 
+test('reads the expiry from a yt-dlp HLS manifest path', () => {
+  assert.deepEqual(getEarliestYtDlpFormatExpiry([{
+    url: 'https://example.com/api/manifest/hls_playlist/expire/2000/master.m3u8'
+  }]), new Date(2000 * 1000))
+})
+
 test('reuses DASH sources until the early expiry margin', () => {
   let now = 1000000
   const cache = new YtDlpPlaybackSourceCache({


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Make sure to follow the contributing guidelines. -->
<!-- Important note, we may remove your pull request if you do not use this provided PR template correctly. -->
<!-- Agent instructions: Preserve every heading, comment, and marker in this template. Never remove or rewrite the release-note-category:start/end, release-note:start/end, or release-note-image:start/end marker pairs. Never remove or rewrite the Release note images section; leave its contents for a human. -->

## Pull Request Type
<!-- Please select what type of pull request this is: [x] -->
- [x] Bugfix
- [ ] Feature Implementation
- [ ] Documentation
- [ ] Other

## Related issue
<!-- Please link the issue your pull request is referring to. -->
<!-- If this pull request fully resolves the relevant issue, put "closes" before the issue number. -->
<!-- Example: "closes #123456". -->

## Description
<!-- Please write a clear and concise description of what the pull request does. -->
Authenticated restricted playback could reject a playable progressive stream, stay at 360p when an authenticated HLS ladder was available, and request another cookie retry when reopening a video.

This accepts validated progressive-only results, follows yt-dlp's recommended authenticated client order, and caches HLS or progressive sources until their signed URLs expire. Reopening a video can therefore restore a valid authenticated source without reading browser cookies again.

## Release note category
<!-- Select exactly one category. Every pull request must select one. -->
<!-- Select "Not noteworthy" when the pull request fixes a bug in or improves functionality that has not yet appeared in a stable release. -->
<!-- release-note-category:start -->
- [x] Not noteworthy
- [ ] Highlights
- [ ] More improvements
- [ ] Fixed bugs
<!-- release-note-category:end -->

## Release note
<!-- Required unless "Not noteworthy" is selected. -->
<!-- Write one concise, user-facing entry without a leading bullet. -->
<!-- release-note:start -->
Authenticated restricted videos can use higher-quality HLS streams and reopen from cache without another cookie retry.
<!-- release-note:end -->

## Release note images
<!-- Human-only: Agents must preserve this entire section and leave it empty. -->
<!-- Optional. Paste one or more Markdown images or HTML image tags here. -->
<!-- The release notes will use an HTML image tag and limit images taller than 300 pixels. -->
<!-- release-note-image:start -->

<!-- release-note-image:end -->

## Testing
<!-- How can reviewers verify that the PR produces correct results? -->
<!-- Please provide instructions so that others can ensure that your pull request would produce correct results. For examples see, https://github.com/FreeTubeApp/FreeTube/pull/5743, https://github.com/FreeTubeApp/FreeTube/pull/7349, https://github.com/FreeTubeApp/FreeTube/pull/5125, https://github.com/FreeTubeApp/FreeTube/pull/7338 -->
<!-- Agent instructions: Only write human-facing steps that explain how to verify the change while running this branch in dev mode. Include expected results and, when applicable, helpful console snippets for interactive verification. Do not include automated checks, commands, results, pass counts, or CI status. -->
1. Configure browser cookies for yt-dlp playback and open an age-restricted video.
2. Retry with the configured cookies. Playback should start, and higher-quality HLS options should appear when the video provides them.
3. Leave and reopen the same video while its signed source is still valid. Playback should restore from cache without showing another cookie-retry prompt.
4. Verify that a video exposing only a combined progressive stream still plays successfully.

## Additional context
<!-- Add any other context about the pull request here. -->
The authenticated client order follows the current yt-dlp guidance linked from the implementation comment.
