### PR TITLE
feat(sync): identify client version in user agent

### DIFF
--- a/PRIVACY.md
+++ b/PRIVACY.md
@@ -24,8 +24,8 @@ Rows for optional services apply only when the feature is enabled. An IP address
 | DeArrow | Configured SponsorBlock/DeArrow and thumbnail-service operators | IP address, timing, video-ID hash prefixes for branding lookups, and full video identifiers and timestamps for generated-thumbnail requests |
 | Return YouTube Dislike | Configured Return YouTube Dislike operator | IP address, video identifiers, and timing |
 | Voice-over translation | Unofficial Yandex voice-over translation service | IP address, YouTube video identifier and URL, video duration, requested output language, and timing |
-| Enhanced-privacy sync | Configured sync operator | IP address, OpenTubeX application version, account identifier, authentication data, encrypted payloads, collection names, payload sizes, revisions, and timing; not the decrypted selected data |
-| Legacy sync | Configured sync operator | IP address, OpenTubeX application version, account identifier, authentication data, selected synced data, and timing |
+| Enhanced-privacy sync | Configured sync operator | IP address, OpenTubeX application version from Electron desktop builds, account identifier, authentication data, encrypted payloads, collection names, payload sizes, revisions, and timing; not the decrypted selected data |
+| Legacy sync | Configured sync operator | IP address, OpenTubeX application version from Electron desktop builds, account identifier, authentication data, selected synced data, and timing |
 | `yt-dlp` playback and downloads | YouTube and the configured proxy, if any | IP address, requested page and media resources, video identifier, formats, and timing. OpenTubeX's proxy setting is passed to `yt-dlp`. |
 
 Voice-over translation is disabled by default. When it is enabled, no translation-service request is made until you request a translation. The separate background-preparation option is also disabled by default; enabling it requests a translation whenever a supported non-live video loads. These requests omit browser credentials and cookies.

--- a/PRIVACY.md
+++ b/PRIVACY.md
@@ -24,8 +24,8 @@ Rows for optional services apply only when the feature is enabled. An IP address
 | DeArrow | Configured SponsorBlock/DeArrow and thumbnail-service operators | IP address, timing, video-ID hash prefixes for branding lookups, and full video identifiers and timestamps for generated-thumbnail requests |
 | Return YouTube Dislike | Configured Return YouTube Dislike operator | IP address, video identifiers, and timing |
 | Voice-over translation | Unofficial Yandex voice-over translation service | IP address, YouTube video identifier and URL, video duration, requested output language, and timing |
-| Enhanced-privacy sync | Configured sync operator | IP address, account identifier, authentication data, encrypted payloads, collection names, payload sizes, revisions, and timing; not the decrypted selected data |
-| Legacy sync | Configured sync operator | IP address, account identifier, authentication data, selected synced data, and timing |
+| Enhanced-privacy sync | Configured sync operator | IP address, OpenTubeX application version, account identifier, authentication data, encrypted payloads, collection names, payload sizes, revisions, and timing; not the decrypted selected data |
+| Legacy sync | Configured sync operator | IP address, OpenTubeX application version, account identifier, authentication data, selected synced data, and timing |
 | `yt-dlp` playback and downloads | YouTube and the configured proxy, if any | IP address, requested page and media resources, video identifier, formats, and timing. OpenTubeX's proxy setting is passed to `yt-dlp`. |
 
 Voice-over translation is disabled by default. When it is enabled, no translation-service request is made until you request a translation. The separate background-preparation option is also disabled by default; enabling it requests a translation whenever a supported non-live video loads. These requests omit browser credentials and cookies.

--- a/src/main/index.js
+++ b/src/main/index.js
@@ -32,6 +32,7 @@ import {
   normalizeCustomTheme,
   normalizeCustomThemes,
 } from '../customTheme'
+import { applySyncServerUserAgent } from '../syncServerUserAgent'
 import * as baseHandlers from '../datastores/handlers/base'
 import { liveReminders } from '../datastores'
 import { extractExpiryTimestamp, ImageCache } from './ImageCache'
@@ -1928,6 +1929,10 @@ function runApp() {
     }
     session.defaultSession.webRequest.onBeforeSendHeaders(onBeforeSendHeadersRequestFilter, ({ requestHeaders, url, webContents }, callback) => {
       const urlObj = new URL(url)
+
+      if (webContents && isOpenTubeXUrl(webContents.getURL())) {
+        applySyncServerUserAgent(requestHeaders)
+      }
 
       if (url.startsWith('https://www.youtube.com/youtubei/')) {
         // make InnerTube requests work with the fetch function

--- a/src/renderer/helpers/sync-server-request.js
+++ b/src/renderer/helpers/sync-server-request.js
@@ -1,0 +1,29 @@
+import { SYNC_SERVER_VERSION_HEADER } from '../../syncServerUserAgent.js'
+
+/**
+ * Build the headers shared by every sync-server request.
+ * @param {object} options
+ * @param {boolean} [options.hasBody]
+ * @param {HeadersInit} [options.headers]
+ * @param {string} [options.token]
+ * @param {string} options.version
+ * @returns {Headers}
+ */
+export function createSyncServerRequestHeaders({ hasBody = false, headers, token = '', version }) {
+  const requestHeaders = new Headers(headers)
+
+  if (!requestHeaders.has('Accept')) {
+    requestHeaders.set('Accept', 'application/json')
+  }
+  if (version) {
+    requestHeaders.set(SYNC_SERVER_VERSION_HEADER, version)
+  }
+  if (hasBody) {
+    requestHeaders.set('Content-Type', 'application/json')
+  }
+  if (token) {
+    requestHeaders.set('Authorization', token)
+  }
+
+  return requestHeaders
+}

--- a/src/renderer/helpers/sync-server.js
+++ b/src/renderer/helpers/sync-server.js
@@ -1,4 +1,5 @@
 import { MAIN_PROFILE_ID } from '../../constants'
+import packageDetails from '../../../package.json'
 import {
   CUSTOM_THEMES_SYNC_KEY,
   customThemeIdFromValue,
@@ -22,6 +23,7 @@ import {
   getSyncProfileBackground,
   getSyncProfileTextColor
 } from './profile-sync.js'
+import { createSyncServerRequestHeaders } from './sync-server-request'
 
 const LEGACY_HISTORY_PAGE_SIZE = 50
 const BULK_SYNC_CHUNK_SIZE = 100
@@ -85,14 +87,12 @@ export class SyncServerClient {
     const controller = new AbortController()
     this.requestControllers.add(controller)
     const timeout = setTimeout(() => controller.abort(), timeoutMs)
-    const headers = { Accept: 'application/json', ...options.headers }
-
-    if (options.body != null) {
-      headers['Content-Type'] = 'application/json'
-    }
-    if (this.token) {
-      headers.Authorization = this.token
-    }
+    const headers = createSyncServerRequestHeaders({
+      hasBody: options.body != null,
+      headers: options.headers,
+      token: this.token,
+      version: process.env.IS_ELECTRON ? packageDetails.version : '',
+    })
 
     try {
       const response = await fetch(`${this.serverUrl}${path}`, {

--- a/src/syncServerUserAgent.js
+++ b/src/syncServerUserAgent.js
@@ -1,0 +1,22 @@
+export const SYNC_SERVER_VERSION_HEADER = 'OpenTubeX-Client-Version'
+
+/**
+ * Move the internal sync version marker into the outgoing user agent.
+ * @param {Record<string, string | string[]>} requestHeaders
+ * @returns {Record<string, string | string[]>}
+ */
+export function applySyncServerUserAgent(requestHeaders) {
+  const markerName = Object.keys(requestHeaders).find(
+    name => name.toLowerCase() === SYNC_SERVER_VERSION_HEADER.toLowerCase()
+  )
+  if (!markerName) return requestHeaders
+
+  const markerValue = requestHeaders[markerName]
+  const version = Array.isArray(markerValue) ? markerValue[0] : markerValue
+  delete requestHeaders[markerName]
+  if (version) {
+    requestHeaders['User-Agent'] = `OpenTubeX/${version}`
+  }
+
+  return requestHeaders
+}

--- a/tests/unit/sync-server-request.test.mjs
+++ b/tests/unit/sync-server-request.test.mjs
@@ -1,0 +1,46 @@
+import assert from 'node:assert/strict'
+import test from 'node:test'
+
+import { applySyncServerUserAgent } from '../../src/syncServerUserAgent.js'
+import { createSyncServerRequestHeaders } from '../../src/renderer/helpers/sync-server-request.js'
+
+test('unauthenticated sync requests expose the unchanged version through the user agent', () => {
+  const requestHeaders = createSyncServerRequestHeaders({
+    headers: { 'X-Request-Context': 'health-check' },
+    version: '0.32.0-beta',
+  })
+  const headers = new Headers(applySyncServerUserAgent(Object.fromEntries(requestHeaders)))
+
+  assert.equal(headers.get('Accept'), 'application/json')
+  assert.equal(headers.get('User-Agent'), 'OpenTubeX/0.32.0-beta')
+  assert.equal(headers.get('X-Request-Context'), 'health-check')
+  assert.equal(headers.has('Authorization'), false)
+  assert.equal(headers.has('OpenTubeX-Client-Version'), false)
+})
+
+test('authenticated sync requests retain authentication, content type, and caller headers', () => {
+  const requestHeaders = createSyncServerRequestHeaders({
+    hasBody: true,
+    headers: new Headers({
+      Accept: 'application/vnd.sync+json',
+      'X-Request-Context': 'encrypted-sync',
+    }),
+    token: 'sync-token',
+    version: '0.32.0-nightly-976',
+  })
+  const headers = new Headers(applySyncServerUserAgent(Object.fromEntries(requestHeaders)))
+
+  assert.equal(headers.get('Accept'), 'application/vnd.sync+json')
+  assert.equal(headers.get('Authorization'), 'sync-token')
+  assert.equal(headers.get('Content-Type'), 'application/json')
+  assert.equal(headers.get('User-Agent'), 'OpenTubeX/0.32.0-nightly-976')
+  assert.equal(headers.get('X-Request-Context'), 'encrypted-sync')
+  assert.equal(headers.has('OpenTubeX-Client-Version'), false)
+})
+
+test('browser sync requests do not add the Electron-only version marker', () => {
+  const headers = createSyncServerRequestHeaders({ version: '' })
+
+  assert.equal(headers.get('Accept'), 'application/json')
+  assert.equal(headers.has('OpenTubeX-Client-Version'), false)
+})


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Make sure to follow the contributing guidelines. -->
<!-- Important note, we may remove your pull request if you do not use this provided PR template correctly. -->
<!-- Agent instructions: Preserve every heading, comment, and marker in this template. Never remove or rewrite the release-note-category:start/end, release-note:start/end, or release-note-image:start/end marker pairs. Never remove or rewrite the Release note images section; leave its contents for a human. -->

## Pull Request Type
<!-- Please select what type of pull request this is: [x] -->
- [ ] Bugfix
- [x] Feature Implementation
- [ ] Documentation
- [ ] Other

## Related issue
<!-- Please link the issue your pull request is referring to. -->
<!-- If this pull request fully resolves the relevant issue, put "closes" before the issue number. -->
<!-- Example: "closes #123456". -->

No linked issue.

## Description
<!-- Please write a clear and concise description of what the pull request does. -->

Sync-server operators currently cannot tell which OpenTubeX versions still use deprecated endpoints. This sets a sync-only `User-Agent` of `OpenTubeX/<version>` using the same canonical package version shown on the About page and used by update checks. Electron's request hook removes the private renderer marker before transmission, so sync servers need no custom-header or CORS changes. Existing authorization, content type, and caller headers remain intact, and the privacy policy now discloses the version sent to configured sync servers.

## Release note category
<!-- Select exactly one category. Every pull request must select one. -->
<!-- Select "Not noteworthy" when the pull request fixes a bug in or improves functionality that has not yet appeared in a stable release. -->
<!-- release-note-category:start -->
- [ ] Not noteworthy
- [ ] Highlights
- [x] More improvements
- [ ] Fixed bugs
<!-- release-note-category:end -->

## Release note
<!-- Required unless "Not noteworthy" is selected. -->
<!-- Write one concise, user-facing entry without a leading bullet. -->
<!-- release-note:start -->
Configured sync servers now receive the OpenTubeX application version with each request.
<!-- release-note:end -->

## Release note images
<!-- Human-only: Agents must preserve this entire section and leave it empty. -->
<!-- Optional. Paste one or more Markdown images or HTML image tags here. -->
<!-- The release notes will use an HTML image tag and limit images taller than 300 pixels. -->
<!-- release-note-image:start -->

<!-- release-note-image:end -->

## Testing
<!-- How can reviewers verify that the PR produces correct results? -->
<!-- Please provide instructions so that others can ensure that your pull request would produce correct results. For examples see, https://github.com/FreeTubeApp/FreeTube/pull/5743, https://github.com/FreeTubeApp/FreeTube/pull/7349, https://github.com/FreeTubeApp/FreeTube/pull/5125, https://github.com/FreeTubeApp/FreeTube/pull/7338 -->
<!-- Agent instructions: Only write human-facing steps that explain how to verify the change while running this branch in dev mode. Include expected results and, when applicable, helpful console snippets for interactive verification. Do not include automated checks, commands, results, pass counts, or CI status. -->

1. Run OpenTubeX in development mode and configure a sync server that can display received request headers.
2. Enter the server URL and confirm its health request uses `User-Agent: OpenTubeX/<exact application version>`.
3. Log in or register, then run a sync. Confirm authenticated requests use the same user agent while retaining `Authorization` and JSON `Content-Type` headers.
4. Confirm the server receives no `OpenTubeX-Client-Version` header and no CORS preflight request.
5. Repeat with a legacy sync server. Health, authentication, and legacy sync requests should complete without a CORS or networking error.

## Additional context
<!-- Add any other context about the pull request here. -->

The version is client-controlled informational metadata and must not be used for authentication or authorization. No device, account, operating-system, architecture, or other fingerprinting fields were added. Server-side logging and aggregation remain separate companion work.
