### PR TITLE
fix(settings): keep SponsorBlock highlights inside their columns

### DIFF
--- a/e2e/tests/offline/settings.spec.mjs
+++ b/e2e/tests/offline/settings.spec.mjs
@@ -663,7 +663,7 @@ test.describe('settings', () => {
     expect(gaps.after).toBeLessThanOrEqual(16)
   })
 
-  test('keeps SponsorBlock category colors in its flexible layout', async ({ page }) => {
+  test('keeps SponsorBlock category controls inside its flexible layout', async ({ page }) => {
     const addOns = await goToSettingsSection(page, 'add-ons')
     await addOns.locator('label.switch-label').filter({ hasText: 'Enable SponsorBlock' }).click()
 
@@ -677,6 +677,28 @@ test.describe('settings', () => {
       getComputedStyle(element.querySelector('.select-icon')).color
     )))
     expect(paletteColors).toEqual(['rgb(76, 175, 80)', 'rgb(255, 235, 59)'])
+
+    const expectControlsInsideCategories = async () => {
+      const maximumOverflow = await categories.evaluateAll(elements => Math.max(...elements.flatMap(element => {
+        const categoryBounds = element.getBoundingClientRect()
+        return Array.from(element.querySelectorAll('.select')).map(select => {
+          const selectBounds = select.getBoundingClientRect()
+          return Math.max(
+            categoryBounds.left - selectBounds.left,
+            selectBounds.right - categoryBounds.right
+          )
+        })
+      })))
+      expect(maximumOverflow).toBeLessThanOrEqual(1)
+    }
+
+    await expectControlsInsideCategories()
+    await page.evaluate(async () => {
+      const store = document.querySelector('#app').__vue_app__.config.globalProperties.$store
+      await store.dispatch('updateUiScale', 95)
+    })
+    await expect.poll(() => page.evaluate(() => window.devicePixelRatio)).toBeCloseTo(0.95, 2)
+    await expectControlsInsideCategories()
   })
 
   test('offers a custom SponsorBlock category color initialized from its default', async ({ app, page }) => {

--- a/src/renderer/components/FtSponsorBlockCategory/FtSponsorBlockCategory.css
+++ b/src/renderer/components/FtSponsorBlockCategory/FtSponsorBlockCategory.css
@@ -13,6 +13,7 @@
 }
 
 .sponsorBlockCategory :deep(.select) {
+  box-sizing: border-box;
   inline-size: 100%;
 }
 


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Make sure to follow the contributing guidelines. -->
<!-- Important note, we may remove your pull request if you do not use this provided PR template correctly. -->
<!-- Agent instructions: Preserve every heading, comment, and marker in this template. Never remove or rewrite the release-note-category:start/end, release-note:start/end, or release-note-image:start/end marker pairs. Never remove or rewrite the Release note images section; leave its contents for a human. -->

## Pull Request Type
<!-- Please select what type of pull request this is: [x] -->
- [x] Bugfix
- [ ] Feature Implementation
- [ ] Documentation
- [ ] Other

## Related issue
<!-- Please link the issue your pull request is referring to. -->
<!-- If this pull request fully resolves the relevant issue, put "closes" before the issue number. -->
<!-- Example: "closes #123456". -->

## Description
<!-- Please write a clear and concise description of what the pull request does. -->
Changed-setting highlight gutters made the 100%-wide SponsorBlock selects overflow their category columns, which could push them into neighboring settings. This keeps each select's border and padding inside its declared width and adds regression coverage at 100% and 95% UI scale.

## Release note category
<!-- Select exactly one category. Every pull request must select one. -->
<!-- Select "Not noteworthy" when the pull request fixes a bug in or improves functionality that has not yet appeared in a stable release. -->
<!-- release-note-category:start -->
- [ ] Not noteworthy
- [ ] Highlights
- [ ] More improvements
- [x] Fixed bugs
<!-- release-note-category:end -->

## Release note
<!-- Required unless "Not noteworthy" is selected. -->
<!-- Write one concise, user-facing entry without a leading bullet. -->
<!-- release-note:start -->
SponsorBlock settings no longer overlap neighboring controls when changed-setting highlights are enabled.
<!-- release-note:end -->

## Release note images
<!-- Human-only: Agents must preserve this entire section and leave it empty. -->
<!-- Optional. Paste one or more Markdown images or HTML image tags here. -->
<!-- The release notes will use an HTML image tag and limit images taller than 300 pixels. -->
<!-- release-note-image:start -->

<!-- release-note-image:end -->

## Testing
<!-- How can reviewers verify that the PR produces correct results? -->
<!-- Please provide instructions so that others can ensure that your pull request would produce correct results. For examples see, https://github.com/FreeTubeApp/FreeTube/pull/5743, https://github.com/FreeTubeApp/FreeTube/pull/7349, https://github.com/FreeTubeApp/FreeTube/pull/5125, https://github.com/FreeTubeApp/FreeTube/pull/7338 -->
<!-- Agent instructions: Only write human-facing steps that explain how to verify the change while running this branch in dev mode. Include expected results and, when applicable, helpful console snippets for interactive verification. Do not include automated checks, commands, results, pass counts, or CI status. -->
1. Open Settings, enable "Highlight settings changed from defaults," then open Add-ons and enable SponsorBlock.
2. Change the color and skip option for every SponsorBlock category.
3. Resize the settings window and repeat at 95% UI scale. Every highlight rail and select should stay inside its category column without touching neighboring settings.

## Additional context
<!-- Add any other context about the pull request here. -->
The fix is limited to the nested SponsorBlock selects and does not change the shared highlight gutter styles.
