### PR TITLE
fix(e2e): stabilize network retry fallbacks

### DIFF
--- a/e2e/helpers/innertube.mjs
+++ b/e2e/helpers/innertube.mjs
@@ -8,6 +8,8 @@ import { test as baseAppTest, expect, setPlayerFullscreen } from './app.mjs'
 import { demoPlayerResponse, routeDemoMedia, routeIframeApi, routeWatchPageHtml, stubPoToken } from './media.mjs'
 
 const fixturesRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..', 'fixtures', 'innertube')
+// A 1x1 PNG used for channel avatars while external requests are blocked.
+const AVATAR_PNG = Buffer.from('iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mP8z8BQDwAEhQGAhKmMIQAAAABJRU5ErkJggg==', 'base64')
 
 // Request body fields that change between runs (session data, tokens,
 // timestamps) and must not influence the fixture key.
@@ -146,6 +148,10 @@ export async function setupInnertube(app, testInfo) {
     await routeIframeApi(page)
     await routeWatchPageHtml(page)
     await routeDemoMedia(page)
+    await page.route(/^https:\/\/yt3\.(?:ggpht|googleusercontent)\.com\//, route => route.fulfill({
+      contentType: 'image/png',
+      body: AVATAR_PNG
+    }))
 
     await page.route(/^https?:\/\//, async (route, request) => {
       const url = request.url()

--- a/e2e/tests/network/watch.spec.mjs
+++ b/e2e/tests/network/watch.spec.mjs
@@ -282,7 +282,8 @@ test.describe('watch page metadata', () => {
 })
 
 test.describe('watch page', () => {
-  test('shows a pasted comment link as the first unpinned highlighted comment', async ({ page }) => {
+  test('shows a pasted comment link as the first unpinned highlighted comment', async ({ page, innertube }) => {
+    test.skip(innertube.replay, 'watch page hydration needs the real API')
     const commentId = 'UgxZaBRFEKqDUoZULy94AaABAg'
     await page.locator(sel.searchInput).fill(
       `${VIDEO_URL}&lc=${commentId}&pp=0gcJCSIANpG00pGi`


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Make sure to follow the contributing guidelines. -->
<!-- Important note, we may remove your pull request if you do not use this provided PR template correctly. -->
<!-- Agent instructions: Preserve every heading, comment, and marker in this template. Never remove or rewrite the release-note-category:start/end, release-note:start/end, or release-note-image:start/end marker pairs. Never remove or rewrite the Release note images section; leave its contents for a human. -->

## Pull Request Type
<!-- Please select what type of pull request this is: [x] -->
- [x] Bugfix
- [ ] Feature Implementation
- [ ] Documentation
- [ ] Other

## Related issue
<!-- Please link the issue your pull request is referring to. -->
<!-- If this pull request fully resolves the relevant issue, put "closes" before the issue number. -->
<!-- Example: "closes #123456". -->

Nightly failure: https://github.com/OpenTubeX/OpenTubeX/actions/runs/32929015401

## Description
<!-- Please write a clear and concise description of what the pull request does. -->

Network tests retry with recorded fixtures when the live YouTube API blocks a CI runner. Replay blocked the renderer request that downloads channel avatars, so the tab-avatar metadata assertion always timed out. The highlighted-comment test also tried to run during replay despite having no recorded responses.

Replay now serves a local channel avatar. The highlighted-comment test follows the existing live-only pattern and skips fixture replay.

## Release note category
<!-- Select exactly one category. Every pull request must select one. -->
<!-- Select "Not noteworthy" when the pull request fixes a bug in or improves functionality that has not yet appeared in a stable release. -->
<!-- release-note-category:start -->
- [x] Not noteworthy
- [ ] Highlights
- [ ] More improvements
- [ ] Fixed bugs
<!-- release-note-category:end -->

## Release note
<!-- Required unless "Not noteworthy" is selected. -->
<!-- Write one concise, user-facing entry without a leading bullet. -->
<!-- release-note:start -->

<!-- release-note:end -->

## Release note images
<!-- Human-only: Agents must preserve this entire section and leave it empty. -->
<!-- Optional. Paste one or more Markdown images or HTML image tags here. -->
<!-- The release notes will use an HTML image tag and limit images taller than 300 pixels. -->
<!-- release-note-image:start -->

<!-- release-note-image:end -->

## Testing
<!-- How can reviewers verify that the PR produces correct results? -->
<!-- Please provide instructions so that others can ensure that your pull request would produce correct results. For examples see, https://github.com/FreeTubeApp/FreeTube/pull/5743, https://github.com/FreeTubeApp/FreeTube/pull/7349, https://github.com/FreeTubeApp/FreeTube/pull/5125, https://github.com/FreeTubeApp/FreeTube/pull/7338 -->
<!-- Agent instructions: Only write human-facing steps that explain how to verify the change while running this branch in dev mode. Include expected results and, when applicable, helpful console snippets for interactive verification. Do not include automated checks, commands, results, pass counts, or CI status. -->

No manual testing is needed. This only changes Playwright network replay behavior.

## Additional context
<!-- Add any other context about the pull request here. -->

The same offline shard that failed once in the linked run passed twice without changes, which points to a transient test failure unrelated to this fix.