### PR TITLE
feat(comments): add translations with distraction-free control

### DIFF
--- a/e2e/tests/offline/settings.spec.mjs
+++ b/e2e/tests/offline/settings.spec.mjs
@@ -646,6 +646,21 @@ test.describe('settings', () => {
     ])
   })
 
+  test('disables the comment translation button setting when comments are hidden', async ({ page }) => {
+    const focus = await goToSettingsSection(page, 'focus')
+    const hideTranslationButtons = focus.getByRole('checkbox', {
+      name: /^Hide Comment Translation Buttons/
+    })
+    const hideComments = focus.getByRole('checkbox', { name: /^Hide comments/ })
+
+    await expect(hideTranslationButtons).toBeEnabled()
+    await hideTranslationButtons.locator('..').locator('label.switch-label').click()
+    await expect(hideTranslationButtons).toBeChecked()
+    await hideComments.locator('..').locator('label.switch-label').click()
+    await expect(hideComments).toBeChecked()
+    await expect(hideTranslationButtons).toBeDisabled()
+  })
+
   test('keeps General help icons close to their selects', async ({ page }) => {
     await goTo(page, 'settings')
     const startup = page.locator('.generalSelectGrid .select').filter({ hasText: 'On Startup' })

--- a/e2e/tests/offline/watch-page.spec.mjs
+++ b/e2e/tests/offline/watch-page.spec.mjs
@@ -3019,6 +3019,105 @@ test.describe('manual comment loading', () => {
     }
   })
 
+  test('translates a comment and restores its original text', async ({ app, page }) => {
+    await mockPlayableWatchPage(app, page)
+
+    await page.evaluate(async () => {
+      const store = document.querySelector('#app').__vue_app__.config.globalProperties.$store
+      await store.dispatch('updateCurrentLocale', 'de-DE')
+    })
+
+    let translationRequestCount = 0
+    await page.route(/\/youtubei\/v1\/comment\/perform_comment_action/, route => {
+      translationRequestCount++
+      return route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: JSON.stringify({
+          frameworkUpdates: {
+            entityBatchUpdate: {
+              mutations: [{
+                payload: {
+                  commentEntityPayload: {
+                    translatedContent: {
+                      content: 'Translated comment text'
+                    }
+                  }
+                }
+              }]
+            }
+          }
+        })
+      })
+    })
+
+    await openMockedVideo(page)
+
+    const loadComments = page.locator('.getCommentsTitle')
+    await loadComments.scrollIntoViewIfNeeded()
+    await loadComments.click()
+    await expect(page.locator('.commentsTitle')).toBeVisible({ timeout: 30_000 })
+
+    const comment = page.locator('.commentThread').filter({
+      has: page.locator(':scope > .commentTranslation .commentTranslationButton')
+    }).first()
+    await expect(comment).toBeVisible()
+    const commentText = comment.locator(':scope > .commentText')
+    const originalText = await commentText.textContent()
+    const translate = comment.locator(':scope > .commentTranslation .commentTranslationButton')
+
+    await translate.click()
+
+    await expect(commentText).toHaveText('Translated comment text')
+    await translate.click()
+    await expect(commentText).toHaveText(originalText)
+
+    await translate.click()
+    await expect(commentText).toHaveText('Translated comment text')
+    expect(translationRequestCount).toBe(1)
+  })
+
+  test('does not offer to translate a comment already in the app language', async ({ app, page }) => {
+    await mockPlayableWatchPage(app, page)
+    await openMockedVideo(page)
+
+    const loadComments = page.locator('.getCommentsTitle')
+    await loadComments.scrollIntoViewIfNeeded()
+    await loadComments.click()
+    await expect(page.locator('.commentsTitle')).toBeVisible({ timeout: 30_000 })
+
+    const englishComment = page.locator('.commentThread').filter({
+      hasText: "We're so honored that the first ever YouTube video was filmed here!"
+    })
+    await expect(englishComment).toBeVisible()
+    await expect(englishComment.locator(':scope > .commentTranslation .commentTranslationButton')).toHaveCount(0)
+  })
+
+  test('hides comment translation buttons through the distraction-free setting', async ({ app, page }) => {
+    await mockPlayableWatchPage(app, page)
+
+    await page.evaluate(async () => {
+      const store = document.querySelector('#app').__vue_app__.config.globalProperties.$store
+      await store.dispatch('updateCurrentLocale', 'de-DE')
+    })
+
+    await openMockedVideo(page)
+
+    const loadComments = page.locator('.getCommentsTitle')
+    await loadComments.scrollIntoViewIfNeeded()
+    await loadComments.click()
+    await expect(page.locator('.commentsTitle')).toBeVisible({ timeout: 30_000 })
+
+    const translationButtons = page.locator('.commentTranslationButton')
+    await expect(translationButtons.first()).toBeVisible()
+
+    await page.evaluate(async () => {
+      const store = document.querySelector('#app').__vue_app__.config.globalProperties.$store
+      await store.dispatch('updateHideCommentTranslationButtons', true)
+    })
+    await expect(translationButtons).toHaveCount(0)
+  })
+
   test('identifies collapsed replies from the video uploader', async ({ app, page, attachScreenshot }) => {
     await mockPlayableWatchPage(app, page, { ownerReply: true })
     await openMockedVideo(page)

--- a/e2e/tests/offline/watch-page.spec.mjs
+++ b/e2e/tests/offline/watch-page.spec.mjs
@@ -3058,9 +3058,10 @@ test.describe('manual comment loading', () => {
     await loadComments.click()
     await expect(page.locator('.commentsTitle')).toBeVisible({ timeout: 30_000 })
 
-    const comment = page.locator('.commentThread').filter({
+    const translatableComment = page.locator('.commentThread').filter({
       has: page.locator(':scope > .commentTranslation .commentTranslationButton')
     }).first()
+    const comment = page.locator(`#${await translatableComment.getAttribute('id')}`)
     await expect(comment).toBeVisible()
     const commentText = comment.locator(':scope > .commentText')
     const originalText = await commentText.textContent()
@@ -3075,6 +3076,16 @@ test.describe('manual comment loading', () => {
     await translate.click()
     await expect(commentText).toHaveText('Translated comment text')
     expect(translationRequestCount).toBe(1)
+
+    await page.evaluate(async () => {
+      const store = document.querySelector('#app').__vue_app__.config.globalProperties.$store
+      await store.dispatch('updateCurrentLocale', 'fr-FR')
+    })
+
+    await expect(commentText).toHaveText(originalText)
+    await translate.click()
+    await expect(commentText).toHaveText('Translated comment text')
+    expect(translationRequestCount).toBe(2)
   })
 
   test('does not offer to translate a comment already in the app language', async ({ app, page }) => {

--- a/package.json
+++ b/package.json
@@ -69,7 +69,7 @@
     "autolinker": "^4.1.5",
     "bgutils-js": "^4.0.3",
     "dompurify": "^3.4.13",
-    "eld": "2.1.0",
+    "eld": "^2.1.0",
     "font-list": "^2.1.0",
     "googlevideo": "^4.1.1",
     "marked": "^18.0.10",

--- a/package.json
+++ b/package.json
@@ -69,6 +69,7 @@
     "autolinker": "^4.1.5",
     "bgutils-js": "^4.0.3",
     "dompurify": "^3.4.13",
+    "eld": "2.1.0",
     "font-list": "^2.1.0",
     "googlevideo": "^4.1.1",
     "marked": "^18.0.10",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -36,7 +36,7 @@ importers:
         specifier: ^3.4.13
         version: 3.4.13
       eld:
-        specifier: 2.1.0
+        specifier: ^2.1.0
         version: 2.1.0
       font-list:
         specifier: ^2.1.0

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -35,6 +35,9 @@ importers:
       dompurify:
         specifier: ^3.4.13
         version: 3.4.13
+      eld:
+        specifier: 2.1.0
+        version: 2.1.0
       font-list:
         specifier: ^2.1.0
         version: 2.1.0
@@ -2470,6 +2473,10 @@ packages:
     resolution: {integrity: sha512-UeJmFfOrAQS8OJWPZ4qtgHyWExa088/MtK5UEyoJGFH67cDEXkZSviOiKRCZ4Xij0zxI3JECgYs3oKx+AizQBA==}
     engines: {node: '>=0.10.0'}
     hasBin: true
+
+  eld@2.1.0:
+    resolution: {integrity: sha512-hDQ9FX17th7NDNMO8/St6m3ADQVqjF0sQoOHI6NUAxC7yDaPmZ9wC9d8zau/9FIqOV7KtNwrPKRt6fkkrzZj0g==}
+    engines: {node: '>=14.17.0'}
 
   electron-builder-squirrel-windows@26.15.7:
     resolution: {integrity: sha512-B4uvn2NzFSuf084udWqugludFull6CRJiWe2dLzMnZLl6G5hdAGk0fsBMGlBSpKjvQCJn8IPc+S7OnJ+GXqwLA==}
@@ -7779,6 +7786,8 @@ snapshots:
   ejs@3.1.10:
     dependencies:
       jake: 10.9.4
+
+  eld@2.1.0: {}
 
   electron-builder-squirrel-windows@26.15.7(dmg-builder@26.15.7):
     dependencies:

--- a/src/renderer/components/CommentSection/CommentReply.vue
+++ b/src/renderer/components/CommentSection/CommentReply.vue
@@ -85,8 +85,16 @@
       </p>
       <FtTimestampCatcher
         class="commentText"
-        :input-html="reply.text"
+        :input-html="reply.showTranslated ? reply.translatedText : reply.text"
         @timestamp-event="emit('timestamp-event', $event)"
+      />
+      <CommentTranslationButton
+        v-if="translationEnabled && reply.translationText"
+        :comment="reply"
+        :loading="loadingTranslationIds.has(reply.id)"
+        :target-language="translationLanguage"
+        :target-language-name="translationLanguageName"
+        @translate-comment="emit('translate-comment', $event)"
       />
       <p class="commentLikeCount">
         <template v-if="!hideCommentLikes">
@@ -130,10 +138,15 @@
         :subscribed-channel-ids="subscribedChannelIds"
         :channel-thumbnail="channelThumbnail"
         :loading-reply-ids="loadingReplyIds"
+        :loading-translation-ids="loadingTranslationIds"
+        :translation-enabled="translationEnabled"
+        :translation-language="translationLanguage"
+        :translation-language-name="translationLanguageName"
         :highlighted-comment-id="highlightedCommentId"
         @copy-youtube-link="emit('copy-youtube-link', $event)"
         @get-more-replies="emit('get-more-replies', $event)"
         @timestamp-event="emit('timestamp-event', $event)"
+        @translate-comment="emit('translate-comment', $event)"
       />
       <div
         v-if="loadingReplyIds.has(reply.id) || (reply.dataType === 'local' && reply.hasReplyToken)"
@@ -169,6 +182,7 @@
 import { FtIcon } from '@opentubex/icons'
 
 import FtTimestampCatcher from '../FtTimestampCatcher.vue'
+import CommentTranslationButton from './CommentTranslationButton.vue'
 import FtRetryImage from '../FtRetryImage.vue'
 import FtSpinner from '../FtSpinner/FtSpinner.vue'
 import { useRelativeTimeClock } from '../../composables/useRelativeTimeClock'
@@ -211,6 +225,22 @@ const props = defineProps({
     type: Set,
     required: true
   },
+  loadingTranslationIds: {
+    type: Set,
+    required: true
+  },
+  translationEnabled: {
+    type: Boolean,
+    required: true
+  },
+  translationLanguage: {
+    type: String,
+    required: true
+  },
+  translationLanguageName: {
+    type: String,
+    required: true
+  },
   highlightedCommentId: {
     type: String,
     default: null
@@ -227,7 +257,7 @@ function formatCommentTime(comment) {
 
 const reply = props.node.reply
 
-const emit = defineEmits(['copy-youtube-link', 'get-more-replies', 'timestamp-event'])
+const emit = defineEmits(['copy-youtube-link', 'get-more-replies', 'timestamp-event', 'translate-comment'])
 </script>
 
 <style scoped src="./CommentSection.css" />

--- a/src/renderer/components/CommentSection/CommentReply.vue
+++ b/src/renderer/components/CommentSection/CommentReply.vue
@@ -85,7 +85,9 @@
       </p>
       <FtTimestampCatcher
         class="commentText"
-        :input-html="reply.showTranslated ? reply.translatedText : reply.text"
+        :input-html="reply.showTranslated && reply.translatedLanguage === translationLanguage
+          ? reply.translatedText
+          : reply.text"
         @timestamp-event="emit('timestamp-event', $event)"
       />
       <CommentTranslationButton

--- a/src/renderer/components/CommentSection/CommentSection.css
+++ b/src/renderer/components/CommentSection/CommentSection.css
@@ -334,6 +334,45 @@
   overflow-wrap: break-word;
 }
 
+.commentTranslation {
+  margin-block: 2px;
+  margin-inline-start: 60px;
+}
+
+.commentTranslationButton {
+  display: inline-flex;
+  min-block-size: 32px;
+  max-inline-size: calc(100% - 60px);
+  align-items: center;
+  padding-block: 4px;
+  padding-inline: 10px;
+  color: var(--title-color);
+  background-color: transparent;
+  border: 0;
+  border-radius: calc(16px * var(--ui-roundness));
+  cursor: pointer;
+  font: inherit;
+  font-size: 12px;
+  font-weight: 600;
+  text-align: start;
+}
+
+.commentTranslationButton:hover,
+.commentTranslationButton:focus-visible {
+  color: var(--side-nav-hover-text-color);
+  background-color: var(--side-nav-hover-color);
+}
+
+.commentTranslationButton:disabled {
+  cursor: default;
+  opacity: 0.65;
+}
+
+.commentTranslationButton:disabled:hover {
+  color: var(--title-color);
+  background-color: transparent;
+}
+
 /* stylelint-disable liberty/use-logical-spec */
 :global(body[dir='rtl'] .commentText) {
   margin-left: initial;

--- a/src/renderer/components/CommentSection/CommentSection.vue
+++ b/src/renderer/components/CommentSection/CommentSection.vue
@@ -236,7 +236,9 @@
           </p>
           <FtTimestampCatcher
             class="commentText"
-            :input-html="comment.showTranslated ? comment.translatedText : comment.text"
+            :input-html="comment.showTranslated && comment.translatedLanguage === translationLanguage
+              ? comment.translatedText
+              : comment.text"
             @timestamp-event="onTimestamp"
           />
           <CommentTranslationButton
@@ -748,7 +750,7 @@ const translationLanguageName = computed(() => {
  * @param {Comment} comment
  */
 async function toggleCommentTranslation(comment) {
-  if (comment.showTranslated) {
+  if (comment.showTranslated && comment.translatedLanguage === translationLanguage.value) {
     comment.showTranslated = false
     return
   }

--- a/src/renderer/components/CommentSection/CommentSection.vue
+++ b/src/renderer/components/CommentSection/CommentSection.vue
@@ -236,8 +236,16 @@
           </p>
           <FtTimestampCatcher
             class="commentText"
-            :input-html="comment.text"
+            :input-html="comment.showTranslated ? comment.translatedText : comment.text"
             @timestamp-event="onTimestamp"
+          />
+          <CommentTranslationButton
+            v-if="translationEnabled && comment.translationText"
+            :comment="comment"
+            :loading="loadingTranslationIds.has(comment.id)"
+            :target-language="translationLanguage"
+            :target-language-name="translationLanguageName"
+            @translate-comment="toggleCommentTranslation"
           />
           <p class="commentLikeCount">
             <template
@@ -326,10 +334,15 @@
               :subscribed-channel-ids="subscribedChannelIds"
               :channel-thumbnail="channelThumbnail"
               :loading-reply-ids="loadingReplyIds"
+              :loading-translation-ids="loadingTranslationIds"
+              :translation-enabled="translationEnabled"
+              :translation-language="translationLanguage"
+              :translation-language-name="translationLanguageName"
               :highlighted-comment-id="highlightedCommentId"
               @copy-youtube-link="copyCommentYoutubeLink"
               @get-more-replies="getCommentReplies(index, $event)"
               @timestamp-event="onTimestamp"
+              @translate-comment="toggleCommentTranslation"
             />
             <div
               v-if="isReplyLoading(comment.id) || comment.hasReplyToken"
@@ -465,6 +478,7 @@ import { useI18n } from 'vue-i18n'
 
 import FtCard from '../ft-card/ft-card.vue'
 import CommentReply from './CommentReply.vue'
+import CommentTranslationButton from './CommentTranslationButton.vue'
 import FtIconButton from '../FtIconButton/FtIconButton.vue'
 import FtLoader from '../FtLoader/FtLoader.vue'
 import FtRetryImage from '../FtRetryImage.vue'
@@ -491,8 +505,10 @@ import {
   getLocalCommunityPostComments,
   getLocalComments,
   parseLocalComment,
-  parseLocalSubscriberCount
+  parseLocalSubscriberCount,
+  translateCommentText
 } from '../../helpers/api/local'
+import { normalizeYouTubeCaptionLanguageCode } from '../../helpers/player/youtubeCaptionLanguages'
 import {
   getInvidiousCommunityPostCommentReplies,
   getInvidiousCommunityPostComments,
@@ -500,7 +516,7 @@ import {
   invidiousGetComments
 } from '../../helpers/api/invidious'
 
-const { t } = useI18n()
+const { locale, t } = useI18n()
 const relativeTimeNow = useRelativeTimeClock()
 
 function formatCommentTime(comment) {
@@ -555,6 +571,7 @@ const props = defineProps({
 const isLoading = ref(false)
 const isLoadingMoreComments = ref(false)
 const loadingReplyIds = ref(new Set())
+const loadingTranslationIds = ref(new Set())
 const showComments = ref(false)
 const nextPageToken = shallowRef(null)
 
@@ -709,6 +726,58 @@ const backendPreference = computed(() => {
 const backendFallback = computed(() => {
   return store.getters.getBackendFallback
 })
+
+const translationEnabled = computed(() => {
+  return process.env.SUPPORTS_LOCAL_API && !store.getters.getHideCommentTranslationButtons
+})
+
+const translationLanguage = computed(() => {
+  return normalizeYouTubeCaptionLanguageCode(locale.value)
+})
+
+const translationLanguageName = computed(() => {
+  const language = translationLanguage.value
+  if (!language) {
+    return locale.value
+  }
+
+  return new Intl.DisplayNames([locale.value, 'en'], { type: 'language' }).of(language) ?? language
+})
+
+/**
+ * @param {Comment} comment
+ */
+async function toggleCommentTranslation(comment) {
+  if (comment.showTranslated) {
+    comment.showTranslated = false
+    return
+  }
+
+  const targetLanguage = translationLanguage.value
+  if (!targetLanguage || loadingTranslationIds.value.has(comment.id)) {
+    return
+  }
+
+  if (comment.translatedText && comment.translatedLanguage === targetLanguage) {
+    comment.showTranslated = true
+    return
+  }
+
+  loadingTranslationIds.value = new Set(loadingTranslationIds.value).add(comment.id)
+
+  try {
+    comment.translatedText = await translateCommentText(comment.translationText, targetLanguage)
+    comment.translatedLanguage = targetLanguage
+    comment.showTranslated = true
+  } catch (error) {
+    console.error(error)
+    showApiErrorToast(t('Comments.Comment translation failed'), error)
+  } finally {
+    const nextLoadingTranslationIds = new Set(loadingTranslationIds.value)
+    nextLoadingTranslationIds.delete(comment.id)
+    loadingTranslationIds.value = nextLoadingTranslationIds
+  }
+}
 
 /** @type {import('vue').ComputedRef<boolean>} */
 const hideCommentLikes = computed(() => {

--- a/src/renderer/components/CommentSection/CommentTranslationButton.vue
+++ b/src/renderer/components/CommentSection/CommentTranslationButton.vue
@@ -1,0 +1,79 @@
+<template>
+  <div
+    v-if="translationAvailable"
+    class="commentTranslation"
+  >
+    <button
+      type="button"
+      class="commentTranslationButton"
+      :disabled="loading"
+      :aria-busy="loading"
+      @click="emit('translate-comment', comment)"
+    >
+      <FtSpinner
+        v-if="loading"
+        inline
+        size="14px"
+        border-width="2px"
+        :label="$t('Comments.Translating comment, please wait')"
+      />
+      <template v-else-if="comment.showTranslated">
+        {{ $t('Comments.Show original') }}
+      </template>
+      <template v-else>
+        {{ $t('Comments.Translate to {language}', { language: targetLanguageName }) }}
+      </template>
+    </button>
+  </div>
+</template>
+
+<script setup>
+import { ref, watch } from 'vue'
+
+import FtSpinner from '../FtSpinner/FtSpinner.vue'
+import { shouldOfferCommentTranslation } from '../../helpers/comment-translations'
+
+const props = defineProps({
+  comment: {
+    type: Object,
+    required: true
+  },
+  loading: {
+    type: Boolean,
+    required: true
+  },
+  targetLanguage: {
+    type: String,
+    required: true
+  },
+  targetLanguageName: {
+    type: String,
+    required: true
+  }
+})
+
+const translationAvailable = ref(false)
+let detectionGeneration = 0
+
+watch(
+  [() => props.comment.translationText, () => props.targetLanguage],
+  async ([text, targetLanguage]) => {
+    const generation = ++detectionGeneration
+    translationAvailable.value = false
+
+    try {
+      const available = await shouldOfferCommentTranslation(text, targetLanguage)
+      if (generation === detectionGeneration) {
+        translationAvailable.value = available
+      }
+    } catch (error) {
+      console.error('Comment language detection failed', error)
+    }
+  },
+  { immediate: true }
+)
+
+const emit = defineEmits(['translate-comment'])
+</script>
+
+<style scoped src="./CommentSection.css" />

--- a/src/renderer/components/CommentSection/CommentTranslationButton.vue
+++ b/src/renderer/components/CommentSection/CommentTranslationButton.vue
@@ -17,7 +17,7 @@
         border-width="2px"
         :label="$t('Comments.Translating comment, please wait')"
       />
-      <template v-else-if="comment.showTranslated">
+      <template v-else-if="comment.showTranslated && comment.translatedLanguage === targetLanguage">
         {{ $t('Comments.Show original') }}
       </template>
       <template v-else>

--- a/src/renderer/components/DistractionSettings/DistractionSettings.vue
+++ b/src/renderer/components/DistractionSettings/DistractionSettings.vue
@@ -344,6 +344,15 @@
           setting-key="hideCommentLikes"
           @change="updateHideCommentLikes"
         />
+        <FtToggleSwitch
+          v-if="SUPPORTS_LOCAL_API"
+          :label="t('Settings.Distraction Free Settings.Hide Comment Translation Buttons')"
+          :compact="true"
+          :disabled="hideComments"
+          :default-value="hideCommentTranslationButtons"
+          setting-key="hideCommentTranslationButtons"
+          @change="updateHideCommentTranslationButtons"
+        />
       </div>
       <div class="switchColumn">
         <FtToggleSwitch
@@ -474,6 +483,16 @@ const hideCommentLikes = computed(() => store.getters.getHideCommentLikes)
  */
 function updateHideCommentLikes(value) {
   store.dispatch('updateHideCommentLikes', value)
+}
+
+/** @type {import('vue').ComputedRef<boolean>} */
+const hideCommentTranslationButtons = computed(() => store.getters.getHideCommentTranslationButtons)
+
+/**
+ * @param {boolean} value
+ */
+function updateHideCommentTranslationButtons(value) {
+  store.dispatch('updateHideCommentTranslationButtons', value)
 }
 
 /** @type {import('vue').ComputedRef<boolean>} */

--- a/src/renderer/helpers/api/invidious.js
+++ b/src/renderer/helpers/api/invidious.js
@@ -443,6 +443,7 @@ export async function invidiousGetVideoInformation(videoId) {
  * @property {string} author
  * @property {number} likes
  * @property {string} text
+ * @property {string} translationText
  * @property {string} dataType
  * @property {boolean} isOwner
  * @property {boolean} isPinned
@@ -630,6 +631,7 @@ function parseInvidiousCommentData(response) {
       author: comment.author,
       likes: comment.likeCount,
       text: autolinker.link(invidiousImageUrlToInvidious(comment.contentHtml, getCurrentInstanceUrl())),
+      translationText: comment.content,
       dataType: 'invidious',
       isOwner: comment.authorIsChannelOwner,
       isPinned: comment.isPinned,

--- a/src/renderer/helpers/api/local.js
+++ b/src/renderer/helpers/api/local.js
@@ -6,6 +6,7 @@ import { SEARCH_CHAR_LIMIT } from '../../../constants'
 import store from '../../store/index'
 import { PlayerCache } from './PlayerCache'
 import { loadSearchContinuation } from '../search-continuation'
+import { formatCommentTranslation, getCommentTranslationSource } from '../comment-translations'
 import { parseLocalShortLinkedVideo } from '../player/shorts'
 import { getPaidPromotionDurationMs } from '../player/paidPromotion'
 import { getLocalPremiereState } from '../premiere'
@@ -148,6 +149,18 @@ export async function getLocalSearchSuggestions(query) {
   }
 
   return await searchSuggestionsSession.getSearchSuggestions(query)
+}
+
+/**
+ * Translate comment text with YouTube's comment translation service.
+ * @param {string} text
+ * @param {string} targetLanguage
+ * @returns {Promise<string>}
+ */
+export async function translateCommentText(text, targetLanguage) {
+  const innertube = await createInnertube()
+  const response = await innertube.interact.translate(text, targetLanguage)
+  return formatCommentTranslation(response.translated_content)
 }
 
 export function clearLocalSearchSuggestionsSession() {
@@ -2635,6 +2648,7 @@ export function mapLocalLegacyFormat(format) {
  * @property {boolean} isOwner
  * @property {boolean} isMember
  * @property {string} text
+ * @property {string} translationText
  * @property {boolean} isHearted
  * @property {boolean} hasOwnerReplied
  * @property {boolean} hasReplyToken
@@ -2680,6 +2694,7 @@ export function parseLocalComment(comment, commentThread = undefined) {
     isOwner: !!comment.author_is_channel_owner,
     isMember: !!comment.is_member,
     text: Autolinker.link(parseLocalTextRuns(commentTextRuns, 16, { looseChannelNameDetection: true })),
+    translationText: getCommentTranslationSource(commentTextRuns),
     isHearted: !!comment.is_hearted,
     hasOwnerReplied,
     hasReplyToken,

--- a/src/renderer/helpers/comment-translations.js
+++ b/src/renderer/helpers/comment-translations.js
@@ -1,0 +1,76 @@
+import Autolinker from 'autolinker'
+
+const MIN_LANGUAGE_SCORE_MARGIN = 0.3
+let languageDetectorPromise
+
+function normalizeDetectedLanguageTarget(language) {
+  const baseLanguage = language.split('-')[0]
+  if (baseLanguage === 'nb' || baseLanguage === 'nn') {
+    return 'no'
+  }
+
+  return baseLanguage
+}
+
+async function getLanguageDetector() {
+  languageDetectorPromise ??= import('eld/extrasmall').then(({ eld }) => eld)
+  return await languageDetectorPromise
+}
+
+/**
+ * Only offer translation when local detection can confidently distinguish the
+ * comment from the target language. Ambiguous and unsupported text stays
+ * button-free instead of prompting for a translation it may not need.
+ * @param {string} text
+ * @param {string} targetLanguage
+ * @returns {Promise<boolean>}
+ */
+export async function shouldOfferCommentTranslation(text, targetLanguage) {
+  if (!text.trim() || !targetLanguage) {
+    return false
+  }
+
+  const detector = await getLanguageDetector()
+  const normalizedTarget = normalizeDetectedLanguageTarget(targetLanguage)
+  const supportedLanguages = Object.values(detector.info().Languages)
+  if (!supportedLanguages.includes(normalizedTarget)) {
+    return false
+  }
+
+  const result = detector.detect(text.replaceAll(/(?:^|\s)@\S+/g, ' '))
+  if (!result.language || !result.isReliable() || result.language === normalizedTarget) {
+    return false
+  }
+
+  const scores = result.getScores()
+  return scores[result.language] - (scores[normalizedTarget] ?? 0) >= MIN_LANGUAGE_SCORE_MARGIN
+}
+
+/**
+ * Keep the text sent for translation separate from the rendered comment HTML.
+ * @param {{text?: string}[]} runs
+ * @returns {string}
+ */
+export function getCommentTranslationSource(runs) {
+  return runs.map(run => run.text ?? '').join('')
+}
+
+/**
+ * Escape translated text before adding links and passing it to the comment renderer.
+ * @param {unknown} translatedText
+ * @returns {string}
+ */
+export function formatCommentTranslation(translatedText) {
+  if (typeof translatedText !== 'string' || translatedText.trim() === '') {
+    throw new Error('YouTube did not return a comment translation')
+  }
+
+  const escapedText = translatedText
+    .replaceAll('&', '&amp;')
+    .replaceAll('<', '&lt;')
+    .replaceAll('>', '&gt;')
+    .replaceAll('"', '&quot;')
+    .replaceAll("'", '&apos;')
+
+  return Autolinker.link(escapedText)
+}

--- a/src/renderer/helpers/settingsSearch.js
+++ b/src/renderer/helpers/settingsSearch.js
@@ -268,6 +268,7 @@ function isSettingsSearchMessageVisible(sectionType, path, options) {
         store.getters.getForbiddenTitlesParsed.length > 0
     }
     if (group === 'Hide Trending Videos') return supportsLocalApi
+    if (group === 'Hide Comment Translation Buttons') return supportsLocalApi
   }
 
   if (sectionType === 'theme') {

--- a/src/renderer/store/modules/settings.js
+++ b/src/renderer/store/modules/settings.js
@@ -286,6 +286,7 @@ const state = {
   hideChannelSubscriptions: false,
   hideCommentLikes: false,
   hideCommentPhotos: false,
+  hideCommentTranslationButtons: false,
   hideComments: false,
   hideEndScreenAnnotations: false,
   hidePaidPromotion: false,

--- a/static/locales/de-DE.yaml
+++ b/static/locales/de-DE.yaml
@@ -966,6 +966,7 @@ Settings:
     Hide Recommended Videos: Empfohlene Videos ausblenden
     Hide Channel Subscribers: Abozahl für Kanäle ausblenden
     Hide Comment Likes: Likes bei Kommentaren ausblenden
+    Hide Comment Translation Buttons: Schaltflächen zum Übersetzen von Kommentaren ausblenden
     Hide Video Likes And Dislikes: Likes und Dislikes ausblenden
     Hide Video Views: Videoaufrufe ausblenden
     Distraction Free Settings: Ablenkungsfreier Modus
@@ -1866,6 +1867,10 @@ Comments:
     sie gelöscht oder ausgeblendet, daher wurde die Antwortschaltfläche entfernt.
   Highlighted comment: Hervorgehobener Kommentar
   Highlighted reply: Hervorgehobene Antwort
+  Translate to {language}: Auf {language} übersetzen
+  Show original: Original anzeigen
+  Translating comment, please wait: Kommentar wird übersetzt, bitte warten
+  Comment translation failed: Kommentar konnte nicht übersetzt werden
 Up Next: Nächster Titel
 
 # Toast Messages

--- a/static/locales/en-US.yaml
+++ b/static/locales/en-US.yaml
@@ -1208,6 +1208,7 @@ Settings:
     Hide Video Likes And Dislikes: Hide Video Likes And Dislikes
     Hide Channel Subscribers: Hide Channel Subscribers
     Hide Comment Likes: Hide Comment Likes
+    Hide Comment Translation Buttons: Hide Comment Translation Buttons
     Hide Recommended Videos: Hide Recommended Videos
     Hide Trending Videos: Hide Trending Videos
     Hide Popular Videos: Hide Popular Videos
@@ -2148,6 +2149,10 @@ Comments:
   Highlighted comment: Highlighted comment
   Highlighted reply: Highlighted reply
   YouTube comment link copied to clipboard: YouTube comment link copied to clipboard
+  Translate to {language}: Translate to {language}
+  Show original: Show original
+  Translating comment, please wait: Translating comment, please wait
+  Comment translation failed: Comment translation failed
 
 Up Next: Up Next
 Description:

--- a/tests/unit/comment-translations.test.mjs
+++ b/tests/unit/comment-translations.test.mjs
@@ -1,0 +1,41 @@
+import assert from 'node:assert/strict'
+import test from 'node:test'
+
+import {
+  formatCommentTranslation,
+  getCommentTranslationSource,
+  shouldOfferCommentTranslation
+} from '../../src/renderer/helpers/comment-translations.js'
+
+test('does not offer translation for the target language or ambiguous text', async () => {
+  assert.equal(await shouldOfferCommentTranslation('This comment is already in English.', 'en'), false)
+  assert.equal(await shouldOfferCommentTranslation('Das ist bereits ein deutscher Kommentar.', 'de'), false)
+  assert.equal(await shouldOfferCommentTranslation('Cool', 'en'), false)
+})
+
+test('offers translation for a confidently detected different language', async () => {
+  assert.equal(await shouldOfferCommentTranslation('Das ist ein deutscher Kommentar.', 'en'), true)
+  assert.equal(await shouldOfferCommentTranslation('Este comentario está escrito en español.', 'en'), true)
+})
+
+test('keeps plain comment text as the translation source', () => {
+  assert.equal(getCommentTranslationSource([
+    { text: 'Hallo ' },
+    { text: 'Welt' }
+  ]), 'Hallo Welt')
+})
+
+test('escapes translated markup and links translated URLs', () => {
+  const formatted = formatCommentTranslation('<script>alert(1)</script> https://example.com')
+
+  assert.doesNotMatch(formatted, /<script>/)
+  assert.match(formatted, /&lt;script&gt;alert\(1\)&lt;\/script&gt;/)
+  assert.match(formatted, /<a href="https:\/\/example\.com"/)
+})
+
+test('rejects an empty translation response', () => {
+  assert.throws(
+    () => formatCommentTranslation('  '),
+    /YouTube did not return a comment translation/
+  )
+})

--- a/tests/unit/comment-translations.test.mjs
+++ b/tests/unit/comment-translations.test.mjs
@@ -28,7 +28,7 @@ test('keeps plain comment text as the translation source', () => {
 test('escapes translated markup and links translated URLs', () => {
   const formatted = formatCommentTranslation('<script>alert(1)</script> https://example.com')
 
-  assert.doesNotMatch(formatted, /<script>/)
+  assert.equal(formatted.includes('<script>'), false)
   assert.match(formatted, /&lt;script&gt;alert\(1\)&lt;\/script&gt;/)
   assert.match(formatted, /<a href="https:\/\/example\.com"/)
 })

--- a/tests/unit/settings-search-config.test.mjs
+++ b/tests/unit/settings-search-config.test.mjs
@@ -188,3 +188,37 @@ test('persistent playback cache search results follow desktop visibility', () =>
   assert.ok(desktopValues.some(({ label }) => label === 'yt-dlp stream URL cache limit'))
   assert.ok(!webValues.some(({ label }) => label === 'yt-dlp stream URL cache limit'))
 })
+
+test('comment translation button setting follows local API availability', () => {
+  const options = {
+    sections: [{
+      type: 'focus',
+      title: 'Distraction Free',
+      description: locale.Settings.Categories['Distraction Free Description'],
+    }],
+    tm: path => getAtPath(locale, path),
+    store: {
+      getters: new Proxy({}, {
+        get() {
+          return false
+        }
+      })
+    },
+    usingElectron: true,
+    isMac: false,
+    isLinuxWayland: false,
+    systemUsesDarkTheme: true,
+  }
+
+  const localApiValues = createSettingsSearchIndex({
+    ...options,
+    supportsLocalApi: true,
+  }).get('focus')
+  const webValues = createSettingsSearchIndex({
+    ...options,
+    supportsLocalApi: false,
+  }).get('focus')
+
+  assert.ok(localApiValues.some(({ label }) => label === 'Hide Comment Translation Buttons'))
+  assert.ok(!webValues.some(({ label }) => label === 'Hide Comment Translation Buttons'))
+})


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Make sure to follow the contributing guidelines. -->
<!-- Important note, we may remove your pull request if you do not use this provided PR template correctly. -->
<!-- Agent instructions: Preserve every heading, comment, and marker in this template. Never remove or rewrite the release-note-category:start/end, release-note:start/end, or release-note-image:start/end marker pairs. Never remove or rewrite the Release note images section; leave its contents for a human. -->

## Pull Request Type
<!-- Please select what type of pull request this is: [x] -->
- [ ] Bugfix
- [x] Feature Implementation
- [ ] Documentation
- [ ] Other

## Related issue
<!-- Please link the issue your pull request is referring to. -->
<!-- If this pull request fully resolves the relevant issue, put "closes" before the issue number. -->
<!-- Example: "closes #123456". -->
Resolves FreeTubeApp/FreeTube#4292.

## Description
<!-- Please write a clear and concise description of what the pull request does. -->
Comments could not be translated in the app, which forced users to copy foreign-language text into another service.

This adds per-comment and per-reply translation into the current app language through YouTube's comment translation endpoint. A local, lazily loaded language detector hides the action for comments already in the target language and for ambiguous short text. Translations are cached per comment, can be switched back to the original, and work with Local API and Invidious comment sources when the Local API is available.

A new Distraction Free setting hides comment translation buttons. The setting is disabled when all comments are hidden and is omitted from builds that cannot translate comments.

## Release note category
<!-- Select exactly one category. Every pull request must select one. -->
<!-- Select "Not noteworthy" when the pull request fixes a bug in or improves functionality that has not yet appeared in a stable release. -->
<!-- release-note-category:start -->
- [ ] Not noteworthy
- [ ] Highlights
- [x] More improvements
- [ ] Fixed bugs
<!-- release-note-category:end -->

## Release note
<!-- Required unless "Not noteworthy" is selected. -->
<!-- Write one concise, user-facing entry without a leading bullet. -->
<!-- release-note:start -->
Comments and replies can now be translated into the app language, with a Distraction Free setting to hide translation buttons.
<!-- release-note:end -->

## Release note images
<!-- Human-only: Agents must preserve this entire section and leave it empty. -->
<!-- Optional. Paste one or more Markdown images or HTML image tags here. -->
<!-- The release notes will use an HTML image tag and limit images taller than 300 pixels. -->
<!-- release-note-image:start -->

<picture>
  <source media="(prefers-color-scheme: dark)" srcset="https://github.com/OpenTubeX/media/releases/download/attachments/20260827T091534Z-936-comment-translation-dark-dark-3c214f1e9e.png">
  <source media="(prefers-color-scheme: light)" srcset="https://github.com/OpenTubeX/media/releases/download/attachments/20260827T091534Z-936-comment-translation-light-light-4114bb3ad8.png">
  <img alt="Comment translations" src="https://github.com/OpenTubeX/media/releases/download/attachments/20260827T091534Z-936-comment-translation-dark-dark-3c214f1e9e.png">
</picture>

<!-- release-note-image:end -->

## Testing
<!-- How can reviewers verify that the PR produces correct results? -->
<!-- Please provide instructions so that others can ensure that your pull request would produce correct results. For examples see, https://github.com/FreeTubeApp/FreeTube/pull/5743, https://github.com/FreeTubeApp/FreeTube/pull/7349, https://github.com/FreeTubeApp/FreeTube/pull/5125, https://github.com/FreeTubeApp/FreeTube/pull/7338 -->
<!-- Agent instructions: Only write human-facing steps that explain how to verify the change while running this branch in dev mode. Include expected results and, when applicable, helpful console snippets for interactive verification. Do not include automated checks, commands, results, pass counts, or CI status. -->
1. Set the application language to English and open a video with both English and non-English comments.
2. Confirm that confidently detected non-English comments and replies show "Translate to English", while English and ambiguous short comments do not.
3. Translate a comment, switch back to the original, then translate it again. The text should toggle without a second translation request.
4. Change the application language to another supported language. Translation actions should update to target that language.
5. Enable Distraction Free > Watch Page > Hide Comment Translation Buttons. Translation actions should disappear from comments and replies, then return when the setting is disabled.
6. Repeat with Invidious selected as the comment source on a build that supports the Local API. Translation should still work.

## Additional context
<!-- Add any other context about the pull request here. -->
Language detection runs on-device. Comment text is sent for translation only after the user selects the translation action.

