### PR TITLE
feat(player): keep mini player visible across tabs

### DIFF
--- a/e2e/tests/offline/player.spec.mjs
+++ b/e2e/tests/offline/player.spec.mjs
@@ -39,6 +39,36 @@ function scrollBelowPlayer(player) {
   })
 }
 
+/** Asserts that the overlay owns a point where it intersects the detached player. */
+async function expectOverlayAbovePlayer(player, overlay) {
+  await expect(overlay).toBeVisible()
+  const playerElement = await player.elementHandle()
+  expect(playerElement).not.toBeNull()
+
+  const result = await overlay.evaluate((overlayElement, playerElement) => {
+    const overlayRect = overlayElement.getBoundingClientRect()
+    const playerRect = playerElement.getBoundingClientRect()
+    const left = Math.max(overlayRect.left, playerRect.left)
+    const right = Math.min(overlayRect.right, playerRect.right)
+    const top = Math.max(overlayRect.top, playerRect.top)
+    const bottom = Math.min(overlayRect.bottom, playerRect.bottom)
+
+    if (right <= left || bottom <= top) {
+      return { intersects: false, overlayIsTopmost: false }
+    }
+
+    const topmost = document.elementFromPoint((left + right) / 2, (top + bottom) / 2)
+    return {
+      intersects: true,
+      overlayIsTopmost: topmost !== null && overlayElement.contains(topmost)
+    }
+  }, playerElement)
+
+  await playerElement.dispose()
+  expect(result.intersects).toBe(true)
+  expect(result.overlayIsTopmost).toBe(true)
+}
+
 test('playback starts', async ({ app, page, attachScreenshot }) => {
   const video = await openDemoVideo({ app, page })
 
@@ -659,6 +689,124 @@ test.describe('scroll mini player', () => {
     await page.waitForTimeout(350)
     expect(await page.evaluate(() => window.scrollMiniPlayerAnimationCount))
       .toBe(animationCountBeforeReturn)
+  })
+
+  test.describe('on all tabs', () => {
+    test.use({
+      seed: {
+        settings: {
+          ...PLAYER_SEED,
+          scrollMiniPlayerOnAllTabs: true,
+          uiScale: 125
+        }
+      }
+    })
+
+    test('keeps the most recently left video visible across tabs', async ({ app, page, attachScreenshot }) => {
+      const video = await openDemoVideo({ app, page })
+      const playbackTimeBeforeSwitch = await video.evaluate(element => element.currentTime)
+
+      const player = page.locator('.ftVideoPlayer')
+      await page.locator('.tabBar .newTabButton').click()
+      await expect(page.locator('.tabBar .tab')).toHaveCount(2)
+      await expect(player).toBeVisible()
+      await expect(player).toHaveClass(/scrollMiniPlayer/)
+      const returnButton = player.locator('.scrollMiniScrollTop')
+      await expect(returnButton).toHaveAttribute(
+        'title',
+        'Return to video tab'
+      )
+      await expect(returnButton).toHaveAttribute('tabindex', '0')
+      const floatingVideo = player.locator('video')
+      await expect.poll(() => floatingVideo.evaluate(element => element.currentTime))
+        .toBeGreaterThan(playbackTimeBeforeSwitch)
+
+      const playPauseButton = player.locator('.scrollMiniPlayPause')
+      await playPauseButton.click()
+      await expect.poll(() => floatingVideo.evaluate(element => element.paused)).toBe(true)
+      await playPauseButton.click()
+      await expect.poll(() => floatingVideo.evaluate(element => element.paused)).toBe(false)
+      await attachScreenshot('mini player on another tab')
+
+      await page.locator('.tabBar .newTabButton').click()
+      await expect(page.locator('.tabBar .tab')).toHaveCount(3)
+      await expect(player).toBeVisible()
+
+      await player.locator('.scrollMiniScrollTop').click()
+      await expect(page.locator(`${activeTab} .ftVideoPlayer`)).toBeVisible()
+      await expect(player).not.toHaveClass(/scrollMiniPlayer/)
+    })
+
+    test('removes the mini player when its source tab closes', async ({ app, page }) => {
+      await openDemoVideo({ app, page })
+
+      await page.locator('.tabBar .newTabButton').click()
+      await expect(page.locator('.ftVideoPlayer')).toBeVisible()
+
+      await page.locator('.tabBar .tab').first().locator('.closeButton').click()
+      await expect(page.locator('.tabBar .tab')).toHaveCount(1)
+      await expect(page.locator('.ftVideoPlayer')).toHaveCount(0)
+    })
+
+    test('keeps menus and utility windows above the mini player', async ({ app, page }) => {
+      await openDemoVideo({ app, page })
+
+      const player = page.locator('.ftVideoPlayer')
+      await page.locator('.tabBar .newTabButton').click()
+      await expect(player).toHaveClass(/scrollMiniPlayer/)
+
+      await page.locator('.profileTrigger').click()
+      const quickSettings = page.getByRole('dialog', { name: 'Quick settings' })
+      await expectOverlayAbovePlayer(player, quickSettings)
+
+      await quickSettings.getByRole('button', { name: 'All settings' }).click()
+      const settings = page.getByRole('dialog', { name: 'Settings', exact: true })
+      await expectOverlayAbovePlayer(player, settings)
+      await settings.getByRole('button', { name: 'Close', exact: true }).click()
+
+      await page.locator('.profileTrigger').click()
+      await page.getByRole('dialog', { name: 'Quick settings' })
+        .getByRole('button', { name: 'Downloads' }).click()
+      const downloads = page.getByRole('dialog', { name: 'Downloads', exact: true })
+      await expectOverlayAbovePlayer(player, downloads)
+    })
+
+    test.describe('with automatic Picture-in-Picture', () => {
+      test.use({
+        seed: {
+          settings: {
+            ...PLAYER_SEED,
+            autoPictureInPictureTriggers: ['tab'],
+            scrollMiniPlayerOnAllTabs: true,
+            uiScale: 125
+          }
+        }
+      })
+
+      test('uses PiP instead of the cross-tab mini player', async ({ app, page }) => {
+        await openDemoVideo({ app, page })
+        const player = page.locator('.ftVideoPlayer')
+        const video = player.locator('video')
+
+        await page.locator('.tabBar .newTabButton').click()
+        await expect.poll(() => video.evaluate(
+          element => document.pictureInPictureElement === element
+        )).toBe(true)
+        await expect(player).toBeHidden()
+        await expect(player).not.toHaveClass(/scrollMiniPlayer/)
+
+        // A later scroll update must not bring the in-app player back while
+        // the same video is still presented by the native PiP window.
+        await page.evaluate(() => window.dispatchEvent(new Event('scroll')))
+        await expect(player).toBeHidden()
+        await expect(player).not.toHaveClass(/scrollMiniPlayer/)
+
+        await page.evaluate(() => document.exitPictureInPicture())
+        await expect.poll(() => page.evaluate(
+          () => document.pictureInPictureElement === null
+        )).toBe(true)
+      })
+    })
   })
 
   test('scales the captions down with the scroll mini player', async ({ app, page, attachScreenshot }) => {

--- a/e2e/tests/offline/player.spec.mjs
+++ b/e2e/tests/offline/player.spec.mjs
@@ -669,13 +669,15 @@ test.describe('scroll mini player', () => {
       }
     })
 
-    const player = page.locator(`${activeTab} .ftVideoPlayer`)
+    const player = page.locator('.ftVideoPlayer')
     await scrollBelowPlayer(player)
     await expect(player).toHaveClass(/scrollMiniPlayer/)
     await expect.poll(() => page.evaluate(() => window.scrollMiniPlayerAnimationCount)).toBe(1)
 
     await page.locator('.tabBar .newTabButton').click()
     await expect(page.locator('.tabBar .tab')).toHaveCount(2)
+    await expect(player).toBeHidden()
+    await expect(player).not.toHaveClass(/scrollMiniPlayer/)
     await attachScreenshot('second tab open')
     const animationCountBeforeReturn = await page.evaluate(
       () => window.scrollMiniPlayerAnimationCount

--- a/e2e/tests/offline/player.spec.mjs
+++ b/e2e/tests/offline/player.spec.mjs
@@ -771,6 +771,30 @@ test.describe('scroll mini player', () => {
       await expectOverlayAbovePlayer(player, downloads)
     })
 
+    test('hides an existing mini player when automatic PiP takes over tab changes', async ({ app, page }) => {
+      const video = await openDemoVideo({ app, page })
+      await video.evaluate(element => element.pause())
+
+      const player = page.locator('.ftVideoPlayer')
+      await page.locator('.tabBar .newTabButton').click()
+      await expect(player).toHaveClass(/scrollMiniPlayer/)
+
+      await page.locator('.profileTrigger').click()
+      await page.getByRole('dialog', { name: 'Quick settings' })
+        .getByRole('button', { name: 'All settings' }).click()
+      const settings = page.getByRole('dialog', { name: 'Settings', exact: true })
+      await settings.locator('.settingsMenu [data-section="playback"]').click()
+      await settings.locator('.pure-checkbox label')
+        .filter({ hasText: 'When switching tabs' }).click()
+
+      await expect(settings.getByRole('checkbox', {
+        name: 'When switching tabs',
+        exact: true
+      })).toBeChecked()
+      await expect(player).toBeHidden()
+      await expect(player).not.toHaveClass(/scrollMiniPlayer/)
+    })
+
     test.describe('with automatic Picture-in-Picture', () => {
       test.use({
         seed: {
@@ -805,6 +829,21 @@ test.describe('scroll mini player', () => {
         await expect.poll(() => page.evaluate(
           () => document.pictureInPictureElement === null
         )).toBe(true)
+      })
+
+      test('does not fall back to the cross-tab mini player while paused', async ({ app, page }) => {
+        const video = await openDemoVideo({ app, page })
+        await video.evaluate(element => element.pause())
+        await expect.poll(() => video.evaluate(element => element.paused)).toBe(true)
+
+        const player = page.locator('.ftVideoPlayer')
+        await page.locator('.tabBar .newTabButton').click()
+
+        await expect.poll(() => page.evaluate(
+          () => document.pictureInPictureElement === null
+        )).toBe(true)
+        await expect(player).toBeHidden()
+        await expect(player).not.toHaveClass(/scrollMiniPlayer/)
       })
     })
   })

--- a/e2e/tests/offline/settings.spec.mjs
+++ b/e2e/tests/offline/settings.spec.mjs
@@ -2353,6 +2353,35 @@ test.describe('settings', () => {
     await expect(toggle).not.toBeChecked()
   })
 
+  test('disables the cross-tab mini player while automatic PiP on tab change is enabled', async ({ page }) => {
+    const playback = await goToSettingsSection(page, 'playback')
+    const miniPlayerToggle = playback.getByRole('checkbox', {
+      name: 'Keep a mini player on screen when switching tabs'
+    })
+    const automaticPipToggle = playback.getByRole('checkbox', {
+      name: 'When switching tabs',
+      exact: true
+    })
+    const automaticPipLabel = playback.locator('.pure-checkbox label')
+      .filter({ hasText: 'When switching tabs' })
+
+    await expect(miniPlayerToggle).toBeEnabled()
+    await playback.locator('label.switch-label')
+      .filter({ hasText: 'Keep a mini player on screen when switching tabs' })
+      .click()
+    await expect(miniPlayerToggle).toBeChecked()
+
+    await automaticPipLabel.click()
+    await expect(automaticPipToggle).toBeChecked()
+    await expect(miniPlayerToggle).toBeDisabled()
+    await expect(miniPlayerToggle).toBeChecked()
+
+    await automaticPipLabel.click()
+    await expect(automaticPipToggle).not.toBeChecked()
+    await expect(miniPlayerToggle).toBeEnabled()
+    await expect(miniPlayerToggle).toBeChecked()
+  })
+
   test('shows voice-over settings disabled until translation is enabled', async ({ page }) => {
     await goTo(page, 'settings')
     await page.locator('.settingsMenu [data-section="add-ons"]').click()

--- a/src/main/tabs/TabManager.js
+++ b/src/main/tabs/TabManager.js
@@ -3672,7 +3672,9 @@ export async function setupTabsIPC(options = {}) {
       (async () => {
         const root = Array.from(document.querySelectorAll('.tabContent[data-tab-id]'))
           .find(element => element.dataset.tabId === ${JSON.stringify(tabId)})
-        const target = root?.querySelector('video.player')
+        const detachedPlayer = Array.from(document.querySelectorAll('.ftVideoPlayer[data-tab-id]'))
+          .find(element => element.dataset.tabId === ${JSON.stringify(tabId)})
+        const target = root?.querySelector('video.player') ?? detachedPlayer?.querySelector('video.player')
         if (!target?.ui?.getControls) return false
 
         if (document.pictureInPictureElement && document.pictureInPictureElement !== target) {

--- a/src/renderer/App.css
+++ b/src/renderer/App.css
@@ -30,6 +30,14 @@
   container-type: inline-size;
 }
 
+.crossTabMiniPlayerLayer {
+  position: relative;
+
+  /* Keep the detached player above route content, but below app chrome and
+     utility windows. Its own z-index remains local to this stacking context. */
+  z-index: 4;
+}
+
 .banner {
   inline-size: 85%;
   margin-block: 40px;

--- a/src/renderer/App.vue
+++ b/src/renderer/App.vue
@@ -42,6 +42,10 @@
       :inert="isAnyPromptOpen"
     >
       <div
+        id="cross-tab-mini-player-layer"
+        class="crossTabMiniPlayerLayer"
+      />
+      <div
         v-if="showUpdatesBanner"
         class="banner-wrapper"
       >

--- a/src/renderer/components/PlayerSettings/PlayerSettings.vue
+++ b/src/renderer/components/PlayerSettings/PlayerSettings.vue
@@ -170,6 +170,15 @@
           setting-key="scrollMiniPlayerEnabled"
           @change="updateScrollMiniPlayerEnabled"
         />
+        <FtToggleSwitch
+          v-if="USING_ELECTRON"
+          :label="t('Settings.Player Settings.Scroll Mini Player.On All Tabs')"
+          :compact="true"
+          :default-value="scrollMiniPlayerOnAllTabs"
+          :disabled="autoPictureInPictureTriggers.includes('tab')"
+          setting-key="scrollMiniPlayerOnAllTabs"
+          @change="updateScrollMiniPlayerOnAllTabs"
+        />
       </div>
     </div>
     <FtFlexBox class="autoPictureInPictureSettings">
@@ -853,11 +862,21 @@ const autoPictureInPictureTriggers = computed({
 /** @type {import('vue').ComputedRef<boolean>} */
 const scrollMiniPlayerEnabled = computed(() => store.getters.getScrollMiniPlayerEnabled)
 
+/** @type {import('vue').ComputedRef<boolean>} */
+const scrollMiniPlayerOnAllTabs = computed(() => store.getters.getScrollMiniPlayerOnAllTabs)
+
 /**
  * @param {boolean} value
  */
 function updateScrollMiniPlayerEnabled(value) {
   store.dispatch('updateScrollMiniPlayerEnabled', value)
+}
+
+/**
+ * @param {boolean} value
+ */
+function updateScrollMiniPlayerOnAllTabs(value) {
+  store.dispatch('updateScrollMiniPlayerOnAllTabs', value)
 }
 
 const FORMAT_VALUES = ['dash', 'legacy', 'audio']

--- a/src/renderer/components/ft-shaka-video-player/ft-shaka-video-player.js
+++ b/src/renderer/components/ft-shaka-video-player/ft-shaka-video-player.js
@@ -1215,18 +1215,12 @@ export default defineComponent({
           applyPendingPresentationModes()
           remeasureControlPanelWidth()
         })
-        // An already-scrolled tab that was inactive never got to reevaluate its
-        // scroll position, so restore the mini-player state now that it is active.
-        updateScrollMiniPlayer({ animateActivation: false })
       } else {
         if (controlPanelLayoutFrame !== null) {
           cancelAnimationFrame(controlPanelLayoutFrame)
           controlPanelLayoutFrame = null
         }
         handleTemporaryPlaybackRateFocusLoss()
-        if (scrollMiniPlayerActive.value) {
-          deactivateScrollMiniPlayer()
-        }
       }
     })
 
@@ -5019,7 +5013,12 @@ export default defineComponent({
       shortsPaused.value = false
       shortsEnded.value = false
       const isCurrentPictureInPictureVideo = document.pictureInPictureElement === video.value
-      if (process.env.IS_ELECTRON && !isActiveTab.value && !isCurrentPictureInPictureVideo) {
+      if (
+        process.env.IS_ELECTRON &&
+        !isActiveTab.value &&
+        !isCurrentPictureInPictureVideo &&
+        !scrollMiniPlayerDetached.value
+      ) {
         video.value.pause()
         return
       }
@@ -5361,6 +5360,7 @@ export default defineComponent({
     const videoElementHeight = ref(0)
     /** Height of the video element in CSS pixels, used to scale the captions with the player. */
     const videoElementLayoutHeight = ref(0)
+    const pictureInPictureActive = ref(false)
 
     const captionPlayerVariables = computed(() => {
       return getCaptionPlayerVariables(videoElementLayoutHeight.value)
@@ -5397,6 +5397,7 @@ export default defineComponent({
       scrollMiniPlaceholderHeight,
       scrollMiniPlayerActive,
       scrollMiniPlayerAnimating,
+      scrollMiniPlayerDetached,
       scrollMiniPlayerStyle,
       scrollMiniPlayPauseVisible,
       scrollMiniResizeCorner,
@@ -5422,7 +5423,9 @@ export default defineComponent({
       fullWindowEnabled,
       getUi: () => ui,
       isActiveTab,
+      pictureInPictureActive,
       props,
+      tabId,
       video,
     })
 
@@ -5489,6 +5492,7 @@ export default defineComponent({
      * @param {PictureInPictureEvent} event
      */
     function handleEnterPictureInPicture(event) {
+      pictureInPictureActive.value = true
       pipWindow = event.pictureInPictureWindow
       tabMediaCoordinator.setPictureInPicture(mediaTabId, true)
       handlePictureInPictureResize()
@@ -5503,6 +5507,7 @@ export default defineComponent({
     }
 
     function handleLeavePictureInPicture() {
+      pictureInPictureActive.value = false
       tabMediaCoordinator.setPictureInPicture(mediaTabId, false)
 
       if (pipWindow) {
@@ -9965,6 +9970,7 @@ export default defineComponent({
       toggleQuickBookmark,
 
       autoQualitySupported,
+      tabId,
 
       fullWindowEnabled,
       fullWindowPlaceholderHeight,
@@ -10066,6 +10072,7 @@ export default defineComponent({
 
       scrollMiniPlayerActive,
       scrollMiniPlayerAnimating,
+      scrollMiniPlayerDetached,
       scrollMiniPlaceholderHeight,
       scrollMiniPlayerStyle,
       scrollMiniIsPaused,

--- a/src/renderer/components/ft-shaka-video-player/ft-shaka-video-player.vue
+++ b/src/renderer/components/ft-shaka-video-player/ft-shaka-video-player.vue
@@ -38,9 +38,15 @@
       :style="{ height: `${scrollMiniPlaceholderHeight}px` }"
       aria-hidden="true"
     />
+    <!-- eslint-disable vue/html-indent -->
+    <Teleport
+      to="#cross-tab-mini-player-layer"
+      :disabled="!scrollMiniPlayerDetached"
+    >
     <div
       ref="container"
       class="ftVideoPlayer shaka-video-container"
+      :data-tab-id="tabId"
       :class="{
         autoQualityUnavailable: !autoQualitySupported,
         fullWindow: fullWindowEnabled,
@@ -1160,9 +1166,11 @@
         />
         <button
           type="button"
-          tabindex="-1"
+          :tabindex="scrollMiniPlayerDetached ? 0 : -1"
           class="scrollMiniScrollTop"
-          :title="$t('Video.Player.Scroll Mini Player.Back to Top')"
+          :title="scrollMiniPlayerDetached
+            ? $t('Video.Player.Scroll Mini Player.Return to Video Tab')
+            : $t('Video.Player.Scroll Mini Player.Back to Top')"
           @click.stop.prevent="scrollMiniScrollToTop"
           @mousedown.stop.prevent
         >
@@ -1170,7 +1178,7 @@
         </button>
         <button
           type="button"
-          tabindex="-1"
+          :tabindex="scrollMiniPlayerDetached ? 0 : -1"
           class="scrollMiniPlayPause"
           :class="{ isHidden: !scrollMiniPlayPauseVisible }"
           :title="scrollMiniIsPaused ? $t('Video.Player.Scroll Mini Player.Play') : $t('Video.Player.Scroll Mini Player.Pause')"
@@ -1200,7 +1208,7 @@
           >
             <input
               type="range"
-              tabindex="-1"
+              :tabindex="scrollMiniPlayerDetached ? 0 : -1"
               class="shaka-range-element scrollMiniVolumeBar"
               min="0"
               max="100"
@@ -1236,6 +1244,8 @@
         />
       </div>
     </div>
+    </Teleport>
+    <!-- eslint-enable vue/html-indent -->
   </div>
 </template>
 

--- a/src/renderer/components/ft-shaka-video-player/opentubex/useScrollMiniPlayer.js
+++ b/src/renderer/components/ft-shaka-video-player/opentubex/useScrollMiniPlayer.js
@@ -2,6 +2,13 @@ import { computed, nextTick, ref, watch } from 'vue'
 
 import store from '../../../store/index'
 import { applyAnimationSpeed } from '../../../helpers/animationSpeed'
+import {
+  isCrossTabMiniPlayerOwner,
+  markCrossTabMiniPlayerActive,
+  markCrossTabMiniPlayerInactive,
+  refreshCrossTabMiniPlayer,
+  unregisterCrossTabMiniPlayer,
+} from '../../../helpers/crossTabMiniPlayer'
 import { isReducedMotionEnabled } from '../../../helpers/reducedMotion'
 import {
   animateScrollMiniPlayerBounce,
@@ -48,13 +55,16 @@ const SCROLL_MINI_LAYOUT_ANIMATION_DURATION_MS = 300
  *   fullWindowEnabled: import('vue').Ref<boolean>,
  *   getUi: () => import('shaka-player').ui.Overlay | null,
  *   isActiveTab: import('vue').ComputedRef<boolean>,
+ *   pictureInPictureActive: import('vue').Ref<boolean>,
  *   props: { format: string, videoId: string },
+ *   tabId?: string | null,
  *   video: import('vue').Ref<HTMLVideoElement | null>
  * }} options
  */
-export function useScrollMiniPlayer({ container, fullWindowEnabled, getUi, isActiveTab, props, video }) {
+export function useScrollMiniPlayer({ container, fullWindowEnabled, getUi, isActiveTab, pictureInPictureActive, props, tabId = null, video }) {
   const scrollMiniVideoAspectRatio = ref(DEFAULT_ASPECT_RATIO)
   const scrollMiniPlayerEnabled = computed(() => store.getters.getScrollMiniPlayerEnabled)
+  const scrollMiniPlayerOnAllTabs = computed(() => store.getters.getScrollMiniPlayerOnAllTabs)
   const scrollMiniPlayerActive = ref(false)
   const scrollMiniPlayerAnimating = ref(false)
   const scrollMiniPlaceholderHeight = ref(0)
@@ -71,7 +81,18 @@ export function useScrollMiniPlayer({ container, fullWindowEnabled, getUi, isAct
   const scrollMiniPlaceholder = ref(null)
   const scrollMiniVolumeTrack = ref(null)
 
+  const crossTabMiniPlayerCandidate = {
+    canShow: () => canShowCrossTabMiniPlayer(),
+    hide: () => deactivateScrollMiniPlayer(),
+    show: () => activateScrollMiniPlayer(false),
+  }
+
   const scrollMiniPlayerStyle = computed(() => scrollMiniPlayerRectToStyle(scrollMiniPlayerRect.value))
+  const scrollMiniPlayerDetached = computed(() => {
+    return scrollMiniPlayerActive.value &&
+      !isActiveTab.value &&
+      isCrossTabMiniPlayerOwner(crossTabMiniPlayerCandidate)
+  })
   const scrollMiniVolumePercent = computed(() => Math.round(scrollMiniVolume.value * 100))
   const scrollMiniVolumeIcon = computed(() => {
     if (scrollMiniVolume.value === 0) {
@@ -305,7 +326,7 @@ export function useScrollMiniPlayer({ container, fullWindowEnabled, getUi, isAct
   }
 
   function isNativePipActive() {
-    return Boolean(getUi()?.getControls?.()?.isPiPEnabled?.())
+    return pictureInPictureActive.value
   }
 
   function isNativeFullscreenActive() {
@@ -356,9 +377,7 @@ export function useScrollMiniPlayer({ container, fullWindowEnabled, getUi, isAct
     togglePlayerFullScreen()
   }
 
-  function canUseScrollMiniPlayer() {
-    if (!isActiveTab.value) return false
-    if (!scrollMiniPlayerEnabled.value) return false
+  function canUseScrollMiniPlayerBase() {
     if (props.format === 'audio') return false
     if (fullWindowEnabled.value) return false
     if (isNativeFullscreenActive()) return false
@@ -366,6 +385,23 @@ export function useScrollMiniPlayer({ container, fullWindowEnabled, getUi, isAct
     const videoElement = video.value
     if (!videoElement || videoElement.ended) return false
     return true
+  }
+
+  function canShowCrossTabMiniPlayer() {
+    return !isActiveTab.value &&
+      scrollMiniPlayerOnAllTabs.value &&
+      canUseScrollMiniPlayerBase()
+  }
+
+  function canUseScrollMiniPlayer() {
+    if (!canUseScrollMiniPlayerBase()) return false
+
+    if (isActiveTab.value) {
+      return scrollMiniPlayerEnabled.value
+    }
+
+    return scrollMiniPlayerOnAllTabs.value &&
+      isCrossTabMiniPlayerOwner(crossTabMiniPlayerCandidate)
   }
 
   function getScrollMiniAnchor() {
@@ -641,6 +677,10 @@ export function useScrollMiniPlayer({ container, fullWindowEnabled, getUi, isAct
 
   /** @param {{ animateActivation?: boolean }} [options] */
   function updateScrollMiniPlayer({ animateActivation = true } = {}) {
+    if (!isActiveTab.value) {
+      refreshCrossTabMiniPlayer(crossTabMiniPlayerCandidate)
+    }
+
     // Check first: everything below reads layout, which forces a synchronous
     // reflow. Measuring before knowing whether the mini player can run at all
     // would do that on every scroll event even with the feature turned off.
@@ -654,6 +694,16 @@ export function useScrollMiniPlayer({ container, fullWindowEnabled, getUi, isAct
     rememberInlinePlayerLayoutHeight()
 
     repairScrollMiniPlaceholderHeight()
+
+    if (!isActiveTab.value) {
+      if (scrollMiniPlayerActive.value) {
+        syncScrollMiniPlayerState()
+        updateScrollMiniDragHandleContrast()
+      } else if (canActivateScrollMiniPlayer()) {
+        activateScrollMiniPlayer(false)
+      }
+      return
+    }
 
     const anchor = getScrollMiniAnchor()
     if (!anchor) return
@@ -721,6 +771,12 @@ export function useScrollMiniPlayer({ container, fullWindowEnabled, getUi, isAct
   function scrollMiniScrollToTop(event) {
     event?.preventDefault()
     event?.stopPropagation()
+
+    if (scrollMiniPlayerDetached.value && tabId) {
+      store.dispatch('activateTab', tabId)
+      return
+    }
+
     window.scrollTo({ top: 0, behavior: 'smooth' })
   }
 
@@ -917,6 +973,8 @@ export function useScrollMiniPlayer({ container, fullWindowEnabled, getUi, isAct
   }
 
   function teardownScrollMiniPlayer() {
+    unregisterCrossTabMiniPlayer(crossTabMiniPlayerCandidate)
+
     if (scrollMiniIntersectionObserver) {
       scrollMiniIntersectionObserver.disconnect()
       scrollMiniIntersectionObserver = null
@@ -950,6 +1008,16 @@ export function useScrollMiniPlayer({ container, fullWindowEnabled, getUi, isAct
     }
   })
 
+  watch(isActiveTab, (active) => {
+    if (active) {
+      markCrossTabMiniPlayerActive(crossTabMiniPlayerCandidate)
+    } else {
+      markCrossTabMiniPlayerInactive(crossTabMiniPlayerCandidate)
+    }
+
+    nextTick(() => updateScrollMiniPlayer({ animateActivation: false }))
+  }, { flush: 'sync' })
+
   watch(
     () => store.getters.getScrollMiniPlayerSavedRect,
     loadScrollMiniPlayerSavedRectFromSettings,
@@ -957,7 +1025,11 @@ export function useScrollMiniPlayer({ container, fullWindowEnabled, getUi, isAct
   )
 
   watch(scrollMiniPlayerEnabled, () => updateScrollMiniPlayer())
-  watch(fullWindowEnabled, () => updateScrollMiniPlayer())
+  watch(scrollMiniPlayerOnAllTabs, () => updateScrollMiniPlayer())
+  watch(fullWindowEnabled, () => {
+    refreshCrossTabMiniPlayer(crossTabMiniPlayerCandidate)
+    updateScrollMiniPlayer()
+  })
 
   // Toggling or resizing the vertical tab bar changes the usable area without
   // firing a window resize, so re-dock explicitly (after the DOM updates, so the
@@ -991,6 +1063,7 @@ export function useScrollMiniPlayer({ container, fullWindowEnabled, getUi, isAct
     scrollMiniPlaceholderHeight,
     scrollMiniPlayerActive,
     scrollMiniPlayerAnimating,
+    scrollMiniPlayerDetached,
     scrollMiniPlayerStyle,
     scrollMiniPlayPauseVisible,
     scrollMiniResizeCorner,

--- a/src/renderer/components/ft-shaka-video-player/opentubex/useScrollMiniPlayer.js
+++ b/src/renderer/components/ft-shaka-video-player/opentubex/useScrollMiniPlayer.js
@@ -65,6 +65,9 @@ export function useScrollMiniPlayer({ container, fullWindowEnabled, getUi, isAct
   const scrollMiniVideoAspectRatio = ref(DEFAULT_ASPECT_RATIO)
   const scrollMiniPlayerEnabled = computed(() => store.getters.getScrollMiniPlayerEnabled)
   const scrollMiniPlayerOnAllTabs = computed(() => store.getters.getScrollMiniPlayerOnAllTabs)
+  const autoPictureInPictureOnTabChange = computed(
+    () => store.getters.getAutoPictureInPictureTriggers.includes('tab')
+  )
   const scrollMiniPlayerActive = ref(false)
   const scrollMiniPlayerAnimating = ref(false)
   const scrollMiniPlaceholderHeight = ref(0)
@@ -389,6 +392,7 @@ export function useScrollMiniPlayer({ container, fullWindowEnabled, getUi, isAct
 
   function canShowCrossTabMiniPlayer() {
     return !isActiveTab.value &&
+      !autoPictureInPictureOnTabChange.value &&
       scrollMiniPlayerOnAllTabs.value &&
       canUseScrollMiniPlayerBase()
   }
@@ -400,7 +404,8 @@ export function useScrollMiniPlayer({ container, fullWindowEnabled, getUi, isAct
       return scrollMiniPlayerEnabled.value
     }
 
-    return scrollMiniPlayerOnAllTabs.value &&
+    return !autoPictureInPictureOnTabChange.value &&
+      scrollMiniPlayerOnAllTabs.value &&
       isCrossTabMiniPlayerOwner(crossTabMiniPlayerCandidate)
   }
 
@@ -1026,6 +1031,7 @@ export function useScrollMiniPlayer({ container, fullWindowEnabled, getUi, isAct
 
   watch(scrollMiniPlayerEnabled, () => updateScrollMiniPlayer())
   watch(scrollMiniPlayerOnAllTabs, () => updateScrollMiniPlayer())
+  watch(autoPictureInPictureOnTabChange, () => updateScrollMiniPlayer())
   watch(fullWindowEnabled, () => {
     refreshCrossTabMiniPlayer(crossTabMiniPlayerCandidate)
     updateScrollMiniPlayer()

--- a/src/renderer/helpers/crossTabMiniPlayer.js
+++ b/src/renderer/helpers/crossTabMiniPlayer.js
@@ -1,0 +1,96 @@
+/**
+ * Coordinates the single scroll mini player that may be shown outside its
+ * source tab. Multiple logical tabs can keep a player mounted, but only the
+ * most recently left video tab should float above the presented tab.
+ */
+
+/**
+ * @typedef {{
+ *   canShow: () => boolean,
+ *   hide: () => void,
+ *   show: () => void
+ * }} CrossTabMiniPlayerCandidate
+ */
+
+/** @type {CrossTabMiniPlayerCandidate | null} */
+let latestCandidate = null
+
+/** @type {CrossTabMiniPlayerCandidate | null} */
+let owner = null
+
+/**
+ * @param {CrossTabMiniPlayerCandidate} candidate
+ */
+function showCandidate(candidate) {
+  if (owner === candidate) {
+    return
+  }
+
+  owner?.hide()
+  owner = candidate
+  candidate.show()
+}
+
+/**
+ * Records that a player tab was left and shows it when the preference allows.
+ *
+ * @param {CrossTabMiniPlayerCandidate} candidate
+ */
+export function markCrossTabMiniPlayerInactive(candidate) {
+  latestCandidate = candidate
+  refreshCrossTabMiniPlayer(candidate)
+}
+
+/**
+ * Stops presenting a player that has become the active tab again.
+ *
+ * @param {CrossTabMiniPlayerCandidate} candidate
+ */
+export function markCrossTabMiniPlayerActive(candidate) {
+  if (latestCandidate === candidate) {
+    latestCandidate = null
+  }
+
+  if (owner === candidate) {
+    owner = null
+  }
+}
+
+/**
+ * Applies preference and playback-state changes to a mounted candidate.
+ *
+ * @param {CrossTabMiniPlayerCandidate} candidate
+ */
+export function refreshCrossTabMiniPlayer(candidate) {
+  if (owner === candidate && !candidate.canShow()) {
+    owner = null
+    candidate.hide()
+    return
+  }
+
+  if (latestCandidate === candidate && candidate.canShow()) {
+    showCandidate(candidate)
+  }
+}
+
+/**
+ * @param {CrossTabMiniPlayerCandidate} candidate
+ * @returns {boolean}
+ */
+export function isCrossTabMiniPlayerOwner(candidate) {
+  return owner === candidate
+}
+
+/**
+ * Removes an unmounted player from the coordinator.
+ *
+ * @param {CrossTabMiniPlayerCandidate} candidate
+ */
+export function unregisterCrossTabMiniPlayer(candidate) {
+  if (latestCandidate === candidate) {
+    latestCandidate = null
+  }
+  if (owner === candidate) {
+    owner = null
+  }
+}

--- a/src/renderer/store/modules/settings.js
+++ b/src/renderer/store/modules/settings.js
@@ -198,6 +198,7 @@ const state = {
   // Combinable triggers for automatically entering Picture-in-Picture: 'tab', 'minimize', 'blur'
   autoPictureInPictureTriggers: [],
   scrollMiniPlayerEnabled: true,
+  scrollMiniPlayerOnAllTabs: false,
   scrollMiniPlayerSavedRect: '',
   scrollbarThumbWidth: DEFAULT_SCROLLBAR_THUMB_WIDTH,
   avoidTranslation: 'disabled',

--- a/static/locales/de-DE.yaml
+++ b/static/locales/de-DE.yaml
@@ -726,6 +726,7 @@ Settings:
     Scroll Mini Player:
       Scroll Mini Player: Scroll mini player
       When Scrolling Down: Einen Mini Player auf dem Bildschirm anzeigen beim runterscrollen
+      On All Tabs: Mini-Player beim Wechseln zwischen Tabs auf dem Bildschirm behalten
     Remember Volume: Lautstärke beibehalten
     Customize Quick Playback Speed Bar: Schnelle Wiedergabegeschwindigkeitsleiste anpassen
     Quick Playback Speed Bar Manager: Schnelle Wiedergabegeschwindigkeitsleiste
@@ -1658,6 +1659,7 @@ Video:
     Autoplay is on: Automatische Wiedergabe ist eingeschaltet
     Scroll Mini Player:
       Back to Top: Zurück nach oben
+      Return to Video Tab: Zum Video-Tab zurückkehren
       Volume: Lautstärke
       Play: Abspielen
       Pause: Pausieren

--- a/static/locales/en-US.yaml
+++ b/static/locales/en-US.yaml
@@ -842,6 +842,7 @@ Settings:
     Scroll Mini Player:
       Scroll Mini Player: Scroll mini player
       When Scrolling Down: Keep a mini player on screen when scrolling down
+      On All Tabs: Keep a mini player on screen when switching tabs
     Scroll Volume Over Video Player: Scroll Volume Over Video Player
     Scroll Playback Rate Over Video Player: Scroll Playback Rate Over Video Player
     Skip by Scrolling Over Video Player: Skip by Scrolling Over Video Player
@@ -1883,6 +1884,7 @@ Video:
     Playback will resume automatically when your connection comes back: Playback will resume automatically when your connection comes back.
     Scroll Mini Player:
       Back to Top: Back to top
+      Return to Video Tab: Return to video tab
       Volume: Volume
       Play: Play
       Pause: Pause

--- a/tests/unit/cross-tab-mini-player.test.mjs
+++ b/tests/unit/cross-tab-mini-player.test.mjs
@@ -1,0 +1,58 @@
+import assert from 'node:assert/strict'
+import test from 'node:test'
+
+import {
+  isCrossTabMiniPlayerOwner,
+  markCrossTabMiniPlayerActive,
+  markCrossTabMiniPlayerInactive,
+  refreshCrossTabMiniPlayer,
+  unregisterCrossTabMiniPlayer,
+} from '../../src/renderer/helpers/crossTabMiniPlayer.js'
+
+function createCandidate () {
+  const calls = []
+  let canShow = true
+
+  return {
+    calls,
+    candidate: {
+      canShow: () => canShow,
+      hide: () => calls.push('hide'),
+      show: () => calls.push('show'),
+    },
+    setCanShow (value) {
+      canShow = value
+    },
+  }
+}
+
+test('only the most recently left video tab owns the cross-tab mini player', () => {
+  const first = createCandidate()
+  const second = createCandidate()
+
+  markCrossTabMiniPlayerInactive(first.candidate)
+  assert.equal(isCrossTabMiniPlayerOwner(first.candidate), true)
+  assert.deepEqual(first.calls, ['show'])
+
+  markCrossTabMiniPlayerInactive(second.candidate)
+  assert.equal(isCrossTabMiniPlayerOwner(first.candidate), false)
+  assert.equal(isCrossTabMiniPlayerOwner(second.candidate), true)
+  assert.deepEqual(first.calls, ['show', 'hide'])
+  assert.deepEqual(second.calls, ['show'])
+
+  second.setCanShow(false)
+  refreshCrossTabMiniPlayer(second.candidate)
+  assert.equal(isCrossTabMiniPlayerOwner(second.candidate), false)
+  assert.deepEqual(second.calls, ['show', 'hide'])
+
+  second.setCanShow(true)
+  refreshCrossTabMiniPlayer(second.candidate)
+  assert.equal(isCrossTabMiniPlayerOwner(second.candidate), true)
+  assert.deepEqual(second.calls, ['show', 'hide', 'show'])
+
+  markCrossTabMiniPlayerActive(second.candidate)
+  assert.equal(isCrossTabMiniPlayerOwner(second.candidate), false)
+
+  unregisterCrossTabMiniPlayer(first.candidate)
+  unregisterCrossTabMiniPlayer(second.candidate)
+})


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Make sure to follow the contributing guidelines. -->
<!-- Important note, we may remove your pull request if you do not use this provided PR template correctly. -->
<!-- Agent instructions: Preserve every heading, comment, and marker in this template. Never remove or rewrite the release-note-category:start/end, release-note:start/end, or release-note-image:start/end marker pairs. Never remove or rewrite the Release note images section; leave its contents for a human. -->

## Pull Request Type
<!-- Please select what type of pull request this is: [x] -->
- [ ] Bugfix
- [x] Feature Implementation
- [ ] Documentation
- [ ] Other

## Related issue
<!-- Please link the issue your pull request is referring to. -->
<!-- If this pull request fully resolves the relevant issue, put "closes" before the issue number. -->
<!-- Example: "closes #123456". -->

Closes #827

## Description
<!-- Please write a clear and concise description of what the pull request does. -->

Videos currently disappear when their tab is no longer active, even when the scroll mini player is enabled. This adds an Electron-only setting that keeps the latest video in the mini player while browsing other tabs.

The player stays attached to its source tab, keeps playing, and offers controls to return to that tab, pause playback, and change volume. Closing the source tab removes it. App menus and utility windows remain above the player.

Automatic Picture-in-Picture takes priority. The in-app mini player stays hidden while PiP is active, and enabling automatic PiP on tab changes disables the conflicting mini-player setting without clearing its saved value.

## Release note category
<!-- Select exactly one category. Every pull request must select one. -->
<!-- Select "Not noteworthy" when the pull request fixes a bug in or improves functionality that has not yet appeared in a stable release. -->
<!-- release-note-category:start -->
- [ ] Not noteworthy
- [ ] Highlights
- [x] More improvements
- [ ] Fixed bugs
<!-- release-note-category:end -->

## Release note
<!-- Required unless "Not noteworthy" is selected. -->
<!-- Write one concise, user-facing entry without a leading bullet. -->
<!-- release-note:start -->
Keep a mini player on screen while switching tabs.
<!-- release-note:end -->

## Release note images
<!-- Human-only: Agents must preserve this entire section and leave it empty. -->
<!-- Optional. Paste one or more Markdown images or HTML image tags here. -->
<!-- The release notes will use an HTML image tag and limit images taller than 300 pixels. -->
<!-- release-note-image:start -->

<picture>
  <source media="(prefers-color-scheme: dark)" srcset="https://github.com/OpenTubeX/media/releases/download/attachments/20260827T093432Z-937-cross-tab-mini-player-dark-dark-a5c2094e77.webp">
  <source media="(prefers-color-scheme: light)" srcset="https://github.com/OpenTubeX/media/releases/download/attachments/20260827T093432Z-937-cross-tab-mini-player-light-light-c891741308.webp">
  <img alt="Mini player across tabs" src="https://github.com/OpenTubeX/media/releases/download/attachments/20260827T093432Z-937-cross-tab-mini-player-dark-dark-a5c2094e77.webp">
</picture>

<!-- release-note-image:end -->

## Testing
<!-- How can reviewers verify that the PR produces correct results? -->
<!-- Please provide instructions so that others can ensure that your pull request would produce correct results. For examples see, https://github.com/FreeTubeApp/FreeTube/pull/5743, https://github.com/FreeTubeApp/FreeTube/pull/7349, https://github.com/FreeTubeApp/FreeTube/pull/5125, https://github.com/FreeTubeApp/FreeTube/pull/7338 -->
<!-- Agent instructions: Only write human-facing steps that explain how to verify the change while running this branch in dev mode. Include expected results and, when applicable, helpful console snippets for interactive verification. Do not include automated checks, commands, results, pass counts, or CI status. -->

1. Open Player settings and enable "Keep a mini player on screen when switching tabs."
2. Play a video, then switch to a new or existing tab. The video should continue in the bottom-right mini player.
3. Use the mini-player controls to pause, resume, change volume, and return to the source video tab.
4. While the mini player is visible, open Quick Settings, Settings, and Downloads. Each window should appear above the player.
5. Enable automatic Picture-in-Picture when switching tabs. The cross-tab mini-player setting should become disabled, and switching tabs should open PiP without showing the in-app mini player.
6. Disable automatic PiP on tab changes. The cross-tab mini-player setting should become available again with its previous value intact.
7. Close a video tab while its mini player is visible on another tab. The mini player should disappear.

## Additional context
<!-- Add any other context about the pull request here. -->

The setting is available in Electron builds and is off by default.


