### PR TITLE
feat(results): add optional channel avatars

### DIFF
--- a/e2e/tests/offline/video-result-avatars.spec.mjs
+++ b/e2e/tests/offline/video-result-avatars.spec.mjs
@@ -1,0 +1,178 @@
+import { test, expect, goTo, goToSettingsSection, sel } from '../../helpers/app.mjs'
+
+const CHANNEL_ID = 'UCaaaaaaaaaaaaaaaaaaaaaa'
+const AVATAR = 'data:image/svg+xml,<svg xmlns="http://www.w3.org/2000/svg" width="24" height="24"><rect width="24" height="24" fill="red"/></svg>'
+
+test.describe('subscription video avatars', () => {
+  test.use({
+    seed: {
+      settings: {
+        fetchSubscriptionsAutomatically: false,
+        listType: 'grid'
+      },
+      profiles: [{
+        _id: 'allChannels',
+        name: 'All Channels',
+        bgColor: '#000000',
+        textColor: '#FFFFFF',
+        subscriptions: [{ id: CHANNEL_ID, name: 'Channel A', thumbnail: AVATAR }]
+      }],
+      subscriptionCache: [{
+        _id: CHANNEL_ID,
+        videos: [{
+          type: 'video',
+          videoId: 'avatarfeed1',
+          title: 'Subscription avatar result',
+          author: 'Channel A',
+          authorId: CHANNEL_ID,
+          published: Date.now(),
+          viewCount: 1,
+          lengthSeconds: 60,
+          liveNow: false
+        }],
+        videosTimestamp: new Date().toISOString(),
+        shorts: [],
+        shortsTimestamp: new Date().toISOString(),
+        liveStreams: [],
+        liveStreamsTimestamp: new Date().toISOString(),
+        communityPosts: [],
+        communityPostsTimestamp: new Date().toISOString()
+      }]
+    }
+  })
+
+  test('uses the cached subscription thumbnail', async ({ page }) => {
+    await goTo(page, 'subscriptions')
+
+    const video = page.locator('.ft-list-video').filter({ hasText: 'Subscription avatar result' })
+    await expect(video.locator('.channelAvatarImage')).toHaveAttribute('src', AVATAR)
+  })
+})
+
+test.describe('Invidious search video avatars', () => {
+  const instanceUrl = 'https://invidious.test'
+  const avatarUrl = `${instanceUrl}/ggpht/channel-avatar`
+
+  test.use({
+    seed: {
+      settings: {
+        backendPreference: 'invidious',
+        defaultInvidiousInstance: instanceUrl,
+        generalAutoLoadMorePaginatedItemsEnabled: false,
+        listType: 'list',
+        uiScale: 125
+      }
+    }
+  })
+
+  test('shares one unknown channel lookup across video and playlist results', async ({ page }) => {
+    let channelRequests = 0
+
+    await page.route(`${instanceUrl}/api/v1/search/**`, route => route.fulfill({
+      json: [
+        invidiousVideo('avatar-search-1', 'First avatar search result'),
+        invidiousVideo('avatar-search-2', 'Second avatar search result'),
+        invidiousPlaylist()
+      ]
+    }))
+    await page.route(`${instanceUrl}/api/v1/channels/${CHANNEL_ID}?**`, route => {
+      channelRequests++
+      return route.fulfill({
+        json: {
+          author: 'Channel A',
+          authorThumbnails: [{ url: avatarUrl }],
+          tabs: []
+        }
+      })
+    })
+    await page.route(avatarUrl, route => route.fulfill({
+      body: '<svg xmlns="http://www.w3.org/2000/svg" width="24" height="24"><rect width="24" height="24" fill="red"/></svg>',
+      contentType: 'image/svg+xml'
+    }))
+
+    await page.locator(sel.searchInput).fill('avatar results')
+    await page.locator(sel.searchInput).press('Enter')
+
+    const avatars = page.locator('.ft-list-video .channelAvatarImage')
+    await expect(avatars).toHaveCount(3)
+    await expect(avatars.first()).toHaveAttribute('src', avatarUrl)
+    await expect.poll(() => avatars.evaluateAll(images => {
+      return images.every(image => image.complete && image.naturalWidth === 24)
+    })).toBe(true)
+    await expect(page.locator('.ft-list-video').filter({
+      has: page.getByRole('heading', { name: 'Avatar search playlist' })
+    }).locator('.channelAvatarImage')).toHaveAttribute('src', avatarUrl)
+    expect(channelRequests).toBe(1)
+  })
+
+  test('hides video and playlist avatars without fetching channel data', async ({ page }) => {
+    let channelRequests = 0
+
+    await page.route(`${instanceUrl}/api/v1/search/**`, route => route.fulfill({
+      json: [
+        invidiousVideo('avatar-search-hidden', 'Hidden avatar video'),
+        invidiousPlaylist()
+      ]
+    }))
+    await page.route(`${instanceUrl}/api/v1/channels/${CHANNEL_ID}?**`, route => {
+      channelRequests++
+      return route.fulfill({
+        json: {
+          author: 'Channel A',
+          authorThumbnails: [{ url: avatarUrl }],
+          tabs: []
+        }
+      })
+    })
+
+    const focusSettings = await goToSettingsSection(page, 'focus')
+    const hideAvatars = focusSettings.getByRole('checkbox', { name: 'Hide Channel Avatars' })
+    await focusSettings.locator('label.switch-label').filter({ hasText: 'Hide Channel Avatars' }).click()
+    await expect(hideAvatars).toBeChecked()
+    await page.locator('.settingsCloseButton').click()
+
+    await page.locator(sel.searchInput).fill('hidden avatar results')
+    await page.locator(sel.searchInput).press('Enter')
+
+    await expect(page.locator('.ft-list-video')).toHaveCount(2)
+    await expect(page.locator('.ft-list-video .channelAvatar')).toHaveCount(0)
+    expect(channelRequests).toBe(0)
+  })
+})
+
+function invidiousVideo(videoId, title) {
+  return {
+    type: 'video',
+    title,
+    videoId,
+    author: 'Channel A',
+    authorId: CHANNEL_ID,
+    authorUrl: `/channel/${CHANNEL_ID}`,
+    authorVerified: false,
+    videoThumbnails: [],
+    description: '',
+    descriptionHtml: '',
+    viewCount: 1,
+    published: Math.floor(Date.now() / 1000),
+    publishedText: 'now',
+    lengthSeconds: 60,
+    liveNow: false,
+    premium: false,
+    isUpcoming: false
+  }
+}
+
+function invidiousPlaylist() {
+  return {
+    type: 'playlist',
+    title: 'Avatar search playlist',
+    playlistId: 'PL-avatar-search',
+    playlistThumbnail: 'https://i.ytimg.com/vi/avatar-search-1/hqdefault.jpg',
+    author: 'Channel A',
+    authorId: CHANNEL_ID,
+    authorUrl: `/channel/${CHANNEL_ID}`,
+    authorVerified: false,
+    videoCount: 2,
+    videos: []
+  }
+}

--- a/src/renderer/components/DistractionSettings/DistractionSettings.vue
+++ b/src/renderer/components/DistractionSettings/DistractionSettings.vue
@@ -50,6 +50,13 @@
       </div>
       <div class="switchColumn">
         <FtToggleSwitch
+          :label="t('Settings.Distraction Free Settings.Hide Channel Avatars')"
+          :compact="true"
+          :default-value="hideChannelAvatars"
+          setting-key="hideChannelAvatars"
+          @change="updateHideChannelAvatars"
+        />
+        <FtToggleSwitch
           :label="t('Settings.Distraction Free Settings.Hide Live Streams')"
           :compact="true"
           :default-value="hideLiveStreams"
@@ -443,6 +450,16 @@ const hideVideoViews = computed(() => store.getters.getHideVideoViews)
  */
 function updateHideVideoViews(value) {
   store.dispatch('updateHideVideoViews', value)
+}
+
+/** @type {import('vue').ComputedRef<boolean>} */
+const hideChannelAvatars = computed(() => store.getters.getHideChannelAvatars)
+
+/**
+ * @param {boolean} value
+ */
+function updateHideChannelAvatars(value) {
+  store.dispatch('updateHideChannelAvatars', value)
 }
 
 /** @type {import('vue').ComputedRef<boolean>} */

--- a/src/renderer/components/FtChannelAvatar/FtChannelAvatar.css
+++ b/src/renderer/components/FtChannelAvatar/FtChannelAvatar.css
@@ -1,0 +1,23 @@
+.channelAvatar {
+  block-size: 24px;
+  color: var(--tertiary-text-color);
+  display: inline-grid;
+  flex: 0 0 24px;
+  inline-size: 24px;
+  place-items: center;
+}
+
+.channelAvatarImage,
+.channelAvatarFallback {
+  block-size: 24px;
+  border-radius: 50%;
+  inline-size: 24px;
+}
+
+.channelAvatarImage {
+  object-fit: cover;
+}
+
+.channelAvatarFallback {
+  font-size: 24px;
+}

--- a/src/renderer/components/FtChannelAvatar/FtChannelAvatar.vue
+++ b/src/renderer/components/FtChannelAvatar/FtChannelAvatar.vue
@@ -1,0 +1,43 @@
+<template>
+  <span
+    class="channelAvatar"
+    aria-hidden="true"
+  >
+    <img
+      v-if="thumbnail && !thumbnailLoadFailed"
+      class="channelAvatarImage"
+      :src="thumbnail"
+      alt=""
+      width="24"
+      height="24"
+      loading="lazy"
+      decoding="async"
+      @error="thumbnailLoadFailed = true"
+    >
+    <FtIcon
+      v-else
+      class="channelAvatarFallback"
+      :icon="['fas', 'circle-user']"
+    />
+  </span>
+</template>
+
+<script setup>
+import { FtIcon } from '@opentubex/icons'
+import { ref, watch } from 'vue'
+
+const props = defineProps({
+  thumbnail: {
+    type: String,
+    default: null
+  }
+})
+
+const thumbnailLoadFailed = ref(false)
+
+watch(() => props.thumbnail, () => {
+  thumbnailLoadFailed.value = false
+})
+</script>
+
+<style scoped src="./FtChannelAvatar.css" />

--- a/src/renderer/components/FtListPlaylist/FtListPlaylist.scss
+++ b/src/renderer/components/FtListPlaylist/FtListPlaylist.scss
@@ -4,6 +4,19 @@
   filter: blur(20px);
 }
 
+.channelName {
+  align-items: center;
+  display: inline-flex;
+  gap: 6px;
+  max-inline-size: 100%;
+  vertical-align: middle;
+}
+
+.channelNameText {
+  min-inline-size: 0;
+  overflow-wrap: anywhere;
+}
+
 .playlistButtonStack {
   align-items: flex-start;
   display: flex;

--- a/src/renderer/components/FtListPlaylist/FtListPlaylist.vue
+++ b/src/renderer/components/FtListPlaylist/FtListPlaylist.vue
@@ -52,13 +52,21 @@
           dir="auto"
           :to="`/channel/${channelId}`"
         >
-          {{ channelName }}
+          <FtChannelAvatar
+            v-if="showChannelAvatar"
+            :thumbnail="channelThumbnail"
+          />
+          <span class="channelNameText">{{ channelName }}</span>
         </RouterLink>
         <bdi
           v-else
           class="channelName"
         >
-          {{ channelName }}
+          <FtChannelAvatar
+            v-if="showChannelAvatar"
+            :thumbnail="channelThumbnail"
+          />
+          <span class="channelNameText">{{ channelName }}</span>
         </bdi>
       </div>
       <div class="buttonStack playlistButtonStack">
@@ -107,14 +115,16 @@
 
 <script setup>
 import { FtIcon } from '@opentubex/icons'
-import { computed, ref, watch } from 'vue'
+import { computed, ref, toRef, watch } from 'vue'
 import { useI18n } from 'vue-i18n'
 
+import FtChannelAvatar from '../FtChannelAvatar/FtChannelAvatar.vue'
 import FtIconButton from '../FtIconButton/FtIconButton.vue'
 import WatchVideoDownloadPrompt from '../WatchVideoDownloadPrompt/WatchVideoDownloadPrompt.vue'
 
 import store from '../../store/index'
 
+import { useResultChannelAvatar } from '../../composables/useResultChannelAvatar'
 import { showToast } from '../../helpers/utils'
 import thumbnailPlaceholder from '../../assets/img/thumbnail_placeholder.svg'
 
@@ -146,9 +156,9 @@ let playlistId = ''
 let title = ''
 /** @type {string} */
 let thumbnail = thumbnailPlaceholder
-/** @type {string | null} */
-let channelId = null
-let channelName = ''
+/** @type {import('vue').Ref<string | null>} */
+const channelId = ref(null)
+const channelName = ref('')
 let videoCount = 0
 
 /** @type {import('vue').ComputedRef<'grid' | 'list'>} */
@@ -208,8 +218,8 @@ function parseInvidiousData() {
     .replace('https://i.ytimg.com', currentInvidiousInstanceUrl.value)
     .replace('hqdefault', 'mqdefault')
 
-  channelName = props.data.author
-  channelId = props.data.authorId
+  channelName.value = props.data.author
+  channelId.value = props.data.authorId
   playlistId = props.data.playlistId
   videoCount = props.data.videoCount
 
@@ -223,8 +233,8 @@ function parseLocalData() {
 
   thumbnail = props.data.thumbnail
 
-  channelName = props.data.channelName
-  channelId = props.data.channelId
+  channelName.value = props.data.channelName
+  channelId.value = props.data.channelId
   playlistId = props.data.playlistId
   videoCount = props.data.videoCount
 }
@@ -240,11 +250,26 @@ function parseUserData() {
     thumbnail = `${origin}/vi/${props.data.videos[0].videoId}/mqdefault.jpg`
   }
 
-  channelName = ''
-  channelId = ''
+  channelName.value = ''
+  channelId.value = ''
   playlistId = props.data._id
   videoCount = props.data.videos.length
 }
+
+const showChannelAvatar = computed(() => (
+  !store.getters.getHideChannelAvatars &&
+  (props.appearance === 'result' || props.appearance === 'youtubeShort') &&
+  typeof channelName.value === 'string' &&
+  channelName.value !== '' &&
+  typeof channelId.value === 'string' &&
+  channelId.value !== ''
+))
+
+const { channelThumbnail } = useResultChannelAvatar(
+  toRef(props, 'data'),
+  channelId,
+  showChannelAvatar
+)
 
 /** @type {import('vue').ComputedRef<string | null>} */
 const quickBookmarkPlaylistId = computed(() => store.getters.getQuickBookmarkTargetPlaylistId)

--- a/src/renderer/components/FtListVideo/FtListVideo.scss
+++ b/src/renderer/components/FtListVideo/FtListVideo.scss
@@ -4,6 +4,19 @@
   outline: 3px solid var(--side-nav-hover-color);
 }
 
+.channelName {
+  align-items: center;
+  display: inline-flex;
+  gap: 6px;
+  max-inline-size: 100%;
+  vertical-align: middle;
+}
+
+.channelNameText {
+  min-inline-size: 0;
+  overflow-wrap: anywhere;
+}
+
 .grabBar {
   color: var(--tertiary-text-color);
   cursor: grab;

--- a/src/renderer/components/FtListVideo/FtListVideo.vue
+++ b/src/renderer/components/FtListVideo/FtListVideo.vue
@@ -210,7 +210,11 @@
           :disabled="isFetchingCollaborators"
           @click.stop.prevent="openChannelByline"
         >
-          {{ channelName }}
+          <FtChannelAvatar
+            v-if="showChannelAvatar"
+            :thumbnail="channelThumbnail"
+          />
+          <span class="channelNameText">{{ channelName }}</span>
         </button>
         <component
           :is="disableChannelLinks ? 'span' : 'router-link'"
@@ -220,10 +224,21 @@
           :to="`/channel/${channelId}`"
           @auxclick="handleChannelLinkClick"
         >
-          {{ channelName }}
+          <FtChannelAvatar
+            v-if="showChannelAvatar"
+            :thumbnail="channelThumbnail"
+          />
+          <span class="channelNameText">{{ channelName }}</span>
         </component>
-        <bdi v-else-if="channelName !== null">
-          {{ channelName }}
+        <bdi
+          v-else-if="channelName !== null"
+          class="channelName"
+        >
+          <FtChannelAvatar
+            v-if="showChannelAvatar"
+            :thumbnail="channelThumbnail"
+          />
+          <span class="channelNameText">{{ channelName }}</span>
         </bdi>
         <span
           v-if="!isLive && !isUpcoming && !isPremium && !hideViews && viewCount != null"
@@ -370,11 +385,12 @@
 
 <script setup>
 import { FtIcon } from '@opentubex/icons'
-import { computed, onBeforeUnmount, onMounted, ref, watch } from 'vue'
+import { computed, onBeforeUnmount, onMounted, ref, toRef, watch } from 'vue'
 import { useI18n } from 'vue-i18n'
 import { useRoute } from 'vue-router'
 
 import FtAddToPlaylistDropdown from '../FtAddToPlaylistDropdown/FtAddToPlaylistDropdown.vue'
+import FtChannelAvatar from '../FtChannelAvatar/FtChannelAvatar.vue'
 import FtCollaboratorsPrompt from '../FtCollaboratorsPrompt/FtCollaboratorsPrompt.vue'
 import FtEmbeddedProgress from '../FtEmbeddedProgress/FtEmbeddedProgress.vue'
 import FtIconButton from '../FtIconButton/FtIconButton.vue'
@@ -411,6 +427,7 @@ import {
 } from '../../helpers/viewTransitions.js'
 import { setCollaboratorsLoading } from './collaboratorsLoading.js'
 import { useRelativeTimeClock } from '../../composables/useRelativeTimeClock.js'
+import { useResultChannelAvatar } from '../../composables/useResultChannelAvatar.js'
 import thumbnailPlaceholder from '../../assets/img/thumbnail_placeholder.svg'
 
 const props = defineProps({
@@ -738,6 +755,19 @@ const backendPreference = computed(() => store.getters.getBackendPreference)
 
 /** @type {import('vue').ComputedRef<string>} */
 const currentInvidiousInstanceUrl = computed(() => store.getters.getCurrentInvidiousInstanceUrl)
+
+const showChannelAvatar = computed(() => (
+  !store.getters.getHideChannelAvatars &&
+  (props.appearance === 'result' || props.appearance === 'youtubeShort') &&
+  channelName.value !== null &&
+  channelId.value !== null
+))
+
+const { channelThumbnail } = useResultChannelAvatar(
+  toRef(props, 'data'),
+  channelId,
+  showChannelAvatar
+)
 
 const showPlaylists = computed(() => !store.getters.getHidePlaylists)
 const useSponsorBlock = computed(() => store.getters.getUseSponsorBlock)

--- a/src/renderer/composables/useResultChannelAvatar.js
+++ b/src/renderer/composables/useResultChannelAvatar.js
@@ -1,0 +1,73 @@
+import { onBeforeUnmount, ref, watch } from 'vue'
+
+import store from '../store/index'
+
+import { youtubeImageUrlToInvidious } from '../helpers/api/invidious'
+import { fetchChannelInfo, getCachedChannelInfo } from '../helpers/channel-preferences'
+import { getResultAuthorThumbnailUrl } from '../helpers/result-channel-avatar'
+
+/**
+ * Resolves the channel avatar for a video or playlist result.
+ * @param {import('vue').Ref<object>} result
+ * @param {import('vue').Ref<string | null>} channelId
+ * @param {import('vue').ComputedRef<boolean>} enabled
+ */
+export function useResultChannelAvatar(result, channelId, enabled) {
+  const channelThumbnail = ref(null)
+  let loadGeneration = 0
+
+  function normalizeThumbnail(url) {
+    if (typeof url !== 'string' || url === '') {
+      return null
+    }
+
+    const normalizedUrl = url.startsWith('//') ? `https:${url}` : url
+    return store.getters.getBackendPreference === 'invidious'
+      ? youtubeImageUrlToInvidious(normalizedUrl, store.getters.getCurrentInvidiousInstanceUrl)
+      : normalizedUrl
+  }
+
+  async function resolveThumbnail() {
+    const generation = ++loadGeneration
+    channelThumbnail.value = null
+
+    if (!enabled.value) {
+      return
+    }
+
+    const resolvingChannelId = channelId.value
+    const directThumbnail = getResultAuthorThumbnailUrl(result.value)
+    const cachedChannel = getCachedChannelInfo(
+      resolvingChannelId,
+      store.getters.getSubscribedChannelsById
+    )
+    const cachedThumbnail = normalizeThumbnail(
+      directThumbnail ?? cachedChannel?.thumbnail
+    )
+
+    if (cachedThumbnail !== null) {
+      channelThumbnail.value = cachedThumbnail
+      return
+    }
+
+    const resolvedChannel = await fetchChannelInfo(resolvingChannelId, {
+      preference: store.getters.getBackendPreference,
+      fallback: store.getters.getBackendFallback
+    })
+
+    if (
+      generation === loadGeneration &&
+      resolvingChannelId === channelId.value
+    ) {
+      channelThumbnail.value = normalizeThumbnail(resolvedChannel?.thumbnail)
+    }
+  }
+
+  watch([result, channelId, enabled], resolveThumbnail, { immediate: true })
+
+  onBeforeUnmount(() => {
+    loadGeneration++
+  })
+
+  return { channelThumbnail }
+}

--- a/src/renderer/helpers/api/local.js
+++ b/src/renderer/helpers/api/local.js
@@ -13,6 +13,7 @@ import { getLocalPremiereState } from '../premiere'
 import { shouldHideMembersOnlyContent } from '../restricted-playback'
 import { getThumbnailPreviewUrl } from '../thumbnailPreview'
 import { isCollaborativeVideoAuthor, parseLocalVideoChannels } from '../video-collaborators'
+import { getResultAuthorThumbnailUrl } from '../result-channel-avatar'
 import {
   CHANNEL_HANDLE_REGEX,
   calculatePublishedDate,
@@ -1583,6 +1584,7 @@ export function parseLocalListPlaylist(playlist, channelId = undefined, channelN
       playlistId: gridPlaylist.id,
       channelName: gridPlaylist.author?.name,
       channelId: gridPlaylist.author?.id,
+      authorThumbnailUrl: getResultAuthorThumbnailUrl(gridPlaylist),
       videoCount: extractNumberFromString(gridPlaylist.video_count.text)
     }
   } else {
@@ -1619,6 +1621,7 @@ export function parseLocalListPlaylist(playlist, channelId = undefined, channelN
       thumbnail: thumbnailRenderer ? thumbnailRenderer.thumbnail[0].url : playlist.thumbnails[0].url,
       channelName: internalChannelName,
       channelId: internalChannelId,
+      authorThumbnailUrl: getResultAuthorThumbnailUrl(playlist),
       playlistId: playlist.id,
       videoCount: extractNumberFromString(playlist.video_count.text)
     }
@@ -1966,6 +1969,7 @@ export function parseLocalListVideo(item, channelId, channelName) {
       title: video.title.text?.trim(),
       author: video.author.name !== 'N/A' ? video.author.name : channelName,
       authorId: video.author.id !== 'N/A' ? video.author.id : channelId,
+      authorThumbnailUrl: getResultAuthorThumbnailUrl(video),
       hasCollaborators: video.author.id === 'N/A' && isCollaborativeVideoAuthor(video.author.name),
       description: video.description,
       viewCount,

--- a/src/renderer/helpers/channel-preferences.js
+++ b/src/renderer/helpers/channel-preferences.js
@@ -63,6 +63,8 @@ export function parseChannelPreferences(value, settingKey) {
  * @type {Map<string, ChannelInfo>}
  */
 const resolvedChannels = new Map()
+/** @type {Map<string, Promise<ChannelInfo | null>>} */
+const pendingChannels = new Map()
 
 /**
  * Resolves a channel id to a name and avatar without a network request, if possible.
@@ -91,10 +93,25 @@ export async function fetchChannelInfo(channelId, backendOptions) {
     return resolvedChannels.get(channelId)
   }
 
+  if (pendingChannels.has(channelId)) {
+    return await pendingChannels.get(channelId)
+  }
+
   if (!checkYoutubeChannelId(channelId)) {
     return null
   }
 
+  const request = resolveChannelInfo(channelId, backendOptions)
+  pendingChannels.set(channelId, request)
+
+  try {
+    return await request
+  } finally {
+    pendingChannels.delete(channelId)
+  }
+}
+
+async function resolveChannelInfo(channelId, backendOptions) {
   try {
     const { preferredName, icon, invalidId } = await findChannelTagInfo(channelId, backendOptions)
 

--- a/src/renderer/helpers/result-channel-avatar.js
+++ b/src/renderer/helpers/result-channel-avatar.js
@@ -1,0 +1,16 @@
+/**
+ * Returns the channel avatar included with a normalized or local result.
+ * @param {object | null | undefined} result
+ * @returns {string | null}
+ */
+export function getResultAuthorThumbnailUrl(result) {
+  const url = result?.authorThumbnailUrl ??
+    result?.authorThumbnails?.at(-1)?.url ??
+    result?.author?.best_thumbnail?.url
+
+  if (typeof url !== 'string' || url === '') {
+    return null
+  }
+
+  return url.startsWith('//') ? `https:${url}` : url
+}

--- a/src/renderer/store/modules/settings.js
+++ b/src/renderer/store/modules/settings.js
@@ -276,6 +276,7 @@ const state = {
   ytDlpAutomaticDownloadRules: '{}',
   expandSideBar: false,
   hideActiveSubscriptions: false,
+  hideChannelAvatars: false,
   hideChannelCommunity: false,
   hideChannelHome: false,
   hideChannelPlaylists: false,

--- a/static/locales/de-DE.yaml
+++ b/static/locales/de-DE.yaml
@@ -969,6 +969,7 @@ Settings:
     Hide Comment Translation Buttons: Schaltflächen zum Übersetzen von Kommentaren ausblenden
     Hide Video Likes And Dislikes: Likes und Dislikes ausblenden
     Hide Video Views: Videoaufrufe ausblenden
+    Hide Channel Avatars: Kanalavatare ausblenden
     Distraction Free Settings: Ablenkungsfreier Modus
     Hide Active Subscriptions: Aktive Abos ausblenden
     Hide Playlists: Playlists ausblenden

--- a/static/locales/en-US.yaml
+++ b/static/locales/en-US.yaml
@@ -1209,6 +1209,7 @@ Settings:
       General: General
       Visible While Paused: Visible While Paused in Full Window / Full Screen
     Hide Video Views: Hide Video Views
+    Hide Channel Avatars: Hide Channel Avatars
     Shorten View Counts: Shorten View Counts
     Hide Video Likes And Dislikes: Hide Video Likes And Dislikes
     Hide Channel Subscribers: Hide Channel Subscribers

--- a/tests/unit/result-channel-avatar.test.mjs
+++ b/tests/unit/result-channel-avatar.test.mjs
@@ -1,0 +1,25 @@
+import assert from 'node:assert/strict'
+import test from 'node:test'
+
+import { getResultAuthorThumbnailUrl } from '../../src/renderer/helpers/result-channel-avatar.js'
+
+test('keeps the channel avatar from local video search results', () => {
+  const thumbnail = getResultAuthorThumbnailUrl({
+    author: {
+      best_thumbnail: { url: 'https://yt3.ggpht.com/channel-avatar=s88' }
+    }
+  })
+
+  assert.equal(thumbnail, 'https://yt3.ggpht.com/channel-avatar=s88')
+})
+
+test('uses the largest Invidious author thumbnail', () => {
+  const thumbnail = getResultAuthorThumbnailUrl({
+    authorThumbnails: [
+      { url: '//invidious.example/avatar-small' },
+      { url: '//invidious.example/avatar-large' }
+    ]
+  })
+
+  assert.equal(thumbnail, 'https://invidious.example/avatar-large')
+})


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Make sure to follow the contributing guidelines. -->
<!-- Important note, we may remove your pull request if you do not use this provided PR template correctly. -->
<!-- Agent instructions: Preserve every heading, comment, and marker in this template. Never remove or rewrite the release-note-category:start/end, release-note:start/end, or release-note-image:start/end marker pairs. Never remove or rewrite the Release note images section; leave its contents for a human. -->

## Pull Request Type
<!-- Please select what type of pull request this is: [x] -->
- [ ] Bugfix
- [x] Feature Implementation
- [ ] Documentation
- [ ] Other

## Related issue
<!-- Please link the issue your pull request is referring to. -->
<!-- If this pull request fully resolves the relevant issue, put "closes" before the issue number. -->
<!-- Example: "closes #123456". -->
FreeTubeApp/FreeTube#5211

## Description
<!-- Please write a clear and concise description of what the pull request does. -->
Video and playlist result cards only showed the channel name, which made creators harder to spot while scanning subscriptions and search results.

This adds a shared channel avatar beside the channel name on video and playlist results. It uses thumbnails already present in result or subscription data first, deduplicates fallback channel lookups, and adds a Distraction Free setting that hides avatars without fetching their channel data.

## Release note category
<!-- Select exactly one category. Every pull request must select one. -->
<!-- Select "Not noteworthy" when the pull request fixes a bug in or improves functionality that has not yet appeared in a stable release. -->
<!-- release-note-category:start -->
- [ ] Not noteworthy
- [ ] Highlights
- [x] More improvements
- [ ] Fixed bugs
<!-- release-note-category:end -->

## Release note
<!-- Required unless "Not noteworthy" is selected. -->
<!-- Write one concise, user-facing entry without a leading bullet. -->
<!-- release-note:start -->
Channel avatars now appear beside channel names in video and playlist results, with an option to hide them in Distraction Free settings.
<!-- release-note:end -->

## Release note images
<!-- Human-only: Agents must preserve this entire section and leave it empty. -->
<!-- Optional. Paste one or more Markdown images or HTML image tags here. -->
<!-- The release notes will use an HTML image tag and limit images taller than 300 pixels. -->
<!-- release-note-image:start -->

<picture>
  <source media="(prefers-color-scheme: dark)" srcset="https://github.com/OpenTubeX/media/releases/download/attachments/20260827T091534Z-938-channel-avatars-dark-dark-56df4bda9e.png">
  <source media="(prefers-color-scheme: light)" srcset="https://github.com/OpenTubeX/media/releases/download/attachments/20260827T091534Z-938-channel-avatars-light-light-3fa490d1b6.png">
  <img alt="Channel avatars in search results" src="https://github.com/OpenTubeX/media/releases/download/attachments/20260827T091534Z-938-channel-avatars-dark-dark-56df4bda9e.png">
</picture>

<!-- release-note-image:end -->

## Testing
<!-- How can reviewers verify that the PR produces correct results? -->
<!-- Please provide instructions so that others can ensure that your pull request would produce correct results. For examples see, https://github.com/FreeTubeApp/FreeTube/pull/5743, https://github.com/FreeTubeApp/FreeTube/pull/7349, https://github.com/FreeTubeApp/FreeTube/pull/5125, https://github.com/FreeTubeApp/FreeTube/pull/7338 -->
<!-- Agent instructions: Only write human-facing steps that explain how to verify the change while running this branch in dev mode. Include expected results and, when applicable, helpful console snippets for interactive verification. Do not include automated checks, commands, results, pass counts, or CI status. -->
1. Open the subscription feed and confirm each video result shows the channel avatar beside its channel name.
2. Search for a query that returns both videos and playlists. Confirm both result types show the correct channel avatar in grid and list layouts.
3. Open Distraction Free settings and enable "Hide Channel Avatars". Return to the subscription feed and search results, then confirm video and playlist avatars are hidden.
4. Disable the setting and confirm the avatars return.

## Additional context
<!-- Add any other context about the pull request here. -->
The fallback channel request is shared by concurrent results from the same channel. Enabling the hide setting also suppresses that request.

