### PR TITLE
feat(comments): add search, creator filtering, and personal pins

### DIFF
--- a/e2e/helpers/watch.mjs
+++ b/e2e/helpers/watch.mjs
@@ -68,6 +68,26 @@ function addOwnerReplyMarker(body) {
   throw new Error('Unable to add an owner-reply marker to the comment fixture')
 }
 
+function addCommentTimestamp(body) {
+  const response = JSON.parse(body)
+  const pending = [response]
+
+  while (pending.length > 0) {
+    const value = pending.pop()
+    if (!value || typeof value !== 'object') continue
+
+    const payload = value.commentEntityPayload
+    if (payload?.properties?.replyLevel === 0 && payload.properties.content?.content) {
+      payload.properties.content.content += ' Start at 0:05.'
+      return Buffer.from(JSON.stringify(response))
+    }
+
+    pending.push(...Object.values(value))
+  }
+
+  throw new Error('Unable to add a timestamp to the comment fixture')
+}
+
 /**
  * Serves the watch page for `jNQXAC9IVRw` from the committed Innertube
  * fixtures, without any network access.
@@ -86,13 +106,15 @@ function addOwnerReplyMarker(body) {
  * @param {string} [options.captionCueSettings] append WebVTT settings to the test caption cue
  * @param {string[]|null} [options.captionVideoIds] limit captions to these video IDs
  * @param {boolean} [options.ownerReply] mark the first reply thread as containing a video-owner reply
+ * @param {boolean} [options.commentTimestamp] add a timestamp to one top-level comment
  */
 export async function mockWatchPage(app, page, {
   playable = false,
   captionTranslations = false,
   captionCueSettings = '',
   captionVideoIds = null,
-  ownerReply = false
+  ownerReply = false,
+  commentTimestamp = false
 } = {}) {
   const counters = new Map()
   const includeCaptions = captionTranslations || captionCueSettings !== '' || captionVideoIds !== null
@@ -215,6 +237,9 @@ export async function mockWatchPage(app, page, {
       if (body) {
         if (ownerReply && body.includes('commentThreadRenderer')) {
           body = addOwnerReplyMarker(body)
+        }
+        if (commentTimestamp && body.includes('commentEntityPayload')) {
+          body = addCommentTimestamp(body)
         }
         return route.fulfill({ status: 200, contentType: 'application/json', body })
       }

--- a/e2e/tests/offline/watch-page.spec.mjs
+++ b/e2e/tests/offline/watch-page.spec.mjs
@@ -18,6 +18,34 @@ const WATCH_PAGE_SEED = {
 
 test.use({ seed: { settings: WATCH_PAGE_SEED } })
 
+test('offers a YouTube link action in the watch tab context menu', async ({ app, page }) => {
+  await mockPlayableWatchPage(app, page)
+  await openMockedVideo(page)
+
+  await page.locator('.tab.active').click({ button: 'right' })
+  await expect(page.getByRole('menuitem', { name: 'Copy YouTube Link', exact: true })).toBeVisible()
+})
+
+test('uses the stored watch route for a dev-server tab link action', async ({ app, page }) => {
+  const watchTab = await page.evaluate(() => window.ftElectron.tabs.create({
+    url: 'http://localhost:9080/#/watch/jNQXAC9IVRw',
+    title: 'Dev watch tab',
+    makeActive: false,
+    lazyLoad: true
+  }))
+
+  await expect.poll(async () => {
+    const state = await page.evaluate(() => window.ftElectron.tabs.getState())
+    return state.tabs.find(tab => tab.id === watchTab.id)?.route.fullPath
+  }).toBe('/watch/jNQXAC9IVRw')
+  await page.locator(`.tab[data-tab-id="${watchTab.id}"]`).click({ button: 'right' })
+  const copyYouTubeLink = page.getByRole('menuitem', { name: 'Copy YouTube Link', exact: true })
+  await expect(copyYouTubeLink).toBeVisible()
+  await copyYouTubeLink.click()
+  await expect.poll(() => app.electronApp.evaluate(({ clipboard }) => clipboard.readText()))
+    .toBe('https://youtu.be/jNQXAC9IVRw')
+})
+
 for (const { name, options, expectedCount } of [
   { name: 'hides transcript actions without captions', options: {}, expectedCount: 0 },
   {
@@ -3006,6 +3034,65 @@ test('loads initial comments with the video when automatic pagination is enabled
   expect(await page.evaluate(() => window.scrollY)).toBe(0)
 })
 
+test('pauses automatic comment pagination while filtering', async ({ app, page }) => {
+  await mockPlayableWatchPage(app, page)
+
+  let commentRequestCount = 0
+  await page.route(/\/youtubei\/v1\/next/, async (route, request) => {
+    const body = JSON.parse(request.postData() ?? '{}')
+    if (body.continuation) {
+      commentRequestCount++
+    }
+    await route.fallback()
+  })
+
+  await page.evaluate(() => {
+    const store = document.querySelector('#app').__vue_app__.config.globalProperties.$store
+    store.commit('setGeneralAutoLoadMorePaginatedItemsEnabled', true)
+  })
+  await openMockedVideo(page)
+  await expect(page.locator('.commentsTitle')).toBeVisible({ timeout: 30_000 })
+
+  await page.getByRole('button', { name: 'From creator' }).click()
+  const requestCountAfterFiltering = commentRequestCount
+
+  await page.waitForTimeout(750)
+  expect(commentRequestCount).toBe(requestCountAfterFiltering)
+  await expect(page.locator('.getMoreComments')).toBeVisible()
+})
+
+async function expectCommentHeaderToolsAligned(page) {
+  const commentHeaderActions = [
+    page.getByRole('button', { name: 'Search loaded comments' }),
+    page.getByRole('button', { name: 'From creator' }),
+    page.getByRole('button', { name: 'Reload Comments' })
+  ]
+  const actionCenters = await Promise.all(commentHeaderActions.map(action => (
+    action.evaluate(element => {
+      const bounds = element.getBoundingClientRect()
+      return bounds.top + bounds.height / 2
+    })
+  )))
+  expect(Math.max(...actionCenters) - Math.min(...actionCenters)).toBeLessThanOrEqual(1)
+
+  const actionRightEdges = await Promise.all(commentHeaderActions.map(action => (
+    action.evaluate(element => element.getBoundingClientRect().right)
+  )))
+  const sortControlLeft = await page.locator('.commentHeaderActions .select').evaluate(element => {
+    return element.getBoundingClientRect().left
+  })
+  expect(Math.max(...actionRightEdges)).toBeLessThan(sortControlLeft)
+
+  const commentHeaderBottom = await page.locator('.commentHeader').evaluate(element => {
+    const bounds = element.getBoundingClientRect()
+    return bounds.bottom
+  })
+  const searchInputTop = await page.getByRole('searchbox', { name: 'Search loaded comments' }).evaluate(element => {
+    return element.getBoundingClientRect().top
+  })
+  expect(searchInputTop - commentHeaderBottom).toBeGreaterThanOrEqual(7.5)
+}
+
 test.describe('manual comment loading', () => {
   // These drive the click-to-load path and the reply pagination on top of a
   // single loaded page, so they turn off the automatic pagination that would
@@ -3149,6 +3236,174 @@ test.describe('manual comment loading', () => {
     await expect(ownerReplyToggle).not.toContainText('from')
     await ownerReplyToggle.scrollIntoViewIfNeeded()
     await attachScreenshot('uploader reply indicator')
+  })
+
+  test('searches the comments loaded for the current video', async ({ app, page }) => {
+    await mockPlayableWatchPage(app, page)
+    await openMockedVideo(page)
+
+    const loadComments = page.locator('.getCommentsTitle')
+    await loadComments.scrollIntoViewIfNeeded()
+    await loadComments.click()
+    await expect(page.locator('.commentsTitle')).toBeVisible({ timeout: 30_000 })
+
+    const comments = page.locator('.commentThread')
+    const initialCommentCount = await comments.count()
+    expect(initialCommentCount).toBeGreaterThan(1)
+
+    await expect(page.getByRole('searchbox', { name: 'Search loaded comments' })).toHaveCount(0)
+    await page.getByRole('button', { name: 'Search loaded comments' }).click()
+    const commentSearchInput = page.getByRole('searchbox', { name: 'Search loaded comments' })
+    await expect(commentSearchInput).toBeFocused()
+    await expect(page.locator('.commentTools .clearInputTextButton')).toHaveCount(0)
+    await expectCommentHeaderToolsAligned(page)
+    await commentSearchInput.fill('honored')
+
+    const searchCancelButtonStyles = await page.evaluate(() => {
+      const rules = [...document.styleSheets].flatMap(sheet => [...sheet.cssRules])
+      const baseRule = rules.find(rule => (
+        rule.selectorText?.includes('input[type="search"]::-webkit-search-cancel-button') &&
+        !rule.selectorText.includes(':hover') &&
+        !rule.selectorText.includes(':active')
+      ))
+      const hoverRule = rules.find(rule => rule.selectorText?.includes('::-webkit-search-cancel-button:hover'))
+
+      return {
+        appearance: baseRule?.style.getPropertyValue('-webkit-appearance'),
+        backgroundColor: baseRule?.style.backgroundColor,
+        blockSize: baseRule?.style.blockSize,
+        hoverBackgroundColor: hoverRule?.style.backgroundColor,
+        inlineSize: baseRule?.style.inlineSize,
+        maskSize: baseRule?.style.maskSize
+      }
+    })
+    expect(searchCancelButtonStyles).toEqual({
+      appearance: 'none',
+      backgroundColor: 'var(--secondary-text-color)',
+      blockSize: '24px',
+      hoverBackgroundColor: 'var(--primary-color)',
+      inlineSize: '24px',
+      maskSize: '12px 12px',
+    })
+
+    await expect(comments).toHaveCount(1)
+    await expect(comments).toContainText("We're so honored that the first ever YouTube video was filmed here!")
+    await expect(comments.locator('.commentText mark')).toHaveText('honored')
+    await expect(page.getByText(`1 of ${initialCommentCount} loaded comments`)).toBeVisible()
+
+    await commentSearchInput.fill('WahilPro')
+    await expect(comments).toHaveCount(1)
+    await expect(comments.locator('.commentAuthor mark')).toHaveText('WahilPro')
+  })
+
+  test('keeps personal comment pins for the current video', async ({ app, page }) => {
+    await mockPlayableWatchPage(app, page)
+    await openMockedVideo(page)
+
+    const loadComments = page.locator('.getCommentsTitle')
+    await loadComments.scrollIntoViewIfNeeded()
+    await loadComments.click()
+    await expect(page.locator('.commentsTitle')).toBeVisible({ timeout: 30_000 })
+
+    const pinnedComment = page.locator('.commentThread').filter({ hasText: 'Who is here today?' })
+    await pinnedComment.getByRole('button', { name: 'Pin comment by @WahilPro' }).click()
+    await expect(pinnedComment).toContainText('Pinned by you')
+    await expect(pinnedComment.getByRole('button', { name: 'Unpin comment by @WahilPro' })).toHaveAttribute('aria-pressed', 'true')
+    await expect(pinnedComment).toHaveCSS('background-color', 'rgba(0, 0, 0, 0)')
+    await expect(pinnedComment.locator('.commentPersonalPin')).not.toHaveCSS('background-color', 'rgba(0, 0, 0, 0)')
+    await expect(page.locator('.commentThread').first()).toContainText('Who is here today?')
+
+    const reloadResponse = page.waitForResponse(/\/youtubei\/v1\/next/, { timeout: 30_000 })
+    await page.getByRole('button', { name: 'Reload Comments' }).click()
+    await reloadResponse
+
+    await expect(page.locator('.commentThread').first()).toContainText('Who is here today?')
+    await expect(page.locator('.commentThread').first()).toContainText('Pinned by you')
+  })
+
+  test('filters loaded comments to the video creator', async ({ app, page }) => {
+    await mockPlayableWatchPage(app, page)
+    await openMockedVideo(page)
+
+    const loadComments = page.locator('.getCommentsTitle')
+    await loadComments.scrollIntoViewIfNeeded()
+    await loadComments.click()
+    await expect(page.locator('.commentsTitle')).toBeVisible({ timeout: 30_000 })
+
+    const creatorFilter = page.getByRole('button', { name: 'From creator' })
+    await expect(creatorFilter.locator('.commentCreatorFilterAvatar')).toHaveAttribute('src', /.+/)
+    await creatorFilter.click()
+
+    await expect(page.locator('.commentThread')).toHaveCount(1)
+    await expect(page.locator('.commentThread')).toContainText('@jawed')
+    await expect(page.locator('.commentThread')).toContainText('Hello')
+  })
+
+  test('applies the shortened view count setting to comment likes', async ({ app, page }) => {
+    await mockPlayableWatchPage(app, page)
+    await openMockedVideo(page)
+
+    const loadComments = page.locator('.getCommentsTitle')
+    await loadComments.scrollIntoViewIfNeeded()
+    await loadComments.click()
+    await expect(page.locator('.commentsTitle')).toBeVisible({ timeout: 30_000 })
+
+    const commentLikes = page.locator('.commentThread')
+      .filter({ hasText: "We're so honored" })
+      .locator('.commentLikeCount')
+    await expect(commentLikes).toContainText(/4\.6\s?m/i)
+
+    await page.evaluate(() => {
+      const store = document.querySelector('#app').__vue_app__.config.globalProperties.$store
+      return store.dispatch('updateShortenViewCounts', false)
+    })
+    await expect(commentLikes).toContainText('4,600,000')
+  })
+
+  test.describe('comment filtering at 125% UI scale', () => {
+    test.use({
+      seed: {
+        settings: {
+          ...WATCH_PAGE_SEED,
+          generalAutoLoadMorePaginatedItemsEnabled: false,
+          uiScale: 125
+        }
+      }
+    })
+
+    test('clamps fullscreen comment scrolling after filtering', async ({ app, page }) => {
+      await mockPlayableWatchPage(app, page)
+      await openMockedVideo(page)
+
+      const loadComments = page.locator('.getCommentsTitle')
+      await loadComments.scrollIntoViewIfNeeded()
+      await loadComments.click()
+      await expect(page.locator('.commentsTitle')).toBeVisible({ timeout: 30_000 })
+
+      await page.getByRole('button', { name: 'Search loaded comments' }).click()
+      await expectCommentHeaderToolsAligned(page)
+      await page.getByRole('button', { name: 'Search loaded comments' }).click()
+
+      await setPlayerFullscreen(page, true)
+      await page.locator('.fullscreenCommentsToggle').click({ force: true })
+
+      const dock = page.locator('.fullscreenCommentsOverlay.open')
+      const scroller = dock.locator('.commentsContentWrapper')
+      const scrollbar = scroller.locator(':scope > .os-scrollbar-vertical')
+      await expect(dock.getByRole('button', { name: 'From creator' }).locator('.commentCreatorFilterAvatar')).toHaveAttribute('src', /.+/)
+      await expect.poll(() => scroller.evaluate(element => element.scrollHeight > element.clientHeight)).toBe(true)
+      await expect(scrollbar).not.toHaveClass(/os-scrollbar-unusable/)
+
+      await scroller.evaluate(element => { element.scrollTop = element.scrollHeight })
+      await expect.poll(() => scroller.evaluate(element => element.scrollTop)).toBeGreaterThan(0)
+
+      await dock.getByRole('button', { name: 'Search loaded comments' }).click()
+      await dock.getByRole('searchbox', { name: 'Search loaded comments' }).fill('honored')
+
+      await expect(dock.locator('.commentThread')).toHaveCount(1)
+      await expect.poll(() => scroller.evaluate(element => element.scrollTop)).toBe(0)
+      await expect(scrollbar).toHaveClass(/os-scrollbar-unusable/)
+    })
   })
 
   test('stale reply controls disappear after an empty final reply page', async ({ app, page }) => {

--- a/e2e/tests/offline/watch-page.spec.mjs
+++ b/e2e/tests/offline/watch-page.spec.mjs
@@ -3053,7 +3053,8 @@ test('pauses automatic comment pagination while filtering', async ({ app, page }
   await openMockedVideo(page)
   await expect(page.locator('.commentsTitle')).toBeVisible({ timeout: 30_000 })
 
-  await page.getByRole('button', { name: 'From creator' }).click()
+  await page.getByRole('button', { name: 'Filter loaded comments' }).click()
+  await page.getByRole('checkbox', { name: 'From creator' }).click()
   const requestCountAfterFiltering = commentRequestCount
 
   await page.waitForTimeout(750)
@@ -3063,8 +3064,7 @@ test('pauses automatic comment pagination while filtering', async ({ app, page }
 
 async function expectCommentHeaderToolsAligned(page) {
   const commentHeaderActions = [
-    page.getByRole('button', { name: 'Search loaded comments' }),
-    page.getByRole('button', { name: 'From creator' }),
+    page.getByRole('button', { name: 'Filter loaded comments' }),
     page.getByRole('button', { name: 'Reload Comments' })
   ]
   const actionCenters = await Promise.all(commentHeaderActions.map(action => (
@@ -3252,7 +3252,10 @@ test.describe('manual comment loading', () => {
     expect(initialCommentCount).toBeGreaterThan(1)
 
     await expect(page.getByRole('searchbox', { name: 'Search loaded comments' })).toHaveCount(0)
-    await page.getByRole('button', { name: 'Search loaded comments' }).click()
+    await page.getByRole('button', { name: 'Filter loaded comments' }).click()
+    const searchFilter = page.getByRole('checkbox', { name: 'Search loaded comments' })
+    await expect(searchFilter).toBeFocused()
+    await searchFilter.click()
     const commentSearchInput = page.getByRole('searchbox', { name: 'Search loaded comments' })
     await expect(commentSearchInput).toBeFocused()
     await expect(page.locator('.commentTools .clearInputTextButton')).toHaveCount(0)
@@ -3296,6 +3299,58 @@ test.describe('manual comment loading', () => {
     await expect(comments.locator('.commentAuthor mark')).toHaveText('WahilPro')
   })
 
+  test('searches loaded replies and keeps their parent thread', async ({ app, page }) => {
+    await mockPlayableWatchPage(app, page)
+    await openMockedVideo(page)
+
+    const loadComments = page.locator('.getCommentsTitle')
+    await loadComments.scrollIntoViewIfNeeded()
+    await loadComments.click()
+    await expect(page.locator('.commentsTitle')).toBeVisible({ timeout: 30_000 })
+
+    const thread = page.locator('.commentThread').first()
+    await thread.locator('.commentReplyRootToggle button').click()
+    const firstReply = thread.locator('.commentReplyContent').first()
+    await expect(firstReply).toBeVisible({ timeout: 30_000 })
+    const replyAuthor = await firstReply.locator('.commentAuthor').innerText()
+
+    await page.getByRole('button', { name: 'Filter loaded comments' }).click()
+    await page.getByRole('checkbox', { name: 'Search loaded comments' }).click()
+    await page.getByRole('searchbox', { name: 'Search loaded comments' }).fill(replyAuthor)
+
+    await expect(page.locator('.commentThread')).toHaveCount(1)
+    await expect(page.locator('.commentReplyContent')).toHaveCount(1)
+    await expect(page.locator('.commentReplyContent .commentAuthor mark')).toHaveText(replyAuthor)
+  })
+
+  test('filters comments with timestamps and keeps highlighted timestamps clickable', async ({ app, page }) => {
+    await mockPlayableWatchPage(app, page, { commentTimestamp: true })
+    await openMockedVideo(page)
+
+    const loadComments = page.locator('.getCommentsTitle')
+    await loadComments.scrollIntoViewIfNeeded()
+    await loadComments.click()
+    await expect(page.locator('.commentsTitle')).toBeVisible({ timeout: 30_000 })
+
+    await page.getByRole('button', { name: 'Filter loaded comments' }).click()
+    await page.getByRole('checkbox', { name: 'Contains timestamps' }).click()
+    await expect(page.locator('.commentThread')).toHaveCount(1)
+
+    await page.getByRole('checkbox', { name: 'Search loaded comments' }).click()
+    const search = page.getByRole('searchbox', { name: 'Search loaded comments' })
+    await search.fill('0:05')
+    const timestamp = page.locator('.commentThread .commentText a[data-time="5"]')
+    await expect(timestamp.locator('mark')).toHaveText('0:05')
+
+    const video = page.locator('video')
+    await video.evaluate(element => {
+      element.pause()
+      element.currentTime = 0
+    })
+    await timestamp.locator('mark').click()
+    await expect.poll(() => video.evaluate(element => element.currentTime)).toBeCloseTo(5, 1)
+  })
+
   test('keeps personal comment pins for the current video', async ({ app, page }) => {
     await mockPlayableWatchPage(app, page)
     await openMockedVideo(page)
@@ -3321,6 +3376,34 @@ test.describe('manual comment loading', () => {
     await expect(page.locator('.commentThread').first()).toContainText('Pinned by you')
   })
 
+  test('keeps personal pins on loaded replies', async ({ app, page }) => {
+    await mockPlayableWatchPage(app, page)
+    await openMockedVideo(page)
+
+    const loadComments = page.locator('.getCommentsTitle')
+    await loadComments.scrollIntoViewIfNeeded()
+    await loadComments.click()
+    await expect(page.locator('.commentsTitle')).toBeVisible({ timeout: 30_000 })
+
+    let thread = page.locator('.commentThread').first()
+    await thread.locator('.commentReplyRootToggle button').click()
+    let firstReply = thread.locator('.commentReplyContent').first()
+    await expect(firstReply).toBeVisible({ timeout: 30_000 })
+    const replyAuthor = await firstReply.locator('.commentAuthor').innerText()
+    await firstReply.getByRole('button', { name: `Pin comment by ${replyAuthor}` }).click()
+    await expect(firstReply).toContainText('Pinned by you')
+
+    const reloadResponse = page.waitForResponse(/\/youtubei\/v1\/next/, { timeout: 30_000 })
+    await page.getByRole('button', { name: 'Reload Comments' }).click()
+    await reloadResponse
+
+    thread = page.locator('.commentThread').first()
+    await thread.locator('.commentReplyRootToggle button').click()
+    firstReply = thread.locator('.commentReplyContent').filter({ hasText: replyAuthor })
+    await expect(firstReply.getByRole('button', { name: `Unpin comment by ${replyAuthor}` })).toHaveAttribute('aria-pressed', 'true')
+    await expect(firstReply).toContainText('Pinned by you')
+  })
+
   test('filters loaded comments to the video creator', async ({ app, page }) => {
     await mockPlayableWatchPage(app, page)
     await openMockedVideo(page)
@@ -3330,7 +3413,8 @@ test.describe('manual comment loading', () => {
     await loadComments.click()
     await expect(page.locator('.commentsTitle')).toBeVisible({ timeout: 30_000 })
 
-    const creatorFilter = page.getByRole('button', { name: 'From creator' })
+    await page.getByRole('button', { name: 'Filter loaded comments' }).click()
+    const creatorFilter = page.getByRole('checkbox', { name: 'From creator' })
     await expect(creatorFilter.locator('.commentCreatorFilterAvatar')).toHaveAttribute('src', /.+/)
     await creatorFilter.click()
 
@@ -3380,9 +3464,10 @@ test.describe('manual comment loading', () => {
       await loadComments.click()
       await expect(page.locator('.commentsTitle')).toBeVisible({ timeout: 30_000 })
 
-      await page.getByRole('button', { name: 'Search loaded comments' }).click()
+      await page.getByRole('button', { name: 'Filter loaded comments' }).click()
+      await page.getByRole('checkbox', { name: 'Search loaded comments' }).click()
       await expectCommentHeaderToolsAligned(page)
-      await page.getByRole('button', { name: 'Search loaded comments' }).click()
+      await page.getByRole('searchbox', { name: 'Search loaded comments' }).press('Escape')
 
       await setPlayerFullscreen(page, true)
       await page.locator('.fullscreenCommentsToggle').click({ force: true })
@@ -3390,14 +3475,17 @@ test.describe('manual comment loading', () => {
       const dock = page.locator('.fullscreenCommentsOverlay.open')
       const scroller = dock.locator('.commentsContentWrapper')
       const scrollbar = scroller.locator(':scope > .os-scrollbar-vertical')
-      await expect(dock.getByRole('button', { name: 'From creator' }).locator('.commentCreatorFilterAvatar')).toHaveAttribute('src', /.+/)
+      await dock.getByRole('button', { name: 'Filter loaded comments' }).click()
+      await expect(dock.getByRole('checkbox', { name: 'From creator' }).locator('.commentCreatorFilterAvatar')).toHaveAttribute('src', /.+/)
+      await dock.getByRole('button', { name: 'Filter loaded comments' }).click()
       await expect.poll(() => scroller.evaluate(element => element.scrollHeight > element.clientHeight)).toBe(true)
       await expect(scrollbar).not.toHaveClass(/os-scrollbar-unusable/)
 
       await scroller.evaluate(element => { element.scrollTop = element.scrollHeight })
       await expect.poll(() => scroller.evaluate(element => element.scrollTop)).toBeGreaterThan(0)
 
-      await dock.getByRole('button', { name: 'Search loaded comments' }).click()
+      await dock.getByRole('button', { name: 'Filter loaded comments' }).click()
+      await dock.getByRole('checkbox', { name: 'Search loaded comments' }).click()
       await dock.getByRole('searchbox', { name: 'Search loaded comments' }).fill('honored')
 
       await expect(dock.locator('.commentThread')).toHaveCount(1)

--- a/src/main/index.js
+++ b/src/main/index.js
@@ -791,7 +791,7 @@ function runApp() {
         all: 'Reload All Feeds'
       }
       const contextMenuTabYouTubeUrls = contextMenuTabs.map(tab => {
-        const route = getOpenTubeXRouteFromUrl(tab.url)
+        const route = tab.route?.fullPath ?? getOpenTubeXRouteFromUrl(tab.url)
         return isShareableOpenTubeXRoute(route)
           ? transformOpenTubeXRouteUrl(route, true)
           : null

--- a/src/renderer/components/CommentSection/CommentFilterMenu.vue
+++ b/src/renderer/components/CommentSection/CommentFilterMenu.vue
@@ -1,0 +1,173 @@
+<template>
+  <div
+    class="commentFilterMenuAnchor"
+    :class="{ commentHeaderIconActionAligned: aligned }"
+    @focusout="handleFocusout"
+    @keydown.esc.stop.prevent="closeAndFocusTrigger"
+  >
+    <button
+      ref="trigger"
+      type="button"
+      :class="[
+        fullscreen ? 'fullscreenCommentAction' : 'commentHeaderIconAction',
+        { active: hasActiveFilters }
+      ]"
+      :aria-label="$t('Comments.Filter loaded comments')"
+      :title="$t('Comments.Filter loaded comments')"
+      aria-haspopup="dialog"
+      :aria-expanded="String(open)"
+      @click="emit('update:open', !open)"
+    >
+      <FtIcon :icon="['fas', 'filter']" />
+    </button>
+    <div
+      v-if="open"
+      ref="menu"
+      class="commentFilterMenu"
+      :class="{ fullscreenCommentFilterMenu: fullscreen }"
+      role="dialog"
+      :aria-label="$t('Comments.Comment filters')"
+    >
+      <button
+        type="button"
+        role="checkbox"
+        :aria-checked="searchOpen"
+        @click="emit('toggle-search')"
+      >
+        <span
+          class="commentFilterMenuIcon"
+          aria-hidden="true"
+        >
+          <FtIcon :icon="['fas', 'magnifying-glass']" />
+        </span>
+        <span>{{ $t('Comments.Search loaded comments') }}</span>
+        <FtIcon
+          v-if="searchOpen"
+          :icon="['fas', 'check']"
+          aria-hidden="true"
+        />
+      </button>
+      <button
+        type="button"
+        role="checkbox"
+        :aria-checked="creatorCommentsOnly"
+        @click="emit('toggle-creator')"
+      >
+        <span
+          class="commentFilterMenuIcon"
+          aria-hidden="true"
+        >
+          <FtRetryImage
+            v-if="channelThumbnail"
+            :src="channelThumbnail"
+            class="commentCreatorFilterAvatar"
+          />
+          <FtIcon
+            v-else
+            :icon="['fas', 'circle-user']"
+          />
+        </span>
+        <span>{{ $t('Comments.From creator') }}</span>
+        <FtIcon
+          v-if="creatorCommentsOnly"
+          :icon="['fas', 'check']"
+          aria-hidden="true"
+        />
+      </button>
+      <button
+        type="button"
+        role="checkbox"
+        :aria-checked="timestampCommentsOnly"
+        @click="emit('toggle-timestamps')"
+      >
+        <span
+          class="commentFilterMenuIcon"
+          aria-hidden="true"
+        >
+          <FtIcon :icon="['fas', 'clock']" />
+        </span>
+        <span>{{ $t('Comments.Contains timestamps') }}</span>
+        <FtIcon
+          v-if="timestampCommentsOnly"
+          :icon="['fas', 'check']"
+          aria-hidden="true"
+        />
+      </button>
+    </div>
+  </div>
+</template>
+
+<script setup>
+import { FtIcon } from '@opentubex/icons'
+import { computed, nextTick, useTemplateRef, watch } from 'vue'
+
+import FtRetryImage from '../FtRetryImage.vue'
+
+const props = defineProps({
+  open: {
+    type: Boolean,
+    required: true
+  },
+  fullscreen: {
+    type: Boolean,
+    default: false
+  },
+  aligned: {
+    type: Boolean,
+    default: false
+  },
+  channelThumbnail: {
+    type: String,
+    default: ''
+  },
+  creatorCommentsOnly: {
+    type: Boolean,
+    required: true
+  },
+  timestampCommentsOnly: {
+    type: Boolean,
+    required: true
+  },
+  searchOpen: {
+    type: Boolean,
+    required: true
+  }
+})
+
+const trigger = useTemplateRef('trigger')
+const menu = useTemplateRef('menu')
+const hasActiveFilters = computed(() => {
+  return props.searchOpen || props.creatorCommentsOnly || props.timestampCommentsOnly
+})
+const emit = defineEmits([
+  'update:open',
+  'toggle-search',
+  'toggle-creator',
+  'toggle-timestamps'
+])
+
+watch(() => props.open, (open) => {
+  if (open) {
+    nextTick(() => menu.value?.querySelector('button')?.focus())
+  }
+})
+
+function handleFocusout(event) {
+  if (!event.currentTarget.contains(event.relatedTarget)) {
+    emit('update:open', false)
+  }
+}
+
+function closeAndFocusTrigger() {
+  emit('update:open', false)
+  nextTick(() => trigger.value?.focus())
+}
+
+function focusTrigger() {
+  trigger.value?.focus()
+}
+
+defineExpose({ focusTrigger })
+</script>
+
+<style scoped src="./CommentSection.css" />

--- a/src/renderer/components/CommentSection/CommentReply.vue
+++ b/src/renderer/components/CommentSection/CommentReply.vue
@@ -44,6 +44,16 @@
           class="commentThumbnail"
         />
       </component>
+      <p
+        v-if="isPersonallyPinned"
+        class="commentPinned commentPersonalPin"
+      >
+        <FtIcon
+          :icon="['fas', 'thumbtack']"
+          aria-hidden="true"
+        />
+        {{ $t('Comments.Pinned by you') }}
+      </p>
       <p class="commentAuthorWrapper">
         <component
           :is="enableChannelLinks ? 'router-link' : 'span'"
@@ -52,7 +62,15 @@
           :class="{ commentOwner: reply.isOwner }"
           :to="`/channel/${reply.authorLink}`"
         >
-          {{ reply.author }}
+          <template
+            v-for="(segment, segmentIndex) in authorSearchSegments"
+            :key="segmentIndex"
+          >
+            <mark v-if="segment.highlighted">{{ segment.text }}</mark>
+            <template v-else>
+              {{ segment.text }}
+            </template>
+          </template>
         </component>
         <img
           v-if="reply.isMember"
@@ -75,6 +93,19 @@
         </span>
         <button
           type="button"
+          class="commentPinButton"
+          :class="{ active: isPersonallyPinned }"
+          :title="personalPinActionLabel"
+          :aria-label="personalPinActionLabel"
+          :aria-pressed="isPersonallyPinned"
+          @click="emit('toggle-personal-pin', reply.id)"
+        >
+          <FtIcon
+            :icon="['fas', isPersonallyPinned ? 'thumbtack-slash' : 'thumbtack']"
+          />
+        </button>
+        <button
+          type="button"
           class="commentCopyLink"
           :title="$t('Comments.Copy YouTube Link')"
           :aria-label="$t('Comments.Copy YouTube Link')"
@@ -88,6 +119,7 @@
         :input-html="reply.showTranslated && reply.translatedLanguage === translationLanguage
           ? reply.translatedText
           : reply.text"
+        :highlight="highlight"
         @timestamp-event="emit('timestamp-event', $event)"
       />
       <CommentTranslationButton
@@ -101,7 +133,7 @@
       <p class="commentLikeCount">
         <template v-if="!hideCommentLikes">
           <FtIcon :icon="['fas', 'thumbs-up']" />
-          {{ reply.likes }}
+          {{ formatViewCount(reply.likes, shortenViewCounts) }}
         </template>
         <span
           v-if="reply.isHearted"
@@ -126,7 +158,7 @@
       </p>
     </div>
     <div
-      v-if="node.children.length > 0 || (reply.dataType === 'local' && reply.hasReplyToken) || loadingReplyIds.has(reply.id)"
+      v-if="node.children.length > 0 || (!filtering && ((reply.dataType === 'local' && reply.hasReplyToken) || loadingReplyIds.has(reply.id)))"
       class="commentReplyChildren"
     >
       <CommentReply
@@ -145,13 +177,18 @@
         :translation-language="translationLanguage"
         :translation-language-name="translationLanguageName"
         :highlighted-comment-id="highlightedCommentId"
+        :highlight="highlight"
+        :personal-pinned-comment-ids="personalPinnedCommentIds"
+        :filtering="filtering"
+        :shorten-view-counts="shortenViewCounts"
         @copy-youtube-link="emit('copy-youtube-link', $event)"
         @get-more-replies="emit('get-more-replies', $event)"
+        @toggle-personal-pin="emit('toggle-personal-pin', $event)"
         @timestamp-event="emit('timestamp-event', $event)"
         @translate-comment="emit('translate-comment', $event)"
       />
       <div
-        v-if="loadingReplyIds.has(reply.id) || (reply.dataType === 'local' && reply.hasReplyToken)"
+        v-if="!filtering && (loadingReplyIds.has(reply.id) || (reply.dataType === 'local' && reply.hasReplyToken))"
         class="commentReplyContinuation"
       >
         <button
@@ -182,13 +219,17 @@
 
 <script setup>
 import { FtIcon } from '@opentubex/icons'
+import { computed } from 'vue'
+import { useI18n } from 'vue-i18n'
 
 import FtTimestampCatcher from '../FtTimestampCatcher.vue'
 import CommentTranslationButton from './CommentTranslationButton.vue'
 import FtRetryImage from '../FtRetryImage.vue'
 import FtSpinner from '../FtSpinner/FtSpinner.vue'
 import { useRelativeTimeClock } from '../../composables/useRelativeTimeClock'
-import { getRelativeTimeFromDate } from '../../helpers/utils'
+import { formatViewCount, getRelativeTimeFromDate } from '../../helpers/utils'
+
+const { t } = useI18n()
 
 const props = defineProps({
   node: {
@@ -246,6 +287,22 @@ const props = defineProps({
   highlightedCommentId: {
     type: String,
     default: null
+  },
+  highlight: {
+    type: String,
+    default: ''
+  },
+  personalPinnedCommentIds: {
+    type: Set,
+    required: true
+  },
+  filtering: {
+    type: Boolean,
+    required: true
+  },
+  shortenViewCounts: {
+    type: Boolean,
+    required: true
   }
 })
 
@@ -258,8 +315,49 @@ function formatCommentTime(comment) {
 }
 
 const reply = props.node.reply
+const isPersonallyPinned = computed(() => props.personalPinnedCommentIds.has(reply.id))
+const personalPinActionLabel = computed(() => {
+  return isPersonallyPinned.value
+    ? t('Comments.Unpin comment by author', { author: reply.author })
+    : t('Comments.Pin comment by author', { author: reply.author })
+})
+const authorSearchSegments = computed(() => {
+  const query = props.highlight
+  if (query === '') {
+    return [{ text: reply.author, highlighted: false }]
+  }
 
-const emit = defineEmits(['copy-youtube-link', 'get-more-replies', 'timestamp-event', 'translate-comment'])
+  const normalizedAuthor = reply.author.toLocaleLowerCase()
+  const segments = []
+  let start = 0
+  let matchIndex = normalizedAuthor.indexOf(query)
+
+  while (matchIndex !== -1) {
+    if (matchIndex > start) {
+      segments.push({ text: reply.author.slice(start, matchIndex), highlighted: false })
+    }
+    segments.push({
+      text: reply.author.slice(matchIndex, matchIndex + query.length),
+      highlighted: true
+    })
+    start = matchIndex + query.length
+    matchIndex = normalizedAuthor.indexOf(query, start)
+  }
+
+  if (start < reply.author.length) {
+    segments.push({ text: reply.author.slice(start), highlighted: false })
+  }
+
+  return segments
+})
+
+const emit = defineEmits([
+  'copy-youtube-link',
+  'get-more-replies',
+  'timestamp-event',
+  'toggle-personal-pin',
+  'translate-comment'
+])
 </script>
 
 <style scoped src="./CommentSection.css" />

--- a/src/renderer/components/CommentSection/CommentSection.css
+++ b/src/renderer/components/CommentSection/CommentSection.css
@@ -4,13 +4,13 @@
 
   /* Contain floated comment content inside the card. */
   display: flow-root;
+  container-name: comments;
+  container-type: inline-size;
 }
 
 .commentsContentWrapper {
   /* Contain floated comment avatars inside the comments area. */
   display: flow-root;
-  container-name: comments;
-  container-type: inline-size;
 }
 
 .fullscreenCommentCard {
@@ -88,6 +88,17 @@
 .fullscreenCommentAction:focus-visible,
 .fullscreenCommentAction.active {
   background-color: rgb(255 255 255 / 20%);
+}
+
+.commentCreatorFilterAvatar {
+  inline-size: var(--comment-creator-filter-avatar-size, 20px);
+  block-size: var(--comment-creator-filter-avatar-size, 20px);
+  border-radius: 50%;
+  object-fit: cover;
+}
+
+.fullscreenCommentAction .commentCreatorFilterAvatar {
+  --comment-creator-filter-avatar-size: 24px;
 }
 
 .fullscreenSortMenu {
@@ -207,6 +218,73 @@
   margin-inline-end: 8px;
 }
 
+.commentHeaderIconAction {
+  display: inline-flex;
+  inline-size: 28px;
+  block-size: 28px;
+  flex: 0 0 28px;
+  align-items: center;
+  justify-content: center;
+  padding: 0;
+  color: var(--title-color);
+  background-color: transparent;
+  border: 0;
+  border-radius: 50%;
+  cursor: pointer;
+  font-size: 12px;
+}
+
+.commentHeaderIconAction:hover,
+.commentHeaderIconAction:focus-visible,
+.commentHeaderIconAction.active {
+  color: var(--side-nav-hover-text-color);
+  background-color: var(--side-nav-hover-color);
+}
+
+.commentHeaderIconActionAligned {
+  margin-block-start: 39px;
+}
+
+.commentTools {
+  padding-block: 8px;
+}
+
+.fullscreenCommentCard > .commentTools {
+  flex: 0 0 auto;
+  padding-block: 12px;
+  padding-inline: 14px;
+  background-color: rgb(20 20 20 / 52%);
+  border-block-end: 1px solid rgb(255 255 255 / 10%);
+}
+
+.fullscreenCommentCard > .commentTools :deep(.ft-input) {
+  color: #fff;
+  background-color: rgb(0 0 0 / 35%);
+}
+
+.commentTools :deep(.ft-input) {
+  margin-block-end: 0;
+}
+
+.commentFilterCount,
+.noCommentFilterResults {
+  color: var(--secondary-text-color);
+}
+
+.commentFilterCount {
+  margin-block: 8px 0;
+  font-size: 13px;
+}
+
+.noCommentFilterResults {
+  margin-block: 24px;
+  text-align: center;
+}
+
+.fullscreenCommentCard > .commentTools .commentFilterCount {
+  color: #fff;
+}
+
 @container comments (width <= 520px) {
   .commentHeaderActions {
     flex: 1 0 100%;
@@ -221,6 +299,16 @@
 
 .reloadComments {
   color: var(--title-color);
+}
+
+.reloadComments :deep(.iconButton) {
+  inline-size: 28px;
+  block-size: 28px;
+
+  /* FtIconButton's inline padding scales independently of authored CSS at
+     non-100% Electron zoom factors. Keep this toolbar control a fixed size. */
+  /* stylelint-disable-next-line declaration-no-important */
+  padding: 0 !important;
 }
 
 .reloadCommentsAligned {
@@ -413,7 +501,8 @@
   margin-block-start: 0;
 }
 
-.commentCopyLink {
+.commentCopyLink,
+.commentPinButton {
   display: inline-flex;
   align-items: center;
   justify-content: center;
@@ -431,9 +520,29 @@
 }
 
 .commentCopyLink:hover,
-.commentCopyLink:focus-visible {
+.commentCopyLink:focus-visible,
+.commentPinButton:hover,
+.commentPinButton:focus-visible,
+.commentPinButton.active {
   color: var(--side-nav-hover-text-color);
   background-color: var(--side-nav-hover-color);
+}
+
+.commentPersonalPin {
+  display: table;
+  padding-block: 2px;
+  padding-inline: 5px;
+  color: var(--primary-text-color);
+  background-color: color-mix(in srgb, var(--side-nav-hover-color) 45%, transparent);
+  border-radius: calc(4px * var(--ui-roundness));
+}
+
+.commentAuthor mark,
+.commentText :deep(mark) {
+  padding-inline: 1px;
+  color: var(--text-with-accent-color);
+  background-color: var(--accent-color);
+  border-radius: calc(2px * var(--ui-roundness));
 }
 
 .commentHeartBadge {

--- a/src/renderer/components/CommentSection/CommentSection.css
+++ b/src/renderer/components/CommentSection/CommentSection.css
@@ -101,6 +101,64 @@
   --comment-creator-filter-avatar-size: 24px;
 }
 
+.commentFilterMenuAnchor {
+  position: relative;
+  display: flex;
+  flex: 0 0 auto;
+}
+
+.commentFilterMenu {
+  position: absolute;
+  z-index: 5;
+  inset-block-start: calc(100% + 8px);
+  inset-inline-end: 0;
+  display: flex;
+  flex-direction: column;
+  inline-size: min(240px, calc(100vw - 32px));
+  padding: 6px;
+  color: var(--primary-text-color);
+  background-color: color-mix(in srgb, var(--card-bg-color) 96%, var(--bg-color));
+  border: 1px solid color-mix(in srgb, var(--border-color) 55%, transparent);
+  border-radius: calc(10px * var(--ui-roundness));
+  box-shadow: 0 8px 24px rgb(0 0 0 / 28%);
+}
+
+.commentFilterMenu button {
+  display: grid;
+  grid-template-columns: 24px minmax(0, 1fr) 14px;
+  min-block-size: 40px;
+  align-items: center;
+  gap: 10px;
+  padding-block: 8px;
+  padding-inline: 10px;
+  color: inherit;
+  font: inherit;
+  text-align: start;
+  background: transparent;
+  border: 0;
+  border-radius: calc(8px * var(--ui-roundness));
+  cursor: pointer;
+}
+
+.commentFilterMenu :where(button:hover, button:focus-visible) {
+  color: var(--side-nav-hover-text-color);
+  background-color: var(--side-nav-hover-color);
+}
+
+.commentFilterMenuIcon {
+  display: grid;
+  place-items: center;
+  inline-size: 24px;
+}
+
+.fullscreenCommentFilterMenu {
+  color: #fff;
+  background-color: rgb(12 12 12 / 82%);
+  border-color: rgb(255 255 255 / 12%);
+  box-shadow: 0 8px 24px rgb(0 0 0 / 40%);
+  backdrop-filter: blur(14px) saturate(1.05);
+}
+
 .fullscreenSortMenu {
   position: absolute;
   z-index: 3;

--- a/src/renderer/components/CommentSection/CommentSection.vue
+++ b/src/renderer/components/CommentSection/CommentSection.vue
@@ -14,42 +14,22 @@
       <div
         class="fullscreenCommentActions"
         @focusout="handleFullscreenActionsFocusout"
-        @keydown.esc.stop.prevent="sortMenuOpen = false"
+        @keydown.esc.stop.prevent="closeCommentMenus"
       >
-        <button
+        <CommentFilterMenu
           v-if="canUseCommentTools"
-          ref="commentSearchToggle"
-          type="button"
-          class="fullscreenCommentAction"
-          :class="{ active: commentSearchOpen }"
-          :aria-label="$t('Comments.Search loaded comments')"
-          :title="$t('Comments.Search loaded comments')"
-          :aria-expanded="String(commentSearchOpen)"
-          @click="toggleCommentSearch"
-        >
-          <FtIcon :icon="['fas', 'magnifying-glass']" />
-        </button>
-        <button
-          v-if="canUseCommentTools"
-          type="button"
-          class="fullscreenCommentAction"
-          :class="{ active: creatorCommentsOnly }"
-          :aria-label="$t('Comments.From creator')"
-          :title="$t('Comments.From creator')"
-          :aria-pressed="creatorCommentsOnly"
-          @click="toggleCreatorCommentsFilter"
-        >
-          <FtRetryImage
-            v-if="channelThumbnail"
-            :src="channelThumbnail"
-            class="commentCreatorFilterAvatar"
-            aria-hidden="true"
-          />
-          <FtIcon
-            v-else
-            :icon="['fas', 'circle-user']"
-          />
-        </button>
+          ref="commentFilterMenu"
+          :open="commentFilterMenuOpen"
+          fullscreen
+          :channel-thumbnail="channelThumbnail"
+          :creator-comments-only="creatorCommentsOnly"
+          :timestamp-comments-only="timestampCommentsOnly"
+          :search-open="commentSearchOpen"
+          @update:open="setCommentFilterMenuOpen"
+          @toggle-search="toggleCommentSearch"
+          @toggle-creator="toggleCreatorCommentsFilter"
+          @toggle-timestamps="toggleTimestampCommentsFilter"
+        />
         <button
           v-if="showSortBy && !commentsDisabled"
           type="button"
@@ -58,7 +38,7 @@
           :aria-label="$t('Global.Sort By')"
           :title="$t('Global.Sort By')"
           :aria-expanded="String(sortMenuOpen)"
-          @click="sortMenuOpen = !sortMenuOpen"
+          @click="toggleSortMenu"
         >
           <FtIcon :icon="['fas', 'arrow-down-short-wide']" />
         </button>
@@ -122,46 +102,20 @@
         class="commentHeaderActions"
         :class="{ commentHeaderActionsEmpty: !showSortBy }"
       >
-        <button
+        <CommentFilterMenu
           v-if="canUseCommentTools"
-          ref="commentSearchToggle"
-          type="button"
-          class="commentHeaderIconAction"
-          :class="{
-            active: commentSearchOpen,
-            commentHeaderIconActionAligned: showSortBy
-          }"
-          :aria-label="$t('Comments.Search loaded comments')"
-          :title="$t('Comments.Search loaded comments')"
-          :aria-expanded="String(commentSearchOpen)"
-          @click="toggleCommentSearch"
-        >
-          <FtIcon :icon="['fas', 'magnifying-glass']" />
-        </button>
-        <button
-          v-if="canUseCommentTools"
-          type="button"
-          class="commentHeaderIconAction"
-          :class="{
-            active: creatorCommentsOnly,
-            commentHeaderIconActionAligned: showSortBy
-          }"
-          :aria-label="$t('Comments.From creator')"
-          :title="$t('Comments.From creator')"
-          :aria-pressed="creatorCommentsOnly"
-          @click="toggleCreatorCommentsFilter"
-        >
-          <FtRetryImage
-            v-if="channelThumbnail"
-            :src="channelThumbnail"
-            class="commentCreatorFilterAvatar"
-            aria-hidden="true"
-          />
-          <FtIcon
-            v-else
-            :icon="['fas', 'circle-user']"
-          />
-        </button>
+          ref="commentFilterMenu"
+          :open="commentFilterMenuOpen"
+          :aligned="showSortBy"
+          :channel-thumbnail="channelThumbnail"
+          :creator-comments-only="creatorCommentsOnly"
+          :timestamp-comments-only="timestampCommentsOnly"
+          :search-open="commentSearchOpen"
+          @update:open="setCommentFilterMenuOpen"
+          @toggle-search="toggleCommentSearch"
+          @toggle-creator="toggleCreatorCommentsFilter"
+          @toggle-timestamps="toggleTimestampCommentsFilter"
+        />
         <FtIconButton
           :title="$t('Comments.Reload Comments')"
           :icon="['fas', 'sync']"
@@ -202,9 +156,9 @@
         aria-live="polite"
       >
         {{ $t('Comments.Loaded comment search result count', {
-          count: visibleCommentEntries.length,
-          total: commentData.length
-        }, visibleCommentEntries.length) }}
+          count: matchingCommentCount,
+          total: loadedCommentCount
+        }, matchingCommentCount) }}
       </p>
     </div>
     <div
@@ -239,13 +193,13 @@
         ref="commentsList"
       >
         <div
-          v-for="({ comment, index }) in visibleCommentEntries"
+          v-for="({ comment, index, replyNodes }) in visibleCommentEntries"
           :id="'comment' + index"
           :key="comment.id"
           class="comment commentThread"
           :class="{
-            commentThreadExpanded: comment.showReplies,
-            commentThreadCollapsed: comment.numReplies > 0 && !comment.showReplies,
+            commentThreadExpanded: shouldShowCommentReplies(comment, replyNodes),
+            commentThreadCollapsed: !hasActiveCommentFilters && comment.numReplies > 0 && !comment.showReplies,
             highlightedComment: comment.id === highlightedCommentId
           }"
         >
@@ -408,7 +362,7 @@
             </span>
           </p>
           <div
-            v-if="comment.numReplies > 0 && !comment.showReplies"
+            v-if="!hasActiveCommentFilters && comment.numReplies > 0 && !comment.showReplies"
             class="commentReplyContinuation commentReplyRootToggle"
           >
             <button
@@ -449,11 +403,11 @@
             </button>
           </div>
           <div
-            v-if="comment.showReplies"
+            v-if="shouldShowCommentReplies(comment, replyNodes)"
             class="commentReplies"
           >
             <CommentReply
-              v-for="node in replyTrees[index]"
+              v-for="node in replyNodes"
               :key="node.reply.id"
               :node="node"
               :thread-index="index"
@@ -469,13 +423,18 @@
               :translation-language="translationLanguage"
               :translation-language-name="translationLanguageName"
               :highlighted-comment-id="highlightedCommentId"
+              :highlight="normalizedCommentSearchQuery"
+              :personal-pinned-comment-ids="personalPinnedCommentIds"
+              :filtering="hasActiveCommentFilters"
+              :shorten-view-counts="shortenViewCounts"
               @copy-youtube-link="copyCommentYoutubeLink"
               @get-more-replies="getCommentReplies(index, $event)"
+              @toggle-personal-pin="togglePersonalCommentPin"
               @timestamp-event="onTimestamp"
               @translate-comment="toggleCommentTranslation"
             />
             <div
-              v-if="isReplyLoading(comment.id) || comment.hasReplyToken"
+              v-if="!hasActiveCommentFilters && (isReplyLoading(comment.id) || comment.hasReplyToken)"
               class="commentReplyContinuation"
             >
               <button
@@ -501,7 +460,7 @@
               </button>
             </div>
             <div
-              v-if="comment.numReplies > 0"
+              v-if="!hasActiveCommentFilters && comment.numReplies > 0"
               class="commentReplyContinuation"
             >
               <button
@@ -613,6 +572,7 @@ import { computed, nextTick, ref, shallowRef, useTemplateRef, watch } from 'vue'
 import { useI18n } from 'vue-i18n'
 
 import FtCard from '../ft-card/ft-card.vue'
+import CommentFilterMenu from './CommentFilterMenu.vue'
 import CommentReply from './CommentReply.vue'
 import CommentTranslationButton from './CommentTranslationButton.vue'
 import FtIconButton from '../FtIconButton/FtIconButton.vue'
@@ -724,11 +684,13 @@ const commentData = ref([])
 const commentCount = ref(props.initialCommentCount)
 const commentsContentWrapper = useTemplateRef('commentsContentWrapper')
 const commentsList = useTemplateRef('commentsList')
+const commentFilterMenu = useTemplateRef('commentFilterMenu')
 const commentSearch = useTemplateRef('commentSearch')
-const commentSearchToggle = useTemplateRef('commentSearchToggle')
 const commentSearchOpen = ref(false)
 const commentSearchQuery = ref('')
+const commentFilterMenuOpen = ref(false)
 const creatorCommentsOnly = ref(false)
+const timestampCommentsOnly = ref(false)
 const activeProfileId = computed(() => store.getters.getActiveProfile._id)
 const commentPinStorageKey = computed(() => {
   return getCommentPinStorageKey(activeProfileId.value, props.id, props.isPostComments)
@@ -766,33 +728,118 @@ function resetCommentsScroll() {
   }
 }
 
-const replyTrees = computed(() => commentData.value.map(buildReplyTree))
+const COMMENT_TIMESTAMP_PATTERN = /(?:(?:\d+):)?\d+:\d+/
+
+function getCommentPlainText(comment) {
+  const document = new DOMParser().parseFromString(comment.text ?? '', 'text/html')
+  return document.body.textContent ?? ''
+}
 
 function getCommentSearchText(comment) {
-  const document = new DOMParser().parseFromString(comment.text ?? '', 'text/html')
-  return `${comment.author ?? ''} ${document.body.textContent ?? ''}`.toLocaleLowerCase()
+  return `${comment.author ?? ''} ${getCommentPlainText(comment)}`.toLocaleLowerCase()
 }
 
 const normalizedCommentSearchQuery = computed(() => {
   return commentSearchQuery.value.trim().toLocaleLowerCase()
 })
 
+const hasActiveCommentFilters = computed(() => {
+  return normalizedCommentSearchQuery.value !== '' ||
+    creatorCommentsOnly.value ||
+    timestampCommentsOnly.value
+})
+
+function commentMatchesActiveFilters(comment) {
+  if (creatorCommentsOnly.value && !comment.isOwner) {
+    return false
+  }
+
+  if (timestampCommentsOnly.value && !COMMENT_TIMESTAMP_PATTERN.test(getCommentPlainText(comment))) {
+    return false
+  }
+
+  return normalizedCommentSearchQuery.value === '' ||
+    getCommentSearchText(comment).includes(normalizedCommentSearchQuery.value)
+}
+
+function replyNodeHasPersonalPin(node) {
+  return isCommentPersonallyPinned(node.reply.id) || node.children.some(replyNodeHasPersonalPin)
+}
+
+function sortReplyNodesByPersonalPins(nodes) {
+  return nodes
+    .map(node => ({
+      ...node,
+      children: sortReplyNodesByPersonalPins(node.children)
+    }))
+    .sort((first, second) => {
+      return Number(replyNodeHasPersonalPin(second)) - Number(replyNodeHasPersonalPin(first))
+    })
+}
+
+function filterReplyNodes(nodes) {
+  return sortReplyNodesByPersonalPins(nodes.flatMap(node => {
+    const children = filterReplyNodes(node.children)
+    if (!commentMatchesActiveFilters(node.reply) && children.length === 0) {
+      return []
+    }
+
+    return [{ ...node, children }]
+  }))
+}
+
+function getVisibleReplyNodes(comment) {
+  const nodes = buildReplyTree(comment)
+  return hasActiveCommentFilters.value
+    ? filterReplyNodes(nodes)
+    : sortReplyNodesByPersonalPins(nodes)
+}
+
+function commentTreeHasPersonalPin(comment) {
+  return isCommentPersonallyPinned(comment.id) || comment.replies.some(commentTreeHasPersonalPin)
+}
+
 const visibleCommentEntries = computed(() => {
   return commentData.value
-    .map((comment, index) => ({ comment, index }))
-    .filter(({ comment }) => !creatorCommentsOnly.value || comment.isOwner)
-    .filter(({ comment }) => {
-      return normalizedCommentSearchQuery.value === '' ||
-        getCommentSearchText(comment).includes(normalizedCommentSearchQuery.value)
+    .map((comment, index) => ({
+      comment,
+      index,
+      replyNodes: getVisibleReplyNodes(comment)
+    }))
+    .filter(({ comment, replyNodes }) => {
+      return !hasActiveCommentFilters.value ||
+        commentMatchesActiveFilters(comment) ||
+        replyNodes.length > 0
     })
     .sort(({ comment: first }, { comment: second }) => {
-      return Number(isCommentPersonallyPinned(second.id)) - Number(isCommentPersonallyPinned(first.id))
+      return Number(commentTreeHasPersonalPin(second)) - Number(commentTreeHasPersonalPin(first))
     })
 })
 
-const hasActiveCommentFilters = computed(() => {
-  return normalizedCommentSearchQuery.value !== '' || creatorCommentsOnly.value
+function countLoadedComments(comment) {
+  return 1 + comment.replies.reduce((count, reply) => count + countLoadedComments(reply), 0)
+}
+
+function countMatchingComments(comment) {
+  return Number(commentMatchesActiveFilters(comment)) +
+    comment.replies.reduce((count, reply) => count + countMatchingComments(reply), 0)
+}
+
+const loadedCommentCount = computed(() => {
+  return commentData.value.reduce((count, comment) => count + countLoadedComments(comment), 0)
 })
+
+const matchingCommentCount = computed(() => {
+  if (!hasActiveCommentFilters.value) {
+    return loadedCommentCount.value
+  }
+
+  return commentData.value.reduce((count, comment) => count + countMatchingComments(comment), 0)
+})
+
+function shouldShowCommentReplies(comment, replyNodes) {
+  return replyNodes.length > 0 && (comment.showReplies || hasActiveCommentFilters.value)
+}
 
 function getCommentAuthorSearchSegments(author) {
   const query = normalizedCommentSearchQuery.value
@@ -843,8 +890,11 @@ function updateCommentSearchQuery(query) {
 
 function toggleCommentSearch() {
   commentSearchOpen.value = !commentSearchOpen.value
+  commentFilterMenuOpen.value = false
+
   if (!commentSearchOpen.value) {
     updateCommentSearchQuery('')
+    nextTick(() => commentFilterMenu.value?.focusTrigger())
     return
   }
 
@@ -854,7 +904,7 @@ function toggleCommentSearch() {
 function closeCommentSearch() {
   commentSearchOpen.value = false
   updateCommentSearchQuery('')
-  nextTick(() => commentSearchToggle.value?.focus())
+  nextTick(() => commentFilterMenu.value?.focusTrigger())
 }
 
 function isCommentPersonallyPinned(commentId) {
@@ -887,9 +937,28 @@ function toggleCreatorCommentsFilter() {
   clampCommentsScrollAfterRender()
 }
 
+function toggleTimestampCommentsFilter() {
+  timestampCommentsOnly.value = !timestampCommentsOnly.value
+  clampCommentsScrollAfterRender()
+}
+
+function setCommentFilterMenuOpen(open) {
+  commentFilterMenuOpen.value = open
+  if (open) {
+    sortMenuOpen.value = false
+  }
+}
+
+function closeCommentMenus() {
+  commentFilterMenuOpen.value = false
+  sortMenuOpen.value = false
+}
+
 watch(commentPinStorageKey, (contentKey) => {
   personalPinnedCommentIds.value = loadCommentPins(contentKey)
+  commentFilterMenuOpen.value = false
   creatorCommentsOnly.value = false
+  timestampCommentsOnly.value = false
   commentSearchOpen.value = false
   commentSearchQuery.value = ''
 })
@@ -1172,9 +1241,16 @@ const sortMenuOpen = ref(false)
 
 const currentSortValue = computed(() => sortNewest.value ? 'newest' : 'top')
 
+function toggleSortMenu() {
+  sortMenuOpen.value = !sortMenuOpen.value
+  if (sortMenuOpen.value) {
+    commentFilterMenuOpen.value = false
+  }
+}
+
 function handleSortChange(value) {
   const newest = value === 'newest'
-  sortMenuOpen.value = false
+  closeCommentMenus()
 
   if (sortNewest.value === newest) {
     return
@@ -1198,7 +1274,7 @@ function reloadCommentData() {
 
 function handleFullscreenActionsFocusout(event) {
   if (!event.currentTarget.contains(event.relatedTarget)) {
-    sortMenuOpen.value = false
+    closeCommentMenus()
   }
 }
 

--- a/src/renderer/components/CommentSection/CommentSection.vue
+++ b/src/renderer/components/CommentSection/CommentSection.vue
@@ -17,6 +17,40 @@
         @keydown.esc.stop.prevent="sortMenuOpen = false"
       >
         <button
+          v-if="canUseCommentTools"
+          ref="commentSearchToggle"
+          type="button"
+          class="fullscreenCommentAction"
+          :class="{ active: commentSearchOpen }"
+          :aria-label="$t('Comments.Search loaded comments')"
+          :title="$t('Comments.Search loaded comments')"
+          :aria-expanded="String(commentSearchOpen)"
+          @click="toggleCommentSearch"
+        >
+          <FtIcon :icon="['fas', 'magnifying-glass']" />
+        </button>
+        <button
+          v-if="canUseCommentTools"
+          type="button"
+          class="fullscreenCommentAction"
+          :class="{ active: creatorCommentsOnly }"
+          :aria-label="$t('Comments.From creator')"
+          :title="$t('Comments.From creator')"
+          :aria-pressed="creatorCommentsOnly"
+          @click="toggleCreatorCommentsFilter"
+        >
+          <FtRetryImage
+            v-if="channelThumbnail"
+            :src="channelThumbnail"
+            class="commentCreatorFilterAvatar"
+            aria-hidden="true"
+          />
+          <FtIcon
+            v-else
+            :icon="['fas', 'circle-user']"
+          />
+        </button>
+        <button
           v-if="showSortBy && !commentsDisabled"
           type="button"
           class="fullscreenCommentAction"
@@ -68,55 +102,116 @@
       </div>
     </header>
     <div
+      v-if="!fullscreenOverlay && showComments && !isLoading && commentData.length > 0"
+      class="commentHeader"
+    >
+      <h3 class="commentsTitle">
+        <span>{{ commentsTitle }}</span>
+        <span
+          class="commentTitleAction"
+          role="button"
+          tabindex="0"
+          @click="showComments = false"
+          @keydown.space.prevent="showComments = false"
+          @keydown.enter.prevent="showComments = false"
+        >
+          {{ $t("Comments.Hide Comments") }}
+        </span>
+      </h3>
+      <div
+        class="commentHeaderActions"
+        :class="{ commentHeaderActionsEmpty: !showSortBy }"
+      >
+        <button
+          v-if="canUseCommentTools"
+          ref="commentSearchToggle"
+          type="button"
+          class="commentHeaderIconAction"
+          :class="{
+            active: commentSearchOpen,
+            commentHeaderIconActionAligned: showSortBy
+          }"
+          :aria-label="$t('Comments.Search loaded comments')"
+          :title="$t('Comments.Search loaded comments')"
+          :aria-expanded="String(commentSearchOpen)"
+          @click="toggleCommentSearch"
+        >
+          <FtIcon :icon="['fas', 'magnifying-glass']" />
+        </button>
+        <button
+          v-if="canUseCommentTools"
+          type="button"
+          class="commentHeaderIconAction"
+          :class="{
+            active: creatorCommentsOnly,
+            commentHeaderIconActionAligned: showSortBy
+          }"
+          :aria-label="$t('Comments.From creator')"
+          :title="$t('Comments.From creator')"
+          :aria-pressed="creatorCommentsOnly"
+          @click="toggleCreatorCommentsFilter"
+        >
+          <FtRetryImage
+            v-if="channelThumbnail"
+            :src="channelThumbnail"
+            class="commentCreatorFilterAvatar"
+            aria-hidden="true"
+          />
+          <FtIcon
+            v-else
+            :icon="['fas', 'circle-user']"
+          />
+        </button>
+        <FtIconButton
+          :title="$t('Comments.Reload Comments')"
+          :icon="['fas', 'sync']"
+          :size="12"
+          :padding="8"
+          :use-shadow="false"
+          class="reloadComments"
+          :class="{ reloadCommentsAligned: showSortBy }"
+          @click="reloadCommentData"
+        />
+        <FtSelect
+          v-if="showSortBy"
+          :placeholder="$t('Global.Sort By')"
+          :value="currentSortValue"
+          :select-names="sortNames"
+          :select-values="sortValues"
+          :icon="['fas', 'arrow-down-short-wide']"
+          @change="handleSortChange"
+        />
+      </div>
+    </div>
+    <div
+      v-if="canUseCommentTools && commentSearchOpen"
+      ref="commentSearch"
+      class="commentTools"
+      @keydown.esc.stop.prevent="closeCommentSearch"
+    >
+      <FtInput
+        input-type="search"
+        :placeholder="$t('Comments.Search loaded comments')"
+        :show-action-button="false"
+        :value="commentSearchQuery"
+        @input="updateCommentSearchQuery"
+      />
+      <p
+        v-if="hasActiveCommentFilters"
+        class="commentFilterCount"
+        aria-live="polite"
+      >
+        {{ $t('Comments.Loaded comment search result count', {
+          count: visibleCommentEntries.length,
+          total: commentData.length
+        }, visibleCommentEntries.length) }}
+      </p>
+    </div>
+    <div
       ref="commentsContentWrapper"
       v-overlay-scrollbars
       class="commentsContentWrapper"
     >
-      <div
-        v-if="!fullscreenOverlay && showComments && !isLoading && commentData.length > 0"
-        class="commentHeader"
-      >
-        <h3
-          v-if="commentData.length > 0"
-          class="commentsTitle"
-        >
-          <span>{{ commentsTitle }}</span>
-          <span
-            class="commentTitleAction"
-            role="button"
-            tabindex="0"
-            @click="showComments = false"
-            @keydown.space.prevent="showComments = false"
-            @keydown.enter.prevent="showComments = false"
-          >
-            {{ $t("Comments.Hide Comments") }}
-          </span>
-        </h3>
-        <div
-          class="commentHeaderActions"
-          :class="{ commentHeaderActionsEmpty: !showSortBy }"
-        >
-          <FtSelect
-            v-if="showSortBy"
-            :placeholder="$t('Global.Sort By')"
-            :value="currentSortValue"
-            :select-names="sortNames"
-            :select-values="sortValues"
-            :icon="['fas', 'arrow-down-short-wide']"
-            @change="handleSortChange"
-          />
-          <FtIconButton
-            :title="$t('Comments.Reload Comments')"
-            :icon="['fas', 'sync']"
-            :size="12"
-            :padding="8"
-            :use-shadow="false"
-            class="reloadComments"
-            :class="{ reloadCommentsAligned: showSortBy }"
-            @click="reloadCommentData"
-          />
-        </div>
-      </div>
       <h4
         v-if="canPerformInitialCommentLoading"
         class="getCommentsTitle"
@@ -141,9 +236,10 @@
       </h4>
       <div
         v-if="commentData.length > 0 && showComments"
+        ref="commentsList"
       >
         <div
-          v-for="(comment, index) in commentData"
+          v-for="({ comment, index }) in visibleCommentEntries"
           :id="'comment' + index"
           :key="comment.id"
           class="comment commentThread"
@@ -188,6 +284,16 @@
             {{ $t("Comments.Pinned by") }} <bdi>{{ channelName }}</bdi>
           </p>
           <p
+            v-if="isCommentPersonallyPinned(comment.id)"
+            class="commentPinned commentPersonalPin"
+          >
+            <FtIcon
+              :icon="['fas', 'thumbtack']"
+              aria-hidden="true"
+            />
+            {{ $t('Comments.Pinned by you') }}
+          </p>
+          <p
             class="commentAuthorWrapper"
           >
             <component
@@ -199,7 +305,15 @@
               }"
               :to="`/channel/${comment.authorLink}`"
             >
-              {{ comment.author }}
+              <template
+                v-for="(segment, segmentIndex) in getCommentAuthorSearchSegments(comment.author)"
+                :key="segmentIndex"
+              >
+                <mark v-if="segment.highlighted">{{ segment.text }}</mark>
+                <template v-else>
+                  {{ segment.text }}
+                </template>
+              </template>
             </component>
             <img
               v-if="comment.isMember"
@@ -224,6 +338,19 @@
             </span>
             <button
               type="button"
+              class="commentPinButton"
+              :class="{ active: isCommentPersonallyPinned(comment.id) }"
+              :title="personalPinActionLabel(comment)"
+              :aria-label="personalPinActionLabel(comment)"
+              :aria-pressed="isCommentPersonallyPinned(comment.id)"
+              @click="togglePersonalCommentPin(comment.id)"
+            >
+              <FtIcon
+                :icon="['fas', isCommentPersonallyPinned(comment.id) ? 'thumbtack-slash' : 'thumbtack']"
+              />
+            </button>
+            <button
+              type="button"
               class="commentCopyLink"
               :title="$t('Comments.Copy YouTube Link')"
               :aria-label="$t('Comments.Copy YouTube Link')"
@@ -239,6 +366,7 @@
             :input-html="comment.showTranslated && comment.translatedLanguage === translationLanguage
               ? comment.translatedText
               : comment.text"
+            :highlight="normalizedCommentSearchQuery"
             @timestamp-event="onTimestamp"
           />
           <CommentTranslationButton
@@ -256,7 +384,7 @@
               <FtIcon
                 :icon="['fas', 'thumbs-up']"
               />
-              {{ comment.likes }}
+              {{ formatCommentLikeCount(comment.likes) }}
             </template>
             <span
               v-if="comment.isHearted"
@@ -391,6 +519,12 @@
             </div>
           </div>
         </div>
+        <p
+          v-if="visibleCommentEntries.length === 0"
+          class="noCommentFilterResults"
+        >
+          {{ $t('Comments.No loaded comments match your filters') }}
+        </p>
       </div>
       <div
         v-else-if="commentsDisabled || (showComments && !isLoading)"
@@ -445,7 +579,7 @@
         :label="$t('Comments.Load More Comments')"
       />
       <h4
-        v-else-if="!generalAutoLoadMorePaginatedItemsEnabled && canPerformMoreCommentLoading"
+        v-else-if="shouldShowManualLoadMoreComments"
         class="getMoreComments"
         role="button"
         tabindex="0"
@@ -482,6 +616,7 @@ import FtCard from '../ft-card/ft-card.vue'
 import CommentReply from './CommentReply.vue'
 import CommentTranslationButton from './CommentTranslationButton.vue'
 import FtIconButton from '../FtIconButton/FtIconButton.vue'
+import FtInput from '../FtInput/FtInput.vue'
 import FtLoader from '../FtLoader/FtLoader.vue'
 import FtRetryImage from '../FtRetryImage.vue'
 import FtSelect from '../FtSelect/FtSelect.vue'
@@ -490,7 +625,7 @@ import FtTimestampCatcher from '../FtTimestampCatcher.vue'
 
 import store from '../../store/index'
 
-import { copyToClipboard, formatNumber, getRelativeTimeFromDate, showApiErrorToast, showToast } from '../../helpers/utils'
+import { copyToClipboard, formatNumber, formatViewCount, getRelativeTimeFromDate, showApiErrorToast, showToast } from '../../helpers/utils'
 import { useRelativeTimeClock } from '../../composables/useRelativeTimeClock'
 import {
   getCommentReplyAccessibleLabel,
@@ -501,8 +636,9 @@ import {
   isMissingReplyResponseError,
   shouldLoadInitialReplies
 } from '../../helpers/comment-replies'
-import { restoreOverlayScrollTop } from '../../helpers/overlayScrollbars'
+import { clampOverlayScrollTop, restoreOverlayScrollTop } from '../../helpers/overlayScrollbars'
 import { getYoutubeCommunityPostCommentUrl, getYoutubeVideoCommentUrl } from '../../helpers/share'
+import { getCommentPinStorageKey, loadCommentPins, saveCommentPins } from '../../helpers/commentPins'
 import {
   getLocalCommunityPostComments,
   getLocalComments,
@@ -520,6 +656,11 @@ import {
 
 const { locale, t } = useI18n()
 const relativeTimeNow = useRelativeTimeClock()
+const shortenViewCounts = computed(() => store.getters.getShortenViewCounts)
+
+function formatCommentLikeCount(likeCount) {
+  return formatViewCount(likeCount, shortenViewCounts.value)
+}
 
 function formatCommentTime(comment) {
   return comment.published
@@ -582,6 +723,17 @@ const nextPageToken = shallowRef(null)
 const commentData = ref([])
 const commentCount = ref(props.initialCommentCount)
 const commentsContentWrapper = useTemplateRef('commentsContentWrapper')
+const commentsList = useTemplateRef('commentsList')
+const commentSearch = useTemplateRef('commentSearch')
+const commentSearchToggle = useTemplateRef('commentSearchToggle')
+const commentSearchOpen = ref(false)
+const commentSearchQuery = ref('')
+const creatorCommentsOnly = ref(false)
+const activeProfileId = computed(() => store.getters.getActiveProfile._id)
+const commentPinStorageKey = computed(() => {
+  return getCommentPinStorageKey(activeProfileId.value, props.id, props.isPostComments)
+})
+const personalPinnedCommentIds = ref(loadCommentPins(commentPinStorageKey.value))
 let fullscreenScrollTop = 0
 let highlightedTargetGeneration = 0
 const MAX_HIGHLIGHTED_REPLY_PAGES = 20
@@ -615,6 +767,132 @@ function resetCommentsScroll() {
 }
 
 const replyTrees = computed(() => commentData.value.map(buildReplyTree))
+
+function getCommentSearchText(comment) {
+  const document = new DOMParser().parseFromString(comment.text ?? '', 'text/html')
+  return `${comment.author ?? ''} ${document.body.textContent ?? ''}`.toLocaleLowerCase()
+}
+
+const normalizedCommentSearchQuery = computed(() => {
+  return commentSearchQuery.value.trim().toLocaleLowerCase()
+})
+
+const visibleCommentEntries = computed(() => {
+  return commentData.value
+    .map((comment, index) => ({ comment, index }))
+    .filter(({ comment }) => !creatorCommentsOnly.value || comment.isOwner)
+    .filter(({ comment }) => {
+      return normalizedCommentSearchQuery.value === '' ||
+        getCommentSearchText(comment).includes(normalizedCommentSearchQuery.value)
+    })
+    .sort(({ comment: first }, { comment: second }) => {
+      return Number(isCommentPersonallyPinned(second.id)) - Number(isCommentPersonallyPinned(first.id))
+    })
+})
+
+const hasActiveCommentFilters = computed(() => {
+  return normalizedCommentSearchQuery.value !== '' || creatorCommentsOnly.value
+})
+
+function getCommentAuthorSearchSegments(author) {
+  const query = normalizedCommentSearchQuery.value
+  if (query === '') {
+    return [{ text: author, highlighted: false }]
+  }
+
+  const normalizedAuthor = author.toLocaleLowerCase()
+  const segments = []
+  let start = 0
+  let matchIndex = normalizedAuthor.indexOf(query)
+
+  while (matchIndex !== -1) {
+    if (matchIndex > start) {
+      segments.push({ text: author.slice(start, matchIndex), highlighted: false })
+    }
+    segments.push({
+      text: author.slice(matchIndex, matchIndex + query.length),
+      highlighted: true
+    })
+    start = matchIndex + query.length
+    matchIndex = normalizedAuthor.indexOf(query, start)
+  }
+
+  if (start < author.length) {
+    segments.push({ text: author.slice(start), highlighted: false })
+  }
+
+  return segments
+}
+
+const canUseCommentTools = computed(() => {
+  return commentData.value.length > 0 && showComments.value && !isLoading.value
+})
+
+function clampCommentsScrollAfterRender() {
+  nextTick(() => {
+    if (commentsContentWrapper.value != null && commentsList.value != null) {
+      clampOverlayScrollTop(commentsContentWrapper.value, commentsList.value)
+    }
+  })
+}
+
+function updateCommentSearchQuery(query) {
+  commentSearchQuery.value = query
+  clampCommentsScrollAfterRender()
+}
+
+function toggleCommentSearch() {
+  commentSearchOpen.value = !commentSearchOpen.value
+  if (!commentSearchOpen.value) {
+    updateCommentSearchQuery('')
+    return
+  }
+
+  nextTick(() => commentSearch.value?.querySelector('input')?.focus())
+}
+
+function closeCommentSearch() {
+  commentSearchOpen.value = false
+  updateCommentSearchQuery('')
+  nextTick(() => commentSearchToggle.value?.focus())
+}
+
+function isCommentPersonallyPinned(commentId) {
+  return personalPinnedCommentIds.value.has(commentId)
+}
+
+function personalPinActionLabel(comment) {
+  if (isCommentPersonallyPinned(comment.id)) {
+    return t('Comments.Unpin comment by author', { author: comment.author })
+  }
+
+  return t('Comments.Pin comment by author', { author: comment.author })
+}
+
+function togglePersonalCommentPin(commentId) {
+  const commentIds = new Set(personalPinnedCommentIds.value)
+  if (commentIds.has(commentId)) {
+    commentIds.delete(commentId)
+  } else {
+    commentIds.add(commentId)
+  }
+
+  personalPinnedCommentIds.value = commentIds
+  saveCommentPins(commentPinStorageKey.value, commentIds)
+  clampCommentsScrollAfterRender()
+}
+
+function toggleCreatorCommentsFilter() {
+  creatorCommentsOnly.value = !creatorCommentsOnly.value
+  clampCommentsScrollAfterRender()
+}
+
+watch(commentPinStorageKey, (contentKey) => {
+  personalPinnedCommentIds.value = loadCommentPins(contentKey)
+  creatorCommentsOnly.value = false
+  commentSearchOpen.value = false
+  commentSearchQuery.value = ''
+})
 
 function normalizeCommentAuthor(author) {
   return String(author)
@@ -832,6 +1110,17 @@ const canPerformMoreCommentLoading = computed(() => {
   return commentData.value.length > 0 && !isLoading.value && !isLoadingMoreComments.value && showComments.value && !!nextPageToken.value
 })
 
+const canAutomaticallyLoadMoreComments = computed(() => {
+  return generalAutoLoadMorePaginatedItemsEnabled.value &&
+    !hasActiveCommentFilters.value &&
+    canPerformMoreCommentLoading.value
+})
+
+const shouldShowManualLoadMoreComments = computed(() => {
+  return canPerformMoreCommentLoading.value &&
+    (!generalAutoLoadMorePaginatedItemsEnabled.value || hasActiveCommentFilters.value)
+})
+
 const shouldShowAutoLoadMoreCommentsSpinner = computed(() => {
   return commentData.value.length > 0 &&
     !isLoading.value &&
@@ -840,7 +1129,7 @@ const shouldShowAutoLoadMoreCommentsSpinner = computed(() => {
 })
 
 const observeVisibilityOptions = computed(() => {
-  if (!generalAutoLoadMorePaginatedItemsEnabled.value) {
+  if (!generalAutoLoadMorePaginatedItemsEnabled.value || hasActiveCommentFilters.value) {
     return false
   }
 
@@ -855,7 +1144,7 @@ const observeVisibilityOptions = computed(() => {
       // It's possible the comments are being loaded/already loaded
       if (canPerformInitialCommentLoading.value) {
         getCommentData()
-      } else if (canPerformMoreCommentLoading.value) {
+      } else if (canAutomaticallyLoadMoreComments.value) {
         getMoreComments()
       }
     },

--- a/src/renderer/components/DistractionSettings/DistractionSettings.vue
+++ b/src/renderer/components/DistractionSettings/DistractionSettings.vue
@@ -19,7 +19,6 @@
         <FtToggleSwitch
           :label="t('Settings.Distraction Free Settings.Shorten View Counts')"
           :compact="true"
-          :disabled="hideVideoViews"
           :default-value="shortenViewCounts"
           setting-key="shortenViewCounts"
           :tooltip="t('Tooltips.Distraction Free Settings.Shorten View Counts')"

--- a/src/renderer/components/FtTimestampCatcher.vue
+++ b/src/renderer/components/FtTimestampCatcher.vue
@@ -104,10 +104,11 @@ const emit = defineEmits(['timestamp-event'])
  * @param {PointerEvent} event
  */
 function catchTimestampClick(event) {
-  /** @type {HTMLAnchorElement} */
-  const target = event.target
+  const target = event.target instanceof Element
+    ? event.target.closest('a[data-time]')
+    : null
 
-  if (target.tagName === 'A' && target.dataset.time) {
+  if (target?.dataset.time) {
     const timeSeconds = parseInt(target.dataset.time)
 
     if (!isNaN(timeSeconds)) {

--- a/src/renderer/components/FtTimestampCatcher.vue
+++ b/src/renderer/components/FtTimestampCatcher.vue
@@ -22,29 +22,81 @@ const props = defineProps({
     type: String,
     default: '0'
   },
+  highlight: {
+    type: String,
+    default: ''
+  }
 })
 
 const router = useRouter()
 const videoId = router.currentRoute.value.params.id
 
-/** @type {import('vue').ComputedRef<string>} */
-const displayText = computed(() => props.inputHtml.replaceAll(/(?:(\d+):)?(\d+):(\d+)/g, (timestamp, hours, minutes, seconds) => {
-  let time = 60 * Number(minutes) + Number(seconds)
-
-  if (hours) {
-    time += 3600 * Number(hours)
+function highlightHtmlText(inputHtml, query) {
+  const normalizedQuery = query.trim().toLocaleLowerCase()
+  if (normalizedQuery === '') {
+    return inputHtml
   }
 
-  const url = router.resolve({
-    path: `/watch/${videoId}`,
-    query: {
-      timestamp: time
-    }
-  }).href
+  const document = new DOMParser().parseFromString(inputHtml, 'text/html')
+  const walker = document.createTreeWalker(document.body, NodeFilter.SHOW_TEXT)
+  const textNodes = []
+  let textNode = walker.nextNode()
 
-  // Adding the URL lets the user open the video in a new window at this timestamp
-  return `<a tabindex="${props.linkTabIndex}" href="${url}" data-time="${time}">${timestamp}</a>`
-}))
+  while (textNode !== null) {
+    textNodes.push(textNode)
+    textNode = walker.nextNode()
+  }
+
+  for (const node of textNodes) {
+    const text = node.textContent ?? ''
+    const normalizedText = text.toLocaleLowerCase()
+    let start = 0
+    let matchIndex = normalizedText.indexOf(normalizedQuery)
+
+    if (matchIndex === -1) {
+      continue
+    }
+
+    const fragment = document.createDocumentFragment()
+    while (matchIndex !== -1) {
+      fragment.append(text.slice(start, matchIndex))
+
+      const mark = document.createElement('mark')
+      mark.textContent = text.slice(matchIndex, matchIndex + normalizedQuery.length)
+      fragment.append(mark)
+
+      start = matchIndex + normalizedQuery.length
+      matchIndex = normalizedText.indexOf(normalizedQuery, start)
+    }
+    fragment.append(text.slice(start))
+    node.replaceWith(fragment)
+  }
+
+  return document.body.innerHTML
+}
+
+/** @type {import('vue').ComputedRef<string>} */
+const displayText = computed(() => {
+  const timestampHtml = props.inputHtml.replaceAll(/(?:(\d+):)?(\d+):(\d+)/g, (timestamp, hours, minutes, seconds) => {
+    let time = 60 * Number(minutes) + Number(seconds)
+
+    if (hours) {
+      time += 3600 * Number(hours)
+    }
+
+    const url = router.resolve({
+      path: `/watch/${videoId}`,
+      query: {
+        timestamp: time
+      }
+    }).href
+
+    // Adding the URL lets the user open the video in a new window at this timestamp
+    return `<a tabindex="${props.linkTabIndex}" href="${url}" data-time="${time}">${timestamp}</a>`
+  })
+
+  return highlightHtmlText(timestampHtml, props.highlight)
+})
 
 const emit = defineEmits(['timestamp-event'])
 

--- a/src/renderer/directives/vSaferHtml.js
+++ b/src/renderer/directives/vSaferHtml.js
@@ -72,6 +72,7 @@ export const vSaferHtml = (element, { value, oldValue, modifiers }) => {
             'br',
             'b',
             'i',
+            'mark',
             's',
             {
               name: 'a',
@@ -90,7 +91,7 @@ export const vSaferHtml = (element, { value, oldValue, modifiers }) => {
     } else {
       if (domPurifyStrictConfig === undefined) {
         domPurifyStrictConfig = {
-          ALLOWED_TAGS: ['br', 'b', 'i', 's', 'a', 'img'],
+          ALLOWED_TAGS: ['br', 'b', 'i', 'mark', 's', 'a', 'img'],
           ALLOWED_ATTR: ['alt', 'data-time', 'dir', 'height', 'href', 'lang', 'loading', 'src', 'style', 'tabindex', 'title', 'width']
         }
       }

--- a/src/renderer/helpers/commentPins.js
+++ b/src/renderer/helpers/commentPins.js
@@ -1,0 +1,45 @@
+const STORAGE_KEY = 'opentubex-comment-pins'
+
+function readStoredPins(storage) {
+  try {
+    const stored = JSON.parse(storage.getItem(STORAGE_KEY) ?? '{}')
+    if (stored === null || typeof stored !== 'object' || Array.isArray(stored)) {
+      return {}
+    }
+
+    return Object.fromEntries(Object.entries(stored).map(([contentKey, commentIds]) => [
+      contentKey,
+      Array.isArray(commentIds) ? commentIds.filter(commentId => typeof commentId === 'string') : []
+    ]))
+  } catch {
+    return {}
+  }
+}
+
+export function getCommentPinStorageKey(profileId, contentId, isPost = false) {
+  return `${profileId}:${isPost ? 'post' : 'video'}:${contentId}`
+}
+
+export function loadCommentPins(contentKey, storage = localStorage) {
+  return new Set(readStoredPins(storage)[contentKey] ?? [])
+}
+
+export function saveCommentPins(contentKey, commentIds, storage = localStorage) {
+  const stored = readStoredPins(storage)
+
+  if (commentIds.size === 0) {
+    delete stored[contentKey]
+  } else {
+    stored[contentKey] = Array.from(commentIds)
+  }
+
+  try {
+    if (Object.keys(stored).length === 0) {
+      storage.removeItem(STORAGE_KEY)
+    } else {
+      storage.setItem(STORAGE_KEY, JSON.stringify(stored))
+    }
+  } catch {
+    // Keep pinning usable for the current view when storage is unavailable.
+  }
+}

--- a/src/renderer/themes.css
+++ b/src/renderer/themes.css
@@ -64,6 +64,38 @@ body {
   background-color: var(--selection-background-color);
 }
 
+input[type='search']::-webkit-search-cancel-button {
+  /* Chromium only exposes this native control through its prefixed appearance. */
+  /* stylelint-disable-next-line property-no-vendor-prefix */
+  -webkit-appearance: none;
+  appearance: none;
+  block-size: 24px;
+  inline-size: 24px;
+  margin-inline-start: 8px;
+  border-radius: 50%;
+  background-color: var(--secondary-text-color);
+  cursor: pointer;
+  mask-image:
+    linear-gradient(45deg, transparent 44%, #000 44% 56%, transparent 56%),
+    linear-gradient(-45deg, transparent 44%, #000 44% 56%, transparent 56%);
+  mask-position: center;
+  mask-repeat: no-repeat;
+  mask-size: 12px 12px;
+  opacity: 0.7;
+  transition:
+    background-color 0.15s ease-in-out,
+    opacity 0.15s ease-in-out;
+}
+
+input[type='search']::-webkit-search-cancel-button:hover {
+  background-color: var(--primary-color);
+  opacity: 1;
+}
+
+input[type='search']::-webkit-search-cancel-button:active {
+  background-color: var(--primary-color-active);
+}
+
 /*************** RULE TWEAKS ***************/
 
 /* Default sidenav hover text color and primary input color not needed to be changed for most themes */

--- a/static/locales/de-DE.yaml
+++ b/static/locales/de-DE.yaml
@@ -1010,7 +1010,7 @@ Settings:
     Hide Channel Courses: Tab „Kurse“ im Kanal ausblenden
     Hide Channel Posts: Tab „Beiträge“ im Kanal ausblenden
     Hide Subscriptions Posts: Beiträge aus Abos ausblenden
-    Shorten View Counts: Aufrufzahlen abkürzen
+    Shorten View Counts: Aufrufzahlen und Kommentar-Likes abkürzen
     Hide Live Chat Replay: Livechat-Wiederholung ausblenden
     Hide End-Screen Annotations: Anmerkungen auf dem Abspann ausblenden
     Hide Paid Promotion Badge: Hinweis auf bezahlte Werbung ausblenden
@@ -1847,6 +1847,10 @@ Comments:
   Top comments: Top-Kommentare
   Show More Replies: Weitere Antworten anzeigen
   Pinned by: Angeheftet von
+  Pinned by you: Von dir angeheftet
+  From creator: Vom Ersteller
+  Pin comment by author: Kommentar von {author} anheften
+  Unpin comment by author: Kommentar von {author} lösen
   Member: Mitglied
   View {replyCount} replies: '1 Antwort ansehen | {replyCount} Antworten ansehen'
   Hearted: Gefällt mir
@@ -1868,6 +1872,9 @@ Comments:
     sie gelöscht oder ausgeblendet, daher wurde die Antwortschaltfläche entfernt.
   Highlighted comment: Hervorgehobener Kommentar
   Highlighted reply: Hervorgehobene Antwort
+  Search loaded comments: Geladene Kommentare durchsuchen
+  Loaded comment search result count: 1 von {total} geladenen Kommentaren | {count} von {total} geladenen Kommentaren
+  No loaded comments match your filters: Keine geladenen Kommentare entsprechen deinen Filtern
   Translate to {language}: Auf {language} übersetzen
   Show original: Original anzeigen
   Translating comment, please wait: Kommentar wird übersetzt, bitte warten
@@ -2049,8 +2056,8 @@ Tooltips:
     Hide Videos, Playlists and Channels Containing Text: Gib ein Wort, einen Teil eines Wortes oder einen Satz ein (Groß-/Kleinschreibung wird ignoriert), um alle Videos und Playlists, welche es in ihren Originaltiteln enthalten, auf ganz OpenTubeX auszublenden. Dein Verlauf, deine eigenen Playlists und Videos innerhalb Playlists sind davon nicht betroffen.
     Hide Videos on Watch: Blendet bereits angesehene Videos aus den Tabs „Videos“, „Shorts“ und „Live“ der Abo- und Kanalseiten aus. Beeinflusst nicht den „Home“-Tab der Kanalseiten
     Shorten View Counts: >-
-      Zeigt von YouTube bereits gerundete Aufrufzahlen in abgekürzter Form an, z. B. 14 Tsd. statt 14.000. Exakte
-      Aufrufzahlen werden immer vollständig angezeigt.
+      Zeigt von YouTube bereits gerundete Aufrufzahlen und Like-Zahlen von Kommentaren in abgekürzter Form an,
+      z. B. 14 Tsd. statt 14.000. Exakte Zahlen werden immer vollständig angezeigt.
   SponsorBlock Settings:
     UseDeArrowTitles: Videotitel durch von der Community eingereichte Titel von DeArrow ersetzen.
     UseDeArrowThumbnails: Video-Miniaturansichten durch Miniaturansichten von DeArrow ersetzen.

--- a/static/locales/de-DE.yaml
+++ b/static/locales/de-DE.yaml
@@ -1848,7 +1848,10 @@ Comments:
   Show More Replies: Weitere Antworten anzeigen
   Pinned by: Angeheftet von
   Pinned by you: Von dir angeheftet
+  Filter loaded comments: Geladene Kommentare filtern
+  Comment filters: Kommentarfilter
   From creator: Vom Ersteller
+  Contains timestamps: Enthält Zeitstempel
   Pin comment by author: Kommentar von {author} anheften
   Unpin comment by author: Kommentar von {author} lösen
   Member: Mitglied

--- a/static/locales/en-US.yaml
+++ b/static/locales/en-US.yaml
@@ -2149,7 +2149,10 @@ Comments:
   Load More Comments: Load More Comments
   Pinned by: Pinned by
   Pinned by you: Pinned by you
+  Filter loaded comments: Filter loaded comments
+  Comment filters: Comment filters
   From creator: From creator
+  Contains timestamps: Contains timestamps
   Pin comment by author: Pin comment by {author}
   Unpin comment by author: Unpin comment by {author}
   Member: Member

--- a/static/locales/en-US.yaml
+++ b/static/locales/en-US.yaml
@@ -1210,7 +1210,7 @@ Settings:
       Visible While Paused: Visible While Paused in Full Window / Full Screen
     Hide Video Views: Hide Video Views
     Hide Channel Avatars: Hide Channel Avatars
-    Shorten View Counts: Shorten View Counts
+    Shorten View Counts: Shorten View and Comment Like Counts
     Hide Video Likes And Dislikes: Hide Video Likes And Dislikes
     Hide Channel Subscribers: Hide Channel Subscribers
     Hide Comment Likes: Hide Comment Likes
@@ -2148,12 +2148,19 @@ Comments:
   YouTube did not provide advertised replies: YouTube showed that this comment has replies, but did not provide them. They may have been deleted or hidden, so the reply button was removed.
   Load More Comments: Load More Comments
   Pinned by: Pinned by
+  Pinned by you: Pinned by you
+  From creator: From creator
+  Pin comment by author: Pin comment by {author}
+  Unpin comment by author: Unpin comment by {author}
   Member: Member
   Subscribed: Subscribed
   Edited: (edited)
   Hearted: Hearted
   Highlighted comment: Highlighted comment
   Highlighted reply: Highlighted reply
+  Search loaded comments: Search loaded comments
+  Loaded comment search result count: 1 of {total} loaded comments | {count} of {total} loaded comments
+  No loaded comments match your filters: No loaded comments match your filters
   YouTube comment link copied to clipboard: YouTube comment link copied to clipboard
   Translate to {language}: Translate to {language}
   Show original: Show original
@@ -2276,7 +2283,7 @@ Tooltips:
       and for audio conversion. By default, OpenTubeX will assume that FFmpeg can be found
       via the PATH environment variable. If needed, a custom path can be set here.
   Distraction Free Settings:
-    Shorten View Counts: Shows view counts that YouTube has already rounded in a shortened form, e.g. 14K instead of 14,000. Exact view counts are always shown in full.
+    Shorten View Counts: Shows view and comment like counts that YouTube has already rounded in a shortened form, e.g. 14K instead of 14,000. Exact counts are always shown in full.
     Hide Channels: Enter a channel ID to hide all videos, playlists and the channel itself from appearing in search, trending, most popular and recommended.
        The channel ID entered must be a complete match and is case sensitive.
     Hide Subscriptions Live: 'This setting is overridden by the app-wide "{appWideSetting}" setting, in the "{subsection}" section of the "{settingsSection}"'

--- a/tests/unit/comment-pins.test.mjs
+++ b/tests/unit/comment-pins.test.mjs
@@ -1,0 +1,56 @@
+import assert from 'node:assert/strict'
+import test from 'node:test'
+
+import {
+  getCommentPinStorageKey,
+  loadCommentPins,
+  saveCommentPins
+} from '../../src/renderer/helpers/commentPins.js'
+
+function createMemoryStorage (initialValue = null) {
+  let value = initialValue
+
+  return {
+    getItem: () => value,
+    setItem: (_key, nextValue) => { value = nextValue },
+    removeItem: () => { value = null }
+  }
+}
+
+test('keeps personal comment pins separate by profile and video', () => {
+  const storage = createMemoryStorage()
+  const firstVideo = getCommentPinStorageKey('profile-a', 'video-a')
+  const secondVideo = getCommentPinStorageKey('profile-a', 'video-b')
+  const secondProfile = getCommentPinStorageKey('profile-b', 'video-a')
+
+  saveCommentPins(firstVideo, new Set(['comment-a', 'comment-b']), storage)
+
+  assert.deepEqual(loadCommentPins(firstVideo, storage), new Set(['comment-a', 'comment-b']))
+  assert.deepEqual(loadCommentPins(secondVideo, storage), new Set())
+  assert.deepEqual(loadCommentPins(secondProfile, storage), new Set())
+})
+
+test('removes empty pin groups and ignores malformed storage', () => {
+  const contentKey = getCommentPinStorageKey('profile-a', 'video-a')
+  const storage = createMemoryStorage('{not-json')
+
+  assert.deepEqual(loadCommentPins(contentKey, storage), new Set())
+
+  saveCommentPins(contentKey, new Set(['comment-a']), storage)
+  saveCommentPins(contentKey, new Set(), storage)
+
+  assert.equal(storage.getItem('opentubex-comment-pins'), null)
+})
+
+test('keeps pinning usable when storage is unavailable', () => {
+  const contentKey = getCommentPinStorageKey('profile-a', 'video-a')
+  const storage = {
+    getItem: () => { throw new Error('storage unavailable') },
+    setItem: () => { throw new Error('storage unavailable') },
+    removeItem: () => { throw new Error('storage unavailable') }
+  }
+
+  assert.deepEqual(loadCommentPins(contentKey, storage), new Set())
+  assert.doesNotThrow(() => saveCommentPins(contentKey, new Set(['comment-a']), storage))
+  assert.doesNotThrow(() => saveCommentPins(contentKey, new Set(), storage))
+})


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Make sure to follow the contributing guidelines. -->
<!-- Important note, we may remove your pull request if you do not use this provided PR template correctly. -->
<!-- Agent instructions: Preserve every heading, comment, and marker in this template. Never remove or rewrite the release-note-category:start/end, release-note:start/end, or release-note-image:start/end marker pairs. Never remove or rewrite the Release note images section; leave its contents for a human. -->

## Pull Request Type
<!-- Please select what type of pull request this is: [x] -->
- [ ] Bugfix
- [x] Feature Implementation
- [ ] Documentation
- [ ] Other

## Related issue
<!-- Please link the issue your pull request is referring to. -->
<!-- If this pull request fully resolves the relevant issue, put "closes" before the issue number. -->
<!-- Example: "closes #123456". -->

Closes #861.
Closes #889.

## Description
<!-- Please write a clear and concise description of what the pull request does. -->

Long comment sections make it hard to find a loaded comment again, and useful comments can move when their ranking changes.

This adds a compact comment toolbar for searching loaded comments and filtering comments from the video creator. Search matches are highlighted, filtering pauses automatic pagination, and the scroll position is clamped after the list shrinks. Users can also pin comments privately per profile and video; pinned comments stay at the top and persist across reloads.

The existing shortened-view-count setting now also applies to comment likes. This also fixes the dev-server tab context menu so "Copy YouTube Link" uses the tab's stored route.

## Release note category
<!-- Select exactly one category. Every pull request must select one. -->
<!-- Select "Not noteworthy" when the pull request fixes a bug in or improves functionality that has not yet appeared in a stable release. -->
<!-- release-note-category:start -->
- [ ] Not noteworthy
- [ ] Highlights
- [x] More improvements
- [ ] Fixed bugs
<!-- release-note-category:end -->

## Release note
<!-- Required unless "Not noteworthy" is selected. -->
<!-- Write one concise, user-facing entry without a leading bullet. -->
<!-- release-note:start -->
Search loaded comments, filter comments from the video creator, and keep personal comment pins at the top.
<!-- release-note:end -->

## Release note images
<!-- Human-only: Agents must preserve this entire section and leave it empty. -->
<!-- Optional. Paste one or more Markdown images or HTML image tags here. -->
<!-- The release notes will use an HTML image tag and limit images taller than 300 pixels. -->
<!-- release-note-image:start -->

<picture>
  <source media="(prefers-color-scheme: dark)" srcset="https://github.com/OpenTubeX/media/releases/download/attachments/20260827T091534Z-939-comment-search-pins-dark-dark-6a86772413.png">
  <source media="(prefers-color-scheme: light)" srcset="https://github.com/OpenTubeX/media/releases/download/attachments/20260827T091534Z-939-comment-search-pins-light-light-6dc1798855.png">
  <img alt="Comment search and personal pins" src="https://github.com/OpenTubeX/media/releases/download/attachments/20260827T091534Z-939-comment-search-pins-dark-dark-6a86772413.png">
</picture>

<!-- release-note-image:end -->

## Testing
<!-- How can reviewers verify that the PR produces correct results? -->
<!-- Please provide instructions so that others can ensure that your pull request produces correct results. For examples see, https://github.com/FreeTubeApp/FreeTube/pull/5743, https://github.com/FreeTubeApp/FreeTube/pull/7349, https://github.com/FreeTubeApp/FreeTube/pull/5125, https://github.com/FreeTubeApp/FreeTube/pull/7338 -->
<!-- Agent instructions: Only write human-facing steps that explain how to verify the change while running this branch in dev mode. Include expected results and, when applicable, helpful console snippets for interactive verification. Do not include automated checks, commands, results, pass counts, or CI status. -->

1. Open a video with several comments. The search and creator-avatar controls should sit to the left of the sort control.
2. Search for text from a loaded comment. Only matching comments should remain, matching author or body text should be highlighted, and the result count should update.
3. Scroll down before filtering to one result. The comment panel should clamp to the new end without repeated loading or empty space.
4. Pin a comment, then reload the comments or reopen the video. The comment should remain at the top with a compact "Pinned by you" label. It should not appear pinned for another profile or video.
5. Enable and disable "Shorten View and Comment Like Counts". Rounded comment-like counts should switch between compact and full formatting.
6. In a dev-server window, right-click a watch tab and choose "Copy YouTube Link". The clipboard should contain the matching external YouTube URL.

## Additional context
<!-- Add any other context about the pull request here. -->

Personal comment pins remain local to this installation and are not included in sync yet.

