### PR TITLE
feat(release): support themed release note media

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -40,6 +40,7 @@
 <!-- Agent instructions:
 For a noteworthy visible change, add media when it makes the change easier to understand. Prefer a still image unless motion is the point; recordings must use animated WebP.
 Capture the default dark theme. When both app themes can be captured and differ, run `node _scripts/releaseNoteMedia.mjs --dark DARK_FILE --light LIGHT_FILE --alt "DESCRIPTION"`. GitHub will display the matching theme and use dark as the fallback.
+Capture or crop to the smallest region that still makes the change clear. Do not include the full window when the affected component can be understood on its own.
 For one dark capture, run `node _scripts/releaseNoteMedia.mjs FILE --alt "DESCRIPTION"`.
 Check for personal information, tokens, private repository names, and unrelated desktop content before uploading. Uploaded media is public.
 Paste only the generated markup between the marker comments. Leave this section empty when media would not help.

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,6 +1,6 @@
 <!-- Thanks for sending a pull request! Make sure to follow the contributing guidelines. -->
 <!-- Important note, we may remove your pull request if you do not use this provided PR template correctly. -->
-<!-- Agent instructions: Preserve every heading, comment, and marker in this template. Never remove or rewrite the release-note-category:start/end, release-note:start/end, or release-note-image:start/end marker pairs. Never remove or rewrite the Release note images section; leave its contents for a human. -->
+<!-- Agent instructions: Preserve every heading, comment, and marker in this template. Never remove or rewrite the release-note-category:start/end, release-note:start/end, or release-note-image:start/end marker pairs. -->
 
 ## Pull Request Type
 <!-- Please select what type of pull request this is: [x] -->
@@ -35,9 +35,15 @@
 <!-- release-note:end -->
 
 ## Release note images
-<!-- Human-only: Agents must preserve this entire section and leave it empty. -->
-<!-- Optional. Paste one or more Markdown images or HTML image tags here. -->
-<!-- The release notes will use an HTML image tag and limit images taller than 300 pixels. -->
+<!-- Optional. Paste one or more Markdown images, HTML image tags, or dark/light <picture> elements here. -->
+<!-- The release notes normalize the markup and limit images taller than 300 pixels. -->
+<!-- Agent instructions:
+For a noteworthy visible change, add media when it makes the change easier to understand. Prefer a still image unless motion is the point; recordings must use animated WebP.
+Capture the default dark theme. When both app themes can be captured and differ, run `node _scripts/releaseNoteMedia.mjs --dark DARK_FILE --light LIGHT_FILE --alt "DESCRIPTION"`. GitHub will display the matching theme and use dark as the fallback.
+For one dark capture, run `node _scripts/releaseNoteMedia.mjs FILE --alt "DESCRIPTION"`.
+Check for personal information, tokens, private repository names, and unrelated desktop content before uploading. Uploaded media is public.
+Paste only the generated markup between the marker comments. Leave this section empty when media would not help.
+-->
 <!-- release-note-image:start -->
 
 <!-- release-note-image:end -->

--- a/_scripts/releaseNoteMedia.mjs
+++ b/_scripts/releaseNoteMedia.mjs
@@ -1,0 +1,214 @@
+import { execFileSync, spawnSync } from 'node:child_process'
+import crypto from 'node:crypto'
+import fs from 'node:fs'
+import os from 'node:os'
+import path from 'node:path'
+import process from 'node:process'
+import { parseArgs } from 'node:util'
+import { fileURLToPath } from 'node:url'
+
+const MEDIA_REPOSITORY = 'OpenTubeX/media'
+const MEDIA_RELEASE = 'attachments'
+const MIME_EXTENSIONS = new Map([
+  ['image/gif', 'gif'],
+  ['image/jpeg', 'jpg'],
+  ['image/png', 'png'],
+  ['image/webp', 'webp'],
+])
+const VIDEO_MIME_TYPES = new Set([
+  'video/mp4',
+  'video/quicktime',
+  'video/webm',
+])
+
+function usage() {
+  return `Usage:
+  node _scripts/releaseNoteMedia.mjs FILE [--alt ALT_TEXT]
+  node _scripts/releaseNoteMedia.mjs --dark FILE --light FILE --alt ALT_TEXT`
+}
+
+function fail(message) {
+  throw new Error(`${message}\n\n${usage()}`)
+}
+
+function readOptions(args) {
+  let parsed
+
+  try {
+    parsed = parseArgs({
+      allowPositionals: true,
+      args,
+      options: {
+        alt: { type: 'string' },
+        dark: { type: 'string' },
+        light: { type: 'string' },
+      },
+      strict: true,
+    })
+  } catch (error) {
+    fail(error.message)
+  }
+
+  const { values, positionals } = parsed
+  const hasThemeOption = values.dark !== undefined || values.light !== undefined
+
+  if (hasThemeOption) {
+    if (!values.dark || !values.light || positionals.length > 0) {
+      fail('Themed media requires both --dark and --light and no positional file.')
+    }
+
+    return {
+      alt: values.alt || path.basename(values.dark, path.extname(values.dark)),
+      inputs: [
+        { path: values.dark, theme: 'dark' },
+        { path: values.light, theme: 'light' },
+      ],
+    }
+  }
+
+  if (positionals.length !== 1) { fail('Provide one media file.') }
+
+  return {
+    alt: values.alt || path.basename(positionals[0], path.extname(positionals[0])),
+    inputs: [{ path: positionals[0], theme: null }],
+  }
+}
+
+function run(command, args, options = {}) {
+  const result = spawnSync(command, args, {
+    encoding: 'utf8',
+    ...options,
+  })
+
+  if (result.error) { throw result.error }
+  if (result.status !== 0) {
+    throw new Error(result.stderr.trim() || `${command} exited with status ${result.status}.`)
+  }
+
+  return result.stdout.trim()
+}
+
+function slugify(value) {
+  return value
+    .replaceAll(/[^A-Za-z0-9._-]+/g, '-')
+    .replaceAll(/^-+|-+$/g, '') || 'media'
+}
+
+function prepareMedia(input, timestamp, tempDirectory) {
+  const sourcePath = path.resolve(input.path)
+
+  if (!fs.statSync(sourcePath, { throwIfNoEntry: false })?.isFile()) {
+    throw new Error(`Media file not found: ${sourcePath}`)
+  }
+
+  const mimeType = run('file', ['-b', '--mime-type', sourcePath])
+  const imageExtension = MIME_EXTENSIONS.get(mimeType)
+
+  if (!imageExtension && !VIDEO_MIME_TYPES.has(mimeType)) {
+    throw new Error(`Expected a PNG, JPEG, GIF, WebP, MP4, MOV, or WebM file, got ${mimeType}.`)
+  }
+
+  const checksum = crypto.createHash('sha256').update(fs.readFileSync(sourcePath)).digest('hex').slice(0, 10)
+  const sourceName = path.basename(sourcePath, path.extname(sourcePath))
+  const themeSuffix = input.theme ? `-${input.theme}` : ''
+  const extension = imageExtension ?? 'webp'
+  const assetName = `${timestamp}-${slugify(sourceName)}${themeSuffix}-${checksum}.${extension}`
+  const uploadPath = path.join(tempDirectory, assetName)
+
+  if (imageExtension) {
+    fs.copyFileSync(sourcePath, uploadPath)
+  } else {
+    run('ffmpeg', [
+      '-hide_banner',
+      '-loglevel', 'error',
+      '-i', sourcePath,
+      '-map', '0:v:0',
+      '-vf', "fps=10,scale=w='min(800,iw)':h=-2:flags=lanczos",
+      '-an',
+      '-loop', '0',
+      '-c:v', 'libwebp_anim',
+      '-quality', '65',
+      '-compression_level', '4',
+      uploadPath,
+    ])
+  }
+
+  return {
+    assetName,
+    theme: input.theme,
+    uploadPath,
+    url: `https://github.com/${MEDIA_REPOSITORY}/releases/download/${MEDIA_RELEASE}/${assetName}`,
+  }
+}
+
+function escapeHtmlAttribute(value) {
+  return value
+    .replaceAll('&', '&amp;')
+    .replaceAll('"', '&quot;')
+    .replaceAll('<', '&lt;')
+    .replaceAll('>', '&gt;')
+}
+
+export function renderMediaMarkup(media, alt) {
+  const safeAlt = escapeHtmlAttribute(alt)
+
+  if (media.length === 1) {
+    return `<img src="${escapeHtmlAttribute(media[0].url)}" alt="${safeAlt}">`
+  }
+
+  const dark = media.find(({ theme }) => theme === 'dark')
+  const light = media.find(({ theme }) => theme === 'light')
+
+  if (!dark || !light) { throw new Error('Themed media needs a dark and a light asset.') }
+
+  return `<picture>
+  <source media="(prefers-color-scheme: dark)" srcset="${escapeHtmlAttribute(dark.url)}">
+  <source media="(prefers-color-scheme: light)" srcset="${escapeHtmlAttribute(light.url)}">
+  <img alt="${safeAlt}" src="${escapeHtmlAttribute(dark.url)}">
+</picture>`
+}
+
+function upload(media) {
+  execFileSync('gh', [
+    'release',
+    'upload',
+    MEDIA_RELEASE,
+    ...media.map(({ uploadPath }) => uploadPath),
+    '--repo',
+    MEDIA_REPOSITORY,
+  ], {
+    stdio: 'inherit',
+  })
+}
+
+function main() {
+  const options = readOptions(process.argv.slice(2))
+  const tempDirectory = fs.mkdtempSync(path.join(os.tmpdir(), 'opentubex-release-media-'))
+
+  try {
+    const timestamp = new Date().toISOString().replaceAll(/[-:]/g, '').replace(/\.\d{3}Z$/, 'Z')
+    const media = options.inputs.map((input) => prepareMedia(input, timestamp, tempDirectory))
+
+    upload(media)
+
+    console.log('\nPaste this inside the release-note-image markers:\n')
+    console.log(renderMediaMarkup(media, options.alt))
+    console.log('\nDelete the uploaded assets with:')
+    for (const { assetName } of media) {
+      console.log(`gh release delete-asset ${MEDIA_RELEASE} ${assetName} --repo ${MEDIA_REPOSITORY} --yes`)
+    }
+  } finally {
+    fs.rmSync(tempDirectory, { force: true, recursive: true })
+  }
+}
+
+const isMainModule = process.argv[1] && path.resolve(process.argv[1]) === fileURLToPath(import.meta.url)
+
+if (isMainModule) {
+  try {
+    main()
+  } catch (error) {
+    console.error(error.message)
+    process.exitCode = 1
+  }
+}

--- a/_scripts/releaseNotes.mjs
+++ b/_scripts/releaseNotes.mjs
@@ -81,22 +81,86 @@ function extractHtmlAttribute(tag, attribute) {
   return match?.[1] ?? match?.[2] ?? null
 }
 
+function parseThemedReleaseImage(picture) {
+  const content = picture
+    .replace(/^<picture\s*>/i, '')
+    .replace(/<\/picture\s*>$/i, '')
+  const tags = [...content.matchAll(/<source\b[^>]*>|<img\b[^>]*>/gi)]
+  let end = 0
+
+  for (const tag of tags) {
+    if (content.slice(end, tag.index).trim()) {
+      throw new Error('A themed release note image may contain only two <source> tags and one <img> tag.')
+    }
+
+    end = tag.index + tag[0].length
+  }
+
+  if (content.slice(end).trim()) {
+    throw new Error('A themed release note image may contain only two <source> tags and one <img> tag.')
+  }
+
+  const sources = new Map()
+  let fallback = null
+
+  for (const tag of tags) {
+    if (/^<img\b/i.test(tag[0])) {
+      if (fallback) { throw new Error('A themed release note image must contain exactly one <img> tag.') }
+
+      const url = extractHtmlAttribute(tag[0], 'src')
+
+      if (!url) { throw new Error('A themed release note image is missing its fallback src attribute.') }
+
+      fallback = {
+        alt: decodeHtml(extractHtmlAttribute(tag[0], 'alt') ?? ''),
+        url: decodeHtml(url),
+      }
+      continue
+    }
+
+    const media = extractHtmlAttribute(tag[0], 'media')
+    const theme = media?.match(/^\(prefers-color-scheme:\s*(dark|light)\)$/i)?.[1].toLowerCase()
+    const url = extractHtmlAttribute(tag[0], 'srcset')
+
+    if (!theme || !url || sources.has(theme)) {
+      throw new Error('A themed release note image needs one dark and one light <source> tag.')
+    }
+
+    sources.set(theme, decodeHtml(url))
+  }
+
+  if (!fallback || sources.size !== 2 || !sources.has('dark') || !sources.has('light')) {
+    throw new Error('A themed release note image needs one dark source, one light source, and one fallback image.')
+  }
+
+  if (fallback.url !== sources.get('dark')) {
+    throw new Error('A themed release note image must use the dark source as its fallback image.')
+  }
+
+  return {
+    alt: fallback.alt,
+    darkUrl: sources.get('dark'),
+    lightUrl: sources.get('light'),
+    url: fallback.url,
+  }
+}
+
 export function parseReleaseImages(section) {
   if (!section) { return [] }
 
-  const matches = [...section.matchAll(/!\[([^\]]*)\]\(([^\s)]+)(?:\s+["'][^"']*["'])?\)|<img\b[^>]*>/gi)]
+  const matches = [...section.matchAll(/!\[([^\]]*)\]\(([^\s)]+)(?:\s+["'][^"']*["'])?\)|<picture\s*>[\s\S]*?<\/picture\s*>|<img\b[^>]*>/gi)]
   let end = 0
 
   for (const match of matches) {
     if (section.slice(end, match.index).trim()) {
-      throw new Error('Release note images must be Markdown images or <img> tags.')
+      throw new Error('Release note images must be Markdown images, <img> tags, or themed <picture> elements.')
     }
 
     end = match.index + match[0].length
   }
 
   if (section.slice(end).trim()) {
-    throw new Error('Release note images must be Markdown images or <img> tags.')
+    throw new Error('Release note images must be Markdown images, <img> tags, or themed <picture> elements.')
   }
 
   const images = matches
@@ -107,6 +171,8 @@ export function parseReleaseImages(section) {
           url: match[2],
         }
       }
+
+      if (/^<picture\b/i.test(match[0])) { return parseThemedReleaseImage(match[0]) }
 
       const url = extractHtmlAttribute(match[0], 'src')
 
@@ -119,7 +185,7 @@ export function parseReleaseImages(section) {
     })
 
   if (images.length === 0) {
-    throw new Error('Release note images must be Markdown images or <img> tags.')
+    throw new Error('Release note images must be Markdown images, <img> tags, or themed <picture> elements.')
   }
 
   return images
@@ -150,7 +216,10 @@ export function parseReleaseNote(body) {
 
   const images = parseReleaseNoteImages(body)
 
-  for (const image of images) { validateImageUrl(image.url) }
+  for (const image of images) {
+    validateImageUrl(image.url)
+    if (image.lightUrl) { validateImageUrl(image.lightUrl) }
+  }
 
   return { images, note }
 }
@@ -333,16 +402,34 @@ function escapeHtmlAttribute(value) {
 }
 
 export async function normalizeReleaseImage(image, fallbackAlt, loadImage = downloadImage) {
-  const url = validateImageUrl(image.url)
-  const buffer = await loadImage(url)
-  const size = probeImageSize(buffer)
+  const variants = [
+    { theme: 'dark', url: validateImageUrl(image.url) },
+    ...(image.lightUrl ? [{ theme: 'light', url: validateImageUrl(image.lightUrl) }] : []),
+  ]
+  const normalized = []
 
-  if (!size) { throw new Error(`Could not determine the dimensions of ${url}.`) }
+  for (const variant of variants) {
+    const buffer = await loadImage(variant.url)
+    const size = probeImageSize(buffer)
+
+    if (!size) { throw new Error(`Could not determine the dimensions of ${variant.url}.`) }
+
+    normalized.push({ ...variant, size })
+  }
 
   const alt = image.alt || fallbackAlt
-  const height = size.height > MAX_IMAGE_HEIGHT ? ` height="${MAX_IMAGE_HEIGHT}"` : ''
+  const height = normalized.some(({ size }) => size.height > MAX_IMAGE_HEIGHT)
+    ? ` height="${MAX_IMAGE_HEIGHT}"`
+    : ''
+  const darkUrl = escapeHtmlAttribute(normalized[0].url.href)
 
-  return `<img src="${escapeHtmlAttribute(url.href)}" alt="${escapeHtmlAttribute(alt)}"${height}>`
+  if (normalized.length === 2) {
+    const lightUrl = escapeHtmlAttribute(normalized[1].url.href)
+
+    return `<picture>\n  <source media="(prefers-color-scheme: dark)" srcset="${darkUrl}">\n  <source media="(prefers-color-scheme: light)" srcset="${lightUrl}">\n  <img src="${darkUrl}" alt="${escapeHtmlAttribute(alt)}"${height}>\n</picture>`
+  }
+
+  return `<img src="${darkUrl}" alt="${escapeHtmlAttribute(alt)}"${height}>`
 }
 
 function gitIsAncestor(ancestor, descendant) {
@@ -436,7 +523,7 @@ export async function renderReleaseNotes(pullRequests, {
 
     for (const image of parsed.images) {
       try {
-        releaseNote += `\n  ${await normalizeReleaseImage(image, pullRequest.title, loadImage)}`
+        releaseNote += `\n  ${indentContinuationLines(await normalizeReleaseImage(image, pullRequest.title, loadImage))}`
       } catch (error) {
         const imageError = new Error(`PR #${pullRequest.number}: ${error.message}`, { cause: error })
 

--- a/tests/unit/release-note-media.test.mjs
+++ b/tests/unit/release-note-media.test.mjs
@@ -1,0 +1,25 @@
+import assert from 'node:assert/strict'
+import test from 'node:test'
+
+import { renderMediaMarkup } from '../../_scripts/releaseNoteMedia.mjs'
+
+test('a single release note asset renders as an image', () => {
+  assert.equal(renderMediaMarkup([{
+    theme: null,
+    url: 'https://github.com/OpenTubeX/media/releases/download/attachments/settings.webp',
+  }], 'Settings & playback'), '<img src="https://github.com/OpenTubeX/media/releases/download/attachments/settings.webp" alt="Settings &amp; playback">')
+})
+
+test('themed release note assets use the dark image as the fallback', () => {
+  assert.equal(renderMediaMarkup([{
+    theme: 'dark',
+    url: 'https://github.com/OpenTubeX/media/releases/download/attachments/dark.webp',
+  }, {
+    theme: 'light',
+    url: 'https://github.com/OpenTubeX/media/releases/download/attachments/light.webp',
+  }], 'Settings'), `<picture>
+  <source media="(prefers-color-scheme: dark)" srcset="https://github.com/OpenTubeX/media/releases/download/attachments/dark.webp">
+  <source media="(prefers-color-scheme: light)" srcset="https://github.com/OpenTubeX/media/releases/download/attachments/light.webp">
+  <img alt="Settings" src="https://github.com/OpenTubeX/media/releases/download/attachments/dark.webp">
+</picture>`)
+})

--- a/tests/unit/release-notes.test.mjs
+++ b/tests/unit/release-notes.test.mjs
@@ -213,6 +213,47 @@ ${NOTE_MARKERS}
   })
 })
 
+test('dark and light release note images are parsed from a picture element', () => {
+  const result = parseReleaseNote(`
+${NOTE_MARKERS}
+<!-- release-note-image:start -->
+<picture>
+  <source media="(prefers-color-scheme: dark)" srcset="https://github.com/OpenTubeX/media/releases/download/attachments/dark.webp">
+  <source media="(prefers-color-scheme: light)" srcset="https://github.com/OpenTubeX/media/releases/download/attachments/light.webp">
+  <img alt="The settings panel" src="https://github.com/OpenTubeX/media/releases/download/attachments/dark.webp">
+</picture>
+<!-- release-note-image:end -->
+`)
+
+  assert.deepEqual(result.images, [{
+    alt: 'The settings panel',
+    darkUrl: 'https://github.com/OpenTubeX/media/releases/download/attachments/dark.webp',
+    lightUrl: 'https://github.com/OpenTubeX/media/releases/download/attachments/light.webp',
+    url: 'https://github.com/OpenTubeX/media/releases/download/attachments/dark.webp',
+  }])
+})
+
+test('themed release note images require a dark fallback and both theme sources', () => {
+  const releaseNoteWithPicture = (sources, fallback = 'dark.webp') => `
+${NOTE_MARKERS}
+<!-- release-note-image:start -->
+<picture>
+  ${sources}
+  <img alt="Settings" src="https://github.com/OpenTubeX/media/releases/download/attachments/${fallback}">
+</picture>
+<!-- release-note-image:end -->
+`
+
+  assert.throws(() => parseReleaseNote(releaseNoteWithPicture(`
+    <source media="(prefers-color-scheme: dark)" srcset="https://github.com/OpenTubeX/media/releases/download/attachments/dark.webp">
+  `)), /one dark source, one light source/)
+
+  assert.throws(() => parseReleaseNote(releaseNoteWithPicture(`
+    <source media="(prefers-color-scheme: dark)" srcset="https://github.com/OpenTubeX/media/releases/download/attachments/dark.webp">
+    <source media="(prefers-color-scheme: light)" srcset="https://github.com/OpenTubeX/media/releases/download/attachments/light.webp">
+  `, 'light.webp')), /dark source as its fallback/)
+})
+
 test('HTML entities in image attributes are decoded only once', () => {
   const result = parseReleaseNote(`
 ${NOTE_MARKERS}
@@ -267,7 +308,7 @@ ${NOTE_MARKERS}
 ![Screenshot](https://github.com/user-attachments/assets/example)
 ${malformedImage}
 <!-- release-note-image:end -->
-`), /must be Markdown images or <img> tags/)
+`), /must be Markdown images/)
   }
 })
 
@@ -337,6 +378,48 @@ test('images up to 300 pixels have no dimensions', async () => {
     result,
     '<img src="https://github.com/user-attachments/assets/example" alt="Compact player">',
   )
+})
+
+test('themed images keep the dark fallback and limit either tall variant', async () => {
+  const result = await normalizeReleaseImage({
+    alt: 'Settings',
+    darkUrl: 'https://github.com/OpenTubeX/media/releases/download/attachments/dark.webp',
+    lightUrl: 'https://github.com/OpenTubeX/media/releases/download/attachments/light.webp',
+    url: 'https://github.com/OpenTubeX/media/releases/download/attachments/dark.webp',
+  }, 'Fallback', async (url) => png(800, url.href.endsWith('light.webp') ? 301 : 300))
+
+  assert.equal(result, `<picture>
+  <source media="(prefers-color-scheme: dark)" srcset="https://github.com/OpenTubeX/media/releases/download/attachments/dark.webp">
+  <source media="(prefers-color-scheme: light)" srcset="https://github.com/OpenTubeX/media/releases/download/attachments/light.webp">
+  <img src="https://github.com/OpenTubeX/media/releases/download/attachments/dark.webp" alt="Settings" height="300">
+</picture>`)
+})
+
+test('themed images stay inside their release note list item', async () => {
+  const result = await renderReleaseNotes([{
+    body: pullRequestBody('Highlights', {
+      images: `<picture>
+  <source media="(prefers-color-scheme: dark)" srcset="https://github.com/OpenTubeX/media/releases/download/attachments/dark.webp">
+  <source media="(prefers-color-scheme: light)" srcset="https://github.com/OpenTubeX/media/releases/download/attachments/light.webp">
+  <img alt="Settings" src="https://github.com/OpenTubeX/media/releases/download/attachments/dark.webp">
+</picture>`,
+      note: 'Adds theme-aware settings.',
+    }),
+    number: 42,
+    title: 'Theme-aware settings',
+  }], {
+    loadImage: async () => png(800, 300),
+  })
+
+  assert.equal(result, `## Highlights
+
+- Adds theme-aware settings. (#42)
+  <picture>
+    <source media="(prefers-color-scheme: dark)" srcset="https://github.com/OpenTubeX/media/releases/download/attachments/dark.webp">
+    <source media="(prefers-color-scheme: light)" srcset="https://github.com/OpenTubeX/media/releases/download/attachments/light.webp">
+    <img src="https://github.com/OpenTubeX/media/releases/download/attachments/dark.webp" alt="Settings">
+  </picture>
+`)
 })
 
 test('release notes render under their selected categories', async () => {


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Make sure to follow the contributing guidelines. -->
<!-- Important note, we may remove your pull request if you do not use this provided PR template correctly. -->
<!-- Agent instructions: Preserve every heading, comment, and marker in this template. Never remove or rewrite the release-note-category:start/end, release-note:start/end, or release-note-image:start/end marker pairs. -->

## Pull Request Type
<!-- Please select what type of pull request this is: [x] -->
- [ ] Bugfix
- [x] Feature Implementation
- [ ] Documentation
- [ ] Other

## Related issue
<!-- Please link the issue your pull request is referring to. -->
<!-- If this pull request fully resolves the relevant issue, put "closes" before the issue number. -->
<!-- Example: "closes #123456". -->

None.

## Description
<!-- Please write a clear and concise description of what the pull request does. -->

Agents could not add release-note visuals because the pull request template reserved the image section for humans. The release-note generator also had no way to preserve separate dark and light captures.

This adds a media uploader backed by the public `OpenTubeX/media` release. It accepts still images and converts videos to animated WebP. Paired captures use GitHub's theme-aware `<picture>` markup with the dark image as the fallback, and the release-note generator validates and preserves that markup in generated releases.

## Release note category
<!-- Select exactly one category. Every pull request must select one. -->
<!-- Select "Not noteworthy" when the pull request fixes a bug in or improves functionality that has not yet appeared in a stable release. -->
<!-- release-note-category:start -->
- [x] Not noteworthy
- [ ] Highlights
- [ ] More improvements
- [ ] Fixed bugs
<!-- release-note-category:end -->

## Release note
<!-- Required unless "Not noteworthy" is selected. -->
<!-- Write one concise, user-facing entry without a leading bullet. -->
<!-- release-note:start -->

<!-- release-note:end -->

## Release note images
<!-- Optional. Paste one or more Markdown images, HTML image tags, or dark/light <picture> elements here. -->
<!-- The release notes normalize the markup and limit images taller than 300 pixels. -->
<!-- Agent instructions:
For a noteworthy visible change, add media when it makes the change easier to understand. Prefer a still image unless motion is the point; recordings must use animated WebP.
Capture the default dark theme. When both app themes can be captured and differ, run `node _scripts/releaseNoteMedia.mjs --dark DARK_FILE --light LIGHT_FILE --alt "DESCRIPTION"`. GitHub will display the matching theme and use dark as the fallback.
For one dark capture, run `node _scripts/releaseNoteMedia.mjs FILE --alt "DESCRIPTION"`.
Check for personal information, tokens, private repository names, and unrelated desktop content before uploading. Uploaded media is public.
Paste only the generated markup between the marker comments. Leave this section empty when media would not help.
-->
<!-- release-note-image:start -->

<!-- release-note-image:end -->

## Testing
<!-- How can reviewers verify that the PR produces correct results? -->
<!-- Please provide instructions so that others can ensure that your pull request would produce correct results. For examples see, https://github.com/FreeTubeApp/FreeTube/pull/5743, https://github.com/FreeTubeApp/FreeTube/pull/7349, https://github.com/FreeTubeApp/FreeTube/pull/5125, https://github.com/FreeTubeApp/FreeTube/pull/7338 -->
<!-- Agent instructions: Only write human-facing steps that explain how to verify the change while running this branch in dev mode. Include expected results and, when applicable, helpful console snippets for interactive verification. Do not include automated checks, commands, results, pass counts, or CI status. -->

Not applicable to dev mode. This changes contributor tooling and release generation rather than the running app.

## Additional context
<!-- Add any other context about the pull request here. -->

Media assets are stored in [OpenTubeX/media](https://github.com/OpenTubeX/media/releases/tag/attachments) instead of the application repository's Git history.
