### PR TITLE
feat(settings): add adjustable scroll speed

### DIFF
--- a/e2e/tests/offline/scrollbar-overlay.spec.mjs
+++ b/e2e/tests/offline/scrollbar-overlay.spec.mjs
@@ -32,6 +32,25 @@ test.describe('overlay scrollbars', () => {
     expect(clientWidth).toBe(innerWidth)
   })
 
+  test('applies the configured wheel speed to page scrolling', async ({ page }) => {
+    await addPageOverflow(page)
+    await page.evaluate(() => {
+      const store = document.querySelector('#app').__vue_app__.config.globalProperties.$store
+      store.commit('setScrollSpeed', 200)
+      window.ftElectron.setZoomFactor(1.25)
+      document.addEventListener('wheel', (event) => {
+        window.__scrollSpeedTestDelta = event.deltaY
+      }, { capture: true, once: true })
+    })
+
+    await page.mouse.move(800, 400)
+    await page.mouse.wheel(0, 120)
+    await expect.poll(() => page.evaluate(() => (
+      window.__scrollSpeedTestDelta > 0 &&
+      window.scrollY === window.__scrollSpeedTestDelta * 2
+    ))).toBe(true)
+  })
+
   test('the page scrollbar stays on the content side of right vertical tabs', async ({ page }) => {
     await addPageOverflow(page)
     await page.evaluate(() => {

--- a/e2e/tests/offline/scrollbar-overlay.spec.mjs
+++ b/e2e/tests/offline/scrollbar-overlay.spec.mjs
@@ -202,6 +202,85 @@ test.describe('overlay scrollbars', () => {
       expect(measurements.scrollTop).toBe(120)
     })
 
+    test('only adds a blocking wheel listener while a custom speed is active', async ({ page }) => {
+      const listenerCounts = await page.evaluate(() => {
+        const viewport = document.createElement('div')
+        viewport.style.overflowY = 'auto'
+        const content = document.createElement('div')
+        content.style.height = '300px'
+        viewport.append(content)
+        document.body.append(viewport)
+
+        const counts = { added: 0, removed: 0 }
+        const addEventListener = viewport.addEventListener.bind(viewport)
+        const removeEventListener = viewport.removeEventListener.bind(viewport)
+        viewport.addEventListener = (type, listener, options) => {
+          if (type === 'wheel' && options?.passive === false) counts.added++
+          addEventListener(type, listener, options)
+        }
+        viewport.removeEventListener = (type, listener, options) => {
+          if (type === 'wheel') counts.removed++
+          removeEventListener(type, listener, options)
+        }
+
+        const app = document.querySelector('#app').__vue_app__
+        const store = app.config.globalProperties.$store
+        app._context.directives['overlay-scrollbars'].mounted(viewport, { value: true })
+        const afterDefaultSetup = { ...counts }
+        store.commit('setScrollSpeed', 200)
+        const afterCustomSpeed = { ...counts }
+        store.commit('setScrollSpeed', 100)
+
+        return { afterDefaultSetup, afterCustomSpeed, afterReset: counts }
+      })
+
+      expect(listenerCounts).toEqual({
+        afterDefaultSetup: { added: 0, removed: 0 },
+        afterCustomSpeed: { added: 1, removed: 0 },
+        afterReset: { added: 1, removed: 1 },
+      })
+    })
+
+    test('bubbles scaled wheel input from a nested boundary to the page', async ({ page }) => {
+      await addPageOverflow(page)
+      await page.evaluate(() => {
+        const viewport = document.createElement('div')
+        viewport.dataset.scrollSpeedBubbleTest = ''
+        Object.assign(viewport.style, {
+          height: '100px',
+          left: '100px',
+          overflowY: 'auto',
+          position: 'fixed',
+          top: '100px',
+          width: '200px',
+          zIndex: '9999',
+        })
+        const content = document.createElement('div')
+        content.style.height = '300px'
+        viewport.append(content)
+        document.body.append(viewport)
+
+        const app = document.querySelector('#app').__vue_app__
+        const store = app.config.globalProperties.$store
+        app._context.directives['overlay-scrollbars'].mounted(viewport, { value: true })
+        store.commit('setScrollSpeed', 200)
+        viewport.scrollTop = viewport.scrollHeight
+        window.scrollTo(0, 0)
+        document.addEventListener('wheel', (event) => {
+          window.__scrollSpeedBubbleTestDelta = event.deltaY
+        }, { capture: true, once: true })
+      })
+
+      const viewport = page.locator('[data-scroll-speed-bubble-test]')
+      await viewport.hover()
+      await page.mouse.wheel(0, 120)
+
+      await expect.poll(() => page.evaluate(() => (
+        window.__scrollSpeedBubbleTestDelta > 0 &&
+        window.scrollY === window.__scrollSpeedBubbleTestDelta * 2
+      ))).toBe(true)
+    })
+
     test('reconciles an end position after the viewport grows', async ({ page }) => {
       await page.evaluate(() => {
         const viewport = document.createElement('div')

--- a/e2e/tests/offline/settings.spec.mjs
+++ b/e2e/tests/offline/settings.spec.mjs
@@ -2350,6 +2350,8 @@ test.describe('settings', () => {
     await goTo(page, 'settings')
 
     await page.evaluate(() => {
+      const store = document.querySelector('#app').__vue_app__.config.globalProperties.$store
+      store.commit('setScrollSpeed', 200)
       document.body.style.minBlockSize = '4000px'
       document.scrollingElement.scrollTop = 1000
     })
@@ -2586,6 +2588,35 @@ test.describe('settings', () => {
       return store.dispatch('updateReducedMotion', 'off')
     })
     await expect(slider).toBeEnabled()
+  })
+
+  test('configures wheel scroll speed', async ({ page }) => {
+    await goTo(page, 'settings')
+    await page.locator('.settingsMenu [data-section="appearance"]').click()
+
+    const slider = page.getByRole('slider', { name: /Scroll Speed/ })
+    await expect(slider).toHaveValue('100')
+    await slider.fill('200')
+    await expect.poll(() => page.evaluate(() => {
+      const store = document.querySelector('#app').__vue_app__.config.globalProperties.$store
+      return store.getters.getScrollSpeed
+    })).toBe(200)
+
+    const content = page.locator('.settingsContent')
+    await content.evaluate(element => { element.scrollTop = 0 })
+    await content.hover({ position: { x: 20, y: 20 } })
+    await page.mouse.wheel(0, 120)
+    await expect.poll(() => content.evaluate(element => element.scrollTop)).toBe(240)
+
+    await slider.fill('50')
+    await expect.poll(() => page.evaluate(() => {
+      const store = document.querySelector('#app').__vue_app__.config.globalProperties.$store
+      return store.getters.getScrollSpeed
+    })).toBe(50)
+    await content.evaluate(element => { element.scrollTop = 0 })
+    await content.hover({ position: { x: 20, y: 20 } })
+    await page.mouse.wheel(0, 120)
+    await expect.poll(() => content.evaluate(element => element.scrollTop)).toBe(60)
   })
 
   test('keeps the watched progress mode when history is toggled', async ({ page }) => {
@@ -4433,19 +4464,19 @@ test.describe('synced setting indicators', () => {
     await goTo(page, 'settings')
     const themeSection = await goToSettingsSection(page, 'appearance')
     const sliders = themeSection.locator('.sliderGrid > *')
-    await expect(sliders).toHaveCount(5)
+    await expect(sliders).toHaveCount(6)
 
     const boxes = await sliders.evaluateAll((elements) => elements.map((element) => {
       const { y, width } = element.getBoundingClientRect()
       return { y: Math.round(y), width: Math.round(width) }
     }))
 
-    // Three and two, rather than four squeezed together and a lone fifth.
+    // Two even rows, rather than four squeezed together and two below.
     const rowSizes = new Map()
     for (const { y } of boxes) {
       rowSizes.set(y, (rowSizes.get(y) ?? 0) + 1)
     }
-    expect([...rowSizes.values()]).toEqual([3, 2])
+    expect([...rowSizes.values()]).toEqual([3, 3])
     // The row they landed on doesn't change how much room they get.
     expect(new Set(boxes.map(({ width }) => width)).size).toBe(1)
   })

--- a/src/renderer/components/ThemeSettings.vue
+++ b/src/renderer/components/ThemeSettings.vue
@@ -311,6 +311,17 @@
         @change="updateScrollbarThumbWidth"
       />
       <FtSlider
+        :label="t('Settings.Theme Settings.Scroll Speed')"
+        :tooltip="t('Tooltips.Theme Settings.Scroll Speed')"
+        :default-value="scrollSpeed"
+        setting-key="scrollSpeed"
+        :min-value="MIN_SCROLL_SPEED"
+        :max-value="MAX_SCROLL_SPEED"
+        :step="SCROLL_SPEED_STEP"
+        value-extension="%"
+        @change="updateScrollSpeed"
+      />
+      <FtSlider
         :label="t('Settings.Theme Settings.Animation Speed')"
         :default-value="animationSpeed"
         setting-key="animationSpeed"
@@ -375,6 +386,12 @@ import {
 } from '../constants/scrollbar'
 import { normalizeToastPosition, TOAST_POSITION_VALUES } from '../constants/toastPosition'
 import { setAnimationSpeed } from '../helpers/animationSpeed'
+import {
+  MAX_SCROLL_SPEED,
+  MIN_SCROLL_SPEED,
+  normalizeScrollSpeed,
+  SCROLL_SPEED_STEP
+} from '../helpers/scrollSpeed'
 import { getMissingTabAvatarTabs, loadMissingTabAvatars } from '../helpers/loadTabAvatars'
 import { showToast } from '../helpers/utils'
 import { ICON_PACKS } from '../icons/iconPackState'
@@ -822,6 +839,7 @@ const uiRoundness = computed(() => store.getters.getUiRoundness)
 const scrollbarThumbWidth = computed(
   () => normalizeScrollbarThumbWidth(store.getters.getScrollbarThumbWidth)
 )
+const scrollSpeed = computed(() => normalizeScrollSpeed(store.getters.getScrollSpeed))
 const animationSpeed = computed(() => store.getters.getAnimationSpeed)
 
 const systemReducedMotion = window.matchMedia('(prefers-reduced-motion: reduce)')
@@ -883,6 +901,13 @@ function previewScrollbarThumbWidth(value) {
  */
 function updateScrollbarThumbWidth(value) {
   store.dispatch('updateScrollbarThumbWidth', value)
+}
+
+/**
+ * @param {number} value
+ */
+function updateScrollSpeed(value) {
+  store.dispatch('updateScrollSpeed', value)
 }
 
 /**

--- a/src/renderer/helpers/overlayScrollbars.js
+++ b/src/renderer/helpers/overlayScrollbars.js
@@ -2,6 +2,11 @@ import { watch } from 'vue'
 import { ClickScrollPlugin, OverlayScrollbars } from 'overlayscrollbars'
 
 import store from '../store/index'
+import {
+  addScrollSpeedHandler,
+  DEFAULT_SCROLL_SPEED,
+  normalizeScrollSpeed
+} from './scrollSpeed'
 
 // Kept out of the core bundle by the library, so `clickScroll` below silently
 // does nothing unless it is registered.
@@ -20,6 +25,8 @@ OverlayScrollbars.plugin(ClickScrollPlugin)
  * @type {Map<import('overlayscrollbars').OverlayScrollbars, HTMLElement | object>}
  */
 const instances = new Map()
+/** @type {WeakMap<import('overlayscrollbars').OverlayScrollbars, () => void>} */
+const removeScrollSpeedHandlers = new WeakMap()
 const SCROLL_BOUNDARY_TOLERANCE = 1
 
 function scrollbarOptions(initialization) {
@@ -53,7 +60,11 @@ function scrollbarOptions(initialization) {
 function create(initialization) {
   const instance = OverlayScrollbars(initialization, scrollbarOptions(initialization))
   instances.set(instance, initialization)
-  instance.on('destroyed', () => instances.delete(instance))
+  updateScrollSpeedHandler(instance)
+  instance.on('destroyed', () => {
+    instances.delete(instance)
+    removeScrollSpeedHandler(instance)
+  })
 
   if (initialization === document.body) {
     updateBodyScrollbarPosition(instance)
@@ -63,6 +74,34 @@ function create(initialization) {
   }
 
   return instance
+}
+
+/**
+ * Blocking wheel listeners keep Chromium's scrolling on the main thread, so
+ * only install them while a custom speed is active. At 100%, Chromium handles
+ * wheel and touchpad input without renderer involvement.
+ *
+ * @param {import('overlayscrollbars').OverlayScrollbars} instance
+ */
+function updateScrollSpeedHandler(instance) {
+  const usesCustomSpeed = normalizeScrollSpeed(store.getters.getScrollSpeed) !== DEFAULT_SCROLL_SPEED
+  const hasHandler = removeScrollSpeedHandlers.has(instance)
+
+  if (usesCustomSpeed && !hasHandler) {
+    const { scrollOffsetElement } = instance.elements()
+    removeScrollSpeedHandlers.set(instance, addScrollSpeedHandler(
+      scrollOffsetElement,
+      () => store.getters.getScrollSpeed
+    ))
+  } else if (!usesCustomSpeed && hasHandler) {
+    removeScrollSpeedHandler(instance)
+  }
+}
+
+/** @param {import('overlayscrollbars').OverlayScrollbars} instance */
+function removeScrollSpeedHandler(instance) {
+  removeScrollSpeedHandlers.get(instance)?.()
+  removeScrollSpeedHandlers.delete(instance)
 }
 
 /**
@@ -253,6 +292,16 @@ function optimizeBodyScrollbarDrag(instance) {
  */
 export function initializeAppScrollbars() {
   create(document.body)
+
+  watch(
+    () => normalizeScrollSpeed(store.getters.getScrollSpeed),
+    () => {
+      for (const instance of instances.keys()) {
+        updateScrollSpeedHandler(instance)
+      }
+    },
+    { flush: 'sync' }
+  )
 
   watch(
     () => [store.getters.getTabBarPosition, store.getters.getVerticalTabBarWidth],

--- a/src/renderer/helpers/scrollSpeed.js
+++ b/src/renderer/helpers/scrollSpeed.js
@@ -3,7 +3,6 @@ export const MIN_SCROLL_SPEED = 25
 export const MAX_SCROLL_SPEED = 300
 export const SCROLL_SPEED_STEP = 5
 
-const SCROLLABLE_OVERFLOW = new Set(['auto', 'scroll'])
 const CONTAINED_OVERSCROLL = new Set(['contain', 'none'])
 
 /**
@@ -18,14 +17,15 @@ export function normalizeScrollSpeed(value) {
 }
 
 /**
- * Applies the configured speed to ordinary wheel scrolling. Wheel gestures
- * owned by a component, such as player controls and Shorts navigation, call
- * preventDefault before reaching this handler and keep their existing action.
+ * Applies the configured speed to one scrolling element. Register this on
+ * every OverlayScrollbars scroll offset element so native event bubbling can
+ * hand input from a nested boundary to its parent.
  *
+ * @param {HTMLElement} element
  * @param {() => number} getScrollSpeed
  * @returns {() => void} removes the listener
  */
-export function initializeScrollSpeed(getScrollSpeed) {
+export function addScrollSpeedHandler(element, getScrollSpeed) {
   const handleWheel = (event) => {
     if (event.defaultPrevented || event.ctrlKey || event.metaKey) {
       return
@@ -41,25 +41,25 @@ export function initializeScrollSpeed(getScrollSpeed) {
       return
     }
 
-    const target = findWheelScrollTarget(event, wheel.axis, wheel.delta)
-    if (target === null) {
+    if (!canScroll(element, wheel.axis, wheel.delta)) {
+      if (hasContainedOverscroll(element, wheel.axis)) {
+        // The default scroll is canceled at a contained boundary. Parent
+        // handlers see defaultPrevented and leave the page in place.
+        event.preventDefault()
+      }
       return
     }
 
     event.preventDefault()
-    if (target.element === null) {
-      return
-    }
-
-    const distance = wheelDeltaInPixels(event, target.element, wheel.axis, wheel.delta) *
+    const distance = wheelDeltaInPixels(event, element, wheel.axis, wheel.delta) *
       speed / DEFAULT_SCROLL_SPEED
-    target.element.scrollBy(wheel.axis === 'x'
+    element.scrollBy(wheel.axis === 'x'
       ? { left: distance }
       : { top: distance })
   }
 
-  document.addEventListener('wheel', handleWheel, { passive: false })
-  return () => document.removeEventListener('wheel', handleWheel)
+  element.addEventListener('wheel', handleWheel, { passive: false })
+  return () => element.removeEventListener('wheel', handleWheel)
 }
 
 /**
@@ -78,41 +78,16 @@ function getPrimaryWheelMovement(event) {
 }
 
 /**
- * @param {WheelEvent} event
+ * @param {HTMLElement} element
  * @param {'x' | 'y'} axis
- * @param {number} delta
- * @returns {{ element: HTMLElement | null } | null}
+ * @returns {boolean}
  */
-function findWheelScrollTarget(event, axis, delta) {
-  for (const target of event.composedPath()) {
-    if (!(target instanceof HTMLElement) ||
-      target === document.body ||
-      target === document.documentElement) {
-      continue
-    }
-
-    const style = getComputedStyle(target)
-    const overflow = axis === 'x' ? style.overflowX : style.overflowY
-    if (!SCROLLABLE_OVERFLOW.has(overflow)) {
-      continue
-    }
-
-    if (canScroll(target, axis, delta)) {
-      return { element: target }
-    }
-
-    const overscrollBehavior = axis === 'x'
-      ? style.overscrollBehaviorX
-      : style.overscrollBehaviorY
-    if (CONTAINED_OVERSCROLL.has(overscrollBehavior)) {
-      return { element: null }
-    }
-  }
-
-  const page = document.scrollingElement
-  return page instanceof HTMLElement && canScroll(page, axis, delta)
-    ? { element: page }
-    : null
+function hasContainedOverscroll(element, axis) {
+  const style = getComputedStyle(element)
+  const overscrollBehavior = axis === 'x'
+    ? style.overscrollBehaviorX
+    : style.overscrollBehaviorY
+  return CONTAINED_OVERSCROLL.has(overscrollBehavior)
 }
 
 /**

--- a/src/renderer/helpers/scrollSpeed.js
+++ b/src/renderer/helpers/scrollSpeed.js
@@ -1,0 +1,148 @@
+export const DEFAULT_SCROLL_SPEED = 100
+export const MIN_SCROLL_SPEED = 25
+export const MAX_SCROLL_SPEED = 300
+export const SCROLL_SPEED_STEP = 5
+
+const SCROLLABLE_OVERFLOW = new Set(['auto', 'scroll'])
+const CONTAINED_OVERSCROLL = new Set(['contain', 'none'])
+
+/**
+ * @param {unknown} value percentage of the browser's default wheel distance
+ * @returns {number}
+ */
+export function normalizeScrollSpeed(value) {
+  const speed = typeof value === 'number' ? value : Number.parseFloat(value)
+  return Number.isFinite(speed) && speed > 0
+    ? Math.min(Math.max(speed, MIN_SCROLL_SPEED), MAX_SCROLL_SPEED)
+    : DEFAULT_SCROLL_SPEED
+}
+
+/**
+ * Applies the configured speed to ordinary wheel scrolling. Wheel gestures
+ * owned by a component, such as player controls and Shorts navigation, call
+ * preventDefault before reaching this handler and keep their existing action.
+ *
+ * @param {() => number} getScrollSpeed
+ * @returns {() => void} removes the listener
+ */
+export function initializeScrollSpeed(getScrollSpeed) {
+  const handleWheel = (event) => {
+    if (event.defaultPrevented || event.ctrlKey || event.metaKey) {
+      return
+    }
+
+    const speed = normalizeScrollSpeed(getScrollSpeed())
+    if (speed === DEFAULT_SCROLL_SPEED) {
+      return
+    }
+
+    const wheel = getPrimaryWheelMovement(event)
+    if (wheel.delta === 0) {
+      return
+    }
+
+    const target = findWheelScrollTarget(event, wheel.axis, wheel.delta)
+    if (target === null) {
+      return
+    }
+
+    event.preventDefault()
+    if (target.element === null) {
+      return
+    }
+
+    const distance = wheelDeltaInPixels(event, target.element, wheel.axis, wheel.delta) *
+      speed / DEFAULT_SCROLL_SPEED
+    target.element.scrollBy(wheel.axis === 'x'
+      ? { left: distance }
+      : { top: distance })
+  }
+
+  document.addEventListener('wheel', handleWheel, { passive: false })
+  return () => document.removeEventListener('wheel', handleWheel)
+}
+
+/**
+ * Uses the dominant wheel axis, matching how the app's other wheel-controlled
+ * interfaces interpret diagonal touchpad gestures.
+ *
+ * @param {WheelEvent} event
+ * @returns {{ axis: 'x' | 'y', delta: number }}
+ */
+function getPrimaryWheelMovement(event) {
+  const deltaX = event.shiftKey && event.deltaX === 0 ? event.deltaY : event.deltaX
+  const deltaY = event.shiftKey && event.deltaX === 0 ? 0 : event.deltaY
+  return Math.abs(deltaX) > Math.abs(deltaY)
+    ? { axis: 'x', delta: deltaX }
+    : { axis: 'y', delta: deltaY }
+}
+
+/**
+ * @param {WheelEvent} event
+ * @param {'x' | 'y'} axis
+ * @param {number} delta
+ * @returns {{ element: HTMLElement | null } | null}
+ */
+function findWheelScrollTarget(event, axis, delta) {
+  for (const target of event.composedPath()) {
+    if (!(target instanceof HTMLElement) ||
+      target === document.body ||
+      target === document.documentElement) {
+      continue
+    }
+
+    const style = getComputedStyle(target)
+    const overflow = axis === 'x' ? style.overflowX : style.overflowY
+    if (!SCROLLABLE_OVERFLOW.has(overflow)) {
+      continue
+    }
+
+    if (canScroll(target, axis, delta)) {
+      return { element: target }
+    }
+
+    const overscrollBehavior = axis === 'x'
+      ? style.overscrollBehaviorX
+      : style.overscrollBehaviorY
+    if (CONTAINED_OVERSCROLL.has(overscrollBehavior)) {
+      return { element: null }
+    }
+  }
+
+  const page = document.scrollingElement
+  return page instanceof HTMLElement && canScroll(page, axis, delta)
+    ? { element: page }
+    : null
+}
+
+/**
+ * @param {HTMLElement} element
+ * @param {'x' | 'y'} axis
+ * @param {number} delta
+ */
+function canScroll(element, axis, delta) {
+  const position = axis === 'x' ? element.scrollLeft : element.scrollTop
+  const maximum = axis === 'x'
+    ? element.scrollWidth - element.clientWidth
+    : element.scrollHeight - element.clientHeight
+  return maximum > 0 && (delta < 0 ? position > 0 : position < maximum)
+}
+
+/**
+ * @param {WheelEvent} event
+ * @param {HTMLElement} element
+ * @param {'x' | 'y'} axis
+ * @param {number} delta
+ */
+function wheelDeltaInPixels(event, element, axis, delta) {
+  if (event.deltaMode === WheelEvent.DOM_DELTA_LINE) {
+    const lineHeight = Number.parseFloat(getComputedStyle(element).lineHeight)
+    return delta * (Number.isFinite(lineHeight) ? lineHeight : 16)
+  }
+
+  if (event.deltaMode === WheelEvent.DOM_DELTA_PAGE) {
+    return delta * (axis === 'x' ? element.clientWidth : element.clientHeight)
+  }
+
+  return delta
+}

--- a/src/renderer/main.js
+++ b/src/renderer/main.js
@@ -7,7 +7,6 @@ import { initializeTabNavigationService } from './tabs/TabNavigationService'
 import { showExternalPlayerUnsupportedActionToast, showToast } from './helpers/utils'
 import { installViewTransitions } from './helpers/viewTransitions'
 import { initializeAppScrollbars, overlayScrollbarsDirective } from './helpers/overlayScrollbars'
-import { initializeScrollSpeed } from './helpers/scrollSpeed'
 import { releaseAutomaticDownloadSchedule } from './helpers/automaticDownloads'
 // import the styles
 import 'overlayscrollbars/styles/overlayscrollbars.css'
@@ -39,7 +38,6 @@ const tabNavigation = initializeTabNavigationService(router, store)
 router.isReady().then(() => {
   app.mount('#app')
   initializeAppScrollbars()
-  initializeScrollSpeed(() => store.getters.getScrollSpeed)
 })
 
 // to avoid accessing electron api from web app build

--- a/src/renderer/main.js
+++ b/src/renderer/main.js
@@ -7,6 +7,7 @@ import { initializeTabNavigationService } from './tabs/TabNavigationService'
 import { showExternalPlayerUnsupportedActionToast, showToast } from './helpers/utils'
 import { installViewTransitions } from './helpers/viewTransitions'
 import { initializeAppScrollbars, overlayScrollbarsDirective } from './helpers/overlayScrollbars'
+import { initializeScrollSpeed } from './helpers/scrollSpeed'
 import { releaseAutomaticDownloadSchedule } from './helpers/automaticDownloads'
 // import the styles
 import 'overlayscrollbars/styles/overlayscrollbars.css'
@@ -38,6 +39,7 @@ const tabNavigation = initializeTabNavigationService(router, store)
 router.isReady().then(() => {
   app.mount('#app')
   initializeAppScrollbars()
+  initializeScrollSpeed(() => store.getters.getScrollSpeed)
 })
 
 // to avoid accessing electron api from web app build

--- a/src/renderer/store/modules/settings.js
+++ b/src/renderer/store/modules/settings.js
@@ -18,6 +18,7 @@ import { normalizeTabBarPosition } from '../../constants/tabBarPosition'
 import { DEFAULT_SCROLLBAR_THUMB_WIDTH } from '../../constants/scrollbar'
 import { setReducedMotionPreference } from '../../helpers/reducedMotion'
 import { setAnimationSpeed } from '../../helpers/animationSpeed'
+import { DEFAULT_SCROLL_SPEED } from '../../helpers/scrollSpeed'
 import { DEFAULT_SEARCH_ENGINES_SETTING } from '../../../searchEngines'
 import { DEFAULT_SEGMENT_PREFETCH_LIMIT } from '../../helpers/player/segmentPrefetch'
 import { normalizeYouTubeCaptionLanguageCode } from '../../helpers/player/youtubeCaptionLanguages'
@@ -202,6 +203,7 @@ const state = {
   scrollMiniPlayerOnAllTabs: false,
   scrollMiniPlayerSavedRect: '',
   scrollbarThumbWidth: DEFAULT_SCROLLBAR_THUMB_WIDTH,
+  scrollSpeed: DEFAULT_SCROLL_SPEED,
   avoidTranslation: 'disabled',
   backendFallback: false,
   backendPreference: !process.env.SUPPORTS_LOCAL_API ? 'invidious' : 'local',

--- a/static/locales/de-DE.yaml
+++ b/static/locales/de-DE.yaml
@@ -503,6 +503,7 @@ Settings:
     Move Settings to App Header: Einstellungen in die App-Kopfzeile verschieben
     UI Roundness: Rundung der Benutzeroberfläche
     Scrollbar Width: Scrollbar-Breite
+    Scroll Speed: Scrollgeschwindigkeit
     Animation Speed: Animationsgeschwindigkeit
     Show Tab Icons: Tab-Symbole anzeigen
     Load Missing Tab Icons: Fehlende Tab-Symbole laden
@@ -2140,6 +2141,7 @@ Tooltips:
     Always Show Scrollbars: >-
       Hält die Scrollbars immer sichtbar. Wenn deaktiviert, werden sie kurz nach dem Ende der Mausbewegung
       ausgeblendet und bei der nächsten Bewegung wieder eingeblendet.
+    Scroll Speed: Ändert die Scrollweite von Mausrad- und Touchpad-Gesten.
     Use Fixed Tab Width: Gibt jedem Tab in der horizontalen Tableiste dieselbe Breite, statt sie an den Titel anzupassen.
     Use Grid Player Menu: Ordnet das Einstellungsmenü des Videoplayers als Kachelraster statt als Liste an.
 Playing Next Video Interval: Nächstes Video wird sofort abgespielt. Zum Abbrechen klicken. | Nächstes Video wird in {nextVideoInterval} Sekunden abgespielt. Zum Abbrechen klicken. | Nächstes Video wird in {nextVideoInterval} Sekunden abgespielt. Zum Abbrechen klicken.

--- a/static/locales/en-US.yaml
+++ b/static/locales/en-US.yaml
@@ -566,6 +566,7 @@ Settings:
     UI Scale: UI Scale
     UI Roundness: UI Roundness
     Scrollbar Width: Scrollbar Width
+    Scroll Speed: Scroll Speed
     Animation Speed: Animation Speed
     Thumbnail Size: Thumbnail Size
     Show Tab Icons: Show Tab Icons
@@ -2369,6 +2370,7 @@ Tooltips:
   Theme Settings:
     Show Progress as Notification: Shows a persistent notification with live progress for background operations, such as subscription refreshes and managed tool downloads, instead of using the global progress bar.
     Always Show Scrollbars: Keeps the scrollbars visible at all times. When disabled, they fade out shortly after you stop moving the mouse and reappear as soon as you move it again.
+    Scroll Speed: Changes how far mouse-wheel and touchpad wheel gestures scroll.
     Use Fixed Tab Width: Gives every tab in the horizontal tab bar the same width instead of sizing them to their title.
     Use Grid Player Menu: Arranges the video player's settings menu as a grid of tiles instead of a list of rows.
   Experimental Settings:

--- a/tests/unit/scroll-speed.test.mjs
+++ b/tests/unit/scroll-speed.test.mjs
@@ -1,0 +1,17 @@
+import assert from 'node:assert/strict'
+import test from 'node:test'
+
+import {
+  normalizeScrollSpeed
+} from '../../src/renderer/helpers/scrollSpeed.js'
+
+test('clamps scroll speed to the supported range', () => {
+  assert.equal(normalizeScrollSpeed(10), 25)
+  assert.equal(normalizeScrollSpeed(25), 25)
+  assert.equal(normalizeScrollSpeed(100), 100)
+  assert.equal(normalizeScrollSpeed('200'), 200)
+  assert.equal(normalizeScrollSpeed(300), 300)
+  assert.equal(normalizeScrollSpeed(400), 300)
+  assert.equal(normalizeScrollSpeed(0), 100)
+  assert.equal(normalizeScrollSpeed(Number.NaN), 100)
+})


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Make sure to follow the contributing guidelines. -->
<!-- Important note, we may remove your pull request if you do not use this provided PR template correctly. -->
<!-- Agent instructions: Preserve every heading, comment, and marker in this template. Never remove or rewrite the release-note-category:start/end, release-note:start/end, or release-note-image:start/end marker pairs. Never remove or rewrite the Release note images section; leave its contents for a human. -->

## Pull Request Type
<!-- Please select what type of pull request this is: [x] -->
- [ ] Bugfix
- [x] Feature Implementation
- [ ] Documentation
- [ ] Other

## Related issue
<!-- Please link the issue your pull request is referring to. -->
<!-- If this pull request fully resolves the relevant issue, put "closes" before the issue number. -->
<!-- Example: "closes #123456". -->

## Description
<!-- Please write a clear and concise description of what the pull request does. -->
Scrolling distance is currently fixed, which can make mouse wheels and touchpads feel too slow or too sensitive. This adds a synced Appearance setting that adjusts wheel scrolling from 25% to 300%, with 100% preserving the browser default.

The multiplier applies to page and nested scrolling while preserving contained scroll areas and component-owned wheel actions such as player controls and Shorts navigation.

## Release note category
<!-- Select exactly one category. Every pull request must select one. -->
<!-- Select "Not noteworthy" when the pull request fixes a bug in or improves functionality that has not yet appeared in a stable release. -->
<!-- release-note-category:start -->
- [ ] Not noteworthy
- [ ] Highlights
- [x] More improvements
- [ ] Fixed bugs
<!-- release-note-category:end -->

## Release note
<!-- Required unless "Not noteworthy" is selected. -->
<!-- Write one concise, user-facing entry without a leading bullet. -->
<!-- release-note:start -->
You can now adjust mouse-wheel and touchpad scroll speed from 25% to 300% in Appearance settings.
<!-- release-note:end -->

## Release note images
<!-- Human-only: Agents must preserve this entire section and leave it empty. -->
<!-- Optional. Paste one or more Markdown images or HTML image tags here. -->
<!-- The release notes will use an HTML image tag and limit images taller than 300 pixels. -->
<!-- release-note-image:start -->

<!-- release-note-image:end -->

## Testing
<!-- How can reviewers verify that the PR produces correct results? -->
<!-- Please provide instructions so that others can ensure that your pull request would produce correct results. For examples see, https://github.com/FreeTubeApp/FreeTube/pull/5743, https://github.com/FreeTubeApp/FreeTube/pull/7349, https://github.com/FreeTubeApp/FreeTube/pull/5125, https://github.com/FreeTubeApp/FreeTube/pull/7338 -->
<!-- Agent instructions: Only write human-facing steps that explain how to verify the change while running this branch in dev mode. Include expected results and, when applicable, helpful console snippets for interactive verification. Do not include automated checks, commands, results, pass counts, or CI status. -->
1. Open Settings, select Appearance, and find the Scroll Speed slider. It should default to 100% and offer values from 25% to 300%.
2. Open a long page such as History. Repeat the same wheel or touchpad gesture at 50%, 100%, and 200%. The distance should be roughly half, unchanged, and doubled respectively.
3. Scroll a nested menu or panel to its end. Scrolling should remain contained where it was contained before, without moving the page behind it.
4. Set UI Scale to 125% and repeat the comparison. The selected multiplier should still apply.
5. Use a wheel-controlled player action or Shorts navigation. Its existing action should still run without scrolling the page.

## Additional context
<!-- Add any other context about the pull request here. -->
The default 100% path leaves native browser wheel handling untouched.
