### PR TITLE
fix(tabs): keep interrupted drag animations smooth

### DIFF
--- a/e2e/tests/offline/tabs.spec.mjs
+++ b/e2e/tests/offline/tabs.spec.mjs
@@ -805,6 +805,75 @@ test.describe('tab bar', () => {
     ])
   })
 
+  test('animates vertical tabs when a new drag interrupts settling', async ({ page }) => {
+    await page.evaluate(() => window.ftElectron.setZoomFactor(0.95))
+    await page.keyboard.press('F1')
+    await expect(page.locator('.app')).toHaveClass(/tabBar-left/)
+    await page.locator(sel.newTabButton).click()
+    await page.locator(sel.newTabButton).click()
+    await page.locator(sel.newTabButton).click()
+
+    const neighborAnimation = await page.evaluate(() => {
+      const tabs = Array.from(document.querySelectorAll('.tabBar .tab'))
+
+      function pointerEvent(type, target, point, buttons = 0) {
+        target.dispatchEvent(new PointerEvent(type, {
+          bubbles: true,
+          button: 0,
+          buttons,
+          clientX: point.left + point.width / 2,
+          clientY: point.top + point.height / 2
+        }))
+      }
+
+      function drag(source, target) {
+        const sourceRect = source.getBoundingClientRect()
+        const targetRect = target.getBoundingClientRect()
+        pointerEvent('pointerdown', source, sourceRect, 1)
+        pointerEvent('pointermove', window, targetRect, 1)
+        pointerEvent('pointerup', window, targetRect)
+      }
+
+      drag(tabs[3], tabs[0])
+
+      const sourceRect = tabs[1].getBoundingClientRect()
+      const targetRect = tabs[3].getBoundingClientRect()
+      pointerEvent('pointerdown', tabs[1], sourceRect, 1)
+      pointerEvent('pointermove', window, targetRect, 1)
+
+      return new Promise(resolve => {
+        let inspectedFrames = 0
+
+        function inspectAnimation() {
+          inspectedFrames++
+          const animation = tabs[2].getAnimations().find(candidate => {
+            return candidate.effect instanceof KeyframeEffect &&
+              candidate.effect.target === tabs[2] &&
+              candidate.effect.getKeyframes().some(frame => frame.transform != null) &&
+              candidate.effect.getComputedTiming().duration > 0
+          })
+          if (!animation && inspectedFrames < 4) {
+            requestAnimationFrame(inspectAnimation)
+            return
+          }
+
+          pointerEvent('pointerup', window, targetRect)
+          resolve({
+            duration: animation?.effect.getComputedTiming().duration ?? 0,
+            playState: animation?.playState ?? null
+          })
+        }
+
+        requestAnimationFrame(inspectAnimation)
+      })
+    })
+
+    expect(neighborAnimation).toEqual({
+      duration: 200,
+      playState: 'running'
+    })
+  })
+
   test('keeps consecutive selected drags aligned while reorder updates are delayed', async ({ app, page }) => {
     await page.evaluate(() => window.ftElectron.setZoomFactor(0.95))
     await page.locator(sel.newTabButton).click()

--- a/e2e/tests/offline/tabs.spec.mjs
+++ b/e2e/tests/offline/tabs.spec.mjs
@@ -874,6 +874,51 @@ test.describe('tab bar', () => {
     })
   })
 
+  test('restores animations when a deferred drag ends before its resume frame', async ({ page }) => {
+    await page.evaluate(() => window.ftElectron.setZoomFactor(0.95))
+    await page.keyboard.press('F1')
+    await expect(page.locator('.app')).toHaveClass(/tabBar-left/)
+    await page.locator(sel.newTabButton).click()
+    await page.locator(sel.newTabButton).click()
+    await page.locator(sel.newTabButton).click()
+
+    const transitionProperties = await page.evaluate(() => {
+      const tabs = Array.from(document.querySelectorAll('.tabBar .tab'))
+
+      function pointerEvent(type, target, point, buttons = 0) {
+        target.dispatchEvent(new PointerEvent(type, {
+          bubbles: true,
+          button: 0,
+          buttons,
+          clientX: point.left + point.width / 2,
+          clientY: point.top + point.height / 2
+        }))
+      }
+
+      const firstSourceRect = tabs[3].getBoundingClientRect()
+      const firstTargetRect = tabs[0].getBoundingClientRect()
+      pointerEvent('pointerdown', tabs[3], firstSourceRect, 1)
+      pointerEvent('pointermove', window, firstTargetRect, 1)
+      pointerEvent('pointercancel', window, firstTargetRect)
+
+      const secondSourceRect = tabs[1].getBoundingClientRect()
+      pointerEvent('pointerdown', tabs[1], secondSourceRect, 1)
+
+      return new Promise(resolve => {
+        requestAnimationFrame(() => {
+          requestAnimationFrame(() => {
+            pointerEvent('pointerup', window, secondSourceRect)
+            requestAnimationFrame(() => {
+              resolve(tabs.map(tab => getComputedStyle(tab).transitionProperty))
+            })
+          })
+        })
+      })
+    })
+
+    expect(transitionProperties.every(properties => properties.includes('transform'))).toBe(true)
+  })
+
   test('keeps consecutive selected drags aligned while reorder updates are delayed', async ({ app, page }) => {
     await page.evaluate(() => window.ftElectron.setZoomFactor(0.95))
     await page.locator(sel.newTabButton).click()

--- a/src/renderer/components/TabBar/TabBar.vue
+++ b/src/renderer/components/TabBar/TabBar.vue
@@ -344,7 +344,12 @@ function resumeDragAfterSettle(session) {
   nextTick(() => {
     requestAnimationFrame(() => {
       requestAnimationFrame(() => {
-        if (dragSession !== session) return
+        if (dragSession !== session) {
+          if (!dragSession?.deferPositionUpdates) {
+            suppressTransitions.value = false
+          }
+          return
+        }
 
         session.deferPositionUpdates = false
         suppressTransitions.value = false

--- a/src/renderer/components/TabBar/TabBar.vue
+++ b/src/renderer/components/TabBar/TabBar.vue
@@ -222,6 +222,7 @@ const suppressTransitions = ref(false)
  * @property {boolean} started
  * @property {boolean} moved
  * @property {number} draggedOffset
+ * @property {boolean} deferPositionUpdates
  */
 
 /** @type {DragSession | null} */
@@ -263,6 +264,7 @@ function handleTabContainerPointerDown(event) {
     return
   }
 
+  const interruptedSettle = isSettling.value
   const pendingTabOrder = finishSettle(true)
 
   const container = dropZoneRef.value
@@ -318,12 +320,38 @@ function handleTabContainerPointerDown(event) {
     gap,
     started: false,
     moved: false,
-    draggedOffset: 0
+    draggedOffset: 0,
+    deferPositionUpdates: interruptedSettle
   }
+  const currentDragSession = dragSession
 
   window.addEventListener('pointermove', handleDragPointerMove)
   window.addEventListener('pointerup', handleDragPointerUp)
   window.addEventListener('pointercancel', handleDragPointerCancel)
+
+  if (interruptedSettle) {
+    resumeDragAfterSettle(currentDragSession)
+  }
+}
+
+/**
+ * Let the interrupted reorder render once without transitions before applying
+ * offsets from the new drag. Otherwise the old layout swap and new transform
+ * animation are combined into one frame and neighboring tabs jump.
+ * @param {DragSession} session
+ */
+function resumeDragAfterSettle(session) {
+  nextTick(() => {
+    requestAnimationFrame(() => {
+      requestAnimationFrame(() => {
+        if (dragSession !== session) return
+
+        session.deferPositionUpdates = false
+        suppressTransitions.value = false
+        updateActiveDragPosition()
+      })
+    })
+  })
 }
 
 /**
@@ -355,10 +383,13 @@ function handleDragPointerMove(event) {
   // Prevent text selection while dragging
   event.preventDefault()
 
-  updateActiveDragPosition()
+  updateActiveDragPosition(!dragSession.deferPositionUpdates)
 }
 
-function updateActiveDragPosition() {
+/**
+ * @param {boolean} [updateVisuals]
+ */
+function updateActiveDragPosition(updateVisuals = true) {
   if (!dragSession || !dragSession.started) return
 
   const container = dropZoneRef.value
@@ -416,13 +447,15 @@ function updateActiveDragPosition() {
 
   dragSession.indexShift = indexShift
   dragSession.reorderedTabIds = reorderedTabIds
-  tabOffsets.value = computeTabOffsets(
-    rects,
-    reorderedTabIds,
-    gap,
-    draggedTabIdSet,
-    draggedOffset
-  )
+  if (updateVisuals) {
+    tabOffsets.value = computeTabOffsets(
+      rects,
+      reorderedTabIds,
+      gap,
+      draggedTabIdSet,
+      draggedOffset
+    )
+  }
 }
 
 function handleDragPointerUp() {
@@ -509,7 +542,9 @@ async function commitReorder(pendingReorder, cleanupVisuals = true) {
 
   nextTick(() => {
     requestAnimationFrame(() => {
-      suppressTransitions.value = false
+      if (!dragSession?.deferPositionUpdates) {
+        suppressTransitions.value = false
+      }
     })
   })
 }
@@ -612,7 +647,9 @@ function finishSettle(cancel) {
     if (!pendingReorder) {
       nextTick(() => {
         requestAnimationFrame(() => {
-          suppressTransitions.value = false
+          if (!dragSession?.deferPositionUpdates) {
+            suppressTransitions.value = false
+          }
         })
       })
     }


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Make sure to follow the contributing guidelines. -->
<!-- Important note, we may remove your pull request if you do not use this provided PR template correctly. -->
<!-- Agent instructions: Preserve every heading, comment, and marker in this template. Never remove or rewrite the release-note-category:start/end, release-note:start/end, or release-note-image:start/end marker pairs. Never remove or rewrite the Release note images section; leave its contents for a human. -->

## Pull Request Type
<!-- Please select what type of pull request this is: [x] -->
- [x] Bugfix
- [ ] Feature Implementation
- [ ] Documentation
- [ ] Other

## Related issue
<!-- Please link the issue your pull request is referring to. -->
<!-- If this pull request fully resolves the relevant issue, put "closes" before the issue number. -->
<!-- Example: "closes #123456". -->

None.

## Description
<!-- Please write a clear and concise description of what the pull request does. -->

On slower systems, starting another tab drag before the previous drop finished settling could make neighboring vertical tabs jump up or down instead of animating.

Keep tracking the new pointer position while the previous layout renders one stable frame with transitions suppressed. The latest drag offsets are then applied with transform transitions restored, so neighboring tabs move smoothly without changing the final reorder behavior.

## Release note category
<!-- Select exactly one category. Every pull request must select one. -->
<!-- Select "Not noteworthy" when the pull request fixes a bug in or improves functionality that has not yet appeared in a stable release. -->
<!-- release-note-category:start -->
- [ ] Not noteworthy
- [ ] Highlights
- [ ] More improvements
- [x] Fixed bugs
<!-- release-note-category:end -->

## Release note
<!-- Required unless "Not noteworthy" is selected. -->
<!-- Write one concise, user-facing entry without a leading bullet. -->
<!-- release-note:start -->
Neighboring tabs now animate smoothly when rearranging vertical tabs on slower systems.
<!-- release-note:end -->

## Release note images
<!-- Human-only: Agents must preserve this entire section and leave it empty. -->
<!-- Optional. Paste one or more Markdown images or HTML image tags here. -->
<!-- The release notes will use an HTML image tag and limit images taller than 300 pixels. -->
<!-- release-note-image:start -->

<!-- release-note-image:end -->

## Testing
<!-- How can reviewers verify that the PR produces correct results? -->
<!-- Please provide instructions so that others can ensure that your pull request would produce correct results. For examples see, https://github.com/FreeTubeApp/FreeTube/pull/5743, https://github.com/FreeTubeApp/FreeTube/pull/7349, https://github.com/FreeTubeApp/FreeTube/pull/5125, https://github.com/FreeTubeApp/FreeTube/pull/7338 -->
<!-- Agent instructions: Only write human-facing steps that explain how to verify the change while running this branch in dev mode. Include expected results and, when applicable, helpful console snippets for interactive verification. Do not include automated checks, commands, results, pass counts, or CI status. -->

1. Set Tab Bar Position to Left or Right and UI Scale to 95%.
2. Open at least four tabs, drag the last tab to the first position, then immediately drag another tab before the first drop finishes settling.
3. Confirm the neighboring tabs animate smoothly along the vertical axis without jumping, and both drops finish in the requested order.

## Additional context
<!-- Add any other context about the pull request here. -->

The regression test holds the second drag open and checks that a neighboring tab has an active transform animation at fractional UI scale.