### PR TITLE
fix(shortcuts): keep Ctrl+J from reloading active tab

### DIFF
--- a/e2e/tests/offline/keyboard-shortcut-restrictions.spec.mjs
+++ b/e2e/tests/offline/keyboard-shortcut-restrictions.spec.mjs
@@ -1,5 +1,15 @@
 import { test, expect, goTo } from '../../helpers/app.mjs'
 
+test('opens Downloads without navigating or reloading the active tab', async ({ page }) => {
+  const activeView = page.locator('.tabContent[aria-hidden="false"] > .routerView')
+  await activeView.evaluate(element => { element.dataset.downloadShortcutSentinel = 'mounted' })
+
+  await page.keyboard.press('Control+j')
+
+  await expect(page.getByRole('dialog', { name: 'Downloads', exact: true })).toBeVisible()
+  expect(await activeView.getAttribute('data-download-shortcut-sentinel')).toBe('mounted')
+})
+
 test('context-dependent shortcuts are shown as non-editable', async ({ page }) => {
   await goTo(page, 'settings')
   await page.getByRole('button', { name: 'Show Keyboard Shortcuts' }).click()

--- a/src/renderer/App.vue
+++ b/src/renderer/App.vue
@@ -2241,7 +2241,7 @@ function handleKeyboardShortcuts(event) {
 
   if (matchesKeyboardShortcut(event, shortcuts.NAVIGATE_TO_DOWNLOADS)) {
     event.preventDefault()
-    openInternalPath({ path: '/downloads' })
+    store.dispatch('showSettingsWindow', 'downloads')
     return
   }
 


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Make sure to follow the contributing guidelines. -->
<!-- Important note, we may remove your pull request if you do not use this provided PR template correctly. -->
<!-- Agent instructions: Preserve every heading, comment, and marker in this template. Never remove or rewrite the release-note-category:start/end, release-note:start/end, or release-note-image:start/end marker pairs. Never remove or rewrite the Release note images section; leave its contents for a human. -->

## Pull Request Type
<!-- Please select what type of pull request this is: [x] -->
- [x] Bugfix
- [ ] Feature Implementation
- [ ] Documentation
- [ ] Other

## Related issue
<!-- Please link the issue your pull request is referring to. -->
<!-- If this pull request fully resolves the relevant issue, put "closes" before the issue number. -->
<!-- Example: "closes #123456". -->

None.

## Description
<!-- Please write a clear and concise description of what the pull request does. -->

Ctrl+J opened Downloads by navigating the active logical tab through `/downloads`. `SettingsRoute` then navigated back, unmounting and recreating the current page. Opening Downloads through Quick Settings skipped that route, which is why the bug only affected the keyboard shortcut.

This change opens Downloads through the settings window action and adds an Electron regression test that verifies the active view remains mounted.

## Release note category
<!-- Select exactly one category. Every pull request must select one. -->
<!-- Select "Not noteworthy" when the pull request fixes a bug in or improves functionality that has not yet appeared in a stable release. -->
<!-- release-note-category:start -->
- [ ] Not noteworthy
- [ ] Highlights
- [ ] More improvements
- [x] Fixed bugs
<!-- release-note-category:end -->

## Release note
<!-- Required unless "Not noteworthy" is selected. -->
<!-- Write one concise, user-facing entry without a leading bullet. -->
<!-- release-note:start -->
Opening Downloads with Ctrl+J no longer reloads the active tab.
<!-- release-note:end -->

## Release note images
<!-- Human-only: Agents must preserve this entire section and leave it empty. -->
<!-- Optional. Paste one or more Markdown images or HTML image tags here. -->
<!-- The release notes will use an HTML image tag and limit images taller than 300 pixels. -->
<!-- release-note-image:start -->

<!-- release-note-image:end -->

## Testing
<!-- How can reviewers verify that the PR produces correct results? -->
<!-- Please provide instructions so that others can ensure that your pull request would produce correct results. For examples see, https://github.com/FreeTubeApp/FreeTube/pull/5743, https://github.com/FreeTubeApp/FreeTube/pull/7349, https://github.com/FreeTubeApp/FreeTube/pull/5125, https://github.com/FreeTubeApp/FreeTube/pull/7338 -->
<!-- Agent instructions: Only write human-facing steps that explain how to verify the change while running this branch in dev mode. Include expected results and, when applicable, helpful console snippets for interactive verification. Do not include automated checks, commands, results, pass counts, or CI status. -->

1. Start the app in development mode and open any page in the active tab.
2. Press Ctrl+J. Downloads should open without reloading the page behind it or losing that page's state.
3. Close Downloads, then open it through Quick Settings. Both entry points should behave the same way.

## Additional context
<!-- Add any other context about the pull request here. -->
