### PR TITLE
fix(comments): show blank like counts as zero

### DIFF
--- a/e2e/helpers/watch.mjs
+++ b/e2e/helpers/watch.mjs
@@ -88,6 +88,27 @@ function addCommentTimestamp(body) {
   throw new Error('Unable to add a timestamp to the comment fixture')
 }
 
+function blankCommentLikeCount(body) {
+  const response = JSON.parse(body)
+  const pending = [response]
+
+  while (pending.length > 0) {
+    const value = pending.pop()
+    if (!value || typeof value !== 'object') continue
+
+    const payload = value.commentEntityPayload
+    if (payload?.properties?.content?.content === "We're so honored that the first ever YouTube video was filmed here!") {
+      payload.toolbar.likeCountNotliked = ' '
+      payload.toolbar.likeCountA11y = '0 likes'
+      return Buffer.from(JSON.stringify(response))
+    }
+
+    pending.push(...Object.values(value))
+  }
+
+  throw new Error('Unable to blank the comment like count in the fixture')
+}
+
 /**
  * Serves the watch page for `jNQXAC9IVRw` from the committed Innertube
  * fixtures, without any network access.
@@ -107,6 +128,7 @@ function addCommentTimestamp(body) {
  * @param {string[]|null} [options.captionVideoIds] limit captions to these video IDs
  * @param {boolean} [options.ownerReply] mark the first reply thread as containing a video-owner reply
  * @param {boolean} [options.commentTimestamp] add a timestamp to one top-level comment
+ * @param {boolean} [options.blankCommentLikes] replace one comment's zero-like count with YouTube's whitespace representation
  */
 export async function mockWatchPage(app, page, {
   playable = false,
@@ -114,7 +136,8 @@ export async function mockWatchPage(app, page, {
   captionCueSettings = '',
   captionVideoIds = null,
   ownerReply = false,
-  commentTimestamp = false
+  commentTimestamp = false,
+  blankCommentLikes = false
 } = {}) {
   const counters = new Map()
   const includeCaptions = captionTranslations || captionCueSettings !== '' || captionVideoIds !== null
@@ -240,6 +263,9 @@ export async function mockWatchPage(app, page, {
         }
         if (commentTimestamp && body.includes('commentEntityPayload')) {
           body = addCommentTimestamp(body)
+        }
+        if (blankCommentLikes && body.includes("We're so honored")) {
+          body = blankCommentLikeCount(body)
         }
         return route.fulfill({ status: 200, contentType: 'application/json', body })
       }

--- a/e2e/tests/offline/watch-page.spec.mjs
+++ b/e2e/tests/offline/watch-page.spec.mjs
@@ -3562,6 +3562,21 @@ test.describe('manual comment loading', () => {
     await expect(commentLikes).toContainText('4,600,000')
   })
 
+  test('renders whitespace-only zero like counts as zero', async ({ app, page }) => {
+    await mockPlayableWatchPage(app, page, { blankCommentLikes: true })
+    await openMockedVideo(page)
+
+    const loadComments = page.locator('.getCommentsTitle')
+    await loadComments.scrollIntoViewIfNeeded()
+    await loadComments.click()
+    await expect(page.locator('.commentsTitle')).toBeVisible({ timeout: 30_000 })
+
+    const commentLikes = page.locator('.commentThread')
+      .filter({ hasText: "We're so honored" })
+      .locator('.commentLikeCount')
+    await expect(commentLikes).toHaveText('0')
+  })
+
   test.describe('comment filtering at 125% UI scale', () => {
     test.use({
       seed: {

--- a/src/renderer/helpers/api/local.js
+++ b/src/renderer/helpers/api/local.js
@@ -2709,7 +2709,7 @@ export function parseLocalComment(comment, commentThread = undefined) {
     time: getRelativeTimeFromDate(published, false),
     published,
     isEdited: publishedText.includes('(edited)'),
-    likes: parseLocalSubscriberCount(String(comment.like_count ?? '0')),
+    likes: parseLocalSubscriberCount(comment.like_count?.trim() || '0'),
     numReplies: hasReplyToken
       ? parseLocalSubscriberCount(String(comment.reply_count_a11y ?? comment.reply_count ?? '0'))
       : 0

--- a/src/renderer/helpers/api/local.js
+++ b/src/renderer/helpers/api/local.js
@@ -2709,7 +2709,7 @@ export function parseLocalComment(comment, commentThread = undefined) {
     time: getRelativeTimeFromDate(published, false),
     published,
     isEdited: publishedText.includes('(edited)'),
-    likes: parseLocalSubscriberCount(comment.like_count?.trim() || '0'),
+    likes: parseLocalSubscriberCount(String(comment.like_count ?? '0').trim() || '0'),
     numReplies: hasReplyToken
       ? parseLocalSubscriberCount(String(comment.reply_count_a11y ?? comment.reply_count ?? '0'))
       : 0


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Make sure to follow the contributing guidelines. -->
<!-- Important note, we may remove your pull request if you do not use this provided PR template correctly. -->
<!-- Agent instructions: Preserve every heading, comment, and marker in this template. Never remove or rewrite the release-note-category:start/end, release-note:start/end, or release-note-image:start/end marker pairs. Never remove or rewrite the Release note images section; leave its contents for a human. -->

## Pull Request Type
<!-- Please select what type of pull request this is: [x] -->
- [x] Bugfix
- [ ] Feature Implementation
- [ ] Documentation
- [ ] Other

## Related issue
<!-- Please link the issue your pull request is referring to. -->
<!-- If this pull request fully resolves the relevant issue, put "closes" before the issue number. -->
<!-- Example: "closes #123456". -->

## Description
<!-- Please write a clear and concise description of what the pull request does. -->
YouTube can return a single space as the visible like count for a comment with zero likes. OpenTubeX parsed that whitespace as `NaN` and displayed it next to the like icon.

Trim the local comment count before parsing it and fall back to zero when nothing remains. The existing compact count formatting still handles nonzero counts and the Shorten View Counts setting.

## Release note category
<!-- Select exactly one category. Every pull request must select one. -->
<!-- Select "Not noteworthy" when the pull request fixes a bug in or improves functionality that has not yet appeared in a stable release. -->
<!-- release-note-category:start -->
- [ ] Not noteworthy
- [ ] Highlights
- [ ] More improvements
- [x] Fixed bugs
<!-- release-note-category:end -->

## Release note
<!-- Required unless "Not noteworthy" is selected. -->
<!-- Write one concise, user-facing entry without a leading bullet. -->
<!-- release-note:start -->
Comments with no likes now show 0 instead of NaN.
<!-- release-note:end -->

## Release note images
<!-- Human-only: Agents must preserve this entire section and leave it empty. -->
<!-- Optional. Paste one or more Markdown images or HTML image tags here. -->
<!-- The release notes will use an HTML image tag and limit images taller than 300 pixels. -->
<!-- release-note-image:start -->

<!-- release-note-image:end -->

## Testing
<!-- How can reviewers verify that the PR produces correct results? -->
<!-- Please provide instructions so that others can ensure that your pull request would produce correct results. For examples see, https://github.com/FreeTubeApp/FreeTube/pull/5743, https://github.com/FreeTubeApp/FreeTube/pull/7349, https://github.com/FreeTubeApp/FreeTube/pull/5125, https://github.com/FreeTubeApp/FreeTube/pull/7338 -->
<!-- Agent instructions: Only write human-facing steps that explain how to verify the change while running this branch in dev mode. Include expected results and, when applicable, helpful console snippets for interactive verification. Do not include automated checks, commands, results, pass counts, or CI status. -->
1. Open `https://www.youtube.com/watch?v=px7hXaTPAAQ&lc=UgzSnMKm-BqK5DsJh9F4AaABAg` and load the comments.
2. Find the highlighted `peak vid` comment. When YouTube returns its zero-like count as whitespace, confirm OpenTubeX shows `0` instead of `NaN`.
3. Check a comment with a compact count such as `4.6M`, then disable Shorten View Counts and confirm it changes to the full localized number.

## Additional context
<!-- Add any other context about the pull request here. -->
The creator heart is separate from the comment like count and remains unchanged.
