### PR TITLE
fix(settings): align playback controls responsively

### DIFF
--- a/e2e/tests/offline/settings.spec.mjs
+++ b/e2e/tests/offline/settings.spec.mjs
@@ -870,6 +870,54 @@ test.describe('settings', () => {
     expect(Math.max(...preferenceOffsets)).toBeLessThanOrEqual(1)
   })
 
+  test('aligns Playback toggles and selects in a narrow settings window', async ({ page }) => {
+    await page.evaluate(() => {
+      localStorage.setItem('opentubex-settings-window-bounds', JSON.stringify({
+        x: 40,
+        y: 40,
+        width: 400,
+        height: 700
+      }))
+    })
+    const playback = await goToSettingsSection(page, 'playback')
+    const playerSettings = playback.locator('.settingsSection').filter({
+      has: page.getByRole('heading', { name: 'Player', exact: true })
+    })
+
+    async function expectControlsAligned() {
+      const firstToggles = playerSettings.locator('.switchColumn').first()
+        .locator(':scope > .switch-ctn')
+      await expect(firstToggles.first()).toBeVisible()
+      const toggleLabelLeftEdges = await firstToggles.evaluateAll(elements => elements.slice(0, 3)
+        .map(element => element.querySelector('.switch-label-text').getBoundingClientRect().left))
+      expect.soft(Math.max(...toggleLabelLeftEdges) - Math.min(...toggleLabelLeftEdges))
+        .toBeLessThanOrEqual(1)
+
+      const tooltipToggle = playerSettings.locator('.switch-ctn')
+        .filter({ hasText: 'Show Skip Silence Toggle' })
+      const toggleCenterOffset = await tooltipToggle.evaluate(element => {
+        const label = element.querySelector('.switch-label').getBoundingClientRect()
+        const text = element.querySelector('.switch-label-text').getBoundingClientRect()
+        return Math.abs(label.top + label.height / 2 - (text.top + text.height / 2))
+      })
+      expect.soft(toggleCenterOffset).toBeLessThanOrEqual(1)
+
+      const selectLeftEdges = await playerSettings.locator('.select .select-text')
+        .evaluateAll(elements => elements.map(element => element.getBoundingClientRect().left))
+      expect.soft(selectLeftEdges).toHaveLength(4)
+      expect.soft(Math.max(...selectLeftEdges) - Math.min(...selectLeftEdges))
+        .toBeLessThanOrEqual(1)
+    }
+
+    await expectControlsAligned()
+    await page.evaluate(async () => {
+      const store = document.querySelector('#app').__vue_app__.config.globalProperties.$store
+      await store.dispatch('updateUiScale', 125)
+    })
+    await expect.poll(() => page.evaluate(() => window.devicePixelRatio)).toBeCloseTo(1.25, 2)
+    await expectControlsAligned()
+  })
+
   test('groups confirmation preferences together', async ({ page }) => {
     await goTo(page, 'settings')
 
@@ -4358,6 +4406,60 @@ test.describe('synced setting indicators', () => {
     expect([...rowSizes.values()]).toEqual([3, 2])
     // The row they landed on doesn't change how much room they get.
     expect(new Set(boxes.map(({ width }) => width)).size).toBe(1)
+  })
+
+  test('wraps the playback sliders in the same grid as the theme sliders', async ({ page }) => {
+    await goTo(page, 'settings')
+    const playbackSection = await goToSettingsSection(page, 'playback')
+    const sliders = playbackSection.locator('.sliderGrid > *')
+    await expect(sliders).toHaveCount(7)
+    await expect(sliders.nth(5)).toContainText(/Max video playback rate/i)
+    await expect(sliders.nth(6)).toContainText(/Parallel segment loading/i)
+
+    const boxes = await sliders.evaluateAll((elements) => elements.map((element) => {
+      const { x, y, width } = element.getBoundingClientRect()
+      return { x: Math.round(x), y: Math.round(y), width: Math.round(width) }
+    }))
+
+    const rowSizes = new Map()
+    for (const { y } of boxes) {
+      rowSizes.set(y, (rowSizes.get(y) ?? 0) + 1)
+    }
+    expect([...rowSizes.values()]).toEqual([3, 3, 1])
+    expect(new Set(boxes.map(({ width }) => width)).size).toBe(1)
+
+    const lastSlider = boxes.at(-1)
+    const gridCenter = await playbackSection.locator('.sliderGrid').evaluate(element => {
+      const bounds = element.getBoundingClientRect()
+      return bounds.x + bounds.width / 2
+    })
+    expect(lastSlider.x + lastSlider.width / 2).toBeCloseTo(gridCenter, 0)
+
+    await page.evaluate(async () => {
+      const store = document.querySelector('#app').__vue_app__.config.globalProperties.$store
+      await store.dispatch('updateUiScale', 125)
+    })
+    await expect.poll(() => page.evaluate(() => window.devicePixelRatio)).toBeCloseTo(1.25, 2)
+
+    const scaledLayout = await playbackSection.locator('.sliderGrid').evaluate(element => {
+      const gridBounds = element.getBoundingClientRect()
+      const sliderBounds = Array.from(element.children, child => child.getBoundingClientRect())
+      const rowSizes = new Map()
+      for (const bounds of sliderBounds) {
+        const y = Math.round(bounds.y)
+        rowSizes.set(y, (rowSizes.get(y) ?? 0) + 1)
+      }
+
+      return {
+        maximumOverflow: Math.max(...sliderBounds.flatMap(bounds => [
+          gridBounds.left - bounds.left,
+          bounds.right - gridBounds.right
+        ])),
+        maximumRowSize: Math.max(...rowSizes.values())
+      }
+    })
+    expect(scaledLayout.maximumOverflow).toBeLessThanOrEqual(1)
+    expect(scaledLayout.maximumRowSize).toBeLessThanOrEqual(3)
   })
 
   test('does not move a setting when its changed highlight appears', async ({ page }) => {

--- a/src/renderer/components/FtSettingsSection/FtSettingsSection.scss
+++ b/src/renderer/components/FtSettingsSection/FtSettingsSection.scss
@@ -133,6 +133,11 @@
       vertical-align: middle;
     }
 
+    :deep(.switchColumn .switch-ctn.containsTooltip .switch-label) {
+      align-items: center;
+      display: inline-flex;
+    }
+
     :deep(:not(.select, .selectLabel, .groupTitle, .selectIndicators) > .tooltip) {
       display: inline-block;
       position: absolute;

--- a/src/renderer/components/FtSliderGrid/FtSliderGrid.vue
+++ b/src/renderer/components/FtSliderGrid/FtSliderGrid.vue
@@ -1,0 +1,42 @@
+<template>
+  <div class="sliderGrid">
+    <slot />
+  </div>
+</template>
+
+<style scoped>
+.sliderGrid {
+  --slider-gap: 24px;
+
+  display: flex;
+  flex-wrap: wrap;
+  justify-content: center;
+  gap: var(--slider-gap);
+}
+
+.sliderGrid :deep(.pure-material-slider) {
+  box-sizing: border-box;
+  flex: 1 1 180px;
+  max-inline-size: 380px;
+  inline-size: auto;
+
+  /* The gap already spaces them out, and their own margin would count towards
+     how many fit in a row. */
+  margin-inline: 0;
+}
+
+/* Up to four sliders fill a row evenly, but a fifth would sit alone on the next
+   one while the others are squeezed together. Sizing them as thirds of the row
+   splits them into rows of at most three, all the same width, with more room
+   for each label. */
+.sliderGrid:has(:nth-child(5)) :deep(.pure-material-slider) {
+  --slider-size: clamp(
+    180px,
+    calc((100% - 2 * var(--slider-gap)) / 3),
+    380px
+  );
+
+  flex-basis: var(--slider-size);
+  max-inline-size: var(--slider-size);
+}
+</style>

--- a/src/renderer/components/PlayerSettings/PlayerSettings.css
+++ b/src/renderer/components/PlayerSettings/PlayerSettings.css
@@ -2,6 +2,38 @@
   margin-block: 1rem;
 }
 
+@container settings-content (width <= 680px) {
+  .playerSwitchGrid .switchColumn {
+    align-items: stretch;
+    inline-size: min(100%, 294px);
+  }
+
+  .playerSelectGrid {
+    align-items: center;
+    flex-direction: column;
+  }
+
+  .playerSelectGrid :deep(.select) {
+    box-sizing: border-box;
+    inline-size: min(100%, 270px);
+    margin-inline-end: 0;
+  }
+
+  .playerSelectGrid :deep(.select-text),
+  .playerSelectGrid :deep(.nativeSelect),
+  .playerSelectGrid :deep(.select-bar) {
+    inline-size: calc(100% - 70px);
+  }
+
+  .playerSelectGrid :deep(.iconSelect) {
+    inset-inline-end: 80px;
+  }
+
+  .playerSelectGrid :deep(.selectIndicators) {
+    inset-inline: auto 8px;
+  }
+}
+
 .screenshotFolderContainer {
   align-items: center;
   column-gap: 1rem;

--- a/src/renderer/components/PlayerSettings/PlayerSettings.vue
+++ b/src/renderer/components/PlayerSettings/PlayerSettings.vue
@@ -3,7 +3,7 @@
     v-bind="$attrs"
     :title="t('Settings.Player Settings.Player Settings')"
   >
-    <div class="switchColumnGrid">
+    <div class="switchColumnGrid playerSwitchGrid">
       <div class="switchColumn">
         <FtToggleSwitch
           :label="t('Settings.Player Settings.Turn on Subtitles by Default')"
@@ -192,7 +192,7 @@
         :tooltips="isLinuxWayland ? { minimize: t('Settings.Player Settings.Auto Picture in Picture.Wayland Minimize Unsupported') } : {}"
       />
     </FtFlexBox>
-    <FtFlexBox>
+    <FtFlexBox class="playerSelectGrid">
       <FtSelect
         :placeholder="t('Settings.Player Settings.Default Viewing Mode.Default Viewing Mode')"
         :value="defaultViewingMode"
@@ -232,7 +232,7 @@
         @change="updateVideoPlaybackRateInterval"
       />
     </FtFlexBox>
-    <FtFlexBox>
+    <FtSliderGrid>
       <FtSlider
         :label="t('Settings.Player Settings.Next Video Interval')"
         :default-value="defaultInterval"
@@ -286,16 +286,6 @@
         @change="updateDefaultPlayback"
       />
       <FtSlider
-        :label="t('Settings.Player Settings.Parallel Segment Loading')"
-        :default-value="segmentPrefetchLimit"
-        setting-key="segmentPrefetchLimit"
-        :min-value="DEFAULT_SEGMENT_PREFETCH_LIMIT"
-        :max-value="MAX_SEGMENT_PREFETCH_LIMIT"
-        :step="1"
-        :tooltip="t('Tooltips.Player Settings.Parallel Segment Loading')"
-        @change="updateSegmentPrefetchLimit"
-      />
-      <FtSlider
         :label="t('Settings.Player Settings.Max Video Playback Rate')"
         :default-value="maxVideoPlaybackRate"
         setting-key="maxVideoPlaybackRate"
@@ -305,7 +295,17 @@
         value-extension="x"
         @change="updateMaxVideoPlaybackRate"
       />
-    </FtFlexBox>
+      <FtSlider
+        :label="t('Settings.Player Settings.Parallel Segment Loading')"
+        :default-value="segmentPrefetchLimit"
+        setting-key="segmentPrefetchLimit"
+        :min-value="DEFAULT_SEGMENT_PREFETCH_LIMIT"
+        :max-value="MAX_SEGMENT_PREFETCH_LIMIT"
+        :step="1"
+        :tooltip="t('Tooltips.Player Settings.Parallel Segment Loading')"
+        @change="updateSegmentPrefetchLimit"
+      />
+    </FtSliderGrid>
     <br>
     <FtFlexBox>
       <FtToggleSwitch
@@ -541,6 +541,7 @@ import FtSelect from '../FtSelect/FtSelect.vue'
 import FtToggleSwitch from '../FtToggleSwitch/FtToggleSwitch.vue'
 import FtCheckboxList from '../FtCheckboxList/FtCheckboxList.vue'
 import FtSlider from '../FtSlider/FtSlider.vue'
+import FtSliderGrid from '../FtSliderGrid/FtSliderGrid.vue'
 import FtFlexBox from '../ft-flex-box/ft-flex-box.vue'
 import FtButton from '../FtButton/FtButton.vue'
 import FtSyncedSettingIndicator from '../FtSyncedSettingIndicator/FtSyncedSettingIndicator.vue'

--- a/src/renderer/components/ThemeSettings.vue
+++ b/src/renderer/components/ThemeSettings.vue
@@ -266,7 +266,7 @@
         />
       </FtFlexBox>
     </template>
-    <div class="sliderGrid">
+    <FtSliderGrid>
       <FtSlider
         v-if="usingElectron"
         :label="$t('Settings.Theme Settings.UI Scale')"
@@ -322,7 +322,7 @@
         @input="previewAnimationSpeed"
         @change="updateAnimationSpeed"
       />
-    </div>
+    </FtSliderGrid>
     <FtPrompt
       v-if="showRestartPrompt"
       autosize
@@ -342,6 +342,7 @@ import FtSettingsSection from './FtSettingsSection/FtSettingsSection.vue'
 import FtSelect from './FtSelect/FtSelect.vue'
 import FtToggleSwitch from './FtToggleSwitch/FtToggleSwitch.vue'
 import FtSlider from './FtSlider/FtSlider.vue'
+import FtSliderGrid from './FtSliderGrid/FtSliderGrid.vue'
 import FtFlexBox from './ft-flex-box/ft-flex-box.vue'
 import FtButton from './FtButton/FtButton.vue'
 import FtPrompt from './FtPrompt/FtPrompt.vue'
@@ -945,15 +946,6 @@ function handleSmoothScrolling(value) {
 </script>
 
 <style scoped>
-.sliderGrid {
-  --slider-gap: 24px;
-
-  display: flex;
-  flex-wrap: wrap;
-  justify-content: center;
-  gap: var(--slider-gap);
-}
-
 .customThemeActions {
   margin-block-start: 24px;
 }
@@ -982,28 +974,4 @@ function handleSmoothScrolling(value) {
   }
 }
 
-.sliderGrid :deep(.pure-material-slider) {
-  box-sizing: border-box;
-  flex: 1 1 180px;
-  max-inline-size: 380px;
-  inline-size: auto;
-
-  /* The gap already spaces them out, and their own margin would count towards
-     how many fit in a row. */
-  margin-inline: 0;
-}
-
-/* Up to four sliders fill a row evenly, but a fifth would sit alone on the next
-   one while the others are squeezed together. Sizing them as thirds of the row
-   splits them 3 + 2, all the same width, with more room each. */
-.sliderGrid:has(:nth-child(5)) :deep(.pure-material-slider) {
-  --slider-size: clamp(
-    180px,
-    calc((100% - 2 * var(--slider-gap)) / 3),
-    380px
-  );
-
-  flex-basis: var(--slider-size);
-  max-inline-size: var(--slider-size);
-}
 </style>


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Make sure to follow the contributing guidelines. -->
<!-- Important note, we may remove your pull request if you do not use this provided PR template correctly. -->
<!-- Agent instructions: Preserve every heading, comment, and marker in this template. Never remove or rewrite the release-note-category:start/end, release-note:start/end, or release-note-image:start/end marker pairs. Never remove or rewrite the Release note images section; leave its contents for a human. -->

## Pull Request Type
<!-- Please select what type of pull request this is: [x] -->
- [x] Bugfix
- [ ] Feature Implementation
- [ ] Documentation
- [ ] Other

## Related issue
<!-- Please link the issue your pull request is referring to. -->
<!-- If this pull request fully resolves the relevant issue, put "closes" before the issue number. -->
<!-- Example: "closes #123456". -->

## Description
<!-- Please write a clear and concise description of what the pull request does. -->
Playback settings sliders stacked unnecessarily, while narrow toggle labels and select fields shifted based on label and tooltip width. This made the section uneven and could move switch labels off center.

This uses the same responsive slider grid for Appearance and Playback, moves Parallel Segment Loading after Max Video Playback Rate, and gives compact Playback controls consistent label, switch, and indicator columns. The regression coverage also checks the layout at 100% and 125% UI scale.

## Release note category
<!-- Select exactly one category. Every pull request must select one. -->
<!-- Select "Not noteworthy" when the pull request fixes a bug in or improves functionality that has not yet appeared in a stable release. -->
<!-- release-note-category:start -->
- [ ] Not noteworthy
- [ ] Highlights
- [ ] More improvements
- [x] Fixed bugs
<!-- release-note-category:end -->

## Release note
<!-- Required unless "Not noteworthy" is selected. -->
<!-- Write one concise, user-facing entry without a leading bullet. -->
<!-- release-note:start -->
Playback settings controls now stay evenly aligned and wrap cleanly at narrow window sizes and non-default UI scales.
<!-- release-note:end -->

## Release note images
<!-- Human-only: Agents must preserve this entire section and leave it empty. -->
<!-- Optional. Paste one or more Markdown images or HTML image tags here. -->
<!-- The release notes will use an HTML image tag and limit images taller than 300 pixels. -->
<!-- release-note-image:start -->

<!-- release-note-image:end -->

## Testing
<!-- How can reviewers verify that the PR produces correct results? -->
<!-- Please provide instructions so that others can ensure that your pull request would produce correct results. For examples see, https://github.com/FreeTubeApp/FreeTube/pull/5743, https://github.com/FreeTubeApp/FreeTube/pull/7349, https://github.com/FreeTubeApp/FreeTube/pull/5125, https://github.com/FreeTubeApp/FreeTube/pull/7338 -->
<!-- Agent instructions: Only write human-facing steps that explain how to verify the change while running this branch in dev mode. Include expected results and, when applicable, helpful console snippets for interactive verification. Do not include automated checks, commands, results, pass counts, or CI status. -->
1. Run the app in dev mode and open Settings > Playback.
2. Confirm the sliders wrap into equal-width, centered rows and that Parallel Segment Loading follows Max Video Playback Rate.
3. Resize the settings window to about 400 px wide. Confirm the toggle labels, switches, tooltip icons, and select boxes remain aligned.
4. Set UI Scale to 125% and repeat the narrow-window check. The controls should remain centered without horizontal overflow.

## Additional context
<!-- Add any other context about the pull request here. -->
