### PR TITLE
fix(player): prevent shortcuts while selecting settings

### DIFF
--- a/e2e/tests/offline/player.spec.mjs
+++ b/e2e/tests/offline/player.spec.mjs
@@ -1,4 +1,4 @@
-import { sel, setWindowSize, test, expect } from '../../helpers/app.mjs'
+import { goTo, sel, setWindowSize, test, expect } from '../../helpers/app.mjs'
 import {
   activeTab,
   expectDockedToBottomRight,
@@ -217,6 +217,28 @@ test('keyboard shortcuts change the playback rate', async ({ app, page, attachSc
   await page.locator('body').press('o')
   await expect.poll(() => video.evaluate((element) => element.playbackRate)).toBeLessThan(raisedRate)
   await attachScreenshot('playback rate lowered')
+})
+
+test('player shortcuts do not run while typing in a focused select', async ({ app, page }) => {
+  const video = await openDemoVideo({ app, page })
+  await goTo(page, 'settings')
+
+  const region = page.getByRole('combobox', { name: 'Region for Trending' })
+  await region.focus()
+  await expect(region).toHaveAttribute('aria-expanded', 'false')
+  await region.pressSequentially('kenya')
+  await expect(region.locator('.selectedValue')).toHaveText('Kenya')
+  await expect.poll(() => video.evaluate(element => element.paused)).toBe(false)
+
+  await region.click()
+  await expect(region).toHaveAttribute('aria-expanded', 'true')
+
+  await region.pressSequentially('kenya')
+
+  await expect(region).toHaveAttribute('aria-activedescendant', /-option-\d+$/)
+  const activeOptionId = await region.getAttribute('aria-activedescendant')
+  await expect(page.locator(`#${activeOptionId}`)).toHaveText('Kenya')
+  await expect.poll(() => video.evaluate(element => element.paused)).toBe(false)
 })
 
 test('playback rate shortcuts use the normal rate while hold-to-double is active', async ({ app, page }) => {

--- a/src/renderer/components/ft-shaka-video-player/ft-shaka-video-player.js
+++ b/src/renderer/components/ft-shaka-video-player/ft-shaka-video-player.js
@@ -8189,6 +8189,7 @@ export default defineComponent({
         target.tagName === 'INPUT' ||
         target.tagName === 'TEXTAREA' ||
         target.tagName === 'SELECT' ||
+        target.getAttribute('role') === 'combobox' ||
         target.isContentEditable
     }
 


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Make sure to follow the contributing guidelines. -->
<!-- Important note, we may remove your pull request if you do not use this provided PR template correctly. -->
<!-- Agent instructions: Preserve every heading, comment, and marker in this template. Never remove or rewrite the release-note-category:start/end, release-note:start/end, or release-note-image:start/end marker pairs. Never remove or rewrite the Release note images section; leave its contents for a human. -->

## Pull Request Type
<!-- Please select what type of pull request this is: [x] -->
- [x] Bugfix
- [ ] Feature Implementation
- [ ] Documentation
- [ ] Other

## Related issue
<!-- Please link the issue your pull request is referring to. -->
<!-- If this pull request fully resolves the relevant issue, put "closes" before the issue number. -->
<!-- Example: "closes #123456". -->

## Description
<!-- Please write a clear and concise description of what the pull request does. -->
When a custom settings select had focus, its printable-key typeahead events continued to the document-level player handler. Typing a region such as Kenya could therefore pause a video when the user pressed `k`.

The player now treats ARIA comboboxes as form controls and ignores player shortcuts while they are focused. An offline regression test covers typeahead with both closed and open selects.

## Release note category
<!-- Select exactly one category. Every pull request must select one. -->
<!-- Select "Not noteworthy" when the pull request fixes a bug in or improves functionality that has not yet appeared in a stable release. -->
<!-- release-note-category:start -->
- [ ] Not noteworthy
- [ ] Highlights
- [ ] More improvements
- [x] Fixed bugs
<!-- release-note-category:end -->

## Release note
<!-- Required unless "Not noteworthy" is selected. -->
<!-- Write one concise, user-facing entry without a leading bullet. -->
<!-- release-note:start -->
Prevented player keyboard shortcuts from firing while typing in focused settings selects.
<!-- release-note:end -->

## Release note images
<!-- Human-only: Agents must preserve this entire section and leave it empty. -->
<!-- Optional. Paste one or more Markdown images or HTML image tags here. -->
<!-- The release notes will use an HTML image tag and limit images taller than 300 pixels. -->
<!-- release-note-image:start -->

<!-- release-note-image:end -->

## Testing
<!-- How can reviewers verify that the PR produces correct results? -->
<!-- Please provide instructions so that others can ensure that your pull request would produce correct results. For examples see, https://github.com/FreeTubeApp/FreeTube/pull/5743, https://github.com/FreeTubeApp/FreeTube/pull/7349, https://github.com/FreeTubeApp/FreeTube/pull/5125, https://github.com/FreeTubeApp/FreeTube/pull/7338 -->
<!-- Agent instructions: Only write human-facing steps that explain how to verify the change while running this branch in dev mode. Include expected results and, when applicable, helpful console snippets for interactive verification. Do not include automated checks, commands, results, pass counts, or CI status. -->
1. Start a video, then open Settings and find the Region for Trending select.
2. Focus the closed select and type `kenya`. Kenya should be selected while playback continues unchanged.
3. Open the select and type `kenya` again. Kenya should become the active option while playback continues unchanged.

## Additional context
<!-- Add any other context about the pull request here. -->
