### PR TITLE
fix(comments): clarify pinned reply threads

### DIFF
--- a/e2e/tests/offline/watch-page.spec.mjs
+++ b/e2e/tests/offline/watch-page.spec.mjs
@@ -3450,22 +3450,38 @@ test.describe('manual comment loading', () => {
     await expect(page.locator('.commentsTitle')).toBeVisible({ timeout: 30_000 })
 
     let thread = page.locator('.commentThread').first()
+    const parentAuthor = await thread.locator(':scope > .commentAuthorWrapper .commentAuthor').innerText()
     await thread.locator('.commentReplyRootToggle button').click()
     let firstReply = thread.locator('.commentReplyContent').first()
     await expect(firstReply).toBeVisible({ timeout: 30_000 })
     const replyAuthor = await firstReply.locator('.commentAuthor').innerText()
     await firstReply.getByRole('button', { name: `Pin comment by ${replyAuthor}` }).click()
     await expect(firstReply).toContainText('Pinned by you')
+    await expect(thread.locator(':scope > .commentPersonalPin')).toContainText('A reply is pinned')
+    await expect(thread.getByRole('button', { name: `Pin comment by ${parentAuthor}` })).toHaveAttribute('aria-pressed', 'false')
 
     const reloadResponse = page.waitForResponse(/\/youtubei\/v1\/next/, { timeout: 30_000 })
     await page.getByRole('button', { name: 'Reload Comments' }).click()
     await reloadResponse
 
     thread = page.locator('.commentThread').first()
+    await expect(thread.locator(':scope > .commentPersonalPin')).toContainText('A reply is pinned')
+    const parentPinButton = thread.getByRole('button', { name: `Pin comment by ${parentAuthor}` })
+    await expect(parentPinButton).toHaveAttribute('aria-pressed', 'false')
     await thread.locator('.commentReplyRootToggle button').click()
     firstReply = thread.locator('.commentReplyContent').filter({ hasText: replyAuthor })
-    await expect(firstReply.getByRole('button', { name: `Unpin comment by ${replyAuthor}` })).toHaveAttribute('aria-pressed', 'true')
+    const replyUnpinButton = firstReply.getByRole('button', { name: `Unpin comment by ${replyAuthor}` })
+    await expect(replyUnpinButton).toHaveAttribute('aria-pressed', 'true')
     await expect(firstReply).toContainText('Pinned by you')
+
+    await replyUnpinButton.click()
+    await expect(thread.locator(':scope > .commentPersonalPin')).toHaveCount(0)
+    await firstReply.getByRole('button', { name: `Pin comment by ${replyAuthor}` }).click()
+    await expect(thread.locator(':scope > .commentPersonalPin')).toContainText('A reply is pinned')
+
+    await parentPinButton.click()
+    await expect(thread.locator(':scope > .commentPersonalPin')).toContainText('Pinned by you')
+    await expect(thread.getByRole('button', { name: `Unpin comment by ${parentAuthor}` })).toHaveAttribute('aria-pressed', 'true')
   })
 
   test('filters loaded comments to the video creator', async ({ app, page }) => {

--- a/src/renderer/components/CommentSection/CommentSection.vue
+++ b/src/renderer/components/CommentSection/CommentSection.vue
@@ -238,14 +238,19 @@
             {{ $t("Comments.Pinned by") }} <bdi>{{ channelName }}</bdi>
           </p>
           <p
-            v-if="isCommentPersonallyPinned(comment.id)"
+            v-if="commentTreeHasPersonalPin(comment)"
             class="commentPinned commentPersonalPin"
           >
             <FtIcon
               :icon="['fas', 'thumbtack']"
               aria-hidden="true"
             />
-            {{ $t('Comments.Pinned by you') }}
+            <template v-if="isCommentPersonallyPinned(comment.id)">
+              {{ $t('Comments.Pinned by you') }}
+            </template>
+            <template v-else>
+              {{ $t('Comments.A reply is pinned') }}
+            </template>
           </p>
           <p
             class="commentAuthorWrapper"
@@ -432,7 +437,7 @@
               :shorten-view-counts="shortenViewCounts"
               @copy-youtube-link="copyCommentYoutubeLink"
               @get-more-replies="getCommentReplies(index, $event)"
-              @toggle-personal-pin="togglePersonalCommentPin"
+              @toggle-personal-pin="togglePersonalCommentPin($event, comment.id)"
               @timestamp-event="onTimestamp"
               @translate-comment="toggleCommentTranslation"
               @translation-unavailable="restoreCommentTranslation"
@@ -602,7 +607,13 @@ import {
 } from '../../helpers/comment-replies'
 import { clampOverlayScrollTop, restoreOverlayScrollTop } from '../../helpers/overlayScrollbars'
 import { getYoutubeCommunityPostCommentUrl, getYoutubeVideoCommentUrl } from '../../helpers/share'
-import { getCommentPinStorageKey, loadCommentPins, saveCommentPins } from '../../helpers/commentPins'
+import {
+  getCommentPinStorageKey,
+  getCommentReplyPinMarker,
+  hasPinnedCommentReply,
+  loadCommentPins,
+  saveCommentPins
+} from '../../helpers/commentPins'
 import {
   getLocalCommunityPostComments,
   getLocalComments,
@@ -800,7 +811,9 @@ function getVisibleReplyNodes(comment) {
 }
 
 function commentTreeHasPersonalPin(comment) {
-  return isCommentPersonallyPinned(comment.id) || comment.replies.some(commentTreeHasPersonalPin)
+  return isCommentPersonallyPinned(comment.id) ||
+    hasPinnedCommentReply(personalPinnedCommentIds.value, comment.id) ||
+    comment.replies.some(commentTreeHasPersonalPin)
 }
 
 const visibleCommentEntries = computed(() => {
@@ -923,12 +936,18 @@ function personalPinActionLabel(comment) {
   return t('Comments.Pin comment by author', { author: comment.author })
 }
 
-function togglePersonalCommentPin(commentId) {
+function togglePersonalCommentPin(commentId, rootCommentId = null) {
   const commentIds = new Set(personalPinnedCommentIds.value)
   if (commentIds.has(commentId)) {
     commentIds.delete(commentId)
+    if (rootCommentId !== null) {
+      commentIds.delete(getCommentReplyPinMarker(rootCommentId, commentId))
+    }
   } else {
     commentIds.add(commentId)
+    if (rootCommentId !== null) {
+      commentIds.add(getCommentReplyPinMarker(rootCommentId, commentId))
+    }
   }
 
   personalPinnedCommentIds.value = commentIds

--- a/src/renderer/helpers/commentPins.js
+++ b/src/renderer/helpers/commentPins.js
@@ -1,4 +1,9 @@
 const STORAGE_KEY = 'opentubex-comment-pins'
+const REPLY_PIN_MARKER_PREFIX = 'opentubex-reply-pin:'
+
+function getReplyPinMarkerPrefix(rootCommentId) {
+  return `${REPLY_PIN_MARKER_PREFIX}${encodeURIComponent(rootCommentId)}:`
+}
 
 function readStoredPins(storage) {
   try {
@@ -18,6 +23,15 @@ function readStoredPins(storage) {
 
 export function getCommentPinStorageKey(profileId, contentId, isPost = false) {
   return `${profileId}:${isPost ? 'post' : 'video'}:${contentId}`
+}
+
+export function getCommentReplyPinMarker(rootCommentId, replyId) {
+  return `${getReplyPinMarkerPrefix(rootCommentId)}${encodeURIComponent(replyId)}`
+}
+
+export function hasPinnedCommentReply(commentIds, rootCommentId) {
+  const markerPrefix = getReplyPinMarkerPrefix(rootCommentId)
+  return Array.from(commentIds).some(commentId => commentId.startsWith(markerPrefix))
 }
 
 export function loadCommentPins(contentKey, storage = localStorage) {

--- a/static/locales/de-DE.yaml
+++ b/static/locales/de-DE.yaml
@@ -1899,6 +1899,7 @@ Comments:
   Show More Replies: Weitere Antworten anzeigen
   Pinned by: Angeheftet von
   Pinned by you: Von dir angeheftet
+  A reply is pinned: Eine Antwort ist angeheftet
   Filter loaded comments: Geladene Kommentare filtern
   Comment filters: Kommentarfilter
   From creator: Vom Ersteller

--- a/static/locales/en-US.yaml
+++ b/static/locales/en-US.yaml
@@ -2200,6 +2200,7 @@ Comments:
   Load More Comments: Load More Comments
   Pinned by: Pinned by
   Pinned by you: Pinned by you
+  A reply is pinned: A reply is pinned
   Filter loaded comments: Filter loaded comments
   Comment filters: Comment filters
   From creator: From creator

--- a/tests/unit/comment-pins.test.mjs
+++ b/tests/unit/comment-pins.test.mjs
@@ -3,6 +3,8 @@ import test from 'node:test'
 
 import {
   getCommentPinStorageKey,
+  getCommentReplyPinMarker,
+  hasPinnedCommentReply,
   loadCommentPins,
   saveCommentPins
 } from '../../src/renderer/helpers/commentPins.js'
@@ -28,6 +30,22 @@ test('keeps personal comment pins separate by profile and video', () => {
   assert.deepEqual(loadCommentPins(firstVideo, storage), new Set(['comment-a', 'comment-b']))
   assert.deepEqual(loadCommentPins(secondVideo, storage), new Set())
   assert.deepEqual(loadCommentPins(secondProfile, storage), new Set())
+})
+
+test('tracks pinned replies separately from their root comment', () => {
+  const firstReplyMarker = getCommentReplyPinMarker('root/comment', 'reply:one')
+  const secondReplyMarker = getCommentReplyPinMarker('root/comment', 'reply:two')
+  const commentIds = new Set(['reply:one', firstReplyMarker, 'reply:two', secondReplyMarker])
+
+  assert.equal(commentIds.has('root/comment'), false)
+  assert.equal(hasPinnedCommentReply(commentIds, 'root/comment'), true)
+  assert.equal(hasPinnedCommentReply(commentIds, 'other-root'), false)
+
+  commentIds.delete(firstReplyMarker)
+  assert.equal(hasPinnedCommentReply(commentIds, 'root/comment'), true)
+
+  commentIds.delete(secondReplyMarker)
+  assert.equal(hasPinnedCommentReply(commentIds, 'root/comment'), false)
 })
 
 test('removes empty pin groups and ignores malformed storage', () => {


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Make sure to follow the contributing guidelines. -->
<!-- Important note, we may remove your pull request if you do not use this provided PR template correctly. -->
<!-- Agent instructions: Preserve every heading, comment, and marker in this template. Never remove or rewrite the release-note-category:start/end, release-note:start/end, or release-note-image:start/end marker pairs. Never remove or rewrite the Release note images section; leave its contents for a human. -->

## Pull Request Type
<!-- Please select what type of pull request this is: [x] -->
- [x] Bugfix
- [ ] Feature Implementation
- [ ] Documentation
- [ ] Other

## Related issue
<!-- Please link the issue your pull request is referring to. -->
<!-- If this pull request fully resolves the relevant issue, put "closes" before the issue number. -->
<!-- Example: "closes #123456". -->

## Description
<!-- Please write a clear and concise description of what the pull request does. -->
Pinning a reply moved its parent thread with the pinned comments without explaining why. Treating the parent as directly pinned would also make its own pin action unavailable.

The parent thread now shows "A reply is pinned" while only a reply is pinned. Reply-to-parent associations persist across comment reloads, and the parent comment remains independently pinnable.

## Release note category
<!-- Select exactly one category. Every pull request must select one. -->
<!-- Select "Not noteworthy" when the pull request fixes a bug in or improves functionality that has not yet appeared in a stable release. -->
<!-- release-note-category:start -->
- [x] Not noteworthy
- [ ] Highlights
- [ ] More improvements
- [ ] Fixed bugs
<!-- release-note-category:end -->

## Release note
<!-- Required unless "Not noteworthy" is selected. -->
<!-- Write one concise, user-facing entry without a leading bullet. -->
<!-- release-note:start -->
Pinned replies now label their parent thread clearly while leaving the parent comment independently pinnable.
<!-- release-note:end -->

## Release note images
<!-- Human-only: Agents must preserve this entire section and leave it empty. -->
<!-- Optional. Paste one or more Markdown images or HTML image tags here. -->
<!-- The release notes will use an HTML image tag and limit images taller than 300 pixels. -->
<!-- release-note-image:start -->

<!-- release-note-image:end -->

## Testing
<!-- How can reviewers verify that the PR produces correct results? -->
<!-- Please provide instructions so that others can ensure that your pull request would produce correct results. For examples see, https://github.com/FreeTubeApp/FreeTube/pull/5743, https://github.com/FreeTubeApp/FreeTube/pull/7349, https://github.com/FreeTubeApp/FreeTube/pull/5125, https://github.com/FreeTubeApp/FreeTube/pull/7338 -->
<!-- Agent instructions: Only write human-facing steps that explain how to verify the change while running this branch in dev mode. Include expected results and, when applicable, helpful console snippets for interactive verification. Do not include automated checks, commands, results, pass counts, or CI status. -->
1. Open a video with comment replies and pin one reply.
2. Confirm the parent thread moves with the pinned comments and says "A reply is pinned" while its pin button remains available.
3. Reload the comments and confirm the reply-only badge and parent pin button remain unchanged.
4. Pin the parent comment and confirm its badge changes to "Pinned by you" and its button becomes an unpin action.

## Additional context
<!-- Add any other context about the pull request here. -->
The new badge is translated in English and German. Weblate can handle the remaining locales.
