### PR TITLE
fix(search): align metadata with channel avatars

### DIFF
--- a/e2e/tests/offline/video-result-avatars.spec.mjs
+++ b/e2e/tests/offline/video-result-avatars.spec.mjs
@@ -65,7 +65,7 @@ test.describe('Invidious search video avatars', () => {
     }
   })
 
-  test('shares one unknown channel lookup across video and playlist results', async ({ page }) => {
+  test('loads shared avatars and vertically aligns result metadata', async ({ page }) => {
     let channelRequests = 0
 
     await page.route(`${instanceUrl}/api/v1/search/**`, route => route.fulfill({
@@ -102,6 +102,19 @@ test.describe('Invidious search video avatars', () => {
     await expect(page.locator('.ft-list-video').filter({
       has: page.getByRole('heading', { name: 'Avatar search playlist' })
     }).locator('.channelAvatarImage')).toHaveAttribute('src', avatarUrl)
+    const infoLine = page.locator('.ft-list-video').filter({
+      has: page.getByRole('heading', { name: 'First avatar search result' })
+    }).locator('.infoLine')
+    await expect.poll(() => infoLine.evaluate(element => {
+      const channelRect = element.querySelector('.channelName').getBoundingClientRect()
+      const channelCenter = (channelRect.top + channelRect.bottom) / 2
+
+      return Math.max(...['.viewCount', '.uploadedTime'].map(selector => {
+        const detailRect = element.querySelector(selector).getBoundingClientRect()
+        const detailCenter = (detailRect.top + detailRect.bottom) / 2
+        return Math.abs(channelCenter - detailCenter)
+      }))
+    })).toBeLessThanOrEqual(0.5)
     expect(channelRequests).toBe(1)
   })
 

--- a/src/renderer/components/FtListVideo/FtListVideo.scss
+++ b/src/renderer/components/FtListVideo/FtListVideo.scss
@@ -17,6 +17,11 @@
   overflow-wrap: anywhere;
 }
 
+.infoLine > .viewCount,
+.infoLine > .uploadedTime {
+  vertical-align: middle;
+}
+
 .grabBar {
   color: var(--tertiary-text-color);
   cursor: grab;


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Make sure to follow the contributing guidelines. -->
<!-- Important note, we may remove your pull request if you do not use this provided PR template correctly. -->
<!-- Agent instructions: Preserve every heading, comment, and marker in this template. Never remove or rewrite the release-note-category:start/end, release-note:start/end, or release-note-image:start/end marker pairs. Never remove or rewrite the Release note images section; leave its contents for a human. -->

## Pull Request Type
<!-- Please select what type of pull request this is: [x] -->
- [x] Bugfix
- [ ] Feature Implementation
- [ ] Documentation
- [ ] Other

## Related issue
<!-- Please link the issue your pull request is referring to. -->
<!-- If this pull request fully resolves the relevant issue, put "closes" before the issue number. -->
<!-- Example: "closes #123456". -->

## Description
<!-- Please write a clear and concise description of what the pull request does. -->
When channel avatars were visible in result listings, the taller channel link used middle alignment while the view count and upload time remained baseline-aligned. This left the metadata visibly lower than the channel name, especially at fractional UI scales.

This applies the same middle alignment to the metadata spans and adds a regression check at 125% UI scale.

## Release note category
<!-- Select exactly one category. Every pull request must select one. -->
<!-- Select "Not noteworthy" when the pull request fixes a bug in or improves functionality that has not yet appeared in a stable release. -->
<!-- release-note-category:start -->
- [x] Not noteworthy
- [ ] Highlights
- [ ] More improvements
- [ ] Fixed bugs
<!-- release-note-category:end -->

## Release note
<!-- Required unless "Not noteworthy" is selected. -->
<!-- Write one concise, user-facing entry without a leading bullet. -->
<!-- release-note:start -->

<!-- release-note:end -->

## Release note images
<!-- Human-only: Agents must preserve this entire section and leave it empty. -->
<!-- Optional. Paste one or more Markdown images or HTML image tags here. -->
<!-- The release notes will use an HTML image tag and limit images taller than 300 pixels. -->
<!-- release-note-image:start -->

<!-- release-note-image:end -->

## Testing
<!-- How can reviewers verify that the PR produces correct results? -->
<!-- Please provide instructions so that others can ensure that your pull request would produce correct results. For examples see, https://github.com/FreeTubeApp/FreeTube/pull/5743, https://github.com/FreeTubeApp/FreeTube/pull/7349, https://github.com/FreeTubeApp/FreeTube/pull/5125, https://github.com/FreeTubeApp/FreeTube/pull/7338 -->
<!-- Agent instructions: Only write human-facing steps that explain how to verify the change while running this branch in dev mode. Include expected results and, when applicable, helpful console snippets for interactive verification. Do not include automated checks, commands, results, pass counts, or CI status. -->
1. Enable channel avatars for result listings and use the list layout.
2. Set UI Scale to 125%.
3. Search for videos that show a view count and upload time.
4. Confirm the channel name, view count, and upload time are vertically centered on the same line beside the avatar.

## Additional context
<!-- Add any other context about the pull request here. -->
