### PR TITLE
feat: automate winget release submissions

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -371,6 +371,42 @@ jobs:
           --ref "$GITHUB_REF_NAME" \
           -f "releaseTag=$TAG"
 
+  trigger-winget:
+    name: Trigger winget update
+    needs: publish-release
+    if: inputs.publishRelease
+    runs-on: ubuntu-latest
+
+    permissions:
+      actions: write
+      contents: read
+
+    steps:
+    - name: Resolve release tag
+      id: release
+      env:
+        GH_TOKEN: ${{ github.token }}
+        RELEASE_ID: ${{ inputs.releaseId }}
+      shell: bash
+      run: |
+        set -euo pipefail
+
+        tag="$(gh api "repos/${GITHUB_REPOSITORY}/releases/${RELEASE_ID}" --jq .tag_name)"
+        echo "tag=$tag" >> "$GITHUB_OUTPUT"
+
+    - name: Trigger winget workflow
+      env:
+        GH_TOKEN: ${{ github.token }}
+        TAG: ${{ steps.release.outputs.tag }}
+      shell: bash
+      run: |
+        set -euo pipefail
+
+        gh workflow run winget.yml \
+          --repo "$GITHUB_REPOSITORY" \
+          --ref "$GITHUB_REF_NAME" \
+          -f "releaseTag=$TAG"
+
   trigger-aur-update:
     name: Trigger AUR repository update
     needs: publish-release

--- a/.github/workflows/winget.yml
+++ b/.github/workflows/winget.yml
@@ -1,0 +1,377 @@
+name: Submit winget update
+
+on:
+  release:
+    types: [published]
+  workflow_dispatch:
+    inputs:
+      releaseTag:
+        description: Published release tag to retry, for example v0.32.1-beta
+        required: true
+        type: string
+
+permissions:
+  contents: read
+
+concurrency:
+  group: winget-${{ github.event.release.tag_name || inputs.releaseTag }}
+  cancel-in-progress: false
+
+jobs:
+  submit:
+    if: github.repository == 'OpenTubeX/OpenTubeX'
+    runs-on: ubuntu-24.04
+    timeout-minutes: 20
+
+    steps:
+    - name: Check out OpenTubeX
+      uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+      with:
+        persist-credentials: false
+
+    - name: Resolve release
+      id: release
+      env:
+        GH_TOKEN: ${{ github.token }}
+        RELEASE_TAG: ${{ github.event.release.tag_name || inputs.releaseTag }}
+      shell: bash
+      run: |
+        set -euo pipefail
+
+        if [[ ! "$RELEASE_TAG" =~ ^v([0-9]+\.[0-9]+\.[0-9]+)-beta$ ]]; then
+          echo "Ignoring unrelated release tag: $RELEASE_TAG"
+          echo 'eligible=false' >> "$GITHUB_OUTPUT"
+          exit 0
+        fi
+
+        version="${BASH_REMATCH[1]}"
+        release_json="${RUNNER_TEMP}/winget-release.json"
+        topics_json="${RUNNER_TEMP}/winget-topics.json"
+
+        gh api "repos/${GITHUB_REPOSITORY}/releases/tags/${RELEASE_TAG}" > "$release_json"
+        gh api "repos/${GITHUB_REPOSITORY}/topics" > "$topics_json"
+
+        if [[ "$(jq --raw-output .draft "$release_json")" != false ||
+          "$(jq --raw-output .published_at "$release_json")" == null ]]; then
+          echo "::error::${RELEASE_TAG} is not a published release."
+          exit 1
+        fi
+
+        for architecture in x64 arm64; do
+          asset="opentubex-${version}-beta-setup-${architecture}.exe"
+          count="$(jq --arg asset "$asset" '[.assets[] | select(.name == $asset)] | length' "$release_json")"
+
+          if [[ "$count" != 1 ]]; then
+            echo "::error::Expected one release asset named ${asset}, found ${count}."
+            exit 1
+          fi
+        done
+
+        {
+          echo 'eligible=true'
+          echo "version=$version"
+          echo "tag=$RELEASE_TAG"
+          echo "release_json=$release_json"
+          echo "topics_json=$topics_json"
+        } >> "$GITHUB_OUTPUT"
+
+    - name: Check for an accepted manifest or open pull request
+      if: steps.release.outputs.eligible == 'true'
+      id: duplicate
+      env:
+        GH_TOKEN: ${{ github.token }}
+        VERSION: ${{ steps.release.outputs.version }}
+      shell: bash
+      run: |
+        set -euo pipefail
+
+        manifest_path="manifests/o/OpenTubeX/OpenTubeX/${VERSION}"
+
+        if gh api "repos/microsoft/winget-pkgs/contents/${manifest_path}" >/dev/null 2>&1; then
+          echo "winget already contains OpenTubeX.OpenTubeX ${VERSION}."
+          echo 'needed=false' >> "$GITHUB_OUTPUT"
+          exit 0
+        fi
+
+        existing_pr="$({
+          gh pr list \
+            --repo microsoft/winget-pkgs \
+            --state open \
+            --search "\"OpenTubeX.OpenTubeX\" \"${VERSION}\" in:title" \
+            --json title,url \
+            --limit 100
+        } | jq --arg version "$VERSION" \
+          'first(.[] | select((.title | contains("OpenTubeX.OpenTubeX")) and (.title | contains($version)))) // empty')"
+
+        if [[ -n "$existing_pr" ]]; then
+          echo "An open pull request already updates OpenTubeX.OpenTubeX ${VERSION}:"
+          jq --raw-output .url <<< "$existing_pr"
+          echo 'needed=false' >> "$GITHUB_OUTPUT"
+          exit 0
+        fi
+
+        echo 'needed=true' >> "$GITHUB_OUTPUT"
+
+    - name: Install Komac 2.16.0
+      if: steps.duplicate.outputs.needed == 'true'
+      env:
+        GH_TOKEN: ${{ github.token }}
+      shell: bash
+      run: |
+        set -euo pipefail
+
+        archive='komac-2.16.0-x86_64-unknown-linux-gnu.tar.gz'
+        install_dir="${RUNNER_TEMP}/komac-2.16.0"
+        mkdir -p "$install_dir"
+
+        gh release download v2.16.0 \
+          --repo russellbanks/Komac \
+          --pattern "$archive" \
+          --dir "$install_dir"
+
+        echo '7d2707fa6210f2789a3702de49fbd150b736dbf426ee0b9bc8e098736f9fd82d  '"$install_dir/$archive" \
+          | sha256sum --check --status
+        tar --extract --gzip --file "$install_dir/$archive" --directory "$install_dir"
+        chmod 755 "$install_dir/komac"
+        echo "$install_dir" >> "$GITHUB_PATH"
+
+    - name: Generate and validate manifests
+      if: steps.duplicate.outputs.needed == 'true'
+      id: manifest
+      env:
+        GITHUB_TOKEN: ${{ github.token }}
+        RELEASE_JSON: ${{ steps.release.outputs.release_json }}
+        RELEASE_TAG: ${{ steps.release.outputs.tag }}
+        TOPICS_JSON: ${{ steps.release.outputs.topics_json }}
+        VERSION: ${{ steps.release.outputs.version }}
+      shell: bash
+      run: |
+        set -euo pipefail
+
+        output_dir="${RUNNER_TEMP}/komac-output"
+        manifest_dir="${output_dir}/manifests/o/OpenTubeX/OpenTubeX/${VERSION}"
+        release_url="https://github.com/${GITHUB_REPOSITORY}/releases/tag/${RELEASE_TAG}"
+        x64_url="https://github.com/${GITHUB_REPOSITORY}/releases/download/${RELEASE_TAG}/opentubex-${VERSION}-beta-setup-x64.exe"
+        arm64_url="https://github.com/${GITHUB_REPOSITORY}/releases/download/${RELEASE_TAG}/opentubex-${VERSION}-beta-setup-arm64.exe"
+
+        # --submit --dry-run avoids Komac's interactive prompt. Submission is
+        # handled below because Komac only supports personal forks.
+        komac update OpenTubeX.OpenTubeX \
+          --version "$VERSION" \
+          --urls "$x64_url" "$arm64_url" \
+          --release-notes-url "$release_url" \
+          --output "$output_dir" \
+          --skip-pr-check \
+          --submit \
+          --dry-run
+
+        node _scripts/prepareWingetManifest.mjs \
+          --manifest-dir "$manifest_dir" \
+          --release-json "$RELEASE_JSON" \
+          --topics-json "$TOPICS_JSON"
+
+        # Komac reparses and validates the final, post-processed manifests.
+        komac submit --dry-run --yes "$manifest_dir"
+
+        echo "directory=$manifest_dir" >> "$GITHUB_OUTPUT"
+
+    - name: Validate winget credentials
+      if: steps.duplicate.outputs.needed == 'true'
+      env:
+        WINGET_TOKEN: ${{ secrets.WINGET_TOKEN }}
+      shell: bash
+      run: |
+        set -euo pipefail
+
+        if [[ -z "$WINGET_TOKEN" ]]; then
+          echo '::error::The WINGET_TOKEN repository secret is missing.'
+          exit 1
+        fi
+
+        echo "::add-mask::${WINGET_TOKEN}"
+
+    - name: Create or synchronize the organization fork
+      if: steps.duplicate.outputs.needed == 'true'
+      env:
+        GH_TOKEN: ${{ secrets.WINGET_TOKEN }}
+      shell: bash
+      run: |
+        set -euo pipefail
+
+        if ! gh api repos/OpenTubeX/winget-pkgs >/dev/null 2>&1; then
+          echo 'Creating OpenTubeX/winget-pkgs.'
+          gh api \
+            --method POST \
+            repos/microsoft/winget-pkgs/forks \
+            -f organization=OpenTubeX \
+            -f name=winget-pkgs \
+            -F default_branch_only=true \
+            >/dev/null
+
+          for attempt in {1..30}; do
+            if gh api repos/OpenTubeX/winget-pkgs >/dev/null 2>&1; then
+              break
+            fi
+
+            if (( attempt == 30 )); then
+              echo '::error::OpenTubeX/winget-pkgs was not ready after 60 seconds.'
+              exit 1
+            fi
+
+            sleep 2
+          done
+        fi
+
+        parent="$(gh api repos/OpenTubeX/winget-pkgs --jq '.parent.full_name // ""')"
+
+        if [[ "$parent" != microsoft/winget-pkgs ]]; then
+          echo "::error::OpenTubeX/winget-pkgs is not a fork of microsoft/winget-pkgs."
+          exit 1
+        fi
+
+        gh api \
+          --method POST \
+          repos/OpenTubeX/winget-pkgs/merge-upstream \
+          -f branch=master \
+          >/dev/null
+
+    - name: Create the signed version commit
+      if: steps.duplicate.outputs.needed == 'true'
+      env:
+        BRANCH: OpenTubeX.OpenTubeX-${{ steps.release.outputs.version }}
+        GH_TOKEN: ${{ secrets.WINGET_TOKEN }}
+        MANIFEST_DIR: ${{ steps.manifest.outputs.directory }}
+        VERSION: ${{ steps.release.outputs.version }}
+      shell: bash
+      run: |
+        set -euo pipefail
+
+        work_dir="${RUNNER_TEMP}/winget-pkgs"
+        package_dir="manifests/o/OpenTubeX/OpenTubeX/${VERSION}"
+        gh auth setup-git
+
+        git init "$work_dir"
+        git -C "$work_dir" remote add origin https://github.com/OpenTubeX/winget-pkgs.git
+        git -C "$work_dir" remote add upstream https://github.com/microsoft/winget-pkgs.git
+        git -C "$work_dir" fetch --depth=1 --filter=blob:none upstream master
+        upstream_sha="$(git -C "$work_dir" rev-parse FETCH_HEAD)"
+
+        remote_sha="$(gh api "repos/OpenTubeX/winget-pkgs/git/ref/heads/${BRANCH}" --jq .object.sha 2>/dev/null || true)"
+
+        if [[ -n "$remote_sha" ]]; then
+          git -C "$work_dir" push origin "${upstream_sha}:refs/heads/${BRANCH}" \
+            --force-with-lease="refs/heads/${BRANCH}:${remote_sha}"
+        else
+          git -C "$work_dir" push origin "${upstream_sha}:refs/heads/${BRANCH}"
+        fi
+
+        branch_id="$(gh api "repos/OpenTubeX/winget-pkgs/git/ref/heads/${BRANCH}" --jq .node_id)"
+        mutation="${RUNNER_TEMP}/winget-commit.json"
+        response="${RUNNER_TEMP}/winget-commit-response.json"
+
+        jq --null-input \
+          --arg query 'mutation($input: CreateCommitOnBranchInput!) { createCommitOnBranch(input: $input) { commit { oid url } } }' \
+          --arg branch_id "$branch_id" \
+          --arg expected_head_oid "$upstream_sha" \
+          --arg headline "Update OpenTubeX.OpenTubeX to ${VERSION}" \
+          --arg installer_path "${package_dir}/OpenTubeX.OpenTubeX.installer.yaml" \
+          --arg installer_contents "$(base64 --wrap=0 "$MANIFEST_DIR/OpenTubeX.OpenTubeX.installer.yaml")" \
+          --arg locale_path "${package_dir}/OpenTubeX.OpenTubeX.locale.en-US.yaml" \
+          --arg locale_contents "$(base64 --wrap=0 "$MANIFEST_DIR/OpenTubeX.OpenTubeX.locale.en-US.yaml")" \
+          --arg version_path "${package_dir}/OpenTubeX.OpenTubeX.yaml" \
+          --arg version_contents "$(base64 --wrap=0 "$MANIFEST_DIR/OpenTubeX.OpenTubeX.yaml")" \
+          '{
+            query: $query,
+            variables: {
+              input: {
+                branch: { id: $branch_id },
+                expectedHeadOid: $expected_head_oid,
+                fileChanges: {
+                  additions: [
+                    { path: $installer_path, contents: $installer_contents },
+                    { path: $locale_path, contents: $locale_contents },
+                    { path: $version_path, contents: $version_contents }
+                  ]
+                },
+                message: { headline: $headline }
+              }
+            }
+          }' > "$mutation"
+
+        gh api graphql --input "$mutation" > "$response"
+        commit_sha="$(jq --raw-output '.data.createCommitOnBranch.commit.oid // empty' "$response")"
+
+        if [[ -z "$commit_sha" ]]; then
+          jq .errors "$response" >&2
+          echo '::error::GitHub did not create the winget manifest commit.'
+          exit 1
+        fi
+
+        # createCommitOnBranch uses GitHub's signing key. Fail instead of
+        # opening a pull request with an unsigned automation commit.
+        if [[ "$(gh api "repos/OpenTubeX/winget-pkgs/commits/${commit_sha}" --jq .commit.verification.verified)" != true ]]; then
+          echo '::error::GitHub did not report the winget manifest commit as signed.'
+          exit 1
+        fi
+
+    - name: Open winget pull request
+      if: steps.duplicate.outputs.needed == 'true'
+      env:
+        BRANCH: OpenTubeX.OpenTubeX-${{ steps.release.outputs.version }}
+        GH_TOKEN: ${{ secrets.WINGET_TOKEN }}
+        VERSION: ${{ steps.release.outputs.version }}
+      shell: bash
+      run: |
+        set -euo pipefail
+
+        existing_pr="$(gh pr list \
+          --repo microsoft/winget-pkgs \
+          --state open \
+          --search "\"OpenTubeX.OpenTubeX\" \"${VERSION}\" in:title" \
+          --json title,url \
+          --limit 100 \
+          | jq --arg version "$VERSION" \
+            'first(.[] | select((.title | contains("OpenTubeX.OpenTubeX")) and (.title | contains($version)))) // empty')"
+
+        if [[ -n "$existing_pr" ]]; then
+          echo "An open pull request appeared while this workflow was running:"
+          jq --raw-output .url <<< "$existing_pr"
+          exit 0
+        fi
+
+        template="${RUNNER_TEMP}/winget-pr-template.md"
+        body="${RUNNER_TEMP}/winget-pr-body.md"
+        gh api repos/microsoft/winget-pkgs/contents/.github/PULL_REQUEST_TEMPLATE.md \
+          --jq .content \
+          | base64 --decode > "$template"
+
+        awk -v version="$VERSION" '
+          { print }
+          /^<!-- Describe what this PR changes\./ {
+            print ""
+            print "Updates OpenTubeX.OpenTubeX to " version " using the x64 and ARM64 installers from the published OpenTubeX release."
+            print "The manifest keeps user and machine installation scopes and uses the current OpenTubeX repository topics."
+          }
+        ' "$template" \
+          | sed \
+            -e "s/- \[ \] Checked that there aren't other open/- [x] Checked that there aren't other open/" \
+            -e 's/- \[ \] This PR only modifies/- [x] This PR only modifies/' \
+          > "$body"
+
+        cat >> "$body" <<EOF
+
+        Komac 2.16.0 generated and validated the manifests before this branch was pushed.
+        EOF
+
+        pr_url="$(gh pr create \
+          --repo microsoft/winget-pkgs \
+          --base master \
+          --head "OpenTubeX:${BRANCH}" \
+          --title "Update: OpenTubeX.OpenTubeX to ${VERSION}" \
+          --body-file "$body")"
+
+        {
+          echo '## winget submission'
+          echo
+          echo "Created ready-for-review pull request: ${pr_url}"
+        } >> "$GITHUB_STEP_SUMMARY"

--- a/_scripts/prepareWingetManifest.mjs
+++ b/_scripts/prepareWingetManifest.mjs
@@ -62,11 +62,14 @@ function stripHtmlMarkup(value) {
 
       index = commentEnd === -1 ? value.length : commentEnd + 3
     } else if (value[index] === '<') {
-      const tagEnd = value.indexOf('>', index + 1)
+      const tag = value.slice(index).match(/^<\/?[a-z][a-z0-9:-]*(?:\s[^<>]*)?\s*\/?>/i)
 
-      index = tagEnd === -1 ? index + 1 : tagEnd + 1
-    } else if (value[index] === '>') {
-      index += 1
+      if (tag) {
+        index += tag[0].length
+      } else {
+        plainText += value[index]
+        index += 1
+      }
     } else {
       plainText += value[index]
       index += 1
@@ -83,6 +86,7 @@ export function cleanReleaseNotes(markdown) {
   notes = notes.replaceAll(/<a\b[^>]*>\s*<img\b[^>]*>\s*<\/a>/gi, '')
   notes = notes.replaceAll(/<img\b[^>]*\/?\s*>/gi, '')
   notes = notes.replaceAll(/\[!\[[^\]]*\]\([^)]*\)\]\([^)]*\)/g, '')
+  notes = notes.replaceAll(/\[!\[[^\]]*\]\[[^\]]*\]\]\[[^\]]*\]/g, '')
   notes = notes.replaceAll(/!\[[^\]]*\]\([^)]*\)/g, '')
   notes = notes.replaceAll(/!\[[^\]]*\]\[[^\]]*\]/g, '')
 

--- a/_scripts/prepareWingetManifest.mjs
+++ b/_scripts/prepareWingetManifest.mjs
@@ -117,6 +117,7 @@ export function cleanReleaseNotes(markdown) {
   notes = notes.replaceAll(/<br\s*\/?>/gi, '\n')
   notes = stripHtmlMarkup(notes)
   notes = decodeHtml(notes)
+  notes = stripHtmlMarkup(notes)
   notes = notes.replaceAll(/^#{1,6}\s+/gm, '')
   notes = notes.replaceAll(/\[([^\]]+)\]\([^)]*\)/g, '$1')
   notes = notes.replaceAll(/\[([^\]]+)\]\[[^\]]*\]/g, '$1')

--- a/_scripts/prepareWingetManifest.mjs
+++ b/_scripts/prepareWingetManifest.mjs
@@ -1,0 +1,295 @@
+import assert from 'node:assert/strict'
+import fs from 'node:fs'
+import path from 'node:path'
+import process from 'node:process'
+import { fileURLToPath } from 'node:url'
+
+const PACKAGE_IDENTIFIER = 'OpenTubeX.OpenTubeX'
+const MAX_WINGET_TAGS = 16
+
+function decodeHtml(value) {
+  const namedEntities = {
+    amp: '&',
+    apos: '\'',
+    gt: '>',
+    lt: '<',
+    nbsp: ' ',
+    quot: '"',
+  }
+
+  return value.replaceAll(/&(#(?:x[\da-f]+|\d+)|[a-z]+);/gi, (entity, name) => {
+    if (name.startsWith('#x')) {
+      return String.fromCodePoint(Number.parseInt(name.slice(2), 16))
+    }
+
+    if (name.startsWith('#')) {
+      return String.fromCodePoint(Number.parseInt(name.slice(1), 10))
+    }
+
+    return namedEntities[name.toLowerCase()] ?? entity
+  })
+}
+
+function removePromotionSections(lines) {
+  const promotionHeading = /^(#{1,6})\s+(?:donate|promotion|sponsors?|support(?: us| the project)?)\b/i
+  let skippedHeadingLevel = null
+
+  return lines.filter((line) => {
+    const heading = line.match(/^(#{1,6})\s+/)
+
+    if (skippedHeadingLevel !== null) {
+      if (!heading || heading[1].length > skippedHeadingLevel) { return false }
+      skippedHeadingLevel = null
+    }
+
+    const promotion = line.match(promotionHeading)
+
+    if (promotion) {
+      skippedHeadingLevel = promotion[1].length
+      return false
+    }
+
+    return true
+  })
+}
+
+export function cleanReleaseNotes(markdown) {
+  let notes = markdown.replaceAll('\r\n', '\n')
+
+  notes = notes.replaceAll(/<!--[^]*?-->/g, '')
+  notes = notes.replaceAll(/<(?:picture|svg|video)\b[^]*?<\/(?:picture|svg|video)>/gi, '')
+  notes = notes.replaceAll(/<a\b[^>]*>\s*<img\b[^>]*>\s*<\/a>/gi, '')
+  notes = notes.replaceAll(/<img\b[^>]*\/?\s*>/gi, '')
+  notes = notes.replaceAll(/\[!\[[^\]]*\]\([^)]*\)\]\([^)]*\)/g, '')
+  notes = notes.replaceAll(/!\[[^\]]*\]\([^)]*\)/g, '')
+  notes = notes.replaceAll(/!\[[^\]]*\]\[[^\]]*\]/g, '')
+
+  const firstReleaseHeading = notes.search(/^##\s+\S/m)
+
+  if (firstReleaseHeading !== -1) {
+    notes = notes.slice(firstReleaseHeading)
+  }
+
+  let lines = removePromotionSections(notes.split('\n'))
+  let inPromotionalQuote = false
+
+  lines = lines.flatMap((line) => {
+    if (/^>\s*\[!(?:IMPORTANT|NOTE|TIP)\]/i.test(line)) {
+      inPromotionalQuote = true
+      return []
+    }
+
+    if (inPromotionalQuote) {
+      if (/^>/.test(line) || line.trim() === '') { return [] }
+      inPromotionalQuote = false
+    }
+
+    return [line]
+  })
+
+  notes = lines.join('\n')
+  notes = notes.replaceAll(/<br\s*\/?>/gi, '\n')
+  notes = notes.replaceAll(/<[^>]+>/g, '')
+  notes = decodeHtml(notes)
+  notes = notes.replaceAll(/^#{1,6}\s+/gm, '')
+  notes = notes.replaceAll(/\[([^\]]+)\]\([^)]*\)/g, '$1')
+  notes = notes.replaceAll(/\[([^\]]+)\]\[[^\]]*\]/g, '$1')
+  notes = notes.replaceAll(/^\[[^\]]+\]:\s+\S+.*$/gm, '')
+  notes = notes.replaceAll(/(\*\*|__)(.*?)\1/g, '$2')
+  notes = notes.replaceAll(/`([^`]+)`/g, '$1')
+  notes = notes.replaceAll(/^\s*```.*$/gm, '')
+
+  lines = notes
+    .split('\n')
+    .map((line) => line.trimEnd())
+    .filter((line) => !/^\s*(?:image|badge)\s*$/i.test(line))
+    .filter((line) => !/product\s*hunt/i.test(line))
+    .filter((line) => !/^\s*https?:\/\/\S+\.(?:avif|gif|jpe?g|png|svg|webp)(?:\?\S*)?\s*$/i.test(line))
+
+  return lines
+    .join('\n')
+    .replaceAll(/[ \t]+\n/g, '\n')
+    .replaceAll(/(^\s*-\s.*)\n\n(?=\s*-\s)/gm, '$1\n')
+    .replaceAll(/\n{3,}/g, '\n\n')
+    .trim()
+}
+
+function replaceScalar(manifest, key, value, { all = false } = {}) {
+  const expression = new RegExp(`^(\\s*(?:-\\s*)?)${key}:.*$`, all ? 'gm' : 'm')
+  const matches = manifest.match(expression) ?? []
+
+  assert(matches.length > 0, `Missing ${key} in manifest`)
+
+  return manifest.replace(expression, `$1${key}: ${value}`)
+}
+
+function replaceTags(manifest, tags) {
+  const start = manifest.indexOf('\nTags:\n')
+  const end = manifest.indexOf('\nReleaseNotes:', start)
+
+  assert(start !== -1 && end !== -1, 'Could not find the Tags block')
+
+  const replacement = `\nTags:\n${tags.map((tag) => `- ${tag}`).join('\n')}`
+  return `${manifest.slice(0, start)}${replacement}${manifest.slice(end)}`
+}
+
+function replaceReleaseNotes(manifest, releaseNotes) {
+  const start = manifest.indexOf('\nReleaseNotes: |-\n')
+  const end = manifest.indexOf('\nReleaseNotesUrl:', start)
+
+  assert(start !== -1 && end !== -1, 'Could not find the ReleaseNotes block')
+
+  const indentedNotes = releaseNotes
+    .split('\n')
+    .map((line) => line ? `  ${line}` : '')
+    .join('\n')
+  const replacement = `\nReleaseNotes: |-\n${indentedNotes}`
+
+  return `${manifest.slice(0, start)}${replacement}${manifest.slice(end)}`
+}
+
+function scalar(block, key) {
+  return block.match(new RegExp(`^\\s*${key}:\\s*(.+)$`, 'm'))?.[1].trim()
+}
+
+function validateInstallerManifest(manifest, { release, version }) {
+  const expectedAssets = new Map([
+    ['arm64', `opentubex-${version}-beta-setup-arm64.exe`],
+    ['x64', `opentubex-${version}-beta-setup-x64.exe`],
+  ])
+  const assets = new Map(release.assets.map((asset) => [asset.name, asset]))
+  const installerBlocks = manifest
+    .split('\n- Architecture: ')
+    .slice(1)
+    .map((block) => `Architecture: ${block}`)
+  const productCodes = [...manifest.matchAll(/^\s*ProductCode:\s*(\S+)$/gm)]
+    .map((match) => match[1])
+
+  assert.equal(scalar(manifest, 'PackageIdentifier'), PACKAGE_IDENTIFIER)
+  assert.equal(scalar(manifest, 'PackageVersion'), version)
+  assert.equal(scalar(manifest, 'InstallerType'), 'nullsoft')
+  assert.equal(scalar(manifest, 'ReleaseDate'), release.published_at.slice(0, 10))
+  assert.match(manifest, /^Protocols:\n- opentubex$/m)
+  assert(productCodes.length >= 2, 'Expected the package ProductCode in installer metadata')
+  assert(productCodes.every((productCode) => productCode === productCodes[0]), 'ProductCode values do not match')
+  assert.equal(manifest.match(/^\s*- DisplayName:\s*(.+)$/m)?.[1], `OpenTubeX ${version}`)
+  assert.equal(installerBlocks.length, 4, 'Expected four installer entries')
+
+  for (const architecture of ['x64', 'arm64']) {
+    const assetName = expectedAssets.get(architecture)
+    const asset = assets.get(assetName)
+
+    assert(asset, `Missing release asset ${assetName}`)
+    assert.match(asset.digest ?? '', /^sha256:[\da-f]{64}$/i, `Missing SHA-256 digest for ${assetName}`)
+
+    for (const scope of ['user', 'machine']) {
+      const block = installerBlocks.find((entry) =>
+        scalar(entry, 'Architecture') === architecture && scalar(entry, 'Scope') === scope)
+
+      assert(block, `Missing ${architecture} ${scope} installer`)
+      assert.equal(scalar(block, 'InstallerUrl'), asset.browser_download_url)
+      assert.equal(scalar(block, 'InstallerSha256').toLowerCase(), asset.digest.slice('sha256:'.length).toLowerCase())
+      assert.equal(scalar(block, 'Custom'), scope === 'user' ? '/CURRENTUSER' : '/ALLUSERS')
+    }
+  }
+}
+
+function validateLocaleManifest(manifest, { releaseNotes, releaseUrl, tags, version }) {
+  assert.equal(scalar(manifest, 'PackageIdentifier'), PACKAGE_IDENTIFIER)
+  assert.equal(scalar(manifest, 'PackageVersion'), version)
+  assert.equal(scalar(manifest, 'PackageName'), 'OpenTubeX')
+  assert.equal(scalar(manifest, 'ReleaseNotesUrl'), releaseUrl)
+  assert(!/<[^>]+>/.test(releaseNotes), 'Release notes still contain HTML')
+  assert(!/!\[[^\]]*\]/.test(releaseNotes), 'Release notes still contain a Markdown image')
+  assert(!/^\s*image\s*$/im.test(releaseNotes), 'Release notes still contain a stray image label')
+  assert(!/product\s*hunt/i.test(releaseNotes), 'Release notes still contain a promotional block')
+
+  for (const tag of tags) {
+    assert.match(manifest, new RegExp(`^- ${tag}$`, 'm'))
+  }
+}
+
+function parseArguments(args) {
+  const values = {}
+
+  for (let index = 0; index < args.length; index += 2) {
+    const key = args[index]
+    const value = args[index + 1]
+
+    assert(key?.startsWith('--') && value, `Invalid argument ${key ?? ''}`)
+    values[key.slice(2)] = value
+  }
+
+  for (const required of ['manifest-dir', 'release-json', 'topics-json']) {
+    assert(values[required], `Missing --${required}`)
+  }
+
+  return values
+}
+
+export function prepareManifest({ manifestDirectory, release, topics }) {
+  assert.match(release.tag_name, /^v\d+\.\d+\.\d+-beta$/)
+
+  const version = release.tag_name.slice(1, -'-beta'.length)
+  const releaseDate = release.published_at?.slice(0, 10)
+  const releaseUrl = release.html_url
+  const releaseNotes = cleanReleaseNotes(release.body ?? '')
+  const tags = [...new Set(topics.names)].sort()
+
+  assert.match(releaseDate ?? '', /^\d{4}-\d{2}-\d{2}$/)
+  assert.match(releaseUrl ?? '', /^https:\/\/github\.com\/OpenTubeX\/OpenTubeX\/releases\/tag\//)
+  assert(releaseNotes, 'Release notes are empty after cleaning')
+  assert(tags.length > 0, 'The repository has no GitHub topics')
+  assert(tags.length <= MAX_WINGET_TAGS, `winget accepts at most ${MAX_WINGET_TAGS} tags`)
+
+  for (const tag of tags) {
+    assert.match(tag, /^[a-z0-9][a-z0-9-]{0,39}$/, `Invalid winget tag: ${tag}`)
+  }
+
+  const files = {
+    installer: path.join(manifestDirectory, `${PACKAGE_IDENTIFIER}.installer.yaml`),
+    locale: path.join(manifestDirectory, `${PACKAGE_IDENTIFIER}.locale.en-US.yaml`),
+    version: path.join(manifestDirectory, `${PACKAGE_IDENTIFIER}.yaml`),
+  }
+
+  for (const file of Object.values(files)) {
+    assert(fs.existsSync(file), `Missing generated manifest ${file}`)
+  }
+
+  let installerManifest = fs.readFileSync(files.installer, 'utf8').replaceAll('\r\n', '\n')
+  let localeManifest = fs.readFileSync(files.locale, 'utf8').replaceAll('\r\n', '\n')
+  const versionManifest = fs.readFileSync(files.version, 'utf8').replaceAll('\r\n', '\n')
+
+  installerManifest = replaceScalar(installerManifest, 'ReleaseDate', releaseDate)
+  installerManifest = replaceScalar(installerManifest, 'DisplayName', `OpenTubeX ${version}`, { all: true })
+  localeManifest = replaceTags(localeManifest, tags)
+  localeManifest = replaceReleaseNotes(localeManifest, releaseNotes)
+  localeManifest = replaceScalar(localeManifest, 'ReleaseNotesUrl', releaseUrl)
+
+  validateInstallerManifest(installerManifest, { release, version })
+  validateLocaleManifest(localeManifest, { releaseNotes, releaseUrl, tags, version })
+  assert.equal(scalar(versionManifest, 'PackageIdentifier'), PACKAGE_IDENTIFIER)
+  assert.equal(scalar(versionManifest, 'PackageVersion'), version)
+
+  fs.writeFileSync(files.installer, installerManifest)
+  fs.writeFileSync(files.locale, localeManifest)
+
+  return { releaseNotes, tags, version }
+}
+
+async function main() {
+  const args = parseArguments(process.argv.slice(2))
+  const release = JSON.parse(fs.readFileSync(args['release-json'], 'utf8'))
+  const topics = JSON.parse(fs.readFileSync(args['topics-json'], 'utf8'))
+  const result = prepareManifest({
+    manifestDirectory: args['manifest-dir'],
+    release,
+    topics,
+  })
+
+  process.stdout.write(`Prepared and validated ${PACKAGE_IDENTIFIER} ${result.version}.\n`)
+}
+
+if (process.argv[1] && fileURLToPath(import.meta.url) === path.resolve(process.argv[1])) {
+  await main()
+}

--- a/_scripts/prepareWingetManifest.mjs
+++ b/_scripts/prepareWingetManifest.mjs
@@ -53,10 +53,32 @@ function removePromotionSections(lines) {
   })
 }
 
+function stripHtmlMarkup(value) {
+  let plainText = ''
+
+  for (let index = 0; index < value.length;) {
+    if (value.startsWith('<!--', index)) {
+      const commentEnd = value.indexOf('-->', index + 4)
+
+      index = commentEnd === -1 ? value.length : commentEnd + 3
+    } else if (value[index] === '<') {
+      const tagEnd = value.indexOf('>', index + 1)
+
+      index = tagEnd === -1 ? index + 1 : tagEnd + 1
+    } else if (value[index] === '>') {
+      index += 1
+    } else {
+      plainText += value[index]
+      index += 1
+    }
+  }
+
+  return plainText
+}
+
 export function cleanReleaseNotes(markdown) {
   let notes = markdown.replaceAll('\r\n', '\n')
 
-  notes = notes.replaceAll(/<!--[^]*?-->/g, '')
   notes = notes.replaceAll(/<(?:picture|svg|video)\b[^]*?<\/(?:picture|svg|video)>/gi, '')
   notes = notes.replaceAll(/<a\b[^>]*>\s*<img\b[^>]*>\s*<\/a>/gi, '')
   notes = notes.replaceAll(/<img\b[^>]*\/?\s*>/gi, '')
@@ -89,7 +111,7 @@ export function cleanReleaseNotes(markdown) {
 
   notes = lines.join('\n')
   notes = notes.replaceAll(/<br\s*\/?>/gi, '\n')
-  notes = notes.replaceAll(/<[^>]+>/g, '')
+  notes = stripHtmlMarkup(notes)
   notes = decodeHtml(notes)
   notes = notes.replaceAll(/^#{1,6}\s+/gm, '')
   notes = notes.replaceAll(/\[([^\]]+)\]\([^)]*\)/g, '$1')

--- a/tests/unit/winget-manifest.test.mjs
+++ b/tests/unit/winget-manifest.test.mjs
@@ -110,6 +110,13 @@ test('release note cleanup preserves comparison operators', () => {
   )
 })
 
+test('release note cleanup removes escaped HTML markup', () => {
+  assert.equal(
+    cleanReleaseNotes('## Highlights\n\n- Use &lt;kbd&gt;Ctrl&lt;/kbd&gt; and reject &lt;script&gt;alert(1)&lt;/script&gt;.'),
+    'Highlights\n\n- Use Ctrl and reject alert(1).'
+  )
+})
+
 test('release note cleanup removes reference-style linked badges', () => {
   assert.equal(
     cleanReleaseNotes(`## Fixed bugs

--- a/tests/unit/winget-manifest.test.mjs
+++ b/tests/unit/winget-manifest.test.mjs
@@ -103,6 +103,27 @@ test('release note cleanup removes incomplete HTML markup', () => {
   )
 })
 
+test('release note cleanup preserves comparison operators', () => {
+  assert.equal(
+    cleanReleaseNotes('## Performance\n\n- Keep count < 10 and latency > 20 ms.'),
+    'Performance\n\n- Keep count < 10 and latency > 20 ms.'
+  )
+})
+
+test('release note cleanup removes reference-style linked badges', () => {
+  assert.equal(
+    cleanReleaseNotes(`## Fixed bugs
+
+[![Build badge][badge-image]][badge-link]
+
+- Fixed a bug.
+
+[badge-image]: https://example.com/build.svg
+[badge-link]: https://example.com/build`),
+    'Fixed bugs\n\n- Fixed a bug.'
+  )
+})
+
 test('manifest preparation applies release metadata and validates installers', (context) => {
   const directory = fs.mkdtempSync(path.join(os.tmpdir(), 'winget-manifest-test-'))
   context.after(() => fs.rmSync(directory, { recursive: true }))

--- a/tests/unit/winget-manifest.test.mjs
+++ b/tests/unit/winget-manifest.test.mjs
@@ -92,6 +92,17 @@ More improvements
 - Read the guide.`)
 })
 
+test('release note cleanup removes incomplete HTML markup', () => {
+  assert.equal(
+    cleanReleaseNotes('## Fixed bugs\n\n- Removed <script and an orphan > marker.'),
+    'Fixed bugs\n\n- Removed  marker.'
+  )
+  assert.equal(
+    cleanReleaseNotes('## Fixed bugs\n\n- Kept this.\n<!-- unfinished comment'),
+    'Fixed bugs\n\n- Kept this.'
+  )
+})
+
 test('manifest preparation applies release metadata and validates installers', (context) => {
   const directory = fs.mkdtempSync(path.join(os.tmpdir(), 'winget-manifest-test-'))
   context.after(() => fs.rmSync(directory, { recursive: true }))

--- a/tests/unit/winget-manifest.test.mjs
+++ b/tests/unit/winget-manifest.test.mjs
@@ -1,0 +1,158 @@
+import assert from 'node:assert/strict'
+import fs from 'node:fs'
+import os from 'node:os'
+import path from 'node:path'
+import test from 'node:test'
+
+import {
+  cleanReleaseNotes,
+  prepareManifest,
+} from '../../_scripts/prepareWingetManifest.mjs'
+
+const VERSION = '1.2.3'
+const PRODUCT_CODE = 'a38f022d-fec2-5f80-a7fe-620ccf1a2767'
+
+function asset (architecture, digestCharacter) {
+  const name = `opentubex-${VERSION}-beta-setup-${architecture}.exe`
+
+  return {
+    browser_download_url: `https://github.com/OpenTubeX/OpenTubeX/releases/download/v${VERSION}-beta/${name}`,
+    digest: `sha256:${digestCharacter.repeat(64)}`,
+    name,
+  }
+}
+
+function installerManifest () {
+  const installers = [
+    ['x64', 'user', '/CURRENTUSER', 'a'],
+    ['x64', 'machine', '/ALLUSERS', 'a'],
+    ['arm64', 'user', '/CURRENTUSER', 'b'],
+    ['arm64', 'machine', '/ALLUSERS', 'b'],
+  ].map(([architecture, scope, installerSwitch, digestCharacter]) => `- Architecture: ${architecture}
+  Scope: ${scope}
+  InstallerUrl: ${asset(architecture, digestCharacter).browser_download_url}
+  InstallerSha256: ${digestCharacter.repeat(64)}
+  InstallerSwitches:
+    Custom: ${installerSwitch}`).join('\n')
+
+  return `PackageIdentifier: OpenTubeX.OpenTubeX
+PackageVersion: ${VERSION}
+InstallerType: nullsoft
+Protocols:
+- opentubex
+ProductCode: ${PRODUCT_CODE}
+ReleaseDate: 2000-01-01
+AppsAndFeaturesEntries:
+- DisplayName: Old name
+  ProductCode: ${PRODUCT_CODE}
+Installers:
+${installers}
+ManifestType: installer
+ManifestVersion: 1.12.0
+`
+}
+
+function localeManifest () {
+  return `PackageIdentifier: OpenTubeX.OpenTubeX
+PackageVersion: ${VERSION}
+PackageLocale: en-US
+PackageName: OpenTubeX
+Tags:
+- old-tag
+ReleaseNotes: |-
+  Old notes
+ReleaseNotesUrl: https://example.com/old
+ManifestType: defaultLocale
+ManifestVersion: 1.12.0
+`
+}
+
+test('release note cleanup removes promotional and image content', () => {
+  const markdown = `> [!NOTE]
+> OpenTubeX is now on ProductHunt
+> <a href="https://example.com"><img alt="badge" src="badge.svg"></a>
+
+## Highlights
+
+- Use the <kbd>Ctrl</kbd> key. ![Screenshot](screenshot.png)
+  <img alt="image" src="image.webp">
+
+## More improvements
+
+- Read [the guide](https://example.com).
+  image
+`
+
+  assert.equal(cleanReleaseNotes(markdown), `Highlights
+
+- Use the Ctrl key.
+
+More improvements
+
+- Read the guide.`)
+})
+
+test('manifest preparation applies release metadata and validates installers', (context) => {
+  const directory = fs.mkdtempSync(path.join(os.tmpdir(), 'winget-manifest-test-'))
+  context.after(() => fs.rmSync(directory, { recursive: true }))
+
+  fs.writeFileSync(path.join(directory, 'OpenTubeX.OpenTubeX.installer.yaml'), installerManifest())
+  fs.writeFileSync(path.join(directory, 'OpenTubeX.OpenTubeX.locale.en-US.yaml'), localeManifest())
+  fs.writeFileSync(path.join(directory, 'OpenTubeX.OpenTubeX.yaml'), `PackageIdentifier: OpenTubeX.OpenTubeX
+PackageVersion: ${VERSION}
+ManifestType: version
+ManifestVersion: 1.12.0
+`)
+
+  const result = prepareManifest({
+    manifestDirectory: directory,
+    release: {
+      assets: [asset('x64', 'a'), asset('arm64', 'b')],
+      body: '## Fixed bugs\n\n- Fixed a bug.\n\n<img alt="image" src="bug.png">',
+      html_url: `https://github.com/OpenTubeX/OpenTubeX/releases/tag/v${VERSION}-beta`,
+      published_at: '2026-08-27T10:00:00Z',
+      tag_name: `v${VERSION}-beta`,
+    },
+    topics: {
+      names: ['youtube', 'privacy', 'electron'],
+    },
+  })
+
+  assert.deepEqual(result.tags, ['electron', 'privacy', 'youtube'])
+  assert.equal(result.releaseNotes, 'Fixed bugs\n\n- Fixed a bug.')
+
+  const installer = fs.readFileSync(path.join(directory, 'OpenTubeX.OpenTubeX.installer.yaml'), 'utf8')
+  const locale = fs.readFileSync(path.join(directory, 'OpenTubeX.OpenTubeX.locale.en-US.yaml'), 'utf8')
+
+  assert.match(installer, /^ReleaseDate: 2026-08-27$/m)
+  assert.match(installer, /^- DisplayName: OpenTubeX 1\.2\.3$/m)
+  assert.match(locale, /Tags:\n- electron\n- privacy\n- youtube/)
+  assert.match(locale, /ReleaseNotes: \|-\n {2}Fixed bugs\n\n {2}- Fixed a bug\./)
+  assert.match(locale, new RegExp(`ReleaseNotesUrl: https://github.com/OpenTubeX/OpenTubeX/releases/tag/v${VERSION}-beta`))
+})
+
+test('manifest preparation rejects missing installer scopes', (context) => {
+  const directory = fs.mkdtempSync(path.join(os.tmpdir(), 'winget-manifest-test-'))
+  context.after(() => fs.rmSync(directory, { recursive: true }))
+
+  fs.writeFileSync(
+    path.join(directory, 'OpenTubeX.OpenTubeX.installer.yaml'),
+    installerManifest().replace(/- Architecture: arm64\n {2}Scope: machine[^]*?(?=\nManifestType:)/, '')
+  )
+  fs.writeFileSync(path.join(directory, 'OpenTubeX.OpenTubeX.locale.en-US.yaml'), localeManifest())
+  fs.writeFileSync(path.join(directory, 'OpenTubeX.OpenTubeX.yaml'), `PackageIdentifier: OpenTubeX.OpenTubeX
+PackageVersion: ${VERSION}
+`)
+
+  assert.throws(() => prepareManifest({
+    manifestDirectory: directory,
+    release: {
+      assets: [asset('x64', 'a'), asset('arm64', 'b')],
+      body: '## Fixed bugs\n\n- Fixed a bug.',
+      html_url: `https://github.com/OpenTubeX/OpenTubeX/releases/tag/v${VERSION}-beta`,
+      published_at: '2026-08-27T10:00:00Z',
+      tag_name: `v${VERSION}-beta`,
+    },
+    topics: { names: ['privacy'] },
+  }), /Expected four installer entries/)
+})


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Make sure to follow the contributing guidelines. -->
<!-- Important note, we may remove your pull request if you do not use this provided PR template correctly. -->
<!-- Agent instructions: Preserve every heading, comment, and marker in this template. Never remove or rewrite the release-note-category:start/end, release-note:start/end, or release-note-image:start/end marker pairs. Never remove or rewrite the Release note images section; leave its contents for a human. -->

## Pull Request Type
<!-- Please select what type of pull request this is: [x] -->
- [ ] Bugfix
- [ ] Feature Implementation
- [ ] Documentation
- [x] Other

## Related issue
<!-- Please link the issue your pull request is referring to. -->
<!-- If this pull request fully resolves the relevant issue, put "closes" before the issue number. -->
<!-- Example: "closes #123456". -->

## Description
<!-- Please write a clear and concise description of what the pull request does. -->

Stable beta releases currently need a manual winget update, and previous submissions came from a personal fork. This adds release automation that generates and validates `OpenTubeX.OpenTubeX` manifests, then opens future updates from the OpenTubeX organization fork.

The workflow accepts only `vX.Y.Z-beta` releases with both Windows installers. It keeps user and machine scopes for x64 and ARM64, reads the latest accepted manifest through Komac, cleans release notes, uses current repository topics, and skips versions that winget or an open pull request already covers. Manual dispatches can retry a tag without creating duplicate branches or pull requests.

## Release note category
<!-- Select exactly one category. Every pull request must select one. -->
<!-- Select "Not noteworthy" when the pull request fixes a bug in or improves functionality that has not yet appeared in a stable release. -->
<!-- release-note-category:start -->
- [x] Not noteworthy
- [ ] Highlights
- [ ] More improvements
- [ ] Fixed bugs
<!-- release-note-category:end -->

## Release note
<!-- Required unless "Not noteworthy" is selected. -->
<!-- Write one concise, user-facing entry without a leading bullet. -->
<!-- release-note:start -->

<!-- release-note:end -->

## Release note images
<!-- Human-only: Agents must preserve this entire section and leave it empty. -->
<!-- Optional. Paste one or more Markdown images or HTML image tags here. -->
<!-- The release notes will use an HTML image tag and limit images taller than 300 pixels. -->
<!-- release-note-image:start -->

<!-- release-note-image:end -->

## Testing
<!-- How can reviewers verify that the PR produces correct results? -->
<!-- Please provide instructions so that others can ensure that your pull request would produce correct results. For examples see, https://github.com/FreeTubeApp/FreeTube/pull/5743, https://github.com/FreeTubeApp/FreeTube/pull/7349, https://github.com/FreeTubeApp/FreeTube/pull/5125, https://github.com/FreeTubeApp/FreeTube/pull/7338 -->
<!-- Agent instructions: Only write human-facing steps that explain how to verify the change while running this branch in dev mode. Include expected results and, when applicable, helpful console snippets for interactive verification. Do not include automated checks, commands, results, pass counts, or CI status. -->

Not applicable. This changes GitHub release automation and has no dev-mode UI or runtime behavior.

## Additional context
<!-- Add any other context about the pull request here. -->

`OpenTubeX/winget-pkgs` now exists and tracks `microsoft/winget-pkgs`. The existing 0.32.1 update from D3SOX remains untouched; duplicate detection makes this automation apply to future versions.
