### PR TITLE
chore(release): make agent media previews reliable

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -39,10 +39,15 @@
 <!-- The release notes normalize the markup and limit images taller than 300 pixels. -->
 <!-- Agent instructions:
 For a noteworthy visible change, add media when it makes the change easier to understand. Prefer a still image unless motion is the point; recordings must use animated WebP.
+After implementing a visible change, proactively capture the result and show the local media to the user for approval before uploading it or updating the pull request.
 Capture the default dark theme. When both app themes can be captured and differ, run `node _scripts/releaseNoteMedia.mjs --dark DARK_FILE --light LIGHT_FILE --alt "DESCRIPTION"`. GitHub will display the matching theme and use dark as the fallback.
 Capture or crop to the smallest region that still makes the change clear. Do not include the full window when the affected component can be understood on its own.
+Use English unless localization is the subject. Keep components at their normal dimensions and placement instead of resizing them to fill the frame.
+Use deterministic local fixtures for visible remote images. Reusable avatar and thumbnail fixtures are available through `e2e/helpers/visual-fixtures.mjs`. Before capturing, verify that every visible image has loaded successfully (`complete === true` and `naturalWidth > 0`).
+Inspect the final dark and light files for failed images, missing content, unrelated UI, awkward animation, and misleading layout. Omit media when it does not explain the change clearly.
 For one dark capture, run `node _scripts/releaseNoteMedia.mjs FILE --alt "DESCRIPTION"`.
 Check for personal information, tokens, private repository names, and unrelated desktop content before uploading. Uploaded media is public.
+Keep capture-only scripts, test hooks, screenshots, and recordings out of commits. Remove them before committing unless the capture code is also a reusable regression test. Never commit generated release-note media.
 Paste only the generated markup between the marker comments. Leave this section empty when media would not help.
 -->
 <!-- release-note-image:start -->

--- a/e2e/fixtures/media/avatar.svg
+++ b/e2e/fixtures/media/avatar.svg
@@ -1,0 +1,10 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="48" height="48" viewBox="0 0 48 48">
+  <defs>
+    <linearGradient id="avatar-gradient" x2="1" y2="1">
+      <stop stop-color="#2563eb" />
+      <stop offset="1" stop-color="#7c3aed" />
+    </linearGradient>
+  </defs>
+  <circle cx="24" cy="24" r="24" fill="url(#avatar-gradient)" />
+  <text x="24" y="29" fill="#fff" font-family="sans-serif" font-size="14" font-weight="700" text-anchor="middle">OT</text>
+</svg>

--- a/e2e/fixtures/media/video-thumbnail.svg
+++ b/e2e/fixtures/media/video-thumbnail.svg
@@ -1,0 +1,12 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="320" height="180" viewBox="0 0 320 180">
+  <defs>
+    <linearGradient id="thumbnail-gradient" x2="1" y2="1">
+      <stop stop-color="#2563eb" />
+      <stop offset="1" stop-color="#7c3aed" />
+    </linearGradient>
+  </defs>
+  <rect width="320" height="180" rx="12" fill="url(#thumbnail-gradient)" />
+  <circle cx="160" cy="82" r="32" fill="#000" fill-opacity=".45" />
+  <path d="m153 65 24 17-24 17z" fill="#fff" />
+  <text x="20" y="154" fill="#fff" font-family="sans-serif" font-size="18" font-weight="700">OpenTubeX E2E</text>
+</svg>

--- a/e2e/helpers/visual-fixtures.mjs
+++ b/e2e/helpers/visual-fixtures.mjs
@@ -1,0 +1,33 @@
+import { readFile } from 'node:fs/promises'
+
+import { expect } from '@playwright/test'
+
+const fixtures = new Map([
+  ['avatar', new URL('../fixtures/media/avatar.svg', import.meta.url)],
+  ['video-thumbnail', new URL('../fixtures/media/video-thumbnail.svg', import.meta.url)]
+])
+
+/**
+ * Serves a local SVG for a routed image request.
+ * @param {import('@playwright/test').Route} route
+ * @param {'avatar' | 'video-thumbnail'} name
+ */
+export async function fulfillVisualFixture(route, name) {
+  const fixture = fixtures.get(name)
+  if (!fixture) throw new Error(`Unknown visual fixture: ${name}`)
+
+  await route.fulfill({
+    body: await readFile(fixture),
+    contentType: 'image/svg+xml'
+  })
+}
+
+/**
+ * Waits until at least one matched image has loaded successfully.
+ * @param {import('@playwright/test').Locator} locator
+ */
+export async function expectImagesLoaded(locator) {
+  await expect.poll(() => locator.evaluateAll(images => (
+    images.length > 0 && images.every(image => image.complete && image.naturalWidth > 0)
+  ))).toBe(true)
+}

--- a/e2e/tests/offline/video-result-avatars.spec.mjs
+++ b/e2e/tests/offline/video-result-avatars.spec.mjs
@@ -1,4 +1,5 @@
 import { test, expect, goTo, goToSettingsSection, sel } from '../../helpers/app.mjs'
+import { expectImagesLoaded, fulfillVisualFixture } from '../../helpers/visual-fixtures.mjs'
 
 const CHANNEL_ID = 'UCaaaaaaaaaaaaaaaaaaaaaa'
 const AVATAR = 'data:image/svg+xml,<svg xmlns="http://www.w3.org/2000/svg" width="24" height="24"><rect width="24" height="24" fill="red"/></svg>'
@@ -85,10 +86,9 @@ test.describe('Invidious search video avatars', () => {
         }
       })
     })
-    await page.route(avatarUrl, route => route.fulfill({
-      body: '<svg xmlns="http://www.w3.org/2000/svg" width="24" height="24"><rect width="24" height="24" fill="red"/></svg>',
-      contentType: 'image/svg+xml'
-    }))
+    await page.route(avatarUrl, route => fulfillVisualFixture(route, 'avatar'))
+    await page.route(`${instanceUrl}/vi/**`, route => fulfillVisualFixture(route, 'video-thumbnail'))
+    await page.route('https://i.ytimg.com/**', route => fulfillVisualFixture(route, 'video-thumbnail'))
 
     await page.locator(sel.searchInput).fill('avatar results')
     await page.locator(sel.searchInput).press('Enter')
@@ -97,8 +97,9 @@ test.describe('Invidious search video avatars', () => {
     await expect(avatars).toHaveCount(3)
     await expect(avatars.first()).toHaveAttribute('src', avatarUrl)
     await expect.poll(() => avatars.evaluateAll(images => {
-      return images.every(image => image.complete && image.naturalWidth === 24)
+      return images.every(image => image.complete && image.naturalWidth === 48)
     })).toBe(true)
+    await expectImagesLoaded(page.locator('.ft-list-video .thumbnailImage'))
     await expect(page.locator('.ft-list-video').filter({
       has: page.getByRole('heading', { name: 'Avatar search playlist' })
     }).locator('.channelAvatarImage')).toHaveAttribute('src', avatarUrl)


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Make sure to follow the contributing guidelines. -->
<!-- Important note, we may remove your pull request if you do not use this provided PR template correctly. -->
<!-- Agent instructions: Preserve every heading, comment, and marker in this template. Never remove or rewrite the release-note-category:start/end, release-note:start/end, or release-note-image:start/end marker pairs. -->

## Pull Request Type
<!-- Please select what type of pull request this is: [x] -->
- [ ] Bugfix
- [ ] Feature Implementation
- [ ] Documentation
- [x] Other

## Related issue
<!-- Please link the issue your pull request is referring to. -->
<!-- If this pull request fully resolves the relevant issue, put "closes" before the issue number. -->
<!-- Example: "closes #123456". -->

## Description
<!-- Please write a clear and concise description of what the pull request does. -->
Agents can produce release-note previews with missing remote images, the wrong locale, distorted component dimensions, or temporary capture code left in a commit.

Add reusable local avatar and thumbnail fixtures with a helper that serves them and verifies that visible images loaded. Expand the pull request template so agents show local previews for approval, keep the normal UI layout, inspect both themes, and remove capture-only files before committing.

## Release note category
<!-- Select exactly one category. Every pull request must select one. -->
<!-- Select "Not noteworthy" when the pull request fixes a bug in or improves functionality that has not yet appeared in a stable release. -->
<!-- release-note-category:start -->
- [x] Not noteworthy
- [ ] Highlights
- [ ] More improvements
- [ ] Fixed bugs
<!-- release-note-category:end -->

## Release note
<!-- Required unless "Not noteworthy" is selected. -->
<!-- Write one concise, user-facing entry without a leading bullet. -->
<!-- release-note:start -->

<!-- release-note:end -->

## Release note images
<!-- Optional. Paste one or more Markdown images, HTML image tags, or dark/light <picture> elements here. -->
<!-- The release notes normalize the markup and limit images taller than 300 pixels. -->
<!-- Agent instructions:
For a noteworthy visible change, add media when it makes the change easier to understand. Prefer a still image unless motion is the point; recordings must use animated WebP.
After implementing a visible change, proactively capture the result and show the local media to the user for approval before uploading it or updating the pull request.
Capture the default dark theme. When both app themes can be captured and differ, run `node _scripts/releaseNoteMedia.mjs --dark DARK_FILE --light LIGHT_FILE --alt "DESCRIPTION"`. GitHub will display the matching theme and use dark as the fallback.
Capture or crop to the smallest region that still makes the change clear. Do not include the full window when the affected component can be understood on its own.
Use English unless localization is the subject. Keep components at their normal dimensions and placement instead of resizing them to fill the frame.
Use deterministic local fixtures for visible remote images. Reusable avatar and thumbnail fixtures are available through `e2e/helpers/visual-fixtures.mjs`. Before capturing, verify that every visible image has loaded successfully (`complete === true` and `naturalWidth > 0`).
Inspect the final dark and light files for failed images, missing content, unrelated UI, awkward animation, and misleading layout. Omit media when it does not explain the change clearly.
For one dark capture, run `node _scripts/releaseNoteMedia.mjs FILE --alt "DESCRIPTION"`.
Check for personal information, tokens, private repository names, and unrelated desktop content before uploading. Uploaded media is public.
Keep capture-only scripts, test hooks, screenshots, and recordings out of commits. Remove them before committing unless the capture code is also a reusable regression test. Never commit generated release-note media.
Paste only the generated markup between the marker comments. Leave this section empty when media would not help.
-->
<!-- release-note-image:start -->

<!-- release-note-image:end -->

## Testing
<!-- How can reviewers verify that the PR produces correct results? -->
<!-- Please provide instructions so that others can ensure that your pull request would produce correct results. For examples see, https://github.com/FreeTubeApp/FreeTube/pull/5743, https://github.com/FreeTubeApp/FreeTube/pull/7349, https://github.com/FreeTubeApp/FreeTube/pull/5125, https://github.com/FreeTubeApp/FreeTube/pull/7338 -->
<!-- Agent instructions: Only write human-facing steps that explain how to verify the change while running this branch in dev mode. Include expected results and, when applicable, helpful console snippets for interactive verification. Do not include automated checks, commands, results, pass counts, or CI status. -->
- Open the pull request template and confirm the media section tells agents to show previews before upload and remove capture-only files before committing.
- Use the visual fixture helper in an offline browser test and confirm the local avatar and thumbnail render without failed-image placeholders.

## Additional context
<!-- Add any other context about the pull request here. -->
The fixtures are opt-in so tests that cover real image loading can continue using their own routes.
