### PR TITLE
fix: preserve comment pins and restore German error text

### DIFF
--- a/e2e/tests/offline/watch-page.spec.mjs
+++ b/e2e/tests/offline/watch-page.spec.mjs
@@ -3782,9 +3782,14 @@ test.describe('manual comment loading', () => {
     await mockPlayableWatchPage(app, page)
     await openMockedVideo(page)
 
+    const initialCommentsResponsePromise = page.waitForResponse(response => {
+      if (!/\/youtubei\/v1\/next/.test(response.url())) return false
+      return Boolean(JSON.parse(response.request().postData() ?? '{}').continuation)
+    }, { timeout: 30_000 })
     const loadComments = page.locator('.getCommentsTitle')
     await loadComments.scrollIntoViewIfNeeded()
     await loadComments.click()
+    const initialCommentsResponse = await initialCommentsResponsePromise
     await expect(page.locator('.commentsTitle')).toBeVisible({ timeout: 30_000 })
 
     const pinnedComment = page.locator('.commentThread').filter({ hasText: 'Who is here today?' })
@@ -3795,10 +3800,35 @@ test.describe('manual comment loading', () => {
     await expect(pinnedComment.locator('.commentPersonalPin')).not.toHaveCSS('background-color', 'rgba(0, 0, 0, 0)')
     await expect(page.locator('.commentThread').first()).toContainText('Who is here today?')
 
+    const commentsWithoutPinned = await initialCommentsResponse.json()
+    const mutations = commentsWithoutPinned.frameworkUpdates.entityBatchUpdate.mutations
+    const pinnedMutation = mutations.find(mutation => {
+      return mutation.payload?.commentEntityPayload?.properties?.content?.content === 'Who is here today?'
+    })
+    const pinnedCommentId = pinnedMutation.payload.commentEntityPayload.properties.commentId
+    commentsWithoutPinned.frameworkUpdates.entityBatchUpdate.mutations = mutations.filter(mutation => {
+      return mutation.payload?.commentEntityPayload?.properties?.commentId !== pinnedCommentId
+    })
+    for (const endpoint of commentsWithoutPinned.onResponseReceivedEndpoints) {
+      const command = endpoint.reloadContinuationItemsCommand ?? endpoint.appendContinuationItemsAction
+      if (!Array.isArray(command?.continuationItems)) continue
+
+      command.continuationItems = command.continuationItems.filter(item => {
+        return item.commentThreadRenderer?.commentViewModel?.commentViewModel?.commentId !== pinnedCommentId
+      })
+    }
+    expect(JSON.stringify(commentsWithoutPinned)).not.toContain('Who is here today?')
+
+    await page.route(/\/youtubei\/v1\/next/, route => route.fulfill({
+      status: 200,
+      contentType: 'application/json',
+      body: JSON.stringify(commentsWithoutPinned)
+    }), { times: 1 })
     const reloadResponse = page.waitForResponse(/\/youtubei\/v1\/next/, { timeout: 30_000 })
     await page.getByRole('button', { name: 'Reload Comments' }).click()
     await reloadResponse
 
+    await expect(pinnedComment).toHaveCount(1)
     await expect(page.locator('.commentThread').first()).toContainText('Who is here today?')
     await expect(page.locator('.commentThread').first()).toContainText('Pinned by you')
   })

--- a/e2e/tests/offline/watch-page.spec.mjs
+++ b/e2e/tests/offline/watch-page.spec.mjs
@@ -3939,8 +3939,111 @@ test.describe('manual comment loading', () => {
           ...WATCH_PAGE_SEED,
           generalAutoLoadMorePaginatedItemsEnabled: false,
           uiScale: 125
-        }
+        },
+        profiles: [{
+          _id: 'allChannels',
+          name: 'All Channels',
+          bgColor: '#d50000',
+          textColor: '#FFFFFF',
+          subscriptions: []
+        }, {
+          _id: 'commentPinsProfile',
+          name: 'Comment pins profile',
+          bgColor: '#558B2F',
+          textColor: '#FFFFFF',
+          subscriptions: []
+        }]
       }
+    })
+
+    test('clamps fullscreen comment scrolling after switching pin storage groups', async ({ app, page }) => {
+      await mockPlayableWatchPage(app, page)
+      await openMockedVideo(page)
+
+      const loadComments = page.locator('.getCommentsTitle')
+      await loadComments.scrollIntoViewIfNeeded()
+      await loadComments.click()
+      await expect(page.locator('.commentsTitle')).toBeVisible({ timeout: 30_000 })
+
+      const liveCommentCount = await page.locator('.commentThread').count()
+      const persistedCommentCount = 20
+      await page.evaluate(({ persistedCommentCount }) => {
+        const commentSnapshots = Array.from({ length: persistedCommentCount }, (_, index) => ({
+          id: `persisted-comment-${index}`,
+          author: `@PersistedAuthor${index}`,
+          authorId: `UC-persisted-${index}`,
+          authorLink: `UC-persisted-${index}`,
+          authorThumb: '',
+          dataType: 'local',
+          hasOwnerReplied: false,
+          hasReplyToken: false,
+          isEdited: false,
+          isHearted: false,
+          isMember: false,
+          isOwner: false,
+          isPinned: false,
+          likes: 0,
+          memberIconUrl: '',
+          numReplies: 0,
+          published: 0,
+          replies: [],
+          showReplies: false,
+          text: `Persisted pinned comment ${index}`,
+          time: 'now',
+          translationText: ''
+        }))
+        localStorage.setItem('opentubex-comment-pins', JSON.stringify({
+          'allChannels:video:jNQXAC9IVRw': {
+            commentIds: commentSnapshots.map(comment => comment.id),
+            commentSnapshots
+          }
+        }))
+      }, { persistedCommentCount })
+
+      await page.evaluate(() => {
+        const store = document.querySelector('#app').__vue_app__.config.globalProperties.$store
+        return store.dispatch('updateActiveProfile', 'commentPinsProfile')
+      })
+      await expect.poll(() => page.evaluate(() => {
+        const store = document.querySelector('#app').__vue_app__.config.globalProperties.$store
+        return store.getters.getActiveProfile._id
+      })).toBe('commentPinsProfile')
+      await page.evaluate(() => {
+        const store = document.querySelector('#app').__vue_app__.config.globalProperties.$store
+        return store.dispatch('updateActiveProfile', 'allChannels')
+      })
+      await expect(page.locator('.commentThread')).toHaveCount(liveCommentCount + persistedCommentCount)
+
+      await setPlayerFullscreen(page, true)
+      await page.locator('.fullscreenCommentsToggle').click({ force: true })
+
+      const dock = page.locator('.fullscreenCommentsOverlay.open')
+      const scroller = dock.locator('.commentsContentWrapper')
+      const scrollbar = scroller.locator(':scope > .os-scrollbar-vertical')
+      const commentsList = dock.locator('.commentThread').first().locator('..')
+      await expect.poll(() => scroller.evaluate(element => element.scrollHeight > element.clientHeight)).toBe(true)
+      await scroller.evaluate(element => { element.scrollTop = element.scrollHeight })
+      const previousContentHeight = await commentsList.evaluate(element => element.offsetHeight)
+
+      await page.evaluate(() => {
+        const store = document.querySelector('#app').__vue_app__.config.globalProperties.$store
+        return store.dispatch('updateActiveProfile', 'commentPinsProfile')
+      })
+      await expect(dock.locator('.commentThread')).toHaveCount(liveCommentCount)
+      await expect.poll(() => commentsList.evaluate(element => element.offsetHeight))
+        .toBeLessThan(previousContentHeight)
+      await expect.poll(() => scroller.evaluate(element => {
+        const contentElement = element.querySelector('.commentThread')?.parentElement
+        if (!contentElement) return false
+
+        const viewportBounds = element.getBoundingClientRect()
+        const contentBounds = contentElement.getBoundingClientRect()
+        const contentMarginBlockEnd = Number.parseFloat(getComputedStyle(contentElement).marginBlockEnd) || 0
+        const viewportPaddingBottom = Number.parseFloat(getComputedStyle(element).paddingBottom) || 0
+        const renderedEndGap = viewportBounds.bottom - contentBounds.bottom
+        return Math.abs(renderedEndGap - contentMarginBlockEnd - viewportPaddingBottom) <= 1
+      })).toBe(true)
+      await expect(scrollbar).not.toHaveClass(/os-scrollbar-unusable/)
     })
 
     test('clamps fullscreen comment scrolling after filtering', async ({ app, page }) => {

--- a/src/renderer/components/CommentSection/CommentSection.vue
+++ b/src/renderer/components/CommentSection/CommentSection.vue
@@ -82,7 +82,7 @@
       </div>
     </header>
     <div
-      v-if="!fullscreenOverlay && showComments && !isLoading && commentData.length > 0"
+      v-if="!fullscreenOverlay && showComments && !isLoading && commentEntries.length > 0"
       class="commentHeader"
     >
       <h3 class="commentsTitle">
@@ -178,7 +178,7 @@
         {{ $t("Comments.Click to View Comments") }}
       </h4>
       <h4
-        v-if="commentData.length > 0 && !isLoading && !showComments"
+        v-if="commentEntries.length > 0 && !isLoading && !showComments"
         class="getCommentsTitle"
         role="button"
         tabindex="0"
@@ -189,12 +189,12 @@
         {{ $t("Comments.Click to View Comments") }}
       </h4>
       <div
-        v-if="commentData.length > 0 && showComments"
+        v-if="commentEntries.length > 0 && showComments"
         ref="commentsList"
       >
         <div
           v-for="({ comment, index, replyNodes }) in visibleCommentEntries"
-          :id="'comment' + index"
+          :id="index === null ? `comment-pinned-${comment.id}` : 'comment' + index"
           :key="comment.id"
           class="comment commentThread"
           :class="{
@@ -302,7 +302,7 @@
               :title="personalPinActionLabel(comment)"
               :aria-label="personalPinActionLabel(comment)"
               :aria-pressed="isCommentPersonallyPinned(comment.id)"
-              @click="togglePersonalCommentPin(comment.id)"
+              @click="togglePersonalCommentPin(comment.id, comment)"
             >
               <FtIcon
                 :icon="['fas', isCommentPersonallyPinned(comment.id) ? 'thumbtack-slash' : 'thumbtack']"
@@ -369,7 +369,7 @@
             </span>
           </p>
           <div
-            v-if="!hasActiveCommentFilters && comment.numReplies > 0 && !comment.showReplies"
+            v-if="index !== null && !hasActiveCommentFilters && comment.numReplies > 0 && !comment.showReplies"
             class="commentReplyContinuation commentReplyRootToggle"
           >
             <button
@@ -417,7 +417,7 @@
               v-for="node in replyNodes"
               :key="node.reply.id"
               :node="node"
-              :thread-index="index"
+              :thread-index="index ?? -1"
               root-level
               :enable-channel-links="enableChannelLinks"
               :hide-comment-likes="hideCommentLikes"
@@ -437,13 +437,13 @@
               :shorten-view-counts="shortenViewCounts"
               @copy-youtube-link="copyCommentYoutubeLink"
               @get-more-replies="getCommentReplies(index, $event)"
-              @toggle-personal-pin="togglePersonalCommentPin($event, comment.id)"
+              @toggle-personal-pin="togglePersonalCommentPin($event, comment)"
               @timestamp-event="onTimestamp"
               @translate-comment="toggleCommentTranslation"
               @translation-unavailable="restoreCommentTranslation"
             />
             <div
-              v-if="!hasActiveCommentFilters && (isReplyLoading(comment.id) || comment.hasReplyToken)"
+              v-if="index !== null && !hasActiveCommentFilters && (isReplyLoading(comment.id) || comment.hasReplyToken)"
               class="commentReplyContinuation"
             >
               <button
@@ -469,7 +469,7 @@
               </button>
             </div>
             <div
-              v-if="!hasActiveCommentFilters && comment.numReplies > 0"
+              v-if="index !== null && !hasActiveCommentFilters && comment.numReplies > 0"
               class="commentReplyContinuation"
             >
               <button
@@ -608,10 +608,12 @@ import {
 import { clampOverlayScrollTop, restoreOverlayScrollTop } from '../../helpers/overlayScrollbars'
 import { getYoutubeCommunityPostCommentUrl, getYoutubeVideoCommentUrl } from '../../helpers/share'
 import {
+  createCommentPinSnapshot,
   getCommentPinStorageKey,
   getCommentReplyPinMarker,
   hasPinnedCommentReply,
   loadCommentPins,
+  mergePinnedCommentSnapshots,
   saveCommentPins
 } from '../../helpers/commentPins'
 import {
@@ -710,7 +712,9 @@ const activeProfileId = computed(() => store.getters.getActiveProfile._id)
 const commentPinStorageKey = computed(() => {
   return getCommentPinStorageKey(activeProfileId.value, props.id, props.isPostComments)
 })
-const personalPinnedCommentIds = ref(loadCommentPins(commentPinStorageKey.value))
+const initialCommentPinState = loadCommentPins(commentPinStorageKey.value)
+const personalPinnedCommentIds = ref(initialCommentPinState.commentIds)
+const personalPinnedCommentSnapshots = ref(initialCommentPinState.commentSnapshots)
 let fullscreenScrollTop = 0
 let highlightedTargetGeneration = 0
 const MAX_HIGHLIGHTED_REPLY_PAGES = 20
@@ -816,9 +820,13 @@ function commentTreeHasPersonalPin(comment) {
     comment.replies.some(commentTreeHasPersonalPin)
 }
 
+const commentEntries = computed(() => {
+  return mergePinnedCommentSnapshots(commentData.value, personalPinnedCommentSnapshots.value)
+})
+
 const visibleCommentEntries = computed(() => {
-  return commentData.value
-    .map((comment, index) => ({
+  return commentEntries.value
+    .map(({ comment, index }) => ({
       comment,
       index,
       replyNodes: getVisibleReplyNodes(comment)
@@ -843,7 +851,7 @@ function countMatchingComments(comment) {
 }
 
 const loadedCommentCount = computed(() => {
-  return commentData.value.reduce((count, comment) => count + countLoadedComments(comment), 0)
+  return commentEntries.value.reduce((count, { comment }) => count + countLoadedComments(comment), 0)
 })
 
 const matchingCommentCount = computed(() => {
@@ -851,7 +859,7 @@ const matchingCommentCount = computed(() => {
     return loadedCommentCount.value
   }
 
-  return commentData.value.reduce((count, comment) => count + countMatchingComments(comment), 0)
+  return commentEntries.value.reduce((count, { comment }) => count + countMatchingComments(comment), 0)
 })
 
 function shouldShowCommentReplies(comment, replyNodes) {
@@ -889,7 +897,7 @@ function getCommentAuthorSearchSegments(author) {
 }
 
 const canUseCommentTools = computed(() => {
-  return commentData.value.length > 0 && showComments.value && !isLoading.value
+  return commentEntries.value.length > 0 && showComments.value && !isLoading.value
 })
 
 function clampCommentsScrollAfterRender() {
@@ -936,22 +944,30 @@ function personalPinActionLabel(comment) {
   return t('Comments.Pin comment by author', { author: comment.author })
 }
 
-function togglePersonalCommentPin(commentId, rootCommentId = null) {
+function togglePersonalCommentPin(commentId, rootComment) {
   const commentIds = new Set(personalPinnedCommentIds.value)
+  const isReply = commentId !== rootComment.id
   if (commentIds.has(commentId)) {
     commentIds.delete(commentId)
-    if (rootCommentId !== null) {
-      commentIds.delete(getCommentReplyPinMarker(rootCommentId, commentId))
+    if (isReply) {
+      commentIds.delete(getCommentReplyPinMarker(rootComment.id, commentId))
     }
   } else {
     commentIds.add(commentId)
-    if (rootCommentId !== null) {
-      commentIds.add(getCommentReplyPinMarker(rootCommentId, commentId))
+    if (isReply) {
+      commentIds.add(getCommentReplyPinMarker(rootComment.id, commentId))
     }
   }
 
+  const commentSnapshots = personalPinnedCommentSnapshots.value
+    .filter(comment => comment.id !== rootComment.id)
+  if (commentIds.has(rootComment.id) || hasPinnedCommentReply(commentIds, rootComment.id)) {
+    commentSnapshots.push(createCommentPinSnapshot(rootComment))
+  }
+
   personalPinnedCommentIds.value = commentIds
-  saveCommentPins(commentPinStorageKey.value, commentIds)
+  personalPinnedCommentSnapshots.value = commentSnapshots
+  saveCommentPins(commentPinStorageKey.value, { commentIds, commentSnapshots })
   clampCommentsScrollAfterRender()
 }
 
@@ -978,7 +994,9 @@ function closeCommentMenus() {
 }
 
 watch(commentPinStorageKey, (contentKey) => {
-  personalPinnedCommentIds.value = loadCommentPins(contentKey)
+  const pinState = loadCommentPins(contentKey)
+  personalPinnedCommentIds.value = pinState.commentIds
+  personalPinnedCommentSnapshots.value = pinState.commentSnapshots
   commentFilterMenuOpen.value = false
   creatorCommentsOnly.value = false
   timestampCommentsOnly.value = false

--- a/src/renderer/components/CommentSection/CommentSection.vue
+++ b/src/renderer/components/CommentSection/CommentSection.vue
@@ -1002,6 +1002,7 @@ watch(commentPinStorageKey, (contentKey) => {
   timestampCommentsOnly.value = false
   commentSearchOpen.value = false
   commentSearchQuery.value = ''
+  clampCommentsScrollAfterRender()
 })
 
 function normalizeCommentAuthor(author) {

--- a/src/renderer/components/FtListPlaylist/FtListPlaylist.scss
+++ b/src/renderer/components/FtListPlaylist/FtListPlaylist.scss
@@ -4,19 +4,6 @@
   filter: blur(20px);
 }
 
-.channelName {
-  align-items: center;
-  display: inline-flex;
-  gap: 6px;
-  max-inline-size: 100%;
-  vertical-align: middle;
-}
-
-.channelNameText {
-  min-inline-size: 0;
-  overflow-wrap: anywhere;
-}
-
 .playlistButtonStack {
   align-items: flex-start;
   display: flex;

--- a/src/renderer/components/FtListVideo/FtListVideo.scss
+++ b/src/renderer/components/FtListVideo/FtListVideo.scss
@@ -4,19 +4,6 @@
   outline: 3px solid var(--side-nav-hover-color);
 }
 
-.channelName {
-  align-items: center;
-  display: inline-flex;
-  gap: 6px;
-  max-inline-size: 100%;
-  vertical-align: middle;
-}
-
-.channelNameText {
-  min-inline-size: 0;
-  overflow-wrap: anywhere;
-}
-
 .infoLine > .viewCount,
 .infoLine > .uploadedTime {
   vertical-align: middle;

--- a/src/renderer/helpers/commentPins.js
+++ b/src/renderer/helpers/commentPins.js
@@ -1,8 +1,92 @@
 const STORAGE_KEY = 'opentubex-comment-pins'
 const REPLY_PIN_MARKER_PREFIX = 'opentubex-reply-pin:'
 
+const COMMENT_STRING_FIELDS = [
+  'author',
+  'authorId',
+  'authorLink',
+  'authorThumb',
+  'dataType',
+  'memberIconUrl',
+  'text',
+  'time',
+  'translatedLanguage',
+  'translatedText',
+  'translationText'
+]
+const COMMENT_BOOLEAN_FIELDS = [
+  'hasOwnerReplied',
+  'isEdited',
+  'isHearted',
+  'isMember',
+  'isOwner',
+  'isPinned',
+  'showReplies',
+  'showTranslated'
+]
+const COMMENT_NUMBER_FIELDS = ['likes', 'numReplies', 'published']
+
 function getReplyPinMarkerPrefix(rootCommentId) {
   return `${REPLY_PIN_MARKER_PREFIX}${encodeURIComponent(rootCommentId)}:`
+}
+
+function sanitizeCommentSnapshot(comment) {
+  if (comment === null || typeof comment !== 'object' || Array.isArray(comment) ||
+    typeof comment.id !== 'string' || comment.id === '' ||
+    typeof comment.author !== 'string' || typeof comment.text !== 'string' ||
+    !Array.isArray(comment.replies)) {
+    return null
+  }
+
+  const snapshot = {
+    id: comment.id,
+    hasReplyToken: false,
+    replies: []
+  }
+
+  for (const field of COMMENT_STRING_FIELDS) {
+    if (typeof comment[field] === 'string') {
+      snapshot[field] = comment[field]
+    }
+  }
+
+  for (const field of COMMENT_BOOLEAN_FIELDS) {
+    if (typeof comment[field] === 'boolean') {
+      snapshot[field] = comment[field]
+    }
+  }
+
+  for (const field of COMMENT_NUMBER_FIELDS) {
+    if (typeof comment[field] === 'number' && Number.isFinite(comment[field])) {
+      snapshot[field] = comment[field]
+    }
+  }
+
+  snapshot.replies = comment.replies
+    .map(sanitizeCommentSnapshot)
+    .filter(Boolean)
+
+  return snapshot
+}
+
+function normalizePinState(pinState) {
+  if (pinState === null || typeof pinState !== 'object' || Array.isArray(pinState)) {
+    return { commentIds: [], commentSnapshots: [] }
+  }
+
+  const commentIds = Array.isArray(pinState.commentIds)
+    ? pinState.commentIds.filter(commentId => typeof commentId === 'string')
+    : []
+  const commentIdSet = new Set(commentIds)
+  const commentSnapshots = Array.isArray(pinState.commentSnapshots)
+    ? pinState.commentSnapshots
+        .map(sanitizeCommentSnapshot)
+        .filter(snapshot => snapshot !== null && (
+          commentIdSet.has(snapshot.id) || hasPinnedCommentReply(commentIdSet, snapshot.id)
+        ))
+    : []
+
+  return { commentIds, commentSnapshots }
 }
 
 function readStoredPins(storage) {
@@ -12,13 +96,17 @@ function readStoredPins(storage) {
       return {}
     }
 
-    return Object.fromEntries(Object.entries(stored).map(([contentKey, commentIds]) => [
+    return Object.fromEntries(Object.entries(stored).map(([contentKey, pinState]) => [
       contentKey,
-      Array.isArray(commentIds) ? commentIds.filter(commentId => typeof commentId === 'string') : []
+      normalizePinState(pinState)
     ]))
   } catch {
     return {}
   }
+}
+
+export function createCommentPinSnapshot(comment) {
+  return sanitizeCommentSnapshot(comment)
 }
 
 export function getCommentPinStorageKey(profileId, contentId, isPost = false) {
@@ -35,16 +123,37 @@ export function hasPinnedCommentReply(commentIds, rootCommentId) {
 }
 
 export function loadCommentPins(contentKey, storage = localStorage) {
-  return new Set(readStoredPins(storage)[contentKey] ?? [])
+  const pinState = readStoredPins(storage)[contentKey] ?? { commentIds: [], commentSnapshots: [] }
+  return {
+    commentIds: new Set(pinState.commentIds),
+    commentSnapshots: pinState.commentSnapshots
+  }
 }
 
-export function saveCommentPins(contentKey, commentIds, storage = localStorage) {
+export function mergePinnedCommentSnapshots(liveComments, commentSnapshots) {
+  const liveCommentIds = new Set(liveComments.map(comment => comment.id))
+  const persistedEntries = commentSnapshots
+    .filter(comment => !liveCommentIds.has(comment.id))
+    .map(comment => ({ comment, index: null, persisted: true }))
+  const liveEntries = liveComments.map((comment, index) => ({
+    comment,
+    index,
+    persisted: false
+  }))
+
+  return persistedEntries.concat(liveEntries)
+}
+
+export function saveCommentPins(contentKey, { commentIds, commentSnapshots }, storage = localStorage) {
   const stored = readStoredPins(storage)
 
   if (commentIds.size === 0) {
     delete stored[contentKey]
   } else {
-    stored[contentKey] = Array.from(commentIds)
+    stored[contentKey] = normalizePinState({
+      commentIds: Array.from(commentIds),
+      commentSnapshots
+    })
   }
 
   try {

--- a/src/renderer/scss-partials/_ft-list-item.scss
+++ b/src/renderer/scss-partials/_ft-list-item.scss
@@ -52,6 +52,19 @@ $watched-transition-duration: 0.5s;
   }
 }
 
+.channelName {
+  align-items: center;
+  display: inline-flex;
+  gap: 6px;
+  max-inline-size: 100%;
+  vertical-align: middle;
+}
+
+.channelNameText {
+  min-inline-size: 0;
+  overflow-wrap: anywhere;
+}
+
 .ft-list-item {
   padding: 6px;
 

--- a/static/locales/de-DE.yaml
+++ b/static/locales/de-DE.yaml
@@ -123,6 +123,8 @@ Trending:
   Trending Tabs: Trends-Tabs
   Gaming: Gaming
   Sports: Sport
+  Load Error: Trends konnten nicht geladen werden.
+  Unsupported Backend: Trends benötigen die lokale API. Wähle die lokale API aus oder aktiviere den Backend-Fallback.
 Most Popular: Am beliebtesten
 Playlists: Playlists
 User Playlists:
@@ -175,6 +177,9 @@ User Playlists:
       This playlist has a video with a duration error: Diese Playlist enthält mindestens ein Video ohne Dauer. Daher wird die Playlist so sortiert, als ob die Dauer null wäre.
       Video has been removed. Click here to undo.: Video wurde entfernt. Klicke hier, um das Entfernen rückgängig zu machen.
     Search for Videos: Nach Videos suchen
+    Retry: Erneut versuchen
+    This playlist could not be loaded.: Diese Playlist konnte nicht geladen werden.
+    More videos could not be loaded.: Weitere Videos konnten nicht geladen werden.
   AddVideoPrompt:
     N playlists selected: '{playlistCount} ausgewählt'
     Search in Playlists: In Playlists suchen

--- a/tests/unit/comment-pins.test.mjs
+++ b/tests/unit/comment-pins.test.mjs
@@ -2,10 +2,12 @@ import assert from 'node:assert/strict'
 import test from 'node:test'
 
 import {
+  createCommentPinSnapshot,
   getCommentPinStorageKey,
   getCommentReplyPinMarker,
   hasPinnedCommentReply,
   loadCommentPins,
+  mergePinnedCommentSnapshots,
   saveCommentPins
 } from '../../src/renderer/helpers/commentPins.js'
 
@@ -25,11 +27,78 @@ test('keeps personal comment pins separate by profile and video', () => {
   const secondVideo = getCommentPinStorageKey('profile-a', 'video-b')
   const secondProfile = getCommentPinStorageKey('profile-b', 'video-a')
 
-  saveCommentPins(firstVideo, new Set(['comment-a', 'comment-b']), storage)
+  saveCommentPins(firstVideo, {
+    commentIds: new Set(['comment-a', 'comment-b']),
+    commentSnapshots: []
+  }, storage)
 
-  assert.deepEqual(loadCommentPins(firstVideo, storage), new Set(['comment-a', 'comment-b']))
-  assert.deepEqual(loadCommentPins(secondVideo, storage), new Set())
-  assert.deepEqual(loadCommentPins(secondProfile, storage), new Set())
+  assert.deepEqual(loadCommentPins(firstVideo, storage), {
+    commentIds: new Set(['comment-a', 'comment-b']),
+    commentSnapshots: []
+  })
+  assert.deepEqual(loadCommentPins(secondVideo, storage), {
+    commentIds: new Set(),
+    commentSnapshots: []
+  })
+  assert.deepEqual(loadCommentPins(secondProfile, storage), {
+    commentIds: new Set(),
+    commentSnapshots: []
+  })
+})
+
+test('restores a pinned comment that is missing from the current response', () => {
+  const storage = createMemoryStorage()
+  const contentKey = getCommentPinStorageKey('profile-a', 'video-a')
+  const pinnedComment = {
+    id: 'pinned-comment',
+    author: 'Pinned author',
+    authorId: 'UCpinned',
+    authorLink: 'UCpinned',
+    authorThumb: 'https://example.com/pinned.jpg',
+    dataType: 'local',
+    hasOwnerReplied: false,
+    hasReplyToken: true,
+    isEdited: false,
+    isHearted: false,
+    isMember: false,
+    isOwner: false,
+    isPinned: false,
+    likes: 4,
+    memberIconUrl: '',
+    numReplies: 0,
+    published: 123,
+    replies: [],
+    showReplies: false,
+    text: 'Pinned text',
+    time: '1 day ago',
+    translationText: 'Pinned text'
+  }
+
+  saveCommentPins(contentKey, {
+    commentIds: new Set([pinnedComment.id]),
+    commentSnapshots: [createCommentPinSnapshot(pinnedComment)]
+  }, storage)
+
+  const restored = loadCommentPins(contentKey, storage)
+  const currentComment = { ...pinnedComment, id: 'current-comment', text: 'Current text' }
+  assert.deepEqual(restored.commentIds, new Set([pinnedComment.id]))
+  assert.equal(restored.commentSnapshots[0].hasReplyToken, false)
+  assert.deepEqual(
+    mergePinnedCommentSnapshots([currentComment], restored.commentSnapshots),
+    [
+      { comment: restored.commentSnapshots[0], index: null, persisted: true },
+      { comment: currentComment, index: 0, persisted: false }
+    ]
+  )
+
+  const livePinnedComment = { ...pinnedComment, text: 'Fresh pinned text' }
+  assert.deepEqual(
+    mergePinnedCommentSnapshots([currentComment, livePinnedComment], restored.commentSnapshots),
+    [
+      { comment: currentComment, index: 0, persisted: false },
+      { comment: livePinnedComment, index: 1, persisted: false }
+    ]
+  )
 })
 
 test('tracks pinned replies separately from their root comment', () => {
@@ -52,12 +121,26 @@ test('removes empty pin groups and ignores malformed storage', () => {
   const contentKey = getCommentPinStorageKey('profile-a', 'video-a')
   const storage = createMemoryStorage('{not-json')
 
-  assert.deepEqual(loadCommentPins(contentKey, storage), new Set())
+  assert.deepEqual(loadCommentPins(contentKey, storage), {
+    commentIds: new Set(),
+    commentSnapshots: []
+  })
 
-  saveCommentPins(contentKey, new Set(['comment-a']), storage)
-  saveCommentPins(contentKey, new Set(), storage)
+  saveCommentPins(contentKey, { commentIds: new Set(['comment-a']), commentSnapshots: [] }, storage)
+  saveCommentPins(contentKey, { commentIds: new Set(), commentSnapshots: [] }, storage)
 
   assert.equal(storage.getItem('opentubex-comment-pins'), null)
+
+  const malformedSnapshotStorage = createMemoryStorage(JSON.stringify({
+    [contentKey]: {
+      commentIds: ['comment-a'],
+      commentSnapshots: [{ id: 'comment-a' }]
+    }
+  }))
+  assert.deepEqual(loadCommentPins(contentKey, malformedSnapshotStorage), {
+    commentIds: new Set(['comment-a']),
+    commentSnapshots: []
+  })
 })
 
 test('keeps pinning usable when storage is unavailable', () => {
@@ -68,7 +151,16 @@ test('keeps pinning usable when storage is unavailable', () => {
     removeItem: () => { throw new Error('storage unavailable') }
   }
 
-  assert.deepEqual(loadCommentPins(contentKey, storage), new Set())
-  assert.doesNotThrow(() => saveCommentPins(contentKey, new Set(['comment-a']), storage))
-  assert.doesNotThrow(() => saveCommentPins(contentKey, new Set(), storage))
+  assert.deepEqual(loadCommentPins(contentKey, storage), {
+    commentIds: new Set(),
+    commentSnapshots: []
+  })
+  assert.doesNotThrow(() => saveCommentPins(contentKey, {
+    commentIds: new Set(['comment-a']),
+    commentSnapshots: []
+  }, storage))
+  assert.doesNotThrow(() => saveCommentPins(contentKey, {
+    commentIds: new Set(),
+    commentSnapshots: []
+  }, storage))
 })


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Make sure to follow the contributing guidelines. -->
<!-- Important note, we may remove your pull request if you do not use this provided PR template correctly. -->
<!-- Agent instructions: Preserve every heading, comment, and marker in this template. Never remove or rewrite the release-note-category:start/end, release-note:start/end, or release-note-image:start/end marker pairs. -->

## Pull Request Type
<!-- Please select what type of pull request this is: [x] -->
- [x] Bugfix
- [ ] Feature Implementation
- [ ] Documentation
- [ ] Other

## Related issue
<!-- Please link the issue your pull request is referring to. -->
<!-- If this pull request fully resolves the relevant issue, put "closes" before the issue number. -->
<!-- Example: "closes #123456". -->

None.

## Description
<!-- Please write a clear and concise description of what the pull request does. -->

Personal comment pins only stored comment IDs. A pinned thread disappeared after a reload when the API no longer returned it on the first page. The German locale also lacked five recent error messages, and the video and playlist list items duplicated their channel-name styles.

This stores a validated local snapshot for each pinned comment thread and restores it without an extra request. Fresh API data still wins when the same thread returns. It also adds the missing German strings and moves the shared channel-name styles into the existing list-item partial.

## Release note category
<!-- Select exactly one category. Every pull request must select one. -->
<!-- Select "Not noteworthy" when the pull request fixes a bug in or improves functionality that has not yet appeared in a stable release. -->
<!-- release-note-category:start -->
- [x] Not noteworthy
- [ ] Highlights
- [ ] More improvements
- [ ] Fixed bugs
<!-- release-note-category:end -->

## Release note
<!-- Required unless "Not noteworthy" is selected. -->
<!-- Write one concise, user-facing entry without a leading bullet. -->
<!-- release-note:start -->

<!-- release-note:end -->

## Release note images
<!-- Optional. Paste one or more Markdown images, HTML image tags, or dark/light <picture> elements here. -->
<!-- The release notes normalize the markup and limit images taller than 300 pixels. -->
<!-- Agent instructions:
For a noteworthy visible change, add media when it makes the change easier to understand. Prefer a still image unless motion is the point; recordings must use animated WebP.
After implementing a visible change, proactively capture the result and show the local media to the user for approval before uploading it or updating the pull request.
Capture the default dark theme. When both app themes can be captured and differ, run `node _scripts/releaseNoteMedia.mjs --dark DARK_FILE --light LIGHT_FILE --alt "DESCRIPTION"`. GitHub will display the matching theme and use dark as the fallback.
Capture or crop to the smallest region that still makes the change clear. Do not include the full window when the affected component can be understood on its own.
Use English unless localization is the subject. Keep components at their normal dimensions and placement instead of resizing them to fill the frame.
Use deterministic local fixtures for visible remote images. Reusable avatar and thumbnail fixtures are available through `e2e/helpers/visual-fixtures.mjs`. Before capturing, verify that every visible image has loaded successfully (`complete === true` and `naturalWidth > 0`).
Inspect the final dark and light files for failed images, missing content, unrelated UI, awkward animation, and misleading layout. Omit media when it does not explain the change clearly.
For one dark capture, run `node _scripts/releaseNoteMedia.mjs FILE --alt "DESCRIPTION"`.
Check for personal information, tokens, private repository names, and unrelated desktop content before uploading. Uploaded media is public.
Keep capture-only scripts, test hooks, screenshots, and recordings out of commits. Remove them before committing unless the capture code is also a reusable regression test. Never commit generated release-note media.
Paste only the generated markup between the marker comments. Leave this section empty when media would not help.
-->
<!-- release-note-image:start -->

<!-- release-note-image:end -->

## Testing
<!-- How can reviewers verify that the PR produces correct results? -->
<!-- Please provide instructions so that others can ensure that your pull request produces correct results. For examples see, https://github.com/FreeTubeApp/FreeTube/pull/5743, https://github.com/FreeTubeApp/FreeTube/pull/7349, https://github.com/FreeTubeApp/FreeTube/pull/5125, https://github.com/FreeTubeApp/FreeTube/pull/7338 -->
<!-- Agent instructions: Only write human-facing steps that explain how to verify the change while running this branch in dev mode. Include expected results and, when applicable, helpful console snippets for interactive verification. Do not include automated checks, commands, results, pass counts, or CI status. -->

1. Open a video with comments, load the comments, and pin a top comment.
2. Change the comment sort or reload after that comment has left the first response page. The stored comment should remain at the top with the "Pinned by you" label.
3. Load the same comment from the API again. It should appear once and use the fresh API data.
4. Switch the interface to German and open the recent Trending and playlist error states. Their messages and retry action should be translated.
5. Check video and playlist list items with a long channel name. The name should wrap without displacing the adjacent channel badge.

## Additional context
<!-- Add any other context about the pull request here. -->

Comment snapshots are plain validated data. Reply continuation tokens are never persisted, so restoring a pin does not trigger hidden pagination.
