### PR TITLE
ci: balance E2E shards automatically

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -27,6 +27,9 @@ jobs:
     if: ${{ github.event_name != 'pull_request' || github.head_ref != 'weblate-translations' }}
     runs-on: ubuntu-latest
 
+    outputs:
+      matrix: ${{ steps.shards.outputs.matrix }}
+
     permissions:
       contents: read
 
@@ -66,6 +69,54 @@ jobs:
     - run: pnpm run ci
       shell: bash
 
+    - name: Create E2E shard matrix
+      id: shards
+      env:
+        SELECTED_PROJECT: ${{ github.event_name == 'workflow_dispatch' && inputs.project || 'all' }}
+      run: |
+        # JavaScript template literals belong to Node.
+        # shellcheck disable=SC2016
+        pnpm exec playwright test -c e2e/playwright.config.mjs --list --reporter=json |
+          node --input-type=module -e '
+            let input = ""
+            for await (const chunk of process.stdin) input += chunk
+
+            const counts = {}
+            const visit = (value) => {
+              if (Array.isArray(value)) {
+                value.forEach(visit)
+              } else if (value && typeof value === "object") {
+                if (value.projectName) {
+                  counts[value.projectName] = (counts[value.projectName] ?? 0) + 1
+                } else {
+                  Object.values(value).forEach(visit)
+                }
+              }
+            }
+
+            visit(JSON.parse(input).suites)
+
+            const projects = process.env.SELECTED_PROJECT === "all"
+              ? ["offline", "network"]
+              : [process.env.SELECTED_PROJECT]
+            const testsPerShard = 200
+            const maxShards = 8
+            const include = projects.flatMap((project) => {
+              const testCount = counts[project]
+              if (!testCount) throw new Error(`No tests found for project ${project}`)
+
+              const shardTotal = Math.min(maxShards, Math.ceil(testCount / testsPerShard))
+              return Array.from({ length: shardTotal }, (_, index) => ({
+                project,
+                shard: index + 1,
+                shardTotal
+              }))
+            })
+
+            console.log(`matrix=${JSON.stringify({ include })}`)
+          ' >> "$GITHUB_OUTPUT"
+      shell: bash
+
     - name: Get Electron version
       id: electron
       run: printf 'version=%s\n' "$(node -p "require('./node_modules/electron/package.json').version")" >> "$GITHUB_OUTPUT"
@@ -96,14 +147,13 @@ jobs:
         retention-days: 1
 
   e2e-shard:
-    name: e2e (${{ matrix.shard }}/4)
+    name: e2e (${{ matrix.project }} ${{ matrix.shard }}/${{ matrix.shardTotal }})
     if: ${{ github.event_name != 'pull_request' || github.head_ref != 'weblate-translations' }}
     needs: prepare-e2e
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false
-      matrix:
-        shard: [ 1, 2, 3, 4 ]
+      matrix: ${{ fromJSON(needs.prepare-e2e.outputs.matrix) }}
     env:
       OPENTUBEX_SYNC_SERVER_URL: http://127.0.0.1:8080
 
@@ -167,18 +217,8 @@ jobs:
         name: dist-e2e
         path: dist-e2e
 
-    - name: Determine test project
-      id: project
-      shell: bash
-      run: |
-        if [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
-          echo "project=${{ inputs.project }}" >> "$GITHUB_OUTPUT"
-        else
-          echo "project=all" >> "$GITHUB_OUTPUT"
-        fi
-
     - name: Start sync server
-      if: ${{ steps.project.outputs.project != 'offline' }}
+      if: ${{ matrix.project == 'network' }}
       run: docker compose -f e2e/sync-server/compose.yml up -d --wait --pull always
       shell: bash
 
@@ -186,20 +226,16 @@ jobs:
     # attempt and automatically falls back to recorded fixtures on retry.
     - name: Run E2E tests
       run: |
-        test_args=("--shard=${{ matrix.shard }}/4")
+        test_args=("--shard=${{ matrix.shard }}/${{ matrix.shardTotal }}")
         if [ "${{ github.event_name }}" = "pull_request" ]; then
           test_args+=("--only-changed=origin/${GITHUB_BASE_REF}" "--pass-with-no-tests")
         fi
 
-        if [ "${{ steps.project.outputs.project }}" = "all" ]; then
-          xvfb-run --auto-servernum --server-args='-screen 0 1920x1080x24' pnpm run test:e2e "${test_args[@]}"
-        else
-          xvfb-run --auto-servernum --server-args='-screen 0 1920x1080x24' pnpm run test:e2e:${{ steps.project.outputs.project }} "${test_args[@]}"
-        fi
+        xvfb-run --auto-servernum --server-args='-screen 0 1920x1080x24' pnpm run test:e2e:${{ matrix.project }} "${test_args[@]}"
       shell: bash
 
     - name: Stop sync server
-      if: ${{ always() && steps.project.outputs.project != 'offline' }}
+      if: ${{ always() && matrix.project == 'network' }}
       run: docker compose -f e2e/sync-server/compose.yml down -v
       shell: bash
 
@@ -209,7 +245,7 @@ jobs:
       if: ${{ !cancelled() }}
       uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
       with:
-        name: playwright-report-${{ matrix.shard }}
+        name: playwright-report-${{ matrix.project }}-${{ matrix.shard }}
         path: |
           e2e/report/
           e2e/results/


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Make sure to follow the contributing guidelines. -->
<!-- Important note, we may remove your pull request if you do not use this provided PR template correctly. -->
<!-- Agent instructions: Preserve every heading, comment, and marker in this template. Never remove or rewrite the release-note-category:start/end, release-note:start/end, or release-note-image:start/end marker pairs. -->

## Pull Request Type
<!-- Please select what type of pull request this is: [x] -->
- [ ] Bugfix
- [ ] Feature Implementation
- [ ] Documentation
- [x] Other

## Related issue
<!-- Please link the issue your pull request is referring to. -->
<!-- If this pull request fully resolves the relevant issue, put "closes" before the issue number. -->
<!-- Example: "closes #123456". -->

## Description
<!-- Please write a clear and concise description of what the pull request does. -->
The fixed four-way E2E matrix puts every network test in the fourth shard, leaving it several minutes slower than the others and requiring manual shard-count updates as the suite grows.

This calculates a separate shard count for each Playwright project, targeting 200 tests per shard with an eight-shard ceiling. The current suite runs as four offline shards and one network shard, so offline jobs no longer start an unused sync server.

## Release note category
<!-- Select exactly one category. Every pull request must select one. -->
<!-- Select "Not noteworthy" when the pull request fixes a bug in or improves functionality that has not yet appeared in a stable release. -->
<!-- release-note-category:start -->
- [x] Not noteworthy
- [ ] Highlights
- [ ] More improvements
- [ ] Fixed bugs
<!-- release-note-category:end -->

## Release note
<!-- Required unless "Not noteworthy" is selected. -->
<!-- Write one concise, user-facing entry without a leading bullet. -->
<!-- release-note:start -->

<!-- release-note:end -->

## Release note images
<!-- Optional. Paste one or more Markdown images, HTML image tags, or dark/light <picture> elements here. -->
<!-- The release notes normalize the markup and limit images taller than 300 pixels. -->
<!-- Agent instructions:
For a noteworthy visible change, add media when it makes the change easier to understand. Prefer a still image unless motion is the point; recordings must use animated WebP.
After implementing a visible change, proactively capture the result and show the local media to the user for approval before uploading it or updating the pull request.
When the affected UI differs between dark and light themes, capturing both themes is required. A dark-only image is incomplete. Run `node _scripts/releaseNoteMedia.mjs --dark DARK_FILE --light LIGHT_FILE --alt "DESCRIPTION"`; GitHub will display the matching theme and use dark as the fallback. Use a single default-dark capture only when the light theme cannot be captured or looks identical.
Capture or crop to the smallest region that still makes the change clear. Do not include the full window when the affected component can be understood on its own.
Use English unless localization is the subject. Keep components at their normal dimensions and placement instead of resizing them to fill the frame.
Use deterministic local fixtures for visible remote images. Reusable avatar and thumbnail fixtures are available through `e2e/helpers/visual-fixtures.mjs`. Before capturing, verify that every visible image has loaded successfully (`complete === true` and `naturalWidth > 0`).
Inspect the final dark and light files for failed images, missing content, unrelated UI, awkward animation, and misleading layout. Omit media when it does not explain the change clearly.
For one dark capture, run `node _scripts/releaseNoteMedia.mjs FILE --alt "DESCRIPTION"`.
Check for personal information, tokens, private repository names, and unrelated desktop content before uploading. Uploaded media is public.
Keep capture-only scripts, test hooks, screenshots, and recordings out of commits. Remove them before committing unless the capture code is also a reusable regression test. Never commit generated release-note media.
Paste only the generated markup between the marker comments. Leave this section empty when media would not help.
-->
<!-- release-note-image:start -->

<!-- release-note-image:end -->

## Testing
<!-- How can reviewers verify that the PR produces correct results? -->
<!-- Please provide instructions so that others can ensure that your pull request would produce correct results. For examples see, https://github.com/FreeTubeApp/FreeTube/pull/5743, https://github.com/FreeTubeApp/FreeTube/pull/7349, https://github.com/FreeTubeApp/FreeTube/pull/5125, https://github.com/FreeTubeApp/FreeTube/pull/7338 -->
<!-- Agent instructions: Only write human-facing steps that explain how to verify the change while running this branch in dev mode. Include expected results and, when applicable, helpful console snippets for interactive verification. Do not include automated checks, commands, results, pass counts, or CI status. -->
Inspect the E2E job matrix for this branch. The current suite should produce four offline jobs and one network job. Only the network job should start the sync server.

## Additional context
<!-- Add any other context about the pull request here. -->
The shard count increases automatically for every 200 tests in a project and stops at eight shards per project.
