### PR TITLE
fix(comments): translate comments containing emoji

### DIFF
--- a/src/renderer/helpers/api/local.js
+++ b/src/renderer/helpers/api/local.js
@@ -6,7 +6,11 @@ import { SEARCH_CHAR_LIMIT } from '../../../constants'
 import store from '../../store/index'
 import { PlayerCache } from './PlayerCache'
 import { loadSearchContinuation } from '../search-continuation'
-import { formatCommentTranslation, getCommentTranslationSource } from '../comment-translations'
+import {
+  formatCommentTranslation,
+  getCommentTranslationSource,
+  sanitizeCommentTranslationSource
+} from '../comment-translations'
 import { parseLocalShortLinkedVideo } from '../player/shorts'
 import { getPaidPromotionDurationMs } from '../player/paidPromotion'
 import { getLocalPremiereState } from '../premiere'
@@ -160,7 +164,8 @@ export async function getLocalSearchSuggestions(query) {
  */
 export async function translateCommentText(text, targetLanguage) {
   const innertube = await createInnertube()
-  const response = await innertube.interact.translate(text, targetLanguage)
+  const source = sanitizeCommentTranslationSource(text)
+  const response = await innertube.interact.translate(source, targetLanguage)
   return formatCommentTranslation(response.translated_content)
 }
 

--- a/src/renderer/helpers/api/local.js
+++ b/src/renderer/helpers/api/local.js
@@ -7,9 +7,8 @@ import store from '../../store/index'
 import { PlayerCache } from './PlayerCache'
 import { loadSearchContinuation } from '../search-continuation'
 import {
-  formatCommentTranslation,
   getCommentTranslationSource,
-  sanitizeCommentTranslationSource
+  requestCommentTranslation
 } from '../comment-translations'
 import { parseLocalShortLinkedVideo } from '../player/shorts'
 import { getPaidPromotionDurationMs } from '../player/paidPromotion'
@@ -163,10 +162,10 @@ export async function getLocalSearchSuggestions(query) {
  * @returns {Promise<string>}
  */
 export async function translateCommentText(text, targetLanguage) {
-  const innertube = await createInnertube()
-  const source = sanitizeCommentTranslationSource(text)
-  const response = await innertube.interact.translate(source, targetLanguage)
-  return formatCommentTranslation(response.translated_content)
+  return await requestCommentTranslation(text, targetLanguage, async (source, language) => {
+    const innertube = await createInnertube()
+    return await innertube.interact.translate(source, language)
+  })
 }
 
 export function clearLocalSearchSuggestionsSession() {

--- a/src/renderer/helpers/comment-translations.js
+++ b/src/renderer/helpers/comment-translations.js
@@ -121,6 +121,22 @@ export function sanitizeCommentTranslationSource(text) {
 }
 
 /**
+ * @param {string} text
+ * @param {string} targetLanguage
+ * @param {(text: string, targetLanguage: string) => Promise<{translated_content: unknown}>} translate
+ * @returns {Promise<string>}
+ */
+export async function requestCommentTranslation(text, targetLanguage, translate) {
+  const source = sanitizeCommentTranslationSource(text)
+  if (source.trim() === '') {
+    return formatCommentTranslation(source)
+  }
+
+  const response = await translate(source, targetLanguage)
+  return formatCommentTranslation(response.translated_content)
+}
+
+/**
  * Escape translated text before adding links and passing it to the comment renderer.
  * @param {unknown} translatedText
  * @returns {string}

--- a/src/renderer/helpers/comment-translations.js
+++ b/src/renderer/helpers/comment-translations.js
@@ -111,6 +111,16 @@ export function getCommentTranslationSource(runs) {
 }
 
 /**
+ * @param {string} text
+ * @returns {string}
+ */
+export function sanitizeCommentTranslationSource(text) {
+  // InnerTube rejects emoji and other symbols with HTTP 400. Match the
+  // character set used by youtubei.js' CommentView translation method.
+  return text.replaceAll(/[^\p{L}\p{N}\p{P}\p{Z}]/gu, '')
+}
+
+/**
  * Escape translated text before adding links and passing it to the comment renderer.
  * @param {unknown} translatedText
  * @returns {string}

--- a/tests/unit/comment-translations.test.mjs
+++ b/tests/unit/comment-translations.test.mjs
@@ -6,6 +6,7 @@ import {
   formatCommentTranslation,
   getCommentTranslationSource,
   normalizeCommentTranslationLanguageCode,
+  sanitizeCommentTranslationSource,
   shouldOfferCommentTranslation,
   terminateCommentTranslationLanguageDetector,
 } from '../../src/renderer/helpers/comment-translations.js'
@@ -84,6 +85,13 @@ test('keeps plain comment text as the translation source', () => {
     { text: 'Hallo ' },
     { text: 'Welt' }
   ]), 'Hallo Welt')
+})
+
+test('removes characters rejected by YouTube comment translations', () => {
+  assert.equal(
+    sanitizeCommentTranslationSource('Thanks 💗 and 💙‼️'),
+    'Thanks  and ‼'
+  )
 })
 
 test('escapes translated markup and links translated URLs', () => {

--- a/tests/unit/comment-translations.test.mjs
+++ b/tests/unit/comment-translations.test.mjs
@@ -6,6 +6,7 @@ import {
   formatCommentTranslation,
   getCommentTranslationSource,
   normalizeCommentTranslationLanguageCode,
+  requestCommentTranslation,
   sanitizeCommentTranslationSource,
   shouldOfferCommentTranslation,
   terminateCommentTranslationLanguageDetector,
@@ -92,6 +93,34 @@ test('removes characters rejected by YouTube comment translations', () => {
     sanitizeCommentTranslationSource('Thanks 💗 and 💙‼️'),
     'Thanks  and ‼'
   )
+})
+
+test('does not request a translation without supported text', async () => {
+  let requestCount = 0
+
+  await assert.rejects(
+    requestCommentTranslation('💗💙', 'en', async () => {
+      requestCount++
+      return { translated_content: 'unused' }
+    }),
+    /YouTube did not return a comment translation/
+  )
+  assert.equal(requestCount, 0)
+})
+
+test('requests a translation with sanitized text', async () => {
+  const requests = []
+  const translatedText = await requestCommentTranslation(
+    'Danke 💗',
+    'en',
+    async (text, targetLanguage) => {
+      requests.push({ text, targetLanguage })
+      return { translated_content: 'Thanks' }
+    }
+  )
+
+  assert.equal(translatedText, 'Thanks')
+  assert.deepEqual(requests, [{ text: 'Danke ', targetLanguage: 'en' }])
 })
 
 test('escapes translated markup and links translated URLs', () => {


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Make sure to follow the contributing guidelines. -->
<!-- Important note, we may remove your pull request if you do not use this provided PR template correctly. -->
<!-- Agent instructions: Preserve every heading, comment, and marker in this template. Never remove or rewrite the release-note-category:start/end, release-note:start/end, or release-note-image:start/end marker pairs. -->

## Pull Request Type
<!-- Please select what type of pull request this is: [x] -->
- [x] Bugfix
- [ ] Feature Implementation
- [ ] Documentation
- [ ] Other

## Related issue
<!-- Please link the issue your pull request is referring to. -->
<!-- If this pull request fully resolves the relevant issue, put "closes" before the issue number. -->
<!-- Example: "closes #123456". -->

closes #966

## Description
<!-- Please write a clear and concise description of what the pull request does. -->

YouTube returns HTTP 400 when comment translation requests contain emoji or other unsupported symbols. This sanitizes only the text sent to InnerTube, using the same allowed character categories as youtubei.js, while leaving the displayed original comment unchanged.

## Release note category
<!-- Select exactly one category. Every pull request must select one. -->
<!-- Select "Not noteworthy" when the pull request fixes a bug in or improves functionality that has not yet appeared in a stable release. -->
<!-- release-note-category:start -->
- [x] Not noteworthy
- [ ] Highlights
- [ ] More improvements
- [ ] Fixed bugs
<!-- release-note-category:end -->

## Release note
<!-- Required unless "Not noteworthy" is selected. -->
<!-- Write one concise, user-facing entry without a leading bullet. -->
<!-- release-note:start -->

<!-- release-note:end -->

## Release note images
<!-- Optional. Paste one or more Markdown images, HTML image tags, or dark/light <picture> elements here. -->
<!-- The release notes normalize the markup and limit images taller than 300 pixels. -->
<!-- Agent instructions:
For a noteworthy visible change, add media when it makes the change easier to understand. Prefer a still image unless motion is the point; recordings must use animated WebP.
After implementing a visible change, proactively capture the result and show the local media to the user for approval before uploading it or updating the pull request.
When the affected UI differs between dark and light themes, capturing both themes is required. A dark-only image is incomplete. Run `node _scripts/releaseNoteMedia.mjs --dark DARK_FILE --light LIGHT_FILE --alt "DESCRIPTION"`; GitHub will display the matching theme and use dark as the fallback. Use a single default-dark capture only when the light theme cannot be captured or looks identical.
Capture or crop to the smallest region that still makes the change clear. Do not include the full window when the affected component can be understood on its own.
Use English unless localization is the subject. Keep components at their normal dimensions and placement instead of resizing them to fill the frame.
Use deterministic local fixtures for visible remote images. Reusable avatar and thumbnail fixtures are available through `e2e/helpers/visual-fixtures.mjs`. Before capturing, verify that every visible image has loaded successfully (`complete === true` and `naturalWidth > 0`).
Inspect the final dark and light files for failed images, missing content, unrelated UI, awkward animation, and misleading layout. Omit media when it does not explain the change clearly.
For one dark capture, run `node _scripts/releaseNoteMedia.mjs FILE --alt "DESCRIPTION"`.
Check for personal information, tokens, private repository names, and unrelated desktop content before uploading. Uploaded media is public.
Keep capture-only scripts, test hooks, screenshots, and recordings out of commits. Remove them before committing unless the capture code is also a reusable regression test. Never commit generated release-note media.
Paste only the generated markup between the marker comments. Leave this section empty when media would not help.
-->
<!-- release-note-image:start -->

<!-- release-note-image:end -->

## Testing
<!-- How can reviewers verify that the PR produces correct results? -->
<!-- Please provide instructions so that others can ensure that your pull request would produce correct results. For examples see, https://github.com/FreeTubeApp/FreeTube/pull/5743, https://github.com/FreeTubeApp/FreeTube/pull/7349, https://github.com/FreeTubeApp/FreeTube/pull/5125, https://github.com/FreeTubeApp/FreeTube/pull/7338 -->
<!-- Agent instructions: Only write human-facing steps that explain how to verify the change while running this branch in dev mode. Include expected results and, when applicable, helpful console snippets for interactive verification. Do not include automated checks, commands, results, pass counts, or CI status. -->

1. Run this branch in dev mode and open a video with a non-English comment containing emoji.
2. Translate that comment. The translation should load without an HTTP 400 error.
3. Restore the original text. The original comment, including its emoji, should appear unchanged.

## Additional context
<!-- Add any other context about the pull request here. -->

The translated version may omit emoji because YouTube rejects them in the translation request. The original comment data is not modified.
