### PR TITLE
refactor(i18n): consolidate duplicate translation keys

### DIFF
--- a/src/main/index.js
+++ b/src/main/index.js
@@ -722,6 +722,21 @@ function runApp() {
 
   // Registered per-webContents in 'web-contents-created' so the shared
   // BrowserWindow renderer can resolve native menu targets through TabManager.
+  const sharedContextMenuLabelKeys = {
+    Blue: 'Settings.Theme Settings.Main Color Theme.Blue',
+    'Close Tab': 'Close Tab',
+    Copy: 'Copy',
+    Cut: 'Cut',
+    Green: 'Settings.Theme Settings.Main Color Theme.Green',
+    'New Tab': 'New Tab',
+    'New Window': 'New Window',
+    Orange: 'Settings.Theme Settings.Main Color Theme.Orange',
+    Paste: 'Paste',
+    Red: 'Settings.Theme Settings.Main Color Theme.Red',
+    Ungrouped: 'Tab Organizer.Ungrouped',
+    Yellow: 'Settings.Theme Settings.Main Color Theme.Yellow'
+  }
+
   /**
    * @param {string} key
    * @param {Record<string, string | number>} [parameters]
@@ -730,7 +745,7 @@ function runApp() {
    */
   function contextMenuLabel(key, parameters = {}, fallback = key) {
     return {
-      key: `Context Menu.${key}`,
+      key: sharedContextMenuLabelKeys[key] ?? `Context Menu.${key}`,
       parameters,
       fallback
     }

--- a/src/renderer/components/AutomaticDownloadSettings/AutomaticDownloadSettings.vue
+++ b/src/renderer/components/AutomaticDownloadSettings/AutomaticDownloadSettings.vue
@@ -16,7 +16,7 @@
         {{ t('Settings.Download Settings.Automatic Downloads New Only') }}
       </p>
       <FtInput
-        :placeholder="t('Settings.Download Settings.Search Automatic Download Channels')"
+        :placeholder="t('Settings.Channel Settings.Search Channels')"
         :show-action-button="false"
         :show-clear-text-button="true"
         :value="searchQuery"
@@ -87,7 +87,7 @@
                   @change="value => updateRule(channel.id, 'template', value)"
                 />
                 <FtToggleSwitch
-                  :label="t('Settings.Download Settings.Automatic Downloads Videos')"
+                  :label="t('Global.Videos')"
                   :compact="true"
                   :default-value="ruleFor(channel.id).includeVideos"
                   @change="value => updateRule(channel.id, 'includeVideos', value)"

--- a/src/renderer/components/ChannelSettings/ChannelSettings.vue
+++ b/src/renderer/components/ChannelSettings/ChannelSettings.vue
@@ -142,7 +142,7 @@
                 />
                 <FtSlider
                   v-if="preference.type === 'playbackSpeed'"
-                  :label="t('Settings.Channel Settings.Playback Speed')"
+                  :label="t('Settings.Player Settings.Playback Speed')"
                   :default-value="preference.value"
                   :min-value="videoPlaybackRateInterval"
                   :max-value="maxVideoPlaybackRate"
@@ -276,7 +276,7 @@ const PREFERENCE_ICONS = Object.freeze({
 })
 
 const preferenceLabels = computed(() => ({
-  playbackSpeed: t('Settings.Channel Settings.Playback Speed'),
+  playbackSpeed: t('Settings.Player Settings.Playback Speed'),
   videoQuality: t('Settings.Channel Settings.Video Quality'),
   subtitlesState: t('Settings.Channel Settings.Subtitles Enabled'),
   volume: t('Settings.Channel Settings.Volume')

--- a/src/renderer/components/CommentSection/CommentReply.vue
+++ b/src/renderer/components/CommentSection/CommentReply.vue
@@ -107,8 +107,8 @@
         <button
           type="button"
           class="commentCopyLink"
-          :title="$t('Comments.Copy YouTube Link')"
-          :aria-label="$t('Comments.Copy YouTube Link')"
+          :title="$t('Video.Copy YouTube Link')"
+          :aria-label="$t('Video.Copy YouTube Link')"
           @click="emit('copy-youtube-link', reply.id)"
         >
           <FtIcon :icon="['fas', 'link']" />

--- a/src/renderer/components/CommentSection/CommentSection.vue
+++ b/src/renderer/components/CommentSection/CommentSection.vue
@@ -311,8 +311,8 @@
             <button
               type="button"
               class="commentCopyLink"
-              :title="$t('Comments.Copy YouTube Link')"
-              :aria-label="$t('Comments.Copy YouTube Link')"
+              :title="$t('Video.Copy YouTube Link')"
+              :aria-label="$t('Video.Copy YouTube Link')"
               @click="copyCommentYoutubeLink(comment.id)"
             >
               <FtIcon

--- a/src/renderer/components/CustomThemeEditor/CustomThemeEditor.vue
+++ b/src/renderer/components/CustomThemeEditor/CustomThemeEditor.vue
@@ -59,7 +59,7 @@
         />
         <div class="darkThemeControl">
           <FtToggleSwitch
-            :label="t('Settings.Theme Settings.Custom Theme.Is Dark Theme')"
+            :label="t('Settings.Theme Settings.Dark Theme')"
             :default-value="draft.isDark"
             compact
             @change="updateDarkTheme"

--- a/src/renderer/components/DownloadTemplateSettings/DownloadTemplateSettings.vue
+++ b/src/renderer/components/DownloadTemplateSettings/DownloadTemplateSettings.vue
@@ -36,7 +36,7 @@
         <FtSelect
           :placeholder="t('Downloads.Media Type')"
           :value="options.mode"
-          :select-names="[t('Downloads.Video'), t('Downloads.Audio'), t('Downloads.Subtitles')]"
+          :select-names="[t('Downloads.Video'), t('Downloads.Audio'), t('Search Listing.Label.Subtitles')]"
           :select-values="['video', 'audio', 'subtitles']"
           @change="setOption('mode', $event)"
         />
@@ -108,7 +108,7 @@
       </section>
 
       <section class="optionSection">
-        <h3>{{ t('Downloads.SponsorBlock') }}</h3>
+        <h3>{{ t('Settings.SponsorBlock Settings.SponsorBlock Settings') }}</h3>
         <div class="toggleGrid">
           <FtToggleSwitch
             compact

--- a/src/renderer/components/FtCommandPalette/FtCommandPalette.vue
+++ b/src/renderer/components/FtCommandPalette/FtCommandPalette.vue
@@ -148,7 +148,7 @@
           aria-hidden="true"
         >
           <span><kbd>{{ t('CommandPalette.Keys.Up') }}</kbd><kbd>{{ t('CommandPalette.Keys.Down') }}</kbd> {{ t('CommandPalette.Move') }}</span>
-          <span><kbd>{{ t('CommandPalette.Keys.Enter') }}</kbd> {{ t('CommandPalette.Run') }}</span>
+          <span><kbd>{{ t('Keys.enter') }}</kbd> {{ t('CommandPalette.Run') }}</span>
           <span><kbd>{{ t('CommandPalette.Keys.Escape') }}</kbd> {{ t('Close') }}</span>
         </footer>
         <p

--- a/src/renderer/components/FtKeyboardShortcutPrompt/FtKeyboardShortcutPrompt.vue
+++ b/src/renderer/components/FtKeyboardShortcutPrompt/FtKeyboardShortcutPrompt.vue
@@ -185,8 +185,8 @@ const shortcutConflictCanBeReassigned = computed(() =>
 )
 
 const shortcutConflictOptionNames = computed(() => shortcutConflictCanBeReassigned.value
-  ? [t('KeyboardShortcutPrompt.Reassign'), t('KeyboardShortcutPrompt.Undo')]
-  : [t('KeyboardShortcutPrompt.Undo')]
+  ? [t('KeyboardShortcutPrompt.Reassign'), t('Undo')]
+  : [t('Undo')]
 )
 
 const shortcutConflictOptionValues = computed(() => shortcutConflictCanBeReassigned.value
@@ -332,7 +332,7 @@ const localizedShortcutNameToShortcutsMappings = computed(() => {
       'HISTORY_FORWARD_ALT_MAC',
     ]],
     [t('KeyboardShortcutPrompt.Navigate to Settings'), ['NAVIGATE_TO_SETTINGS']],
-    [t('KeyboardShortcutPrompt.Navigate to Downloads'), ['NAVIGATE_TO_DOWNLOADS']],
+    [t('Downloads.Open Downloads'), ['NAVIGATE_TO_DOWNLOADS']],
     [t('KeyboardShortcutPrompt.Navigate to History'), ['NAVIGATE_TO_HISTORY', 'NAVIGATE_TO_HISTORY_MAC']],
     [t('KeyboardShortcutPrompt.New Window'), ['NEW_WINDOW']],
     [t('KeyboardShortcutPrompt.New Tab'), ['NEW_TAB']],

--- a/src/renderer/components/FtQuickSettingsMenu/FtQuickSettingsMenu.vue
+++ b/src/renderer/components/FtQuickSettingsMenu/FtQuickSettingsMenu.vue
@@ -125,8 +125,8 @@
               v-if="showDownloadsShortcut"
               type="button"
               class="quickSettingsShortcut downloadsShortcut"
-              :aria-label="t('Downloads.Downloads')"
-              :title="t('Downloads.Downloads')"
+              :aria-label="t('Settings.Download Settings.Download Settings')"
+              :title="t('Settings.Download Settings.Download Settings')"
               @click="openDownloads"
             >
               <FtIcon :icon="['fas', 'download']" />

--- a/src/renderer/components/PasswordSettings/PasswordSettings.vue
+++ b/src/renderer/components/PasswordSettings/PasswordSettings.vue
@@ -17,7 +17,7 @@
       class="settingsFlexStart460px"
     >
       <FtInput
-        :placeholder="$t('Settings.Password Settings.Password')"
+        :placeholder="$t('Settings.Password Dialog.Password')"
         :label="$t('Settings.Password Settings.Set Password To Prevent Access')"
         :show-action-button="false"
         show-label

--- a/src/renderer/components/StorageSettings/StorageSettings.vue
+++ b/src/renderer/components/StorageSettings/StorageSettings.vue
@@ -87,7 +87,7 @@
 
     <FtSettingsSection
       v-if="USING_ELECTRON"
-      :title="t('Settings.Storage Settings.Downloads')"
+      :title="t('Settings.Download Settings.Download Settings')"
     >
       <StorageItem
         :title="t('Settings.Storage Settings.Downloaded Media')"
@@ -295,7 +295,7 @@
         />
       </StorageItem>
       <StorageItem
-        :title="t('Settings.Storage Settings.Playlists')"
+        :title="t('Playlists')"
         :size="sizeText('playlists')"
         :description="t('Settings.Storage Settings.Playlists Description')"
         location="playlists.db"

--- a/src/renderer/components/SyncSettings/SyncSettings.vue
+++ b/src/renderer/components/SyncSettings/SyncSettings.vue
@@ -33,7 +33,7 @@
         />
         <FtInput
           v-if="!connected"
-          :placeholder="t('Settings.Sync Settings.Password')"
+          :placeholder="t('Settings.Password Dialog.Password')"
           :show-action-button="false"
           :value="password"
           :disabled="serverCredentialsDisabled"
@@ -180,7 +180,7 @@
             @change="store.dispatch('updateSyncServerSyncSessions', $event)"
           />
           <FtToggleSwitch
-            :label="t('Settings.Sync Settings.Settings')"
+            :label="t('Settings.Settings')"
             :default-value="syncSettingsEnabled"
             :disabled="busy || settingsSupported === false"
             compact
@@ -301,7 +301,7 @@
             {{ t('Settings.Sync Settings.Delete Account Warning') }}
           </p>
           <FtInput
-            :placeholder="t('Settings.Sync Settings.Password')"
+            :placeholder="t('Settings.Password Dialog.Password')"
             :show-action-button="false"
             :value="deleteAccountPassword"
             input-type="password"

--- a/src/renderer/components/TabOrganizer/TabOrganizer.vue
+++ b/src/renderer/components/TabOrganizer/TabOrganizer.vue
@@ -116,7 +116,7 @@
                 :icon="['fas', 'rectangle-xmark']"
                 aria-hidden="true"
               />
-              {{ t('Tab Organizer.Close') }}
+              {{ t('Close') }}
             </button>
             <FtSelect
               class="compactSelect bulkActionSelect"
@@ -141,7 +141,7 @@
                 v-model="query"
                 type="search"
                 autocomplete="off"
-                :placeholder="t('Tab Organizer.Search Placeholder')"
+                :placeholder="t('Tab Organizer.Search Label')"
                 :aria-label="t('Tab Organizer.Search Label')"
               >
             </label>
@@ -390,7 +390,7 @@
                     type="button"
                     class="iconButton"
                     :aria-label="t('Tab Organizer.Close Tab', { title: tab.title })"
-                    :title="t('Tab Organizer.Close')"
+                    :title="t('Close')"
                     @click="runAction('close', [tab.id])"
                   >
                     <FtIcon
@@ -443,7 +443,7 @@
                       :icon="['fas', 'clock-rotate-left']"
                       aria-hidden="true"
                     />
-                    {{ t('Tab Organizer.Restore') }}
+                    {{ t('Restore') }}
                   </button>
                 </li>
               </ul>
@@ -509,11 +509,11 @@ const canUnpinSelectedTabs = computed(() => selectedTabs.value.some(tab => tab.i
 const canLoadSelectedTabs = computed(() => selectedTabs.value.some(tab => tab.isUnloaded))
 const canUnloadSelectedTabs = computed(() => selectedTabs.value.some(tab => !tab.isUnloaded))
 const localizedTabColors = computed(() => [
-  { value: 'red', label: t('Context Menu.Red') },
-  { value: 'orange', label: t('Context Menu.Orange') },
-  { value: 'yellow', label: t('Context Menu.Yellow') },
-  { value: 'green', label: t('Context Menu.Green') },
-  { value: 'blue', label: t('Context Menu.Blue') },
+  { value: 'red', label: t('Settings.Theme Settings.Main Color Theme.Red') },
+  { value: 'orange', label: t('Settings.Theme Settings.Main Color Theme.Orange') },
+  { value: 'yellow', label: t('Settings.Theme Settings.Main Color Theme.Yellow') },
+  { value: 'green', label: t('Settings.Theme Settings.Main Color Theme.Green') },
+  { value: 'blue', label: t('Settings.Theme Settings.Main Color Theme.Blue') },
   { value: 'purple', label: t('Context Menu.Purple') }
 ])
 const editableGroupColors = computed(() => [

--- a/src/renderer/components/TopNav/TopNav.vue
+++ b/src/renderer/components/TopNav/TopNav.vue
@@ -131,8 +131,8 @@
           type="button"
           class="downloadsButton navButton"
           :class="{ active: downloadsWindowOpen }"
-          :aria-label="t('Downloads.Downloads')"
-          :title="t('Downloads.Downloads')"
+          :aria-label="t('Settings.Download Settings.Download Settings')"
+          :title="t('Settings.Download Settings.Download Settings')"
           :aria-pressed="downloadsWindowOpen"
           @click="toggleDownloadsWindow"
         >
@@ -322,7 +322,7 @@ const showSettingsButton = computed(() => (
 ))
 const minimizedSettingsWindowTitle = computed(() => {
   if (settingsWindowView.value === 'about') return t('About.About')
-  if (settingsWindowView.value === 'downloads') return t('Downloads.Downloads')
+  if (settingsWindowView.value === 'downloads') return t('Settings.Download Settings.Download Settings')
   return t('Settings.Settings')
 })
 const minimizedSettingsWindowIcon = computed(() => {

--- a/src/renderer/components/WatchVideoDownloadPrompt/WatchVideoDownloadPrompt.vue
+++ b/src/renderer/components/WatchVideoDownloadPrompt/WatchVideoDownloadPrompt.vue
@@ -61,7 +61,7 @@
           <FtSelect
             :placeholder="t('Downloads.Media Type')"
             :value="options.mode"
-            :select-names="[t('Downloads.Video'), t('Downloads.Audio'), t('Downloads.Subtitles')]"
+            :select-names="[t('Downloads.Video'), t('Downloads.Audio'), t('Search Listing.Label.Subtitles')]"
             :select-values="['video', 'audio', 'subtitles']"
             @change="setOption('mode', $event)"
           />
@@ -134,7 +134,7 @@
         </section>
 
         <section class="optionSection">
-          <h3>{{ t('Downloads.SponsorBlock') }}</h3>
+          <h3>{{ t('Settings.SponsorBlock Settings.SponsorBlock Settings') }}</h3>
           <div class="toggleGrid">
             <FtToggleSwitch
               compact

--- a/src/renderer/components/WatchVideoFormatPrompt/WatchVideoFormatPrompt.vue
+++ b/src/renderer/components/WatchVideoFormatPrompt/WatchVideoFormatPrompt.vue
@@ -160,7 +160,7 @@ const { t } = useI18n()
 
 const engineLabel = computed(() => {
   if (props.playbackEngineSelection !== 'yt-dlp') {
-    return t('Change Format.Engines.Built-in')
+    return t('Settings.General Settings.Stream Extraction Method.Built-in')
   }
 
   // showing the version makes it verifiable that the streams really came from yt-dlp
@@ -185,11 +185,11 @@ const streamTypeLabel = computed(() => {
 const engines = computed(() => [
   {
     value: 'yt-dlp',
-    label: t('Change Format.Engines.yt-dlp')
+    label: t('Settings.General Settings.Stream Extraction Method.yt-dlp')
   },
   {
     value: 'built-in',
-    label: t('Change Format.Engines.Built-in')
+    label: t('Settings.General Settings.Stream Extraction Method.Built-in')
   }
 ])
 

--- a/src/renderer/components/WatchVideoInfo/WatchVideoInfo.vue
+++ b/src/renderer/components/WatchVideoInfo/WatchVideoInfo.vue
@@ -242,7 +242,7 @@
           />
           <FtIconButton
             v-if="metadataHistory"
-            :title="t('Video.Metadata Cache.History')"
+            :title="t('Settings.Privacy Settings.Cache Video Metadata')"
             :icon="['fas', 'clock-rotate-left']"
             @click="showMetadataHistory = true"
           />
@@ -876,11 +876,11 @@ function createChannelSettingSaveAction(type, visible, label, settingLabel, icon
 
 const channelSettingSaveActions = computed(() => [
   createChannelSettingSaveAction('playbackSpeed', showSaveChannelPlaybackSpeedButton.value,
-    t('Video.Save Channel Playback Speed'), t('Settings.Channel Settings.Playback Speed'), ['fas', 'gauge']),
+    t('Video.Save Channel Playback Speed'), t('Settings.Player Settings.Playback Speed'), ['fas', 'gauge']),
   createChannelSettingSaveAction('videoQuality', showSaveChannelVideoQualityButton.value,
     t('Video.Save Channel Video Quality'), t('Settings.Channel Settings.Video Quality'), ['fas', 'photo-film']),
   createChannelSettingSaveAction('subtitlesState', showSaveChannelSubtitlesStateButton.value,
-    t('Video.Save Channel Subtitles State'), t('Settings.Channel Settings.Subtitles State'),
+    t('Video.Save Channel Subtitles State'), t('Search Listing.Label.Subtitles'),
     ['fas', 'closed-captioning']),
   createChannelSettingSaveAction('volume', showSaveChannelVolumeButton.value,
     t('Video.Save Channel Volume'), t('Settings.Channel Settings.Volume'), ['fas', 'volume-high'])

--- a/src/renderer/components/WatchVideoMetadataHistory/WatchVideoMetadataHistory.vue
+++ b/src/renderer/components/WatchVideoMetadataHistory/WatchVideoMetadataHistory.vue
@@ -1,6 +1,6 @@
 <template>
   <FtPrompt
-    :label="$t('Video.Metadata Cache.History')"
+    :label="$t('Settings.Privacy Settings.Cache Video Metadata')"
     card-class="videoMetadataHistoryPrompt"
     fixed-layout
     @click="emit('close')"

--- a/src/renderer/components/WatchVideoSponsorBlock/WatchVideoSponsorBlock.vue
+++ b/src/renderer/components/WatchVideoSponsorBlock/WatchVideoSponsorBlock.vue
@@ -8,7 +8,7 @@
         >
           <ft-icon :icon="['fas', 'shield-halved']" />
         </span>
-        <h3>{{ $t('Video.Player.SponsorBlock.InfoPanelTitle') }}</h3>
+        <h3>{{ $t('Settings.SponsorBlock Settings.SponsorBlock Settings') }}</h3>
       </div>
       <div class="sponsorBlockHeaderActions">
         <button

--- a/src/renderer/components/WatchVideoTranscript/WatchVideoTranscript.vue
+++ b/src/renderer/components/WatchVideoTranscript/WatchVideoTranscript.vue
@@ -44,7 +44,7 @@
           class="transcriptActions"
         >
           <FtIconButton
-            :title="t('Video.Transcript.Copy')"
+            :title="t('Copy')"
             :icon="['fas', 'copy']"
             :disabled="isLoading || segments.length === 0"
             theme="base-no-default"

--- a/src/renderer/components/ft-shaka-video-player/ft-shaka-video-player.vue
+++ b/src/renderer/components/ft-shaka-video-player/ft-shaka-video-player.vue
@@ -193,7 +193,7 @@
               max="100"
               step="any"
               :value="scrollMiniVolumePercent"
-              :aria-label="$t('Video.Player.Scroll Mini Player.Volume')"
+              :aria-label="$t('Settings.Channel Settings.Volume')"
               @input.stop="updateScrollMiniVolume"
               @click.stop
             >
@@ -615,7 +615,7 @@
         }"
         :style="fullscreenDockStyle('sponsorBlock')"
         role="dialog"
-        :aria-label="$t('Video.Player.SponsorBlock.InfoPanelTitle')"
+        :aria-label="$t('Settings.SponsorBlock Settings.SponsorBlock Settings')"
         :aria-hidden="String(!showFullscreenSponsorBlock)"
         :inert="!showFullscreenSponsorBlock"
         @click.stop
@@ -1100,7 +1100,7 @@
                   class="sponsorBlockDraftActionButton"
                   @click="deleteSponsorBlockDraft(segment.id)"
                 >
-                  {{ $t('Video.Player.SponsorBlock.DeleteSegment') }}
+                  {{ $t('Delete') }}
                 </button>
                 <button
                   v-if="!isSponsorBlockFullVideoSegment(segment)"
@@ -1132,7 +1132,7 @@
                   {{
                     isSponsorBlockDraftEditing(segment.id)
                       ? $t('Video.Player.SponsorBlock.SaveSegment')
-                      : $t('Video.Player.SponsorBlock.EditSegment')
+                      : $t('Edit')
                   }}
                 </button>
               </div>
@@ -1214,7 +1214,7 @@
               max="100"
               step="any"
               :value="scrollMiniVolumePercent"
-              :aria-label="$t('Video.Player.Scroll Mini Player.Volume')"
+              :aria-label="$t('Settings.Channel Settings.Volume')"
               @input.stop="updateScrollMiniVolume"
               @pointerdown.stop="handleScrollMiniVolumePointerDown"
             >

--- a/src/renderer/components/ft-shaka-video-player/player-components/CaptionSelection.js
+++ b/src/renderer/components/ft-shaka-video-player/player-components/CaptionSelection.js
@@ -373,7 +373,7 @@ export class CaptionSelection extends shaka.ui.TextSelection {
   /** @private */
   updateLocalisedStrings_() {
     const optionsLabel = i18n.global.t('Video.Player.Caption Appearance.Options')
-    const title = i18n.global.t('Video.Player.Caption Appearance.Title')
+    const title = i18n.global.t('Settings.Player Settings.Caption Appearance.Caption Appearance')
 
     this.optionsButton_.textContent = optionsLabel
     this.optionsButton_.ariaLabel = optionsLabel

--- a/src/renderer/components/ft-shaka-video-player/player-components/VoiceOverTranslationButton.js
+++ b/src/renderer/components/ft-shaka-video-player/player-components/VoiceOverTranslationButton.js
@@ -63,7 +63,7 @@ export class VoiceOverTranslationButton extends shaka.ui.Element {
   }
 
   update_() {
-    const label = i18n.global.t('Video.Player.Voice-over Translation.Voice-over Translation')
+    const label = i18n.global.t('Settings.Player Settings.Voice-over Translation.Title')
     let stateLabel
 
     if (this.state_.value === 'loading') {

--- a/src/renderer/helpers/commandPaletteRegistry.js
+++ b/src/renderer/helpers/commandPaletteRegistry.js
@@ -12,9 +12,9 @@ import { getFirstCharacter } from './strings'
 const SETTINGS_SECTIONS = [
   ['general', 'Settings.General Settings.General Settings', 'Settings.Categories.General Description', ['preferences', 'options']],
   ['appearance', 'Settings.Categories.Appearance', 'Settings.Categories.Appearance Description', ['theme', 'display']],
-  ['playback', 'Settings.Categories.Playback', 'Settings.Categories.Playback Description', ['player', 'video']],
+  ['playback', 'Settings.Quick Settings.Playback', 'Settings.Categories.Playback Description', ['player', 'video']],
   ['add-ons', 'Settings.Categories.Add-ons', 'Settings.Categories.Add-ons Description', ['addons', 'extensions', 'sponsorblock']],
-  ['subscriptions', 'Settings.Categories.Subscriptions', 'Settings.Categories.Subscriptions Description', ['feeds', 'channels']],
+  ['subscriptions', 'Subscriptions.Subscriptions', 'Settings.Categories.Subscriptions Description', ['feeds', 'channels']],
   ['download', 'Settings.Download Settings.Download Settings', 'Settings.Categories.Downloads Description', ['yt-dlp', 'files']],
   ['focus', 'Settings.Distraction Free Settings.Distraction Free Settings', 'Settings.Categories.Distraction Free Description', ['distraction free', 'hide']],
   ['privacy', 'Settings.Privacy Settings.Privacy Settings', 'Settings.Categories.Privacy Description', ['history', 'security']],
@@ -75,12 +75,12 @@ export function createCommandPaletteRegistry(context) {
   const groups = {
     app: t('CommandPalette.Groups.App'),
     navigation: t('CommandPalette.Groups.Navigation'),
-    settings: t('CommandPalette.Groups.Settings'),
+    settings: t('Settings.Settings'),
     tabs: t('CommandPalette.Groups.Tabs'),
-    profiles: t('CommandPalette.Groups.Profiles'),
-    playlists: t('CommandPalette.Groups.Playlists'),
-    downloads: t('CommandPalette.Groups.Downloads'),
-    playback: t('CommandPalette.Groups.Playback'),
+    profiles: t('Settings.Sync Settings.Profiles'),
+    playlists: t('Playlists'),
+    downloads: t('Settings.Download Settings.Download Settings'),
+    playback: t('Settings.Quick Settings.Playback'),
   }
   const commands = []
   const configuredShortcuts = getConfiguredKeyboardShortcuts(store.getters.getKeyboardShortcuts)
@@ -173,7 +173,7 @@ export function createCommandPaletteRegistry(context) {
       icon: ['fas', 'info-circle'],
       run: () => openSettingsView('about'),
     }),
-    command('downloads.open', t('Downloads.Downloads'), groups.downloads, {
+    command('downloads.open', t('Settings.Download Settings.Download Settings'), groups.downloads, {
       aliases: ['files', 'yt-dlp'],
       icon: ['fas', 'download'],
       disabledReason: !isElectron ? t('CommandPalette.Unavailable.Desktop') : '',

--- a/src/renderer/helpers/settings-search-config.js
+++ b/src/renderer/helpers/settings-search-config.js
@@ -273,7 +273,6 @@ export const SETTINGS_SEARCH_EXCLUDED_MESSAGE_PATHS = {
   general: new Set(['System Default']),
   'context-menu-search': new Set(['Engine Name', 'Search URL']),
   player: new Set(['Skip Silence']),
-  password: new Set(['Password']),
   'sponsor-block': new Set(['Generated SponsorBlock User ID Copy Button']),
   subscription: new Set(['Auto Refresh Interval']),
   'caption-appearance': new Set(['Application Language']),

--- a/src/renderer/views/Downloads/DownloadRow.vue
+++ b/src/renderer/views/Downloads/DownloadRow.vue
@@ -227,7 +227,7 @@ const modeLabel = computed(() => {
     case 'audio':
       return t('Downloads.Audio')
     case 'subtitles':
-      return t('Downloads.Subtitles')
+      return t('Search Listing.Label.Subtitles')
     default:
       return ''
   }

--- a/src/renderer/views/Settings/Settings.vue
+++ b/src/renderer/views/Settings/Settings.vue
@@ -539,7 +539,7 @@ const showMinimizeButton = computed(() => {
 const isKeyboardShortcutPromptOpen = computed(() => store.getters.getIsKeyboardShortcutPromptShown)
 const windowTitle = computed(() => {
   if (isAboutOpen.value) return t('About.About')
-  if (isDownloadsOpen.value) return t('Downloads.Downloads')
+  if (isDownloadsOpen.value) return t('Settings.Download Settings.Download Settings')
   return t('Settings.Settings')
 })
 const standaloneViewIcon = computed(() => isDownloadsOpen.value
@@ -556,7 +556,7 @@ const settingsComponentsData = computed(() => [
   },
   {
     type: 'playback',
-    title: t('Settings.Categories.Playback'),
+    title: t('Settings.Quick Settings.Playback'),
     description: t('Settings.Categories.Playback Description'),
     icon: ['fas', 'circle-play'],
     component: PlaybackSettings
@@ -571,7 +571,7 @@ const settingsComponentsData = computed(() => [
   },
   {
     type: 'subscriptions',
-    title: t('Settings.Categories.Subscriptions'),
+    title: t('Subscriptions.Subscriptions'),
     description: t('Settings.Categories.Subscriptions Description'),
     icon: ['fas', 'users'],
     component: SubscriptionCategorySettings

--- a/static/locales/de-DE.yaml
+++ b/static/locales/de-DE.yaml
@@ -256,9 +256,7 @@ Settings:
     Appearance Description: Design, Layout und Vorschaubilder
     Content appearance: Videolisten und Vorschaubilder
     Layout: Layout
-    Playback: Wiedergabe
     Playback Description: Player, Untertitel und Kanaleinstellungen
-    Subscriptions: Abos
     Subscriptions Description: Feed-Aktualisierung und Anzeigeoptionen
     Downloads Description: Ordner, Vorlagen und automatische Regeln
     Distraction Free Description: Inhalte ausblenden und die Anzeige begrenzen
@@ -298,8 +296,6 @@ Settings:
       List: Liste
     Playlist View Type:
       Playlist View Type: Playlist-Ansicht
-      Grid: Raster
-      List: Liste
     Thumbnail Preference:
       Thumbnail Preference: Vorschaubilder
       Default: Standard
@@ -547,7 +543,6 @@ Settings:
       Edit Custom Theme: Benutzerdefiniertes Design bearbeiten
       Custom Theme Creator: Editor für benutzerdefinierte Designs
       Theme Name: Name des Designs
-      Is Dark Theme: Dunkles Design
       Based On: Basiert auf
       Import Theme: Design importieren
       Export Theme: Design exportieren
@@ -841,7 +836,6 @@ Settings:
     Not Available: Genaue Größe nicht verfügbar
     At Least: 'Mindestens {size}'
     Failed To Read Storage: Einige Speichergrößen konnten nicht ermittelt werden
-    Downloads: Downloads
     Downloaded Media Description: Video-, Audio- und Untertiteldateien, die noch im Downloadverlauf erfasst sind.
     Selected Download Folders: Vom Benutzer ausgewählte Downloadordner
     Download History Records: Downloadverlaufseinträge
@@ -907,7 +901,6 @@ Settings:
     Subscriptions And Profiles: Abos und Profile
     Subscriptions And Profiles Description: Speichert abonnierte Kanäle, Profilnamen und Profilzugehörigkeiten.
     Subscriptions And Profiles Effect: Alle Abos und zusätzlichen Profile werden dauerhaft gelöscht. Feed-Cache-Daten werden ebenfalls gelöscht.
-    Playlists: Playlists
     Playlists Description: Speichert Namen und Beschreibungen von Playlists sowie darin gespeicherte Videos.
     Playlists Effect: Jede Playlist und ihre gespeicherten Videos werden dauerhaft gelöscht. Heruntergeladene Mediendateien bleiben erhalten.
     Settings And Sessions: Einstellungen, Tab-Sitzungen und Erinnerungen
@@ -1125,9 +1118,7 @@ Settings:
       Beim Aktivieren eines Kanals wird erst dessen nächster neuer Upload heruntergeladen. Vorhandene Videos und ältere
       Videos des Kanals werden nicht heruntergeladen.
     Automatic Downloads No Channels: Abonniere einen Kanal, bevor du automatische Downloads einrichtest.
-    Search Automatic Download Channels: Kanäle durchsuchen
     No Matching Automatic Download Channels: Keine Kanäle entsprechen deiner Suche.
-    Automatic Downloads Videos: Videos
     Automatic Downloads Livestreams: Livestreams
     Minimum Duration Seconds: Mindestdauer (Sekunden)
     Maximum Duration Seconds: Höchstdauer (Sekunden)
@@ -1217,7 +1208,6 @@ Settings:
     Unlock: Entsperren
     Unlocking: Wird entsperrt…
   Password Settings:
-    Password: Passwort
     Remove Password: Passwort entfernen
     Password Settings: Passwort
     Set Password To Prevent Access: Passwort festlegen, um den Zugriff auf die Einstellungen zu verhindern
@@ -1285,9 +1275,7 @@ Settings:
     Forget Channel: Alle Einstellungen für diesen Kanal vergessen
     Forget Value: Diese Einstellung vergessen
     Add Setting: Eine weitere Einstellung für diesen Kanal speichern
-    Playback Speed: Wiedergabegeschwindigkeit
     Video Quality: Videoqualität
-    Subtitles State: Untertitel
     Subtitles Enabled: Untertitel aktiviert
     Volume: Lautstärke
   Sync Settings:
@@ -1310,7 +1298,6 @@ Settings:
     Checking Server: Synchronisierungsserver wird überprüft…
     Server Unavailable: Verbindung zu diesem Synchronisierungsserver fehlgeschlagen. Überprüfe die URL und versuche es erneut.
     Username: Benutzername
-    Password: Passwort
     Log In: Anmelden
     Register: Registrieren
     Pair Another Device: Weiteres Gerät koppeln
@@ -1368,7 +1355,6 @@ Settings:
     Automatic Sync: Nach Änderungen und alle fünf Minuten automatisch synchronisieren
     Profiles: Profile
     Open Tabs: Offene Tabs und Sitzung
-    Settings: Einstellungen
     Disable Setting Sync: Synchronisierung dieser Einstellung beenden
     Enable Setting Sync: Diese Einstellung synchronisieren
     Sync Now: Jetzt synchronisieren
@@ -1497,7 +1483,6 @@ Video:
     Title: Transkript
     Search: Transkript durchsuchen
     Language: Transkriptsprache
-    Copy: Kopieren
     Save: Speichern
     Show: Transkript anzeigen
     Hide: Transkript ausblenden
@@ -1597,7 +1582,6 @@ Video:
   Player:
     Caption Appearance:
       Options: Optionen
-      Title: Untertiteldarstellung
       Sample: So sehen Untertitel aus
     Sleep Timer:
       Sleep Timer: Einschlaftimer
@@ -1644,9 +1628,7 @@ Video:
       ClearSegmentsPrompt: Bist du sicher, dass du alle entworfenen SponsorBlock-Segmente für dieses Video löschen möchtest?
       CompleteSegmentsBeforeSubmitting: Vervollständige jedes entworfene Segment, bevor du es absendest.
       CategoryLabel: Kategorie
-      DeleteSegment: Löschen
       DuplicateSegments: Doppelte entworfene Segmente sind nicht erlaubt.
-      EditSegment: Bearbeiten
       EndAction: (Ende)
       EndActionLabel: Ende
       EndTimeAfterStart: Die Endzeit des Segments muss nach der Startzeit liegen.
@@ -1684,7 +1666,6 @@ Video:
       SkipToastReskip: Nochmal überspringen
       SkipPrompt: '{segmentCategory} überspringen?'
       SkipPromptAction: Überspringen
-      InfoPanelTitle: SponsorBlock
       InfoPanelLoading: Segmente werden noch geladen...
       InfoPanelHasSegments: 'Dieses Video hat Segmente in der Datenbank!'
       InfoPanelNoSegments: Keine Segmente gefunden
@@ -1727,13 +1708,11 @@ Video:
     Scroll Mini Player:
       Back to Top: Zurück nach oben
       Return to Video Tab: Zum Video-Tab zurückkehren
-      Volume: Lautstärke
       Play: Abspielen
       Pause: Pausieren
       Drag Handle: Mini-Player verschieben
     MusicPlaybackRateOverride: Musikvideo erkannt, wird mit 1-facher Geschwindigkeit wiedergegeben
     Voice-over Translation:
-      Voice-over Translation: Voice-over-Übersetzung
       Start: Übersetzen
       Cancel: Abbrechen
       Progress: Voice-over-Übersetzung wird vorbereitet…
@@ -1792,7 +1771,6 @@ Video:
   Metadata: Videoinformationen
   Close Metadata: Videoinformationen schließen
   Metadata Cache:
-    History: Metadatenverlauf
     Title History: Titelverlauf
     Thumbnail History: Vorschaubildverlauf
     Description History: Beschreibungsverlauf
@@ -1863,9 +1841,6 @@ Change Format:
   Playback Engine: Wiedergabe-Engine
   Streaming Protocol: Streamingprotokoll
   Not Available For This Video: Für dieses Video nicht verfügbar
-  Engines:
-    Built-in: Integriert
-    yt-dlp: yt-dlp
   Protocols:
     Progressive: Progressiv
   Descriptions:
@@ -1931,7 +1906,6 @@ Comments:
   Hide {replyCount} replies: 1 Antwort ausblenden | {replyCount} Antworten ausblenden
   View 1 reply from {channelName}: 1 Antwort von {channelName} ansehen
   View {replyCount} replies from {channelName} and others: '{replyCount} Antworten von {channelName} und anderen ansehen'
-  Copy YouTube Link: YouTube-Link kopieren
   Reload Comments: Kommentare neu laden
   YouTube comment link copied to clipboard: YouTube Kommentar-Link in die Zwischenablage kopiert
   Comment Count: 1 Kommentar | {count} Kommentare
@@ -2246,7 +2220,6 @@ KeyboardShortcutPrompt:
   Shortcut Conflict: '{shortcut} ist bereits für {actions} belegt. Möchtest du die Tastenkombination neu zuweisen?'
   Reserved Shortcut Conflict: '{shortcut} ist für {actions} reserviert und kann nicht neu zugewiesen werden.'
   Reassign: Neu zuweisen
-  Undo: Rückgängig
   Sections:
     Video:
       Playback: 'Video: Wiedergabe'
@@ -2260,7 +2233,6 @@ KeyboardShortcutPrompt:
   History Backward: Eine Seite zurückgehen
   New Window: Ein neues Fenster öffnen
   Navigate to Settings: Zur Einstellungsseite navigieren
-  Navigate to Downloads: Downloads öffnen
   Navigate to History: Zur Verlaufsseite navigieren
   Stats: Video-Statistiken anzeigen
   Fullscreen: Vollbildmodus umschalten
@@ -2333,9 +2305,6 @@ Close find bar: Suchleiste schließen
 No matches: Keine Treffer
 Context Menu:
   Context Menu: Kontextmenü
-  Cut: Ausschneiden
-  Copy: Kopieren
-  Paste: Einfügen
   Select All: Alles auswählen
   Save Image As…: Bild speichern unter…
   Copy Image: Bild kopieren
@@ -2345,7 +2314,6 @@ Context Menu:
   Reload Live: Live neu laden
   Reload Posts: Beiträge neu laden
   Reload All Feeds: Alle Feeds neu laden
-  Close Tab: Tab schließen
   Close Multiple Tabs: '{count} Tabs schließen'
   Duplicate Tab: Tab duplizieren
   Duplicate Multiple Tabs: '{count} Tabs duplizieren'
@@ -2354,7 +2322,6 @@ Context Menu:
   Move Tab to Group: Tab in Gruppe verschieben
   Collapse Group: Gruppe einklappen
   Move Tabs to Group: Tabs in Gruppe verschieben
-  Ungrouped: Ohne Gruppe
   Manage Tab Groups…: Tab-Gruppen verwalten …
   To Beginning: An den Anfang
   To End: Ans Ende
@@ -2372,14 +2339,7 @@ Context Menu:
   Unpin Tabs: Tabs lösen
   Tab Color: Tab-Farbe
   Default: Standard
-  Red: Rot
-  Orange: Orange
-  Yellow: Gelb
-  Green: Grün
-  Blue: Blau
   Purple: Violett
-  New Tab: Neuer Tab
-  New Window: Neues Fenster
   Reopen Closed Tab: Geschlossenen Tab wieder öffnen
   Reload Tab: Tab neu laden
   Reload Tabs: Tabs neu laden
@@ -2402,7 +2362,6 @@ Context Menu:
 Tab Organizer:
   Title: Tab-Organizer
   Open Tab Count: '{count} offener Tab | {count} offene Tabs'
-  Search Placeholder: Tabs durchsuchen
   Search Label: Tabs durchsuchen
   Selected Count: '{count} Tab ausgewählt | {count} Tabs ausgewählt'
   Tab Count: '{count} Tab | {count} Tabs'
@@ -2416,7 +2375,6 @@ Tab Organizer:
   Load: Laden
   Unload: Entladen
   Unload All: Alle entladen
-  Close: Schließen
   Close All: Alle schließen
   Ungroup: Gruppierung aufheben
   Group Name: Gruppenname
@@ -2439,7 +2397,6 @@ Tab Organizer:
   No Open Results: Keine offenen Tabs entsprechen der Suche.
   Recently Closed: Kürzlich geschlossen
   Clear: Leeren
-  Restore: Wiederherstellen
   No Closed Results: Keine kürzlich geschlossenen Tabs entsprechen der Suche.
   Drag Tab: Ziehen, um den Tab in eine Gruppe zu verschieben
 
@@ -2491,7 +2448,6 @@ CommandPalette:
   Keys:
     Up: ↑
     Down: ↓
-    Enter: Enter
     Escape: Esc
   Switch to Tab: 'Zum Tab wechseln: {title}'
   Switch Profile: 'Profil wechseln: {name}'
@@ -2500,12 +2456,7 @@ CommandPalette:
   Groups:
     App: Anwendung
     Navigation: Navigation
-    Settings: Einstellungen
     Tabs: Tabs
-    Profiles: Profile
-    Playlists: Playlists
-    Downloads: Downloads
-    Playback: Wiedergabe
   Unavailable:
     Current Page: Du bist bereits auf dieser Seite
     No History: Keine Seite in dieser Richtung
@@ -2550,9 +2501,7 @@ Downloads:
     Video Resolution: Video - {resolution}
     Audio Best: Audio - Beste Qualität
     Audio Format: Audio - {format}
-    Custom Arguments: Benutzerdefinierte yt-dlp-Argumente
     Subtitles Format: Untertitel – {format}
-  Downloads: Downloads
   Download Playlist: Wiedergabeliste herunterladen
   Downloading: Wird heruntergeladen
   Queue: Warteschlange
@@ -2592,7 +2541,6 @@ Downloads:
   Media Type: Medientyp
   Video: Video
   Audio: Audio
-  Subtitles: Untertitel
   Maximum Resolution: Maximale Auflösung
   Best Available: Beste verfügbare
   Automatic: Automatisch
@@ -2606,7 +2554,6 @@ Downloads:
   End Time: Endzeit (HH:MM:SS)
   Split by Chapters: Nach Kapiteln in separate Dateien aufteilen
   Remove Segments: Segmente entfernen
-  SponsorBlock: SponsorBlock
   Subtitles and Metadata: Untertitel und Metadaten
   Include Subtitles: Untertitel einbeziehen
   Embed Subtitles: Untertitel in die Mediendatei einbetten

--- a/static/locales/en-US.yaml
+++ b/static/locales/en-US.yaml
@@ -413,9 +413,7 @@ Settings:
     Appearance Description: Theme, layout, and thumbnails
     Content appearance: Video lists and thumbnails
     Layout: Layout
-    Playback: Playback
     Playback Description: Player, captions, and channel preferences
-    Subscriptions: Subscriptions
     Subscriptions Description: Feed refresh and display options
     Downloads Description: Folders, templates, and automatic rules
     Distraction Free Description: Hide content and set viewing limits
@@ -513,8 +511,6 @@ Settings:
       List: List
     Playlist View Type:
       Playlist View Type: Playlist View Type
-      Grid: Grid
-      List: List
     Thumbnail Preference:
       Thumbnail Preference: Thumbnail Preference
       Default: Default
@@ -638,7 +634,6 @@ Settings:
       Edit Custom Theme: Edit custom theme
       Custom Theme Creator: Custom theme creator
       Theme Name: Theme name
-      Is Dark Theme: Dark theme
       Based On: Based on
       Import Theme: Import theme
       Export Theme: Export theme
@@ -957,9 +952,7 @@ Settings:
     Forget Channel: Forget all settings for this channel
     Forget Value: Forget this setting
     Add Setting: Remember another setting for this channel
-    Playback Speed: Playback Speed
     Video Quality: Video Quality
-    Subtitles State: Subtitles
     Subtitles Enabled: Subtitles Enabled
     Volume: Volume
   External Player Settings:
@@ -1000,9 +993,7 @@ Settings:
     Automatic Downloads Description: Select a download template and filters for each subscribed channel. Matching videos download in the background when subscription feeds refresh.
     Automatic Downloads New Only: Enabling a channel starts with its next new upload. Existing videos and the channel backlog are not downloaded.
     Automatic Downloads No Channels: Subscribe to a channel before configuring automatic downloads.
-    Search Automatic Download Channels: Search channels
     No Matching Automatic Download Channels: No channels match your search.
-    Automatic Downloads Videos: Videos
     Automatic Downloads Livestreams: Livestreams
     Minimum Duration Seconds: Minimum duration (seconds)
     Maximum Duration Seconds: Maximum duration (seconds)
@@ -1121,7 +1112,6 @@ Settings:
     Not Available: Exact size unavailable
     At Least: 'At least {size}'
     Failed To Read Storage: Some storage sizes could not be read
-    Downloads: Downloads
     Downloaded Media Description: Video, audio, and subtitle files that download history still tracks.
     Selected Download Folders: User-selected download folders
     Download History Records: Download history records
@@ -1187,7 +1177,6 @@ Settings:
     Subscriptions And Profiles: Subscriptions and profiles
     Subscriptions And Profiles Description: Stores subscribed channels, profile names, and profile membership.
     Subscriptions And Profiles Effect: All subscriptions and extra profiles will be deleted permanently. Feed cache data will also be cleared.
-    Playlists: Playlists
     Playlists Description: Stores playlist names, descriptions, and saved videos.
     Playlists Effect: Every playlist and its saved-video list will be deleted permanently. Downloaded media files will remain.
     Settings And Sessions: Settings, tab sessions, and reminders
@@ -1349,7 +1338,6 @@ Settings:
     Checking Server: Checking sync server…
     Server Unavailable: Unable to connect to this sync server. Check the URL and try again.
     Username: Username
-    Password: Password
     Log In: Log in
     Register: Register
     Pair Another Device: Pair another device
@@ -1405,7 +1393,6 @@ Settings:
     Automatic Sync: Sync automatically after changes and every five minutes
     Profiles: Profiles
     Open Tabs: Open tabs and session
-    Settings: Settings
     Disable Setting Sync: Stop syncing this setting
     Enable Setting Sync: Sync this setting
     Sync Now: Sync now
@@ -1500,7 +1487,6 @@ Settings:
   No Settings Found: No settings found
   Password Settings:
     Password Settings: Password
-    Password: Password
     Set Password To Prevent Access: Set a password to prevent access to settings
     Set Password: Set Password
     Remove Password: Remove Password
@@ -1712,7 +1698,6 @@ Video:
   Metadata: Video information
   Close Metadata: Close video information
   Metadata Cache:
-    History: Metadata history
     Title History: Title history
     Thumbnail History: Thumbnail history
     Description History: Description history
@@ -1723,7 +1708,6 @@ Video:
     Title: Transcript
     Search: Search transcript
     Language: Transcript language
-    Copy: Copy
     Save: Save
     Show: Show transcript
     Hide: Hide transcript
@@ -1881,7 +1865,6 @@ Video:
       looping playlists: looping playlists
   Player:
     Voice-over Translation:
-      Voice-over Translation: Voice-over translation
       Start: Translate
       Cancel: Cancel
       Progress: Preparing voice-over translation…
@@ -1890,7 +1873,6 @@ Video:
       Duration Error: Voice-over translation is only available for videos up to four hours long.
     Caption Appearance:
       Options: Options
-      Title: Caption Appearance
       Sample: Captions look like this
     Auto-translate: Auto-translate
     Sleep Timer:
@@ -1945,7 +1927,6 @@ Video:
     Scroll Mini Player:
       Back to Top: Back to top
       Return to Video Tab: Return to video tab
-      Volume: Volume
       Play: Play
       Pause: Pause
       Drag Handle: Move mini player
@@ -1957,9 +1938,7 @@ Video:
       CompleteSegmentsBeforeSubmitting: Complete every drafted segment before submitting.
       CategoryLabel: Category
       ActionTypeLabel: Segment type
-      DeleteSegment: Delete
       DuplicateSegments: Duplicate drafted segments are not allowed.
-      EditSegment: Edit
       EndAction: (End)
       EndActionLabel: End
       EndTimeAfterStart: The segment end time must be after the start time.
@@ -1999,7 +1978,6 @@ Video:
       SkipToastReskip: Reskip
       MutedSegment: '{segmentCategory} Muted'
       MuteToastUnmute: Unmute
-      InfoPanelTitle: SponsorBlock
       InfoPanelLoading: Segments still loading...
       InfoPanelHasSegments: 'This video has segments in the database!'
       InfoPanelNoSegments: No segments found
@@ -2075,9 +2053,6 @@ Change Format:
   Playback Engine: Playback engine
   Streaming Protocol: Streaming protocol
   Not Available For This Video: Not available for this video
-  Engines:
-    Built-in: Built-in
-    yt-dlp: yt-dlp
   Protocols:
     Progressive: Progressive
   Descriptions:
@@ -2116,9 +2091,6 @@ Clipboard:
 
 Context Menu:
   Context Menu: Context menu
-  Cut: Cut
-  Copy: Copy
-  Paste: Paste
   Select All: Select All
   Save Image As…: Save Image As…
   Copy Image: Copy Image
@@ -2129,7 +2101,6 @@ Context Menu:
   Reload Live: Reload Live
   Reload Posts: Reload Posts
   Reload All Feeds: Reload All Feeds
-  Close Tab: Close Tab
   Close Multiple Tabs: Close {count} Tabs
   Duplicate Tab: Duplicate Tab
   Duplicate Multiple Tabs: Duplicate {count} Tabs
@@ -2138,7 +2109,6 @@ Context Menu:
   Move Tab to Group: Move Tab to Group
   Collapse Group: Collapse Group
   Move Tabs to Group: Move Tabs to Group
-  Ungrouped: Ungrouped
   Manage Tab Groups…: Manage Tab Groups…
   To Beginning: To Beginning
   To End: To End
@@ -2156,14 +2126,7 @@ Context Menu:
   Unpin Tabs: Unpin Tabs
   Tab Color: Tab Color
   Default: Default
-  Red: Red
-  Orange: Orange
-  Yellow: Yellow
-  Green: Green
-  Blue: Blue
   Purple: Purple
-  New Tab: New Tab
-  New Window: New Window
   Reopen Closed Tab: Reopen Closed Tab
   Reload Tab: Reload Tab
   Reload Tabs: Reload Tabs
@@ -2186,7 +2149,6 @@ Context Menu:
 Tab Organizer:
   Title: Tab Organizer
   Open Tab Count: '{count} open tab | {count} open tabs'
-  Search Placeholder: Search tabs
   Search Label: Search tabs
   Selected Count: '{count} tab selected | {count} tabs selected'
   Tab Count: '{count} tab | {count} tabs'
@@ -2200,7 +2162,6 @@ Tab Organizer:
   Load: Load
   Unload: Unload
   Unload All: Unload All
-  Close: Close
   Close All: Close All
   Ungroup: Ungroup
   Group Name: Group name
@@ -2223,7 +2184,6 @@ Tab Organizer:
   No Open Results: No open tabs match this search.
   Recently Closed: Recently Closed
   Clear: Clear
-  Restore: Restore
   No Closed Results: No recently closed tabs match this search.
   Drag Tab: Drag to move to a group
 
@@ -2240,7 +2200,6 @@ Comments:
   Comment Count: 1 Comment | {count} Comments
   Show Comments: Show Comments
   Click to View Comments: Click to View Comments
-  Copy YouTube Link: Copy YouTube Link
   Getting comment replies, please wait: Getting comment replies, please wait
   There are no more comments for this video: There are no more comments for this video
   Hide Comments: Hide Comments
@@ -2505,7 +2464,6 @@ KeyboardShortcutPrompt:
   Shortcut Conflict: '{shortcut} is already assigned to {actions}. Do you want to reassign it?'
   Reserved Shortcut Conflict: '{shortcut} is reserved for {actions} and cannot be reassigned.'
   Reassign: Reassign
-  Undo: Undo
   Sections:
     Video:
       Playback: Video: Playback
@@ -2528,7 +2486,6 @@ KeyboardShortcutPrompt:
   Switch to Tab: Switch to tab 1–9
   Toggle Tab Orientation: Switch between tab layouts
   Navigate to Settings: Navigate to the Settings page
-  Navigate to Downloads: Open Downloads
   Navigate to History: Navigate to the History page
   Refresh: Refresh feed with latest content
   Find in Page: Find text on the current page
@@ -2586,7 +2543,6 @@ CommandPalette:
   Keys:
     Up: ↑
     Down: ↓
-    Enter: Enter
     Escape: Esc
   Switch to Tab: 'Switch to tab: {title}'
   Switch Profile: 'Switch profile: {name}'
@@ -2595,12 +2551,7 @@ CommandPalette:
   Groups:
     App: App
     Navigation: Navigation
-    Settings: Settings
     Tabs: Tabs
-    Profiles: Profiles
-    Playlists: Playlists
-    Downloads: Downloads
-    Playback: Playback
   Unavailable:
     Current Page: Already on this page
     No History: No page in this direction
@@ -2612,7 +2563,6 @@ CommandPalette:
     Download Finished: This download is no longer running
     Video: Open a video first
 Downloads:
-  Downloads: Downloads
   Download: Download
   Download Video: Download Video
   Download Playlist: Download Playlist
@@ -2653,7 +2603,6 @@ Downloads:
   Media Type: Media Type
   Video: Video
   Audio: Audio
-  Subtitles: Subtitles
   Maximum Resolution: Maximum Resolution
   Best Available: Best Available
   Automatic: Automatic
@@ -2667,7 +2616,6 @@ Downloads:
   End Time: End Time (HH:MM:SS)
   Split by Chapters: Split into separate files by chapter
   Remove Segments: Remove segments
-  SponsorBlock: SponsorBlock
   Subtitles and Metadata: Subtitles and Metadata
   Include Subtitles: Include subtitles
   Embed Subtitles: Embed subtitles in the media file
@@ -2717,4 +2665,3 @@ Downloads:
     Audio Best: Audio - Best Quality
     Audio Format: Audio - {format}
     Subtitles Format: Subtitles - {format}
-    Custom Arguments: Custom yt-dlp Arguments

--- a/tests/unit/settings-search-config.test.mjs
+++ b/tests/unit/settings-search-config.test.mjs
@@ -79,8 +79,8 @@ test('settings search excludes values that only exist in hidden controls', () =>
     SETTINGS_SEARCH_SELECT_GROUP_LABELS.player['Auto Picture in Picture'],
     ['Auto Picture in Picture']
   )
-  assert.ok(SETTINGS_SEARCH_EXCLUDED_MESSAGE_PATHS.password.has('Password'))
-  assert.equal(typeof getAtPath(locale, 'Settings.Password Settings.Password'), 'string')
+  assert.equal(getAtPath(locale, 'Settings.Password Settings.Password'), undefined)
+  assert.equal(typeof getAtPath(locale, 'Settings.Password Dialog.Password'), 'string')
   assert.ok(
     SETTINGS_SEARCH_EXCLUDED_MESSAGE_PATHS['sponsor-block']
       .has('Generated SponsorBlock User ID Copy Button')


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Make sure to follow the contributing guidelines. -->
<!-- Important note, we may remove your pull request if you do not use this provided PR template correctly. -->
<!-- Agent instructions: Preserve every heading, comment, and marker in this template. Never remove or rewrite the release-note-category:start/end, release-note:start/end, or release-note-image:start/end marker pairs. -->

## Pull Request Type
<!-- Please select what type of pull request this is: [x] -->
- [ ] Bugfix
- [ ] Feature Implementation
- [ ] Documentation
- [x] Other

## Related issue
<!-- Please link the issue your pull request is referring to. -->
<!-- If this pull request fully resolves the relevant issue, put "closes" before the issue number. -->
<!-- Example: "closes #123456". -->

## Description
<!-- Please write a clear and concise description of what the pull request does. -->
The English and German locale files contained many keys with identical labels, while their call sites treated each copy as a separate translation.

This consolidates 52 duplicate leaf keys in each locale and points the affected settings, downloads, player, command palette, tab organizer, and native context-menu labels at their existing shared translations. The consolidation was checked across every shipped locale. Keys remain separate when another locale uses different wording or lacks the shared key.

## Release note category
<!-- Select exactly one category. Every pull request must select one. -->
<!-- Select "Not noteworthy" when the pull request fixes a bug in or improves functionality that has not yet appeared in a stable release. -->
<!-- release-note-category:start -->
- [x] Not noteworthy
- [ ] Highlights
- [ ] More improvements
- [ ] Fixed bugs
<!-- release-note-category:end -->

## Release note
<!-- Required unless "Not noteworthy" is selected. -->
<!-- Write one concise, user-facing entry without a leading bullet. -->
<!-- release-note:start -->

<!-- release-note:end -->

## Release note images
<!-- Optional. Paste one or more Markdown images, HTML image tags, or dark/light <picture> elements here. -->
<!-- The release notes normalize the markup and limit images taller than 300 pixels. -->
<!-- Agent instructions:
For a noteworthy visible change, add media when it makes the change easier to understand. Prefer a still image unless motion is the point; recordings must use animated WebP.
After implementing a visible change, proactively capture the result and show the local media to the user for approval before uploading it or updating the pull request.
When the affected UI differs between dark and light themes, capturing both themes is required. A dark-only image is incomplete. Run `node _scripts/releaseNoteMedia.mjs --dark DARK_FILE --light LIGHT_FILE --alt "DESCRIPTION"`; GitHub will display the matching theme and use dark as the fallback. Use a single default-dark capture only when the light theme cannot be captured or looks identical.
Capture or crop to the smallest region that still makes the change clear. Do not include the full window when the affected component can be understood on its own.
Use English unless localization is the subject. Keep components at their normal dimensions and placement instead of resizing them to fill the frame.
Use deterministic local fixtures for visible remote images. Reusable avatar and thumbnail fixtures are available through `e2e/helpers/visual-fixtures.mjs`. Before capturing, verify that every visible image has loaded successfully (`complete === true` and `naturalWidth > 0`).
Inspect the final dark and light files for failed images, missing content, unrelated UI, awkward animation, and misleading layout. Omit media when it does not explain the change clearly.
For one dark capture, run `node _scripts/releaseNoteMedia.mjs FILE --alt "DESCRIPTION"`.
Check for personal information, tokens, private repository names, and unrelated desktop content before uploading. Uploaded media is public.
Keep capture-only scripts, test hooks, screenshots, and recordings out of commits. Remove them before committing unless the capture code is also a reusable regression test. Never commit generated release-note media.
Paste only the generated markup between the marker comments. Leave this section empty when media would not help.
-->
<!-- release-note-image:start -->

<!-- release-note-image:end -->

## Testing
<!-- How can reviewers verify that the PR produces correct results? -->
<!-- Please provide instructions so that others can ensure that your pull request would produce correct results. For examples see, https://github.com/FreeTubeApp/FreeTube/pull/5743, https://github.com/FreeTubeApp/FreeTube/pull/7349, https://github.com/FreeTubeApp/FreeTube/pull/5125, https://github.com/FreeTubeApp/FreeTube/pull/7338 -->
<!-- Agent instructions: Only write human-facing steps that explain how to verify the change while running this branch in dev mode. Include expected results and, when applicable, helpful console snippets for interactive verification. Do not include automated checks, commands, results, pass counts, or CI status. -->
1. Run the app in English and open Settings, Downloads, the command palette, the tab organizer, and a video player.
2. Check the affected labels, including playback, subscriptions, passwords, download types, captions, SponsorBlock, and tab actions. They should render normally without showing translation paths.
3. Repeat in German and confirm the labels retain their existing wording.

## Additional context
<!-- Add any other context about the pull request here. -->
Other locale files remain unchanged because Weblate manages those translations. The cross-locale audit required each replacement key to exist with the same value anywhere the removed key was translated.
