### PR TITLE
feat(tabs): improve organizer layout, selection, and unloading

### DIFF
--- a/e2e/tests/offline/tabs.spec.mjs
+++ b/e2e/tests/offline/tabs.spec.mjs
@@ -1228,6 +1228,8 @@ test.describe('tab bar', () => {
     await expect(collapsedGroup).toHaveCount(1)
     await expect(collapsedGroup).toHaveClass(/active/)
     await expect(collapsedGroup).toHaveAttribute('title', 'Expand Research, 2 tabs')
+    await expect(collapsedGroup.locator('.collapsedTabGroupName')).toHaveText('Research')
+    await expect(collapsedGroup.locator('[data-icon="layer-group"]')).toBeVisible()
     await expect.poll(() => page.evaluate(async (groupId) => {
       return (await window.ftElectron.tabs.getState()).groups.find(group => group.id === groupId)?.isCollapsed
     }, setup.groupId)).toBe(true)

--- a/e2e/tests/offline/tabs.spec.mjs
+++ b/e2e/tests/offline/tabs.spec.mjs
@@ -604,6 +604,36 @@ test.describe('tab bar', () => {
     await expect(page.locator(`${sel.tabs}.unloaded`)).toHaveCount(5)
   })
 
+  test('unloads an active selected tab from the tab context menu', async ({ page }) => {
+    await page.locator(sel.newTabButton).click()
+    await page.locator(sel.newTabButton).click()
+    const tabs = page.locator(sel.tabs)
+    await expect(tabs).toHaveCount(3)
+
+    await tabs.first().click()
+    const initialState = await page.evaluate(() => window.ftElectron.tabs.getState())
+    const selectedTabIds = initialState.tabs.slice(0, 2).map(tab => tab.id)
+    const survivingTabId = initialState.tabs[2].id
+    await expect.poll(() => page.evaluate(tabId => {
+      return window.ftElectron.tabs.getState().then(state => state.presentedTabId === tabId)
+    }, selectedTabIds[0])).toBe(true)
+
+    await tabs.nth(1).click({ modifiers: ['Control'] })
+    await tabs.nth(1).click({ button: 'right' })
+    await page.getByRole('menuitem', { name: 'Unload Tabs', exact: true }).click()
+
+    await expect.poll(() => page.evaluate(async selectedTabIds => {
+      const state = await window.ftElectron.tabs.getState()
+      return {
+        activeTabId: state.activeTabId,
+        unloaded: selectedTabIds.map(tabId => state.tabs.find(tab => tab.id === tabId)?.isUnloaded)
+      }
+    }, selectedTabIds), { timeout: 2_000 }).toEqual({
+      activeTabId: survivingTabId,
+      unloaded: [true, true]
+    })
+  })
+
   test('does not confirm when closing fewer tabs than the threshold', async ({ page }) => {
     await page.locator(sel.newTabButton).click()
     await page.locator(sel.newTabButton).click()
@@ -2099,6 +2129,79 @@ test.describe('background tab shortcuts', () => {
 })
 
 test.describe('tab organizer', () => {
+  test('selects a visible range with Shift-click', async ({ page }) => {
+    await page.evaluate(async () => {
+      for (let index = 1; index <= 3; index++) {
+        if (index === 2) {
+          await window.ftElectron.tabs.create({
+            route: '/history?range=hidden',
+            title: 'Hidden gap tab',
+            makeActive: false,
+            lazyLoad: true
+          })
+        }
+        await window.ftElectron.tabs.create({
+          route: `/history?range=${index}`,
+          title: `Range tab ${index}`,
+          makeActive: false,
+          lazyLoad: true
+        })
+      }
+    })
+
+    await page.locator(sel.tabOrganizerButton).click()
+    const organizer = page.getByRole('dialog', { name: 'Tab Organizer' })
+    await organizer.getByRole('searchbox', { name: 'Search tabs' }).fill('Range tab')
+    const rangeRows = organizer.locator('.tabOrganizerRow').filter({ hasText: 'Range tab' })
+    await expect(rangeRows).toHaveCount(3)
+
+    await rangeRows.first().locator('.tabSelection label').click()
+    await rangeRows.last().locator('.tabSelection label').click({ modifiers: ['Shift'] })
+
+    await expect(rangeRows.locator('input[type="checkbox"]:checked')).toHaveCount(3)
+    await expect(rangeRows.last().getByRole('checkbox')).toBeFocused()
+    await expect(organizer.getByText('3 tabs selected', { exact: true })).toBeVisible()
+    await expect(organizer.locator('.tabOrganizerRow').filter({ hasNotText: 'Range tab' })
+      .locator('input[type="checkbox"]:checked')).toHaveCount(0)
+  })
+
+  test('unloads an active tab as part of a group bulk action', async ({ page }) => {
+    const groupedTabIds = await page.evaluate(async () => {
+      const backgroundTab = await window.ftElectron.tabs.create({
+        route: '/history',
+        title: 'Bulk background tab',
+        makeActive: false,
+        lazyLoad: false
+      })
+      const activeTab = await window.ftElectron.tabs.create({
+        route: '/subscriptions',
+        title: 'Bulk active tab',
+        makeActive: true,
+        lazyLoad: false
+      })
+      const group = await window.ftElectron.tabs.createGroup({ name: 'Bulk unload group' })
+      await window.ftElectron.tabs.setGroup([backgroundTab.id, activeTab.id], group.id)
+      return [backgroundTab.id, activeTab.id]
+    })
+
+    await page.locator(sel.tabOrganizerButton).click()
+    const group = page.getByRole('dialog', { name: 'Tab Organizer' })
+      .locator('.tabGroup')
+      .filter({ hasText: 'Bulk unload group' })
+    await group.getByRole('button', { name: 'Unload All' }).click()
+
+    await expect.poll(() => page.evaluate(async tabIds => {
+      const state = await window.ftElectron.tabs.getState()
+      return {
+        activeTabIsOutsideGroup: !tabIds.includes(state.activeTabId),
+        unloaded: tabIds.map(tabId => state.tabs.find(tab => tab.id === tabId)?.isUnloaded)
+      }
+    }, groupedTabIds), { timeout: 2_000 }).toEqual({
+      activeTabIsOutsideGroup: true,
+      unloaded: [true, true]
+    })
+  })
+
   test('clamps its scroll position after collapsing and filtering at fractional UI scale', async ({ page }) => {
     await page.setViewportSize({ width: 1280, height: 800 })
     await page.evaluate(() => window.ftElectron.setZoomFactor(0.95))
@@ -2278,7 +2381,7 @@ test.describe('tab organizer', () => {
     await researchGroup.getByRole('option', { name: 'Blue', exact: true }).click()
     await expect(researchGroup.getByRole('button', { name: 'Collapse group' }).locator('svg')).toBeVisible()
     await expect(researchGroup.getByRole('button', { name: 'Activate First' })).toHaveCount(0)
-    await expect(researchGroup.getByRole('button', { name: 'Unload All' })).toBeVisible()
+    await expect(researchGroup.getByRole('button', { name: 'Unload All' })).toBeDisabled()
     await expect(researchGroup.getByRole('button', { name: 'Close All' })).toBeVisible()
     await expect(researchGroup.getByRole('button', { name: 'Ungroup' }).locator('[data-icon="link-slash"]')).toBeVisible()
     await expect(researchGroup.locator('.tabOrganizerRow')).toContainText('Alpha video')
@@ -2377,6 +2480,50 @@ test.describe('tab organizer', () => {
     await expect(reopenedGroup.locator('.tabOrganizerRow')).toContainText('Alpha video')
     await expect(reopenedGroup.getByRole('button', { name: 'Expand group' }))
       .toHaveAttribute('aria-expanded', 'true')
+  })
+
+  test('lays out vertical tab actions and organizer tab metadata', async ({ page }) => {
+    await page.evaluate(async () => {
+      const store = document.querySelector('#app').__vue_app__.config.globalProperties.$store
+      store.commit('setTabBarPosition', 'left')
+      await window.ftElectron.setZoomFactor(0.95)
+      const tab = await window.ftElectron.tabs.create({
+        route: '/history',
+        title: 'History entry - OpenTubeX',
+        makeActive: false,
+        lazyLoad: true
+      })
+      await window.ftElectron.tabs.createGroup({ name: 'Unloaded group' })
+        .then(group => window.ftElectron.tabs.setGroup([tab.id], group.id))
+    })
+
+    await expect(page.locator('.app')).toHaveClass(/verticalTabsLeft/)
+    const organizerButton = page.locator(sel.tabOrganizerButton)
+    const newTabButton = page.locator(sel.newTabButton)
+    const [organizerButtonBox, newTabButtonBox] = await Promise.all([
+      organizerButton.boundingBox(),
+      newTabButton.boundingBox()
+    ])
+    expect(Math.abs(organizerButtonBox.y - newTabButtonBox.y)).toBeLessThanOrEqual(1)
+    expect(newTabButtonBox.x).toBeGreaterThanOrEqual(organizerButtonBox.x + organizerButtonBox.width)
+
+    await organizerButton.click()
+    const organizer = page.getByRole('dialog', { name: 'Tab Organizer' })
+    const group = organizer.locator('.tabGroup').filter({ hasText: 'Unloaded group' })
+    const row = group.locator('.tabOrganizerRow')
+    await expect(row.locator('.tabIdentity > span')).toHaveText('History entry')
+    await expect(row).not.toContainText(' - OpenTubeX')
+    await expect(row.locator('.tabIcon [data-icon="clock-rotate-left"]')).toBeVisible()
+    await expect(group.getByRole('button', { name: 'Unload All' })).toBeDisabled()
+
+    const [iconBox, titleBox, urlBox] = await Promise.all([
+      row.locator('.tabIcon').boundingBox(),
+      row.locator('.tabIdentity > span').boundingBox(),
+      row.locator('.tabIdentity > small').boundingBox()
+    ])
+    expect(Math.abs(
+      iconBox.y + iconBox.height / 2 - (titleBox.y + urlBox.y + urlBox.height) / 2
+    )).toBeLessThanOrEqual(1)
   })
 })
 

--- a/src/main/tabs/TabManager.js
+++ b/src/main/tabs/TabManager.js
@@ -2524,22 +2524,27 @@ export class TabManager {
         console.error('Failed to refresh preview before unloading tab:', error)
       })
 
-      const nextTabId = this.activeTabId !== tabId && this.tabs.has(this.activeTabId)
-        ? this.activeTabId
-        : this._getNeighborTabId(tabId, true)
-      if (nextTabId) {
-        this._deferredUnloadTabIds.add(tabId)
-        this.bridge.send(IpcChannels.TABS_EXIT_FULLSCREEN, tabId)
-        if (this.activeTabId === tabId) {
-          this.activeTabId = null
-          if (this._prepareNeighborActivation(nextTabId)) {
-            this.activateTab(nextTabId)
+      // A bulk unload may have already activated and presented the replacement
+      // while the preview refresh was in flight. Only defer when this tab is
+      // still presented, otherwise no later presentation event would finalize it.
+      if (tab.id === this.presentedTabId) {
+        const nextTabId = this.activeTabId !== tabId && this.tabs.has(this.activeTabId)
+          ? this.activeTabId
+          : this._getNeighborTabId(tabId, true)
+        if (nextTabId) {
+          this._deferredUnloadTabIds.add(tabId)
+          this.bridge.send(IpcChannels.TABS_EXIT_FULLSCREEN, tabId)
+          if (this.activeTabId === tabId) {
+            this.activeTabId = null
+            if (this._prepareNeighborActivation(nextTabId)) {
+              this.activateTab(nextTabId)
+            }
           }
+          this._saveSession()
+          return true
         }
-        this._saveSession()
         return true
       }
-      return true
     }
 
     if (tab.id === this.presentedTabId) {

--- a/src/renderer/App.vue
+++ b/src/renderer/App.vue
@@ -265,14 +265,14 @@
             <img
               v-if="getUsableTabSwitcherPreviewUrl(tab)"
               :src="tabSwitcherPreviewUrls[tab.id]"
-              :alt="`${formatTabSwitcherTitle(tab.title)} preview`"
+              :alt="`${formatTabTitle(tab.title)} preview`"
               draggable="false"
               @error="handleTabSwitcherPreviewError(tab)"
             >
             <img
               v-else-if="!tabSwitcherPreviewPending[tab.id] && getUsableTabSwitcherAvatarUrl(tab)"
               :src="getUsableTabSwitcherAvatarUrl(tab)"
-              :alt="`${formatTabSwitcherTitle(tab.title)} preview`"
+              :alt="`${formatTabTitle(tab.title)} preview`"
               class="tabSwitcherPreviewAvatar"
               draggable="false"
               @error="handleTabSwitcherAvatarError(tab)"
@@ -304,7 +304,7 @@
               aria-hidden="true"
             />
             <span class="tabSwitcherTitleText">
-              {{ formatTabSwitcherTitle(tab.title) }}
+              {{ formatTabTitle(tab.title) }}
             </span>
           </span>
         </button>
@@ -363,6 +363,7 @@ import {
   SUBSCRIPTION_REFRESH_STARTED_EVENT
 } from './helpers/subscriptions'
 import { translateWindowTitle } from './helpers/strings'
+import { formatTabTitle } from './tabs/tabTitle'
 import { normalizeScrollbarThumbWidth } from './constants/scrollbar'
 import { getAppFontFamily } from './helpers/appFont'
 import { getTabAccentColor } from './constants/tabColors'
@@ -2826,19 +2827,6 @@ function cancelTabSwitcher() {
   tabSwitcherPointerActive.value = false
   tabSwitcherPreviewRequestId++
   window.ftElectron.tabs.setPreviewCapturePaused(false)
-}
-
-/**
- * @param {string} title
- * @returns {string}
- */
-function formatTabSwitcherTitle(title) {
-  if (!title) return title
-  const suffix = ` - ${packageDetails.productName}`
-  if (title.endsWith(suffix)) {
-    return title.slice(0, -suffix.length)
-  }
-  return title
 }
 
 /**

--- a/src/renderer/components/TabBar/SortableTab.vue
+++ b/src/renderer/components/TabBar/SortableTab.vue
@@ -139,9 +139,9 @@
 <script setup>
 import { FtIcon } from '@opentubex/icons'
 import { computed, nextTick, onBeforeUnmount, onMounted, ref, useTemplateRef, watch } from 'vue'
-import packageDetails from '@root/package.json'
 import { getTabAccentColor } from '../../constants/tabColors'
 import { getTabAvatarUrl, getTabPageIcon, getTabPreviewFallbackUrl } from '../../tabs/tabPreview'
+import { formatTabTitle } from '../../tabs/tabTitle'
 
 const props = defineProps({
   tab: {
@@ -257,15 +257,7 @@ const tabStyle = computed(() => {
   return style
 })
 
-const displayTitle = computed(() => {
-  const title = props.tab.title
-  if (!title) return title
-  const suffix = ` - ${packageDetails.productName}`
-  if (title.endsWith(suffix)) {
-    return title.slice(0, -suffix.length)
-  }
-  return title
-})
+const displayTitle = computed(() => formatTabTitle(props.tab.title))
 
 const tooltipId = computed(() => `tab-tooltip-${props.tab.id}`)
 const tooltipPreviewAlt = computed(() => `${displayTitle.value} preview`)

--- a/src/renderer/components/TabBar/TabBar.css
+++ b/src/renderer/components/TabBar/TabBar.css
@@ -58,11 +58,14 @@
   box-sizing: border-box;
   display: flex;
   align-items: center;
-  justify-content: center;
-  flex: 0 0 30px;
-  inline-size: 30px;
+  justify-content: flex-start;
+  flex: 0 0 auto;
+  gap: 6px;
+  min-inline-size: var(--fixed-tab-width, 100px);
+  max-inline-size: var(--fixed-tab-width, 200px);
   block-size: 30px;
-  padding: 0;
+  padding-inline: 10px;
+  padding-block: 0;
   border: 1px solid transparent;
   border-block-end: 0;
   border-radius: calc(6px * var(--ui-roundness)) calc(6px * var(--ui-roundness)) 0 0;
@@ -103,6 +106,8 @@
 .collapsedTabGroup.vertical {
   flex-basis: 30px;
   inline-size: calc(100% - 1px);
+  min-inline-size: 0;
+  max-inline-size: none;
   border-block-end: 1px solid transparent;
   border-radius: calc(6px * var(--ui-roundness));
 }
@@ -113,7 +118,18 @@
 }
 
 .collapsedTabGroup svg {
+  flex: 0 0 auto;
   font-size: 12px;
+}
+
+.collapsedTabGroupName {
+  color: var(--primary-text-color);
+  font-size: 12px;
+  line-height: 16px;
+  min-inline-size: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
 }
 
 .tabsScrollbar {

--- a/src/renderer/components/TabBar/TabBar.css
+++ b/src/renderer/components/TabBar/TabBar.css
@@ -179,6 +179,10 @@
   font-size: 12px;
 }
 
+.tabBarActions {
+  display: contents;
+}
+
 /* ===== Bottom layout: fixed row on the bottom edge ===== */
 
 .tabBar.position-bottom {
@@ -250,14 +254,17 @@
 }
 /* stylelint-enable liberty/use-logical-spec */
 
-.tabBar.vertical .newTabButton,
-.tabBar.vertical .tabOrganizerButton {
-  align-self: stretch;
+.tabBar.vertical .tabBarActions {
+  display: flex;
+  flex: 0 0 auto;
+  gap: 2px;
   margin-inline: var(--tab-bar-inline-padding);
-  padding-block-end: 10px;
 }
 
+.tabBar.vertical .newTabButton,
 .tabBar.vertical .tabOrganizerButton {
+  flex: 1;
+  margin: 0;
   padding-block: 6px;
 }
 

--- a/src/renderer/components/TabBar/TabBar.vue
+++ b/src/renderer/components/TabBar/TabBar.vue
@@ -84,29 +84,32 @@
         />
       </div>
     </div>
-    <button
-      class="tabOrganizerButton"
-      :aria-label="t('Tab Organizer.Title')"
-      :title="t('Tab Organizer.Title')"
-      @click="openTabOrganizer"
-    >
-      <FtIcon
-        :icon="['fas', 'layer-group']"
-        class="newTabIcon"
-        aria-hidden="true"
-      />
-    </button>
-    <button
-      class="newTabButton"
-      :aria-label="t('New Tab')"
-      :title="newTabTooltip"
-      @click="createNewTab"
-    >
-      <FtIcon
-        :icon="['fas', 'plus']"
-        class="newTabIcon"
-      />
-    </button>
+    <div class="tabBarActions">
+      <button
+        class="tabOrganizerButton"
+        :aria-label="t('Tab Organizer.Title')"
+        :title="t('Tab Organizer.Title')"
+        @click="openTabOrganizer"
+      >
+        <FtIcon
+          :icon="['fas', 'layer-group']"
+          class="newTabIcon"
+          aria-hidden="true"
+        />
+      </button>
+      <button
+        class="newTabButton"
+        :aria-label="t('New Tab')"
+        :title="newTabTooltip"
+        @click="createNewTab"
+      >
+        <FtIcon
+          :icon="['fas', 'plus']"
+          class="newTabIcon"
+          aria-hidden="true"
+        />
+      </button>
+    </div>
     <div
       v-if="vertical"
       class="tabBarResizeHandle"

--- a/src/renderer/components/TabBar/TabBar.vue
+++ b/src/renderer/components/TabBar/TabBar.vue
@@ -68,6 +68,9 @@
               :icon="['fas', 'layer-group']"
               aria-hidden="true"
             />
+            <span class="collapsedTabGroupName">
+              {{ item.group.name }}
+            </span>
           </button>
         </template>
       </div>

--- a/src/renderer/components/TabOrganizer/TabOrganizer.css
+++ b/src/renderer/components/TabOrganizer/TabOrganizer.css
@@ -415,10 +415,26 @@
   border-radius: calc(8px * var(--ui-roundness));
   display: grid;
   gap: 10px;
-  grid-template-columns: 24px 34px minmax(0, 1fr) auto 36px;
+  grid-template-columns: 24px 34px 24px minmax(0, 1fr) auto 36px;
   min-block-size: 54px;
   padding-block: 4px;
   padding-inline: 8px;
+}
+
+.tabIcon {
+  align-items: center;
+  align-self: center;
+  color: var(--secondary-text-color);
+  display: flex;
+  inline-size: 24px;
+  justify-content: center;
+}
+
+.tabIcon img {
+  block-size: 20px;
+  border-radius: 50%;
+  inline-size: 20px;
+  object-fit: cover;
 }
 
 .tabOrganizerRow.dragging {
@@ -485,6 +501,7 @@
   border: 0 !important;
   display: flex;
   flex-direction: column;
+  justify-content: center;
   min-inline-size: 0;
   padding-inline: 2px !important;
   text-align: start;
@@ -531,7 +548,7 @@
 }
 
 .closedTabRow {
-  grid-template-columns: minmax(0, 1fr) auto;
+  grid-template-columns: 24px minmax(0, 1fr) auto;
 }
 
 .closedTabRow > button,
@@ -582,7 +599,11 @@
   }
 
   .tabOrganizerRow {
-    grid-template-columns: 24px 34px minmax(0, 1fr) 36px;
+    grid-template-columns: 24px 34px 24px minmax(0, 1fr) 36px;
+  }
+
+  .closedTabRow {
+    grid-template-columns: 24px minmax(0, 1fr) auto;
   }
 
   .compactSelect.bulkActionSelect {

--- a/src/renderer/components/TabOrganizer/TabOrganizer.vue
+++ b/src/renderer/components/TabOrganizer/TabOrganizer.vue
@@ -303,6 +303,7 @@
                   <button
                     v-if="section.allTabs.length > 0"
                     type="button"
+                    :disabled="section.allTabs.every(tab => tab.isUnloaded)"
                     @click="runAction('unload', section.allTabs.map(tab => tab.id))"
                   >
                     <FtIcon
@@ -368,16 +369,31 @@
                   <FtCheckboxList
                     class="tabSelection"
                     :model-value="selectedTabIds.has(tab.id) ? [tab.id] : []"
-                    :labels="[t('Tab Organizer.Select Tab', { title: tab.title })]"
+                    :labels="[t('Tab Organizer.Select Tab', { title: formatTabTitle(tab.title) })]"
                     :values="[tab.id]"
+                    @click.capture="handleTabSelectionClick($event, tab.id)"
                     @update:model-value="toggleTabSelection(tab.id, $event.includes(tab.id))"
                   />
+                  <span class="tabIcon">
+                    <img
+                      v-if="usableTabAvatarUrl(tab)"
+                      :src="usableTabAvatarUrl(tab)"
+                      alt=""
+                      draggable="false"
+                      @error="handleTabAvatarError(tab)"
+                    >
+                    <FtIcon
+                      v-else
+                      :icon="getTabPageIcon(tab) || ['fas', 'display']"
+                      aria-hidden="true"
+                    />
+                  </span>
                   <button
                     type="button"
                     class="tabIdentity"
                     @click="activateTab(tab.id)"
                   >
-                    <span>{{ tab.title }}</span>
+                    <span>{{ formatTabTitle(tab.title) }}</span>
                     <small>{{ tab.route.fullPath || tab.url }}</small>
                   </button>
                   <div class="tabIndicators">
@@ -389,7 +405,7 @@
                   <button
                     type="button"
                     class="iconButton"
-                    :aria-label="t('Tab Organizer.Close Tab', { title: tab.title })"
+                    :aria-label="t('Tab Organizer.Close Tab', { title: formatTabTitle(tab.title) })"
                     :title="t('Close')"
                     @click="runAction('close', [tab.id])"
                   >
@@ -431,8 +447,14 @@
                   :key="tab.id"
                   class="tabOrganizerRow closedTabRow"
                 >
+                  <span class="tabIcon">
+                    <FtIcon
+                      :icon="getTabPageIcon(tab) || ['fas', 'display']"
+                      aria-hidden="true"
+                    />
+                  </span>
                   <div class="tabIdentity">
-                    <span>{{ tab.title }}</span>
+                    <span>{{ formatTabTitle(tab.title) }}</span>
                     <small>{{ tab.route.fullPath || tab.url }}</small>
                   </div>
                   <button
@@ -469,6 +491,8 @@ import { useI18n } from 'vue-i18n'
 import { getTabAccentColor } from '../../constants/tabColors'
 import { clampOverlayScrollTop, restoreOverlayScrollTop } from '../../helpers/overlayScrollbars'
 import store from '../../store/index'
+import { getTabAvatarUrl, getTabPageIcon } from '../../tabs/tabPreview'
+import { formatTabTitle } from '../../tabs/tabTitle'
 import FtCheckboxList from '../FtCheckboxList/FtCheckboxList.vue'
 import { lockBodyScroll, unlockBodyScroll } from '../FtPrompt/scrollLock'
 import FtSelect from '../FtSelect/FtSelect.vue'
@@ -489,12 +513,14 @@ const dragTargetGroupId = ref(undefined)
 const editingNameGroupId = ref(null)
 const editingGroupName = ref('')
 const editingColorGroupId = ref(null)
+const failedTabAvatarUrls = ref({})
 const dialogRef = useTemplateRef('dialogRef')
 const searchRef = useTemplateRef('searchRef')
 const scrollRef = useTemplateRef('scrollRef')
 const scrollContentRef = useTemplateRef('scrollContentRef')
 let lastActiveElement = null
 let resizeObserver = null
+let selectionAnchorId = null
 
 const tabs = computed(() => store.getters.getTabs)
 const groups = computed(() => store.getters.getTabGroups)
@@ -627,6 +653,18 @@ function matchesSearch(tab) {
   return haystack.includes(needle)
 }
 
+function usableTabAvatarUrl(tab) {
+  const avatarUrl = getTabAvatarUrl(tab)
+  return failedTabAvatarUrls.value[tab.id] === avatarUrl ? null : avatarUrl
+}
+
+function handleTabAvatarError(tab) {
+  failedTabAvatarUrls.value = {
+    ...failedTabAvatarUrls.value,
+    [tab.id]: getTabAvatarUrl(tab)
+  }
+}
+
 function close() {
   emit('close')
 }
@@ -642,7 +680,33 @@ function toggleTabSelection(tabId, checked) {
   store.dispatch('setTabSelection', [...next])
 }
 
+function handleTabSelectionClick(event, tabId) {
+  if (!event.shiftKey) {
+    selectionAnchorId = tabId
+    return
+  }
+
+  const displayedTabIds = displayedSections.value.flatMap(section => (
+    !section.isCollapsed || normalizedQuery.value.length > 0
+      ? section.tabs.map(tab => tab.id)
+      : []
+  ))
+  const anchorIndex = displayedTabIds.indexOf(selectionAnchorId)
+  const targetIndex = displayedTabIds.indexOf(tabId)
+  if (anchorIndex === -1 || targetIndex === -1) {
+    selectionAnchorId = tabId
+    return
+  }
+
+  event.preventDefault()
+  event.stopPropagation()
+  event.currentTarget.querySelector('input[type="checkbox"]')?.focus()
+  const [start, end] = [anchorIndex, targetIndex].sort((a, b) => a - b)
+  store.dispatch('setTabSelection', displayedTabIds.slice(start, end + 1))
+}
+
 function toggleAllTabsSelection() {
+  selectionAnchorId = null
   store.dispatch('setTabSelection', hasSelectedTabs.value ? [] : visibleTabs.value.map(tab => tab.id))
 }
 

--- a/src/renderer/store/modules/tabs.js
+++ b/src/renderer/store/modules/tabs.js
@@ -2,6 +2,7 @@ import packageDetails from '../../../../package.json'
 import { getTabPageIcon } from '../../tabs/tabPageIcon'
 import { DEFAULT_VIDEO_ZOOM } from '../../helpers/player/videoZoom'
 import { reconcilePendingTabOrder } from '../../tabs/pendingTabOrder'
+import { formatTabTitle } from '../../tabs/tabTitle'
 
 const MAX_LOGICAL_HISTORY_ENTRIES = 100
 const NAV_HISTORY_DISPLAY_LIMIT = 15
@@ -588,11 +589,10 @@ function buildFullPath(path, query, hash) {
 }
 
 function stripDocumentTitle(title) {
-  const suffix = ` - ${packageDetails.productName}`
   if (title === packageDetails.productName) {
     return ''
   }
-  return title.endsWith(suffix) ? title.slice(0, -suffix.length) : title
+  return formatTabTitle(title)
 }
 
 function searchParamsToQuery(searchParams) {

--- a/src/renderer/tabs/tabTitle.js
+++ b/src/renderer/tabs/tabTitle.js
@@ -1,0 +1,14 @@
+import packageDetails from '@root/package.json'
+
+const PRODUCT_NAME_SUFFIX = ` - ${packageDetails.productName}`
+
+/**
+ * Remove the app name appended to document titles when displaying a tab title.
+ * @param {string | null | undefined} title
+ * @returns {string | null | undefined}
+ */
+export function formatTabTitle(title) {
+  return title?.endsWith(PRODUCT_NAME_SUFFIX)
+    ? title.slice(0, -PRODUCT_NAME_SUFFIX.length)
+    : title
+}


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Make sure to follow the contributing guidelines. -->
<!-- Important note, we may remove your pull request if you do not use this provided PR template correctly. -->
<!-- Agent instructions: Preserve every heading, comment, and marker in this template. Never remove or rewrite the release-note-category:start/end, release-note:start/end, or release-note-image:start/end marker pairs. -->

## Pull Request Type
<!-- Please select what type of pull request this is: [x] -->
- [x] Bugfix
- [x] Feature Implementation
- [ ] Documentation
- [ ] Other

## Related issue
<!-- Please link the issue your pull request is referring to. -->
<!-- If this pull request fully resolves the relevant issue, put "closes" before the issue number. -->
<!-- Example: "closes #123456". -->

No linked issue.

## Description
<!-- Please write a clear and concise description of what the pull request does. -->

The tab organizer did not expose enough tab context, and several organizer actions behaved inconsistently. In particular, bulk unloading could leave the presented active tab loaded.

This change:

- places the organizer and new-tab buttons beside each other in vertical tab bars;
- shows each collapsed tab group's name beside its group icon;
- shows each tab's avatar or page icon and removes the trailing app name from displayed titles;
- disables a group's Unload All action once every tab is unloaded;
- fixes bulk unloading for presented active tabs in both the organizer and tab context menu;
- adds Shift-click range selection across visible organizer rows.

## Release note category
<!-- Select exactly one category. Every pull request must select one. -->
<!-- Select "Not noteworthy" when the pull request fixes a bug in or improves functionality that has not yet appeared in a stable release. -->
<!-- release-note-category:start -->
- [x] Not noteworthy
- [ ] Highlights
- [ ] More improvements
- [ ] Fixed bugs
<!-- release-note-category:end -->

## Release note
<!-- Required unless "Not noteworthy" is selected. -->
<!-- Write one concise, user-facing entry without a leading bullet. -->
<!-- release-note:start -->

<!-- release-note:end -->

## Release note images
<!-- Optional. Paste one or more Markdown images, HTML image tags, or dark/light <picture> elements here. -->
<!-- The release notes normalize the markup and limit images taller than 300 pixels. -->
<!-- Agent instructions:
For a noteworthy visible change, add media when it makes the change easier to understand. Prefer a still image unless motion is the point; recordings must use animated WebP.
After implementing a visible change, proactively capture the result and show the local media to the user for approval before uploading it or updating the pull request.
When the affected UI differs between dark and light themes, capturing both themes is required. A dark-only image is incomplete. Run `node _scripts/releaseNoteMedia.mjs --dark DARK_FILE --light LIGHT_FILE --alt "DESCRIPTION"`; GitHub will display the matching theme and use dark as the fallback. Use a single default-dark capture only when the light theme cannot be captured or looks identical.
Capture or crop to the smallest region that still makes the change clear. Do not include the full window when the affected component can be understood on its own.
Use English unless localization is the subject. Keep components at their normal dimensions and placement instead of resizing them to fill the frame.
Use deterministic local fixtures for visible remote images. Reusable avatar and thumbnail fixtures are available through `e2e/helpers/visual-fixtures.mjs`. Before capturing, verify that every visible image has loaded successfully (`complete === true` and `naturalWidth > 0`).
Inspect the final dark and light files for failed images, missing content, unrelated UI, awkward animation, and misleading layout. Omit media when it does not explain the change clearly.
For one dark capture, run `node _scripts/releaseNoteMedia.mjs FILE --alt "DESCRIPTION"`.
Check for personal information, tokens, private repository names, and unrelated desktop content before uploading. Uploaded media is public.
Keep capture-only scripts, test hooks, screenshots, and recordings out of commits. Remove them before committing unless the capture code is also a reusable regression test. Never commit generated release-note media.
Paste only the generated markup between the marker comments. Leave this section empty when media would not help.
-->
<!-- release-note-image:start -->

<!-- release-note-image:end -->

## Testing
<!-- How can reviewers verify that the PR produces correct results? -->
<!-- Please provide instructions so that others can ensure that your pull request would produce correct results. For examples see, https://github.com/FreeTubeApp/FreeTube/pull/5743, https://github.com/FreeTubeApp/FreeTube/pull/7349, https://github.com/FreeTubeApp/FreeTube/pull/5125, https://github.com/FreeTubeApp/FreeTube/pull/7338 -->
<!-- Agent instructions: Only write human-facing steps that explain how to verify the change while running this branch in dev mode. Include expected results and, when applicable, helpful console snippets for interactive verification. Do not include automated checks, commands, results, pass counts, or CI status. -->

1. Set the tab bar position to the left or right. Confirm that the organizer and new-tab buttons share one horizontal row.
2. Collapse a named tab group. Confirm that its tab-bar button shows the group icon and name, with long names kept to one line.
3. Open the organizer with loaded and unloaded tabs. Confirm that each row has an icon, titles omit the trailing ` - OpenTubeX`, and a group's Unload All button becomes disabled once every tab in that group is unloaded.
4. Select a tab checkbox, then Shift-click another visible checkbox. Confirm that the full visible range is selected.
5. Put the active tab and another loaded tab in the same group, then use Unload All. Confirm that both tabs unload and another tab becomes active.
6. Select an active tab and another loaded tab in the tab bar, open their context menu, and choose Unload Tabs. Confirm that both selected tabs unload.

## Additional context
<!-- Add any other context about the pull request here. -->

The tab organizer has not appeared in a stable release, so this PR is marked Not noteworthy.
