### PR TITLE
fix(player): prevent overlapping mini players

### DIFF
--- a/e2e/tests/offline/player.spec.mjs
+++ b/e2e/tests/offline/player.spec.mjs
@@ -39,6 +39,55 @@ function scrollBelowPlayer(player) {
   })
 }
 
+async function openCrossTabMiniPlayerOverWatchTab({ app, page }) {
+  await openDemoVideo({ app, page })
+  const firstTab = page.locator('.tabBar .tab').first()
+  const firstTabId = await page.locator(activeTab).getAttribute('data-tab-id')
+
+  await page.locator('.tabBar .newTabButton').click()
+  await openDemoVideo({ app, page })
+  const secondTab = page.locator('.tabBar .tab').nth(1)
+  const secondTabId = await page.locator(activeTab).getAttribute('data-tab-id')
+
+  await firstTab.click()
+  const firstPlayer = page.locator(`.ftVideoPlayer[data-tab-id="${firstTabId}"]`)
+  const firstVideo = firstPlayer.locator('video')
+  await firstVideo.evaluate(element => element.play())
+  await expect.poll(() => firstVideo.evaluate(element => element.paused)).toBe(false)
+
+  await secondTab.click()
+  const activePlayer = page.locator(`.ftVideoPlayer[data-tab-id="${secondTabId}"]`)
+  await expect(firstPlayer).toHaveClass(/scrollMiniPlayer/)
+  await expect(activePlayer).not.toHaveClass(/scrollMiniPlayer/)
+
+  return { activePlayer, firstPlayer, firstVideo }
+}
+
+async function expectNoScrollMiniPlayerActivation(page, player, trigger) {
+  await player.evaluate(element => {
+    window.scrollMiniPlayerActivationCount = 0
+    window.scrollMiniPlayerActivationObserver = new MutationObserver(() => {
+      if (element.classList.contains('scrollMiniPlayer')) {
+        window.scrollMiniPlayerActivationCount++
+      }
+    })
+    window.scrollMiniPlayerActivationObserver.observe(element, { attributeFilter: ['class'] })
+  })
+
+  await trigger()
+  await page.waitForTimeout(350)
+
+  const activationCount = await page.evaluate(() => {
+    window.scrollMiniPlayerActivationObserver.disconnect()
+    const count = window.scrollMiniPlayerActivationCount
+    delete window.scrollMiniPlayerActivationObserver
+    delete window.scrollMiniPlayerActivationCount
+    return count
+  })
+  expect(activationCount).toBe(0)
+  await expect(player).not.toHaveClass(/scrollMiniPlayer/)
+}
+
 /** Asserts that the overlay owns a point where it intersects the detached player. */
 async function expectOverlayAbovePlayer(player, overlay) {
   await expect(overlay).toBeVisible()
@@ -815,6 +864,44 @@ test.describe('scroll mini player', () => {
       await expect(player).not.toHaveClass(/scrollMiniPlayer/)
     })
 
+    test('does not show a second mini player after switching between watch tabs', async ({ app, page }) => {
+      const { activePlayer } = await openCrossTabMiniPlayerOverWatchTab({ app, page })
+
+      await expectNoScrollMiniPlayerActivation(
+        page,
+        activePlayer,
+        () => scrollBelowPlayer(activePlayer)
+      )
+      await expect(page.locator('.ftVideoPlayer.scrollMiniPlayer')).toHaveCount(1)
+    })
+
+    test('allows the active tab mini player after the cross-tab video ends', async ({ app, page }) => {
+      const { activePlayer, firstPlayer, firstVideo } = await openCrossTabMiniPlayerOverWatchTab({ app, page })
+
+      await firstVideo.evaluate(element => {
+        Object.defineProperty(element, 'ended', { configurable: true, value: true })
+        element.dispatchEvent(new Event('ended'))
+      })
+      await expect(firstPlayer).not.toHaveClass(/scrollMiniPlayer/)
+
+      await scrollBelowPlayer(activePlayer)
+
+      await expect(activePlayer).toHaveClass(/scrollMiniPlayer/)
+      await expect(page.locator('.ftVideoPlayer.scrollMiniPlayer')).toHaveCount(1)
+    })
+
+    test('does not show the cross-tab mini player for a paused video', async ({ app, page }) => {
+      const video = await openDemoVideo({ app, page })
+      await video.evaluate(element => element.pause())
+      await expect.poll(() => video.evaluate(element => element.paused)).toBe(true)
+
+      const player = page.locator('.ftVideoPlayer')
+      await page.locator('.tabBar .newTabButton').click()
+
+      await expect(player).toBeHidden()
+      await expect(player).not.toHaveClass(/scrollMiniPlayer/)
+    })
+
     test('removes the mini player when its source tab closes', async ({ app, page }) => {
       await openDemoVideo({ app, page })
 
@@ -850,12 +937,14 @@ test.describe('scroll mini player', () => {
     })
 
     test('hides an existing mini player when automatic PiP takes over tab changes', async ({ app, page }) => {
-      const video = await openDemoVideo({ app, page })
-      await video.evaluate(element => element.pause())
+      await openDemoVideo({ app, page })
 
       const player = page.locator('.ftVideoPlayer')
+      const video = player.locator('video')
       await page.locator('.tabBar .newTabButton').click()
       await expect(player).toHaveClass(/scrollMiniPlayer/)
+      await video.evaluate(element => element.pause())
+      await expect.poll(() => video.evaluate(element => element.paused)).toBe(true)
 
       await page.locator('.profileTrigger').click()
       await page.getByRole('dialog', { name: 'Quick settings' })

--- a/src/renderer/components/ft-shaka-video-player/opentubex/useScrollMiniPlayer.js
+++ b/src/renderer/components/ft-shaka-video-player/opentubex/useScrollMiniPlayer.js
@@ -3,10 +3,12 @@ import { computed, nextTick, ref, watch } from 'vue'
 import store from '../../../store/index'
 import { applyAnimationSpeed } from '../../../helpers/animationSpeed'
 import {
+  hasCrossTabMiniPlayerOwner,
   isCrossTabMiniPlayerOwner,
   markCrossTabMiniPlayerActive,
   markCrossTabMiniPlayerInactive,
   refreshCrossTabMiniPlayer,
+  releaseCrossTabMiniPlayerOwnership,
   unregisterCrossTabMiniPlayer,
 } from '../../../helpers/crossTabMiniPlayer'
 import { isReducedMotionEnabled } from '../../../helpers/reducedMotion'
@@ -391,17 +393,19 @@ export function useScrollMiniPlayer({ container, fullWindowEnabled, getUi, isAct
   }
 
   function canShowCrossTabMiniPlayer() {
+    const videoElement = video.value
     return !isActiveTab.value &&
       !autoPictureInPictureOnTabChange.value &&
       scrollMiniPlayerOnAllTabs.value &&
-      canUseScrollMiniPlayerBase()
+      canUseScrollMiniPlayerBase() &&
+      (isCrossTabMiniPlayerOwner(crossTabMiniPlayerCandidate) || !videoElement.paused)
   }
 
   function canUseScrollMiniPlayer() {
     if (!canUseScrollMiniPlayerBase()) return false
 
     if (isActiveTab.value) {
-      return scrollMiniPlayerEnabled.value
+      return scrollMiniPlayerEnabled.value && !hasCrossTabMiniPlayerOwner()
     }
 
     return !autoPictureInPictureOnTabChange.value &&
@@ -656,6 +660,8 @@ export function useScrollMiniPlayer({ container, fullWindowEnabled, getUi, isAct
 
   /** @param {boolean} [animate] */
   function deactivateScrollMiniPlayer(animate = false) {
+    releaseCrossTabMiniPlayerOwnership(crossTabMiniPlayerCandidate)
+
     const playerContainer = container.value
     const shouldAnimate = animate && playerContainer !== null && !isReducedMotionEnabled()
     const previousRect = shouldAnimate ? playerContainer.getBoundingClientRect() : null

--- a/src/renderer/helpers/crossTabMiniPlayer.js
+++ b/src/renderer/helpers/crossTabMiniPlayer.js
@@ -51,9 +51,7 @@ export function markCrossTabMiniPlayerActive(candidate) {
     latestCandidate = null
   }
 
-  if (owner === candidate) {
-    owner = null
-  }
+  releaseCrossTabMiniPlayerOwnership(candidate)
 }
 
 /**
@@ -82,6 +80,24 @@ export function isCrossTabMiniPlayerOwner(candidate) {
 }
 
 /**
+ * @returns {boolean}
+ */
+export function hasCrossTabMiniPlayerOwner() {
+  return owner !== null
+}
+
+/**
+ * Releases a player that no longer presents its detached mini player.
+ *
+ * @param {CrossTabMiniPlayerCandidate} candidate
+ */
+export function releaseCrossTabMiniPlayerOwnership(candidate) {
+  if (owner === candidate) {
+    owner = null
+  }
+}
+
+/**
  * Removes an unmounted player from the coordinator.
  *
  * @param {CrossTabMiniPlayerCandidate} candidate
@@ -90,7 +106,5 @@ export function unregisterCrossTabMiniPlayer(candidate) {
   if (latestCandidate === candidate) {
     latestCandidate = null
   }
-  if (owner === candidate) {
-    owner = null
-  }
+  releaseCrossTabMiniPlayerOwnership(candidate)
 }

--- a/tests/unit/cross-tab-mini-player.test.mjs
+++ b/tests/unit/cross-tab-mini-player.test.mjs
@@ -2,10 +2,12 @@ import assert from 'node:assert/strict'
 import test from 'node:test'
 
 import {
+  hasCrossTabMiniPlayerOwner,
   isCrossTabMiniPlayerOwner,
   markCrossTabMiniPlayerActive,
   markCrossTabMiniPlayerInactive,
   refreshCrossTabMiniPlayer,
+  releaseCrossTabMiniPlayerOwnership,
   unregisterCrossTabMiniPlayer,
 } from '../../src/renderer/helpers/crossTabMiniPlayer.js'
 
@@ -31,6 +33,7 @@ test('only the most recently left video tab owns the cross-tab mini player', () 
   const second = createCandidate()
 
   markCrossTabMiniPlayerInactive(first.candidate)
+  assert.equal(hasCrossTabMiniPlayerOwner(), true)
   assert.equal(isCrossTabMiniPlayerOwner(first.candidate), true)
   assert.deepEqual(first.calls, ['show'])
 
@@ -51,8 +54,22 @@ test('only the most recently left video tab owns the cross-tab mini player', () 
   assert.deepEqual(second.calls, ['show', 'hide', 'show'])
 
   markCrossTabMiniPlayerActive(second.candidate)
+  assert.equal(hasCrossTabMiniPlayerOwner(), false)
   assert.equal(isCrossTabMiniPlayerOwner(second.candidate), false)
 
   unregisterCrossTabMiniPlayer(first.candidate)
   unregisterCrossTabMiniPlayer(second.candidate)
+})
+
+test('a hidden cross-tab mini player releases its ownership', () => {
+  const player = createCandidate()
+
+  markCrossTabMiniPlayerInactive(player.candidate)
+  assert.equal(hasCrossTabMiniPlayerOwner(), true)
+
+  releaseCrossTabMiniPlayerOwnership(player.candidate)
+  assert.equal(hasCrossTabMiniPlayerOwner(), false)
+  assert.equal(isCrossTabMiniPlayerOwner(player.candidate), false)
+
+  unregisterCrossTabMiniPlayer(player.candidate)
 })


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Make sure to follow the contributing guidelines. -->
<!-- Important note, we may remove your pull request if you do not use this provided PR template correctly. -->
<!-- Agent instructions: Preserve every heading, comment, and marker in this template. Never remove or rewrite the release-note-category:start/end, release-note:start/end, or release-note-image:start/end marker pairs. -->

## Pull Request Type
<!-- Please select what type of pull request this is: [x] -->
- [x] Bugfix
- [ ] Feature Implementation
- [ ] Documentation
- [ ] Other

## Related issue
<!-- Please link the issue your pull request is referring to. -->
<!-- If this pull request fully resolves the relevant issue, put "closes" before the issue number. -->
<!-- Example: "closes #123456". -->

No related issue.

## Description
<!-- Please write a clear and concise description of what the pull request does. -->

Enabling both scroll mini-player settings could place the active watch tab's mini player over the one carried across from the previous tab. The tab-switch mini player also appeared for paused videos.

This change coordinates mini-player ownership across tabs, requires playback before a tab-switch mini player first appears, and releases ownership whenever that player closes. An already-open mini player can still be paused and resumed from its controls.

## Release note category
<!-- Select exactly one category. Every pull request must select one. -->
<!-- Select "Not noteworthy" when the pull request fixes a bug in or improves functionality that has not yet appeared in a stable release. -->
<!-- release-note-category:start -->
- [x] Not noteworthy
- [ ] Highlights
- [ ] More improvements
- [ ] Fixed bugs
<!-- release-note-category:end -->

## Release note
<!-- Required unless "Not noteworthy" is selected. -->
<!-- Write one concise, user-facing entry without a leading bullet. -->
<!-- release-note:start -->
Prevent two mini players from overlapping when switching between video tabs and scrolling.
<!-- release-note:end -->

## Release note images
<!-- Optional. Paste one or more Markdown images, HTML image tags, or dark/light <picture> elements here. -->
<!-- The release notes normalize the markup and limit images taller than 300 pixels. -->
<!-- Agent instructions:
For a noteworthy visible change, add media when it makes the change easier to understand. Prefer a still image unless motion is the point; recordings must use animated WebP.
After implementing a visible change, proactively capture the result and show the local media to the user for approval before uploading it or updating the pull request.
When the affected UI differs between dark and light themes, capturing both themes is required. A dark-only image is incomplete. Run `node _scripts/releaseNoteMedia.mjs --dark DARK_FILE --light LIGHT_FILE --alt "DESCRIPTION"`; GitHub will display the matching theme and use dark as the fallback. Use a single default-dark capture only when the light theme cannot be captured or looks identical.
Capture or crop to the smallest region that still makes the change clear. Do not include the full window when the affected component can be understood on its own.
Use English unless localization is the subject. Keep components at their normal dimensions and placement instead of resizing them to fill the frame.
Use deterministic local fixtures for visible remote images. Reusable avatar and thumbnail fixtures are available through `e2e/helpers/visual-fixtures.mjs`. Before capturing, verify that every visible image has loaded successfully (`complete === true` and `naturalWidth > 0`).
Inspect the final dark and light files for failed images, missing content, unrelated UI, awkward animation, and misleading layout. Omit media when it does not explain the change clearly.
For one dark capture, run `node _scripts/releaseNoteMedia.mjs FILE --alt "DESCRIPTION"`.
Check for personal information, tokens, private repository names, and unrelated desktop content before uploading. Uploaded media is public.
Keep capture-only scripts, test hooks, screenshots, and recordings out of commits. Remove them before committing unless the capture code is also a reusable regression test. Never commit generated release-note media.
Paste only the generated markup between the marker comments. Leave this section empty when media would not help.
-->
<!-- release-note-image:start -->

<!-- release-note-image:end -->

## Testing
<!-- How can reviewers verify that the PR produces correct results? -->
<!-- Please provide instructions so that others can ensure that your pull request would produce correct results. For examples see, https://github.com/FreeTubeApp/FreeTube/pull/5743, https://github.com/FreeTubeApp/FreeTube/pull/7349, https://github.com/FreeTubeApp/FreeTube/pull/5125, https://github.com/FreeTubeApp/FreeTube/pull/7338 -->
<!-- Agent instructions: Only write human-facing steps that explain how to verify the change while running this branch in dev mode. Include expected results and, when applicable, helpful console snippets for interactive verification. Do not include automated checks, commands, results, pass counts, or CI status. -->

1. Enable "Keep a mini player on screen when scrolling down" and "Keep a mini player on screen when switching tabs".
2. Play a video, switch to another watch tab, and scroll its player out of view. Only the mini player from the previous tab should remain visible.
3. Pause a video before switching tabs. No tab-switch mini player should appear.
4. Let a tab-switch mini player reach the end of its video, then scroll the active watch tab. The active tab's mini player should appear normally.

## Additional context
<!-- Add any other context about the pull request here. -->

An already-open tab-switch mini player remains available when paused from its own controls.
