### PR TITLE
feat(subscriptions): add a tabbed New feed view

### DIFF
--- a/e2e/tests/offline/subscriptions-header-layout.spec.mjs
+++ b/e2e/tests/offline/subscriptions-header-layout.spec.mjs
@@ -24,7 +24,8 @@ test.use({
       fetchSubscriptionsAutomatically: false,
       hideSubscriptionsVideos: false,
       hideSubscriptionsShorts: false,
-      showNewSubscriptionFeedIndicators: true
+      showNewSubscriptionFeedIndicators: true,
+      uiScale: 95
     },
     profiles: [
       {
@@ -95,6 +96,8 @@ test.describe('subscriptions header layout', () => {
       const select = document.querySelector('.headerSortSelect .select-text')
 
       return {
+        header: toBox(document.querySelector('.subscriptionsHeader')),
+        viewToggle: toBox(document.querySelector('.headerViewToggle .iconButton')),
         select: toBox(select),
         label: toBox(document.querySelector('.headerSortSelect .select-label')),
         refresh: toBox(document.querySelector('.headerRefreshWidget .refreshButton')),
@@ -103,7 +106,14 @@ test.describe('subscriptions header layout', () => {
     })
 
     expect(layout.selectedText).toBe('Newest first')
+    expect(layout.viewToggle.start).toBeGreaterThanOrEqual(layout.header.start)
+    expect(layout.viewToggle.end).toBeLessThanOrEqual(layout.select.start)
     expect(layout.select.end).toBeLessThanOrEqual(layout.refresh.start)
+    expect(layout.refresh.end).toBeLessThanOrEqual(layout.header.end)
+    expect(Math.abs(
+      (layout.viewToggle.top + layout.viewToggle.bottom) / 2 -
+      (layout.select.top + layout.select.bottom) / 2
+    )).toBeLessThanOrEqual(1)
     expect(Math.abs(
       (layout.select.top + layout.select.bottom) / 2 -
       (layout.refresh.top + layout.refresh.bottom) / 2
@@ -111,6 +121,90 @@ test.describe('subscriptions header layout', () => {
     expect(layout.label.top).toBeGreaterThanOrEqual(layout.select.top)
     expect(layout.label.bottom).toBeLessThanOrEqual(layout.select.bottom)
     await attachScreenshot('compact New feed header actions')
+  })
+
+  test('separates the main feed tabs from the centered New feed tabs', async ({ app, page, attachScreenshot }) => {
+    await goTo(page, 'subscriptions')
+    await page.locator('[data-subscription-feed-tab="all"]').click()
+    await page.getByRole('button', { name: 'Show tabbed view' }).click()
+
+    const separatorLayout = () => page.evaluate(() => {
+      const header = document.querySelector('.subscriptionsHeader')
+      const headerRow = header.querySelector('.headerRow')
+      const mainTabs = [...header.querySelectorAll('[data-subscription-feed-tab]')]
+      const newFeedTabs = [...header.querySelectorAll('[data-new-feed-tab]')]
+      const headerRowRect = headerRow.getBoundingClientRect()
+      const headerStyle = getComputedStyle(header)
+      const headerRowStyle = getComputedStyle(headerRow)
+
+      return {
+        headerShadow: headerStyle.boxShadow,
+        separatorWidth: Number.parseFloat(headerRowStyle.borderBottomWidth),
+        separatorY: headerRowRect.bottom,
+        mainTabsBottom: Math.max(...mainTabs.map(tab => tab.getBoundingClientRect().bottom)),
+        newFeedTabsTop: Math.min(...newFeedTabs.map(tab => tab.getBoundingClientRect().top))
+      }
+    })
+
+    for (const width of [1400, 700]) {
+      await setWindowWidth(app, page, width)
+      const layout = await separatorLayout()
+
+      expect(layout.headerShadow).toBe('none')
+      expect(layout.separatorWidth).toBeGreaterThan(0)
+      expect(layout.separatorWidth).toBeLessThanOrEqual(1.1)
+      expect(layout.separatorY).toBeGreaterThanOrEqual(layout.mainTabsBottom)
+      expect(layout.newFeedTabsTop).toBeGreaterThanOrEqual(layout.separatorY)
+    }
+
+    await attachScreenshot('New feed tabs separator')
+  })
+
+  test('keeps the New feed controls on the same line as the main feed tabs', async ({ app, page, attachScreenshot }) => {
+    await goTo(page, 'subscriptions')
+    await page.locator('[data-subscription-feed-tab="all"]').click()
+    await page.getByRole('button', { name: 'Show tabbed view' }).click()
+
+    for (const width of [1120, 680, 375, 340]) {
+      await setWindowWidth(app, page, width)
+      await expect(page.locator('.subscriptionsHeader')).not.toHaveClass(/singleRow/)
+
+      const layout = await page.evaluate(() => {
+        const toBox = selector => {
+          const rect = document.querySelector(selector).getBoundingClientRect()
+          return { start: rect.left, end: rect.right, top: rect.top, bottom: rect.bottom }
+        }
+
+        const header = toBox('.subscriptionsHeader')
+        const upperTabs = [...document.querySelectorAll('[data-subscription-feed-tab]')]
+          .map(tab => {
+            const rect = tab.getBoundingClientRect()
+            return { start: rect.left, end: rect.right }
+          })
+
+        return {
+          header,
+          title: toBox('.pageTitle'),
+          tabs: toBox('.tabs'),
+          actions: toBox('.headerActions'),
+          upperTabs
+        }
+      })
+
+      expect(layout.tabs.top).toBeGreaterThanOrEqual(layout.title.bottom)
+      expect(layout.actions.top).toBeGreaterThanOrEqual(layout.title.bottom)
+      expect(layout.actions.top).toBeLessThan(layout.tabs.bottom)
+      expect(layout.tabs.top).toBeLessThan(layout.actions.bottom)
+      expect(layout.actions.start).toBeGreaterThanOrEqual(layout.header.start)
+      expect(layout.actions.end).toBeLessThanOrEqual(layout.header.end)
+      expect(Math.min(...layout.upperTabs.map(tab => tab.start))).toBeGreaterThanOrEqual(layout.header.start)
+      expect(Math.max(...layout.upperTabs.map(tab => tab.end))).toBeLessThanOrEqual(layout.header.end)
+      await expect.poll(() => page.evaluate(() => {
+        return document.documentElement.scrollWidth - document.documentElement.clientWidth
+      })).toBeLessThanOrEqual(2)
+    }
+
+    await attachScreenshot('New feed controls aligned with main tabs')
   })
 
   test('puts the tabs beside the title when they fit', async ({ page, attachScreenshot }) => {
@@ -139,11 +233,11 @@ test.describe('subscriptions header layout', () => {
 
     const { title, tabs, refreshWidget } = await headerBoxes(page)
 
-    // Two lines: title and refresh widget above, the tabs below both
-    expect(refreshWidget.top).toBeLessThan(title.bottom)
-    expect(refreshWidget.end).toBeGreaterThan(title.end)
+    // Two lines: the title is above, with the tabs and refresh widget together
     expect(tabs.top).toBeGreaterThanOrEqual(title.bottom)
-    expect(tabs.top).toBeGreaterThanOrEqual(refreshWidget.bottom)
+    expect(refreshWidget.top).toBeGreaterThanOrEqual(title.bottom)
+    expect(refreshWidget.top).toBeLessThan(tabs.bottom)
+    expect(tabs.top).toBeLessThan(refreshWidget.bottom)
   })
 
   test('merges the rows again when the window grows back', async ({ app, page, attachScreenshot }) => {

--- a/e2e/tests/offline/subscriptions-new-feed.spec.mjs
+++ b/e2e/tests/offline/subscriptions-new-feed.spec.mjs
@@ -141,6 +141,96 @@ test.describe('new subscriptions feed', () => {
     await expect(page.locator('.headerRefreshWidget .lastRefreshTimestamp')).toHaveCount(0)
   })
 
+  test('switches between the combined and tabbed views and remembers the choice', async ({ app, page, attachScreenshot }) => {
+    await goTo(page, 'subscriptions')
+    await page.locator('[data-subscription-feed-tab="all"]').click()
+
+    const showTabbedView = page.getByRole('button', { name: 'Show tabbed view' })
+    await expect(showTabbedView).toHaveAttribute('aria-pressed', 'false')
+    await showTabbedView.click()
+
+    const newContentTabs = page.getByRole('tablist', { name: 'New content tabs' })
+    const newContentTabsIndicator = newContentTabs.locator('.newFeedTabsIndicator')
+    await expect(newContentTabs).toBeVisible()
+    await expect(newContentTabsIndicator).toBeVisible()
+    await expect(page.getByRole('button', { name: 'Show combined view' })).toHaveAttribute('aria-pressed', 'true')
+    await expect(newContentTabs.locator('[data-new-feed-tab="videos"]')).toHaveAttribute('aria-selected', 'true')
+    await expect(page.getByText('New video', { exact: true })).toBeVisible()
+    await expect(page.getByText('New short', { exact: true })).toHaveCount(0)
+
+    const centerDifference = await page.evaluate(() => {
+      const header = document.querySelector('.subscriptionsHeader').getBoundingClientRect()
+      const tabs = [...document.querySelectorAll('[data-new-feed-tab]')]
+        .map(tab => tab.getBoundingClientRect())
+
+      return Math.abs(
+        (tabs[0].left + tabs.at(-1).right) / 2 -
+        (header.left + header.right) / 2
+      )
+    })
+    expect(centerDifference).toBeLessThanOrEqual(1)
+    await attachScreenshot('tabbed New feed')
+
+    const shortsTab = newContentTabs.locator('[data-new-feed-tab="shorts"]')
+    await shortsTab.click()
+    await expect(shortsTab).toHaveAttribute('aria-selected', 'true')
+    await expect(newContentTabsIndicator).toHaveCSS('transition-property', 'transform')
+    await expect(page.getByText('New short', { exact: true })).toBeVisible()
+    await expect(page.getByText('New video', { exact: true })).toHaveCount(0)
+
+    await page.waitForTimeout(400)
+    const indicatorAlignment = await page.evaluate(() => {
+      const indicator = document.querySelector('.newFeedTabsIndicator').getBoundingClientRect()
+      const tab = document.querySelector('[data-new-feed-tab="shorts"]').getBoundingClientRect()
+
+      return {
+        x: Math.abs(indicator.x - tab.x),
+        width: Math.abs(indicator.width - tab.width),
+        top: Math.abs(indicator.top - tab.bottom)
+      }
+    })
+    expect(indicatorAlignment.x).toBeLessThan(2)
+    expect(indicatorAlignment.width).toBeLessThan(2)
+    expect(indicatorAlignment.top).toBeLessThan(2)
+
+    await shortsTab.focus()
+    await shortsTab.press('ArrowRight')
+    await expect(newContentTabs.locator('[data-new-feed-tab="live"]')).toBeFocused()
+    await expect(page.getByText('New live stream', { exact: true })).toBeVisible()
+
+    const liveTab = newContentTabs.locator('[data-new-feed-tab="live"]')
+    const altArrowWasNotPrevented = await liveTab.evaluate(element => {
+      return element.dispatchEvent(new KeyboardEvent('keydown', {
+        key: 'ArrowRight',
+        altKey: true,
+        bubbles: true,
+        cancelable: true
+      }))
+    })
+    expect(altArrowWasNotPrevented).toBe(true)
+    await expect(liveTab).toHaveAttribute('aria-selected', 'true')
+    await expect(liveTab).toBeFocused()
+
+    await newContentTabs.locator('[data-new-feed-tab="posts"]').click()
+    await expect(page.getByText('New community post', { exact: true })).toBeVisible()
+
+    const relaunched = await app.relaunch()
+    await goTo(relaunched.page, 'subscriptions')
+    await relaunched.page.locator('[data-subscription-feed-tab="all"]').click()
+
+    const relaunchedTabs = relaunched.page.getByRole('tablist', { name: 'New content tabs' })
+    await expect(relaunchedTabs).toBeVisible()
+    await expect(relaunchedTabs.locator('[data-new-feed-tab="posts"]')).toHaveAttribute('aria-selected', 'true')
+    await expect(relaunched.page.getByText('New community post', { exact: true })).toBeVisible()
+
+    await relaunched.page.getByRole('button', { name: 'Show combined view' }).click()
+    await expect(relaunchedTabs).toHaveCount(0)
+    await expect(relaunched.page.getByRole('heading', { name: 'Videos', exact: true })).toBeVisible()
+    await expect(relaunched.page.getByRole('heading', { name: 'Shorts', exact: true })).toBeVisible()
+    await expect(relaunched.page.getByRole('heading', { name: 'Live', exact: true })).toBeVisible()
+    await expect(relaunched.page.getByRole('heading', { name: 'Posts', exact: true })).toBeVisible()
+  })
+
   test('shows Shorts as portrait cards with their duration and upload time', async ({ page }) => {
     await goTo(page, 'subscriptions')
     await page.locator('[data-subscription-feed-tab="shorts"]').click()

--- a/src/renderer/components/SubscriptionsNew.vue
+++ b/src/renderer/components/SubscriptionsNew.vue
@@ -1,25 +1,26 @@
 <template>
   <SubscriptionsTabUi
-    ref="tabUi"
     class="newFeed"
     :is-loading="isLoading"
-    :video-list="newVideos"
+    :video-list="displayedEntries"
     :error-channels="errorChannels"
     :attempted-fetch="attemptedFetch"
     :only-show-new="true"
-    :has-additional-content="hasAdditionalContent"
+    :has-additional-content="showCombinedView && hasAdditionalContent"
+    :is-community="activeCategory === 'posts'"
+    :youtube-style-shorts="activeCategory === 'shorts' && useCustomShortsPlayer"
     :track-global-refresh="false"
     stable-item-keys
     @refresh="refresh"
   >
     <template #before-list="{ hasVisibleContent }">
-      <h3 v-if="hasVisibleContent">
+      <h3 v-if="showCombinedView && hasVisibleContent">
         {{ $t('Global.Videos') }}
       </h3>
     </template>
     <Transition name="new-feed-section">
       <section
-        v-if="newShorts.length > 0"
+        v-if="showCombinedView && newShorts.length > 0"
         class="mediaSection"
       >
         <h3>{{ $t('Global.Shorts') }}</h3>
@@ -33,7 +34,7 @@
     </Transition>
     <Transition name="new-feed-section">
       <section
-        v-if="newLive.length > 0"
+        v-if="showCombinedView && newLive.length > 0"
         class="mediaSection"
       >
         <h3>{{ $t('Global.Live') }}</h3>
@@ -46,7 +47,7 @@
     </Transition>
     <Transition name="new-feed-section">
       <section
-        v-if="newPosts.length > 0"
+        v-if="showCombinedView && newPosts.length > 0"
         class="postsSection"
       >
         <h3>{{ $t('Global.Posts') }}</h3>
@@ -71,7 +72,7 @@
 </template>
 
 <script setup>
-import { computed, useTemplateRef } from 'vue'
+import { computed } from 'vue'
 import { useI18n } from 'vue-i18n'
 
 import FtElementList from './FtElementList/FtElementList.vue'
@@ -85,8 +86,15 @@ import { useRefreshAllSubscriptionFeeds } from '../composables/useRefreshAllSubs
 import { isHistoryEntryWatched } from '../helpers/history'
 import { isVideoHiddenByPreferences } from '../helpers/subscriptions'
 
+const props = defineProps({
+  activeCategory: {
+    type: String,
+    default: null,
+    validator: value => value === null || ['videos', 'shorts', 'live', 'posts'].includes(value)
+  }
+})
+
 const { t } = useI18n()
-const tabUi = useTemplateRef('tabUi')
 useKeepAliveEffectScope()
 const {
   activeSubscriptionIds,
@@ -219,6 +227,19 @@ const newPosts = computed(() => applySortPreference(
   })
 ))
 const useCustomShortsPlayer = computed(() => store.getters.getUseCustomShortsPlayer)
+const showCombinedView = computed(() => props.activeCategory === null)
+const displayedEntries = computed(() => {
+  switch (props.activeCategory) {
+    case 'shorts':
+      return newShorts.value
+    case 'live':
+      return newLive.value
+    case 'posts':
+      return newPosts.value
+    default:
+      return newVideos.value
+  }
+})
 
 const hasAdditionalContent = computed(() => {
   return newShorts.value.length > 0 || newLive.value.length > 0 || newPosts.value.length > 0
@@ -229,7 +250,7 @@ const isLoading = computed(() => {
 })
 
 const hasNewContent = computed(() => {
-  return hasAdditionalContent.value || tabUi.value?.hasNewContent === true
+  return newVideos.value.length > 0 || hasAdditionalContent.value
 })
 
 defineExpose({

--- a/src/renderer/store/modules/settings.js
+++ b/src/renderer/store/modules/settings.js
@@ -493,6 +493,7 @@ const state = {
   showScheduledLiveStreamsFirst: true,
   showNewSubscriptionFeed: true,
   showNewSubscriptionFeedIndicators: false,
+  newSubscriptionFeedView: 'combined',
   newSubscriptionFeedSortBy: 'newest',
   subscriptionFeedAutoRefreshInterval: '0',
   subscriptionShortsAutoRefreshInterval: '0',

--- a/src/renderer/views/Subscriptions/Subscriptions.css
+++ b/src/renderer/views/Subscriptions/Subscriptions.css
@@ -28,12 +28,32 @@
   box-shadow: 0 1px 0 var(--primary-shadow-color);
 }
 
+.subscriptionsHeader.tabbedNewFeed {
+  box-shadow: none;
+}
+
 .headerRow {
   display: flex;
   align-items: center;
   justify-content: space-between;
   gap: 12px 20px;
   flex-wrap: wrap;
+}
+
+.feedTabsControlsRow {
+  align-items: center;
+  display: flex;
+  flex: 1 1 auto;
+  flex-wrap: wrap;
+  gap: 8px 20px;
+  min-inline-size: 0;
+}
+
+.subscriptionsHeader.tabbedNewFeed .headerRow {
+  margin-inline: -16px;
+  padding-block-end: 8px;
+  padding-inline: 16px;
+  border-block-end: 1px solid var(--primary-shadow-color);
 }
 
 .pageTitle {
@@ -74,14 +94,32 @@
   display: flex;
   gap: 12px;
 
-  /* Size to its content so the header row positions the whole widget: tucked to
-     the inline-end while it fits beside the title, and flush to the inline-start
-     once it wraps onto its own line. */
+  /* Size to its content so the header row keeps the whole widget together. */
   max-inline-size: 100%;
 }
 
-.headerActions .headerSortSelect {
+.headerViewToggle {
   flex-shrink: 0;
+}
+
+.headerViewToggle :deep(.iconButton) {
+  block-size: 36px;
+  inline-size: 36px;
+}
+
+.headerViewToggle :deep(.iconButton[aria-pressed='true']) {
+  background-color: var(--side-nav-active-color);
+  color: var(--side-nav-active-text-color);
+}
+
+.subscriptionsHeader .headerActions .headerRefreshWidget {
+  flex: 0 0 auto;
+  inline-size: auto;
+}
+
+.headerActions .headerSortSelect {
+  flex: 1 1 220px;
+  min-inline-size: 0;
   inline-size: 220px;
   margin-block-start: 0;
 }
@@ -140,11 +178,25 @@
   color: var(--tertiary-text-color);
 }
 
-/* Two line layout: the tabs are moved past the refresh widget, so that they end
-   up on the line below the one with the title */
-.subscriptionsHeader:not(.singleRow) .tabsRow {
-  order: 1;
+/* Two line layout: the grouped tabs and controls move below the title together.
+   Giving the tabs a zero basis lets their own flex container wrap before the
+   controls are pushed onto another line. */
+.subscriptionsHeader:not(.singleRow) .feedTabsControlsRow {
   flex-basis: 100%;
+}
+
+.subscriptionsHeader:not(.singleRow) .tabsRow {
+  flex: 1 1 0;
+  min-inline-size: 0;
+}
+
+.subscriptionsHeader:not(.singleRow) .tabs {
+  min-inline-size: 0;
+}
+
+.subscriptionsHeader:not(.singleRow) .headerActions {
+  flex: 0 1 auto;
+  margin-inline-start: auto;
 }
 
 .subscriptionsHeader.singleRow .headerRow {
@@ -157,9 +209,14 @@
   flex-shrink: 0;
 }
 
+.subscriptionsHeader.singleRow .feedTabsControlsRow,
 .subscriptionsHeader.singleRow .tabsRow,
 .subscriptionsHeader.singleRow .tabs {
   flex-wrap: nowrap;
+}
+
+.subscriptionsHeader.singleRow .feedTabsControlsRow > * {
+  flex-shrink: 0;
 }
 
 .subscriptionsHeader.singleRow .tabsRow {
@@ -233,6 +290,37 @@
   color: var(--primary-color);
 }
 
+.newFeedTabs {
+  align-items: stretch;
+  justify-content: center;
+  gap: 4px 10px;
+  margin-block: 8px -3px;
+  position: relative;
+  color: var(--tertiary-text-color);
+}
+
+.newFeedTab {
+  position: relative;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  gap: 8px;
+  min-block-size: 44px;
+  padding-block: 9px;
+  padding-inline: 15px;
+  border: 0;
+  background: transparent;
+  color: inherit;
+  cursor: pointer;
+  font: inherit;
+  text-align: center;
+}
+
+.newFeedTab:hover {
+  color: var(--primary-text-color);
+  font-weight: bold;
+}
+
 .tab .tabLoadingIndicator {
   display: inline-flex;
   inline-size: auto;
@@ -263,6 +351,54 @@
   }
 
   .tabs {
+    gap: 4px;
+  }
+
+  .tab {
+    padding-inline: 10px;
+  }
+
+  .feedTabsControlsRow {
+    gap: 8px;
+  }
+
+  .headerActions {
+    gap: 6px;
+  }
+
+  .headerActions .headerSortSelect {
+    flex-basis: 128px;
+    inline-size: 128px;
+  }
+
+  .headerSortSelect :deep(.select-text) {
+    padding-inline-start: 36px;
+  }
+
+  .headerSortSelect :deep(.select-label),
+  .headerSortSelect :deep(.select-text ~ .select-label) {
+    max-inline-size: 16px;
+  }
+
+  .headerSortSelect :deep(.select-label-text) {
+    /* The icon and selected value keep the compact control understandable. */
+    display: none;
+  }
+
+  .markAllSeenButton {
+    min-block-size: 36px;
+  }
+
+  .markAllSeenLabel {
+    position: absolute;
+    inline-size: 1px;
+    block-size: 1px;
+    overflow: hidden;
+    clip-path: inset(50%);
+    white-space: nowrap;
+  }
+
+  .newFeedTabs {
     gap: 4px;
   }
 }

--- a/src/renderer/views/Subscriptions/Subscriptions.vue
+++ b/src/renderer/views/Subscriptions/Subscriptions.vue
@@ -6,7 +6,10 @@
     <FtCard class="card">
       <div
         class="subscriptionsHeader"
-        :class="{ singleRow: headerFitsOneRow }"
+        :class="{
+          singleRow: headerFitsOneRow,
+          tabbedNewFeed: currentTab === 'new' && newFeedView === 'tabbed'
+        }"
       >
         <div
           ref="headerRowRef"
@@ -20,200 +23,258 @@
             {{ $t("Subscriptions.Subscriptions") }}
           </h2>
           <div
-            ref="tabsRowRef"
-            class="tabsRow"
+            ref="feedTabsControlsRowRef"
+            class="feedTabsControlsRow"
           >
-            <FtFlexBox
-              ref="tabsContainerRef"
-              class="tabs"
-              role="tablist"
-              :aria-label="$t('Subscriptions.Subscriptions Tabs')"
+            <div
+              ref="tabsRowRef"
+              class="tabsRow"
             >
-              <div
-                v-if="tabsIndicatorStyle"
-                class="tabsIndicator"
-                data-animation-speed-managed
-                :style="[tabsIndicatorStyle, { transitionDuration: tabsIndicatorTransitionDuration }]"
-                aria-hidden="true"
+              <FtFlexBox
+                ref="tabsContainerRef"
+                class="tabs"
+                role="tablist"
+                :aria-label="$t('Subscriptions.Subscriptions Tabs')"
+              >
+                <div
+                  v-if="tabsIndicatorStyle"
+                  class="tabsIndicator"
+                  data-animation-speed-managed
+                  :style="[tabsIndicatorStyle, { transitionDuration: tabsIndicatorTransitionDuration }]"
+                  aria-hidden="true"
+                />
+                <!-- eslint-disable-next-line vuejs-accessibility/interactive-supports-focus -->
+                <div
+                  v-if="!hideSubscriptionsVideos"
+                  ref="videosTab"
+                  class="tab"
+                  role="tab"
+                  :aria-selected="currentTab === 'videos'"
+                  aria-controls="subscriptionsPanel"
+                  data-subscription-feed-tab="videos"
+                  :tabindex="currentTab === 'videos' ? 0 : -1"
+                  :class="{ selectedTab: selectedTab === 'videos' }"
+                  @click="changeTabFromPointer($event, 'videos')"
+                  @keydown.space.enter.prevent="changeTab('videos')"
+                  @keydown.left.right="switchTab($event, 'videos')"
+                >
+                  <FtIcon
+                    :icon="['fa', 'video']"
+                    class="subscriptionIcon"
+                  />
+                  <span
+                    class="tabLabel"
+                    :data-label="$t('Global.Videos')"
+                  ><span>{{ $t("Global.Videos") }}</span></span>
+                  <FtLoader
+                    v-if="refreshingFeedTab === 'videos'"
+                    class="tabLoadingIndicator"
+                  />
+                </div>
+                <!-- eslint-disable-next-line vuejs-accessibility/interactive-supports-focus -->
+                <div
+                  v-if="!hideSubscriptionsShorts"
+                  ref="shortsTab"
+                  class="tab"
+                  role="tab"
+                  :aria-selected="currentTab === 'shorts'"
+                  aria-controls="subscriptionsPanel"
+                  data-subscription-feed-tab="shorts"
+                  :tabindex="currentTab === 'shorts' ? 0 : -1"
+                  :class="{ selectedTab: selectedTab === 'shorts' }"
+                  @click="changeTabFromPointer($event, 'shorts')"
+                  @keydown.space.enter.prevent="changeTab('shorts')"
+                  @keydown.left.right="switchTab($event, 'shorts')"
+                >
+                  <FtIcon
+                    :icon="['fa', 'clapperboard']"
+                    class="subscriptionIcon"
+                  />
+                  <span
+                    class="tabLabel"
+                    :data-label="$t('Global.Shorts')"
+                  ><span>{{ $t("Global.Shorts") }}</span></span>
+                  <FtLoader
+                    v-if="refreshingFeedTab === 'shorts'"
+                    class="tabLoadingIndicator"
+                  />
+                </div>
+                <!-- eslint-disable-next-line vuejs-accessibility/interactive-supports-focus -->
+                <div
+                  v-if="!hideSubscriptionsLive"
+                  ref="liveTab"
+                  class="tab"
+                  role="tab"
+                  :aria-selected="currentTab === 'live'"
+                  aria-controls="subscriptionsPanel"
+                  data-subscription-feed-tab="live"
+                  :tabindex="currentTab === 'live' ? 0 : -1"
+                  :class="{ selectedTab: selectedTab === 'live' }"
+                  @click="changeTabFromPointer($event, 'live')"
+                  @keydown.space.enter.prevent="changeTab('live')"
+                  @keydown.left.right="switchTab($event, 'live')"
+                >
+                  <FtIcon
+                    :icon="['fa', 'tower-broadcast']"
+                    class="subscriptionIcon"
+                  />
+                  <span
+                    class="tabLabel"
+                    :data-label="$t('Global.Live')"
+                  ><span>{{ $t("Global.Live") }}</span></span>
+                  <FtLoader
+                    v-if="refreshingFeedTab === 'live'"
+                    class="tabLoadingIndicator"
+                  />
+                </div>
+                <!-- eslint-disable-next-line vuejs-accessibility/interactive-supports-focus -->
+                <div
+                  v-if="visibleTabs.includes('community')"
+                  ref="communityTab"
+                  class="tab"
+                  role="tab"
+                  :aria-selected="currentTab === 'community'"
+                  aria-controls="subscriptionsPanel"
+                  data-subscription-feed-tab="posts"
+                  :tabindex="currentTab === 'community' ? 0 : -1"
+                  :class="{ selectedTab: selectedTab === 'community' }"
+                  @click="changeTabFromPointer($event, 'community')"
+                  @keydown.space.enter.prevent="changeTab('community')"
+                  @keydown.left.right="switchTab($event, 'community')"
+                >
+                  <FtIcon
+                    :icon="['fa', 'message']"
+                    class="subscriptionIcon"
+                  />
+                  <span
+                    class="tabLabel"
+                    :data-label="$t('Global.Posts')"
+                  ><span>{{ $t("Global.Posts") }}</span></span>
+                  <FtLoader
+                    v-if="refreshingFeedTab === 'posts'"
+                    class="tabLoadingIndicator"
+                  />
+                </div>
+                <!-- eslint-disable-next-line vuejs-accessibility/interactive-supports-focus -->
+                <div
+                  v-if="visibleTabs.includes('new')"
+                  ref="newTab"
+                  class="tab"
+                  role="tab"
+                  :aria-selected="currentTab === 'new'"
+                  aria-controls="subscriptionsPanel"
+                  data-subscription-feed-tab="all"
+                  :tabindex="currentTab === 'new' ? 0 : -1"
+                  :class="{ selectedTab: selectedTab === 'new' }"
+                  @click="changeTabFromPointer($event, 'new')"
+                  @keydown.space.enter.prevent="changeTab('new')"
+                  @keydown.left.right="switchTab($event, 'new')"
+                >
+                  <FtIcon
+                    :icon="['fa', 'fire']"
+                    class="subscriptionIcon"
+                  />
+                  <span
+                    class="tabLabel"
+                    :data-label="$t('Global.New')"
+                  ><span>{{ $t("Global.New") }}</span></span>
+                </div>
+              </FtFlexBox>
+              <button
+                v-if="currentTabHasNewContent"
+                class="markAllSeenButton"
+                type="button"
+                :disabled="markingSeenTab !== null || currentTabRefreshing"
+                @click="markAllAsSeen(currentTab)"
+              >
+                <FtIcon :icon="['fas', 'check']" />
+                <span class="markAllSeenLabel">
+                  {{ $t('Subscriptions.Mark All as Seen') }}
+                </span>
+              </button>
+            </div>
+            <div
+              v-if="currentTabPanel !== null"
+              class="headerActions"
+            >
+              <FtIconButton
+                v-if="currentTab === 'new'"
+                class="headerViewToggle"
+                :title="newFeedView === 'tabbed'
+                  ? $t('Subscriptions.Show Combined View')
+                  : $t('Subscriptions.Show Tabbed View')"
+                :icon="newFeedView === 'tabbed' ? ['fas', 'layer-group'] : ['fas', 'clone']"
+                :aria-pressed="newFeedView === 'tabbed'"
+                :use-shadow="false"
+                :padding="8"
+                :size="20"
+                theme="base-no-default"
+                @click="toggleNewFeedView"
               />
-              <!-- eslint-disable-next-line vuejs-accessibility/interactive-supports-focus -->
-              <div
-                v-if="!hideSubscriptionsVideos"
-                ref="videosTab"
-                class="tab"
-                role="tab"
-                :aria-selected="currentTab === 'videos'"
-                aria-controls="subscriptionsPanel"
-                data-subscription-feed-tab="videos"
-                :tabindex="currentTab === 'videos' ? 0 : -1"
-                :class="{ selectedTab: selectedTab === 'videos' }"
-                @click="changeTabFromPointer($event, 'videos')"
-                @keydown.space.enter.prevent="changeTab('videos')"
-                @keydown.left.right="switchTab($event, 'videos')"
-              >
-                <FtIcon
-                  :icon="['fa', 'video']"
-                  class="subscriptionIcon"
-                />
-                <span
-                  class="tabLabel"
-                  :data-label="$t('Global.Videos')"
-                ><span>{{ $t("Global.Videos") }}</span></span>
-                <FtLoader
-                  v-if="refreshingFeedTab === 'videos'"
-                  class="tabLoadingIndicator"
-                />
-              </div>
-              <!-- eslint-disable-next-line vuejs-accessibility/interactive-supports-focus -->
-              <div
-                v-if="!hideSubscriptionsShorts"
-                ref="shortsTab"
-                class="tab"
-                role="tab"
-                :aria-selected="currentTab === 'shorts'"
-                aria-controls="subscriptionsPanel"
-                data-subscription-feed-tab="shorts"
-                :tabindex="currentTab === 'shorts' ? 0 : -1"
-                :class="{ selectedTab: selectedTab === 'shorts' }"
-                @click="changeTabFromPointer($event, 'shorts')"
-                @keydown.space.enter.prevent="changeTab('shorts')"
-                @keydown.left.right="switchTab($event, 'shorts')"
-              >
-                <FtIcon
-                  :icon="['fa', 'clapperboard']"
-                  class="subscriptionIcon"
-                />
-                <span
-                  class="tabLabel"
-                  :data-label="$t('Global.Shorts')"
-                ><span>{{ $t("Global.Shorts") }}</span></span>
-                <FtLoader
-                  v-if="refreshingFeedTab === 'shorts'"
-                  class="tabLoadingIndicator"
-                />
-              </div>
-              <!-- eslint-disable-next-line vuejs-accessibility/interactive-supports-focus -->
-              <div
-                v-if="!hideSubscriptionsLive"
-                ref="liveTab"
-                class="tab"
-                role="tab"
-                :aria-selected="currentTab === 'live'"
-                aria-controls="subscriptionsPanel"
-                data-subscription-feed-tab="live"
-                :tabindex="currentTab === 'live' ? 0 : -1"
-                :class="{ selectedTab: selectedTab === 'live' }"
-                @click="changeTabFromPointer($event, 'live')"
-                @keydown.space.enter.prevent="changeTab('live')"
-                @keydown.left.right="switchTab($event, 'live')"
-              >
-                <FtIcon
-                  :icon="['fa', 'tower-broadcast']"
-                  class="subscriptionIcon"
-                />
-                <span
-                  class="tabLabel"
-                  :data-label="$t('Global.Live')"
-                ><span>{{ $t("Global.Live") }}</span></span>
-                <FtLoader
-                  v-if="refreshingFeedTab === 'live'"
-                  class="tabLoadingIndicator"
-                />
-              </div>
-              <!-- eslint-disable-next-line vuejs-accessibility/interactive-supports-focus -->
-              <div
-                v-if="visibleTabs.includes('community')"
-                ref="communityTab"
-                class="tab"
-                role="tab"
-                :aria-selected="currentTab === 'community'"
-                aria-controls="subscriptionsPanel"
-                data-subscription-feed-tab="posts"
-                :tabindex="currentTab === 'community' ? 0 : -1"
-                :class="{ selectedTab: selectedTab === 'community' }"
-                @click="changeTabFromPointer($event, 'community')"
-                @keydown.space.enter.prevent="changeTab('community')"
-                @keydown.left.right="switchTab($event, 'community')"
-              >
-                <FtIcon
-                  :icon="['fa', 'message']"
-                  class="subscriptionIcon"
-                />
-                <span
-                  class="tabLabel"
-                  :data-label="$t('Global.Posts')"
-                ><span>{{ $t("Global.Posts") }}</span></span>
-                <FtLoader
-                  v-if="refreshingFeedTab === 'posts'"
-                  class="tabLoadingIndicator"
-                />
-              </div>
-              <!-- eslint-disable-next-line vuejs-accessibility/interactive-supports-focus -->
-              <div
-                v-if="visibleTabs.includes('new')"
-                ref="newTab"
-                class="tab"
-                role="tab"
-                :aria-selected="currentTab === 'new'"
-                aria-controls="subscriptionsPanel"
-                data-subscription-feed-tab="all"
-                :tabindex="currentTab === 'new' ? 0 : -1"
-                :class="{ selectedTab: selectedTab === 'new' }"
-                @click="changeTabFromPointer($event, 'new')"
-                @keydown.space.enter.prevent="changeTab('new')"
-                @keydown.left.right="switchTab($event, 'new')"
-              >
-                <FtIcon
-                  :icon="['fa', 'fire']"
-                  class="subscriptionIcon"
-                />
-                <span
-                  class="tabLabel"
-                  :data-label="$t('Global.New')"
-                ><span>{{ $t("Global.New") }}</span></span>
-              </div>
-            </FtFlexBox>
-            <button
-              v-if="currentTabHasNewContent"
-              class="markAllSeenButton"
-              type="button"
-              :disabled="markingSeenTab !== null || currentTabRefreshing"
-              @click="markAllAsSeen(currentTab)"
-            >
-              <FtIcon :icon="['fas', 'check']" />
-              {{ $t('Subscriptions.Mark All as Seen') }}
-            </button>
-          </div>
-          <div
-            v-if="currentTabPanel !== null"
-            class="headerActions"
-          >
-            <FtSelect
-              v-if="currentTab === 'new'"
-              class="headerSortSelect"
-              :placeholder="$t('Global.Sort By')"
-              :value="newFeedSortBy"
-              :select-names="newFeedSortByNames"
-              :select-values="NEW_FEED_SORT_BY_VALUES"
-              :icon="newFeedSortByIcon"
-              @change="updateNewFeedSortBy"
-            />
-            <FtRefreshWidget
-              embedded
-              class="headerRefreshWidget"
-              :disable-refresh="subscriptionFeedRefreshInProgress || currentTabPanel.isLoading || activeSubscriptionList.length === 0"
-              :last-refresh-timestamp="currentTabPanel.lastRefreshTimestamp"
-              :next-auto-refresh-timestamp="currentTabPanel.nextAutoRefreshTimestamp"
-              :next-auto-refresh-tooltip="currentTabPanel.nextAutoRefreshTooltip"
-              :next-auto-refresh-at="currentAutoRefresh.timestamp"
-              :auto-refresh-interval="currentAutoRefresh.interval"
-              :title="currentTabPanel.refreshTitle"
-              :refresh-in-progress="subscriptionFeedRefreshInProgress"
-              @click="refreshCurrentTab"
-              @cancel="cancelRefresh"
-            />
+              <FtSelect
+                v-if="currentTab === 'new'"
+                class="headerSortSelect"
+                :placeholder="$t('Global.Sort By')"
+                :value="newFeedSortBy"
+                :select-names="newFeedSortByNames"
+                :select-values="NEW_FEED_SORT_BY_VALUES"
+                :icon="newFeedSortByIcon"
+                @change="updateNewFeedSortBy"
+              />
+              <FtRefreshWidget
+                embedded
+                class="headerRefreshWidget"
+                :disable-refresh="subscriptionFeedRefreshInProgress || currentTabPanel.isLoading || activeSubscriptionList.length === 0"
+                :last-refresh-timestamp="currentTabPanel.lastRefreshTimestamp"
+                :next-auto-refresh-timestamp="currentTabPanel.nextAutoRefreshTimestamp"
+                :next-auto-refresh-tooltip="currentTabPanel.nextAutoRefreshTooltip"
+                :next-auto-refresh-at="currentAutoRefresh.timestamp"
+                :auto-refresh-interval="currentAutoRefresh.interval"
+                :title="currentTabPanel.refreshTitle"
+                :refresh-in-progress="subscriptionFeedRefreshInProgress"
+                @click="refreshCurrentTab"
+                @cancel="cancelRefresh"
+              />
+            </div>
           </div>
         </div>
+        <FtFlexBox
+          v-if="currentTab === 'new' && newFeedView === 'tabbed'"
+          ref="newFeedTabsContainerRef"
+          class="newFeedTabs"
+          role="tablist"
+          :aria-label="$t('Subscriptions.New Content Tabs')"
+        >
+          <div
+            v-if="newFeedTabsIndicatorStyle"
+            class="tabsIndicator newFeedTabsIndicator"
+            data-animation-speed-managed
+            :style="[newFeedTabsIndicatorStyle, { transitionDuration: tabsIndicatorTransitionDuration }]"
+            aria-hidden="true"
+          />
+          <button
+            v-for="tab in visibleNewFeedTabs"
+            :key="tab.id"
+            :ref="element => setNewFeedTabRef(tab.id, element)"
+            class="newFeedTab"
+            :class="{ selectedTab: currentNewFeedTab === tab.id }"
+            type="button"
+            role="tab"
+            :aria-selected="currentNewFeedTab === tab.id"
+            aria-controls="subscriptionsPanel"
+            :data-new-feed-tab="tab.id"
+            :tabindex="currentNewFeedTab === tab.id ? 0 : -1"
+            @click="changeNewFeedTab(tab.id)"
+            @keydown.left.right="switchNewFeedTab($event, tab.id)"
+            @keydown.home.end.prevent="switchNewFeedTab($event, tab.id)"
+          >
+            <FtIcon
+              :icon="tab.icon"
+              class="subscriptionIcon"
+            />
+            <span>{{ tab.label }}</span>
+          </button>
+        </FtFlexBox>
       </div>
       <KeepAlive>
         <SubscriptionsVideos
@@ -250,6 +311,7 @@
           key="subscriptions-new"
           ref="newPanel"
           role="tabpanel"
+          :active-category="newFeedView === 'tabbed' ? currentNewFeedTab : null"
         />
       </KeepAlive>
       <p v-if="currentTab === null">
@@ -279,6 +341,7 @@ import { useI18n } from 'vue-i18n'
 import FtCard from '../../components/ft-card/ft-card.vue'
 import FtLoader from '../../components/FtLoader/FtLoader.vue'
 import FtFlexBox from '../../components/ft-flex-box/ft-flex-box.vue'
+import FtIconButton from '../../components/FtIconButton/FtIconButton.vue'
 import FtPrompt from '../../components/FtPrompt/FtPrompt.vue'
 import FtRefreshWidget from '../../components/FtRefreshWidget/FtRefreshWidget.vue'
 import FtSelect from '../../components/FtSelect/FtSelect.vue'
@@ -316,6 +379,7 @@ const {
   showRefreshWarning: showAllFeedsRefreshWarning
 } = useRefreshAllSubscriptionFeeds()
 const currentTabStorageKey = 'Subscriptions/currentTab'
+const currentNewFeedTabStorageKey = 'Subscriptions/currentNewFeedTab'
 const NEW_FEED_SORT_BY_VALUES = ['newest', 'oldest']
 
 /** @type {import('vue').ComputedRef<boolean>} */
@@ -355,11 +419,20 @@ const newFeedSortByNames = computed(() => [
   t('Subscriptions.Oldest First')
 ])
 const newFeedSortByIcon = computed(() => getIconForSortPreference(newFeedSortBy.value))
+const newFeedView = computed(() => {
+  return store.getters.getNewSubscriptionFeedView === 'tabbed' ? 'tabbed' : 'combined'
+})
 
 function updateNewFeedSortBy(value) {
   if (NEW_FEED_SORT_BY_VALUES.includes(value)) {
     store.dispatch('updateNewSubscriptionFeedSortBy', value)
   }
+}
+
+async function toggleNewFeedView() {
+  const value = newFeedView.value === 'tabbed' ? 'combined' : 'tabbed'
+  await store.dispatch('updateNewSubscriptionFeedView', value)
+  resetNewFeedScroll()
 }
 
 const activeSubscriptionList = computed(() => {
@@ -560,6 +633,37 @@ const visibleTabs = computed(() => {
   return tabs
 })
 
+const newFeedTabDefinitions = computed(() => [
+  { id: 'videos', icon: ['fa', 'video'], label: t('Global.Videos') },
+  { id: 'shorts', icon: ['fa', 'clapperboard'], label: t('Global.Shorts') },
+  { id: 'live', icon: ['fa', 'tower-broadcast'], label: t('Global.Live') },
+  { id: 'posts', icon: ['fa', 'message'], label: t('Global.Posts') }
+])
+
+const visibleNewFeedTabs = computed(() => {
+  const visibleCategories = new Set(visibleTabs.value.map(tab => {
+    return tab === 'community' ? 'posts' : tab
+  }))
+
+  return newFeedTabDefinitions.value.filter(tab => visibleCategories.has(tab.id))
+})
+
+const storedNewFeedTab = localStorage.getItem(currentNewFeedTabStorageKey)
+/** @type {import('vue').Ref<'videos' | 'shorts' | 'live' | 'posts'>} */
+const currentNewFeedTab = ref(storedNewFeedTab ?? 'videos')
+/** @type {Map<string, HTMLElement>} */
+const newFeedTabRefs = new Map()
+
+watch(visibleNewFeedTabs, tabs => {
+  if (!tabs.some(tab => tab.id === currentNewFeedTab.value)) {
+    currentNewFeedTab.value = tabs[0]?.id ?? 'videos'
+  }
+}, { immediate: true })
+
+watch(currentNewFeedTab, value => {
+  localStorage.setItem(currentNewFeedTabStorageKey, value)
+})
+
 watch(visibleTabs, (value) => {
   if (value.length === 0) {
     tabChangeSequence++
@@ -637,6 +741,96 @@ function changeTabFromPointer(event, tab) {
 
   if (event.detail > 0 && document.activeElement instanceof HTMLElement) {
     document.activeElement.blur()
+  }
+}
+
+/**
+ * @param {'videos' | 'shorts' | 'live' | 'posts'} tab
+ */
+function changeNewFeedTab(tab) {
+  if (
+    tab === currentNewFeedTab.value ||
+    !visibleNewFeedTabs.value.some(visibleTab => visibleTab.id === tab)
+  ) {
+    return
+  }
+
+  currentNewFeedTab.value = tab
+  resetNewFeedScroll()
+}
+
+/**
+ * @param {KeyboardEvent} event
+ * @param {'videos' | 'shorts' | 'live' | 'posts'} focusedTab
+ */
+function switchNewFeedTab(event, focusedTab) {
+  if (event.altKey) {
+    return
+  }
+
+  event.preventDefault()
+
+  const tabs = visibleNewFeedTabs.value
+  let index = tabs.findIndex(tab => tab.id === focusedTab)
+
+  if (event.key === 'Home') {
+    index = 0
+  } else if (event.key === 'End') {
+    index = tabs.length - 1
+  } else if (event.key === 'ArrowLeft') {
+    index = index <= 0 ? tabs.length - 1 : index - 1
+  } else {
+    index = index >= tabs.length - 1 ? 0 : index + 1
+  }
+
+  const tab = tabs[index]?.id
+  if (tab == null) {
+    return
+  }
+
+  changeNewFeedTab(tab)
+  nextTick(() => newFeedTabRefs.get(tab)?.focus())
+  store.commit('setOutlinesHidden', false)
+}
+
+/**
+ * @param {'videos' | 'shorts' | 'live' | 'posts'} tab
+ * @param {Element | import('vue').ComponentPublicInstance | null} element
+ */
+function setNewFeedTabRef(tab, element) {
+  if (element instanceof HTMLElement) {
+    newFeedTabRefs.set(tab, element)
+  } else {
+    newFeedTabRefs.delete(tab)
+  }
+}
+
+async function resetNewFeedScroll() {
+  tabScrollPositions.new = 0
+
+  if (
+    currentTab.value !== 'new' ||
+    (isElectron && isTabPresented?.value !== true)
+  ) {
+    return
+  }
+
+  if (isElectron && tabId) {
+    getTabNavigationService().resetScroll(tabId)
+  } else {
+    window.scrollTo({ left: 0, top: 0, behavior: 'instant' })
+  }
+
+  await nextTick()
+  await nextAnimationFrame()
+
+  if (
+    isMounted &&
+    currentTab.value === 'new' &&
+    (!isElectron || isTabPresented?.value === true)
+  ) {
+    window.scrollTo({ left: 0, top: 0, behavior: 'instant' })
+    scrollPositionOwnerTab = 'new'
   }
 }
 
@@ -872,6 +1066,7 @@ async function handleFeedReloadRequest(payload) {
 
 // ===== Single row header =====
 const headerRowRef = useTemplateRef('headerRowRef')
+const feedTabsControlsRowRef = useTemplateRef('feedTabsControlsRowRef')
 const tabsRowRef = useTemplateRef('tabsRowRef')
 /** @type {import('vue').Ref<boolean>} */
 const headerFitsOneRow = ref(false)
@@ -886,6 +1081,7 @@ let headerResizeObserver = null
  */
 function singleLineWidth(container, childWidth = child => child.getBoundingClientRect().width) {
   const children = Array.from(container.children)
+    .filter(child => getComputedStyle(child).position !== 'absolute')
   const columnGap = Number.parseFloat(getComputedStyle(container).columnGap) || 0
 
   return children.reduce((total, child) => total + childWidth(child), 0) +
@@ -893,28 +1089,57 @@ function singleLineWidth(container, childWidth = child => child.getBoundingClien
 }
 
 /**
- * The tabs sit next to the page title while the title, the tabs and the refresh
- * widget fit onto one line together, otherwise the tabs drop onto a line of
- * their own. The single row layout doesn't let its children shrink and the tabs
- * are measured through their content, so the measurement is the same in both
- * layouts and they can't flip back and forth.
+ * The inline size available to flex children. getBoundingClientRect includes
+ * the padding used to extend the tabbed-view separator across the header.
+ * @param {HTMLElement} element
+ */
+function contentBoxWidth(element) {
+  const style = getComputedStyle(element)
+  return element.getBoundingClientRect().width -
+    (Number.parseFloat(style.paddingInlineStart) || 0) -
+    (Number.parseFloat(style.paddingInlineEnd) || 0) -
+    (Number.parseFloat(style.borderInlineStartWidth) || 0) -
+    (Number.parseFloat(style.borderInlineEndWidth) || 0)
+}
+
+/**
+ * The tabs and actions sit next to the page title while all three fit onto one
+ * line. Otherwise the tabs and actions move together below the title. The
+ * single row layout doesn't let its children shrink and the tabs are measured
+ * through their content, so the measurement is stable in both layouts.
  */
 function updateHeaderFitsOneRow() {
   const row = headerRowRef.value
+  const feedTabsControlsRow = feedTabsControlsRowRef.value
   const tabsRow = tabsRowRef.value
+  const tabs = tabsContainerRef.value?.$el
 
-  if (!(row instanceof HTMLElement) || row.getClientRects().length === 0) {
+  if (
+    !(row instanceof HTMLElement) ||
+    !(feedTabsControlsRow instanceof HTMLElement) ||
+    !(tabsRow instanceof HTMLElement) ||
+    !(tabs instanceof HTMLElement) ||
+    row.getClientRects().length === 0
+  ) {
     return
   }
 
+  const tabsRowWidth = singleLineWidth(tabsRow, child => {
+    return child === tabs ? singleLineWidth(tabs) : child.getBoundingClientRect().width
+  })
+  const feedTabsControlsRowWidth = singleLineWidth(feedTabsControlsRow, child => {
+    return child === tabsRow ? tabsRowWidth : child.getBoundingClientRect().width
+  })
   const requiredWidth = singleLineWidth(row, child => {
-    // The tabs stretch across the whole header while they have their own line
-    return child === tabsRow ? singleLineWidth(child) : child.getBoundingClientRect().width
+    // The grouped row stretches across the header in the split layout
+    return child === feedTabsControlsRow
+      ? feedTabsControlsRowWidth
+      : child.getBoundingClientRect().width
   })
 
   // Fractional widths throughout, as rounding the available space up would let
   // the single row layout overflow, which puts the tabs onto a second line again
-  headerFitsOneRow.value = requiredWidth <= row.getBoundingClientRect().width
+  headerFitsOneRow.value = requiredWidth <= contentBoxWidth(row)
 }
 
 function observeHeaderRow() {
@@ -935,7 +1160,15 @@ function observeHeaderRow() {
     headerResizeObserver.observe(child)
   }
 
+  for (const child of feedTabsControlsRowRef.value?.children ?? []) {
+    headerResizeObserver.observe(child)
+  }
+
   for (const child of tabsRowRef.value?.children ?? []) {
+    headerResizeObserver.observe(child)
+  }
+
+  for (const child of tabsContainerRef.value?.$el?.children ?? []) {
     headerResizeObserver.observe(child)
   }
 }
@@ -949,8 +1182,11 @@ watch([currentTabPanel, currentTabHasNewContent], () => nextTick(() => {
 
 // ===== Sliding feed tab indicator =====
 const tabsContainerRef = useTemplateRef('tabsContainerRef')
+const newFeedTabsContainerRef = useTemplateRef('newFeedTabsContainerRef')
 /** @type {import('vue').Ref<Record<string, string> | null>} */
 const tabsIndicatorStyle = ref(null)
+/** @type {import('vue').Ref<Record<string, string> | null>} */
+const newFeedTabsIndicatorStyle = ref(null)
 const tabsIndicatorTransitionDuration = computed(() => {
   return `${200 / getAnimationSpeedMultiplier(store.getters.getAnimationSpeed)}ms`
 })
@@ -958,59 +1194,88 @@ let tabsResizeObserver = null
 // Place the indicator without animating when it was last measured while
 // hidden (e.g. in a background browser tab, where all offsets read 0),
 // otherwise it visibly flies in from the stale position.
-let tabsIndicatorWasHidden = true
+const tabsIndicatorState = { wasHidden: true }
+const newFeedTabsIndicatorState = { wasHidden: true }
 
 /**
- * @param {HTMLElement} tabElement
- * @returns {boolean} whether the indicator was positioned on the tab
+ * @param {import('vue').ShallowRef<import('vue').ComponentPublicInstance | null>} containerRef
+ * @param {string} selectedTabSelector
+ * @param {import('vue').Ref<Record<string, string> | null>} indicatorStyle
+ * @param {{ wasHidden: boolean }} state
  */
-function placeTabsIndicator(tabElement) {
-  if (tabElement.getClientRects().length === 0) {
-    tabsIndicatorWasHidden = true
-    return false
-  }
-
-  // Physical values to match the physical offset measurements (RTL-safe).
-  // The indicator sits just below the tab, like the old selectedTab border
-  // (which extended past the box through its -3px margin).
-  // Only the transform is animated, so the movement runs on the compositor and
-  // doesn't stutter while the main thread renders a large feed.
-  const style = {
-    transform: `translate(${tabElement.offsetLeft}px, ${tabElement.offsetTop + tabElement.offsetHeight}px) scaleX(${tabElement.offsetWidth})`
-  }
-
-  if (tabsIndicatorWasHidden) {
-    style.transition = 'none'
-    tabsIndicatorWasHidden = false
-  }
-
-  tabsIndicatorStyle.value = style
-  return true
-}
-
-function updateTabsIndicator() {
-  const container = tabsContainerRef.value?.$el
-  const selected = container?.querySelector('.tab.selectedTab')
+function updateTabIndicator(containerRef, selectedTabSelector, indicatorStyle, state) {
+  const container = containerRef.value?.$el
+  const selected = container?.querySelector(selectedTabSelector)
 
   if (!(selected instanceof HTMLElement)) {
-    tabsIndicatorStyle.value = null
-    tabsIndicatorWasHidden = true
+    indicatorStyle.value = null
+    state.wasHidden = true
     return
   }
 
-  placeTabsIndicator(selected)
+  if (selected.getClientRects().length === 0) {
+    indicatorStyle.value = null
+    state.wasHidden = true
+    return
+  }
+
+  // Physical values match the physical offset measurements and remain RTL-safe.
+  // The indicator sits just below the tab and only its transform is animated,
+  // keeping movement on the compositor while a large feed renders.
+  const style = {
+    transform: `translate(${selected.offsetLeft}px, ${selected.offsetTop + selected.offsetHeight}px) scaleX(${selected.offsetWidth})`
+  }
+
+  if (state.wasHidden) {
+    style.transition = 'none'
+  }
+
+  indicatorStyle.value = style
+  state.wasHidden = false
+}
+
+const updateTabsIndicator = () => updateTabIndicator(
+  tabsContainerRef,
+  '.tab.selectedTab',
+  tabsIndicatorStyle,
+  tabsIndicatorState
+)
+const updateNewFeedTabsIndicator = () => updateTabIndicator(
+  newFeedTabsContainerRef,
+  '.newFeedTab.selectedTab',
+  newFeedTabsIndicatorStyle,
+  newFeedTabsIndicatorState
+)
+
+function observeTabContainers() {
+  if (tabsResizeObserver === null) {
+    return
+  }
+
+  tabsResizeObserver.disconnect()
+
+  for (const container of [tabsContainerRef.value?.$el, newFeedTabsContainerRef.value?.$el]) {
+    if (container instanceof HTMLElement) {
+      tabsResizeObserver.observe(container)
+    }
+  }
 }
 
 watch([selectedTab, visibleTabs, refreshingFeedTab], () => nextTick(updateTabsIndicator))
+watch([currentNewFeedTab, visibleNewFeedTabs], () => nextTick(updateNewFeedTabsIndicator))
+watch([currentTab, newFeedView], () => nextTick(() => {
+  observeTabContainers()
+  updateNewFeedTabsIndicator()
+}))
 
 onMounted(() => {
   if (typeof ResizeObserver === 'function') {
     // Per-tab loaders resize the container while a refresh is running
-    tabsResizeObserver = new ResizeObserver(() => updateTabsIndicator())
-
-    if (tabsContainerRef.value?.$el instanceof HTMLElement) {
-      tabsResizeObserver.observe(tabsContainerRef.value.$el)
-    }
+    tabsResizeObserver = new ResizeObserver(() => {
+      updateTabsIndicator()
+      updateNewFeedTabsIndicator()
+    })
+    observeTabContainers()
 
     headerResizeObserver = new ResizeObserver(() => updateHeaderFitsOneRow())
     observeHeaderRow()
@@ -1019,6 +1284,7 @@ onMounted(() => {
   nextTick(() => {
     updateHeaderFitsOneRow()
     updateTabsIndicator()
+    updateNewFeedTabsIndicator()
   })
 })
 

--- a/static/locales/de-DE.yaml
+++ b/static/locales/de-DE.yaml
@@ -115,6 +115,9 @@ Subscriptions:
   New Since Last Refresh: Neu seit der letzten Aktualisierung
   Mark All as Seen: Alle als gesehen markieren
   No New Content: Es gibt keine neuen Inhalte.
+  New Content Tabs: Registerkarten für neue Inhalte
+  Show Tabbed View: Registerkartenansicht anzeigen
+  Show Combined View: Kombinierte Ansicht anzeigen
   Mark as Seen: Als gesehen markieren
   Newest First: Neueste zuerst
   Oldest First: Älteste zuerst

--- a/static/locales/en-US.yaml
+++ b/static/locales/en-US.yaml
@@ -233,6 +233,9 @@ Subscriptions:
   Mark as Seen: Mark as seen
   Mark All as Seen: Mark all as seen
   No New Content: There is no new content.
+  New Content Tabs: New content tabs
+  Show Tabbed View: Show tabbed view
+  Show Combined View: Show combined view
   Newest First: Newest first
   Oldest First: Oldest first
 More: More


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Make sure to follow the contributing guidelines. -->
<!-- Important note, we may remove your pull request if you do not use this provided PR template correctly. -->
<!-- Agent instructions: Preserve every heading, comment, and marker in this template. Never remove or rewrite the release-note-category:start/end, release-note:start/end, or release-note-image:start/end marker pairs. -->

## Pull Request Type
<!-- Please select what type of pull request this is: [x] -->
- [ ] Bugfix
- [x] Feature Implementation
- [ ] Documentation
- [ ] Other

## Related issue
<!-- Please link the issue your pull request is referring to. -->
<!-- If this pull request fully resolves the relevant issue, put "closes" before the issue number. -->
<!-- Example: "closes #123456". -->

## Description
<!-- Please write a clear and concise description of what the pull request does. -->
The New subscriptions feed currently puts every content type on one long page. This adds an optional tabbed view so videos, Shorts, live streams, and posts can be viewed separately without losing the existing combined view.

The toggle sits immediately before the sort control and remembers the chosen view. The centered content tabs use the same sliding indicator as the main feed tabs, while the header keeps its tabs and controls aligned as the window narrows.

## Release note category
<!-- Select exactly one category. Every pull request must select one. -->
<!-- Select "Not noteworthy" when the pull request fixes a bug in or improves functionality that has not yet appeared in a stable release. -->
<!-- release-note-category:start -->
- [ ] Not noteworthy
- [ ] Highlights
- [x] More improvements
- [ ] Fixed bugs
<!-- release-note-category:end -->

## Release note
<!-- Required unless "Not noteworthy" is selected. -->
<!-- Write one concise, user-facing entry without a leading bullet. -->
<!-- release-note:start -->
The New subscriptions feed can now switch between combined sections or tabs.
<!-- release-note:end -->

## Release note images
<!-- Optional. Paste one or more Markdown images, HTML image tags, or dark/light <picture> elements here. -->
<!-- The release notes normalize the markup and limit images taller than 300 pixels. -->
<!-- Agent instructions:
For a noteworthy visible change, add media when it makes the change easier to understand. Prefer a still image unless motion is the point; recordings must use animated WebP.
After implementing a visible change, proactively capture the result and show the local media to the user for approval before uploading it or updating the pull request.
When the affected UI differs between dark and light themes, capturing both themes is required. A dark-only image is incomplete. Run `node _scripts/releaseNoteMedia.mjs --dark DARK_FILE --light LIGHT_FILE --alt "DESCRIPTION"`; GitHub will display the matching theme and use dark as the fallback. Use a single default-dark capture only when the light theme cannot be captured or looks identical.
Capture or crop to the smallest region that still makes the change clear. Do not include the full window when the affected component can be understood on its own.
Use English unless localization is the subject. Keep components at their normal dimensions and placement instead of resizing them to fill the frame.
Use deterministic local fixtures for visible remote images. Reusable avatar and thumbnail fixtures are available through `e2e/helpers/visual-fixtures.mjs`. Before capturing, verify that every visible image has loaded successfully (`complete === true` and `naturalWidth > 0`).
Inspect the final dark and light files for failed images, missing content, unrelated UI, awkward animation, and misleading layout. Omit media when it does not explain the change clearly.
For one dark capture, run `node _scripts/releaseNoteMedia.mjs FILE --alt "DESCRIPTION"`.
Check for personal information, tokens, private repository names, and unrelated desktop content before uploading. Uploaded media is public.
Keep capture-only scripts, test hooks, screenshots, and recordings out of commits. Remove them before committing unless the capture code is also a reusable regression test. Never commit generated release-note media.
Paste only the generated markup between the marker comments. Leave this section empty when media would not help.
-->
<!-- release-note-image:start -->
<picture>
  <source media="(prefers-color-scheme: dark)" srcset="https://github.com/OpenTubeX/media/releases/download/attachments/20260827T200027Z-new-feed-tabbed-dark-dark-8c5a594149.png">
  <source media="(prefers-color-scheme: light)" srcset="https://github.com/OpenTubeX/media/releases/download/attachments/20260827T200027Z-new-feed-tabbed-light-light-e57a70f649.png">
  <img alt="Tabbed New subscriptions feed in dark and light themes" src="https://github.com/OpenTubeX/media/releases/download/attachments/20260827T200027Z-new-feed-tabbed-dark-dark-8c5a594149.png">
</picture>
<!-- release-note-image:end -->

## Testing
<!-- How can reviewers verify that the PR produces correct results? -->
<!-- Please provide instructions so that others can ensure that your pull request would produce correct results. For examples see, https://github.com/FreeTubeApp/FreeTube/pull/5743, https://github.com/FreeTubeApp/FreeTube/pull/7349, https://github.com/FreeTubeApp/FreeTube/pull/5125, https://github.com/FreeTubeApp/FreeTube/pull/7338 -->
<!-- Agent instructions: Only write human-facing steps that explain how to verify the change while running this branch in dev mode. Include expected results and, when applicable, helpful console snippets for interactive verification. Do not include automated checks, commands, results, pass counts, or CI status. -->
1. Open Subscriptions and select the New feed.
2. Use the view button immediately left of Sort By. The tabbed view should add a centered Videos, Shorts, Live, and Posts row below the main feed tabs, with a separator between both rows.
3. Switch between the content tabs. The indicator should slide to the selected tab and the feed should show only that content type.
4. Narrow the window until the page title wraps above the main tabs. The sort, view, and refresh controls should remain aligned with those tabs without horizontal overflow.
5. Return to combined view, restart the app, and revisit the New feed. The selected view, content tab, and sort order should persist.
6. Focus a content tab and use Left Arrow, Right Arrow, Home, and End. Focus and content should follow the selected tab, while Alt+Left Arrow and Alt+Right Arrow remain available for navigation.

## Additional context
<!-- Add any other context about the pull request here. -->
