### PR TITLE
fix: correct comment filter layering and creator replies

### DIFF
--- a/e2e/tests/offline/watch-page.spec.mjs
+++ b/e2e/tests/offline/watch-page.spec.mjs
@@ -3697,16 +3697,20 @@ test.describe('manual comment loading', () => {
     await expect(ownerReplyToggle.locator('.commentReplyToggleText')).toHaveText(/\d+ replies/)
     await expect(ownerReplyToggle).not.toContainText('from')
     const ownerReplyThread = page.locator('.commentThread').filter({ has: ownerReplyToggle })
-    const ownerReplyCommentText = await ownerReplyThread.locator('.commentText').first().innerText()
+    const ownerReplyThreadElement = await ownerReplyThread.elementHandle()
+    expect(ownerReplyThreadElement).not.toBeNull()
     await expect(ownerReplyThread.locator('.commentReplyContent')).toHaveCount(0)
     await ownerReplyToggle.scrollIntoViewIfNeeded()
     await attachScreenshot('uploader reply indicator')
 
     await page.getByRole('button', { name: 'Filter loaded comments' }).click()
     await page.getByRole('checkbox', { name: 'From creator' }).click()
-    const filteredOwnerReplyThread = page.locator('.commentThread').filter({ hasText: ownerReplyCommentText })
-    await expect(filteredOwnerReplyThread).toBeVisible()
-    await expect(filteredOwnerReplyThread.locator('.commentReplyContent')).toHaveCount(0)
+    await expect.poll(() => ownerReplyThreadElement.evaluate(element => ({
+      isConnected: element.isConnected,
+      isVisible: element.getClientRects().length > 0,
+      loadedReplyCount: element.querySelectorAll('.commentReplyContent').length
+    }))).toEqual({ isConnected: true, isVisible: true, loadedReplyCount: 0 })
+    await ownerReplyThreadElement.dispose()
   })
 
   test('searches the comments loaded for the current video', async ({ app, page }) => {
@@ -4090,7 +4094,7 @@ test.describe('manual comment loading', () => {
       await expect(scrollbar).not.toHaveClass(/os-scrollbar-unusable/)
     })
 
-    test('clamps fullscreen comment scrolling after filtering', async ({ app, page }) => {
+    test('clamps fullscreen comment scrolling after creator and search filtering', async ({ app, page }) => {
       await mockPlayableWatchPage(app, page)
       await openMockedVideo(page)
 
@@ -4116,6 +4120,21 @@ test.describe('manual comment loading', () => {
       await expect.poll(() => scroller.evaluate(element => element.scrollHeight > element.clientHeight)).toBe(true)
       await expect(scrollbar).not.toHaveClass(/os-scrollbar-unusable/)
 
+      await scroller.evaluate(element => { element.scrollTop = element.scrollHeight })
+      await expect.poll(() => scroller.evaluate(element => element.scrollTop)).toBeGreaterThan(0)
+
+      await dock.getByRole('button', { name: 'Filter loaded comments' }).click()
+      const creatorFilter = dock.getByRole('checkbox', { name: 'From creator' })
+      await creatorFilter.click()
+
+      await expect(dock.locator('.commentThread')).toHaveCount(1)
+      await expect.poll(() => scroller.evaluate(element => element.scrollTop)).toBe(0)
+      await expect(scrollbar).toHaveClass(/os-scrollbar-unusable/)
+
+      await creatorFilter.click()
+      await expect.poll(() => scroller.evaluate(element => element.scrollHeight > element.clientHeight)).toBe(true)
+      await expect(scrollbar).not.toHaveClass(/os-scrollbar-unusable/)
+      await dock.getByRole('button', { name: 'Filter loaded comments' }).click()
       await scroller.evaluate(element => { element.scrollTop = element.scrollHeight })
       await expect.poll(() => scroller.evaluate(element => element.scrollTop)).toBeGreaterThan(0)
 

--- a/e2e/tests/offline/watch-page.spec.mjs
+++ b/e2e/tests/offline/watch-page.spec.mjs
@@ -2414,6 +2414,41 @@ test.describe('watch page', () => {
     await watchComponent.dispose()
   })
 
+  test('keeps the Shorts comment filter menu above creator hearts', async ({ app, page, attachScreenshot }) => {
+    await mockPlayableWatchPage(app, page)
+    await page.locator(sel.searchInput).fill('https://www.youtube.com/shorts/jNQXAC9IVRw')
+    await page.locator(sel.searchInput).press('Enter')
+    await expect(page).toHaveURL(/#\/watch\/jNQXAC9IVRw\?short=true/)
+    await waitForPlayback(page)
+
+    const watchComponent = await page.evaluateHandle(findWatchComponent)
+    await watchComponent.evaluate(async (component) => {
+      component.proxy.toggleShortsComments()
+      await component.proxy.$nextTick()
+    })
+
+    const commentsPanel = page.locator('.shortsCommentsPanel')
+    const heart = commentsPanel.locator('.commentHeartBadgeRed').first()
+    await expect(heart).toBeVisible({ timeout: 30_000 })
+    await commentsPanel.getByRole('button', { name: 'Filter loaded comments' }).click()
+
+    const menu = commentsPanel.getByRole('dialog', { name: 'Comment filters' })
+    await expect(menu).toBeVisible()
+    await attachScreenshot('Shorts comment filter above creator heart')
+    const menuCoversHeart = await menu.evaluate((element, heartElement) => {
+      const menuBounds = element.getBoundingClientRect()
+      const heartBounds = heartElement.getBoundingClientRect()
+      const x = Math.max(menuBounds.left, heartBounds.left) + 1
+      const y = Math.max(menuBounds.top, heartBounds.top) + 1
+      const overlaps = x < Math.min(menuBounds.right, heartBounds.right) &&
+        y < Math.min(menuBounds.bottom, heartBounds.bottom)
+      return overlaps && document.elementFromPoint(x, y)?.closest('.commentFilterMenu') === element
+    }, await heart.elementHandle())
+
+    expect(menuCoversHeart).toBe(true)
+    await watchComponent.dispose()
+  })
+
   test('sidebar chapters and SponsorBlock honor roundness while closing beside the description', async ({ app, page }) => {
     await mockPlayableWatchPage(app, page)
     await openMockedVideo(page)
@@ -3643,7 +3678,7 @@ test.describe('manual comment loading', () => {
     await expect(translationButtons).toHaveCount(0)
   })
 
-  test('identifies collapsed replies from the video uploader', async ({ app, page, attachScreenshot }) => {
+  test('identifies and filters collapsed replies from the video uploader', async ({ app, page, attachScreenshot }) => {
     await mockPlayableWatchPage(app, page, { ownerReply: true })
     await openMockedVideo(page)
 
@@ -3661,8 +3696,17 @@ test.describe('manual comment loading', () => {
     await expect(ownerReplyToggle.locator('.commentReplyOwnerSeparator')).toHaveText('•')
     await expect(ownerReplyToggle.locator('.commentReplyToggleText')).toHaveText(/\d+ replies/)
     await expect(ownerReplyToggle).not.toContainText('from')
+    const ownerReplyThread = page.locator('.commentThread').filter({ has: ownerReplyToggle })
+    const ownerReplyCommentText = await ownerReplyThread.locator('.commentText').first().innerText()
+    await expect(ownerReplyThread.locator('.commentReplyContent')).toHaveCount(0)
     await ownerReplyToggle.scrollIntoViewIfNeeded()
     await attachScreenshot('uploader reply indicator')
+
+    await page.getByRole('button', { name: 'Filter loaded comments' }).click()
+    await page.getByRole('checkbox', { name: 'From creator' }).click()
+    const filteredOwnerReplyThread = page.locator('.commentThread').filter({ hasText: ownerReplyCommentText })
+    await expect(filteredOwnerReplyThread).toBeVisible()
+    await expect(filteredOwnerReplyThread.locator('.commentReplyContent')).toHaveCount(0)
   })
 
   test('searches the comments loaded for the current video', async ({ app, page }) => {

--- a/src/renderer/components/CommentSection/CommentSection.css
+++ b/src/renderer/components/CommentSection/CommentSection.css
@@ -606,6 +606,7 @@
 .commentHeartBadge {
   display: inline-block;
   position: relative;
+  isolation: isolate;
   inline-size: 25px;
   block-size: 20px;
   margin-inline-start: 10px;

--- a/src/renderer/components/CommentSection/CommentSection.vue
+++ b/src/renderer/components/CommentSection/CommentSection.vue
@@ -769,7 +769,7 @@ const hasActiveCommentFilters = computed(() => {
 })
 
 function commentMatchesActiveFilters(comment) {
-  if (creatorCommentsOnly.value && !comment.isOwner) {
+  if (creatorCommentsOnly.value && !comment.isOwner && !comment.hasOwnerReplied) {
     return false
   }
 


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Make sure to follow the contributing guidelines. -->
<!-- Important note, we may remove your pull request if you do not use this provided PR template correctly. -->
<!-- Agent instructions: Preserve every heading, comment, and marker in this template. Never remove or rewrite the release-note-category:start/end, release-note:start/end, or release-note-image:start/end marker pairs. -->

## Pull Request Type
<!-- Please select what type of pull request this is: [x] -->
- [x] Bugfix
- [ ] Feature Implementation
- [ ] Documentation
- [ ] Other

## Related issue
<!-- Please link the issue your pull request is referring to. -->
<!-- If this pull request fully resolves the relevant issue, put "closes" before the issue number. -->
<!-- Example: "closes #123456". -->
No linked issue.

## Description
<!-- Please write a clear and concise description of what the pull request does. -->
Creator hearts could paint above the comment-filter popover in Shorts. The "From creator" filter also removed threads where the API reported an unloaded creator reply.

This isolates the heart badge's internal layers and treats the existing `hasOwnerReplied` marker as a creator-filter match. Focused regressions cover both cases.

## Release note category
<!-- Select exactly one category. Every pull request must select one. -->
<!-- Select "Not noteworthy" when the pull request fixes a bug in or improves functionality that has not yet appeared in a stable release. -->
<!-- release-note-category:start -->
- [x] Not noteworthy
- [ ] Highlights
- [ ] More improvements
- [ ] Fixed bugs
<!-- release-note-category:end -->

## Release note
<!-- Required unless "Not noteworthy" is selected. -->
<!-- Write one concise, user-facing entry without a leading bullet. -->
<!-- release-note:start -->
Comment filters no longer appear behind creator hearts and now include threads with unloaded creator replies.
<!-- release-note:end -->

## Release note images
<!-- Optional. Paste one or more Markdown images, HTML image tags, or dark/light <picture> elements here. -->
<!-- The release notes normalize the markup and limit images taller than 300 pixels. -->
<!-- Agent instructions:
For a noteworthy visible change, add media when it makes the change easier to understand. Prefer a still image unless motion is the point; recordings must use animated WebP.
After implementing a visible change, proactively capture the result and show the local media to the user for approval before uploading it or updating the pull request.
When the affected UI differs between dark and light themes, capturing both themes is required. A dark-only image is incomplete. Run `node _scripts/releaseNoteMedia.mjs --dark DARK_FILE --light LIGHT_FILE --alt "DESCRIPTION"`; GitHub will display the matching theme and use dark as the fallback. Use a single default-dark capture only when the light theme cannot be captured or looks identical.
Capture or crop to the smallest region that still makes the change clear. Do not include the full window when the affected component can be understood on its own.
Use English unless localization is the subject. Keep components at their normal dimensions and placement instead of resizing them to fill the frame.
Use deterministic local fixtures for visible remote images. Reusable avatar and thumbnail fixtures are available through `e2e/helpers/visual-fixtures.mjs`. Before capturing, verify that every visible image has loaded successfully (`complete === true` and `naturalWidth > 0`).
Inspect the final dark and light files for failed images, missing content, unrelated UI, awkward animation, and misleading layout. Omit media when it does not explain the change clearly.
Keep capture-only scripts, test hooks, screenshots, and recordings out of commits. Remove them before committing unless the capture code is also a reusable regression test. Never commit generated release-note media.
Paste only the generated markup between the marker comments. Leave this section empty when media would not help.
-->
<!-- release-note-image:start -->

<!-- release-note-image:end -->

## Testing
<!-- How can reviewers verify that the PR produces correct results? -->
<!-- Please provide instructions so that others can ensure that your pull request would produce correct results. For examples see, https://github.com/FreeTubeApp/FreeTube/pull/5743, https://github.com/FreeTubeApp/pull/7349, https://github.com/FreeTubeApp/FreeTube/pull/5125, https://github.com/FreeTubeApp/FreeTube/pull/7338 -->
<!-- Agent instructions: Only write human-facing steps that explain how to verify the change while running this branch in dev mode. Include expected results and, when applicable, helpful console snippets for interactive verification. Do not include automated checks, commands, results, pass counts, or CI status. -->
1. Open a Short with creator-hearted comments, open its comments panel, and open the comment-filter menu. Confirm the menu stays above every creator heart.
2. Open a video with a collapsed thread that shows the creator-reply avatar. Select "From creator" before loading that thread's replies. Confirm the parent thread remains visible and its replies remain unloaded.

## Additional context
<!-- Add any other context about the pull request here. -->
The collapsed-reply avatar and the filter now use the same `hasOwnerReplied` signal.
