### PR TITLE
feat(themes): share custom themes through Discussions

### DIFF
--- a/e2e/tests/offline/appearance.spec.mjs
+++ b/e2e/tests/offline/appearance.spec.mjs
@@ -415,6 +415,46 @@ test.describe('custom theme editor', () => {
     })).toMatch(/^custom:/)
   })
 
+  test('opens a pre-filled theme discussion with the current draft', async ({ app, page }) => {
+    await app.electronApp.evaluate(({ shell }) => {
+      globalThis.openedThemeDiscussionUrl = null
+      shell.openExternal = async (url) => {
+        globalThis.openedThemeDiscussionUrl = url
+      }
+    })
+    await goToSettingsSection(page, 'theme')
+    await page.getByRole('button', { name: 'Create custom theme' }).click()
+    await page.getByRole('textbox', { name: 'Theme name' }).fill('Aurora & Night')
+
+    const shareButton = page.getByRole('button', { name: 'Share theme' })
+    await expect(shareButton.locator('.ft-icon')).toBeVisible()
+    await shareButton.click()
+
+    await expect.poll(() => app.electronApp.evaluate(() => {
+      return globalThis.openedThemeDiscussionUrl
+    })).not.toBeNull()
+    const openedUrl = await app.electronApp.evaluate(() => globalThis.openedThemeDiscussionUrl)
+    const discussionUrl = new URL(openedUrl)
+    expect(discussionUrl.origin).toBe('https://github.com')
+    expect(discussionUrl.pathname).toBe('/OpenTubeX/OpenTubeX/discussions/new')
+    expect(discussionUrl.searchParams.get('category')).toBe('themes')
+    expect(discussionUrl.searchParams.get('title')).toBe('Aurora & Night')
+
+    const body = discussionUrl.searchParams.get('body')
+    expect(body).toContain('## Description')
+    expect(body).toContain('## Screenshots')
+    expect(body).toContain('Drag and drop one or more screenshots here.')
+    expect(body).toContain('<details>')
+    expect(body).toContain('<summary>Theme JSON</summary>')
+    const themeJson = body.match(/```json\n([\s\S]+)\n```/)
+    expect(themeJson).not.toBeNull()
+    expect(JSON.parse(themeJson[1])).toMatchObject({
+      version: 2,
+      name: 'Aurora & Night',
+      basedOn: 'dark'
+    })
+  })
+
   test('copies built-in themes, previews efficiently, persists, and survives closing settings', async ({ app, page }) => {
     await goToSettingsSection(page, 'theme')
     await page.getByRole('button', { name: 'Highlight settings changed from defaults' }).click()

--- a/src/renderer/components/CustomThemeEditor/CustomThemeEditor.vue
+++ b/src/renderer/components/CustomThemeEditor/CustomThemeEditor.vue
@@ -28,6 +28,11 @@
             :icon="['fas', 'download']"
             @click="exportTheme"
           />
+          <FtIconButton
+            :title="t('Settings.Theme Settings.Custom Theme.Share Theme')"
+            :icon="['fas', 'share-alt']"
+            @click="shareTheme"
+          />
         </div>
       </div>
       <div class="themeSources">
@@ -158,7 +163,9 @@ import {
   saveCustomTheme,
 } from '../../helpers/customTheme'
 import { colors } from '../../helpers/colors'
-import { readFileWithPicker, showToast, writeFileWithPicker } from '../../helpers/utils'
+import { openExternalLink, readFileWithPicker, showToast, writeFileWithPicker } from '../../helpers/utils'
+
+const CUSTOM_THEME_DISCUSSION_URL = 'https://github.com/OpenTubeX/OpenTubeX/discussions/new'
 
 const props = defineProps({
   open: {
@@ -580,6 +587,43 @@ async function exportTheme() {
     }
   } catch (error) {
     showError(t('Settings.Theme Settings.Custom Theme.Unable to Export'), error)
+  }
+}
+
+async function shareTheme() {
+  try {
+    const theme = normalizeCustomTheme(draft)
+    const themeJson = JSON.stringify(theme, null, 2)
+    const longestBacktickRun = Math.max(
+      2,
+      ...Array.from(themeJson.matchAll(/`+/g), match => match[0].length)
+    )
+    const codeFence = '`'.repeat(longestBacktickRun + 1)
+    const body = [
+      `## ${t('Settings.Theme Settings.Custom Theme.Share Description Heading')}`,
+      '',
+      `<!-- ${t('Settings.Theme Settings.Custom Theme.Share Description Prompt')} -->`,
+      '',
+      `## ${t('Settings.Theme Settings.Custom Theme.Share Screenshots Heading')}`,
+      '',
+      `<!-- ${t('Settings.Theme Settings.Custom Theme.Share Screenshots Prompt')} -->`,
+      '',
+      '<details>',
+      `<summary>${t('Settings.Theme Settings.Custom Theme.Share Code Summary')}</summary>`,
+      '',
+      `${codeFence}json`,
+      themeJson,
+      codeFence,
+      '',
+      '</details>'
+    ].join('\n')
+    const url = new URL(CUSTOM_THEME_DISCUSSION_URL)
+    url.searchParams.set('category', 'themes')
+    url.searchParams.set('title', theme.name)
+    url.searchParams.set('body', body)
+    await openExternalLink(url.toString())
+  } catch (error) {
+    showError(t('Settings.Theme Settings.Custom Theme.Unable to Share'), error)
   }
 }
 

--- a/static/locales/de-DE.yaml
+++ b/static/locales/de-DE.yaml
@@ -546,6 +546,12 @@ Settings:
       Based On: Basiert auf
       Import Theme: Design importieren
       Export Theme: Design exportieren
+      Share Theme: Design teilen
+      Share Description Heading: Beschreibung
+      Share Description Prompt: Beschreibe das Design und was andere vor der Verwendung wissen sollten.
+      Share Screenshots Heading: Screenshots
+      Share Screenshots Prompt: Ziehe einen oder mehrere Screenshots hierher.
+      Share Code Summary: Design-JSON
       Delete Theme: Design löschen
       Delete Theme Confirmation: „{name}“ löschen? Dies kann nicht rückgängig gemacht werden.
       Save and Apply: Speichern und anwenden
@@ -559,6 +565,7 @@ Settings:
       Unable to Load: Benutzerdefiniertes Design konnte nicht geladen werden
       Unable to Save: Benutzerdefiniertes Design konnte nicht gespeichert werden
       Unable to Export: Benutzerdefiniertes Design konnte nicht exportiert werden
+      Unable to Share: Benutzerdefiniertes Design konnte nicht geteilt werden
       Unable to Delete: Benutzerdefiniertes Design konnte nicht gelöscht werden
       Invalid Theme File: Ungültige Datei für ein benutzerdefiniertes Design
       Colors:

--- a/static/locales/en-US.yaml
+++ b/static/locales/en-US.yaml
@@ -637,6 +637,12 @@ Settings:
       Based On: Based on
       Import Theme: Import theme
       Export Theme: Export theme
+      Share Theme: Share theme
+      Share Description Heading: Description
+      Share Description Prompt: Describe the theme and anything people should know before using it.
+      Share Screenshots Heading: Screenshots
+      Share Screenshots Prompt: Drag and drop one or more screenshots here.
+      Share Code Summary: Theme JSON
       Delete Theme: Delete theme
       Delete Theme Confirmation: Delete “{name}”? This cannot be undone.
       Save and Apply: Save and apply
@@ -650,6 +656,7 @@ Settings:
       Unable to Load: Unable to load the custom theme
       Unable to Save: Unable to save the custom theme
       Unable to Export: Unable to export the custom theme
+      Unable to Share: Unable to share the custom theme
       Unable to Delete: Unable to delete the custom theme
       Invalid Theme File: Invalid custom theme file
       Colors:


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Make sure to follow the contributing guidelines. -->
<!-- Important note, we may remove your pull request if you do not use this provided PR template correctly. -->
<!-- Agent instructions: Preserve every heading, comment, and marker in this template. Never remove or rewrite the release-note-category:start/end, release-note:start/end, or release-note-image:start/end marker pairs. -->

## Pull Request Type
<!-- Please select what type of pull request this is: [x] -->
- [ ] Bugfix
- [x] Feature Implementation
- [ ] Documentation
- [ ] Other

## Related issue
<!-- Please link the issue your pull request is referring to. -->
<!-- If this pull request fully resolves the relevant issue, put "closes" before the issue number. -->
<!-- Example: "closes #123456". -->

None. This was requested directly for the new [Themes discussion category](https://github.com/OpenTubeX/OpenTubeX/discussions/categories/themes).

## Description
<!-- Please write a clear and concise description of what the pull request does. -->

Sharing a custom theme currently requires people to copy and format its data by hand before posting it in the new Themes discussion category.

This adds a Share theme action to the theme editor. It opens a new discussion in the Themes category with the current theme name, description and screenshot prompts, and the normalized theme JSON in a collapsible fenced code block. The action uses the current draft, including unsaved edits. English and German translations and focused Electron coverage are included.

## Release note category
<!-- Select exactly one category. Every pull request must select one. -->
<!-- Select "Not noteworthy" when the pull request fixes a bug in or improves functionality that has not yet appeared in a stable release. -->
<!-- release-note-category:start -->
- [ ] Not noteworthy
- [ ] Highlights
- [x] More improvements
- [ ] Fixed bugs
<!-- release-note-category:end -->

## Release note
<!-- Required unless "Not noteworthy" is selected. -->
<!-- Write one concise, user-facing entry without a leading bullet. -->
<!-- release-note:start -->
Custom themes can now be shared directly from the theme editor through a pre-filled GitHub Discussion.
<!-- release-note:end -->

## Release note images
<!-- Optional. Paste one or more Markdown images, HTML image tags, or dark/light <picture> elements here. -->
<!-- The release notes normalize the markup and limit images taller than 300 pixels. -->
<!-- Agent instructions:
For a noteworthy visible change, add media when it makes the change easier to understand. Prefer a still image unless motion is the point; recordings must use animated WebP.
After implementing a visible change, proactively capture the result and show the local media to the user for approval before uploading it or updating the pull request.
When the affected UI differs between dark and light themes, capturing both themes is required. A dark-only image is incomplete. Run `node _scripts/releaseNoteMedia.mjs --dark DARK_FILE --light LIGHT_FILE --alt "DESCRIPTION"`; GitHub will display the matching theme and use dark as the fallback. Use a single default-dark capture only when the light theme cannot be captured or looks identical.
Capture or crop to the smallest region that still makes the change clear. Do not include the full window when the affected component can be understood on its own.
Use English unless localization is the subject. Keep components at their normal dimensions and placement instead of resizing them to fill the frame.
Use deterministic local fixtures for visible remote images. Reusable avatar and thumbnail fixtures are available through `e2e/helpers/visual-fixtures.mjs`. Before capturing, verify that every visible image has loaded successfully (`complete === true` and `naturalWidth > 0`).
Inspect the final dark and light files for failed images, missing content, unrelated UI, awkward animation, and misleading layout. Omit media when it does not explain the change clearly.
For one dark capture, run `node _scripts/releaseNoteMedia.mjs FILE --alt "DESCRIPTION"`.
Check for personal information, tokens, private repository names, and unrelated desktop content before uploading. Uploaded media is public.
Keep capture-only scripts, test hooks, screenshots, and recordings out of commits. Remove them before committing unless the capture code is also a reusable regression test. Never commit generated release-note media.
Paste only the generated markup between the marker comments. Leave this section empty when media would not help.
-->
<!-- release-note-image:start -->

<!-- release-note-image:end -->

## Testing
<!-- How can reviewers verify that the PR produces correct results? -->
<!-- Please provide instructions so that others can ensure that your pull request would produce correct results. For examples see, https://github.com/FreeTubeApp/FreeTube/pull/5743, https://github.com/FreeTubeApp/FreeTube/pull/7349, https://github.com/FreeTubeApp/FreeTube/pull/5125, https://github.com/FreeTubeApp/FreeTube/pull/7338 -->
<!-- Agent instructions: Only write human-facing steps that explain how to verify the change while running this branch in dev mode. Include expected results and, when applicable, helpful console snippets for interactive verification. Do not include automated checks, commands, results, pass counts, or CI status. -->

1. Open the theme settings and create or edit a custom theme.
2. Change the theme name without saving, then select the Share theme button beside Import and Export.
3. Confirm the default browser opens GitHub's new-discussion form in the Themes category.
4. Confirm the discussion title uses the current theme name and the body contains description and screenshot prompts plus a collapsible Theme JSON block with the unsaved edits.

## Additional context
<!-- Add any other context about the pull request here. -->

The generated Markdown uses a fence longer than any backtick run in the theme JSON so imported theme names cannot break the code block.
