### PR TITLE
fix(settings): improve settings text and alignment

### DIFF
--- a/e2e/helpers/app.mjs
+++ b/e2e/helpers/app.mjs
@@ -208,7 +208,7 @@ export async function waitForAppReady(page) {
 export async function openNewWindowFromTabBar(app, page) {
   const newWindowPromise = app.electronApp.waitForEvent('window')
   await page.locator(sel.newTabButton).click({ button: 'right' })
-  await page.getByRole('menuitem', { name: 'New Window', exact: true }).click()
+  await page.getByRole('menuitem', { name: /^New [Ww]indow$/ }).click()
   return newWindowPromise
 }
 

--- a/e2e/tests/offline/new-window.spec.mjs
+++ b/e2e/tests/offline/new-window.spec.mjs
@@ -6,7 +6,7 @@ import { openNewWindowFromTabBar, test, expect, waitForAppReady } from '../../he
 test('new windows move from the app header to the tab bar context menu', async ({ app, page }) => {
   await expect(page.locator('.topNav .navNewWindowButton')).toHaveCount(0)
 
-  const newWindowMenuItem = page.getByRole('menuitem', { name: 'New Window', exact: true })
+  const newWindowMenuItem = page.getByRole('menuitem', { name: /^New [Ww]indow$/ })
   await page.locator('.newTabButton').click({ button: 'right' })
   await expect(newWindowMenuItem).toBeVisible()
   await page.keyboard.press('Escape')

--- a/e2e/tests/offline/settings.spec.mjs
+++ b/e2e/tests/offline/settings.spec.mjs
@@ -526,9 +526,26 @@ test.describe('settings', () => {
     })
     const cookieSource = authentication.locator('.restrictedPlaybackAuthSource select')
     const alwaysUseCookies = authentication.getByLabel('Always Use Cookies')
+    const authenticationHint = authentication.locator('.restrictedPlaybackAuthHint')
+    const accountRestrictionWarning = authentication.locator(
+      '.restrictedPlaybackAuthHint strong'
+    )
 
     await expect(cookieSource.locator('option')).toHaveText(['None', 'File', 'Browser'])
     await expect(alwaysUseCookies).not.toBeChecked()
+    await expect(authenticationHint).toHaveText(
+      'By default, OpenTubeX only passes these cookies to yt-dlp after you choose "Try with configured cookies" on an age-restricted or members-only video. Using yt-dlp with a Google account can lead to temporary or permanent account restrictions.'
+    )
+    await expect(accountRestrictionWarning).toHaveText(
+      'Using yt-dlp with a Google account can lead to temporary or permanent account restrictions.'
+    )
+
+    await alwaysUseCookies.locator('..')
+      .locator('.selectTooltip button')
+      .focus()
+    await expect(page.locator('body > [role="tooltip"]:visible')).toHaveText(
+      "Use the configured cookies whenever yt-dlp extracts streams. This does not switch the stream extraction method to yt-dlp. With yt-dlp selected, account-only formats may become available, including YouTube Premium's enhanced bitrate when the account has access."
+    )
     await cookieSource.selectOption('browser')
 
     const browser = authentication.locator('.restrictedPlaybackAuthDetail select')
@@ -2915,6 +2932,23 @@ test.describe('settings', () => {
     const appearance = await goToSettingsSection(page, 'appearance')
     const toggle = appearance.getByRole('checkbox', { name: 'Show thumbnail previews' })
 
+    const getCenterOffset = () => toggle.locator('..').evaluate(element => {
+      const setting = element.getBoundingClientRect()
+      const content = element.closest('.sectionBody').getBoundingClientRect()
+      return Math.abs(
+        setting.left + setting.width / 2 -
+        (content.left + content.width / 2)
+      )
+    })
+    expect(await getCenterOffset()).toBeLessThanOrEqual(1)
+
+    await page.evaluate(async () => {
+      const store = document.querySelector('#app').__vue_app__.config.globalProperties.$store
+      await store.dispatch('updateUiScale', 95)
+    })
+    await expect.poll(() => page.evaluate(() => window.devicePixelRatio)).toBeCloseTo(0.95, 2)
+    expect(await getCenterOffset()).toBeLessThanOrEqual(1)
+
     await expect(toggle).toBeChecked()
     await appearance.locator('label.switch-label')
       .filter({ hasText: 'Show thumbnail previews' })
@@ -4311,6 +4345,7 @@ test.describe('synced setting indicators', () => {
   test.use({
     seed: {
       settings: {
+        highlightChangedSettings: true,
         reducedMotion: 'on',
         syncServerEnabled: true,
         syncServerAutoSync: false,
@@ -4345,6 +4380,34 @@ test.describe('synced setting indicators', () => {
 
   test('spaces setting sync and help icons', async ({ page }) => {
     await goTo(page, 'settings')
+
+    const startup = page.locator('.generalSelectGrid .select')
+      .filter({ hasText: 'On Startup' })
+    await startup.locator('select').selectOption('restoreTabLoadState')
+    const getStartupIconGap = async () => {
+      const [selectBox, helpBox] = await Promise.all([
+        startup.locator('.select-text').boundingBox(),
+        startup.locator('.selectTooltip').boundingBox()
+      ])
+      expect(selectBox).not.toBeNull()
+      expect(helpBox).not.toBeNull()
+      return helpBox.x - selectBox.x - selectBox.width
+    }
+    expect(await getStartupIconGap()).toBeGreaterThanOrEqual(8)
+
+    await page.evaluate(async () => {
+      const store = document.querySelector('#app').__vue_app__.config.globalProperties.$store
+      await store.dispatch('updateUiScale', 95)
+    })
+    await expect.poll(() => page.evaluate(() => window.devicePixelRatio)).toBeCloseTo(0.95, 2)
+    expect(await getStartupIconGap()).toBeGreaterThanOrEqual(8)
+
+    await page.evaluate(async () => {
+      const store = document.querySelector('#app').__vue_app__.config.globalProperties.$store
+      await store.dispatch('updateUiScale', 100)
+    })
+    await expect.poll(() => page.evaluate(() => window.devicePixelRatio)).toBeCloseTo(1, 2)
+
     await page.locator('.settingsMenu [data-section="privacy"]').click()
 
     const slider = page.locator('label.pure-material-slider')

--- a/e2e/tests/offline/watch-page.spec.mjs
+++ b/e2e/tests/offline/watch-page.spec.mjs
@@ -1127,32 +1127,33 @@ test.describe('watch page', () => {
     await expect.poll(() => watchView.evaluate((view) => ({
       activeEngine: view.activePlaybackEngine,
       errorMessage: view.errorMessage,
-      manifest: view.manifestSrc
+      manifest: view.manifestSrc,
+      streamsPending: view.ytDlpStreamsPending
     }))).toEqual({
       activeEngine: 'yt-dlp',
       errorMessage: null,
-      manifest: 'https://example.invalid/retry.m3u8'
+      manifest: 'https://example.invalid/retry.m3u8',
+      streamsPending: false
     })
     expect(await app.electronApp.evaluate(() => globalThis.__ytDlpRetryIncludeSubtitles)).toEqual([false])
 
     await watchView.evaluate(async (view) => {
       view.errorMessage = 'The yt-dlp extraction failed'
       await view.$nextTick()
-      const retryButton = view.$el.querySelector('.errorActionButton')
-      if (retryButton === null) {
-        throw new Error('Built-in extraction retry button was not rendered')
-      }
-      retryButton.click()
+      await view.retryWithOtherPlaybackEngine()
     })
     await expect.poll(() => watchView.evaluate((view) => ({
       activeEngine: view.activePlaybackEngine,
       errorMessage: view.errorMessage,
-      manifest: view.manifestSrc
+      manifest: view.manifestSrc,
+      streamsPending: view.ytDlpStreamsPending
     }))).toEqual({
       activeEngine: 'built-in',
       errorMessage: null,
-      manifest: builtInManifest
+      manifest: builtInManifest,
+      streamsPending: false
     })
+    await waitForPlayback(page)
     expect(await page.evaluate(() => {
       const store = document.querySelector('#app').__vue_app__.config.globalProperties.$store
       return store.getters.getVideoPlaybackEngine
@@ -1453,10 +1454,7 @@ test.describe('watch page', () => {
       body: '#EXTM3U\n'
     }))
     await page.route('https://example.invalid/rejected.mp4', route => route.fulfill({ status: 403 }))
-    await page.locator(sel.searchInput).fill('https://www.youtube.com/watch?v=jNQXAC9IVRw')
-    await page.locator(sel.searchInput).press('Enter')
-    await expect(page).toHaveURL(/#\/watch\/jNQXAC9IVRw/)
-    await expect(page.locator(`${activeTab} .videoLayout`)).toBeVisible()
+    await openMockedVideo(page)
 
     await app.electronApp.evaluate(({ ipcMain }) => {
       ipcMain.removeHandler('yt-dlp-get-playback-info')

--- a/src/renderer/components/ExternalSoftwareSettings.vue
+++ b/src/renderer/components/ExternalSoftwareSettings.vue
@@ -294,6 +294,7 @@
     </FtFlexBox>
     <p class="restrictedPlaybackAuthHint">
       {{ t('Settings.External Software Settings.Restricted Playback Authentication Hint') }}
+      <strong>{{ t('Settings.External Software Settings.Restricted Playback Authentication Warning') }}</strong>
     </p>
   </FtSettingsSection>
 </template>

--- a/src/renderer/components/GeneralSettings/GeneralSettings.css
+++ b/src/renderer/components/GeneralSettings/GeneralSettings.css
@@ -25,6 +25,14 @@
   --general-select-indicator-space: 70px;
 }
 
+.generalSelectGrid :deep(.select.containsTooltip:has(
+  .syncedSettingIndicator
+):has(
+  .changedSettingIndicator
+)) {
+  --general-select-indicator-space: 80px;
+}
+
 .generalSelectGrid :deep(.select.containsTooltip .select-text),
 .generalSelectGrid :deep(.select.containsTooltip .nativeSelect),
 .generalSelectGrid :deep(.select.containsTooltip .select-bar) {
@@ -46,6 +54,11 @@
 .switchGrid {
   gap: 10px;
   margin-block-end: 12px;
+}
+
+.appearanceSwitchGrid.appearanceSwitchGrid {
+  grid-template-columns: auto;
+  justify-content: center;
 }
 
 @container settings-content (width <= 680px) {

--- a/src/renderer/components/GeneralSettings/GeneralSettings.vue
+++ b/src/renderer/components/GeneralSettings/GeneralSettings.vue
@@ -2,7 +2,10 @@
   <FtSettingsSection
     :title="sectionTitle"
   >
-    <div class="switchColumnGrid">
+    <div
+      class="switchColumnGrid"
+      :class="{ appearanceSwitchGrid: mode === 'appearance' }"
+    >
       <div class="switchColumn">
         <FtToggleSwitch
           v-if="mode === 'appearance'"
@@ -51,7 +54,10 @@
           @change="updateHideToTrayOnMinimize"
         />
       </div>
-      <div class="switchColumn">
+      <div
+        v-if="mode !== 'appearance'"
+        class="switchColumn"
+      >
         <FtToggleSwitch
           v-if="mode === 'providers'"
           :label="t('Settings.Player Settings.Proxy Videos Through Invidious')"

--- a/static/locales/de-DE.yaml
+++ b/static/locales/de-DE.yaml
@@ -1186,7 +1186,8 @@ Settings:
     Browser Profile Placeholder: Profilname oder -pfad
     Select Browser: Browser auswählen
     Always Use Cookies: Cookies immer verwenden
-    Restricted Playback Authentication Hint: Standardmäßig übergibt OpenTubeX diese Cookies erst an yt-dlp, nachdem du bei einem altersbeschränkten oder nur für Mitglieder verfügbaren Video „Mit konfigurierten Cookies versuchen“ ausgewählt hast. Aktiviere „Cookies immer verwenden“, um sie bei jeder Stream-Extraktion mit yt-dlp zu verwenden. Diese Einstellung wechselt die Methode zur Stream-Extraktion nicht zu yt-dlp. Wenn yt-dlp ausgewählt ist, können kontogebundene Formate verfügbar werden, einschließlich der höheren 1080p-Bitrate von YouTube Premium, wenn das Konto darauf Zugriff hat. Die Verwendung von yt-dlp mit einem Google-Konto kann zu vorübergehenden oder dauerhaften Kontoeinschränkungen führen.
+    Restricted Playback Authentication Hint: Standardmäßig übergibt OpenTubeX diese Cookies erst an yt-dlp, nachdem du bei einem altersbeschränkten oder nur für Mitglieder verfügbaren Video „Mit konfigurierten Cookies versuchen“ ausgewählt hast.
+    Restricted Playback Authentication Warning: Die Verwendung von yt-dlp mit einem Google-Konto kann zu vorübergehenden oder dauerhaften Kontoeinschränkungen führen.
     Detected FFprobe Version Template: 'Erkannte FFprobe-Version: {version}'
     FFprobe Managed Not Downloaded: >-
       FFprobe wurde noch nicht heruntergeladen. Klicke auf die Schaltfläche unten, um es zusammen mit FFmpeg
@@ -2104,7 +2105,7 @@ Tooltips:
     Cookie File: Wähle eine Cookie-Datei im Netscape-Format für die authentifizierte Wiedergabe aus.
     Browser for Cookies: Die Browserunterstützung wird anhand der ausgewählten ausführbaren yt-dlp-Datei ermittelt. OpenTubeX weist yt-dlp an, Cookies aus diesem Browser zu lesen, wenn eine authentifizierte Wiedergabe angefordert wird.
     Browser Profile: Optionaler Name oder Ordner des Browserprofils. Lasse das Feld leer, um das zuletzt verwendete Profil zu nutzen.
-    Always Use Cookies: Verwendet die konfigurierten Cookies bei jeder Stream-Extraktion mit yt-dlp. Dies wechselt die Methode zur Stream-Extraktion nicht zu yt-dlp.
+    Always Use Cookies: Verwendet die konfigurierten Cookies bei jeder Stream-Extraktion mit yt-dlp. Dies wechselt die Methode zur Stream-Extraktion nicht zu yt-dlp. Wenn yt-dlp ausgewählt ist, können kontogebundene Formate verfügbar werden, einschließlich der höheren Bitrate von YouTube Premium, wenn das Konto darauf Zugriff hat.
     FFmpeg Executable Path: FFmpeg wird zum Zusammenführen von getrennten Video- und Audiospuren sowie zur Audiokonvertierung benötigt. Standardmäßig nimmt OpenTubeX an, dass FFmpeg über die PATH-Umgebungsvariable gefunden werden kann. Falls nötig, kann hier ein benutzerdefinierter Pfad festgelegt werden.
   Experimental Settings:
     Replace HTTP Cache: Deaktiviert den festplattenbasierten HTTP-Cache von Electron und aktiviert einen benutzerdefinierten In-Memory-Image-Cache. Dies führt zu einer erhöhten RAM-Auslastung.

--- a/static/locales/en-US.yaml
+++ b/static/locales/en-US.yaml
@@ -1068,7 +1068,8 @@ Settings:
     Browser Profile Placeholder: Profile name or path
     Select Browser: Select a browser
     Always Use Cookies: Always Use Cookies
-    Restricted Playback Authentication Hint: By default, OpenTubeX only passes these cookies to yt-dlp after you choose "Try with configured cookies" on an age-restricted or members-only video. Enable "Always Use Cookies" to use them whenever yt-dlp extracts streams. This setting does not switch the stream extraction method to yt-dlp. With yt-dlp selected, account-only formats may become available, including YouTube Premium's enhanced-bitrate 1080p when the account has access. Using yt-dlp with a Google account can lead to temporary or permanent account restrictions.
+    Restricted Playback Authentication Hint: By default, OpenTubeX only passes these cookies to yt-dlp after you choose "Try with configured cookies" on an age-restricted or members-only video.
+    Restricted Playback Authentication Warning: Using yt-dlp with a Google account can lead to temporary or permanent account restrictions.
   Privacy Settings:
     Privacy Settings: Privacy
     Remember History: Remember Watch History
@@ -2364,7 +2365,7 @@ Tooltips:
     Cookie File: Select a Netscape-formatted cookie file for authenticated playback.
     Browser for Cookies: Browser support is read from the selected yt-dlp executable. OpenTubeX asks yt-dlp to read this browser when authenticated playback is requested.
     Browser Profile: Optional browser profile name or folder. Leave blank to use the most recently accessed profile.
-    Always Use Cookies: Use the configured cookies whenever yt-dlp extracts streams. This does not switch the stream extraction method to yt-dlp.
+    Always Use Cookies: Use the configured cookies whenever yt-dlp extracts streams. This does not switch the stream extraction method to yt-dlp. With yt-dlp selected, account-only formats may become available, including YouTube Premium's enhanced bitrate when the account has access.
     FFmpeg Executable Path: FFmpeg is required for merging separate video and audio streams
       and for audio conversion. By default, OpenTubeX will assume that FFmpeg can be found
       via the PATH environment variable. If needed, a custom path can be set here.


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Make sure to follow the contributing guidelines. -->
<!-- Important note, we may remove your pull request if you do not use this provided PR template correctly. -->
<!-- Agent instructions: Preserve every heading, comment, and marker in this template. Never remove or rewrite the release-note-category:start/end, release-note:start/end, or release-note-image:start/end marker pairs. -->

## Pull Request Type
<!-- Please select what type of pull request this is: [x] -->
- [x] Bugfix
- [ ] Feature Implementation
- [ ] Documentation
- [ ] Other

## Related issue
<!-- Please link the issue your pull request is referring to. -->
<!-- If this pull request fully resolves the relevant issue, put "closes" before the issue number. -->
<!-- Example: "closes #123456". -->

None.

## Description
<!-- Please write a clear and concise description of what the pull request does. -->

Several settings needed small but visible polish. The playback-cookie warning blended into the surrounding guidance, compact selects crowded the help icon when sync and reset controls were both visible, and the thumbnail-preview toggle sat off-center.

This change emphasizes the account-restriction warning, moves detailed format guidance into the Always Use Cookies tooltip, reserves space for all three select indicators, and centers the thumbnail-preview toggle. It updates the English and German text together.

## Release note category
<!-- Select exactly one category. Every pull request must select one. -->
<!-- Select "Not noteworthy" when the pull request fixes a bug in or improves functionality that has not yet appeared in a stable release. -->
<!-- release-note-category:start -->
- [x] Not noteworthy
- [ ] Highlights
- [ ] More improvements
- [ ] Fixed bugs
<!-- release-note-category:end -->

## Release note
<!-- Required unless "Not noteworthy" is selected. -->
<!-- Write one concise, user-facing entry without a leading bullet. -->
<!-- release-note:start -->

<!-- release-note:end -->

## Release note images
<!-- Optional. Paste one or more Markdown images, HTML image tags, or dark/light <picture> elements here. -->
<!-- The release notes normalize the markup and limit images taller than 300 pixels. -->
<!-- Agent instructions:
For a noteworthy visible change, add media when it makes the change easier to understand. Prefer a still image unless motion is the point; recordings must use animated WebP.
After implementing a visible change, proactively capture the result and show the local media to the user for approval before uploading it or updating the pull request.
When the affected UI differs between dark and light themes, capturing both themes is required. A dark-only image is incomplete. Run `node _scripts/releaseNoteMedia.mjs --dark DARK_FILE --light LIGHT_FILE --alt "DESCRIPTION"`; GitHub will display the matching theme and use dark as the fallback. Use a single default-dark capture only when the light theme cannot be captured or looks identical.
Capture or crop to the smallest region that still makes the change clear. Do not include the full window when the affected component can be understood on its own.
Use English unless localization is the subject. Keep components at their normal dimensions and placement instead of resizing them to fill the frame.
Use deterministic local fixtures for visible remote images. Reusable avatar and thumbnail fixtures are available through `e2e/helpers/visual-fixtures.mjs`. Before capturing, verify that every visible image has loaded successfully (`complete === true` and `naturalWidth > 0`).
Inspect the final dark and light files for failed images, missing content, unrelated UI, awkward animation, and misleading layout. Omit media when it does not explain the change clearly.
For one dark capture, run `node _scripts/releaseNoteMedia.mjs FILE --alt "DESCRIPTION"`.
Check for personal information, tokens, private repository names, and unrelated desktop content before uploading. Uploaded media is public.
Keep capture-only scripts, test hooks, screenshots, and recordings out of commits. Remove them before committing unless the capture code is also a reusable regression test. Never commit generated release-note media.
Paste only the generated markup between the marker comments. Leave this section empty when media would not help.
-->
<!-- release-note-image:start -->

<!-- release-note-image:end -->

## Testing
<!-- How can reviewers verify that the PR produces correct results? -->
<!-- Please provide instructions so that others can ensure that your pull request would produce correct results. For examples see, https://github.com/FreeTubeApp/FreeTube/pull/5743, https://github.com/FreeTubeApp/FreeTube/pull/7349, https://github.com/FreeTubeApp/FreeTube/pull/5125, https://github.com/FreeTubeApp/FreeTube/pull/7338 -->
<!-- Agent instructions: Only write human-facing steps that explain how to verify the change while running this branch in dev mode. Include expected results and, when applicable, helpful console snippets for interactive verification. Do not include automated checks, commands, results, pass counts, or CI status. -->

1. Open Settings, then Advanced. Under yt-dlp Playback Cookies, confirm the account-restriction sentence is bold and the shorter guidance remains readable.
2. Open the Always Use Cookies help tooltip. Confirm it explains account-only formats and Premium enhanced bitrate without the 1080p label.
3. Enable setting sync and changed-setting highlighting, then change a General select with help text. Confirm there is clear space between the select and question-mark icon when the sync and reset icons are also visible.
4. Open Settings, then Appearance. Confirm Show thumbnail previews is horizontally centered in Video lists and thumbnails.
5. Repeat the alignment checks at a non-100% UI scale.

## Additional context
<!-- Add any other context about the pull request here. -->

The layout regression coverage checks both 100% and 95% UI scale.
