### PR TITLE
fix(tabs): remove stale vertical scroll after group collapse

### DIFF
--- a/e2e/tests/offline/tabs.spec.mjs
+++ b/e2e/tests/offline/tabs.spec.mjs
@@ -1338,6 +1338,59 @@ test.describe('tab bar', () => {
     await expect(scrollbar).toBeHidden()
   })
 
+  test('clamps its vertical scrollbar after collapsing an expanded group at the scroll end', async ({ page, attachScreenshot }) => {
+    await page.setViewportSize({ width: 800, height: 450 })
+    await page.evaluate(() => window.ftElectron.setZoomFactor(0.95))
+    const groupId = await page.evaluate(async () => {
+      const tabIds = []
+      for (let index = 0; index < 14; index++) {
+        const tab = await window.ftElectron.tabs.create({
+          route: `/watch/vertical-tab-bar-scroll-${index}`,
+          title: `Vertical scrollable tab ${index}`,
+          makeActive: false,
+          lazyLoad: true
+        })
+        tabIds.push(tab.id)
+      }
+      const group = await window.ftElectron.tabs.createGroup({
+        name: 'Vertical scrollable group',
+        color: 'green'
+      })
+      await window.ftElectron.tabs.setGroup(tabIds.slice(2), group.id)
+      await window.ftElectron.tabs.updateGroup(group.id, { isCollapsed: true })
+      const store = document.querySelector('#app').__vue_app__.config.globalProperties.$store
+      store.commit('setTabBarPosition', 'left')
+      return group.id
+    })
+
+    const container = page.locator('.tabsContainer')
+    const scrollbar = container.locator(':scope > .os-scrollbar-vertical')
+    const collapsedGroup = page.getByRole('button', {
+      name: 'Expand Vertical scrollable group, 12 tabs',
+      exact: true
+    })
+    await expect(collapsedGroup).toBeVisible()
+    await expect(scrollbar).toHaveClass(/os-scrollbar-unusable/)
+
+    await collapsedGroup.click()
+    await expect(page.locator('.tab[data-tab-id]')).toHaveCount(15)
+    await expect(scrollbar).not.toHaveClass(/os-scrollbar-unusable/)
+    await container.evaluate(element => { element.scrollTop = element.scrollHeight })
+    await expect.poll(() => container.evaluate(element => (
+      element.scrollTop > 0 &&
+      Math.abs(element.scrollTop - (element.scrollHeight - element.clientHeight)) <= 1
+    ))).toBe(true)
+
+    await page.evaluate(groupId => window.ftElectron.tabs.updateGroup(groupId, { isCollapsed: true }), groupId)
+    await expect(collapsedGroup).toBeVisible()
+    await expect.poll(() => container.evaluate(element => ({
+      maxScroll: Math.max(0, element.scrollHeight - element.clientHeight),
+      scrollTop: element.scrollTop
+    }))).toEqual({ maxScroll: 0, scrollTop: 0 })
+    await expect(scrollbar).toHaveClass(/os-scrollbar-unusable/)
+    await attachScreenshot('vertical tab group collapsed without stale scroll range')
+  })
+
   test('keeps a submenu inside the viewport for a bottom vertical tab', async ({ page }) => {
     await page.setViewportSize({ width: 800, height: 450 })
     await page.keyboard.press('F1')

--- a/src/renderer/components/TabBar/TabBar.vue
+++ b/src/renderer/components/TabBar/TabBar.vue
@@ -141,6 +141,7 @@ import { getTabAccentColor } from '../../constants/tabColors'
 import { removeLegacyTabAvatar } from '../../helpers/channelThumbnailStorage'
 import { fetchTabAvatarBytes } from '../../helpers/tabAvatar'
 import { loadMissingTabAvatars } from '../../helpers/loadTabAvatars'
+import { clampOverlayScrollTop } from '../../helpers/overlayScrollbars'
 import SortableTab from './SortableTab.vue'
 import {
   buildCurrentShiftedTabIds,
@@ -1344,10 +1345,15 @@ watch(tabBarScrollPosition, (newPosition) => {
 watch(stripItems, () => {
   const container = dropZoneRef.value
   if (container) {
-    const maxScroll = Math.max(0, container.scrollWidth - container.clientWidth)
-    container.scrollLeft = Math.min(container.scrollLeft, maxScroll)
-    if (scrollTarget != null) {
-      scrollTarget = Math.min(scrollTarget, maxScroll)
+    if (vertical.value) {
+      const renderedItems = container.querySelectorAll(':scope > .tabBarReorderItem')
+      clampOverlayScrollTop(container, renderedItems[renderedItems.length - 1] ?? null)
+    } else {
+      const maxScroll = Math.max(0, container.scrollWidth - container.clientWidth)
+      container.scrollLeft = Math.min(container.scrollLeft, maxScroll)
+      if (scrollTarget != null) {
+        scrollTarget = Math.min(scrollTarget, maxScroll)
+      }
     }
   }
   updateScrollbar()


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Make sure to follow the contributing guidelines. -->
<!-- Important note, we may remove your pull request if you do not use this provided PR template correctly. -->
<!-- Agent instructions: Preserve every heading, comment, and marker in this template. Never remove or rewrite the release-note-category:start/end, release-note:start/end, or release-note-image:start/end marker pairs. -->

## Pull Request Type
<!-- Please select what type of pull request this is: [x] -->
- [x] Bugfix
- [ ] Feature Implementation
- [ ] Documentation
- [ ] Other

## Related issue
<!-- Please link the issue your pull request is referring to. -->
<!-- If this pull request fully resolves the relevant issue, put "closes" before the issue number. -->
<!-- Example: "closes #123456". -->

None.

## Description
<!-- Please write a clear and concise description of what the pull request does. -->

Collapsing an expanded tab group at the end of a vertical tab bar could leave Chromium and OverlayScrollbars using the old scroll range. The tab bar now clamps its vertical offset against the final rendered strip item after Vue updates the list, which removes the stale scrollbar and blank space. The horizontal path keeps its existing behavior. A regression test covers collapsing after bottom scrolling at 95% UI scale.

## Release note category
<!-- Select exactly one category. Every pull request must select one. -->
<!-- Select "Not noteworthy" when the pull request fixes a bug in or improves functionality that has not yet appeared in a stable release. -->
<!-- release-note-category:start -->
- [x] Not noteworthy
- [ ] Highlights
- [ ] More improvements
- [ ] Fixed bugs
<!-- release-note-category:end -->

## Release note
<!-- Required unless "Not noteworthy" is selected. -->
<!-- Write one concise, user-facing entry without a leading bullet. -->
<!-- release-note:start -->

Collapsing a tab group now removes stale scrollbars and empty space from vertical tab bars.

<!-- release-note:end -->

## Release note images
<!-- Optional. Paste one or more Markdown images, HTML image tags, or dark/light <picture> elements here. -->
<!-- The release notes normalize the markup and limit images taller than 300 pixels. -->
<!-- Agent instructions:
For a noteworthy visible change, add media when it makes the change easier to understand. Prefer a still image unless motion is the point; recordings must use animated WebP.
After implementing a visible change, proactively capture the result and show the local media to the user for approval before uploading it or updating the pull request.
When the affected UI differs between dark and light themes, capturing both themes is required. A dark-only image is incomplete. Run `node _scripts/releaseNoteMedia.mjs --dark DARK_FILE --light LIGHT_FILE --alt "DESCRIPTION"`; GitHub will display the matching theme and use dark as the fallback. Use a single default-dark capture only when the light theme cannot be captured or looks identical.
Capture or crop to the smallest region that still makes the change clear. Do not include the full window when the affected component can be understood on its own.
Use English unless localization is the subject. Keep components at their normal dimensions and placement instead of resizing them to fill the frame.
Use deterministic local fixtures for visible remote images. Reusable avatar and thumbnail fixtures are available through `e2e/helpers/visual-fixtures.mjs`. Before capturing, verify that every visible image has loaded successfully (`complete === true` and `naturalWidth > 0`).
Inspect the final dark and light files for failed images, missing content, unrelated UI, awkward animation, and misleading layout. Omit media when it does not explain the change clearly.
For one dark capture, run `node _scripts/releaseNoteMedia.mjs FILE --alt "DESCRIPTION"`.
Check for personal information, tokens, private repository names, and unrelated desktop content before uploading. Uploaded media is public.
Keep capture-only scripts, test hooks, screenshots, and recordings out of commits. Remove them before committing unless the capture code is also a reusable regression test. Never commit generated release-note media.
Paste only the generated markup between the marker comments. Leave this section empty when media would not help.
-->
<!-- release-note-image:start -->

<!-- release-note-image:end -->

## Testing
<!-- How can reviewers verify that the PR produces correct results? -->
<!-- Please provide instructions so that others can ensure that your pull request would produce correct results. For examples see, https://github.com/FreeTubeApp/FreeTube/pull/5743, https://github.com/FreeTubeApp/FreeTube/pull/7349, https://github.com/FreeTubeApp/FreeTube/pull/5125, https://github.com/FreeTubeApp/FreeTube/pull/7338 -->
<!-- Agent instructions: Only write human-facing steps that explain how to verify the change while running this branch in dev mode. Include expected results and, when applicable, helpful console snippets for interactive verification. Do not include automated checks, commands, results, pass counts, or CI status. -->

1. Set the tab bar position to Left or Right and set UI Scale to 95%.
2. Create enough tabs to overflow the tab bar, put most of them in one group, and collapse the group.
3. Expand the group, scroll the tab area to the bottom, then collapse the group again from a grouped tab's context menu.
4. Confirm the tab-area scrollbar disappears when the remaining items fit and that no empty space remains below the tabs.

## Additional context
<!-- Add any other context about the pull request here. -->

None.
