### PR TITLE
fix(subscriptions): improve tabbed new feed controls

### DIFF
--- a/e2e/tests/offline/subscriptions-header-layout.spec.mjs
+++ b/e2e/tests/offline/subscriptions-header-layout.spec.mjs
@@ -83,9 +83,16 @@ function headerBoxes (page) {
 }
 
 test.describe('subscriptions header layout', () => {
-  test('keeps the New feed sort control compact beside refresh', async ({ app, page, attachScreenshot }) => {
+  test('keeps the New feed sort control wide until its row needs to shrink', async ({ app, page, attachScreenshot }) => {
     await goTo(page, 'subscriptions')
     await page.locator('[data-subscription-feed-tab="all"]').click()
+
+    await setWindowWidth(app, page, 640)
+    const roomySelectWidth = await page.locator('.headerSortSelect .select-text').evaluate(element => {
+      return element.getBoundingClientRect().width
+    })
+    expect(roomySelectWidth).toBeGreaterThanOrEqual(210)
+
     await setWindowWidth(app, page, 340)
 
     const layout = await page.evaluate(() => {
@@ -106,6 +113,7 @@ test.describe('subscriptions header layout', () => {
     })
 
     expect(layout.selectedText).toBe('Newest first')
+    expect(layout.select.end - layout.select.start).toBeLessThan(roomySelectWidth)
     expect(layout.viewToggle.start).toBeGreaterThanOrEqual(layout.header.start)
     expect(layout.viewToggle.end).toBeLessThanOrEqual(layout.select.start)
     expect(layout.select.end).toBeLessThanOrEqual(layout.refresh.start)
@@ -160,51 +168,59 @@ test.describe('subscriptions header layout', () => {
     await attachScreenshot('New feed tabs separator')
   })
 
-  test('keeps the New feed controls on the same line as the main feed tabs', async ({ app, page, attachScreenshot }) => {
+  test('puts the New feed controls below the main feed tabs at narrow widths', async ({ app, page, attachScreenshot }) => {
     await goTo(page, 'subscriptions')
     await page.locator('[data-subscription-feed-tab="all"]').click()
     await page.getByRole('button', { name: 'Show tabbed view' }).click()
 
-    for (const width of [1120, 680, 375, 340]) {
+    const readLayout = () => page.evaluate(() => {
+      const toBox = selector => {
+        const rect = document.querySelector(selector).getBoundingClientRect()
+        return { start: rect.left, end: rect.right, top: rect.top, bottom: rect.bottom }
+      }
+
+      return {
+        row: toBox('.feedTabsControlsRow'),
+        header: toBox('.subscriptionsHeader'),
+        title: toBox('.pageTitle'),
+        tabs: toBox('.tabs'),
+        actions: toBox('.headerActions'),
+        upperTabs: [...document.querySelectorAll('[data-subscription-feed-tab]')]
+          .map(tab => {
+            const rect = tab.getBoundingClientRect()
+            return { start: rect.left, end: rect.right, top: rect.top }
+          })
+      }
+    })
+
+    await setWindowWidth(app, page, 1120)
+    const wideLayout = await readLayout()
+    expect(wideLayout.actions.top).toBeLessThan(wideLayout.tabs.bottom)
+    expect(wideLayout.tabs.top).toBeLessThan(wideLayout.actions.bottom)
+    expect(Math.abs(wideLayout.row.end - wideLayout.actions.end)).toBeLessThanOrEqual(1)
+
+    for (const width of [900, 680, 375, 340]) {
       await setWindowWidth(app, page, width)
       await expect(page.locator('.subscriptionsHeader')).not.toHaveClass(/singleRow/)
 
-      const layout = await page.evaluate(() => {
-        const toBox = selector => {
-          const rect = document.querySelector(selector).getBoundingClientRect()
-          return { start: rect.left, end: rect.right, top: rect.top, bottom: rect.bottom }
-        }
-
-        const header = toBox('.subscriptionsHeader')
-        const upperTabs = [...document.querySelectorAll('[data-subscription-feed-tab]')]
-          .map(tab => {
-            const rect = tab.getBoundingClientRect()
-            return { start: rect.left, end: rect.right }
-          })
-
-        return {
-          header,
-          title: toBox('.pageTitle'),
-          tabs: toBox('.tabs'),
-          actions: toBox('.headerActions'),
-          upperTabs
-        }
-      })
+      const layout = await readLayout()
 
       expect(layout.tabs.top).toBeGreaterThanOrEqual(layout.title.bottom)
-      expect(layout.actions.top).toBeGreaterThanOrEqual(layout.title.bottom)
-      expect(layout.actions.top).toBeLessThan(layout.tabs.bottom)
-      expect(layout.tabs.top).toBeLessThan(layout.actions.bottom)
+      expect(layout.actions.top - layout.tabs.bottom).toBeGreaterThanOrEqual(8)
+      expect(Math.abs(layout.actions.start - layout.tabs.start)).toBeLessThanOrEqual(1)
       expect(layout.actions.start).toBeGreaterThanOrEqual(layout.header.start)
       expect(layout.actions.end).toBeLessThanOrEqual(layout.header.end)
       expect(Math.min(...layout.upperTabs.map(tab => tab.start))).toBeGreaterThanOrEqual(layout.header.start)
       expect(Math.max(...layout.upperTabs.map(tab => tab.end))).toBeLessThanOrEqual(layout.header.end)
+      if (width >= 680) {
+        expect(new Set(layout.upperTabs.map(tab => tab.top)).size).toBe(1)
+      }
       await expect.poll(() => page.evaluate(() => {
         return document.documentElement.scrollWidth - document.documentElement.clientWidth
       })).toBeLessThanOrEqual(2)
     }
 
-    await attachScreenshot('New feed controls aligned with main tabs')
+    await attachScreenshot('New feed controls below main tabs')
   })
 
   test('puts the tabs beside the title when they fit', async ({ page, attachScreenshot }) => {
@@ -222,7 +238,7 @@ test.describe('subscriptions header layout', () => {
     expect(refreshWidget.top).toBeLessThan(tabs.bottom)
   })
 
-  test('drops the tabs onto their own line when the window is too narrow', async ({ app, page, attachScreenshot }) => {
+  test('moves the controls below the tabs before the tabs wrap', async ({ app, page, attachScreenshot }) => {
     await goTo(page, 'subscriptions')
     await expect(page.locator('.subscriptionsHeader')).toHaveClass(/singleRow/)
 
@@ -232,12 +248,14 @@ test.describe('subscriptions header layout', () => {
     await attachScreenshot('two row header')
 
     const { title, tabs, refreshWidget } = await headerBoxes(page)
+    const tabRows = await page.locator('[data-subscription-feed-tab]').evaluateAll(tabs => {
+      return new Set(tabs.map(tab => tab.getBoundingClientRect().top)).size
+    })
 
-    // Two lines: the title is above, with the tabs and refresh widget together
+    // The controls move down before taking enough space to wrap the tabs.
     expect(tabs.top).toBeGreaterThanOrEqual(title.bottom)
-    expect(refreshWidget.top).toBeGreaterThanOrEqual(title.bottom)
-    expect(refreshWidget.top).toBeLessThan(tabs.bottom)
-    expect(tabs.top).toBeLessThan(refreshWidget.bottom)
+    expect(refreshWidget.top - tabs.bottom).toBeGreaterThanOrEqual(8)
+    expect(tabRows).toBe(1)
   })
 
   test('merges the rows again when the window grows back', async ({ app, page, attachScreenshot }) => {
@@ -299,10 +317,10 @@ test.describe('subscriptions header layout', () => {
     // Narrow enough that the tabs no longer fit on one line inside their own
     // row, so their rendered width is the shrunken one rather than the width
     // they would need. That must not be mistaken for fitting next to the title.
-    await setWindowWidth(app, page, 700)
+    await setWindowWidth(app, page, 500)
 
     const wrapped = await page.evaluate(() => {
-      const tabs = [...document.querySelectorAll('.tab')]
+      const tabs = [...document.querySelectorAll('[data-subscription-feed-tab]')]
       return new Set(tabs.map(tab => tab.getBoundingClientRect().top)).size > 1
     })
     expect(wrapped, 'the tabs are expected to wrap at this width').toBe(true)

--- a/e2e/tests/offline/subscriptions-new-feed.spec.mjs
+++ b/e2e/tests/offline/subscriptions-new-feed.spec.mjs
@@ -231,6 +231,36 @@ test.describe('new subscriptions feed', () => {
     await expect(relaunched.page.getByRole('heading', { name: 'Posts', exact: true })).toBeVisible()
   })
 
+  test('marks only the active category as seen in the tabbed New feed', async ({ page }) => {
+    await goTo(page, 'subscriptions')
+    await page.locator('[data-subscription-feed-tab="all"]').click()
+    await page.getByRole('button', { name: 'Show tabbed view' }).click()
+
+    await page.evaluate(() => {
+      const store = document.querySelector('#app').__vue_app__.config.globalProperties.$store
+      window.__markSeenMutations = []
+      window.__unsubscribeMarkSeen = store.subscribe((mutation) => {
+        if (mutation.type === 'markSubscriptionEntriesAsSeenInCache') {
+          window.__markSeenMutations.push(mutation.payload)
+        }
+      })
+    })
+
+    await page.getByRole('button', { name: 'Mark all as seen' }).click()
+
+    await expect(page.getByText('New video', { exact: true })).toHaveCount(0)
+    await expect(page.getByRole('button', { name: 'Mark all as seen' })).toHaveCount(0)
+    await page.locator('[data-new-feed-tab="shorts"]').click()
+    await expect(page.getByText('New short', { exact: true })).toBeVisible()
+    await expect(page.getByRole('button', { name: 'Mark all as seen' })).toBeVisible()
+    expect(await page.evaluate(() => {
+      window.__unsubscribeMarkSeen()
+      return window.__markSeenMutations
+    })).toEqual([[
+      { tab: 'videos', channelId: CHANNEL_ID }
+    ]])
+  })
+
   test('shows Shorts as portrait cards with their duration and upload time', async ({ page }) => {
     await goTo(page, 'subscriptions')
     await page.locator('[data-subscription-feed-tab="shorts"]').click()

--- a/src/renderer/components/SubscriptionsNew.vue
+++ b/src/renderer/components/SubscriptionsNew.vue
@@ -250,6 +250,10 @@ const isLoading = computed(() => {
 })
 
 const hasNewContent = computed(() => {
+  if (!showCombinedView.value) {
+    return displayedEntries.value.length > 0
+  }
+
   return newVideos.value.length > 0 || hasAdditionalContent.value
 })
 

--- a/src/renderer/views/Subscriptions/Subscriptions.css
+++ b/src/renderer/views/Subscriptions/Subscriptions.css
@@ -45,7 +45,7 @@
   display: flex;
   flex: 1 1 auto;
   flex-wrap: wrap;
-  gap: 8px 20px;
+  gap: 12px 20px;
   min-inline-size: 0;
 }
 
@@ -175,28 +175,31 @@
   gap: 4px 10px;
   margin-block: 0;
   position: relative;
+  overflow-inline: clip;
   color: var(--tertiary-text-color);
 }
 
-/* Two line layout: the grouped tabs and controls move below the title together.
-   Giving the tabs a zero basis lets their own flex container wrap before the
-   controls are pushed onto another line. */
+/* Two line layout: the grouped tabs and controls move below the title together. */
 .subscriptionsHeader:not(.singleRow) .feedTabsControlsRow {
   flex-basis: 100%;
 }
 
 .subscriptionsHeader:not(.singleRow) .tabsRow {
-  flex: 1 1 0;
+  /* Keep the tabs at their natural width so the controls wrap first. The tabs
+     only wrap once they have the full row and still do not fit. */
+  flex: 1 0 max-content;
+  max-inline-size: 100%;
   min-inline-size: 0;
 }
 
 .subscriptionsHeader:not(.singleRow) .tabs {
+  flex: 0 0 max-content;
+  max-inline-size: 100%;
   min-inline-size: 0;
 }
 
 .subscriptionsHeader:not(.singleRow) .headerActions {
   flex: 0 1 auto;
-  margin-inline-start: auto;
 }
 
 .subscriptionsHeader.singleRow .headerRow {
@@ -296,6 +299,7 @@
   gap: 4px 10px;
   margin-block: 8px -3px;
   position: relative;
+  overflow-inline: clip;
   color: var(--tertiary-text-color);
 }
 
@@ -359,16 +363,11 @@
   }
 
   .feedTabsControlsRow {
-    gap: 8px;
+    gap: 12px 8px;
   }
 
   .headerActions {
     gap: 6px;
-  }
-
-  .headerActions .headerSortSelect {
-    flex-basis: 128px;
-    inline-size: 128px;
   }
 
   .headerSortSelect :deep(.select-text) {

--- a/src/renderer/views/Subscriptions/Subscriptions.vue
+++ b/src/renderer/views/Subscriptions/Subscriptions.vue
@@ -884,7 +884,9 @@ async function markAllAsSeen(tab) {
   markingSeenTab.value = tab
   try {
     const feedTabs = tab === 'new'
-      ? visibleTabs.value.filter(visibleTab => visibleTab !== 'new')
+      ? newFeedView.value === 'tabbed'
+        ? [currentNewFeedTab.value]
+        : visibleTabs.value.filter(visibleTab => visibleTab !== 'new')
       : [tab]
 
     const channelIds = activeSubscriptionList.value.map(channel => channel.id)
@@ -1246,6 +1248,10 @@ const updateNewFeedTabsIndicator = () => updateTabIndicator(
   newFeedTabsIndicatorStyle,
   newFeedTabsIndicatorState
 )
+const updateTabIndicators = () => {
+  updateTabsIndicator()
+  updateNewFeedTabsIndicator()
+}
 
 function observeTabContainers() {
   if (tabsResizeObserver === null) {
@@ -1271,20 +1277,19 @@ watch([currentTab, newFeedView], () => nextTick(() => {
 onMounted(() => {
   if (typeof ResizeObserver === 'function') {
     // Per-tab loaders resize the container while a refresh is running
-    tabsResizeObserver = new ResizeObserver(() => {
-      updateTabsIndicator()
-      updateNewFeedTabsIndicator()
-    })
+    tabsResizeObserver = new ResizeObserver(updateTabIndicators)
     observeTabContainers()
 
-    headerResizeObserver = new ResizeObserver(() => updateHeaderFitsOneRow())
+    headerResizeObserver = new ResizeObserver(() => {
+      updateHeaderFitsOneRow()
+      updateTabIndicators()
+    })
     observeHeaderRow()
   }
 
   nextTick(() => {
     updateHeaderFitsOneRow()
-    updateTabsIndicator()
-    updateNewFeedTabsIndicator()
+    updateTabIndicators()
   })
 })
 


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Make sure to follow the contributing guidelines. -->
<!-- Important note, we may remove your pull request if you do not use this provided PR template correctly. -->
<!-- Agent instructions: Preserve every heading, comment, and marker in this template. Never remove or rewrite the release-note-category:start/end, release-note:start/end, or release-note-image:start/end marker pairs. -->

## Pull Request Type
<!-- Please select what type of pull request this is: [x] -->
- [x] Bugfix
- [ ] Feature Implementation
- [ ] Documentation
- [ ] Other

## Related issue
<!-- Please link the issue your pull request is referring to. -->
<!-- If this pull request fully resolves the relevant issue, put "closes" before the issue number. -->
<!-- Example: "closes #123456". -->

## Description
<!-- Please write a clear and concise description of what the pull request does. -->
In the tabbed subscriptions New feed, “Mark all as seen” cleared every category instead of only the category being viewed. At narrower window widths, the header controls also competed with the tabs for space, causing the tabs to wrap too early and the sort control to shrink unnecessarily.

This scopes the seen action to the active New-feed category and makes the header move its controls into a left-aligned row below the tabs before the tabs need to wrap. The sort control keeps its normal width until the controls row is genuinely constrained, and tab indicators remain aligned after responsive reflow.

## Release note category
<!-- Select exactly one category. Every pull request must select one. -->
<!-- Select "Not noteworthy" when the pull request fixes a bug in or improves functionality that has not yet appeared in a stable release. -->
<!-- release-note-category:start -->
- [ ] Not noteworthy
- [ ] Highlights
- [ ] More improvements
- [x] Fixed bugs
<!-- release-note-category:end -->

## Release note
<!-- Required unless "Not noteworthy" is selected. -->
<!-- Write one concise, user-facing entry without a leading bullet. -->
<!-- release-note:start -->
The tabbed subscriptions New feed now marks only the active category as seen and keeps its header controls usable at narrow widths.
<!-- release-note:end -->

## Release note images
<!-- Optional. Paste one or more Markdown images, HTML image tags, or dark/light <picture> elements here. -->
<!-- The release notes normalize the markup and limit images taller than 300 pixels. -->
<!-- Agent instructions:
For a noteworthy visible change, add media when it makes the change easier to understand. Prefer a still image unless motion is the point; recordings must use animated WebP.
After implementing a visible change, proactively capture the result and show the local media to the user for approval before uploading it or updating the pull request.
When the affected UI differs between dark and light themes, capturing both themes is required. A dark-only image is incomplete. Run `node _scripts/releaseNoteMedia.mjs --dark DARK_FILE --light LIGHT_FILE --alt "DESCRIPTION"`; GitHub will display the matching theme and use dark as the fallback. Use a single default-dark capture only when the light theme cannot be captured or looks identical.
Capture or crop to the smallest region that still makes the change clear. Do not include the full window when the affected component can be understood on its own.
Use English unless localization is the subject. Keep components at their normal dimensions and placement instead of resizing them to fill the frame.
Use deterministic local fixtures for visible remote images. Reusable avatar and thumbnail fixtures are available through `e2e/helpers/visual-fixtures.mjs`. Before capturing, verify that every visible image has loaded successfully (`complete === true` and `naturalWidth > 0`).
Inspect the final dark and light files for failed images, missing content, unrelated UI, awkward animation, and misleading layout. Omit media when it does not explain the change clearly.
For one dark capture, run `node _scripts/releaseNoteMedia.mjs FILE --alt "DESCRIPTION"`.
Check for personal information, tokens, private repository names, and unrelated desktop content before uploading. Uploaded media is public.
Keep capture-only scripts, test hooks, screenshots, and recordings out of commits. Remove them before committing unless the capture code is also a reusable regression test. Never commit generated release-note media.
Paste only the generated markup between the marker comments. Leave this section empty when media would not help.
-->
<!-- release-note-image:start -->

<!-- release-note-image:end -->

## Testing
<!-- How can reviewers verify that the PR produces correct results? -->
<!-- Please provide instructions so that others can ensure that your pull request produces correct results. For examples see, https://github.com/FreeTubeApp/FreeTube/pull/5743, https://github.com/FreeTubeApp/FreeTube/pull/7349, https://github.com/FreeTubeApp/FreeTube/pull/5125, https://github.com/FreeTubeApp/FreeTube/pull/7338 -->
<!-- Agent instructions: Only write human-facing steps that explain how to verify the change while running this branch in dev mode. Include expected results and, when applicable, helpful console snippets for interactive verification. Do not include automated checks, commands, results, pass counts, or CI status. -->
1. Open Subscriptions, switch to the New feed, and enable its tabbed view. With unseen entries in multiple categories, select one category and use “Mark all as seen”; only that category should be cleared.
2. Resize the window from wide to narrow. The controls should stay beside the tabs while they fit, then move into a left-aligned row below them before the tabs wrap.
3. Continue narrowing the window. The sort control should retain its normal width while space is available and shrink only when necessary to keep the controls within the header.

## Additional context
<!-- Add any other context about the pull request here. -->
