### PR TITLE
fix(theme): keep quick settings avatar clear of scrollbars

### DIFF
--- a/e2e/tests/offline/scrollbar-overlay.spec.mjs
+++ b/e2e/tests/offline/scrollbar-overlay.spec.mjs
@@ -63,6 +63,33 @@ test.describe('overlay scrollbars', () => {
     expect(Math.abs(scrollbarBox.x + scrollbarBox.width - innerWidth)).toBeLessThanOrEqual(1)
   })
 
+  test('keeps the quick settings avatar clear of a wide page scrollbar', async ({ page }) => {
+    await addPageOverflow(page)
+    await page.evaluate(() => {
+      const store = document.querySelector('#app').__vue_app__.config.globalProperties.$store
+      store.commit('setScrollbarThumbWidth', 20)
+    })
+
+    for (const zoomFactor of [1, 1.25]) {
+      await page.evaluate((factor) => window.ftElectron.setZoomFactor(factor), zoomFactor)
+      await expect.poll(async () => {
+        const [avatarBox, scrollbarBox] = await Promise.all([
+          page.locator('.topNav .profileTrigger').boundingBox(),
+          page.locator(PAGE_SCROLLBAR).boundingBox()
+        ])
+        return scrollbarBox.x - (avatarBox.x + avatarBox.width)
+      }).toBeGreaterThanOrEqual(5)
+    }
+
+    await page.evaluate(() => window.ftElectron.setZoomFactor(1))
+    await page.setViewportSize({ width: 400, height: 720 })
+    await page.locator('.topNav .profileTrigger').click()
+    const menuBox = await page.locator('.quickSettingsMenu').boundingBox()
+
+    expect(menuBox.x).toBeGreaterThanOrEqual(0)
+    expect(menuBox.x + menuBox.width).toBeLessThanOrEqual(400)
+  })
+
   test('the scrollbar hides once the pointer rests and follows it back', async ({ page }) => {
     await addPageOverflow(page)
     const scrollbar = page.locator(PAGE_SCROLLBAR)

--- a/src/renderer/components/FtQuickSettingsMenu/FtQuickSettingsMenu.css
+++ b/src/renderer/components/FtQuickSettingsMenu/FtQuickSettingsMenu.css
@@ -169,7 +169,7 @@
   inset-inline-end: 0;
   margin: 0;
   max-block-size: calc(100vh - 76px - var(--quick-settings-viewport-offset, calc(0 * 1px)));
-  inline-size: min(440px, calc(100vw - 20px));
+  inline-size: min(440px, calc(100vw - var(--scrollbar-track-width) - 20px));
   line-height: normal;
   overscroll-behavior: contain;
   overflow: hidden;

--- a/src/renderer/components/TopNav/TopNav.scss
+++ b/src/renderer/components/TopNav/TopNav.scss
@@ -214,6 +214,7 @@
 
   &.profiles {
     justify-content: flex-end;
+    margin-inline-end: calc(var(--scrollbar-track-width) + 6px);
   }
 
   .navSearchButton {

--- a/src/renderer/themes.css
+++ b/src/renderer/themes.css
@@ -8,6 +8,7 @@ body {
   --app-font-family: 'Roboto', system-ui, sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol', 'Noto Color Emoji';
   --ui-roundness: 1;
   --scrollbar-thumb-width: 6px;
+  --scrollbar-track-width: calc(var(--scrollbar-thumb-width) + 4px);
   --border-color: var(--tertiary-text-color);
   --divider-color: color-mix(in srgb, var(--border-color) 45%, transparent);
   --subtle-surface-color: var(--tertiary-text-color);
@@ -2290,7 +2291,7 @@ body .os-scrollbar {
 
   /* The padding is subtracted from the track, so the handle ends up exactly as
      wide as the configured thumb width. */
-  --os-size: calc(var(--scrollbar-thumb-width) + 4px);
+  --os-size: var(--scrollbar-track-width);
   --os-padding-perpendicular: 2px;
   --os-padding-axis: 2px;
   --os-handle-interactive-area-offset: 4px;


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Make sure to follow the contributing guidelines. -->
<!-- Important note, we may remove your pull request if you do not use this provided PR template correctly. -->
<!-- Agent instructions: Preserve every heading, comment, and marker in this template. Never remove or rewrite the release-note-category:start/end, release-note:start/end, or release-note-image:start/end marker pairs. -->

## Pull Request Type
<!-- Please select what type of pull request this is: [x] -->
- [x] Bugfix
- [ ] Feature Implementation
- [ ] Documentation
- [ ] Other

## Related issue
<!-- Please link the issue your pull request is referring to. -->
<!-- If this pull request fully resolves the relevant issue, put "closes" before the issue number. -->
<!-- Example: "closes #123456". -->
Closes #968

## Description
<!-- Please write a clear and concise description of what the pull request does. -->
The Quick settings avatar sits too close to the overlay page scrollbar, and wider scrollbar settings can cover it.

This derives the header margin from the rendered scrollbar track width while keeping a 6 px gap. The Quick settings menu also uses the available width beside that track, so it stays inside narrow windows.

## Release note category
<!-- Select exactly one category. Every pull request must select one. -->
<!-- Select "Not noteworthy" when the pull request fixes a bug in or improves functionality that has not yet appeared in a stable release. -->
<!-- release-note-category:start -->
- [ ] Not noteworthy
- [ ] Highlights
- [ ] More improvements
- [x] Fixed bugs
<!-- release-note-category:end -->

## Release note
<!-- Required unless "Not noteworthy" is selected. -->
<!-- Write one concise, user-facing entry without a leading bullet. -->
<!-- release-note:start -->
Keep the Quick settings avatar clear of wider scrollbars.
<!-- release-note:end -->

## Release note images
<!-- Optional. Paste one or more Markdown images, HTML image tags, or dark/light <picture> elements here. -->
<!-- The release notes normalize the markup and limit images taller than 300 pixels. -->
<!-- Agent instructions:
For a noteworthy visible change, add media when it makes the change easier to understand. Prefer a still image unless motion is the point; recordings must use animated WebP.
After implementing a visible change, proactively capture the result and show the local media to the user for approval before uploading it or updating the pull request.
When the affected UI differs between dark and light themes, capturing both themes is required. A dark-only image is incomplete. Run `node _scripts/releaseNoteMedia.mjs --dark DARK_FILE --light LIGHT_FILE --alt "DESCRIPTION"`; GitHub will display the matching theme and use dark as the fallback.
Capture or crop to the smallest region that still makes the change clear. Do not include the full window when the affected component can be understood on its own.
Use English unless localization is the subject. Keep components at their normal dimensions and placement instead of resizing them to fill the frame.
Use deterministic local fixtures for visible remote images. Reusable avatar and thumbnail fixtures are available through `e2e/helpers/visual-fixtures.mjs`. Before capturing, verify that every visible image has loaded successfully (`complete === true` and `naturalWidth > 0`).
Inspect the final dark and light files for failed images, missing content, unrelated UI, awkward animation, and misleading layout. Omit media when it does not explain the change clearly.
For one dark capture, run `node _scripts/releaseNoteMedia.mjs FILE --alt "DESCRIPTION"`.
Check for personal information, tokens, private repository names, and unrelated desktop content before uploading. Uploaded media is public.
Keep capture-only scripts, test hooks, screenshots, and recordings out of commits. Remove them before committing unless the capture code is also a reusable regression test. Never commit generated release-note media.
Paste only the generated markup between the marker comments. Leave this section empty when media would not help.
-->
<!-- release-note-image:start -->

<!-- release-note-image:end -->

## Testing
<!-- How can reviewers verify that the PR produces correct results? -->
<!-- Please provide instructions so that others can ensure that your pull request would produce correct results. For examples see, https://github.com/FreeTubeApp/FreeTube/pull/5743, https://github.com/FreeTubeApp/FreeTube/pull/7349, https://github.com/FreeTubeApp/FreeTube/pull/5125, https://github.com/FreeTubeApp/FreeTube/pull/7338 -->
<!-- Agent instructions: Only write human-facing steps that explain how to verify the change while running this branch in dev mode. Include expected results and, when applicable, helpful console snippets for interactive verification. Do not include automated checks, commands, results, pass counts, or CI status. -->
1. Open a page long enough to show the page scrollbar.
2. Open Appearance settings and increase Scrollbar Width to 20 px.
3. Confirm the Quick settings avatar retains a visible gap from the scrollbar.
4. Set UI Scale to 125%, narrow the window to about 400 px, and open Quick settings. The avatar must remain clear of the scrollbar and the menu must stay inside the window.

## Additional context
<!-- Add any other context about the pull request here. -->
