### PR TITLE
feat(navigation): add gamepad controls and themed focus feedback

### DIFF
--- a/e2e/tests/offline/gamepad-navigation.spec.mjs
+++ b/e2e/tests/offline/gamepad-navigation.spec.mjs
@@ -111,8 +111,11 @@ test('navigates and activates the interface with a standard gamepad', async ({ a
   await connectMockGamepad(page)
 
   const categories = page.locator('.settingsMenu [data-section]')
-  await categories.first().focus()
+  await page.evaluate(() => document.activeElement?.blur())
+  await pressGamepadButton(page, 'primary')
+  await expect.poll(() => page.evaluate(() => document.activeElement !== document.body)).toBe(true)
 
+  await categories.first().focus()
   await moveGamepadAxis(page, 1, 1)
   await expect(categories.nth(1)).toBeFocused()
   await pressGamepadButton(page, 'down')
@@ -151,6 +154,7 @@ test.describe('at 95% UI scale', () => {
   test('keeps spatial gamepad navigation aligned', async ({ page }) => {
     await goTo(page, 'settings')
     await expect.poll(() => page.evaluate(() => window.devicePixelRatio)).toBeCloseTo(0.95, 2)
+    await page.bringToFront()
     await connectMockGamepad(page)
 
     const categories = page.locator('.settingsMenu [data-section]')
@@ -233,6 +237,7 @@ test('adjusts and leaves sliders and commits select options', async ({ attachScr
 test('keeps a changed quick settings slider focused', async ({ attachScreenshot, page }) => {
   const trigger = page.locator('.profileTrigger')
   await trigger.focus()
+  await page.bringToFront()
   await connectMockGamepad(page)
   await pressGamepadButton(page, 'primary')
 
@@ -251,6 +256,7 @@ test('keeps a changed quick settings slider focused', async ({ attachScreenshot,
 
   await expect(slider).not.toHaveValue(initialValue)
   await expect(slider).toBeFocused()
+  await expect.poll(() => slider.evaluate(element => element.matches(':focus-visible'))).toBe(true)
   await expect(slider).toHaveAttribute('data-gamepad-active', 'true')
   await expect(menu).not.toBeFocused()
   await attachScreenshot('active quick settings gamepad slider')
@@ -270,6 +276,7 @@ test.describe('quick settings changed-setting controls', () => {
   test('keeps quick settings open after resetting with a gamepad', async ({ page }) => {
     const trigger = page.locator('.profileTrigger')
     await trigger.focus()
+    await page.bringToFront()
     await connectMockGamepad(page)
     await pressGamepadButton(page, 'primary')
 
@@ -355,6 +362,7 @@ test.describe('configured gamepad highlight roundness', () => {
 test('uses the menu button to toggle playback', async ({ app, page }) => {
   await mockPlayableWatchPage(app, page)
   const video = await openMockedVideo(page)
+  await page.bringToFront()
   await connectMockGamepad(page)
 
   await expect.poll(() => video.evaluate(element => element.paused)).toBe(false)
@@ -367,6 +375,7 @@ test('uses the menu button to toggle playback', async ({ app, page }) => {
 test('backs out of the player menu without leaving the video', async ({ app, page }) => {
   await mockPlayableWatchPage(app, page)
   await openMockedVideo(page)
+  await page.bringToFront()
   await connectMockGamepad(page)
 
   const pageUrl = page.url()

--- a/e2e/tests/offline/gamepad-navigation.spec.mjs
+++ b/e2e/tests/offline/gamepad-navigation.spec.mjs
@@ -1,0 +1,382 @@
+import { expect, goTo, goToSettingsSection, test } from '../../helpers/app.mjs'
+import { openMockedVideo } from '../../helpers/player.mjs'
+import { mockPlayableWatchPage } from '../../helpers/watch.mjs'
+
+const PLAYER_SEED = {
+  baseTheme: 'dark',
+  videoPlaybackEngine: 'built-in',
+  ytDlpPlaybackEngineDefaultMigration: true
+}
+
+const GAMEPAD_BUTTON_INDEX = Object.freeze({
+  primary: 0,
+  back: 1,
+  playPause: 9,
+  up: 12,
+  down: 13,
+  left: 14,
+  right: 15,
+})
+
+test.use({ seed: { settings: PLAYER_SEED } })
+
+async function connectMockGamepad(page) {
+  await page.evaluate(() => {
+    const buttons = Array.from({ length: 17 }, () => ({ pressed: false, value: 0 }))
+    const gamepad = {
+      axes: [0, 0, 0, 0],
+      buttons,
+      connected: true,
+      id: 'E2E standard controller',
+      index: 1,
+      mapping: 'standard',
+      timestamp: 0,
+    }
+
+    Object.defineProperty(navigator, 'getGamepads', {
+      configurable: true,
+      value: () => [null, gamepad]
+    })
+    window.__e2eGamepad = gamepad
+    const event = new Event('gamepadconnected')
+    Object.defineProperty(event, 'gamepad', { value: gamepad })
+    window.dispatchEvent(event)
+  })
+}
+
+async function pressGamepadButton(page, action) {
+  const buttonIndex = GAMEPAD_BUTTON_INDEX[action]
+  if (buttonIndex === undefined) {
+    throw new Error(`Unknown gamepad action: ${action}`)
+  }
+
+  await page.evaluate((index) => {
+    const button = window.__e2eGamepad.buttons[index]
+    button.pressed = true
+    button.value = 1
+    window.__e2eGamepad.timestamp++
+  }, buttonIndex)
+  await page.waitForTimeout(50)
+  await page.evaluate((index) => {
+    const button = window.__e2eGamepad.buttons[index]
+    button.pressed = false
+    button.value = 0
+    window.__e2eGamepad.timestamp++
+  }, buttonIndex)
+  await page.waitForTimeout(50)
+}
+
+async function moveGamepadAxis(page, axisIndex, value) {
+  await page.evaluate(({ index, axisValue }) => {
+    window.__e2eGamepad.axes[index] = axisValue
+    window.__e2eGamepad.timestamp++
+  }, { index: axisIndex, axisValue: value })
+  await page.waitForTimeout(50)
+  await page.evaluate((index) => {
+    window.__e2eGamepad.axes[index] = 0
+    window.__e2eGamepad.timestamp++
+  }, axisIndex)
+  await page.waitForTimeout(50)
+}
+
+async function expectContainedContrastFocusIndicator(locator, contrastColor) {
+  const focusIndicator = await locator.evaluate((element) => {
+    const style = getComputedStyle(element)
+    const width = Number.parseFloat(style.outlineWidth)
+    const offset = Number.parseFloat(style.outlineOffset)
+    const contrastProbe = document.createElement('span')
+    contrastProbe.style.color = 'var(--focus-ring-contrast-color)'
+    element.append(contrastProbe)
+    const contrastColor = getComputedStyle(contrastProbe).color
+    contrastProbe.remove()
+    return {
+      contrastColor,
+      contrastInset: style.boxShadow.includes(contrastColor) && style.boxShadow.includes('inset'),
+      style: style.outlineStyle,
+      outsideExtent: Math.max(0, width + offset),
+    }
+  })
+  expect(focusIndicator).toEqual({
+    contrastColor,
+    contrastInset: true,
+    style: 'solid',
+    outsideExtent: 0,
+  })
+}
+
+test('navigates and activates the interface with a standard gamepad', async ({ attachScreenshot, page }) => {
+  await goTo(page, 'settings')
+  const pageUrl = page.url()
+  await page.bringToFront()
+  await connectMockGamepad(page)
+
+  const categories = page.locator('.settingsMenu [data-section]')
+  await categories.first().focus()
+
+  await moveGamepadAxis(page, 1, 1)
+  await expect(categories.nth(1)).toBeFocused()
+  await pressGamepadButton(page, 'down')
+  await expect(categories.nth(2)).toBeFocused()
+  await expect(page.locator('.app')).not.toHaveClass(/hideOutlines/)
+  const focusColors = await categories.nth(2).evaluate((element) => {
+    const colorProbe = document.createElement('span')
+    colorProbe.style.color = 'var(--primary-color)'
+    element.append(colorProbe)
+    const colors = {
+      actual: getComputedStyle(element).outlineColor,
+      expected: getComputedStyle(colorProbe).color,
+    }
+    colorProbe.remove()
+    return colors
+  })
+  expect(focusColors.actual).toBe(focusColors.expected)
+  await attachScreenshot('gamepad focus uses the theme color')
+
+  const selectedSection = await categories.nth(2).getAttribute('data-section')
+  await pressGamepadButton(page, 'primary')
+  await expect(page.locator(`.settingsContent > [data-section="${selectedSection}"]`)).toBeVisible()
+
+  await pressGamepadButton(page, 'back')
+  await expect(page.getByRole('dialog', { name: 'Settings', exact: true })).toBeHidden()
+  await expect(page).toHaveURL(pageUrl)
+
+  await goTo(page, 'history')
+  await pressGamepadButton(page, 'back')
+  await expect(page).toHaveURL(pageUrl)
+})
+
+test.describe('at 95% UI scale', () => {
+  test.use({ seed: { settings: { ...PLAYER_SEED, uiScale: 95 } } })
+
+  test('keeps spatial gamepad navigation aligned', async ({ page }) => {
+    await goTo(page, 'settings')
+    await expect.poll(() => page.evaluate(() => window.devicePixelRatio)).toBeCloseTo(0.95, 2)
+    await connectMockGamepad(page)
+
+    const categories = page.locator('.settingsMenu [data-section]')
+    await categories.first().focus()
+    await moveGamepadAxis(page, 1, 1)
+    await expect(categories.nth(1)).toBeFocused()
+    await pressGamepadButton(page, 'down')
+    await expect(categories.nth(2)).toBeFocused()
+  })
+})
+
+test('keeps the focus indicator inside controls at layout edges', async ({ attachScreenshot, page }) => {
+  await goTo(page, 'subscriptions')
+  await page.bringToFront()
+  await connectMockGamepad(page)
+
+  const videosTab = page.locator('[data-subscription-feed-tab="videos"]')
+  const shortsTab = page.locator('[data-subscription-feed-tab="shorts"]')
+  await shortsTab.focus()
+  await pressGamepadButton(page, 'left')
+  await expect(videosTab).toBeFocused()
+
+  await expectContainedContrastFocusIndicator(videosTab, 'rgb(255, 255, 255)')
+  await attachScreenshot('contained gamepad focus indicator')
+
+  await page.evaluate(() => document.body.classList.replace('dark', 'light'))
+  await expectContainedContrastFocusIndicator(videosTab, 'rgb(0, 0, 0)')
+  await attachScreenshot('light theme gamepad focus indicator')
+  await page.evaluate(() => document.body.classList.replace('light', 'dark'))
+
+  const sideNavOption = page.locator('.sideNav .navOption').first()
+  await pressGamepadButton(page, 'left')
+  await expect(sideNavOption).toBeFocused()
+  await expectContainedContrastFocusIndicator(sideNavOption, 'rgb(255, 255, 255)')
+  const sideNavLayers = await sideNavOption.evaluate((element) => ({
+    activeIndicator: Number.parseInt(getComputedStyle(element.parentElement.querySelector('.activeIndicator')).zIndex),
+    focusedOption: Number.parseInt(getComputedStyle(element).zIndex),
+  }))
+  expect(sideNavLayers.focusedOption).toBeGreaterThan(sideNavLayers.activeIndicator)
+  await attachScreenshot('contained side navigation focus indicator')
+})
+
+test('adjusts and leaves sliders and commits select options', async ({ attachScreenshot, page }) => {
+  const playbackSettings = await goToSettingsSection(page, 'playback')
+  await page.bringToFront()
+  await connectMockGamepad(page)
+
+  const select = playbackSettings.locator('.select-text').first()
+  await select.focus()
+  await pressGamepadButton(page, 'primary')
+  await expect(select).toHaveAttribute('aria-expanded', 'true')
+
+  const options = page.locator(`#${await select.getAttribute('aria-controls')} [role="option"]`)
+  const activeOptionId = await select.getAttribute('aria-activedescendant')
+  const activeOptionIndex = await options.evaluateAll((elements, id) => (
+    elements.findIndex(element => element.id === id)
+  ), activeOptionId)
+  await pressGamepadButton(page, activeOptionIndex < await options.count() - 1 ? 'down' : 'up')
+
+  const optionName = await options.filter({ has: page.locator('.optionName') })
+    .evaluateAll(elements => elements.find(element => element.classList.contains('active'))?.textContent.trim())
+  await pressGamepadButton(page, 'primary')
+  await expect(select).toHaveAttribute('aria-expanded', 'false')
+  await expect(select.locator('.selectedValue')).toHaveText(optionName)
+
+  const slider = playbackSettings.locator('input[type="range"]').first()
+  await slider.focus()
+  await pressGamepadButton(page, 'primary')
+  await expect(slider).toHaveAttribute('data-gamepad-active', 'true')
+  await attachScreenshot('active gamepad slider')
+  const initialValue = await slider.inputValue()
+  await pressGamepadButton(page, 'right')
+  await expect(slider).not.toHaveValue(initialValue)
+  await pressGamepadButton(page, 'primary')
+  await expect(slider).not.toHaveAttribute('data-gamepad-active')
+  await pressGamepadButton(page, 'down')
+  await expect(slider).not.toBeFocused()
+})
+
+test('keeps a changed quick settings slider focused', async ({ attachScreenshot, page }) => {
+  const trigger = page.locator('.profileTrigger')
+  await trigger.focus()
+  await connectMockGamepad(page)
+  await pressGamepadButton(page, 'primary')
+
+  const menu = page.getByRole('dialog', { name: 'Quick settings' })
+  await expect(menu).toBeVisible()
+  await expect(menu).not.toBeFocused()
+  await expect(menu.locator(':focus')).toHaveCount(1)
+
+  const slider = menu.getByRole('slider').first()
+  await slider.focus()
+  await pressGamepadButton(page, 'primary')
+  await expect(slider).toHaveAttribute('data-gamepad-active', 'true')
+
+  const initialValue = await slider.inputValue()
+  await pressGamepadButton(page, 'right')
+
+  await expect(slider).not.toHaveValue(initialValue)
+  await expect(slider).toBeFocused()
+  await expect(slider).toHaveAttribute('data-gamepad-active', 'true')
+  await expect(menu).not.toBeFocused()
+  await attachScreenshot('active quick settings gamepad slider')
+})
+
+test.describe('quick settings changed-setting controls', () => {
+  test.use({
+    seed: {
+      settings: {
+        ...PLAYER_SEED,
+        highlightChangedSettings: true,
+        thumbnailSize: 110
+      }
+    }
+  })
+
+  test('keeps quick settings open after resetting with a gamepad', async ({ page }) => {
+    const trigger = page.locator('.profileTrigger')
+    await trigger.focus()
+    await connectMockGamepad(page)
+    await pressGamepadButton(page, 'primary')
+
+    const menu = page.getByRole('dialog', { name: 'Quick settings' })
+    const slider = menu.locator('.thumbnailSizeSlider').getByRole('slider')
+    const reset = slider.locator('..').getByRole('button', {
+      name: 'Reset this setting to its default'
+    })
+    await reset.focus()
+    await pressGamepadButton(page, 'primary')
+    await page.waitForTimeout(300)
+
+    await expect(reset).toHaveCount(0)
+    await expect(trigger).toHaveAttribute('aria-expanded', 'true')
+    await expect(menu).toBeVisible()
+    await expect(slider).toBeFocused()
+  })
+})
+
+test.describe('configured gamepad highlight roundness', () => {
+  test.use({
+    seed: {
+      settings: {
+        ...PLAYER_SEED,
+        disableSmoothScrolling: true,
+        highlightChangedSettings: true,
+        uiRoundness: 200
+      }
+    }
+  })
+
+  test('applies UI roundness to focus and active slider highlights', async ({ attachScreenshot, page }) => {
+    await goTo(page, 'subscriptions')
+    await page.bringToFront()
+    await connectMockGamepad(page)
+
+    const tab = page.locator('[data-subscription-feed-tab="videos"]')
+    await page.locator('[data-subscription-feed-tab="shorts"]').focus()
+    await pressGamepadButton(page, 'left')
+    await expect(tab).toBeFocused()
+    await expect(tab).toHaveCSS('border-radius', '8px')
+
+    const appearanceSettings = await goToSettingsSection(page, 'appearance')
+    const switchInput = appearanceSettings.getByRole('checkbox', {
+      name: 'Disable Smooth Scrolling'
+    })
+    const switchSetting = switchInput.locator('..')
+    const switchLabel = switchSetting.locator('.switch-label')
+    const unfocusedSwitchPositions = await switchLabel.evaluate(element => ({
+      textStart: element.querySelector('.switch-label-text').getBoundingClientRect().left,
+      thumbStart: element.getBoundingClientRect().left +
+        Number.parseFloat(getComputedStyle(element, '::after').insetInlineStart)
+    }))
+    await page.evaluate(() => (
+      document.querySelector('#app').__vue_app__.config.globalProperties.$store.dispatch('showOutlines')
+    ))
+    await switchInput.evaluate(element => element.focus({ focusVisible: true }))
+    await expect(switchInput).toBeFocused()
+    await expect(switchInput).toHaveCSS('outline-style', 'none')
+    await expect(switchLabel).toHaveCSS('outline-style', 'solid')
+    await expect(switchLabel).toHaveCSS('border-radius', '8px')
+    await expect(switchSetting).toHaveCSS('border-left-width', '3px')
+    const focusedSwitchPositions = await switchLabel.evaluate(element => ({
+      ringStartPadding: Number.parseFloat(getComputedStyle(element, '::after').insetInlineStart),
+      textStart: element.querySelector('.switch-label-text').getBoundingClientRect().left,
+      thumbStart: element.getBoundingClientRect().left +
+        Number.parseFloat(getComputedStyle(element, '::after').insetInlineStart)
+    }))
+    expect(focusedSwitchPositions.ringStartPadding).toBeGreaterThanOrEqual(5)
+    expect(focusedSwitchPositions.textStart).toBeCloseTo(unfocusedSwitchPositions.textStart)
+    expect(focusedSwitchPositions.thumbStart).toBeCloseTo(unfocusedSwitchPositions.thumbStart)
+    await attachScreenshot('focused changed switch label')
+
+    const playbackSettings = await goToSettingsSection(page, 'playback')
+    const slider = playbackSettings.locator('input[type="range"]').first()
+    await slider.focus()
+    await pressGamepadButton(page, 'primary')
+    await expect(slider).toHaveAttribute('data-gamepad-active', 'true')
+    await expect(slider.locator('..')).toHaveCSS('border-radius', '8px')
+  })
+})
+
+test('uses the menu button to toggle playback', async ({ app, page }) => {
+  await mockPlayableWatchPage(app, page)
+  const video = await openMockedVideo(page)
+  await connectMockGamepad(page)
+
+  await expect.poll(() => video.evaluate(element => element.paused)).toBe(false)
+  await pressGamepadButton(page, 'playPause')
+  await expect.poll(() => video.evaluate(element => element.paused)).toBe(true)
+  await pressGamepadButton(page, 'playPause')
+  await expect.poll(() => video.evaluate(element => element.paused)).toBe(false)
+})
+
+test('backs out of the player menu without leaving the video', async ({ app, page }) => {
+  await mockPlayableWatchPage(app, page)
+  await openMockedVideo(page)
+  await connectMockGamepad(page)
+
+  const pageUrl = page.url()
+  const player = page.locator('.tabContent[aria-hidden="false"] .ftVideoPlayer')
+  await player.hover()
+  await player.getByRole('button', { name: 'More settings' }).click()
+  const overflowMenu = player.locator('.shaka-overflow-menu')
+  await expect(overflowMenu).toBeVisible()
+
+  await pressGamepadButton(page, 'back')
+  await expect(overflowMenu).toBeHidden()
+  await expect(page).toHaveURL(pageUrl)
+})

--- a/e2e/tests/offline/settings.spec.mjs
+++ b/e2e/tests/offline/settings.spec.mjs
@@ -198,6 +198,15 @@ test.describe('skip silence settings search', () => {
 test.describe('settings search highlights', () => {
   test.use({ seed: { settings: { currentLocale: 'en-US' } } })
 
+  test('does not draw a separate focus frame inside the search field', async ({ page }) => {
+    await goTo(page, 'settings')
+    const search = page.getByRole('searchbox', { name: 'Search settings' })
+
+    await expect(search).toBeFocused()
+    await expect(search).toHaveCSS('outline-style', 'none')
+    await expect(search).toHaveCSS('box-shadow', 'none')
+  })
+
   test('finds and highlights specific subscription refresh interval selects', async ({ page }) => {
     await expectSubscriptionRefreshIntervalSelectHighlight(page)
   })

--- a/src/renderer/App.vue
+++ b/src/renderer/App.vue
@@ -343,6 +343,7 @@ import { MULTIPLE_TABS_CONFIRM_THRESHOLD, KeyboardShortcuts } from '../constants
 import { resolveBaseTheme } from '../appearanceSettings'
 import { resolveColor } from './helpers/colors'
 import { matchesKeyboardShortcut } from './helpers/keyboardShortcuts'
+import { hasVisibleGamepadLayer, initializeGamepadNavigation } from './helpers/gamepadNavigation'
 import { keyboardEventInitFromShortcut, OPEN_COMMAND_PALETTE_EVENT } from './helpers/commandPalette'
 import { createCommandPaletteRegistry } from './helpers/commandPaletteRegistry'
 import { initializePlatformInfo, isLinuxWayland } from './helpers/platform'
@@ -608,6 +609,7 @@ let removeConfirmMultipleTabsActionListener = null
 let removeOpenUrlListener = null
 let removeYtDlpBinaryUpdatedListener = null
 let removeOpenTabOrganizerListener = null
+let removeGamepadNavigation = () => {}
 /** @type {number|null} */
 let utilityRoutePreloadId = null
 let utilityRoutePreloadUsesIdleCallback = false
@@ -947,6 +949,11 @@ async function completeTutorial() {
 }
 
 onMounted(async () => {
+  removeGamepadNavigation = initializeGamepadNavigation({
+    onBack: handleGamepadBack,
+    onNavigate: () => store.dispatch('showOutlines'),
+    onPlayPause: handleGamepadPlayPause,
+  })
   let tabsReady = Promise.resolve()
 
   if (isElectron) {
@@ -1120,6 +1127,7 @@ onMounted(async () => {
 })
 
 onBeforeUnmount(() => {
+  removeGamepadNavigation()
   removeCustomThemeListener()
   cancelUtilityRoutePreload()
   systemColorScheme.removeEventListener('change', handleSystemColorSchemeChange)
@@ -2253,6 +2261,34 @@ function runShortcutFromCommandPalette(shortcut) {
   nextTick(() => {
     document.dispatchEvent(new KeyboardEvent('keydown', keyboardEventInitFromShortcut(shortcut)))
   })
+}
+
+function handleGamepadPlayPause() {
+  document.dispatchEvent(new KeyboardEvent(
+    'keydown',
+    keyboardEventInitFromShortcut(KeyboardShortcuts.VIDEO_PLAYER.PLAYBACK.PLAY)
+  ))
+}
+
+function handleGamepadBack() {
+  const hadOpenLayer = hasVisibleGamepadLayer()
+  const target = document.activeElement instanceof HTMLElement ? document.activeElement : document
+  const escapeEvent = new KeyboardEvent('keydown', {
+    key: 'Escape',
+    code: 'Escape',
+    bubbles: true,
+    cancelable: true,
+  })
+
+  if (!target.dispatchEvent(escapeEvent) || hadOpenLayer) {
+    return
+  }
+  if (document.fullscreenElement !== null) {
+    document.exitFullscreen()
+    return
+  }
+
+  goHistoryFromCommandPalette(-1)
 }
 
 /**

--- a/src/renderer/components/FtQuickSettingsMenu/FtQuickSettingsMenu.vue
+++ b/src/renderer/components/FtQuickSettingsMenu/FtQuickSettingsMenu.vue
@@ -689,7 +689,7 @@ async function runSettingUpdate(update) {
   } finally {
     await nextTick()
     if (focusTarget?.isConnected && menu?.contains(focusTarget)) {
-      focusTarget.focus({ preventScroll: true })
+      focusTarget.focus({ preventScroll: true, focusVisible: true })
     } else if (!menu?.matches(':focus-within')) {
       await focusMenu()
     }

--- a/src/renderer/components/FtQuickSettingsMenu/FtQuickSettingsMenu.vue
+++ b/src/renderer/components/FtQuickSettingsMenu/FtQuickSettingsMenu.vue
@@ -614,9 +614,27 @@ function closeProfilePanel() {
 function handleMenuFocusOut(event) {
   if (event.relatedTarget === null) {
     const controlChangedDuringClick = pointerDownInsideMenu || pendingSettingUpdateCount > 0
+    const focusTarget = event.target
+    const focusTargetLabel = focusTarget instanceof HTMLElement
+      ? focusTarget.closest('label')
+      : null
+    const associatedControl = focusTargetLabel instanceof HTMLLabelElement
+      ? focusTargetLabel.control
+      : null
     setTimeout(() => {
-      if (controlChangedDuringClick) {
-        focusMenu()
+      const focusedControlWasRemoved = focusTarget instanceof Node && !focusTarget.isConnected
+      if (controlChangedDuringClick || focusedControlWasRemoved) {
+        const menu = menuRef.value?.$el
+        if (
+          focusedControlWasRemoved &&
+          associatedControl instanceof HTMLElement &&
+          associatedControl.isConnected &&
+          menu?.contains(associatedControl)
+        ) {
+          associatedControl.focus({ preventScroll: true, focusVisible: true })
+        } else if (!menu?.matches(':focus-within')) {
+          focusMenu()
+        }
         return
       }
       if (document.hasFocus() && !menuRef.value?.$el.matches(':focus-within')) {
@@ -661,11 +679,20 @@ async function updateSetting(setting, value) {
 }
 
 async function runSettingUpdate(update) {
+  const menu = menuRef.value?.$el
+  const focusTarget = document.activeElement instanceof HTMLElement && menu?.contains(document.activeElement)
+    ? document.activeElement
+    : null
   pendingSettingUpdateCount++
   try {
     await update()
   } finally {
-    await focusMenu()
+    await nextTick()
+    if (focusTarget?.isConnected && menu?.contains(focusTarget)) {
+      focusTarget.focus({ preventScroll: true })
+    } else if (!menu?.matches(':focus-within')) {
+      await focusMenu()
+    }
     pendingSettingUpdateCount--
   }
 }

--- a/src/renderer/components/FtSlider/FtSlider.css
+++ b/src/renderer/components/FtSlider/FtSlider.css
@@ -55,6 +55,12 @@
   opacity: 0.38;
 }
 
+.pure-material-slider:has(> .input[data-gamepad-active='true']) {
+  border-radius: calc(4px * var(--ui-roundness));
+  background-color: var(--accent-color-opacity2);
+  box-shadow: inset 0 0 0 2px var(--primary-color);
+}
+
 .input::-webkit-slider-runnable-track {
   margin-block: 17px;
   margin-inline: 0;

--- a/src/renderer/components/FtToggleSwitch/FtToggleSwitch.scss
+++ b/src/renderer/components/FtToggleSwitch/FtToggleSwitch.scss
@@ -24,8 +24,9 @@
   cursor: pointer;
   display: inline-block;
   font-weight: 500;
+  margin-inline-start: -5px;
   padding-block: 12px;
-  padding-inline: 44px 0;
+  padding-inline: 49px 0;
   position: relative;
   text-align: start;
 
@@ -44,7 +45,7 @@
     background-color: #9e9e9e;
     border-radius: 8px;
     block-size: 14px;
-    inset-inline-start: 1px;
+    inset-inline-start: 6px;
     inline-size: 34px;
 
     .switch-input:checked + & {
@@ -61,7 +62,7 @@
     border-radius: 50%;
     box-shadow: 0 3px 1px -2px rgb(0 0 0 / 14%), 0 2px 2px 0 rgb(0 0 0 / 9.8%), 0 1px 5px 0 rgb(0 0 0 / 8.4%);
     block-size: 20px;
-    inset-inline-start: 0;
+    inset-inline-start: 5px;
     inline-size: 20px;
 
     .switch-input:checked + & {
@@ -91,4 +92,18 @@
   .switch-label-text {
     opacity: 0.4;
   }
+}
+
+/* The label is the visible control, so it also owns the focus indicator. */
+/* stylelint-disable-next-line a11y/no-outline-none */
+.switch-input:focus-visible {
+  outline: none;
+  box-shadow: none;
+}
+
+.switch-input:focus-visible + .switch-label {
+  border-radius: calc(4px * var(--ui-roundness));
+  outline: 2px solid var(--primary-color);
+  outline-offset: -3px;
+  box-shadow: inset 0 0 0 1px var(--focus-ring-contrast-color);
 }

--- a/src/renderer/components/SideNav/SideNav.css
+++ b/src/renderer/components/SideNav/SideNav.css
@@ -76,6 +76,11 @@
   text-decoration: inherit;
 }
 
+.navOption:focus-visible,
+.navChannel:focus-visible {
+  z-index: 2;
+}
+
 .navOption:hover,
 .navChannel:hover {
   background-color: var(--side-nav-hover-color);

--- a/src/renderer/helpers/gamepadNavigation.js
+++ b/src/renderer/helpers/gamepadNavigation.js
@@ -1,0 +1,433 @@
+const GAMEPAD_AXIS_THRESHOLD = 0.55
+const GAMEPAD_REPEAT_DELAY = 350
+const GAMEPAD_REPEAT_INTERVAL = 110
+const GAMEPAD_ACTIVE_RANGE_ATTRIBUTE = 'data-gamepad-active'
+
+const GAMEPAD_BUTTONS = {
+  primary: 0,
+  back: 1,
+  playPause: 9,
+  up: 12,
+  down: 13,
+  left: 14,
+  right: 15,
+}
+
+const DIRECTION_ACTIONS = new Set(['up', 'down', 'left', 'right'])
+const ACTION_ORDER = ['up', 'down', 'left', 'right', 'primary', 'back', 'playPause']
+const GAMEPAD_LAYER_SELECTOR = [
+  '[role="dialog"]',
+  '[role="menu"]',
+  '.shaka-overflow-menu:not(.shaka-hidden)',
+  '.shaka-settings-menu:not(.shaka-hidden)',
+  '.shaka-sub-menu:not(.shaka-hidden)',
+  '.shaka-context-menu:not(.shaka-hidden)',
+].join(',')
+const FOCUSABLE_SELECTOR = [
+  'a[href]',
+  'button',
+  'input:not([type="hidden"])',
+  'select',
+  'textarea',
+  'summary',
+  '[contenteditable]:not([contenteditable="false"])',
+  '[tabindex]',
+  '[role="tab"]',
+  '.tabBar .tab[role="button"]',
+].join(',')
+
+/**
+ * Enables navigation with controllers that follow the standard Gamepad mapping.
+ *
+ * @param {object} options
+ * @param {() => void} options.onBack
+ * @param {() => void} options.onNavigate
+ * @param {() => void} options.onPlayPause
+ * @returns {() => void}
+ */
+export function initializeGamepadNavigation({ onBack, onNavigate, onPlayPause }) {
+  if (typeof navigator.getGamepads !== 'function') {
+    return () => {}
+  }
+
+  /** @type {Map<string, number>} */
+  const heldActions = new Map()
+  let animationFrame = null
+  let stopped = false
+
+  function startPolling() {
+    if (animationFrame === null && !stopped) {
+      animationFrame = requestAnimationFrame(pollGamepads)
+    }
+  }
+
+  /** @param {number} timestamp */
+  function pollGamepads(timestamp) {
+    animationFrame = null
+    const gamepads = getConnectedGamepads()
+
+    if (!document.hasFocus()) {
+      heldActions.clear()
+    } else {
+      const pressedActions = getPressedActions(gamepads)
+
+      for (const action of ACTION_ORDER) {
+        if (!pressedActions.has(action)) {
+          heldActions.delete(action)
+          continue
+        }
+
+        const nextRepeat = heldActions.get(action)
+        if (nextRepeat === undefined) {
+          runAction(action)
+          heldActions.set(
+            action,
+            DIRECTION_ACTIONS.has(action) ? timestamp + GAMEPAD_REPEAT_DELAY : Number.POSITIVE_INFINITY
+          )
+        } else if (timestamp >= nextRepeat) {
+          runAction(action)
+          heldActions.set(action, timestamp + GAMEPAD_REPEAT_INTERVAL)
+        }
+      }
+    }
+
+    if (gamepads.length > 0 || heldActions.size > 0) {
+      startPolling()
+    }
+  }
+
+  /** @param {string} action */
+  function runAction(action) {
+    if (DIRECTION_ACTIONS.has(action)) {
+      onNavigate()
+      moveGamepadFocus(action)
+    } else if (action === 'primary') {
+      onNavigate()
+      activateGamepadFocus()
+    } else if (action === 'back') {
+      if (!deactivateActiveRangeInput()) {
+        onBack()
+      }
+    } else if (action === 'playPause') {
+      onPlayPause()
+    }
+  }
+
+  window.addEventListener('gamepadconnected', startPolling)
+  window.addEventListener('gamepaddisconnected', startPolling)
+  startPolling()
+
+  return () => {
+    stopped = true
+    window.removeEventListener('gamepadconnected', startPolling)
+    window.removeEventListener('gamepaddisconnected', startPolling)
+    if (animationFrame !== null) {
+      cancelAnimationFrame(animationFrame)
+    }
+  }
+}
+
+function getConnectedGamepads() {
+  try {
+    return Array.from(navigator.getGamepads())
+      .filter(gamepad => gamepad != null && gamepad.connected !== false)
+  } catch {
+    return []
+  }
+}
+
+/** @param {Gamepad[]} gamepads */
+function getPressedActions(gamepads) {
+  const actions = new Set()
+
+  for (const gamepad of gamepads) {
+    for (const [action, buttonIndex] of Object.entries(GAMEPAD_BUTTONS)) {
+      const button = gamepad.buttons[buttonIndex]
+      if (button?.pressed || button?.value > 0.5) {
+        actions.add(action)
+      }
+    }
+
+    const horizontalAxis = gamepad.axes[0] ?? 0
+    const verticalAxis = gamepad.axes[1] ?? 0
+    if (Math.abs(horizontalAxis) >= GAMEPAD_AXIS_THRESHOLD) {
+      actions.add(horizontalAxis < 0 ? 'left' : 'right')
+    }
+    if (Math.abs(verticalAxis) >= GAMEPAD_AXIS_THRESHOLD) {
+      actions.add(verticalAxis < 0 ? 'up' : 'down')
+    }
+  }
+
+  return actions
+}
+
+/**
+ * @param {'up' | 'down' | 'left' | 'right'} direction
+ * @returns {boolean}
+ */
+export function moveGamepadFocus(direction) {
+  const activeElement = document.activeElement
+  if (
+    activeElement instanceof HTMLInputElement &&
+    activeElement.type === 'range' &&
+    activeElement.hasAttribute(GAMEPAD_ACTIVE_RANGE_ATTRIBUTE)
+  ) {
+    if (direction === 'left' || direction === 'right') {
+      adjustRangeInput(activeElement, direction)
+      return true
+    }
+  }
+
+  if (
+    activeElement instanceof HTMLElement &&
+    activeElement.getAttribute('role') === 'combobox' &&
+    activeElement.getAttribute('aria-expanded') === 'true'
+  ) {
+    activeElement.dispatchEvent(new KeyboardEvent('keydown', {
+      key: `Arrow${direction[0].toUpperCase()}${direction.slice(1)}`,
+      bubbles: true,
+      cancelable: true,
+    }))
+    return true
+  }
+
+  const focusableElements = getFocusableElements()
+  if (focusableElements.length === 0) {
+    return false
+  }
+
+  const currentElement = activeElement instanceof HTMLElement &&
+    focusableElements.includes(activeElement) &&
+    isVisible(activeElement)
+    ? activeElement
+    : null
+  const nextElement = currentElement === null
+    ? focusableElements[0]
+    : findSpatialCandidate(currentElement, focusableElements, direction)
+
+  if (nextElement === null) {
+    return false
+  }
+
+  nextElement.focus({ preventScroll: true, focusVisible: true })
+  nextElement.scrollIntoView({ block: 'nearest', inline: 'nearest' })
+  return true
+}
+
+export function activateGamepadFocus() {
+  const activeElement = document.activeElement
+  if (!(activeElement instanceof HTMLElement) || !isVisible(activeElement)) {
+    return moveGamepadFocus('down')
+  }
+
+  if (
+    activeElement.getAttribute('role') === 'combobox' &&
+    activeElement.getAttribute('aria-expanded') === 'true'
+  ) {
+    activeElement.dispatchEvent(new KeyboardEvent('keydown', {
+      key: 'Enter',
+      code: 'Enter',
+      bubbles: true,
+      cancelable: true,
+    }))
+    return true
+  }
+
+  if (activeElement instanceof HTMLInputElement && activeElement.type === 'range') {
+    setRangeInputActive(
+      activeElement,
+      !activeElement.hasAttribute(GAMEPAD_ACTIVE_RANGE_ATTRIBUTE)
+    )
+    return true
+  }
+
+  if (activeElement.matches(GAMEPAD_LAYER_SELECTOR)) {
+    return moveGamepadFocus('down')
+  }
+
+  const activeLayer = activeElement.closest(GAMEPAD_LAYER_SELECTOR)
+  const focusableElements = activeLayer === null ? [] : getFocusableElements(activeLayer)
+  const activeIndex = focusableElements.indexOf(activeElement)
+  activeElement.click()
+  requestAnimationFrame(() => {
+    if (
+      !activeElement.isConnected &&
+      activeLayer instanceof HTMLElement &&
+      activeLayer.isConnected &&
+      isVisible(activeLayer) &&
+      !activeLayer.contains(document.activeElement)
+    ) {
+      const remainingFocusableElements = getFocusableElements(activeLayer)
+      const nextElement = remainingFocusableElements[
+        Math.min(Math.max(activeIndex, 0), remainingFocusableElements.length - 1)
+      ]
+      if (nextElement !== undefined) {
+        nextElement.focus({ preventScroll: true, focusVisible: true })
+        nextElement.scrollIntoView({ block: 'nearest', inline: 'nearest' })
+      }
+    }
+
+    if (
+      document.activeElement instanceof HTMLElement &&
+      document.activeElement.matches(GAMEPAD_LAYER_SELECTOR)
+    ) {
+      moveGamepadFocus('down')
+    }
+  })
+  return true
+}
+
+/** @param {Event} event */
+function handleRangeInputBlur(event) {
+  if (event.currentTarget instanceof HTMLInputElement) {
+    setRangeInputActive(event.currentTarget, false)
+  }
+}
+
+/**
+ * @param {HTMLInputElement} input
+ * @param {boolean} active
+ */
+function setRangeInputActive(input, active) {
+  if (active) {
+    input.setAttribute(GAMEPAD_ACTIVE_RANGE_ATTRIBUTE, 'true')
+    input.addEventListener('blur', handleRangeInputBlur, { once: true })
+  } else {
+    input.removeAttribute(GAMEPAD_ACTIVE_RANGE_ATTRIBUTE)
+    input.removeEventListener('blur', handleRangeInputBlur)
+  }
+}
+
+function deactivateActiveRangeInput() {
+  const activeElement = document.activeElement
+  if (
+    !(activeElement instanceof HTMLInputElement) ||
+    activeElement.type !== 'range' ||
+    !activeElement.hasAttribute(GAMEPAD_ACTIVE_RANGE_ATTRIBUTE)
+  ) {
+    return false
+  }
+
+  setRangeInputActive(activeElement, false)
+  return true
+}
+
+/** @param {HTMLElement | null} [navigationRootOverride] */
+function getFocusableElements(navigationRootOverride = null) {
+  const visibleLayers = Array.from(document.querySelectorAll(GAMEPAD_LAYER_SELECTOR))
+    .filter(element => element instanceof HTMLElement && isVisible(element))
+  const activeLayer = document.activeElement instanceof HTMLElement
+    ? document.activeElement.closest(GAMEPAD_LAYER_SELECTOR)
+    : null
+  const navigationRoot = navigationRootOverride ?? activeLayer ?? visibleLayers.at(-1) ?? document
+
+  return Array.from(navigationRoot.querySelectorAll(FOCUSABLE_SELECTOR)).filter(element => {
+    if (!(element instanceof HTMLElement) || !isVisible(element)) {
+      return false
+    }
+    if (element.matches(':disabled, [aria-disabled="true"]')) {
+      return false
+    }
+    if (element.closest('[inert], [aria-hidden="true"]')) {
+      return false
+    }
+
+    return element.tabIndex >= 0 ||
+      element.getAttribute('role') === 'tab' ||
+      element.matches('.tabBar .tab[role="button"]')
+  })
+}
+
+export function hasVisibleGamepadLayer() {
+  return Array.from(document.querySelectorAll(
+    `${GAMEPAD_LAYER_SELECTOR}, [aria-expanded="true"][aria-haspopup]`
+  )).some(element => element instanceof HTMLElement && isVisible(element))
+}
+
+/**
+ * @param {HTMLElement} currentElement
+ * @param {HTMLElement[]} candidates
+ * @param {'up' | 'down' | 'left' | 'right'} direction
+ * @returns {HTMLElement | null}
+ */
+function findSpatialCandidate(currentElement, candidates, direction) {
+  const currentRect = currentElement.getBoundingClientRect()
+  const currentCenter = getRectCenter(currentRect)
+  let closestElement = null
+  let closestScore = Number.POSITIVE_INFINITY
+
+  for (const candidate of candidates) {
+    if (candidate === currentElement || currentElement.contains(candidate)) {
+      continue
+    }
+
+    const candidateRect = candidate.getBoundingClientRect()
+    const candidateCenter = getRectCenter(candidateRect)
+    const horizontalDistance = candidateCenter.x - currentCenter.x
+    const verticalDistance = candidateCenter.y - currentCenter.y
+    const isHorizontal = direction === 'left' || direction === 'right'
+    const primaryDistance = isHorizontal ? horizontalDistance : verticalDistance
+    const pointsInDirection = direction === 'left' || direction === 'up'
+      ? primaryDistance < -1
+      : primaryDistance > 1
+
+    if (!pointsInDirection) {
+      continue
+    }
+
+    const crossDistance = Math.abs(isHorizontal ? verticalDistance : horizontalDistance)
+    const aligned = isHorizontal
+      ? rangesOverlap(currentRect.top, currentRect.bottom, candidateRect.top, candidateRect.bottom)
+      : rangesOverlap(currentRect.left, currentRect.right, candidateRect.left, candidateRect.right)
+    const score = Math.abs(primaryDistance) + crossDistance * (aligned ? 0.2 : 2) + (aligned ? 0 : 100)
+
+    if (score < closestScore) {
+      closestElement = candidate
+      closestScore = score
+    }
+  }
+
+  return closestElement
+}
+
+function getRectCenter(rect) {
+  return {
+    x: rect.left + rect.width / 2,
+    y: rect.top + rect.height / 2,
+  }
+}
+
+function rangesOverlap(firstStart, firstEnd, secondStart, secondEnd) {
+  return firstStart < secondEnd && secondStart < firstEnd
+}
+
+/**
+ * @param {HTMLInputElement} input
+ * @param {'up' | 'down' | 'left' | 'right'} direction
+ */
+function adjustRangeInput(input, direction) {
+  const minimum = Number(input.min || 0)
+  const maximum = Number(input.max || 100)
+  const configuredStep = Number(input.step)
+  const step = Number.isFinite(configuredStep) && configuredStep > 0
+    ? configuredStep
+    : (maximum - minimum) / 100
+  const increase = direction === 'right' || direction === 'up'
+  const currentValue = Number.isFinite(input.valueAsNumber) ? input.valueAsNumber : minimum
+  const nextValue = Math.min(maximum, Math.max(minimum, currentValue + (increase ? step : -step)))
+
+  input.valueAsNumber = nextValue
+  input.dispatchEvent(new Event('input', { bubbles: true }))
+  input.dispatchEvent(new Event('change', { bubbles: true }))
+}
+
+/** @param {HTMLElement} element */
+function isVisible(element) {
+  const rect = element.getBoundingClientRect()
+  const style = getComputedStyle(element)
+  return rect.width > 0 &&
+    rect.height > 0 &&
+    style.display !== 'none' &&
+    style.visibility !== 'hidden' &&
+    style.visibility !== 'collapse'
+}

--- a/src/renderer/helpers/gamepadNavigation.js
+++ b/src/renderer/helpers/gamepadNavigation.js
@@ -216,7 +216,11 @@ export function moveGamepadFocus(direction) {
 
 export function activateGamepadFocus() {
   const activeElement = document.activeElement
-  if (!(activeElement instanceof HTMLElement) || !isVisible(activeElement)) {
+  if (
+    !(activeElement instanceof HTMLElement) ||
+    activeElement === document.body ||
+    !isVisible(activeElement)
+  ) {
     return moveGamepadFocus('down')
   }
 

--- a/src/renderer/themes.css
+++ b/src/renderer/themes.css
@@ -16,6 +16,7 @@ body {
   --dropdown-item-hover-text-color: var(--scrollbar-text-color-hover);
   --selection-background-color: var(--primary-color);
   --selection-text-color: var(--text-with-main-color);
+  --focus-ring-contrast-color: #000;
 
   /*
     This works because CSS variables are just a find and replace and
@@ -63,6 +64,13 @@ body {
 ::selection {
   color: var(--selection-text-color);
   background-color: var(--selection-background-color);
+}
+
+:focus-visible {
+  outline: 2px solid var(--primary-color);
+  outline-offset: -3px;
+  border-radius: calc(4px * var(--ui-roundness));
+  box-shadow: inset 0 0 0 1px var(--focus-ring-contrast-color);
 }
 
 input[type='search']::-webkit-search-cancel-button {
@@ -159,6 +167,7 @@ it can be safely elided. This looks quite pleasant on this theme. */
 .everforestDarkHard,
 .everforestDarkMedium,
 .everforestDarkLow {
+  --focus-ring-contrast-color: #fff;
   --primary-shadow-color: rgb(0 0 0 / 75%);
   --members-only-color: #55c86b;
 

--- a/src/renderer/views/Settings/Settings.css
+++ b/src/renderer/views/Settings/Settings.css
@@ -177,6 +177,7 @@
   padding: 0;
   border: 0;
   outline: 0;
+  box-shadow: none;
   color: var(--primary-text-color);
   background: transparent;
   font: inherit;


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Make sure to follow the contributing guidelines. -->
<!-- Important note, we may remove your pull request if you do not use this provided PR template correctly. -->
<!-- Agent instructions: Preserve every heading, comment, and marker in this template. Never remove or rewrite the release-note-category:start/end, release-note:start/end, or release-note-image:start/end marker pairs. -->

## Pull Request Type
<!-- Please select what type of pull request this is: [x] -->
- [ ] Bugfix
- [x] Feature Implementation
- [ ] Documentation
- [ ] Other

## Related issue
<!-- Please link the issue your pull request is referring to. -->
<!-- If this pull request fully resolves the relevant issue, put "closes" before the issue number. -->
<!-- Example: "closes #123456". -->

Closes #970.

## Description
<!-- Please write a clear and concise description of what the pull request does. -->

OpenTubeX could not be operated with a game controller. This adds spatial navigation for standard gamepads, including activation, back navigation, playback control, selects, and sliders.

Gamepad focus uses the active theme and configured UI roundness. Sliders show when they are active, switches highlight their full labels, and Quick Settings keeps focus on controls while values update or reset.

## Release note category
<!-- Select exactly one category. Every pull request must select one. -->
<!-- Select "Not noteworthy" when the pull request fixes a bug in or improves functionality that has not yet appeared in a stable release. -->
<!-- release-note-category:start -->
- [ ] Not noteworthy
- [x] Highlights
- [ ] More improvements
- [ ] Fixed bugs
<!-- release-note-category:end -->

## Release note
<!-- Required unless "Not noteworthy" is selected. -->
<!-- Write one concise, user-facing entry without a leading bullet. -->
<!-- release-note:start -->
Navigate OpenTubeX with a standard gamepad, including menus, sliders, playback, and back controls.
<!-- release-note:end -->

## Release note images
<!-- Optional. Paste one or more Markdown images, HTML image tags, or dark/light <picture> elements here. -->
<!-- The release notes normalize the markup and limit images taller than 300 pixels. -->
<!-- Agent instructions:
For a noteworthy visible change, add media when it makes the change easier to understand. Prefer a still image unless motion is the point; recordings must use animated WebP.
After implementing a visible change, proactively capture the result and show the local media to the user for approval before uploading it or updating the pull request.
When the affected UI differs between dark and light themes, capturing both themes is required. A dark-only image is incomplete. Run `node _scripts/releaseNoteMedia.mjs --dark DARK_FILE --light LIGHT_FILE --alt "DESCRIPTION"`; GitHub will display the matching theme and use dark as the fallback. Use a single default-dark capture only when the light theme cannot be captured or looks identical.
Capture or crop to the smallest region that still makes the change clear. Do not include the full window when the affected component can be understood on its own.
Use English unless localization is the subject. Keep components at their normal dimensions and placement instead of resizing them to fill the frame.
Use deterministic local fixtures for visible remote images. Reusable avatar and thumbnail fixtures are available through `e2e/helpers/visual-fixtures.mjs`. Before capturing, verify that every visible image has loaded successfully (`complete === true` and `naturalWidth > 0`).
Inspect the final dark and light files for failed images, missing content, unrelated UI, awkward animation, and misleading layout. Omit media when it does not explain the change clearly.
For one dark capture, run `node _scripts/releaseNoteMedia.mjs FILE --alt "DESCRIPTION"`.
Check for personal information, tokens, private repository names, and unrelated desktop content before uploading. Uploaded media is public.
Keep capture-only scripts, test hooks, screenshots, and recordings out of commits. Remove them before committing unless the capture code is also a reusable regression test. Never commit generated release-note media.
Paste only the generated markup between the marker comments. Leave this section empty when media would not help.
-->
<!-- release-note-image:start -->

<!-- release-note-image:end -->

## Testing
<!-- How can reviewers verify that the PR produces correct results? -->
<!-- Please provide instructions so that others can ensure that your pull request would produce correct results. For examples see, https://github.com/FreeTubeApp/FreeTube/pull/5743, https://github.com/FreeTubeApp/FreeTube/pull/7349, https://github.com/FreeTubeApp/FreeTube/pull/5125, https://github.com/FreeTubeApp/FreeTube/pull/7338 -->
<!-- Agent instructions: Only write human-facing steps that explain how to verify the change while running this branch in dev mode. Include expected results and, when applicable, helpful console snippets for interactive verification. Do not include automated checks, commands, results, pass counts, or CI status. -->

1. Start OpenTubeX in dev mode and open the renderer DevTools console.
2. Paste this temporary keyboard-backed standard gamepad emulator:

   ```js
   const buttons = Array.from({ length: 17 }, () => ({ pressed: false, value: 0 }))
   const gamepad = {
     axes: [0, 0, 0, 0], buttons, connected: true,
     id: 'Dev standard controller', index: 0, mapping: 'standard', timestamp: 0
   }
   Object.defineProperty(navigator, 'getGamepads', {
     configurable: true,
     value: () => [gamepad]
   })
   const buttonForKey = new Map([
     ['Enter', 0], ['q', 1], ['p', 9],
     ['ArrowUp', 12], ['ArrowDown', 13], ['ArrowLeft', 14], ['ArrowRight', 15]
   ])
   const updateButton = (event, pressed) => {
     const index = buttonForKey.get(event.key)
     if (index === undefined) return
     event.preventDefault()
     event.stopImmediatePropagation()
     buttons[index].pressed = pressed
     buttons[index].value = pressed ? 1 : 0
     gamepad.timestamp++
   }
   addEventListener('keydown', event => updateButton(event, true), true)
   addEventListener('keyup', event => updateButton(event, false), true)
   const connected = new Event('gamepadconnected')
   Object.defineProperty(connected, 'gamepad', { value: gamepad })
   dispatchEvent(connected)
   ```

3. Use the arrow keys to move focus and Enter to activate controls. Focus should follow the nearest control and use the current theme color and UI roundness.
4. Focus a slider and press Enter. Its active state should become visible, the arrow keys should change its value, and Enter should leave adjustment mode.
5. Open Quick Settings, change a slider, then activate its reset button. The menu should stay open and focus should return to the slider.
6. Press Q to close an open menu or go back, and press P on a playing video to toggle playback.
7. Open Settings without using the emulator. Its search field should keep its normal appearance without a second outline around the input text.

## Additional context
<!-- Add any other context about the pull request here. -->

The release note has no still image because controller navigation is a motion interaction and a static focus ring would not explain the feature.
