### PR TITLE
feat(release): submit FlatPark updates from the organization fork

### DIFF
--- a/.github/workflows/flatpark.yml
+++ b/.github/workflows/flatpark.yml
@@ -54,9 +54,24 @@ jobs:
           exit 1
         fi
 
-        latest_tag="$(gh api "repos/${GITHUB_REPOSITORY}/releases/latest" --jq .tag_name)"
-        if [[ "$latest_tag" != "$RELEASE_TAG" ]]; then
-          echo "::error::FlatPark can only be updated to the latest release (${latest_tag}), not ${RELEASE_TAG}."
+        latest_beta_tag="$({
+          gh api --paginate "repos/${GITHUB_REPOSITORY}/releases?per_page=100"
+        } | jq --raw-output --slurp '
+          [
+            .[][]
+            | select(.draft == false and .published_at != null)
+            | select(.tag_name | test("^v[0-9]+\\.[0-9]+\\.[0-9]+-beta$"))
+          ]
+          | max_by(.published_at).tag_name // empty
+        ')"
+
+        if [[ -z "$latest_beta_tag" ]]; then
+          echo '::error::The repository has no published beta release.'
+          exit 1
+        fi
+
+        if [[ "$latest_beta_tag" != "$RELEASE_TAG" ]]; then
+          echo "::error::FlatPark can only be updated to the latest beta (${latest_beta_tag}), not ${RELEASE_TAG}."
           exit 1
         fi
 

--- a/.github/workflows/flatpark.yml
+++ b/.github/workflows/flatpark.yml
@@ -218,8 +218,7 @@ jobs:
 
     - name: Validate package submission credentials
       env:
-        # Keep the old secret as a fallback because GitHub cannot rename or copy secrets.
-        PACKAGE_SUBMISSION_TOKEN: ${{ secrets.PACKAGE_SUBMISSION_TOKEN || secrets.WINGET_TOKEN }}
+        PACKAGE_SUBMISSION_TOKEN: ${{ secrets.PACKAGE_SUBMISSION_TOKEN }}
       shell: bash
       run: |
         set -euo pipefail
@@ -233,7 +232,7 @@ jobs:
 
     - name: Create or synchronize the organization fork
       env:
-        GH_TOKEN: ${{ secrets.PACKAGE_SUBMISSION_TOKEN || secrets.WINGET_TOKEN }}
+        GH_TOKEN: ${{ secrets.PACKAGE_SUBMISSION_TOKEN }}
       shell: bash
       run: |
         set -euo pipefail
@@ -278,7 +277,7 @@ jobs:
     - name: Create the signed update commit
       env:
         BRANCH: org.opentubex.OpenTubeX-${{ needs.prepare.outputs.version }}
-        GH_TOKEN: ${{ secrets.PACKAGE_SUBMISSION_TOKEN || secrets.WINGET_TOKEN }}
+        GH_TOKEN: ${{ secrets.PACKAGE_SUBMISSION_TOKEN }}
         VERSION: ${{ needs.prepare.outputs.version }}
       shell: bash
       run: |
@@ -362,7 +361,7 @@ jobs:
     - name: Open FlatPark pull request
       env:
         BRANCH: org.opentubex.OpenTubeX-${{ needs.prepare.outputs.version }}
-        GH_TOKEN: ${{ secrets.PACKAGE_SUBMISSION_TOKEN || secrets.WINGET_TOKEN }}
+        GH_TOKEN: ${{ secrets.PACKAGE_SUBMISSION_TOKEN }}
         RELEASE_TAG: ${{ needs.prepare.outputs.tag }}
         VERSION: ${{ needs.prepare.outputs.version }}
       shell: bash

--- a/.github/workflows/flatpark.yml
+++ b/.github/workflows/flatpark.yml
@@ -1,0 +1,405 @@
+name: Submit FlatPark update
+
+on:
+  release:
+    types: [published]
+  workflow_dispatch:
+    inputs:
+      releaseTag:
+        description: Published release tag to retry, for example v0.32.1-beta
+        required: true
+        type: string
+
+permissions:
+  contents: read
+
+concurrency:
+  group: flatpark-${{ github.event.release.tag_name || inputs.releaseTag }}
+  cancel-in-progress: false
+
+jobs:
+  prepare:
+    if: github.repository == 'OpenTubeX/OpenTubeX'
+    runs-on: ubuntu-24.04
+    timeout-minutes: 20
+
+    outputs:
+      needed: ${{ steps.duplicate.outputs.needed }}
+      tag: ${{ steps.release.outputs.tag }}
+      version: ${{ steps.release.outputs.version }}
+
+    steps:
+    - name: Resolve release
+      id: release
+      env:
+        GH_TOKEN: ${{ github.token }}
+        RELEASE_TAG: ${{ github.event.release.tag_name || inputs.releaseTag }}
+      shell: bash
+      run: |
+        set -euo pipefail
+
+        if [[ ! "$RELEASE_TAG" =~ ^v([0-9]+\.[0-9]+\.[0-9]+-beta)$ ]]; then
+          echo "Ignoring unrelated release tag: $RELEASE_TAG"
+          echo 'eligible=false' >> "$GITHUB_OUTPUT"
+          exit 0
+        fi
+
+        version="${BASH_REMATCH[1]}"
+        release_json="${RUNNER_TEMP}/flatpark-release.json"
+        gh api "repos/${GITHUB_REPOSITORY}/releases/tags/${RELEASE_TAG}" > "$release_json"
+
+        if [[ "$(jq --raw-output .draft "$release_json")" != false ||
+          "$(jq --raw-output .published_at "$release_json")" == null ]]; then
+          echo "::error::${RELEASE_TAG} is not a published release."
+          exit 1
+        fi
+
+        latest_tag="$(gh api "repos/${GITHUB_REPOSITORY}/releases/latest" --jq .tag_name)"
+        if [[ "$latest_tag" != "$RELEASE_TAG" ]]; then
+          echo "::error::FlatPark can only be updated to the latest release (${latest_tag}), not ${RELEASE_TAG}."
+          exit 1
+        fi
+
+        for architecture in x64 arm64; do
+          asset="opentubex-${version}-linux-${architecture}-portable.zip"
+          count="$(jq --arg asset "$asset" '[.assets[] | select(.name == $asset)] | length' "$release_json")"
+
+          if [[ "$count" != 1 ]]; then
+            echo "::error::Expected one release asset named ${asset}, found ${count}."
+            exit 1
+          fi
+        done
+
+        {
+          echo 'eligible=true'
+          echo "version=$version"
+          echo "tag=$RELEASE_TAG"
+          echo "release_json=$release_json"
+        } >> "$GITHUB_OUTPUT"
+
+    - name: Check for an accepted update or open pull request
+      if: steps.release.outputs.eligible == 'true'
+      id: duplicate
+      env:
+        GH_TOKEN: ${{ github.token }}
+        VERSION: ${{ steps.release.outputs.version }}
+      shell: bash
+      run: |
+        set -euo pipefail
+
+        manifest="${RUNNER_TEMP}/flatpark-metainfo.xml"
+        gh api \
+          repos/flatpark/flatpark/contents/registry/org.opentubex.OpenTubeX/org.opentubex.OpenTubeX.metainfo.xml \
+          --jq .content \
+          | base64 --decode > "$manifest"
+
+        if grep --fixed-strings --quiet "<release version=\"${VERSION}\"" "$manifest"; then
+          echo "FlatPark already contains org.opentubex.OpenTubeX ${VERSION}."
+          echo 'needed=false' >> "$GITHUB_OUTPUT"
+          exit 0
+        fi
+
+        existing_pr="$({
+          gh pr list \
+            --repo flatpark/flatpark \
+            --state open \
+            --search '"org.opentubex.OpenTubeX" in:title' \
+            --json title,url \
+            --limit 100
+        } | jq --arg version "$VERSION" \
+          'first(.[] | select(.title | contains($version))) // empty')"
+
+        if [[ -n "$existing_pr" ]]; then
+          echo "An open pull request already updates org.opentubex.OpenTubeX ${VERSION}:"
+          jq --raw-output .url <<< "$existing_pr"
+          echo 'needed=false' >> "$GITHUB_OUTPUT"
+          exit 0
+        fi
+
+        echo 'needed=true' >> "$GITHUB_OUTPUT"
+
+    - name: Check out FlatPark
+      if: steps.duplicate.outputs.needed == 'true'
+      uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+      with:
+        repository: flatpark/flatpark
+        path: flatpark
+        persist-credentials: false
+
+    - name: Prepare FlatPark pins
+      if: steps.duplicate.outputs.needed == 'true'
+      env:
+        RELEASE_JSON: ${{ steps.release.outputs.release_json }}
+        RELEASE_TAG: ${{ steps.release.outputs.tag }}
+        VERSION: ${{ steps.release.outputs.version }}
+      shell: bash
+      run: |
+        set -euo pipefail
+
+        app_dir='flatpark/registry/org.opentubex.OpenTubeX'
+        manifest="${app_dir}/org.opentubex.OpenTubeX.yml"
+        metainfo="${app_dir}/org.opentubex.OpenTubeX.metainfo.xml"
+        resolver_json="${RUNNER_TEMP}/flatpark-resolver.json"
+        release_url="https://github.com/${GITHUB_REPOSITORY}/releases/tag/${RELEASE_TAG}"
+
+        jq \
+          --arg version "$VERSION" \
+          --arg release_url "$release_url" \
+          --arg x64 "opentubex-${VERSION}-linux-x64-portable.zip" \
+          --arg arm64 "opentubex-${VERSION}-linux-arm64-portable.zip" \
+          '{
+            version: $version,
+            releaseDate: (.published_at | split("T")[0]),
+            releaseUrl: $release_url,
+            sources: [
+              {
+                filename: "opentubex-x86_64.zip",
+                url: (first(.assets[] | select(.name == $x64)) | .browser_download_url)
+              },
+              {
+                filename: "opentubex-aarch64.zip",
+                url: (first(.assets[] | select(.name == $arm64)) | .browser_download_url)
+              }
+            ]
+          }' "$RELEASE_JSON" > "$resolver_json"
+
+        node flatpark/scripts/update-pins.mjs "$manifest" "$metainfo" < "$resolver_json"
+
+        expected_changes="$(printf '%s\n' \
+          'registry/org.opentubex.OpenTubeX/org.opentubex.OpenTubeX.metainfo.xml' \
+          'registry/org.opentubex.OpenTubeX/org.opentubex.OpenTubeX.yml')"
+        actual_changes="$(git -C flatpark diff --name-only | sort)"
+
+        if [[ "$actual_changes" != "$expected_changes" ]]; then
+          echo '::error::The FlatPark pin updater changed unexpected files.'
+          git -C flatpark status --short
+          exit 1
+        fi
+
+        git -C flatpark diff --check
+        grep --fixed-strings --quiet \
+          "releases/download/${RELEASE_TAG}/opentubex-${VERSION}-linux-x64-portable.zip" \
+          "$manifest"
+        grep --fixed-strings --quiet \
+          "releases/download/${RELEASE_TAG}/opentubex-${VERSION}-linux-arm64-portable.zip" \
+          "$manifest"
+
+        latest_version="$(sed -n 's/.*<release version="\([^"]*\)".*/\1/p' "$metainfo" | sed -n '1p')"
+        if [[ "$latest_version" != "$VERSION" ]]; then
+          echo "::error::Expected the latest AppStream release to be ${VERSION}, found ${latest_version}."
+          exit 1
+        fi
+
+        install -Dm644 "$manifest" submission/manifest.yml
+        install -Dm644 "$metainfo" submission/metainfo.xml
+        git -C flatpark rev-parse HEAD > submission/base-sha
+
+    - name: Store the prepared update
+      if: steps.duplicate.outputs.needed == 'true'
+      uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+      with:
+        name: flatpark-update-${{ github.run_id }}
+        path: submission/
+        if-no-files-found: error
+        retention-days: 1
+
+  submit:
+    needs: prepare
+    if: needs.prepare.outputs.needed == 'true'
+    runs-on: ubuntu-24.04
+    timeout-minutes: 10
+
+    steps:
+    - name: Download the prepared update
+      uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+      with:
+        name: flatpark-update-${{ github.run_id }}
+        path: submission
+
+    - name: Validate package submission credentials
+      env:
+        # Keep the old secret as a fallback because GitHub cannot rename or copy secrets.
+        PACKAGE_SUBMISSION_TOKEN: ${{ secrets.PACKAGE_SUBMISSION_TOKEN || secrets.WINGET_TOKEN }}
+      shell: bash
+      run: |
+        set -euo pipefail
+
+        if [[ -z "$PACKAGE_SUBMISSION_TOKEN" ]]; then
+          echo '::error::The PACKAGE_SUBMISSION_TOKEN repository secret is missing.'
+          exit 1
+        fi
+
+        echo "::add-mask::${PACKAGE_SUBMISSION_TOKEN}"
+
+    - name: Create or synchronize the organization fork
+      env:
+        GH_TOKEN: ${{ secrets.PACKAGE_SUBMISSION_TOKEN || secrets.WINGET_TOKEN }}
+      shell: bash
+      run: |
+        set -euo pipefail
+
+        if ! gh api repos/OpenTubeX/flatpark-registry >/dev/null 2>&1; then
+          echo 'Creating OpenTubeX/flatpark-registry.'
+          gh api \
+            --method POST \
+            repos/flatpark/flatpark/forks \
+            -f organization=OpenTubeX \
+            -f name=flatpark-registry \
+            -F default_branch_only=true \
+            >/dev/null
+
+          for attempt in {1..30}; do
+            if gh api repos/OpenTubeX/flatpark-registry >/dev/null 2>&1; then
+              break
+            fi
+
+            if (( attempt == 30 )); then
+              echo '::error::OpenTubeX/flatpark-registry was not ready after 60 seconds.'
+              exit 1
+            fi
+
+            sleep 2
+          done
+        fi
+
+        parent="$(gh api repos/OpenTubeX/flatpark-registry --jq '.parent.full_name // ""')"
+
+        if [[ "$parent" != flatpark/flatpark ]]; then
+          echo '::error::OpenTubeX/flatpark-registry is not a fork of flatpark/flatpark.'
+          exit 1
+        fi
+
+        gh api \
+          --method POST \
+          repos/OpenTubeX/flatpark-registry/merge-upstream \
+          -f branch=main \
+          >/dev/null
+
+    - name: Create the signed update commit
+      env:
+        BRANCH: org.opentubex.OpenTubeX-${{ needs.prepare.outputs.version }}
+        GH_TOKEN: ${{ secrets.PACKAGE_SUBMISSION_TOKEN || secrets.WINGET_TOKEN }}
+        VERSION: ${{ needs.prepare.outputs.version }}
+      shell: bash
+      run: |
+        set -euo pipefail
+
+        base_sha="$(< submission/base-sha)"
+        if [[ ! "$base_sha" =~ ^[0-9a-f]{40}$ ]]; then
+          echo '::error::The prepared FlatPark base commit is invalid.'
+          exit 1
+        fi
+
+        if ! gh api "repos/flatpark/flatpark/commits/${base_sha}" >/dev/null; then
+          echo '::error::The prepared FlatPark base commit no longer exists.'
+          exit 1
+        fi
+
+        if gh api "repos/OpenTubeX/flatpark-registry/git/ref/heads/${BRANCH}" >/dev/null 2>&1; then
+          gh api \
+            --method PATCH \
+            "repos/OpenTubeX/flatpark-registry/git/refs/heads/${BRANCH}" \
+            -f sha="$base_sha" \
+            -F force=true \
+            >/dev/null
+        else
+          gh api \
+            --method POST \
+            repos/OpenTubeX/flatpark-registry/git/refs \
+            -f ref="refs/heads/${BRANCH}" \
+            -f sha="$base_sha" \
+            >/dev/null
+        fi
+
+        branch_id="$(gh api "repos/OpenTubeX/flatpark-registry/git/ref/heads/${BRANCH}" --jq .node_id)"
+        mutation="${RUNNER_TEMP}/flatpark-commit.json"
+        response="${RUNNER_TEMP}/flatpark-commit-response.json"
+
+        jq --null-input \
+          --arg query 'mutation($input: CreateCommitOnBranchInput!) { createCommitOnBranch(input: $input) { commit { oid url } } }' \
+          --arg branch_id "$branch_id" \
+          --arg expected_head_oid "$base_sha" \
+          --arg headline "chore(update): org.opentubex.OpenTubeX ${VERSION} (upstream release)" \
+          --arg manifest_contents "$(base64 --wrap=0 submission/manifest.yml)" \
+          --arg metainfo_contents "$(base64 --wrap=0 submission/metainfo.xml)" \
+          '{
+            query: $query,
+            variables: {
+              input: {
+                branch: { id: $branch_id },
+                expectedHeadOid: $expected_head_oid,
+                fileChanges: {
+                  additions: [
+                    {
+                      path: "registry/org.opentubex.OpenTubeX/org.opentubex.OpenTubeX.yml",
+                      contents: $manifest_contents
+                    },
+                    {
+                      path: "registry/org.opentubex.OpenTubeX/org.opentubex.OpenTubeX.metainfo.xml",
+                      contents: $metainfo_contents
+                    }
+                  ]
+                },
+                message: { headline: $headline }
+              }
+            }
+          }' > "$mutation"
+
+        gh api graphql --input "$mutation" > "$response"
+        commit_sha="$(jq --raw-output '.data.createCommitOnBranch.commit.oid // empty' "$response")"
+
+        if [[ -z "$commit_sha" ]]; then
+          jq .errors "$response" >&2
+          echo '::error::GitHub did not create the FlatPark update commit.'
+          exit 1
+        fi
+
+        if [[ "$(gh api "repos/OpenTubeX/flatpark-registry/commits/${commit_sha}" --jq .commit.verification.verified)" != true ]]; then
+          echo '::error::GitHub did not report the FlatPark update commit as signed.'
+          exit 1
+        fi
+
+    - name: Open FlatPark pull request
+      env:
+        BRANCH: org.opentubex.OpenTubeX-${{ needs.prepare.outputs.version }}
+        GH_TOKEN: ${{ secrets.PACKAGE_SUBMISSION_TOKEN || secrets.WINGET_TOKEN }}
+        RELEASE_TAG: ${{ needs.prepare.outputs.tag }}
+        VERSION: ${{ needs.prepare.outputs.version }}
+      shell: bash
+      run: |
+        set -euo pipefail
+
+        existing_pr="$(gh pr list \
+          --repo flatpark/flatpark \
+          --state open \
+          --search '"org.opentubex.OpenTubeX" in:title' \
+          --json title,url \
+          --limit 100 \
+          | jq --arg version "$VERSION" \
+            'first(.[] | select(.title | contains($version))) // empty')"
+
+        if [[ -n "$existing_pr" ]]; then
+          echo "An open pull request appeared while this workflow was running:"
+          jq --raw-output .url <<< "$existing_pr"
+          exit 0
+        fi
+
+        body="${RUNNER_TEMP}/flatpark-pr-body.md"
+        cat > "$body" <<EOF
+        OpenTubeX published [${RELEASE_TAG}](https://github.com/${GITHUB_REPOSITORY}/releases/tag/${RELEASE_TAG}). This updates the pinned x86_64 and ARM64 portable archives and adds the AppStream release entry.
+
+        FlatPark's current pin updater downloaded both release assets and calculated their SHA-256 hashes and sizes before the organization fork was updated.
+        EOF
+
+        pr_url="$(gh pr create \
+          --repo flatpark/flatpark \
+          --base main \
+          --head "OpenTubeX:${BRANCH}" \
+          --title "chore(opentubex): update to ${VERSION}" \
+          --body-file "$body")"
+
+        {
+          echo '## FlatPark submission'
+          echo
+          echo "Created ready-for-review pull request: ${pr_url}"
+        } >> "$GITHUB_STEP_SUMMARY"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -407,6 +407,42 @@ jobs:
           --ref "$GITHUB_REF_NAME" \
           -f "releaseTag=$TAG"
 
+  trigger-flatpark:
+    name: Trigger FlatPark update
+    needs: publish-release
+    if: inputs.publishRelease
+    runs-on: ubuntu-latest
+
+    permissions:
+      actions: write
+      contents: read
+
+    steps:
+    - name: Resolve release tag
+      id: release
+      env:
+        GH_TOKEN: ${{ github.token }}
+        RELEASE_ID: ${{ inputs.releaseId }}
+      shell: bash
+      run: |
+        set -euo pipefail
+
+        tag="$(gh api "repos/${GITHUB_REPOSITORY}/releases/${RELEASE_ID}" --jq .tag_name)"
+        echo "tag=$tag" >> "$GITHUB_OUTPUT"
+
+    - name: Trigger FlatPark workflow
+      env:
+        GH_TOKEN: ${{ github.token }}
+        TAG: ${{ steps.release.outputs.tag }}
+      shell: bash
+      run: |
+        set -euo pipefail
+
+        gh workflow run flatpark.yml \
+          --repo "$GITHUB_REPOSITORY" \
+          --ref "$GITHUB_REF_NAME" \
+          -f "releaseTag=$TAG"
+
   trigger-aur-update:
     name: Trigger AUR repository update
     needs: publish-release

--- a/.github/workflows/winget.yml
+++ b/.github/workflows/winget.yml
@@ -178,8 +178,7 @@ jobs:
     - name: Validate package submission credentials
       if: steps.duplicate.outputs.needed == 'true'
       env:
-        # Keep the old secret as a fallback because GitHub cannot rename or copy secrets.
-        PACKAGE_SUBMISSION_TOKEN: ${{ secrets.PACKAGE_SUBMISSION_TOKEN || secrets.WINGET_TOKEN }}
+        PACKAGE_SUBMISSION_TOKEN: ${{ secrets.PACKAGE_SUBMISSION_TOKEN }}
       shell: bash
       run: |
         set -euo pipefail
@@ -194,7 +193,7 @@ jobs:
     - name: Create or synchronize the organization fork
       if: steps.duplicate.outputs.needed == 'true'
       env:
-        GH_TOKEN: ${{ secrets.PACKAGE_SUBMISSION_TOKEN || secrets.WINGET_TOKEN }}
+        GH_TOKEN: ${{ secrets.PACKAGE_SUBMISSION_TOKEN }}
       shell: bash
       run: |
         set -euo pipefail
@@ -240,7 +239,7 @@ jobs:
       if: steps.duplicate.outputs.needed == 'true'
       env:
         BRANCH: OpenTubeX.OpenTubeX-${{ steps.release.outputs.version }}
-        GH_TOKEN: ${{ secrets.PACKAGE_SUBMISSION_TOKEN || secrets.WINGET_TOKEN }}
+        GH_TOKEN: ${{ secrets.PACKAGE_SUBMISSION_TOKEN }}
         MANIFEST_DIR: ${{ steps.manifest.outputs.directory }}
         VERSION: ${{ steps.release.outputs.version }}
       shell: bash
@@ -319,7 +318,7 @@ jobs:
       if: steps.duplicate.outputs.needed == 'true'
       env:
         BRANCH: OpenTubeX.OpenTubeX-${{ steps.release.outputs.version }}
-        GH_TOKEN: ${{ secrets.PACKAGE_SUBMISSION_TOKEN || secrets.WINGET_TOKEN }}
+        GH_TOKEN: ${{ secrets.PACKAGE_SUBMISSION_TOKEN }}
         VERSION: ${{ steps.release.outputs.version }}
       shell: bash
       run: |

--- a/.github/workflows/winget.yml
+++ b/.github/workflows/winget.yml
@@ -175,25 +175,26 @@ jobs:
 
         echo "directory=$manifest_dir" >> "$GITHUB_OUTPUT"
 
-    - name: Validate winget credentials
+    - name: Validate package submission credentials
       if: steps.duplicate.outputs.needed == 'true'
       env:
-        WINGET_TOKEN: ${{ secrets.WINGET_TOKEN }}
+        # Keep the old secret as a fallback because GitHub cannot rename or copy secrets.
+        PACKAGE_SUBMISSION_TOKEN: ${{ secrets.PACKAGE_SUBMISSION_TOKEN || secrets.WINGET_TOKEN }}
       shell: bash
       run: |
         set -euo pipefail
 
-        if [[ -z "$WINGET_TOKEN" ]]; then
-          echo '::error::The WINGET_TOKEN repository secret is missing.'
+        if [[ -z "$PACKAGE_SUBMISSION_TOKEN" ]]; then
+          echo '::error::The PACKAGE_SUBMISSION_TOKEN repository secret is missing.'
           exit 1
         fi
 
-        echo "::add-mask::${WINGET_TOKEN}"
+        echo "::add-mask::${PACKAGE_SUBMISSION_TOKEN}"
 
     - name: Create or synchronize the organization fork
       if: steps.duplicate.outputs.needed == 'true'
       env:
-        GH_TOKEN: ${{ secrets.WINGET_TOKEN }}
+        GH_TOKEN: ${{ secrets.PACKAGE_SUBMISSION_TOKEN || secrets.WINGET_TOKEN }}
       shell: bash
       run: |
         set -euo pipefail
@@ -239,7 +240,7 @@ jobs:
       if: steps.duplicate.outputs.needed == 'true'
       env:
         BRANCH: OpenTubeX.OpenTubeX-${{ steps.release.outputs.version }}
-        GH_TOKEN: ${{ secrets.WINGET_TOKEN }}
+        GH_TOKEN: ${{ secrets.PACKAGE_SUBMISSION_TOKEN || secrets.WINGET_TOKEN }}
         MANIFEST_DIR: ${{ steps.manifest.outputs.directory }}
         VERSION: ${{ steps.release.outputs.version }}
       shell: bash
@@ -318,7 +319,7 @@ jobs:
       if: steps.duplicate.outputs.needed == 'true'
       env:
         BRANCH: OpenTubeX.OpenTubeX-${{ steps.release.outputs.version }}
-        GH_TOKEN: ${{ secrets.WINGET_TOKEN }}
+        GH_TOKEN: ${{ secrets.PACKAGE_SUBMISSION_TOKEN || secrets.WINGET_TOKEN }}
         VERSION: ${{ steps.release.outputs.version }}
       shell: bash
       run: |


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Make sure to follow the contributing guidelines. -->
<!-- Important note, we may remove your pull request if you do not use this provided PR template correctly. -->
<!-- Agent instructions: Preserve every heading, comment, and marker in this template. Never remove or rewrite the release-note-category:start/end, release-note:start/end, or release-note-image:start/end marker pairs. -->

## Pull Request Type
<!-- Please select what type of pull request this is: [x] -->
- [ ] Bugfix
- [x] Feature Implementation
- [ ] Documentation
- [ ] Other

## Related issue
<!-- Please link the issue your pull request is referring to. -->
<!-- If this pull request fully resolves the relevant issue, put "closes" before the issue number. -->
<!-- Example: "closes #123456". -->

None.

## Description
<!-- Please write a clear and concise description of what the pull request does. -->

FlatPark updates currently rely on FlatPark's daily polling job. Direct submissions also used Nico's personal fork when manual work was needed.

Add a release workflow that validates the published beta and both portable Linux assets, runs FlatPark's current pin updater in a read-only preparation job, and passes only the generated manifest and AppStream metadata to the submission job. The submission job synchronizes the new `OpenTubeX/flatpark-registry` fork, creates a GitHub-signed commit, and opens a ready-for-review PR against `flatpark/flatpark`. Accepted versions and matching open PRs are skipped so this does not race FlatPark's own updater.

The release workflow now dispatches the FlatPark submission alongside winget. Both submission workflows use the shared `PACKAGE_SUBMISSION_TOKEN` secret.

## Release note category
<!-- Select exactly one category. Every pull request must select one. -->
<!-- Select "Not noteworthy" when the pull request fixes a bug in or improves functionality that has not yet appeared in a stable release. -->
<!-- release-note-category:start -->
- [x] Not noteworthy
- [ ] Highlights
- [ ] More improvements
- [ ] Fixed bugs
<!-- release-note-category:end -->

## Release note
<!-- Required unless "Not noteworthy" is selected. -->
<!-- Write one concise, user-facing entry without a leading bullet. -->
<!-- release-note:start -->

<!-- release-note:end -->

## Release note images
<!-- Optional. Paste one or more Markdown images, HTML image tags, or dark/light <picture> elements here. -->
<!-- The release notes normalize the markup and limit images taller than 300 pixels. -->
<!-- Agent instructions:
For a noteworthy visible change, add media when it makes the change easier to understand. Prefer a still image unless motion is the point; recordings must use animated WebP.
After implementing a visible change, proactively capture the result and show the local media to the user for approval before uploading it or updating the pull request.
When the affected UI differs between dark and light themes, capturing both themes is required. A dark-only image is incomplete. Run `node _scripts/releaseNoteMedia.mjs --dark DARK_FILE --light LIGHT_FILE --alt "DESCRIPTION"`; GitHub will display the matching theme and use dark as the fallback. Use a single default-dark capture only when the light theme cannot be captured or looks identical.
Capture or crop to the smallest region that still makes the change clear. Do not include the full window when the affected component can be understood on its own.
Use English unless localization is the subject. Keep components at their normal dimensions and placement instead of resizing them to fill the frame.
Use deterministic local fixtures for visible remote images. Reusable avatar and thumbnail fixtures are available through `e2e/helpers/visual-fixtures.mjs`. Before capturing, verify that every visible image has loaded successfully (`complete === true` and `naturalWidth > 0`).
Inspect the final dark and light files for failed images, missing content, unrelated UI, awkward animation, and misleading layout. Omit media when it does not explain the change clearly.
For one dark capture, run `node _scripts/releaseNoteMedia.mjs FILE --alt "DESCRIPTION"`.
Check for personal information, tokens, private repository names, and unrelated desktop content before uploading. Uploaded media is public.
Keep capture-only scripts, test hooks, screenshots, and recordings out of commits. Remove them before committing unless the capture code is also a reusable regression test. Never commit generated release-note media.
Paste only the generated markup between the marker comments. Leave this section empty when media would not help.
-->
<!-- release-note-image:start -->

<!-- release-note-image:end -->

## Testing
<!-- How can reviewers verify that the PR produces correct results? -->
<!-- Please provide instructions so that others can ensure that your pull request would produce correct results. For examples see, https://github.com/FreeTubeApp/FreeTube/pull/5743, https://github.com/FreeTubeApp/FreeTube/pull/7349, https://github.com/FreeTubeApp/FreeTube/pull/5125, https://github.com/FreeTubeApp/FreeTube/pull/7338 -->
<!-- Agent instructions: Only write human-facing steps that explain how to verify the change while running this branch in dev mode. Include expected results and, when applicable, helpful console snippets for interactive verification. Do not include automated checks, commands, results, pass counts, or CI status. -->

Not applicable. This changes release-only GitHub Actions automation.

## Additional context
<!-- Add any other context about the pull request here. -->

The organization fork is available at https://github.com/OpenTubeX/flatpark-registry. It cannot use the shorter `OpenTubeX/flatpak` name because that repository already contains OpenTubeX's own Flatpak packaging source.


