### PR TITLE
fix: avoid false age restriction badges after metadata errors

### DIFF
--- a/e2e/tests/offline/watch-page.spec.mjs
+++ b/e2e/tests/offline/watch-page.spec.mjs
@@ -55,6 +55,23 @@ async function expectPlayerMenuScrollState(menu, atEnd = true) {
 
 test.use({ seed: { settings: WATCH_PAGE_SEED } })
 
+test('does not show an age-restricted badge when metadata loading fails', async ({ app, page }) => {
+  await mockPlayableWatchPage(app, page)
+  await app.electronApp.evaluate(({ ipcMain }) => {
+    ipcMain.removeHandler('generate-po-token')
+    ipcMain.handle('generate-po-token', () => {
+      throw new Error('VM operation timed out')
+    })
+  })
+
+  await page.locator(sel.searchInput).fill('https://www.youtube.com/watch?v=4FEzLc7iBY0')
+  await page.locator(sel.searchInput).press('Enter')
+
+  await expect(page).toHaveURL(/#\/watch\/4FEzLc7iBY0/)
+  await expect(page.locator('.errorMessage')).toContainText('VM operation timed out')
+  await expect(page.locator('.infoArea .ageRestrictedBadge')).toHaveCount(0)
+})
+
 test('offers a YouTube link action in the watch tab context menu', async ({ app, page }) => {
   await mockPlayableWatchPage(app, page)
   await openMockedVideo(page)

--- a/e2e/tests/offline/watch-page.spec.mjs
+++ b/e2e/tests/offline/watch-page.spec.mjs
@@ -55,13 +55,17 @@ async function expectPlayerMenuScrollState(menu, atEnd = true) {
 
 test.use({ seed: { settings: WATCH_PAGE_SEED } })
 
-test('does not show an age-restricted badge when metadata loading fails', async ({ app, page }) => {
+test('keeps metadata errors visible in family-friendly-only mode', async ({ app, page }) => {
   await mockPlayableWatchPage(app, page)
   await app.electronApp.evaluate(({ ipcMain }) => {
     ipcMain.removeHandler('generate-po-token')
     ipcMain.handle('generate-po-token', () => {
       throw new Error('VM operation timed out')
     })
+  })
+  await page.evaluate(async () => {
+    const store = document.querySelector('#app').__vue_app__.config.globalProperties.$store
+    await store.dispatch('updateShowFamilyFriendlyOnly', true)
   })
 
   await page.locator(sel.searchInput).fill('https://www.youtube.com/watch?v=4FEzLc7iBY0')

--- a/src/renderer/views/Watch/Watch.js
+++ b/src/renderer/views/Watch/Watch.js
@@ -207,7 +207,8 @@ export default defineComponent({
       applyDefaultTheatreModeAfterLoad: false,
       theatreLayoutAvailable: window.innerWidth > RESPONSIVE_THEATRE_MODE_MAX_WIDTH,
       videoPlayerLoaded: false,
-      isFamilyFriendly: false,
+      /** @type {boolean|null} */
+      isFamilyFriendly: null,
       commentsDisabled: false,
       isLive: false,
       isPremiere: false,
@@ -1839,7 +1840,7 @@ export default defineComponent({
       this.playlistScrollPositions.sidebar = null
       this.playlistScrollPositions.fullscreen = null
       this.isLoading = true
-      this.isFamilyFriendly = false
+      this.isFamilyFriendly = null
       this.commentsDisabled = false
       this.isLive = false
       this.isPremiere = false
@@ -2693,7 +2694,7 @@ export default defineComponent({
           })
         }
 
-        if (this.showFamilyFriendlyOnly && !this.isFamilyFriendly) {
+        if (this.showFamilyFriendlyOnly && this.isFamilyFriendly === false) {
           this.isLoading = false
           this.handleVideoEnded()
           return

--- a/src/renderer/views/Watch/Watch.vue
+++ b/src/renderer/views/Watch/Watch.vue
@@ -13,7 +13,7 @@
     }"
   >
     <div
-      v-if="(isFamilyFriendly || !showFamilyFriendlyOnly)"
+      v-if="(isFamilyFriendly !== false || !showFamilyFriendlyOnly)"
       class="videoArea"
       :style="customShortsPlayerActive
         ? {
@@ -721,7 +721,7 @@
       class="ageRestricted"
     />
     <div
-      v-if="(isFamilyFriendly || !showFamilyFriendlyOnly)"
+      v-if="(isFamilyFriendly !== false || !showFamilyFriendlyOnly)"
       class="infoArea"
     >
       <div
@@ -824,7 +824,7 @@
       </Teleport>
     </div>
     <div
-      v-if="(isFamilyFriendly || !showFamilyFriendlyOnly)"
+      v-if="(isFamilyFriendly !== false || !showFamilyFriendlyOnly)"
       class="sidebarArea"
     >
       <div
@@ -1029,7 +1029,7 @@
       />
     </div>
     <div
-      v-if="(isFamilyFriendly || !showFamilyFriendlyOnly)"
+      v-if="(isFamilyFriendly !== false || !showFamilyFriendlyOnly)"
       class="commentsArea"
     >
       <Teleport

--- a/src/renderer/views/Watch/Watch.vue
+++ b/src/renderer/views/Watch/Watch.vue
@@ -627,7 +627,7 @@
             :metadata-history="videoMetadataHistory"
             :in-user-playlist="!!selectedUserPlaylist"
             :is-unlisted="isUnlisted"
-            :is-age-restricted="!isFamilyFriendly"
+            :is-age-restricted="isFamilyFriendly === false"
             :has-ai-generated-content="hasAiGeneratedContent"
             :sponsor-block-full-video-category="sponsorBlockFullVideoCategory"
             :active-format="activeFormat"
@@ -717,7 +717,7 @@
       </div>
     </div>
     <ft-age-restricted
-      v-if="(!isLoading && !isFamilyFriendly && showFamilyFriendlyOnly)"
+      v-if="(!isLoading && isFamilyFriendly === false && showFamilyFriendlyOnly)"
       class="ageRestricted"
     />
     <div
@@ -765,7 +765,7 @@
           :metadata-history="videoMetadataHistory"
           :in-user-playlist="!!selectedUserPlaylist"
           :is-unlisted="isUnlisted"
-          :is-age-restricted="!isFamilyFriendly"
+          :is-age-restricted="isFamilyFriendly === false"
           :has-ai-generated-content="hasAiGeneratedContent"
           :sponsor-block-full-video-category="sponsorBlockFullVideoCategory"
           :active-format="activeFormat"


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Make sure to follow the contributing guidelines. -->
<!-- Important note, we may remove your pull request if you do not use this provided PR template correctly. -->
<!-- Agent instructions: Preserve every heading, comment, and marker in this template. Never remove or rewrite the release-note-category:start/end, release-note:start/end, or release-note-image:start/end marker pairs. -->

## Pull Request Type
<!-- Please select what type of pull request this is: [x] -->
- [x] Bugfix
- [ ] Feature Implementation
- [ ] Documentation
- [ ] Other

## Related issue
<!-- Please link the issue your pull request is referring to. -->
<!-- If this pull request fully resolves the relevant issue, put "closes" before the issue number. -->
<!-- Example: "closes #123456". -->

None.

## Description
<!-- Please write a clear and concise description of what the pull request does. -->

When metadata loading failed before YouTube's family-safe value arrived, the watch page treated its default state as a confirmed age restriction and showed the wrong badge.

This changes the state to distinguish unknown metadata from a confirmed restriction. The badge and family-friendly filter now treat only an explicit `false` value as age restricted. An offline regression test covers the PO-token timeout reported with `4FEzLc7iBY0`.

## Release note category
<!-- Select exactly one category. Every pull request must select one. -->
<!-- Select "Not noteworthy" when the pull request fixes a bug in or improves functionality that has not yet appeared in a stable release. -->
<!-- release-note-category:start -->
- [x] Not noteworthy
- [ ] Highlights
- [ ] More improvements
- [ ] Fixed bugs
<!-- release-note-category:end -->

## Release note
<!-- Required unless "Not noteworthy" is selected. -->
<!-- Write one concise, user-facing entry without a leading bullet. -->
<!-- release-note:start -->
Metadata loading errors no longer label videos as age restricted.
<!-- release-note:end -->

## Release note images
<!-- Optional. Paste one or more Markdown images, HTML image tags, or dark/light <picture> elements here. -->
<!-- The release notes normalize the markup and limit images taller than 300 pixels. -->
<!-- Agent instructions:
For a noteworthy visible change, add media when it makes the change easier to understand. Prefer a still image unless motion is the point; recordings must use animated WebP.
After implementing a visible change, proactively capture the result and show the local media to the user for approval before uploading it or updating the pull request.
When the affected UI differs between dark and light themes, capturing both themes is required. A dark-only image is incomplete. Run `node _scripts/releaseNoteMedia.mjs --dark DARK_FILE --light LIGHT_FILE --alt "DESCRIPTION"`; GitHub will display the matching theme and use dark as the fallback. Use a single default-dark capture only when the light theme cannot be captured or looks identical.
Capture or crop to the smallest region that still makes the change clear. Do not include the full window when the affected component can be understood on its own.
Use English unless localization is the subject. Keep components at their normal dimensions and placement instead of resizing them to fill the frame.
Use deterministic local fixtures for visible remote images. Reusable avatar and thumbnail fixtures are available through `e2e/helpers/visual-fixtures.mjs`. Before capturing, verify that every visible image has loaded successfully (`complete === true` and `naturalWidth > 0`).
Inspect the final dark and light files for failed images, missing content, unrelated UI, awkward animation, and misleading layout. Omit media when it does not explain the change clearly.
For one dark capture, run `node _scripts/releaseNoteMedia.mjs FILE --alt "DESCRIPTION"`.
Check for personal information, tokens, private repository names, and unrelated desktop content before uploading. Uploaded media is public.
Keep capture-only scripts, test hooks, screenshots, and recordings out of commits. Remove them before committing unless the capture code is also a reusable regression test. Never commit generated release-note media.
Paste only the generated markup between the marker comments. Leave this section empty when media would not help.
-->
<!-- release-note-image:start -->

<!-- release-note-image:end -->

## Testing
<!-- How can reviewers verify that the PR produces correct results? -->
<!-- Please provide instructions so that others can ensure that your pull request would produce correct results. For examples see, https://github.com/FreeTubeApp/FreeTube/pull/5743, https://github.com/FreeTubeApp/FreeTube/pull/7349, https://github.com/FreeTubeApp/FreeTube/pull/5125, https://github.com/FreeTubeApp/FreeTube/pull/7338 -->
<!-- Agent instructions: Only write human-facing steps that explain how to verify the change while running this branch in dev mode. Include expected results and, when applicable, helpful console snippets for interactive verification. Do not include automated checks, commands, results, pass counts, or CI status. -->

1. In a dev window, make the `generate-po-token` IPC handler reject with `new Error('VM operation timed out')`.
2. Open `https://youtu.be/4FEzLc7iBY0` and confirm the timeout error appears without an Age restricted badge.
3. Restore the handler, load a response where `isFamilySafe` is `false`, and confirm the Age restricted badge still appears.

## Additional context
<!-- Add any other context about the pull request here. -->

The original report came from a transient PO-token timeout. The timeout remains visible and retryable; this change prevents missing metadata from being presented as an age restriction.
