### PR TITLE
fix(comments): translate Asian-language comments reliably

### DIFF
--- a/patches/youtubei.js@18.0.0.patch
+++ b/patches/youtubei.js@18.0.0.patch
@@ -306,3 +306,15 @@ index 90faaabfaf9e2f80d08d410bb272f708ceea94b7..b0cf4a9ba22fa9e1e482d9084738319e
      }
      /**
       * Ensures actions are emitted at the right speed.
+diff --git a/dist/src/utils/ProtoUtils.js b/dist/src/utils/ProtoUtils.js
+--- a/dist/src/utils/ProtoUtils.js
++++ b/dist/src/utils/ProtoUtils.js
+@@ -31,7 +31,7 @@ export function encodeCommentActionParams(type, args = {}) {
+         };
+     }
+     const writer = PeformCommentActionParams.encode(data);
+-    return encodeURIComponent(u8ToBase64(writer.finish()));
++    return u8ToBase64(writer.finish(), true);
+ }
+ export function encodeNextParams(video_ids, playlist_title) {
+     const writer = NextParams.encode({ videoId: video_ids, playlistTitle: playlist_title });

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -11,7 +11,7 @@ overrides:
 patchedDependencies:
   shaka-player@5.1.12: 17d85e267c8958999207ce9d6c29a2ddf18734d0499fb30870ac8a55d90303fa
   vue-sonner@2.0.9: ae94d00b3ff46bede626a25ac5a36a6cd35987f33d73c14ffc73afbd5767f95c
-  youtubei.js@18.0.0: 40ae5aea42ff258367c92ebab6db7dd0a61ba88e7fbf6efe4a8bbe9c2111d45e
+  youtubei.js@18.0.0: 0dcd01c7f812975961b3f68ef0f3bfac4bb13b2241b07bcbcc24b50f95475218
 
 importers:
 
@@ -88,7 +88,7 @@ importers:
         version: 4.1.0(vue@3.5.41(typescript@6.0.3))
       youtubei.js:
         specifier: ^18.0.0
-        version: 18.0.0(patch_hash=40ae5aea42ff258367c92ebab6db7dd0a61ba88e7fbf6efe4a8bbe9c2111d45e)
+        version: 18.0.0(patch_hash=0dcd01c7f812975961b3f68ef0f3bfac4bb13b2241b07bcbcc24b50f95475218)
     devDependencies:
       '@babel/core':
         specifier: ^8.0.1
@@ -10753,7 +10753,7 @@ snapshots:
 
   yocto-queue@0.1.0: {}
 
-  youtubei.js@18.0.0(patch_hash=40ae5aea42ff258367c92ebab6db7dd0a61ba88e7fbf6efe4a8bbe9c2111d45e):
+  youtubei.js@18.0.0(patch_hash=0dcd01c7f812975961b3f68ef0f3bfac4bb13b2241b07bcbcc24b50f95475218):
     dependencies:
       '@bufbuild/protobuf': 2.12.1
       fflate: 0.8.3

--- a/tests/unit/youtubei-comment-actions.test.mjs
+++ b/tests/unit/youtubei-comment-actions.test.mjs
@@ -1,0 +1,20 @@
+import assert from 'node:assert/strict'
+import test from 'node:test'
+
+import { ProtoUtils } from 'youtubei.js'
+
+test('encodes comment translation actions as URL-safe base64', () => {
+  const japaneseAction = ProtoUtils.encodeCommentActionParams(22, {
+    text: 'これは日本語です',
+    target_language: 'en'
+  })
+  const koreanAction = ProtoUtils.encodeCommentActionParams(22, {
+    text: '이것은 한국어 댓글',
+    target_language: 'en'
+  })
+
+  assert.doesNotMatch(japaneseAction, /%2F/i)
+  assert.doesNotMatch(koreanAction, /%2B/i)
+  assert.match(japaneseAction, /_/)
+  assert.match(koreanAction, /-/)
+})


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Make sure to follow the contributing guidelines. -->
<!-- Important note, we may remove your pull request if you do not use this provided PR template correctly. -->
<!-- Agent instructions: Preserve every heading, comment, and marker in this template. Never remove or rewrite the release-note-category:start/end, release-note:start/end, or release-note-image:start/end marker pairs. -->

## Pull Request Type
<!-- Please select what type of pull request this is: [x] -->
- [x] Bugfix
- [ ] Feature Implementation
- [ ] Documentation
- [ ] Other

## Related issue
<!-- Please link the issue your pull request is referring to. -->
<!-- If this pull request fully resolves the relevant issue, put "closes" before the issue number. -->
<!-- Example: "closes #123456". -->

closes #986

## Description
<!-- Please write a clear and concise description of what the pull request does. -->

Some Korean and Japanese comments failed to translate with HTTP 400 when their encoded action contained standard Base64 `+` or `/` characters. The earlier emoji sanitization did not address that encoding-dependent failure.

This patches youtubei.js to emit URL-safe Base64 for comment translation actions, matching the format accepted by YouTube. It also adds regression coverage for Japanese and Korean payloads that exercise both substituted characters.

## Release note category
<!-- Select exactly one category. Every pull request must select one. -->
<!-- Select "Not noteworthy" when the pull request fixes a bug in or improves functionality that has not yet appeared in a stable release. -->
<!-- release-note-category:start -->
- [x] Not noteworthy
- [ ] Highlights
- [ ] More improvements
- [ ] Fixed bugs
<!-- release-note-category:end -->

## Release note
<!-- Required unless "Not noteworthy" is selected. -->
<!-- Write one concise, user-facing entry without a leading bullet. -->
<!-- release-note:start -->

<!-- release-note:end -->

## Release note images
<!-- Optional. Paste one or more Markdown images, HTML image tags, or dark/light <picture> elements here. -->
<!-- The release notes normalize the markup and limit images taller than 300 pixels. -->
<!-- Agent instructions:
For a noteworthy visible change, add media when it makes the change easier to understand. Prefer a still image unless motion is the point; recordings must use animated WebP.
After implementing a visible change, proactively capture the result and show the local media to the user for approval before uploading it or updating the pull request.
When the affected UI differs between dark and light themes, capturing both themes is required. A dark-only image is incomplete. Run `node _scripts/releaseNoteMedia.mjs --dark DARK_FILE --light LIGHT_FILE --alt "DESCRIPTION"`; GitHub will display the matching theme and use dark as the fallback. Use a single default-dark capture only when the light theme cannot be captured or looks identical.
Capture or crop to the smallest region that still makes the change clear. Do not include the full window when the affected component can be understood on its own.
Use English unless localization is the subject. Keep components at their normal dimensions and placement instead of resizing them to fill the frame.
Use deterministic local fixtures for visible remote images. Reusable avatar and thumbnail fixtures are available through `e2e/helpers/visual-fixtures.mjs`. Before capturing, verify that every visible image has loaded successfully (`complete === true` and `naturalWidth > 0`).
Inspect the final dark and light files for failed images, missing content, unrelated UI, awkward animation, and misleading layout. Omit media when it does not explain the change clearly.
For one dark capture, run `node _scripts/releaseNoteMedia.mjs FILE --alt "DESCRIPTION"`.
Check for personal information, tokens, private repository names, and unrelated desktop content before uploading. Uploaded media is public.
Keep capture-only scripts, test hooks, screenshots, and recordings out of commits. Remove them before committing unless the capture code is also a reusable regression test. Never commit generated release-note media.
Paste only the generated markup between the marker comments. Leave this section empty when media would not help.
-->
<!-- release-note-image:start -->

<!-- release-note-image:end -->

## Testing
<!-- How can reviewers verify that the PR produces correct results? -->
<!-- Please provide instructions so that others can ensure that your pull request would produce correct results. For examples see, https://github.com/FreeTubeApp/FreeTube/pull/5743, https://github.com/FreeTubeApp/FreeTube/pull/7349, https://github.com/FreeTubeApp/FreeTube/pull/5125, https://github.com/FreeTubeApp/FreeTube/pull/7338 -->
<!-- Agent instructions: Only write human-facing steps that explain how to verify the change while running this branch in dev mode. Include expected results and, when applicable, helpful console snippets for interactive verification. Do not include automated checks, commands, results, pass counts, or CI status. -->

1. Use the Local API and open a video with Japanese or Korean comments.
2. Translate a longer comment, including one containing emoji if available.
3. Confirm that the translated text appears and no HTTP 400 translation error is shown.

## Additional context
<!-- Add any other context about the pull request here. -->

YouTube accepts the same protobuf bytes when they use the URL-safe Base64 alphabet and rejects the percent-escaped standard Base64 form whenever it contains `+` or `/`.
