### PR TITLE
fix(navigation): show focus rings only during navigation

### DIFF
--- a/e2e/tests/offline/appearance.spec.mjs
+++ b/e2e/tests/offline/appearance.spec.mjs
@@ -377,6 +377,32 @@ test.describe('custom theme editor', () => {
     await expect(trigger).toBeFocused()
   })
 
+  test('shows keyboard focus feedback inside the teleported color picker', async ({ page }) => {
+    await goToSettingsSection(page, 'theme')
+    await page.getByRole('button', { name: 'Create custom theme' }).click()
+
+    const trigger = page.getByRole('button', { name: 'Page background', exact: true })
+    await trigger.focus()
+    await page.keyboard.press('Tab')
+    await page.keyboard.press('Shift+Tab')
+    await expect(trigger).toBeFocused()
+    await page.keyboard.press('Enter')
+
+    const picker = page.getByRole('dialog', { name: 'Page background' })
+    const hexInput = picker.getByRole('textbox', { name: 'Hex color' })
+    await hexInput.focus()
+
+    await expect(page.locator('.app')).not.toHaveClass(/hideOutlines/)
+    await expect(page.locator('.app').getByRole('dialog', { name: 'Page background' })).toHaveCount(0)
+    await expect(hexInput).toHaveCSS('outline-style', 'solid')
+    await expect(hexInput).not.toHaveCSS('box-shadow', 'none')
+
+    await hexInput.click()
+    await expect(page.locator('.app')).toHaveClass(/hideOutlines/)
+    await expect(hexInput).toHaveCSS('outline-style', 'none')
+    await expect(hexInput).toHaveCSS('box-shadow', 'none')
+  })
+
   test('keeps the hue when dragging outside the saturation and brightness area', async ({ page }) => {
     await goToSettingsSection(page, 'theme')
     await page.getByRole('button', { name: 'Create custom theme' }).click()

--- a/e2e/tests/offline/findbar-keyboard.spec.mjs
+++ b/e2e/tests/offline/findbar-keyboard.spec.mjs
@@ -10,6 +10,12 @@ test('Enter and Shift+Enter navigate one find bar match at a time', async ({ pag
   await page.keyboard.press('Control+f')
   const findbarInput = page.locator('.findbarInput')
   const findbarStatus = page.locator('.findbarStatus')
+  await expect(findbarInput).toBeFocused()
+  await expect(page.locator('.app')).not.toHaveClass(/hideOutlines/)
+  await expect(findbarInput).not.toHaveCSS('box-shadow', 'none')
+  await findbarInput.click()
+  await expect(page.locator('.app')).toHaveClass(/hideOutlines/)
+  await expect(findbarInput).toHaveCSS('box-shadow', 'none')
   await findbarInput.fill('findbar regression marker')
   await expect(findbarStatus).toHaveText('1/2')
 

--- a/e2e/tests/offline/gamepad-navigation.spec.mjs
+++ b/e2e/tests/offline/gamepad-navigation.spec.mjs
@@ -20,6 +20,22 @@ const GAMEPAD_BUTTON_INDEX = Object.freeze({
 
 test.use({ seed: { settings: PLAYER_SEED } })
 
+test('only shows focus feedback during keyboard or gamepad navigation', async ({ page }) => {
+  const searchInput = page.locator('.topNav .searchInput input.ft-input')
+
+  await searchInput.click()
+  await expect(page.locator('.app')).toHaveClass(/hideOutlines/)
+  await expect(searchInput).toHaveCSS('outline-style', 'none')
+  await expect(searchInput).toHaveCSS('box-shadow', 'none')
+
+  await page.keyboard.press('Shift+Tab')
+  await page.keyboard.press('Tab')
+  await expect(searchInput).toBeFocused()
+  await expect(page.locator('.app')).not.toHaveClass(/hideOutlines/)
+  await expect(searchInput).toHaveCSS('outline-style', 'solid')
+  await expect(searchInput).not.toHaveCSS('box-shadow', 'none')
+})
+
 async function connectMockGamepad(page) {
   await page.evaluate(() => {
     const buttons = Array.from({ length: 17 }, () => ({ pressed: false, value: 0 }))

--- a/src/renderer/App.css
+++ b/src/renderer/App.css
@@ -198,7 +198,7 @@
   outline: none;
 }
 
-.findbarInput:focus {
+:global(:root:not(.hideOutlines)) .findbarInput:focus {
   border-color: var(--primary-text-color);
   box-shadow: 0 0 0 2px color-mix(in srgb, var(--primary-text-color) 18%, transparent);
 }

--- a/src/renderer/App.vue
+++ b/src/renderer/App.vue
@@ -1127,6 +1127,7 @@ onMounted(async () => {
 })
 
 onBeforeUnmount(() => {
+  document.documentElement.classList.remove('hideOutlines')
   removeGamepadNavigation()
   removeCustomThemeListener()
   cancelUtilityRoutePreload()
@@ -2146,6 +2147,10 @@ function openDownloadsPage() {
 /** @type {import('vue').ComputedRef<boolean>} */
 const outlinesHidden = computed(() => store.getters.getOutlinesHidden)
 
+watch(outlinesHidden, hidden => {
+  document.documentElement.classList.toggle('hideOutlines', hidden)
+}, { flush: 'sync', immediate: true })
+
 const commandPaletteCommands = computed(() => createCommandPaletteRegistry({
   t,
   tm,
@@ -2313,6 +2318,7 @@ function handleKeyboardShortcuts(event) {
 
   if (matchesKeyboardShortcut(event, shortcuts.FIND_IN_PAGE)) {
     event.preventDefault()
+    store.dispatch('showOutlines')
     openFindbar()
     return
   }

--- a/src/renderer/themes.css
+++ b/src/renderer/themes.css
@@ -66,7 +66,7 @@ body {
   background-color: var(--selection-background-color);
 }
 
-:focus-visible {
+:where(:root:not(.hideOutlines)) :focus:not(:disabled) {
   outline: 2px solid var(--primary-color);
   outline-offset: -3px;
   border-radius: calc(4px * var(--ui-roundness));


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Make sure to follow the contributing guidelines. -->
<!-- Important note, we may remove your pull request if you do not use this provided PR template correctly. -->
<!-- Agent instructions: Preserve every heading, comment, and marker in this template. Never remove or rewrite the release-note-category:start/end, release-note:start/end, or release-note-image:start/end marker pairs. -->

## Pull Request Type
<!-- Please select what type of pull request this is: [x] -->
- [x] Bugfix
- [ ] Feature Implementation
- [ ] Documentation
- [ ] Other

## Related issue
<!-- Please link the issue your pull request is referring to. -->
<!-- If this pull request fully resolves the relevant issue, put "closes" before the issue number. -->
<!-- Example: "closes #123456". -->

Follow-up to #984.

## Description
<!-- Please write a clear and concise description of what the pull request does. -->

The gamepad navigation merge added a themed focus ring that also appeared when pointer-focusing text inputs, including the top search bar.

This limits the shared focus ring to keyboard and gamepad navigation. The same navigation state now covers body-level teleports, so popovers retain focus feedback during navigation without showing it for pointer focus. Regression tests cover the top search input and a teleported color picker.

## Release note category
<!-- Select exactly one category. Every pull request must select one. -->
<!-- Select "Not noteworthy" when the pull request fixes a bug in or improves functionality that has not yet appeared in a stable release. -->
<!-- release-note-category:start -->
- [x] Not noteworthy
- [ ] Highlights
- [ ] More improvements
- [ ] Fixed bugs
<!-- release-note-category:end -->

## Release note
<!-- Required unless "Not noteworthy" is selected. -->
<!-- Write one concise, user-facing entry without a leading bullet. -->
<!-- release-note:start -->

<!-- release-note:end -->

## Release note images
<!-- Optional. Paste one or more Markdown images, HTML image tags, or dark/light <picture> elements here. -->
<!-- The release notes normalize the markup and limit images taller than 300 pixels. -->
<!-- Agent instructions:
For a noteworthy visible change, add media when it makes the change easier to understand. Prefer a still image unless motion is the point; recordings must use animated WebP.
After implementing a visible change, proactively capture the result and show the local media to the user for approval before uploading it or updating the pull request.
When the affected UI differs between dark and light themes, capturing both themes is required. A dark-only image is incomplete. Run `node _scripts/releaseNoteMedia.mjs --dark DARK_FILE --light LIGHT_FILE --alt "DESCRIPTION"`; GitHub will display the matching theme and use dark as the fallback. Use a single default-dark capture only when the light theme cannot be captured or looks identical.
Capture or crop to the smallest region that still makes the change clear. Do not include the full window when the affected component can be understood on its own.
Use English unless localization is the subject. Keep components at their normal dimensions and placement instead of resizing them to fill the frame.
Use deterministic local fixtures for visible remote images. Reusable avatar and thumbnail fixtures are available through `e2e/helpers/visual-fixtures.mjs`. Before capturing, verify that every visible image has loaded successfully (`complete === true` and `naturalWidth > 0`).
Inspect the final dark and light files for failed images, missing content, unrelated UI, awkward animation, and misleading layout. Omit media when it does not explain the change clearly.
For one dark capture, run `node _scripts/releaseNoteMedia.mjs FILE --alt "DESCRIPTION"`.
Check for personal information, tokens, private repository names, and unrelated desktop content before uploading. Uploaded media is public.
Keep capture-only scripts, test hooks, screenshots, and recordings out of commits. Remove them before committing unless the capture code is also a reusable regression test. Never commit generated release-note media.
Paste only the generated markup between the marker comments. Leave this section empty when media would not help.
-->
<!-- release-note-image:start -->

<!-- release-note-image:end -->

## Testing
<!-- How can reviewers verify that the PR produces correct results? -->
<!-- Please provide instructions so that others can ensure that your pull request would produce correct results. For examples see, https://github.com/FreeTubeApp/FreeTube/pull/5743, https://github.com/FreeTubeApp/FreeTube/pull/7349, https://github.com/FreeTubeApp/FreeTube/pull/5125, https://github.com/FreeTubeApp/FreeTube/pull/7338 -->
<!-- Agent instructions: Only write human-facing steps that explain how to verify the change while running this branch in dev mode. Include expected results and, when applicable, helpful console snippets for interactive verification. Do not include automated checks, commands, results, pass counts, or CI status. -->

1. Start OpenTubeX in dev mode and click the search input in the middle of the top navigation. It should receive focus without a themed ring.
2. Press Shift+Tab and then Tab to return to the search input. The themed focus ring should appear.
3. Open Settings, create a custom theme, and open the Page background color picker with the keyboard. Move focus to the Hex color input. The themed ring should remain visible even though the picker is rendered outside the main app element.
4. Click the Hex color input. The themed and native focus rings should disappear.
5. Navigate controls with a connected gamepad. Focused controls should retain the themed ring.

## Additional context
<!-- Add any other context about the pull request here. -->

This is a follow-up to the focus feedback introduced in #984.
