### PR TITLE
fix(player): avoid delayed SponsorBlock auto skips

### DIFF
--- a/e2e/tests/offline/watch-page.spec.mjs
+++ b/e2e/tests/offline/watch-page.spec.mjs
@@ -1274,6 +1274,62 @@ async function mockTranslatedEndscreen(app, page) {
   })
 }
 
+async function measureSponsorBlockSkipStartTime(app, page, { cpuThrottlingRate } = {}) {
+  await mockPlayableWatchPage(app, page)
+  await page.route('**/api/skipSegments/**', route => route.fulfill({
+    body: JSON.stringify([{
+      videoID: 'jNQXAC9IVRw',
+      segments: [{
+        UUID: 'timed-skip-segment',
+        actionType: 'skip',
+        category: 'sponsor',
+        description: '',
+        locked: 0,
+        segment: [15, 20],
+        videoDuration: 30,
+        votes: 1
+      }]
+    }]),
+    contentType: 'application/json'
+  }))
+  await page.evaluate(() => {
+    const store = document.querySelector('#app').__vue_app__.config.globalProperties.$store
+    store.commit('setUseSponsorBlock', true)
+  })
+
+  await openMockedVideo(page)
+  await expect(page.locator('.sponsorBlockMarker')).toHaveCount(1)
+
+  if (cpuThrottlingRate !== undefined) {
+    const cdpSession = await page.context().newCDPSession(page)
+    await cdpSession.send('Emulation.setCPUThrottlingRate', { rate: cpuThrottlingRate })
+  }
+
+  const video = page.locator('.ftVideoPlayer video')
+  await video.evaluate(element => {
+    element.pause()
+    element.currentTime = 14.57
+    element.dispatchEvent(new Event('timeupdate'))
+
+    const currentTime = Object.getOwnPropertyDescriptor(HTMLMediaElement.prototype, 'currentTime')
+    Object.defineProperty(element, 'currentTime', {
+      configurable: true,
+      get: currentTime.get,
+      set(value) {
+        if (value === 20) {
+          window.__sponsorBlockSkipStartedAt = currentTime.get.call(this)
+        }
+        currentTime.set.call(this, value)
+      }
+    })
+    element.addEventListener('timeupdate', event => event.stopImmediatePropagation(), { capture: true })
+    return element.play()
+  })
+
+  await expect.poll(() => page.evaluate(() => window.__sponsorBlockSkipStartedAt ?? null)).not.toBeNull()
+  return page.evaluate(() => window.__sponsorBlockSkipStartedAt)
+}
+
 test.describe('watch page', () => {
   test('keeps private and DRM errors ineligible for extraction retry after locale changes', async ({ app, page }) => {
     await mockPlayableWatchPage(app, page)
@@ -3220,56 +3276,15 @@ test.describe('watch page', () => {
   })
 
   test('skips SponsorBlock segments at their boundary without timeupdate events', async ({ app, page }) => {
-    await mockPlayableWatchPage(app, page)
-    await page.route('**/api/skipSegments/**', route => route.fulfill({
-      body: JSON.stringify([{
-        videoID: 'jNQXAC9IVRw',
-        segments: [{
-          UUID: 'precise-skip-segment',
-          actionType: 'skip',
-          category: 'sponsor',
-          description: '',
-          locked: 0,
-          segment: [15, 20],
-          videoDuration: 30,
-          votes: 1
-        }]
-      }]),
-      contentType: 'application/json'
-    }))
-    await page.evaluate(() => {
-      const store = document.querySelector('#app').__vue_app__.config.globalProperties.$store
-      store.commit('setUseSponsorBlock', true)
-    })
-
-    await openMockedVideo(page)
-    await expect(page.locator('.sponsorBlockMarker')).toHaveCount(1)
-
-    const video = page.locator('.ftVideoPlayer video')
-    await video.evaluate(element => {
-      element.pause()
-      element.currentTime = 14.57
-      element.dispatchEvent(new Event('timeupdate'))
-
-      const currentTime = Object.getOwnPropertyDescriptor(HTMLMediaElement.prototype, 'currentTime')
-      Object.defineProperty(element, 'currentTime', {
-        configurable: true,
-        get: currentTime.get,
-        set(value) {
-          if (value === 20) {
-            window.__sponsorBlockSkipStartedAt = currentTime.get.call(this)
-          }
-          currentTime.set.call(this, value)
-        }
-      })
-      element.addEventListener('timeupdate', event => event.stopImmediatePropagation(), { capture: true })
-      return element.play()
-    })
-
-    await expect.poll(() => page.evaluate(() => window.__sponsorBlockSkipStartedAt ?? null)).not.toBeNull()
-    const skipStartedAt = await page.evaluate(() => window.__sponsorBlockSkipStartedAt)
+    const skipStartedAt = await measureSponsorBlockSkipStartTime(app, page)
     expect(skipStartedAt).toBeGreaterThanOrEqual(15)
     expect(skipStartedAt).toBeLessThan(15.05)
+  })
+
+  test('skips SponsorBlock segments promptly under renderer load', async ({ app, page }) => {
+    const skipStartedAt = await measureSponsorBlockSkipStartTime(app, page, { cpuThrottlingRate: 12 })
+    expect(skipStartedAt).toBeGreaterThanOrEqual(15)
+    expect(skipStartedAt).toBeLessThan(15.3)
   })
 
   test('displays and submits full-video SponsorBlock labels', async ({ app, page }) => {

--- a/src/renderer/components/ft-shaka-video-player/ft-shaka-video-player.js
+++ b/src/renderer/components/ft-shaka-video-player/ft-shaka-video-player.js
@@ -121,7 +121,7 @@ import thumbnailPlaceholder from '../../assets/img/thumbnail_placeholder.svg'
 
 const SPONSORBLOCK_HIGHLIGHT_LABEL_PLAYBACK_MS = 5000
 const SPONSORBLOCK_SEGMENT_START_TOLERANCE_SECONDS = 0.1
-const SPONSORBLOCK_SKIP_SCHEDULE_LEAD_MS = 150
+const SPONSORBLOCK_SKIP_SCHEDULE_LEAD_MS = 500
 const SPONSORBLOCK_SKIP_POLL_INTERVAL_MS = 4
 const SPONSORBLOCK_TERMINAL_OUTRO_TOLERANCE_SECONDS = 1
 const AB_REPEAT_MIN_RANGE_SECONDS = 0.05
@@ -1865,12 +1865,15 @@ export default defineComponent({
     let sponsorBlockNotFoundRefetchTimeout = null
     let sponsorBlockSkipScheduleTimeout = null
     let sponsorBlockSkipScheduleInterval = null
+    let sponsorBlockSkipScheduleTaskController = null
 
     function cancelSponsorBlockSkipSchedule() {
       clearTimeout(sponsorBlockSkipScheduleTimeout)
       clearInterval(sponsorBlockSkipScheduleInterval)
+      sponsorBlockSkipScheduleTaskController?.abort()
       sponsorBlockSkipScheduleTimeout = null
       sponsorBlockSkipScheduleInterval = null
+      sponsorBlockSkipScheduleTaskController = null
     }
 
     function clearSponsorBlockNotFoundRefetchTimeout() {
@@ -2857,11 +2860,11 @@ export default defineComponent({
     }
 
     function startSponsorBlockSkipPolling(segment) {
-      sponsorBlockSkipScheduleInterval = setInterval(() => {
+      function checkBoundary() {
         const videoElement = video.value
         if (!videoElement || videoElement.paused || videoElement.ended) {
           cancelSponsorBlockSkipSchedule()
-          return
+          return false
         }
 
         const currentTime = videoElement.currentTime
@@ -2869,14 +2872,47 @@ export default defineComponent({
           const remainingMs = (segment.startTime - currentTime) * 1000 / videoElement.playbackRate
           if (remainingMs > SPONSORBLOCK_SKIP_SCHEDULE_LEAD_MS) {
             scheduleSponsorBlockSkip()
+            return false
           }
-          return
+          return true
         }
 
         cancelSponsorBlockSkipSchedule()
         skipSponsorBlockSegments(currentTime)
         scheduleSponsorBlockSkip()
-      }, SPONSORBLOCK_SKIP_POLL_INTERVAL_MS)
+        return false
+      }
+
+      function scheduleTaskCheck() {
+        return scheduleSponsorBlockSkipTask(() => {
+          if (checkBoundary()) {
+            scheduleTaskCheck()
+          }
+        }, SPONSORBLOCK_SKIP_POLL_INTERVAL_MS)
+      }
+
+      if (!scheduleTaskCheck()) {
+        sponsorBlockSkipScheduleInterval = setInterval(checkBoundary, SPONSORBLOCK_SKIP_POLL_INTERVAL_MS)
+      }
+    }
+
+    function scheduleSponsorBlockSkipTask(callback, delayMs) {
+      if (typeof window.scheduler?.postTask !== 'function') {
+        return false
+      }
+
+      const controller = sponsorBlockSkipScheduleTaskController ?? new AbortController()
+      sponsorBlockSkipScheduleTaskController = controller
+      window.scheduler.postTask(callback, {
+        delay: delayMs,
+        priority: 'user-blocking',
+        signal: controller.signal
+      }).catch((error) => {
+        if (error !== controller.signal.reason) {
+          console.error(error)
+        }
+      })
+      return true
     }
 
     function scheduleSponsorBlockSkip() {
@@ -2908,10 +2944,15 @@ export default defineComponent({
         return
       }
 
-      sponsorBlockSkipScheduleTimeout = setTimeout(() => {
-        sponsorBlockSkipScheduleTimeout = null
-        startSponsorBlockSkipPolling(segment)
-      }, delayMs - SPONSORBLOCK_SKIP_SCHEDULE_LEAD_MS)
+      if (!scheduleSponsorBlockSkipTask(
+        () => startSponsorBlockSkipPolling(segment),
+        delayMs - SPONSORBLOCK_SKIP_SCHEDULE_LEAD_MS
+      )) {
+        sponsorBlockSkipScheduleTimeout = setTimeout(() => {
+          sponsorBlockSkipScheduleTimeout = null
+          startSponsorBlockSkipPolling(segment)
+        }, delayMs - SPONSORBLOCK_SKIP_SCHEDULE_LEAD_MS)
+      }
     }
 
     function syncSponsorBlockMuteSegments(currentTime, autoMuteEnabled = true) {


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Make sure to follow the contributing guidelines. -->
<!-- Important note, we may remove your pull request if you do not use this provided PR template correctly. -->
<!-- Agent instructions: Preserve every heading, comment, and marker in this template. Never remove or rewrite the release-note-category:start/end, release-note:start/end, or release-note-image:start/end marker pairs. -->

## Pull Request Type
<!-- Please select what type of pull request this is: [x] -->
- [x] Bugfix
- [ ] Feature Implementation
- [ ] Documentation
- [ ] Other

## Related issue
<!-- Please link the issue your pull request is referring to. -->
<!-- If this pull request fully resolves the relevant issue, put "closes" before the issue number. -->
<!-- Example: "closes #123456". -->

## Description
<!-- Please write a clear and concise description of what the pull request does. -->
SponsorBlock automatic skips relied on normal timer tasks near each segment boundary. Chromium can defer those tasks when the renderer is slow or busy, which makes the skip noticeably late.

This starts boundary checks earlier and schedules them as cancellable, user-blocking tasks when Chromium supports that API. The existing timer path remains as a fallback. A throttled Electron regression test covers loaded renderers while the original test keeps the normal-speed boundary within 50 ms and prevents early skips.

## Release note category
<!-- Select exactly one category. Every pull request must select one. -->
<!-- Select "Not noteworthy" when the pull request fixes a bug in or improves functionality that has not yet appeared in a stable release. -->
<!-- release-note-category:start -->
- [ ] Not noteworthy
- [ ] Highlights
- [ ] More improvements
- [x] Fixed bugs
<!-- release-note-category:end -->

## Release note
<!-- Required unless "Not noteworthy" is selected. -->
<!-- Write one concise, user-facing entry without a leading bullet. -->
<!-- release-note:start -->
SponsorBlock automatic skips now trigger more promptly on slow or heavily loaded systems.
<!-- release-note:end -->

## Release note images
<!-- Optional. Paste one or more Markdown images, HTML image tags, or dark/light <picture> elements here. -->
<!-- The release notes normalize the markup and limit images taller than 300 pixels. -->
<!-- Agent instructions:
For a noteworthy visible change, add media when it makes the change easier to understand. Prefer a still image unless motion is the point; recordings must use animated WebP.
After implementing a visible change, proactively capture the result and show the local media to the user for approval before uploading it or updating the pull request.
When the affected UI differs between dark and light themes, capturing both themes is required. A dark-only image is incomplete. Run `node _scripts/releaseNoteMedia.mjs --dark DARK_FILE --light LIGHT_FILE --alt "DESCRIPTION"`; GitHub will display the matching theme and use dark as the fallback. Use a single default-dark capture only when the light theme cannot be captured or looks identical.
Capture or crop to the smallest region that still makes the change clear. Do not include the full window when the affected component can be understood on its own.
Use English unless localization is the subject. Keep components at their normal dimensions and placement instead of resizing them to fill the frame.
Use deterministic local fixtures for visible remote images. Reusable avatar and thumbnail fixtures are available through `e2e/helpers/visual-fixtures.mjs`. Before capturing, verify that every visible image has loaded successfully (`complete === true` and `naturalWidth > 0`).
Inspect the final dark and light files for failed images, missing content, unrelated UI, awkward animation, and misleading layout. Omit media when it does not explain the change clearly.
For one dark capture, run `node _scripts/releaseNoteMedia.mjs FILE --alt "DESCRIPTION"`.
Check for personal information, tokens, private repository names, and unrelated desktop content before uploading. Uploaded media is public.
Keep capture-only scripts, test hooks, screenshots, and recordings out of commits. Remove them before committing unless the capture code is also a reusable regression test. Never commit generated release-note media.
Paste only the generated markup between the marker comments. Leave this section empty when media would not help.
-->
<!-- release-note-image:start -->

<!-- release-note-image:end -->

## Testing
<!-- How can reviewers verify that the PR produces correct results? -->
<!-- Please provide instructions so that others can ensure that your pull request produces correct results. For examples see, https://github.com/FreeTubeApp/FreeTube/pull/5743, https://github.com/FreeTubeApp/FreeTube/pull/7349, https://github.com/FreeTubeApp/FreeTube/pull/5125, https://github.com/FreeTubeApp/FreeTube/pull/7338 -->
<!-- Agent instructions: Only write human-facing steps that explain how to verify the change while running this branch in dev mode. Include expected results and, when applicable, helpful console snippets for interactive verification. Do not include automated checks, commands, results, pass counts, or CI status. -->
1. Enable SponsorBlock and automatic skipping for the Sponsor category.
2. Play a video with a known SponsorBlock segment and confirm playback skips at the segment boundary without cutting off content early.
3. Repeat while the renderer or system is under CPU load and confirm the skip still happens near the boundary without a noticeable pause inside the segment.

## Additional context
<!-- Add any other context about the pull request here. -->
The timer fallback keeps the behavior available in environments without the Prioritized Task Scheduling API.
