### PR TITLE
fix(subscriptions): align new feed separator and view icon

### DIFF
--- a/e2e/tests/offline/subscriptions-header-layout.spec.mjs
+++ b/e2e/tests/offline/subscriptions-header-layout.spec.mjs
@@ -134,7 +134,14 @@ test.describe('subscriptions header layout', () => {
   test('separates the main feed tabs from the centered New feed tabs', async ({ app, page, attachScreenshot }) => {
     await goTo(page, 'subscriptions')
     await page.locator('[data-subscription-feed-tab="all"]').click()
-    await page.getByRole('button', { name: 'Show tabbed view' }).click()
+
+    const combinedSeparatorTopMargin = () => page.evaluate(() => {
+      const header = document.querySelector('.subscriptionsHeader')
+      const mainTabs = [...header.querySelectorAll('[data-subscription-feed-tab]')]
+
+      return header.getBoundingClientRect().bottom -
+        Math.max(...mainTabs.map(tab => tab.getBoundingClientRect().bottom))
+    })
 
     const separatorLayout = () => page.evaluate(() => {
       const header = document.querySelector('.subscriptionsHeader')
@@ -149,18 +156,28 @@ test.describe('subscriptions header layout', () => {
         headerShadow: headerStyle.boxShadow,
         separatorWidth: Number.parseFloat(headerRowStyle.borderBottomWidth),
         separatorY: headerRowRect.bottom,
+        separatorTopMargin: headerRowRect.bottom -
+          Number.parseFloat(headerRowStyle.borderBottomWidth) -
+          Math.max(...mainTabs.map(tab => tab.getBoundingClientRect().bottom)),
         mainTabsBottom: Math.max(...mainTabs.map(tab => tab.getBoundingClientRect().bottom)),
         newFeedTabsTop: Math.min(...newFeedTabs.map(tab => tab.getBoundingClientRect().top))
       }
     })
 
-    for (const width of [1400, 700]) {
+    for (const width of [1400, 700, 375]) {
       await setWindowWidth(app, page, width)
+      if (await page.getByRole('button', { name: 'Show combined view' }).isVisible()) {
+        await page.getByRole('button', { name: 'Show combined view' }).click()
+      }
+      const combinedTopMargin = await combinedSeparatorTopMargin()
+
+      await page.getByRole('button', { name: 'Show tabbed view' }).click()
       const layout = await separatorLayout()
 
       expect(layout.headerShadow).toBe('none')
       expect(layout.separatorWidth).toBeGreaterThan(0)
       expect(layout.separatorWidth).toBeLessThanOrEqual(1.1)
+      expect(Math.abs(layout.separatorTopMargin - combinedTopMargin)).toBeLessThanOrEqual(1)
       expect(layout.separatorY).toBeGreaterThanOrEqual(layout.mainTabsBottom)
       expect(layout.newFeedTabsTop).toBeGreaterThanOrEqual(layout.separatorY)
     }

--- a/e2e/tests/offline/subscriptions-new-feed.spec.mjs
+++ b/e2e/tests/offline/subscriptions-new-feed.spec.mjs
@@ -147,6 +147,7 @@ test.describe('new subscriptions feed', () => {
 
     const showTabbedView = page.getByRole('button', { name: 'Show tabbed view' })
     await expect(showTabbedView).toHaveAttribute('aria-pressed', 'false')
+    await expect(showTabbedView.locator('[data-icon="horizontal-tabs"]')).toBeVisible()
     await showTabbedView.click()
 
     const newContentTabs = page.getByRole('tablist', { name: 'New content tabs' })

--- a/src/renderer/views/Subscriptions/Subscriptions.css
+++ b/src/renderer/views/Subscriptions/Subscriptions.css
@@ -1,5 +1,6 @@
 .card {
   --subscriptions-header-gap: 8px;
+  --subscriptions-header-padding-block-end: 12px;
   --subscriptions-top-bar-block-size: 60px;
 
   box-sizing: border-box;
@@ -19,7 +20,7 @@
   inset-block-start: var(--subscriptions-top-bar-block-size);
   z-index: 3;
   margin-inline: -16px;
-  padding-block: calc(3px + var(--subscriptions-header-gap)) 12px;
+  padding-block: calc(3px + var(--subscriptions-header-gap)) var(--subscriptions-header-padding-block-end);
   padding-inline: 16px;
   border-start-start-radius: calc(8px * var(--ui-roundness));
   border-start-end-radius: calc(8px * var(--ui-roundness));
@@ -51,7 +52,7 @@
 
 .subscriptionsHeader.tabbedNewFeed .headerRow {
   margin-inline: -16px;
-  padding-block-end: 8px;
+  padding-block-end: var(--subscriptions-header-padding-block-end);
   padding-inline: 16px;
   border-block-end: 1px solid var(--primary-shadow-color);
 }
@@ -339,11 +340,9 @@
 
 @media only screen and (width <= 680px) {
   .card {
-    inline-size: 100%;
-  }
+    --subscriptions-header-padding-block-end: 10px;
 
-  .subscriptionsHeader {
-    padding-block-end: 10px;
+    inline-size: 100%;
   }
 
   .headerRow {

--- a/src/renderer/views/Subscriptions/Subscriptions.vue
+++ b/src/renderer/views/Subscriptions/Subscriptions.vue
@@ -203,7 +203,7 @@
                 :title="newFeedView === 'tabbed'
                   ? $t('Subscriptions.Show Combined View')
                   : $t('Subscriptions.Show Tabbed View')"
-                :icon="newFeedView === 'tabbed' ? ['fas', 'layer-group'] : ['fas', 'clone']"
+                :icon="newFeedView === 'tabbed' ? ['fas', 'layer-group'] : ['fac', 'horizontal-tabs']"
                 :aria-pressed="newFeedView === 'tabbed'"
                 :use-shadow="false"
                 :padding="8"


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Make sure to follow the contributing guidelines. -->
<!-- Important note, we may remove your pull request if you do not use this provided PR template correctly. -->
<!-- Agent instructions: Preserve every heading, comment, and marker in this template. Never remove or rewrite the release-note-category:start/end, release-note:start/end, or release-note-image:start/end marker pairs. -->

## Pull Request Type
<!-- Please select what type of pull request this is: [x] -->
- [x] Bugfix
- [ ] Feature Implementation
- [ ] Documentation
- [ ] Other

## Related issue
<!-- Please link the issue your pull request is referring to. -->
<!-- If this pull request fully resolves the relevant issue, put "closes" before the issue number. -->
<!-- Example: "closes #123456". -->

## Description
<!-- Please write a clear and concise description of what the pull request does. -->
Switching the New feed from the combined view to the tabbed view moved the horizontal separator upward by four CSS pixels. This change gives both separators the same responsive top margin and adds a rendered-geometry regression check for desktop, compact, and narrow layouts at 95% UI scale. The Show tabbed view control now uses the semantic horizontal-tabs icon, which gives the Remix pack a layout glyph instead of an unrelated share-box glyph.

## Release note category
<!-- Select exactly one category. Every pull request must select one. -->
<!-- Select "Not noteworthy" when the pull request fixes a bug in or improves functionality that has not yet appeared in a stable release. -->
<!-- release-note-category:start -->
- [x] Not noteworthy
- [ ] Highlights
- [ ] More improvements
- [ ] Fixed bugs
<!-- release-note-category:end -->

## Release note
<!-- Required unless "Not noteworthy" is selected. -->
<!-- Write one concise, user-facing entry without a leading bullet. -->
<!-- release-note:start -->
Fixed the New feed separator shifting upward when switching views and clarified the tabbed-view icon in the Remix pack.
<!-- release-note:end -->

## Release note images
<!-- Optional. Paste one or more Markdown images, HTML image tags, or dark/light <picture> elements here. -->
<!-- The release notes normalize the markup and limit images taller than 300 pixels. -->
<!-- Agent instructions:
For a noteworthy visible change, add media when it makes the change easier to understand. Prefer a still image unless motion is the point; recordings must use animated WebP.
After implementing a visible change, proactively capture the result and show the local media to the user for approval before uploading it or updating the pull request.
When the affected UI differs between dark and light themes, capturing both themes is required. A dark-only image is incomplete. Run `node _scripts/releaseNoteMedia.mjs --dark DARK_FILE --light LIGHT_FILE --alt "DESCRIPTION"`; GitHub will display the matching theme and use dark as the fallback.
Capture or crop to the smallest region that still makes the change clear. Do not include the full window when the affected component can be understood on its own.
Use English unless localization is the subject. Keep components at their normal dimensions and placement instead of resizing them to fill the frame.
Use deterministic local fixtures for visible remote images. Reusable avatar and thumbnail fixtures are available through `e2e/helpers/visual-fixtures.mjs`. Before capturing, verify that every visible image has loaded successfully (`complete === true` and `naturalWidth > 0`).
Inspect the final dark and light files for failed images, missing content, unrelated UI, awkward animation, and misleading layout. Omit media when it does not explain the change clearly.
For one dark capture, run `node _scripts/releaseNoteMedia.mjs FILE --alt "DESCRIPTION"`.
Check for personal information, tokens, private repository names, and unrelated desktop content before uploading. Uploaded media is public.
Keep capture-only scripts, test hooks, screenshots, and recordings out of commits. Remove them before committing unless the capture code is also a reusable regression test. Never commit generated release-note media.
Paste only the generated markup between the marker comments. Leave this section empty when media would not help.
-->
<!-- release-note-image:start -->

<!-- release-note-image:end -->

## Testing
<!-- How can reviewers verify that the PR produces correct results? -->
<!-- Please provide instructions so that others can ensure that your pull request would produce correct results. For examples see, https://github.com/FreeTubeApp/FreeTube/pull/5743, https://github.com/FreeTubeApp/FreeTube/pull/7349, https://github.com/FreeTubeApp/FreeTube/pull/5125, https://github.com/FreeTubeApp/FreeTube/pull/7338 -->
<!-- Agent instructions: Only write human-facing steps that explain how to verify the change while running this branch in dev mode. Include expected results and, when applicable, helpful console snippets for interactive verification. Do not include automated checks, commands, results, pass counts, or CI status. -->
1. Open Subscriptions and select the New feed.
2. Switch between the combined and tabbed views.
3. Confirm that the horizontal separator keeps the same margin above it in both views.
4. Resize the window to a narrow layout and repeat the check. The separator margin should remain stable.
5. Select the Remix icon pack and confirm that Show tabbed view uses the tabs-above-content layout icon.

## Additional context
<!-- Add any other context about the pull request here. -->
The tabbed separator previously used an independent 8px value while the combined separator used the header's responsive 12px or 10px block-end padding. Using the existing horizontal-tabs mapping keeps the global clone icon unchanged for duplicate-tab, new-window, and picture-in-picture actions.
