### PR TITLE
fix(player): prevent stale timelink titles and unintended playback

### DIFF
--- a/e2e/tests/offline/player.spec.mjs
+++ b/e2e/tests/offline/player.spec.mjs
@@ -187,9 +187,63 @@ test('does not restore a consumed link timestamp after an app restart', async ({
   const video = await waitForPlayback(page)
   await expect.poll(() => video.evaluate(element => element.currentTime)).toBeGreaterThan(2)
   await expect(page).toHaveURL(/#\/watch\/jNQXAC9IVRw$/)
+  await expect(page.locator('.tab.active .tabTitleText')).toHaveText('Me at the zoo')
+  await expect(page).toHaveTitle('Me at the zoo - OpenTubeX')
 
   ;({ page } = await app.relaunch())
   await expect(page).toHaveURL(/#\/watch\/jNQXAC9IVRw$/)
+  await expect(page.locator('.tab.active .tabTitleText')).toHaveText('Me at the zoo')
+  await expect(page).toHaveTitle('Me at the zoo - OpenTubeX')
+})
+
+test('a timestamped video stays paused when the window loses focus', async ({ app, page }) => {
+  await mockPlayableWatchPage(app, page)
+  await page.locator(sel.searchInput).fill('https://www.youtube.com/watch?v=jNQXAC9IVRw&t=2')
+  await page.locator(sel.searchInput).press('Enter')
+
+  const video = await waitForPlayback(page)
+  await video.evaluate(element => element.pause())
+  await expect.poll(() => video.evaluate(element => element.paused)).toBe(true)
+
+  await app.electronApp.evaluate(({ BrowserWindow }) => {
+    BrowserWindow.getAllWindows()[0].emit('blur')
+  })
+  await page.waitForTimeout(2000)
+
+  expect(await video.evaluate(element => element.paused)).toBe(true)
+})
+
+test('a Short opened in a background tab never starts playback', async ({ app, page }) => {
+  await mockPlayableWatchPage(app, page)
+  await page.evaluate(() => {
+    window.__backgroundShortPlaybackEvents = []
+    for (const type of ['play', 'playing']) {
+      document.addEventListener(type, (event) => {
+        const tabContent = event.target.closest('.tabContent')
+        if (tabContent?.getAttribute('aria-hidden') === 'true') {
+          window.__backgroundShortPlaybackEvents.push(type)
+        }
+      }, true)
+    }
+  })
+
+  const backgroundTab = await page.evaluate(() => window.ftElectron.tabs.create({
+    route: '/watch/background-short?short=true',
+    title: 'Background Short',
+    makeActive: false,
+    preloadInBackground: true
+  }))
+  const backgroundVideo = page.locator(`.tabContent[data-tab-id="${backgroundTab.id}"] video`)
+
+  await expect(backgroundVideo).toHaveCount(1, { timeout: 30_000 })
+  await expect.poll(() => backgroundVideo.evaluate(element => element.readyState)).toBeGreaterThanOrEqual(2)
+  await page.waitForTimeout(1000)
+
+  expect(await page.evaluate(() => window.__backgroundShortPlaybackEvents)).toEqual([])
+  expect(await backgroundVideo.evaluate(element => ({
+    paused: element.paused,
+    currentTime: element.currentTime
+  }))).toEqual({ paused: true, currentTime: 0 })
 })
 
 test('hides configured paused interface elements until pointer activity', async ({ app, page }) => {

--- a/e2e/tests/offline/sabr-error-recovery.spec.mjs
+++ b/e2e/tests/offline/sabr-error-recovery.spec.mjs
@@ -578,6 +578,59 @@ test('a SABR reload preserves the tab title while adding its resume timestamp', 
   await expect(page).toHaveTitle(`${titles.titleBeforeReload} - OpenTubeX`)
 })
 
+test('pausing keeps a SABR replacement paused when autoplay is enabled', async ({ app, page }) => {
+  await mockPlayableWatchPage(app, page)
+  const video = await openMockedVideo(page)
+  const watchView = await watchViewHandle(page)
+
+  await watchView.evaluate(view => {
+    view.$store.commit('setAutoplayVideos', true)
+    view.getTimestamp = () => 0
+
+    const reloadView = view.reloadView.bind(view)
+    let releaseReload
+    const reloadGate = new Promise(resolve => {
+      releaseReload = resolve
+    })
+
+    view.reloadView = async options => {
+      await reloadGate
+      return reloadView(options)
+    }
+    window.__releaseSabrReload = releaseReload
+    window.__sabrReloadFinished = view.performSabrReload(
+      { wasPlaying: true },
+      'Synthetic SABR reload'
+    )
+  })
+
+  await expect.poll(() => watchView.evaluate(view => view.resumePlaybackAfterSabrReload)).toBe(true)
+  await video.evaluate(element => element.pause())
+  await expect.poll(() => watchView.evaluate(view => view.resumePlaybackAfterSabrReload)).toBe(false)
+  await page.evaluate(() => {
+    window.__sabrReplacementPlayEvents = []
+    document.addEventListener('play', event => {
+      if (event.target instanceof HTMLVideoElement) {
+        window.__sabrReplacementPlayEvents.push(event.target.currentTime)
+      }
+    }, true)
+  })
+
+  await app.electronApp.evaluate(({ BrowserWindow }) => {
+    BrowserWindow.getAllWindows()[0].emit('blur')
+  })
+  await page.evaluate(() => window.__releaseSabrReload())
+  await page.evaluate(() => window.__sabrReloadFinished)
+
+  const replacementVideo = page.locator('.tabContent[aria-hidden="false"] video')
+  await expect(replacementVideo).toHaveCount(1, { timeout: 30_000 })
+  await expect.poll(() => replacementVideo.evaluate(element => element.readyState)).toBeGreaterThanOrEqual(2)
+  await page.waitForTimeout(1000)
+
+  expect(await page.evaluate(() => window.__sabrReplacementPlayEvents)).toEqual([])
+  expect(await replacementVideo.evaluate(element => element.paused)).toBe(true)
+})
+
 test('a second SABR failure after successful playback refetches instead of dropping to legacy', async ({ app, page }) => {
   await mockUnplayableWatchPage(app, page)
   await goTo(page, 'history')

--- a/src/renderer/components/ft-shaka-video-player/ft-shaka-video-player.js
+++ b/src/renderer/components/ft-shaka-video-player/ft-shaka-video-player.js
@@ -486,6 +486,10 @@ export default defineComponent({
       type: Boolean,
       default: false
     },
+    suppressAutoplayAfterSabrReload: {
+      type: Boolean,
+      default: false
+    },
     sabrReloadCaptionIndex: {
       type: Number,
       default: null
@@ -1215,9 +1219,14 @@ export default defineComponent({
       isTabPresented,
     })
 
+    // Capture the replacement player's initial state. The parent clears its
+    // pending SABR state after this player loads, but that must not add autoplay
+    // to the same media element afterward.
+    const suppressInitialAutoplay = props.suppressAutoplayAfterSabrReload
+
     /** @type {import('vue').ComputedRef<boolean>} */
     const autoplayVideos = computed(() => {
-      return store.getters.getAutoplayVideos && isActiveTab.value
+      return !suppressInitialAutoplay && store.getters.getAutoplayVideos && isActiveTab.value
     })
 
     /** @type {import('vue').ComputedRef<boolean>} */
@@ -9885,6 +9894,8 @@ export default defineComponent({
 
       if (props.resumePlaybackAfterSabrReload) {
         video.value?.play()
+      }
+      if (props.resumePlaybackAfterSabrReload || suppressInitialAutoplay) {
         emit('resume-playback-after-sabr-reload-done')
       }
     }
@@ -10535,6 +10546,7 @@ export default defineComponent({
       annotationVideoFit,
 
       autoplayVideos,
+      suppressInitialAutoplay,
       loopShorts,
       sponsorBlockShowSkippedToast,
       sponsorBlockDraftEditValues,

--- a/src/renderer/components/ft-shaka-video-player/ft-shaka-video-player.vue
+++ b/src/renderer/components/ft-shaka-video-player/ft-shaka-video-player.vue
@@ -114,7 +114,7 @@
         preload="auto"
         crossorigin="anonymous"
         playsinline
-        :autoplay="autoplayVideos || shortsPlayer ? true : null"
+        :autoplay="autoplayVideos || (!suppressInitialAutoplay && shortsPlayer && isActiveTab) ? true : null"
         :loop="shortsPlayer && loopShorts"
         :poster="format === 'audio' || showPoster ? thumbnail : null"
         @play="handlePlay"

--- a/src/renderer/views/Watch/Watch.js
+++ b/src/renderer/views/Watch/Watch.js
@@ -419,6 +419,9 @@ export default defineComponent({
 
       // When true, the new player after a SABR reload should start playback (was playing before reload)
       resumePlaybackAfterSabrReload: false,
+      // When true, the new player after a SABR reload must ignore the normal autoplay setting.
+      suppressAutoplayAfterSabrReload: false,
+      playerTeardownInProgress: false,
       /** @type {number|null} */
       sabrReloadCaptionIndex: null,
       /** @type {number|null} */
@@ -1924,6 +1927,8 @@ export default defineComponent({
       this.currentSubtitlesState = null
       this.currentVolume = null
       if (!preserveTitle) {
+        this.resumePlaybackAfterSabrReload = false
+        this.suppressAutoplayAfterSabrReload = false
         this.sabrReloadCaptionIndex = null
         this.sabrReloadPlaybackRate = null
         this.sabrReloadVideoQuality = null
@@ -3906,6 +3911,18 @@ export default defineComponent({
       this._saveWatchProgress()
     },
     handleVideoPause() {
+      // A reload remembers whether the outgoing player was playing, but the
+      // user can still pause it before the replacement starts loading. Do not
+      // let that stale snapshot restart the replacement player. Ignore pauses
+      // emitted while the outgoing player is being torn down.
+      if (
+        !this.isLoading &&
+        !this.playerTeardownInProgress &&
+        this.resumePlaybackAfterSabrReload
+      ) {
+        this.resumePlaybackAfterSabrReload = false
+        this.suppressAutoplayAfterSabrReload = true
+      }
       this.watchTimeLastTick = null
       this.flushWatchTime()
       this.handleWatchProgressAutoSaveWhenProgressEnabled()
@@ -4158,7 +4175,11 @@ export default defineComponent({
       await this.tabRouter.replace({
         path: this.tabRoute.path,
         query,
-        hash: this.tabRoute.hash
+        hash: this.tabRoute.hash,
+        state: {
+          skipTabRouteLoading: true,
+          tabTitle: this.videoTitle,
+        },
       })
       this.timestamp = null
     },
@@ -5693,15 +5714,20 @@ export default defineComponent({
     },
 
     destroyPlayer: async function() {
-      const uiState = await this.$refs.player.destroyPlayer()
-      this.startNextVideoInFullscreen = uiState.startNextVideoInFullscreen
-      this.startNextVideoInFullwindow = uiState.startNextVideoInFullwindow
-      this.startNextVideoInPip = uiState.startNextVideoInPip
-      this.startNextVideoWithChapters = uiState.startNextVideoWithChapters
-      this.startNextVideoWithFullscreenMetadata = uiState.startNextVideoWithFullscreenMetadata
-      this.startNextVideoWithFullscreenComments = uiState.startNextVideoWithFullscreenComments
-      this.startNextVideoWithFullscreenLiveChat = uiState.startNextVideoWithFullscreenLiveChat
-      this.startNextVideoWithFullscreenPlaylist = uiState.startNextVideoWithFullscreenPlaylist
+      this.playerTeardownInProgress = true
+      try {
+        const uiState = await this.$refs.player.destroyPlayer()
+        this.startNextVideoInFullscreen = uiState.startNextVideoInFullscreen
+        this.startNextVideoInFullwindow = uiState.startNextVideoInFullwindow
+        this.startNextVideoInPip = uiState.startNextVideoInPip
+        this.startNextVideoWithChapters = uiState.startNextVideoWithChapters
+        this.startNextVideoWithFullscreenMetadata = uiState.startNextVideoWithFullscreenMetadata
+        this.startNextVideoWithFullscreenComments = uiState.startNextVideoWithFullscreenComments
+        this.startNextVideoWithFullscreenLiveChat = uiState.startNextVideoWithFullscreenLiveChat
+        this.startNextVideoWithFullscreenPlaylist = uiState.startNextVideoWithFullscreenPlaylist
+      } finally {
+        this.playerTeardownInProgress = false
+      }
     },
 
     isSabrVideoStream() {
@@ -5755,7 +5781,9 @@ export default defineComponent({
     },
 
     async performSabrReload(payload, toastMessage) {
-      this.resumePlaybackAfterSabrReload = payload?.wasPlaying === true
+      const wasPlaying = payload?.wasPlaying === true
+      this.resumePlaybackAfterSabrReload = wasPlaying
+      this.suppressAutoplayAfterSabrReload = !wasPlaying
       this.sabrReloadCaptionIndex = Number.isInteger(payload?.captionIndex) ? payload.captionIndex : null
       const playbackRate = Number(payload?.playbackRate)
       this.sabrReloadPlaybackRate = Number.isFinite(playbackRate) && playbackRate > 0.07
@@ -5793,6 +5821,7 @@ export default defineComponent({
 
     onResumePlaybackAfterSabrReloadDone() {
       this.resumePlaybackAfterSabrReload = false
+      this.suppressAutoplayAfterSabrReload = false
     },
 
     ...mapActions([

--- a/src/renderer/views/Watch/Watch.vue
+++ b/src/renderer/views/Watch/Watch.vue
@@ -149,6 +149,7 @@
           :paid-promotion="showPaidPromotion"
           :paid-promotion-duration-ms="paidPromotionDurationMs"
           :resume-playback-after-sabr-reload="resumePlaybackAfterSabrReload"
+          :suppress-autoplay-after-sabr-reload="suppressAutoplayAfterSabrReload"
           :sabr-reload-caption-index="sabrReloadCaptionIndex"
           :sabr-reload-playback-rate="sabrReloadPlaybackRate"
           :shorts-player="customShortsPlayerActive"


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Make sure to follow the contributing guidelines. -->
<!-- Important note, we may remove your pull request if you do not use this provided PR template correctly. -->
<!-- Agent instructions: Preserve every heading, comment, and marker in this template. Never remove or rewrite the release-note-category:start/end, release-note:start/end, or release-note-image:start/end marker pairs. -->

## Pull Request Type
<!-- Please select what type of pull request this is: [x] -->
- [x] Bugfix
- [ ] Feature Implementation
- [ ] Documentation
- [ ] Other

## Related issue
<!-- Please link the issue your pull request is referring to. -->
<!-- If this pull request fully resolves the relevant issue, put "closes" before the issue number. -->
<!-- Example: "closes #123456". -->

No linked issue.

## Description
<!-- Please write a clear and concise description of what the pull request does. -->

Timestamped links could replace a resolved tab title with the watch URL after consuming their timestamp. Separately, a paused video could restart during SABR recovery, and Shorts opened in background tabs could briefly play audio.

This keeps the resolved title in tab navigation state, preserves an explicit pause across replacement-player loading even when autoplay is enabled, and applies the existing active-tab autoplay guard to Shorts.

## Release note category
<!-- Select exactly one category. Every pull request must select one. -->
<!-- Select "Not noteworthy" when the pull request fixes a bug in or improves functionality that has not yet appeared in a stable release. -->
<!-- release-note-category:start -->
- [ ] Not noteworthy
- [ ] Highlights
- [ ] More improvements
- [x] Fixed bugs
<!-- release-note-category:end -->

## Release note
<!-- Required unless "Not noteworthy" is selected. -->
<!-- Write one concise, user-facing entry without a leading bullet. -->
<!-- release-note:start -->
Timelinks now keep resolved tab titles after restart, and paused or background videos no longer start playing unexpectedly.
<!-- release-note:end -->

## Release note images
<!-- Optional. Paste one or more Markdown images, HTML image tags, or dark/light <picture> elements here. -->
<!-- The release notes normalize the markup and limit images taller than 300 pixels. -->
<!-- Agent instructions:
For a noteworthy visible change, add media when it makes the change easier to understand. Prefer a still image unless motion is the point; recordings must use animated WebP.
After implementing a visible change, proactively capture the result and show the local media to the user for approval before uploading it or updating the pull request.
When the affected UI differs between dark and light themes, capturing both themes is required. A dark-only image is incomplete. Run `node _scripts/releaseNoteMedia.mjs --dark DARK_FILE --light LIGHT_FILE --alt "DESCRIPTION"`; GitHub will display the matching theme and use dark as the fallback. Use a single default-dark capture only when the light theme cannot be captured or looks identical.
Capture or crop to the smallest region that still makes the change clear. Do not include the full window when the affected component can be understood on its own.
Use English unless localization is the subject. Keep components at their normal dimensions and placement instead of resizing them to fill the frame.
Use deterministic local fixtures for visible remote images. Reusable avatar and thumbnail fixtures are available through `e2e/helpers/visual-fixtures.mjs`. Before capturing, verify that every visible image has loaded successfully (`complete === true` and `naturalWidth > 0`).
Inspect the final dark and light files for failed images, missing content, unrelated UI, awkward animation, and misleading layout. Omit media when it does not explain the change clearly.
For one dark capture, run `node _scripts/releaseNoteMedia.mjs FILE --alt "DESCRIPTION"`.
Check for personal information, tokens, private repository names, and unrelated desktop content before uploading. Uploaded media is public.
Keep capture-only scripts, test hooks, screenshots, and recordings out of commits. Remove them before committing unless the capture code is also a reusable regression test. Never commit generated release-note media.
Paste only the generated markup between the marker comments. Leave this section empty when media would not help.
-->
<!-- release-note-image:start -->

<!-- release-note-image:end -->

## Testing
<!-- How can reviewers verify that the PR produces correct results? -->
<!-- Please provide instructions so that others can ensure that this pull request would produce correct results. For examples see, https://github.com/FreeTubeApp/FreeTube/pull/5743, https://github.com/FreeTubeApp/FreeTube/pull/7349, https://github.com/FreeTubeApp/FreeTube/pull/5125, https://github.com/FreeTubeApp/FreeTube/pull/7338 -->
<!-- Agent instructions: Only write human-facing steps that explain how to verify the change while running this branch in dev mode. Include expected results and, when applicable, helpful console snippets for interactive verification. Do not include automated checks, commands, results, pass counts, or CI status. -->

1. Paste a video URL containing a timestamp. After playback begins, confirm the timestamp is consumed while the tab and window titles keep the video title. Restart the app and confirm the title still remains.
2. With video autoplay enabled, pause a playing video during SABR stream recovery and switch to another application. Confirm the replacement player remains paused.
3. Open a Short in a background tab and leave it there until media is ready. Confirm it emits no audio and remains at its initial position until the tab is activated.

## Additional context
<!-- Add any other context about the pull request here. -->

The paused-state fix distinguishes user pauses from pause events emitted while tearing down the outgoing player. It also suppresses the replacement media element's initial autoplay for that single SABR reload.
