### PR TITLE
fix(ui): polish onboarding tutorial and theme selectors

### DIFF
--- a/e2e/tests/offline/appearance.spec.mjs
+++ b/e2e/tests/offline/appearance.spec.mjs
@@ -183,6 +183,27 @@ test.describe('default appearance', () => {
     }
   })
 
+  test('shows color swatches in every color-theme selector', async ({ page }) => {
+    const themeSection = await goToSettingsSection(page, 'theme')
+    const mainColor = themeSection.getByRole('combobox', { name: /Main colou?r theme/i })
+    const secondaryColor = themeSection.getByRole('combobox', { name: /Secondary colou?r theme/i })
+
+    await expect(mainColor.locator('.optionColorDot')).toHaveCSS('background-color', 'rgb(213, 0, 0)')
+    await expect(secondaryColor.locator('.optionColorDot')).toHaveCSS('background-color', 'rgb(41, 98, 255)')
+    await mainColor.click()
+    const options = page.locator(`#${await mainColor.getAttribute('aria-controls')}`)
+    await expect(options.getByRole('option', { name: 'Blue', exact: true }).locator('.optionColorDot'))
+      .toHaveCSS('background-color', 'rgb(41, 98, 255)')
+    await page.keyboard.press('Escape')
+
+    await page.getByRole('button', { name: 'Create custom theme' }).click()
+    const editor = page.locator('.customThemeEditor')
+    await expect(editor.getByRole('combobox', { name: /Main colou?r theme/i }).locator('.optionColorDot'))
+      .toBeVisible()
+    await expect(editor.getByRole('combobox', { name: /Secondary colou?r theme/i }).locator('.optionColorDot'))
+      .toBeVisible()
+  })
+
   test('maps system light and dark modes to chosen themes', async ({ app, page }) => {
     await page.emulateMedia({ colorScheme: 'light' })
     await goToSettingsSection(page, 'theme')

--- a/e2e/tests/offline/quick-settings.spec.mjs
+++ b/e2e/tests/offline/quick-settings.spec.mjs
@@ -80,6 +80,20 @@ test.describe('quick settings menu', () => {
     await expect(page.locator('.selectDropdown')).toContainText('English (US) (100%)')
   })
 
+  test('shows color swatches in the color-theme selector', async ({ page }) => {
+    await page.locator('.profileTrigger').click()
+    const colorTheme = page.getByRole('dialog', { name: 'Quick settings' })
+      .getByRole('combobox', { name: /Main colou?r theme/i })
+
+    await expect(colorTheme.locator('.optionColorDot')).toHaveCSS('background-color', 'rgb(213, 0, 0)')
+    await colorTheme.click()
+
+    const options = page.locator('.selectDropdown').getByRole('option')
+    await expect(options.first().locator('.optionColorDot')).toHaveCSS('background-color', 'rgb(213, 0, 0)')
+    await expect(page.getByRole('option', { name: 'Blue', exact: true }).locator('.optionColorDot'))
+      .toHaveCSS('background-color', 'rgb(41, 98, 255)')
+  })
+
   test('hides the unavailable main color selector', async ({ page }) => {
     await page.setViewportSize({ width: 480, height: 420 })
     await page.locator('.profileTrigger').click()

--- a/e2e/tests/offline/tutorial.spec.mjs
+++ b/e2e/tests/offline/tutorial.spec.mjs
@@ -102,33 +102,82 @@ test('keeps the tutorial actions reachable in a short window', async ({ app, pag
   })).toBe(true)
 })
 
-test('keeps every import action reachable in a narrow window', async ({ app, page }) => {
-  await app.electronApp.evaluate(({ BrowserWindow }) => {
-    BrowserWindow.getAllWindows()[0].setSize(340, 600)
-  })
-  await page.evaluate(() => localStorage.setItem('opentubex.tutorial.audience', 'new'))
-  await page.reload()
+test.describe('translated import actions', () => {
+  test.use({ seed: { settings: { currentLocale: 'de-DE' } } })
 
-  const tutorial = page.locator('.tutorialCard')
-  for (let step = 0; step < 5; step++) {
-    await tutorial.getByRole('button', { name: 'Next' }).click()
-  }
-  await expect(tutorial).toHaveAccessibleName('Bring your data with you')
-
-  const actions = ['Back', 'Not now', 'Import data'].map(name => {
-    return tutorial.getByRole('button', { name })
-  })
-  await Promise.all(actions.map(action => expect(action).toBeVisible()))
-  await expect.poll(async () => {
-    const [cardBounds, ...actionBounds] = await Promise.all([
-      tutorial.evaluate(element => element.getBoundingClientRect().toJSON()),
-      ...actions.map(action => action.evaluate(element => element.getBoundingClientRect().toJSON()))
-    ])
-    return actionBounds.every(bounds => {
-      return bounds.left >= cardBounds.left && bounds.right <= cardBounds.right &&
-        bounds.top >= cardBounds.top && bounds.bottom <= cardBounds.bottom
+  test('keep their labels when they fit on one row', async ({ app, page }) => {
+    await app.electronApp.evaluate(({ BrowserWindow }) => {
+      BrowserWindow.getAllWindows()[0].setSize(500, 600)
     })
-  }).toBe(true)
+    await page.evaluate(() => localStorage.setItem('opentubex.tutorial.audience', 'new'))
+    await page.reload()
+    await page.evaluate(() => window.ftElectron.setZoomFactor(1.05))
+
+    const tutorial = page.locator('.tutorialCard')
+    for (let step = 0; step < 5; step++) {
+      await tutorial.getByRole('button', { name: 'Weiter' }).click()
+    }
+
+    const actions = ['Zurück', 'Nicht jetzt', 'Daten importieren'].map(name => {
+      return tutorial.getByRole('button', { name })
+    })
+    await Promise.all(actions.map(action => expect(action.locator('.tutorialActionText')).toBeVisible()))
+    const actionTops = await Promise.all(actions.map(action => {
+      return action.evaluate(element => Math.round(element.getBoundingClientRect().top))
+    }))
+    expect(new Set(actionTops).size).toBe(1)
+  })
+
+  test('stay on one row in a narrow window', async ({ app, page }) => {
+    await app.electronApp.evaluate(({ BrowserWindow }) => {
+      BrowserWindow.getAllWindows()[0].setSize(340, 600)
+    })
+    await page.evaluate(() => localStorage.setItem('opentubex.tutorial.audience', 'new'))
+    await page.reload()
+    await page.evaluate(() => window.ftElectron.setZoomFactor(1.05))
+
+    const tutorial = page.locator('.tutorialCard')
+    for (let step = 0; step < 5; step++) {
+      await tutorial.getByRole('button', { name: 'Weiter' }).click()
+    }
+    await expect(tutorial).toHaveAccessibleName('Nimm deine Daten mit')
+
+    const actions = ['Zurück', 'Nicht jetzt', 'Daten importieren'].map(name => {
+      return tutorial.getByRole('button', { name })
+    })
+    await Promise.all(actions.map(action => expect(action).toBeVisible()))
+    await expect.poll(async () => {
+      const [cardBounds, ...actionBounds] = await Promise.all([
+        tutorial.evaluate(element => element.getBoundingClientRect().toJSON()),
+        ...actions.map(action => action.evaluate(element => element.getBoundingClientRect().toJSON()))
+      ])
+      return actionBounds.every(bounds => {
+        return bounds.left >= cardBounds.left && bounds.right <= cardBounds.right &&
+          bounds.top >= cardBounds.top && bounds.bottom <= cardBounds.bottom
+      })
+    }).toBe(true)
+    await expect.poll(async () => {
+      const actionBounds = await Promise.all(actions.map(action => {
+        return action.evaluate(element => element.getBoundingClientRect().toJSON())
+      }))
+      return new Set(actionBounds.map(bounds => Math.round(bounds.top))).size
+    }).toBe(1)
+    const actionWidths = await Promise.all(actions.map(action => {
+      return action.evaluate(element => {
+        const contentRange = document.createRange()
+        contentRange.selectNodeContents(element)
+        const styles = getComputedStyle(element)
+        return {
+          availableWidth: element.clientWidth - Number.parseFloat(styles.paddingLeft) - Number.parseFloat(styles.paddingRight),
+          contentWidth: contentRange.getBoundingClientRect().width
+        }
+      })
+    }))
+    expect(
+      actionWidths.every(({ availableWidth, contentWidth }) => contentWidth <= availableWidth),
+      JSON.stringify(actionWidths)
+    ).toBe(true)
+  })
 })
 
 test('resets the managed content viewport after a shorter step replaces it', async ({ app, page }) => {
@@ -264,6 +313,30 @@ test('walks new users through the essential controls', async ({ page }) => {
 
   await page.reload()
   await expect(page.locator('.tutorialOverlay')).toHaveCount(0)
+})
+
+test('repositions the tab highlight when the layout is reset', async ({ page }) => {
+  await page.evaluate(() => localStorage.setItem('opentubex.tutorial.audience', 'new'))
+  await page.reload()
+  await page.evaluate(() => window.ftElectron.setZoomFactor(0.95))
+
+  const tutorial = page.locator('.tutorialCard')
+  for (let step = 0; step < 3; step++) {
+    await tutorial.getByRole('button', { name: 'Next' }).click()
+  }
+  await expect(tutorial).toHaveAccessibleName('Keep pages open in tabs')
+
+  const layout = tutorial.getByRole('combobox', { name: 'Tab Layout' })
+  await layout.click()
+  await page.locator(`#${await layout.getAttribute('aria-controls')}`)
+    .getByRole('option', { name: 'Vertical on right', exact: true }).click()
+  await expect(page.locator('.tabBar.position-right')).toBeVisible()
+  await expectHighlightCenteredOn(page, '[data-tutorial="tabs"]')
+
+  await tutorial.getByRole('button', { name: 'Reset this setting to its default' }).click()
+  await expect(page.locator('.tabBar.position-top')).toBeVisible()
+  await expect(layout).toHaveText('Horizontal at top')
+  await expectHighlightCenteredOn(page, '[data-tutorial="tabs"]')
 })
 
 test.describe('fresh profile relaunch', () => {

--- a/src/renderer/components/CustomThemeEditor/CustomThemeEditor.vue
+++ b/src/renderer/components/CustomThemeEditor/CustomThemeEditor.vue
@@ -49,6 +49,7 @@
           :value="draft.mainColor"
           :select-names="themeColorNames"
           :select-values="COLOR_VALUES"
+          :option-colors="COLOR_SWATCHES"
           :icon="['fas', 'palette']"
           icon-color="var(--primary-color)"
           @change="copyMainColor"
@@ -58,6 +59,7 @@
           :value="draft.secondaryColor"
           :select-names="themeColorNames"
           :select-values="COLOR_VALUES"
+          :option-colors="COLOR_SWATCHES"
           :icon="['fas', 'palette']"
           icon-color="var(--accent-color)"
           @change="copySecondaryColor"
@@ -220,6 +222,7 @@ const baseThemeNames = computed(() => {
   return BASE_THEME_TRANSLATION_KEYS.map(key => translations[key] ?? key)
 })
 const COLOR_VALUES = colors.map(color => color.name)
+const COLOR_SWATCHES = colors.map(color => color.value)
 const themeColorNames = useColorTranslations()
 const colorNames = computed(() => tm('Settings.Theme Settings.Custom Theme.Colors'))
 const isSavedTheme = computed(() => store.getters.getCustomThemes.some(({ id }) => id === draft.id))

--- a/src/renderer/components/FtQuickSettingsMenu/FtQuickSettingsMenu.vue
+++ b/src/renderer/components/FtQuickSettingsMenu/FtQuickSettingsMenu.vue
@@ -174,6 +174,7 @@
                     setting-key="mainColor"
                     :select-names="colorNames"
                     :select-values="COLOR_VALUES"
+                    :option-colors="COLOR_SWATCHES"
                     :icon="['fas', 'palette']"
                     icon-color="var(--primary-color)"
                     @change="updateSetting('MainColor', $event)"
@@ -423,6 +424,7 @@ const baseThemeNames = computed(() => [
 ])
 
 const COLOR_VALUES = colors.map(color => color.name)
+const COLOR_SWATCHES = colors.map(color => color.value)
 const colorNames = useColorTranslations()
 const VIEW_TYPE_VALUES = ['grid', 'list']
 const viewTypeNames = computed(() => [

--- a/src/renderer/components/FtTutorialOverlay/FtTutorialOverlay.css
+++ b/src/renderer/components/FtTutorialOverlay/FtTutorialOverlay.css
@@ -43,6 +43,10 @@
   position: relative;
 }
 
+.tutorialImportCard {
+  inline-size: min(440px, calc(100vw - 24px));
+}
+
 .tutorialProgress {
   display: flex;
   justify-content: center;
@@ -123,9 +127,45 @@
   margin: 0;
 }
 
+.tutorialImportActions {
+  display: grid;
+  grid-template-columns: repeat(3, auto);
+}
+
+.tutorialImportActions :deep(.btn) {
+  min-inline-size: 0;
+  padding-inline: 12px;
+}
+
 @media only screen and (width <= 500px) {
   .tutorialCard {
     padding: 20px;
+  }
+
+  .tutorialImportCard {
+    padding-inline: 16px;
+  }
+}
+
+@media only screen and (width <= 400px) {
+  .tutorialImportActions :deep(.tutorialCompactAction) {
+    padding-inline: 2px;
+  }
+
+  .tutorialImportActions {
+    grid-template-columns: 40px 40px minmax(0, 1fr);
+  }
+
+  .tutorialImportActions :deep(.tutorialCompactAction .tutorialActionText) {
+    display: none;
+  }
+
+  .tutorialImportActions :deep(.tutorialPrimaryAction) {
+    padding-inline: 4px;
+  }
+
+  .tutorialImportActions :deep(.tutorialPrimaryAction .ft-icon) {
+    display: none;
   }
 }
 

--- a/src/renderer/components/FtTutorialOverlay/FtTutorialOverlay.vue
+++ b/src/renderer/components/FtTutorialOverlay/FtTutorialOverlay.vue
@@ -15,6 +15,7 @@
       <FtCard
         ref="cardRef"
         class="tutorialCard"
+        :class="{ tutorialImportCard: step.showImportAction }"
         :style="cardStyle"
         role="dialog"
         aria-modal="true"
@@ -91,7 +92,10 @@
                 @change="updateDefaultQuality"
               />
             </div>
-            <div class="tutorialActions">
+            <div
+              class="tutorialActions"
+              :class="{ tutorialImportActions: step.showImportAction }"
+            >
               <FtButton
                 v-if="steps.length > 1 && stepIndex === 0"
                 :label="t('Tutorial.Skip')"
@@ -101,26 +105,44 @@
               />
               <FtButton
                 v-if="steps.length > 1 && stepIndex > 0"
-                :label="t('Back')"
-                :icon="['fas', 'arrow-left']"
+                class="tutorialCompactAction"
+                :aria-label="t('Back')"
                 :text-color="null"
                 :background-color="null"
                 @click="retreatTutorial"
-              />
+              >
+                <FtIcon
+                  :icon="['fas', 'arrow-left']"
+                  aria-hidden="true"
+                />
+                <span class="tutorialActionText">{{ t('Back') }}</span>
+              </FtButton>
               <FtButton
                 v-if="step.showImportAction"
-                :label="t('Tutorial.Import Data.Not Now')"
-                :icon="['fas', 'xmark']"
+                class="tutorialCompactAction"
+                :aria-label="t('Tutorial.Import Data.Not Now')"
                 :text-color="null"
                 :background-color="null"
                 @click="finishTutorial"
-              />
+              >
+                <FtIcon
+                  :icon="['fas', 'xmark']"
+                  aria-hidden="true"
+                />
+                <span class="tutorialActionText">{{ t('Tutorial.Import Data.Not Now') }}</span>
+              </FtButton>
               <FtButton
                 v-if="step.showImportAction"
-                :label="t('Tutorial.Import Data.Action')"
-                :icon="['fas', 'database']"
+                class="tutorialPrimaryAction"
+                :aria-label="t('Tutorial.Import Data.Action')"
                 @click="openDataImport"
-              />
+              >
+                <FtIcon
+                  :icon="['fas', 'database']"
+                  aria-hidden="true"
+                />
+                <span class="tutorialActionText">{{ t('Tutorial.Import Data.Action') }}</span>
+              </FtButton>
               <FtButton
                 v-else
                 ref="primaryButtonRef"
@@ -138,7 +160,7 @@
 
 <script setup>
 import { FtIcon } from '@opentubex/icons'
-import { computed, nextTick, onBeforeUnmount, onMounted, ref, useId, useTemplateRef } from 'vue'
+import { computed, nextTick, onBeforeUnmount, onMounted, ref, useId, useTemplateRef, watch } from 'vue'
 import { useI18n } from 'vue-i18n'
 
 import store from '../../store/index'
@@ -291,6 +313,8 @@ const defaultQuality = computed(() => {
   const value = store.getters.getDefaultQuality
   return value === 'auto' && !autoQualityAvailable.value ? AUTO_QUALITY_FALLBACK : value
 })
+
+watch(tabBarPosition, schedulePositionUpdate, { flush: 'post' })
 
 const highlightStyle = computed(() => {
   if (targetRect.value === null) return {}
@@ -459,7 +483,6 @@ function handleKeydown(event) {
 
 async function updateTabBarPosition(value) {
   await store.dispatch('updateTabBarPosition', value)
-  schedulePositionUpdate()
 }
 
 function updateBaseTheme(value) {

--- a/src/renderer/components/ThemeSettings.vue
+++ b/src/renderer/components/ThemeSettings.vue
@@ -71,6 +71,7 @@
         setting-key="mainColor"
         :select-names="colorNames"
         :select-values="COLOR_VALUES"
+        :option-colors="COLOR_SWATCHES"
         :disabled="!areColorThemesEnabled"
         :icon="['fas', 'palette']"
         icon-color="var(--primary-color)"
@@ -82,6 +83,7 @@
         setting-key="secColor"
         :select-names="colorNames"
         :select-values="COLOR_VALUES"
+        :option-colors="COLOR_SWATCHES"
         :disabled="!areColorThemesEnabled"
         :icon="['fas', 'palette']"
         icon-color="var(--accent-color)"
@@ -474,6 +476,7 @@ function updateTabBarPosition(value) {
 }
 
 const COLOR_VALUES = colors.map(color => color.name)
+const COLOR_SWATCHES = colors.map(color => color.value)
 const colorNames = useColorTranslations()
 const showCustomThemeEditor = ref(false)
 const editingCustomThemeId = ref(null)

--- a/static/locales/de-DE.yaml
+++ b/static/locales/de-DE.yaml
@@ -2654,12 +2654,12 @@ Tutorial:
     Description: Suche Videos und Kanäle oder füge eine unterstützte Video-URL direkt in das Suchfeld ein.
   Tabs:
     Title: Seiten in Tabs geöffnet halten
-    Description: Öffne mehrere Seiten gleichzeitig und wechsle zwischen ihnen, ohne deine Position zu verlieren.
+    Description: Öffne mehrere Seiten gleichzeitig und wechsle zwischen ihnen, ohne deine Position zu verlieren. Wähle, wo die Tabs in deinem Layout angezeigt werden sollen.
   Quick Settings:
     Title: Passe alles an dich an
     Description: >-
-      Wähle oben rechts dein Profil aus, um das Profil zu wechseln, häufige Einstellungen zu ändern oder alle
-      Einstellungen zu öffnen. Mit einem Rechtsklick gelangst du direkt zur Profilauswahl.
+      Wähle ein Farbschema und die Standardqualität für Videos. Diese und weitere Einstellungen kannst du jederzeit
+      über dein Profilmenü ändern. Mit einem Rechtsklick auf dein Profil gelangst du direkt zur Profilauswahl.
   Import Data:
     Title: Nimm deine Daten mit
     Description: Importiere bei Bedarf Abos, Verlauf, Playlists, Suchverlauf oder Einstellungen aus einer anderen unterstützten Anwendung oder Sicherung.


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Make sure to follow the contributing guidelines. -->
<!-- Important note, we may remove your pull request if you do not use this provided PR template correctly. -->
<!-- Agent instructions: Preserve every heading, comment, and marker in this template. Never remove or rewrite the release-note-category:start/end, release-note:start/end, or release-note-image:start/end marker pairs. -->

## Pull Request Type
<!-- Please select what type of pull request this is: [x] -->
- [x] Bugfix
- [ ] Feature Implementation
- [ ] Documentation
- [ ] Other

## Related issue
<!-- Please link the issue your pull request is referring to. -->
<!-- If this pull request fully resolves the relevant issue, put "closes" before the issue number. -->
<!-- Example: "closes #123456". -->

No linked issue.

## Description
<!-- Please write a clear and concise description of what the pull request does. -->

The onboarding tutorial could leave its tab spotlight behind after resetting the layout, wrap translated import actions, and describe the controls unclearly in German. Theme color selectors also lacked a direct color preview.

This updates the German tutorial copy, resynchronizes the spotlight with the tab position, keeps import actions on one row while preserving labels whenever they fit, and adds color dots to main and secondary theme selectors.

## Release note category
<!-- Select exactly one category. Every pull request must select one. -->
<!-- Select "Not noteworthy" when the pull request fixes a bug in or improves functionality that has not yet appeared in a stable release. -->
<!-- release-note-category:start -->
- [ ] Not noteworthy
- [ ] Highlights
- [ ] More improvements
- [x] Fixed bugs
<!-- release-note-category:end -->

## Release note
<!-- Required unless "Not noteworthy" is selected. -->
<!-- Write one concise, user-facing entry without a leading bullet. -->
<!-- release-note:start -->
Improved the onboarding tutorial and added color previews to theme selectors.
<!-- release-note:end -->

## Release note images
<!-- Optional. Paste one or more Markdown images, HTML image tags, or dark/light <picture> elements here. -->
<!-- The release notes normalize the markup and limit images taller than 300 pixels. -->
<!-- Agent instructions:
For a noteworthy visible change, add media when it makes the change easier to understand. Prefer a still image unless motion is the point; recordings must use animated WebP.
After implementing a visible change, proactively capture the result and show the local media to the user for approval before uploading it or updating the pull request.
When the affected UI differs between dark and light themes, capturing both themes is required. A dark-only image is incomplete. Run `node _scripts/releaseNoteMedia.mjs --dark DARK_FILE --light LIGHT_FILE --alt "DESCRIPTION"`; GitHub will display the matching theme and use dark as the fallback. Use a single default-dark capture only when the light theme cannot be captured or looks identical.
Capture or crop to the smallest region that still makes the change clear. Do not include the full window when the affected component can be understood on its own.
Use English unless localization is the subject. Keep components at their normal dimensions and placement instead of resizing them to fill the frame.
Use deterministic local fixtures for visible remote images. Reusable avatar and thumbnail fixtures are available through `e2e/helpers/visual-fixtures.mjs`. Before capturing, verify that every visible image has loaded successfully (`complete === true` and `naturalWidth > 0`).
Inspect the final dark and light files for failed images, missing content, unrelated UI, awkward animation, and misleading layout. Omit media when it does not explain the change clearly.
For one dark capture, run `node _scripts/releaseNoteMedia.mjs FILE --alt "DESCRIPTION"`.
Check for personal information, tokens, private repository names, and unrelated desktop content before uploading. Uploaded media is public.
Keep capture-only scripts, test hooks, screenshots, and recordings out of commits. Remove them before committing unless the capture code is also a reusable regression test. Never commit generated release-note media.
Paste only the generated markup between the marker comments. Leave this section empty when media would not help.
-->
<!-- release-note-image:start -->

<!-- release-note-image:end -->

## Testing
<!-- How can reviewers verify that the PR produces correct results? -->
<!-- Please provide instructions so that others can ensure that your pull request would produce correct results. For examples see, https://github.com/FreeTubeApp/FreeTube/pull/5743, https://github.com/FreeTubeApp/FreeTube/pull/7349, https://github.com/FreeTubeApp/FreeTube/pull/5125, https://github.com/FreeTubeApp/FreeTube/pull/7338 -->
<!-- Agent instructions: Only write human-facing steps that explain how to verify the change while running this branch in dev mode. Include expected results and, when applicable, helpful console snippets for interactive verification. Do not include automated checks, commands, results, pass counts, or CI status. -->

1. Start the new-user tutorial and advance to the tab-layout step. Select "Vertical on right," then reset the setting. The tabs and spotlight should both return to the top.
2. Switch to German and advance to the import step. At regular widths all three action labels should remain visible on one row. At a very narrow width the secondary actions should become accessible icon buttons without wrapping.
3. Open Quick Settings, Appearance settings, and the custom-theme editor. Main and secondary color selectors should show the corresponding color dot beside the selected value and each option.

## Additional context
<!-- Add any other context about the pull request here. -->

The release-note image is omitted because the PR combines several small controls across separate screens; one image would not explain the full change clearly.
