### PR TITLE
fix(sync): surface background sync failures

### DIFF
--- a/e2e/tests/offline/settings.spec.mjs
+++ b/e2e/tests/offline/settings.spec.mjs
@@ -4045,6 +4045,31 @@ test.describe('sync settings', () => {
     await expect(username).toHaveValue('paired-user')
   })
 
+  test('shows session expiration and other sync failures outside Sync settings', async ({ page }) => {
+    let response = { status: 500, body: 'Background sync failed' }
+    await page.route('https://sync.d3sox.me/**', async (route) => {
+      await route.fulfill(response)
+    })
+
+    const sync = () => page.evaluate(async () => {
+      const store = document.querySelector('#app').__vue_app__.config.globalProperties.$store
+      await store.dispatch('syncWithSyncServer').catch(() => {})
+    })
+
+    await sync()
+    const toast = page.locator('.toast', {
+      hasText: 'Sync failed: Background sync failed'
+    })
+    await expect(toast).toBeVisible()
+    await expect(toast.locator('.icon[data-icon="circle-exclamation"]')).toBeVisible()
+
+    response = { status: 401, body: 'Invalid or missing authentication token' }
+    await sync()
+    await expect(page.locator('.toast', {
+      hasText: 'Sync failed: Sync server session expired. Sign in again to resume syncing.'
+    })).toBeVisible()
+  })
+
   test('clears a sync error and enables credentials after disconnecting', async ({ page }) => {
     let finishServerCheck
     let serverCheckStarted
@@ -4069,6 +4094,8 @@ test.describe('sync settings', () => {
     const syncSection = page.locator('[data-section="sync"]')
     await syncSection.getByRole('button', { name: 'Sync now' }).click()
     await expect(syncSection.locator('.error')).toHaveText('Sync failed')
+    await page.waitForTimeout(250)
+    await expect(page.locator('.toast', { hasText: 'Sync failed: Sync failed' })).toHaveCount(0)
 
     await expect(syncSection.getByLabel('Server URL')).toBeDisabled()
     await expect(syncSection.getByLabel('Username')).toBeDisabled()

--- a/src/renderer/App.vue
+++ b/src/renderer/App.vue
@@ -614,6 +614,21 @@ let removeGamepadNavigation = () => {}
 let utilityRoutePreloadId = null
 let utilityRoutePreloadUsesIdleCallback = false
 
+function isSyncSettingsVisible() {
+  return settingsWindowOpen.value && document.querySelector(
+    '.settingsWindow .settingsContent > [data-section="sync"]'
+  ) !== null
+}
+
+watch([dataReady, () => store.getters.getSyncServerError], ([ready, error]) => {
+  if (!ready || error === '' || isSyncSettingsVisible()) return
+
+  showToast({
+    message: t('Settings.Sync Settings.Sync failed', { error }),
+    icon: ['fas', 'circle-exclamation'],
+  })
+}, { flush: 'post' })
+
 function scheduleUtilityRoutePreload() {
   if (utilityRoutePreloadId !== null) {
     return

--- a/static/locales/de-DE.yaml
+++ b/static/locales/de-DE.yaml
@@ -1384,6 +1384,7 @@ Settings:
     History not supported: Diese Serverversion unterstützt die Synchronisierung des Wiedergabeverlaufs nicht.
     Settings not supported: Diese Serverversion unterstützt die Synchronisierung der Einstellungen nicht.
     Sync completed: Synchronisierung abgeschlossen
+    Sync failed: 'Synchronisierung fehlgeschlagen: {error}'
     Data Loss Confirmation: Destruktive Synchronisierung bestätigen?
     Data Loss Warning: >-
       Der Serverstatus würde {deleted} von {previous} zuvor synchronisierten Elementen der Kategorie „{collection}“

--- a/static/locales/en-US.yaml
+++ b/static/locales/en-US.yaml
@@ -1422,6 +1422,7 @@ Settings:
     History not supported: This server version does not support watch history syncing.
     Settings not supported: This server version does not support settings syncing.
     Sync completed: Sync completed
+    Sync failed: 'Sync failed: {error}'
     Data Loss Confirmation: Confirm destructive sync?
     Data Loss Warning: 'The server state would delete {deleted} of {previous} previously synced {collection} items. This can indicate a failed server migration or reset. Continue only if this deletion is intentional and you have a backup.'
     Confirm Data Loss: Delete and continue


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Make sure to follow the contributing guidelines. -->
<!-- Important note, we may remove your pull request if you do not use this provided PR template correctly. -->
<!-- Agent instructions: Preserve every heading, comment, and marker in this template. Never remove or rewrite the release-note-category:start/end, release-note:start/end, or release-note-image:start/end marker pairs. -->

## Pull Request Type
<!-- Please select what type of pull request this is: [x] -->
- [x] Bugfix
- [ ] Feature Implementation
- [ ] Documentation
- [ ] Other

## Related issue
<!-- Please link the issue your pull request is referring to. -->
<!-- If this pull request fully resolves the relevant issue, put "closes" before the issue number. -->
<!-- Example: "closes #123456". -->

Related to #942.

## Description
<!-- Please write a clear and concise description of what the pull request does. -->

Background sync failures were only visible inside Sync settings, so users could miss expired sessions and other errors. This shows sync failures in an accessible toast whenever the Sync settings content is not visible, while keeping the existing inline error when it is open.

## Release note category
<!-- Select exactly one category. Every pull request must select one. -->
<!-- Select "Not noteworthy" when the pull request fixes a bug in or improves functionality that has not yet appeared in a stable release. -->
<!-- release-note-category:start -->
- [ ] Not noteworthy
- [ ] Highlights
- [ ] More improvements
- [x] Fixed bugs
<!-- release-note-category:end -->

## Release note
<!-- Required unless "Not noteworthy" is selected. -->
<!-- Write one concise, user-facing entry without a leading bullet. -->
<!-- release-note:start -->
Sync failures now show a toast when Sync settings is not open.
<!-- release-note:end -->

## Release note images
<!-- Optional. Paste one or more Markdown images, HTML image tags, or dark/light <picture> elements here. -->
<!-- The release notes normalize the markup and limit images taller than 300 pixels. -->
<!-- Agent instructions:
For a noteworthy visible change, add media when it makes the change easier to understand. Prefer a still image unless motion is the point; recordings must use animated WebP.
After implementing a visible change, proactively capture the result and show the local media to the user for approval before uploading it or updating the pull request.
When the affected UI differs between dark and light themes, capturing both themes is required. A dark-only image is incomplete. Run `node _scripts/releaseNoteMedia.mjs --dark DARK_FILE --light LIGHT_FILE --alt "DESCRIPTION"`; GitHub will display the matching theme and use dark as the fallback. Use a single default-dark capture only when the light theme cannot be captured or looks identical.
Capture or crop to the smallest region that still makes the change clear. Do not include the full window when the affected component can be understood on its own.
Use English unless localization is the subject. Keep components at their normal dimensions and placement instead of resizing them to fill the frame.
Use deterministic local fixtures for visible remote images. Reusable avatar and thumbnail fixtures are available through `e2e/helpers/visual-fixtures.mjs`. Before capturing, verify that every visible image has loaded successfully (`complete === true` and `naturalWidth > 0`).
Inspect the final dark and light files for failed images, missing content, unrelated UI, awkward animation, and misleading layout. Omit media when it does not explain the change clearly.
For one dark capture, run `node _scripts/releaseNoteMedia.mjs FILE --alt "DESCRIPTION"`.
Check for personal information, tokens, private repository names, and unrelated desktop content before uploading. Uploaded media is public.
Keep capture-only scripts, test hooks, screenshots, and recordings out of commits. Remove them before committing unless the capture code is also a reusable regression test. Never commit generated release-note media.
Paste only the generated markup between the marker comments. Leave this section empty when media would not help.
-->
<!-- release-note-image:start -->

<!-- release-note-image:end -->

## Testing
<!-- How can reviewers verify that the PR produces correct results? -->
<!-- Please provide instructions so that others can ensure that your pull request would produce correct results. For examples see, https://github.com/FreeTubeApp/FreeTube/pull/5743, https://github.com/FreeTubeApp/OpenTubeX/pull/7349, https://github.com/FreeTubeApp/OpenTubeX/pull/5125, https://github.com/FreeTubeApp/OpenTubeX/pull/7338 -->
<!-- Agent instructions: Only write human-facing steps that explain how to verify the change while running this branch in dev mode. Include expected results and, when applicable, helpful console snippets for interactive verification. Do not include automated checks, commands, results, pass counts, or CI status. -->

1. Sign in to a sync account and navigate away from Sync settings.
2. Make a sync request fail, for example by making the configured server unavailable, then trigger a sync.
3. Confirm that a localized `Sync failed` toast reports the error.
4. Open Sync settings while a sync error is active and confirm that the error remains inline without a duplicate toast.
5. Repeat with an expired or otherwise unauthorized session and confirm that the authentication failure is also surfaced outside Sync settings.

## Additional context
<!-- Add any other context about the pull request here. -->

The session-management issue now separately tracks password changes and session revocation behavior.