### PR TITLE
fix(live-chat): preserve replay messages across metadata and seeks

### DIFF
--- a/patches/youtubei.js@18.0.0.patch
+++ b/patches/youtubei.js@18.0.0.patch
@@ -107,7 +107,7 @@ index 90faaabfaf9e2f80d08d410bb272f708ceea94b7..b0cf4a9ba22fa9e1e482d9084738319e
              else {
                  // There are more than 10 actions, emit them asynchronously so we can request the next incremental continuation.
                  this.#emitSmoothedActions(actions);
-@@ -69,54 +68,161 @@ export default class LiveChat extends EventEmitter {
+@@ -69,54 +68,164 @@ export default class LiveChat extends EventEmitter {
          if (!this.running) {
              this.running = true;
              this.#pollLivechat();
@@ -205,6 +205,7 @@ index 90faaabfaf9e2f80d08d410bb272f708ceea94b7..b0cf4a9ba22fa9e1e482d9084738319e
 +        // a resolved promise that would claim its actions have been emitted.
 +        if (this.#polling)
 +            return this.#poll_promise ?? Promise.resolve();
++        this.#retry_count = 0;
 +        this.#polling = true;
 +        const seek_generation = this.#seek_generation;
 +        let poll_again = false;
@@ -239,17 +240,19 @@ index 90faaabfaf9e2f80d08d410bb272f708ceea94b7..b0cf4a9ba22fa9e1e482d9084738319e
 +                        this.emit('start', contents);
 +                        poll_again = this.running && !this.is_replay;
 +                    }
-+                    else if (this.is_replay) {
++                    if (this.is_replay) {
 +                        // Replay actions carry their own player offsets, so instead of pacing them
 +                        // ourselves we hand them over right away and let the consumer decide when
 +                        // to display them.
 +                        for (const action of contents.actions) {
++                            if (seek_generation !== this.#seek_generation)
++                                return;
 +                            this.emit('chat-update', action);
 +                        }
 +                        // Once the end of the chat is reached there is no continuation left, which
 +                        // makes pollNext() a no-op until a seek puts us back into the chat's range.
 +                    }
-+                    else {
++                    else if (!contents.header) {
 +                        this.smoothed_queue.enqueueActionGroup(contents.actions);
 +                    }
 +                    this.#retry_count = 0;

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -11,7 +11,7 @@ overrides:
 patchedDependencies:
   shaka-player@5.1.12: 17d85e267c8958999207ce9d6c29a2ddf18734d0499fb30870ac8a55d90303fa
   vue-sonner@2.0.9: ae94d00b3ff46bede626a25ac5a36a6cd35987f33d73c14ffc73afbd5767f95c
-  youtubei.js@18.0.0: 0dcd01c7f812975961b3f68ef0f3bfac4bb13b2241b07bcbcc24b50f95475218
+  youtubei.js@18.0.0: 0b135b4394353469ed23f38c1f7c8d46790e2033a3b7e5adc4578cac5e480bb0
 
 importers:
 
@@ -88,7 +88,7 @@ importers:
         version: 4.1.0(vue@3.5.41(typescript@6.0.3))
       youtubei.js:
         specifier: ^18.0.0
-        version: 18.0.0(patch_hash=0dcd01c7f812975961b3f68ef0f3bfac4bb13b2241b07bcbcc24b50f95475218)
+        version: 18.0.0(patch_hash=0b135b4394353469ed23f38c1f7c8d46790e2033a3b7e5adc4578cac5e480bb0)
     devDependencies:
       '@babel/core':
         specifier: ^8.0.1
@@ -10753,7 +10753,7 @@ snapshots:
 
   yocto-queue@0.1.0: {}
 
-  youtubei.js@18.0.0(patch_hash=0dcd01c7f812975961b3f68ef0f3bfac4bb13b2241b07bcbcc24b50f95475218):
+  youtubei.js@18.0.0(patch_hash=0b135b4394353469ed23f38c1f7c8d46790e2033a3b7e5adc4578cac5e480bb0):
     dependencies:
       '@bufbuild/protobuf': 2.12.1
       fflate: 0.8.3

--- a/tests/unit/live-chat-replay-polling.test.mjs
+++ b/tests/unit/live-chat-replay-polling.test.mjs
@@ -106,7 +106,7 @@ test('replays hand their actions over without pacing them', async () => {
     continuation_contents: fakeContinuation({
       continuation: `AFTER_${callIndex}`,
       header: callIndex === 0 ? {} : null,
-      actions: [fakeReplayAction('60000'), fakeReplayAction('61000')],
+      actions: callIndex === 0 ? [] : [fakeReplayAction('60000'), fakeReplayAction('61000')],
     }),
   }))
 
@@ -117,6 +117,36 @@ test('replays hand their actions over without pacing them', async () => {
   // The smoothed queue would have spread these out over the next few seconds,
   // which is the wrong pacing for messages that carry their own player offsets.
   assert.deepEqual(updates, [fakeReplayAction('60000'), fakeReplayAction('61000')])
+})
+
+test('replays emit actions from responses that also contain headers', async () => {
+  const actions = [fakeReplayAction('1000'), fakeReplayAction('2000')]
+  const { liveChat, updates } = createReplay(() => ({
+    continuation_contents: fakeContinuation({ header: {}, actions }),
+  }))
+
+  liveChat.start()
+  await flush()
+
+  assert.deepEqual(updates, actions)
+})
+
+test('replays stop emitting a batch when a listener seeks', async () => {
+  const actions = [fakeReplayAction('60000'), fakeReplayAction('61000')]
+  const { liveChat, updates } = createReplay((args, callIndex) => ({
+    continuation_contents: fakeContinuation({
+      continuation: `AFTER_${callIndex}`,
+      header: callIndex === 0 ? {} : null,
+      actions: callIndex === 0 ? [] : actions,
+    }),
+  }))
+
+  liveChat.on('chat-update', () => liveChat.seekTo(120_000))
+  liveChat.start()
+  await flush()
+  await liveChat.pollNext()
+
+  assert.deepEqual(updates, actions.slice(0, 1))
 })
 
 test('seeking re-anchors the replay to the given player position', async () => {
@@ -292,6 +322,50 @@ test('concurrent polls share a transient failure retry sequence', async () => {
   assert.equal(requests[1].args.continuation, 'AFTER_0')
   assert.equal(requests[2].args.continuation, 'AFTER_0')
   assert.deepEqual(updates, [fakeReplayAction('5000')])
+})
+
+test('a new polling generation gets a fresh retry budget', async (t) => {
+  t.mock.method(globalThis, 'setTimeout', (callback) => {
+    queueMicrotask(callback)
+    return 0
+  })
+
+  const deliveredAction = fakeReplayAction('5000')
+  const { liveChat, requests, updates } = createReplay((args, callIndex) => {
+    if (callIndex > 0 && callIndex <= 11) {
+      throw new Error('temporary failure')
+    }
+
+    return {
+      continuation_contents: fakeContinuation({
+        continuation: `AFTER_${callIndex}`,
+        header: callIndex === 0 ? {} : null,
+        actions: callIndex === 12 ? [deliveredAction] : [],
+      }),
+    }
+  })
+
+  let ended = false
+  let invalidatedFailures = 0
+  liveChat.on('end', () => { ended = true })
+  liveChat.on('error', (error) => {
+    if (error.message === 'temporary failure' && invalidatedFailures < 10) {
+      invalidatedFailures++
+      liveChat.seekTo(invalidatedFailures * 1000)
+    }
+  })
+
+  liveChat.start()
+  await flush()
+
+  for (let generation = 0; generation < 10; generation++) {
+    await liveChat.pollNext()
+  }
+  await liveChat.pollNext()
+
+  assert.equal(ended, false)
+  assert.equal(requests.length, 13)
+  assert.deepEqual(updates, [deliveredAction])
 })
 
 test('switching views moves the chat onto the other continuation', async () => {


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Make sure to follow the contributing guidelines. -->
<!-- Important note, we may remove your pull request if you do not use this provided PR template correctly. -->
<!-- Agent instructions: Preserve every heading, comment, and marker in this template. Never remove or rewrite the release-note-category:start/end, release-note:start/end, or release-note-image:start/end marker pairs. -->

## Pull Request Type
<!-- Please select what type of pull request this is: [x] -->
- [x] Bugfix
- [ ] Feature Implementation
- [ ] Documentation
- [ ] Other

## Related issue
<!-- Please link the issue your pull request is referring to. -->
<!-- If this pull request fully resolves the relevant issue, put "closes" before the issue number. -->
<!-- Example: "closes #123456". -->

Follow-up to the outside-diff findings in the review of #990.

## Description
<!-- Please write a clear and concise description of what the pull request does. -->

Live chat replays could drop every action in a continuation when YouTube returned header metadata in the same response. A replay could also keep emitting the rest of an obsolete batch when a `chat-update` listener sought, changed the chat filter, or stopped playback. New polling generations inherited the retry budget spent by earlier generations, which could end a replay on their first failure.

This processes replay actions independently from header metadata, checks the replay generation before each action emit, and resets the retry budget when a new generation starts. Regression tests cover all three failure modes.

## Release note category
<!-- Select exactly one category. Every pull request must select one. -->
<!-- Select "Not noteworthy" when the pull request fixes a bug in or improves functionality that has not yet appeared in a stable release. -->
<!-- release-note-category:start -->
- [ ] Not noteworthy
- [ ] Highlights
- [ ] More improvements
- [x] Fixed bugs
<!-- release-note-category:end -->

## Release note
<!-- Required unless "Not noteworthy" is selected. -->
<!-- Write one concise, user-facing entry without a leading bullet. -->
<!-- release-note:start -->
Live chat replays no longer omit messages returned alongside chat metadata, continue showing stale messages after seeking, or stop retrying early after playback changes.
<!-- release-note:end -->

## Release note images
<!-- Optional. Paste one or more Markdown images, HTML image tags, or dark/light <picture> elements here. -->
<!-- The release notes normalize the markup and limit images taller than 300 pixels. -->
<!-- Agent instructions:
For a noteworthy visible change, add media when it makes the change easier to understand. Prefer a still image unless motion is the point; recordings must use animated WebP.
After implementing a visible change, proactively capture the result and show the local media to the user for approval before uploading it or updating the pull request.
When the affected UI differs between dark and light themes, capturing both themes is required. A dark-only image is incomplete. Run `node _scripts/releaseNoteMedia.mjs --dark DARK_FILE --light LIGHT_FILE --alt "DESCRIPTION"`; GitHub will display the matching theme and use dark as the fallback. Use a single default-dark capture only when the light theme cannot be captured or looks identical.
Capture or crop to the smallest region that still makes the change clear. Do not include the full window when the affected component can be understood on its own.
Use English unless localization is the subject. Keep components at their normal dimensions and placement instead of resizing them to fill the frame.
Use deterministic local fixtures for visible remote images. Reusable avatar and thumbnail fixtures are available through `e2e/helpers/visual-fixtures.mjs`. Before capturing, verify that every visible image has loaded successfully (`complete === true` and `naturalWidth > 0`).
Inspect the final dark and light files for failed images, missing content, unrelated UI, awkward animation, and misleading layout. Omit media when it does not explain the change clearly.
Check for personal information, tokens, private repository names, and unrelated desktop content before uploading. Uploaded media is public.
Keep capture-only scripts, test hooks, screenshots, and recordings out of commits. Remove them before committing unless the capture code is also a reusable regression test. Never commit generated release-note media.
Paste only the generated markup between the marker comments. Leave this section empty when media would not help.
-->
<!-- release-note-image:start -->

<!-- release-note-image:end -->

## Testing
<!-- How can reviewers verify that the PR produces correct results? -->
<!-- Please provide instructions so that others can ensure that your pull request would produce correct results. For examples see, https://github.com/FreeTubeApp/FreeTube/pull/5743, https://github.com/FreeTubeApp/FreeTube/pull/7349, https://github.com/FreeTubeApp/FreeTube/pull/5125, https://github.com/FreeTubeApp/FreeTube/pull/7338 -->
<!-- Agent instructions: Only write human-facing steps that explain how to verify the change while running this branch in dev mode. Include expected results and, when applicable, helpful console snippets for interactive verification. Do not include automated checks, commands, results, pass counts, or CI status. -->

1. Open a finished livestream with a busy live chat replay and start playback from the beginning.
2. Confirm that the first available chat messages appear when the replay starts.
3. Seek to another part of the video while chat messages are loading.
4. Confirm that messages from the old playback position stop appearing and the replay continues from the new position.

## Additional context
<!-- Add any other context about the pull request here. -->

CodeRabbit reported both bugs as outside-diff findings during the final review of #990. They came from the live-chat replay code added in #681, so they were split into this focused PR.

