### PR TITLE
fix: open mobile YouTube links in app

### DIFF
--- a/e2e/tests/offline/internal-link-shortcuts.spec.mjs
+++ b/e2e/tests/offline/internal-link-shortcuts.spec.mjs
@@ -7,6 +7,29 @@ async function historyLinkLabel(page) {
   return page.locator(`${sel.sideNavLink('history')}:visible`).first().locator('.navLabel')
 }
 
+test.describe('YouTube links', () => {
+  test.use({
+    seed: {
+      settings: { externalLinkHandling: 'openLinkAfterPrompt' }
+    }
+  })
+
+  test('opens mobile video links in the app', async ({ page }) => {
+    const link = page.locator('body').getByRole('link', { name: 'Mobile YouTube video' })
+    await page.locator('body').evaluate((body) => {
+      body.insertAdjacentHTML(
+        'beforeend',
+        '<a href="https://m.youtube.com/watch?v=jNQXAC9IVRw">Mobile YouTube video</a>'
+      )
+    })
+
+    await link.click()
+
+    await expect(page.getByText('Are you sure you want to open this link?')).not.toBeVisible()
+    await expect(page).toHaveURL(/#\/watch\/jNQXAC9IVRw/)
+  })
+})
+
 test('middle-clicking an internal link opens it in a background tab', async ({ page }) => {
   const linkLabel = await historyLinkLabel(page)
 

--- a/src/renderer/App.vue
+++ b/src/renderer/App.vue
@@ -3197,7 +3197,7 @@ function handleLinkClick(event, link) {
   event.preventDefault()
 
   // Check if it's a YouTube link, but exclude live chat pop out
-  const youtubeUrlPattern = /^https?:\/\/((www\.)?youtube\.com(\/embed)?|youtu\.be)\/(?!.*live_chat).*$/
+  const youtubeUrlPattern = /^https?:\/\/((www\.|m\.)?youtube\.com(\/embed)?|youtu\.be)\/(?!.*live_chat).*$/
   const isYoutubeLink = youtubeUrlPattern.test(href)
 
   // Determine if we should open in new tab or new window.


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Make sure to follow the contributing guidelines. -->
<!-- Important note, we may remove your pull request if you do not use this provided PR template correctly. -->
<!-- Agent instructions: Preserve every heading, comment, and marker in this template. Never remove or rewrite the release-note-category:start/end, release-note:start/end, or release-note-image:start/end marker pairs. -->

## Pull Request Type
<!-- Please select what type of pull request this is: [x] -->
- [x] Bugfix
- [ ] Feature Implementation
- [ ] Documentation
- [ ] Other

## Related issue
<!-- Please link the issue your pull request is referring to. -->
<!-- If this pull request fully resolves the relevant issue, put "closes" before the issue number. -->
<!-- Example: "closes #123456". -->

No related issue.

## Description
<!-- Please write a clear and concise description of what the pull request does. -->

Mobile YouTube links were treated as external links, so clicking them could show the external-link prompt and hand them to the browser. This adds `m.youtube.com` to the in-app YouTube URL matcher and covers the route with an offline regression test.

## Release note category
<!-- Select exactly one category. Every pull request must select one. -->
<!-- Select "Not noteworthy" when the pull request fixes a bug in or improves functionality that has not yet appeared in a stable release. -->
<!-- release-note-category:start -->
- [ ] Not noteworthy
- [ ] Highlights
- [ ] More improvements
- [x] Fixed bugs
<!-- release-note-category:end -->

## Release note
<!-- Required unless "Not noteworthy" is selected. -->
<!-- Write one concise, user-facing entry without a leading bullet. -->
<!-- release-note:start -->
Mobile YouTube links now open inside the app.
<!-- release-note:end -->

## Release note images
<!-- Optional. Paste one or more Markdown images, HTML image tags, or dark/light <picture> elements here. -->
<!-- The release notes normalize the markup and limit images taller than 300 pixels. -->
<!-- Agent instructions:
For a noteworthy visible change, add media when it makes the change easier to understand. Prefer a still image unless motion is the point; recordings must use animated WebP.
After implementing a visible change, proactively capture the result and show the local media to the user for approval before uploading it or updating the pull request.
When the affected UI differs between dark and light themes, capturing both themes is required. A dark-only image is incomplete. Run `node _scripts/releaseNoteMedia.mjs --dark DARK_FILE --light LIGHT_FILE --alt "DESCRIPTION"`; GitHub will display the matching theme and use dark as the fallback. Use a single default-dark capture only when the light theme cannot be captured or looks identical.
Capture or crop to the smallest region that still makes the change clear. Do not include the full window when the affected component can be understood on its own.
Use English unless localization is the subject. Keep components at their normal dimensions and placement instead of resizing them to fill the frame.
Use deterministic local fixtures for visible remote images. Reusable avatar and thumbnail fixtures are available through `e2e/helpers/visual-fixtures.mjs`. Before capturing, verify that every visible image has loaded successfully (`complete === true` and `naturalWidth > 0`).
Inspect the final dark and light files for failed images, missing content, unrelated UI, awkward animation, and misleading layout. Omit media when it does not explain the change clearly.
For one dark capture, run `node _scripts/releaseNoteMedia.mjs FILE --alt "DESCRIPTION"`.
Check for personal information, tokens, private repository names, and unrelated desktop content before uploading. Uploaded media is public.
Keep capture-only scripts, test hooks, screenshots, and recordings out of commits. Remove them before committing unless the capture code is also a reusable regression test. Never commit generated release-note media.
Paste only the generated markup between the marker comments. Leave this section empty when media would not help.
-->
<!-- release-note-image:start -->

<!-- release-note-image:end -->

## Testing
<!-- How can reviewers verify that the PR produces correct results? -->
<!-- Please provide instructions so that others can ensure that your pull request would produce correct results. For examples see, https://github.com/FreeTubeApp/FreeTube/pull/5743, https://github.com/FreeTubeApp/FreeTube/pull/7349, https://github.com/FreeTubeApp/FreeTube/pull/5125, https://github.com/FreeTubeApp/FreeTube/pull/7338 -->
<!-- Agent instructions: Only write human-facing steps that explain how to verify the change while running this branch in dev mode. Include expected results and, when applicable, helpful console snippets for interactive verification. Do not include automated checks, commands, results, pass counts, or CI status. -->

1. Set external-link handling to ask before opening links.
2. Open a page containing a mobile YouTube watch link and click it.
3. Confirm that the video opens in the current app tab without an external-link prompt or browser window.

## Additional context
<!-- Add any other context about the pull request here. -->
