### PR TITLE
fix: use main text color for upcoming premieres

### DIFF
--- a/e2e/tests/offline/playlists.spec.mjs
+++ b/e2e/tests/offline/playlists.spec.mjs
@@ -3,6 +3,8 @@ import path from 'node:path'
 
 import { test, expect, sel, goTo, goToSettingsSection } from '../../helpers/app.mjs'
 
+const seededPremiereStart = Date.now() + 86_400_000
+
 test.describe('playlist creation', () => {
   test('a playlist can be created through the UI', async ({ page }) => {
     await goTo(page, 'userplaylists')
@@ -58,8 +60,10 @@ test.describe('seeded playlists', () => {
               author: 'Test Channel',
               authorId: 'UC-test-channel-id',
               lengthSeconds: 120,
-              published: Date.now() + 86_400_000,
-              premiereDate: new Date(Date.now() + 86_400_000).toISOString(),
+              published: seededPremiereStart,
+              isUpcoming: true,
+              isPremiere: true,
+              premiereDate: new Date(seededPremiereStart).toISOString(),
               timeAdded: Date.now(),
               playlistItemId: 'e2e-item-2',
               type: 'video'
@@ -81,6 +85,24 @@ test.describe('seeded playlists', () => {
     await expect(page.getByText('Seeded video one')).toBeVisible()
     // Local playlists intentionally ignore the global hide-upcoming setting.
     await expect(page.getByText('Upcoming seeded premiere')).toBeVisible()
+  })
+
+  test('restores running premiere styling when the scheduled time arrives', async ({ page }) => {
+    await goTo(page, 'userplaylists')
+    await page.clock.install({ time: seededPremiereStart - 86_400_000 })
+    await page.getByText('My seeded playlist').click()
+
+    const card = page.locator('.ft-list-video').filter({ hasText: 'Upcoming seeded premiere' })
+    const title = card.getByText('Upcoming seeded premiere', { exact: true })
+    await page.locator('body').evaluate(element => {
+      element.style.setProperty('--primary-text-color', '#123456')
+      element.style.setProperty('--tertiary-text-color', '#654321')
+    })
+    await expect(title).toHaveCSS('color', 'rgb(18, 52, 86)')
+
+    await page.clock.fastForward(86_400_001)
+
+    await expect(title).toHaveCSS('color', 'rgb(101, 67, 33)')
   })
 
   test('playlist artwork keeps its native aspect ratio', async ({ page }) => {

--- a/e2e/tests/offline/subscriptions-feed.spec.mjs
+++ b/e2e/tests/offline/subscriptions-feed.spec.mjs
@@ -328,6 +328,19 @@ test.describe('subscriptions feed with upcoming premieres shown', () => {
     await expect(page.getByRole('option', { name: 'Add to Queue' })).toBeVisible()
   })
 
+  test('uses the main text color for an upcoming premiere title', async ({ page }) => {
+    await goTo(page, 'subscriptions')
+
+    const upcomingPremiere = page.locator('.ft-list-video').filter({ hasText: 'Upcoming premiere video' })
+    const title = upcomingPremiere.getByText('Upcoming premiere video', { exact: true })
+    await expect(title).toBeVisible()
+    await page.locator('body').evaluate(element => {
+      element.style.setProperty('--primary-text-color', '#123456')
+      element.style.setProperty('--tertiary-text-color', '#654321')
+    })
+    await expect(title).toHaveCSS('color', 'rgb(18, 52, 86)')
+  })
+
   test('toggles a reminder from the rightmost thumbnail action', async ({ app }) => {
     await app.electronApp.evaluate(({ Notification }) => {
       Notification.isSupported = () => true

--- a/src/renderer/components/FtListVideo/FtListVideo.vue
+++ b/src/renderer/components/FtListVideo/FtListVideo.vue
@@ -6,7 +6,7 @@
       grid: !effectiveListTypeIsList,
       [appearance]: true,
       watched: addWatchedStyle,
-      premiereVideo: isPremiere && !isUpcoming
+      premiereVideo: isPremiere && !isUpcomingForCurrentTime
     }"
   >
     <div
@@ -599,6 +599,10 @@ const isWatched = computed(() => isHistoryEntryWatched(historyEntry.value))
 
 const premiereTimestamp = computed(() => getUpcomingPremiereTimestamp(props.data))
 const premiereNow = ref(Date.now())
+const isUpcomingForCurrentTime = computed(() => (
+  isUpcoming.value &&
+  (premiereTimestamp.value == null || premiereTimestamp.value > premiereNow.value)
+))
 const MAX_TIMEOUT_DELAY = 2_147_483_647
 let premiereStartTimer = null
 

--- a/src/renderer/components/FtListVideo/FtListVideo.vue
+++ b/src/renderer/components/FtListVideo/FtListVideo.vue
@@ -6,7 +6,7 @@
       grid: !effectiveListTypeIsList,
       [appearance]: true,
       watched: addWatchedStyle,
-      premiereVideo: isPremiere || isUpcoming
+      premiereVideo: isPremiere && !isUpcoming
     }"
   >
     <div


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Make sure to follow the contributing guidelines. -->
<!-- Important note, we may remove your pull request if you do not use this provided PR template correctly. -->
<!-- Agent instructions: Preserve every heading, comment, and marker in this template. Never remove or rewrite the release-note-category:start/end, release-note:start/end, or release-note-image:start/end marker pairs. -->

## Pull Request Type
<!-- Please select what type of pull request this is: [x] -->
- [x] Bugfix
- [ ] Feature Implementation
- [ ] Documentation
- [ ] Other

## Related issue
<!-- Please link the issue your pull request is referring to. -->
<!-- If this pull request fully resolves the relevant issue, put "closes" before the issue number. -->
<!-- Example: "closes #123456". -->

Closes #1002

## Description
<!-- Please write a clear and concise description of what the pull request does. -->

Upcoming premiere titles were forced to use the Subtle Text theme color, so changing Main Text in a custom theme had no effect on them. This limits the existing subtle premiere styling to running premieres, allowing upcoming premiere titles to use the normal Main Text color.

## Release note category
<!-- Select exactly one category. Every pull request must select one. -->
<!-- Select "Not noteworthy" when the pull request fixes a bug in or improves functionality that has not yet appeared in a stable release. -->
<!-- release-note-category:start -->
- [ ] Not noteworthy
- [ ] Highlights
- [ ] More improvements
- [x] Fixed bugs
<!-- release-note-category:end -->

## Release note
<!-- Required unless "Not noteworthy" is selected. -->
<!-- Write one concise, user-facing entry without a leading bullet. -->
<!-- release-note:start -->
Upcoming premiere titles now follow the Main Text color in custom themes.
<!-- release-note:end -->

## Release note images
<!-- Optional. Paste one or more Markdown images, HTML image tags, or dark/light <picture> elements here. -->
<!-- The release notes normalize the markup and limit images taller than 300 pixels. -->
<!-- Agent instructions:
For a noteworthy visible change, add media when it makes the change easier to understand. Prefer a still image unless motion is the point; recordings must use animated WebP.
After implementing a visible change, proactively capture the result and show the local media to the user for approval before uploading it or updating the pull request.
When the affected UI differs between dark and light themes, capturing both themes is required. A dark-only image is incomplete. Run `node _scripts/releaseNoteMedia.mjs --dark DARK_FILE --light LIGHT_FILE --alt "DESCRIPTION"`; GitHub will display the matching theme and use dark as the fallback. Use a single default-dark capture only when the light theme cannot be captured or looks identical.
Capture or crop to the smallest region that still makes the change clear. Do not include the full window when the affected component can be understood on its own.
Use English unless localization is the subject. Keep components at their normal dimensions and placement instead of resizing them to fill the frame.
Use deterministic local fixtures for visible remote images. Reusable avatar and thumbnail fixtures are available through `e2e/helpers/visual-fixtures.mjs`. Before capturing, verify that every visible image has loaded successfully (`complete === true` and `naturalWidth > 0`).
Inspect the final dark and light files for failed images, missing content, unrelated UI, awkward animation, and misleading layout. Omit media when it does not explain the change clearly.
For one dark capture, run `node _scripts/releaseNoteMedia.mjs FILE --alt "DESCRIPTION"`.
Check for personal information, tokens, private repository names, and unrelated desktop content before uploading. Uploaded media is public.
Keep capture-only scripts, test hooks, screenshots, and recordings out of commits. Remove them before committing unless the capture code is also a reusable regression test. Never commit generated release-note media.
Paste only the generated markup between the marker comments. Leave this section empty when media would not help.
-->
<!-- release-note-image:start -->

<!-- release-note-image:end -->

## Testing
<!-- How can reviewers verify that the PR produces correct results? -->
<!-- Please provide instructions so that others can ensure that your pull request would produce correct results. For examples see, https://github.com/FreeTubeApp/FreeTube/pull/5743, https://github.com/FreeTubeApp/FreeTube/pull/7349, https://github.com/FreeTubeApp/FreeTube/pull/5125, https://github.com/FreeTubeApp/FreeTube/pull/7338 -->
<!-- Agent instructions: Only write human-facing steps that explain how to verify the change while running this branch in dev mode. Include expected results and, when applicable, helpful console snippets for interactive verification. Do not include automated checks, commands, results, pass counts, or CI status. -->

1. Open Settings > Appearance > Theme and edit or create a custom theme.
2. Set Main Text and Subtle Text to clearly different colors, then save and apply the theme.
3. Open a feed containing an upcoming premiere.
4. Confirm that the upcoming premiere title uses Main Text. Running premiere cards should retain their previous subtle styling.

## Additional context
<!-- Add any other context about the pull request here. -->

The regression test assigns distinct Main Text and Subtle Text variables before checking the computed title color.
