### PR TITLE
fix: reuse open tabs from Continue Watching

### DIFF
--- a/e2e/tests/offline/home.spec.mjs
+++ b/e2e/tests/offline/home.spec.mjs
@@ -270,6 +270,32 @@ test('opens the subscriptions New feed from its Home summary', async ({ page }) 
   await expect(page).toHaveURL(/#\/subscriptions\?tab=videos$/)
 })
 
+test('activates an existing video tab from Continue watching', async ({ page }) => {
+  await goTo(page, 'home')
+
+  const homeTabId = await page.locator('.tab.active').getAttribute('data-tab-id')
+  const videoTab = await page.evaluate(() => window.ftElectron.tabs.create({
+    route: '/watch/homevideo01',
+    title: 'Partly watched video',
+    makeActive: false,
+    lazyLoad: true
+  }))
+  await expect(page.locator('.tab')).toHaveCount(2)
+
+  await page.locator('[data-home-section="continueWatching"]')
+    .getByRole('link', { name: /Partly watched video/ })
+    .click()
+
+  await expect.poll(async () => page.evaluate(() => window.ftElectron.tabs.getState()))
+    .toMatchObject({
+      activeTabId: videoTab.id,
+      tabs: [
+        { id: homeTabId, route: { fullPath: '/home' } },
+        { id: videoTab.id, route: { fullPath: '/watch/homevideo01' } }
+      ]
+    })
+})
+
 test('shows recent active and completed downloads', async ({ page }) => {
   await goTo(page, 'home')
   await page.evaluate(() => {

--- a/e2e/tests/offline/home.spec.mjs
+++ b/e2e/tests/offline/home.spec.mjs
@@ -294,6 +294,22 @@ test('activates an existing video tab from Continue watching', async ({ page }) 
         { id: videoTab.id, route: { fullPath: '/watch/homevideo01' } }
       ]
     })
+
+  await page.evaluate(tabId => window.ftElectron.tabs.close(tabId), videoTab.id)
+  await expect(page.locator('.tab')).toHaveCount(1)
+  await expect(page).toHaveURL(/#\/home$/)
+
+  await page.locator('[data-home-section="continueWatching"]')
+    .getByRole('link', { name: /Partly watched video/ })
+    .click()
+
+  await expect(page).toHaveURL(/#\/watch\/homevideo01$/)
+  await expect(page.locator('.tab')).toHaveCount(1)
+  await expect.poll(async () => page.evaluate(() => window.ftElectron.tabs.getState()))
+    .toMatchObject({
+      activeTabId: homeTabId,
+      tabs: [{ id: homeTabId, route: { fullPath: '/watch/homevideo01' } }]
+    })
 })
 
 test('shows recent active and completed downloads', async ({ page }) => {

--- a/src/main/tabs/TabManager.js
+++ b/src/main/tabs/TabManager.js
@@ -33,6 +33,7 @@ import {
   TAB_PREVIEW_JPEG_QUALITY,
   tabPreviewBufferToDataUrl
 } from './tabPreviewCache.js'
+import { isTabActivatable } from './tabAvailability.js'
 import {
   cropTabPreviewToContent,
   getTabPreviewTargetSize,
@@ -1228,18 +1229,23 @@ export class TabManager {
   }
 
   /**
+   * @param {TabInfo | undefined} tab
+   * @returns {boolean}
+   */
+  _isTabActivatable(tab) {
+    return isTabActivatable(
+      tab,
+      this._deferredCloseTabIds,
+      this._deferredUnloadTabIds
+    )
+  }
+
+  /**
    * @param {string} tabId
    */
   activateTab(tabId) {
     const tab = this.tabs.get(tabId)
-    if (
-      !tab ||
-      tab.isTransferStaged === true ||
-      this._deferredCloseTabIds.has(tabId) ||
-      this._deferredUnloadTabIds.has(tabId)
-    ) {
-      return
-    }
+    if (!this._isTabActivatable(tab)) return
 
     const previousActiveId = this.activeTabId
     if (
@@ -2923,6 +2929,7 @@ export class TabManager {
         title: tab.title,
         avatarUrl: tab.avatarDataUrl,
         isActive: tab.id === this.activeTabId,
+        isActivatable: this._isTabActivatable(tab),
         isUnloaded: tab.loadState === 'unloaded',
         isLoading: this._getTabLoadingState(tab),
         isPlaying: tab.isPlaying || false,

--- a/src/main/tabs/tabAvailability.js
+++ b/src/main/tabs/tabAvailability.js
@@ -1,0 +1,12 @@
+/**
+ * @param {{ id: string, isTransferStaged?: boolean } | undefined} tab
+ * @param {Set<string>} deferredCloseTabIds
+ * @param {Set<string>} deferredUnloadTabIds
+ * @returns {boolean}
+ */
+export function isTabActivatable(tab, deferredCloseTabIds, deferredUnloadTabIds) {
+  return tab != null &&
+    tab.isTransferStaged !== true &&
+    !deferredCloseTabIds.has(tab.id) &&
+    !deferredUnloadTabIds.has(tab.id)
+}

--- a/src/renderer/views/Home/Home.vue
+++ b/src/renderer/views/Home/Home.vue
@@ -615,7 +615,9 @@ function activateExistingContinueWatchingTab(event, videoId) {
     return
   }
 
-  const videoTab = store.getters.getTabs.find(tab => tab.route.path === `/watch/${videoId}`)
+  const videoTab = store.getters.getTabs.find(tab => (
+    tab.isActivatable && tab.route.path === `/watch/${videoId}`
+  ))
   if (videoTab == null) { return }
 
   event.preventDefault()

--- a/src/renderer/views/Home/Home.vue
+++ b/src/renderer/views/Home/Home.vue
@@ -107,7 +107,10 @@
                 v-for="video in items"
                 :key="video.videoId"
               >
-                <RouterLink :to="`/watch/${video.videoId}`">
+                <RouterLink
+                  :to="`/watch/${video.videoId}`"
+                  @click.capture="activateExistingContinueWatchingTab($event, video.videoId)"
+                >
                   <span class="mediaThumbnail">
                     <FtRetryImage
                       :src="videoThumbnail(video)"
@@ -598,6 +601,25 @@ function watchProgressPercent(video) {
   }
 
   return `${Math.min(100, Math.max(0, progress / duration * 100))}%`
+}
+
+function activateExistingContinueWatchingTab(event, videoId) {
+  if (
+    !IS_ELECTRON ||
+    event.button !== 0 ||
+    event.ctrlKey ||
+    event.metaKey ||
+    event.shiftKey ||
+    event.altKey
+  ) {
+    return
+  }
+
+  const videoTab = store.getters.getTabs.find(tab => tab.route.path === `/watch/${videoId}`)
+  if (videoTab == null) { return }
+
+  event.preventDefault()
+  store.dispatch('activateTab', videoTab.id)
 }
 
 function setSectionVisibility(sectionId, visible) {

--- a/tests/unit/tab-availability.test.mjs
+++ b/tests/unit/tab-availability.test.mjs
@@ -1,0 +1,21 @@
+import assert from 'node:assert/strict'
+import test from 'node:test'
+
+import { isTabActivatable } from '../../src/main/tabs/tabAvailability.js'
+
+const tab = { id: 'video-tab' }
+
+test('reports normal tabs as activatable', () => {
+  assert.equal(isTabActivatable(tab, new Set(), new Set()), true)
+})
+
+test('rejects tabs that cannot be activated', () => {
+  assert.equal(isTabActivatable(undefined, new Set(), new Set()), false)
+  assert.equal(isTabActivatable(
+    { ...tab, isTransferStaged: true },
+    new Set(),
+    new Set()
+  ), false)
+  assert.equal(isTabActivatable(tab, new Set([tab.id]), new Set()), false)
+  assert.equal(isTabActivatable(tab, new Set(), new Set([tab.id])), false)
+})


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Make sure to follow the contributing guidelines. -->
<!-- Important note, we may remove your pull request if you do not use this provided PR template correctly. -->
<!-- Agent instructions: Preserve every heading, comment, and marker in this template. Never remove or rewrite the release-note-category:start/end, release-note:start/end, or release-note-image:start/end marker pairs. -->

## Pull Request Type
<!-- Please select what type of pull request this is: [x] -->
- [x] Bugfix
- [ ] Feature Implementation
- [ ] Documentation
- [ ] Other

## Related issue
<!-- Please link the issue your pull request is referring to. -->
<!-- If this pull request fully resolves the relevant issue, put "closes" before the issue number. -->
<!-- Example: "closes #123456". -->

None.

## Description
<!-- Please write a clear and concise description of what the pull request does. -->

Clicking a Continue Watching video that was already open replaced the Home tab with a duplicate video view. Continue Watching now activates the existing video tab while leaving ordinary clicks and modifier shortcuts unchanged when no matching tab is open.

## Release note category
<!-- Select exactly one category. Every pull request must select one. -->
<!-- Select "Not noteworthy" when the pull request fixes a bug in or improves functionality that has not yet appeared in a stable release. -->
<!-- release-note-category:start -->
- [x] Not noteworthy
- [ ] Highlights
- [ ] More improvements
- [ ] Fixed bugs
<!-- release-note-category:end -->

## Release note
<!-- Required unless "Not noteworthy" is selected. -->
<!-- Write one concise, user-facing entry without a leading bullet. -->
<!-- release-note:start -->

<!-- release-note:end -->

## Release note images
<!-- Optional. Paste one or more Markdown images, HTML image tags, or dark/light <picture> elements here. -->
<!-- The release notes normalize the markup and limit images taller than 300 pixels. -->
<!-- Agent instructions:
For a noteworthy visible change, add media when it makes the change easier to understand. Prefer a still image unless motion is the point; recordings must use animated WebP.
After implementing a visible change, proactively capture the result and show the local media to the user for approval before uploading it or updating the pull request.
When the affected UI differs between dark and light themes, capturing both themes is required. A dark-only image is incomplete. Run `node _scripts/releaseNoteMedia.mjs --dark DARK_FILE --light LIGHT_FILE --alt "DESCRIPTION"`; GitHub will display the matching theme and use dark as the fallback. Use a single default-dark capture only when the light theme cannot be captured or looks identical.
Capture or crop to the smallest region that still makes the change clear. Do not include the full window when the affected component can be understood on its own.
Use English unless localization is the subject. Keep components at their normal dimensions and placement instead of resizing them to fill the frame.
Use deterministic local fixtures for visible remote images. Reusable avatar and thumbnail fixtures are available through `e2e/helpers/visual-fixtures.mjs`. Before capturing, verify that every visible image has loaded successfully (`complete === true` and `naturalWidth > 0`).
Inspect the final dark and light files for failed images, missing content, unrelated UI, awkward animation, and misleading layout. Omit media when it does not explain the change clearly.
For one dark capture, run `node _scripts/releaseNoteMedia.mjs FILE --alt "DESCRIPTION"`.
Check for personal information, tokens, private repository names, and unrelated desktop content before uploading. Uploaded media is public.
Keep capture-only scripts, test hooks, screenshots, and recordings out of commits. Remove them before committing unless the capture code is also a reusable regression test. Never commit generated release-note media.
Paste only the generated markup between the marker comments. Leave this section empty when media would not help.
-->
<!-- release-note-image:start -->

<!-- release-note-image:end -->

## Testing
<!-- How can reviewers verify that the PR produces correct results? -->
<!-- Please provide instructions so that others can ensure that your pull request would produce correct results. For examples see, https://github.com/FreeTubeApp/FreeTube/pull/5743, https://github.com/FreeTubeApp/FreeTube/pull/7349, https://github.com/FreeTubeApp/FreeTube/pull/5125, https://github.com/FreeTubeApp/FreeTube/pull/7338 -->
<!-- Agent instructions: Only write human-facing steps that explain how to verify the change while running this branch in dev mode. Include expected results and, when applicable, helpful console snippets for interactive verification. Do not include automated checks, commands, results, pass counts, or CI status. -->

1. Partially watch a video so it appears under Continue Watching on Home.
2. Keep that video open in one tab, then switch to the Home tab.
3. Click the same video under Continue Watching.
4. Confirm the existing video tab becomes active and the Home tab remains open without a duplicate video tab.
5. Close the video tab and click the Continue Watching entry again. Confirm it opens normally in the current tab.

## Additional context
<!-- Add any other context about the pull request here. -->

None.
