### PR TITLE
fix(scroll): keep custom speeds smooth

### DIFF
--- a/e2e/tests/offline/scrollbar-overlay.spec.mjs
+++ b/e2e/tests/offline/scrollbar-overlay.spec.mjs
@@ -18,6 +18,46 @@ async function addPageOverflow(page) {
   await expect.poll(() => pageOverflows(page)).toBe(true)
 }
 
+async function recordCustomSpeedPageScroll(page) {
+  await addPageOverflow(page)
+  await page.evaluate(() => {
+    const store = document.querySelector('#app').__vue_app__.config.globalProperties.$store
+    store.commit('setScrollSpeed', 200)
+    window.__scrollSpeedAnimationPositions = []
+    document.addEventListener('scroll', () => {
+      window.__scrollSpeedAnimationPositions.push(window.scrollY)
+    })
+  })
+}
+
+async function addNestedCustomSpeedScroller(page, attribute, scrollTop) {
+  await page.evaluate(({ attribute, scrollTop }) => {
+    const viewport = document.createElement('div')
+    viewport.setAttribute(attribute, '')
+    Object.assign(viewport.style, {
+      height: '100px',
+      left: '100px',
+      overflowY: 'auto',
+      position: 'fixed',
+      top: '100px',
+      width: '200px',
+      zIndex: '9999',
+    })
+    const content = document.createElement('div')
+    content.style.height = '300px'
+    viewport.append(content)
+    document.body.append(viewport)
+
+    const app = document.querySelector('#app').__vue_app__
+    const store = app.config.globalProperties.$store
+    app._context.directives['overlay-scrollbars'].mounted(viewport, { value: true })
+    store.commit('setScrollSpeed', 200)
+    viewport.scrollTop = scrollTop
+  }, { attribute, scrollTop })
+
+  return page.locator(`[${attribute}]`)
+}
+
 test.describe('overlay scrollbars', () => {
   test('the main scroll container reserves no layout space for its scrollbar', async ({ page }) => {
     await addPageOverflow(page)
@@ -49,6 +89,54 @@ test.describe('overlay scrollbars', () => {
       window.__scrollSpeedTestDelta > 0 &&
       window.scrollY === window.__scrollSpeedTestDelta * 2
     ))).toBe(true)
+  })
+
+  test('animates wheel scrolling at a custom speed', async ({ page }) => {
+    await recordCustomSpeedPageScroll(page)
+
+    await page.mouse.move(800, 400)
+    await page.mouse.wheel(0, 120)
+    await expect.poll(() => page.evaluate(() => window.scrollY)).toBe(240)
+
+    const positions = await page.evaluate(() => window.__scrollSpeedAnimationPositions)
+    expect(new Set(positions).size).toBeGreaterThan(2)
+  })
+
+  test('preserves a burst of wheel deltas while custom scrolling is animated', async ({ page }) => {
+    await addPageOverflow(page)
+    await page.evaluate(() => {
+      const store = document.querySelector('#app').__vue_app__.config.globalProperties.$store
+      store.commit('setScrollSpeed', 200)
+
+      for (let index = 0; index < 3; index++) {
+        document.body.dispatchEvent(new WheelEvent('wheel', {
+          bubbles: true,
+          cancelable: true,
+          deltaY: 120,
+        }))
+      }
+    })
+
+    await expect.poll(() => page.evaluate(() => window.scrollY)).toBe(720)
+  })
+
+  test('reverses a pending custom-speed scroll at the current boundary', async ({ page }) => {
+    await addPageOverflow(page)
+    await page.evaluate(() => {
+      const store = document.querySelector('#app').__vue_app__.config.globalProperties.$store
+      store.commit('setScrollSpeed', 200)
+
+      for (const deltaY of [120, -120]) {
+        document.body.dispatchEvent(new WheelEvent('wheel', {
+          bubbles: true,
+          cancelable: true,
+          deltaY,
+        }))
+      }
+    })
+
+    await page.waitForTimeout(300)
+    expect(await page.evaluate(() => window.scrollY)).toBe(0)
   })
 
   test('the page scrollbar stays on the content side of right vertical tabs', async ({ page }) => {
@@ -270,35 +358,18 @@ test.describe('overlay scrollbars', () => {
 
     test('bubbles scaled wheel input from a nested boundary to the page', async ({ page }) => {
       await addPageOverflow(page)
+      const viewport = await addNestedCustomSpeedScroller(
+        page,
+        'data-scroll-speed-bubble-test',
+        200
+      )
       await page.evaluate(() => {
-        const viewport = document.createElement('div')
-        viewport.dataset.scrollSpeedBubbleTest = ''
-        Object.assign(viewport.style, {
-          height: '100px',
-          left: '100px',
-          overflowY: 'auto',
-          position: 'fixed',
-          top: '100px',
-          width: '200px',
-          zIndex: '9999',
-        })
-        const content = document.createElement('div')
-        content.style.height = '300px'
-        viewport.append(content)
-        document.body.append(viewport)
-
-        const app = document.querySelector('#app').__vue_app__
-        const store = app.config.globalProperties.$store
-        app._context.directives['overlay-scrollbars'].mounted(viewport, { value: true })
-        store.commit('setScrollSpeed', 200)
-        viewport.scrollTop = viewport.scrollHeight
         window.scrollTo(0, 0)
         document.addEventListener('wheel', (event) => {
           window.__scrollSpeedBubbleTestDelta = event.deltaY
         }, { capture: true, once: true })
       })
 
-      const viewport = page.locator('[data-scroll-speed-bubble-test]')
       await viewport.hover()
       await page.mouse.wheel(0, 120)
 
@@ -306,6 +377,31 @@ test.describe('overlay scrollbars', () => {
         window.__scrollSpeedBubbleTestDelta > 0 &&
         window.scrollY === window.__scrollSpeedBubbleTestDelta * 2
       ))).toBe(true)
+    })
+
+    test('hands a wheel burst to the page at a pending nested boundary', async ({ page }) => {
+      await addPageOverflow(page)
+      const viewport = await addNestedCustomSpeedScroller(
+        page,
+        'data-scroll-speed-burst-boundary-test',
+        150
+      )
+      await viewport.evaluate((element) => {
+        window.scrollTo(0, 0)
+
+        for (let index = 0; index < 2; index++) {
+          element.dispatchEvent(new WheelEvent('wheel', {
+            bubbles: true,
+            cancelable: true,
+            deltaY: 50,
+          }))
+        }
+      })
+
+      await expect.poll(async () => ({
+        page: await page.evaluate(() => window.scrollY),
+        viewport: await viewport.evaluate((element) => element.scrollTop),
+      }), { timeout: 2000 }).toEqual({ page: 100, viewport: 200 })
     })
 
     test('reconciles an end position after the viewport grows', async ({ page }) => {
@@ -396,5 +492,20 @@ test.describe('overlay scrollbars', () => {
     // Roughly, not exactly: flipping the switch also reflows the settings page
     // a little by revealing the "changed setting" indicator.
     expect(await page.evaluate(() => window.scrollY)).toBeGreaterThan(250)
+  })
+})
+
+test.describe('overlay scrollbars with smooth scrolling disabled', () => {
+  test.use({ seed: { settings: { disableSmoothScrolling: true } } })
+
+  test('keeps custom-speed wheel scrolling immediate', async ({ page }) => {
+    await recordCustomSpeedPageScroll(page)
+
+    await page.mouse.move(800, 400)
+    await page.mouse.wheel(0, 120)
+
+    await expect.poll(() => page.evaluate(
+      () => window.__scrollSpeedAnimationPositions
+    )).toEqual([240])
   })
 })

--- a/e2e/tests/offline/scrollbar-overlay.spec.mjs
+++ b/e2e/tests/offline/scrollbar-overlay.spec.mjs
@@ -404,6 +404,31 @@ test.describe('overlay scrollbars', () => {
       }), { timeout: 2000 }).toEqual({ page: 100, viewport: 200 })
     })
 
+    test('reverses a pending scroll after the content shrinks', async ({ page }) => {
+      const viewport = await addNestedCustomSpeedScroller(
+        page,
+        'data-scroll-speed-shrink-test',
+        100
+      )
+      await viewport.evaluate((element) => {
+        element.dispatchEvent(new WheelEvent('wheel', {
+          bubbles: true,
+          cancelable: true,
+          deltaY: 50,
+        }))
+        element.firstElementChild.style.height = '200px'
+        element.dispatchEvent(new WheelEvent('wheel', {
+          bubbles: true,
+          cancelable: true,
+          deltaY: -25,
+        }))
+      })
+
+      await expect.poll(() => viewport.evaluate(
+        (element) => element.scrollTop
+      )).toBe(50)
+    })
+
     test('reconciles an end position after the viewport grows', async ({ page }) => {
       await page.evaluate(() => {
         const viewport = document.createElement('div')

--- a/src/renderer/helpers/scrollSpeed.js
+++ b/src/renderer/helpers/scrollSpeed.js
@@ -26,6 +26,16 @@ export function normalizeScrollSpeed(value) {
  * @returns {() => void} removes the listener
  */
 export function addScrollSpeedHandler(element, getScrollSpeed) {
+  // Repeated smooth relative scrolls use the element's current position,
+  // which loses wheel deltas that arrive before the animation advances. Keep
+  // the destination separately so every delta extends the same animation.
+  const smoothTargets = { x: null, y: null }
+
+  const clearSmoothTargets = () => {
+    smoothTargets.x = null
+    smoothTargets.y = null
+  }
+
   const handleWheel = (event) => {
     if (event.defaultPrevented || event.ctrlKey || event.metaKey) {
       return
@@ -41,7 +51,13 @@ export function addScrollSpeedHandler(element, getScrollSpeed) {
       return
     }
 
-    if (!canScroll(element, wheel.axis, wheel.delta)) {
+    const position = wheel.axis === 'x' ? element.scrollLeft : element.scrollTop
+    const maximum = wheel.axis === 'x'
+      ? element.scrollWidth - element.clientWidth
+      : element.scrollHeight - element.clientHeight
+    const target = smoothTargets[wheel.axis] ?? position
+
+    if (!canMoveScrollTarget(target, maximum, wheel.delta)) {
       if (hasContainedOverscroll(element, wheel.axis)) {
         // The default scroll is canceled at a contained boundary. Parent
         // handlers see defaultPrevented and leave the page in place.
@@ -53,13 +69,23 @@ export function addScrollSpeedHandler(element, getScrollSpeed) {
     event.preventDefault()
     const distance = wheelDeltaInPixels(event, element, wheel.axis, wheel.delta) *
       speed / DEFAULT_SCROLL_SPEED
-    element.scrollBy(wheel.axis === 'x'
-      ? { left: distance }
-      : { top: distance })
+    smoothTargets[wheel.axis] = Math.min(
+      Math.max(target + distance, 0),
+      maximum
+    )
+    element.scrollTo({
+      behavior: 'smooth',
+      left: smoothTargets.x ?? element.scrollLeft,
+      top: smoothTargets.y ?? element.scrollTop
+    })
   }
 
   element.addEventListener('wheel', handleWheel, { passive: false })
-  return () => element.removeEventListener('wheel', handleWheel)
+  element.addEventListener('scrollend', clearSmoothTargets)
+  return () => {
+    element.removeEventListener('wheel', handleWheel)
+    element.removeEventListener('scrollend', clearSmoothTargets)
+  }
 }
 
 /**
@@ -91,16 +117,12 @@ function hasContainedOverscroll(element, axis) {
 }
 
 /**
- * @param {HTMLElement} element
- * @param {'x' | 'y'} axis
+ * @param {number} target
+ * @param {number} maximum
  * @param {number} delta
  */
-function canScroll(element, axis, delta) {
-  const position = axis === 'x' ? element.scrollLeft : element.scrollTop
-  const maximum = axis === 'x'
-    ? element.scrollWidth - element.clientWidth
-    : element.scrollHeight - element.clientHeight
-  return maximum > 0 && (delta < 0 ? position > 0 : position < maximum)
+function canMoveScrollTarget(target, maximum, delta) {
+  return maximum > 0 && (delta < 0 ? target > 0 : target < maximum)
 }
 
 /**

--- a/src/renderer/helpers/scrollSpeed.js
+++ b/src/renderer/helpers/scrollSpeed.js
@@ -55,7 +55,10 @@ export function addScrollSpeedHandler(element, getScrollSpeed) {
     const maximum = wheel.axis === 'x'
       ? element.scrollWidth - element.clientWidth
       : element.scrollHeight - element.clientHeight
-    const target = smoothTargets[wheel.axis] ?? position
+    const target = Math.min(
+      Math.max(smoothTargets[wheel.axis] ?? position, 0),
+      maximum
+    )
 
     if (!canMoveScrollTarget(target, maximum, wheel.delta)) {
       if (hasContainedOverscroll(element, wheel.axis)) {


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Make sure to follow the contributing guidelines. -->
<!-- Important note, we may remove your pull request if you do not use this provided PR template correctly. -->
<!-- Agent instructions: Preserve every heading, comment, and marker in this template. Never remove or rewrite the release-note-category:start/end, release-note:start/end, or release-note-image:start/end marker pairs. -->

## Pull Request Type
<!-- Please select what type of pull request this is: [x] -->
- [x] Bugfix
- [ ] Feature Implementation
- [ ] Documentation
- [ ] Other

## Related issue
<!-- Please link the issue your pull request is referring to. -->
<!-- If this pull request fully resolves the relevant issue, put "closes" before the issue number. -->
<!-- Example: "closes #123456". -->

## Description
<!-- Please write a clear and concise description of what the pull request does. -->
Setting scroll speed to anything other than 100% replaced Chromium's smooth wheel scrolling with immediate JavaScript jumps.

Custom-speed wheel input now animates toward an accumulated, bounded target. Rapid wheel events keep their full distance, direction reversals update the pending target, and nested scrollers hand input to the page as soon as their pending target reaches the boundary.

## Release note category
<!-- Select exactly one category. Every pull request must select one. -->
<!-- Select "Not noteworthy" when the pull request fixes a bug in or improves functionality that has not yet appeared in a stable release. -->
<!-- release-note-category:start -->
- [x] Not noteworthy
- [ ] Highlights
- [ ] More improvements
- [ ] Fixed bugs
<!-- release-note-category:end -->

## Release note
<!-- Required unless "Not noteworthy" is selected. -->
<!-- Write one concise, user-facing entry without a leading bullet. -->
<!-- release-note:start -->

<!-- release-note:end -->

## Release note images
<!-- Optional. Paste one or more Markdown images, HTML image tags, or dark/light <picture> elements here. -->
<!-- The release notes normalize the markup and limit images taller than 300 pixels. -->
<!-- Agent instructions:
For a noteworthy visible change, add media when it makes the change easier to understand. Prefer a still image unless motion is the point; recordings must use animated WebP.
After implementing a visible change, proactively capture the result and show the local media to the user for approval before uploading it or updating the pull request.
When the affected UI differs between dark and light themes, capturing both themes is required. A dark-only image is incomplete. Run `node _scripts/releaseNoteMedia.mjs --dark DARK_FILE --light LIGHT_FILE --alt "DESCRIPTION"`; GitHub will display the matching theme and use dark as the fallback. Use a single default-dark capture only when the light theme cannot be captured or looks identical.
Capture or crop to the smallest region that still makes the change clear. Do not include the full window when the affected component can be understood on its own.
Use English unless localization is the subject. Keep components at their normal dimensions and placement instead of resizing them to fill the frame.
Use deterministic local fixtures for visible remote images. Reusable avatar and thumbnail fixtures are available through `e2e/helpers/visual-fixtures.mjs`. Before capturing, verify that every visible image has loaded successfully (`complete === true` and `naturalWidth > 0`).
Inspect the final dark and light files for failed images, missing content, unrelated UI, awkward animation, and misleading layout. Omit media when it does not explain the change clearly.
For one dark capture, run `node _scripts/releaseNoteMedia.mjs FILE --alt "DESCRIPTION"`.
Check for personal information, tokens, private repository names, and unrelated desktop content before uploading. Uploaded media is public.
Keep capture-only scripts, test hooks, screenshots, and recordings out of commits. Remove them before committing unless the capture code is also a reusable regression test. Never commit generated release-note media.
Paste only the generated markup between the marker comments. Leave this section empty when media would not help.
-->
<!-- release-note-image:start -->

<!-- release-note-image:end -->

## Testing
<!-- How can reviewers verify that the PR produces correct results? -->
<!-- Please provide instructions so that others can ensure that your pull request would produce correct results. For examples see, https://github.com/FreeTubeApp/FreeTube/pull/5743, https://github.com/FreeTubeApp/FreeTube/pull/7349, https://github.com/FreeTubeApp/FreeTube/pull/5125, https://github.com/FreeTubeApp/FreeTube/pull/7338 -->
<!-- Agent instructions: Only write human-facing steps that explain how to verify the change while running this branch in dev mode. Include expected results and, when applicable, helpful console snippets for interactive verification. Do not include automated checks, commands, results, pass counts, or CI status. -->
1. Set Scroll Speed to 50% or 200%, then use the wheel on a long page. The configured distance should be applied through smooth movement rather than an immediate jump.
2. At the top of a page, scroll down and immediately reverse direction. The pending movement should reverse without continuing in the old direction.
3. Scroll a nested menu or panel toward its end with a rapid wheel burst. Once the panel's pending target reaches the end, continued input should move the page unless that panel contains overscroll.
4. Enable Disable Smooth Scrolling and restart the app. Custom scroll speeds should remain immediate while that setting is active.
5. Set UI Scale to 125% and repeat the checks. Smoothness, distance, and boundary handoff should remain correct.

## Additional context
<!-- Add any other context about the pull request here. -->
The 100% path still uses Chromium's native wheel handling without a blocking listener.
