### PR TITLE
fix(settings): keep one comment translation control

### DIFF
--- a/e2e/tests/offline/settings.spec.mjs
+++ b/e2e/tests/offline/settings.spec.mjs
@@ -720,19 +720,12 @@ test.describe('settings', () => {
     ])
   })
 
-  test('disables the comment translation button setting when comments are hidden', async ({ page }) => {
+  test('keeps comment translation controls out of Distraction Free settings', async ({ page }) => {
     const focus = await goToSettingsSection(page, 'focus')
-    const hideTranslationButtons = focus.getByRole('checkbox', {
-      name: /^Hide Comment Translation Buttons/
-    })
-    const hideComments = focus.getByRole('checkbox', { name: /^Hide comments/ })
 
-    await expect(hideTranslationButtons).toBeEnabled()
-    await hideTranslationButtons.locator('..').locator('label.switch-label').click()
-    await expect(hideTranslationButtons).toBeChecked()
-    await hideComments.locator('..').locator('label.switch-label').click()
-    await expect(hideComments).toBeChecked()
-    await expect(hideTranslationButtons).toBeDisabled()
+    await expect(focus.getByRole('checkbox', {
+      name: 'Hide Comment Translation Buttons'
+    })).toHaveCount(0)
   })
 
   test('disables A-B repeat from Distraction Free settings', async ({ page }) => {

--- a/e2e/tests/offline/watch-page.spec.mjs
+++ b/e2e/tests/offline/watch-page.spec.mjs
@@ -3920,31 +3920,6 @@ test.describe('manual comment loading', () => {
     await expect(translationButtons.first()).toBeVisible()
   })
 
-  test('hides comment translation buttons through the distraction-free setting', async ({ app, page }) => {
-    await mockPlayableWatchPage(app, page)
-
-    await page.evaluate(async () => {
-      const store = document.querySelector('#app').__vue_app__.config.globalProperties.$store
-      await store.dispatch('updateCurrentLocale', 'de-DE')
-    })
-
-    await openMockedVideo(page)
-
-    const loadComments = page.locator('.getCommentsTitle')
-    await loadComments.scrollIntoViewIfNeeded()
-    await loadComments.click()
-    await expect(page.locator('.commentsTitle')).toBeVisible({ timeout: 30_000 })
-
-    const translationButtons = page.locator('.commentTranslationButton')
-    await expect(translationButtons.first()).toBeVisible()
-
-    await page.evaluate(async () => {
-      const store = document.querySelector('#app').__vue_app__.config.globalProperties.$store
-      await store.dispatch('updateHideCommentTranslationButtons', true)
-    })
-    await expect(translationButtons).toHaveCount(0)
-  })
-
   test('loads collapsed replies from the video uploader while filtering', async ({ app, page, attachScreenshot }) => {
     await mockPlayableWatchPage(app, page, { creatorReply: true, ownerReply: true })
     await openMockedVideo(page)

--- a/src/renderer/components/CommentSection/CommentSection.vue
+++ b/src/renderer/components/CommentSection/CommentSection.vue
@@ -1196,11 +1196,9 @@ const backendFallback = computed(() => {
   return store.getters.getBackendFallback
 })
 
-const translationEnabled = computed(() => {
-  return process.env.SUPPORTS_LOCAL_API &&
-    store.getters.getEnableCommentTranslations &&
-    !store.getters.getHideCommentTranslationButtons
-})
+const translationEnabled = computed(() => (
+  process.env.SUPPORTS_LOCAL_API && store.getters.getEnableCommentTranslations
+))
 
 const translationLanguage = computed(() => {
   return normalizeYouTubeCaptionLanguageCode(locale.value)

--- a/src/renderer/components/DistractionSettings/DistractionSettings.vue
+++ b/src/renderer/components/DistractionSettings/DistractionSettings.vue
@@ -364,15 +364,6 @@
           setting-key="hideCommentLikes"
           @change="updateHideCommentLikes"
         />
-        <FtToggleSwitch
-          v-if="SUPPORTS_LOCAL_API"
-          :label="t('Settings.Distraction Free Settings.Hide Comment Translation Buttons')"
-          :compact="true"
-          :disabled="hideComments"
-          :default-value="hideCommentTranslationButtons"
-          setting-key="hideCommentTranslationButtons"
-          @change="updateHideCommentTranslationButtons"
-        />
       </div>
       <div class="switchColumn">
         <FtToggleSwitch
@@ -516,16 +507,6 @@ const hideCommentLikes = computed(() => store.getters.getHideCommentLikes)
  */
 function updateHideCommentLikes(value) {
   store.dispatch('updateHideCommentLikes', value)
-}
-
-/** @type {import('vue').ComputedRef<boolean>} */
-const hideCommentTranslationButtons = computed(() => store.getters.getHideCommentTranslationButtons)
-
-/**
- * @param {boolean} value
- */
-function updateHideCommentTranslationButtons(value) {
-  store.dispatch('updateHideCommentTranslationButtons', value)
 }
 
 /** @type {import('vue').ComputedRef<boolean>} */

--- a/src/renderer/helpers/settingsSearch.js
+++ b/src/renderer/helpers/settingsSearch.js
@@ -271,7 +271,6 @@ function isSettingsSearchMessageVisible(sectionType, path, options) {
         store.getters.getForbiddenTitlesParsed.length > 0
     }
     if (group === 'Hide Trending Videos') return supportsLocalApi
-    if (group === 'Hide Comment Translation Buttons') return supportsLocalApi
   }
 
   if (sectionType === 'theme') {

--- a/src/renderer/store/modules/settings.js
+++ b/src/renderer/store/modules/settings.js
@@ -299,7 +299,6 @@ const state = {
   hideChannelSubscriptions: false,
   hideCommentLikes: false,
   hideCommentPhotos: false,
-  hideCommentTranslationButtons: false,
   hideComments: false,
   hideEndScreenAnnotations: false,
   hidePaidPromotion: false,

--- a/static/locales/ai/ar.yaml
+++ b/static/locales/ai/ar.yaml
@@ -724,7 +724,6 @@ Settings:
       Visible While Paused: مرئي أثناء الإيقاف المؤقت في نافذة كاملة/شاشة كاملة
     Hide Channel Avatars: إخفاء الصور الرمزية للقناة
     Shorten View Counts: تقصير مرات المشاهدة والتعليق على عدد الإعجابات
-    Hide Comment Translation Buttons: إخفاء أزرار ترجمة التعليق
     Hide Home: إخفاء الصفحة الرئيسية
     Hide Live Chat Replay: إخفاء إعادة تشغيل الدردشة المباشرة
     Disable A-B Repeat: تعطيل تكرار A-B

--- a/static/locales/ai/be.yaml
+++ b/static/locales/ai/be.yaml
@@ -746,7 +746,6 @@ Settings:
       Visible While Paused: Бачныя падчас паўзы ў поўным акне або поўнаэкранным рэжыме
     Hide Channel Avatars: Хаваць аватары каналаў
     Shorten View Counts: Скарачаць колькасць праглядаў і ўпадабанняў каментарыяў
-    Hide Comment Translation Buttons: Хаваць кнопкі перакладу каментарыяў
     Hide Home: Хаваць галоўную
     Hide Live Chat Replay: Хаваць паўтор жывога чата
     Disable A-B Repeat: Адключыць паўтор A-B

--- a/static/locales/ai/bg.yaml
+++ b/static/locales/ai/bg.yaml
@@ -718,7 +718,6 @@ Settings:
       Visible While Paused: Видими при поставяне на пауза в режим на цял прозорец / цял екран
     Hide Channel Avatars: Скриване на аватарите на каналите
     Shorten View Counts: Съкращаване на броя гледания и харесвания на коментари
-    Hide Comment Translation Buttons: Скриване на бутоните за превод на коментари
     Hide Home: Скриване на началната страница
     Hide Live Chat Replay: Скриване на повторението на чата на живо
     Disable A-B Repeat: Изключване на повторението A-B

--- a/static/locales/ai/br.yaml
+++ b/static/locales/ai/br.yaml
@@ -716,7 +716,6 @@ Settings:
       Visible While Paused: "Gwelus e-pad un ehan er prenestr leun pe er skramm leun"
     Hide Channel Avatars: "Kuzhat skeudennoù ar chadennoù"
     Shorten View Counts: "Berraat niver ar selladennoù ha plijadennoù an evezhiadennoù"
-    Hide Comment Translation Buttons: "Kuzhat boutonoù treiñ an evezhiadennoù"
     Hide Home: "Kuzhat ar bajenn degemer"
     Hide Live Chat Replay: "Kuzhat adlenn ar flapañ war-eeun"
     Disable A-B Repeat: "Diweredekaat an adlenn A-B"

--- a/static/locales/ai/ca.yaml
+++ b/static/locales/ai/ca.yaml
@@ -986,7 +986,6 @@ Settings:
       Visible While Paused: Visible durant la pausa a finestra completa o pantalla completa
     Hide Channel Avatars: Oculta els avatars dels canals
     Shorten View Counts: Abreuja els recomptes de visualitzacions i de m'agrades dels comentaris
-    Hide Comment Translation Buttons: Oculta els botons de traducció dels comentaris
     Hide Home: Oculta l'inici
     Hide Live Chat Replay: Oculta la repetició del xat en directe
     Hide Video Description: Oculta la descripció del vídeo

--- a/static/locales/ai/cs.yaml
+++ b/static/locales/ai/cs.yaml
@@ -718,7 +718,6 @@ Settings:
       Visible While Paused: Viditelné při pozastavení v režimu celého okna nebo celé obrazovky
     Hide Channel Avatars: Skrýt avatary kanálů
     Shorten View Counts: Zkracovat počty zhlédnutí a hodnocení komentářů
-    Hide Comment Translation Buttons: Skrýt tlačítka pro překlad komentářů
     Hide Home: Skrýt domovskou stránku
     Hide Live Chat Replay: Skrýt záznam živého chatu
     Disable A-B Repeat: Vypnout opakování A-B

--- a/static/locales/ai/cy.yaml
+++ b/static/locales/ai/cy.yaml
@@ -718,7 +718,6 @@ Settings:
       Visible While Paused: Yn weladwy wrth oedi mewn ffenestr lawn / sgrin lawn
     Hide Channel Avatars: Cuddio afatarau sianeli
     Shorten View Counts: Byrhau cyfrif gwylwyr a hoffiadau sylwadau
-    Hide Comment Translation Buttons: Cuddio botymau cyfieithu sylwadau
     Hide Home: Cuddio'r hafan
     Hide Live Chat Replay: Cuddio ailchwarae sgwrs fyw
     Disable A-B Repeat: Analluogi ailadrodd A-B

--- a/static/locales/ai/da.yaml
+++ b/static/locales/ai/da.yaml
@@ -742,7 +742,6 @@ Settings:
       Visible While Paused: Synligt ved pause i helt vindue eller fuld skærm
     Hide Channel Avatars: Skjul kanalavatarer
     Shorten View Counts: Forkort antal visninger og likes på kommentarer
-    Hide Comment Translation Buttons: Skjul knapper til oversættelse af kommentarer
     Hide Home: Skjul startsiden
     Hide Live Chat Replay: Skjul genafspilning af livechat
     Disable A-B Repeat: Deaktivér A-B-gentagelse

--- a/static/locales/ai/el.yaml
+++ b/static/locales/ai/el.yaml
@@ -729,7 +729,6 @@ Settings:
       Visible While Paused: Ορατά κατά την παύση σε πλήρες παράθυρο / πλήρη οθόνη
     Hide Channel Avatars: Απόκρυψη εικόνων προφίλ καναλιών
     Shorten View Counts: Συντόμευση πλήθους προβολών και θετικών ψήφων σχολίων
-    Hide Comment Translation Buttons: Απόκρυψη κουμπιών μετάφρασης σχολίων
     Hide Home: Απόκρυψη αρχικής
     Hide Live Chat Replay: Απόκρυψη επανάληψης ζωντανής συνομιλίας
     Disable A-B Repeat: Απενεργοποίηση επανάληψης A-B

--- a/static/locales/ai/en-GB.yaml
+++ b/static/locales/ai/en-GB.yaml
@@ -700,7 +700,6 @@ Settings:
   Distraction Free Settings:
     Hide Channel Avatars: Hide Channel Avatars
     Shorten View Counts: Shorten View and Comment Like Counts
-    Hide Comment Translation Buttons: Hide Comment Translation Buttons
     Hide Home: Hide Home
     Hide Live Chat Replay: Hide Live Chat Replay
     Disable A-B Repeat: Disable A-B Repeat

--- a/static/locales/ai/es-AR.yaml
+++ b/static/locales/ai/es-AR.yaml
@@ -800,7 +800,6 @@ Settings:
       Visible While Paused: Visible al pausar en ventana completa o pantalla completa
     Hide Channel Avatars: Ocultar avatares de canales
     Shorten View Counts: Abreviar recuentos de visualizaciones y «Me gusta» en comentarios
-    Hide Comment Translation Buttons: Ocultar botones de traducción de comentarios
     Hide Home: Ocultar Inicio
     Hide Live Chat Replay: Ocultar repetición del chat en directo
     Disable A-B Repeat: Desactivar repetición A-B

--- a/static/locales/ai/es-MX.yaml
+++ b/static/locales/ai/es-MX.yaml
@@ -849,7 +849,6 @@ Settings:
       Visible While Paused: Visible al pausar en ventana completa o pantalla completa
     Hide Channel Avatars: Ocultar avatares de canales
     Shorten View Counts: Abreviar recuentos de visualizaciones y «Me gusta» en comentarios
-    Hide Comment Translation Buttons: Ocultar botones de traducción de comentarios
     Hide Live Chat Replay: Ocultar repetición del chat en directo
     Hide Video Description: Ocultar la descripción del video
     Hide Comments: Ocultar comentarios

--- a/static/locales/ai/es.yaml
+++ b/static/locales/ai/es.yaml
@@ -722,7 +722,6 @@ Settings:
       Visible While Paused: Visible al pausar en ventana completa o pantalla completa
     Hide Channel Avatars: Ocultar avatares de canales
     Shorten View Counts: Abreviar recuentos de visualizaciones y «Me gusta» en comentarios
-    Hide Comment Translation Buttons: Ocultar botones de traducción de comentarios
     Hide Home: Ocultar Inicio
     Hide Live Chat Replay: Ocultar repetición del chat en directo
     Disable A-B Repeat: Desactivar repetición A-B

--- a/static/locales/ai/et.yaml
+++ b/static/locales/ai/et.yaml
@@ -716,7 +716,6 @@ Settings:
       Visible While Paused: Pausi ajal täisaknas või täisekraanil nähtav
     Hide Channel Avatars: Peida kanalite avatarid
     Shorten View Counts: Lühenda vaatamiste ja kommentaaride meeldimiste arvu
-    Hide Comment Translation Buttons: Peida kommentaaride tõlkimise nupud
     Hide Live Chat Replay: Peida otsevestluse kordus
     Hide Home: Peida avaleht
     Disable A-B Repeat: Lülita A-B-kordus välja

--- a/static/locales/ai/eu.yaml
+++ b/static/locales/ai/eu.yaml
@@ -718,7 +718,6 @@ Settings:
       Visible While Paused: Ikusgai pausatuta dagoenean leiho osoan edo pantaila osoan
     Hide Channel Avatars: Ezkutatu kanalen abatarrak
     Shorten View Counts: Laburtu ikustaldien eta iruzkinetako atsegiteen kopuruak
-    Hide Comment Translation Buttons: Ezkutatu iruzkinak itzultzeko botoiak
     Hide Live Chat Replay: Ezkutatu zuzeneko txataren errepikapena
     Hide Home: Ezkutatu hasiera
     Disable A-B Repeat: Desgaitu A-B errepikapena

--- a/static/locales/ai/fa.yaml
+++ b/static/locales/ai/fa.yaml
@@ -746,7 +746,6 @@ Settings:
       Visible While Paused: نمایش هنگام توقف در پنجرهٔ کامل / تمام‌صفحه
     Hide Channel Avatars: پنهان‌کردن آواتار کانال‌ها
     Shorten View Counts: کوتاه‌کردن شمار بازدید و پسند دیدگاه‌ها
-    Hide Comment Translation Buttons: پنهان‌کردن دکمه‌های ترجمهٔ دیدگاه
     Hide Live Chat Replay: پنهان‌کردن بازپخش گفت‌وگوی زنده
     Hide Home: پنهان‌کردن صفحهٔ اصلی
     Disable A-B Repeat: غیرفعال‌کردن تکرار A-B

--- a/static/locales/ai/fi.yaml
+++ b/static/locales/ai/fi.yaml
@@ -729,7 +729,6 @@ Settings:
       Visible While Paused: Näkyvissä keskeytyksen aikana koko ikkunan tai koko näytön tilassa
     Hide Channel Avatars: Piilota kanavien profiilikuvat
     Shorten View Counts: Lyhennä katselukertojen ja kommenttien tykkäysten määrät
-    Hide Comment Translation Buttons: Piilota kommenttien käännöspainikkeet
     Hide Live Chat Replay: Piilota livekeskustelun tallenne
     Hide Home: Piilota etusivu
     Disable A-B Repeat: Poista A-B-toisto käytöstä

--- a/static/locales/ai/fr-FR.yaml
+++ b/static/locales/ai/fr-FR.yaml
@@ -716,7 +716,6 @@ Settings:
       Visible While Paused: Visible pendant la pause en mode pleine fenêtre ou plein écran
     Hide Channel Avatars: Masquer les avatars des chaînes
     Shorten View Counts: Abréger le nombre de vues et de mentions J’aime sur les commentaires
-    Hide Comment Translation Buttons: Masquer les boutons de traduction des commentaires
     Hide Live Chat Replay: Masquer la rediffusion du chat en direct
     Hide Home: Masquer l’accueil
     Disable A-B Repeat: Désactiver la répétition A-B

--- a/static/locales/ai/gl.yaml
+++ b/static/locales/ai/gl.yaml
@@ -724,7 +724,6 @@ Settings:
       Visible While Paused: Visibles durante a pausa en xanela completa ou pantalla completa
     Hide Channel Avatars: Ocultar os avatares das canles
     Shorten View Counts: Abreviar as cifras de visualizacións e de valoracións positivas dos comentarios
-    Hide Comment Translation Buttons: Ocultar os botóns de tradución dos comentarios
     Hide Live Chat Replay: Ocultar a repetición da conversa en directo
     Hide Home: Ocultar o inicio
     Disable A-B Repeat: Desactivar a repetición A-B

--- a/static/locales/ai/he.yaml
+++ b/static/locales/ai/he.yaml
@@ -729,7 +729,6 @@ Settings:
       Visible While Paused: מוצג בזמן השהיה בחלון מלא או במסך מלא
     Hide Channel Avatars: הסתרת תמונות ערוצים
     Shorten View Counts: קיצור מספרי צפיות ולייקים לתגובות
-    Hide Comment Translation Buttons: הסתרת כפתורי תרגום תגובות
     Hide Live Chat Replay: הסתרת ההפעלה החוזרת של הצ'אט החי
     Hide Home: הסתרת דף הבית
     Disable A-B Repeat: השבתת חזרה A-B

--- a/static/locales/ai/hr.yaml
+++ b/static/locales/ai/hr.yaml
@@ -718,7 +718,6 @@ Settings:
       Visible While Paused: Vidljivo tijekom pauze u punom prozoru / preko cijelog zaslona
     Hide Channel Avatars: Sakrij avatare kanala
     Shorten View Counts: Skrati prikaz broja pregleda i oznaka „sviđa mi se” na komentarima
-    Hide Comment Translation Buttons: Sakrij gumbe za prijevod komentara
     Hide Live Chat Replay: Sakrij ponovnu reprodukciju razgovora uživo
     Hide Home: Sakrij početnu
     Disable A-B Repeat: Onemogući A-B ponavljanje

--- a/static/locales/ai/hu.yaml
+++ b/static/locales/ai/hu.yaml
@@ -716,7 +716,6 @@ Settings:
       Visible While Paused: Szüneteltetéskor látható teljes ablakos vagy teljes képernyős módban
     Hide Channel Avatars: Csatornaavatarok elrejtése
     Shorten View Counts: Megtekintések és hozzászóláskedvelések számának rövidítése
-    Hide Comment Translation Buttons: Hozzászólásfordító gombok elrejtése
     Hide Live Chat Replay: Élő csevegés visszajátszásának elrejtése
     Hide Home: Kezdőlap elrejtése
     Disable A-B Repeat: A-B ismétlés letiltása

--- a/static/locales/ai/id.yaml
+++ b/static/locales/ai/id.yaml
@@ -724,7 +724,6 @@ Settings:
       Visible While Paused: Terlihat Saat Dijeda dalam Jendela Penuh / Layar Penuh
     Hide Channel Avatars: Sembunyikan Avatar Saluran
     Shorten View Counts: Persingkat Jumlah Penayangan dan Suka Komentar
-    Hide Comment Translation Buttons: Sembunyikan Tombol Terjemahan Komentar
     Hide Live Chat Replay: Sembunyikan Pemutaran Ulang Chat Langsung
     Hide Home: Sembunyikan Beranda
     Disable A-B Repeat: Nonaktifkan Pengulangan A-B

--- a/static/locales/ai/is.yaml
+++ b/static/locales/ai/is.yaml
@@ -724,7 +724,6 @@ Settings:
       Visible While Paused: Sýnilegt þegar gert er hlé í heilum glugga eða á öllum skjánum
     Hide Channel Avatars: Fela auðkennismyndir rása
     Shorten View Counts: Stytta tölur yfir áhorf og líkar við athugasemdir
-    Hide Comment Translation Buttons: Fela þýðingarhnappa athugasemda
     Hide Live Chat Replay: Fela endurspilun beinspjalls
     Hide Home: Fela heimasíðu
     Disable A-B Repeat: Slökkva á A-B-endurtekningu

--- a/static/locales/ai/it.yaml
+++ b/static/locales/ai/it.yaml
@@ -718,7 +718,6 @@ Settings:
       Visible While Paused: Visibile durante la pausa in finestra intera o a schermo intero
     Hide Channel Avatars: Nascondi avatar dei canali
     Shorten View Counts: Abbrevia conteggi delle visualizzazioni e dei Mi piace ai commenti
-    Hide Comment Translation Buttons: Nascondi pulsanti di traduzione dei commenti
     Hide Home: Nascondi Home
     Hide Live Chat Replay: Nascondi replica della chat dal vivo
     Disable A-B Repeat: Disattiva ripetizione A-B

--- a/static/locales/ai/ja.yaml
+++ b/static/locales/ai/ja.yaml
@@ -718,7 +718,6 @@ Settings:
       Visible While Paused: 全ウィンドウ表示・全画面表示で一時停止中に表示
     Hide Channel Avatars: チャンネルのアバターを非表示
     Shorten View Counts: 視聴回数とコメントの高評価数を省略表示
-    Hide Comment Translation Buttons: コメントの翻訳ボタンを非表示
     Hide Home: ホームを非表示
     Hide Live Chat Replay: ライブチャットのリプレイを非表示
     Disable A-B Repeat: A-Bリピートを無効化

--- a/static/locales/ai/ko.yaml
+++ b/static/locales/ai/ko.yaml
@@ -915,7 +915,6 @@ Settings:
       Visible While Paused: 전체 창 / 전체 화면에서 일시 정지 중 표시
     Hide Channel Avatars: 채널 아바타 숨기기
     Shorten View Counts: 조회수 및 댓글 좋아요 수 줄여 표시
-    Hide Comment Translation Buttons: 댓글 번역 버튼 숨기기
     Hide Home: 홈 숨기기
     Hide Live Chat Replay: 실시간 채팅 다시보기 숨기기
     Hide Profile Pictures in Comments: 댓글의 프로필 사진 숨기기

--- a/static/locales/ai/lt.yaml
+++ b/static/locales/ai/lt.yaml
@@ -935,7 +935,6 @@ Settings:
       Visible While Paused: Rodoma pristabdžius viso lango arba viso ekrano režimu
     Hide Channel Avatars: Slėpti kanalų pseudoportretus
     Shorten View Counts: Trumpinti peržiūrų ir komentarų patiktukų skaičius
-    Hide Comment Translation Buttons: Slėpti komentarų vertimo mygtukus
     Hide Home: Slėpti pradžios puslapį
     Hide Live Chat Replay: Slėpti tiesioginio pokalbio įrašą
     Hide Profile Pictures in Comments: Slėpti profilio nuotraukas komentaruose

--- a/static/locales/ai/nb-NO.yaml
+++ b/static/locales/ai/nb-NO.yaml
@@ -724,7 +724,6 @@ Settings:
       Visible While Paused: Synlig ved pause i fullt vindu / fullskjerm
     Hide Channel Avatars: Skjul kanalavatarer
     Shorten View Counts: Forkort antall visninger og likerklikk på kommentarer
-    Hide Comment Translation Buttons: Skjul oversettelsesknapper for kommentarer
     Hide Home: Skjul startsiden
     Hide Live Chat Replay: Skjul reprise av direktechat
     Disable A-B Repeat: Deaktiver A-B-gjentakelse

--- a/static/locales/ai/nl.yaml
+++ b/static/locales/ai/nl.yaml
@@ -729,7 +729,6 @@ Settings:
       Visible While Paused: Zichtbaar wanneer gepauzeerd in volledig venster of volledig scherm
     Hide Channel Avatars: Kanaalavatars verbergen
     Shorten View Counts: Aantallen weergaven en vind-ik-leuks bij reacties inkorten
-    Hide Comment Translation Buttons: Knoppen voor het vertalen van reacties verbergen
     Hide Home: Startpagina verbergen
     Hide Live Chat Replay: Herhaling van livechat verbergen
     Disable A-B Repeat: A-B-herhaling uitschakelen

--- a/static/locales/ai/nn.yaml
+++ b/static/locales/ai/nn.yaml
@@ -952,7 +952,6 @@ Settings:
       Visible While Paused: Synleg ved pause i fullt vindauge eller på fullskjerm
     Hide Channel Avatars: Gøym kanalavatarar
     Shorten View Counts: Forkort talet på visingar og likerklikk på kommentarar
-    Hide Comment Translation Buttons: Gøym omsetjingsknappar for kommentarar
     Hide Home: Gøym heimesida
     Hide Live Chat Replay: Gøym opptak av direktepraten
     Hide Profile Pictures in Comments: Gøym profilbilete i kommentarar

--- a/static/locales/ai/pl.yaml
+++ b/static/locales/ai/pl.yaml
@@ -264,7 +264,6 @@ Settings:
       Visible While Paused: Widoczne po wstrzymaniu w trybie pełnego okna lub pełnego ekranu
     Hide Channel Avatars: Ukrywaj awatary kanałów
     Shorten View Counts: Skracaj liczbę wyświetleń i polubień komentarzy
-    Hide Comment Translation Buttons: Ukrywaj przyciski tłumaczenia komentarzy
     Hide Home: Ukryj stronę główną
     Hide Live Chat Replay: Ukrywaj powtórkę czatu na żywo
     Disable A-B Repeat: Wyłącz powtarzanie A-B

--- a/static/locales/ai/pt-BR.yaml
+++ b/static/locales/ai/pt-BR.yaml
@@ -716,7 +716,6 @@ Settings:
       Visible While Paused: Visível durante a pausa em tela cheia ou tela cheia
     Hide Channel Avatars: Ocultar avatares dos canais
     Shorten View Counts: Abreviar contagens de visualizações e de gostos nos comentários
-    Hide Comment Translation Buttons: Ocultar botões de tradução dos comentários
     Hide Home: Ocultar página inicial
     Hide Live Chat Replay: Ocultar repetição do chat ao vivo
     Disable A-B Repeat: Desativar repetição A-B

--- a/static/locales/ai/pt-PT.yaml
+++ b/static/locales/ai/pt-PT.yaml
@@ -724,7 +724,6 @@ Settings:
       Visible While Paused: Visível durante a pausa em janela inteira ou ecrã inteiro
     Hide Channel Avatars: Ocultar avatares dos canais
     Shorten View Counts: Abreviar contagens de visualizações e de gostos nos comentários
-    Hide Comment Translation Buttons: Ocultar botões de tradução dos comentários
     Hide Home: Ocultar página inicial
     Hide Live Chat Replay: Ocultar repetição do chat em direto
     Disable A-B Repeat: Desativar repetição A-B

--- a/static/locales/ai/pt.yaml
+++ b/static/locales/ai/pt.yaml
@@ -732,7 +732,6 @@ Settings:
       Visible While Paused: Visível durante a pausa em janela inteira ou ecrã inteiro
     Hide Channel Avatars: Ocultar avatares dos canais
     Shorten View Counts: Abreviar contagens de visualizações e de gostos nos comentários
-    Hide Comment Translation Buttons: Ocultar botões de tradução dos comentários
     Hide Home: Ocultar página inicial
     Hide Live Chat Replay: Ocultar repetição do chat em direto
     Disable A-B Repeat: Desativar repetição A-B

--- a/static/locales/ai/ro.yaml
+++ b/static/locales/ai/ro.yaml
@@ -720,7 +720,6 @@ Settings:
       Visible While Paused: Vizibile în pauză în fereastră completă / pe ecran complet
     Hide Channel Avatars: Ascunde avatarurile canalelor
     Shorten View Counts: Abreviază numărul de vizionări și aprecieri ale comentariilor
-    Hide Comment Translation Buttons: Ascunde butoanele de traducere a comentariilor
     Hide Home: Ascunde pagina principală
     Hide Live Chat Replay: Ascunde reluarea chatului în direct
     Disable A-B Repeat: Dezactivează repetarea A-B

--- a/static/locales/ai/ru.yaml
+++ b/static/locales/ai/ru.yaml
@@ -701,7 +701,6 @@ Settings:
       Visible While Paused: Показывать во время паузы в полнооконном и полноэкранном режимах
     Hide Channel Avatars: Скрывать аватары каналов
     Shorten View Counts: Сокращать числа просмотров и отметок «Нравится» у комментариев
-    Hide Comment Translation Buttons: Скрывать кнопки перевода комментариев
     Hide Home: Скрыть главную
     Hide Live Chat Replay: Скрывать запись чата трансляции
     Disable A-B Repeat: Отключить повтор A-B

--- a/static/locales/ai/sk.yaml
+++ b/static/locales/ai/sk.yaml
@@ -718,7 +718,6 @@ Settings:
       Visible While Paused: Viditeľné počas pozastavenia v režime celého okna alebo celej obrazovky
     Hide Channel Avatars: Skryť avatary kanálov
     Shorten View Counts: Skrátiť počty pozretí a označení Páči sa mi to pri komentároch
-    Hide Comment Translation Buttons: Skryť tlačidlá prekladu komentárov
     Hide Home: Skryť domovskú stránku
     Hide Live Chat Replay: Skryť záznam živého četu
     Disable A-B Repeat: Vypnúť opakovanie A-B

--- a/static/locales/ai/sl.yaml
+++ b/static/locales/ai/sl.yaml
@@ -953,7 +953,6 @@ Settings:
       Visible While Paused: Vidno med premorom v celotnem oknu/celozaslonskem načinu
     Hide Channel Avatars: Skrij slike kanalov
     Shorten View Counts: Skrajšaj število ogledov in všečkov komentarjev
-    Hide Comment Translation Buttons: Skrij gumbe za prevajanje komentarjev
     Hide Home: Skrij domačo stran
     Hide Live Chat Replay: Skrij ponovitev klepeta v živo
     Hide Profile Pictures in Comments: Skrij profilne slike v komentarjih

--- a/static/locales/ai/sr.yaml
+++ b/static/locales/ai/sr.yaml
@@ -739,7 +739,6 @@ Settings:
       Visible While Paused: Видљиво током паузе у целом прозору / преко целог екрана
     Hide Channel Avatars: Сакриј аватаре канала
     Shorten View Counts: Скрати број прегледа и свиђања коментара
-    Hide Comment Translation Buttons: Сакриј дугмад за превод коментара
     Hide Home: Сакриј почетну страницу
     Hide Live Chat Replay: Сакриј снимак ћаскања уживо
     Disable A-B Repeat: Онемогући A-B понављање

--- a/static/locales/ai/sv.yaml
+++ b/static/locales/ai/sv.yaml
@@ -718,7 +718,6 @@ Settings:
       Visible While Paused: Synligt under paus i helfönster eller helskärm
     Hide Channel Avatars: Dölj kanalavatarer
     Shorten View Counts: Förkorta antal visningar och gilla-markeringar på kommentarer
-    Hide Comment Translation Buttons: Dölj knappar för kommentaröversättning
     Hide Live Chat Replay: Dölj repriser av livechattar
     Hide Home: Dölj startsidan
     Disable A-B Repeat: Inaktivera A-B-upprepning

--- a/static/locales/ai/ta.yaml
+++ b/static/locales/ai/ta.yaml
@@ -728,7 +728,6 @@ Settings:
       Visible While Paused: முழுச் சாளரம் / முழுத்திரையில் இடைநிறுத்தியிருக்கும்போது தெரிபவை
     Hide Channel Avatars: சேனல் அவதார்களை மறை
     Shorten View Counts: பார்வை மற்றும் கருத்து விருப்ப எண்ணிக்கைகளைச் சுருக்கு
-    Hide Comment Translation Buttons: கருத்து மொழிபெயர்ப்புப் பொத்தான்களை மறை
     Hide Live Chat Replay: நேரலை அரட்டை மறுஇயக்கத்தை மறை
     Hide Home: முகப்பை மறை
     Disable A-B Repeat: A-B மீளியக்கத்தை முடக்கு

--- a/static/locales/ai/tr.yaml
+++ b/static/locales/ai/tr.yaml
@@ -716,7 +716,6 @@ Settings:
       Visible While Paused: Tam Pencere / Tam Ekranda Duraklatıldığında Görünür
     Hide Channel Avatars: Kanal Avatarlarını Gizle
     Shorten View Counts: İzlenme ve Yorum Beğeni Sayılarını Kısalt
-    Hide Comment Translation Buttons: Yorum Çevirisi Düğmelerini Gizle
     Hide Live Chat Replay: Canlı Sohbet Tekrarını Gizle
     Hide Home: Ana Sayfayı Gizle
     Disable A-B Repeat: A-B Tekrarını Devre Dışı Bırak

--- a/static/locales/ai/uk.yaml
+++ b/static/locales/ai/uk.yaml
@@ -724,7 +724,6 @@ Settings:
       Visible While Paused: Видимі під час паузи в режимі на все вікно або на весь екран
     Hide Channel Avatars: Приховувати аватари каналів
     Shorten View Counts: Скорочувати кількість переглядів і вподобань коментарів
-    Hide Comment Translation Buttons: Приховувати кнопки перекладу коментарів
     Hide Live Chat Replay: Приховувати повтор чату трансляції
     Hide Home: Приховати головну
     Disable A-B Repeat: Вимкнути повтор A-B

--- a/static/locales/ai/vi.yaml
+++ b/static/locales/ai/vi.yaml
@@ -724,7 +724,6 @@ Settings:
       Visible While Paused: Hiện khi tạm dừng ở chế độ toàn cửa sổ / toàn màn hình
     Hide Channel Avatars: Ẩn ảnh đại diện kênh
     Shorten View Counts: Rút gọn số lượt xem và lượt thích bình luận
-    Hide Comment Translation Buttons: Ẩn nút dịch bình luận
     Hide Home: Ẩn Trang chủ
     Hide Live Chat Replay: Ẩn bản phát lại trò chuyện trực tiếp
     Disable A-B Repeat: Tắt lặp A-B

--- a/static/locales/ai/zh-CN.yaml
+++ b/static/locales/ai/zh-CN.yaml
@@ -716,7 +716,6 @@ Settings:
       Visible While Paused: 全窗口或全屏暂停时显示
     Hide Channel Avatars: 隐藏频道头像
     Shorten View Counts: 简写观看次数和评论点赞数
-    Hide Comment Translation Buttons: 隐藏评论翻译按钮
     Hide Home: 隐藏首页
     Hide Live Chat Replay: 隐藏直播聊天回放
     Disable A-B Repeat: 禁用 A-B 循环

--- a/static/locales/ai/zh-TW.yaml
+++ b/static/locales/ai/zh-TW.yaml
@@ -718,7 +718,6 @@ Settings:
       Visible While Paused: 在全視窗／全螢幕模式暫停播放時顯示
     Hide Channel Avatars: 隱藏頻道頭像
     Shorten View Counts: 縮寫觀看次數和留言按讚數
-    Hide Comment Translation Buttons: 隱藏留言翻譯按鈕
     Hide Home: 隱藏首頁
     Hide Live Chat Replay: 隱藏即時聊天室重播
     Disable A-B Repeat: 停用 A-B 循環

--- a/static/locales/de-DE.yaml
+++ b/static/locales/de-DE.yaml
@@ -1012,7 +1012,6 @@ Settings:
     Hide Home: Startseite ausblenden
     Hide Channel Subscribers: Abozahl für Kanäle ausblenden
     Hide Comment Likes: Likes bei Kommentaren ausblenden
-    Hide Comment Translation Buttons: Schaltflächen zum Übersetzen von Kommentaren ausblenden
     Hide Video Likes And Dislikes: Likes und Dislikes ausblenden
     Hide Video Views: Videoaufrufe ausblenden
     Hide Channel Avatars: Kanalavatare ausblenden

--- a/static/locales/en-US.yaml
+++ b/static/locales/en-US.yaml
@@ -1253,7 +1253,6 @@ Settings:
     Hide Video Likes And Dislikes: Hide Video Likes And Dislikes
     Hide Channel Subscribers: Hide Channel Subscribers
     Hide Comment Likes: Hide Comment Likes
-    Hide Comment Translation Buttons: Hide Comment Translation Buttons
     Hide Recommended Videos: Hide Recommended Videos
     Hide Home: Hide Home
     Hide Trending Videos: Hide Trending Videos

--- a/tests/unit/settings-search-config.test.mjs
+++ b/tests/unit/settings-search-config.test.mjs
@@ -189,40 +189,6 @@ test('persistent playback cache search results follow desktop visibility', () =>
   assert.ok(!webValues.some(({ label }) => label === 'yt-dlp stream URL cache limit'))
 })
 
-test('comment translation button setting follows local API availability', () => {
-  const options = {
-    sections: [{
-      type: 'focus',
-      title: 'Distraction Free',
-      description: locale.Settings.Categories['Distraction Free Description'],
-    }],
-    tm: path => getAtPath(locale, path),
-    store: {
-      getters: new Proxy({}, {
-        get() {
-          return false
-        }
-      })
-    },
-    usingElectron: true,
-    isMac: false,
-    isLinuxWayland: false,
-    systemUsesDarkTheme: true,
-  }
-
-  const localApiValues = createSettingsSearchIndex({
-    ...options,
-    supportsLocalApi: true,
-  }).get('focus')
-  const webValues = createSettingsSearchIndex({
-    ...options,
-    supportsLocalApi: false,
-  }).get('focus')
-
-  assert.ok(localApiValues.some(({ label }) => label === 'Hide Comment Translation Buttons'))
-  assert.ok(!webValues.some(({ label }) => label === 'Hide Comment Translation Buttons'))
-})
-
 test('ignored comment translation languages follow local API availability', () => {
   const options = {
     sections: [{


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Make sure to follow the contributing guidelines. -->
<!-- Important note, we may remove your pull request if you do not use this provided PR template correctly. -->
<!-- Agent instructions: Preserve every heading, comment, and marker in this template. Never remove or rewrite the release-note-category:start/end, release-note:start/end, or release-note-image:start/end marker pairs. -->

## Pull Request Type
<!-- Please select what type of pull request this is: [x] -->
- [x] Bugfix
- [ ] Feature Implementation
- [ ] Documentation
- [ ] Other

## Related issue
<!-- Please link the issue you are referring to. -->
<!-- If this pull request fully resolves the relevant issue, put "closes" before the issue number. -->
<!-- Example: "closes #123456". -->

## Description
<!-- Please write a clear and concise description of what this pull request does. -->
Comment translations had two independent settings that both removed the only way to translate a comment. This could leave translations enabled in General while their buttons remained hidden by Distraction Free.

This removes the redundant Distraction Free preference and keeps General > Comment translations as the sole control. It also removes the obsolete state, search handling, translations, and tests tied to the duplicate setting.

## Release note category
<!-- Select exactly one category. Every pull request must select one. -->
<!-- Select "Not noteworthy" when the pull request fixes a bug in or improves functionality that has not yet appeared in a stable release. -->
<!-- release-note-category:start -->
- [x] Not noteworthy
- [ ] Highlights
- [ ] More improvements
- [ ] Fixed bugs
<!-- release-note-category:end -->

## Release note
<!-- Required unless "Not noteworthy" is selected. -->
<!-- Write one concise, user-facing entry without a leading bullet. -->
<!-- release-note:start -->

<!-- release-note:end -->

## Release note images
<!-- Optional. Paste one or more Markdown images, HTML image tags, or dark/light <picture> elements here. -->
<!-- The release notes normalize the markup and limit images taller than 300 pixels. -->
<!-- Agent instructions:
For a noteworthy visible change, add media when it makes the change easier to understand. Prefer a still image unless motion is the point; recordings must use animated WebP.
After implementing a visible change, proactively capture the result and show the local media to the user for approval before uploading it or updating the pull request.
When the affected UI differs between dark and light themes, capturing both themes is required. A dark-only image is incomplete. Run `node _scripts/releaseNoteMedia.mjs --dark DARK_FILE --light LIGHT_FILE --alt "DESCRIPTION"`; GitHub will display the matching theme and use dark as the fallback. Use a single default-dark capture only when the light theme cannot be captured or looks identical.
Capture or crop to the smallest region that still makes the change clear. Do not include the full window when the affected component can be understood on its own.
Use English unless localization is the subject. Keep components at their normal dimensions and placement instead of resizing them to fill the frame.
Use deterministic local fixtures for visible remote images. Reusable avatar and thumbnail fixtures are available through `e2e/helpers/visual-fixtures.mjs`. Before capturing, verify that every visible image has loaded successfully (`complete === true` and `naturalWidth > 0`).
Inspect the final dark and light files for failed images, missing content, unrelated UI, awkward animation, and misleading layout. Omit media when it does not explain the change clearly.
For one dark capture, run `node _scripts/releaseNoteMedia.mjs FILE --alt "DESCRIPTION"`.
Check for personal information, tokens, private repository names, and unrelated desktop content before uploading. Uploaded media is public.
Keep capture-only scripts, test hooks, screenshots, and recordings out of commits. Remove them before committing unless the capture code is also a reusable regression test. Never commit generated release-note media.
Paste only the generated markup between the marker comments. Leave this section empty when media would not help.
-->
<!-- release-note-image:start -->

<!-- release-note-image:end -->

## Testing
<!-- How can reviewers verify that the PR produces correct results? -->
<!-- Please provide instructions so that others can ensure that your pull request would produce correct results. For examples, see https://github.com/FreeTubeApp/FreeTube/pull/5743, https://github.com/FreeTubeApp/FreeTube/pull/7349, https://github.com/FreeTubeApp/FreeTube/pull/5125, and https://github.com/FreeTubeApp/FreeTube/pull/7338. -->
<!-- Agent instructions: Only write human-facing steps that explain how to verify the change while running this branch in dev mode. Include expected results and, when applicable, helpful console snippets for interactive verification. Do not include automated checks, commands, results, pass counts, or CI status. -->
1. Open General settings and confirm Comment translations contains the enable switch and language exclusions.
2. Open Distraction Free settings and confirm the comment translation button setting is absent.
3. Open a video with a translatable comment. Disable comment translations in General and confirm every translation action disappears, then re-enable it and confirm the actions return.

## Additional context
<!-- Add any other context about the pull request here. -->
The duplicate preference was introduced by #936 and became redundant when #954 added the General master switch. Both changes are unreleased, so this removes the original setting without a compatibility path.
