### PR TITLE
feat(settings): add playlist view type to quick settings

### DIFF
--- a/e2e/tests/offline/quick-settings.spec.mjs
+++ b/e2e/tests/offline/quick-settings.spec.mjs
@@ -63,7 +63,7 @@ test.describe('quick settings menu', () => {
     await page.locator('.profileTrigger').click()
     const menu = page.locator('.quickSettingsMenu')
     const pairs = menu.locator('.selectPair')
-    await expect(pairs).toHaveCount(2)
+    await expect(pairs).toHaveCount(3)
 
     for (const pair of await pairs.all()) {
       const selects = pair.locator('.quickSelect')
@@ -78,6 +78,22 @@ test.describe('quick settings menu', () => {
 
     await menu.getByRole('combobox', { name: 'Language preference' }).click()
     await expect(page.locator('.selectDropdown')).toContainText('English (US) (100%)')
+  })
+
+  test('updates the playlist view type independently', async ({ page }) => {
+    await page.locator('.profileTrigger').click()
+    const menu = page.getByRole('dialog', { name: 'Quick settings' })
+    const videoViewType = menu.getByRole('combobox', { name: 'Video View Type' })
+    const playlistViewType = menu.getByRole('combobox', { name: 'Playlist View Type' })
+
+    await expect(videoViewType).toContainText('Grid')
+    await expect(playlistViewType).toContainText('Grid')
+    await playlistViewType.click()
+    await page.getByRole('option', { name: 'List', exact: true }).click()
+
+    await expect(playlistViewType).toContainText('List')
+    await expect(videoViewType).toContainText('Grid')
+    await expect(menu).toBeVisible()
   })
 
   test('shows color swatches in the color-theme selector', async ({ page }) => {

--- a/src/renderer/components/FtQuickSettingsMenu/FtQuickSettingsMenu.vue
+++ b/src/renderer/components/FtQuickSettingsMenu/FtQuickSettingsMenu.vue
@@ -237,16 +237,28 @@
 
               <section class="menuSection">
                 <h3>{{ t('Settings.Quick Settings.Content') }}</h3>
-                <FtSelect
-                  class="quickSelect"
-                  :placeholder="t('Settings.General Settings.Video View Type.Video View Type')"
-                  :value="listType"
-                  setting-key="listType"
-                  :select-names="viewTypeNames"
-                  :select-values="VIEW_TYPE_VALUES"
-                  :icon="listType === 'grid' ? ['fas', 'grip'] : ['fas', 'list']"
-                  @change="updateSetting('ListType', $event)"
-                />
+                <div class="selectPair">
+                  <FtSelect
+                    class="quickSelect"
+                    :placeholder="t('Settings.General Settings.Video View Type.Video View Type')"
+                    :value="listType"
+                    setting-key="listType"
+                    :select-names="viewTypeNames"
+                    :select-values="VIEW_TYPE_VALUES"
+                    :icon="listType === 'grid' ? ['fas', 'grip'] : ['fas', 'list']"
+                    @change="updateSetting('ListType', $event)"
+                  />
+                  <FtSelect
+                    class="quickSelect"
+                    :placeholder="t('Settings.General Settings.Playlist View Type.Playlist View Type')"
+                    :value="playlistViewType"
+                    setting-key="playlistViewType"
+                    :select-names="viewTypeNames"
+                    :select-values="VIEW_TYPE_VALUES"
+                    :icon="playlistViewType === 'grid' ? ['fas', 'grip'] : ['fas', 'list']"
+                    @change="updateSetting('PlaylistViewType', $event)"
+                  />
+                </div>
                 <FtToggleSwitch
                   :label="t('Settings.Distraction Free Settings.Hide Recommended Videos')"
                   :default-value="hideRecommendedVideos"
@@ -455,6 +467,7 @@ const thumbnailSize = computed(() => store.getters.getThumbnailSize)
 const playNextVideo = computed(() => store.getters.getPlayNextVideo)
 const enableSubtitlesByDefault = computed(() => store.getters.getEnableSubtitlesByDefault)
 const listType = computed(() => store.getters.getListType)
+const playlistViewType = computed(() => store.getters.getPlaylistViewType)
 const hideRecommendedVideos = computed(() => store.getters.getHideRecommendedVideos)
 const hideComments = computed(() => store.getters.getHideComments)
 const currentLocale = computed(() => store.getters.getCurrentLocale)


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Make sure to follow the contributing guidelines. -->
<!-- Important note, we may remove your pull request if you do not use this provided PR template correctly. -->
<!-- Agent instructions: Preserve every heading, comment, and marker in this template. Never remove or rewrite the release-note-category:start/end, release-note:start/end, or release-note-image:start/end marker pairs. -->

## Pull Request Type
<!-- Please select what type of pull request this is: [x] -->
- [ ] Bugfix
- [x] Feature Implementation
- [ ] Documentation
- [ ] Other

## Related issue
<!-- Please link the issue your pull request is referring to. -->
<!-- If this pull request fully resolves the relevant issue, put "closes" before the issue number. -->
<!-- Example: "closes #123456". -->

No related issue. This change was requested directly.

## Description
<!-- Please write a clear and concise description of what the pull request does. -->

Quick settings only exposed the video view type, so changing the playlist layout required opening the full settings window.

This adds the playlist view type beside the video view type in the Content section. Both controls use the existing responsive pair layout, and changing one does not affect the other.

## Release note category
<!-- Select exactly one category. Every pull request must select one. -->
<!-- Select "Not noteworthy" when the pull request fixes a bug in or improves functionality that has not yet appeared in a stable release. -->
<!-- release-note-category:start -->
- [ ] Not noteworthy
- [ ] Highlights
- [x] More improvements
- [ ] Fixed bugs
<!-- release-note-category:end -->

## Release note
<!-- Required unless "Not noteworthy" is selected. -->
<!-- Write one concise, user-facing entry without a leading bullet. -->
<!-- release-note:start -->

Playlist view type can now be changed from Quick settings alongside the video view type.

<!-- release-note:end -->

## Release note images
<!-- Optional. Paste one or more Markdown images, HTML image tags, or dark/light <picture> elements here. -->
<!-- The release notes normalize the markup and limit images taller than 300 pixels. -->
<!-- Agent instructions:
For a noteworthy visible change, add media when it makes the change easier to understand. Prefer a still image unless motion is the point; recordings must use animated WebP.
After implementing a visible change, proactively capture the result and show the local media to the user for approval before uploading it or updating the pull request.
When the affected UI differs between dark and light themes, capturing both themes is required. A dark-only image is incomplete. Run `node _scripts/releaseNoteMedia.mjs --dark DARK_FILE --light LIGHT_FILE --alt "DESCRIPTION"`; GitHub will display the matching theme and use dark as the fallback. Use a single default-dark capture only when the light theme cannot be captured or looks identical.
Capture or crop to the smallest region that still makes the change clear. Do not include the full window when the affected component can be understood on its own.
Use English unless localization is the subject. Keep components at their normal dimensions and placement instead of resizing them to fill the frame.
Use deterministic local fixtures for visible remote images. Reusable avatar and thumbnail fixtures are available through `e2e/helpers/visual-fixtures.mjs`. Before capturing, verify that every visible image has loaded successfully (`complete === true` and `naturalWidth > 0`).
Inspect the final dark and light files for failed images, missing content, unrelated UI, awkward animation, and misleading layout. Omit media when it does not explain the change clearly.
For one dark capture, run `node _scripts/releaseNoteMedia.mjs FILE --alt "DESCRIPTION"`.
Check for personal information, tokens, private repository names, and unrelated desktop content before uploading. Uploaded media is public.
Keep capture-only scripts, test hooks, screenshots, and recordings out of commits. Remove them before committing unless the capture code is also a reusable regression test. Never commit generated release-note media.
Paste only the generated markup between the marker comments. Leave this section empty when media would not help.
-->
<!-- release-note-image:start -->

<picture>
  <source media="(prefers-color-scheme: dark)" srcset="https://github.com/OpenTubeX/media/releases/download/attachments/20260829T185115Z-playlist-view-quick-settings-dark-dark-d41dc4b548.png">
  <source media="(prefers-color-scheme: light)" srcset="https://github.com/OpenTubeX/media/releases/download/attachments/20260829T185115Z-playlist-view-quick-settings-light-light-f51db52175.png">
  <img alt="Video and playlist view type controls in quick settings" src="https://github.com/OpenTubeX/media/releases/download/attachments/20260829T185115Z-playlist-view-quick-settings-dark-dark-d41dc4b548.png">
</picture>

<!-- release-note-image:end -->

## Testing
<!-- How can reviewers verify that the PR produces correct results? -->
<!-- Please provide instructions so that others can ensure that your pull request would produce correct results. For examples see, https://github.com/FreeTubeApp/FreeTube/pull/5743, https://github.com/FreeTubeApp/FreeTube/pull/7349, https://github.com/FreeTubeApp/FreeTube/pull/5125, https://github.com/FreeTubeApp/FreeTube/pull/7338 -->
<!-- Agent instructions: Only write human-facing steps that explain how to verify the change while running this branch in dev mode. Include expected results and, when applicable, helpful console snippets for interactive verification. Do not include automated checks, commands, results, pass counts, or CI status. -->

1. Open Quick settings and find the Content section.
2. Confirm Playlist View Type appears beside Video View Type.
3. Change Playlist View Type to List and confirm the playlist layout changes while Video View Type keeps its previous value.

## Additional context
<!-- Add any other context about the pull request here. -->

The labels, icons, state, and setting actions already existed on the full Appearance settings page and are reused here.
