### PR TITLE
fix(settings): fill incomplete toggle rows from start

### DIFF
--- a/e2e/tests/offline/settings.spec.mjs
+++ b/e2e/tests/offline/settings.spec.mjs
@@ -902,6 +902,33 @@ test.describe('settings', () => {
     await attachScreenshot('compact General setting selects')
   })
 
+  test('places an incomplete General toggle row at the inline start', async ({ page }) => {
+    const general = await goToSettingsSection(page, 'general')
+    const minimizeToTray = general.getByRole('checkbox', {
+      name: /Minimi[sz]e to system tray/
+    }).locator('..')
+    await expect(minimizeToTray).toBeVisible()
+    await minimizeToTray.evaluate(element => { element.style.display = 'none' })
+
+    const aiTranslations = general.getByRole('checkbox', {
+      name: 'Fill missing translations with AI-generated text'
+    }).locator('..')
+    const grid = general.locator('.switchColumnGrid').first()
+
+    for (const direction of ['ltr', 'rtl']) {
+      await page.evaluate(value => { document.documentElement.dir = value }, direction)
+      const inlineOffset = await grid.evaluate((element, aiTranslationElement) => {
+        const gridBounds = element.getBoundingClientRect()
+        const settingBounds = aiTranslationElement.getBoundingClientRect()
+        const physicalOffset = settingBounds.left + settingBounds.width / 2 -
+          (gridBounds.left + gridBounds.width / 2)
+        return getComputedStyle(element).direction === 'rtl' ? -physicalOffset : physicalOffset
+      }, await aiTranslations.elementHandle())
+
+      expect(inlineOffset, direction).toBeLessThan(0)
+    }
+  })
+
   test('keeps General selects compact in the one-column layout', async ({ page }) => {
     await page.evaluate(() => {
       localStorage.setItem('opentubex-settings-window-bounds', JSON.stringify({
@@ -946,7 +973,7 @@ test.describe('settings', () => {
     })
     await goTo(page, 'settings')
 
-    for (const sectionType of ['subscriptions', 'focus', 'privacy']) {
+    for (const sectionType of ['general', 'subscriptions', 'focus', 'privacy']) {
       await page.locator(`.settingsMenu [data-section="${sectionType}"]`).click()
       const grids = page.locator(
         `.settingsContent > [data-section="${sectionType}"] .switchColumnGrid`
@@ -956,12 +983,13 @@ test.describe('settings', () => {
       const centerOffsets = await grids.evaluateAll(elements => elements.flatMap(grid => {
         const gridBounds = grid.getBoundingClientRect()
         const gridCenter = gridBounds.left + gridBounds.width / 2
-        return Array.from(grid.querySelectorAll(':scope > .switchColumn')).flatMap(column => {
-          return Array.from(column.children)
-            .map(child => child.getBoundingClientRect())
-            .filter(bounds => bounds.width > 0 && bounds.height > 0)
-            .map(bounds => Math.abs(bounds.left + bounds.width / 2 - gridCenter))
-        })
+        const columnControls = Array.from(grid.querySelectorAll(':scope > .switchColumn'))
+          .flatMap(column => Array.from(column.children))
+        const flowControls = Array.from(grid.querySelectorAll(':scope > .switch-ctn'))
+        return [...columnControls, ...flowControls]
+          .map(child => child.getBoundingClientRect())
+          .filter(bounds => bounds.width > 0 && bounds.height > 0)
+          .map(bounds => Math.abs(bounds.left + bounds.width / 2 - gridCenter))
       }))
 
       expect(Math.max(...centerOffsets), sectionType).toBeLessThanOrEqual(1)

--- a/src/renderer/components/FtSettingsSection/FtSettingsSection.scss
+++ b/src/renderer/components/FtSettingsSection/FtSettingsSection.scss
@@ -127,13 +127,15 @@
       padding-inline: 10px;
     }
 
-    :deep(.switchColumn .switch-label > .tooltip) {
+    :deep(.switchColumn .switch-label > .tooltip),
+    :deep(.switchFlowGrid .switch-label > .tooltip) {
       position: static;
       inset: auto;
       vertical-align: middle;
     }
 
-    :deep(.switchColumn .switch-ctn.containsTooltip .switch-label) {
+    :deep(.switchColumn .switch-ctn.containsTooltip .switch-label),
+    :deep(.switchFlowGrid .switch-ctn.containsTooltip .switch-label) {
       align-items: center;
       display: inline-flex;
     }

--- a/src/renderer/components/GeneralSettings/GeneralSettings.vue
+++ b/src/renderer/components/GeneralSettings/GeneralSettings.vue
@@ -3,99 +3,89 @@
     :title="sectionTitle"
   >
     <div
-      class="switchColumnGrid"
+      class="switchColumnGrid switchFlowGrid"
       :class="{ appearanceSwitchGrid: mode === 'appearance' }"
     >
-      <div class="switchColumn">
-        <FtToggleSwitch
-          v-if="mode === 'appearance'"
-          :label="t('Settings.General Settings.Show Thumbnail Previews')"
-          :default-value="showThumbnailPreviews"
-          setting-key="showThumbnailPreviews"
-          :compact="true"
-          :tooltip="t('Tooltips.General Settings.Show Thumbnail Previews')"
-          @change="updateShowThumbnailPreviews"
-        />
-        <FtToggleSwitch
-          v-if="mode === 'general'"
-          :label="t('Settings.General Settings.Check for Updates')"
-          :default-value="checkForUpdates"
-          setting-key="checkForUpdates"
-          :compact="true"
-          @change="updateCheckForUpdates"
-        />
-        <FtToggleSwitch
-          v-if="mode === 'providers' && SUPPORTS_LOCAL_API"
-          :label="t('Settings.General Settings.Fallback to Non-Preferred Backend on Failure')"
-          :default-value="backendFallback"
-          setting-key="backendFallback"
-          :compact="true"
-          :tooltip="t('Tooltips.General Settings.Fallback to Non-Preferred Backend on Failure')"
-          @change="updateBackendFallback"
-        />
-        <FtToggleSwitch
-          v-if="mode === 'general'"
-          :label="t('Settings.General Settings.Update Relative Timestamps')"
-          :tooltip="t('Tooltips.General Settings.Update Relative Timestamps')"
-          :default-value="updateRelativeTimestamps"
-          setting-key="updateRelativeTimestamps"
-          :compact="true"
-          @change="updateRelativeTimestampsSetting"
-        />
-        <!-- Last in this column on purpose: it is the only one of these that
-             some platforms hide, so the columns stay even where it is missing
-             and this one stays the longer of the two where it is not. -->
-        <FtToggleSwitch
-          v-if="mode === 'general' && !IS_MAC && !isLinuxWayland && USING_ELECTRON"
-          :label="t('Settings.General Settings.Minimize to system tray')"
-          :default-value="hideToTrayOnMinimize"
-          setting-key="hideToTrayOnMinimize"
-          :compact="true"
-          @change="updateHideToTrayOnMinimize"
-        />
-      </div>
-      <div
-        v-if="mode !== 'appearance'"
-        class="switchColumn"
-      >
-        <FtToggleSwitch
-          v-if="mode === 'providers'"
-          :label="t('Settings.Player Settings.Proxy Videos Through Invidious')"
-          :compact="true"
-          :default-value="showProxyVideosAsDisabled ? false : proxyVideos"
-          :disabled="showProxyVideosAsDisabled"
-          :tooltip="t('Tooltips.Player Settings.Proxy Videos Through Invidious')"
-          @change="updateProxyVideos"
-        />
-        <FtToggleSwitch
-          v-if="mode === 'general' && USING_ELECTRON"
-          :label="t('Settings.General Settings.Open Deep Links In New Window')"
-          :default-value="openDeepLinksInNewWindow"
-          setting-key="openDeepLinksInNewWindow"
-          :compact="true"
-          :tooltip="t('Tooltips.General Settings.Open Deep Links In New Window')"
-          @change="updateOpenDeepLinksInNewWindow"
-        />
-        <FtToggleSwitch
-          v-if="mode === 'general'"
-          :label="t('Settings.General Settings.Auto Load Next Page.Label')"
-          :default-value="generalAutoLoadMorePaginatedItemsEnabled"
-          setting-key="generalAutoLoadMorePaginatedItemsEnabled"
-          :compact="true"
-          :tooltip="t('Settings.General Settings.Auto Load Next Page.Tooltip')"
-          @change="updateGeneralAutoLoadMorePaginatedItemsEnabled"
-        />
-        <FtToggleSwitch
-          v-if="mode === 'general'"
-          :label="t('Settings.General Settings.Use AI Translation Completions')"
-          :default-value="useAITranslationCompletions"
-          setting-key="useAITranslationCompletions"
-          :compact="true"
-          :disabled="aiTranslationCompletionsDisabled"
-          :tooltip="t('Tooltips.General Settings.Use AI Translation Completions')"
-          @change="updateUseAITranslationCompletions"
-        />
-      </div>
+      <FtToggleSwitch
+        v-if="mode === 'appearance'"
+        :label="t('Settings.General Settings.Show Thumbnail Previews')"
+        :default-value="showThumbnailPreviews"
+        setting-key="showThumbnailPreviews"
+        :compact="true"
+        :tooltip="t('Tooltips.General Settings.Show Thumbnail Previews')"
+        @change="updateShowThumbnailPreviews"
+      />
+      <FtToggleSwitch
+        v-if="mode === 'general'"
+        :label="t('Settings.General Settings.Check for Updates')"
+        :default-value="checkForUpdates"
+        setting-key="checkForUpdates"
+        :compact="true"
+        @change="updateCheckForUpdates"
+      />
+      <FtToggleSwitch
+        v-if="mode === 'general' && USING_ELECTRON"
+        :label="t('Settings.General Settings.Open Deep Links In New Window')"
+        :default-value="openDeepLinksInNewWindow"
+        setting-key="openDeepLinksInNewWindow"
+        :compact="true"
+        :tooltip="t('Tooltips.General Settings.Open Deep Links In New Window')"
+        @change="updateOpenDeepLinksInNewWindow"
+      />
+      <FtToggleSwitch
+        v-if="mode === 'providers' && SUPPORTS_LOCAL_API"
+        :label="t('Settings.General Settings.Fallback to Non-Preferred Backend on Failure')"
+        :default-value="backendFallback"
+        setting-key="backendFallback"
+        :compact="true"
+        :tooltip="t('Tooltips.General Settings.Fallback to Non-Preferred Backend on Failure')"
+        @change="updateBackendFallback"
+      />
+      <FtToggleSwitch
+        v-if="mode === 'providers'"
+        :label="t('Settings.Player Settings.Proxy Videos Through Invidious')"
+        :compact="true"
+        :default-value="showProxyVideosAsDisabled ? false : proxyVideos"
+        :disabled="showProxyVideosAsDisabled"
+        :tooltip="t('Tooltips.Player Settings.Proxy Videos Through Invidious')"
+        @change="updateProxyVideos"
+      />
+      <FtToggleSwitch
+        v-if="mode === 'general'"
+        :label="t('Settings.General Settings.Update Relative Timestamps')"
+        :tooltip="t('Tooltips.General Settings.Update Relative Timestamps')"
+        :default-value="updateRelativeTimestamps"
+        setting-key="updateRelativeTimestamps"
+        :compact="true"
+        @change="updateRelativeTimestampsSetting"
+      />
+      <FtToggleSwitch
+        v-if="mode === 'general'"
+        :label="t('Settings.General Settings.Auto Load Next Page.Label')"
+        :default-value="generalAutoLoadMorePaginatedItemsEnabled"
+        setting-key="generalAutoLoadMorePaginatedItemsEnabled"
+        :compact="true"
+        :tooltip="t('Settings.General Settings.Auto Load Next Page.Tooltip')"
+        @change="updateGeneralAutoLoadMorePaginatedItemsEnabled"
+      />
+      <FtToggleSwitch
+        v-if="mode === 'general' && !IS_MAC && !isLinuxWayland && USING_ELECTRON"
+        :label="t('Settings.General Settings.Minimize to system tray')"
+        :default-value="hideToTrayOnMinimize"
+        setting-key="hideToTrayOnMinimize"
+        :compact="true"
+        @change="updateHideToTrayOnMinimize"
+      />
+      <FtToggleSwitch
+        v-if="mode === 'general'"
+        :label="t('Settings.General Settings.Use AI Translation Completions')"
+        :default-value="useAITranslationCompletions"
+        setting-key="useAITranslationCompletions"
+        :compact="true"
+        :disabled="aiTranslationCompletionsDisabled"
+        :tooltip="t('Tooltips.General Settings.Use AI Translation Completions')"
+        @change="updateUseAITranslationCompletions"
+      />
     </div>
     <div class="switchGrid generalSelectGrid">
       <FtSelect


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Make sure to follow the contributing guidelines. -->
<!-- Important note, we may remove your pull request if you do not use this provided PR template correctly. -->
<!-- Agent instructions: Preserve every heading, comment, and marker in this template. Never remove or rewrite the release-note-category:start/end, release-note:start/end, or release-note-image:start/end marker pairs. -->

## Pull Request Type
<!-- Please select what type of pull request this is: [x] -->
- [x] Bugfix
- [ ] Feature Implementation
- [ ] Documentation
- [ ] Other

## Related issue
<!-- Please link the issue your pull request is referring to. -->
<!-- If this pull request fully resolves the relevant issue, put "closes" before the issue number. -->
<!-- Example: "closes #123456". -->

Reported directly without an issue.

## Description
<!-- Please write a clear and concise description of what the pull request does. -->

General settings used fixed column wrappers, so hiding a platform-specific toggle could leave the final setting alone in the trailing column.

This changes the toggle group to fill rows from inline start. Incomplete rows now end on the left in LTR layouts and on the right in RTL layouts. The rendered order also matches keyboard navigation order.

## Release note category
<!-- Select exactly one category. Every pull request must select one. -->
<!-- Select "Not noteworthy" when the pull request fixes a bug in or improves functionality that has not yet appeared in a stable release. -->
<!-- release-note-category:start -->
- [ ] Not noteworthy
- [ ] Highlights
- [ ] More improvements
- [x] Fixed bugs
<!-- release-note-category:end -->

## Release note
<!-- Required unless "Not noteworthy" is selected. -->
<!-- Write one concise, user-facing entry without a leading bullet. -->
<!-- release-note:start -->
Settings with an incomplete two-column toggle row now place the remaining option on the language's starting side.
<!-- release-note:end -->

## Release note images
<!-- Optional. Paste one or more Markdown images, HTML image tags, or dark/light <picture> elements here. -->
<!-- The release notes normalize the markup and limit images taller than 300 pixels. -->
<!-- Agent instructions:
For a noteworthy visible change, add media when it makes the change easier to understand. Prefer a still image unless motion is the point; recordings must use animated WebP.
After implementing a visible change, proactively capture the result and show the local media to the user for approval before uploading it or updating the pull request.
When the affected UI differs between dark and light themes, capturing both themes is required. A dark-only image is incomplete. Run `node _scripts/releaseNoteMedia.mjs --dark DARK_FILE --light LIGHT_FILE --alt "DESCRIPTION"`; GitHub will display the matching theme and use dark as the fallback. Use a single default-dark capture only when the light theme cannot be captured or looks identical.
Capture or crop to the smallest region that still makes the change clear. Do not include the full window when the affected component can be understood on its own.
Use English unless localization is the subject. Keep components at their normal dimensions and placement instead of resizing them to fill the frame.
Use deterministic local fixtures for visible remote images. Reusable avatar and thumbnail fixtures are available through `e2e/helpers/visual-fixtures.mjs`. Before capturing, verify that every visible image has loaded successfully (`complete === true` and `naturalWidth > 0`).
Inspect the final dark and light files for failed images, missing content, unrelated UI, awkward animation, and misleading layout. Omit media when it does not explain the change clearly.
For one dark capture, run `node _scripts/releaseNoteMedia.mjs FILE --alt "DESCRIPTION"`.
Check for personal information, tokens, private repository names, and unrelated desktop content before uploading. Uploaded media is public.
Keep capture-only scripts, test hooks, screenshots, and recordings out of commits. Remove them before committing unless the capture code is also a reusable regression test. Never commit generated release-note media.
Paste only the generated markup between the marker comments. Leave this section empty when media would not help.
-->
<!-- release-note-image:start -->

<!-- release-note-image:end -->

## Testing
<!-- How can reviewers verify that the PR produces correct results? -->
<!-- Please provide instructions so that others can ensure that your pull request would produce correct results. For examples see, https://github.com/FreeTubeApp/FreeTube/pull/5743, https://github.com/FreeTubeApp/FreeTube/pull/7349, https://github.com/FreeTubeApp/FreeTube/pull/5125, https://github.com/FreeTubeApp/FreeTube/pull/7338 -->
<!-- Agent instructions: Only write human-facing steps that explain how to verify the change while running this branch in dev mode. Include expected results and, when applicable, helpful console snippets for interactive verification. Do not include automated checks, commands, results, pass counts, or CI status. -->

1. Open General settings on a platform where "Minimize to system tray" is unavailable, such as Linux Wayland.
2. At a wide settings-window size, verify that the fifth toggle occupies the left side of the final row in an LTR locale.
3. Switch to an RTL locale and verify that the final toggle moves to the right side.
4. Narrow the settings window and verify that the toggles collapse into one centered column.

## Additional context
<!-- Add any other context about the pull request here. -->

The previous fixed column wrappers could not rebalance after a conditional toggle disappeared. Row-first grid placement handles the platform-dependent count without JavaScript layout logic.
