### PR TITLE
fix: keep filtered comment replies accessible

### DIFF
--- a/e2e/helpers/watch.mjs
+++ b/e2e/helpers/watch.mjs
@@ -46,67 +46,72 @@ async function fixture(dir, name) {
   }
 }
 
-function addOwnerReplyMarker(body) {
+function mutateFirstObject(body, mutate, errorMessage) {
   const response = JSON.parse(body)
   const pending = [response]
+  let nextIndex = 0
 
-  while (pending.length > 0) {
-    const value = pending.pop()
+  while (nextIndex < pending.length) {
+    const value = pending[nextIndex++]
     if (!value || typeof value !== 'object') continue
 
-    const replies = value.commentThreadRenderer?.replies?.commentRepliesRenderer
-    if (replies) {
-      replies.viewRepliesCreatorThumbnail = {
-        thumbnails: [{ url: 'https://images.test/channel-owner.png' }]
-      }
+    if (mutate(value)) {
       return Buffer.from(JSON.stringify(response))
     }
 
     pending.push(...Object.values(value))
   }
 
-  throw new Error('Unable to add an owner-reply marker to the comment fixture')
+  throw new Error(errorMessage)
+}
+
+function addOwnerReplyMarker(body) {
+  return mutateFirstObject(body, value => {
+    const replies = value.commentThreadRenderer?.replies?.commentRepliesRenderer
+    if (!replies) return false
+
+    replies.viewRepliesCreatorThumbnail = {
+      thumbnails: [{ url: 'https://images.test/channel-owner.png' }]
+    }
+    return true
+  }, 'Unable to add an owner-reply marker to the comment fixture')
+}
+
+function markFirstReplyAsCreator(body) {
+  return mutateFirstObject(body, value => {
+    const payload = value.commentEntityPayload
+    if (payload?.properties?.replyLevel > 0 && payload.author) {
+      payload.author.isCreator = true
+      return true
+    }
+
+    return false
+  }, 'Unable to mark a reply as the video creator in the comment fixture')
 }
 
 function addCommentTimestamp(body) {
-  const response = JSON.parse(body)
-  const pending = [response]
-
-  while (pending.length > 0) {
-    const value = pending.pop()
-    if (!value || typeof value !== 'object') continue
-
+  return mutateFirstObject(body, value => {
     const payload = value.commentEntityPayload
     if (payload?.properties?.replyLevel === 0 && payload.properties.content?.content) {
       payload.properties.content.content += ' Start at 0:05.'
-      return Buffer.from(JSON.stringify(response))
+      return true
     }
 
-    pending.push(...Object.values(value))
-  }
-
-  throw new Error('Unable to add a timestamp to the comment fixture')
+    return false
+  }, 'Unable to add a timestamp to the comment fixture')
 }
 
 function blankCommentLikeCount(body) {
-  const response = JSON.parse(body)
-  const pending = [response]
-
-  while (pending.length > 0) {
-    const value = pending.pop()
-    if (!value || typeof value !== 'object') continue
-
+  return mutateFirstObject(body, value => {
     const payload = value.commentEntityPayload
     if (payload?.properties?.content?.content === "We're so honored that the first ever YouTube video was filmed here!") {
       payload.toolbar.likeCountNotliked = ' '
       payload.toolbar.likeCountA11y = '0 likes'
-      return Buffer.from(JSON.stringify(response))
+      return true
     }
 
-    pending.push(...Object.values(value))
-  }
-
-  throw new Error('Unable to blank the comment like count in the fixture')
+    return false
+  }, 'Unable to blank the comment like count in the fixture')
 }
 
 /**
@@ -127,6 +132,7 @@ function blankCommentLikeCount(body) {
  * @param {string} [options.captionCueSettings] append WebVTT settings to the test caption cue
  * @param {string[]|null} [options.captionVideoIds] limit captions to these video IDs
  * @param {boolean} [options.ownerReply] mark the first reply thread as containing a video-owner reply
+ * @param {boolean} [options.creatorReply] mark the first loaded reply as written by the video creator
  * @param {boolean} [options.commentTimestamp] add a timestamp to one top-level comment
  * @param {boolean} [options.blankCommentLikes] replace one comment's zero-like count with YouTube's whitespace representation
  */
@@ -136,6 +142,7 @@ export async function mockWatchPage(app, page, {
   captionCueSettings = '',
   captionVideoIds = null,
   ownerReply = false,
+  creatorReply = false,
   commentTimestamp = false,
   blankCommentLikes = false
 } = {}) {
@@ -258,8 +265,11 @@ export async function mockWatchPage(app, page, {
       }
 
       if (body) {
-        if (ownerReply && body.includes('commentThreadRenderer')) {
+        if (ownerReply && body.includes('"replyLevel":0')) {
           body = addOwnerReplyMarker(body)
+        }
+        if (creatorReply && body.includes('"replyLevel":1')) {
+          body = markFirstReplyAsCreator(body)
         }
         if (commentTimestamp && body.includes('commentEntityPayload')) {
           body = addCommentTimestamp(body)

--- a/e2e/tests/offline/watch-page.spec.mjs
+++ b/e2e/tests/offline/watch-page.spec.mjs
@@ -3945,8 +3945,8 @@ test.describe('manual comment loading', () => {
     await expect(translationButtons).toHaveCount(0)
   })
 
-  test('identifies and filters collapsed replies from the video uploader', async ({ app, page, attachScreenshot }) => {
-    await mockPlayableWatchPage(app, page, { ownerReply: true })
+  test('loads collapsed replies from the video uploader while filtering', async ({ app, page, attachScreenshot }) => {
+    await mockPlayableWatchPage(app, page, { creatorReply: true, ownerReply: true })
     await openMockedVideo(page)
 
     const loadComments = page.locator('.getCommentsTitle')
@@ -3963,7 +3963,8 @@ test.describe('manual comment loading', () => {
     await expect(ownerReplyToggle.locator('.commentReplyOwnerSeparator')).toHaveText('•')
     await expect(ownerReplyToggle.locator('.commentReplyToggleText')).toHaveText(/\d+ replies/)
     await expect(ownerReplyToggle).not.toContainText('from')
-    const ownerReplyThread = page.locator('.commentThread').filter({ has: ownerReplyToggle })
+    const ownerReplyThreadWithToggle = page.locator('.commentThread').filter({ has: ownerReplyToggle })
+    const ownerReplyThread = page.locator(`#${await ownerReplyThreadWithToggle.getAttribute('id')}`)
     const ownerReplyThreadElement = await ownerReplyThread.elementHandle()
     expect(ownerReplyThreadElement).not.toBeNull()
     await expect(ownerReplyThread.locator('.commentReplyContent')).toHaveCount(0)
@@ -3977,6 +3978,12 @@ test.describe('manual comment loading', () => {
       isVisible: element.getClientRects().length > 0,
       loadedReplyCount: element.querySelectorAll('.commentReplyContent').length
     }))).toEqual({ isConnected: true, isVisible: true, loadedReplyCount: 0 })
+    await expect(ownerReplyToggle).toBeVisible()
+    await ownerReplyToggle.click()
+    await expect.poll(() => ownerReplyThread.evaluate(element => {
+      const replies = [...element.querySelectorAll('.commentReplyContent')]
+      return replies.length > 0 && replies.every(reply => reply.querySelector('.commentOwner'))
+    })).toBe(true)
     await ownerReplyThreadElement.dispose()
   })
 
@@ -4063,6 +4070,46 @@ test.describe('manual comment loading', () => {
     await expect(page.locator('.commentThread')).toHaveCount(1)
     await expect(page.locator('.commentReplyContent')).toHaveCount(1)
     await expect(page.locator('.commentReplyContent .commentAuthor mark')).toHaveText(replyAuthor)
+  })
+
+  test('ends filtered thread lines at the last reply from the creator', async ({ app, page }) => {
+    await mockPlayableWatchPage(app, page, { creatorReply: true })
+    await openMockedVideo(page)
+
+    const loadComments = page.locator('.getCommentsTitle')
+    await loadComments.scrollIntoViewIfNeeded()
+    await loadComments.click()
+    await expect(page.locator('.commentsTitle')).toBeVisible({ timeout: 30_000 })
+
+    const thread = page.locator('.commentThread').first()
+    await thread.locator('.commentReplyRootToggle button').click()
+    await expect(thread.locator('.commentReplyContent').first()).toBeVisible({ timeout: 30_000 })
+
+    await page.getByRole('button', { name: 'Filter loaded comments' }).click()
+    await page.getByRole('checkbox', { name: 'From creator' }).click()
+
+    const filteredReplyThread = page.locator('.commentThread').filter({
+      has: page.locator('.commentReplyContent')
+    })
+    await expect(filteredReplyThread).toHaveCount(1)
+    await expect(filteredReplyThread.locator('.commentReplyContent')).toHaveCount(1)
+
+    const expectLineToEndAtLastConnector = () => expect.poll(() => filteredReplyThread.evaluate(element => {
+      const lineStyle = getComputedStyle(element, '::before')
+      const lineEnd = element.getBoundingClientRect().bottom - Number.parseFloat(lineStyle.insetBlockEnd)
+      const connectors = element.querySelectorAll(
+        ':scope > .commentReplies > .commentReplyBranchRoot > .commentReplyConnector'
+      )
+      const connectorEnd = connectors.item(connectors.length - 1).getBoundingClientRect().bottom
+      return Math.abs(lineEnd - connectorEnd)
+    })).toBeLessThanOrEqual(0.5)
+
+    await expectLineToEndAtLastConnector()
+    await page.evaluate(() => {
+      const store = document.querySelector('#app').__vue_app__.config.globalProperties.$store
+      return store.dispatch('updateUiScale', 125)
+    })
+    await expectLineToEndAtLastConnector()
   })
 
   test('filters comments with timestamps and keeps highlighted timestamps clickable', async ({ app, page }) => {

--- a/src/renderer/components/CommentSection/CommentSection.css
+++ b/src/renderer/components/CommentSection/CommentSection.css
@@ -410,7 +410,7 @@
   content: '';
   position: absolute;
   z-index: 0;
-  inset-block: 75px 71px;
+  inset-block: 75px var(--filtered-comment-thread-line-inset-block-end, 71px);
   inset-inline-start: 45px;
   border-inline-start: 1px solid var(--comment-thread-line-color);
   pointer-events: none;

--- a/src/renderer/components/CommentSection/CommentSection.vue
+++ b/src/renderer/components/CommentSection/CommentSection.vue
@@ -196,10 +196,11 @@
           v-for="({ comment, index, replyNodes }) in visibleCommentEntries"
           :id="index === null ? `comment-pinned-${comment.id}` : 'comment' + index"
           :key="comment.id"
+          v-filtered-comment-thread-line="hasActiveCommentFilters"
           class="comment commentThread"
           :class="{
             commentThreadExpanded: shouldShowCommentReplies(comment, replyNodes),
-            commentThreadCollapsed: !hasActiveCommentFilters && comment.numReplies > 0 && !comment.showReplies,
+            commentThreadCollapsed: shouldShowCommentReplyToggle(comment, replyNodes),
             highlightedComment: comment.id === highlightedCommentId
           }"
         >
@@ -369,7 +370,7 @@
             </span>
           </p>
           <div
-            v-if="index !== null && !hasActiveCommentFilters && comment.numReplies > 0 && !comment.showReplies"
+            v-if="index !== null && shouldShowCommentReplyToggle(comment, replyNodes)"
             class="commentReplyContinuation commentReplyRootToggle"
           >
             <button
@@ -443,7 +444,7 @@
               @translation-unavailable="restoreCommentTranslation"
             />
             <div
-              v-if="index !== null && !hasActiveCommentFilters && (isReplyLoading(comment.id) || comment.hasReplyToken)"
+              v-if="index !== null && shouldShowCommentReplyContinuation(comment, replyNodes)"
               class="commentReplyContinuation"
             >
               <button
@@ -762,6 +763,61 @@ const normalizedCommentSearchQuery = computed(() => {
   return commentSearchQuery.value.trim().toLocaleLowerCase()
 })
 
+const filteredCommentThreadLineObservers = new WeakMap()
+
+function updateFilteredCommentThreadLine(element, filtering) {
+  if (!filtering) {
+    element.style.removeProperty('--filtered-comment-thread-line-inset-block-end')
+    return
+  }
+
+  const connectors = element.querySelectorAll(
+    ':scope > .commentReplies > .commentReplyBranchRoot > .commentReplyConnector'
+  )
+  const lastConnector = connectors.item(connectors.length - 1)
+  if (!lastConnector) {
+    element.style.removeProperty('--filtered-comment-thread-line-inset-block-end')
+    return
+  }
+
+  const inset = element.getBoundingClientRect().bottom - lastConnector.getBoundingClientRect().bottom
+  element.style.setProperty('--filtered-comment-thread-line-inset-block-end', `${inset}px`)
+}
+
+function observeFilteredCommentThreadLine(element, filtering) {
+  const state = filteredCommentThreadLineObservers.get(element)
+  if (!state) return
+
+  if (!filtering) {
+    state.observer?.disconnect()
+    state.observer = null
+    updateFilteredCommentThreadLine(element, false)
+    return
+  }
+
+  if (!state.observer) {
+    state.observer = new ResizeObserver(() => {
+      updateFilteredCommentThreadLine(element, true)
+    })
+    state.observer.observe(element)
+  }
+  updateFilteredCommentThreadLine(element, true)
+}
+
+const vFilteredCommentThreadLine = {
+  mounted(element, binding) {
+    filteredCommentThreadLineObservers.set(element, { observer: null })
+    observeFilteredCommentThreadLine(element, binding.value)
+  },
+  updated(element, binding) {
+    observeFilteredCommentThreadLine(element, binding.value)
+  },
+  unmounted(element) {
+    filteredCommentThreadLineObservers.get(element)?.observer?.disconnect()
+    filteredCommentThreadLineObservers.delete(element)
+  }
+}
+
 const hasActiveCommentFilters = computed(() => {
   return normalizedCommentSearchQuery.value !== '' ||
     creatorCommentsOnly.value ||
@@ -862,8 +918,30 @@ const matchingCommentCount = computed(() => {
   return commentEntries.value.reduce((count, { comment }) => count + countMatchingComments(comment), 0)
 })
 
+function shouldLoadFilteredCreatorReplies(comment, replyNodes) {
+  return creatorCommentsOnly.value &&
+    comment.hasOwnerReplied &&
+    replyNodes.length === 0
+}
+
+function shouldShowCommentReplyToggle(comment, replyNodes) {
+  if (comment.numReplies <= 0 || comment.showReplies) {
+    return false
+  }
+
+  return !hasActiveCommentFilters.value || shouldLoadFilteredCreatorReplies(comment, replyNodes)
+}
+
+function shouldShowCommentReplyContinuation(comment, replyNodes) {
+  const canLoadMore = isReplyLoading(comment.id) || comment.hasReplyToken
+  return canLoadMore && (
+    !hasActiveCommentFilters.value || shouldLoadFilteredCreatorReplies(comment, replyNodes)
+  )
+}
+
 function shouldShowCommentReplies(comment, replyNodes) {
-  return replyNodes.length > 0 && (comment.showReplies || hasActiveCommentFilters.value)
+  return (replyNodes.length > 0 && (comment.showReplies || hasActiveCommentFilters.value)) ||
+    (comment.showReplies && shouldShowCommentReplyContinuation(comment, replyNodes))
 }
 
 function getCommentAuthorSearchSegments(author) {


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Make sure to follow the contributing guidelines. -->
<!-- Important note, we may remove your pull request if you do not use this provided PR template correctly. -->
<!-- Agent instructions: Preserve every heading, comment, and marker in this template. Never remove or rewrite the release-note-category:start/end, release-note:start/end, or release-note-image:start/end marker pairs. -->

## Pull Request Type
<!-- Please select what type of pull request this is: [x] -->
- [x] Bugfix
- [ ] Feature Implementation
- [ ] Documentation
- [ ] Other

## Related issue
<!-- Please link the issue your pull request is referring to. -->
<!-- If this pull request fully resolves the relevant issue, put "closes" before the issue number. -->
<!-- Example: "closes #123456". -->

## Description
<!-- Please write a clear and concise description of what the pull request does. -->

Filtering loaded comments could leave thread lines extending past the last visible reply. The "From creator" filter could also retain a parent comment because the creator replied while hiding the control needed to load that reply.

This measures filtered thread lines against their last visible connector and keeps the reply-loading control available until the creator's reply is shown.

## Release note category
<!-- Select exactly one category. Every pull request must select one. -->
<!-- Select "Not noteworthy" when the pull request fixes a bug in or improves functionality that has not yet appeared in a stable release. -->
<!-- release-note-category:start -->
- [ ] Not noteworthy
- [ ] Highlights
- [ ] More improvements
- [x] Fixed bugs
<!-- release-note-category:end -->

## Release note
<!-- Required unless "Not noteworthy" is selected. -->
<!-- Write one concise, user-facing entry without a leading bullet. -->
<!-- release-note:start -->
Comment filters now keep thread lines aligned and let you open creator replies from retained parent comments.
<!-- release-note:end -->

## Release note images
<!-- Optional. Paste one or more Markdown images, HTML image tags, or dark/light <picture> elements here. -->
<!-- The release notes normalize the markup and limit images taller than 300 pixels. -->
<!-- Agent instructions:
For a noteworthy visible change, add media when it makes the change easier to understand. Prefer a still image unless motion is the point; recordings must use animated WebP.
After implementing a visible change, proactively capture the result and show the local media to the user for approval before uploading it or updating the pull request.
When the affected UI differs between dark and light themes, capturing both themes is required. A dark-only image is incomplete. Run `node _scripts/releaseNoteMedia.mjs --dark DARK_FILE --light LIGHT_FILE --alt "DESCRIPTION"`; GitHub will display the matching theme and use dark as the fallback. Use a single default-dark capture only when the light theme cannot be captured or looks identical.
Capture or crop to the smallest region that still makes the change clear. Do not include the full window when the affected component can be understood on its own.
Use English unless localization is the subject. Keep components at their normal dimensions and placement instead of resizing them to fill the frame.
Use deterministic local fixtures for visible remote images. Reusable avatar and thumbnail fixtures are available through `e2e/helpers/visual-fixtures.mjs`. Before capturing, verify that every visible image has loaded successfully (`complete === true` and `naturalWidth > 0`).
Inspect the final dark and light files for failed images, missing content, unrelated UI, awkward animation, and misleading layout. Omit media when it does not explain the change clearly.
For one dark capture, run `node _scripts/releaseNoteMedia.mjs FILE --alt "DESCRIPTION"`.
Check for personal information, tokens, private repository names, and unrelated desktop content before uploading. Uploaded media is public.
Keep capture-only scripts, test hooks, screenshots, and recordings out of commits. Remove them before committing unless the capture code is also a reusable regression test. Never commit generated release-note media.
Paste only the generated markup between the marker comments. Leave this section empty when media would not help.
-->
<!-- release-note-image:start -->

<!-- release-note-image:end -->

## Testing
<!-- How can reviewers verify that the PR produces correct results? -->
<!-- Please provide instructions so that others can ensure that your pull request produces correct results. For examples see, https://github.com/FreeTubeApp/FreeTube/pull/5743, https://github.com/FreeTubeApp/FreeTube/pull/7349, https://github.com/FreeTubeApp/FreeTube/pull/5125, https://github.com/FreeTubeApp/FreeTube/pull/7338 -->
<!-- Agent instructions: Only write human-facing steps that explain how to verify the change while running this branch in dev mode. Include expected results and, when applicable, helpful console snippets for interactive verification. Do not include automated checks, commands, results, pass counts, or CI status. -->

1. Open a video whose comments include a collapsed thread marked as containing a reply from the video creator.
2. Enable the "From creator" comment filter. The retained parent comment should still show its replies button.
3. Open the replies. The creator's reply should appear, while unrelated replies remain filtered out.
4. Load a thread with several replies, enable a comment filter, and confirm its vertical thread line ends at the final visible reply.
5. Repeat the filtered thread check at a non-default UI scale such as 125%.

## Additional context
<!-- Add any other context about the pull request here. -->
