### PR TITLE
feat(playlists): save YouTube playlists

### DIFF
--- a/e2e/tests/offline/playlist-loading.spec.mjs
+++ b/e2e/tests/offline/playlist-loading.spec.mjs
@@ -1,4 +1,4 @@
-import { test, expect, sel } from '../../helpers/app.mjs'
+import { test, expect, goTo, sel } from '../../helpers/app.mjs'
 
 test.use({
   seed: {
@@ -83,6 +83,105 @@ test('shows a persistent initial error and retries without navigation', async ({
 
   await expect(playlistPage.getByText('Playlist video 1', { exact: true })).toBeVisible()
   expect(requestCount).toBe(2)
+})
+
+test('saves a YouTube playlist as a read-only link and persists it', async ({ app, page }) => {
+  const playlistId = 'saved-playlist'
+  const response = {
+    ...playlistResponse([playlistVideo(0)], 1),
+    title: 'Saved YouTube playlist',
+    playlistId,
+  }
+  const mockPlaylist = currentPage => currentPage.route(
+    new RegExp(`/api/v1/playlists/${playlistId}\\?`),
+    route => route.fulfill({ json: response })
+  )
+
+  await mockPlaylist(page)
+  await page.route('https://invidious.test/vi/video-00000/mqdefault.jpg', route => route.fulfill({
+    contentType: 'image/svg+xml',
+    body: '<svg xmlns="http://www.w3.org/2000/svg" width="16" height="9"/>',
+  }))
+  await openPlaylistTab(page, `/playlist/${playlistId}`)
+
+  const saveButton = page.getByTitle('Save Playlist')
+  await expect(saveButton).toHaveAttribute('aria-pressed', 'false')
+  await saveButton.click()
+  await expect(page.getByTitle('Remove Saved Playlist')).toHaveAttribute('aria-pressed', 'true')
+
+  await goTo(page, 'userplaylists')
+  const savedPlaylistLink = page.getByRole('link', { name: 'Saved YouTube playlist' })
+  await expect(savedPlaylistLink).toBeVisible()
+  const savedPlaylistCard = savedPlaylistLink
+    .locator('xpath=ancestor::div[contains(@class, "ft-list-item")]')
+  const savedPlaylistThumbnail = savedPlaylistCard.locator('img.thumbnailImage')
+  await expect(savedPlaylistThumbnail).toHaveAttribute(
+    'src',
+    'https://invidious.test/vi/video-00000/mqdefault.jpg'
+  )
+  await expect.poll(() => savedPlaylistThumbnail.evaluate(image => image.naturalWidth))
+    .toBeGreaterThan(0)
+
+  ;({ page } = await app.relaunch())
+  await goTo(page, 'userplaylists')
+  await expect(page.getByRole('link', { name: 'Saved YouTube playlist' })).toBeVisible()
+
+  await mockPlaylist(page)
+  await page.getByRole('link', { name: 'Saved YouTube playlist' }).click()
+  await expect(page).toHaveURL(new RegExp(`#/playlist/${playlistId}(?:\\?|$)`))
+  await expect(page.getByTitle('Edit Playlist Info')).toHaveCount(0)
+
+  await page.getByTitle('Remove Saved Playlist').click()
+  await goTo(page, 'userplaylists')
+  await expect(page.getByRole('link', { name: 'Saved YouTube playlist' })).toHaveCount(0)
+})
+
+test('keeps the search result thumbnail when saving a playlist', async ({ page }) => {
+  const playlistId = 'search-thumbnail-playlist'
+  const searchThumbnailVideoId = 'search-thumbnail-video'
+  const firstPlaylistVideoId = 'first-playlist-video'
+
+  await page.route('https://invidious.test/api/v1/search/**', route => route.fulfill({
+    json: [{
+      type: 'playlist',
+      title: 'Playlist with search thumbnail',
+      playlistId,
+      playlistThumbnail: `https://i.ytimg.com/vi/${searchThumbnailVideoId}/hqdefault.jpg`,
+      author: 'Playlist channel',
+      authorId: 'UCplaylistchannel',
+      authorUrl: '/channel/UCplaylistchannel',
+      authorVerified: false,
+      videoCount: 1,
+      videos: [],
+    }],
+  }))
+  await page.route(new RegExp(`/api/v1/playlists/${playlistId}\\?`), route => route.fulfill({
+    json: {
+      ...playlistResponse([playlistVideo(0, firstPlaylistVideoId)], 1),
+      title: 'Playlist with search thumbnail',
+      playlistId,
+    },
+  }))
+
+  await page.locator(sel.searchInput).fill('playlist thumbnail')
+  await page.locator(sel.searchInput).press('Enter')
+
+  const searchResultLink = page.getByRole('link', { name: 'Playlist with search thumbnail' }).last()
+  const searchResultCard = searchResultLink
+    .locator('xpath=ancestor::div[contains(@class, "ft-list-item")]')
+  const searchResultThumbnail = searchResultCard.locator('img.thumbnailImage')
+  const expectedThumbnail = `https://invidious.test/vi/${searchThumbnailVideoId}/mqdefault.jpg`
+  await expect(searchResultThumbnail).toHaveAttribute('src', expectedThumbnail)
+
+  await searchResultLink.click()
+  await page.getByTitle('Save Playlist').click()
+  await goTo(page, 'userplaylists')
+
+  const savedPlaylistLink = page.getByRole('link', { name: 'Playlist with search thumbnail' }).last()
+  const savedPlaylistCard = savedPlaylistLink
+    .locator('xpath=ancestor::div[contains(@class, "ft-list-item")]')
+  await expect(savedPlaylistCard.locator('img.thumbnailImage'))
+    .toHaveAttribute('src', expectedThumbnail)
 })
 
 test('retries the failed Invidious page and merges its overlapping videos once', async ({ page }) => {
@@ -181,4 +280,50 @@ test('ignores an Invidious continuation that finishes after playlist navigation'
   await continuationFinished
   await page.waitForTimeout(100)
   await expect(page.locator('.playlistPage').getByText('Playlist video 100', { exact: true })).toHaveCount(0)
+})
+
+test.describe('saved playlist thumbnails', () => {
+  test.use({
+    seed: {
+      settings: {
+        backendPreference: 'local',
+        defaultInvidiousInstance: 'https://invidious.test',
+        playlistBookmarks: [{
+          playlist: {
+            id: 'saved-local-playlist',
+            title: 'Saved local playlist',
+            description: '',
+            thumbnail_url: 'https://i.ytimg.com/vi/saved-video/mqdefault.jpg',
+            video_count: 1,
+          },
+          uploader: {
+            id: 'saved-channel',
+            name: 'Saved channel',
+            avatar: null,
+            verified: false,
+          },
+          savedAt: 1_700_000_000_000,
+        }],
+      },
+    },
+  })
+
+  test('loads a saved playlist thumbnail through the active local backend', async ({ page }) => {
+    await page.route('https://i.ytimg.com/vi/saved-video/mqdefault.jpg', route => route.fulfill({
+      contentType: 'image/svg+xml',
+      body: '<svg xmlns="http://www.w3.org/2000/svg" width="16" height="9"/>',
+    }))
+    await page.route('https://invidious.test/vi/saved-video/mqdefault.jpg', route => route.abort())
+
+    await goTo(page, 'userplaylists')
+
+    const playlistCard = page.getByRole('link', { name: 'Saved local playlist' })
+      .locator('xpath=ancestor::div[contains(@class, "ft-list-item")]')
+    const thumbnail = playlistCard.locator('img.thumbnailImage')
+    await expect(thumbnail).toHaveAttribute(
+      'src',
+      'https://i.ytimg.com/vi/saved-video/mqdefault.jpg'
+    )
+    await expect.poll(() => thumbnail.evaluate(image => image.naturalWidth)).toBeGreaterThan(0)
+  })
 })

--- a/src/renderer/components/FtListPlaylist/FtListPlaylist.vue
+++ b/src/renderer/components/FtListPlaylist/FtListPlaylist.vue
@@ -98,6 +98,15 @@
           @disabled-click="handleQuickBookmarkEnabledDisabledClick"
           @click="enableQuickBookmarkForThisPlaylist"
         />
+        <FtIconButton
+          v-if="isPlaylistBookmark"
+          :title="t('User Playlists.Remove Saved Playlist')"
+          :icon="['fas', 'bookmark']"
+          :aria-pressed="true"
+          theme="secondary"
+          :size="16"
+          @click="removePlaylistBookmark"
+        />
       </div>
     </div>
     <WatchVideoDownloadPrompt
@@ -187,15 +196,26 @@ const thumbnailForDisplay = computed(() => {
 })
 
 const isUserPlaylist = computed(() => props.data._id != null)
+const isPlaylistBookmark = computed(() => props.data.isPlaylistBookmark === true)
 
 // For `router-link` attribute `to`
-const playlistPageLinkTo = computed(() => ({
-  path: `/playlist/${playlistId}`,
-  query: {
+const playlistPageLinkTo = computed(() => {
+  const query = {
     playlistType: isUserPlaylist.value ? 'user' : '',
     searchQueryText: props.searchQueryText,
-  },
-}))
+  }
+  const playlistThumbnail = props.data.dataSource === 'local'
+    ? props.data.thumbnail
+    : props.data.playlistThumbnail
+  if (!isUserPlaylist.value && typeof playlistThumbnail === 'string' && playlistThumbnail !== '') {
+    query.playlistThumbnail = playlistThumbnail
+  }
+
+  return {
+    path: `/playlist/${playlistId}`,
+    query,
+  }
+})
 
 /** @type {import('vue').ComputedRef<'local' | 'invidious'>} */
 const backendPreference = computed(() => store.getters.getBackendPreference)
@@ -214,9 +234,12 @@ if (isUserPlaylist.value) {
 function parseInvidiousData() {
   title = props.data.title
 
-  thumbnail = props.data.playlistThumbnail
-    .replace('https://i.ytimg.com', currentInvidiousInstanceUrl.value)
-    .replace('hqdefault', 'mqdefault')
+  if (typeof props.data.playlistThumbnail === 'string' && props.data.playlistThumbnail !== '') {
+    thumbnail = props.data.playlistThumbnail.replace('hqdefault', 'mqdefault')
+    if (!isPlaylistBookmark.value || backendPreference.value === 'invidious') {
+      thumbnail = thumbnail.replace('https://i.ytimg.com', currentInvidiousInstanceUrl.value)
+    }
+  }
 
   channelName.value = props.data.author
   channelId.value = props.data.authorId
@@ -316,6 +339,16 @@ async function enableQuickBookmarkForThisPlaylist() {
     showToast({
       message: t('User Playlists.SinglePlaylistView.Toast.This playlist is now used for quick bookmark'),
       icon: ['fas', 'bookmark'],
+    })
+  }
+}
+
+async function removePlaylistBookmark() {
+  const removed = await store.dispatch('removePlaylistBookmark', playlistId)
+  if (!removed) {
+    showToast({
+      message: t('User Playlists.SinglePlaylistView.Toast["There was an issue with updating this playlist."]'),
+      icon: ['fas', 'circle-exclamation'],
     })
   }
 }

--- a/src/renderer/components/PlaylistInfo/PlaylistInfo.vue
+++ b/src/renderer/components/PlaylistInfo/PlaylistInfo.vue
@@ -167,6 +167,15 @@
             @click="enterEditMode"
           />
           <FtIconButton
+            v-if="!editMode && !isUserPlaylist && showPlaylists"
+            :title="isPlaylistBookmarked ? $t('User Playlists.Remove Saved Playlist') : $t('User Playlists.Save Playlist')"
+            :icon="isPlaylistBookmarked ? ['fas', 'bookmark'] : ['far', 'bookmark']"
+            :aria-pressed="isPlaylistBookmarked"
+            :disabled="playlistBookmarkPending"
+            :theme="isPlaylistBookmarked ? 'secondary' : 'base-no-default'"
+            @click="emit('toggle-playlist-bookmark')"
+          />
+          <FtIconButton
             v-if="videoCount > 0 && showPlaylists && !editMode"
             :title="$t('User Playlists.Copy Playlist')"
             :icon="['fas', 'copy']"
@@ -398,9 +407,17 @@ const props = defineProps({
     type: String,
     required: true,
   },
+  isPlaylistBookmarked: {
+    type: Boolean,
+    required: true,
+  },
+  playlistBookmarkPending: {
+    type: Boolean,
+    required: true,
+  },
 })
 
-const emit = defineEmits(['enter-edit-mode', 'exit-edit-mode', 'search-video-query-change', 'prompt-open', 'prompt-close'])
+const emit = defineEmits(['enter-edit-mode', 'exit-edit-mode', 'search-video-query-change', 'prompt-open', 'prompt-close', 'toggle-playlist-bookmark'])
 
 const { locale, t } = useI18n()
 const IS_ELECTRON = process.env.IS_ELECTRON

--- a/src/renderer/components/SyncSettings/SyncSettings.vue
+++ b/src/renderer/components/SyncSettings/SyncSettings.vue
@@ -416,6 +416,7 @@ const syncProgressLabel = computed(() => {
     download: t('Settings.Sync Settings.Downloading encrypted data'),
     subscriptions: t('Settings.Sync Settings.Syncing subscriptions'),
     playlists: t('Settings.Sync Settings.Syncing playlists'),
+    playlistBookmarks: t('Settings.Sync Settings.Syncing playlists'),
     history: t('Settings.Sync Settings.Syncing history'),
     profiles: t('Settings.Sync Settings.Syncing profiles'),
     sessions: t('Settings.Sync Settings.Syncing open tabs'),

--- a/src/renderer/helpers/playlist-bookmarks.js
+++ b/src/renderer/helpers/playlist-bookmarks.js
@@ -90,3 +90,24 @@ export function playlistBookmarkForSync(bookmark) {
     uploader: bookmark.uploader,
   }
 }
+
+export function mergePlaylistBookmarkConflict({ original, local, remote }) {
+  const originalById = new Map(original.map(entry => [entry.playlist.id, entry]))
+  const localById = new Map(local.map(entry => [entry.playlist.id, entry]))
+  const remoteById = new Map(remote.map(entry => [entry.playlist.id, entry]))
+  const ids = new Set([...remoteById.keys(), ...localById.keys(), ...originalById.keys()])
+
+  return Array.from(ids).flatMap(id => {
+    const originalEntry = originalById.get(id)
+    const localEntry = localById.get(id)
+    const remoteEntry = remoteById.get(id)
+
+    if (originalEntry && (!localEntry || !remoteEntry)) return []
+    if (!localEntry) return remoteEntry ? [remoteEntry] : []
+    if (!remoteEntry || !originalEntry) return [localEntry]
+
+    const localChanged = JSON.stringify(localEntry) !== JSON.stringify(originalEntry)
+    const remoteChanged = JSON.stringify(remoteEntry) !== JSON.stringify(originalEntry)
+    return [remoteChanged && !localChanged ? remoteEntry : localEntry]
+  })
+}

--- a/src/renderer/helpers/playlist-bookmarks.js
+++ b/src/renderer/helpers/playlist-bookmarks.js
@@ -1,0 +1,92 @@
+const YOUTUBE_THUMBNAIL_ORIGIN = 'https://i.ytimg.com'
+const YOUTUBE_AVATAR_ORIGIN = 'https://yt3.googleusercontent.com'
+
+function canonicalYouTubeImageUrl(url, proxiedPath, youtubeOrigin) {
+  if (typeof url !== 'string' || url === '') return null
+
+  try {
+    const parsedUrl = new URL(url)
+    if (parsedUrl.pathname.startsWith(proxiedPath)) {
+      return `${youtubeOrigin}${parsedUrl.pathname.slice(proxiedPath.length)}${parsedUrl.search}`
+    }
+  } catch {
+    return url
+  }
+
+  return url
+}
+
+export function canonicalPlaylistThumbnailUrl(url) {
+  return canonicalYouTubeImageUrl(url, '/vi/', `${YOUTUBE_THUMBNAIL_ORIGIN}/vi/`)
+}
+
+export function canonicalChannelAvatarUrl(url) {
+  return canonicalYouTubeImageUrl(url, '/ggpht/', `${YOUTUBE_AVATAR_ORIGIN}/`)
+}
+
+export function createPlaylistBookmark({
+  id,
+  title,
+  description = '',
+  thumbnailUrl = null,
+  videoCount = null,
+  uploaderId,
+  uploaderName,
+  uploaderAvatar = null,
+  uploaderVerified = false,
+  savedAt = Date.now(),
+}) {
+  return {
+    playlist: {
+      id,
+      title,
+      description,
+      thumbnail_url: canonicalPlaylistThumbnailUrl(thumbnailUrl),
+      video_count: Number.isFinite(videoCount) ? videoCount : null,
+    },
+    uploader: {
+      id: uploaderId,
+      name: uploaderName,
+      avatar: canonicalChannelAvatarUrl(uploaderAvatar),
+      verified: uploaderVerified,
+    },
+    savedAt,
+  }
+}
+
+export function isValidPlaylistBookmark(bookmark) {
+  return typeof bookmark?.playlist?.id === 'string' && bookmark.playlist.id !== '' &&
+    typeof bookmark.playlist.title === 'string' &&
+    typeof bookmark?.uploader?.id === 'string' && bookmark.uploader.id !== '' &&
+    typeof bookmark.uploader.name === 'string'
+}
+
+export function playlistBookmarkToListData(bookmark) {
+  const { playlist, uploader } = bookmark
+  const savedAt = Number.isFinite(bookmark.savedAt) ? bookmark.savedAt : 0
+
+  return {
+    type: 'playlist',
+    isPlaylistBookmark: true,
+    title: playlist.title,
+    playlistName: playlist.title,
+    description: playlist.description ?? '',
+    playlistId: playlist.id,
+    playlistThumbnail: playlist.thumbnail_url ?? '',
+    author: uploader.name,
+    authorId: uploader.id,
+    authorVerified: uploader.verified === true,
+    authorThumbnails: uploader.avatar ? [{ url: uploader.avatar }] : [],
+    videoCount: Number.isFinite(playlist.video_count) ? playlist.video_count : 0,
+    createdAt: savedAt,
+    lastUpdatedAt: savedAt,
+    videos: [],
+  }
+}
+
+export function playlistBookmarkForSync(bookmark) {
+  return {
+    playlist: bookmark.playlist,
+    uploader: bookmark.uploader,
+  }
+}

--- a/src/renderer/helpers/sync-server-privacy.js
+++ b/src/renderer/helpers/sync-server-privacy.js
@@ -278,6 +278,7 @@ export class EncryptedSyncAdapter {
     this.document.profiles ??= []
     this.document.settings ??= []
     this.document.sessions ??= []
+    this.document.playlistBookmarks ??= []
   }
 
   async getSubscriptions() { return structuredClone(this.document.subscriptions) }
@@ -294,6 +295,19 @@ export class EncryptedSyncAdapter {
 
   async getPlaylist(id) {
     return structuredClone(this.document.playlists.find(entry => entry.playlist.id === id))
+  }
+
+  async getPlaylistBookmarks() {
+    return structuredClone(this.document.playlistBookmarks)
+  }
+
+  async createPlaylistBookmark(bookmark) {
+    this.document.playlistBookmarks.push(structuredClone(bookmark))
+  }
+
+  async deletePlaylistBookmark(id) {
+    this.document.playlistBookmarks = this.document.playlistBookmarks
+      .filter(entry => entry.playlist.id !== id)
   }
 
   async createPlaylist(playlist) {

--- a/src/renderer/helpers/sync-server-scheduling.js
+++ b/src/renderer/helpers/sync-server-scheduling.js
@@ -16,6 +16,7 @@ export const SYNC_ACTION_REASONS = new Map([
   ['removeFromHistory', 'history'],
   ['removeHistoryOlderThan', 'history'],
   ['removePlaylist', 'playlists'],
+  ['removePlaylistBookmark', 'playlists'],
   ['removePlaylists', 'playlists'],
   ['removeProfile', 'profiles'],
   ['removeVideo', 'playlists'],
@@ -23,6 +24,7 @@ export const SYNC_ACTION_REASONS = new Map([
   ['updateHistory', 'history'],
   ['updateCustomThemes', 'settings'],
   ['updatePlaylist', 'playlists'],
+  ['savePlaylistBookmark', 'playlists'],
   ['updateProfile', 'profilesOrSubscriptions'],
   ['updateWatchProgress', 'history'],
 ])
@@ -44,6 +46,7 @@ export const SYNC_MUTATION_REASONS = new Map([
   ['removePlaylists', 'playlists'],
   ['removeVideo', 'playlists'],
   ['removeVideos', 'playlists'],
+  ['setPlaylistBookmarks', 'playlists'],
   ['upsertPlaylistToList', 'playlists'],
   ['upsertToHistoryCache', 'history'],
   ['setHistoryCacheSorted', 'history'],

--- a/src/renderer/helpers/sync-server.js
+++ b/src/renderer/helpers/sync-server.js
@@ -24,6 +24,7 @@ import {
   getSyncProfileTextColor
 } from './profile-sync.js'
 import { createSyncServerRequestHeaders } from './sync-server-request'
+import { isValidPlaylistBookmark, playlistBookmarkForSync } from './playlist-bookmarks'
 
 const LEGACY_HISTORY_PAGE_SIZE = 50
 const BULK_SYNC_CHUNK_SIZE = 100
@@ -343,6 +344,17 @@ export class SyncServerClient {
     return this.apiRequest('/playlist_bookmarks/')
   }
 
+  createPlaylistBookmark(bookmark) {
+    return this.apiRequest('/playlist_bookmarks/', { method: 'POST', body: bookmark })
+  }
+
+  deletePlaylistBookmark(playlistId) {
+    return this.apiRequest(
+      `/playlist_bookmarks/${encodeURIComponent(playlistId)}`,
+      { method: 'DELETE' }
+    )
+  }
+
   getPlaylist(playlistId) {
     return this.apiRequest(`/playlists/${encodeURIComponent(playlistId)}`)
   }
@@ -648,6 +660,42 @@ export async function syncSubscriptions(client, store, previousIds = [], options
     if (!metadataEquals(profile.subscriptions, updatedProfile.subscriptions)) {
       await store.dispatch('updateProfile', updatedProfile)
     }
+  }
+
+  return Array.from(mergedIds)
+}
+
+export async function syncPlaylistBookmarks(client, store, previousIds = [], options = {}) {
+  const localBookmarks = (Array.isArray(store.state.settings.playlistBookmarks)
+    ? store.state.settings.playlistBookmarks
+    : []).filter(isValidPlaylistBookmark)
+  const localById = mapBy(localBookmarks, bookmark => bookmark.playlist.id)
+  const remoteBookmarks = (await client.getPlaylistBookmarks()).filter(isValidPlaylistBookmark)
+  const remoteById = mapBy(remoteBookmarks, bookmark => bookmark.playlist.id)
+  const mergedIds = mergeIds(localById.keys(), remoteById.keys(), previousIds, {
+    ...options,
+    collection: 'saved playlists',
+  })
+
+  for (const id of remoteById.keys()) {
+    if (!mergedIds.has(id)) {
+      await client.deletePlaylistBookmark(id)
+    }
+  }
+
+  for (const id of localById.keys()) {
+    if (!remoteById.has(id) && mergedIds.has(id)) {
+      await client.createPlaylistBookmark(playlistBookmarkForSync(localById.get(id)))
+    }
+  }
+
+  const mergedBookmarks = Array.from(mergedIds).map(id => {
+    return localById.get(id) ?? { ...remoteById.get(id), savedAt: Date.now() }
+  })
+
+  if (!metadataEquals(localBookmarks, mergedBookmarks)) {
+    const saved = await store.dispatch('replacePlaylistBookmarks', mergedBookmarks)
+    if (!saved) throw new Error('Could not save synced playlist bookmarks')
   }
 
   return Array.from(mergedIds)

--- a/src/renderer/store/modules/settings.js
+++ b/src/renderer/store/modules/settings.js
@@ -454,6 +454,7 @@ const state = {
   syncServerSettingsExcluded: [],
   syncServerLastSyncAt: 0,
   syncServerSnapshot: '{}',
+  playlistBookmarks: [],
   useProxy: false,
   userPlaylistSortOrder: 'date_added_descending',
   useRssFeeds: false,
@@ -755,6 +756,8 @@ export const NON_TRANSFERABLE_SETTINGS = new Set([
 
 export const NON_SYNCABLE_SETTINGS = new Set([
   ...NON_TRANSFERABLE_SETTINGS,
+  // Playlist bookmarks sync with playlists as their own collection.
+  'playlistBookmarks',
   // Updating is tied to the installed application and operating system.
   'checkForUpdates',
   // Window coordinates are only valid for the display they were saved on.
@@ -784,6 +787,15 @@ const customState = {
 
 const customGetters = {
   getLandingPage: (state) => resolveLandingPage(state.landingPage, state.hideHome),
+
+  getPlaylistBookmarks: (state) => {
+    return Array.isArray(state.playlistBookmarks) ? state.playlistBookmarks : []
+  },
+
+  getPlaylistBookmark: (state) => (playlistId) => {
+    if (!Array.isArray(state.playlistBookmarks)) return undefined
+    return state.playlistBookmarks.find(bookmark => bookmark?.playlist?.id === playlistId)
+  },
 
   // These parsed variants are cached by Vuex,
   // so that list items don't each have to parse the JSON strings themselves
@@ -837,7 +849,37 @@ async function updateValidatedSetting(commit, settingId, value) {
   }
 }
 
+async function persistPlaylistBookmarks(commit, bookmarks) {
+  try {
+    await DBSettingHandlers.upsert('playlistBookmarks', bookmarks)
+    commit('setPlaylistBookmarks', bookmarks)
+    return true
+  } catch (error) {
+    console.error(error)
+    return false
+  }
+}
+
 const customActions = {
+  savePlaylistBookmark: async ({ commit, getters }, bookmark) => {
+    const bookmarks = getters.getPlaylistBookmarks
+      .filter(entry => entry?.playlist?.id !== bookmark.playlist.id)
+    bookmarks.push(bookmark)
+
+    return persistPlaylistBookmarks(commit, bookmarks)
+  },
+
+  removePlaylistBookmark: async ({ commit, getters }, playlistId) => {
+    const bookmarks = getters.getPlaylistBookmarks
+      .filter(bookmark => bookmark?.playlist?.id !== playlistId)
+
+    return persistPlaylistBookmarks(commit, bookmarks)
+  },
+
+  replacePlaylistBookmarks: async ({ commit }, bookmarks) => {
+    return persistPlaylistBookmarks(commit, bookmarks)
+  },
+
   updatePreferredCaptionLocale: ({ commit }, value) => updateValidatedSetting(
     commit,
     'preferredCaptionLocale',

--- a/src/renderer/store/modules/sync-server.js
+++ b/src/renderer/store/modules/sync-server.js
@@ -7,6 +7,7 @@ import {
   isSessionExpiredError,
   normalizeSyncServerUrl,
   syncHistory,
+  syncPlaylistBookmarks,
   syncPlaylists,
   syncProfiles,
   syncSessions,
@@ -115,6 +116,7 @@ async function runSync(context, { allowDataLoss = false } = {}) {
     ...(settings.syncServerPrivacyMode === 'enhanced' ? ['download'] : []),
     ...(settings.syncServerSyncSubscriptions ? ['subscriptions'] : []),
     ...(settings.syncServerSyncPlaylists ? ['playlists'] : []),
+    ...(settings.syncServerSyncPlaylists ? ['playlistBookmarks'] : []),
     ...(settings.syncServerSyncHistory ? ['history'] : []),
     ...(settings.syncServerSyncProfiles ? ['profiles'] : []),
     ...(process.env.IS_ELECTRON &&
@@ -173,6 +175,15 @@ async function runSync(context, { allowDataLoss = false } = {}) {
           { allowDataLoss }
         )
         result.playlists = Object.keys(next.playlists).length
+        break
+      case 'playlistBookmarks':
+        next.playlistBookmarks = await syncPlaylistBookmarks(
+          targetClient,
+          store,
+          previous.playlistBookmarks,
+          { allowDataLoss }
+        )
+        result.playlistBookmarks = next.playlistBookmarks.length
         break
       case 'history': {
         const history = await syncHistory(

--- a/src/renderer/store/modules/sync-server.js
+++ b/src/renderer/store/modules/sync-server.js
@@ -24,6 +24,7 @@ import {
   migrateLegacyPlaybackSpeedsToSettings,
   preparePrivacyKey,
 } from '../../helpers/sync-server-privacy'
+import { mergePlaylistBookmarkConflict } from '../../helpers/playlist-bookmarks'
 import {
   AUTO_SYNC_INTERVAL_MS,
   isRecentSync,
@@ -337,10 +338,12 @@ async function runSync(context, { allowDataLoss = false } = {}) {
                 settings.syncServerPrivacyKey
               )
               if (collection === 'playlistBookmarks') {
-                const bookmarks = new Map(remoteData.map(entry => [entry.playlist.id, entry]))
-                for (const entry of data) bookmarks.set(entry.playlist.id, entry)
                 revision = remote.revision
-                data = Array.from(bookmarks.values())
+                data = mergePlaylistBookmarkConflict({
+                  original: encryptedCollections.original.playlistBookmarks,
+                  local: data,
+                  remote: remoteData,
+                })
                 continue
               }
               retryDocument[collection] = remoteData

--- a/src/renderer/views/Playlist/Playlist.vue
+++ b/src/renderer/views/Playlist/Playlist.vue
@@ -55,6 +55,8 @@
         :is-duration-approximate="isDurationApproximate"
         :info-source="infoSource"
         :more-video-data-available="moreVideoDataAvailable"
+        :is-playlist-bookmarked="isPlaylistBookmarked"
+        :playlist-bookmark-pending="playlistBookmarkPending"
         :search-video-mode-allowed="isUserPlaylistRequested && shownVideoCount > 1"
         :search-query-text="searchQueryTextRequested"
         :theme="listType === 'list' ? 'base' : 'top-bar'"
@@ -65,6 +67,7 @@
         @search-video-query-change="handleVideoSearchQueryChange"
         @prompt-open="promptOpen = true"
         @prompt-close="promptOpen = false"
+        @toggle-playlist-bookmark="togglePlaylistBookmark"
       />
     </div>
 
@@ -245,6 +248,7 @@ import {
 import { invidiousGetPlaylistInfo, youtubeImageUrlToInvidious } from '../../helpers/api/invidious'
 import { hasMoreInvidiousPlaylistPages, mergeInvidiousPlaylistVideos } from '../../helpers/api/invidious-playlists'
 import { runRetryablePlaylistRequest } from '../../helpers/playlist-pagination'
+import { createPlaylistBookmark } from '../../helpers/playlist-bookmarks'
 import { fillMissingPlaylistVideoDurations, getSortedPlaylistItems, SORT_BY_VALUES } from '../../helpers/playlists'
 import { MOBILE_WIDTH_THRESHOLD, PLAYLIST_HEIGHT_FORCE_LIST_THRESHOLD } from '../../../constants'
 import { useTabContext, useTabLifecycle, useTabTitle } from '../../tabs/TabContext'
@@ -300,6 +304,7 @@ const toBeDeletedPlaylistItemIds = ref([])
 /** @type {import('vue').Ref<string[]>} */
 const videosWithPlaylistToUnset = ref([])
 const pendingDeletionRemovalInProgress = ref(false)
+const playlistBookmarkPending = ref(false)
 /** @type {AbortController | null} */
 let undoToastAbortController = null
 let removePendingVideosAfterDrag = false
@@ -321,6 +326,12 @@ const userPlaylistSortOrder = computed(() => store.getters.getUserPlaylistSortOr
 const sortOrder = computed(() => isUserPlaylistRequested.value ? userPlaylistSortOrder.value : SORT_BY_VALUES.Custom)
 
 const playlistId = computed(() => route.params.id)
+
+const linkedPlaylistThumbnail = computed(() => {
+  return typeof route.query.playlistThumbnail === 'string'
+    ? route.query.playlistThumbnail
+    : ''
+})
 
 /** @type {import('vue').ComputedRef<'grid' | 'list'>} */
 const listType = computed(() => !forceListView.value ? store.getters.getPlaylistViewType : 'list')
@@ -372,6 +383,41 @@ const searchQueryTextPresent = computed(() => {
 })
 
 const isUserPlaylistRequested = computed(() => route.query.playlistType === 'user')
+
+const isPlaylistBookmarked = computed(() => {
+  return !isUserPlaylistRequested.value && store.getters.getPlaylistBookmark(playlistId.value) != null
+})
+
+async function togglePlaylistBookmark() {
+  if (playlistBookmarkPending.value || isUserPlaylistRequested.value) return
+
+  playlistBookmarkPending.value = true
+  try {
+    const saved = isPlaylistBookmarked.value
+      ? await store.dispatch('removePlaylistBookmark', playlistId.value)
+      : await store.dispatch('savePlaylistBookmark', createPlaylistBookmark({
+          id: playlistId.value,
+          title: playlistTitle.value,
+          description: playlistDescription.value,
+          thumbnailUrl: linkedPlaylistThumbnail.value || playlistThumbnail.value || (firstVideoId.value
+            ? `https://i.ytimg.com/vi/${firstVideoId.value}/mqdefault.jpg`
+            : null),
+          videoCount: videoCount.value,
+          uploaderId: channelId.value || playlistId.value,
+          uploaderName: channelName.value || playlistTitle.value,
+          uploaderAvatar: channelThumbnail.value,
+        }))
+
+    if (!saved) {
+      showTabToast({
+        message: t('User Playlists.SinglePlaylistView.Toast["There was an issue with updating this playlist."]'),
+        icon: ['fas', 'circle-exclamation'],
+      })
+    }
+  } finally {
+    playlistBookmarkPending.value = false
+  }
+}
 
 /** @type {import('vue').ComputedRef<string | undefined>} */
 const quickBookmarkPlaylistId = computed(() => store.getters.getQuickBookmarkTargetPlaylistId)

--- a/src/renderer/views/UserPlaylists/UserPlaylists.vue
+++ b/src/renderer/views/UserPlaylists/UserPlaylists.vue
@@ -113,6 +113,7 @@ import FtToggleSwitch from '../../components/FtToggleSwitch/FtToggleSwitch.vue'
 import store from '../../store/index'
 
 import { ctrlFHandler, debounce, getIconForSortPreference } from '../../helpers/utils'
+import { isValidPlaylistBookmark, playlistBookmarkToListData } from '../../helpers/playlist-bookmarks'
 import { useTabContext } from '../../tabs/TabContext'
 
 const { locale, t } = useI18n()
@@ -180,7 +181,12 @@ const cachedCollator = computed(() => new Intl.Collator([locale.value, 'en'], { 
 /** @type {import('vue').ComputedRef<any[]>} */
 const allPlaylists = computed(() => {
   /** @type {any[]} */
-  const playlists = store.getters.getAllPlaylists
+  const playlists = [
+    ...store.getters.getAllPlaylists,
+    ...store.getters.getPlaylistBookmarks
+      .filter(isValidPlaylistBookmark)
+      .map(playlistBookmarkToListData),
+  ]
 
   const sortBy_ = sortBy.value
 

--- a/static/locales/ai/ar.yaml
+++ b/static/locales/ai/ar.yaml
@@ -145,6 +145,8 @@ Feed:
   Cancel Refresh: إلغاء التحديث
   Next Auto Refresh: 'التحديث التلقائي التالي: {date}'
 User Playlists:
+  Save Playlist: "حفظ قائمة التشغيل"
+  Remove Saved Playlist: "إزالة قائمة التشغيل المحفوظة"
   Load More Playlists: تحميل المزيد من قوائم التشغيل
   Save to: حفظ إلى...
   Move Video to the Top: نقل الفيديو إلى الأعلى

--- a/static/locales/ai/be.yaml
+++ b/static/locales/ai/be.yaml
@@ -151,6 +151,8 @@ Feed:
   Cancel Refresh: Скасаваць абнаўленне
   Next Auto Refresh: 'Наступнае аўтаабнаўленне: {date}'
 User Playlists:
+  Save Playlist: "Захаваць плэйліст"
+  Remove Saved Playlist: "Выдаліць захаваны плэйліст"
   Load More Playlists: Загрузіць яшчэ спісы прайгравання
   Save to: Захаваць у…
   Move Video to the Top: Перамясціць відэа ў пачатак

--- a/static/locales/ai/bg.yaml
+++ b/static/locales/ai/bg.yaml
@@ -145,6 +145,8 @@ Feed:
   Cancel Refresh: Отмени обновяването
   Next Auto Refresh: 'Следващо автоматично обновяване: {date}'
 User Playlists:
+  Save Playlist: "Запазване на плейлиста"
+  Remove Saved Playlist: "Премахване на запазения плейлист"
   Load More Playlists: Зареди още плейлисти
   Save to: Запази в…
   Quick Bookmark Icon: Икона за бърза отметка

--- a/static/locales/ai/br.yaml
+++ b/static/locales/ai/br.yaml
@@ -143,6 +143,8 @@ Feed:
   Cancel Refresh: "Nullañ an adkargañ"
   Next Auto Refresh: "Adkargañ emgefreek da-heul: {date}"
 User Playlists:
+  Save Playlist: "Enrollañ ar roll-lenn"
+  Remove Saved Playlist: "Lemel ar roll-lenn enrollet"
   Load More Playlists: "Kargañ muioc'h a rolloù-videoioù"
   Save to: "Enrollañ e…"
   Quick Bookmark Icon: "Arlun ar sined prim"

--- a/static/locales/ai/ca.yaml
+++ b/static/locales/ai/ca.yaml
@@ -186,6 +186,8 @@ Feed:
   Next Auto Refresh: 'Propera actualització automàtica: {date}'
   Refresh Feed: Actualitza {subscriptionName}
 User Playlists:
+  Save Playlist: "Desa la llista de reproducció"
+  Remove Saved Playlist: "Elimina la llista de reproducció desada"
   Load More Playlists: Carrega més llistes de reproducció
   You have no playlists. Click on the create new playlist button to create a new one.: No teniu cap llista de reproducció. Feu clic al botó per crear-ne una de nova.
   Playlists with Matching Videos: Llistes de reproducció amb vídeos coincidents

--- a/static/locales/ai/cs.yaml
+++ b/static/locales/ai/cs.yaml
@@ -145,6 +145,8 @@ Feed:
   Cancel Refresh: Zrušit obnovení
   Next Auto Refresh: 'Další automatické obnovení: {date}'
 User Playlists:
+  Save Playlist: "Uložit playlist"
+  Remove Saved Playlist: "Odebrat uložený playlist"
   Load More Playlists: Načíst další playlisty
   Save to: Uložit do…
   Quick Bookmark Icon: Ikona rychlé záložky

--- a/static/locales/ai/cy.yaml
+++ b/static/locales/ai/cy.yaml
@@ -145,6 +145,8 @@ Feed:
   Cancel Refresh: Canslo'r adnewyddiad
   Next Auto Refresh: 'Adnewyddiad awtomatig nesaf: {date}'
 User Playlists:
+  Save Playlist: "Cadw'r rhestr chwarae"
+  Remove Saved Playlist: "Dileu'r rhestr chwarae sydd wedi'i chadw"
   Load More Playlists: Llwytho rhagor o restrau chwarae
   Save to: Cadw i…
   Quick Bookmark Icon: Eicon nod tudalen cyflym

--- a/static/locales/ai/da.yaml
+++ b/static/locales/ai/da.yaml
@@ -147,6 +147,8 @@ Feed:
   Cancel Refresh: Annuller opdatering
   Next Auto Refresh: 'Næste automatiske opdatering: {date}'
 User Playlists:
+  Save Playlist: "Gem playliste"
+  Remove Saved Playlist: "Fjern gemt playliste"
   Load More Playlists: Indlæs flere playlister
   Save to: Gem på…
   Move Video to the Top: Flyt video øverst

--- a/static/locales/ai/el.yaml
+++ b/static/locales/ai/el.yaml
@@ -145,6 +145,8 @@ Feed:
   Cancel Refresh: Ακύρωση ανανέωσης
   Next Auto Refresh: 'Επόμενη αυτόματη ανανέωση: {date}'
 User Playlists:
+  Save Playlist: "Αποθήκευση λίστας αναπαραγωγής"
+  Remove Saved Playlist: "Αφαίρεση αποθηκευμένης λίστας αναπαραγωγής"
   Load More Playlists: Φόρτωση περισσότερων λιστών αναπαραγωγής
   Save to: Αποθήκευση σε…
   Move Video to the Top: Μετακίνηση βίντεο στην κορυφή

--- a/static/locales/ai/en-GB.yaml
+++ b/static/locales/ai/en-GB.yaml
@@ -144,6 +144,8 @@ Feed:
   Cancel Refresh: Cancel refresh
   Next Auto Refresh: 'Next auto refresh: {date}'
 User Playlists:
+  Save Playlist: "Save Playlist"
+  Remove Saved Playlist: "Remove Saved Playlist"
   Load More Playlists: Load More Playlists
   Save to: Save to…
   Quick Bookmark Icon: Quick bookmark icon

--- a/static/locales/ai/es-AR.yaml
+++ b/static/locales/ai/es-AR.yaml
@@ -153,6 +153,8 @@ Feed:
   Cancel Refresh: Cancelar actualización
   Next Auto Refresh: 'Próxima actualización automática: {date}'
 User Playlists:
+  Save Playlist: "Guardar lista de reproducción"
+  Remove Saved Playlist: "Eliminar lista de reproducción guardada"
   Load More Playlists: Cargar más listas de reproducción
   Save to: Guardar en…
   Move Video to the Top: Mover video al principio

--- a/static/locales/ai/es-MX.yaml
+++ b/static/locales/ai/es-MX.yaml
@@ -152,6 +152,8 @@ Feed:
   Cancel Refresh: Cancelar actualización
   Next Auto Refresh: 'Próxima actualización automática: {date}'
 User Playlists:
+  Save Playlist: "Guardar lista de reproducción"
+  Remove Saved Playlist: "Eliminar lista de reproducción guardada"
   Load More Playlists: Cargar más listas de reproducción
   Save to: Guardar en…
   Move Video to the Top: Mover video al principio

--- a/static/locales/ai/es.yaml
+++ b/static/locales/ai/es.yaml
@@ -145,6 +145,8 @@ Feed:
   Cancel Refresh: Cancelar actualización
   Next Auto Refresh: 'Próxima actualización automática: {date}'
 User Playlists:
+  Save Playlist: "Guardar lista de reproducción"
+  Remove Saved Playlist: "Eliminar lista de reproducción guardada"
   Load More Playlists: Cargar más listas de reproducción
   Save to: Guardar en…
   Quick Bookmark Icon: Icono de marcador rápido

--- a/static/locales/ai/et.yaml
+++ b/static/locales/ai/et.yaml
@@ -143,6 +143,8 @@ Feed:
   Cancel Refresh: Tühista värskendamine
   Next Auto Refresh: 'Järgmine automaatne värskendamine: {date}'
 User Playlists:
+  Save Playlist: "Salvesta esitusloend"
+  Remove Saved Playlist: "Eemalda salvestatud esitusloend"
   Load More Playlists: Laadi veel esitusloendeid
   Save to: Salvesta asukohta…
   Quick Bookmark Icon: Kiirjärjehoidja ikoon

--- a/static/locales/ai/eu.yaml
+++ b/static/locales/ai/eu.yaml
@@ -145,6 +145,8 @@ Feed:
   Cancel Refresh: Utzi freskatzeari
   Next Auto Refresh: 'Hurrengo freskatze automatikoa: {date}'
 User Playlists:
+  Save Playlist: "Gorde erreprodukzio-zerrenda"
+  Remove Saved Playlist: "Kendu gordetako erreprodukzio-zerrenda"
   Load More Playlists: Kargatu erreprodukzio-zerrenda gehiago
   Save to: Gorde hemen…
   Quick Bookmark Icon: Laster-marka azkarraren ikonoa

--- a/static/locales/ai/fa.yaml
+++ b/static/locales/ai/fa.yaml
@@ -155,6 +155,8 @@ Feed:
   Cancel Refresh: لغو تازه‌سازی
   Next Auto Refresh: 'تازه‌سازی خودکار بعدی: {date}'
 User Playlists:
+  Save Playlist: "ذخیره فهرست پخش"
+  Remove Saved Playlist: "حذف فهرست پخش ذخیره‌شده"
   Load More Playlists: بارگذاری فهرست‌های پخش بیشتر
   Save to: ذخیره در…
   Move Video to the Top: انتقال ویدیو به ابتدا

--- a/static/locales/ai/fi.yaml
+++ b/static/locales/ai/fi.yaml
@@ -145,6 +145,8 @@ Feed:
   Cancel Refresh: Peruuta päivitys
   Next Auto Refresh: 'Seuraava automaattinen päivitys: {date}'
 User Playlists:
+  Save Playlist: "Tallenna soittolista"
+  Remove Saved Playlist: "Poista tallennettu soittolista"
   Load More Playlists: Lataa lisää soittolistoja
   Save to: Tallenna kohteeseen…
   Move Video to the Top: Siirrä video ylimmäksi

--- a/static/locales/ai/fr-FR.yaml
+++ b/static/locales/ai/fr-FR.yaml
@@ -143,6 +143,8 @@ Feed:
   Cancel Refresh: Annuler l’actualisation
   Next Auto Refresh: 'Prochaine actualisation automatique : {date}'
 User Playlists:
+  Save Playlist: "Enregistrer la playlist"
+  Remove Saved Playlist: "Supprimer la playlist enregistrée"
   Load More Playlists: Charger davantage de playlists
   Save to: Enregistrer dans…
   Quick Bookmark Icon: Icône de favori rapide

--- a/static/locales/ai/gl.yaml
+++ b/static/locales/ai/gl.yaml
@@ -145,6 +145,8 @@ Feed:
   Cancel Refresh: Cancelar a actualización
   Next Auto Refresh: 'Seguinte actualización automática: {date}'
 User Playlists:
+  Save Playlist: "Gardar lista de reprodución"
+  Remove Saved Playlist: "Eliminar a lista de reprodución gardada"
   Load More Playlists: Cargar máis listas de reprodución
   Save to: Gardar en…
   Move Video to the Top: Mover o vídeo ao principio

--- a/static/locales/ai/he.yaml
+++ b/static/locales/ai/he.yaml
@@ -145,6 +145,8 @@ Feed:
   Cancel Refresh: ביטול הרענון
   Next Auto Refresh: 'הרענון האוטומטי הבא: {date}'
 User Playlists:
+  Save Playlist: "שמירת הפלייליסט"
+  Remove Saved Playlist: "הסרת הפלייליסט השמור"
   Load More Playlists: טעינת רשימות השמעה נוספות
   Save to: שמירה ב־…
   Move Video to the Top: העברת הסרטון לראש הרשימה

--- a/static/locales/ai/hr.yaml
+++ b/static/locales/ai/hr.yaml
@@ -145,6 +145,8 @@ Feed:
   Cancel Refresh: Otkaži osvježavanje
   Next Auto Refresh: 'Sljedeće automatsko osvježavanje: {date}'
 User Playlists:
+  Save Playlist: "Spremi popis za reprodukciju"
+  Remove Saved Playlist: "Ukloni spremljeni popis za reprodukciju"
   Load More Playlists: Učitaj još popisa za reprodukciju
   Save to: Spremi u…
   Quick Bookmark Icon: Ikona brze oznake

--- a/static/locales/ai/hu.yaml
+++ b/static/locales/ai/hu.yaml
@@ -143,6 +143,8 @@ Feed:
   Cancel Refresh: Frissítés megszakítása
   Next Auto Refresh: 'Következő automatikus frissítés: {date}'
 User Playlists:
+  Save Playlist: "Lejátszási lista mentése"
+  Remove Saved Playlist: "Mentett lejátszási lista eltávolítása"
   Load More Playlists: További lejátszási listák betöltése
   Save to: Mentés ide…
   Quick Bookmark Icon: Gyors könyvjelző ikonja

--- a/static/locales/ai/id.yaml
+++ b/static/locales/ai/id.yaml
@@ -145,6 +145,8 @@ Feed:
   Cancel Refresh: Batalkan pembaruan
   Next Auto Refresh: 'Pembaruan otomatis berikutnya: {date}'
 User Playlists:
+  Save Playlist: "Simpan playlist"
+  Remove Saved Playlist: "Hapus playlist tersimpan"
   Load More Playlists: Muat Daftar Putar Lainnya
   Save to: Simpan ke…
   Move Video to the Top: Pindahkan Video ke Paling Atas

--- a/static/locales/ai/is.yaml
+++ b/static/locales/ai/is.yaml
@@ -145,6 +145,8 @@ Feed:
   Cancel Refresh: Hætta við endurnýjun
   Next Auto Refresh: 'Næsta sjálfvirka endurnýjun: {date}'
 User Playlists:
+  Save Playlist: "Vista spilunarlista"
+  Remove Saved Playlist: "Fjarlægja vistaðan spilunarlista"
   Load More Playlists: Hlaða fleiri spilunarlistum
   Save to: Vista í…
   Move Video to the Top: Færa myndband efst

--- a/static/locales/ai/it.yaml
+++ b/static/locales/ai/it.yaml
@@ -145,6 +145,8 @@ Feed:
   Cancel Refresh: Annulla aggiornamento
   Next Auto Refresh: 'Prossimo aggiornamento automatico: {date}'
 User Playlists:
+  Save Playlist: "Salva playlist"
+  Remove Saved Playlist: "Rimuovi playlist salvata"
   Load More Playlists: Carica altre playlist
   Save to: Salva in…
   Quick Bookmark Icon: Icona del segnalibro rapido

--- a/static/locales/ai/ja.yaml
+++ b/static/locales/ai/ja.yaml
@@ -145,6 +145,8 @@ Feed:
   Cancel Refresh: 更新をキャンセル
   Next Auto Refresh: '次回の自動更新: {date}'
 User Playlists:
+  Save Playlist: "再生リストを保存"
+  Remove Saved Playlist: "保存した再生リストを削除"
   Load More Playlists: プレイリストをさらに読み込む
   Save to: 保存先…
   Quick Bookmark Icon: クイックブックマークのアイコン

--- a/static/locales/ai/ko.yaml
+++ b/static/locales/ai/ko.yaml
@@ -152,6 +152,8 @@ Feed:
   Cancel Refresh: 새로 고침 취소
   Next Auto Refresh: '다음 자동 새로 고침: {date}'
 User Playlists:
+  Save Playlist: "재생목록 저장"
+  Remove Saved Playlist: "저장한 재생목록 삭제"
   Load More Playlists: 재생목록 더 불러오기
   Save to: 저장 위치…
   Add to Favorites: '{playlistName}에 추가'

--- a/static/locales/ai/lt.yaml
+++ b/static/locales/ai/lt.yaml
@@ -172,6 +172,8 @@ Feed:
   Next Auto Refresh: 'Kitas automatinis atnaujinimas: {date}'
   Refresh Feed: Atnaujinti {subscriptionName}
 User Playlists:
+  Save Playlist: "Išsaugoti grojaraštį"
+  Remove Saved Playlist: "Pašalinti išsaugotą grojaraštį"
   Load More Playlists: Įkelti daugiau grojaraščių
   You have no playlists. Click on the create new playlist button to create a new one.: Grojaraščių neturite. Norėdami sukurti, spustelėkite naujo grojaraščio kūrimo mygtuką.
   Playlists with Matching Videos: Grojaraščiai su atitinkančiais vaizdo įrašais

--- a/static/locales/ai/nb-NO.yaml
+++ b/static/locales/ai/nb-NO.yaml
@@ -145,6 +145,8 @@ Feed:
   Cancel Refresh: Avbryt oppdatering
   Next Auto Refresh: 'Neste automatiske oppdatering: {date}'
 User Playlists:
+  Save Playlist: "Lagre spilleliste"
+  Remove Saved Playlist: "Fjern lagret spilleliste"
   Load More Playlists: Last inn flere spillelister
   Save to: Lagre i…
   Quick Bookmark Icon: Hurtigbokmerkeikon

--- a/static/locales/ai/nl.yaml
+++ b/static/locales/ai/nl.yaml
@@ -145,6 +145,8 @@ Feed:
   Cancel Refresh: Vernieuwen annuleren
   Next Auto Refresh: 'Volgende automatische vernieuwing: {date}'
 User Playlists:
+  Save Playlist: "Afspeellijst opslaan"
+  Remove Saved Playlist: "Opgeslagen afspeellijst verwijderen"
   Load More Playlists: Meer afspeellijsten laden
   Save to: Opslaan in…
   Move Video to the Top: Video bovenaan zetten

--- a/static/locales/ai/nn.yaml
+++ b/static/locales/ai/nn.yaml
@@ -184,6 +184,8 @@ Feed:
   Next Auto Refresh: 'Neste automatiske oppdatering: {date}'
   Refresh Feed: Oppdater {subscriptionName}
 User Playlists:
+  Save Playlist: "Lagre speleliste"
+  Remove Saved Playlist: "Fjern lagra speleliste"
   Load More Playlists: Last inn fleire spelelister
   You have no playlists. Click on the create new playlist button to create a new one.: Du har ingen spelelister. Trykk på knappen for å lage ei ny speleliste.
   Playlists with Matching Videos: Spelelister med videoar som passar

--- a/static/locales/ai/pl.yaml
+++ b/static/locales/ai/pl.yaml
@@ -42,6 +42,8 @@ Trending:
   Unsupported Backend: Popularne treści wymagają lokalnego API. Wybierz lokalne API lub włącz zapasowy backend.
 Most Popular Feed Empty: Kanał „Najpopularniejsze” tej instancji Invidious jest pusty.
 User Playlists:
+  Save Playlist: "Zapisz playlistę"
+  Remove Saved Playlist: "Usuń zapisaną playlistę"
   Load More Playlists: Wczytaj więcej playlist
   SinglePlaylistView:
     Retry: Spróbuj ponownie

--- a/static/locales/ai/pt-BR.yaml
+++ b/static/locales/ai/pt-BR.yaml
@@ -143,6 +143,8 @@ Feed:
   Cancel Refresh: Cancelar atualização
   Next Auto Refresh: 'Próxima atualização automática: {date}'
 User Playlists:
+  Save Playlist: "Salvar playlist"
+  Remove Saved Playlist: "Remover playlist salva"
   Load More Playlists: Carregar mais listas de reprodução
   Save to: Salvar em…
   Quick Bookmark Icon: Ícone de marcador rápido

--- a/static/locales/ai/pt-PT.yaml
+++ b/static/locales/ai/pt-PT.yaml
@@ -145,6 +145,8 @@ Feed:
   Cancel Refresh: Cancelar atualização
   Next Auto Refresh: 'Próxima atualização automática: {date}'
 User Playlists:
+  Save Playlist: "Guardar lista de reprodução"
+  Remove Saved Playlist: "Remover lista de reprodução guardada"
   Load More Playlists: Carregar mais listas de reprodução
   Save to: Guardar em…
   Move Video to the Top: Mover vídeo para o início

--- a/static/locales/ai/pt.yaml
+++ b/static/locales/ai/pt.yaml
@@ -145,6 +145,8 @@ Feed:
   Cancel Refresh: Cancelar atualização
   Next Auto Refresh: 'Próxima atualização automática: {date}'
 User Playlists:
+  Save Playlist: "Guardar lista de reprodução"
+  Remove Saved Playlist: "Remover lista de reprodução guardada"
   Load More Playlists: Carregar mais listas de reprodução
   Save to: Guardar em…
   Move Video to the Top: Mover vídeo para o início

--- a/static/locales/ai/ro.yaml
+++ b/static/locales/ai/ro.yaml
@@ -145,6 +145,8 @@ Feed:
   Cancel Refresh: Anulează reîmprospătarea
   Next Auto Refresh: 'Următoarea reîmprospătare automată: {date}'
 User Playlists:
+  Save Playlist: "Salvează lista de redare"
+  Remove Saved Playlist: "Elimină lista de redare salvată"
   Load More Playlists: Încarcă mai multe playlisturi
   Save to: Salvează în…
   Quick Bookmark Icon: Pictogramă pentru marcaj rapid

--- a/static/locales/ai/ru.yaml
+++ b/static/locales/ai/ru.yaml
@@ -120,6 +120,8 @@ Feed:
   Cancel Refresh: Отменить обновление
   Next Auto Refresh: 'Следующее автоматическое обновление: {date}'
 User Playlists:
+  Save Playlist: "Сохранить плейлист"
+  Remove Saved Playlist: "Удалить сохранённый плейлист"
   Load More Playlists: Загрузить ещё плейлисты
   Save to: Сохранить в…
   Move Video to the Top: Переместить видео в начало

--- a/static/locales/ai/sk.yaml
+++ b/static/locales/ai/sk.yaml
@@ -145,6 +145,8 @@ Feed:
   Cancel Refresh: Zrušiť obnovenie
   Next Auto Refresh: 'Ďalšie automatické obnovenie: {date}'
 User Playlists:
+  Save Playlist: "Uložiť playlist"
+  Remove Saved Playlist: "Odstrániť uložený playlist"
   Load More Playlists: Načítať ďalšie zoznamy videí
   Save to: Uložiť do…
   Quick Bookmark Icon: Ikona rýchlej záložky

--- a/static/locales/ai/sl.yaml
+++ b/static/locales/ai/sl.yaml
@@ -179,6 +179,8 @@ Feed:
   Next Auto Refresh: 'Naslednja samodejna osvežitev: {date}'
   Refresh Feed: Osveži {subscriptionName}
 User Playlists:
+  Save Playlist: "Shrani seznam predvajanja"
+  Remove Saved Playlist: "Odstrani shranjeni seznam predvajanja"
   Load More Playlists: Naloži več seznamov predvajanja
   You have no playlists. Click on the create new playlist button to create a new one.: Nimate seznamov predvajanja. Če želite ustvariti novega, kliknite gumb za ustvarjanje novega seznama predvajanja.
   Playlists with Matching Videos: Seznami predvajanja z ujemajočimi se videoposnetki

--- a/static/locales/ai/sr.yaml
+++ b/static/locales/ai/sr.yaml
@@ -147,6 +147,8 @@ Feed:
   Cancel Refresh: Откажи освежавање
   Next Auto Refresh: 'Следеће аутоматско освежавање: {date}'
 User Playlists:
+  Save Playlist: "Сачувај плејлисту"
+  Remove Saved Playlist: "Уклони сачувану плејлисту"
   Load More Playlists: Учитај још листа за репродукцију
   Save to: Сачувај у…
   Move Video to the Top: Премести видео-снимак на врх

--- a/static/locales/ai/sv.yaml
+++ b/static/locales/ai/sv.yaml
@@ -145,6 +145,8 @@ Feed:
   Cancel Refresh: Avbryt uppdatering
   Next Auto Refresh: 'Nästa automatiska uppdatering: {date}'
 User Playlists:
+  Save Playlist: "Spara spellista"
+  Remove Saved Playlist: "Ta bort sparad spellista"
   Load More Playlists: Läs in fler spellistor
   Save to: Spara i…
   Quick Bookmark Icon: Ikon för snabbbokmärke

--- a/static/locales/ai/ta.yaml
+++ b/static/locales/ai/ta.yaml
@@ -148,6 +148,8 @@ Feed:
   Cancel Refresh: புதுப்பிப்பை ரத்துசெய்
   Next Auto Refresh: 'அடுத்த தானியக்கப் புதுப்பிப்பு: {date}'
 User Playlists:
+  Save Playlist: "பிளேலிஸ்ட்டைச் சேமி"
+  Remove Saved Playlist: "சேமித்த பிளேலிஸ்ட்டை அகற்று"
   Load More Playlists: மேலும் பிளேலிஸ்ட்களை ஏற்று
   Save to: இதில் சேமி…
   Quick Bookmark Icon: விரைவுப் புத்தகக்குறி படவுரு

--- a/static/locales/ai/tr.yaml
+++ b/static/locales/ai/tr.yaml
@@ -143,6 +143,8 @@ Feed:
   Cancel Refresh: Yenilemeyi iptal et
   Next Auto Refresh: 'Sonraki otomatik yenileme: {date}'
 User Playlists:
+  Save Playlist: "Oynatma listesini kaydet"
+  Remove Saved Playlist: "Kaydedilen oynatma listesini kaldır"
   Load More Playlists: Daha Fazla Oynatma Listesi Yükle
   Save to: Kaydet…
   Quick Bookmark Icon: Hızlı yer imi simgesi

--- a/static/locales/ai/uk.yaml
+++ b/static/locales/ai/uk.yaml
@@ -145,6 +145,8 @@ Feed:
   Cancel Refresh: Скасувати оновлення
   Next Auto Refresh: 'Наступне автоматичне оновлення: {date}'
 User Playlists:
+  Save Playlist: "Зберегти плейліст"
+  Remove Saved Playlist: "Видалити збережений плейліст"
   Load More Playlists: Завантажити більше списків відтворення
   Save to: Зберегти до…
   Move Video to the Top: Перемістити відео на початок

--- a/static/locales/ai/vi.yaml
+++ b/static/locales/ai/vi.yaml
@@ -145,6 +145,8 @@ Feed:
   Cancel Refresh: Hủy làm mới
   Next Auto Refresh: 'Lần tự động làm mới tiếp theo: {date}'
 User Playlists:
+  Save Playlist: "Lưu danh sách phát"
+  Remove Saved Playlist: "Xóa danh sách phát đã lưu"
   Load More Playlists: Tải thêm danh sách phát
   Save to: Lưu vào…
   Move Video to the Top: Chuyển video lên đầu

--- a/static/locales/ai/zh-CN.yaml
+++ b/static/locales/ai/zh-CN.yaml
@@ -143,6 +143,8 @@ Feed:
   Cancel Refresh: 取消刷新
   Next Auto Refresh: '下次自动刷新：{date}'
 User Playlists:
+  Save Playlist: "保存播放列表"
+  Remove Saved Playlist: "移除已保存的播放列表"
   Load More Playlists: 加载更多播放列表
   Save to: 保存到…
   Quick Bookmark Icon: 快速书签图标

--- a/static/locales/ai/zh-TW.yaml
+++ b/static/locales/ai/zh-TW.yaml
@@ -145,6 +145,8 @@ Feed:
   Cancel Refresh: 取消重新整理
   Next Auto Refresh: '下次自動重新整理：{date}'
 User Playlists:
+  Save Playlist: "儲存播放清單"
+  Remove Saved Playlist: "移除已儲存的播放清單"
   Load More Playlists: 載入更多播放清單
   Save to: 儲存至…
   Quick Bookmark Icon: 快速加入書籤圖示

--- a/static/locales/de-DE.yaml
+++ b/static/locales/de-DE.yaml
@@ -170,6 +170,8 @@ User Playlists:
   You have no playlists. Click on the create new playlist button to create a new one.: Du hast keine Playlists. Klicke auf die Schaltfläche „Neue Playlist erstellen“, um eine neue zu erstellen.
   Playlist Description: Beschreibung der Playlist
   Save Changes: Änderungen speichern
+  Save Playlist: Playlist speichern
+  Remove Saved Playlist: Gespeicherte Playlist entfernen
   Cancel: Abbrechen
   Edit Playlist Info: Playlist-Infos bearbeiten
   Copy Playlist: Playlist kopieren

--- a/static/locales/en-US.yaml
+++ b/static/locales/en-US.yaml
@@ -319,6 +319,8 @@ User Playlists:
   Use Bookmark Icon: Use bookmark icon
 
   Save Changes: Save Changes
+  Save Playlist: Save Playlist
+  Remove Saved Playlist: Remove Saved Playlist
   Cancel: Cancel
   Edit Playlist Info: Edit Playlist Info
   Copy Playlist: Copy Playlist

--- a/tests/unit/playlist-bookmarks.test.mjs
+++ b/tests/unit/playlist-bookmarks.test.mjs
@@ -1,0 +1,45 @@
+import assert from 'node:assert/strict'
+import test from 'node:test'
+
+import {
+  createPlaylistBookmark,
+  playlistBookmarkToListData,
+} from '../../src/renderer/helpers/playlist-bookmarks.js'
+
+function bookmark(id, savedAt = 123) {
+  return createPlaylistBookmark({
+    id,
+    title: `Playlist ${id}`,
+    description: 'A saved YouTube playlist',
+    thumbnailUrl: `https://invidious.test/vi/${id}/hqdefault.jpg`,
+    videoCount: 4,
+    uploaderId: `channel-${id}`,
+    uploaderName: `Channel ${id}`,
+    uploaderAvatar: `https://invidious.test/ggpht/avatar-${id}`,
+    savedAt,
+  })
+}
+
+test('creates portable bookmark metadata and read-only playlist list data', () => {
+  const saved = bookmark('local')
+
+  assert.equal(saved.playlist.thumbnail_url, 'https://i.ytimg.com/vi/local/hqdefault.jpg')
+  assert.equal(saved.uploader.avatar, 'https://yt3.googleusercontent.com/avatar-local')
+  assert.deepEqual(playlistBookmarkToListData(saved), {
+    type: 'playlist',
+    isPlaylistBookmark: true,
+    title: 'Playlist local',
+    playlistName: 'Playlist local',
+    description: 'A saved YouTube playlist',
+    playlistId: 'local',
+    playlistThumbnail: 'https://i.ytimg.com/vi/local/hqdefault.jpg',
+    author: 'Channel local',
+    authorId: 'channel-local',
+    authorVerified: false,
+    authorThumbnails: [{ url: 'https://yt3.googleusercontent.com/avatar-local' }],
+    videoCount: 4,
+    createdAt: 123,
+    lastUpdatedAt: 123,
+    videos: [],
+  })
+})

--- a/tests/unit/playlist-bookmarks.test.mjs
+++ b/tests/unit/playlist-bookmarks.test.mjs
@@ -3,10 +3,12 @@ import test from 'node:test'
 
 import {
   createPlaylistBookmark,
+  mergePlaylistBookmarkConflict,
+  playlistBookmarkForSync,
   playlistBookmarkToListData,
 } from '../../src/renderer/helpers/playlist-bookmarks.js'
 
-function bookmark(id, savedAt = 123) {
+function bookmark (id, savedAt = 123) {
   return createPlaylistBookmark({
     id,
     title: `Playlist ${id}`,
@@ -42,4 +44,20 @@ test('creates portable bookmark metadata and read-only playlist list data', () =
     lastUpdatedAt: 123,
     videos: [],
   })
+})
+
+test('preserves playlist bookmark deletions during an encrypted sync conflict retry', () => {
+  const deleted = playlistBookmarkForSync(bookmark('deleted'))
+  const unchanged = playlistBookmarkForSync(bookmark('unchanged'))
+  const remoteChanged = {
+    ...unchanged,
+    playlist: { ...unchanged.playlist, title: 'Changed remotely' },
+  }
+  const remoteAdded = playlistBookmarkForSync(bookmark('remote-added'))
+
+  assert.deepEqual(mergePlaylistBookmarkConflict({
+    original: [deleted, unchanged],
+    local: [unchanged],
+    remote: [deleted, remoteChanged, remoteAdded],
+  }), [remoteChanged, remoteAdded])
 })

--- a/tests/unit/sync-server-privacy.test.mjs
+++ b/tests/unit/sync-server-privacy.test.mjs
@@ -2,8 +2,10 @@ import assert from 'node:assert/strict'
 import test from 'node:test'
 
 import {
+  createEmptySyncDocument,
   decryptLegacySyncDocument,
   decryptSyncDocument,
+  EncryptedSyncAdapter,
   migrateLegacyPlaybackSpeedsToSettings,
   preparePrivacyKey,
 } from '../../src/renderer/helpers/sync-server-privacy.js'
@@ -104,4 +106,18 @@ test('keeps the current settings collection instead of legacy playback speeds', 
 
   assert.equal(migrateLegacyPlaybackSpeedsToSettings(document, '{}', 789), false)
   assert.deepEqual(document.settings, [current])
+})
+
+test('stores playlist bookmarks in the encrypted sync document', async () => {
+  const adapter = new EncryptedSyncAdapter(createEmptySyncDocument())
+  const bookmark = {
+    playlist: { id: 'saved-playlist', title: 'Saved playlist' },
+    uploader: { id: 'saved-channel', name: 'Saved channel' },
+  }
+
+  await adapter.createPlaylistBookmark(bookmark)
+  assert.deepEqual(await adapter.getPlaylistBookmarks(), [bookmark])
+
+  await adapter.deletePlaylistBookmark('saved-playlist')
+  assert.deepEqual(await adapter.getPlaylistBookmarks(), [])
 })


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Make sure to follow the contributing guidelines. -->
<!-- Important note, we may remove your pull request if you do not use this provided PR template correctly. -->
<!-- Agent instructions: Preserve every heading, comment, and marker in this template. Never remove or rewrite the release-note-category:start/end, release-note:start/end, or release-note-image:start/end marker pairs. -->

## Pull Request Type
<!-- Please select what type of pull request this is: [x] -->
- [ ] Bugfix
- [x] Feature Implementation
- [ ] Documentation
- [ ] Other

## Related issue
<!-- Please link the issue your pull request is referring to. -->
<!-- If this pull request fully resolves the relevant issue, put "closes" before the issue number. -->
<!-- Example: "closes #123456". -->

closes #1012

## Description
<!-- Please write a clear and concise description of what the pull request does. -->

YouTube playlists currently need to be searched for again after leaving them. This adds a bookmark control to YouTube playlist pages and lists saved playlists in Your Playlists as read-only links to their live source.

Bookmarks preserve the playlist metadata and thumbnail shown to the user, persist across restarts, and sync with playlist data in both legacy and enhanced privacy modes. They can be removed from either the playlist page or Your Playlists without exposing local-playlist editing controls.

## Release note category
<!-- Select exactly one category. Every pull request must select one. -->
<!-- Select "Not noteworthy" when the pull request fixes a bug in or improves functionality that has not yet appeared in a stable release. -->
<!-- release-note-category:start -->
- [ ] Not noteworthy
- [ ] Highlights
- [x] More improvements
- [ ] Fixed bugs
<!-- release-note-category:end -->

## Release note
<!-- Required unless "Not noteworthy" is selected. -->
<!-- Write one concise, user-facing entry without a leading bullet. -->
<!-- release-note:start -->
Save YouTube playlists as read-only bookmarks in Your Playlists.
<!-- release-note:end -->

## Release note images
<!-- Optional. Paste one or more Markdown images, HTML image tags, or dark/light <picture> elements here. -->
<!-- The release notes normalize the markup and limit images taller than 300 pixels. -->
<!-- Agent instructions:
For a noteworthy visible change, add media when it makes the change easier to understand. Prefer a still image unless motion is the point; recordings must use animated WebP.
After implementing a visible change, proactively capture the result and show the local media to the user for approval before uploading it or updating the pull request.
When the affected UI differs between dark and light themes, capturing both themes is required. A dark-only image is incomplete. Run `node _scripts/releaseNoteMedia.mjs --dark DARK_FILE --light LIGHT_FILE --alt "DESCRIPTION"`; GitHub will display the matching theme and use dark as the fallback. Use a single default-dark capture only when the light theme cannot be captured or looks identical.
Capture or crop to the smallest region that still makes the change clear. Do not include the full window when the affected component can be understood on its own.
Use English unless localization is the subject. Keep components at their normal dimensions and placement instead of resizing them to fill the frame.
Use deterministic local fixtures for visible remote images. Reusable avatar and thumbnail fixtures are available through `e2e/helpers/visual-fixtures.mjs`. Before capturing, verify that every visible image has loaded successfully (`complete === true` and `naturalWidth > 0`).
Inspect the final dark and light files for failed images, missing content, unrelated UI, awkward animation, and misleading layout. Omit media when it does not explain the change clearly.
For one dark capture, run `node _scripts/releaseNoteMedia.mjs FILE --alt "DESCRIPTION"`.
Check for personal information, tokens, private repository names, and unrelated desktop content before uploading. Uploaded media is public.
Keep capture-only scripts, test hooks, screenshots, and recordings out of commits. Remove them before committing unless the capture code is also a reusable regression test. Never commit generated release-note media.
Paste only the generated markup between the marker comments. Leave this section empty when media would not help.
-->
<!-- release-note-image:start -->
<picture>
  <source media="(prefers-color-scheme: dark)" srcset="https://github.com/OpenTubeX/media/releases/download/attachments/20260830T075432Z-saved-playlist-dark-dark-815812ca6c.png">
  <source media="(prefers-color-scheme: light)" srcset="https://github.com/OpenTubeX/media/releases/download/attachments/20260830T075432Z-saved-playlist-light-light-fdb2f428ab.png">
  <img alt="Saved YouTube playlist in Your Playlists" src="https://github.com/OpenTubeX/media/releases/download/attachments/20260830T075432Z-saved-playlist-dark-dark-815812ca6c.png">
</picture>
<!-- release-note-image:end -->

## Testing
<!-- How can reviewers verify that the PR produces correct results? -->
<!-- Please provide instructions so that others can ensure that your pull request would produce correct results. For examples see, https://github.com/FreeTubeApp/FreeTube/pull/5743, https://github.com/FreeTubeApp/FreeTube/pull/7349, https://github.com/FreeTubeApp/FreeTube/pull/5125, https://github.com/FreeTubeApp/FreeTube/pull/7338 -->
<!-- Agent instructions: Only write human-facing steps that explain how to verify the change while running this branch in dev mode. Include expected results and, when applicable, helpful console snippets for interactive verification. Do not include automated checks, commands, results, pass counts, or CI status. -->

1. Search for a YouTube playlist and open it. Use the bookmark button, then open Your Playlists. The saved playlist should appear with the same thumbnail shown in search.
2. Open the saved playlist. It should load the live YouTube playlist and offer removal, but no local-playlist edit controls.
3. Restart the app and confirm the saved playlist remains in Your Playlists.
4. Switch between Local API and Invidious, then confirm the saved thumbnail loads through the selected backend.

## Additional context
<!-- Add any other context about the pull request here. -->

Saved entries contain playlist metadata only. Videos remain owned by the source playlist and are fetched when the bookmark is opened.
