### PR TITLE
fix(results): wrap video metadata without orphan separators

### DIFF
--- a/e2e/tests/offline/subscriptions-feed.spec.mjs
+++ b/e2e/tests/offline/subscriptions-feed.spec.mjs
@@ -226,11 +226,11 @@ test.describe('subscriptions feed from cache', () => {
     await goTo(page, 'subscriptions')
 
     const newestVideo = page.locator('.ft-list-video').filter({ hasText: 'Video B newest' })
-    await expect(newestVideo.locator('.uploadedTime')).toHaveText('• 30 minutes ago')
+    await expect(newestVideo.locator('.uploadedTime')).toHaveText('30 minutes ago')
 
     await page.clock.fastForward(31 * 60_000)
 
-    await expect(newestVideo.locator('.uploadedTime')).toHaveText('• 1 hour ago')
+    await expect(newestVideo.locator('.uploadedTime')).toHaveText('1 hour ago')
   })
 })
 

--- a/e2e/tests/offline/subscriptions-feed.spec.mjs
+++ b/e2e/tests/offline/subscriptions-feed.spec.mjs
@@ -268,14 +268,14 @@ test.describe('relative timestamp updates disabled', () => {
     await goTo(page, 'subscriptions')
 
     const newestVideo = page.locator('.ft-list-video').filter({ hasText: 'Video B newest' })
-    await expect(newestVideo.locator('.uploadedTime')).toHaveText('• 30 minutes ago')
+    await expect(newestVideo.locator('.uploadedTime')).toHaveText('30 minutes ago')
 
     await page.clock.fastForward(31 * 60_000)
-    await expect(newestVideo.locator('.uploadedTime')).toHaveText('• 30 minutes ago')
+    await expect(newestVideo.locator('.uploadedTime')).toHaveText('30 minutes ago')
 
     await goTo(page, 'trending')
     await goTo(page, 'subscriptions')
-    await expect(newestVideo.locator('.uploadedTime')).toHaveText('• 1 hour ago')
+    await expect(newestVideo.locator('.uploadedTime')).toHaveText('1 hour ago')
   })
 
   test('uses the current time when a reused card receives new data', async ({ page }) => {
@@ -303,7 +303,7 @@ test.describe('relative timestamp updates disabled', () => {
     }, { channelId: CHANNEL_B, published: now + 1.5 * HOUR })
 
     await expect(page.locator('[data-reuse-marker="relative-time"]')).toBeVisible()
-    await expect(newestVideo.locator('.uploadedTime')).toHaveText('• 30 minutes ago')
+    await expect(newestVideo.locator('.uploadedTime')).toHaveText('30 minutes ago')
   })
 })
 

--- a/e2e/tests/offline/video-result-avatars.spec.mjs
+++ b/e2e/tests/offline/video-result-avatars.spec.mjs
@@ -66,7 +66,7 @@ test.describe('Invidious search video avatars', () => {
     }
   })
 
-  test('loads shared avatars and vertically aligns result metadata', async ({ page }) => {
+  test('loads shared avatars and lays out result metadata responsively', async ({ page }) => {
     let channelRequests = 0
 
     await page.route(`${instanceUrl}/api/v1/search/**`, route => route.fulfill({
@@ -106,17 +106,68 @@ test.describe('Invidious search video avatars', () => {
     const infoLine = page.locator('.ft-list-video').filter({
       has: page.getByRole('heading', { name: 'First avatar search result' })
     }).locator('.infoLine')
-    await expect.poll(() => infoLine.evaluate(element => {
-      const channelRect = element.querySelector('.channelName').getBoundingClientRect()
-      const channelCenter = (channelRect.top + channelRect.bottom) / 2
+    expect(await infoLine.evaluate(element => {
+      const textBounds = (selector) => {
+        const range = document.createRange()
+        range.selectNodeContents(element.querySelector(selector))
+        return range.getBoundingClientRect()
+      }
+      const channelBounds = textBounds('.channelNameText')
+      const channelCenter = (channelBounds.top + channelBounds.bottom) / 2
+      const details = element.querySelector('.videoInfo')
+      const detailBounds = details.getBoundingClientRect()
+      const separator = getComputedStyle(details, '::before')
+      const separatorCenter = detailBounds.top + Number.parseFloat(separator.insetBlockStart)
 
-      return Math.max(...['.viewCount', '.uploadedTime'].map(selector => {
-        const detailRect = element.querySelector(selector).getBoundingClientRect()
-        const detailCenter = (detailRect.top + detailRect.bottom) / 2
-        return Math.abs(channelCenter - detailCenter)
-      }))
-    })).toBeLessThanOrEqual(0.5)
+      return {
+        metadataAligned: Math.max(...['.viewCount', '.uploadedTime'].map(selector => {
+          const bounds = textBounds(selector)
+          return Math.abs(channelCenter - (bounds.top + bounds.bottom) / 2)
+        })) <= 0.5,
+        separatorIsVisible: separator.content === '""' &&
+          getComputedStyle(details).overflowX === 'visible' &&
+          detailBounds.left + Number.parseFloat(separator.insetInlineStart) >
+            element.querySelector('.channelName').getBoundingClientRect().right,
+        separatorAligned: Math.abs(channelCenter - separatorCenter) <= 0.5
+      }
+    })).toEqual({
+      metadataAligned: true,
+      separatorAligned: true,
+      separatorIsVisible: true,
+    })
     expect(channelRequests).toBe(1)
+
+    await infoLine.evaluate(element => {
+      const channelWidth = element.querySelector('.channelName').getBoundingClientRect().width
+      const detailsWidth = element.querySelector('.videoInfo').getBoundingClientRect().width
+      element.style.flex = 'none'
+      element.style.inlineSize = `${Math.ceil(Math.max(channelWidth, detailsWidth))}px`
+    })
+    await expect.poll(() => infoLine.evaluate(element => {
+      const channelTop = element.querySelector('.channelName').getBoundingClientRect().top
+      const viewTop = element.querySelector('.viewCount').getBoundingClientRect().top
+      const uploadedTop = element.querySelector('.uploadedTime').getBoundingClientRect().top
+
+      return {
+        detailsShareRow: Math.abs(viewTop - uploadedTop) <= 0.5,
+        detailsStartNewRow: viewTop > channelTop + 0.5
+      }
+    })).toEqual({
+      detailsShareRow: true,
+      detailsStartNewRow: true
+    })
+    expect(await infoLine.locator('.viewCount').textContent()).not.toMatch(/^\s*•/)
+    expect(await infoLine.evaluate(element => {
+      const details = element.querySelector('.videoInfo')
+      const lineBounds = element.getBoundingClientRect()
+      const detailBounds = details.getBoundingClientRect()
+      const separator = getComputedStyle(details, '::before')
+
+      return separator.content === '""' &&
+        separator.backgroundColor === getComputedStyle(details).color &&
+        getComputedStyle(element).overflowX === 'clip' &&
+        detailBounds.left + Number.parseFloat(separator.insetInlineStart) < lineBounds.left
+    })).toBe(true)
   })
 
   test('hides video and playlist avatars without fetching channel data', async ({ page }) => {

--- a/src/renderer/components/FtListVideo/FtListVideo.vue
+++ b/src/renderer/components/FtListVideo/FtListVideo.vue
@@ -240,21 +240,20 @@
           />
           <span class="channelNameText">{{ channelName }}</span>
         </bdi>
-        <span
-          v-if="!isLive && !isUpcoming && !isPremium && !hideViews && viewCount != null"
-          class="viewCount"
-        >
-          <template v-if="channelId !== null || channelName !== null"> • </template>
-          {{ t('Global.Counts.View Count', { count: parsedViewCount }, viewCount) }}
+        <span class="videoInfo">
+          <span
+            v-if="!isLive && !isUpcoming && !isPremium && !hideViews && viewCount != null"
+            class="viewCount"
+          >{{ t('Global.Counts.View Count', { count: parsedViewCount }, viewCount) }}</span>
+          <span
+            v-if="displayedUploadedTime !== '' && !isLive"
+            class="uploadedTime"
+          >{{ displayedUploadedTime }}</span>
+          <span
+            v-if="isLive && !hideViews"
+            class="viewCount"
+          >{{ t('Global.Counts.Watching Count', { count: parsedViewCount }, viewCount) }}</span>
         </span>
-        <span
-          v-if="displayedUploadedTime !== '' && !isLive"
-          class="uploadedTime"
-        > • {{ displayedUploadedTime }}</span>
-        <span
-          v-if="isLive && !hideViews"
-          class="viewCount"
-        > • {{ t('Global.Counts.Watching Count', { count: parsedViewCount }, viewCount) }}</span>
       </div>
       <FtCollaboratorsPrompt
         v-if="showCollaboratorsPrompt"

--- a/src/renderer/scss-partials/_ft-list-item.scss
+++ b/src/renderer/scss-partials/_ft-list-item.scss
@@ -321,9 +321,15 @@ $watched-transition-duration: 0.5s;
     }
 
     .infoLine {
+      align-items: center;
+      column-gap: 0.75em;
+      display: flex;
+      flex-wrap: wrap;
       font-size: 14px;
       grid-area: infoLine;
       margin-block-start: 5px;
+      overflow-clip-margin: 2px;
+      overflow-x: clip;
       overflow-wrap: anywhere;
       text-align: start;
 
@@ -334,7 +340,53 @@ $watched-transition-duration: 0.5s;
       }
 
       .channelName {
+        flex: 0 0 auto;
+
         @include low-contrast-when-watched(var(--secondary-text-color));
+      }
+
+      .videoInfo {
+        column-gap: 0.75em;
+        display: flex;
+        flex: 0 0 auto;
+        flex-wrap: wrap;
+        inline-size: max-content;
+        max-inline-size: 100%;
+        position: relative;
+      }
+
+      .videoInfo:empty {
+        display: none;
+      }
+
+      .videoInfo::before,
+      .videoInfo > span + span::before {
+        background-color: currentcolor;
+        block-size: 0.25em;
+        border-radius: 50%;
+        content: '';
+        inline-size: 0.25em;
+        inset-inline-start: -0.5em;
+        position: absolute;
+        transform: translateY(-50%);
+      }
+
+      .videoInfo::before {
+        content: none;
+        inset-block-start: 0.5lh;
+      }
+
+      .channelName + .videoInfo::before {
+        content: '';
+      }
+
+      .videoInfo > span {
+        position: relative;
+        white-space: nowrap;
+      }
+
+      .videoInfo > span + span::before {
+        inset-block-start: 50%;
       }
     }
 


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Make sure to follow the contributing guidelines. -->
<!-- Important note, we may remove your pull request if you do not use this provided PR template correctly. -->
<!-- Agent instructions: Preserve every heading, comment, and marker in this template. Never remove or rewrite the release-note-category:start/end, release-note:start/end, or release-note-image:start/end marker pairs. -->

## Pull Request Type
<!-- Please select what type of pull request this is: [x] -->
- [x] Bugfix
- [ ] Feature Implementation
- [ ] Documentation
- [ ] Other

## Related issue
<!-- Please link the issue your pull request is referring to. -->
<!-- If this pull request fully resolves the relevant issue, put "closes" before the issue number. -->
<!-- Example: "closes #123456". -->

## Description
<!-- Please write a clear and concise description of what the pull request does. -->

Narrow video cards could wrap channel and video metadata awkwardly, leaving separators at the start of new rows and misaligning text beside channel avatars.

The view count and upload age now stay together as a responsive metadata row. The separator remains visible when the metadata fits beside the channel name and disappears when the metadata wraps to its own row. The row also stays aligned at fractional UI scales.

## Release note category
<!-- Select exactly one category. Every pull request must select one. -->
<!-- Select "Not noteworthy" when the pull request fixes a bug in or improves functionality that has not yet appeared in a stable release. -->
<!-- release-note-category:start -->
- [ ] Not noteworthy
- [ ] Highlights
- [ ] More improvements
- [x] Fixed bugs
<!-- release-note-category:end -->

## Release note
<!-- Required unless "Not noteworthy" is selected. -->
<!-- Write one concise, user-facing entry without a leading bullet. -->
<!-- release-note:start -->

Video metadata now wraps cleanly below channel names on narrow result cards.

<!-- release-note:end -->

## Release note images
<!-- Optional. Paste one or more Markdown images, HTML image tags, or dark/light <picture> elements here. -->
<!-- The release notes normalize the markup and limit images taller than 300 pixels. -->
<!-- Agent instructions:
For a noteworthy visible change, add media when it makes the change easier to understand. Prefer a still image unless motion is the point; recordings must use animated WebP.
After implementing a visible change, proactively capture the result and show the local media to the user for approval before uploading it or updating the pull request.
When the affected UI differs between dark and light themes, capturing both themes is required. A dark-only image is incomplete. Run `node _scripts/releaseNoteMedia.mjs --dark DARK_FILE --light LIGHT_FILE --alt "DESCRIPTION"`; GitHub will display the matching theme and use dark as the fallback. Use a single default-dark capture only when the light theme cannot be captured or looks identical.
Capture or crop to the smallest region that still makes the change clear. Do not include the full window when the affected component can be understood on its own.
Use English unless localization is the subject. Keep components at their normal dimensions and placement instead of resizing them to fill the frame.
Use deterministic local fixtures for visible remote images. Reusable avatar and thumbnail fixtures are available through `e2e/helpers/visual-fixtures.mjs`. Before capturing, verify that every visible image has loaded successfully (`complete === true` and `naturalWidth > 0`).
Inspect the final dark and light files for failed images, missing content, unrelated UI, awkward animation, and misleading layout. Omit media when it does not explain the change clearly.
For one dark capture, run `node _scripts/releaseNoteMedia.mjs FILE --alt "DESCRIPTION"`.
Check for personal information, tokens, private repository names, and unrelated desktop content before uploading. Uploaded media is public.
Keep capture-only scripts, test hooks, screenshots, and recordings out of commits. Remove them before committing unless the capture code is also a reusable regression test. Never commit generated release-note media.
Paste only the generated markup between the marker comments. Leave this section empty when media would not help.
-->
<!-- release-note-image:start -->

<!-- release-note-image:end -->

## Testing
<!-- How can reviewers verify that the PR produces correct results? -->
<!-- Please provide instructions so that others can ensure that your pull request would produce correct results. For examples see, https://github.com/FreeTubeApp/FreeTube/pull/5743, https://github.com/FreeTubeApp/FreeTube/pull/7349, https://github.com/FreeTubeApp/FreeTube/pull/5125, https://github.com/FreeTubeApp/FreeTube/pull/7338 -->
<!-- Agent instructions: Only write human-facing steps that explain how to verify the change while running this branch in dev mode. Include expected results and, when applicable, helpful console snippets for interactive verification. Do not include automated checks, commands, results, pass counts, or CI status. -->

1. Open a page with video result cards and channel avatars.
2. Narrow the window until the view count and upload age wrap below the channel name. The wrapped row should have no leading separator and should align with the channel name.
3. Widen the window again. The metadata should return beside the channel name with a centered separator between them.
4. Repeat at 125% UI scale and confirm both layouts stay aligned.

## Additional context
<!-- Add any other context about the pull request here. -->
