### PR TITLE
fix(playlists): refresh saved playlist thumbnails

### DIFF
--- a/e2e/tests/offline/playlist-loading.spec.mjs
+++ b/e2e/tests/offline/playlist-loading.spec.mjs
@@ -187,6 +187,12 @@ test('keeps the search result thumbnail when saving a playlist', async ({ page }
 test('refreshes a saved playlist thumbnail after opening the playlist again', async ({ app, page }) => {
   const playlistId = 'dynamic-saved-playlist'
   let firstVideoId = 'original-first-video'
+  let markStaleRequestStarted
+  const staleRequestStarted = new Promise(resolve => { markStaleRequestStarted = resolve })
+  let releaseStaleRequest
+  const staleRequestRelease = new Promise(resolve => { releaseStaleRequest = resolve })
+  let markStaleRequestFinished
+  const staleRequestFinished = new Promise(resolve => { markStaleRequestFinished = resolve })
 
   await page.route(new RegExp(`/api/v1/playlists/${playlistId}\\?`), route => route.fulfill({
     json: {
@@ -195,6 +201,18 @@ test('refreshes a saved playlist thumbnail after opening the playlist again', as
       playlistId,
     },
   }))
+  await page.route(/\/api\/v1\/playlists\/stale-thumbnail-source\?/, async route => {
+    markStaleRequestStarted()
+    await staleRequestRelease
+    await route.fulfill({
+      json: {
+        ...playlistResponse([playlistVideo(0, 'stale-first-video')], 1),
+        title: 'Stale thumbnail source',
+        playlistId: 'stale-thumbnail-source',
+      },
+    })
+    markStaleRequestFinished()
+  })
 
   await openPlaylistTab(page, `/playlist/${playlistId}`)
   await page.getByTitle('Save Playlist').click()
@@ -209,8 +227,13 @@ test('refreshes a saved playlist thumbnail after opening the playlist again', as
   )
 
   firstVideoId = 'updated-first-video'
-  await page.getByRole('link', { name: 'Dynamic saved playlist' }).click()
+  await openPlaylistTab(page, '/playlist/stale-thumbnail-source')
+  await staleRequestStarted
+  await page.locator(sel.searchInput).fill(`https://www.youtube.com/playlist?list=${playlistId}`)
+  await page.locator(sel.searchInput).press('Enter')
   await expect(page.getByText('Playlist video 1', { exact: true })).toBeVisible()
+  releaseStaleRequest()
+  await staleRequestFinished
   await goTo(page, 'userplaylists')
 
   const updatedThumbnailUrl = 'https://invidious.test/vi/updated-first-video/mqdefault.jpg'

--- a/e2e/tests/offline/playlist-loading.spec.mjs
+++ b/e2e/tests/offline/playlist-loading.spec.mjs
@@ -184,6 +184,46 @@ test('keeps the search result thumbnail when saving a playlist', async ({ page }
     .toHaveAttribute('src', expectedThumbnail)
 })
 
+test('refreshes a saved playlist thumbnail after opening the playlist again', async ({ app, page }) => {
+  const playlistId = 'dynamic-saved-playlist'
+  let firstVideoId = 'original-first-video'
+
+  await page.route(new RegExp(`/api/v1/playlists/${playlistId}\\?`), route => route.fulfill({
+    json: {
+      ...playlistResponse([playlistVideo(0, firstVideoId)], 1),
+      title: 'Dynamic saved playlist',
+      playlistId,
+    },
+  }))
+
+  await openPlaylistTab(page, `/playlist/${playlistId}`)
+  await page.getByTitle('Save Playlist').click()
+  await goTo(page, 'userplaylists')
+
+  const savedPlaylistCard = page.getByRole('link', { name: 'Dynamic saved playlist' })
+    .locator('xpath=ancestor::div[contains(@class, "ft-list-item")]')
+  const savedPlaylistThumbnail = savedPlaylistCard.locator('img.thumbnailImage')
+  await expect(savedPlaylistThumbnail).toHaveAttribute(
+    'src',
+    'https://invidious.test/vi/original-first-video/mqdefault.jpg'
+  )
+
+  firstVideoId = 'updated-first-video'
+  await page.getByRole('link', { name: 'Dynamic saved playlist' }).click()
+  await expect(page.getByText('Playlist video 1', { exact: true })).toBeVisible()
+  await goTo(page, 'userplaylists')
+
+  const updatedThumbnailUrl = 'https://invidious.test/vi/updated-first-video/mqdefault.jpg'
+  await expect(savedPlaylistThumbnail).toHaveAttribute('src', updatedThumbnailUrl)
+
+  ;({ page } = await app.relaunch())
+  await goTo(page, 'userplaylists')
+  const persistedPlaylistCard = page.getByRole('link', { name: 'Dynamic saved playlist' })
+    .locator('xpath=ancestor::div[contains(@class, "ft-list-item")]')
+  await expect(persistedPlaylistCard.locator('img.thumbnailImage'))
+    .toHaveAttribute('src', updatedThumbnailUrl)
+})
+
 test('retries the failed Invidious page and merges its overlapping videos once', async ({ page }) => {
   const requestedPages = []
   await page.route(/\/api\/v1\/playlists\/pagination-test\?/, async (route) => {

--- a/src/renderer/views/Playlist/Playlist.vue
+++ b/src/renderer/views/Playlist/Playlist.vue
@@ -611,8 +611,13 @@ function resetState() {
 }
 
 async function getPlaylistLocal() {
+  const requestGeneration = playlistRequestGeneration
+  const requestedPlaylistId = playlistId.value
+  const requestIsCurrent = () => requestGeneration === playlistRequestGeneration && requestedPlaylistId === playlistId.value
+
   try {
-    const result = await getLocalPlaylist(playlistId.value)
+    const result = await getLocalPlaylist(requestedPlaylistId)
+    if (!requestIsCurrent()) return
 
     let channelName_
 
@@ -652,6 +657,7 @@ async function getPlaylistLocal() {
     playlistItems.value = playlistItems_
 
     await refreshPlaylistBookmarkThumbnail()
+    if (!requestIsCurrent()) return
 
     let shouldGetNextPage = false
     if (result.has_continuation) {
@@ -668,6 +674,8 @@ async function getPlaylistLocal() {
 
     isLoading.value = false
   } catch (err) {
+    if (!requestIsCurrent()) return
+
     console.error(err)
 
     if (backendPreference.value === 'local' && backendFallback.value) {
@@ -682,8 +690,13 @@ async function getPlaylistLocal() {
 }
 
 async function getPlaylistInvidious() {
+  const requestGeneration = playlistRequestGeneration
+  const requestedPlaylistId = playlistId.value
+  const requestIsCurrent = () => requestGeneration === playlistRequestGeneration && requestedPlaylistId === playlistId.value
+
   try {
-    const result = await invidiousGetPlaylistInfo(playlistId.value)
+    const result = await invidiousGetPlaylistInfo(requestedPlaylistId)
+    if (!requestIsCurrent()) return
 
     playlistTitle.value = result.title
     playlistDescription.value = result.description
@@ -707,6 +720,7 @@ async function getPlaylistInvidious() {
 
     playlistItems.value = result.videos
     await refreshPlaylistBookmarkThumbnail()
+    if (!requestIsCurrent()) return
     const hasMorePages = hasMoreInvidiousPlaylistPages(
       result.videoCount,
       1,
@@ -721,6 +735,8 @@ async function getPlaylistInvidious() {
 
     isLoading.value = false
   } catch (err) {
+    if (!requestIsCurrent()) return
+
     console.error(err)
 
     if (process.env.SUPPORTS_LOCAL_API && backendPreference.value === 'invidious' && backendFallback.value) {

--- a/src/renderer/views/Playlist/Playlist.vue
+++ b/src/renderer/views/Playlist/Playlist.vue
@@ -248,7 +248,7 @@ import {
 import { invidiousGetPlaylistInfo, youtubeImageUrlToInvidious } from '../../helpers/api/invidious'
 import { hasMoreInvidiousPlaylistPages, mergeInvidiousPlaylistVideos } from '../../helpers/api/invidious-playlists'
 import { runRetryablePlaylistRequest } from '../../helpers/playlist-pagination'
-import { createPlaylistBookmark } from '../../helpers/playlist-bookmarks'
+import { canonicalPlaylistThumbnailUrl, createPlaylistBookmark } from '../../helpers/playlist-bookmarks'
 import { fillMissingPlaylistVideoDurations, getSortedPlaylistItems, SORT_BY_VALUES } from '../../helpers/playlists'
 import { MOBILE_WIDTH_THRESHOLD, PLAYLIST_HEIGHT_FORCE_LIST_THRESHOLD } from '../../../constants'
 import { useTabContext, useTabLifecycle, useTabTitle } from '../../tabs/TabContext'
@@ -387,6 +387,25 @@ const isUserPlaylistRequested = computed(() => route.query.playlistType === 'use
 const isPlaylistBookmarked = computed(() => {
   return !isUserPlaylistRequested.value && store.getters.getPlaylistBookmark(playlistId.value) != null
 })
+
+async function refreshPlaylistBookmarkThumbnail() {
+  const bookmark = store.getters.getPlaylistBookmark(playlistId.value)
+  if (bookmark == null) return
+
+  const thumbnailUrl = playlistThumbnail.value || (firstVideoId.value
+    ? `https://i.ytimg.com/vi/${firstVideoId.value}/mqdefault.jpg`
+    : null)
+  const canonicalThumbnailUrl = canonicalPlaylistThumbnailUrl(thumbnailUrl)
+  if (bookmark.playlist.thumbnail_url === canonicalThumbnailUrl) return
+
+  await store.dispatch('savePlaylistBookmark', {
+    ...bookmark,
+    playlist: {
+      ...bookmark.playlist,
+      thumbnail_url: canonicalThumbnailUrl,
+    },
+  })
+}
 
 async function togglePlaylistBookmark() {
   if (playlistBookmarkPending.value || isUserPlaylistRequested.value) return
@@ -632,6 +651,8 @@ async function getPlaylistLocal() {
 
     playlistItems.value = playlistItems_
 
+    await refreshPlaylistBookmarkThumbnail()
+
     let shouldGetNextPage = false
     if (result.has_continuation) {
       continuationData.value = result
@@ -685,6 +706,7 @@ async function getPlaylistInvidious() {
     lastUpdated.value = dateString.toLocaleDateString(locale.value, { year: 'numeric', month: 'short', day: 'numeric' })
 
     playlistItems.value = result.videos
+    await refreshPlaylistBookmarkThumbnail()
     const hasMorePages = hasMoreInvidiousPlaylistPages(
       result.videoCount,
       1,


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Make sure to follow the contributing guidelines. -->
<!-- Important note, we may remove your pull request if you do not use this provided PR template correctly. -->
<!-- Agent instructions: Preserve every heading, comment, and marker in this template. Never remove or rewrite the release-note-category:start/end, release-note:start/end, or release-note-image:start/end marker pairs. -->

## Pull Request Type
<!-- Please select what type of pull request this is: [x] -->
- [x] Bugfix
- [ ] Feature Implementation
- [ ] Documentation
- [ ] Other

## Related issue
<!-- Please link the issue your pull request is referring to. -->
<!-- If this pull request fully resolves the relevant issue, put "closes" before the issue number. -->
<!-- Example: "closes #123456". -->

Closes #1018

## Description
<!-- Please write a clear and concise description of what the pull request does. -->

Saved playlists kept the thumbnail captured when they were first saved, even after a dynamic playlist's first video changed. This refreshes the stored thumbnail from newly loaded playlist data whenever the user opens a saved playlist. It skips the write when the thumbnail URL has not changed.

## Release note category
<!-- Select exactly one category. Every pull request must select one. -->
<!-- Select "Not noteworthy" when the pull request fixes a bug in or improves functionality that has not yet appeared in a stable release. -->
<!-- release-note-category:start -->
- [x] Not noteworthy
- [ ] Highlights
- [ ] More improvements
- [ ] Fixed bugs
<!-- release-note-category:end -->

## Release note
<!-- Required unless "Not noteworthy" is selected. -->
<!-- Write one concise, user-facing entry without a leading bullet. -->
<!-- release-note:start -->
Saved playlist thumbnails now update when the playlist's first video changes.
<!-- release-note:end -->

## Release note images
<!-- Optional. Paste one or more Markdown images, HTML image tags, or dark/light <picture> elements here. -->
<!-- The release notes normalize the markup and limit images taller than 300 pixels. -->
<!-- Agent instructions:
For a noteworthy visible change, add media when it makes the change easier to understand. Prefer a still image unless motion is the point; recordings must use animated WebP.
After implementing a visible change, proactively capture the result and show the local media to the user for approval before uploading it or updating the pull request.
When the affected UI differs between dark and light themes, capturing both themes is required. A dark-only image is incomplete. Run `node _scripts/releaseNoteMedia.mjs --dark DARK_FILE --light LIGHT_FILE --alt "DESCRIPTION"`; GitHub will display the matching theme and use dark as the fallback. Use a single default-dark capture only when the light theme cannot be captured or looks identical.
Capture or crop to the smallest region that still makes the change clear. Do not include the full window when the affected component can be understood on its own.
Use English unless localization is the subject. Keep components at their normal dimensions and placement instead of resizing them to fill the frame.
Use deterministic local fixtures for visible remote images. Reusable avatar and thumbnail fixtures are available through `e2e/helpers/visual-fixtures.mjs`. Before capturing, verify that every visible image has loaded successfully (`complete === true` and `naturalWidth > 0`).
Inspect the final dark and light files for failed images, missing content, unrelated UI, awkward animation, and misleading layout. Omit media when it does not explain the change clearly.
For one dark capture, run `node _scripts/releaseNoteMedia.mjs FILE --alt "DESCRIPTION"`.
Check for personal information, tokens, private repository names, and unrelated desktop content before uploading. Uploaded media is public.
Keep capture-only scripts, test hooks, screenshots, and recordings out of commits. Remove them before committing unless the capture code is also a reusable regression test. Never commit generated release-note media.
Paste only the generated markup between the marker comments. Leave this section empty when media would not help.
-->
<!-- release-note-image:start -->

<!-- release-note-image:end -->

## Testing
<!-- How can reviewers verify that the PR produces correct results? -->
<!-- Please provide instructions so that others can ensure that your pull request would produce correct results. For examples see, https://github.com/FreeTubeApp/FreeTube/pull/5743, https://github.com/FreeTubeApp/FreeTube/pull/7349, https://github.com/FreeTubeApp/FreeTube/pull/5125, https://github.com/FreeTubeApp/FreeTube/pull/7338 -->
<!-- Agent instructions: Only write human-facing steps that explain how to verify the change while running this branch in dev mode. Include expected results and, when applicable, helpful console snippets for interactive verification. Do not include automated checks, commands, results, pass counts, or CI status. -->

1. Save a YouTube playlist and note its thumbnail on the Playlists page.
2. Change the playlist so a different video appears first, then open the saved playlist again.
3. Return to the Playlists page. The card should use the new first video's thumbnail, including after restarting the app.

## Additional context
<!-- Add any other context about the pull request here. -->

The refresh preserves the bookmark's original save time and other stored metadata.
