### PR TITLE
fix(youtube): stop parser warning spam

### DIFF
--- a/patches/youtubei.js@18.0.0.patch
+++ b/patches/youtubei.js@18.0.0.patch
@@ -1,3 +1,68 @@
+diff --git a/dist/src/parser/classes/VideoTitleHeaderView.d.ts b/dist/src/parser/classes/VideoTitleHeaderView.d.ts
+new file mode 100644
+index 0000000000000000000000000000000000000000..eb9bb89142dcc70d0c84ee8bb68d90794f60677b
+--- /dev/null
++++ b/dist/src/parser/classes/VideoTitleHeaderView.d.ts
+@@ -0,0 +1,12 @@
++import { YTNode } from '../helpers.js';
++import { type RawNode } from '../index.js';
++import Text from './misc/Text.js';
++import RendererContext from './misc/RendererContext.js';
++import ButtonView from './ButtonView.js';
++export default class VideoTitleHeaderView extends YTNode {
++    static type: string;
++    video_title: Text;
++    header_button: ButtonView | null;
++    renderer_context?: RendererContext;
++    constructor(data: RawNode);
++}
+diff --git a/dist/src/parser/classes/VideoTitleHeaderView.js b/dist/src/parser/classes/VideoTitleHeaderView.js
+new file mode 100644
+index 0000000000000000000000000000000000000000..7f5b5872e1a87cda497e7b4c14444fa43b525316
+--- /dev/null
++++ b/dist/src/parser/classes/VideoTitleHeaderView.js
+@@ -0,0 +1,19 @@
++import { YTNode } from '../helpers.js';
++import { Parser } from '../index.js';
++import Text from './misc/Text.js';
++import RendererContext from './misc/RendererContext.js';
++import ButtonView from './ButtonView.js';
++export default class VideoTitleHeaderView extends YTNode {
++    static type = 'VideoTitleHeaderView';
++    video_title;
++    header_button;
++    renderer_context;
++    constructor(data) {
++        super();
++        this.video_title = Text.fromAttributed(data.videoTitle);
++        this.header_button = Parser.parseItem(data.headerButton, ButtonView);
++        if ('rendererContext' in data) {
++            this.renderer_context = new RendererContext(data.rendererContext);
++        }
++    }
++}
+diff --git a/dist/src/parser/nodes.d.ts b/dist/src/parser/nodes.d.ts
+index 270a1d15489deec9645e790215b544b42b372307..7837992e5fb0e1a723f7c2636103761dc5ea24a6 100644
+--- a/dist/src/parser/nodes.d.ts
++++ b/dist/src/parser/nodes.d.ts
+@@ -542,5 +542,6 @@ export { default as VideoSecondaryInfo } from './classes/VideoSecondaryInfo.js';
+ export { default as VideoSummaryContentView } from './classes/VideoSummaryContentView.js';
+ export { default as VideoSummaryParagraphView } from './classes/VideoSummaryParagraphView.js';
++export { default as VideoTitleHeaderView } from './classes/VideoTitleHeaderView.js';
+ export { default as VideoViewCount } from './classes/VideoViewCount.js';
+ export { default as ViewCountFactoid } from './classes/ViewCountFactoid.js';
+ export { default as WatchCardCompactVideo } from './classes/WatchCardCompactVideo.js';
+diff --git a/dist/src/parser/nodes.js b/dist/src/parser/nodes.js
+index 3511b11a22302980a4c1b57bbc897a307e1e51bd..240195d26d731f5e347d5192e96d57e5b0af71ce 100644
+--- a/dist/src/parser/nodes.js
++++ b/dist/src/parser/nodes.js
+@@ -544,5 +544,6 @@ export { default as VideoSecondaryInfo } from './classes/VideoSecondaryInfo.js';
+ export { default as VideoSummaryContentView } from './classes/VideoSummaryContentView.js';
+ export { default as VideoSummaryParagraphView } from './classes/VideoSummaryParagraphView.js';
++export { default as VideoTitleHeaderView } from './classes/VideoTitleHeaderView.js';
+ export { default as VideoViewCount } from './classes/VideoViewCount.js';
+ export { default as ViewCountFactoid } from './classes/ViewCountFactoid.js';
+ export { default as WatchCardCompactVideo } from './classes/WatchCardCompactVideo.js';
 diff --git a/dist/src/parser/classes/misc/Text.js b/dist/src/parser/classes/misc/Text.js
 index 54f783de192662508fc358134e73ff8002051cf8..e11ebe9b762b543a2555010b1aab510c769a265c 100644
 --- a/dist/src/parser/classes/misc/Text.js

--- a/patches/youtubei.js@18.0.0.patch
+++ b/patches/youtubei.js@18.0.0.patch
@@ -1,3 +1,23 @@
+diff --git a/dist/src/parser/classes/misc/Text.js b/dist/src/parser/classes/misc/Text.js
+index 54f783de192662508fc358134e73ff8002051cf8..e11ebe9b762b543a2555010b1aab510c769a265c 100644
+--- a/dist/src/parser/classes/misc/Text.js
++++ b/dist/src/parser/classes/misc/Text.js
+@@ -95,8 +95,13 @@ export default class Text {
+             this.processStyleRuns(runs, style_runs, data);
+         if (command_runs?.length)
+             this.processCommandRuns(runs, command_runs, data);
+-        if (attachment_runs?.length)
+-            this.processAttachmentRuns(runs, attachment_runs, data);
++        const normalized_attachment_runs = attachment_runs?.map((run) => ({
++            ...run,
++            startIndex: run.startIndex ?? 0,
++            length: run.length ?? 0
++        }));
++        if (normalized_attachment_runs?.length)
++            this.processAttachmentRuns(runs, normalized_attachment_runs, data);
+         return new Text({ runs });
+     }
+     static processStyleRuns(runs, style_runs, data) {
 diff --git a/dist/src/parser/classes/VideoAttributeView.d.ts b/dist/src/parser/classes/VideoAttributeView.d.ts
 index fe90c6fe53ec4428d9a55c60902da64771541c60..f02b34a6727688b0dc21c800d96277b8151e9272 100644
 --- a/dist/src/parser/classes/VideoAttributeView.d.ts

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -11,7 +11,7 @@ overrides:
 patchedDependencies:
   shaka-player@5.1.12: 17d85e267c8958999207ce9d6c29a2ddf18734d0499fb30870ac8a55d90303fa
   vue-sonner@2.0.9: ae94d00b3ff46bede626a25ac5a36a6cd35987f33d73c14ffc73afbd5767f95c
-  youtubei.js@18.0.0: e4a67203ce48a3f01073b5d654662cd225e44ac2f60835ffb7223d4708f1901b
+  youtubei.js@18.0.0: 5939f9d50ce37ef8075961245288956568c781818db04171892485bdf96278e9
 
 importers:
 
@@ -88,7 +88,7 @@ importers:
         version: 4.1.0(vue@3.5.41(typescript@6.0.3))
       youtubei.js:
         specifier: ^18.0.0
-        version: 18.0.0(patch_hash=e4a67203ce48a3f01073b5d654662cd225e44ac2f60835ffb7223d4708f1901b)
+        version: 18.0.0(patch_hash=5939f9d50ce37ef8075961245288956568c781818db04171892485bdf96278e9)
     devDependencies:
       '@babel/core':
         specifier: ^8.0.1
@@ -10944,7 +10944,7 @@ snapshots:
 
   yocto-queue@0.1.0: {}
 
-  youtubei.js@18.0.0(patch_hash=e4a67203ce48a3f01073b5d654662cd225e44ac2f60835ffb7223d4708f1901b):
+  youtubei.js@18.0.0(patch_hash=5939f9d50ce37ef8075961245288956568c781818db04171892485bdf96278e9):
     dependencies:
       '@bufbuild/protobuf': 2.12.1
       fflate: 0.8.3

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -11,7 +11,7 @@ overrides:
 patchedDependencies:
   shaka-player@5.1.12: 17d85e267c8958999207ce9d6c29a2ddf18734d0499fb30870ac8a55d90303fa
   vue-sonner@2.0.9: ae94d00b3ff46bede626a25ac5a36a6cd35987f33d73c14ffc73afbd5767f95c
-  youtubei.js@18.0.0: 0b135b4394353469ed23f38c1f7c8d46790e2033a3b7e5adc4578cac5e480bb0
+  youtubei.js@18.0.0: e4a67203ce48a3f01073b5d654662cd225e44ac2f60835ffb7223d4708f1901b
 
 importers:
 
@@ -88,7 +88,7 @@ importers:
         version: 4.1.0(vue@3.5.41(typescript@6.0.3))
       youtubei.js:
         specifier: ^18.0.0
-        version: 18.0.0(patch_hash=0b135b4394353469ed23f38c1f7c8d46790e2033a3b7e5adc4578cac5e480bb0)
+        version: 18.0.0(patch_hash=e4a67203ce48a3f01073b5d654662cd225e44ac2f60835ffb7223d4708f1901b)
     devDependencies:
       '@babel/core':
         specifier: ^8.0.1
@@ -10944,7 +10944,7 @@ snapshots:
 
   yocto-queue@0.1.0: {}
 
-  youtubei.js@18.0.0(patch_hash=0b135b4394353469ed23f38c1f7c8d46790e2033a3b7e5adc4578cac5e480bb0):
+  youtubei.js@18.0.0(patch_hash=e4a67203ce48a3f01073b5d654662cd225e44ac2f60835ffb7223d4708f1901b):
     dependencies:
       '@bufbuild/protobuf': 2.12.1
       fflate: 0.8.3

--- a/tests/unit/youtubei-attributed-text.test.mjs
+++ b/tests/unit/youtubei-attributed-text.test.mjs
@@ -1,0 +1,33 @@
+import assert from 'node:assert/strict'
+import test from 'node:test'
+
+// Loads the platform shim that youtubei.js' parser dependencies need.
+import 'youtubei.js'
+
+import Text from '../../node_modules/youtubei.js/dist/src/parser/classes/misc/Text.js'
+
+test('parses attachment runs whose omitted length represents a point attachment', (t) => {
+  const warn = t.mock.method(console, 'warn', () => {})
+  const attachment = {
+    startIndex: 5,
+    element: {
+      type: {
+        imageType: {
+          image: { sources: [] }
+        }
+      }
+    },
+    alignment: 'ALIGNMENT_VERTICAL_CENTER'
+  }
+
+  const text = Text.fromAttributed({
+    content: 'fa_sc and Fabiano',
+    attachmentRuns: [attachment]
+  })
+
+  assert.equal(warn.mock.callCount(), 0)
+  assert.equal(text.toString(), 'fa_sc and Fabiano')
+  assert.ok(text.runs)
+  assert.equal(text.runs[0].attachment.length, 0)
+  assert.deepEqual(text.runs[0].attachment.element, attachment.element)
+})

--- a/tests/unit/youtubei-video-title-header.test.mjs
+++ b/tests/unit/youtubei-video-title-header.test.mjs
@@ -1,0 +1,25 @@
+import assert from 'node:assert/strict'
+import test from 'node:test'
+
+import { Parser, YTNodes } from 'youtubei.js'
+
+test('parses video title header view models without generating a runtime parser', (t) => {
+  const warn = t.mock.method(console, 'warn', () => {})
+
+  const header = Parser.parseItem({
+    videoTitleHeaderViewModel: {
+      videoTitle: { content: 'Fixture title' },
+      headerButton: {
+        buttonViewModel: { title: 'Open' }
+      },
+      rendererContext: {}
+    }
+  })
+
+  assert.equal(warn.mock.callCount(), 0)
+  assert.ok(header instanceof YTNodes.VideoTitleHeaderView)
+  assert.equal(header.video_title.toString(), 'Fixture title')
+  assert.ok(header.header_button instanceof YTNodes.ButtonView)
+  assert.equal(header.header_button.title, 'Open')
+  assert.ok(header.renderer_context)
+})


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Make sure to follow the contributing guidelines. -->
<!-- Important note, we may remove your pull request if you do not use this provided PR template correctly. -->
<!-- Agent instructions: Preserve every heading, comment, and marker in this template. Never remove or rewrite the release-note-category:start/end, release-note:start/end, or release-note-image:start/end marker pairs. -->

## Pull Request Type
<!-- Please select what type of pull request this is: [x] -->
- [x] Bugfix
- [ ] Feature Implementation
- [ ] Documentation
- [ ] Other

## Related issue
<!-- Please link the issue your pull request is referring to. -->
<!-- If this pull request fully resolves the relevant issue, put "closes" before the issue number. -->
<!-- Example: "closes #123456". -->

No linked issue.

## Description
<!-- Please write a clear and concise description of what the pull request does. -->

YouTube.js 18 is missing two upstream parser fixes. An omitted attachment length made it log the same warning for every affected collaborator avatar. New `videoTitleHeaderViewModel` responses also fell back to a generated runtime parser and logged `VideoTitleHeaderView not found!`.

This backports both fixes. Missing attachment lengths are treated as zero so point attachments remain intact, and `VideoTitleHeaderView` is registered as a normal parser node. Each response shape has a regression test.

## Release note category
<!-- Select exactly one category. Every pull request must select one. -->
<!-- Select "Not noteworthy" when the pull request fixes a bug in or improves functionality that has not yet appeared in a stable release. -->
<!-- release-note-category:start -->
- [ ] Not noteworthy
- [ ] Highlights
- [ ] More improvements
- [x] Fixed bugs
<!-- release-note-category:end -->

## Release note
<!-- Required unless "Not noteworthy" is selected. -->
<!-- Write one concise, user-facing entry without a leading bullet. -->
<!-- release-note:start -->
Stop repeated YouTube parser warnings for collaborator avatars and newer video title headers.
<!-- release-note:end -->

## Release note images
<!-- Optional. Paste one or more Markdown images, HTML image tags, or dark/light <picture> elements here. -->
<!-- The release notes normalize the markup and limit images taller than 300 pixels. -->
<!-- Agent instructions:
For a noteworthy visible change, add media when it makes the change easier to understand. Prefer a still image unless motion is the point; recordings must use animated WebP.
After implementing a visible change, proactively capture the result and show the local media to the user for approval before uploading it or updating the pull request.
When the affected UI differs between dark and light themes, capturing both themes is required. A dark-only image is incomplete. Run `node _scripts/releaseNoteMedia.mjs --dark DARK_FILE --light LIGHT_FILE --alt "DESCRIPTION"`; GitHub will display the matching theme and use dark as the fallback. Use a single default-dark capture only when the light theme cannot be captured or looks identical.
Capture or crop to the smallest region that still makes the change clear. Do not include the full window when the affected component can be understood on its own.
Use English unless localization is the subject. Keep components at their normal dimensions and placement instead of resizing them to fill the frame.
Use deterministic local fixtures for visible remote images. Reusable avatar and thumbnail fixtures are available through `e2e/helpers/visual-fixtures.mjs`. Before capturing, verify that every visible image has loaded successfully (`complete === true` and `naturalWidth > 0`).
Inspect the final dark and light files for failed images, missing content, unrelated UI, awkward animation, and misleading layout. Omit media when it does not explain the change clearly.
For one dark capture, run `node _scripts/releaseNoteMedia.mjs FILE --alt "DESCRIPTION"`.
Check for personal information, tokens, private repository names, and unrelated desktop content before uploading. Uploaded media is public.
Keep capture-only scripts, test hooks, screenshots, and recordings out of commits. Remove them before committing unless the capture code is also a reusable regression test. Never commit generated release-note media.
Paste only the generated markup between the marker comments. Leave this section empty when media would not help.
-->
<!-- release-note-image:start -->

<!-- release-note-image:end -->

## Testing
<!-- How can reviewers verify that the PR produces correct results? -->
<!-- Please provide instructions so that others can ensure that your pull request would produce correct results. For examples see, https://github.com/FreeTubeApp/FreeTube/pull/5743, https://github.com/FreeTubeApp/FreeTube/pull/7349, https://github.com/FreeTubeApp/FreeTube/pull/5125, https://github.com/FreeTubeApp/FreeTube/pull/7338 -->
<!-- Agent instructions: Only write human-facing steps that explain how to verify the change while running this branch in dev mode. Include expected results and, when applicable, helpful console snippets for interactive verification. Do not include automated checks, commands, results, pass counts, or CI status. -->

1. Run this branch in dev mode and open the renderer DevTools console.
2. Open a video whose owner byline contains collaborators. Confirm the collaborator byline still loads without `[YOUTUBEJS][Text]: Unable to find matching run for attachment run. Skipping...` warnings.
3. Open a video whose response contains `videoTitleHeaderViewModel`. Confirm its title header parses without a `VideoTitleHeaderView not found!` warning.

## Additional context
<!-- Add any other context about the pull request here. -->

Backports upstream YouTube.js commits https://github.com/LuanRT/YouTube.js/commit/c636d81127a3 and https://github.com/LuanRT/YouTube.js/commit/e26e13d9b7cc. Version 18.0.0 remains the latest published release, so upgrading cannot pick up either fix yet.
