### PR TITLE
fix(navigation): remove About from mobile menu

### DIFF
--- a/e2e/tests/offline/navigation.spec.mjs
+++ b/e2e/tests/offline/navigation.spec.mjs
@@ -16,6 +16,22 @@ test.describe('side nav navigation', () => {
     })
   }
 
+  test('omits About from the mobile navigation', async ({ page }) => {
+    const sideNav = page.locator('.sideNav')
+    const moreButton = sideNav.getByRole('button', { name: 'More', exact: true })
+
+    for (const viewport of [
+      { width: 375, height: 667 },
+      { width: 667, height: 375 }
+    ]) {
+      await page.setViewportSize(viewport)
+      await moreButton.click()
+      await expect(sideNav.locator('.moreOptionContainer')).toBeVisible()
+      await expect(sideNav.getByRole('link', { name: 'About', exact: true })).toHaveCount(0)
+      await moreButton.click()
+    }
+  })
+
   test('navigation history back and forward work', async ({ page }) => {
     await goTo(page, 'history')
     await goTo(page, 'userplaylists')

--- a/src/renderer/components/SideNavMoreOptions/SideNavMoreOptions.vue
+++ b/src/renderer/components/SideNavMoreOptions/SideNavMoreOptions.vue
@@ -96,26 +96,6 @@
         </p>
       </router-link>
       <router-link
-        class="navOption"
-        :title="$t('About.About')"
-        :aria-label="hideLabelsSideBar ? $t('About.About') : null"
-        to="/about"
-        @click="closeMenu"
-      >
-        <FtIcon
-          :icon="['fas', 'info-circle']"
-          class="navIcon"
-          :class="applyNavIconExpand"
-        />
-        <p
-          v-if="!hideLabelsSideBar"
-          id="aboutNavLabel"
-          class="navLabel"
-        >
-          {{ $t("About.About") }}
-        </p>
-      </router-link>
-      <router-link
         v-if="showWatchStats"
         class="navOption"
         :title="$t('Stats.Stats')"
@@ -152,25 +132,6 @@
         class="navLabel"
       >
         {{ $t("History.History") }}
-      </p>
-    </router-link>
-    <hr>
-    <router-link
-      class="navOption mobileHidden"
-      :title="$t('About.About')"
-      to="/about"
-      :aria-label="hideLabelsSideBar ? $t('About.About') : null"
-    >
-      <FtIcon
-        :icon="['fas', 'info-circle']"
-        class="navIcon"
-        :class="applyNavIconExpand"
-      />
-      <p
-        v-if="!hideLabelsSideBar"
-        class="navLabel"
-      >
-        {{ $t("About.About") }}
       </p>
     </router-link>
   </div>


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Make sure to follow the contributing guidelines. -->
<!-- Important note, we may remove your pull request if you do not use this provided PR template correctly. -->
<!-- Agent instructions: Preserve every heading, comment, and marker in this template. Never remove or rewrite the release-note-category:start/end, release-note:start/end, or release-note-image:start/end marker pairs. -->

## Pull Request Type
<!-- Please select what type of pull request this is: [x] -->
- [x] Bugfix
- [ ] Feature Implementation
- [ ] Documentation
- [ ] Other

## Related issue
<!-- Please link the issue your pull request is referring to. -->
<!-- If this pull request fully resolves the relevant issue, put "closes" before the issue number. -->
<!-- Example: "closes #123456". -->

None.

## Description
<!-- Please write a clear and concise description of what the pull request does. -->

About remained in the mobile navigation after it became available from quick settings, leaving a redundant option. This removes both legacy About links from the mobile navigation component and adds regression coverage for portrait and landscape layouts.

## Release note category
<!-- Select exactly one category. Every pull request must select one. -->
<!-- Select "Not noteworthy" when the pull request fixes a bug in or improves functionality that has not yet appeared in a stable release. -->
<!-- release-note-category:start -->
- [ ] Not noteworthy
- [ ] Highlights
- [ ] More improvements
- [x] Fixed bugs
<!-- release-note-category:end -->

## Release note
<!-- Required unless "Not noteworthy" is selected. -->
<!-- Write one concise, user-facing entry without a leading bullet. -->
<!-- release-note:start -->
Removed the redundant About option from the mobile navigation.
<!-- release-note:end -->

## Release note images
<!-- Optional. Paste one or more Markdown images, HTML image tags, or dark/light <picture> elements here. -->
<!-- The release notes normalize the markup and limit images taller than 300 pixels. -->
<!-- Agent instructions:
For a noteworthy visible change, add media when it makes the change easier to understand. Prefer a still image unless motion is the point; recordings must use animated WebP.
After implementing a visible change, proactively capture the result and show the local media to the user for approval before uploading it or updating the pull request.
When the affected UI differs between dark and light themes, capturing both themes is required. A dark-only image is incomplete. Run `node _scripts/releaseNoteMedia.mjs --dark DARK_FILE --light LIGHT_FILE --alt "DESCRIPTION"`; GitHub will display the matching theme and use dark as the fallback. Use a single default-dark capture only when the light theme cannot be captured or looks identical.
Capture or crop to the smallest region that still makes the change clear. Do not include the full window when the affected component can be understood on its own.
Use English unless localization is the subject. Keep components at their normal dimensions and placement instead of resizing them to fill the frame.
Use deterministic local fixtures for visible remote images. Reusable avatar and thumbnail fixtures are available through `e2e/helpers/visual-fixtures.mjs`. Before capturing, verify that every visible image has loaded successfully (`complete === true` and `naturalWidth > 0`).
Inspect the final dark and light files for failed images, missing content, unrelated UI, awkward animation, and misleading layout. Omit media when it does not explain the change clearly.
For one dark capture, run `node _scripts/releaseNoteMedia.mjs FILE --alt "DESCRIPTION"`.
Check for personal information, tokens, private repository names, and unrelated desktop content before uploading. Uploaded media is public.
Keep capture-only scripts, test hooks, screenshots, and recordings out of commits. Remove them before committing unless the capture code is also a reusable regression test. Never commit generated release-note media.
Paste only the generated markup between the marker comments. Leave this section empty when media would not help.
-->
<!-- release-note-image:start -->

<!-- release-note-image:end -->

## Testing
<!-- How can reviewers verify that the PR produces correct results? -->
<!-- Please provide instructions so that others can ensure that your pull request would produce correct results. For examples see, https://github.com/FreeTubeApp/FreeTube/pull/5743, https://github.com/FreeTubeApp/OpenTubeX/pull/7349, https://github.com/FreeTubeApp/OpenTubeX/pull/5125, https://github.com/FreeTubeApp/OpenTubeX/pull/7338 -->
<!-- Agent instructions: Only write human-facing steps that explain how to verify the change while running this branch in dev mode. Include expected results and, when applicable, helpful console snippets for interactive verification. Do not include automated checks, commands, results, pass counts, or CI status. -->

1. Resize the app window to 680 pixels wide or less.
2. Open the More menu in the bottom navigation.
3. Confirm that About is absent while the remaining navigation options still work.
4. Repeat in portrait and landscape window shapes.

## Additional context
<!-- Add any other context about the pull request here. -->

About remains available from quick settings and the command palette.
