### PR TITLE
fix(sidebar): keep RTL channel names clear of scrollbar

### DIFF
--- a/e2e/tests/offline/navigation.spec.mjs
+++ b/e2e/tests/offline/navigation.spec.mjs
@@ -57,6 +57,62 @@ test.describe('side nav navigation', () => {
   })
 })
 
+test.describe('side nav channel names', () => {
+  test.use({
+    seed: {
+      settings: {
+        alwaysShowScrollbars: true,
+        currentLocale: 'en-US',
+        expandSideBar: true,
+        uiScale: 125
+      },
+      profiles: [{
+        _id: 'allChannels',
+        name: 'All Channels',
+        bgColor: '#000000',
+        textColor: '#FFFFFF',
+        subscriptions: [
+          {
+            id: 'UCarabicchannelname00000',
+            name: 'قناة عربية',
+            thumbnail: ''
+          },
+          ...Array.from({ length: 24 }, (_, index) => ({
+            id: `UC${index.toString().padStart(22, '0')}`,
+            name: `Channel ${index.toString().padStart(2, '0')}`,
+            thumbnail: ''
+          }))
+        ]
+      }]
+    }
+  })
+
+  test('keeps RTL channel names clear of the scrollbar in an LTR app', async ({ page }) => {
+    await goTo(page, 'subscribedchannels')
+
+    const sideNav = page.locator('.sideNav.expanded')
+    const arabicChannel = sideNav.locator('.navChannel', { hasText: 'قناة عربية' })
+    await expect(arabicChannel).toBeVisible()
+
+    const metrics = await arabicChannel.evaluate((channel) => {
+      const label = channel.querySelector('.navLabel')
+      const scrollbar = channel.closest('.inner').querySelector('.os-scrollbar-vertical')
+      const labelBounds = label.getBoundingClientRect()
+      const scrollbarBounds = scrollbar.getBoundingClientRect()
+
+      return {
+        appDirection: getComputedStyle(channel).direction,
+        labelDirection: getComputedStyle(label).direction,
+        scrollbarClearance: scrollbarBounds.left - labelBounds.right
+      }
+    })
+
+    expect(metrics.appDirection).toBe('ltr')
+    expect(metrics.labelDirection).toBe('rtl')
+    expect(metrics.scrollbarClearance).toBeGreaterThanOrEqual(4)
+  })
+})
+
 for (const uiScale of [90, 100, 125]) {
   test.describe(`side nav without labels at ${uiScale}% UI scale`, () => {
     test.use({

--- a/src/renderer/components/SideNav/SideNav.css
+++ b/src/renderer/components/SideNav/SideNav.css
@@ -241,6 +241,10 @@
     align-items: center;
   }
 
+  .expanded .navChannel {
+    padding-inline-end: calc(var(--scrollbar-track-width) + 5px);
+  }
+
   .expanded .navChannel .navLabel {
     font-size: 12px;
     flex-grow: 1;


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Make sure to follow the contributing guidelines. -->
<!-- Important note, we may remove your pull request if you do not use this provided PR template correctly. -->
<!-- Agent instructions: Preserve every heading, comment, and marker in this template. Never remove or rewrite the release-note-category:start/end, release-note:start/end, or release-note-image:start/end marker pairs. -->

## Pull Request Type
<!-- Please select what type of pull request this is: [x] -->
- [x] Bugfix
- [ ] Feature Implementation
- [ ] Documentation
- [ ] Other

## Related issue
<!-- Please link the issue your pull request is referring to. -->
<!-- If this pull request fully resolves the relevant issue, put "closes" before the issue number. -->
<!-- Example: "closes #123456". -->

Closes #1024.

## Description
<!-- Please write a clear and concise description of what the pull request does. -->

Arabic and other RTL channel names can align against the expanded sidebar's right edge in an otherwise LTR interface, leaving them underneath the overlay scrollbar. This reserves the configured scrollbar track width plus the sidebar's existing 5px spacing at the end of each channel row.

A regression test recreates the LTR interface with an Arabic channel name, an always-visible scrollbar, enough channels to overflow, and 125% UI scale.

## Release note category
<!-- Select exactly one category. Every pull request must select one. -->
<!-- Select "Not noteworthy" when the pull request fixes a bug in or improves functionality that has not yet appeared in a stable release. -->
<!-- release-note-category:start -->
- [ ] Not noteworthy
- [ ] Highlights
- [ ] More improvements
- [x] Fixed bugs
<!-- release-note-category:end -->

## Release note
<!-- Required unless "Not noteworthy" is selected. -->
<!-- Write one concise, user-facing entry without a leading bullet. -->
<!-- release-note:start -->

Added space between RTL channel names and the sidebar scrollbar.

<!-- release-note:end -->

## Release note images
<!-- Optional. Paste one or more Markdown images, HTML image tags, or dark/light <picture> elements here. -->
<!-- The release notes normalize the markup and limit images taller than 300 pixels. -->
<!-- Agent instructions:
For a noteworthy visible change, add media when it makes the change easier to understand. Prefer a still image unless motion is the point; recordings must use animated WebP.
After implementing a visible change, proactively capture the result and show the local media to the user for approval before uploading it or updating the pull request.
When the affected UI differs between dark and light themes, capturing both themes is required. A dark-only image is incomplete. Run `node _scripts/releaseNoteMedia.mjs --dark DARK_FILE --light LIGHT_FILE --alt "DESCRIPTION"`; GitHub will display the matching theme and use dark as the fallback. Use a single default-dark capture only when the light theme cannot be captured or looks identical.
Capture or crop to the smallest region that still makes the change clear. Do not include the full window when the affected component can be understood on its own.
Use English unless localization is the subject. Keep components at their normal dimensions and placement instead of resizing them to fill the frame.
Use deterministic local fixtures for visible remote images. Reusable avatar and thumbnail fixtures are available through `e2e/helpers/visual-fixtures.mjs`. Before capturing, verify that every visible image has loaded successfully (`complete === true` and `naturalWidth > 0`).
Inspect the final dark and light files for failed images, missing content, unrelated UI, awkward animation, and misleading layout. Omit media when it does not explain the change clearly.
For one dark capture, run `node _scripts/releaseNoteMedia.mjs FILE --alt "DESCRIPTION"`.
Check for personal information, tokens, private repository names, and unrelated desktop content before uploading. Uploaded media is public.
Keep capture-only scripts, test hooks, screenshots, and recordings out of commits. Remove them before committing unless the capture code is also a reusable regression test. Never commit generated release-note media.
Paste only the generated markup between the marker comments. Leave this section empty when media would not help.
-->
<!-- release-note-image:start -->

<!-- release-note-image:end -->

## Testing
<!-- How can reviewers verify that the PR produces correct results? -->
<!-- Please provide instructions so that others can ensure that your pull request would produce correct results. For examples see, https://github.com/FreeTubeApp/FreeTube/pull/5743, https://github.com/FreeTubeApp/FreeTube/pull/7349, https://github.com/FreeTubeApp/FreeTube/pull/5125, https://github.com/FreeTubeApp/FreeTube/pull/7338 -->
<!-- Agent instructions: Only write human-facing steps that explain how to verify the change while running this branch in dev mode. Include expected results and, when applicable, helpful console snippets for interactive verification. Do not include automated checks, commands, results, pass counts, or CI status. -->

1. Keep the app language set to English and expand the sidebar.
2. Enable always-visible scrollbars and subscribe to enough channels for the sidebar to scroll, including a channel with an Arabic name.
3. Scroll to the Arabic channel and confirm its name has a visible gap before the right-side scrollbar.
4. Repeat at a non-100% UI scale and confirm the gap remains.

## Additional context
<!-- Add any other context about the pull request here. -->
