### PR TITLE
feat(settings): customize date and time formats

### DIFF
--- a/e2e/tests/offline/settings.spec.mjs
+++ b/e2e/tests/offline/settings.spec.mjs
@@ -4865,11 +4865,19 @@ test.describe('synced setting indicators', () => {
     const neighboringIndicators = page.locator('.select')
       .filter({ hasText: 'Prefer untranslated video text' })
       .locator('.selectIndicators')
-    const [tooltipBox, indicatorsBox] = await Promise.all([
-      tooltipText.boundingBox(),
-      neighboringIndicators.boundingBox()
-    ])
+    const tooltipBox = await tooltipText.boundingBox()
     expect(tooltipBox).not.toBeNull()
+    await neighboringIndicators.evaluate((element, { x, y }) => {
+      element.style.position = 'fixed'
+      element.style.inset = 'auto'
+      element.style.left = `${x}px`
+      element.style.top = `${y}px`
+      element.style.transform = 'none'
+    }, {
+      x: tooltipBox.x + 10,
+      y: tooltipBox.y + 10
+    })
+    const indicatorsBox = await neighboringIndicators.boundingBox()
     expect(indicatorsBox).not.toBeNull()
 
     const overlapLeft = Math.max(tooltipBox.x, indicatorsBox.x)

--- a/e2e/tests/offline/settings.spec.mjs
+++ b/e2e/tests/offline/settings.spec.mjs
@@ -236,6 +236,27 @@ test.describe('AI translation completions', () => {
   })
 })
 
+test.describe('date and time format preferences', () => {
+  test.use({ seed: { settings: { currentLocale: 'en-US' } } })
+
+  test('defaults to the app language and offers explicit date and clock formats', async ({ page }) => {
+    const general = await goToSettingsSection(page, 'general')
+    const dateFormat = general.getByRole('combobox', { name: 'Date Format' })
+
+    await expect(dateFormat).toContainText(/^Language default \(/)
+    await dateFormat.click()
+    await expect(page.getByRole('option', { name: 'DD.MM.YYYY', exact: true })).toBeVisible()
+    await page.getByRole('option', { name: 'DD.MM.YYYY', exact: true }).click()
+    await expect(dateFormat).toHaveText('DD.MM.YYYY')
+
+    const timeFormat = general.getByRole('combobox', { name: 'Time Format' })
+    await expect(timeFormat).toContainText(/^Language default \(/)
+    await timeFormat.click()
+    await page.getByRole('option', { name: /^24h \(/ }).click()
+    await expect(timeFormat).toContainText(/^24h \(/)
+  })
+})
+
 test.describe('settings search highlights', () => {
   test.use({ seed: { settings: { currentLocale: 'en-US' } } })
 

--- a/e2e/tests/offline/subscriptions-feed.spec.mjs
+++ b/e2e/tests/offline/subscriptions-feed.spec.mjs
@@ -328,6 +328,45 @@ test.describe('subscriptions feed with upcoming premieres shown', () => {
     await expect(page.getByRole('option', { name: 'Add to Queue' })).toBeVisible()
   })
 
+  test.describe('with date and time formats independent of the app language', () => {
+    test.use({
+      seed: {
+        ...seed,
+        settings: {
+          ...seed.settings,
+          currentLocale: 'en-US',
+          dateFormat: 'DD.MM.YYYY',
+          timeFormat: '24-hour',
+          hideUpcomingPremieres: false,
+        },
+      },
+    })
+
+    test('formats an upcoming premiere with the selected date and clock formats', async ({ page }) => {
+      await goTo(page, 'subscriptions')
+
+      const premiereDate = new Date(now + 30 * 24 * HOUR)
+      const numericParts = Object.fromEntries(
+        new Intl.DateTimeFormat('en-US', {
+          year: 'numeric',
+          month: '2-digit',
+          day: '2-digit',
+        }).formatToParts(premiereDate).map(part => [part.type, part.value])
+      )
+      const time = new Intl.DateTimeFormat('en-US', {
+        hour: 'numeric',
+        minute: '2-digit',
+        second: '2-digit',
+        hourCycle: 'h23',
+      }).format(premiereDate)
+      const upcomingPremiere = page.locator('.ft-list-video').filter({ hasText: 'Upcoming premiere video' })
+
+      await expect(upcomingPremiere.locator('.uploadedTime')).toHaveText(
+        `${numericParts.day}.${numericParts.month}.${numericParts.year}, ${time}`
+      )
+    })
+  })
+
   test('uses the main text color for an upcoming premiere title', async ({ page }) => {
     await goTo(page, 'subscriptions')
 

--- a/src/renderer/components/ChannelAbout/ChannelAbout.vue
+++ b/src/renderer/components/ChannelAbout/ChannelAbout.vue
@@ -128,8 +128,10 @@ import store from '../../store/index'
 import { useTabContext } from '../../tabs/TabContext'
 
 import { formatNumber } from '../../helpers/utils'
+import { formatDate } from '../../helpers/dateFormat'
 
 const { locale } = useI18n()
+const dateFormat = computed(() => store.getters.getDateFormat)
 const { tabId: injectedTabId } = useTabContext()
 const tabId = injectedTabId ?? 'web'
 
@@ -180,7 +182,7 @@ const searchSettings = computed(() => {
 })
 
 const formattedJoined = computed(() => {
-  return new Intl.DateTimeFormat([locale.value, 'en'], { dateStyle: 'long' }).format(props.joined)
+  return formatDate(props.joined, locale.value, dateFormat.value, { dateStyle: 'long' })
 })
 
 const formattedViews = computed(() => formatNumber(props.views))

--- a/src/renderer/components/FtListVideo/FtListVideo.vue
+++ b/src/renderer/components/FtListVideo/FtListVideo.vue
@@ -427,6 +427,7 @@ import {
 import { setCollaboratorsLoading } from './collaboratorsLoading.js'
 import { useRelativeTimeClock } from '../../composables/useRelativeTimeClock.js'
 import { useResultChannelAvatar } from '../../composables/useResultChannelAvatar.js'
+import { formatDate, formatDateTime } from '../../helpers/dateFormat.js'
 import thumbnailPlaceholder from '../../assets/img/thumbnail_placeholder.svg'
 
 const props = defineProps({
@@ -523,6 +524,8 @@ const emit = defineEmits([
 
 const { locale, t } = useI18n()
 const route = useRoute()
+const dateFormat = computed(() => store.getters.getDateFormat)
+const timeFormat = computed(() => store.getters.getTimeFormat)
 
 const id = ref('')
 const title = ref('')
@@ -1752,12 +1755,59 @@ function handleExtraThumbnailAction() {
   handleOptionsClick(extraThumbnailAction.value)
 }
 
-function parseVideoData() {
-  relativeTimeDataLoadedAt.value = Date.now()
-  relativeTimeClockAtLoad.value = relativeTimeNow.value
+function updateUploadedTime() {
   uploadedTime.value = ''
   uploadedTimeIsRelative.value = false
   published.value = undefined
+
+  if (props.data.premiereDate !== undefined) {
+    let premiereDate = props.data.premiereDate
+
+    // premiereDate will be a string when the subscriptions are restored from the cache
+    if (typeof premiereDate === 'string') {
+      premiereDate = new Date(premiereDate)
+    }
+    uploadedTime.value = formatDateTime(
+      premiereDate,
+      locale.value,
+      dateFormat.value,
+      { year: 'numeric', month: 'numeric', day: 'numeric' },
+      { hour: 'numeric', minute: '2-digit', second: '2-digit' },
+      timeFormat.value
+    )
+    published.value = premiereDate.getTime()
+  } else if (props.data.premiereTimestamp > 0) {
+    const premiereDate = new Date(props.data.premiereTimestamp * 1000)
+    uploadedTime.value = formatDateTime(
+      premiereDate,
+      locale.value,
+      dateFormat.value,
+      { year: 'numeric', month: 'numeric', day: 'numeric' },
+      { hour: 'numeric', minute: '2-digit', second: '2-digit' },
+      timeFormat.value
+    )
+    published.value = props.data.premiereTimestamp * 1000
+  } else if (typeof props.data.published === 'number' && !isLive.value) {
+    published.value = props.data.published
+
+    if (inHistory.value) {
+      uploadedTime.value = formatDate(
+        props.data.published,
+        locale.value,
+        dateFormat.value,
+        { year: 'numeric', month: 'numeric', day: 'numeric' }
+      )
+    } else {
+      // Use 30 days per month, just like calculatePublishedDate
+      uploadedTime.value = getRelativeTimeFromDate(props.data.published, false)
+      uploadedTimeIsRelative.value = true
+    }
+  }
+}
+
+function parseVideoData() {
+  relativeTimeDataLoadedAt.value = Date.now()
+  relativeTimeClockAtLoad.value = relativeTimeNow.value
   id.value = props.data.videoId
   title.value = props.data.title
 
@@ -1801,30 +1851,7 @@ function parseVideoData() {
   isMembersOnly.value = props.data.isMembersOnly === true
   isPremium.value = props.data.premium || false
   viewCount.value = props.data.viewCount
-
-  if (props.data.premiereDate !== undefined) {
-    let premiereDate = props.data.premiereDate
-
-    // premiereDate will be a string when the subscriptions are restored from the cache
-    if (typeof premiereDate === 'string') {
-      premiereDate = new Date(premiereDate)
-    }
-    uploadedTime.value = premiereDate.toLocaleString([locale.value, 'en'])
-    published.value = premiereDate.getTime()
-  } else if (props.data.premiereTimestamp > 0) {
-    uploadedTime.value = new Date(props.data.premiereTimestamp * 1000).toLocaleString([locale.value, 'en'])
-    published.value = props.data.premiereTimestamp * 1000
-  } else if (typeof props.data.published === 'number' && !isLive.value) {
-    published.value = props.data.published
-
-    if (inHistory.value) {
-      uploadedTime.value = new Date(props.data.published).toLocaleDateString([locale.value, 'en'])
-    } else {
-      // Use 30 days per month, just like calculatePublishedDate
-      uploadedTime.value = getRelativeTimeFromDate(props.data.published, false)
-      uploadedTimeIsRelative.value = true
-    }
-  }
+  updateUploadedTime()
 
   hideViews.value = hideVideoViews.value ||
     (props.data.viewCount == null && props.data.viewCountText === undefined)
@@ -2023,6 +2050,7 @@ function onDragStart(event) {
 }
 
 watch(() => props.data, parseVideoData, { immediate: true })
+watch([locale, dateFormat, timeFormat], updateUploadedTime)
 
 showDeArrowTitle.value = useDeArrowTitles.value
 showDeArrowThumbnail.value = useDeArrowThumbnails.value

--- a/src/renderer/components/GeneralSettings/GeneralSettings.vue
+++ b/src/renderer/components/GeneralSettings/GeneralSettings.vue
@@ -206,6 +206,26 @@
       />
       <FtSelect
         v-if="mode === 'general'"
+        :placeholder="t('Settings.General Settings.Date Format')"
+        :value="dateFormat"
+        setting-key="dateFormat"
+        :select-names="dateFormatNames"
+        :select-values="DATE_FORMAT_OPTIONS"
+        :icon="['fas', 'calendar-days']"
+        @change="updateDateFormat"
+      />
+      <FtSelect
+        v-if="mode === 'general'"
+        :placeholder="t('Settings.General Settings.Time Format')"
+        :value="timeFormat"
+        setting-key="timeFormat"
+        :select-names="timeFormatNames"
+        :select-values="TIME_FORMAT_OPTIONS"
+        :icon="['fas', 'clock']"
+        @change="updateTimeFormat"
+      />
+      <FtSelect
+        v-if="mode === 'general'"
         :placeholder="t('Settings.General Settings.Reduced Motion.Reduced Motion')"
         :value="reducedMotion"
         setting-key="reducedMotion"
@@ -321,6 +341,14 @@ import allLocales from '../../../../static/locales/activeLocales.json'
 import { debounce, randomArrayItem, showToast } from '../../helpers/utils'
 import { translateWindowTitle } from '../../helpers/strings'
 import { initializePlatformInfo, isLinuxWayland } from '../../helpers/platform'
+import {
+  DATE_FORMAT_OPTIONS,
+  TIME_FORMAT_OPTIONS,
+  formatDate,
+  formatTime,
+  normalizeDateFormat,
+  normalizeTimeFormat,
+} from '../../helpers/dateFormat'
 
 const USING_ELECTRON = !!process.env.IS_ELECTRON
 const SUPPORTS_LOCAL_API = !!process.env.SUPPORTS_LOCAL_API
@@ -760,6 +788,38 @@ const aiTranslationCompletionsDisabled = computed(() => {
  */
 function updateCurrentLocale(value) {
   store.dispatch('updateCurrentLocale', value)
+}
+
+/** @type {import('vue').ComputedRef<string>} */
+const dateFormat = computed(() => normalizeDateFormat(store.getters.getDateFormat))
+
+const dateFormatNames = computed(() => [
+  `${t('Settings.General Settings.Language Default')} (${formatDate(new Date(), locale.value, 'locale')})`,
+  ...DATE_FORMAT_OPTIONS.slice(1),
+])
+
+/** @param {string} value */
+function updateDateFormat(value) {
+  store.dispatch('updateDateFormat', value)
+}
+
+/** @type {import('vue').ComputedRef<string>} */
+const timeFormat = computed(() => normalizeTimeFormat(store.getters.getTimeFormat))
+
+const timeFormatNames = computed(() => {
+  const example = new Date()
+  const options = { hour: 'numeric', minute: '2-digit' }
+
+  return [
+    `${t('Settings.General Settings.Language Default')} (${formatTime(example, locale.value, 'locale', options)})`,
+    `12h (${formatTime(example, locale.value, '12-hour', options)})`,
+    `24h (${formatTime(example, locale.value, '24-hour', options)})`,
+  ]
+})
+
+/** @param {string} value */
+function updateTimeFormat(value) {
+  store.dispatch('updateTimeFormat', value)
 }
 
 /** @param {boolean} value */

--- a/src/renderer/components/SubscriptionPosts/SubscriptionsPosts.vue
+++ b/src/renderer/components/SubscriptionPosts/SubscriptionsPosts.vue
@@ -34,7 +34,8 @@ import store from '../../store/index'
 import { useKeepAliveEffectScope } from '../../composables/useKeepAliveEffectScope'
 import { useRelativeTimeClock } from '../../composables/useRelativeTimeClock'
 import { useSubscriptionChannelUpdates } from '../../composables/useSubscriptionChannelUpdates'
-import { getCachedRelativeTimeFormat, getCachedShortDateTimeFormat, getRelativeTimeFromDate } from '../../helpers/utils'
+import { getCachedRelativeTimeFormat, getRelativeTimeFromDate } from '../../helpers/utils'
+import { formatShortDateTime } from '../../helpers/dateFormat'
 import { refreshSubscriptionPostsFromRemote } from '../../helpers/subscriptions'
 
 const { locale, t } = useI18n()
@@ -47,6 +48,8 @@ const errorChannels = ref([])
 const attemptedFetch = ref(false)
 /** @type {import('vue').Ref<number | null>} */
 const lastRemoteRefreshSuccessTimestamp = ref(null)
+const dateFormat = computed(() => store.getters.getDateFormat)
+const timeFormat = computed(() => store.getters.getTimeFormat)
 
 const now = useRelativeTimeClock()
 
@@ -128,7 +131,7 @@ const nextAutoRefreshTimestamp = computed(() => {
     return ''
   }
 
-  return getCachedShortDateTimeFormat(locale.value).format(timestamp)
+  return formatShortDateTime(timestamp, locale.value, dateFormat.value, timeFormat.value)
 })
 
 const nextAutoRefreshTooltip = computed(() => {

--- a/src/renderer/components/SubscriptionsLive.vue
+++ b/src/renderer/components/SubscriptionsLive.vue
@@ -21,7 +21,8 @@ import store from '../store/index'
 import { useKeepAliveEffectScope } from '../composables/useKeepAliveEffectScope'
 import { useRelativeTimeClock } from '../composables/useRelativeTimeClock'
 import { useSubscriptionChannelUpdates } from '../composables/useSubscriptionChannelUpdates'
-import { getCachedRelativeTimeFormat, getCachedShortDateTimeFormat, getRelativeTimeFromDate } from '../helpers/utils'
+import { getCachedRelativeTimeFormat, getRelativeTimeFromDate } from '../helpers/utils'
+import { formatShortDateTime } from '../helpers/dateFormat'
 import {
   refreshSubscriptionLiveFromRemote,
   updateVideoListAfterProcessing
@@ -37,6 +38,8 @@ const errorChannels = ref([])
 const attemptedFetch = ref(false)
 /** @type {import('vue').Ref<number | null>} */
 const lastRemoteRefreshSuccessTimestamp = ref(null)
+const dateFormat = computed(() => store.getters.getDateFormat)
+const timeFormat = computed(() => store.getters.getTimeFormat)
 
 let alreadyLoadedRemotely = false
 
@@ -115,7 +118,7 @@ const nextAutoRefreshTimestamp = computed(() => {
     return ''
   }
 
-  return getCachedShortDateTimeFormat(locale.value).format(timestamp)
+  return formatShortDateTime(timestamp, locale.value, dateFormat.value, timeFormat.value)
 })
 
 const nextAutoRefreshTooltip = computed(() => {

--- a/src/renderer/components/SubscriptionsShorts.vue
+++ b/src/renderer/components/SubscriptionsShorts.vue
@@ -26,7 +26,8 @@ import {
   refreshSubscriptionShortsFromRemote,
   updateVideoListAfterProcessing
 } from '../helpers/subscriptions'
-import { getCachedRelativeTimeFormat, getCachedShortDateTimeFormat, getRelativeTimeFromDate } from '../helpers/utils'
+import { getCachedRelativeTimeFormat, getRelativeTimeFromDate } from '../helpers/utils'
+import { formatShortDateTime } from '../helpers/dateFormat'
 
 const { locale, t } = useI18n()
 const tabUi = useTemplateRef('tabUi')
@@ -40,6 +41,8 @@ const attemptedFetch = ref(false)
 const useCustomShortsPlayer = computed(() => store.getters.getUseCustomShortsPlayer)
 /** @type {import('vue').Ref<number | null>} */
 const lastRemoteRefreshSuccessTimestamp = ref(null)
+const dateFormat = computed(() => store.getters.getDateFormat)
+const timeFormat = computed(() => store.getters.getTimeFormat)
 
 let alreadyLoadedRemotely = false
 
@@ -117,7 +120,7 @@ const nextAutoRefreshTimestamp = computed(() => {
     return ''
   }
 
-  return getCachedShortDateTimeFormat(locale.value).format(timestamp)
+  return formatShortDateTime(timestamp, locale.value, dateFormat.value, timeFormat.value)
 })
 
 const nextAutoRefreshTooltip = computed(() => {

--- a/src/renderer/components/SubscriptionsVideos.vue
+++ b/src/renderer/components/SubscriptionsVideos.vue
@@ -36,7 +36,8 @@ import {
   ensureUpcomingSubscriptionFeedPublished,
   getUpcomingPremiereTimestamp
 } from '../helpers/subscription-entries'
-import { getCachedRelativeTimeFormat, getCachedShortDateTimeFormat, getRelativeTimeFromDate } from '../helpers/utils'
+import { getCachedRelativeTimeFormat, getRelativeTimeFromDate } from '../helpers/utils'
+import { formatShortDateTime } from '../helpers/dateFormat'
 import {
   refreshSubscriptionVideosFromRemote,
   updateVideoListAfterProcessing
@@ -52,6 +53,8 @@ const errorChannels = ref([])
 const attemptedFetch = ref(false)
 /** @type {import('vue').Ref<number | null>} */
 const lastRemoteRefreshSuccessTimestamp = ref(null)
+const dateFormat = computed(() => store.getters.getDateFormat)
+const timeFormat = computed(() => store.getters.getTimeFormat)
 const now = useRelativeTimeClock()
 const premiereUpdateNow = ref(Date.now())
 const MAX_TIMEOUT_MS = 2 ** 31 - 1
@@ -193,7 +196,7 @@ const nextVideoAutoRefreshTimestamp = computed(() => {
     return ''
   }
 
-  return getCachedShortDateTimeFormat(locale.value).format(timestamp)
+  return formatShortDateTime(timestamp, locale.value, dateFormat.value, timeFormat.value)
 })
 
 const nextVideoAutoRefreshTooltip = computed(() => {

--- a/src/renderer/components/SyncSettings/SyncPairing.vue
+++ b/src/renderer/components/SyncSettings/SyncPairing.vue
@@ -309,6 +309,7 @@ import {
   decryptSyncDocument,
 } from '../../helpers/sync-server-privacy'
 import { SyncServerClient, normalizeSyncServerUrl } from '../../helpers/sync-server'
+import { formatTime } from '../../helpers/dateFormat'
 import store from '../../store/index'
 
 const props = defineProps({
@@ -335,6 +336,7 @@ const props = defineProps({
 
 const emit = defineEmits(['paired'])
 const { locale, t } = useI18n()
+const timeFormat = computed(() => store.getters.getTimeFormat)
 
 const receivePromptOpen = ref(false)
 const receiveStage = ref('name')
@@ -355,9 +357,12 @@ const approvalVerificationCode = ref('')
 const scannerVideo = useTemplateRef('scannerVideo')
 const manualPairingCodeInput = useTemplateRef('manualPairingCodeInput')
 
-const receiveExpiryLabel = computed(() => new Intl.DateTimeFormat(locale.value, {
-  timeStyle: 'medium',
-}).format(receiveExpiresAt.value))
+const receiveExpiryLabel = computed(() => formatTime(
+  receiveExpiresAt.value,
+  locale.value,
+  timeFormat.value,
+  { timeStyle: 'medium' }
+))
 
 let receiver = null
 let pollTimer = null

--- a/src/renderer/components/SyncSettings/SyncSettings.vue
+++ b/src/renderer/components/SyncSettings/SyncSettings.vue
@@ -354,8 +354,11 @@ import {
   normalizeSyncServerUrl,
 } from '../../helpers/sync-server'
 import { showToast } from '../../helpers/utils'
+import { formatDateTime } from '../../helpers/dateFormat'
 
 const { locale, t } = useI18n()
+const dateFormat = computed(() => store.getters.getDateFormat)
+const timeFormat = computed(() => store.getters.getTimeFormat)
 
 const OPENTUBEX_SYNC_SERVER_URL = 'https://sync.d3sox.me'
 const OPENTUBEX_SYNC_SERVER_PRIVACY_POLICY_URL =
@@ -454,10 +457,14 @@ const sessionsSupported = computed(() => (
 const lastSyncLabel = computed(() => {
   const timestamp = store.getters.getSyncServerLastSyncAt
   if (!timestamp) return ''
-  return new Intl.DateTimeFormat(locale.value, {
-    dateStyle: 'medium',
-    timeStyle: 'medium',
-  }).format(timestamp)
+  return formatDateTime(
+    timestamp,
+    locale.value,
+    dateFormat.value,
+    { dateStyle: 'medium' },
+    { timeStyle: 'medium' },
+    timeFormat.value
+  )
 })
 
 let serverCheckTimer = null

--- a/src/renderer/components/WatchVideoInfo/WatchVideoInfo.vue
+++ b/src/renderer/components/WatchVideoInfo/WatchVideoInfo.vue
@@ -338,8 +338,10 @@ import { parseChannelPreferences } from '../../helpers/channel-preferences'
 import { useTabContext } from '../../tabs/TabContext'
 import { tabMediaCoordinator } from '../../tabs/TabMediaCoordinator'
 import { useRelativeTimeClock } from '../../composables/useRelativeTimeClock'
+import { formatDate } from '../../helpers/dateFormat'
 
 const { tabId } = useTabContext()
+const dateFormat = computed(() => store.getters.getDateFormat)
 
 const props = defineProps({
   id: {
@@ -695,8 +697,12 @@ const validPublishedDate = computed(() => {
 const dateString = computed(() => {
   if (!validPublishedDate.value) return ''
 
-  const formatter = new Intl.DateTimeFormat([locale.value, 'en'], { dateStyle: 'medium' })
-  const localeDateString = formatter.format(validPublishedDate.value)
+  const localeDateString = formatDate(
+    validPublishedDate.value,
+    locale.value,
+    dateFormat.value,
+    { dateStyle: 'medium' }
+  )
   // replace spaces with no break spaces to make the date act as a single entity while wrapping
   return localeDateString.replaceAll(' ', '\u00A0')
 })

--- a/src/renderer/components/WatchVideoLiveChat/WatchVideoLiveChat.vue
+++ b/src/renderer/components/WatchVideoLiveChat/WatchVideoLiveChat.vue
@@ -430,6 +430,7 @@ import { vSaferHtml } from '../../directives/vSaferHtml.js'
 import store from '../../store/index'
 
 import { formatNumber } from '../../helpers/utils'
+import { formatTime } from '../../helpers/dateFormat'
 import { getRandomColorClass } from '../../helpers/colors'
 import { getLocalVideoInfo, parseLocalTextRuns } from '../../helpers/api/local'
 import { clampOverlayScrollTop, restoreOverlayScrollTop } from '../../helpers/overlayScrollbars'
@@ -467,6 +468,7 @@ const props = defineProps({
 const emit = defineEmits(['close'])
 
 const { locale, t } = useI18n()
+const timeFormat = computed(() => store.getters.getTimeFormat)
 
 /** @type {import('youtubei.js').YT.LiveChat|null} */
 let liveChatInstance = null
@@ -1169,7 +1171,7 @@ function formatLiveChatTimestamp(comment) {
   }
 
   if (Number.isFinite(comment.timestamp)) {
-    return new Intl.DateTimeFormat([locale.value, 'en'], { timeStyle: 'short' }).format(comment.timestamp)
+    return formatTime(comment.timestamp, locale.value, timeFormat.value, { timeStyle: 'short' })
   }
 
   return ''

--- a/src/renderer/components/WatchVideoMetadataHistory/WatchVideoMetadataHistory.vue
+++ b/src/renderer/components/WatchVideoMetadataHistory/WatchVideoMetadataHistory.vue
@@ -103,6 +103,8 @@ import { computed, nextTick, onBeforeUnmount, onMounted, useTemplateRef } from '
 import { useI18n } from 'vue-i18n'
 
 import { clampOverlayScrollTop } from '../../helpers/overlayScrollbars'
+import { formatDateTime } from '../../helpers/dateFormat'
+import store from '../../store'
 import FtButton from '../FtButton/FtButton.vue'
 import FtFlexBox from '../ft-flex-box/ft-flex-box.vue'
 import FtPrompt from '../FtPrompt/FtPrompt.vue'
@@ -117,6 +119,8 @@ const props = defineProps({
 const emit = defineEmits(['close'])
 const { locale, t } = useI18n()
 const descriptionScrollers = useTemplateRef('descriptionScrollers')
+const dateFormat = computed(() => store.getters.getDateFormat)
+const timeFormat = computed(() => store.getters.getTimeFormat)
 
 let descriptionResizeObserver = null
 
@@ -144,11 +148,6 @@ onMounted(() => {
 })
 
 onBeforeUnmount(() => descriptionResizeObserver?.disconnect())
-
-const dateFormatter = computed(() => new Intl.DateTimeFormat(locale.value, {
-  dateStyle: 'medium',
-  timeStyle: 'short'
-}))
 
 const materializedRevisions = computed(() => {
   let thumbnail = null
@@ -188,7 +187,14 @@ function versionLabel(index) {
 }
 
 function formatDate(cachedAt) {
-  return dateFormatter.value.format(cachedAt)
+  return formatDateTime(
+    cachedAt,
+    locale.value,
+    dateFormat.value,
+    { dateStyle: 'medium' },
+    { timeStyle: 'short' },
+    timeFormat.value
+  )
 }
 
 function dateTime(cachedAt) {

--- a/src/renderer/helpers/dateFormat.js
+++ b/src/renderer/helpers/dateFormat.js
@@ -1,0 +1,172 @@
+export const DEFAULT_DATE_FORMAT = 'locale'
+export const DEFAULT_TIME_FORMAT = 'locale'
+
+export const DATE_FORMAT_OPTIONS = Object.freeze([
+  DEFAULT_DATE_FORMAT,
+  'MM/DD/YYYY',
+  'DD/MM/YYYY',
+  'YYYY-MM-DD',
+  'YYYY/MM/DD',
+  'DD.MM.YYYY',
+  'MM.DD.YYYY',
+])
+
+export const TIME_FORMAT_OPTIONS = Object.freeze([
+  DEFAULT_TIME_FORMAT,
+  '12-hour',
+  '24-hour',
+])
+
+const CUSTOM_DATE_FORMATS = Object.freeze({
+  'MM/DD/YYYY': { order: ['month', 'day', 'year'], separator: '/' },
+  'DD/MM/YYYY': { order: ['day', 'month', 'year'], separator: '/' },
+  'YYYY-MM-DD': { order: ['year', 'month', 'day'], separator: '-' },
+  'YYYY/MM/DD': { order: ['year', 'month', 'day'], separator: '/' },
+  'DD.MM.YYYY': { order: ['day', 'month', 'year'], separator: '.' },
+  'MM.DD.YYYY': { order: ['month', 'day', 'year'], separator: '.' },
+})
+
+const formatterCache = new Map()
+
+/**
+ * @param {string} dateFormat
+ * @returns {string}
+ */
+export function normalizeDateFormat(dateFormat) {
+  return DATE_FORMAT_OPTIONS.includes(dateFormat) ? dateFormat : DEFAULT_DATE_FORMAT
+}
+
+/**
+ * @param {string} timeFormat
+ * @returns {string}
+ */
+export function normalizeTimeFormat(timeFormat) {
+  return TIME_FORMAT_OPTIONS.includes(timeFormat) ? timeFormat : DEFAULT_TIME_FORMAT
+}
+
+/**
+ * @param {string} timeFormat
+ * @param {Intl.DateTimeFormatOptions} options
+ * @returns {Intl.DateTimeFormatOptions}
+ */
+function resolveTimeOptions(timeFormat, options) {
+  const normalizedFormat = normalizeTimeFormat(timeFormat)
+  const resolvedOptions = { ...options }
+
+  if (normalizedFormat !== DEFAULT_TIME_FORMAT) {
+    delete resolvedOptions.hour12
+    resolvedOptions.hourCycle = normalizedFormat === '12-hour' ? 'h12' : 'h23'
+  }
+
+  return resolvedOptions
+}
+
+/**
+ * @param {string} locale
+ * @param {Intl.DateTimeFormatOptions} options
+ * @returns {Intl.DateTimeFormat}
+ */
+function getFormatter(locale, options) {
+  const key = `${locale}|${JSON.stringify(options)}`
+  let formatter = formatterCache.get(key)
+
+  if (!formatter) {
+    formatter = new Intl.DateTimeFormat([locale, 'en'], options)
+    formatterCache.set(key, formatter)
+  }
+
+  return formatter
+}
+
+/**
+ * @param {Date | number} date
+ * @param {string} locale
+ * @param {string} dateFormat
+ * @param {Intl.DateTimeFormatOptions} options
+ * @returns {string}
+ */
+export function formatDate(date, locale, dateFormat = DEFAULT_DATE_FORMAT, options = {}) {
+  const normalizedFormat = normalizeDateFormat(dateFormat)
+  if (normalizedFormat === DEFAULT_DATE_FORMAT) {
+    return getFormatter(locale, options).format(date)
+  }
+
+  const numericOptions = {
+    year: 'numeric',
+    month: '2-digit',
+    day: '2-digit',
+  }
+  for (const key of ['calendar', 'numberingSystem', 'timeZone']) {
+    if (options[key] !== undefined) numericOptions[key] = options[key]
+  }
+
+  const values = Object.fromEntries(
+    getFormatter(locale, numericOptions)
+      .formatToParts(date)
+      .filter(part => ['year', 'month', 'day'].includes(part.type))
+      .map(part => [part.type, part.value])
+  )
+  const { order, separator } = CUSTOM_DATE_FORMATS[normalizedFormat]
+  return order.map(part => values[part]).join(separator)
+}
+
+/**
+ * @param {Date | number} date
+ * @param {string} locale
+ * @param {string} timeFormat
+ * @param {Intl.DateTimeFormatOptions} options
+ * @returns {string}
+ */
+export function formatTime(date, locale, timeFormat = DEFAULT_TIME_FORMAT, options = {}) {
+  return getFormatter(locale, resolveTimeOptions(timeFormat, options)).format(date)
+}
+
+/**
+ * @param {Date | number} date
+ * @param {string} locale
+ * @param {string} dateFormat
+ * @param {Intl.DateTimeFormatOptions} dateOptions
+ * @param {Intl.DateTimeFormatOptions} timeOptions
+ * @param {string} timeFormat
+ * @returns {string}
+ */
+export function formatDateTime(
+  date,
+  locale,
+  dateFormat = DEFAULT_DATE_FORMAT,
+  dateOptions = {},
+  timeOptions = {},
+  timeFormat = DEFAULT_TIME_FORMAT
+) {
+  const normalizedFormat = normalizeDateFormat(dateFormat)
+  const normalizedTimeFormat = normalizeTimeFormat(timeFormat)
+  if (normalizedFormat === DEFAULT_DATE_FORMAT) {
+    const resolvedOptions = { ...dateOptions, ...resolveTimeOptions(normalizedTimeFormat, timeOptions) }
+    return getFormatter(locale, resolvedOptions).format(date)
+  }
+
+  return `${formatDate(date, locale, normalizedFormat, dateOptions)}, ${formatTime(date, locale, normalizedTimeFormat, timeOptions)}`
+}
+
+/**
+ * @param {Date | number} date
+ * @param {string} locale
+ * @param {string} dateFormat
+ * @param {string} timeFormat
+ * @returns {string}
+ */
+export function formatShortDateTime(
+  date,
+  locale,
+  dateFormat = DEFAULT_DATE_FORMAT,
+  timeFormat = DEFAULT_TIME_FORMAT
+) {
+  return formatDateTime(
+    date,
+    locale,
+    dateFormat,
+    { dateStyle: 'short' },
+    { timeStyle: 'short' },
+    timeFormat
+  )
+}

--- a/src/renderer/helpers/utils.js
+++ b/src/renderer/helpers/utils.js
@@ -976,24 +976,6 @@ export function getCachedRelativeTimeFormat(locale, numeric = 'always') {
   return formatter
 }
 
-/** @type {Map<string, Intl.DateTimeFormat>} */
-const shortDateTimeFormatCache = new Map()
-
-/**
- * @param {string} locale
- * @returns {Intl.DateTimeFormat}
- */
-export function getCachedShortDateTimeFormat(locale) {
-  let formatter = shortDateTimeFormatCache.get(locale)
-
-  if (!formatter) {
-    formatter = new Intl.DateTimeFormat([locale, 'en'], { dateStyle: 'short', timeStyle: 'short' })
-    shortDateTimeFormatCache.set(locale, formatter)
-  }
-
-  return formatter
-}
-
 /**
  *
  * @param {number} date

--- a/src/renderer/store/modules/settings.js
+++ b/src/renderer/store/modules/settings.js
@@ -518,6 +518,8 @@ const state = {
   quickBookmarkTargetPlaylistId: 'favorites',
   generalAutoLoadMorePaginatedItemsEnabled: true,
   hideToTrayOnMinimize: false,
+  dateFormat: 'locale',
+  timeFormat: 'locale',
 
   // The settings below have side effects
   useAITranslationCompletions: true,

--- a/src/renderer/views/Home/Home.vue
+++ b/src/renderer/views/Home/Home.vue
@@ -420,12 +420,15 @@ import {
   getNewSubscriptionFeedEntries,
 } from '../../helpers/newSubscriptionFeed'
 import thumbnailPlaceholder from '../../assets/img/thumbnail_placeholder.svg'
+import { formatDateTime } from '../../helpers/dateFormat'
 
 const { locale, t } = useI18n()
 const IS_ELECTRON = process.env.IS_ELECTRON
 const customizing = ref(false)
 const reorderStatus = ref('')
 const reminders = ref([])
+const dateFormat = computed(() => store.getters.getDateFormat)
+const timeFormat = computed(() => store.getters.getTimeFormat)
 let removeReminderListener = null
 let reminderLoadGeneration = 0
 
@@ -713,10 +716,14 @@ function openDownloads() {
 }
 
 function formatReminderTime(timestamp) {
-  return new Intl.DateTimeFormat(locale.value, {
-    dateStyle: 'medium',
-    timeStyle: 'short',
-  }).format(new Date(timestamp))
+  return formatDateTime(
+    timestamp,
+    locale.value,
+    dateFormat.value,
+    { dateStyle: 'medium' },
+    { timeStyle: 'short' },
+    timeFormat.value
+  )
 }
 
 async function loadReminders() {

--- a/src/renderer/views/Playlist/Playlist.vue
+++ b/src/renderer/views/Playlist/Playlist.vue
@@ -248,6 +248,7 @@ import {
 import { invidiousGetPlaylistInfo, youtubeImageUrlToInvidious } from '../../helpers/api/invidious'
 import { hasMoreInvidiousPlaylistPages, mergeInvidiousPlaylistVideos } from '../../helpers/api/invidious-playlists'
 import { runRetryablePlaylistRequest } from '../../helpers/playlist-pagination'
+import { formatDate } from '../../helpers/dateFormat'
 import { canonicalPlaylistThumbnailUrl, createPlaylistBookmark } from '../../helpers/playlist-bookmarks'
 import { fillMissingPlaylistVideoDurations, getSortedPlaylistItems, SORT_BY_VALUES } from '../../helpers/playlists'
 import { MOBILE_WIDTH_THRESHOLD, PLAYLIST_HEIGHT_FORCE_LIST_THRESHOLD } from '../../../constants'
@@ -274,6 +275,20 @@ const viewCount = ref(0)
 const videoCount = ref(0)
 /** @type {import('vue').Ref<string | undefined>} */
 const lastUpdated = ref(undefined)
+const lastUpdatedDate = ref(null)
+const dateFormat = computed(() => store.getters.getDateFormat)
+
+function updateLastUpdatedDate() {
+  if (lastUpdatedDate.value === null) return
+
+  lastUpdated.value = formatDate(lastUpdatedDate.value, locale.value, dateFormat.value, {
+    year: 'numeric',
+    month: 'short',
+    day: 'numeric',
+  })
+}
+
+watch([locale, dateFormat], updateLastUpdatedDate)
 const channelName = ref('')
 const channelThumbnail = ref('')
 const channelId = ref('')
@@ -596,6 +611,7 @@ function resetState() {
   viewCount.value = 0
   videoCount.value = 0
   lastUpdated.value = undefined
+  lastUpdatedDate.value = null
   channelName.value = ''
   channelThumbnail.value = ''
   channelId.value = ''
@@ -643,6 +659,7 @@ async function getPlaylistLocal() {
     viewCount.value = result.info.views.toLowerCase() === 'no views' ? 0 : extractNumberFromString(result.info.views)
     videoCount.value = extractNumberFromString(result.info.total_items)
     lastUpdated.value = result.info.last_updated ?? ''
+    lastUpdatedDate.value = null
     channelName.value = channelName_ ?? ''
     channelThumbnail.value = result.info.author?.best_thumbnail?.url ?? ''
     channelId.value = result.info.author?.id
@@ -715,8 +732,8 @@ async function getPlaylistInvidious() {
       channelId: channelId.value
     })
 
-    const dateString = new Date(result.updated * 1000)
-    lastUpdated.value = dateString.toLocaleDateString(locale.value, { year: 'numeric', month: 'short', day: 'numeric' })
+    lastUpdatedDate.value = new Date(result.updated * 1000)
+    updateLastUpdatedDate()
 
     playlistItems.value = result.videos
     await refreshPlaylistBookmarkThumbnail()
@@ -762,8 +779,8 @@ function parseUserPlaylist(playlist) {
     firstVideoPlaylistItemId.value = ''
   }
 
-  const dateString = new Date(playlist.lastUpdatedAt)
-  lastUpdated.value = dateString.toLocaleDateString(locale.value, { year: 'numeric', month: 'short', day: 'numeric' })
+  lastUpdatedDate.value = new Date(playlist.lastUpdatedAt)
+  updateLastUpdatedDate()
   viewCount.value = 0
   channelName.value = ''
   channelThumbnail.value = ''

--- a/src/renderer/views/Stats/Stats.vue
+++ b/src/renderer/views/Stats/Stats.vue
@@ -268,6 +268,7 @@ import FtPrompt from '../../components/FtPrompt/FtPrompt.vue'
 import FtSelect from '../../components/FtSelect/FtSelect.vue'
 import store from '../../store'
 import { showToast } from '../../helpers/utils'
+import { formatDate } from '../../helpers/dateFormat'
 
 const { locale, t } = useI18n()
 const router = useRouter()
@@ -284,6 +285,7 @@ const channelPlaybackSpeeds = computed(() => store.getters.getChannelPlaybackSpe
 const playbackSpeedInterval = computed(() => store.getters.getVideoPlaybackRateInterval)
 const maximumPlaybackSpeed = computed(() => store.getters.getMaxVideoPlaybackRate)
 const statsWeekStartsOn = computed(() => Number(store.getters.getStatsWeekStartsOn))
+const dateFormat = computed(() => store.getters.getDateFormat)
 const watchStatsVisible = computed(() => {
   return store.getters.getRememberHistory && store.getters.getEnableWatchStats
 })
@@ -462,7 +464,6 @@ const summaries = computed(() => [
 
 const dailyData = computed(() => {
   const formatter = new Intl.DateTimeFormat(locale.value, { weekday: 'short' })
-  const fullFormatter = new Intl.DateTimeFormat(locale.value, { dateStyle: 'medium' })
   const today = startOfDay(new Date())
 
   return Array.from({ length: 14 }, (_, index) => {
@@ -473,7 +474,7 @@ const dailyData = computed(() => {
     return {
       date: dateKey,
       label: formatter.format(date).slice(0, 2),
-      fullLabel: fullFormatter.format(date),
+      fullLabel: formatDate(date, locale.value, dateFormat.value, { dateStyle: 'medium' }),
       seconds: watchSecondsByDate.value[dateKey] ?? 0,
     }
   })
@@ -496,7 +497,6 @@ const dailyChart = computed(() => {
 
 const weeklyTotals = computed(() => {
   const labelFormatter = new Intl.DateTimeFormat(locale.value, { month: 'short', day: 'numeric' })
-  const fullFormatter = new Intl.DateTimeFormat(locale.value, { dateStyle: 'medium' })
   const currentWeek = startOfWeek(new Date())
   const weeks = Array.from({ length: 8 }, (_, index) => {
     const date = new Date(currentWeek)
@@ -504,7 +504,7 @@ const weeklyTotals = computed(() => {
     return {
       date: toDateKey(date),
       label: labelFormatter.format(date),
-      fullLabel: fullFormatter.format(date),
+      fullLabel: formatDate(date, locale.value, dateFormat.value, { dateStyle: 'medium' }),
       seconds: 0,
     }
   })

--- a/src/renderer/views/Watch/Watch.js
+++ b/src/renderer/views/Watch/Watch.js
@@ -92,6 +92,7 @@ import { tabMediaCoordinator } from '../../tabs/TabMediaCoordinator'
 import { useTabToast } from '../../composables/useTabToast'
 import { useRelativeTimeClock } from '../../composables/useRelativeTimeClock'
 import { areCommentsAvailable } from './watchComments'
+import { formatDateTime } from '../../helpers/dateFormat'
 
 /**
  * @typedef {{
@@ -446,6 +447,12 @@ export default defineComponent({
     }
   },
   computed: {
+    dateFormatPreference: function () {
+      return this.$store.getters.getDateFormat
+    },
+    timeFormatPreference: function () {
+      return this.$store.getters.getTimeFormat
+    },
     localPlaybackDownloads: function () {
       const downloads = Object.values(this.$store.getters.getYtDlpDownloads)
         .filter(download => download.status === 'completed' && ['video', 'audio'].includes(download.mode))
@@ -1077,6 +1084,9 @@ export default defineComponent({
     }
   },
   watch: {
+    currentLocale: 'updateUpcomingTimestamp',
+    dateFormatPreference: 'updateUpcomingTimestamp',
+    timeFormatPreference: 'updateUpcomingTimestamp',
     isLoading(loading) {
       if (!loading) {
         this.updateVideoMetadataCache()
@@ -1228,6 +1238,26 @@ export default defineComponent({
     }
   },
   methods: {
+    updateUpcomingTimestamp: function () {
+      if (!(this.premiereDate instanceof Date)) return
+
+      const dateOptions = {
+        month: 'long',
+        day: 'numeric',
+      }
+      if (new Date().getFullYear() < this.premiereDate.getFullYear()) {
+        dateOptions.year = 'numeric'
+      }
+
+      this.upcomingTimestamp = formatDateTime(
+        this.premiereDate,
+        this.currentLocale,
+        this.dateFormatPreference,
+        dateOptions,
+        { hour: 'numeric', minute: '2-digit' },
+        this.timeFormatPreference
+      )
+    },
     async updateVideoMetadataCache() {
       if (
         !this.enableVideoMetadataCache ||
@@ -2971,19 +3001,9 @@ export default defineComponent({
           const upcomingTimestamp = result.basic_info.start_timestamp
 
           if (upcomingTimestamp) {
-            const timestampOptions = {
-              month: 'long',
-              day: 'numeric',
-              hour: 'numeric',
-              minute: '2-digit'
-            }
             const now = new Date()
-            if (now.getFullYear() < upcomingTimestamp.getFullYear()) {
-              Object.defineProperty(timestampOptions, 'year', {
-                value: 'numeric'
-              })
-            }
-            this.upcomingTimestamp = Intl.DateTimeFormat(this.currentLocale, timestampOptions).format(upcomingTimestamp)
+            this.premiereDate = upcomingTimestamp
+            this.updateUpcomingTimestamp()
 
             let upcomingTimeLeft = upcomingTimestamp - now
 
@@ -3015,7 +3035,6 @@ export default defineComponent({
               this.upcomingTimeLeft = new Intl.RelativeTimeFormat(this.currentLocale).format(upcomingTimeLeft, timeUnit)
             }
 
-            this.premiereDate = upcomingTimestamp
             this.scheduleLiveReminderStartInvalidation()
             this.syncLiveReminder(loadGeneration, videoId).catch(error => {
               console.error('Failed to load live stream reminder', error)

--- a/static/locales/ai/ar.yaml
+++ b/static/locales/ai/ar.yaml
@@ -217,6 +217,9 @@ Settings:
       Network: شبكة
       Disk: القرص
   General Settings:
+    Date Format: تنسيق التاريخ
+    Time Format: تنسيق الوقت
+    Language Default: الإعداد الافتراضي للغة
     Update Relative Timestamps: حافظ على تحديث الطوابع الزمنية النسبية
     Stream Extraction Method:
       Stream Extraction Method: طريقة استخراج الدفق

--- a/static/locales/ai/be.yaml
+++ b/static/locales/ai/be.yaml
@@ -229,6 +229,9 @@ Settings:
       Network: сетка
       Disk: дыск
   General Settings:
+    Date Format: Фармат даты
+    Time Format: Фармат часу
+    Language Default: Паводле мовы
     Update Relative Timestamps: Абнаўляць адносныя пазнакі часу
     Stream Extraction Method:
       Stream Extraction Method: Спосаб атрымання медыяструменя

--- a/static/locales/ai/bg.yaml
+++ b/static/locales/ai/bg.yaml
@@ -215,6 +215,9 @@ Settings:
       Network: мрежата
       Disk: диска
   General Settings:
+    Date Format: Формат на датата
+    Time Format: Формат на часа
+    Language Default: По подразбиране за езика
     Update Relative Timestamps: Поддържай относителните времеви обозначения актуални
     Stream Extraction Method:
       Stream Extraction Method: Метод за извличане на потока

--- a/static/locales/ai/br.yaml
+++ b/static/locales/ai/br.yaml
@@ -213,6 +213,9 @@ Settings:
       Network: "ar rouedad"
       Disk: "ar bladenn"
   General Settings:
+    Date Format: Mentrezh an deiziad
+    Time Format: Mentrezh an eur
+    Language Default: Dre ziouer ar yezh
     Update Relative Timestamps: "Hizivaat an deiziadoù hag eurioù keñverel"
     Stream Extraction Method:
       Stream Extraction Method: "Doare eztennañ ar gwazh"

--- a/static/locales/ai/ca.yaml
+++ b/static/locales/ai/ca.yaml
@@ -340,6 +340,9 @@ Settings:
       Disk: disc
   Return to Settings Menu: Torna al menú de configuració
   General Settings:
+    Date Format: Format de data
+    Time Format: Format d'hora
+    Language Default: Predeterminat de l'idioma
     Update Relative Timestamps: Manté actualitzades les marques horàries relatives
     Stream Extraction Method:
       Stream Extraction Method: Mètode d'extracció dels fluxos

--- a/static/locales/ai/cs.yaml
+++ b/static/locales/ai/cs.yaml
@@ -215,6 +215,9 @@ Settings:
       Network: sítě
       Disk: disku
   General Settings:
+    Date Format: Formát data
+    Time Format: Formát času
+    Language Default: Výchozí podle jazyka
     Update Relative Timestamps: Průběžně aktualizovat relativní časové údaje
     Stream Extraction Method:
       Stream Extraction Method: Způsob získávání streamu

--- a/static/locales/ai/cy.yaml
+++ b/static/locales/ai/cy.yaml
@@ -215,6 +215,9 @@ Settings:
       Network: rhwydwaith
       Disk: disg
   General Settings:
+    Date Format: Fformat dyddiad
+    Time Format: Fformat amser
+    Language Default: Rhagosodiad yr iaith
     Update Relative Timestamps: Diweddaru stampiau amser cymharol
     Stream Extraction Method:
       Stream Extraction Method: Dull echdynnu ffrydiau

--- a/static/locales/ai/da.yaml
+++ b/static/locales/ai/da.yaml
@@ -226,7 +226,7 @@ Settings:
   General Settings:
     Date Format: Datoformat
     Time Format: Tidsformat
-    Language Default: Sprogstandard
+    Language Default: Baseret på sprog
     Update Relative Timestamps: Hold relative tidsangivelser opdateret
     Stream Extraction Method:
       Stream Extraction Method: Metode til udtræk af streams

--- a/static/locales/ai/da.yaml
+++ b/static/locales/ai/da.yaml
@@ -224,6 +224,9 @@ Settings:
       Network: netværk
       Disk: diskplads
   General Settings:
+    Date Format: Datoformat
+    Time Format: Tidsformat
+    Language Default: Sprogstandard
     Update Relative Timestamps: Hold relative tidsangivelser opdateret
     Stream Extraction Method:
       Stream Extraction Method: Metode til udtræk af streams

--- a/static/locales/ai/el.yaml
+++ b/static/locales/ai/el.yaml
@@ -217,6 +217,9 @@ Settings:
       Network: δικτύου
       Disk: δίσκου
   General Settings:
+    Date Format: Μορφή ημερομηνίας
+    Time Format: Μορφή ώρας
+    Language Default: Προεπιλογή γλώσσας
     Update Relative Timestamps: Συνεχής ενημέρωση σχετικών χρονικών ενδείξεων
     Stream Extraction Method:
       Stream Extraction Method: Μέθοδος εξαγωγής ροής

--- a/static/locales/ai/en-GB.yaml
+++ b/static/locales/ai/en-GB.yaml
@@ -212,6 +212,9 @@ Settings:
       Network: network
       Disk: disk
   General Settings:
+    Date Format: Date format
+    Time Format: Time format
+    Language Default: Language default
     Use AI Translation Completions: Fill missing translations with AI-generated text
     Update Relative Timestamps: Keep relative timestamps updated
     Stream Extraction Method:

--- a/static/locales/ai/es-AR.yaml
+++ b/static/locales/ai/es-AR.yaml
@@ -233,6 +233,9 @@ Settings:
       Network: red
       Disk: disco
   General Settings:
+    Date Format: Formato de fecha
+    Time Format: Formato de hora
+    Language Default: Predeterminado del idioma
     Update Relative Timestamps: Mantener actualizadas las marcas de tiempo relativas
     Stream Extraction Method:
       Stream Extraction Method: Método de extracción de emisiones

--- a/static/locales/ai/es-MX.yaml
+++ b/static/locales/ai/es-MX.yaml
@@ -241,6 +241,9 @@ Settings:
       Network: red
       Disk: disco
   General Settings:
+    Date Format: Formato de fecha
+    Time Format: Formato de hora
+    Language Default: Predeterminado del idioma
     Update Relative Timestamps: Mantener actualizadas las marcas de tiempo relativas
     Stream Extraction Method:
       Stream Extraction Method: Método de extracción de emisiones

--- a/static/locales/ai/es.yaml
+++ b/static/locales/ai/es.yaml
@@ -215,6 +215,9 @@ Settings:
       Network: red
       Disk: disco
   General Settings:
+    Date Format: Formato de fecha
+    Time Format: Formato de hora
+    Language Default: Predeterminado del idioma
     Update Relative Timestamps: Mantener actualizadas las marcas de tiempo relativas
     Stream Extraction Method:
       Stream Extraction Method: Método de extracción de emisiones

--- a/static/locales/ai/et.yaml
+++ b/static/locales/ai/et.yaml
@@ -213,6 +213,9 @@ Settings:
       Network: võrgu
       Disk: ketta
   General Settings:
+    Date Format: Kuupäevavorming
+    Time Format: Kellaajavorming
+    Language Default: Keele vaikeseade
     Update Relative Timestamps: Hoia suhtelised ajatemplid ajakohasena
     Stream Extraction Method:
       Stream Extraction Method: Voo eraldamise meetod

--- a/static/locales/ai/eu.yaml
+++ b/static/locales/ai/eu.yaml
@@ -215,6 +215,9 @@ Settings:
       Network: sarea
       Disk: diskoa
   General Settings:
+    Date Format: Data-formatua
+    Time Format: Ordu-formatua
+    Language Default: Hizkuntzaren lehenetsia
     Update Relative Timestamps: Mantendu denbora-marka erlatiboak eguneratuta
     Stream Extraction Method:
       Stream Extraction Method: Korronteak erauzteko metodoa

--- a/static/locales/ai/fa.yaml
+++ b/static/locales/ai/fa.yaml
@@ -230,6 +230,9 @@ Settings:
       Network: شبکه
       Disk: دیسک
   General Settings:
+    Date Format: قالب تاریخ
+    Time Format: قالب زمان
+    Language Default: پیش‌فرض زبان
     Update Relative Timestamps: زمان‌های نسبی را به‌روز نگه دارید
     Stream Extraction Method:
       Stream Extraction Method: روش استخراج جریان

--- a/static/locales/ai/fi.yaml
+++ b/static/locales/ai/fi.yaml
@@ -217,6 +217,9 @@ Settings:
       Network: verkko
       Disk: levytila
   General Settings:
+    Date Format: Päivämäärän muoto
+    Time Format: Ajan muoto
+    Language Default: Kielen oletus
     Update Relative Timestamps: Pidä suhteelliset aikaleimat ajan tasalla
     Stream Extraction Method:
       Stream Extraction Method: Suoratoiston poimintatapa

--- a/static/locales/ai/fr-FR.yaml
+++ b/static/locales/ai/fr-FR.yaml
@@ -213,6 +213,9 @@ Settings:
       Network: le réseau
       Disk: le disque
   General Settings:
+    Date Format: Format de date
+    Time Format: Format de l'heure
+    Language Default: Valeur par défaut de la langue
     Update Relative Timestamps: Actualiser les horodatages relatifs
     Stream Extraction Method:
       Stream Extraction Method: Méthode d’extraction des flux

--- a/static/locales/ai/gl.yaml
+++ b/static/locales/ai/gl.yaml
@@ -217,6 +217,9 @@ Settings:
       Network: rede
       Disk: disco
   General Settings:
+    Date Format: Formato da data
+    Time Format: Formato da hora
+    Language Default: Predeterminado do idioma
     Update Relative Timestamps: Manter actualizadas as marcas de tempo relativas
     Stream Extraction Method:
       Stream Extraction Method: Método de extracción das emisións

--- a/static/locales/ai/he.yaml
+++ b/static/locales/ai/he.yaml
@@ -217,6 +217,9 @@ Settings:
       Network: רשת
       Disk: כונן
   General Settings:
+    Date Format: תבנית תאריך
+    Time Format: תבנית שעה
+    Language Default: ברירת המחדל של השפה
     Update Relative Timestamps: עדכון רציף של חותמות זמן יחסיות
     Stream Extraction Method:
       Stream Extraction Method: שיטת חילוץ הזרם

--- a/static/locales/ai/hr.yaml
+++ b/static/locales/ai/hr.yaml
@@ -215,6 +215,9 @@ Settings:
       Network: mreže
       Disk: diska
   General Settings:
+    Date Format: Format datuma
+    Time Format: Format vremena
+    Language Default: Zadano za jezik
     Update Relative Timestamps: Ažuriraj relativne vremenske oznake
     Stream Extraction Method:
       Stream Extraction Method: Način izdvajanja medijskog toka

--- a/static/locales/ai/hu.yaml
+++ b/static/locales/ai/hu.yaml
@@ -213,6 +213,9 @@ Settings:
       Network: hálózat
       Disk: lemez
   General Settings:
+    Date Format: Dátumformátum
+    Time Format: Időformátum
+    Language Default: Nyelvi alapértelmezés
     Update Relative Timestamps: Relatív időbélyegek folyamatos frissítése
     Stream Extraction Method:
       Stream Extraction Method: Adatfolyam-kinyerési mód

--- a/static/locales/ai/id.yaml
+++ b/static/locales/ai/id.yaml
@@ -217,6 +217,9 @@ Settings:
       Network: jaringan
       Disk: disk
   General Settings:
+    Date Format: Format tanggal
+    Time Format: Format waktu
+    Language Default: Default bahasa
     Update Relative Timestamps: Terus perbarui stempel waktu relatif
     Stream Extraction Method:
       Stream Extraction Method: Metode ekstraksi stream

--- a/static/locales/ai/is.yaml
+++ b/static/locales/ai/is.yaml
@@ -217,6 +217,9 @@ Settings:
       Network: nets
       Disk: disks
   General Settings:
+    Date Format: Dagsetningarsnið
+    Time Format: Tímasnið
+    Language Default: Sjálfgefið fyrir tungumál
     Update Relative Timestamps: Uppfæra afstæða tímastimpla
     Stream Extraction Method:
       Stream Extraction Method: Aðferð við öflun streymis

--- a/static/locales/ai/it.yaml
+++ b/static/locales/ai/it.yaml
@@ -215,6 +215,9 @@ Settings:
       Network: rete
       Disk: disco
   General Settings:
+    Date Format: Formato data
+    Time Format: Formato ora
+    Language Default: Predefinito della lingua
     Update Relative Timestamps: Mantieni aggiornati gli orari relativi
     Stream Extraction Method:
       Stream Extraction Method: Metodo di estrazione dei flussi

--- a/static/locales/ai/ja.yaml
+++ b/static/locales/ai/ja.yaml
@@ -215,6 +215,9 @@ Settings:
       Network: ネットワーク
       Disk: ディスク
   General Settings:
+    Date Format: 日付形式
+    Time Format: 時刻形式
+    Language Default: 言語の既定値
     Update Relative Timestamps: 相対日時を自動更新
     Stream Extraction Method:
       Stream Extraction Method: ストリーム抽出方式

--- a/static/locales/ai/ko.yaml
+++ b/static/locales/ai/ko.yaml
@@ -301,6 +301,9 @@ Settings:
       Disk: 디스크
   Return to Settings Menu: 설정 메뉴로 돌아가기
   General Settings:
+    Date Format: 날짜 형식
+    Time Format: 시간 형식
+    Language Default: 언어 기본값
     Update Relative Timestamps: 상대 시간 표시 계속 업데이트
     Stream Extraction Method:
       Stream Extraction Method: 스트림 추출 방법

--- a/static/locales/ai/lt.yaml
+++ b/static/locales/ai/lt.yaml
@@ -326,6 +326,9 @@ Settings:
       Disk: disko
   Return to Settings Menu: Grįžti į nustatymų meniu
   General Settings:
+    Date Format: Datos formatas
+    Time Format: Laiko formatas
+    Language Default: Kalbos numatytasis
     Update Relative Timestamps: Nuolat atnaujinti santykines laiko žymas
     Stream Extraction Method:
       Stream Extraction Method: Srauto išgavimo būdas

--- a/static/locales/ai/lt.yaml
+++ b/static/locales/ai/lt.yaml
@@ -328,7 +328,7 @@ Settings:
   General Settings:
     Date Format: Datos formatas
     Time Format: Laiko formatas
-    Language Default: Kalbos numatytasis
+    Language Default: Pagal kalbą
     Update Relative Timestamps: Nuolat atnaujinti santykines laiko žymas
     Stream Extraction Method:
       Stream Extraction Method: Srauto išgavimo būdas

--- a/static/locales/ai/nb-NO.yaml
+++ b/static/locales/ai/nb-NO.yaml
@@ -215,6 +215,9 @@ Settings:
       Network: nettverk
       Disk: disk
   General Settings:
+    Date Format: Datoformat
+    Time Format: Tidsformat
+    Language Default: Språkstandard
     Update Relative Timestamps: Hold relative tidsangivelser oppdatert
     Stream Extraction Method:
       Stream Extraction Method: Metode for uthenting av strømmer

--- a/static/locales/ai/nl.yaml
+++ b/static/locales/ai/nl.yaml
@@ -217,6 +217,9 @@ Settings:
       Network: netwerk
       Disk: schijf
   General Settings:
+    Date Format: Datumnotatie
+    Time Format: Tijdnotatie
+    Language Default: Standaard voor taal
     Update Relative Timestamps: Relatieve tijdsaanduidingen blijven bijwerken
     Stream Extraction Method:
       Stream Extraction Method: Methode voor stream-extractie

--- a/static/locales/ai/nn.yaml
+++ b/static/locales/ai/nn.yaml
@@ -338,6 +338,9 @@ Settings:
       Disk: disk
   Return to Settings Menu: Tilbake til innstillingsmenyen
   General Settings:
+    Date Format: Datoformat
+    Time Format: Tidsformat
+    Language Default: Språkstandard
     Update Relative Timestamps: Hald relative tidsstempel oppdaterte
     Stream Extraction Method:
       Stream Extraction Method: Metode for uthenting av straum

--- a/static/locales/ai/pl.yaml
+++ b/static/locales/ai/pl.yaml
@@ -70,6 +70,9 @@ Settings:
     Advanced Description: Dostawcy, aplikacje zewnętrzne i sieć
     Alternative providers: Dostawcy filmów i metadanych
   General Settings:
+    Date Format: Format daty
+    Time Format: Format czasu
+    Language Default: Domyślny dla języka
     Use AI Translation Completions: Uzupełniaj brakujące tłumaczenia tekstem wygenerowanym przez AI
     Comment Translation:
       Title: Tłumaczenie komentarzy

--- a/static/locales/ai/pt-BR.yaml
+++ b/static/locales/ai/pt-BR.yaml
@@ -213,6 +213,9 @@ Settings:
       Network: rede
       Disk: disco
   General Settings:
+    Date Format: Formato da data
+    Time Format: Formato de hora
+    Language Default: Padrão do idioma
     Update Relative Timestamps: Manter as marcas temporais relativas atualizadas
     Stream Extraction Method:
       Stream Extraction Method: Método de extração de transmissões

--- a/static/locales/ai/pt-PT.yaml
+++ b/static/locales/ai/pt-PT.yaml
@@ -217,6 +217,9 @@ Settings:
       Network: rede
       Disk: disco
   General Settings:
+    Date Format: Formato da data
+    Time Format: Formato da hora
+    Language Default: Predefinição do idioma
     Update Relative Timestamps: Manter as marcas temporais relativas atualizadas
     Stream Extraction Method:
       Stream Extraction Method: Método de extração de transmissões

--- a/static/locales/ai/pt.yaml
+++ b/static/locales/ai/pt.yaml
@@ -217,6 +217,9 @@ Settings:
       Network: rede
       Disk: disco
   General Settings:
+    Date Format: Formato da data
+    Time Format: Formato da hora
+    Language Default: Predefinição do idioma
     Update Relative Timestamps: Manter as marcas temporais relativas atualizadas
     Stream Extraction Method:
       Stream Extraction Method: Método de extração de transmissões

--- a/static/locales/ai/ro.yaml
+++ b/static/locales/ai/ro.yaml
@@ -215,6 +215,9 @@ Settings:
       Network: rețea
       Disk: disc
   General Settings:
+    Date Format: Formatul datei
+    Time Format: Formatul orei
+    Language Default: Valoarea implicită a limbii
     Update Relative Timestamps: Menține actualizate marcajele temporale relative
     Stream Extraction Method:
       Stream Extraction Method: Metodă de extragere a fluxului

--- a/static/locales/ai/ru.yaml
+++ b/static/locales/ai/ru.yaml
@@ -192,6 +192,9 @@ Settings:
       Network: сеть
       Disk: диск
   General Settings:
+    Date Format: Формат даты
+    Time Format: Формат времени
+    Language Default: По умолчанию для языка
     Update Relative Timestamps: Обновлять относительные отметки времени
     Stream Extraction Method:
       Stream Extraction Method: Способ извлечения потоков

--- a/static/locales/ai/sk.yaml
+++ b/static/locales/ai/sk.yaml
@@ -215,6 +215,9 @@ Settings:
       Network: sieť
       Disk: disk
   General Settings:
+    Date Format: Formát dátumu
+    Time Format: Formát času
+    Language Default: Predvolené pre jazyk
     Update Relative Timestamps: Priebežne aktualizovať relatívne časové údaje
     Stream Extraction Method:
       Stream Extraction Method: Spôsob získavania streamov

--- a/static/locales/ai/sl.yaml
+++ b/static/locales/ai/sl.yaml
@@ -333,6 +333,9 @@ Settings:
       Disk: disk
   Return to Settings Menu: Nazaj v meni z nastavitvami
   General Settings:
+    Date Format: Oblika datuma
+    Time Format: Oblika časa
+    Language Default: Privzeto za jezik
     Update Relative Timestamps: Posodabljaj relativne časovne oznake
     Stream Extraction Method:
       Stream Extraction Method: Način pridobivanja tokov

--- a/static/locales/ai/sr.yaml
+++ b/static/locales/ai/sr.yaml
@@ -223,6 +223,9 @@ Settings:
       Network: мрежа
       Disk: диск
   General Settings:
+    Date Format: Формат датума
+    Time Format: Формат времена
+    Language Default: Подразумевано за језик
     Update Relative Timestamps: Редовно ажурирај релативне временске ознаке
     Stream Extraction Method:
       Stream Extraction Method: Начин издвајања стрима

--- a/static/locales/ai/sv.yaml
+++ b/static/locales/ai/sv.yaml
@@ -215,6 +215,9 @@ Settings:
       Network: nätverk
       Disk: diskutrymme
   General Settings:
+    Date Format: Datumformat
+    Time Format: Tidsformat
+    Language Default: Språkstandard
     Update Relative Timestamps: Håll relativa tidsangivelser uppdaterade
     Stream Extraction Method:
       Stream Extraction Method: Metod för strömutvinning

--- a/static/locales/ai/ta.yaml
+++ b/static/locales/ai/ta.yaml
@@ -218,6 +218,9 @@ Settings:
       Network: பிணையம்
       Disk: வட்டு
   General Settings:
+    Date Format: தேதி வடிவம்
+    Time Format: நேர வடிவம்
+    Language Default: மொழி இயல்புநிலை
     Update Relative Timestamps: சார்புநேரக் குறிப்புகளைப் புதுப்பித்தபடி வைத்திரு
     Stream Extraction Method:
       Stream Extraction Method: ஸ்ட்ரீம் பிரித்தெடுக்கும் முறை

--- a/static/locales/ai/tr.yaml
+++ b/static/locales/ai/tr.yaml
@@ -213,6 +213,9 @@ Settings:
       Network: ağ
       Disk: disk
   General Settings:
+    Date Format: Tarih biçimi
+    Time Format: Saat biçimi
+    Language Default: Dil varsayılanı
     Update Relative Timestamps: Göreli zaman damgalarını güncel tut
     Stream Extraction Method:
       Stream Extraction Method: Akış çıkarma yöntemi

--- a/static/locales/ai/uk.yaml
+++ b/static/locales/ai/uk.yaml
@@ -217,6 +217,9 @@ Settings:
       Network: мережа
       Disk: диск
   General Settings:
+    Date Format: Формат дати
+    Time Format: Формат часу
+    Language Default: Типовий для мови
     Update Relative Timestamps: Оновлювати відносні позначки часу
     Stream Extraction Method:
       Stream Extraction Method: Спосіб отримання потоку

--- a/static/locales/ai/vi.yaml
+++ b/static/locales/ai/vi.yaml
@@ -217,6 +217,9 @@ Settings:
       Network: mạng
       Disk: ổ đĩa
   General Settings:
+    Date Format: Định dạng ngày
+    Time Format: Định dạng thời gian
+    Language Default: Mặc định theo ngôn ngữ
     Update Relative Timestamps: Luôn cập nhật mốc thời gian tương đối
     Stream Extraction Method:
       Stream Extraction Method: Phương thức trích xuất luồng

--- a/static/locales/ai/zh-CN.yaml
+++ b/static/locales/ai/zh-CN.yaml
@@ -213,6 +213,9 @@ Settings:
       Network: 网络
       Disk: 磁盘
   General Settings:
+    Date Format: 日期格式
+    Time Format: 时间格式
+    Language Default: 语言默认
     Update Relative Timestamps: 持续更新相对时间戳
     Stream Extraction Method:
       Stream Extraction Method: 流提取方式

--- a/static/locales/ai/zh-TW.yaml
+++ b/static/locales/ai/zh-TW.yaml
@@ -215,6 +215,9 @@ Settings:
       Network: 網路
       Disk: 磁碟
   General Settings:
+    Date Format: 日期格式
+    Time Format: 時間格式
+    Language Default: 語言預設
     Update Relative Timestamps: 持續更新相對時間
     Stream Extraction Method:
       Stream Extraction Method: 串流擷取方式

--- a/static/locales/de-DE.yaml
+++ b/static/locales/de-DE.yaml
@@ -318,6 +318,9 @@ Settings:
 
       Load previously loaded tabs: Zuvor geladene Tabs laden
     Locale Preference: Sprache
+    Date Format: Datumsformat
+    Time Format: Zeitformat
+    Language Default: Sprachvorgabe
     Use AI Translation Completions: Fehlende Übersetzungen mit KI ergänzen
     Preferred API Backend:
       Preferred API Backend: Bevorzugtes API-Backend

--- a/static/locales/en-US.yaml
+++ b/static/locales/en-US.yaml
@@ -515,6 +515,9 @@ Settings:
       Load last active tab: Load last active tab
       Start with an empty session: Start with an empty session
     Locale Preference: Locale Preference
+    Date Format: Date Format
+    Time Format: Time Format
+    Language Default: Language default
     Use AI Translation Completions: Fill missing translations with AI-generated text
     Reduced Motion:
       Reduced Motion: Reduced Motion

--- a/tests/unit/date-format.test.mjs
+++ b/tests/unit/date-format.test.mjs
@@ -1,0 +1,69 @@
+import assert from 'node:assert/strict'
+import test from 'node:test'
+
+import {
+  DEFAULT_DATE_FORMAT,
+  DEFAULT_TIME_FORMAT,
+  formatDate,
+  formatDateTime,
+  formatTime,
+  normalizeDateFormat,
+  normalizeTimeFormat,
+} from '../../src/renderer/helpers/dateFormat.js'
+
+const date = new Date('2024-04-15T19:05:00Z')
+const dateOptions = { year: 'numeric', month: 'numeric', day: 'numeric', timeZone: 'UTC' }
+
+test('uses the locale date order by default', () => {
+  assert.equal(formatDate(date, 'en-US', DEFAULT_DATE_FORMAT, dateOptions), '4/15/2024')
+  assert.equal(formatDate(date, 'en-GB', DEFAULT_DATE_FORMAT, dateOptions), '15/04/2024')
+})
+
+test('supports each explicit date format independently of the locale', () => {
+  const expectedFormats = {
+    'MM/DD/YYYY': '04/15/2024',
+    'DD/MM/YYYY': '15/04/2024',
+    'YYYY-MM-DD': '2024-04-15',
+    'YYYY/MM/DD': '2024/04/15',
+    'DD.MM.YYYY': '15.04.2024',
+    'MM.DD.YYYY': '04.15.2024',
+  }
+
+  for (const [format, expected] of Object.entries(expectedFormats)) {
+    assert.equal(formatDate(date, 'en-US', format, dateOptions), expected)
+  }
+})
+
+test('uses the locale clock by default and supports explicit 12-hour and 24-hour clocks', () => {
+  const timeOptions = { hour: 'numeric', minute: '2-digit', timeZone: 'UTC' }
+
+  assert.equal(formatTime(date, 'en-US', DEFAULT_TIME_FORMAT, timeOptions), '7:05 PM')
+  assert.equal(formatTime(date, 'en-US', '12-hour', timeOptions), '7:05 PM')
+  assert.equal(formatTime(date, 'en-US', '24-hour', timeOptions), '19:05')
+  assert.equal(formatTime(date, 'de-DE', DEFAULT_TIME_FORMAT, timeOptions), '19:05')
+  assert.equal(formatTime(date, 'de-DE', '12-hour', timeOptions), '7:05 PM')
+})
+
+test('combines independently selected date and time formats', () => {
+  assert.equal(
+    formatDateTime(
+      date,
+      'en-US',
+      'DD.MM.YYYY',
+      { timeZone: 'UTC' },
+      { hour: 'numeric', minute: '2-digit', timeZone: 'UTC' },
+      '24-hour'
+    ),
+    '15.04.2024, 19:05'
+  )
+})
+
+test('falls back to locale formatting for unknown saved values', () => {
+  assert.equal(normalizeDateFormat('unknown'), DEFAULT_DATE_FORMAT)
+  assert.equal(normalizeTimeFormat('unknown'), DEFAULT_TIME_FORMAT)
+  assert.equal(formatDate(date, 'en-US', 'unknown', dateOptions), '4/15/2024')
+  assert.equal(
+    formatTime(date, 'en-US', 'unknown', { hour: 'numeric', minute: '2-digit', timeZone: 'UTC' }),
+    '7:05 PM'
+  )
+})


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Make sure to follow the contributing guidelines. -->
<!-- Important note, we may remove your pull request if you do not use this provided PR template correctly. -->
<!-- Agent instructions: Preserve every heading, comment, and marker in this template. Never remove or rewrite the release-note-category:start/end, release-note:start/end, or release-note-image:start/end marker pairs. -->

## Pull Request Type
<!-- Please select what type of pull request this is: [x] -->
- [ ] Bugfix
- [x] Feature Implementation
- [ ] Documentation
- [ ] Other

## Related issue
<!-- Please link the issue your pull request is referring to. -->
<!-- If this pull request fully resolves the relevant issue, put "closes" before the issue number. -->
<!-- Example: "closes #123456". -->

Closes #969.

## Description
<!-- Please write a clear and concise description of what the pull request does. -->

Date and time formatting currently follows the selected app language, so users cannot choose a regional format independently.

This adds separate Date Format and Time Format selectors under General settings. Both retain the language-based default, while explicit choices apply consistently to date, time, and combined timestamp displays throughout the app.

## Release note category
<!-- Select exactly one category. Every pull request must select one. -->
<!-- Select "Not noteworthy" when the pull request fixes a bug in or improves functionality that has not yet appeared in a stable release. -->
<!-- release-note-category:start -->
- [ ] Not noteworthy
- [ ] Highlights
- [x] More improvements
- [ ] Fixed bugs
<!-- release-note-category:end -->

## Release note
<!-- Required unless "Not noteworthy" is selected. -->
<!-- Write one concise, user-facing entry without a leading bullet. -->
<!-- release-note:start -->
Choose date and time formats independently of the app language.
<!-- release-note:end -->

## Release note images
<!-- Optional. Paste one or more Markdown images, HTML image tags, or dark/light <picture> elements here. -->
<!-- The release notes normalize the markup and limit images taller than 300 pixels. -->
<!-- Agent instructions:
For a noteworthy visible change, add media when it makes the change easier to understand. Prefer a still image unless motion is the point; recordings must use animated WebP.
After implementing a visible change, proactively capture the result and show the local media to the user for approval before uploading it or updating the pull request.
When the affected UI differs between dark and light themes, capturing both themes is required. A dark-only image is incomplete. Run `node _scripts/releaseNoteMedia.mjs --dark DARK_FILE --light LIGHT_FILE --alt "DESCRIPTION"`; GitHub will display the matching theme and use dark as the fallback. Use a single default-dark capture only when the light theme cannot be captured or looks identical.
Capture or crop to the smallest region that still makes the change clear. Do not include the full window when the affected component can be understood on its own.
Use English unless localization is the subject. Keep components at their normal dimensions and placement instead of resizing them to fill the frame.
Use deterministic local fixtures for visible remote images. Reusable avatar and thumbnail fixtures are available through `e2e/helpers/visual-fixtures.mjs`. Before capturing, verify that every visible image has loaded successfully (`complete === true` and `naturalWidth > 0`).
Inspect the final dark and light files for failed images, missing content, unrelated UI, awkward animation, and misleading layout. Omit media when it does not explain the change clearly.
For one dark capture, run `node _scripts/releaseNoteMedia.mjs FILE --alt "DESCRIPTION"`.
Check for personal information, tokens, private repository names, and unrelated desktop content before uploading. Uploaded media is public.
Keep capture-only scripts, test hooks, screenshots, and recordings out of commits. Remove them before committing unless the capture code is also a reusable regression test. Never commit generated release-note media.
Paste only the generated markup between the marker comments. Leave this section empty when media would not help.
-->
<!-- release-note-image:start -->
<picture>
  <source media="(prefers-color-scheme: dark)" srcset="https://github.com/OpenTubeX/media/releases/download/attachments/20260907T111826Z-date-time-dark-dark-53c1707f04.png">
  <source media="(prefers-color-scheme: light)" srcset="https://github.com/OpenTubeX/media/releases/download/attachments/20260907T111826Z-date-time-light-light-275bd7ee64.png">
  <img alt="Date and time format settings with independent date, clock, and app language controls" src="https://github.com/OpenTubeX/media/releases/download/attachments/20260907T111826Z-date-time-dark-dark-53c1707f04.png">
</picture>
<!-- release-note-image:end -->

## Testing
<!-- How can reviewers verify that the PR produces correct results? -->
<!-- Please provide instructions so that others can ensure that your pull request would produce correct results. For examples see, https://github.com/FreeTubeApp/FreeTube/pull/5743, https://github.com/FreeTubeApp/FreeTube/pull/7349, https://github.com/FreeTubeApp/FreeTube/pull/5125, https://github.com/FreeTubeApp/FreeTube/pull/7338 -->
<!-- Agent instructions: Only write human-facing steps that explain how to verify the change while running this branch in dev mode. Include expected results and, when applicable, helpful console snippets for interactive verification. Do not include automated checks, commands, results, pass counts, or CI status. -->

1. Open Settings, then General.
2. Confirm Date Format and Time Format default to Language default and show an example matching the current language.
3. Choose an explicit date format and either the 12h or 24h clock.
4. Open a feed containing an upcoming premiere and confirm its timestamp uses both selections.
5. Change the app language and confirm explicit date and time selections remain active. Switch either selector back to Language default and confirm that part follows the new language again.

## Additional context
<!-- Add any other context about the pull request here. -->

Explicit time formats only select the clock cycle. The active locale still controls digits and localized day-period text.

