### PR TITLE
fix(linux): use app-specific MPRIS name

### DIFF
--- a/_scripts/ebuilder.config.mjs
+++ b/_scripts/ebuilder.config.mjs
@@ -1,4 +1,5 @@
 import packageDetails from '../package.json' with { type: 'json' }
+import { patchLinuxMprisName } from './patchLinuxMprisName.mjs'
 
 /** @type {import('electron-builder').Configuration} */
 export default {
@@ -30,6 +31,7 @@ export default {
   // electron-builder will however still spend time scanning the `node_modules` folder and building up a list of dependencies,
   // returning `false` from the `beforeBuild` hook skips that.
   beforeBuild: () => Promise.resolve(false),
+  afterPack: patchLinuxMprisName,
   dmg: {
     contents: [
       {

--- a/_scripts/patchLinuxMprisName.mjs
+++ b/_scripts/patchLinuxMprisName.mjs
@@ -1,0 +1,49 @@
+import { readFile, writeFile } from 'node:fs/promises'
+import { join } from 'node:path'
+
+export const chromiumMprisServiceName =
+  'org.mpris.MediaPlayer2.chromium.instance%i'
+export const opentubexMprisServiceName =
+  'org.mpris.MediaPlayer2.opentubex.instanc%i'
+
+if (Buffer.byteLength(chromiumMprisServiceName) !==
+  Buffer.byteLength(opentubexMprisServiceName)) {
+  throw new Error('MPRIS service names must have equal byte lengths')
+}
+
+/**
+ * Give Electron's Linux MPRIS service an application-specific D-Bus prefix.
+ *
+ * Chromium hardcodes its generic service name in the executable. Replacing it
+ * with an equal-length string preserves the ELF layout while allowing Linux
+ * sandbox policies to grant only OpenTubeX's MPRIS namespace.
+ *
+ * @param {import('electron-builder').AfterPackContext} context
+ */
+export async function patchLinuxMprisName (context) {
+  if (context.electronPlatformName !== 'linux') {
+    return
+  }
+
+  const executablePath = join(
+    context.appOutDir,
+    context.packager.executableName
+  )
+  const executable = await readFile(executablePath)
+  const chromiumName = Buffer.from(chromiumMprisServiceName)
+  const opentubexName = Buffer.from(opentubexMprisServiceName)
+  let offset = 0
+  let replacements = 0
+
+  while ((offset = executable.indexOf(chromiumName, offset)) !== -1) {
+    opentubexName.copy(executable, offset)
+    offset += opentubexName.length
+    replacements += 1
+  }
+
+  if (replacements === 0) {
+    throw new Error(`Could not find Chromium's MPRIS service name in ${executablePath}`)
+  }
+
+  await writeFile(executablePath, executable)
+}

--- a/_scripts/patchLinuxMprisName.mjs
+++ b/_scripts/patchLinuxMprisName.mjs
@@ -3,6 +3,8 @@ import { join } from 'node:path'
 
 export const chromiumMprisServiceName =
   'org.mpris.MediaPlayer2.chromium.instance%i'
+// "instance" is shortened because "opentubex" is one byte longer than
+// "chromium" and the replacement must preserve the executable's byte layout.
 export const opentubexMprisServiceName =
   'org.mpris.MediaPlayer2.opentubex.instanc%i'
 

--- a/tests/unit/linux-mpris-name.test.mjs
+++ b/tests/unit/linux-mpris-name.test.mjs
@@ -1,0 +1,60 @@
+import assert from 'node:assert/strict'
+import { mkdtemp, readFile, rm, writeFile } from 'node:fs/promises'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import test from 'node:test'
+
+import {
+  chromiumMprisServiceName,
+  opentubexMprisServiceName,
+  patchLinuxMprisName,
+} from '../../_scripts/patchLinuxMprisName.mjs'
+
+const createContext = (appOutDir, electronPlatformName = 'linux') => ({
+  appOutDir,
+  electronPlatformName,
+  packager: {
+    executableName: 'opentubex',
+  },
+})
+
+test('uses an OpenTubeX-specific MPRIS name in Linux packages', async (t) => {
+  const appOutDir = await mkdtemp(join(tmpdir(), 'opentubex-mpris-'))
+  t.after(() => rm(appOutDir, { force: true, recursive: true }))
+
+  const executablePath = join(appOutDir, 'opentubex')
+  const original = Buffer.from(`prefix${chromiumMprisServiceName}suffix`)
+  await writeFile(executablePath, original)
+
+  await patchLinuxMprisName(createContext(appOutDir))
+
+  const patched = await readFile(executablePath)
+  assert.equal(patched.length, original.length)
+  assert.equal(patched.includes(chromiumMprisServiceName), false)
+  assert.equal(patched.includes(opentubexMprisServiceName), true)
+})
+
+test('does not modify packages for other platforms', async (t) => {
+  const appOutDir = await mkdtemp(join(tmpdir(), 'opentubex-mpris-'))
+  t.after(() => rm(appOutDir, { force: true, recursive: true }))
+
+  const executablePath = join(appOutDir, 'opentubex')
+  const original = Buffer.from(chromiumMprisServiceName)
+  await writeFile(executablePath, original)
+
+  await patchLinuxMprisName(createContext(appOutDir, 'win32'))
+
+  assert.deepEqual(await readFile(executablePath), original)
+})
+
+test('fails if Electron changes its MPRIS service name', async (t) => {
+  const appOutDir = await mkdtemp(join(tmpdir(), 'opentubex-mpris-'))
+  t.after(() => rm(appOutDir, { force: true, recursive: true }))
+
+  await writeFile(join(appOutDir, 'opentubex'), 'no MPRIS service name')
+
+  await assert.rejects(
+    patchLinuxMprisName(createContext(appOutDir)),
+    /Could not find Chromium's MPRIS service name/
+  )
+})

--- a/tests/unit/linux-mpris-name.test.mjs
+++ b/tests/unit/linux-mpris-name.test.mjs
@@ -4,11 +4,12 @@ import { tmpdir } from 'node:os'
 import { join } from 'node:path'
 import test from 'node:test'
 
-import {
-  chromiumMprisServiceName,
-  opentubexMprisServiceName,
-  patchLinuxMprisName,
-} from '../../_scripts/patchLinuxMprisName.mjs'
+import { patchLinuxMprisName } from '../../_scripts/patchLinuxMprisName.mjs'
+
+const chromiumMprisServiceName =
+  'org.mpris.MediaPlayer2.chromium.instance%i'
+const opentubexMprisServiceName =
+  'org.mpris.MediaPlayer2.opentubex.instanc%i'
 
 const createContext = (appOutDir, electronPlatformName = 'linux') => ({
   appOutDir,


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Make sure to follow the contributing guidelines. -->
<!-- Important note, we may remove your pull request if you do not use this provided PR template correctly. -->
<!-- Agent instructions: Preserve every heading, comment, and marker in this template. Never remove or rewrite the release-note-category:start/end, release-note:start/end, or release-note-image:start/end marker pairs. -->

## Pull Request Type
<!-- Please select what type of pull request this is: [x] -->
- [x] Bugfix
- [ ] Feature Implementation
- [ ] Documentation
- [ ] Other

## Related issue
<!-- Please link the issue your pull request is referring to. -->
<!-- If this pull request fully resolves the relevant issue, put "closes" before the issue number. -->
<!-- Example: "closes #123456". -->

## Description
<!-- Please write a clear and concise description of what the pull request does. -->
Electron registers Linux media controls under Chromium's generic MPRIS D-Bus name. Sandboxed packages cannot grant OpenTubeX a distinct MPRIS namespace while the executable still requests that generic name.

Patch the hardcoded service name during Linux packaging, using an equal-length OpenTubeX-specific replacement so the ELF layout stays unchanged. The build fails if a future Electron version no longer contains the expected string. Other platforms remain untouched.

## Release note category
<!-- Select exactly one category. Every pull request must select one. -->
<!-- Select "Not noteworthy" when the pull request fixes a bug in or improves functionality that has not yet appeared in a stable release. -->
<!-- release-note-category:start -->
- [x] Not noteworthy
- [ ] Highlights
- [ ] More improvements
- [ ] Fixed bugs
<!-- release-note-category:end -->

## Release note
<!-- Required unless "Not noteworthy" is selected. -->
<!-- Write one concise, user-facing entry without a leading bullet. -->
<!-- release-note:start -->
Use an OpenTubeX-specific MPRIS service name for Linux media controls.
<!-- release-note:end -->

## Release note images
<!-- Optional. Paste one or more Markdown images, HTML image tags, or dark/light <picture> elements here. -->
<!-- The release notes normalize the markup and limit images taller than 300 pixels. -->
<!-- Agent instructions:
For a noteworthy visible change, add media when it makes the change easier to understand. Prefer a still image unless motion is the point; recordings must use animated WebP.
After implementing a visible change, proactively capture the result and show the local media to the user for approval before uploading it or updating the pull request.
When the affected UI differs between dark and light themes, capturing both themes is required. A dark-only image is incomplete. Run `node _scripts/releaseNoteMedia.mjs --dark DARK_FILE --light LIGHT_FILE --alt "DESCRIPTION"`; GitHub will display the matching theme and use dark as the fallback. Use a single default-dark capture only when the light theme cannot be captured or looks identical.
Capture or crop to the smallest region that still makes the change clear. Do not include the full window when the affected component can be understood on its own.
Use English unless localization is the subject. Keep components at their normal dimensions and placement instead of resizing them to fill the frame.
Use deterministic local fixtures for visible remote images. Reusable avatar and thumbnail fixtures are available through `e2e/helpers/visual-fixtures.mjs`. Before capturing, verify that every visible image has loaded successfully (`complete === true` and `naturalWidth > 0`).
Inspect the final dark and light files for failed images, missing content, unrelated UI, awkward animation, and misleading layout. Omit media when it does not explain the change clearly.
For one dark capture, run `node _scripts/releaseNoteMedia.mjs FILE --alt "DESCRIPTION"`.
Check for personal information, tokens, private repository names, and unrelated desktop content before uploading. Uploaded media is public.
Keep capture-only scripts, test hooks, screenshots, and recordings out of commits. Remove them before committing unless the capture code is also a reusable regression test. Never commit generated release-note media.
Paste only the generated markup between the marker comments. Leave this section empty when media would not help.
-->
<!-- release-note-image:start -->

<!-- release-note-image:end -->

## Testing
<!-- How can reviewers verify that the PR produces correct results? -->
<!-- Please provide instructions so that others can ensure that your pull request would produce correct results. For examples see, https://github.com/FreeTubeApp/FreeTube/pull/5743, https://github.com/FreeTubeApp/FreeTube/pull/7349, https://github.com/FreeTubeApp/FreeTube/pull/5125, https://github.com/FreeTubeApp/FreeTube/pull/7338 -->
<!-- Agent instructions: Only write human-facing steps that explain how to verify the change while running this branch in dev mode. Include expected results and, when applicable, helpful console snippets for interactive verification. Do not include automated checks, commands, results, pass counts, or CI status. -->
1. On Linux, start the application in dev mode and play a video.
2. Use the desktop environment's media controls to pause, resume, and seek.
3. Confirm each action controls the active OpenTubeX video. The service-name replacement itself runs only during packaging.

## Additional context
<!-- Add any other context about the pull request here. -->
Electron does not currently expose an API for overriding Chromium's hardcoded MPRIS service name. See electron/electron#51601.
