### PR TITLE
fix(release): sync FlatPark sandbox permissions

### DIFF
--- a/.github/workflows/flatpark.yml
+++ b/.github/workflows/flatpark.yml
@@ -21,7 +21,7 @@ jobs:
   prepare:
     if: github.repository == 'OpenTubeX/OpenTubeX'
     runs-on: ubuntu-24.04
-    timeout-minutes: 20
+    timeout-minutes: 45
 
     outputs:
       needed: ${{ steps.duplicate.outputs.needed }}
@@ -140,11 +140,40 @@ jobs:
         path: opentubex
         persist-credentials: false
 
+    - name: Resolve official Flatpak packaging revision
+      if: steps.duplicate.outputs.needed == 'true'
+      id: flatpak
+      env:
+        GH_TOKEN: ${{ github.token }}
+        RELEASE_TAG: ${{ steps.release.outputs.tag }}
+      shell: bash
+      run: |
+        set -euo pipefail
+
+        for attempt in {1..120}; do
+          sha="$(gh api \
+            "repos/OpenTubeX/flatpak/commits/${RELEASE_TAG}" \
+            --jq .sha 2>/dev/null || true)"
+
+          if [[ "$sha" =~ ^[0-9a-f]{40}$ ]]; then
+            echo "sha=$sha" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
+          if (( attempt < 120 )); then
+            sleep 15
+          fi
+        done
+
+        echo "::error::The official Flatpak release ${RELEASE_TAG} was not published within 30 minutes."
+        exit 1
+
     - name: Check out official Flatpak packaging
       if: steps.duplicate.outputs.needed == 'true'
       uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
       with:
         repository: OpenTubeX/flatpak
+        ref: ${{ steps.flatpak.outputs.sha }}
         path: official-flatpak
         persist-credentials: false
 

--- a/.github/workflows/flatpark.yml
+++ b/.github/workflows/flatpark.yml
@@ -133,6 +133,21 @@ jobs:
 
         echo 'needed=true' >> "$GITHUB_OUTPUT"
 
+    - name: Check out OpenTubeX release automation
+      if: steps.duplicate.outputs.needed == 'true'
+      uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+      with:
+        path: opentubex
+        persist-credentials: false
+
+    - name: Check out official Flatpak packaging
+      if: steps.duplicate.outputs.needed == 'true'
+      uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+      with:
+        repository: OpenTubeX/flatpak
+        path: official-flatpak
+        persist-credentials: false
+
     - name: Check out FlatPark
       if: steps.duplicate.outputs.needed == 'true'
       uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
@@ -179,6 +194,9 @@ jobs:
           }' "$RELEASE_JSON" > "$resolver_json"
 
         node flatpark/scripts/update-pins.mjs "$manifest" "$metainfo" < "$resolver_json"
+        node opentubex/_scripts/syncFlatpakFinishArgs.mjs \
+          official-flatpak/org.opentubex.OpenTubeX.yml \
+          "$manifest"
 
         expected_changes="$(printf '%s\n' \
           'registry/org.opentubex.OpenTubeX/org.opentubex.OpenTubeX.metainfo.xml' \
@@ -208,6 +226,7 @@ jobs:
         install -Dm644 "$manifest" submission/manifest.yml
         install -Dm644 "$metainfo" submission/metainfo.xml
         git -C flatpark rev-parse HEAD > submission/base-sha
+        git -C official-flatpak rev-parse HEAD > submission/official-flatpak-sha
 
     - name: Store the prepared update
       if: steps.duplicate.outputs.needed == 'true'
@@ -399,10 +418,13 @@ jobs:
         fi
 
         body="${RUNNER_TEMP}/flatpark-pr-body.md"
+        official_flatpak_sha="$(< submission/official-flatpak-sha)"
         cat > "$body" <<EOF
         OpenTubeX published [${RELEASE_TAG}](https://github.com/${GITHUB_REPOSITORY}/releases/tag/${RELEASE_TAG}). This updates the pinned x86_64 and ARM64 portable archives and adds the AppStream release entry.
 
         FlatPark's current pin updater downloaded both release assets and calculated their SHA-256 hashes and sizes before the organization fork was updated.
+
+        The sandbox permissions were copied from OpenTubeX's [official Flatpak manifest](https://github.com/OpenTubeX/flatpak/blob/${official_flatpak_sha}/org.opentubex.OpenTubeX.yml) so both packages use the same release permissions.
         EOF
 
         pr_url="$(gh pr create \

--- a/_scripts/syncFlatpakFinishArgs.mjs
+++ b/_scripts/syncFlatpakFinishArgs.mjs
@@ -1,0 +1,73 @@
+import { readFile, writeFile } from 'node:fs/promises'
+import { pathToFileURL } from 'node:url'
+
+function findFinishArgs (manifest, label) {
+  const lines = manifest.split('\n')
+  const start = lines.findIndex((line) => /^finish-args:\s*$/.test(line))
+
+  if (start === -1) {
+    throw new Error(`${label} has no top-level finish-args block`)
+  }
+
+  let end = start + 1
+  while (end < lines.length && !/^\S/.test(lines[end])) {
+    end += 1
+  }
+
+  const args = []
+  for (const line of lines.slice(start + 1, end)) {
+    const match = line.match(/^\s+-\s+(--\S.*?)\s*$/)
+
+    if (match) {
+      args.push(match[1])
+    } else if (line.trim() !== '' && !line.trimStart().startsWith('#')) {
+      throw new Error(`${label} has an unsupported finish-args entry: ${line.trim()}`)
+    }
+  }
+
+  if (args.length === 0) {
+    throw new Error(`${label} has an empty finish-args block`)
+  }
+
+  return { args, end, lines, start }
+}
+
+export function syncFlatpakFinishArgs (officialManifest, flatparkManifest) {
+  const official = findFinishArgs(officialManifest, 'Official Flatpak manifest')
+  const flatpark = findFinishArgs(flatparkManifest, 'FlatPark manifest')
+  const finishArgs = official.args.map((arg) => `  - ${arg}`)
+
+  flatpark.lines.splice(
+    flatpark.start + 1,
+    flatpark.end - flatpark.start - 1,
+    ...finishArgs
+  )
+
+  return flatpark.lines.join('\n')
+}
+
+async function main () {
+  const [officialPath, flatparkPath] = process.argv.slice(2)
+
+  if (!officialPath || !flatparkPath) {
+    throw new Error('Usage: syncFlatpakFinishArgs.mjs OFFICIAL_MANIFEST FLATPARK_MANIFEST')
+  }
+
+  const [officialManifest, flatparkManifest] = await Promise.all([
+    readFile(officialPath, 'utf8'),
+    readFile(flatparkPath, 'utf8')
+  ])
+
+  const updatedManifest = syncFlatpakFinishArgs(
+    officialManifest,
+    flatparkManifest
+  )
+
+  if (updatedManifest !== flatparkManifest) {
+    await writeFile(flatparkPath, updatedManifest)
+  }
+}
+
+if (process.argv[1] && import.meta.url === pathToFileURL(process.argv[1]).href) {
+  await main()
+}

--- a/tests/unit/flatpark-finish-args.test.mjs
+++ b/tests/unit/flatpark-finish-args.test.mjs
@@ -1,0 +1,51 @@
+import assert from 'node:assert/strict'
+import test from 'node:test'
+
+import { syncFlatpakFinishArgs } from '../../_scripts/syncFlatpakFinishArgs.mjs'
+
+const officialManifest = `app-id: org.opentubex.OpenTubeX
+finish-args:
+  - --device=dri
+  - --own-name=org.mpris.MediaPlayer2.opentubex.*
+  - --unset-env=ELECTRON_RUN_AS_NODE
+modules: []
+`
+
+test('copies the official finish-args into the FlatPark manifest', () => {
+  const flatparkManifest = `id: org.opentubex.OpenTubeX
+finish-args:
+  # Permission for the currently published package.
+  - --own-name=org.mpris.MediaPlayer2.chromium.*
+  - --own-name=org.mpris.MediaPlayer2.opentubex
+  # This comment must not leave stale permission documentation behind.
+modules: []
+`
+
+  assert.equal(
+    syncFlatpakFinishArgs(officialManifest, flatparkManifest),
+    `id: org.opentubex.OpenTubeX
+finish-args:
+  - --device=dri
+  - --own-name=org.mpris.MediaPlayer2.opentubex.*
+  - --unset-env=ELECTRON_RUN_AS_NODE
+modules: []
+`
+  )
+})
+
+test('is idempotent when FlatPark already has the official permissions', () => {
+  assert.equal(
+    syncFlatpakFinishArgs(officialManifest, officialManifest),
+    officialManifest
+  )
+})
+
+test('rejects unsupported official finish-args structures', () => {
+  assert.throws(
+    () => syncFlatpakFinishArgs(
+      'finish-args:\n  socket: wayland\nmodules: []\n',
+      officialManifest
+    ),
+    /unsupported finish-args entry/
+  )
+})


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Make sure to follow the contributing guidelines. -->
<!-- Important note, we may remove your pull request if you do not use this provided PR template correctly. -->
<!-- Agent instructions: Preserve every heading, comment, and marker in this template. Never remove or rewrite the release-note-category:start/end, release-note:start/end, or release-note-image:start/end marker pairs. -->

## Pull Request Type
<!-- Please select what type of pull request this is: [x] -->
- [x] Bugfix
- [ ] Feature Implementation
- [ ] Documentation
- [ ] Other

## Related issue
<!-- Please link the issue your pull request is referring to. -->
<!-- If this pull request fully resolves the relevant issue, put "closes" before the issue number. -->
<!-- Example: "closes #123456". -->

None.

## Description
<!-- Please write a clear and concise description of what the pull request does. -->

FlatPark release PRs currently update OpenTubeX binaries without carrying sandbox-permission changes from the official Flatpak package. That would leave the next release without permission to own the newly branded MPRIS service.

This makes the OpenTubeX-owned release workflow copy the complete `finish-args` block from `OpenTubeX/flatpak` while preparing the static FlatPark update. It records the exact packaging commit and links it in the generated PR, so reviewers can verify the source. FlatPark itself does not fetch or execute content from another repository.

## Release note category
<!-- Select exactly one category. Every pull request must select one. -->
<!-- Select "Not noteworthy" when the pull request fixes a bug in or improves functionality that has not yet appeared in a stable release. -->
<!-- release-note-category:start -->
- [x] Not noteworthy
- [ ] Highlights
- [ ] More improvements
- [ ] Fixed bugs
<!-- release-note-category:end -->

## Release note
<!-- Required unless "Not noteworthy" is selected. -->
<!-- Write one concise, user-facing entry without a leading bullet. -->
<!-- release-note:start -->

<!-- release-note:end -->

## Release note images
<!-- Optional. Paste one or more Markdown images, HTML image tags, or dark/light <picture> elements here. -->
<!-- The release notes normalize the markup and limit images taller than 300 pixels. -->
<!-- Agent instructions:
For a noteworthy visible change, add media when it makes the change easier to understand. Prefer a still image unless motion is the point; recordings must use animated WebP.
After implementing a visible change, proactively capture the result and show the local media to the user for approval before uploading it or updating the pull request.
When the affected UI differs between dark and light themes, capturing both themes is required. A dark-only image is incomplete. Run `node _scripts/releaseNoteMedia.mjs --dark DARK_FILE --light LIGHT_FILE --alt "DESCRIPTION"`; GitHub will display the matching theme and use dark as the fallback. Use a single default-dark capture only when the light theme cannot be captured or looks identical.
Capture or crop to the smallest region that still makes the change clear. Do not include the full window when the affected component can be understood on its own.
Use English unless localization is the subject. Keep components at their normal dimensions and placement instead of resizing them to fill the frame.
Use deterministic local fixtures for visible remote images. Reusable avatar and thumbnail fixtures are available through `e2e/helpers/visual-fixtures.mjs`. Before capturing, verify that every visible image has loaded successfully (`complete === true` and `naturalWidth > 0`).
Inspect the final dark and light files for failed images, missing content, unrelated UI, awkward animation, and misleading layout. Omit media when it does not explain the change clearly.
For one dark capture, run `node _scripts/releaseNoteMedia.mjs FILE --alt "DESCRIPTION"`.
Check for personal information, tokens, private repository names, and unrelated desktop content before uploading. Uploaded media is public.
Keep capture-only scripts, test hooks, screenshots, and recordings out of commits. Remove them before committing unless the capture code is also a reusable regression test. Never commit generated release-note media.
Paste only the generated markup between the marker comments. Leave this section empty when media would not help.
-->
<!-- release-note-image:start -->

<!-- release-note-image:end -->

## Testing
<!-- How can reviewers verify that the PR produces correct results? -->
<!-- Please provide instructions so that others can ensure that your pull request would produce correct results. For examples see, https://github.com/FreeTubeApp/FreeTube/pull/5743, https://github.com/FreeTubeApp/FreeTube/pull/7349, https://github.com/FreeTubeApp/FreeTube/pull/5125, https://github.com/FreeTubeApp/FreeTube/pull/7338 -->
<!-- Agent instructions: Only write human-facing steps that explain how to verify the change while running this branch in dev mode. Include expected results and, when applicable, helpful console snippets for interactive verification. Do not include automated checks, commands, results, pass counts, or CI status. -->

Not applicable. This changes release automation and has no dev-mode user interface.

## Additional context
<!-- Add any other context about the pull request here. -->

The generated FlatPark PR contains only static manifest changes and identifies the exact official Flatpak packaging revision used.
