### PR TITLE
fix(comments): keep filtered thread lines connected

### DIFF
--- a/e2e/tests/offline/watch-page.spec.mjs
+++ b/e2e/tests/offline/watch-page.spec.mjs
@@ -4180,7 +4180,7 @@ test.describe('manual comment loading', () => {
     await expect(page.locator('.commentReplyContent .commentAuthor mark')).toHaveText(replyAuthor)
   })
 
-  test('ends filtered thread lines at the last reply from the creator', async ({ app, page }) => {
+  test('keeps creator-filtered thread lines connected without dangling stems', async ({ app, page }) => {
     await mockPlayableWatchPage(app, page, { creatorReply: true })
     await openMockedVideo(page)
 
@@ -4191,7 +4191,30 @@ test.describe('manual comment loading', () => {
 
     const thread = page.locator('.commentThread').first()
     await thread.locator('.commentReplyRootToggle button').click()
-    await expect(thread.locator('.commentReplyContent').first()).toBeVisible({ timeout: 30_000 })
+    const firstReply = thread.locator('.commentReplyContent').first()
+    await expect(firstReply).toBeVisible({ timeout: 30_000 })
+    await firstReply.evaluate(element => {
+      const branch = element.closest('.commentReplyBranch')
+      const app = document.querySelector('#app')?.__vue_app__
+      const find = vnode => {
+        if (vnode?.component?.subTree?.el === branch) return vnode.component
+        if (vnode?.component?.subTree) {
+          const match = find(vnode.component.subTree)
+          if (match) return match
+        }
+        if (Array.isArray(vnode?.children)) {
+          for (const child of vnode.children) {
+            const match = find(child)
+            if (match) return match
+          }
+        }
+        return null
+      }
+      const replyComponent = find(app?._container?._vnode)
+      if (!replyComponent) throw new Error('Unable to access the comment reply')
+      replyComponent.props.node.reply.hasReplyToken = true
+    })
+    await expect(firstReply.locator(':scope > .commentReplyChildStem')).toHaveCount(1)
 
     await page.getByRole('button', { name: 'Filter loaded comments' }).click()
     await page.getByRole('checkbox', { name: 'From creator' }).click()
@@ -4201,23 +4224,24 @@ test.describe('manual comment loading', () => {
     })
     await expect(filteredReplyThread).toHaveCount(1)
     await expect(filteredReplyThread.locator('.commentReplyContent')).toHaveCount(1)
+    await expect(filteredReplyThread.locator('.commentReplyChildStem')).toHaveCount(0)
 
-    const expectLineToEndAtLastConnector = () => expect.poll(() => filteredReplyThread.evaluate(element => {
+    const expectLineToEndAtLastConnectorStart = () => expect.poll(() => filteredReplyThread.evaluate(element => {
       const lineStyle = getComputedStyle(element, '::before')
       const lineEnd = element.getBoundingClientRect().bottom - Number.parseFloat(lineStyle.insetBlockEnd)
       const connectors = element.querySelectorAll(
         ':scope > .commentReplies > .commentReplyBranchRoot > .commentReplyConnector'
       )
-      const connectorEnd = connectors.item(connectors.length - 1).getBoundingClientRect().bottom
-      return Math.abs(lineEnd - connectorEnd)
+      const connectorStart = connectors.item(connectors.length - 1).getBoundingClientRect().top
+      return Math.abs(lineEnd - connectorStart)
     })).toBeLessThanOrEqual(0.5)
 
-    await expectLineToEndAtLastConnector()
+    await expectLineToEndAtLastConnectorStart()
     await page.evaluate(() => {
       const store = document.querySelector('#app').__vue_app__.config.globalProperties.$store
       return store.dispatch('updateUiScale', 125)
     })
-    await expectLineToEndAtLastConnector()
+    await expectLineToEndAtLastConnectorStart()
   })
 
   test('filters comments with timestamps and keeps highlighted timestamps clickable', async ({ app, page }) => {

--- a/src/renderer/components/CommentSection/CommentReply.vue
+++ b/src/renderer/components/CommentSection/CommentReply.vue
@@ -22,7 +22,7 @@
         {{ $t('Comments.Highlighted reply') }}
       </p>
       <span
-        v-if="node.children.length > 0 || (reply.dataType === 'local' && reply.hasReplyToken) || loadingReplyIds.has(reply.id)"
+        v-if="showReplyChildren"
         class="commentReplyChildStem"
         aria-hidden="true"
       />
@@ -160,7 +160,7 @@
       </p>
     </div>
     <div
-      v-if="node.children.length > 0 || (!filtering && ((reply.dataType === 'local' && reply.hasReplyToken) || loadingReplyIds.has(reply.id)))"
+      v-if="showReplyChildren"
       class="commentReplyChildren"
     >
       <CommentReply
@@ -323,6 +323,13 @@ function formatCommentTime(comment) {
 }
 
 const reply = props.node.reply
+const showReplyChildren = computed(() => {
+  return props.node.children.length > 0 ||
+    (!props.filtering && (
+      (reply.dataType === 'local' && reply.hasReplyToken) ||
+      props.loadingReplyIds.has(reply.id)
+    ))
+})
 const isPersonallyPinned = computed(() => props.personalPinnedCommentIds.has(reply.id))
 const personalPinActionLabel = computed(() => {
   return isPersonallyPinned.value

--- a/src/renderer/components/CommentSection/CommentSection.vue
+++ b/src/renderer/components/CommentSection/CommentSection.vue
@@ -780,7 +780,7 @@ function updateFilteredCommentThreadLine(element, filtering) {
     return
   }
 
-  const inset = element.getBoundingClientRect().bottom - lastConnector.getBoundingClientRect().bottom
+  const inset = element.getBoundingClientRect().bottom - lastConnector.getBoundingClientRect().top
   element.style.setProperty('--filtered-comment-thread-line-inset-block-end', `${inset}px`)
 }
 


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Make sure to follow the contributing guidelines. -->
<!-- Important note, we may remove your pull request if you do not use this provided PR template correctly. -->
<!-- Agent instructions: Preserve every heading, comment, and marker in this template. Never remove or rewrite the release-note-category:start/end, release-note:start/end, or release-note-image:start/end marker pairs. -->

## Pull Request Type
<!-- Please select what type of pull request this is: [x] -->
- [x] Bugfix
- [ ] Feature Implementation
- [ ] Documentation
- [ ] Other

## Related issue
<!-- Please link the issue your pull request is referring to. -->
<!-- If this pull request fully resolves the relevant issue, put "closes" before the issue number. -->
<!-- Example: "closes #123456". -->

Follow-up to #1011.

## Description
<!-- Please write a clear and concise description of what the pull request does. -->

Filtering comments could leave a dangling reply stem, and the parent thread line continued through the rounded reply connector.

This change shares the reply-stem and child-container visibility condition, then ends the filtered parent line where the final connector begins. The regression test covers the creator filter at 100% and 125% UI scale.

## Release note category
<!-- Select exactly one category. Every pull request must select one. -->
<!-- Select "Not noteworthy" when the pull request fixes a bug in or improves functionality that has not yet appeared in a stable release. -->
<!-- release-note-category:start -->
- [x] Not noteworthy
- [ ] Highlights
- [ ] More improvements
- [ ] Fixed bugs
<!-- release-note-category:end -->

## Release note
<!-- Required unless "Not noteworthy" is selected. -->
<!-- Write one concise, user-facing entry without a leading bullet. -->
<!-- release-note:start -->

<!-- release-note:end -->

## Release note images
<!-- Optional. Paste one or more Markdown images, HTML image tags, or dark/light <picture> elements here. -->
<!-- The release notes normalize the markup and limit images taller than 300 pixels. -->
<!-- Agent instructions:
For a noteworthy visible change, add media when it makes the change easier to understand. Prefer a still image unless motion is the point; recordings must use animated WebP.
After implementing a visible change, proactively capture the result and show the local media to the user for approval before uploading it or updating the pull request.
When the affected UI differs between dark and light themes, capturing both themes is required. A dark-only image is incomplete. Run `node _scripts/releaseNoteMedia.mjs --dark DARK_FILE --light LIGHT_FILE --alt "DESCRIPTION"`; GitHub will display the matching theme and use dark as the fallback. Use a single default-dark capture only when the light theme cannot be captured or looks identical.
Capture or crop to the smallest region that still makes the change clear. Do not include the full window when the affected component can be understood on its own.
Use English unless localization is the subject. Keep components at their normal dimensions and placement instead of resizing them to fill the frame.
Use deterministic local fixtures for visible remote images. Reusable avatar and thumbnail fixtures are available through `e2e/helpers/visual-fixtures.mjs`. Before capturing, verify that every visible image has loaded successfully (`complete === true` and `naturalWidth > 0`).
Inspect the final dark and light files for failed images, missing content, unrelated UI, awkward animation, and misleading layout. Omit media when it does not explain the change clearly.
Check for personal information, tokens, private repository names, and unrelated desktop content before uploading. Uploaded media is public.
Keep capture-only scripts, test hooks, screenshots, and recordings out of commits. Remove them before committing unless the capture code is also a reusable regression test. Never commit generated release-note media.
Paste only the generated markup between the marker comments. Leave this section empty when media would not help.
-->
<!-- release-note-image:start -->

<!-- release-note-image:end -->

## Testing
<!-- How can reviewers verify that the PR produces correct results? -->
<!-- Please provide instructions so that others can ensure that your pull request produces correct results. For examples see, https://github.com/FreeTubeApp/FreeTube/pull/5743, https://github.com/FreeTubeApp/FreeTube/pull/7349, https://github.com/FreeTubeApp/FreeTube/pull/5125, https://github.com/FreeTubeApp/FreeTube/pull/7338 -->
<!-- Agent instructions: Only write human-facing steps that explain how to verify the change while running this branch in dev mode. Include expected results and, when applicable, helpful console snippets for interactive verification. Do not include automated checks, commands, results, pass counts, or CI status. -->

1. Open a video whose comment thread contains a creator reply with more replies available.
2. Expand the thread and enable **Filter loaded comments → From creator**.
3. Confirm that the parent line turns into the reply connector without extending through its rounded corner, and that no line continues below the final visible reply.
4. Repeat at 125% UI scale.

## Additional context
<!-- Add any other context about the pull request here. -->

The visibility predicate is shared between the reply stem and its child container so the two cannot drift apart again.
