### PR TITLE
feat(player): add YouTube Music audio player and visualizer

### DIFF
--- a/e2e/README.md
+++ b/e2e/README.md
@@ -1,8 +1,8 @@
 # End-to-end tests
 
 Playwright drives the packed Electron app (`dist/main.js`) against an isolated,
-per-test userData directory. The local API (youtubei.js) is always used —
-Invidious is never exercised.
+per-test userData directory. Playback tests use the local API (youtubei.js).
+Offline metadata tests may use Invidious when they mock every request.
 
 ## Running locally
 

--- a/e2e/tests/offline/video-actions.spec.mjs
+++ b/e2e/tests/offline/video-actions.spec.mjs
@@ -964,7 +964,7 @@ test.describe('video downloads', () => {
     await expect(formatPrompt.getByRole('button', { name: /Local audio file/ })).toBeVisible()
     await formatPrompt.getByRole('button', { name: /Local audio file/ }).click()
     await expect(page).toHaveURL(new RegExp(`downloadId=${audioResult.id}`))
-    await expect(page.locator('.audioPoster')).toBeVisible()
+    await expect(page.locator('.musicAudioPlayer .musicAudioSurface')).toBeVisible()
     await page.getByRole('button', { name: 'Change Media Formats' }).click()
     await expect(formatPrompt.getByRole('button', { name: /Local audio file/ })).toHaveAttribute('aria-pressed', 'true')
     await formatPrompt.getByRole('button', { name: /Online video/ }).click()

--- a/e2e/tests/offline/watch-page.spec.mjs
+++ b/e2e/tests/offline/watch-page.spec.mjs
@@ -245,6 +245,17 @@ test('shows the audio-track player and custom visualizer for YouTube Music track
   await expect(video).toHaveCSS('opacity', '0')
   await expect(canvas).toBeVisible()
 
+  const artwork = surface.locator('.musicAudioArtwork')
+  const artworkSrc = await artwork.getAttribute('src')
+  await artwork.dispatchEvent('error')
+  await expect(artwork).toBeHidden()
+  await artwork.evaluate((element) => {
+    element.src = 'data:image/svg+xml,%3Csvg xmlns="http://www.w3.org/2000/svg" width="1" height="1"/%3E'
+  })
+  await expect(artwork).toBeVisible()
+  await artwork.evaluate((element, src) => { element.src = src }, artworkSrc)
+  await expect.poll(() => artwork.evaluate(element => element.naturalWidth)).toBeGreaterThan(0)
+
   await player.getByRole('button', { name: 'More settings' }).click({ force: true })
   const visualizerToggle = player.getByRole('button', { name: 'Music visualizer', exact: true })
   await expect(visualizerToggle).toBeVisible()
@@ -290,6 +301,9 @@ test('shows the audio-track player and custom visualizer for YouTube Music track
   const capturedStreamCount = await page.evaluate(() => (
     window.__musicVisualizerTestCapturedStreams.length
   ))
+  await expect.poll(() => page.evaluate(() => (
+    window.__musicVisualizerTestCapturedStreams.at(-1).getAudioTracks().length
+  ))).toBeGreaterThan(0)
   await page.evaluate(() => {
     const track = window.__musicVisualizerTestCapturedStreams.at(-1).getAudioTracks()[0]
     track.stop()

--- a/e2e/tests/offline/watch-page.spec.mjs
+++ b/e2e/tests/offline/watch-page.spec.mjs
@@ -9,6 +9,7 @@ import {
   demoPlayerResponse,
   routePostLiveMedia
 } from '../../helpers/media.mjs'
+import { fulfillVisualFixture } from '../../helpers/visual-fixtures.mjs'
 
 // These used to live in the network suite, gated on the live API. They all use
 // "Me at the zoo", whose page and comment pages are recorded, so they run
@@ -142,6 +143,281 @@ test('shows age-restricted and unlisted badges below the video title', async ({ 
   expect(badgeBounds).not.toBeNull()
   expect(titleBounds).not.toBeNull()
   expect(badgeBounds.y).toBeGreaterThanOrEqual(titleBounds.y + titleBounds.height)
+})
+
+async function mockMusicMediaType(app, page, musicVideoType) {
+  await mockPlayableWatchPage(app, page)
+  await page.route('https://i.ytimg.com/**', route => fulfillVisualFixture(route, 'video-thumbnail'))
+  await page.route(/\/youtubei\/v1\/player/, (route, request) => {
+    const requestBody = JSON.parse(request.postData() ?? '{}')
+    const videoId = requestBody.videoId ?? 'jNQXAC9IVRw'
+    const response = demoPlayerResponse(videoId)
+    response.microformat.playerMicroformatRenderer.category = 'Music'
+    if (requestBody.context?.client?.clientName === 'WEB_REMIX' && musicVideoType !== undefined) {
+      response.videoDetails.musicVideoType = musicVideoType
+    }
+    return route.fulfill({
+      status: 200,
+      contentType: 'application/json',
+      body: JSON.stringify(response)
+    })
+  })
+}
+
+async function countDistinctVisualizerFrames(canvas) {
+  return canvas.evaluate(async (element) => {
+    const signatures = new Set()
+    for (let sample = 0; sample < 5; sample++) {
+      await new Promise(resolve => setTimeout(resolve, 80))
+      const data = element.getContext('2d').getImageData(0, 0, element.width, element.height).data
+      let signature = 0
+      for (let index = 3; index < data.length; index += 4) {
+        signature = (signature + data[index] * index) >>> 0
+      }
+      signatures.add(signature)
+    }
+    return signatures.size
+  })
+}
+
+test('shows the audio-track player and custom visualizer for YouTube Music tracks', async ({ app, page, attachScreenshot }) => {
+  await mockMusicMediaType(app, page, 'MUSIC_VIDEO_TYPE_ATV')
+  await page.evaluate(async () => {
+    const NativeAudioContext = window.AudioContext
+    window.__musicVisualizerTestAudioContexts = []
+    window.__musicVisualizerTestCapturedStreams = []
+    window.AudioContext = new Proxy(NativeAudioContext, {
+      construct(Target, args) {
+        const context = Reflect.construct(Target, args)
+        const createAnalyser = context.createAnalyser.bind(context)
+        context.createAnalyser = (...analyserArgs) => {
+          const analyser = createAnalyser(...analyserArgs)
+          const readFrequencyData = analyser.getByteFrequencyData.bind(analyser)
+          let frame = 0
+          analyser.getByteFrequencyData = (data) => {
+            readFrequencyData(data)
+            if (context.state === 'running') {
+              data.fill(32 + (frame++ * 37) % 192)
+            }
+          }
+          return analyser
+        }
+        window.__musicVisualizerTestAudioContexts.push(context)
+        return context
+      }
+    })
+
+    const captureStream = HTMLMediaElement.prototype.captureStream
+    HTMLMediaElement.prototype.captureStream = function (...args) {
+      const sourceStream = captureStream.apply(this, args)
+      let capturedStream = sourceStream
+      if (window.__musicVisualizerTestCapturedStreams.length === 0) {
+        window.__musicVisualizerTestReplacementTrack = sourceStream.getAudioTracks()[0].clone()
+      } else {
+        capturedStream = new MediaStream(sourceStream.getVideoTracks())
+        setTimeout(() => {
+          const track = window.__musicVisualizerTestReplacementTrack
+          capturedStream.addTrack(track)
+          capturedStream.dispatchEvent(new MediaStreamTrackEvent('addtrack', { track }))
+        }, 100)
+      }
+      window.__musicVisualizerTestCapturedStreams.push(capturedStream)
+      return capturedStream
+    }
+
+    const store = document.querySelector('#app').__vue_app__.config.globalProperties.$store
+    await Promise.all([
+      store.dispatch('updateReducedMotion', 'off'),
+      store.dispatch('updateUiScale', 125),
+    ])
+  })
+
+  const video = await openMockedVideo(page)
+  const player = page.locator(`${activeTab} .ftVideoPlayer`)
+  const surface = player.locator('.musicAudioSurface')
+  const canvas = surface.locator('.musicVisualizerCanvas')
+
+  await expect(player).toHaveClass(/musicAudioPlayer/)
+  await expect(surface).toBeVisible()
+  await expect(surface.locator('.musicAudioArtwork')).toBeVisible()
+  await expect(surface.locator('.musicAudioTitle')).toHaveText(/\S/)
+  await expect(surface.locator('.musicAudioArtist')).toHaveText(/\S/)
+  await expect(video).toHaveCSS('opacity', '0')
+  await expect(canvas).toBeVisible()
+
+  await player.getByRole('button', { name: 'More settings' }).click({ force: true })
+  const visualizerToggle = player.getByRole('button', { name: 'Music visualizer', exact: true })
+  await expect(visualizerToggle).toBeVisible()
+  await expect(visualizerToggle).toHaveAttribute('aria-pressed', 'true')
+  await visualizerToggle.click()
+  await expect(visualizerToggle).toHaveAttribute('aria-pressed', 'false')
+  await expect(canvas).toBeHidden()
+  await visualizerToggle.click()
+  await expect(visualizerToggle).toHaveAttribute('aria-pressed', 'true')
+  await expect(canvas).toBeVisible()
+  await page.keyboard.press('Escape')
+
+  const seekBar = player.locator('.shaka-seek-bar-container')
+  await player.hover()
+  await seekBar.hover({ position: { x: 120, y: 4 } })
+  await expect(player.locator('.shaka-player-ui-thumbnail-image-container')).toBeHidden()
+  await expect(player.locator('.shaka-player-ui-thumbnail-time-container')).toBeVisible()
+
+  await expect.poll(() => canvas.evaluate((element) => {
+    const context = element.getContext('2d')
+    return context && context.getImageData(0, 0, element.width, element.height)
+      .data.some((channel, index) => index % 4 === 3 && channel > 0)
+  }), { timeout: 10_000 }).toBe(true)
+  await expect.poll(() => countDistinctVisualizerFrames(canvas)).toBeGreaterThan(1)
+
+  const playbackTimeBeforeSuspension = await video.evaluate(element => element.currentTime)
+  await page.evaluate(async () => {
+    await window.__musicVisualizerTestAudioContexts.at(-1).suspend()
+  })
+  await expect.poll(() => page.evaluate(() => (
+    window.__musicVisualizerTestAudioContexts.at(-1).state
+  )), {
+    timeout: 5_000,
+    message: 'visualizer should recover when its audio context is suspended while media keeps playing'
+  }).toBe('running')
+  await expect.poll(() => video.evaluate(element => element.currentTime))
+    .toBeGreaterThan(playbackTimeBeforeSuspension)
+  await expect.poll(() => countDistinctVisualizerFrames(canvas)).toBeGreaterThan(1)
+
+  const audioContextCount = await page.evaluate(() => (
+    window.__musicVisualizerTestAudioContexts.length
+  ))
+  const capturedStreamCount = await page.evaluate(() => (
+    window.__musicVisualizerTestCapturedStreams.length
+  ))
+  await page.evaluate(() => {
+    const track = window.__musicVisualizerTestCapturedStreams.at(-1).getAudioTracks()[0]
+    track.stop()
+    track.dispatchEvent(new Event('ended'))
+  })
+  await expect.poll(() => page.evaluate(() => (
+    window.__musicVisualizerTestCapturedStreams.length
+  )), {
+    message: 'visualizer should capture the media element again after its audio track ends'
+  }).toBeGreaterThan(capturedStreamCount)
+  await expect.poll(() => page.evaluate(() => (
+    window.__musicVisualizerTestAudioContexts.length
+  )), {
+    message: 'visualizer should rebuild after its captured audio track ends'
+  }).toBeGreaterThan(audioContextCount)
+  await expect.poll(() => countDistinctVisualizerFrames(canvas)).toBeGreaterThan(1)
+
+  await attachScreenshot('YouTube Music audio-track player')
+
+  const [playerBounds, artworkBounds] = await Promise.all([
+    player.boundingBox(),
+    surface.locator('.musicAudioArtwork').boundingBox(),
+  ])
+  expect(playerBounds).not.toBeNull()
+  expect(artworkBounds).not.toBeNull()
+  expect(artworkBounds.x).toBeGreaterThanOrEqual(playerBounds.x)
+  expect(artworkBounds.y).toBeGreaterThanOrEqual(playerBounds.y)
+  expect(artworkBounds.x + artworkBounds.width)
+    .toBeLessThanOrEqual(playerBounds.x + playerBounds.width)
+  expect(artworkBounds.y + artworkBounds.height)
+    .toBeLessThanOrEqual(playerBounds.y + playerBounds.height)
+
+  await video.evaluate(element => element.pause())
+  await expect.poll(() => canvas.evaluate((element) => {
+    const context = element.getContext('2d')
+    return context && context.getImageData(0, 0, element.width, element.height)
+      .data.some((channel, index) => index % 4 === 3 && channel > 0)
+  })).toBe(false)
+
+  await page.evaluate(async () => {
+    const store = document.querySelector('#app').__vue_app__.config.globalProperties.$store
+    await store.dispatch('updateReducedMotion', 'on')
+  })
+  await video.evaluate(element => element.play())
+  await expect(canvas).toBeHidden()
+})
+
+for (const { label, musicVideoType } of [
+  { label: 'official music videos', musicVideoType: 'MUSIC_VIDEO_TYPE_OMV' },
+  { label: 'Music category videos without a YouTube Music type', musicVideoType: undefined },
+]) {
+  test(`keeps ${label} in the video player`, async ({ app, page }) => {
+    await mockMusicMediaType(app, page, musicVideoType)
+    const video = await openMockedVideo(page)
+    const player = page.locator(`${activeTab} .ftVideoPlayer`)
+
+    await expect(player).not.toHaveClass(/musicAudioPlayer/)
+    await expect(player.locator('.musicAudioSurface')).toHaveCount(0)
+    await expect(video).toHaveCSS('opacity', '1')
+  })
+}
+
+test('detects Invidious audio tracks from artist topic channels', async ({ page }) => {
+  const instanceUrl = 'https://invidious.test'
+  await page.route(/^https?:\/\//, route => route.abort())
+  await page.route(`${instanceUrl}/api/v1/videos/**`, route => route.fulfill({
+    json: {
+      title: 'Invidious audio track',
+      viewCount: 1,
+      paid: false,
+      subCountText: '1',
+      likeCount: 1,
+      dislikeCount: 0,
+      genre: 'Music',
+      keywords: [],
+      author: 'Example Artist - Topic',
+      authorId: 'UC-example-artist-topic',
+      authorThumbnails: [],
+      description: '',
+      descriptionHtml: '',
+      published: 1_700_000_000,
+      recommendedVideos: [],
+      liveNow: false,
+      premiereTimestamp: 0,
+      isFamilyFriendly: true,
+      isPostLiveDvr: false,
+      isListed: true,
+      captions: [],
+      videoThumbnails: [{ url: '/vi/jNQXAC9IVRw/hqdefault.jpg', width: 480, height: 360 }],
+    }
+  }))
+  await page.evaluate(async (url) => {
+    const store = document.querySelector('#app').__vue_app__.config.globalProperties.$store
+    await Promise.all([
+      store.dispatch('updateBackendPreference', 'invidious'),
+      store.dispatch('updateDefaultInvidiousInstance', url),
+      store.dispatch('updateHideChapters', true),
+    ])
+  }, instanceUrl)
+
+  await page.locator(sel.searchInput).fill('https://www.youtube.com/watch?v=jNQXAC9IVRw')
+  await page.locator(sel.searchInput).press('Enter')
+  await expect(page).toHaveURL(/#\/watch\/jNQXAC9IVRw/)
+  await expect(page.locator('.infoArea .videoTitle')).toHaveText('Invidious audio track')
+  const watchView = await watchViewHandle(page)
+  await expect.poll(() => watchView.evaluate(view => view.musicMediaType)).toBe('audioTrack')
+  await watchView.dispose()
+})
+
+test('updates boolean settings from the player options', async ({ app, page }) => {
+  await mockPlayableWatchPage(app, page)
+  await page.evaluate(async () => {
+    const store = document.querySelector('#app').__vue_app__.config.globalProperties.$store
+    await store.dispatch('updateShowSkipSilenceButton', true)
+  })
+  await openMockedVideo(page)
+
+  const player = page.locator(`${activeTab} .ftVideoPlayer`)
+  await player.getByRole('button', { name: 'More settings' }).click({ force: true })
+  const ambientMode = player.getByRole('button', { name: 'Ambient Mode', exact: true })
+  const skipSilence = player.getByRole('button', { name: 'Skip Silence', exact: true })
+
+  await expect(ambientMode).toHaveAttribute('aria-pressed', 'false')
+  await ambientMode.click()
+  await expect(ambientMode).toHaveAttribute('aria-pressed', 'true')
+  await expect(skipSilence).toHaveAttribute('aria-pressed', 'false')
+  await skipSilence.click()
+  await expect(skipSilence).toHaveAttribute('aria-pressed', 'true')
 })
 
 for (const { name, options, expectedCount } of [

--- a/src/renderer/components/PlayerSettings/PlayerSettings.vue
+++ b/src/renderer/components/PlayerSettings/PlayerSettings.vue
@@ -93,6 +93,13 @@
           :tooltip="t('Tooltips.Player Settings.Ambient Mode')"
           @change="updateAmbientMode"
         />
+        <FtToggleSwitch
+          :label="t('Settings.Player Settings.Music Visualizer')"
+          :compact="true"
+          :default-value="musicVisualizer"
+          setting-key="musicVisualizer"
+          @change="updateMusicVisualizer"
+        />
       </div>
       <div class="switchColumn">
         <FtToggleSwitch
@@ -750,6 +757,16 @@ const ambientMode = computed(() => store.getters.getAmbientMode)
  */
 function updateAmbientMode(value) {
   store.dispatch('updateAmbientMode', value)
+}
+
+/** @type {import('vue').ComputedRef<boolean>} */
+const musicVisualizer = computed(() => store.getters.getMusicVisualizer)
+
+/**
+ * @param {boolean} value
+ */
+function updateMusicVisualizer(value) {
+  store.dispatch('updateMusicVisualizer', value)
 }
 
 /** @type {import('vue').ComputedRef<boolean>} */

--- a/src/renderer/components/ft-shaka-video-player/ft-shaka-video-player.css
+++ b/src/renderer/components/ft-shaka-video-player/ft-shaka-video-player.css
@@ -37,18 +37,155 @@
     transform 200ms ease-out;
 }
 
-.audioPoster {
+.player.audioOnly,
+.player.musicAudioTrack {
+  opacity: 0;
+}
+
+.musicAudioSurface {
   position: absolute;
   z-index: 0;
   inset: 0;
-  inline-size: 100%;
-  block-size: 100%;
-  object-fit: contain;
+  display: grid;
+  place-items: center;
+  overflow: hidden;
+  color: #fff;
+  background: #080808;
   pointer-events: none;
 }
 
-.player.audioOnly {
-  opacity: 0;
+.musicAudioBackdrop,
+.musicAudioShade,
+.musicVisualizerCanvas {
+  position: absolute;
+  inset: 0;
+  inline-size: 100%;
+  block-size: 100%;
+}
+
+.musicAudioBackdrop {
+  object-fit: cover;
+  opacity: 0.42;
+  filter: blur(30px) saturate(1.15);
+  transform: scale(1.14);
+}
+
+.musicAudioShade {
+  background:
+    radial-gradient(circle at 50% 35%, transparent 0, rgb(0 0 0 / 24%) 55%, rgb(0 0 0 / 70%) 100%),
+    linear-gradient(to bottom, rgb(0 0 0 / 12%), rgb(0 0 0 / 62%));
+}
+
+.musicVisualizerCanvas {
+  inset-block: auto 11%;
+  block-size: 42%;
+  opacity: 0.48;
+  mask-image: linear-gradient(to bottom, transparent, #000 28%, #000);
+}
+
+.musicAudioContent {
+  position: relative;
+  z-index: 1;
+  display: flex;
+  align-items: center;
+  gap: clamp(20px, 4vi, 56px);
+  box-sizing: border-box;
+  inline-size: min(82%, 980px);
+  max-block-size: 68%;
+  margin-block-end: clamp(42px, 8%, 88px);
+}
+
+.musicAudioArtwork {
+  flex: none;
+  inline-size: clamp(120px, 28vi, 340px);
+  max-inline-size: 46%;
+  max-block-size: min(48vb, 340px);
+  aspect-ratio: 1;
+  border-radius: calc(12px * var(--ui-roundness));
+  object-fit: contain;
+  background: rgb(0 0 0 / 32%);
+  box-shadow: 0 18px 48px rgb(0 0 0 / 38%);
+}
+
+.musicAudioMetadata {
+  min-inline-size: 0;
+  text-shadow: 0 2px 12px rgb(0 0 0 / 85%);
+}
+
+.musicAudioTitle {
+  display: -webkit-box;
+  overflow: hidden;
+  font-size: clamp(20px, 3.1vi, 42px);
+  font-weight: 650;
+  line-height: 1.14;
+  -webkit-box-orient: vertical;
+  -webkit-line-clamp: 3;
+}
+
+.musicAudioArtist {
+  overflow: hidden;
+  margin-block-start: clamp(8px, 1.3vi, 16px);
+  color: rgb(255 255 255 / 78%);
+  font-size: clamp(14px, 1.8vi, 23px);
+  line-height: 1.35;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.ftVideoPlayer.scrollMiniPlayer .musicAudioContent {
+  justify-content: center;
+  inline-size: 100%;
+  max-block-size: 76%;
+  margin-block-end: 0;
+}
+
+.ftVideoPlayer.scrollMiniPlayer .musicAudioArtwork {
+  inline-size: auto;
+  block-size: 74%;
+  max-inline-size: 74%;
+  max-block-size: 74%;
+}
+
+html[data-reduced-motion='reduce'] .musicVisualizerCanvas {
+  display: none !important;
+}
+
+.ftVideoPlayer.scrollMiniPlayer .musicAudioMetadata,
+.ftVideoPlayer.scrollMiniPlayer .musicVisualizerCanvas {
+  display: none;
+}
+
+.ftVideoPlayer.musicAudioPlayer :deep(.shaka-player-ui-thumbnail-image-container) {
+  display: none;
+}
+
+@media (width <= 560px) {
+  .musicAudioContent {
+    flex-direction: column;
+    justify-content: center;
+    gap: 12px;
+    inline-size: 82%;
+    max-block-size: 76%;
+    margin-block-end: 48px;
+    text-align: center;
+  }
+
+  .musicAudioArtwork {
+    inline-size: auto;
+    block-size: min(42vi, 42vb);
+    max-inline-size: 60%;
+    max-block-size: 56%;
+  }
+
+  .musicAudioTitle {
+    font-size: clamp(16px, 5vi, 24px);
+    -webkit-line-clamp: 2;
+  }
+
+  .musicAudioArtist {
+    margin-block-start: 4px;
+    font-size: clamp(13px, 3.8vi, 18px);
+  }
 }
 
 /*

--- a/src/renderer/components/ft-shaka-video-player/ft-shaka-video-player.js
+++ b/src/renderer/components/ft-shaka-video-player/ft-shaka-video-player.js
@@ -22,6 +22,7 @@ import { CopyVideoUrlButton, setCopyVideoUrlContext } from './player-components/
 import { FullWindowButton } from './player-components/FullWindowButton'
 import { LegacyQualitySelection } from './player-components/LegacyQualitySelection'
 import { LoopButton, setLoopButtonContext } from './player-components/LoopButton'
+import { MusicVisualizerButton } from './player-components/MusicVisualizerButton'
 import { QuickPlaybackRateBar, setQuickPlaybackRateBarContext } from './player-components/QuickPlaybackRateBar'
 import { ScreenshotButton } from './player-components/ScreenshotButton'
 import { SkipSilenceButton } from './player-components/SkipSilenceButton'
@@ -69,6 +70,7 @@ import { addOverlayScrollbars, removeOverlayScrollbars } from '../../helpers/ove
 import { isReducedMotionEnabled } from '../../helpers/reducedMotion'
 import { appendTimestamp, getInvidiousVideoUrl, getYoutubeVideoShareUrl } from '../../helpers/share'
 import { MANIFEST_TYPE_SABR } from '../../helpers/player/SabrManifestParser'
+import { MUSIC_MEDIA_TYPE } from '../../helpers/player/musicMediaType'
 import { resolveSegmentPrefetchLimit } from '../../helpers/player/segmentPrefetch'
 import { AUTO_QUALITY_FALLBACK, streamsSupportAutoQuality } from '../../helpers/player/autoQuality'
 import { setupSabrScheme } from '../../helpers/player/SabrSchemePlugin'
@@ -104,6 +106,7 @@ import {
 } from '../../helpers/player/caption-settings'
 import { useAmbientMode } from './opentubex/useAmbientMode'
 import { useAutoPictureInPicture } from './opentubex/useAutoPictureInPicture'
+import { useMusicVisualizer } from './opentubex/useMusicVisualizer'
 import { useScrollMiniPlayer } from './opentubex/useScrollMiniPlayer'
 import { useSilenceSkipping } from './opentubex/useSilenceSkipping'
 import { useSleepTimer } from './opentubex/useSleepTimer'
@@ -309,6 +312,15 @@ export default defineComponent({
     title: {
       type: String,
       default: ''
+    },
+    artist: {
+      type: String,
+      default: ''
+    },
+    musicMediaType: {
+      type: String,
+      default: MUSIC_MEDIA_TYPE.UNKNOWN,
+      validator: value => Object.values(MUSIC_MEDIA_TYPE).includes(value)
     },
     thumbnail: {
       type: String,
@@ -1265,6 +1277,28 @@ export default defineComponent({
       return store.getters.getAmbientMode
     })
 
+    const musicAudioTrack = computed(() => {
+      return props.musicMediaType === MUSIC_MEDIA_TYPE.AUDIO_TRACK
+    })
+
+    const audioPlayerMode = computed(() => {
+      return props.format === 'audio' || musicAudioTrack.value
+    })
+
+    const musicVisualizer = computed(() => {
+      return store.getters.getMusicVisualizer
+    })
+
+    const musicVisualizerEnabled = computed(() => {
+      return audioPlayerMode.value && musicVisualizer.value
+    })
+
+    function hideBrokenMusicImage(event) {
+      if (event.currentTarget instanceof HTMLImageElement) {
+        event.currentTarget.hidden = true
+      }
+    }
+
     const skipSilence = computed(() => {
       return store.getters.getTabSkipSilence(mediaTabId)
     })
@@ -1351,6 +1385,11 @@ export default defineComponent({
     /** @param {boolean} value */
     function updateAmbientMode(value) {
       store.dispatch('updateAmbientMode', value)
+    }
+
+    /** @param {boolean} value */
+    function updateMusicVisualizer(value) {
+      store.dispatch('updateMusicVisualizer', value)
     }
 
     /** @param {boolean} value */
@@ -4055,6 +4094,7 @@ export default defineComponent({
           ...(props.chapters.length > 0 ? ['ft_chapters'] : []),
           'ft_skip_silence',
           'ft_voice_over_translation',
+          'ft_music_visualizer',
           'ft_ambient_mode',
           'ft_video_zoom',
           'ft_loop',
@@ -4103,6 +4143,7 @@ export default defineComponent({
           'ft_sleep_timer',
           'ft_skip_silence',
           'ft_voice_over_translation',
+          'ft_music_visualizer',
           'ft_ambient_mode',
           'ft_video_zoom',
           'ft_loop',
@@ -4133,6 +4174,10 @@ export default defineComponent({
 
       if (props.format === 'audio' || useVrMode.value) {
         removeFromArrayIfExists(uiConfig.overflowMenuButtons, 'ft_ambient_mode')
+      }
+
+      if (!audioPlayerMode.value) {
+        removeFromArrayIfExists(uiConfig.overflowMenuButtons, 'ft_music_visualizer')
       }
 
       if (!videoZoomPossible.value) {
@@ -5907,6 +5952,19 @@ export default defineComponent({
         !scrollMiniPlayerActive.value
     })
 
+    const musicVisualizerActive = computed(() => {
+      return musicVisualizerEnabled.value &&
+        isActiveTab.value &&
+        !scrollMiniPlayerActive.value &&
+        !playerPaused.value
+    })
+
+    const { musicVisualizerCanvas } = useMusicVisualizer({
+      active: musicVisualizerActive,
+      video,
+      sourceKey: () => `${props.videoId}:${props.playbackSourceKey}`,
+    })
+
     const fullscreenAmbientBarsVisible = computed(() => {
       const contentAspectRatio = annotationVideoAspectRatio.value
       const elementWidth = videoElementWidth.value
@@ -7579,6 +7637,27 @@ export default defineComponent({
       }
 
       registerOwnElement(shakaOverflowMenu, 'ft_ambient_mode', new AmbientModeButtonFactory())
+    }
+
+    function registerMusicVisualizerButton() {
+      /** @implements {shaka.extern.IUIElement.Factory} */
+      class MusicVisualizerButtonFactory {
+        create(rootElement, controls) {
+          return new MusicVisualizerButton(
+            musicVisualizer,
+            updateMusicVisualizer,
+            events,
+            rootElement,
+            controls
+          )
+        }
+      }
+
+      registerOwnElement(
+        shakaOverflowMenu,
+        'ft_music_visualizer',
+        new MusicVisualizerButtonFactory()
+      )
     }
 
     function registerVideoZoomSelection() {
@@ -9570,6 +9649,7 @@ export default defineComponent({
       registerChapterOverlayButton()
       registerAutoplayToggle()
       registerAmbientModeButton()
+      registerMusicVisualizerButton()
       registerVideoZoomSelection()
       registerSkipSilenceButton()
       registerVoiceOverTranslationButton()
@@ -10502,6 +10582,11 @@ export default defineComponent({
       ambientFullscreenCanvas,
       ambientLayoutCanvas,
       ambientModeVisible,
+      audioPlayerMode,
+      musicAudioTrack,
+      hideBrokenMusicImage,
+      musicVisualizerCanvas,
+      musicVisualizerEnabled,
       fullscreenAmbientBarsVisible,
       captionCssVariables,
       captionPlayerVariables,

--- a/src/renderer/components/ft-shaka-video-player/ft-shaka-video-player.js
+++ b/src/renderer/components/ft-shaka-video-player/ft-shaka-video-player.js
@@ -1299,6 +1299,12 @@ export default defineComponent({
       }
     }
 
+    function showMusicImage(event) {
+      if (event.currentTarget instanceof HTMLImageElement) {
+        event.currentTarget.hidden = false
+      }
+    }
+
     const skipSilence = computed(() => {
       return store.getters.getTabSkipSilence(mediaTabId)
     })
@@ -8151,6 +8157,7 @@ export default defineComponent({
       shakaContextMenu.registerElement('ft_loop', null)
       shakaContextMenu.registerElement('ft_stats', null)
       shakaOverflowMenu.registerElement('ft_ambient_mode', null)
+      shakaOverflowMenu.registerElement('ft_music_visualizer', null)
       shakaOverflowMenu.registerElement('ft_video_zoom', null)
       shakaOverflowMenu.registerElement('ft_skip_silence', null)
       shakaOverflowMenu.registerElement('ft_voice_over_translation', null)
@@ -10585,6 +10592,7 @@ export default defineComponent({
       audioPlayerMode,
       musicAudioTrack,
       hideBrokenMusicImage,
+      showMusicImage,
       musicVisualizerCanvas,
       musicVisualizerEnabled,
       fullscreenAmbientBarsVisible,

--- a/src/renderer/components/ft-shaka-video-player/ft-shaka-video-player.vue
+++ b/src/renderer/components/ft-shaka-video-player/ft-shaka-video-player.vue
@@ -143,6 +143,7 @@
           class="musicAudioBackdrop"
           :src="thumbnail"
           alt=""
+          @load="showMusicImage"
           @error="hideBrokenMusicImage"
         >
         <div class="musicAudioShade" />
@@ -157,6 +158,7 @@
             class="musicAudioArtwork"
             :src="thumbnail"
             alt=""
+            @load="showMusicImage"
             @error="hideBrokenMusicImage"
           >
           <div

--- a/src/renderer/components/ft-shaka-video-player/ft-shaka-video-player.vue
+++ b/src/renderer/components/ft-shaka-video-player/ft-shaka-video-player.vue
@@ -54,7 +54,8 @@
         fullWindow: fullWindowEnabled,
         shortsPlayer,
         shortsPaused: shortsPaused && hasLoaded,
-        sixteenByNine: (format === 'audio' || forceAspectRatio) && !fullWindowEnabled && !scrollMiniPlayerActive,
+        sixteenByNine: (audioPlayerMode || forceAspectRatio) && !fullWindowEnabled && !scrollMiniPlayerActive,
+        musicAudioPlayer: audioPlayerMode,
         scrollMiniPlayer: scrollMiniPlayerActive,
         scrollMiniPlayerAnimating,
         scrollMiniPlayerDismissed,
@@ -109,14 +110,14 @@
       <video
         ref="video"
         class="player"
-        :class="{ audioOnly: format === 'audio' }"
+        :class="{ audioOnly: format === 'audio', musicAudioTrack }"
         :style="videoZoomStyle"
         preload="auto"
         crossorigin="anonymous"
         playsinline
         :autoplay="autoplayVideos || (!suppressInitialAutoplay && shortsPlayer && isActiveTab) ? true : null"
         :loop="shortsPlayer && loopShorts"
-        :poster="format === 'audio' || showPoster ? thumbnail : null"
+        :poster="!audioPlayerMode && showPoster ? thumbnail : null"
         @play="handlePlay"
         @playing="handlePlaying"
         @waiting="handleWaiting"
@@ -132,13 +133,51 @@
         @enterpictureinpicture="handleEnterPictureInPicture"
         @leavepictureinpicture="handleLeavePictureInPicture"
       />
-      <img
-        v-if="format === 'audio' && thumbnail"
-        class="audioPoster"
-        :src="thumbnail"
-        alt=""
+      <div
+        v-if="audioPlayerMode"
+        class="musicAudioSurface"
         aria-hidden="true"
       >
+        <img
+          v-if="thumbnail"
+          class="musicAudioBackdrop"
+          :src="thumbnail"
+          alt=""
+          @error="hideBrokenMusicImage"
+        >
+        <div class="musicAudioShade" />
+        <canvas
+          v-show="musicVisualizerEnabled && !scrollMiniPlayerActive"
+          ref="musicVisualizerCanvas"
+          class="musicVisualizerCanvas"
+        />
+        <div class="musicAudioContent">
+          <img
+            v-if="thumbnail"
+            class="musicAudioArtwork"
+            :src="thumbnail"
+            alt=""
+            @error="hideBrokenMusicImage"
+          >
+          <div
+            v-if="title || artist"
+            class="musicAudioMetadata"
+          >
+            <div
+              v-if="title"
+              class="musicAudioTitle"
+            >
+              {{ title }}
+            </div>
+            <div
+              v-if="artist"
+              class="musicAudioArtist"
+            >
+              {{ artist }}
+            </div>
+          </div>
+        </div>
+      </div>
       <div
         v-if="voiceOverTranslationState === 'loading'"
         class="voiceOverTranslationProgress shaka-no-propagation"

--- a/src/renderer/components/ft-shaka-video-player/opentubex/useMusicVisualizer.js
+++ b/src/renderer/components/ft-shaka-video-player/opentubex/useMusicVisualizer.js
@@ -1,0 +1,359 @@
+import { nextTick, onBeforeUnmount, onMounted, ref, watch } from 'vue'
+
+const FFT_SIZE = 256
+const MAX_DEVICE_PIXEL_RATIO = 2
+const MIN_FRAME_INTERVAL_MS = 1000 / 30
+
+/**
+ * Draws a spectrum from the media element's captured audio without changing
+ * the element's existing audio output path.
+ * @param {object} options
+ * @param {import('vue').ComputedRef<boolean>} options.active
+ * @param {import('vue').Ref<HTMLVideoElement | null>} options.video
+ * @param {import('vue').WatchSource<unknown>} options.sourceKey
+ */
+export function useMusicVisualizer({ active, video, sourceKey }) {
+  /** @type {import('vue').Ref<HTMLCanvasElement | null>} */
+  const musicVisualizerCanvas = ref(null)
+
+  /** @type {AudioContext | null} */
+  let audioContext = null
+  /** @type {AnalyserNode | null} */
+  let analyser = null
+  /** @type {MediaStreamAudioSourceNode | null} */
+  let streamSource = null
+  /** @type {MediaStream | null} */
+  let capturedStream = null
+  /** @type {ResizeObserver | null} */
+  let resizeObserver = null
+  /** @type {MutationObserver | null} */
+  let reducedMotionObserver = null
+  /** @type {number | null} */
+  let animationFrame = null
+  /** @type {Uint8Array<ArrayBuffer> | null} */
+  let frequencyData = null
+  let lastFrameTime = 0
+  let hasLoggedVisualizerError = false
+
+  function logVisualizerError(error) {
+    if (!hasLoggedVisualizerError) {
+      console.warn('Unable to run the music visualizer', error)
+      hasLoggedVisualizerError = true
+    }
+  }
+
+  function runVisualizerTask(task) {
+    task.catch(logVisualizerError)
+  }
+
+  function canDraw() {
+    return active.value &&
+      !document.hidden &&
+      document.documentElement.dataset.reducedMotion !== 'reduce' &&
+      video.value?.paused === false
+  }
+
+  function resizeCanvas() {
+    const canvas = musicVisualizerCanvas.value
+    if (!canvas) {
+      return
+    }
+
+    const ratio = Math.min(window.devicePixelRatio || 1, MAX_DEVICE_PIXEL_RATIO)
+    const width = Math.max(1, Math.round(canvas.clientWidth * ratio))
+    const height = Math.max(1, Math.round(canvas.clientHeight * ratio))
+
+    if (canvas.width !== width || canvas.height !== height) {
+      canvas.width = width
+      canvas.height = height
+    }
+  }
+
+  function clearCanvas() {
+    const canvas = musicVisualizerCanvas.value
+    const context = canvas?.getContext('2d')
+    if (canvas && context) {
+      context.clearRect(0, 0, canvas.width, canvas.height)
+    }
+  }
+
+  function stopDrawing() {
+    if (animationFrame !== null) {
+      cancelAnimationFrame(animationFrame)
+      animationFrame = null
+    }
+
+    lastFrameTime = 0
+    clearCanvas()
+
+    if (audioContext?.state === 'running') {
+      runVisualizerTask(audioContext.suspend())
+    }
+  }
+
+  function hasLiveCapturedAudioTrack() {
+    return capturedStream?.getAudioTracks().some(track => track.readyState === 'live') === true
+  }
+
+  function handleCapturedAudioTrackEnded() {
+    runVisualizerTask(disposeAudioGraph().then(startDrawing))
+  }
+
+  function handleCapturedStreamAddTrack(event) {
+    if (event.track.kind !== 'audio') {
+      return
+    }
+
+    event.track.addEventListener('ended', handleCapturedAudioTrackEnded)
+    if (!audioContext) {
+      runVisualizerTask(startDrawing())
+    }
+  }
+
+  function handleCapturedStreamRemoveTrack(event) {
+    event.track.removeEventListener('ended', handleCapturedAudioTrackEnded)
+    if (event.track.kind === 'audio') {
+      runVisualizerTask(disposeAudioGraph().then(startDrawing))
+    }
+  }
+
+  function attachCapturedStreamListeners(stream) {
+    stream.addEventListener('addtrack', handleCapturedStreamAddTrack)
+    stream.addEventListener('removetrack', handleCapturedStreamRemoveTrack)
+    stream.getAudioTracks().forEach((track) => {
+      track.addEventListener('ended', handleCapturedAudioTrackEnded)
+    })
+  }
+
+  function detachCapturedStreamListeners(stream) {
+    stream?.removeEventListener('addtrack', handleCapturedStreamAddTrack)
+    stream?.removeEventListener('removetrack', handleCapturedStreamRemoveTrack)
+    stream?.getAudioTracks().forEach((track) => {
+      track.removeEventListener('ended', handleCapturedAudioTrackEnded)
+    })
+  }
+
+  async function disposeAudioGraph() {
+    const contextToClose = audioContext
+    contextToClose?.removeEventListener('statechange', handleAudioContextStateChange)
+    detachCapturedStreamListeners(capturedStream)
+    streamSource?.disconnect()
+    analyser?.disconnect()
+    capturedStream?.getTracks().forEach(track => track.stop())
+
+    audioContext = null
+    analyser = null
+    streamSource = null
+    capturedStream = null
+    frequencyData = null
+    stopDrawing()
+
+    if (contextToClose && contextToClose.state !== 'closed') {
+      await contextToClose.close()
+    }
+  }
+
+  function drawFrame(timestamp) {
+    animationFrame = null
+
+    if (!canDraw() || !analyser || !frequencyData) {
+      stopDrawing()
+      return
+    }
+
+    animationFrame = requestAnimationFrame(drawFrame)
+    if (timestamp - lastFrameTime < MIN_FRAME_INTERVAL_MS) {
+      return
+    }
+
+    lastFrameTime = timestamp
+    const canvas = musicVisualizerCanvas.value
+    const context = canvas?.getContext('2d')
+    if (!canvas || !context) {
+      return
+    }
+
+    analyser.getByteFrequencyData(frequencyData)
+    context.clearRect(0, 0, canvas.width, canvas.height)
+
+    const barCount = Math.min(48, frequencyData.length)
+    const gap = Math.max(2, canvas.width * 0.004)
+    const barWidth = Math.max(1, (canvas.width - gap * (barCount - 1)) / barCount)
+    const gradient = context.createLinearGradient(0, canvas.height, 0, 0)
+    gradient.addColorStop(0, 'rgb(255 255 255 / 18%)')
+    gradient.addColorStop(0.45, 'rgb(255 255 255 / 60%)')
+    gradient.addColorStop(1, 'rgb(255 255 255 / 95%)')
+    context.fillStyle = gradient
+
+    for (let index = 0; index < barCount; index++) {
+      const sourceIndex = Math.floor(index * frequencyData.length * 0.72 / barCount)
+      const strength = frequencyData[sourceIndex] / 255
+      const height = Math.max(canvas.height * 0.018, strength * canvas.height * 0.82)
+      const x = index * (barWidth + gap)
+      const y = canvas.height - height
+      const radius = Math.min(barWidth / 2, 6)
+
+      context.beginPath()
+      context.roundRect(x, y, barWidth, height, radius)
+      context.fill()
+    }
+  }
+
+  async function ensureAudioGraph() {
+    const videoElement = video.value
+    if (audioContext || !videoElement || typeof videoElement.captureStream !== 'function') {
+      return Boolean(audioContext)
+    }
+
+    try {
+      if (capturedStream?.getAudioTracks().length && !hasLiveCapturedAudioTrack()) {
+        await disposeAudioGraph()
+      }
+
+      if (!capturedStream) {
+        capturedStream = videoElement.captureStream()
+        attachCapturedStreamListeners(capturedStream)
+      }
+
+      if (!hasLiveCapturedAudioTrack()) {
+        return false
+      }
+
+      const context = new AudioContext()
+      const source = context.createMediaStreamSource(capturedStream)
+      const nextAnalyser = context.createAnalyser()
+      nextAnalyser.fftSize = FFT_SIZE
+      nextAnalyser.smoothingTimeConstant = 0.82
+      source.connect(nextAnalyser)
+      context.addEventListener('statechange', handleAudioContextStateChange)
+
+      audioContext = context
+      streamSource = source
+      analyser = nextAnalyser
+      frequencyData = new Uint8Array(nextAnalyser.frequencyBinCount)
+      return true
+    } catch (error) {
+      logVisualizerError(error)
+      await disposeAudioGraph()
+      return false
+    }
+  }
+
+  async function startDrawing() {
+    if (!canDraw()) {
+      return
+    }
+
+    if (audioContext?.state === 'closed') {
+      await disposeAudioGraph()
+    }
+
+    if (!await ensureAudioGraph() || !audioContext) {
+      return
+    }
+
+    if (audioContext.state !== 'running') {
+      await audioContext.resume()
+    }
+
+    if (canDraw() && animationFrame === null) {
+      animationFrame = requestAnimationFrame(drawFrame)
+    }
+  }
+
+  function handleAudioContextStateChange() {
+    if (audioContext?.state !== 'running' && canDraw()) {
+      runVisualizerTask(startDrawing())
+    }
+  }
+
+  function handleVisibilityChange() {
+    if (document.hidden) {
+      stopDrawing()
+    } else {
+      runVisualizerTask(startDrawing())
+    }
+  }
+
+  function handlePlaybackStateChange() {
+    if (video.value?.paused) {
+      stopDrawing()
+    } else {
+      runVisualizerTask(startDrawing())
+    }
+  }
+
+  function attachVideoListeners(element) {
+    element?.addEventListener('play', handlePlaybackStateChange)
+    element?.addEventListener('pause', handlePlaybackStateChange)
+    element?.addEventListener('ended', handlePlaybackStateChange)
+  }
+
+  function detachVideoListeners(element) {
+    element?.removeEventListener('play', handlePlaybackStateChange)
+    element?.removeEventListener('pause', handlePlaybackStateChange)
+    element?.removeEventListener('ended', handlePlaybackStateChange)
+  }
+
+  watch(video, (nextVideo, previousVideo) => {
+    detachVideoListeners(previousVideo)
+    attachVideoListeners(nextVideo)
+    runVisualizerTask(disposeAudioGraph().then(startDrawing))
+  })
+
+  watch(musicVisualizerCanvas, (nextCanvas, previousCanvas) => {
+    if (resizeObserver && previousCanvas) {
+      resizeObserver.unobserve(previousCanvas)
+    }
+    if (resizeObserver && nextCanvas) {
+      resizeObserver.observe(nextCanvas)
+      resizeCanvas()
+    }
+  })
+
+  watch(active, (isActive) => {
+    if (isActive) {
+      runVisualizerTask(nextTick(startDrawing))
+    } else {
+      stopDrawing()
+    }
+  })
+
+  watch(sourceKey, () => {
+    runVisualizerTask(disposeAudioGraph().then(startDrawing))
+  })
+
+  onMounted(() => {
+    attachVideoListeners(video.value)
+    document.addEventListener('visibilitychange', handleVisibilityChange)
+
+    resizeObserver = new ResizeObserver(resizeCanvas)
+    if (musicVisualizerCanvas.value) {
+      resizeObserver.observe(musicVisualizerCanvas.value)
+    }
+
+    reducedMotionObserver = new MutationObserver(() => {
+      if (document.documentElement.dataset.reducedMotion === 'reduce') {
+        stopDrawing()
+      } else {
+        runVisualizerTask(startDrawing())
+      }
+    })
+    reducedMotionObserver.observe(document.documentElement, {
+      attributeFilter: ['data-reduced-motion']
+    })
+
+    resizeCanvas()
+    runVisualizerTask(startDrawing())
+  })
+
+  onBeforeUnmount(() => {
+    detachVideoListeners(video.value)
+    document.removeEventListener('visibilitychange', handleVisibilityChange)
+    resizeObserver?.disconnect()
+    reducedMotionObserver?.disconnect()
+    runVisualizerTask(disposeAudioGraph())
+  })
+
+  return { musicVisualizerCanvas }
+}

--- a/src/renderer/components/ft-shaka-video-player/player-components/AmbientModeButton.js
+++ b/src/renderer/components/ft-shaka-video-player/player-components/AmbientModeButton.js
@@ -1,10 +1,8 @@
-import shaka from 'shaka-player'
-import { watch } from 'vue'
-
 import i18n from '../../../i18n/index'
 import { PlayerIcons } from '../../../../constants'
+import { BooleanSettingButton } from './BooleanSettingButton'
 
-export class AmbientModeButton extends shaka.ui.Element {
+export class AmbientModeButton extends BooleanSettingButton {
   /**
    * @param {import('vue').ComputedRef<boolean>} ambientMode
    * @param {(value: boolean) => void} updateAmbientMode
@@ -13,96 +11,13 @@ export class AmbientModeButton extends shaka.ui.Element {
    * @param {shaka.ui.Controls} controls
    */
   constructor(ambientMode, updateAmbientMode, events, parent, controls) {
-    super(parent, controls)
-
-    /** @private */
-    this.ambientMode_ = ambientMode
-
-    /** @private */
-    this.updateAmbientMode_ = updateAmbientMode
-
-    /** @private */
-    this.button_ = document.createElement('button')
-    this.button_.classList.add('ambient-mode-button', 'shaka-no-propagation', 'shaka-tooltip')
-
-    /** @private */
-    this.icon_ = new shaka.ui.Icon(this.button_, PlayerIcons.LIGHT_MODE_FILLED)
-
-    const label = document.createElement('label')
-    label.classList.add(
-      'shaka-overflow-button-label',
-      'shaka-overflow-menu-only',
-      'shaka-simple-overflow-button-label-inline'
-    )
-
-    /** @private */
-    this.nameSpan_ = document.createElement('span')
-    label.appendChild(this.nameSpan_)
-
-    /** @private */
-    this.currentState_ = document.createElement('span')
-    this.currentState_.classList.add('shaka-current-selection-span', 'ft-toggle-state')
-
-    /** @private */
-    this.currentStateValue_ = document.createElement('span')
-    this.currentState_.appendChild(this.currentStateValue_)
-
-    /** @private */
-    this.currentStateSizer_ = document.createElement('span')
-    this.currentStateSizer_.classList.add('ft-toggle-state-sizer')
-    this.currentStateSizer_.ariaHidden = 'true'
-    this.currentState_.appendChild(this.currentStateSizer_)
-    label.appendChild(this.currentState_)
-
-    this.button_.appendChild(label)
-    this.parent.appendChild(this.button_)
-
-    this.eventManager.listen(this.button_, 'click', () => {
-      this.updateAmbientMode_(!this.ambientMode_.value)
-    })
-
-    this.eventManager.listen(events, 'localeChanged', () => {
-      this.updateLocalisedStrings_()
-    })
-
-    if (this.isSubMenu) {
-      this.eventManager.listen(this.controls, 'submenuopen', () => {
-        this.updateVisibility_()
-      })
-
-      this.eventManager.listen(this.controls, 'submenuclose', () => {
-        this.updateVisibility_()
-      })
-    }
-
-    /** @private */
-    this.stopAmbientModeWatch_ = watch(this.ambientMode_, () => {
-      this.updateLocalisedStrings_()
-    })
-
-    this.updateLocalisedStrings_()
-  }
-
-  release() {
-    this.stopAmbientModeWatch_()
-    super.release()
-  }
-
-  /** @private */
-  updateLocalisedStrings_() {
-    const label = i18n.global.t('Global.Ambient Mode')
-    const enabledLabel = this.localization.resolve('ON')
-    const disabledLabel = this.localization.resolve('OFF')
-
-    this.nameSpan_.textContent = label
-    this.currentStateValue_.textContent = this.ambientMode_.value ? enabledLabel : disabledLabel
-    this.currentStateSizer_.textContent = this.ambientMode_.value ? disabledLabel : enabledLabel
-    this.button_.ariaLabel = label
-    this.button_.ariaPressed = this.ambientMode_.value ? 'true' : 'false'
-  }
-
-  /** @private */
-  updateVisibility_() {
-    this.button_.classList.toggle('shaka-hidden', this.isSubMenuOpened)
+    super({
+      value: ambientMode,
+      updateValue: updateAmbientMode,
+      events,
+      className: 'ambient-mode-button',
+      icon: PlayerIcons.LIGHT_MODE_FILLED,
+      getLabel: () => i18n.global.t('Global.Ambient Mode'),
+    }, parent, controls)
   }
 }

--- a/src/renderer/components/ft-shaka-video-player/player-components/BooleanSettingButton.js
+++ b/src/renderer/components/ft-shaka-video-player/player-components/BooleanSettingButton.js
@@ -1,0 +1,115 @@
+import shaka from 'shaka-player'
+import { watch } from 'vue'
+
+/**
+ * Shared Shaka overflow-menu control for boolean Vue settings.
+ */
+export class BooleanSettingButton extends shaka.ui.Element {
+  /**
+   * @param {object} options
+   * @param {import('vue').ComputedRef<boolean>} options.value
+   * @param {(value: boolean) => void} options.updateValue
+   * @param {EventTarget} options.events
+   * @param {string} options.className
+   * @param {string} options.icon
+   * @param {() => string} options.getLabel
+   * @param {HTMLElement} parent
+   * @param {shaka.ui.Controls} controls
+   */
+  constructor({ value, updateValue, events, className, icon, getLabel }, parent, controls) {
+    super(parent, controls)
+
+    /** @private */
+    this.value_ = value
+
+    /** @private */
+    this.updateValue_ = updateValue
+
+    /** @private */
+    this.getLabel_ = getLabel
+
+    /** @private */
+    this.button_ = document.createElement('button')
+    this.button_.classList.add(className, 'shaka-no-propagation', 'shaka-tooltip')
+
+    /** @private */
+    this.icon_ = new shaka.ui.Icon(this.button_, icon)
+
+    const label = document.createElement('label')
+    label.classList.add(
+      'shaka-overflow-button-label',
+      'shaka-overflow-menu-only',
+      'shaka-simple-overflow-button-label-inline'
+    )
+
+    /** @private */
+    this.nameSpan_ = document.createElement('span')
+    label.appendChild(this.nameSpan_)
+
+    /** @private */
+    this.currentState_ = document.createElement('span')
+    this.currentState_.classList.add('shaka-current-selection-span', 'ft-toggle-state')
+
+    /** @private */
+    this.currentStateValue_ = document.createElement('span')
+    this.currentState_.appendChild(this.currentStateValue_)
+
+    /** @private */
+    this.currentStateSizer_ = document.createElement('span')
+    this.currentStateSizer_.classList.add('ft-toggle-state-sizer')
+    this.currentStateSizer_.ariaHidden = 'true'
+    this.currentState_.appendChild(this.currentStateSizer_)
+    label.appendChild(this.currentState_)
+
+    this.button_.appendChild(label)
+    this.parent.appendChild(this.button_)
+
+    this.eventManager.listen(this.button_, 'click', () => {
+      this.updateValue_(!this.value_.value)
+    })
+
+    this.eventManager.listen(events, 'localeChanged', () => {
+      this.updateLocalisedStrings_()
+    })
+
+    if (this.isSubMenu) {
+      this.eventManager.listen(this.controls, 'submenuopen', () => {
+        this.updateVisibility_()
+      })
+
+      this.eventManager.listen(this.controls, 'submenuclose', () => {
+        this.updateVisibility_()
+      })
+    }
+
+    /** @private */
+    this.stopValueWatch_ = watch(this.value_, () => {
+      this.updateLocalisedStrings_()
+    })
+
+    this.updateLocalisedStrings_()
+  }
+
+  release() {
+    this.stopValueWatch_()
+    super.release()
+  }
+
+  /** @private */
+  updateLocalisedStrings_() {
+    const label = this.getLabel_()
+    const enabledLabel = this.localization.resolve('ON')
+    const disabledLabel = this.localization.resolve('OFF')
+
+    this.nameSpan_.textContent = label
+    this.currentStateValue_.textContent = this.value_.value ? enabledLabel : disabledLabel
+    this.currentStateSizer_.textContent = this.value_.value ? disabledLabel : enabledLabel
+    this.button_.ariaLabel = label
+    this.button_.ariaPressed = this.value_.value ? 'true' : 'false'
+  }
+
+  /** @private */
+  updateVisibility_() {
+    this.button_.classList.toggle('shaka-hidden', this.isSubMenuOpened)
+  }
+}

--- a/src/renderer/components/ft-shaka-video-player/player-components/MusicVisualizerButton.js
+++ b/src/renderer/components/ft-shaka-video-player/player-components/MusicVisualizerButton.js
@@ -1,0 +1,23 @@
+import i18n from '../../../i18n/index'
+import { PlayerIcons } from '../../../../constants'
+import { BooleanSettingButton } from './BooleanSettingButton'
+
+export class MusicVisualizerButton extends BooleanSettingButton {
+  /**
+   * @param {import('vue').ComputedRef<boolean>} musicVisualizer
+   * @param {(value: boolean) => void} updateMusicVisualizer
+   * @param {EventTarget} events
+   * @param {HTMLElement} parent
+   * @param {shaka.ui.Controls} controls
+   */
+  constructor(musicVisualizer, updateMusicVisualizer, events, parent, controls) {
+    super({
+      value: musicVisualizer,
+      updateValue: updateMusicVisualizer,
+      events,
+      className: 'music-visualizer-button',
+      icon: PlayerIcons.INSERT_CHART_FILLED,
+      getLabel: () => i18n.global.t('Settings.Player Settings.Music Visualizer'),
+    }, parent, controls)
+  }
+}

--- a/src/renderer/components/ft-shaka-video-player/player-components/SkipSilenceButton.js
+++ b/src/renderer/components/ft-shaka-video-player/player-components/SkipSilenceButton.js
@@ -1,11 +1,9 @@
-import shaka from 'shaka-player'
-import { watch } from 'vue'
-
 import { KeyboardShortcuts, PlayerIcons } from '../../../../constants'
 import i18n from '../../../i18n/index'
 import { addKeyboardShortcutToActionTitle } from '../../../helpers/utils'
+import { BooleanSettingButton } from './BooleanSettingButton'
 
-export class SkipSilenceButton extends shaka.ui.Element {
+export class SkipSilenceButton extends BooleanSettingButton {
   /**
    * @param {import('vue').ComputedRef<boolean>} skipSilence
    * @param {(value: boolean) => void} updateSkipSilence
@@ -14,103 +12,19 @@ export class SkipSilenceButton extends shaka.ui.Element {
    * @param {shaka.ui.Controls} controls
    */
   constructor(skipSilence, updateSkipSilence, events, parent, controls) {
-    super(parent, controls)
-
-    /** @private */
-    this.skipSilence_ = skipSilence
-
-    /** @private */
-    this.updateSkipSilence_ = updateSkipSilence
-
-    /** @private */
-    this.button_ = document.createElement('button')
-    this.button_.classList.add('skip-silence-button', 'shaka-no-propagation', 'shaka-tooltip')
-
-    /** @private */
-    this.icon_ = new shaka.ui.Icon(
-      this.button_,
-      PlayerIcons.SKIP_NEXT_FILLED
-    )
-
-    const label = document.createElement('label')
-    label.classList.add(
-      'shaka-overflow-button-label',
-      'shaka-overflow-menu-only',
-      'shaka-simple-overflow-button-label-inline'
-    )
-
-    /** @private */
-    this.nameSpan_ = document.createElement('span')
-    label.appendChild(this.nameSpan_)
-
-    /** @private */
-    this.currentState_ = document.createElement('span')
-    this.currentState_.classList.add('shaka-current-selection-span', 'ft-toggle-state')
-
-    /** @private */
-    this.currentStateValue_ = document.createElement('span')
-    this.currentState_.appendChild(this.currentStateValue_)
-
-    /** @private */
-    this.currentStateSizer_ = document.createElement('span')
-    this.currentStateSizer_.classList.add('ft-toggle-state-sizer')
-    this.currentStateSizer_.ariaHidden = 'true'
-    this.currentState_.appendChild(this.currentStateSizer_)
-    label.appendChild(this.currentState_)
-
-    this.button_.appendChild(label)
-    this.parent.appendChild(this.button_)
-
-    this.eventManager.listen(this.button_, 'click', () => {
-      this.updateSkipSilence_(!this.skipSilence_.value)
-    })
-
-    this.eventManager.listen(events, 'localeChanged', () => {
-      this.updateLocalisedStrings_()
-    })
-
-    if (this.isSubMenu) {
-      this.eventManager.listen(this.controls, 'submenuopen', () => {
-        this.updateVisibility_()
-      })
-
-      this.eventManager.listen(this.controls, 'submenuclose', () => {
-        this.updateVisibility_()
-      })
-    }
-
-    /** @private */
-    this.stopSkipSilenceWatch_ = watch(this.skipSilence_, () => {
-      this.updateLocalisedStrings_()
-    })
-
-    this.updateLocalisedStrings_()
-  }
-
-  release() {
-    this.stopSkipSilenceWatch_()
-    super.release()
-  }
-
-  /** @private */
-  updateLocalisedStrings_() {
-    const baseLabel = i18n.global.t('Settings.Player Settings.Skip Silence')
-    const shortcut = KeyboardShortcuts.VIDEO_PLAYER.PLAYBACK.TOGGLE_SKIP_SILENCE
-    const label = shortcut
-      ? addKeyboardShortcutToActionTitle(baseLabel, shortcut)
-      : baseLabel
-    const enabledLabel = this.localization.resolve('ON')
-    const disabledLabel = this.localization.resolve('OFF')
-
-    this.nameSpan_.textContent = label
-    this.currentStateValue_.textContent = this.skipSilence_.value ? enabledLabel : disabledLabel
-    this.currentStateSizer_.textContent = this.skipSilence_.value ? disabledLabel : enabledLabel
-    this.button_.ariaLabel = label
-    this.button_.ariaPressed = this.skipSilence_.value ? 'true' : 'false'
-  }
-
-  /** @private */
-  updateVisibility_() {
-    this.button_.classList.toggle('shaka-hidden', this.isSubMenuOpened)
+    super({
+      value: skipSilence,
+      updateValue: updateSkipSilence,
+      events,
+      className: 'skip-silence-button',
+      icon: PlayerIcons.SKIP_NEXT_FILLED,
+      getLabel: () => {
+        const baseLabel = i18n.global.t('Settings.Player Settings.Skip Silence')
+        const shortcut = KeyboardShortcuts.VIDEO_PLAYER.PLAYBACK.TOGGLE_SKIP_SILENCE
+        return shortcut
+          ? addKeyboardShortcutToActionTitle(baseLabel, shortcut)
+          : baseLabel
+      },
+    }, parent, controls)
   }
 }

--- a/src/renderer/helpers/api/invidious.js
+++ b/src/renderer/helpers/api/invidious.js
@@ -4,6 +4,7 @@ import { isNullOrEmpty } from '../strings'
 import { enrichFallbackInvidiousPublicationDates } from './invidious-channel-videos'
 import { getInvidiousCommentAuthorThumbnail } from './invidious-comments'
 import { filterUnavailableInvidiousPlaylistVideos } from './invidious-playlists'
+import { classifyInvidiousMusicMediaType } from '../player/musicMediaType'
 import autolinker from 'autolinker'
 import { FormatUtils, Misc, Player } from 'youtubei.js'
 
@@ -458,14 +459,17 @@ export async function fetchAllInvidiousPlaylistVideos(playlistId, initialOffset 
  *    album: string,
  *    license: string
  *  }[]?,
+ *  musicMediaType: import('../player/musicMediaType').MusicMediaType,
  *  recommendedVideos: InvidiousVideoType[]
  * }>}
  */
 export async function invidiousGetVideoInformation(videoId) {
-  return await invidiousAPICall({
+  const video = await invidiousAPICall({
     resource: 'videos',
     id: videoId,
   })
+  video.musicMediaType = classifyInvidiousMusicMediaType(video)
+  return video
 }
 
 /**

--- a/src/renderer/helpers/api/local.js
+++ b/src/renderer/helpers/api/local.js
@@ -12,6 +12,7 @@ import {
 } from '../comment-translations'
 import { parseLocalShortLinkedVideo } from '../player/shorts'
 import { getPaidPromotionDurationMs } from '../player/paidPromotion'
+import { classifyMusicMediaType, MUSIC_MEDIA_TYPE } from '../player/musicMediaType'
 import { getLocalPremiereState } from '../premiere'
 import { shouldHideMembersOnlyContent } from '../restricted-playback'
 import { getThumbnailPreviewUrl } from '../thumbnailPreview'
@@ -594,6 +595,28 @@ function buildSessionFromYtConfig(ytConfig, fetchFunc) {
   )
 }
 
+async function resolveMusicMediaType(playerResponse, actions, videoId) {
+  const directType = classifyMusicMediaType(playerResponse.data?.videoDetails?.musicVideoType)
+  const category = playerResponse.data?.microformat?.playerMicroformatRenderer?.category
+
+  if (directType !== MUSIC_MEDIA_TYPE.UNKNOWN || category !== 'Music') {
+    return directType
+  }
+
+  try {
+    const musicPlayerResponse = await actions.execute('/player', {
+      videoId,
+      client: 'YTMUSIC',
+      parse: false,
+      racyCheckOk: true,
+      contentCheckOk: true,
+    })
+    return classifyMusicMediaType(musicPlayerResponse.data?.videoDetails?.musicVideoType)
+  } catch {
+    return directType
+  }
+}
+
 /**
  * @param {string} id
  * @returns {Promise<{
@@ -608,7 +631,8 @@ function buildSessionFromYtConfig(ytConfig, fetchFunc) {
  *   adEndTimeUnixMs: number,
  *   paidPromotionDurationMs: number | null,
  *   isPremiere: boolean | undefined,
- *   watchPageIpBlocked: boolean
+ *   watchPageIpBlocked: boolean,
+ *   musicMediaType: import('../player/musicMediaType').MusicMediaType
  * }>}
  */
 export async function getLocalVideoInfo(id) {
@@ -734,6 +758,12 @@ export async function getLocalVideoInfo(id) {
     })
   }
 
+  const musicMediaTypeRequest = resolveMusicMediaType(
+    playerResponse,
+    htmlExtracts.session.actions,
+    id
+  )
+
   if (htmlExtracts.nextResponse) {
     nextResponse = { data: htmlExtracts.nextResponse }
   } else {
@@ -747,6 +777,7 @@ export async function getLocalVideoInfo(id) {
   const cpn = Utils.generateRandomString(16)
 
   const info = new YT.VideoInfo([playerResponse, nextResponse], htmlExtracts.session.actions, cpn)
+  const musicMediaType = await musicMediaTypeRequest
   await paidPromotionRequest
   const totalAdTimeMilliseconds = extractTotalAdTimeMilliseconds(playerResponse.data)
 
@@ -802,7 +833,7 @@ export async function getLocalVideoInfo(id) {
 
   if ((info.playability_status.status === 'UNPLAYABLE' && (!hasTrailer || trailerIsAgeRestricted)) ||
     info.playability_status.status === 'LOGIN_REQUIRED') {
-    return { info, poToken: undefined, clientInfo, paidPromotionDurationMs, isPremiere, watchPageIpBlocked }
+    return { info, poToken: undefined, clientInfo, paidPromotionDurationMs, isPremiere, watchPageIpBlocked, musicMediaType }
   }
 
   if (hasTrailer && info.playability_status.status !== 'OK') {
@@ -870,6 +901,7 @@ export async function getLocalVideoInfo(id) {
     paidPromotionDurationMs,
     isPremiere,
     watchPageIpBlocked,
+    musicMediaType,
   }
 }
 

--- a/src/renderer/helpers/player/musicMediaType.js
+++ b/src/renderer/helpers/player/musicMediaType.js
@@ -1,0 +1,48 @@
+export const MUSIC_MEDIA_TYPE = Object.freeze({
+  AUDIO_TRACK: 'audioTrack',
+  OFFICIAL_VIDEO: 'officialVideo',
+  PODCAST: 'podcast',
+  UNKNOWN: 'unknown',
+  USER_VIDEO: 'userVideo',
+})
+
+/** @typedef {(typeof MUSIC_MEDIA_TYPE)[keyof typeof MUSIC_MEDIA_TYPE]} MusicMediaType */
+
+const YOUTUBE_MUSIC_VIDEO_TYPES = Object.freeze({
+  MUSIC_VIDEO_TYPE_ATV: MUSIC_MEDIA_TYPE.AUDIO_TRACK,
+  MUSIC_VIDEO_TYPE_OMV: MUSIC_MEDIA_TYPE.OFFICIAL_VIDEO,
+  MUSIC_VIDEO_TYPE_PODCAST_EPISODE: MUSIC_MEDIA_TYPE.PODCAST,
+  MUSIC_VIDEO_TYPE_UGC: MUSIC_MEDIA_TYPE.USER_VIDEO,
+})
+
+/**
+ * Converts YouTube's player-response value into a stable app classification.
+ * Unknown values deliberately stay unknown so normal videos never receive the
+ * audio-track player based on a category or channel-name guess.
+ *
+ * @param {unknown} musicVideoType
+ * @returns {(typeof MUSIC_MEDIA_TYPE)[keyof typeof MUSIC_MEDIA_TYPE]}
+ */
+export function classifyMusicMediaType(musicVideoType) {
+  return typeof musicVideoType === 'string'
+    ? YOUTUBE_MUSIC_VIDEO_TYPES[musicVideoType] ?? MUSIC_MEDIA_TYPE.UNKNOWN
+    : MUSIC_MEDIA_TYPE.UNKNOWN
+}
+
+/**
+ * Invidious does not expose YouTube's musicVideoType field. Artist topic
+ * channels are the conservative fallback that distinguishes auto-generated
+ * audio tracks from official and user-uploaded music videos.
+ *
+ * @param {object} video
+ * @param {unknown} video.author
+ * @param {unknown} video.genre
+ * @returns {(typeof MUSIC_MEDIA_TYPE)[keyof typeof MUSIC_MEDIA_TYPE]}
+ */
+export function classifyInvidiousMusicMediaType(video) {
+  return video.genre === 'Music' &&
+    typeof video.author === 'string' &&
+    video.author.endsWith(' - Topic')
+    ? MUSIC_MEDIA_TYPE.AUDIO_TRACK
+    : MUSIC_MEDIA_TYPE.UNKNOWN
+}

--- a/src/renderer/helpers/player/musicMediaType.js
+++ b/src/renderer/helpers/player/musicMediaType.js
@@ -15,6 +15,8 @@ const YOUTUBE_MUSIC_VIDEO_TYPES = Object.freeze({
   MUSIC_VIDEO_TYPE_UGC: MUSIC_MEDIA_TYPE.USER_VIDEO,
 })
 
+const ARTIST_TOPIC_SUFFIX = ' - Topic'
+
 /**
  * Converts YouTube's player-response value into a stable app classification.
  * Unknown values deliberately stay unknown so normal videos never receive the
@@ -42,7 +44,18 @@ export function classifyMusicMediaType(musicVideoType) {
 export function classifyInvidiousMusicMediaType(video) {
   return video.genre === 'Music' &&
     typeof video.author === 'string' &&
-    video.author.endsWith(' - Topic')
+    video.author.endsWith(ARTIST_TOPIC_SUFFIX)
     ? MUSIC_MEDIA_TYPE.AUDIO_TRACK
     : MUSIC_MEDIA_TYPE.UNKNOWN
+}
+
+/**
+ * Removes Invidious' artist topic-channel suffix from the player label.
+ * @param {string} author
+ * @returns {string}
+ */
+export function getMusicTrackArtist(author) {
+  return author.endsWith(ARTIST_TOPIC_SUFFIX)
+    ? author.slice(0, -ARTIST_TOPIC_SUFFIX.length)
+    : author
 }

--- a/src/renderer/store/modules/settings.js
+++ b/src/renderer/store/modules/settings.js
@@ -248,6 +248,7 @@ const state = {
   disableChannelLinks: false,
   displayVideoPlayButton: false,
   ambientMode: false,
+  musicVisualizer: true,
   enableVideoMetadataCache: false,
   enableWatchStats: true,
   statsWeekStartsOn: '1',

--- a/src/renderer/views/Watch/Watch.js
+++ b/src/renderer/views/Watch/Watch.js
@@ -76,7 +76,7 @@ import {
   MANIFEST_TYPE_HLS
 } from '../../helpers/player/utils'
 import { getYtDlpPlaybackSource, invalidateYtDlpPlaybackSource } from '../../helpers/player/ytDlpPlayback'
-import { MUSIC_MEDIA_TYPE } from '../../helpers/player/musicMediaType'
+import { getMusicTrackArtist, MUSIC_MEDIA_TYPE } from '../../helpers/player/musicMediaType'
 import { selectSponsorBlockFullVideoLabel } from '../../helpers/player/sponsorBlockFullVideo'
 import {
   buildSubscriptionShortsFeed,
@@ -450,6 +450,11 @@ export default defineComponent({
     }
   },
   computed: {
+    musicPlayerArtist: function () {
+      return this.musicMediaType === MUSIC_MEDIA_TYPE.AUDIO_TRACK
+        ? getMusicTrackArtist(this.channelName)
+        : this.channelName
+    },
     dateFormatPreference: function () {
       return this.$store.getters.getDateFormat
     },

--- a/src/renderer/views/Watch/Watch.js
+++ b/src/renderer/views/Watch/Watch.js
@@ -76,6 +76,7 @@ import {
   MANIFEST_TYPE_HLS
 } from '../../helpers/player/utils'
 import { getYtDlpPlaybackSource, invalidateYtDlpPlaybackSource } from '../../helpers/player/ytDlpPlayback'
+import { MUSIC_MEDIA_TYPE } from '../../helpers/player/musicMediaType'
 import { selectSponsorBlockFullVideoLabel } from '../../helpers/player/sponsorBlockFullVideo'
 import {
   buildSubscriptionShortsFeed,
@@ -407,6 +408,8 @@ export default defineComponent({
       /** @type {'private' | 'drm' | null} */
       nonRetryablePlaybackError: null,
       videoGenreIsMusic: false,
+      /** @type {(typeof MUSIC_MEDIA_TYPE)[keyof typeof MUSIC_MEDIA_TYPE]} */
+      musicMediaType: MUSIC_MEDIA_TYPE.UNKNOWN,
       /** @type {Date|null} */
       streamingDataExpiryDate: null,
       currentPlaybackRate: null,
@@ -1951,6 +1954,7 @@ export default defineComponent({
       this.restrictedPlaybackError = null
       this.nonRetryablePlaybackError = null
       this.videoGenreIsMusic = false
+      this.musicMediaType = MUSIC_MEDIA_TYPE.UNKNOWN
       this.streamingDataExpiryDate = null
       this.ipBlockDetectedInCurrentChain = false
       // Cleared until the new player reports its ready state; otherwise the
@@ -2650,7 +2654,18 @@ export default defineComponent({
         const videoInfo = await getLocalVideoInfo(videoId)
         if (!this.isCurrentVideoLoad(loadGeneration, videoId)) { return }
 
-        const { info: result, poToken, clientInfo, adEndTimeUnixMs, paidPromotionDurationMs, isPremiere, watchPageIpBlocked } = videoInfo
+        const {
+          info: result,
+          poToken,
+          clientInfo,
+          adEndTimeUnixMs,
+          paidPromotionDurationMs,
+          isPremiere,
+          watchPageIpBlocked,
+          musicMediaType,
+        } = videoInfo
+
+        this.musicMediaType = musicMediaType
 
         if (watchPageIpBlocked) {
           this.ipBlockDetectedInCurrentChain = true
@@ -3292,6 +3307,7 @@ export default defineComponent({
           this.videoCategory = result.genre ?? ''
           this.videoTags = result.keywords ?? []
           this.videoGenreIsMusic = this.videoCategory === 'Music'
+          this.musicMediaType = result.musicMediaType
 
           this.channelId = result.authorId
           this.channelName = result.author

--- a/src/renderer/views/Watch/Watch.vue
+++ b/src/renderer/views/Watch/Watch.vue
@@ -109,7 +109,7 @@
           :chapters-kind="videoChaptersKind"
           :chapters-src="chaptersSrc"
           :title="videoTitle"
-          :artist="channelName"
+          :artist="musicPlayerArtist"
           :music-media-type="musicMediaType"
           :theatre-possible="theatreTogglePossible"
           :use-theatre-mode="useTheatreMode"

--- a/src/renderer/views/Watch/Watch.vue
+++ b/src/renderer/views/Watch/Watch.vue
@@ -109,6 +109,8 @@
           :chapters-kind="videoChaptersKind"
           :chapters-src="chaptersSrc"
           :title="videoTitle"
+          :artist="channelName"
+          :music-media-type="musicMediaType"
           :theatre-possible="theatreTogglePossible"
           :use-theatre-mode="useTheatreMode"
           :autoplay-possible="autoplayPossible"

--- a/static/locales/ai/ar.yaml
+++ b/static/locales/ai/ar.yaml
@@ -424,6 +424,7 @@ Settings:
         Destructive pressed: الضغط المدمر
         Text and icons on destructive actions: النص والأيقونات على الإجراءات المدمرة
   Player Settings:
+    Music Visualizer: مؤثرات موسيقية مرئية
     Automatically Open Chapters: فتح الفصول تلقائيا
     Caption Appearance:
       Caption Appearance: مظهر التسمية التوضيحية

--- a/static/locales/ai/be.yaml
+++ b/static/locales/ai/be.yaml
@@ -441,6 +441,7 @@ Settings:
       Catppuccin Latte Mauve: Catppuccin Latte Mauve
       Catppuccin Latte Red: Catppuccin Latte Red
   Player Settings:
+    Music Visualizer: Музычны візуалізатар
     Automatically Open Chapters: Аўтаматычна адкрываць раздзелы
     Caption Appearance:
       Caption Appearance: Выгляд субцітраў

--- a/static/locales/ai/bg.yaml
+++ b/static/locales/ai/bg.yaml
@@ -422,6 +422,7 @@ Settings:
         Destructive pressed: Опасно действие при натискане
         Text and icons on destructive actions: Текст и икони върху опасните действия
   Player Settings:
+    Music Visualizer: Музикален визуализатор
     Automatically Open Chapters: Автоматично отваряне на главите
     Caption Appearance:
       Caption Appearance: Изглед на субтитрите

--- a/static/locales/ai/br.yaml
+++ b/static/locales/ai/br.yaml
@@ -420,6 +420,7 @@ Settings:
         Destructive pressed: "Ober distrujus pouezet"
         Text and icons on destructive actions: "Testenn hag arlunioù war an oberoù distrujus"
   Player Settings:
+    Music Visualizer: Gweladur sonerezh
     Automatically Open Chapters: "Digeriñ ar chabistroù ent emgefreek"
     Caption Appearance:
       Caption Appearance: "Neuz an istitloù"

--- a/static/locales/ai/ca.yaml
+++ b/static/locales/ai/ca.yaml
@@ -635,6 +635,7 @@ Settings:
       Everforest Light Blue: Everforest Light Blue
       Everforest Light Purple: Everforest Light Purple
   Player Settings:
+    Music Visualizer: Visualitzador de música
     Automatically Open Chapters: Obre els capítols automàticament
     Caption Appearance:
       Caption Appearance: Aparança dels subtítols

--- a/static/locales/ai/cs.yaml
+++ b/static/locales/ai/cs.yaml
@@ -420,6 +420,7 @@ Settings:
         Destructive pressed: Destruktivní akce při stisknutí
         Text and icons on destructive actions: Text a ikony destruktivních akcí
   Player Settings:
+    Music Visualizer: Hudební vizualizér
     Automatically Open Chapters: Automaticky otevírat kapitoly
     Caption Appearance:
       Caption Appearance: Vzhled titulků

--- a/static/locales/ai/cy.yaml
+++ b/static/locales/ai/cy.yaml
@@ -422,6 +422,7 @@ Settings:
         Destructive pressed: Gweithred ddinistriol wedi'i gwasgu
         Text and icons on destructive actions: Testun ac eiconau ar weithredoedd dinistriol
   Player Settings:
+    Music Visualizer: Delweddydd cerddoriaeth
     Automatically Open Chapters: Agor penodau'n awtomatig
     Caption Appearance:
       Caption Appearance: Golwg capsiynau

--- a/static/locales/ai/da.yaml
+++ b/static/locales/ai/da.yaml
@@ -436,6 +436,7 @@ Settings:
       Catppuccin Latte Mauve: Catppuccin Latte Mauve
       Catppuccin Latte Red: Catppuccin Latte Red
   Player Settings:
+    Music Visualizer: Musikvisualisering
     Automatically Open Chapters: Åbn kapitler automatisk
     Caption Appearance:
       Caption Appearance: Underteksternes udseende

--- a/static/locales/ai/el.yaml
+++ b/static/locales/ai/el.yaml
@@ -424,6 +424,7 @@ Settings:
         Destructive pressed: Καταστροφική ενέργεια κατά το πάτημα
         Text and icons on destructive actions: Κείμενο και εικονίδια καταστροφικών ενεργειών
   Player Settings:
+    Music Visualizer: Οπτικοποίηση μουσικής
     Automatically Open Chapters: Αυτόματο άνοιγμα κεφαλαίων
     Caption Appearance:
       Caption Appearance: Εμφάνιση υποτίτλων

--- a/static/locales/ai/en-GB.yaml
+++ b/static/locales/ai/en-GB.yaml
@@ -407,6 +407,7 @@ Settings:
         Destructive pressed: Destructive pressed
         Text and icons on destructive actions: Text and icons on destructive actions
   Player Settings:
+    Music Visualizer: Music visualiser
     Automatically Open Chapters: Automatically Open Chapters
     Caption Appearance:
       Caption Appearance: Caption Appearance

--- a/static/locales/ai/es-AR.yaml
+++ b/static/locales/ai/es-AR.yaml
@@ -495,6 +495,7 @@ Settings:
       Everforest Light Blue: Everforest Claro Azul
       Everforest Light Purple: Everforest Claro Morado
   Player Settings:
+    Music Visualizer: Visualizador de música
     Automatically Open Chapters: Abrir capítulos automáticamente
     Caption Appearance:
       Caption Appearance: Apariencia de los subtítulos

--- a/static/locales/ai/es-MX.yaml
+++ b/static/locales/ai/es-MX.yaml
@@ -520,6 +520,7 @@ Settings:
       Everforest Light Blue: Everforest Claro Azul
       Everforest Light Purple: Everforest Claro Morado
   Player Settings:
+    Music Visualizer: Visualizador de música
     Automatically Open Chapters: Abrir capítulos automáticamente
     Caption Appearance:
       Caption Appearance: Apariencia de los subtítulos

--- a/static/locales/ai/es.yaml
+++ b/static/locales/ai/es.yaml
@@ -422,6 +422,7 @@ Settings:
         Destructive pressed: Acción destructiva al pulsarla
         Text and icons on destructive actions: Texto e iconos de las acciones destructivas
   Player Settings:
+    Music Visualizer: Visualizador de música
     Automatically Open Chapters: Abrir capítulos automáticamente
     Caption Appearance:
       Caption Appearance: Apariencia de los subtítulos

--- a/static/locales/ai/et.yaml
+++ b/static/locales/ai/et.yaml
@@ -420,6 +420,7 @@ Settings:
         Destructive pressed: Pöördumatu toiming vajutamisel
         Text and icons on destructive actions: Pöördumatute toimingute tekst ja ikoonid
   Player Settings:
+    Music Visualizer: Muusika visualiseerija
     Automatically Open Chapters: Ava peatükid automaatselt
     Caption Appearance:
       Caption Appearance: Subtiitrite välimus

--- a/static/locales/ai/eu.yaml
+++ b/static/locales/ai/eu.yaml
@@ -422,6 +422,7 @@ Settings:
         Destructive pressed: Ekintza suntsitzailea sakatzean
         Text and icons on destructive actions: Ekintza suntsitzaileetako testua eta ikonoak
   Player Settings:
+    Music Visualizer: Musika-bistaratzailea
     Automatically Open Chapters: Ireki kapituluak automatikoki
     Caption Appearance:
       Caption Appearance: Azpitituluen itxura

--- a/static/locales/ai/fa.yaml
+++ b/static/locales/ai/fa.yaml
@@ -441,6 +441,7 @@ Settings:
       Catppuccin Latte Mauve: Catppuccin Latte Mauve
       Catppuccin Latte Red: Catppuccin Latte Red
   Player Settings:
+    Music Visualizer: تصویرساز موسیقی
     Automatically Open Chapters: بازکردن خودکار فصل‌ها
     Caption Appearance:
       Caption Appearance: ظاهر زیرنویس

--- a/static/locales/ai/fi.yaml
+++ b/static/locales/ai/fi.yaml
@@ -424,6 +424,7 @@ Settings:
         Destructive pressed: Poistava toiminto painettaessa
         Text and icons on destructive actions: Poistavien toimintojen teksti ja kuvakkeet
   Player Settings:
+    Music Visualizer: Musiikkivisualisointi
     Automatically Open Chapters: Avaa luvut automaattisesti
     Caption Appearance:
       Caption Appearance: Tekstityksen ulkoasu

--- a/static/locales/ai/fr-FR.yaml
+++ b/static/locales/ai/fr-FR.yaml
@@ -420,6 +420,7 @@ Settings:
         Destructive pressed: Action destructive à l’appui
         Text and icons on destructive actions: Texte et icônes des actions destructives
   Player Settings:
+    Music Visualizer: Visualiseur de musique
     Automatically Open Chapters: Ouvrir automatiquement les chapitres
     Caption Appearance:
       Caption Appearance: Apparence des sous-titres

--- a/static/locales/ai/gl.yaml
+++ b/static/locales/ai/gl.yaml
@@ -424,6 +424,7 @@ Settings:
         Destructive pressed: Acción destrutiva premida
         Text and icons on destructive actions: Texto e iconas das accións destrutivas
   Player Settings:
+    Music Visualizer: Visualizador de música
     Automatically Open Chapters: Abrir os capítulos automaticamente
     Caption Appearance:
       Caption Appearance: Aparencia dos subtítulos

--- a/static/locales/ai/he.yaml
+++ b/static/locales/ai/he.yaml
@@ -424,6 +424,7 @@ Settings:
         Destructive pressed: פעולה הרסנית בלחיצה
         Text and icons on destructive actions: טקסט וסמלים בפעולות הרסניות
   Player Settings:
+    Music Visualizer: מציג מוזיקה
     Automatically Open Chapters: פתיחת פרקים אוטומטית
     Caption Appearance:
       Caption Appearance: מראה הכתוביות

--- a/static/locales/ai/hr.yaml
+++ b/static/locales/ai/hr.yaml
@@ -422,6 +422,7 @@ Settings:
         Destructive pressed: Pritisnuta destruktivna radnja
         Text and icons on destructive actions: Tekst i ikone na destruktivnim radnjama
   Player Settings:
+    Music Visualizer: Vizualizator glazbe
     Automatically Open Chapters: Automatski otvori poglavlja
     Caption Appearance:
       Caption Appearance: Izgled titlova

--- a/static/locales/ai/hu.yaml
+++ b/static/locales/ai/hu.yaml
@@ -420,6 +420,7 @@ Settings:
         Destructive pressed: Törlő művelet lenyomáskor
         Text and icons on destructive actions: Törlő műveletek szövege és ikonjai
   Player Settings:
+    Music Visualizer: Zenevizualizáció
     Automatically Open Chapters: Fejezetek automatikus megnyitása
     Caption Appearance:
       Caption Appearance: Feliratok megjelenése

--- a/static/locales/ai/id.yaml
+++ b/static/locales/ai/id.yaml
@@ -424,6 +424,7 @@ Settings:
         Destructive pressed: Tindakan destruktif saat ditekan
         Text and icons on destructive actions: Teks dan ikon pada tindakan destruktif
   Player Settings:
+    Music Visualizer: Visualisator musik
     Automatically Open Chapters: Buka Bab Secara Otomatis
     Caption Appearance:
       Caption Appearance: Tampilan Takarir

--- a/static/locales/ai/is.yaml
+++ b/static/locales/ai/is.yaml
@@ -424,6 +424,7 @@ Settings:
         Destructive pressed: Eyðandi aðgerð þegar ýtt er
         Text and icons on destructive actions: Texti og tákn á eyðandi aðgerðum
   Player Settings:
+    Music Visualizer: Tónlistarsjónræna
     Automatically Open Chapters: Opna kafla sjálfkrafa
     Caption Appearance:
       Caption Appearance: Útlit skjátexta

--- a/static/locales/ai/is.yaml
+++ b/static/locales/ai/is.yaml
@@ -424,7 +424,7 @@ Settings:
         Destructive pressed: Eyðandi aðgerð þegar ýtt er
         Text and icons on destructive actions: Texti og tákn á eyðandi aðgerðum
   Player Settings:
-    Music Visualizer: Tónlistarsjónræna
+    Music Visualizer: Tónlistarmyndgerð
     Automatically Open Chapters: Opna kafla sjálfkrafa
     Caption Appearance:
       Caption Appearance: Útlit skjátexta

--- a/static/locales/ai/it.yaml
+++ b/static/locales/ai/it.yaml
@@ -420,6 +420,7 @@ Settings:
         Destructive pressed: Azione distruttiva premuta
         Text and icons on destructive actions: Testo e icone sulle azioni distruttive
   Player Settings:
+    Music Visualizer: Visualizzatore musicale
     Automatically Open Chapters: Apri automaticamente i capitoli
     Caption Appearance:
       Caption Appearance: Aspetto dei sottotitoli

--- a/static/locales/ai/ja.yaml
+++ b/static/locales/ai/ja.yaml
@@ -420,6 +420,7 @@ Settings:
         Destructive pressed: 破壊的な操作の押下時
         Text and icons on destructive actions: 破壊的な操作上のテキストとアイコン
   Player Settings:
+    Music Visualizer: 音楽ビジュアライザー
     Automatically Open Chapters: チャプターを自動的に開く
     Caption Appearance:
       Caption Appearance: 字幕の外観

--- a/static/locales/ai/ko.yaml
+++ b/static/locales/ai/ko.yaml
@@ -580,6 +580,7 @@ Settings:
       Everforest Light Blue: Everforest Light Blue
       Everforest Light Purple: Everforest Light Purple
   Player Settings:
+    Music Visualizer: 음악 시각화
     Automatically Open Chapters: 챕터 자동 열기
     Caption Appearance:
       Caption Appearance: 자막 모양

--- a/static/locales/ai/lt.yaml
+++ b/static/locales/ai/lt.yaml
@@ -605,6 +605,7 @@ Settings:
       Everforest Light Blue: Everforest Light Blue
       Everforest Light Purple: Everforest Light Purple
   Player Settings:
+    Music Visualizer: Muzikos vizualizacija
     Automatically Open Chapters: Automatiškai atverti skyrius
     Caption Appearance:
       Caption Appearance: Subtitrų išvaizda

--- a/static/locales/ai/nb-NO.yaml
+++ b/static/locales/ai/nb-NO.yaml
@@ -422,6 +422,7 @@ Settings:
         Destructive pressed: Destruktiv handling ved trykk
         Text and icons on destructive actions: Tekst og ikoner på destruktive handlinger
   Player Settings:
+    Music Visualizer: Musikkvisualisering
     Automatically Open Chapters: Åpne kapitler automatisk
     Caption Appearance:
       Caption Appearance: Utseende på undertekster

--- a/static/locales/ai/nl.yaml
+++ b/static/locales/ai/nl.yaml
@@ -424,6 +424,7 @@ Settings:
         Destructive pressed: Verwijderactie bij indrukken
         Text and icons on destructive actions: Tekst en pictogrammen bij verwijderacties
   Player Settings:
+    Music Visualizer: Muziekvisualisatie
     Automatically Open Chapters: Hoofdstukken automatisch openen
     Caption Appearance:
       Caption Appearance: Uiterlijk van ondertiteling

--- a/static/locales/ai/nn.yaml
+++ b/static/locales/ai/nn.yaml
@@ -617,6 +617,7 @@ Settings:
       Everforest Light Blue: Everforest Light Blue
       Everforest Light Purple: Everforest Light Purple
   Player Settings:
+    Music Visualizer: Musikkvisualisering
     Automatically Open Chapters: Opne kapittel automatisk
     Caption Appearance:
       Caption Appearance: Utsjånad på undertekstar

--- a/static/locales/ai/pl.yaml
+++ b/static/locales/ai/pl.yaml
@@ -141,6 +141,7 @@ Settings:
         Destructive hover and focus: Działanie usuwające dane po najechaniu lub zaznaczeniu
         Destructive pressed: Działanie usuwające dane po naciśnięciu
   Player Settings:
+    Music Visualizer: Wizualizator muzyki
     Scroll Mini Player:
       On All Tabs: Nie ukrywaj miniodtwarzacza podczas przełączania kart
     Enable Skip Silence by Default: Domyślnie włącz pomijanie ciszy

--- a/static/locales/ai/pt-BR.yaml
+++ b/static/locales/ai/pt-BR.yaml
@@ -420,6 +420,7 @@ Settings:
         Destructive pressed: Ação destrutiva ao premir
         Text and icons on destructive actions: Texto e ícones nas ações destrutivas
   Player Settings:
+    Music Visualizer: Visualizador de música
     Automatically Open Chapters: Abrir capítulos automaticamente
     Caption Appearance:
       Caption Appearance: Aparência das legendas

--- a/static/locales/ai/pt-PT.yaml
+++ b/static/locales/ai/pt-PT.yaml
@@ -424,6 +424,7 @@ Settings:
         Destructive pressed: Ação destrutiva ao premir
         Text and icons on destructive actions: Texto e ícones nas ações destrutivas
   Player Settings:
+    Music Visualizer: Visualizador de música
     Automatically Open Chapters: Abrir capítulos automaticamente
     Caption Appearance:
       Caption Appearance: Aspeto das legendas

--- a/static/locales/ai/pt.yaml
+++ b/static/locales/ai/pt.yaml
@@ -427,6 +427,7 @@ Settings:
       Catppuccin Latte Mauve: Catppuccin Latte Mauve
       Catppuccin Latte Red: Catppuccin Latte Red
   Player Settings:
+    Music Visualizer: Visualizador de música
     Automatically Open Chapters: Abrir capítulos automaticamente
     Caption Appearance:
       Caption Appearance: Aspeto das legendas

--- a/static/locales/ai/ro.yaml
+++ b/static/locales/ai/ro.yaml
@@ -422,6 +422,7 @@ Settings:
         Destructive pressed: Acțiune distructivă la apăsare
         Text and icons on destructive actions: Text și pictograme pentru acțiunile distructive
   Player Settings:
+    Music Visualizer: Vizualizator muzical
     Automatically Open Chapters: Deschide automat capitolele
     Caption Appearance:
       Caption Appearance: Aspectul subtitrărilor

--- a/static/locales/ai/ru.yaml
+++ b/static/locales/ai/ru.yaml
@@ -399,6 +399,7 @@ Settings:
         Destructive pressed: Опасное действие при нажатии
         Text and icons on destructive actions: Текст и значки опасных действий
   Player Settings:
+    Music Visualizer: Музыкальный визуализатор
     Automatically Open Chapters: Автоматически открывать главы
     Caption Appearance:
       Caption Appearance: Оформление субтитров

--- a/static/locales/ai/sk.yaml
+++ b/static/locales/ai/sk.yaml
@@ -420,6 +420,7 @@ Settings:
         Destructive pressed: Deštruktívna akcia pri stlačení
         Text and icons on destructive actions: Text a ikony deštruktívnych akcií
   Player Settings:
+    Music Visualizer: Hudobný vizualizér
     Automatically Open Chapters: Automaticky otvárať kapitoly
     Caption Appearance:
       Caption Appearance: Vzhľad titulkov

--- a/static/locales/ai/sl.yaml
+++ b/static/locales/ai/sl.yaml
@@ -612,6 +612,7 @@ Settings:
       Everforest Light Blue: Everforest Light Blue
       Everforest Light Purple: Everforest Light Purple
   Player Settings:
+    Music Visualizer: Glasbeni vizualizator
     Automatically Open Chapters: Samodejno odpri poglavja
     Caption Appearance:
       Caption Appearance: Videz podnapisov

--- a/static/locales/ai/sr.yaml
+++ b/static/locales/ai/sr.yaml
@@ -434,6 +434,7 @@ Settings:
       Catppuccin Latte Mauve: Catppuccin Latte Mauve
       Catppuccin Latte Red: Catppuccin Latte Red
   Player Settings:
+    Music Visualizer: Музички визуализатор
     Automatically Open Chapters: Аутоматски отварај поглавља
     Caption Appearance:
       Caption Appearance: Изглед титлова

--- a/static/locales/ai/sv.yaml
+++ b/static/locales/ai/sv.yaml
@@ -422,6 +422,7 @@ Settings:
         Destructive pressed: Nedtryckt destruktiv åtgärd
         Text and icons on destructive actions: Text och ikoner på destruktiva åtgärder
   Player Settings:
+    Music Visualizer: Musikvisualisering
     Automatically Open Chapters: Öppna kapitel automatiskt
     Caption Appearance:
       Caption Appearance: Undertexternas utseende

--- a/static/locales/ai/ta.yaml
+++ b/static/locales/ai/ta.yaml
@@ -425,6 +425,7 @@ Settings:
         Destructive pressed: அழிக்கும் செயல் அழுத்தப்பட்டது
         Text and icons on destructive actions: அழிக்கும் செயல்களிலுள்ள உரையும் படவுருக்களும்
   Player Settings:
+    Music Visualizer: இசைக் காட்சிப்படுத்தி
     Automatically Open Chapters: அத்தியாயங்களைத் தானாகத் திற
     Caption Appearance:
       Caption Appearance: வசன வரித் தோற்றம்

--- a/static/locales/ai/tr.yaml
+++ b/static/locales/ai/tr.yaml
@@ -420,6 +420,7 @@ Settings:
         Destructive pressed: Basılı yıkıcı işlem
         Text and icons on destructive actions: Yıkıcı işlemlerdeki metin ve simgeler
   Player Settings:
+    Music Visualizer: Müzik görselleştirici
     Automatically Open Chapters: Bölümleri Otomatik Olarak Aç
     Caption Appearance:
       Caption Appearance: Alt Yazı Görünümü

--- a/static/locales/ai/uk.yaml
+++ b/static/locales/ai/uk.yaml
@@ -424,6 +424,7 @@ Settings:
         Destructive pressed: Натиснута небезпечна дія
         Text and icons on destructive actions: Текст і піктограми небезпечних дій
   Player Settings:
+    Music Visualizer: Музичний візуалізатор
     Automatically Open Chapters: Автоматично відкривати розділи
     Caption Appearance:
       Caption Appearance: Вигляд субтитрів

--- a/static/locales/ai/vi.yaml
+++ b/static/locales/ai/vi.yaml
@@ -424,6 +424,7 @@ Settings:
         Destructive pressed: Thao tác xóa khi nhấn
         Text and icons on destructive actions: Chữ và biểu tượng trên thao tác xóa
   Player Settings:
+    Music Visualizer: Trình trực quan hóa nhạc
     Automatically Open Chapters: Tự động mở chương
     Caption Appearance:
       Caption Appearance: Giao diện phụ đề

--- a/static/locales/ai/zh-CN.yaml
+++ b/static/locales/ai/zh-CN.yaml
@@ -420,6 +420,7 @@ Settings:
         Destructive pressed: 危险操作按下状态
         Text and icons on destructive actions: 危险操作的文本和图标
   Player Settings:
+    Music Visualizer: 音乐可视化
     Automatically Open Chapters: 自动展开章节
     Caption Appearance:
       Caption Appearance: 字幕外观

--- a/static/locales/ai/zh-TW.yaml
+++ b/static/locales/ai/zh-TW.yaml
@@ -422,6 +422,7 @@ Settings:
         Destructive pressed: 危險操作的按下狀態
         Text and icons on destructive actions: 危險操作上的文字與圖示
   Player Settings:
+    Music Visualizer: 音樂視覺化工具
     Automatically Open Chapters: 自動開啟章節
     Caption Appearance:
       Caption Appearance: 字幕外觀

--- a/static/locales/de-DE.yaml
+++ b/static/locales/de-DE.yaml
@@ -664,6 +664,7 @@ Settings:
         Text and icons on destructive actions: Text und Symbole auf destruktiven Aktionen
   Player Settings:
     Player Settings: Video-Player
+    Music Visualizer: Musikvisualisierung
     Play Next Video: Empfohlene Videos automatisch abspielen
     Turn on Subtitles by Default: Untertitel standardmäßig einschalten
     Autoplay Videos: Videos automatisch starten

--- a/static/locales/en-US.yaml
+++ b/static/locales/en-US.yaml
@@ -844,6 +844,7 @@ Settings:
         #* Main Color Theme
   Player Settings:
     Player Settings: Player
+    Music Visualizer: Music visualizer
     Play Next Video: Autoplay Recommended Videos
     Autoplay Playlists: Autoplay Playlist Videos
     Autoplay Videos: Start Videos Automatically

--- a/tests/unit/music-media-type.test.mjs
+++ b/tests/unit/music-media-type.test.mjs
@@ -4,6 +4,7 @@ import test from 'node:test'
 import {
   classifyInvidiousMusicMediaType,
   classifyMusicMediaType,
+  getMusicTrackArtist,
   MUSIC_MEDIA_TYPE,
 } from '../../src/renderer/helpers/player/musicMediaType.js'
 
@@ -25,6 +26,11 @@ test('classifies Invidious music from artist topic channels as audio tracks', ()
     author: 'Example Artist - Topic',
     genre: 'Music',
   }), MUSIC_MEDIA_TYPE.AUDIO_TRACK)
+})
+
+test('removes the topic-channel suffix from music track artists', () => {
+  assert.equal(getMusicTrackArtist('Example Artist - Topic'), 'Example Artist')
+  assert.equal(getMusicTrackArtist('Example Artist'), 'Example Artist')
 })
 
 test('keeps ambiguous Invidious music and non-music topic videos unknown', () => {

--- a/tests/unit/music-media-type.test.mjs
+++ b/tests/unit/music-media-type.test.mjs
@@ -1,0 +1,43 @@
+import assert from 'node:assert/strict'
+import test from 'node:test'
+
+import {
+  classifyInvidiousMusicMediaType,
+  classifyMusicMediaType,
+  MUSIC_MEDIA_TYPE,
+} from '../../src/renderer/helpers/player/musicMediaType.js'
+
+test('classifies YouTube Music audio tracks separately from music videos', () => {
+  assert.equal(classifyMusicMediaType('MUSIC_VIDEO_TYPE_ATV'), MUSIC_MEDIA_TYPE.AUDIO_TRACK)
+  assert.equal(classifyMusicMediaType('MUSIC_VIDEO_TYPE_OMV'), MUSIC_MEDIA_TYPE.OFFICIAL_VIDEO)
+  assert.equal(classifyMusicMediaType('MUSIC_VIDEO_TYPE_UGC'), MUSIC_MEDIA_TYPE.USER_VIDEO)
+  assert.equal(classifyMusicMediaType('MUSIC_VIDEO_TYPE_PODCAST_EPISODE'), MUSIC_MEDIA_TYPE.PODCAST)
+})
+
+test('keeps missing and new YouTube music types unknown', () => {
+  assert.equal(classifyMusicMediaType(undefined), MUSIC_MEDIA_TYPE.UNKNOWN)
+  assert.equal(classifyMusicMediaType('MUSIC_VIDEO_TYPE_FUTURE'), MUSIC_MEDIA_TYPE.UNKNOWN)
+  assert.equal(classifyMusicMediaType(''), MUSIC_MEDIA_TYPE.UNKNOWN)
+})
+
+test('classifies Invidious music from artist topic channels as audio tracks', () => {
+  assert.equal(classifyInvidiousMusicMediaType({
+    author: 'Example Artist - Topic',
+    genre: 'Music',
+  }), MUSIC_MEDIA_TYPE.AUDIO_TRACK)
+})
+
+test('keeps ambiguous Invidious music and non-music topic videos unknown', () => {
+  assert.equal(classifyInvidiousMusicMediaType({
+    author: 'Example Artist',
+    genre: 'Music',
+  }), MUSIC_MEDIA_TYPE.UNKNOWN)
+  assert.equal(classifyInvidiousMusicMediaType({
+    author: 'Example Game - Topic',
+    genre: 'Gaming',
+  }), MUSIC_MEDIA_TYPE.UNKNOWN)
+  assert.equal(classifyInvidiousMusicMediaType({
+    author: null,
+    genre: 'Music',
+  }), MUSIC_MEDIA_TYPE.UNKNOWN)
+})


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Make sure to follow the contributing guidelines. -->
<!-- Important note, we may remove your pull request if you do not use this provided PR template correctly. -->
<!-- Agent instructions: Preserve every heading, comment, and marker in this template. Never remove or rewrite the release-note-category:start/end, release-note:start/end, or release-note-image:start/end marker pairs. -->

## Pull Request Type
<!-- Please select what type of pull request this is: [x] -->
- [ ] Bugfix
- [x] Feature Implementation
- [ ] Documentation
- [ ] Other

## Related issue
<!-- Please link the issue your pull request is referring to. -->
<!-- If this pull request fully resolves the relevant issue, put "closes" before the issue number. -->
<!-- Example: "closes #123456". -->
closes #393

## Description
<!-- Please write a clear and concise description of what the pull request does. -->
YouTube Music audio tracks and audio-only formats now use a dedicated artwork player. It includes a canvas visualizer that is enabled by default and can be toggled in the player options. The seek bar keeps its time preview in this mode without showing video thumbnails.

YouTube Music classification uses Innertube music metadata when available, with a narrow artist topic-channel fallback for Invidious. Official music videos and ordinary Music-category videos remain in the video player.

## Release note category
<!-- Select exactly one category. Every pull request must select one. -->
<!-- Select "Not noteworthy" when the pull request fixes a bug in or improves functionality that has not yet appeared in a stable release. -->
<!-- release-note-category:start -->
- [ ] Not noteworthy
- [x] Highlights
- [ ] More improvements
- [ ] Fixed bugs
<!-- release-note-category:end -->

## Release note
<!-- Required unless "Not noteworthy" is selected. -->
<!-- Write one concise, user-facing entry without a leading bullet. -->
<!-- release-note:start -->
YouTube Music audio tracks and audio-only formats now use a dedicated artwork player with an optional visualizer.
<!-- release-note:end -->

## Release note images
<!-- Optional. Paste one or more Markdown images, HTML image tags, or dark/light <picture> elements here. -->
<!-- The release notes normalize the markup and limit images taller than 300 pixels. -->
<!-- Agent instructions:
For a noteworthy visible change, add media when it makes the change easier to understand. Prefer a still image unless motion is the point; recordings must use animated WebP.
After implementing a visible change, proactively capture the result and show the local media to the user for approval before uploading it or updating the pull request.
When the affected UI differs between dark and light themes, capturing both themes is required. A dark-only image is incomplete. Run `node _scripts/releaseNoteMedia.mjs --dark DARK_FILE --light LIGHT_FILE --alt "DESCRIPTION"`; GitHub will display the matching theme and use dark as the fallback. Use a single default-dark capture only when the light theme cannot be captured or looks identical.
Capture or crop to the smallest region that still makes the change clear. Do not include the full window when the affected component can be understood on its own.
Use English unless localization is the subject. Keep components at their normal dimensions and placement instead of resizing them to fill the frame.
Use deterministic local fixtures for visible remote images. Reusable avatar and thumbnail fixtures are available through `e2e/helpers/visual-fixtures.mjs`. Before capturing, verify that every visible image has loaded successfully (`complete === true` and `naturalWidth > 0`).
Inspect the final dark and light files for failed images, missing content, unrelated UI, awkward animation, and misleading layout. Omit media when it does not explain the change clearly.
For one dark capture, run `node _scripts/releaseNoteMedia.mjs FILE --alt "DESCRIPTION"`.
Check for personal information, tokens, private repository names, and unrelated desktop content before uploading. Uploaded media is public.
Keep capture-only scripts, test hooks, screenshots, and recordings out of commits. Remove them before committing unless the capture code is also a reusable regression test. Never commit generated release-note media.
Paste only the generated markup between the marker comments. Leave this section empty when media would not help.
-->
<!-- release-note-image:start -->
<img src="https://github.com/OpenTubeX/media/releases/download/attachments/20260831T212640Z-opentubex-music-player-real-song-82408ea747.webp" alt="YouTube Music artwork player with an animated audio spectrum">
<!-- release-note-image:end -->

## Testing
<!-- How can reviewers verify that the PR produces correct results? -->
<!-- Please provide instructions so that others can ensure that your pull request would produce correct results. For examples see, https://github.com/FreeTubeApp/FreeTube/pull/5743, https://github.com/FreeTubeApp/FreeTube/pull/7349, https://github.com/FreeTubeApp/FreeTube/pull/5125, https://github.com/FreeTubeApp/FreeTube/pull/7338 -->
<!-- Agent instructions: Only write human-facing steps that explain how to verify the change while running this branch in dev mode. Include expected results and, when applicable, helpful console snippets for interactive verification. Do not include automated checks, commands, results, pass counts, or CI status. -->
1. Open a YouTube Music audio track or an upload from an artist topic channel. The player should show the thumbnail, title, artist, and animated visualizer instead of the video.
2. Hover the seek bar. The time preview should remain visible, but the thumbnail preview should stay hidden.
3. Open the player options and toggle `Music visualizer`. The canvas should disappear and return without interrupting playback.
4. Select an audio-only default video format and open a regular video. The same artwork player should be used.
5. Open an official music video. It should continue to use the normal video player.

## Additional context
<!-- Add any other context about the pull request here. -->
The visualizer is implemented locally with Canvas and the Web Audio API. It does not add a visualization dependency or send audio anywhere.