### PR TITLE
fix(subscriptions): resurface videos when membership ends

### DIFF
--- a/src/renderer/helpers/subscription-entries.js
+++ b/src/renderer/helpers/subscription-entries.js
@@ -244,7 +244,7 @@ export function reconcileFetchedSubscriptionEntries(
     const wasPreviouslyNew = previousEntry?.isNewInSubscriptionFeed === true
     const becamePublic = idKey === 'videoId' &&
       previousEntry?.isMembersOnly === true &&
-      entry.isMembersOnly !== true
+      entry.isMembersOnly === false
     const isNewlyFetched = firstPreviouslyFetchedIndex > 0 &&
       index < firstPreviouslyFetchedIndex &&
       isPlausiblyRecent

--- a/src/renderer/helpers/subscription-entries.js
+++ b/src/renderer/helpers/subscription-entries.js
@@ -242,13 +242,16 @@ export function reconcileFetchedSubscriptionEntries(
     const isWatched = idKey === 'videoId' && isHistoryEntryWatched(historyById?.[entry[idKey]])
     const previousEntry = previousEntriesById?.get(entry[idKey])
     const wasPreviouslyNew = previousEntry?.isNewInSubscriptionFeed === true
+    const becamePublic = idKey === 'videoId' &&
+      previousEntry?.isMembersOnly === true &&
+      entry.isMembersOnly !== true
     const isNewlyFetched = firstPreviouslyFetchedIndex > 0 &&
       index < firstPreviouslyFetchedIndex &&
       isPlausiblyRecent
 
     const reconciledEntry = {
       ...entry,
-      isNewInSubscriptionFeed: !isWatched && (wasPreviouslyNew || isNewlyFetched)
+      isNewInSubscriptionFeed: !isWatched && (wasPreviouslyNew || becamePublic || isNewlyFetched)
     }
 
     if (entry.isUpcoming === true || entry.premiere === true) {

--- a/tests/unit/subscription-entries.test.mjs
+++ b/tests/unit/subscription-entries.test.mjs
@@ -320,6 +320,20 @@ test('marks entries published since the previous fetch as new', () => {
   assert.deepEqual(reconciled.map(entry => entry.isNewInSubscriptionFeed), [true, false])
 })
 
+test('marks a seen members-only video as new when it becomes public', () => {
+  const reconciled = reconcileFetchedSubscriptionEntries(
+    [video('members-first', now - HOUR, { isMembersOnly: false })],
+    [video('members-first', now - HOUR, {
+      isMembersOnly: true,
+      isNewInSubscriptionFeed: false
+    })],
+    'videoId',
+    now - 2 * HOUR
+  )
+
+  assert.equal(reconciled[0].isNewInSubscriptionFeed, true)
+})
+
 test('keeps entries that were already marked as new', () => {
   const previousEntries = [video('a', now - 2 * HOUR, { isNewInSubscriptionFeed: true })]
   const entries = [video('a', now - 2 * HOUR)]

--- a/tests/unit/subscription-entries.test.mjs
+++ b/tests/unit/subscription-entries.test.mjs
@@ -334,6 +334,20 @@ test('marks a seen members-only video as new when it becomes public', () => {
   assert.equal(reconciled[0].isNewInSubscriptionFeed, true)
 })
 
+test('keeps a seen members-only video seen when its membership state is unknown', () => {
+  const reconciled = reconcileFetchedSubscriptionEntries(
+    [video('members-first', now - HOUR)],
+    [video('members-first', now - HOUR, {
+      isMembersOnly: true,
+      isNewInSubscriptionFeed: false
+    })],
+    'videoId',
+    now - 2 * HOUR
+  )
+
+  assert.equal(reconciled[0].isNewInSubscriptionFeed, false)
+})
+
 test('keeps entries that were already marked as new', () => {
   const previousEntries = [video('a', now - 2 * HOUR, { isNewInSubscriptionFeed: true })]
   const entries = [video('a', now - 2 * HOUR)]


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Make sure to follow the contributing guidelines. -->
<!-- Important note, we may remove your pull request if you do not use this provided PR template correctly. -->
<!-- Agent instructions: Preserve every heading, comment, and marker in this template. Never remove or rewrite the release-note-category:start/end, release-note:start/end, or release-note-image:start/end marker pairs. -->

## Pull Request Type
<!-- Please select what type of pull request this is: [x] -->
- [x] Bugfix
- [ ] Feature Implementation
- [ ] Documentation
- [ ] Other

## Related issue
<!-- Please link the issue your pull request is referring to. -->
<!-- If this pull request fully resolves the relevant issue, put "closes" before the issue number. -->
<!-- Example: "closes #123456". -->

No linked issue. The bug was reported directly with its reproduction sequence.

## Description
<!-- Please write a clear and concise description of what the pull request does. -->

A members-only or members-first video could appear in the subscription feed, be marked as seen, and later become public without appearing as new again.

Subscription cache reconciliation now treats the members-only-to-public transition as new content. Videos already present in watch history remain excluded. A regression test covers the seen-to-public sequence.

## Release note category
<!-- Select exactly one category. Every pull request must select one. -->
<!-- Select "Not noteworthy" when the pull request fixes a bug in or improves functionality that has not yet appeared in a stable release. -->
<!-- release-note-category:start -->
- [ ] Not noteworthy
- [ ] Highlights
- [ ] More improvements
- [x] Fixed bugs
<!-- release-note-category:end -->

## Release note
<!-- Required unless "Not noteworthy" is selected. -->
<!-- Write one concise, user-facing entry without a leading bullet. -->
<!-- release-note:start -->
Videos that become public after a members-only period now appear as new in subscriptions.
<!-- release-note:end -->

## Release note images
<!-- Optional. Paste one or more Markdown images, HTML image tags, or dark/light <picture> elements here. -->
<!-- The release notes normalize the markup and limit images taller than 300 pixels. -->
<!-- Agent instructions:
For a noteworthy visible change, add media when it makes the change easier to understand. Prefer a still image unless motion is the point; recordings must use animated WebP.
After implementing a visible change, proactively capture the result and show the local media to the user for approval before uploading it or updating the pull request.
When the affected UI differs between dark and light themes, capturing both themes is required. A dark-only image is incomplete. Run `node _scripts/releaseNoteMedia.mjs --dark DARK_FILE --light LIGHT_FILE --alt "DESCRIPTION"`; GitHub will display the matching theme and use dark as the fallback. Use a single default-dark capture only when the light theme cannot be captured or looks identical.
Capture or crop to the smallest region that still makes the change clear. Do not include the full window when the affected component can be understood on its own.
Use English unless localization is the subject. Keep components at their normal dimensions and placement instead of resizing them to fill the frame.
Use deterministic local fixtures for visible remote images. Reusable avatar and thumbnail fixtures are available through `e2e/helpers/visual-fixtures.mjs`. Before capturing, verify that every visible image has loaded successfully (`complete === true` and `naturalWidth > 0`).
Inspect the final dark and light files for failed images, missing content, unrelated UI, awkward animation, and misleading layout. Omit media when it does not explain the change clearly.
For one dark capture, run `node _scripts/releaseNoteMedia.mjs FILE --alt "DESCRIPTION"`.
Check for personal information, tokens, private repository names, and unrelated desktop content before uploading. Uploaded media is public.
Keep capture-only scripts, test hooks, screenshots, and recordings out of commits. Remove them before committing unless the capture code is also a reusable regression test. Never commit generated release-note media.
Paste only the generated markup between the marker comments. Leave this section empty when media would not help.
-->
<!-- release-note-image:start -->

<!-- release-note-image:end -->

## Testing
<!-- How can reviewers verify that the PR produces correct results? -->
<!-- Please provide instructions so that others can ensure that your pull request produces correct results. For examples see, https://github.com/FreeTubeApp/FreeTube/pull/5743, https://github.com/FreeTubeApp/FreeTube/pull/7349, https://github.com/FreeTubeApp/FreeTube/pull/5125, https://github.com/FreeTubeApp/FreeTube/pull/7338 -->
<!-- Agent instructions: Only write human-facing steps that explain how to verify the change while running this branch in dev mode. Include expected results and, when applicable, helpful console snippets for interactive verification. Do not include automated checks, commands, results, pass counts, or CI status. -->

1. While running this branch in dev mode with restricted-playback authentication configured, refresh subscriptions while a subscribed channel has a members-first video.
2. Mark that video as seen in the subscription feed.
3. Once the video becomes public, refresh subscriptions again.
4. Confirm that the video reappears in the New feed. If the video was watched instead of only marked as seen, confirm that it stays out of the New feed.

## Additional context
<!-- Add any other context about the pull request here. -->

The Local API uses the same badge for members-only and members-first videos. Its parsed `isMembersOnly` value changes to `false` after the badge disappears, which gives reconciliation a stable transition to detect.
