### PR TITLE
fix(sponsorblock): hide contribution stats when submissions are disabled

### DIFF
--- a/e2e/tests/offline/watch-page.spec.mjs
+++ b/e2e/tests/offline/watch-page.spec.mjs
@@ -60,6 +60,29 @@ async function expectPlayerMenuScrollState(menu, atEnd = true) {
   }, atEnd)).toEqual({ scrollPositionValid: true, scrollbarMatchesOverflow: true })
 }
 
+async function expectSponsorBlockContentClamp(content, previousScrollTop) {
+  await expect.poll(() => content.evaluate((element, previousScrollTop) => {
+    const viewportBounds = element.getBoundingClientRect()
+    const contentEndBounds = element.querySelector('.sponsorBlockFooter').getBoundingClientRect()
+    const maximumScrollTop = Math.max(
+      0,
+      element.scrollTop + contentEndBounds.bottom - viewportBounds.bottom
+    )
+    const scrollbar = element.querySelector(':scope > .os-scrollbar-vertical')
+    const hasVerticalOverflow = maximumScrollTop > 1
+    return {
+      scrollTopReduced: element.scrollTop < previousScrollTop,
+      withinRenderedRange: element.scrollTop <= maximumScrollTop + 1,
+      scrollbarMatchesOverflow:
+        scrollbar?.classList.contains('os-scrollbar-visible') === hasVerticalOverflow
+    }
+  }, previousScrollTop)).toEqual({
+    scrollTopReduced: true,
+    withinRenderedRange: true,
+    scrollbarMatchesOverflow: true
+  })
+}
+
 test.use({ seed: { settings: WATCH_PAGE_SEED } })
 
 test('keeps metadata errors visible in family-friendly-only mode', async ({ app, page }) => {
@@ -3437,6 +3460,7 @@ test.describe('watch page', () => {
       const store = document.querySelector('#app').__vue_app__.config.globalProperties.$store
       store.commit('setUseSponsorBlock', true)
       store.commit('setSponsorBlockGeneratedUserId', 'test-contributor')
+      await store.dispatch('updateSponsorBlockEnableSubmission', true)
       await store.dispatch('updateUiScale', 125)
     })
     await openMockedVideo(page)
@@ -3485,21 +3509,21 @@ test.describe('watch page', () => {
     await panel.evaluate((element) => { element.style.inlineSize = '' })
     await expect.poll(() => panel.evaluate(element => element.getBoundingClientRect().width))
       .toBeGreaterThan(240)
-    await expect.poll(() => content.evaluate((element, previousScrollTop) => {
-      const viewportBounds = element.getBoundingClientRect()
-      const contentEndBounds = element.querySelector('.sponsorBlockFooter').getBoundingClientRect()
-      const maximumScrollTop = Math.max(
-        0,
-        element.scrollTop + contentEndBounds.bottom - viewportBounds.bottom
-      )
-      return {
-        scrollTopReduced: element.scrollTop < previousScrollTop,
-        withinRenderedRange: element.scrollTop <= maximumScrollTop + 1
-      }
-    }, narrowScrollTop)).toEqual({
-      scrollTopReduced: true,
-      withinRenderedRange: true
+    await expectSponsorBlockContentClamp(content, narrowScrollTop)
+
+    await content.evaluate((element) => { element.scrollTop = element.scrollHeight })
+    const enabledScrollTop = await content.evaluate(element => element.scrollTop)
+    await page.evaluate(async () => {
+      const store = document.querySelector('#app').__vue_app__.config.globalProperties.$store
+      await store.dispatch('updateSponsorBlockEnableSubmission', false)
     })
+    await expect(stats).toHaveCount(0)
+    await expectSponsorBlockContentClamp(content, enabledScrollTop)
+    await page.evaluate(async () => {
+      const store = document.querySelector('#app').__vue_app__.config.globalProperties.$store
+      await store.dispatch('updateSponsorBlockEnableSubmission', true)
+    })
+    await expect(stats).toBeVisible()
 
     await panel.getByRole('button', { name: 'Close' }).click()
     await page.getByRole('button', { name: 'Open SponsorBlock info' }).click()
@@ -3525,6 +3549,23 @@ test.describe('watch page', () => {
     })
   })
 
+  test('hides SponsorBlock contribution stats when submission is disabled', async ({ app, page }) => {
+    await mockPlayableWatchPage(app, page)
+    await page.evaluate(() => {
+      const store = document.querySelector('#app').__vue_app__.config.globalProperties.$store
+      store.commit('setUseSponsorBlock', true)
+      store.commit('setSponsorBlockGeneratedUserId', 'test-contributor')
+    })
+    await expect.poll(() => page.evaluate(() => {
+      return document.querySelector('#app').__vue_app__.config.globalProperties.$store.getters
+        .getSponsorBlockEnableSubmission
+    })).toBe(false)
+    await openMockedVideo(page)
+    await page.getByRole('button', { name: 'Open SponsorBlock info' }).click()
+
+    await expect(page.locator('.sponsorBlockContributionStats')).toHaveCount(0)
+  })
+
   test('does not create a SponsorBlock user ID to load contribution stats', async ({ app, page }) => {
     await mockPlayableWatchPage(app, page)
 
@@ -3533,9 +3574,10 @@ test.describe('watch page', () => {
       userInfoRequests++
       return route.abort()
     })
-    await page.evaluate(() => {
+    await page.evaluate(async () => {
       const store = document.querySelector('#app').__vue_app__.config.globalProperties.$store
       store.commit('setUseSponsorBlock', true)
+      await store.dispatch('updateSponsorBlockEnableSubmission', true)
     })
     await openMockedVideo(page)
     await page.getByRole('button', { name: 'Open SponsorBlock info' }).click()

--- a/src/renderer/components/WatchVideoSponsorBlock/WatchVideoSponsorBlock.vue
+++ b/src/renderer/components/WatchVideoSponsorBlock/WatchVideoSponsorBlock.vue
@@ -13,14 +13,14 @@
       <div class="sponsorBlockHeaderActions">
         <button
           type="button"
-          :disabled="loading || contributionStatsLoading"
+          :disabled="loading || (submissionEnabled && contributionStatsLoading)"
           :aria-label="$t('Video.Player.SponsorBlock.RefreshInfo')"
           :title="$t('Video.Player.SponsorBlock.RefreshInfo')"
           @click="$emit('refresh')"
         >
           <ft-icon
             :icon="['fas', 'sync']"
-            :spin="loading || contributionStatsLoading"
+            :spin="loading || (submissionEnabled && contributionStatsLoading)"
           />
         </button>
         <button
@@ -48,6 +48,7 @@
             : $t('Video.Player.SponsorBlock.InfoPanelNoSegments') }}
       </div>
       <section
+        v-if="submissionEnabled"
         class="sponsorBlockContributionStats"
         :aria-busy="String(contributionStatsLoading || !contributionStatsLoaded)"
       >
@@ -336,6 +337,7 @@ watch(
     props.contributionStatsError,
     props.contributionStatsLoaded,
     props.contributionStatsLoading,
+    props.submissionEnabled,
     selectedUuid.value,
   ],
   scheduleScrollClamp

--- a/src/renderer/components/ft-shaka-video-player/ft-shaka-video-player.js
+++ b/src/renderer/components/ft-shaka-video-player/ft-shaka-video-player.js
@@ -2081,14 +2081,15 @@ export default defineComponent({
     }
 
     async function refreshSponsorBlockInfo() {
-      await Promise.all([
-        setupSponsorBlock(),
-        refreshSponsorBlockContributionStats()
-      ])
+      const refreshTasks = [setupSponsorBlock()]
+      if (sponsorBlockEnableSubmission.value) {
+        refreshTasks.push(refreshSponsorBlockContributionStats())
+      }
+      await Promise.all(refreshTasks)
     }
 
     async function refreshSponsorBlockContributionStats() {
-      if (sponsorBlockContributionStatsLoading.value) {
+      if (!sponsorBlockEnableSubmission.value || sponsorBlockContributionStatsLoading.value) {
         return
       }
 
@@ -2134,6 +2135,7 @@ export default defineComponent({
       sponsorBlockInfoOpen.value = !sponsorBlockInfoOpen.value
       if (
         sponsorBlockInfoOpen.value &&
+        sponsorBlockEnableSubmission.value &&
         !sponsorBlockContributionStatsLoaded.value &&
         !sponsorBlockContributionStatsLoading.value
       ) {
@@ -5072,7 +5074,17 @@ export default defineComponent({
 
     watch(sponsorSkips, scheduleSponsorBlockSkip)
 
-    watch(sponsorBlockEnableSubmission, () => emitSponsorBlockInfoState())
+    watch(sponsorBlockEnableSubmission, (enabled) => {
+      if (
+        enabled &&
+        sponsorBlockInfoOpen.value &&
+        !sponsorBlockContributionStatsLoaded.value &&
+        !sponsorBlockContributionStatsLoading.value
+      ) {
+        refreshSponsorBlockContributionStats()
+      }
+      emitSponsorBlockInfoState()
+    })
 
     watch(sponsorBlockDraftSegmentsByVideoId, () => {
       loadSponsorBlockDrafts()


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Make sure to follow the contributing guidelines. -->
<!-- Important note, we may remove your pull request if you do not use this provided PR template correctly. -->
<!-- Agent instructions: Preserve every heading, comment, and marker in this template. Never remove or rewrite the release-note-category:start/end, release-note:start/end, or release-note-image:start/end marker pairs. -->

## Pull Request Type
<!-- Please select what type of pull request this is: [x] -->
- [x] Bugfix
- [ ] Feature Implementation
- [ ] Documentation
- [ ] Other

## Related issue
<!-- Please link the issue your pull request is referring to. -->
<!-- If this pull request fully resolves the relevant issue, put "closes" before the issue number. -->
<!-- Example: "closes #123456". -->

No linked issue.

## Description
<!-- Please write a clear and concise description of what the pull request does. -->

The SponsorBlock panel showed contribution stats even when submissions were disabled. This change hides the stats in that state, avoids fetching them until submissions are enabled, and keeps the panel's scroll position valid when the card disappears.

## Release note category
<!-- Select exactly one category. Every pull request must select one. -->
<!-- Select "Not noteworthy" when the pull request fixes a bug in or improves functionality that has not yet appeared in a stable release. -->
<!-- release-note-category:start -->
- [ ] Not noteworthy
- [ ] Highlights
- [ ] More improvements
- [x] Fixed bugs
<!-- release-note-category:end -->

## Release note
<!-- Required unless "Not noteworthy" is selected. -->
<!-- Write one concise, user-facing entry without a leading bullet. -->
<!-- release-note:start -->
SponsorBlock contribution stats no longer appear when submissions are disabled.
<!-- release-note:end -->

## Release note images
<!-- Optional. Paste one or more Markdown images, HTML image tags, or dark/light <picture> elements here. -->
<!-- The release notes normalize the markup and limit images taller than 300 pixels. -->
<!-- Agent instructions:
For a noteworthy visible change, add media when it makes the change easier to understand. Prefer a still image unless motion is the point; recordings must use animated WebP.
After implementing a visible change, proactively capture the result and show the local media to the user for approval before uploading it or updating the pull request.
When the affected UI differs between dark and light themes, capturing both themes is required. A dark-only image is incomplete. Run `node _scripts/releaseNoteMedia.mjs --dark DARK_FILE --light LIGHT_FILE --alt "DESCRIPTION"`; GitHub will display the matching theme and use dark as the fallback. Use a single default-dark capture only when the light theme cannot be captured or looks identical.
Capture or crop to the smallest region that still makes the change clear. Do not include the full window when the affected component can be understood on its own.
Use English unless localization is the subject. Keep components at their normal dimensions and placement instead of resizing them to fill the frame.
Use deterministic local fixtures for visible remote images. Reusable avatar and thumbnail fixtures are available through `e2e/helpers/visual-fixtures.mjs`. Before capturing, verify that every visible image has loaded successfully (`complete === true` and `naturalWidth > 0`).
Inspect the final dark and light files for failed images, missing content, unrelated UI, awkward animation, and misleading layout. Omit media when it does not explain the change clearly.
For one dark capture, run `node _scripts/releaseNoteMedia.mjs FILE --alt "DESCRIPTION"`.
Check for personal information, tokens, private repository names, and unrelated desktop content before uploading. Uploaded media is public.
Keep capture-only scripts, test hooks, screenshots, and recordings out of commits. Remove them before committing unless the capture code is also a reusable regression test. Never commit generated release-note media.
Paste only the generated markup between the marker comments. Leave this section empty when media would not help.
-->
<!-- release-note-image:start -->

<!-- release-note-image:end -->

## Testing
<!-- How can reviewers verify that the PR produces correct results? -->
<!-- Please provide instructions so that others can ensure that your pull request would produce correct results. For examples see, https://github.com/FreeTubeApp/FreeTube/pull/5743, https://github.com/FreeTubeApp/FreeTube/pull/7349, https://github.com/FreeTubeApp/FreeTube/pull/5125, https://github.com/FreeTubeApp/FreeTube/pull/7338 -->
<!-- Agent instructions: Only write human-facing steps that explain how to verify the change while running this branch in dev mode. Include expected results and, when applicable, helpful console snippets for interactive verification. Do not include automated checks, commands, results, pass counts, or CI status. -->

1. Enable SponsorBlock but leave SponsorBlock submission disabled, then open a video's SponsorBlock info panel. The contribution stats card should be absent.
2. Enable SponsorBlock submission and open the panel again. The contribution stats card should appear and load the existing user's stats.
3. Disable submission while the panel is open and scrolled to the bottom. The card should disappear without leaving empty space or an invalid scrollbar position.

## Additional context
<!-- Add any other context about the pull request here. -->
