### PR TITLE
feat(settings): add test toast control

### DIFF
--- a/e2e/tests/offline/settings.spec.mjs
+++ b/e2e/tests/offline/settings.spec.mjs
@@ -3350,6 +3350,20 @@ test.describe('settings', () => {
     await expect(toast).toHaveCount(0)
   })
 
+  test('shows a test toast from the toast position setting', async ({ page }) => {
+    await goTo(page, 'settings')
+    await page.locator('.settingsMenu [data-section="appearance"]').click()
+
+    const themeSection = page.locator('[data-section="appearance"]')
+    const toastPositionRow = themeSection.locator('.themeSelectRow')
+      .filter({ hasText: 'Toast Position' })
+    const holder = page.locator('.toast-holder')
+
+    await toastPositionRow.getByRole('button', { name: 'Test toast' }).click()
+
+    await expect(holder.locator('.toast', { hasText: 'Test toast' })).toBeVisible()
+  })
+
   test('does not dismiss non-actionable toasts when clicked', async ({ page }) => {
     await page.evaluate(() => {
       window.ftElectron.showToastOnAllTabs('Swipe-only dismissal', 10000)

--- a/e2e/tests/offline/settings.spec.mjs
+++ b/e2e/tests/offline/settings.spec.mjs
@@ -3339,6 +3339,7 @@ test.describe('settings', () => {
     await page.mouse.up()
     await expect(toast).toHaveCount(0)
 
+    await positionSelect.selectOption('bottom-right')
     await positionSelect.selectOption('top-right')
     await expect(holder).toHaveClass(/position-top-right/)
     toast = await showToast('Top right toast')

--- a/e2e/tests/offline/settings.spec.mjs
+++ b/e2e/tests/offline/settings.spec.mjs
@@ -3357,10 +3357,15 @@ test.describe('settings', () => {
     const themeSection = page.locator('[data-section="appearance"]')
     const toastPositionRow = themeSection.locator('.themeSelectRow')
       .filter({ hasText: 'Toast Position' })
+    const positionSelect = toastPositionRow.locator('.select')
+      .filter({ hasText: 'Toast Position' })
+      .locator('select')
     const holder = page.locator('.toast-holder')
 
+    await positionSelect.selectOption('top-right')
     await toastPositionRow.getByRole('button', { name: 'Test toast' }).click()
 
+    await expect(holder).toHaveClass(/position-top-right/)
     await expect(holder.locator('.toast', { hasText: 'Test toast' })).toBeVisible()
   })
 

--- a/src/renderer/components/ThemeSettings.vue
+++ b/src/renderer/components/ThemeSettings.vue
@@ -824,15 +824,17 @@ const toastPositionNames = computed(() => [
 
 /** @type {import('vue').ComputedRef<'bottom-left' | 'bottom-center' | 'bottom-right' | 'top-left' | 'top-center' | 'top-right'>} */
 const toastPosition = computed(() => normalizeToastPosition(store.getters.getToastPosition))
+let toastPositionUpdatePromise = Promise.resolve()
 
 /**
  * @param {'bottom-left' | 'bottom-center' | 'bottom-right' | 'top-left' | 'top-center' | 'top-right'} value
  */
 function updateToastPosition(value) {
-  store.dispatch('updateToastPosition', value)
+  toastPositionUpdatePromise = store.dispatch('updateToastPosition', value)
 }
 
-function showTestToast() {
+async function showTestToast() {
+  await toastPositionUpdatePromise
   showToast({
     message: t('Settings.Theme Settings.Toast Position.Test Toast'),
     icon: ['fas', 'message']

--- a/src/renderer/components/ThemeSettings.vue
+++ b/src/renderer/components/ThemeSettings.vue
@@ -30,6 +30,12 @@
         :icon="['fas', 'message']"
         @change="updateToastPosition"
       />
+      <FtButton
+        class="testToastButton"
+        :label="t('Settings.Theme Settings.Toast Position.Test Toast')"
+        :icon="['fas', 'message']"
+        @click="showTestToast"
+      />
     </FtFlexBox>
     <FtFlexBox
       v-if="baseTheme === 'system'"
@@ -826,6 +832,13 @@ function updateToastPosition(value) {
   store.dispatch('updateToastPosition', value)
 }
 
+function showTestToast() {
+  showToast({
+    message: t('Settings.Theme Settings.Toast Position.Test Toast'),
+    icon: ['fas', 'message']
+  })
+}
+
 /** @type {import('vue').ComputedRef<number>} */
 const uiScale = computed(() => store.getters.getUiScale)
 
@@ -990,7 +1003,11 @@ function handleSmoothScrolling(value) {
   max-inline-size: 200px;
 }
 
-@container settings-content (width <= 720px) {
+.testToastButton {
+  margin-block-start: 30px;
+}
+
+@container settings-content (width <= 760px) {
   .themeSelectRow {
     align-items: center;
     flex-direction: column;
@@ -999,6 +1016,10 @@ function handleSmoothScrolling(value) {
   .themeSelectRow :deep(.select) {
     flex: 0 0 auto;
     inline-size: min(200px, 100%);
+  }
+
+  .testToastButton {
+    margin-block-start: 5px;
   }
 }
 

--- a/src/renderer/components/ThemeSettings.vue
+++ b/src/renderer/components/ThemeSettings.vue
@@ -830,7 +830,8 @@ let toastPositionUpdatePromise = Promise.resolve()
  * @param {'bottom-left' | 'bottom-center' | 'bottom-right' | 'top-left' | 'top-center' | 'top-right'} value
  */
 function updateToastPosition(value) {
-  toastPositionUpdatePromise = store.dispatch('updateToastPosition', value)
+  toastPositionUpdatePromise = toastPositionUpdatePromise
+    .then(() => store.dispatch('updateToastPosition', value))
 }
 
 async function showTestToast() {

--- a/static/locales/ai/ar.yaml
+++ b/static/locales/ai/ar.yaml
@@ -316,6 +316,7 @@ Settings:
     Show Progress as Notification: إظهار التقدم كإخطار
     Operation in Progress: العملية قيد التقدم
     Toast Position:
+      Test Toast: إشعار تجريبي
       Toast Position: موضع الإشعار
       Bottom Left: أسفل اليسار
       Bottom Center: المركز السفلي

--- a/static/locales/ai/be.yaml
+++ b/static/locales/ai/be.yaml
@@ -329,6 +329,7 @@ Settings:
     Show Progress as Notification: Паказваць ход выканання як апавяшчэнне
     Operation in Progress: Аперацыя выконваецца
     Toast Position:
+      Test Toast: Тэставае апавяшчэнне
       Toast Position: Размяшчэнне апавяшчэнняў
       Bottom Left: Знізу злева
       Bottom Center: Знізу па цэнтры

--- a/static/locales/ai/bg.yaml
+++ b/static/locales/ai/bg.yaml
@@ -314,6 +314,7 @@ Settings:
     Show Progress as Notification: Показвай напредъка като известие
     Operation in Progress: Извършва се операция
     Toast Position:
+      Test Toast: Тестово известие
       Toast Position: Позиция на изскачащите известия
       Bottom Left: Долу вляво
       Bottom Center: Долу в средата

--- a/static/locales/ai/br.yaml
+++ b/static/locales/ai/br.yaml
@@ -312,6 +312,7 @@ Settings:
     Show Progress as Notification: "Diskouez an araokadur evel ur rebuad"
     Operation in Progress: "Oberiadur war ober"
     Toast Position:
+      Test Toast: Kemennadenn amprouiñ
       Toast Position: "Lec'h ar c'hemennadennoù berr"
       Bottom Left: "En traoñ a-gleiz"
       Bottom Center: "En traoñ e-kreiz"

--- a/static/locales/ai/ca.yaml
+++ b/static/locales/ai/ca.yaml
@@ -447,6 +447,7 @@ Settings:
     Show Progress as Notification: Mostra el progrés com a notificació
     Operation in Progress: Operació en curs
     Toast Position:
+      Test Toast: Notificació de prova
       Toast Position: Posició de les notificacions emergents
       Bottom Left: A baix a l'esquerra
       Bottom Center: A baix al centre

--- a/static/locales/ai/cs.yaml
+++ b/static/locales/ai/cs.yaml
@@ -312,6 +312,7 @@ Settings:
     Show Progress as Notification: Zobrazovat průběh jako oznámení
     Operation in Progress: Probíhá operace
     Toast Position:
+      Test Toast: Testovací oznámení
       Toast Position: Umístění oznámení
       Bottom Left: Vlevo dole
       Bottom Center: Uprostřed dole

--- a/static/locales/ai/cy.yaml
+++ b/static/locales/ai/cy.yaml
@@ -314,6 +314,7 @@ Settings:
     Show Progress as Notification: Dangos cynnydd fel hysbysiad
     Operation in Progress: Gweithred ar y gweill
     Toast Position:
+      Test Toast: Hysbysiad prawf
       Toast Position: Safle hysbysiadau
       Bottom Left: Gwaelod chwith
       Bottom Center: Canol y gwaelod

--- a/static/locales/ai/da.yaml
+++ b/static/locales/ai/da.yaml
@@ -324,6 +324,7 @@ Settings:
     Show Progress as Notification: Vis status som meddelelse
     Operation in Progress: Handlingen er i gang
     Toast Position:
+      Test Toast: Testmeddelelse
       Toast Position: Placering af pop op-meddelelser
       Bottom Left: Nederst til venstre
       Bottom Center: Nederst i midten

--- a/static/locales/ai/el.yaml
+++ b/static/locales/ai/el.yaml
@@ -316,6 +316,7 @@ Settings:
     Show Progress as Notification: Εμφάνιση προόδου ως ειδοποίησης
     Operation in Progress: Η λειτουργία βρίσκεται σε εξέλιξη
     Toast Position:
+      Test Toast: Δοκιμαστική ειδοποίηση
       Toast Position: Θέση ειδοποιήσεων
       Bottom Left: Κάτω αριστερά
       Bottom Center: Κάτω στο κέντρο

--- a/static/locales/ai/en-GB.yaml
+++ b/static/locales/ai/en-GB.yaml
@@ -299,6 +299,7 @@ Settings:
     Show Progress as Notification: Show progress as notification
     Operation in Progress: Operation in progress
     Toast Position:
+      Test Toast: Test toast
       Toast Position: Toast Position
       Bottom Left: Bottom left
       Bottom Center: Bottom centre

--- a/static/locales/ai/es-AR.yaml
+++ b/static/locales/ai/es-AR.yaml
@@ -333,6 +333,7 @@ Settings:
     Show Progress as Notification: Mostrar el progreso como notificación
     Operation in Progress: Operación en curso
     Toast Position:
+      Test Toast: Notificación de prueba
       Toast Position: Posición de las notificaciones emergentes
       Bottom Left: Abajo a la izquierda
       Bottom Center: Abajo en el centro

--- a/static/locales/ai/es-MX.yaml
+++ b/static/locales/ai/es-MX.yaml
@@ -341,6 +341,7 @@ Settings:
     Show Progress as Notification: Mostrar el progreso como notificación
     Operation in Progress: Operación en curso
     Toast Position:
+      Test Toast: Notificación de prueba
       Toast Position: Posición de las notificaciones emergentes
       Bottom Left: Abajo a la izquierda
       Bottom Center: Abajo en el centro

--- a/static/locales/ai/es.yaml
+++ b/static/locales/ai/es.yaml
@@ -314,6 +314,7 @@ Settings:
     Show Progress as Notification: Mostrar el progreso como notificación
     Operation in Progress: Operación en curso
     Toast Position:
+      Test Toast: Notificación de prueba
       Toast Position: Posición de las notificaciones emergentes
       Bottom Left: Abajo a la izquierda
       Bottom Center: Abajo en el centro

--- a/static/locales/ai/et.yaml
+++ b/static/locales/ai/et.yaml
@@ -312,6 +312,7 @@ Settings:
     Show Progress as Notification: Kuva edenemine teavitusena
     Operation in Progress: Toiming on pooleli
     Toast Position:
+      Test Toast: Testteavitus
       Toast Position: Hüpikteate asukoht
       Bottom Left: All vasakul
       Bottom Center: All keskel

--- a/static/locales/ai/eu.yaml
+++ b/static/locales/ai/eu.yaml
@@ -314,6 +314,7 @@ Settings:
     Show Progress as Notification: Erakutsi aurrerapena jakinarazpen gisa
     Operation in Progress: Eragiketa abian
     Toast Position:
+      Test Toast: Probako jakinarazpena
       Toast Position: Jakinarazpen iragankorraren kokapena
       Bottom Left: Behean ezkerrean
       Bottom Center: Behean erdian

--- a/static/locales/ai/fa.yaml
+++ b/static/locales/ai/fa.yaml
@@ -329,6 +329,7 @@ Settings:
     Show Progress as Notification: نمایش پیشرفت به‌صورت اعلان
     Operation in Progress: عملیات در حال انجام است
     Toast Position:
+      Test Toast: اعلان آزمایشی
       Toast Position: جایگاه اعلان موقت
       Bottom Left: پایین چپ
       Bottom Center: پایین وسط

--- a/static/locales/ai/fi.yaml
+++ b/static/locales/ai/fi.yaml
@@ -316,6 +316,7 @@ Settings:
     Show Progress as Notification: Näytä edistyminen ilmoituksena
     Operation in Progress: Toiminto on käynnissä
     Toast Position:
+      Test Toast: Testi-ilmoitus
       Toast Position: Ponnahdusilmoituksen sijainti
       Bottom Left: Alhaalla vasemmalla
       Bottom Center: Alhaalla keskellä

--- a/static/locales/ai/fr-FR.yaml
+++ b/static/locales/ai/fr-FR.yaml
@@ -312,6 +312,7 @@ Settings:
     Show Progress as Notification: Afficher la progression dans une notification
     Operation in Progress: Opération en cours
     Toast Position:
+      Test Toast: Notification de test
       Toast Position: Position des notifications
       Bottom Left: En bas à gauche
       Bottom Center: En bas au centre

--- a/static/locales/ai/gl.yaml
+++ b/static/locales/ai/gl.yaml
@@ -316,6 +316,7 @@ Settings:
     Show Progress as Notification: Amosar o progreso como notificación
     Operation in Progress: Operación en curso
     Toast Position:
+      Test Toast: Notificación de proba
       Toast Position: Posición das notificacións
       Bottom Left: Abaixo á esquerda
       Bottom Center: Abaixo no centro

--- a/static/locales/ai/he.yaml
+++ b/static/locales/ai/he.yaml
@@ -316,6 +316,7 @@ Settings:
     Show Progress as Notification: הצגת ההתקדמות כהתראה
     Operation in Progress: הפעולה מתבצעת
     Toast Position:
+      Test Toast: התראת בדיקה
       Toast Position: מיקום ההודעה הקופצת
       Bottom Left: למטה משמאל
       Bottom Center: למטה במרכז

--- a/static/locales/ai/hr.yaml
+++ b/static/locales/ai/hr.yaml
@@ -314,6 +314,7 @@ Settings:
     Show Progress as Notification: Prikaži napredak kao obavijest
     Operation in Progress: Radnja je u tijeku
     Toast Position:
+      Test Toast: Testna obavijest
       Toast Position: Položaj skočne obavijesti
       Bottom Left: Dolje lijevo
       Bottom Center: Dolje u sredini

--- a/static/locales/ai/hu.yaml
+++ b/static/locales/ai/hu.yaml
@@ -312,6 +312,7 @@ Settings:
     Show Progress as Notification: Folyamat megjelenítése értesítésként
     Operation in Progress: Művelet folyamatban
     Toast Position:
+      Test Toast: Tesztértesítés
       Toast Position: Értesítés helye
       Bottom Left: Balra lent
       Bottom Center: Középen lent

--- a/static/locales/ai/id.yaml
+++ b/static/locales/ai/id.yaml
@@ -316,6 +316,7 @@ Settings:
     Show Progress as Notification: Tampilkan progres sebagai notifikasi
     Operation in Progress: Operasi sedang berlangsung
     Toast Position:
+      Test Toast: Notifikasi uji coba
       Toast Position: Posisi Notifikasi Singkat
       Bottom Left: Kiri bawah
       Bottom Center: Tengah bawah

--- a/static/locales/ai/is.yaml
+++ b/static/locales/ai/is.yaml
@@ -316,6 +316,7 @@ Settings:
     Show Progress as Notification: Sýna framvindu sem tilkynningu
     Operation in Progress: Aðgerð í gangi
     Toast Position:
+      Test Toast: Prófunartilkynning
       Toast Position: Staðsetning spretttilkynninga
       Bottom Left: Neðst til vinstri
       Bottom Center: Neðst fyrir miðju

--- a/static/locales/ai/it.yaml
+++ b/static/locales/ai/it.yaml
@@ -312,6 +312,7 @@ Settings:
     Show Progress as Notification: Mostra avanzamento come notifica
     Operation in Progress: Operazione in corso
     Toast Position:
+      Test Toast: Notifica di prova
       Toast Position: Posizione delle notifiche a comparsa
       Bottom Left: In basso a sinistra
       Bottom Center: In basso al centro

--- a/static/locales/ai/ja.yaml
+++ b/static/locales/ai/ja.yaml
@@ -312,6 +312,7 @@ Settings:
     Show Progress as Notification: 進行状況を通知として表示
     Operation in Progress: 処理中
     Toast Position:
+      Test Toast: テスト通知
       Toast Position: トーストの位置
       Bottom Left: 左下
       Bottom Center: 下中央

--- a/static/locales/ai/ko.yaml
+++ b/static/locales/ai/ko.yaml
@@ -408,6 +408,7 @@ Settings:
     Show Progress as Notification: 진행률을 알림으로 표시
     Operation in Progress: 작업 진행 중
     Toast Position:
+      Test Toast: 테스트 알림
       Toast Position: 알림 메시지 위치
       Bottom Left: 왼쪽 아래
       Bottom Center: 가운데 아래

--- a/static/locales/ai/lt.yaml
+++ b/static/locales/ai/lt.yaml
@@ -433,6 +433,7 @@ Settings:
     Show Progress as Notification: Eigą rodyti pranešime
     Operation in Progress: Vykdoma operacija
     Toast Position:
+      Test Toast: Bandomasis pranešimas
       Toast Position: Iškylančiojo pranešimo vieta
       Bottom Left: Apačioje kairėje
       Bottom Center: Apačioje per vidurį

--- a/static/locales/ai/nb-NO.yaml
+++ b/static/locales/ai/nb-NO.yaml
@@ -314,6 +314,7 @@ Settings:
     Show Progress as Notification: Vis fremdrift som varsel
     Operation in Progress: En handling pågår
     Toast Position:
+      Test Toast: Testvarsel
       Toast Position: Varselplassering
       Bottom Left: Nederst til venstre
       Bottom Center: Nederst i midten

--- a/static/locales/ai/nl.yaml
+++ b/static/locales/ai/nl.yaml
@@ -316,6 +316,7 @@ Settings:
     Show Progress as Notification: Voortgang als melding tonen
     Operation in Progress: Bewerking wordt uitgevoerd
     Toast Position:
+      Test Toast: Testmelding
       Toast Position: Positie van meldingen
       Bottom Left: Linksonder
       Bottom Center: Middenonder

--- a/static/locales/ai/nn.yaml
+++ b/static/locales/ai/nn.yaml
@@ -445,6 +445,7 @@ Settings:
     Show Progress as Notification: Vis framdrift som varsel
     Operation in Progress: Operasjonen er i gang
     Toast Position:
+      Test Toast: Testvarsel
       Toast Position: Plassering av varsel
       Bottom Left: Nede til venstre
       Bottom Center: Nede i midten

--- a/static/locales/ai/pl.yaml
+++ b/static/locales/ai/pl.yaml
@@ -85,6 +85,8 @@ Settings:
       Playlist View Type: Sposób wyświetlania playlisty
     Show Thumbnail Previews: Pokazuj podgląd miniatur
   Theme Settings:
+    Toast Position:
+      Test Toast: Powiadomienie testowe
     Scroll Speed: Szybkość przewijania
     Custom Theme:
       Share Theme: Udostępnij motyw

--- a/static/locales/ai/pt-BR.yaml
+++ b/static/locales/ai/pt-BR.yaml
@@ -312,6 +312,7 @@ Settings:
     Show Progress as Notification: Mostrar progresso como notificação
     Operation in Progress: Operação em curso
     Toast Position:
+      Test Toast: Notificação de teste
       Toast Position: Posição das notificações
       Bottom Left: Em baixo à esquerda
       Bottom Center: Em baixo ao centro

--- a/static/locales/ai/pt-PT.yaml
+++ b/static/locales/ai/pt-PT.yaml
@@ -316,6 +316,7 @@ Settings:
     Show Progress as Notification: Mostrar progresso como notificação
     Operation in Progress: Operação em curso
     Toast Position:
+      Test Toast: Notificação de teste
       Toast Position: Posição das notificações
       Bottom Left: Em baixo à esquerda
       Bottom Center: Em baixo ao centro

--- a/static/locales/ai/pt.yaml
+++ b/static/locales/ai/pt.yaml
@@ -316,6 +316,7 @@ Settings:
     Show Progress as Notification: Mostrar progresso como notificação
     Operation in Progress: Operação em curso
     Toast Position:
+      Test Toast: Notificação de teste
       Toast Position: Posição das notificações
       Bottom Left: Em baixo à esquerda
       Bottom Center: Em baixo ao centro

--- a/static/locales/ai/ro.yaml
+++ b/static/locales/ai/ro.yaml
@@ -314,6 +314,7 @@ Settings:
     Show Progress as Notification: Afișează progresul ca notificare
     Operation in Progress: Operațiune în curs
     Toast Position:
+      Test Toast: Notificare de test
       Toast Position: Poziția notificărilor temporare
       Bottom Left: Jos, în stânga
       Bottom Center: Jos, în centru

--- a/static/locales/ai/ru.yaml
+++ b/static/locales/ai/ru.yaml
@@ -291,6 +291,7 @@ Settings:
     Show Progress as Notification: Показывать ход выполнения в уведомлении
     Operation in Progress: Выполняется операция
     Toast Position:
+      Test Toast: Тестовое уведомление
       Toast Position: Расположение уведомлений
       Bottom Left: Снизу слева
       Bottom Center: Снизу по центру

--- a/static/locales/ai/sk.yaml
+++ b/static/locales/ai/sk.yaml
@@ -312,6 +312,7 @@ Settings:
     Show Progress as Notification: Zobraziť priebeh ako oznámenie
     Operation in Progress: Prebieha operácia
     Toast Position:
+      Test Toast: Testovacie oznámenie
       Toast Position: Umiestnenie oznámení
       Bottom Left: Vľavo dole
       Bottom Center: V strede dole

--- a/static/locales/ai/sl.yaml
+++ b/static/locales/ai/sl.yaml
@@ -440,6 +440,7 @@ Settings:
     Show Progress as Notification: Prikaži napredek kot obvestilo
     Operation in Progress: Opravilo poteka
     Toast Position:
+      Test Toast: Preskusno obvestilo
       Toast Position: Položaj obvestila
       Bottom Left: Spodaj levo
       Bottom Center: Spodaj na sredini

--- a/static/locales/ai/sr.yaml
+++ b/static/locales/ai/sr.yaml
@@ -322,6 +322,7 @@ Settings:
     Show Progress as Notification: Прикажи напредак као обавештење
     Operation in Progress: Радња је у току
     Toast Position:
+      Test Toast: Пробно обавештење
       Toast Position: Положај обавештења
       Bottom Left: Доле лево
       Bottom Center: Доле у средини

--- a/static/locales/ai/sv.yaml
+++ b/static/locales/ai/sv.yaml
@@ -314,6 +314,7 @@ Settings:
     Show Progress as Notification: Visa förlopp som avisering
     Operation in Progress: Åtgärd pågår
     Toast Position:
+      Test Toast: Testavisering
       Toast Position: Placering av popupmeddelanden
       Bottom Left: Nederst till vänster
       Bottom Center: Nederst i mitten

--- a/static/locales/ai/ta.yaml
+++ b/static/locales/ai/ta.yaml
@@ -317,6 +317,7 @@ Settings:
     Show Progress as Notification: முன்னேற்றத்தை அறிவிப்பாகக் காட்டு
     Operation in Progress: செயல் நடைபெறுகிறது
     Toast Position:
+      Test Toast: சோதனை அறிவிப்பு
       Toast Position: அறிவிப்பு இடம்
       Bottom Left: கீழ் இடது
       Bottom Center: கீழ் நடு

--- a/static/locales/ai/tr.yaml
+++ b/static/locales/ai/tr.yaml
@@ -312,6 +312,7 @@ Settings:
     Show Progress as Notification: İlerlemeyi bildirim olarak göster
     Operation in Progress: İşlem sürüyor
     Toast Position:
+      Test Toast: Test bildirimi
       Toast Position: Bildirim Konumu
       Bottom Left: Sol alt
       Bottom Center: Alt orta

--- a/static/locales/ai/uk.yaml
+++ b/static/locales/ai/uk.yaml
@@ -316,6 +316,7 @@ Settings:
     Show Progress as Notification: Показувати поступ у сповіщенні
     Operation in Progress: Виконується операція
     Toast Position:
+      Test Toast: Тестове сповіщення
       Toast Position: Розташування сповіщення
       Bottom Left: Унизу ліворуч
       Bottom Center: Унизу посередині

--- a/static/locales/ai/vi.yaml
+++ b/static/locales/ai/vi.yaml
@@ -316,6 +316,7 @@ Settings:
     Show Progress as Notification: Hiện tiến trình dưới dạng thông báo
     Operation in Progress: Đang thực hiện thao tác
     Toast Position:
+      Test Toast: Thông báo thử
       Toast Position: Vị trí thông báo
       Bottom Left: Dưới cùng bên trái
       Bottom Center: Dưới cùng ở giữa

--- a/static/locales/ai/zh-CN.yaml
+++ b/static/locales/ai/zh-CN.yaml
@@ -312,6 +312,7 @@ Settings:
     Show Progress as Notification: 以通知形式显示进度
     Operation in Progress: 操作正在进行
     Toast Position:
+      Test Toast: 测试通知
       Toast Position: 提示消息位置
       Bottom Left: 左下角
       Bottom Center: 底部居中

--- a/static/locales/ai/zh-TW.yaml
+++ b/static/locales/ai/zh-TW.yaml
@@ -314,6 +314,7 @@ Settings:
     Show Progress as Notification: 以通知顯示進度
     Operation in Progress: 作業進行中
     Toast Position:
+      Test Toast: 測試通知
       Toast Position: 快顯通知位置
       Bottom Left: 左下
       Bottom Center: 中下

--- a/static/locales/de-DE.yaml
+++ b/static/locales/de-DE.yaml
@@ -558,6 +558,7 @@ Settings:
     Operation in Progress: Vorgang läuft
     Toast Position:
       Toast Position: Position der Benachrichtigungen
+      Test Toast: Testbenachrichtigung
       Bottom Left: Unten links
       Bottom Center: Unten mittig
       Bottom Right: Unten rechts

--- a/static/locales/en-US.yaml
+++ b/static/locales/en-US.yaml
@@ -623,6 +623,7 @@ Settings:
     Operation in Progress: Operation in progress
     Toast Position:
       Toast Position: Toast Position
+      Test Toast: Test toast
       Bottom Left: Bottom left
       Bottom Center: Bottom center
       Bottom Right: Bottom right


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Make sure to follow the contributing guidelines. -->
<!-- Important note, we may remove your pull request if you do not use this provided PR template correctly. -->
<!-- Agent instructions: Preserve every heading, comment, and marker in this template. Never remove or rewrite the release-note-category:start/end, release-note:start/end, or release-note-image:start/end marker pairs. -->

## Pull Request Type
<!-- Please select what type of pull request this is: [x] -->
- [ ] Bugfix
- [x] Feature Implementation
- [ ] Documentation
- [ ] Other

## Related issue
<!-- Please link the issue your pull request is referring to. -->
<!-- If this pull request fully resolves the relevant issue, put "closes" before the issue number. -->
<!-- Example: "closes #123456". -->

No linked issue; requested directly.

## Description
<!-- Please write a clear and concise description of what the pull request does. -->

Users could choose where toast notifications appear, but could not preview that position from the setting itself.

This adds a localized Test toast button beside the toast position selector. It uses the existing toast path and message icon, and the selector row stacks responsively when space is limited.

## Release note category
<!-- Select exactly one category. Every pull request must select one. -->
<!-- Select "Not noteworthy" when the pull request fixes a bug in or improves functionality that has not yet appeared in a stable release. -->
<!-- release-note-category:start -->
- [ ] Not noteworthy
- [ ] Highlights
- [x] More improvements
- [ ] Fixed bugs
<!-- release-note-category:end -->

## Release note
<!-- Required unless "Not noteworthy" is selected. -->
<!-- Write one concise, user-facing entry without a leading bullet. -->
<!-- release-note:start -->
Added a test toast button beside the toast position setting.
<!-- release-note:end -->

## Release note images
<!-- Optional. Paste one or more Markdown images, HTML image tags, or dark/light <picture> elements here. -->
<!-- The release notes normalize the markup and limit images taller than 300 pixels. -->
<!-- Agent instructions:
For a noteworthy visible change, add media when it makes the change easier to understand. Prefer a still image unless motion is the point; recordings must use animated WebP.
After implementing a visible change, proactively capture the result and show the local media to the user for approval before uploading it or updating the pull request.
When the affected UI differs between dark and light themes, capturing both themes is required. A dark-only image is incomplete. Run `node _scripts/releaseNoteMedia.mjs --dark DARK_FILE --light LIGHT_FILE --alt "DESCRIPTION"`; GitHub will display the matching theme and use dark as the fallback. Use a single default-dark capture only when the light theme cannot be captured or looks identical.
Capture or crop to the smallest region that still makes the change clear. Do not include the full window when the affected component can be understood on its own.
Use English unless localization is the subject. Keep components at their normal dimensions and placement instead of resizing them to fill the frame.
Use deterministic local fixtures for visible remote images. Reusable avatar and thumbnail fixtures are available through `e2e/helpers/visual-fixtures.mjs`. Before capturing, verify that every visible image has loaded successfully (`complete === true` and `naturalWidth > 0`).
Inspect the final dark and light files for failed images, missing content, unrelated UI, awkward animation, and misleading layout. Omit media when it does not explain the change clearly.
For one dark capture, run `node _scripts/releaseNoteMedia.mjs FILE --alt "DESCRIPTION"`.
Check for personal information, tokens, private repository names, and unrelated desktop content before uploading. Uploaded media is public.
Keep capture-only scripts, test hooks, screenshots, and recordings out of commits. Remove them before committing unless the capture code is also a reusable regression test. Never commit generated release-note media.
Paste only the generated markup between the marker comments. Leave this section empty when media would not help.
-->
<!-- release-note-image:start -->
<picture>
  <source media="(prefers-color-scheme: dark)" srcset="https://github.com/OpenTubeX/media/releases/download/attachments/20260907T114442Z-test-toast-dark-dark-e9cafb825f.png">
  <source media="(prefers-color-scheme: light)" srcset="https://github.com/OpenTubeX/media/releases/download/attachments/20260907T114442Z-test-toast-light-light-6f68d3bb5a.png">
  <img alt="Toast position setting with the Test toast button" src="https://github.com/OpenTubeX/media/releases/download/attachments/20260907T114442Z-test-toast-dark-dark-e9cafb825f.png">
</picture>
<!-- release-note-image:end -->

## Testing
<!-- How can reviewers verify that the PR produces correct results? -->
<!-- Please provide instructions so that others can ensure that your pull request would produce correct results. For examples see, https://github.com/FreeTubeApp/FreeTube/pull/5743, https://github.com/FreeTubeApp/FreeTube/pull/7349, https://github.com/FreeTubeApp/FreeTube/pull/5125, https://github.com/FreeTubeApp/FreeTube/pull/7338 -->
<!-- Agent instructions: Only write human-facing steps that explain how to verify the change while running this branch in dev mode. Include expected results and, when applicable, helpful console snippets for interactive verification. Do not include automated checks, commands, results, pass counts, or CI status. -->

1. Open Settings and select Appearance.
2. Choose a value under Toast Position.
3. Click Test toast and verify that a toast with the same label appears at the chosen position.
4. Narrow the settings window and verify that the selectors and button stack without horizontal overflow.

## Additional context
<!-- Add any other context about the pull request here. -->

The existing message icon already has Material and Remix mappings.
