### PR TITLE
fix(tutorial): keep navigation highlight aligned after resize

### DIFF
--- a/e2e/tests/offline/tutorial.spec.mjs
+++ b/e2e/tests/offline/tutorial.spec.mjs
@@ -1,4 +1,4 @@
-import { test, expect } from '../../helpers/app.mjs'
+import { test, expect, setWindowSize } from '../../helpers/app.mjs'
 
 test.use({ showTutorial: true })
 
@@ -313,6 +313,21 @@ test('walks new users through the essential controls', async ({ page }) => {
 
   await page.reload()
   await expect(page.locator('.tutorialOverlay')).toHaveCount(0)
+})
+
+test('repositions the navigation highlight after crossing the mobile breakpoint', async ({ app, page }) => {
+  await setWindowSize(app, page, { width: 600, height: 700 })
+  await page.evaluate(() => localStorage.setItem('opentubex.tutorial.audience', 'new'))
+  await page.reload()
+  await page.evaluate(() => window.ftElectron.setZoomFactor(1.05))
+
+  const tutorial = page.locator('.tutorialCard')
+  await tutorial.getByRole('button', { name: 'Next' }).click()
+  await expect(tutorial).toHaveAccessibleName('Your library is always nearby')
+  await expectHighlightCenteredOn(page, '[data-tutorial="navigation"]')
+
+  await setWindowSize(app, page, { width: 1000, height: 800 })
+  await expectHighlightCenteredOn(page, '[data-tutorial="navigation"]')
 })
 
 test('repositions the tab highlight when the layout is reset', async ({ page }) => {

--- a/src/renderer/components/FtTutorialOverlay/FtTutorialOverlay.vue
+++ b/src/renderer/components/FtTutorialOverlay/FtTutorialOverlay.vue
@@ -197,6 +197,8 @@ const cardStyle = ref({})
 let updateFrame = null
 let lastActiveElement = null
 let contentResizeObserver = null
+let targetResizeObserver = null
+let observedTarget = null
 
 const BASE_THEME_VALUES = [
   'system', 'light', 'dark', 'black', 'nordic', 'hotPink', 'pastelPink',
@@ -347,6 +349,7 @@ onBeforeUnmount(() => {
   window.removeEventListener('scroll', schedulePositionUpdate, true)
   document.removeEventListener('keydown', handleDocumentKeydown, true)
   contentResizeObserver?.disconnect()
+  targetResizeObserver?.disconnect()
   store.commit('removeOpenPrompt', promptId)
   unlockBodyScroll()
   nextTick(() => lastActiveElement?.focus())
@@ -375,6 +378,18 @@ function observeTutorialContent() {
   clampTutorialScroll()
 }
 
+function observeTarget(target) {
+  if (observedTarget === target) return
+
+  targetResizeObserver?.disconnect()
+  observedTarget = target
+
+  if (target) {
+    targetResizeObserver ??= new ResizeObserver(schedulePositionUpdate)
+    targetResizeObserver.observe(target)
+  }
+}
+
 async function updatePosition() {
   const target = step.value.target === null
     ? null
@@ -382,6 +397,7 @@ async function updatePosition() {
         const rect = element.getBoundingClientRect()
         return rect.width > 0 && rect.height > 0
       })
+  observeTarget(target)
   const rect = target?.getBoundingClientRect()
   targetRect.value = rect && rect.width > 0 && rect.height > 0
     ? {


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Make sure to follow the contributing guidelines. -->
<!-- Important note, we may remove your pull request if you do not use this provided PR template correctly. -->
<!-- Agent instructions: Preserve every heading, comment, and marker in this template. Never remove or rewrite the release-note-category:start/end, release-note:start/end, or release-note-image:start/end marker pairs. -->

## Pull Request Type
<!-- Please select what type of pull request this is: [x] -->
- [x] Bugfix
- [ ] Feature Implementation
- [ ] Documentation
- [ ] Other

## Related issue
<!-- Please link the issue your pull request is referring to. -->
<!-- If this pull request fully resolves the relevant issue, put "closes" before the issue number. -->
<!-- Example: "closes #123456". -->

No related issue.

## Description
<!-- Please write a clear and concise description of what the pull request does. -->

The tutorial navigation highlight kept the width of the mobile bottom navigation after the window grew into the desktop layout. The highlight now observes its active target, so it follows the navigation through its responsive size transition. A regression test covers the mobile-to-desktop resize at 105% UI scale.

## Release note category
<!-- Select exactly one category. Every pull request must select one. -->
<!-- Select "Not noteworthy" when the pull request fixes a bug in or improves functionality that has not yet appeared in a stable release. -->
<!-- release-note-category:start -->
- [ ] Not noteworthy
- [ ] Highlights
- [ ] More improvements
- [x] Fixed bugs
<!-- release-note-category:end -->

## Release note
<!-- Required unless "Not noteworthy" is selected. -->
<!-- Write one concise, user-facing entry without a leading bullet. -->
<!-- release-note:start -->
The tutorial highlight now follows navigation layout changes when resizing the window.
<!-- release-note:end -->

## Release note images
<!-- Optional. Paste one or more Markdown images, HTML image tags, or dark/light <picture> elements here. -->
<!-- The release notes normalize the markup and limit images taller than 300 pixels. -->
<!-- Agent instructions:
For a noteworthy visible change, add media when it makes the change easier to understand. Prefer a still image unless motion is the point; recordings must use animated WebP.
After implementing a visible change, proactively capture the result and show the local media to the user for approval before uploading it or updating the pull request.
When the affected UI differs between dark and light themes, capturing both themes is required. A dark-only image is incomplete. Run `node _scripts/releaseNoteMedia.mjs --dark DARK_FILE --light LIGHT_FILE --alt "DESCRIPTION"`; GitHub will display the matching theme and use dark as the fallback. Use a single default-dark capture only when the light theme cannot be captured or looks identical.
Capture or crop to the smallest region that still makes the change clear. Do not include the full window when the affected component can be understood on its own.
Use English unless localization is the subject. Keep components at their normal dimensions and placement instead of resizing them to fill the frame.
Use deterministic local fixtures for visible remote images. Reusable avatar and thumbnail fixtures are available through `e2e/helpers/visual-fixtures.mjs`. Before capturing, verify that every visible image has loaded successfully (`complete === true` and `naturalWidth > 0`).
Inspect the final dark and light files for failed images, missing content, unrelated UI, awkward animation, and misleading layout. Omit media when it does not explain the change clearly.
For one dark capture, run `node _scripts/releaseNoteMedia.mjs FILE --alt "DESCRIPTION"`.
Check for personal information, tokens, private repository names, and unrelated desktop content before uploading. Uploaded media is public.
Keep capture-only scripts, test hooks, screenshots, and recordings out of commits. Remove them before committing unless the capture code is also a reusable regression test. Never commit generated release-note media.
Paste only the generated markup between the marker comments. Leave this section empty when media would not help.
-->
<!-- release-note-image:start -->

<!-- release-note-image:end -->

## Testing
<!-- How can reviewers verify that the PR produces correct results? -->
<!-- Please provide instructions so that others can ensure that your pull request would produce correct results. For examples see, https://github.com/FreeTubeApp/FreeTube/pull/5743, https://github.com/FreeTubeApp/FreeTube/pull/7349, https://github.com/FreeTubeApp/FreeTube/pull/5125, https://github.com/FreeTubeApp/FreeTube/pull/7338 -->
<!-- Agent instructions: Only write human-facing steps that explain how to verify the change while running this branch in dev mode. Include expected results and, when applicable, helpful console snippets for interactive verification. Do not include automated checks, commands, results, pass counts, or CI status. -->

1. Start the app with a fresh profile in a window narrow enough to show the bottom navigation.
2. Advance the tutorial to "Your library is always nearby" and confirm the red border frames the bottom navigation.
3. Enlarge the window past the desktop breakpoint. The red border should shrink and move to frame the vertical side navigation.

## Additional context
<!-- Add any other context about the pull request here. -->

The resize event measured the navigation at the start of its 150 ms width transition. Observing the rendered target size keeps the highlight synchronized until the transition finishes.
