### PR TITLE
feat(search): preserve filtered history presets

### DIFF
--- a/e2e/tests/offline/search-history.spec.mjs
+++ b/e2e/tests/offline/search-history.spec.mjs
@@ -126,7 +126,7 @@ test.describe('search history suggestions', () => {
     await expect(page.locator('input[type="radio"][value="three_to_twenty_mins"]')).toBeChecked()
   })
 
-  test('a search saves its active filters', async ({ app, page }) => {
+  test('the same query saves and restores each distinct filter set', async ({ app, page }) => {
     await page.locator('.navFilterButton').click()
     await page.locator('.searchRadio', { hasText: 'Time' }).getByText('Today', { exact: true }).click()
     await page.locator('.searchRadio', { hasText: 'Duration' }).getByText('3 - 20 minutes', { exact: true }).click()
@@ -134,19 +134,44 @@ test.describe('search history suggestions', () => {
 
     await page.locator(sel.searchInput).fill('daily news')
     await page.locator(sel.searchInput).press('Enter')
+    await expect(page.getByRole('heading', { name: 'Search results' })).toBeVisible()
+
+    await page.evaluate(() => {
+      const store = document.querySelector('#app').__vue_app__.config.globalProperties.$store
+      const tabId = store.getters.getPresentedTabId ?? 'web'
+      store.commit('setSearchTime', { tabId, value: 'week' })
+    })
+    await page.locator(sel.searchInput).press('Enter')
 
     await expect.poll(async () => {
       const contents = await readFile(path.join(app.userDataDir, 'search-history.db'), 'utf8')
       const records = contents.trim().split('\n').map((line) => JSON.parse(line))
-      const record = records.filter((entry) => entry._id === 'daily news').at(-1)
-      return record && record.searchSettings
-    }).toEqual({
-      prioritize: 'relevance',
-      time: 'today',
-      type: 'all',
-      duration: 'three_to_twenty_mins',
-      features: []
+      return records
+        .filter((entry) => entry.query === 'daily news' && !entry.$$deleted)
+        .map((entry) => entry.searchSettings.time)
+        .sort()
+    }).toEqual(['today', 'week'])
+
+    await page.locator(sel.searchInput).click()
+    const matchingSuggestions = suggestions(page).filter({ hasText: 'daily news' })
+    await expect(matchingSuggestions).toHaveCount(2)
+    await expect(matchingSuggestions.nth(0)).toContainText(/This week/i)
+    await expect(matchingSuggestions.nth(1)).toContainText('Today')
+
+    const savedTimes = await matchingSuggestions.locator('.optionWrapper').evaluateAll((links) => {
+      return links.map((link) => new URL(link.href).hash.match(/[?&]time=([^&]*)/)?.[1]).sort()
     })
+    expect(savedTimes).toEqual(['today', 'week'])
+
+    await matchingSuggestions.locator('.optionWrapper[href*="time=today"]').click()
+    await expect.poll(() => new URLSearchParams(page.url().split('?')[1]).get('time')).toBe('today')
+
+    await page.locator(sel.searchInput).click()
+    await suggestions(page)
+      .filter({ hasText: 'daily news' })
+      .locator('.optionWrapper[href*="time=week"]')
+      .click()
+    await expect.poll(() => new URLSearchParams(page.url().split('?')[1]).get('time')).toBe('week')
   })
 
   test('a recent search can be removed and stays removed', async ({ app, page }) => {

--- a/e2e/tests/offline/search-history.spec.mjs
+++ b/e2e/tests/offline/search-history.spec.mjs
@@ -1,7 +1,7 @@
 import { readFile } from 'node:fs/promises'
 import path from 'node:path'
 
-import { test, expect, goTo, sel } from '../../helpers/app.mjs'
+import { test, expect, goTo, goToSettingsSection, sel } from '../../helpers/app.mjs'
 
 const now = Date.now()
 
@@ -204,6 +204,139 @@ test.describe('search history suggestions', () => {
       const records = contents.trim().split('\n').map((line) => JSON.parse(line))
       return records.filter(entry => entry._id === 'android tutorial').at(-1)?.query
     }).toBe('android tutorial')
+  })
+
+  test('a YouTube export round trip preserves filter presets for the same query', async ({ page }) => {
+    const dataSection = await goToSettingsSection(page, 'data')
+
+    await page.evaluate(() => {
+      const store = document.querySelector('#app').__vue_app__.config.globalProperties.$store
+      store.commit('setSearchHistoryEntries', [
+        {
+          _id: 'round-trip-today',
+          query: 'round trip',
+          lastUpdatedAt: 100,
+          searchSettings: { time: 'today', features: ['hd', '4k'] }
+        },
+        {
+          _id: 'round-trip-week',
+          query: 'round trip',
+          lastUpdatedAt: 200,
+          searchSettings: { time: 'week', features: ['subtitles'] }
+        }
+      ])
+      window.__searchHistoryExport = null
+      Object.defineProperty(window, 'showSaveFilePicker', {
+        configurable: true,
+        value: async () => ({
+          createWritable: async () => ({
+            write: async (content) => { window.__searchHistoryExport = content },
+            close: async () => {}
+          })
+        })
+      })
+    })
+
+    await dataSection.getByRole('button', { name: 'Export search history', exact: true }).click()
+    await page.getByRole('button', { name: 'Export YouTube (.json)', exact: true }).click()
+
+    await expect.poll(() => page.evaluate(() => window.__searchHistoryExport)).not.toBeNull()
+    expect(await page.evaluate(() => JSON.parse(window.__searchHistoryExport)
+      .map(({ searchSettings }) => searchSettings))).toEqual([
+      {
+        prioritize: 'relevance',
+        time: 'today',
+        type: 'all',
+        duration: '',
+        features: ['4k', 'hd']
+      },
+      {
+        prioritize: 'relevance',
+        time: 'week',
+        type: 'all',
+        duration: '',
+        features: ['subtitles']
+      }
+    ])
+
+    await page.evaluate(async () => {
+      const store = document.querySelector('#app').__vue_app__.config.globalProperties.$store
+      await store.dispatch('removeAllSearchHistoryEntries')
+      Object.defineProperty(window, 'showOpenFilePicker', {
+        configurable: true,
+        value: async () => [{
+          getFile: async () => new File(
+            [window.__searchHistoryExport],
+            'youtube-search-history.json',
+            { type: 'application/json' }
+          )
+        }]
+      })
+    })
+
+    await dataSection.getByRole('button', { name: 'Import search history', exact: true }).click()
+
+    await expect.poll(() => page.evaluate(() => {
+      const store = document.querySelector('#app').__vue_app__.config.globalProperties.$store
+      return store.getters.getSearchHistoryEntries
+        .filter(({ query }) => query === 'round trip')
+        .map(({ searchSettings }) => ({
+          time: searchSettings.time,
+          features: searchSettings.features
+        }))
+        .sort((a, b) => a.time.localeCompare(b.time))
+    })).toEqual([
+      { time: 'today', features: ['4k', 'hd'] },
+      { time: 'week', features: ['subtitles'] }
+    ])
+  })
+
+  test('session cache lookup and removal ignore feature order', async ({ page }) => {
+    await page.evaluate(() => {
+      const store = document.querySelector('#app').__vue_app__.config.globalProperties.$store
+      const tabId = store.getters.getPresentedTabId ?? 'web'
+      store.commit('addToSessionSearchHistory', {
+        query: 'feature order',
+        data: [{
+          type: 'video',
+          videoId: 'featureord1',
+          title: 'Cached feature-order result',
+          author: 'OpenTubeX',
+          authorId: 'feature-order-author',
+          lengthSeconds: 60,
+          viewCount: 1,
+          publishedText: 'Today',
+          videoThumbnails: []
+        }],
+        searchSettings: {
+          prioritize: 'relevance',
+          time: '',
+          type: 'all',
+          duration: '',
+          features: ['4k', 'hd']
+        }
+      })
+      store.commit('setSearchFeatures', { tabId, value: ['hd', '4k'] })
+    })
+
+    await page.locator(sel.searchInput).fill('feature order')
+    await page.locator(sel.searchInput).press('Enter')
+    await expect(page.getByText('Cached feature-order result')).toBeVisible()
+
+    expect(await page.evaluate(() => {
+      const store = document.querySelector('#app').__vue_app__.config.globalProperties.$store
+      store.commit('removeFromSessionSearchHistory', {
+        query: 'feature order',
+        searchSettings: {
+          prioritize: 'relevance',
+          time: '',
+          type: 'all',
+          duration: '',
+          features: ['hd', '4k']
+        }
+      })
+      return store.getters.getSessionSearchHistory.length
+    })).toBe(0)
   })
 
   test('a recent search can be removed and stays removed', async ({ app, page }) => {

--- a/e2e/tests/offline/search-history.spec.mjs
+++ b/e2e/tests/offline/search-history.spec.mjs
@@ -174,6 +174,38 @@ test.describe('search history suggestions', () => {
     await expect.poll(() => new URLSearchParams(page.url().split('?')[1]).get('time')).toBe('week')
   })
 
+  test('an early search reuses a matching legacy database entry', async ({ app, page }) => {
+    await page.evaluate(() => {
+      const store = document.querySelector('#app').__vue_app__.config.globalProperties.$store
+      const tabId = store.getters.getPresentedTabId ?? 'web'
+      store.commit('setSearchHistoryEntries', [])
+      store.commit('setSearchPrioritize', { tabId, value: 'popularity' })
+      store.commit('setSearchTime', { tabId, value: 'today' })
+      store.commit('setSearchType', { tabId, value: 'video' })
+      store.commit('setSearchDuration', { tabId, value: 'three_to_twenty_mins' })
+      store.commit('setSearchFeatures', { tabId, value: ['subtitles', 'hd'] })
+    })
+
+    await page.locator(sel.searchInput).fill('android tutorial')
+    await page.locator(sel.searchInput).press('Enter')
+
+    await expect.poll(async () => {
+      const contents = await readFile(path.join(app.userDataDir, 'search-history.db'), 'utf8')
+      const records = contents.trim().split('\n').map((line) => JSON.parse(line))
+      return [...new Set(records
+        .filter(entry => !entry.$$deleted && (
+          entry._id === 'android tutorial' || entry.query === 'android tutorial'
+        ))
+        .map(entry => entry._id))]
+    }).toEqual(['android tutorial'])
+
+    await expect.poll(async () => {
+      const contents = await readFile(path.join(app.userDataDir, 'search-history.db'), 'utf8')
+      const records = contents.trim().split('\n').map((line) => JSON.parse(line))
+      return records.filter(entry => entry._id === 'android tutorial').at(-1)?.query
+    }).toBe('android tutorial')
+  })
+
   test('a recent search can be removed and stays removed', async ({ app, page }) => {
     await page.locator(sel.searchInput).click()
     await expect(suggestions(page)).toHaveCount(2)

--- a/src/datastores/handlers/base.js
+++ b/src/datastores/handlers/base.js
@@ -1,6 +1,7 @@
 import * as db from '../index'
 import { PlaylistVideoAddResult } from '../../constants'
 import { hasReachedWatchedThreshold, migrateLegacyHistoryRecord } from '../../history'
+import { resolveSearchHistoryEntry } from '../../search-history'
 
 const HISTORY_WATCHED_STATUS_MIGRATION_ID = 'historyWatchedStatusMigrated'
 
@@ -637,8 +638,18 @@ class SearchHistory {
     return db.searchHistory.findAsync({}).sort({ lastUpdatedAt: -1 })
   }
 
-  static upsert(searchHistoryEntry) {
-    return db.searchHistory.updateAsync({ _id: searchHistoryEntry._id }, searchHistoryEntry, { upsert: true })
+  static async upsert(searchHistoryEntry) {
+    const matchingCandidates = await db.searchHistory.findAsync({
+      $or: [
+        { _id: searchHistoryEntry._id },
+        { _id: searchHistoryEntry.query },
+        { query: searchHistoryEntry.query },
+      ],
+    })
+    const resolvedEntry = resolveSearchHistoryEntry(searchHistoryEntry, matchingCandidates)
+
+    await db.searchHistory.updateAsync({ _id: resolvedEntry._id }, resolvedEntry, { upsert: true })
+    return resolvedEntry
   }
 
   static async overwrite(records) {

--- a/src/main/index.js
+++ b/src/main/index.js
@@ -4973,14 +4973,15 @@ function runApp() {
         case DBActions.GENERAL.FIND:
           return await baseHandlers.searchHistory.find()
 
-        case DBActions.GENERAL.UPSERT:
-          await baseHandlers.searchHistory.upsert(data)
+        case DBActions.GENERAL.UPSERT: {
+          const updatedEntry = await baseHandlers.searchHistory.upsert(data)
           syncOtherWindows(
             IpcChannels.SYNC_SEARCH_HISTORY,
             event,
-            { event: SyncEvents.GENERAL.UPSERT, data }
+            { event: SyncEvents.GENERAL.UPSERT, data: updatedEntry }
           )
-          return null
+          return updatedEntry
+        }
 
         case DBActions.GENERAL.OVERWRITE:
           await baseHandlers.searchHistory.overwrite(data)

--- a/src/renderer/components/DataSettings/DataSettings.vue
+++ b/src/renderer/components/DataSettings/DataSettings.vue
@@ -196,6 +196,7 @@ import {
   DEFAULT_SEARCH_SETTINGS,
   mergeSearchHistoryEntries,
   normalizeSearchHistoryEntry,
+  normalizeSearchSettings,
 } from '../../../search-history'
 
 const IMPORT_DIRECTORY_ID = 'data-settings-import'
@@ -1705,7 +1706,9 @@ async function importYouTubeSearchHistory(historyData) {
             _id: query,
             query,
             lastUpdatedAt,
-            searchSettings: DEFAULT_SEARCH_SETTINGS,
+            searchSettings: isJsonObject(entry.searchSettings)
+              ? normalizeSearchSettings(entry.searchSettings)
+              : DEFAULT_SEARCH_SETTINGS,
           })
         }
       } catch (error) {
@@ -1770,6 +1773,7 @@ async function exportYouTubeSearchHistory() {
       title: `Searched for ${entry.query}`,
       titleUrl: `https://www.youtube.com/results?search_query=${encodeURIComponent(entry.query)}`,
       time: new Date(entry.lastUpdatedAt).toISOString(),
+      searchSettings: normalizeSearchSettings(entry.searchSettings),
       products: [
         'YouTube'
       ],

--- a/src/renderer/components/DataSettings/DataSettings.vue
+++ b/src/renderer/components/DataSettings/DataSettings.vue
@@ -192,6 +192,11 @@ import {
   isLibreTubeWatchHistoryBackup,
 } from '../../helpers/libretube'
 import { parseLineDelimitedJson } from '../../helpers/line-delimited-json'
+import {
+  DEFAULT_SEARCH_SETTINGS,
+  mergeSearchHistoryEntries,
+  normalizeSearchHistoryEntry,
+} from '../../helpers/search-history'
 
 const IMPORT_DIRECTORY_ID = 'data-settings-import'
 const START_IN_DIRECTORY = 'downloads'
@@ -1635,8 +1640,8 @@ async function importSearchHistory() {
  */
 async function importFreeTubeSearchHistory(searchHistoryRecords) {
   // deep copy so we don't get errors from Electron when we try to pass reactive objects through the IPC channels
-  const historyItems = new Map(deepCopy(searchHistoryEntries.value).map(entry => [entry._id, entry]))
-  let importedCount = 0
+  const currentEntries = deepCopy(searchHistoryEntries.value)
+  const importedEntries = []
 
   searchHistoryRecords.forEach((entry) => {
     if (!isJsonObject(entry) || typeof entry._id !== 'string' || typeof entry.lastUpdatedAt !== 'number') {
@@ -1646,28 +1651,20 @@ async function importFreeTubeSearchHistory(searchHistoryRecords) {
       })
       console.error('Missing keys:', entry)
     } else {
-      importedCount++
-      const existingEntry = historyItems.get(entry._id)
-
-      if (existingEntry == null || entry.lastUpdatedAt > existingEntry.lastUpdatedAt) {
-        let newEntry
-
-        if (Object.keys(entry) === 2) {
-          newEntry = entry
-        } else {
-          newEntry = { _id: entry._id, lastUpdatedAt: entry.lastUpdatedAt }
-        }
-
-        historyItems.set(entry._id, newEntry)
-      }
+      importedEntries.push(normalizeSearchHistoryEntry({
+        _id: entry._id,
+        query: typeof entry.query === 'string' ? entry.query : entry._id,
+        lastUpdatedAt: entry.lastUpdatedAt,
+        searchSettings: isJsonObject(entry.searchSettings) ? entry.searchSettings : undefined,
+      }))
     }
   })
 
-  if (importedCount === 0) {
+  if (importedEntries.length === 0) {
     return
   }
 
-  const newSearchHistoryEntries = Array.from(historyItems.values())
+  const newSearchHistoryEntries = mergeSearchHistoryEntries(currentEntries, importedEntries)
 
   await store.dispatch('overwriteSearchHistory', newSearchHistoryEntries)
 
@@ -1682,7 +1679,8 @@ async function importFreeTubeSearchHistory(searchHistoryRecords) {
  */
 async function importYouTubeSearchHistory(historyData) {
   // deep copy so we don't get errors from Electron when we try to pass reactive objects through the IPC channels
-  const historyItems = new Map(deepCopy(searchHistoryEntries.value).map(entry => [entry._id, entry]))
+  const currentEntries = deepCopy(searchHistoryEntries.value)
+  const importedEntries = []
 
   for (const entry of historyData) {
     if (
@@ -1703,11 +1701,12 @@ async function importYouTubeSearchHistory(historyData) {
           })
           console.error('Missing keys:', entry)
         } else {
-          const existingEntry = historyItems.get(query)
-
-          if (existingEntry == null || lastUpdatedAt > existingEntry.lastUpdatedAt) {
-            historyItems.set(query, { _id: query, lastUpdatedAt })
-          }
+          importedEntries.push({
+            _id: query,
+            query,
+            lastUpdatedAt,
+            searchSettings: DEFAULT_SEARCH_SETTINGS,
+          })
         }
       } catch (error) {
         console.error(error)
@@ -1719,7 +1718,7 @@ async function importYouTubeSearchHistory(historyData) {
     }
   }
 
-  const newSearchHistoryEntries = Array.from(historyItems.values())
+  const newSearchHistoryEntries = mergeSearchHistoryEntries(currentEntries, importedEntries)
 
   await store.dispatch('overwriteSearchHistory', newSearchHistoryEntries)
 
@@ -1768,8 +1767,8 @@ async function exportYouTubeSearchHistory() {
   const historyData = searchHistoryEntries.value.map((entry) => {
     return {
       header: 'YouTube',
-      title: `Searched for ${entry._id}`,
-      titleUrl: `https://www.youtube.com/results?search_query=${encodeURIComponent(entry._id)}`,
+      title: `Searched for ${entry.query}`,
+      titleUrl: `https://www.youtube.com/results?search_query=${encodeURIComponent(entry.query)}`,
       time: new Date(entry.lastUpdatedAt).toISOString(),
       products: [
         'YouTube'

--- a/src/renderer/components/DataSettings/DataSettings.vue
+++ b/src/renderer/components/DataSettings/DataSettings.vue
@@ -196,7 +196,7 @@ import {
   DEFAULT_SEARCH_SETTINGS,
   mergeSearchHistoryEntries,
   normalizeSearchHistoryEntry,
-} from '../../helpers/search-history'
+} from '../../../search-history'
 
 const IMPORT_DIRECTORY_ID = 'data-settings-import'
 const START_IN_DIRECTORY = 'downloads'

--- a/src/renderer/components/FtInput/FtInput.vue
+++ b/src/renderer/components/FtInput/FtInput.vue
@@ -103,6 +103,8 @@
             :is="getDataListProperty(index)?.isLink ? 'a' : 'div'"
             class="optionWrapper"
             :href="getDataListProperty(index)?.href"
+            :aria-label="getDataListProperty(index)?.ariaLabel"
+            :title="getDataListProperty(index)?.ariaLabel"
             @click.prevent="handleOptionClick(index, $event)"
             @auxclick.middle="handleOptionAuxClick(index, $event)"
           >
@@ -111,7 +113,7 @@
               :icon="['fas', getDataListProperty(index).iconName]"
               class="searchResultIcon"
             />
-            <bdi>{{ entry }}</bdi>
+            <bdi>{{ getDataListProperty(index)?.displayText ?? entry }}</bdi>
           </component>
           <a
             v-if="getDataListProperty(index)?.isRemoveable"
@@ -242,6 +244,7 @@ const searchState = reactive({
   keyboardSelectedOptionIndex: -1
 })
 const visibleDataList = ref(props.dataList)
+const visibleDataListIndexes = ref(props.dataList.map((_, index) => index))
 const removeButtonSelectedIndex = ref(-1)
 const removalMade = ref(false)
 const actionButtonIconName = shallowRef(props.forceActionButtonIconName ?? ['fas', 'search'])
@@ -462,7 +465,7 @@ function handleRemoveClick(index) {
   // keep input in focus even when the to-be-removed "Remove" button was clicked
   inputRef.value.focus()
   removalMade.value = true
-  emit('remove', visibleDataList.value[index])
+  emit('remove', visibleDataList.value[index], { dataListIndex: getDataListIndex(index) })
 }
 
 /**
@@ -470,7 +473,7 @@ function handleRemoveClick(index) {
  * @returns {number}
  */
 function getDataListIndex(visibleIndex) {
-  return props.dataList.indexOf(visibleDataList.value[visibleIndex])
+  return visibleDataListIndexes.value[visibleIndex]
 }
 
 /**
@@ -569,13 +572,15 @@ async function updateVisibleDataList(preserveSelectionAfterRemoval = false) {
 
   if (inputData.value.trim() === '') {
     visibleDataList.value = props.dataList
+    visibleDataListIndexes.value = props.dataList.map((_, index) => index)
   } else {
     // get list of items that match input
     const lowerCaseInputData = inputData.value.toLowerCase()
 
-    visibleDataList.value = props.dataList.filter(x => {
-      return x.toLowerCase().includes(lowerCaseInputData)
-    })
+    visibleDataListIndexes.value = props.dataList
+      .map((_, index) => index)
+      .filter(index => props.dataList[index].toLowerCase().includes(lowerCaseInputData))
+    visibleDataList.value = visibleDataListIndexes.value.map(index => props.dataList[index])
   }
 
   // Keep the same row selected only while the removal is reflected in the

--- a/src/renderer/components/TopNav/TopNav.vue
+++ b/src/renderer/components/TopNav/TopNav.vue
@@ -176,6 +176,7 @@ import store from '../../store/index'
 
 import { getConfiguredKeyboardShortcuts, MOBILE_WIDTH_THRESHOLD, SEARCH_RESULTS_DISPLAY_LIMIT } from '../../../constants'
 import { matchesKeyboardShortcut } from '../../helpers/keyboardShortcuts'
+import { getSearchHistoryEntryQuery } from '../../helpers/search-history'
 import { debounce, localizeAndAddKeyboardShortcutToActionTitle, openInternalPath } from '../../helpers/utils'
 import { translateWindowTitle } from '../../helpers/strings'
 import { clearLocalSearchSuggestionsSession, getLocalSearchSuggestions } from '../../helpers/api/local'
@@ -346,13 +347,72 @@ function restoreSettingsWindow() {
 
 const usingOnlySearchHistoryResults = computed(() => lastSuggestionQuery.value.length === 0)
 
-/** @type {import('vue').ComputedRef<string[]>} */
-const latestMatchingSearchHistoryNames = computed(() => {
-  return store.getters.getLatestMatchingSearchHistoryNames(lastSuggestionQuery.value)
+/** @type {import('vue').ComputedRef<object[]>} */
+const latestMatchingSearchHistoryEntries = computed(() => {
+  return store.getters.getLatestMatchingSearchHistoryEntries(lastSuggestionQuery.value)
 })
 
-/** @type {import('vue').ComputedRef<string[]>} */
-const latestSearchHistoryNames = computed(() => store.getters.getLatestSearchHistoryNames)
+/** @type {import('vue').ComputedRef<object[]>} */
+const latestSearchHistoryEntries = computed(() => store.getters.getLatestSearchHistoryEntries)
+
+const activeSearchHistoryEntries = computed(() => usingOnlySearchHistoryResults.value
+  ? latestSearchHistoryEntries.value
+  : latestMatchingSearchHistoryEntries.value)
+
+const searchFilterLabels = computed(() => ({
+  prioritize: {
+    popularity: t('Search Filters.Prioritize.Popularity'),
+  },
+  time: {
+    today: t('Search Filters.Time.Today'),
+    week: t('Search Filters.Time.This Week'),
+    month: t('Search Filters.Time.This Month'),
+    year: t('Search Filters.Time.This Year'),
+  },
+  type: {
+    video: t('Search Filters.Type.Videos'),
+    shorts: t('Global.Shorts'),
+    channel: t('Search Filters.Type.Channels'),
+    playlist: t('Playlists'),
+    movie: t('Search Filters.Type.Movies'),
+  },
+  duration: {
+    under_three_mins: t('Search Filters.Duration.< 3 minutes'),
+    three_to_twenty_mins: t('Search Filters.Duration.3 - 20 minutes'),
+    over_twenty_mins: t('Search Filters.Duration.> 20 minutes'),
+  },
+  features: {
+    live: t('Search Filters.Features.Live'),
+    '4k': t('Search Filters.Features.4K'),
+    hd: t('Search Filters.Features.HD'),
+    subtitles: t('Search Filters.Features.Subtitles'),
+    creative_commons: t('Search Filters.Features.Creative Commons'),
+    360: t('Search Filters.Features.360 Video'),
+    vr180: t('Search Filters.Features.VR180'),
+    '3d': t('Search Filters.Features.3D'),
+    hdr: t('Search Filters.Features.HDR'),
+    location: t('Search Filters.Features.Location'),
+  },
+}))
+
+/**
+ * @param {{ query: string, searchSettings: object }} entry
+ * @returns {string}
+ */
+function getSearchHistoryEntryDisplayText(entry) {
+  const settings = entry.searchSettings
+  const filterLabels = ['prioritize', 'time', 'type', 'duration']
+    .map(group => searchFilterLabels.value[group][settings[group]])
+    .filter(Boolean)
+
+  for (const feature of settings.features) {
+    filterLabels.push(searchFilterLabels.value.features[feature] ?? feature)
+  }
+
+  return filterLabels.length === 0
+    ? entry.query
+    : `${entry.query} (${filterLabels.join(', ')})`
+}
 
 /** @type {import('vue').ComputedRef<string>} */
 const searchFilterTabId = computed(() => process.env.IS_ELECTRON
@@ -365,15 +425,16 @@ const searchSettings = computed(() => store.getters.getSearchSettings(searchFilt
 const activeDataList = computed(() => {
   // show latest search history when the search bar is empty
   if (usingOnlySearchHistoryResults.value) {
-    return latestSearchHistoryNames.value
+    return latestSearchHistoryEntries.value.map(getSearchHistoryEntryQuery)
   }
 
-  const searchResults = [...latestMatchingSearchHistoryNames.value]
+  const searchHistoryNames = latestMatchingSearchHistoryEntries.value.map(getSearchHistoryEntryQuery)
+  const searchResults = [...searchHistoryNames]
 
   if (enableSearchSuggestions.value) {
     for (const searchSuggestion of searchSuggestionsDataList.value) {
       // prevent duplicate results between search history entries and YT search suggestions
-      if (latestMatchingSearchHistoryNames.value.includes(searchSuggestion)) {
+      if (searchHistoryNames.includes(searchSuggestion)) {
         continue
       }
 
@@ -388,21 +449,27 @@ const activeDataList = computed(() => {
   return searchResults
 })
 
-const searchHistoryEntriesCount = computed(() => usingOnlySearchHistoryResults.value
-  ? latestSearchHistoryNames.value.length
-  : latestMatchingSearchHistoryNames.value.length)
+const searchHistoryEntriesCount = computed(() => activeSearchHistoryEntries.value.length)
 
-const searchResultHrefs = shallowRef(new Map())
+const searchResultHrefs = shallowRef([])
 
 const activeDataListProperties = computed(() => {
   const properties = []
 
   for (let i = 0; i < activeDataList.value.length; i++) {
-    const queryText = activeDataList.value[i]
-    const href = searchResultHrefs.value.get(queryText)
+    const href = searchResultHrefs.value[i]
+    const searchHistoryEntry = activeSearchHistoryEntries.value[i]
 
     properties.push(i < searchHistoryEntriesCount.value
-      ? { isLink: true, isRemoveable: true, isSearchHistory: true, iconName: 'clock-rotate-left', href }
+      ? {
+          isLink: true,
+          isRemoveable: true,
+          isSearchHistory: true,
+          iconName: 'clock-rotate-left',
+          href,
+          displayText: getSearchHistoryEntryDisplayText(searchHistoryEntry),
+          ariaLabel: getSearchHistoryEntryDisplayText(searchHistoryEntry),
+        }
       : { isLink: true, isRemoveable: false, isSearchHistory: false, iconName: 'magnifying-glass', href }
     )
   }
@@ -616,18 +683,16 @@ async function getSearchDestination(queryText, selectedSearchSettings = null) {
 }
 
 let searchHrefRequestId = 0
-watch([activeDataList, searchSettings], async ([dataList]) => {
+watch([activeDataList, activeSearchHistoryEntries, searchSettings], async ([dataList, searchHistoryEntries]) => {
   const requestId = ++searchHrefRequestId
-  const hrefEntries = await Promise.all(dataList.map(async (queryText, index) => {
-    const searchHistoryEntry = index < searchHistoryEntriesCount.value
-      ? store.getters.getSearchHistoryEntryWithId(queryText)
-      : null
+  const hrefs = await Promise.all(dataList.map(async (queryText, index) => {
+    const searchHistoryEntry = searchHistoryEntries[index] ?? null
     const destination = await getSearchDestination(queryText, searchHistoryEntry?.searchSettings)
-    return [queryText, router.resolve({ path: destination.path, query: destination.query }).href]
+    return router.resolve({ path: destination.path, query: destination.query }).href
   }))
 
   if (requestId === searchHrefRequestId) {
-    searchResultHrefs.value = new Map(hrefEntries)
+    searchResultHrefs.value = hrefs
   }
 }, { deep: true, immediate: true })
 
@@ -657,7 +722,7 @@ async function goToSearch(queryText, { event, dataListIndex }) {
   clearLocalSearchSuggestionsSession()
 
   const selectedSearchHistoryEntry = activeDataListProperties.value[dataListIndex]?.isSearchHistory
-    ? store.getters.getSearchHistoryEntryWithId(queryText)
+    ? activeSearchHistoryEntries.value[dataListIndex]
     : null
   const selectedSearchSettings = selectedSearchHistoryEntry?.searchSettings
 
@@ -770,10 +835,20 @@ async function getSearchSuggestionsInvidious(query) {
 
 /**
  * @param {string} query
+ * @param {object} options
+ * @param {number} options.dataListIndex
  */
-function removeSearchHistoryEntryInDbAndCache(query) {
-  store.dispatch('removeSearchHistoryEntry', query)
-  store.commit('removeFromSessionSearchHistory', query)
+function removeSearchHistoryEntryInDbAndCache(query, { dataListIndex }) {
+  const searchHistoryEntry = activeSearchHistoryEntries.value[dataListIndex]
+  if (searchHistoryEntry == null) {
+    return
+  }
+
+  store.dispatch('removeSearchHistoryEntry', searchHistoryEntry._id)
+  store.commit('removeFromSessionSearchHistory', {
+    query,
+    searchSettings: searchHistoryEntry.searchSettings,
+  })
 }
 
 function toggleSearchContainer() {

--- a/src/renderer/components/TopNav/TopNav.vue
+++ b/src/renderer/components/TopNav/TopNav.vue
@@ -176,7 +176,7 @@ import store from '../../store/index'
 
 import { getConfiguredKeyboardShortcuts, MOBILE_WIDTH_THRESHOLD, SEARCH_RESULTS_DISPLAY_LIMIT } from '../../../constants'
 import { matchesKeyboardShortcut } from '../../helpers/keyboardShortcuts'
-import { getSearchHistoryEntryQuery } from '../../helpers/search-history'
+import { getSearchHistoryEntryQuery } from '../../../search-history'
 import { debounce, localizeAndAddKeyboardShortcutToActionTitle, openInternalPath } from '../../helpers/utils'
 import { translateWindowTitle } from '../../helpers/strings'
 import { clearLocalSearchSuggestionsSession, getLocalSearchSuggestions } from '../../helpers/api/local'

--- a/src/renderer/helpers/search-history.js
+++ b/src/renderer/helpers/search-history.js
@@ -1,3 +1,119 @@
+export const DEFAULT_SEARCH_SETTINGS = Object.freeze({
+  prioritize: 'relevance',
+  time: '',
+  type: 'all',
+  duration: '',
+  features: Object.freeze([]),
+})
+
+/**
+ * @param {object | null | undefined} searchSettings
+ * @returns {{ prioritize: string, time: string, type: string, duration: string, features: string[] }}
+ */
+export function normalizeSearchSettings(searchSettings) {
+  return {
+    prioritize: typeof searchSettings?.prioritize === 'string'
+      ? searchSettings.prioritize
+      : DEFAULT_SEARCH_SETTINGS.prioritize,
+    time: typeof searchSettings?.time === 'string'
+      ? searchSettings.time
+      : DEFAULT_SEARCH_SETTINGS.time,
+    type: typeof searchSettings?.type === 'string'
+      ? searchSettings.type
+      : DEFAULT_SEARCH_SETTINGS.type,
+    duration: typeof searchSettings?.duration === 'string'
+      ? searchSettings.duration
+      : DEFAULT_SEARCH_SETTINGS.duration,
+    features: Array.isArray(searchSettings?.features)
+      ? [...new Set(searchSettings.features.filter(feature => typeof feature === 'string'))].sort()
+      : [],
+  }
+}
+
+/**
+ * @param {{ _id: string, query?: string }} entry
+ * @returns {string}
+ */
+export function getSearchHistoryEntryQuery(entry) {
+  return typeof entry.query === 'string' ? entry.query : entry._id
+}
+
+/**
+ * @param {string} query
+ * @param {object | null | undefined} searchSettings
+ * @returns {string}
+ */
+export function getSearchHistoryEntryKey(query, searchSettings) {
+  const settings = normalizeSearchSettings(searchSettings)
+  return JSON.stringify([
+    query,
+    settings.prioritize,
+    settings.time,
+    settings.type,
+    settings.duration,
+    settings.features,
+  ])
+}
+
+/**
+ * @param {{ _id: string, query?: string, searchSettings?: object }} entry
+ * @returns {string}
+ */
+export function getSearchHistoryEntryKeyFromEntry(entry) {
+  return getSearchHistoryEntryKey(getSearchHistoryEntryQuery(entry), entry.searchSettings)
+}
+
+/**
+ * @param {string} query
+ * @param {object | null | undefined} searchSettings
+ * @returns {string}
+ */
+export function getSearchHistoryEntryId(query, searchSettings) {
+  return `search-history:${getSearchHistoryEntryKey(query, searchSettings)}`
+}
+
+/**
+ * @param {{ _id: string, query?: string, lastUpdatedAt: number, searchSettings?: object }} entry
+ * @returns {{ _id: string, query: string, lastUpdatedAt: number, searchSettings: ReturnType<typeof normalizeSearchSettings> }}
+ */
+export function normalizeSearchHistoryEntry(entry) {
+  return {
+    ...entry,
+    query: getSearchHistoryEntryQuery(entry),
+    searchSettings: normalizeSearchSettings(entry.searchSettings),
+  }
+}
+
+/**
+ * Merge search history without collapsing the same query with different filters.
+ * @param {{ _id: string, query?: string, lastUpdatedAt: number, searchSettings?: object }[]} currentEntries
+ * @param {{ _id: string, query?: string, lastUpdatedAt: number, searchSettings?: object }[]} importedEntries
+ * @returns {ReturnType<typeof normalizeSearchHistoryEntry>[]}
+ */
+export function mergeSearchHistoryEntries(currentEntries, importedEntries) {
+  const entriesByKey = new Map()
+
+  for (const entry of currentEntries) {
+    const normalizedEntry = normalizeSearchHistoryEntry(entry)
+    entriesByKey.set(getSearchHistoryEntryKeyFromEntry(normalizedEntry), normalizedEntry)
+  }
+
+  for (const entry of importedEntries) {
+    const normalizedEntry = normalizeSearchHistoryEntry(entry)
+    const key = getSearchHistoryEntryKeyFromEntry(normalizedEntry)
+    const existingEntry = entriesByKey.get(key)
+
+    if (existingEntry == null || normalizedEntry.lastUpdatedAt > existingEntry.lastUpdatedAt) {
+      entriesByKey.set(key, {
+        ...normalizedEntry,
+        _id: existingEntry?._id ?? getSearchHistoryEntryId(normalizedEntry.query, normalizedEntry.searchSettings),
+      })
+    }
+  }
+
+  return Array.from(entriesByKey.values())
+}
+
 /**
  * Sorts search history in place from the most recent entry to the oldest.
  * @param {{ lastUpdatedAt: number }[]} historyItems

--- a/src/renderer/helpers/utils.js
+++ b/src/renderer/helpers/utils.js
@@ -3,6 +3,7 @@ import i18n from '../i18n/index'
 import router from '../router/index'
 import { getTabNavigationService } from '../tabs/TabNavigationService'
 import { UnsupportedPlayerActions } from '../../constants'
+import { getSearchHistoryEntryKey } from '../../search-history'
 import { getPreferredShortThumbnailUrl } from './player/shorts'
 import { isRoundedNumber } from './viewCounts'
 
@@ -699,11 +700,7 @@ export function formatDurationAsTimestamp(lengthSeconds) {
  * @returns {boolean}
  */
 export function searchFiltersMatch(filtersA, filtersB) {
-  return filtersA?.prioritize === filtersB?.prioritize &&
-    filtersA?.time === filtersB?.time &&
-    filtersA?.type === filtersB?.type &&
-    filtersA?.duration === filtersB?.duration &&
-    filtersA?.features?.length === filtersB?.features?.length && filtersA?.features?.every((val, index) => val === filtersB?.features[index])
+  return getSearchHistoryEntryKey('', filtersA) === getSearchHistoryEntryKey('', filtersB)
 }
 
 /**

--- a/src/renderer/store/modules/search-history.js
+++ b/src/renderer/store/modules/search-history.js
@@ -1,6 +1,12 @@
 import { MIXED_SEARCH_HISTORY_ENTRIES_DISPLAY_LIMIT } from '../../../constants'
 import { DBSearchHistoryHandlers } from '../../../datastores/handlers/index'
-import { sortSearchHistoryByLastUpdatedAt } from '../../helpers/search-history'
+import {
+  getSearchHistoryEntryId,
+  getSearchHistoryEntryKeyFromEntry,
+  getSearchHistoryEntryQuery,
+  normalizeSearchHistoryEntry,
+  sortSearchHistoryByLastUpdatedAt,
+} from '../../helpers/search-history'
 
 const state = {
   searchHistoryEntries: []
@@ -11,32 +17,27 @@ const getters = {
     return state.searchHistoryEntries
   },
 
-  getLatestSearchHistoryNames: (state) => {
-    return state.searchHistoryEntries.map((entry) => entry._id)
+  getLatestSearchHistoryEntries: (state) => {
+    return state.searchHistoryEntries
   },
 
-  getLatestMatchingSearchHistoryNames: (state) => (id) => {
+  getLatestMatchingSearchHistoryEntries: (state) => (query) => {
     const matches = []
-    let counter = 0
 
     for (const entry of state.searchHistoryEntries) {
-      if (entry._id.startsWith(id)) {
-        matches.push(entry._id)
+      if (getSearchHistoryEntryQuery(entry).startsWith(query)) {
+        matches.push(entry)
 
-        counter++
-
-        if (counter === MIXED_SEARCH_HISTORY_ENTRIES_DISPLAY_LIMIT) {
+        if (matches.length === MIXED_SEARCH_HISTORY_ENTRIES_DISPLAY_LIMIT) {
           break
         }
       }
     }
 
     // prioritize more concise matches
-    return matches.sort((a, b) => a.length - b.length)
-  },
-
-  getSearchHistoryEntryWithId: (state) => (id) => {
-    return state.searchHistoryEntries.find(p => p._id === id)
+    return matches.sort((a, b) => {
+      return getSearchHistoryEntryQuery(a).length - getSearchHistoryEntryQuery(b).length
+    })
   },
 }
 const actions = {
@@ -49,10 +50,20 @@ const actions = {
     }
   },
 
-  async updateSearchHistoryEntry({ commit }, searchHistoryEntry) {
+  async updateSearchHistoryEntry({ state, commit }, searchHistoryEntry) {
     try {
-      await DBSearchHistoryHandlers.upsert(searchHistoryEntry)
-      commit('upsertSearchHistoryEntryToList', searchHistoryEntry)
+      const normalizedEntry = normalizeSearchHistoryEntry(searchHistoryEntry)
+      const entryKey = getSearchHistoryEntryKeyFromEntry(normalizedEntry)
+      const existingEntry = state.searchHistoryEntries.find(entry => {
+        return getSearchHistoryEntryKeyFromEntry(entry) === entryKey
+      })
+      const updatedEntry = {
+        ...normalizedEntry,
+        _id: existingEntry?._id ?? getSearchHistoryEntryId(normalizedEntry.query, normalizedEntry.searchSettings),
+      }
+
+      await DBSearchHistoryHandlers.upsert(updatedEntry)
+      commit('upsertSearchHistoryEntryToList', updatedEntry)
     } catch (errMessage) {
       console.error(errMessage)
     }
@@ -98,10 +109,11 @@ const actions = {
 
 const mutations = {
   setSearchHistoryEntries(state, searchHistoryEntries) {
-    state.searchHistoryEntries = searchHistoryEntries
+    state.searchHistoryEntries = searchHistoryEntries.map(normalizeSearchHistoryEntry)
   },
 
   upsertSearchHistoryEntryToList(state, updatedSearchHistoryEntry) {
+    updatedSearchHistoryEntry = normalizeSearchHistoryEntry(updatedSearchHistoryEntry)
     state.searchHistoryEntries = state.searchHistoryEntries.filter((p) => {
       return p._id !== updatedSearchHistoryEntry._id
     })

--- a/src/renderer/store/modules/search-history.js
+++ b/src/renderer/store/modules/search-history.js
@@ -1,12 +1,12 @@
 import { MIXED_SEARCH_HISTORY_ENTRIES_DISPLAY_LIMIT } from '../../../constants'
 import { DBSearchHistoryHandlers } from '../../../datastores/handlers/index'
 import {
-  getSearchHistoryEntryId,
-  getSearchHistoryEntryKeyFromEntry,
   getSearchHistoryEntryQuery,
+  mergeSearchHistoryEntries,
   normalizeSearchHistoryEntry,
+  resolveSearchHistoryEntry,
   sortSearchHistoryByLastUpdatedAt,
-} from '../../helpers/search-history'
+} from '../../../search-history'
 
 const state = {
   searchHistoryEntries: []
@@ -44,7 +44,7 @@ const actions = {
   async grabSearchHistoryEntries({ commit }) {
     try {
       const results = await DBSearchHistoryHandlers.find()
-      commit('setSearchHistoryEntries', results)
+      commit('mergeLoadedSearchHistoryEntries', results)
     } catch (errMessage) {
       console.error(errMessage)
     }
@@ -52,18 +52,9 @@ const actions = {
 
   async updateSearchHistoryEntry({ state, commit }, searchHistoryEntry) {
     try {
-      const normalizedEntry = normalizeSearchHistoryEntry(searchHistoryEntry)
-      const entryKey = getSearchHistoryEntryKeyFromEntry(normalizedEntry)
-      const existingEntry = state.searchHistoryEntries.find(entry => {
-        return getSearchHistoryEntryKeyFromEntry(entry) === entryKey
-      })
-      const updatedEntry = {
-        ...normalizedEntry,
-        _id: existingEntry?._id ?? getSearchHistoryEntryId(normalizedEntry.query, normalizedEntry.searchSettings),
-      }
-
-      await DBSearchHistoryHandlers.upsert(updatedEntry)
-      commit('upsertSearchHistoryEntryToList', updatedEntry)
+      const updatedEntry = resolveSearchHistoryEntry(searchHistoryEntry, state.searchHistoryEntries)
+      const persistedEntry = await DBSearchHistoryHandlers.upsert(updatedEntry)
+      commit('upsertSearchHistoryEntryToList', persistedEntry ?? updatedEntry)
     } catch (errMessage) {
       console.error(errMessage)
     }
@@ -108,6 +99,11 @@ const actions = {
 }
 
 const mutations = {
+  mergeLoadedSearchHistoryEntries(state, searchHistoryEntries) {
+    state.searchHistoryEntries = mergeSearchHistoryEntries(searchHistoryEntries, state.searchHistoryEntries)
+    sortSearchHistoryByLastUpdatedAt(state.searchHistoryEntries)
+  },
+
   setSearchHistoryEntries(state, searchHistoryEntries) {
     state.searchHistoryEntries = searchHistoryEntries.map(normalizeSearchHistoryEntry)
   },

--- a/src/renderer/store/modules/utils.js
+++ b/src/renderer/store/modules/utils.js
@@ -874,8 +874,10 @@ const mutations = {
     cache[videoId] = avatar
   },
 
-  removeFromSessionSearchHistory (state, query) {
-    state.sessionSearchHistory = state.sessionSearchHistory.filter((search) => search.query !== query)
+  removeFromSessionSearchHistory (state, { query, searchSettings }) {
+    state.sessionSearchHistory = state.sessionSearchHistory.filter((search) => {
+      return search.query !== query || !searchFiltersMatch(search.searchSettings, searchSettings)
+    })
   },
 
   addToSessionSearchHistory (state, payload) {

--- a/src/renderer/views/SearchPage/SearchPage.vue
+++ b/src/renderer/views/SearchPage/SearchPage.vue
@@ -175,7 +175,7 @@ onMounted(() => {
 
 function updateSearchHistoryEntry(searchSettings) {
   const persistentSearchHistoryPayload = {
-    _id: processedQuery.value,
+    query: processedQuery.value,
     lastUpdatedAt: Date.now(),
     searchSettings: {
       prioritize: searchSettings.prioritize,

--- a/src/search-history.js
+++ b/src/search-history.js
@@ -73,6 +73,28 @@ export function getSearchHistoryEntryId(query, searchSettings) {
 }
 
 /**
+ * Preserve an existing ID for a matching query and filter preset.
+ * @param {{ _id?: string, query: string, lastUpdatedAt: number, searchSettings?: object }} entry
+ * @param {{ _id: string, query?: string, lastUpdatedAt: number, searchSettings?: object }[]} existingEntries
+ * @returns {ReturnType<typeof normalizeSearchHistoryEntry>}
+ */
+export function resolveSearchHistoryEntry(entry, existingEntries) {
+  const normalizedEntry = normalizeSearchHistoryEntry(entry)
+  const entryKey = getSearchHistoryEntryKeyFromEntry(normalizedEntry)
+  const existingEntry = existingEntries.find(candidate => {
+    return getSearchHistoryEntryKeyFromEntry(candidate) === entryKey
+  })
+
+  return {
+    ...normalizedEntry,
+    _id: existingEntry?._id ?? normalizedEntry._id ?? getSearchHistoryEntryId(
+      normalizedEntry.query,
+      normalizedEntry.searchSettings
+    ),
+  }
+}
+
+/**
  * @param {{ _id: string, query?: string, lastUpdatedAt: number, searchSettings?: object }} entry
  * @returns {{ _id: string, query: string, lastUpdatedAt: number, searchSettings: ReturnType<typeof normalizeSearchSettings> }}
  */

--- a/tests/unit/search-history-sort.test.mjs
+++ b/tests/unit/search-history-sort.test.mjs
@@ -1,7 +1,12 @@
 import assert from 'node:assert/strict'
 import test from 'node:test'
 
-import { sortSearchHistoryByLastUpdatedAt } from '../../src/renderer/helpers/search-history.js'
+import {
+  getSearchHistoryEntryKeyFromEntry,
+  mergeSearchHistoryEntries,
+  normalizeSearchHistoryEntry,
+  sortSearchHistoryByLastUpdatedAt,
+} from '../../src/renderer/helpers/search-history.js'
 
 test('sorts overwritten search history by newest update first', () => {
   const older = { _id: 'older search', lastUpdatedAt: 100 }
@@ -12,4 +17,84 @@ test('sorts overwritten search history by newest update first', () => {
 
   assert.equal(sorted, historyItems)
   assert.deepEqual(sorted, [newer, older])
+})
+
+test('normalizes legacy search history to a static default filter set', () => {
+  assert.deepEqual(normalizeSearchHistoryEntry({ _id: 'legacy query', lastUpdatedAt: 100 }), {
+    _id: 'legacy query',
+    query: 'legacy query',
+    lastUpdatedAt: 100,
+    searchSettings: {
+      prioritize: 'relevance',
+      time: '',
+      type: 'all',
+      duration: '',
+      features: [],
+    },
+  })
+})
+
+test('keeps the same query with different filters as separate history entries', () => {
+  const today = {
+    _id: 'today',
+    query: 'daily news',
+    lastUpdatedAt: 100,
+    searchSettings: { time: 'today' },
+  }
+  const week = {
+    _id: 'week',
+    query: 'daily news',
+    lastUpdatedAt: 200,
+    searchSettings: { time: 'week' },
+  }
+
+  const merged = mergeSearchHistoryEntries([], [today, week])
+
+  assert.equal(merged.length, 2)
+  assert.notEqual(merged[0]._id, merged[1]._id)
+  assert.notEqual(
+    getSearchHistoryEntryKeyFromEntry(merged[0]),
+    getSearchHistoryEntryKeyFromEntry(merged[1])
+  )
+})
+
+test('treats reordered and duplicate features as one filter set', () => {
+  const hdThen4k = normalizeSearchHistoryEntry({
+    _id: 'first',
+    query: 'trailers',
+    lastUpdatedAt: 100,
+    searchSettings: { features: ['hd', '4k', 'hd'] },
+  })
+  const fourKThenHd = normalizeSearchHistoryEntry({
+    _id: 'second',
+    query: 'trailers',
+    lastUpdatedAt: 200,
+    searchSettings: { features: ['4k', 'hd'] },
+  })
+
+  assert.deepEqual(hdThen4k.searchSettings.features, ['4k', 'hd'])
+  assert.deepEqual(mergeSearchHistoryEntries([hdThen4k], [fourKThenHd]), [{
+    ...fourKThenHd,
+    _id: 'first',
+  }])
+})
+
+test('updates matching query and filter imports without replacing their id', () => {
+  const existing = {
+    _id: 'existing-id',
+    query: 'daily news',
+    lastUpdatedAt: 100,
+    searchSettings: { time: 'today' },
+  }
+  const imported = {
+    _id: 'imported-id',
+    query: 'daily news',
+    lastUpdatedAt: 200,
+    searchSettings: { time: 'today' },
+  }
+
+  assert.deepEqual(mergeSearchHistoryEntries([existing], [imported]), [{
+    ...normalizeSearchHistoryEntry(imported),
+    _id: 'existing-id',
+  }])
 })

--- a/tests/unit/search-history-sort.test.mjs
+++ b/tests/unit/search-history-sort.test.mjs
@@ -5,8 +5,9 @@ import {
   getSearchHistoryEntryKeyFromEntry,
   mergeSearchHistoryEntries,
   normalizeSearchHistoryEntry,
+  resolveSearchHistoryEntry,
   sortSearchHistoryByLastUpdatedAt,
-} from '../../src/renderer/helpers/search-history.js'
+} from '../../src/search-history.js'
 
 test('sorts overwritten search history by newest update first', () => {
   const older = { _id: 'older search', lastUpdatedAt: 100 }
@@ -97,4 +98,30 @@ test('updates matching query and filter imports without replacing their id', () 
     ...normalizeSearchHistoryEntry(imported),
     _id: 'existing-id',
   }])
+})
+
+test('preserves a matching legacy id when history has not loaded into the store yet', () => {
+  const legacyEntry = {
+    _id: 'trailers',
+    lastUpdatedAt: 100,
+    searchSettings: { features: ['hd', '4k'] },
+  }
+  const submittedEntry = {
+    query: 'trailers',
+    lastUpdatedAt: 200,
+    searchSettings: { features: ['4k', 'hd'] },
+  }
+
+  assert.deepEqual(resolveSearchHistoryEntry(submittedEntry, [legacyEntry]), {
+    _id: 'trailers',
+    query: 'trailers',
+    lastUpdatedAt: 200,
+    searchSettings: {
+      prioritize: 'relevance',
+      time: '',
+      type: 'all',
+      duration: '',
+      features: ['4k', 'hd'],
+    },
+  })
 })


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Make sure to follow the contributing guidelines. -->
<!-- Important note, we may remove your pull request if you do not use this provided PR template correctly. -->
<!-- Agent instructions: Preserve every heading, comment, and marker in this template. Never remove or rewrite the release-note-category:start/end, release-note:start/end, or release-note-image:start/end marker pairs. -->

## Pull Request Type
<!-- Please select what type of pull request this is: [x] -->
- [ ] Bugfix
- [x] Feature Implementation
- [ ] Documentation
- [ ] Other

## Related issue
<!-- Please link the issue your pull request is referring to. -->
<!-- If this pull request fully resolves the relevant issue, put "closes" before the issue number. -->
<!-- Example: "closes #123456". -->

closes #526

## Description
<!-- Please write a clear and concise description of what the pull request does. -->

Search history currently identifies entries by query text, so running the same query with different filters overwrites the earlier preset.

This change gives each query and filter combination its own stable identity, restores the saved filters when selected, and labels duplicate queries with their filter details. It also preserves these presets through OpenTubeX history import and export while keeping legacy entries usable with default filters.

## Release note category
<!-- Select exactly one category. Every pull request must select one. -->
<!-- Select "Not noteworthy" when the pull request fixes a bug in or improves functionality that has not yet appeared in a stable release. -->
<!-- release-note-category:start -->
- [ ] Not noteworthy
- [ ] Highlights
- [x] More improvements
- [ ] Fixed bugs
<!-- release-note-category:end -->

## Release note
<!-- Required unless "Not noteworthy" is selected. -->
<!-- Write one concise, user-facing entry without a leading bullet. -->
<!-- release-note:start -->

Search history can now save the same query with different filters and restore each preset exactly.

<!-- release-note:end -->

## Release note images
<!-- Optional. Paste one or more Markdown images, HTML image tags, or dark/light <picture> elements here. -->
<!-- The release notes normalize the markup and limit images taller than 300 pixels. -->
<!-- Agent instructions:
For a noteworthy visible change, add media when it makes the change easier to understand. Prefer a still image unless motion is the point; recordings must use animated WebP.
After implementing a visible change, proactively capture the result and show the local media to the user for approval before uploading it or updating the pull request.
When the affected UI differs between dark and light themes, capturing both themes is required. A dark-only image is incomplete. Run `node _scripts/releaseNoteMedia.mjs --dark DARK_FILE --light LIGHT_FILE --alt "DESCRIPTION"`; GitHub will display the matching theme and use dark as the fallback. Use a single default-dark capture only when the light theme cannot be captured or looks identical.
Capture or crop to the smallest region that still makes the change clear. Do not include the full window when the affected component can be understood on its own.
Use English unless localization is the subject. Keep components at their normal dimensions and placement instead of resizing them to fill the frame.
Use deterministic local fixtures for visible remote images. Reusable avatar and thumbnail fixtures are available through `e2e/helpers/visual-fixtures.mjs`. Before capturing, verify that every visible image has loaded successfully (`complete === true` and `naturalWidth > 0`).
Inspect the final dark and light files for failed images, missing content, unrelated UI, awkward animation, and misleading layout. Omit media when it does not explain the change clearly.
For one dark capture, run `node _scripts/releaseNoteMedia.mjs FILE --alt "DESCRIPTION"`.
Check for personal information, tokens, private repository names, and unrelated desktop content before uploading. Uploaded media is public.
Keep capture-only scripts, test hooks, screenshots, and recordings out of commits. Remove them before committing unless the capture code is also a reusable regression test. Never commit generated release-note media.
Paste only the generated markup between the marker comments. Leave this section empty when media would not help.
-->
<!-- release-note-image:start -->

<picture>
  <source media="(prefers-color-scheme: dark)" srcset="https://github.com/OpenTubeX/media/releases/download/attachments/20260901T182410Z-search-history-dark-dark-a2e6328d63.png">
  <source media="(prefers-color-scheme: light)" srcset="https://github.com/OpenTubeX/media/releases/download/attachments/20260901T182410Z-search-history-light-light-c1e3d5c3bc.png">
  <img alt="Search history entries for the same query with distinct saved filters" src="https://github.com/OpenTubeX/media/releases/download/attachments/20260901T182410Z-search-history-dark-dark-a2e6328d63.png">
</picture>

<!-- release-note-image:end -->

## Testing
<!-- How can reviewers verify that the PR produces correct results? -->
<!-- Please provide instructions so that others can ensure that your pull request would produce correct results. For examples see, https://github.com/FreeTubeApp/FreeTube/pull/5743, https://github.com/FreeTubeApp/FreeTube/pull/7349, https://github.com/FreeTubeApp/FreeTube/pull/5125, https://github.com/FreeTubeApp/FreeTube/pull/7338 -->
<!-- Agent instructions: Only write human-facing steps that explain how to verify the change while running this branch in dev mode. Include expected results and, when applicable, helpful console snippets for interactive verification. Do not include automated checks, commands, results, pass counts, or CI status. -->

1. Set the search time filter to Today and search for a term.
2. Change the time filter to This Week, then submit the same term again.
3. Focus the search field. Two entries should appear for the term, each labeled with its saved filters.
4. Select each entry in turn. The search URL and filter dialog should restore that entry's exact filter set.
5. Remove one entry. The other preset should remain available and unchanged.

## Additional context
<!-- Add any other context about the pull request here. -->

Legacy search-history entries without stored filters are treated as default-filter presets.
