### PR TITLE
fix(player): keep yt-dlp cache after timeouts

### DIFF
--- a/e2e/tests/offline/sabr-error-recovery.spec.mjs
+++ b/e2e/tests/offline/sabr-error-recovery.spec.mjs
@@ -342,11 +342,11 @@ test('yt-dlp playback refreshes once then prefers built-in SABR over legacy', as
 })
 
 test('yt-dlp timeout reload reuses cache while a rejected source is invalidated', async ({ app, page }) => {
-  await mockUnplayableWatchPage(app, page)
+  await mockPlayableWatchPage(app, page)
   await goTo(page, 'history')
   await page.getByText('SABR test video').click()
   await expect(page).toHaveURL(/#\/watch\/jNQXAC9IVRw/)
-  await expect(page.locator('.errorMessage')).toBeVisible({ timeout: 30_000 })
+  await expect(page.locator('.ftVideoPlayer')).toBeVisible({ timeout: 30_000 })
 
   const watchView = await watchViewHandle(page)
   const result = await watchView.evaluate(async (view) => {
@@ -382,30 +382,39 @@ test('yt-dlp timeout reload reuses cache while a rejected source is invalidated'
     view.activePlaybackEngineVersion = 'test'
     view.streamErrorReloadAttemptedForCurrentVideo = false
     view.playbackEngineFallbackAttemptedForCurrentVideo = false
-    view.playbackEngineFallbackTarget = null
-    view.ytDlpStreamsPending = true
+    view.playbackEngineFallbackTarget = 'yt-dlp'
     view.manifestSrc = 'data:application/dash+xml,yt-dlp'
     view.manifestMimeType = 'application/dash+xml'
     view.legacyFormats = []
 
-    let refreshes = 0
+    const initialLoadGeneration = view.videoLoadGeneration
     const cacheReuseResults = []
-    view.reloadView = async () => {
-      refreshes++
-      cacheReuseResults.push(await view.extractYtDlpPlaybackSource(
-        view.videoLoadGeneration,
-        view.videoId,
-        view.playbackEngineSwitchGeneration,
+    const extractYtDlpPlaybackSource = view.extractYtDlpPlaybackSource.bind(view)
+    view.extractYtDlpPlaybackSource = async (...args) => {
+      const [loadGeneration, videoId, playbackEngineSwitchGeneration] = args
+      const reused = await extractYtDlpPlaybackSource(
+        loadGeneration,
+        videoId,
+        playbackEngineSwitchGeneration,
         useAuthentication,
         true
-      ))
+      )
+      cacheReuseResults.push(reused)
+      // Keep the synthetic cached manifest from mounting a player between reloads.
+      view.errorMessage = 'Synthetic player hold'
+      return reused
     }
-    let sabrReloads = 0
-    view.performSabrReload = async () => {
-      sabrReloads++
+    const waitForCacheLookup = async (count) => {
+      for (let attempt = 0; attempt < 100; attempt++) {
+        if (cacheReuseResults.length >= count) return
+        await new Promise(resolve => setTimeout(resolve, 10))
+      }
+      throw new Error('Timed out waiting for the yt-dlp cache lookup')
     }
 
     await view.handlePlayerError({ code: TIMEOUT, data: [] })
+    await waitForCacheLookup(1)
+    const activePlaybackEngineAfterTimeout = view.activePlaybackEngine
     const cacheEntryAfterTimeout = await window.ftElectron.ytDlpPlaybackCacheGet(
       view.videoId,
       cacheKey
@@ -421,27 +430,26 @@ test('yt-dlp timeout reload reuses cache while a rejected source is invalidated'
     }
     view.streamErrorReloadAttemptedForCurrentVideo = false
     await view.handlePlayerError({ code: BAD_HTTP_STATUS, data: ['https://example.invalid/video', 403] })
+    await waitForCacheLookup(2)
 
     return {
-      activePlaybackEngine: view.activePlaybackEngine,
+      activePlaybackEngineAfterTimeout,
       cacheEntryAfterRejection: await window.ftElectron.ytDlpPlaybackCacheGet(
         view.videoId,
         cacheKey
       ),
       cachePreservedAfterTimeout: cacheEntryAfterTimeout !== null,
       cacheReuseResults,
-      refreshes,
-      sabrReloads
+      reloads: view.videoLoadGeneration - initialLoadGeneration
     }
   })
 
   expect(result).toEqual({
-    activePlaybackEngine: 'yt-dlp',
+    activePlaybackEngineAfterTimeout: 'yt-dlp',
     cacheEntryAfterRejection: null,
     cachePreservedAfterTimeout: true,
     cacheReuseResults: [true, false],
-    refreshes: 2,
-    sabrReloads: 0
+    reloads: 2
   })
 })
 

--- a/e2e/tests/offline/sabr-error-recovery.spec.mjs
+++ b/e2e/tests/offline/sabr-error-recovery.spec.mjs
@@ -341,6 +341,110 @@ test('yt-dlp playback refreshes once then prefers built-in SABR over legacy', as
   })
 })
 
+test('yt-dlp timeout reload reuses cache while a rejected source is invalidated', async ({ app, page }) => {
+  await mockUnplayableWatchPage(app, page)
+  await goTo(page, 'history')
+  await page.getByText('SABR test video').click()
+  await expect(page).toHaveURL(/#\/watch\/jNQXAC9IVRw/)
+  await expect(page.locator('.errorMessage')).toBeVisible({ timeout: 30_000 })
+
+  const watchView = await watchViewHandle(page)
+  const result = await watchView.evaluate(async (view) => {
+    const BAD_HTTP_STATUS = 1001
+    const TIMEOUT = 1003
+    const useAuthentication = view.alwaysUseYtDlpPlaybackCookies
+    const cacheKey = JSON.stringify([view.ytDlpPlaybackCacheKey, useAuthentication])
+    const expiryTime = Date.now() + 60 * 60 * 1000
+    const source = {
+      manifestSrc: 'data:application/dash+xml;charset=UTF-8,cached',
+      manifestMimeType: 'application/dash+xml',
+      legacyFormats: [],
+      title: 'Cached timeout test',
+      isLive: false,
+      subtitlesIncluded: true,
+      version: 'test'
+    }
+    if (!await window.ftElectron.ytDlpPlaybackCacheSet(
+      view.videoId,
+      cacheKey,
+      expiryTime,
+      source
+    )) {
+      throw new Error('Unable to seed the yt-dlp playback cache')
+    }
+
+    view.errorMessage = ''
+    view.isLoading = false
+    view.isLive = false
+    view.isPostLiveDvr = false
+    view.activeFormat = 'dash'
+    view.activePlaybackEngine = 'yt-dlp'
+    view.activePlaybackEngineVersion = 'test'
+    view.streamErrorReloadAttemptedForCurrentVideo = false
+    view.playbackEngineFallbackAttemptedForCurrentVideo = false
+    view.playbackEngineFallbackTarget = null
+    view.ytDlpStreamsPending = true
+    view.manifestSrc = 'data:application/dash+xml,yt-dlp'
+    view.manifestMimeType = 'application/dash+xml'
+    view.legacyFormats = []
+
+    let refreshes = 0
+    const cacheReuseResults = []
+    view.reloadView = async () => {
+      refreshes++
+      cacheReuseResults.push(await view.extractYtDlpPlaybackSource(
+        view.videoLoadGeneration,
+        view.videoId,
+        view.playbackEngineSwitchGeneration,
+        useAuthentication,
+        true
+      ))
+    }
+    let sabrReloads = 0
+    view.performSabrReload = async () => {
+      sabrReloads++
+    }
+
+    await view.handlePlayerError({ code: TIMEOUT, data: [] })
+    const cacheEntryAfterTimeout = await window.ftElectron.ytDlpPlaybackCacheGet(
+      view.videoId,
+      cacheKey
+    )
+
+    if (!await window.ftElectron.ytDlpPlaybackCacheSet(
+      view.videoId,
+      cacheKey,
+      expiryTime,
+      source
+    )) {
+      throw new Error('Unable to restore the yt-dlp playback cache')
+    }
+    view.streamErrorReloadAttemptedForCurrentVideo = false
+    await view.handlePlayerError({ code: BAD_HTTP_STATUS, data: ['https://example.invalid/video', 403] })
+
+    return {
+      activePlaybackEngine: view.activePlaybackEngine,
+      cacheEntryAfterRejection: await window.ftElectron.ytDlpPlaybackCacheGet(
+        view.videoId,
+        cacheKey
+      ),
+      cachePreservedAfterTimeout: cacheEntryAfterTimeout !== null,
+      cacheReuseResults,
+      refreshes,
+      sabrReloads
+    }
+  })
+
+  expect(result).toEqual({
+    activePlaybackEngine: 'yt-dlp',
+    cacheEntryAfterRejection: null,
+    cachePreservedAfterTimeout: true,
+    cacheReuseResults: [true, false],
+    refreshes: 2,
+    sabrReloads: 0
+  })
+})
+
 test('expired built-in playback source is refreshed before yt-dlp falls back', async ({ app, page }) => {
   await mockUnplayableWatchPage(app, page)
   await goTo(page, 'history')

--- a/e2e/tests/offline/sabr-error-recovery.spec.mjs
+++ b/e2e/tests/offline/sabr-error-recovery.spec.mjs
@@ -405,11 +405,13 @@ test('yt-dlp timeout reload reuses cache while a rejected source is invalidated'
       return reused
     }
     const waitForCacheLookup = async (count) => {
-      for (let attempt = 0; attempt < 100; attempt++) {
+      for (let attempt = 0; attempt < 1500; attempt++) {
         if (cacheReuseResults.length >= count) return
         await new Promise(resolve => setTimeout(resolve, 10))
       }
-      throw new Error('Timed out waiting for the yt-dlp cache lookup')
+      throw new Error(
+        `Timed out waiting for yt-dlp cache lookup ${count}, got ${cacheReuseResults.length}`
+      )
     }
 
     await view.handlePlayerError({ code: TIMEOUT, data: [] })

--- a/src/renderer/views/Watch/Watch.js
+++ b/src/renderer/views/Watch/Watch.js
@@ -4682,7 +4682,12 @@ export default defineComponent({
       // URL or extraction. Refresh those streams once before changing format or
       // restoring the cached built-in source (which may use SABR).
       if (this.activePlaybackEngine === 'yt-dlp') {
-        invalidateYtDlpPlaybackSource(this.videoId)
+        // A timeout says nothing about whether the cached source is stale. Keep
+        // valid cached streams for that reload so recovery does not needlessly
+        // run yt-dlp again, while other failures retain the existing refresh.
+        if (error.code !== Code.TIMEOUT) {
+          invalidateYtDlpPlaybackSource(this.videoId)
+        }
         const status = error.code === Code.BAD_HTTP_STATUS ? error.data[1] : error.code
         if (await this.reloadAfterStreamErrorOnce(`[PLAYER_ERROR: ${status}]`)) {
           return


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Make sure to follow the contributing guidelines. -->
<!-- Important note, we may remove your pull request if you do not use this provided PR template correctly. -->
<!-- Agent instructions: Preserve every heading, comment, and marker in this template. Never remove or rewrite the release-note-category:start/end, release-note:start/end, or release-note-image:start/end marker pairs. -->

## Pull Request Type
<!-- Please select what type of pull request this is: [x] -->
- [x] Bugfix
- [ ] Feature Implementation
- [ ] Documentation
- [ ] Other

## Related issue
<!-- Please link the issue your pull request is referring to. -->
<!-- If this pull request fully resolves the relevant issue, put "closes" before the issue number. -->
<!-- Example: "closes #123456". -->
Follow-up to #1020, which resolved #1017.

## Description
<!-- Please write a clear and concise description of what the pull request does. -->
After Shaka timeout 1003, playback recovery deleted the valid yt-dlp cache entry before reloading. The reload therefore ran yt-dlp again and could fall back to the Built-in engine and SABR when extraction failed.

Keep the cached source only for timeout recovery. Other player failures, including rejected stream URLs, retain the existing invalidation and fresh-extraction behavior.

## Release note category
<!-- Select exactly one category. Every pull request must select one. -->
<!-- Select "Not noteworthy" when the pull request fixes a bug in or improves functionality that has not yet appeared in a stable release. -->
<!-- release-note-category:start -->
- [x] Not noteworthy
- [ ] Highlights
- [ ] More improvements
- [ ] Fixed bugs
<!-- release-note-category:end -->

## Release note
<!-- Required unless "Not noteworthy" is selected. -->
<!-- Write one concise, user-facing entry without a leading bullet. -->
<!-- release-note:start -->

<!-- release-note:end -->

## Release note images
<!-- Optional. Paste one or more Markdown images, HTML image tags, or dark/light <picture> elements here. -->
<!-- The release notes normalize the markup and limit images taller than 300 pixels. -->
<!-- Agent instructions:
For a noteworthy visible change, add media when it makes the change easier to understand. Prefer a still image unless motion is the point; recordings must use animated WebP.
After implementing a visible change, proactively capture the result and show the local media to the user for approval before uploading it or updating the pull request.
When the affected UI differs between dark and light themes, capturing both themes is required. A dark-only image is incomplete. Run `node _scripts/releaseNoteMedia.mjs --dark DARK_FILE --light LIGHT_FILE --alt "DESCRIPTION"`; GitHub will display the matching theme and use dark as the fallback. Use a single default-dark capture only when the light theme cannot be captured or looks identical.
Capture or crop to the smallest region that still makes the change clear. Do not include the full window when the affected component can be understood on its own.
Use English unless localization is the subject. Keep components at their normal dimensions and placement instead of resizing them to fill the frame.
Use deterministic local fixtures for visible remote images. Reusable avatar and thumbnail fixtures are available through `e2e/helpers/visual-fixtures.mjs`. Before capturing, verify that every visible image has loaded successfully (`complete === true` and `naturalWidth > 0`).
Inspect the final dark and light files for failed images, missing content, unrelated UI, awkward animation, and misleading layout. Omit media when it does not explain the change clearly.
For one dark capture, run `node _scripts/releaseNoteMedia.mjs FILE --alt "DESCRIPTION"`.
Check for personal information, tokens, private repository names, and unrelated desktop content before uploading. Uploaded media is public.
Keep capture-only scripts, test hooks, screenshots, and recordings out of commits. Remove them before committing unless the capture code is also a reusable regression test. Never commit generated release-note media.
Paste only the generated markup between the marker comments. Leave this section empty when media would not help.
-->
<!-- release-note-image:start -->

<!-- release-note-image:end -->

## Testing
<!-- How can reviewers verify that the PR produces correct results? -->
<!-- Please provide instructions so that others can ensure that your pull request would produce correct results. For examples see, https://github.com/FreeTubeApp/FreeTube/pull/5743, https://github.com/FreeTubeApp/FreeTube/pull/7349, https://github.com/FreeTubeApp/FreeTube/pull/5125, https://github.com/FreeTubeApp/FreeTube/pull/7338 -->
<!-- Agent instructions: Only write human-facing steps that explain how to verify the change while running this branch in dev mode. Include expected results and, when applicable, helpful console snippets for interactive verification. Do not include automated checks, commands, results, pass counts, or CI status. -->
1. Select the yt-dlp playback engine and open a video whose playback source is cached.
2. Interrupt segment requests long enough for Shaka to report timeout 1003, then allow the automatic reload.
3. Confirm the reload stays on yt-dlp, reuses the cached source, and does not start another yt-dlp extraction.
4. Repeat with a stream URL that returns an HTTP rejection and confirm recovery invalidates the cache and requests fresh streams.

## Additional context
<!-- Add any other context about the pull request here. -->
The Post-Live-DVR work in #1020 did not add the generic cache invalidation. It made that older recovery path apply to recently ended live streams, which exposed the unconditional invalidation during testing.
