### PR TITLE
feat(subscriptions): show and clear new content per tab

### DIFF
--- a/e2e/tests/offline/subscriptions-new-feed.spec.mjs
+++ b/e2e/tests/offline/subscriptions-new-feed.spec.mjs
@@ -262,6 +262,41 @@ test.describe('new subscriptions feed', () => {
     ]])
   })
 
+  test('shows category dots and marks an inactive category as seen from its context menu', async ({ page }) => {
+    await goTo(page, 'subscriptions')
+    await page.locator('[data-subscription-feed-tab="all"]').click()
+    await page.getByRole('button', { name: 'Show tabbed view' }).click()
+
+    const tabs = page.getByRole('tablist', { name: 'New content tabs' })
+    const videosTab = tabs.locator('[data-new-feed-tab="videos"]')
+    const shortsTab = tabs.locator('[data-new-feed-tab="shorts"]')
+    const liveTab = tabs.locator('[data-new-feed-tab="live"]')
+    const postsTab = tabs.locator('[data-new-feed-tab="posts"]')
+
+    await expect(videosTab.locator('.newContentDot')).toBeVisible()
+    await expect(shortsTab.locator('.newContentDot')).toBeVisible()
+    await expect(liveTab.locator('.newContentDot')).toBeVisible()
+    await expect(postsTab.locator('.newContentDot')).toBeVisible()
+    await expect(videosTab).toHaveAttribute('aria-selected', 'true')
+
+    await shortsTab.click({ button: 'right' })
+    const menu = page.getByRole('menu', { name: 'Context menu' })
+    await menu.getByRole('menuitem', { name: 'Mark all as seen' }).click()
+
+    await expect(videosTab).toHaveAttribute('aria-selected', 'true')
+    await expect(shortsTab.locator('.newContentDot')).toHaveCount(0)
+    await expect(videosTab.locator('.newContentDot')).toBeVisible()
+    await expect(liveTab.locator('.newContentDot')).toBeVisible()
+    await expect(postsTab.locator('.newContentDot')).toBeVisible()
+
+    await shortsTab.click()
+    await expect(page.getByText('There is no new content.')).toBeVisible()
+    await expect(page.getByRole('button', { name: 'Mark all as seen' })).toHaveCount(0)
+
+    await shortsTab.click({ button: 'right' })
+    await expect(menu.getByRole('menuitem', { name: 'Mark all as seen' })).toHaveCount(0)
+  })
+
   test('shows Shorts as portrait cards with their duration and upload time', async ({ page }) => {
     await goTo(page, 'subscriptions')
     await page.locator('[data-subscription-feed-tab="shorts"]').click()
@@ -546,6 +581,9 @@ test.describe('new feed settings and seen state', () => {
     await expect(page.getByRole('button', { name: 'Mark all as seen' })).toHaveCount(0)
 
     await page.locator('[data-subscription-feed-tab="all"]').click()
+    await page.getByRole('button', { name: 'Show tabbed view' }).click()
+    await expect(page.getByRole('tablist', { name: 'New content tabs' }).locator('.newContentDot')).toHaveCount(0)
+    await page.getByRole('button', { name: 'Show combined view' }).click()
     const newVideoCard = page.locator('.ft-list-video').filter({
       has: page.getByRole('heading', { name: 'New video', exact: true })
     })

--- a/src/constants.js
+++ b/src/constants.js
@@ -45,6 +45,7 @@ const IpcChannels = {
   SUBSCRIPTION_AUTO_REFRESH_RELEASE: 'subscription-auto-refresh-release',
   SUBSCRIPTION_AUTO_REFRESH_SET_PROGRESS: 'subscription-auto-refresh-set-progress',
   SUBSCRIPTION_AUTO_REFRESH_STATE_CHANGED: 'subscription-auto-refresh-state-changed',
+  SUBSCRIPTION_FEED_REQUEST_MARK_SEEN: 'subscription-feed-request-mark-seen',
   SUBSCRIPTION_FEED_REQUEST_RELOAD: 'subscription-feed-request-reload',
 
   // Tab management

--- a/src/main/index.js
+++ b/src/main/index.js
@@ -765,6 +765,7 @@ function runApp() {
     Copy: 'Copy',
     Cut: 'Cut',
     Green: 'Settings.Theme Settings.Main Color Theme.Green',
+    'Mark All as Seen': 'Subscriptions.Mark All as Seen',
     'New Tab': 'New Tab',
     'New Window': 'New Window',
     Orange: 'Settings.Theme Settings.Main Color Theme.Orange',
@@ -836,6 +837,8 @@ function runApp() {
       const subscriptionFeedTab = manager?.contextMenuSurface === 'subscriptionFeedTab'
         ? manager.contextMenuSubscriptionFeedTab
         : null
+      const isSubscriptionNewFeedTab = subscriptionFeedTab != null &&
+        manager?.contextMenuSubscriptionNewFeedTab === true
       const subscriptionFeedLabelKeys = {
         videos: 'Reload Videos',
         shorts: 'Reload Shorts',
@@ -947,6 +950,21 @@ function runApp() {
             if (!manager.presentedTabId) return
 
             manager.bridge.send(IpcChannels.SUBSCRIPTION_FEED_REQUEST_RELOAD, {
+              tabId: manager.presentedTabId,
+              feedTab: subscriptionFeedTab
+            })
+          }
+        },
+        {
+          label: contextMenuLabel('Mark All as Seen'),
+          visible: isSubscriptionNewFeedTab &&
+            manager?.contextMenuSubscriptionNewFeedHasContent === true,
+          click: () => {
+            if (!manager?.presentedTabId || !subscriptionFeedTab || subscriptionFeedTab === 'all') {
+              return
+            }
+
+            manager.bridge.send(IpcChannels.SUBSCRIPTION_FEED_REQUEST_MARK_SEEN, {
               tabId: manager.presentedTabId,
               feedTab: subscriptionFeedTab
             })

--- a/src/main/tabs/TabManager.js
+++ b/src/main/tabs/TabManager.js
@@ -727,6 +727,8 @@ export class TabManager {
     this.lastReorderRequestId = null
     this.contextMenuSurface = 'content'
     this.contextMenuSubscriptionFeedTab = null
+    this.contextMenuSubscriptionNewFeedTab = false
+    this.contextMenuSubscriptionNewFeedHasContent = false
     this.contextMenuTabBarVertical = false
     this._sessionPersistenceDisabled = false
     this.sessionUpdatedAt = 0
@@ -3964,6 +3966,10 @@ export async function setupTabsIPC(options = {}) {
       ['videos', 'shorts', 'live', 'posts', 'all'].includes(payload?.feedTab)
       ? payload.feedTab
       : null
+    manager.contextMenuSubscriptionNewFeedTab = manager.contextMenuSubscriptionFeedTab !== null &&
+      payload?.isNewFeedTab === true
+    manager.contextMenuSubscriptionNewFeedHasContent = manager.contextMenuSubscriptionNewFeedTab &&
+      payload?.hasNewContent === true
     manager.contextMenuTabBarVertical = payload?.verticalLayout === true
   })
 

--- a/src/preload/interface.js
+++ b/src/preload/interface.js
@@ -802,6 +802,17 @@ export default {
 
   subscriptionFeeds: {
     /**
+     * Listen for a mark-seen request from a tabbed New feed category's context menu.
+     * @param {(payload: {tabId: string, feedTab: 'videos' | 'shorts' | 'live' | 'posts'}) => void} handler
+     * @returns {() => void}
+     */
+    onRequestMarkSeen: (handler) => {
+      const listener = (_event, payload) => handler(payload)
+      ipcRenderer.on(IpcChannels.SUBSCRIPTION_FEED_REQUEST_MARK_SEEN, listener)
+      return () => ipcRenderer.removeListener(IpcChannels.SUBSCRIPTION_FEED_REQUEST_MARK_SEEN, listener)
+    },
+
+    /**
      * Listen for a reload requested from a subscription feed tab's context menu.
      * @param {(payload: {tabId: string, feedTab: 'videos' | 'shorts' | 'live' | 'posts' | 'all'}) => void} handler
      * @returns {() => void}
@@ -1309,7 +1320,7 @@ export default {
 
     /**
      * Track which tab-related surface the next context menu should target.
-     * @param {{ tabId: string | null, selectedTabIds?: string[], surface: 'tab' | 'tabBar' | 'content' | 'subscriptionFeedTab', feedTab?: 'videos' | 'shorts' | 'live' | 'posts' | 'all' | null, verticalLayout?: boolean }} payload
+     * @param {{ tabId: string | null, selectedTabIds?: string[], surface: 'tab' | 'tabBar' | 'content' | 'subscriptionFeedTab', feedTab?: 'videos' | 'shorts' | 'live' | 'posts' | 'all' | null, isNewFeedTab?: boolean, hasNewContent?: boolean, verticalLayout?: boolean }} payload
      */
     setContextMenuTab: (payload) => {
       ipcRenderer.send(IpcChannels.TABS_SET_CONTEXT_MENU_TAB, payload)

--- a/src/renderer/components/SubscriptionsNew.vue
+++ b/src/renderer/components/SubscriptionsNew.vue
@@ -161,6 +161,13 @@ const hasNewContent = computed(() => {
   return newVideos.value.length > 0 || hasAdditionalContent.value
 })
 
+const hasNewContentByCategory = computed(() => ({
+  videos: newVideos.value.length > 0,
+  shorts: newShorts.value.length > 0,
+  live: newLive.value.length > 0,
+  posts: newPosts.value.length > 0
+}))
+
 defineExpose({
   refresh,
   isLoading,
@@ -168,7 +175,8 @@ defineExpose({
   nextAutoRefreshTimestamp: '',
   nextAutoRefreshTooltip: '',
   refreshTitle: computed(() => t('Subscriptions.New Content')),
-  hasNewContent
+  hasNewContent,
+  hasNewContentByCategory
 })
 </script>
 

--- a/src/renderer/components/TabBar/TabBar.vue
+++ b/src/renderer/components/TabBar/TabBar.vue
@@ -976,10 +976,30 @@ function createNewTab() {
 
 // ===== Context menu =====
 /**
- * @param {{ tabId: string | null, selectedTabIds?: string[], surface: 'tab' | 'tabBar' | 'content' | 'subscriptionFeedTab', feedTab?: 'videos' | 'shorts' | 'live' | 'posts' | 'all' | null }} payload
+ * @param {{ tabId: string | null, selectedTabIds?: string[], surface: 'tab' | 'tabBar' | 'content' | 'subscriptionFeedTab', feedTab?: 'videos' | 'shorts' | 'live' | 'posts' | 'all' | null, isNewFeedTab?: boolean, hasNewContent?: boolean }} payload
  */
 function updateContextMenuTab(payload) {
   window.ftElectron.tabs.setContextMenuTab({ ...payload, verticalLayout: vertical.value })
+}
+
+/**
+ * @param {Element} target
+ */
+function updateContextMenuTarget(target) {
+  const tabId = target.closest('.tab[data-tab-id]')?.dataset.tabId ?? null
+  const contextMenuSelectedTabIds = getContextMenuSelectedTabIds(tabId)
+  const newFeedTab = target.closest('[data-new-feed-tab]')
+  const feedTab = target.closest('[data-subscription-feed-tab]')?.dataset.subscriptionFeedTab ??
+    newFeedTab?.dataset.newFeedTab ?? null
+  const isTabBar = target.closest('.tabBar') != null
+  updateContextMenuTab({
+    tabId,
+    selectedTabIds: contextMenuSelectedTabIds,
+    surface: tabId ? 'tab' : isTabBar ? 'tabBar' : feedTab ? 'subscriptionFeedTab' : 'content',
+    feedTab,
+    isNewFeedTab: newFeedTab != null,
+    hasNewContent: newFeedTab?.dataset.hasNewContent === 'true'
+  })
 }
 
 /**
@@ -990,16 +1010,7 @@ function handleContextMenuPointerDown(event) {
     return
   }
 
-  const tabId = event.target.closest('.tab[data-tab-id]')?.dataset.tabId ?? null
-  const contextMenuSelectedTabIds = getContextMenuSelectedTabIds(tabId)
-  const feedTab = event.target.closest('[data-subscription-feed-tab]')?.dataset.subscriptionFeedTab ?? null
-  const isTabBar = event.target.closest('.tabBar') != null
-  updateContextMenuTab({
-    tabId,
-    selectedTabIds: contextMenuSelectedTabIds,
-    surface: tabId ? 'tab' : isTabBar ? 'tabBar' : feedTab ? 'subscriptionFeedTab' : 'content',
-    feedTab
-  })
+  updateContextMenuTarget(event.target)
 }
 
 /**
@@ -1010,16 +1021,7 @@ function handleContextMenuEvent(event) {
     return
   }
 
-  const tabId = event.target.closest('.tab[data-tab-id]')?.dataset.tabId ?? null
-  const contextMenuSelectedTabIds = getContextMenuSelectedTabIds(tabId)
-  const feedTab = event.target.closest('[data-subscription-feed-tab]')?.dataset.subscriptionFeedTab ?? null
-  const isTabBar = event.target.closest('.tabBar') != null
-  updateContextMenuTab({
-    tabId,
-    selectedTabIds: contextMenuSelectedTabIds,
-    surface: tabId ? 'tab' : isTabBar ? 'tabBar' : feedTab ? 'subscriptionFeedTab' : 'content',
-    feedTab
-  })
+  updateContextMenuTarget(event.target)
 }
 
 /**

--- a/src/renderer/views/Subscriptions/Subscriptions.css
+++ b/src/renderer/views/Subscriptions/Subscriptions.css
@@ -326,6 +326,13 @@
   font-weight: bold;
 }
 
+.newFeedTabDot {
+  inset-block-start: 8px;
+  inset-inline-end: 7px;
+  margin: 0;
+  position: absolute;
+}
+
 .tab .tabLoadingIndicator {
   display: inline-flex;
   inline-size: auto;

--- a/src/renderer/views/Subscriptions/Subscriptions.vue
+++ b/src/renderer/views/Subscriptions/Subscriptions.vue
@@ -263,6 +263,7 @@
             :aria-selected="currentNewFeedTab === tab.id"
             aria-controls="subscriptionsPanel"
             :data-new-feed-tab="tab.id"
+            :data-has-new-content="newFeedTabHasNewContent(tab.id)"
             :tabindex="currentNewFeedTab === tab.id ? 0 : -1"
             @click="changeNewFeedTab(tab.id)"
             @keydown.left.right="switchNewFeedTab($event, tab.id)"
@@ -273,6 +274,10 @@
               class="subscriptionIcon"
             />
             <span>{{ tab.label }}</span>
+            <FtNewContentDot
+              v-if="showNewSubscriptionFeedIndicators && newFeedTabHasNewContent(tab.id)"
+              class="newFeedTabDot"
+            />
           </button>
         </FtFlexBox>
       </div>
@@ -341,6 +346,7 @@ import { useRoute, useRouter } from 'vue-router'
 
 import FtCard from '../../components/ft-card/ft-card.vue'
 import FtLoader from '../../components/FtLoader/FtLoader.vue'
+import FtNewContentDot from '../../components/FtNewContentDot/FtNewContentDot.vue'
 import FtFlexBox from '../../components/ft-flex-box/ft-flex-box.vue'
 import FtIconButton from '../../components/FtIconButton/FtIconButton.vue'
 import FtPrompt from '../../components/FtPrompt/FtPrompt.vue'
@@ -555,6 +561,7 @@ function nextAnimationFrame() {
 
 let isMounted = false
 let removeFeedReloadRequestListener = null
+let removeFeedMarkSeenRequestListener = null
 
 onMounted(() => {
   isMounted = true
@@ -562,6 +569,7 @@ onMounted(() => {
 
   if (isElectron) {
     removeFeedReloadRequestListener = window.ftElectron.subscriptionFeeds.onRequestReload(handleFeedReloadRequest)
+    removeFeedMarkSeenRequestListener = window.ftElectron.subscriptionFeeds.onRequestMarkSeen(handleFeedMarkSeenRequest)
   }
 })
 
@@ -570,6 +578,7 @@ onBeforeUnmount(() => {
   tabChangeSequence++
   document.removeEventListener('keydown', handlePanelTabNavigation)
   removeFeedReloadRequestListener?.()
+  removeFeedMarkSeenRequestListener?.()
 })
 
 watch(currentTab, async (value) => {
@@ -863,6 +872,13 @@ const shortsPanel = useTemplateRef('shortsPanel')
 const communityPanel = useTemplateRef('communityPanel')
 const newPanel = useTemplateRef('newPanel')
 
+/**
+ * @param {'videos' | 'shorts' | 'live' | 'posts'} tab
+ */
+function newFeedTabHasNewContent(tab) {
+  return newPanel.value?.hasNewContentByCategory?.[tab] === true
+}
+
 const currentTabPanel = computed(() => {
   switch (currentTab.value) {
     case 'videos':
@@ -893,8 +909,9 @@ const markingSeenTab = ref(null)
 
 /**
  * @param {'videos' | 'shorts' | 'live' | 'community' | 'new'} tab
+ * @param {'videos' | 'shorts' | 'live' | 'posts'} [newFeedTab=currentNewFeedTab.value]
  */
-async function markAllAsSeen(tab) {
+async function markAllAsSeen(tab, newFeedTab = currentNewFeedTab.value) {
   if (markingSeenTab.value !== null) {
     return
   }
@@ -903,7 +920,7 @@ async function markAllAsSeen(tab) {
   try {
     const feedTabs = tab === 'new'
       ? newFeedView.value === 'tabbed'
-        ? [currentNewFeedTab.value]
+        ? [newFeedTab]
         : visibleTabs.value.filter(visibleTab => visibleTab !== 'new')
       : [tab]
 
@@ -920,6 +937,22 @@ async function markAllAsSeen(tab) {
   } finally {
     markingSeenTab.value = null
   }
+}
+
+/**
+ * @param {{tabId: string, feedTab: 'videos' | 'shorts' | 'live' | 'posts'}} payload
+ */
+function handleFeedMarkSeenRequest(payload) {
+  if (
+    payload?.tabId !== tabId ||
+    currentTab.value !== 'new' ||
+    newFeedView.value !== 'tabbed' ||
+    !visibleNewFeedTabs.value.some(tab => tab.id === payload.feedTab)
+  ) {
+    return
+  }
+
+  markAllAsSeen('new', payload.feedTab)
 }
 
 const currentAutoRefresh = computed(() => {


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Make sure to follow the contributing guidelines. -->
<!-- Important note, we may remove your pull request if you do not use this provided PR template correctly. -->
<!-- Agent instructions: Preserve every heading, comment, and marker in this template. Never remove or rewrite the release-note-category:start/end, release-note:start/end, or release-note-image:start/end marker pairs. -->

## Pull Request Type
<!-- Please select what type of pull request this is: [x] -->
- [ ] Bugfix
- [x] Feature Implementation
- [ ] Documentation
- [ ] Other

## Related issue
<!-- Please link the issue your pull request is referring to. -->
<!-- If this pull request fully resolves the relevant issue, put "closes" before the issue number. -->
<!-- Example: "closes #123456". -->

No linked issue. This was requested directly.

## Description
<!-- Please write a clear and concise description of what the pull request does. -->

The tabbed Subscriptions New feed did not show which categories still contained new content, and clearing an inactive category required switching to it first.

This adds setting-controlled new-content dots to the Videos, Shorts, Live, and Posts tabs. Right-clicking a category with new content now offers "Mark all as seen" and clears that category without changing the selected tab.

## Release note category
<!-- Select exactly one category. Every pull request must select one. -->
<!-- Select "Not noteworthy" when the pull request fixes a bug in or improves functionality that has not yet appeared in a stable release. -->
<!-- release-note-category:start -->
- [ ] Not noteworthy
- [ ] Highlights
- [x] More improvements
- [ ] Fixed bugs
<!-- release-note-category:end -->

## Release note
<!-- Required unless "Not noteworthy" is selected. -->
<!-- Write one concise, user-facing entry without a leading bullet. -->
<!-- release-note:start -->

Subscription New feed tabs now show which categories have unseen content and let you mark a category as seen from its context menu.

<!-- release-note:end -->

## Release note images
<!-- Optional. Paste one or more Markdown images, HTML image tags, or dark/light <picture> elements here. -->
<!-- The release notes normalize the markup and limit images taller than 300 pixels. -->
<!-- Agent instructions:
For a noteworthy visible change, add media when it makes the change easier to understand. Prefer a still image unless motion is the point; recordings must use animated WebP.
After implementing a visible change, proactively capture the result and show the local media to the user for approval before uploading it or updating the pull request.
When the affected UI differs between dark and light themes, capturing both themes is required. A dark-only image is incomplete. Run `node _scripts/releaseNoteMedia.mjs --dark DARK_FILE --light LIGHT_FILE --alt "DESCRIPTION"`; GitHub will display the matching theme and use dark as the fallback. Use a single default-dark capture only when the light theme cannot be captured or looks identical.
Capture or crop to the smallest region that still makes the change clear. Do not include the full window when the affected component can be understood on its own.
Use English unless localization is the subject. Keep components at their normal dimensions and placement instead of resizing them to fill the frame.
Use deterministic local fixtures for visible remote images. Reusable avatar and thumbnail fixtures are available through `e2e/helpers/visual-fixtures.mjs`. Before capturing, verify that every visible image has loaded successfully (`complete === true` and `naturalWidth > 0`).
Inspect the final dark and light files for failed images, missing content, unrelated UI, awkward animation, and misleading layout. Omit media when it does not explain the change clearly.
Check for personal information, tokens, private repository names, and unrelated desktop content before uploading. Uploaded media is public.
Keep capture-only scripts, test hooks, screenshots, and recordings out of commits. Remove them before committing unless the capture code is also a reusable regression test. Never commit generated release-note media.
Paste only the generated markup between the marker comments. Leave this section empty when media would not help.
-->
<!-- release-note-image:start -->
<picture>
  <source media="(prefers-color-scheme: dark)" srcset="https://github.com/OpenTubeX/media/releases/download/attachments/20260907T114444Z-new-feed-indicators-dark-dark-21c85f7d86.png">
  <source media="(prefers-color-scheme: light)" srcset="https://github.com/OpenTubeX/media/releases/download/attachments/20260907T114444Z-new-feed-indicators-light-light-1901e5e570.png">
  <img alt="New subscription feed category indicators and the Mark all as seen context menu" src="https://github.com/OpenTubeX/media/releases/download/attachments/20260907T114444Z-new-feed-indicators-dark-dark-21c85f7d86.png">
</picture>
<!-- release-note-image:end -->

## Testing
<!-- How can reviewers verify that the PR produces correct results? -->
<!-- Please provide instructions so that others can ensure that your pull request would produce correct results. For examples see, https://github.com/FreeTubeApp/FreeTube/pull/5743, https://github.com/FreeTubeApp/FreeTube/pull/7349, https://github.com/FreeTubeApp/FreeTube/pull/5125, https://github.com/FreeTubeApp/FreeTube/pull/7338 -->
<!-- Agent instructions: Only write human-facing steps that explain how to verify the change while running this branch in dev mode. Include expected results and, when applicable, helpful console snippets for interactive verification. Do not include automated checks, commands, results, pass counts, or CI status. -->

1. Enable "Show New Content Feed" and "Show New Content Indicators" in the subscription settings.
2. Open Subscriptions, select New, and switch to the tabbed view.
3. Refresh feeds with new content. Verify that each category containing new content has a dot.
4. Right-click a dotted category that is not selected and choose "Mark all as seen". Verify that its dot disappears without changing the selected category.
5. Disable "Show New Content Indicators" and verify that the category dots are hidden.

## Additional context
<!-- Add any other context about the pull request here. -->

Release note media is omitted because the state change and context-menu interaction are clearer to verify live than in a still image.
