### PR TITLE
fix(player): restore PiP after video reloads

### DIFF
--- a/e2e/helpers/watch.mjs
+++ b/e2e/helpers/watch.mjs
@@ -298,16 +298,23 @@ export function mockPlayableWatchPage(app, page, options = {}) {
 }
 
 /**
- * Returns a handle to the mounted Watch view, so tests can drive its methods
- * directly instead of going through a real player.
+ * Returns a handle to a mounted Watch view, so tests can drive its methods
+ * directly instead of going through a real player. A tab ID selects the Watch
+ * view when multiple logical tabs are mounted.
  *
  * @param {import('@playwright/test').Page} page
+ * @param {string|null} [tabId]
  */
-export function watchViewHandle(page) {
-  return page.evaluateHandle(() => {
+export function watchViewHandle(page, tabId = null) {
+  return page.evaluateHandle((targetTabId) => {
     const app = document.querySelector('#app')?.__vue_app__
     const find = (vnode) => {
-      if (vnode?.component?.type?.name === 'Watch') return vnode.component.proxy
+      if (
+        vnode?.component?.type?.name === 'Watch' &&
+        (targetTabId === null || vnode.component.proxy?.tabId === targetTabId)
+      ) {
+        return vnode.component.proxy
+      }
       if (vnode?.component?.subTree) {
         const match = find(vnode.component.subTree)
         if (match) return match
@@ -326,5 +333,5 @@ export function watchViewHandle(page) {
       throw new Error('Unable to access the watch view')
     }
     return watchView
-  })
+  }, tabId)
 }

--- a/e2e/tests/offline/picture-in-picture-reload.spec.mjs
+++ b/e2e/tests/offline/picture-in-picture-reload.spec.mjs
@@ -1,5 +1,5 @@
 import { test, expect } from '../../helpers/app.mjs'
-import { openMockedVideo } from '../../helpers/player.mjs'
+import { activeTab, openMockedVideo, waitForPlayback } from '../../helpers/player.mjs'
 import { mockPlayableWatchPage, watchViewHandle } from '../../helpers/watch.mjs'
 
 test.use({
@@ -63,4 +63,29 @@ test('restores user-opened Picture-in-Picture across a video reload', async ({ a
   await setMinimized(app, false)
   await page.waitForTimeout(1000)
   expect(await pictureInPictureActive(page)).toBe(true)
+})
+
+test('does not transfer Picture-in-Picture from another tab during reload', async ({ app, page }) => {
+  await mockPlayableWatchPage(app, page)
+  await setFocused(app, page, true)
+  const firstVideo = await openMockedVideo(page)
+  const firstTabId = await page.locator(activeTab).getAttribute('data-tab-id')
+
+  await firstVideo.evaluate(element => element.requestPictureInPicture())
+  await expect.poll(() => firstVideo.evaluate(
+    element => document.pictureInPictureElement === element
+  )).toBe(true)
+
+  await page.keyboard.press('Control+t')
+  await openMockedVideo(page)
+  const secondTabId = await page.locator(activeTab).getAttribute('data-tab-id')
+
+  const watchView = await watchViewHandle(page, secondTabId)
+  await watchView.evaluate(view => view.reloadView())
+  await waitForPlayback(page)
+
+  const originalVideo = page.locator(`.tabContent[data-tab-id="${firstTabId}"] video`)
+  expect(await originalVideo.evaluate(
+    element => document.pictureInPictureElement === element
+  )).toBe(true)
 })

--- a/e2e/tests/offline/picture-in-picture-reload.spec.mjs
+++ b/e2e/tests/offline/picture-in-picture-reload.spec.mjs
@@ -1,0 +1,66 @@
+import { test, expect } from '../../helpers/app.mjs'
+import { openMockedVideo } from '../../helpers/player.mjs'
+import { mockPlayableWatchPage, watchViewHandle } from '../../helpers/watch.mjs'
+
+test.use({
+  seed: {
+    settings: {
+      autoPictureInPictureTriggers: ['minimize'],
+      videoPlaybackEngine: 'built-in',
+      ytDlpPlaybackEngineDefaultMigration: true
+    }
+  }
+})
+
+async function setFocused(app, page, focused) {
+  await page.evaluate((value) => {
+    window.__e2eFocused = value
+    document.hasFocus = () => window.__e2eFocused
+  }, focused)
+  await app.electronApp.evaluate(({ BrowserWindow }, value) => {
+    BrowserWindow.getAllWindows()[0].emit(value ? 'focus' : 'blur')
+  }, focused)
+}
+
+async function setMinimized(app, minimized) {
+  await app.electronApp.evaluate(({ BrowserWindow }, value) => {
+    BrowserWindow.getAllWindows()[0].emit(value ? 'minimize' : 'restore')
+  }, minimized)
+}
+
+function pictureInPictureActive(page) {
+  return page.evaluate(() => document.pictureInPictureElement !== null)
+}
+
+test('restores automatic Picture-in-Picture across a video reload', async ({ app, page }) => {
+  await mockPlayableWatchPage(app, page)
+  await setFocused(app, page, true)
+  await openMockedVideo(page)
+
+  await setMinimized(app, true)
+  await expect.poll(() => pictureInPictureActive(page)).toBe(true)
+
+  const watchView = await watchViewHandle(page)
+  await watchView.evaluate(view => view.reloadView())
+  await expect.poll(() => pictureInPictureActive(page)).toBe(true)
+
+  await setMinimized(app, false)
+  await expect.poll(() => pictureInPictureActive(page)).toBe(false)
+})
+
+test('restores user-opened Picture-in-Picture across a video reload', async ({ app, page }) => {
+  await mockPlayableWatchPage(app, page)
+  await setFocused(app, page, true)
+  const video = await openMockedVideo(page)
+
+  await video.evaluate(element => element.requestPictureInPicture())
+  await expect.poll(() => pictureInPictureActive(page)).toBe(true)
+
+  const watchView = await watchViewHandle(page)
+  await watchView.evaluate(view => view.reloadView())
+  await expect.poll(() => pictureInPictureActive(page)).toBe(true)
+
+  await setMinimized(app, false)
+  await page.waitForTimeout(1000)
+  expect(await pictureInPictureActive(page)).toBe(true)
+})

--- a/src/renderer/components/ft-shaka-video-player/ft-shaka-video-player.js
+++ b/src/renderer/components/ft-shaka-video-player/ft-shaka-video-player.js
@@ -394,6 +394,10 @@ export default defineComponent({
       type: Boolean,
       default: false
     },
+    autoPictureInPictureState: {
+      type: Object,
+      default: null
+    },
     startWithChapters: {
       type: Boolean,
       default: false
@@ -1217,9 +1221,11 @@ export default defineComponent({
     // #region settings
 
     const {
+      getAutoPictureInPictureState,
       initializeActiveTab,
       isActiveTab,
       notifyPictureInPictureState,
+      restorePictureInPicture,
       setupAutoPictureInPicture,
       teardownAutoPictureInPicture,
       updateAutoPip,
@@ -1229,6 +1235,7 @@ export default defineComponent({
       video,
       tabId,
       isTabPresented,
+      initialState: props.autoPictureInPictureState,
     })
 
     // Capture the replacement player's initial state. The parent clears its
@@ -5660,11 +5667,12 @@ export default defineComponent({
       if (
         startInPip &&
         props.format !== 'audio' &&
+        video.value?.readyState >= HTMLMediaElement.HAVE_METADATA &&
         ui.getControls().isPiPAllowed() &&
         process.env.IS_ELECTRON
       ) {
         startInPip = false
-        window.ftElectron.requestPiP(tabId)
+        restorePictureInPicture(props.autoPictureInPictureState?.autoPipActive === true)
       }
     }
 
@@ -10437,6 +10445,7 @@ export default defineComponent({
      *   startNextVideoInFullscreen: boolean,
      *   startNextVideoInFullwindow: boolean,
      *   startNextVideoInPip: boolean,
+     *   autoPictureInPictureState: object | null,
      *   startNextVideoWithChapters: boolean,
      *   startNextVideoWithFullscreenMetadata: boolean,
      *   startNextVideoWithFullscreenComments: boolean,
@@ -10456,6 +10465,7 @@ export default defineComponent({
         startNextVideoInFullscreen: false,
         startNextVideoInFullwindow: false,
         startNextVideoInPip: false,
+        autoPictureInPictureState: null,
         startNextVideoWithChapters: false,
         startNextVideoWithFullscreenMetadata: false,
         startNextVideoWithFullscreenComments: false,
@@ -10471,6 +10481,9 @@ export default defineComponent({
             startNextVideoInFullscreen: controls.isFullScreenEnabled(),
             startNextVideoInFullwindow: fullWindowEnabled.value,
             startNextVideoInPip: controls.isPiPEnabled(),
+            autoPictureInPictureState: controls.isPiPEnabled()
+              ? getAutoPictureInPictureState()
+              : null,
             startNextVideoWithChapters: showChaptersOverlay.value,
             startNextVideoWithFullscreenMetadata: showFullscreenMetadata.value,
             startNextVideoWithFullscreenComments: showFullscreenComments.value,

--- a/src/renderer/components/ft-shaka-video-player/ft-shaka-video-player.js
+++ b/src/renderer/components/ft-shaka-video-player/ft-shaka-video-player.js
@@ -10477,11 +10477,12 @@ export default defineComponent({
         if (ui.getControls()) {
           // save the state of player settings to reinitialize them upon next creation
           const controls = ui.getControls()
+          const isCurrentPlayerInPip = document.pictureInPictureElement === video.value
           uiState = {
             startNextVideoInFullscreen: controls.isFullScreenEnabled(),
             startNextVideoInFullwindow: fullWindowEnabled.value,
-            startNextVideoInPip: controls.isPiPEnabled(),
-            autoPictureInPictureState: controls.isPiPEnabled()
+            startNextVideoInPip: isCurrentPlayerInPip,
+            autoPictureInPictureState: isCurrentPlayerInPip
               ? getAutoPictureInPictureState()
               : null,
             startNextVideoWithChapters: showChaptersOverlay.value,

--- a/src/renderer/components/ft-shaka-video-player/opentubex/autoPictureInPictureState.js
+++ b/src/renderer/components/ft-shaka-video-player/opentubex/autoPictureInPictureState.js
@@ -22,24 +22,38 @@ export const BLUR_TRIGGER_RECHECK_DELAY_MS = 750
  */
 
 /**
- * @param {{ minimized?: boolean, focused?: boolean }} [initial]
+ * @param {{
+ *   minimized?: boolean,
+ *   focused?: boolean,
+ *   autoPipActive?: boolean,
+ *   pendingPipTarget?: boolean | null,
+ *   blurTriggerArmed?: boolean,
+ *   pictureInPictureDismissed?: boolean
+ * }} [initial]
  * @returns {AutoPictureInPictureState}
  */
-export function createAutoPictureInPictureState({ minimized = false, focused = true } = {}) {
+export function createAutoPictureInPictureState({
+  minimized = false,
+  focused = true,
+  autoPipActive = false,
+  pendingPipTarget = null,
+  blurTriggerArmed = true,
+  pictureInPictureDismissed = false
+} = {}) {
   return {
     windowMinimized: minimized,
     windowFocused: focused,
     // Whether the current PiP window was opened automatically. Only then may it
     // be closed again automatically, so a manually opened one is left alone.
-    autoPipActive: false,
+    autoPipActive,
     // Desired PiP state of a toggle that was requested but not observed yet.
-    pendingPipTarget: null,
+    pendingPipTarget,
     // A blur only counts as a trigger once the document has been focused since
     // the last restore, see `applyMinimizedState`.
-    blurTriggerArmed: true,
+    blurTriggerArmed,
     // Whether the user closed an automatically opened PiP window while its
     // trigger still applies, see `applyPictureInPictureState`.
-    pictureInPictureDismissed: false
+    pictureInPictureDismissed
   }
 }
 
@@ -107,10 +121,11 @@ export function resolveAutoPictureInPictureAction(state, { wantPip, inPip }) {
 /**
  * @param {AutoPictureInPictureState} state
  * @param {boolean} target
+ * @param {{ automatic?: boolean }} [options]
  */
-export function markPictureInPictureRequested(state, target) {
+export function markPictureInPictureRequested(state, target, { automatic = target } = {}) {
   state.pendingPipTarget = target
-  state.autoPipActive = target
+  state.autoPipActive = target && automatic
 }
 
 /**

--- a/src/renderer/components/ft-shaka-video-player/opentubex/useAutoPictureInPicture.js
+++ b/src/renderer/components/ft-shaka-video-player/opentubex/useAutoPictureInPicture.js
@@ -21,10 +21,25 @@ import {
  *   props: { format: string },
  *   video: import('vue').Ref<HTMLVideoElement | null>,
  *   tabId?: string | null,
- *   isTabPresented?: import('vue').ComputedRef<boolean> | null
+ *   isTabPresented?: import('vue').ComputedRef<boolean> | null,
+ *   initialState?: {
+ *     minimized?: boolean,
+ *     focused?: boolean,
+ *     autoPipActive?: boolean,
+ *     pendingPipTarget?: boolean | null,
+ *     blurTriggerArmed?: boolean,
+ *     pictureInPictureDismissed?: boolean
+ *   } | null
  * }} options
  */
-export function useAutoPictureInPicture({ getUi, props, video, tabId = null, isTabPresented = null }) {
+export function useAutoPictureInPicture({
+  getUi,
+  props,
+  video,
+  tabId = null,
+  isTabPresented = null,
+  initialState = null
+}) {
   const isActiveTab = computed(() => {
     return !process.env.IS_ELECTRON || isTabPresented?.value === true
   })
@@ -38,7 +53,7 @@ export function useAutoPictureInPicture({ getUi, props, video, tabId = null, isT
   // In Electron the minimized state is driven by native window events (see setup below),
   // because `document.hidden` doesn't fire on minimize on Wayland. On the web we fall back
   // to `document.hidden`, which also covers browser-tab switches.
-  const state = createAutoPictureInPictureState({
+  const state = createAutoPictureInPictureState(initialState ?? {
     minimized: process.env.IS_ELECTRON ? false : document.hidden,
     focused: document.hasFocus()
   })
@@ -177,6 +192,30 @@ export function useAutoPictureInPicture({ getUi, props, video, tabId = null, isT
     }
   }
 
+  /**
+   * Restores PiP without letting an active automatic trigger request a second
+   * toggle before Chromium reports the first one.
+   *
+   * @param {boolean} automatic
+   */
+  function restorePictureInPicture(automatic) {
+    markPictureInPictureRequested(state, true, { automatic })
+    if (!triggerPipToggle()) {
+      markPictureInPictureRequestFailed(state)
+    }
+  }
+
+  function getAutoPictureInPictureState() {
+    return {
+      minimized: state.windowMinimized,
+      focused: state.windowFocused,
+      autoPipActive: state.autoPipActive,
+      pendingPipTarget: state.pendingPipTarget,
+      blurTriggerArmed: state.blurTriggerArmed,
+      pictureInPictureDismissed: state.pictureInPictureDismissed
+    }
+  }
+
   function teardownAutoPictureInPicture() {
     if (process.env.IS_ELECTRON) {
       removeMinimizedListener?.()
@@ -196,9 +235,11 @@ export function useAutoPictureInPicture({ getUi, props, video, tabId = null, isT
   watch(autoPictureInPictureTriggers, updateAutoPip)
 
   return {
+    getAutoPictureInPictureState,
     initializeActiveTab,
     isActiveTab,
     notifyPictureInPictureState,
+    restorePictureInPicture,
     setupAutoPictureInPicture,
     teardownAutoPictureInPicture,
     updateAutoPip,

--- a/src/renderer/views/Watch/Watch.js
+++ b/src/renderer/views/Watch/Watch.js
@@ -188,6 +188,7 @@ export default defineComponent({
       startNextVideoInFullscreen: false,
       startNextVideoInFullwindow: false,
       startNextVideoInPip: false,
+      nextVideoAutoPictureInPictureState: null,
       startNextVideoWithChapters: false,
       startNextVideoWithFullscreenMetadata: false,
       startNextVideoWithFullscreenComments: false,
@@ -5768,6 +5769,7 @@ export default defineComponent({
         this.startNextVideoInFullscreen = uiState.startNextVideoInFullscreen
         this.startNextVideoInFullwindow = uiState.startNextVideoInFullwindow
         this.startNextVideoInPip = uiState.startNextVideoInPip
+        this.nextVideoAutoPictureInPictureState = uiState.autoPictureInPictureState
         this.startNextVideoWithChapters = uiState.startNextVideoWithChapters
         this.startNextVideoWithFullscreenMetadata = uiState.startNextVideoWithFullscreenMetadata
         this.startNextVideoWithFullscreenComments = uiState.startNextVideoWithFullscreenComments

--- a/src/renderer/views/Watch/Watch.vue
+++ b/src/renderer/views/Watch/Watch.vue
@@ -125,6 +125,7 @@
           :start-in-fullscreen="startNextVideoInFullscreen"
           :start-in-fullwindow="startNextVideoInFullwindow"
           :start-in-pip="startNextVideoInPip"
+          :auto-picture-in-picture-state="nextVideoAutoPictureInPictureState"
           :start-with-chapters="startNextVideoWithChapters"
           :start-with-fullscreen-metadata="startNextVideoWithFullscreenMetadata"
           :start-with-fullscreen-comments="startNextVideoWithFullscreenComments"

--- a/tests/unit/auto-picture-in-picture.test.mjs
+++ b/tests/unit/auto-picture-in-picture.test.mjs
@@ -191,6 +191,27 @@ test('PiP opened by the user is not closed on restore', () => {
   assert.deepEqual(player.toggles, [])
 })
 
+test('a restored automatic PiP request keeps its ownership while settling', () => {
+  const state = createAutoPictureInPictureState()
+
+  markPictureInPictureRequested(state, true, { automatic: true })
+  assert.equal(resolveAutoPictureInPictureAction(state, { wantPip: true, inPip: false }), 'wait')
+  applyPictureInPictureState(state, true)
+
+  assert.equal(state.autoPipActive, true)
+  assert.equal(resolveAutoPictureInPictureAction(state, { wantPip: false, inPip: true }), 'exit')
+})
+
+test('a restored manual PiP request remains user-owned', () => {
+  const state = createAutoPictureInPictureState()
+
+  markPictureInPictureRequested(state, true, { automatic: false })
+  applyPictureInPictureState(state, true)
+
+  assert.equal(state.autoPipActive, false)
+  assert.equal(resolveAutoPictureInPictureAction(state, { wantPip: false, inPip: true }), 'none')
+})
+
 test('window minimize and blur only trigger for the presented tab', () => {
   const state = createAutoPictureInPictureState({ minimized: true, focused: false })
   const options = { ...ALL_TRIGGERS, isActiveTab: false, triggerOnTabChange: false }


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Make sure to follow the contributing guidelines. -->
<!-- Important note, we may remove your pull request if you do not use this provided PR template correctly. -->
<!-- Agent instructions: Preserve every heading, comment, and marker in this template. Never remove or rewrite the release-note-category:start/end, release-note:start/end, or release-note-image:start/end marker pairs. -->

## Pull Request Type
<!-- Please select what type of pull request this is: [x] -->
- [x] Bugfix
- [ ] Feature Implementation
- [ ] Documentation
- [ ] Other

## Related issue
<!-- Please link the issue your pull request is referring to. -->
<!-- If this pull request fully resolves the relevant issue, put "closes" before the issue number. -->
<!-- Example: "closes #123456". -->

No linked issue. This fixes a directly reported Picture-in-Picture reload bug.

## Description
<!-- Please write a clear and concise description of what the pull request does. -->

Reloading a video replaced its media element while Picture-in-Picture was active. The replacement attempted to restore PiP before media metadata was ready, and automatic PiP lost its ownership and window-trigger state during the handoff.

The player now waits for media metadata before restoring PiP and transfers the automatic PiP state to the replacement. User-opened PiP remains open after reload, while automatically opened PiP still closes when its trigger ends.

## Release note category
<!-- Select exactly one category. Every pull request must select one. -->
<!-- Select "Not noteworthy" when the pull request fixes a bug in or improves functionality that has not yet appeared in a stable release. -->
<!-- release-note-category:start -->
- [ ] Not noteworthy
- [ ] Highlights
- [ ] More improvements
- [x] Fixed bugs
<!-- release-note-category:end -->

## Release note
<!-- Required unless "Not noteworthy" is selected. -->
<!-- Write one concise, user-facing entry without a leading bullet. -->
<!-- release-note:start -->

Restored Picture-in-Picture after the video player reloads.

<!-- release-note:end -->

## Release note images
<!-- Optional. Paste one or more Markdown images, HTML image tags, or dark/light <picture> elements here. -->
<!-- The release notes normalize the markup and limit images taller than 300 pixels. -->
<!-- Agent instructions:
For a noteworthy visible change, add media when it makes the change easier to understand. Prefer a still image unless motion is the point; recordings must use animated WebP.
After implementing a visible change, proactively capture the result and show the local media to the user for approval before uploading it or updating the pull request.
When the affected UI differs between dark and light themes, capturing both themes is required. A dark-only image is incomplete. Run `node _scripts/releaseNoteMedia.mjs --dark DARK_FILE --light LIGHT_FILE --alt "DESCRIPTION"`; GitHub will display the matching theme and use dark as the fallback. Use a single default-dark capture only when the light theme cannot be captured or looks identical.
Capture or crop to the smallest region that still makes the change clear. Do not include the full window when the affected component can be understood on its own.
Use English unless localization is the subject. Keep components at their normal dimensions and placement instead of resizing them to fill the frame.
Use deterministic local fixtures for visible remote images. Reusable avatar and thumbnail fixtures are available through `e2e/helpers/visual-fixtures.mjs`. Before capturing, verify that every visible image has loaded successfully (`complete === true` and `naturalWidth > 0`).
Inspect the final dark and light files for failed images, missing content, unrelated UI, awkward animation, and misleading layout. Omit media when it does not explain the change clearly.
For one dark capture, run `node _scripts/releaseNoteMedia.mjs FILE --alt "DESCRIPTION"`.
Check for personal information, tokens, private repository names, and unrelated desktop content before uploading. Uploaded media is public.
Keep capture-only scripts, test hooks, screenshots, and recordings out of commits. Remove them before committing unless the capture code is also a reusable regression test. Never commit generated release-note media.
Paste only the generated markup between the marker comments. Leave this section empty when media would not help.
-->
<!-- release-note-image:start -->

<!-- release-note-image:end -->

## Testing
<!-- How can reviewers verify that the PR produces correct results? -->
<!-- Please provide instructions so that others can ensure that your pull request would produce correct results. For examples see, https://github.com/FreeTubeApp/FreeTube/pull/5743, https://github.com/FreeTubeApp/FreeTube/pull/7349, https://github.com/FreeTubeApp/FreeTube/pull/5125, https://github.com/FreeTubeApp/FreeTube/pull/7338 -->
<!-- Agent instructions: Only write human-facing steps that explain how to verify the change while running this branch in dev mode. Include expected results and, when applicable, helpful console snippets for interactive verification. Do not include automated checks, commands, results, pass counts, or CI status. -->

1. Play a video, enter Picture-in-Picture, and trigger a player reload. The replacement video should return to Picture-in-Picture.
2. Enable automatic Picture-in-Picture when minimizing the window, minimize the app, and trigger a player reload. Picture-in-Picture should remain active through the reload and close after restoring the app.
3. Open Picture-in-Picture manually and restore the app window. The manually opened Picture-in-Picture window should remain open.

## Additional context
<!-- Add any other context about the pull request here. -->

The regression tests use local media fixtures and Chromium's native Picture-in-Picture API.
