### PR TITLE
fix(e2e): stabilize regression tests

### DIFF
--- a/e2e/tests/network/sync-server.spec.mjs
+++ b/e2e/tests/network/sync-server.spec.mjs
@@ -108,7 +108,7 @@ test.describe('OpenTubeX sync server', () => {
     }
   })
 
-  test('pushes local data from multiple profiles and pulls remote changes', async ({ app, page }) => {
+  test('pushes local data from multiple profiles and pulls remote changes', async ({ app, page }, testInfo) => {
     const username = `opentubex-${Date.now()}-${Math.random().toString(16).slice(2)}`
     const capabilities = await getSyncCapabilities()
     const enhancedPrivacy = capabilities.encrypted_sync === 1
@@ -448,7 +448,10 @@ test.describe('OpenTubeX sync server', () => {
 
     const deletedAccountLoginResponse = await fetch(`${syncServerUrl}${apiPrefix}/account/login`, {
       method: 'POST',
-      headers: { 'Content-Type': 'application/json' },
+      headers: {
+        'Content-Type': 'application/json',
+        'X-Forwarded-For': rateLimitClient(testInfo)
+      },
       body: JSON.stringify({ name: username, password: accountPassword })
     })
     expect(deletedAccountLoginResponse.ok).toBe(false)
@@ -458,7 +461,7 @@ test.describe('OpenTubeX sync server', () => {
     expect(await readFile(path.join(app.userDataDir, 'history.db'), 'utf8')).toContain('dQw4w9WgXcQ')
   })
 
-  test('disconnects after revoking the current account session', async ({ page }) => {
+  test('disconnects after revoking the current account session', async ({ page }, testInfo) => {
     const capabilities = await getSyncCapabilities()
     test.skip(
       capabilities.encrypted_sync !== 1 || capabilities.account_sessions !== 1,
@@ -484,7 +487,10 @@ test.describe('OpenTubeX sync server', () => {
 
     const loginResponse = await fetch(`${syncServerUrl}/v1/account/login`, {
       method: 'POST',
-      headers: { 'Content-Type': 'application/json' },
+      headers: {
+        'Content-Type': 'application/json',
+        'X-Forwarded-For': rateLimitClient(testInfo)
+      },
       body: JSON.stringify({ name: username, password })
     })
     expect(loginResponse.ok).toBe(true)
@@ -493,7 +499,8 @@ test.describe('OpenTubeX sync server', () => {
       method: 'DELETE',
       headers: {
         Authorization: jwt,
-        'Content-Type': 'application/json'
+        'Content-Type': 'application/json',
+        'X-Forwarded-For': rateLimitClient(testInfo)
       },
       body: JSON.stringify({ password })
     })
@@ -690,7 +697,7 @@ test.describe('OpenTubeX sync server', () => {
     expect(plaintextResponse.status).toBe(409)
   })
 
-  test('uses advertised history optimizations without rewriting unchanged local data', async ({ app, page }) => {
+  test('uses advertised history optimizations without rewriting unchanged local data', async ({ app, page }, testInfo) => {
     const username = `opentubex-fast-${Date.now()}-${Math.random().toString(16).slice(2)}`
     const bulkRequests = []
     const historyPageSizes = []
@@ -746,14 +753,15 @@ test.describe('OpenTubeX sync server', () => {
       method: 'DELETE',
       headers: {
         Authorization: settings.syncServerToken,
-        'Content-Type': 'application/json'
+        'Content-Type': 'application/json',
+        'X-Forwarded-For': rateLimitClient(testInfo)
       },
       body: JSON.stringify({ password: 'local-test-password' })
     })
     expect(cleanupResponse.ok).toBe(true)
   })
 
-  test('requires confirmation before an empty remote deletes local data', async ({ app, page }) => {
+  test('requires confirmation before an empty remote deletes local data', async ({ app, page }, testInfo) => {
     const username = `opentubex-reset-guard-${Date.now()}-${Math.random().toString(16).slice(2)}`
 
     await page.route('**/health', route => route.fulfill({
@@ -813,7 +821,8 @@ test.describe('OpenTubeX sync server', () => {
       method: 'DELETE',
       headers: {
         Authorization: settings.syncServerToken,
-        'Content-Type': 'application/json'
+        'Content-Type': 'application/json',
+        'X-Forwarded-For': rateLimitClient(testInfo)
       },
       body: JSON.stringify({ password: 'local-test-password' })
     })

--- a/e2e/tests/offline/line-delimited-imports.spec.mjs
+++ b/e2e/tests/offline/line-delimited-imports.spec.mjs
@@ -194,8 +194,8 @@ test('line-delimited search history keeps valid rows around a malformed row', as
   await expect.poll(() => page.evaluate(() => {
     const store = document.querySelector('#app').__vue_app__.config.globalProperties.$store
     return store.getters.getSearchHistoryEntries
-      .map(({ _id }) => _id)
-      .filter(id => id.startsWith('issue866-search-'))
+      .map(({ query }) => query)
+      .filter(query => query.startsWith('issue866-search-'))
       .sort()
   })).toEqual(['issue866-search-a', 'issue866-search-b'])
   expect(pageErrors).toEqual([])

--- a/e2e/tests/offline/search-history.spec.mjs
+++ b/e2e/tests/offline/search-history.spec.mjs
@@ -314,7 +314,10 @@ test.describe('search history suggestions', () => {
           type: 'all',
           duration: '',
           features: ['4k', 'hd']
-        }
+        },
+        nextPageRef: null,
+        hasMoreResults: false,
+        apiUsed: 'local'
       })
       store.commit('setSearchFeatures', { tabId, value: ['hd', '4k'] })
     })


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Make sure to follow the contributing guidelines. -->
<!-- Important note, we may remove your pull request if you do not use this provided PR template correctly. -->
<!-- Agent instructions: Preserve every heading, comment, and marker in this template. Never remove or rewrite the release-note-category:start/end, release-note:start/end, or release-note-image:start/end marker pairs. -->

## Pull Request Type
<!-- Please select what type of pull request this is: [x] -->
- [x] Bugfix
- [ ] Feature Implementation
- [ ] Documentation
- [ ] Other

## Related issue
<!-- Please link the issue your pull request is referring to. -->
<!-- If this pull request fully resolves the relevant issue, put "closes" before the issue number. -->
<!-- Example: "closes #123456". -->

[Scheduled E2E failure](https://github.com/OpenTubeX/OpenTubeX/actions/runs/33606390817)

## Description
<!-- Please write a clear and concise description of what the pull request does. -->

Recent application changes left three E2E assumptions stale and caused the scheduled suite to fail. This updates the affected fixtures and assertions to match current behavior, and isolates direct sync-server account requests into per-test rate-limit buckets so earlier tests cannot exhaust a shared runner-IP limit.

## Release note category
<!-- Select exactly one category. Every pull request must select one. -->
<!-- Select "Not noteworthy" when the pull request fixes a bug in or improves functionality that has not yet appeared in a stable release. -->
<!-- release-note-category:start -->
- [x] Not noteworthy
- [ ] Highlights
- [ ] More improvements
- [ ] Fixed bugs
<!-- release-note-category:end -->

## Release note
<!-- Required unless "Not noteworthy" is selected. -->
<!-- Write one concise, user-facing entry without a leading bullet. -->
<!-- release-note:start -->

<!-- release-note:end -->

## Release note images
<!-- Optional. Paste one or more Markdown images, HTML image tags, or dark/light <picture> elements here. -->
<!-- The release notes normalize the markup and limit images taller than 300 pixels. -->
<!-- Agent instructions:
For a noteworthy visible change, add media when it makes the change easier to understand. Prefer a still image unless motion is the point; recordings must use animated WebP.
After implementing a visible change, proactively capture the result and show the local media to the user for approval before uploading it or updating the pull request.
When the affected UI differs between dark and light themes, capturing both themes is required. A dark-only image is incomplete. Run `node _scripts/releaseNoteMedia.mjs --dark DARK_FILE --light LIGHT_FILE --alt "DESCRIPTION"`; GitHub will display the matching theme and use dark as the fallback. Use a single default-dark capture only when the light theme cannot be captured or looks identical.
Capture or crop to the smallest region that still makes the change clear. Do not include the full window when the affected component can be understood on its own.
Use English unless localization is the subject. Keep components at their normal dimensions and placement instead of resizing them to fill the frame.
Use deterministic local fixtures for visible remote images. Reusable avatar and thumbnail fixtures are available through `e2e/helpers/visual-fixtures.mjs`. Before capturing, verify that every visible image has loaded successfully (`complete === true` and `naturalWidth > 0`).
Inspect the final dark and light files for failed images, missing content, unrelated UI, awkward animation, and misleading layout. Omit media when it does not explain the change clearly.
For one dark capture, run `node _scripts/releaseNoteMedia.mjs FILE --alt "DESCRIPTION"`.
Check for personal information, tokens, private repository names, and unrelated desktop content before uploading. Uploaded media is public.
Keep capture-only scripts, test hooks, screenshots, and recordings out of commits. Remove them before committing unless the capture code is also a reusable regression test. Never commit generated release-note media.
Paste only the generated markup between the marker comments. Leave this section empty when media would not help.
-->
<!-- release-note-image:start -->

<!-- release-note-image:end -->

## Testing
<!-- How can reviewers verify that the PR produces correct results? -->
<!-- Please provide instructions so that others can ensure that your pull request would produce correct results. For examples see, https://github.com/FreeTubeApp/FreeTube/pull/5743, https://github.com/FreeTubeApp/FreeTube/pull/7349, https://github.com/FreeTubeApp/FreeTube/pull/5125, https://github.com/FreeTubeApp/FreeTube/pull/7338 -->
<!-- Agent instructions: Only write human-facing steps that explain how to verify the change while running this branch in dev mode. Include expected results and, when applicable, helpful console snippets for interactive verification. Do not include automated checks, commands, results, pass counts, or CI status. -->

1. Import line-delimited search history with a malformed row between two valid rows. Both valid queries should remain in search history.
2. Open a search whose cached response is marked complete. Its cached result should remain visible without a follow-up page replacing it with a loader.
3. Exercise account registration, session revocation, account deletion, and the sync cleanup flows against the local sync server. Requests from one flow should not cause later flows to be rate-limited.

## Additional context
<!-- Add any other context about the pull request here. -->

The failures were introduced by current development-branch behavior: canonical search-history IDs, stricter cached-search pagination behavior, and cumulative account endpoint rate limiting in the shared CI job.
