### PR TITLE
feat: polish sync devices and add promo generator

### DIFF
--- a/_scripts/releaseNotePromo.mjs
+++ b/_scripts/releaseNotePromo.mjs
@@ -1,0 +1,468 @@
+import { spawnSync } from 'node:child_process'
+import fs from 'node:fs'
+import os from 'node:os'
+import path from 'node:path'
+import process from 'node:process'
+import { createRequire } from 'node:module'
+import { parseArgs } from 'node:util'
+import { fileURLToPath } from 'node:url'
+
+import { _electron as electron } from '@playwright/test'
+
+const WIDTH = 1600
+const HEIGHT = 900
+const here = path.dirname(fileURLToPath(import.meta.url))
+const require = createRequire(import.meta.url)
+const projectRoot = path.resolve(here, '..')
+const electronEntry = path.join(here, 'releaseNotePromoElectron.mjs')
+const appIconPath = path.join(projectRoot, '_scripts/brand/icon-master.svg')
+const fontPath = path.join(projectRoot, 'src/renderer/assets/font/Roboto-Regular.ttf')
+const MIME_TYPES = new Map([
+  ['.jpeg', 'image/jpeg'],
+  ['.jpg', 'image/jpeg'],
+  ['.png', 'image/png'],
+  ['.svg', 'image/svg+xml'],
+  ['.ttf', 'font/ttf'],
+  ['.webp', 'image/webp'],
+])
+
+function usage() {
+  return `Usage:
+  node _scripts/releaseNotePromo.mjs \\
+    --screenshot SCREENSHOT \\
+    --title "TITLE" \\
+    --description "DESCRIPTION" \\
+    --output OUTPUT.png \\
+    [--accent "#8b7cff"] \\
+    (--icon MATERIAL_SYMBOL | --motif IMAGE)
+
+The icon can be a Material Symbols name such as "devices-rounded".
+On Linux the command automatically renders inside a private X server.`
+}
+
+function fail(message) {
+  throw new Error(`${message}\n\n${usage()}`)
+}
+
+function readOptions(args) {
+  let parsed
+
+  try {
+    parsed = parseArgs({
+      allowPositionals: false,
+      args,
+      options: {
+        accent: { type: 'string', default: '#8b7cff' },
+        description: { type: 'string' },
+        help: { type: 'boolean', short: 'h' },
+        icon: { type: 'string' },
+        motif: { type: 'string' },
+        output: { type: 'string' },
+        screenshot: { type: 'string' },
+        title: { type: 'string' },
+      },
+      strict: true,
+    })
+  } catch (error) {
+    fail(error.message)
+  }
+
+  const { values } = parsed
+  if (values.help) return { help: true }
+
+  for (const name of ['description', 'output', 'screenshot', 'title']) {
+    if (!values[name]?.trim()) fail(`--${name} is required.`)
+  }
+
+  if (!/^#[\dA-Fa-f]{6}$/.test(values.accent)) {
+    fail('--accent must be a six-digit hex color such as #8b7cff.')
+  }
+
+  if (path.extname(values.output).toLowerCase() !== '.png') {
+    fail('--output must end in .png.')
+  }
+
+  if (Boolean(values.icon) === Boolean(values.motif)) {
+    fail('Provide either --icon or --motif, but not both.')
+  }
+
+  return {
+    accent: values.accent,
+    description: values.description.trim(),
+    icon: values.icon?.trim(),
+    motif: values.motif,
+    output: path.resolve(values.output),
+    screenshot: path.resolve(values.screenshot),
+    title: values.title.trim(),
+  }
+}
+
+export function materialSymbolMotifDataUrl(iconName, accent) {
+  const collectionPath = require.resolve('@iconify-json/material-symbols/icons.json')
+  const collection = JSON.parse(fs.readFileSync(collectionPath, 'utf8'))
+  const normalizedName = iconName.replace(/^material-symbols:/, '')
+  const fallbackName = normalizedName.endsWith('-rounded') ? normalizedName : `${normalizedName}-rounded`
+  const icon = collection.icons[normalizedName] ?? collection.icons[fallbackName]
+
+  if (!icon) {
+    fail(`Unknown Material Symbols icon: ${iconName}`)
+  }
+
+  const width = icon.width ?? collection.width ?? 24
+  const height = icon.height ?? collection.height ?? 24
+  const iconScale = 132 / Math.max(width, height)
+  const iconX = (256 - (width * iconScale)) / 2
+  const iconY = (246 - (height * iconScale)) / 2
+  const svg = `<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 256 256">
+  <defs>
+    <linearGradient id="shield" x1="38" y1="24" x2="216" y2="230" gradientUnits="userSpaceOnUse">
+      <stop stop-color="${accent}" stop-opacity=".55"/>
+      <stop offset="1" stop-color="#172363" stop-opacity=".82"/>
+    </linearGradient>
+    <linearGradient id="stroke" x1="46" y1="30" x2="208" y2="225" gradientUnits="userSpaceOnUse">
+      <stop stop-color="#c9c1ff"/>
+      <stop offset=".45" stop-color="${accent}"/>
+      <stop offset="1" stop-color="#4f6de8"/>
+    </linearGradient>
+    <filter id="glow" x="-50%" y="-50%" width="200%" height="200%">
+      <feGaussianBlur stdDeviation="8" result="blur"/>
+      <feMerge><feMergeNode in="blur"/><feMergeNode in="SourceGraphic"/></feMerge>
+    </filter>
+  </defs>
+  <path d="M128 14 218 50v65c0 59-34 103-90 128-56-25-90-69-90-128V50z" fill="url(#shield)" stroke="url(#stroke)" stroke-width="6" filter="url(#glow)"/>
+  <g color="#eeeaff" transform="translate(${iconX} ${iconY}) scale(${iconScale})">${icon.body}</g>
+</svg>`
+
+  return `data:image/svg+xml;base64,${Buffer.from(svg).toString('base64')}`
+}
+
+function escapeHtml(value) {
+  return value
+    .replaceAll('&', '&amp;')
+    .replaceAll('<', '&lt;')
+    .replaceAll('>', '&gt;')
+    .replaceAll('"', '&quot;')
+}
+
+function fileDataUrl(filePath, allowedMimeTypes) {
+  const resolvedPath = path.resolve(filePath)
+  if (!fs.statSync(resolvedPath, { throwIfNoEntry: false })?.isFile()) {
+    fail(`File not found: ${resolvedPath}`)
+  }
+
+  const mimeType = MIME_TYPES.get(path.extname(resolvedPath).toLowerCase())
+  if (!mimeType || !allowedMimeTypes.has(mimeType)) {
+    fail(`Unsupported image type: ${resolvedPath}`)
+  }
+
+  return `data:${mimeType};base64,${fs.readFileSync(resolvedPath).toString('base64')}`
+}
+
+export function renderPromoHtml({
+  accent,
+  description,
+  fontDataUrl,
+  iconDataUrl,
+  motifDataUrl,
+  screenshotDataUrl,
+  title,
+}) {
+  const safeAccent = escapeHtml(accent)
+  const safeDescription = escapeHtml(description)
+  const safeTitle = escapeHtml(title)
+
+  return `<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8">
+    <meta name="viewport" content="width=${WIDTH}, initial-scale=1">
+    <style>
+      @font-face {
+        font-family: "OpenTubeX Promo";
+        font-style: normal;
+        font-weight: 100 900;
+        src: url("${fontDataUrl}") format("truetype");
+      }
+
+      :root {
+        color-scheme: dark;
+        --accent: ${safeAccent};
+        --background: #060713;
+        --panel: #0c0d15;
+        --text: #f7f7fa;
+        --muted: #a7a7b3;
+      }
+
+      * {
+        box-sizing: border-box;
+      }
+
+      html,
+      body {
+        height: ${HEIGHT}px;
+        margin: 0;
+        overflow: hidden;
+        width: ${WIDTH}px;
+      }
+
+      body {
+        background:
+          radial-gradient(circle at 48% 30%, color-mix(in srgb, var(--accent) 18%, transparent), transparent 31%),
+          radial-gradient(circle at 83% 86%, rgb(34 64 150 / 16%), transparent 35%),
+          linear-gradient(132deg, #05060d 0%, var(--background) 54%, #050713 100%);
+        color: var(--text);
+        font-family: "OpenTubeX Promo", system-ui, sans-serif;
+      }
+
+      .promo {
+        display: grid;
+        gap: 42px;
+        grid-template-columns: minmax(0, 41fr) minmax(0, 59fr);
+        height: 100%;
+        padding-block: 40px;
+        padding-inline: 36px;
+        position: relative;
+      }
+
+      .copy {
+        display: flex;
+        flex-direction: column;
+        min-width: 0;
+        position: relative;
+        z-index: 2;
+      }
+
+      .brand {
+        background: linear-gradient(150deg, #212229, #07080d);
+        border: 1px solid rgb(255 255 255 / 20%);
+        border-radius: 30px;
+        box-shadow: 0 14px 40px rgb(0 0 0 / 28%);
+        height: 126px;
+        object-fit: contain;
+        padding: 7px;
+        width: 126px;
+      }
+
+      .message {
+        margin-block-start: 70px;
+        max-width: 610px;
+      }
+
+      h1 {
+        font-size: 68px;
+        font-weight: 800;
+        letter-spacing: -2.4px;
+        line-height: 1.04;
+        margin: 0;
+        text-wrap: balance;
+      }
+
+      .description {
+        color: var(--muted);
+        font-size: 29px;
+        line-height: 1.42;
+        margin-block: 34px 0;
+        max-width: 565px;
+      }
+
+      .orbit {
+        bottom: 16px;
+        height: 245px;
+        left: 10px;
+        opacity: 0.9;
+        position: absolute;
+        width: 520px;
+      }
+
+      .orbit::before,
+      .orbit::after {
+        border: 3px solid color-mix(in srgb, var(--accent) 58%, transparent);
+        border-radius: 50%;
+        content: "";
+        filter: drop-shadow(0 0 12px color-mix(in srgb, var(--accent) 54%, transparent));
+        inset: 70px 10px;
+        position: absolute;
+        transform: rotate(-18deg);
+      }
+
+      .orbit::after {
+        border-color: rgb(48 87 231 / 48%);
+        inset: 82px 42px;
+        transform: rotate(-10deg);
+      }
+
+      .motif {
+        filter: drop-shadow(0 0 22px color-mix(in srgb, var(--accent) 42%, transparent));
+        height: 218px;
+        inset-block-start: -6px;
+        inset-inline-start: 150px;
+        object-fit: contain;
+        position: absolute;
+        width: 218px;
+        z-index: 1;
+      }
+
+      .visual {
+        align-items: center;
+        display: flex;
+        justify-content: center;
+        min-width: 0;
+        position: relative;
+        z-index: 2;
+      }
+
+      .screenshot-frame {
+        background:
+          linear-gradient(var(--panel), var(--panel)) padding-box,
+          linear-gradient(135deg, color-mix(in srgb, var(--accent) 46%, #626477), rgb(255 255 255 / 10%)) border-box;
+        border: 1px solid transparent;
+        border-radius: 28px;
+        box-shadow:
+          0 32px 90px rgb(0 0 0 / 48%),
+          0 0 52px color-mix(in srgb, var(--accent) 11%, transparent);
+        max-width: 100%;
+        padding: 18px;
+        position: relative;
+        width: 100%;
+      }
+
+      .screenshot-frame::before {
+        background: linear-gradient(90deg, var(--accent), #4f6de8);
+        border-radius: 999px;
+        content: "";
+        height: 3px;
+        inset-block-start: 0;
+        inset-inline: 48px;
+        opacity: 0.6;
+        position: absolute;
+      }
+
+      .screenshot {
+        border: 1px solid rgb(255 255 255 / 12%);
+        border-radius: 18px;
+        display: block;
+        height: auto;
+        max-height: 790px;
+        object-fit: contain;
+        width: 100%;
+      }
+    </style>
+  </head>
+  <body>
+    <main class="promo">
+      <section class="copy">
+        <img class="brand" alt="" src="${iconDataUrl}">
+        <div class="message">
+          <h1>${safeTitle}</h1>
+          <p class="description">${safeDescription}</p>
+        </div>
+        <div class="orbit" aria-hidden="true">
+          <img class="motif" alt="" src="${motifDataUrl}">
+        </div>
+      </section>
+      <section class="visual">
+        <div class="screenshot-frame">
+          <img class="screenshot" alt="" src="${screenshotDataUrl}">
+        </div>
+      </section>
+    </main>
+  </body>
+</html>`
+}
+
+function runInPrivateX(args) {
+  if (process.platform !== 'linux' || process.env.OPENTUBEX_RELEASE_PROMO_PRIVATE_X === '1') {
+    return false
+  }
+
+  const result = spawnSync('xvfb-run', [
+    '-a',
+    '-s', `-screen 0 ${WIDTH}x${HEIGHT}x24`,
+    process.execPath,
+    fileURLToPath(import.meta.url),
+    ...args,
+  ], {
+    env: {
+      ...process.env,
+      OPENTUBEX_RELEASE_PROMO_PRIVATE_X: '1',
+    },
+    stdio: 'inherit',
+  })
+
+  if (result.error) {
+    throw new Error(`Could not start the private X server: ${result.error.message}`)
+  }
+
+  process.exitCode = result.status ?? 1
+  return true
+}
+
+async function main() {
+  const args = process.argv.slice(2)
+  const options = readOptions(args)
+  if (options.help) {
+    console.log(usage())
+    return
+  }
+  if (runInPrivateX(args)) return
+
+  const screenshotDataUrl = fileDataUrl(options.screenshot, new Set([
+    'image/jpeg',
+    'image/png',
+    'image/webp',
+  ]))
+  const iconDataUrl = fileDataUrl(appIconPath, new Set(['image/svg+xml']))
+  const fontDataUrl = fileDataUrl(fontPath, new Set(['font/ttf']))
+  const motifDataUrl = options.motif
+    ? fileDataUrl(options.motif, new Set(['image/jpeg', 'image/png', 'image/svg+xml', 'image/webp']))
+    : materialSymbolMotifDataUrl(options.icon, options.accent)
+  const html = renderPromoHtml({
+    accent: options.accent,
+    description: options.description,
+    fontDataUrl,
+    iconDataUrl,
+    motifDataUrl,
+    screenshotDataUrl,
+    title: options.title,
+  })
+  const tempDirectory = fs.mkdtempSync(path.join(os.tmpdir(), 'opentubex-release-promo-'))
+  const htmlPath = path.join(tempDirectory, 'promo.html')
+  fs.writeFileSync(htmlPath, html)
+  fs.mkdirSync(path.dirname(options.output), { recursive: true })
+
+  let electronApp
+  try {
+    electronApp = await electron.launch({
+      args: [electronEntry],
+      env: {
+        ...process.env,
+        OPENTUBEX_RELEASE_PROMO_HTML: htmlPath,
+      },
+      timeout: 30_000,
+    })
+    const page = await electronApp.firstWindow({ timeout: 30_000 })
+    await page.waitForFunction(() => (
+      document.fonts.status === 'loaded' &&
+      [...document.images].every(image => image.complete && image.naturalWidth > 0)
+    ), undefined, { timeout: 30_000 })
+    await page.screenshot({
+      animations: 'disabled',
+      path: options.output,
+      type: 'png',
+    })
+  } finally {
+    await electronApp?.close()
+    fs.rmSync(tempDirectory, { force: true, recursive: true })
+  }
+
+  console.log(`Wrote ${options.output}`)
+}
+
+const isMainModule = process.argv[1] && path.resolve(process.argv[1]) === fileURLToPath(import.meta.url)
+
+if (isMainModule) {
+  main().catch((error) => {
+    console.error(error.message)
+    process.exitCode = 1
+  })
+}

--- a/_scripts/releaseNotePromo.mjs
+++ b/_scripts/releaseNotePromo.mjs
@@ -426,12 +426,12 @@ async function main() {
     title: options.title,
   })
   const tempDirectory = fs.mkdtempSync(path.join(os.tmpdir(), 'opentubex-release-promo-'))
-  const htmlPath = path.join(tempDirectory, 'promo.html')
-  fs.writeFileSync(htmlPath, html)
-  fs.mkdirSync(path.dirname(options.output), { recursive: true })
-
   let electronApp
   try {
+    const htmlPath = path.join(tempDirectory, 'promo.html')
+    fs.writeFileSync(htmlPath, html)
+    fs.mkdirSync(path.dirname(options.output), { recursive: true })
+
     electronApp = await electron.launch({
       args: [electronEntry],
       env: {

--- a/_scripts/releaseNotePromoElectron.mjs
+++ b/_scripts/releaseNotePromoElectron.mjs
@@ -1,0 +1,35 @@
+import { app, BrowserWindow } from 'electron'
+
+const htmlPath = process.env.OPENTUBEX_RELEASE_PROMO_HTML
+
+if (!htmlPath) {
+  throw new Error('OPENTUBEX_RELEASE_PROMO_HTML is required.')
+}
+
+app.commandLine.appendSwitch('disable-gpu')
+app.commandLine.appendSwitch('force-color-profile', 'srgb')
+app.commandLine.appendSwitch('force-device-scale-factor', '1')
+
+let mainWindow
+
+app.whenReady().then(async () => {
+  mainWindow = new BrowserWindow({
+    width: 1600,
+    height: 900,
+    useContentSize: true,
+    show: false,
+    frame: false,
+    resizable: false,
+    backgroundColor: '#060713',
+    webPreferences: {
+      sandbox: true,
+    },
+  })
+
+  await mainWindow.loadFile(htmlPath)
+}).catch((error) => {
+  console.error(error)
+  app.exit(1)
+})
+
+app.on('window-all-closed', () => app.quit())

--- a/e2e/tests/network/sync-server.spec.mjs
+++ b/e2e/tests/network/sync-server.spec.mjs
@@ -254,6 +254,9 @@ test.describe('OpenTubeX sync server', () => {
       const currentCard = devices.locator('.sessionCard', { hasText: 'Current device' })
       await expect(currentCard).toBeVisible()
       await expect(currentCard.getByRole('heading')).not.toHaveText('Unknown device')
+      const lastActiveTime = currentCard.locator('.sessionDetails > div', { hasText: 'Last active' }).locator('time')
+      await expect(lastActiveTime).toHaveText(/ago|Moments ago/)
+      await expect(lastActiveTime).toHaveAttribute('title', /\b20\d{2}\b/)
       const deviceInfo = await page.evaluate(() => window.ftElectron.getDeviceInfo())
       await expect(currentCard).toContainText(
         `${deviceInfo.platform}${deviceInfo.release ? ` ${deviceInfo.release}` : ''}`
@@ -335,7 +338,7 @@ test.describe('OpenTubeX sync server', () => {
       await devices.getByRole('button', { name: 'Refresh devices' }).click()
       await staleSessionRequestRequested
       try {
-        await syncSection.getByRole('button', { name: 'Change password' }).click()
+        await devices.getByRole('button', { name: 'Change password' }).click()
         const passwordPrompt = page.getByRole('dialog', { name: 'Change password' })
         await passwordPrompt.getByLabel('Current password').fill(accountPassword)
         await passwordPrompt.getByLabel('New password', { exact: true }).fill('new-local-test-password')

--- a/package.json
+++ b/package.json
@@ -34,6 +34,7 @@
     "get-instances": "node _scripts/getInstances.js",
     "get-regions": "node _scripts/getRegions.mjs",
     "generate-iconify-bundle": "node _scripts/generateIconifyBundle.mjs",
+    "release-note-promo": "node _scripts/releaseNotePromo.mjs",
     "lint-all": "pnpm run \"/^(lint|lint-json)$/\"",
     "lint": "pnpm run \"/^(eslint-lint|lint-style)$/\"",
     "lint-fix": "pnpm run \"/^(eslint-lint|lint-style)-fix$/\"",

--- a/src/renderer/components/SyncSettings/SyncAccountManagement.css
+++ b/src/renderer/components/SyncSettings/SyncAccountManagement.css
@@ -1,7 +1,13 @@
 .accountManagement {
-  border-block-start: 1px solid var(--side-nav-color);
+  background-color: var(--secondary-card-bg-color);
+  border: 1px solid var(--divider-color);
+  border-radius: calc(12px * var(--ui-roundness));
+  box-shadow: 0 8px 24px rgb(0 0 0 / 14%);
+  box-sizing: border-box;
   margin-block-start: 1.25rem;
-  padding-block-start: 1rem;
+  margin-inline: auto;
+  max-inline-size: 64rem;
+  padding: 1.25rem;
 }
 
 .managementHeader {
@@ -12,6 +18,31 @@
   margin-block-end: 1rem;
 }
 
+.managementTitle {
+  align-items: center;
+  display: flex;
+  gap: 0.875rem;
+  min-inline-size: 0;
+}
+
+.managementIcon,
+.sessionDeviceIcon,
+.passwordActionIcon {
+  align-items: center;
+  background-color: color-mix(in srgb, var(--primary-color) 14%, transparent);
+  color: var(--primary-color);
+  display: inline-flex;
+  flex-shrink: 0;
+  justify-content: center;
+}
+
+.managementIcon {
+  block-size: 2.75rem;
+  border-radius: calc(10px * var(--ui-roundness));
+  font-size: 1.35rem;
+  inline-size: 2.75rem;
+}
+
 .managementHeader h3,
 .managementHeader p,
 .sessionSummary h4,
@@ -19,9 +50,30 @@
   margin: 0;
 }
 
+.managementHeader h3 {
+  font-size: 1.25rem;
+}
+
 .managementHeader p {
   color: var(--secondary-text-color);
-  margin-block-start: 0.25rem;
+  line-height: 1.4;
+  margin-block-start: 0.2rem;
+}
+
+.managementAction :deep(.iconButton),
+.sessionAction :deep(.iconButton) {
+  background-color: color-mix(in srgb, var(--card-bg-color) 82%, var(--primary-text-color));
+  border: 1px solid var(--divider-color);
+  border-radius: calc(9px * var(--ui-roundness));
+  box-sizing: border-box;
+  min-block-size: 44px;
+  min-inline-size: 44px;
+}
+
+.managementAction :deep(.iconButton:not(.disabled):is(:hover, :focus-visible, :active)),
+.sessionAction :deep(.iconButton:not(.disabled):is(:hover, :focus-visible, :active)) {
+  background-color: var(--side-nav-hover-color);
+  color: var(--side-nav-hover-text-color);
 }
 
 .sessionActions,
@@ -30,63 +82,167 @@
 }
 
 .sessionActions {
+  display: flex;
   flex-shrink: 0;
+  gap: 0.5rem;
 }
 
 .sessionList {
   display: grid;
   gap: 0.75rem;
-  grid-template-columns: repeat(auto-fit, minmax(min(22rem, 100%), 1fr));
   list-style: none;
   margin: 0;
   padding: 0;
 }
 
 .sessionCard {
-  background-color: var(--side-nav-color);
-  border-radius: calc(0.5rem * var(--ui-roundness));
+  align-items: start;
+  background-color: var(--card-bg-color);
+  border: 1px solid var(--divider-color);
+  border-radius: calc(10px * var(--ui-roundness));
+  box-shadow: 0 1px 3px rgb(0 0 0 / 16%);
   box-sizing: border-box;
+  display: grid;
+  gap: 1rem;
+  grid-template-columns: auto minmax(0, 1fr) auto;
   padding: 1rem;
 }
 
+.sessionCard.currentSession {
+  border-color: color-mix(in srgb, var(--primary-color) 44%, var(--divider-color));
+}
+
+.sessionDeviceIcon {
+  block-size: 3.25rem;
+  border: 1px solid color-mix(in srgb, var(--primary-color) 24%, transparent);
+  border-radius: 50%;
+  font-size: 1.5rem;
+  inline-size: 3.25rem;
+}
+
+.sessionContent {
+  min-inline-size: 0;
+}
+
 .sessionSummary {
-  align-items: flex-start;
+  align-items: center;
   display: flex;
-  gap: 0.75rem;
-  justify-content: space-between;
+  flex-wrap: wrap;
+  gap: 0.5rem;
+  min-block-size: 1.75rem;
 }
 
 .sessionSummary h4 {
+  font-size: 1.05rem;
   overflow-wrap: anywhere;
 }
 
 .currentBadge {
+  background-color: color-mix(in srgb, var(--primary-color) 16%, transparent);
+  border: 1px solid color-mix(in srgb, var(--primary-color) 28%, transparent);
+  border-radius: calc(999px * var(--ui-roundness));
   color: var(--primary-color);
   display: inline-block;
-  font-size: 0.875rem;
+  font-size: 0.78rem;
   font-weight: 600;
-  margin-block-start: 0.25rem;
+  line-height: 1;
+  padding-block: 0.35rem;
+  padding-inline: 0.55rem;
+  white-space: nowrap;
 }
 
 .sessionDetails {
   display: grid;
-  gap: 0.5rem;
-  margin-block: 1rem 0;
+  gap: 0.75rem 1.25rem;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  margin-block: 0.875rem 0;
 }
 
 .sessionDetails div {
-  display: grid;
-  gap: 0.25rem;
-  grid-template-columns: minmax(7rem, 1fr) minmax(0, 1.5fr);
+  min-inline-size: 0;
 }
 
 .sessionDetails dt {
+  align-items: center;
   color: var(--secondary-text-color);
+  display: flex;
+  font-size: 0.8rem;
+  gap: 0.4rem;
+  line-height: 1.3;
+}
+
+.sessionDetails dt :deep(.ft-icon) {
+  color: var(--primary-color);
+  flex: 0 0 1rem;
+  inline-size: 1rem;
 }
 
 .sessionDetails dd {
-  margin: 0;
+  font-size: 0.9rem;
+  line-height: 1.35;
+  margin-block-start: 0.2rem;
+  margin-inline: 1.4rem 0;
   overflow-wrap: anywhere;
+}
+
+.revokeAction :deep(.iconButton) {
+  background-color: color-mix(in srgb, var(--destructive-color) 12%, transparent);
+  border-color: color-mix(in srgb, var(--destructive-color) 42%, transparent);
+  color: var(--destructive-color);
+}
+
+.revokeAction :deep(.iconButton:not(.disabled):is(:hover, :focus-visible, :active)) {
+  background-color: color-mix(in srgb, var(--destructive-color) 22%, transparent);
+  border-color: var(--destructive-color);
+  color: var(--destructive-color);
+}
+
+.passwordAction {
+  align-items: center;
+  background-color: var(--card-bg-color);
+  border: 1px solid var(--divider-color);
+  border-radius: calc(10px * var(--ui-roundness));
+  box-sizing: border-box;
+  color: var(--primary-text-color);
+  cursor: pointer;
+  display: grid;
+  font: inherit;
+  font-weight: 600;
+  gap: 0.75rem;
+  grid-template-columns: auto minmax(0, 1fr) auto;
+  inline-size: 100%;
+  margin-block-start: 0.75rem;
+  min-block-size: 3.75rem;
+  padding-block: 0.625rem;
+  padding-inline: 0.875rem;
+  text-align: start;
+  transition: background-color 150ms ease, border-color 150ms ease;
+}
+
+.passwordAction:disabled {
+  cursor: not-allowed;
+  opacity: 0.5;
+}
+
+.passwordAction:not(:disabled):is(:hover, :focus-visible) {
+  background-color: var(--side-nav-hover-color);
+  border-color: color-mix(in srgb, var(--primary-color) 44%, var(--divider-color));
+  color: var(--side-nav-hover-text-color);
+}
+
+.passwordAction:not(:disabled):active {
+  background-color: var(--side-nav-active-color);
+}
+
+.passwordActionIcon {
+  block-size: 2.25rem;
+  border-radius: calc(8px * var(--ui-roundness));
+  inline-size: 2.25rem;
+}
+
+.passwordActionArrow {
+  color: var(--secondary-text-color);
+  margin-inline: 0.25rem;
 }
 
 .managementError {
@@ -110,18 +266,49 @@
   margin-inline: auto;
 }
 
-@media only screen and (width <= 600px) {
-  .managementHeader,
-  .sessionSummary {
-    align-items: stretch;
-    flex-direction: column;
+@media only screen and (width <= 700px) {
+  .accountManagement {
+    padding: 1rem;
+  }
+
+  .sessionCard {
+    grid-template-columns: auto minmax(0, 1fr);
   }
 
   .sessionActions {
-    align-items: stretch;
+    grid-column: 2;
+    justify-content: flex-start;
   }
 
-  .sessionDetails div {
+  .sessionDetails {
     grid-template-columns: 1fr;
+  }
+}
+
+@media only screen and (width <= 480px) {
+  .managementHeader {
+    align-items: flex-start;
+  }
+
+  .managementIcon {
+    display: none;
+  }
+
+  .sessionCard {
+    grid-template-columns: 1fr;
+  }
+
+  .sessionDeviceIcon {
+    display: none;
+  }
+
+  .sessionActions {
+    grid-column: 1;
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .passwordAction {
+    transition: none;
   }
 }

--- a/src/renderer/components/SyncSettings/SyncAccountManagement.vue
+++ b/src/renderer/components/SyncSettings/SyncAccountManagement.vue
@@ -4,16 +4,29 @@
     :aria-labelledby="headingId"
   >
     <div class="managementHeader">
-      <div>
-        <h3 :id="headingId">
-          {{ t('Settings.Sync Settings.Devices') }}
-        </h3>
-        <p>{{ t('Settings.Sync Settings.Devices Hint') }}</p>
+      <div class="managementTitle">
+        <span
+          class="managementIcon"
+          aria-hidden="true"
+        >
+          <FtIcon :icon="['fas', 'display']" />
+        </span>
+        <div>
+          <h3 :id="headingId">
+            {{ t('Settings.Sync Settings.Devices') }}
+          </h3>
+          <p>{{ t('Settings.Sync Settings.Devices Hint') }}</p>
+        </div>
       </div>
-      <FtButton
-        :label="t('Settings.Sync Settings.Refresh Devices')"
+      <FtIconButton
+        class="managementAction"
+        :title="t('Settings.Sync Settings.Refresh Devices')"
         :icon="['fas', 'sync']"
         :disabled="loading || actionBusy"
+        :use-shadow="false"
+        :padding="11"
+        :size="20"
+        theme="base-no-default"
         @click="loadSessions"
       />
     </div>
@@ -34,9 +47,16 @@
         v-for="session in sessions"
         :key="session.id"
         class="sessionCard"
+        :class="{ currentSession: session.current }"
       >
-        <div class="sessionSummary">
-          <div>
+        <span
+          class="sessionDeviceIcon"
+          aria-hidden="true"
+        >
+          <FtIcon :icon="deviceIcon(session.deviceInfo.platform)" />
+        </span>
+        <div class="sessionContent">
+          <div class="sessionSummary">
             <h4>{{ session.deviceInfo.name }}</h4>
             <span
               v-if="session.current"
@@ -45,42 +65,101 @@
               {{ t('Settings.Sync Settings.Current Device') }}
             </span>
           </div>
-          <FtFlexBox class="sessionActions">
-            <FtButton
-              :label="t('Settings.Sync Settings.Rename Device')"
-              :icon="['fas', 'edit']"
-              :disabled="actionBusy"
-              @click="openRenamePrompt(session)"
-            />
-            <FtButton
-              :label="t('Settings.Sync Settings.Revoke Session')"
-              :icon="['fas', 'trash']"
-              theme="destructive"
-              :disabled="actionBusy"
-              @click="sessionToRevoke = session"
-            />
-          </FtFlexBox>
+          <dl class="sessionDetails">
+            <div v-if="systemLabel(session.deviceInfo)">
+              <dt>
+                <FtIcon
+                  :icon="['fas', 'display']"
+                  aria-hidden="true"
+                />
+                {{ t('Settings.Sync Settings.Operating System') }}
+              </dt>
+              <dd>{{ systemLabel(session.deviceInfo) }}</dd>
+            </div>
+            <div>
+              <dt>
+                <FtIcon
+                  :icon="['fas', 'calendar-days']"
+                  aria-hidden="true"
+                />
+                {{ t('Settings.Sync Settings.Session Created') }}
+              </dt>
+              <dd><time :datetime="isoDate(session.created_at)">{{ dateLabel(session.created_at) }}</time></dd>
+            </div>
+            <div>
+              <dt>
+                <FtIcon
+                  :icon="['fas', 'clock']"
+                  aria-hidden="true"
+                />
+                {{ t('Settings.Sync Settings.Last Active') }}
+              </dt>
+              <dd>
+                <time
+                  :datetime="isoDate(session.last_active_at)"
+                  :title="dateLabel(session.last_active_at)"
+                >{{ relativeDateLabel(session.last_active_at) }}</time>
+              </dd>
+            </div>
+            <div>
+              <dt>
+                <FtIcon
+                  :icon="['fas', 'clock-rotate-left']"
+                  aria-hidden="true"
+                />
+                {{ t('Settings.Sync Settings.Session Expires') }}
+              </dt>
+              <dd><time :datetime="isoDate(session.expires_at)">{{ dateLabel(session.expires_at) }}</time></dd>
+            </div>
+          </dl>
         </div>
-        <dl class="sessionDetails">
-          <div v-if="systemLabel(session.deviceInfo)">
-            <dt>{{ t('Settings.Sync Settings.Operating System') }}</dt>
-            <dd>{{ systemLabel(session.deviceInfo) }}</dd>
-          </div>
-          <div>
-            <dt>{{ t('Settings.Sync Settings.Session Created') }}</dt>
-            <dd><time :datetime="isoDate(session.created_at)">{{ dateLabel(session.created_at) }}</time></dd>
-          </div>
-          <div>
-            <dt>{{ t('Settings.Sync Settings.Last Active') }}</dt>
-            <dd><time :datetime="isoDate(session.last_active_at)">{{ dateLabel(session.last_active_at) }}</time></dd>
-          </div>
-          <div>
-            <dt>{{ t('Settings.Sync Settings.Session Expires') }}</dt>
-            <dd><time :datetime="isoDate(session.expires_at)">{{ dateLabel(session.expires_at) }}</time></dd>
-          </div>
-        </dl>
+        <div class="sessionActions">
+          <FtIconButton
+            class="sessionAction"
+            :title="t('Settings.Sync Settings.Rename Device')"
+            :icon="['fas', 'edit']"
+            :disabled="actionBusy"
+            :use-shadow="false"
+            :padding="11"
+            :size="20"
+            theme="base-no-default"
+            @click="openRenamePrompt(session)"
+          />
+          <FtIconButton
+            class="sessionAction revokeAction"
+            :title="t('Settings.Sync Settings.Revoke Session')"
+            :icon="['fas', 'trash']"
+            :disabled="actionBusy"
+            :use-shadow="false"
+            :padding="11"
+            :size="20"
+            theme="base-no-default"
+            @click="sessionToRevoke = session"
+          />
+        </div>
       </li>
     </ul>
+
+    <button
+      v-if="passwordLogin"
+      class="passwordAction"
+      type="button"
+      :disabled="accountActionsDisabled || actionBusy"
+      @click="emit('change-password')"
+    >
+      <span
+        class="passwordActionIcon"
+        aria-hidden="true"
+      >
+        <FtIcon :icon="['fas', 'key']" />
+      </span>
+      <span>{{ t('Settings.Sync Settings.Change Password') }}</span>
+      <FtIcon
+        class="passwordActionArrow"
+        :icon="['fas', 'arrow-right']"
+        aria-hidden="true"
+      />
+    </button>
 
     <FtPrompt
       v-if="sessionToRename"
@@ -162,15 +241,18 @@
 </template>
 
 <script setup>
+import { FtIcon } from '@opentubex/icons'
 import { computed, onMounted, ref, useId } from 'vue'
 import { useI18n } from 'vue-i18n'
 
 import FtButton from '../FtButton/FtButton.vue'
 import FtFlexBox from '../ft-flex-box/ft-flex-box.vue'
+import FtIconButton from '../FtIconButton/FtIconButton.vue'
 import FtInput from '../FtInput/FtInput.vue'
 import FtLoader from '../FtLoader/FtLoader.vue'
 import FtPrompt from '../FtPrompt/FtPrompt.vue'
 
+import { useRelativeTimeClock } from '../../composables/useRelativeTimeClock'
 import { formatDateTime } from '../../helpers/dateFormat'
 import {
   SyncServerClient,
@@ -183,7 +265,7 @@ import {
   isValidSyncServerDeviceId,
   isValidSyncServerDeviceName,
 } from '../../helpers/sync-server-sessions'
-import { showToast } from '../../helpers/utils'
+import { getRelativeTimeFromDate, showToast } from '../../helpers/utils'
 import store from '../../store/index'
 
 const props = defineProps({
@@ -207,13 +289,22 @@ const props = defineProps({
     type: String,
     required: true,
   },
+  passwordLogin: {
+    type: Boolean,
+    required: true,
+  },
+  accountActionsDisabled: {
+    type: Boolean,
+    required: true,
+  },
 })
-const emit = defineEmits(['current-revoked', 'password-login-changed'])
+const emit = defineEmits(['change-password', 'current-revoked', 'password-login-changed'])
 
 const { locale, t } = useI18n()
 const headingId = useId()
 const dateFormat = computed(() => store.getters.getDateFormat)
 const timeFormat = computed(() => store.getters.getTimeFormat)
+const relativeTimeNow = useRelativeTimeClock()
 const loading = ref(true)
 const actionBusy = ref(false)
 const error = ref('')
@@ -238,6 +329,10 @@ function dateLabel(timestamp) {
   )
 }
 
+function relativeDateLabel(timestamp) {
+  return getRelativeTimeFromDate(timestamp, true, true, relativeTimeNow.value)
+}
+
 function isoDate(timestamp) {
   return new Date(timestamp).toISOString()
 }
@@ -258,6 +353,10 @@ function systemLabel(deviceInfo) {
   return [platform && `${platform}${deviceInfo.release ? ` ${deviceInfo.release}` : ''}`, deviceInfo.architecture]
     .filter(Boolean)
     .join(' · ')
+}
+
+function deviceIcon(platform) {
+  return platform === 'web' ? ['fas', 'globe'] : ['fas', 'display']
 }
 
 async function handleRequestError(requestError, requestToken, target = error) {

--- a/src/renderer/components/SyncSettings/SyncSettings.vue
+++ b/src/renderer/components/SyncSettings/SyncSettings.vue
@@ -230,13 +230,6 @@
             @click="disconnect"
           />
           <FtButton
-            v-if="passwordLogin"
-            :label="t('Settings.Sync Settings.Change Password')"
-            :icon="['fas', 'key']"
-            :disabled="busy || accountActionBusy"
-            @click="openPasswordPrompt"
-          />
-          <FtButton
             :label="t('Settings.Sync Settings.Delete Account')"
             theme="destructive"
             :icon="['fas', 'trash']"
@@ -252,6 +245,9 @@
           :privacy-key="privacyKey"
           :device-id="currentDeviceId"
           :device-name="currentDeviceName"
+          :password-login="passwordLogin"
+          :account-actions-disabled="busy || accountActionBusy"
+          @change-password="openPasswordPrompt"
           @current-revoked="disconnect"
           @password-login-changed="passwordLogin = $event"
         />

--- a/tests/unit/release-note-promo.test.mjs
+++ b/tests/unit/release-note-promo.test.mjs
@@ -1,0 +1,34 @@
+import assert from 'node:assert/strict'
+import test from 'node:test'
+
+import { materialSymbolMotifDataUrl, renderPromoHtml } from '../../_scripts/releaseNotePromo.mjs'
+
+const options = {
+  accent: '#8b7cff',
+  description: 'A real <app> screenshot.',
+  fontDataUrl: 'data:font/ttf;base64,font',
+  iconDataUrl: 'data:image/svg+xml;base64,icon',
+  motifDataUrl: 'data:image/svg+xml;base64,motif',
+  screenshotDataUrl: 'data:image/png;base64,screenshot',
+  title: 'Release & notes',
+}
+
+test('renders deterministic promotional artwork with escaped copy', () => {
+  const first = renderPromoHtml(options)
+  const second = renderPromoHtml(options)
+
+  assert.equal(first, second)
+  assert.match(first, /Release &amp; notes/)
+  assert.match(first, /A real &lt;app&gt; screenshot\./)
+  assert.match(first, /data:image\/png;base64,screenshot/)
+  assert.match(first, /data:image\/svg\+xml;base64,motif/)
+  assert.match(first, /--accent: #8b7cff/)
+})
+
+test('renders a deterministic feature motif from a Material Symbol', () => {
+  const first = materialSymbolMotifDataUrl('devices-rounded', '#8b7cff')
+  const second = materialSymbolMotifDataUrl('devices-rounded', '#8b7cff')
+
+  assert.equal(first, second)
+  assert.match(first, /^data:image\/svg\+xml;base64,/)
+})


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Make sure to follow the contributing guidelines. -->
<!-- Important note, we may remove your pull request if you do not use this provided PR template correctly. -->
<!-- Agent instructions: Preserve every heading, comment, and marker in this template. Never remove or rewrite the release-note-category:start/end, release-note:start/end, or release-note-image:start/end marker pairs. -->

## Pull Request Type
<!-- Please select what type of pull request this is: [x] -->
- [ ] Bugfix
- [x] Feature Implementation
- [ ] Documentation
- [ ] Other

## Related issue
<!-- Please link the issue your pull request is referring to. -->
<!-- If this pull request fully resolves the relevant issue, put "closes" before the issue number. -->
<!-- Example: "closes #123456". -->
Follow-up to #1042.

## Description
<!-- Please write a clear and concise description of what the pull request does. -->
The Devices section added in #1042 worked, but its layout did not match the release artwork and it showed an absolute value for recent activity. Creating matching promotional images also remained a manual process.

This follow-up brings the card-and-icon layout into the app, moves password changes into the Devices panel, and shows relative activity with the exact timestamp on hover. It also adds a deterministic 1600×900 promotional-image generator that places a real app screenshot on the right and builds a feature-specific motif from Material Symbols.

## Release note category
<!-- Select exactly one category. Every pull request must select one. -->
<!-- Select "Not noteworthy" when the pull request fixes a bug in or improves functionality that has not yet appeared in a stable release. -->
<!-- release-note-category:start -->
- [x] Not noteworthy
- [ ] Highlights
- [ ] More improvements
- [ ] Fixed bugs
<!-- release-note-category:end -->

## Release note
<!-- Required unless "Not noteworthy" is selected. -->
<!-- Write one concise, user-facing entry without a leading bullet. -->
<!-- release-note:start -->

<!-- release-note:end -->

## Release note images
<!-- Optional. Paste one or more Markdown images, HTML image tags, or dark/light <picture> elements here. -->
<!-- The release notes normalize the markup and limit images taller than 300 pixels. -->
<!-- Agent instructions:
For a noteworthy visible change, add media when it makes the change easier to understand. Prefer a still image unless motion is the point; recordings must use animated WebP.
After implementing a visible change, proactively capture the result and show the local media to the user for approval before uploading it or updating the pull request.
When the affected UI differs between dark and light themes, capturing both themes is required. A dark-only image is incomplete. Run `node _scripts/releaseNoteMedia.mjs --dark DARK_FILE --light LIGHT_FILE --alt "DESCRIPTION"`; GitHub will display the matching theme and use dark as the fallback. Use a single default-dark capture only when the light theme cannot be captured or looks identical.
Capture or crop to the smallest region that still makes the change clear. Do not include the full window when the affected component can be understood on its own.
Use English unless localization is the subject. Keep components at their normal dimensions and placement instead of resizing them to fill the frame.
Use deterministic local fixtures for visible remote images. Reusable avatar and thumbnail fixtures are available through `e2e/helpers/visual-fixtures.mjs`. Before capturing, verify that every visible image has loaded successfully (`complete === true` and `naturalWidth > 0`).
Inspect the final dark and light files for failed images, missing content, unrelated UI, awkward animation, and misleading layout. Omit media when it does not explain the change clearly.
For one dark capture, run `node _scripts/releaseNoteMedia.mjs FILE --alt "DESCRIPTION"`.
Check for personal information, tokens, private repository names, and unrelated desktop content before uploading. Uploaded media is public.
Keep capture-only scripts, test hooks, screenshots, and recordings out of commits. Remove them before committing unless the capture code is also a reusable regression test. Never commit generated release-note media.
Paste only the generated markup between the marker comments. Leave this section empty when media would not help.
-->
<!-- release-note-image:start -->

<!-- release-note-image:end -->

## Testing
<!-- How can reviewers verify that the PR produces correct results? -->
<!-- Please provide instructions so that others can ensure that your pull request would produce correct results. For examples see, https://github.com/FreeTubeApp/FreeTube/pull/5743, https://github.com/FreeTubeApp/FreeTube/pull/7349, https://github.com/FreeTubeApp/FreeTube/pull/5125, https://github.com/FreeTubeApp/FreeTube/pull/7338 -->
<!-- Agent instructions: Only write human-facing steps that explain how to verify the change while running this branch in dev mode. Include expected results and, when applicable, helpful console snippets for interactive verification. Do not include automated checks, commands, results, pass counts, or CI status. -->
1. Connect a password-backed sync account, then open Settings > Sync.
2. Confirm the Devices panel shows device metadata in a responsive card, keeps rename and revoke actions accessible, and places Change password below the session list.
3. Confirm Last active uses relative time and hovering it reveals the full configured date and time.
4. Switch between dark and light themes and narrow the window. The panel should remain legible without clipped metadata or controls.
5. Run `pnpm run release-note-promo --help`, then generate an image with a real screenshot and `--icon devices-rounded`. The output should be a 1600×900 PNG with the screenshot on the right and a Devices motif near the lower left.

## Additional context
<!-- Add any other context about the pull request here. -->
The generator uses the repository's existing Electron, Playwright, Material Symbols, brand icon, and Roboto font. It adds no dependency.

![Sync device management in the dark theme](https://github.com/user-attachments/assets/0843c221-1573-4c40-b469-2997d0fc3cac)

![Sync device management in the light theme](https://github.com/user-attachments/assets/e2cc1886-7998-4541-9e6e-0d1151e6111c)