### PR TITLE
feat(player): preload upcoming yt-dlp videos

### DIFF
--- a/e2e/tests/offline/playlists.spec.mjs
+++ b/e2e/tests/offline/playlists.spec.mjs
@@ -75,6 +75,27 @@ test.describe('seeded playlists', () => {
           ],
           createdAt: Date.now() - 86_400_000,
           lastUpdatedAt: Date.now()
+        },
+        {
+          _id: 'secondary',
+          playlistName: 'Secondary preload playlist',
+          protected: false,
+          description: 'Playlist used to test switching during preloading',
+          videos: [
+            {
+              videoId: 'eeeeeeeeeee',
+              title: 'Secondary seeded video',
+              author: 'Test Channel',
+              authorId: 'UC-test-channel-id',
+              lengthSeconds: 120,
+              published: Date.now() - 86_400_000,
+              timeAdded: Date.now(),
+              playlistItemId: 'e2e-item-3',
+              type: 'video'
+            }
+          ],
+          createdAt: Date.now() - 86_400_000,
+          lastUpdatedAt: Date.now()
         }
       ]
     }
@@ -194,6 +215,63 @@ test.describe('seeded playlists', () => {
       BrowserWindow.getAllWindows()[0].webContents.send(channel)
     }, IpcChannels.YT_DLP_BINARY_UPDATED)
     await expect(page.getByTitle('Preload all videos')).toHaveAttribute('aria-disabled', 'false')
+  })
+
+  test('releases stale preload UI when switching playlists', async ({ app, page }) => {
+    await app.electronApp.evaluate(({ ipcMain }, channel) => {
+      globalThis.__ytDlpPreloadVideoIds = []
+      globalThis.__ytDlpPreloadResolvers = []
+      const requestCounts = new Map()
+      ipcMain.removeHandler(channel)
+      ipcMain.handle(channel, (_event, videoId) => {
+        globalThis.__ytDlpPreloadVideoIds.push(videoId)
+        const requestCount = (requestCounts.get(videoId) ?? 0) + 1
+        requestCounts.set(videoId, requestCount)
+        if (requestCount === 1) {
+          return new Promise(resolve => globalThis.__ytDlpPreloadResolvers.push({ videoId, resolve }))
+        }
+        return { error: 'mock failure' }
+      })
+    }, IpcChannels.YT_DLP_GET_PLAYBACK_INFO)
+
+    await goTo(page, 'userplaylists')
+    await page.getByText('My seeded playlist').click()
+    await page.getByTitle('Preload all videos').click()
+
+    await expect.poll(() => app.electronApp.evaluate(
+      () => [...new Set(globalThis.__ytDlpPreloadVideoIds)]
+    )).toEqual(['ccccccccccc', 'ddddddddddd'])
+
+    await page.locator(sel.searchInput).fill(
+      'https://www.youtube.com/playlist?list=secondary&playlistType=user'
+    )
+    await page.locator(sel.searchInput).press('Enter')
+    await expect(page.getByText('Secondary preload playlist')).toBeVisible()
+    await expect(page.getByTestId('progress-toast')).toHaveCount(0)
+
+    const secondaryPreloadButton = page.getByTitle('Preload all videos')
+    await expect(secondaryPreloadButton).toHaveAttribute('aria-disabled', 'false')
+    await secondaryPreloadButton.click()
+    await expect(page.getByTestId('progress-toast')).toContainText('Preloading videos: 0 of 1')
+
+    await app.electronApp.evaluate(() => {
+      for (const entry of globalThis.__ytDlpPreloadResolvers.splice(0)) {
+        entry.resolve({ error: 'mock failure' })
+      }
+    })
+    await expect.poll(() => app.electronApp.evaluate(
+      () => [...new Set(globalThis.__ytDlpPreloadVideoIds)]
+    )).toEqual(['ccccccccccc', 'ddddddddddd', 'eeeeeeeeeee'])
+
+    await app.electronApp.evaluate(() => {
+      for (const entry of globalThis.__ytDlpPreloadResolvers.splice(0)) {
+        entry.resolve({ error: 'mock failure' })
+      }
+    })
+    await expect(page.getByText(
+      'Preloaded 0 of 1 videos. 1 could not be preloaded.'
+    )).toBeVisible()
+    await expect(page.getByTestId('progress-toast')).toHaveCount(0)
   })
 
   test('restores running premiere styling when the scheduled time arrives', async ({ page }) => {

--- a/e2e/tests/offline/playlists.spec.mjs
+++ b/e2e/tests/offline/playlists.spec.mjs
@@ -1,7 +1,9 @@
 import { readFile } from 'node:fs/promises'
 import path from 'node:path'
 
+import { IpcChannels } from '../../../src/constants.js'
 import { test, expect, sel, goTo, goToSettingsSection } from '../../helpers/app.mjs'
+import { DEMO_MEDIA_URL, routeDemoMedia } from '../../helpers/media.mjs'
 
 const seededPremiereStart = Date.now() + 86_400_000
 
@@ -25,7 +27,9 @@ test.describe('seeded playlists', () => {
     seed: {
       settings: {
         hideUpcomingPremieres: true,
-        quickBookmarkTargetPlaylistId: 'favorites'
+        quickBookmarkTargetPlaylistId: 'favorites',
+        videoPlaybackEngine: 'yt-dlp',
+        ytDlpPlaybackEngineDefaultMigration: true
       },
       playlists: [
         {
@@ -85,6 +89,111 @@ test.describe('seeded playlists', () => {
     await expect(page.getByText('Seeded video one')).toBeVisible()
     // Local playlists intentionally ignore the global hide-upcoming setting.
     await expect(page.getByText('Upcoming seeded premiere')).toBeVisible()
+  })
+
+  test('preloads every video in a user playlist with yt-dlp', async ({ app, page }) => {
+    await app.electronApp.evaluate(({ ipcMain }, channel) => {
+      globalThis.__ytDlpPreloadVideoIds = []
+      globalThis.__ytDlpPreloadResolvers = []
+      const requestCounts = new Map()
+      ipcMain.removeHandler(channel)
+      ipcMain.handle(channel, (_event, videoId) => {
+        globalThis.__ytDlpPreloadVideoIds.push(videoId)
+        const requestCount = (requestCounts.get(videoId) ?? 0) + 1
+        requestCounts.set(videoId, requestCount)
+        if (requestCount === 1) {
+          return new Promise(resolve => globalThis.__ytDlpPreloadResolvers.push(resolve))
+        }
+        return { error: 'mock failure' }
+      })
+    }, IpcChannels.YT_DLP_GET_PLAYBACK_INFO)
+
+    await goTo(page, 'userplaylists')
+    await page.getByText('My seeded playlist').click()
+    await page.getByTitle('Preload all videos').click()
+
+    await expect.poll(() => app.electronApp.evaluate(
+      () => [...new Set(globalThis.__ytDlpPreloadVideoIds)]
+    )).toEqual(['ccccccccccc', 'ddddddddddd'])
+
+    const pendingButton = page.getByTitle('Preloading all videos...')
+    await expect(pendingButton).toHaveAttribute('aria-disabled', 'true')
+    await expect(pendingButton.locator('.ft-icon--spin')).toBeVisible()
+
+    const progressToast = page.getByTestId('progress-toast')
+    await expect(progressToast).toContainText('Preloading videos: 0 of 2')
+    await expect(progressToast.locator('.progress-indicator')).toHaveAttribute('data-progress', '0')
+
+    await app.electronApp.evaluate(() => globalThis.__ytDlpPreloadResolvers.shift()({ error: 'mock failure' }))
+    await expect(progressToast).toContainText('Preloading videos: 1 of 2')
+    await expect(progressToast.locator('.progress-indicator')).toHaveAttribute('data-progress', '50')
+
+    await app.electronApp.evaluate(() => globalThis.__ytDlpPreloadResolvers.shift()({ error: 'mock failure' }))
+    await expect(page.getByText(
+      'Preloaded 0 of 2 videos. 2 could not be preloaded.'
+    )).toBeVisible()
+    await expect(progressToast).toHaveCount(0)
+    await expect(page.getByTitle('Preload all videos')).toHaveAttribute('aria-disabled', 'false')
+  })
+
+  test('keeps a successfully preloaded playlist disabled', async ({ app, page }) => {
+    await routeDemoMedia(page)
+    await app.electronApp.evaluate(({ ipcMain }, { channel, mediaUrl }) => {
+      ipcMain.removeHandler(channel)
+      ipcMain.handle(channel, (_event, videoId) => ({
+        isLive: false,
+        liveStatus: 'not_live',
+        hlsManifestUrl: null,
+        formats: [{
+          formatId: '43',
+          url: `${mediaUrl}&expire=4102444800`,
+          manifestUrl: null,
+          protocol: 'https',
+          ext: 'webm',
+          container: 'webm',
+          vcodec: 'vp9',
+          acodec: 'opus',
+          width: 640,
+          height: 360,
+          fps: 15,
+          bitrate: 200_000,
+          audioSampleRate: 48_000,
+          audioChannels: 2,
+          language: null,
+          formatNote: '360p',
+          dynamicRange: 'SDR',
+          availableAt: null,
+        }],
+        duration: 30,
+        storyboardVtt: null,
+        captions: [],
+        captionTranslations: [],
+        title: videoId,
+        version: 'test',
+      }))
+    }, {
+      channel: IpcChannels.YT_DLP_GET_PLAYBACK_INFO,
+      mediaUrl: DEMO_MEDIA_URL,
+    })
+
+    await goTo(page, 'userplaylists')
+    await page.getByText('My seeded playlist').click()
+    await page.getByTitle('Preload all videos').click()
+
+    await expect(page.getByText('Preloaded videos: 2.')).toBeVisible()
+    const completedButton = page.getByTitle('All playlist videos are already preloaded')
+    await expect(completedButton).toHaveAttribute('aria-disabled', 'true')
+    await expect(completedButton.locator('.ft-icon--spin')).toHaveCount(0)
+    await expect(page.getByTestId('progress-toast')).toHaveCount(0)
+
+    await goTo(page, 'userplaylists')
+    await page.getByText('My seeded playlist').click()
+    await expect(page.getByTitle('All playlist videos are already preloaded')).toHaveAttribute('aria-disabled', 'true')
+
+    await app.electronApp.evaluate(({ BrowserWindow }, channel) => {
+      BrowserWindow.getAllWindows()[0].webContents.send(channel)
+    }, IpcChannels.YT_DLP_BINARY_UPDATED)
+    await expect(page.getByTitle('Preload all videos')).toHaveAttribute('aria-disabled', 'false')
   })
 
   test('restores running premiere styling when the scheduled time arrives', async ({ page }) => {

--- a/e2e/tests/offline/settings.spec.mjs
+++ b/e2e/tests/offline/settings.spec.mjs
@@ -4819,9 +4819,10 @@ test.describe('synced setting indicators', () => {
     await goTo(page, 'settings')
     const playbackSection = await goToSettingsSection(page, 'playback')
     const sliders = playbackSection.locator('.sliderGrid > *')
-    await expect(sliders).toHaveCount(7)
+    await expect(sliders).toHaveCount(8)
     await expect(sliders.nth(5)).toContainText(/Max video playback rate/i)
     await expect(sliders.nth(6)).toContainText(/Parallel segment loading/i)
+    await expect(sliders.nth(7)).toContainText(/Upcoming videos to preload/i)
 
     const boxes = await sliders.evaluateAll((elements) => elements.map((element) => {
       const { x, y, width } = element.getBoundingClientRect()
@@ -4832,15 +4833,8 @@ test.describe('synced setting indicators', () => {
     for (const { y } of boxes) {
       rowSizes.set(y, (rowSizes.get(y) ?? 0) + 1)
     }
-    expect([...rowSizes.values()]).toEqual([3, 3, 1])
+    expect([...rowSizes.values()]).toEqual([3, 3, 2])
     expect(new Set(boxes.map(({ width }) => width)).size).toBe(1)
-
-    const lastSlider = boxes.at(-1)
-    const gridCenter = await playbackSection.locator('.sliderGrid').evaluate(element => {
-      const bounds = element.getBoundingClientRect()
-      return bounds.x + bounds.width / 2
-    })
-    expect(lastSlider.x + lastSlider.width / 2).toBeCloseTo(gridCenter, 0)
 
     await page.evaluate(async () => {
       const store = document.querySelector('#app').__vue_app__.config.globalProperties.$store

--- a/e2e/tests/offline/watch-page.spec.mjs
+++ b/e2e/tests/offline/watch-page.spec.mjs
@@ -1965,7 +1965,7 @@ test.describe('watch page', () => {
     })
   })
 
-  test('ignores a superseded yt-dlp extraction after rapid engine switches', async ({ app, page }) => {
+  test('shares a pending yt-dlp extraction after rapid engine switches', async ({ app, page }) => {
     await mockPlayableWatchPage(app, page)
     await page.route('https://example.invalid/*.m3u8', route => route.fulfill({
       contentType: 'application/x-mpegURL',
@@ -1994,37 +1994,24 @@ test.describe('watch page', () => {
       await view.handlePlaybackEngineChange('built-in')
       window.__secondEngineSwitch = view.handlePlaybackEngineChange('yt-dlp')
     })
-    await expect.poll(() => app.electronApp.evaluate(
+    expect(await app.electronApp.evaluate(
       () => globalThis.__ytDlpPlaybackResolvers.length
-    )).toBe(2)
+    )).toBe(1)
 
     await app.electronApp.evaluate(() => {
       globalThis.__ytDlpPlaybackResolvers.shift()({
         isLive: true,
         liveStatus: 'is_live',
-        hlsManifestUrl: 'https://example.invalid/first.m3u8',
+        hlsManifestUrl: 'https://example.invalid/shared.m3u8',
         formats: [],
         duration: null,
-        version: 'first'
+        version: 'shared'
       })
     })
-    await page.evaluate(() => window.__firstEngineSwitch)
-    expect(await watchView.evaluate((view) => ({
-      activeEngine: view.activePlaybackEngine,
-      pending: view.ytDlpStreamsPending
-    }))).toEqual({ activeEngine: 'built-in', pending: true })
-
-    await app.electronApp.evaluate(() => {
-      globalThis.__ytDlpPlaybackResolvers.shift()({
-        isLive: true,
-        liveStatus: 'is_live',
-        hlsManifestUrl: 'https://example.invalid/second.m3u8',
-        formats: [],
-        duration: null,
-        version: 'second'
-      })
-    })
-    await page.evaluate(() => window.__secondEngineSwitch)
+    await page.evaluate(() => Promise.all([
+      window.__firstEngineSwitch,
+      window.__secondEngineSwitch
+    ]))
     expect(await watchView.evaluate((view) => ({
       activeEngine: view.activePlaybackEngine,
       builtInManifest: view.builtInPlaybackSource.manifestSrc,
@@ -2034,10 +2021,40 @@ test.describe('watch page', () => {
     }))).toEqual({
       activeEngine: 'yt-dlp',
       builtInManifest,
-      manifest: 'https://example.invalid/second.m3u8',
+      manifest: 'https://example.invalid/shared.m3u8',
       pending: false,
-      version: 'second'
+      version: 'shared'
     })
+  })
+
+  test('preloads the configured number of upcoming yt-dlp recommendations', async ({ app, page }) => {
+    await mockPlayableWatchPage(app, page)
+    await openMockedVideo(page)
+
+    await app.electronApp.evaluate(({ ipcMain }) => {
+      globalThis.__ytDlpPreloadCalls = []
+      ipcMain.removeHandler('yt-dlp-get-playback-info')
+      ipcMain.handle('yt-dlp-get-playback-info', (_event, videoId) => {
+        globalThis.__ytDlpPreloadCalls.push(videoId)
+        return { error: 'expected test extraction failure' }
+      })
+    })
+
+    const watchView = await watchViewHandle(page)
+    await watchView.evaluate(async (view) => {
+      view.recommendedVideos = [
+        { videoId: 'nextvideo01', title: 'First recommendation' },
+        { videoId: 'nextvideo02', title: 'Second recommendation' },
+        { videoId: 'nextvideo03', title: 'Third recommendation' }
+      ]
+      await view.$store.dispatch('updateYtDlpPreloadCount', 2)
+      await view.$store.dispatch('updateYtDlpPreloadEnabled', true)
+      await view.$store.dispatch('updateVideoPlaybackEngine', 'yt-dlp')
+    })
+
+    await expect.poll(() => app.electronApp.evaluate(() => [
+      ...new Set(globalThis.__ytDlpPreloadCalls.filter(videoId => videoId.startsWith('nextvideo')))
+    ])).toEqual(['nextvideo01', 'nextvideo02'])
   })
 
   test('an IP-blocked playback fallback retries yt-dlp with its default clients', async ({ app, page }) => {

--- a/e2e/tests/offline/yt-dlp-preload-settings.spec.mjs
+++ b/e2e/tests/offline/yt-dlp-preload-settings.spec.mjs
@@ -1,0 +1,55 @@
+import { readFile } from 'node:fs/promises'
+import path from 'node:path'
+
+import { test, expect, goToSettingsSection, latestSettings } from '../../helpers/app.mjs'
+
+async function openPreloadSettings(page) {
+  const section = await goToSettingsSection(page, 'playback')
+  return {
+    toggle: section.getByRole('checkbox', { name: 'Preload Upcoming Videos' }),
+    toggleLabel: section.locator('label.switch-label').filter({ hasText: 'Preload Upcoming Videos' }),
+    slider: section.getByRole('slider', { name: /Upcoming Videos to Preload/ })
+  }
+}
+
+test.describe('yt-dlp playback preloading', () => {
+  test.use({
+    seed: {
+      settings: {
+        videoPlaybackEngine: 'yt-dlp',
+        ytDlpPlaybackEngineDefaultMigration: true
+      }
+    }
+  })
+
+  test('persists the switch and number of upcoming videos', async ({ app }) => {
+    const { toggle, toggleLabel, slider } = await openPreloadSettings(app.page)
+
+    await expect(toggle).not.toBeChecked()
+    await expect(toggle).toBeEnabled()
+    await expect(slider).toBeDisabled()
+    await expect(slider).toHaveValue('2')
+    await expect(slider).toHaveAttribute('min', '1')
+    await expect(slider).toHaveAttribute('max', '10')
+
+    await toggleLabel.click()
+    await expect(toggle).toBeChecked()
+    await expect(slider).toBeEnabled()
+    await slider.fill('4')
+
+    await expect.poll(async () => {
+      const settings = latestSettings(
+        await readFile(path.join(app.userDataDir, 'settings.db'), 'utf8')
+      )
+      return {
+        enabled: settings.ytDlpPreloadEnabled,
+        count: settings.ytDlpPreloadCount
+      }
+    }).toEqual({ enabled: true, count: 4 })
+
+    const relaunched = await app.relaunch()
+    const reloaded = await openPreloadSettings(relaunched.page)
+    await expect(reloaded.toggle).toBeChecked()
+    await expect(reloaded.slider).toHaveValue('4')
+  })
+})

--- a/src/renderer/App.vue
+++ b/src/renderer/App.vue
@@ -420,6 +420,7 @@ import {
   resolveExternalLinkAction,
   resolveMobileContextLinkCopyUrl,
 } from './helpers/mobileLinkActions'
+import { startProgressBarOperation } from './helpers/progressBar'
 import { initializePlatformInfo, isLinuxWayland } from './helpers/platform'
 import {
   shouldShowProgressStartToast,
@@ -915,12 +916,19 @@ async function initializeManagedExternalSoftware(requestedUpdates = null) {
 
   let downloadStarted = missingManagedBinaries.length > 0
   let toolProgressPercentage = 0
+  let progressOperation = null
 
   function showToolProgress(message) {
-    store.commit('setProgressBarMessage', message)
-    store.commit('setProgressBarIcon', ['fas', 'download'])
-    store.commit('setProgressBarPercentage', toolProgressPercentage)
-    store.commit('setShowProgressBar', true)
+    const progress = {
+      icon: ['fas', 'download'],
+      message,
+      percentage: toolProgressPercentage,
+    }
+    if (progressOperation === null) {
+      progressOperation = startProgressBarOperation(store, progress)
+    } else {
+      progressOperation.update(progress)
+    }
   }
 
   if (downloadStarted) {
@@ -954,7 +962,7 @@ async function initializeManagedExternalSoftware(requestedUpdates = null) {
     const percentages = Object.values(progressByBinary)
     const combinedPercentage = percentages.reduce((sum, value) => sum + value, 0) / percentages.length
     toolProgressPercentage = Math.max(toolProgressPercentage, combinedPercentage)
-    store.commit('setProgressBarPercentage', toolProgressPercentage)
+    progressOperation.update({ percentage: toolProgressPercentage })
   })
 
   try {
@@ -972,7 +980,7 @@ async function initializeManagedExternalSoftware(requestedUpdates = null) {
 
     if (failures.length === 0 && updatedBinaries.length > 0) {
       toolProgressPercentage = 100
-      store.commit('setProgressBarPercentage', toolProgressPercentage)
+      progressOperation?.update({ percentage: toolProgressPercentage })
       const updatedTools = updatedBinaries.join(' and ')
       showToast({
         message: missingManagedBinaries.length > 0
@@ -991,12 +999,7 @@ async function initializeManagedExternalSoftware(requestedUpdates = null) {
     }
   } finally {
     removeProgressListener()
-    if (downloadStarted) {
-      store.commit('setShowProgressBar', false)
-      store.commit('setProgressBarPercentage', 0)
-      store.commit('setProgressBarMessage', '')
-      store.commit('setProgressBarIcon', ['fas', 'sync'])
-    }
+    progressOperation?.finish()
   }
 
   if (updateMode === 'ask' && requestedUpdates === null) {

--- a/src/renderer/components/DataSettings/DataSettings.vue
+++ b/src/renderer/components/DataSettings/DataSettings.vue
@@ -171,6 +171,7 @@ import FtTooltip from '../FtTooltip/FtTooltip.vue'
 import store from '../../store/index'
 import { defaultUpdaterId, NON_TRANSFERABLE_SETTINGS } from '../../store/modules/settings'
 import { migrateLegacySettings } from '../../helpers/settings-migrations'
+import { startProgressBarOperation } from '../../helpers/progressBar'
 
 import { MAIN_PROFILE_ID } from '../../../constants'
 import { calculateColorLuminance, getRandomColor } from '../../helpers/colors'
@@ -396,6 +397,22 @@ function isChannelSubscribed(channelId, subscriptions) {
 }
 
 /**
+ * @param {(progressOperation: ReturnType<typeof startProgressBarOperation>) => void} importSubscriptions
+ */
+function runWithDataImportProgress(importSubscriptions) {
+  const progressOperation = startProgressBarOperation(store, {
+    icon: ['fas', 'sync'],
+    message: '',
+    percentage: 0,
+  })
+  try {
+    importSubscriptions(progressOperation)
+  } finally {
+    progressOperation.finish()
+  }
+}
+
+/**
  * @param {any[]} oldData
  */
 function convertOldFreeTubeFormatToNew(oldData) {
@@ -552,90 +569,86 @@ function importFreeTubeSubscriptions(profileRecords) {
  * @param {string} textDecode
  */
 function importCsvYouTubeSubscriptions(textDecode) { // first row = header, last row = empty
-  const youtubeSubscriptions = textDecode.split('\n').filter(sub => {
-    return sub !== ''
-  })
-  const subscriptions = []
-
-  store.commit('setShowProgressBar', true)
-  store.commit('setProgressBarPercentage', 0)
-
-  const splitCSVRegex = /(?:,|\n|^)("(?:(?:"")|[^"])*"|[^\n",]*|(?:\n|$))/g
-
-  const ytsubs = youtubeSubscriptions.slice(1).map(yt => {
-    return [...yt.matchAll(splitCSVRegex)].map(s => {
-      let newVal = s[1]
-      if (newVal.startsWith('"')) {
-        newVal = newVal.substring(1, newVal.length - 1).replaceAll('""', '"')
-      }
-      return newVal
+  runWithDataImportProgress(() => {
+    const youtubeSubscriptions = textDecode.split('\n').filter(sub => {
+      return sub !== ''
     })
-  }).filter(channel => {
-    return channel.length > 0
-  })
+    const subscriptions = []
 
-  ytsubs.forEach((yt) => {
-    const channelId = yt[0]
-    if (!isChannelSubscribed(channelId, subscriptions)) {
-      const subscription = {
-        id: channelId,
-        name: yt[2],
-        thumbnail: null
+    const splitCSVRegex = /(?:,|\n|^)("(?:(?:"")|[^"])*"|[^\n",]*|(?:\n|$))/g
+
+    const ytsubs = youtubeSubscriptions.slice(1).map(yt => {
+      return [...yt.matchAll(splitCSVRegex)].map(s => {
+        let newVal = s[1]
+        if (newVal.startsWith('"')) {
+          newVal = newVal.substring(1, newVal.length - 1).replaceAll('""', '"')
+        }
+        return newVal
+      })
+    }).filter(channel => {
+      return channel.length > 0
+    })
+
+    ytsubs.forEach((yt) => {
+      const channelId = yt[0]
+      if (!isChannelSubscribed(channelId, subscriptions)) {
+        const subscription = {
+          id: channelId,
+          name: yt[2],
+          thumbnail: null
+        }
+
+        subscriptions.push(subscription)
       }
+    })
 
-      subscriptions.push(subscription)
-    }
+    primaryProfile.value.subscriptions = primaryProfile.value.subscriptions.concat(subscriptions)
+    store.dispatch('updateProfile', primaryProfile.value)
+    showToast({
+      message: t('Settings.Data Settings.All subscriptions have been successfully imported'),
+      icon: ['fas', 'rss'],
+    })
   })
-
-  primaryProfile.value.subscriptions = primaryProfile.value.subscriptions.concat(subscriptions)
-  store.dispatch('updateProfile', primaryProfile.value)
-  showToast({
-    message: t('Settings.Data Settings.All subscriptions have been successfully imported'),
-    icon: ['fas', 'rss'],
-  })
-  store.commit('setShowProgressBar', false)
 }
 
 /**
  * @param {object} textDecode
  */
 function importYouTubeSubscriptions(textDecode) {
-  const subscriptions = []
-  let count = 0
+  runWithDataImportProgress(progressOperation => {
+    const subscriptions = []
+    let count = 0
 
-  store.commit('setShowProgressBar', true)
-  store.commit('setProgressBarPercentage', 0)
+    textDecode.forEach((channel) => {
+      const snippet = channel.snippet
+      if (typeof snippet === 'undefined') {
+        const message = t('Settings.Data Settings.Invalid subscriptions file')
+        showToast({ message: message, icon: ['fas', 'circle-exclamation'] })
+        throw new Error('Unable to find channel data')
+      }
 
-  textDecode.forEach((channel) => {
-    const snippet = channel.snippet
-    if (typeof snippet === 'undefined') {
-      const message = t('Settings.Data Settings.Invalid subscriptions file')
-      showToast({ message: message, icon: ['fas', 'circle-exclamation'] })
-      throw new Error('Unable to find channel data')
-    }
+      const channelId = snippet.resourceId.channelId
+      if (!isChannelSubscribed(channelId, subscriptions)) {
+        subscriptions.push({
+          id: channelId,
+          name: snippet.title,
+          thumbnail: snippet.thumbnails.default.url
+        })
+      }
 
-    const channelId = snippet.resourceId.channelId
-    if (!isChannelSubscribed(channelId, subscriptions)) {
-      subscriptions.push({
-        id: channelId,
-        name: snippet.title,
-        thumbnail: snippet.thumbnails.default.url
-      })
-    }
+      count++
 
-    count++
+      const progressPercentage = (count / (textDecode.length - 1)) * 100
+      progressOperation.update({ percentage: progressPercentage })
+    })
 
-    const progressPercentage = (count / (textDecode.length - 1)) * 100
-    store.commit('setProgressBarPercentage', progressPercentage)
+    primaryProfile.value.subscriptions = primaryProfile.value.subscriptions.concat(subscriptions)
+    store.dispatch('updateProfile', primaryProfile.value)
+    showToast({
+      message: t('Settings.Data Settings.All subscriptions have been successfully imported'),
+      icon: ['fas', 'rss'],
+    })
   })
-
-  primaryProfile.value.subscriptions = primaryProfile.value.subscriptions.concat(subscriptions)
-  store.dispatch('updateProfile', primaryProfile.value)
-  showToast({
-    message: t('Settings.Data Settings.All subscriptions have been successfully imported'),
-    icon: ['fas', 'rss'],
-  })
-  store.commit('setShowProgressBar', false)
 }
 
 /**
@@ -674,48 +687,46 @@ function importOpmlYouTubeSubscriptions(data) {
     return
   }
 
-  const subscriptions = []
+  runWithDataImportProgress(progressOperation => {
+    const subscriptions = []
 
-  store.commit('setShowProgressBar', true)
-  store.commit('setProgressBarPercentage', 0)
+    let count = 0
 
-  let count = 0
-
-  feedData.forEach((channel) => {
-    const xmlUrl = channel.getAttribute('xmlUrl')
-    const channelName = channel.getAttribute('title')
-    let channelId
-    if (xmlUrl.includes('https://www.youtube.com/feeds/videos.xml?channel_id=')) {
-      channelId = new URL(xmlUrl).searchParams.get('channel_id')
-    } else if (xmlUrl.includes('/feed/channel/')) {
-      // handle invidious exports https://yewtu.be/feed/channel/{CHANNELID}
-      channelId = new URL(xmlUrl).pathname.split('/').filter(part => part).at(-1)
-    } else {
-      console.error(`Unknown xmlUrl format: ${xmlUrl}`)
-    }
-
-    if (!isChannelSubscribed(channelId, subscriptions)) {
-      const subscription = {
-        id: channelId,
-        name: channelName,
-        thumbnail: null
+    feedData.forEach((channel) => {
+      const xmlUrl = channel.getAttribute('xmlUrl')
+      const channelName = channel.getAttribute('title')
+      let channelId
+      if (xmlUrl.includes('https://www.youtube.com/feeds/videos.xml?channel_id=')) {
+        channelId = new URL(xmlUrl).searchParams.get('channel_id')
+      } else if (xmlUrl.includes('/feed/channel/')) {
+        // handle invidious exports https://yewtu.be/feed/channel/{CHANNELID}
+        channelId = new URL(xmlUrl).pathname.split('/').filter(part => part).at(-1)
+      } else {
+        console.error(`Unknown xmlUrl format: ${xmlUrl}`)
       }
-      subscriptions.push(subscription)
-    }
 
-    count++
+      if (!isChannelSubscribed(channelId, subscriptions)) {
+        const subscription = {
+          id: channelId,
+          name: channelName,
+          thumbnail: null
+        }
+        subscriptions.push(subscription)
+      }
 
-    const progressPercentage = (count / feedData.length) * 100
-    store.commit('setProgressBarPercentage', progressPercentage)
+      count++
+
+      const progressPercentage = (count / feedData.length) * 100
+      progressOperation.update({ percentage: progressPercentage })
+    })
+
+    primaryProfile.value.subscriptions = primaryProfile.value.subscriptions.concat(subscriptions)
+    store.dispatch('updateProfile', primaryProfile.value)
+    showToast({
+      message: t('Settings.Data Settings.All subscriptions have been successfully imported'),
+      icon: ['fas', 'rss'],
+    })
   })
-
-  primaryProfile.value.subscriptions = primaryProfile.value.subscriptions.concat(subscriptions)
-  store.dispatch('updateProfile', primaryProfile.value)
-  showToast({
-    message: t('Settings.Data Settings.All subscriptions have been successfully imported'),
-    icon: ['fas', 'rss'],
-  })
-  store.commit('setShowProgressBar', false)
 }
 
 /**
@@ -736,27 +747,25 @@ function importLibreTubeSubscriptions(libreTubeSubscriptions) {
  * @param {{ id: string, name: string, thumbnail: string | null }[]} subscriptions
  */
 function mergeSubscriptionsIntoPrimaryProfile(subscriptions) {
-  store.commit('setShowProgressBar', true)
-  store.commit('setProgressBarPercentage', 0)
+  runWithDataImportProgress(progressOperation => {
+    const newSubscriptions = []
 
-  const newSubscriptions = []
+    subscriptions.forEach((channel, index) => {
+      if (!isChannelSubscribed(channel.id, newSubscriptions)) {
+        newSubscriptions.push(channel)
+      }
 
-  subscriptions.forEach((channel, index) => {
-    if (!isChannelSubscribed(channel.id, newSubscriptions)) {
-      newSubscriptions.push(channel)
-    }
+      const progressPercentage = ((index + 1) / subscriptions.length) * 100
+      progressOperation.update({ percentage: progressPercentage })
+    })
 
-    const progressPercentage = ((index + 1) / subscriptions.length) * 100
-    store.commit('setProgressBarPercentage', progressPercentage)
+    primaryProfile.value.subscriptions = primaryProfile.value.subscriptions.concat(newSubscriptions)
+    store.dispatch('updateProfile', primaryProfile.value)
+    showToast({
+      message: t('Settings.Data Settings.All subscriptions have been successfully imported'),
+      icon: ['fas', 'rss'],
+    })
   })
-
-  primaryProfile.value.subscriptions = primaryProfile.value.subscriptions.concat(newSubscriptions)
-  store.dispatch('updateProfile', primaryProfile.value)
-  showToast({
-    message: t('Settings.Data Settings.All subscriptions have been successfully imported'),
-    icon: ['fas', 'rss'],
-  })
-  store.commit('setShowProgressBar', false)
 }
 
 /**

--- a/src/renderer/components/FtIconButton/FtIconButton.vue
+++ b/src/renderer/components/FtIconButton/FtIconButton.vue
@@ -29,7 +29,10 @@
         v-if="overlayIcon"
         class="icon"
       >
-        <FtIcon :icon="icon" />
+        <FtIcon
+          :icon="icon"
+          :spin="spin"
+        />
         <FtIcon
           class="overlayIcon"
           :icon="overlayIcon"
@@ -40,6 +43,7 @@
         v-else
         class="icon"
         :icon="icon"
+        :spin="spin"
       />
     </button>
     <template
@@ -176,6 +180,10 @@ const props = defineProps({
     default: null
   },
   disabled: {
+    type: Boolean,
+    default: false
+  },
+  spin: {
     type: Boolean,
     default: false
   },

--- a/src/renderer/components/PlayerSettings/PlayerSettings.vue
+++ b/src/renderer/components/PlayerSettings/PlayerSettings.vue
@@ -127,6 +127,16 @@
           @change="updateAutoplayVideos"
         />
         <FtToggleSwitch
+          v-if="USING_ELECTRON"
+          :label="t('Settings.Player Settings.Preload Upcoming Videos')"
+          :compact="true"
+          :disabled="videoPlaybackEngine !== 'yt-dlp'"
+          :default-value="ytDlpPreloadEnabled"
+          setting-key="ytDlpPreloadEnabled"
+          :tooltip="t('Tooltips.Player Settings.Preload Upcoming Videos')"
+          @change="updateYtDlpPreloadEnabled"
+        />
+        <FtToggleSwitch
           :label="t('Settings.Player Settings.Use YouTube-style Shorts')"
           :compact="true"
           :default-value="useCustomShortsPlayer"
@@ -346,6 +356,18 @@
         :step="1"
         :tooltip="t('Tooltips.Player Settings.Parallel Segment Loading')"
         @change="updateSegmentPrefetchLimit"
+      />
+      <FtSlider
+        v-if="USING_ELECTRON"
+        :label="t('Settings.Player Settings.Upcoming Videos to Preload')"
+        :default-value="ytDlpPreloadCount"
+        setting-key="ytDlpPreloadCount"
+        :min-value="1"
+        :max-value="MAX_YT_DLP_PRELOAD_COUNT"
+        :step="1"
+        :disabled="videoPlaybackEngine !== 'yt-dlp' || !ytDlpPreloadEnabled"
+        :tooltip="t('Tooltips.Player Settings.Upcoming Videos to Preload')"
+        @change="updateYtDlpPreloadCount"
       />
     </FtSliderGrid>
     <br>
@@ -599,6 +621,7 @@ import {
   MAX_SEGMENT_PREFETCH_LIMIT
 } from '../../helpers/player/segmentPrefetch'
 import { AUTO_QUALITY_FALLBACK, playbackEngineSupportsAutoQuality } from '../../helpers/player/autoQuality'
+import { MAX_YT_DLP_PRELOAD_COUNT } from '../../helpers/player/ytDlpPlaybackPreload'
 
 defineOptions({ inheritAttrs: false })
 
@@ -611,6 +634,7 @@ const QUICK_PLAYBACK_SPEED_LIMIT = 14
 /** @type {boolean} */
 const USING_ELECTRON = process.env.IS_ELECTRON
 const IS_CAPACITOR = process.env.IS_CAPACITOR
+const videoPlaybackEngine = computed(() => store.getters.getVideoPlaybackEngine)
 
 /** @type {import('vue').ComputedRef<boolean>} */
 const enableSubtitlesByDefault = computed(() => store.getters.getEnableSubtitlesByDefault)
@@ -743,6 +767,26 @@ const autoplayVideos = computed(() => store.getters.getAutoplayVideos)
  */
 function updateAutoplayVideos(value) {
   store.dispatch('updateAutoplayVideos', value)
+}
+
+/** @type {import('vue').ComputedRef<boolean>} */
+const ytDlpPreloadEnabled = computed(() => store.getters.getYtDlpPreloadEnabled)
+
+/**
+ * @param {boolean} value
+ */
+function updateYtDlpPreloadEnabled(value) {
+  store.dispatch('updateYtDlpPreloadEnabled', value)
+}
+
+/** @type {import('vue').ComputedRef<number>} */
+const ytDlpPreloadCount = computed(() => store.getters.getYtDlpPreloadCount)
+
+/**
+ * @param {number} value
+ */
+function updateYtDlpPreloadCount(value) {
+  store.dispatch('updateYtDlpPreloadCount', value)
 }
 
 /** @type {import('vue').ComputedRef<boolean>} */

--- a/src/renderer/components/PlaylistInfo/PlaylistInfo.vue
+++ b/src/renderer/components/PlaylistInfo/PlaylistInfo.vue
@@ -197,6 +197,19 @@
             @click="showDownloadPrompt = true"
           />
           <FtIconButton
+            v-if="preloadAvailable && !editMode && videoCount > 0"
+            :title="preloadPending
+              ? t('Playlist.Preloading Playlist')
+              : preloadComplete
+                ? t('Playlist.Playlist Already Preloaded')
+                : t('Playlist.Preload Playlist')"
+            :icon="['fas', 'forward']"
+            :disabled="preloadPending || preloadComplete"
+            :spin="preloadPending"
+            theme="secondary"
+            @click="emit('preload-playlist')"
+          />
+          <FtIconButton
             v-if="!editMode && userPlaylistDuplicateItemCount > 0"
             :title="$t('User Playlists.Remove Duplicate Videos')"
             :icon="['fas', 'users-slash']"
@@ -415,9 +428,21 @@ const props = defineProps({
     type: Boolean,
     required: true,
   },
+  preloadAvailable: {
+    type: Boolean,
+    default: false,
+  },
+  preloadPending: {
+    type: Boolean,
+    default: false,
+  },
+  preloadComplete: {
+    type: Boolean,
+    default: false,
+  },
 })
 
-const emit = defineEmits(['enter-edit-mode', 'exit-edit-mode', 'search-video-query-change', 'prompt-open', 'prompt-close', 'toggle-playlist-bookmark'])
+const emit = defineEmits(['enter-edit-mode', 'exit-edit-mode', 'search-video-query-change', 'prompt-open', 'prompt-close', 'toggle-playlist-bookmark', 'preload-playlist'])
 
 const { locale, t } = useI18n()
 const IS_ELECTRON = process.env.IS_ELECTRON

--- a/src/renderer/components/WatchVideoPlaylist/WatchVideoPlaylist.vue
+++ b/src/renderer/components/WatchVideoPlaylist/WatchVideoPlaylist.vue
@@ -303,7 +303,7 @@ const props = defineProps({
   },
 })
 
-const emit = defineEmits(['close', 'pause-player', 'skip-availability-change'])
+const emit = defineEmits(['close', 'pause-player', 'skip-availability-change', 'upcoming-videos-change'])
 
 const { locale, t } = useI18n()
 const router = useRouter()
@@ -444,6 +444,21 @@ const nextVideo = computed(() => {
 
   return targetList[targetVideoIndex] ?? null
 })
+
+const upcomingVideos = computed(() => {
+  const targetList = shuffleEnabled.value ? randomizedPlaylistItems.value : playlistItems.value
+  const currentIndex = findIndexOfCurrentVideoInPlaylist(targetList)
+  const startIndex = currentIndex === -1 ? 0 : currentIndex + 1
+  const remainingVideos = targetList.slice(startIndex)
+
+  return loopEnabled.value && currentIndex !== -1
+    ? remainingVideos.concat(targetList.slice(0, startIndex))
+    : remainingVideos
+})
+
+watch(upcomingVideos, videos => {
+  emit('upcoming-videos-change', videos)
+}, { immediate: true })
 
 const playlistPageLinkTo = computed(() => ({
   path: `/playlist/${props.playlistId}`,

--- a/src/renderer/helpers/player/ytDlpPlayback.js
+++ b/src/renderer/helpers/player/ytDlpPlayback.js
@@ -29,11 +29,77 @@ const ITAG_REGEX = /^\d+/
 const URL_PROBE_TIMEOUT = 10_000
 const MINIMUM_LIVE_DVR_WINDOW_SECONDS = 30
 const playbackSourceCache = new YtDlpPlaybackSourceCache()
+const pendingPlaybackSourceLoads = new Map()
+const playbackSourceCacheChangeListeners = new Set()
+
+function notifyPlaybackSourceCacheChanged() {
+  for (const listener of playbackSourceCacheChangeListeners) listener()
+}
+
+function effectivePlaybackSourceCacheKey(cacheKey, useAuthentication) {
+  return JSON.stringify([cacheKey, useAuthentication])
+}
+
+/**
+ * @param {() => void} listener
+ * @returns {() => void}
+ */
+export function onYtDlpPlaybackSourceCacheChange(listener) {
+  playbackSourceCacheChangeListeners.add(listener)
+  return () => playbackSourceCacheChangeListeners.delete(listener)
+}
+
+/**
+ * Returns the earliest time at which any requested source stops being safely
+ * reusable, or null when at least one source is not cached.
+ * @param {string[]} videoIds
+ * @param {string} cacheKey
+ * @param {boolean} useAuthentication
+ * @param {boolean} [requireSubtitles]
+ * @returns {number | null}
+ */
+export function getYtDlpPlaybackSourcesUsableUntil(
+  videoIds,
+  cacheKey,
+  useAuthentication,
+  requireSubtitles = true
+) {
+  const uniqueVideoIds = [...new Set(videoIds)]
+  if (uniqueVideoIds.length === 0) return null
+
+  const effectiveCacheKey = effectivePlaybackSourceCacheKey(cacheKey, useAuthentication)
+  let usableUntil = Infinity
+
+  for (const videoId of uniqueVideoIds) {
+    const sourceUsableUntil = playbackSourceCache.getUsableUntil(
+      videoId,
+      effectiveCacheKey,
+      requireSubtitles
+    )
+    if (sourceUsableUntil === null) return null
+
+    usableUntil = Math.min(usableUntil, sourceUsableUntil)
+  }
+
+  return usableUntil
+}
+
+/**
+ * Keeps every source requested by an explicit playlist preload available for
+ * the rest of the app session, even when the playlist exceeds the normal LRU
+ * limit.
+ * @param {number} entries
+ */
+export function reserveYtDlpPlaybackSourceCache(entries) {
+  playbackSourceCache.ensureCapacity(entries)
+}
 
 async function cacheYtDlpPlaybackSource(videoId, cacheKey, source) {
   if (source.isLive) return
 
-  playbackSourceCache.set(videoId, cacheKey, source)
+  if (playbackSourceCache.set(videoId, cacheKey, source)) {
+    notifyPlaybackSourceCacheChanged()
+  }
   if (source.expiryDate === null) return
 
   try {
@@ -61,14 +127,18 @@ function hasLimitedLiveDvrWindow(url) {
  * @param {string} videoId
  */
 export function invalidateYtDlpPlaybackSource(videoId) {
-  playbackSourceCache.delete(videoId)
+  if (playbackSourceCache.delete(videoId)) {
+    notifyPlaybackSourceCacheChanged()
+  }
   window.ftElectron.ytDlpPlaybackCacheDelete(videoId).catch(error => {
     console.warn('Could not remove an entry from the persistent yt-dlp playback cache', error)
   })
 }
 
 export function invalidateAllYtDlpPlaybackSources() {
-  playbackSourceCache.clear()
+  if (playbackSourceCache.clear()) {
+    notifyPlaybackSourceCacheChanged()
+  }
   return window.ftElectron.ytDlpPlaybackCacheClear().catch(error => {
     console.warn('Could not clear the persistent yt-dlp playback cache', error)
     return false
@@ -387,7 +457,7 @@ function createPostLiveDvrActions(duration, fragmentCount) {
  * @param {boolean} [includeSubtitles] whether yt-dlp should request automatic subtitles
  * @returns {Promise<YtDlpPlaybackSource | null>}
  */
-export async function getYtDlpPlaybackSource(
+export function getYtDlpPlaybackSource(
   videoId,
   cacheKey = '',
   onDefaultClientsFallback,
@@ -395,7 +465,67 @@ export async function getYtDlpPlaybackSource(
   cachedOnly = false,
   includeSubtitles = true
 ) {
-  const effectiveCacheKey = JSON.stringify([cacheKey, useAuthentication])
+  if (cachedOnly) {
+    return loadYtDlpPlaybackSource(
+      videoId,
+      cacheKey,
+      onDefaultClientsFallback,
+      useAuthentication,
+      true,
+      includeSubtitles
+    )
+  }
+
+  const requestKey = JSON.stringify([videoId, cacheKey, useAuthentication, includeSubtitles])
+  const pendingLoad = pendingPlaybackSourceLoads.get(requestKey)
+  if (pendingLoad !== undefined) {
+    if (onDefaultClientsFallback !== undefined) {
+      pendingLoad.defaultClientsFallbackCallbacks.add(onDefaultClientsFallback)
+      if (pendingLoad.defaultClientsFallbackStarted) {
+        onDefaultClientsFallback()
+      }
+    }
+    return pendingLoad.promise
+  }
+
+  const defaultClientsFallbackCallbacks = new Set()
+  if (onDefaultClientsFallback !== undefined) {
+    defaultClientsFallbackCallbacks.add(onDefaultClientsFallback)
+  }
+
+  const pendingEntry = {
+    defaultClientsFallbackCallbacks,
+    defaultClientsFallbackStarted: false,
+    promise: null,
+  }
+  pendingEntry.promise = loadYtDlpPlaybackSource(
+    videoId,
+    cacheKey,
+    () => {
+      pendingEntry.defaultClientsFallbackStarted = true
+      for (const callback of defaultClientsFallbackCallbacks) callback()
+    },
+    useAuthentication,
+    false,
+    includeSubtitles
+  ).finally(() => {
+    if (pendingPlaybackSourceLoads.get(requestKey) === pendingEntry) {
+      pendingPlaybackSourceLoads.delete(requestKey)
+    }
+  })
+  pendingPlaybackSourceLoads.set(requestKey, pendingEntry)
+  return pendingEntry.promise
+}
+
+async function loadYtDlpPlaybackSource(
+  videoId,
+  cacheKey,
+  onDefaultClientsFallback,
+  useAuthentication,
+  cachedOnly,
+  includeSubtitles
+) {
+  const effectiveCacheKey = effectivePlaybackSourceCacheKey(cacheKey, useAuthentication)
   let cachedSource = playbackSourceCache.get(videoId, effectiveCacheKey)
 
   if (cachedSource === null) {
@@ -409,7 +539,9 @@ export async function getYtDlpPlaybackSource(
           subtitlesIncluded: entry.source.subtitlesIncluded ?? false,
           expiryDate: new Date(entry.expiryTime)
         }
-        playbackSourceCache.set(videoId, effectiveCacheKey, source)
+        if (playbackSourceCache.set(videoId, effectiveCacheKey, source)) {
+          notifyPlaybackSourceCacheChanged()
+        }
         cachedSource = playbackSourceCache.get(videoId, effectiveCacheKey)
 
         if (cachedSource === null) {

--- a/src/renderer/helpers/player/ytDlpPlaybackCache.js
+++ b/src/renderer/helpers/player/ytDlpPlaybackCache.js
@@ -2,6 +2,20 @@ const DEFAULT_EXPIRY_MARGIN_MS = 2 * 60 * 1000
 const DEFAULT_MAX_ENTRIES = 50
 
 /**
+ * @param {import('./ytDlpPlayback').YtDlpPlaybackSource} source
+ * @param {number} [now]
+ * @param {number} [expiryMarginMs]
+ */
+export function isYtDlpPlaybackSourceCacheable(
+  source,
+  now = Date.now(),
+  expiryMarginMs = DEFAULT_EXPIRY_MARGIN_MS
+) {
+  const expiryTime = source.expiryDate instanceof Date ? source.expiryDate.getTime() : NaN
+  return !source.isLive && Number.isFinite(expiryTime) && now < expiryTime - expiryMarginMs
+}
+
+/**
  * @param {{ url: string }[]} formats
  * @returns {Date | null}
  */
@@ -69,14 +83,11 @@ export class YtDlpPlaybackSourceCache {
    * @param {string} videoId
    * @param {string} cacheKey
    * @param {import('./ytDlpPlayback').YtDlpPlaybackSource} source
+   * @returns {boolean} whether the source was cached
    */
   set(videoId, cacheKey, source) {
-    const expiryTime = source.expiryDate instanceof Date ? source.expiryDate.getTime() : NaN
-    if (
-      !Number.isFinite(expiryTime) ||
-      this.now() >= expiryTime - this.expiryMarginMs
-    ) {
-      return
+    if (!isYtDlpPlaybackSourceCacheable(source, this.now(), this.expiryMarginMs)) {
+      return false
     }
 
     this.sources.delete(videoId)
@@ -84,16 +95,63 @@ export class YtDlpPlaybackSourceCache {
       this.sources.delete(this.sources.keys().next().value)
     }
     this.sources.set(videoId, { cacheKey, source })
+    return true
+  }
+
+  /**
+   * Returns when a cached source stops being safely reusable without changing
+   * its LRU position.
+   * @param {string} videoId
+   * @param {string} cacheKey
+   * @param {boolean} [requireSubtitles]
+   * @returns {number | null}
+   */
+  getUsableUntil(videoId, cacheKey, requireSubtitles = false) {
+    const entry = this.sources.get(videoId)
+    const expiryTime = entry?.source.expiryDate instanceof Date
+      ? entry.source.expiryDate.getTime()
+      : NaN
+
+    if (
+      entry === undefined ||
+      entry.cacheKey !== cacheKey ||
+      !Number.isFinite(expiryTime) ||
+      this.now() >= expiryTime - this.expiryMarginMs
+    ) {
+      this.sources.delete(videoId)
+      return null
+    }
+
+    if (requireSubtitles && !entry.source.subtitlesIncluded) return null
+
+    return expiryTime - this.expiryMarginMs
+  }
+
+  /**
+   * Expands the session cache for an explicit playlist preload. Automatic
+   * preloading remains within the normal entry limit.
+   * @param {number} entries
+   */
+  ensureCapacity(entries) {
+    if (Number.isInteger(entries) && entries > this.maxEntries) {
+      this.maxEntries = entries
+    }
   }
 
   /**
    * @param {string} videoId
+   * @returns {boolean} whether a source was removed
    */
   delete(videoId) {
-    this.sources.delete(videoId)
+    return this.sources.delete(videoId)
   }
 
+  /**
+   * @returns {boolean} whether any sources were removed
+   */
   clear() {
+    const changed = this.sources.size > 0
     this.sources.clear()
+    return changed
   }
 }

--- a/src/renderer/helpers/player/ytDlpPlaybackPreload.js
+++ b/src/renderer/helpers/player/ytDlpPlaybackPreload.js
@@ -1,0 +1,135 @@
+import { isYtDlpPlaybackSourceCacheable } from './ytDlpPlaybackCache.js'
+
+export const DEFAULT_YT_DLP_PRELOAD_COUNT = 2
+export const MAX_YT_DLP_PRELOAD_COUNT = 10
+export const YT_DLP_PRELOAD_CONCURRENCY = 2
+
+/**
+ * Identifies every setting that can change yt-dlp's extracted stream URLs.
+ * @param {Record<string, unknown>} getters
+ */
+export function buildYtDlpPlaybackCacheKey(getters) {
+  const proxyConfiguration = getters.getUseProxy
+    ? [
+        getters.getProxyProtocol,
+        getters.getProxyHostname,
+        getters.getProxyPort,
+        getters.getProxyUsername,
+        getters.getProxyPassword,
+      ]
+    : []
+
+  return JSON.stringify([
+    'captions-v4',
+    getters.getYtDlpSource,
+    getters.getYtDlpChannel,
+    getters.getYtDlpPath,
+    getters.getUseProxy,
+    ...proxyConfiguration,
+    getters.getYtDlpPlaybackAuthMode,
+    getters.getYtDlpPlaybackCookiesPath,
+    getters.getYtDlpPlaybackCookiesBrowser,
+    getters.getYtDlpPlaybackCookiesBrowserProfile,
+  ])
+}
+
+/**
+ * @param {unknown} value
+ */
+export function normalizeYtDlpPreloadCount(value) {
+  const count = Number(value)
+  if (!Number.isInteger(count) || count <= 0) return 0
+  return Math.min(count, MAX_YT_DLP_PRELOAD_COUNT)
+}
+
+/**
+ * Selects the videos that can actually play next. The watch queue takes
+ * precedence over a playlist, which takes precedence over recommendations.
+ * @param {object} options
+ * @param {string} options.currentVideoId
+ * @param {number} options.limit
+ * @param {{ videoId?: string }[]} options.queuedVideos
+ * @param {{ videoId?: string }[] | null} options.playlistVideos null outside a playlist
+ * @param {{ videoId?: string }[]} options.recommendedVideos
+ */
+export function selectYtDlpPreloadVideoIds({
+  currentVideoId,
+  limit,
+  queuedVideos,
+  playlistVideos,
+  recommendedVideos,
+}) {
+  const normalizedLimit = normalizeYtDlpPreloadCount(limit)
+  if (normalizedLimit === 0) return []
+
+  const candidates = queuedVideos.length > 0
+    ? queuedVideos
+    : playlistVideos !== null
+      ? playlistVideos
+      : recommendedVideos
+  const videoIds = []
+  const seen = new Set([currentVideoId])
+
+  for (const candidate of candidates) {
+    const videoId = candidate?.videoId
+    if (typeof videoId !== 'string' || videoId === '' || seen.has(videoId)) continue
+
+    seen.add(videoId)
+    videoIds.push(videoId)
+    if (videoIds.length === normalizedLimit) break
+  }
+
+  return videoIds
+}
+
+/**
+ * @param {string[]} videoIds
+ * @param {object} options
+ * @param {(videoId: string) => Promise<unknown>} options.loadSource
+ * @param {number} [options.concurrency]
+ * @param {(progress: { requested: number, completed: number, preloaded: number, failed: number }) => void} [options.onProgress]
+ */
+export async function preloadYtDlpPlaybackSources(videoIds, {
+  loadSource,
+  concurrency = YT_DLP_PRELOAD_CONCURRENCY,
+  onProgress = () => {},
+}) {
+  const uniqueVideoIds = [...new Set(videoIds.filter(videoId => typeof videoId === 'string' && videoId !== ''))]
+  let nextIndex = 0
+  let preloaded = 0
+  let failed = 0
+
+  async function worker() {
+    while (nextIndex < uniqueVideoIds.length) {
+      const videoId = uniqueVideoIds[nextIndex++]
+      try {
+        const source = await loadSource(videoId)
+        if (source === null || !isYtDlpPlaybackSourceCacheable(source)) {
+          failed++
+        } else {
+          preloaded++
+        }
+      } catch {
+        failed++
+      }
+      onProgress({
+        requested: uniqueVideoIds.length,
+        completed: preloaded + failed,
+        preloaded,
+        failed,
+      })
+    }
+  }
+
+  const workerCount = Math.min(
+    uniqueVideoIds.length,
+    Math.max(1, Math.floor(concurrency))
+  )
+  await Promise.all(Array.from({ length: workerCount }, worker))
+
+  return {
+    requested: uniqueVideoIds.length,
+    preloaded,
+    failed,
+  }
+}

--- a/src/renderer/helpers/player/ytDlpPlaybackPreload.js
+++ b/src/renderer/helpers/player/ytDlpPlaybackPreload.js
@@ -4,6 +4,31 @@ export const DEFAULT_YT_DLP_PRELOAD_COUNT = 2
 export const MAX_YT_DLP_PRELOAD_COUNT = 10
 export const YT_DLP_PRELOAD_CONCURRENCY = 2
 
+const pendingPreloadTasks = []
+let activePreloadTasks = 0
+
+function startPendingPreloadTasks() {
+  while (activePreloadTasks < YT_DLP_PRELOAD_CONCURRENCY && pendingPreloadTasks.length > 0) {
+    const task = pendingPreloadTasks.shift()
+    activePreloadTasks++
+
+    Promise.resolve()
+      .then(task.loadSource)
+      .then(task.resolve, task.reject)
+      .finally(() => {
+        activePreloadTasks--
+        startPendingPreloadTasks()
+      })
+  }
+}
+
+function scheduleYtDlpPlaybackPreload(loadSource) {
+  return new Promise((resolve, reject) => {
+    pendingPreloadTasks.push({ loadSource, resolve, reject })
+    startPendingPreloadTasks()
+  })
+}
+
 /**
  * Identifies every setting that can change yt-dlp's extracted stream URLs.
  * @param {Record<string, unknown>} getters
@@ -103,7 +128,7 @@ export async function preloadYtDlpPlaybackSources(videoIds, {
     while (nextIndex < uniqueVideoIds.length) {
       const videoId = uniqueVideoIds[nextIndex++]
       try {
-        const source = await loadSource(videoId)
+        const source = await scheduleYtDlpPlaybackPreload(() => loadSource(videoId))
         if (source === null || !isYtDlpPlaybackSourceCacheable(source)) {
           failed++
         } else {

--- a/src/renderer/helpers/player/ytDlpPlaybackPreloadProgress.js
+++ b/src/renderer/helpers/player/ytDlpPlaybackPreloadProgress.js
@@ -1,0 +1,59 @@
+const operationsByStore = new WeakMap()
+
+function showProgress(store, progress) {
+  store.commit('setProgressBarIcon', progress.icon)
+  store.commit('setProgressBarMessage', progress.message)
+  store.commit('setProgressBarPercentage', progress.percentage)
+  store.commit('setShowProgressBar', true)
+}
+
+function clearProgress(store) {
+  store.commit('setShowProgressBar', false)
+  store.commit('setProgressBarPercentage', 0)
+  store.commit('setProgressBarMessage', '')
+  store.commit('setProgressBarIcon', ['fas', 'sync'])
+}
+
+/**
+ * Keeps the most recently started playlist preload visible while allowing an
+ * earlier preload to resume ownership if the newer one finishes first.
+ * @param {{ commit: (mutation: string, value: unknown) => void }} store
+ * @param {{ icon: string[], message: string, percentage: number }} initialProgress
+ * @returns {{
+ *   update: (progress: { icon?: string[], message?: string, percentage?: number }) => void,
+ *   finish: () => void,
+ * }}
+ */
+export function startYtDlpPlaybackPreloadProgress(store, initialProgress) {
+  const operations = operationsByStore.get(store) ?? []
+  operationsByStore.set(store, operations)
+
+  const operation = { ...initialProgress }
+  operations.push(operation)
+  showProgress(store, operation)
+
+  return {
+    update(progress) {
+      Object.assign(operation, progress)
+      if (operations.at(-1) === operation) {
+        showProgress(store, operation)
+      }
+    },
+    finish() {
+      const operationIndex = operations.indexOf(operation)
+      if (operationIndex === -1) return
+
+      const wasVisible = operationIndex === operations.length - 1
+      operations.splice(operationIndex, 1)
+      if (!wasVisible) return
+
+      const previousOperation = operations.at(-1)
+      if (previousOperation == null) {
+        operationsByStore.delete(store)
+        clearProgress(store)
+      } else {
+        showProgress(store, previousOperation)
+      }
+    },
+  }
+}

--- a/src/renderer/helpers/progressBar.js
+++ b/src/renderer/helpers/progressBar.js
@@ -15,8 +15,8 @@ function clearProgress(store) {
 }
 
 /**
- * Keeps the most recently started playlist preload visible while allowing an
- * earlier preload to resume ownership if the newer one finishes first.
+ * Keeps the most recently started operation visible while allowing an earlier
+ * operation to resume ownership if the newer one finishes first.
  * @param {{ commit: (mutation: string, value: unknown) => void }} store
  * @param {{ icon: string[], message: string, percentage: number }} initialProgress
  * @returns {{
@@ -24,7 +24,7 @@ function clearProgress(store) {
  *   finish: () => void,
  * }}
  */
-export function startYtDlpPlaybackPreloadProgress(store, initialProgress) {
+export function startProgressBarOperation(store, initialProgress) {
   const operations = operationsByStore.get(store) ?? []
   operationsByStore.set(store, operations)
 

--- a/src/renderer/store/modules/settings.js
+++ b/src/renderer/store/modules/settings.js
@@ -34,6 +34,7 @@ import {
   TUTORIAL_AUDIENCE_SETTING_ID,
 } from '../../helpers/tutorialState.js'
 import { DEFAULT_YT_DLP_PLAYBACK_CACHE_MAX_ENTRY_SIZE_MB } from '../../../ytDlpPlaybackCacheSettings.js'
+import { DEFAULT_YT_DLP_PRELOAD_COUNT } from '../../helpers/player/ytDlpPlaybackPreload.js'
 import { terminateCommentTranslationLanguageDetector } from '../../helpers/comment-translations'
 import { DEFAULT_HOME_SECTION_LAYOUT } from '../../helpers/homeSections.js'
 import { isSettingSyncableOnPlatform } from '../../helpers/platformSettings.js'
@@ -279,6 +280,8 @@ const state = {
   ytDlpPlaybackCookiesBrowserProfile: '',
   ytDlpPlaybackAlwaysUseCookies: false,
   ytDlpPlaybackCacheMaxEntrySize: DEFAULT_YT_DLP_PLAYBACK_CACHE_MAX_ENTRY_SIZE_MB,
+  ytDlpPreloadEnabled: false,
+  ytDlpPreloadCount: DEFAULT_YT_DLP_PRELOAD_COUNT,
   ytDlpFfmpegSource: 'system',
   ytDlpFfmpegPath: '',
   externalSoftwareUpdateMode: 'automatic',

--- a/src/renderer/views/Playlist/Playlist.vue
+++ b/src/renderer/views/Playlist/Playlist.vue
@@ -336,6 +336,7 @@ const playlistBookmarkPending = ref(false)
 const playlistPreloadPending = ref(false)
 const playlistPreloadComplete = ref(false)
 let playlistPreloadExpiryTimer = null
+let playlistPreloadRun = null
 /** @type {AbortController | null} */
 let undoToastAbortController = null
 let removePendingVideosAfterDrag = false
@@ -546,6 +547,8 @@ async function preloadPlaylist() {
     message: t('Playlist.Preloading Playlist'),
     percentage: 0,
   })
+  const preloadRun = { progressOperation }
+  playlistPreloadRun = preloadRun
   try {
     while (!isUserPlaylistRequested.value && moreVideoDataAvailable.value && nextPageError.value === '') {
       if (isLoadingMore.value) {
@@ -618,9 +621,20 @@ async function preloadPlaylist() {
       icon: result.failed === 0 ? ['fas', 'check'] : ['fas', 'circle-exclamation'],
     })
   } finally {
-    playlistPreloadPending.value = false
     progressOperation.finish()
+    if (playlistPreloadRun === preloadRun) {
+      playlistPreloadRun = null
+      playlistPreloadPending.value = false
+    }
   }
+}
+
+function releasePlaylistPreloadUi() {
+  if (playlistPreloadRun === null) return
+
+  playlistPreloadRun.progressOperation.finish()
+  playlistPreloadRun = null
+  playlistPreloadPending.value = false
 }
 
 /** @type {import('vue').ComputedRef<string | undefined>} */
@@ -773,6 +787,7 @@ const getPlaylistInfoDebounce = debounce(getPlaylistInfo, 100)
 
 function resetState() {
   playlistRequestGeneration++
+  releasePlaylistPreloadUi()
   clearPlaylistPreloadComplete()
   isLoading.value = true
   playlistTitle.value = ''
@@ -1565,6 +1580,7 @@ onMounted(() => {
 
 onBeforeUnmount(() => {
   playlistRequestGeneration++
+  releasePlaylistPreloadUi()
   clearPlaylistPreloadComplete()
   removePlaybackSourceCacheChangeListener()
   window.removeEventListener('resize', handleResize)

--- a/src/renderer/views/Playlist/Playlist.vue
+++ b/src/renderer/views/Playlist/Playlist.vue
@@ -57,6 +57,9 @@
         :more-video-data-available="moreVideoDataAvailable"
         :is-playlist-bookmarked="isPlaylistBookmarked"
         :playlist-bookmark-pending="playlistBookmarkPending"
+        :preload-available="playlistPreloadAvailable"
+        :preload-pending="playlistPreloadPending"
+        :preload-complete="playlistPreloadComplete"
         :search-video-mode-allowed="isUserPlaylistRequested && shownVideoCount > 1"
         :search-query-text="searchQueryTextRequested"
         :theme="listType === 'list' ? 'base' : 'top-bar'"
@@ -68,6 +71,7 @@
         @prompt-open="promptOpen = true"
         @prompt-close="promptOpen = false"
         @toggle-playlist-bookmark="togglePlaylistBookmark"
+        @preload-playlist="preloadPlaylist"
       />
     </div>
 
@@ -251,6 +255,14 @@ import { runRetryablePlaylistRequest } from '../../helpers/playlist-pagination'
 import { formatDate } from '../../helpers/dateFormat'
 import { canonicalPlaylistThumbnailUrl, createPlaylistBookmark } from '../../helpers/playlist-bookmarks'
 import { fillMissingPlaylistVideoDurations, getSortedPlaylistItems, SORT_BY_VALUES } from '../../helpers/playlists'
+import { hasConfiguredRestrictedPlaybackAuthentication } from '../../helpers/restricted-playback'
+import {
+  getYtDlpPlaybackSource,
+  getYtDlpPlaybackSourcesUsableUntil,
+  onYtDlpPlaybackSourceCacheChange,
+  reserveYtDlpPlaybackSourceCache,
+} from '../../helpers/player/ytDlpPlayback'
+import { buildYtDlpPlaybackCacheKey, preloadYtDlpPlaybackSources } from '../../helpers/player/ytDlpPlaybackPreload'
 import { MOBILE_WIDTH_THRESHOLD, PLAYLIST_HEIGHT_FORCE_LIST_THRESHOLD } from '../../../constants'
 import { useTabContext, useTabLifecycle, useTabTitle } from '../../tabs/TabContext'
 import { useTabToast } from '../../composables/useTabToast'
@@ -320,6 +332,9 @@ const toBeDeletedPlaylistItemIds = ref([])
 const videosWithPlaylistToUnset = ref([])
 const pendingDeletionRemovalInProgress = ref(false)
 const playlistBookmarkPending = ref(false)
+const playlistPreloadPending = ref(false)
+const playlistPreloadComplete = ref(false)
+let playlistPreloadExpiryTimer = null
 /** @type {AbortController | null} */
 let undoToastAbortController = null
 let removePendingVideosAfterDrag = false
@@ -329,6 +344,54 @@ const backendPreference = computed(() => store.getters.getBackendPreference)
 
 /** @type {import('vue').ComputedRef<boolean>} */
 const backendFallback = computed(() => store.getters.getBackendFallback)
+
+const playlistPreloadAvailable = computed(() => {
+  return process.env.IS_ELECTRON && store.getters.getVideoPlaybackEngine === 'yt-dlp'
+})
+
+const playlistPreloadVideoIds = computed(() => [...new Set(playlistItems.value
+  .map(video => video.videoId)
+  .filter(videoId => typeof videoId === 'string' && videoId !== ''))])
+const playlistPreloadVideoIdsKey = computed(() => playlistPreloadVideoIds.value.join('\0'))
+const ytDlpPlaybackCacheKey = computed(() => buildYtDlpPlaybackCacheKey(store.getters))
+const ytDlpPlaybackUseAuthentication = computed(() =>
+  store.getters.getYtDlpPlaybackAlwaysUseCookies &&
+  hasConfiguredRestrictedPlaybackAuthentication(store.getters)
+)
+
+function clearPlaylistPreloadComplete() {
+  clearTimeout(playlistPreloadExpiryTimer)
+  playlistPreloadExpiryTimer = null
+  playlistPreloadComplete.value = false
+}
+
+function refreshPlaylistPreloadComplete() {
+  clearTimeout(playlistPreloadExpiryTimer)
+  playlistPreloadExpiryTimer = null
+
+  if (isLoading.value || playlistPreloadHasUnknownVideos.value) {
+    playlistPreloadComplete.value = false
+    return
+  }
+
+  const usableUntil = getYtDlpPlaybackSourcesUsableUntil(
+    playlistPreloadVideoIds.value,
+    ytDlpPlaybackCacheKey.value,
+    ytDlpPlaybackUseAuthentication.value
+  )
+  playlistPreloadComplete.value = usableUntil !== null
+  if (usableUntil === null) return
+
+  const delay = Math.min(
+    Math.max(usableUntil - Date.now() + 1, 0),
+    2_147_483_647
+  )
+  playlistPreloadExpiryTimer = setTimeout(refreshPlaylistPreloadComplete, delay)
+}
+
+const removePlaybackSourceCacheChangeListener = onYtDlpPlaybackSourceCacheChange(() => {
+  refreshPlaylistPreloadComplete()
+})
 
 /** @type {import('vue').ComputedRef<string>} */
 const currentInvidiousInstanceUrl = computed(() => store.getters.getCurrentInvidiousInstanceUrl)
@@ -399,6 +462,25 @@ const searchQueryTextPresent = computed(() => {
 
 const isUserPlaylistRequested = computed(() => route.query.playlistType === 'user')
 
+const playlistPreloadHasUnknownVideos = computed(() =>
+  !isUserPlaylistRequested.value && (
+    infoSource.value === 'invidious'
+      ? nextInvidiousPlaylistPage.value !== null
+      : continuationData.value !== null
+  )
+)
+
+watch(
+  [
+    playlistPreloadVideoIdsKey,
+    ytDlpPlaybackCacheKey,
+    ytDlpPlaybackUseAuthentication,
+    isLoading,
+    playlistPreloadHasUnknownVideos,
+  ],
+  refreshPlaylistPreloadComplete
+)
+
 const isPlaylistBookmarked = computed(() => {
   return !isUserPlaylistRequested.value && store.getters.getPlaylistBookmark(playlistId.value) != null
 })
@@ -450,6 +532,91 @@ async function togglePlaylistBookmark() {
     }
   } finally {
     playlistBookmarkPending.value = false
+  }
+}
+
+async function preloadPlaylist() {
+  if (!playlistPreloadAvailable.value || playlistPreloadPending.value || playlistPreloadComplete.value) return
+
+  const requestGeneration = playlistRequestGeneration
+  playlistPreloadPending.value = true
+  store.commit('setProgressBarIcon', ['fas', 'forward'])
+  store.commit('setProgressBarMessage', t('Playlist.Preloading Playlist'))
+  store.commit('setProgressBarPercentage', 0)
+  store.commit('setShowProgressBar', true)
+  try {
+    while (!isUserPlaylistRequested.value && moreVideoDataAvailable.value && nextPageError.value === '') {
+      if (isLoadingMore.value) {
+        await new Promise(resolve => {
+          const stop = watch(isLoadingMore, loading => {
+            if (!loading) {
+              stop()
+              resolve()
+            }
+          })
+        })
+        if (requestGeneration !== playlistRequestGeneration) return
+        if (!moreVideoDataAvailable.value || nextPageError.value !== '') break
+      }
+
+      await getNextPage()
+      if (requestGeneration !== playlistRequestGeneration) return
+    }
+
+    if (!isUserPlaylistRequested.value && moreVideoDataAvailable.value) {
+      showTabToast({
+        message: t('Playlist.Playlist Preload Pagination Failed'),
+        icon: ['fas', 'circle-exclamation'],
+      })
+      return
+    }
+
+    const videoIds = playlistPreloadVideoIds.value
+    store.commit('setProgressBarMessage', t('Playlist.Playlist Preload Progress', {
+      completed: 0,
+      requested: videoIds.length,
+    }))
+    reserveYtDlpPlaybackSourceCache(videoIds.length)
+
+    const cacheKey = ytDlpPlaybackCacheKey.value
+    const result = await preloadYtDlpPlaybackSources(videoIds, {
+      loadSource: videoId => getYtDlpPlaybackSource(
+        videoId,
+        cacheKey,
+        undefined,
+        ytDlpPlaybackUseAuthentication.value,
+        false,
+        true
+      ),
+      onProgress: progress => {
+        if (requestGeneration !== playlistRequestGeneration) return
+
+        store.commit('setProgressBarMessage', t('Playlist.Playlist Preload Progress', progress))
+        store.commit('setProgressBarPercentage', progress.requested === 0
+          ? 0
+          : progress.completed / progress.requested * 100)
+      },
+    })
+    if (requestGeneration !== playlistRequestGeneration) return
+
+    if (result.requested > 0 && result.failed === 0) {
+      refreshPlaylistPreloadComplete()
+    } else {
+      clearPlaylistPreloadComplete()
+    }
+
+    showTabToast({
+      message: result.failed === 0
+        ? t('Playlist.Playlist Preload Complete', { count: result.preloaded })
+        : t('Playlist.Playlist Preload Partial', result),
+      icon: result.failed === 0 ? ['fas', 'check'] : ['fas', 'circle-exclamation'],
+    })
+  } finally {
+    playlistPreloadPending.value = false
+    store.commit('setShowProgressBar', false)
+    store.commit('setProgressBarPercentage', 0)
+    store.commit('setProgressBarMessage', '')
+    store.commit('setProgressBarIcon', ['fas', 'sync'])
   }
 }
 
@@ -603,6 +770,7 @@ const getPlaylistInfoDebounce = debounce(getPlaylistInfo, 100)
 
 function resetState() {
   playlistRequestGeneration++
+  clearPlaylistPreloadComplete()
   isLoading.value = true
   playlistTitle.value = ''
   playlistDescription.value = ''
@@ -1394,6 +1562,8 @@ onMounted(() => {
 
 onBeforeUnmount(() => {
   playlistRequestGeneration++
+  clearPlaylistPreloadComplete()
+  removePlaybackSourceCacheChangeListener()
   window.removeEventListener('resize', handleResize)
 })
 

--- a/src/renderer/views/Playlist/Playlist.vue
+++ b/src/renderer/views/Playlist/Playlist.vue
@@ -263,6 +263,7 @@ import {
   reserveYtDlpPlaybackSourceCache,
 } from '../../helpers/player/ytDlpPlayback'
 import { buildYtDlpPlaybackCacheKey, preloadYtDlpPlaybackSources } from '../../helpers/player/ytDlpPlaybackPreload'
+import { startYtDlpPlaybackPreloadProgress } from '../../helpers/player/ytDlpPlaybackPreloadProgress'
 import { MOBILE_WIDTH_THRESHOLD, PLAYLIST_HEIGHT_FORCE_LIST_THRESHOLD } from '../../../constants'
 import { useTabContext, useTabLifecycle, useTabTitle } from '../../tabs/TabContext'
 import { useTabToast } from '../../composables/useTabToast'
@@ -540,10 +541,11 @@ async function preloadPlaylist() {
 
   const requestGeneration = playlistRequestGeneration
   playlistPreloadPending.value = true
-  store.commit('setProgressBarIcon', ['fas', 'forward'])
-  store.commit('setProgressBarMessage', t('Playlist.Preloading Playlist'))
-  store.commit('setProgressBarPercentage', 0)
-  store.commit('setShowProgressBar', true)
+  const progressOperation = startYtDlpPlaybackPreloadProgress(store, {
+    icon: ['fas', 'forward'],
+    message: t('Playlist.Preloading Playlist'),
+    percentage: 0,
+  })
   try {
     while (!isUserPlaylistRequested.value && moreVideoDataAvailable.value && nextPageError.value === '') {
       if (isLoadingMore.value) {
@@ -572,10 +574,12 @@ async function preloadPlaylist() {
     }
 
     const videoIds = playlistPreloadVideoIds.value
-    store.commit('setProgressBarMessage', t('Playlist.Playlist Preload Progress', {
-      completed: 0,
-      requested: videoIds.length,
-    }))
+    progressOperation.update({
+      message: t('Playlist.Playlist Preload Progress', {
+        completed: 0,
+        requested: videoIds.length,
+      }),
+    })
     reserveYtDlpPlaybackSourceCache(videoIds.length)
 
     const cacheKey = ytDlpPlaybackCacheKey.value
@@ -588,13 +592,15 @@ async function preloadPlaylist() {
         false,
         true
       ),
-      onProgress: progress => {
+      onProgress: preloadProgress => {
         if (requestGeneration !== playlistRequestGeneration) return
 
-        store.commit('setProgressBarMessage', t('Playlist.Playlist Preload Progress', progress))
-        store.commit('setProgressBarPercentage', progress.requested === 0
-          ? 0
-          : progress.completed / progress.requested * 100)
+        progressOperation.update({
+          message: t('Playlist.Playlist Preload Progress', preloadProgress),
+          percentage: preloadProgress.requested === 0
+            ? 0
+            : preloadProgress.completed / preloadProgress.requested * 100,
+        })
       },
     })
     if (requestGeneration !== playlistRequestGeneration) return
@@ -613,10 +619,7 @@ async function preloadPlaylist() {
     })
   } finally {
     playlistPreloadPending.value = false
-    store.commit('setShowProgressBar', false)
-    store.commit('setProgressBarPercentage', 0)
-    store.commit('setProgressBarMessage', '')
-    store.commit('setProgressBarIcon', ['fas', 'sync'])
+    progressOperation.finish()
   }
 }
 

--- a/src/renderer/views/Playlist/Playlist.vue
+++ b/src/renderer/views/Playlist/Playlist.vue
@@ -263,7 +263,7 @@ import {
   reserveYtDlpPlaybackSourceCache,
 } from '../../helpers/player/ytDlpPlayback'
 import { buildYtDlpPlaybackCacheKey, preloadYtDlpPlaybackSources } from '../../helpers/player/ytDlpPlaybackPreload'
-import { startYtDlpPlaybackPreloadProgress } from '../../helpers/player/ytDlpPlaybackPreloadProgress'
+import { startProgressBarOperation } from '../../helpers/progressBar'
 import { MOBILE_WIDTH_THRESHOLD, PLAYLIST_HEIGHT_FORCE_LIST_THRESHOLD } from '../../../constants'
 import { useTabContext, useTabLifecycle, useTabTitle } from '../../tabs/TabContext'
 import { useTabToast } from '../../composables/useTabToast'
@@ -541,7 +541,7 @@ async function preloadPlaylist() {
 
   const requestGeneration = playlistRequestGeneration
   playlistPreloadPending.value = true
-  const progressOperation = startYtDlpPlaybackPreloadProgress(store, {
+  const progressOperation = startProgressBarOperation(store, {
     icon: ['fas', 'forward'],
     message: t('Playlist.Preloading Playlist'),
     percentage: 0,

--- a/src/renderer/views/Watch/Watch.js
+++ b/src/renderer/views/Watch/Watch.js
@@ -77,6 +77,11 @@ import {
   MANIFEST_TYPE_HLS
 } from '../../helpers/player/utils'
 import { getYtDlpPlaybackSource, invalidateYtDlpPlaybackSource } from '../../helpers/player/ytDlpPlayback'
+import {
+  buildYtDlpPlaybackCacheKey,
+  preloadYtDlpPlaybackSources,
+  selectYtDlpPreloadVideoIds,
+} from '../../helpers/player/ytDlpPlaybackPreload'
 import { getMusicTrackArtist, MUSIC_MEDIA_TYPE } from '../../helpers/player/musicMediaType'
 import { selectSponsorBlockFullVideoLabel } from '../../helpers/player/sponsorBlockFullVideo'
 import {
@@ -379,6 +384,7 @@ export default defineComponent({
       autoplayNextRecommendedVideo: false,
       autoplayNextPlaylistVideo: false,
       recommendedVideos: [],
+      upcomingPlaylistVideos: [],
       watchingPlaylist: false,
       playlistSkipAvailability: { canPlayNext: true, canPlayPrevious: true },
       playlistId: '',
@@ -601,30 +607,7 @@ export default defineComponent({
       return this.$store.getters.getProxyVideos
     },
     ytDlpPlaybackCacheKey: function () {
-      const getters = this.$store.getters
-      const proxyConfiguration = getters.getUseProxy
-        ? [
-            getters.getProxyProtocol,
-            getters.getProxyHostname,
-            getters.getProxyPort,
-            getters.getProxyUsername,
-            getters.getProxyPassword
-          ]
-        : []
-
-      // Older cached sources do not record whether yt-dlp checked for subtitles.
-      return JSON.stringify([
-        'captions-v4',
-        getters.getYtDlpSource,
-        getters.getYtDlpChannel,
-        getters.getYtDlpPath,
-        getters.getUseProxy,
-        ...proxyConfiguration,
-        getters.getYtDlpPlaybackAuthMode,
-        getters.getYtDlpPlaybackCookiesPath,
-        getters.getYtDlpPlaybackCookiesBrowser,
-        getters.getYtDlpPlaybackCookiesBrowserProfile
-      ])
+      return buildYtDlpPlaybackCacheKey(this.$store.getters)
     },
     hasConfiguredRestrictedPlaybackAuthentication: function () {
       return hasConfiguredRestrictedPlaybackAuthentication(this.$store.getters)
@@ -912,6 +895,27 @@ export default defineComponent({
     nextQueuedVideo: function () {
       return this.$store.getters.getNextQueuedVideo
     },
+    upcomingYtDlpPreloadVideoIds: function () {
+      if (
+        !process.env.IS_ELECTRON ||
+        this.videoPlaybackEngine !== 'yt-dlp' ||
+        !this.$store.getters.getYtDlpPreloadEnabled
+      ) return []
+
+      const recommendedVideos = this.hideRecommendedVideos
+        ? []
+        : this.recommendedVideos.filter(video =>
+            !this.isHiddenVideo(this.forbiddenTitles, this.channelsHidden, video)
+          )
+
+      return selectYtDlpPreloadVideoIds({
+        currentVideoId: this.videoId,
+        limit: this.$store.getters.getYtDlpPreloadCount,
+        queuedVideos: this.$store.getters.getWatchQueue,
+        playlistVideos: this.watchingPlaylist ? this.upcomingPlaylistVideos : null,
+        recommendedVideos,
+      })
+    },
     thumbnailPreference: function () {
       return this.$store.getters.getThumbnailPreference
     },
@@ -1186,6 +1190,12 @@ export default defineComponent({
     canSkipToPreviousVideo() {
       this.syncMediaSessionSkipHandlers()
     },
+    upcomingYtDlpPreloadVideoIds: {
+      immediate: true,
+      handler(videoIds) {
+        this.preloadUpcomingYtDlpPlaybackSources(videoIds)
+      }
+    },
   },
   created: function () {
     this.theatreModeAnimations = []
@@ -1252,6 +1262,25 @@ export default defineComponent({
     }
   },
   methods: {
+    handleUpcomingPlaylistVideosChange(videos) {
+      this.upcomingPlaylistVideos = Array.isArray(videos) ? videos : []
+    },
+    preloadUpcomingYtDlpPlaybackSources(videoIds) {
+      if (videoIds.length === 0) return
+
+      preloadYtDlpPlaybackSources(videoIds, {
+        loadSource: videoId => getYtDlpPlaybackSource(
+          videoId,
+          this.ytDlpPlaybackCacheKey,
+          undefined,
+          this.alwaysUseYtDlpPlaybackCookies,
+          false,
+          true
+        )
+      }).catch(error => {
+        console.warn('Could not preload upcoming yt-dlp playback sources', error)
+      })
+    },
     updateUpcomingTimestamp: function () {
       if (!(this.premiereDate instanceof Date)) return
 

--- a/src/renderer/views/Watch/Watch.vue
+++ b/src/renderer/views/Watch/Watch.vue
@@ -1015,6 +1015,7 @@
           @close="closeFullscreenPlaylist"
           @pause-player="pausePlayer"
           @skip-availability-change="handlePlaylistSkipAvailabilityChange"
+          @upcoming-videos-change="handleUpcomingPlaylistVideosChange"
         />
       </Teleport>
       <watch-video-recommendations

--- a/static/locales/ai/ar.yaml
+++ b/static/locales/ai/ar.yaml
@@ -508,6 +508,8 @@ Settings:
     Parallel Segment Loading: تحميل القطاع الموازي
     Rotate Wide Videos to Landscape in Fullscreen: 'تدوير مقاطع الفيديو العريضة إلى الوضع الأفقي في ملء الشاشة'
     Swipe Up or Down to Enter or Exit Fullscreen: 'اسحب لأعلى أو لأسفل للدخول إلى ملء الشاشة أو الخروج منها'
+    Preload Upcoming Videos: "تحميل الفيديوهات القادمة مسبقًا"
+    Upcoming Videos to Preload: "عدد الفيديوهات المراد تحميلها مسبقًا"
   Channel Settings:
     Channel Settings: إعدادات القناة
     Channel Settings Description: تذكر الإعدادات التي تختارها أثناء المشاهدة لكل قناة على حدة، بحيث يتم تطبيقها مرة أخرى في المرة التالية التي تشاهد فيها أحد مقاطع الفيديو الخاصة بها.
@@ -1205,7 +1207,14 @@ Video:
       DownvoteSegment: التصويت السلبي
       VoteFailed: فشل إرسال تصويت SponsorBlock.
 Playlist:
+  Playlist Already Preloaded: "تم تحميل جميع فيديوهات قائمة التشغيل مسبقًا بالفعل"
+  Playlist Preload Progress: "جارٍ تحميل الفيديوهات مسبقًا: {completed} من {requested}"
   Close Playlist: إغلاق قائمة التشغيل
+  Preload Playlist: "تحميل كل الفيديوهات مسبقًا"
+  Preloading Playlist: "جارٍ تحميل كل الفيديوهات مسبقًا..."
+  Playlist Preload Complete: "الفيديوهات المحمّلة مسبقًا: {count}."
+  Playlist Preload Partial: "تم تحميل {preloaded} من أصل {requested} فيديو مسبقًا. تعذر تحميل {failed}."
+  Playlist Preload Pagination Failed: "تعذر تحميل قائمة التشغيل كاملة، لذا أُلغي التحميل المسبق."
 Change Format:
   Local Video File: ملف فيديو محلي
   Local Audio File: ملف صوتي محلي
@@ -1387,6 +1396,8 @@ Tooltips:
     Ambient Mode: يمزج ألوان الفيديو في المنطقة المحيطة بالمشغل.
     Default Volume: تم تعطيله أثناء تمكين تذكر مستوى الصوت. قم بإيقاف تشغيل تذكر مستوى الصوت لتعيين مستوى صوت ثابت لبدء التشغيل لكل فيديو.
     Parallel Segment Loading: "عدد مقاطع الفيديو والصوت التي سيتم تحميلها مرة واحدة قبل التشغيل.\nقد تساعد القيم الأعلى في الاتصالات البطيئة أو غير المستقرة، ولكنها تستخدم المزيد من النطاق الترددي والذاكرة.\nوقد يجعلون أيضًا Auto يقلل من سرعة الاتصال ويحدد جودة أقل.\nتتجاهل التدفقات التي تقتصر على طلب واحد في كل مرة هذا الإعداد."
+    Preload Upcoming Videos: "يجلب روابط بث yt-dlp للفيديوهات التالية ويخزنها مؤقتًا. لقائمة الانتظار الأولوية على قوائم التشغيل والاقتراحات."
+    Upcoming Videos to Preload: "الحد الأقصى لعدد الفيديوهات القادمة التي تُجلب روابط بثها في الخلفية."
   Download Settings:
     Download Folder: يتم حفظ مقاطع الفيديو في هذا المجلد. اتركه فارغًا لاستخدام مجلد التنزيلات الخاص بنظامك.
     Global Additional yt-dlp Arguments: يتم تمرير وسيطات سطر الأوامر الإضافية إلى yt-dlp لكل عملية تنزيل، على سبيل المثال --cookies-from-browser Firefox.

--- a/static/locales/ai/be.yaml
+++ b/static/locales/ai/be.yaml
@@ -530,6 +530,8 @@ Settings:
         Clipboard: Скапіраваць у буфер абмену
     Rotate Wide Videos to Landscape in Fullscreen: 'Паварочваць шырокія відэа гарызантальна ў поўнаэкранным рэжыме'
     Swipe Up or Down to Enter or Exit Fullscreen: 'Правядзіце ўверх або ўніз, каб увайсці ў поўнаэкранны рэжым або выйсці з яго'
+    Preload Upcoming Videos: "Папярэдне загружаць наступныя відэа"
+    Upcoming Videos to Preload: "Колькасць відэа для папярэдняй загрузкі"
   Channel Settings:
     Channel Settings: Налады каналаў
     Channel Settings Description: Запамінаць асобныя налады, абраныя падчас прагляду кожнага канала, і ўжываць іх пры наступным праглядзе відэа з гэтага канала.
@@ -1252,7 +1254,14 @@ Video:
     'Remaining preroll-ad time: {remindingTimeSeconds}s': 'Да канца рэкламы перад відэа: {remindingTimeSeconds} с'
     'Remaining SABR backoff time: {remindingTimeSeconds}s': 'Да паўторнай спробы SABR: {remindingTimeSeconds} с'
 Playlist:
+  Playlist Already Preloaded: "Усе відэа плэйліста ўжо папярэдне загружаны"
+  Playlist Preload Progress: "Папярэдняя загрузка відэа: {completed} з {requested}"
   Close Playlist: Закрыць спіс прайгравання
+  Preload Playlist: "Папярэдне загрузіць усе відэа"
+  Preloading Playlist: "Папярэдняя загрузка ўсіх відэа..."
+  Playlist Preload Complete: "Папярэдне загружана відэа: {count}."
+  Playlist Preload Partial: "Папярэдне загружана {preloaded} з {requested} відэа. Не ўдалося загрузіць {failed}."
+  Playlist Preload Pagination Failed: "Не ўдалося загрузіць увесь плэйліст, таму папярэдняя загрузка скасавана."
 Change Format:
   Local Video File: Лакальны відэафайл
   Local Audio File: Лакальны аўдыяфайл
@@ -1453,6 +1462,8 @@ Tooltips:
       Большыя значэнні могуць дапамагчы пры павольным або нестабільным злучэнні, але патрабуюць больш прапускной здольнасці і памяці.
       Таксама праз іх аўтаматычная ацэнка можа занізіць хуткасць злучэння і выбраць ніжэйшую якасць.
       Плыні з абмежаваннем у адзін адначасовы запыт не ўлічваюць гэтую наладу.
+    Preload Upcoming Videos: "Атрымлівае і кэшуе спасылкі yt-dlp для наступных відэа. Чарга мае прыярытэт над плэйлістамі і рэкамендацыямі."
+    Upcoming Videos to Preload: "Максімальная колькасць наступных відэа, спасылкі на якія атрымліваюцца ў фоне."
   Download Settings:
     Download Folder: Відэа захоўваюцца ў гэтай папцы. Пакіньце поле пустым, каб выкарыстоўваць сістэмную папку «Спампоўванні».
     Global Additional yt-dlp Arguments: Дадатковыя аргументы каманднага радка, якія перадаюцца yt-dlp пры кожным спампоўванні, напрыклад --cookies-from-browser firefox.

--- a/static/locales/ai/bg.yaml
+++ b/static/locales/ai/bg.yaml
@@ -502,6 +502,8 @@ Settings:
     Parallel Segment Loading: Паралелно зареждане на сегменти
     Rotate Wide Videos to Landscape in Fullscreen: 'Завъртане на широките видеоклипове хоризонтално на цял екран'
     Swipe Up or Down to Enter or Exit Fullscreen: 'Плъзнете нагоре или надолу за включване или изключване на цял екран'
+    Preload Upcoming Videos: "Предварително зареждане на следващите видеа"
+    Upcoming Videos to Preload: "Брой видеа за предварително зареждане"
   Channel Settings:
     Channel Settings: Настройки за каналите
     Channel Settings Description: Запомняне на избраните при гледане настройки поотделно за всеки канал, за да бъдат приложени отново следващия път, когато гледате негов видеоклип.
@@ -1186,7 +1188,14 @@ Video:
       DownvoteSegment: Гласуване „против“
       VoteFailed: Гласът в SponsorBlock не можа да бъде изпратен.
 Playlist:
+  Playlist Already Preloaded: "Всички видеоклипове в плейлиста вече са предварително заредени"
+  Playlist Preload Progress: "Предварително зареждане на видеоклипове: {completed} от {requested}"
   Close Playlist: Затваряне на плейлиста
+  Preload Playlist: "Предварително зареждане на всички видеа"
+  Preloading Playlist: "Предварително зареждане на всички видеа..."
+  Playlist Preload Complete: "Предварително заредени видеа: {count}."
+  Playlist Preload Partial: "Предварително заредени са {preloaded} от {requested} видеа. {failed} не можаха да се заредят."
+  Playlist Preload Pagination Failed: "Пълният плейлист не можа да се зареди и предварителното зареждане бе отменено."
 Change Format:
   Local Video File: Локален видеофайл
   Local Audio File: Локален аудиофайл
@@ -1383,6 +1392,8 @@ Tooltips:
       По-високите стойности може да помогнат при бавна или нестабилна връзка, но използват повече трафик и памет.
       Те може също да накарат автоматичния режим да подцени скоростта на връзката и да избере по-ниско качество.
       Потоците, ограничени до една заявка наведнъж, пренебрегват тази настройка.
+    Preload Upcoming Videos: "Извлича и кешира yt-dlp адресите за следващите видеа. Опашката е с приоритет пред плейлистите и препоръките."
+    Upcoming Videos to Preload: "Максималният брой предстоящи видеа, чиито yt-dlp адреси се извличат във фонов режим."
   Download Settings:
     Download Folder: Видеоклиповете се запазват в тази папка. Оставете празно, за да използвате системната папка за изтегляния.
     Global Additional yt-dlp Arguments: Допълнителни аргументи от командния ред, подавани на yt-dlp при всяко изтегляне, например --cookies-from-browser firefox.

--- a/static/locales/ai/br.yaml
+++ b/static/locales/ai/br.yaml
@@ -500,6 +500,8 @@ Settings:
     Parallel Segment Loading: "Kargañ ar rannoù a-stroll"
     Rotate Wide Videos to Landscape in Fullscreen: 'C’hwelañ ar videoioù ledan d’ar mod gweledva er skramm leun'
     Swipe Up or Down to Enter or Exit Fullscreen: 'Riklañ war-grec’h pe war-draoñ evit mont er skramm leun pe kuitaat anezhañ'
+    Preload Upcoming Videos: "Rakgargañ ar videoioù da-heul"
+    Upcoming Videos to Preload: "Niver a videoioù da rakgargañ"
   Channel Settings:
     Channel Settings: "Arventennoù ar chadennoù"
     Channel Settings Description: "Derc'hel soñj, evit pep chadenn, eus an arventennoù a zibabit pa sellit. Arloet e vint en-dro ar wech da-heul ma sellot ouzh unan eus he videoioù."
@@ -1191,7 +1193,14 @@ Video:
       DownvoteSegment: "Mouezhiañ a-enep"
       VoteFailed: "N'eus ket bet gallet kas ar vouezh SponsorBlock."
 Playlist:
+  Playlist Already Preloaded: "Karget eo bet holl videoioù ar roll-lenn en a-raok"
+  Playlist Preload Progress: "O kargañ videoioù en a-raok: {completed} diwar {requested}"
   Close Playlist: "Serriñ ar roll-videoioù"
+  Preload Playlist: "Rakgargañ an holl videoioù"
+  Preloading Playlist: "O rakgargañ an holl videoioù..."
+  Playlist Preload Complete: "Videoioù rakgarget: {count}."
+  Playlist Preload Partial: "{preloaded} diwar {requested} video rakgarget. C’hwitet ez eus bet war {failed}."
+  Playlist Preload Pagination Failed: "N’haller ket kargañ ar roll lenn a-bezh, setu eo bet nullet ar rakgargañ."
 Change Format:
   Local Video File: "Restr video lec'hel"
   Local Audio File: "Restr son lec'hel"
@@ -1388,6 +1397,8 @@ Tooltips:
       Gallout a ra gwerzhioù uheloc'h sikour gant kennaskoù gorrek pe distabil, met muioc'h a ledander-bann hag a vemor a vez implijet ganto.
       Gallout a reont ivez lakaat ar mod Emgefreek da briziañ tizh ar c'hennask re izel ha da zibab ur berzhded izeloc'h.
       Ar gwazhioù bevennet d'un azgoulenn war un dro ne zalc'hont ket kont eus an arventenn-mañ.
+    Preload Upcoming Videos: "Kargañ ha krubuilhañ a ra liammoù yt-dlp ar videoioù da-heul. Ar steudad a zo kentoc’h eget ar rolloù lenn hag an erbedadennoù."
+    Upcoming Videos to Preload: "Niver brasañ a videoioù da-heul a vez karget o liammoù yt-dlp en drekleur."
   Download Settings:
     Download Folder: "Enrollet e vez ar videoioù en teuliad-mañ. Laoskit goullo evit implijout teuliad Pellgargadennoù ho reizhiad."
     Global Additional yt-dlp Arguments: "Arventennoù arc'had ouzhpenn tremenet da yt-dlp evit pep pellgargadenn, da skouer --cookies-from-browser firefox."

--- a/static/locales/ai/ca.yaml
+++ b/static/locales/ai/ca.yaml
@@ -743,6 +743,8 @@ Settings:
         Empty File Name: Nom de fitxer buit
     Rotate Wide Videos to Landscape in Fullscreen: 'Gira els vídeos amples al mode apaïsat en pantalla completa'
     Swipe Up or Down to Enter or Exit Fullscreen: 'Llisca amunt o avall per entrar o sortir de la pantalla completa'
+    Preload Upcoming Videos: "Precarrega els vídeos següents"
+    Upcoming Videos to Preload: "Vídeos següents per precarregar"
   Channel Settings:
     Channel Settings: Configuració dels canals
     Channel Settings Description: Recorda per separat la configuració que trieu mentre mireu cada canal, per tornar-la a aplicar la propera vegada que mireu un dels seus vídeos.
@@ -1650,6 +1652,8 @@ Video:
     'Remaining preroll-ad time: {remindingTimeSeconds}s': 'Temps restant de l''anunci previ: {remindingTimeSeconds}s'
     'Remaining SABR backoff time: {remindingTimeSeconds}s': 'Temps d''espera de SABR restant: {remindingTimeSeconds}s'
 Playlist:
+  Playlist Already Preloaded: "Tots els vídeos de la llista ja estan precarregats"
+  Playlist Preload Progress: "S'estan precarregant vídeos: {completed} de {requested}"
   Playlist: Llista de reproducció
   Close Playlist: Tanca la llista de reproducció
   Sort By:
@@ -1664,6 +1668,11 @@ Playlist:
     VideoDurationAscending: Durada (més curta)
     VideoDurationDescending: Durada (més llarga)
     Custom: Personalitzat
+  Preload Playlist: "Precarrega tots els vídeos"
+  Preloading Playlist: "S’estan precarregant tots els vídeos..."
+  Playlist Preload Complete: "Vídeos precarregats: {count}."
+  Playlist Preload Partial: "S’han precarregat {preloaded} de {requested} vídeos. No se n’han pogut precarregar {failed}."
+  Playlist Preload Pagination Failed: "No s’ha pogut carregar la llista sencera i s’ha cancel·lat la precàrrega."
 Change Format:
   Local Video File: Fitxer de vídeo local
   Local Audio File: Fitxer d'àudio local
@@ -1904,6 +1913,8 @@ Tooltips:
       Els valors més alts poden ajudar amb connexions lentes o inestables, però utilitzen més amplada de banda i memòria.
       També poden fer que Automàtic subestimi la velocitat de connexió i seleccioni una qualitat inferior.
       Els fluxos limitats a una sol·licitud alhora ignoren aquesta opció.
+    Preload Upcoming Videos: "Obté i desa a la memòria cau els URL de yt-dlp dels vídeos següents. La cua té prioritat sobre les llistes i les recomanacions."
+    Upcoming Videos to Preload: "Nombre màxim de vídeos següents els URL de yt-dlp dels quals s’obtenen en segon pla."
   External Player Settings:
     External Player: En triar un reproductor extern, es mostrarà a la miniatura una icona per obrir-hi el vídeo o, si s'admet, la llista de reproducció. La configuració d'Invidious no afecta els reproductors externs.
     Custom External Player Executable: De manera predeterminada, l'OpenTubeX suposa que el reproductor extern triat es pot trobar mitjançant la variable d'entorn PATH. Si cal, podeu definir aquí un camí personalitzat.

--- a/static/locales/ai/cs.yaml
+++ b/static/locales/ai/cs.yaml
@@ -500,6 +500,8 @@ Settings:
     Parallel Segment Loading: Souběžné načítání segmentů
     Rotate Wide Videos to Landscape in Fullscreen: 'Otočit široká videa na šířku v režimu celé obrazovky'
     Swipe Up or Down to Enter or Exit Fullscreen: 'Přejetím nahoru nebo dolů otevřít či opustit celou obrazovku'
+    Preload Upcoming Videos: "Přednačítat následující videa"
+    Upcoming Videos to Preload: "Počet videí k přednačtení"
   Channel Settings:
     Channel Settings: Nastavení kanálů
     Channel Settings Description: Zapamatuje nastavení zvolená při sledování pro každý kanál zvlášť a znovu je použije při příštím sledování některého z jeho videí.
@@ -1182,7 +1184,14 @@ Video:
       DownvoteSegment: Hlasovat proti
       VoteFailed: Hlas pro SponsorBlock se nepodařilo odeslat.
 Playlist:
+  Playlist Already Preloaded: "Všechna videa v playlistu jsou již přednačtena"
+  Playlist Preload Progress: "Přednačítání videí: {completed} z {requested}"
   Close Playlist: Zavřít playlist
+  Preload Playlist: "Přednačíst všechna videa"
+  Preloading Playlist: "Přednačítají se všechna videa..."
+  Playlist Preload Complete: "Přednačtená videa: {count}."
+  Playlist Preload Partial: "Přednačteno {preloaded} z {requested} videí. {failed} se nepodařilo přednačíst."
+  Playlist Preload Pagination Failed: "Celý playlist se nepodařilo načíst, přednačítání bylo zrušeno."
 Change Format:
   Local Video File: Místní soubor videa
   Local Audio File: Místní zvukový soubor
@@ -1379,6 +1388,8 @@ Tooltips:
       Vyšší hodnoty mohou pomoci při pomalém nebo nestabilním připojení, ale spotřebují více přenosové rychlosti a paměti.
       Mohou také způsobit, že automatický režim podhodnotí rychlost připojení a zvolí nižší kvalitu.
       Streamy omezené na jeden požadavek současně toto nastavení ignorují.
+    Preload Upcoming Videos: "Načte a uloží do mezipaměti adresy yt-dlp pro následující videa. Fronta má přednost před playlisty a doporučeními."
+    Upcoming Videos to Preload: "Nejvyšší počet následujících videí, jejichž adresy yt-dlp se načtou na pozadí."
   Download Settings:
     Download Folder: Videa se ukládají do této složky. Chcete-li použít systémovou složku Stažené, ponechte pole prázdné.
     Global Additional yt-dlp Arguments: Další argumenty příkazového řádku předávané nástroji yt-dlp při každém stahování, například --cookies-from-browser firefox.

--- a/static/locales/ai/cy.yaml
+++ b/static/locales/ai/cy.yaml
@@ -502,6 +502,8 @@ Settings:
     Parallel Segment Loading: Llwytho segmentau ochr yn ochr
     Rotate Wide Videos to Landscape in Fullscreen: 'Cylchdroi fideos llydan i’r dirwedd yn y sgrin lawn'
     Swipe Up or Down to Enter or Exit Fullscreen: 'Llithro i fyny neu i lawr i fynd i mewn neu allan o’r sgrin lawn'
+    Preload Upcoming Videos: "Rhaglwytho fideos nesaf"
+    Upcoming Videos to Preload: "Nifer y fideos i’w rhaglwytho"
   Channel Settings:
     Channel Settings: Gosodiadau sianeli
     Channel Settings Description: Cofiwch y gosodiadau a ddewiswch wrth wylio ar gyfer pob sianel ar wahân, fel eu bod yn cael eu gosod eto y tro nesaf y byddwch yn gwylio un o'i fideos.
@@ -1195,7 +1197,14 @@ Video:
       DownvoteSegment: Pleidleisio yn erbyn
       VoteFailed: Methodd cyflwyno pleidlais SponsorBlock.
 Playlist:
+  Playlist Already Preloaded: "Mae holl fideos y rhestr chwarae eisoes wedi'u rhaglwytho"
+  Playlist Preload Progress: "Yn rhaglwytho fideos: {completed} o {requested}"
   Close Playlist: Cau'r rhestr chwarae
+  Preload Playlist: "Rhaglwytho pob fideo"
+  Preloading Playlist: "Wrthi’n rhaglwytho pob fideo..."
+  Playlist Preload Complete: "Fideos wedi’u rhaglwytho: {count}."
+  Playlist Preload Partial: "Rhaglwythwyd {preloaded} o {requested} fideo. Methodd {failed}."
+  Playlist Preload Pagination Failed: "Ni ellid llwytho’r rhestr chwarae gyfan, felly canslwyd y rhaglwytho."
 Change Format:
   Local Video File: Ffeil fideo leol
   Local Audio File: Ffeil sain leol
@@ -1392,6 +1401,8 @@ Tooltips:
       Gall gwerthoedd uwch helpu ar gysylltiadau araf neu ansefydlog, ond maent yn defnyddio rhagor o led band a chof.
       Gallant hefyd beri i Awtomatig danamcangyfrif cyflymder y cysylltiad a dewis ansawdd is.
       Mae ffrydiau sydd wedi'u cyfyngu i un cais ar y tro yn anwybyddu'r gosodiad hwn.
+    Preload Upcoming Videos: "Mae’n nôl ac yn storio URLau yt-dlp y fideos nesaf. Mae’r ciw yn cael blaenoriaeth dros restrau chwarae ac argymhellion."
+    Upcoming Videos to Preload: "Uchafswm y fideos nesaf y nôlir eu URLau yt-dlp yn y cefndir."
   Download Settings:
     Download Folder: Caiff fideos eu cadw yn y ffolder hon. Gadewch yn wag i ddefnyddio ffolder Lawrlwythiadau eich system.
     Global Additional yt-dlp Arguments: Ymresymiadau llinell orchymyn ychwanegol a drosglwyddir i yt-dlp ar gyfer pob lawrlwythiad, er enghraifft --cookies-from-browser firefox.

--- a/static/locales/ai/da.yaml
+++ b/static/locales/ai/da.yaml
@@ -525,6 +525,8 @@ Settings:
         Clipboard: Kopiér til udklipsholder
     Rotate Wide Videos to Landscape in Fullscreen: 'Roter brede videoer til liggende format i fuld skærm'
     Swipe Up or Down to Enter or Exit Fullscreen: 'Stryg op eller ned for at åbne eller forlade fuld skærm'
+    Preload Upcoming Videos: "Forudindlæs kommende videoer"
+    Upcoming Videos to Preload: "Antal videoer, der skal forudindlæses"
   Channel Settings:
     Channel Settings: Kanalindstillinger
     Channel Settings Description: Husk de indstillinger, du vælger under afspilning, for hver kanal, så de anvendes igen, næste gang du ser en af kanalens videoer.
@@ -1241,7 +1243,14 @@ Video:
     'Remaining preroll-ad time: {remindingTimeSeconds}s': 'Resterende tid for preroll-annonce: {remindingTimeSeconds}s'
     'Remaining SABR backoff time: {remindingTimeSeconds}s': 'Resterende SABR-ventetid: {remindingTimeSeconds}s'
 Playlist:
+  Playlist Already Preloaded: "Alle videoer i playlisten er allerede forudindlæst"
+  Playlist Preload Progress: "Forudindlæser videoer: {completed} af {requested}"
   Close Playlist: Luk playliste
+  Preload Playlist: "Forudindlæs alle videoer"
+  Preloading Playlist: "Forudindlæser alle videoer..."
+  Playlist Preload Complete: "Forudindlæste videoer: {count}."
+  Playlist Preload Partial: "Forudindlæste {preloaded} af {requested} videoer. {failed} kunne ikke forudindlæses."
+  Playlist Preload Pagination Failed: "Hele afspilningslisten kunne ikke indlæses, så forudindlæsningen blev annulleret."
 Change Format:
   Local Video File: Lokal videofil
   Local Audio File: Lokal lydfil
@@ -1442,6 +1451,8 @@ Tooltips:
       Højere værdier kan hjælpe på langsomme eller ustabile forbindelser, men bruger mere båndbredde og hukommelse.
       De kan også få Auto til at undervurdere forbindelseshastigheden og vælge en lavere kvalitet.
       Streams, der er begrænset til én anmodning ad gangen, ignorerer denne indstilling.
+    Preload Upcoming Videos: "Henter og gemmer yt-dlp-streamadresser for de næste videoer. Køen har prioritet over afspilningslister og anbefalinger."
+    Upcoming Videos to Preload: "Det højeste antal kommende videoer, hvis yt-dlp-streamadresser hentes i baggrunden."
   Download Settings:
     Download Folder: Videoer gemmes i denne mappe. Lad feltet stå tomt for at bruge systemets Downloads-mappe.
     Global Additional yt-dlp Arguments: Yderligere kommandolinjeargumenter, der sendes til yt-dlp ved hver download, f.eks. --cookies-from-browser firefox.

--- a/static/locales/ai/el.yaml
+++ b/static/locales/ai/el.yaml
@@ -513,6 +513,8 @@ Settings:
         Clipboard: Αντιγραφή στο πρόχειρο
     Rotate Wide Videos to Landscape in Fullscreen: 'Περιστροφή ευρέων βίντεο σε οριζόντιο προσανατολισμό σε πλήρη οθόνη'
     Swipe Up or Down to Enter or Exit Fullscreen: 'Σύρετε πάνω ή κάτω για είσοδο ή έξοδο από την πλήρη οθόνη'
+    Preload Upcoming Videos: "Προφόρτωση επόμενων βίντεο"
+    Upcoming Videos to Preload: "Πλήθος βίντεο για προφόρτωση"
   Channel Settings:
     Channel Settings: Ρυθμίσεις καναλιών
     Channel Settings Description: Απομνημόνευση των ρυθμίσεων που επιλέγετε κατά την παρακολούθηση, ξεχωριστά για κάθε κανάλι, ώστε να εφαρμόζονται ξανά την επόμενη φορά που θα παρακολουθήσετε κάποιο βίντεό του.
@@ -1210,7 +1212,14 @@ Video:
       DownvoteSegment: Αρνητική ψήφος
       VoteFailed: Απέτυχε η υποβολή ψήφου στο SponsorBlock.
 Playlist:
+  Playlist Already Preloaded: "Όλα τα βίντεο της λίστας αναπαραγωγής έχουν ήδη προφορτωθεί"
+  Playlist Preload Progress: "Προφόρτωση βίντεο: {completed} από {requested}"
   Close Playlist: Κλείσιμο λίστας αναπαραγωγής
+  Preload Playlist: "Προφόρτωση όλων των βίντεο"
+  Preloading Playlist: "Γίνεται προφόρτωση όλων των βίντεο..."
+  Playlist Preload Complete: "Προφορτωμένα βίντεο: {count}."
+  Playlist Preload Partial: "Προφορτώθηκαν {preloaded} από {requested} βίντεο. Απέτυχαν {failed}."
+  Playlist Preload Pagination Failed: "Δεν ήταν δυνατή η φόρτωση ολόκληρης της λίστας, οπότε η προφόρτωση ακυρώθηκε."
 Change Format:
   Local Video File: Τοπικό αρχείο βίντεο
   Local Audio File: Τοπικό αρχείο ήχου
@@ -1407,6 +1416,8 @@ Tooltips:
       Οι υψηλότερες τιμές μπορεί να βοηθήσουν σε αργές ή ασταθείς συνδέσεις, αλλά χρησιμοποιούν περισσότερο εύρος ζώνης και μνήμη.
       Μπορεί επίσης να προκαλέσουν στην Αυτόματη ρύθμιση υποεκτίμηση της ταχύτητας σύνδεσης και επιλογή χαμηλότερης ποιότητας.
       Οι ροές που περιορίζονται σε ένα αίτημα κάθε φορά αγνοούν αυτήν τη ρύθμιση.
+    Preload Upcoming Videos: "Ανακτά και αποθηκεύει προσωρινά τις διευθύνσεις yt-dlp των επόμενων βίντεο. Η ουρά προηγείται των λιστών και των προτάσεων."
+    Upcoming Videos to Preload: "Ο μέγιστος αριθμός επόμενων βίντεο των οποίων οι διευθύνσεις yt-dlp ανακτώνται στο παρασκήνιο."
   Download Settings:
     Download Folder: Τα βίντεο αποθηκεύονται σε αυτόν τον φάκελο. Αφήστε το κενό για να χρησιμοποιηθεί ο φάκελος Λήψεις του συστήματός σας.
     Global Additional yt-dlp Arguments: Πρόσθετα ορίσματα γραμμής εντολών που διαβιβάζονται στο yt-dlp για κάθε λήψη, για παράδειγμα --cookies-from-browser firefox.

--- a/static/locales/ai/en-GB.yaml
+++ b/static/locales/ai/en-GB.yaml
@@ -487,6 +487,8 @@ Settings:
     Parallel Segment Loading: Parallel Segment Loading
     Rotate Wide Videos to Landscape in Fullscreen: 'Rotate wide videos to landscape in fullscreen'
     Swipe Up or Down to Enter or Exit Fullscreen: 'Swipe up or down to enter or exit fullscreen'
+    Preload Upcoming Videos: "Preload Upcoming Videos"
+    Upcoming Videos to Preload: "Upcoming Videos to Preload"
   Channel Settings:
     Channel Settings: Channel Settings
     Channel Settings Description: Remember the settings you pick while watching for each channel individually, so they are applied again the next time you watch one of its videos.
@@ -1153,7 +1155,14 @@ Video:
       DownvoteSegment: Downvote
       VoteFailed: Failed to submit SponsorBlock vote.
 Playlist:
+  Playlist Already Preloaded: "All playlist videos are already preloaded"
+  Playlist Preload Progress: "Preloading videos: {completed} of {requested}"
   Close Playlist: Close Playlist
+  Preload Playlist: "Preload all videos"
+  Preloading Playlist: "Preloading all videos..."
+  Playlist Preload Complete: "Preloaded videos: {count}."
+  Playlist Preload Partial: "Preloaded {preloaded} of {requested} videos. {failed} could not be preloaded."
+  Playlist Preload Pagination Failed: "The full playlist could not be loaded, so preloading was cancelled."
 Change Format:
   Local Video File: Local video file
   Local Audio File: Local audio file
@@ -1350,6 +1359,8 @@ Tooltips:
       Higher values may help on slow or unstable connections, but use more bandwidth and memory.
       They may also make Auto underestimate the connection speed and select a lower quality.
       Streams limited to one request at a time ignore this setting.
+    Preload Upcoming Videos: "Fetches and caches yt-dlp stream URLs for the videos that can play next. The queue takes priority over playlists and recommendations."
+    Upcoming Videos to Preload: "The maximum number of upcoming videos whose yt-dlp stream URLs are fetched in the background."
   Download Settings:
     Download Folder: Videos are saved to this folder. Leave blank to use your system's Downloads folder.
     Global Additional yt-dlp Arguments: Additional command line arguments passed to yt-dlp for every download, for example --cookies-from-browser firefox.

--- a/static/locales/ai/es-AR.yaml
+++ b/static/locales/ai/es-AR.yaml
@@ -584,6 +584,8 @@ Settings:
         Clipboard: Copiar al Portapapeles
     Rotate Wide Videos to Landscape in Fullscreen: 'Girar videos anchos a horizontal en pantalla completa'
     Swipe Up or Down to Enter or Exit Fullscreen: 'Deslizá hacia arriba o abajo para entrar o salir de pantalla completa'
+    Preload Upcoming Videos: "Precargar próximos vídeos"
+    Upcoming Videos to Preload: "Vídeos próximos para precargar"
   Channel Settings:
     Channel Settings: Ajustes de canales
     Channel Settings Description: Recuerda por separado los ajustes que elijas al ver cada canal para volver a aplicarlos la próxima vez que veas uno de sus videos.
@@ -1543,6 +1545,8 @@ Video:
     'Remaining preroll-ad time: {remindingTimeSeconds}s': 'Tiempo restante previo al anuncio: {remindingTimeSeconds} s'
     'Remaining SABR backoff time: {remindingTimeSeconds}s': 'Tiempo restante de retroceso de SABR: {remindingTimeSeconds} s'
 Playlist:
+  Playlist Already Preloaded: "Todos los videos de la lista ya están precargados"
+  Playlist Preload Progress: "Precargando videos: {completed} de {requested}"
   Playlist: Lista de reproducción
   Close Playlist: Cerrar lista de reproducción
   View Full Playlist: Ver la lista de reproducción completa
@@ -1559,6 +1563,11 @@ Playlist:
     VideoDurationAscending: Duración (Más corta)
     VideoDurationDescending: Duración (más larga)
     Custom: Personalizado
+  Preload Playlist: "Precargar todos los vídeos"
+  Preloading Playlist: "Precargando todos los vídeos..."
+  Playlist Preload Complete: "Vídeos precargados: {count}."
+  Playlist Preload Partial: "Se precargaron {preloaded} de {requested} vídeos. No se pudieron precargar {failed}."
+  Playlist Preload Pagination Failed: "No se pudo cargar la lista completa, así que se canceló la precarga."
 Change Format:
   Change Media Formats: Cambiar formato de video
   Use Dash Formats: Utilizar formatos DASH
@@ -1817,6 +1826,8 @@ Tooltips:
       Los valores más altos pueden ayudar en conexiones lentas o inestables, pero consumen más ancho de banda y memoria.
       También pueden hacer que Automático calcule una velocidad de conexión demasiado baja y seleccione una calidad inferior.
       Las emisiones limitadas a una solicitud simultánea ignoran este ajuste.
+    Preload Upcoming Videos: "Obtiene y guarda en caché las URL de yt-dlp de los próximos vídeos. La cola tiene prioridad sobre las listas y las recomendaciones."
+    Upcoming Videos to Preload: "Número máximo de próximos vídeos cuyas URL de yt-dlp se obtienen en segundo plano."
   External Player Settings:
     External Player: La elección de un reproductor externo mostrará un icono, para abrir el video (lista de reproducción si es compatible) en el reproductor externo, en la miniatura. Atención, los ajustes de Invidious no afectan a los reproductores externos.
     Custom External Player Executable: Por defecto, OpenTubeX buscará el reproductor externo seleccionado mediante la variable de entorno PATH, de no encontrarlo, podrás especificar una ruta personalizada acá.

--- a/static/locales/ai/es-MX.yaml
+++ b/static/locales/ai/es-MX.yaml
@@ -618,6 +618,8 @@ Settings:
       File Name Label: Patrón de nombre de archivo
     Rotate Wide Videos to Landscape in Fullscreen: 'Girar videos anchos a horizontal en pantalla completa'
     Swipe Up or Down to Enter or Exit Fullscreen: 'Desliza hacia arriba o abajo para entrar o salir de pantalla completa'
+    Preload Upcoming Videos: "Precargar próximos vídeos"
+    Upcoming Videos to Preload: "Vídeos próximos para precargar"
   Channel Settings:
     Channel Settings: Ajustes de canales
     Channel Settings Description: Recuerda por separado los ajustes que elijas al ver cada canal para volver a aplicarlos la próxima vez que veas uno de sus videos.
@@ -1485,6 +1487,8 @@ Video:
     'Remaining preroll-ad time: {remindingTimeSeconds}s': 'Tiempo restante previo al anuncio: {remindingTimeSeconds} s'
     'Remaining SABR backoff time: {remindingTimeSeconds}s': 'Tiempo restante de retroceso de SABR: {remindingTimeSeconds} s'
 Playlist:
+  Playlist Already Preloaded: "Todos los videos de la lista ya están precargados"
+  Playlist Preload Progress: "Precargando videos: {completed} de {requested}"
   Close Playlist: Cerrar lista de reproducción
   Sort By:
     DateAddedNewest: Fecha de adición (Más reciente)
@@ -1498,6 +1502,11 @@ Playlist:
     VideoDurationAscending: Duración (Más corta)
     VideoDurationDescending: Duración (más larga)
     Custom: Personalizado
+  Preload Playlist: "Precargar todos los vídeos"
+  Preloading Playlist: "Precargando todos los vídeos..."
+  Playlist Preload Complete: "Vídeos precargados: {count}."
+  Playlist Preload Partial: "Se precargaron {preloaded} de {requested} vídeos. No se pudieron precargar {failed}."
+  Playlist Preload Pagination Failed: "No se pudo cargar la lista completa, así que se canceló la precarga."
 Change Format:
   Local Video File: Archivo de video local
   Local Audio File: Archivo de audio local
@@ -1713,6 +1722,8 @@ Tooltips:
       Los valores más altos pueden ayudar en conexiones lentas o inestables, pero consumen más ancho de banda y memoria.
       También pueden hacer que Automático calcule una velocidad de conexión demasiado baja y seleccione una calidad inferior.
       Las emisiones limitadas a una solicitud simultánea ignoran este ajuste.
+    Preload Upcoming Videos: "Obtiene y guarda en caché las URL de yt-dlp de los próximos vídeos. La cola tiene prioridad sobre las listas y las recomendaciones."
+    Upcoming Videos to Preload: "Número máximo de próximos vídeos cuyas URL de yt-dlp se obtienen en segundo plano."
   External Player Settings:
     Ignore Default Arguments: No envíe ningún argumento predeterminado al reproductor externo aparte de la URL del video (por ejemplo, velocidad de reproducción, URL de la lista de reproducción, etc.). Los argumentos personalizados se seguirán transmitiendo.
   Download Settings:

--- a/static/locales/ai/es.yaml
+++ b/static/locales/ai/es.yaml
@@ -506,6 +506,8 @@ Settings:
     Parallel Segment Loading: Carga paralela de segmentos
     Rotate Wide Videos to Landscape in Fullscreen: 'Girar vídeos anchos a horizontal en pantalla completa'
     Swipe Up or Down to Enter or Exit Fullscreen: 'Desliza hacia arriba o abajo para entrar o salir de pantalla completa'
+    Preload Upcoming Videos: "Precargar próximos vídeos"
+    Upcoming Videos to Preload: "Vídeos próximos para precargar"
   Channel Settings:
     Channel Settings: Ajustes de canales
     Channel Settings Description: Recuerda por separado los ajustes que elijas al ver cada canal para volver a aplicarlos la próxima vez que veas uno de sus vídeos.
@@ -1200,7 +1202,14 @@ Video:
       DownvoteSegment: Votar en contra
       VoteFailed: No se pudo enviar el voto a SponsorBlock.
 Playlist:
+  Playlist Already Preloaded: "Todos los videos de la lista ya están precargados"
+  Playlist Preload Progress: "Precargando videos: {completed} de {requested}"
   Close Playlist: Cerrar lista de reproducción
+  Preload Playlist: "Precargar todos los vídeos"
+  Preloading Playlist: "Precargando todos los vídeos..."
+  Playlist Preload Complete: "Vídeos precargados: {count}."
+  Playlist Preload Partial: "Se precargaron {preloaded} de {requested} vídeos. No se pudieron precargar {failed}."
+  Playlist Preload Pagination Failed: "No se pudo cargar la lista completa, así que se canceló la precarga."
 Change Format:
   Local Video File: Archivo de vídeo local
   Local Audio File: Archivo de audio local
@@ -1397,6 +1406,8 @@ Tooltips:
       Los valores más altos pueden ayudar en conexiones lentas o inestables, pero consumen más ancho de banda y memoria.
       También pueden hacer que Automático calcule una velocidad de conexión demasiado baja y seleccione una calidad inferior.
       Las emisiones limitadas a una solicitud simultánea ignoran este ajuste.
+    Preload Upcoming Videos: "Obtiene y guarda en caché las URL de yt-dlp de los próximos vídeos. La cola tiene prioridad sobre las listas y las recomendaciones."
+    Upcoming Videos to Preload: "Número máximo de próximos vídeos cuyas URL de yt-dlp se obtienen en segundo plano."
   Download Settings:
     Download Folder: Los vídeos se guardan en esta carpeta. Déjala en blanco para usar la carpeta Descargas del sistema.
     Global Additional yt-dlp Arguments: Argumentos de línea de comandos adicionales que se pasan a yt-dlp en todas las descargas, por ejemplo, --cookies-from-browser firefox.

--- a/static/locales/ai/et.yaml
+++ b/static/locales/ai/et.yaml
@@ -500,6 +500,8 @@ Settings:
     Parallel Segment Loading: Segmentide paralleelne laadimine
     Rotate Wide Videos to Landscape in Fullscreen: 'Pööra laiad videod täisekraanil rõhtpaigutusse'
     Swipe Up or Down to Enter or Exit Fullscreen: 'Täisekraanile minemiseks või sealt väljumiseks nipsa üles või alla'
+    Preload Upcoming Videos: "Järgmiste videote eellaadimine"
+    Upcoming Videos to Preload: "Eellaaditavate videote arv"
   Channel Settings:
     Channel Settings: Kanali seaded
     Channel Settings Description: Jäta iga kanali jaoks eraldi meelde vaatamise ajal valitud seaded, et need rakenduksid uuesti, kui vaatad järgmisel korral selle kanali videot.
@@ -1184,7 +1186,14 @@ Video:
       DownvoteSegment: Anna vastuhääl
       VoteFailed: SponsorBlocki hääle saatmine nurjus.
 Playlist:
+  Playlist Already Preloaded: "Kõik esitusloendi videod on juba eellaaditud"
+  Playlist Preload Progress: "Videote eellaadimine: {completed}/{requested}"
   Close Playlist: Sulge esitusloend
+  Preload Playlist: "Eellaadi kõik videod"
+  Preloading Playlist: "Kõigi videote eellaadimine..."
+  Playlist Preload Complete: "Eellaaditud videoid: {count}."
+  Playlist Preload Partial: "Eellaaditi {preloaded}/{requested} videot. {failed} eellaadimine nurjus."
+  Playlist Preload Pagination Failed: "Tervet esitusloendit ei saanud laadida, seega eellaadimine tühistati."
 Change Format:
   Local Video File: Kohalik videofail
   Local Audio File: Kohalik helifail
@@ -1381,6 +1390,8 @@ Tooltips:
       Suuremad väärtused võivad aidata aeglase või ebastabiilse ühenduse korral, kuid kasutavad rohkem ribalaiust ja mälu.
       Samuti võivad need panna automaatvaliku ühenduse kiirust alahindama ja madalamat kvaliteeti valima.
       Vood, mida saab laadida ainult ühe päringu kaupa, eiravad seda seadet.
+    Preload Upcoming Videos: "Hangib ja salvestab järgmiste videote yt-dlp voogedastusaadressid vahemällu. Järjekord on esitusloenditest ja soovitustest tähtsam."
+    Upcoming Videos to Preload: "Taustal hangitavate yt-dlp aadressidega järgmiste videote suurim arv."
   Download Settings:
     Download Folder: Videod salvestatakse sellesse kausta. Süsteemi allalaadimiste kausta kasutamiseks jäta väli tühjaks.
     Global Additional yt-dlp Arguments: Täiendavad käsureaargumendid, mis edastatakse iga allalaadimise puhul yt-dlp-le, näiteks --cookies-from-browser firefox.

--- a/static/locales/ai/eu.yaml
+++ b/static/locales/ai/eu.yaml
@@ -502,6 +502,8 @@ Settings:
     Parallel Segment Loading: Segmentuak paraleloan kargatzea
     Rotate Wide Videos to Landscape in Fullscreen: 'Biratu bideo zabalak horizontalera pantaila osoan'
     Swipe Up or Down to Enter or Exit Fullscreen: 'Irristatu gora edo behera pantaila osoan sartzeko edo irteteko'
+    Preload Upcoming Videos: "Aurrekargatu hurrengo bideoak"
+    Upcoming Videos to Preload: "Aurrekargatu beharreko bideo kopurua"
   Channel Settings:
     Channel Settings: Kanalen ezarpenak
     Channel Settings Description: Gogoratu kanal bakoitzerako bideoak ikustean aukeratutako ezarpenak, kanal horretako beste bideo bat ikusten duzunean berriro aplikatzeko.
@@ -1195,7 +1197,14 @@ Video:
       DownvoteSegment: Eman kontrako botoa
       VoteFailed: Ezin izan da SponsorBlock botoa bidali.
 Playlist:
+  Playlist Already Preloaded: "Erreprodukzio-zerrendako bideo guztiak aurrez kargatuta daude"
+  Playlist Preload Progress: "Bideoak aurrez kargatzen: {completed}/{requested}"
   Close Playlist: Itxi erreprodukzio-zerrenda
+  Preload Playlist: "Aurrekargatu bideo guztiak"
+  Preloading Playlist: "Bideo guztiak aurrekargatzen..."
+  Playlist Preload Complete: "Aurrekargatutako bideoak: {count}."
+  Playlist Preload Partial: "{requested} bideotatik {preloaded} aurrekargatu dira. {failed} ezin izan dira aurrekargatu."
+  Playlist Preload Pagination Failed: "Ezin izan da erreprodukzio-zerrenda osoa kargatu; aurrekarga bertan behera utzi da."
 Change Format:
   Local Video File: Bideo-fitxategi lokala
   Local Audio File: Audio-fitxategi lokala
@@ -1392,6 +1401,8 @@ Tooltips:
       Balio handiagoek konexio motel edo ezegonkorretan lagun dezakete, baina banda-zabalera eta memoria gehiago erabiltzen dituzte.
       Baliteke Automatikoa aukerak konexioaren abiadura txikiagoa dela kalkulatzea eta kalitate txikiagoa hautatzea ere.
       Aldiko eskaera bakarrera mugatutako korronteek ezarpen hau baztertzen dute.
+    Preload Upcoming Videos: "Hurrengo bideoen yt-dlp URLak eskuratu eta cachean gordetzen ditu. Ilarak lehentasuna du zerrenden eta gomendioen aurretik."
+    Upcoming Videos to Preload: "Atzeko planoan yt-dlp URLak eskuratuko zaizkien hurrengo bideoen gehieneko kopurua."
   Download Settings:
     Download Folder: Bideoak karpeta honetan gordetzen dira. Utzi hutsik sistemako Deskargak karpeta erabiltzeko.
     Global Additional yt-dlp Arguments: Deskarga bakoitzean yt-dlp-ri emandako komando-lerroko argumentu gehigarriak; adibidez, --cookies-from-browser firefox.

--- a/static/locales/ai/fa.yaml
+++ b/static/locales/ai/fa.yaml
@@ -530,6 +530,8 @@ Settings:
         Clipboard: رونوشت در تخته‌گیره
     Rotate Wide Videos to Landscape in Fullscreen: 'چرخاندن ویدیوهای عریض به حالت افقی در تمام‌صفحه'
     Swipe Up or Down to Enter or Exit Fullscreen: 'برای ورود به تمام‌صفحه یا خروج از آن، بالا یا پایین بکشید'
+    Preload Upcoming Videos: "پیش‌بارگیری ویدیوهای بعدی"
+    Upcoming Videos to Preload: "تعداد ویدیوها برای پیش‌بارگیری"
   Channel Settings:
     Channel Settings: تنظیمات کانال
     Channel Settings Description: تنظیمات انتخابی هنگام تماشای هر کانال را جداگانه به‌خاطر بسپار تا دفعهٔ بعد برای ویدیوهای آن دوباره اعمال شوند.
@@ -1246,7 +1248,14 @@ Video:
     'Remaining preroll-ad time: {remindingTimeSeconds}s': 'زمان باقی‌ماندهٔ تبلیغ پیش از پخش: {remindingTimeSeconds}s'
     'Remaining SABR backoff time: {remindingTimeSeconds}s': 'زمان باقی‌ماندهٔ وقفهٔ SABR: {remindingTimeSeconds}s'
 Playlist:
+  Playlist Already Preloaded: "همه ویدیوهای فهرست پخش از قبل پیش‌بارگذاری شده‌اند"
+  Playlist Preload Progress: "در حال پیش‌بارگذاری ویدیوها: {completed} از {requested}"
   Close Playlist: بستن فهرست پخش
+  Preload Playlist: "پیش‌بارگیری همهٔ ویدیوها"
+  Preloading Playlist: "در حال پیش‌بارگیری همهٔ ویدیوها..."
+  Playlist Preload Complete: "ویدیوهای پیش‌بارگیری‌شده: {count}."
+  Playlist Preload Partial: "از {requested} ویدیو، {preloaded} مورد پیش‌بارگیری شد. پیش‌بارگیری {failed} مورد ناموفق بود."
+  Playlist Preload Pagination Failed: "فهرست پخش کامل بارگیری نشد، بنابراین پیش‌بارگیری لغو شد."
 Change Format:
   Local Video File: فایل ویدیویی محلی
   Local Audio File: فایل صوتی محلی
@@ -1447,6 +1456,8 @@ Tooltips:
       مقادیر بالاتر ممکن است به اتصال‌های کند یا ناپایدار کمک کنند، اما پهنای باند و حافظه بیشتری مصرف می‌کنند.
       همچنین ممکن است باعث شوند «خودکار» سرعت اتصال را کمتر برآورد کند و کیفیت پایین‌تری برگزیند.
       جریان‌هایی که هر بار به یک درخواست محدودند، این تنظیم را نادیده می‌گیرند.
+    Preload Upcoming Videos: "نشانی‌های پخش yt-dlp ویدیوهای بعدی را دریافت و ذخیره می‌کند. صف بر فهرست‌های پخش و پیشنهادها اولویت دارد."
+    Upcoming Videos to Preload: "بیشترین تعداد ویدیوهای بعدی که نشانی yt-dlp آن‌ها در پس‌زمینه دریافت می‌شود."
   Download Settings:
     Download Folder: ویدیوها در این پوشه ذخیره می‌شوند. برای استفاده از پوشه «بارگیری‌ها»ی سیستم، خالی بگذارید.
     Global Additional yt-dlp Arguments: آرگومان‌های اضافی خط فرمان که برای هر بارگیری به yt-dlp فرستاده می‌شوند؛ برای مثال --cookies-from-browser firefox.

--- a/static/locales/ai/fi.yaml
+++ b/static/locales/ai/fi.yaml
@@ -513,6 +513,8 @@ Settings:
         Clipboard: Kopioi leikepöydälle
     Rotate Wide Videos to Landscape in Fullscreen: 'Kierrä leveät videot vaakasuuntaan koko näytöllä'
     Swipe Up or Down to Enter or Exit Fullscreen: 'Siirry koko näytön tilaan tai poistu siitä pyyhkäisemällä ylös tai alas'
+    Preload Upcoming Videos: "Esilataa seuraavat videot"
+    Upcoming Videos to Preload: "Esiladattavien videoiden määrä"
   Channel Settings:
     Channel Settings: Kanava-asetukset
     Channel Settings Description: Muista katselun aikana valitsemasi asetukset kanavakohtaisesti, jotta niitä käytetään uudelleen, kun katsot seuraavan kerran saman kanavan videota.
@@ -1210,7 +1212,14 @@ Video:
       DownvoteSegment: Äänestä vastaan
       VoteFailed: SponsorBlock-äänen lähettäminen epäonnistui.
 Playlist:
+  Playlist Already Preloaded: "Kaikki soittolistan videot on jo esiladattu"
+  Playlist Preload Progress: "Esiladataan videoita: {completed}/{requested}"
   Close Playlist: Sulje soittolista
+  Preload Playlist: "Esilataa kaikki videot"
+  Preloading Playlist: "Esiladataan kaikkia videoita..."
+  Playlist Preload Complete: "Esiladattuja videoita: {count}."
+  Playlist Preload Partial: "Esiladattiin {preloaded}/{requested} videota. {failed} videon esilataus epäonnistui."
+  Playlist Preload Pagination Failed: "Koko soittolistaa ei voitu ladata, joten esilataus peruttiin."
 Change Format:
   Local Video File: Paikallinen videotiedosto
   Local Audio File: Paikallinen äänitiedosto
@@ -1407,6 +1416,8 @@ Tooltips:
       Suuremmat arvot voivat auttaa hitailla tai epävakailla yhteyksillä, mutta ne käyttävät enemmän kaistanleveyttä ja muistia.
       Ne voivat myös saada automaattisen asetuksen aliarvioimaan yhteysnopeuden ja valitsemaan heikomman laadun.
       Tämä asetus ei vaikuta suoratoistovirtoihin, joissa sallitaan vain yksi pyyntö kerrallaan.
+    Preload Upcoming Videos: "Noutaa ja tallentaa välimuistiin seuraavien videoiden yt-dlp-osoitteet. Jono on etusijalla soittolistoihin ja suosituksiin nähden."
+    Upcoming Videos to Preload: "Enimmäismäärä seuraavia videoita, joiden yt-dlp-osoitteet noudetaan taustalla."
   Download Settings:
     Download Folder: Videot tallennetaan tähän kansioon. Jos kenttä jätetään tyhjäksi, käytetään järjestelmän Lataukset-kansiota.
     Global Additional yt-dlp Arguments: Kaikissa latauksissa yt-dlp:lle välitettävät komentorivin lisäargumentit, esimerkiksi --cookies-from-browser firefox.

--- a/static/locales/ai/fr-FR.yaml
+++ b/static/locales/ai/fr-FR.yaml
@@ -500,6 +500,8 @@ Settings:
     Parallel Segment Loading: Chargement parallèle des segments
     Rotate Wide Videos to Landscape in Fullscreen: 'Faire pivoter les vidéos larges en mode paysage en plein écran'
     Swipe Up or Down to Enter or Exit Fullscreen: 'Balayer vers le haut ou le bas pour ouvrir ou quitter le plein écran'
+    Preload Upcoming Videos: "Précharger les vidéos suivantes"
+    Upcoming Videos to Preload: "Nombre de vidéos à précharger"
   Channel Settings:
     Channel Settings: Paramètres des chaînes
     Channel Settings Description: Mémorisez séparément pour chaque chaîne les paramètres choisis pendant le visionnage afin de les appliquer de nouveau à la prochaine vidéo de cette chaîne.
@@ -1181,7 +1183,14 @@ Video:
       DownvoteSegment: Voter contre
       VoteFailed: Échec de l’envoi du vote à SponsorBlock.
 Playlist:
+  Playlist Already Preloaded: "Toutes les vidéos de la playlist sont déjà préchargées"
+  Playlist Preload Progress: "Préchargement des vidéos : {completed} sur {requested}"
   Close Playlist: Fermer la playlist
+  Preload Playlist: "Précharger toutes les vidéos"
+  Preloading Playlist: "Préchargement de toutes les vidéos..."
+  Playlist Preload Complete: "Vidéos préchargées : {count}."
+  Playlist Preload Partial: "{preloaded} vidéos sur {requested} ont été préchargées. Échec pour {failed}."
+  Playlist Preload Pagination Failed: "La playlist complète n’a pas pu être chargée, le préchargement a donc été annulé."
 Change Format:
   Local Video File: Fichier vidéo local
   Local Audio File: Fichier audio local
@@ -1377,6 +1386,8 @@ Tooltips:
       Des valeurs élevées peuvent améliorer les connexions lentes ou instables, mais utilisent davantage de bande passante et de mémoire.
       Elles peuvent aussi amener le mode Auto à sous-estimer la vitesse de connexion et à sélectionner une qualité inférieure.
       Les flux limités à une requête à la fois ignorent ce paramètre.
+    Preload Upcoming Videos: "Récupère et met en cache les URL yt-dlp des vidéos suivantes. La file d’attente est prioritaire sur les playlists et les recommandations."
+    Upcoming Videos to Preload: "Nombre maximal de vidéos suivantes dont les URL yt-dlp sont récupérées en arrière-plan."
   Download Settings:
     Download Folder: Les vidéos sont enregistrées dans ce dossier. Laissez ce champ vide pour utiliser le dossier Téléchargements de votre système.
     Global Additional yt-dlp Arguments: Arguments de ligne de commande supplémentaires transmis à yt-dlp pour chaque téléchargement, par exemple --cookies-from-browser firefox.

--- a/static/locales/ai/gl.yaml
+++ b/static/locales/ai/gl.yaml
@@ -508,6 +508,8 @@ Settings:
     Parallel Segment Loading: Carga paralela de segmentos
     Rotate Wide Videos to Landscape in Fullscreen: 'Xirar os vídeos panorámicos a horizontal na pantalla completa'
     Swipe Up or Down to Enter or Exit Fullscreen: 'Pasa o dedo cara arriba ou abaixo para entrar ou saír da pantalla completa'
+    Preload Upcoming Videos: "Precargar os seguintes vídeos"
+    Upcoming Videos to Preload: "Número de vídeos para precargar"
   Channel Settings:
     Channel Settings: Configuración das canles
     Channel Settings Description: Lembrar por separado os axustes escollidos mentres ves vídeos de cada canle para aplicalos de novo a próxima vez que vexas un dos seus vídeos.
@@ -1214,7 +1216,14 @@ Video:
       DownvoteSegment: Valorar negativamente
       VoteFailed: Non se puido enviar o voto a SponsorBlock.
 Playlist:
+  Playlist Already Preloaded: "Todos os vídeos da lista xa están precargados"
+  Playlist Preload Progress: "Precargando vídeos: {completed} de {requested}"
   Close Playlist: Pechar a lista de reprodución
+  Preload Playlist: "Precargar todos os vídeos"
+  Preloading Playlist: "Precargando todos os vídeos..."
+  Playlist Preload Complete: "Vídeos precargados: {count}."
+  Playlist Preload Partial: "Precargáronse {preloaded} de {requested} vídeos. Non se puideron precargar {failed}."
+  Playlist Preload Pagination Failed: "Non se puido cargar a lista completa, polo que se cancelou a precarga."
 Change Format:
   Local Video File: Ficheiro de vídeo local
   Local Audio File: Ficheiro de son local
@@ -1411,6 +1420,8 @@ Tooltips:
       Os valores máis altos poden axudar con conexións lentas ou inestables, pero usan máis largura de banda e memoria.
       Tamén poden facer que o modo automático calcule á baixa a velocidade da conexión e escolla unha calidade inferior.
       As emisións limitadas a unha solicitude á vez ignoran este axuste.
+    Preload Upcoming Videos: "Obtén e garda na caché os URL de yt-dlp dos seguintes vídeos. A cola ten prioridade sobre as listas e as recomendacións."
+    Upcoming Videos to Preload: "Número máximo de vídeos seguintes cuxos URL de yt-dlp se obteñen en segundo plano."
   Download Settings:
     Download Folder: Os vídeos gárdanse neste cartafol. Déixao en branco para usar o cartafol Descargas do sistema.
     Global Additional yt-dlp Arguments: Argumentos adicionais da liña de ordes que se pasan a yt-dlp en todas as descargas, por exemplo --cookies-from-browser firefox.

--- a/static/locales/ai/he.yaml
+++ b/static/locales/ai/he.yaml
@@ -513,6 +513,8 @@ Settings:
         Clipboard: העתקה ללוח
     Rotate Wide Videos to Landscape in Fullscreen: 'סיבוב סרטונים רחבים לרוחב במסך מלא'
     Swipe Up or Down to Enter or Exit Fullscreen: 'החלקה למעלה או למטה כדי להיכנס למסך מלא או לצאת ממנו'
+    Preload Upcoming Videos: "טעינה מראש של הסרטונים הבאים"
+    Upcoming Videos to Preload: "מספר הסרטונים לטעינה מראש"
   Channel Settings:
     Channel Settings: הגדרות ערוץ
     Channel Settings Description: שמירת ההגדרות שנבחרו בזמן צפייה לכל ערוץ בנפרד, כדי שיוחלו שוב בצפייה הבאה באחד מסרטוניו.
@@ -1212,7 +1214,14 @@ Video:
       DownvoteSegment: הצבעה נגד
       VoteFailed: שליחת ההצבעה אל SponsorBlock נכשלה.
 Playlist:
+  Playlist Already Preloaded: "כל סרטוני הפלייליסט כבר נטענו מראש"
+  Playlist Preload Progress: "טוען סרטונים מראש: {completed} מתוך {requested}"
   Close Playlist: סגירת רשימת ההשמעה
+  Preload Playlist: "טעינת כל הסרטונים מראש"
+  Preloading Playlist: "כל הסרטונים נטענים מראש..."
+  Playlist Preload Complete: "סרטונים שנטענו מראש: {count}."
+  Playlist Preload Partial: "נטענו מראש {preloaded} מתוך {requested} סרטונים. טעינת {failed} נכשלה."
+  Playlist Preload Pagination Failed: "לא ניתן היה לטעון את כל רשימת ההשמעה, לכן הטעינה מראש בוטלה."
 Change Format:
   Local Video File: קובץ וידאו מקומי
   Local Audio File: קובץ שמע מקומי
@@ -1409,6 +1418,8 @@ Tooltips:
       ערכים גבוהים עשויים לעזור בחיבור איטי או לא יציב, אך צורכים יותר רוחב פס וזיכרון.
       הם גם עלולים לגרום למצב אוטומטי להעריך את מהירות החיבור בחסר ולבחור באיכות נמוכה יותר.
       זרמים המוגבלים לבקשה אחת בכל פעם מתעלמים מהגדרה זו.
+    Preload Upcoming Videos: "אחזור ושמירה במטמון של כתובות yt-dlp לסרטונים הבאים. לתור יש עדיפות על רשימות השמעה והמלצות."
+    Upcoming Videos to Preload: "המספר המרבי של סרטונים הבאים שכתובות yt-dlp שלהם יאוחזרו ברקע."
   Download Settings:
     Download Folder: הסרטונים נשמרים בתיקייה זו. השאירו ריק כדי להשתמש בתיקיית ההורדות של המערכת.
     Global Additional yt-dlp Arguments: ארגומנטים נוספים לשורת הפקודה שיועברו אל yt-dlp בכל הורדה, לדוגמה --cookies-from-browser firefox.

--- a/static/locales/ai/hr.yaml
+++ b/static/locales/ai/hr.yaml
@@ -502,8 +502,8 @@ Settings:
     Parallel Segment Loading: Paralelno učitavanje segmenata
     Rotate Wide Videos to Landscape in Fullscreen: 'Zakreni široke videozapise vodoravno preko cijelog zaslona'
     Swipe Up or Down to Enter or Exit Fullscreen: 'Povucite gore ili dolje za ulazak u prikaz preko cijelog zaslona ili izlazak iz njega'
-    Preload Upcoming Videos: "Predmemoriraj sljedeće videozapise"
-    Upcoming Videos to Preload: "Broj videozapisa za predmemoriranje"
+    Preload Upcoming Videos: "Predučitaj sljedeće videozapise"
+    Upcoming Videos to Preload: "Broj videozapisa za predučitavanje"
   Channel Settings:
     Channel Settings: Postavke kanala
     Channel Settings Description: Postavke koje odaberete tijekom gledanja pamte se zasebno za svaki kanal kako bi se ponovno primijenile kada sljedeći put gledate neki njegov videozapis.
@@ -1195,11 +1195,11 @@ Playlist:
   Playlist Already Preloaded: "Svi videozapisi na popisu već su predučitani"
   Playlist Preload Progress: "Predučitavanje videozapisa: {completed} od {requested}"
   Close Playlist: Zatvori popis za reprodukciju
-  Preload Playlist: "Predmemoriraj sve videozapise"
-  Preloading Playlist: "Predmemoriranje svih videozapisa..."
-  Playlist Preload Complete: "Predmemorirani videozapisi: {count}."
-  Playlist Preload Partial: "Predmemorirano je {preloaded} od {requested} videozapisa. {failed} nije uspjelo."
-  Playlist Preload Pagination Failed: "Cijeli popis nije se mogao učitati pa je predmemoriranje otkazano."
+  Preload Playlist: "Predučitaj sve videozapise"
+  Preloading Playlist: "Predučitavanje svih videozapisa..."
+  Playlist Preload Complete: "Predučitani videozapisi: {count}."
+  Playlist Preload Partial: "Predučitano je {preloaded} od {requested} videozapisa. Predučitavanje {failed} videozapisa nije uspjelo."
+  Playlist Preload Pagination Failed: "Cijeli popis nije se mogao učitati pa je predučitavanje otkazano."
 Change Format:
   Local Video File: Lokalna videodatoteka
   Local Audio File: Lokalna audiodatoteka

--- a/static/locales/ai/hr.yaml
+++ b/static/locales/ai/hr.yaml
@@ -502,6 +502,8 @@ Settings:
     Parallel Segment Loading: Paralelno učitavanje segmenata
     Rotate Wide Videos to Landscape in Fullscreen: 'Zakreni široke videozapise vodoravno preko cijelog zaslona'
     Swipe Up or Down to Enter or Exit Fullscreen: 'Povucite gore ili dolje za ulazak u prikaz preko cijelog zaslona ili izlazak iz njega'
+    Preload Upcoming Videos: "Predmemoriraj sljedeće videozapise"
+    Upcoming Videos to Preload: "Broj videozapisa za predmemoriranje"
   Channel Settings:
     Channel Settings: Postavke kanala
     Channel Settings Description: Postavke koje odaberete tijekom gledanja pamte se zasebno za svaki kanal kako bi se ponovno primijenile kada sljedeći put gledate neki njegov videozapis.
@@ -1190,7 +1192,14 @@ Video:
       DownvoteSegment: Glasaj protiv
       VoteFailed: Slanje glasa u SponsorBlock nije uspjelo.
 Playlist:
+  Playlist Already Preloaded: "Svi videozapisi na popisu već su predučitani"
+  Playlist Preload Progress: "Predučitavanje videozapisa: {completed} od {requested}"
   Close Playlist: Zatvori popis za reprodukciju
+  Preload Playlist: "Predmemoriraj sve videozapise"
+  Preloading Playlist: "Predmemoriranje svih videozapisa..."
+  Playlist Preload Complete: "Predmemorirani videozapisi: {count}."
+  Playlist Preload Partial: "Predmemorirano je {preloaded} od {requested} videozapisa. {failed} nije uspjelo."
+  Playlist Preload Pagination Failed: "Cijeli popis nije se mogao učitati pa je predmemoriranje otkazano."
 Change Format:
   Local Video File: Lokalna videodatoteka
   Local Audio File: Lokalna audiodatoteka
@@ -1387,6 +1396,8 @@ Tooltips:
       Veće vrijednosti mogu pomoći na sporim ili nestabilnim vezama, ali troše više propusnosti i memorije.
       Zbog njih Automatski odabir također može podcijeniti brzinu veze i odabrati nižu kvalitetu.
       Tokovi ograničeni na jedan zahtjev istodobno zanemaruju ovu postavku.
+    Preload Upcoming Videos: "Dohvaća i sprema yt-dlp adrese za sljedeće videozapise. Red čekanja ima prednost pred popisima i preporukama."
+    Upcoming Videos to Preload: "Najveći broj sljedećih videozapisa čije se yt-dlp adrese dohvaćaju u pozadini."
   Download Settings:
     Download Folder: Videozapisi se spremaju u ovu mapu. Ostavite prazno za upotrebu sustavske mape Preuzimanja.
     Global Additional yt-dlp Arguments: Dodatni argumenti naredbenog retka koji se prosljeđuju alatu yt-dlp pri svakom preuzimanju, primjerice --cookies-from-browser firefox.

--- a/static/locales/ai/hu.yaml
+++ b/static/locales/ai/hu.yaml
@@ -500,6 +500,8 @@ Settings:
     Parallel Segment Loading: Szakaszok párhuzamos betöltése
     Rotate Wide Videos to Landscape in Fullscreen: 'A széles videók elforgatása fekvő helyzetbe teljes képernyőn'
     Swipe Up or Down to Enter or Exit Fullscreen: 'Húzd felfelé vagy lefelé a teljes képernyő megnyitásához vagy bezárásához'
+    Preload Upcoming Videos: "Következő videók előtöltése"
+    Upcoming Videos to Preload: "Előtöltendő videók száma"
   Channel Settings:
     Channel Settings: Csatornabeállítások
     Channel Settings Description: Csatornánként megjegyzi a videónézés közben kiválasztott beállításokat, és a csatorna következő videójánál újra alkalmazza őket.
@@ -1182,7 +1184,14 @@ Video:
       DownvoteSegment: Negatív szavazat
       VoteFailed: Nem sikerült elküldeni a SponsorBlock-szavazatot.
 Playlist:
+  Playlist Already Preloaded: "A lejátszási lista összes videója már elő van töltve"
+  Playlist Preload Progress: "Videók előtöltése: {completed}/{requested}"
   Close Playlist: Lejátszási lista bezárása
+  Preload Playlist: "Összes videó előtöltése"
+  Preloading Playlist: "Az összes videó előtöltése..."
+  Playlist Preload Complete: "Előtöltött videók: {count}."
+  Playlist Preload Partial: "{requested} videóból {preloaded} előtöltve. {failed} előtöltése sikertelen."
+  Playlist Preload Pagination Failed: "A teljes lejátszási lista nem tölthető be, ezért az előtöltés megszakadt."
 Change Format:
   Local Video File: Helyi videófájl
   Local Audio File: Helyi hangfájl
@@ -1379,6 +1388,8 @@ Tooltips:
       A nagyobb érték lassú vagy instabil kapcsolatnál segíthet, de több sávszélességet és memóriát használ.
       Emiatt az Auto alábecsülheti a kapcsolat sebességét, és gyengébb minőséget választhat.
       Az egyszerre egy kérésre korlátozott adatfolyamok figyelmen kívül hagyják ezt a beállítást.
+    Preload Upcoming Videos: "Lekéri és gyorsítótárazza a következő videók yt-dlp-címeit. A várólista elsőbbséget élvez a lejátszási listákkal és ajánlásokkal szemben."
+    Upcoming Videos to Preload: "A háttérben lekért yt-dlp-címmel rendelkező következő videók legnagyobb száma."
   Download Settings:
     Download Folder: A videók ebbe a mappába kerülnek. Hagyja üresen a rendszer Letöltések mappájának használatához.
     Global Additional yt-dlp Arguments: Minden letöltésnél a yt-dlp számára átadott további parancssori argumentumok, például --cookies-from-browser firefox.

--- a/static/locales/ai/id.yaml
+++ b/static/locales/ai/id.yaml
@@ -508,6 +508,8 @@ Settings:
     Parallel Segment Loading: Pemuatan Segmen Paralel
     Rotate Wide Videos to Landscape in Fullscreen: 'Putar video lebar ke lanskap dalam layar penuh'
     Swipe Up or Down to Enter or Exit Fullscreen: 'Geser ke atas atau bawah untuk masuk atau keluar dari layar penuh'
+    Preload Upcoming Videos: "Pramuat video berikutnya"
+    Upcoming Videos to Preload: "Jumlah video yang dipramuat"
   Channel Settings:
     Channel Settings: Pengaturan Saluran
     Channel Settings Description: Ingat pengaturan yang Anda pilih saat menonton untuk setiap saluran, lalu terapkan lagi saat Anda menonton video saluran tersebut berikutnya.
@@ -1204,7 +1206,14 @@ Video:
       DownvoteSegment: Beri suara negatif
       VoteFailed: Gagal mengirim suara SponsorBlock.
 Playlist:
+  Playlist Already Preloaded: "Semua video dalam daftar putar sudah dimuat sebelumnya"
+  Playlist Preload Progress: "Memuat video terlebih dahulu: {completed} dari {requested}"
   Close Playlist: Tutup Daftar Putar
+  Preload Playlist: "Pramuat semua video"
+  Preloading Playlist: "Mempramuat semua video..."
+  Playlist Preload Complete: "Video yang dipramuat: {count}."
+  Playlist Preload Partial: "Berhasil mempramuat {preloaded} dari {requested} video. {failed} gagal dipramuat."
+  Playlist Preload Pagination Failed: "Daftar putar lengkap tidak dapat dimuat, sehingga pramuat dibatalkan."
 Change Format:
   Local Video File: Berkas video lokal
   Local Audio File: Berkas audio lokal
@@ -1401,6 +1410,8 @@ Tooltips:
       Nilai yang lebih tinggi dapat membantu pada koneksi lambat atau tidak stabil, tetapi menggunakan lebih banyak lebar pita dan memori.
       Nilai tersebut juga dapat membuat Otomatis memperkirakan kecepatan koneksi terlalu rendah dan memilih kualitas yang lebih rendah.
       Stream yang dibatasi satu permintaan pada satu waktu mengabaikan pengaturan ini.
+    Preload Upcoming Videos: "Mengambil dan menyimpan URL yt-dlp untuk video berikutnya. Antrean didahulukan dari daftar putar dan rekomendasi."
+    Upcoming Videos to Preload: "Jumlah maksimum video berikutnya yang URL yt-dlp-nya diambil di latar belakang."
   Download Settings:
     Download Folder: Video disimpan ke folder ini. Biarkan kosong untuk menggunakan folder Unduhan sistem.
     Global Additional yt-dlp Arguments: Argumen baris perintah tambahan yang diteruskan ke yt-dlp untuk setiap unduhan, misalnya --cookies-from-browser firefox.

--- a/static/locales/ai/is.yaml
+++ b/static/locales/ai/is.yaml
@@ -508,6 +508,8 @@ Settings:
     Parallel Segment Loading: Samhliða hleðsla búta
     Rotate Wide Videos to Landscape in Fullscreen: 'Snúa breiðum myndskeiðum lárétt á öllum skjánum'
     Swipe Up or Down to Enter or Exit Fullscreen: 'Strjúktu upp eða niður til að opna eða loka öllum skjánum'
+    Preload Upcoming Videos: "Forhlaða næstu myndskeið"
+    Upcoming Videos to Preload: "Fjöldi myndskeiða til að forhlaða"
   Channel Settings:
     Channel Settings: Rásarstillingar
     Channel Settings Description: Muna stillingarnar sem þú velur við áhorf fyrir hverja rás, svo þær verði notaðar aftur næst þegar þú horfir á myndband frá henni.
@@ -1211,7 +1213,14 @@ Video:
       DownvoteSegment: Gefa neikvætt atkvæði
       VoteFailed: Ekki tókst að senda SponsorBlock-atkvæði.
 Playlist:
+  Playlist Already Preloaded: "Öll myndskeið spilunarlistans eru þegar forhlaðin"
+  Playlist Preload Progress: "Forhleð myndskeið: {completed} af {requested}"
   Close Playlist: Loka spilunarlista
+  Preload Playlist: "Forhlaða öll myndskeið"
+  Preloading Playlist: "Forhleð öllum myndskeiðum..."
+  Playlist Preload Complete: "Forhlaðin myndskeið: {count}."
+  Playlist Preload Partial: "Forhlóð {preloaded} af {requested} myndskeiðum. Ekki tókst að forhlaða {failed}."
+  Playlist Preload Pagination Failed: "Ekki tókst að hlaða allan spilunarlistann og forhleðslu var hætt."
 Change Format:
   Local Video File: Staðbundin myndbandsskrá
   Local Audio File: Staðbundin hljóðskrá
@@ -1408,6 +1417,8 @@ Tooltips:
       Hærri gildi geta hjálpað á hægum eða óstöðugum tengingum en nota meiri bandbreidd og minni.
       Þau geta einnig valdið því að Sjálfvirkt vanmeti tengingarhraðann og velji minni gæði.
       Streymi sem er takmarkað við eina beiðni í einu hunsar þessa stillingu.
+    Preload Upcoming Videos: "Sækir og vistar yt-dlp-slóðir næstu myndskeiða. Biðröðin hefur forgang fram yfir spilunarlista og tillögur."
+    Upcoming Videos to Preload: "Hámarksfjöldi næstu myndskeiða sem yt-dlp-slóðir eru sóttar fyrir í bakgrunni."
   Download Settings:
     Download Folder: Myndbönd vistast í þessa möppu. Skildu reitinn eftir auðan til að nota niðurhalsmöppu kerfisins.
     Global Additional yt-dlp Arguments: Viðbótarviðföng skipanalínu sem eru send til yt-dlp við hvert niðurhal, til dæmis --cookies-from-browser firefox.

--- a/static/locales/ai/is.yaml
+++ b/static/locales/ai/is.yaml
@@ -1214,10 +1214,10 @@ Video:
       VoteFailed: Ekki tókst að senda SponsorBlock-atkvæði.
 Playlist:
   Playlist Already Preloaded: "Öll myndskeið spilunarlistans eru þegar forhlaðin"
-  Playlist Preload Progress: "Forhleð myndskeið: {completed} af {requested}"
+  Playlist Preload Progress: "Forhleðsla myndskeiða: {completed} af {requested}"
   Close Playlist: Loka spilunarlista
   Preload Playlist: "Forhlaða öll myndskeið"
-  Preloading Playlist: "Forhleð öllum myndskeiðum..."
+  Preloading Playlist: "Forhleðsla allra myndskeiða..."
   Playlist Preload Complete: "Forhlaðin myndskeið: {count}."
   Playlist Preload Partial: "Forhlóð {preloaded} af {requested} myndskeiðum. Ekki tókst að forhlaða {failed}."
   Playlist Preload Pagination Failed: "Ekki tókst að hlaða allan spilunarlistann og forhleðslu var hætt."

--- a/static/locales/ai/it.yaml
+++ b/static/locales/ai/it.yaml
@@ -500,6 +500,8 @@ Settings:
     Parallel Segment Loading: Caricamento parallelo dei segmenti
     Rotate Wide Videos to Landscape in Fullscreen: 'Ruota i video larghi in orizzontale a schermo intero'
     Swipe Up or Down to Enter or Exit Fullscreen: 'Scorri verso l’alto o il basso per aprire o chiudere lo schermo intero'
+    Preload Upcoming Videos: "Precarica i prossimi video"
+    Upcoming Videos to Preload: "Numero di video da precaricare"
   Channel Settings:
     Channel Settings: Impostazioni dei canali
     Channel Settings Description: Ricorda separatamente per ogni canale le impostazioni scelte durante la visione e le riapplica quando guardi un altro video dello stesso canale.
@@ -1182,7 +1184,14 @@ Video:
       DownvoteSegment: Voto negativo
       VoteFailed: Impossibile inviare il voto a SponsorBlock.
 Playlist:
+  Playlist Already Preloaded: "Tutti i video della playlist sono già precaricati"
+  Playlist Preload Progress: "Precaricamento video: {completed} di {requested}"
   Close Playlist: Chiudi playlist
+  Preload Playlist: "Precarica tutti i video"
+  Preloading Playlist: "Precaricamento di tutti i video..."
+  Playlist Preload Complete: "Video precaricati: {count}."
+  Playlist Preload Partial: "Precaricati {preloaded} video su {requested}. Impossibile precaricarne {failed}."
+  Playlist Preload Pagination Failed: "Non è stato possibile caricare l’intera playlist, quindi il precaricamento è stato annullato."
 Change Format:
   Local Video File: File video locale
   Local Audio File: File audio locale
@@ -1379,6 +1388,8 @@ Tooltips:
       Valori più alti possono essere utili con connessioni lente o instabili, ma usano più banda e memoria.
       Possono anche indurre la modalità Automatica a sottostimare la velocità della connessione e scegliere una qualità inferiore.
       I flussi limitati a una richiesta alla volta ignorano questa impostazione.
+    Preload Upcoming Videos: "Recupera e memorizza nella cache gli URL yt-dlp dei prossimi video. La coda ha la priorità su playlist e consigli."
+    Upcoming Videos to Preload: "Numero massimo di prossimi video i cui URL yt-dlp vengono recuperati in background."
   Download Settings:
     Download Folder: I video vengono salvati in questa cartella. Lascia vuoto per usare la cartella Download del sistema.
     Global Additional yt-dlp Arguments: Argomenti aggiuntivi della riga di comando passati a yt-dlp per ogni download, ad esempio --cookies-from-browser firefox.

--- a/static/locales/ai/ja.yaml
+++ b/static/locales/ai/ja.yaml
@@ -500,6 +500,8 @@ Settings:
     Parallel Segment Loading: セグメントを並列読み込み
     Rotate Wide Videos to Landscape in Fullscreen: '全画面表示で横長の動画を横向きに回転する'
     Swipe Up or Down to Enter or Exit Fullscreen: '上下にスワイプして全画面表示を開始または終了する'
+    Preload Upcoming Videos: "次の動画を先読み"
+    Upcoming Videos to Preload: "先読みする動画数"
   Channel Settings:
     Channel Settings: チャンネル設定
     Channel Settings Description: 視聴中に選んだ設定をチャンネルごとに記憶し、次回そのチャンネルの動画を見るときに再度適用します。
@@ -1182,7 +1184,14 @@ Video:
       DownvoteSegment: 低評価
       VoteFailed: SponsorBlockの評価を送信できませんでした。
 Playlist:
+  Playlist Already Preloaded: "プレイリストのすべての動画は先読み済みです"
+  Playlist Preload Progress: "動画を先読み中: {requested} 本中 {completed} 本"
   Close Playlist: プレイリストを閉じる
+  Preload Playlist: "すべての動画を先読み"
+  Preloading Playlist: "すべての動画を先読みしています..."
+  Playlist Preload Complete: "先読みした動画: {count}。"
+  Playlist Preload Partial: "{requested} 本中 {preloaded} 本を先読みしました。{failed} 本は先読みできませんでした。"
+  Playlist Preload Pagination Failed: "再生リスト全体を読み込めなかったため、先読みを中止しました。"
 Change Format:
   Local Video File: ローカル動画ファイル
   Local Audio File: ローカル音声ファイル
@@ -1379,6 +1388,8 @@ Tooltips:
       値を大きくすると、低速または不安定な接続では改善する場合がありますが、帯域幅とメモリの使用量が増えます。
       また、「自動」が接続速度を実際より低く見積もり、低い品質を選ぶ場合があります。
       一度に1件の要求しか行えないストリームでは、この設定は無視されます。
+    Preload Upcoming Videos: "次に再生可能な動画の yt-dlp URL を取得してキャッシュします。キューは再生リストやおすすめより優先されます。"
+    Upcoming Videos to Preload: "バックグラウンドで yt-dlp URL を取得する次の動画の最大数です。"
   Download Settings:
     Download Folder: 動画をこのフォルダーに保存します。空欄にすると、システムのダウンロードフォルダーを使用します。
     Global Additional yt-dlp Arguments: 'すべてのダウンロードでyt-dlpに渡す追加のコマンドライン引数です。例: --cookies-from-browser firefox'

--- a/static/locales/ai/ko.yaml
+++ b/static/locales/ai/ko.yaml
@@ -675,6 +675,8 @@ Settings:
         Clipboard: 클립보드에 복사
     Rotate Wide Videos to Landscape in Fullscreen: '전체 화면에서 가로형 동영상을 가로 방향으로 회전'
     Swipe Up or Down to Enter or Exit Fullscreen: '위아래로 밀어 전체 화면 시작 또는 종료'
+    Preload Upcoming Videos: "다음 동영상 미리 불러오기"
+    Upcoming Videos to Preload: "미리 불러올 동영상 수"
   Channel Settings:
     Channel Settings: 채널 설정
     Channel Settings Description: 채널마다 시청 중 선택한 설정을 기억하고, 다음에 해당 채널의 동영상을 시청할 때 다시 적용합니다.
@@ -1520,6 +1522,8 @@ Video:
     'Remaining preroll-ad time: {remindingTimeSeconds}s': '프리롤 광고 남은 시간: {remindingTimeSeconds}초'
     'Remaining SABR backoff time: {remindingTimeSeconds}s': 'SABR 대기 남은 시간: {remindingTimeSeconds}초'
 Playlist:
+  Playlist Already Preloaded: "재생목록의 모든 동영상을 이미 미리 불러왔습니다"
+  Playlist Preload Progress: "동영상 미리 불러오는 중: {requested}개 중 {completed}개"
   Close Playlist: 재생목록 닫기
   Sort By:
     DateAddedNewest: 추가한 날짜 (최신순)
@@ -1533,6 +1537,11 @@ Playlist:
     VideoDurationAscending: 재생 시간 (짧은순)
     VideoDurationDescending: 재생 시간 (긴순)
     Custom: 사용자 지정
+  Preload Playlist: "모든 동영상 미리 불러오기"
+  Preloading Playlist: "모든 동영상을 미리 불러오는 중..."
+  Playlist Preload Complete: "미리 불러온 동영상: {count}개."
+  Playlist Preload Partial: "동영상 {requested}개 중 {preloaded}개를 미리 불러왔습니다. {failed}개는 실패했습니다."
+  Playlist Preload Pagination Failed: "재생목록 전체를 불러오지 못해 미리 불러오기를 취소했습니다."
 Change Format:
   Local Video File: 로컬 동영상 파일
   Local Audio File: 로컬 오디오 파일
@@ -1740,6 +1749,8 @@ Tooltips:
       값이 높으면 느리거나 불안정한 연결에서 도움이 될 수 있지만 대역폭과 메모리를 더 많이 사용합니다.
       또한 자동 설정이 연결 속도를 실제보다 낮게 판단하여 더 낮은 화질을 선택할 수 있습니다.
       한 번에 하나의 요청으로 제한된 스트림에는 이 설정이 적용되지 않습니다.
+    Preload Upcoming Videos: "다음에 재생할 동영상의 yt-dlp URL을 가져와 캐시합니다. 대기열이 재생목록과 추천보다 우선합니다."
+    Upcoming Videos to Preload: "백그라운드에서 yt-dlp URL을 가져올 다음 동영상의 최대 개수입니다."
   External Player Settings:
     Ignore Default Arguments: 동영상 URL 외의 기본 인수를 외부 플레이어에 보내지 않습니다. 예를 들어 재생 속도와 재생목록 URL이 해당됩니다. 사용자 지정 인수는 계속 전달됩니다.
   Download Settings:

--- a/static/locales/ai/lt.yaml
+++ b/static/locales/ai/lt.yaml
@@ -700,6 +700,8 @@ Settings:
         Clipboard: Kopijuoti į iškarpinę
     Rotate Wide Videos to Landscape in Fullscreen: 'Pasukti plačius vaizdo įrašus gulsčiai visame ekrane'
     Swipe Up or Down to Enter or Exit Fullscreen: 'Braukite aukštyn arba žemyn, kad įjungtumėte arba išjungtumėte visą ekraną'
+    Preload Upcoming Videos: "Iš anksto įkelti kitus vaizdo įrašus"
+    Upcoming Videos to Preload: "Iš anksto įkeliamų vaizdo įrašų skaičius"
   Channel Settings:
     Channel Settings: Kanalo nustatymai
     Channel Settings Description: Atskirai įsiminti kiekvienam kanalui žiūrint pasirinktus nustatymus, kad jie vėl būtų pritaikyti kitą kartą žiūrint vieną iš jo vaizdo įrašų.
@@ -1555,6 +1557,8 @@ Video:
     'Remaining preroll-ad time: {remindingTimeSeconds}s': 'Reklamos prieš vaizdo įrašą likęs laikas: {remindingTimeSeconds} s'
     'Remaining SABR backoff time: {remindingTimeSeconds}s': 'Likęs SABR delsos laikas: {remindingTimeSeconds} s'
 Playlist:
+  Playlist Already Preloaded: "Visi grojaraščio vaizdo įrašai jau įkelti iš anksto"
+  Playlist Preload Progress: "Vaizdo įrašų išankstinis įkėlimas: {completed} iš {requested}"
   Close Playlist: Uždaryti grojaraštį
   Sort By:
     DateAddedNewest: Pridėjimo data (naujausi viršuje)
@@ -1568,6 +1572,11 @@ Playlist:
     VideoDurationAscending: Trukmė (trumpiausi viršuje)
     VideoDurationDescending: Trukmė (ilgiausi viršuje)
     Custom: Pasirinktinė tvarka
+  Preload Playlist: "Iš anksto įkelti visus vaizdo įrašus"
+  Preloading Playlist: "Iš anksto įkeliami visi vaizdo įrašai..."
+  Playlist Preload Complete: "Iš anksto įkelta vaizdo įrašų: {count}."
+  Playlist Preload Partial: "Iš anksto įkelta {preloaded} iš {requested} vaizdo įrašų. Nepavyko įkelti {failed}."
+  Playlist Preload Pagination Failed: "Nepavyko įkelti viso grojaraščio, todėl išankstinis įkėlimas atšauktas."
 Change Format:
   Local Video File: Vietinis vaizdo įrašo failas
   Local Audio File: Vietinis garso failas
@@ -1778,6 +1787,8 @@ Tooltips:
       Didesnės reikšmės gali padėti esant lėtam ar nestabiliam ryšiui, bet naudoja daugiau pralaidumo ir atminties.
       Dėl jų Auto taip pat gali nepakankamai įvertinti ryšio greitį ir pasirinkti prastesnę kokybę.
       Srautai, apriboti iki vienos užklausos vienu metu, nepaiso šio nustatymo.
+    Preload Upcoming Videos: "Gauna ir talpykloje išsaugo kitų vaizdo įrašų yt-dlp adresus. Eilė yra svarbesnė už grojaraščius ir rekomendacijas."
+    Upcoming Videos to Preload: "Didžiausias kitų vaizdo įrašų skaičius, kurių yt-dlp adresai gaunami fone."
   External Player Settings:
     Ignore Default Arguments: Išoriniam leistuvui nesiųsti jokių numatytųjų argumentų, išskyrus vaizdo įrašo URL (pvz., atkūrimo greitį, grojaraščio URL ir kt.). Pasirinktiniai argumentai vis tiek bus perduoti.
   Download Settings:

--- a/static/locales/ai/nb-NO.yaml
+++ b/static/locales/ai/nb-NO.yaml
@@ -508,6 +508,8 @@ Settings:
         Clipboard: Kopier til utklippstavlen
     Rotate Wide Videos to Landscape in Fullscreen: 'Roter brede videoer til liggende format i fullskjerm'
     Swipe Up or Down to Enter or Exit Fullscreen: 'Sveip opp eller ned for å åpne eller avslutte fullskjerm'
+    Preload Upcoming Videos: "Forhåndslast kommende videoer"
+    Upcoming Videos to Preload: "Antall videoer som skal forhåndslastes"
   Channel Settings:
     Channel Settings: Kanalinnstillinger
     Channel Settings Description: Husk innstillingene du velger mens du ser på hver kanal, slik at de brukes igjen neste gang du ser en av videoene fra kanalen.
@@ -1209,7 +1211,14 @@ Video:
       DownvoteSegment: Stem ned
       VoteFailed: Kunne ikke sende inn SponsorBlock-stemmen.
 Playlist:
+  Playlist Already Preloaded: "Alle videoene i spillelisten er allerede forhåndslastet"
+  Playlist Preload Progress: "Forhåndslaster videoer: {completed} av {requested}"
   Close Playlist: Lukk spillelisten
+  Preload Playlist: "Forhåndslast alle videoer"
+  Preloading Playlist: "Forhåndslaster alle videoer..."
+  Playlist Preload Complete: "Forhåndslastede videoer: {count}."
+  Playlist Preload Partial: "Forhåndslastet {preloaded} av {requested} videoer. {failed} kunne ikke forhåndslastes."
+  Playlist Preload Pagination Failed: "Hele spillelisten kunne ikke lastes, så forhåndslastingen ble avbrutt."
 Change Format:
   Local Video File: Lokal videofil
   Local Audio File: Lokal lydfil
@@ -1406,6 +1415,8 @@ Tooltips:
       Høyere verdier kan hjelpe på trege eller ustabile forbindelser, men bruker mer båndbredde og minne.
       De kan også føre til at Automatisk undervurderer tilkoblingshastigheten og velger lavere kvalitet.
       Strømmer som er begrenset til én forespørsel om gangen, ignorerer denne innstillingen.
+    Preload Upcoming Videos: "Henter og mellomlagrer yt-dlp-adresser for de neste videoene. Køen prioriteres foran spillelister og anbefalinger."
+    Upcoming Videos to Preload: "Maksimalt antall kommende videoer som får yt-dlp-adressene hentet i bakgrunnen."
   Download Settings:
     Download Folder: Videoer lagres i denne mappen. La feltet stå tomt for å bruke systemets nedlastingsmappe.
     Global Additional yt-dlp Arguments: Ekstra kommandolinjeargumenter som sendes til yt-dlp for hver nedlasting, for eksempel --cookies-from-browser firefox.

--- a/static/locales/ai/nl.yaml
+++ b/static/locales/ai/nl.yaml
@@ -513,6 +513,8 @@ Settings:
         Clipboard: Naar klembord kopiëren
     Rotate Wide Videos to Landscape in Fullscreen: 'Brede video’s liggend draaien in volledig scherm'
     Swipe Up or Down to Enter or Exit Fullscreen: 'Veeg omhoog of omlaag om volledig scherm te openen of te sluiten'
+    Preload Upcoming Videos: "Volgende video’s vooraf laden"
+    Upcoming Videos to Preload: "Aantal vooraf te laden video’s"
   Channel Settings:
     Channel Settings: Kanaalinstellingen
     Channel Settings Description: Onthoud de instellingen die je tijdens het kijken kiest afzonderlijk voor elk kanaal, zodat ze weer worden toegepast wanneer je een andere video van dat kanaal bekijkt.
@@ -1221,7 +1223,14 @@ Video:
     'Remaining preroll-ad time: {remindingTimeSeconds}s': 'Resterende tijd van preroll-advertentie: {remindingTimeSeconds}s'
     'Remaining SABR backoff time: {remindingTimeSeconds}s': 'Resterende SABR-wachttijd: {remindingTimeSeconds}s'
 Playlist:
+  Playlist Already Preloaded: "Alle video's in de afspeellijst zijn al vooraf geladen"
+  Playlist Preload Progress: "Video's vooraf laden: {completed} van {requested}"
   Close Playlist: Afspeellijst sluiten
+  Preload Playlist: "Alle video’s vooraf laden"
+  Preloading Playlist: "Alle video’s worden vooraf geladen..."
+  Playlist Preload Complete: "Vooraf geladen video’s: {count}."
+  Playlist Preload Partial: "{preloaded} van {requested} video’s vooraf geladen. {failed} konden niet worden geladen."
+  Playlist Preload Pagination Failed: "De volledige afspeellijst kon niet worden geladen. Vooraf laden is geannuleerd."
 Change Format:
   Local Video File: Lokaal videobestand
   Local Audio File: Lokaal audiobestand
@@ -1418,6 +1427,8 @@ Tooltips:
       Hogere waarden kunnen helpen bij langzame of instabiele verbindingen, maar gebruiken meer bandbreedte en geheugen.
       Hierdoor kan Automatisch de verbindingssnelheid ook onderschatten en een lagere kwaliteit kiezen.
       Streams die tot één aanvraag tegelijk zijn beperkt, negeren deze instelling.
+    Preload Upcoming Videos: "Haalt yt-dlp-URL’s voor de volgende video’s op en bewaart ze in de cache. De wachtrij heeft voorrang op afspeellijsten en aanbevelingen."
+    Upcoming Videos to Preload: "Het maximale aantal volgende video’s waarvan de yt-dlp-URL’s op de achtergrond worden opgehaald."
   Download Settings:
     Download Folder: Video's worden in deze map opgeslagen. Laat dit leeg om de downloadmap van je systeem te gebruiken.
     Global Additional yt-dlp Arguments: Aanvullende opdrachtregelargumenten die bij elke download aan yt-dlp worden doorgegeven, bijvoorbeeld --cookies-from-browser firefox.

--- a/static/locales/ai/nn.yaml
+++ b/static/locales/ai/nn.yaml
@@ -712,6 +712,8 @@ Settings:
         Clipboard: Kopier til utklippstavla
     Rotate Wide Videos to Landscape in Fullscreen: 'Roter breie videoar til liggjande format i fullskjerm'
     Swipe Up or Down to Enter or Exit Fullscreen: 'Sveip opp eller ned for å opne eller avslutte fullskjerm'
+    Preload Upcoming Videos: "Førehandslast komande videoar"
+    Upcoming Videos to Preload: "Talet på videoar som skal førehandslastast"
   Channel Settings:
     Channel Settings: Kanalinnstillingar
     Channel Settings Description: Hugs innstillingane du vel medan du ser på kvar einskild kanal, slik at dei blir brukte att neste gong du ser ein av videoane til kanalen.
@@ -1562,6 +1564,8 @@ Video:
     'Remaining preroll-ad time: {remindingTimeSeconds}s': 'Attverande tid for førehandsannonsen: {remindingTimeSeconds}s'
     'Remaining SABR backoff time: {remindingTimeSeconds}s': 'Attverande ventetid for SABR: {remindingTimeSeconds}s'
 Playlist:
+  Playlist Already Preloaded: "Alle videoane i spelelista er allereie førehandslasta"
+  Playlist Preload Progress: "Førehandslastar videoar: {completed} av {requested}"
   Close Playlist: Lukk spelelista
   Sort By:
     DateAddedNewest: Dato lagd til (nyaste)
@@ -1575,6 +1579,11 @@ Playlist:
     VideoDurationAscending: Lengd (kortaste)
     VideoDurationDescending: Lengd (lengste)
     Custom: Eigendefinert
+  Preload Playlist: "Førehandslast alle videoar"
+  Preloading Playlist: "Førehandslastar alle videoar..."
+  Playlist Preload Complete: "Førehandslasta videoar: {count}."
+  Playlist Preload Partial: "Førehandslasta {preloaded} av {requested} videoar. {failed} kunne ikkje førehandslastast."
+  Playlist Preload Pagination Failed: "Heile spelelista kunne ikkje lastast, så førehandslastinga vart avbroten."
 Change Format:
   Local Video File: Lokal videofil
   Local Audio File: Lokal lydfil
@@ -1782,6 +1791,8 @@ Tooltips:
       Høgare verdiar kan hjelpe på treige eller ustabile samband, men brukar meir bandbreidd og minne.
       Dei kan òg få Automatisk til å undervurdere tilkoplingsfarten og velje lågare kvalitet.
       Straumar som er avgrensa til éin førespurnad om gongen, ser bort frå denne innstillinga.
+    Preload Upcoming Videos: "Hentar og mellomlagrar yt-dlp-adresser for dei neste videoane. Køen har prioritet framfor spelelister og tilrådingar."
+    Upcoming Videos to Preload: "Det høgaste talet på komande videoar som får yt-dlp-adressene henta i bakgrunnen."
   External Player Settings:
     Ignore Default Arguments: Ikkje send andre standardargument enn URL-en til videoen til den eksterne spelaren, til dømes avspelingsfart eller URL til spelelista. Eigne argument vert framleis sende vidare.
   Download Settings:

--- a/static/locales/ai/pl.yaml
+++ b/static/locales/ai/pl.yaml
@@ -156,6 +156,8 @@ Settings:
       Attribution: (obsługiwane przez Yandex)
     Rotate Wide Videos to Landscape in Fullscreen: 'Obracaj szerokie filmy poziomo w trybie pełnoekranowym'
     Swipe Up or Down to Enter or Exit Fullscreen: 'Przesuń w górę lub w dół, aby włączyć lub wyłączyć pełny ekran'
+    Preload Upcoming Videos: "Wstępnie wczytuj następne filmy"
+    Upcoming Videos to Preload: "Liczba filmów do wstępnego wczytania"
   Download Settings:
     Concurrent Downloads: Jednoczesne pobieranie
     Bandwidth Limit: Limit przepustowości (KiB/s, 0 oznacza brak limitu)
@@ -648,6 +650,8 @@ Tooltips:
       Wyższe wartości mogą pomóc przy wolnym lub niestabilnym połączeniu, ale zwiększają użycie transferu i pamięci.
       Mogą też sprawić, że tryb Auto zaniży prędkość połączenia i wybierze niższą jakość.
       To ustawienie nie wpływa na strumienie ograniczone do jednego żądania naraz.
+    Preload Upcoming Videos: "Pobiera i zapisuje w pamięci podręcznej adresy yt-dlp następnych filmów. Kolejka ma pierwszeństwo przed playlistami i rekomendacjami."
+    Upcoming Videos to Preload: "Maksymalna liczba następnych filmów, których adresy yt-dlp są pobierane w tle."
   Download Settings:
     Global Additional yt-dlp Arguments: Dodatkowe argumenty wiersza poleceń przekazywane do yt-dlp przy każdym pobieraniu, na przykład --cookies-from-browser firefox.
     Concurrent Downloads: Maksymalna liczba zadań yt-dlp wykonywanych jednocześnie.
@@ -787,3 +791,11 @@ Downloads:
   Automatic Download Skipped: Pominięte przez filtry automatycznego pobierania
   Templates:
     Subtitles Format: Napisy - {format}
+Playlist:
+  Playlist Already Preloaded: "Wszystkie filmy z playlisty są już wstępnie wczytane"
+  Playlist Preload Progress: "Wstępne wczytywanie filmów: {completed} z {requested}"
+  Preload Playlist: "Wstępnie wczytaj wszystkie filmy"
+  Preloading Playlist: "Wstępne wczytywanie wszystkich filmów..."
+  Playlist Preload Complete: "Wstępnie wczytane filmy: {count}."
+  Playlist Preload Partial: "Wstępnie wczytano {preloaded} z {requested} filmów. Nie udało się wczytać {failed}."
+  Playlist Preload Pagination Failed: "Nie udało się wczytać całej playlisty, więc anulowano wstępne wczytywanie."

--- a/static/locales/ai/pt-BR.yaml
+++ b/static/locales/ai/pt-BR.yaml
@@ -500,6 +500,8 @@ Settings:
     Parallel Segment Loading: Carregamento paralelo de segmentos
     Rotate Wide Videos to Landscape in Fullscreen: 'Girar vídeos largos para paisagem em tela cheia'
     Swipe Up or Down to Enter or Exit Fullscreen: 'Deslize para cima ou para baixo para entrar ou sair da tela cheia'
+    Preload Upcoming Videos: "Pré-carregar os próximos vídeos"
+    Upcoming Videos to Preload: "Número de vídeos a pré-carregar"
   Channel Settings:
     Channel Settings: Configurações dos canais
     Channel Settings Description: Memorizar individualmente para cada canal as configurações escolhidas durante a visualização, para que sejam aplicadas quando voltar a ver um dos seus vídeos.
@@ -1182,7 +1184,14 @@ Video:
       DownvoteSegment: Voto negativo
       VoteFailed: Não foi possível enviar o voto ao SponsorBlock.
 Playlist:
+  Playlist Already Preloaded: "Todos os vídeos da playlist já estão pré-carregados"
+  Playlist Preload Progress: "Pré-carregando vídeos: {completed} de {requested}"
   Close Playlist: Fechar lista de reprodução
+  Preload Playlist: "Pré-carregar todos os vídeos"
+  Preloading Playlist: "A pré-carregar todos os vídeos..."
+  Playlist Preload Complete: "Vídeos pré-carregados: {count}."
+  Playlist Preload Partial: "Foram pré-carregados {preloaded} de {requested} vídeos. Não foi possível pré-carregar {failed}."
+  Playlist Preload Pagination Failed: "Não foi possível carregar a lista completa, por isso o pré-carregamento foi cancelado."
 Change Format:
   Local Video File: Arquivo de vídeo local
   Local Audio File: Arquivo de áudio local
@@ -1379,6 +1388,8 @@ Tooltips:
       Valores mais altos podem ajudar em conexões lentas ou instáveis, mas utilizam mais largura de banda e memória.
       Também podem fazer com que o modo Automático subestime a velocidade da conexão e selecione uma qualidade inferior.
       As transmissões limitadas a um pedido de cada vez ignoram esta configuração.
+    Preload Upcoming Videos: "Obtém e guarda em cache os URL do yt-dlp dos próximos vídeos. A fila tem prioridade sobre listas e recomendações."
+    Upcoming Videos to Preload: "Número máximo de próximos vídeos cujos URL do yt-dlp são obtidos em segundo plano."
   Download Settings:
     Download Folder: Os vídeos são salvos nesta pasta. Deixe em branco para usar a pasta Downloads do sistema.
     Global Additional yt-dlp Arguments: Argumentos adicionais da linha de comandos passados ao yt-dlp em cada download, por exemplo --cookies-from-browser firefox.

--- a/static/locales/ai/pt-PT.yaml
+++ b/static/locales/ai/pt-PT.yaml
@@ -508,6 +508,8 @@ Settings:
     Parallel Segment Loading: Carregamento paralelo de segmentos
     Rotate Wide Videos to Landscape in Fullscreen: 'Rodar vídeos largos para a orientação horizontal em ecrã inteiro'
     Swipe Up or Down to Enter or Exit Fullscreen: 'Deslize para cima ou para baixo para entrar ou sair do ecrã inteiro'
+    Preload Upcoming Videos: "Pré-carregar os próximos vídeos"
+    Upcoming Videos to Preload: "Número de vídeos a pré-carregar"
   Channel Settings:
     Channel Settings: Definições dos canais
     Channel Settings Description: Memorizar individualmente para cada canal as definições escolhidas durante a visualização, para que sejam aplicadas quando voltar a ver um dos seus vídeos.
@@ -1202,7 +1204,14 @@ Video:
       DownvoteSegment: Voto negativo
       VoteFailed: Não foi possível enviar o voto ao SponsorBlock.
 Playlist:
+  Playlist Already Preloaded: "Todos os vídeos da lista já estão pré-carregados"
+  Playlist Preload Progress: "A pré-carregar vídeos: {completed} de {requested}"
   Close Playlist: Fechar lista de reprodução
+  Preload Playlist: "Pré-carregar todos os vídeos"
+  Preloading Playlist: "A pré-carregar todos os vídeos..."
+  Playlist Preload Complete: "Vídeos pré-carregados: {count}."
+  Playlist Preload Partial: "Foram pré-carregados {preloaded} de {requested} vídeos. Não foi possível pré-carregar {failed}."
+  Playlist Preload Pagination Failed: "Não foi possível carregar a lista completa, por isso o pré-carregamento foi cancelado."
 Change Format:
   Local Video File: Ficheiro de vídeo local
   Local Audio File: Ficheiro de áudio local
@@ -1398,6 +1407,8 @@ Tooltips:
       Valores mais altos podem ajudar em ligações lentas ou instáveis, mas utilizam mais largura de banda e memória.
       Também podem fazer com que o modo Automático subestime a velocidade da ligação e selecione uma qualidade inferior.
       As transmissões limitadas a um pedido de cada vez ignoram esta definição.
+    Preload Upcoming Videos: "Obtém e guarda em cache os URL do yt-dlp dos próximos vídeos. A fila tem prioridade sobre listas e recomendações."
+    Upcoming Videos to Preload: "Número máximo de próximos vídeos cujos URL do yt-dlp são obtidos em segundo plano."
   Download Settings:
     Download Folder: Os vídeos são guardados nesta pasta. Deixe em branco para utilizar a pasta Transferências do sistema.
     Global Additional yt-dlp Arguments: Argumentos adicionais da linha de comandos passados ao yt-dlp em cada descarga, por exemplo --cookies-from-browser firefox.

--- a/static/locales/ai/pt.yaml
+++ b/static/locales/ai/pt.yaml
@@ -516,6 +516,8 @@ Settings:
         Clipboard: Copiar para a área de transferência
     Rotate Wide Videos to Landscape in Fullscreen: 'Rodar vídeos largos para a orientação horizontal em ecrã inteiro'
     Swipe Up or Down to Enter or Exit Fullscreen: 'Deslize para cima ou para baixo para entrar ou sair do ecrã inteiro'
+    Preload Upcoming Videos: "Pré-carregar os próximos vídeos"
+    Upcoming Videos to Preload: "Número de vídeos a pré-carregar"
   Channel Settings:
     Channel Settings: Definições dos canais
     Channel Settings Description: Memorizar individualmente para cada canal as definições escolhidas durante a visualização, para que sejam aplicadas quando voltar a ver um dos seus vídeos.
@@ -1217,7 +1219,14 @@ Video:
     'Remaining preroll-ad time: {remindingTimeSeconds}s': 'Tempo restante do anúncio inicial: {remindingTimeSeconds}s'
     'Remaining SABR backoff time: {remindingTimeSeconds}s': 'Tempo restante de espera do SABR: {remindingTimeSeconds}s'
 Playlist:
+  Playlist Already Preloaded: "Todos os vídeos da lista já estão pré-carregados"
+  Playlist Preload Progress: "A pré-carregar vídeos: {completed} de {requested}"
   Close Playlist: Fechar lista de reprodução
+  Preload Playlist: "Pré-carregar todos os vídeos"
+  Preloading Playlist: "A pré-carregar todos os vídeos..."
+  Playlist Preload Complete: "Vídeos pré-carregados: {count}."
+  Playlist Preload Partial: "Foram pré-carregados {preloaded} de {requested} vídeos. Não foi possível pré-carregar {failed}."
+  Playlist Preload Pagination Failed: "Não foi possível carregar a lista completa, por isso o pré-carregamento foi cancelado."
 Change Format:
   Local Video File: Ficheiro de vídeo local
   Local Audio File: Ficheiro de áudio local
@@ -1414,6 +1423,8 @@ Tooltips:
       Valores mais altos podem ajudar em ligações lentas ou instáveis, mas utilizam mais largura de banda e memória.
       Também podem fazer com que o modo Automático subestime a velocidade da ligação e selecione uma qualidade inferior.
       As transmissões limitadas a um pedido de cada vez ignoram esta definição.
+    Preload Upcoming Videos: "Obtém e guarda em cache os URL do yt-dlp dos próximos vídeos. A fila tem prioridade sobre listas e recomendações."
+    Upcoming Videos to Preload: "Número máximo de próximos vídeos cujos URL do yt-dlp são obtidos em segundo plano."
   Download Settings:
     Download Folder: Os vídeos são guardados nesta pasta. Deixe em branco para utilizar a pasta Transferências do sistema.
     Global Additional yt-dlp Arguments: Argumentos adicionais da linha de comandos passados ao yt-dlp em cada descarga, por exemplo --cookies-from-browser firefox.

--- a/static/locales/ai/ro.yaml
+++ b/static/locales/ai/ro.yaml
@@ -504,6 +504,8 @@ Settings:
     Parallel Segment Loading: Încărcarea paralelă a segmentelor
     Rotate Wide Videos to Landscape in Fullscreen: 'Rotește videoclipurile late în modul peisaj pe ecran complet'
     Swipe Up or Down to Enter or Exit Fullscreen: 'Glisează în sus sau în jos pentru a intra sau a ieși din ecranul complet'
+    Preload Upcoming Videos: "Preîncarcă videoclipurile următoare"
+    Upcoming Videos to Preload: "Numărul de videoclipuri de preîncărcat"
   Channel Settings:
     Channel Settings: Setări pentru canale
     Channel Settings Description: Rețineți separat pentru fiecare canal setările alese în timpul vizionării, pentru a fi aplicate din nou când vizionați alt videoclip al canalului.
@@ -1208,7 +1210,14 @@ Video:
     'Remaining preroll-ad time: {remindingTimeSeconds}s': 'Timp rămas din reclama de început: {remindingTimeSeconds}s'
     'Remaining SABR backoff time: {remindingTimeSeconds}s': 'Timp rămas din așteptarea SABR: {remindingTimeSeconds}s'
 Playlist:
+  Playlist Already Preloaded: "Toate videoclipurile din lista de redare sunt deja preîncărcate"
+  Playlist Preload Progress: "Se preîncarcă videoclipurile: {completed} din {requested}"
   Close Playlist: Închide playlistul
+  Preload Playlist: "Preîncarcă toate videoclipurile"
+  Preloading Playlist: "Se preîncarcă toate videoclipurile..."
+  Playlist Preload Complete: "Videoclipuri preîncărcate: {count}."
+  Playlist Preload Partial: "S-au preîncărcat {preloaded} din {requested} videoclipuri. {failed} nu au putut fi preîncărcate."
+  Playlist Preload Pagination Failed: "Lista completă nu a putut fi încărcată, așa că preîncărcarea a fost anulată."
 Change Format:
   Local Video File: Fișier video local
   Local Audio File: Fișier audio local
@@ -1409,6 +1418,8 @@ Tooltips:
       Valorile mai mari pot fi utile în cazul conexiunilor lente sau instabile, dar folosesc mai multă lățime de bandă și memorie.
       De asemenea, pot determina modul Automat să subestimeze viteza conexiunii și să selecteze o calitate mai scăzută.
       Fluxurile limitate la o singură solicitare simultană ignoră această setare.
+    Preload Upcoming Videos: "Obține și memorează în cache adresele yt-dlp ale videoclipurilor următoare. Coada are prioritate față de liste și recomandări."
+    Upcoming Videos to Preload: "Numărul maxim de videoclipuri următoare ale căror adrese yt-dlp sunt obținute în fundal."
   Download Settings:
     Download Folder: Videoclipurile sunt salvate în acest folder. Lăsați necompletat pentru a folosi folderul Descărcări al sistemului.
     Global Additional yt-dlp Arguments: Argumente suplimentare de linie de comandă transmise către yt-dlp pentru fiecare descărcare, de exemplu --cookies-from-browser firefox.

--- a/static/locales/ai/ru.yaml
+++ b/static/locales/ai/ru.yaml
@@ -485,6 +485,8 @@ Settings:
       Mode: Режим снимка экрана
     Rotate Wide Videos to Landscape in Fullscreen: 'Поворачивать широкие видео горизонтально в полноэкранном режиме'
     Swipe Up or Down to Enter or Exit Fullscreen: 'Проведите вверх или вниз, чтобы открыть или закрыть полноэкранный режим'
+    Preload Upcoming Videos: "Предзагружать следующие видео"
+    Upcoming Videos to Preload: "Количество видео для предзагрузки"
   Channel Settings:
     Channel Settings: Настройки каналов
     Channel Settings Description: Запоминать выбранные при просмотре настройки отдельно для каждого канала и применять их снова при следующем просмотре видео с этого канала.
@@ -1182,7 +1184,14 @@ Video:
       DownvoteSegment: Не нравится
       VoteFailed: Не удалось отправить оценку в SponsorBlock.
 Playlist:
+  Playlist Already Preloaded: "Все видео из плейлиста уже предварительно загружены"
+  Playlist Preload Progress: "Предварительная загрузка видео: {completed} из {requested}"
   Close Playlist: Закрыть плейлист
+  Preload Playlist: "Предзагрузить все видео"
+  Preloading Playlist: "Предзагрузка всех видео..."
+  Playlist Preload Complete: "Предзагружено видео: {count}."
+  Playlist Preload Partial: "Предзагружено {preloaded} из {requested} видео. Не удалось загрузить {failed}."
+  Playlist Preload Pagination Failed: "Не удалось загрузить весь плейлист, поэтому предзагрузка отменена."
 Change Format:
   Local Video File: Локальный видеофайл
   Local Audio File: Локальный аудиофайл
@@ -1379,6 +1388,8 @@ Tooltips:
       Высокие значения могут помочь при медленном или нестабильном соединении, но требуют больше пропускной способности и памяти.
       Из-за них режим «Авто» также может занизить скорость соединения и выбрать более низкое качество.
       Этот параметр не влияет на потоки, ограниченные одним запросом за раз.
+    Preload Upcoming Videos: "Получает и кэширует адреса yt-dlp для следующих видео. Очередь имеет приоритет над плейлистами и рекомендациями."
+    Upcoming Videos to Preload: "Максимальное количество следующих видео, адреса yt-dlp которых загружаются в фоне."
   Download Settings:
     Download Folder: Видео сохраняются в эту папку. Оставьте поле пустым, чтобы использовать системную папку «Загрузки».
     Global Additional yt-dlp Arguments: Дополнительные аргументы командной строки, передаваемые yt-dlp при каждой загрузке, например --cookies-from-browser firefox.

--- a/static/locales/ai/sk.yaml
+++ b/static/locales/ai/sk.yaml
@@ -500,6 +500,8 @@ Settings:
     Parallel Segment Loading: Súbežné načítavanie segmentov
     Rotate Wide Videos to Landscape in Fullscreen: 'Otočiť široké videá na šírku v režime celej obrazovky'
     Swipe Up or Down to Enter or Exit Fullscreen: 'Potiahnutím nahor alebo nadol otvoriť či opustiť celú obrazovku'
+    Preload Upcoming Videos: "Prednačítavať nasledujúce videá"
+    Upcoming Videos to Preload: "Počet videí na prednačítanie"
   Channel Settings:
     Channel Settings: Nastavenia kanálov
     Channel Settings Description: Nastavenia, ktoré vyberiete pri sledovaní, sa zapamätajú pre každý kanál samostatne a znova sa použijú pri ďalšom sledovaní jeho videa.
@@ -1182,7 +1184,14 @@ Video:
       DownvoteSegment: Hlasovať proti
       VoteFailed: Hlas SponsorBlock sa nepodarilo odoslať.
 Playlist:
+  Playlist Already Preloaded: "Všetky videá v playliste sú už predbežne načítané"
+  Playlist Preload Progress: "Predbežné načítavanie videí: {completed} z {requested}"
   Close Playlist: Zavrieť zoznam videí
+  Preload Playlist: "Prednačítať všetky videá"
+  Preloading Playlist: "Prednačítavajú sa všetky videá..."
+  Playlist Preload Complete: "Prednačítané videá: {count}."
+  Playlist Preload Partial: "Prednačítaných {preloaded} z {requested} videí. {failed} sa nepodarilo prednačítať."
+  Playlist Preload Pagination Failed: "Celý zoznam sa nepodarilo načítať, preto bolo prednačítanie zrušené."
 Change Format:
   Local Video File: Miestny súbor videa
   Local Audio File: Miestny zvukový súbor
@@ -1379,6 +1388,8 @@ Tooltips:
       Vyššie hodnoty môžu pomôcť pri pomalom alebo nestabilnom pripojení, ale využívajú väčšiu šírku pásma a viac pamäte.
       Môžu tiež spôsobiť, že automatický režim podhodnotí rýchlosť pripojenia a vyberie nižšiu kvalitu.
       Streamy obmedzené na jednu požiadavku naraz toto nastavenie ignorujú.
+    Preload Upcoming Videos: "Načíta a uloží do vyrovnávacej pamäte adresy yt-dlp pre nasledujúce videá. Front má prednosť pred zoznamami a odporúčaniami."
+    Upcoming Videos to Preload: "Najvyšší počet nasledujúcich videí, ktorých adresy yt-dlp sa načítajú na pozadí."
   Download Settings:
     Download Folder: Videá sa ukladajú do tohto priečinka. Ak chcete použiť systémový priečinok Stiahnuté súbory, ponechajte pole prázdne.
     Global Additional yt-dlp Arguments: Dodatočné argumenty príkazového riadka odovzdané nástroju yt-dlp pri každom sťahovaní, napríklad --cookies-from-browser firefox.

--- a/static/locales/ai/sl.yaml
+++ b/static/locales/ai/sl.yaml
@@ -712,6 +712,8 @@ Settings:
         Clipboard: Kopiraj v odložišče
     Rotate Wide Videos to Landscape in Fullscreen: 'Zavrti široke videoposnetke ležeče v celozaslonskem načinu'
     Swipe Up or Down to Enter or Exit Fullscreen: 'Podrsajte navzgor ali navzdol za vstop v celozaslonski način ali izhod iz njega'
+    Preload Upcoming Videos: "Prednaloži naslednje videoposnetke"
+    Upcoming Videos to Preload: "Število videov za prednalaganje"
   Channel Settings:
     Channel Settings: Nastavitve kanalov
     Channel Settings Description: Zapomni si nastavitve, ki jih med gledanjem izberete za vsak kanal posebej, in jih znova uporabi ob naslednjem ogledu enega od njegovih videoposnetkov.
@@ -1629,6 +1631,8 @@ Video:
     'Remaining preroll-ad time: {remindingTimeSeconds}s': 'Preostali čas oglasa pred videoposnetkom: {remindingTimeSeconds}s'
     'Remaining SABR backoff time: {remindingTimeSeconds}s': 'Preostali čas zakasnitve SABR: {remindingTimeSeconds}s'
 Playlist:
+  Playlist Already Preloaded: "Vsi videoposnetki na seznamu so že prednaloženi"
+  Playlist Preload Progress: "Prednalaganje videoposnetkov: {completed} od {requested}"
   Close Playlist: Zapri seznam predvajanja
   Sort By:
     DateAddedNewest: Datum dodajanja (najnovejši)
@@ -1642,6 +1646,11 @@ Playlist:
     VideoDurationAscending: Trajanje (najkrajši)
     VideoDurationDescending: Trajanje (najdaljši)
     Custom: Po meri
+  Preload Playlist: "Prednaloži vse videoposnetke"
+  Preloading Playlist: "Prednalaganje vseh videoposnetkov..."
+  Playlist Preload Complete: "Prednaloženi videoposnetki: {count}."
+  Playlist Preload Partial: "Prednaloženih je {preloaded} od {requested} videov. {failed} jih ni bilo mogoče prednaložiti."
+  Playlist Preload Pagination Failed: "Celotnega seznama ni bilo mogoče naložiti, zato je bilo prednalaganje preklicano."
 Change Format:
   Local Video File: Lokalna videodatoteka
   Local Audio File: Lokalna zvočna datoteka
@@ -1865,6 +1874,8 @@ Tooltips:
       Višje vrednosti lahko pomagajo pri počasnih ali nestabilnih povezavah, vendar porabijo več pasovne širine in pomnilnika.
       Lahko tudi povzročijo, da možnost »Samodejno« podceni hitrost povezave in izbere nižjo kakovost.
       Pretoki, omejeni na eno zahtevo naenkrat, to nastavitev prezrejo.
+    Preload Upcoming Videos: "Pridobi in predpomni naslove yt-dlp naslednjih videov. Čakalna vrsta ima prednost pred seznami in priporočili."
+    Upcoming Videos to Preload: "Največje število naslednjih videov, katerih naslovi yt-dlp se pridobijo v ozadju."
   External Player Settings:
     External Player: Če izberete zunanji predvajalnik, se na sličici prikaže ikona za odpiranje videoposnetka oziroma seznama predvajanja, če je podprt, v zunanjem predvajalniku. Nastavitve Invidious ne vplivajo na zunanje predvajalnike.
     Custom External Player Executable: OpenTubeX privzeto predvideva, da je izbrani zunanji predvajalnik mogoče najti prek okoljske spremenljivke PATH. Po potrebi lahko tukaj nastavite pot po meri.

--- a/static/locales/ai/sr.yaml
+++ b/static/locales/ai/sr.yaml
@@ -523,8 +523,8 @@ Settings:
         Clipboard: Копирај у оставу
     Rotate Wide Videos to Landscape in Fullscreen: 'Окрени широке видео-снимке водоравно преко целог екрана'
     Swipe Up or Down to Enter or Exit Fullscreen: 'Превуците нагоре или надоле за улазак у приказ преко целог екрана или излазак из њега'
-    Preload Upcoming Videos: "Unapred učitaj sledeće video-snimke"
-    Upcoming Videos to Preload: "Broj snimaka za učitavanje unapred"
+    Preload Upcoming Videos: "Учитај следеће видео-снимке унапред"
+    Upcoming Videos to Preload: "Број снимака за учитавање унапред"
   Channel Settings:
     Channel Settings: Подешавања канала
     Channel Settings Description: За сваки канал засебно запамти подешавања која изабереш током гледања, како би поново била примењена када следећи пут гледаш неки његов видео-снимак.
@@ -1240,11 +1240,11 @@ Playlist:
   Playlist Already Preloaded: "Сви видео снимци са плејлисте су већ претходно учитани"
   Playlist Preload Progress: "Претходно учитавање видео снимака: {completed} од {requested}"
   Close Playlist: Затвори листу за репродукцију
-  Preload Playlist: "Unapred učitaj sve snimke"
-  Preloading Playlist: "Učitavanje svih snimaka unapred..."
-  Playlist Preload Complete: "Unapred učitani snimci: {count}."
-  Playlist Preload Partial: "Unapred je učitano {preloaded} od {requested} snimaka. {failed} nije uspelo."
-  Playlist Preload Pagination Failed: "Cela plejlista nije mogla da se učita, pa je učitavanje unapred otkazano."
+  Preload Playlist: "Учитај све снимке унапред"
+  Preloading Playlist: "Учитавање свих снимака унапред..."
+  Playlist Preload Complete: "Унапред учитани снимци: {count}."
+  Playlist Preload Partial: "Унапред је учитано {preloaded} од {requested} снимака. Учитавање {failed} видео-снимака унапред није успело."
+  Playlist Preload Pagination Failed: "Цела плејлиста није могла да се учита, па је учитавање унапред отказано."
 Change Format:
   Local Video File: Локална видео-датотека
   Local Audio File: Локална аудио-датотека
@@ -1445,8 +1445,8 @@ Tooltips:
       Веће вредности могу помоћи на спорим или нестабилним везама, али користе више пропусног опсега и меморије.
       Због њих аутоматски избор може потценити брзину везе и изабрати нижи квалитет.
       Токови ограничени на један захтев истовремено занемарују ово подешавање.
-    Preload Upcoming Videos: "Preuzima i kešira yt-dlp adrese sledećih snimaka. Red ima prednost nad plejlistama i preporukama."
-    Upcoming Videos to Preload: "Najveći broj sledećih snimaka čije se yt-dlp adrese preuzimaju u pozadini."
+    Preload Upcoming Videos: "Преузима и кешира yt-dlp адресе следећих снимака. Ред има предност над плејлистама и препорукама."
+    Upcoming Videos to Preload: "Највећи број следећих снимака чије се yt-dlp адресе преузимају у позадини."
   Download Settings:
     Download Folder: Видео-снимци се чувају у овој фасцикли. Оставите празно да бисте користили системску фасциклу за преузимања.
     Global Additional yt-dlp Arguments: Додатни аргументи командне линије који се прослеђују програму yt-dlp при сваком преузимању, на пример --cookies-from-browser firefox.

--- a/static/locales/ai/sr.yaml
+++ b/static/locales/ai/sr.yaml
@@ -523,6 +523,8 @@ Settings:
         Clipboard: Копирај у оставу
     Rotate Wide Videos to Landscape in Fullscreen: 'Окрени широке видео-снимке водоравно преко целог екрана'
     Swipe Up or Down to Enter or Exit Fullscreen: 'Превуците нагоре или надоле за улазак у приказ преко целог екрана или излазак из њега'
+    Preload Upcoming Videos: "Unapred učitaj sledeće video-snimke"
+    Upcoming Videos to Preload: "Broj snimaka za učitavanje unapred"
   Channel Settings:
     Channel Settings: Подешавања канала
     Channel Settings Description: За сваки канал засебно запамти подешавања која изабереш током гледања, како би поново била примењена када следећи пут гледаш неки његов видео-снимак.
@@ -1235,7 +1237,14 @@ Video:
     'Remaining preroll-ad time: {remindingTimeSeconds}s': 'Преостало време уводног огласа: {remindingTimeSeconds}s'
     'Remaining SABR backoff time: {remindingTimeSeconds}s': 'Преостало време до поновног покушаја SABR-а: {remindingTimeSeconds}s'
 Playlist:
+  Playlist Already Preloaded: "Сви видео снимци са плејлисте су већ претходно учитани"
+  Playlist Preload Progress: "Претходно учитавање видео снимака: {completed} од {requested}"
   Close Playlist: Затвори листу за репродукцију
+  Preload Playlist: "Unapred učitaj sve snimke"
+  Preloading Playlist: "Učitavanje svih snimaka unapred..."
+  Playlist Preload Complete: "Unapred učitani snimci: {count}."
+  Playlist Preload Partial: "Unapred je učitano {preloaded} od {requested} snimaka. {failed} nije uspelo."
+  Playlist Preload Pagination Failed: "Cela plejlista nije mogla da se učita, pa je učitavanje unapred otkazano."
 Change Format:
   Local Video File: Локална видео-датотека
   Local Audio File: Локална аудио-датотека
@@ -1436,6 +1445,8 @@ Tooltips:
       Веће вредности могу помоћи на спорим или нестабилним везама, али користе више пропусног опсега и меморије.
       Због њих аутоматски избор може потценити брзину везе и изабрати нижи квалитет.
       Токови ограничени на један захтев истовремено занемарују ово подешавање.
+    Preload Upcoming Videos: "Preuzima i kešira yt-dlp adrese sledećih snimaka. Red ima prednost nad plejlistama i preporukama."
+    Upcoming Videos to Preload: "Najveći broj sledećih snimaka čije se yt-dlp adrese preuzimaju u pozadini."
   Download Settings:
     Download Folder: Видео-снимци се чувају у овој фасцикли. Оставите празно да бисте користили системску фасциклу за преузимања.
     Global Additional yt-dlp Arguments: Додатни аргументи командне линије који се прослеђују програму yt-dlp при сваком преузимању, на пример --cookies-from-browser firefox.

--- a/static/locales/ai/sv.yaml
+++ b/static/locales/ai/sv.yaml
@@ -502,6 +502,8 @@ Settings:
     Parallel Segment Loading: Parallell inläsning av segment
     Rotate Wide Videos to Landscape in Fullscreen: 'Rotera breda videor till liggande läge i helskärm'
     Swipe Up or Down to Enter or Exit Fullscreen: 'Svep uppåt eller nedåt för att öppna eller lämna helskärm'
+    Preload Upcoming Videos: "Förinläs kommande videor"
+    Upcoming Videos to Preload: "Antal videor att förinläsa"
   Channel Settings:
     Channel Settings: Kanalinställningar
     Channel Settings Description: Kom ihåg inställningarna du väljer när du tittar för varje enskild kanal och använd dem nästa gång du tittar på en av kanalens videor.
@@ -1186,7 +1188,14 @@ Video:
       DownvoteSegment: Rösta ned
       VoteFailed: Det gick inte att skicka SponsorBlock-rösten.
 Playlist:
+  Playlist Already Preloaded: "Alla videor i spellistan är redan förladdade"
+  Playlist Preload Progress: "Förladdar videor: {completed} av {requested}"
   Close Playlist: Stäng spellista
+  Preload Playlist: "Förinläs alla videor"
+  Preloading Playlist: "Förinläser alla videor..."
+  Playlist Preload Complete: "Förinlästa videor: {count}."
+  Playlist Preload Partial: "Förinläste {preloaded} av {requested} videor. {failed} kunde inte förinläsas."
+  Playlist Preload Pagination Failed: "Hela spellistan kunde inte läsas in, så förinläsningen avbröts."
 Change Format:
   Local Video File: Lokal videofil
   Local Audio File: Lokal ljudfil
@@ -1383,6 +1392,8 @@ Tooltips:
       Högre värden kan hjälpa vid långsamma eller instabila anslutningar men använder mer bandbredd och minne.
       De kan även göra att Auto underskattar anslutningshastigheten och väljer en lägre kvalitet.
       Strömmar som är begränsade till en begäran åt gången ignorerar inställningen.
+    Preload Upcoming Videos: "Hämtar och mellanlagrar yt-dlp-adresser för nästa videor. Kön prioriteras före spellistor och rekommendationer."
+    Upcoming Videos to Preload: "Det högsta antalet kommande videor vars yt-dlp-adresser hämtas i bakgrunden."
   Download Settings:
     Download Folder: Videor sparas i den här mappen. Lämna tomt för att använda systemets nedladdningsmapp.
     Global Additional yt-dlp Arguments: Extra kommandoradsargument som skickas till yt-dlp vid varje nedladdning, exempelvis --cookies-from-browser firefox.

--- a/static/locales/ai/ta.yaml
+++ b/static/locales/ai/ta.yaml
@@ -512,6 +512,8 @@ Settings:
         Clipboard: இடைநிலைப் பலகைக்கு நகலெடு
     Rotate Wide Videos to Landscape in Fullscreen: 'முழுத்திரையில் அகலமான காணொளிகளைக் கிடைமட்டமாகச் சுழற்றவும்'
     Swipe Up or Down to Enter or Exit Fullscreen: 'முழுத்திரையில் நுழைய அல்லது வெளியேற மேலே அல்லது கீழே தேய்க்கவும்'
+    Preload Upcoming Videos: "அடுத்த காணொளிகளை முன்பே ஏற்று"
+    Upcoming Videos to Preload: "முன்பே ஏற்ற வேண்டிய காணொளிகளின் எண்ணிக்கை"
   Channel Settings:
     Channel Settings: சேனல் அமைப்புகள்
     Channel Settings Description: ஒவ்வொரு சேனலையும் பார்க்கும்போது தேர்ந்தெடுக்கும் அமைப்புகளைத் தனித்தனியாக நினைவில் கொண்டு, அதன் காணொளியை அடுத்த முறை பார்க்கும்போது மீண்டும் பயன்படுத்தும்.
@@ -1215,7 +1217,14 @@ Video:
   Watch:
     'Remaining preroll-ad time: {remindingTimeSeconds}s': 'தொடக்க விளம்பரத்தில் மீதமுள்ள நேரம்: {remindingTimeSeconds}வி.'
 Playlist:
+  Playlist Already Preloaded: "பிளேலிஸ்ட்டின் அனைத்து காணொளிகளும் ஏற்கனவே முன்பே ஏற்றப்பட்டுள்ளன"
+  Playlist Preload Progress: "காணொளிகளை முன்பே ஏற்றுகிறது: {requested} இல் {completed}"
   Close Playlist: பிளேலிஸ்ட்டை மூடு
+  Preload Playlist: "அனைத்து காணொளிகளையும் முன்பே ஏற்று"
+  Preloading Playlist: "அனைத்து காணொளிகளும் முன்பே ஏற்றப்படுகின்றன..."
+  Playlist Preload Complete: "முன்பே ஏற்றப்பட்ட காணொளிகள்: {count}."
+  Playlist Preload Partial: "{requested} காணொளிகளில் {preloaded} முன்பே ஏற்றப்பட்டன. {failed} ஏற்ற முடியவில்லை."
+  Playlist Preload Pagination Failed: "முழு இயக்கப்பட்டியலை ஏற்ற முடியாததால் முன்பே ஏற்றுவது நிறுத்தப்பட்டது."
 Change Format:
   Local Video File: உள்ளகக் காணொளிக் கோப்பு
   Local Audio File: உள்ளக ஒலிக் கோப்பு
@@ -1412,6 +1421,8 @@ Tooltips:
       அதிக மதிப்புகள் மெதுவான அல்லது நிலையற்ற இணைப்புகளில் உதவலாம். ஆனால் அதிக அலைவரிசையையும் நினைவகத்தையும் பயன்படுத்தும்.
       இணைப்பு வேகத்தைத் தானியக்கத் தேர்வு குறைவாக மதிப்பிட்டு, குறைந்த தரத்தைத் தேர்ந்தெடுக்கவும் அவை காரணமாகலாம்.
       ஒரே நேரத்தில் ஒரு கோரிக்கைக்கு வரம்பிடப்பட்ட ஸ்ட்ரீம்கள் இந்த அமைப்பைப் பொருட்படுத்தாது.
+    Preload Upcoming Videos: "அடுத்த காணொளிகளின் yt-dlp முகவரிகளைப் பெற்று தற்காலிகமாக சேமிக்கிறது. வரிசைக்கு இயக்கப்பட்டியல் மற்றும் பரிந்துரைகளை விட முன்னுரிமை உண்டு."
+    Upcoming Videos to Preload: "பின்னணியில் yt-dlp முகவரிகள் பெறப்படும் அடுத்த காணொளிகளின் அதிகபட்ச எண்ணிக்கை."
   Download Settings:
     Download Folder: காணொளிகள் இந்தக் கோப்புறையில் சேமிக்கப்படும். உங்கள் கணினியின் பதிவிறக்கங்கள் கோப்புறையைப் பயன்படுத்தக் காலியாக விடவும்.
     Global Additional yt-dlp Arguments: ஒவ்வொரு பதிவிறக்கத்திற்கும் yt-dlp-க்குக் கொடுக்கப்படும் கூடுதல் கட்டளைவரி அளவுருக்கள். எடுத்துக்காட்டு, --cookies-from-browser firefox.

--- a/static/locales/ai/tr.yaml
+++ b/static/locales/ai/tr.yaml
@@ -500,6 +500,8 @@ Settings:
     Parallel Segment Loading: Paralel Bölüm Yükleme
     Rotate Wide Videos to Landscape in Fullscreen: 'Geniş videoları tam ekranda yatay konuma döndür'
     Swipe Up or Down to Enter or Exit Fullscreen: 'Tam ekrana girmek veya çıkmak için yukarı ya da aşağı kaydır'
+    Preload Upcoming Videos: "Sonraki videoları önceden yükle"
+    Upcoming Videos to Preload: "Önceden yüklenecek video sayısı"
   Channel Settings:
     Channel Settings: Kanal Ayarları
     Channel Settings Description: İzlerken seçtiğiniz ayarları her kanal için ayrı ayrı hatırlayarak kanalın bir sonraki videosunda yeniden uygular.
@@ -1182,7 +1184,14 @@ Video:
       DownvoteSegment: Olumsuz oy ver
       VoteFailed: SponsorBlock oyu gönderilemedi.
 Playlist:
+  Playlist Already Preloaded: "Oynatma listesindeki tüm videolar zaten önceden yüklendi"
+  Playlist Preload Progress: "Videolar önceden yükleniyor: {completed}/{requested}"
   Close Playlist: Oynatma Listesini Kapat
+  Preload Playlist: "Tüm videoları önceden yükle"
+  Preloading Playlist: "Tüm videolar önceden yükleniyor..."
+  Playlist Preload Complete: "Önceden yüklenen videolar: {count}."
+  Playlist Preload Partial: "{requested} videodan {preloaded} tanesi önceden yüklendi. {failed} tanesi yüklenemedi."
+  Playlist Preload Pagination Failed: "Oynatma listesinin tamamı yüklenemediği için önceden yükleme iptal edildi."
 Change Format:
   Local Video File: Yerel video dosyası
   Local Audio File: Yerel ses dosyası
@@ -1379,6 +1388,8 @@ Tooltips:
       Yüksek değerler yavaş veya kararsız bağlantılarda yardımcı olabilir ancak daha fazla bant genişliği ve bellek kullanır.
       Otomatik seçeneğinin bağlantı hızını düşük hesaplayıp daha düşük kalite seçmesine de neden olabilir.
       Aynı anda tek istekle sınırlı akışlar bu ayarı yok sayar.
+    Preload Upcoming Videos: "Sonraki videoların yt-dlp adreslerini alıp önbelleğe kaydeder. Kuyruk, oynatma listeleri ve önerilerden önce gelir."
+    Upcoming Videos to Preload: "yt-dlp adresleri arka planda alınacak sonraki videoların azami sayısı."
   Download Settings:
     Download Folder: Videolar bu klasöre kaydedilir. Sisteminizin İndirilenler klasörünü kullanmak için boş bırakın.
     Global Additional yt-dlp Arguments: Her indirmede yt-dlp'ye iletilen ek komut satırı argümanları, örneğin --cookies-from-browser firefox.

--- a/static/locales/ai/uk.yaml
+++ b/static/locales/ai/uk.yaml
@@ -508,6 +508,8 @@ Settings:
     Parallel Segment Loading: Паралельне завантаження сегментів
     Rotate Wide Videos to Landscape in Fullscreen: 'Повертати широкі відео горизонтально в повноекранному режимі'
     Swipe Up or Down to Enter or Exit Fullscreen: 'Проведіть угору або вниз, щоб відкрити чи закрити повноекранний режим'
+    Preload Upcoming Videos: "Попередньо завантажувати наступні відео"
+    Upcoming Videos to Preload: "Кількість відео для попереднього завантаження"
   Channel Settings:
     Channel Settings: Налаштування каналів
     Channel Settings Description: Запам’ятовувати вибрані під час перегляду налаштування окремо для кожного каналу й застосовувати їх під час наступного перегляду його відео.
@@ -1205,7 +1207,14 @@ Video:
       DownvoteSegment: Проголосувати проти
       VoteFailed: Не вдалося надіслати голос у SponsorBlock.
 Playlist:
+  Playlist Already Preloaded: "Усі відео з плейлиста вже попередньо завантажені"
+  Playlist Preload Progress: "Попереднє завантаження відео: {completed} з {requested}"
   Close Playlist: Закрити список відтворення
+  Preload Playlist: "Попередньо завантажити всі відео"
+  Preloading Playlist: "Попереднє завантаження всіх відео..."
+  Playlist Preload Complete: "Попередньо завантажено відео: {count}."
+  Playlist Preload Partial: "Попередньо завантажено {preloaded} з {requested} відео. Не вдалося завантажити {failed}."
+  Playlist Preload Pagination Failed: "Не вдалося завантажити весь список, тому попереднє завантаження скасовано."
 Change Format:
   Local Video File: Локальний відеофайл
   Local Audio File: Локальний аудіофайл
@@ -1402,6 +1411,8 @@ Tooltips:
       Вищі значення можуть допомогти за повільного або нестабільного з'єднання, але потребують більшої пропускної здатності та пам'яті.
       Через них режим «Авто» також може недооцінити швидкість з'єднання й вибрати нижчу якість.
       Це налаштування не діє на потоки, обмежені одним одночасним запитом.
+    Preload Upcoming Videos: "Отримує та кешує адреси yt-dlp для наступних відео. Черга має пріоритет над списками й рекомендаціями."
+    Upcoming Videos to Preload: "Найбільша кількість наступних відео, адреси yt-dlp яких отримуються у тлі."
   Download Settings:
     Download Folder: Відео зберігаються в цій папці. Залиште поле порожнім, щоб використовувати системну папку «Завантаження».
     Global Additional yt-dlp Arguments: Додаткові аргументи командного рядка, що передаються yt-dlp під час кожного завантаження, наприклад --cookies-from-browser firefox.

--- a/static/locales/ai/uk.yaml
+++ b/static/locales/ai/uk.yaml
@@ -1213,7 +1213,7 @@ Playlist:
   Preload Playlist: "Попередньо завантажити всі відео"
   Preloading Playlist: "Попереднє завантаження всіх відео..."
   Playlist Preload Complete: "Попередньо завантажено відео: {count}."
-  Playlist Preload Partial: "Попередньо завантажено {preloaded} з {requested} відео. Не вдалося завантажити {failed}."
+  Playlist Preload Partial: "Попередньо завантажено {preloaded} з {requested} відео. Не вдалося попередньо завантажити {failed} відео."
   Playlist Preload Pagination Failed: "Не вдалося завантажити весь список, тому попереднє завантаження скасовано."
 Change Format:
   Local Video File: Локальний відеофайл

--- a/static/locales/ai/vi.yaml
+++ b/static/locales/ai/vi.yaml
@@ -508,6 +508,8 @@ Settings:
     Parallel Segment Loading: Tải song song các phân đoạn
     Rotate Wide Videos to Landscape in Fullscreen: 'Xoay video rộng sang ngang khi ở chế độ toàn màn hình'
     Swipe Up or Down to Enter or Exit Fullscreen: 'Vuốt lên hoặc xuống để vào hoặc thoát chế độ toàn màn hình'
+    Preload Upcoming Videos: "Tải trước các video tiếp theo"
+    Upcoming Videos to Preload: "Số video cần tải trước"
   Channel Settings:
     Channel Settings: Cài đặt kênh
     Channel Settings Description: Ghi nhớ riêng các cài đặt bạn chọn khi xem từng kênh để áp dụng lại vào lần sau khi bạn xem video của kênh đó.
@@ -1202,7 +1204,14 @@ Video:
       DownvoteSegment: Bình chọn tiêu cực
       VoteFailed: Không thể gửi bình chọn SponsorBlock.
 Playlist:
+  Playlist Already Preloaded: "Tất cả video trong danh sách phát đã được tải trước"
+  Playlist Preload Progress: "Đang tải trước video: {completed}/{requested}"
   Close Playlist: Đóng danh sách phát
+  Preload Playlist: "Tải trước tất cả video"
+  Preloading Playlist: "Đang tải trước tất cả video..."
+  Playlist Preload Complete: "Video đã tải trước: {count}."
+  Playlist Preload Partial: "Đã tải trước {preloaded}/{requested} video. Không thể tải trước {failed} video."
+  Playlist Preload Pagination Failed: "Không thể tải toàn bộ danh sách phát nên đã hủy tải trước."
 Change Format:
   Local Video File: Tệp video cục bộ
   Local Audio File: Tệp âm thanh cục bộ
@@ -1399,6 +1408,8 @@ Tooltips:
       Giá trị cao hơn có thể hữu ích với kết nối chậm hoặc không ổn định nhưng dùng nhiều băng thông và bộ nhớ hơn.
       Giá trị cao cũng có thể khiến chế độ Tự động đánh giá thấp tốc độ kết nối và chọn chất lượng thấp hơn.
       Luồng bị giới hạn ở một yêu cầu mỗi lần sẽ bỏ qua cài đặt này.
+    Preload Upcoming Videos: "Lấy và lưu đệm URL yt-dlp của các video tiếp theo. Hàng đợi được ưu tiên hơn danh sách phát và đề xuất."
+    Upcoming Videos to Preload: "Số video tiếp theo tối đa có URL yt-dlp được lấy trong nền."
   Download Settings:
     Download Folder: Video được lưu vào thư mục này. Để trống để dùng thư mục Tải xuống của hệ thống.
     Global Additional yt-dlp Arguments: Đối số dòng lệnh bổ sung được chuyển cho yt-dlp trong mọi lượt tải, ví dụ --cookies-from-browser firefox.

--- a/static/locales/ai/zh-CN.yaml
+++ b/static/locales/ai/zh-CN.yaml
@@ -500,6 +500,8 @@ Settings:
     Parallel Segment Loading: 并行加载视频片段
     Rotate Wide Videos to Landscape in Fullscreen: '全屏时将宽屏视频旋转为横屏'
     Swipe Up or Down to Enter or Exit Fullscreen: '上下滑动以进入或退出全屏'
+    Preload Upcoming Videos: "预加载后续视频"
+    Upcoming Videos to Preload: "要预加载的视频数量"
   Channel Settings:
     Channel Settings: 频道设置
     Channel Settings Description: 分别记住观看各频道时选择的设置，以便下次观看该频道的视频时再次应用。
@@ -1182,7 +1184,14 @@ Video:
       DownvoteSegment: 反对
       VoteFailed: SponsorBlock 投票提交失败。
 Playlist:
+  Playlist Already Preloaded: "播放列表中的所有视频均已预加载"
+  Playlist Preload Progress: "正在预加载视频：{completed}/{requested}"
   Close Playlist: 关闭播放列表
+  Preload Playlist: "预加载所有视频"
+  Preloading Playlist: "正在预加载所有视频..."
+  Playlist Preload Complete: "已预加载视频：{count}。"
+  Playlist Preload Partial: "已预加载 {requested} 个视频中的 {preloaded} 个，{failed} 个未能预加载。"
+  Playlist Preload Pagination Failed: "无法加载完整播放列表，已取消预加载。"
 Change Format:
   Local Video File: 本地视频文件
   Local Audio File: 本地音频文件
@@ -1379,6 +1388,8 @@ Tooltips:
       较高的值可能有助于改善缓慢或不稳定的连接，但会占用更多带宽和内存。
       这也可能导致“自动”低估连接速度并选择较低的画质。
       对于限制为一次只能发出一个请求的流，此设置无效。
+    Preload Upcoming Videos: "获取并缓存后续视频的 yt-dlp 流地址。队列优先于播放列表和推荐。"
+    Upcoming Videos to Preload: "在后台获取 yt-dlp 流地址的后续视频数量上限。"
   Download Settings:
     Download Folder: 视频将保存到此文件夹。留空则使用系统的“下载”文件夹。
     Global Additional yt-dlp Arguments: 每次下载时传递给 yt-dlp 的额外命令行参数，例如 --cookies-from-browser firefox。

--- a/static/locales/ai/zh-TW.yaml
+++ b/static/locales/ai/zh-TW.yaml
@@ -502,6 +502,8 @@ Settings:
     Parallel Segment Loading: 平行載入片段
     Rotate Wide Videos to Landscape in Fullscreen: '全螢幕時將寬幅影片旋轉為橫向'
     Swipe Up or Down to Enter or Exit Fullscreen: '向上或向下滑動以進入或離開全螢幕'
+    Preload Upcoming Videos: "預先載入後續影片"
+    Upcoming Videos to Preload: "要預先載入的影片數量"
   Channel Settings:
     Channel Settings: 頻道設定
     Channel Settings Description: 為各頻道分別記住觀看時選擇的設定，下次觀看該頻道的影片時便會再次套用。
@@ -1188,7 +1190,14 @@ Video:
       DownvoteSegment: 投反對票
       VoteFailed: 無法提交 SponsorBlock 投票。
 Playlist:
+  Playlist Already Preloaded: "播放清單中的所有影片均已預載"
+  Playlist Preload Progress: "正在預載影片：{completed}/{requested}"
   Close Playlist: 關閉播放清單
+  Preload Playlist: "預先載入所有影片"
+  Preloading Playlist: "正在預先載入所有影片..."
+  Playlist Preload Complete: "已預先載入影片：{count}。"
+  Playlist Preload Partial: "已預先載入 {requested} 部影片中的 {preloaded} 部，{failed} 部無法載入。"
+  Playlist Preload Pagination Failed: "無法載入完整播放清單，已取消預先載入。"
 Change Format:
   Local Video File: 本機影片檔案
   Local Audio File: 本機音訊檔案
@@ -1385,6 +1394,8 @@ Tooltips:
       較高的值可能有助於改善緩慢或不穩定的連線，但會使用更多頻寬與記憶體。
       也可能使「自動」低估連線速度並選擇較低的畫質。
       限制為一次只能提出一項請求的串流會忽略此設定。
+    Preload Upcoming Videos: "取得並快取後續影片的 yt-dlp 串流網址。佇列優先於播放清單和推薦。"
+    Upcoming Videos to Preload: "在背景取得 yt-dlp 串流網址的後續影片數量上限。"
   Download Settings:
     Download Folder: 影片會儲存至此資料夾。留白可使用系統的「下載」資料夾。
     Global Additional yt-dlp Arguments: 每次下載時傳遞給 yt-dlp 的額外命令列引數，例如 --cookies-from-browser firefox。

--- a/static/locales/de-DE.yaml
+++ b/static/locales/de-DE.yaml
@@ -768,6 +768,8 @@ Settings:
     Multiply Seek Interval by Playback Rate: Sprungintervalle mit Wiedergabegeschwindigkeit multiplizieren
     Show Playback Rate Adjusted Timestamp: Wiedergabegeschwindigkeitsangepasste Zeitstempel anzeigen
     Autoplay Interruption Timer: Abbruch-Timer für Automatische Wiedergabe
+    Preload Upcoming Videos: Bevorstehende Videos vorladen
+    Upcoming Videos to Preload: Anzahl vorzuladender Videos
     Default Viewing Mode:
       Theater: Kinomodus
       Picture in Picture: Bild im Bild
@@ -1928,6 +1930,13 @@ Playlist:
   #& About
   Close Playlist: Playlist schließen
   View Full Playlist: Vollständige Playlist ansehen
+  Preload Playlist: Alle Videos vorladen
+  Preloading Playlist: Alle Videos werden vorgeladen ...
+  Playlist Already Preloaded: Alle Videos der Playlist sind bereits vorgeladen
+  Playlist Preload Progress: 'Videos werden vorgeladen: {completed} von {requested}'
+  Playlist Preload Complete: 'Vorgeladene Videos: {count}.'
+  Playlist Preload Partial: '{preloaded} von {requested} Videos wurden vorgeladen. {failed} konnten nicht vorgeladen werden.'
+  Playlist Preload Pagination Failed: Die vollständige Playlist konnte nicht geladen werden. Das Vorladen wurde abgebrochen.
   Last Updated On: Zuletzt aktualisiert am
   Playlist: Playlist
 
@@ -2191,6 +2200,8 @@ Tooltips:
       auswählen.
 
       Streams, die auf jeweils eine Anfrage beschränkt sind, ignorieren diese Einstellung.
+    Preload Upcoming Videos: Ruft die yt-dlp-Stream-URLs der Videos ab, die als Nächstes abgespielt werden können, und speichert sie zwischen. Die Warteschlange hat Vorrang vor Playlists und Empfehlungen.
+    Upcoming Videos to Preload: Die Höchstzahl bevorstehender Videos, deren yt-dlp-Stream-URLs im Hintergrund abgerufen werden.
   External Player Settings:
     Custom External Player Arguments: Alle benutzerdefinierten Befehlszeilenargumente, die an den externen Video-Player übergeben werden sollen.
     Ignore Warnings: Warnungen unterdrücken, wenn der aktuelle externe Video-Player die aktuelle Aktion nicht unterstützt (z. B. das Umkehren von Playlists usw.).

--- a/static/locales/en-US.yaml
+++ b/static/locales/en-US.yaml
@@ -915,6 +915,8 @@ Settings:
     Loop Shorts: Loop Shorts
     Next Video Interval: Autoplay Countdown Timer
     Autoplay Interruption Timer: Autoplay Interruption Timer
+    Preload Upcoming Videos: Preload Upcoming Videos
+    Upcoming Videos to Preload: Upcoming Videos to Preload
     Fast-Forward / Rewind Interval: Fast-Forward / Rewind Interval
     Default Volume: Default Volume
     Remember Volume: Remember Volume
@@ -2135,6 +2137,13 @@ Playlist:
   Playlist: Playlist
   Close Playlist: Close Playlist
   View Full Playlist: View Full Playlist
+  Preload Playlist: Preload all videos
+  Preloading Playlist: Preloading all videos...
+  Playlist Already Preloaded: All playlist videos are already preloaded
+  Playlist Preload Progress: 'Preloading videos: {completed} of {requested}'
+  Playlist Preload Complete: 'Preloaded videos: {count}.'
+  Playlist Preload Partial: 'Preloaded {preloaded} of {requested} videos. {failed} could not be preloaded.'
+  Playlist Preload Pagination Failed: The full playlist could not be loaded, so preloading was canceled.
   Last Updated On: Last Updated On
   Sort By:
     DateAddedNewest: Date added (Newest)
@@ -2441,6 +2450,8 @@ Tooltips:
       Higher values may help on slow or unstable connections, but use more bandwidth and memory.
       They may also make Auto underestimate the connection speed and select a lower quality.
       Streams limited to one request at a time ignore this setting.
+    Preload Upcoming Videos: Fetches and caches yt-dlp stream URLs for videos that can play next. The watch queue takes priority over playlists and recommendations.
+    Upcoming Videos to Preload: The maximum number of upcoming videos whose yt-dlp stream URLs are fetched in the background.
   External Player Settings:
     External Player: Choosing an external player will display an icon, for opening the
       video (playlist if supported) in the external player, on the thumbnail. Warning, Invidious settings do not affect external players.

--- a/tests/unit/progress-bar.test.mjs
+++ b/tests/unit/progress-bar.test.mjs
@@ -1,7 +1,7 @@
 import assert from 'node:assert/strict'
 import test from 'node:test'
 
-import { startYtDlpPlaybackPreloadProgress } from '../../src/renderer/helpers/player/ytDlpPlaybackPreloadProgress.js'
+import { startProgressBarOperation } from '../../src/renderer/helpers/progressBar.js'
 
 function createStore () {
   const state = {}
@@ -13,26 +13,26 @@ function createStore () {
   }
 }
 
-test('restores an earlier playlist preload after an overlapping preload finishes', () => {
+test('restores an earlier operation after an overlapping operation finishes', () => {
   const store = createStore()
-  const first = startYtDlpPlaybackPreloadProgress(store, {
+  const first = startProgressBarOperation(store, {
     icon: ['fas', 'forward'],
-    message: 'First: 0 of 2',
+    message: 'Playlist: 0 of 2',
     percentage: 0,
   })
-  first.update({ message: 'First: 1 of 2', percentage: 50 })
+  first.update({ message: 'Playlist: 1 of 2', percentage: 50 })
 
-  const second = startYtDlpPlaybackPreloadProgress(store, {
+  const second = startProgressBarOperation(store, {
     icon: ['fas', 'forward'],
-    message: 'Second: 0 of 1',
+    message: 'Tool download: 0%',
     percentage: 0,
   })
-  first.update({ message: 'First: 2 of 2', percentage: 100 })
-  assert.equal(store.state.setProgressBarMessage, 'Second: 0 of 1')
+  first.update({ message: 'Playlist: 2 of 2', percentage: 100 })
+  assert.equal(store.state.setProgressBarMessage, 'Tool download: 0%')
 
   second.finish()
   assert.equal(store.state.setShowProgressBar, true)
-  assert.equal(store.state.setProgressBarMessage, 'First: 2 of 2')
+  assert.equal(store.state.setProgressBarMessage, 'Playlist: 2 of 2')
   assert.equal(store.state.setProgressBarPercentage, 100)
 
   first.finish()
@@ -41,14 +41,14 @@ test('restores an earlier playlist preload after an overlapping preload finishes
   assert.equal(store.state.setProgressBarPercentage, 0)
 })
 
-test('keeps a newer playlist preload visible when an earlier one finishes', () => {
+test('keeps a newer operation visible when an earlier operation finishes', () => {
   const store = createStore()
-  const first = startYtDlpPlaybackPreloadProgress(store, {
+  const first = startProgressBarOperation(store, {
     icon: ['fas', 'forward'],
     message: 'First',
     percentage: 50,
   })
-  const second = startYtDlpPlaybackPreloadProgress(store, {
+  const second = startProgressBarOperation(store, {
     icon: ['fas', 'forward'],
     message: 'Second',
     percentage: 25,

--- a/tests/unit/yt-dlp-playback-cache.test.mjs
+++ b/tests/unit/yt-dlp-playback-cache.test.mjs
@@ -91,6 +91,44 @@ test('evicts the least recently used source at the size limit', () => {
   assert.equal(cache.get('third', 'settings'), third)
 })
 
+test('can reserve enough in-memory entries for an explicit playlist preload', () => {
+  const cache = new YtDlpPlaybackSourceCache({ maxEntries: 2, now: () => 0 })
+  cache.ensureCapacity(3)
+
+  cache.set('first', 'settings', source(new Date(1000000)))
+  cache.set('second', 'settings', source(new Date(1000000)))
+  cache.set('third', 'settings', source(new Date(1000000)))
+
+  assert.equal(cache.get('first', 'settings').expiryDate.getTime(), 1000000)
+  assert.equal(cache.get('second', 'settings').expiryDate.getTime(), 1000000)
+  assert.equal(cache.get('third', 'settings').expiryDate.getTime(), 1000000)
+})
+
+test('reports when a cached source stops being safely reusable', () => {
+  let now = 1000000
+  const cache = new YtDlpPlaybackSourceCache({
+    expiryMarginMs: 120000,
+    now: () => now
+  })
+  cache.set('video', 'settings', {
+    ...source(new Date(now + 300000)),
+    subtitlesIncluded: true
+  })
+
+  assert.equal(cache.getUsableUntil('video', 'settings', true), now + 180000)
+  now += 180000
+  assert.equal(cache.getUsableUntil('video', 'settings', true), null)
+})
+
+test('reports when a preloaded source is evicted', () => {
+  const cache = new YtDlpPlaybackSourceCache({ maxEntries: 1, now: () => 0 })
+  cache.set('playlist-video', 'settings', source(new Date(1000000)))
+  assert.equal(cache.getUsableUntil('playlist-video', 'settings'), 880000)
+
+  cache.set('other-video', 'settings', source(new Date(1000000)))
+  assert.equal(cache.getUsableUntil('playlist-video', 'settings'), null)
+})
+
 test('does not reuse sources extracted with different settings', () => {
   const cache = new YtDlpPlaybackSourceCache({ now: () => 0 })
   cache.set('video', 'old-settings', source(new Date(1000000)))

--- a/tests/unit/yt-dlp-playback-preload-progress.test.mjs
+++ b/tests/unit/yt-dlp-playback-preload-progress.test.mjs
@@ -1,0 +1,64 @@
+import assert from 'node:assert/strict'
+import test from 'node:test'
+
+import { startYtDlpPlaybackPreloadProgress } from '../../src/renderer/helpers/player/ytDlpPlaybackPreloadProgress.js'
+
+function createStore () {
+  const state = {}
+  return {
+    state,
+    commit (mutation, value) {
+      state[mutation] = value
+    },
+  }
+}
+
+test('restores an earlier playlist preload after an overlapping preload finishes', () => {
+  const store = createStore()
+  const first = startYtDlpPlaybackPreloadProgress(store, {
+    icon: ['fas', 'forward'],
+    message: 'First: 0 of 2',
+    percentage: 0,
+  })
+  first.update({ message: 'First: 1 of 2', percentage: 50 })
+
+  const second = startYtDlpPlaybackPreloadProgress(store, {
+    icon: ['fas', 'forward'],
+    message: 'Second: 0 of 1',
+    percentage: 0,
+  })
+  first.update({ message: 'First: 2 of 2', percentage: 100 })
+  assert.equal(store.state.setProgressBarMessage, 'Second: 0 of 1')
+
+  second.finish()
+  assert.equal(store.state.setShowProgressBar, true)
+  assert.equal(store.state.setProgressBarMessage, 'First: 2 of 2')
+  assert.equal(store.state.setProgressBarPercentage, 100)
+
+  first.finish()
+  assert.equal(store.state.setShowProgressBar, false)
+  assert.equal(store.state.setProgressBarMessage, '')
+  assert.equal(store.state.setProgressBarPercentage, 0)
+})
+
+test('keeps a newer playlist preload visible when an earlier one finishes', () => {
+  const store = createStore()
+  const first = startYtDlpPlaybackPreloadProgress(store, {
+    icon: ['fas', 'forward'],
+    message: 'First',
+    percentage: 50,
+  })
+  const second = startYtDlpPlaybackPreloadProgress(store, {
+    icon: ['fas', 'forward'],
+    message: 'Second',
+    percentage: 25,
+  })
+
+  first.finish()
+  assert.equal(store.state.setShowProgressBar, true)
+  assert.equal(store.state.setProgressBarMessage, 'Second')
+  assert.equal(store.state.setProgressBarPercentage, 25)
+
+  second.finish()
+  assert.equal(store.state.setShowProgressBar, false)
+})

--- a/tests/unit/yt-dlp-playback-preload.test.mjs
+++ b/tests/unit/yt-dlp-playback-preload.test.mjs
@@ -141,6 +141,45 @@ test('preloads unique videos with bounded concurrency and reports failures', asy
   ])
 })
 
+test('shares the preload concurrency limit across overlapping runs', async () => {
+  let active = 0
+  let peakActive = 0
+  const loaded = []
+  const releases = []
+  const loadSource = videoId => new Promise(resolve => {
+    active++
+    peakActive = Math.max(peakActive, active)
+    loaded.push(videoId)
+    releases.push(() => {
+      active--
+      resolve(source(videoId))
+    })
+  })
+
+  const firstRun = preloadYtDlpPlaybackSources(['first00001', 'first00002', 'first00003'], { loadSource })
+  const secondRun = preloadYtDlpPlaybackSources(['second0001', 'second0002'], { loadSource })
+
+  await new Promise(resolve => setImmediate(resolve))
+  assert.equal(loaded.length, 2)
+
+  for (let completed = 0; completed < 5; completed++) {
+    const release = releases.shift()
+    assert.ok(release)
+    release()
+    await new Promise(resolve => setImmediate(resolve))
+  }
+
+  await Promise.all([firstRun, secondRun])
+  assert.equal(peakActive, 2)
+  assert.deepEqual(new Set(loaded), new Set([
+    'first00001',
+    'first00002',
+    'first00003',
+    'second0001',
+    'second0002',
+  ]))
+})
+
 test('reports sources that cannot be cached as preload failures', async () => {
   const results = new Map([
     ['live0000001', { isLive: true, expiryDate: new Date(Date.now() + 10 * 60 * 1000) }],

--- a/tests/unit/yt-dlp-playback-preload.test.mjs
+++ b/tests/unit/yt-dlp-playback-preload.test.mjs
@@ -1,0 +1,159 @@
+import assert from 'node:assert/strict'
+import test from 'node:test'
+
+import {
+  buildYtDlpPlaybackCacheKey,
+  MAX_YT_DLP_PRELOAD_COUNT,
+  normalizeYtDlpPreloadCount,
+  preloadYtDlpPlaybackSources,
+  selectYtDlpPreloadVideoIds,
+} from '../../src/renderer/helpers/player/ytDlpPlaybackPreload.js'
+
+const video = videoId => ({ videoId })
+const source = videoId => ({
+  videoId,
+  isLive: false,
+  expiryDate: new Date(Date.now() + 10 * 60 * 1000),
+})
+
+test('includes proxy and authentication settings in the playback cache key', () => {
+  const getters = {
+    getYtDlpSource: 'system',
+    getYtDlpChannel: 'stable',
+    getYtDlpPath: '/usr/bin/yt-dlp',
+    getUseProxy: true,
+    getProxyProtocol: 'socks5',
+    getProxyHostname: 'localhost',
+    getProxyPort: 9050,
+    getProxyUsername: 'user',
+    getProxyPassword: 'password',
+    getYtDlpPlaybackAuthMode: 'browser',
+    getYtDlpPlaybackCookiesPath: '',
+    getYtDlpPlaybackCookiesBrowser: 'firefox',
+    getYtDlpPlaybackCookiesBrowserProfile: 'default',
+  }
+
+  assert.deepEqual(JSON.parse(buildYtDlpPlaybackCacheKey(getters)), [
+    'captions-v4', 'system', 'stable', '/usr/bin/yt-dlp', true,
+    'socks5', 'localhost', 9050, 'user', 'password',
+    'browser', '', 'firefox', 'default',
+  ])
+})
+
+test('normalizes the number of upcoming yt-dlp videos to preload', () => {
+  assert.equal(normalizeYtDlpPreloadCount(3), 3)
+  assert.equal(normalizeYtDlpPreloadCount('4'), 4)
+  assert.equal(normalizeYtDlpPreloadCount(0), 0)
+  assert.equal(normalizeYtDlpPreloadCount(-1), 0)
+  assert.equal(normalizeYtDlpPreloadCount(MAX_YT_DLP_PRELOAD_COUNT + 1), MAX_YT_DLP_PRELOAD_COUNT)
+  assert.equal(normalizeYtDlpPreloadCount(1.5), 0)
+})
+
+test('preloads queued videos before playlist or recommendation candidates', () => {
+  assert.deepEqual(selectYtDlpPreloadVideoIds({
+    currentVideoId: 'current00001',
+    limit: 3,
+    queuedVideos: [video('queue000001'), video('queue000002'), video('queue000003'), video('queue000004')],
+    playlistVideos: [video('list0000001'), video('list0000002')],
+    recommendedVideos: [video('recommend01')],
+  }), ['queue000001', 'queue000002', 'queue000003'])
+})
+
+test('uses the active playlist when the watch queue is empty', () => {
+  assert.deepEqual(selectYtDlpPreloadVideoIds({
+    currentVideoId: 'current00001',
+    limit: 4,
+    queuedVideos: [],
+    playlistVideos: [
+      video('current00001'),
+      video('list0000001'),
+      video('list0000001'),
+      { title: 'Unavailable' },
+      video('list0000002'),
+    ],
+    recommendedVideos: [video('recommend01')],
+  }), ['list0000001', 'list0000002'])
+})
+
+test('uses recommendations outside a queue or playlist', () => {
+  assert.deepEqual(selectYtDlpPreloadVideoIds({
+    currentVideoId: 'current00001',
+    limit: 2,
+    queuedVideos: [],
+    playlistVideos: null,
+    recommendedVideos: [video('current00001'), video('recommend01'), video('recommend02'), video('recommend03')],
+  }), ['recommend01', 'recommend02'])
+})
+
+test('does not fall back to recommendations at the end of a playlist', () => {
+  assert.deepEqual(selectYtDlpPreloadVideoIds({
+    currentVideoId: 'current00001',
+    limit: 2,
+    queuedVideos: [],
+    playlistVideos: [],
+    recommendedVideos: [video('recommend01')],
+  }), [])
+})
+
+test('preloads unique videos with bounded concurrency and reports failures', async () => {
+  let active = 0
+  let peakActive = 0
+  const loaded = []
+  const progressUpdates = []
+  const release = new Map()
+  const loadSource = videoId => new Promise((resolve, reject) => {
+    active++
+    peakActive = Math.max(peakActive, active)
+    loaded.push(videoId)
+    release.set(videoId, (error = null) => {
+      active--
+      error === null ? resolve(source(videoId)) : reject(error)
+    })
+  })
+
+  const resultPromise = preloadYtDlpPlaybackSources(
+    ['video000001', 'video000002', 'video000001', 'video000003'],
+    {
+      concurrency: 2,
+      loadSource,
+      onProgress: progress => progressUpdates.push(progress),
+    }
+  )
+
+  await new Promise(resolve => setImmediate(resolve))
+  assert.deepEqual(loaded, ['video000001', 'video000002'])
+  release.get('video000001')()
+  await new Promise(resolve => setImmediate(resolve))
+  assert.deepEqual(loaded, ['video000001', 'video000002', 'video000003'])
+  release.get('video000002')(new Error('unavailable'))
+  release.get('video000003')()
+
+  assert.deepEqual(await resultPromise, {
+    requested: 3,
+    preloaded: 2,
+    failed: 1,
+  })
+  assert.equal(peakActive, 2)
+  assert.deepEqual(progressUpdates, [
+    { requested: 3, completed: 1, preloaded: 1, failed: 0 },
+    { requested: 3, completed: 2, preloaded: 1, failed: 1 },
+    { requested: 3, completed: 3, preloaded: 2, failed: 1 },
+  ])
+})
+
+test('reports sources that cannot be cached as preload failures', async () => {
+  const results = new Map([
+    ['live0000001', { isLive: true, expiryDate: new Date(Date.now() + 10 * 60 * 1000) }],
+    ['noexpiry001', { isLive: false, expiryDate: null }],
+    ['expired0001', { isLive: false, expiryDate: new Date(0) }],
+    ['cached00001', source('cached00001')],
+  ])
+
+  assert.deepEqual(await preloadYtDlpPlaybackSources([...results.keys()], {
+    loadSource: async videoId => results.get(videoId)
+  }), {
+    requested: 4,
+    preloaded: 1,
+    failed: 3,
+  })
+})


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Make sure to follow the contributing guidelines. -->
<!-- Important note, we may remove your pull request if you do not use this provided PR template correctly. -->
<!-- Agent instructions: Preserve every heading, comment, and marker in this template. Never remove or rewrite the release-note-category:start/end, release-note:start/end, or release-note-image:start/end marker pairs. -->

## Pull Request Type
<!-- Please select what type of pull request this is: [x] -->
- [ ] Bugfix
- [x] Feature Implementation
- [ ] Documentation
- [ ] Other

## Related issue
<!-- Please link the issue your pull request is referring to. -->
<!-- If this pull request fully resolves the relevant issue, put "closes" before the issue number. -->
<!-- Example: "closes #123456". -->

Closes #1045

## Description
<!-- Please write a clear and concise description of what the pull request does. -->

yt-dlp normally extracts stream URLs only when playback reaches each video, which can delay transitions between videos. This adds an opt-in setting to preload the next configured number of videos and a playlist action that preloads every video before playback.

Automatic preloading follows the watch queue, active playlist, or recommendations and runs at most two extractions in parallel. The playlist action loads remote continuations, reports determinate progress through the persistent progress notification, and keeps its action disabled while every cached source remains usable.

## Release note category
<!-- Select exactly one category. Every pull request must select one. -->
<!-- Select "Not noteworthy" when the pull request fixes a bug in or improves functionality that has not yet appeared in a stable release. -->
<!-- release-note-category:start -->
- [ ] Not noteworthy
- [ ] Highlights
- [x] More improvements
- [ ] Fixed bugs
<!-- release-note-category:end -->

## Release note
<!-- Required unless "Not noteworthy" is selected. -->
<!-- Write one concise, user-facing entry without a leading bullet. -->
<!-- release-note:start -->
Preload upcoming yt-dlp videos automatically or cache an entire playlist before watching.
<!-- release-note:end -->

## Release note images
<!-- Optional. Paste one or more Markdown images, HTML image tags, or dark/light <picture> elements here. -->
<!-- The release notes normalize the markup and limit images taller than 300 pixels. -->
<!-- Agent instructions:
For a noteworthy visible change, add media when it makes the change easier to understand. Prefer a still image unless motion is the point; recordings must use animated WebP.
After implementing a visible change, proactively capture the result and show the local media to the user for approval before uploading it or updating the pull request.
When the affected UI differs between dark and light themes, capturing both themes is required. A dark-only image is incomplete. Run `node _scripts/releaseNoteMedia.mjs --dark DARK_FILE --light LIGHT_FILE --alt "DESCRIPTION"`; GitHub will display the matching theme and use dark as the fallback. Use a single default-dark capture only when the light theme cannot be captured or looks identical.
Capture or crop to the smallest region that still makes the change clear. Do not include the full window when the affected component can be understood on its own.
Use English unless localization is the subject. Keep components at their normal dimensions and placement instead of resizing them to fill the frame.
Use deterministic local fixtures for visible remote images. Reusable avatar and thumbnail fixtures are available through `e2e/helpers/visual-fixtures.mjs`. Before capturing, verify that every visible image has loaded successfully (`complete === true` and `naturalWidth > 0`).
Inspect the final dark and light files for failed images, missing content, unrelated UI, awkward animation, and misleading layout. Omit media when it does not explain the change clearly.
For one dark capture, run `node _scripts/releaseNoteMedia.mjs FILE --alt "DESCRIPTION"`.
Check for personal information, tokens, private repository names, and unrelated desktop content before uploading. Uploaded media is public.
Keep capture-only scripts, test hooks, screenshots, and recordings out of commits. Remove them before committing unless the capture code is also a reusable regression test. Never commit generated release-note media.
Paste only the generated markup between the marker comments. Leave this section empty when media would not help.
-->
<!-- release-note-image:start -->
<picture>
  <source media="(prefers-color-scheme: dark)" srcset="https://github.com/OpenTubeX/media/releases/download/attachments/20260907T114447Z-playlist-preload-dark-dark-9a8ed3e374.png">
  <source media="(prefers-color-scheme: light)" srcset="https://github.com/OpenTubeX/media/releases/download/attachments/20260907T114447Z-playlist-preload-light-light-2721e09f24.png">
  <img alt="Playlist preload action and progress notification" src="https://github.com/OpenTubeX/media/releases/download/attachments/20260907T114447Z-playlist-preload-dark-dark-9a8ed3e374.png">
</picture>
<!-- release-note-image:end -->

## Testing
<!-- How can reviewers verify that the PR produces correct results? -->
<!-- Please provide instructions so that others can ensure that your pull request would produce correct results. For examples see, https://github.com/FreeTubeApp/FreeTube/pull/5743, https://github.com/FreeTubeApp/FreeTube/pull/7349, https://github.com/FreeTubeApp/FreeTube/pull/5125, https://github.com/FreeTubeApp/FreeTube/pull/7338 -->
<!-- Agent instructions: Only write human-facing steps that explain how to verify the change while running this branch in dev mode. Include expected results and, when applicable, helpful console snippets for interactive verification. Do not include automated checks, commands, results, pass counts, or CI status. -->

1. Select the yt-dlp playback engine, enable "Preload Upcoming Videos", and choose a count in Playback settings.
2. Open a video outside a playlist and confirm the configured number of recommendations starts without a later yt-dlp extraction delay.
3. Open a playlist and click "Preload all videos". Confirm the icon spins and the persistent notification updates its count and bottom progress bar.
4. After a successful preload, confirm the action stays disabled with the "All playlist videos are already preloaded" tooltip. A partial failure should leave it available for retry.

## Additional context
<!-- Add any other context about the pull request here. -->

Preloading is disabled by default. Both automatic and playlist-wide preloading use a concurrency limit of two, and in-flight requests for the same source are shared with normal playback.
