### PR TITLE
feat(settings): make Quick Settings customizable

### DIFF
--- a/e2e/tests/offline/appearance.spec.mjs
+++ b/e2e/tests/offline/appearance.spec.mjs
@@ -350,7 +350,14 @@ test.describe('default appearance', () => {
 })
 
 test.describe('custom theme editor', () => {
-  test.use({ seed: { settings: { baseTheme: 'dark' } } })
+  test.use({
+    seed: {
+      settings: {
+        baseTheme: 'dark',
+        quickSettings: ['baseTheme', 'mainColor'],
+      },
+    },
+  })
 
   test('clamps the color-source list after a responsive reflow', async ({ app, page }) => {
     await setWindowWidth(app, 420)
@@ -504,10 +511,6 @@ test.describe('custom theme editor', () => {
   })
 
   test('copies built-in themes, previews efficiently, persists, and survives closing settings', async ({ app, page }) => {
-    await page.evaluate(() => {
-      const store = document.querySelector('#app').__vue_app__.config.globalProperties.$store
-      return store.dispatch('updateQuickSettings', ['baseTheme', 'mainColor'])
-    })
     await goToSettingsSection(page, 'theme')
     await page.getByRole('button', { name: 'Highlight settings changed from defaults' }).click()
     await page.getByRole('button', { name: 'Create custom theme' }).click()

--- a/e2e/tests/offline/appearance.spec.mjs
+++ b/e2e/tests/offline/appearance.spec.mjs
@@ -325,6 +325,7 @@ test.describe('default appearance', () => {
     await expect(fontOptions.nth(3)).toHaveAttribute('aria-selected', 'true')
     await appFont.click()
 
+    await page.locator('.settingsCloseButton').click()
     await page.locator('.profileTrigger').click()
     const profileSummary = page.locator('.profileSummary')
     await expect(profileSummary).toBeVisible()

--- a/e2e/tests/offline/appearance.spec.mjs
+++ b/e2e/tests/offline/appearance.spec.mjs
@@ -503,6 +503,10 @@ test.describe('custom theme editor', () => {
   })
 
   test('copies built-in themes, previews efficiently, persists, and survives closing settings', async ({ app, page }) => {
+    await page.evaluate(() => {
+      const store = document.querySelector('#app').__vue_app__.config.globalProperties.$store
+      return store.dispatch('updateQuickSettings', ['baseTheme', 'mainColor'])
+    })
     await goToSettingsSection(page, 'theme')
     await page.getByRole('button', { name: 'Highlight settings changed from defaults' }).click()
     await page.getByRole('button', { name: 'Create custom theme' }).click()

--- a/e2e/tests/offline/quick-settings.spec.mjs
+++ b/e2e/tests/offline/quick-settings.spec.mjs
@@ -1,20 +1,5 @@
 import { test, expect, goToSettingsSection } from '../../helpers/app.mjs'
-
-const DEFAULT_QUICK_SETTINGS = [
-  'baseTheme',
-  'mainColor',
-  'uiScale',
-  'thumbnailSize',
-  'defaultQuality',
-  'playNextVideo',
-  'enableSubtitlesByDefault',
-  'listType',
-  'playlistViewType',
-  'hideRecommendedVideos',
-  'hideComments',
-  'currentLocale',
-  'region',
-]
+import { DEFAULT_QUICK_SETTINGS } from '../../../src/renderer/helpers/quickSettings.js'
 
 const ALL_QUICK_SETTINGS = [
   ...DEFAULT_QUICK_SETTINGS,

--- a/e2e/tests/offline/quick-settings.spec.mjs
+++ b/e2e/tests/offline/quick-settings.spec.mjs
@@ -336,8 +336,11 @@ test.describe('customizable quick settings', () => {
   test('adds basic controls from Appearance and resets them', async ({ app, page }) => {
     const appearance = await goToSettingsSection(page, 'appearance')
     const customizeButton = appearance.getByRole('button', { name: 'Customize quick settings' })
+    const launcher = appearance.locator('.quickSettingsLauncher')
+    await expect(launcher).toBeVisible()
+    await expect(customizeButton).toBeVisible()
     const [launcherBounds, buttonBounds] = await Promise.all([
-      appearance.locator('.quickSettingsLauncher').boundingBox(),
+      launcher.boundingBox(),
       customizeButton.boundingBox(),
     ])
     expect(Math.abs(

--- a/e2e/tests/offline/quick-settings.spec.mjs
+++ b/e2e/tests/offline/quick-settings.spec.mjs
@@ -1,6 +1,29 @@
-import { test, expect } from '../../helpers/app.mjs'
+import { test, expect, goToSettingsSection } from '../../helpers/app.mjs'
+
+const DEFAULT_QUICK_SETTINGS = [
+  'baseTheme',
+  'mainColor',
+  'uiScale',
+  'thumbnailSize',
+  'defaultQuality',
+  'playNextVideo',
+  'enableSubtitlesByDefault',
+  'listType',
+  'playlistViewType',
+  'hideRecommendedVideos',
+  'hideComments',
+  'currentLocale',
+  'region',
+]
+
+const ALL_QUICK_SETTINGS = [
+  ...DEFAULT_QUICK_SETTINGS,
+  'useProxy',
+]
 
 test.describe('quick settings menu', () => {
+  test.use({ seed: { settings: { quickSettings: ALL_QUICK_SETTINGS } } })
+
   test('opens the command palette from the header action', async ({ page }) => {
     await page.locator('.profileTrigger').click()
     const menu = page.getByRole('dialog', { name: 'Quick settings' })
@@ -108,16 +131,18 @@ test.describe('quick settings menu', () => {
   test('keeps paired selects aligned and shows locale completeness', async ({ page }) => {
     await page.locator('.profileTrigger').click()
     const menu = page.locator('.quickSettingsMenu')
-    const pairs = menu.locator('.selectPair')
-    await expect(pairs).toHaveCount(3)
+    const pairs = [
+      ['baseTheme', 'mainColor'],
+      ['listType', 'playlistViewType'],
+      ['currentLocale', 'region'],
+    ]
 
-    for (const pair of await pairs.all()) {
-      const selects = pair.locator('.quickSelect')
-      await expect(selects).toHaveCount(2)
-      const [first, second] = await selects.evaluateAll(elements => elements.map(element => {
+    for (const pair of pairs) {
+      const controls = pair.map(settingId => menu.locator(`[data-setting-id="${settingId}"]`))
+      const [first, second] = await Promise.all(controls.map(control => control.evaluate(element => {
         const { x, y, width } = element.getBoundingClientRect()
         return { x, y, width }
-      }))
+      })))
       expect(Math.abs(first.y - second.y)).toBeLessThanOrEqual(1)
       expect(second.x).toBeGreaterThan(first.x + first.width)
     }
@@ -173,9 +198,11 @@ test.describe('quick settings menu', () => {
     await expect(menu).toBeVisible()
     await expect(baseTheme).toBeVisible()
     await expect(appearance.getByRole('combobox', { name: 'Main Color Theme' })).toHaveCount(0)
-    expect(await appearance.locator('.selectPair').evaluate(element => {
-      return getComputedStyle(element).gridTemplateColumns.split(' ').length
-    })).toBe(1)
+    const [sectionWidth, controlWidth] = await Promise.all([
+      appearance.evaluate(element => element.clientWidth),
+      appearance.locator('[data-setting-id="baseTheme"]').evaluate(element => element.clientWidth),
+    ])
+    expect(controlWidth).toBeGreaterThan(sectionWidth * 0.8)
     await expect.poll(() => scrollViewport.evaluate(element => {
       const content = element.querySelector('.quickSettingsContent')
       return element.scrollTop <= Math.max(0, content.offsetTop + content.offsetHeight - element.clientHeight) + 1
@@ -262,6 +289,218 @@ test.describe('quick settings menu', () => {
     await expect(aboutWindow.locator('.settingsBreadcrumb')).toContainText('About')
     await expect(aboutWindow.locator('.settingsMenu')).toHaveCount(0)
     await expect(aboutWindow).toBeHidden()
+  })
+})
+
+test.describe('automatic quick setting select pairs', () => {
+  test.use({ seed: { settings: { quickSettings: ['baseTheme', 'iconPack'] } } })
+
+  test('places any adjacent selects in two columns', async ({ page }) => {
+    await page.locator('.profileTrigger').click()
+    const menu = page.locator('.quickSettingsMenu')
+    const controls = ['baseTheme', 'iconPack'].map(settingId => (
+      menu.locator(`[data-setting-id="${settingId}"]`)
+    ))
+    const [first, second] = await Promise.all(controls.map(control => control.evaluate(element => {
+      const { x, y, width } = element.getBoundingClientRect()
+      return { x, y, width }
+    })))
+
+    expect(Math.abs(first.y - second.y)).toBeLessThanOrEqual(1)
+    expect(second.x).toBeGreaterThan(first.x + first.width)
+  })
+})
+
+test.describe('customizable quick settings', () => {
+  test('starts with the original quick settings', async ({ page }) => {
+    await page.locator('.profileTrigger').click()
+    const menu = page.getByRole('dialog', { name: 'Quick settings' })
+
+    await expect(menu.getByRole('combobox', { name: 'Base Theme' })).toBeVisible()
+    await expect(menu.getByRole('slider', { name: 'UI Scale' })).toBeVisible()
+    await expect(menu.getByRole('slider', { name: 'Thumbnail Size' })).toBeVisible()
+    await expect(menu.getByRole('combobox', { name: 'Default Quality' })).toBeVisible()
+    await expect(menu.getByRole('checkbox', { name: 'Autoplay Recommended Videos' })).toBeVisible()
+    await expect(menu.getByRole('checkbox', { name: 'Enable Subtitles by Default' })).toBeVisible()
+    await expect(menu.getByRole('combobox', { name: 'Video View Type' })).toBeVisible()
+    await expect(menu.getByRole('combobox', { name: 'Playlist View Type' })).toBeVisible()
+    await expect(menu.getByRole('checkbox', { name: 'Hide Recommended Videos' })).toBeVisible()
+    await expect(menu.getByRole('checkbox', { name: 'Hide Comments' })).toBeVisible()
+    await expect(menu.getByRole('combobox', { name: 'Language preference' })).toBeVisible()
+    await expect(menu.getByRole('combobox', { name: 'Region for Trending' })).toBeVisible()
+
+    await expect(menu.getByRole('checkbox', { name: 'Enable Tor / Proxy' })).toHaveCount(0)
+    await expect(menu.getByRole('button', { name: 'Customize quick settings' })).toHaveCount(0)
+  })
+
+  test('adds basic controls from Appearance and resets them', async ({ app, page }) => {
+    const appearance = await goToSettingsSection(page, 'appearance')
+    const customizeButton = appearance.getByRole('button', { name: 'Customize quick settings' })
+    const [launcherBounds, buttonBounds] = await Promise.all([
+      appearance.locator('.quickSettingsLauncher').boundingBox(),
+      customizeButton.boundingBox(),
+    ])
+    expect(Math.abs(
+      launcherBounds.x + launcherBounds.width / 2 - buttonBounds.x - buttonBounds.width / 2
+    )).toBeLessThanOrEqual(1)
+    await customizeButton.click()
+    await expect(page.locator('.settingsBreadcrumb')).toContainText('Customize quick settings')
+
+    const selectedSettings = page.locator('.selectedSettings')
+    await expect(selectedSettings.locator('.selectedSetting')).toHaveCount(DEFAULT_QUICK_SETTINGS.length)
+    await expect(selectedSettings.locator('.selectedSettingIcon')).toHaveCount(DEFAULT_QUICK_SETTINGS.length)
+    await expect.poll(() => selectedSettings.locator('.selectedSetting').evaluateAll(rows => (
+      rows.map(row => row.dataset.settingId)
+    ))).toEqual(DEFAULT_QUICK_SETTINGS)
+    const actions = page.locator('.quickSettingsActions')
+    const [subpageBounds, actionsBounds, settingsBounds, actionButtonBounds] = await Promise.all([
+      page.locator('.settingsSubpageContent').boundingBox(),
+      actions.boundingBox(),
+      selectedSettings.boundingBox(),
+      actions.getByRole('button').evaluateAll(buttons => buttons.map(button => (
+        button.getBoundingClientRect().toJSON()
+      ))),
+    ])
+    const subpageCenter = subpageBounds.x + subpageBounds.width / 2
+    expect(Math.abs(actionsBounds.x + actionsBounds.width / 2 - subpageCenter)).toBeLessThanOrEqual(1)
+    expect(Math.abs(settingsBounds.x + settingsBounds.width / 2 - subpageCenter)).toBeLessThanOrEqual(1)
+    const actionGroupCenter = (
+      actionButtonBounds[0].x + actionButtonBounds.at(-1).x + actionButtonBounds.at(-1).width
+    ) / 2
+    expect(Math.abs(actionGroupCenter - subpageCenter)).toBeLessThanOrEqual(1)
+    await page.getByRole('button', { name: 'Remove Hide Comments' }).click()
+    await expect(selectedSettings).not.toContainText('Hide Comments')
+
+    await page.getByRole('button', { name: 'Add setting' }).click()
+    const settingPicker = page.getByPlaceholder('Search settings')
+    const settingPopover = page.getByRole('dialog', { name: 'Add setting' })
+    await expect(settingPopover).toBeVisible()
+    await expect(settingPopover).toHaveCSS('position', 'absolute')
+    await expect(settingPicker).toHaveAttribute('type', 'search')
+    await expect(settingPopover.locator('.clearInputTextButton')).toHaveCount(0)
+    for (const setting of ['Icon Pack', 'UI Roundness', 'Enable Tor / Proxy']) {
+      await settingPicker.fill(setting)
+      await page.locator('.settingPicker .optionWrapper').filter({ hasText: setting }).click()
+    }
+    await settingPicker.press('Escape')
+    await expect(settingPopover).toBeHidden()
+    await expect(page.getByRole('button', { name: 'Add setting' })).toBeFocused()
+    await page.locator('.settingsCloseButton').click()
+
+    await page.locator('.profileTrigger').click()
+    const menu = page.getByRole('dialog', { name: 'Quick settings' })
+    const iconPack = menu.getByRole('combobox', { name: 'Icon Pack' })
+    await expect(iconPack).toBeVisible()
+    await expect(menu.getByRole('slider', { name: 'UI Roundness' })).toBeVisible()
+    await expect(menu.getByRole('checkbox', { name: 'Hide Comments' })).toHaveCount(0)
+    await iconPack.click()
+    await page.getByRole('option', { name: 'Remix Icon' }).click()
+    await expect(iconPack).toContainText('Remix Icon')
+    await menu.locator('label.switch-label').filter({ hasText: 'Enable Tor / Proxy' }).click()
+    await expect.poll(() => app.electronApp.evaluate(async ({ BrowserWindow }) => {
+      return BrowserWindow.getAllWindows()[0].webContents.session.resolveProxy('https://example.com')
+    })).toContain('127.0.0.1:9050')
+
+    await menu.getByRole('button', { name: 'All Settings' }).click()
+    const reopenedAppearance = await goToSettingsSection(page, 'appearance')
+    await reopenedAppearance.getByRole('button', { name: 'Customize quick settings' }).click()
+    await page.getByRole('button', { name: 'Reset to defaults' }).click()
+    await expect(page.locator('.selectedSetting')).toHaveCount(DEFAULT_QUICK_SETTINGS.length)
+    await expect(page.locator('.selectedSettings')).toContainText(/Base theme/i)
+    await expect(page.locator('.selectedSettings')).not.toContainText('Icon Pack')
+  })
+
+  test('rearranges controls with buttons and drag and drop', async ({ page }) => {
+    const appearance = await goToSettingsSection(page, 'appearance')
+    await appearance.getByRole('button', { name: 'Customize quick settings' }).click()
+
+    const selectedSettings = page.locator('.selectedSettings')
+    const settingIds = () => selectedSettings.locator('.selectedSetting').evaluateAll(rows => (
+      rows.map(row => row.dataset.settingId)
+    ))
+    await expect(page.getByRole('button', { name: 'Move Base Theme up' })).toBeDisabled()
+    await expect(page.getByRole('button', { name: 'Move Region for Trending down' })).toBeDisabled()
+
+    await page.getByRole('button', { name: 'Move Hide Comments up' }).click()
+    const hideCommentsMovedUp = [...DEFAULT_QUICK_SETTINGS]
+    const hideCommentsIndex = hideCommentsMovedUp.indexOf('hideComments')
+    hideCommentsMovedUp.splice(hideCommentsIndex, 1)
+    hideCommentsMovedUp.splice(hideCommentsIndex - 1, 0, 'hideComments')
+    await expect.poll(settingIds).toEqual(hideCommentsMovedUp)
+
+    const dragData = await page.evaluateHandle(() => new DataTransfer())
+    const hideComments = selectedSettings.locator('[data-setting-id="hideComments"]')
+    const baseTheme = selectedSettings.locator('[data-setting-id="baseTheme"]')
+    await hideComments.locator('.dragHandle').dispatchEvent('dragstart', { dataTransfer: dragData })
+    await baseTheme.dispatchEvent('dragover', { dataTransfer: dragData })
+    await baseTheme.dispatchEvent('drop', { dataTransfer: dragData })
+    await hideComments.locator('.dragHandle').dispatchEvent('dragend', { dataTransfer: dragData })
+    const hideCommentsFirst = [
+      'hideComments',
+      ...DEFAULT_QUICK_SETTINGS.filter(settingId => settingId !== 'hideComments'),
+    ]
+    await expect.poll(settingIds).toEqual(hideCommentsFirst)
+
+    await page.locator('.settingsCloseButton').click()
+    await page.locator('.profileTrigger').click()
+    const menu = page.getByRole('dialog', { name: 'Quick settings' })
+    await expect.poll(() => menu.locator('.quickSettingControl').evaluateAll(controls => (
+      controls.map(control => control.dataset.settingId)
+    ))).toEqual(hideCommentsFirst)
+
+    await menu.getByRole('button', { name: 'All Settings' }).click()
+    const reopenedAppearance = await goToSettingsSection(page, 'appearance')
+    await reopenedAppearance.getByRole('button', { name: 'Customize quick settings' }).click()
+    await expect.poll(settingIds).toEqual(hideCommentsFirst)
+  })
+})
+
+test.describe('quick settings customization at fractional UI scale', () => {
+  test.use({ seed: { settings: { uiScale: 125 } } })
+
+  test('keeps the searchable setting list usable when filtering shortens it', async ({ app, page }) => {
+    await app.electronApp.evaluate(({ BrowserWindow }) => {
+      BrowserWindow.getAllWindows()[0]?.setBounds({ x: 0, y: 0, width: 900, height: 650 })
+    })
+    const appearance = await goToSettingsSection(page, 'appearance')
+    await appearance.getByRole('button', { name: 'Customize quick settings' }).click()
+    await page.getByRole('button', { name: 'Add setting' }).click()
+
+    const settingPicker = page.getByPlaceholder('Search settings')
+    const settingPopover = page.getByRole('dialog', { name: 'Add setting' })
+    const options = page.locator('.settingPicker .list')
+    const scrollbar = options.locator('.os-scrollbar-vertical')
+    await expect(options).toBeVisible()
+    await expect(settingPicker).toHaveCSS('padding-inline-start', '16px')
+    await expect(scrollbar).toHaveClass(/os-scrollbar-visible/)
+    await options.evaluate(element => element.scrollTo(0, element.scrollHeight))
+    await expect.poll(() => options.evaluate(element => element.scrollTop)).toBeGreaterThan(0)
+    const [popoverBounds, scrollbarBounds] = await Promise.all([
+      settingPopover.evaluate(element => element.getBoundingClientRect().toJSON()),
+      scrollbar.evaluate(element => element.getBoundingClientRect().toJSON()),
+    ])
+    expect(scrollbarBounds.x).toBeGreaterThanOrEqual(popoverBounds.x - 1)
+    expect(scrollbarBounds.y).toBeGreaterThanOrEqual(popoverBounds.y - 1)
+    expect(scrollbarBounds.x + scrollbarBounds.width).toBeLessThanOrEqual(
+      popoverBounds.x + popoverBounds.width + 1
+    )
+    expect(scrollbarBounds.y + scrollbarBounds.height).toBeLessThanOrEqual(
+      popoverBounds.y + popoverBounds.height + 1
+    )
+    const hoveredOption = options.locator('li').nth(1)
+    await hoveredOption.hover()
+    const [hoveredOptionBounds, scrollbarTrackBounds] = await Promise.all([
+      hoveredOption.evaluate(element => element.getBoundingClientRect().toJSON()),
+      scrollbar.evaluate(element => element.getBoundingClientRect().toJSON()),
+    ])
+    expect(hoveredOptionBounds.x + hoveredOptionBounds.width).toBeLessThanOrEqual(
+      scrollbarTrackBounds.x + 1
+    )
+
+    await settingPicker.fill('Icon Pack')
+    await expect(options.locator('li')).toHaveCount(1)
+    await expect(options).toHaveJSProperty('scrollTop', 0)
+    await expect(scrollbar).toHaveClass(/os-scrollbar-unusable/)
   })
 })
 

--- a/e2e/tests/offline/settings.spec.mjs
+++ b/e2e/tests/offline/settings.spec.mjs
@@ -1784,7 +1784,7 @@ test.describe('settings', () => {
     await expect(downloadsShortcut).toBeVisible()
     await expect(allSettingsShortcut).toBeVisible()
     await expect(menu.getByRole('heading', { name: 'Playback', exact: true })).toBeVisible()
-    await expect(menu.getByRole('heading', { name: 'Language and region', exact: true })).toBeVisible()
+    await expect(menu.getByRole('heading', { name: 'Content', exact: true })).toBeVisible()
     await page.locator('.profileTrigger').click()
 
     await themeSection.locator('label.switch-label')

--- a/e2e/tests/offline/settings.spec.mjs
+++ b/e2e/tests/offline/settings.spec.mjs
@@ -674,7 +674,12 @@ test.describe('settings', () => {
     const appearance = await goToSettingsSection(page, 'appearance')
     const headings = appearance.getByRole('heading', { level: 3 })
 
-    await expect(headings).toHaveText(['Theme', 'Layout', 'Video lists and thumbnails'])
+    await expect(headings).toHaveText([
+      'Theme',
+      'Layout',
+      'Quick settings',
+      'Video lists and thumbnails',
+    ])
     const theme = appearance.locator('.settingsSection').filter({
       has: page.getByRole('heading', { name: 'Theme', exact: true })
     })

--- a/src/renderer/components/FtInput/FtInput.vue
+++ b/src/renderer/components/FtInput/FtInput.vue
@@ -7,7 +7,7 @@
       forceTextColor,
       showActionButton,
       showClearTextButton,
-      clearTextButtonVisible: inputDataPresent || showOptions,
+      clearTextButtonVisible: showClearTextButton && (inputDataPresent || showOptions),
       inputDataPresent,
       showOptions
     }"

--- a/src/renderer/components/FtQuickSettingControl/FtQuickSettingControl.vue
+++ b/src/renderer/components/FtQuickSettingControl/FtQuickSettingControl.vue
@@ -1,0 +1,65 @@
+<template>
+  <FtToggleSwitch
+    v-if="definition.control === 'toggle'"
+    :label="label"
+    :default-value="value"
+    :setting-key="definition.id"
+    compact
+    @change="emitUpdate"
+  />
+  <FtSelect
+    v-else-if="definition.control === 'select'"
+    class="quickSelect"
+    :placeholder="label"
+    :value="value"
+    :setting-key="definition.id"
+    :select-names="selectNames"
+    :select-values="definition.values"
+    @change="emitUpdate"
+  />
+  <FtSlider
+    v-else-if="definition.control === 'slider'"
+    :label="label"
+    :default-value="value"
+    :setting-key="definition.id"
+    :min-value="definition.min"
+    :max-value="definition.max"
+    :step="definition.step"
+    :value-extension="definition.extension"
+    @change="emitUpdate"
+  />
+</template>
+
+<script setup>
+import { computed } from 'vue'
+import { useI18n } from 'vue-i18n'
+
+import FtSelect from '../FtSelect/FtSelect.vue'
+import FtSlider from '../FtSlider/FtSlider.vue'
+import FtToggleSwitch from '../FtToggleSwitch/FtToggleSwitch.vue'
+
+import store from '../../store/index'
+
+const props = defineProps({
+  definition: {
+    type: Object,
+    required: true,
+  },
+})
+
+const emit = defineEmits(['update'])
+const { t } = useI18n()
+
+// Catalog entries use translation keys so the same descriptor stays localized.
+// eslint-disable-next-line @intlify/vue-i18n/no-dynamic-keys
+const label = computed(() => t(props.definition.labelKey))
+const value = computed(() => store.state.settings[props.definition.id])
+const selectNames = computed(() => props.definition.optionLabelKeys?.map((key) => {
+  // eslint-disable-next-line @intlify/vue-i18n/no-dynamic-keys
+  return t(key)
+}) ?? [])
+
+function emitUpdate(value) {
+  emit('update', props.definition.id, value)
+}
+</script>

--- a/src/renderer/components/FtQuickSettingsMenu/FtQuickSettingsMenu.css
+++ b/src/renderer/components/FtQuickSettingsMenu/FtQuickSettingsMenu.css
@@ -206,6 +206,9 @@
 
 .menuSection {
   border-block-start: 1px solid var(--divider-color);
+  column-gap: 12px;
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
   padding-block: 10px 12px;
   padding-inline: 18px;
 }
@@ -214,10 +217,19 @@
   color: var(--secondary-text-color);
   font-size: 12px;
   font-weight: 600;
+  grid-column: 1 / -1;
   line-height: 1.2;
   margin-block: 0 10px;
   margin-inline: 0;
   text-transform: uppercase;
+}
+
+.quickSettingControl {
+  grid-column: 1 / -1;
+}
+
+.quickSettingControl.pairedQuickSetting {
+  grid-column: auto;
 }
 
 .menuSection :deep(.pure-material-slider),
@@ -233,20 +245,6 @@
 
 .menuSection :deep(.quickSelect + .quickSelect) {
   margin-block-start: 28px;
-}
-
-.selectPair {
-  display: grid;
-  gap: 12px;
-  grid-template-columns: repeat(2, minmax(0, 1fr));
-}
-
-.selectPair:has(> :only-child) {
-  grid-template-columns: minmax(0, 1fr);
-}
-
-.selectPair :deep(.quickSelect + .quickSelect) {
-  margin-block-start: 26px;
 }
 
 .menuSection :deep(.quickSelect .select-text),
@@ -336,11 +334,7 @@
 }
 
 @media only screen and (width <= 400px) {
-  .selectPair {
-    grid-template-columns: 1fr;
-  }
-
-  .selectPair :deep(.quickSelect + .quickSelect) {
-    margin-block-start: 28px;
+  .quickSettingControl.pairedQuickSetting {
+    grid-column: 1 / -1;
   }
 }

--- a/src/renderer/components/FtQuickSettingsMenu/FtQuickSettingsMenu.vue
+++ b/src/renderer/components/FtQuickSettingsMenu/FtQuickSettingsMenu.vue
@@ -152,10 +152,21 @@
               ref="mainContentRef"
               class="quickSettingsContent"
             >
-              <section class="menuSection">
-                <h3>{{ t('Settings.Quick Settings.Appearance') }}</h3>
-                <div class="selectPair">
+              <section
+                v-for="(section, sectionIndex) in orderedQuickSettingSections"
+                :key="`${section.id}-${sectionIndex}`"
+                class="menuSection"
+              >
+                <h3>{{ section.label }}</h3>
+                <div
+                  v-for="setting in section.settings"
+                  :key="setting.id"
+                  class="quickSettingControl"
+                  :class="{ pairedQuickSetting: isPairedQuickSetting(section.settings, setting.id) }"
+                  :data-setting-id="setting.id"
+                >
                   <FtSelect
+                    v-if="setting.id === 'baseTheme'"
                     class="quickSelect"
                     :placeholder="t('Settings.Theme Settings.Base Theme.Base Theme')"
                     :value="baseTheme"
@@ -167,7 +178,7 @@
                     @change="updateSetting('BaseTheme', $event)"
                   />
                   <FtSelect
-                    v-if="mainColorAvailable"
+                    v-else-if="setting.id === 'mainColor'"
                     class="quickSelect"
                     :placeholder="t('Settings.Theme Settings.Main Color Theme.Main Color Theme')"
                     :value="mainColor"
@@ -179,66 +190,67 @@
                     icon-color="var(--primary-color)"
                     @change="updateSetting('MainColor', $event)"
                   />
-                </div>
-                <div class="sliderGroup">
-                  <FtSlider
-                    v-if="USING_ELECTRON"
-                    :label="t('Settings.Theme Settings.UI Scale')"
-                    :default-value="uiScale"
-                    :min-value="50"
-                    :max-value="300"
-                    :step="5"
-                    value-extension="%"
-                    @change="updateUiScale"
-                  />
-                  <FtSlider
-                    class="thumbnailSizeSlider"
-                    :label="t('Settings.Theme Settings.Thumbnail Size')"
-                    :default-value="thumbnailSize"
-                    setting-key="thumbnailSize"
-                    :min-value="MIN_THUMBNAIL_SIZE"
-                    :max-value="MAX_THUMBNAIL_SIZE"
-                    :step="THUMBNAIL_SIZE_STEP"
-                    value-extension="%"
-                    @input="previewThumbnailSize"
-                    @change="updateThumbnailSize"
-                  />
-                </div>
-              </section>
-
-              <section class="menuSection">
-                <h3>{{ t('Settings.Quick Settings.Playback') }}</h3>
-                <FtSelect
-                  class="quickSelect"
-                  :placeholder="t('Settings.Player Settings.Default Quality.Default Quality')"
-                  :value="defaultQuality"
-                  setting-key="defaultQuality"
-                  :select-names="qualityNames"
-                  :select-values="qualityValues"
-                  :icon="['fas', 'photo-film']"
-                  @change="updateSetting('DefaultQuality', $event)"
-                />
-                <FtToggleSwitch
-                  :label="t('Settings.Player Settings.Play Next Video')"
-                  :default-value="playNextVideo"
-                  :disabled="hideRecommendedVideos"
-                  setting-key="playNextVideo"
-                  compact
-                  @change="updateSetting('PlayNextVideo', $event)"
-                />
-                <FtToggleSwitch
-                  :label="t('Settings.Player Settings.Turn on Subtitles by Default')"
-                  :default-value="enableSubtitlesByDefault"
-                  setting-key="enableSubtitlesByDefault"
-                  compact
-                  @change="updateSetting('EnableSubtitlesByDefault', $event)"
-                />
-              </section>
-
-              <section class="menuSection">
-                <h3>{{ t('Settings.Quick Settings.Content') }}</h3>
-                <div class="selectPair">
+                  <div
+                    v-else-if="setting.id === 'uiScale'"
+                    class="sliderGroup"
+                  >
+                    <FtSlider
+                      :label="t('Settings.Theme Settings.UI Scale')"
+                      :default-value="uiScale"
+                      :min-value="50"
+                      :max-value="300"
+                      :step="5"
+                      value-extension="%"
+                      @change="updateUiScale"
+                    />
+                  </div>
+                  <div
+                    v-else-if="setting.id === 'thumbnailSize'"
+                    class="sliderGroup"
+                  >
+                    <FtSlider
+                      class="thumbnailSizeSlider"
+                      :label="t('Settings.Theme Settings.Thumbnail Size')"
+                      :default-value="thumbnailSize"
+                      setting-key="thumbnailSize"
+                      :min-value="MIN_THUMBNAIL_SIZE"
+                      :max-value="MAX_THUMBNAIL_SIZE"
+                      :step="THUMBNAIL_SIZE_STEP"
+                      value-extension="%"
+                      @input="previewThumbnailSize"
+                      @change="updateThumbnailSize"
+                    />
+                  </div>
                   <FtSelect
+                    v-else-if="setting.id === 'defaultQuality'"
+                    class="quickSelect"
+                    :placeholder="t('Settings.Player Settings.Default Quality.Default Quality')"
+                    :value="defaultQuality"
+                    setting-key="defaultQuality"
+                    :select-names="qualityNames"
+                    :select-values="qualityValues"
+                    :icon="['fas', 'photo-film']"
+                    @change="updateSetting('DefaultQuality', $event)"
+                  />
+                  <FtToggleSwitch
+                    v-else-if="setting.id === 'playNextVideo'"
+                    :label="t('Settings.Player Settings.Play Next Video')"
+                    :default-value="playNextVideo"
+                    :disabled="hideRecommendedVideos"
+                    setting-key="playNextVideo"
+                    compact
+                    @change="updateSetting('PlayNextVideo', $event)"
+                  />
+                  <FtToggleSwitch
+                    v-else-if="setting.id === 'enableSubtitlesByDefault'"
+                    :label="t('Settings.Player Settings.Turn on Subtitles by Default')"
+                    :default-value="enableSubtitlesByDefault"
+                    setting-key="enableSubtitlesByDefault"
+                    compact
+                    @change="updateSetting('EnableSubtitlesByDefault', $event)"
+                  />
+                  <FtSelect
+                    v-else-if="setting.id === 'listType'"
                     class="quickSelect"
                     :placeholder="t('Settings.General Settings.Video View Type.Video View Type')"
                     :value="listType"
@@ -249,6 +261,7 @@
                     @change="updateSetting('ListType', $event)"
                   />
                   <FtSelect
+                    v-else-if="setting.id === 'playlistViewType'"
                     class="quickSelect"
                     :placeholder="t('Settings.General Settings.Playlist View Type.Playlist View Type')"
                     :value="playlistViewType"
@@ -258,27 +271,24 @@
                     :icon="playlistViewType === 'grid' ? ['fas', 'grip'] : ['fas', 'list']"
                     @change="updateSetting('PlaylistViewType', $event)"
                   />
-                </div>
-                <FtToggleSwitch
-                  :label="t('Settings.Distraction Free Settings.Hide Recommended Videos')"
-                  :default-value="hideRecommendedVideos"
-                  setting-key="hideRecommendedVideos"
-                  compact
-                  @change="handleHideRecommendedVideos"
-                />
-                <FtToggleSwitch
-                  :label="t('Settings.Distraction Free Settings.Hide Comments')"
-                  :default-value="hideComments"
-                  setting-key="hideComments"
-                  compact
-                  @change="updateSetting('HideComments', $event)"
-                />
-              </section>
-
-              <section class="menuSection">
-                <h3>{{ t('Settings.Quick Settings.Language and Region') }}</h3>
-                <div class="selectPair">
+                  <FtToggleSwitch
+                    v-else-if="setting.id === 'hideRecommendedVideos'"
+                    :label="t('Settings.Distraction Free Settings.Hide Recommended Videos')"
+                    :default-value="hideRecommendedVideos"
+                    setting-key="hideRecommendedVideos"
+                    compact
+                    @change="handleHideRecommendedVideos"
+                  />
+                  <FtToggleSwitch
+                    v-else-if="setting.id === 'hideComments'"
+                    :label="t('Settings.Distraction Free Settings.Hide Comments')"
+                    :default-value="hideComments"
+                    setting-key="hideComments"
+                    compact
+                    @change="updateSetting('HideComments', $event)"
+                  />
                   <FtSelect
+                    v-else-if="setting.id === 'currentLocale'"
                     class="quickSelect"
                     :placeholder="t('Settings.General Settings.Locale Preference')"
                     :value="currentLocale"
@@ -290,7 +300,7 @@
                     @change="updateSetting('CurrentLocale', $event)"
                   />
                   <FtSelect
-                    v-if="regionValues.length > 0"
+                    v-else-if="setting.id === 'region'"
                     class="quickSelect"
                     :placeholder="t('Settings.General Settings.Region for Trending')"
                     :value="region"
@@ -299,6 +309,19 @@
                     :select-values="regionValues"
                     :icon="['fas', 'globe']"
                     @change="updateSetting('Region', $event)"
+                  />
+                  <FtToggleSwitch
+                    v-else-if="setting.id === 'useProxy'"
+                    :label="t('Settings.Proxy Settings.Enable Tor / Proxy')"
+                    :default-value="useProxy"
+                    setting-key="useProxy"
+                    compact
+                    @change="updateProxy"
+                  />
+                  <FtQuickSettingControl
+                    v-else
+                    :definition="setting"
+                    @update="updateBasicQuickSetting"
                   />
                 </div>
               </section>
@@ -346,6 +369,7 @@ import FtSelect from '../FtSelect/FtSelect.vue'
 import FtSlider from '../FtSlider/FtSlider.vue'
 import FtToggleSwitch from '../FtToggleSwitch/FtToggleSwitch.vue'
 import FtProfileIcon from '../FtProfileIcon/FtProfileIcon.vue'
+import FtQuickSettingControl from '../FtQuickSettingControl/FtQuickSettingControl.vue'
 
 import store from '../../store/index'
 import allLocales from '../../../../static/locales/activeLocales.json'
@@ -361,6 +385,12 @@ import {
 import { AUTO_QUALITY_FALLBACK, playbackEngineSupportsAutoQuality } from '../../helpers/player/autoQuality'
 import { getFirstCharacter } from '../../helpers/strings'
 import { clampOverlayScrollTop, restoreOverlayScrollTop } from '../../helpers/overlayScrollbars'
+import {
+  createQuickSettingCatalog,
+  createQuickSettingSections,
+  isQuickSettingPaired,
+} from '../../helpers/quickSettings'
+import { defaultUpdaterId } from '../../store/modules/settings'
 import { switchActiveProfile, translateProfileName as getTranslatedProfileName } from '../../helpers/profileSwitching'
 import { customThemeValue, isCustomThemeValue } from '../../../customTheme'
 
@@ -474,6 +504,10 @@ const currentLocale = computed(() => store.getters.getCurrentLocale)
 const region = computed(() => store.getters.getRegion)
 const regionNames = computed(() => store.getters.getRegionNames)
 const regionValues = computed(() => store.getters.getRegionValues)
+const useProxy = computed(() => store.getters.getUseProxy)
+const proxyUrl = computed(() => (
+  `${store.getters.getProxyProtocol}://${store.getters.getProxyHostname}:${store.getters.getProxyPort}`
+))
 const showDownloadsShortcut = computed(() => (
   USING_ELECTRON &&
   store.getters.getEnableDownloads &&
@@ -482,6 +516,42 @@ const showDownloadsShortcut = computed(() => (
 const showSettingsShortcut = computed(() => (
   !USING_ELECTRON || !store.getters.getMoveSettingsToAppHeader
 ))
+
+const quickSettings = computed(() => store.getters.getQuickSettings)
+const quickSettingCatalog = computed(() => createQuickSettingCatalog(t, USING_ELECTRON))
+const quickSettingSectionLabels = computed(() => new Map(
+  createQuickSettingSections(t, USING_ELECTRON).map(section => [section.id, section.label])
+))
+const orderedQuickSettingSections = computed(() => {
+  const catalogById = new Map(quickSettingCatalog.value.map(setting => [setting.id, setting]))
+  const visibleSettings = quickSettings.value
+    .map(settingId => catalogById.get(settingId))
+    .filter(setting => setting != null && (
+      (setting.id !== 'mainColor' || mainColorAvailable.value) &&
+      (setting.id !== 'region' || regionValues.value.length > 0)
+    ))
+
+  return visibleSettings.reduce((sections, setting) => {
+    let section = sections.at(-1)
+    if (section?.id !== setting.section) {
+      section = {
+        id: setting.section,
+        label: setting.id === 'useProxy'
+          ? t('Settings.Proxy Settings.Proxy Settings')
+          : quickSettingSectionLabels.value.get(setting.section),
+        settings: [],
+      }
+      sections.push(section)
+    }
+    section.settings.push(setting)
+    return sections
+  }, [])
+})
+
+function isPairedQuickSetting(settings, settingId) {
+  const settingIndex = settings.findIndex(setting => setting.id === settingId)
+  return isQuickSettingPaired(settings, settingIndex)
+}
 
 const RESOLUTION_VALUES = ['2160', '1440', '1080', '720', '480', '360', '240', '144']
 const autoQualityAvailable = computed(() => playbackEngineSupportsAutoQuality(store.getters.getVideoPlaybackEngine))
@@ -597,13 +667,13 @@ onBeforeUnmount(() => {
   stopObservingMainContent()
 })
 
-watch(profilePanelOpen, async (open) => {
+watch(profilePanelOpen, async (profileOpen) => {
   if (!menuOpen.value) return
   stopObservingMainContent()
   await nextTick()
-  const scrollViewport = open ? profileScrollRef.value : mainScrollRef.value
+  const scrollViewport = profileOpen ? profileScrollRef.value : mainScrollRef.value
   if (scrollViewport) restoreOverlayScrollTop(scrollViewport, 0)
-  if (!open) observeMainContent()
+  if (!profileOpen) observeMainContent()
 })
 
 watch(mainColorAvailable, async () => {
@@ -624,6 +694,10 @@ function openProfilePanelFromContextMenu() {
 function closeProfilePanel() {
   profilePanelOpen.value = false
   focusMenu()
+}
+
+function updateBasicQuickSetting(settingId, value) {
+  return runSettingUpdate(() => store.dispatch(defaultUpdaterId(settingId), value))
 }
 
 function handleMenuFocusOut(event) {
@@ -714,6 +788,19 @@ async function runSettingUpdate(update) {
 
 function updateUiScale(value) {
   return runSettingUpdate(() => store.dispatch('updateUiScale', value))
+}
+
+function updateProxy(value) {
+  return runSettingUpdate(async () => {
+    if (USING_ELECTRON) {
+      if (value) {
+        await window.ftElectron.enableProxy(proxyUrl.value)
+      } else {
+        await window.ftElectron.disableProxy()
+      }
+    }
+    await store.dispatch('updateUseProxy', value)
+  })
 }
 
 function previewThumbnailSize(value) {

--- a/src/renderer/components/QuickSettingsCustomizer/QuickSettingsCustomizer.vue
+++ b/src/renderer/components/QuickSettingsCustomizer/QuickSettingsCustomizer.vue
@@ -1,0 +1,489 @@
+<template>
+  <FtSettingsSection :title="t('Settings.Quick Settings.Quick Settings')">
+    <div class="quickSettingsLauncher">
+      <FtButton
+        :label="t('Settings.Quick Settings.Customize Quick Settings')"
+        :icon="['fas', 'sliders-h']"
+        @click="open = true"
+      />
+    </div>
+  </FtSettingsSection>
+
+  <FtSettingsSubpage
+    :open="open"
+    :title="t('Settings.Quick Settings.Customize Quick Settings')"
+    :icon="['fas', 'sliders-h']"
+    @close="close"
+  >
+    <div class="quickSettingsActions">
+      <div
+        ref="settingPickerAnchorRef"
+        class="settingPickerAnchor"
+      >
+        <FtButton
+          :label="t('Settings.Quick Settings.Add Setting')"
+          :icon="['fas', 'plus']"
+          aria-haspopup="dialog"
+          :aria-expanded="settingPickerOpen"
+          :aria-controls="settingPickerId"
+          @click="toggleSettingPicker"
+        />
+        <div
+          v-if="settingPickerOpen"
+          :id="settingPickerId"
+          class="settingPickerPopover"
+          data-settings-escape-scope
+          role="dialog"
+          :aria-label="t('Settings.Quick Settings.Add Setting')"
+          @keydown.esc.stop="closeSettingPicker(true)"
+        >
+          <FtInput
+            ref="settingPickerRef"
+            class="settingPicker"
+            input-type="search"
+            :placeholder="t('Settings.Search Settings')"
+            :label="t('Settings.Search Settings')"
+            :show-label="false"
+            :show-action-button="false"
+            :show-data-when-empty="true"
+            :is-search="true"
+            :value="settingSearchQuery"
+            :data-list="availableSettingLabels"
+            :data-list-properties="availableSettingProperties"
+            @input="settingSearchQuery = $event"
+            @click="addQuickSetting"
+          />
+        </div>
+      </div>
+      <FtButton
+        :label="t('KeyboardShortcutPrompt.Reset to Defaults')"
+        :icon="['fas', 'undo']"
+        theme="secondary"
+        @click="resetQuickSettings"
+      />
+    </div>
+
+    <ul
+      v-if="selectedSettings.length > 0"
+      class="selectedSettings"
+    >
+      <li
+        v-for="(setting, index) in selectedSettings"
+        :key="setting.id"
+        class="selectedSetting"
+        :data-setting-id="setting.id"
+        :class="{
+          dragging: draggedSettingId === setting.id,
+          dropBefore: dropTarget?.id === setting.id && !dropTarget.after,
+          dropAfter: dropTarget?.id === setting.id && dropTarget.after,
+        }"
+        @dragover.prevent="handleDragOver($event, setting.id)"
+        @drop.prevent="dropQuickSetting($event, setting.id)"
+      >
+        <span
+          class="dragHandle"
+          draggable="true"
+          aria-hidden="true"
+          @dragstart="startDragging($event, setting.id)"
+          @dragend="stopDragging"
+        >
+          <FtIcon :icon="['fas', 'grip']" />
+        </span>
+        <FtIcon
+          class="selectedSettingIcon"
+          :icon="setting.icon"
+          aria-hidden="true"
+        />
+        <span>{{ setting.label }}</span>
+        <div class="settingActions">
+          <button
+            type="button"
+            class="settingAction"
+            :aria-label="t('Home Page.Move section up', { section: setting.label })"
+            :title="t('Home Page.Move section up', { section: setting.label })"
+            :disabled="index === 0"
+            @click="moveQuickSetting(setting.id, -1)"
+          >
+            <FtIcon
+              :icon="['fas', 'arrow-up']"
+              aria-hidden="true"
+            />
+          </button>
+          <button
+            type="button"
+            class="settingAction"
+            :aria-label="t('Home Page.Move section down', { section: setting.label })"
+            :title="t('Home Page.Move section down', { section: setting.label })"
+            :disabled="index === selectedSettings.length - 1"
+            @click="moveQuickSetting(setting.id, 1)"
+          >
+            <FtIcon
+              :icon="['fas', 'arrow-down']"
+              aria-hidden="true"
+            />
+          </button>
+          <button
+            type="button"
+            class="settingAction"
+            :aria-label="`${t('Search Bar.Remove')} ${setting.label}`"
+            :title="`${t('Search Bar.Remove')} ${setting.label}`"
+            @click="removeQuickSetting(setting.id)"
+          >
+            <FtIcon
+              :icon="['fas', 'xmark']"
+              aria-hidden="true"
+            />
+          </button>
+        </div>
+      </li>
+    </ul>
+    <p
+      v-else
+      class="emptyState"
+    >
+      {{ t('Settings.No Settings Found') }}
+    </p>
+    <p
+      class="reorderStatus"
+      role="status"
+      aria-live="polite"
+      aria-atomic="true"
+    >
+      {{ reorderStatus }}
+    </p>
+  </FtSettingsSubpage>
+</template>
+
+<script setup>
+import { FtIcon } from '@opentubex/icons'
+import { computed, nextTick, onBeforeUnmount, onMounted, ref, useId, useTemplateRef } from 'vue'
+import { useI18n } from 'vue-i18n'
+
+import FtButton from '../FtButton/FtButton.vue'
+import FtInput from '../FtInput/FtInput.vue'
+import FtSettingsSection from '../FtSettingsSection/FtSettingsSection.vue'
+import FtSettingsSubpage from '../FtSettingsSubpage/FtSettingsSubpage.vue'
+
+import store from '../../store/index'
+import {
+  createQuickSettingCatalog,
+  DEFAULT_QUICK_SETTINGS,
+  moveQuickSettingByVisibleOffset,
+} from '../../helpers/quickSettings'
+
+const { locale, t } = useI18n()
+const open = ref(false)
+const settingPickerOpen = ref(false)
+const settingSearchQuery = ref('')
+const draggedSettingId = ref(null)
+const dropTarget = ref(null)
+const reorderStatus = ref('')
+const settingPickerId = `quick-setting-picker-${useId().replaceAll(':', '')}`
+const settingPickerAnchorRef = useTemplateRef('settingPickerAnchorRef')
+const settingPickerRef = useTemplateRef('settingPickerRef')
+
+const catalog = computed(() => createQuickSettingCatalog(t, process.env.IS_ELECTRON))
+const catalogById = computed(() => new Map(catalog.value.map(setting => [setting.id, setting])))
+const quickSettings = computed(() => store.getters.getQuickSettings)
+const selectedSettings = computed(() => quickSettings.value
+  .map(id => catalogById.value.get(id))
+  .filter(setting => setting != null))
+const availableSettings = computed(() => catalog.value
+  .filter(setting => !quickSettings.value.includes(setting.id))
+  .toSorted((left, right) => left.label.localeCompare(right.label, locale.value)))
+const availableSettingLabels = computed(() => availableSettings.value.map(setting => setting.label))
+const availableSettingProperties = computed(() => availableSettings.value.map(setting => ({
+  ariaLabel: setting.label,
+  displayText: setting.label,
+  iconName: setting.icon[1],
+})))
+
+function close() {
+  open.value = false
+  closeSettingPicker()
+  stopDragging()
+}
+
+async function toggleSettingPicker() {
+  if (settingPickerOpen.value) {
+    closeSettingPicker()
+    return
+  }
+
+  settingPickerOpen.value = true
+  settingSearchQuery.value = ''
+  await nextTick()
+  settingPickerRef.value?.focus()
+}
+
+function closeSettingPicker(restoreFocus = false) {
+  settingPickerOpen.value = false
+  settingSearchQuery.value = ''
+  if (restoreFocus) {
+    nextTick(() => settingPickerAnchorRef.value?.querySelector('button')?.focus())
+  }
+}
+
+function closeSettingPickerFromOutside(event) {
+  if (!settingPickerOpen.value || settingPickerAnchorRef.value?.contains(event.target)) return
+  closeSettingPicker()
+}
+
+onMounted(() => document.addEventListener('pointerdown', closeSettingPickerFromOutside))
+onBeforeUnmount(() => document.removeEventListener('pointerdown', closeSettingPickerFromOutside))
+
+async function addQuickSetting(_, { dataListIndex }) {
+  const setting = availableSettings.value[dataListIndex]
+  if (!setting) return
+
+  await store.dispatch('updateQuickSettings', [...quickSettings.value, setting.id])
+  settingSearchQuery.value = ''
+  await nextTick()
+  settingPickerRef.value?.setText('')
+  settingPickerRef.value?.focus()
+}
+
+function removeQuickSetting(settingId) {
+  return store.dispatch(
+    'updateQuickSettings',
+    quickSettings.value.filter(id => id !== settingId)
+  )
+}
+
+function announceQuickSettingMoved(settingId, position) {
+  const setting = catalogById.value.get(settingId)
+  reorderStatus.value = t('Home Page.Section moved', {
+    section: setting?.label ?? settingId,
+    position: position + 1,
+    total: quickSettings.value.length,
+  })
+}
+
+function moveQuickSetting(settingId, offset) {
+  const visibleSettings = selectedSettings.value.map(setting => setting.id)
+  const currentIndex = visibleSettings.indexOf(settingId)
+  const targetIndex = currentIndex + offset
+  const reordered = moveQuickSettingByVisibleOffset(
+    quickSettings.value,
+    visibleSettings,
+    settingId,
+    offset
+  )
+  if (reordered === quickSettings.value) return
+
+  store.dispatch('updateQuickSettings', reordered)
+  announceQuickSettingMoved(settingId, targetIndex)
+}
+
+function startDragging(event, settingId) {
+  draggedSettingId.value = settingId
+  event.dataTransfer.effectAllowed = 'move'
+  event.dataTransfer.setData('text/plain', settingId)
+  event.dataTransfer.setDragImage(event.currentTarget.closest('.selectedSetting'), 20, 20)
+}
+
+function handleDragOver(event, settingId) {
+  if (draggedSettingId.value == null || draggedSettingId.value === settingId) {
+    dropTarget.value = null
+    return
+  }
+
+  const bounds = event.currentTarget.getBoundingClientRect()
+  dropTarget.value = {
+    id: settingId,
+    after: event.clientY >= bounds.top + bounds.height / 2,
+  }
+  event.dataTransfer.dropEffect = 'move'
+}
+
+function dropQuickSetting(event, settingId) {
+  const draggedId = draggedSettingId.value
+  if (draggedId == null || draggedId === settingId) {
+    stopDragging()
+    return
+  }
+
+  const sourceIndex = quickSettings.value.indexOf(draggedId)
+  const targetIndex = quickSettings.value.indexOf(settingId)
+  if (sourceIndex === -1 || targetIndex === -1) {
+    stopDragging()
+    return
+  }
+
+  const bounds = event.currentTarget.getBoundingClientRect()
+  let insertIndex = targetIndex + (event.clientY >= bounds.top + bounds.height / 2 ? 1 : 0)
+  const reordered = quickSettings.value.slice()
+  reordered.splice(sourceIndex, 1)
+  if (sourceIndex < insertIndex) insertIndex--
+  reordered.splice(insertIndex, 0, draggedId)
+  store.dispatch('updateQuickSettings', reordered)
+  announceQuickSettingMoved(draggedId, insertIndex)
+  stopDragging()
+}
+
+function stopDragging() {
+  draggedSettingId.value = null
+  dropTarget.value = null
+}
+
+function resetQuickSettings() {
+  return store.dispatch('updateQuickSettings', [...DEFAULT_QUICK_SETTINGS])
+}
+</script>
+
+<style scoped>
+.quickSettingsLauncher {
+  display: flex;
+  justify-content: center;
+}
+
+.quickSettingsActions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 12px;
+  inline-size: 100%;
+  justify-content: center;
+  margin-block-end: 20px;
+  margin-inline: auto;
+  max-inline-size: 720px;
+  position: relative;
+}
+
+.settingPickerPopover {
+  background: var(--card-bg-color);
+  border: 1px solid var(--divider-color);
+  border-radius: calc(6px * var(--ui-roundness));
+  box-shadow: 0 8px 24px rgb(0 0 0 / 35%);
+  box-sizing: border-box;
+  inline-size: min(520px, 100%);
+  inset-block-start: calc(100% + 8px);
+  inset-inline-start: 50%;
+  padding: 12px;
+  position: absolute;
+  translate: -50% 0;
+  z-index: 20;
+}
+
+.settingPicker {
+  inline-size: 100%;
+}
+
+.settingPicker :deep(.list) {
+  border-block-start: 1px solid var(--divider-color);
+  border-radius: 0 0 calc(5px * var(--ui-roundness)) calc(5px * var(--ui-roundness));
+  box-shadow: none;
+  margin-block-start: 8px;
+  position: relative;
+}
+
+.settingPicker :deep(.list:has(> .os-scrollbar-vertical:not(.os-scrollbar-unusable)) > li) {
+  margin-inline-end: var(--scrollbar-track-width);
+}
+
+.selectedSettings {
+  display: grid;
+  gap: 8px;
+  inline-size: 100%;
+  list-style: none;
+  margin-block: 0;
+  margin-inline: auto;
+  max-inline-size: 720px;
+  padding: 0;
+}
+
+.selectedSetting {
+  align-items: center;
+  background: var(--card-bg-color);
+  border: 1px solid var(--divider-color);
+  border-radius: calc(6px * var(--ui-roundness));
+  display: grid;
+  grid-template-columns: 44px 24px minmax(0, 1fr) auto;
+  min-block-size: 56px;
+  position: relative;
+}
+
+.selectedSetting.dragging {
+  opacity: 0.5;
+}
+
+.selectedSetting.dropBefore::before,
+.selectedSetting.dropAfter::after {
+  background: var(--primary-color);
+  block-size: 3px;
+  border-radius: 2px;
+  content: '';
+  inset-inline: 0;
+  position: absolute;
+}
+
+.selectedSetting.dropBefore::before {
+  inset-block-start: -6px;
+}
+
+.selectedSetting.dropAfter::after {
+  inset-block-end: -6px;
+}
+
+.dragHandle {
+  align-items: center;
+  align-self: stretch;
+  color: var(--secondary-text-color);
+  cursor: grab;
+  display: flex;
+  inline-size: 44px;
+  justify-content: center;
+}
+
+.dragHandle:active {
+  cursor: grabbing;
+}
+
+.selectedSettingIcon {
+  block-size: 20px;
+  color: var(--secondary-text-color);
+  inline-size: 20px;
+}
+
+.settingActions {
+  align-self: stretch;
+  display: flex;
+}
+
+.settingAction {
+  align-items: center;
+  background: transparent;
+  border: 0;
+  border-radius: calc(6px * var(--ui-roundness));
+  color: var(--secondary-text-color);
+  cursor: pointer;
+  display: flex;
+  inline-size: 44px;
+  justify-content: center;
+}
+
+.settingAction:hover:not(:disabled),
+.settingAction:focus-visible {
+  background: var(--side-nav-hover-color);
+  color: var(--side-nav-hover-text-color);
+}
+
+.settingAction:disabled {
+  cursor: default;
+  opacity: 0.35;
+}
+
+.reorderStatus {
+  block-size: 1px;
+  clip-path: inset(50%);
+  inline-size: 1px;
+  overflow: hidden;
+  position: absolute;
+  white-space: nowrap;
+}
+
+.emptyState {
+  color: var(--secondary-text-color);
+  margin-block: 24px;
+  text-align: center;
+}
+</style>

--- a/src/renderer/components/ThemeSettings.vue
+++ b/src/renderer/components/ThemeSettings.vue
@@ -370,6 +370,7 @@
       @click="handleSmoothScrolling"
     />
   </FtSettingsSection>
+  <QuickSettingsCustomizer />
 </template>
 
 <script setup>
@@ -385,6 +386,7 @@ import FtFlexBox from './ft-flex-box/ft-flex-box.vue'
 import FtButton from './FtButton/FtButton.vue'
 import FtPrompt from './FtPrompt/FtPrompt.vue'
 import CustomThemeEditor from './CustomThemeEditor/CustomThemeEditor.vue'
+import QuickSettingsCustomizer from './QuickSettingsCustomizer/QuickSettingsCustomizer.vue'
 
 import store from '../store/index'
 import { customThemeIdFromValue, customThemeValue, isCustomThemeValue } from '../../customTheme'

--- a/src/renderer/helpers/quickSettings.js
+++ b/src/renderer/helpers/quickSettings.js
@@ -1,0 +1,192 @@
+const CORE_QUICK_SETTINGS = [
+  ['baseTheme', 'appearance', 'Settings.Theme Settings.Base Theme.Base Theme', { control: 'select', icon: ['fas', 'palette'] }],
+  ['mainColor', 'appearance', 'Settings.Theme Settings.Main Color Theme.Main Color Theme', { control: 'select', icon: ['fas', 'palette'] }],
+  ['uiScale', 'appearance', 'Settings.Theme Settings.UI Scale', { control: 'slider', electronOnly: true, icon: ['fas', 'sliders-h'] }],
+  ['thumbnailSize', 'appearance', 'Settings.Theme Settings.Thumbnail Size', { control: 'slider', icon: ['fas', 'photo-film'] }],
+  ['defaultQuality', 'playback', 'Settings.Player Settings.Default Quality.Default Quality', { control: 'select', icon: ['fas', 'photo-film'] }],
+  ['playNextVideo', 'playback', 'Settings.Player Settings.Play Next Video', { control: 'toggle', icon: ['fas', 'step-forward'] }],
+  ['enableSubtitlesByDefault', 'playback', 'Settings.Player Settings.Turn on Subtitles by Default', { control: 'toggle', icon: ['fas', 'closed-captioning'] }],
+  ['listType', 'content', 'Settings.General Settings.Video View Type.Video View Type', { control: 'select', icon: ['fas', 'grip'] }],
+  ['playlistViewType', 'content', 'Settings.General Settings.Playlist View Type.Playlist View Type', { control: 'select', icon: ['fas', 'list'] }],
+  ['hideRecommendedVideos', 'content', 'Settings.Distraction Free Settings.Hide Recommended Videos', { control: 'toggle', icon: ['fas', 'eye-slash'] }],
+  ['hideComments', 'content', 'Settings.Distraction Free Settings.Hide Comments', { control: 'toggle', icon: ['fas', 'comment'] }],
+  ['currentLocale', 'language', 'Settings.General Settings.Locale Preference', { control: 'select', icon: ['fas', 'language'] }],
+  ['region', 'language', 'Settings.General Settings.Region for Trending', { control: 'select', icon: ['fas', 'globe'] }],
+  ['useProxy', 'advanced', 'Settings.Proxy Settings.Enable Tor / Proxy', { control: 'toggle', electronOnly: true, icon: ['fas', 'globe'] }],
+]
+
+export const BASIC_QUICK_SETTING_DEFINITIONS = Object.freeze([
+  {
+    id: 'iconPack',
+    section: 'appearance',
+    labelKey: 'Settings.Theme Settings.Icon Pack.Icon Pack',
+    control: 'select',
+    values: ['material', 'remix'],
+    optionLabelKeys: [
+      'Settings.Theme Settings.Icon Pack.Material Symbols',
+      'Settings.Theme Settings.Icon Pack.Remix Icon',
+    ],
+    icon: ['fas', 'icons'],
+  },
+  {
+    id: 'uiRoundness',
+    section: 'appearance',
+    labelKey: 'Settings.Theme Settings.UI Roundness',
+    control: 'slider',
+    min: 0,
+    max: 200,
+    step: 5,
+    extension: '%',
+    icon: ['fas', 'palette'],
+  },
+  {
+    id: 'animationSpeed',
+    section: 'appearance',
+    labelKey: 'Settings.Theme Settings.Animation Speed',
+    control: 'slider',
+    min: 25,
+    max: 200,
+    step: 5,
+    extension: '%',
+    icon: ['fas', 'gauge-high'],
+  },
+  ['barColor', 'Settings.Theme Settings.Match Top Bar with Main Color', 'appearance', ['fas', 'palette']],
+  ['hideSideBarOnWatchPages', 'Settings.Theme Settings.Hide Side Bar on Watch Pages', 'appearance', ['fas', 'eye-slash']],
+  ['alwaysShowScrollbars', 'Settings.Theme Settings.Always Show Scrollbars', 'appearance', ['fas', 'sliders-h']],
+  ['showToastTimeoutIndicator', 'Settings.Theme Settings.Show Toast Timeout Indicator', 'appearance', ['fas', 'message']],
+  ['useSponsorBlock', 'Settings.SponsorBlock Settings.Enable SponsorBlock', 'add-ons', ['fas', 'forward']],
+  ['useReturnYouTubeDislikes', 'Settings.Return YouTube Dislike Settings.Enable Return YouTube Dislike', 'add-ons', ['fas', 'thumbs-down']],
+  ['hideTrendingVideos', 'Settings.Distraction Free Settings.Hide Trending Videos', 'content', ['fas', 'fire']],
+  ['hidePopularVideos', 'Settings.Distraction Free Settings.Hide Popular Videos', 'content', ['fas', 'users']],
+].map(definition => Object.freeze(Array.isArray(definition)
+  ? {
+      id: definition[0],
+      labelKey: definition[1],
+      section: definition[2] ?? 'appearance',
+      icon: definition[3],
+      control: 'toggle',
+    }
+  : definition)))
+
+export const QUICK_SETTING_DEFINITIONS = Object.freeze([
+  ...CORE_QUICK_SETTINGS.map(([id, section, labelKey, options = {}]) => Object.freeze({
+    id,
+    section,
+    labelKey,
+    ...options,
+  })),
+  ...BASIC_QUICK_SETTING_DEFINITIONS,
+])
+
+const SECTION_LABEL_KEYS = Object.freeze({
+  appearance: 'Settings.Quick Settings.Appearance',
+  playback: 'Settings.Quick Settings.Playback',
+  content: 'Settings.Quick Settings.Content',
+  language: 'Settings.Quick Settings.Language and Region',
+  'add-ons': 'Settings.Categories.Add-ons',
+  advanced: 'Settings.Categories.Advanced',
+})
+
+export function createQuickSettingCatalog(t, usingElectron) {
+  return QUICK_SETTING_DEFINITIONS
+    .filter(definition => !definition.electronOnly || usingElectron)
+    .map(definition => ({
+      ...definition,
+      // eslint-disable-next-line @intlify/vue-i18n/no-dynamic-keys
+      label: t(definition.labelKey),
+    }))
+}
+
+export function createQuickSettingSections(t, usingElectron) {
+  const sections = new Map()
+
+  for (const definition of createQuickSettingCatalog(t, usingElectron)) {
+    if (!sections.has(definition.section)) {
+      sections.set(definition.section, {
+        id: definition.section,
+        // eslint-disable-next-line @intlify/vue-i18n/no-dynamic-keys
+        label: t(SECTION_LABEL_KEYS[definition.section]),
+        settings: [],
+      })
+    }
+    sections.get(definition.section).settings.push({
+      ...definition,
+    })
+  }
+
+  return [...sections.values()]
+}
+
+/**
+ * Pairs consecutive selects two at a time. An odd select at the end of a run
+ * stays full-width instead of leaving an empty second column.
+ *
+ * @param {Array<{ control?: string }>} settings
+ * @param {number} settingIndex
+ */
+export function isQuickSettingPaired(settings, settingIndex) {
+  if (settings[settingIndex]?.control !== 'select') return false
+
+  let runStart = settingIndex
+  while (settings[runStart - 1]?.control === 'select') runStart--
+
+  const positionInRun = settingIndex - runStart
+  return positionInRun % 2 === 1 || settings[settingIndex + 1]?.control === 'select'
+}
+
+/**
+ * Moves a setting relative to its visible neighbors while preserving settings
+ * that are unavailable on the current platform.
+ *
+ * @param {string[]} settings
+ * @param {string[]} visibleSettings
+ * @param {string} settingId
+ * @param {number} offset
+ * @returns {string[]}
+ */
+export function moveQuickSettingByVisibleOffset(settings, visibleSettings, settingId, offset) {
+  const visibleIndex = visibleSettings.indexOf(settingId)
+  const targetId = visibleSettings[visibleIndex + offset]
+  if (visibleIndex === -1 || targetId == null) return settings
+
+  const reordered = settings.slice()
+  const sourceIndex = reordered.indexOf(settingId)
+  if (sourceIndex === -1) return settings
+
+  reordered.splice(sourceIndex, 1)
+  const targetIndex = reordered.indexOf(targetId)
+  reordered.splice(targetIndex + (offset > 0 ? 1 : 0), 0, settingId)
+  return reordered
+}
+
+export const DEFAULT_QUICK_SETTINGS = Object.freeze([
+  'baseTheme',
+  'mainColor',
+  'uiScale',
+  'thumbnailSize',
+  'defaultQuality',
+  'playNextVideo',
+  'enableSubtitlesByDefault',
+  'listType',
+  'playlistViewType',
+  'hideRecommendedVideos',
+  'hideComments',
+  'currentLocale',
+  'region',
+])
+
+const QUICK_SETTING_IDS = new Set(QUICK_SETTING_DEFINITIONS.map(({ id }) => id))
+
+/**
+ * Removes unknown and duplicate entries while preserving the user's order.
+ *
+ * @param {unknown} value
+ * @returns {string[]}
+ */
+export function normalizeQuickSettings(value) {
+  if (!Array.isArray(value)) {
+    return [...DEFAULT_QUICK_SETTINGS]
+  }
+
+  return [...new Set(value.filter(id => QUICK_SETTING_IDS.has(id)))]
+}

--- a/src/renderer/store/modules/settings.js
+++ b/src/renderer/store/modules/settings.js
@@ -39,6 +39,7 @@ import { terminateCommentTranslationLanguageDetector } from '../../helpers/comme
 import { DEFAULT_HOME_SECTION_LAYOUT } from '../../helpers/homeSections.js'
 import { isSettingSyncableOnPlatform } from '../../helpers/platformSettings.js'
 import { CUSTOM_THEMES_SYNC_KEY } from '../../../customTheme.js'
+import { DEFAULT_QUICK_SETTINGS, normalizeQuickSettings } from '../../helpers/quickSettings.js'
 
 const CHANNEL_SETTINGS_SYNC_MIGRATION_SETTING = 'channelSettingsSyncMigration'
 const TUTORIAL_STATE_SETTING_IDS = new Set([
@@ -365,6 +366,7 @@ const state = {
   fixedTabWidth: DEFAULT_FIXED_TAB_WIDTH,
   listType: 'grid',
   playlistViewType: 'grid',
+  quickSettings: [...DEFAULT_QUICK_SETTINGS],
   maxVideoPlaybackRate: 3,
   onlyShowLatestFromChannel: false,
   onlyShowLatestFromChannelNumber: 1,
@@ -837,6 +839,8 @@ const customState = {
 }
 
 const customGetters = {
+  getQuickSettings: (state) => normalizeQuickSettings(state.quickSettings),
+
   getLandingPage: (state) => resolveLandingPage(state.landingPage, state.hideHome),
 
   getPlaylistBookmarks: (state) => {
@@ -916,6 +920,13 @@ const customActions = {
   recordSyncSettingEdit: ({ commit, state }, settingId) => (
     recordSettingSyncTimestamp(commit, state, settingId)
   ),
+  updateQuickSettings: ({ commit, state }, value) => updateValidatedSetting(
+    commit,
+    state,
+    'quickSettings',
+    normalizeQuickSettings(value)
+  ),
+
   savePlaylistBookmark: async ({ commit, getters }, bookmark) => {
     const bookmarks = getters.getPlaylistBookmarks
       .filter(entry => entry?.playlist?.id !== bookmark.playlist.id)

--- a/src/renderer/views/Settings/Settings.vue
+++ b/src/renderer/views/Settings/Settings.vue
@@ -1307,7 +1307,7 @@ function restoreSettingsWindow() {
 }
 
 function handleSettingsEscape(event) {
-  if (event.target.closest('[aria-expanded="true"]')) return
+  if (event.target.closest('[aria-expanded="true"], [data-settings-escape-scope]')) return
   event.stopPropagation()
   closeSettings()
 }

--- a/static/locales/ai/ar.yaml
+++ b/static/locales/ai/ar.yaml
@@ -178,6 +178,8 @@ History:
 Settings:
   Quick Settings:
     Quick Settings: إعدادات سريعة
+    Customize Quick Settings: تخصيص الإعدادات السريعة
+    Add Setting: إضافة إعداد
     Appearance: مظهر
     Playback: التشغيل
     Content: محتوى

--- a/static/locales/ai/be.yaml
+++ b/static/locales/ai/be.yaml
@@ -190,6 +190,8 @@ History:
 Settings:
   Quick Settings:
     Quick Settings: Хуткія налады
+    Customize Quick Settings: Наладзіць хуткія налады
+    Add Setting: Дадаць наладу
     Appearance: Выгляд
     Playback: Прайграванне
     Content: Змесціва

--- a/static/locales/ai/bg.yaml
+++ b/static/locales/ai/bg.yaml
@@ -176,6 +176,8 @@ History:
 Settings:
   Quick Settings:
     Quick Settings: Бързи настройки
+    Customize Quick Settings: Персонализиране на бързите настройки
+    Add Setting: Добавяне на настройка
     Appearance: Външен вид
     Playback: Възпроизвеждане
     Content: Съдържание

--- a/static/locales/ai/br.yaml
+++ b/static/locales/ai/br.yaml
@@ -174,6 +174,8 @@ History:
 Settings:
   Quick Settings:
     Quick Settings: "Arventennoù prim"
+    Customize Quick Settings: Personelaat an arventennoù prim
+    Add Setting: Ouzhpennañ un arventenn
     Appearance: "Neuz"
     Playback: "Lenn"
     Content: "Endalc'had"

--- a/static/locales/ai/ca.yaml
+++ b/static/locales/ai/ca.yaml
@@ -300,6 +300,8 @@ History:
 Settings:
   Quick Settings:
     Quick Settings: Configuració ràpida
+    Customize Quick Settings: Personalitza la configuració ràpida
+    Add Setting: Afegeix una opció
     Appearance: Aparança
     Playback: Reproducció
     Content: Contingut

--- a/static/locales/ai/cs.yaml
+++ b/static/locales/ai/cs.yaml
@@ -174,6 +174,8 @@ History:
 Settings:
   Quick Settings:
     Quick Settings: Rychlé nastavení
+    Customize Quick Settings: Přizpůsobit rychlé nastavení
+    Add Setting: Přidat nastavení
     Appearance: Vzhled
     Playback: Přehrávání
     Content: Obsah

--- a/static/locales/ai/cy.yaml
+++ b/static/locales/ai/cy.yaml
@@ -176,6 +176,8 @@ History:
 Settings:
   Quick Settings:
     Quick Settings: Gosodiadau cyflym
+    Customize Quick Settings: Addasu gosodiadau cyflym
+    Add Setting: Ychwanegu gosodiad
     Appearance: Golwg
     Playback: Chwarae
     Content: Cynnwys

--- a/static/locales/ai/da.yaml
+++ b/static/locales/ai/da.yaml
@@ -185,6 +185,8 @@ History:
 Settings:
   Quick Settings:
     Quick Settings: Hurtigindstillinger
+    Customize Quick Settings: Tilpas hurtigindstillinger
+    Add Setting: Tilføj indstilling
     Appearance: Udseende
     Playback: Afspilning
     Content: Indhold

--- a/static/locales/ai/el.yaml
+++ b/static/locales/ai/el.yaml
@@ -178,6 +178,8 @@ History:
 Settings:
   Quick Settings:
     Quick Settings: Γρήγορες ρυθμίσεις
+    Customize Quick Settings: Προσαρμογή γρήγορων ρυθμίσεων
+    Add Setting: Προσθήκη ρύθμισης
     Appearance: Εμφάνιση
     Playback: Αναπαραγωγή
     Content: Περιεχόμενο

--- a/static/locales/ai/en-GB.yaml
+++ b/static/locales/ai/en-GB.yaml
@@ -175,6 +175,8 @@ History:
 Settings:
   Quick Settings:
     Quick Settings: Quick settings
+    Customize Quick Settings: Customise quick settings
+    Add Setting: Add setting
     Appearance: Appearance
     Playback: Playback
     Content: Content

--- a/static/locales/ai/es-AR.yaml
+++ b/static/locales/ai/es-AR.yaml
@@ -194,6 +194,8 @@ History:
 Settings:
   Quick Settings:
     Quick Settings: Ajustes rápidos
+    Customize Quick Settings: Personalizar ajustes rápidos
+    Add Setting: Agregar ajuste
     Appearance: Apariencia
     Playback: Reproducción
     Content: Contenido

--- a/static/locales/ai/es-MX.yaml
+++ b/static/locales/ai/es-MX.yaml
@@ -202,6 +202,8 @@ History:
 Settings:
   Quick Settings:
     Quick Settings: Ajustes rápidos
+    Customize Quick Settings: Personalizar ajustes rápidos
+    Add Setting: Agregar ajuste
     Appearance: Apariencia
     Playback: Reproducción
     Content: Contenido

--- a/static/locales/ai/es.yaml
+++ b/static/locales/ai/es.yaml
@@ -176,6 +176,8 @@ History:
 Settings:
   Quick Settings:
     Quick Settings: Ajustes rápidos
+    Customize Quick Settings: Personalizar ajustes rápidos
+    Add Setting: Añadir ajuste
     Appearance: Apariencia
     Playback: Reproducción
     Content: Contenido

--- a/static/locales/ai/et.yaml
+++ b/static/locales/ai/et.yaml
@@ -174,6 +174,8 @@ History:
 Settings:
   Quick Settings:
     Quick Settings: Kiirseaded
+    Customize Quick Settings: Kiirseadete kohandamine
+    Add Setting: Lisa säte
     Appearance: Välimus
     Playback: Esitus
     Content: Sisu

--- a/static/locales/ai/eu.yaml
+++ b/static/locales/ai/eu.yaml
@@ -176,6 +176,8 @@ History:
 Settings:
   Quick Settings:
     Quick Settings: Ezarpen azkarrak
+    Customize Quick Settings: Pertsonalizatu ezarpen azkarrak
+    Add Setting: Gehitu ezarpena
     Appearance: Itxura
     Playback: Erreprodukzioa
     Content: Edukia

--- a/static/locales/ai/fa.yaml
+++ b/static/locales/ai/fa.yaml
@@ -191,6 +191,8 @@ History:
 Settings:
   Quick Settings:
     Quick Settings: تنظیمات سریع
+    Customize Quick Settings: سفارشی‌سازی تنظیمات سریع
+    Add Setting: افزودن تنظیم
     Appearance: ظاهر
     Playback: پخش
     Content: محتوا

--- a/static/locales/ai/fi.yaml
+++ b/static/locales/ai/fi.yaml
@@ -178,6 +178,8 @@ History:
 Settings:
   Quick Settings:
     Quick Settings: Pika-asetukset
+    Customize Quick Settings: Mukauta pika-asetuksia
+    Add Setting: Lisää asetus
     Appearance: Ulkoasu
     Playback: Toisto
     Content: Sisältö

--- a/static/locales/ai/fr-FR.yaml
+++ b/static/locales/ai/fr-FR.yaml
@@ -174,6 +174,8 @@ History:
 Settings:
   Quick Settings:
     Quick Settings: Paramètres rapides
+    Customize Quick Settings: Personnaliser les paramètres rapides
+    Add Setting: Ajouter un paramètre
     Appearance: Apparence
     Playback: Lecture
     Content: Contenu

--- a/static/locales/ai/gl.yaml
+++ b/static/locales/ai/gl.yaml
@@ -178,6 +178,8 @@ History:
 Settings:
   Quick Settings:
     Quick Settings: Configuración rápida
+    Customize Quick Settings: Personalizar a configuración rápida
+    Add Setting: Engadir axuste
     Appearance: Aparencia
     Playback: Reprodución
     Content: Contido

--- a/static/locales/ai/he.yaml
+++ b/static/locales/ai/he.yaml
@@ -178,6 +178,8 @@ History:
 Settings:
   Quick Settings:
     Quick Settings: הגדרות מהירות
+    Customize Quick Settings: התאמה אישית של ההגדרות המהירות
+    Add Setting: הוספת הגדרה
     Appearance: מראה
     Playback: הפעלה
     Content: תוכן

--- a/static/locales/ai/hr.yaml
+++ b/static/locales/ai/hr.yaml
@@ -176,6 +176,8 @@ History:
 Settings:
   Quick Settings:
     Quick Settings: Brze postavke
+    Customize Quick Settings: Prilagodi brze postavke
+    Add Setting: Dodaj postavku
     Appearance: Izgled
     Playback: Reprodukcija
     Content: Sadržaj

--- a/static/locales/ai/hu.yaml
+++ b/static/locales/ai/hu.yaml
@@ -174,6 +174,8 @@ History:
 Settings:
   Quick Settings:
     Quick Settings: Gyorsbeállítások
+    Customize Quick Settings: Gyorsbeállítások testreszabása
+    Add Setting: Beállítás hozzáadása
     Appearance: Megjelenés
     Playback: Lejátszás
     Content: Tartalom

--- a/static/locales/ai/id.yaml
+++ b/static/locales/ai/id.yaml
@@ -178,6 +178,8 @@ History:
 Settings:
   Quick Settings:
     Quick Settings: Pengaturan cepat
+    Customize Quick Settings: Sesuaikan pengaturan cepat
+    Add Setting: Tambahkan pengaturan
     Appearance: Tampilan
     Playback: Pemutaran
     Content: Konten

--- a/static/locales/ai/is.yaml
+++ b/static/locales/ai/is.yaml
@@ -178,6 +178,8 @@ History:
 Settings:
   Quick Settings:
     Quick Settings: Flýtistillingar
+    Customize Quick Settings: Sérsníða flýtistillingar
+    Add Setting: Bæta við stillingu
     Appearance: Útlit
     Playback: Spilun
     Content: Efni

--- a/static/locales/ai/it.yaml
+++ b/static/locales/ai/it.yaml
@@ -174,6 +174,8 @@ History:
 Settings:
   Quick Settings:
     Quick Settings: Impostazioni rapide
+    Customize Quick Settings: Personalizza impostazioni rapide
+    Add Setting: Aggiungi impostazione
     Appearance: Aspetto
     Playback: Riproduzione
     Content: Contenuti

--- a/static/locales/ai/ja.yaml
+++ b/static/locales/ai/ja.yaml
@@ -174,6 +174,8 @@ History:
 Settings:
   Quick Settings:
     Quick Settings: クイック設定
+    Customize Quick Settings: クイック設定をカスタマイズ
+    Add Setting: 設定を追加
     Appearance: 外観
     Playback: 再生
     Content: コンテンツ

--- a/static/locales/ai/ko.yaml
+++ b/static/locales/ai/ko.yaml
@@ -261,6 +261,8 @@ History:
 Settings:
   Quick Settings:
     Quick Settings: 빠른 설정
+    Customize Quick Settings: 빠른 설정 맞춤설정
+    Add Setting: 설정 추가
     Appearance: 모양
     Playback: 재생
     Content: 콘텐츠

--- a/static/locales/ai/lt.yaml
+++ b/static/locales/ai/lt.yaml
@@ -286,6 +286,8 @@ History:
 Settings:
   Quick Settings:
     Quick Settings: Spartieji nustatymai
+    Customize Quick Settings: Tinkinti sparčiuosius nustatymus
+    Add Setting: Pridėti nustatymą
     Appearance: Išvaizda
     Playback: Atkūrimas
     Content: Turinys

--- a/static/locales/ai/nb-NO.yaml
+++ b/static/locales/ai/nb-NO.yaml
@@ -176,6 +176,8 @@ History:
 Settings:
   Quick Settings:
     Quick Settings: Hurtiginnstillinger
+    Customize Quick Settings: Tilpass hurtiginnstillinger
+    Add Setting: Legg til innstilling
     Appearance: Utseende
     Playback: Avspilling
     Content: Innhold

--- a/static/locales/ai/nl.yaml
+++ b/static/locales/ai/nl.yaml
@@ -178,6 +178,8 @@ History:
 Settings:
   Quick Settings:
     Quick Settings: Snelle instellingen
+    Customize Quick Settings: Snelle instellingen aanpassen
+    Add Setting: Instelling toevoegen
     Appearance: Uiterlijk
     Playback: Afspelen
     Content: Content

--- a/static/locales/ai/nn.yaml
+++ b/static/locales/ai/nn.yaml
@@ -298,6 +298,8 @@ History:
 Settings:
   Quick Settings:
     Quick Settings: Snøgginnstillingar
+    Customize Quick Settings: Tilpass snøgginnstillingar
+    Add Setting: Legg til innstilling
     Appearance: Utsjånad
     Playback: Avspeling
     Content: Innhald

--- a/static/locales/ai/pl.yaml
+++ b/static/locales/ai/pl.yaml
@@ -50,6 +50,9 @@ User Playlists:
     This playlist could not be loaded.: Nie udało się wczytać tej playlisty.
     More videos could not be loaded.: Nie udało się wczytać kolejnych filmów.
 Settings:
+  Quick Settings:
+    Customize Quick Settings: Dostosuj szybkie ustawienia
+    Add Setting: Dodaj ustawienie
   Categories:
     General Description: Język, uruchamianie, karty i działanie aplikacji
     Appearance: Wygląd

--- a/static/locales/ai/pt-BR.yaml
+++ b/static/locales/ai/pt-BR.yaml
@@ -174,6 +174,8 @@ History:
 Settings:
   Quick Settings:
     Quick Settings: Configurações rápidas
+    Customize Quick Settings: Personalizar configurações rápidas
+    Add Setting: Adicionar configuração
     Appearance: Aparência
     Playback: Reprodução
     Content: Conteúdo

--- a/static/locales/ai/pt-PT.yaml
+++ b/static/locales/ai/pt-PT.yaml
@@ -178,6 +178,8 @@ History:
 Settings:
   Quick Settings:
     Quick Settings: Definições rápidas
+    Customize Quick Settings: Personalizar definições rápidas
+    Add Setting: Adicionar definição
     Appearance: Aspeto
     Playback: Reprodução
     Content: Conteúdo

--- a/static/locales/ai/pt.yaml
+++ b/static/locales/ai/pt.yaml
@@ -178,6 +178,8 @@ History:
 Settings:
   Quick Settings:
     Quick Settings: Definições rápidas
+    Customize Quick Settings: Personalizar definições rápidas
+    Add Setting: Adicionar definição
     Appearance: Aspeto
     Playback: Reprodução
     Content: Conteúdo

--- a/static/locales/ai/ro.yaml
+++ b/static/locales/ai/ro.yaml
@@ -176,6 +176,8 @@ History:
 Settings:
   Quick Settings:
     Quick Settings: Setări rapide
+    Customize Quick Settings: Personalizează setările rapide
+    Add Setting: Adaugă o setare
     Appearance: Aspect
     Playback: Redare
     Content: Conținut

--- a/static/locales/ai/ru.yaml
+++ b/static/locales/ai/ru.yaml
@@ -153,6 +153,8 @@ History:
 Settings:
   Quick Settings:
     Quick Settings: Быстрые настройки
+    Customize Quick Settings: Настроить быстрые настройки
+    Add Setting: Добавить настройку
     Appearance: Внешний вид
     Playback: Воспроизведение
     Content: Содержимое

--- a/static/locales/ai/sk.yaml
+++ b/static/locales/ai/sk.yaml
@@ -174,6 +174,8 @@ History:
 Settings:
   Quick Settings:
     Quick Settings: Rýchle nastavenia
+    Customize Quick Settings: Prispôsobiť rýchle nastavenia
+    Add Setting: Pridať nastavenie
     Appearance: Vzhľad
     Playback: Prehrávanie
     Content: Obsah

--- a/static/locales/ai/sl.yaml
+++ b/static/locales/ai/sl.yaml
@@ -293,6 +293,8 @@ History:
 Settings:
   Quick Settings:
     Quick Settings: Hitre nastavitve
+    Customize Quick Settings: Prilagodi hitre nastavitve
+    Add Setting: Dodaj nastavitev
     Appearance: Videz
     Playback: Predvajanje
     Content: Vsebina

--- a/static/locales/ai/sr.yaml
+++ b/static/locales/ai/sr.yaml
@@ -184,6 +184,8 @@ History:
 Settings:
   Quick Settings:
     Quick Settings: Брза подешавања
+    Customize Quick Settings: Прилагоди брза подешавања
+    Add Setting: Додај подешавање
     Appearance: Изглед
     Playback: Репродукција
     Content: Садржај

--- a/static/locales/ai/sv.yaml
+++ b/static/locales/ai/sv.yaml
@@ -176,6 +176,8 @@ History:
 Settings:
   Quick Settings:
     Quick Settings: Snabbinställningar
+    Customize Quick Settings: Anpassa snabbinställningar
+    Add Setting: Lägg till inställning
     Appearance: Utseende
     Playback: Uppspelning
     Content: Innehåll

--- a/static/locales/ai/ta.yaml
+++ b/static/locales/ai/ta.yaml
@@ -179,6 +179,8 @@ History:
 Settings:
   Quick Settings:
     Quick Settings: விரைவு அமைப்புகள்
+    Customize Quick Settings: விரைவு அமைப்புகளைத் தனிப்பயனாக்கு
+    Add Setting: அமைப்பைச் சேர்
     Appearance: தோற்றம்
     Playback: இயக்கம்
     Content: உள்ளடக்கம்

--- a/static/locales/ai/tr.yaml
+++ b/static/locales/ai/tr.yaml
@@ -174,6 +174,8 @@ History:
 Settings:
   Quick Settings:
     Quick Settings: Hızlı ayarlar
+    Customize Quick Settings: Hızlı ayarları özelleştir
+    Add Setting: Ayar ekle
     Appearance: Görünüm
     Playback: Oynatma
     Content: İçerik

--- a/static/locales/ai/uk.yaml
+++ b/static/locales/ai/uk.yaml
@@ -178,6 +178,8 @@ History:
 Settings:
   Quick Settings:
     Quick Settings: Швидкі налаштування
+    Customize Quick Settings: Налаштувати швидкі налаштування
+    Add Setting: Додати налаштування
     Appearance: Вигляд
     Playback: Відтворення
     Content: Вміст

--- a/static/locales/ai/vi.yaml
+++ b/static/locales/ai/vi.yaml
@@ -178,6 +178,8 @@ History:
 Settings:
   Quick Settings:
     Quick Settings: Cài đặt nhanh
+    Customize Quick Settings: Tùy chỉnh cài đặt nhanh
+    Add Setting: Thêm cài đặt
     Appearance: Giao diện
     Playback: Phát
     Content: Nội dung

--- a/static/locales/ai/zh-CN.yaml
+++ b/static/locales/ai/zh-CN.yaml
@@ -174,6 +174,8 @@ History:
 Settings:
   Quick Settings:
     Quick Settings: 快速设置
+    Customize Quick Settings: 自定义快速设置
+    Add Setting: 添加设置
     Appearance: 外观
     Playback: 播放
     Content: 内容

--- a/static/locales/ai/zh-TW.yaml
+++ b/static/locales/ai/zh-TW.yaml
@@ -176,6 +176,8 @@ History:
 Settings:
   Quick Settings:
     Quick Settings: 快速設定
+    Customize Quick Settings: 自訂快速設定
+    Add Setting: 新增設定
     Appearance: 外觀
     Playback: 播放
     Content: 內容

--- a/static/locales/de-DE.yaml
+++ b/static/locales/de-DE.yaml
@@ -1277,6 +1277,8 @@ Settings:
     Return YouTube Dislike Url: Return YouTube Dislike API URL (Standard ist https://ryd-proxy.kavin.rocks)
   Quick Settings:
     Quick Settings: Schnelleinstellungen
+    Customize Quick Settings: Schnelleinstellungen anpassen
+    Add Setting: Einstellung hinzufügen
     Appearance: Erscheinungsbild
     Playback: Wiedergabe
     Content: Inhalte

--- a/static/locales/en-US.yaml
+++ b/static/locales/en-US.yaml
@@ -433,6 +433,8 @@ Settings:
   Settings: Settings
   Quick Settings:
     Quick Settings: Quick settings
+    Customize Quick Settings: Customize quick settings
+    Add Setting: Add setting
     Appearance: Appearance
     Playback: Playback
     Content: Content

--- a/tests/unit/quick-settings.test.mjs
+++ b/tests/unit/quick-settings.test.mjs
@@ -1,0 +1,81 @@
+import assert from 'node:assert/strict'
+import test from 'node:test'
+
+import {
+  DEFAULT_QUICK_SETTINGS,
+  isQuickSettingPaired,
+  moveQuickSettingByVisibleOffset,
+  normalizeQuickSettings,
+  QUICK_SETTING_DEFINITIONS,
+} from '../../src/renderer/helpers/quickSettings.js'
+
+test('keeps the original quick settings as defaults', () => {
+  assert.deepEqual(DEFAULT_QUICK_SETTINGS, [
+    'baseTheme',
+    'mainColor',
+    'uiScale',
+    'thumbnailSize',
+    'defaultQuality',
+    'playNextVideo',
+    'enableSubtitlesByDefault',
+    'listType',
+    'playlistViewType',
+    'hideRecommendedVideos',
+    'hideComments',
+    'currentLocale',
+    'region',
+  ])
+})
+
+test('gives every customizable setting an icon', () => {
+  for (const setting of QUICK_SETTING_DEFINITIONS) {
+    assert.equal(Array.isArray(setting.icon) && setting.icon.length, 2, setting.id)
+  }
+})
+
+test('pairs adjacent selects without leaving an odd select in a half-row', () => {
+  const select = { control: 'select' }
+  const toggle = { control: 'toggle' }
+
+  assert.deepEqual(
+    [select, select, toggle, select, select, select].map((_, index, settings) => (
+      isQuickSettingPaired(settings, index)
+    )),
+    [true, true, false, true, true, false]
+  )
+})
+
+test('moves between visible settings without dropping hidden platform settings', () => {
+  assert.deepEqual(
+    moveQuickSettingByVisibleOffset(
+      ['baseTheme', 'mainColor', 'uiScale', 'thumbnailSize'],
+      ['baseTheme', 'mainColor', 'thumbnailSize'],
+      'mainColor',
+      1
+    ),
+    ['baseTheme', 'uiScale', 'thumbnailSize', 'mainColor']
+  )
+})
+
+test('keeps valid quick settings in the selected order', () => {
+  assert.deepEqual(
+    normalizeQuickSettings(['useProxy', 'baseTheme', 'hideComments']),
+    ['useProxy', 'baseTheme', 'hideComments']
+  )
+})
+
+test('removes unknown setting identifiers and duplicates', () => {
+  assert.deepEqual(
+    normalizeQuickSettings(['useProxy', 'removedSetting', 'useProxy']),
+    ['useProxy']
+  )
+})
+
+test('removes values that cannot identify a setting', () => {
+  assert.deepEqual(normalizeQuickSettings(['baseTheme', '', null, 4]), ['baseTheme'])
+})
+
+test('falls back to defaults only when the stored value is invalid', () => {
+  assert.deepEqual(normalizeQuickSettings(null), DEFAULT_QUICK_SETTINGS)
+  assert.deepEqual(normalizeQuickSettings([]), [])
+})


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Make sure to follow the contributing guidelines. -->
<!-- Important note, we may remove your pull request if you do not use this provided PR template correctly. -->
<!-- Agent instructions: Preserve every heading, comment, and marker in this template. Never remove or rewrite the release-note-category:start/end, release-note:start/end, or release-note-image:start/end marker pairs. -->

## Pull Request Type
<!-- Please select what type of pull request this is: [x] -->
- [ ] Bugfix
- [x] Feature Implementation
- [ ] Documentation
- [ ] Other

## Related issue
<!-- Please link the issue your pull request is referring to. -->
<!-- If this pull request fully resolves the relevant issue, put "closes" before the issue number. -->
<!-- Example: "closes #123456". -->

Closes #1046

## Description
<!-- Please write a clear and concise description of what the pull request does. -->

Quick Settings previously had a fixed set of controls, while useful settings such as the configured proxy required opening the full settings window.

This adds a customization subpage under Appearance. Users can search for basic top-level settings, add or remove them, rearrange them with drag and drop or accessible move buttons, and restore the original defaults. Quick Settings now renders the chosen order, groups adjacent selects into responsive two-column rows, and applies proxy changes immediately. The searchable picker uses the app's input and overlay scrollbar behavior.

## Release note category
<!-- Select exactly one category. Every pull request must select one. -->
<!-- Select "Not noteworthy" when the pull request fixes a bug in or improves functionality that has not yet appeared in a stable release. -->
<!-- release-note-category:start -->
- [ ] Not noteworthy
- [ ] Highlights
- [x] More improvements
- [ ] Fixed bugs
<!-- release-note-category:end -->

## Release note
<!-- Required unless "Not noteworthy" is selected. -->
<!-- Write one concise, user-facing entry without a leading bullet. -->
<!-- release-note:start -->
Customize which basic controls appear in Quick Settings from the Appearance settings.
<!-- release-note:end -->

## Release note images
<!-- Optional. Paste one or more Markdown images, HTML image tags, or dark/light <picture> elements here. -->
<!-- The release notes normalize the markup and limit images taller than 300 pixels. -->
<!-- Agent instructions:
For a noteworthy visible change, add media when it makes the change easier to understand. Prefer a still image unless motion is the point; recordings must use animated WebP.
After implementing a visible change, proactively capture the result and show the local media to the user for approval before uploading it or updating the pull request.
When the affected UI differs between dark and light themes, capturing both themes is required. A dark-only image is incomplete. Run `node _scripts/releaseNoteMedia.mjs --dark DARK_FILE --light LIGHT_FILE --alt "DESCRIPTION"`; GitHub will display the matching theme and use dark as the fallback. Use a single default-dark capture only when the light theme cannot be captured or looks identical.
Capture or crop to the smallest region that still makes the change clear. Do not include the full window when the affected component can be understood on its own.
Use English unless localization is the subject. Keep components at their normal dimensions and placement instead of resizing them to fill the frame.
Use deterministic local fixtures for visible remote images. Reusable avatar and thumbnail fixtures are available through `e2e/helpers/visual-fixtures.mjs`. Before capturing, verify that every visible image has loaded successfully (`complete === true` and `naturalWidth > 0`).
Inspect the final dark and light files for failed images, missing content, unrelated UI, awkward animation, and misleading layout. Omit media when it does not explain the change clearly.
For one dark capture, run `node _scripts/releaseNoteMedia.mjs FILE --alt "DESCRIPTION"`.
Check for personal information, tokens, private repository names, and unrelated desktop content before uploading. Uploaded media is public.
Keep capture-only scripts, test hooks, screenshots, and recordings out of commits. Remove them before committing unless the capture code is also a reusable regression test. Never commit generated release-note media.
Paste only the generated markup between the marker comments. Leave this section empty when media would not help.
-->
<!-- release-note-image:start -->
<picture>
  <source media="(prefers-color-scheme: dark)" srcset="https://github.com/OpenTubeX/media/releases/download/attachments/20260907T114449Z-quick-customization-dark-dark-90cdbcaee5.png">
  <source media="(prefers-color-scheme: light)" srcset="https://github.com/OpenTubeX/media/releases/download/attachments/20260907T114449Z-quick-customization-light-light-086ae9337d.png">
  <img alt="Quick Settings customization with selected controls and reorder buttons" src="https://github.com/OpenTubeX/media/releases/download/attachments/20260907T114449Z-quick-customization-dark-dark-90cdbcaee5.png">
</picture>
<!-- release-note-image:end -->

## Testing
<!-- How can reviewers verify that the PR produces correct results? -->
<!-- Please provide instructions so that others can ensure that your pull request produces correct results. For examples see, https://github.com/FreeTubeApp/FreeTube/pull/5743, https://github.com/FreeTubeApp/FreeTube/pull/7349, https://github.com/FreeTubeApp/FreeTube/pull/5125, https://github.com/FreeTubeApp/FreeTube/pull/7338 -->
<!-- Agent instructions: Only write human-facing steps that explain how to verify the change while running this branch in dev mode. Include expected results and, when applicable, helpful console snippets for interactive verification. Do not include automated checks, commands, results, pass counts, or CI status. -->

1. Open Settings, go to Appearance, and open Customize Quick Settings. The launcher and subpage content should be centered.
2. Remove a default setting, add basic controls through the searchable Add Setting popover, and rearrange controls with both the move buttons and drag and drop.
3. Open Quick Settings and confirm the selected controls and order are preserved. Adjacent selects should share a row on wider windows and stack on narrow windows.
4. Toggle the proxy control after adding it and confirm the configured proxy is enabled or disabled immediately.
5. Reopen the customization subpage and reset it. The original Quick Settings should be restored.

## Additional context
<!-- Add any other context about the pull request here. -->

The custom list is normalized against the supported basic-control catalog, so removed or unknown setting identifiers are discarded.
