### PR TITLE
feat(settings): batch-edit subscriptions and add saved channels

### DIFF
--- a/e2e/helpers/app.mjs
+++ b/e2e/helpers/app.mjs
@@ -40,6 +40,23 @@ export function latestSettings(contents) {
     .map(record => [record._id, record.value]))
 }
 
+export async function updateInputWithoutScrolling(input, value) {
+  await input.evaluate((element, nextValue) => {
+    element.value = nextValue
+    element.dispatchEvent(new Event('input', { bubbles: true }))
+  }, value)
+}
+
+export async function expectScrollAtRenderedEnd(scroller) {
+  await expect.poll(() => scroller.evaluate((element) => {
+    const content = element.querySelector(':scope > div')
+    const contentEnd = content.offsetTop + content.offsetHeight +
+      Number.parseFloat(getComputedStyle(element).paddingBottom)
+    const maximumScrollTop = Math.max(0, contentEnd - element.clientHeight)
+    return Math.abs(element.scrollTop - maximumScrollTop)
+  })).toBeLessThanOrEqual(1)
+}
+
 /**
  * Creates an isolated userData directory, optionally seeded with
  * settings and datastore documents.

--- a/e2e/tests/network/channel.spec.mjs
+++ b/e2e/tests/network/channel.spec.mjs
@@ -73,7 +73,8 @@ test.describe('channel page', () => {
     expect(Math.abs(externalPlayerBounds.y - downloadBounds.y)).toBeLessThanOrEqual(2)
     expect(externalPlayerBounds.x + externalPlayerBounds.width).toBeLessThanOrEqual(downloadBounds.x)
 
-    await page.locator('.channelSearch .clearInputTextButton').click()
+    await expect(page.locator('.channelSearch input')).toHaveAttribute('type', 'search')
+    await page.locator('.channelSearch input').fill('')
     await expect(page).not.toHaveURL(/searchQueryText=/)
     await expect(page.locator(sel.activeTab)).toContainText('Blender')
 

--- a/e2e/tests/offline/channel-settings.spec.mjs
+++ b/e2e/tests/offline/channel-settings.spec.mjs
@@ -1,4 +1,9 @@
-import { test, expect, goToSettingsSection } from '../../helpers/app.mjs'
+import {
+  test,
+  expect,
+  goToSettingsSection,
+  updateInputWithoutScrolling
+} from '../../helpers/app.mjs'
 
 const CHANNEL_ID = 'UCaaaaaaaaaaaaaaaaaaaaaa'
 const CHANNEL_NAME = 'Alpha Channel'
@@ -11,13 +16,6 @@ const EXTRA_SUBSCRIPTIONS = Array.from({ length: 30 }, (_, index) => ({
   name: `Extra Channel ${index + 1}`,
   thumbnail: ''
 }))
-
-async function updateInputWithoutScrolling(input, value) {
-  await input.evaluate((element, nextValue) => {
-    element.value = nextValue
-    element.dispatchEvent(new Event('input', { bubbles: true }))
-  }, value)
-}
 
 test.use({
   seed: {
@@ -171,7 +169,7 @@ test.describe('channel settings', () => {
     await page.evaluate(() => {
       const store = document.querySelector('#app').__vue_app__.config.globalProperties.$store
       window.updateChannelVolumes = store._actions.updateChannelVolumes[0]
-      store._actions.updateChannelVolumes = [() => Promise.resolve()]
+      store._actions.updateChannelVolumes = [() => Promise.reject(new Error('write failed'))]
     })
 
     const picker = page.getByRole('dialog', { name: 'Add subscribed channel' })

--- a/e2e/tests/offline/channel-settings.spec.mjs
+++ b/e2e/tests/offline/channel-settings.spec.mjs
@@ -163,6 +163,43 @@ test.describe('channel settings', () => {
     await expect(reopenedPicker.getByRole('button', { name: OTHER_CHANNEL_NAME, exact: true })).toBeVisible()
   })
 
+  test('keeps the subscribed-channel picker open when initialization fails', async ({ page }) => {
+    await goToSettingsSection(page, 'playback')
+    await page.getByRole('button', { name: 'Manage Saved Channels (1)' }).click()
+    await page.getByRole('button', { name: 'Add subscribed channel' }).click()
+
+    await page.evaluate(() => {
+      const store = document.querySelector('#app').__vue_app__.config.globalProperties.$store
+      window.updateChannelVolumes = store._actions.updateChannelVolumes[0]
+      store._actions.updateChannelVolumes = [() => Promise.resolve()]
+    })
+
+    const picker = page.getByRole('dialog', { name: 'Add subscribed channel' })
+    const channel = picker.getByRole('button', { name: NEW_CHANNEL_NAME, exact: true })
+    await channel.click()
+
+    await expect(picker).toBeVisible()
+    await expect(page.locator('.toast', {
+      hasText: 'Failed to save channel settings'
+    })).toBeVisible()
+    await expect(channel).toBeEnabled()
+    await expect.poll(() => page.evaluate(channelId => {
+      const settings = document.querySelector('#app').__vue_app__.config.globalProperties.$store.state.settings
+      return {
+        playbackSpeed: JSON.parse(settings.channelPlaybackSpeeds)[channelId],
+        volume: JSON.parse(settings.channelVolumes)[channelId]
+      }
+    }, NEW_CHANNEL_ID)).toEqual({ playbackSpeed: undefined, volume: undefined })
+
+    await page.evaluate(() => {
+      const store = document.querySelector('#app').__vue_app__.config.globalProperties.$store
+      store._actions.updateChannelVolumes = [window.updateChannelVolumes]
+    })
+    await channel.click()
+
+    await expect(picker).toHaveCount(0)
+  })
+
   test('points to Playback settings when channel settings are disabled', async ({ page }) => {
     await page.evaluate(async () => {
       const store = document.querySelector('#app').__vue_app__.config.globalProperties.$store

--- a/e2e/tests/offline/channel-settings.spec.mjs
+++ b/e2e/tests/offline/channel-settings.spec.mjs
@@ -2,6 +2,22 @@ import { test, expect, goToSettingsSection } from '../../helpers/app.mjs'
 
 const CHANNEL_ID = 'UCaaaaaaaaaaaaaaaaaaaaaa'
 const CHANNEL_NAME = 'Alpha Channel'
+const NEW_CHANNEL_ID = 'UCbbbbbbbbbbbbbbbbbbbbbb'
+const NEW_CHANNEL_NAME = 'Beta Channel'
+const OTHER_CHANNEL_ID = 'UCcccccccccccccccccccccc'
+const OTHER_CHANNEL_NAME = 'Gamma Channel'
+const EXTRA_SUBSCRIPTIONS = Array.from({ length: 30 }, (_, index) => ({
+  id: `UC${String(index).padStart(22, '0')}`,
+  name: `Extra Channel ${index + 1}`,
+  thumbnail: ''
+}))
+
+async function updateInputWithoutScrolling(input, value) {
+  await input.evaluate((element, nextValue) => {
+    element.value = nextValue
+    element.dispatchEvent(new Event('input', { bubbles: true }))
+  }, value)
+}
 
 test.use({
   seed: {
@@ -9,6 +25,10 @@ test.use({
       channelPlaybackSpeeds: JSON.stringify({
         [CHANNEL_ID]: 1.5
       }),
+      defaultPlayback: 1.25,
+      defaultVolume: 0.4,
+      rememberPlaybackSpeedPerChannel: true,
+      rememberVolumePerChannel: true,
       syncServerSettingsExcluded: ['channelPlaybackSpeeds'],
       syncServerAutoSync: false,
       syncServerEnabled: true,
@@ -23,7 +43,10 @@ test.use({
         bgColor: '#000000',
         textColor: '#FFFFFF',
         subscriptions: [
-          { id: CHANNEL_ID, name: CHANNEL_NAME, thumbnail: '' }
+          { id: CHANNEL_ID, name: CHANNEL_NAME, thumbnail: '' },
+          { id: NEW_CHANNEL_ID, name: NEW_CHANNEL_NAME, thumbnail: '' },
+          { id: OTHER_CHANNEL_ID, name: OTHER_CHANNEL_NAME, thumbnail: '' },
+          ...EXTRA_SUBSCRIPTIONS
         ]
       }
     ]
@@ -90,6 +113,84 @@ test.describe('channel settings', () => {
     await expect(page).toHaveURL(new RegExp(`#/channel/${CHANNEL_ID}`))
     await expect(settingsWindow).toBeVisible()
     await expect(settingsWindow.locator('.settingsBreadcrumb')).toContainText('Saved Channel Settings')
+  })
+
+  test('adds subscriptions without saved channel settings', async ({ attachScreenshot, page }) => {
+    await goToSettingsSection(page, 'playback')
+    await page.getByRole('button', { name: 'Manage Saved Channels (1)' }).click()
+
+    const settingsWindow = page.locator('.settingsWindow')
+    const addChannel = settingsWindow.getByRole('button', { name: 'Add subscribed channel' })
+    await addChannel.click()
+
+    const picker = page.getByRole('dialog', { name: 'Add subscribed channel' })
+    const search = picker.getByPlaceholder('Search channels')
+    await expect(search).toBeVisible()
+    await expect(search).toBeFocused()
+    await expect(search).toHaveAttribute('type', 'search')
+    await expect(picker.getByRole('button', { name: 'Clear Input' })).toHaveCount(0)
+    const scroller = picker.locator('.promptContentScroller')
+    const scrollbar = scroller.locator(':scope > .os-scrollbar-vertical')
+    await expect(scroller).toHaveAttribute('data-overlayscrollbars-viewport')
+    await scroller.evaluate(element => { element.scrollTop = element.scrollHeight })
+    await expect.poll(() => scroller.evaluate(element => element.scrollTop)).toBeGreaterThan(0)
+    await expect(scrollbar).not.toHaveClass(/os-scrollbar-unusable/)
+
+    await updateInputWithoutScrolling(search, NEW_CHANNEL_NAME)
+    await expect(picker.getByRole('button', { name: CHANNEL_NAME, exact: true })).toHaveCount(0)
+    await expect(picker.getByRole('button', { name: NEW_CHANNEL_NAME, exact: true })).toBeVisible()
+    await expect(picker.getByRole('button', { name: OTHER_CHANNEL_NAME, exact: true })).toHaveCount(0)
+    await expect.poll(() => scroller.evaluate(element => element.scrollTop)).toBe(0)
+    await expect(scrollbar).toHaveClass(/os-scrollbar-unusable/)
+    await attachScreenshot('add subscription to saved channel settings')
+
+    await picker.getByRole('button', { name: NEW_CHANNEL_NAME, exact: true }).click()
+    const newChannel = settingsWindow.locator('.channelEntry', { hasText: NEW_CHANNEL_NAME })
+    await expect(newChannel).toBeVisible()
+    await expect(newChannel.locator('.channelPreference')).toHaveCount(2)
+
+    await expect.poll(() => page.evaluate(channelId => {
+      const settings = document.querySelector('#app').__vue_app__.config.globalProperties.$store.state.settings
+      return {
+        playbackSpeed: JSON.parse(settings.channelPlaybackSpeeds)[channelId],
+        volume: JSON.parse(settings.channelVolumes)[channelId]
+      }
+    }, NEW_CHANNEL_ID)).toEqual({ playbackSpeed: 1.25, volume: 0.4 })
+
+    await addChannel.click()
+    const reopenedPicker = page.getByRole('dialog', { name: 'Add subscribed channel' })
+    await expect(reopenedPicker.getByRole('button', { name: NEW_CHANNEL_NAME, exact: true })).toHaveCount(0)
+    await expect(reopenedPicker.getByRole('button', { name: OTHER_CHANNEL_NAME, exact: true })).toBeVisible()
+  })
+
+  test('points to Playback settings when channel settings are disabled', async ({ page }) => {
+    await page.evaluate(async () => {
+      const store = document.querySelector('#app').__vue_app__.config.globalProperties.$store
+      await Promise.all([
+        store.dispatch('updateRememberPlaybackSpeedPerChannel', false),
+        store.dispatch('updateRememberVideoQualityPerChannel', false),
+        store.dispatch('updateRememberSubtitlesStatePerChannel', false),
+        store.dispatch('updateRememberVolumePerChannel', false)
+      ])
+    })
+
+    await goToSettingsSection(page, 'playback')
+    await page.getByRole('button', { name: 'Manage Saved Channels (1)' }).click()
+    await page.getByRole('button', { name: 'Add subscribed channel' }).click()
+
+    const picker = page.getByRole('dialog', { name: 'Add subscribed channel' })
+    const message = picker.getByText(
+      'Enable at least one channel setting in Playback settings before adding a channel'
+    )
+    await expect(message).toBeVisible()
+
+    const [pickerBox, messageBox] = await Promise.all([
+      picker.boundingBox(),
+      message.boundingBox()
+    ])
+    expect(Math.abs(
+      pickerBox.x + pickerBox.width / 2 - (messageBox.x + messageBox.width / 2)
+    )).toBeLessThanOrEqual(1)
   })
 
   test('saved channels are not links when channel links are disabled', async ({ page }) => {

--- a/e2e/tests/offline/channel-settings.spec.mjs
+++ b/e2e/tests/offline/channel-settings.spec.mjs
@@ -198,7 +198,7 @@ test.describe('channel settings', () => {
     await expect(picker).toHaveCount(0)
   })
 
-  test('preserves newer saved-channel edits when initialization rolls back', async ({ page }) => {
+  test('preserves newer edits when initialization rolls back', async ({ page }) => {
     await goToSettingsSection(page, 'playback')
     await page.getByRole('button', { name: 'Manage Saved Channels (1)' }).click()
     await page.getByRole('button', { name: 'Add subscribed channel' }).click()
@@ -217,13 +217,14 @@ test.describe('channel settings', () => {
     ))).toBe(true)
     await picker.getByRole('button', { name: 'Close' }).click()
 
-    await page.evaluate(async ({ channelId }) => {
+    await page.evaluate(async ({ channelId, newChannelId }) => {
       const store = document.querySelector('#app').__vue_app__.config.globalProperties.$store
       const playbackSpeeds = JSON.parse(store.state.settings.channelPlaybackSpeeds)
       playbackSpeeds[channelId] = 1.75
+      playbackSpeeds[newChannelId] = 1.5
       await store.dispatch('updateChannelPlaybackSpeeds', JSON.stringify(playbackSpeeds))
       window.rejectChannelVolumeUpdate(new Error('write failed'))
-    }, { channelId: CHANNEL_ID })
+    }, { channelId: CHANNEL_ID, newChannelId: NEW_CHANNEL_ID })
 
     await expect(page.locator('.toast', {
       hasText: 'Failed to save channel settings'
@@ -237,7 +238,7 @@ test.describe('channel settings', () => {
       }
     }, { channelId: CHANNEL_ID, newChannelId: NEW_CHANNEL_ID })).toEqual({
       existingChannel: 1.75,
-      newChannel: undefined
+      newChannel: 1.5
     })
   })
 

--- a/e2e/tests/offline/channel-settings.spec.mjs
+++ b/e2e/tests/offline/channel-settings.spec.mjs
@@ -198,6 +198,49 @@ test.describe('channel settings', () => {
     await expect(picker).toHaveCount(0)
   })
 
+  test('preserves newer saved-channel edits when initialization rolls back', async ({ page }) => {
+    await goToSettingsSection(page, 'playback')
+    await page.getByRole('button', { name: 'Manage Saved Channels (1)' }).click()
+    await page.getByRole('button', { name: 'Add subscribed channel' }).click()
+
+    await page.evaluate(() => {
+      const store = document.querySelector('#app').__vue_app__.config.globalProperties.$store
+      store._actions.updateChannelVolumes = [() => new Promise((_resolve, reject) => {
+        window.rejectChannelVolumeUpdate = reject
+      })]
+    })
+
+    const picker = page.getByRole('dialog', { name: 'Add subscribed channel' })
+    await picker.getByRole('button', { name: NEW_CHANNEL_NAME, exact: true }).click()
+    await expect.poll(() => page.evaluate(() => (
+      typeof window.rejectChannelVolumeUpdate === 'function'
+    ))).toBe(true)
+    await picker.getByRole('button', { name: 'Close' }).click()
+
+    await page.evaluate(async ({ channelId }) => {
+      const store = document.querySelector('#app').__vue_app__.config.globalProperties.$store
+      const playbackSpeeds = JSON.parse(store.state.settings.channelPlaybackSpeeds)
+      playbackSpeeds[channelId] = 1.75
+      await store.dispatch('updateChannelPlaybackSpeeds', JSON.stringify(playbackSpeeds))
+      window.rejectChannelVolumeUpdate(new Error('write failed'))
+    }, { channelId: CHANNEL_ID })
+
+    await expect(page.locator('.toast', {
+      hasText: 'Failed to save channel settings'
+    })).toBeVisible()
+    await expect.poll(() => page.evaluate(({ channelId, newChannelId }) => {
+      const settings = document.querySelector('#app').__vue_app__.config.globalProperties.$store.state.settings
+      const playbackSpeeds = JSON.parse(settings.channelPlaybackSpeeds)
+      return {
+        existingChannel: playbackSpeeds[channelId],
+        newChannel: playbackSpeeds[newChannelId]
+      }
+    }, { channelId: CHANNEL_ID, newChannelId: NEW_CHANNEL_ID })).toEqual({
+      existingChannel: 1.75,
+      newChannel: undefined
+    })
+  })
+
   test('points to Playback settings when channel settings are disabled', async ({ page }) => {
     await page.evaluate(async () => {
       const store = document.querySelector('#app').__vue_app__.config.globalProperties.$store

--- a/e2e/tests/offline/channel-settings.spec.mjs
+++ b/e2e/tests/offline/channel-settings.spec.mjs
@@ -217,14 +217,26 @@ test.describe('channel settings', () => {
     ))).toBe(true)
     await picker.getByRole('button', { name: 'Close' }).click()
 
-    await page.evaluate(async ({ channelId, newChannelId }) => {
+    const newChannel = page.locator('.settingsWindow .channelEntry', { hasText: NEW_CHANNEL_NAME })
+    const playbackSpeed = newChannel.getByRole('slider', { name: /Playback Speed/ })
+    await playbackSpeed.fill('1.5')
+    await expect.poll(() => page.evaluate(channelId => {
+      const settings = document.querySelector('#app').__vue_app__.config.globalProperties.$store.state.settings
+      return JSON.parse(settings.channelPlaybackSpeeds)[channelId]
+    }, NEW_CHANNEL_ID)).toBe(1.5)
+    await playbackSpeed.fill('1.25')
+    await expect.poll(() => page.evaluate(channelId => {
+      const settings = document.querySelector('#app').__vue_app__.config.globalProperties.$store.state.settings
+      return JSON.parse(settings.channelPlaybackSpeeds)[channelId]
+    }, NEW_CHANNEL_ID)).toBe(1.25)
+
+    await page.evaluate(async ({ channelId }) => {
       const store = document.querySelector('#app').__vue_app__.config.globalProperties.$store
       const playbackSpeeds = JSON.parse(store.state.settings.channelPlaybackSpeeds)
       playbackSpeeds[channelId] = 1.75
-      playbackSpeeds[newChannelId] = 1.5
       await store.dispatch('updateChannelPlaybackSpeeds', JSON.stringify(playbackSpeeds))
       window.rejectChannelVolumeUpdate(new Error('write failed'))
-    }, { channelId: CHANNEL_ID, newChannelId: NEW_CHANNEL_ID })
+    }, { channelId: CHANNEL_ID })
 
     await expect(page.locator('.toast', {
       hasText: 'Failed to save channel settings'
@@ -238,7 +250,7 @@ test.describe('channel settings', () => {
       }
     }, { channelId: CHANNEL_ID, newChannelId: NEW_CHANNEL_ID })).toEqual({
       existingChannel: 1.75,
-      newChannel: 1.5
+      newChannel: 1.25
     })
   })
 

--- a/e2e/tests/offline/channel-settings.spec.mjs
+++ b/e2e/tests/offline/channel-settings.spec.mjs
@@ -198,6 +198,37 @@ test.describe('channel settings', () => {
     await expect(picker).toHaveCount(0)
   })
 
+  test('shows a partially saved channel when initialization cannot roll back', async ({ page }) => {
+    await goToSettingsSection(page, 'playback')
+    await page.getByRole('button', { name: 'Manage Saved Channels (1)' }).click()
+    await page.getByRole('button', { name: 'Add subscribed channel' }).click()
+
+    await page.evaluate(channelId => {
+      const store = document.querySelector('#app').__vue_app__.config.globalProperties.$store
+      const updatePlaybackSpeeds = store._actions.updateChannelPlaybackSpeeds[0]
+      store._actions.updateChannelPlaybackSpeeds = [value => {
+        const playbackSpeeds = JSON.parse(value)
+        return Object.hasOwn(playbackSpeeds, channelId)
+          ? updatePlaybackSpeeds(value)
+          : Promise.resolve(false)
+      }]
+      store._actions.updateChannelVolumes = [() => Promise.reject(new Error('write failed'))]
+    }, NEW_CHANNEL_ID)
+
+    const picker = page.getByRole('dialog', { name: 'Add subscribed channel' })
+    await picker.getByRole('button', { name: NEW_CHANNEL_NAME, exact: true }).click()
+
+    await expect(picker).toHaveCount(0)
+    await expect(page.locator('.toast', {
+      hasText: 'Failed to save channel settings'
+    })).toBeVisible()
+
+    const newChannel = page.locator('.settingsWindow .channelEntry', { hasText: NEW_CHANNEL_NAME })
+    await expect(newChannel).toBeVisible()
+    await expect(newChannel.locator('.channelPreference')).toHaveCount(1)
+    await expect(newChannel.getByRole('slider', { name: /Playback Speed/ })).toBeVisible()
+  })
+
   test('preserves newer edits when initialization rolls back', async ({ page }) => {
     await goToSettingsSection(page, 'playback')
     await page.getByRole('button', { name: 'Manage Saved Channels (1)' }).click()

--- a/e2e/tests/offline/download-settings.spec.mjs
+++ b/e2e/tests/offline/download-settings.spec.mjs
@@ -1,7 +1,13 @@
 import { chmod, copyFile, readFile, writeFile } from 'node:fs/promises'
 import path from 'node:path'
 
-import { test, expect, goToSettingsSection, setWindowSize } from '../../helpers/app.mjs'
+import {
+  test,
+  expect,
+  expectScrollAtRenderedEnd,
+  goToSettingsSection,
+  setWindowSize
+} from '../../helpers/app.mjs'
 import { DEMO_MEDIA_PATH } from '../../helpers/media.mjs'
 
 const ALPHA_CHANNEL_ID = 'UCaaaaaaaaaaaaaaaaaaaaaa'
@@ -40,16 +46,6 @@ const AUTOMATIC_RULE = {
 async function scrollToBottom(scroller) {
   await scroller.evaluate(element => { element.scrollTop = element.scrollHeight })
   await expect.poll(() => scroller.evaluate(element => element.scrollTop)).toBeGreaterThan(0)
-}
-
-async function expectScrollAtRenderedEnd(scroller) {
-  await expect.poll(() => scroller.evaluate((element) => {
-    const content = element.querySelector(':scope > div')
-    const contentEnd = content.offsetTop + content.offsetHeight +
-      Number.parseFloat(getComputedStyle(element).paddingBottom)
-    const maximumScrollTop = Math.max(0, contentEnd - element.clientHeight)
-    return Math.abs(element.scrollTop - maximumScrollTop)
-  })).toBeLessThanOrEqual(1)
 }
 
 test.use({

--- a/e2e/tests/offline/download-settings.spec.mjs
+++ b/e2e/tests/offline/download-settings.spec.mjs
@@ -152,7 +152,7 @@ test.describe('download settings', () => {
     await page.getByRole('button', { name: 'Manage Automatic Downloads (0)' }).click()
 
     const manager = page.locator('.settingsSubpageContent')
-    const search = manager.getByRole('textbox', { name: 'Search channels' })
+    const search = manager.getByRole('searchbox', { name: 'Search channels' })
     const scroller = manager.locator('.automaticDownloadsScroller')
     const scrollbar = scroller.locator(':scope > .os-scrollbar-vertical')
     await scrollToBottom(scroller)

--- a/e2e/tests/offline/history.spec.mjs
+++ b/e2e/tests/offline/history.spec.mjs
@@ -1,7 +1,7 @@
 import { readFile } from 'node:fs/promises'
 import path from 'node:path'
 
-import { test, expect, goTo } from '../../helpers/app.mjs'
+import { test, expect, goTo, updateInputWithoutScrolling } from '../../helpers/app.mjs'
 
 const now = Date.now()
 const DAY = 86_400_000
@@ -85,13 +85,6 @@ async function expectPageScrollWithinRenderedRange(page) {
     scrollWithinRenderedRange: true,
     scrollbarMatchesOverflow: true
   })
-}
-
-async function updateInputWithoutScrolling(input, value) {
-  await input.evaluate((element, nextValue) => {
-    element.value = nextValue
-    element.dispatchEvent(new Event('input', { bubbles: true }))
-  }, value)
 }
 
 test.use({

--- a/e2e/tests/offline/history.spec.mjs
+++ b/e2e/tests/offline/history.spec.mjs
@@ -368,9 +368,9 @@ test.describe('history search pagination', () => {
     await goTo(page, 'history')
 
     const historySearch = page.locator('.ft-input-component').filter({
-      has: page.getByRole('textbox', { name: 'Search in History' })
+      has: page.getByRole('searchbox', { name: 'Search in History' })
     })
-    const filterInput = historySearch.getByRole('textbox', { name: 'Search in History' })
+    const filterInput = historySearch.getByRole('searchbox', { name: 'Search in History' })
     const videos = page.locator('.tabContent[aria-hidden="false"] .autoGrid > *')
     const loadMoreButton = page.getByRole('button', { name: 'Load More Videos' })
 
@@ -395,7 +395,8 @@ test.describe('history search pagination', () => {
     await expect(loadMoreButton).toHaveCount(0)
 
     await scrollPageToEnd(page)
-    await historySearch.getByRole('button', { name: 'Clear Input' }).evaluate(button => button.click())
+    await expect(filterInput).toHaveAttribute('type', 'search')
+    await filterInput.fill('')
     await expect(filterInput).toHaveValue('')
     await expect(videos.first()).toContainText('Decoy match')
     await expect(videos).toHaveCount(100)
@@ -428,7 +429,7 @@ test.describe('history search automatic pagination', () => {
   test('loads the next filtered batch when the pagination control enters view', async ({ page }) => {
     await goTo(page, 'history')
 
-    const filterInput = page.getByRole('textbox', { name: 'Search in History' })
+    const filterInput = page.getByRole('searchbox', { name: 'Search in History' })
     const videos = page.locator('.tabContent[aria-hidden="false"] .autoGrid > *')
 
     await filterInput.fill('Automatic match')

--- a/e2e/tests/offline/subscription-channel-settings.spec.mjs
+++ b/e2e/tests/offline/subscription-channel-settings.spec.mjs
@@ -299,7 +299,7 @@ test('reports subscription setting write failures from the channel popover', asy
   await shorts.click()
 
   await expect(page.locator('.toast', {
-    hasText: 'Failed to save subscription settings'
+    hasText: 'Failed to save channel settings'
   })).toBeVisible()
   await expect(shorts).toHaveAttribute('aria-checked', 'false')
 })
@@ -345,7 +345,7 @@ test('does not carry a failed popover edit into a later update', async ({ app, p
     }
   }).toEqual({ dailyVideoLimit: 2, showMembersOnly: false })
   await expect(page.locator('.toast', {
-    hasText: 'Failed to save subscription settings'
+    hasText: 'Failed to save channel settings'
   })).toBeVisible()
 })
 
@@ -363,7 +363,7 @@ test('reports subscription setting write failures from the settings manager', as
   await shorts.click()
 
   await expect(page.locator('.toast', {
-    hasText: 'Failed to save subscription settings'
+    hasText: 'Failed to save channel settings'
   })).toBeVisible()
   await expect(shorts).toHaveAttribute('aria-checked', 'false')
 })

--- a/e2e/tests/offline/subscription-channel-settings.spec.mjs
+++ b/e2e/tests/offline/subscription-channel-settings.spec.mjs
@@ -1,15 +1,26 @@
 import { readFile } from 'node:fs/promises'
 import path from 'node:path'
 
-import { test, expect, goTo, goToSettingsSection } from '../../helpers/app.mjs'
+import { test, expect, goTo, goToSettingsSection, setWindowSize } from '../../helpers/app.mjs'
 
 const CHANNEL_ID = `UC${'0'.repeat(22)}`
 const subscriptions = Array.from({ length: 18 }, (_, index) => ({
   id: `UC${String(index).padStart(22, '0')}`,
   name: index === 0 ? 'Alpha Channel' : `Channel ${String(index).padStart(2, '0')}`,
   thumbnail: '',
-  ...(index === 0 ? { feedTypes: ['videos'] } : {})
+  ...(index === 0 ? { feedTypes: ['videos'] } : {}),
+  ...(index === 1 ? { dailyVideoLimit: 1, showMembersOnly: true } : {})
 }))
+
+async function expectScrollAtRenderedEnd(scroller) {
+  await expect.poll(() => scroller.evaluate((element) => {
+    const content = element.querySelector(':scope > div')
+    const contentEnd = content.offsetTop + content.offsetHeight +
+      Number.parseFloat(getComputedStyle(element).paddingBottom)
+    const maximumScrollTop = Math.max(0, contentEnd - element.clientHeight)
+    return Math.abs(element.scrollTop - maximumScrollTop)
+  })).toBeLessThanOrEqual(1)
+}
 
 test.use({
   seed: {
@@ -155,10 +166,108 @@ test('keeps the popover and Subscription Settings manager in sync', async ({ app
     .getByRole('combobox', { name: 'Videos per day' })).toHaveText('Unlimited')
 })
 
+test('changes subscription settings for selected channels', async ({ app, attachScreenshot, page }) => {
+  const subscriptionSettings = await goToSettingsSection(page, 'subscription')
+  await subscriptionSettings.getByRole('button', { name: 'Subscription settings', exact: true }).click()
+
+  const selectionToolbar = page.locator('.channelSelectionToolbar')
+  const selectAll = selectionToolbar.getByRole('button', { name: 'Select All' })
+  const selectNone = selectionToolbar.getByRole('button', { name: 'Select None' })
+  await expect(selectAll.locator('.channelSelectionActionIcon')).toHaveCount(1)
+  await expect(selectNone.locator('.channelSelectionActionIcon')).toHaveCount(1)
+  for (const button of [selectAll, selectNone]) {
+    await expect.poll(() => button.evaluate(element => {
+      const label = element.querySelector(':scope > span')
+      const icon = element.querySelector(':scope > .channelSelectionActionIcon')
+      return label?.getBoundingClientRect().right <= icon?.getBoundingClientRect().left
+    })).toBe(true)
+  }
+  await expect(selectionToolbar).toContainText('0 selected')
+  await expect(page.locator('.bulkFeedTypeSettings')).toHaveCount(0)
+
+  await selectAll.click()
+  await expect(selectionToolbar).toContainText(`${subscriptions.length} selected`)
+  await expect(page.getByRole('checkbox', { name: 'Alpha Channel' }))
+    .toHaveAttribute('aria-checked', 'true')
+  await selectNone.click()
+
+  await page.getByRole('checkbox', { name: 'Alpha Channel' }).click()
+  await page.getByRole('checkbox', { name: 'Channel 01' }).click()
+  await expect(selectionToolbar).toContainText('2 selected')
+
+  const bulkSettings = page.locator('.bulkFeedTypeSettings')
+  const bulkVideos = bulkSettings.getByRole('checkbox', { name: 'Videos' })
+  const bulkShorts = bulkSettings.getByRole('checkbox', { name: 'Shorts' })
+  const bulkMembersOnly = bulkSettings.getByRole('checkbox', { name: 'Members only' })
+  const bulkDailyLimit = bulkSettings.getByRole('combobox', { name: 'Videos per day' })
+  await expect(bulkVideos).toHaveAttribute('aria-checked', 'true')
+  await expect(bulkShorts).toHaveAttribute('aria-checked', 'mixed')
+  await expect(bulkMembersOnly).toHaveAttribute('aria-checked', 'mixed')
+  await expect(bulkDailyLimit).toHaveText('Different values')
+
+  await setWindowSize(app, page, { width: 375, height: 700 })
+  await expect.poll(() => page.locator('.settingsContent').evaluate(element => (
+    element.scrollWidth - element.clientWidth
+  ))).toBeLessThanOrEqual(1)
+  await attachScreenshot('compact subscription channel selection controls')
+  await bulkDailyLimit.scrollIntoViewIfNeeded()
+  await expect(bulkMembersOnly).toBeVisible()
+  await expect(bulkDailyLimit).toBeVisible()
+  await attachScreenshot('compact subscription channel batch settings')
+
+  await bulkVideos.click()
+  await bulkShorts.click()
+  await bulkMembersOnly.click()
+  await bulkDailyLimit.click()
+  await page.getByRole('option', { name: '2', exact: true }).click()
+  await expect(bulkVideos).toHaveAttribute('aria-checked', 'false')
+  await expect(bulkShorts).toHaveAttribute('aria-checked', 'true')
+  await expect(bulkMembersOnly).toHaveAttribute('aria-checked', 'true')
+  await expect(bulkDailyLimit).toHaveText('2')
+
+  await expect.poll(async () => {
+    const contents = await readFile(path.join(app.userDataDir, 'profiles.db'), 'utf8')
+    const records = contents.trim().split('\n').map(line => JSON.parse(line))
+    const latestProfiles = new Map(records.map(record => [record._id, record]))
+    return ['allChannels', 'profile-1'].map(profileId => (
+      latestProfiles.get(profileId).subscriptions
+        .filter(channel => [subscriptions[0].id, subscriptions[1].id].includes(channel.id))
+        .sort((left, right) => left.id.localeCompare(right.id))
+        .map(channel => ({
+          dailyVideoLimit: channel.dailyVideoLimit,
+          feedTypes: channel.feedTypes,
+          showMembersOnly: channel.showMembersOnly
+        }))
+    ))
+  }).toEqual([
+    [
+      { dailyVideoLimit: 2, feedTypes: ['shorts'], showMembersOnly: true },
+      { dailyVideoLimit: 2, feedTypes: ['shorts', 'live', 'posts'], showMembersOnly: true }
+    ],
+    [
+      { dailyVideoLimit: 2, feedTypes: ['shorts'], showMembersOnly: true }
+    ]
+  ])
+
+  const scroller = page.locator('.channelSettingsScroller')
+  const scrollbar = scroller.locator(':scope > .os-scrollbar-vertical')
+  await scroller.evaluate(element => { element.scrollTop = element.scrollHeight })
+  await expect.poll(() => scroller.evaluate(element => element.scrollTop)).toBeGreaterThan(0)
+  await expect(scrollbar).not.toHaveClass(/os-scrollbar-unusable/)
+
+  await selectNone.evaluate(button => button.click())
+  await expect(selectionToolbar).toContainText('0 selected')
+  await expect(page.locator('.bulkFeedTypeSettings')).toHaveCount(0)
+  await expectScrollAtRenderedEnd(scroller)
+  await expect(scrollbar).not.toHaveClass(/os-scrollbar-unusable/)
+})
+
 test('only offers members-only controls when yt-dlp playback cookies are configured', async ({ page }) => {
   const subscriptionSettings = await goToSettingsSection(page, 'subscription')
   await subscriptionSettings.getByRole('button', { name: 'Subscription settings', exact: true }).click()
   await expect(page.getByRole('checkbox', { name: 'Members only' })).toHaveCount(subscriptions.length)
+  await page.locator('.channelSelectionToolbar').getByRole('button', { name: 'Select All' }).click()
+  await expect(page.getByRole('checkbox', { name: 'Members only' })).toHaveCount(subscriptions.length + 1)
 
   await page.evaluate(async () => {
     const store = document.querySelector('#app').__vue_app__.config.globalProperties.$store

--- a/e2e/tests/offline/subscription-channel-settings.spec.mjs
+++ b/e2e/tests/offline/subscription-channel-settings.spec.mjs
@@ -1,7 +1,14 @@
 import { readFile } from 'node:fs/promises'
 import path from 'node:path'
 
-import { test, expect, goTo, goToSettingsSection, setWindowSize } from '../../helpers/app.mjs'
+import {
+  test,
+  expect,
+  expectScrollAtRenderedEnd,
+  goTo,
+  goToSettingsSection,
+  setWindowSize
+} from '../../helpers/app.mjs'
 
 const CHANNEL_ID = `UC${'0'.repeat(22)}`
 const subscriptions = Array.from({ length: 18 }, (_, index) => ({
@@ -11,16 +18,6 @@ const subscriptions = Array.from({ length: 18 }, (_, index) => ({
   ...(index === 0 ? { feedTypes: ['videos'] } : {}),
   ...(index === 1 ? { dailyVideoLimit: 1, showMembersOnly: true } : {})
 }))
-
-async function expectScrollAtRenderedEnd(scroller) {
-  await expect.poll(() => scroller.evaluate((element) => {
-    const content = element.querySelector(':scope > div')
-    const contentEnd = content.offsetTop + content.offsetHeight +
-      Number.parseFloat(getComputedStyle(element).paddingBottom)
-    const maximumScrollTop = Math.max(0, contentEnd - element.clientHeight)
-    return Math.abs(element.scrollTop - maximumScrollTop)
-  })).toBeLessThanOrEqual(1)
-}
 
 test.use({
   seed: {
@@ -366,6 +363,33 @@ test('reports subscription setting write failures from the settings manager', as
     hasText: 'Failed to save channel settings'
   })).toBeVisible()
   await expect(shorts).toHaveAttribute('aria-checked', 'false')
+})
+
+test('reports one failure toast for a failed batch update', async ({ page }) => {
+  const subscriptionSettings = await goToSettingsSection(page, 'subscription')
+  await subscriptionSettings.getByRole('button', { name: 'Subscription settings', exact: true }).click()
+
+  await page.evaluate(() => {
+    const store = document.querySelector('#app').__vue_app__.config.globalProperties.$store
+    let updateCount = 0
+    store._actions.updateChannelSettings = [() => {
+      updateCount += 1
+      return Promise.resolve(false)
+    }]
+    window.channelSettingsUpdateCount = () => updateCount
+  })
+
+  const selectionToolbar = page.locator('.channelSelectionToolbar')
+  await selectionToolbar.getByRole('button', { name: 'Select All' }).click()
+  await page.locator('.bulkFeedTypeSettings')
+    .getByRole('checkbox', { name: 'Videos' })
+    .click()
+
+  await expect.poll(() => page.evaluate(() => window.channelSettingsUpdateCount()))
+    .toBe(subscriptions.length)
+  await expect(page.locator('.toast', {
+    hasText: 'Failed to save channel settings'
+  })).toHaveCount(1)
 })
 
 test('reports a partial write when a requested profile no longer exists', async ({ page }) => {

--- a/src/renderer/components/AutomaticDownloadSettings/AutomaticDownloadSettings.vue
+++ b/src/renderer/components/AutomaticDownloadSettings/AutomaticDownloadSettings.vue
@@ -16,12 +16,11 @@
         {{ t('Settings.Download Settings.Automatic Downloads New Only') }}
       </p>
       <FtInput
+        input-type="search"
         :placeholder="t('Settings.Channel Settings.Search Channels')"
         :show-action-button="false"
-        :show-clear-text-button="true"
         :value="searchQuery"
         @input="searchQuery = $event"
-        @clear="searchQuery = ''"
       />
     </div>
     <div

--- a/src/renderer/components/ChannelDetails/ChannelDetails.vue
+++ b/src/renderer/components/ChannelDetails/ChannelDetails.vue
@@ -270,13 +270,12 @@
         <FtInput
           v-if="showSearchBar"
           ref="searchBar"
+          input-type="search"
           :placeholder="$t('Channel.Search Channel')"
           :value="query"
-          :show-clear-text-button="true"
           class="channelSearch"
           :maxlength="255"
           @input="handleSearchInput"
-          @clear="clearSearch"
           @click="search"
         />
       </FtFlexBox>

--- a/src/renderer/components/ChannelSettings/ChannelSettings.css
+++ b/src/renderer/components/ChannelSettings/ChannelSettings.css
@@ -35,6 +35,68 @@
   margin-inline-start: 0;
 }
 
+.channelManagerToolbar {
+  display: flex;
+  justify-content: flex-end;
+  padding-block-end: 12px;
+}
+
+.addSubscribedChannelPicker {
+  padding-inline: 12px;
+  text-align: start;
+}
+
+.addSubscribedChannelSearch {
+  margin-block-end: 8px;
+}
+
+.addSubscribedChannelEmptyState {
+  margin-block: 16px;
+  margin-inline: auto;
+  max-inline-size: 320px;
+  text-align: center;
+}
+
+.addSubscribedChannelList {
+  display: grid;
+  gap: 4px;
+  list-style: none;
+  margin: 0;
+  padding: 0;
+}
+
+.addSubscribedChannelOption {
+  align-items: center;
+  background: transparent;
+  border: 0;
+  border-radius: calc(4px * var(--ui-roundness));
+  color: inherit;
+  cursor: pointer;
+  display: grid;
+  font: inherit;
+  gap: 12px;
+  grid-template-columns: 40px minmax(0, 1fr) 16px;
+  inline-size: 100%;
+  min-block-size: 48px;
+  padding-block: 4px;
+  padding-inline: 8px;
+  text-align: start;
+}
+
+.addSubscribedChannelOption:is(:hover, :focus-visible) {
+  background-color: var(--side-nav-hover-color);
+  color: var(--side-nav-hover-text-color);
+}
+
+.addSubscribedChannelName {
+  min-inline-size: 0;
+  overflow-wrap: anywhere;
+}
+
+.addSubscribedChannelIcon {
+  justify-self: center;
+}
+
 .channelSearch {
   margin-block-end: 1em;
 }

--- a/src/renderer/components/ChannelSettings/ChannelSettings.vue
+++ b/src/renderer/components/ChannelSettings/ChannelSettings.vue
@@ -56,15 +56,24 @@
           :disable-label="savedChannelSyncDisableLabel"
         />
       </template>
+      <div
+        v-if="availableSubscriptions.length > 0"
+        class="channelManagerToolbar"
+      >
+        <FtButton
+          :label="t('Settings.Channel Settings.Add Subscribed Channel')"
+          :icon="['fas', 'plus']"
+          @click="showAddChannelPrompt = true"
+        />
+      </div>
       <FtInput
         v-if="channelEntries.length > SEARCH_THRESHOLD"
         class="channelSearch"
+        input-type="search"
         :placeholder="t('Settings.Channel Settings.Search Channels')"
         :show-action-button="false"
-        :show-clear-text-button="true"
         :value="searchQuery"
         @input="value => searchQuery = value"
-        @clear="searchQuery = ''"
       />
       <div
         v-overlay-scrollbars
@@ -187,19 +196,101 @@
           </li>
         </ul>
       </div>
+      <FtPrompt
+        v-if="showAddChannelPrompt"
+        :label="t('Settings.Channel Settings.Add Subscribed Channel')"
+        theme="readable-width"
+        fixed-layout
+        @click="closeAddChannelPrompt"
+      >
+        <div class="addSubscribedChannelPicker">
+          <p
+            v-if="enabledPreferences.length === 0"
+            class="addSubscribedChannelEmptyState"
+          >
+            {{ t('Settings.Channel Settings.Enable Setting Before Adding Channel') }}
+          </p>
+          <template v-else>
+            <FtInput
+              ref="addChannelSearch"
+              class="addSubscribedChannelSearch"
+              input-type="search"
+              :placeholder="t('Settings.Channel Settings.Search Channels')"
+              :show-action-button="false"
+              :value="addChannelSearchQuery"
+              @input="value => addChannelSearchQuery = value"
+            />
+            <p
+              v-if="visibleAvailableSubscriptions.length === 0"
+              class="addSubscribedChannelEmptyState"
+            >
+              {{ t('Settings.Channel Settings.No Matching Channels') }}
+            </p>
+            <ul
+              v-else
+              class="addSubscribedChannelList"
+            >
+              <li
+                v-for="channel in visibleAvailableSubscriptions"
+                :key="channel.id"
+              >
+                <button
+                  type="button"
+                  class="addSubscribedChannelOption"
+                  @click="addSubscribedChannel(channel.id)"
+                >
+                  <img
+                    v-if="channel.thumbnail"
+                    class="channelThumbnail"
+                    :src="channel.thumbnail"
+                    alt=""
+                  >
+                  <span
+                    v-else
+                    class="channelThumbnail channelThumbnailPlaceholder"
+                    aria-hidden="true"
+                  >
+                    <FtIcon :icon="['fas', 'circle-user']" />
+                  </span>
+                  <span
+                    class="addSubscribedChannelName"
+                    dir="auto"
+                  >
+                    {{ channel.name }}
+                  </span>
+                  <FtIcon
+                    class="addSubscribedChannelIcon"
+                    :icon="['fas', 'plus']"
+                    aria-hidden="true"
+                  />
+                </button>
+              </li>
+            </ul>
+          </template>
+        </div>
+        <template #footer>
+          <FtFlexBox>
+            <FtButton
+              :label="t('Close')"
+              @click="closeAddChannelPrompt"
+            />
+          </FtFlexBox>
+        </template>
+      </FtPrompt>
     </FtSettingsSubpage>
   </FtSettingsSection>
 </template>
 
 <script setup>
 import { FtIcon } from '@opentubex/icons'
-import { computed, ref, watch } from 'vue'
+import { computed, nextTick, ref, useTemplateRef, watch } from 'vue'
 import { useI18n } from 'vue-i18n'
 
 import FtButton from '../FtButton/FtButton.vue'
 import FtFlexBox from '../ft-flex-box/ft-flex-box.vue'
 import FtIconButton from '../FtIconButton/FtIconButton.vue'
 import FtInput from '../FtInput/FtInput.vue'
+import FtPrompt from '../FtPrompt/FtPrompt.vue'
 import FtSettingsSubpage from '../FtSettingsSubpage/FtSettingsSubpage.vue'
 import FtSelect from '../FtSelect/FtSelect.vue'
 import FtSettingsSection from '../FtSettingsSection/FtSettingsSection.vue'
@@ -321,6 +412,21 @@ const backendOptions = computed(() => ({
 }))
 
 const showManager = ref(false)
+const showAddChannelPrompt = ref(false)
+const addChannelSearchQuery = ref('')
+const addChannelSearch = useTemplateRef('addChannelSearch')
+
+watch(showAddChannelPrompt, async (open) => {
+  if (!open || enabledPreferences.value.length === 0) {
+    return
+  }
+
+  // FtPrompt assigns its initial focus after mounting. Wait for that pass,
+  // then put keyboard users directly in the channel search.
+  await nextTick()
+  await nextTick()
+  addChannelSearch.value?.focus()
+})
 
 /** @param {MouseEvent} event */
 function handleChannelLinkClick(event) {
@@ -426,6 +532,35 @@ const channelEntries = computed(() => {
   return entries.sort((a, b) => collator.value.compare(a.name, b.name))
 })
 
+const enabledPreferences = computed(() => (
+  PREFERENCES.filter(({ rememberKey }) => settings.value[rememberKey])
+))
+
+/** Subscriptions that do not have any saved channel preference yet. */
+const availableSubscriptions = computed(() => {
+  const savedChannelIds = new Set(channelEntries.value.map(({ id }) => id))
+
+  return Array.from(subscriptionsById.value, ([id, channel]) => ({
+    id,
+    name: channel.name || id,
+    thumbnail: channel.thumbnail ?? ''
+  }))
+    .filter(({ id }) => !savedChannelIds.has(id))
+    .sort((a, b) => collator.value.compare(a.name, b.name))
+})
+
+const visibleAvailableSubscriptions = computed(() => {
+  const query = addChannelSearchQuery.value.trim().toLowerCase()
+
+  if (query === '') {
+    return availableSubscriptions.value
+  }
+
+  return availableSubscriptions.value.filter(({ id, name }) => (
+    name.toLowerCase().includes(query) || id.toLowerCase().includes(query)
+  ))
+})
+
 const visibleChannelEntries = computed(() => {
   const query = searchQuery.value.trim().toLowerCase()
 
@@ -496,6 +631,29 @@ function addPreference(channelId, type) {
       setPreference(channelId, type, store.getters.getDefaultVolume)
       break
   }
+}
+
+/**
+ * Creates a saved channel entry with the global defaults for every enabled
+ * per-channel preference.
+ * @param {string} channelId
+ */
+function addSubscribedChannel(channelId) {
+  if (enabledPreferences.value.length === 0) {
+    return
+  }
+
+  for (const { type } of enabledPreferences.value) {
+    addPreference(channelId, type)
+  }
+
+  addChannelSearchQuery.value = ''
+  showAddChannelPrompt.value = false
+}
+
+function closeAddChannelPrompt() {
+  showAddChannelPrompt.value = false
+  addChannelSearchQuery.value = ''
 }
 
 /**

--- a/src/renderer/components/ChannelSettings/ChannelSettings.vue
+++ b/src/renderer/components/ChannelSettings/ChannelSettings.vue
@@ -675,10 +675,17 @@ async function addSubscribedChannel(channelId) {
     )))
 
     if (saved.some(value => !value)) {
-      await Promise.all(preferencesToAdd.map(({ type, initialValue }) => (
+      const rolledBack = await Promise.all(preferencesToAdd.map(({ type, initialValue }) => (
         rollbackPreference(channelId, type, initialValue, initializationToken)
-          .catch(error => console.error(error))
+          .catch(error => {
+            console.error(error)
+            return false
+          })
       )))
+      if (rolledBack.some(value => !value)) {
+        addChannelSearchQuery.value = ''
+        showAddChannelPrompt.value = false
+      }
       showToast({
         message: t('Channel.Failed to save subscription settings'),
         icon: ['fas', 'circle-exclamation']

--- a/src/renderer/components/ChannelSettings/ChannelSettings.vue
+++ b/src/renderer/components/ChannelSettings/ChannelSettings.vue
@@ -417,6 +417,7 @@ const showManager = ref(false)
 const showAddChannelPrompt = ref(false)
 const addChannelSearchQuery = ref('')
 const addingSubscribedChannel = ref(false)
+const pendingPreferenceInitializations = new Map()
 const addChannelSearch = useTemplateRef('addChannelSearch')
 
 watch(showAddChannelPrompt, async (open) => {
@@ -608,8 +609,16 @@ watch([showManager, channelEntries], ([isManagerOpen]) => {
  * @param {string} channelId
  * @param {'playbackSpeed' | 'videoQuality' | 'subtitlesState' | 'volume'} type
  * @param {number | string | boolean} value
+ * @param {symbol} [initializationToken]
  */
-function setPreference(channelId, type, value) {
+function setPreference(channelId, type, value, initializationToken) {
+  const key = `${channelId}:${type}`
+  if (initializationToken === undefined) {
+    pendingPreferenceInitializations.delete(key)
+  } else {
+    pendingPreferenceInitializations.set(key, initializationToken)
+  }
+
   const { valuesKey, values } = preferenceValuesFor(type)
   values[channelId] = value
   return updateSetting(valuesKey, JSON.stringify(values))
@@ -651,14 +660,15 @@ async function addSubscribedChannel(channelId) {
     return
   }
 
+  const preferencesToAdd = enabledPreferences.value.map(({ type }) => ({
+    type,
+    initialValue: defaultPreferenceValue(type)
+  }))
   addingSubscribedChannel.value = true
+  const initializationToken = Symbol(channelId)
   try {
-    const preferencesToAdd = enabledPreferences.value.map(({ type }) => ({
-      type,
-      initialValue: defaultPreferenceValue(type)
-    }))
     const saved = await Promise.all(preferencesToAdd.map(({ type, initialValue }) => (
-      setPreference(channelId, type, initialValue).catch((error) => {
+      setPreference(channelId, type, initialValue, initializationToken).catch((error) => {
         console.error(error)
         return false
       })
@@ -666,7 +676,8 @@ async function addSubscribedChannel(channelId) {
 
     if (saved.some(value => !value)) {
       await Promise.all(preferencesToAdd.map(({ type, initialValue }) => (
-        rollbackPreference(channelId, type, initialValue).catch(error => console.error(error))
+        rollbackPreference(channelId, type, initialValue, initializationToken)
+          .catch(error => console.error(error))
       )))
       showToast({
         message: t('Channel.Failed to save subscription settings'),
@@ -678,6 +689,12 @@ async function addSubscribedChannel(channelId) {
     addChannelSearchQuery.value = ''
     showAddChannelPrompt.value = false
   } finally {
+    for (const { type } of preferencesToAdd) {
+      const key = `${channelId}:${type}`
+      if (pendingPreferenceInitializations.get(key) === initializationToken) {
+        pendingPreferenceInitializations.delete(key)
+      }
+    }
     addingSubscribedChannel.value = false
   }
 }
@@ -692,13 +709,20 @@ function closeAddChannelPrompt() {
  * @param {string} channelId
  * @param {'playbackSpeed' | 'videoQuality' | 'subtitlesState' | 'volume'} type
  * @param {number | string | boolean} initialValue
+ * @param {symbol} initializationToken
  */
-function rollbackPreference(channelId, type, initialValue) {
+function rollbackPreference(channelId, type, initialValue, initializationToken) {
+  const key = `${channelId}:${type}`
   const { valuesKey, values } = preferenceValuesFor(type)
-  if (!Object.hasOwn(values, channelId) || values[channelId] !== initialValue) {
+  if (
+    pendingPreferenceInitializations.get(key) !== initializationToken ||
+    !Object.hasOwn(values, channelId) ||
+    values[channelId] !== initialValue
+  ) {
     return Promise.resolve(true)
   }
 
+  pendingPreferenceInitializations.delete(key)
   delete values[channelId]
   return updateSetting(valuesKey, JSON.stringify(values))
 }

--- a/src/renderer/components/ChannelSettings/ChannelSettings.vue
+++ b/src/renderer/components/ChannelSettings/ChannelSettings.vue
@@ -653,12 +653,17 @@ async function addSubscribedChannel(channelId) {
     })
 
     const saved = await Promise.all(preferencesToAdd.map(({ type }) => (
-      addPreference(channelId, type)
+      addPreference(channelId, type).catch((error) => {
+        console.error(error)
+        return false
+      })
     )))
 
     if (saved.some(value => !value)) {
       await Promise.all(previousValues.map(({ valuesKey, value }, index) => (
-        saved[index] ? updateSetting(valuesKey, value) : Promise.resolve(true)
+        saved[index]
+          ? updateSetting(valuesKey, value).catch(error => console.error(error))
+          : Promise.resolve(true)
       )))
       showToast({
         message: t('Channel.Failed to save subscription settings'),

--- a/src/renderer/components/ChannelSettings/ChannelSettings.vue
+++ b/src/renderer/components/ChannelSettings/ChannelSettings.vue
@@ -622,15 +622,22 @@ function setPreference(channelId, type, value) {
  * @param {'playbackSpeed' | 'videoQuality' | 'subtitlesState' | 'volume'} type
  */
 function addPreference(channelId, type) {
+  return setPreference(channelId, type, defaultPreferenceValue(type))
+}
+
+/**
+ * @param {'playbackSpeed' | 'videoQuality' | 'subtitlesState' | 'volume'} type
+ */
+function defaultPreferenceValue(type) {
   switch (type) {
     case 'playbackSpeed':
-      return setPreference(channelId, type, store.getters.getDefaultPlayback)
+      return store.getters.getDefaultPlayback
     case 'videoQuality':
-      return setPreference(channelId, type, defaultQuality.value)
+      return defaultQuality.value
     case 'subtitlesState':
-      return setPreference(channelId, type, store.getters.getEnableSubtitlesByDefault)
+      return store.getters.getEnableSubtitlesByDefault
     case 'volume':
-      return setPreference(channelId, type, store.getters.getDefaultVolume)
+      return store.getters.getDefaultVolume
   }
 }
 
@@ -646,17 +653,20 @@ async function addSubscribedChannel(channelId) {
 
   addingSubscribedChannel.value = true
   try {
-    const preferencesToAdd = enabledPreferences.value
-    const saved = await Promise.all(preferencesToAdd.map(({ type }) => (
-      addPreference(channelId, type).catch((error) => {
+    const preferencesToAdd = enabledPreferences.value.map(({ type }) => ({
+      type,
+      initialValue: defaultPreferenceValue(type)
+    }))
+    const saved = await Promise.all(preferencesToAdd.map(({ type, initialValue }) => (
+      setPreference(channelId, type, initialValue).catch((error) => {
         console.error(error)
         return false
       })
     )))
 
     if (saved.some(value => !value)) {
-      await Promise.all(preferencesToAdd.map(({ type }) => (
-        deletePreference(channelId, type).catch(error => console.error(error))
+      await Promise.all(preferencesToAdd.map(({ type, initialValue }) => (
+        rollbackPreference(channelId, type, initialValue).catch(error => console.error(error))
       )))
       showToast({
         message: t('Channel.Failed to save subscription settings'),
@@ -678,15 +688,27 @@ function closeAddChannelPrompt() {
 }
 
 /**
+ * Removes an initialized value unless it has since been edited.
+ * @param {string} channelId
+ * @param {'playbackSpeed' | 'videoQuality' | 'subtitlesState' | 'volume'} type
+ * @param {number | string | boolean} initialValue
+ */
+function rollbackPreference(channelId, type, initialValue) {
+  const { valuesKey, values } = preferenceValuesFor(type)
+  if (!Object.hasOwn(values, channelId) || values[channelId] !== initialValue) {
+    return Promise.resolve(true)
+  }
+
+  delete values[channelId]
+  return updateSetting(valuesKey, JSON.stringify(values))
+}
+
+/**
  * @param {string} channelId
  * @param {'playbackSpeed' | 'videoQuality' | 'subtitlesState' | 'volume'} type
  */
 function deletePreference(channelId, type) {
   const { valuesKey, values } = preferenceValuesFor(type)
-  if (!Object.hasOwn(values, channelId)) {
-    return Promise.resolve(true)
-  }
-
   delete values[channelId]
   return updateSetting(valuesKey, JSON.stringify(values))
 }

--- a/src/renderer/components/ChannelSettings/ChannelSettings.vue
+++ b/src/renderer/components/ChannelSettings/ChannelSettings.vue
@@ -237,6 +237,7 @@
                 <button
                   type="button"
                   class="addSubscribedChannelOption"
+                  :disabled="addingSubscribedChannel"
                   @click="addSubscribedChannel(channel.id)"
                 >
                   <img
@@ -305,6 +306,7 @@ import {
   getCachedChannelInfo,
   parseChannelPreferences
 } from '../../helpers/channel-preferences'
+import { showToast } from '../../helpers/utils'
 import { AUTO_QUALITY_FALLBACK, playbackEngineSupportsAutoQuality } from '../../helpers/player/autoQuality'
 
 const { locale, t } = useI18n()
@@ -414,6 +416,7 @@ const backendOptions = computed(() => ({
 const showManager = ref(false)
 const showAddChannelPrompt = ref(false)
 const addChannelSearchQuery = ref('')
+const addingSubscribedChannel = ref(false)
 const addChannelSearch = useTemplateRef('addChannelSearch')
 
 watch(showAddChannelPrompt, async (open) => {
@@ -444,10 +447,12 @@ const fetchedChannels = ref(new Map())
 
 /**
  * @param {string} settingKey
- * @param {boolean} value
+ * @param {boolean | number | string} value
+ * @returns {Promise<boolean>}
  */
-function updateSetting(settingKey, value) {
-  store.dispatch(`update${settingKey[0].toUpperCase()}${settingKey.slice(1)}`, value)
+async function updateSetting(settingKey, value) {
+  await store.dispatch(`update${settingKey[0].toUpperCase()}${settingKey.slice(1)}`, value)
+  return settings.value[settingKey] === value
 }
 
 /**
@@ -607,7 +612,7 @@ watch([showManager, channelEntries], ([isManagerOpen]) => {
 function setPreference(channelId, type, value) {
   const { valuesKey, values } = preferenceValuesFor(type)
   values[channelId] = value
-  updateSetting(valuesKey, JSON.stringify(values))
+  return updateSetting(valuesKey, JSON.stringify(values))
 }
 
 /**
@@ -619,17 +624,13 @@ function setPreference(channelId, type, value) {
 function addPreference(channelId, type) {
   switch (type) {
     case 'playbackSpeed':
-      setPreference(channelId, type, store.getters.getDefaultPlayback)
-      break
+      return setPreference(channelId, type, store.getters.getDefaultPlayback)
     case 'videoQuality':
-      setPreference(channelId, type, defaultQuality.value)
-      break
+      return setPreference(channelId, type, defaultQuality.value)
     case 'subtitlesState':
-      setPreference(channelId, type, store.getters.getEnableSubtitlesByDefault)
-      break
+      return setPreference(channelId, type, store.getters.getEnableSubtitlesByDefault)
     case 'volume':
-      setPreference(channelId, type, store.getters.getDefaultVolume)
-      break
+      return setPreference(channelId, type, store.getters.getDefaultVolume)
   }
 }
 
@@ -638,17 +639,39 @@ function addPreference(channelId, type) {
  * per-channel preference.
  * @param {string} channelId
  */
-function addSubscribedChannel(channelId) {
-  if (enabledPreferences.value.length === 0) {
+async function addSubscribedChannel(channelId) {
+  if (enabledPreferences.value.length === 0 || addingSubscribedChannel.value) {
     return
   }
 
-  for (const { type } of enabledPreferences.value) {
-    addPreference(channelId, type)
-  }
+  addingSubscribedChannel.value = true
+  try {
+    const preferencesToAdd = enabledPreferences.value
+    const previousValues = preferencesToAdd.map(({ type }) => {
+      const { valuesKey } = preferenceValuesFor(type)
+      return { valuesKey, value: settings.value[valuesKey] }
+    })
 
-  addChannelSearchQuery.value = ''
-  showAddChannelPrompt.value = false
+    const saved = await Promise.all(preferencesToAdd.map(({ type }) => (
+      addPreference(channelId, type)
+    )))
+
+    if (saved.some(value => !value)) {
+      await Promise.all(previousValues.map(({ valuesKey, value }, index) => (
+        saved[index] ? updateSetting(valuesKey, value) : Promise.resolve(true)
+      )))
+      showToast({
+        message: t('Channel.Failed to save subscription settings'),
+        icon: ['fas', 'circle-exclamation']
+      })
+      return
+    }
+
+    addChannelSearchQuery.value = ''
+    showAddChannelPrompt.value = false
+  } finally {
+    addingSubscribedChannel.value = false
+  }
 }
 
 function closeAddChannelPrompt() {

--- a/src/renderer/components/ChannelSettings/ChannelSettings.vue
+++ b/src/renderer/components/ChannelSettings/ChannelSettings.vue
@@ -647,11 +647,6 @@ async function addSubscribedChannel(channelId) {
   addingSubscribedChannel.value = true
   try {
     const preferencesToAdd = enabledPreferences.value
-    const previousValues = preferencesToAdd.map(({ type }) => {
-      const { valuesKey } = preferenceValuesFor(type)
-      return { valuesKey, value: settings.value[valuesKey] }
-    })
-
     const saved = await Promise.all(preferencesToAdd.map(({ type }) => (
       addPreference(channelId, type).catch((error) => {
         console.error(error)
@@ -660,10 +655,8 @@ async function addSubscribedChannel(channelId) {
     )))
 
     if (saved.some(value => !value)) {
-      await Promise.all(previousValues.map(({ valuesKey, value }, index) => (
-        saved[index]
-          ? updateSetting(valuesKey, value).catch(error => console.error(error))
-          : Promise.resolve(true)
+      await Promise.all(preferencesToAdd.map(({ type }) => (
+        deletePreference(channelId, type).catch(error => console.error(error))
       )))
       showToast({
         message: t('Channel.Failed to save subscription settings'),
@@ -690,8 +683,12 @@ function closeAddChannelPrompt() {
  */
 function deletePreference(channelId, type) {
   const { valuesKey, values } = preferenceValuesFor(type)
+  if (!Object.hasOwn(values, channelId)) {
+    return Promise.resolve(true)
+  }
+
   delete values[channelId]
-  updateSetting(valuesKey, JSON.stringify(values))
+  return updateSetting(valuesKey, JSON.stringify(values))
 }
 
 /**

--- a/src/renderer/components/FtInput/FtInput.vue
+++ b/src/renderer/components/FtInput/FtInput.vue
@@ -184,6 +184,8 @@ const props = defineProps({
     default: null
   },
   showClearTextButton: {
+    // Reserved for TopNav autocomplete. Regular search fields use inputType="search"
+    // so Chromium supplies the themed native cancel control.
     type: Boolean,
     default: false
   },

--- a/src/renderer/components/FtPlaylistAddVideoPrompt/FtPlaylistAddVideoPrompt.vue
+++ b/src/renderer/components/FtPlaylistAddVideoPrompt/FtPlaylistAddVideoPrompt.vue
@@ -16,12 +16,11 @@
     >
       <FtInput
         ref="searchBar"
+        input-type="search"
         :placeholder="t('User Playlists.AddVideoPrompt.Search in Playlists')"
-        :show-clear-text-button="true"
         :show-action-button="false"
         :maxlength="255"
         @input="updateQueryDebounce"
-        @clear="updateQueryDebounce('')"
       />
     </div>
     <div

--- a/src/renderer/components/PlaylistInfo/PlaylistInfo.vue
+++ b/src/renderer/components/PlaylistInfo/PlaylistInfo.vue
@@ -247,13 +247,12 @@
           <FtInput
             ref="searchInput"
             class="inputElement"
+            input-type="search"
             :placeholder="$t('User Playlists.SinglePlaylistView.Search for Videos')"
-            :show-clear-text-button="true"
             :show-action-button="false"
             :value="query"
             :maxlength="255"
             @input="updateQueryDebounced"
-            @clear="updateQueryDebounced('')"
           />
         </div>
       </div>

--- a/src/renderer/components/SubscriptionChannelSettings/SubscriptionChannelSettings.css
+++ b/src/renderer/components/SubscriptionChannelSettings/SubscriptionChannelSettings.css
@@ -4,6 +4,103 @@
   padding-inline: 20px;
 }
 
+.channelSelectionToolbar {
+  border: 1px solid var(--border-color);
+  border-radius: calc(6px * var(--ui-roundness));
+  margin-block-end: 12px;
+  padding: 12px;
+}
+
+.channelSelectionSummary {
+  align-items: center;
+  display: flex;
+  gap: 12px;
+  justify-content: space-between;
+}
+
+.channelSelectionSummary > p {
+  margin: 0;
+}
+
+.channelSelectionActions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px;
+  justify-content: flex-end;
+}
+
+.channelSelectionActions :deep(.btn) {
+  margin-block: 0;
+}
+
+.channelSelectionActionIcon {
+  flex: none;
+  margin-inline-start: auto;
+}
+
+.bulkFeedTypeSettings {
+  border-block-start: 1px solid var(--divider-color);
+  margin-block-start: 12px;
+  padding-block-start: 12px;
+}
+
+.bulkFeedTypeOptions {
+  max-inline-size: 680px;
+}
+
+.bulkAdditionalSettings {
+  align-items: end;
+  display: grid;
+  gap: 12px;
+  grid-template-columns: repeat(auto-fit, minmax(min(100%, 240px), 1fr));
+  margin-block-start: 12px;
+  max-inline-size: 680px;
+}
+
+.bulkMembersOnlySetting {
+  align-items: center;
+  background-color: var(--search-bar-color);
+  border: 1px solid transparent;
+  border-radius: calc(5px * var(--ui-roundness));
+  color: var(--primary-text-color);
+  cursor: pointer;
+  display: grid;
+  font: inherit;
+  gap: 8px;
+  grid-template-columns: minmax(0, 1fr) 14px;
+  min-block-size: 45px;
+  padding-inline: 16px;
+  text-align: start;
+}
+
+.bulkMembersOnlySetting:is(:hover, :focus-visible) {
+  border-color: var(--primary-color);
+}
+
+.bulkMembersOnlySetting:focus-visible {
+  outline: 2px solid var(--primary-color);
+  outline-offset: -2px;
+}
+
+.bulkMembersOnlySetting:is(.enabled, .mixed) {
+  border-color: color-mix(in srgb, var(--primary-color) 55%, var(--border-color));
+}
+
+.bulkMembersOnlyLabel {
+  min-inline-size: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.bulkSettingCheck {
+  color: var(--primary-color);
+}
+
+.bulkDailyLimitSelect {
+  inline-size: 100%;
+}
+
 .channelSettingsScroller {
   flex: 1;
   min-block-size: 0;
@@ -36,11 +133,60 @@
   padding: 16px;
 }
 
+.channelSettings.selected {
+  border-color: color-mix(in srgb, var(--primary-color) 55%, var(--border-color));
+}
+
 .channelIdentity {
   align-items: center;
   display: flex;
   gap: 12px;
   min-inline-size: 0;
+}
+
+.channelSelectionOption {
+  align-items: center;
+  background: transparent;
+  border: 0;
+  color: var(--text-with-main-color);
+  cursor: pointer;
+  display: flex;
+  flex: none;
+  justify-content: center;
+  min-block-size: 44px;
+  min-inline-size: 44px;
+  padding: 0;
+  position: relative;
+}
+
+.channelSelectionOption::before {
+  block-size: 18px;
+  border: 2px solid var(--primary-text-color);
+  border-radius: calc(3px * var(--ui-roundness));
+  box-sizing: border-box;
+  content: '';
+  inline-size: 18px;
+  position: absolute;
+}
+
+.channelSelectionOption:is(:hover, :focus-visible)::before {
+  border-color: var(--primary-color);
+}
+
+.channelSelectionOption:focus-visible {
+  outline: 2px solid var(--primary-color);
+  outline-offset: -2px;
+}
+
+.channelSelectionOption.selected::before {
+  background-color: var(--primary-color);
+  border-color: var(--primary-color);
+}
+
+.channelSelectionOption .ft-icon {
+  font-size: 12px;
+  position: relative;
+  z-index: 1;
 }
 
 .channelThumbnail {
@@ -120,6 +266,11 @@
   color: var(--primary-text-color);
 }
 
+.feedTypeOption.mixed {
+  border-color: color-mix(in srgb, var(--primary-color) 55%, var(--border-color));
+  color: var(--primary-text-color);
+}
+
 .feedTypeOption > span {
   min-inline-size: 0;
   overflow: hidden;
@@ -129,6 +280,13 @@
 
 .feedTypeCheck {
   color: var(--primary-color);
+}
+
+.feedTypeMixedIndicator {
+  background-color: var(--primary-color);
+  block-size: 2px;
+  inline-size: 10px;
+  justify-self: center;
 }
 
 .membersOnlySetting,
@@ -143,6 +301,24 @@
 }
 
 @container (width <= 560px) {
+  .channelSelectionSummary {
+    align-items: stretch;
+    flex-direction: column;
+  }
+
+  .channelSelectionActions {
+    justify-content: stretch;
+  }
+
+  .channelSelectionActions :deep(.btn) {
+    block-size: auto;
+    flex: 1 1 0;
+    margin: 0;
+    min-inline-size: 0;
+    padding-inline: 8px;
+    white-space: normal;
+  }
+
   .feedTypeOptions {
     grid-template-columns: repeat(2, minmax(0, 1fr));
   }

--- a/src/renderer/components/SubscriptionChannelSettings/SubscriptionChannelSettings.vue
+++ b/src/renderer/components/SubscriptionChannelSettings/SubscriptionChannelSettings.vue
@@ -12,12 +12,11 @@
   >
     <div class="channelSettingsHeader">
       <FtInput
+        input-type="search"
         :placeholder="t('Settings.Channel Settings.Search Channels')"
         :show-action-button="false"
-        :show-clear-text-button="true"
         :value="searchQuery"
         @input="searchQuery = $event"
-        @clear="searchQuery = ''"
       />
     </div>
     <div
@@ -26,6 +25,126 @@
       class="channelSettingsScroller"
     >
       <div ref="channelSettingsContent">
+        <div
+          v-if="channels.length > 0"
+          class="channelSelectionToolbar"
+        >
+          <div class="channelSelectionSummary">
+            <p
+              :id="`${id}-selection-summary`"
+              aria-live="polite"
+            >
+              {{ selectedChannelCountText }}
+            </p>
+            <div class="channelSelectionActions">
+              <FtButton
+                :disabled="visibleChannels.length === 0 || allVisibleChannelsSelected"
+                @click="selectAllVisibleChannels"
+              >
+                <span>{{ t('Profile.Select All') }}</span>
+                <FtIcon
+                  class="channelSelectionActionIcon"
+                  :icon="['fas', 'check']"
+                  aria-hidden="true"
+                />
+              </FtButton>
+              <FtButton
+                :disabled="selectedChannelIds.size === 0"
+                @click="clearChannelSelection"
+              >
+                <span>{{ t('Profile.Select None') }}</span>
+                <FtIcon
+                  class="channelSelectionActionIcon"
+                  :icon="['fas', 'xmark']"
+                  aria-hidden="true"
+                />
+              </FtButton>
+            </div>
+          </div>
+          <div
+            v-if="selectedChannelIds.size > 0"
+            class="bulkFeedTypeSettings"
+            role="group"
+            :aria-labelledby="`${id}-selection-summary ${id}-bulk-feed-types`"
+          >
+            <p
+              :id="`${id}-bulk-feed-types`"
+              class="settingLabel"
+            >
+              {{ t('Channel.Show in subscription feed') }}
+            </p>
+            <div class="feedTypeOptions bulkFeedTypeOptions">
+              <button
+                v-for="feedType in feedTypes"
+                :key="feedType.id"
+                type="button"
+                class="feedTypeOption"
+                :class="{
+                  enabled: selectedFeedTypeState(feedType.id) === true,
+                  mixed: selectedFeedTypeState(feedType.id) === 'mixed'
+                }"
+                role="checkbox"
+                :aria-checked="selectedFeedTypeState(feedType.id)"
+                @click="updateSelectedFeedType(feedType.id)"
+              >
+                <FtIcon
+                  :icon="feedType.icon"
+                  aria-hidden="true"
+                />
+                <span>{{ feedType.label }}</span>
+                <FtIcon
+                  v-if="selectedFeedTypeState(feedType.id) === true"
+                  class="feedTypeCheck"
+                  :icon="['fas', 'check']"
+                  aria-hidden="true"
+                />
+                <span
+                  v-else-if="selectedFeedTypeState(feedType.id) === 'mixed'"
+                  class="feedTypeMixedIndicator"
+                  aria-hidden="true"
+                />
+              </button>
+            </div>
+            <div class="bulkAdditionalSettings">
+              <button
+                v-if="restrictedPlaybackConfigured"
+                type="button"
+                class="bulkMembersOnlySetting"
+                :class="{
+                  enabled: selectedMembersOnlyState === true,
+                  mixed: selectedMembersOnlyState === 'mixed'
+                }"
+                role="checkbox"
+                :aria-checked="selectedMembersOnlyState"
+                @click="updateSelectedShowMembersOnly"
+              >
+                <span class="bulkMembersOnlyLabel">
+                  {{ t('Search Listing.Label.Members Only') }}
+                </span>
+                <FtIcon
+                  v-if="selectedMembersOnlyState === true"
+                  class="bulkSettingCheck"
+                  :icon="['fas', 'check']"
+                  aria-hidden="true"
+                />
+                <span
+                  v-else-if="selectedMembersOnlyState === 'mixed'"
+                  class="feedTypeMixedIndicator"
+                  aria-hidden="true"
+                />
+              </button>
+              <FtSelect
+                class="bulkDailyLimitSelect"
+                :placeholder="t('Channel.Videos per day')"
+                :value="selectedDailyLimitValue"
+                :select-names="bulkLimitNames"
+                :select-values="bulkLimitValues"
+                :icon="['fas', 'clock']"
+                @change="updateSelectedChannelLimit"
+              />
+            </div>
+          </div>
+        </div>
         <p
           v-if="channels.length === 0"
           class="emptyState"
@@ -46,10 +165,26 @@
             v-for="(channel, index) in visibleChannels"
             :key="channel.id"
             class="channelSettings"
+            :class="{ selected: isChannelSelected(channel.id) }"
             role="group"
             :aria-labelledby="`${id}-channel-${index}`"
           >
             <div class="channelIdentity">
+              <button
+                type="button"
+                class="channelSelectionOption"
+                :class="{ selected: isChannelSelected(channel.id) }"
+                role="checkbox"
+                :aria-checked="isChannelSelected(channel.id)"
+                :aria-labelledby="`${id}-channel-${index}`"
+                @click="toggleChannelSelection(channel.id)"
+              >
+                <FtIcon
+                  v-if="isChannelSelected(channel.id)"
+                  :icon="['fas', 'check']"
+                  aria-hidden="true"
+                />
+              </button>
               <img
                 v-if="channel.thumbnail"
                 class="channelThumbnail"
@@ -170,6 +305,7 @@ const searchQuery = ref('')
 const channelSettingsScroller = useTemplateRef('channelSettingsScroller')
 const channelSettingsContent = useTemplateRef('channelSettingsContent')
 const optimisticChannelSettings = shallowRef(new Map())
+const selectedChannelIds = shallowRef(new Set())
 const restrictedPlaybackConfigured = computed(() => (
   hasConfiguredRestrictedPlaybackAuthentication(store.getters)
 ))
@@ -232,6 +368,39 @@ const feedTypes = computed(() => getSubscriptionFeedTypeOptions(t))
 const limitOptions = computed(() => getSubscriptionDailyVideoLimitOptions(t))
 const limitNames = computed(() => limitOptions.value.map(option => option.label))
 const limitValues = computed(() => limitOptions.value.map(option => option.value))
+const selectedChannels = computed(() => channels.value.filter(channel => (
+  selectedChannelIds.value.has(channel.id)
+)))
+const selectedChannelCountText = computed(() => t('Profile.{number} selected', {
+  number: selectedChannelIds.value.size
+}))
+const allVisibleChannelsSelected = computed(() => (
+  visibleChannels.value.length > 0 &&
+  visibleChannels.value.every(channel => selectedChannelIds.value.has(channel.id))
+))
+const selectedMembersOnlyState = computed(() => selectedState(channel => (
+  channelSettings(channel).showMembersOnly
+)))
+const selectedDailyLimitValue = computed(() => {
+  const values = selectedChannels.value.map(channelLimitValue)
+  return values.every(value => value === values[0]) ? values[0] : 'mixed'
+})
+const bulkLimitOptions = computed(() => selectedDailyLimitValue.value === 'mixed'
+  ? [{ value: 'mixed', label: t('Channel.Different values') }, ...limitOptions.value]
+  : limitOptions.value)
+const bulkLimitNames = computed(() => bulkLimitOptions.value.map(option => option.label))
+const bulkLimitValues = computed(() => bulkLimitOptions.value.map(option => option.value))
+
+watch(channels, (channelList) => {
+  const channelIds = new Set(channelList.map(channel => channel.id))
+  const nextSelection = new Set(
+    [...selectedChannelIds.value].filter(channelId => channelIds.has(channelId))
+  )
+
+  if (nextSelection.size !== selectedChannelIds.value.size) {
+    selectedChannelIds.value = nextSelection
+  }
+})
 
 /**
  * @typedef {object} SubscriptionChannel
@@ -254,6 +423,93 @@ function channelLimitValue(channel) {
  */
 function isFeedTypeEnabled(channel, feedType) {
   return channelSettings(channel).feedTypes.includes(feedType)
+}
+
+/**
+ * @param {string} channelId
+ */
+function isChannelSelected(channelId) {
+  return selectedChannelIds.value.has(channelId)
+}
+
+/**
+ * @param {string} channelId
+ */
+function toggleChannelSelection(channelId) {
+  const nextSelection = new Set(selectedChannelIds.value)
+  if (nextSelection.has(channelId)) {
+    nextSelection.delete(channelId)
+  } else {
+    nextSelection.add(channelId)
+  }
+  selectedChannelIds.value = nextSelection
+}
+
+function selectAllVisibleChannels() {
+  selectedChannelIds.value = new Set([
+    ...selectedChannelIds.value,
+    ...visibleChannels.value.map(channel => channel.id)
+  ])
+}
+
+function clearChannelSelection() {
+  selectedChannelIds.value = new Set()
+}
+
+/**
+ * @param {(channel: SubscriptionChannel) => boolean} isEnabled
+ * @returns {boolean | 'mixed'}
+ */
+function selectedState(isEnabled) {
+  const enabledCount = selectedChannels.value.filter(isEnabled).length
+
+  if (enabledCount === 0) return false
+  if (enabledCount === selectedChannels.value.length) return true
+  return 'mixed'
+}
+
+/**
+ * @param {'videos' | 'shorts' | 'live' | 'posts'} feedType
+ * @returns {boolean | 'mixed'}
+ */
+function selectedFeedTypeState(feedType) {
+  return selectedState(channel => (
+    isFeedTypeEnabled(channel, feedType)
+  ))
+}
+
+/**
+ * @param {'videos' | 'shorts' | 'live' | 'posts'} feedType
+ */
+function updateSelectedFeedType(feedType) {
+  const enabled = selectedFeedTypeState(feedType) !== true
+  selectedChannels.value.forEach((channel) => {
+    if (isFeedTypeEnabled(channel, feedType) !== enabled) {
+      updateFeedType(channel, feedType, enabled)
+    }
+  })
+}
+
+function updateSelectedShowMembersOnly() {
+  const enabled = selectedMembersOnlyState.value !== true
+  selectedChannels.value.forEach((channel) => {
+    if (channelSettings(channel).showMembersOnly !== enabled) {
+      updateShowMembersOnly(channel, enabled)
+    }
+  })
+}
+
+/**
+ * @param {string} value
+ */
+function updateSelectedChannelLimit(value) {
+  if (value === 'mixed') return
+
+  selectedChannels.value.forEach((channel) => {
+    if (channelLimitValue(channel) !== value) {
+      updateChannelLimit(channel, value)
+    }
+  })
 }
 
 /**

--- a/src/renderer/components/SubscriptionChannelSettings/SubscriptionChannelSettings.vue
+++ b/src/renderer/components/SubscriptionChannelSettings/SubscriptionChannelSettings.vue
@@ -80,11 +80,11 @@
                 type="button"
                 class="feedTypeOption"
                 :class="{
-                  enabled: selectedFeedTypeState(feedType.id) === true,
-                  mixed: selectedFeedTypeState(feedType.id) === 'mixed'
+                  enabled: selectedFeedTypeStates[feedType.id] === true,
+                  mixed: selectedFeedTypeStates[feedType.id] === 'mixed'
                 }"
                 role="checkbox"
-                :aria-checked="selectedFeedTypeState(feedType.id)"
+                :aria-checked="selectedFeedTypeStates[feedType.id]"
                 @click="updateSelectedFeedType(feedType.id)"
               >
                 <FtIcon
@@ -93,13 +93,13 @@
                 />
                 <span>{{ feedType.label }}</span>
                 <FtIcon
-                  v-if="selectedFeedTypeState(feedType.id) === true"
+                  v-if="selectedFeedTypeStates[feedType.id] === true"
                   class="feedTypeCheck"
                   :icon="['fas', 'check']"
                   aria-hidden="true"
                 />
                 <span
-                  v-else-if="selectedFeedTypeState(feedType.id) === 'mixed'"
+                  v-else-if="selectedFeedTypeStates[feedType.id] === 'mixed'"
                   class="feedTypeMixedIndicator"
                   aria-hidden="true"
                 />
@@ -313,6 +313,8 @@ const restrictedPlaybackConfigured = computed(() => (
 let contentResizeObserver = null
 let observationGeneration = 0
 let updateSequence = 0
+let pendingChannelSettingsUpdates = 0
+let hasFailedChannelSettingsUpdate = false
 let channelSettingsUpdateQueue = Promise.resolve()
 const latestUpdateByChannel = new Map()
 
@@ -478,6 +480,10 @@ function selectedFeedTypeState(feedType) {
   ))
 }
 
+const selectedFeedTypeStates = computed(() => Object.fromEntries(
+  feedTypes.value.map(({ id }) => [id, selectedFeedTypeState(id)])
+))
+
 /**
  * @param {'videos' | 'shorts' | 'live' | 'posts'} feedType
  */
@@ -561,6 +567,7 @@ function channelSettings(channel) {
 function persistChannelSettings(channel, patch) {
   const settings = { ...channelSettings(channel), ...patch }
   const sequence = ++updateSequence
+  pendingChannelSettingsUpdates += 1
   latestUpdateByChannel.set(channel.id, sequence)
   optimisticChannelSettings.value = new Map(optimisticChannelSettings.value)
     .set(channel.id, settings)
@@ -581,7 +588,10 @@ function persistChannelSettings(channel, patch) {
         optimisticChannelSettings.value = nextSettings
         latestUpdateByChannel.delete(channel.id)
       }
-      if (!saved) {
+      if (!saved) hasFailedChannelSettingsUpdate = true
+      pendingChannelSettingsUpdates -= 1
+      if (pendingChannelSettingsUpdates === 0 && hasFailedChannelSettingsUpdate) {
+        hasFailedChannelSettingsUpdate = false
         showToast({
           message: t('Channel.Failed to save subscription settings'),
           icon: ['fas', 'circle-exclamation']

--- a/src/renderer/components/SubscriptionChannelSettings/SubscriptionChannelSettings.vue
+++ b/src/renderer/components/SubscriptionChannelSettings/SubscriptionChannelSettings.vue
@@ -580,12 +580,12 @@ function persistChannelSettings(channel, patch) {
         nextSettings.delete(channel.id)
         optimisticChannelSettings.value = nextSettings
         latestUpdateByChannel.delete(channel.id)
-        if (!saved) {
-          showToast({
-            message: t('Channel.Failed to save subscription settings'),
-            icon: ['fas', 'circle-exclamation']
-          })
-        }
+      }
+      if (!saved) {
+        showToast({
+          message: t('Channel.Failed to save subscription settings'),
+          icon: ['fas', 'circle-exclamation']
+        })
       }
     }
   })

--- a/src/renderer/components/WatchVideoTranscript/WatchVideoTranscript.vue
+++ b/src/renderer/components/WatchVideoTranscript/WatchVideoTranscript.vue
@@ -93,12 +93,11 @@
       class="transcriptControls"
     >
       <FtInput
+        input-type="search"
         :value="searchQuery"
         :placeholder="t('Video.Transcript.Search')"
         :show-action-button="false"
-        :show-clear-text-button="true"
         @input="searchQuery = $event"
-        @clear="searchQuery = ''"
       />
     </div>
 

--- a/src/renderer/helpers/settingUpdateQueue.js
+++ b/src/renderer/helpers/settingUpdateQueue.js
@@ -1,0 +1,32 @@
+/**
+ * Runs setting writes in order while dropping queued values that have already
+ * been superseded. The callback can check whether an in-flight write is still
+ * current before committing its result.
+ */
+export function createSettingUpdateQueue() {
+  const latestUpdates = new Map()
+  const pendingUpdates = new Map()
+
+  return (settingId, update) => {
+    const token = {}
+    latestUpdates.set(settingId, token)
+
+    const previousUpdate = pendingUpdates.get(settingId) ?? Promise.resolve()
+    const pendingUpdate = previousUpdate
+      .catch(() => {})
+      .then(() => latestUpdates.get(settingId) === token
+        ? update(() => latestUpdates.get(settingId) === token)
+        : undefined)
+
+    pendingUpdates.set(settingId, pendingUpdate)
+
+    return pendingUpdate.finally(() => {
+      if (pendingUpdates.get(settingId) === pendingUpdate) {
+        pendingUpdates.delete(settingId)
+      }
+      if (latestUpdates.get(settingId) === token) {
+        latestUpdates.delete(settingId)
+      }
+    })
+  }
+}

--- a/src/renderer/store/modules/settings.js
+++ b/src/renderer/store/modules/settings.js
@@ -40,6 +40,7 @@ import { DEFAULT_HOME_SECTION_LAYOUT } from '../../helpers/homeSections.js'
 import { isSettingSyncableOnPlatform } from '../../helpers/platformSettings.js'
 import { CUSTOM_THEMES_SYNC_KEY } from '../../../customTheme.js'
 import { DEFAULT_QUICK_SETTINGS, normalizeQuickSettings } from '../../helpers/quickSettings.js'
+import { createSettingUpdateQueue } from '../../helpers/settingUpdateQueue.js'
 
 const CHANNEL_SETTINGS_SYNC_MIGRATION_SETTING = 'channelSettingsSyncMigration'
 const TUTORIAL_STATE_SETTING_IDS = new Set([
@@ -1489,6 +1490,7 @@ const customActions = {
 const getters = {}
 const mutations = {}
 const actions = {}
+const runSettingUpdate = createSettingUpdateQueue()
 
 // Build default getters, mutations and actions for every setting id
 for (const settingId of Object.keys(state)) {
@@ -1505,31 +1507,34 @@ for (const settingId of Object.keys(state)) {
     // If setting has side effects, generate action to handle them
     actions[triggerId] = sideEffectHandlers[settingId]
 
-    actions[updaterId] = async ({ commit, dispatch, state }, value) => {
-      try {
+    actions[updaterId] = ({ commit, dispatch, state }, value) => (
+      runSettingUpdate(settingId, async isLatest => {
         await DBSettingHandlers.upsert(settingId, value)
 
+        if (!isLatest()) return
         await recordSettingSyncTimestamp(commit, state, settingId)
 
+        if (!isLatest()) return
         dispatch(triggerId, value)
 
         commit(mutationId, value)
-      } catch (errMessage) {
+      }).catch(errMessage => {
         console.error(errMessage)
-      }
-    }
+      })
+    )
   } else {
-    actions[updaterId] = async ({ commit, state }, value) => {
-      try {
+    actions[updaterId] = ({ commit, state }, value) => (
+      runSettingUpdate(settingId, async isLatest => {
         await DBSettingHandlers.upsert(settingId, value)
 
+        if (!isLatest()) return
         await recordSettingSyncTimestamp(commit, state, settingId)
 
-        commit(mutationId, value)
-      } catch (errMessage) {
+        if (isLatest()) commit(mutationId, value)
+      }).catch(errMessage => {
         console.error(errMessage)
-      }
-    }
+      })
+    )
   }
 }
 

--- a/src/renderer/views/History/History.vue
+++ b/src/renderer/views/History/History.vue
@@ -37,12 +37,11 @@
         v-show="fullData.length > 1"
         ref="searchBar"
         class="historySearch"
+        input-type="search"
         :placeholder="t('History.Search bar placeholder')"
-        :show-clear-text-button="true"
         :show-action-button="false"
         :value="query"
         @input="handleQueryChange"
-        @clear="() => handleQueryChange('')"
       />
       <div
         v-if="fullData.length > 1"

--- a/src/renderer/views/SubscribedChannels/SubscribedChannels.vue
+++ b/src/renderer/views/SubscribedChannels/SubscribedChannels.vue
@@ -13,13 +13,12 @@
       <ft-input
         v-show="subscribedChannels.length > 1"
         ref="searchBarChannels"
+        input-type="search"
         :placeholder="$t('Channels.Search bar placeholder')"
         :value="query"
-        :show-clear-text-button="true"
         :show-action-button="false"
         :maxlength="255"
         @input="handleQueryChange"
-        @clear="() => handleQueryChange('')"
       />
       <ft-flex-box
         v-if="activeSubscriptionList.length === 0"

--- a/src/renderer/views/UserPlaylists/UserPlaylists.vue
+++ b/src/renderer/views/UserPlaylists/UserPlaylists.vue
@@ -24,13 +24,12 @@
         >
           <FtInput
             ref="searchBar"
+            input-type="search"
             :placeholder="$t('User Playlists.Search bar placeholder')"
             :value="query"
-            :show-clear-text-button="true"
             :show-action-button="false"
             :maxlength="255"
             @input="handleQueryChange"
-            @clear="() => handleQueryChange('')"
           />
         </div>
         <div

--- a/static/locales/ai/ar.yaml
+++ b/static/locales/ai/ar.yaml
@@ -976,7 +976,7 @@ Profile:
   Theme Color: لون الموضوع
 Channel:
   Subscription settings: إعدادات الاشتراك
-  Failed to save subscription settings: تعذّر حفظ إعدادات الاشتراك
+  Failed to save subscription settings: تعذّر حفظ إعدادات القناة
   Videos per day: مقاطع الفيديو يوميًا
   Different values: قيم مختلفة
   Use global setting: استخدام الإعداد العام

--- a/static/locales/ai/ar.yaml
+++ b/static/locales/ai/ar.yaml
@@ -532,6 +532,8 @@ Settings:
     Forget Channel: نسيان جميع إعدادات هذه القناة
     Forget Value: نسيان هذا الإعداد
     Add Setting: تذكر إعدادًا آخر لهذه القناة
+    Add Subscribed Channel: إضافة قناة مشترك بها
+    Enable Setting Before Adding Channel: فعّل إعداد قناة واحدًا على الأقل في إعدادات التشغيل قبل إضافة قناة
     Video Quality: جودة الفيديو
     Subtitles Enabled: تم تمكين الترجمات
     Volume: مستوى الصوت
@@ -976,6 +978,7 @@ Channel:
   Subscription settings: إعدادات الاشتراك
   Failed to save subscription settings: تعذّر حفظ إعدادات الاشتراك
   Videos per day: مقاطع الفيديو يوميًا
+  Different values: قيم مختلفة
   Use global setting: استخدام الإعداد العام
   Unlimited: بلا حدود
   More videos hidden: '+{count} مقاطع فيديو أخرى | +{count} مقطع فيديو آخر | +{count} مقطعا فيديو آخران | +{count} مقاطع فيديو أخرى | +{count} مقطع فيديو آخر | +{count} مقطع فيديو آخر'

--- a/static/locales/ai/be.yaml
+++ b/static/locales/ai/be.yaml
@@ -554,6 +554,8 @@ Settings:
     Forget Channel: Забыць усе налады гэтага канала
     Forget Value: Забыць гэту наладу
     Add Setting: Запомніць яшчэ адну наладу для гэтага канала
+    Add Subscribed Channel: Дадаць канал з падпісак
+    Enable Setting Before Adding Channel: Перад даданнем канала ўключыце хаця б адну наладу канала ў наладах прайгравання
     Video Quality: Якасць відэа
     Subtitles Enabled: Субцітры ўключаныя
     Volume: Гучнасць
@@ -1010,6 +1012,7 @@ Channel:
   Subscription settings: Налады падпіскі
   Failed to save subscription settings: Не ўдалося захаваць налады падпіскі
   Videos per day: Відэа за дзень
+  Different values: Розныя значэнні
   Use global setting: Выкарыстоўваць агульную наладу
   Unlimited: Без абмежаванняў
   More videos hidden: '+{count} яшчэ | +{count} яшчэ | +{count} яшчэ'

--- a/static/locales/ai/be.yaml
+++ b/static/locales/ai/be.yaml
@@ -1010,7 +1010,7 @@ Profile:
   Theme Color: Колер тэмы
 Channel:
   Subscription settings: Налады падпіскі
-  Failed to save subscription settings: Не ўдалося захаваць налады падпіскі
+  Failed to save subscription settings: Не ўдалося захаваць налады канала
   Videos per day: Відэа за дзень
   Different values: Розныя значэнні
   Use global setting: Выкарыстоўваць агульную наладу

--- a/static/locales/ai/bg.yaml
+++ b/static/locales/ai/bg.yaml
@@ -959,7 +959,7 @@ Profile:
   Theme Color: Цвят на темата
 Channel:
   Subscription settings: Настройки на абонамента
-  Failed to save subscription settings: Настройките за абонамента не можаха да бъдат запазени
+  Failed to save subscription settings: Настройките на канала не можаха да бъдат запазени
   Videos per day: Видеоклипове на ден
   Different values: Различни стойности
   Use global setting: Използване на глобалната настройка

--- a/static/locales/ai/bg.yaml
+++ b/static/locales/ai/bg.yaml
@@ -526,6 +526,8 @@ Settings:
     Forget Channel: Забравяне на всички настройки за този канал
     Forget Value: Забравяне на тази настройка
     Add Setting: Запомняне на още една настройка за този канал
+    Add Subscribed Channel: Добавяне на абониран канал
+    Enable Setting Before Adding Channel: Активирайте поне една настройка за канал в настройките за възпроизвеждане, преди да добавите канал
     Video Quality: Качество на видеоклипа
     Subtitles Enabled: Включени субтитри
     Volume: Сила на звука
@@ -959,6 +961,7 @@ Channel:
   Subscription settings: Настройки на абонамента
   Failed to save subscription settings: Настройките за абонамента не можаха да бъдат запазени
   Videos per day: Видеоклипове на ден
+  Different values: Различни стойности
   Use global setting: Използване на глобалната настройка
   Unlimited: Без ограничение
   More videos hidden: '+{count} още | +{count} още'

--- a/static/locales/ai/br.yaml
+++ b/static/locales/ai/br.yaml
@@ -524,6 +524,8 @@ Settings:
     Forget Channel: "Ankouaat holl arventennoù ar chadenn-mañ"
     Forget Value: "Ankouaat an arventenn-mañ"
     Add Setting: "Derc'hel soñj eus un arventenn all evit ar chadenn-mañ"
+    Add Subscribed Channel: Ouzhpennañ ur chadenn koumanantet
+    Enable Setting Before Adding Channel: Gweredekaat da nebeutañ un arventenn chadenn en arventennoù lenn a-raok ouzhpennañ ur chadenn
     Video Quality: "Perzhded ar video"
     Subtitles Enabled: "Istitloù gweredekaet"
     Volume: "Live ar son"
@@ -957,6 +959,7 @@ Channel:
   Subscription settings: Arventennoù ar c'houmanant
   Failed to save subscription settings: N'eus ket bet gallet enrollañ arventennoù ar c'houmanant
   Videos per day: Videoioù dre zevezh
+  Different values: Gwerzhioù disheñvel
   Use global setting: Ober gant an arventenn hollek
   Unlimited: Didermen
   More videos hidden: '+{count} ouzhpenn | +{count} ouzhpenn | +{count} ouzhpenn | +{count} ouzhpenn | +{count} ouzhpenn'

--- a/static/locales/ai/br.yaml
+++ b/static/locales/ai/br.yaml
@@ -957,7 +957,7 @@ Profile:
   Theme Color: "Liv an neuz"
 Channel:
   Subscription settings: Arventennoù ar c'houmanant
-  Failed to save subscription settings: N'eus ket bet gallet enrollañ arventennoù ar c'houmanant
+  Failed to save subscription settings: N'eus ket bet gallet enrollañ arventennoù ar chadenn
   Videos per day: Videoioù dre zevezh
   Different values: Gwerzhioù disheñvel
   Use global setting: Ober gant an arventenn hollek

--- a/static/locales/ai/ca.yaml
+++ b/static/locales/ai/ca.yaml
@@ -767,6 +767,8 @@ Settings:
     Forget Channel: Oblida tota la configuració d'aquest canal
     Forget Value: Oblida aquesta opció
     Add Setting: Recorda una altra opció per a aquest canal
+    Add Subscribed Channel: Afegeix un canal subscrit
+    Enable Setting Before Adding Channel: Activa almenys un paràmetre de canal a la configuració de reproducció abans d'afegir un canal
     Video Quality: Qualitat del vídeo
     Subtitles Enabled: Subtítols activats
     Volume: Volum
@@ -1316,6 +1318,7 @@ Channel:
   Subscription settings: Configuració de la subscripció
   Failed to save subscription settings: No s'han pogut desar els paràmetres de subscripció
   Videos per day: Vídeos per dia
+  Different values: Valors diferents
   Use global setting: Utilitza la configuració global
   Unlimited: Sense límit
   More videos hidden: '+{count} més | +{count} més | +{count} més'

--- a/static/locales/ai/ca.yaml
+++ b/static/locales/ai/ca.yaml
@@ -1316,7 +1316,7 @@ Profile:
   Open Profile Dropdown: Obre el desplegable del perfil
 Channel:
   Subscription settings: Configuració de la subscripció
-  Failed to save subscription settings: No s'han pogut desar els paràmetres de subscripció
+  Failed to save subscription settings: No s'han pogut desar els paràmetres del canal
   Videos per day: Vídeos per dia
   Different values: Valors diferents
   Use global setting: Utilitza la configuració global

--- a/static/locales/ai/cs.yaml
+++ b/static/locales/ai/cs.yaml
@@ -524,6 +524,8 @@ Settings:
     Forget Channel: Zapomenout všechna nastavení tohoto kanálu
     Forget Value: Zapomenout toto nastavení
     Add Setting: Zapamatovat si pro tento kanál další nastavení
+    Add Subscribed Channel: Přidat odebíraný kanál
+    Enable Setting Before Adding Channel: Před přidáním kanálu povolte alespoň jedno nastavení kanálu v nastavení přehrávání
     Video Quality: Kvalita videa
     Subtitles Enabled: Titulky zapnuté
     Volume: Hlasitost
@@ -957,6 +959,7 @@ Channel:
   Subscription settings: Nastavení odběru
   Failed to save subscription settings: Nastavení odběru se nepodařilo uložit
   Videos per day: Videa za den
+  Different values: Různé hodnoty
   Use global setting: Použít globální nastavení
   Unlimited: Bez omezení
   More videos hidden: '+{count} dalších | +{count} dalších | +{count} dalších'

--- a/static/locales/ai/cs.yaml
+++ b/static/locales/ai/cs.yaml
@@ -957,7 +957,7 @@ Profile:
   Theme Color: Barva motivu
 Channel:
   Subscription settings: Nastavení odběru
-  Failed to save subscription settings: Nastavení odběru se nepodařilo uložit
+  Failed to save subscription settings: Nastavení kanálu se nepodařilo uložit
   Videos per day: Videa za den
   Different values: Různé hodnoty
   Use global setting: Použít globální nastavení

--- a/static/locales/ai/cy.yaml
+++ b/static/locales/ai/cy.yaml
@@ -959,7 +959,7 @@ Profile:
   Theme Color: Lliw'r thema
 Channel:
   Subscription settings: Gosodiadau tanysgrifiad
-  Failed to save subscription settings: Methwyd cadw gosodiadau'r tanysgrifiad
+  Failed to save subscription settings: Methwyd cadw gosodiadau'r sianel
   Videos per day: Fideos y dydd
   Different values: Gwerthoedd gwahanol
   Use global setting: Defnyddio'r gosodiad cyffredinol

--- a/static/locales/ai/cy.yaml
+++ b/static/locales/ai/cy.yaml
@@ -526,6 +526,8 @@ Settings:
     Forget Channel: Anghofio pob gosodiad ar gyfer y sianel hon
     Forget Value: Anghofio'r gosodiad hwn
     Add Setting: Cofio gosodiad arall ar gyfer y sianel hon
+    Add Subscribed Channel: Ychwanegu sianel rydych wedi tanysgrifio iddi
+    Enable Setting Before Adding Channel: Galluogwch o leiaf un gosodiad sianel yn y gosodiadau chwarae cyn ychwanegu sianel
     Video Quality: Ansawdd fideo
     Subtitles Enabled: Isdeitlau wedi'u galluogi
     Volume: Lefel y sain
@@ -959,6 +961,7 @@ Channel:
   Subscription settings: Gosodiadau tanysgrifiad
   Failed to save subscription settings: Methwyd cadw gosodiadau'r tanysgrifiad
   Videos per day: Fideos y dydd
+  Different values: Gwerthoedd gwahanol
   Use global setting: Defnyddio'r gosodiad cyffredinol
   Unlimited: Diderfyn
   More videos hidden: '+{count} yn rhagor | +{count} yn rhagor | +{count} yn rhagor | +{count} yn rhagor | +{count} yn rhagor | +{count} yn rhagor'

--- a/static/locales/ai/da.yaml
+++ b/static/locales/ai/da.yaml
@@ -1006,7 +1006,7 @@ Profile:
   Theme Color: Temafarve
 Channel:
   Subscription settings: Abonnementsindstillinger
-  Failed to save subscription settings: Abonnementsindstillingerne kunne ikke gemmes
+  Failed to save subscription settings: Kanalindstillingerne kunne ikke gemmes
   Videos per day: Videoer pr. dag
   Different values: Forskellige værdier
   Use global setting: Brug global indstilling

--- a/static/locales/ai/da.yaml
+++ b/static/locales/ai/da.yaml
@@ -549,6 +549,8 @@ Settings:
     Forget Channel: Glem alle indstillinger for denne kanal
     Forget Value: Glem denne indstilling
     Add Setting: Husk endnu en indstilling for denne kanal
+    Add Subscribed Channel: Tilføj kanal, du abonnerer på
+    Enable Setting Before Adding Channel: Aktivér mindst én kanalindstilling under afspilningsindstillinger, før du tilføjer en kanal
     Video Quality: Videokvalitet
     Subtitles Enabled: Undertekster slået til
     Volume: Lydstyrke
@@ -1006,6 +1008,7 @@ Channel:
   Subscription settings: Abonnementsindstillinger
   Failed to save subscription settings: Abonnementsindstillingerne kunne ikke gemmes
   Videos per day: Videoer pr. dag
+  Different values: Forskellige værdier
   Use global setting: Brug global indstilling
   Unlimited: Ubegrænset
   More videos hidden: '+{count} mere | +{count} mere'

--- a/static/locales/ai/el.yaml
+++ b/static/locales/ai/el.yaml
@@ -981,7 +981,7 @@ Profile:
   Theme Color: Χρώμα θέματος
 Channel:
   Subscription settings: Ρυθμίσεις συνδρομής
-  Failed to save subscription settings: Δεν ήταν δυνατή η αποθήκευση των ρυθμίσεων συνδρομής
+  Failed to save subscription settings: Δεν ήταν δυνατή η αποθήκευση των ρυθμίσεων καναλιού
   Videos per day: Βίντεο ανά ημέρα
   Different values: Διαφορετικές τιμές
   Use global setting: Χρήση καθολικής ρύθμισης

--- a/static/locales/ai/el.yaml
+++ b/static/locales/ai/el.yaml
@@ -537,6 +537,8 @@ Settings:
     Forget Channel: Διαγραφή όλων των ρυθμίσεων αυτού του καναλιού
     Forget Value: Διαγραφή αυτής της ρύθμισης
     Add Setting: Απομνημόνευση άλλης ρύθμισης για αυτό το κανάλι
+    Add Subscribed Channel: Προσθήκη εγγεγραμμένου καναλιού
+    Enable Setting Before Adding Channel: Ενεργοποιήστε τουλάχιστον μία ρύθμιση καναλιού στις ρυθμίσεις αναπαραγωγής πριν προσθέσετε ένα κανάλι
     Video Quality: Ποιότητα βίντεο
     Subtitles Enabled: Υπότιτλοι ενεργοποιημένοι
     Volume: Ένταση ήχου
@@ -981,6 +983,7 @@ Channel:
   Subscription settings: Ρυθμίσεις συνδρομής
   Failed to save subscription settings: Δεν ήταν δυνατή η αποθήκευση των ρυθμίσεων συνδρομής
   Videos per day: Βίντεο ανά ημέρα
+  Different values: Διαφορετικές τιμές
   Use global setting: Χρήση καθολικής ρύθμισης
   Unlimited: Χωρίς όριο
   More videos hidden: '+{count} ακόμη | +{count} ακόμη'

--- a/static/locales/ai/en-GB.yaml
+++ b/static/locales/ai/en-GB.yaml
@@ -511,6 +511,8 @@ Settings:
     Forget Channel: Forget all settings for this channel
     Forget Value: Forget this setting
     Add Setting: Remember another setting for this channel
+    Add Subscribed Channel: Add subscribed channel
+    Enable Setting Before Adding Channel: Enable at least one channel setting in Playback settings before adding a channel
     Video Quality: Video Quality
     Subtitles Enabled: Subtitles Enabled
     Volume: Volume
@@ -935,6 +937,7 @@ Channel:
   Subscription settings: Subscription settings
   Failed to save subscription settings: Failed to save subscription settings
   Videos per day: Videos per day
+  Different values: Different values
   Use global setting: Use global setting
   Unlimited: Unlimited
   More videos hidden: '+{count} more | +{count} more'

--- a/static/locales/ai/en-GB.yaml
+++ b/static/locales/ai/en-GB.yaml
@@ -935,7 +935,7 @@ Profile:
   Theme Color: Theme Colour
 Channel:
   Subscription settings: Subscription settings
-  Failed to save subscription settings: Failed to save subscription settings
+  Failed to save subscription settings: Failed to save channel settings
   Videos per day: Videos per day
   Different values: Different values
   Use global setting: Use global setting

--- a/static/locales/ai/es-AR.yaml
+++ b/static/locales/ai/es-AR.yaml
@@ -608,6 +608,8 @@ Settings:
     Forget Channel: Olvidar todos los ajustes de este canal
     Forget Value: Olvidar este ajuste
     Add Setting: Recordar otro ajuste para este canal
+    Add Subscribed Channel: Añadir canal suscrito
+    Enable Setting Before Adding Channel: Activa al menos un ajuste de canal en los ajustes de reproducción antes de añadir un canal
     Video Quality: Calidad de video
     Subtitles Enabled: Subtítulos activados
     Volume: Volumen
@@ -1138,6 +1140,7 @@ Channel:
   Subscription settings: Configuración de la suscripción
   Failed to save subscription settings: No se pudo guardar la configuración de la suscripción
   Videos per day: Videos por día
+  Different values: Valores diferentes
   Use global setting: Usar configuración global
   Unlimited: Sin límite
   More videos hidden: '+{count} más | +{count} más | +{count} más'

--- a/static/locales/ai/es-AR.yaml
+++ b/static/locales/ai/es-AR.yaml
@@ -1138,7 +1138,7 @@ Profile:
   Open Profile Dropdown: Abrir el desplegable del Perfil
 Channel:
   Subscription settings: Configuración de la suscripción
-  Failed to save subscription settings: No se pudo guardar la configuración de la suscripción
+  Failed to save subscription settings: No se pudo guardar la configuración del canal
   Videos per day: Videos por día
   Different values: Valores diferentes
   Use global setting: Usar configuración global

--- a/static/locales/ai/es-MX.yaml
+++ b/static/locales/ai/es-MX.yaml
@@ -1171,7 +1171,7 @@ Profile:
   Open Profile Dropdown: Abrir el desplegable del Perfil
 Channel:
   Subscription settings: Configuración de la suscripción
-  Failed to save subscription settings: No se pudo guardar la configuración de la suscripción
+  Failed to save subscription settings: No se pudo guardar la configuración del canal
   Videos per day: Videos por día
   Different values: Valores diferentes
   Use global setting: Usar configuración global

--- a/static/locales/ai/es-MX.yaml
+++ b/static/locales/ai/es-MX.yaml
@@ -642,6 +642,8 @@ Settings:
     Forget Channel: Olvidar todos los ajustes de este canal
     Forget Value: Olvidar este ajuste
     Add Setting: Recordar otro ajuste para este canal
+    Add Subscribed Channel: Añadir canal suscrito
+    Enable Setting Before Adding Channel: Activa al menos un ajuste de canal en los ajustes de reproducción antes de añadir un canal
     Video Quality: Calidad de video
     Subtitles Enabled: Subtítulos activados
     Volume: Volumen
@@ -1171,6 +1173,7 @@ Channel:
   Subscription settings: Configuración de la suscripción
   Failed to save subscription settings: No se pudo guardar la configuración de la suscripción
   Videos per day: Videos por día
+  Different values: Valores diferentes
   Use global setting: Usar configuración global
   Unlimited: Sin límite
   More videos hidden: '+{count} más | +{count} más | +{count} más'

--- a/static/locales/ai/es.yaml
+++ b/static/locales/ai/es.yaml
@@ -972,7 +972,7 @@ Profile:
   Theme Color: Color del tema
 Channel:
   Subscription settings: Configuración de la suscripción
-  Failed to save subscription settings: No se pudo guardar la configuración de la suscripción
+  Failed to save subscription settings: No se pudo guardar la configuración del canal
   Videos per day: Vídeos por día
   Different values: Valores diferentes
   Use global setting: Usar configuración global

--- a/static/locales/ai/es.yaml
+++ b/static/locales/ai/es.yaml
@@ -530,6 +530,8 @@ Settings:
     Forget Channel: Olvidar todos los ajustes de este canal
     Forget Value: Olvidar este ajuste
     Add Setting: Recordar otro ajuste para este canal
+    Add Subscribed Channel: Añadir canal suscrito
+    Enable Setting Before Adding Channel: Activa al menos un ajuste de canal en los ajustes de reproducción antes de añadir un canal
     Video Quality: Calidad de vídeo
     Subtitles Enabled: Subtítulos activados
     Volume: Volumen
@@ -972,6 +974,7 @@ Channel:
   Subscription settings: Configuración de la suscripción
   Failed to save subscription settings: No se pudo guardar la configuración de la suscripción
   Videos per day: Vídeos por día
+  Different values: Valores diferentes
   Use global setting: Usar configuración global
   Unlimited: Sin límite
   More videos hidden: '+{count} más | +{count} más | +{count} más'

--- a/static/locales/ai/et.yaml
+++ b/static/locales/ai/et.yaml
@@ -957,7 +957,7 @@ Profile:
   Theme Color: Kujunduse värv
 Channel:
   Subscription settings: Tellimuse seaded
-  Failed to save subscription settings: Tellimuse seadeid ei õnnestunud salvestada
+  Failed to save subscription settings: Kanali seadeid ei õnnestunud salvestada
   Videos per day: Videoid päevas
   Different values: Erinevad väärtused
   Use global setting: Kasuta üldist seadet

--- a/static/locales/ai/et.yaml
+++ b/static/locales/ai/et.yaml
@@ -524,6 +524,8 @@ Settings:
     Forget Channel: Unusta kõik selle kanali seaded
     Forget Value: Unusta see seade
     Add Setting: Jäta selle kanali jaoks meelde veel üks seade
+    Add Subscribed Channel: Lisa tellitud kanal
+    Enable Setting Before Adding Channel: Enne kanali lisamist luba taasesituse seadetes vähemalt üks kanaliseade
     Video Quality: Video kvaliteet
     Subtitles Enabled: Subtiitrid lubatud
     Volume: Helitugevus
@@ -957,6 +959,7 @@ Channel:
   Subscription settings: Tellimuse seaded
   Failed to save subscription settings: Tellimuse seadeid ei õnnestunud salvestada
   Videos per day: Videoid päevas
+  Different values: Erinevad väärtused
   Use global setting: Kasuta üldist seadet
   Unlimited: Piiramata
   More videos hidden: '+{count} veel | +{count} veel'

--- a/static/locales/ai/eu.yaml
+++ b/static/locales/ai/eu.yaml
@@ -526,6 +526,8 @@ Settings:
     Forget Channel: Ahaztu kanal honen ezarpen guztiak
     Forget Value: Ahaztu ezarpen hau
     Add Setting: Gogoratu beste ezarpen bat kanal honetarako
+    Add Subscribed Channel: Gehitu harpidetutako kanal bat
+    Enable Setting Before Adding Channel: Gaitu gutxienez kanal-ezarpen bat erreprodukzio-ezarpenetan kanal bat gehitu aurretik
     Video Quality: Bideo-kalitatea
     Subtitles Enabled: Azpitituluak gaituta
     Volume: Bolumena
@@ -959,6 +961,7 @@ Channel:
   Subscription settings: Harpidetzaren ezarpenak
   Failed to save subscription settings: Ezin izan dira harpidetzaren ezarpenak gorde
   Videos per day: Eguneko bideoak
+  Different values: Balio desberdinak
   Use global setting: Erabili ezarpen orokorra
   Unlimited: Mugagabea
   More videos hidden: '+{count} gehiago | +{count} gehiago'

--- a/static/locales/ai/eu.yaml
+++ b/static/locales/ai/eu.yaml
@@ -959,7 +959,7 @@ Profile:
   Theme Color: Gaiaren kolorea
 Channel:
   Subscription settings: Harpidetzaren ezarpenak
-  Failed to save subscription settings: Ezin izan dira harpidetzaren ezarpenak gorde
+  Failed to save subscription settings: Ezin izan dira kanalaren ezarpenak gorde
   Videos per day: Eguneko bideoak
   Different values: Balio desberdinak
   Use global setting: Erabili ezarpen orokorra

--- a/static/locales/ai/fa.yaml
+++ b/static/locales/ai/fa.yaml
@@ -554,6 +554,8 @@ Settings:
     Forget Channel: فراموش‌کردن همهٔ تنظیمات این کانال
     Forget Value: فراموش‌کردن این تنظیم
     Add Setting: به‌خاطر سپردن تنظیمی دیگر برای این کانال
+    Add Subscribed Channel: افزودن کانال مشترک‌شده
+    Enable Setting Before Adding Channel: پیش از افزودن کانال، حداقل یکی از تنظیمات کانال را در تنظیمات پخش فعال کنید
     Video Quality: کیفیت ویدیو
     Subtitles Enabled: زیرنویس فعال است
     Volume: بلندی صدا
@@ -1007,6 +1009,7 @@ Channel:
   Subscription settings: تنظیمات اشتراک
   Failed to save subscription settings: تنظیمات اشتراک ذخیره نشد
   Videos per day: ویدیو در روز
+  Different values: مقادیر متفاوت
   Use global setting: استفاده از تنظیم سراسری
   Unlimited: نامحدود
   More videos hidden: '+{count} ویدیوی دیگر | +{count} ویدیوی دیگر'

--- a/static/locales/ai/fa.yaml
+++ b/static/locales/ai/fa.yaml
@@ -1007,7 +1007,7 @@ Profile:
   Theme Color: رنگ پوسته
 Channel:
   Subscription settings: تنظیمات اشتراک
-  Failed to save subscription settings: تنظیمات اشتراک ذخیره نشد
+  Failed to save subscription settings: تنظیمات کانال ذخیره نشد
   Videos per day: ویدیو در روز
   Different values: مقادیر متفاوت
   Use global setting: استفاده از تنظیم سراسری

--- a/static/locales/ai/fi.yaml
+++ b/static/locales/ai/fi.yaml
@@ -537,6 +537,8 @@ Settings:
     Forget Channel: Poista tämän kanavan kaikki asetukset
     Forget Value: Poista tämä asetus
     Add Setting: Muista toinen asetus tälle kanavalle
+    Add Subscribed Channel: Lisää tilattu kanava
+    Enable Setting Before Adding Channel: Ota ennen kanavan lisäämistä käyttöön vähintään yksi kanava-asetus toistoasetuksissa
     Video Quality: Videon laatu
     Subtitles Enabled: Tekstitys käytössä
     Volume: Äänenvoimakkuus
@@ -981,6 +983,7 @@ Channel:
   Subscription settings: Tilausasetukset
   Failed to save subscription settings: Tilausasetusten tallentaminen epäonnistui
   Videos per day: Videoita päivässä
+  Different values: Eri arvot
   Use global setting: Käytä yleistä asetusta
   Unlimited: Rajoittamaton
   More videos hidden: '+{count} lisää | +{count} lisää'

--- a/static/locales/ai/fi.yaml
+++ b/static/locales/ai/fi.yaml
@@ -981,7 +981,7 @@ Profile:
   Theme Color: Teemaväri
 Channel:
   Subscription settings: Tilausasetukset
-  Failed to save subscription settings: Tilausasetusten tallentaminen epäonnistui
+  Failed to save subscription settings: Kanava-asetusten tallentaminen epäonnistui
   Videos per day: Videoita päivässä
   Different values: Eri arvot
   Use global setting: Käytä yleistä asetusta

--- a/static/locales/ai/fr-FR.yaml
+++ b/static/locales/ai/fr-FR.yaml
@@ -524,6 +524,8 @@ Settings:
     Forget Channel: Oublier tous les paramètres de cette chaîne
     Forget Value: Oublier ce paramètre
     Add Setting: Mémoriser un autre paramètre pour cette chaîne
+    Add Subscribed Channel: Ajouter une chaîne suivie
+    Enable Setting Before Adding Channel: Activez au moins un paramètre de chaîne dans les paramètres de lecture avant d'ajouter une chaîne
     Video Quality: Qualité vidéo
     Subtitles Enabled: Sous-titres activés
     Volume: Volume
@@ -956,6 +958,7 @@ Channel:
   Subscription settings: Paramètres d'abonnement
   Failed to save subscription settings: Impossible d’enregistrer les paramètres d’abonnement
   Videos per day: Vidéos par jour
+  Different values: Valeurs différentes
   Use global setting: Utiliser le paramètre général
   Unlimited: Illimité
   More videos hidden: '+{count} de plus | +{count} de plus | +{count} de plus'

--- a/static/locales/ai/fr-FR.yaml
+++ b/static/locales/ai/fr-FR.yaml
@@ -956,7 +956,7 @@ Profile:
   Theme Color: Couleur du thème
 Channel:
   Subscription settings: Paramètres d'abonnement
-  Failed to save subscription settings: Impossible d’enregistrer les paramètres d’abonnement
+  Failed to save subscription settings: Impossible d’enregistrer les paramètres de la chaîne
   Videos per day: Vidéos par jour
   Different values: Valeurs différentes
   Use global setting: Utiliser le paramètre général

--- a/static/locales/ai/gl.yaml
+++ b/static/locales/ai/gl.yaml
@@ -532,6 +532,8 @@ Settings:
     Forget Channel: Esquecer toda a configuración desta canle
     Forget Value: Esquecer este axuste
     Add Setting: Lembrar outro axuste para esta canle
+    Add Subscribed Channel: Engadir unha canle subscrita
+    Enable Setting Before Adding Channel: Activa polo menos unha configuración de canle nos axustes de reprodución antes de engadir unha canle
     Video Quality: Calidade do vídeo
     Subtitles Enabled: Subtítulos activados
     Volume: Volume
@@ -976,6 +978,7 @@ Channel:
   Subscription settings: Configuración da subscrición
   Failed to save subscription settings: Non se puido gardar a configuración da subscrición
   Videos per day: Vídeos ao día
+  Different values: Valores diferentes
   Use global setting: Usar a configuración global
   Unlimited: Sen límite
   More videos hidden: '+{count} máis | +{count} máis'

--- a/static/locales/ai/gl.yaml
+++ b/static/locales/ai/gl.yaml
@@ -976,7 +976,7 @@ Profile:
   Theme Color: Cor do tema
 Channel:
   Subscription settings: Configuración da subscrición
-  Failed to save subscription settings: Non se puido gardar a configuración da subscrición
+  Failed to save subscription settings: Non se puido gardar a configuración da canle
   Videos per day: Vídeos ao día
   Different values: Valores diferentes
   Use global setting: Usar a configuración global

--- a/static/locales/ai/he.yaml
+++ b/static/locales/ai/he.yaml
@@ -537,6 +537,8 @@ Settings:
     Forget Channel: הסרת כל ההגדרות של ערוץ זה
     Forget Value: הסרת הגדרה זו
     Add Setting: שמירת הגדרה נוספת לערוץ זה
+    Add Subscribed Channel: הוספת ערוץ שנרשמת אליו
+    Enable Setting Before Adding Channel: יש להפעיל לפחות הגדרת ערוץ אחת בהגדרות ההפעלה לפני הוספת ערוץ
     Video Quality: איכות וידאו
     Subtitles Enabled: הכתוביות מופעלות
     Volume: עוצמת קול
@@ -981,6 +983,7 @@ Channel:
   Subscription settings: הגדרות מינוי
   Failed to save subscription settings: לא ניתן לשמור את הגדרות המינוי
   Videos per day: סרטונים ביום
+  Different values: ערכים שונים
   Use global setting: שימוש בהגדרה הכללית
   Unlimited: ללא הגבלה
   More videos hidden: '+{count} נוספים | +{count} נוספים | +{count} נוספים'

--- a/static/locales/ai/he.yaml
+++ b/static/locales/ai/he.yaml
@@ -981,7 +981,7 @@ Profile:
   Theme Color: צבע ערכת הנושא
 Channel:
   Subscription settings: הגדרות מינוי
-  Failed to save subscription settings: לא ניתן לשמור את הגדרות המינוי
+  Failed to save subscription settings: לא ניתן לשמור את הגדרות הערוץ
   Videos per day: סרטונים ביום
   Different values: ערכים שונים
   Use global setting: שימוש בהגדרה הכללית

--- a/static/locales/ai/hr.yaml
+++ b/static/locales/ai/hr.yaml
@@ -526,6 +526,8 @@ Settings:
     Forget Channel: Zaboravi sve postavke za ovaj kanal
     Forget Value: Zaboravi ovu postavku
     Add Setting: Zapamti još jednu postavku za ovaj kanal
+    Add Subscribed Channel: Dodaj kanal na koji ste pretplaćeni
+    Enable Setting Before Adding Channel: Prije dodavanja kanala omogućite barem jednu postavku kanala u postavkama reprodukcije
     Video Quality: Kvaliteta videozapisa
     Subtitles Enabled: Titlovi su omogućeni
     Volume: Glasnoća
@@ -959,6 +961,7 @@ Channel:
   Subscription settings: Postavke pretplate
   Failed to save subscription settings: Nije moguće spremiti postavke pretplate
   Videos per day: Videozapisa dnevno
+  Different values: Različite vrijednosti
   Use global setting: Koristi globalnu postavku
   Unlimited: Neograničeno
   More videos hidden: '+{count} više | +{count} više | +{count} više'

--- a/static/locales/ai/hr.yaml
+++ b/static/locales/ai/hr.yaml
@@ -959,7 +959,7 @@ Profile:
   Theme Color: Boja teme
 Channel:
   Subscription settings: Postavke pretplate
-  Failed to save subscription settings: Nije moguće spremiti postavke pretplate
+  Failed to save subscription settings: Nije moguće spremiti postavke kanala
   Videos per day: Videozapisa dnevno
   Different values: Različite vrijednosti
   Use global setting: Koristi globalnu postavku

--- a/static/locales/ai/hu.yaml
+++ b/static/locales/ai/hu.yaml
@@ -957,7 +957,7 @@ Profile:
   Theme Color: Téma színe
 Channel:
   Subscription settings: Feliratkozási beállítások
-  Failed to save subscription settings: Nem sikerült menteni a feliratkozási beállításokat
+  Failed to save subscription settings: Nem sikerült menteni a csatornabeállításokat
   Videos per day: Videók naponta
   Different values: Eltérő értékek
   Use global setting: Globális beállítás használata

--- a/static/locales/ai/hu.yaml
+++ b/static/locales/ai/hu.yaml
@@ -524,6 +524,8 @@ Settings:
     Forget Channel: A csatorna összes beállításának elfelejtése
     Forget Value: Beállítás elfelejtése
     Add Setting: További beállítás megjegyzése ennél a csatornánál
+    Add Subscribed Channel: Feliratkozott csatorna hozzáadása
+    Enable Setting Before Adding Channel: Csatorna hozzáadása előtt engedélyezz legalább egy csatornabeállítást a lejátszási beállításokban
     Video Quality: Videóminőség
     Subtitles Enabled: Feliratok engedélyezve
     Volume: Hangerő
@@ -957,6 +959,7 @@ Channel:
   Subscription settings: Feliratkozási beállítások
   Failed to save subscription settings: Nem sikerült menteni a feliratkozási beállításokat
   Videos per day: Videók naponta
+  Different values: Eltérő értékek
   Use global setting: Globális beállítás használata
   Unlimited: Korlátlan
   More videos hidden: '+{count} további | +{count} további'

--- a/static/locales/ai/id.yaml
+++ b/static/locales/ai/id.yaml
@@ -532,6 +532,8 @@ Settings:
     Forget Channel: Lupakan semua pengaturan untuk saluran ini
     Forget Value: Lupakan pengaturan ini
     Add Setting: Ingat pengaturan lain untuk saluran ini
+    Add Subscribed Channel: Tambahkan channel langganan
+    Enable Setting Before Adding Channel: Aktifkan setidaknya satu pengaturan channel di pengaturan Pemutaran sebelum menambahkan channel
     Video Quality: Kualitas Video
     Subtitles Enabled: Takarir Diaktifkan
     Volume: Volume
@@ -974,6 +976,7 @@ Channel:
   Subscription settings: Pengaturan langganan
   Failed to save subscription settings: Gagal menyimpan pengaturan langganan
   Videos per day: Video per hari
+  Different values: Nilai berbeda
   Use global setting: Gunakan pengaturan global
   Unlimited: Tanpa batas
   More videos hidden: '+{count} lainnya'

--- a/static/locales/ai/id.yaml
+++ b/static/locales/ai/id.yaml
@@ -974,7 +974,7 @@ Profile:
   Theme Color: Warna Tema
 Channel:
   Subscription settings: Pengaturan langganan
-  Failed to save subscription settings: Gagal menyimpan pengaturan langganan
+  Failed to save subscription settings: Gagal menyimpan pengaturan saluran
   Videos per day: Video per hari
   Different values: Nilai berbeda
   Use global setting: Gunakan pengaturan global

--- a/static/locales/ai/is.yaml
+++ b/static/locales/ai/is.yaml
@@ -974,7 +974,7 @@ Profile:
   Theme Color: Þemalitur
 Channel:
   Subscription settings: Áskriftarstillingar
-  Failed to save subscription settings: Ekki tókst að vista áskriftarstillingar
+  Failed to save subscription settings: Ekki tókst að vista rásarstillingar
   Videos per day: Myndskeið á dag
   Different values: Mismunandi gildi
   Use global setting: Nota almenna stillingu

--- a/static/locales/ai/is.yaml
+++ b/static/locales/ai/is.yaml
@@ -532,6 +532,8 @@ Settings:
     Forget Channel: Gleyma öllum stillingum þessarar rásar
     Forget Value: Gleyma þessari stillingu
     Add Setting: Muna aðra stillingu fyrir þessa rás
+    Add Subscribed Channel: Bæta við áskriftarrás
+    Enable Setting Before Adding Channel: Virkjaðu að minnsta kosti eina rásarstillingu í spilunarstillingum áður en þú bætir við rás
     Video Quality: Myndgæði
     Subtitles Enabled: Skjátextar virkir
     Volume: Hljóðstyrkur
@@ -974,6 +976,7 @@ Channel:
   Subscription settings: Áskriftarstillingar
   Failed to save subscription settings: Ekki tókst að vista áskriftarstillingar
   Videos per day: Myndskeið á dag
+  Different values: Mismunandi gildi
   Use global setting: Nota almenna stillingu
   Unlimited: Ótakmarkað
   More videos hidden: '+{count} til viðbótar | +{count} til viðbótar'

--- a/static/locales/ai/it.yaml
+++ b/static/locales/ai/it.yaml
@@ -524,6 +524,8 @@ Settings:
     Forget Channel: Dimentica tutte le impostazioni di questo canale
     Forget Value: Dimentica questa impostazione
     Add Setting: Ricorda un'altra impostazione per questo canale
+    Add Subscribed Channel: Aggiungi canale a cui sei iscritto
+    Enable Setting Before Adding Channel: Attiva almeno un'impostazione del canale nelle impostazioni di riproduzione prima di aggiungere un canale
     Video Quality: Qualità video
     Subtitles Enabled: Sottotitoli abilitati
     Volume: Volume
@@ -957,6 +959,7 @@ Channel:
   Subscription settings: Impostazioni iscrizione
   Failed to save subscription settings: Impossibile salvare le impostazioni dell’iscrizione
   Videos per day: Video al giorno
+  Different values: Valori diversi
   Use global setting: Usa impostazione globale
   Unlimited: Senza limiti
   More videos hidden: '+{count} altri | +{count} altri | +{count} altri'

--- a/static/locales/ai/it.yaml
+++ b/static/locales/ai/it.yaml
@@ -957,7 +957,7 @@ Profile:
   Theme Color: Colore del tema
 Channel:
   Subscription settings: Impostazioni iscrizione
-  Failed to save subscription settings: Impossibile salvare le impostazioni dell’iscrizione
+  Failed to save subscription settings: Impossibile salvare le impostazioni del canale
   Videos per day: Video al giorno
   Different values: Valori diversi
   Use global setting: Usa impostazione globale

--- a/static/locales/ai/ja.yaml
+++ b/static/locales/ai/ja.yaml
@@ -957,7 +957,7 @@ Profile:
   Theme Color: テーマカラー
 Channel:
   Subscription settings: 登録設定
-  Failed to save subscription settings: 登録設定を保存できませんでした
+  Failed to save subscription settings: チャンネル設定を保存できませんでした
   Videos per day: 1日あたりの動画数
   Different values: 異なる値
   Use global setting: 全体設定を使用

--- a/static/locales/ai/ja.yaml
+++ b/static/locales/ai/ja.yaml
@@ -524,6 +524,8 @@ Settings:
     Forget Channel: このチャンネルの設定をすべて削除
     Forget Value: この設定を削除
     Add Setting: このチャンネルで別の設定を記憶
+    Add Subscribed Channel: 登録チャンネルを追加
+    Enable Setting Before Adding Channel: チャンネルを追加する前に、再生設定でチャンネル設定を1つ以上有効にしてください
     Video Quality: 動画品質
     Subtitles Enabled: 字幕を有効化
     Volume: 音量
@@ -957,6 +959,7 @@ Channel:
   Subscription settings: 登録設定
   Failed to save subscription settings: 登録設定を保存できませんでした
   Videos per day: 1日あたりの動画数
+  Different values: 異なる値
   Use global setting: 全体設定を使用
   Unlimited: 無制限
   More videos hidden: '他{count}件'

--- a/static/locales/ai/ko.yaml
+++ b/static/locales/ai/ko.yaml
@@ -699,6 +699,8 @@ Settings:
     Forget Channel: 이 채널의 모든 설정 삭제
     Forget Value: 이 설정 삭제
     Add Setting: 이 채널에 다른 설정 저장
+    Add Subscribed Channel: 구독 채널 추가
+    Enable Setting Before Adding Channel: 채널을 추가하기 전에 재생 설정에서 채널 설정을 하나 이상 활성화하세요
     Video Quality: 동영상 화질
     Subtitles Enabled: 자막 활성화됨
     Volume: 음량
@@ -1211,6 +1213,7 @@ Channel:
   Subscription settings: 구독 설정
   Failed to save subscription settings: 구독 설정을 저장하지 못했습니다
   Videos per day: 일일 동영상 수
+  Different values: 서로 다른 값
   Use global setting: 전역 설정 사용
   Unlimited: 무제한
   More videos hidden: '+{count}개 더'

--- a/static/locales/ai/ko.yaml
+++ b/static/locales/ai/ko.yaml
@@ -1211,7 +1211,7 @@ Profile:
   Open Profile Dropdown: 프로필 드롭다운 열기
 Channel:
   Subscription settings: 구독 설정
-  Failed to save subscription settings: 구독 설정을 저장하지 못했습니다
+  Failed to save subscription settings: 채널 설정을 저장하지 못했습니다
   Videos per day: 일일 동영상 수
   Different values: 서로 다른 값
   Use global setting: 전역 설정 사용

--- a/static/locales/ai/lt.yaml
+++ b/static/locales/ai/lt.yaml
@@ -724,6 +724,8 @@ Settings:
     Forget Channel: Pamiršti visus šio kanalo nustatymus
     Forget Value: Pamiršti šį nustatymą
     Add Setting: Įsiminti kitą šio kanalo nustatymą
+    Add Subscribed Channel: Pridėti prenumeruojamą kanalą
+    Enable Setting Before Adding Channel: Prieš pridėdami kanalą, atkūrimo nustatymuose įjunkite bent vieną kanalo nustatymą
     Video Quality: Vaizdo kokybė
     Subtitles Enabled: Subtitrai įjungti
     Volume: Garsumas
@@ -1233,6 +1235,7 @@ Channel:
   Subscription settings: Prenumeratos nustatymai
   Failed to save subscription settings: Nepavyko išsaugoti prenumeratos nustatymų
   Videos per day: Vaizdo įrašų per dieną
+  Different values: Skirtingos reikšmės
   Use global setting: Naudoti bendrąjį nustatymą
   Unlimited: Neribota
   More videos hidden: '+{count} daugiau | +{count} daugiau | +{count} daugiau'

--- a/static/locales/ai/lt.yaml
+++ b/static/locales/ai/lt.yaml
@@ -1233,7 +1233,7 @@ Profile:
   Open Profile Dropdown: Atverti profilio išskleidžiamąjį meniu
 Channel:
   Subscription settings: Prenumeratos nustatymai
-  Failed to save subscription settings: Nepavyko išsaugoti prenumeratos nustatymų
+  Failed to save subscription settings: Nepavyko išsaugoti kanalo nustatymų
   Videos per day: Vaizdo įrašų per dieną
   Different values: Skirtingos reikšmės
   Use global setting: Naudoti bendrąjį nustatymą

--- a/static/locales/ai/nb-NO.yaml
+++ b/static/locales/ai/nb-NO.yaml
@@ -976,7 +976,7 @@ Profile:
   Theme Color: Temafarge
 Channel:
   Subscription settings: Abonnementsinnstillinger
-  Failed to save subscription settings: Kunne ikke lagre abonnementsinnstillingene
+  Failed to save subscription settings: Kunne ikke lagre kanalinnstillingene
   Videos per day: Videoer per dag
   Different values: Ulike verdier
   Use global setting: Bruk global innstilling

--- a/static/locales/ai/nb-NO.yaml
+++ b/static/locales/ai/nb-NO.yaml
@@ -532,6 +532,8 @@ Settings:
     Forget Channel: Glem alle innstillingene for denne kanalen
     Forget Value: Glem denne innstillingen
     Add Setting: Husk en annen innstilling for denne kanalen
+    Add Subscribed Channel: Legg til kanal du abonnerer på
+    Enable Setting Before Adding Channel: Aktiver minst én kanalinnstilling i avspillingsinnstillingene før du legger til en kanal
     Video Quality: Videokvalitet
     Subtitles Enabled: Undertekster slått på
     Volume: Lydstyrke
@@ -976,6 +978,7 @@ Channel:
   Subscription settings: Abonnementsinnstillinger
   Failed to save subscription settings: Kunne ikke lagre abonnementsinnstillingene
   Videos per day: Videoer per dag
+  Different values: Ulike verdier
   Use global setting: Bruk global innstilling
   Unlimited: Ubegrenset
   More videos hidden: '+{count} til | +{count} til'

--- a/static/locales/ai/nl.yaml
+++ b/static/locales/ai/nl.yaml
@@ -984,7 +984,7 @@ Profile:
   Theme Color: Themakleur
 Channel:
   Subscription settings: Abonnementsinstellingen
-  Failed to save subscription settings: Kan de abonnementsinstellingen niet opslaan
+  Failed to save subscription settings: Kan de kanaalinstellingen niet opslaan
   Videos per day: Video's per dag
   Different values: Verschillende waarden
   Use global setting: Algemene instelling gebruiken

--- a/static/locales/ai/nl.yaml
+++ b/static/locales/ai/nl.yaml
@@ -537,6 +537,8 @@ Settings:
     Forget Channel: Alle instellingen voor dit kanaal vergeten
     Forget Value: Deze instelling vergeten
     Add Setting: Nog een instelling voor dit kanaal onthouden
+    Add Subscribed Channel: Geabonneerd kanaal toevoegen
+    Enable Setting Before Adding Channel: Schakel minstens één kanaalinstelling in bij de afspeelinstellingen voordat je een kanaal toevoegt
     Video Quality: Videokwaliteit
     Subtitles Enabled: Ondertiteling ingeschakeld
     Volume: Volume
@@ -984,6 +986,7 @@ Channel:
   Subscription settings: Abonnementsinstellingen
   Failed to save subscription settings: Kan de abonnementsinstellingen niet opslaan
   Videos per day: Video's per dag
+  Different values: Verschillende waarden
   Use global setting: Algemene instelling gebruiken
   Unlimited: Onbeperkt
   More videos hidden: '+{count} meer | +{count} meer'

--- a/static/locales/ai/nn.yaml
+++ b/static/locales/ai/nn.yaml
@@ -736,6 +736,8 @@ Settings:
     Forget Channel: Gløym alle innstillingane for denne kanalen
     Forget Value: Gløym denne innstillinga
     Add Setting: Hugs ei innstilling til for denne kanalen
+    Add Subscribed Channel: Legg til kanal du abonnerer på
+    Enable Setting Before Adding Channel: Slå på minst éi kanalinnstilling i avspelingsinnstillingane før du legg til ein kanal
     Video Quality: Videokvalitet
     Subtitles Enabled: Undertekstar på
     Volume: Lydstyrke
@@ -1248,6 +1250,7 @@ Channel:
   Subscription settings: Abonnementsinnstillingar
   Failed to save subscription settings: Klarte ikkje å lagre abonnementsinnstillingane
   Videos per day: Videoar per dag
+  Different values: Ulike verdiar
   Use global setting: Bruk global innstilling
   Unlimited: Uavgrensa
   More videos hidden: '+{count} til | +{count} til'

--- a/static/locales/ai/nn.yaml
+++ b/static/locales/ai/nn.yaml
@@ -1248,7 +1248,7 @@ Profile:
   Open Profile Dropdown: Opna profilmenyen
 Channel:
   Subscription settings: Abonnementsinnstillingar
-  Failed to save subscription settings: Klarte ikkje å lagre abonnementsinnstillingane
+  Failed to save subscription settings: Klarte ikkje å lagre kanalinnstillingane
   Videos per day: Videoar per dag
   Different values: Ulike verdiar
   Use global setting: Bruk global innstilling

--- a/static/locales/ai/pl.yaml
+++ b/static/locales/ai/pl.yaml
@@ -161,6 +161,9 @@ Settings:
     Swipe Up or Down to Enter or Exit Fullscreen: 'Przesuń w górę lub w dół, aby włączyć lub wyłączyć pełny ekran'
     Preload Upcoming Videos: "Wstępnie wczytuj następne filmy"
     Upcoming Videos to Preload: "Liczba filmów do wstępnego wczytania"
+  Channel Settings:
+    Add Subscribed Channel: Dodaj subskrybowany kanał
+    Enable Setting Before Adding Channel: Przed dodaniem kanału włącz co najmniej jedno ustawienie kanału w ustawieniach odtwarzania
   Download Settings:
     Concurrent Downloads: Jednoczesne pobieranie
     Bandwidth Limit: Limit przepustowości (KiB/s, 0 oznacza brak limitu)
@@ -436,6 +439,7 @@ Channel:
   Subscription settings: Ustawienia subskrypcji
   Failed to save subscription settings: Nie udało się zapisać ustawień subskrypcji
   Videos per day: Filmy dziennie
+  Different values: Różne wartości
   Use global setting: Użyj ustawienia globalnego
   Unlimited: Bez ograniczeń
   More videos hidden: '+{count} więcej | +{count} więcej | +{count} więcej'

--- a/static/locales/ai/pl.yaml
+++ b/static/locales/ai/pl.yaml
@@ -437,7 +437,7 @@ Profile:
   Theme Color: Kolor motywu
 Channel:
   Subscription settings: Ustawienia subskrypcji
-  Failed to save subscription settings: Nie udało się zapisać ustawień subskrypcji
+  Failed to save subscription settings: Nie udało się zapisać ustawień kanału
   Videos per day: Filmy dziennie
   Different values: Różne wartości
   Use global setting: Użyj ustawienia globalnego

--- a/static/locales/ai/pt-BR.yaml
+++ b/static/locales/ai/pt-BR.yaml
@@ -957,7 +957,7 @@ Profile:
   Theme Color: Cor do tema
 Channel:
   Subscription settings: Configurações da inscrição
-  Failed to save subscription settings: Não foi possível salvar as configurações da inscrição
+  Failed to save subscription settings: Não foi possível salvar as configurações do canal
   Videos per day: Vídeos por dia
   Different values: Valores diferentes
   Use global setting: Usar configuração global

--- a/static/locales/ai/pt-BR.yaml
+++ b/static/locales/ai/pt-BR.yaml
@@ -524,6 +524,8 @@ Settings:
     Forget Channel: Esquecer todas as configurações deste canal
     Forget Value: Esquecer esta configuração
     Add Setting: Memorizar outra configuração para este canal
+    Add Subscribed Channel: Adicionar canal inscrito
+    Enable Setting Before Adding Channel: Ative pelo menos uma configuração de canal nas configurações de reprodução antes de adicionar um canal
     Video Quality: Qualidade do vídeo
     Subtitles Enabled: Legendas ativadas
     Volume: Volume
@@ -957,6 +959,7 @@ Channel:
   Subscription settings: Configurações da inscrição
   Failed to save subscription settings: Não foi possível salvar as configurações da inscrição
   Videos per day: Vídeos por dia
+  Different values: Valores diferentes
   Use global setting: Usar configuração global
   Unlimited: Sem limite
   More videos hidden: '+{count} a mais | +{count} a mais | +{count} a mais'

--- a/static/locales/ai/pt-PT.yaml
+++ b/static/locales/ai/pt-PT.yaml
@@ -973,7 +973,7 @@ Profile:
   Theme Color: Cor do tema
 Channel:
   Subscription settings: Definições da subscrição
-  Failed to save subscription settings: Não foi possível guardar as definições da subscrição
+  Failed to save subscription settings: Não foi possível guardar as definições do canal
   Videos per day: Vídeos por dia
   Different values: Valores diferentes
   Use global setting: Usar definição global

--- a/static/locales/ai/pt-PT.yaml
+++ b/static/locales/ai/pt-PT.yaml
@@ -532,6 +532,8 @@ Settings:
     Forget Channel: Esquecer todas as definições deste canal
     Forget Value: Esquecer esta definição
     Add Setting: Memorizar outra definição para este canal
+    Add Subscribed Channel: Adicionar canal subscrito
+    Enable Setting Before Adding Channel: Ative pelo menos uma definição de canal nas definições de reprodução antes de adicionar um canal
     Video Quality: Qualidade do vídeo
     Subtitles Enabled: Legendas ativadas
     Volume: Volume
@@ -973,6 +975,7 @@ Channel:
   Subscription settings: Definições da subscrição
   Failed to save subscription settings: Não foi possível guardar as definições da subscrição
   Videos per day: Vídeos por dia
+  Different values: Valores diferentes
   Use global setting: Usar definição global
   Unlimited: Sem limite
   More videos hidden: '+{count} adicional | +{count} adicionais | +{count} adicionais'

--- a/static/locales/ai/pt.yaml
+++ b/static/locales/ai/pt.yaml
@@ -540,6 +540,8 @@ Settings:
     Forget Channel: Esquecer todas as definições deste canal
     Forget Value: Esquecer esta definição
     Add Setting: Memorizar outra definição para este canal
+    Add Subscribed Channel: Adicionar canal subscrito
+    Enable Setting Before Adding Channel: Ative pelo menos uma definição de canal nas definições de reprodução antes de adicionar um canal
     Video Quality: Qualidade do vídeo
     Subtitles Enabled: Legendas ativadas
     Volume: Volume
@@ -984,6 +986,7 @@ Channel:
   Subscription settings: Definições da subscrição
   Failed to save subscription settings: Não foi possível guardar as definições da subscrição
   Videos per day: Vídeos por dia
+  Different values: Valores diferentes
   Use global setting: Usar definição global
   Unlimited: Sem limite
   More videos hidden: '+{count} mais | +{count} mais | +{count} mais'

--- a/static/locales/ai/pt.yaml
+++ b/static/locales/ai/pt.yaml
@@ -984,7 +984,7 @@ Profile:
   Theme Color: Cor do tema
 Channel:
   Subscription settings: Definições da subscrição
-  Failed to save subscription settings: Não foi possível guardar as definições da subscrição
+  Failed to save subscription settings: Não foi possível guardar as definições do canal
   Videos per day: Vídeos por dia
   Different values: Valores diferentes
   Use global setting: Usar definição global

--- a/static/locales/ai/ro.yaml
+++ b/static/locales/ai/ro.yaml
@@ -528,6 +528,8 @@ Settings:
     Forget Channel: Uită toate setările acestui canal
     Forget Value: Uită această setare
     Add Setting: Reține altă setare pentru acest canal
+    Add Subscribed Channel: Adaugă canal abonat
+    Enable Setting Before Adding Channel: Activează cel puțin o setare de canal în setările de redare înainte de a adăuga un canal
     Video Quality: Calitate video
     Subtitles Enabled: Subtitrări activate
     Volume: Volum
@@ -975,6 +977,7 @@ Channel:
   Subscription settings: Setări abonament
   Failed to save subscription settings: Setările abonamentului nu au putut fi salvate
   Videos per day: Videoclipuri pe zi
+  Different values: Valori diferite
   Use global setting: Folosește setarea globală
   Unlimited: Nelimitat
   More videos hidden: '+{count} în plus | +{count} în plus | +{count} în plus'

--- a/static/locales/ai/ro.yaml
+++ b/static/locales/ai/ro.yaml
@@ -975,7 +975,7 @@ Profile:
   Theme Color: Culoarea temei
 Channel:
   Subscription settings: Setări abonament
-  Failed to save subscription settings: Setările abonamentului nu au putut fi salvate
+  Failed to save subscription settings: Setările canalului nu au putut fi salvate
   Videos per day: Videoclipuri pe zi
   Different values: Valori diferite
   Use global setting: Folosește setarea globală

--- a/static/locales/ai/ru.yaml
+++ b/static/locales/ai/ru.yaml
@@ -509,6 +509,8 @@ Settings:
     Forget Channel: Забыть все настройки этого канала
     Forget Value: Забыть эту настройку
     Add Setting: Запомнить ещё одну настройку для этого канала
+    Add Subscribed Channel: Добавить канал из подписок
+    Enable Setting Before Adding Channel: Перед добавлением канала включите хотя бы одну настройку канала в настройках воспроизведения
     Video Quality: Качество видео
     Subtitles Enabled: Субтитры включены
     Volume: Громкость
@@ -953,6 +955,7 @@ Channel:
   Subscription settings: Настройки подписки
   Failed to save subscription settings: Не удалось сохранить настройки подписки
   Videos per day: Видео в день
+  Different values: Разные значения
   Use global setting: Использовать общую настройку
   Unlimited: Без ограничений
   More videos hidden: '+{count} ещё | +{count} ещё | +{count} ещё'

--- a/static/locales/ai/ru.yaml
+++ b/static/locales/ai/ru.yaml
@@ -953,7 +953,7 @@ Profile:
   Theme Color: Цвет темы
 Channel:
   Subscription settings: Настройки подписки
-  Failed to save subscription settings: Не удалось сохранить настройки подписки
+  Failed to save subscription settings: Не удалось сохранить настройки канала
   Videos per day: Видео в день
   Different values: Разные значения
   Use global setting: Использовать общую настройку

--- a/static/locales/ai/sk.yaml
+++ b/static/locales/ai/sk.yaml
@@ -957,7 +957,7 @@ Profile:
   Theme Color: Farba motívu
 Channel:
   Subscription settings: Nastavenia odberu
-  Failed to save subscription settings: Nastavenia odberu sa nepodarilo uložiť
+  Failed to save subscription settings: Nastavenia kanála sa nepodarilo uložiť
   Videos per day: Videá za deň
   Different values: Rôzne hodnoty
   Use global setting: Použiť globálne nastavenie

--- a/static/locales/ai/sk.yaml
+++ b/static/locales/ai/sk.yaml
@@ -524,6 +524,8 @@ Settings:
     Forget Channel: Zabudnúť všetky nastavenia tohto kanála
     Forget Value: Zabudnúť toto nastavenie
     Add Setting: Zapamätať si ďalšie nastavenie tohto kanála
+    Add Subscribed Channel: Pridať odoberaný kanál
+    Enable Setting Before Adding Channel: Pred pridaním kanála povoľte aspoň jedno nastavenie kanála v nastaveniach prehrávania
     Video Quality: Kvalita videa
     Subtitles Enabled: Titulky zapnuté
     Volume: Hlasitosť
@@ -957,6 +959,7 @@ Channel:
   Subscription settings: Nastavenia odberu
   Failed to save subscription settings: Nastavenia odberu sa nepodarilo uložiť
   Videos per day: Videá za deň
+  Different values: Rôzne hodnoty
   Use global setting: Použiť globálne nastavenie
   Unlimited: Bez obmedzenia
   More videos hidden: '+{count} ďalších | +{count} ďalších | +{count} ďalších'

--- a/static/locales/ai/sl.yaml
+++ b/static/locales/ai/sl.yaml
@@ -1285,7 +1285,7 @@ Profile:
   Open Profile Dropdown: Odpri spustni meni profila
 Channel:
   Subscription settings: Nastavitve naročnine
-  Failed to save subscription settings: Nastavitev naročnine ni bilo mogoče shraniti
+  Failed to save subscription settings: Nastavitev kanala ni bilo mogoče shraniti
   Videos per day: Videoposnetkov na dan
   Different values: Različne vrednosti
   Use global setting: Uporabi splošno nastavitev

--- a/static/locales/ai/sl.yaml
+++ b/static/locales/ai/sl.yaml
@@ -736,6 +736,8 @@ Settings:
     Forget Channel: Pozabi vse nastavitve tega kanala
     Forget Value: Pozabi to nastavitev
     Add Setting: Zapomni si še eno nastavitev za ta kanal
+    Add Subscribed Channel: Dodaj naročen kanal
+    Enable Setting Before Adding Channel: Pred dodajanjem kanala omogočite vsaj eno nastavitev kanala v nastavitvah predvajanja
     Video Quality: Kakovost videoposnetka
     Subtitles Enabled: Podnapisi so omogočeni
     Volume: Glasnost
@@ -1285,6 +1287,7 @@ Channel:
   Subscription settings: Nastavitve naročnine
   Failed to save subscription settings: Nastavitev naročnine ni bilo mogoče shraniti
   Videos per day: Videoposnetkov na dan
+  Different values: Različne vrednosti
   Use global setting: Uporabi splošno nastavitev
   Unlimited: Neomejeno
   More videos hidden: '+{count} več | +{count} več | +{count} več | +{count} več'

--- a/static/locales/ai/sr.yaml
+++ b/static/locales/ai/sr.yaml
@@ -547,6 +547,8 @@ Settings:
     Forget Channel: Заборави сва подешавања за овај канал
     Forget Value: Заборави ово подешавање
     Add Setting: Запамти још једно подешавање за овај канал
+    Add Subscribed Channel: Додај канал на који сте претплаћени
+    Enable Setting Before Adding Channel: Пре додавања канала омогућите бар једно подешавање канала у подешавањима репродукције
     Video Quality: Квалитет видео-снимка
     Subtitles Enabled: Титлови укључени
     Volume: Јачина звука
@@ -1002,6 +1004,7 @@ Channel:
   Subscription settings: Подешавања претплате
   Failed to save subscription settings: Није могуће сачувати подешавања претплате
   Videos per day: Видео-снимака дневно
+  Different values: Различите вредности
   Use global setting: Користи глобално подешавање
   Unlimited: Неограничено
   More videos hidden: '+{count} још | +{count} још | +{count} још'

--- a/static/locales/ai/sr.yaml
+++ b/static/locales/ai/sr.yaml
@@ -1002,7 +1002,7 @@ Profile:
   Theme Color: Боја теме
 Channel:
   Subscription settings: Подешавања претплате
-  Failed to save subscription settings: Није могуће сачувати подешавања претплате
+  Failed to save subscription settings: Није могуће сачувати подешавања канала
   Videos per day: Видео-снимака дневно
   Different values: Различите вредности
   Use global setting: Користи глобално подешавање

--- a/static/locales/ai/sv.yaml
+++ b/static/locales/ai/sv.yaml
@@ -959,7 +959,7 @@ Profile:
   Theme Color: Temafärg
 Channel:
   Subscription settings: Prenumerationsinställningar
-  Failed to save subscription settings: Det gick inte att spara prenumerationsinställningarna
+  Failed to save subscription settings: Det gick inte att spara kanalinställningarna
   Videos per day: Videor per dag
   Different values: Olika värden
   Use global setting: Använd global inställning

--- a/static/locales/ai/sv.yaml
+++ b/static/locales/ai/sv.yaml
@@ -526,6 +526,8 @@ Settings:
     Forget Channel: Glöm alla inställningar för den här kanalen
     Forget Value: Glöm den här inställningen
     Add Setting: Kom ihåg en annan inställning för den här kanalen
+    Add Subscribed Channel: Lägg till kanal du prenumererar på
+    Enable Setting Before Adding Channel: Aktivera minst en kanalinställning i uppspelningsinställningarna innan du lägger till en kanal
     Video Quality: Videokvalitet
     Subtitles Enabled: Undertexter aktiverade
     Volume: Volym
@@ -959,6 +961,7 @@ Channel:
   Subscription settings: Prenumerationsinställningar
   Failed to save subscription settings: Det gick inte att spara prenumerationsinställningarna
   Videos per day: Videor per dag
+  Different values: Olika värden
   Use global setting: Använd global inställning
   Unlimited: Obegränsat
   More videos hidden: '+{count} till | +{count} till'

--- a/static/locales/ai/ta.yaml
+++ b/static/locales/ai/ta.yaml
@@ -980,7 +980,7 @@ Profile:
   Theme Color: அலங்கார நிறம்
 Channel:
   Subscription settings: சந்தா அமைப்புகள்
-  Failed to save subscription settings: சந்தா அமைப்புகளைச் சேமிக்க முடியவில்லை
+  Failed to save subscription settings: சேனல் அமைப்புகளைச் சேமிக்க முடியவில்லை
   Videos per day: ஒரு நாளுக்கான காணொளிகள்
   Different values: வெவ்வேறு மதிப்புகள்
   Use global setting: பொதுவான அமைப்பைப் பயன்படுத்து

--- a/static/locales/ai/ta.yaml
+++ b/static/locales/ai/ta.yaml
@@ -536,6 +536,8 @@ Settings:
     Forget Channel: இந்தச் சேனலின் எல்லா அமைப்புகளையும் மற
     Forget Value: இந்த அமைப்பை மற
     Add Setting: இந்தச் சேனலுக்கான மற்றொரு அமைப்பை நினைவில் கொள்
+    Add Subscribed Channel: குழுசேர்ந்த சேனலைச் சேர்
+    Enable Setting Before Adding Channel: சேனலைச் சேர்ப்பதற்கு முன் பிளேபேக் அமைப்புகளில் குறைந்தது ஒரு சேனல் அமைப்பையாவது இயக்கு
     Video Quality: காணொளித் தரம்
     Subtitles Enabled: துணைத்தலைப்புகள் இயக்கப்பட்டுள்ளன
     Volume: ஒலியளவு
@@ -980,6 +982,7 @@ Channel:
   Subscription settings: சந்தா அமைப்புகள்
   Failed to save subscription settings: சந்தா அமைப்புகளைச் சேமிக்க முடியவில்லை
   Videos per day: ஒரு நாளுக்கான காணொளிகள்
+  Different values: வெவ்வேறு மதிப்புகள்
   Use global setting: பொதுவான அமைப்பைப் பயன்படுத்து
   Unlimited: வரம்பற்றது
   More videos hidden: '+{count} மேலும் | +{count} மேலும்'

--- a/static/locales/ai/tr.yaml
+++ b/static/locales/ai/tr.yaml
@@ -957,7 +957,7 @@ Profile:
   Theme Color: Tema Rengi
 Channel:
   Subscription settings: Abonelik ayarları
-  Failed to save subscription settings: Abonelik ayarları kaydedilemedi
+  Failed to save subscription settings: Kanal ayarları kaydedilemedi
   Videos per day: Günlük video sayısı
   Different values: Farklı değerler
   Use global setting: Genel ayarı kullan

--- a/static/locales/ai/tr.yaml
+++ b/static/locales/ai/tr.yaml
@@ -524,6 +524,8 @@ Settings:
     Forget Channel: Bu kanalın tüm ayarlarını unut
     Forget Value: Bu ayarı unut
     Add Setting: Bu kanal için başka bir ayarı hatırla
+    Add Subscribed Channel: Abone olunan kanalı ekle
+    Enable Setting Before Adding Channel: Kanal eklemeden önce Oynatma ayarlarında en az bir kanal ayarını etkinleştirin
     Video Quality: Video Kalitesi
     Subtitles Enabled: Alt Yazılar Etkin
     Volume: Ses Düzeyi
@@ -957,6 +959,7 @@ Channel:
   Subscription settings: Abonelik ayarları
   Failed to save subscription settings: Abonelik ayarları kaydedilemedi
   Videos per day: Günlük video sayısı
+  Different values: Farklı değerler
   Use global setting: Genel ayarı kullan
   Unlimited: Sınırsız
   More videos hidden: '+{count} daha | +{count} daha'

--- a/static/locales/ai/uk.yaml
+++ b/static/locales/ai/uk.yaml
@@ -976,7 +976,7 @@ Profile:
   Theme Color: Колір теми
 Channel:
   Subscription settings: Налаштування підписки
-  Failed to save subscription settings: Не вдалося зберегти налаштування підписки
+  Failed to save subscription settings: Не вдалося зберегти налаштування каналу
   Videos per day: Відео на день
   Different values: Різні значення
   Use global setting: Використовувати загальне налаштування

--- a/static/locales/ai/uk.yaml
+++ b/static/locales/ai/uk.yaml
@@ -532,6 +532,8 @@ Settings:
     Forget Channel: Забути всі налаштування цього каналу
     Forget Value: Забути це налаштування
     Add Setting: Запам’ятати ще одне налаштування цього каналу
+    Add Subscribed Channel: Додати канал із підписок
+    Enable Setting Before Adding Channel: Перш ніж додавати канал, увімкніть принаймні одне налаштування каналу в налаштуваннях відтворення
     Video Quality: Якість відео
     Subtitles Enabled: Субтитри ввімкнено
     Volume: Гучність
@@ -976,6 +978,7 @@ Channel:
   Subscription settings: Налаштування підписки
   Failed to save subscription settings: Не вдалося зберегти налаштування підписки
   Videos per day: Відео на день
+  Different values: Різні значення
   Use global setting: Використовувати загальне налаштування
   Unlimited: Без обмежень
   More videos hidden: '+{count} ще | +{count} ще | +{count} ще'

--- a/static/locales/ai/vi.yaml
+++ b/static/locales/ai/vi.yaml
@@ -974,7 +974,7 @@ Profile:
   Theme Color: Màu chủ đề
 Channel:
   Subscription settings: Cài đặt đăng ký
-  Failed to save subscription settings: Không thể lưu cài đặt đăng ký
+  Failed to save subscription settings: Không thể lưu cài đặt kênh
   Videos per day: Video mỗi ngày
   Different values: Các giá trị khác nhau
   Use global setting: Dùng cài đặt chung

--- a/static/locales/ai/vi.yaml
+++ b/static/locales/ai/vi.yaml
@@ -532,6 +532,8 @@ Settings:
     Forget Channel: Xóa mọi cài đặt cho kênh này
     Forget Value: Xóa cài đặt này
     Add Setting: Ghi nhớ thêm một cài đặt cho kênh này
+    Add Subscribed Channel: Thêm kênh đã đăng ký
+    Enable Setting Before Adding Channel: Bật ít nhất một cài đặt kênh trong phần cài đặt phát trước khi thêm kênh
     Video Quality: Chất lượng video
     Subtitles Enabled: Đã bật phụ đề
     Volume: Âm lượng
@@ -974,6 +976,7 @@ Channel:
   Subscription settings: Cài đặt đăng ký
   Failed to save subscription settings: Không thể lưu cài đặt đăng ký
   Videos per day: Video mỗi ngày
+  Different values: Các giá trị khác nhau
   Use global setting: Dùng cài đặt chung
   Unlimited: Không giới hạn
   More videos hidden: '+{count} video khác'

--- a/static/locales/ai/zh-CN.yaml
+++ b/static/locales/ai/zh-CN.yaml
@@ -957,7 +957,7 @@ Profile:
   Theme Color: 主题颜色
 Channel:
   Subscription settings: 订阅设置
-  Failed to save subscription settings: 无法保存订阅设置
+  Failed to save subscription settings: 无法保存频道设置
   Videos per day: 每日视频数
   Different values: 不同的值
   Use global setting: 使用全局设置

--- a/static/locales/ai/zh-CN.yaml
+++ b/static/locales/ai/zh-CN.yaml
@@ -524,6 +524,8 @@ Settings:
     Forget Channel: 清除该频道的所有设置
     Forget Value: 清除此设置
     Add Setting: 为该频道记住其他设置
+    Add Subscribed Channel: 添加已订阅的频道
+    Enable Setting Before Adding Channel: 添加频道前，请先在播放设置中启用至少一项频道设置
     Video Quality: 视频画质
     Subtitles Enabled: 字幕已启用
     Volume: 音量
@@ -957,6 +959,7 @@ Channel:
   Subscription settings: 订阅设置
   Failed to save subscription settings: 无法保存订阅设置
   Videos per day: 每日视频数
+  Different values: 不同的值
   Use global setting: 使用全局设置
   Unlimited: 不限
   More videos hidden: '另有 {count} 个'

--- a/static/locales/ai/zh-TW.yaml
+++ b/static/locales/ai/zh-TW.yaml
@@ -959,7 +959,7 @@ Profile:
   Theme Color: 佈景主題色彩
 Channel:
   Subscription settings: 訂閱設定
-  Failed to save subscription settings: 無法儲存訂閱設定
+  Failed to save subscription settings: 無法儲存頻道設定
   Videos per day: 每日影片數
   Different values: 不同的值
   Use global setting: 使用全域設定

--- a/static/locales/ai/zh-TW.yaml
+++ b/static/locales/ai/zh-TW.yaml
@@ -526,6 +526,8 @@ Settings:
     Forget Channel: 清除這個頻道的所有設定
     Forget Value: 清除這項設定
     Add Setting: 為這個頻道記住另一項設定
+    Add Subscribed Channel: 新增已訂閱的頻道
+    Enable Setting Before Adding Channel: 新增頻道前，請先在播放設定中啟用至少一項頻道設定
     Video Quality: 影片畫質
     Subtitles Enabled: 字幕已啟用
     Volume: 音量
@@ -959,6 +961,7 @@ Channel:
   Subscription settings: 訂閱設定
   Failed to save subscription settings: 無法儲存訂閱設定
   Videos per day: 每日影片數
+  Different values: 不同的值
   Use global setting: 使用全域設定
   Unlimited: 不限
   More videos hidden: '另有 {count} 部'

--- a/static/locales/de-DE.yaml
+++ b/static/locales/de-DE.yaml
@@ -1334,6 +1334,8 @@ Settings:
     Forget Channel: Alle Einstellungen für diesen Kanal vergessen
     Forget Value: Diese Einstellung vergessen
     Add Setting: Eine weitere Einstellung für diesen Kanal speichern
+    Add Subscribed Channel: Abonnierten Kanal hinzufügen
+    Enable Setting Before Adding Channel: Aktiviere in den Wiedergabeeinstellungen mindestens eine Kanaleinstellung, bevor du einen Kanal hinzufügst
     Video Quality: Videoqualität
     Subtitles Enabled: Untertitel aktiviert
     Volume: Lautstärke
@@ -1513,6 +1515,7 @@ Channel:
   Subscription settings: Abo-Einstellungen
   Failed to save subscription settings: Abo-Einstellungen konnten nicht gespeichert werden
   Videos per day: Videos pro Tag
+  Different values: Unterschiedliche Werte
   Use global setting: Globale Einstellung verwenden
   Unlimited: Unbegrenzt
   More videos hidden: '+{count} weiteres | +{count} weitere'

--- a/static/locales/de-DE.yaml
+++ b/static/locales/de-DE.yaml
@@ -1513,7 +1513,7 @@ About:
   Matrix: Matrix
 Channel:
   Subscription settings: Abo-Einstellungen
-  Failed to save subscription settings: Abo-Einstellungen konnten nicht gespeichert werden
+  Failed to save subscription settings: Kanaleinstellungen konnten nicht gespeichert werden
   Videos per day: Videos pro Tag
   Different values: Unterschiedliche Werte
   Use global setting: Globale Einstellung verwenden

--- a/static/locales/en-US.yaml
+++ b/static/locales/en-US.yaml
@@ -1710,7 +1710,7 @@ Profile:
 #On Channel Page
 Channel:
   Subscription settings: Subscription settings
-  Failed to save subscription settings: Failed to save subscription settings
+  Failed to save subscription settings: Failed to save channel settings
   Videos per day: Videos per day
   Different values: Different values
   Use global setting: Use global setting

--- a/static/locales/en-US.yaml
+++ b/static/locales/en-US.yaml
@@ -1009,6 +1009,8 @@ Settings:
     Forget Channel: Forget all settings for this channel
     Forget Value: Forget this setting
     Add Setting: Remember another setting for this channel
+    Add Subscribed Channel: Add subscribed channel
+    Enable Setting Before Adding Channel: Enable at least one channel setting in Playback settings before adding a channel
     Video Quality: Video Quality
     Subtitles Enabled: Subtitles Enabled
     Volume: Volume
@@ -1710,6 +1712,7 @@ Channel:
   Subscription settings: Subscription settings
   Failed to save subscription settings: Failed to save subscription settings
   Videos per day: Videos per day
+  Different values: Different values
   Use global setting: Use global setting
   Unlimited: Unlimited
   More videos hidden: '+{count} more | +{count} more'

--- a/tests/unit/setting-update-queue.test.mjs
+++ b/tests/unit/setting-update-queue.test.mjs
@@ -1,0 +1,62 @@
+import assert from 'node:assert/strict'
+import test from 'node:test'
+
+import { createSettingUpdateQueue } from '../../src/renderer/helpers/settingUpdateQueue.js'
+
+function deferred () {
+  let resolvePromise
+  const promise = new Promise(resolve => {
+    resolvePromise = resolve
+  })
+  return { promise, resolve: resolvePromise }
+}
+
+test('keeps an in-flight setting write from applying after a newer update', async () => {
+  const runUpdate = createSettingUpdateQueue()
+  const firstStarted = deferred()
+  const releaseFirst = deferred()
+  const appliedValues = []
+
+  const first = runUpdate('scrollbarThumbWidth', async isLatest => {
+    firstStarted.resolve()
+    await releaseFirst.promise
+    if (isLatest()) appliedValues.push(7)
+  })
+  await firstStarted.promise
+
+  const second = runUpdate('scrollbarThumbWidth', async isLatest => {
+    if (isLatest()) appliedValues.push(8)
+  })
+  const third = runUpdate('scrollbarThumbWidth', async isLatest => {
+    if (isLatest()) appliedValues.push(9)
+  })
+
+  releaseFirst.resolve()
+  await Promise.all([first, second, third])
+
+  assert.deepEqual(appliedValues, [9])
+})
+
+test('continues with the latest setting write after an earlier write fails', async () => {
+  const runUpdate = createSettingUpdateQueue()
+  const firstStarted = deferred()
+  const releaseFirst = deferred()
+  const appliedValues = []
+
+  const first = runUpdate('scrollbarThumbWidth', async () => {
+    firstStarted.resolve()
+    await releaseFirst.promise
+    throw new Error('write failed')
+  })
+  await firstStarted.promise
+
+  const second = runUpdate('scrollbarThumbWidth', async isLatest => {
+    if (isLatest()) appliedValues.push(8)
+  })
+
+  releaseFirst.resolve()
+  await assert.rejects(first, /write failed/)
+  await second
+
+  assert.deepEqual(appliedValues, [8])
+})


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Make sure to follow the contributing guidelines. -->
<!-- Important note, we may remove your pull request if you do not use this provided PR template correctly. -->
<!-- Agent instructions: Preserve every heading, comment, and marker in this template. Never remove or rewrite the release-note-category:start/end, release-note:start/end, or release-note-image:start/end marker pairs. -->

## Pull Request Type
<!-- Please select what type of pull request this is: [x] -->
- [ ] Bugfix
- [x] Feature Implementation
- [ ] Documentation
- [ ] Other

## Related issue
<!-- Please link the issue your pull request is referring to. -->
<!-- If this pull request fully resolves the relevant issue, put "closes" before the issue number. -->
<!-- Example: "closes #123456". -->

## Description
<!-- Please write a clear and concise description of what the pull request does. -->
Editing display and playback preferences one subscription at a time is cumbersome for users with many channels. Saved channel settings also could not be created directly from Playback settings, and the disabled-state guidance pointed users to the wrong place.

This adds batch selection and editing for subscription channel display settings, members-only visibility, and videos per day. It also adds a searchable subscription picker to Saved Channel Settings, corrects the disabled-state guidance, and uses native styled clear buttons for regular search fields while keeping the custom clear button exclusive to the top navigation search.

## Release note category
<!-- Select exactly one category. Every pull request must select one. -->
<!-- Select "Not noteworthy" when the pull request fixes a bug in or improves functionality that has not yet appeared in a stable release. -->
<!-- release-note-category:start -->
- [ ] Not noteworthy
- [ ] Highlights
- [x] More improvements
- [ ] Fixed bugs
<!-- release-note-category:end -->

## Release note
<!-- Required unless "Not noteworthy" is selected. -->
<!-- Write one concise, user-facing entry without a leading bullet. -->
<!-- release-note:start -->
Batch-edit subscription display and playback preferences, and add subscribed channels directly to Saved Channel Settings.
<!-- release-note:end -->

## Release note images
<!-- Optional. Paste one or more Markdown images, HTML image tags, or dark/light <picture> elements here. -->
<!-- The release notes normalize the markup and limit images taller than 300 pixels. -->
<!-- Agent instructions:
For a noteworthy visible change, add media when it makes the change easier to understand. Prefer a still image unless motion is the point; recordings must use animated WebP.
After implementing a visible change, proactively capture the result and show the local media to the user for approval before uploading it or updating the pull request.
When the affected UI differs between dark and light themes, capturing both themes is required. A dark-only image is incomplete. Run `node _scripts/releaseNoteMedia.mjs --dark DARK_FILE --light LIGHT_FILE --alt "DESCRIPTION"`; GitHub will display the matching theme and use dark as the fallback. Use a single default-dark capture only when the light theme cannot be captured or looks identical.
Capture or crop to the smallest region that still makes the change clear. Do not include the full window when the affected component can be understood on its own.
Use English unless localization is the subject. Keep components at their normal dimensions and placement instead of resizing them to fill the frame.
Use deterministic local fixtures for visible remote images. Reusable avatar and thumbnail fixtures are available through `e2e/helpers/visual-fixtures.mjs`. Before capturing, verify that every visible image has loaded successfully (`complete === true` and `naturalWidth > 0`).
Inspect the final dark and light files for failed images, missing content, unrelated UI, awkward animation, and misleading layout. Omit media when it does not explain the change clearly.
For one dark capture, run `node _scripts/releaseNoteMedia.mjs FILE --alt "DESCRIPTION"`.
Check for personal information, tokens, private repository names, and unrelated desktop content before uploading. Uploaded media is public.
Keep capture-only scripts, test hooks, screenshots, and recordings out of commits. Remove them before committing unless the capture code is also a reusable regression test. Never commit generated release-note media.
Paste only the generated markup between the marker comments. Leave this section empty when media would not help.
-->
<!-- release-note-image:start -->
<picture>
  <source media="(prefers-color-scheme: dark)" srcset="https://github.com/OpenTubeX/media/releases/download/attachments/20260907T114453Z-batch-subscriptions-dark-dark-ef51a6a481.png">
  <source media="(prefers-color-scheme: light)" srcset="https://github.com/OpenTubeX/media/releases/download/attachments/20260907T114453Z-batch-subscriptions-light-light-cc047ab4c2.png">
  <img alt="Two selected channels with shared subscription feed settings" src="https://github.com/OpenTubeX/media/releases/download/attachments/20260907T114453Z-batch-subscriptions-dark-dark-ef51a6a481.png">
</picture>

<picture>
  <source media="(prefers-color-scheme: dark)" srcset="https://github.com/OpenTubeX/media/releases/download/attachments/20260907T114455Z-add-saved-channel-dark-dark-2697e20875.png">
  <source media="(prefers-color-scheme: light)" srcset="https://github.com/OpenTubeX/media/releases/download/attachments/20260907T114455Z-add-saved-channel-light-light-5f46cab110.png">
  <img alt="Searchable subscribed-channel picker for Saved Channel Settings" src="https://github.com/OpenTubeX/media/releases/download/attachments/20260907T114455Z-add-saved-channel-dark-dark-2697e20875.png">
</picture>
<!-- release-note-image:end -->

## Testing
<!-- How can reviewers verify that the PR produces correct results? -->
<!-- Please provide instructions so that others can ensure that this pull request produces the correct results. For examples see, https://github.com/FreeTubeApp/FreeTube/pull/5743, https://github.com/FreeTubeApp/FreeTube/pull/7349, https://github.com/FreeTubeApp/FreeTube/pull/5125, https://github.com/FreeTubeApp/FreeTube/pull/7338 -->
<!-- Agent instructions: Only write human-facing steps that explain how to verify the change while running this branch in dev mode. Include expected results and, when applicable, helpful console snippets for interactive verification. Do not include automated checks, commands, results, pass counts, or CI status. -->
1. Open Settings > Subscriptions > Channel Settings with several subscriptions. Select individual channels or use the right-side select-all button, then batch-change Videos, Shorts, Live, Posts, members-only visibility, and videos per day. Confirm every selected row updates and the select-all button toggles to select-none.
2. Open Settings > Playback > Saved Channel Settings and use the button above the saved-channel list. Search for a subscribed channel without saved settings, clear the search with Chromium's native clear control, add the channel, and confirm it appears in the saved list.
3. Disable saved channel settings and confirm the guidance is centered and tells the user to enable the feature in Playback settings.
4. Check another regular search field and the top navigation search. Regular searches should use the native styled clear control; only the top navigation search should use the custom clear button.

## Additional context
<!-- Add any other context about the pull request here. -->
Regression coverage includes batch selection, batch edits, saved-channel search and insertion, failed writes, native search clearing, and scroll clamping after filtering or collapsing content.
