### PR TITLE
fix(player): retain preloads across proxy changes

### DIFF
--- a/e2e/README.md
+++ b/e2e/README.md
@@ -127,12 +127,12 @@ compares the median of seven samples. A single pull-request comment and the
 Actions summary show the comparison, and the raw samples are uploaded as
 `performance-results.json`.
 
-The workflow fails when the candidate crosses a metric's absolute limit or
-exceeds both its relative limit and minimum delta. Elapsed metrics allow 15%,
-longest-frame metrics 20%, renderer heap growth 50%, and packed code size 5%. Each
-metric's minimum delta lives in `e2e/performance/report.mjs`. A trusted
-follow-up workflow updates the comment so pull requests from forks never
-receive a write-capable token.
+The workflow fails when the candidate crosses a metric's absolute limit from
+below or exceeds both its relative limit and minimum delta. Elapsed metrics
+allow 15%, longest-frame metrics 20%, renderer heap growth 50%, and packed code
+size 5%. Each metric's minimum delta lives in `e2e/performance/report.mjs`. A
+trusted follow-up workflow updates the comment so pull requests from forks
+never receive a write-capable token.
 
 To compare two checkouts locally, build `dist-e2e` in both and run:
 

--- a/e2e/performance/report.mjs
+++ b/e2e/performance/report.mjs
@@ -175,12 +175,12 @@ export function comparePerformanceSamples(samples) {
     const thresholdRatio = candidateMedian /
       Math.max(baseMedian, definition.relativeBaselineFloor ?? Number.MIN_VALUE)
     const gated = definition.gate !== false
-    const exceedsAbsoluteLimit = gated && definition.absoluteLimit !== undefined &&
-      candidateMedian >= definition.absoluteLimit
+    const crossesAbsoluteLimit = gated && definition.absoluteLimit !== undefined &&
+      baseMedian < definition.absoluteLimit && candidateMedian >= definition.absoluteLimit
     const relativeRegression = gated && definition.relativeLimit !== undefined &&
       thresholdRatio > definition.relativeLimit && delta > definition.minimumDelta
 
-    if (exceedsAbsoluteLimit) {
+    if (crossesAbsoluteLimit) {
       failures.push(
         `${definition.label} is ${metricValue(definition, candidateMedian)}, ` +
         `at or above the ${metricValue(definition, definition.absoluteLimit)} limit`
@@ -201,9 +201,9 @@ export function comparePerformanceSamples(samples) {
       candidateMedian,
       delta,
       ratio,
-      exceedsAbsoluteLimit,
+      crossesAbsoluteLimit,
       relativeRegression,
-      passed: !exceedsAbsoluteLimit && !relativeRegression
+      passed: !crossesAbsoluteLimit && !relativeRegression
     }
   })
 

--- a/src/renderer/helpers/player/ytDlpPlaybackPreload.js
+++ b/src/renderer/helpers/player/ytDlpPlaybackPreload.js
@@ -30,27 +30,15 @@ function scheduleYtDlpPlaybackPreload(loadSource) {
 }
 
 /**
- * Identifies every setting that can change yt-dlp's extracted stream URLs.
+ * Identifies every setting that requires fresh yt-dlp stream URLs.
  * @param {Record<string, unknown>} getters
  */
 export function buildYtDlpPlaybackCacheKey(getters) {
-  const proxyConfiguration = getters.getUseProxy
-    ? [
-        getters.getProxyProtocol,
-        getters.getProxyHostname,
-        getters.getProxyPort,
-        getters.getProxyUsername,
-        getters.getProxyPassword,
-      ]
-    : []
-
   return JSON.stringify([
     'captions-v4',
     getters.getYtDlpSource,
     getters.getYtDlpChannel,
     getters.getYtDlpPath,
-    getters.getUseProxy,
-    ...proxyConfiguration,
     getters.getYtDlpPlaybackAuthMode,
     getters.getYtDlpPlaybackCookiesPath,
     getters.getYtDlpPlaybackCookiesBrowser,

--- a/tests/unit/performance-comment.test.mjs
+++ b/tests/unit/performance-comment.test.mjs
@@ -93,6 +93,31 @@ test('recomputes regressions instead of trusting artifact conclusions', () => {
   assert.match(comment, /Repeated subscription switch elapsed regressed by 100\.0 ms \(\+125\.0%\)/)
 })
 
+test('does not fail an absolute limit when the candidate improves on an over-limit base', () => {
+  const input = result({ firstSwitchElapsedMs: 252.5 })
+  input.samples.base = Array.from({ length: 7 }, () => sample({
+    firstSwitchElapsedMs: 258
+  }))
+
+  const comment = renderPerformanceComment(input, { headSha, runUrl })
+
+  assert.match(comment, /First subscription switch elapsed .+ -2\.1% .+ Pass/)
+  assert.doesNotMatch(comment, /First subscription switch elapsed is .+ at or above/)
+})
+
+test('fails when the candidate crosses an absolute limit from below', () => {
+  const input = result({ firstSwitchElapsedMs: 250 })
+  input.samples.base = Array.from({ length: 7 }, () => sample({
+    firstSwitchElapsedMs: 240
+  }))
+
+  const comment = renderPerformanceComment(input, { headSha, runUrl })
+
+  assert.match(comment, /First subscription switch elapsed .+ \+4\.2% .+ Regression/)
+  assert.match(comment, /First subscription switch elapsed is 250\.0 ms, at or above/)
+  assert.doesNotMatch(comment, /First subscription switch elapsed regressed by/)
+})
+
 test('ignores a one-frame shift in longest-frame samples', () => {
   const input = result({ subscribedChannelsNavigationLongestFrameMs: 83.3 })
   input.samples.base = Array.from({ length: 7 }, () => sample({

--- a/tests/unit/yt-dlp-playback-preload.test.mjs
+++ b/tests/unit/yt-dlp-playback-preload.test.mjs
@@ -16,28 +16,48 @@ const source = videoId => ({
   expiryDate: new Date(Date.now() + 10 * 60 * 1000),
 })
 
-test('includes proxy and authentication settings in the playback cache key', () => {
-  const getters = {
+test('reuses preloaded playback sources across proxy changes', () => {
+  const directGetters = {
     getYtDlpSource: 'system',
     getYtDlpChannel: 'stable',
     getYtDlpPath: '/usr/bin/yt-dlp',
+    getUseProxy: false,
+    getYtDlpPlaybackAuthMode: 'browser',
+    getYtDlpPlaybackCookiesPath: '',
+    getYtDlpPlaybackCookiesBrowser: 'firefox',
+    getYtDlpPlaybackCookiesBrowserProfile: 'default',
+  }
+  const proxyGetters = {
+    ...directGetters,
     getUseProxy: true,
     getProxyProtocol: 'socks5',
     getProxyHostname: 'localhost',
     getProxyPort: 9050,
     getProxyUsername: 'user',
     getProxyPassword: 'password',
-    getYtDlpPlaybackAuthMode: 'browser',
-    getYtDlpPlaybackCookiesPath: '',
-    getYtDlpPlaybackCookiesBrowser: 'firefox',
-    getYtDlpPlaybackCookiesBrowserProfile: 'default',
   }
+  const directKey = buildYtDlpPlaybackCacheKey(directGetters)
 
-  assert.deepEqual(JSON.parse(buildYtDlpPlaybackCacheKey(getters)), [
-    'captions-v4', 'system', 'stable', '/usr/bin/yt-dlp', true,
-    'socks5', 'localhost', 9050, 'user', 'password',
-    'browser', '', 'firefox', 'default',
-  ])
+  assert.equal(
+    directKey,
+    buildYtDlpPlaybackCacheKey(proxyGetters)
+  )
+
+  for (const [setting, value] of Object.entries({
+    getYtDlpSource: 'bundled',
+    getYtDlpChannel: 'nightly',
+    getYtDlpPath: '/opt/yt-dlp',
+    getYtDlpPlaybackAuthMode: 'cookies',
+    getYtDlpPlaybackCookiesPath: '/tmp/cookies.txt',
+    getYtDlpPlaybackCookiesBrowser: 'chromium',
+    getYtDlpPlaybackCookiesBrowserProfile: 'Profile 1',
+  })) {
+    assert.notEqual(
+      directKey,
+      buildYtDlpPlaybackCacheKey({ ...directGetters, [setting]: value }),
+      setting
+    )
+  }
 })
 
 test('normalizes the number of upcoming yt-dlp videos to preload', () => {


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Make sure to follow the contributing guidelines. -->
<!-- Important note, we may remove your pull request if you do not use this provided PR template correctly. -->
<!-- Agent instructions: Preserve every heading, comment, and marker in this template. Never remove or rewrite the release-note-category:start/end, release-note:start/end, or release-note-image:start/end marker pairs. -->

## Pull Request Type
<!-- Please select what type of pull request this is: [x] -->
- [x] Bugfix
- [ ] Feature Implementation
- [ ] Documentation
- [ ] Other

## Related issue
<!-- Please link the issue your pull request is referring to. -->
<!-- If this pull request fully resolves the relevant issue, put "closes" before the issue number. -->
<!-- Example: "closes #123456". -->

closes #1063

## Description
<!-- Please write a clear and concise description of what the pull request does. -->

Changing the proxy currently gives preloaded yt-dlp videos a different cache key, so users must preload them again even when the extracted links still work.

This stops including proxy state and configuration in the playback cache key. Valid preloaded links now remain available when users enable, disable, or reconfigure the proxy. A playback failure still invalidates the cached source so yt-dlp can extract a fresh one.

The performance comparison now treats an absolute limit as a regression only when the candidate crosses it from below. If the base is already over the limit, the relative threshold still catches material slowdowns without blocking an improving candidate.

## Release note category
<!-- Select exactly one category. Every pull request must select one. -->
<!-- Select "Not noteworthy" when the pull request fixes a bug in or improves functionality that has not yet appeared in a stable release. -->
<!-- release-note-category:start -->
- [x] Not noteworthy
- [ ] Highlights
- [ ] More improvements
- [ ] Fixed bugs
<!-- release-note-category:end -->

## Release note
<!-- Required unless "Not noteworthy" is selected. -->
<!-- Write one concise, user-facing entry without a leading bullet. -->
<!-- release-note:start -->

<!-- release-note:end -->

## Release note images
<!-- Optional. Paste one or more Markdown images, HTML image tags, or dark/light <picture> elements here. -->
<!-- The release notes normalize the markup and limit images taller than 300 pixels. -->
<!-- Agent instructions:
For a noteworthy visible change, add media when it makes the change easier to understand. Prefer a still image unless motion is the point; recordings must use animated WebP.
After implementing a visible change, proactively capture the result and show the local media to the user for approval before uploading it or updating the pull request.
When the affected UI differs between dark and light themes, capturing both themes is required. A dark-only image is incomplete. Run `node _scripts/releaseNoteMedia.mjs --dark DARK_FILE --light LIGHT_FILE --alt "DESCRIPTION"`; GitHub will display the matching theme and use dark as the fallback. Use a single default-dark capture only when the light theme cannot be captured or looks identical.
Capture or crop to the smallest region that still makes the change clear. Do not include the full window when the affected component can be understood on its own.
Use English unless localization is the subject. Keep components at their normal dimensions and placement instead of resizing them to fill the frame.
Use deterministic local fixtures for visible remote images. Reusable avatar and thumbnail fixtures are available through `e2e/helpers/visual-fixtures.mjs`. Before capturing, verify that every visible image has loaded successfully (`complete === true` and `naturalWidth > 0`).
Inspect the final dark and light files for failed images, missing content, unrelated UI, awkward animation, and misleading layout. Omit media when it does not explain the change clearly.
For one dark capture, run `node _scripts/releaseNoteMedia.mjs FILE --alt "DESCRIPTION"`.
Check for personal information, tokens, private repository names, and unrelated desktop content before uploading. Uploaded media is public.
Keep capture-only scripts, test hooks, screenshots, and recordings out of commits. Remove them before committing unless the capture code is also a reusable regression test. Never commit generated release-note media.
Paste only the generated markup between the marker comments. Leave this section empty when media would not help.
-->
<!-- release-note-image:start -->

<!-- release-note-image:end -->

## Testing
<!-- How can reviewers verify that the PR produces correct results? -->
<!-- Please provide instructions so that others can ensure that your pull request would produce correct results. For examples see, https://github.com/FreeTubeApp/FreeTube/pull/5743, https://github.com/FreeTubeApp/FreeTube/pull/7349, https://github.com/FreeTubeApp/FreeTube/pull/5125, https://github.com/FreeTubeApp/FreeTube/pull/7338 -->
<!-- Agent instructions: Only write human-facing steps that explain how to verify the change while running this branch in dev mode. Include expected results and, when applicable, helpful console snippets for interactive verification. Do not include automated checks, commands, results, pass counts, or CI status. -->

1. Select yt-dlp as the stream extraction method and enable upcoming-video preloading.
2. Open a playlist and wait for the upcoming videos to preload.
3. Enable, disable, or reconfigure the proxy.
4. Return to the playlist and confirm the previously extracted videos remain preloaded and play normally.

## Additional context
<!-- Add any other context about the pull request here. -->

The cache does not store a detected public IP. Proxy configuration previously affected only the settings-derived cache key. The key still changes for yt-dlp source, binary, and playback authentication changes.

