### PR TITLE
fix(playlists): update card metadata dynamically

### DIFF
--- a/e2e/tests/offline/playlists.spec.mjs
+++ b/e2e/tests/offline/playlists.spec.mjs
@@ -7,6 +7,18 @@ import { DEMO_MEDIA_URL, routeDemoMedia } from '../../helpers/media.mjs'
 
 const seededPremiereStart = Date.now() + 86_400_000
 
+async function dispatchStoreAction(page, action, payload) {
+  await page.evaluate(async ({ action, payload }) => {
+    const store = document.querySelector('#app').__vue_app__.config.globalProperties.$store
+    await store.dispatch(action, payload)
+  }, { action, payload })
+}
+
+async function allThumbnailsInclude(playlistCard, expectedUrlPart) {
+  const sources = await playlistCard.locator('.thumbnailImage').evaluateAll(images => images.map(image => image.src))
+  return sources.length > 0 && sources.every(source => source.includes(expectedUrlPart))
+}
+
 test.describe('playlist creation', () => {
   test('a playlist can be created through the UI', async ({ page }) => {
     await goTo(page, 'userplaylists')
@@ -110,6 +122,45 @@ test.describe('seeded playlists', () => {
     await expect(page.getByText('Seeded video one')).toBeVisible()
     // Local playlists intentionally ignore the global hide-upcoming setting.
     await expect(page.getByText('Upcoming seeded premiere')).toBeVisible()
+  })
+
+  test('updates a playlist card video count while the list remains open', async ({ page }) => {
+    await goTo(page, 'userplaylists')
+
+    const playlistCard = page.locator('.ft-list-video', {
+      has: page.getByRole('link', { name: 'My seeded playlist', exact: true })
+    })
+    const thumbnail = playlistCard.locator('.thumbnailImage')
+    const displayedVideoCounts = async () => {
+      const counts = await playlistCard.locator('.videoCountContainer').allTextContents()
+      return [...new Set(counts)]
+    }
+    await expect.poll(displayedVideoCounts).toEqual(['2'])
+    await expect(thumbnail).toHaveAttribute('src', /ccccccccccc/)
+
+    await dispatchStoreAction(page, 'removeAllVideos', 'e2eseeded')
+    await expect.poll(displayedVideoCounts).toEqual(['0'])
+    await expect(thumbnail).toHaveAttribute('src', /thumbnail_placeholder/)
+
+    await dispatchStoreAction(page, 'addVideo', {
+      _id: 'e2eseeded',
+      videoData: {
+        videoId: 'fffffffffff',
+        title: 'New playlist video',
+        playlistItemId: 'e2e-item-4',
+        type: 'video'
+      }
+    })
+    await expect.poll(displayedVideoCounts).toEqual(['1'])
+    await expect.poll(() => allThumbnailsInclude(playlistCard, 'fffffffffff')).toBe(true)
+
+    await dispatchStoreAction(page, 'removeVideo', {
+      _id: 'e2eseeded',
+      videoId: 'fffffffffff',
+      playlistItemId: 'e2e-item-4'
+    })
+    await expect.poll(displayedVideoCounts).toEqual(['0'])
+    await expect.poll(() => allThumbnailsInclude(playlistCard, 'thumbnail_placeholder')).toBe(true)
   })
 
   test('preloads every video in a user playlist with yt-dlp', async ({ app, page }) => {
@@ -246,7 +297,7 @@ test.describe('seeded playlists', () => {
       'https://www.youtube.com/playlist?list=secondary&playlistType=user'
     )
     await page.locator(sel.searchInput).press('Enter')
-    await expect(page.getByText('Secondary preload playlist')).toBeVisible()
+    await expect(page.getByRole('heading', { name: 'Secondary preload playlist' })).toBeVisible()
     await expect(page.getByTestId('progress-toast')).toHaveCount(0)
 
     const secondaryPreloadButton = page.getByTitle('Preload all videos')
@@ -370,6 +421,66 @@ test.describe('seeded playlists', () => {
     await goTo(page, 'userplaylists')
     await page.getByText('Favorites').click()
     await expect(page.getByTitle('Quick Bookmark Enabled').locator('.ft-custom-icon__emoji')).toHaveText('❤️‍🔥')
+  })
+})
+
+test.describe('saved playlist metadata', () => {
+  test.use({
+    seed: {
+      settings: {
+        playlistBookmarks: [{
+          playlist: {
+            id: 'saved-playlist',
+            title: 'Saved playlist',
+            description: '',
+            thumbnail_url: 'https://i.ytimg.com/vi/ggggggggggg/mqdefault.jpg',
+            video_count: 4
+          },
+          uploader: {
+            id: 'UC-saved-playlist',
+            name: 'Saved channel',
+            avatar: null,
+            verified: false
+          },
+          savedAt: 1
+        }]
+      }
+    }
+  })
+
+  test('updates saved playlist card metadata while the list remains open', async ({ page }) => {
+    await goTo(page, 'userplaylists')
+
+    const playlistCard = page.locator('.ft-list-video', {
+      has: page.locator('a.title[href*="/playlist/saved-playlist"]')
+    })
+    await expect(playlistCard.locator('.h3Title')).toHaveText('Saved playlist')
+    await expect(playlistCard.locator('.channelNameText')).toHaveText('Saved channel')
+    await expect(playlistCard.locator('.thumbnailImage')).toHaveAttribute('src', /ggggggggggg/)
+    await expect(playlistCard.locator('.videoCountContainer')).toHaveText('4')
+
+    await dispatchStoreAction(page, 'savePlaylistBookmark', {
+      playlist: {
+        id: 'saved-playlist',
+        title: 'Saved playlist updated',
+        description: 'Updated metadata',
+        thumbnail_url: 'https://i.ytimg.com/vi/hhhhhhhhhhh/mqdefault.jpg',
+        video_count: 5
+      },
+      uploader: {
+        id: 'UC-updated-saved-playlist',
+        name: 'Updated saved channel',
+        avatar: null,
+        verified: false
+      },
+      savedAt: 1
+    })
+
+    await expect(playlistCard.locator('.h3Title')).toHaveText('Saved playlist updated')
+    await expect(playlistCard.locator('.channelNameText')).toHaveText('Updated saved channel')
+    await expect(playlistCard.locator('.thumbnailImage')).toHaveAttribute('src', /hhhhhhhhhhh/)
+    await expect(playlistCard.locator('.videoCountContainer')).toHaveText('5')
+    await expect(playlistCard.locator('.channelName')).toHaveAttribute('href', '#/channel/UC-updated-saved-playlist')
   })
 })
 

--- a/src/renderer/components/FtListPlaylist/FtListPlaylist.vue
+++ b/src/renderer/components/FtListPlaylist/FtListPlaylist.vue
@@ -28,7 +28,7 @@
       >
         <div class="background" />
         <div class="inner">
-          <div>{{ videoCount }}</div>
+          <div>{{ playlistMetadata.videoCount }}</div>
           <div><FtIcon :icon="['fas','list']" /></div>
         </div>
       </div>
@@ -47,16 +47,16 @@
       </RouterLink>
       <div class="infoLine">
         <RouterLink
-          v-if="channelId && enableChannelLinks"
+          v-if="playlistMetadata.channelId && enableChannelLinks"
           class="channelName"
           dir="auto"
-          :to="`/channel/${channelId}`"
+          :to="`/channel/${playlistMetadata.channelId}`"
         >
           <FtChannelAvatar
             v-if="showChannelAvatar"
             :thumbnail="channelThumbnail"
           />
-          <span class="channelNameText">{{ channelName }}</span>
+          <span class="channelNameText">{{ playlistMetadata.channelName }}</span>
         </RouterLink>
         <bdi
           v-else
@@ -66,7 +66,7 @@
             v-if="showChannelAvatar"
             :thumbnail="channelThumbnail"
           />
-          <span class="channelNameText">{{ channelName }}</span>
+          <span class="channelNameText">{{ playlistMetadata.channelName }}</span>
         </bdi>
       </div>
       <div class="buttonStack playlistButtonStack">
@@ -81,7 +81,7 @@
           @click="handleExternalPlayer"
         />
         <FtIconButton
-          v-if="IS_ELECTRON && enableDownloads && videoCount > 0"
+          v-if="IS_ELECTRON && enableDownloads && playlistMetadata.videoCount > 0"
           :title="t('Downloads.Download Playlist')"
           :icon="['fas', 'download']"
           theme="base-no-default"
@@ -111,11 +111,11 @@
     </div>
     <WatchVideoDownloadPrompt
       v-if="enableDownloads && showDownloadPrompt"
-      :playlist-id="isUserPlaylist ? '' : playlistId"
-      :playlist-key="playlistId"
+      :playlist-id="isUserPlaylist ? '' : playlistMetadata.playlistId"
+      :playlist-key="playlistMetadata.playlistId"
       :video-ids="isUserPlaylist ? data.videos.map(video => video.videoId) : []"
       :is-playlist="true"
-      :title="title"
+      :title="playlistMetadata.title"
       :thumbnail="thumbnailForDisplay"
       @close="showDownloadPrompt = false"
     />
@@ -161,28 +161,8 @@ watch(enableDownloads, (enabled) => {
   if (!enabled) showDownloadPrompt.value = false
 })
 
-let playlistId = ''
-let title = ''
-/** @type {string} */
-let thumbnail = thumbnailPlaceholder
-/** @type {import('vue').Ref<string | null>} */
-const channelId = ref(null)
-const channelName = ref('')
-let videoCount = 0
-
 /** @type {import('vue').ComputedRef<'grid' | 'list'>} */
 const listType = computed(() => store.getters.getListType)
-
-const titleForDisplay = computed(() => {
-  if (typeof title !== 'string') {
-    return ''
-  }
-  if (title.length <= 255) {
-    return title
-  }
-
-  return `${title.slice(0, 255)}...`
-})
 
 /** @type {import('vue').ComputedRef<boolean>} */
 const blurThumbnails = computed(() => store.getters.getBlurThumbnails)
@@ -190,13 +170,78 @@ const blurThumbnails = computed(() => store.getters.getBlurThumbnails)
 /** @type {import('vue').ComputedRef<'' | 'start' | 'middle' | 'end' | 'hidden' | 'blur'>} */
 const thumbnailPreference = computed(() => store.getters.getThumbnailPreference)
 
+/** @type {import('vue').ComputedRef<'local' | 'invidious'>} */
+const backendPreference = computed(() => store.getters.getBackendPreference)
+
 /** @type {import('vue').ComputedRef<string>} */
-const thumbnailForDisplay = computed(() => {
-  return thumbnailPreference.value !== 'hidden' ? thumbnail : thumbnailPlaceholder
-})
+const currentInvidiousInstanceUrl = computed(() => store.getters.getCurrentInvidiousInstanceUrl)
 
 const isUserPlaylist = computed(() => props.data._id != null)
 const isPlaylistBookmark = computed(() => props.data.isPlaylistBookmark === true)
+const playlistMetadata = computed(() => {
+  if (isUserPlaylist.value) {
+    let thumbnailUrl = thumbnailPlaceholder
+    if (props.data.videos.length > 0) {
+      const origin = backendPreference.value === 'invidious'
+        ? currentInvidiousInstanceUrl.value
+        : 'https://i.ytimg.com'
+      thumbnailUrl = `${origin}/vi/${props.data.videos[0].videoId}/mqdefault.jpg`
+    }
+
+    return {
+      playlistId: props.data._id,
+      title: props.data.playlistName,
+      thumbnailUrl,
+      channelName: '',
+      channelId: '',
+      videoCount: props.data.videos.length,
+    }
+  }
+
+  if (props.data.dataSource === 'local') {
+    return {
+      playlistId: props.data.playlistId,
+      title: props.data.title,
+      thumbnailUrl: props.data.thumbnail,
+      channelName: props.data.channelName,
+      channelId: props.data.channelId,
+      videoCount: props.data.videoCount,
+    }
+  }
+
+  let thumbnailUrl = thumbnailPlaceholder
+  if (props.data.proxyThumbnail === false) {
+    thumbnailUrl = props.data.playlistThumbnail
+  } else if (typeof props.data.playlistThumbnail === 'string' && props.data.playlistThumbnail !== '') {
+    thumbnailUrl = props.data.playlistThumbnail.replace('hqdefault', 'mqdefault')
+    if (!isPlaylistBookmark.value || backendPreference.value === 'invidious') {
+      thumbnailUrl = thumbnailUrl.replace('https://i.ytimg.com', currentInvidiousInstanceUrl.value)
+    }
+  }
+
+  return {
+    playlistId: props.data.playlistId,
+    title: props.data.title,
+    thumbnailUrl,
+    channelName: props.data.author,
+    channelId: props.data.authorId,
+    videoCount: props.data.videoCount,
+  }
+})
+
+const titleForDisplay = computed(() => {
+  const { title } = playlistMetadata.value
+  if (typeof title !== 'string') return ''
+  if (title.length <= 255) return title
+  return `${title.slice(0, 255)}...`
+})
+
+/** @type {import('vue').ComputedRef<string>} */
+const thumbnailForDisplay = computed(() => {
+  return thumbnailPreference.value !== 'hidden'
+    ? playlistMetadata.value.thumbnailUrl
+    : thumbnailPlaceholder
+})
 
 // For `router-link` attribute `to`
 const playlistPageLinkTo = computed(() => {
@@ -212,80 +257,20 @@ const playlistPageLinkTo = computed(() => {
   }
 
   return {
-    path: `/playlist/${playlistId}`,
+    path: `/playlist/${playlistMetadata.value.playlistId}`,
     query,
   }
 })
 
-/** @type {import('vue').ComputedRef<'local' | 'invidious'>} */
-const backendPreference = computed(() => store.getters.getBackendPreference)
-
-/** @type {import('vue').ComputedRef<string>} */
-const currentInvidiousInstanceUrl = computed(() => store.getters.getCurrentInvidiousInstanceUrl)
-
-if (isUserPlaylist.value) {
-  parseUserData()
-} else if (props.data.dataSource === 'local') {
-  parseLocalData()
-} else {
-  parseInvidiousData()
-}
-
-function parseInvidiousData() {
-  title = props.data.title
-
-  if (typeof props.data.playlistThumbnail === 'string' && props.data.playlistThumbnail !== '') {
-    thumbnail = props.data.playlistThumbnail.replace('hqdefault', 'mqdefault')
-    if (!isPlaylistBookmark.value || backendPreference.value === 'invidious') {
-      thumbnail = thumbnail.replace('https://i.ytimg.com', currentInvidiousInstanceUrl.value)
-    }
-  }
-
-  channelName.value = props.data.author
-  channelId.value = props.data.authorId
-  playlistId = props.data.playlistId
-  videoCount = props.data.videoCount
-
-  if (props.data.proxyThumbnail === false) {
-    thumbnail = props.data.playlistThumbnail
-  }
-}
-
-function parseLocalData() {
-  title = props.data.title
-
-  thumbnail = props.data.thumbnail
-
-  channelName.value = props.data.channelName
-  channelId.value = props.data.channelId
-  playlistId = props.data.playlistId
-  videoCount = props.data.videoCount
-}
-
-function parseUserData() {
-  title = props.data.playlistName
-
-  if (props.data.videos.length > 0) {
-    const origin = backendPreference.value === 'invidious'
-      ? currentInvidiousInstanceUrl.value
-      : 'https://i.ytimg.com'
-
-    thumbnail = `${origin}/vi/${props.data.videos[0].videoId}/mqdefault.jpg`
-  }
-
-  channelName.value = ''
-  channelId.value = ''
-  playlistId = props.data._id
-  videoCount = props.data.videos.length
-}
+const channelId = computed(() => playlistMetadata.value.channelId)
 
 const showChannelAvatar = computed(() => (
   !store.getters.getHideChannelAvatars &&
   (props.appearance === 'result' || props.appearance === 'youtubeShort') &&
-  typeof channelName.value === 'string' &&
-  channelName.value !== '' &&
-  typeof channelId.value === 'string' &&
-  channelId.value !== ''
+  typeof playlistMetadata.value.channelName === 'string' &&
+  playlistMetadata.value.channelName !== '' &&
+  typeof playlistMetadata.value.channelId === 'string' &&
+  playlistMetadata.value.channelId !== ''
 ))
 
 const { channelThumbnail } = useResultChannelAvatar(
@@ -300,9 +285,9 @@ const quickBookmarkIcon = computed(() => store.getters.getQuickBookmarkIcon)
 
 const markedAsQuickBookmarkTarget = computed(() => {
   // Only user playlists can be target
-  return playlistId != null &&
+  return playlistMetadata.value.playlistId != null &&
     quickBookmarkPlaylistId.value != null &&
-    quickBookmarkPlaylistId.value === playlistId
+    quickBookmarkPlaylistId.value === playlistMetadata.value.playlistId
 })
 
 function handleQuickBookmarkEnabledDisabledClick() {
@@ -315,7 +300,7 @@ function handleQuickBookmarkEnabledDisabledClick() {
 async function enableQuickBookmarkForThisPlaylist() {
   const currentQuickBookmarkTargetPlaylist = store.getters.getQuickBookmarkPlaylist
 
-  store.dispatch('updateQuickBookmarkTargetPlaylistId', playlistId)
+  store.dispatch('updateQuickBookmarkTargetPlaylistId', playlistMetadata.value.playlistId)
 
   if (currentQuickBookmarkTargetPlaylist != null) {
     showToast({
@@ -344,7 +329,7 @@ async function enableQuickBookmarkForThisPlaylist() {
 }
 
 async function removePlaylistBookmark() {
-  const removed = await store.dispatch('removePlaylistBookmark', playlistId)
+  const removed = await store.dispatch('removePlaylistBookmark', playlistMetadata.value.playlistId)
   if (!removed) {
     showToast({
       message: t('User Playlists.SinglePlaylistView.Toast["There was an issue with updating this playlist."]'),
@@ -364,7 +349,7 @@ const enableChannelLinks = computed(() => !store.getters.getDisableChannelLinks)
 function handleExternalPlayer() {
   if (process.env.IS_ELECTRON) {
     window.ftElectron.openInExternalPlayer({
-      playlistId: playlistId,
+      playlistId: playlistMetadata.value.playlistId,
       playbackRate: defaultPlayback.value,
     })
   }


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Make sure to follow the contributing guidelines. -->
<!-- Important note, we may remove your pull request if you do not use this provided PR template correctly. -->
<!-- Agent instructions: Preserve every heading, comment, and marker in this template. Never remove or rewrite the release-note-category:start/end, release-note:start/end, or release-note-image:start/end marker pairs. -->

## Pull Request Type
<!-- Please select what type of pull request this is: [x] -->
- [x] Bugfix
- [ ] Feature Implementation
- [ ] Documentation
- [ ] Other

## Related issue
<!-- Please link the issue your pull request is referring to. -->
<!-- If this pull request fully resolves the relevant issue, put "closes" before the issue number. -->
<!-- Example: "closes #123456". -->

Closes #1062.

## Description
<!-- Please write a clear and concise description of what the pull request does. -->

Playlist cards parsed their metadata only when the component mounted, so adding or removing videos left the displayed count stale. Other card metadata could become stale for the same reason.

Derive playlist card metadata reactively from the current playlist data. This updates the video count, title, thumbnail, channel, links, and related actions without remounting the card. Regression coverage exercises user-playlist video changes and saved-playlist metadata replacement while the list remains open.

## Release note category
<!-- Select exactly one category. Every pull request must select one. -->
<!-- Select "Not noteworthy" when the pull request fixes a bug in or improves functionality that has not yet appeared in a stable release. -->
<!-- release-note-category:start -->
- [ ] Not noteworthy
- [ ] Highlights
- [ ] More improvements
- [x] Fixed bugs
<!-- release-note-category:end -->

## Release note
<!-- Required unless "Not noteworthy" is selected. -->
<!-- Write one concise, user-facing entry without a leading bullet. -->
<!-- release-note:start -->
Playlist cards now update their video count and other metadata immediately when a playlist changes.
<!-- release-note:end -->

## Release note images
<!-- Optional. Paste one or more Markdown images, HTML image tags, or dark/light <picture> elements here. -->
<!-- The release notes normalize the markup and limit images taller than 300 pixels. -->
<!-- Agent instructions:
For a noteworthy visible change, add media when it makes the change easier to understand. Prefer a still image unless motion is the point; recordings must use animated WebP.
After implementing a visible change, proactively capture the result and show the local media to the user for approval before uploading it or updating the pull request.
When the affected UI differs between dark and light themes, capturing both themes is required. A dark-only image is incomplete. Run `node _scripts/releaseNoteMedia.mjs --dark DARK_FILE --light LIGHT_FILE --alt "DESCRIPTION"`; GitHub will display the matching theme and use dark as the fallback. Use a single default-dark capture only when the light theme cannot be captured or looks identical.
Capture or crop to the smallest region that still makes the change clear. Do not include the full window when the affected component can be understood on its own.
Use English unless localization is the subject. Keep components at their normal dimensions and placement instead of resizing them to fill the frame.
Use deterministic local fixtures for visible remote images. Reusable avatar and thumbnail fixtures are available through `e2e/helpers/visual-fixtures.mjs`. Before capturing, verify that every visible image has loaded successfully (`complete === true` and `naturalWidth > 0`).
Inspect the final dark and light files for failed images, missing content, unrelated UI, awkward animation, and misleading layout. Omit media when it does not explain the change clearly.
For one dark capture, run `node _scripts/releaseNoteMedia.mjs FILE --alt "DESCRIPTION"`.
Check for personal information, tokens, private repository names, and unrelated desktop content before uploading. Uploaded media is public.
Keep capture-only scripts, test hooks, screenshots, and recordings out of commits. Remove them before committing unless the capture code is also a reusable regression test. Never commit generated release-note media.
Paste only the generated markup between the marker comments. Leave this section empty when media would not help.
-->
<!-- release-note-image:start -->

<!-- release-note-image:end -->

## Testing
<!-- How can reviewers verify that the PR produces correct results? -->
<!-- Please provide instructions so that others can ensure that your pull request produces correct results. For examples see, https://github.com/FreeTubeApp/FreeTube/pull/5743, https://github.com/FreeTubeApp/FreeTube/pull/7349, https://github.com/FreeTubeApp/FreeTube/pull/5125, https://github.com/FreeTubeApp/FreeTube/pull/7338 -->
<!-- Agent instructions: Only write human-facing steps that explain how to verify the change while running this branch in dev mode. Include expected results and, when applicable, helpful console snippets for interactive verification. Do not include automated checks, commands, results, pass counts, or CI status. -->

1. Open the User Playlists page and keep it open.
2. Add a video to a playlist, then remove it again.
3. Confirm the playlist card updates its count and first-video thumbnail after each change without navigating away.
4. Refresh a saved playlist and confirm its title, channel, thumbnail, and video count update on the existing card.

## Additional context
<!-- Add any other context about the pull request here. -->
