### PR TITLE
fix(player): recover yt-dlp errors without reloading watch page

### DIFF
--- a/e2e/tests/offline/sabr-error-recovery.spec.mjs
+++ b/e2e/tests/offline/sabr-error-recovery.spec.mjs
@@ -487,6 +487,8 @@ test('yt-dlp recovery remounts only the player and preserves playback state', as
   const player = page.locator('.ftVideoPlayer')
   const video = player.locator('video')
   await expect(player).toBeVisible({ timeout: 30_000 })
+  await expect.poll(() => video.evaluate(element => element.currentTime))
+    .toBeGreaterThanOrEqual(watchHistoryEntry.watchProgress)
   await video.evaluate((element) => {
     element.pause()
     element.currentTime = 5.25
@@ -496,6 +498,15 @@ test('yt-dlp recovery remounts only the player and preserves playback state', as
 
   const playerBeforeReload = await player.elementHandle()
   const watchView = await watchViewHandle(page)
+  const activeVideoQualityBeforeReload = await watchView.evaluate(view => {
+    const getSabrReloadState = view.$refs.player.getSabrReloadState.bind(view.$refs.player)
+    view.$refs.player.getSabrReloadState = () => ({
+      ...getSabrReloadState(),
+      videoQuality: '360'
+    })
+    view.currentVideoQuality = 'auto'
+    return view.$refs.player.getSabrReloadState().videoQuality
+  })
   const stateBeforeReload = await watchView.evaluate(view => ({
     videoLoadGeneration: view.videoLoadGeneration,
     videoTitle: view.videoTitle,
@@ -515,6 +526,7 @@ test('yt-dlp recovery remounts only the player and preserves playback state', as
   await expect.poll(() => video.evaluate(element => element.currentTime)).toBeCloseTo(5, 1)
   await expect.poll(() => video.evaluate(element => element.playbackRate)).toBe(1.5)
   expect(await video.evaluate(element => element.paused)).toBe(true)
+  expect(await watchView.evaluate(view => view.currentVideoQuality)).toBe(activeVideoQualityBeforeReload)
 
   const playerAfterReload = await player.elementHandle()
   expect(await playerBeforeReload.evaluate(

--- a/e2e/tests/offline/sabr-error-recovery.spec.mjs
+++ b/e2e/tests/offline/sabr-error-recovery.spec.mjs
@@ -277,8 +277,9 @@ test('yt-dlp playback refreshes once then prefers built-in SABR over legacy', as
     }
 
     let refreshes = 0
-    watchView.reloadView = async () => {
+    watchView.extractYtDlpPlaybackSource = async () => {
       refreshes++
+      return true
     }
     let progressSaves = 0
     watchView.handleWatchProgressAutoSaveWhenProgressEnabled = () => {
@@ -341,7 +342,7 @@ test('yt-dlp playback refreshes once then prefers built-in SABR over legacy', as
   })
 })
 
-test('yt-dlp timeout reload reuses cache while a rejected source is invalidated', async ({ app, page }) => {
+test('yt-dlp player reload keeps metadata and reuses cache while a rejected source is invalidated', async ({ app, page }) => {
   await mockPlayableWatchPage(app, page)
   await goTo(page, 'history')
   await page.getByText('SABR test video').click()
@@ -386,7 +387,20 @@ test('yt-dlp timeout reload reuses cache while a rejected source is invalidated'
     view.manifestSrc = 'data:application/dash+xml,yt-dlp'
     view.manifestMimeType = 'application/dash+xml'
     view.legacyFormats = []
+    view.builtInPlaybackSource = {
+      manifestSrc: 'data:application/dash+xml,built-in',
+      manifestMimeType: 'application/dash+xml',
+      sabrData: null,
+      legacyFormats: [],
+      streamingDataExpiryDate: new Date(Date.now() + 60_000)
+    }
 
+    const metadataBeforeReload = JSON.stringify({
+      title: view.videoTitle,
+      description: view.videoDescription,
+      channelName: view.channelName,
+      recommendations: view.recommendedVideos
+    })
     const initialLoadGeneration = view.videoLoadGeneration
     const cacheReuseResults = []
     const extractYtDlpPlaybackSource = view.extractYtDlpPlaybackSource.bind(view)
@@ -436,26 +450,87 @@ test('yt-dlp timeout reload reuses cache while a rejected source is invalidated'
 
     return {
       activePlaybackEngineAfterTimeout,
+      activePlaybackEngineAfterRejection: view.activePlaybackEngine,
       cacheEntryAfterRejection: await window.ftElectron.ytDlpPlaybackCacheGet(
         view.videoId,
         cacheKey
       ),
       cachePreservedAfterTimeout: cacheEntryAfterTimeout !== null,
       cacheReuseResults,
+      metadataPreserved: metadataBeforeReload === JSON.stringify({
+        title: view.videoTitle,
+        description: view.videoDescription,
+        channelName: view.channelName,
+        recommendations: view.recommendedVideos
+      }),
       reloads: view.videoLoadGeneration - initialLoadGeneration
     }
   })
 
   expect(result).toEqual({
     activePlaybackEngineAfterTimeout: 'yt-dlp',
+    activePlaybackEngineAfterRejection: 'built-in',
     cacheEntryAfterRejection: null,
     cachePreservedAfterTimeout: true,
     cacheReuseResults: [true, false],
-    reloads: 2
+    metadataPreserved: true,
+    reloads: 0
   })
 })
 
-test('expired built-in playback source is refreshed before yt-dlp falls back', async ({ app, page }) => {
+test('yt-dlp recovery remounts only the player and preserves playback state', async ({ app, page }) => {
+  await mockPlayableWatchPage(app, page)
+  await goTo(page, 'history')
+  await page.getByText('SABR test video').click()
+  await expect(page).toHaveURL(/#\/watch\/jNQXAC9IVRw/)
+
+  const player = page.locator('.ftVideoPlayer')
+  const video = player.locator('video')
+  await expect(player).toBeVisible({ timeout: 30_000 })
+  await video.evaluate((element) => {
+    element.pause()
+    element.currentTime = 5.25
+    element.playbackRate = 1.5
+  })
+  await expect.poll(() => video.evaluate(element => element.currentTime)).toBeCloseTo(5.25, 1)
+
+  const playerBeforeReload = await player.elementHandle()
+  const watchView = await watchViewHandle(page)
+  const stateBeforeReload = await watchView.evaluate(view => ({
+    videoLoadGeneration: view.videoLoadGeneration,
+    videoTitle: view.videoTitle,
+    videoDescription: view.videoDescription,
+    channelName: view.channelName,
+    recommendedVideos: view.recommendedVideos
+  }))
+
+  await watchView.evaluate(async (view) => {
+    view.activePlaybackEngine = 'yt-dlp'
+    view.streamErrorReloadAttemptedForCurrentVideo = false
+    view.extractYtDlpPlaybackSource = async () => true
+    await view.handlePlayerError({ code: 1003, data: [] })
+  })
+
+  await expect(player).toBeVisible()
+  await expect.poll(() => video.evaluate(element => element.currentTime)).toBeCloseTo(5, 1)
+  await expect.poll(() => video.evaluate(element => element.playbackRate)).toBe(1.5)
+  expect(await video.evaluate(element => element.paused)).toBe(true)
+
+  const playerAfterReload = await player.elementHandle()
+  expect(await playerBeforeReload.evaluate(
+    (before, after) => before === after,
+    playerAfterReload
+  )).toBe(false)
+  expect(await watchView.evaluate(view => ({
+    videoLoadGeneration: view.videoLoadGeneration,
+    videoTitle: view.videoTitle,
+    videoDescription: view.videoDescription,
+    channelName: view.channelName,
+    recommendedVideos: view.recommendedVideos
+  }))).toEqual(stateBeforeReload)
+})
+
+test('expired built-in playback source is not restored after yt-dlp fails', async ({ app, page }) => {
   await mockUnplayableWatchPage(app, page)
   await goTo(page, 'history')
   await page.getByText('SABR test video').click()
@@ -487,6 +562,7 @@ test('expired built-in playback source is refreshed before yt-dlp falls back', a
     watchView.isPostLiveDvr = false
     watchView.activePlaybackEngine = 'yt-dlp'
     watchView.playbackEngineFallbackTarget = null
+    watchView.manifestSrc = 'https://example.invalid/yt-dlp.mpd'
     watchView.builtInPlaybackSource = {
       manifestSrc: 'https://example.invalid/expired.mpd',
       manifestMimeType: 'application/dash+xml',
@@ -495,34 +571,18 @@ test('expired built-in playback source is refreshed before yt-dlp falls back', a
       streamingDataExpiryDate: new Date(Date.now() - 1)
     }
 
-    let reloadOptions = null
-    watchView.reloadView = async (options) => {
-      reloadOptions = options
-      watchView.activePlaybackEngine = 'built-in'
-      watchView.manifestSrc = 'https://example.invalid/refreshed.mpd'
-    }
+    let reloads = 0
+    watchView.reloadView = async () => { reloads++ }
 
     const fallbackApplied = await watchView.tryPlaybackEngineFallback({
       code: 1002,
       data: ['https://example.invalid/video', 500]
     })
 
-    watchView.activePlaybackEngine = 'yt-dlp'
-    watchView.playbackEngineFallbackAttemptedForCurrentVideo = false
-    watchView.playbackEngineFallbackTarget = null
-    watchView.reloadView = async () => {
-      throw new Error('Synthetic built-in source refresh rejection')
-    }
-    const rejectedFallbackApplied = await watchView.tryPlaybackEngineFallback({
-      code: 1002,
-      data: ['https://example.invalid/video', 500]
-    })
-
     return {
       fallbackApplied,
-      rejectedFallbackApplied,
-      pendingAfterRejectedRefresh: watchView.ytDlpStreamsPending,
-      reloadOptions,
+      reloads,
+      pending: watchView.ytDlpStreamsPending,
       fallbackTarget: watchView.playbackEngineFallbackTarget,
       activePlaybackEngine: watchView.activePlaybackEngine,
       manifestSrc: watchView.manifestSrc
@@ -530,13 +590,12 @@ test('expired built-in playback source is refreshed before yt-dlp falls back', a
   })
 
   expect(result).toEqual({
-    fallbackApplied: true,
-    rejectedFallbackApplied: false,
-    pendingAfterRejectedRefresh: false,
-    reloadOptions: { preserveTitle: true },
-    fallbackTarget: 'built-in',
+    fallbackApplied: false,
+    reloads: 0,
+    pending: false,
+    fallbackTarget: null,
     activePlaybackEngine: 'yt-dlp',
-    manifestSrc: 'https://example.invalid/refreshed.mpd'
+    manifestSrc: 'https://example.invalid/yt-dlp.mpd'
   })
 })
 

--- a/src/renderer/views/Watch/Watch.js
+++ b/src/renderer/views/Watch/Watch.js
@@ -4670,12 +4670,11 @@ export default defineComponent({
     },
 
     /**
-     * Reload once for a playback error that may be fixed by fetching fresh
-     * streaming data.
+     * Starts the one stream-error recovery allowed for the current video.
      * @param {string} specificError
-     * @returns {Promise<boolean>} whether a reload was started
+     * @returns {boolean} whether recovery started
      */
-    reloadAfterStreamErrorOnce: async function (specificError) {
+    beginStreamErrorRecoveryOnce: function (specificError) {
       if (this.streamErrorReloadAttemptedForCurrentVideo) {
         return false
       }
@@ -4686,8 +4685,73 @@ export default defineComponent({
         message: `${this.t('Video.Reloading video after streaming URL error')}: ${specificError}`,
         icon: ['fas', 'sync'],
       })
+      return true
+    },
+
+    /**
+     * Reload once for a playback error that may be fixed by fetching fresh
+     * streaming data.
+     * @param {string} specificError
+     * @returns {Promise<boolean>} whether a reload was started
+     */
+    reloadAfterStreamErrorOnce: async function (specificError) {
+      if (!this.beginStreamErrorRecoveryOnce(specificError)) {
+        return false
+      }
+
       await this.reloadView()
       return true
+    },
+
+    /**
+     * Refreshes yt-dlp's streams and recreates only the player. The watch-page
+     * metadata and the built-in fallback source stay loaded.
+     * @param {string} specificError
+     * @returns {Promise<boolean>} whether recovery handled the error
+     */
+    reloadYtDlpPlayerAfterStreamErrorOnce: async function (specificError) {
+      if (!this.beginStreamErrorRecoveryOnce(specificError)) {
+        return false
+      }
+
+      const loadGeneration = this.videoLoadGeneration
+      const videoId = this.videoId
+      const playbackEngineSwitchGeneration = this.playbackEngineSwitchGeneration
+      this.setPlayerReloadState(this.$refs.player?.getSabrReloadState())
+
+      const timestamp = this.getTimestamp()
+      if (timestamp > 0) {
+        this.oneTimeTimestamp = timestamp
+      }
+
+      if (this.$refs.player) {
+        await this.destroyPlayer()
+      }
+
+      if (
+        !this.isCurrentVideoLoad(loadGeneration, videoId) ||
+        playbackEngineSwitchGeneration !== this.playbackEngineSwitchGeneration
+      ) {
+        return true
+      }
+
+      this.ytDlpStreamsPending = true
+      await this.$nextTick()
+
+      try {
+        return await this.extractYtDlpPlaybackSource(
+          loadGeneration,
+          videoId,
+          playbackEngineSwitchGeneration
+        )
+      } finally {
+        if (
+          this.isCurrentVideoLoad(loadGeneration, videoId) &&
+          playbackEngineSwitchGeneration === this.playbackEngineSwitchGeneration
+        ) {
+          this.ytDlpStreamsPending = false
+        }
+      }
     },
 
     /**
@@ -4724,7 +4788,7 @@ export default defineComponent({
           invalidateYtDlpPlaybackSource(this.videoId)
         }
         const status = error.code === Code.BAD_HTTP_STATUS ? error.data[1] : error.code
-        if (await this.reloadAfterStreamErrorOnce(`[PLAYER_ERROR: ${status}]`)) {
+        if (await this.reloadYtDlpPlayerAfterStreamErrorOnce(`[PLAYER_ERROR: ${status}]`)) {
           return
         }
       }
@@ -4899,7 +4963,11 @@ export default defineComponent({
         const source = this.builtInPlaybackSource
         if (
           source === null ||
-          (source.manifestSrc === null && source.legacyFormats.length === 0)
+          (source.manifestSrc === null && source.legacyFormats.length === 0) ||
+          (
+            source.streamingDataExpiryDate !== null &&
+            new Date() > source.streamingDataExpiryDate
+          )
         ) {
           return false
         }
@@ -4925,25 +4993,6 @@ export default defineComponent({
           playbackEngineSwitchGeneration !== this.playbackEngineSwitchGeneration
         ) {
           return true
-        }
-
-        if (
-          source.streamingDataExpiryDate !== null &&
-          new Date() > source.streamingDataExpiryDate
-        ) {
-          try {
-            await this.reloadView({ preserveTitle: true })
-            return true
-          } catch (reloadError) {
-            console.error('Refreshing the built-in playback source failed', reloadError)
-            if (
-              this.tabRoute.params.id === videoId &&
-              playbackEngineSwitchGeneration === this.playbackEngineSwitchGeneration
-            ) {
-              this.ytDlpStreamsPending = false
-            }
-            return false
-          }
         }
 
         this.manifestSrc = source.manifestSrc
@@ -5191,12 +5240,14 @@ export default defineComponent({
 
       if (this.playbackEngineFallbackTarget === 'built-in' && !cachedOnly) { return false }
 
-      this.builtInPlaybackSource = {
-        manifestSrc: this.manifestSrc,
-        manifestMimeType: this.manifestMimeType,
-        sabrData: this.sabrData,
-        legacyFormats: this.legacyFormats,
-        streamingDataExpiryDate: this.streamingDataExpiryDate
+      if (this.activePlaybackEngine !== 'yt-dlp') {
+        this.builtInPlaybackSource = {
+          manifestSrc: this.manifestSrc,
+          manifestMimeType: this.manifestMimeType,
+          sabrData: this.sabrData,
+          legacyFormats: this.legacyFormats,
+          streamingDataExpiryDate: this.streamingDataExpiryDate
+        }
       }
 
       this.manifestSrc = source.manifestSrc
@@ -5864,7 +5915,7 @@ export default defineComponent({
       }
     },
 
-    async performSabrReload(payload, toastMessage) {
+    setPlayerReloadState(payload) {
       const wasPlaying = payload?.wasPlaying === true
       this.resumePlaybackAfterSabrReload = wasPlaying
       this.suppressAutoplayAfterSabrReload = !wasPlaying
@@ -5875,6 +5926,10 @@ export default defineComponent({
         : this.currentPlaybackRate
       this.sabrReloadVideoQuality = this.normalizeVideoQuality(payload?.videoQuality) ||
         this.normalizeVideoQuality(this.currentVideoQuality) || null
+    },
+
+    async performSabrReload(payload, toastMessage) {
+      this.setPlayerReloadState(payload)
       this.preserveTitleOnNextReload = true
       this.showTabToast({ message: toastMessage, icon: ['fas', 'sync'] })
 

--- a/src/renderer/views/Watch/Watch.js
+++ b/src/renderer/views/Watch/Watch.js
@@ -4718,6 +4718,7 @@ export default defineComponent({
       const videoId = this.videoId
       const playbackEngineSwitchGeneration = this.playbackEngineSwitchGeneration
       this.setPlayerReloadState(this.$refs.player?.getSabrReloadState())
+      this.initializeVideoQuality()
 
       const timestamp = this.getTimestamp()
       if (timestamp > 0) {


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Make sure to follow the contributing guidelines. -->
<!-- Important note, we may remove your pull request if you do not use this provided PR template correctly. -->
<!-- Agent instructions: Preserve every heading, comment, and marker in this template. Never remove or rewrite the release-note-category:start/end, release-note:start/end, or release-note-image:start/end marker pairs. -->

## Pull Request Type
<!-- Please select what type of pull request this is: [x] -->
- [x] Bugfix
- [ ] Feature Implementation
- [ ] Documentation
- [ ] Other

## Related issue
<!-- Please link the issue your pull request is referring to. -->
<!-- If this pull request fully resolves the relevant issue, put "closes" before the issue number. -->
<!-- Example: "closes #123456". -->

## Description
<!-- Please write a clear and concise description of what the pull request does. -->
A YT-DLP stream error reloaded the entire watch view, which fetched metadata again and reset unrelated page state. Recovery now refreshes the YT-DLP source and remounts only the player. It restores the playback position, paused state, rate, and quality while keeping the existing metadata and built-in fallback source.

Expired built-in fallback sources are rejected without starting another full-view reload.

## Release note category
<!-- Select exactly one category. Every pull request must select one. -->
<!-- Select "Not noteworthy" when the pull request fixes a bug in or improves functionality that has not yet appeared in a stable release. -->
<!-- release-note-category:start -->
- [ ] Not noteworthy
- [ ] Highlights
- [ ] More improvements
- [x] Fixed bugs
<!-- release-note-category:end -->

## Release note
<!-- Required unless "Not noteworthy" is selected. -->
<!-- Write one concise, user-facing entry without a leading bullet. -->
<!-- release-note:start -->
YT-DLP playback now recovers from stream errors without reloading the watch page.
<!-- release-note:end -->

## Release note images
<!-- Optional. Paste one or more Markdown images, HTML image tags, or dark/light <picture> elements here. -->
<!-- The release notes normalize the markup and limit images taller than 300 pixels. -->
<!-- Agent instructions:
For a noteworthy visible change, add media when it makes the change easier to understand. Prefer a still image unless motion is the point; recordings must use animated WebP.
After implementing a visible change, proactively capture the result and show the local media to the user for approval before uploading it or updating the pull request.
When the affected UI differs between dark and light themes, capturing both themes is required. A dark-only image is incomplete. Run `node _scripts/releaseNoteMedia.mjs --dark DARK_FILE --light LIGHT_FILE --alt "DESCRIPTION"`; GitHub will display the matching theme and use dark as the fallback. Use a single default-dark capture only when the light theme cannot be captured or looks identical.
Capture or crop to the smallest region that still makes the change clear. Do not include the full window when the affected component can be understood on its own.
Use English unless localization is the subject. Keep components at their normal dimensions and placement instead of resizing them to fill the frame.
Use deterministic local fixtures for visible remote images. Reusable avatar and thumbnail fixtures are available through `e2e/helpers/visual-fixtures.mjs`. Before capturing, verify that every visible image has loaded successfully (`complete === true` and `naturalWidth > 0`).
Inspect the final dark and light files for failed images, missing content, unrelated UI, awkward animation, and misleading layout. Omit media when it does not explain the change clearly.
For one dark capture, run `node _scripts/releaseNoteMedia.mjs FILE --alt "DESCRIPTION"`.
Check for personal information, tokens, private repository names, and unrelated desktop content before uploading. Uploaded media is public.
Keep capture-only scripts, test hooks, screenshots, and recordings out of commits. Remove them before committing unless the capture code is also a reusable regression test. Never commit generated release-note media.
Paste only the generated markup between the marker comments. Leave this section empty when media would not help.
-->
<!-- release-note-image:start -->

<!-- release-note-image:end -->

## Testing
<!-- How can reviewers verify that the PR produces correct results? -->
<!-- Please provide instructions so that others can ensure that your pull request would produce correct results. For examples see, https://github.com/FreeTubeApp/FreeTube/pull/5743, https://github.com/FreeTubeApp/FreeTube/pull/7349, https://github.com/FreeTubeApp/FreeTube/pull/5125, https://github.com/FreeTubeApp/FreeTube/pull/7338 -->
<!-- Agent instructions: Only write human-facing steps that explain how to verify the change while running this branch in dev mode. Include expected results and, when applicable, helpful console snippets for interactive verification. Do not include automated checks, commands, results, pass counts, or CI status. -->
1. Play a video with YT-DLP, seek away from the beginning, change the playback rate, and pause it.
2. Trigger a recoverable stream error.
3. Confirm that the player is recreated and resumes at the saved position with the same paused state and playback rate.
4. Confirm that the title, description, channel details, and recommendations do not reload.
5. Trigger another stream error and confirm that recovery does not enter a retry loop.

## Additional context
<!-- Add any other context about the pull request here. -->
No release-note image is included because successful recovery leaves the visible watch page unchanged.
