### PR TITLE
fix(player): support minimize auto PiP on KDE Wayland

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -23,6 +23,7 @@ updates:
       - dependency-name: "@iconify/vue"
       - dependency-name: "@playwright/test"
       - dependency-name: "@vot.js/core"
+      - dependency-name: "dbus-native"
       - dependency-name: "eld"
       - dependency-name: "font-list"
       - dependency-name: "overlayscrollbars"

--- a/package.json
+++ b/package.json
@@ -77,6 +77,7 @@
     "@vot.js/core": "^3.0.2",
     "autolinker": "^4.1.5",
     "bgutils-js": "^4.0.3",
+    "dbus-native": "^0.15.2",
     "dompurify": "^3.4.13",
     "eld": "^2.1.0",
     "font-list": "^2.1.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -50,6 +50,9 @@ importers:
       bgutils-js:
         specifier: ^4.0.3
         version: 4.0.3
+      dbus-native:
+        specifier: ^0.15.2
+        version: 0.15.2
       dompurify:
         specifier: ^3.4.13
         version: 3.4.14
@@ -2458,6 +2461,11 @@ packages:
 
   csstype@3.2.3:
     resolution: {integrity: sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==}
+
+  dbus-native@0.15.2:
+    resolution: {integrity: sha512-J1IBi4LmbqrFhroN66Dj1tCCTP6TVbZgUKhWQZf3uS6t93yRWEcRRDjOZV9N6boGRhOp/BOjLliFm9vWu1QZOA==}
+    engines: {node: '>=22.12.0'}
+    hasBin: true
 
   debug@2.6.9:
     resolution: {integrity: sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==}
@@ -8076,6 +8084,10 @@ snapshots:
       css-tree: 2.2.1
 
   csstype@3.2.3: {}
+
+  dbus-native@0.15.2:
+    dependencies:
+      xml2js: 0.6.2
 
   debug@2.6.9:
     dependencies:

--- a/src/constants.js
+++ b/src/constants.js
@@ -101,6 +101,7 @@ const IpcChannels = {
   TABS_REQUEST_PICTURE_IN_PICTURE: 'tabs-request-picture-in-picture',
   WINDOW_MINIMIZED_STATE: 'window-minimized-state',
   WINDOW_FOCUSED_STATE: 'window-focused-state',
+  SUPPORTS_AUTO_PICTURE_IN_PICTURE_MINIMIZE: 'supports-auto-picture-in-picture-minimize',
   TABS_REQUEST_FULLSCREEN: 'tabs-request-fullscreen',
   TABS_SET_TAB_BAR_SCROLL: 'tabs-set-tab-bar-scroll',
   TABS_SET_CONTEXT_MENU_TAB: 'tabs-set-context-menu-tab',

--- a/src/main/index.js
+++ b/src/main/index.js
@@ -70,6 +70,12 @@ import { clearVideoMetadataCache, getVideoMetadataCacheSize, updateVideoMetadata
 import { shouldAdvanceDockMediaSequence } from './dockMediaSession'
 import { clearStorage, compactStorageDatabases, getStorageUsage } from './storage'
 import { getLinuxDistributionInfo } from './linuxDistribution'
+import {
+  createKdeWaylandWindowStateBackend,
+  isWaylandPlatform as detectWaylandPlatform,
+  monitorKdeWaylandWindowState,
+  shouldMonitorKdeWaylandWindowState,
+} from './kdeWaylandWindowState'
 
 const brotliDecompressAsync = promisify(brotliDecompress)
 if (process.argv.includes('--version')) {
@@ -1690,7 +1696,27 @@ function runApp() {
   const pendingOpenUrlsByWebContentsId = new Map()
   const openUrlReadyWebContentsIds = new Set()
   const activeLiveNotifications = new Set()
-  const isTrayOnMinimizeSupported = process.platform !== 'darwin' && (process.platform !== 'linux' || app.commandLine.getSwitchValue('ozone-platform') !== 'wayland')
+  const ozonePlatform = app.commandLine.getSwitchValue('ozone-platform')
+  const isWaylandPlatform = detectWaylandPlatform({
+    platform: process.platform,
+    ozonePlatform,
+    environment: process.env,
+  })
+  const monitorsKdeWaylandWindowState = shouldMonitorKdeWaylandWindowState({
+    platform: process.platform,
+    ozonePlatform,
+    environment: process.env,
+  })
+  const kdeWaylandWindowStateBackend = monitorsKdeWaylandWindowState
+    ? createKdeWaylandWindowStateBackend()
+    : Promise.resolve(null)
+  app.once('will-quit', () => {
+    kdeWaylandWindowStateBackend.then(backend => backend?.close()).catch(() => {})
+  })
+  const supportsAutoPictureInPictureMinimize = isWaylandPlatform
+    ? kdeWaylandWindowStateBackend.then(backend => backend !== null)
+    : Promise.resolve(true)
+  const isTrayOnMinimizeSupported = process.platform !== 'darwin' && !isWaylandPlatform
 
   const userDataPath = app.getPath('userData')
 
@@ -2703,6 +2729,25 @@ function runApp() {
             height: 800
           }
     })
+    const kdeWindowIdentity = monitorsKdeWaylandWindowState
+      ? `\u2063${newWindow.id.toString(2).replaceAll('0', '\u200b').replaceAll('1', '\u200c')}`
+      : ''
+    let kdeWindowIdentityReleased = false
+    const formatKdeWindowTitle = title => (
+      kdeWindowIdentityReleased || kdeWindowIdentity === '' || title.endsWith(kdeWindowIdentity)
+        ? title
+        : `${title}${kdeWindowIdentity}`
+    )
+    const applyKdeWindowIdentity = () => {
+      const title = formatKdeWindowTitle(newWindow.getTitle())
+      if (title !== newWindow.getTitle()) newWindow.setTitle(title)
+    }
+    const releaseKdeWindowIdentity = () => {
+      kdeWindowIdentityReleased = true
+      if (kdeWindowIdentity !== '' && !newWindow.isDestroyed() && newWindow.getTitle().endsWith(kdeWindowIdentity)) {
+        newWindow.setTitle(newWindow.getTitle().slice(0, -kdeWindowIdentity.length))
+      }
+    }
 
     // The single BrowserWindow renderer owns window.open handling through its
     // TabManager; logical tabs do not create child webContents.
@@ -2716,7 +2761,8 @@ function runApp() {
       newWindow,
       ROOT_APP_URL,
       preloadPath,
-      sessionData?.sessionId
+      sessionData?.sessionId,
+      title => newWindow.setTitle(formatKdeWindowTitle(title))
     )
 
     // Forward the native window minimized state to the renderer. The renderer can't
@@ -2732,6 +2778,15 @@ function runApp() {
     // Cover minimize-to-tray (and app hide), where the window is hidden rather than minimized.
     newWindow.on('hide', () => sendMinimizedState(true))
     newWindow.on('show', () => sendMinimizedState(false))
+    if (monitorsKdeWaylandWindowState) {
+      monitorKdeWaylandWindowState({
+        browserWindow: newWindow,
+        backend: kdeWaylandWindowStateBackend,
+        applyWindowIdentity: applyKdeWindowIdentity,
+        onMinimizedState: sendMinimizedState,
+        releaseWindowIdentity: releaseKdeWindowIdentity,
+      })
+    }
 
     // Renderer focus events can be skipped on Windows when focus returns after
     // another application's window is closed. Forward the native state so
@@ -2833,6 +2888,7 @@ function runApp() {
       if (isTrayOnMinimizeSupported && trayOnMinimize && trayWindows.length > 0) {
         trayClick(newWindow)
       } else {
+        applyKdeWindowIdentity()
         newWindow.show()
         newWindow.focus()
       }
@@ -3788,7 +3844,13 @@ function runApp() {
 
   ipcMain.handle(IpcChannels.IS_WAYLAND_PLATFORM, (event) => {
     if (isOpenTubeXUrl(event.senderFrame.url)) {
-      return app.commandLine.getSwitchValue('ozone-platform') === 'wayland'
+      return isWaylandPlatform
+    }
+  })
+
+  ipcMain.handle(IpcChannels.SUPPORTS_AUTO_PICTURE_IN_PICTURE_MINIMIZE, async (event) => {
+    if (isOpenTubeXUrl(event.senderFrame.url)) {
+      return supportsAutoPictureInPictureMinimize
     }
   })
 

--- a/src/main/kdeWaylandWindowState.js
+++ b/src/main/kdeWaylandWindowState.js
@@ -1,0 +1,387 @@
+import dbus from 'dbus-native'
+
+const KDE_DESKTOP_PATTERN = /(?:^|[:;/_-])(?:kde|plasma(?:wayland)?)(?:$|[:;/_-])/i
+const KWIN_SERVICE = 'org.kde.KWin'
+const WINDOW_SEARCH_TERM = 'OpenTubeX'
+
+/**
+ * @param {NodeJS.ProcessEnv} environment
+ * @returns {boolean}
+ */
+export function isKdePlasmaDesktop(environment) {
+  if (environment.KDE_FULL_SESSION === 'true') return true
+
+  return [
+    environment.XDG_CURRENT_DESKTOP,
+    environment.XDG_SESSION_DESKTOP,
+    environment.DESKTOP_SESSION,
+  ].some(value => typeof value === 'string' && KDE_DESKTOP_PATTERN.test(value))
+}
+
+/**
+ * @param {{
+ *   platform: NodeJS.Platform,
+ *   ozonePlatform: string,
+ *   environment: NodeJS.ProcessEnv
+ * }} options
+ * @returns {boolean}
+ */
+export function isWaylandPlatform({ platform, ozonePlatform }) {
+  return platform === 'linux' && ozonePlatform === 'wayland'
+}
+
+/**
+ * @param {{
+ *   platform: NodeJS.Platform,
+ *   ozonePlatform: string,
+ *   environment: NodeJS.ProcessEnv
+ * }} options
+ * @returns {boolean}
+ */
+function mayUseWayland({ platform, ozonePlatform, environment }) {
+  if (platform !== 'linux' || ozonePlatform === 'x11') return false
+  if (ozonePlatform === 'wayland') return true
+
+  return environment.XDG_SESSION_TYPE === 'wayland' ||
+    typeof environment.WAYLAND_DISPLAY === 'string'
+}
+
+/**
+ * @param {{
+ *   platform: NodeJS.Platform,
+ *   ozonePlatform: string,
+ *   environment: NodeJS.ProcessEnv
+ * }} options
+ * @returns {boolean}
+ */
+export function shouldMonitorKdeWaylandWindowState({
+  platform,
+  ozonePlatform,
+  environment,
+}) {
+  return mayUseWayland({ platform, ozonePlatform, environment }) &&
+    isKdePlasmaDesktop(environment)
+}
+
+/**
+ * @typedef {{
+ *   uuid: string,
+ *   caption: string,
+ *   minimized: boolean,
+ *   pid: number,
+ *   width: number,
+ *   height: number
+ * }} KwinWindowInfo
+ */
+
+/**
+ * @param {unknown} value
+ * @returns {KwinWindowInfo | null}
+ */
+export function normalizeKwinWindowInfo(value) {
+  if (value === null || typeof value !== 'object') return null
+
+  const { uuid, caption, minimized, pid, width, height } = value
+  const numericPid = typeof pid === 'bigint' ? Number(pid) : pid
+  if (
+    typeof uuid !== 'string' ||
+    typeof caption !== 'string' ||
+    typeof minimized !== 'boolean' ||
+    !Number.isSafeInteger(numericPid) ||
+    ![width, height].every(Number.isSafeInteger)
+  ) {
+    return null
+  }
+
+  return {
+    uuid,
+    caption,
+    minimized,
+    pid: numericPid,
+    width,
+    height,
+  }
+}
+
+/**
+ * @param {unknown} matches
+ * @returns {string[]}
+ */
+export function extractKwinWindowHandles(matches) {
+  if (!Array.isArray(matches)) return []
+
+  return matches.flatMap(match => {
+    const id = Array.isArray(match) ? match[0] : null
+    const handle = typeof id === 'string'
+      ? id.match(/^0_(\{[0-9a-f-]+\})$/i)?.[1]
+      : null
+    return handle === undefined || handle === null ? [] : [handle]
+  })
+}
+
+/**
+ * @param {KwinWindowInfo[]} previous
+ * @param {KwinWindowInfo[]} current
+ * @param {{ caption: string, bounds: Electron.Rectangle }} target
+ * @returns {KwinWindowInfo | null}
+ */
+export function findNewlyMinimizedWindow(previous, current, target) {
+  const previousByUuid = new Map(previous.map(window => [window.uuid, window]))
+  const transitionedWindows = current.filter(window => (
+    window.minimized &&
+    previousByUuid.get(window.uuid)?.minimized === false
+  ))
+  const transitionedWindow = findMatchingWindow(transitionedWindows, target)
+  if (transitionedWindow !== null) return transitionedWindow
+
+  if (previous.length === 0) {
+    return findMatchingWindow(current.filter(window => window.minimized), target)
+  }
+
+  return null
+}
+
+/**
+ * BrowserWindow bounds and KWin frame geometry can differ by the server-side
+ * decoration size. Native Wayland does not expose reliable window positions
+ * to Electron, so use the size only when more than one minimized window has
+ * the same caption.
+ *
+ * @param {KwinWindowInfo[]} windows
+ * @param {{ caption: string, bounds: Electron.Rectangle }} target
+ * @returns {KwinWindowInfo | null}
+ */
+function findMatchingWindow(windows, { caption, bounds }) {
+  const maximumDecorationSize = 64
+  const matchingWindows = windows.filter(window => window.caption === caption)
+  if (matchingWindows.length === 1) return matchingWindows[0]
+
+  const candidates = matchingWindows.flatMap(window => {
+    const differences = [
+      Math.abs(window.width - bounds.width),
+      Math.abs(window.height - bounds.height),
+    ]
+    if (differences.some(difference => difference > maximumDecorationSize)) return []
+
+    return [{ window, distance: differences.reduce((total, difference) => total + difference, 0) }]
+  }).sort((left, right) => left.distance - right.distance)
+
+  if (candidates.length === 0 || candidates[0].distance === candidates[1]?.distance) return null
+  return candidates[0].window
+}
+
+/**
+ * @param {import('dbus-native').DBusInterface} kwin
+ * @param {string} uuid
+ * @returns {Promise<KwinWindowInfo | null>}
+ */
+async function queryKwinWindow(kwin, uuid) {
+  return normalizeKwinWindowInfo(await kwin.getWindowInfo(uuid))
+}
+
+/**
+ * @param {import('dbus-native').DBusInterface} kwin
+ * @param {import('dbus-native').DBusInterface} runner
+ * @param {number} processId
+ * @returns {Promise<KwinWindowInfo[]>}
+ */
+async function queryKwinWindows(kwin, runner, processId) {
+  const handles = [...new Set(extractKwinWindowHandles(await runner.Match(WINDOW_SEARCH_TERM)))]
+  const windows = await Promise.all(handles.map(handle => queryKwinWindow(kwin, handle)))
+
+  return windows.filter(window => window?.pid === processId)
+}
+
+/**
+ * Connect to KWin through the user's D-Bus session and verify the interfaces
+ * used by the monitor.
+ *
+ * @returns {Promise<{
+ *   close: () => Promise<void>,
+ *   queryWindow: (uuid: string) => Promise<KwinWindowInfo | null>,
+ *   queryWindows: (processId: number) => Promise<KwinWindowInfo[]>
+ * } | null>}
+ */
+export async function createKdeWaylandWindowStateBackend() {
+  let bus
+
+  try {
+    bus = dbus.sessionBus({ reconnect: true, timeout: 2_000 })
+    bus.connection.on('error', () => {})
+    const service = bus.getService(KWIN_SERVICE)
+    const [kwin, runner] = await Promise.all([
+      service.getInterface('/KWin', 'org.kde.KWin'),
+      service.getInterface('/WindowsRunner', 'org.kde.krunner1'),
+    ])
+    await runner.Match(WINDOW_SEARCH_TERM)
+
+    return {
+      close: () => bus.close(),
+      queryWindow: uuid => queryKwinWindow(kwin, uuid),
+      queryWindows: processId => queryKwinWindows(kwin, runner, processId),
+    }
+  } catch {
+    await bus?.close().catch(() => {})
+    return null
+  }
+}
+
+/**
+ * Electron does not receive KWin's compositor-driven minimize event on native
+ * Wayland. Compare KWin state after blur, then poll only while minimized so a
+ * restore is forwarded too.
+ *
+ * @param {{
+ *   browserWindow: import('electron').BrowserWindow,
+ *   backend: ReturnType<typeof createKdeWaylandWindowStateBackend>,
+ *   applyWindowIdentity?: () => void,
+ *   onMinimizedState: (minimized: boolean) => void,
+ *   releaseWindowIdentity?: () => void,
+ *   processId?: number,
+ *   detectionDelay?: number,
+ *   pollInterval?: number
+ * }} options
+ * @returns {() => void}
+ */
+export function monitorKdeWaylandWindowState({
+  browserWindow,
+  backend,
+  applyWindowIdentity = () => {},
+  onMinimizedState,
+  releaseWindowIdentity = () => {},
+  processId = process.pid,
+  detectionDelay = 100,
+  pollInterval = 1_000,
+}) {
+  let baseline = []
+  let generation = 0
+  let minimized = false
+  let minimizedUuid = null
+  let windowUuid = null
+  let pollTimer = null
+  let stopped = false
+
+  const clearPoll = () => {
+    if (pollTimer !== null) clearTimeout(pollTimer)
+    pollTimer = null
+  }
+  const setMinimized = value => {
+    if (minimized === value) return
+    minimized = value
+    onMinimizedState(value)
+  }
+  const refreshBaseline = token => {
+    const target = {
+      caption: browserWindow.getTitle(),
+      bounds: browserWindow.getBounds(),
+    }
+    const pending = backend.then(value => value?.queryWindows(processId) ?? [])
+    pending.then(windows => {
+      if (!stopped && generation === token && !minimized && browserWindow.isFocused()) {
+        baseline = windows
+        const window = findMatchingWindow(windows, target)
+        if (window !== null) {
+          windowUuid = window.uuid
+          releaseWindowIdentity()
+        }
+      }
+    }).catch(() => {})
+    return pending
+  }
+  const schedulePoll = token => {
+    clearPoll()
+    if (stopped) return
+    pollTimer = setTimeout(async () => {
+      pollTimer = null
+      if (stopped || generation !== token || minimizedUuid === null) return
+
+      let window
+      try {
+        const value = await backend
+        if (value === null) return
+        window = await value.queryWindow(minimizedUuid)
+      } catch {
+        schedulePoll(token)
+        return
+      }
+      if (stopped || generation !== token) return
+
+      if (window?.minimized) {
+        schedulePoll(token)
+        return
+      }
+
+      minimizedUuid = null
+      setMinimized(false)
+      refreshBaseline(token).catch(() => {})
+    }, pollInterval)
+  }
+  const handleFocus = () => {
+    applyWindowIdentity()
+    const token = ++generation
+    clearPoll()
+    minimizedUuid = null
+    setMinimized(false)
+    refreshBaseline(token).catch(() => {})
+  }
+  const handleBlur = async () => {
+    applyWindowIdentity()
+    const token = ++generation
+    clearPoll()
+
+    const previous = baseline
+    try {
+      await new Promise(resolve => setTimeout(resolve, detectionDelay))
+      if (stopped || generation !== token) return
+
+      const value = await backend
+      if (value === null) {
+        releaseWindowIdentity()
+        return
+      }
+      applyWindowIdentity()
+      const target = {
+        caption: browserWindow.getTitle(),
+        bounds: browserWindow.getBounds(),
+      }
+      const current = await value.queryWindows(processId)
+      if (stopped || generation !== token) return
+
+      baseline = current
+      const previousByUuid = new Map(previous.map(window => [window.uuid, window]))
+      const claimedWindow = windowUuid === null
+        ? null
+        : current.find(window => (
+          window.uuid === windowUuid &&
+          window.minimized &&
+          (previous.length === 0 || previousByUuid.get(windowUuid)?.minimized === false)
+        )) ?? null
+      const window = claimedWindow ?? findNewlyMinimizedWindow(previous, current, target)
+      if (window === null) return
+
+      windowUuid = window.uuid
+      releaseWindowIdentity()
+      minimizedUuid = window.uuid
+      setMinimized(true)
+      schedulePoll(token)
+    } catch {
+      // A failed query disables this transition only. The next focus or blur
+      // retries without affecting normal Electron window events.
+    }
+  }
+  const stop = () => {
+    stopped = true
+    generation++
+    clearPoll()
+    browserWindow.removeListener('focus', handleFocus)
+    browserWindow.removeListener('blur', handleBlur)
+    browserWindow.removeListener('closed', stop)
+  }
+
+  browserWindow.on('focus', handleFocus)
+  browserWindow.on('blur', handleBlur)
+  browserWindow.once('closed', stop)
+  refreshBaseline(generation).catch(() => {})
+
+  return stop
+}

--- a/src/main/tabs/TabManager.js
+++ b/src/main/tabs/TabManager.js
@@ -702,9 +702,11 @@ export class TabManager {
    * @param {string} rootAppUrl
    * @param {string} _preloadPath
    * @param {string} [sessionId]
+   * @param {(title: string) => void} [setWindowTitle]
    */
-  constructor(browserWindow, rootAppUrl, _preloadPath, sessionId) {
+  constructor(browserWindow, rootAppUrl, _preloadPath, sessionId, setWindowTitle) {
     this.browserWindow = browserWindow
+    this._setWindowTitle = setWindowTitle ?? (title => browserWindow.setTitle(title))
     this.rootAppUrl = rootAppUrl
     this.sessionId = sessionId || randomUUID()
     /** @type {Map<string, TabInfo>} */
@@ -852,7 +854,7 @@ export class TabManager {
 
     tab.title = nextTitle
     if (this.activeTabId === tab.id) {
-      this.browserWindow.setTitle(nextTitle)
+      this._setWindowTitle(nextTitle)
     }
 
     this._broadcastStateUpdate()
@@ -1288,7 +1290,7 @@ export class TabManager {
     tab.lastActiveAt = Date.now()
     this.activeTabId = tabId
     this.selectionRevision += 1
-    this.browserWindow.setTitle(tab.title)
+    this._setWindowTitle(tab.title)
     this.bridge.send(IpcChannels.TABS_ACTIVE_CHANGED, tabId, this.selectionRevision)
     if (shouldResumeDeferredStartupWatchTabs) {
       this._resumeDeferredStartupWatchTabs()
@@ -3273,7 +3275,7 @@ export class TabManager {
       if (nextActiveTabId !== this.activeTabId || this.tabs.get(nextActiveTabId)?.loadState === 'unloaded') {
         this.activateTab(nextActiveTabId)
       } else {
-        this.browserWindow.setTitle(this.tabs.get(nextActiveTabId).title)
+        this._setWindowTitle(this.tabs.get(nextActiveTabId).title)
         this._broadcastStateUpdate()
       }
 

--- a/src/preload/interface.js
+++ b/src/preload/interface.js
@@ -119,6 +119,13 @@ export default {
   },
 
   /**
+   * @returns {Promise<boolean>}
+   */
+  supportsAutoPictureInPictureMinimize: () => {
+    return ipcRenderer.invoke(IpcChannels.SUPPORTS_AUTO_PICTURE_IN_PICTURE_MINIMIZE)
+  },
+
+  /**
    * @param {string} path
    * @param {Record<string, string> | null | undefined} query
    * @param {string | null | undefined} searchQueryText

--- a/src/renderer/components/PlayerSettings/PlayerSettings.vue
+++ b/src/renderer/components/PlayerSettings/PlayerSettings.vue
@@ -238,9 +238,9 @@
         :title="t('Settings.Player Settings.Auto Picture in Picture.Auto Picture in Picture')"
         :labels="autoPictureInPictureTriggerLabels"
         :values="AUTO_PIP_TRIGGER_VALUES"
-        :disabled-values="isLinuxWayland ? ['minimize'] : []"
+        :disabled-values="supportsAutoPictureInPictureMinimize ? [] : ['minimize']"
         setting-key="autoPictureInPictureTriggers"
-        :tooltips="isLinuxWayland ? { minimize: t('Settings.Player Settings.Auto Picture in Picture.Wayland Minimize Unsupported') } : {}"
+        :tooltips="supportsAutoPictureInPictureMinimize ? {} : { minimize: t('Settings.Player Settings.Auto Picture in Picture.Wayland Minimize Unsupported') }"
       />
     </FtFlexBox>
     <FtFlexBox class="playerSelectGrid">
@@ -615,7 +615,7 @@ import FtSettingsSubpage from '../FtSettingsSubpage/FtSettingsSubpage.vue'
 
 import store from '../../store/index'
 import { DEFAULT_QUICK_PLAYBACK_SPEED_BAR_OPTIONS } from '../../../constants'
-import { initializePlatformInfo, isLinuxWayland } from '../../helpers/platform'
+import { initializePlatformInfo, supportsAutoPictureInPictureMinimize } from '../../helpers/platform'
 import {
   DEFAULT_SEGMENT_PREFETCH_LIMIT,
   MAX_SEGMENT_PREFETCH_LIMIT
@@ -961,8 +961,6 @@ function updateDefaultViewingMode(value) {
 
 const AUTO_PIP_TRIGGER_VALUES = ['tab', 'minimize', 'blur']
 
-// The 'minimize' window event doesn't fire on Wayland, so the minimize trigger can't work there.
-// https://github.com/electron/electron/issues/51766
 initializePlatformInfo()
 
 const autoPictureInPictureTriggerLabels = computed(() => [

--- a/src/renderer/helpers/platform.js
+++ b/src/renderer/helpers/platform.js
@@ -1,9 +1,11 @@
 import { readonly, ref } from 'vue'
 
 const linuxWayland = ref(false)
+const autoPictureInPictureMinimizeSupported = ref(true)
 let platformInfoPromise = null
 
 export const isLinuxWayland = readonly(linuxWayland)
+export const supportsAutoPictureInPictureMinimize = readonly(autoPictureInPictureMinimizeSupported)
 
 /** Resolve renderer platform details once and share them across every settings view. */
 export function initializePlatformInfo() {
@@ -14,9 +16,13 @@ export function initializePlatformInfo() {
     return platformInfoPromise
   }
 
-  platformInfoPromise = window.ftElectron.isWaylandPlatform()
-    .then(value => {
-      linuxWayland.value = value
+  platformInfoPromise = Promise.all([
+    window.ftElectron.isWaylandPlatform(),
+    window.ftElectron.supportsAutoPictureInPictureMinimize(),
+  ])
+    .then(([wayland, minimizeSupported]) => {
+      linuxWayland.value = wayland
+      autoPictureInPictureMinimizeSupported.value = minimizeSupported
     })
     .catch(error => {
       console.error('Failed to determine whether Electron is using Wayland', error)

--- a/tests/unit/kde-wayland-window-state.test.mjs
+++ b/tests/unit/kde-wayland-window-state.test.mjs
@@ -1,0 +1,240 @@
+import assert from 'node:assert/strict'
+import { EventEmitter } from 'node:events'
+import test from 'node:test'
+
+import {
+  extractKwinWindowHandles,
+  findNewlyMinimizedWindow,
+  isKdePlasmaDesktop,
+  isWaylandPlatform,
+  monitorKdeWaylandWindowState,
+  normalizeKwinWindowInfo,
+  shouldMonitorKdeWaylandWindowState,
+} from '../../src/main/kdeWaylandWindowState.js'
+
+test('recognizes common KDE Plasma desktop environment values', () => {
+  assert.equal(isKdePlasmaDesktop({ XDG_CURRENT_DESKTOP: 'KDE' }), true)
+  assert.equal(isKdePlasmaDesktop({ XDG_CURRENT_DESKTOP: 'KDE:GNOME' }), true)
+  assert.equal(isKdePlasmaDesktop({ XDG_SESSION_DESKTOP: 'plasmawayland' }), true)
+  assert.equal(isKdePlasmaDesktop({ DESKTOP_SESSION: '/usr/share/wayland-sessions/plasma' }), true)
+  assert.equal(isKdePlasmaDesktop({ KDE_FULL_SESSION: 'true' }), true)
+})
+
+test('does not treat other desktops as KDE Plasma', () => {
+  assert.equal(isKdePlasmaDesktop({ XDG_CURRENT_DESKTOP: 'GNOME' }), false)
+  assert.equal(isKdePlasmaDesktop({ XDG_CURRENT_DESKTOP: 'sway' }), false)
+  assert.equal(isKdePlasmaDesktop({}), false)
+})
+
+test('reports native Wayland only for an explicit Electron runtime choice', () => {
+  assert.equal(isWaylandPlatform({
+    platform: 'linux',
+    ozonePlatform: 'wayland',
+    environment: {},
+  }), true)
+  assert.equal(isWaylandPlatform({
+    platform: 'linux',
+    ozonePlatform: '',
+    environment: { XDG_SESSION_TYPE: 'wayland' },
+  }), false)
+  assert.equal(isWaylandPlatform({
+    platform: 'linux',
+    ozonePlatform: 'x11',
+    environment: { XDG_SESSION_TYPE: 'wayland', WAYLAND_DISPLAY: 'wayland-0' },
+  }), false)
+})
+
+test('monitors window state only for KDE Plasma in a Wayland session', () => {
+  const kde = { XDG_CURRENT_DESKTOP: 'KDE' }
+
+  assert.equal(shouldMonitorKdeWaylandWindowState({
+    platform: 'linux',
+    ozonePlatform: 'wayland',
+    environment: kde,
+  }), true)
+  assert.equal(shouldMonitorKdeWaylandWindowState({
+    platform: 'linux',
+    ozonePlatform: 'x11',
+    environment: { ...kde, XDG_SESSION_TYPE: 'wayland' },
+  }), false)
+  assert.equal(shouldMonitorKdeWaylandWindowState({
+    platform: 'linux',
+    ozonePlatform: 'wayland',
+    environment: { XDG_CURRENT_DESKTOP: 'GNOME' },
+  }), false)
+  assert.equal(shouldMonitorKdeWaylandWindowState({
+    platform: 'win32',
+    ozonePlatform: 'wayland',
+    environment: kde,
+  }), false)
+})
+
+test('extracts KWin runner handles and validates D-Bus window state', () => {
+  const matches = [
+    [
+      '0_{01234567-89ab-cdef-0123-456789abcdef}',
+      'Subscriptions - OpenTubeX',
+      'electron',
+      100,
+      1,
+      {},
+    ],
+  ]
+  const windowInfo = {
+    caption: 'Subscriptions - OpenTubeX',
+    height: 832,
+    minimized: true,
+    pid: 1234,
+    uuid: '{01234567-89ab-cdef-0123-456789abcdef}',
+    width: 1200,
+  }
+
+  assert.deepEqual(extractKwinWindowHandles(matches), [
+    '{01234567-89ab-cdef-0123-456789abcdef}',
+  ])
+  assert.deepEqual(normalizeKwinWindowInfo(windowInfo), {
+    uuid: '{01234567-89ab-cdef-0123-456789abcdef}',
+    caption: 'Subscriptions - OpenTubeX',
+    height: 832,
+    minimized: true,
+    pid: 1234,
+    width: 1200,
+  })
+})
+
+test('rejects malformed D-Bus window state and runner matches', () => {
+  assert.equal(normalizeKwinWindowInfo({ minimized: true }), null)
+  assert.deepEqual(extractKwinWindowHandles([['invalid-id'], null]), [])
+})
+
+test('detects the KWin window newly minimized by a shortcut', () => {
+  const previous = [
+    windowInfo({ uuid: 'one', minimized: false }),
+    windowInfo({ uuid: 'two', caption: 'Watch - OpenTubeX', minimized: true }),
+  ]
+  const current = [
+    windowInfo({ uuid: 'one', minimized: true }),
+    windowInfo({ uuid: 'two', caption: 'Watch - OpenTubeX', minimized: true }),
+  ]
+
+  assert.deepEqual(
+    findNewlyMinimizedWindow(previous, current, targetWindow()),
+    current[0]
+  )
+})
+
+test('does not mistake an ordinary focus change for minimize', () => {
+  const state = [
+    windowInfo({ uuid: 'one', minimized: false }),
+  ]
+
+  assert.equal(findNewlyMinimizedWindow(state, state, targetWindow()), null)
+})
+
+test('detects a single minimized window when no earlier KWin snapshot is available', () => {
+  const current = [
+    windowInfo({ uuid: 'one', minimized: true }),
+  ]
+
+  assert.deepEqual(
+    findNewlyMinimizedWindow([], current, targetWindow()),
+    current[0]
+  )
+})
+
+test('identifies the only minimized window among duplicate captions', () => {
+  const current = [
+    windowInfo({ uuid: 'one', minimized: false }),
+    windowInfo({ uuid: 'two', minimized: true }),
+  ]
+
+  assert.deepEqual(findNewlyMinimizedWindow([], current, targetWindow()), current[1])
+})
+
+test('uses size to identify a window when matching captions are already minimized', () => {
+  const current = [
+    windowInfo({ uuid: 'one', minimized: true, width: 900 }),
+    windowInfo({ uuid: 'two', minimized: true }),
+  ]
+
+  assert.deepEqual(findNewlyMinimizedWindow([], current, targetWindow()), current[1])
+})
+
+test('uses the invisible startup identity for equal-sized minimized windows', () => {
+  const target = targetWindow()
+  target.caption += '\u2063\u200b'
+  const current = [
+    windowInfo({ uuid: 'one', minimized: true, caption: `${targetWindow().caption}\u2063\u200c` }),
+    windowInfo({ uuid: 'two', minimized: true, caption: target.caption }),
+  ]
+
+  assert.deepEqual(findNewlyMinimizedWindow([], current, target), current[1])
+})
+
+test('preserves the window identity across title updates during detection', async () => {
+  const browserWindow = new EventEmitter()
+  browserWindow.getBounds = () => targetWindow().bounds
+  let title = targetWindow().caption
+  browserWindow.getTitle = () => title
+  browserWindow.isFocused = () => false
+
+  let resolveBackend
+  const backend = new Promise(resolve => {
+    resolveBackend = resolve
+  })
+  const identity = '\u2063\u200b'
+  const minimized = windowInfo({ minimized: true, caption: `${title}${identity}` })
+  const otherWindow = windowInfo({ uuid: 'other', minimized: true })
+  const setWindowTitle = nextTitle => {
+    title = nextTitle.endsWith(identity) ? nextTitle : `${nextTitle}${identity}`
+  }
+  const states = []
+  const detected = new Promise(resolve => {
+    const stop = monitorKdeWaylandWindowState({
+      browserWindow,
+      backend,
+      applyWindowIdentity: () => {
+        setWindowTitle(targetWindow().caption)
+      },
+      detectionDelay: 0,
+      pollInterval: 60000,
+      onMinimizedState: state => {
+        states.push(state)
+        stop()
+        resolve()
+      },
+    })
+  })
+
+  browserWindow.emit('blur')
+  title = targetWindow().caption
+  resolveBackend({
+    queryWindow: async () => minimized,
+    queryWindows: async () => {
+      setWindowTitle(targetWindow().caption)
+      return [otherWindow, minimized]
+    },
+  })
+  await detected
+
+  assert.deepEqual(states, [true])
+})
+
+function windowInfo (overrides = {}) {
+  return {
+    uuid: 'window',
+    caption: 'Subscriptions - OpenTubeX',
+    minimized: false,
+    pid: 1234,
+    width: 1200,
+    height: 832,
+    ...overrides,
+  }
+}
+
+function targetWindow () {
+  return {
+    caption: 'Subscriptions - OpenTubeX',
+    bounds: { x: 10, y: 20, width: 1200, height: 800 },
+  }
+}


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Make sure to follow the contributing guidelines. -->
<!-- Important note, we may remove your pull request if you do not use this provided PR template correctly. -->
<!-- Agent instructions: Preserve every heading, comment, and marker in this template. Never remove or rewrite the release-note-category:start/end, release-note:start/end, or release-note-image:start/end marker pairs. -->

## Pull Request Type
<!-- Please select what type of pull request this is: [x] -->
- [ ] Bugfix
- [x] Feature Implementation
- [ ] Documentation
- [ ] Other

## Related issue
<!-- Please link the issue your pull request is referring to. -->
<!-- If this pull request fully resolves the relevant issue, put "closes" before the issue number. -->
<!-- Example: "closes #123456". -->
Follow-up to #245.

## Description
<!-- Please write a clear and concise description of what the pull request does. -->
Automatic Picture-in-Picture on minimize was unavailable under native Wayland because KWin does not forward compositor-driven minimize actions to Electron. Plasma shortcuts such as Meta+M, the native title-bar button, and Task Manager actions therefore could not trigger the existing minimize behavior.

On KDE Plasma Wayland, the main process now checks KWin's window state after an Electron blur event and forwards confirmed minimize and restore transitions through the existing renderer IPC. Ordinary focus changes remain distinct from minimization. The setting is enabled only when the local KWin D-Bus interfaces are available, and the main window keeps its normal KWin decorations.

## Release note category
<!-- Select exactly one category. Every pull request must select one. -->
<!-- Select "Not noteworthy" when the pull request fixes a bug in or improves functionality that has not yet appeared in a stable release. -->
<!-- release-note-category:start -->
- [ ] Not noteworthy
- [ ] Highlights
- [x] More improvements
- [ ] Fixed bugs
<!-- release-note-category:end -->

## Release note
<!-- Required unless "Not noteworthy" is selected. -->
<!-- Write one concise, user-facing entry without a leading bullet. -->
<!-- release-note:start -->
Automatic Picture-in-Picture on minimize now works on KDE Plasma Wayland.
<!-- release-note:end -->

## Release note images
<!-- Optional. Paste one or more Markdown images, HTML image tags, or dark/light <picture> elements here. -->
<!-- The release notes normalize the markup and limit images taller than 300 pixels. -->
<!-- Agent instructions:
For a noteworthy visible change, add media when it makes the change easier to understand. Prefer a still image unless motion is the point. Recordings in this section must end up as animated WebP because release notes accept images, not video attachments.
After implementing a visible change, proactively capture the result and show the local media to the user for approval before uploading it or updating the pull request.
When the affected UI differs between dark and light themes, capturing both themes is required. A dark-only image is incomplete. The final pull request body must combine the hosted URLs into a theme-aware `<picture>` with dark and light `prefers-color-scheme` sources and the dark image as its `<img>` fallback. Never leave the two theme captures as separate images. Use a single default-dark capture only when the light theme cannot be captured or looks identical.
Capture or crop to the smallest region that still makes the change clear. Do not include the full window when the affected component can be understood on its own.
Use English unless localization is the subject. Keep components at their normal dimensions and placement instead of resizing them to fill the frame.
Use deterministic local fixtures for visible remote images. Reusable avatar and thumbnail fixtures are available through `e2e/helpers/visual-fixtures.mjs`. Before capturing, verify that every visible image has loaded successfully (`complete === true` and `naturalWidth > 0`).
Inspect the final dark and light files for failed images, missing content, unrelated UI, awkward animation, and misleading layout. Omit media when it does not explain the change clearly.
Use GitHub CLI 2.99.0 or newer to upload images no larger than 10 MB. For one image, write an ordinary Markdown image reference to the local file between the marker comments. Pass the same file to `gh pr create` or `gh pr edit` with `--attach <path>` so GitHub CLI replaces the local path with its hosted URL.
GitHub CLI does not rewrite paths inside HTML attributes. For themed images within its size limit, first upload both files through temporary Markdown image references and repeat `--attach <path>` for each one. Read back the hosted URLs, replace the temporary references with the `<picture>` below, and update the pull request body without `--attach`:
<picture>
  <source media="(prefers-color-scheme: dark)" srcset="HOSTED_DARK_URL">
  <source media="(prefers-color-scheme: light)" srcset="HOSTED_LIGHT_URL">
  <img alt="DESCRIPTION" src="HOSTED_DARK_URL">
</picture>
For every MP4, MOV, or WebM recording, use `node _scripts/releaseNoteMedia.mjs FILE --alt "DESCRIPTION"` regardless of file size so the helper converts it to animated WebP. Use the same command when an image exceeds 10 MB. For a themed pair where either file needs the helper, use `node _scripts/releaseNoteMedia.mjs --dark DARK_FILE --light LIGHT_FILE --alt "DESCRIPTION"`. Paste only its generated markup between the marker comments.
Check for personal information, tokens, private repository names, and unrelated desktop content before uploading. Uploaded media is public.
Keep capture-only scripts, test hooks, screenshots, and recordings out of commits. Remove them before committing unless the capture code is also a reusable regression test. Never commit generated release-note media.
Leave this section empty when media would not help.
-->
<!-- release-note-image:start -->

<!-- release-note-image:end -->

## Testing
<!-- How can reviewers verify that the PR produces correct results? -->
<!-- Please provide instructions so that others can ensure that your pull request produces correct results. For examples see, https://github.com/FreeTubeApp/FreeTube/pull/5743, https://github.com/FreeTubeApp/FreeTube/pull/7349, https://github.com/FreeTubeApp/FreeTube/pull/5125, https://github.com/FreeTubeApp/FreeTube/pull/7338 -->
<!-- Agent instructions: Only write human-facing steps that explain how to verify the change while running this branch in dev mode. Include expected results and, when applicable, helpful console snippets for interactive verification. Do not include automated checks, commands, results, pass counts, or CI status. -->
1. Run the app in dev mode on KDE Plasma Wayland and play a video.
2. Enable only the minimize trigger under Player Settings > Automatic Picture-in-Picture.
3. Press the KWin minimize shortcut, such as Meta+M. The main window should minimize with its normal KWin title bar and the video should enter Picture-in-Picture.
4. Restore the app from Plasma's Task Manager. The video should return to the main window.
5. Switch focus to another application without minimizing OpenTubeX. Picture-in-Picture should remain closed when only the minimize trigger is enabled.

## Additional context
<!-- Add any other context about the pull request here. -->
Plasma installs the required KWin D-Bus service. The integration keeps a native session-bus connection to KWin and does not invoke `qdbus` or another helper command.

