### PR TITLE
feat(tabs): make organizer shortcut configurable

### DIFF
--- a/e2e/tests/offline/keyboard-shortcut-restrictions.spec.mjs
+++ b/e2e/tests/offline/keyboard-shortcut-restrictions.spec.mjs
@@ -77,3 +77,24 @@ test('context-dependent shortcuts are shown as non-editable', async ({ page }) =
   await expect(page.locator('.keyboardShortcutPromptEmbedded')).toHaveCount(0)
   await expect(page.locator('.settingsMenu')).toBeVisible()
 })
+
+test('assigns and runs a shortcut for the tab organizer', async ({ page }) => {
+  await goTo(page, 'settings')
+  await page.getByRole('button', { name: 'Show Keyboard Shortcuts' }).click()
+
+  const shortcut = page.locator('[data-shortcut-path="APP.GENERAL.OPEN_TAB_ORGANIZER"]')
+  await expect(shortcut).toHaveText('Unassigned')
+  await shortcut.click()
+  await shortcut.press('Control+Shift+o')
+  await expect(shortcut).toHaveText('Ctrl+Shift+o')
+  await expect(page.locator('.tabOrganizerButton')).toHaveAttribute(
+    'title',
+    'Tab Organizer (Ctrl+Shift+o)'
+  )
+
+  await page.locator('.settingsCloseButton').click()
+  await expect(page.locator('.settingsWindow')).toBeHidden()
+  await page.keyboard.press('Control+Shift+o')
+
+  await expect(page.getByRole('dialog', { name: 'Tab Organizer' })).toBeVisible()
+})

--- a/src/constants.js
+++ b/src/constants.js
@@ -335,6 +335,7 @@ const DefaultKeyboardShortcuts = {
       PREV_TAB: 'control+shift+tab',
       RESTORE_CLOSED_TAB: 'ctrl+shift+T',
       SWITCH_TO_TAB: 'ctrl+1-9',
+      OPEN_TAB_ORGANIZER: '',
       TOGGLE_TAB_ORIENTATION: 'f1',
     },
     SITUATIONAL: {

--- a/src/renderer/App.vue
+++ b/src/renderer/App.vue
@@ -2685,6 +2685,13 @@ function handleKeyboardShortcuts(event) {
       }
     }
 
+    // Open the tab organizer with its optional user-assigned shortcut
+    if (matchesKeyboardShortcut(event, shortcuts.OPEN_TAB_ORGANIZER) && !isTypingTarget(event.target)) {
+      event.preventDefault()
+      openTabOrganizer()
+      return
+    }
+
     // F1: Toggle between horizontal and vertical tabs
     if (matchesKeyboardShortcut(event, shortcuts.TOGGLE_TAB_ORIENTATION) && !isTypingTarget(event.target)) {
       event.preventDefault()

--- a/src/renderer/components/FtKeyboardShortcutPrompt/FtKeyboardShortcutPrompt.vue
+++ b/src/renderer/components/FtKeyboardShortcutPrompt/FtKeyboardShortcutPrompt.vue
@@ -234,6 +234,7 @@ const tabAppShortcuts = computed(() => getLocalizedShortcutNamesAndValues(
     'NEXT_TAB',
     'PREV_TAB',
     'SWITCH_TO_TAB',
+    'OPEN_TAB_ORGANIZER',
     'TOGGLE_TAB_ORIENTATION',
   ]
 ))
@@ -342,6 +343,7 @@ const localizedShortcutNameToShortcutsMappings = computed(() => {
     [t('KeyboardShortcutPrompt.Next Tab'), ['NEXT_TAB']],
     [t('KeyboardShortcutPrompt.Previous Tab'), ['PREV_TAB']],
     [t('KeyboardShortcutPrompt.Switch to Tab'), ['SWITCH_TO_TAB']],
+    [t('Tab Organizer.Title'), ['OPEN_TAB_ORGANIZER']],
     [t('KeyboardShortcutPrompt.Toggle Tab Orientation'), ['TOGGLE_TAB_ORIENTATION']],
     [t('KeyboardShortcutPrompt.Minimize Window'), ['MINIMIZE_WINDOW']],
     [t('KeyboardShortcutPrompt.Close Window'), ['CLOSE_WINDOW']],

--- a/src/renderer/components/TabBar/TabBar.vue
+++ b/src/renderer/components/TabBar/TabBar.vue
@@ -91,7 +91,7 @@
       <button
         class="tabOrganizerButton"
         :aria-label="t('Tab Organizer.Title')"
-        :title="t('Tab Organizer.Title')"
+        :title="tabOrganizerTooltip"
         @click="openTabOrganizer"
       >
         <FtIcon
@@ -298,6 +298,13 @@ const newTabTooltip = computed(() => {
   return localizeAndAddKeyboardShortcutToActionTitle(
     t('New Tab'),
     appKeyboardShortcuts.value.NEW_TAB
+  )
+})
+
+const tabOrganizerTooltip = computed(() => {
+  return localizeAndAddKeyboardShortcutToActionTitle(
+    t('Tab Organizer.Title'),
+    appKeyboardShortcuts.value.OPEN_TAB_ORGANIZER
   )
 })
 

--- a/tests/unit/keyboard-shortcuts.test.mjs
+++ b/tests/unit/keyboard-shortcuts.test.mjs
@@ -50,6 +50,17 @@ test('opens downloads with Ctrl or Command+J by default', () => {
   assert.equal(getConfiguredKeyboardShortcuts().APP.GENERAL.NAVIGATE_TO_DOWNLOADS, 'ctrl+J')
 })
 
+test('allows the tab organizer shortcut to be configured', () => {
+  assert.equal(getConfiguredKeyboardShortcuts().APP.GENERAL.OPEN_TAB_ORGANIZER, '')
+  assert.equal(getConfiguredKeyboardShortcuts({
+    APP: {
+      GENERAL: {
+        OPEN_TAB_ORGANIZER: 'ctrl+shift+o',
+      }
+    }
+  }).APP.GENERAL.OPEN_TAB_ORGANIZER, 'ctrl+shift+o')
+})
+
 test('allows A-B repeat shortcuts to be configured', () => {
   const shortcuts = getConfiguredKeyboardShortcuts({
     VIDEO_PLAYER: {


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Make sure to follow the contributing guidelines. -->
<!-- Important note, we may remove your pull request if you do not use this provided PR template correctly. -->
<!-- Agent instructions: Preserve every heading, comment, and marker in this template. Never remove or rewrite the release-note-category:start/end, release-note:start/end, or release-note-image:start/end marker pairs. -->

## Pull Request Type
<!-- Please select what type of pull request this is: [x] -->
- [ ] Bugfix
- [x] Feature Implementation
- [ ] Documentation
- [ ] Other

## Related issue
<!-- Please link the issue your pull request is referring to. -->
<!-- If this pull request fully resolves the relevant issue, put "closes" before the issue number. -->
<!-- Example: "closes #123456". -->

Follow-up to #859.

## Description
<!-- Please write a clear and concise description of what the pull request does. -->

The tab organizer could only be opened through the interface. This adds an unassigned, configurable Tab Organizer action to the keyboard shortcut settings. Assigned shortcuts open the existing organizer and appear in the tab bar button tooltip.

## Release note category
<!-- Select exactly one category. Every pull request must select one. -->
<!-- Select "Not noteworthy" when the pull request fixes a bug in or improves functionality that has not yet appeared in a stable release. -->
<!-- release-note-category:start -->
- [ ] Not noteworthy
- [ ] Highlights
- [x] More improvements
- [ ] Fixed bugs
<!-- release-note-category:end -->

## Release note
<!-- Required unless "Not noteworthy" is selected. -->
<!-- Write one concise, user-facing entry without a leading bullet. -->
<!-- release-note:start -->
You can now assign a keyboard shortcut to open the tab organizer.
<!-- release-note:end -->

## Release note images
<!-- Optional. Paste one or more Markdown images, HTML image tags, or dark/light <picture> elements here. -->
<!-- The release notes normalize the markup and limit images taller than 300 pixels. -->
<!-- Agent instructions:
For a noteworthy visible change, add media when it makes the change easier to understand. Prefer a still image unless motion is the point. Recordings in this section must end up as animated WebP because release notes accept images, not video attachments.
After implementing a visible change, proactively capture the result and show the local media to the user for approval before uploading it or updating the pull request.
When the affected UI differs between dark and light themes, capturing both themes is required. A dark-only image is incomplete. The final pull request body must combine the hosted URLs into a theme-aware `<picture>` with dark and light `prefers-color-scheme` sources and the dark image as its `<img>` fallback. Never leave the two theme captures as separate images. Use a single default-dark capture only when the light theme cannot be captured or looks identical.
Capture or crop to the smallest region that still makes the change clear. Do not include the full window when the affected component can be understood on its own.
Use English unless localization is the subject. Keep components at their normal dimensions and placement instead of resizing them to fill the frame.
Use deterministic local fixtures for visible remote images. Reusable avatar and thumbnail fixtures are available through `e2e/helpers/visual-fixtures.mjs`. Before capturing, verify that every visible image has loaded successfully (`complete === true` and `naturalWidth > 0`).
Inspect the final dark and light files for failed images, missing content, unrelated UI, awkward animation, and misleading layout. Omit media when it does not explain the change clearly.
Use GitHub CLI 2.99.0 or newer to upload images no larger than 10 MB. For one image, write an ordinary Markdown image reference to the local file between the marker comments. Pass the same file to `gh pr create` or `gh pr edit` with `--attach <path>` so GitHub CLI replaces the local path with its hosted URL.
GitHub CLI does not rewrite paths inside HTML attributes. For themed images within its size limit, first upload both files through temporary Markdown image references and repeat `--attach <path>` for each one. Read back the hosted URLs, replace the temporary references with the `<picture>` below, and update the pull request body without `--attach`:
<picture>
  <source media="(prefers-color-scheme: dark)" srcset="HOSTED_DARK_URL">
  <source media="(prefers-color-scheme: light)" srcset="HOSTED_LIGHT_URL">
  <img alt="DESCRIPTION" src="HOSTED_DARK_URL">
</picture>
For every MP4, MOV, or WebM recording, use `node _scripts/releaseNoteMedia.mjs FILE --alt "DESCRIPTION"` regardless of file size so the helper converts it to animated WebP. Use the same command when an image exceeds 10 MB. For a themed pair where either file needs the helper, use `node _scripts/releaseNoteMedia.mjs --dark DARK_FILE --light LIGHT_FILE --alt "DESCRIPTION"`. Paste only its generated markup between the marker comments.
Check for personal information, tokens, private repository names, and unrelated desktop content before uploading. Uploaded media is public.
Keep capture-only scripts, test hooks, screenshots, and recordings out of commits. Remove them before committing unless the capture code is also a reusable regression test. Never commit generated release-note media.
Leave this section empty when media would not help.
-->
<!-- release-note-image:start -->
<picture>
  <source media="(prefers-color-scheme: dark)" srcset="https://github.com/OpenTubeX/media/releases/download/attachments/20260907T114459Z-tab-organizer-shortcut-dark-dark-53b1a49dd2.png">
  <source media="(prefers-color-scheme: light)" srcset="https://github.com/OpenTubeX/media/releases/download/attachments/20260907T114459Z-tab-organizer-shortcut-light-light-e07740fa02.png">
  <img alt="Tab Organizer keyboard shortcut with an example binding" src="https://github.com/OpenTubeX/media/releases/download/attachments/20260907T114459Z-tab-organizer-shortcut-dark-dark-53b1a49dd2.png">
</picture>
<!-- release-note-image:end -->

## Testing
<!-- How can reviewers verify that the PR produces correct results? -->
<!-- Please provide instructions so that others can ensure that your pull request would produce correct results. For examples see, https://github.com/FreeTubeApp/FreeTube/pull/5743, https://github.com/FreeTubeApp/FreeTube/pull/7349, https://github.com/FreeTubeApp/FreeTube/pull/5125, https://github.com/FreeTubeApp/FreeTube/pull/7338 -->
<!-- Agent instructions: Only write human-facing steps that explain how to verify the change while running this branch in dev mode. Include expected results and, when applicable, helpful console snippets for interactive verification. Do not include automated checks, commands, results, pass counts, or CI status. -->

1. Open Settings, then Keyboard Shortcuts.
2. Under App: Tabs, select Tab Organizer and record a shortcut. The binding should appear in the list and in the tab organizer button tooltip.
3. Close Settings and press the shortcut. The tab organizer should open.

## Additional context
<!-- Add any other context about the pull request here. -->

The action has no default binding.
