### PR TITLE
feat(tabs): arrange synced device sessions in tabs

### DIFF
--- a/e2e/tests/offline/tabs.spec.mjs
+++ b/e2e/tests/offline/tabs.spec.mjs
@@ -2184,7 +2184,7 @@ test.describe('background tab shortcuts', () => {
 })
 
 test.describe('tab organizer', () => {
-  test('shows and confirms deletion of synced tab sets', async ({ page }) => {
+  test('shows synced tab sets in device tabs and confirms deletion', async ({ page }) => {
     await page.evaluate(() => {
       const store = document.querySelector('#app').__vue_app__.config.globalProperties.$store
       store.commit('setSyncServerEnabled', true)
@@ -2192,15 +2192,25 @@ test.describe('tab organizer', () => {
       store.commit('setSyncServerPrivacyMode', 'enhanced')
       store.commit('setSyncServerSyncSessions', true)
       store.commit('setSyncServerSharedTabs', false)
-      store.commit('setSyncServerOtherDeviceSessions', [{
-        syncDeviceId: 'phone-e2e',
-        syncPlatform: 'mobile',
-        sessionId: 'mobile-session-e2e',
-        tabs: [
-          { id: 'synced-watch', title: 'Synced watch tab', url: '/watch/synced-video' },
-          { id: 'synced-history', title: 'Synced history tab', url: '/history' },
-        ],
-      }])
+      store.commit('setSyncServerOtherDeviceSessions', [
+        {
+          syncDeviceId: 'phone-e2e',
+          syncPlatform: 'mobile',
+          sessionId: 'mobile-session-e2e',
+          tabs: [
+            { id: 'synced-watch', title: 'Synced watch tab', url: '/watch/synced-video' },
+            { id: 'synced-history', title: 'Synced history tab', url: '/history' },
+          ],
+        },
+        {
+          syncDeviceId: 'desktop-e2e',
+          syncPlatform: 'desktop',
+          sessionId: 'desktop-session-e2e',
+          tabs: [
+            { id: 'synced-desktop', title: 'Desktop synced tab', url: '/subscriptions' },
+          ],
+        },
+      ])
       store._actions.deleteSyncServerSession = [session => {
         store.commit(
           'setSyncServerOtherDeviceSessions',
@@ -2216,13 +2226,30 @@ test.describe('tab organizer', () => {
     await page.locator(sel.tabOrganizerButton).click()
     const organizer = page.getByRole('dialog', { name: 'Tab Organizer' })
     const syncedSection = organizer.locator('.syncedTabsSection')
-    const syncedSet = syncedSection.locator('.syncedSessionCard')
+    const sessionTabs = syncedSection.getByRole('tablist', { name: 'Tabs from other devices' })
+    const mobileTab = sessionTabs.getByRole('tab', { name: 'Mobile · 2 tabs', exact: true })
+    const desktopTab = sessionTabs.getByRole('tab', { name: 'Desktop · 1 tab', exact: true })
+    const syncedSet = syncedSection.getByRole('tabpanel')
     await expect(syncedSection.getByRole('heading', { name: 'Tabs from other devices' })).toBeVisible()
-    await expect(syncedSet).toContainText('Mobile · 2 tabs')
-    await expect(syncedSet.locator('[data-icon="layer-group"]')).toBeVisible()
+    await expect(sessionTabs.getByRole('tab')).toHaveCount(2)
+    await expect(mobileTab).toHaveAttribute('aria-selected', 'true')
+    await expect(desktopTab).toHaveAttribute('aria-selected', 'false')
+    await expect(sessionTabs.locator('[data-icon="layer-group"]')).toBeVisible()
+    await expect(sessionTabs.locator('[data-icon="display"]')).toBeVisible()
     await expect(syncedSet.locator('[data-icon="clapperboard"]')).toBeVisible()
     await expect(syncedSet.locator('[data-icon="clock-rotate-left"]')).toBeVisible()
     await expect(syncedSet.locator('[data-icon="arrow-up-right-from-square"]')).toHaveCount(2)
+    await expect(syncedSet).not.toContainText('Desktop synced tab')
+
+    await mobileTab.press('ArrowRight')
+    await expect(desktopTab).toBeFocused()
+    await expect(desktopTab).toHaveAttribute('aria-selected', 'true')
+    await expect(syncedSet).toContainText('Desktop synced tab')
+    await expect(syncedSet).not.toContainText('Synced watch tab')
+
+    await desktopTab.press('Home')
+    await expect(mobileTab).toBeFocused()
+    await expect(syncedSet).toContainText('Synced watch tab')
 
     const deleteSet = syncedSet.getByRole('button', { name: 'Delete: Mobile · 2 tabs' })
     await deleteSet.click()
@@ -2234,7 +2261,58 @@ test.describe('tab organizer', () => {
     await deleteSet.click()
     confirmation = page.getByRole('dialog', { name: 'Delete' })
     await confirmation.getByRole('button', { name: 'Delete', exact: true }).click()
-    await expect(syncedSection).toHaveCount(0)
+    await expect(mobileTab).toHaveCount(0)
+    await expect(desktopTab).toHaveAttribute('aria-selected', 'true')
+    await expect(syncedSet).toContainText('Desktop synced tab')
+  })
+
+  test('clamps scroll after switching to a shorter synced session at fractional UI scale', async ({ page }) => {
+    await page.setViewportSize({ width: 1280, height: 800 })
+    await page.evaluate(() => window.ftElectron.setZoomFactor(0.95))
+    await page.evaluate(() => {
+      const store = document.querySelector('#app').__vue_app__.config.globalProperties.$store
+      store.commit('setSyncServerEnabled', true)
+      store.commit('setSyncServerToken', 'e2e-token')
+      store.commit('setSyncServerPrivacyMode', 'enhanced')
+      store.commit('setSyncServerSyncSessions', true)
+      store.commit('setSyncServerSharedTabs', false)
+      store.commit('setSyncServerOtherDeviceSessions', [
+        {
+          syncDeviceId: 'phone-e2e',
+          syncPlatform: 'mobile',
+          sessionId: 'long-mobile-session',
+          tabs: Array.from({ length: 30 }, (_, index) => ({
+            id: `long-synced-${index}`,
+            title: `Long synced tab ${index}`,
+            url: `/watch/long-synced-${index}`,
+          })),
+        },
+        {
+          syncDeviceId: 'desktop-e2e',
+          syncPlatform: 'desktop',
+          sessionId: 'short-desktop-session',
+          tabs: [{ id: 'short-synced', title: 'Short synced tab', url: '/subscriptions' }],
+        },
+      ])
+    })
+
+    await page.locator(sel.tabOrganizerButton).click()
+    const organizer = page.getByRole('dialog', { name: 'Tab Organizer' })
+    const scroller = organizer.locator('.tabOrganizerScroll')
+    const scrollbar = scroller.locator(':scope > .os-scrollbar-vertical')
+    const syncedSection = organizer.locator('.syncedTabsSection')
+    const desktopTab = syncedSection.getByRole('tab', { name: 'Desktop · 1 tab', exact: true })
+    await expect(scrollbar).not.toHaveClass(/os-scrollbar-unusable/)
+    await scroller.evaluate(element => { element.scrollTop = element.scrollHeight })
+    await expect.poll(() => scroller.evaluate(element => element.scrollTop)).toBeGreaterThan(0)
+
+    await desktopTab.evaluate(element => element.click())
+    await expect(syncedSection.locator('.syncedTabTarget')).toHaveCount(1)
+    await expect.poll(() => scroller.evaluate(element => ({
+      distanceFromEnd: Math.abs(element.scrollTop - Math.max(0, element.scrollHeight - element.clientHeight)),
+      scrollTop: element.scrollTop
+    }))).toEqual({ distanceFromEnd: 0, scrollTop: 0 })
+    await expect(scrollbar).toHaveClass(/os-scrollbar-unusable/)
   })
 
   test('selects a visible range with Shift-click', async ({ page }) => {

--- a/e2e/tests/offline/ui-bugfixes.spec.mjs
+++ b/e2e/tests/offline/ui-bugfixes.spec.mjs
@@ -239,6 +239,8 @@ test('restores and clamps the real phone tab organizer viewports', async ({ app,
     }])
   })
   await expect(page.locator('.capacitorPhoneSyncedTabTarget')).toHaveCount(1)
+  await expect(syncedPanel.locator('.capacitorPhoneSyncedSessionHeader strong'))
+    .toHaveText('Desktop · 1 tab')
   await expect.poll(() => phoneTabScrollState(page, '.capacitorPhoneSyncedTabsContent')).toEqual({
     scrollTop: 0,
     maximum: 0,

--- a/src/renderer/components/TabBar/CapacitorPhoneTabSwitcher.vue
+++ b/src/renderer/components/TabBar/CapacitorPhoneTabSwitcher.vue
@@ -237,7 +237,7 @@
                   class="capacitorPhoneSyncedSession"
                 >
                   <header class="capacitorPhoneSyncedSessionHeader">
-                    <strong>{{ deviceSessionLabel(session) }}</strong>
+                    <strong>{{ formatDeviceSessionLabel(session, t) }}</strong>
                     <button
                       type="button"
                       class="capacitorPhoneSyncedTabButton capacitorPhoneSyncedOpenAll"
@@ -305,7 +305,7 @@ import { useI18n } from 'vue-i18n'
 import store from '../../store/index'
 import { shouldCloseSwipedTab } from '../../helpers/capacitorTabSwipe'
 import { clampOverlayScrollTop, restoreOverlayScrollTop } from '../../helpers/overlayScrollbars'
-import { shouldShowOtherDeviceSessions } from '../../helpers/sync-sessions'
+import { formatDeviceSessionLabel, shouldShowOtherDeviceSessions } from '../../helpers/sync-sessions'
 import { getCapacitorTabService } from '../../tabs/CapacitorTabService'
 import { getTabAvatarUrl, getTabPageIcon } from '../../tabs/tabPreview'
 import FtRetryImage from '../FtRetryImage.vue'
@@ -475,15 +475,6 @@ async function restoreClosedTab() {
 async function activateTab(tabId) {
   if (swipe.suppressClick) return
   await activateTabAction(tabId)
-}
-
-function deviceSessionLabel(session) {
-  return t('Settings.Sync Settings.Device Tab Session', {
-    platform: session.syncPlatform === 'mobile'
-      ? t('Settings.Sync Settings.Mobile Device')
-      : t('Settings.Sync Settings.Desktop Device'),
-    count: session.tabs.length,
-  })
 }
 
 async function openOtherDeviceSession(session) {

--- a/src/renderer/components/TabOrganizer/TabOrganizer.css
+++ b/src/renderer/components/TabOrganizer/TabOrganizer.css
@@ -590,10 +590,56 @@
   color: var(--secondary-text-color);
 }
 
-.syncedSessionGrid {
-  display: grid;
-  gap: 10px;
-  grid-template-columns: repeat(auto-fit, minmax(min(360px, 100%), 1fr));
+.syncedSessionTabs {
+  border-block-end: 1px solid var(--divider-color);
+  display: flex;
+  flex-wrap: wrap;
+  gap: 4px;
+  padding-inline: 4px;
+}
+
+.syncedSessionTab {
+  align-items: center;
+  background: transparent !important;
+  border-color: transparent !important;
+  border-radius: calc(7px * var(--ui-roundness)) calc(7px * var(--ui-roundness)) 0 0 !important;
+  display: flex;
+  gap: 8px;
+  min-block-size: 44px !important;
+  padding-block: 6px !important;
+  position: relative;
+}
+
+.syncedSessionTab::after {
+  background: transparent;
+  block-size: 2px;
+  border-radius: 2px;
+  content: '';
+  inset-block-end: -1px;
+  inset-inline: 8px;
+  position: absolute;
+}
+
+.syncedSessionTab:hover,
+.syncedSessionTab:focus-visible {
+  background: var(--side-nav-hover-color) !important;
+}
+
+.syncedSessionTab.selected {
+  color: var(--primary-text-color);
+}
+
+.syncedSessionTab.selected::after {
+  background: var(--accent-color);
+}
+
+.syncedSessionTab strong {
+  font-size: 13px;
+  overflow-wrap: anywhere;
+}
+
+.syncedSessionPanels {
+  padding-block-start: 10px;
 }
 
 .syncedSessionCard {
@@ -606,7 +652,6 @@
 }
 
 .syncedSessionHeader,
-.syncedSessionIdentity,
 .syncedSessionActions,
 .syncedSessionActionButton {
   align-items: center;
@@ -615,17 +660,7 @@
 
 .syncedSessionHeader {
   gap: 10px;
-  justify-content: space-between;
-}
-
-.syncedSessionIdentity {
-  gap: 9px;
-  min-inline-size: 0;
-}
-
-.syncedSessionIdentity strong {
-  font-size: 13px;
-  overflow-wrap: anywhere;
+  justify-content: flex-end;
 }
 
 .syncedSessionIcon {
@@ -766,8 +801,7 @@
   }
 
   .syncedSessionHeader {
-    align-items: flex-start;
-    flex-direction: column;
+    align-items: stretch;
   }
 
   .syncedSessionActions {

--- a/src/renderer/components/TabOrganizer/TabOrganizer.vue
+++ b/src/renderer/components/TabOrganizer/TabOrganizer.vue
@@ -850,9 +850,10 @@ function syncedSessionTabId(index) {
 
 async function selectOtherDeviceSession(session, focus = false) {
   selectedOtherDeviceSessionKey.value = otherDeviceSessionKey(session)
+  await nextTick()
+  clampScroll()
   if (!focus) return
 
-  await nextTick()
   const index = visibleOtherDeviceSessions.value.findIndex(candidate => (
     otherDeviceSessionKey(candidate) === selectedOtherDeviceSessionKey.value
   ))

--- a/src/renderer/components/TabOrganizer/TabOrganizer.vue
+++ b/src/renderer/components/TabOrganizer/TabOrganizer.vue
@@ -442,27 +442,52 @@
                   {{ t('Settings.Sync Settings.Tabs From Other Devices') }}
                 </h3>
               </header>
-              <div class="syncedSessionGrid">
-                <article
-                  v-for="session in visibleOtherDeviceSessions"
+              <div
+                class="syncedSessionTabs"
+                role="tablist"
+                :aria-label="t('Settings.Sync Settings.Tabs From Other Devices')"
+              >
+                <button
+                  v-for="(session, index) in visibleOtherDeviceSessions"
+                  :id="syncedSessionTabId(index)"
                   :key="`${session.syncDeviceId}:${session.sessionId}`"
+                  type="button"
+                  class="syncedSessionTab"
+                  :class="{ selected: activeOtherDeviceSessionKey === otherDeviceSessionKey(session) }"
+                  role="tab"
+                  :aria-controls="syncedSessionPanelId"
+                  :aria-selected="activeOtherDeviceSessionKey === otherDeviceSessionKey(session)"
+                  :tabindex="activeOtherDeviceSessionKey === otherDeviceSessionKey(session) ? 0 : -1"
+                  @click="selectOtherDeviceSession(session)"
+                  @keydown.left.prevent="selectOtherDeviceSessionAt(index - 1, true)"
+                  @keydown.right.prevent="selectOtherDeviceSessionAt(index + 1, true)"
+                  @keydown.home.prevent="selectOtherDeviceSessionAt(0, true)"
+                  @keydown.end.prevent="selectOtherDeviceSessionAt(visibleOtherDeviceSessions.length - 1, true)"
+                >
+                  <span class="syncedSessionIcon">
+                    <FtIcon
+                      :icon="session.syncPlatform === 'mobile' ? ['fas', 'layer-group'] : ['fas', 'display']"
+                      aria-hidden="true"
+                    />
+                  </span>
+                  <strong>{{ formatDeviceSessionLabel(session, t) }}</strong>
+                </button>
+              </div>
+              <div class="syncedSessionPanels">
+                <article
+                  v-if="activeOtherDeviceSession"
+                  :id="syncedSessionPanelId"
+                  :key="activeOtherDeviceSessionKey"
                   class="syncedSessionCard"
+                  role="tabpanel"
+                  :aria-labelledby="activeOtherDeviceSessionTabId"
                 >
                   <header class="syncedSessionHeader">
-                    <div class="syncedSessionIdentity">
-                      <span class="syncedSessionIcon">
-                        <FtIcon
-                          :icon="session.syncPlatform === 'mobile' ? ['fas', 'layer-group'] : ['fas', 'display']"
-                          aria-hidden="true"
-                        />
-                      </span>
-                      <strong>{{ deviceSessionLabel(session) }}</strong>
-                    </div>
                     <div class="syncedSessionActions">
                       <button
                         type="button"
                         class="syncedSessionActionButton"
-                        @click="openOtherDeviceSession(session)"
+                        @click="openOtherDeviceSession(activeOtherDeviceSession)"
                       >
                         <FtIcon
                           :icon="['fas', 'folder-open']"
@@ -473,9 +498,9 @@
                       <button
                         type="button"
                         class="syncedSessionActionButton iconButton dangerButton"
-                        :aria-label="`${t('Delete')}: ${deviceSessionLabel(session)}`"
+                        :aria-label="`${t('Delete')}: ${formatDeviceSessionLabel(activeOtherDeviceSession, t)}`"
                         :title="t('Delete')"
-                        @click="sessionToDelete = session"
+                        @click="sessionToDelete = activeOtherDeviceSession"
                       >
                         <FtIcon
                           :icon="['fas', 'trash']"
@@ -486,13 +511,13 @@
                   </header>
                   <ul class="syncedTabList">
                     <li
-                      v-for="tab in session.visibleTabs"
+                      v-for="tab in activeOtherDeviceSession.visibleTabs"
                       :key="tab.id"
                     >
                       <button
                         type="button"
                         class="syncedTabTarget"
-                        @click="openOtherDeviceSession({ ...session, tabs: [tab] })"
+                        @click="openOtherDeviceSession({ ...activeOtherDeviceSession, tabs: [tab] })"
                       >
                         <span class="tabIcon">
                           <img
@@ -582,7 +607,7 @@
   <FtPrompt
     v-if="sessionToDelete"
     :label="t('Delete')"
-    :extra-labels="[deviceSessionLabel(sessionToDelete)]"
+    :extra-labels="[formatDeviceSessionLabel(sessionToDelete, t)]"
     :option-names="[t('Delete'), t('Cancel')]"
     :option-values="['delete', 'cancel']"
     is-first-option-destructive
@@ -598,7 +623,7 @@ import { useI18n } from 'vue-i18n'
 
 import { getTabAccentColor } from '../../constants/tabColors'
 import { clampOverlayScrollTop, restoreOverlayScrollTop } from '../../helpers/overlayScrollbars'
-import { shouldShowOtherDeviceSessions } from '../../helpers/sync-sessions'
+import { formatDeviceSessionLabel, shouldShowOtherDeviceSessions } from '../../helpers/sync-sessions'
 import { showToast } from '../../helpers/utils'
 import store from '../../store/index'
 import { getTabAvatarUrl, getTabPageIcon } from '../../tabs/tabPreview'
@@ -612,6 +637,8 @@ const emit = defineEmits(['close'])
 const { locale, t } = useI18n()
 const titleId = `tab-organizer-title-${useId().replaceAll(':', '')}`
 const promptId = `tab-organizer-${useId().replaceAll(':', '')}`
+const syncedSessionIdPrefix = `tab-organizer-synced-session-${useId().replaceAll(':', '')}`
+const syncedSessionPanelId = `${syncedSessionIdPrefix}-panel`
 const teleportTarget = document.fullscreenElement ?? '.app'
 const query = ref('')
 const newGroupName = ref('')
@@ -626,6 +653,7 @@ const editingGroupName = ref('')
 const editingColorGroupId = ref(null)
 const failedTabAvatarUrls = ref({})
 const sessionToDelete = ref(null)
+const selectedOtherDeviceSessionKey = ref(null)
 const dialogRef = useTemplateRef('dialogRef')
 const searchRef = useTemplateRef('searchRef')
 const scrollRef = useTemplateRef('scrollRef')
@@ -707,6 +735,20 @@ const showSyncedTabs = computed(() => shouldShowOtherDeviceSessions({
 const visibleOtherDeviceSessions = computed(() => otherDeviceSessions.value
   .map(session => ({ ...session, visibleTabs: session.tabs.filter(matchesSearch) }))
   .filter(session => session.visibleTabs.length > 0))
+const activeOtherDeviceSession = computed(() => (
+  visibleOtherDeviceSessions.value.find(session => (
+    otherDeviceSessionKey(session) === selectedOtherDeviceSessionKey.value
+  )) ?? visibleOtherDeviceSessions.value[0] ?? null
+))
+const activeOtherDeviceSessionKey = computed(() => (
+  activeOtherDeviceSession.value ? otherDeviceSessionKey(activeOtherDeviceSession.value) : null
+))
+const activeOtherDeviceSessionTabId = computed(() => {
+  const activeIndex = visibleOtherDeviceSessions.value.findIndex(session => (
+    otherDeviceSessionKey(session) === activeOtherDeviceSessionKey.value
+  ))
+  return syncedSessionTabId(Math.max(0, activeIndex))
+})
 
 const displayedSections = computed(() => {
   const sections = groups.value.map(group => ({
@@ -798,13 +840,30 @@ function syncedTabPreview(tab) {
   }
 }
 
-function deviceSessionLabel(session) {
-  return t('Settings.Sync Settings.Device Tab Session', {
-    platform: session.syncPlatform === 'mobile'
-      ? t('Settings.Sync Settings.Mobile Device')
-      : t('Settings.Sync Settings.Desktop Device'),
-    count: session.tabs.length,
-  })
+function otherDeviceSessionKey(session) {
+  return `${session.syncDeviceId}:${session.sessionId}`
+}
+
+function syncedSessionTabId(index) {
+  return `${syncedSessionIdPrefix}-tab-${index}`
+}
+
+async function selectOtherDeviceSession(session, focus = false) {
+  selectedOtherDeviceSessionKey.value = otherDeviceSessionKey(session)
+  if (!focus) return
+
+  await nextTick()
+  const index = visibleOtherDeviceSessions.value.findIndex(candidate => (
+    otherDeviceSessionKey(candidate) === selectedOtherDeviceSessionKey.value
+  ))
+  dialogRef.value?.querySelector(`#${syncedSessionTabId(index)}`)?.focus({ preventScroll: true })
+}
+
+function selectOtherDeviceSessionAt(index, focus = false) {
+  const sessions = visibleOtherDeviceSessions.value
+  if (sessions.length === 0) return
+  const wrappedIndex = (index + sessions.length) % sessions.length
+  selectOtherDeviceSession(sessions[wrappedIndex], focus)
 }
 
 async function openOtherDeviceSession(session) {

--- a/src/renderer/helpers/sync-sessions.js
+++ b/src/renderer/helpers/sync-sessions.js
@@ -115,6 +115,14 @@ export function shouldShowOtherDeviceSessions({
     sessions.length > 0
 }
 
+export function formatDeviceSessionLabel(session, t) {
+  const count = session.tabs.length
+  const platform = session.syncPlatform === 'mobile'
+    ? t('Settings.Sync Settings.Mobile Device')
+    : t('Settings.Sync Settings.Desktop Device')
+  return `${platform} · ${t('Tab Organizer.Tab Count', { count }, count)}`
+}
+
 function claimLegacyDesktopSessions(document, deviceId, platform) {
   if (platform !== 'desktop') return document
 

--- a/tests/unit/sync-sessions.test.mjs
+++ b/tests/unit/sync-sessions.test.mjs
@@ -2,6 +2,7 @@ import assert from 'node:assert/strict'
 import test from 'node:test'
 
 import {
+  formatDeviceSessionLabel,
   getOtherDeviceSessions,
   getPreviousSyncSessions,
   mergeSyncSessions,
@@ -15,6 +16,18 @@ const session = (id, updatedAt, url = `https://opentubex.local/${id}`) => ({
   updatedAt,
   activeTabId: `${id}-tab`,
   tabs: [{ id: `${id}-tab`, url }],
+})
+
+test('formats device session labels with localized tab plurals', () => {
+  const t = (key, { count } = {}, choice) => {
+    if (key === 'Settings.Sync Settings.Mobile Device') return 'Mobile'
+    if (key === 'Settings.Sync Settings.Desktop Device') return 'Desktop'
+    if (key === 'Tab Organizer.Tab Count') return `${count} ${choice === 1 ? 'tab' : 'tabs'}`
+    throw new Error(`Unexpected translation key: ${key}`)
+  }
+
+  assert.equal(formatDeviceSessionLabel({ syncPlatform: 'desktop', tabs: [{}] }, t), 'Desktop · 1 tab')
+  assert.equal(formatDeviceSessionLabel({ syncPlatform: 'mobile', tabs: [{}, {}] }, t), 'Mobile · 2 tabs')
 })
 
 test('treats legacy session arrays as a separate desktop device', () => {


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Make sure to follow the contributing guidelines. -->
<!-- Important note, we may remove your pull request if you do not use this provided PR template correctly. -->
<!-- Agent instructions: Preserve every heading, comment, and marker in this template. Never remove or rewrite the release-note-category:start/end, release-note:start/end, or release-note-image:start/end marker pairs. -->

## Pull Request Type
<!-- Please select what type of pull request this is: [x] -->
- [ ] Bugfix
- [x] Feature Implementation
- [ ] Documentation
- [ ] Other

## Related issue
<!-- Please link the issue your pull request is referring to. -->
<!-- If this pull request fully resolves the relevant issue, put "closes" before the issue number. -->
<!-- Example: "closes #123456". -->

Follow-up to #1072.

## Description
<!-- Please write a clear and concise description of what the pull request does. -->

Other-device tab sessions were displayed as side-by-side cards, which left awkward empty columns when devices had very different tab counts. This replaces the card grid with a device tab list and one full-width session panel. It also uses the existing locale-aware tab-count formatter so singular labels read `1 tab`.

The device tabs support pointer selection and Left, Right, Home, and End keyboard navigation. Switching to a shorter session also clamps the organizer's scroll position to the new rendered range.

## Release note category
<!-- Select exactly one category. Every pull request must select one. -->
<!-- Select "Not noteworthy" when the pull request fixes a bug in or improves functionality that has not yet appeared in a stable release. -->
<!-- release-note-category:start -->
- [x] Not noteworthy
- [ ] Highlights
- [ ] More improvements
- [ ] Fixed bugs
<!-- release-note-category:end -->

## Release note
<!-- Required unless "Not noteworthy" is selected. -->
<!-- Write one concise, user-facing entry without a leading bullet. -->
<!-- release-note:start -->

<!-- release-note:end -->

## Release note images
<!-- Optional. Paste one or more Markdown images, HTML image tags, or dark/light <picture> elements here. -->
<!-- The release notes normalize the markup and limit images taller than 300 pixels. -->
<!-- Agent instructions:
For a noteworthy visible change, add media when it makes the change easier to understand. Prefer a still image unless motion is the point. Recordings in this section must end up as animated WebP because release notes accept images, not video attachments.
After implementing a visible change, proactively capture the result and show the local media to the user for approval before uploading it or updating the pull request.
When the affected UI differs between dark and light themes, capturing both themes is required. A dark-only image is incomplete. The final pull request body must combine the hosted URLs into a theme-aware `<picture>` with dark and light `prefers-color-scheme` sources and the dark image as its `<img>` fallback. Never leave the two theme captures as separate images. Use a single default-dark capture only when the light theme cannot be captured or looks identical.
Capture or crop to the smallest region that still makes the change clear. Do not include the full window when the affected component can be understood on its own.
Use English unless localization is the subject. Keep components at their normal dimensions and placement instead of resizing them to fill the frame.
Use deterministic local fixtures for visible remote images. Reusable avatar and thumbnail fixtures are available through `e2e/helpers/visual-fixtures.mjs`. Before capturing, verify that every visible image has loaded successfully (`complete === true` and `naturalWidth > 0`).
Inspect the final dark and light files for failed images, missing content, unrelated UI, awkward animation, and misleading layout. Omit media when it does not explain the change clearly.
Use GitHub CLI 2.99.0 or newer to upload images no larger than 10 MB. For one image, write an ordinary Markdown image reference to the local file between the marker comments. Pass the same file to `gh pr create` or `gh pr edit` with `--attach <path>` so GitHub CLI replaces the local path with its hosted URL.
GitHub CLI does not rewrite paths inside HTML attributes. For themed images within its size limit, first upload both files through temporary Markdown image references and repeat `--attach <path>` for each one. Read back the hosted URLs, replace the temporary references with the `<picture>` below, and update the pull request body without `--attach`:
<picture>
  <source media="(prefers-color-scheme: dark)" srcset="HOSTED_DARK_URL">
  <source media="(prefers-color-scheme: light)" srcset="HOSTED_LIGHT_URL">
  <img alt="DESCRIPTION" src="HOSTED_DARK_URL">
</picture>
For every MP4, MOV, or WebM recording, use `node _scripts/releaseNoteMedia.mjs FILE --alt "DESCRIPTION"` regardless of file size so the helper converts it to animated WebP. Use the same command when an image exceeds 10 MB. For a themed pair where either file needs the helper, use `node _scripts/releaseNoteMedia.mjs --dark DARK_FILE --light LIGHT_FILE --alt "DESCRIPTION"`. Paste only its generated markup between the marker comments.
Check for personal information, tokens, private repository names, and unrelated desktop content before uploading. Uploaded media is public.
Keep capture-only scripts, test hooks, screenshots, and recordings out of commits. Remove them before committing unless the capture code is also a reusable regression test. Never commit generated release-note media.
Leave this section empty when media would not help.
-->
<!-- release-note-image:start -->

<picture>
  <source media="(prefers-color-scheme: dark)" srcset="https://github.com/user-attachments/assets/feed4504-34ca-405f-96b4-49c4eff66eae">
  <source media="(prefers-color-scheme: light)" srcset="https://github.com/user-attachments/assets/06056f54-36b1-430a-b40e-1791e11335de">
  <img alt="Other-device sessions arranged as tabs" src="https://github.com/user-attachments/assets/feed4504-34ca-405f-96b4-49c4eff66eae">
</picture>

<!-- release-note-image:end -->

## Testing
<!-- How can reviewers verify that the PR produces correct results? -->
<!-- Please provide instructions so that others can ensure that your pull request would produce correct results. For examples see, https://github.com/FreeTubeApp/FreeTube/pull/5743, https://github.com/FreeTubeApp/FreeTube/pull/7349, https://github.com/FreeTubeApp/FreeTube/pull/5125, https://github.com/FreeTubeApp/FreeTube/pull/7338 -->
<!-- Agent instructions: Only write human-facing steps that explain how to verify the change while running this branch in dev mode. Include expected results and, when applicable, helpful console snippets for interactive verification. Do not include automated checks, commands, results, pass counts, or CI status. -->

1. Configure separate session sync with at least two other devices that have different numbers of open tabs.
2. Open the Tab Organizer. The devices should appear as tabs above one full-width session panel.
3. Select each device with the pointer and with the arrow keys. Only the selected device's tabs and actions should be shown.
4. Switch from a long session while scrolled to the bottom to a short session. The organizer should remove obsolete empty space and update its scrollbar.
5. Confirm that a session containing one tab is labelled `1 tab`, while larger sessions use the localized plural form.

## Additional context
<!-- Add any other context about the pull request here. -->

The other-device session UI was introduced on the current development branch and has not shipped in a stable release.
