### PR TITLE
fix(playlists): continue autoplay after Shorts

### DIFF
--- a/e2e/tests/offline/playlist-skip-buttons.spec.mjs
+++ b/e2e/tests/offline/playlist-skip-buttons.spec.mjs
@@ -28,6 +28,7 @@ test.use({
       userPlaylistSortOrder: 'custom',
       useCustomShortsPlayer: true,
       loopShorts: true,
+      autoplayPlaylists: true,
       videoPlaybackEngine: 'built-in',
       ytDlpPlaybackEngineDefaultMigration: true
     },

--- a/e2e/tests/offline/playlist-skip-buttons.spec.mjs
+++ b/e2e/tests/offline/playlist-skip-buttons.spec.mjs
@@ -1,34 +1,57 @@
 import { goTo, test, expect } from '../../helpers/app.mjs'
+import { activeTab, waitForPlayback } from '../../helpers/player.mjs'
+import { mockPlayableWatchPage } from '../../helpers/watch.mjs'
 
 const VIDEO_TITLES = ['Skip test video one', 'Skip test video two', 'Skip test video three']
+const SHORT_PLAYLIST_ID = 'e2eshortplaylist'
+const SHORT_PLAYLIST_NAME = 'Short autoplay playlist'
+
+function playlistVideo(title, index, isShort = false) {
+  return {
+    videoId: `skipvideo${index}`,
+    title,
+    author: 'Test Channel',
+    authorId: 'UC-test-channel-id',
+    lengthSeconds: 120,
+    published: Date.now() - 86_400_000,
+    timeAdded: Date.now() + index,
+    playlistItemId: `e2e-skip-item-${index}`,
+    type: 'video',
+    isShort
+  }
+}
 
 test.use({
   seed: {
     settings: {
       // Keep the seeded order, the default sorts the newest addition to the top
-      userPlaylistSortOrder: 'custom'
+      userPlaylistSortOrder: 'custom',
+      useCustomShortsPlayer: true,
+      loopShorts: true,
+      videoPlaybackEngine: 'built-in',
+      ytDlpPlaybackEngineDefaultMigration: true
     },
-    playlists: [
-      {
-        _id: 'e2eskipplaylist',
-        playlistName: 'Skip button playlist',
-        protected: false,
-        description: 'Playlist for the player skip buttons',
-        videos: VIDEO_TITLES.map((title, index) => ({
-          videoId: `skipvideo${index}`,
-          title,
-          author: 'Test Channel',
-          authorId: 'UC-test-channel-id',
-          lengthSeconds: 120,
-          published: Date.now() - 86_400_000,
-          timeAdded: Date.now() + index,
-          playlistItemId: `e2e-skip-item-${index}`,
-          type: 'video'
-        })),
-        createdAt: Date.now() - 86_400_000,
-        lastUpdatedAt: Date.now()
-      }
-    ],
+    playlists: [{
+      _id: 'e2eskipplaylist',
+      playlistName: 'Skip button playlist',
+      protected: false,
+      description: 'Playlist for the player skip buttons',
+      videos: VIDEO_TITLES.map((title, index) => playlistVideo(title, index)),
+      createdAt: Date.now() - 86_400_000,
+      lastUpdatedAt: Date.now()
+    }, {
+      _id: SHORT_PLAYLIST_ID,
+      playlistName: SHORT_PLAYLIST_NAME,
+      protected: false,
+      description: 'Playlist with a Short followed by a normal video',
+      videos: VIDEO_TITLES.slice(0, 2).map((title, index) => playlistVideo(
+        title,
+        index,
+        index === 0
+      )),
+      createdAt: Date.now() - 86_400_000,
+      lastUpdatedAt: Date.now()
+    }],
     history: ['Queued video', 'Standalone video'].map((title, index) => ({
       _id: `queuevideo${index}`,
       videoId: `queuevideo${index}`,
@@ -129,6 +152,30 @@ test('only offers skipping to playlist videos that exist', async ({ page, attach
     canPlayNext: true,
     canPlayPrevious: true
   })
+})
+
+test('continues a playlist after a Short ends', async ({ app, page }) => {
+  await mockPlayableWatchPage(app, page)
+
+  await goTo(page, 'userplaylists')
+  await page.getByText(SHORT_PLAYLIST_NAME).click()
+  await page.getByText(VIDEO_TITLES[0]).first().click()
+  await expect(page).toHaveURL(new RegExp(`#\\/watch\\/skipvideo0\\?.*playlistId=${SHORT_PLAYLIST_ID}`))
+
+  const video = await waitForPlayback(page)
+  await expect(page.locator(`${activeTab} .ftVideoPlayer`)).toHaveClass(/shortsPlayer/)
+  await expect.poll(() => readSkipAvailability(page)).toEqual({
+    canPlayNext: true,
+    canPlayPrevious: false
+  })
+  expect(await video.evaluate(element => element.loop)).toBe(false)
+
+  await video.evaluate(element => {
+    element.currentTime = Math.max(0, element.duration - 0.25)
+  })
+
+  await expect(page).toHaveURL(new RegExp(`#\\/watch\\/skipvideo1\\?.*playlistId=${SHORT_PLAYLIST_ID}`))
+  await waitForPlayback(page)
 })
 
 test('offers skipping to a queued video without a playlist', async ({ page }) => {

--- a/src/renderer/components/ft-shaka-video-player/ft-shaka-video-player.vue
+++ b/src/renderer/components/ft-shaka-video-player/ft-shaka-video-player.vue
@@ -123,7 +123,7 @@
         crossorigin="anonymous"
         playsinline
         :autoplay="autoplayVideos || (!suppressInitialAutoplay && shortsPlayer && isActiveTab) ? true : null"
-        :loop="shortsPlayer && loopShorts"
+        :loop="shortsPlayer && loopShorts && !autoplayEnabled"
         :poster="!audioPlayerMode && showPoster ? thumbnail : null"
         @play="handlePlay"
         @playing="handlePlaying"

--- a/src/renderer/views/Watch/Watch.js
+++ b/src/renderer/views/Watch/Watch.js
@@ -661,6 +661,9 @@ export default defineComponent({
         this.isShort &&
         this.activeFormat !== 'audio'
     },
+    isStandaloneShort: function () {
+      return this.isShort && !this.watchingPlaylist
+    },
     shortsPlayerWidth: function () {
       const playerHeight = Math.max(0, this.shortsViewportHeight - 156)
       return Math.min(600, playerHeight * (this.videoAspectRatio ?? 9 / 16))
@@ -888,7 +891,7 @@ export default defineComponent({
         !this.manifestSrc.includes('/demuxed/1'))
     },
     autoplayEnabled: function () {
-      if (this.isShort) { return false }
+      if (this.isStandaloneShort) { return false }
       if (this.nextQueuedVideo) { return true }
       return this.watchingPlaylist ? this.autoplayNextPlaylistVideo : this.autoplayNextRecommendedVideo
     },
@@ -997,7 +1000,7 @@ export default defineComponent({
       return this.watchingPlaylist && this.playlistSkipAvailability.canPlayPrevious
     },
     autoplayPossible: function () {
-      return !this.isShort && (
+      return !this.isStandaloneShort && (
         !!this.nextQueuedVideo ||
         (!this.watchingPlaylist && !this.hideRecommendedVideos && !!this.nextRecommendedVideo) ||
         (this.watchingPlaylist && !this.$refs.watchVideoPlaylist?.shouldStopDueToPlaylistEnd)
@@ -4494,16 +4497,15 @@ export default defineComponent({
       if (process.env.IS_ELECTRON && !this.isTabPresented) {
         return
       }
-      // YouTube-style Shorts stop for the replay control instead of advancing.
-      // With looping disabled they emit `ended`, so this must run before queue
-      // autoplay.
-      if (this.customShortsPlayerActive) {
+      // Standalone YouTube-style Shorts stop for the replay control instead of
+      // advancing. Playlist Shorts still follow the playlist autoplay setting.
+      if (this.customShortsPlayerActive && this.isStandaloneShort) {
         return
       }
       if (this.playNextQueuedVideo()) {
         return
       }
-      if (this.isShort) {
+      if (this.isStandaloneShort) {
         return
       }
       if (!this.autoplayEnabled) {


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Make sure to follow the contributing guidelines. -->
<!-- Important note, we may remove your pull request if you do not use this provided PR template correctly. -->
<!-- Agent instructions: Preserve every heading, comment, and marker in this template. Never remove or rewrite the release-note-category:start/end, release-note:start/end, or release-note-image:start/end marker pairs. -->

## Pull Request Type
<!-- Please select what type of pull request this is: [x] -->
- [x] Bugfix
- [ ] Feature Implementation
- [ ] Documentation
- [ ] Other

## Related issue
<!-- Please link the issue your pull request is referring to. -->
<!-- If this pull request fully resolves the relevant issue, put "closes" before the issue number. -->
<!-- Example: "closes #123456". -->

Closes #1078

## Description
<!-- Please write a clear and concise description of what the pull request does. -->

Playlist playback stopped when it reached an item categorized as a Short because standalone Shorts suppress autoplay and may loop without emitting an end event.

Playlist Shorts now use the playlist autoplay setting. When autoplay is enabled, they do not loop and advance through the normal playlist countdown. Standalone Shorts and playlist Shorts with autoplay disabled still honor the Loop Shorts preference.

## Release note category
<!-- Select exactly one category. Every pull request must select one. -->
<!-- Select "Not noteworthy" when the pull request fixes a bug in or improves functionality that has not yet appeared in a stable release. -->
<!-- release-note-category:start -->
- [ ] Not noteworthy
- [ ] Highlights
- [ ] More improvements
- [x] Fixed bugs
<!-- release-note-category:end -->

## Release note
<!-- Required unless "Not noteworthy" is selected. -->
<!-- Write one concise, user-facing entry without a leading bullet. -->
<!-- release-note:start -->

Playlists now continue automatically after Shorts instead of stopping or looping indefinitely.

<!-- release-note:end -->

## Release note images
<!-- Optional. Paste one or more Markdown images, HTML image tags, or dark/light <picture> elements here. -->
<!-- The release notes normalize the markup and limit images taller than 300 pixels. -->
<!-- Agent instructions:
For a noteworthy visible change, add media when it makes the change easier to understand. Prefer a still image unless motion is the point. Recordings in this section must end up as animated WebP because release notes accept images, not video attachments.
After implementing a visible change, proactively capture the result and show the local media to the user for approval before uploading it or updating the pull request.
When the affected UI differs between dark and light themes, capturing both themes is required. A dark-only image is incomplete. The final pull request body must combine the hosted URLs into a theme-aware `<picture>` with dark and light `prefers-color-scheme` sources and the dark image as its `<img>` fallback. Never leave the two theme captures as separate images. Use a single default-dark capture only when the light theme cannot be captured or looks identical.
Capture or crop to the smallest region that still makes the change clear. Do not include the full window when the affected component can be understood on its own.
Use English unless localization is the subject. Keep components at their normal dimensions and placement instead of resizing them to fill the frame.
Use deterministic local fixtures for visible remote images. Reusable avatar and thumbnail fixtures are available through `e2e/helpers/visual-fixtures.mjs`. Before capturing, verify that every visible image has loaded successfully (`complete === true` and `naturalWidth > 0`).
Inspect the final dark and light files for failed images, missing content, unrelated UI, awkward animation, and misleading layout. Omit media when it does not explain the change clearly.
Use GitHub CLI 2.99.0 or newer to upload images no larger than 10 MB. For one image, write an ordinary Markdown image reference to the local file between the marker comments. Pass the same file to `gh pr create` or `gh pr edit` with `--attach <path>` so GitHub CLI replaces the local path with its hosted URL.
GitHub CLI does not rewrite paths inside HTML attributes. For themed images within its size limit, first upload both files through temporary Markdown image references and repeat `--attach <path>` for each one. Read back the hosted URLs, replace the temporary references with the `<picture>` below, and update the pull request body without `--attach`:
<picture>
  <source media="(prefers-color-scheme: dark)" srcset="HOSTED_DARK_URL">
  <source media="(prefers-color-scheme: light)" srcset="HOSTED_LIGHT_URL">
  <img alt="DESCRIPTION" src="HOSTED_DARK_URL">
</picture>
For every MP4, MOV, or WebM recording, use `node _scripts/releaseNoteMedia.mjs FILE --alt "DESCRIPTION"` regardless of file size so the helper converts it to animated WebP. Use the same command when an image exceeds 10 MB. For a themed pair where either file needs the helper, use `node _scripts/releaseNoteMedia.mjs --dark DARK_FILE --light LIGHT_FILE --alt "DESCRIPTION"`. Paste only its generated markup between the marker comments.
Check for personal information, tokens, private repository names, and unrelated desktop content before uploading. Uploaded media is public.
Keep capture-only scripts, test hooks, screenshots, and recordings out of commits. Remove them before committing unless the capture code is also a reusable regression test. Never commit generated release-note media.
Leave this section empty when media would not help.
-->
<!-- release-note-image:start -->

<!-- release-note-image:end -->

## Testing
<!-- How can reviewers verify that the PR produces correct results? -->
<!-- Please provide instructions so that others can ensure that your pull request would produce correct results. For examples see, https://github.com/FreeTubeApp/FreeTube/pull/5743, https://github.com/FreeTubeApp/FreeTube/pull/7349, https://github.com/FreeTubeApp/FreeTube/pull/5125, https://github.com/FreeTubeApp/FreeTube/pull/7338 -->
<!-- Agent instructions: Only write human-facing steps that explain how to verify the change while running this branch in dev mode. Include expected results and, when applicable, helpful console snippets for interactive verification. Do not include automated checks, commands, results, pass counts, or CI status. -->

1. Enable both playlist autoplay and Loop Shorts in settings.
2. Open a playlist where a Short is followed by a normal video.
3. Let the Short finish or seek close to its end.
4. Confirm the next playlist video opens after the autoplay countdown and starts playing.
5. Open a standalone Short and confirm it still follows the Loop Shorts setting.

## Additional context
<!-- Add any other context about the pull request here. -->

The regression test uses a local media fixture and reaches the native media end, so it covers the browser behavior that suppresses `ended` while looping.
