### PR TITLE
feat(tabs): add mobile reload, link copy, and unloading

### DIFF
--- a/src/renderer/App.vue
+++ b/src/renderer/App.vue
@@ -54,7 +54,7 @@
         id="cross-tab-mini-player-layer"
         class="crossTabMiniPlayerLayer"
       />
-      <template v-if="isElectron">
+      <template v-if="usesLogicalTabs">
         <TabContent
           v-for="tab in tabContainers"
           :key="tab.id"

--- a/src/renderer/components/TabBar/CapacitorPhoneTabSwitcher.css
+++ b/src/renderer/components/TabBar/CapacitorPhoneTabSwitcher.css
@@ -303,6 +303,10 @@
   background-color: var(--side-nav-hover-color);
 }
 
+.capacitorPhoneTabRow.unloaded .capacitorPhoneTabTarget {
+  opacity: 0.6;
+}
+
 .capacitorPhoneTabViewTabs {
   display: grid;
   grid-template-columns: repeat(2, minmax(0, 1fr));

--- a/src/renderer/components/TabBar/CapacitorPhoneTabSwitcher.vue
+++ b/src/renderer/components/TabBar/CapacitorPhoneTabSwitcher.vue
@@ -136,6 +136,7 @@
                   :class="{
                     active: tab.id === activeTabId,
                     pinned: tab.isPinned,
+                    unloaded: tab.isUnloaded,
                     dragging: drag.tabId === tab.id,
                     swiping: swipe.tabId === tab.id && swipe.dragging,
                     closing: swipe.tabId === tab.id && swipe.closing
@@ -168,6 +169,7 @@
                     role="tab"
                     :data-tab-id="tab.id"
                     :aria-selected="tab.id === activeTabId"
+                    :aria-label="tabAriaLabel(tab)"
                     :tabindex="tab.id === activeTabId ? 0 : -1"
                     @click="activateTab(tab.id)"
                     @keydown="handleTabTargetKeydown($event, tab.id)"
@@ -284,10 +286,15 @@
             <CapacitorTabActionsMenu
               :tab="actionTab"
               :title="actionTab ? tabTitle(actionTab) : ''"
+              :youtube-url="actionTabYoutubeUrl"
+              :can-toggle-loaded="canToggleActionTabLoaded"
               mode="phone"
               @close="closeActionTab"
+              @copy-youtube-link="copyActionTabYoutubeLink"
               @dismiss="closeTabActions"
               @duplicate="duplicateActionTab"
+              @reload="reloadActionTab"
+              @toggle-loaded="toggleActionTabLoaded"
               @toggle-pinned="toggleActionTabPinned"
             />
           </section>
@@ -369,15 +376,21 @@ const swipe = reactive({
 const drag = reactive({ tabId: null, pointerId: null, moved: false })
 const {
   actionTab,
+  actionTabYoutubeUrl,
   activateTab: activateTabAction,
+  canToggleActionTabLoaded,
   closeActionTab,
   closeTab,
   closeTabActions,
   createTab,
+  copyActionTabYoutubeLink,
   duplicateActionTab,
   handleTabTargetKeydown,
   openTabActions,
+  reloadActionTab,
+  tabAriaLabel,
   tabTitle,
+  toggleActionTabLoaded,
   toggleActionTabPinned,
 } = useCapacitorTabActions({
   tabs,

--- a/src/renderer/components/TabBar/CapacitorTabActionsMenu.css
+++ b/src/renderer/components/TabBar/CapacitorTabActionsMenu.css
@@ -18,7 +18,9 @@
 
 .capacitorTabActions {
   display: grid;
-  gap: 4px;
+  grid-template-rows: auto minmax(0, 1fr);
+  box-sizing: border-box;
+  max-block-size: 100%;
   padding-block: 16px max(16px, var(--safe-area-inset-bottom, env(safe-area-inset-bottom, 0px)));
   padding-inline: 16px;
   color: var(--primary-text-color);
@@ -28,6 +30,13 @@
   box-shadow: 0 -8px 32px rgb(0 0 0 / 35%);
   user-select: none;
   -webkit-tap-highlight-color: transparent;
+}
+
+.capacitorTabActionList {
+  display: grid;
+  gap: 4px;
+  min-block-size: 0;
+  overflow-y: auto;
 }
 
 .capacitorTabActions strong {
@@ -57,6 +66,15 @@
 
 .capacitorTabActions button:is(:hover, :active, :focus-visible) {
   background-color: var(--side-nav-hover-color);
+}
+
+.capacitorTabActions button:disabled {
+  cursor: default;
+  opacity: 0.45;
+}
+
+.capacitorTabActions button:disabled:is(:hover, :active, :focus-visible) {
+  background-color: transparent;
 }
 
 .capacitorTabActions .dangerAction {

--- a/src/renderer/components/TabBar/CapacitorTabActionsMenu.vue
+++ b/src/renderer/components/TabBar/CapacitorTabActionsMenu.vue
@@ -14,40 +14,80 @@
         :aria-label="title"
       >
         <strong dir="auto">{{ title }}</strong>
-        <button
-          type="button"
-          role="menuitem"
-          @click="emit('toggle-pinned')"
+        <div
+          v-overlay-scrollbars
+          class="capacitorTabActionList"
         >
-          <FtIcon
-            :icon="tab.isPinned ? ['fas', 'thumbtack-slash'] : ['fas', 'thumbtack']"
-            aria-hidden="true"
-          />
-          {{ tab.isPinned ? t('Context Menu.Unpin Tab') : t('Context Menu.Pin Tab') }}
-        </button>
-        <button
-          type="button"
-          role="menuitem"
-          @click="emit('duplicate')"
-        >
-          <FtIcon
-            :icon="['fas', 'clone']"
-            aria-hidden="true"
-          />
-          {{ t('Context Menu.Duplicate Tab') }}
-        </button>
-        <button
-          type="button"
-          role="menuitem"
-          class="dangerAction"
-          @click="emit('close')"
-        >
-          <FtIcon
-            :icon="['fas', 'xmark']"
-            aria-hidden="true"
-          />
-          {{ t('Close Tab') }}
-        </button>
+          <button
+            v-if="youtubeUrl"
+            type="button"
+            role="menuitem"
+            @click="emit('copy-youtube-link')"
+          >
+            <FtIcon
+              :icon="['fab', 'youtube']"
+              aria-hidden="true"
+            />
+            {{ t('Context Menu.Copy YouTube Link') }}
+          </button>
+          <button
+            type="button"
+            role="menuitem"
+            @click="emit('toggle-pinned')"
+          >
+            <FtIcon
+              :icon="tab.isPinned ? ['fas', 'thumbtack-slash'] : ['fas', 'thumbtack']"
+              aria-hidden="true"
+            />
+            {{ tab.isPinned ? t('Context Menu.Unpin Tab') : t('Context Menu.Pin Tab') }}
+          </button>
+          <button
+            type="button"
+            role="menuitem"
+            @click="emit('duplicate')"
+          >
+            <FtIcon
+              :icon="['fas', 'clone']"
+              aria-hidden="true"
+            />
+            {{ t('Context Menu.Duplicate Tab') }}
+          </button>
+          <button
+            type="button"
+            role="menuitem"
+            @click="emit('reload')"
+          >
+            <FtIcon
+              :icon="['fas', 'sync']"
+              aria-hidden="true"
+            />
+            {{ t('Context Menu.Reload Tab') }}
+          </button>
+          <button
+            type="button"
+            role="menuitem"
+            :disabled="!canToggleLoaded"
+            @click="emit('toggle-loaded')"
+          >
+            <FtIcon
+              :icon="tab.loadState === 'unloaded' ? ['fas', 'download'] : ['fas', 'right-from-bracket']"
+              aria-hidden="true"
+            />
+            {{ tab.loadState === 'unloaded' ? t('Context Menu.Load Tab') : t('Context Menu.Unload Tab') }}
+          </button>
+          <button
+            type="button"
+            role="menuitem"
+            class="dangerAction"
+            @click="emit('close')"
+          >
+            <FtIcon
+              :icon="['fas', 'xmark']"
+              aria-hidden="true"
+            />
+            {{ t('Close Tab') }}
+          </button>
+        </div>
       </section>
     </div>
   </Transition>
@@ -71,9 +111,25 @@ defineProps({
     type: String,
     default: '',
   },
+  youtubeUrl: {
+    type: String,
+    default: null,
+  },
+  canToggleLoaded: {
+    type: Boolean,
+    default: true,
+  },
 })
 
-const emit = defineEmits(['close', 'dismiss', 'duplicate', 'toggle-pinned'])
+const emit = defineEmits([
+  'close',
+  'copy-youtube-link',
+  'dismiss',
+  'duplicate',
+  'reload',
+  'toggle-loaded',
+  'toggle-pinned'
+])
 const { t } = useI18n()
 </script>
 

--- a/src/renderer/components/TabBar/CapacitorTabletTabBar.css
+++ b/src/renderer/components/TabBar/CapacitorTabletTabBar.css
@@ -126,6 +126,10 @@
   outline-offset: -3px;
 }
 
+.capacitorTabletTab.unloaded .capacitorTabletTabTarget {
+  opacity: 0.6;
+}
+
 .capacitorTabletTabIcon {
   display: grid;
   place-items: center;

--- a/src/renderer/components/TabBar/CapacitorTabletTabBar.vue
+++ b/src/renderer/components/TabBar/CapacitorTabletTabBar.vue
@@ -20,7 +20,7 @@
           v-for="tab in tabs"
           :key="tab.id"
           class="capacitorTabletTab"
-          :class="{ active: tab.id === activeTabId }"
+          :class="{ active: tab.id === activeTabId, unloaded: tab.isUnloaded }"
           @contextmenu.prevent.stop="openTabActions(tab.id)"
         >
           <button
@@ -29,6 +29,7 @@
             role="tab"
             :data-tab-id="tab.id"
             :aria-selected="tab.id === activeTabId"
+            :aria-label="tabAriaLabel(tab)"
             :tabindex="tab.id === activeTabId ? 0 : -1"
             :title="tabTitle(tab)"
             @click="activateTab(tab.id)"
@@ -87,10 +88,15 @@
       <CapacitorTabActionsMenu
         :tab="actionTab"
         :title="actionTab ? tabTitle(actionTab) : ''"
+        :youtube-url="actionTabYoutubeUrl"
+        :can-toggle-loaded="canToggleActionTabLoaded"
         mode="tablet"
         @close="closeActionTab"
+        @copy-youtube-link="copyActionTabYoutubeLink"
         @dismiss="closeTabActions"
         @duplicate="duplicateActionTab"
+        @reload="reloadActionTab"
+        @toggle-loaded="toggleActionTabLoaded"
         @toggle-pinned="toggleActionTabPinned"
       />
     </Teleport>
@@ -123,15 +129,21 @@ const fixedTabWidthStyle = computed(() => store.getters.getUseFixedTabWidth
   : undefined)
 const {
   actionTab,
+  actionTabYoutubeUrl,
   activateTab,
+  canToggleActionTabLoaded,
   closeActionTab,
   closeTab,
   closeTabActions,
   createTab,
+  copyActionTabYoutubeLink,
   duplicateActionTab,
   handleTabTargetKeydown,
   openTabActions,
+  reloadActionTab,
+  tabAriaLabel,
   tabTitle,
+  toggleActionTabLoaded,
   toggleActionTabPinned,
 } = useCapacitorTabActions({
   tabs,

--- a/src/renderer/components/TabBar/useCapacitorTabActions.js
+++ b/src/renderer/components/TabBar/useCapacitorTabActions.js
@@ -1,5 +1,8 @@
 import { computed, ref } from 'vue'
+import { useI18n } from 'vue-i18n'
 
+import { isShareableOpenTubeXRoute, transformOpenTubeXRouteUrl } from '../../helpers/share'
+import { copyToClipboard } from '../../helpers/utils'
 import { getCapacitorTabService } from '../../tabs/CapacitorTabService'
 import { formatTabTitle } from '../../tabs/tabTitle'
 
@@ -30,13 +33,30 @@ export function useCapacitorTabActions({
   afterCloseActions = noop,
   stopContextMenuPropagation = false,
 }) {
+  const { t } = useI18n()
   const actionTabId = ref(null)
   const actionTab = computed(() => (
     tabs.value.find(tab => tab.id === actionTabId.value) ?? null
   ))
+  const actionTabYoutubeUrl = computed(() => {
+    const route = actionTab.value?.route?.fullPath
+    return isShareableOpenTubeXRoute(route)
+      ? transformOpenTubeXRouteUrl(route, true)
+      : null
+  })
+  const canToggleActionTabLoaded = computed(() => {
+    const tab = actionTab.value
+    if (!tab || tab.loadState === 'mounting' || tab.loadState === 'unloading') return false
+    return tab.loadState === 'unloaded' || tabs.value.length > 1
+  })
 
   function tabTitle(tab) {
     return formatTabTitle(tab.contentTitle || tab.title || tab.route.fullPath)
+  }
+
+  function tabAriaLabel(tab) {
+    const title = tabTitle(tab)
+    return tab.isUnloaded ? `${title}, ${t('Tab Organizer.Unloaded')}` : title
   }
 
   async function createTab() {
@@ -94,6 +114,36 @@ export function useCapacitorTabActions({
     await afterDuplicate()
   }
 
+  async function copyActionTabYoutubeLink() {
+    const url = actionTabYoutubeUrl.value
+    if (!url) return
+
+    closeTabActions()
+    await copyToClipboard(url, {
+      messageOnSuccess: t('Share.YouTube URL copied to clipboard')
+    })
+  }
+
+  async function reloadActionTab() {
+    if (!actionTab.value) return
+
+    const tabId = actionTab.value.id
+    closeTabActions()
+    await getCapacitorTabService().reloadTab(tabId)
+  }
+
+  async function toggleActionTabLoaded() {
+    if (!actionTab.value || !canToggleActionTabLoaded.value) return
+
+    const tab = actionTab.value
+    closeTabActions()
+    if (tab.loadState === 'unloaded') {
+      getCapacitorTabService().loadTab(tab.id)
+    } else {
+      await getCapacitorTabService().unloadTab(tab.id)
+    }
+  }
+
   async function closeActionTab() {
     if (!actionTab.value) return
 
@@ -104,15 +154,21 @@ export function useCapacitorTabActions({
 
   return {
     actionTab,
+    actionTabYoutubeUrl,
     activateTab,
+    canToggleActionTabLoaded,
     closeActionTab,
     closeTab,
     closeTabActions,
     createTab,
+    copyActionTabYoutubeLink,
     duplicateActionTab,
     handleTabTargetKeydown,
     openTabActions,
+    reloadActionTab,
+    tabAriaLabel,
     tabTitle,
+    toggleActionTabLoaded,
     toggleActionTabPinned,
   }
 }

--- a/src/renderer/components/TabContent/TabContent.vue
+++ b/src/renderer/components/TabContent/TabContent.vue
@@ -226,6 +226,7 @@ onErrorCaptured((error) => {
 })
 
 onBeforeUnmount(() => {
+  lifecycleRevision += 1
   disposeMountedContent().catch(error => {
     console.error(`Failed to dispose logical tab ${props.tab.id}:`, error)
   })

--- a/src/renderer/components/TabContent/TabContent.vue
+++ b/src/renderer/components/TabContent/TabContent.vue
@@ -39,6 +39,7 @@ import { routeLocationKey, routerKey } from 'vue-router'
 import store from '../../store/index'
 import { resolveRouteComponent } from '../../router/index'
 import { getTabNavigationService } from '../../tabs/TabNavigationService'
+import { getCapacitorTabService } from '../../tabs/CapacitorTabService'
 import { tabLifecycleService } from '../../tabs/TabLifecycleService'
 import { tabRuntimeRegistry } from '../../tabs/TabRuntimeRegistry'
 import { tabIdKey, tabLifecycleKey, tabPresentedKey } from '../../tabs/TabContext'
@@ -100,6 +101,7 @@ let loaderAnimationFrameId = null
 let loaderSettleTimeoutId = null
 let acknowledgedMountRevision = 0
 let previousRefreshKey = props.tab.refreshKey ?? 0
+let lifecycleRevision = 0
 // Guards against notifying `beforeDispose` twice for the same mounted instance:
 // the unload watcher and onBeforeUnmount can both fire for one instance. Reset
 // when the tab mounts again so a subsequent mount receives one notification.
@@ -138,9 +140,11 @@ async function disposeMountedContent() {
 watch(
   () => [shouldMount.value, props.tab.mountRevision, props.tab.refreshKey],
   async ([mount, mountRevision, refreshKey]) => {
+    const revision = ++lifecycleRevision
     if (!mount) {
       if (initialized.value && !disposalNotified) {
         await disposeMountedContent()
+        if (revision !== lifecycleRevision || shouldMount.value) return
         initialized.value = false
       }
       navigation.setLoadingSource(props.tab.id, TAB_LOADER_LOADING_SOURCE, false)
@@ -149,9 +153,11 @@ watch(
 
     if (refreshKey !== previousRefreshKey) {
       await tabLifecycleService.run(props.tab.id, 'beforeReload')
+      if (revision !== lifecycleRevision) return
       previousRefreshKey = refreshKey
       initialized.value = false
       await nextTick()
+      if (revision !== lifecycleRevision) return
       store.commit('applyPendingReloadRoute', props.tab.id)
     }
 
@@ -168,6 +174,9 @@ watch(
       acknowledgedMountRevision = mountRevision
       tabRuntimeRegistry.markMounted(props.tab.id, mountRevision)
       window.ftElectron?.tabs?.mountReady?.(props.tab.id, mountRevision)
+      if (process.env.IS_CAPACITOR) {
+        getCapacitorTabService().markTabMounted(props.tab.id, mountRevision)
+      }
       // Mount readiness can race the initial active-tab watcher. Retry now that
       // the runtime is guaranteed to exist so the tab cannot remain hidden.
       if (
@@ -208,6 +217,9 @@ onErrorCaptured((error) => {
   if (mountRevision > acknowledgedMountRevision) {
     tabRuntimeRegistry.markMountFailed(props.tab.id, mountRevision)
     window.ftElectron?.tabs?.mountFailed?.(props.tab.id, mountRevision)
+    if (process.env.IS_CAPACITOR) {
+      getCapacitorTabService().markTabMountFailed(props.tab.id, mountRevision)
+    }
   }
   // Return undefined (not false) so the error still propagates to the app-level
   // errorHandler in main.js after our IPC notification, preserving observability.

--- a/src/renderer/components/ft-shaka-video-player/ft-shaka-video-player.js
+++ b/src/renderer/components/ft-shaka-video-player/ft-shaka-video-player.js
@@ -5676,7 +5676,6 @@ export default defineComponent({
       shortsEnded.value = false
       const isCurrentPictureInPictureVideo = document.pictureInPictureElement === video.value
       if (
-        process.env.IS_ELECTRON &&
         !isActiveTab.value &&
         !isCurrentPictureInPictureVideo &&
         !scrollMiniPlayerDetached.value

--- a/src/renderer/components/ft-shaka-video-player/opentubex/autoPictureInPictureState.js
+++ b/src/renderer/components/ft-shaka-video-player/opentubex/autoPictureInPictureState.js
@@ -20,6 +20,18 @@ export function canEnableAndroidAutoPictureInPicture(enabled, format, video) {
 }
 
 /**
+ * @param {boolean} isPresented
+ * @param {boolean} enabled
+ * @param {string} format
+ * @param {{ paused: boolean, ended: boolean } | null} video
+ * @returns {boolean | null}
+ */
+export function resolveAndroidAutoPictureInPictureUpdate(isPresented, enabled, format, video) {
+  if (!isPresented) return null
+  return canEnableAndroidAutoPictureInPicture(enabled, format, video)
+}
+
+/**
  * @typedef {{
  *   windowMinimized: boolean,
  *   windowFocused: boolean,

--- a/src/renderer/components/ft-shaka-video-player/opentubex/useAutoPictureInPicture.js
+++ b/src/renderer/components/ft-shaka-video-player/opentubex/useAutoPictureInPicture.js
@@ -7,10 +7,10 @@ import {
   applyMinimizedState,
   applyPictureInPictureState,
   BLUR_TRIGGER_RECHECK_DELAY_MS,
-  canEnableAndroidAutoPictureInPicture,
   createAutoPictureInPictureState,
   markPictureInPictureRequested,
   markPictureInPictureRequestFailed,
+  resolveAndroidAutoPictureInPictureUpdate,
   resolveAutoPictureInPictureAction,
   shouldAutoPictureInPicture
 } from './autoPictureInPictureState'
@@ -103,12 +103,15 @@ export function useAutoPictureInPicture({
   function updateAutoPip() {
     if (process.env.IS_CAPACITOR) {
       const videoElement = video.value
+      const enabled = resolveAndroidAutoPictureInPictureUpdate(
+        isActiveTab.value,
+        androidAutoPictureInPicture.value,
+        props.format,
+        videoElement
+      )
+      if (enabled === null) return
       setAndroidAutoPictureInPicture(
-        canEnableAndroidAutoPictureInPicture(
-          androidAutoPictureInPicture.value,
-          props.format,
-          videoElement
-        ),
+        enabled,
         videoElement
       ).catch(error => console.warn('Failed to configure Android auto Picture-in-Picture:', error))
       return
@@ -242,7 +245,9 @@ export function useAutoPictureInPicture({
       video.value?.removeEventListener('play', updateAutoPip)
       video.value?.removeEventListener('pause', updateAutoPip)
       video.value?.removeEventListener('ended', updateAutoPip)
-      setAndroidAutoPictureInPicture(false, video.value).catch(() => {})
+      if (isActiveTab.value) {
+        setAndroidAutoPictureInPicture(false, video.value).catch(() => {})
+      }
     } else if (process.env.IS_ELECTRON) {
       removeMinimizedListener?.()
       removeMinimizedListener = null

--- a/src/renderer/components/ft-shaka-video-player/opentubex/useAutoPictureInPicture.js
+++ b/src/renderer/components/ft-shaka-video-player/opentubex/useAutoPictureInPicture.js
@@ -43,7 +43,7 @@ export function useAutoPictureInPicture({
   initialState = null
 }) {
   const isActiveTab = computed(() => {
-    return !process.env.IS_ELECTRON || isTabPresented?.value === true
+    return isTabPresented?.value !== false
   })
   const autoPictureInPictureTriggers = computed(() => store.getters.getAutoPictureInPictureTriggers)
   const androidAutoPictureInPicture = computed(() => store.getters.getAndroidAutoPictureInPicture)

--- a/src/renderer/composables/useTabToast.js
+++ b/src/renderer/composables/useTabToast.js
@@ -19,7 +19,7 @@ export function useTabToast() {
 
   return (message, time = null, action = null, abortSignal = null) => {
     // No provider (web build, single view) means there are no background tabs.
-    if (process.env.IS_ELECTRON && isTabPresented != null && !isTabPresented.value) {
+    if (isTabPresented != null && !isTabPresented.value) {
       return
     }
 

--- a/src/renderer/store/modules/tabs.js
+++ b/src/renderer/store/modules/tabs.js
@@ -408,6 +408,9 @@ const actions = {
   },
 
   reloadTab(_context, tabId) {
+    if (process.env.IS_CAPACITOR && tabId) {
+      return getCapacitorTabService().reloadTab(tabId)
+    }
     if (process.env.IS_ELECTRON && tabId) {
       window.ftElectron.tabs.reload(tabId)
     }

--- a/src/renderer/tabs/CapacitorTabService.js
+++ b/src/renderer/tabs/CapacitorTabService.js
@@ -307,7 +307,8 @@ class CapacitorTabService {
         mountRevision: tab.mountRevision,
         refreshKey: tab.refreshKey,
         isLoading: tab.isLoading,
-        isPlaying: tab.isPlaying
+        isPlaying: tab.isPlaying,
+        pendingReloadRoute: tab.pendingReloadRoute
       })),
       closedTabs: this.store.getters.getClosedTabs.toReversed().map(tab => ({
         id: tab.id,

--- a/src/renderer/tabs/CapacitorTabService.js
+++ b/src/renderer/tabs/CapacitorTabService.js
@@ -42,6 +42,7 @@ export class CapacitorTabService {
     this.store = store
     this.navigation = navigation
     this.initialized = false
+    this.sessionGeneration = 0
     this.removeRouterHook = () => {}
     this.removeStoreSubscription = () => {}
   }
@@ -294,13 +295,14 @@ export class CapacitorTabService {
 
   async commitAndPresent(previous, session) {
     const previousPresentedTabId = this.store.getters.getPresentedTabId
-    this.commitSession(session)
+    const presentationGeneration = this.commitSession(session)
     if (await this.navigation.requestPresentation(session.activeTabId, session.selectionRevision)) {
       return true
     }
 
     const current = this.currentSession()
     if (
+      this.sessionGeneration !== presentationGeneration ||
       current.activeTabId !== session.activeTabId ||
       current.selectionRevision !== session.selectionRevision
     ) {
@@ -351,6 +353,8 @@ export class CapacitorTabService {
 
   commitSession(session, presentedTabId = this.store.getters.getPresentedTabId ?? session.activeTabId) {
     this.store.commit('setTabsState', toRuntimeTabState(session, presentedTabId))
+    this.sessionGeneration += 1
+    return this.sessionGeneration
   }
 
   persist() {

--- a/src/renderer/tabs/CapacitorTabService.js
+++ b/src/renderer/tabs/CapacitorTabService.js
@@ -7,13 +7,12 @@ import {
   loadCapacitorTab,
   moveCapacitorTab,
   reloadCapacitorTab,
-  rollbackCapacitorTabActivation,
   restoreClosedCapacitorTab,
   restoreCapacitorTabSession,
   setCapacitorTabPinned,
   toRuntimeTabState,
   unloadCapacitorTab
-} from './capacitorTabState'
+} from './capacitorTabState.js'
 
 const STORAGE_KEY = 'opentubex-capacitor-tabs'
 const PERSISTED_MUTATIONS = new Set([
@@ -37,7 +36,7 @@ export function getCapacitorTabService() {
   return service
 }
 
-class CapacitorTabService {
+export class CapacitorTabService {
   constructor(router, store, navigation) {
     this.router = router
     this.store = store
@@ -89,12 +88,14 @@ class CapacitorTabService {
 
   async createTab(location = `/${this.store.getters.getLandingPage}`, title = '', makeActive = true) {
     const tab = createCapacitorTab(this.router.resolve(location), title)
-    const session = addCapacitorTab(this.currentSession(), tab, makeActive)
-    this.commitSession(session)
-    if (makeActive) {
-      await this.navigation.requestPresentation(session.activeTabId, session.selectionRevision)
+    const previous = this.currentSession()
+    const session = addCapacitorTab(previous, tab, makeActive)
+    if (!makeActive) {
+      this.commitSession(session)
+      return tab.id
     }
-    return tab.id
+
+    return await this.commitAndPresent(previous, session) ? tab.id : null
   }
 
   async activateTab(tabId) {
@@ -102,22 +103,7 @@ class CapacitorTabService {
     const session = activateCapacitorTab(loadCapacitorTab(previous, tabId), tabId)
     if (session === previous) return false
 
-    this.commitSession(session)
-    const presented = await this.navigation.requestPresentation(tabId, session.selectionRevision)
-    if (presented) return true
-
-    const current = this.currentSession()
-    const rolledBack = rollbackCapacitorTabActivation(
-      current,
-      tabId,
-      previous.activeTabId,
-      session.selectionRevision
-    )
-    if (rolledBack !== current) {
-      this.commitSession(rolledBack)
-      await this.navigation.requestPresentation(rolledBack.activeTabId, rolledBack.selectionRevision)
-    }
-    return false
+    return await this.commitAndPresent(previous, session)
   }
 
   async duplicateTab(tabId) {
@@ -126,10 +112,9 @@ class CapacitorTabService {
 
     const tab = createCapacitorTab(source.route)
     tab.title = source.contentTitle || source.title || source.route.fullPath
-    const session = addCapacitorTab(this.currentSession(), tab)
-    this.commitSession(session)
-    await this.navigation.requestPresentation(session.activeTabId, session.selectionRevision)
-    return tab.id
+    const previous = this.currentSession()
+    const session = addCapacitorTab(previous, tab)
+    return await this.commitAndPresent(previous, session) ? tab.id : null
   }
 
   async closeTab(tabId) {
@@ -137,6 +122,8 @@ class CapacitorTabService {
     if (!previous.tabs.some(tab => tab.id === tabId)) return false
 
     const wasActive = previous.activeTabId === tabId
+    const wasPresented = this.store.getters.getPresentedTabId === tabId
+    if (wasPresented && !wasActive) return false
     if (wasActive) this.navigation.saveScroll(tabId)
 
     if (wasActive && previous.tabs.length > 1) {
@@ -151,11 +138,11 @@ class CapacitorTabService {
     if (needsPresentation) {
       session = loadCapacitorTab(session, session.activeTabId)
     }
-    this.commitSession(session)
-
     if (needsPresentation) {
-      await this.navigation.requestPresentation(session.activeTabId, session.selectionRevision)
+      return await this.commitAndPresent(previous, session)
     }
+
+    this.commitSession(session)
     return true
   }
 
@@ -164,9 +151,7 @@ class CapacitorTabService {
     const session = restoreClosedCapacitorTab(previous)
     if (session === previous) return null
 
-    this.commitSession(session)
-    await this.navigation.requestPresentation(session.activeTabId, session.selectionRevision)
-    return session.activeTabId
+    return await this.commitAndPresent(previous, session) ? session.activeTabId : null
   }
 
   getSyncSessions() {
@@ -188,6 +173,7 @@ class CapacitorTabService {
     const synced = sessions.find(session => Array.isArray(session?.tabs) && session.tabs.length > 0)
     if (!synced) return false
 
+    const previous = this.currentSession()
     const tabs = synced.tabs.map(tab => createCapacitorTab(
       this.router.resolve(syncTabRoute(tab.url)),
       tab.title,
@@ -203,9 +189,9 @@ class CapacitorTabService {
         : tabs[0].id,
       closedTabs: [],
     }, this.router.currentRoute.value)
+    if (!await this.commitAndPresent(previous, session)) return false
+
     this.sessionUpdatedAt = Number.isFinite(synced.updatedAt) ? synced.updatedAt : Date.now()
-    this.commitSession(session)
-    await this.navigation.requestPresentation(session.activeTabId, session.selectionRevision)
     this.persist()
     return true
   }
@@ -215,6 +201,7 @@ class CapacitorTabService {
 
     for (const tab of session.tabs) {
       const tabId = await this.createTab(syncTabRoute(tab.url), tab.title)
+      if (!tabId) return false
       if (tab.isPinned === true) this.setPinned(tabId, true)
     }
     return true
@@ -274,6 +261,10 @@ class CapacitorTabService {
     const tab = session.tabs.find(candidate => candidate.id === tabId)
     if (!tab || tab.loadState === 'unloaded' || tab.loadState === 'unloading') return false
 
+    if (this.store.getters.getPresentedTabId === tabId && session.activeTabId !== tabId) {
+      return false
+    }
+
     if (session.activeTabId === tabId) {
       if (session.tabs.length <= 1) return false
 
@@ -301,6 +292,33 @@ class CapacitorTabService {
     if (session !== previous) this.commitSession(session)
   }
 
+  async commitAndPresent(previous, session) {
+    const previousPresentedTabId = this.store.getters.getPresentedTabId
+    this.commitSession(session)
+    if (await this.navigation.requestPresentation(session.activeTabId, session.selectionRevision)) {
+      return true
+    }
+
+    const current = this.currentSession()
+    if (
+      current.activeTabId !== session.activeTabId ||
+      current.selectionRevision !== session.selectionRevision
+    ) {
+      return false
+    }
+
+    const rollbackPresentedTabId = previous.tabs.some(tab => tab.id === previousPresentedTabId)
+      ? previousPresentedTabId
+      : previous.activeTabId
+    const rollback = {
+      ...previous,
+      selectionRevision: current.selectionRevision + 1
+    }
+    this.commitSession(rollback, rollbackPresentedTabId)
+    await this.navigation.requestPresentation(rollback.activeTabId, rollback.selectionRevision)
+    return false
+  }
+
   currentSession() {
     return {
       tabs: this.store.getters.getTabs.map(tab => ({
@@ -317,7 +335,7 @@ class CapacitorTabService {
         isPlaying: tab.isPlaying,
         pendingReloadRoute: tab.pendingReloadRoute
       })),
-      closedTabs: this.store.getters.getClosedTabs.toReversed().map(tab => ({
+      closedTabs: this.store.getters.getClosedTabs.slice().reverse().map(tab => ({
         id: tab.id,
         title: tab.title || tab.route.fullPath,
         isPinned: tab.isPinned === true,
@@ -357,7 +375,7 @@ function findReplacementTabId(tabs, tabId) {
 
   const candidates = [
     ...tabs.slice(tabIndex + 1),
-    ...tabs.slice(0, tabIndex).toReversed()
+    ...tabs.slice(0, tabIndex).reverse()
   ]
   return candidates.find(tab => tab.loadState === 'loaded')?.id ?? candidates[0]?.id ?? null
 }

--- a/src/renderer/tabs/CapacitorTabService.js
+++ b/src/renderer/tabs/CapacitorTabService.js
@@ -2,12 +2,17 @@ import {
   activateCapacitorTab,
   addCapacitorTab,
   closeCapacitorTab,
+  completeCapacitorTabMount,
   createCapacitorTab,
+  loadCapacitorTab,
   moveCapacitorTab,
+  reloadCapacitorTab,
+  rollbackCapacitorTabActivation,
   restoreClosedCapacitorTab,
   restoreCapacitorTabSession,
   setCapacitorTabPinned,
-  toRuntimeTabState
+  toRuntimeTabState,
+  unloadCapacitorTab
 } from './capacitorTabState'
 
 const STORAGE_KEY = 'opentubex-capacitor-tabs'
@@ -49,11 +54,12 @@ class CapacitorTabService {
     this.sessionUpdatedAt = Number.isFinite(persisted?.updatedAt)
       ? persisted.updatedAt
       : Date.now()
-    const session = restoreCapacitorTabSession(
+    let session = restoreCapacitorTabSession(
       persisted,
       currentRoute
     )
-    this.commitSession(session)
+    session = loadCapacitorTab(session, session.activeTabId)
+    this.commitSession(session, session.activeTabId)
     this.store.commit('setPresentedTab', session.activeTabId)
     this.initialized = true
 
@@ -93,11 +99,25 @@ class CapacitorTabService {
 
   async activateTab(tabId) {
     const previous = this.currentSession()
-    const session = activateCapacitorTab(previous, tabId)
+    const session = activateCapacitorTab(loadCapacitorTab(previous, tabId), tabId)
     if (session === previous) return false
 
     this.commitSession(session)
-    return await this.navigation.requestPresentation(tabId, session.selectionRevision)
+    const presented = await this.navigation.requestPresentation(tabId, session.selectionRevision)
+    if (presented) return true
+
+    const current = this.currentSession()
+    const rolledBack = rollbackCapacitorTabActivation(
+      current,
+      tabId,
+      previous.activeTabId,
+      session.selectionRevision
+    )
+    if (rolledBack !== current) {
+      this.commitSession(rolledBack)
+      await this.navigation.requestPresentation(rolledBack.activeTabId, rolledBack.selectionRevision)
+    }
+    return false
   }
 
   async duplicateTab(tabId) {
@@ -120,7 +140,10 @@ class CapacitorTabService {
     if (wasActive) this.navigation.saveScroll(tabId)
 
     const landingRoute = this.router.resolve(`/${this.store.getters.getLandingPage}`)
-    const session = closeCapacitorTab(previous, tabId, landingRoute)
+    let session = closeCapacitorTab(previous, tabId, landingRoute)
+    if (wasActive) {
+      session = loadCapacitorTab(session, session.activeTabId)
+    }
     this.commitSession(session)
 
     if (wasActive) {
@@ -208,6 +231,69 @@ class CapacitorTabService {
     return true
   }
 
+  async reloadTab(tabId) {
+    const tab = this.store.getters.getTabById(tabId)
+    if (!tab) return false
+
+    if (tab.route.path.startsWith('/watch/')) {
+      const timestamp = this.store.getters.getWatchTimestamp(tabId)
+      if (typeof timestamp === 'number' && timestamp > 0) {
+        this.navigation.prepareReload(tabId, {
+          path: tab.route.path,
+          query: { ...tab.route.query, oneTimeTimestamp: Math.floor(timestamp) }
+        })
+      }
+    }
+
+    const previous = this.currentSession()
+    const session = reloadCapacitorTab(previous, tabId)
+    if (session === previous) return false
+
+    this.commitSession(session)
+    return true
+  }
+
+  loadTab(tabId) {
+    const previous = this.currentSession()
+    const session = loadCapacitorTab(previous, tabId)
+    if (session === previous) return false
+
+    this.commitSession(session)
+    return true
+  }
+
+  async unloadTab(tabId) {
+    let session = this.currentSession()
+    const tab = session.tabs.find(candidate => candidate.id === tabId)
+    if (!tab || tab.loadState === 'unloaded' || tab.loadState === 'unloading') return false
+
+    if (session.activeTabId === tabId) {
+      if (session.tabs.length <= 1) return false
+
+      const nextTabId = findReplacementTabId(session.tabs, tabId)
+      if (!nextTabId || !await this.activateTab(nextTabId)) return false
+      session = this.currentSession()
+    }
+
+    const unloaded = unloadCapacitorTab(session, tabId)
+    if (unloaded === session) return false
+
+    this.commitSession(unloaded)
+    return true
+  }
+
+  markTabMounted(tabId, mountRevision) {
+    const previous = this.currentSession()
+    const session = completeCapacitorTabMount(previous, tabId, mountRevision)
+    if (session !== previous) this.commitSession(session)
+  }
+
+  markTabMountFailed(tabId, mountRevision) {
+    const previous = this.currentSession()
+    const session = completeCapacitorTabMount(previous, tabId, mountRevision, false)
+    if (session !== previous) this.commitSession(session)
+  }
+
   currentSession() {
     return {
       tabs: this.store.getters.getTabs.map(tab => ({
@@ -216,7 +302,12 @@ class CapacitorTabService {
         isPinned: tab.isPinned === true,
         route: tab.route,
         history: tab.history,
-        historyIndex: tab.historyIndex
+        historyIndex: tab.historyIndex,
+        loadState: tab.loadState,
+        mountRevision: tab.mountRevision,
+        refreshKey: tab.refreshKey,
+        isLoading: tab.isLoading,
+        isPlaying: tab.isPlaying
       })),
       closedTabs: this.store.getters.getClosedTabs.toReversed().map(tab => ({
         id: tab.id,
@@ -232,14 +323,14 @@ class CapacitorTabService {
     }
   }
 
-  commitSession(session) {
-    this.store.commit('setTabsState', toRuntimeTabState(session))
+  commitSession(session, presentedTabId = this.store.getters.getPresentedTabId ?? session.activeTabId) {
+    this.store.commit('setTabsState', toRuntimeTabState(session, presentedTabId))
   }
 
   persist() {
     try {
       this.sessionUpdatedAt = Date.now()
-      localStorage.setItem(STORAGE_KEY, JSON.stringify(this.currentSession()))
+      localStorage.setItem(STORAGE_KEY, JSON.stringify(toPersistedSession(this.currentSession())))
     } catch (error) {
       console.error('Failed to persist Capacitor tabs:', error)
     }
@@ -249,6 +340,37 @@ class CapacitorTabService {
     this.removeRouterHook()
     this.removeStoreSubscription()
     this.initialized = false
+  }
+}
+
+function findReplacementTabId(tabs, tabId) {
+  const tabIndex = tabs.findIndex(tab => tab.id === tabId)
+  if (tabIndex === -1) return null
+
+  const candidates = [
+    ...tabs.slice(tabIndex + 1),
+    ...tabs.slice(0, tabIndex).toReversed()
+  ]
+  return candidates.find(tab => tab.loadState === 'loaded')?.id ?? candidates[0]?.id ?? null
+}
+
+function toPersistedSession(session) {
+  const serializeTab = (tab, includeLoadState) => ({
+    id: tab.id,
+    title: tab.title,
+    isPinned: tab.isPinned,
+    route: tab.route,
+    history: tab.history,
+    historyIndex: tab.historyIndex,
+    ...(includeLoadState && { isUnloaded: tab.loadState === 'unloaded' })
+  })
+
+  return {
+    tabs: session.tabs.map(tab => serializeTab(tab, true)),
+    closedTabs: session.closedTabs.map(tab => serializeTab(tab, false)),
+    activeTabId: session.activeTabId,
+    selectionRevision: session.selectionRevision,
+    updatedAt: session.updatedAt
   }
 }
 

--- a/src/renderer/tabs/CapacitorTabService.js
+++ b/src/renderer/tabs/CapacitorTabService.js
@@ -133,20 +133,27 @@ class CapacitorTabService {
   }
 
   async closeTab(tabId) {
-    const previous = this.currentSession()
+    let previous = this.currentSession()
     if (!previous.tabs.some(tab => tab.id === tabId)) return false
 
     const wasActive = previous.activeTabId === tabId
     if (wasActive) this.navigation.saveScroll(tabId)
 
+    if (wasActive && previous.tabs.length > 1) {
+      const nextTabId = findReplacementTabId(previous.tabs, tabId)
+      if (!nextTabId || !await this.activateTab(nextTabId)) return false
+      previous = this.currentSession()
+    }
+
     const landingRoute = this.router.resolve(`/${this.store.getters.getLandingPage}`)
     let session = closeCapacitorTab(previous, tabId, landingRoute)
-    if (wasActive) {
+    const needsPresentation = session.activeTabId === tabId
+    if (needsPresentation) {
       session = loadCapacitorTab(session, session.activeTabId)
     }
     this.commitSession(session)
 
-    if (wasActive) {
+    if (needsPresentation) {
       await this.navigation.requestPresentation(session.activeTabId, session.selectionRevision)
     }
     return true

--- a/src/renderer/tabs/TabContext.js
+++ b/src/renderer/tabs/TabContext.js
@@ -30,11 +30,9 @@ export function useTabTitle() {
       return
     }
 
-    const targetTabId = process.env.IS_ELECTRON
-      ? tabId
-      : process.env.IS_CAPACITOR
-        ? store.getters.getActiveTabId
-        : null
+    const targetTabId = process.env.IS_ELECTRON || process.env.IS_CAPACITOR
+      ? tabId ?? store.getters.getActiveTabId
+      : null
 
     if (targetTabId) {
       getTabNavigationService().setTitle(targetTabId, title, options)

--- a/src/renderer/tabs/capacitorTabState.js
+++ b/src/renderer/tabs/capacitorTabState.js
@@ -89,19 +89,6 @@ export function activateCapacitorTab(session, tabId) {
   }
 }
 
-export function rollbackCapacitorTabActivation(session, failedTabId, fallbackTabId, selectionRevision) {
-  if (
-    session.activeTabId !== failedTabId ||
-    session.selectionRevision !== selectionRevision ||
-    failedTabId === fallbackTabId ||
-    !session.tabs.some(tab => tab.id === fallbackTabId)
-  ) {
-    return session
-  }
-
-  return activateCapacitorTab(loadCapacitorTab(session, fallbackTabId), fallbackTabId)
-}
-
 export function loadCapacitorTab(session, tabId) {
   return updateCapacitorTabRuntime(session, tabId, tab => {
     if (tab.loadState !== 'unloaded') return tab
@@ -265,7 +252,7 @@ export function toRuntimeTabState(session, presentedTabId = session.activeTabId)
       preloadInBackground: tab.loadState === 'mounting' && tab.id !== session.activeTabId
     })),
     groups: [],
-    closedTabs: (session.closedTabs ?? []).toReversed().map(tab => ({
+    closedTabs: (session.closedTabs ?? []).slice().reverse().map(tab => ({
       ...tab,
       route: cloneRoute(tab.route),
       history: tab.history.map(entry => ({

--- a/src/renderer/tabs/capacitorTabState.js
+++ b/src/renderer/tabs/capacitorTabState.js
@@ -10,6 +10,10 @@ export function createCapacitorTab(route, title = '', id = window.crypto.randomU
     id,
     title: resolvedTitle,
     isPinned: false,
+    loadState: 'mounting',
+    mountRevision: 1,
+    refreshKey: 0,
+    isLoading: true,
     route: normalizedRoute,
     history: [{
       route: cloneRoute(normalizedRoute),
@@ -85,14 +89,81 @@ export function activateCapacitorTab(session, tabId) {
   }
 }
 
+export function rollbackCapacitorTabActivation(session, failedTabId, fallbackTabId, selectionRevision) {
+  if (
+    session.activeTabId !== failedTabId ||
+    session.selectionRevision !== selectionRevision ||
+    failedTabId === fallbackTabId ||
+    !session.tabs.some(tab => tab.id === fallbackTabId)
+  ) {
+    return session
+  }
+
+  return activateCapacitorTab(loadCapacitorTab(session, fallbackTabId), fallbackTabId)
+}
+
+export function loadCapacitorTab(session, tabId) {
+  return updateCapacitorTabRuntime(session, tabId, tab => {
+    if (tab.loadState !== 'unloaded') return tab
+
+    return {
+      ...tab,
+      loadState: 'mounting',
+      mountRevision: tab.mountRevision + 1,
+      isLoading: true,
+      isPlaying: false
+    }
+  })
+}
+
+export function unloadCapacitorTab(session, tabId) {
+  return updateCapacitorTabRuntime(session, tabId, tab => {
+    if (tab.loadState === 'unloaded' || tab.loadState === 'unloading') return tab
+
+    return {
+      ...tab,
+      loadState: 'unloaded',
+      isLoading: false,
+      isPlaying: false,
+      refreshKey: tab.refreshKey + 1
+    }
+  })
+}
+
+export function reloadCapacitorTab(session, tabId) {
+  return updateCapacitorTabRuntime(session, tabId, tab => ({
+    ...tab,
+    loadState: 'mounting',
+    mountRevision: tab.mountRevision + 1,
+    refreshKey: tab.refreshKey + 1,
+    isLoading: true,
+    isPlaying: false
+  }))
+}
+
+export function completeCapacitorTabMount(session, tabId, mountRevision, succeeded = true) {
+  return updateCapacitorTabRuntime(session, tabId, tab => {
+    if (tab.mountRevision !== mountRevision || tab.loadState !== 'mounting') return tab
+
+    return {
+      ...tab,
+      loadState: succeeded ? 'loaded' : 'unloaded',
+      isLoading: false
+    }
+  })
+}
+
 export function closeCapacitorTab(session, tabId, fallbackRoute) {
   const closedIndex = session.tabs.findIndex(tab => tab.id === tabId)
   if (closedIndex === -1) return session
 
   if (session.tabs.length === 1) {
+    const tab = createCapacitorTab(fallbackRoute, '', tabId)
+    tab.mountRevision = session.tabs[0].mountRevision + 1
+    tab.refreshKey = session.tabs[0].refreshKey + 1
     return {
       ...session,
-      tabs: [createCapacitorTab(fallbackRoute, '', tabId)],
+      tabs: [tab],
       activeTabId: tabId,
       selectionRevision: session.selectionRevision + 1
     }
@@ -120,7 +191,13 @@ export function restoreClosedCapacitorTab(session, createId = () => window.crypt
   if (!Array.isArray(session.closedTabs) || session.closedTabs.length === 0) return session
 
   const closedTab = session.closedTabs.at(-1)
-  const tab = normalizePersistedTab({ ...closedTab, id: createId() })
+  const tab = normalizePersistedTab({
+    ...closedTab,
+    id: createId(),
+    loadState: 'mounting',
+    mountRevision: 1,
+    refreshKey: 0
+  })
   const tabs = tab.isPinned
     ? [
         ...session.tabs.filter(candidate => candidate.isPinned),
@@ -174,16 +251,18 @@ export function moveCapacitorTab(session, tabId, targetIndex) {
   return { ...session, tabs }
 }
 
-export function toRuntimeTabState(session) {
+export function toRuntimeTabState(session, presentedTabId = session.activeTabId) {
   return {
     tabs: session.tabs.map(tab => ({
       ...tab,
       syncedNavigationRevision: session.selectionRevision,
       isActive: tab.id === session.activeTabId,
-      isLoading: false,
-      isPlaying: false,
+      isActivatable: tab.loadState !== 'unloading',
+      isUnloaded: tab.loadState === 'unloaded',
+      isLoading: tab.isLoading === true || tab.loadState === 'mounting',
+      isPlaying: tab.isPlaying === true,
       isPinned: tab.isPinned,
-      loadState: 'loaded'
+      preloadInBackground: tab.loadState === 'mounting' && tab.id !== session.activeTabId
     })),
     groups: [],
     closedTabs: (session.closedTabs ?? []).toReversed().map(tab => ({
@@ -196,7 +275,7 @@ export function toRuntimeTabState(session) {
       }))
     })),
     activeTabId: session.activeTabId,
-    presentedTabId: session.activeTabId,
+    presentedTabId,
     selectionRevision: session.selectionRevision,
     tabBarScrollPosition: 0
   }
@@ -234,7 +313,43 @@ function normalizePersistedTab(tab) {
   history[historyIndex].route = cloneRoute(route)
   history[historyIndex].title = title
 
-  return { id: tab.id, title, isPinned: tab.isPinned === true, route, history, historyIndex }
+  return {
+    id: tab.id,
+    title,
+    isPinned: tab.isPinned === true,
+    route,
+    history,
+    historyIndex,
+    loadState: normalizeLoadState(tab),
+    mountRevision: Number.isInteger(tab.mountRevision) && tab.mountRevision >= 0
+      ? tab.mountRevision
+      : 0,
+    refreshKey: Number.isInteger(tab.refreshKey) && tab.refreshKey >= 0
+      ? tab.refreshKey
+      : 0,
+    isLoading: tab.isLoading === true,
+    isPlaying: tab.isPlaying === true
+  }
+}
+
+function normalizeLoadState(tab) {
+  if (['loaded', 'mounting', 'unloading', 'unloaded'].includes(tab.loadState)) {
+    return tab.loadState
+  }
+  return tab.isUnloaded === true ? 'unloaded' : 'loaded'
+}
+
+function updateCapacitorTabRuntime(session, tabId, update) {
+  const tabIndex = session.tabs.findIndex(tab => tab.id === tabId)
+  if (tabIndex === -1) return session
+
+  const tab = session.tabs[tabIndex]
+  const updatedTab = update(tab)
+  if (updatedTab === tab) return session
+
+  const tabs = [...session.tabs]
+  tabs[tabIndex] = updatedTab
+  return { ...session, tabs }
 }
 
 function normalizeRoute(route) {

--- a/src/renderer/tabs/capacitorTabState.js
+++ b/src/renderer/tabs/capacitorTabState.js
@@ -33,7 +33,7 @@ export function restoreCapacitorTabSession(value, currentRoute, createId = () =>
           seenIds.add(tab.id)
           return true
         })
-        .map(normalizePersistedTab)
+        .map(normalizeRestoredTab)
     : []
 
   const closedTabIds = new Set()
@@ -329,6 +329,19 @@ function normalizePersistedTab(tab) {
       : 0,
     isLoading: tab.isLoading === true,
     isPlaying: tab.isPlaying === true
+  }
+}
+
+function normalizeRestoredTab(tab) {
+  const normalized = normalizePersistedTab(tab)
+  if (normalized.loadState === 'unloaded') return normalized
+
+  return {
+    ...normalized,
+    loadState: 'mounting',
+    mountRevision: 1,
+    isLoading: true,
+    isPlaying: false
   }
 }
 

--- a/src/renderer/views/Subscriptions/Subscriptions.vue
+++ b/src/renderer/views/Subscriptions/Subscriptions.vue
@@ -374,6 +374,7 @@ import {
 import { getSubscriptionsForFeed } from '../../helpers/subscription-channels'
 
 const isElectron = process.env.IS_ELECTRON
+const usesLogicalTabs = process.env.IS_ELECTRON || process.env.IS_CAPACITOR
 
 /** @type {import('vue').ComputedRef<boolean>} */
 const hasHorizontalTabBar = computed(() => isElectron && store.getters.getTabBarPosition === 'top')
@@ -533,7 +534,7 @@ async function resetScrollAfterRefresh(refreshedTab) {
     return
   }
 
-  if (isElectron && tabId) {
+  if (usesLogicalTabs && tabId) {
     getTabNavigationService().resetScroll(tabId)
   } else {
     window.scrollTo({ left: 0, top: 0, behavior: 'instant' })
@@ -549,7 +550,7 @@ async function resetScrollAfterRefresh(refreshedTab) {
   if (
     isMounted &&
     (currentTab.value === refreshedTab || currentTab.value === 'new') &&
-    (!isElectron || isTabPresented?.value === true)
+    (!usesLogicalTabs || isTabPresented?.value === true)
   ) {
     window.scrollTo({ left: 0, top: 0, behavior: 'instant' })
   }
@@ -594,7 +595,7 @@ watch(currentTab, async (value) => {
     return
   }
 
-  if (isElectron && isTabPresented?.value !== true) {
+  if (usesLogicalTabs && isTabPresented?.value !== true) {
     // The shared window scroll still belongs to the presented logical tab.
     // Restore this feed only after tab activation restores its page-level scroll.
     scrollPositionOwnerTab = null
@@ -612,7 +613,7 @@ watch(currentTab, async (value) => {
   if (
     value !== currentTab.value ||
     !isMounted ||
-    (isElectron && isTabPresented?.value !== true)
+    (usesLogicalTabs && isTabPresented?.value !== true)
   ) {
     return
   }
@@ -734,7 +735,7 @@ function changeTab(tab) {
   if (
     !isMounted ||
     target === null ||
-    (isElectron && isTabPresented?.value !== true)
+    (usesLogicalTabs && isTabPresented?.value !== true)
   ) {
     currentTab.value = target
     return
@@ -837,12 +838,12 @@ async function resetNewFeedScroll() {
 
   if (
     currentTab.value !== 'new' ||
-    (isElectron && isTabPresented?.value !== true)
+    (usesLogicalTabs && isTabPresented?.value !== true)
   ) {
     return
   }
 
-  if (isElectron && tabId) {
+  if (usesLogicalTabs && tabId) {
     getTabNavigationService().resetScroll(tabId)
   } else {
     window.scrollTo({ left: 0, top: 0, behavior: 'instant' })
@@ -854,7 +855,7 @@ async function resetNewFeedScroll() {
   if (
     isMounted &&
     currentTab.value === 'new' &&
-    (!isElectron || isTabPresented?.value === true)
+    (!usesLogicalTabs || isTabPresented?.value === true)
   ) {
     window.scrollTo({ left: 0, top: 0, behavior: 'instant' })
     scrollPositionOwnerTab = 'new'

--- a/src/renderer/views/Watch/Watch.js
+++ b/src/renderer/views/Watch/Watch.js
@@ -4082,7 +4082,7 @@ export default defineComponent({
       // A background tab force-pauses its brief autoplay attempt, which would
       // otherwise save a spurious ~1 second resume point. Only persist progress
       // for tabs the user has actually presented.
-      if (!this.hasBeenPresented) { return }
+      if (!this.isCurrentlyPresented() || !this.hasBeenPresented) { return }
       if (!this.$refs.player?.hasLoaded) { return }
 
       const currentTime = this.shortsPlaybackCompleted && this.watchedProgressSavingEnabled
@@ -4481,6 +4481,9 @@ export default defineComponent({
     },
 
     handlePlayerEnded: function (sleepTimerEnded = false) {
+      if (!this.isCurrentlyPresented()) {
+        return
+      }
       this.markAsWatchedIfFinished(this.videoLengthSeconds, true)
 
       if (sleepTimerEnded) {
@@ -4496,10 +4499,10 @@ export default defineComponent({
     },
 
     handleVideoEnded: function () {
-      this.handleWatchProgressAutoSaveWhenProgressEnabled()
-      if (this.isTabPresented === false) {
+      if (!this.isCurrentlyPresented()) {
         return
       }
+      this.handleWatchProgressAutoSaveWhenProgressEnabled()
       // Standalone YouTube-style Shorts stop for the replay control instead of
       // advancing. Playlist Shorts still follow the playlist autoplay setting.
       if (this.customShortsPlayerActive && this.isStandaloneShort) {

--- a/src/renderer/views/Watch/Watch.js
+++ b/src/renderer/views/Watch/Watch.js
@@ -1780,7 +1780,7 @@ export default defineComponent({
     },
 
     activateWatchRuntime() {
-      if (process.env.IS_ELECTRON && !this.isTabPresented) {
+      if (this.isTabPresented === false) {
         return
       }
 
@@ -4082,7 +4082,7 @@ export default defineComponent({
       // A background tab force-pauses its brief autoplay attempt, which would
       // otherwise save a spurious ~1 second resume point. Only persist progress
       // for tabs the user has actually presented.
-      if (process.env.IS_ELECTRON && !this.hasBeenPresented) { return }
+      if (!this.hasBeenPresented) { return }
       if (!this.$refs.player?.hasLoaded) { return }
 
       const currentTime = this.shortsPlaybackCompleted && this.watchedProgressSavingEnabled
@@ -4497,7 +4497,7 @@ export default defineComponent({
 
     handleVideoEnded: function () {
       this.handleWatchProgressAutoSaveWhenProgressEnabled()
-      if (process.env.IS_ELECTRON && !this.isTabPresented) {
+      if (this.isTabPresented === false) {
         return
       }
       // Standalone YouTube-style Shorts stop for the replay control instead of

--- a/tests/unit/auto-picture-in-picture.test.mjs
+++ b/tests/unit/auto-picture-in-picture.test.mjs
@@ -8,6 +8,7 @@ import {
   createAutoPictureInPictureState,
   canEnableAndroidAutoPictureInPicture,
   markPictureInPictureRequested,
+  resolveAndroidAutoPictureInPictureUpdate,
   resolveAutoPictureInPictureAction,
   shouldAutoPictureInPicture
 } from '../../src/renderer/components/ft-shaka-video-player/opentubex/autoPictureInPictureState.js'
@@ -19,6 +20,19 @@ test('Android auto PiP is enabled only while a video is actively playing', () =>
   assert.equal(canEnableAndroidAutoPictureInPicture(false, 'video', { paused: false, ended: false }), false)
   assert.equal(canEnableAndroidAutoPictureInPicture(true, 'audio', { paused: false, ended: false }), false)
   assert.equal(canEnableAndroidAutoPictureInPicture(true, 'video', { paused: false, ended: false }), true)
+})
+
+test('background Android players cannot update the global auto PiP state', () => {
+  const playingVideo = { paused: false, ended: false }
+
+  assert.equal(
+    resolveAndroidAutoPictureInPictureUpdate(false, true, 'video', playingVideo),
+    null
+  )
+  assert.equal(
+    resolveAndroidAutoPictureInPictureUpdate(true, true, 'video', playingVideo),
+    true
+  )
 })
 
 const ALL_TRIGGERS = {
@@ -33,7 +47,7 @@ const ALL_TRIGGERS = {
  * Mirrors the composable: resolve an action, request the matching toggle and
  * report which toggles the player would have been asked to perform.
  */
-function createPlayer(state, options = ALL_TRIGGERS) {
+function createPlayer (state, options = ALL_TRIGGERS) {
   const toggles = []
   let inPip = false
 

--- a/tests/unit/capacitor-tab-service.test.mjs
+++ b/tests/unit/capacitor-tab-service.test.mjs
@@ -1,0 +1,209 @@
+import assert from 'node:assert/strict'
+import { webcrypto } from 'node:crypto'
+import test from 'node:test'
+
+import { CapacitorTabService } from '../../src/renderer/tabs/CapacitorTabService.js'
+import {
+  activateCapacitorTab,
+  addCapacitorTab,
+  closeCapacitorTab,
+  completeCapacitorTabMount,
+  createCapacitorTab,
+  restoreCapacitorTabSession,
+  toRuntimeTabState,
+  unloadCapacitorTab
+} from '../../src/renderer/tabs/capacitorTabState.js'
+
+globalThis.window = {
+  crypto: webcrypto,
+  location: { origin: 'https://localhost' }
+}
+globalThis.localStorage = { setItem () {} }
+
+const HOME_ROUTE = { path: '/home', fullPath: '/home', query: {} }
+const WATCH_ROUTE = { path: '/watch/video', fullPath: '/watch/video', query: {} }
+
+function createStore (session, presentedTabId = session.activeTabId) {
+  let runtime = toRuntimeTabState(session, presentedTabId)
+  const getters = {
+    getLandingPage: 'home',
+    getTabById: tabId => runtime.tabs.find(tab => tab.id === tabId),
+    getWatchTimestamp: () => 0
+  }
+  Object.defineProperties(getters, {
+    getTabs: { get: () => runtime.tabs },
+    getClosedTabs: { get: () => runtime.closedTabs },
+    getActiveTabId: { get: () => runtime.activeTabId },
+    getActiveTab: { get: () => runtime.tabs.find(tab => tab.id === runtime.activeTabId) },
+    getPresentedTabId: { get: () => runtime.presentedTabId }
+  })
+
+  const state = { tabs: {} }
+  Object.defineProperty(state.tabs, 'selectionRevision', {
+    get: () => runtime.selectionRevision
+  })
+
+  return {
+    get runtime () { return runtime },
+    getters,
+    state,
+    commit (type, payload) {
+      if (type === 'setTabsState') runtime = payload
+      else if (type === 'setPresentedTab') runtime.presentedTabId = payload
+      else throw new Error(`Unexpected mutation: ${type}`)
+    }
+  }
+}
+
+function createRouter () {
+  return {
+    currentRoute: { value: HOME_ROUTE },
+    resolve (location) {
+      if (typeof location === 'string') {
+        return { path: location, fullPath: location, query: {} }
+      }
+      return {
+        ...location,
+        fullPath: location.fullPath || location.path,
+        query: location.query || {}
+      }
+    }
+  }
+}
+
+function createNavigation (store, presented = false) {
+  return {
+    projectTitle () {},
+    requestPresentation: async tabId => {
+      if (presented) store.commit('setPresentedTab', tabId)
+      return presented
+    },
+    saveScroll () {}
+  }
+}
+
+function createLoadedSession () {
+  let session = restoreCapacitorTabSession(null, HOME_ROUTE, () => 'tab-a')
+  session = completeCapacitorTabMount(session, 'tab-a', 1)
+  return session
+}
+
+test('does not close or unload the presented tab while another tab is mounting', async () => {
+  for (const action of ['closeTab', 'unloadTab']) {
+    let session = createLoadedSession()
+    session = addCapacitorTab(session, createCapacitorTab(WATCH_ROUTE, 'Video', 'tab-b'))
+    const store = createStore(session, 'tab-a')
+    const service = new CapacitorTabService(createRouter(), store, createNavigation(store))
+
+    assert.equal(await service[action]('tab-a'), false)
+    assert.equal(store.getters.getTabById('tab-a').loadState, 'loaded')
+    assert.equal(store.getters.getPresentedTabId, 'tab-a')
+  }
+})
+
+test('rolls back failed activation without discarding the target tab', async () => {
+  let session = createLoadedSession()
+  session = addCapacitorTab(session, createCapacitorTab(WATCH_ROUTE, 'Video', 'tab-b'))
+  session = completeCapacitorTabMount(session, 'tab-b', 1)
+  session = activateCapacitorTab(session, 'tab-a')
+  session = unloadCapacitorTab(session, 'tab-b')
+  const store = createStore(session)
+  const service = new CapacitorTabService(createRouter(), store, createNavigation(store))
+
+  assert.equal(await service.activateTab('tab-b'), false)
+  assert.deepEqual(store.getters.getTabs.map(tab => tab.id), ['tab-a', 'tab-b'])
+  assert.equal(store.getters.getTabById('tab-b').loadState, 'unloaded')
+  assert.equal(store.getters.getActiveTabId, 'tab-a')
+  assert.equal(store.getters.getPresentedTabId, 'tab-a')
+})
+
+test('does not roll back over a newer tab selection', async () => {
+  let session = createLoadedSession()
+  session = addCapacitorTab(session, createCapacitorTab(WATCH_ROUTE, 'Video', 'tab-b'))
+  session = activateCapacitorTab(session, 'tab-a')
+  const previousRevision = session.selectionRevision
+  const store = createStore(session)
+  const navigation = createNavigation(store)
+  navigation.requestPresentation = async () => {
+    const newer = activateCapacitorTab(service.currentSession(), 'tab-a')
+    store.commit('setTabsState', toRuntimeTabState(newer, 'tab-a'))
+    return false
+  }
+  const service = new CapacitorTabService(createRouter(), store, navigation)
+
+  assert.equal(await service.activateTab('tab-b'), false)
+  assert.equal(store.getters.getActiveTabId, 'tab-a')
+  assert.equal(store.runtime.selectionRevision, previousRevision + 2)
+  assert.deepEqual(store.getters.getTabs.map(tab => tab.id), ['tab-a', 'tab-b'])
+})
+
+test('rolls back newly created tabs when presentation fails', async () => {
+  const store = createStore(createLoadedSession())
+  const service = new CapacitorTabService(createRouter(), store, createNavigation(store))
+  const previousRevision = store.runtime.selectionRevision
+
+  assert.equal(await service.createTab(WATCH_ROUTE), null)
+  assert.deepEqual(store.getters.getTabs.map(tab => tab.id), ['tab-a'])
+  assert.equal(store.getters.getActiveTabId, 'tab-a')
+  assert.equal(store.getters.getPresentedTabId, 'tab-a')
+  assert.equal(store.runtime.selectionRevision, previousRevision + 2)
+})
+
+test('rolls back duplicated and restored tabs when presentation fails', async () => {
+  for (const action of ['duplicateTab', 'restoreClosedTab']) {
+    let session = createLoadedSession()
+    if (action === 'restoreClosedTab') {
+      session = addCapacitorTab(session, createCapacitorTab(WATCH_ROUTE, 'Video', 'tab-b'))
+      session = closeCapacitorTab(session, 'tab-b', HOME_ROUTE)
+    }
+    const store = createStore(session)
+    const service = new CapacitorTabService(createRouter(), store, createNavigation(store))
+
+    const result = action === 'duplicateTab'
+      ? await service.duplicateTab('tab-a')
+      : await service.restoreClosedTab()
+
+    assert.equal(result, null)
+    assert.deepEqual(store.getters.getTabs.map(tab => tab.id), ['tab-a'])
+    assert.equal(store.getters.getActiveTabId, 'tab-a')
+    assert.equal(store.getters.getPresentedTabId, 'tab-a')
+  }
+})
+
+test('restores the previous session when synced-tab presentation fails', async () => {
+  const store = createStore(createLoadedSession())
+  const service = new CapacitorTabService(createRouter(), store, createNavigation(store))
+
+  const applied = await service.applySyncSessions([{
+    activeTabId: 'tab-synced',
+    tabs: [{
+      id: 'tab-synced',
+      title: 'Synced video',
+      url: 'https://localhost/watch/synced',
+      isPinned: false
+    }]
+  }])
+
+  assert.equal(applied, false)
+  assert.deepEqual(store.getters.getTabs.map(tab => tab.id), ['tab-a'])
+  assert.equal(store.getters.getActiveTabId, 'tab-a')
+  assert.equal(store.getters.getPresentedTabId, 'tab-a')
+})
+
+test('uses tab actions on Android WebViews without Array.toReversed', async () => {
+  let session = createLoadedSession()
+  session = addCapacitorTab(session, createCapacitorTab(WATCH_ROUTE, 'Video', 'tab-b'))
+  session = completeCapacitorTabMount(session, 'tab-b', 1)
+  session = activateCapacitorTab(session, 'tab-a')
+  const store = createStore(session)
+  const service = new CapacitorTabService(createRouter(), store, createNavigation(store, true))
+  const toReversed = Array.prototype.toReversed
+  Array.prototype.toReversed = undefined
+
+  try {
+    assert.equal(await service.closeTab('tab-a'), true)
+    assert.deepEqual(store.getters.getTabs.map(tab => tab.id), ['tab-b'])
+  } finally {
+    Array.prototype.toReversed = toReversed
+  }
+})

--- a/tests/unit/capacitor-tab-service.test.mjs
+++ b/tests/unit/capacitor-tab-service.test.mjs
@@ -137,6 +137,29 @@ test('does not roll back over a newer tab selection', async () => {
   assert.deepEqual(store.getters.getTabs.map(tab => tab.id), ['tab-a', 'tab-b'])
 })
 
+test('does not roll back over a reload while presentation is pending', async () => {
+  let session = createLoadedSession()
+  session = addCapacitorTab(session, createCapacitorTab(WATCH_ROUTE, 'Video', 'tab-b'))
+  session = completeCapacitorTabMount(session, 'tab-b', 1)
+  session = activateCapacitorTab(session, 'tab-a')
+  const store = createStore(session)
+  let finishPresentation
+  const navigation = createNavigation(store)
+  navigation.requestPresentation = () => new Promise(resolve => {
+    finishPresentation = resolve
+  })
+  const service = new CapacitorTabService(createRouter(), store, navigation)
+
+  const activation = service.activateTab('tab-b')
+  assert.equal(await service.reloadTab('tab-b'), true)
+  finishPresentation(false)
+
+  assert.equal(await activation, false)
+  assert.equal(store.getters.getActiveTabId, 'tab-b')
+  assert.equal(store.getters.getTabById('tab-b').refreshKey, 1)
+  assert.equal(store.getters.getTabById('tab-b').mountRevision, 2)
+})
+
 test('rolls back newly created tabs when presentation fails', async () => {
   const store = createStore(createLoadedSession())
   const service = new CapacitorTabService(createRouter(), store, createNavigation(store))

--- a/tests/unit/capacitor-tab-state.test.mjs
+++ b/tests/unit/capacitor-tab-state.test.mjs
@@ -161,6 +161,10 @@ test('reloads a Capacitor tab with a fresh mount and refresh key', () => {
   let session = restoreCapacitorTabSession(null, HOME_ROUTE, () => 'tab-1')
   session = completeCapacitorTabMount(session, 'tab-1', 1)
   session.tabs[0].isPlaying = true
+  session.tabs[0].pendingReloadRoute = {
+    path: '/watch/video',
+    fullPath: '/watch/video?oneTimeTimestamp=42'
+  }
 
   session = reloadCapacitorTab(session, 'tab-1')
 
@@ -169,6 +173,10 @@ test('reloads a Capacitor tab with a fresh mount and refresh key', () => {
   assert.equal(session.tabs[0].refreshKey, 1)
   assert.equal(session.tabs[0].isLoading, true)
   assert.equal(session.tabs[0].isPlaying, false)
+  assert.equal(
+    toRuntimeTabState(session).tabs[0].pendingReloadRoute.fullPath,
+    '/watch/video?oneTimeTimestamp=42'
+  )
 })
 
 test('restores unloaded Capacitor tabs from persisted sessions', () => {

--- a/tests/unit/capacitor-tab-state.test.mjs
+++ b/tests/unit/capacitor-tab-state.test.mjs
@@ -10,7 +10,6 @@ import {
   loadCapacitorTab,
   moveCapacitorTab,
   reloadCapacitorTab,
-  rollbackCapacitorTabActivation,
   restoreClosedCapacitorTab,
   restoreCapacitorTabSession,
   setCapacitorTabPinned,
@@ -223,29 +222,6 @@ test('keeps the previously presented Capacitor tab during activation', () => {
   assert.equal(state.presentedTabId, 'tab-1')
 })
 
-test('rolls back a failed Capacitor tab activation without overriding newer selections', () => {
-  let session = restoreCapacitorTabSession(null, HOME_ROUTE, () => 'tab-1')
-  session = completeCapacitorTabMount(session, 'tab-1', 1)
-  session = addCapacitorTab(session, createCapacitorTab(WATCH_ROUTE, 'Video', 'tab-2'))
-  const failedRevision = session.selectionRevision
-  session = completeCapacitorTabMount(session, 'tab-2', 1, false)
-
-  const rolledBack = rollbackCapacitorTabActivation(
-    session,
-    'tab-2',
-    'tab-1',
-    failedRevision
-  )
-  assert.equal(rolledBack.activeTabId, 'tab-1')
-  assert.equal(rolledBack.selectionRevision, failedRevision + 1)
-
-  const newerSelection = activateCapacitorTab(rolledBack, 'tab-2')
-  assert.equal(
-    rollbackCapacitorTabActivation(newerSelection, 'tab-2', 'tab-1', failedRevision),
-    newerSelection
-  )
-})
-
 test('pins Capacitor tabs first and only reorders within their pin group', () => {
   let session = restoreCapacitorTabSession(null, HOME_ROUTE, () => 'tab-1')
   session = addCapacitorTab(session, createCapacitorTab(WATCH_ROUTE, 'Video', 'tab-2'))
@@ -340,6 +316,21 @@ test('persists at most ten closed Capacitor tabs and exposes newest first at run
   const restored = restoreCapacitorTabSession(session, HOME_ROUTE)
   assert.deepEqual(restored.closedTabs.map(tab => tab.title), session.closedTabs.map(tab => tab.title))
   assert.equal(toRuntimeTabState(restored).closedTabs[0].title, 'Video 11')
+})
+
+test('converts a Capacitor session on Android WebViews without Array.toReversed', () => {
+  const toReversed = Array.prototype.toReversed
+  Array.prototype.toReversed = undefined
+
+  try {
+    let session = restoreCapacitorTabSession(null, HOME_ROUTE, () => 'tab-home')
+    session = addCapacitorTab(session, createCapacitorTab(WATCH_ROUTE, 'Video', 'tab-video'))
+    session = closeCapacitorTab(session, 'tab-video', HOME_ROUTE)
+
+    assert.equal(toRuntimeTabState(session).closedTabs[0].title, 'Video')
+  } finally {
+    Array.prototype.toReversed = toReversed
+  }
 })
 
 test('does not retain the synthetic landing tab created when the final tab closes', () => {

--- a/tests/unit/capacitor-tab-state.test.mjs
+++ b/tests/unit/capacitor-tab-state.test.mjs
@@ -5,12 +5,17 @@ import {
   activateCapacitorTab,
   addCapacitorTab,
   closeCapacitorTab,
+  completeCapacitorTabMount,
   createCapacitorTab,
+  loadCapacitorTab,
   moveCapacitorTab,
+  reloadCapacitorTab,
+  rollbackCapacitorTabActivation,
   restoreClosedCapacitorTab,
   restoreCapacitorTabSession,
   setCapacitorTabPinned,
-  toRuntimeTabState
+  toRuntimeTabState,
+  unloadCapacitorTab
 } from '../../src/renderer/tabs/capacitorTabState.js'
 
 const HOME_ROUTE = { path: '/home', fullPath: '/home' }
@@ -106,8 +111,111 @@ test('maps the active Capacitor tab into the existing runtime tab shape', () => 
   assert.equal(state.presentedTabId, 'tab-2')
   assert.equal(state.tabs[0].isActive, false)
   assert.equal(state.tabs[1].isActive, true)
-  assert.equal(state.tabs[1].loadState, 'loaded')
+  assert.equal(state.tabs[1].loadState, 'mounting')
+  assert.equal(state.tabs[1].isLoading, true)
   assert.equal(state.tabs[1].syncedNavigationRevision, session.selectionRevision)
+})
+
+test('loads, unloads, and completes Capacitor tab mounts', () => {
+  let session = restoreCapacitorTabSession(null, HOME_ROUTE, () => 'tab-1')
+  session = completeCapacitorTabMount(session, 'tab-1', 1)
+  const loadedTab = session.tabs[0]
+
+  assert.equal(loadedTab.loadState, 'loaded')
+  assert.equal(loadedTab.isLoading, false)
+
+  loadedTab.isLoading = true
+  loadedTab.isPlaying = true
+  session = unloadCapacitorTab(session, 'tab-1')
+
+  assert.equal(session.tabs[0].loadState, 'unloaded')
+  assert.equal(session.tabs[0].isLoading, false)
+  assert.equal(session.tabs[0].isPlaying, false)
+  assert.equal(session.tabs[0].refreshKey, 1)
+
+  session = loadCapacitorTab(session, 'tab-1')
+
+  assert.equal(session.tabs[0].loadState, 'mounting')
+  assert.equal(session.tabs[0].mountRevision, 2)
+  assert.equal(session.tabs[0].isLoading, true)
+
+  session = completeCapacitorTabMount(session, 'tab-1', 2)
+  assert.equal(session.tabs[0].loadState, 'loaded')
+  assert.equal(session.tabs[0].isLoading, false)
+})
+
+test('ignores stale mount completions and unloads a tab when mounting fails', () => {
+  let session = restoreCapacitorTabSession(null, HOME_ROUTE, () => 'tab-1')
+  session = reloadCapacitorTab(session, 'tab-1')
+
+  const staleCompletion = completeCapacitorTabMount(session, 'tab-1', 1)
+  assert.equal(staleCompletion, session)
+  assert.equal(staleCompletion.tabs[0].loadState, 'mounting')
+
+  session = completeCapacitorTabMount(session, 'tab-1', 2, false)
+  assert.equal(session.tabs[0].loadState, 'unloaded')
+  assert.equal(session.tabs[0].isLoading, false)
+})
+
+test('reloads a Capacitor tab with a fresh mount and refresh key', () => {
+  let session = restoreCapacitorTabSession(null, HOME_ROUTE, () => 'tab-1')
+  session = completeCapacitorTabMount(session, 'tab-1', 1)
+  session.tabs[0].isPlaying = true
+
+  session = reloadCapacitorTab(session, 'tab-1')
+
+  assert.equal(session.tabs[0].loadState, 'mounting')
+  assert.equal(session.tabs[0].mountRevision, 2)
+  assert.equal(session.tabs[0].refreshKey, 1)
+  assert.equal(session.tabs[0].isLoading, true)
+  assert.equal(session.tabs[0].isPlaying, false)
+})
+
+test('restores unloaded Capacitor tabs from persisted sessions', () => {
+  const unloadedTab = createCapacitorTab(WATCH_ROUTE, 'Video', 'tab-1')
+  unloadedTab.isUnloaded = true
+  delete unloadedTab.loadState
+
+  const session = restoreCapacitorTabSession({
+    activeTabId: 'tab-1',
+    tabs: [unloadedTab]
+  }, HOME_ROUTE)
+
+  assert.equal(session.tabs[0].loadState, 'unloaded')
+  assert.equal(toRuntimeTabState(session).tabs[0].isUnloaded, true)
+})
+
+test('keeps the previously presented Capacitor tab during activation', () => {
+  let session = restoreCapacitorTabSession(null, HOME_ROUTE, () => 'tab-1')
+  session = addCapacitorTab(session, createCapacitorTab(WATCH_ROUTE, 'Video', 'tab-2'))
+
+  const state = toRuntimeTabState(session, 'tab-1')
+
+  assert.equal(state.activeTabId, 'tab-2')
+  assert.equal(state.presentedTabId, 'tab-1')
+})
+
+test('rolls back a failed Capacitor tab activation without overriding newer selections', () => {
+  let session = restoreCapacitorTabSession(null, HOME_ROUTE, () => 'tab-1')
+  session = completeCapacitorTabMount(session, 'tab-1', 1)
+  session = addCapacitorTab(session, createCapacitorTab(WATCH_ROUTE, 'Video', 'tab-2'))
+  const failedRevision = session.selectionRevision
+  session = completeCapacitorTabMount(session, 'tab-2', 1, false)
+
+  const rolledBack = rollbackCapacitorTabActivation(
+    session,
+    'tab-2',
+    'tab-1',
+    failedRevision
+  )
+  assert.equal(rolledBack.activeTabId, 'tab-1')
+  assert.equal(rolledBack.selectionRevision, failedRevision + 1)
+
+  const newerSelection = activateCapacitorTab(rolledBack, 'tab-2')
+  assert.equal(
+    rollbackCapacitorTabActivation(newerSelection, 'tab-2', 'tab-1', failedRevision),
+    newerSelection
+  )
 })
 
 test('pins Capacitor tabs first and only reorders within their pin group', () => {

--- a/tests/unit/capacitor-tab-state.test.mjs
+++ b/tests/unit/capacitor-tab-state.test.mjs
@@ -44,6 +44,26 @@ test('restores valid tabs and ignores malformed persisted entries', () => {
   assert.deepEqual(session.tabs.map(tab => tab.id), ['tab-1', 'tab-2'])
   assert.equal(session.activeTabId, 'tab-2')
   assert.equal(session.selectionRevision, 4)
+  assert.equal(session.tabs[0].loadState, 'mounting')
+  assert.equal(session.tabs[0].mountRevision, 1)
+  assert.equal(session.tabs[0].isLoading, true)
+})
+
+test('restored Capacitor tabs can report a fresh mount failure', () => {
+  const persistedTab = createCapacitorTab(WATCH_ROUTE, 'Video', 'tab-1')
+  delete persistedTab.loadState
+  delete persistedTab.mountRevision
+  delete persistedTab.isLoading
+
+  let session = restoreCapacitorTabSession({
+    activeTabId: 'tab-1',
+    tabs: [persistedTab]
+  }, HOME_ROUTE)
+
+  assert.equal(session.tabs[0].loadState, 'mounting')
+  assert.equal(session.tabs[0].mountRevision, 1)
+  session = completeCapacitorTabMount(session, 'tab-1', 1, false)
+  assert.equal(session.tabs[0].loadState, 'unloaded')
 })
 
 test('retains complete Capacitor sessions with more than twenty tabs', () => {

--- a/tests/unit/mobile-link-actions.test.mjs
+++ b/tests/unit/mobile-link-actions.test.mjs
@@ -40,6 +40,25 @@ test('the mobile copy-link action uses the distinct copy icon', async () => {
   assert.match(app, /@click="copyMobileContextLink"[\s\S]*?<FtIcon :icon="\['fas', 'copy'\]"/)
 })
 
+test('mobile tab actions expose copy, reload, load, and unload controls', async () => {
+  const menu = await readFile(
+    path.join(process.cwd(), 'src/renderer/components/TabBar/CapacitorTabActionsMenu.vue'),
+    'utf8'
+  )
+
+  assert.match(menu, /Context Menu\.Copy YouTube Link/)
+  assert.match(menu, /Context Menu\.Reload Tab/)
+  assert.match(menu, /Context Menu\.Load Tab/)
+  assert.match(menu, /Context Menu\.Unload Tab/)
+})
+
+test('mobile renders the logical tab containers needed for load and unload', async () => {
+  const app = await readFile(path.join(process.cwd(), 'src/renderer/App.vue'), 'utf8')
+
+  assert.match(app, /<template v-if="usesLogicalTabs">\s*<TabContent/)
+  assert.match(app, /const usesLogicalTabs = isElectron \|\| isCapacitor/)
+})
+
 test('mobile external links respect the configured opening policy', () => {
   assert.equal(resolveExternalLinkAction('doNothing'), 'disabled')
   assert.equal(resolveExternalLinkAction('openLinkAfterPrompt'), 'prompt')


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Make sure to follow the contributing guidelines. -->
<!-- Important note, we may remove your pull request if you do not use this provided PR template correctly. -->
<!-- Agent instructions: Preserve every heading, comment, and marker in this template. Never remove or rewrite the release-note-category:start/end, release-note:start/end, or release-note-image:start/end marker pairs. -->

## Pull Request Type
<!-- Please select what type of pull request this is: [x] -->
- [ ] Bugfix
- [x] Feature Implementation
- [ ] Documentation
- [ ] Other

## Related issue
<!-- Please link the issue your pull request is referring to. -->
<!-- If this pull request fully resolves the relevant issue, put "closes" before the issue number. -->
<!-- Example: "closes #123456". -->

Closes #1083.

## Description
<!-- Please write a clear and concise description of what the pull request does. -->

Mobile tab menus did not expose reload or YouTube-link copying, and their load state did not control the lifetime of tab content.

This change adds Copy YouTube Link, Reload, and Load/Unload actions to the phone and tablet tab menus. Capacitor tabs now use logical-tab containers, persist unloaded state, preserve the presented tab during transitions, and roll back cleanly when a replacement tab fails to mount. Background tab playback, progress, titles, toasts, Picture-in-Picture, and subscription scrolling now follow the presented tab.

## Release note category
<!-- Select exactly one category. Every pull request must select one. -->
<!-- Select "Not noteworthy" when the pull request fixes a bug in or improves functionality that has not yet appeared in a stable release. -->
<!-- release-note-category:start -->
- [x] Not noteworthy
- [ ] Highlights
- [ ] More improvements
- [ ] Fixed bugs
<!-- release-note-category:end -->

## Release note
<!-- Required unless "Not noteworthy" is selected. -->
<!-- Write one concise, user-facing entry without a leading bullet. -->
<!-- release-note:start -->

Mobile tab menus can now copy YouTube links, reload tabs, and unload tabs to free resources.

<!-- release-note:end -->

## Release note images
<!-- Optional. Paste one or more Markdown images, HTML image tags, or dark/light <picture> elements here. -->
<!-- The release notes normalize the markup and limit images taller than 300 pixels. -->
<!-- Agent instructions:
For a noteworthy visible change, add media when it makes the change easier to understand. Prefer a still image unless motion is the point. Recordings in this section must end up as animated WebP because release notes accept images, not video attachments.
After implementing a visible change, proactively capture the result and show the local media to the user for approval before uploading it or updating the pull request.
When the affected UI differs between dark and light themes, capturing both themes is required. A dark-only image is incomplete. The final pull request body must combine the hosted URLs into a theme-aware `<picture>` with dark and light `prefers-color-scheme` sources and the dark image as its `<img>` fallback. Never leave the two theme captures as separate images. Use a single default-dark capture only when the light theme cannot be captured or looks identical.
Capture or crop to the smallest region that still makes the change clear. Do not include the full window when the affected component can be understood on its own.
Use English unless localization is the subject. Keep components at their normal dimensions and placement instead of resizing them to fill the frame.
Use deterministic local fixtures for visible remote images. Reusable avatar and thumbnail fixtures are available through `e2e/helpers/visual-fixtures.mjs`. Before capturing, verify that every visible image has loaded successfully (`complete === true` and `naturalWidth > 0`).
Inspect the final dark and light files for failed images, missing content, unrelated UI, awkward animation, and misleading layout. Omit media when it does not explain the change clearly.
Use GitHub CLI 2.99.0 or newer to upload images no larger than 10 MB. For one image, write an ordinary Markdown image reference to the local file between the marker comments. Pass the same file to `gh pr create` or `gh pr edit` with `--attach <path>` so GitHub CLI replaces the local path with its hosted URL.
GitHub CLI does not rewrite paths inside HTML attributes. For themed images within its size limit, first upload both files through temporary Markdown image references and repeat `--attach <path>` for each one. Read back the hosted URLs, replace the temporary references with the `<picture>` below, and update the pull request body without `--attach`:
<picture>
  <source media="(prefers-color-scheme: dark)" srcset="HOSTED_DARK_URL">
  <source media="(prefers-color-scheme: light)" srcset="HOSTED_LIGHT_URL">
  <img alt="DESCRIPTION" src="HOSTED_DARK_URL">
</picture>
For every MP4, MOV, or WebM recording, use `node _scripts/releaseNoteMedia.mjs FILE --alt "DESCRIPTION"` regardless of file size so the helper converts it to animated WebP. Use the same command when an image exceeds 10 MB. For a themed pair where either file needs the helper, use `node _scripts/releaseNoteMedia.mjs --dark DARK_FILE --light LIGHT_FILE --alt "DESCRIPTION"`. Paste only its generated markup between the marker comments.
Check for personal information, tokens, private repository names, and unrelated desktop content before uploading. Uploaded media is public.
Keep capture-only scripts, test hooks, screenshots, and recordings out of commits. Remove them before committing unless the capture code is also a reusable regression test. Never commit generated release-note media.
Leave this section empty when media would not help.
-->
<!-- release-note-image:start -->

<!-- release-note-image:end -->

## Testing
<!-- How can reviewers verify that the PR produces correct results? -->
<!-- Please provide instructions so that others can ensure that your pull request produces correct results. For examples see, https://github.com/FreeTubeApp/FreeTube/pull/5743, https://github.com/FreeTubeApp/FreeTube/pull/7349, https://github.com/FreeTubeApp/FreeTube/pull/5125, https://github.com/FreeTubeApp/FreeTube/pull/7338 -->
<!-- Agent instructions: Only write human-facing steps that explain how to verify the change while running this branch in dev mode. Include expected results and, when applicable, helpful console snippets for interactive verification. Do not include automated checks, commands, results, pass counts, or CI status. -->

1. In the mobile app, open two tabs, including a video, channel, playlist, hashtag, or post tab.
2. Open that tab's actions and confirm Copy YouTube Link copies the matching YouTube URL.
3. Choose Reload and confirm the tab reloads while a playing video keeps its current timestamp.
4. Unload the background tab and confirm it appears dimmed and reports its unloaded state to accessibility tools.
5. Load the tab again and confirm its content remounts.
6. Unload the active tab and confirm a neighboring tab opens first.
7. Restart the app and confirm unloaded background tabs remain unloaded until opened or loaded.

## Additional context
<!-- Add any other context about the pull request here. -->

The mobile implementation now uses the same logical-tab lifecycle model as the desktop app. No new dependencies, icons, or translation keys were added.

