### PR TITLE
fix(playlists): refresh saved metadata on open

### DIFF
--- a/e2e/tests/offline/playlist-loading.spec.mjs
+++ b/e2e/tests/offline/playlist-loading.spec.mjs
@@ -184,9 +184,18 @@ test('keeps the search result thumbnail when saving a playlist', async ({ page }
     .toHaveAttribute('src', expectedThumbnail)
 })
 
-test('refreshes a saved playlist thumbnail after opening the playlist again', async ({ app, page }) => {
+test('refreshes saved playlist metadata after opening the playlist again', async ({ app, page }) => {
   const playlistId = 'dynamic-saved-playlist'
   let firstVideoId = 'original-first-video'
+  let videoCount = 1
+  let playlistTitle = 'Dynamic saved playlist'
+  let playlistDescription = 'Original playlist description'
+  let channelName = 'Playlist channel'
+  let channelId = 'UCplaylistchannel'
+  let channelAvatar = 'https://yt3.ggpht.com/original-avatar=s76'
+  const getSavedPlaylistCard = () => page.locator('.ft-list-video:visible', {
+    has: page.locator(`a.title[href*="/playlist/${playlistId}"]`)
+  })
   let markStaleRequestStarted
   const staleRequestStarted = new Promise(resolve => { markStaleRequestStarted = resolve })
   let releaseStaleRequest
@@ -196,9 +205,13 @@ test('refreshes a saved playlist thumbnail after opening the playlist again', as
 
   await page.route(new RegExp(`/api/v1/playlists/${playlistId}\\?`), route => route.fulfill({
     json: {
-      ...playlistResponse([playlistVideo(0, firstVideoId)], 1),
-      title: 'Dynamic saved playlist',
+      ...playlistResponse([playlistVideo(0, firstVideoId)], videoCount),
+      title: playlistTitle,
+      description: playlistDescription,
       playlistId,
+      author: channelName,
+      authorId: channelId,
+      authorThumbnails: [{ url: channelAvatar }],
     },
   }))
   await page.route(/\/api\/v1\/playlists\/stale-thumbnail-source\?/, async route => {
@@ -218,22 +231,44 @@ test('refreshes a saved playlist thumbnail after opening the playlist again', as
   await page.getByTitle('Save Playlist').click()
   await goTo(page, 'userplaylists')
 
-  const savedPlaylistCard = page.getByRole('link', { name: 'Dynamic saved playlist' })
-    .locator('xpath=ancestor::div[contains(@class, "ft-list-item")]')
-  const savedPlaylistThumbnail = savedPlaylistCard.locator('img.thumbnailImage')
+  let savedPlaylistCard = getSavedPlaylistCard()
+  let savedPlaylistThumbnail = savedPlaylistCard.locator('img.thumbnailImage')
   await expect(savedPlaylistThumbnail).toHaveAttribute(
     'src',
     'https://invidious.test/vi/original-first-video/mqdefault.jpg'
   )
+  await expect(savedPlaylistCard.locator('.videoCountContainer')).toHaveText('1')
 
-  firstVideoId = 'updated-first-video'
+  videoCount = 5
+  playlistTitle = 'Updated saved playlist'
+  playlistDescription = 'Updated playlist description'
+  channelName = 'Updated playlist channel'
+  channelId = 'UCupdatedplaylistchannel'
+  channelAvatar = 'https://yt3.ggpht.com/updated-avatar=s76'
   await openPlaylistTab(page, '/playlist/stale-thumbnail-source')
   await staleRequestStarted
   await page.locator(sel.searchInput).fill(`https://www.youtube.com/playlist?list=${playlistId}`)
   await page.locator(sel.searchInput).press('Enter')
   await expect(page.getByText('Playlist video 1', { exact: true })).toBeVisible()
+  await expect(page.locator('.playlistInfo')).toContainText('5 videos')
   releaseStaleRequest()
   await staleRequestFinished
+  await goTo(page, 'userplaylists')
+
+  savedPlaylistCard = getSavedPlaylistCard()
+  savedPlaylistThumbnail = savedPlaylistCard.locator('img.thumbnailImage')
+  await expect(savedPlaylistCard.locator('.h3Title')).toHaveText(playlistTitle)
+  await expect(savedPlaylistCard.locator('.channelNameText')).toHaveText(channelName)
+  await expect(savedPlaylistCard.locator('.channelName')).toHaveAttribute('href', `#/channel/${channelId}`)
+  await expect(savedPlaylistThumbnail).toHaveAttribute(
+    'src',
+    'https://invidious.test/vi/original-first-video/mqdefault.jpg'
+  )
+  await expect(savedPlaylistCard.locator('.videoCountContainer')).toHaveText('5')
+
+  firstVideoId = 'updated-first-video'
+  await page.getByRole('link', { name: playlistTitle }).click()
+  await expect(page.getByText('Playlist video 1', { exact: true })).toBeVisible()
   await goTo(page, 'userplaylists')
 
   const updatedThumbnailUrl = 'https://invidious.test/vi/updated-first-video/mqdefault.jpg'
@@ -241,10 +276,27 @@ test('refreshes a saved playlist thumbnail after opening the playlist again', as
 
   ;({ page } = await app.relaunch())
   await goTo(page, 'userplaylists')
-  const persistedPlaylistCard = page.getByRole('link', { name: 'Dynamic saved playlist' })
-    .locator('xpath=ancestor::div[contains(@class, "ft-list-item")]')
+  const persistedPlaylistCard = getSavedPlaylistCard()
+  await expect(persistedPlaylistCard.locator('.h3Title')).toHaveText(playlistTitle)
+  await expect(persistedPlaylistCard.locator('.channelNameText')).toHaveText(channelName)
+  await expect(persistedPlaylistCard.locator('.channelName')).toHaveAttribute('href', `#/channel/${channelId}`)
   await expect(persistedPlaylistCard.locator('img.thumbnailImage'))
     .toHaveAttribute('src', updatedThumbnailUrl)
+  await expect(persistedPlaylistCard.locator('.videoCountContainer')).toHaveText('5')
+  await expect(page.evaluate(id => {
+    const store = document.querySelector('#app').__vue_app__.config.globalProperties.$store
+    return store.getters.getPlaylistBookmark(id)
+  }, playlistId)).resolves.toMatchObject({
+    playlist: {
+      title: playlistTitle,
+      description: playlistDescription,
+    },
+    uploader: {
+      id: channelId,
+      name: channelName,
+      avatar: 'https://yt3.googleusercontent.com/updated-avatar=s76',
+    },
+  })
 })
 
 test('retries the failed Invidious page and merges its overlapping videos once', async ({ page }) => {

--- a/src/renderer/views/Playlist/Playlist.vue
+++ b/src/renderer/views/Playlist/Playlist.vue
@@ -253,7 +253,11 @@ import { invidiousGetPlaylistInfo, youtubeImageUrlToInvidious } from '../../help
 import { hasMoreInvidiousPlaylistPages, mergeInvidiousPlaylistVideos } from '../../helpers/api/invidious-playlists'
 import { runRetryablePlaylistRequest } from '../../helpers/playlist-pagination'
 import { formatDate } from '../../helpers/dateFormat'
-import { canonicalPlaylistThumbnailUrl, createPlaylistBookmark } from '../../helpers/playlist-bookmarks'
+import {
+  canonicalChannelAvatarUrl,
+  canonicalPlaylistThumbnailUrl,
+  createPlaylistBookmark,
+} from '../../helpers/playlist-bookmarks'
 import { fillMissingPlaylistVideoDurations, getSortedPlaylistItems, SORT_BY_VALUES } from '../../helpers/playlists'
 import { hasConfiguredRestrictedPlaybackAuthentication } from '../../helpers/restricted-playback'
 import {
@@ -487,7 +491,7 @@ const isPlaylistBookmarked = computed(() => {
   return !isUserPlaylistRequested.value && store.getters.getPlaylistBookmark(playlistId.value) != null
 })
 
-async function refreshPlaylistBookmarkThumbnail() {
+async function refreshPlaylistBookmarkMetadata() {
   const bookmark = store.getters.getPlaylistBookmark(playlistId.value)
   if (bookmark == null) return
 
@@ -495,13 +499,33 @@ async function refreshPlaylistBookmarkThumbnail() {
     ? `https://i.ytimg.com/vi/${firstVideoId.value}/mqdefault.jpg`
     : null)
   const canonicalThumbnailUrl = canonicalPlaylistThumbnailUrl(thumbnailUrl)
-  if (bookmark.playlist.thumbnail_url === canonicalThumbnailUrl) return
+  const canonicalChannelAvatar = canonicalChannelAvatarUrl(channelThumbnail.value)
+  const refreshedChannelId = channelId.value || playlistId.value
+  const refreshedChannelName = channelName.value || playlistTitle.value
+  if (
+    bookmark.playlist.title === playlistTitle.value &&
+    bookmark.playlist.description === playlistDescription.value &&
+    bookmark.playlist.thumbnail_url === canonicalThumbnailUrl &&
+    bookmark.playlist.video_count === videoCount.value &&
+    bookmark.uploader.id === refreshedChannelId &&
+    bookmark.uploader.name === refreshedChannelName &&
+    bookmark.uploader.avatar === canonicalChannelAvatar
+  ) return
 
   await store.dispatch('savePlaylistBookmark', {
     ...bookmark,
     playlist: {
       ...bookmark.playlist,
+      title: playlistTitle.value,
+      description: playlistDescription.value,
       thumbnail_url: canonicalThumbnailUrl,
+      video_count: videoCount.value,
+    },
+    uploader: {
+      ...bookmark.uploader,
+      id: refreshedChannelId,
+      name: refreshedChannelName,
+      avatar: canonicalChannelAvatar,
     },
   })
 }
@@ -859,7 +883,7 @@ async function getPlaylistLocal() {
 
     playlistItems.value = playlistItems_
 
-    await refreshPlaylistBookmarkThumbnail()
+    await refreshPlaylistBookmarkMetadata()
     if (!requestIsCurrent()) return
 
     let shouldGetNextPage = false
@@ -922,7 +946,7 @@ async function getPlaylistInvidious() {
     updateLastUpdatedDate()
 
     playlistItems.value = result.videos
-    await refreshPlaylistBookmarkThumbnail()
+    await refreshPlaylistBookmarkMetadata()
     if (!requestIsCurrent()) return
     const hasMorePages = hasMoreInvidiousPlaylistPages(
       result.videoCount,


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Make sure to follow the contributing guidelines. -->
<!-- Important note, we may remove your pull request if you do not use this provided PR template correctly. -->
<!-- Agent instructions: Preserve every heading, comment, and marker in this template. Never remove or rewrite the release-note-category:start/end, release-note:start/end, or release-note-image:start/end marker pairs. -->

## Pull Request Type
<!-- Please select what type of pull request this is: [x] -->
- [x] Bugfix
- [ ] Feature Implementation
- [ ] Documentation
- [ ] Other

## Related issue
<!-- Please link the issue your pull request is referring to. -->
<!-- If this pull request fully resolves the relevant issue, put "closes" before the issue number. -->
<!-- Example: "closes #123456". -->

Closes #1084.

## Description
<!-- Please write a clear and concise description of what the pull request does. -->

Opening a saved playlist refreshed its thumbnail but left the stored video count and other metadata unchanged, so the User Playlists card continued to show values from when the playlist was first saved.

Persist the latest title, description, thumbnail, video count, and uploader identity and avatar through the existing bookmark metadata refresh. The shared refresh works through both the Local API and Invidious loading paths. Regression coverage exercises count-only changes, the other metadata fields, stale request isolation, and persistence after restart.

## Release note category
<!-- Select exactly one category. Every pull request must select one. -->
<!-- Select "Not noteworthy" when the pull request fixes a bug in or improves functionality that has not yet appeared in a stable release. -->
<!-- release-note-category:start -->
- [ ] Not noteworthy
- [ ] Highlights
- [ ] More improvements
- [x] Fixed bugs
<!-- release-note-category:end -->

## Release note
<!-- Required unless "Not noteworthy" is selected. -->
<!-- Write one concise, user-facing entry without a leading bullet. -->
<!-- release-note:start -->
Saved playlists now update their displayed metadata after they are opened.
<!-- release-note:end -->

## Release note images
<!-- Optional. Paste one or more Markdown images, HTML image tags, or dark/light <picture> elements here. -->
<!-- The release notes normalize the markup and limit images taller than 300 pixels. -->
<!-- Agent instructions:
For a noteworthy visible change, add media when it makes the change easier to understand. Prefer a still image unless motion is the point. Recordings in this section must end up as animated WebP because release notes accept images, not video attachments.
After implementing a visible change, proactively capture the result and show the local media to the user for approval before uploading it or updating the pull request.
When the affected UI differs between dark and light themes, capturing both themes is required. A dark-only image is incomplete. The final pull request body must combine the hosted URLs into a theme-aware `<picture>` with dark and light `prefers-color-scheme` sources and the dark image as its `<img>` fallback. Never leave the two theme captures as separate images.
Capture or crop to the smallest region that still makes the change clear. Do not include the full window when the affected component can be understood on its own.
Use English unless localization is the subject. Keep components at their normal dimensions and placement instead of resizing them to fill the frame.
Use deterministic local fixtures for visible remote images. Reusable avatar and thumbnail fixtures are available through `e2e/helpers/visual-fixtures.mjs`. Before capturing, verify that every visible image has loaded successfully (`complete === true` and `naturalWidth > 0`).
Inspect the final dark and light files for failed images, missing content, unrelated UI, awkward animation, and misleading layout. Omit media when it does not explain the change clearly.
Use GitHub CLI 2.99.0 or newer to upload images no larger than 10 MB. For one image, write an ordinary Markdown image reference to the local file between the marker comments. Pass the same file to `gh pr create` or `gh pr edit` with `--attach <path>` so GitHub CLI replaces the local path with its hosted URL.
GitHub CLI does not rewrite paths inside HTML attributes. For themed images within its size limit, first upload both files through temporary Markdown image references and repeat `--attach <path>` for each one. Read back the hosted URLs, replace the temporary references with the `<picture>` below, and update the pull request body without `--attach`:
<picture>
  <source media="(prefers-color-scheme: dark)" srcset="HOSTED_DARK_URL">
  <source media="(prefers-color-scheme: light)" srcset="HOSTED_LIGHT_URL">
  <img alt="DESCRIPTION" src="HOSTED_DARK_URL">
</picture>
For every MP4, MOV, or WebM recording, use `node _scripts/releaseNoteMedia.mjs FILE --alt "DESCRIPTION"` regardless of file size so the helper converts it to animated WebP. Use the same command when an image exceeds 10 MB. For a themed pair where either file needs the helper, use `node _scripts/releaseNoteMedia.mjs --dark DARK_FILE --light LIGHT_FILE --alt "DESCRIPTION"`. Paste only its generated markup between the marker comments.
Check for personal information, tokens, private repository names, and unrelated desktop content before uploading. Uploaded media is public.
Keep capture-only scripts, test hooks, screenshots, and recordings out of commits. Remove them before committing unless the capture code is also a reusable regression test. Never commit generated release-note media.
Leave this section empty when media would not help.
-->
<!-- release-note-image:start -->

<!-- release-note-image:end -->

## Testing
<!-- How can reviewers verify that the PR produces correct results? -->
<!-- Please provide instructions so that others can ensure that your pull request would produce expected results. For examples see, https://github.com/FreeTubeApp/FreeTube/pull/5743, https://github.com/FreeTubeApp/FreeTube/pull/7349, https://github.com/FreeTubeApp/FreeTube/pull/5125, https://github.com/FreeTubeApp/FreeTube/pull/7338 -->
<!-- Agent instructions: Only write human-facing steps that explain how to verify the change while running this branch in dev mode. Include expected results and, when applicable, helpful console snippets for interactive verification. Do not include automated checks, commands, results, pass counts, or CI status. -->

1. Save a YouTube playlist and note its metadata on the User Playlists page.
2. Change its title, description, thumbnail, or video count on YouTube.
3. Open the saved playlist in OpenTubeX, then return to User Playlists.
4. Confirm its card shows the new title, thumbnail, video count, and channel metadata, including when the first video and thumbnail did not change.
5. Restart OpenTubeX and confirm the refreshed values remain visible.

## Additional context
<!-- Please provide any additional context for the pull request here. -->

The previous fix made playlist cards react to store changes but did not update the saved bookmark metadata when a remote playlist was reopened.
