### PR TITLE
fix(comments): restore empty state alignment

### DIFF
--- a/e2e/tests/offline/watch-page.spec.mjs
+++ b/e2e/tests/offline/watch-page.spec.mjs
@@ -4436,6 +4436,69 @@ test('treats an empty comments response as no comments', async ({ app, page }) =
   await page.locator('.commentAutoLoadSentinel').scrollIntoViewIfNeeded()
 
   await expect(page.locator('.noCommentMsg')).toHaveText('There are no comments available for this video')
+  const reloadButton = page.locator('.noCommentActions .reloadComments .iconButton')
+  const sortSelect = page.locator('.noCommentActions .select-text')
+  const expectReloadAlignedBeforeSort = async () => {
+    const [reloadBox, sortBox] = await Promise.all([
+      reloadButton.boundingBox(),
+      sortSelect.boundingBox()
+    ])
+    expect({
+      reloadBeforeSort: reloadBox.x + reloadBox.width <= sortBox.x,
+      verticallyAligned: Math.abs(
+        reloadBox.y + reloadBox.height / 2 -
+        (sortBox.y + sortBox.height / 2)
+      ) <= 1
+    }).toEqual({
+      reloadBeforeSort: true,
+      verticallyAligned: true
+    })
+  }
+  await expectReloadAlignedBeforeSort()
+
+  const [actionsBox, messageBox] = await Promise.all([
+    page.locator('.noCommentActions').boundingBox(),
+    page.locator('.noCommentMsg').boundingBox()
+  ])
+  expect(Math.abs(
+    actionsBox.y + actionsBox.height / 2 -
+    (messageBox.y + messageBox.height / 2)
+  )).toBeLessThanOrEqual(1)
+
+  await page.evaluate(() => window.ftElectron.setZoomFactor(1.25))
+  const [scaledActionsBox, scaledMessageBox] = await Promise.all([
+    page.locator('.noCommentActions').boundingBox(),
+    page.locator('.noCommentMsg').boundingBox()
+  ])
+  expect(Math.abs(
+    scaledActionsBox.y + scaledActionsBox.height / 2 -
+    (scaledMessageBox.y + scaledMessageBox.height / 2)
+  )).toBeLessThanOrEqual(1)
+
+  await setWindowSize(app, page, { width: 375, height: 800 })
+  await page.locator('.app').evaluate((element) => {
+    element.classList.add('capacitorTabs', 'capacitorPhoneLayout')
+    element.classList.remove('topTabs', 'bottomTabs', 'verticalTabs')
+  })
+
+  const readMobileLayout = () => page.locator('.noComments').evaluate((element) => {
+    const actionsBounds = element.querySelector('.noCommentActions').getBoundingClientRect()
+    const messageBounds = element.querySelector('.noCommentMsg').getBoundingClientRect()
+    return {
+      actionsAboveMessage: actionsBounds.bottom <= messageBounds.top,
+      hasHorizontalOverflow: element.scrollWidth > element.clientWidth + 1
+    }
+  })
+  const expectedMobileLayout = {
+    actionsAboveMessage: true,
+    hasHorizontalOverflow: false
+  }
+  expect(await readMobileLayout()).toEqual(expectedMobileLayout)
+  await expectReloadAlignedBeforeSort()
+
+  await setWindowSize(app, page, { width: 800, height: 375 })
+  expect(await readMobileLayout()).toEqual(expectedMobileLayout)
+  await expectReloadAlignedBeforeSort()
   await expect(page.locator('.toast', { hasText: 'Local API Error' })).toHaveCount(0)
   expect(commentRequestCount).toBe(1)
 })

--- a/src/renderer/components/CommentSection/CommentSection.css
+++ b/src/renderer/components/CommentSection/CommentSection.css
@@ -245,8 +245,8 @@
 
 .noComments {
   display: flex;
-  flex-flow: column wrap;
-  align-items: stretch;
+  flex-wrap: wrap;
+  align-items: center;
   justify-content: space-between;
   gap: 8px;
   padding-block: 8px;
@@ -263,12 +263,21 @@
   flex: 0 0 auto;
   align-items: flex-start;
   gap: 8px;
-  align-self: flex-end;
   margin-inline-start: auto;
 }
 
 .noCommentActions :deep(.select) {
-  margin-block-start: 0;
+  margin-block-start: 20px;
+}
+
+:global(.capacitorPhoneLayout .noComments) {
+  flex-flow: column wrap;
+  align-items: stretch;
+}
+
+:global(.capacitorPhoneLayout .noCommentActions) {
+  order: -1;
+  align-self: flex-end;
 }
 
 .commentsTitle {

--- a/src/renderer/components/CommentSection/CommentSection.vue
+++ b/src/renderer/components/CommentSection/CommentSection.vue
@@ -500,30 +500,6 @@
         class="noComments"
         :class="{ noCommentsMessageOnly: commentsDisabled || fullscreenOverlay }"
       >
-        <div
-          v-if="!fullscreenOverlay && !commentsDisabled"
-          class="noCommentActions"
-        >
-          <FtSelect
-            v-if="showSortBy"
-            :placeholder="$t('Global.Sort By')"
-            :value="currentSortValue"
-            :select-names="sortNames"
-            :select-values="sortValues"
-            :icon="['fas', 'arrow-down-short-wide']"
-            @change="handleSortChange"
-          />
-          <FtIconButton
-            :title="$t('Comments.Reload Comments')"
-            :icon="['fas', 'sync']"
-            :size="12"
-            :padding="8"
-            :use-shadow="false"
-            class="reloadComments"
-            :class="{ reloadCommentsAligned: showSortBy }"
-            @click="reloadCommentData"
-          />
-        </div>
         <h3
           v-if="commentsDisabled"
           class="noCommentMsg"
@@ -542,6 +518,30 @@
         >
           {{ $t("Comments.There are no comments available for this video") }}
         </h3>
+        <div
+          v-if="!fullscreenOverlay && !commentsDisabled"
+          class="noCommentActions"
+        >
+          <FtIconButton
+            :title="$t('Comments.Reload Comments')"
+            :icon="['fas', 'sync']"
+            :size="12"
+            :padding="8"
+            :use-shadow="false"
+            class="reloadComments"
+            :class="{ reloadCommentsAligned: showSortBy }"
+            @click="reloadCommentData"
+          />
+          <FtSelect
+            v-if="showSortBy"
+            :placeholder="$t('Global.Sort By')"
+            :value="currentSortValue"
+            :select-names="sortNames"
+            :select-values="sortValues"
+            :icon="['fas', 'arrow-down-short-wide']"
+            @change="handleSortChange"
+          />
+        </div>
       </div>
       <FtSpinner
         v-if="shouldShowAutoLoadMoreCommentsSpinner"


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Make sure to follow the contributing guidelines. -->
<!-- Important note, we may remove your pull request if you do not use this provided PR template correctly. -->
<!-- Agent instructions: Preserve every heading, comment, and marker in this template. Never remove or rewrite the release-note-category:start/end, release-note:start/end, or release-note-image:start/end marker pairs. -->

## Pull Request Type
<!-- Please select what type of pull request this is: [x] -->
- [x] Bugfix
- [ ] Feature Implementation
- [ ] Documentation
- [ ] Other

## Related issue
<!-- Please link the issue your pull request is referring to. -->
<!-- If this pull request fully resolves the relevant issue, put "closes" before the issue number. -->
<!-- Example: "closes #123456". -->
Regression from #1049.

## Description
<!-- Please write a clear and concise description of what the pull request does. -->
The Android mobile layout changed the empty comments state to a vertical stack on every platform, leaving the desktop message below its controls and giving the empty toolbar a different order and alignment than the populated comments toolbar.

This restores the centered desktop row, limits the controls-first stack to the Capacitor phone layout, and consistently places reload before sort with both controls vertically aligned. The regression coverage checks desktop at 100% and 125% UI scale plus phone portrait and landscape layouts.

## Release note category
<!-- Select exactly one category. Every pull request must select one. -->
<!-- Select "Not noteworthy" when the pull request fixes a bug in or improves functionality that has not yet appeared in a stable release. -->
<!-- release-note-category:start -->
- [x] Not noteworthy
- [ ] Highlights
- [ ] More improvements
- [ ] Fixed bugs
<!-- release-note-category:end -->

## Release note
<!-- Required unless "Not noteworthy" is selected. -->
<!-- Write one concise, user-facing entry without a leading bullet. -->
<!-- release-note:start -->

<!-- release-note:end -->

## Release note images
<!-- Optional. Paste one or more Markdown images, HTML image tags, or dark/light <picture> elements here. -->
<!-- The release notes normalize the markup and limit images taller than 300 pixels. -->
<!-- Agent instructions:
For a noteworthy visible change, add media when it makes the change easier to understand. Prefer a still image unless motion is the point. Recordings in this section must end up as animated WebP because release notes accept images, not video attachments.
After implementing a visible change, proactively capture the result and show the local media to the user for approval before uploading it or updating the pull request.
When the affected UI differs between dark and light themes, capturing both themes is required. A dark-only image is incomplete. The final pull request body must combine the hosted URLs into a theme-aware `<picture>` with dark and light `prefers-color-scheme` sources and the dark image as its `<img>` fallback. Never leave the two theme captures as separate images. Use a single default-dark capture only when the light theme cannot be captured or looks identical.
Capture or crop to the smallest region that still makes the change clear. Do not include the full window when the affected component can be understood on its own.
Use English unless localization is the subject. Keep components at their normal dimensions and placement instead of resizing them to fill the frame.
Use deterministic local fixtures for visible remote images. Reusable avatar and thumbnail fixtures are available through `e2e/helpers/visual-fixtures.mjs`. Before capturing, verify that every visible image has loaded successfully (`complete === true` and `naturalWidth > 0`).
Inspect the final dark and light files for failed images, missing content, unrelated UI, awkward animation, and misleading layout. Omit media when it does not explain the change clearly.
Use GitHub CLI 2.99.0 or newer to upload images no larger than 10 MB. For one image, write an ordinary Markdown image reference to the local file between the marker comments. Pass the same file to `gh pr create` or `gh pr edit` with `--attach <path>` so GitHub CLI replaces the local path with its hosted URL.
GitHub CLI does not rewrite paths inside HTML attributes. For themed images within its size limit, first upload both files through temporary Markdown image references and repeat `--attach <path>` for each one. Read back the hosted URLs, replace the temporary references with the `<picture>` below, and update the pull request body without `--attach`:
<picture>
  <source media="(prefers-color-scheme: dark)" srcset="HOSTED_DARK_URL">
  <source media="(prefers-color-scheme: light)" srcset="HOSTED_LIGHT_URL">
  <img alt="DESCRIPTION" src="HOSTED_DARK_URL">
</picture>
For every MP4, MOV, or WebM recording, use `node _scripts/releaseNoteMedia.mjs FILE --alt "DESCRIPTION"` regardless of file size so the helper converts it to animated WebP. Use the same command when an image exceeds 10 MB. For a themed pair where either file needs the helper, use `node _scripts/releaseNoteMedia.mjs --dark DARK_FILE --light LIGHT_FILE --alt "DESCRIPTION"`. Paste only its generated markup between the marker comments.
Check for personal information, tokens, private repository names, and unrelated desktop content before uploading. Uploaded media is public.
Keep capture-only scripts, test hooks, screenshots, and recordings out of commits. Remove them before committing unless the capture code is also a reusable regression test. Never commit generated release-note media.
Leave this section empty when media would not help.
-->
<!-- release-note-image:start -->
<picture>
  <source media="(prefers-color-scheme: dark)" srcset="https://github.com/user-attachments/assets/65cee5bf-783d-4529-8777-81c81aa1fa8d">
  <source media="(prefers-color-scheme: light)" srcset="https://github.com/user-attachments/assets/9480d2f8-0bdf-4cc1-bc3c-2a5214365db5">
  <img alt="Aligned empty comments controls on mobile" src="https://github.com/user-attachments/assets/65cee5bf-783d-4529-8777-81c81aa1fa8d">
</picture>
<!-- release-note-image:end -->

## Testing
<!-- How can reviewers verify that the PR produces correct results? -->
<!-- Please provide instructions so that others can ensure that your pull request produces correct results. For examples see, https://github.com/FreeTubeApp/FreeTube/pull/5743, https://github.com/FreeTubeApp/FreeTube/pull/7349, https://github.com/FreeTubeApp/FreeTube/pull/5125, https://github.com/FreeTubeApp/FreeTube/pull/7338 -->
<!-- Agent instructions: Only write human-facing steps that explain how to verify the change while running this branch in dev mode. Include expected results and, when applicable, helpful console snippets for interactive verification. Do not include automated checks, commands, results, pass counts, or CI status. -->
1. Open a desktop watch page for a video with no comments and load its comments. The empty message should share one vertically centered row with the reload button immediately left of the sort control.
2. Set UI Scale to 125% and repeat. The desktop row and both controls should remain aligned.
3. Open the same video in the Capacitor phone layout in portrait and landscape. Reload should remain left of and vertically aligned with sort, with the controls above the message and no horizontal overflow.

## Additional context
<!-- Add any other context about the pull request here. -->
The global column layout was introduced by the Android mobile experiment. This keeps that mobile presentation without applying it to desktop, while matching the normal comments toolbar order on both layouts.
