### PR TITLE
fix(sync): restore password action placement

### DIFF
--- a/e2e/tests/network/sync-server.spec.mjs
+++ b/e2e/tests/network/sync-server.spec.mjs
@@ -338,7 +338,10 @@ test.describe('OpenTubeX sync server', () => {
       await devices.getByRole('button', { name: 'Refresh devices' }).click()
       await staleSessionRequestRequested
       try {
-        await devices.getByRole('button', { name: 'Change password' }).click()
+        const changePasswordButton = syncSection.getByRole('button', { name: 'Change password' })
+        await expect(changePasswordButton).toBeVisible()
+        await expect(devices.getByRole('button', { name: 'Change password' })).toHaveCount(0)
+        await changePasswordButton.click()
         const passwordPrompt = page.getByRole('dialog', { name: 'Change password' })
         await passwordPrompt.getByLabel('Current password').fill(accountPassword)
         await passwordPrompt.getByLabel('New password', { exact: true }).fill('new-local-test-password')

--- a/e2e/tests/network/sync-server.spec.mjs
+++ b/e2e/tests/network/sync-server.spec.mjs
@@ -893,6 +893,7 @@ test.describe('OpenTubeX sync server', () => {
     await expect(syncSection.getByText(`Connected as ${username}`)).toBeVisible()
     await expect(syncSection.getByLabel('Settings')).toBeVisible()
     await expect(syncSection.getByLabel('Settings')).toBeDisabled()
+    await expect(syncSection.getByRole('button', { name: 'Change password' })).toHaveCount(0)
     await expect(syncSection.getByText(/does not support settings syncing/)).toBeVisible()
     await expect(syncSection.getByText(/Last synced:/)).toBeVisible()
     expect(maxConcurrentSubscriptionWrites).toBeGreaterThan(1)

--- a/src/renderer/components/SyncSettings/SyncAccountManagement.css
+++ b/src/renderer/components/SyncSettings/SyncAccountManagement.css
@@ -26,8 +26,7 @@
 }
 
 .managementIcon,
-.sessionDeviceIcon,
-.passwordActionIcon {
+.sessionDeviceIcon {
   align-items: center;
   background-color: color-mix(in srgb, var(--primary-color) 14%, transparent);
   color: var(--primary-color);
@@ -197,54 +196,6 @@
   color: var(--destructive-color);
 }
 
-.passwordAction {
-  align-items: center;
-  background-color: var(--card-bg-color);
-  border: 1px solid var(--divider-color);
-  border-radius: calc(10px * var(--ui-roundness));
-  box-sizing: border-box;
-  color: var(--primary-text-color);
-  cursor: pointer;
-  display: grid;
-  font: inherit;
-  font-weight: 600;
-  gap: 0.75rem;
-  grid-template-columns: auto minmax(0, 1fr) auto;
-  inline-size: 100%;
-  margin-block-start: 0.75rem;
-  min-block-size: 3.75rem;
-  padding-block: 0.625rem;
-  padding-inline: 0.875rem;
-  text-align: start;
-  transition: background-color 150ms ease, border-color 150ms ease;
-}
-
-.passwordAction:disabled {
-  cursor: not-allowed;
-  opacity: 0.5;
-}
-
-.passwordAction:not(:disabled):is(:hover, :focus-visible) {
-  background-color: var(--side-nav-hover-color);
-  border-color: color-mix(in srgb, var(--primary-color) 44%, var(--divider-color));
-  color: var(--side-nav-hover-text-color);
-}
-
-.passwordAction:not(:disabled):active {
-  background-color: var(--side-nav-active-color);
-}
-
-.passwordActionIcon {
-  block-size: 2.25rem;
-  border-radius: calc(8px * var(--ui-roundness));
-  inline-size: 2.25rem;
-}
-
-.passwordActionArrow {
-  color: var(--secondary-text-color);
-  margin-inline: 0.25rem;
-}
-
 .managementError {
   color: var(--error-color, #c62828);
   text-align: center;
@@ -304,11 +255,5 @@
 
   .sessionActions {
     grid-column: 1;
-  }
-}
-
-@media (prefers-reduced-motion: reduce) {
-  .passwordAction {
-    transition: none;
   }
 }

--- a/src/renderer/components/SyncSettings/SyncAccountManagement.vue
+++ b/src/renderer/components/SyncSettings/SyncAccountManagement.vue
@@ -140,27 +140,6 @@
       </li>
     </ul>
 
-    <button
-      v-if="passwordLogin"
-      class="passwordAction"
-      type="button"
-      :disabled="accountActionsDisabled || actionBusy"
-      @click="emit('change-password')"
-    >
-      <span
-        class="passwordActionIcon"
-        aria-hidden="true"
-      >
-        <FtIcon :icon="['fas', 'key']" />
-      </span>
-      <span>{{ t('Settings.Sync Settings.Change Password') }}</span>
-      <FtIcon
-        class="passwordActionArrow"
-        :icon="['fas', 'arrow-right']"
-        aria-hidden="true"
-      />
-    </button>
-
     <FtPrompt
       v-if="sessionToRename"
       :label="t('Settings.Sync Settings.Rename Device')"
@@ -289,16 +268,8 @@ const props = defineProps({
     type: String,
     required: true,
   },
-  passwordLogin: {
-    type: Boolean,
-    required: true,
-  },
-  accountActionsDisabled: {
-    type: Boolean,
-    required: true,
-  },
 })
-const emit = defineEmits(['change-password', 'current-revoked', 'password-login-changed'])
+const emit = defineEmits(['current-revoked', 'password-login-changed'])
 
 const { locale, t } = useI18n()
 const headingId = useId()

--- a/src/renderer/components/SyncSettings/SyncSettings.vue
+++ b/src/renderer/components/SyncSettings/SyncSettings.vue
@@ -244,7 +244,7 @@
             @click="disconnect"
           />
           <FtButton
-            v-if="passwordLogin"
+            v-if="accountSessionsSupported && passwordLogin"
             :label="t('Settings.Sync Settings.Change Password')"
             :icon="['fas', 'key']"
             :disabled="busy || accountActionBusy"

--- a/src/renderer/components/SyncSettings/SyncSettings.vue
+++ b/src/renderer/components/SyncSettings/SyncSettings.vue
@@ -244,6 +244,13 @@
             @click="disconnect"
           />
           <FtButton
+            v-if="passwordLogin"
+            :label="t('Settings.Sync Settings.Change Password')"
+            :icon="['fas', 'key']"
+            :disabled="busy || accountActionBusy"
+            @click="openPasswordPrompt"
+          />
+          <FtButton
             :label="t('Settings.Sync Settings.Delete Account')"
             theme="destructive"
             :icon="['fas', 'trash']"
@@ -259,9 +266,6 @@
           :privacy-key="privacyKey"
           :device-id="currentDeviceId"
           :device-name="currentDeviceName"
-          :password-login="passwordLogin"
-          :account-actions-disabled="busy || accountActionBusy"
-          @change-password="openPasswordPrompt"
           @current-revoked="disconnect"
           @password-login-changed="passwordLogin = $event"
         />


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Make sure to follow the contributing guidelines. -->
<!-- Important note, we may remove your pull request if you do not use this provided PR template correctly. -->
<!-- Agent instructions: Preserve every heading, comment, and marker in this template. Never remove or rewrite the release-note-category:start/end, release-note:start/end, or release-note-image:start/end marker pairs. -->

## Pull Request Type
<!-- Please select what type of pull request this is: [x] -->
- [x] Bugfix
- [ ] Feature Implementation
- [ ] Documentation
- [ ] Other

## Related issue
<!-- Please link the issue your pull request is referring to. -->
<!-- If this pull request fully resolves the relevant issue, put "closes" before the issue number. -->
<!-- Example: "closes #123456". -->

No linked issue.

## Description
<!-- Please write a clear and concise description of what the pull request does. -->

The change-password action was grouped inside Devices even though it affects the whole sync account. This restores it to the connected account action row and leaves the Devices section focused on device management. The sync-server E2E coverage now checks that placement.

## Release note category
<!-- Select exactly one category. Every pull request must select one. -->
<!-- Select "Not noteworthy" when the pull request fixes a bug in or improves functionality that has not yet appeared in a stable release. -->
<!-- release-note-category:start -->
- [x] Not noteworthy
- [ ] Highlights
- [ ] More improvements
- [ ] Fixed bugs
<!-- release-note-category:end -->

## Release note
<!-- Required unless "Not noteworthy" is selected. -->
<!-- Write one concise, user-facing entry without a leading bullet. -->
<!-- release-note:start -->

<!-- release-note:end -->

## Release note images
<!-- Optional. Paste one or more Markdown images, HTML image tags, or dark/light <picture> elements here. -->
<!-- The release notes normalize the markup and limit images taller than 300 pixels. -->
<!-- Agent instructions:
For a noteworthy visible change, add media when it makes the change easier to understand. Prefer a still image unless motion is the point. Recordings in this section must end up as animated WebP because release notes accept images, not video attachments.
After implementing a visible change, proactively capture the result and show the local media to the user for approval before uploading it or updating the pull request.
When the affected UI differs between dark and light themes, capturing both themes is required. A dark-only image is incomplete. The final pull request body must combine the hosted URLs into a theme-aware `<picture>` with dark and light `prefers-color-scheme` sources and the dark image as its `<img>` fallback. Never leave the two theme captures as separate images. Use a single default-dark capture only when the light theme cannot be captured or looks identical.
Capture or crop to the smallest region that still makes the change clear. Do not include the full window when the affected component can be understood on its own.
Use English unless localization is the subject. Keep components at their normal dimensions and placement instead of resizing them to fill the frame.
Use deterministic local fixtures for visible remote images. Reusable avatar and thumbnail fixtures are available through `e2e/helpers/visual-fixtures.mjs`. Before capturing, verify that every visible image has loaded successfully (`complete === true` and `naturalWidth > 0`).
Inspect the final dark and light files for failed images, missing content, unrelated UI, awkward animation, and misleading layout. Omit media when it does not explain the change clearly.
Use GitHub CLI 2.99.0 or newer to upload images no larger than 10 MB. For one image, write an ordinary Markdown image reference to the local file between the marker comments. Pass the same file to `gh pr create` or `gh pr edit` with `--attach <path>` so GitHub CLI replaces the local path with its hosted URL.
GitHub CLI does not rewrite paths inside HTML attributes. For themed images within its size limit, first upload both files through temporary Markdown image references and repeat `--attach <path>` for each one. Read back the hosted URLs, replace the temporary references with the `<picture>` below, and update the pull request body without `--attach`:
<picture>
  <source media="(prefers-color-scheme: dark)" srcset="HOSTED_DARK_URL">
  <source media="(prefers-color-scheme: light)" srcset="HOSTED_LIGHT_URL">
  <img alt="DESCRIPTION" src="HOSTED_DARK_URL">
</picture>
For every MP4, MOV, or WebM recording, use `node _scripts/releaseNoteMedia.mjs FILE --alt "DESCRIPTION"` regardless of file size so the helper converts it to animated WebP. Use the same command when an image exceeds 10 MB. For a themed pair where either file needs the helper, use `node _scripts/releaseNoteMedia.mjs --dark DARK_FILE --light LIGHT_FILE --alt "DESCRIPTION"`. Paste only its generated markup between the marker comments.
Check for personal information, tokens, private repository names, and unrelated desktop content before uploading. Uploaded media is public.
Keep capture-only scripts, test hooks, screenshots, and recordings out of commits. Remove them before committing unless the capture code is also a reusable regression test. Never commit generated release-note media.
Leave this section empty when media would not help.
-->
<!-- release-note-image:start -->

<picture>
  <source media="(prefers-color-scheme: dark)" srcset="https://github.com/user-attachments/assets/7fde13e5-a773-4a68-b40a-6819f65133cf">
  <source media="(prefers-color-scheme: light)" srcset="https://github.com/user-attachments/assets/7aa92da7-90f1-4bf4-8cfe-2911bb0b5dbd">
  <img alt="Change password restored to the sync account action row above Devices" src="https://github.com/user-attachments/assets/7fde13e5-a773-4a68-b40a-6819f65133cf">
</picture>

<!-- release-note-image:end -->

## Testing
<!-- How can reviewers verify that the PR produces correct results? -->
<!-- Please provide instructions so that others can ensure that your pull request would produce correct results. For examples see, https://github.com/FreeTubeApp/FreeTube/pull/5743, https://github.com/FreeTubeApp/FreeTube/pull/7349, https://github.com/FreeTubeApp/FreeTube/pull/5125, https://github.com/FreeTubeApp/FreeTube/pull/7338 -->
<!-- Agent instructions: Only write human-facing steps that explain how to verify the change while running this branch in dev mode. Include expected results and, when applicable, helpful console snippets for interactive verification. Do not include automated checks, commands, results, pass counts, or CI status. -->

1. Connect to a sync account that uses password login and supports account sessions.
2. Open Settings > Sync and verify that Change password appears in the account action row between Disconnect and Delete sync account.
3. Verify the Devices section contains only device-related controls, then click Change password and confirm the password dialog opens.

## Additional context
<!-- Add any other context about the pull request here. -->

The action remains hidden for accounts that do not use password login.
