### PR TITLE
feat(settings): add customizable navigation

### DIFF
--- a/_scripts/webpack.main.config.js
+++ b/_scripts/webpack.main.config.js
@@ -56,7 +56,8 @@ const config = {
       // Do not bake process.platform here. Cross-compiling (e.g. macOS
       // builds on Linux) would otherwise hardcode the build host OS and
       // download the wrong managed yt-dlp/ffmpeg binaries at runtime.
-      'process.env.IS_ELECTRON_MAIN': true
+      'process.env.IS_ELECTRON_MAIN': true,
+      'process.env.SUPPORTS_LOCAL_API': true
     })
   ],
   output: {

--- a/e2e/tests/offline/home.spec.mjs
+++ b/e2e/tests/offline/home.spec.mjs
@@ -432,8 +432,10 @@ test.describe('hidden Home page', () => {
       lazyLoad: true
     }))
 
-    const distractionSettings = await goToSettingsSection(page, 'distraction')
-    await distractionSettings.locator('label.switch-label').filter({ hasText: 'Hide Home' }).click()
+    const appearanceSettings = await goToSettingsSection(page, 'appearance')
+    await appearanceSettings.getByRole('button', { name: 'Customize navigation' }).click()
+    const navigationSubpage = page.locator('.settingsSubpageContent')
+    await navigationSubpage.getByRole('button', { name: 'Remove Home' }).click()
     await expect(page.locator('.sideNav a[href="#/home"]')).toHaveCount(0)
     await expect(page).toHaveURL(/#\/subscriptions$/)
     await expect(otherWindow).toHaveURL(/#\/subscriptions$/)
@@ -446,14 +448,16 @@ test.describe('hidden Home page', () => {
     await expect(activeNavOption).toHaveAttribute('href', '#/subscriptions')
     await expectSideNavIndicatorAligned(page)
 
-    await distractionSettings.locator('label.switch-label').filter({ hasText: 'Hide Home' }).click()
+    await navigationSubpage.getByRole('button', { name: 'Add item' }).click()
+    await navigationSubpage.getByRole('menuitem', { name: 'Home' }).click()
     await expect(page.locator('.sideNav a[href="#/home"]')).toBeVisible()
     await expectSideNavIndicatorAligned(page)
 
-    await distractionSettings.locator('label.switch-label').filter({ hasText: 'Hide Home' }).click()
+    await navigationSubpage.getByRole('button', { name: 'Remove Home' }).click()
     await expect(page.locator('.sideNav a[href="#/home"]')).toHaveCount(0)
     await expectSideNavIndicatorAligned(page)
 
+    await page.locator('.settingsBackButton').click()
     await goToSettingsSection(page, 'general')
     const landingPageSelect = page.getByRole('combobox', { name: /Default landing page/i })
     await expect(landingPageSelect).toContainText('Subscriptions')
@@ -475,7 +479,32 @@ test.describe('hidden Home page', () => {
         .submenu.items
         .map(item => item.label)
     })
-    expect(navigateItems).not.toContain('Home')
+    expect(navigateItems).toContain('Home')
+  })
+})
+
+test.describe('landing page availability', () => {
+  test.use({
+    seed: {
+      settings: {
+        backendFallback: false,
+        backendPreference: 'local',
+        enableWatchStats: true,
+        landingPage: 'home',
+        navigationItems: ['stats', 'popular', 'subscriptions'],
+        rememberHistory: false,
+      }
+    }
+  })
+
+  test('skips unavailable destinations when choosing a fallback', async ({ page }) => {
+    await expect(page).toHaveURL(/#\/subscriptions$/)
+
+    const tab = await page.evaluate(() => window.ftElectron.tabs.create({
+      makeActive: false,
+      lazyLoad: true,
+    }))
+    expect(tab.route.fullPath).toBe('/subscriptions')
   })
 })
 

--- a/e2e/tests/offline/home.spec.mjs
+++ b/e2e/tests/offline/home.spec.mjs
@@ -508,6 +508,22 @@ test.describe('landing page availability', () => {
   })
 })
 
+test.describe('legacy landing page visibility', () => {
+  test.use({
+    seed: {
+      settings: {
+        hidePlaylists: true,
+        landingPage: 'userplaylists',
+      }
+    }
+  })
+
+  test('applies every legacy navigation switch before opening the first tab', async ({ page }) => {
+    await expect(page).toHaveURL(/#\/home$/)
+    await expect(page.locator('.sideNav a[href="#/userplaylists"]')).toHaveCount(0)
+  })
+})
+
 test.describe('compact scaled Home page', () => {
   test.use({ seed: { ...homeSeed, settings: { uiScale: 95 } } })
 

--- a/e2e/tests/offline/home.spec.mjs
+++ b/e2e/tests/offline/home.spec.mjs
@@ -506,6 +506,23 @@ test.describe('landing page availability', () => {
     }))
     expect(tab.route.fullPath).toBe('/subscriptions')
   })
+
+  test.describe('with Trending configured as the landing page', () => {
+    test.use({
+      seed: {
+        settings: {
+          backendFallback: false,
+          backendPreference: 'local',
+          landingPage: 'trending',
+          navigationItems: ['trending', 'subscriptions'],
+        }
+      }
+    })
+
+    test('opens Trending when the Electron renderer supports the local API', async ({ page }) => {
+      await expect(page).toHaveURL(/#\/trending$/)
+    })
+  })
 })
 
 test.describe('legacy landing page visibility', () => {

--- a/e2e/tests/offline/navigation.spec.mjs
+++ b/e2e/tests/offline/navigation.spec.mjs
@@ -117,6 +117,16 @@ test.describe('side nav navigation', () => {
     ))
     await expect.poll(selectedIds).toEqual(DEFAULT_NAVIGATION_ITEMS)
     await expect(selectedItems.locator('.selectedItem').first()).toHaveCSS('user-select', 'none')
+    const iconOffsets = await selectedItems.locator('.selectedItem').evaluateAll(rows => rows.map(row => {
+      const icon = row.querySelector('.selectedItemIcon > svg')
+      const rowBounds = row.getBoundingClientRect()
+      const iconBounds = icon.getBoundingClientRect()
+      return Math.abs(
+        iconBounds.y + iconBounds.height / 2 -
+        (rowBounds.y + rowBounds.height / 2)
+      )
+    }))
+    expect(Math.max(...iconOffsets)).toBeLessThanOrEqual(0.5)
 
     await page.getByRole('button', { name: 'Remove Most Popular' }).click()
     await page.getByRole('button', { name: 'Add item' }).click()

--- a/e2e/tests/offline/navigation.spec.mjs
+++ b/e2e/tests/offline/navigation.spec.mjs
@@ -1,4 +1,5 @@
-import { test, expect, goTo, sel } from '../../helpers/app.mjs'
+import { test, expect, goTo, goToSettingsSection, sel } from '../../helpers/app.mjs'
+import { DEFAULT_NAVIGATION_ITEMS } from '../../../src/navigationItems.js'
 
 // Pages that work without any network access.
 const OFFLINE_PAGES = [
@@ -104,6 +105,90 @@ test.describe('side nav navigation', () => {
       widthOffset: 0,
     })
     await expect.poll(async () => (await indicator.boundingBox())?.x).not.toBe(initialX)
+  })
+
+  test('customizes navigation order on the side bar and mobile bar', async ({ page }) => {
+    const appearance = await goToSettingsSection(page, 'appearance')
+    await appearance.getByRole('button', { name: 'Customize navigation' }).click()
+
+    const selectedItems = page.locator('.selectedItems')
+    const selectedIds = () => selectedItems.locator('.selectedItem').evaluateAll(rows => (
+      rows.map(row => row.dataset.navigationItemId)
+    ))
+    await expect.poll(selectedIds).toEqual(DEFAULT_NAVIGATION_ITEMS)
+    await expect(selectedItems.locator('.selectedItem').first()).toHaveCSS('user-select', 'none')
+
+    await page.getByRole('button', { name: 'Remove Most Popular' }).click()
+    await page.getByRole('button', { name: 'Add item' }).click()
+    const itemPicker = page.getByRole('menu', { name: 'Add item' })
+    const popularOption = itemPicker.getByRole('menuitem', { name: 'Most Popular' })
+    await expect(itemPicker.getByRole('searchbox')).toHaveCount(0)
+    await expect(popularOption).toHaveCSS('cursor', 'pointer')
+    await expect(popularOption).toHaveCSS('user-select', 'none')
+    await popularOption.click()
+    await expect.poll(selectedIds).toEqual([
+      ...DEFAULT_NAVIGATION_ITEMS.filter(id => id !== 'popular'),
+      'popular',
+    ])
+    await page.getByRole('button', { name: 'Reset to defaults' }).click()
+    await expect.poll(selectedIds).toEqual(DEFAULT_NAVIGATION_ITEMS)
+
+    await page.getByRole('button', { name: 'Move History up' }).click()
+    const reordered = [...DEFAULT_NAVIGATION_ITEMS]
+    reordered.splice(reordered.indexOf('history'), 1)
+    reordered.splice(2, 0, 'history')
+    await expect.poll(selectedIds).toEqual(reordered)
+
+    await page.locator('.settingsCloseButton').click()
+    await page.setViewportSize({ width: 375, height: 700 })
+    await expect.poll(() => page.locator('.sideNav .inner > .navOption:visible').evaluateAll(links => (
+      links.map(link => link.getAttribute('href'))
+    ))).toEqual(reordered.slice(0, 4).map(id => `#/${id}`))
+
+    await page.locator('.sideNav .moreOptionNav').click()
+    await expect.poll(() => page.locator('.sideNav .moreOptionContainer .navOption').evaluateAll(links => (
+      links.map(link => link.getAttribute('href'))
+    ))).toEqual(reordered.filter(id => id !== 'popular').slice(4).map(id => `#/${id}`))
+
+    await page.locator('.sideNav .moreOptionContainer a[href="#/subscribedchannels"]').click()
+    await expect(page).toHaveURL(/#\/subscribedchannels$/)
+    await expect.poll(async () => {
+      const [indicator, moreButton] = await Promise.all([
+        page.locator('.sideNav .activeIndicator').boundingBox(),
+        page.locator('.sideNav .moreOptionNav').boundingBox(),
+      ])
+      if (indicator == null || moreButton == null) return null
+      return {
+        inlineOffset: Math.abs(indicator.x - moreButton.x),
+        widthOffset: Math.abs(indicator.width - moreButton.width),
+      }
+    }).toEqual({ inlineOffset: 0, widthOffset: 0 })
+  })
+
+  test('clamps the add-item picker after its options shrink', async ({ page }) => {
+    const appearance = await goToSettingsSection(page, 'appearance')
+    await appearance.getByRole('button', { name: 'Customize navigation' }).click()
+
+    const selectedItems = page.locator('.selectedItems .selectedItem')
+    while (await selectedItems.count() > 0) {
+      await selectedItems.first().getByRole('button', { name: /^Remove / }).click()
+    }
+
+    await page.getByRole('button', { name: 'Add item' }).click()
+    const picker = page.getByRole('menu', { name: 'Add item' })
+    const scroller = picker.locator('.itemPickerList')
+    const scrollbar = scroller.locator(':scope > .os-scrollbar-vertical')
+    await expect(scrollbar).not.toHaveClass(/os-scrollbar-unusable/)
+
+    const initialScrollTop = await scroller.evaluate(element => {
+      element.scrollTop = element.scrollHeight
+      return element.scrollTop
+    })
+    expect(initialScrollTop).toBeGreaterThan(0)
+
+    await picker.getByRole('menuitem').last().click()
+    await expect.poll(() => scroller.evaluate(element => element.scrollTop)).toBe(0)
+    await expect(scrollbar).toHaveClass(/os-scrollbar-unusable/)
   })
 
   test('navigation history back and forward work', async ({ page }) => {

--- a/e2e/tests/offline/quick-settings.spec.mjs
+++ b/e2e/tests/offline/quick-settings.spec.mjs
@@ -297,6 +297,23 @@ test.describe('automatic quick setting select pairs', () => {
 })
 
 test.describe('customizable quick settings', () => {
+  test('centers setting icons vertically within their rows', async ({ page }) => {
+    const appearance = await goToSettingsSection(page, 'appearance')
+    await appearance.getByRole('button', { name: 'Customize quick settings' }).click()
+
+    const offsets = await page.locator('.selectedSetting').evaluateAll(rows => rows.map(row => {
+      const icon = row.querySelector('.selectedSettingIcon > svg')
+      const rowBounds = row.getBoundingClientRect()
+      const iconBounds = icon.getBoundingClientRect()
+      return Math.abs(
+        iconBounds.y + iconBounds.height / 2 -
+        (rowBounds.y + rowBounds.height / 2)
+      )
+    }))
+
+    expect(Math.max(...offsets)).toBeLessThanOrEqual(0.5)
+  })
+
   test('starts with the original quick settings', async ({ page }) => {
     await page.locator('.profileTrigger').click()
     const menu = page.getByRole('dialog', { name: 'Quick settings' })

--- a/e2e/tests/offline/quick-settings.spec.mjs
+++ b/e2e/tests/offline/quick-settings.spec.mjs
@@ -321,16 +321,11 @@ test.describe('customizable quick settings', () => {
   test('adds basic controls from Appearance and resets them', async ({ app, page }) => {
     const appearance = await goToSettingsSection(page, 'appearance')
     const customizeButton = appearance.getByRole('button', { name: 'Customize quick settings' })
-    const launcher = appearance.locator('.quickSettingsLauncher')
+    const launcher = appearance.locator('.customizerLaunchers')
     await expect(launcher).toBeVisible()
     await expect(customizeButton).toBeVisible()
-    const [launcherBounds, buttonBounds] = await Promise.all([
-      launcher.boundingBox(),
-      customizeButton.boundingBox(),
-    ])
-    expect(Math.abs(
-      launcherBounds.x + launcherBounds.width / 2 - buttonBounds.x - buttonBounds.width / 2
-    )).toBeLessThanOrEqual(1)
+    await expect(launcher.getByRole('button')).toHaveCount(2)
+    await expect(launcher.getByRole('button', { name: 'Customize navigation' })).toBeVisible()
     await customizeButton.click()
     await expect(page.locator('.settingsBreadcrumb')).toContainText('Customize quick settings')
 
@@ -366,6 +361,9 @@ test.describe('customizable quick settings', () => {
     await expect(settingPopover).toHaveCSS('position', 'absolute')
     await expect(settingPicker).toHaveAttribute('type', 'search')
     await expect(settingPopover.locator('.clearInputTextButton')).toHaveCount(0)
+    await expect(page.locator('.settingPicker .optionWrapper').first()).toHaveCSS('cursor', 'pointer')
+    await expect(page.locator('.settingPicker .optionWrapper').first()).toHaveCSS('user-select', 'none')
+    await expect(selectedSettings.locator('.selectedSetting').first()).toHaveCSS('user-select', 'none')
     for (const setting of ['Icon Pack', 'UI Roundness', 'Enable Tor / Proxy']) {
       await settingPicker.fill(setting)
       await page.locator('.settingPicker .optionWrapper').filter({ hasText: setting }).click()

--- a/e2e/tests/offline/settings.spec.mjs
+++ b/e2e/tests/offline/settings.spec.mjs
@@ -3051,6 +3051,37 @@ test.describe('settings', () => {
     expect(Math.max(...switchX) - Math.min(...switchX)).toBeLessThanOrEqual(1)
   })
 
+  test('stacks tab layout controls evenly in a narrow settings window', async ({ app, page }) => {
+    await setWindowSize(app, page, { width: 720, height: 700 })
+    const appearance = await goToSettingsSection(page, 'appearance')
+
+    const tabLayout = appearance.locator('.themeSelectRow').filter({ hasText: 'Tab Layout' })
+    const tabWidth = appearance.locator('.ft-flex-box').filter({
+      has: page.getByRole('slider', { name: /Tab Width/ })
+    }).locator('.switchColumn')
+    const loadIcons = appearance.getByRole('button', { name: 'Load Missing Tab Icons' })
+    const centerDifference = async () => {
+      const centers = await Promise.all([tabLayout, tabWidth, loadIcons].map(async locator => {
+        const bounds = await locator.boundingBox()
+        return bounds.x + bounds.width / 2
+      }))
+      return Math.max(...centers) - Math.min(...centers)
+    }
+
+    expect(await centerDifference()).toBeLessThanOrEqual(3)
+    for (const viewport of [
+      { width: 375, height: 667 },
+      { width: 667, height: 375 },
+    ]) {
+      await page.setViewportSize(viewport)
+      expect(await centerDifference()).toBeLessThanOrEqual(3)
+    }
+
+    await page.evaluate(() => window.ftElectron.setZoomFactor(1.25))
+    await page.setViewportSize({ width: 667, height: 375 })
+    expect(await centerDifference()).toBeLessThanOrEqual(3)
+  })
+
   test('keeps the current icon pack when another pack fails to load', async ({ page }) => {
     await goTo(page, 'settings')
     await page.locator('.settingsMenu [data-section="appearance"]').click()

--- a/e2e/tests/offline/settings.spec.mjs
+++ b/e2e/tests/offline/settings.spec.mjs
@@ -677,7 +677,7 @@ test.describe('settings', () => {
     await expect(headings).toHaveText([
       'Theme',
       'Layout',
-      'Quick settings',
+      'Navigation / Quick settings',
       'Video lists and thumbnails',
     ])
     const theme = appearance.locator('.settingsSection').filter({

--- a/src/constants.js
+++ b/src/constants.js
@@ -628,12 +628,18 @@ const MAIN_PROFILE_ID = 'allChannels'
 const DEFAULT_LANDING_PAGE = 'home'
 const LEGACY_DEFAULT_LANDING_PAGE = 'subscriptions'
 
-function resolveLandingPage(landingPage, hideHome = false) {
-  if (hideHome && landingPage === DEFAULT_LANDING_PAGE) {
-    return LEGACY_DEFAULT_LANDING_PAGE
+function resolveLandingPage(landingPage, availablePages = null) {
+  if (typeof availablePages === 'boolean') {
+    return availablePages && landingPage === DEFAULT_LANDING_PAGE
+      ? LEGACY_DEFAULT_LANDING_PAGE
+      : landingPage
   }
 
-  return landingPage
+  if (!Array.isArray(availablePages) || availablePages.includes(landingPage)) {
+    return landingPage
+  }
+
+  return availablePages[0] ?? LEGACY_DEFAULT_LANDING_PAGE
 }
 
 // Profile colors that follow the selected theme color instead of a fixed value

--- a/src/datastores/handlers/base.js
+++ b/src/datastores/handlers/base.js
@@ -96,15 +96,6 @@ class Settings {
     return db.settings.findOneAsync({ _id })
   }
 
-  static _findSidenavSettings() {
-    return {
-      hideHome: db.settings.findOneAsync({ _id: 'hideHome' }),
-      hideTrendingVideos: db.settings.findOneAsync({ _id: 'hideTrendingVideos' }),
-      hidePopularVideos: db.settings.findOneAsync({ _id: 'hidePopularVideos' }),
-      hidePlaylists: db.settings.findOneAsync({ _id: 'hidePlaylists' }),
-    }
-  }
-
   static _updateBounds(value) {
     return db.settings.updateAsync({ _id: 'bounds' }, { _id: 'bounds', value }, { upsert: true })
   }

--- a/src/main/index.js
+++ b/src/main/index.js
@@ -4601,10 +4601,6 @@ function runApp() {
               backendPreference = data.value
               await setMenu()
               break
-            case 'hideHome':
-            case 'hideTrendingVideos':
-            case 'hidePopularVideos':
-            case 'hidePlaylists':
             case 'keyboardShortcuts':
               await setMenu()
               break
@@ -5472,13 +5468,8 @@ function runApp() {
   }
 
   async function setMenu() {
-    const sidenavSettings = baseHandlers.settings._findSidenavSettings()
     const keyboardShortcutsSetting = await baseHandlers.settings._findOne('keyboardShortcuts')
     const keyboardShortcuts = getConfiguredKeyboardShortcuts(keyboardShortcutsSetting?.value)
-    const hideHome = (await sidenavSettings.hideHome)?.value
-    const hideTrendingVideos = (await sidenavSettings.hideTrendingVideos)?.value
-    const hidePopularVideos = (await sidenavSettings.hidePopularVideos)?.value
-    const hidePlaylists = (await sidenavSettings.hidePlaylists)?.value
 
     const template = [
       ...process.platform === 'darwin'
@@ -5676,7 +5667,7 @@ function runApp() {
       {
         label: 'Navigate',
         submenu: [
-          !hideHome && {
+          {
             label: 'Home',
             click: (_menuItem, browserWindow, _event) => {
               navigateTo('/home', browserWindow)
@@ -5697,21 +5688,21 @@ function runApp() {
             },
             type: 'normal'
           },
-          (!hideTrendingVideos && (backendFallback || backendPreference === 'local')) && {
+          (backendFallback || backendPreference === 'local') && {
             label: 'Trending',
             click: (_menuItem, browserWindow, _event) => {
               navigateTo('/trending', browserWindow)
             },
             type: 'normal'
           },
-          (!hidePopularVideos && (backendFallback || backendPreference === 'invidious')) && {
+          (backendFallback || backendPreference === 'invidious') && {
             label: 'Most Popular',
             click: (_menuItem, browserWindow, _event) => {
               navigateTo('/popular', browserWindow)
             },
             type: 'normal'
           },
-          !hidePlaylists && {
+          {
             label: 'Playlists',
             click: (_menuItem, browserWindow, _event) => {
               navigateTo('/userplaylists', browserWindow)

--- a/src/main/tabs/TabManager.js
+++ b/src/main/tabs/TabManager.js
@@ -8,7 +8,10 @@ import {
   LEGACY_DEFAULT_LANDING_PAGE,
   resolveLandingPage,
 } from '../../constants.js'
-import { normalizeNavigationItems } from '../../navigationItems.js'
+import {
+  navigationItemsFromLegacySettings,
+  normalizeNavigationItems,
+} from '../../navigationItems.js'
 import { filterAvailableNavigationItems } from '../../navigationAvailability.js'
 import * as baseHandlers from '../../datastores/handlers/base.js'
 import { getFixedInternalRouteTitle } from '../../internalRoutes.js'
@@ -318,6 +321,9 @@ export class TabManager {
         landingPageSetting,
         navigationItemsSetting,
         hideHomeSetting,
+        hidePlaylistsSetting,
+        hidePopularVideosSetting,
+        hideTrendingVideosSetting,
         backendPreferenceSetting,
         backendFallbackSetting,
         rememberHistorySetting,
@@ -326,6 +332,9 @@ export class TabManager {
         baseHandlers.settings._findOne('landingPage'),
         baseHandlers.settings._findOne('navigationItems'),
         baseHandlers.settings._findOne('hideHome'),
+        baseHandlers.settings._findOne('hidePlaylists'),
+        baseHandlers.settings._findOne('hidePopularVideos'),
+        baseHandlers.settings._findOne('hideTrendingVideos'),
         baseHandlers.settings._findOne('backendPreference'),
         baseHandlers.settings._findOne('backendFallback'),
         baseHandlers.settings._findOne('rememberHistory'),
@@ -344,9 +353,12 @@ export class TabManager {
       }
 
       const configuredPages = navigationItemsSetting == null
-        ? (hideHomeSetting?.value === true
-            ? normalizeNavigationItems(undefined).filter(id => id !== 'home')
-            : normalizeNavigationItems(undefined))
+        ? navigationItemsFromLegacySettings({
+            hideHome: hideHomeSetting?.value,
+            hidePlaylists: hidePlaylistsSetting?.value,
+            hidePopularVideos: hidePopularVideosSetting?.value,
+            hideTrendingVideos: hideTrendingVideosSetting?.value,
+          })
         : normalizeNavigationItems(navigationItemsSetting.value)
       const supportsLocalApi = !!process.env.SUPPORTS_LOCAL_API
       const availablePages = filterAvailableNavigationItems(configuredPages, {

--- a/src/main/tabs/TabManager.js
+++ b/src/main/tabs/TabManager.js
@@ -8,6 +8,8 @@ import {
   LEGACY_DEFAULT_LANDING_PAGE,
   resolveLandingPage,
 } from '../../constants.js'
+import { normalizeNavigationItems } from '../../navigationItems.js'
+import { filterAvailableNavigationItems } from '../../navigationAvailability.js'
 import * as baseHandlers from '../../datastores/handlers/base.js'
 import { getFixedInternalRouteTitle } from '../../internalRoutes.js'
 import {
@@ -312,9 +314,22 @@ export class TabManager {
    */
   static async getStoredLandingRoute() {
     try {
-      const [landingPageSetting, hideHomeSetting] = await Promise.all([
+      const [
+        landingPageSetting,
+        navigationItemsSetting,
+        hideHomeSetting,
+        backendPreferenceSetting,
+        backendFallbackSetting,
+        rememberHistorySetting,
+        enableWatchStatsSetting,
+      ] = await Promise.all([
         baseHandlers.settings._findOne('landingPage'),
+        baseHandlers.settings._findOne('navigationItems'),
         baseHandlers.settings._findOne('hideHome'),
+        baseHandlers.settings._findOne('backendPreference'),
+        baseHandlers.settings._findOne('backendFallback'),
+        baseHandlers.settings._findOne('rememberHistory'),
+        baseHandlers.settings._findOne('enableWatchStats'),
       ])
 
       let landingPage = landingPageSetting?.value
@@ -328,7 +343,21 @@ export class TabManager {
           : DEFAULT_LANDING_PAGE
       }
 
-      return normalizeRoutePath(resolveLandingPage(landingPage, hideHomeSetting?.value === true))
+      const configuredPages = navigationItemsSetting == null
+        ? (hideHomeSetting?.value === true
+            ? normalizeNavigationItems(undefined).filter(id => id !== 'home')
+            : normalizeNavigationItems(undefined))
+        : normalizeNavigationItems(navigationItemsSetting.value)
+      const supportsLocalApi = !!process.env.SUPPORTS_LOCAL_API
+      const availablePages = filterAvailableNavigationItems(configuredPages, {
+        supportsLocalApi,
+        backendPreference: backendPreferenceSetting?.value ?? (supportsLocalApi ? 'local' : 'invidious'),
+        backendFallback: backendFallbackSetting?.value === true,
+        showWatchStats: (rememberHistorySetting?.value ?? true) &&
+          (enableWatchStatsSetting?.value ?? true),
+      })
+
+      return normalizeRoutePath(resolveLandingPage(landingPage, availablePages))
     } catch (error) {
       console.error('Failed to load landing page preference:', error)
       return `/${LEGACY_DEFAULT_LANDING_PAGE}`

--- a/src/navigationAvailability.js
+++ b/src/navigationAvailability.js
@@ -1,6 +1,4 @@
 /**
- * Provider availability for navigation entries. Distraction-free settings
- * are intentionally handled by each navigation surface separately.
  * @param {object} options
  * @param {boolean} options.supportsLocalApi
  * @param {'local' | 'invidious'} options.backendPreference
@@ -19,4 +17,23 @@ export function isTrendingAvailable({ supportsLocalApi, backendPreference, backe
  */
 export function isMostPopularAvailable({ backendPreference, backendFallback }) {
   return backendFallback || backendPreference === 'invidious'
+}
+
+/**
+ * Removes navigation destinations that cannot be opened in the current app
+ * state while preserving the configured order.
+ *
+ * @param {string[]} items
+ * @param {object} options
+ * @param {boolean} options.supportsLocalApi
+ * @param {'local' | 'invidious'} options.backendPreference
+ * @param {boolean} options.backendFallback
+ * @param {boolean} options.showWatchStats
+ * @returns {string[]}
+ */
+export function filterAvailableNavigationItems(items, options) {
+  return items
+    .filter(id => id !== 'trending' || isTrendingAvailable(options))
+    .filter(id => id !== 'popular' || isMostPopularAvailable(options))
+    .filter(id => id !== 'stats' || options.showWatchStats)
 }

--- a/src/navigationItems.js
+++ b/src/navigationItems.js
@@ -1,0 +1,42 @@
+export const NAVIGATION_ITEM_DEFINITIONS = Object.freeze([
+  { id: 'home', labelKey: 'Home Page.Home', icon: ['fas', 'house'] },
+  { id: 'subscriptions', labelKey: 'Subscriptions.Subscriptions', icon: ['fas', 'rss'] },
+  { id: 'userplaylists', labelKey: 'Playlists', icon: ['fas', 'bookmark'] },
+  { id: 'history', labelKey: 'History.History', icon: ['fas', 'history'] },
+  { id: 'subscribedchannels', labelKey: 'Channels.Channels', icon: ['fas', 'user-check'] },
+  { id: 'trending', labelKey: 'Trending.Trending', icon: ['fas', 'fire'], requiresLocalApi: true },
+  { id: 'popular', labelKey: 'Most Popular', icon: ['fas', 'users'] },
+  { id: 'stats', labelKey: 'Stats.Stats', icon: ['fas', 'chart-line'] },
+].map(Object.freeze))
+
+export const DEFAULT_NAVIGATION_ITEMS = Object.freeze(
+  NAVIGATION_ITEM_DEFINITIONS.map(({ id }) => id)
+)
+
+const NAVIGATION_ITEM_IDS = new Set(DEFAULT_NAVIGATION_ITEMS)
+
+/**
+ * Removes unknown and duplicate entries while preserving the user's order.
+ * @param {unknown} value
+ * @returns {string[]}
+ */
+export function normalizeNavigationItems(value) {
+  if (!Array.isArray(value)) return [...DEFAULT_NAVIGATION_ITEMS]
+  return [...new Set(value.filter(id => NAVIGATION_ITEM_IDS.has(id)))]
+}
+
+/**
+ * Converts the former navigation visibility switches to the ordered list.
+ * @param {Record<string, unknown>} settings
+ * @returns {string[]}
+ */
+export function navigationItemsFromLegacySettings(settings) {
+  const hiddenItems = new Set([
+    ...(settings.hideHome === true ? ['home'] : []),
+    ...(settings.hidePlaylists === true ? ['userplaylists'] : []),
+    ...(settings.hidePopularVideos === true ? ['popular'] : []),
+    ...(settings.hideTrendingVideos === true ? ['trending'] : []),
+  ])
+
+  return DEFAULT_NAVIGATION_ITEMS.filter(id => !hiddenItems.has(id))
+}

--- a/src/orderedItems.js
+++ b/src/orderedItems.js
@@ -1,0 +1,24 @@
+/**
+ * Moves an item relative to its visible neighbors while preserving entries
+ * that are unavailable in the current environment.
+ *
+ * @param {string[]} items
+ * @param {string[]} visibleItems
+ * @param {string} itemId
+ * @param {number} offset
+ * @returns {string[]}
+ */
+export function moveItemByVisibleOffset(items, visibleItems, itemId, offset) {
+  const visibleIndex = visibleItems.indexOf(itemId)
+  const targetId = visibleItems[visibleIndex + offset]
+  if (visibleIndex === -1 || targetId == null) return items
+
+  const reordered = items.slice()
+  const sourceIndex = reordered.indexOf(itemId)
+  if (sourceIndex === -1) return items
+
+  reordered.splice(sourceIndex, 1)
+  const targetIndex = reordered.indexOf(targetId)
+  reordered.splice(targetIndex + (offset > 0 ? 1 : 0), 0, itemId)
+  return reordered
+}

--- a/src/renderer/components/DistractionSettings/DistractionSettings.vue
+++ b/src/renderer/components/DistractionSettings/DistractionSettings.vue
@@ -76,6 +76,13 @@
           setting-key="showDistractionFreeTitles"
           @change="updateShowDistractionFreeTitles"
         />
+        <FtToggleSwitch
+          :label="t('Settings.Distraction Free Settings.Hide Playlists')"
+          :compact="true"
+          :default-value="hidePlaylists"
+          setting-key="hidePlaylists"
+          @change="updateHidePlaylists"
+        />
       </div>
     </div>
     <br class="hide-on-mobile">
@@ -164,39 +171,6 @@
     </h4>
     <div class="switchColumnGrid">
       <div class="switchColumn">
-        <FtToggleSwitch
-          :label="t('Settings.Distraction Free Settings.Hide Home')"
-          :compact="true"
-          :default-value="hideHome"
-          setting-key="hideHome"
-          @change="updateHideHome"
-        />
-        <FtToggleSwitch
-          v-if="SUPPORTS_LOCAL_API"
-          :label="t('Settings.Distraction Free Settings.Hide Trending Videos')"
-          :compact="true"
-          :disabled="disableHideTrendingVideos"
-          :default-value="hideTrendingVideos"
-          setting-key="hideTrendingVideos"
-          @change="updateHideTrendingVideos"
-        />
-        <FtToggleSwitch
-          :label="t('Settings.Distraction Free Settings.Hide Popular Videos')"
-          :compact="true"
-          :disabled="disableHidePopularVideos"
-          :default-value="disableHidePopularVideos || hidePopularVideos"
-          setting-key="hidePopularVideos"
-          @change="updateHidePopularVideos"
-        />
-      </div>
-      <div class="switchColumn">
-        <FtToggleSwitch
-          :label="t('Settings.Distraction Free Settings.Hide Playlists')"
-          :compact="true"
-          :default-value="hidePlaylists"
-          setting-key="hidePlaylists"
-          @change="updateHidePlaylists"
-        />
         <FtToggleSwitch
           :label="t('Settings.Distraction Free Settings.Hide Active Subscriptions')"
           :compact="true"
@@ -417,7 +391,6 @@
 <script setup>
 import { computed, onMounted, ref } from 'vue'
 import { useI18n } from 'vue-i18n'
-import { useRoute, useRouter } from 'vue-router'
 
 import FtSettingsSection from '../FtSettingsSection/FtSettingsSection.vue'
 import FtToggleSwitch from '../FtToggleSwitch/FtToggleSwitch.vue'
@@ -431,10 +404,6 @@ import { showToast } from '../../helpers/utils'
 import { checkYoutubeChannelId, findChannelTagInfo } from '../../helpers/channels'
 
 const { t } = useI18n()
-const route = useRoute()
-const router = useRouter()
-
-const SUPPORTS_LOCAL_API = process.env.SUPPORTS_LOCAL_API
 
 const channelHiderDisabled = ref(false)
 
@@ -521,48 +490,6 @@ function handleHideRecommendedVideos(value) {
   }
 
   store.dispatch('updateHideRecommendedVideos', value)
-}
-
-/** @type {import('vue').ComputedRef<boolean>} */
-const hideTrendingVideos = computed(() => store.getters.getHideTrendingVideos)
-
-const disableHideTrendingVideos = computed(() => backendPreference.value !== 'local' && !backendFallback.value)
-/**
- * @param {boolean} value
- */
-function updateHideTrendingVideos(value) {
-  store.dispatch('updateHideTrendingVideos', value)
-}
-
-/** @type {import('vue').ComputedRef<boolean>} */
-const hideHome = computed(() => store.getters.getHideHome)
-
-/**
- * @param {boolean} value
- */
-async function updateHideHome(value) {
-  await store.dispatch('updateHideHome', value)
-
-  if (!value) { return }
-
-  const landingRoute = { path: `/${store.getters.getLandingPage}` }
-  if (process.env.IS_ELECTRON) {
-    await store.dispatch('redirectHomeTabsToLandingPage')
-  } else if (route.path === '/home') {
-    await router.replace(landingRoute)
-  }
-}
-
-/** @type {import('vue').ComputedRef<boolean>} */
-const hidePopularVideos = computed(() => store.getters.getHidePopularVideos)
-
-const disableHidePopularVideos = computed(() => backendPreference.value !== 'invidious' && !backendFallback.value)
-
-/**
- * @param {boolean} value
- */
-function updateHidePopularVideos(value) {
-  store.dispatch('updateHidePopularVideos', value)
 }
 
 /** @type {import('vue').ComputedRef<boolean>} */

--- a/src/renderer/components/GeneralSettings/GeneralSettings.vue
+++ b/src/renderer/components/GeneralSettings/GeneralSettings.vue
@@ -341,6 +341,7 @@ import allLocales from '../../../../static/locales/activeLocales.json'
 import { debounce, randomArrayItem, showToast } from '../../helpers/utils'
 import { translateWindowTitle } from '../../helpers/strings'
 import { initializePlatformInfo, isLinuxWayland } from '../../helpers/platform'
+import { filterAvailableNavigationItems } from '../../../navigationAvailability'
 import {
   DATE_FORMAT_OPTIONS,
   TIME_FORMAT_OPTIONS,
@@ -545,48 +546,18 @@ function updateBackendPreference(value) {
   store.dispatch('updateBackendPreference', value)
 }
 
-/** @type {import('vue').ComputedRef<boolean>} */
-const hidePlaylists = computed(() => store.getters.getHidePlaylists)
-
-/** @type {import('vue').ComputedRef<boolean>} */
-const hideHome = computed(() => store.getters.getHideHome)
-
-/** @type {import('vue').ComputedRef<boolean>} */
-const hidePopularVideos = computed(() => store.getters.getHidePopularVideos)
-
-/** @type {import('vue').ComputedRef<boolean>} */
-const hideTrendingVideos = computed(() => store.getters.getHideTrendingVideos)
-
-const INCLUDED_DEFAULT_PAGE_NAMES = [
-  'home',
-  'subscriptions',
-  'subscribedChannels',
-  'popular',
-  'userPlaylists',
-  'history',
-  ...(process.env.SUPPORTS_LOCAL_API ? ['trending'] : [])
-]
+const navigationItems = computed(() => store.getters.getNavigationItems)
 
 const defaultPages = computed(() => {
-  let includedPageNames = INCLUDED_DEFAULT_PAGE_NAMES
-
-  if (hideHome.value) {
-    includedPageNames = includedPageNames.filter((pageName) => pageName !== 'home')
-  }
-
-  if (hideTrendingVideos.value || !backendFallback.value || backendPreference.value !== 'local') {
-    includedPageNames = includedPageNames.filter((pageName) => pageName !== 'trending')
-  }
-
-  if (hidePlaylists.value) {
-    includedPageNames = includedPageNames.filter((pageName) => pageName !== 'userPlaylists')
-  }
-
-  if (!(!hidePopularVideos.value && (backendFallback.value || backendPreference.value === 'invidious'))) {
-    includedPageNames = includedPageNames.filter((pageName) => pageName !== 'popular')
-  }
-
-  return router.getRoutes().filter((route) => includedPageNames.includes(route.name))
+  const routeByPath = new Map(router.getRoutes().map(route => [route.path.slice(1), route]))
+  return filterAvailableNavigationItems(navigationItems.value, {
+    supportsLocalApi: SUPPORTS_LOCAL_API,
+    backendPreference: backendPreference.value,
+    backendFallback: backendFallback.value,
+    showWatchStats: store.getters.getRememberHistory && store.getters.getEnableWatchStats,
+  })
+    .map(id => routeByPath.get(id))
+    .filter(route => route != null)
 })
 
 const defaultPageNames = computed(() => defaultPages.value.map((route) => translateWindowTitle(route.meta.title)))
@@ -596,7 +567,7 @@ const defaultPageValues = computed(() => {
   return defaultPages.value.map((route) => route.path.slice(1))
 })
 
-/** @type {import('vue').ComputedRef<'home' | 'subscriptions' | 'subscribedChannels' | 'popular' | 'userPlaylists' | 'history' | 'trending'>} */
+/** @type {import('vue').ComputedRef<'home' | 'subscriptions' | 'subscribedchannels' | 'popular' | 'userplaylists' | 'history' | 'trending' | 'stats'>} */
 const landingPage = computed(() => store.getters.getLandingPage)
 
 /**

--- a/src/renderer/components/NavigationCustomizer/NavigationCustomizer.vue
+++ b/src/renderer/components/NavigationCustomizer/NavigationCustomizer.vue
@@ -486,9 +486,12 @@ function resetItems() {
 }
 
 .selectedItemIcon {
+  align-items: center;
   block-size: 20px;
   color: var(--secondary-text-color);
+  display: flex;
   inline-size: 20px;
+  justify-content: center;
 }
 
 .itemActions {

--- a/src/renderer/components/NavigationCustomizer/NavigationCustomizer.vue
+++ b/src/renderer/components/NavigationCustomizer/NavigationCustomizer.vue
@@ -1,0 +1,536 @@
+<template>
+  <FtButton
+    :label="t('Settings.General Settings.Navigation.Customize Navigation')"
+    :icon="['fas', 'bars']"
+    @click="open = true"
+  />
+
+  <FtSettingsSubpage
+    :open="open"
+    :title="t('Settings.General Settings.Navigation.Customize Navigation')"
+    :icon="['fas', 'bars']"
+    @close="close"
+  >
+    <div class="navigationActions">
+      <div
+        ref="itemPickerAnchorRef"
+        class="itemPickerAnchor"
+      >
+        <FtButton
+          :label="t('Settings.General Settings.Navigation.Add Item')"
+          :icon="['fas', 'plus']"
+          aria-haspopup="menu"
+          :aria-expanded="itemPickerOpen"
+          :aria-controls="itemPickerId"
+          :disabled="availableItems.length === 0"
+          @click="toggleItemPicker"
+        />
+        <div
+          v-if="itemPickerOpen"
+          :id="itemPickerId"
+          class="itemPickerPopover"
+          data-settings-escape-scope
+          role="menu"
+          tabindex="-1"
+          :aria-label="t('Settings.General Settings.Navigation.Add Item')"
+          @keydown.esc.stop="closeItemPicker(true)"
+          @keydown.down.prevent="focusAdjacentPickerItem($event, 1)"
+          @keydown.up.prevent="focusAdjacentPickerItem($event, -1)"
+        >
+          <div
+            ref="itemPickerListRef"
+            v-overlay-scrollbars
+            class="itemPickerList"
+            role="none"
+          >
+            <ul
+              ref="itemPickerContentRef"
+              class="itemPickerContent"
+              role="none"
+            >
+              <li
+                v-for="item in availableItems"
+                :key="item.id"
+                role="none"
+              >
+                <button
+                  type="button"
+                  class="itemPickerOption"
+                  role="menuitem"
+                  @click="addItem(item.id)"
+                >
+                  <FtIcon
+                    class="itemPickerIcon"
+                    :icon="item.icon"
+                    aria-hidden="true"
+                  />
+                  <bdi>{{ item.label }}</bdi>
+                </button>
+              </li>
+            </ul>
+          </div>
+        </div>
+      </div>
+      <FtButton
+        :label="t('KeyboardShortcutPrompt.Reset to Defaults')"
+        :icon="['fas', 'undo']"
+        theme="secondary"
+        @click="resetItems"
+      />
+    </div>
+
+    <ul
+      v-if="selectedItems.length > 0"
+      class="selectedItems"
+    >
+      <li
+        v-for="(item, index) in selectedItems"
+        :key="item.id"
+        class="selectedItem"
+        :data-navigation-item-id="item.id"
+        :class="{
+          dragging: draggedItemId === item.id,
+          dropBefore: dropTarget?.id === item.id && !dropTarget.after,
+          dropAfter: dropTarget?.id === item.id && dropTarget.after,
+        }"
+        @dragover.prevent="handleDragOver($event, item.id)"
+        @drop.prevent="dropItem($event, item.id)"
+      >
+        <span
+          class="dragHandle"
+          draggable="true"
+          aria-hidden="true"
+          @dragstart="startDragging($event, item.id)"
+          @dragend="stopDragging"
+        >
+          <FtIcon :icon="['fas', 'grip']" />
+        </span>
+        <FtIcon
+          class="selectedItemIcon"
+          :icon="item.icon"
+          aria-hidden="true"
+        />
+        <span>{{ item.label }}</span>
+        <div class="itemActions">
+          <button
+            type="button"
+            class="itemAction"
+            :aria-label="t('Home Page.Move section up', { section: item.label })"
+            :title="t('Home Page.Move section up', { section: item.label })"
+            :disabled="index === 0"
+            @click="moveItem(item.id, -1)"
+          >
+            <FtIcon
+              :icon="['fas', 'arrow-up']"
+              aria-hidden="true"
+            />
+          </button>
+          <button
+            type="button"
+            class="itemAction"
+            :aria-label="t('Home Page.Move section down', { section: item.label })"
+            :title="t('Home Page.Move section down', { section: item.label })"
+            :disabled="index === selectedItems.length - 1"
+            @click="moveItem(item.id, 1)"
+          >
+            <FtIcon
+              :icon="['fas', 'arrow-down']"
+              aria-hidden="true"
+            />
+          </button>
+          <button
+            type="button"
+            class="itemAction"
+            :aria-label="`${t('Search Bar.Remove')} ${item.label}`"
+            :title="`${t('Search Bar.Remove')} ${item.label}`"
+            @click="removeItem(item.id)"
+          >
+            <FtIcon
+              :icon="['fas', 'xmark']"
+              aria-hidden="true"
+            />
+          </button>
+        </div>
+      </li>
+    </ul>
+    <p
+      v-else
+      class="emptyState"
+    >
+      {{ t('Settings.No Settings Found') }}
+    </p>
+    <p
+      class="reorderStatus"
+      role="status"
+      aria-live="polite"
+      aria-atomic="true"
+    >
+      {{ reorderStatus }}
+    </p>
+  </FtSettingsSubpage>
+</template>
+
+<script setup>
+import { FtIcon } from '@opentubex/icons'
+import { computed, nextTick, onBeforeUnmount, onMounted, ref, useId, useTemplateRef, watch } from 'vue'
+import { useI18n } from 'vue-i18n'
+import { useRoute, useRouter } from 'vue-router'
+
+import FtButton from '../FtButton/FtButton.vue'
+import FtSettingsSubpage from '../FtSettingsSubpage/FtSettingsSubpage.vue'
+
+import store from '../../store/index'
+import { clampOverlayScrollTop } from '../../helpers/overlayScrollbars'
+import { useOrderedItemDrag } from '../../composables/useOrderedItemDrag'
+import { moveItemByVisibleOffset } from '../../../orderedItems'
+import {
+  DEFAULT_NAVIGATION_ITEMS,
+  NAVIGATION_ITEM_DEFINITIONS,
+} from '../../../navigationItems'
+
+const { locale, t } = useI18n()
+const route = useRoute()
+const router = useRouter()
+const open = ref(false)
+const itemPickerOpen = ref(false)
+const reorderStatus = ref('')
+const itemPickerId = `navigation-item-picker-${useId().replaceAll(':', '')}`
+const itemPickerAnchorRef = useTemplateRef('itemPickerAnchorRef')
+const itemPickerListRef = useTemplateRef('itemPickerListRef')
+const itemPickerContentRef = useTemplateRef('itemPickerContentRef')
+let itemPickerResizeObserver = null
+
+const catalog = computed(() => NAVIGATION_ITEM_DEFINITIONS
+  .filter(item => !item.requiresLocalApi || process.env.SUPPORTS_LOCAL_API)
+  .map(item => ({
+    ...item,
+    // eslint-disable-next-line @intlify/vue-i18n/no-dynamic-keys
+    label: t(item.labelKey),
+  })))
+const catalogById = computed(() => new Map(catalog.value.map(item => [item.id, item])))
+const navigationItems = computed(() => store.getters.getNavigationItems)
+const selectedItems = computed(() => navigationItems.value
+  .map(id => catalogById.value.get(id))
+  .filter(item => item != null))
+const availableItems = computed(() => catalog.value
+  .filter(item => !navigationItems.value.includes(item.id))
+  .toSorted((left, right) => left.label.localeCompare(right.label, locale.value)))
+
+function close() {
+  open.value = false
+  closeItemPicker()
+  stopDragging()
+}
+
+async function toggleItemPicker() {
+  if (itemPickerOpen.value) {
+    closeItemPicker()
+    return
+  }
+
+  itemPickerOpen.value = true
+  await nextTick()
+  itemPickerListRef.value?.querySelector('.itemPickerOption')?.focus()
+}
+
+function closeItemPicker(restoreFocus = false) {
+  itemPickerOpen.value = false
+  if (restoreFocus) {
+    nextTick(() => itemPickerAnchorRef.value?.querySelector('button')?.focus())
+  }
+}
+
+function focusAdjacentPickerItem(event, offset) {
+  const options = Array.from(itemPickerListRef.value?.querySelectorAll('.itemPickerOption') ?? [])
+  const currentIndex = options.indexOf(event.target.closest('.itemPickerOption'))
+  if (currentIndex === -1 || options.length === 0) return
+
+  options[(currentIndex + offset + options.length) % options.length].focus()
+}
+
+function closeItemPickerFromOutside(event) {
+  if (!itemPickerOpen.value || itemPickerAnchorRef.value?.contains(event.target)) return
+  closeItemPicker()
+}
+
+function clampItemPickerScroll() {
+  if (itemPickerListRef.value !== null && itemPickerContentRef.value !== null) {
+    clampOverlayScrollTop(itemPickerListRef.value, itemPickerContentRef.value)
+  }
+}
+
+function stopObservingItemPicker() {
+  itemPickerResizeObserver?.disconnect()
+  itemPickerResizeObserver = null
+}
+
+watch(itemPickerOpen, async (isOpen) => {
+  stopObservingItemPicker()
+  if (!isOpen) return
+
+  await nextTick()
+  if (itemPickerListRef.value === null || itemPickerContentRef.value === null) return
+
+  itemPickerResizeObserver = new ResizeObserver(clampItemPickerScroll)
+  itemPickerResizeObserver.observe(itemPickerListRef.value)
+  itemPickerResizeObserver.observe(itemPickerContentRef.value)
+  clampItemPickerScroll()
+})
+
+onMounted(() => document.addEventListener('pointerdown', closeItemPickerFromOutside))
+onBeforeUnmount(() => {
+  stopObservingItemPicker()
+  document.removeEventListener('pointerdown', closeItemPickerFromOutside)
+})
+
+async function updateItems(items) {
+  const removedHome = navigationItems.value.includes('home') && !items.includes('home')
+  await store.dispatch('updateNavigationItems', items)
+
+  if (!removedHome) return
+  if (process.env.IS_ELECTRON) {
+    await store.dispatch('redirectHomeTabsToLandingPage')
+  } else if (route.path === '/home') {
+    await router.replace({ path: `/${store.getters.getLandingPage}` })
+  }
+}
+
+async function addItem(itemId) {
+  if (!availableItems.value.some(item => item.id === itemId)) return
+
+  await updateItems([...navigationItems.value, itemId])
+  await nextTick()
+  clampItemPickerScroll()
+  const nextOption = itemPickerListRef.value?.querySelector('.itemPickerOption')
+  if (nextOption) {
+    nextOption.focus()
+  } else {
+    closeItemPicker(true)
+  }
+}
+
+function removeItem(itemId) {
+  return updateItems(navigationItems.value.filter(id => id !== itemId))
+}
+
+function announceItemMoved(itemId, position) {
+  const item = catalogById.value.get(itemId)
+  reorderStatus.value = t('Home Page.Section moved', {
+    section: item?.label ?? itemId,
+    position: position + 1,
+    total: navigationItems.value.length,
+  })
+}
+
+function moveItem(itemId, offset) {
+  const visibleItems = selectedItems.value.map(item => item.id)
+  const targetIndex = visibleItems.indexOf(itemId) + offset
+  const reordered = moveItemByVisibleOffset(
+    navigationItems.value,
+    visibleItems,
+    itemId,
+    offset
+  )
+  if (reordered === navigationItems.value) return
+
+  updateItems(reordered)
+  announceItemMoved(itemId, targetIndex)
+}
+
+const {
+  draggedItemId,
+  dropTarget,
+  dropItem,
+  handleDragOver,
+  startDragging,
+  stopDragging,
+} = useOrderedItemDrag({
+  items: navigationItems,
+  rowSelector: '.selectedItem',
+  updateItems,
+  announceMoved: announceItemMoved,
+})
+
+function resetItems() {
+  return updateItems([...DEFAULT_NAVIGATION_ITEMS])
+}
+</script>
+
+<style scoped>
+.navigationActions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 12px;
+  inline-size: 100%;
+  justify-content: center;
+  margin-block-end: 20px;
+  margin-inline: auto;
+  max-inline-size: 720px;
+  position: relative;
+}
+
+.itemPickerPopover {
+  background: var(--card-bg-color);
+  border: 1px solid var(--divider-color);
+  border-radius: calc(6px * var(--ui-roundness));
+  box-shadow: 0 8px 24px rgb(0 0 0 / 35%);
+  box-sizing: border-box;
+  inline-size: min(520px, 100%);
+  inset-block-start: calc(100% + 8px);
+  inset-inline-start: 50%;
+  padding: 12px;
+  position: absolute;
+  translate: -50% 0;
+  z-index: 20;
+}
+
+.itemPickerList {
+  max-block-size: min(50vh, 20rem);
+  overflow-y: auto;
+}
+
+.itemPickerContent {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+}
+
+.itemPickerOption {
+  align-items: center;
+  background: transparent;
+  border: 0;
+  border-radius: calc(4px * var(--ui-roundness));
+  color: inherit;
+  cursor: pointer;
+  display: flex;
+  font: inherit;
+  gap: 10px;
+  inline-size: 100%;
+  min-block-size: 44px;
+  padding-block: 8px;
+  padding-inline: 12px;
+  text-align: start;
+  user-select: none;
+}
+
+.itemPickerOption:hover,
+.itemPickerOption:focus-visible {
+  background: var(--dropdown-item-hover-color);
+  color: var(--dropdown-item-hover-text-color);
+}
+
+.itemPickerIcon {
+  block-size: 16px;
+  flex: 0 0 16px;
+  inline-size: 16px;
+  opacity: 0.6;
+}
+
+.selectedItems {
+  display: grid;
+  gap: 8px;
+  inline-size: 100%;
+  list-style: none;
+  margin-block: 0;
+  margin-inline: auto;
+  max-inline-size: 720px;
+  padding: 0;
+}
+
+.selectedItem {
+  align-items: center;
+  background: var(--card-bg-color);
+  border: 1px solid var(--divider-color);
+  border-radius: calc(6px * var(--ui-roundness));
+  display: grid;
+  grid-template-columns: 44px 24px minmax(0, 1fr) auto;
+  min-block-size: 56px;
+  position: relative;
+  user-select: none;
+}
+
+.selectedItem.dragging {
+  opacity: 0.5;
+}
+
+.selectedItem.dropBefore::before,
+.selectedItem.dropAfter::after {
+  background: var(--primary-color);
+  block-size: 3px;
+  border-radius: 2px;
+  content: '';
+  inset-inline: 0;
+  position: absolute;
+}
+
+.selectedItem.dropBefore::before {
+  inset-block-start: -6px;
+}
+
+.selectedItem.dropAfter::after {
+  inset-block-end: -6px;
+}
+
+.dragHandle {
+  align-items: center;
+  align-self: stretch;
+  color: var(--secondary-text-color);
+  cursor: grab;
+  display: flex;
+  inline-size: 44px;
+  justify-content: center;
+}
+
+.dragHandle:active {
+  cursor: grabbing;
+}
+
+.selectedItemIcon {
+  block-size: 20px;
+  color: var(--secondary-text-color);
+  inline-size: 20px;
+}
+
+.itemActions {
+  align-self: stretch;
+  display: flex;
+}
+
+.itemAction {
+  align-items: center;
+  background: transparent;
+  border: 0;
+  border-radius: calc(6px * var(--ui-roundness));
+  color: var(--secondary-text-color);
+  cursor: pointer;
+  display: flex;
+  inline-size: 44px;
+  justify-content: center;
+}
+
+.itemAction:hover:not(:disabled),
+.itemAction:focus-visible {
+  background: var(--side-nav-hover-color);
+  color: var(--side-nav-hover-text-color);
+}
+
+.itemAction:disabled {
+  cursor: default;
+  opacity: 0.35;
+}
+
+.reorderStatus {
+  block-size: 1px;
+  clip-path: inset(50%);
+  inline-size: 1px;
+  overflow: hidden;
+  position: absolute;
+  white-space: nowrap;
+}
+
+.emptyState {
+  color: var(--secondary-text-color);
+  margin-block: 24px;
+  text-align: center;
+}
+</style>

--- a/src/renderer/components/QuickSettingsCustomizer/QuickSettingsCustomizer.vue
+++ b/src/renderer/components/QuickSettingsCustomizer/QuickSettingsCustomizer.vue
@@ -412,9 +412,12 @@ function resetQuickSettings() {
 }
 
 .selectedSettingIcon {
+  align-items: center;
   block-size: 20px;
   color: var(--secondary-text-color);
+  display: flex;
   inline-size: 20px;
+  justify-content: center;
 }
 
 .settingActions {

--- a/src/renderer/components/QuickSettingsCustomizer/QuickSettingsCustomizer.vue
+++ b/src/renderer/components/QuickSettingsCustomizer/QuickSettingsCustomizer.vue
@@ -1,11 +1,14 @@
 <template>
-  <FtSettingsSection :title="t('Settings.Quick Settings.Quick Settings')">
-    <div class="quickSettingsLauncher">
+  <FtSettingsSection
+    :title="`${t('Settings.General Settings.Navigation.Navigation')} / ${t('Settings.Quick Settings.Quick Settings')}`"
+  >
+    <div class="customizerLaunchers">
       <FtButton
         :label="t('Settings.Quick Settings.Customize Quick Settings')"
         :icon="['fas', 'sliders-h']"
         @click="open = true"
       />
+      <NavigationCustomizer />
     </div>
   </FtSettingsSection>
 
@@ -163,20 +166,20 @@ import FtButton from '../FtButton/FtButton.vue'
 import FtInput from '../FtInput/FtInput.vue'
 import FtSettingsSection from '../FtSettingsSection/FtSettingsSection.vue'
 import FtSettingsSubpage from '../FtSettingsSubpage/FtSettingsSubpage.vue'
+import NavigationCustomizer from '../NavigationCustomizer/NavigationCustomizer.vue'
 
 import store from '../../store/index'
+import { moveItemByVisibleOffset } from '../../../orderedItems'
+import { useOrderedItemDrag } from '../../composables/useOrderedItemDrag'
 import {
   createQuickSettingCatalog,
   DEFAULT_QUICK_SETTINGS,
-  moveQuickSettingByVisibleOffset,
 } from '../../helpers/quickSettings'
 
 const { locale, t } = useI18n()
 const open = ref(false)
 const settingPickerOpen = ref(false)
 const settingSearchQuery = ref('')
-const draggedSettingId = ref(null)
-const dropTarget = ref(null)
 const reorderStatus = ref('')
 const settingPickerId = `quick-setting-picker-${useId().replaceAll(':', '')}`
 const settingPickerAnchorRef = useTemplateRef('settingPickerAnchorRef')
@@ -263,7 +266,7 @@ function moveQuickSetting(settingId, offset) {
   const visibleSettings = selectedSettings.value.map(setting => setting.id)
   const currentIndex = visibleSettings.indexOf(settingId)
   const targetIndex = currentIndex + offset
-  const reordered = moveQuickSettingByVisibleOffset(
+  const reordered = moveItemByVisibleOffset(
     quickSettings.value,
     visibleSettings,
     settingId,
@@ -275,56 +278,19 @@ function moveQuickSetting(settingId, offset) {
   announceQuickSettingMoved(settingId, targetIndex)
 }
 
-function startDragging(event, settingId) {
-  draggedSettingId.value = settingId
-  event.dataTransfer.effectAllowed = 'move'
-  event.dataTransfer.setData('text/plain', settingId)
-  event.dataTransfer.setDragImage(event.currentTarget.closest('.selectedSetting'), 20, 20)
-}
-
-function handleDragOver(event, settingId) {
-  if (draggedSettingId.value == null || draggedSettingId.value === settingId) {
-    dropTarget.value = null
-    return
-  }
-
-  const bounds = event.currentTarget.getBoundingClientRect()
-  dropTarget.value = {
-    id: settingId,
-    after: event.clientY >= bounds.top + bounds.height / 2,
-  }
-  event.dataTransfer.dropEffect = 'move'
-}
-
-function dropQuickSetting(event, settingId) {
-  const draggedId = draggedSettingId.value
-  if (draggedId == null || draggedId === settingId) {
-    stopDragging()
-    return
-  }
-
-  const sourceIndex = quickSettings.value.indexOf(draggedId)
-  const targetIndex = quickSettings.value.indexOf(settingId)
-  if (sourceIndex === -1 || targetIndex === -1) {
-    stopDragging()
-    return
-  }
-
-  const bounds = event.currentTarget.getBoundingClientRect()
-  let insertIndex = targetIndex + (event.clientY >= bounds.top + bounds.height / 2 ? 1 : 0)
-  const reordered = quickSettings.value.slice()
-  reordered.splice(sourceIndex, 1)
-  if (sourceIndex < insertIndex) insertIndex--
-  reordered.splice(insertIndex, 0, draggedId)
-  store.dispatch('updateQuickSettings', reordered)
-  announceQuickSettingMoved(draggedId, insertIndex)
-  stopDragging()
-}
-
-function stopDragging() {
-  draggedSettingId.value = null
-  dropTarget.value = null
-}
+const {
+  draggedItemId: draggedSettingId,
+  dropTarget,
+  dropItem: dropQuickSetting,
+  handleDragOver,
+  startDragging,
+  stopDragging,
+} = useOrderedItemDrag({
+  items: quickSettings,
+  rowSelector: '.selectedSetting',
+  updateItems: items => store.dispatch('updateQuickSettings', items),
+  announceMoved: announceQuickSettingMoved,
+})
 
 function resetQuickSettings() {
   return store.dispatch('updateQuickSettings', [...DEFAULT_QUICK_SETTINGS])
@@ -332,8 +298,9 @@ function resetQuickSettings() {
 </script>
 
 <style scoped>
-.quickSettingsLauncher {
+.customizerLaunchers {
   display: flex;
+  flex-wrap: wrap;
   justify-content: center;
 }
 
@@ -380,6 +347,11 @@ function resetQuickSettings() {
   margin-inline-end: var(--scrollbar-track-width);
 }
 
+.settingPicker :deep(.optionWrapper) {
+  cursor: pointer;
+  user-select: none;
+}
+
 .selectedSettings {
   display: grid;
   gap: 8px;
@@ -400,6 +372,7 @@ function resetQuickSettings() {
   grid-template-columns: 44px 24px minmax(0, 1fr) auto;
   min-block-size: 56px;
   position: relative;
+  user-select: none;
 }
 
 .selectedSetting.dragging {

--- a/src/renderer/components/SideNav/SideNav.vue
+++ b/src/renderer/components/SideNav/SideNav.vue
@@ -18,171 +18,32 @@
         aria-hidden="true"
       />
       <router-link
-        v-if="!hideHome"
-        class="navOption topNavOption mobileShow"
+        v-for="(item, index) in visibleNavigationItems"
+        :key="item.id"
+        class="navOption"
+        :class="{
+          topNavOption: index === 0,
+          mobileHidden: !mobilePrimaryItemIds.has(item.id),
+        }"
         role="button"
-        to="/home"
-        :title="$t('Home Page.Home')"
+        :to="`/${item.id}`"
+        :title="item.id === 'history' ? historyTitle : item.label"
       >
         <div class="thumbnailContainer">
           <FtIcon
-            :icon="['fas', 'house']"
+            :icon="item.icon"
             class="navIcon"
             :class="applyNavIconExpand"
           />
         </div>
         <p class="navLabel">
-          {{ $t('Home Page.Home') }}
+          {{ item.label }}
         </p>
       </router-link>
-      <router-link
-        class="navOption mobileShow"
-        role="button"
-        to="/subscriptions"
-        :title="$t('Subscriptions.Subscriptions')"
-      >
-        <div
-          class="thumbnailContainer"
-        >
-          <FtIcon
-            :icon="['fas', 'rss']"
-            class="navIcon"
-            :class="applyNavIconExpand"
-          />
-        </div>
-        <p
-          class="navLabel"
-        >
-          {{ $t("Subscriptions.Subscriptions") }}
-        </p>
-      </router-link>
-      <router-link
-        class="navOption mobileHidden"
-        role="button"
-        to="/subscribedchannels"
-        :title="$t('Channels.Channels')"
-      >
-        <div
-          class="thumbnailContainer"
-        >
-          <FtIcon
-            :icon="['fas', 'user-check']"
-            class="navIcon"
-            :class="applyNavIconExpand"
-          />
-        </div>
-        <p
-          class="navLabel"
-        >
-          {{ $t("Channels.Channels") }}
-        </p>
-      </router-link>
-      <router-link
-        v-if="trendingAvailable && !hideTrendingVideos"
-        class="navOption mobileHidden"
-        role="button"
-        to="/trending"
-        :title="$t('Trending.Trending')"
-      >
-        <div
-          class="thumbnailContainer"
-        >
-          <FtIcon
-            :icon="['fas', 'fire']"
-            class="navIcon"
-            :class="applyNavIconExpand"
-          />
-        </div>
-        <p
-          class="navLabel"
-        >
-          {{ $t("Trending.Trending") }}
-        </p>
-      </router-link>
-      <router-link
-        v-if="popularAvailable && !hidePopularVideos"
-        class="navOption mobileHidden"
-        role="button"
-        to="/popular"
-        :title="$t('Most Popular')"
-      >
-        <div
-          class="thumbnailContainer"
-        >
-          <FtIcon
-            :icon="['fas', 'users']"
-            class="navIcon"
-            :class="applyNavIconExpand"
-          />
-        </div>
-        <p
-          class="navLabel"
-        >
-          {{ $t("Most Popular") }}
-        </p>
-      </router-link>
-      <router-link
-        v-if="!hidePlaylists"
-        class="navOption mobileShow"
-        role="button"
-        to="/userplaylists"
-        :title="$t('Playlists')"
-      >
-        <div
-          class="thumbnailContainer"
-        >
-          <FtIcon
-            :icon="['fas', 'bookmark']"
-            class="navIcon"
-            :class="applyNavIconExpand"
-          />
-        </div>
-        <p
-          class="navLabel"
-        >
-          {{ $t("Playlists") }}
-        </p>
-      </router-link>
-      <SideNavMoreOptions />
-      <router-link
-        class="navOption mobileShow"
-        role="button"
-        to="/history"
-        :title="historyTitle"
-      >
-        <div
-          class="thumbnailContainer"
-        >
-          <FtIcon
-            :icon="['fas', 'history']"
-            class="navIcon"
-            :class="applyNavIconExpand"
-          />
-        </div>
-        <p
-          class="navLabel"
-        >
-          {{ $t("History.History") }}
-        </p>
-      </router-link>
-      <router-link
-        v-if="showWatchStats"
-        class="navOption mobileHidden"
-        role="button"
-        to="/stats"
-        :title="$t('Stats.Stats')"
-      >
-        <div class="thumbnailContainer">
-          <FtIcon
-            :icon="['fas', 'chart-line']"
-            class="navIcon"
-            :class="applyNavIconExpand"
-          />
-        </div>
-        <p class="navLabel">
-          {{ $t('Stats.Stats') }}
-        </p>
-      </router-link>
+      <SideNavMoreOptions
+        v-if="mobileOverflowItems.length > 0"
+        :items="mobileOverflowItems"
+      />
       <hr>
       <div
         v-if="!hideActiveSubscriptions"
@@ -250,9 +111,10 @@ import SideNavMoreOptions from '../SideNavMoreOptions/SideNavMoreOptions.vue'
 import store from '../../store/index'
 
 import { youtubeImageUrlToInvidious } from '../../helpers/api/invidious'
-import { isMostPopularAvailable, isTrendingAvailable } from '../../helpers/navigationAvailability'
+import { filterAvailableNavigationItems } from '../../../navigationAvailability'
 import { deepCopy, localizeAndAddKeyboardShortcutToActionTitle } from '../../helpers/utils'
 import { getConfiguredKeyboardShortcuts } from '../../../constants'
+import { NAVIGATION_ITEM_DEFINITIONS } from '../../../navigationItems'
 
 const { locale, t } = useI18n()
 const appKeyboardShortcuts = computed(() => getConfiguredKeyboardShortcuts(
@@ -283,17 +145,6 @@ const backendFallback = computed(() => {
 const backendPreference = computed(() => {
   return store.getters.getBackendPreference
 })
-
-const trendingAvailable = computed(() => isTrendingAvailable({
-  supportsLocalApi: !!SUPPORTS_LOCAL_API,
-  backendPreference: backendPreference.value,
-  backendFallback: backendFallback.value,
-}))
-
-const popularAvailable = computed(() => isMostPopularAvailable({
-  backendPreference: backendPreference.value,
-  backendFallback: backendFallback.value,
-}))
 
 /** @type {import('vue').ComputedRef<string>} */
 const currentInvidiousInstanceUrl = computed(() => {
@@ -348,26 +199,6 @@ function onActiveSubscriptionsVisibilityChanged(isVisible) {
 }
 
 /** @type {import('vue').ComputedRef<boolean>} */
-const hidePopularVideos = computed(() => {
-  return store.getters.getHidePopularVideos
-})
-
-/** @type {import('vue').ComputedRef<boolean>} */
-const hideHome = computed(() => {
-  return store.getters.getHideHome
-})
-
-/** @type {import('vue').ComputedRef<boolean>} */
-const hidePlaylists = computed(() => {
-  return store.getters.getHidePlaylists
-})
-
-/** @type {import('vue').ComputedRef<boolean>} */
-const hideTrendingVideos = computed(() => {
-  return store.getters.getHideTrendingVideos
-})
-
-/** @type {import('vue').ComputedRef<boolean>} */
 const hideActiveSubscriptions = computed(() => {
   return store.getters.getHideActiveSubscriptions
 })
@@ -376,6 +207,35 @@ const hideActiveSubscriptions = computed(() => {
 const showWatchStats = computed(() => {
   return store.getters.getRememberHistory && store.getters.getEnableWatchStats
 })
+
+const navigationCatalog = computed(() => new Map(NAVIGATION_ITEM_DEFINITIONS.map(item => [
+  item.id,
+  {
+    ...item,
+    // eslint-disable-next-line @intlify/vue-i18n/no-dynamic-keys
+    label: t(item.labelKey),
+  },
+])))
+
+const visibleNavigationItems = computed(() => filterAvailableNavigationItems(
+  store.getters.getNavigationItems,
+  {
+    supportsLocalApi: !!SUPPORTS_LOCAL_API,
+    backendPreference: backendPreference.value,
+    backendFallback: backendFallback.value,
+    showWatchStats: showWatchStats.value,
+  }
+)
+  .map(id => navigationCatalog.value.get(id))
+  .filter(item => item != null))
+
+const mobilePrimaryItems = computed(() => visibleNavigationItems.value.length > 5
+  ? visibleNavigationItems.value.slice(0, 4)
+  : visibleNavigationItems.value)
+const mobilePrimaryItemIds = computed(() => new Set(mobilePrimaryItems.value.map(({ id }) => id)))
+const mobileOverflowItems = computed(() => visibleNavigationItems.value.length > 5
+  ? visibleNavigationItems.value.slice(4)
+  : [])
 
 /** @type {import('vue').ComputedRef<boolean>} */
 const hideText = computed(() => {
@@ -417,11 +277,11 @@ let navMutationObserver = null
 function updateIndicator() {
   const inner = innerRef.value
   const mobile = window.matchMedia('(max-width: 680px)').matches
-  // Skip hidden matches (e.g. links inside the collapsed "More" menu)
+  // Hidden overflow links use the visible More button as their mobile target.
   const active = inner == null
     ? null
     : Array.from(inner.querySelectorAll(mobile
-        ? ':scope > .navOption.router-link-active'
+        ? ':scope > .navOption.router-link-active, :scope > .sideNavMoreOptions > .moreOptionNav.router-link-active'
         : '.navOption.router-link-active, .navChannel.router-link-active'))
         .find((el) => el instanceof HTMLElement && el.offsetParent !== null)
 

--- a/src/renderer/components/SideNavMoreOptions/SideNavMoreOptions.vue
+++ b/src/renderer/components/SideNavMoreOptions/SideNavMoreOptions.vue
@@ -5,9 +5,12 @@
   >
     <div
       class="navOption moreOptionNav"
+      :class="{ 'router-link-active': overflowRouteActive }"
       tabindex="0"
       role="button"
-      aria-labelledby="moreNavLabel"
+      :aria-labelledby="hideLabelsSideBar ? null : 'moreNavLabel'"
+      :aria-label="hideLabelsSideBar ? $t('More') : null"
+      :aria-expanded="openMoreOptions"
       :title="$t('More')"
       @click="openMoreOptions = !openMoreOptions"
       @keydown.enter.space.prevent="openMoreOptions = !openMoreOptions"
@@ -30,81 +33,16 @@
       class="moreOptionContainer"
     >
       <router-link
-        class="navOption mobileHidden"
-        :title="$t('Channels.Channels')"
-        :aria-label="hideLabelsSideBar ? $t('Channels.Channels') : null"
-        to="/subscribedchannels"
-        @click="closeMenu"
-      >
-        <div
-          class="thumbnailContainer"
-        >
-          <FtIcon
-            :icon="['fas', 'user-check']"
-            class="navIcon"
-            :class="applyNavIconExpand"
-          />
-        </div>
-        <p
-          v-if="!hideLabelsSideBar"
-          id="channelLabel"
-          class="navLabel"
-        >
-          {{ $t("Channels.Channels") }}
-        </p>
-      </router-link>
-      <router-link
-        v-if="trendingVisible"
+        v-for="item in items"
+        :key="item.id"
         class="navOption"
-        :title="$t('Trending.Trending')"
-        :aria-label="hideLabelsSideBar ? $t('Trending.Trending') : null"
-        to="/trending"
+        :title="item.label"
+        :aria-label="hideLabelsSideBar ? item.label : null"
+        :to="`/${item.id}`"
         @click="closeMenu"
       >
         <FtIcon
-          :icon="['fas', 'fire']"
-          class="navIcon"
-          :class="applyNavIconExpand"
-        />
-        <p
-          v-if="!hideLabelsSideBar"
-          id="trendingNavLabel"
-          class="navLabel"
-        >
-          {{ $t("Trending.Trending") }}
-        </p>
-      </router-link>
-      <router-link
-        v-if="popularVisible"
-        class="navOption"
-        :title="$t('Most Popular')"
-        :aria-label="hideLabelsSideBar ? $t('Most Popular') : null"
-        to="/popular"
-        @click="closeMenu"
-      >
-        <FtIcon
-          :icon="['fas', 'users']"
-          class="navIcon"
-          :class="applyNavIconExpand"
-        />
-        <p
-          v-if="!hideLabelsSideBar"
-          id="mostPopularNavLabel"
-          class="navLabel"
-        >
-          {{ $t("Most Popular") }}
-        </p>
-      </router-link>
-      <router-link
-        v-if="showWatchStats"
-        class="navOption"
-        :title="$t('Stats.Stats')"
-        :aria-label="hideLabelsSideBar ? $t('Stats.Stats') : null"
-        to="/stats"
-        @click="closeMenu"
-      >
-        <FtIcon
-          :icon="['fas', 'chart-line']"
+          :icon="item.icon"
           class="navIcon"
           :class="applyNavIconExpand"
         />
@@ -112,72 +50,36 @@
           v-if="!hideLabelsSideBar"
           class="navLabel"
         >
-          {{ $t('Stats.Stats') }}
+          {{ item.label }}
         </p>
       </router-link>
     </div>
-    <router-link
-      class="navOption navOptionButton mobileShow"
-      :title="$t('History.History')"
-      :aria-label="hideLabelsSideBar ? $t('History.History'): null"
-      to="/history"
-    >
-      <FtIcon
-        :icon="['fas', 'history']"
-        class="navIcon"
-        :class="applyNavIconExpand"
-      />
-      <p
-        id="historyNavLabel"
-        class="navLabel"
-      >
-        {{ $t("History.History") }}
-      </p>
-    </router-link>
   </div>
 </template>
 
 <script setup>
 import { FtIcon } from '@opentubex/icons'
 import { computed, ref, onMounted, onBeforeUnmount, useTemplateRef } from 'vue'
-import { useRouter } from 'vue-router'
+import { useRoute, useRouter } from 'vue-router'
 
 import store from '../../store/index'
-import { isMostPopularAvailable, isTrendingAvailable } from '../../helpers/navigationAvailability'
 
-const SUPPORTS_LOCAL_API = process.env.SUPPORTS_LOCAL_API
+const props = defineProps({
+  items: {
+    type: Array,
+    required: true,
+  },
+})
 
 const openMoreOptions = ref(false)
+const route = useRoute()
 
 const menuRef = useTemplateRef('menuRef')
-
-/** @type {import('vue').ComputedRef<boolean>} */
-const trendingVisible = computed(() => {
-  return !store.getters.getHideTrendingVideos &&
-    isTrendingAvailable({
-      supportsLocalApi: !!SUPPORTS_LOCAL_API,
-      backendPreference: store.getters.getBackendPreference,
-      backendFallback: store.getters.getBackendFallback,
-    })
-})
+const overflowRouteActive = computed(() => props.items.some(item => route.path === `/${item.id}`))
 
 /** @type {import('vue').ComputedRef<boolean>} */
 const hideLabelsSideBar = computed(() => {
   return store.getters.getHideLabelsSideBar
-})
-
-/** @type {import('vue').ComputedRef<boolean>} */
-const popularVisible = computed(() => {
-  return !store.getters.getHidePopularVideos &&
-    isMostPopularAvailable({
-      backendPreference: store.getters.getBackendPreference,
-      backendFallback: store.getters.getBackendFallback,
-    })
-})
-
-/** @type {import('vue').ComputedRef<boolean>} */
-const showWatchStats = computed(() => {
-  return store.getters.getRememberHistory && store.getters.getEnableWatchStats
 })
 
 const applyNavIconExpand = computed(() => {

--- a/src/renderer/components/SideNavMoreOptions/SideNavMoreOptions.vue
+++ b/src/renderer/components/SideNavMoreOptions/SideNavMoreOptions.vue
@@ -99,15 +99,16 @@ function handleClickOutside(event) {
 }
 
 const router = useRouter()
+let removeNavigationHook = null
 
 onMounted(() => {
   document.addEventListener('click', handleClickOutside)
-  router.afterEach(() => {
-    closeMenu()
-  })
+  removeNavigationHook = router.afterEach(closeMenu)
 })
 onBeforeUnmount(() => {
   document.removeEventListener('click', handleClickOutside)
+  removeNavigationHook?.()
+  removeNavigationHook = null
 })
 </script>
 

--- a/src/renderer/components/ThemeSettings.vue
+++ b/src/renderer/components/ThemeSettings.vue
@@ -267,7 +267,7 @@
           @change="updateTabBarPosition"
         />
       </FtFlexBox>
-      <FtFlexBox>
+      <FtFlexBox class="tabSettingsRow">
         <div class="switchColumn">
           <FtSlider
             :label="$t('Settings.Theme Settings.Tab Width')"
@@ -1043,6 +1043,13 @@ function handleSmoothScrolling(value) {
   .themeSelectRow {
     align-items: center;
     flex-direction: column;
+  }
+
+  .tabSettingsRow {
+    align-items: center;
+    flex-direction: column;
+    gap: 12px;
+    justify-content: center;
   }
 
   .themeSelectRow :deep(.select) {

--- a/src/renderer/composables/useOrderedItemDrag.js
+++ b/src/renderer/composables/useOrderedItemDrag.js
@@ -1,0 +1,76 @@
+import { ref } from 'vue'
+
+/**
+ * Shares pointer drag reordering between ordered settings lists.
+ *
+ * @param {object} options
+ * @param {import('vue').ComputedRef<string[]>} options.items
+ * @param {string} options.rowSelector
+ * @param {(items: string[]) => unknown} options.updateItems
+ * @param {(itemId: string, position: number) => void} options.announceMoved
+ */
+export function useOrderedItemDrag({ items, rowSelector, updateItems, announceMoved }) {
+  const draggedItemId = ref(null)
+  const dropTarget = ref(null)
+
+  function startDragging(event, itemId) {
+    draggedItemId.value = itemId
+    event.dataTransfer.effectAllowed = 'move'
+    event.dataTransfer.setData('text/plain', itemId)
+    const row = event.currentTarget.closest(rowSelector)
+    if (row !== null) event.dataTransfer.setDragImage(row, 20, 20)
+  }
+
+  function handleDragOver(event, itemId) {
+    if (draggedItemId.value == null || draggedItemId.value === itemId) {
+      dropTarget.value = null
+      return
+    }
+
+    const bounds = event.currentTarget.getBoundingClientRect()
+    dropTarget.value = {
+      id: itemId,
+      after: event.clientY >= bounds.top + bounds.height / 2,
+    }
+    event.dataTransfer.dropEffect = 'move'
+  }
+
+  function dropItem(event, itemId) {
+    const draggedId = draggedItemId.value
+    if (draggedId == null || draggedId === itemId) {
+      stopDragging()
+      return
+    }
+
+    const sourceIndex = items.value.indexOf(draggedId)
+    const targetIndex = items.value.indexOf(itemId)
+    if (sourceIndex === -1 || targetIndex === -1) {
+      stopDragging()
+      return
+    }
+
+    const bounds = event.currentTarget.getBoundingClientRect()
+    let insertIndex = targetIndex + (event.clientY >= bounds.top + bounds.height / 2 ? 1 : 0)
+    const reordered = items.value.slice()
+    reordered.splice(sourceIndex, 1)
+    if (sourceIndex < insertIndex) insertIndex--
+    reordered.splice(insertIndex, 0, draggedId)
+    updateItems(reordered)
+    announceMoved(draggedId, insertIndex)
+    stopDragging()
+  }
+
+  function stopDragging() {
+    draggedItemId.value = null
+    dropTarget.value = null
+  }
+
+  return {
+    draggedItemId,
+    dropTarget,
+    dropItem,
+    handleDragOver,
+    startDragging,
+    stopDragging,
+  }
+}

--- a/src/renderer/helpers/commandPaletteRegistry.js
+++ b/src/renderer/helpers/commandPaletteRegistry.js
@@ -4,7 +4,7 @@ import {
   KeyboardShortcuts,
 } from '../../constants'
 import { createSettingsSearchIndex } from './settingsSearch'
-import { isMostPopularAvailable, isTrendingAvailable } from './navigationAvailability'
+import { isMostPopularAvailable, isTrendingAvailable } from '../../navigationAvailability'
 import { getTabAvatarUrl, getTabPageIcon } from '../tabs/tabPreview'
 import { switchActiveProfile, translateProfileName } from './profileSwitching'
 import { getFirstCharacter } from './strings'

--- a/src/renderer/helpers/quickSettings.js
+++ b/src/renderer/helpers/quickSettings.js
@@ -56,8 +56,6 @@ export const BASIC_QUICK_SETTING_DEFINITIONS = Object.freeze([
   ['showToastTimeoutIndicator', 'Settings.Theme Settings.Show Toast Timeout Indicator', 'appearance', ['fas', 'message']],
   ['useSponsorBlock', 'Settings.SponsorBlock Settings.Enable SponsorBlock', 'add-ons', ['fas', 'forward']],
   ['useReturnYouTubeDislikes', 'Settings.Return YouTube Dislike Settings.Enable Return YouTube Dislike', 'add-ons', ['fas', 'thumbs-down']],
-  ['hideTrendingVideos', 'Settings.Distraction Free Settings.Hide Trending Videos', 'content', ['fas', 'fire']],
-  ['hidePopularVideos', 'Settings.Distraction Free Settings.Hide Popular Videos', 'content', ['fas', 'users']],
 ].map(definition => Object.freeze(Array.isArray(definition)
   ? {
       id: definition[0],
@@ -132,31 +130,6 @@ export function isQuickSettingPaired(settings, settingIndex) {
 
   const positionInRun = settingIndex - runStart
   return positionInRun % 2 === 1 || settings[settingIndex + 1]?.control === 'select'
-}
-
-/**
- * Moves a setting relative to its visible neighbors while preserving settings
- * that are unavailable on the current platform.
- *
- * @param {string[]} settings
- * @param {string[]} visibleSettings
- * @param {string} settingId
- * @param {number} offset
- * @returns {string[]}
- */
-export function moveQuickSettingByVisibleOffset(settings, visibleSettings, settingId, offset) {
-  const visibleIndex = visibleSettings.indexOf(settingId)
-  const targetId = visibleSettings[visibleIndex + offset]
-  if (visibleIndex === -1 || targetId == null) return settings
-
-  const reordered = settings.slice()
-  const sourceIndex = reordered.indexOf(settingId)
-  if (sourceIndex === -1) return settings
-
-  reordered.splice(sourceIndex, 1)
-  const targetIndex = reordered.indexOf(targetId)
-  reordered.splice(targetIndex + (offset > 0 ? 1 : 0), 0, settingId)
-  return reordered
 }
 
 export const DEFAULT_QUICK_SETTINGS = Object.freeze([

--- a/src/renderer/helpers/settings-migrations.js
+++ b/src/renderer/helpers/settings-migrations.js
@@ -1,3 +1,5 @@
+import { navigationItemsFromLegacySettings } from '../../navigationItems.js'
+
 /**
  * Replaces setting keys that were renamed between exported settings formats.
  * Current keys take precedence when an import contains both versions.
@@ -6,6 +8,20 @@
  */
 export function migrateLegacySettings(settings) {
   const migratedSettings = { ...settings }
+
+  const formerNavigationKeys = [
+    'hideHome',
+    'hidePopularVideos',
+    'hideTrendingVideos',
+  ]
+  const navigationMigrationKeys = [...formerNavigationKeys, 'hidePlaylists']
+  if (
+    !Object.hasOwn(migratedSettings, 'navigationItems') &&
+    navigationMigrationKeys.some(key => Object.hasOwn(migratedSettings, key))
+  ) {
+    migratedSettings.navigationItems = navigationItemsFromLegacySettings(migratedSettings)
+  }
+  for (const key of formerNavigationKeys) delete migratedSettings[key]
 
   if (Object.hasOwn(migratedSettings, 'showSubscriptionRefreshToast')) {
     if (!Object.hasOwn(migratedSettings, 'showProgressBarToast')) {

--- a/src/renderer/helpers/settings-search-config.js
+++ b/src/renderer/helpers/settings-search-config.js
@@ -23,6 +23,7 @@ const GENERAL_EVERYDAY_KEYS = new Set([
 
 const GENERAL_APPEARANCE_KEYS = new Set([
   'Mobile Layout',
+  'Navigation',
   'Playlist View Type',
   'Show Thumbnail Previews',
   'Thumbnail Preference',
@@ -105,7 +106,12 @@ export const SETTINGS_SEARCH_SOURCES = {
   }],
   focus: [{
     type: 'distraction',
-    key: 'Settings.Distraction Free Settings'
+    key: 'Settings.Distraction Free Settings',
+    exclude: new Set([
+      'Hide Home',
+      'Hide Popular Videos',
+      'Hide Trending Videos',
+    ])
   }, {
     type: 'parental-control',
     key: 'Settings.Parental Control Settings'

--- a/src/renderer/store/modules/settings.js
+++ b/src/renderer/store/modules/settings.js
@@ -41,6 +41,12 @@ import { isSettingSyncableOnPlatform } from '../../helpers/platformSettings.js'
 import { CUSTOM_THEMES_SYNC_KEY } from '../../../customTheme.js'
 import { DEFAULT_QUICK_SETTINGS, normalizeQuickSettings } from '../../helpers/quickSettings.js'
 import { createSettingUpdateQueue } from '../../helpers/settingUpdateQueue.js'
+import { filterAvailableNavigationItems } from '../../../navigationAvailability.js'
+import {
+  DEFAULT_NAVIGATION_ITEMS,
+  navigationItemsFromLegacySettings,
+  normalizeNavigationItems,
+} from '../../../navigationItems.js'
 
 const CHANNEL_SETTINGS_SYNC_MIGRATION_SETTING = 'channelSettingsSyncMigration'
 const TUTORIAL_STATE_SETTING_IDS = new Set([
@@ -324,7 +330,9 @@ const state = {
   hideLiveChatReplay: false,
   hideLiveStreams: false,
   hideHeaderLogo: false,
+  // Former navigation switches remain loadable so older settings can migrate.
   hideHome: false,
+  // This also controls playlist actions outside navigation.
   hidePlaylists: false,
   hidePopularVideos: false,
   hideRecommendedVideos: false,
@@ -368,6 +376,7 @@ const state = {
   listType: 'grid',
   playlistViewType: 'grid',
   quickSettings: [...DEFAULT_QUICK_SETTINGS],
+  navigationItems: [...DEFAULT_NAVIGATION_ITEMS],
   maxVideoPlaybackRate: 3,
   onlyShowLatestFromChannel: false,
   onlyShowLatestFromChannelNumber: 1,
@@ -843,7 +852,17 @@ const customState = {
 const customGetters = {
   getQuickSettings: (state) => normalizeQuickSettings(state.quickSettings),
 
-  getLandingPage: (state) => resolveLandingPage(state.landingPage, state.hideHome),
+  getNavigationItems: (state) => normalizeNavigationItems(state.navigationItems),
+
+  getLandingPage: (state) => resolveLandingPage(
+    state.landingPage,
+    filterAvailableNavigationItems(normalizeNavigationItems(state.navigationItems), {
+      supportsLocalApi: !!process.env.SUPPORTS_LOCAL_API,
+      backendPreference: state.backendPreference,
+      backendFallback: state.backendFallback,
+      showWatchStats: state.rememberHistory && state.enableWatchStats,
+    })
+  ),
 
   getPlaylistBookmarks: (state) => {
     return Array.isArray(state.playlistBookmarks) ? state.playlistBookmarks : []
@@ -927,6 +946,13 @@ const customActions = {
     state,
     'quickSettings',
     normalizeQuickSettings(value)
+  ),
+
+  updateNavigationItems: ({ commit, state }, value) => updateValidatedSetting(
+    commit,
+    state,
+    'navigationItems',
+    normalizeNavigationItems(value)
   ),
 
   savePlaylistBookmark: async ({ commit, getters }, bookmark) => {
@@ -1084,6 +1110,13 @@ const customActions = {
         if (mutationIds.includes(defaultMutationId(_id))) {
           commit(defaultMutationId(_id), resolvedValue)
         }
+      }
+
+      const hasNavigationItems = userSettings.some(entry => entry._id === 'navigationItems')
+      if (!hasNavigationItems && userSettings.length > 0) {
+        await dispatch('updateNavigationItems', navigationItemsFromLegacySettings(
+          Object.fromEntries(userSettings.map(({ _id, value }) => [_id, value]))
+        ))
       }
 
       const preferredCaptionLocaleEntry = userSettings.find(
@@ -1271,9 +1304,12 @@ const customActions = {
             }
 
             commit(defaultMutationId(data._id), data.value)
-            if (data._id === 'hideHome' && data.value === true) {
+            if (
+              data._id === 'navigationItems' &&
+              !normalizeNavigationItems(data.value).includes('home')
+            ) {
               dispatch('redirectHomeTabsToLandingPage').catch(error => {
-                console.error('Failed to redirect Home tabs after syncing Hide Home', error)
+                console.error('Failed to redirect Home tabs after syncing navigation items', error)
               })
             }
             if (data._id === 'syncServerEnabled') {

--- a/static/locales/ai/ar.yaml
+++ b/static/locales/ai/ar.yaml
@@ -219,6 +219,10 @@ Settings:
       Network: شبكة
       Disk: القرص
   General Settings:
+    Navigation:
+      Navigation: التنقل
+      Customize Navigation: تخصيص التنقل
+      Add Item: إضافة عنصر
     Date Format: تنسيق التاريخ
     Time Format: تنسيق الوقت
     Language Default: الإعداد الافتراضي للغة

--- a/static/locales/ai/be.yaml
+++ b/static/locales/ai/be.yaml
@@ -231,6 +231,10 @@ Settings:
       Network: сетка
       Disk: дыск
   General Settings:
+    Navigation:
+      Navigation: Навігацыя
+      Customize Navigation: Наладзіць навігацыю
+      Add Item: Дадаць элемент
     Date Format: Фармат даты
     Time Format: Фармат часу
     Language Default: Паводле мовы

--- a/static/locales/ai/bg.yaml
+++ b/static/locales/ai/bg.yaml
@@ -217,6 +217,10 @@ Settings:
       Network: мрежата
       Disk: диска
   General Settings:
+    Navigation:
+      Navigation: Навигация
+      Customize Navigation: Персонализиране на навигацията
+      Add Item: Добавяне на елемент
     Date Format: Формат на датата
     Time Format: Формат на часа
     Language Default: По подразбиране за езика

--- a/static/locales/ai/br.yaml
+++ b/static/locales/ai/br.yaml
@@ -215,6 +215,10 @@ Settings:
       Network: "ar rouedad"
       Disk: "ar bladenn"
   General Settings:
+    Navigation:
+      Navigation: Merdeiñ
+      Customize Navigation: Personelaat ar merdeiñ
+      Add Item: Ouzhpennañ un elfenn
     Date Format: Mentrezh an deiziad
     Time Format: Mentrezh an eur
     Language Default: Dre ziouer ar yezh

--- a/static/locales/ai/ca.yaml
+++ b/static/locales/ai/ca.yaml
@@ -342,6 +342,10 @@ Settings:
       Disk: disc
   Return to Settings Menu: Torna al menú de configuració
   General Settings:
+    Navigation:
+      Navigation: Navegació
+      Customize Navigation: Personalitza la navegació
+      Add Item: Afegeix un element
     Date Format: Format de data
     Time Format: Format d'hora
     Language Default: Predeterminat de l'idioma

--- a/static/locales/ai/cs.yaml
+++ b/static/locales/ai/cs.yaml
@@ -215,6 +215,10 @@ Settings:
       Network: sítě
       Disk: disku
   General Settings:
+    Navigation:
+      Navigation: Navigace
+      Customize Navigation: Přizpůsobit navigaci
+      Add Item: Přidat položku
     Date Format: Formát data
     Time Format: Formát času
     Language Default: Výchozí podle jazyka

--- a/static/locales/ai/cy.yaml
+++ b/static/locales/ai/cy.yaml
@@ -217,6 +217,10 @@ Settings:
       Network: rhwydwaith
       Disk: disg
   General Settings:
+    Navigation:
+      Navigation: Llywio
+      Customize Navigation: Addasu'r llywio
+      Add Item: Ychwanegu eitem
     Date Format: Fformat dyddiad
     Time Format: Fformat amser
     Language Default: Rhagosodiad yr iaith

--- a/static/locales/ai/da.yaml
+++ b/static/locales/ai/da.yaml
@@ -226,6 +226,10 @@ Settings:
       Network: netværk
       Disk: diskplads
   General Settings:
+    Navigation:
+      Navigation: Navigation
+      Customize Navigation: Tilpas navigation
+      Add Item: Tilføj element
     Date Format: Datoformat
     Time Format: Tidsformat
     Language Default: Baseret på sprog

--- a/static/locales/ai/el.yaml
+++ b/static/locales/ai/el.yaml
@@ -219,6 +219,10 @@ Settings:
       Network: δικτύου
       Disk: δίσκου
   General Settings:
+    Navigation:
+      Navigation: Πλοήγηση
+      Customize Navigation: Προσαρμογή πλοήγησης
+      Add Item: Προσθήκη στοιχείου
     Date Format: Μορφή ημερομηνίας
     Time Format: Μορφή ώρας
     Language Default: Προεπιλογή γλώσσας

--- a/static/locales/ai/en-GB.yaml
+++ b/static/locales/ai/en-GB.yaml
@@ -214,6 +214,10 @@ Settings:
       Network: network
       Disk: disk
   General Settings:
+    Navigation:
+      Navigation: Navigation
+      Customize Navigation: Customise navigation
+      Add Item: Add item
     Date Format: Date format
     Time Format: Time format
     Language Default: Language default

--- a/static/locales/ai/es-AR.yaml
+++ b/static/locales/ai/es-AR.yaml
@@ -235,6 +235,10 @@ Settings:
       Network: red
       Disk: disco
   General Settings:
+    Navigation:
+      Navigation: Navegación
+      Customize Navigation: Personalizar navegación
+      Add Item: Agregar elemento
     Date Format: Formato de fecha
     Time Format: Formato de hora
     Language Default: Predeterminado del idioma

--- a/static/locales/ai/es-MX.yaml
+++ b/static/locales/ai/es-MX.yaml
@@ -243,6 +243,10 @@ Settings:
       Network: red
       Disk: disco
   General Settings:
+    Navigation:
+      Navigation: Navegación
+      Customize Navigation: Personalizar navegación
+      Add Item: Agregar elemento
     Date Format: Formato de fecha
     Time Format: Formato de hora
     Language Default: Predeterminado del idioma

--- a/static/locales/ai/es.yaml
+++ b/static/locales/ai/es.yaml
@@ -217,6 +217,10 @@ Settings:
       Network: red
       Disk: disco
   General Settings:
+    Navigation:
+      Navigation: Navegación
+      Customize Navigation: Personalizar navegación
+      Add Item: Añadir elemento
     Date Format: Formato de fecha
     Time Format: Formato de hora
     Language Default: Predeterminado del idioma

--- a/static/locales/ai/et.yaml
+++ b/static/locales/ai/et.yaml
@@ -215,6 +215,10 @@ Settings:
       Network: võrgu
       Disk: ketta
   General Settings:
+    Navigation:
+      Navigation: Navigeerimine
+      Customize Navigation: Kohanda navigeerimist
+      Add Item: Lisa üksus
     Date Format: Kuupäevavorming
     Time Format: Kellaajavorming
     Language Default: Keele vaikeseade

--- a/static/locales/ai/eu.yaml
+++ b/static/locales/ai/eu.yaml
@@ -217,6 +217,10 @@ Settings:
       Network: sarea
       Disk: diskoa
   General Settings:
+    Navigation:
+      Navigation: Nabigazioa
+      Customize Navigation: Pertsonalizatu nabigazioa
+      Add Item: Gehitu elementua
     Date Format: Data-formatua
     Time Format: Ordu-formatua
     Language Default: Hizkuntzaren lehenetsia

--- a/static/locales/ai/fa.yaml
+++ b/static/locales/ai/fa.yaml
@@ -232,6 +232,10 @@ Settings:
       Network: شبکه
       Disk: دیسک
   General Settings:
+    Navigation:
+      Navigation: پیمایش
+      Customize Navigation: سفارشی‌سازی پیمایش
+      Add Item: افزودن مورد
     Date Format: قالب تاریخ
     Time Format: قالب زمان
     Language Default: پیش‌فرض زبان

--- a/static/locales/ai/fi.yaml
+++ b/static/locales/ai/fi.yaml
@@ -219,6 +219,10 @@ Settings:
       Network: verkko
       Disk: levytila
   General Settings:
+    Navigation:
+      Navigation: Siirtyminen
+      Customize Navigation: Mukauta siirtymistä
+      Add Item: Lisää kohde
     Date Format: Päivämäärän muoto
     Time Format: Ajan muoto
     Language Default: Kielen oletus

--- a/static/locales/ai/fi.yaml
+++ b/static/locales/ai/fi.yaml
@@ -220,8 +220,8 @@ Settings:
       Disk: levytila
   General Settings:
     Navigation:
-      Navigation: Siirtyminen
-      Customize Navigation: Mukauta siirtymistä
+      Navigation: Navigointi
+      Customize Navigation: Mukauta navigointia
       Add Item: Lisää kohde
     Date Format: Päivämäärän muoto
     Time Format: Ajan muoto

--- a/static/locales/ai/fr-FR.yaml
+++ b/static/locales/ai/fr-FR.yaml
@@ -215,6 +215,10 @@ Settings:
       Network: le réseau
       Disk: le disque
   General Settings:
+    Navigation:
+      Navigation: Navigation
+      Customize Navigation: Personnaliser la navigation
+      Add Item: Ajouter un élément
     Date Format: Format de date
     Time Format: Format de l'heure
     Language Default: Valeur par défaut de la langue

--- a/static/locales/ai/gl.yaml
+++ b/static/locales/ai/gl.yaml
@@ -219,6 +219,10 @@ Settings:
       Network: rede
       Disk: disco
   General Settings:
+    Navigation:
+      Navigation: Navegación
+      Customize Navigation: Personalizar a navegación
+      Add Item: Engadir elemento
     Date Format: Formato da data
     Time Format: Formato da hora
     Language Default: Predeterminado do idioma

--- a/static/locales/ai/he.yaml
+++ b/static/locales/ai/he.yaml
@@ -219,6 +219,10 @@ Settings:
       Network: רשת
       Disk: כונן
   General Settings:
+    Navigation:
+      Navigation: ניווט
+      Customize Navigation: התאמה אישית של הניווט
+      Add Item: הוספת פריט
     Date Format: תבנית תאריך
     Time Format: תבנית שעה
     Language Default: ברירת המחדל של השפה

--- a/static/locales/ai/hr.yaml
+++ b/static/locales/ai/hr.yaml
@@ -217,6 +217,10 @@ Settings:
       Network: mreže
       Disk: diska
   General Settings:
+    Navigation:
+      Navigation: Navigacija
+      Customize Navigation: Prilagodi navigaciju
+      Add Item: Dodaj stavku
     Date Format: Format datuma
     Time Format: Format vremena
     Language Default: Zadano za jezik

--- a/static/locales/ai/hu.yaml
+++ b/static/locales/ai/hu.yaml
@@ -215,6 +215,10 @@ Settings:
       Network: hálózat
       Disk: lemez
   General Settings:
+    Navigation:
+      Navigation: Navigáció
+      Customize Navigation: Navigáció testreszabása
+      Add Item: Elem hozzáadása
     Date Format: Dátumformátum
     Time Format: Időformátum
     Language Default: Nyelvi alapértelmezés

--- a/static/locales/ai/id.yaml
+++ b/static/locales/ai/id.yaml
@@ -219,6 +219,10 @@ Settings:
       Network: jaringan
       Disk: disk
   General Settings:
+    Navigation:
+      Navigation: Navigasi
+      Customize Navigation: Sesuaikan navigasi
+      Add Item: Tambah item
     Date Format: Format tanggal
     Time Format: Format waktu
     Language Default: Default bahasa

--- a/static/locales/ai/is.yaml
+++ b/static/locales/ai/is.yaml
@@ -219,6 +219,10 @@ Settings:
       Network: nets
       Disk: disks
   General Settings:
+    Navigation:
+      Navigation: Leiðsögn
+      Customize Navigation: Sérsníða leiðsögn
+      Add Item: Bæta við atriði
     Date Format: Dagsetningarsnið
     Time Format: Tímasnið
     Language Default: Sjálfgefið fyrir tungumál

--- a/static/locales/ai/it.yaml
+++ b/static/locales/ai/it.yaml
@@ -215,6 +215,10 @@ Settings:
       Network: rete
       Disk: disco
   General Settings:
+    Navigation:
+      Navigation: Navigazione
+      Customize Navigation: Personalizza la navigazione
+      Add Item: Aggiungi elemento
     Date Format: Formato data
     Time Format: Formato ora
     Language Default: Predefinito della lingua

--- a/static/locales/ai/ja.yaml
+++ b/static/locales/ai/ja.yaml
@@ -215,6 +215,10 @@ Settings:
       Network: ネットワーク
       Disk: ディスク
   General Settings:
+    Navigation:
+      Navigation: ナビゲーション
+      Customize Navigation: ナビゲーションをカスタマイズ
+      Add Item: 項目を追加
     Date Format: 日付形式
     Time Format: 時刻形式
     Language Default: 言語の既定値

--- a/static/locales/ai/ko.yaml
+++ b/static/locales/ai/ko.yaml
@@ -303,6 +303,10 @@ Settings:
       Disk: 디스크
   Return to Settings Menu: 설정 메뉴로 돌아가기
   General Settings:
+    Navigation:
+      Navigation: 탐색
+      Customize Navigation: 탐색 맞춤 설정
+      Add Item: 항목 추가
     Date Format: 날짜 형식
     Time Format: 시간 형식
     Language Default: 언어 기본값

--- a/static/locales/ai/lt.yaml
+++ b/static/locales/ai/lt.yaml
@@ -328,6 +328,10 @@ Settings:
       Disk: disko
   Return to Settings Menu: Grįžti į nustatymų meniu
   General Settings:
+    Navigation:
+      Navigation: Naršymas
+      Customize Navigation: Tinkinti naršymą
+      Add Item: Pridėti elementą
     Date Format: Datos formatas
     Time Format: Laiko formatas
     Language Default: Pagal kalbą

--- a/static/locales/ai/nb-NO.yaml
+++ b/static/locales/ai/nb-NO.yaml
@@ -217,6 +217,10 @@ Settings:
       Network: nettverk
       Disk: disk
   General Settings:
+    Navigation:
+      Navigation: Navigasjon
+      Customize Navigation: Tilpass navigasjon
+      Add Item: Legg til element
     Date Format: Datoformat
     Time Format: Tidsformat
     Language Default: Språkstandard

--- a/static/locales/ai/nl.yaml
+++ b/static/locales/ai/nl.yaml
@@ -219,6 +219,10 @@ Settings:
       Network: netwerk
       Disk: schijf
   General Settings:
+    Navigation:
+      Navigation: Navigatie
+      Customize Navigation: Navigatie aanpassen
+      Add Item: Item toevoegen
     Date Format: Datumnotatie
     Time Format: Tijdnotatie
     Language Default: Standaard voor taal

--- a/static/locales/ai/nn.yaml
+++ b/static/locales/ai/nn.yaml
@@ -340,6 +340,10 @@ Settings:
       Disk: disk
   Return to Settings Menu: Tilbake til innstillingsmenyen
   General Settings:
+    Navigation:
+      Navigation: Navigasjon
+      Customize Navigation: Tilpass navigasjon
+      Add Item: Legg til element
     Date Format: Datoformat
     Time Format: Tidsformat
     Language Default: Språkstandard

--- a/static/locales/ai/pl.yaml
+++ b/static/locales/ai/pl.yaml
@@ -73,6 +73,10 @@ Settings:
     Advanced Description: Dostawcy, aplikacje zewnętrzne i sieć
     Alternative providers: Dostawcy filmów i metadanych
   General Settings:
+    Navigation:
+      Navigation: Nawigacja
+      Customize Navigation: Dostosuj nawigację
+      Add Item: Dodaj element
     Date Format: Format daty
     Time Format: Format czasu
     Language Default: Domyślny dla języka

--- a/static/locales/ai/pt-BR.yaml
+++ b/static/locales/ai/pt-BR.yaml
@@ -215,6 +215,10 @@ Settings:
       Network: rede
       Disk: disco
   General Settings:
+    Navigation:
+      Navigation: Navegação
+      Customize Navigation: Personalizar navegação
+      Add Item: Adicionar item
     Date Format: Formato da data
     Time Format: Formato de hora
     Language Default: Padrão do idioma

--- a/static/locales/ai/pt-PT.yaml
+++ b/static/locales/ai/pt-PT.yaml
@@ -219,6 +219,10 @@ Settings:
       Network: rede
       Disk: disco
   General Settings:
+    Navigation:
+      Navigation: Navegação
+      Customize Navigation: Personalizar navegação
+      Add Item: Adicionar item
     Date Format: Formato da data
     Time Format: Formato da hora
     Language Default: Predefinição do idioma

--- a/static/locales/ai/pt.yaml
+++ b/static/locales/ai/pt.yaml
@@ -219,6 +219,10 @@ Settings:
       Network: rede
       Disk: disco
   General Settings:
+    Navigation:
+      Navigation: Navegação
+      Customize Navigation: Personalizar navegação
+      Add Item: Adicionar item
     Date Format: Formato da data
     Time Format: Formato da hora
     Language Default: Predefinição do idioma

--- a/static/locales/ai/ro.yaml
+++ b/static/locales/ai/ro.yaml
@@ -217,6 +217,10 @@ Settings:
       Network: rețea
       Disk: disc
   General Settings:
+    Navigation:
+      Navigation: Navigare
+      Customize Navigation: Personalizează navigarea
+      Add Item: Adaugă element
     Date Format: Formatul datei
     Time Format: Formatul orei
     Language Default: Valoarea implicită a limbii

--- a/static/locales/ai/ru.yaml
+++ b/static/locales/ai/ru.yaml
@@ -194,6 +194,10 @@ Settings:
       Network: сеть
       Disk: диск
   General Settings:
+    Navigation:
+      Navigation: Навигация
+      Customize Navigation: Настроить навигацию
+      Add Item: Добавить элемент
     Date Format: Формат даты
     Time Format: Формат времени
     Language Default: По умолчанию для языка

--- a/static/locales/ai/sk.yaml
+++ b/static/locales/ai/sk.yaml
@@ -215,6 +215,10 @@ Settings:
       Network: sieť
       Disk: disk
   General Settings:
+    Navigation:
+      Navigation: Navigácia
+      Customize Navigation: Prispôsobiť navigáciu
+      Add Item: Pridať položku
     Date Format: Formát dátumu
     Time Format: Formát času
     Language Default: Predvolené pre jazyk

--- a/static/locales/ai/sl.yaml
+++ b/static/locales/ai/sl.yaml
@@ -335,6 +335,10 @@ Settings:
       Disk: disk
   Return to Settings Menu: Nazaj v meni z nastavitvami
   General Settings:
+    Navigation:
+      Navigation: Krmarjenje
+      Customize Navigation: Prilagodi krmarjenje
+      Add Item: Dodaj element
     Date Format: Oblika datuma
     Time Format: Oblika časa
     Language Default: Privzeto za jezik

--- a/static/locales/ai/sr.yaml
+++ b/static/locales/ai/sr.yaml
@@ -225,6 +225,10 @@ Settings:
       Network: мрежа
       Disk: диск
   General Settings:
+    Navigation:
+      Navigation: Навигација
+      Customize Navigation: Прилагоди навигацију
+      Add Item: Додај ставку
     Date Format: Формат датума
     Time Format: Формат времена
     Language Default: Подразумевано за језик

--- a/static/locales/ai/sv.yaml
+++ b/static/locales/ai/sv.yaml
@@ -217,6 +217,10 @@ Settings:
       Network: nätverk
       Disk: diskutrymme
   General Settings:
+    Navigation:
+      Navigation: Navigering
+      Customize Navigation: Anpassa navigeringen
+      Add Item: Lägg till objekt
     Date Format: Datumformat
     Time Format: Tidsformat
     Language Default: Språkstandard

--- a/static/locales/ai/ta.yaml
+++ b/static/locales/ai/ta.yaml
@@ -220,6 +220,10 @@ Settings:
       Network: பிணையம்
       Disk: வட்டு
   General Settings:
+    Navigation:
+      Navigation: வழிசெலுத்தல்
+      Customize Navigation: வழிசெலுத்தலைத் தனிப்பயனாக்கு
+      Add Item: உருப்படியைச் சேர்
     Date Format: தேதி வடிவம்
     Time Format: நேர வடிவம்
     Language Default: மொழி இயல்புநிலை

--- a/static/locales/ai/tr.yaml
+++ b/static/locales/ai/tr.yaml
@@ -215,6 +215,10 @@ Settings:
       Network: ağ
       Disk: disk
   General Settings:
+    Navigation:
+      Navigation: Gezinme
+      Customize Navigation: Gezinmeyi özelleştir
+      Add Item: Öğe ekle
     Date Format: Tarih biçimi
     Time Format: Saat biçimi
     Language Default: Dil varsayılanı

--- a/static/locales/ai/uk.yaml
+++ b/static/locales/ai/uk.yaml
@@ -219,6 +219,10 @@ Settings:
       Network: мережа
       Disk: диск
   General Settings:
+    Navigation:
+      Navigation: Навігація
+      Customize Navigation: Налаштувати навігацію
+      Add Item: Додати елемент
     Date Format: Формат дати
     Time Format: Формат часу
     Language Default: Типовий для мови

--- a/static/locales/ai/vi.yaml
+++ b/static/locales/ai/vi.yaml
@@ -219,6 +219,10 @@ Settings:
       Network: mạng
       Disk: ổ đĩa
   General Settings:
+    Navigation:
+      Navigation: Điều hướng
+      Customize Navigation: Tùy chỉnh điều hướng
+      Add Item: Thêm mục
     Date Format: Định dạng ngày
     Time Format: Định dạng thời gian
     Language Default: Mặc định theo ngôn ngữ

--- a/static/locales/ai/zh-CN.yaml
+++ b/static/locales/ai/zh-CN.yaml
@@ -215,6 +215,10 @@ Settings:
       Network: 网络
       Disk: 磁盘
   General Settings:
+    Navigation:
+      Navigation: 导航
+      Customize Navigation: 自定义导航
+      Add Item: 添加项目
     Date Format: 日期格式
     Time Format: 时间格式
     Language Default: 语言默认

--- a/static/locales/ai/zh-TW.yaml
+++ b/static/locales/ai/zh-TW.yaml
@@ -217,6 +217,10 @@ Settings:
       Network: 網路
       Disk: 磁碟
   General Settings:
+    Navigation:
+      Navigation: 導覽
+      Customize Navigation: 自訂導覽
+      Add Item: 新增項目
     Date Format: 日期格式
     Time Format: 時間格式
     Language Default: 語言預設

--- a/static/locales/de-DE.yaml
+++ b/static/locales/de-DE.yaml
@@ -303,6 +303,10 @@ Settings:
     Alternative providers: Video- und Metadatenanbieter
   General Settings:
     General Settings: Allgemein
+    Navigation:
+      Navigation: Navigation
+      Customize Navigation: Navigation anpassen
+      Add Item: Eintrag hinzufügen
     Mobile Layout:
       Mobile Layout: Mobiles Layout
       Automatic: Automatisch

--- a/static/locales/en-US.yaml
+++ b/static/locales/en-US.yaml
@@ -478,6 +478,10 @@ Settings:
     app needs to restart for changes to take effect. Restart and apply change?
   General Settings:
     General Settings: General
+    Navigation:
+      Navigation: Navigation
+      Customize Navigation: Customize navigation
+      Add Item: Add item
     Mobile Layout:
       Mobile Layout: Mobile layout
       Automatic: Automatic

--- a/tests/unit/landing-page.test.mjs
+++ b/tests/unit/landing-page.test.mjs
@@ -18,3 +18,15 @@ test('falls back to Subscriptions when Home is hidden', () => {
 test('keeps another configured landing page when Home is hidden', () => {
   assert.equal(resolveLandingPage('history', true), 'history')
 })
+
+test('falls back to the first visible navigation page', () => {
+  assert.equal(resolveLandingPage('home', ['history', 'subscriptions']), 'history')
+})
+
+test('keeps a landing page that remains in navigation', () => {
+  assert.equal(resolveLandingPage('history', ['subscriptions', 'history']), 'history')
+})
+
+test('keeps a usable fallback when navigation is empty', () => {
+  assert.equal(resolveLandingPage('home', []), LEGACY_DEFAULT_LANDING_PAGE)
+})

--- a/tests/unit/navigation-availability.test.mjs
+++ b/tests/unit/navigation-availability.test.mjs
@@ -2,9 +2,10 @@ import assert from 'node:assert/strict'
 import test from 'node:test'
 
 import {
+  filterAvailableNavigationItems,
   isMostPopularAvailable,
   isTrendingAvailable,
-} from '../../src/renderer/helpers/navigationAvailability.js'
+} from '../../src/navigationAvailability.js'
 
 test('exposes only navigation supported by the selected provider', () => {
   const localOnly = {
@@ -36,4 +37,16 @@ test('does not expose Trending in builds without the Local API', () => {
     backendPreference: 'local',
     backendFallback: true,
   }), false)
+})
+
+test('filters unavailable navigation items without changing their order', () => {
+  assert.deepEqual(filterAvailableNavigationItems(
+    ['history', 'stats', 'popular', 'home', 'trending'],
+    {
+      supportsLocalApi: true,
+      backendPreference: 'local',
+      backendFallback: false,
+      showWatchStats: false,
+    }
+  ), ['history', 'home', 'trending'])
 })

--- a/tests/unit/navigation-items.test.mjs
+++ b/tests/unit/navigation-items.test.mjs
@@ -1,0 +1,45 @@
+import assert from 'node:assert/strict'
+import test from 'node:test'
+
+import {
+  DEFAULT_NAVIGATION_ITEMS,
+  navigationItemsFromLegacySettings,
+  normalizeNavigationItems,
+} from '../../src/navigationItems.js'
+
+test('uses the mobile-first navigation order by default', () => {
+  assert.deepEqual(DEFAULT_NAVIGATION_ITEMS, [
+    'home',
+    'subscriptions',
+    'userplaylists',
+    'history',
+    'subscribedchannels',
+    'trending',
+    'popular',
+    'stats',
+  ])
+})
+
+test('keeps valid navigation items in the selected order', () => {
+  assert.deepEqual(
+    normalizeNavigationItems(['history', 'home', 'history', 'removed']),
+    ['history', 'home']
+  )
+})
+
+test('falls back to defaults only for an invalid stored value', () => {
+  assert.deepEqual(normalizeNavigationItems(null), DEFAULT_NAVIGATION_ITEMS)
+  assert.deepEqual(normalizeNavigationItems([]), [])
+})
+
+test('converts the former hide switches to navigation items', () => {
+  assert.deepEqual(
+    navigationItemsFromLegacySettings({
+      hideHome: true,
+      hidePlaylists: true,
+      hidePopularVideos: false,
+      hideTrendingVideos: true,
+    }),
+    ['subscriptions', 'history', 'subscribedchannels', 'popular', 'stats']
+  )
+})

--- a/tests/unit/ordered-items.test.mjs
+++ b/tests/unit/ordered-items.test.mjs
@@ -1,0 +1,16 @@
+import assert from 'node:assert/strict'
+import test from 'node:test'
+
+import { moveItemByVisibleOffset } from '../../src/orderedItems.js'
+
+test('moves visible items without dropping unavailable entries', () => {
+  assert.deepEqual(
+    moveItemByVisibleOffset(
+      ['home', 'trending', 'subscriptions', 'history'],
+      ['home', 'subscriptions', 'history'],
+      'subscriptions',
+      -1
+    ),
+    ['subscriptions', 'home', 'trending', 'history']
+  )
+})

--- a/tests/unit/quick-settings.test.mjs
+++ b/tests/unit/quick-settings.test.mjs
@@ -4,7 +4,6 @@ import test from 'node:test'
 import {
   DEFAULT_QUICK_SETTINGS,
   isQuickSettingPaired,
-  moveQuickSettingByVisibleOffset,
   normalizeQuickSettings,
   QUICK_SETTING_DEFINITIONS,
 } from '../../src/renderer/helpers/quickSettings.js'
@@ -42,18 +41,6 @@ test('pairs adjacent selects without leaving an odd select in a half-row', () =>
       isQuickSettingPaired(settings, index)
     )),
     [true, true, false, true, true, false]
-  )
-})
-
-test('moves between visible settings without dropping hidden platform settings', () => {
-  assert.deepEqual(
-    moveQuickSettingByVisibleOffset(
-      ['baseTheme', 'mainColor', 'uiScale', 'thumbnailSize'],
-      ['baseTheme', 'mainColor', 'thumbnailSize'],
-      'mainColor',
-      1
-    ),
-    ['baseTheme', 'uiScale', 'thumbnailSize', 'mainColor']
   )
 })
 

--- a/tests/unit/settings-migrations.test.mjs
+++ b/tests/unit/settings-migrations.test.mjs
@@ -1,6 +1,7 @@
 import assert from 'node:assert/strict'
 import test from 'node:test'
 
+import { DEFAULT_NAVIGATION_ITEMS } from '../../src/navigationItems.js'
 import { migrateLegacySettings } from '../../src/renderer/helpers/settings-migrations.js'
 
 test('migrates an enabled legacy subscription progress notification preference', () => {
@@ -71,5 +72,42 @@ test('prefers the current Downloads placement preference', () => {
     moveDownloadsToAppHeader: false,
   }), {
     moveDownloadsToAppHeader: false,
+  })
+})
+
+test('migrates navigation visibility switches to an ordered list', () => {
+  assert.deepEqual(migrateLegacySettings({
+    hideHome: true,
+    hidePlaylists: false,
+    hidePopularVideos: true,
+    hideTrendingVideos: false,
+  }), {
+    hidePlaylists: false,
+    navigationItems: [
+      'subscriptions',
+      'userplaylists',
+      'history',
+      'subscribedchannels',
+      'trending',
+      'stats',
+    ],
+  })
+})
+
+test('prefers current navigation items over former visibility switches', () => {
+  assert.deepEqual(migrateLegacySettings({
+    navigationItems: ['history'],
+    hideHome: false,
+  }), {
+    navigationItems: ['history'],
+  })
+})
+
+test('keeps Hide Playlists because it also controls playlist actions', () => {
+  assert.deepEqual(migrateLegacySettings({
+    hidePlaylists: true,
+  }), {
+    hidePlaylists: true,
+    navigationItems: DEFAULT_NAVIGATION_ITEMS.filter(id => id !== 'userplaylists'),
   })
 })

--- a/tests/unit/settings-search-config.test.mjs
+++ b/tests/unit/settings-search-config.test.mjs
@@ -131,6 +131,7 @@ test('shared settings search index includes only settings available on this plat
   }).get('appearance')
 
   assert.ok(desktopValues.some(({ label }) => label === 'Show thumbnail previews'))
+  assert.ok(desktopValues.some(({ label }) => label === 'Navigation'))
   assert.ok(desktopValues.some(({ label }) => label === 'UI Scale'))
   assert.ok(!webValues.some(({ label }) => label === 'UI Scale'))
   assert.ok(mobileValues.some(({ label }) => label === 'Mobile layout'))


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Make sure to follow the contributing guidelines. -->
<!-- Important note, we may remove your pull request if you do not use this provided PR template correctly. -->
<!-- Agent instructions: Preserve every heading, comment, and marker in this template. Never remove or rewrite the release-note-category:start/end, release-note:start/end, or release-note-image:start/end marker pairs. -->

## Pull Request Type
<!-- Please select what type of pull request this is: [x] -->
- [ ] Bugfix
- [x] Feature Implementation
- [ ] Documentation
- [ ] Other

## Related issue
<!-- Please link the issue your pull request is referring to. -->
<!-- If this pull request fully resolves the relevant issue, put "closes" before the issue number. -->
<!-- Example: "closes #123456". -->

No linked issue.

## Description
<!-- Please write a clear and concise description of what the pull request does. -->

Navigation visibility was spread across distraction-free switches, and users could not choose a shared order for the desktop sidebar and mobile bottom bar.

This adds a navigation customizer beside the Quick Settings customizer in Appearance. Destinations can be added, removed, reordered by drag and drop or buttons, and reset to defaults. Existing visibility settings migrate to the ordered list, unavailable provider destinations remain safe, and landing-page fallbacks follow the visible navigation. The change also fixes the narrow Appearance layout around the tab controls.

## Release note category
<!-- Select exactly one category. Every pull request must select one. -->
<!-- Select "Not noteworthy" when the pull request fixes a bug in or improves functionality that has not yet appeared in a stable release. -->
<!-- release-note-category:start -->
- [ ] Not noteworthy
- [ ] Highlights
- [x] More improvements
- [ ] Fixed bugs
<!-- release-note-category:end -->

## Release note
<!-- Required unless "Not noteworthy" is selected. -->
<!-- Write one concise, user-facing entry without a leading bullet. -->
<!-- release-note:start -->

Customize which destinations appear in the navigation bar, and reorder them from Appearance settings.

<!-- release-note:end -->

## Release note images
<!-- Optional. Paste one or more Markdown images, HTML image tags, or dark/light <picture> elements here. -->
<!-- The release notes normalize the markup and limit images taller than 300 pixels. -->
<!-- Agent instructions:
For a noteworthy visible change, add media when it makes the change easier to understand. Prefer a still image unless motion is the point. Recordings in this section must end up as animated WebP because release notes accept images, not video attachments.
After implementing a visible change, proactively capture the result and show the local media to the user for approval before uploading it or updating the pull request.
When the affected UI differs between dark and light themes, capturing both themes is required. A dark-only image is incomplete. The final pull request body must combine the hosted URLs into a theme-aware `<picture>` with dark and light `prefers-color-scheme` sources and the dark image as its `<img>` fallback. Never leave the two theme captures as separate images. Use a single default-dark capture only when the light theme cannot be captured or looks identical.
Capture or crop to the smallest region that still makes the change clear. Do not include the full window when the affected component can be understood on its own.
Use English unless localization is the subject. Keep components at their normal dimensions and placement instead of resizing them to fill the frame.
Use deterministic local fixtures for visible remote images. Reusable avatar and thumbnail fixtures are available through `e2e/helpers/visual-fixtures.mjs`. Before capturing, verify that every visible image has loaded successfully (`complete === true` and `naturalWidth > 0`).
Inspect the final dark and light files for failed images, missing content, unrelated UI, awkward animation, and misleading layout. Omit media when it does not explain the change clearly.
Use GitHub CLI 2.99.0 or newer to upload images no larger than 10 MB. For one image, write an ordinary Markdown image reference to the local file between the marker comments. Pass the same file to `gh pr create` or `gh pr edit` with `--attach <path>` so GitHub CLI replaces the local path with its hosted URL.
GitHub CLI does not rewrite paths inside HTML attributes. For themed images within its size limit, first upload both files through temporary Markdown image references and repeat `--attach <path>` for each one. Read back the hosted URLs, replace the temporary references with the `<picture>` below, and update the pull request body without `--attach`:
<picture>
  <source media="(prefers-color-scheme: dark)" srcset="HOSTED_DARK_URL">
  <source media="(prefers-color-scheme: light)" srcset="HOSTED_LIGHT_URL">
  <img alt="DESCRIPTION" src="HOSTED_DARK_URL">
</picture>
For every MP4, MOV, or WebM recording, use `node _scripts/releaseNoteMedia.mjs FILE --alt "DESCRIPTION"` regardless of file size so the helper converts it to animated WebP. Use the same command when an image exceeds 10 MB. For a themed pair where either file needs the helper, use `node _scripts/releaseNoteMedia.mjs --dark DARK_FILE --light LIGHT_FILE --alt "DESCRIPTION"`. Paste only its generated markup between the marker comments.
Check for personal information, tokens, private repository names, and unrelated desktop content before uploading. Uploaded media is public.
Keep capture-only scripts, test hooks, screenshots, and recordings out of commits. Remove them before committing unless the capture code is also a reusable regression test. Never commit generated release-note media.
Leave this section empty when media would not help.
-->
<!-- release-note-image:start -->

<picture>
  <source media="(prefers-color-scheme: dark)" srcset="https://github.com/user-attachments/assets/3e859256-a8d0-4b9d-8459-05c33d4840ca">
  <source media="(prefers-color-scheme: light)" srcset="https://github.com/user-attachments/assets/ecae69dd-d6a6-4372-b141-7796af240e19">
  <img alt="Navigation customization settings" src="https://github.com/user-attachments/assets/3e859256-a8d0-4b9d-8459-05c33d4840ca">
</picture>

<!-- release-note-image:end -->

## Testing
<!-- How can reviewers verify that the PR produces correct results? -->
<!-- Please provide instructions so that others can ensure that your pull request would produce correct results. For examples see, https://github.com/FreeTubeApp/FreeTube/pull/5743, https://github.com/FreeTubeApp/FreeTube/pull/7349, https://github.com/FreeTubeApp/FreeTube/pull/5125, https://github.com/FreeTubeApp/FreeTube/pull/7338 -->
<!-- Agent instructions: Only write human-facing steps that explain how to verify the change while running this branch in dev mode. Include expected results and, when applicable, helpful console snippets for interactive verification. Do not include automated checks, commands, results, pass counts, or CI status. -->

1. Open Settings > Appearance and confirm the "Navigation / Quick settings" section contains both customization buttons.
2. Open "Customize navigation", remove and add destinations, then reorder them with both the arrow buttons and drag and drop. The desktop sidebar should follow the configured list and order.
3. Narrow the app to the mobile layout. The first four configured destinations should appear in the bottom bar, with any remaining destinations under More.
4. Open the Add item picker. It should list available destinations without a search field, and Downloads should not be offered.
5. Resize Appearance settings below 760 px and check Tab Layout, Tab Width, and Load Missing Tab Icons in portrait and landscape. The controls should stack centrally with even spacing.

## Additional context
<!-- Add any other context about the pull request here. -->

The existing Hide Playlists preference remains available because it also controls playlist actions outside navigation. Sidebar customization does not remove commands or accelerators from Electron's Navigate menu.


