### PR TITLE
fix(player): ignore KDE desktop popups for auto PiP

### DIFF
--- a/src/main/index.js
+++ b/src/main/index.js
@@ -2778,26 +2778,30 @@ function runApp() {
     // Cover minimize-to-tray (and app hide), where the window is hidden rather than minimized.
     newWindow.on('hide', () => sendMinimizedState(true))
     newWindow.on('show', () => sendMinimizedState(false))
-    if (monitorsKdeWaylandWindowState) {
-      monitorKdeWaylandWindowState({
-        browserWindow: newWindow,
-        backend: kdeWaylandWindowStateBackend,
-        applyWindowIdentity: applyKdeWindowIdentity,
-        onMinimizedState: sendMinimizedState,
-        releaseWindowIdentity: releaseKdeWindowIdentity,
-      })
-    }
 
     // Renderer focus events can be skipped on Windows when focus returns after
     // another application's window is closed. Forward the native state so
-    // blur-triggered auto PiP can still re-embed the video.
+    // blur-triggered auto PiP can still re-embed the video. KDE Wayland checks
+    // KWin first because desktop popups blur the Wayland surface without
+    // switching away from the app's top-level window.
     const sendFocusedState = (focused) => {
       if (!newWindow.isDestroyed() && !newWindow.webContents.isDestroyed()) {
         newWindow.webContents.send(IpcChannels.WINDOW_FOCUSED_STATE, focused)
       }
     }
-    newWindow.on('focus', () => sendFocusedState(true))
-    newWindow.on('blur', () => sendFocusedState(false))
+    if (monitorsKdeWaylandWindowState) {
+      monitorKdeWaylandWindowState({
+        browserWindow: newWindow,
+        backend: kdeWaylandWindowStateBackend,
+        applyWindowIdentity: applyKdeWindowIdentity,
+        onFocusedState: sendFocusedState,
+        onMinimizedState: sendMinimizedState,
+        releaseWindowIdentity: releaseKdeWindowIdentity,
+      })
+    } else {
+      newWindow.on('focus', () => sendFocusedState(true))
+      newWindow.on('blur', () => sendFocusedState(false))
+    }
 
     if (isTrayOnMinimizeSupported) {
       function manageTray(window, removeWindow = false) {

--- a/src/main/kdeWaylandWindowState.js
+++ b/src/main/kdeWaylandWindowState.js
@@ -1,7 +1,17 @@
 import dbus from 'dbus-native'
+import { mkdtemp, rm, writeFile } from 'node:fs/promises'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
 
 const KDE_DESKTOP_PATTERN = /(?:^|[:;/_-])(?:kde|plasma(?:wayland)?)(?:$|[:;/_-])/i
 const KWIN_SERVICE = 'org.kde.KWin'
+const KWIN_SCRIPTING_PATH = '/Scripting'
+const KWIN_SCRIPTING_INTERFACE = 'org.kde.kwin.Scripting'
+const KWIN_ACTIVE_WINDOW_SCRIPT_PREFIX = 'opentubex-active-window'
+const ACTIVE_WINDOW_REPORT_PATH = '/io/github/OpenTubeX/KWinActiveWindow'
+const ACTIVE_WINDOW_REPORT_INTERFACE = 'io.github.OpenTubeX.KWinActiveWindow'
+const ACTIVE_WINDOW_QUERY_TIMEOUT = 1_500
+const KDE_DESKTOP_POPUP_CLASS = /(?:^|\.)(?:krunner|plasmashell)$/i
 const WINDOW_SEARCH_TERM = 'OpenTubeX'
 
 /**
@@ -72,6 +82,14 @@ export function shouldMonitorKdeWaylandWindowState({
  *   width: number,
  *   height: number
  * }} KwinWindowInfo
+ */
+
+/**
+ * @typedef {{
+ *   uuid: string,
+ *   skipTaskbar: boolean,
+ *   resourceClass: string
+ * }} KwinActiveWindowInfo
  */
 
 /**
@@ -198,29 +216,142 @@ async function queryKwinWindows(kwin, runner, processId) {
  *
  * @returns {Promise<{
  *   close: () => Promise<void>,
+ *   queryActiveWindow: () => Promise<KwinActiveWindowInfo | null>,
  *   queryWindow: (uuid: string) => Promise<KwinWindowInfo | null>,
  *   queryWindows: (processId: number) => Promise<KwinWindowInfo[]>
  * } | null>}
  */
 export async function createKdeWaylandWindowStateBackend() {
   let bus
+  let scriptDirectory
 
   try {
     bus = dbus.sessionBus({ reconnect: true, timeout: 2_000 })
     bus.connection.on('error', () => {})
     const service = bus.getService(KWIN_SERVICE)
-    const [kwin, runner] = await Promise.all([
+    const [kwin, runner, scripting] = await Promise.all([
       service.getInterface('/KWin', 'org.kde.KWin'),
       service.getInterface('/WindowsRunner', 'org.kde.krunner1'),
+      service.getInterface(KWIN_SCRIPTING_PATH, KWIN_SCRIPTING_INTERFACE),
     ])
     await runner.Match(WINDOW_SEARCH_TERM)
+    if (typeof bus.name !== 'string') throw new Error('D-Bus connection has no unique name')
+
+    scriptDirectory = await mkdtemp(join(tmpdir(), 'opentubex-kwin-'))
+    const scriptPath = join(scriptDirectory, 'active-window.js')
+    const scriptPluginName = `${KWIN_ACTIVE_WINDOW_SCRIPT_PREFIX}-${process.pid}`
+    let activeWindowQueryId = 0
+    let closed = false
+    let pendingReport = null
+    let queryQueue = Promise.resolve()
+
+    // KWin's public getWindowInfo map omits activation state. A one-shot script
+    // can read workspace.activeWindow without staying loaded between queries.
+    const loadScript = (scriptPath, pluginName) => bus.invoke({
+      destination: KWIN_SERVICE,
+      path: KWIN_SCRIPTING_PATH,
+      interface: KWIN_SCRIPTING_INTERFACE,
+      member: 'loadScript',
+      signature: 'ss',
+      body: [scriptPath, pluginName],
+    })
+
+    bus.exportInterface({
+      ReportActiveWindow: (requestId, uuid, skipTaskbar, resourceClass) => {
+        if (pendingReport?.requestId === requestId) {
+          pendingReport.resolve({ uuid, skipTaskbar, resourceClass })
+        }
+        return null
+      },
+    }, ACTIVE_WINDOW_REPORT_PATH, {
+      name: ACTIVE_WINDOW_REPORT_INTERFACE,
+      methods: {
+        ReportActiveWindow: ['ssbs', '', ['requestId', 'uuid', 'skipTaskbar', 'resourceClass'], []],
+      },
+      signals: {},
+      properties: {},
+    })
+
+    // A previous process may have exited while its one-shot script was running.
+    await scripting.unloadScript(scriptPluginName).catch(() => {})
+
+    /** @returns {Promise<KwinActiveWindowInfo | null>} */
+    const runActiveWindowQuery = async () => {
+      if (closed) return null
+
+      const requestId = `${process.pid}-${++activeWindowQueryId}`
+      const script = `
+const activeWindow = workspace.activeWindow;
+callDBus(
+  ${JSON.stringify(bus.name)},
+  ${JSON.stringify(ACTIVE_WINDOW_REPORT_PATH)},
+  ${JSON.stringify(ACTIVE_WINDOW_REPORT_INTERFACE)},
+  "ReportActiveWindow",
+  ${JSON.stringify(requestId)},
+  activeWindow ? activeWindow.internalId.toString() : "",
+  activeWindow ? activeWindow.skipTaskbar : false,
+  activeWindow ? activeWindow.resourceClass.toString() : ""
+);
+`
+      await writeFile(scriptPath, script, 'utf8')
+
+      try {
+        const scriptId = await loadScript(scriptPath, scriptPluginName)
+        if (!Number.isInteger(scriptId) || scriptId < 0) return null
+
+        const scriptInterface = await service.getInterface(
+          `${KWIN_SCRIPTING_PATH}/Script${scriptId}`,
+          'org.kde.kwin.Script'
+        )
+        const report = new Promise(resolve => {
+          const timeout = setTimeout(() => {
+            if (pendingReport?.requestId === requestId) pendingReport = null
+            resolve(null)
+          }, ACTIVE_WINDOW_QUERY_TIMEOUT)
+          pendingReport = {
+            requestId,
+            resolve: value => {
+              clearTimeout(timeout)
+              if (pendingReport?.requestId === requestId) pendingReport = null
+              resolve(value)
+            },
+          }
+        })
+        await scriptInterface.run()
+        return await report
+      } finally {
+        if (pendingReport?.requestId === requestId) {
+          pendingReport.resolve(null)
+        }
+        await scripting.unloadScript(scriptPluginName).catch(() => {})
+      }
+    }
+
+    /** @returns {Promise<KwinActiveWindowInfo | null>} */
+    const queryActiveWindow = () => {
+      const query = queryQueue.then(runActiveWindowQuery)
+      queryQueue = query.catch(() => null)
+      return query
+    }
 
     return {
-      close: () => bus.close(),
+      close: async () => {
+        closed = true
+        pendingReport?.resolve(null)
+        pendingReport = null
+        await scripting.unloadScript(scriptPluginName).catch(() => {})
+        bus.unexportInterface(ACTIVE_WINDOW_REPORT_PATH, ACTIVE_WINDOW_REPORT_INTERFACE)
+        await rm(scriptDirectory, { force: true, recursive: true }).catch(() => {})
+        await bus.close()
+      },
+      queryActiveWindow,
       queryWindow: uuid => queryKwinWindow(kwin, uuid),
       queryWindows: processId => queryKwinWindows(kwin, runner, processId),
     }
   } catch {
+    if (scriptDirectory !== undefined) {
+      await rm(scriptDirectory, { force: true, recursive: true }).catch(() => {})
+    }
     await bus?.close().catch(() => {})
     return null
   }
@@ -235,6 +366,7 @@ export async function createKdeWaylandWindowStateBackend() {
  *   browserWindow: import('electron').BrowserWindow,
  *   backend: ReturnType<typeof createKdeWaylandWindowStateBackend>,
  *   applyWindowIdentity?: () => void,
+ *   onFocusedState?: (focused: boolean) => void,
  *   onMinimizedState: (minimized: boolean) => void,
  *   releaseWindowIdentity?: () => void,
  *   processId?: number,
@@ -247,6 +379,7 @@ export function monitorKdeWaylandWindowState({
   browserWindow,
   backend,
   applyWindowIdentity = () => {},
+  onFocusedState = () => {},
   onMinimizedState,
   releaseWindowIdentity = () => {},
   processId = process.pid,
@@ -258,9 +391,14 @@ export function monitorKdeWaylandWindowState({
   let minimized = false
   let minimizedUuid = null
   let windowUuid = null
+  let focusPollTimer = null
   let pollTimer = null
   let stopped = false
 
+  const clearFocusPoll = () => {
+    if (focusPollTimer !== null) clearTimeout(focusPollTimer)
+    focusPollTimer = null
+  }
   const clearPoll = () => {
     if (pollTimer !== null) clearTimeout(pollTimer)
     pollTimer = null
@@ -316,17 +454,51 @@ export function monitorKdeWaylandWindowState({
       refreshBaseline(token).catch(() => {})
     }, pollInterval)
   }
+  const isDesktopPopup = activeWindow => activeWindow !== null &&
+    activeWindow.skipTaskbar &&
+    KDE_DESKTOP_POPUP_CLASS.test(activeWindow.resourceClass)
+  const isLogicallyFocused = (activeWindow, targetUuid) => (
+    activeWindow !== null && activeWindow.uuid === targetUuid
+  ) || isDesktopPopup(activeWindow)
+  // Starting an app from the launcher does not blur this BrowserWindow again.
+  // Keep checking until the popup closes or hands focus to an app. Some shell
+  // popups leave the app's top-level KWin window active while Electron blurs.
+  const scheduleFocusPoll = (token, targetUuid) => {
+    clearFocusPoll()
+    if (stopped) return
+
+    focusPollTimer = setTimeout(async () => {
+      focusPollTimer = null
+      if (stopped || generation !== token) return
+
+      let activeWindow = null
+      try {
+        const value = await backend
+        if (value !== null) activeWindow = await value.queryActiveWindow()
+      } catch {
+        // Treat an unavailable compositor query as an ordinary focus loss.
+      }
+      if (stopped || generation !== token) return
+
+      const focused = isLogicallyFocused(activeWindow, targetUuid)
+      onFocusedState(focused)
+      if (focused) scheduleFocusPoll(token, targetUuid)
+    }, pollInterval)
+  }
   const handleFocus = () => {
     applyWindowIdentity()
     const token = ++generation
+    clearFocusPoll()
     clearPoll()
     minimizedUuid = null
     setMinimized(false)
+    onFocusedState(true)
     refreshBaseline(token).catch(() => {})
   }
   const handleBlur = async () => {
     applyWindowIdentity()
     const token = ++generation
+    clearFocusPoll()
     clearPoll()
 
     const previous = baseline
@@ -337,6 +509,7 @@ export function monitorKdeWaylandWindowState({
       const value = await backend
       if (value === null) {
         releaseWindowIdentity()
+        onFocusedState(false)
         return
       }
       applyWindowIdentity()
@@ -344,10 +517,20 @@ export function monitorKdeWaylandWindowState({
         caption: browserWindow.getTitle(),
         bounds: browserWindow.getBounds(),
       }
-      const current = await value.queryWindows(processId)
+      const [current, activeWindow] = await Promise.all([
+        value.queryWindows(processId),
+        value.queryActiveWindow(),
+      ])
       if (stopped || generation !== token) return
 
       baseline = current
+      const matchedWindow = windowUuid === null
+        ? findMatchingWindow(current, target)
+        : current.find(window => window.uuid === windowUuid) ?? null
+      const targetUuid = matchedWindow?.uuid ?? windowUuid
+      const focused = isLogicallyFocused(activeWindow, targetUuid)
+      onFocusedState(focused)
+      if (focused) scheduleFocusPoll(token, targetUuid)
       const previousByUuid = new Map(previous.map(window => [window.uuid, window]))
       const claimedWindow = windowUuid === null
         ? null
@@ -367,11 +550,13 @@ export function monitorKdeWaylandWindowState({
     } catch {
       // A failed query disables this transition only. The next focus or blur
       // retries without affecting normal Electron window events.
+      if (!stopped && generation === token) onFocusedState(false)
     }
   }
   const stop = () => {
     stopped = true
     generation++
+    clearFocusPoll()
     clearPoll()
     browserWindow.removeListener('focus', handleFocus)
     browserWindow.removeListener('blur', handleBlur)

--- a/src/main/kdeWaylandWindowState.js
+++ b/src/main/kdeWaylandWindowState.js
@@ -281,12 +281,20 @@ export async function createKdeWaylandWindowStateBackend() {
       properties: {},
     })
 
-    // A previous process may have exited while its activation script was running.
-    await scripting.unloadScript(scriptPluginName).catch(() => {})
-    const script = `
+    const loadActiveWindowScript = async () => {
+      if (closed) return
+      if (typeof bus.name !== 'string') {
+        throw new Error('D-Bus connection has no unique name')
+      }
+
+      const destination = bus.name
+      await scripting.unloadScript(scriptPluginName).catch(() => {})
+      if (closed) return
+
+      const script = `
 const reportActiveWindow = activeWindow => {
   callDBus(
-    ${JSON.stringify(bus.name)},
+    ${JSON.stringify(destination)},
     ${JSON.stringify(ACTIVE_WINDOW_REPORT_PATH)},
     ${JSON.stringify(ACTIVE_WINDOW_REPORT_INTERFACE)},
     "ReportActiveWindow",
@@ -298,31 +306,45 @@ const reportActiveWindow = activeWindow => {
 reportActiveWindow(workspace.activeWindow)
 workspace.windowActivated.connect(reportActiveWindow)
 `
-    await writeFile(scriptPath, script, 'utf8')
-    const scriptId = await bus.invoke({
-      destination: KWIN_SERVICE,
-      path: KWIN_SCRIPTING_PATH,
-      interface: KWIN_SCRIPTING_INTERFACE,
-      member: 'loadScript',
-      signature: 'ss',
-      body: [scriptPath, scriptPluginName],
-    })
-    if (!Number.isInteger(scriptId) || scriptId < 0) {
-      throw new Error('KWin rejected the active-window script')
+      await writeFile(scriptPath, script, 'utf8')
+      if (closed) return
+
+      const scriptId = await bus.invoke({
+        destination: KWIN_SERVICE,
+        path: KWIN_SCRIPTING_PATH,
+        interface: KWIN_SCRIPTING_INTERFACE,
+        member: 'loadScript',
+        signature: 'ss',
+        body: [scriptPath, scriptPluginName],
+      })
+      if (!Number.isInteger(scriptId) || scriptId < 0) {
+        throw new Error('KWin rejected the active-window script')
+      }
+      const scriptInterface = await service.getInterface(
+        `${KWIN_SCRIPTING_PATH}/Script${scriptId}`,
+        'org.kde.kwin.Script'
+      )
+      if (closed) return
+      await scriptInterface.run()
     }
-    const scriptInterface = await service.getInterface(
-      `${KWIN_SCRIPTING_PATH}/Script${scriptId}`,
-      'org.kde.kwin.Script'
-    )
-    await scriptInterface.run()
+
+    // A previous process may have exited while its activation script was running.
+    await loadActiveWindowScript()
     if (await initialReport === null) throw new Error('KWin did not report its active window')
+    let scriptReload = Promise.resolve()
+    const handleReconnect = () => {
+      scriptReload = scriptReload.then(loadActiveWindowScript).catch(() => {})
+    }
+    bus.on('reconnected', handleReconnect)
 
     return {
       close: async () => {
         if (closed) return
         closed = true
+        bus.removeListener('reconnected', handleReconnect)
         resolveInitialReport?.(null)
         activeWindowListeners.clear()
+        await scriptReload
         await scripting.unloadScript(scriptPluginName).catch(() => {})
         bus.unexportInterface(ACTIVE_WINDOW_REPORT_PATH, ACTIVE_WINDOW_REPORT_INTERFACE)
         await rm(scriptDirectory, { force: true, recursive: true }).catch(() => {})

--- a/src/main/kdeWaylandWindowState.js
+++ b/src/main/kdeWaylandWindowState.js
@@ -11,6 +11,7 @@ const KWIN_ACTIVE_WINDOW_SCRIPT_PREFIX = 'opentubex-active-window'
 const ACTIVE_WINDOW_REPORT_PATH = '/io/github/OpenTubeX/KWinActiveWindow'
 const ACTIVE_WINDOW_REPORT_INTERFACE = 'io.github.OpenTubeX.KWinActiveWindow'
 const ACTIVE_WINDOW_QUERY_TIMEOUT = 1_500
+const FOCUS_HANDOFF_POLL_ATTEMPTS = 5
 const KDE_DESKTOP_POPUP_CLASS = /(?:^|\.)(?:krunner|plasmashell)$/i
 const WINDOW_SEARCH_TERM = 'OpenTubeX'
 
@@ -457,13 +458,19 @@ export function monitorKdeWaylandWindowState({
   const isDesktopPopup = activeWindow => activeWindow !== null &&
     activeWindow.skipTaskbar &&
     KDE_DESKTOP_POPUP_CLASS.test(activeWindow.resourceClass)
-  const isLogicallyFocused = (activeWindow, targetUuid) => (
+  const isTargetWindowActive = (activeWindow, targetUuid) => (
     activeWindow !== null && activeWindow.uuid === targetUuid
-  ) || isDesktopPopup(activeWindow)
+  )
+  const isLogicallyFocused = (activeWindow, targetUuid) =>
+    isTargetWindowActive(activeWindow, targetUuid) || isDesktopPopup(activeWindow)
   // Starting an app from the launcher does not blur this BrowserWindow again.
-  // Keep checking until the popup closes or hands focus to an app. Some shell
-  // popups leave the app's top-level KWin window active while Electron blurs.
-  const scheduleFocusPoll = (token, targetUuid) => {
+  // Keep checking while the popup is open. KWin can briefly reactivate this
+  // window during launcher handoff, so allow a bounded number of final polls.
+  const scheduleFocusPoll = (
+    token,
+    targetUuid,
+    remainingHandoffPolls = FOCUS_HANDOFF_POLL_ATTEMPTS
+  ) => {
     clearFocusPoll()
     if (stopped) return
 
@@ -481,9 +488,14 @@ export function monitorKdeWaylandWindowState({
       if (stopped || generation !== token) return
 
       const desktopPopupActive = isDesktopPopup(activeWindow)
-      const focused = isLogicallyFocused(activeWindow, targetUuid)
+      const targetWindowActive = isTargetWindowActive(activeWindow, targetUuid)
+      const focused = targetWindowActive || desktopPopupActive
       onFocusedState(focused)
-      if (desktopPopupActive) scheduleFocusPoll(token, targetUuid)
+      if (desktopPopupActive) {
+        scheduleFocusPoll(token, targetUuid)
+      } else if (targetWindowActive && remainingHandoffPolls > 1) {
+        scheduleFocusPoll(token, targetUuid, remainingHandoffPolls - 1)
+      }
     }, pollInterval)
   }
   const handleFocus = () => {
@@ -529,10 +541,9 @@ export function monitorKdeWaylandWindowState({
         ? findMatchingWindow(current, target)
         : current.find(window => window.uuid === windowUuid) ?? null
       const targetUuid = matchedWindow?.uuid ?? windowUuid
-      const desktopPopupActive = isDesktopPopup(activeWindow)
       const focused = isLogicallyFocused(activeWindow, targetUuid)
       onFocusedState(focused)
-      if (desktopPopupActive) scheduleFocusPoll(token, targetUuid)
+      if (focused) scheduleFocusPoll(token, targetUuid)
       const previousByUuid = new Map(previous.map(window => [window.uuid, window]))
       const claimedWindow = windowUuid === null
         ? null

--- a/src/main/kdeWaylandWindowState.js
+++ b/src/main/kdeWaylandWindowState.js
@@ -480,9 +480,10 @@ export function monitorKdeWaylandWindowState({
       }
       if (stopped || generation !== token) return
 
+      const desktopPopupActive = isDesktopPopup(activeWindow)
       const focused = isLogicallyFocused(activeWindow, targetUuid)
       onFocusedState(focused)
-      if (focused) scheduleFocusPoll(token, targetUuid)
+      if (desktopPopupActive) scheduleFocusPoll(token, targetUuid)
     }, pollInterval)
   }
   const handleFocus = () => {
@@ -528,9 +529,10 @@ export function monitorKdeWaylandWindowState({
         ? findMatchingWindow(current, target)
         : current.find(window => window.uuid === windowUuid) ?? null
       const targetUuid = matchedWindow?.uuid ?? windowUuid
+      const desktopPopupActive = isDesktopPopup(activeWindow)
       const focused = isLogicallyFocused(activeWindow, targetUuid)
       onFocusedState(focused)
-      if (focused) scheduleFocusPoll(token, targetUuid)
+      if (desktopPopupActive) scheduleFocusPoll(token, targetUuid)
       const previousByUuid = new Map(previous.map(window => [window.uuid, window]))
       const claimedWindow = windowUuid === null
         ? null

--- a/src/main/kdeWaylandWindowState.js
+++ b/src/main/kdeWaylandWindowState.js
@@ -11,7 +11,6 @@ const KWIN_ACTIVE_WINDOW_SCRIPT_PREFIX = 'opentubex-active-window'
 const ACTIVE_WINDOW_REPORT_PATH = '/io/github/OpenTubeX/KWinActiveWindow'
 const ACTIVE_WINDOW_REPORT_INTERFACE = 'io.github.OpenTubeX.KWinActiveWindow'
 const ACTIVE_WINDOW_QUERY_TIMEOUT = 1_500
-const FOCUS_HANDOFF_POLL_ATTEMPTS = 5
 const KDE_DESKTOP_POPUP_CLASS = /(?:^|\.)(?:krunner|plasmashell)$/i
 const WINDOW_SEARCH_TERM = 'OpenTubeX'
 
@@ -217,139 +216,133 @@ async function queryKwinWindows(kwin, runner, processId) {
  *
  * @returns {Promise<{
  *   close: () => Promise<void>,
- *   queryActiveWindow: () => Promise<KwinActiveWindowInfo | null>,
  *   queryWindow: (uuid: string) => Promise<KwinWindowInfo | null>,
- *   queryWindows: (processId: number) => Promise<KwinWindowInfo[]>
+ *   queryWindows: (processId: number) => Promise<KwinWindowInfo[]>,
+ *   watchActiveWindow: (listener: (window: KwinActiveWindowInfo) => void) => {
+ *     activeWindow: KwinActiveWindowInfo | null,
+ *     stop: () => void
+ *   }
  * } | null>}
  */
 export async function createKdeWaylandWindowStateBackend() {
   let bus
   let scriptDirectory
+  let scripting
+  let scriptPluginName
 
   try {
     bus = dbus.sessionBus({ reconnect: true, timeout: 2_000 })
     bus.connection.on('error', () => {})
     const service = bus.getService(KWIN_SERVICE)
-    const [kwin, runner, scripting] = await Promise.all([
+    const [kwin, runner, scriptingInterface] = await Promise.all([
       service.getInterface('/KWin', 'org.kde.KWin'),
       service.getInterface('/WindowsRunner', 'org.kde.krunner1'),
       service.getInterface(KWIN_SCRIPTING_PATH, KWIN_SCRIPTING_INTERFACE),
     ])
+    scripting = scriptingInterface
     await runner.Match(WINDOW_SEARCH_TERM)
     if (typeof bus.name !== 'string') throw new Error('D-Bus connection has no unique name')
 
     scriptDirectory = await mkdtemp(join(tmpdir(), 'opentubex-kwin-'))
     const scriptPath = join(scriptDirectory, 'active-window.js')
-    const scriptPluginName = `${KWIN_ACTIVE_WINDOW_SCRIPT_PREFIX}-${process.pid}`
-    let activeWindowQueryId = 0
+    scriptPluginName = `${KWIN_ACTIVE_WINDOW_SCRIPT_PREFIX}-${process.pid}`
+    /** @type {KwinActiveWindowInfo | null} */
+    let activeWindow = null
     let closed = false
-    let pendingReport = null
-    let queryQueue = Promise.resolve()
-
-    // KWin's public getWindowInfo map omits activation state. A one-shot script
-    // can read workspace.activeWindow without staying loaded between queries.
-    const loadScript = (scriptPath, pluginName) => bus.invoke({
-      destination: KWIN_SERVICE,
-      path: KWIN_SCRIPTING_PATH,
-      interface: KWIN_SCRIPTING_INTERFACE,
-      member: 'loadScript',
-      signature: 'ss',
-      body: [scriptPath, pluginName],
+    const activeWindowListeners = new Set()
+    let resolveInitialReport
+    const initialReport = new Promise(resolve => {
+      const timeout = setTimeout(() => {
+        resolveInitialReport = undefined
+        resolve(null)
+      }, ACTIVE_WINDOW_QUERY_TIMEOUT)
+      resolveInitialReport = value => {
+        clearTimeout(timeout)
+        resolveInitialReport = undefined
+        resolve(value)
+      }
     })
 
     bus.exportInterface({
-      ReportActiveWindow: (requestId, uuid, skipTaskbar, resourceClass) => {
-        if (pendingReport?.requestId === requestId) {
-          pendingReport.resolve({ uuid, skipTaskbar, resourceClass })
+      ReportActiveWindow: (uuid, skipTaskbar, resourceClass) => {
+        activeWindow = { uuid, skipTaskbar, resourceClass }
+        resolveInitialReport?.(activeWindow)
+        for (const listener of activeWindowListeners) {
+          listener(activeWindow)
         }
         return null
       },
     }, ACTIVE_WINDOW_REPORT_PATH, {
       name: ACTIVE_WINDOW_REPORT_INTERFACE,
       methods: {
-        ReportActiveWindow: ['ssbs', '', ['requestId', 'uuid', 'skipTaskbar', 'resourceClass'], []],
+        ReportActiveWindow: ['sbs', '', ['uuid', 'skipTaskbar', 'resourceClass'], []],
       },
       signals: {},
       properties: {},
     })
 
-    // A previous process may have exited while its one-shot script was running.
+    // A previous process may have exited while its activation script was running.
     await scripting.unloadScript(scriptPluginName).catch(() => {})
-
-    /** @returns {Promise<KwinActiveWindowInfo | null>} */
-    const runActiveWindowQuery = async () => {
-      if (closed) return null
-
-      const requestId = `${process.pid}-${++activeWindowQueryId}`
-      const script = `
-const activeWindow = workspace.activeWindow;
-callDBus(
-  ${JSON.stringify(bus.name)},
-  ${JSON.stringify(ACTIVE_WINDOW_REPORT_PATH)},
-  ${JSON.stringify(ACTIVE_WINDOW_REPORT_INTERFACE)},
-  "ReportActiveWindow",
-  ${JSON.stringify(requestId)},
-  activeWindow ? activeWindow.internalId.toString() : "",
-  activeWindow ? activeWindow.skipTaskbar : false,
-  activeWindow ? activeWindow.resourceClass.toString() : ""
-);
+    const script = `
+const reportActiveWindow = activeWindow => {
+  callDBus(
+    ${JSON.stringify(bus.name)},
+    ${JSON.stringify(ACTIVE_WINDOW_REPORT_PATH)},
+    ${JSON.stringify(ACTIVE_WINDOW_REPORT_INTERFACE)},
+    "ReportActiveWindow",
+    activeWindow ? activeWindow.internalId.toString() : "",
+    activeWindow ? activeWindow.skipTaskbar : false,
+    activeWindow ? activeWindow.resourceClass.toString() : ""
+  )
+}
+reportActiveWindow(workspace.activeWindow)
+workspace.windowActivated.connect(reportActiveWindow)
 `
-      await writeFile(scriptPath, script, 'utf8')
-
-      try {
-        const scriptId = await loadScript(scriptPath, scriptPluginName)
-        if (!Number.isInteger(scriptId) || scriptId < 0) return null
-
-        const scriptInterface = await service.getInterface(
-          `${KWIN_SCRIPTING_PATH}/Script${scriptId}`,
-          'org.kde.kwin.Script'
-        )
-        const report = new Promise(resolve => {
-          const timeout = setTimeout(() => {
-            if (pendingReport?.requestId === requestId) pendingReport = null
-            resolve(null)
-          }, ACTIVE_WINDOW_QUERY_TIMEOUT)
-          pendingReport = {
-            requestId,
-            resolve: value => {
-              clearTimeout(timeout)
-              if (pendingReport?.requestId === requestId) pendingReport = null
-              resolve(value)
-            },
-          }
-        })
-        await scriptInterface.run()
-        return await report
-      } finally {
-        if (pendingReport?.requestId === requestId) {
-          pendingReport.resolve(null)
-        }
-        await scripting.unloadScript(scriptPluginName).catch(() => {})
-      }
+    await writeFile(scriptPath, script, 'utf8')
+    const scriptId = await bus.invoke({
+      destination: KWIN_SERVICE,
+      path: KWIN_SCRIPTING_PATH,
+      interface: KWIN_SCRIPTING_INTERFACE,
+      member: 'loadScript',
+      signature: 'ss',
+      body: [scriptPath, scriptPluginName],
+    })
+    if (!Number.isInteger(scriptId) || scriptId < 0) {
+      throw new Error('KWin rejected the active-window script')
     }
-
-    /** @returns {Promise<KwinActiveWindowInfo | null>} */
-    const queryActiveWindow = () => {
-      const query = queryQueue.then(runActiveWindowQuery)
-      queryQueue = query.catch(() => null)
-      return query
-    }
+    const scriptInterface = await service.getInterface(
+      `${KWIN_SCRIPTING_PATH}/Script${scriptId}`,
+      'org.kde.kwin.Script'
+    )
+    await scriptInterface.run()
+    if (await initialReport === null) throw new Error('KWin did not report its active window')
 
     return {
       close: async () => {
+        if (closed) return
         closed = true
-        pendingReport?.resolve(null)
-        pendingReport = null
+        resolveInitialReport?.(null)
+        activeWindowListeners.clear()
         await scripting.unloadScript(scriptPluginName).catch(() => {})
         bus.unexportInterface(ACTIVE_WINDOW_REPORT_PATH, ACTIVE_WINDOW_REPORT_INTERFACE)
         await rm(scriptDirectory, { force: true, recursive: true }).catch(() => {})
         await bus.close()
       },
-      queryActiveWindow,
+      watchActiveWindow: listener => {
+        if (closed) return { activeWindow: null, stop: () => {} }
+        activeWindowListeners.add(listener)
+        return {
+          activeWindow,
+          stop: () => activeWindowListeners.delete(listener),
+        }
+      },
       queryWindow: uuid => queryKwinWindow(kwin, uuid),
       queryWindows: processId => queryKwinWindows(kwin, runner, processId),
     }
   } catch {
+    if (scripting !== undefined && scriptPluginName !== undefined) {
+      await scripting.unloadScript(scriptPluginName).catch(() => {})
+    }
     if (scriptDirectory !== undefined) {
       await rm(scriptDirectory, { force: true, recursive: true }).catch(() => {})
     }
@@ -392,13 +385,13 @@ export function monitorKdeWaylandWindowState({
   let minimized = false
   let minimizedUuid = null
   let windowUuid = null
-  let focusPollTimer = null
   let pollTimer = null
+  let stopActiveWindowWatch = null
   let stopped = false
 
-  const clearFocusPoll = () => {
-    if (focusPollTimer !== null) clearTimeout(focusPollTimer)
-    focusPollTimer = null
+  const clearActiveWindowWatch = () => {
+    stopActiveWindowWatch?.()
+    stopActiveWindowWatch = null
   }
   const clearPoll = () => {
     if (pollTimer !== null) clearTimeout(pollTimer)
@@ -464,44 +457,27 @@ export function monitorKdeWaylandWindowState({
   const isLogicallyFocused = (activeWindow, targetUuid) =>
     isTargetWindowActive(activeWindow, targetUuid) || isDesktopPopup(activeWindow)
   // Starting an app from the launcher does not blur this BrowserWindow again.
-  // Keep checking while the popup is open. KWin can briefly reactivate this
-  // window during launcher handoff, so allow a bounded number of final polls.
-  const scheduleFocusPoll = (
-    token,
-    targetUuid,
-    remainingHandoffPolls = FOCUS_HANDOFF_POLL_ATTEMPTS
-  ) => {
-    clearFocusPoll()
-    if (stopped) return
+  // Keep watching KWin after a popup so a later launcher handoff is forwarded
+  // even though Electron does not emit another blur event.
+  const watchActiveWindow = (value, targetUuid) => {
+    clearActiveWindowWatch()
+    const reportActiveWindow = activeWindow => {
+      if (stopped || browserWindow.isFocused()) return
 
-    focusPollTimer = setTimeout(async () => {
-      focusPollTimer = null
-      if (stopped || generation !== token) return
-
-      let activeWindow = null
-      try {
-        const value = await backend
-        if (value !== null) activeWindow = await value.queryActiveWindow()
-      } catch {
-        // Treat an unavailable compositor query as an ordinary focus loss.
-      }
-      if (stopped || generation !== token) return
-
-      const desktopPopupActive = isDesktopPopup(activeWindow)
-      const targetWindowActive = isTargetWindowActive(activeWindow, targetUuid)
-      const focused = targetWindowActive || desktopPopupActive
+      const focused = isLogicallyFocused(activeWindow, targetUuid)
       onFocusedState(focused)
-      if (desktopPopupActive) {
-        scheduleFocusPoll(token, targetUuid)
-      } else if (targetWindowActive && remainingHandoffPolls > 1) {
-        scheduleFocusPoll(token, targetUuid, remainingHandoffPolls - 1)
+      if (!focused && activeWindow !== null && activeWindow.uuid !== '') {
+        clearActiveWindowWatch()
       }
-    }, pollInterval)
+    }
+    const watch = value.watchActiveWindow(reportActiveWindow)
+    stopActiveWindowWatch = watch.stop
+    reportActiveWindow(watch.activeWindow)
   }
   const handleFocus = () => {
     applyWindowIdentity()
     const token = ++generation
-    clearFocusPoll()
+    clearActiveWindowWatch()
     clearPoll()
     minimizedUuid = null
     setMinimized(false)
@@ -511,7 +487,7 @@ export function monitorKdeWaylandWindowState({
   const handleBlur = async () => {
     applyWindowIdentity()
     const token = ++generation
-    clearFocusPoll()
+    clearActiveWindowWatch()
     clearPoll()
 
     const previous = baseline
@@ -530,10 +506,7 @@ export function monitorKdeWaylandWindowState({
         caption: browserWindow.getTitle(),
         bounds: browserWindow.getBounds(),
       }
-      const [current, activeWindow] = await Promise.all([
-        value.queryWindows(processId),
-        value.queryActiveWindow(),
-      ])
+      const current = await value.queryWindows(processId)
       if (stopped || generation !== token) return
 
       baseline = current
@@ -541,9 +514,7 @@ export function monitorKdeWaylandWindowState({
         ? findMatchingWindow(current, target)
         : current.find(window => window.uuid === windowUuid) ?? null
       const targetUuid = matchedWindow?.uuid ?? windowUuid
-      const focused = isLogicallyFocused(activeWindow, targetUuid)
-      onFocusedState(focused)
-      if (focused) scheduleFocusPoll(token, targetUuid)
+      watchActiveWindow(value, targetUuid)
       const previousByUuid = new Map(previous.map(window => [window.uuid, window]))
       const claimedWindow = windowUuid === null
         ? null
@@ -569,7 +540,7 @@ export function monitorKdeWaylandWindowState({
   const stop = () => {
     stopped = true
     generation++
-    clearFocusPoll()
+    clearActiveWindowWatch()
     clearPoll()
     browserWindow.removeListener('focus', handleFocus)
     browserWindow.removeListener('blur', handleBlur)

--- a/tests/unit/kde-wayland-window-state.test.mjs
+++ b/tests/unit/kde-wayland-window-state.test.mjs
@@ -131,18 +131,14 @@ test('does not mistake an ordinary focus change for minimize', () => {
   assert.equal(findNewlyMinimizedWindow(state, state, targetWindow()), null)
 })
 
-test('bounds polling when a KDE desktop popup leaves the window active', async () => {
-  const focusedStates = await focusedStatesAfterBlur(
-    {
-      resourceClass: 'electron',
-      skipTaskbar: false,
-      uuid: 'window',
-    },
-    { pollInterval: 0 }
-  )
+test('keeps focus when a KDE desktop popup leaves the window active', async () => {
+  const focusedStates = await focusedStatesAfterBlur({
+    resourceClass: 'electron',
+    skipTaskbar: false,
+    uuid: 'window',
+  })
 
-  assert.equal(focusedStates.length, 6)
-  assert.equal(focusedStates.every(Boolean), true)
+  assert.deepEqual(focusedStates, [true])
 })
 
 test('keeps focus when a KDE shell popup becomes active', async () => {
@@ -176,32 +172,36 @@ test('does not mistake another app utility window for a KDE shell popup', async 
 })
 
 test('reports an app switch made through a KDE shell popup', async () => {
-  const activeWindows = [
+  const focusedStates = await focusedStatesAfterBlur(
     {
       resourceClass: 'plasmashell',
       skipTaskbar: true,
       uuid: 'launcher',
     },
     {
-      resourceClass: 'electron',
-      skipTaskbar: false,
-      uuid: 'window',
-    },
-    {
-      resourceClass: 'electron',
-      skipTaskbar: false,
-      uuid: 'window',
-    },
-    {
-      resourceClass: 'org.kde.konsole',
-      skipTaskbar: false,
-      uuid: 'konsole',
-    },
-  ]
-  let queryIndex = 0
-  const focusedStates = await focusedStatesAfterBlur(
-    () => activeWindows[Math.min(queryIndex++, activeWindows.length - 1)],
-    { pollInterval: 0 }
+      activeWindowChanges: [
+        {
+          resourceClass: 'electron',
+          skipTaskbar: false,
+          uuid: 'window',
+        },
+        {
+          resourceClass: 'electron',
+          skipTaskbar: false,
+          uuid: 'window',
+        },
+        {
+          resourceClass: 'org.kde.konsole',
+          skipTaskbar: false,
+          uuid: 'konsole',
+        },
+        {
+          resourceClass: 'plasmashell',
+          skipTaskbar: true,
+          uuid: 'launcher',
+        },
+      ],
+    }
   )
 
   assert.deepEqual(focusedStates, [true, true, true, false])
@@ -285,12 +285,12 @@ test('preserves the window identity across title updates during detection', asyn
   browserWindow.emit('blur')
   title = targetWindow().caption
   resolveBackend({
-    queryActiveWindow: async () => null,
     queryWindow: async () => minimized,
     queryWindows: async () => {
       setWindowTitle(targetWindow().caption)
       return [otherWindow, minimized]
     },
+    watchActiveWindow: () => ({ activeWindow: null, stop: () => {} }),
   })
   await detected
 
@@ -316,28 +316,42 @@ function targetWindow () {
   }
 }
 
-async function focusedStatesAfterBlur (activeWindow, { pollInterval = 1000 } = {}) {
+async function focusedStatesAfterBlur (activeWindow, { activeWindowChanges = [] } = {}) {
   const browserWindow = new EventEmitter()
   browserWindow.getBounds = () => targetWindow().bounds
   browserWindow.getTitle = () => targetWindow().caption
   browserWindow.isFocused = () => false
   const focusedStates = []
+  let activeWindowListener = null
   const backend = Promise.resolve({
-    queryActiveWindow: async () => typeof activeWindow === 'function' ? activeWindow() : activeWindow,
     queryWindow: async () => null,
     queryWindows: async () => [windowInfo()],
+    watchActiveWindow: listener => {
+      activeWindowListener = listener
+      return {
+        activeWindow,
+        stop: () => {
+          if (activeWindowListener === listener) activeWindowListener = null
+        },
+      }
+    },
   })
   const stop = monitorKdeWaylandWindowState({
     browserWindow,
     backend,
     detectionDelay: 0,
-    pollInterval,
     onFocusedState: focused => focusedStates.push(focused),
     onMinimizedState: () => {},
   })
 
   browserWindow.emit('blur')
-  await new Promise(resolve => setTimeout(resolve, 20))
+  await new Promise(resolve => setTimeout(resolve, 10))
+  for (const nextActiveWindow of activeWindowChanges) {
+    activeWindow = nextActiveWindow
+    if (activeWindowListener !== null) activeWindowListener(activeWindow)
+    await Promise.resolve()
+  }
+  await new Promise(resolve => setTimeout(resolve, 10))
   stop()
 
   return focusedStates

--- a/tests/unit/kde-wayland-window-state.test.mjs
+++ b/tests/unit/kde-wayland-window-state.test.mjs
@@ -1,8 +1,11 @@
 import assert from 'node:assert/strict'
+import dbus from 'dbus-native'
 import { EventEmitter } from 'node:events'
+import { readFile } from 'node:fs/promises'
 import test from 'node:test'
 
 import {
+  createKdeWaylandWindowStateBackend,
   extractKwinWindowHandles,
   findNewlyMinimizedWindow,
   isKdePlasmaDesktop,
@@ -105,6 +108,69 @@ test('extracts KWin runner handles and validates D-Bus window state', () => {
 test('rejects malformed D-Bus window state and runner matches', () => {
   assert.equal(normalizeKwinWindowInfo({ minimized: true }), null)
   assert.deepEqual(extractKwinWindowHandles([['invalid-id'], null]), [])
+})
+
+test('reloads the KWin reporter with the new D-Bus name after reconnect', async t => {
+  const originalSessionBus = dbus.sessionBus
+  const bus = new EventEmitter()
+  bus.name = ':1.10'
+  bus.connection = new EventEmitter()
+  const scripts = []
+  let reportInterface
+  let scriptRuns = 0
+  let resolveSecondRun
+  const secondRun = new Promise(resolve => {
+    resolveSecondRun = resolve
+  })
+  const scripting = {
+    unloadScript: async () => true,
+  }
+  const service = {
+    getInterface: async path => {
+      if (path === '/KWin') return { getWindowInfo: async () => null }
+      if (path === '/WindowsRunner') return { Match: async () => [] }
+      if (path === '/Scripting') return scripting
+      return {
+        run: async () => {
+          scriptRuns++
+          reportInterface.ReportActiveWindow('window', false, 'electron')
+          if (scriptRuns === 2) resolveSecondRun()
+        },
+      }
+    },
+  }
+  bus.getService = () => service
+  bus.invoke = async ({ body: [scriptPath] }) => {
+    scripts.push(await readFile(scriptPath, 'utf8'))
+    return scripts.length
+  }
+  bus.exportInterface = implementation => {
+    reportInterface = implementation
+  }
+  bus.unexportInterface = () => {}
+  bus.close = async () => {}
+  dbus.sessionBus = () => bus
+  t.after(() => {
+    dbus.sessionBus = originalSessionBus
+  })
+
+  const backend = await createKdeWaylandWindowStateBackend()
+  assert.notEqual(backend, null)
+  assert.match(scripts[0], /":1\.10"/)
+  const activeWindows = []
+  const watch = backend.watchActiveWindow(activeWindow => activeWindows.push(activeWindow))
+
+  bus.name = ':1.11'
+  bus.emit('reconnected', { name: bus.name })
+  await secondRun
+
+  assert.equal(scripts.length, 2)
+  assert.match(scripts[1], /":1\.11"/)
+  assert.doesNotMatch(scripts[1], /":1\.10"/)
+  assert.deepEqual(activeWindows, [{ uuid: 'window', skipTaskbar: false, resourceClass: 'electron' }])
+  watch.stop()
+  await backend.close()
+  assert.equal(bus.listenerCount('reconnected'), 0)
 })
 
 test('detects the KWin window newly minimized by a shortcut', () => {

--- a/tests/unit/kde-wayland-window-state.test.mjs
+++ b/tests/unit/kde-wayland-window-state.test.mjs
@@ -131,7 +131,7 @@ test('does not mistake an ordinary focus change for minimize', () => {
   assert.equal(findNewlyMinimizedWindow(state, state, targetWindow()), null)
 })
 
-test('keeps focus without polling when a KDE desktop popup leaves the window active', async () => {
+test('bounds polling when a KDE desktop popup leaves the window active', async () => {
   const focusedStates = await focusedStatesAfterBlur(
     {
       resourceClass: 'electron',
@@ -141,7 +141,8 @@ test('keeps focus without polling when a KDE desktop popup leaves the window act
     { pollInterval: 0 }
   )
 
-  assert.deepEqual(focusedStates, [true])
+  assert.equal(focusedStates.length, 6)
+  assert.equal(focusedStates.every(Boolean), true)
 })
 
 test('keeps focus when a KDE shell popup becomes active', async () => {
@@ -182,6 +183,16 @@ test('reports an app switch made through a KDE shell popup', async () => {
       uuid: 'launcher',
     },
     {
+      resourceClass: 'electron',
+      skipTaskbar: false,
+      uuid: 'window',
+    },
+    {
+      resourceClass: 'electron',
+      skipTaskbar: false,
+      uuid: 'window',
+    },
+    {
       resourceClass: 'org.kde.konsole',
       skipTaskbar: false,
       uuid: 'konsole',
@@ -193,7 +204,7 @@ test('reports an app switch made through a KDE shell popup', async () => {
     { pollInterval: 0 }
   )
 
-  assert.deepEqual(focusedStates, [true, false])
+  assert.deepEqual(focusedStates, [true, true, true, false])
 })
 
 test('detects a single minimized window when no earlier KWin snapshot is available', () => {

--- a/tests/unit/kde-wayland-window-state.test.mjs
+++ b/tests/unit/kde-wayland-window-state.test.mjs
@@ -131,12 +131,15 @@ test('does not mistake an ordinary focus change for minimize', () => {
   assert.equal(findNewlyMinimizedWindow(state, state, targetWindow()), null)
 })
 
-test('keeps focus when a KDE desktop popup leaves the window active', async () => {
-  const focusedStates = await focusedStatesAfterBlur({
-    resourceClass: 'electron',
-    skipTaskbar: false,
-    uuid: 'window',
-  })
+test('keeps focus without polling when a KDE desktop popup leaves the window active', async () => {
+  const focusedStates = await focusedStatesAfterBlur(
+    {
+      resourceClass: 'electron',
+      skipTaskbar: false,
+      uuid: 'window',
+    },
+    { pollInterval: 0 }
+  )
 
   assert.deepEqual(focusedStates, [true])
 })
@@ -177,28 +180,6 @@ test('reports an app switch made through a KDE shell popup', async () => {
       resourceClass: 'plasmashell',
       skipTaskbar: true,
       uuid: 'launcher',
-    },
-    {
-      resourceClass: 'org.kde.konsole',
-      skipTaskbar: false,
-      uuid: 'konsole',
-    },
-  ]
-  let queryIndex = 0
-  const focusedStates = await focusedStatesAfterBlur(
-    () => activeWindows[Math.min(queryIndex++, activeWindows.length - 1)],
-    { pollInterval: 0 }
-  )
-
-  assert.deepEqual(focusedStates, [true, false])
-})
-
-test('reports an app switch when a desktop popup leaves the window active', async () => {
-  const activeWindows = [
-    {
-      resourceClass: 'electron',
-      skipTaskbar: false,
-      uuid: 'window',
     },
     {
       resourceClass: 'org.kde.konsole',

--- a/tests/unit/kde-wayland-window-state.test.mjs
+++ b/tests/unit/kde-wayland-window-state.test.mjs
@@ -131,6 +131,90 @@ test('does not mistake an ordinary focus change for minimize', () => {
   assert.equal(findNewlyMinimizedWindow(state, state, targetWindow()), null)
 })
 
+test('keeps focus when a KDE desktop popup leaves the window active', async () => {
+  const focusedStates = await focusedStatesAfterBlur({
+    resourceClass: 'electron',
+    skipTaskbar: false,
+    uuid: 'window',
+  })
+
+  assert.deepEqual(focusedStates, [true])
+})
+
+test('keeps focus when a KDE shell popup becomes active', async () => {
+  const focusedStates = await focusedStatesAfterBlur({
+    resourceClass: 'org.kde.krunner',
+    skipTaskbar: true,
+    uuid: 'krunner',
+  })
+
+  assert.deepEqual(focusedStates, [true])
+})
+
+test('reports focus loss when another application window becomes active', async () => {
+  const focusedStates = await focusedStatesAfterBlur({
+    resourceClass: 'org.kde.konsole',
+    skipTaskbar: false,
+    uuid: 'konsole',
+  })
+
+  assert.deepEqual(focusedStates, [false])
+})
+
+test('does not mistake another app utility window for a KDE shell popup', async () => {
+  const focusedStates = await focusedStatesAfterBlur({
+    resourceClass: 'electron',
+    skipTaskbar: true,
+    uuid: 'picture-in-picture',
+  })
+
+  assert.deepEqual(focusedStates, [false])
+})
+
+test('reports an app switch made through a KDE shell popup', async () => {
+  const activeWindows = [
+    {
+      resourceClass: 'plasmashell',
+      skipTaskbar: true,
+      uuid: 'launcher',
+    },
+    {
+      resourceClass: 'org.kde.konsole',
+      skipTaskbar: false,
+      uuid: 'konsole',
+    },
+  ]
+  let queryIndex = 0
+  const focusedStates = await focusedStatesAfterBlur(
+    () => activeWindows[Math.min(queryIndex++, activeWindows.length - 1)],
+    { pollInterval: 0 }
+  )
+
+  assert.deepEqual(focusedStates, [true, false])
+})
+
+test('reports an app switch when a desktop popup leaves the window active', async () => {
+  const activeWindows = [
+    {
+      resourceClass: 'electron',
+      skipTaskbar: false,
+      uuid: 'window',
+    },
+    {
+      resourceClass: 'org.kde.konsole',
+      skipTaskbar: false,
+      uuid: 'konsole',
+    },
+  ]
+  let queryIndex = 0
+  const focusedStates = await focusedStatesAfterBlur(
+    () => activeWindows[Math.min(queryIndex++, activeWindows.length - 1)],
+    { pollInterval: 0 }
+  )
+
+  assert.deepEqual(focusedStates, [true, false])
+})
+
 test('detects a single minimized window when no earlier KWin snapshot is available', () => {
   const current = [
     windowInfo({ uuid: 'one', minimized: true }),
@@ -209,6 +293,7 @@ test('preserves the window identity across title updates during detection', asyn
   browserWindow.emit('blur')
   title = targetWindow().caption
   resolveBackend({
+    queryActiveWindow: async () => null,
     queryWindow: async () => minimized,
     queryWindows: async () => {
       setWindowTitle(targetWindow().caption)
@@ -237,4 +322,31 @@ function targetWindow () {
     caption: 'Subscriptions - OpenTubeX',
     bounds: { x: 10, y: 20, width: 1200, height: 800 },
   }
+}
+
+async function focusedStatesAfterBlur (activeWindow, { pollInterval = 1000 } = {}) {
+  const browserWindow = new EventEmitter()
+  browserWindow.getBounds = () => targetWindow().bounds
+  browserWindow.getTitle = () => targetWindow().caption
+  browserWindow.isFocused = () => false
+  const focusedStates = []
+  const backend = Promise.resolve({
+    queryActiveWindow: async () => typeof activeWindow === 'function' ? activeWindow() : activeWindow,
+    queryWindow: async () => null,
+    queryWindows: async () => [windowInfo()],
+  })
+  const stop = monitorKdeWaylandWindowState({
+    browserWindow,
+    backend,
+    detectionDelay: 0,
+    pollInterval,
+    onFocusedState: focused => focusedStates.push(focused),
+    onMinimizedState: () => {},
+  })
+
+  browserWindow.emit('blur')
+  await new Promise(resolve => setTimeout(resolve, 20))
+  stop()
+
+  return focusedStates
 }


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Make sure to follow the contributing guidelines. -->
<!-- Important note, we may remove your pull request if you do not use this provided PR template correctly. -->
<!-- Agent instructions: Preserve every heading, comment, and marker in this template. Never remove or rewrite the release-note-category:start/end, release-note:start/end, or release-note-image:start/end marker pairs. -->

## Pull Request Type
<!-- Please select what type of pull request this is: [x] -->
- [x] Bugfix
- [ ] Feature Implementation
- [ ] Documentation
- [ ] Other

## Related issue
<!-- Please link the issue your pull request is referring to. -->
<!-- If this pull request fully resolves the relevant issue, put "closes" before the issue number. -->
<!-- Example: "closes #123456". -->

Follow-up to #1075.

## Description
<!-- Please write a clear and concise description of what the pull request does. -->

On KDE Plasma Wayland, desktop popups such as the application launcher and KRunner blur Electron's surface. Focus-loss auto PiP therefore treated opening those popups as switching to another application.

This checks KWin's active window before forwarding the focus state. Plasma shell and KRunner popups keep OpenTubeX logically focused, while switching to another application still enters PiP. A KWin activation listener covers applications launched from a popup because Electron does not send a second blur event in that case, without imposing a polling deadline.

## Release note category
<!-- Select exactly one category. Every pull request must select one. -->
<!-- Select "Not noteworthy" when the pull request fixes a bug in or improves functionality that has not yet appeared in a stable release. -->
<!-- release-note-category:start -->
- [x] Not noteworthy
- [ ] Highlights
- [ ] More improvements
- [ ] Fixed bugs
<!-- release-note-category:end -->

## Release note
<!-- Required unless "Not noteworthy" is selected. -->
<!-- Write one concise, user-facing entry without a leading bullet. -->
<!-- release-note:start -->

<!-- release-note:end -->

## Release note images
<!-- Optional. Paste one or more Markdown images, HTML image tags, or dark/light <picture> elements here. -->
<!-- The release notes normalize the markup and limit images taller than 300 pixels. -->
<!-- Agent instructions:
For a noteworthy visible change, add media when it makes the change easier to understand. Prefer a still image unless motion is the point. Recordings in this section must end up as animated WebP because release notes accept images, not video attachments.
After implementing a visible change, proactively capture the result and show the local media to the user for approval before uploading it or updating the pull request.
When the affected UI differs between dark and light themes, capturing both themes is required. A dark-only image is incomplete. The final pull request body must combine the hosted URLs into a theme-aware `<picture>` with dark and light `prefers-color-scheme` sources and the dark image as its `<img>` fallback. Never leave the two theme captures as separate images. Use a single default-dark capture only when the light theme cannot be captured or looks identical.
Capture or crop to the smallest region that still makes the change clear. Do not include the full window when the affected component can be understood on its own.
Use English unless localization is the subject. Keep components at their normal dimensions and placement instead of resizing them to fill the frame.
Use deterministic local fixtures for visible remote images. Reusable avatar and thumbnail fixtures are available through `e2e/helpers/visual-fixtures.mjs`. Before capturing, verify that every visible image has loaded successfully (`complete === true` and `naturalWidth > 0`).
Inspect the final dark and light files for failed images, missing content, unrelated UI, awkward animation, and misleading layout. Omit media when it does not explain the change clearly.
Use GitHub CLI 2.99.0 or newer to upload images no larger than 10 MB. For one image, write an ordinary Markdown image reference to the local file between the marker comments. Pass the same file to `gh pr create` or `gh pr edit` with `--attach <path>` so GitHub CLI replaces the local path with its hosted URL.
GitHub CLI does not rewrite paths inside HTML attributes. For themed images within its size limit, first upload both files through temporary Markdown image references and repeat `--attach <path>` for each one. Read back the hosted URLs, replace the temporary references with the `<picture>` below, and update the pull request body without `--attach`:
<picture>
  <source media="(prefers-color-scheme: dark)" srcset="HOSTED_DARK_URL">
  <source media="(prefers-color-scheme: light)" srcset="HOSTED_LIGHT_URL">
  <img alt="DESCRIPTION" src="HOSTED_DARK_URL">
</picture>
For every MP4, MOV, or WebM recording, use `node _scripts/releaseNoteMedia.mjs FILE --alt "DESCRIPTION"` regardless of file size so the helper converts it to animated WebP. Use the same command when an image exceeds 10 MB. For a themed pair where either file needs the helper, use `node _scripts/releaseNoteMedia.mjs --dark DARK_FILE --light LIGHT_FILE --alt "DESCRIPTION"`. Paste only its generated markup between the marker comments.
Check for personal information, tokens, private repository names, and unrelated desktop content before uploading. Uploaded media is public.
Keep capture-only scripts, test hooks, screenshots, and recordings out of commits. Remove them before committing unless the capture code is also a reusable regression test. Never commit generated release-note media.
Leave this section empty when media would not help.
-->
<!-- release-note-image:start -->

<!-- release-note-image:end -->

## Testing
<!-- How can reviewers verify that the PR produces correct results? -->
<!-- Please provide instructions so that others can ensure that your pull request would produce correct results. For examples see, https://github.com/FreeTubeApp/FreeTube/pull/5743, https://github.com/FreeTubeApp/FreeTube/pull/7349, https://github.com/FreeTubeApp/FreeTube/pull/5125, https://github.com/FreeTubeApp/FreeTube/pull/7338 -->
<!-- Agent instructions: Only write human-facing steps that explain how to verify the change while running this branch in dev mode. Include expected results and, when applicable, helpful console snippets for interactive verification. Do not include automated checks, commands, results, pass counts, or CI status. -->

1. On KDE Plasma Wayland, enable automatic Picture-in-Picture with the "window loses focus" trigger and play a video.
2. Open the application launcher, a panel popup, and KRunner. The video should remain embedded in OpenTubeX.
3. Switch to another application, including by launching it from the application launcher. The video should enter Picture-in-Picture.
4. Return to OpenTubeX. The video should leave Picture-in-Picture and return to the player.

## Additional context
<!-- Add any other context about the pull request here. -->

KWin's public window-info map does not include activation state, so the KDE Wayland monitor uses a KWin script to report workspace.activeWindow changes over the existing D-Bus connection.

