### PR TITLE
fix: ignore Windows BAM writes in portable test

### DIFF
--- a/_scripts/testWindowsPortable.ps1
+++ b/_scripts/testWindowsPortable.ps1
@@ -1,17 +1,9 @@
 $ErrorActionPreference = 'Stop'
 Set-StrictMode -Version Latest
 
-$registryEventId = @{
-  CreateKey = 1
-  OpenKey = 2
-  DeleteKey = 3
-  SetValue = 5
-  DeleteValue = 6
-  SetInformation = 11
-  Flush = 12
-  Close = 13
-  SetSecurity = 15
-}
+. (Join-Path $PSScriptRoot 'windowsPortableRegistryTrace.ps1')
+& (Join-Path $PSScriptRoot 'testWindowsPortableRegistryTrace.ps1')
+
 $processStartEventId = 1
 $fileEventId = @{
   NameCreate = 10
@@ -27,9 +19,6 @@ $fileEventId = @{
   RenameAlternate = 29
   CreateNewFile = 30
 }
-$registrySuccessStatus = 0
-$newRegistryKeyDisposition = 1
-$keyWriteTimeInformationClass = 0
 $registryProviderName = 'Microsoft-Windows-Kernel-Registry'
 $processProviderName = 'Microsoft-Windows-Kernel-Process'
 $fileProviderName = 'Microsoft-Windows-Kernel-File'
@@ -245,19 +234,6 @@ function Stop-RegistryTrace {
   }
 }
 
-function Convert-RegistryEventNumber {
-  param([Parameter(Mandatory)] [string] $Value)
-
-  $trimmedValue = $Value.Trim()
-  if ($trimmedValue -match '^0[xX](?<Hex>[0-9a-fA-F]+)') {
-    return [Convert]::ToUInt32($Matches.Hex, 16)
-  }
-  if ($trimmedValue -match '^(?<Decimal>[0-9]+)') {
-    return [Convert]::ToUInt32($Matches.Decimal, 10)
-  }
-  return $null
-}
-
 function Get-TraceEventData {
   param([Parameter(Mandatory)] [System.Xml.XmlElement] $Event)
 
@@ -326,47 +302,6 @@ function Test-AppOwnedHostPath {
       return $true
     }
   }
-  return $false
-}
-
-function Test-SuccessfulRegistryMutation {
-  param(
-    [Parameter(Mandatory)] [int] $EventId,
-    [Parameter(Mandatory)] [hashtable] $EventData
-  )
-
-  if (-not $EventData.ContainsKey('Status') -or
-      (Convert-RegistryEventNumber $EventData.Status) -ne $registrySuccessStatus) {
-    return $false
-  }
-
-  if ($EventId -eq $registryEventId.CreateKey) {
-    # CreateKey also reports ordinary opens. NewKey means that the call
-    # created a key; OpenedExistingKey means that it only opened one.
-    return $EventData.ContainsKey('Disposition') -and
-      (Convert-RegistryEventNumber $EventData.Disposition) -eq
-        $newRegistryKeyDisposition
-  }
-
-  if ($EventId -in @(
-    $registryEventId.SetValue,
-    $registryEventId.DeleteValue,
-    $registryEventId.DeleteKey,
-    $registryEventId.Flush,
-    $registryEventId.SetSecurity
-  )) {
-    return $true
-  }
-
-  if ($EventId -eq $registryEventId.SetInformation) {
-    # Only KeyWriteTimeInformation changes persisted key metadata. Other
-    # information classes configure the open handle or runtime state.
-    return $EventData.ContainsKey('InfoClass') -and
-      ((Convert-RegistryEventNumber $EventData.InfoClass) -eq
-         $keyWriteTimeInformationClass -or
-       $EventData.InfoClass -eq 'KeyWriteTimeInformation')
-  }
-
   return $false
 }
 
@@ -530,7 +465,8 @@ function Assert-NoHostWrites {
         $eventData.ContainsKey('KeyObject') -and $eventData.KeyObject) {
       $registryKeyPaths.Remove($eventData.KeyObject.Trim())
     }
-    if (-not (Test-SuccessfulRegistryMutation -EventId $eventId -EventData $eventData)) {
+    if (-not (Test-PortableHostRegistryMutation -EventId $eventId `
+        -EventData $eventData)) {
       continue
     }
     if ($ProcessIds.Contains($eventProcessId)) {

--- a/_scripts/testWindowsPortableRegistryTrace.ps1
+++ b/_scripts/testWindowsPortableRegistryTrace.ps1
@@ -1,0 +1,41 @@
+$ErrorActionPreference = 'Stop'
+Set-StrictMode -Version Latest
+
+. (Join-Path $PSScriptRoot 'windowsPortableRegistryTrace.ps1')
+
+$bamWrite = @{
+  CapturedData = ''
+  CapturedDataSize = '0'
+  DataSize = '24'
+  KeyName = ''
+  KeyObject = '0xFFFFD2834CF1FB90'
+  PreviousData = ''
+  PreviousDataCapturedSize = '0'
+  PreviousDataSize = '0'
+  PreviousDataType = '0'
+  ResolvedKeyName = 'S-1-5-21-1456194669-2875347699-3862154473-500'
+  Status = '0x0'
+  Type = '3'
+  ValueName = '\Device\HarddiskVolume5\a\OpenTubeX\OpenTubeX\build\win-unpacked\OpenTubeX.exe'
+}
+
+if (Test-PortableHostRegistryMutation -EventId $registryEventId.SetValue `
+    -EventData $bamWrite) {
+  throw 'Windows BAM execution-history writes must not count as application registry mutations'
+}
+
+foreach ($change in @(
+  @{ Name = 'DataSize'; Value = '25' },
+  @{ Name = 'ResolvedKeyName'; Value = 'HKEY_CURRENT_USER\Software\OpenTubeX' },
+  @{ Name = 'Type'; Value = '1' },
+  @{ Name = 'ValueName'; Value = 'OpenTubeX' }
+)) {
+  $nearMiss = $bamWrite.Clone()
+  $nearMiss[$change.Name] = $change.Value
+  if (-not (Test-PortableHostRegistryMutation -EventId $registryEventId.SetValue `
+      -EventData $nearMiss)) {
+    throw "A non-BAM registry mutation was ignored after changing $($change.Name)"
+  }
+}
+
+Write-Output 'Windows portable registry trace policy tests passed.'

--- a/_scripts/windowsPortableRegistryTrace.ps1
+++ b/_scripts/windowsPortableRegistryTrace.ps1
@@ -1,0 +1,106 @@
+$registryEventId = @{
+  CreateKey = 1
+  OpenKey = 2
+  DeleteKey = 3
+  SetValue = 5
+  DeleteValue = 6
+  SetInformation = 11
+  Flush = 12
+  Close = 13
+  SetSecurity = 15
+}
+$registrySuccessStatus = 0
+$newRegistryKeyDisposition = 1
+$keyWriteTimeInformationClass = 0
+
+function Convert-RegistryEventNumber {
+  param([Parameter(Mandatory)] [string] $Value)
+
+  $trimmedValue = $Value.Trim()
+  if ($trimmedValue -match '^0[xX](?<Hex>[0-9a-fA-F]+)') {
+    return [Convert]::ToUInt32($Matches.Hex, 16)
+  }
+  if ($trimmedValue -match '^(?<Decimal>[0-9]+)') {
+    return [Convert]::ToUInt32($Matches.Decimal, 10)
+  }
+  return $null
+}
+
+function Test-SuccessfulRegistryMutation {
+  param(
+    [Parameter(Mandatory)] [int] $EventId,
+    [Parameter(Mandatory)] [hashtable] $EventData
+  )
+
+  if (-not $EventData.ContainsKey('Status') -or
+      (Convert-RegistryEventNumber $EventData.Status) -ne $registrySuccessStatus) {
+    return $false
+  }
+
+  if ($EventId -eq $registryEventId.CreateKey) {
+    # CreateKey also reports ordinary opens. NewKey means that the call
+    # created a key; OpenedExistingKey means that it only opened one.
+    return $EventData.ContainsKey('Disposition') -and
+      (Convert-RegistryEventNumber $EventData.Disposition) -eq
+        $newRegistryKeyDisposition
+  }
+
+  if ($EventId -in @(
+    $registryEventId.SetValue,
+    $registryEventId.DeleteValue,
+    $registryEventId.DeleteKey,
+    $registryEventId.Flush,
+    $registryEventId.SetSecurity
+  )) {
+    return $true
+  }
+
+  if ($EventId -eq $registryEventId.SetInformation) {
+    # Only KeyWriteTimeInformation changes persisted key metadata. Other
+    # information classes configure the open handle or runtime state.
+    return $EventData.ContainsKey('InfoClass') -and
+      ((Convert-RegistryEventNumber $EventData.InfoClass) -eq
+         $keyWriteTimeInformationClass -or
+       $EventData.InfoClass -eq 'KeyWriteTimeInformation')
+  }
+
+  return $false
+}
+
+function Test-PortableHostRegistryMutation {
+  param(
+    [Parameter(Mandatory)] [int] $EventId,
+    [Parameter(Mandatory)] [hashtable] $EventData
+  )
+
+  if (-not (Test-SuccessfulRegistryMutation -EventId $EventId `
+      -EventData $EventData)) {
+    return $false
+  }
+
+  if ($EventId -ne $registryEventId.SetValue) {
+    return $true
+  }
+
+  foreach ($requiredField in @(
+    'DataSize', 'KeyName', 'ResolvedKeyName', 'Type', 'ValueName'
+  )) {
+    if (-not $EventData.ContainsKey($requiredField)) {
+      return $true
+    }
+  }
+
+  # Windows records executable launches under the Background Activity
+  # Moderator key before a user-mode proxy DLL can load. When that key was
+  # opened before tracing began, ETW reports only its final SID component.
+  $isBamExecutionHistoryWrite =
+    -not $EventData.KeyName.Trim() -and
+    (Convert-RegistryEventNumber $EventData.DataSize) -eq 24 -and
+    (Convert-RegistryEventNumber $EventData.Type) -eq 3 -and
+    $EventData.ResolvedKeyName.Trim() -match
+      '^(?:\\REGISTRY\\MACHINE\\SYSTEM\\(?:CURRENTCONTROLSET|CONTROLSET\d{3})\\SERVICES\\BAM\\STATE\\USERSETTINGS\\)?S-1-5-(?:\d+-)+\d+$' -and
+    $EventData.ValueName.Trim() -match
+      '^\\Device\\HarddiskVolume\d+\\.+\\OpenTubeX\.exe$'
+
+  return -not $isBamExecutionHistoryWrite
+}


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Make sure to follow the contributing guidelines. -->
<!-- Important note, we may remove your pull request if you do not use this provided PR template correctly. -->
<!-- Agent instructions: Preserve every heading, comment, and marker in this template. Never remove or rewrite the release-note-category:start/end, release-note:start/end, or release-note-image:start/end marker pairs. -->

## Pull Request Type
<!-- Please select what type of pull request this is: [x] -->
- [x] Bugfix
- [ ] Feature Implementation
- [ ] Documentation
- [ ] Other

## Related issue
<!-- Please link the issue your pull request is referring to. -->
<!-- If this pull request fully resolves the relevant issue, put "closes" before the issue number. -->
<!-- Example: "closes #123456". -->

Follow-up to #1090.

## Description
<!-- Please write a clear and concise description of what the pull request does. -->

The Windows x64 build started failing after #1090 because its portable-package test classified Windows Background Activity Moderator execution-history records as application registry writes. Windows writes one of these records for each Electron process before the user-mode Interposer DLL can load.

This change separates registry trace classification from the package smoke test and excludes only the observed BAM signature: a successful 24-byte binary `SetValue` under the BAM user SID whose value name is the packaged `OpenTubeX.exe` NT path. Other registry mutations still fail the package test. A focused PowerShell regression test covers the CI payload and near-miss events.

## Release note category
<!-- Select exactly one category. Every pull request must select one. -->
<!-- Select "Not noteworthy" when the pull request fixes a bug in or improves functionality that has not yet appeared in a stable release. -->
<!-- release-note-category:start -->
- [x] Not noteworthy
- [ ] Highlights
- [ ] More improvements
- [ ] Fixed bugs
<!-- release-note-category:end -->

## Release note
<!-- Required unless "Not noteworthy" is selected. -->
<!-- Write one concise, user-facing entry without a leading bullet. -->
<!-- release-note:start -->

<!-- release-note:end -->

## Release note images
<!-- Optional. Paste one or more Markdown images, HTML image tags, or dark/light <picture> elements here. -->
<!-- The release notes normalize the markup and limit images taller than 300 pixels. -->
<!-- Agent instructions:
For a noteworthy visible change, add media when it makes the change easier to understand. Prefer a still image unless motion is the point. Recordings in this section must end up as animated WebP because release notes accept images, not video attachments.
After implementing a visible change, proactively capture the result and show the local media to the user for approval before uploading it or updating the pull request.
When the affected UI differs between dark and light themes, capturing both themes is required. A dark-only image is incomplete. The final pull request body must combine the hosted URLs into a theme-aware `<picture>` with dark and light `prefers-color-scheme` sources and the dark image as its `<img>` fallback. Never leave the two theme captures as separate images. Use a single default-dark capture only when the light theme cannot be captured or looks identical.
Capture or crop to the smallest region that still makes the change clear. Do not include the full window when the affected component can be understood on its own.
Use English unless localization is the subject. Keep components at their normal dimensions and placement instead of resizing them to fill the frame.
Use deterministic local fixtures for visible remote images. Reusable avatar and thumbnail fixtures are available through `e2e/helpers/visual-fixtures.mjs`. Before capturing, verify that every visible image has loaded successfully (`complete === true` and `naturalWidth > 0`).
Inspect the final dark and light files for failed images, missing content, unrelated UI, awkward animation, and misleading layout. Omit media when it does not explain the change clearly.
Use GitHub CLI 2.99.0 or newer to upload images no larger than 10 MB. For one image, write an ordinary Markdown image reference to the local file between the marker comments. Pass the same file to `gh pr create` or `gh pr edit` with `--attach <path>` so GitHub CLI replaces the local path with its hosted URL.
GitHub CLI does not rewrite paths inside HTML attributes. For themed images within its size limit, first upload both files through temporary Markdown image references and repeat `--attach <path>` for each one. Read back the hosted URLs, replace the temporary references with the `<picture>` below, and update the pull request body without `--attach`:
<picture>
  <source media="(prefers-color-scheme: dark)" srcset="HOSTED_DARK_URL">
  <source media="(prefers-color-scheme: light)" srcset="HOSTED_LIGHT_URL">
  <img alt="DESCRIPTION" src="HOSTED_DARK_URL">
</picture>
For every MP4, MOV, or WebM recording, use `node _scripts/releaseNoteMedia.mjs FILE --alt "DESCRIPTION"` regardless of file size so the helper converts it to animated WebP. Use the same command when an image exceeds 10 MB. For a themed pair where either file needs the helper, use `node _scripts/releaseNoteMedia.mjs --dark DARK_FILE --light LIGHT_FILE --alt "DESCRIPTION"`. Paste only its generated markup between the marker comments.
Check for personal information, tokens, private repository names, and unrelated desktop content before uploading. Uploaded media is public.
Keep capture-only scripts, test hooks, screenshots, and recordings out of commits. Remove them before committing unless the capture code is also a reusable regression test. Never commit generated release-note media.
Leave this section empty when media would not help.
-->
<!-- release-note-image:start -->

<!-- release-note-image:end -->

## Testing
<!-- How can reviewers verify that the PR produces correct results? -->
<!-- Please provide instructions so that others can ensure that your pull request would produce correct results. For examples see, https://github.com/FreeTubeApp/FreeTube/pull/5743, https://github.com/FreeTubeApp/FreeTube/pull/7349, https://github.com/FreeTubeApp/FreeTube/pull/5125, https://github.com/FreeTubeApp/FreeTube/pull/7338 -->
<!-- Agent instructions: Only write human-facing steps that explain how to verify the change while running this branch in dev mode. Include expected results and, when applicable, helpful console snippets for interactive verification. Do not include automated checks, commands, results, pass counts, or CI status. -->

This behavior requires the packaged Windows executable and cannot be checked in ordinary development mode.

1. Build the Windows x64 archive and run its packaged portability check. Windows BAM execution-history records for the packaged executable should not fail the check.
2. Feed the trace policy a similar registry event with a different data size, key, type, or value name. The policy should still classify it as a host-registry mutation.

## Additional context
<!-- Add any other context about the pull request here. -->

The failure is visible in [development build 33797658387](https://github.com/OpenTubeX/OpenTubeX/actions/runs/33797658387/job/100789123449). The trace attributed four identical BAM records to the Electron process tree. A user-mode DLL cannot prevent Windows from writing these records during process creation.

No screenshot is included because this changes CI trace classification and has no visible UI.
