### PR TITLE
fix(sync): identify Android devices correctly

### DIFF
--- a/android/app/src/main/java/org/opentubex/app/AndroidUiPlugin.java
+++ b/android/app/src/main/java/org/opentubex/app/AndroidUiPlugin.java
@@ -9,6 +9,7 @@ import android.content.res.Configuration;
 import android.content.pm.ActivityInfo;
 import android.content.pm.PackageManager;
 import android.os.Build;
+import android.provider.Settings;
 import android.util.Rational;
 
 import androidx.annotation.RequiresApi;
@@ -95,6 +96,30 @@ public class AndroidUiPlugin extends Plugin {
     public void getHardwareKeyboardState(PluginCall call) {
         JSObject result = new JSObject();
         result.put("attached", hasHardwareKeyboard());
+        call.resolve(result);
+    }
+
+    @PluginMethod
+    public void getDeviceInfo(PluginCall call) {
+        String name = null;
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.N_MR1) {
+            name = Settings.Global.getString(
+                getContext().getContentResolver(),
+                Settings.Global.DEVICE_NAME
+            );
+        }
+        if (name == null || name.trim().isEmpty()) {
+            name = Build.MODEL;
+        }
+
+        JSObject result = new JSObject();
+        result.put("name", name);
+        result.put("platform", "android");
+        result.put(
+            "architecture",
+            Build.SUPPORTED_ABIS.length == 0 ? "" : Build.SUPPORTED_ABIS[0]
+        );
+        result.put("release", Build.VERSION.RELEASE);
         call.resolve(result);
     }
 

--- a/e2e/tests/offline/settings.spec.mjs
+++ b/e2e/tests/offline/settings.spec.mjs
@@ -2864,11 +2864,19 @@ test.describe('settings', () => {
     await expect(privacyPolicy).toHaveCount(0)
   })
 
-  test('creates and cancels a secure sync pairing code without uploading key material', async ({ page }) => {
+  test('waits for the device name before creating a secure sync pairing code', async ({ app, page }) => {
     const serverUrl = 'https://pairing.example'
     let createdSession
     let cancelledSessionId
     let cancelledRecipientToken
+
+    await app.electronApp.evaluate(({ ipcMain }) => {
+      globalThis.__pairingDeviceNameResolvers = []
+      ipcMain.removeHandler('get-device-name')
+      ipcMain.handle('get-device-name', () => new Promise(resolve => {
+        globalThis.__pairingDeviceNameResolvers.push(resolve)
+      }))
+    })
 
     await page.route(`${serverUrl}/**`, async route => {
       const request = route.request()
@@ -2924,10 +2932,12 @@ test.describe('settings', () => {
 
     await pairButton.click()
     const dialog = page.getByRole('dialog', { name: 'Pair with an existing device' })
-    const deviceName = await page.evaluate(() => window.ftElectron.getDeviceName())
-    await expect(dialog.getByLabel('Device name')).toHaveValue(deviceName)
-    await dialog.getByLabel('Device name').fill('Travel laptop')
+    await expect(dialog.getByLabel('Device name')).toHaveValue('This device')
     await dialog.getByRole('button', { name: 'Create pairing code' }).click()
+    await app.electronApp.evaluate(() => {
+      for (const resolve of globalThis.__pairingDeviceNameResolvers) resolve('Travel laptop')
+      delete globalThis.__pairingDeviceNameResolvers
+    })
 
     await expect(dialog.getByRole('img', { name: 'Pairing QR code for Travel laptop' })).toBeVisible()
     await expect(dialog.getByText('Pairing code expires at')).toBeVisible()
@@ -4313,7 +4323,19 @@ test.describe('sync settings', () => {
     }
   })
 
-  test('shows the paired username when the connected field becomes disabled', async ({ page }) => {
+  test('keeps the paired username when its device metadata update fails', async ({ page }) => {
+    await page.route('https://sync.d3sox.me/**', route => {
+      const url = new URL(route.request().url())
+      if (url.pathname === '/health') {
+        return route.fulfill({
+          json: { status: 'ok', capabilities: { account_sessions: 1 } }
+        })
+      }
+      if (url.pathname.endsWith('/account/sessions/current')) {
+        return route.fulfill({ status: 503, body: 'metadata unavailable' })
+      }
+      return route.fulfill({ status: 404 })
+    })
     await goTo(page, 'settings')
     await page.locator('.settingsMenu [data-section="sync"]').click()
 
@@ -4333,7 +4355,12 @@ test.describe('sync settings', () => {
         privacyKey: 'paired-privacy-key',
         privacySalt: 'paired-privacy-salt',
         deviceId: 'MDEyMzQ1Njc4OTo7PD0-Pw',
-        deviceName: 'Paired device'
+        deviceName: 'Paired device',
+        deviceSystemInfo: {
+          platform: 'android',
+          architecture: 'arm64-v8a',
+          release: '16'
+        }
       })
     })
 

--- a/src/renderer/components/SyncSettings/SyncPairing.vue
+++ b/src/renderer/components/SyncSettings/SyncPairing.vue
@@ -380,12 +380,13 @@ let approveSequence = 0
 let pairingClient = null
 const pairingApproval = ref(null)
 
-getCurrentSyncServerDeviceInfo().then(({ name }) => {
+const currentDeviceInfoPromise = getCurrentSyncServerDeviceInfo().catch(() => ({ name: '' }))
+currentDeviceInfoPromise.then(({ name }) => {
   const trimmedName = name?.trim()
   if (trimmedName && deviceName.value === fallbackDeviceName) {
     deviceName.value = trimmedName
   }
-}).catch(() => {})
+})
 
 function openReceiver() {
   resetReceiver()
@@ -404,6 +405,15 @@ function resetReceiver() {
 
 async function startReceiving() {
   const sequence = ++receiveSequence
+  receiveStage.value = 'creating'
+  receiveError.value = ''
+
+  const { name } = await currentDeviceInfoPromise
+  if (sequence !== receiveSequence || !receivePromptOpen.value) return
+  const trimmedSystemName = name?.trim()
+  if (trimmedSystemName && deviceName.value === fallbackDeviceName) {
+    deviceName.value = trimmedSystemName
+  }
   const requestedName = deviceName.value.trim()
   if (!requestedName) {
     receiveError.value = t('Settings.Sync Settings.Device Name Required')
@@ -411,8 +421,6 @@ async function startReceiving() {
     return
   }
   deviceName.value = requestedName
-  receiveStage.value = 'creating'
-  receiveError.value = ''
 
   const client = new SyncServerClient(props.serverUrl)
   try {

--- a/src/renderer/components/SyncSettings/SyncPairing.vue
+++ b/src/renderer/components/SyncSettings/SyncPairing.vue
@@ -310,6 +310,7 @@ import {
 import { SyncServerClient, normalizeSyncServerUrl } from '../../helpers/sync-server'
 import {
   encryptSyncServerDeviceInfo,
+  getCurrentSyncServerDeviceInfo,
 } from '../../helpers/sync-server-sessions'
 import { formatTime } from '../../helpers/dateFormat'
 import store from '../../store/index'
@@ -379,7 +380,7 @@ let approveSequence = 0
 let pairingClient = null
 const pairingApproval = ref(null)
 
-window.ftElectron?.getDeviceName?.().then(name => {
+getCurrentSyncServerDeviceInfo().then(({ name }) => {
   const trimmedName = name?.trim()
   if (trimmedName && deviceName.value === fallbackDeviceName) {
     deviceName.value = trimmedName
@@ -521,6 +522,7 @@ async function confirmReceiver() {
   receiveStage.value = 'finishing'
   const privacy = active.transfer
   try {
+    const { name, ...deviceSystemInfo } = await getCurrentSyncServerDeviceInfo()
     await store.dispatch('completeSyncServerPairing', {
       serverUrl: active.request.origin,
       username: privacy.username,
@@ -529,6 +531,7 @@ async function confirmReceiver() {
       privacySalt: privacy.salt,
       deviceId: active.recipient.recipientDeviceId,
       deviceName: active.recipient.recipientDeviceName,
+      deviceSystemInfo,
     })
     await finishReceiver()
     emit('paired', 'completed')

--- a/src/renderer/components/SyncSettings/SyncSettings.vue
+++ b/src/renderer/components/SyncSettings/SyncSettings.vue
@@ -454,10 +454,10 @@ import {
 import { showToast } from '../../helpers/utils'
 import { formatDateTime } from '../../helpers/dateFormat'
 import {
-  getCurrentSyncServerSystemInfo,
+  getCurrentSyncServerDeviceInfo,
   isValidSyncServerDeviceId,
-  isValidSyncServerDeviceName,
   randomSyncServerDeviceId,
+  resolveSyncServerDeviceName,
 } from '../../helpers/sync-server-sessions'
 
 const { locale, t } = useI18n()
@@ -686,19 +686,17 @@ async function ensureDeviceIdentity() {
     await store.dispatch('updateSyncServerDeviceId', id)
   }
 
-  let name = store.getters.getSyncServerDeviceName?.trim()
-  if (!isValidSyncServerDeviceName(name)) {
-    try {
-      const systemName = await window.ftElectron?.getDeviceName?.()
-      const trimmedName = systemName?.trim()
-      if (isValidSyncServerDeviceName(trimmedName)) name = trimmedName
-    } catch {}
-  }
-  if (!isValidSyncServerDeviceName(name)) name = t('Settings.Sync Settings.This Device')
+  const { name: systemName, ...systemInfo } = await getCurrentSyncServerDeviceInfo()
+  const fallbackName = t('Settings.Sync Settings.This Device')
+  const name = resolveSyncServerDeviceName(
+    store.getters.getSyncServerDeviceName,
+    systemName,
+    fallbackName
+  )
   if (name !== store.getters.getSyncServerDeviceName) {
     await store.dispatch('updateSyncServerDeviceName', name)
   }
-  return { id, name, systemInfo: await getCurrentSyncServerSystemInfo() }
+  return { id, name, systemInfo }
 }
 
 async function syncNow() {

--- a/src/renderer/helpers/androidUi.js
+++ b/src/renderer/helpers/androidUi.js
@@ -87,6 +87,10 @@ export async function getAndroidHardwareKeyboardState() {
   return result.attached === true
 }
 
+export function getAndroidDeviceInfo() {
+  return AndroidUi?.getDeviceInfo() ?? Promise.resolve()
+}
+
 export function setAndroidPictureInPictureDocumentState(active) {
   document.body.classList.toggle('androidPictureInPicture', active)
 }

--- a/src/renderer/helpers/sync-server-sessions.js
+++ b/src/renderer/helpers/sync-server-sessions.js
@@ -69,20 +69,54 @@ export function isValidSyncServerDeviceId(value) {
   }
 }
 
-export async function getCurrentSyncServerSystemInfo() {
-  let systemInfo
+export function resolveSyncServerDeviceName(savedName, systemName, fallbackName) {
+  const name = typeof savedName === 'string' ? savedName.trim() : ''
+  if ((!isValidSyncServerDeviceName(name) || name === fallbackName) &&
+      isValidSyncServerDeviceName(systemName)) {
+    return systemName
+  }
+  return isValidSyncServerDeviceName(name) ? name : fallbackName
+}
+
+async function loadAndroidDeviceInfo() {
+  const { getAndroidDeviceInfo } = await import('./androidUi.js')
+  return getAndroidDeviceInfo()
+}
+
+async function loadElectronDeviceInfo() {
+  const [deviceInfo, name] = await Promise.all([
+    globalThis.window?.ftElectron?.getDeviceInfo?.(),
+    globalThis.window?.ftElectron?.getDeviceName?.(),
+  ])
+  return { ...deviceInfo, name }
+}
+
+export async function getCurrentSyncServerDeviceInfo({
+  isCapacitor = Boolean(process.env.IS_CAPACITOR),
+  getAndroidDeviceInfo = loadAndroidDeviceInfo,
+  getElectronDeviceInfo = loadElectronDeviceInfo,
+} = {}) {
+  let deviceInfo
   try {
-    systemInfo = await globalThis.window?.ftElectron?.getDeviceInfo?.()
+    deviceInfo = await (isCapacitor ? getAndroidDeviceInfo() : getElectronDeviceInfo())
   } catch {}
 
   const electronPlatform = typeof process !== 'undefined' && process.env?.IS_ELECTRON
     ? process.platform
     : 'web'
+  const name = typeof deviceInfo?.name === 'string' ? deviceInfo.name.trim() : ''
+  const platform = deviceInfo?.platform || (isCapacitor ? 'android' : electronPlatform) || 'web'
   return {
-    platform: validateSystemField(systemInfo?.platform || electronPlatform || 'web'),
-    architecture: validateSystemField(systemInfo?.architecture || ''),
-    release: validateSystemField(systemInfo?.release || ''),
+    name: isValidSyncServerDeviceName(name) ? name : '',
+    platform: validateSystemField(platform),
+    architecture: validateSystemField(deviceInfo?.architecture || ''),
+    release: validateSystemField(deviceInfo?.release || ''),
   }
+}
+
+export async function getCurrentSyncServerSystemInfo() {
+  const { name, ...systemInfo } = await getCurrentSyncServerDeviceInfo()
+  return systemInfo
 }
 
 export async function encryptSyncServerDeviceInfo(value, exportedKey, deviceId) {

--- a/src/renderer/store/modules/sync-server.js
+++ b/src/renderer/store/modules/sync-server.js
@@ -529,20 +529,6 @@ const actions = {
       throw new Error('Incomplete pairing result')
     }
 
-    if (deviceSystemInfo) {
-      const client = trackSyncClient(new SyncServerClient(normalizedUrl, token))
-      try {
-        const encryptedDeviceInfo = await encryptSyncServerDeviceInfo(
-          { name: deviceName, ...deviceSystemInfo },
-          privacyKey,
-          deviceId
-        )
-        await client.updateAccountSession('current', encryptedDeviceInfo)
-      } finally {
-        releaseSyncClient(client)
-      }
-    }
-
     await dispatch('updateSyncServerUrl', normalizedUrl, { root: true })
     await dispatch('updateSyncServerUsername', trimmedUsername, { root: true })
     await dispatch('updateSyncServerDeviceId', deviceId, { root: true })
@@ -554,6 +540,25 @@ const actions = {
     await dispatch('updateSyncServerPrivacySalt', privacySalt, { root: true })
     await dispatch('updateSyncServerToken', token, { root: true })
     commit('setSyncServerSessionExpired', false)
+
+    if (deviceSystemInfo) {
+      const client = trackSyncClient(new SyncServerClient(normalizedUrl, token))
+      try {
+        if (await client.supportsAccountSessions()) {
+          const encryptedDeviceInfo = await encryptSyncServerDeviceInfo(
+            { name: deviceName, ...deviceSystemInfo },
+            privacyKey,
+            deviceId
+          )
+          await client.updateAccountSession('current', encryptedDeviceInfo)
+        }
+      } catch {
+        // The one-time pairing transfer has already been consumed. Keep the
+        // saved account session; account management repairs its metadata later.
+      } finally {
+        releaseSyncClient(client)
+      }
+    }
 
     return dispatch('startSyncServerAutoSync')
   },

--- a/src/renderer/store/modules/sync-server.js
+++ b/src/renderer/store/modules/sync-server.js
@@ -518,7 +518,7 @@ const actions = {
 
   async completeSyncServerPairing(
     { commit, dispatch, rootState },
-    { serverUrl, username, token, privacyKey, privacySalt, deviceId, deviceName }
+    { serverUrl, username, token, privacyKey, privacySalt, deviceId, deviceName, deviceSystemInfo }
   ) {
     if (!rootState.settings.syncServerEnabled) {
       throw new Error('Enable sync first')
@@ -527,6 +527,20 @@ const actions = {
     const trimmedUsername = username.trim()
     if (!trimmedUsername || !token || !privacyKey || !privacySalt || !deviceId || !deviceName) {
       throw new Error('Incomplete pairing result')
+    }
+
+    if (deviceSystemInfo) {
+      const client = trackSyncClient(new SyncServerClient(normalizedUrl, token))
+      try {
+        const encryptedDeviceInfo = await encryptSyncServerDeviceInfo(
+          { name: deviceName, ...deviceSystemInfo },
+          privacyKey,
+          deviceId
+        )
+        await client.updateAccountSession('current', encryptedDeviceInfo)
+      } finally {
+        releaseSyncClient(client)
+      }
     }
 
     await dispatch('updateSyncServerUrl', normalizedUrl, { root: true })

--- a/tests/unit/sync-server-account-sessions.test.mjs
+++ b/tests/unit/sync-server-account-sessions.test.mjs
@@ -4,9 +4,11 @@ import test from 'node:test'
 import {
   decryptSyncServerDeviceInfo,
   encryptSyncServerDeviceInfo,
+  getCurrentSyncServerDeviceInfo,
   isValidSyncServerDeviceId,
   isValidSyncServerDeviceName,
   randomSyncServerDeviceId,
+  resolveSyncServerDeviceName,
 } from '../../src/renderer/helpers/sync-server-sessions.js'
 
 function bytesToBase64 (bytes) {
@@ -18,6 +20,30 @@ test('creates random canonical device identifiers', () => {
   assert.equal(identifiers.size, 100)
   for (const identifier of identifiers) assert.equal(isValidSyncServerDeviceId(identifier), true)
   assert.equal(isValidSyncServerDeviceId('not a device id'), false)
+})
+
+test('uses native Android identity for the current sync device', async () => {
+  const deviceInfo = await getCurrentSyncServerDeviceInfo({
+    isCapacitor: true,
+    getAndroidDeviceInfo: async () => ({
+      name: 'Pixel 9',
+      platform: 'android',
+      architecture: 'arm64-v8a',
+      release: '16',
+    }),
+  })
+
+  assert.deepEqual(deviceInfo, {
+    name: 'Pixel 9',
+    platform: 'android',
+    architecture: 'arm64-v8a',
+    release: '16',
+  })
+})
+
+test('replaces the generic current-device name without overwriting a custom name', () => {
+  assert.equal(resolveSyncServerDeviceName('This device', 'Pixel 9', 'This device'), 'Pixel 9')
+  assert.equal(resolveSyncServerDeviceName('My phone', 'Pixel 9', 'This device'), 'My phone')
 })
 
 test('encrypts device identification for one device and privacy key', async () => {


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Make sure to follow the contributing guidelines. -->
<!-- Important note, we may remove your pull request if you do not use this provided PR template correctly. -->
<!-- Agent instructions: Preserve every heading, comment, and marker in this template. Never remove or rewrite the release-note-category:start/end, release-note:start/end, or release-note-image:start/end marker pairs. -->

## Pull Request Type
<!-- Please select what type of pull request this is: [x] -->
- [x] Bugfix
- [ ] Feature Implementation
- [ ] Documentation
- [ ] Other

## Related issue
<!-- Please link the issue your pull request is referring to. -->
<!-- If this pull request fully resolves the relevant issue, put "closes" before the issue number. -->
<!-- Example: "closes #123456". -->

## Description
<!-- Please write a clear and concise description of what the pull request does. -->
Android sync sessions were using the web fallback, so newly connected phones appeared as "This device" with "Web" as their operating system. Read the configured Android device name, Android version, and primary ABI through the existing native bridge, then publish that information during password sign-in and key pairing. Custom sync device names remain unchanged.

## Release note category
<!-- Select exactly one category. Every pull request must select one. -->
<!-- Select "Not noteworthy" when the pull request fixes a bug in or improves functionality that has not yet appeared in a stable release. -->
<!-- release-note-category:start -->
- [x] Not noteworthy
- [ ] Highlights
- [ ] More improvements
- [ ] Fixed bugs
<!-- release-note-category:end -->

## Release note
<!-- Required unless "Not noteworthy" is selected. -->
<!-- Write one concise, user-facing entry without a leading bullet. -->
<!-- release-note:start -->

<!-- release-note:end -->

## Release note images
<!-- Optional. Paste one or more Markdown images, HTML image tags, or dark/light <picture> elements here. -->
<!-- The release notes normalize the markup and limit images taller than 300 pixels. -->
<!-- Agent instructions:
For a noteworthy visible change, add media when it makes the change easier to understand. Prefer a still image unless motion is the point. Recordings in this section must end up as animated WebP because release notes accept images, not video attachments.
After implementing a visible change, proactively capture the result and show the local media to the user for approval before uploading it or updating the pull request.
When the affected UI differs between dark and light themes, capturing both themes is required. A dark-only image is incomplete. The final pull request body must combine the hosted URLs into a theme-aware `<picture>` with dark and light `prefers-color-scheme` sources and the dark image as its `<img>` fallback. Never leave the two theme captures as separate images. Use a single default-dark capture only when the light theme cannot be captured or looks identical.
Capture or crop to the smallest region that still makes the change clear. Do not include the full window when the affected component can be understood on its own.
Use English unless localization is the subject. Keep components at their normal dimensions and placement instead of resizing them to fill the frame.
Use deterministic local fixtures for visible remote images. Reusable avatar and thumbnail fixtures are available through `e2e/helpers/visual-fixtures.mjs`. Before capturing, verify that every visible image has loaded successfully (`complete === true` and `naturalWidth > 0`).
Inspect the final dark and light files for failed images, missing content, unrelated UI, awkward animation, and misleading layout. Omit media when it does not explain the change clearly.
Use GitHub CLI 2.99.0 or newer to upload images no larger than 10 MB. For one image, write an ordinary Markdown image reference to the local file between the marker comments. Pass the same file to `gh pr create` or `gh pr edit` with `--attach <path>` so GitHub CLI replaces the local path with its hosted URL.
GitHub CLI does not rewrite paths inside HTML attributes. For themed images within its size limit, first upload both files through temporary Markdown image references and repeat `--attach <path>` for each one. Read back the hosted URLs, replace the temporary references with the `<picture>` below, and update the pull request body without `--attach`:
<picture>
  <source media="(prefers-color-scheme: dark)" srcset="HOSTED_DARK_URL">
  <source media="(prefers-color-scheme: light)" srcset="HOSTED_LIGHT_URL">
  <img alt="DESCRIPTION" src="HOSTED_DARK_URL">
</picture>
For every MP4, MOV, or WebM recording, use `node _scripts/releaseNoteMedia.mjs FILE --alt "DESCRIPTION"` regardless of file size so the helper converts it to animated WebP. Use the same command when an image exceeds 10 MB. For a themed pair where either file needs the helper, use `node _scripts/releaseNoteMedia.mjs --dark DARK_FILE --light LIGHT_FILE --alt "DESCRIPTION"`. Paste only its generated markup between the marker comments.
Check for personal information, tokens, private repository names, and unrelated desktop content before uploading. Uploaded media is public.
Keep capture-only scripts, test hooks, screenshots, and recordings out of commits. Remove them before committing unless the capture code is also a reusable regression test. Never commit generated release-note media.
Leave this section empty when media would not help.
-->
<!-- release-note-image:start -->

<!-- release-note-image:end -->

## Testing
<!-- How can reviewers verify that the PR produces correct results? -->
<!-- Please provide instructions so that others can ensure that your pull request would produce correct results. For examples see, https://github.com/FreeTubeApp/FreeTube/pull/5743, https://github.com/FreeTubeApp/FreeTube/pull/7349, https://github.com/FreeTubeApp/FreeTube/pull/5125, https://github.com/FreeTubeApp/FreeTube/pull/7338 -->
<!-- Agent instructions: Only write human-facing steps that explain how to verify the change while running this branch in dev mode. Include expected results and, when applicable, helpful console snippets for interactive verification. Do not include automated checks, commands, results, pass counts, or CI status. -->
1. Run the Android app and connect it to an enhanced-privacy sync account through password sign-in or key pairing.
2. Open Sync account management on either connected device.
3. Confirm the Android session uses the phone's configured device name and identifies its operating system as Android, including the Android version and ABI.
4. Rename the session, reopen account management, and confirm the custom name remains unchanged.

## Additional context
<!-- Add any other context about the pull request here. -->
The native bridge falls back to the Android model when the configured device name is unavailable.
